### PR TITLE
Fix GLBBuilder and GLBParser

### DIFF
--- a/modules/core/src/glb-loader/unpack-binary-json.js
+++ b/modules/core/src/glb-loader/unpack-binary-json.js
@@ -34,13 +34,12 @@ function decodeJSONPointer(object, buffers) {
   if (pointer) {
     const [field, index] = pointer;
     const buffer = buffers[field] && buffers[field][index];
-    if (!buffer) {
-      console.error(`Invalid JSON pointer ${object}: #/${field}/${index}`); // eslint-disable-line
-      return null;
+    if (buffer) {
+      return buffer;
     }
-    return buffer;
+    console.error(`Invalid JSON pointer ${object}: #/${field}/${index}`); // eslint-disable-line
   }
-  return object;
+  return null;
 }
 
 function parseJSONPointer(value) {
@@ -50,7 +49,7 @@ function parseJSONPointer(value) {
       return value.slice(1);
     }
 
-    let matches = value.match(/\#\/[a-z]+\/([0-9]+)/);
+    let matches = value.match(/\#\/([a-z]+)\/([0-9]+)/);
     if (matches) {
       const index = parseInt(matches[2], 10);
       return [matches[1], index];

--- a/modules/core/src/glb-writer/glb-builder.js
+++ b/modules/core/src/glb-writer/glb-builder.js
@@ -383,6 +383,17 @@ export default class GLBBuilder {
 
     return glbArrayBuffer;
   }
+
+  // Report internal buffer sizes for debug and testing purposes
+  _getInternalCounts() {
+    return {
+      buffers: this.json.buffers.length,
+      bufferViews: this.json.bufferViews.length,
+      accessors: this.json.accessors.length,
+      images: this.json.images.length,
+      meshes: this.json.meshes.length
+    };
+  }
 }
 
 function convertObjectToJsonChunk(json) {

--- a/test/modules/core/glb-loader/glb-parser.spec.js
+++ b/test/modules/core/glb-loader/glb-parser.spec.js
@@ -1,0 +1,19 @@
+/* eslint-disable */
+import test from 'tape-catch';
+
+import {GLBParser, GLBBuilder} from 'loaders.gl';
+
+test('GLBParser#parse', t => {
+  const testJson = {nested: {typedArray: new Float32Array([10.0, 11.0, 12.0])}};
+  const builder = new GLBBuilder();
+  const packedJSON = builder.packJSON(testJson);
+  builder.addExtras(packedJSON);
+  const arrayBuffer = builder.encode();
+
+  const parser = new GLBParser(arrayBuffer);
+  const gltfData = parser.parse();
+  const json = parser.unpackJSON(gltfData.json.extras);
+  t.ok(json.nested.typedArray instanceof Float32Array, 'Float32Array present');
+
+  t.end();
+});

--- a/test/modules/core/glb-loader/index.js
+++ b/test/modules/core/glb-loader/index.js
@@ -1,0 +1,1 @@
+import './glb-parser.spec';

--- a/test/modules/core/glb-writer/glb-builder.spec.js
+++ b/test/modules/core/glb-writer/glb-builder.spec.js
@@ -10,6 +10,139 @@ const BUFFERS = [
   new Float32Array([8, 2, 4, 5])
 ];
 
+function validateGLBJsonFields(t, builder, {numBuffers = 1, numBufferViews = 0, numAccessors = 0, numImages = 0} = {}) {
+  const counts = builder._getInternalCounts();
+  t.equal(counts.buffers, numBuffers, `buffers ${numBufferViews}`);
+  t.equal(counts.bufferViews, numBufferViews, `bufferViews is ${numBufferViews}`);
+  t.equal(counts.accessors, numAccessors, `accessors is ${numAccessors}`);
+  t.equal(counts.images, numImages, `images is ${numImages}`);
+}
+
+test('GLBBuilder#encode with null json', t => {
+  //  20 - header
+  // 100 - json {"buffers":[{"byteLength":0}],"bufferViews":[],"accessors":[],"images":[],"meshes":[],"extras":null}
+  //   8 - header
+  // 128
+  const builder = new GLBBuilder();
+  const packedJSON = builder.packJSON(null);
+  builder.addExtras(packedJSON);
+  const arrayBuffer = builder.encode();
+
+  t.equal(arrayBuffer.byteLength, 128, 'null json encoded with size 128');
+  t.equal(packedJSON, null, 'json is null');
+  validateGLBJsonFields(t, builder);
+
+  t.end();
+});
+
+test('GLBBuilder#encode with empty object json', t => {
+  //  20 - header
+  //  98 - json {"buffers":[{"byteLength":0}],"bufferViews":[],"accessors":[],"images":[],"meshes":[],"extras":{}}
+  //   2 - padding
+  //   8 - header
+  // 128
+  const builder = new GLBBuilder();
+  const packedJSON = builder.packJSON({});
+  builder.addExtras(packedJSON);
+  const arrayBuffer = builder.encode();
+
+  t.equal(arrayBuffer.byteLength, 128, '[] json encoded with size of 128');
+  t.equal(Object.keys(packedJSON).length, 0, 'json has 0 keys in object');
+  validateGLBJsonFields(t, builder);
+
+  t.end();
+});
+
+test('GLBBuilder#encode with simple object json', t => {
+  //  20 - header
+  // 105 - json {"buffers":[{"byteLength":0}],"bufferViews":[],"accessors":[],"images":[],"meshes":[],"extras":{"num":1}}
+  //   3 - padding
+  //   8 - header
+  // 136
+  const builder = new GLBBuilder();
+  const packedJSON = builder.packJSON({num: 1});
+  builder.addExtras(packedJSON);
+  const arrayBuffer = builder.encode();
+
+  t.equal(arrayBuffer.byteLength, 136, 'object with 1 scalar json encoded with size of 136');
+  t.equal(Object.keys(packedJSON).length, 1, 'json has 1 keys in object');
+  validateGLBJsonFields(t, builder);
+
+  t.end();
+});
+
+test('GLBBuilder#encode with typed array json', t => {
+  //  20 - header
+  // 232 - json {"buffers":[{"byteLength":12}],"bufferViews":[{"buffer":0,"byteOffset":0,"byteLength":12}],"accessors":[{"bufferView":0,"type":"VEC3","componentType":5126,"count":1}],"images":[],,"meshes":[],"extras":{"typedArray":"#/accessors/0"}}
+  //   8 - header
+  //  12 - data
+  // 272
+  const testJson = {typedArray: new Float32Array([10.0, 11.0, 12.0])};
+
+  const builder = new GLBBuilder();
+  const packedJSON = builder.packJSON(testJson);
+  builder.addExtras(packedJSON);
+  const arrayBuffer = builder.encode();
+
+  t.equal(arrayBuffer.byteLength, 272, 'object with 1 typed array json encoded with size of 272');
+  t.equal(Object.keys(packedJSON).length, 1, 'json has 1 keys in object');
+  t.ok(typeof packedJSON.typedArray === 'string', 'encoded array should be an accessor string');
+  validateGLBJsonFields(t, builder, {numBufferViews: 1, numAccessors: 1, numImages: 0});
+
+  t.end();
+});
+
+test('GLBBuilder#encode with nested typed array json', t => {
+  //  20 - header
+  // 242 - json {"buffers":[{"byteLength":12}],"bufferViews":[{"buffer":0,"byteOffset":0,"byteLength":12}],"accessors":[{"bufferView":0,"type":"VEC3","componentType":5126,"count":1}],"images":[],"meshes":[],"extras":{"nested":{"typedArray":"#/accessors/0"}}}
+  //   2 - padding
+  //   8 - header
+  //  12 - data
+  // 284
+  const testJson = {nested: {typedArray: new Float32Array([10.0, 11.0, 12.0])}};
+
+  const builder = new GLBBuilder();
+  const packedJSON = builder.packJSON(testJson);
+  builder.addExtras(packedJSON);
+  const arrayBuffer = builder.encode();
+
+  t.equal(arrayBuffer.byteLength, 284, 'nested object with 1 typed array json encoded with size of 284');
+  t.equal(Object.keys(packedJSON).length, 1, 'json has 1 keys in object');
+  t.ok(typeof packedJSON.nested.typedArray === 'string', 'encoded array should be an accessor string');
+  validateGLBJsonFields(t, builder, {numBufferViews: 1, numAccessors: 1, numImages: 0});
+
+  t.end();
+});
+
+test('GLBBuilder#encode complex', t => {
+  // {
+  // "buffers":[{"byteLength":36}],
+  // "bufferViews":[{"buffer":0,"byteOffset":0,"byteLength":12},{"buffer":0,"byteOffset":12,"byteLength":12},{"buffer":0,"byteOffset":24,"byteLength":12}],
+  // "accessors":[{"bufferView":0,"type":"VEC3","componentType":5126,"count":1},{"bufferView":1,"type":"VEC3","componentType":5126,"count":1},{"bufferView":2,"type":"VEC3","componentType":5126,"count":1}],
+  // "images":[],
+  // "meshes":[],
+  // "extra":{"numy":12003.4,"stringy":"foobar","objy":{"foo":"bar"},"simpleArray":[1,2,3],"typedArray":"#/accessors/0","nestedSimpleArray":[[1,2,3],[11,12,13]],"nestedTypedArray":["#/accessors/1","#/accessors/2"]}
+  // }
+  const testJson = {
+    numy: 12003.4,
+    stringy: 'foobar',
+    objy: {foo: 'bar'},
+    simpleArray: [1, 2, 3],
+    typedArray: new Float32Array([10.0, 11.0, 12.0]),
+    nestedSimpleArray: [[1, 2, 3], [11, 12, 13]],
+    nestedTypedArray: [new Float32Array([10.0, 11.0, 12.0]), new Float32Array([20.0, 21.0, 22.0])]
+  };
+
+  const builder = new GLBBuilder();
+  const packedJSON = builder.packJSON(testJson);
+  builder.addExtras(packedJSON);
+  const arrayBuffer = builder.encode();
+
+  t.equal(arrayBuffer.byteLength, 680, 'complex json encoded with size of 680');
+  t.equal(Object.keys(packedJSON).length, 7, 'json has 7 keys in object');
+  t.end();
+});
+
 test('pack-and-unpack-binary-buffers', t => {
   const glbBuilder = new GLBBuilder();
 

--- a/test/modules/core/index.js
+++ b/test/modules/core/index.js
@@ -4,6 +4,7 @@ import './draco-loader/draco-loader.spec';
 import './draco-encoder/draco-encoder.spec';
 
 import './glb-writer';
+import './glb-loader';
 
 import './gltf-loader/gltf-loader.spec';
 


### PR DESCRIPTION
- Added test to capture error encountered below

GLBParser                                                                                                                                                                                                                             [0/1958]
- unpackBinaryJson takes application json, not glb json
- remove jsonKey support
- remove storing accessor in unpacked typed array, unused

GLBBuilder
- encode must call packBinaryJson()
- encode returns {glbArrayBuffer, json}