### PR TITLE
images: Run `getImageDataAsync` on worker

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -107,11 +107,9 @@ Some iterator helper functions have been renamed, the old naming is now deprecat
 
 **`@loaders.gl/images`**
 
-The experimental ImageLoaders for individual formats introduced in 2.0 have been removed, use `ImageLoader` for all formats.
-`@loaders.gl/images`
-
 - `getImageData(image)` now returns an object with `{data, width, height}` instead of just the `data` array. This small breaking change ensures that the concept of _image data_ is consistent across the API.
 - `ImageLoader`: `options.image.type`: The `html` and `ndarray` image types are now deprecated and replaced with `image` and `data` respectively.
+- `ImageLoaders`: The experimental loaders for individual formats introduced in 2.0 have been removed, use `ImageLoader` for all formats.
 
 **`@loaders.gl/3d-tiles`**
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -230,8 +230,8 @@ The new loaders empowers rendering frameworks to visualize various geospatial da
 
 **@loaders.gl/images**
 
-- Images can now be loaded as data: Using the `ImageLoader` with `options.image.type: 'data'` parameter will return an _image data object_ with width, height and a typed array containing the image data (instead of an opaque `Image` or `ImageBitmap` instance).
-- `ImageBitmap` loading now works reliably, use `ImageLoader` with `options.image.type: 'imagebitmap'`.
+- `ImageLoader`: Images can now be (reliably) loaded as `ImageBitmap`, by specifying `options.image.type: 'imagebitmap'`.
+- `ImageLoader`: Images can now be loaded as data (instead of an opaque `Image` or `ImageBitmap` objects), by specifying `options.image.type: 'data'`. The loader will return an _image data object_ with a `data` field with a typed array containing the image data as well as `width` and `height` fields.
 
 **@loaders.gl/json**
 

--- a/modules/images/package.json
+++ b/modules/images/package.json
@@ -28,7 +28,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-worker && npm run build-bundle && npm run build-bundle -- --env.dev",
     "build-bundle": "webpack  --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-worker": "webpack --entry ./src/image-worker.js --output ./dist/image-worker.js --config ../../scripts/webpack/worker.js"
   },

--- a/modules/images/src/image-loader.js
+++ b/modules/images/src/image-loader.js
@@ -20,6 +20,7 @@ export const ImageLoader = {
   name: 'Images',
   id: 'image',
   module: 'images',
+  category: 'image',
   version: VERSION,
   mimeTypes: MIME_TYPES,
   extensions: EXTENSIONS,
@@ -29,8 +30,9 @@ export const ImageLoader = {
   options: {
     image: {
       type: 'auto',
-      decode: true // if format is HTML
+      decode: true, // applies only to images of type: 'image' (Image)
+      _extractDataOnWorker: true // whether to decode data asynchronously on worker
     }
-    // imagebitmap: {} - passes (platform dependent) parameters to ImageBitmap constructor
+    // imagebitmap: {} - if supplied, passes platform dependent parameters to `createImageBitmap`
   }
 };

--- a/modules/images/src/index.d.ts
+++ b/modules/images/src/index.d.ts
@@ -11,13 +11,14 @@ export {ImageWriter} from './image-writer';
 export {getBinaryImageMetadata} from './lib/category-api/binary-image-api';
 
 // Parsed Image API
-export {isImageTypeSupported, getDefaultImageType} from './lib/category-api/image-type';
+export {isImageTypeSupported} from './lib/category-api/image-type';
 
 export {
   isImage,
   getImageType,
   getImageSize,
-  getImageData
+  getImageData,
+  getImageDataAsync
 } from './lib/category-api/parsed-image-api';
 
 // DEPRECATED

--- a/modules/images/src/index.js
+++ b/modules/images/src/index.js
@@ -13,18 +13,13 @@ export {
   isImage,
   getImageType,
   getImageSize,
-  getImageData
+  getImageData,
+  getImageDataAsync
 } from './lib/category-api/parsed-image-api';
 
 // DEPRECATED
 // TODO - Remove in V3
 export {loadImage} from './lib/texture-api/load-image';
-
-import {getDefaultImageType} from './lib/category-api/image-type';
-
-export function getSupportedImageType(imageType = null) {
-  return getDefaultImageType();
-}
 
 export {
   isBinaryImage,

--- a/modules/images/src/lib/category-api/image-type.js
+++ b/modules/images/src/lib/category-api/image-type.js
@@ -1,13 +1,16 @@
 /* global ImageBitmap, Image */
-import {global, isBrowser} from '../utils/globals';
+import {global, isBrowser, isWorker} from '../utils/globals';
 
 // @ts-ignore TS2339: Property does not exist on type
 const {_parseImageNode} = global;
 
-const IMAGE_SUPPORTED = typeof Image !== 'undefined'; // NOTE: "false" positives if jsdom is installed
+// NOTE: "false" positives if jsdom is installed
+const IMAGE_SUPPORTED = typeof Image !== 'undefined' && !isWorker; // NOTE: "false" positives if jsdom is installed
 const IMAGE_BITMAP_SUPPORTED = typeof ImageBitmap !== 'undefined';
 const NODE_IMAGE_SUPPORTED = Boolean(_parseImageNode);
 const DATA_SUPPORTED = isBrowser ? true : NODE_IMAGE_SUPPORTED;
+
+const ERR_INSTALL_POLYFILLS = `Install '@loaders.gl/polyfills' to parse images under Node.js`;
 
 // Checks if a loaders.gl image type is supported
 export function isImageTypeSupported(type) {
@@ -30,7 +33,7 @@ export function isImageTypeSupported(type) {
       return DATA_SUPPORTED;
 
     default:
-      throw new Error(`@loaders.gl/images: image ${type} not supported in this environment`);
+      throw new Error(`@loaders.gl/images: unknown image type ${type}`);
   }
 }
 
@@ -47,5 +50,5 @@ export function getDefaultImageType() {
   }
 
   // This should only happen in Node.js
-  throw new Error(`Install '@loaders.gl/polyfills' to parse images under Node.js`);
+  throw new Error(ERR_INSTALL_POLYFILLS);
 }

--- a/modules/images/src/lib/category-api/parsed-image-api.d.ts
+++ b/modules/images/src/lib/category-api/parsed-image-api.d.ts
@@ -2,5 +2,6 @@ import {ImageType, ImageTypeEnum, ImageDataType} from '../../types';
 
 export function isImage(image: ImageType): boolean;
 export function getImageType(image: ImageType, throwOnError?: boolean): ImageTypeEnum;
-export function getImageData(image: ImageType): ImageDataType | ImageData;
 export function getImageSize(image: ImageType): {width: number; height: number};
+export function getImageData(image: ImageType): ImageDataType | ImageData;
+export function getImageDataAsync(image: ImageType): Promise<ImageDataType>;

--- a/modules/images/src/lib/category-api/parsed-image-api.js
+++ b/modules/images/src/lib/category-api/parsed-image-api.js
@@ -1,18 +1,8 @@
-/* global Image, ImageBitmap */
-import assert from '../utils/assert';
+/* global document, Image, ImageBitmap */
+import runWorker from './run-worker';
 
 export function isImage(image) {
   return Boolean(getImageTypeOrNull(image));
-}
-
-export function deleteImage(image) {
-  switch (getImageType(image)) {
-    case 'imagebitmap':
-      image.close();
-      break;
-    default:
-    // Nothing to do for images and image data objects
-  }
 }
 
 export function getImageType(image) {
@@ -23,32 +13,11 @@ export function getImageType(image) {
   return format;
 }
 
-export function getImageData(image) {
-  switch (getImageType(image)) {
-    case 'data':
-      return image;
-
-    case 'image':
-    case 'imagebitmap':
-      // Extract the image data from the image via a canvas
-      /* global document */
-      const canvas = document.createElement('canvas');
-      // TODO - reuse the canvas?
-      const context = canvas.getContext('2d');
-      if (context) {
-        canvas.width = image.width;
-        canvas.height = image.height;
-        context.drawImage(image, 0, 0);
-        return context.getImageData(0, 0, image.width, image.height);
-      }
-    // eslint-disable no-fallthrough
-    default:
-      return assert(false);
-  }
+export function getImageSize(image) {
+  return getImageType(image) === 'image'
+    ? {width: image.naturalWidth, height: image.naturalHeight}
+    : {width: image.width, height: image.height};
 }
-
-// TODO DEPRECATED not needed (use getImageData)
-export {getImageData as getImageSize};
 
 // PRIVATE
 
@@ -64,4 +33,88 @@ function getImageTypeOrNull(image) {
     return 'data';
   }
   return null;
+}
+
+// MAIN THREAD IMAGE EXTRACTION
+
+let canvas;
+let context2d;
+
+export function getImageData(image, options = {}) {
+  let imageData;
+  switch (getImageType(image)) {
+    case 'image':
+    case 'imagebitmap':
+    // @ts-ignore DEPRECATED Backwards compatibility
+    case 'html': // eslint-disable-line no-fallthrough
+      canvas = canvas || document.createElement('canvas');
+      canvas.width = image.width;
+      canvas.height = image.height;
+      context2d = context2d || canvas.getContext('2d');
+      context2d.drawImage(image, 0, 0);
+      imageData = context2d.getImageData(0, 0, image.width, image.height);
+      // if (options.includeImage) {
+      //   imageData.image = image;
+      // }
+      return imageData;
+
+    case 'data':
+    default:
+      return image;
+  }
+}
+
+// WORKER BASED IMAGE EXTRACTION
+
+const WORKER_SCRIPT = `
+let canvas;
+let context2d;
+onmessage = function(event) {
+  try {
+    const {image, options} = event.data;
+    // TODO - can we reuse and resize instead of creating new canvas for each image?
+    canvas = canvas || new OffscreenCanvas(image.width, image.height);
+    // TODO potentially more efficient, but seems to block 2D context creation?
+    // const bmContext = canvas.getContext('bitmaprenderer');
+    // bmContext.transferFromImageBitmap(image);
+    context2d = context2d || canvas.getContext('2d');
+    context2d.drawImage(image, 0, 0);
+    const imageData = context2d.getImageData(0, 0, image.width, image.height);
+    const {width, height} = imageData;
+
+    // Uint8Array cannot be transferred, so unwrap the underlying ArrayBuffer
+    let data = imageData.data.buffer;
+
+    const result = {width, height, data, worker: true};
+    const transferList = [data];
+
+    // the original image will be detached in the main-thread, but we can optionally "send" it back
+    if (options && options.includeImage) {
+      result.image = image;
+      transferList.push(image);
+    }
+
+    postMessage({type: 'done', result}, [data]);
+  } catch (error) {
+    postMessage({type: 'error', message: error.message});
+  }
+}
+`;
+
+let workerDisabled = false;
+
+export async function getImageDataAsync(image, options) {
+  if (!workerDisabled && typeof ImageBitmap !== 'undefined' && image instanceof ImageBitmap) {
+    try {
+      const imageData = await runWorker(WORKER_SCRIPT, 'getImageAsync', {image, options});
+      // Uint8Array cannot be transferred, so rewrap the underlying ArrayBuffer
+      imageData.data = new Uint8Array(imageData.data);
+      return imageData;
+    } catch (error) {
+      // eslint-disable-next-line
+      console.error(`disabling worker due to error: ${error}`);
+      workerDisabled = true;
+    }
+  }
+  return getImageData(image);
 }

--- a/modules/images/src/lib/category-api/run-worker.js
+++ b/modules/images/src/lib/category-api/run-worker.js
@@ -1,0 +1,26 @@
+import {WorkerFarm} from '@loaders.gl/worker-utils';
+
+/**
+ * this function expects that the worker function sends certain messages,
+ * this can be automated if the worker is wrapper by a call to createWorker in @loaders.gl/loader-utils.
+ */
+export default async function runWorker(workerSource, workerName, data, options = {}) {
+  const workerFarm = getWorkerFarm(options);
+
+  // removes functions which cannot be transferred
+  options = JSON.parse(JSON.stringify(options));
+
+  return await workerFarm.process(workerSource, `${workerName}-worker`, data);
+}
+
+let _workerFarm = null;
+
+// Create a single instance of a worker farm
+function getWorkerFarm(props = {}) {
+  if (!_workerFarm) {
+    _workerFarm = new WorkerFarm({maxConcurrency: 8, ...props});
+  } else {
+    _workerFarm.setProps(props);
+  }
+  return _workerFarm;
+}

--- a/modules/images/src/lib/encoders/encode-image.js
+++ b/modules/images/src/lib/encoders/encode-image.js
@@ -1,7 +1,7 @@
 // Image loading/saving for browser and Node.js
 /* global document, ImageBitmap, ImageData */
 import {global} from '../utils/globals';
-import {getImageSize} from '../category-api/parsed-image-api';
+import {getImageData} from '../category-api/parsed-image-api';
 
 // @ts-ignore TS2339: Property does not exist on type
 const {_encodeImageNode} = global;
@@ -28,7 +28,8 @@ let qualityParamSupported = true;
 async function encodeImageInBrowser(image, options) {
   const {mimeType, jpegQuality} = options.image;
 
-  const {width, height} = getImageSize(image);
+  // TODO - we only need width and height
+  const {width, height} = getImageData(image);
 
   // create a canvas and resize it to the size of our image
   const canvas = document.createElement('canvas');

--- a/modules/images/src/lib/parsers/parse-image.js
+++ b/modules/images/src/lib/parsers/parse-image.js
@@ -1,6 +1,6 @@
 import assert from '../utils/assert';
 import {isImageTypeSupported, getDefaultImageType} from '../category-api/image-type';
-import {getImageData} from '../category-api/parsed-image-api';
+import {getImageData, getImageDataAsync} from '../category-api/parsed-image-api';
 import parseToImage from './parse-to-image';
 import parseToImageBitmap from './parse-to-image-bitmap';
 import parseToNodeImage from './parse-to-node-image';
@@ -36,11 +36,60 @@ export default async function parseImage(arrayBuffer, options, context) {
   }
 
   // Browser: if options.image.type === 'data', we can now extract data from the loaded image
-  if (imageType === 'data') {
-    image = getImageData(image);
+  switch (imageType) {
+    case 'data':
+      // extract data and "delete" the no-longer needed image
+      const imageData = options.image._async
+        ? await getImageDataAsync(image)
+        : await getImageData(image);
+
+      // imagebitmaps can be released explicitly
+      if (image.close) {
+        image.close();
+      }
+
+      return imageData;
+
+    default:
+      return image;
   }
 
-  return image;
+  /*
+  let imagePromise;
+  switch (loadType) {
+    case 'imagebitmap':
+      image = await parseToImageBitmap(arrayBuffer, options, url);
+      break;
+    case 'image':
+      imagePromise = parseToImage(arrayBuffer, options, url);
+      break;
+    case 'data':
+      // Node.js loads imagedata directly
+      imagePromise = parseToNodeImage(arrayBuffer, options);
+      break;
+    default:
+      assert(false);
+  }
+
+  // Browser: if options.image.type === 'data', we can now extract data from the loaded image
+  switch (imageType) {
+    case 'data':
+      // extract data
+      return imagePromise
+        .then(image => getImageDataAsync(image, {includeImage: true}))
+        .then(imageData => {
+          // imageBitmap has a close method to dispose of graphical resources, call if available
+          if (imageData.image && imageData.image.close) {
+            imageData.image.close();
+          }
+          delete imageData.image;
+          return imageData;
+        });
+
+    default:
+      return imagePromise;
+  }
+  */
 }
 
 // Get a loadable image type from image type
@@ -53,7 +102,9 @@ function getLoadableImageType(type) {
       return getDefaultImageType();
     default:
       // Throw an error if not supported
-      isImageTypeSupported(type);
+      if (!isImageTypeSupported(type)) {
+        throw new Error(`@loaders.gl/images: image type ${type} not supported in this environment`);
+      }
       return type;
   }
 }

--- a/modules/images/src/lib/texture-api/load-image.js
+++ b/modules/images/src/lib/texture-api/load-image.js
@@ -1,6 +1,6 @@
 import assert from '../utils/assert';
 import parseImage from '../parsers/parse-image';
-import {getImageSize} from '../category-api/parsed-image-api';
+import {getImageData} from '../category-api/parsed-image-api';
 import {generateUrl} from './generate-url';
 import {deepLoad, shallowLoad} from './deep-load';
 
@@ -24,7 +24,7 @@ async function getMipmappedImageUrls(getUrl, mipLevels, options, urlOptions) {
     const url = generateUrl(getUrl, options, {...urlOptions, lod: 0});
     const image = await shallowLoad(url, parseImage, options);
 
-    const {width, height} = getImageSize(image);
+    const {width, height} = getImageData(image);
     mipLevels = getMipLevels({width, height});
 
     // TODO - push image and make `deepLoad` pass through non-url values, avoid loading twice?

--- a/modules/images/src/types.d.ts
+++ b/modules/images/src/types.d.ts
@@ -7,6 +7,7 @@ export type ImageDataType = {
   width: number;
   height: number;
   compressed?: boolean;
+  worker?: boolean; // if processed on worker
 }
 
 /**

--- a/modules/images/src/workers/get-image-data.worker.js
+++ b/modules/images/src/workers/get-image-data.worker.js
@@ -1,0 +1,36 @@
+/* global self, OffscreenCanvas, postMessage */
+let canvas;
+let context2d;
+
+self.onmessage = function(event) {
+  try {
+    const {image, options} = event.data;
+    // TODO - can we reuse and resize instead of creating new canvas for each image?
+    canvas = canvas || new OffscreenCanvas(image.width, image.height);
+    // TODO potentially more efficient, but seems to block 2D context creation?
+    // const bmContext = canvas.getContext('bitmaprenderer');
+    // bmContext.transferFromImageBitmap(image);
+    context2d = context2d || canvas.getContext('2d');
+    context2d.drawImage(image, 0, 0);
+    const imageData = context2d.getImageData(0, 0, image.width, image.height);
+    const {width, height} = imageData;
+
+    // Uint8Array cannot be transferred, so unwrap the underlying ArrayBuffer
+    const data = imageData.data.buffer;
+
+    const result = {width, height, data, worker: true};
+    const transferList = [data];
+
+    // the original image will be detached in the main-thread, but we can optionally "send" it back
+    if (options && options.image && options.image.returnImage) {
+      result.image = image;
+      transferList.push(image);
+    }
+
+    // @ts-ignore
+    postMessage({type: 'done', result}, [data]);
+  } catch (error) {
+    // @ts-ignore
+    postMessage({type: 'error', message: error.message});
+  }
+};

--- a/modules/images/test/images.bench.js
+++ b/modules/images/test/images.bench.js
@@ -1,16 +1,26 @@
-import {ImageLoader, isImageTypeSupported} from '@loaders.gl/images';
+/* global createImageBitmap */
+import {
+  ImageLoader,
+  isImageTypeSupported,
+  getImageData,
+  getImageDataAsync
+} from '@loaders.gl/images';
 import {fetchFile, parse} from '@loaders.gl/core';
 
 const TEST_URL = '@loaders.gl/images/test/data/tiles/colortile-256x256.png';
 
 const OPTIONS = [
   {type: 'imagebitmap'},
-  {type: 'image', decode: false},
+  {type: 'data', _extractDataOnWorker: true},
+  {type: 'data', _extractDataOnWorker: false},
   {type: 'image', decode: true},
-  {type: 'data'}
+  {type: 'image', decode: false}
 ];
 
 export default async function imageLoaderBench(suite) {
+  // ADD IMAGE DATA EXTRACTION BENCHMARKS
+  await getImageDataBench(suite);
+
   const response = await fetchFile(TEST_URL);
   const masterArrayBuffer = await response.arrayBuffer();
 
@@ -18,6 +28,9 @@ export default async function imageLoaderBench(suite) {
   await parse(masterArrayBuffer.slice(0), ImageLoader);
 
   // Add the tests
+
+  // PARALLEL PARSING
+
   suite.group('ImageLoader: parallel parsing of 256x256 color tiles');
   for (const options of OPTIONS) {
     const {type, worker} = options;
@@ -25,10 +38,16 @@ export default async function imageLoaderBench(suite) {
       suite.addAsync(
         `parse({images: {${JSON.stringify(options)}}) parallel`,
         {unit: 'tiles(256x256)', _throughput: 100, _target: 1000},
-        async () => await parse(masterArrayBuffer.slice(0), ImageLoader, {worker, image: options})
+        async () =>
+          await parse(masterArrayBuffer.slice(0), ImageLoader, {
+            worker,
+            image: options
+          })
       );
     }
   }
+
+  // SEQUENTIAL PARSING
 
   suite.group('ImageLoader: sequential parsing of 256x256 color tiles');
   for (const options of OPTIONS) {
@@ -37,19 +56,67 @@ export default async function imageLoaderBench(suite) {
       suite.addAsync(
         `parse({images: ${JSON.stringify(options)}}) sequential`,
         {unit: 'tiles(256x256)', _target: 1000},
-        async () => {
-          const arrayBuffer = masterArrayBuffer.slice(0);
-          return await parse(arrayBuffer, ImageLoader, {worker, image: options});
-        }
+        async () => await parse(masterArrayBuffer.slice(0), ImageLoader, {worker, image: options})
       );
     }
   }
+}
 
-  // for (const type of ['image', 'imagebitmap', 'data']) {
-  //   if (isImageTypeSupported(type)) {
-  //     suite.addAsync(`parse(ImageLoader, type=${type}, data=true)`, async () => {
-  //       return await parse(arrayBuffer, ImageLoader, {image: {type, data: true}});
-  //     });
-  //   }
-  // }
+async function getImageDataBench(suite) {
+  const response = await fetchFile(TEST_URL);
+  const masterArrayBuffer = await response.arrayBuffer();
+
+  // DATA EXTRACTION
+
+  if (isImageTypeSupported('imagebitmap')) {
+    suite.group('getImageData: parallel data extraction from 256x256 color tiles');
+
+    // We need a lot of ImageBitmaps as they get detached in worker processing
+    const BITMAP_COUNT = 20000;
+    const imageBitmap = await parse(masterArrayBuffer.slice(0), ImageLoader, {
+      image: {type: 'imagebitmap'}
+    });
+    const imageBitmapPromises = new Array(BITMAP_COUNT)
+      .fill(null)
+      .map((_, i) => createImageBitmap(imageBitmap, i % 20, 0, 256 - (i % 20), 256));
+    const imageBitmaps = await Promise.all(imageBitmapPromises);
+    let imageBitmapCounter = 0;
+
+    // Warm up the thread pools
+    const warmUpPromises = [];
+    for (let i = 0; i < 20; ++i) {
+      warmUpPromises.push(getImageDataAsync(imageBitmaps[imageBitmapCounter++]));
+    }
+    await Promise.all(warmUpPromises);
+
+    suite.addAsync(
+      `getImageDataAsync()`,
+      {unit: 'tiles(256x256)', _throughput: 100, _target: 1000},
+      async () => await getImageDataAsync(imageBitmaps[imageBitmapCounter++])
+    );
+
+    suite.addAsync(
+      `getImageData()`,
+      {unit: 'tiles(256x256)', _throughput: 100, _target: 1000},
+      async () => await getImageData(imageBitmaps[imageBitmapCounter++])
+    );
+
+    suite.group('getImageData: sequential data extraction from 256x256 color tiles');
+
+    suite.addAsync(
+      `getImageDataAsync() sequential`,
+      {unit: 'tiles(256x256)', _target: 1000},
+      async () => await getImageDataAsync(imageBitmaps[imageBitmapCounter++])
+    );
+
+    suite.add(`getImageData() sequential`, {unit: 'tiles(256x256)', _target: 1000}, () =>
+      getImageData(imageBitmaps[imageBitmapCounter++])
+    );
+
+    suite.add(
+      `getImageData() sequential (same bitmap) - browser caching defeating benchmarks!`,
+      {unit: 'tiles(256x256)', _target: 1000},
+      () => getImageData(imageBitmap)
+    );
+  }
 }

--- a/modules/images/test/lib/category-api/parsed-image-api.spec.js
+++ b/modules/images/test/lib/category-api/parsed-image-api.spec.js
@@ -1,15 +1,16 @@
+/* global ImageBitmap */
 import test from 'tape-promise/tape';
 import {load} from '@loaders.gl/core';
 import {ImageLoader} from '@loaders.gl/images';
 
 // PARSED IMAGE API
 import {
-  getDefaultImageType,
   isImageTypeSupported,
   isImage,
   getImageType,
   getImageSize,
-  getImageData
+  getImageData,
+  getImageDataAsync
 } from '@loaders.gl/images';
 
 const IMAGE_TYPES = ['auto', 'image', 'imagebitmap', 'data'];
@@ -30,18 +31,11 @@ async function loadImages() {
 }
 
 test('Image Category#Parsed Image API imports', t => {
-  t.ok(getDefaultImageType, 'getDefaultImageType() is defined');
   t.ok(isImageTypeSupported, 'isImageTypeSupported() is defined');
   t.ok(isImage, 'isImage() is defined');
   t.ok(getImageType, 'getImageType() is defined');
   t.ok(getImageSize, 'getImageSize() is defined');
   t.ok(getImageData, 'getImageData() is defined');
-  t.end();
-});
-
-test('Image Category#getDefaultImageType', async t => {
-  const imageType = getDefaultImageType();
-  t.ok(IMAGE_TYPES.includes(imageType), 'Returns an expected image type');
   t.end();
 });
 
@@ -91,9 +85,26 @@ test('Image Category#getImageSize', async t => {
 test('Image Category#getImageData', async t => {
   const IMAGES = await loadImages();
   for (const image of IMAGES) {
-    t.equals(typeof getImageData(image), 'object', 'returns data');
+    const imageData = getImageData(image);
+    t.equals(typeof imageData, 'object', 'returns data');
+    // @ts-ignore
+    t.notOk(imageData.worker, 'processed on main-thread');
   }
   // @ts-ignore
   t.throws(() => getImageData('not an image'));
+  t.end();
+});
+
+test('Image Category#getImageDataAsync', async t => {
+  const IMAGES = await loadImages();
+  for (const image of IMAGES) {
+    const imageData = getImageData(image);
+    const imageData2 = await getImageDataAsync(image);
+    t.deepEquals(imageData.data, imageData2.data, 'returns correct data');
+    if (typeof ImageBitmap !== 'undefined' && image instanceof ImageBitmap) {
+      // @ts-ignore
+      t.ok(imageData2.worker, 'processed on worker');
+    }
+  }
   t.end();
 });

--- a/test/bench/browser.js
+++ b/test/bench/browser.js
@@ -23,6 +23,7 @@ import '@loaders.gl/polyfills';
 import {Bench} from '@probe.gl/bench';
 import {_addAliases} from '@loaders.gl/loader-utils';
 import ALIASES from '../aliases';
+const {Bench} = require('@probe.gl/Bench');
 import {addModuleBenchmarksToSuite} from './modules';
 
 // Sets up aliases for file reader


### PR DESCRIPTION
For `data` type images, doing the data extraction off thread (here via an `OffScreenCanvas`), seems to have significant throughput advantages (~50% increase from 200 to 300 256x256 extractions per second) .

Uses an inline worker script string since no dependencies, no need to build worker.

- [ ] This PR is on hold, pending #843 (intention is to land this in the image-api module, not the images module)

Remaining work
- [ ] Reorganize this code to avoid growing the ImageLoader module.
- [ ] Benchmarks that work around browser caching (current benchmarks do not prove that extraction on worker is faster)
- [x] Make the new non-loader worker work with WorkerFarm.
- [x] add some test that the extracted data is actually correct
- [x] Fallback to extract data from `image` on main thread needs to be verified. The approach seems somewhat "fragile" (e.g. it likely only works on Chrome), logic to activate this only when needed/supported is missing

NOTES about ImageWorkerLoader
- Loading `ImageBitmap`s on a worker is possible, and was tested, but at least in Chrome this did not increase throughput but slightly reduced it (`ImageBitmap` loading is async and presumably already done off-thread, just as one would hope).
