### PR TITLE
website: Add point cloud example to the loaders.gl Examples page

### DIFF
--- a/website/gatsby-config.js
+++ b/website/gatsby-config.js
@@ -63,12 +63,12 @@ module.exports = {
         INDEX_PAGE_URL: resolve(__dirname, './templates/index.jsx'),
 
         EXAMPLES: [
-          // {
-          //   title: 'Point Clouds & Meshes',
-          //   image: 'images/example-pointcloud.png',
-          //   componentUrl: resolve(__dirname, '../examples/pointcloud/app.js'),
-          //   path: 'examples/pointcloud'
-          // },
+          {
+            title: 'Point Clouds & Meshes',
+            image: 'images/example-pointcloud.png',
+            componentUrl: resolve(__dirname, '../examples/deck.gl/pointcloud/app.js'),
+            path: 'examples/pointcloud'
+          },
           {
             title: '3D Tiles',
             image: 'images/example-3d-tiles.png',


### PR DESCRIPTION
Thanks to the contributions of @Gmadges we are quite close to being able to add back the point cloud example to the loaders.gl website.

This is a just a draft PR, since there are unfortunately some remaining issues:
- [x] The layout of the example pane needs to be adapted to the new gatsby theme. 
- [ ] The bounding box calculation seems to fail for the `LUCY` model (very long/tall geometry)
- [ ] It might be nice to include some credentials for each test file and show in the info panel.
- [x] Maybe change the default example to the "richmond azaelias'?
- [x] Maybe lower the spin speed somewhat?

<img width="853" alt="Screen Shot 2020-03-05 at 9 39 06 AM" src="https://user-images.githubusercontent.com/7025232/76009416-0645e180-5ec6-11ea-8934-7b34c2af0b05.png">
