### PR TITLE
[Discussion] Simplify RequestScheduler API

### DIFF
--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -102,6 +102,7 @@
             {"entry": "modules/core/docs/api-reference/set-path-prefix"},
             {"entry": "modules/core/docs/api-reference/binary-utilities"},
             {"entry": "modules/core/docs/api-reference/iterator-utilities"},
+            {"entry": "modules/loader-utils/docs/api-reference/request-scheduler"},
             {"entry": "docs/specifications/loader-object-format"},
             {"entry": "docs/specifications/writer-object-format"}
           ]

--- a/modules/core/src/index.js
+++ b/modules/core/src/index.js
@@ -49,6 +49,7 @@ export {makeChunkIterator, concatenateChunksAsync} from './iterator-utils/chunk-
 export {isBrowser, isWorker, self, window, global, document} from '@loaders.gl/loader-utils';
 export {assert} from '@loaders.gl/loader-utils';
 export {setPathPrefix, getPathPrefix, resolvePath} from '@loaders.gl/loader-utils';
+export {default as RequestScheduler} from '@loaders.gl/loader-utils';
 
 // EXPERIMENTAL
 export {default as _WorkerThread} from './worker-utils/worker-thread';

--- a/modules/loader-utils/docs/api-reference/request-scheduler.md
+++ b/modules/loader-utils/docs/api-reference/request-scheduler.md
@@ -4,15 +4,20 @@ The request scheduler enables an application to "issue" a large number of reques
 
 A getPriority callback is called on all outstanding requests whenever a slot frees up, allowing the application to reprioritize or even cancel "issued" requests if the application state has changed.
 
+Note: The request scheduler does not actually issue requests, it just lets apps know when the request can be issued without overwhelming the connection and the server.
+
+A primary use case is to let the app reprioritize or cancel requests if circumstances change before the request can be scheduled.
+
 ## Usage
 
 To issue
+
 ```js
 const URL = '...';
 const requestToken = await requestScheduler.scheduleRequest(URL);
 if (requestToken) {
   await fetch(URL);
-  requestToken.done();  // NOTE: **must** be called for the next request in queue to resolve
+  requestToken.done(); // NOTE: **must** be called for the next request in queue to resolve
 }
 ```
 
@@ -33,12 +38,13 @@ The promise resolves to an object that contains a `done` method.
 When the application's request has completed (or failed), the application must call the `done` function
 
 Parameters
+
 - `handle` an arbitrary handle to identify the request, e.g. a URL string
 - `getPriority` will be called when request "slots" open up,
-   allowing the caller to update priority or cancel the request
-   Highest priority executes first, priority < 0 cancels the request
+  allowing the caller to update priority or cancel the request
+  Highest priority executes first, priority < 0 cancels the request
 
 Returns a promise that
+
 - resolves when the request can be issued without queueing.
 - rejects if the request has been cancelled (by the callback return < 0).
-

--- a/modules/loader-utils/docs/api-reference/request-scheduler.md
+++ b/modules/loader-utils/docs/api-reference/request-scheduler.md
@@ -1,0 +1,44 @@
+# Request Scheduler
+
+The request scheduler enables an application to "issue" a large number of requests without flooding the browser's limited request queue.
+
+A getPriority callback is called on all outstanding requests whenever a slot frees up, allowing the application to reprioritize or even cancel "issued" requests if the application state has changed.
+
+## Usage
+
+To issue
+```js
+const URL = '...';
+const requestToken = await requestScheduler.scheduleRequest(URL);
+if (requestToken) {
+  await fetch(URL);
+  requestToken.done();  // NOTE: **must** be called for the next request in queue to resolve
+}
+```
+
+## Methods
+
+### constructor(options?: object)
+
+- `id`?: string;
+- `throttleRequests`?: boolean;
+- `maxRequests`?: number;
+
+### scheduleRequest(handle: any, getPriority?: () => number): Promise<{done: () => any)}>;
+
+Called by an application that wants to issue a request, without having it deeply queued by the browser
+
+When the returned promise resolved, it is OK for the application to issue a request.
+The promise resolves to an object that contains a `done` method.
+When the application's request has completed (or failed), the application must call the `done` function
+
+Parameters
+- `handle` an arbitrary handle to identify the request, e.g. a URL string
+- `getPriority` will be called when request "slots" open up,
+   allowing the caller to update priority or cancel the request
+   Highest priority executes first, priority < 0 cancels the request
+
+Returns a promise that
+- resolves when the request can be issued without queueing.
+- rejects if the request has been cancelled (by the callback return < 0).
+

--- a/modules/loader-utils/docs/api-reference/request-scheduler.md
+++ b/modules/loader-utils/docs/api-reference/request-scheduler.md
@@ -8,9 +8,11 @@ Note: The request scheduler does not actually issue requests, it just lets apps 
 
 A primary use case is to let the app reprioritize or cancel requests if circumstances change before the request can be scheduled.
 
+- Some information on browser [request throttling](https://docs.pushtechnology.com/cloud/latest/manual/html/designguide/solution/support/connection_limitations.html)
+
 ## Usage
 
-To issue
+To schedule a request so that it can be issued at a time when it can be immediately processed.
 
 ```js
 const URL = '...';
@@ -46,5 +48,10 @@ Parameters
 
 Returns a promise that
 
-- resolves when the request can be issued without queueing.
-- rejects if the request has been cancelled (by the callback return < 0).
+- resolves to an object (with a `done` field) when the request can be issued without queueing. The application should issue the request and call `done()` when completed.
+- resolves to `null` if the request has been cancelled (by the callback return < 0).
+  In this case the application should not issue the request.
+
+## About Request Priorities
+
+The `getPriority` callback controls priority of requests and also cancellation of outstanding requests.

--- a/modules/loader-utils/src/lib/request-utils/request-scheduler.d.ts
+++ b/modules/loader-utils/src/lib/request-utils/request-scheduler.d.ts
@@ -4,37 +4,25 @@ type RequestSchedulerProps = {
   maxRequests?: number;
 };
 
+type DoneFunction = () => any;
+
 export default class RequestScheduler {
   constructor(props?: RequestSchedulerProps);
 
   /**
    * Called by an application that wants to issue a request, without having it deeply queued by the browser
    * 
+   * When the returned promise resolved, it is OK for the application to issue a request.
+   * The promise resolves to an object that contains a `done` method.
+   * When the application's request has completed (or failed), the application must call the 
+   * 
    * @param handle 
-   * @param callback will be called when request "slots" open up,
+   * @param getPriority will be called when request "slots" open up,
    *    allowing the caller to update priority or cancel the request
    *    Highest priority executes first, priority < 0 cancels the request
-   * @return a promise that resolves when the request can be issued without queueing,
-   *    or rejects if the request has been cancelled (by the callback)
+   * @returns a promise
+   *   - resolves when the request can be issued without queueing,
+   *   - rejects if the request has been cancelled (by the callback return < 0)
    */
-  scheduleRequest(handle: any, callback?: () => number): Promise<boolean>;
-  
-  /**
-   * Called by an application to mark that it is actively making a request
-   * @param handle 
-   */
-  startRequest(handle: any);
-
-  /**
-   * Called by an application to mark that it is finished making a request
-   * @param handle 
-   */
-  endRequest(handle: any);
-
-  /**
-   * Tracks a request promise, starting and then ending the request (triggering new slots).
-   * @param handle 
-   * @param promise 
-   */
-  trackRequestPromise(handle: any, promise: any);
+  scheduleRequest(handle: any, getPriority?: () => number): Promise<{done: DoneFunction}>;
 }

--- a/modules/loader-utils/src/lib/request-utils/request-scheduler.d.ts
+++ b/modules/loader-utils/src/lib/request-utils/request-scheduler.d.ts
@@ -7,6 +7,8 @@ type RequestSchedulerProps = {
 type DoneFunction = () => any;
 
 export default class RequestScheduler {
+  readonly activeRequestCount: number;
+
   constructor(props?: RequestSchedulerProps);
 
   /**
@@ -14,7 +16,7 @@ export default class RequestScheduler {
    * 
    * When the returned promise resolved, it is OK for the application to issue a request.
    * The promise resolves to an object that contains a `done` method.
-   * When the application's request has completed (or failed), the application must call the 
+   * When the application's request has completed (or failed), the application must call the `done` function
    * 
    * @param handle 
    * @param getPriority will be called when request "slots" open up,

--- a/modules/loader-utils/src/lib/request-utils/request-scheduler.d.ts
+++ b/modules/loader-utils/src/lib/request-utils/request-scheduler.d.ts
@@ -23,8 +23,9 @@ export default class RequestScheduler {
    *    allowing the caller to update priority or cancel the request
    *    Highest priority executes first, priority < 0 cancels the request
    * @returns a promise
-   *   - resolves when the request can be issued without queueing,
-   *   - rejects if the request has been cancelled (by the callback return < 0)
+   *   - resolves to a object (with a `done` field) when the request can be issued without queueing,
+   *   - resolves to `null` if the request has been cancelled (by the callback return < 0).
+   *     In this case the application should not issue the request
    */
-  scheduleRequest(handle: any, getPriority?: () => number): Promise<{done: DoneFunction}>;
+  scheduleRequest(handle: any, getPriority?: () => number): Promise<{done: DoneFunction} | null>;
 }

--- a/modules/loader-utils/src/lib/request-utils/request-scheduler.js
+++ b/modules/loader-utils/src/lib/request-utils/request-scheduler.js
@@ -30,7 +30,7 @@ export default class RequestScheduler {
     // Tracks the number of active requests and prioritizes/cancels queued requests.
     this.requestQueue = [];
     this.activeRequestCount = 0;
-    this.requestMap = {};
+    this.requestMap = new Map();
 
     // Returns the statistics used by the request scheduler.
     this.stats = new Stats({id: props.id});
@@ -44,54 +44,61 @@ export default class RequestScheduler {
   }
 
   // Called by an application that wants to issue a request, without having it deeply queued
-  scheduleRequest(handle, callback = () => 0) {
+  // Parameter `getPriority` will be called when request "slots" open up,
+  //    allowing the caller to update priority or cancel the request
+  //    Highest priority executes first, priority < 0 cancels the request
+  // Returns: a promise that resolves to a request token when the request can be issued without queueing,
+  //    or `false` if the request has been cancelled (by getPriority)
+  scheduleRequest(handle, getPriority = () => 0) {
     // Allows throttling to be disabled
     if (!this.props.throttleRequests) {
-      return Promise.resolve(handle);
+      return Promise.resolve({done: () => {}});
     }
 
     // dedupe
-    if (this.requestMap[handle.id]) {
-      return this.requestMap[handle.id];
+    if (this.requestMap.has(handle)) {
+      return this.requestMap.get(handle);
     }
 
-    let request = null;
+    const request = {handle, getPriority};
     const promise = new Promise((resolve, reject) => {
-      request = {handle, callback, resolve, reject};
+      request.resolve = resolve;
+      request.reject = reject;
       return request;
     });
 
-    // TODO - error, request is not defined?
-    // @ts-ignore
-    this.requestQueue.push({promise, ...request});
-    this.requestMap[handle.id] = promise;
+    this.requestQueue.push(request);
+    this.requestMap.set(handle, promise);
     this._issueNewRequests();
     return promise;
   }
 
-  // Called by an application to mark that it is actively making a request
-  startRequest(handle) {
-    this.activeRequestCount++;
-  }
-
-  // Called by an application to mark that it is finished making a request
-  endRequest(handle) {
-    if (this.requestMap[handle.id]) {
-      delete this.requestMap[handle.id];
-    }
-    this.activeRequestCount--;
-    this._issueNewRequests();
-  }
-
-  // Tracks a request promise, starting and then ending the request (triggering new slots).
-  trackRequestPromise(handle, promise) {
-    this.startRequest(handle);
-    promise.then(() => this.endRequest(handle)).catch(() => this.endRequest(handle));
-  }
-
   // PRIVATE
 
-  // debounce request updates, to prevent duplicate updates in the same tick
+  _issueRequest(request) {
+    const {handle, resolve} = request;
+    let isDone = false;
+
+    const done = () => {
+      // can only be called once
+      if (!isDone) {
+        isDone = true;
+
+        // Stop tracking a request - it has completed, failed, cancelled etc
+        this.requestMap.delete(handle);
+        this.activeRequestCount--;
+        // A slot just freed up, see if any queued requests are waiting
+        this._issueNewRequests();
+      }
+    };
+
+    // Track this request
+    this.activeRequestCount++;
+
+    return resolve ? resolve({done}) : Promise.resolve({done});
+  }
+
+  // We check requests asynchronously, to prevent multiple updates
   _issueNewRequests() {
     if (!this._deferredUpdate) {
       this._deferredUpdate = setTimeout(() => this._issueNewRequestsAsync(), 0);
@@ -114,7 +121,7 @@ export default class RequestScheduler {
     for (let i = 0; i < freeSlots; ++i) {
       if (this.requestQueue.length > 0) {
         const request = this.requestQueue.shift();
-        request.resolve(true);
+        this._issueRequest(request);
       }
     }
 
@@ -130,7 +137,7 @@ export default class RequestScheduler {
       if (!this._updateRequest(request)) {
         // Remove the element and make sure to adjust the counter to account for shortened array
         requestQueue.splice(i, 1);
-        delete this.requestMap[request.handle.id];
+        this.requestMap.delete(request.handle);
         i--;
       }
     }
@@ -141,7 +148,7 @@ export default class RequestScheduler {
 
   // Update a single request by calling the callback
   _updateRequest(request) {
-    request.priority = request.callback(request.handle); // eslint-disable-line callback-return
+    request.priority = request.getPriority(request.handle); // eslint-disable-line callback-return
 
     // by returning a negative priority, the callback cancels the request
     if (request.priority < 0) {

--- a/modules/loader-utils/src/lib/request-utils/request-scheduler.js
+++ b/modules/loader-utils/src/lib/request-utils/request-scheduler.js
@@ -17,11 +17,6 @@ const DEFAULT_PROPS = {
   maxRequests: 6
 };
 
-// The request scheduler does not actually issue requests, it just lets apps know
-// when the request can be issued without overwhelming the server.
-// The main use case is to let the app reprioritize or cancel requests if
-//  circumstances change before the request can be scheduled.
-//
 // TODO - Track requests globally, across multiple servers
 export default class RequestScheduler {
   constructor(props = {}) {

--- a/modules/loader-utils/src/lib/request-utils/request-scheduler.js
+++ b/modules/loader-utils/src/lib/request-utils/request-scheduler.js
@@ -56,9 +56,8 @@ export default class RequestScheduler {
     }
 
     const request = {handle, getPriority};
-    const promise = new Promise((resolve, reject) => {
+    const promise = new Promise(resolve => {
       request.resolve = resolve;
-      request.reject = reject;
       return request;
     });
 
@@ -147,7 +146,7 @@ export default class RequestScheduler {
 
     // by returning a negative priority, the callback cancels the request
     if (request.priority < 0) {
-      request.resolve(false);
+      request.resolve(null);
       return false;
     }
     return true;

--- a/modules/loader-utils/test/lib/request-utils/request-scheduler.spec.js
+++ b/modules/loader-utils/test/lib/request-utils/request-scheduler.spec.js
@@ -11,11 +11,18 @@ test('RequestScheduler#scheduleRequest', async t => {
   const requestScheduler = new RequestScheduler({maxRequests: 1});
   t.ok(requestScheduler);
 
-  let result = await requestScheduler.scheduleRequest({id: 1});
-  t.ok(result, 'should issue request');
+  let requestToken = await requestScheduler.scheduleRequest({id: 1});
+  t.ok(requestToken, 'should issue request');
+  t.is(requestScheduler.activeRequestCount, 1, 'active request count');
+  requestToken.done();
+  t.is(requestScheduler.activeRequestCount, 0, 'active request count');
 
-  result = await requestScheduler.scheduleRequest({id: 2}, () => -1);
-  t.notOk(result, 'should not issue request with negative priority');
+  requestToken.done();
+  t.is(requestScheduler.activeRequestCount, 0, 'active request count');
+
+  requestToken = await requestScheduler.scheduleRequest({id: 2}, () => -1);
+  t.notOk(requestToken, 'should not issue request with negative priority');
+  t.is(requestScheduler.activeRequestCount, 0, 'active request count');
 
   // The following test checks that request#4 is only issued AFTER request#3 is resolved
   // By modifying request#4's priority during request#3
@@ -24,18 +31,26 @@ test('RequestScheduler#scheduleRequest', async t => {
     priority4 = -1;
   };
 
+<<<<<<< HEAD
   // @ts-ignore
   result = await Promise.all([
     requestScheduler.scheduleRequest({id: 3}).then(async () => {
       requestScheduler.startRequest({id: 3});
+=======
+  const result = await Promise.all([
+    requestScheduler.scheduleRequest({id: 3}).then(async req => {
+      t.is(requestScheduler.activeRequestCount, 1, 'active request count');
+>>>>>>> core: simplify RequestScheduler
       await request3();
-      requestScheduler.endRequest({id: 3});
+      req.done();
+      t.is(requestScheduler.activeRequestCount, 0, 'active request count');
     }),
     // priority callback should be called after the previous one is fully resolved
     requestScheduler.scheduleRequest({id: 4}, () => priority4)
   ]);
 
   t.notOk(result[1]);
+  t.is(requestScheduler.activeRequestCount, 0, 'active request count');
 
   t.end();
 });

--- a/modules/loader-utils/test/lib/request-utils/request-scheduler.spec.js
+++ b/modules/loader-utils/test/lib/request-utils/request-scheduler.spec.js
@@ -31,16 +31,9 @@ test('RequestScheduler#scheduleRequest', async t => {
     priority4 = -1;
   };
 
-<<<<<<< HEAD
-  // @ts-ignore
-  result = await Promise.all([
-    requestScheduler.scheduleRequest({id: 3}).then(async () => {
-      requestScheduler.startRequest({id: 3});
-=======
   const result = await Promise.all([
     requestScheduler.scheduleRequest({id: 3}).then(async req => {
       t.is(requestScheduler.activeRequestCount, 1, 'active request count');
->>>>>>> core: simplify RequestScheduler
       await request3();
       req.done();
       t.is(requestScheduler.activeRequestCount, 0, 'active request count');

--- a/modules/tiles/src/tileset/tile-3d.js
+++ b/modules/tiles/src/tileset/tile-3d.js
@@ -185,16 +185,19 @@ export default class TileHeader {
 
     this.contentState = TILE_CONTENT_STATE.LOADING;
 
-    const cancelled = !(await this.tileset._requestScheduler.scheduleRequest(this, updatePriority));
+    const requestToken = await this.tileset._requestScheduler.scheduleRequest(
+      this.id,
+      updatePriority
+    );
 
-    if (cancelled) {
+    if (!requestToken) {
+      // cancelled
       this.contentState = TILE_CONTENT_STATE.UNLOADED;
       return false;
     }
 
     try {
       const contentUrl = this.tileset.getTileUrl(this.contentUrl);
-      this.tileset._requestScheduler.startRequest(this);
       // The content can be a binary tile ot a JSON tileset
       const fetchOptions = this.tileset.fetchOptions;
       const loader = this.tileset.loader;
@@ -222,7 +225,7 @@ export default class TileHeader {
       this.contentState = TILE_CONTENT_STATE.FAILED;
       throw error;
     } finally {
-      this.tileset._requestScheduler.endRequest(this);
+      requestToken.done();
     }
   }
 


### PR DESCRIPTION
### Change List

- `handle` is no longer required to have an `id`
- Dropped `trackRequestPromise` (not sure what this accomplishes - it does not trigger the promise)
- Dropped `startRequest` and `endRequest`:

Before

```js
const shouldRun = requestScheduler.scheduleRequest(this);
if (shouldRun) {
  requestScheduler.startRequest(this);
  await runTask();
  requestScheduler.endRequest(this);  // `startRequest`/`endRequest` must be called in pairs for the next request in queue to resolve
}
```

After

```js
const requestToken = requestScheduler.scheduleRequest(this);
if (requestToken) {
  await runTask();
  requestToken.done();  // must be called for the next request in queue to resolve
}
```

This makes it possible to chain after `scheduleRequest` in another component without passing around the `requestScheduler` instance. It also reduces the surface with the application thus less likely to break.