### PR TITLE
Fix imports in JSONLoader docs

### DIFF
--- a/modules/json/docs/api-reference/json-loader.md
+++ b/modules/json/docs/api-reference/json-loader.md
@@ -23,9 +23,9 @@ The JSONLoader supports streaming JSON parsing, in which case it will yield "bat
 
 ```js
 import {JSONLoader} from '@loaders.gl/json';
-import {load} from '@loaders.gl/core';
+import {loadInBatches} from '@loaders.gl/core';
 
-const data = await loadInBatches('geojson.json', JSONLoader);
+const batches = await loadInBatches('geojson.json', JSONLoader);
 
 for await (const batch of batches) {
   // batch.data will contain a number of rows
@@ -44,9 +44,9 @@ The loader will yield an initial and a final batch with `batch.container` provid
 
 ```js
 import {JSONLoader} from '@loaders.gl/json';
-import {load} from '@loaders.gl/core';
+import {loadInBatches} from '@loaders.gl/core';
 
-const data = await loadInBatches('geojson.json', JSONLoader);
+const batches = await loadInBatches('geojson.json', JSONLoader);
 
 for await (const batch of batches) {
   switch (batch.batchType) {


### PR DESCRIPTION
The streaming examples in JSON docs had incorrect imports.

Additionally, should `loadInBatches` be listed as a Supported API? Right now only `load` is listed in the table, which might be confusing?

| Loader         | Characteristic                                       |
| -------------- | ---------------------------------------------------- |
| Supported APIs | `load`, `parse`, `parseSync`, `parseInBatches`       |
