### PR TITLE
Fix links in ImageLoader docs

### DIFF
--- a/modules/images/docs/README.md
+++ b/modules/images/docs/README.md
@@ -46,11 +46,11 @@ The images API also offers functions to load "composite" images for WebGL textur
 
 These functions take a `getUrl` parameter that enables the app to supply the url for each "sub-image", and return a single promise enabling applications to for instance load all the faces of a cube texture, with one image for each mip level for each face in a single async operation.
 
-| Function                                                              | Description                                                                                                           |
-| --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| [`loadImage`](modules/images/docs/api-reference/load-image)           | Load a single image                                                                                                   |
-| [`loadImageArray`](modules/images/docs/api-reference/load-images)     | Load an array of images, e.g. for a `Texture2DArray` or `Texture3D`                                                   |
-| [`loadImageCube`](modules/images/docs/api-reference/load-cube-images) | Load a map of 6 images for the faces of a cube map, or a map of 6 arrays of images for the mip levels of the 6 faces. |
+| Function                                                               | Description                                                                                                           |
+| ---------------------------------------------------------------------  | --------------------------------------------------------------------------------------------------------------------- |
+| [`loadImage`](modules/images/docs/api-reference/load-image)            | Load a single image                                                                                                   |
+| [`loadImageArray`](modules/images/docs/api-reference/load-image-array) | Load an array of images, e.g. for a `Texture2DArray` or `Texture3D`                                                   |
+| [`loadImageCube`](modules/images/docs/api-reference/load-image-cube)   | Load a map of 6 images for the faces of a cube map, or a map of 6 arrays of images for the mip levels of the 6 faces. |
 
 As with all loaders.gl functions, while these functions are intended for use in WebGL applications, they do not call any WebGL functions, and do not actually create any WebGL textures..
 


### PR DESCRIPTION
A couple of the image loader links are currently broken.