### PR TITLE
Default to ImageBitmap when supported

### DIFF
--- a/modules/images/src/lib/parsed-image-api/image-type.js
+++ b/modules/images/src/lib/parsed-image-api/image-type.js
@@ -35,12 +35,11 @@ export function isImageTypeSupported(type) {
 
 // Returns the best loaders.gl image type supported on current run-time environment
 export function getDefaultImageType() {
-  // TODO - switch order... we want to return imagebitmap by default
-  if (isImageTypeSupported('image')) {
-    return 'image';
-  }
   if (isImageTypeSupported('imagebitmap')) {
     return 'imagebitmap';
+  }
+  if (isImageTypeSupported('image')) {
+    return 'image';
   }
   if (isImageTypeSupported('data')) {
     return 'data';


### PR DESCRIPTION
When `image.type: 'auto'` default to `ImageBitmap` when supported.