### PR TITLE
Fix for Node.js being unable to pull files from non local FS

### DIFF
--- a/modules/polyfills/src/fetch-node/read-file.node.js
+++ b/modules/polyfills/src/fetch-node/read-file.node.js
@@ -32,7 +32,7 @@ export async function readFile(url, options = {}) {
     return new Promise((resolve, reject) => {
       options = {...new URL(url), ...options};
       const request = url.startsWith('https:') ? https.request : http.request;
-      request(url, response => concatenateReadStream(response).then(resolve, reject));
+      request(url, response => concatenateReadStream(response).then(resolve, reject)).end();
     });
   }
 

--- a/modules/polyfills/src/fetch-node/utils/stream-utils.node.js
+++ b/modules/polyfills/src/fetch-node/utils/stream-utils.node.js
@@ -4,7 +4,7 @@ export function concatenateReadStream(readStream) {
   let string = '';
 
   return new Promise((resolve, reject) => {
-    readStream.data(chunk => {
+    readStream.on('data', chunk => {
       if (typeof chunk === 'string') {
         string += chunk;
       } else {

--- a/modules/polyfills/test/fetch-node/fetch.node.spec.js
+++ b/modules/polyfills/test/fetch-node/fetch.node.spec.js
@@ -1,9 +1,10 @@
 /* global fetch */
 import test from 'tape-promise/tape';
 import '@loaders.gl/polyfills';
-import {isBrowser, resolvePath} from '@loaders.gl/core';
+import {isBrowser} from '@loaders.gl/core';
 
-const PLY_CUBE_ATT_URL = resolvePath('@loaders.gl/ply/test/data/cube_att.ply');
+const GITHUB_MASTER = 'https://raw.githubusercontent.com/visgl/loaders.gl/master/';
+const PLY_CUBE_ATT_URL = `${GITHUB_MASTER}ply/test/data/cube_att.ply`;
 
 test('fetch polyfill (Node.js)#fetch()', async t => {
   if (!isBrowser) {


### PR DESCRIPTION
Node.js polyfill wrapper (modules/polyfills/src/fetch-node/read-file.node.js) wasn't closing request making it unable to complete for a non-local FS resources.

Fixed this as well as made test cases for node to pull resources from github directly instead of a local file system. (those 2 were failing before the change if pointed to http/https resources) and passing now.