### PR TITLE
Images Category RFC 

### DIFF
--- a/dev-docs/RFCs/README.md
+++ b/dev-docs/RFCs/README.md
@@ -14,6 +14,7 @@ Writeups of directions in major areas of interest
 
 | RFC                                                                   | Author   | Status    | Description                                                 |
 | --------------------------------------------------------------------- | -------- | --------- | ----------------------------------------------------------- |
+| [**Images Category**](vNext/images-category-rfc.md)       | @ibgreen | **Draft** | Images Category                                    |
 | [**Category Improvements**](vNext/category-improvements-rfc.md)       | @ibgreen | **Draft** | Improve category concept                                    |
 | [**MIME type support**](vNext/mime-type-support-rfc.md)               | @ibgreen | **Draft** | Support for MIME types                                      |
 | [**JSON**](vNext/json-support-rfc.md)                                 | @ibgreen | **Draft** | Core support for JSON formats                               |

--- a/dev-docs/RFCs/README.md
+++ b/dev-docs/RFCs/README.md
@@ -14,7 +14,7 @@ Writeups of directions in major areas of interest
 
 | RFC                                                                   | Author   | Status    | Description                                                 |
 | --------------------------------------------------------------------- | -------- | --------- | ----------------------------------------------------------- |
-| [**Images Category**](vNext/images-category-rfc.md)       | @ibgreen | **Draft** | Images Category                                    |
+| [**Images Category**](vNext/images-category-rfc.md)                   | @ibgreen | **Draft** | Images Category                                             |
 | [**Category Improvements**](vNext/category-improvements-rfc.md)       | @ibgreen | **Draft** | Improve category concept                                    |
 | [**MIME type support**](vNext/mime-type-support-rfc.md)               | @ibgreen | **Draft** | Support for MIME types                                      |
 | [**JSON**](vNext/json-support-rfc.md)                                 | @ibgreen | **Draft** | Core support for JSON formats                               |

--- a/dev-docs/RFCs/README.md
+++ b/dev-docs/RFCs/README.md
@@ -14,6 +14,7 @@ Writeups of directions in major areas of interest
 
 | RFC                                                                   | Author   | Status    | Description                                                 |
 | --------------------------------------------------------------------- | -------- | --------- | ----------------------------------------------------------- |
+| [**Category Improvements**](vNext/category-improvements-rfc.md)       | @ibgreen | **Draft** | Improve category concept                                    |
 | [**MIME type support**](vNext/mime-type-support-rfc.md)               | @ibgreen | **Draft** | Support for MIME types                                      |
 | [**JSON**](vNext/json-support-rfc.md)                                 | @ibgreen | **Draft** | Core support for JSON formats                               |
 | [**File System**](vNext/file-system-rfc.md)                           | @ibgreen | **Draft** | `fetch`-ing from "virtual file systems" (Zip, Dropbox, ...) |

--- a/dev-docs/RFCs/vNext/category-improvements-rfc.md
+++ b/dev-docs/RFCs/vNext/category-improvements-rfc.md
@@ -21,21 +21,28 @@ Some loaders have output that can be "converted" to a specific category with som
 
 ### Proposal: Category modules
 
-Reasons for creating category modules:
+There are already category modles for tables and tiles:
+
+- `@loaders.gl/tables` Tabular loaders: already have a category module with support for table batches and Arrow compatible table access API.
+- `@loaders.gl/tiles` 3D tile loaders have a category module: `Tileset3D` class is exported from , which is confusing to users since the intention is that this class supports all 3d tile formats `i3s`, `potree` etc.
+
+There are strong reasons for creating category modules for other categories
 
 - Tabular loaders: already have an `@loaders.gl/tables` module with support for table batches and Arrow compatible table access API.
 - Image loaders: `@loaders.gl/images` already exposes a set of utility functions to work on images. These are not necessary to just use the loader and are a cause for bundle size concerns due to the central role of the `ImageLoader`.
 - 3D tile loaders: `Tileset3D` class is exported from `@loaders.gl/3d-tiles`, which is confusing to users since the intention is that this class supports all 3d tile formats `i3s`, `potree` etc.
-- Scenegraph Loaders: the GLTFLoader comes with a bunch of helper classes but these are not necessarily generalized enough to justify being moved to a category module. However this is essentially a category of one at the moment.
-- Pointcloud/mesh loaders: There is a single `getmeshsize` utility in another module. Worth considering is any other utilities might be useful.
-- Geospatial loaders: Currently unclear.
+- Scenegraph Loaders: the GLTFLoader comes with a bunch of helper classes but these are not necessarily generalized enough to justify being moved to a category module. However this is essentially a "category of one loader".
+- Pointcloud/mesh loaders: There is a single `getmeshsize` utility in another module. Worth considering is any other utilities are likely to be useful for instance packaging loaded meshes as Arrow tables.
+- Geospatial loaders: The work on binary output format for geospatial "feature" loaders would seem to point towards a category.
 
 ### Idea: Application can specify what category it expects
 
 Right now loaders.gl supports parsing against a list of loaders (pre-registered and/or supplied in the `load` call).
 
-if loaders of different categories are registered, The application may get something back that it can handle, or it may not, and even though it is often clear, there is no standard way to check this, r know what is being returned.
+if loaders of different categories are registered, The application may get something back that it can handle, or it may not, and even though it is often clear, there is no standard way to check this, to know what is being returned.
 
-An option could be provided to request data of a certain category only.
+An option could be provided to request data of a certain category only - only loaders capable of returning data in that category's format.
 
 ## Idea: Category-level options
+
+This is already being implemented to some extent, could be made more rigorous.

--- a/dev-docs/RFCs/vNext/category-improvements-rfc.md
+++ b/dev-docs/RFCs/vNext/category-improvements-rfc.md
@@ -1,0 +1,41 @@
+# RFC: File System Support in loaders.gl
+
+- **Authors**: Ib Green
+- **Date**: Jan 2020
+- **Status**: Draft
+
+## Abstract
+
+This RFC discusses structure of loader categories, module naming etc.
+
+## Overview
+
+### Proposal: Clarify what a category is
+
+Update documentation to state that a category provides
+
+- A standardized data format that loaders can return.
+- A set of utility functions/classes that helps the application work on that standardized data.
+
+Some loaders have output that can be "converted" to a specific category with some loss of information. In that case they can offer an option to do this conversion.
+
+### Proposal: Category modules
+
+Reasons for creating category modules:
+
+- Tabular loaders: already have an `@loaders.gl/tables` module with support for table batches and Arrow compatible table access API.
+- Image loaders: `@loaders.gl/images` already exposes a set of utility functions to work on images. These are not necessary to just use the loader and are a cause for bundle size concerns due to the central role of the `ImageLoader`.
+- 3D tile loaders: `Tileset3D` class is exported from `@loaders.gl/3d-tiles`, which is confusing to users since the intention is that this class supports all 3d tile formats `i3s`, `potree` etc.
+- Scenegraph Loaders: the GLTFLoader comes with a bunch of helper classes but these are not necessarily generalized enough to justify being moved to a category module. However this is essentially a category of one at the moment.
+- Pointcloud/mesh loaders: There is a single `getmeshsize` utility in another module. Worth considering is any other utilities might be useful.
+- Geospatial loaders: Currently unclear.
+
+### Idea: Application can specify what category it expects
+
+Right now loaders.gl supports parsing against a list of loaders (pre-registered and/or supplied in the `load` call).
+
+if loaders of different categories are registered, The application may get something back that it can handle, or it may not, and even though it is often clear, there is no standard way to check this, r know what is being returned.
+
+An option could be provided to request data of a certain category only.
+
+## Idea: Category-level options

--- a/dev-docs/RFCs/vNext/images-category-rfc.md
+++ b/dev-docs/RFCs/vNext/images-category-rfc.md
@@ -9,29 +9,40 @@ See also
 
 ## Abstract
 
-This RFC discusses structure of loader categories, module naming etc.
+This RFC discusses how an images category should be defined.
 
-## Motivations
-
-Jusifications for creating an image category modules:
+## Background
 
 - `@loaders.gl/images` exposes a growing set of utility functions to work on images. 
 - But these are not necessary to just use the loader and are a cause for bundle size concerns due to the central role of the `ImageLoader` in most apps.
 - Also we now have `BasisLoader` and `CompressedImageLoader` in this category and may soon have a `GIFWriter` module.
 
-## Proposal: Split images module into a loader and a category module
-
-- `@loaders.gl/image` A new module that contains only the minimal loaders and  the binary sniffing methods need for the arraybuffer tests.
-
-- `@loaders.gl/images` The existing name becomes the category module. For backwards compatibility, it re-exports the `@loaders.gl/image` module.
-
-Applications can now opt to reduce the size of their dependency by importing `@loaders.gl/image`, and we can continue to develop strong image utilities in the category module.
-
-
-## Prior Art: Other category modules
+### Prior Art: Other category modules
 
 Other examples of category modules
 - `@loaders.gl/tables` Tabular loaders: already have a category module with support for table batches and Arrow compatible table access API.
 - `@loaders.gl/tiles` 3D tile loaders have a category module: `Tileset3D` class is exported from , which is confusing to users since the intention is that this class supports all 3d tile formats `i3s`, `potree` etc.
 
 Scenegraph, pointcloud/mesh and GIS loaders do not yet have category modules but there are strong reasons to believe that this will happen, see the separate RFC on category modules linked at the top.
+
+
+## Proposal: Textures module
+
+- Rename the basis module to `@loaders.gl/textures`
+- Move the texture loading utils to the textures module
+
+This will save a ~2-3KB in the images module.
+
+
+## Proposal (WITHDRAWN): Split images module into an "image loader module" and an "images category module"
+
+Status: Currently withdrawn. This idea was [attempted](https://github.com/visgl/loaders.gl/pull/746) but failed to give substantial memory savings. It may make more sense later on if the image category API keeps growing.
+
+The proposal is:
+
+- `@loaders.gl/image` A new module that contains only the minimal loaders and  the binary sniffing methods need for the arraybuffer tests.
+
+- `@loaders.gl/images` The existing name becomes the category module. For backwards compatibility, it re-exports the `@loaders.gl/image` module.
+
+With this chanve, applications could now opt to reduce the size of their dependency by importing `@loaders.gl/image`, and we can continue to develop strong image utilities in the category module.
+

--- a/dev-docs/RFCs/vNext/images-category-rfc.md
+++ b/dev-docs/RFCs/vNext/images-category-rfc.md
@@ -5,6 +5,7 @@
 - **Status**: For Review
 
 See also
+
 - category improvements rfc
 
 ## Abstract
@@ -13,18 +14,18 @@ This RFC discusses how an images category should be defined.
 
 ## Background
 
-- `@loaders.gl/images` exposes a growing set of utility functions to work on images. 
+- `@loaders.gl/images` exposes a growing set of utility functions to work on images.
 - But these are not necessary to just use the loader and are a cause for bundle size concerns due to the central role of the `ImageLoader` in most apps.
 - Also we now have `BasisLoader` and `CompressedImageLoader` in this category and may soon have a `GIFWriter` module.
 
 ### Prior Art: Other category modules
 
 Other examples of category modules
+
 - `@loaders.gl/tables` Tabular loaders: already have a category module with support for table batches and Arrow compatible table access API.
 - `@loaders.gl/tiles` 3D tile loaders have a category module: `Tileset3D` class is exported from , which is confusing to users since the intention is that this class supports all 3d tile formats `i3s`, `potree` etc.
 
 Scenegraph, pointcloud/mesh and GIS loaders do not yet have category modules but there are strong reasons to believe that this will happen, see the separate RFC on category modules linked at the top.
-
 
 ## Proposal: Textures module
 
@@ -33,16 +34,14 @@ Scenegraph, pointcloud/mesh and GIS loaders do not yet have category modules but
 
 This will save a ~2-3KB in the images module.
 
-
 ## Proposal (WITHDRAWN): Split images module into an "image loader module" and an "images category module"
 
 Status: Currently withdrawn. This idea was [attempted](https://github.com/visgl/loaders.gl/pull/746) but failed to give substantial memory savings. It may make more sense later on if the image category API keeps growing.
 
 The proposal is:
 
-- `@loaders.gl/image` A new module that contains only the minimal loaders and  the binary sniffing methods need for the arraybuffer tests.
+- `@loaders.gl/image` A new module that contains only the minimal loaders and the binary sniffing methods need for the arraybuffer tests.
 
 - `@loaders.gl/images` The existing name becomes the category module. For backwards compatibility, it re-exports the `@loaders.gl/image` module.
 
 With this chanve, applications could now opt to reduce the size of their dependency by importing `@loaders.gl/image`, and we can continue to develop strong image utilities in the category module.
-

--- a/dev-docs/RFCs/vNext/images-category-rfc.md
+++ b/dev-docs/RFCs/vNext/images-category-rfc.md
@@ -1,0 +1,37 @@
+# RFC: Separate images category module
+
+- **Authors**: Ib Green
+- **Date**: May 2020
+- **Status**: For Review
+
+See also
+- category improvements rfc
+
+## Abstract
+
+This RFC discusses structure of loader categories, module naming etc.
+
+## Motivations
+
+Jusifications for creating an image category modules:
+
+- `@loaders.gl/images` exposes a growing set of utility functions to work on images. 
+- But these are not necessary to just use the loader and are a cause for bundle size concerns due to the central role of the `ImageLoader` in most apps.
+- Also we now have `BasisLoader` and `CompressedImageLoader` in this category and may soon have a `GIFWriter` module.
+
+## Proposal: Split images module into a loader and a category module
+
+- `@loaders.gl/image` A new module that contains only the minimal loaders and  the binary sniffing methods need for the arraybuffer tests.
+
+- `@loaders.gl/images` The existing name becomes the category module. For backwards compatibility, it re-exports the `@loaders.gl/image` module.
+
+Applications can now opt to reduce the size of their dependency by importing `@loaders.gl/image`, and we can continue to develop strong image utilities in the category module.
+
+
+## Prior Art: Other category modules
+
+Other examples of category modules
+- `@loaders.gl/tables` Tabular loaders: already have a category module with support for table batches and Arrow compatible table access API.
+- `@loaders.gl/tiles` 3D tile loaders have a category module: `Tileset3D` class is exported from , which is confusing to users since the intention is that this class supports all 3d tile formats `i3s`, `potree` etc.
+
+Scenegraph, pointcloud/mesh and GIS loaders do not yet have category modules but there are strong reasons to believe that this will happen, see the separate RFC on category modules linked at the top.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -64,3 +64,13 @@ To get the headless tests working: export DISPLAY=:99.0; sh -e /etc/init.d/xvfb 
 - `yarn test node`: Quick test run under Node.js
 - `yarn test browser`: Test run under browser, good for interactive debugging
 - `yarn test`: Run lint, node test, browser tests (in headless mode)
+
+## Adding a new loader
+
+The loaders follow a consistent file and directory structure and it should not be hard to duplicate. For instance, to add a loader for mapbox vector tiles one could start by copying an existing loader e.g. WKT.
+
+- Copy `modules/wkt` to `modules/mapbox-vector-tile` or `modules/mvt` (I have a slight preference for more readable names to help guide new users through the growing "loader soup", we could call the loader `MVTLoader` though `load(url, MapboxVectorTileLoader)` would make for very clear application code).
+- Add the mapbox mvt module to dependencies.
+- Search replace `WKT` in docs/src/test/package.json
+- Add a couple of MVT test tiles and specify what license those tiles are under in `../test/data/README.md`.
+- If worker loader support is desired, copy the required package.json script and loader object configuration lines from another loader that support workers.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -67,10 +67,11 @@ To get the headless tests working: export DISPLAY=:99.0; sh -e /etc/init.d/xvfb 
 
 ## Adding a new loader
 
-The loaders follow a consistent file and directory structure and it should not be hard to duplicate. For instance, to add a loader for mapbox vector tiles one could start by copying an existing loader e.g. WKT.
+The loaders follow a consistent file and directory structure and it should not be hard to duplicate. For instance, to add a loader for mapbox vector tiles based on the mapbox parser module, one could start by copying an existing loader e.g. WKT.
 
-- Copy `modules/wkt` to `modules/mapbox-vector-tile` or `modules/mvt` (I have a slight preference for more readable names to help guide new users through the growing "loader soup", we could call the loader `MVTLoader` though `load(url, MapboxVectorTileLoader)` would make for very clear application code).
+- Copy `modules/wkt` to `modules/mvt`.
 - Add the mapbox mvt module to dependencies.
-- Search replace `WKT` in docs/src/test/package.json
+- Search / replace `WKT` in docs / src / test / package.json
 - Add a couple of MVT test tiles and specify what license those tiles are under in `../test/data/README.md`.
 - If worker loader support is desired, copy the required package.json script and loader object configuration lines from another loader that support workers.
+

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -74,4 +74,3 @@ The loaders follow a consistent file and directory structure and it should not b
 - Search / replace `WKT` in docs / src / test / package.json
 - Add a couple of MVT test tiles and specify what license those tiles are under in `../test/data/README.md`.
 - If worker loader support is desired, copy the required package.json script and loader object configuration lines from another loader that support workers.
-


### PR DESCRIPTION
- Proposes splitting the images module into a small loader-only module and a bigger utilities module - this RFC is ready for review
- Also contains a draft RFC on category modules - not ready for review but intended to indicate that we will likely have a category module for each category.
- Also salvages some unrelated text on how to add a new module from a github convo.

Background: We need to add more image utilities and this split should help us avoid concerns on e.g. bundle size growth.