### PR TITLE
Bump Arrow to 0.17.0

### DIFF
--- a/modules/arrow/package.json
+++ b/modules/arrow/package.json
@@ -36,6 +36,6 @@
     "@loaders.gl/core": "^2.1.3",
     "@loaders.gl/loader-utils": "^2.1.3",
     "@loaders.gl/tables": "^2.1.3",
-    "apache-arrow": "^0.16.0"
+    "apache-arrow": "^0.17.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2145,10 +2145,10 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-apache-arrow@^0.16.0:
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/apache-arrow/-/apache-arrow-0.16.0.tgz#7ee7a6397d1a2d6349aed90c6ce5b92362e79881"
-  integrity sha512-hiabMZb2XgHiNK6f7C/2x/fyGS85PoCdkeMhJDyZipaJy1il1BJMDDEa3VLvM6mdxsG61pY1zev6zWetOj8Eog==
+apache-arrow@^0.17.0:
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/apache-arrow/-/apache-arrow-0.17.0.tgz#8f976fc6ffc18e34b15a0b327061534f6c2a2494"
+  integrity sha512-cbgSx/tzGgnC1qeUySXnAsSsoxhDykNINqr1D3U5pRwf0/Q0ztVccV3/VRW6gUR+lcOFawk6FtyYwmU+KjglbQ==
   dependencies:
     "@types/flatbuffers" "^1.9.1"
     "@types/node" "^12.0.4"


### PR DESCRIPTION
This is to set up for supporting Feather v2.