### PR TITLE
Update What's New

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -22,6 +22,18 @@ Addresses a number of compatibility issues with different tilesets that have bee
 
 An experimental new module with video loading and GIF generation support.
 
+**@loaders.gl/wkt**
+
+Worker support for the `WKTLoader`, designed to support future binary data improvements.
+
+**@loaders.gl/json**
+
+Experimental `GeoJSONLoader` (exported with an underscore as `_GeoJSONLoader`), desgined to support future binary data improvements.
+
+**@loaders.gl/arrow**
+
+Updated to use `apache-arrow` version `0.17.0`.
+
 ## v2.1
 
 Release Date: Mar 16, 2020

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.9.1",
-  "version": "2.1.0-beta.2",
+  "version": "2.2.0-alpha.0",
   "command": {
     "publish": {},
     "bootstrap": {}


### PR DESCRIPTION
- Worker support for WKT, 
- Experimental GeoJSONLoader
- Bump arrow to 0.17.0

Update `lerna.json` version to `2.2.0-alpha.0`.