### PR TITLE
docs: Add version numbers to doc pages for new exports

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,19 @@
 # Introduction
 
+<p align="center">
+  <img src="https://img.shields.io/badge/loaders.gl-v2.2-blue.svg?style=flat-square" />
+</p>
+
+<p align="center">
+  Docs for older versions are available on github, e.g.
+  <a href="https://github.com/visgl/loaders.gl/blob/2.1-release/docs/README.md">
+    <img src="https://img.shields.io/badge/loaders.gl-v2.1-green.svg?style=flat-square" />
+  </a>
+  <a href="https://github.com/visgl/loaders.gl/blob/1.3-release/docs/README.md">
+    <img src="https://img.shields.io/badge/loaders.gl-v1.3-green.svg?style=flat-square" />
+  </a>
+</p>
+
 loaders.gl is a suite of loaders for file formats focused on visualization of big data, including point clouds, 3D geometries, images, geospatial formats as well as tabular data.
 
 loaders.gl is part of the [vis.gl](https://vis.gl) ecosystem, and frameworks like [deck.gl](https://deck.gl) and [luma.gl](https://luma.gl) come pre-integrated with loaders.gl. However, all the provided loaders and writers are framework independent, and can be used with any application or framework.

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -2,7 +2,7 @@
 
 ## v2.2 (In Development)
 
-Target Release Date: TBD. Intention is to release in sync with deck.gl 8.2. Alpha releases will be made avaialble.
+Target Release Date: June 2020. Intention is to release in sync with deck.gl 8.2. Alpha releases are available.
 
 ### Typescript Type Definitions
 

--- a/modules/core/docs/api-reference/select-loader.md
+++ b/modules/core/docs/api-reference/select-loader.md
@@ -1,5 +1,9 @@
 # selectLoader
 
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v2.2-blue.svg?style=flat-square" alt="From-v2.2" /> 
+</p>
+
 A core feature of loaders.gl is the ability to automatically select an appropriate loader for a specific resource among a list of candidate loaders. This feature is built-in to the `parse` and `load` functions, but applications can also access this feature directly through the `selectLoader` API.
 
 Loader selection heuristics are based on both filename (url) extensions as well as comparison of initial data content against known headers for each file format.

--- a/modules/loader-utils/docs/api-reference/request-scheduler.md
+++ b/modules/loader-utils/docs/api-reference/request-scheduler.md
@@ -1,5 +1,9 @@
 # Request Scheduler
 
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v2.2-blue.svg?style=flat-square" alt="From-v2.2" /> 
+</p>
+
 The request scheduler enables an application to "issue" a large number of requests without flooding the browser's limited request queue.
 
 A getPriority callback is called on all outstanding requests whenever a slot frees up, allowing the application to reprioritize or even cancel "issued" requests if the application state has changed.

--- a/modules/terrain/docs/api-reference/quantized-mesh-loader.md
+++ b/modules/terrain/docs/api-reference/quantized-mesh-loader.md
@@ -1,5 +1,9 @@
 # QuantizedMeshLoader
 
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v2.2-blue.svg?style=flat-square" alt="From-v2.2" /> 
+</p>
+
 The `QuantizedMeshLoader` module reconstructs mesh surfaces from the [quantized
 mesh][quantized_mesh] format.
 

--- a/modules/video/docs/README.md
+++ b/modules/video/docs/README.md
@@ -1,5 +1,9 @@
 # Overview
 
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v2.2-blue.svg?style=flat-square" alt="From-v2.2" /> 
+</p>
+
 The `@loaders.gl/video` module contains loader and writers for images that follow loaders.gl conventions.
 
 > Video support is still experimental, and does not work in Node.js.

--- a/modules/video/docs/api-reference/gif-builder.md
+++ b/modules/video/docs/api-reference/gif-builder.md
@@ -1,5 +1,9 @@
 # GIFBuilder
 
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v2.2-blue.svg?style=flat-square" alt="From-v2.2" /> 
+</p>
+
 > This `GIFBuilder` is currenly highly experimental and may change significantly in minor releases and ev en patch releases. Pin down your loaders.gl version if you wish to use it.
 
 The `GIFBuilder` class creates a base64 encoded GIF image from either:

--- a/modules/video/docs/api-reference/video-loader.md
+++ b/modules/video/docs/api-reference/video-loader.md
@@ -1,8 +1,12 @@
 # VideoLoader
 
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v2.2-blue.svg?style=flat-square" alt="From-v2.2" /> 
+</p>
+
 > The `VideoLoader` is experimental.
 
-An image loader that works under both Node.js (requires `@loaders.gl/polyfills`) and the browser.
+A basic Video element loader. Only works in the browser.
 
 | Loader         | Characteristic                                          |
 | -------------- | ------------------------------------------------------- |

--- a/modules/wkt/docs/api-reference/wkt-loader.md
+++ b/modules/wkt/docs/api-reference/wkt-loader.md
@@ -1,16 +1,20 @@
 # WKTLoader
 
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v2.1-blue.svg?style=flat-square" alt="From-v2.1" /> 
+</p>
+
 Loader and writer for the [Well-known text] format for representation of geometry.
 
-| Loader                | Characteristic                                                                              |
-| --------------------- | ------------------------------------------------------------------------------------------- |
-| File Extension        | `.wkt`,                                                                                     |
-| File Type             | Text                                                                                        |
-| File Format           | [Well Known Text](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry) |
-| Data Format           | [Geometry](/docs/specifications/category-gis)                                               |
-| Supported APIs        | `load`, `parse`, `parseSync`                                                                |
-| Decoder Type          | Synchronous                                                                                 |
-| Worker Thread Support | Yes                                                                                         |
+| Loader                | Characteristic                                                                                               |
+| --------------------- | ------------------------------------------------------------------------------------------------------------ |
+| File Extension        | `.wkt`,                                                                                                      |
+| File Type             | Text                                                                                                         |
+| File Format           | [Well Known Text](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry)                  |
+| Data Format           | [Geometry](/docs/specifications/category-gis)                                                                |
+| Supported APIs        | `load`, `parse`, `parseSync`                                                                                 |
+| Decoder Type          | Synchronous                                                                                                  |
+| Worker Thread Support | Yes [![Website shields.io](https://img.shields.io/badge/v2.2-blue.svg?style=flat-square)](http://shields.io) |
 
 ## Usage
 

--- a/website/package.json
+++ b/website/package.json
@@ -8,9 +8,9 @@
   ],
   "main": "gatsby-config.js",
   "scripts": {
-    "start": "yarn clean && yarn develop",
+    "start": "yarn develop",
     "develop": "yarn clean-examples && yarn build:gallery && yarn gatsby develop",
-    "build": "yarn clean && yarn clean-examples && yarn build:gallery && gatsby build",
+    "build": "rm -rf ./public && yarn clean-examples && yarn build:gallery && gatsby build",
     "serve": "gatsby serve",
     "deploy": "NODE_DEBUG=gh-pages gh-pages -d public",
     "clean": "rm -rf ./.cache ./public",
@@ -49,7 +49,7 @@
     "styled-components": "^4.4.1"
   },
   "devDependencies": {
-    "gatsby": "~2.20.24",
+    "gatsby": "~2.22.17",
     "gatsby-plugin-no-sourcemaps": "^2.1.2",
     "gatsby-theme-ocular": "^1.2.0-beta.8",
     "gh-pages": "^2.2.0"


### PR DESCRIPTION
Let users easily see what is available in each version.

@kylebarron 