### PR TITLE
gltf/3d-tiles: DracoLoader now automatically imported and used

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -16,7 +16,7 @@ The `ImageLoader` now loads images as `Imagebitmap` by default on browsers that 
 
 **@loaders.gl/i3s**
 
-Addresses a number of compatibility issues with different tilesets that have been reported by users. See the git log or issues for details.
+Addresses a number of compatibility issues with different I3S tilesets that have been reported by users.
 
 **@loaders.gl/terrain**
 
@@ -37,6 +37,14 @@ Experimental `GeoJSONLoader` (exported with an underscore as `_GeoJSONLoader`), 
 **@loaders.gl/arrow**
 
 Updated to use `apache-arrow` version `0.17.0`.
+
+**@loaders.gl/3d-tiles**
+
+The `Tile3DLoader` now installs the `DracoLoader`. The application no longer needs to import and register the `DracoWorkerLoader`.
+
+**@loaders.gl/gltf**
+
+The `GLTFLoader` now installs the `DracoLoader`. The application no longer needs to import and register the `DracoWorkerLoader`.
 
 ## v2.1
 

--- a/examples/experimental/gltf-with-deck.gl/app.js
+++ b/examples/experimental/gltf-with-deck.gl/app.js
@@ -7,13 +7,12 @@ import {MapController, COORDINATE_SYSTEM} from '@deck.gl/core';
 import {ScenegraphLayer} from '@deck.gl/mesh-layers';
 
 import {GLTFLoader} from '@loaders.gl/gltf';
-import {DracoWorkerLoader} from '@loaders.gl/draco';
 import {registerLoaders} from '@loaders.gl/core';
 
 import loadIBLEnvironment from './environment';
 
 // To manage dependencies/bundle size, the app decides which loaders to bring in
-registerLoaders([GLTFLoader, DracoWorkerLoader]);
+registerLoaders([GLTFLoader]);
 
 // Set your mapbox token here
 const MAPBOX_TOKEN = process.env.MapboxAccessToken; // eslint-disable-line
@@ -64,11 +63,6 @@ export default class App extends PureComponent {
             id: 'tile-3d-layer',
             data: [{}],
             scenegraph: GLTF_DEFAULT_MODEL,
-            loadOptions: {
-              gltf: {
-                parserVersion: 2
-              }
-            },
             modelMatrix: [1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1],
             _composeModelMatrix: true,
             coordinateSystem: COORDINATE_SYSTEM.METER_OFFSETS,

--- a/examples/experimental/gltf-with-deck.gl/package.json
+++ b/examples/experimental/gltf-with-deck.gl/package.json
@@ -12,6 +12,7 @@
     "@loaders.gl/gltf": "^2.1.3",
     "@loaders.gl/draco": "^2.1.3",
     "@luma.gl/constants": "^8.1.2",
+    "@luma.gl/experimental": "^8.1.2",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
     "react-map-gl": "^5.0.0"

--- a/examples/website/3d-tiles/app.js
+++ b/examples/website/3d-tiles/app.js
@@ -10,17 +10,11 @@ import {Tile3DLayer} from '@deck.gl/geo-layers';
 import {StatsWidget} from '@probe.gl/stats-widget';
 
 // To manage dependencies and bundle size, the app must decide which supporting loaders to bring in
-import {registerLoaders} from '@loaders.gl/core';
-import {DracoWorkerLoader} from '@loaders.gl/draco';
-import {GLTFLoader} from '@loaders.gl/gltf';
 import {CesiumIonLoader} from '@loaders.gl/3d-tiles';
 
 import ControlPanel from './components/control-panel';
 import {loadExampleIndex, INITIAL_EXAMPLE_CATEGORY, INITIAL_EXAMPLE_NAME} from './examples';
 import {INITIAL_MAP_STYLE} from './constants';
-
-// enable DracoWorkerLoader when fixed
-registerLoaders([GLTFLoader, DracoWorkerLoader]);
 
 // Set your mapbox token here
 const MAPBOX_TOKEN = process.env.MapboxAccessToken; // eslint-disable-line

--- a/examples/website/pointcloud/app.js
+++ b/examples/website/pointcloud/app.js
@@ -6,7 +6,7 @@ import DeckGL from '@deck.gl/react';
 import {COORDINATE_SYSTEM, OrbitView, LinearInterpolator} from '@deck.gl/core';
 import {PointCloudLayer} from '@deck.gl/layers';
 
-import {DracoWorkerLoader} from '@loaders.gl/draco';
+import {DracoLoader} from '@loaders.gl/draco';
 import {LASLoader} from '@loaders.gl/las';
 import {PLYLoader} from '@loaders.gl/ply';
 import {PCDLoader} from '@loaders.gl/pcd';
@@ -17,7 +17,7 @@ import ControlPanel from './components/control-panel';
 import FILE_INDEX from './file-index';
 
 // Additional format support can be added here, see
-registerLoaders([DracoWorkerLoader, LASLoader, PLYLoader, PCDLoader, OBJLoader]);
+registerLoaders([DracoLoader, LASLoader, PLYLoader, PCDLoader, OBJLoader]);
 
 const INITIAL_VIEW_STATE = {
   target: [0, 0, 0],

--- a/modules/3d-tiles/docs/api-reference/tiles-3d-loader.md
+++ b/modules/3d-tiles/docs/api-reference/tiles-3d-loader.md
@@ -33,8 +33,6 @@ To decompress tiles containing Draco compressed glTF models or Draco compressed 
 ```js
 import {load, registerLoaders} from '@loaders.gl/core';
 import {Tiles3DLoader} from '@loaders.gl/3d-tiles';
-import {DracoWorkerLoader} from '@loaders.gl/draco';
-registerLoaders(DracoWorkerLoader);
 const tileUrl = 'https://assets.cesium.com/43978/1.pnts';
 const tile = await load(tileUrl, Tiles3DLoader, {decompress: true});
 ```

--- a/modules/3d-tiles/package.json
+++ b/modules/3d-tiles/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@loaders.gl/core": "^2.1.3",
+    "@loaders.gl/draco": "^2.1.3",
     "@loaders.gl/gltf": "^2.1.3",
     "@loaders.gl/loader-utils": "^2.1.3",
     "@loaders.gl/math": "^2.1.3",

--- a/modules/3d-tiles/src/lib/parsers/helpers/parse-3d-tile-gltf-view.js
+++ b/modules/3d-tiles/src/lib/parsers/helpers/parse-3d-tile-gltf-view.js
@@ -68,24 +68,6 @@ export async function extractGLTF(tile, gltfFormat, options, context) {
   }
 }
 
-export function extractGLTFSync(tile, gltfFormat, options, context) {
-  extractGLTFBufferOrURL(tile, gltfFormat, options);
-
-  if (options.loadGLTF) {
-    if (tile.gltfArrayBuffer) {
-      const {parseSync} = context;
-      // TODO - Should handle byteOffset... Not used now...
-      tile.gltf = parseSync(tile.gltfArrayBuffer, GLTFLoader, options, context);
-      delete tile.gltfArrayBuffer;
-      delete tile.gltfByteOffset;
-      delete tile.gltfByteLength;
-    } else if (tile.gltfUrl) {
-      // TODO - use context.fetch or context.load
-      throw new Error('cant load glTF URL synchronously');
-    }
-  }
-}
-
 function extractGLTFBufferOrURL(tile, gltfFormat, options) {
   switch (gltfFormat) {
     case GLTF_FORMAT.URI:

--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile-point-cloud.js
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile-point-cloud.js
@@ -1,8 +1,9 @@
 // This file is derived from the Cesium code base under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 
+import {DracoLoader} from '@loaders.gl/draco';
+import {GL} from '@loaders.gl/math';
 import {Vector3} from '@math.gl/core';
-import {GL} from '@loaders.gl/math'; // 'math.gl/geometry';
 
 import Tile3DFeatureTable from '../classes/tile-3d-feature-table';
 import Tile3DBatchTable from '../classes/tile-3d-batch-table';
@@ -200,7 +201,7 @@ async function parseDraco(tile, featureTable, batchTable, options, context) {
 // eslint-disable-next-line complexity, max-statements
 export async function loadDraco(tile, dracoData, options, context) {
   const {parse} = context;
-  const data = await parse(dracoData.buffer, {});
+  const data = await parse(dracoData.buffer, DracoLoader, {});
 
   const decodedPositions = data.attributes.POSITION && data.attributes.POSITION.value;
   const decodedColors = data.attributes.COLOR_0 && data.attributes.COLOR_0.value;

--- a/modules/gltf/package.json
+++ b/modules/gltf/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@loaders.gl/core": "^2.1.3",
+    "@loaders.gl/draco": "^2.1.3",
     "@loaders.gl/images": "^2.1.3",
     "@loaders.gl/loader-utils": "^2.1.3"
   }

--- a/modules/gltf/src/lib/extensions/KHR_draco_mesh_compression.js
+++ b/modules/gltf/src/lib/extensions/KHR_draco_mesh_compression.js
@@ -2,6 +2,8 @@
 // Only TRIANGLES: 0x0004 and TRIANGLE_STRIP: 0x0005 are supported
 
 /* eslint-disable camelcase */
+
+import {DracoLoader} from '@loaders.gl/draco';
 import {getZeroOffsetArrayBuffer} from '@loaders.gl/loader-utils';
 import GLTFScenegraph from '../gltf-scenegraph';
 import {KHR_DRACO_MESH_COMPRESSION} from '../gltf-constants';
@@ -57,7 +59,7 @@ async function decompressPrimitive(primitive, scenegraph, options, context) {
 
   // this will generate an exception if DracoLoader is not installed
   const {parse} = context;
-  const decodedData = await parse(bufferCopy, [], options, context);
+  const decodedData = await parse(bufferCopy, DracoLoader, options, context);
 
   primitive.attributes = getGLTFAccessors(decodedData.attributes);
   if (decodedData.indices) {


### PR DESCRIPTION
This removes the need for applications to keep track of the `DracoWorkerLoader` (which complicated the API and keeps causing some confusion.)

We should update examples in deck.gl once this lands, will add note to 2.2 checklist

