### PR TITLE
json: Add `batch.bytesRead` field (progress bar enabler)

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -32,7 +32,8 @@ Worker support for the `WKTLoader`, designed to support future binary data impro
 
 **@loaders.gl/json**
 
-Experimental `GeoJSONLoader` (exported with an underscore as `_GeoJSONLoader`), desgined to support future binary data improvements.
+- `parseInBatches` now returns a `batch.bytesRead` field to enable progress bars.
+- `.geojson` is now parsed by a new experimental `GeoJSONLoader` (exported with an underscore as `_GeoJSONLoader`), designed to support future binary data improvements.
 
 **@loaders.gl/arrow**
 

--- a/modules/json/src/lib/parse-json-in-batches.js
+++ b/modules/json/src/lib/parse-json-in-batches.js
@@ -43,7 +43,7 @@ export default async function* parseJSONInBatches(asyncIterator, options) {
       }
     }
 
-    tableBatchBuilder.chunkComplete();
+    tableBatchBuilder.chunkComplete(chunk);
     if (tableBatchBuilder.isFull()) {
       yield tableBatchBuilder.getNormalizedBatch();
     }

--- a/modules/json/test/json-loader.spec.js
+++ b/modules/json/test/json-loader.spec.js
@@ -18,13 +18,16 @@ test('JSONLoader#loadInBatches(geojson.json, rows, batchSize = auto)', async t =
   let batch;
   let batchCount = 0;
   let rowCount = 0;
+  let byteLength = 0;
   for await (batch of iterator) {
     batchCount++;
     rowCount += batch.length;
+    byteLength = batch.bytesRead;
   }
 
   t.ok(batchCount <= 3, 'Correct number of batches received');
   t.equal(rowCount, 308, 'Correct number of row received');
+  t.equal(byteLength, 135910, 'Correct number of bytes received');
   t.end();
 });
 

--- a/modules/tables/src/lib/table/table-batch-builder.js
+++ b/modules/tables/src/lib/table/table-batch-builder.js
@@ -7,6 +7,7 @@ export default class TableBatchBuilder {
     this.batchSize = batchSize;
     this.batch = null;
     this.batchCount = 0;
+    this.bytesRead = 0;
   }
 
   addRow(row) {
@@ -18,7 +19,8 @@ export default class TableBatchBuilder {
     this.batch.addRow(row);
   }
 
-  chunkComplete() {
+  chunkComplete(chunk) {
+    this.bytesRead += chunk.byteLength || chunk.length || 0;
     if (this.batch) {
       this.batch.chunkComplete();
     }
@@ -38,6 +40,7 @@ export default class TableBatchBuilder {
       this.batch = null;
       normalizedBatch.count = this.batchCount;
       this.batchCount++;
+      normalizedBatch.bytesRead = this.bytesRead;
       return normalizedBatch;
     }
     return null;


### PR DESCRIPTION
Unfortunately, this simple strategy doesn't work on CSVLoader since it doesn't use a clean AsyncIterator model.

Another reason to phase out papaparse (in addition to perf)...
