### PR TITLE
core: parseInBatches new metadata option returns additional metadata batch

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -10,6 +10,10 @@ Typescript type definitions (`d.ts` files) are now provided for some loaders.gl 
 
 ### Loader Improvements
 
+**@loaders.gl/core**
+
+- `parseInBatches` a new `options.metadata` option adds an initial batch with metadata about what data format is being loaded.
+
 **@loaders.gl/images**
 
 The `ImageLoader` now loads images as `Imagebitmap` by default on browsers that support `ImageBitmap` (Chrome and Firefox). The performance improvements are dramatic, which can be verified in the new [benchmark example](https://loaders.gl/examples/benchmarks).
@@ -37,7 +41,8 @@ Worker support for the `WKTLoader`, designed to support future binary data impro
 
 **@loaders.gl/csv**
 
-- Header auto-detection via `options.csv.header: 'auto'`.
+- `parseInBatches` now returns a `batch.bytesUsed` field to enable progress bars.
+- Header auto-detection available via `options.csv.header: 'auto'`.
 
 **@loaders.gl/arrow**
 

--- a/modules/core/docs/api-reference/parse-in-batches.md
+++ b/modules/core/docs/api-reference/parse-in-batches.md
@@ -6,6 +6,10 @@ For supporting loaders, the streaming `parseInBatches` function can parse increm
 
 Batched (streaming) parsing is only supported by a subset of loaders. Check documentation of each loader before using this function.
 
+## Usage
+
+Parse CSV in batches (emitting a batch of rows every time data arrives from the network):
+
 ```js
 import {fetchFile, parseInBatches} from '@loaders.gl/core';
 import {CSVLoader} from '@loaders.gl/obj';
@@ -13,6 +17,24 @@ import {CSVLoader} from '@loaders.gl/obj';
 const batchIterator = await parseInBatches(fetchFile(url), CSVLoader);
 for await (const batch of batchIterator) {
   console.log(batch.length);
+}
+```
+
+Parse CSV in batches, requesting an initial metadata batch:
+
+```js
+import {fetchFile, parseInBatches} from '@loaders.gl/core';
+import {CSVLoader} from '@loaders.gl/obj';
+
+const batchIterator = await parseInBatches(fetchFile(url), CSVLoader, {metadata: true});
+for await (const batch of batchIterator) {
+  switch (batch.batchType) {
+    case 'metadata':
+      console.log(batch.metadata);
+      break;
+    default:
+      processBatch(batch.data);
+  }
 }
 ```
 
@@ -53,8 +75,7 @@ Note that many other data sources can also be parsed by first converting them to
 
 ## Remarks
 
-Move below to iterator transforms section
-
-| Option                       | Type     | Description                                                      | Comment                                              |
-| ---------------------------- | -------- | ---------------------------------------------------------------- | ---------------------------------------------------- |
-| `options.batches.chunkSize?` | `number` | When set, "atomic" inputs are chunked, enabling batched parsing. | No effect if input is already an iterator or stream. |
+| Option                       | Type      | Default | Description                                                                                               |
+| ---------------------------- | --------- | ------- | --------------------------------------------------------------------------------------------------------- |
+| `options.metadata`           | `boolean` | `false` | An initial batch with `batchType: 'metadata'` will be added with information about the data being loaded. |
+| `options.batches.chunkSize?` | `number`  | N/A     | When set, "atomic" inputs (like `ArrayBuffer` or `string`) are chunked, enabling batched parsing.         | No effect if input is already an iterator or stream. |

--- a/modules/core/src/lib/api/parse-in-batches.js
+++ b/modules/core/src/lib/api/parse-in-batches.js
@@ -47,8 +47,10 @@ async function parseWithLoaderInBatches(loader, data, options, context) {
 
   const metadataBatch = {
     batchType: 'metadata',
-    _loader: loader,
-    _context: context
+    metadata: {
+      _loader: loader,
+      _context: context
+    }
   };
 
   async function* makeMetadataBatchIterator() {

--- a/modules/core/src/lib/api/parse-in-batches.js
+++ b/modules/core/src/lib/api/parse-in-batches.js
@@ -27,16 +27,34 @@ export async function parseInBatches(data, loaders, options, url) {
 }
 
 async function parseWithLoaderInBatches(loader, data, options, context) {
-  // Create async iterator adapter for data, and concatenate result
   if (!loader.parseInBatches) {
+    // TODO - call parse and emit a single batch (plus metadata batch)
     throw new Error('loader does not support parseInBatches');
   }
 
+  // Create async iterator adapter for data, and concatenate result
   const inputIterator = await getAsyncIteratorFromData(data);
   // Converts ArrayBuffer chunks to text chunks (leaves text chunks alone)
   // if (loader.text) {
   //   inputIterator = makeTextDecoderIterator(inputIterator);
   // }
   const outputIterator = loader.parseInBatches(inputIterator, options, context, loader);
-  return outputIterator;
+
+  // Generate metadata batch if requested
+  if (!options.metadata) {
+    return outputIterator;
+  }
+
+  const metadataBatch = {
+    batchType: 'metadata',
+    _loader: loader,
+    _context: context
+  };
+
+  async function* makeMetadataBatchIterator() {
+    yield metadataBatch;
+    yield* outputIterator;
+  }
+
+  return makeMetadataBatchIterator();
 }

--- a/modules/core/src/lib/constants.js
+++ b/modules/core/src/lib/constants.js
@@ -5,5 +5,6 @@ export const DEFAULT_LOADER_OPTIONS = {
   CDN: 'https://unpkg.com/@loaders.gl',
   worker: true, // By default, use worker if provided by loader
   log: new ConsoleLog(), // A probe.gl compatible (`log.log()()` syntax) that just logs to console
-  dataType: 'arraybuffer' // TODO - explain why this option is needed for parsing
+  dataType: 'arraybuffer', // TODO - explain why this option is needed for parsing
+  metadata: false // TODO - currently only implemented for parseInBatches, adds initial metadata batch
 };

--- a/modules/core/test/index.js
+++ b/modules/core/test/index.js
@@ -17,6 +17,7 @@ import './lib/register-loaders.spec';
 import './lib/select-loader.spec';
 import './lib/parse.spec';
 import './lib/load.spec';
+import './lib/parse-in-batches.spec';
 
 // TODO - The worker-utils specs test loading, not just worker farm
 // so we run them after util tests, until loading has been split out

--- a/modules/core/test/lib/parse-in-batches.spec.js
+++ b/modules/core/test/lib/parse-in-batches.spec.js
@@ -1,0 +1,41 @@
+import test from 'tape-promise/tape';
+
+import {parseInBatches} from '@loaders.gl/core';
+
+const NoOpLoader = {
+  name: 'JSON',
+  extensions: ['json'],
+  testText: null,
+  parseInBatches: (iterator, options) => iterator
+};
+
+test('parseInBatches', async t => {
+  // @ts-ignore
+  let batches = await parseInBatches([1, 1], NoOpLoader);
+
+  let metadata = false;
+  for await (const batch of batches) {
+    if (batch.batchType === 'metadata') {
+      metadata = true;
+    }
+    t.deepEquals(batch, 1, 'parseInBatches returned data');
+  }
+  t.notOk(metadata, 'metadata batch was generated');
+
+  // @ts-ignore
+  batches = await parseInBatches([1, 2], NoOpLoader, {metadata: true});
+
+  const values = [];
+  metadata = false;
+  for await (const batch of batches) {
+    if (batch.batchType === 'metadata') {
+      metadata = true;
+    } else {
+      values.push(batch);
+    }
+  }
+  t.deepEquals(values, [1, 2], 'parseInBatches returned data');
+  t.ok(metadata, 'metadata batch was generated');
+
+  t.end();
+});

--- a/modules/draco/package.json
+++ b/modules/draco/package.json
@@ -40,6 +40,6 @@
   "dependencies": {
     "@babel/runtime": "^7.3.1",
     "@loaders.gl/loader-utils": "^2.1.3",
-    "draco3d": "^1.3.4"
+    "draco3d": "1.3.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1611,7 +1611,7 @@
   dependencies:
     "@babel/runtime" "^7.3.1"
     "@loaders.gl/loader-utils" "2.1.6"
-    draco3d "^1.3.4"
+    draco3d "1.3.4"
 
 "@loaders.gl/gltf@^2.1.3":
   version "2.1.6"
@@ -4110,10 +4110,10 @@ dotignore@~0.1.2:
   dependencies:
     minimatch "^3.0.4"
 
-draco3d@^1.3.4:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/draco3d/-/draco3d-1.3.6.tgz#e4d9e7d846637775328c903721c932b953dce331"
-  integrity sha512-zZoH5JNcdWDrUb2ks2mbzGDUUPvDaDf1ysTJS2St+3/F/8XcKAX4VKgzPjTP7MfHegHQ7Udv8ovS+R3AgXlH7g==
+draco3d@1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/draco3d/-/draco3d-1.3.4.tgz#b17e4fedd4b4b946c9eb8df2e1d2f470a953cdb8"
+  integrity sha512-I7kAKyiSIb++K5VdWGeIC9xXWkoQ1HZ8wSCQhaRMf41KKxYX5jYmy+rRna/o7o3CrunxvCGbZBl6d6bdWVcJXw==
 
 duplexer@^0.1.1:
   version "0.1.1"


### PR DESCRIPTION
Provides the basic capability for kepler to get some information about which format was parsed.

The new metadata batch currently has two experimental fields `_loader` and `_context`, just to unblock.