### PR TITLE
core: Add loader option warnings

### DIFF
--- a/modules/core/src/lib/loader-utils/merge-options.js
+++ b/modules/core/src/lib/loader-utils/merge-options.js
@@ -1,4 +1,3 @@
-import {getValidatedLoaderOptions} from '@loaders.gl/loader-utils';
 import {DEFAULT_LOADER_OPTIONS} from '../constants';
 import {NullLog} from './loggers';
 

--- a/modules/core/src/lib/loader-utils/merge-options.js
+++ b/modules/core/src/lib/loader-utils/merge-options.js
@@ -20,9 +20,9 @@ export function mergeOptions(loader, options, url, topOptions = null) {
 /**
  * Warn for unsupported options
  * @param {*} loader
- * @param {object} options 
- * @param {object | null} topOptions 
- * @param {*} log 
+ * @param {object} options
+ * @param {object | null} topOptions
+ * @param {*} log
  */
 function validateLoaderOptions(loader, options, topOptions, log = console) {
   // Check top level options

--- a/modules/core/src/lib/loader-utils/merge-options.js
+++ b/modules/core/src/lib/loader-utils/merge-options.js
@@ -24,7 +24,12 @@ export function mergeOptions(loader, options, url, topOptions = null) {
  * @param {object | null} topOptions
  * @param {*} log
  */
-function validateLoaderOptions(loader, options, topOptions, log = console) {
+function validateLoaderOptions(
+  loader,
+  options,
+  topOptions = DEFAULT_LOADER_OPTIONS,
+  log = console
+) {
   // Check top level options
   if (topOptions) {
     for (const key in options) {

--- a/modules/core/src/lib/loader-utils/merge-options.js
+++ b/modules/core/src/lib/loader-utils/merge-options.js
@@ -28,6 +28,7 @@ function validateLoaderOptions(
   loader,
   options,
   topOptions = DEFAULT_LOADER_OPTIONS,
+  // eslint-disable-next-line
   log = console
 ) {
   // Check top level options

--- a/modules/csv/package.json
+++ b/modules/csv/package.json
@@ -30,7 +30,7 @@
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js"
   },
   "dependencies": {
-    "@loaders.gl/core": "^2.1.3",
+    "@loaders.gl/loader-utils": "^2.1.3",
     "@loaders.gl/tables": "^2.1.3"
   },
   "devDependencies": {

--- a/modules/gltf/docs/api-reference/gltf-loader.md
+++ b/modules/gltf/docs/api-reference/gltf-loader.md
@@ -49,12 +49,12 @@ Note: while supported, synchronous parsing of glTF (e.g. using `parseSync()`) ha
 
 ## Options
 
-| Option             | Type    | Default |                                                                                | Description |
-| ------------------ | ------- | ------- | ------------------------------------------------------------------------------ | ----------- |
-| `gltf.fetchImages` | Boolean | `false` | Fetch any referenced image files (and decode base64 encoded URIS). Async only. |
-| `gltf.parseImages` | Boolean | `false` |
-| `gltf.decompressMeshes`  | Boolean | `true`  | Decompress Draco compressed meshes (if DracoLoader available).                 |
-| `gltf.postProcess` | Boolean | `true`  | Perform additional post processing on the loaded glTF data.                    |
+| Option                  | Type    | Default |                                                                                | Description |
+| ----------------------- | ------- | ------- | ------------------------------------------------------------------------------ | ----------- |
+| `gltf.fetchImages`      | Boolean | `false` | Fetch any referenced image files (and decode base64 encoded URIS). Async only. |
+| `gltf.parseImages`      | Boolean | `false` |
+| `gltf.decompressMeshes` | Boolean | `true`  | Decompress Draco compressed meshes (if DracoLoader available).                 |
+| `gltf.postProcess`      | Boolean | `true`  | Perform additional post processing on the loaded glTF data.                    |
 
 Remarks:
 

--- a/modules/gltf/docs/api-reference/gltf-loader.md
+++ b/modules/gltf/docs/api-reference/gltf-loader.md
@@ -53,7 +53,7 @@ Note: while supported, synchronous parsing of glTF (e.g. using `parseSync()`) ha
 | ------------------ | ------- | ------- | ------------------------------------------------------------------------------ | ----------- |
 | `gltf.fetchImages` | Boolean | `false` | Fetch any referenced image files (and decode base64 encoded URIS). Async only. |
 | `gltf.parseImages` | Boolean | `false` |
-| `gltf.decompress`  | Boolean | `true`  | Decompress Draco compressed meshes (if DracoLoader available).                 |
+| `gltf.decompressMeshes`  | Boolean | `true`  | Decompress Draco compressed meshes (if DracoLoader available).                 |
 | `gltf.postProcess` | Boolean | `true`  | Perform additional post processing on the loaded glTF data.                    |
 
 Remarks:

--- a/modules/gltf/src/gltf-loader.js
+++ b/modules/gltf/src/gltf-loader.js
@@ -36,7 +36,7 @@ const GLTFLoader = {
     decompress: 'gltf.decompressMeshes',
     postProcess: 'gltf.postProcess',
     gltf: {
-      decompress: 'gltf.decompressMeshes',
+      decompress: 'gltf.decompressMeshes'
     }
   }
 };

--- a/modules/gltf/src/gltf-loader.js
+++ b/modules/gltf/src/gltf-loader.js
@@ -29,6 +29,15 @@ const GLTFLoader = {
     // common?
     uri: '', // base URI
     log: console // eslint-disable-line
+  },
+  deprecatedOptions: {
+    fetchImages: 'gltf.loadImages',
+    createImages: 'gltf.loadImages',
+    decompress: 'gltf.decompressMeshes',
+    postProcess: 'gltf.postProcess',
+    gltf: {
+      decompress: 'gltf.decompressMeshes',
+    }
   }
 };
 

--- a/modules/gltf/test/lib/gltf-scenegraph-accessors.spec.js
+++ b/modules/gltf/test/lib/gltf-scenegraph-accessors.spec.js
@@ -17,7 +17,7 @@ test('GLTFScenegraph#ctor', t => {
 
 test('GLTFScenegraph#BufferView indices resolve correctly', async t => {
   const gltf = await load(GLB_TILE_WITH_DRACO_URL, [GLTFLoader, DracoLoader], {
-    gltf: {decompress: false, postProcess: false}
+    gltf: {decompressMeshes: false, postProcess: false}
   });
 
   const gltfScenegraph = new GLTFScenegraph(gltf);

--- a/modules/images/src/image-loader.js
+++ b/modules/images/src/image-loader.js
@@ -30,7 +30,7 @@ const ImageLoader = {
   test: arrayBuffer => Boolean(getBinaryImageMetadata(new DataView(arrayBuffer))),
   options: {
     image: {
-      format: 'auto',
+      type: 'auto',
       decode: true // if format is HTML
     }
     // imagebitmap: {} - passes (platform dependent) parameters to ImageBitmap constructor

--- a/modules/json/src/json-loader.js
+++ b/modules/json/src/json-loader.js
@@ -11,7 +11,10 @@ const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 const JSONLoaderOptions = {
   json: {
     TableBatch: RowTableBatch,
-    batchSize: 'auto'
+    batchSize: 'auto',
+    _rootObjectBatches: false,
+    table: false,
+    jsonpaths: []
   }
 };
 

--- a/modules/las/src/las-loader.js
+++ b/modules/las/src/las-loader.js
@@ -18,7 +18,8 @@ export const LASWorkerLoader = {
   test: 'LAS',
   options: {
     las: {
-      workerUrl: `https://unpkg.com/@loaders.gl/las@${VERSION}/dist/las-loader.worker.js`
+      workerUrl: `https://unpkg.com/@loaders.gl/las@${VERSION}/dist/las-loader.worker.js`,
+      skip: 1
     }
   }
 };

--- a/modules/las/src/lib/parse-las.js
+++ b/modules/las/src/lib/parse-las.js
@@ -14,7 +14,7 @@ export default function parseLAS(arraybuffer, options = {}) {
 
   const result = {};
   const {onProgress} = options;
-  const {skip = 1} = options.las || {};
+  const {skip} = options.las || {};
 
   parseLASChunked(arraybuffer, skip, (decoder, header) => {
     if (!originalHeader) {

--- a/modules/loader-utils/src/index.d.ts
+++ b/modules/loader-utils/src/index.d.ts
@@ -14,12 +14,14 @@ export {
   document
 } from './lib/env-utils/globals';
 
+// LOADER UTILS
+export {validateLoaderVersion} from './lib/validate-loader-version';
+
 // LIBRARY UTILS
 export {getLibraryUrl, loadLibrary} from './lib/library-utils/library-utils';
 
 // WORKER UTILS
 export {getTransferList} from './lib/worker-utils/get-transfer-list';
-export {validateLoaderVersion} from './lib/validate-loader-version';
 
 // PARSER UTILS
 export {parseJSON} from './lib/parser-utils/parse-json';

--- a/modules/loader-utils/src/index.js
+++ b/modules/loader-utils/src/index.js
@@ -12,12 +12,14 @@ export {
   document
 } from './lib/env-utils/globals';
 
+// LOADER UTILS
+export {validateLoaderVersion} from './lib/validate-loader-version';
+
 // LIBRARY UTILS
 export {getLibraryUrl, loadLibrary} from './lib/library-utils/library-utils';
 
 // WORKER UTILS
 export {getTransferList} from './lib/worker-utils/get-transfer-list';
-export {validateLoaderVersion} from './lib/validate-loader-version';
 
 // PARSER UTILS
 export {parseJSON} from './lib/parser-utils/parse-json';

--- a/modules/potree/src/potree-bin-loader.js
+++ b/modules/potree/src/potree-bin-loader.js
@@ -1,4 +1,5 @@
 import {default as parsePotreeBin} from './parsers/parse-potree-bin';
+/** @typedef {import('@loaders.gl/loader-utils').LoaderObject} LoaderObject */
 
 function parseSync(arrayBuffer, options, url, loader) {
   const index = {};
@@ -7,6 +8,7 @@ function parseSync(arrayBuffer, options, url, loader) {
   return index;
 }
 
+/** @type {LoaderObject} */
 export default {
   id: 'potree',
   name: 'potree Binary Point Attributes',

--- a/modules/potree/src/potree-hierarchy-chunk-loader.js
+++ b/modules/potree/src/potree-hierarchy-chunk-loader.js
@@ -1,9 +1,11 @@
+/** @typedef {import('@loaders.gl/loader-utils').LoaderObject} LoaderObject */
 import {default as parsePotreeHierarchyChunk} from './parsers/parse-potree-hierarchy-chunk';
 
 function parseSync(arrayBuffer, options, url, loader) {
   return parsePotreeHierarchyChunk(arrayBuffer);
 }
 
+/** @type {LoaderObject} */
 export default {
   id: 'potree',
   name: 'potree Hierarchy Chunk',


### PR DESCRIPTION
This adds warnings for scoped loader options that do not match with the selected loader's default options.

Also added checking the top level options, we may need to add a longer white list but this seems to cover the test suite.