### PR TITLE
Ib/unregistered mime types

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -13,6 +13,7 @@ Typescript type definitions (`d.ts` files) are now provided for some loaders.gl 
 **@loaders.gl/core**
 
 - `parseInBatches` a new `options.metadata` option adds an initial batch with metadata about what data format is being loaded.
+- `selectLoader` (and `parse` etc) now recognizes unique unregistered MIME types (e.g `application/x.ply`) for every loader. This enable applications that can set `content-type` headers to have precise control over loader selection.
 
 **@loaders.gl/images**
 

--- a/modules/core/docs/api-reference/select-loader.md
+++ b/modules/core/docs/api-reference/select-loader.md
@@ -6,7 +6,11 @@
 
 A core feature of loaders.gl is the ability to automatically select an appropriate loader for a specific resource among a list of candidate loaders. This feature is built-in to the `parse` and `load` functions, but applications can also access this feature directly through the `selectLoader` API.
 
-Loader selection heuristics are based on both filename (url) extensions as well as comparison of initial data content against known headers for each file format.
+Loader selection heuristics are based on:
+
+- Filename (or url) extensions
+- MIME types (extracted from `Response` `content-type` headers or `Blob.type`/`File.type` fields)
+- Initial data - for certain inputs, the intial bytes can be compared against known headers for the candidate loaders. (Does not work for `Response`/`Stream`/`AsyncIterator` data).
 
 `selectLoader` is also aware of the [loader registry](docs/api-reference/core/register-loaders.md). If no loaders are provided (by passing in a falsy value such as `null`) `selectLoader` will search the list of pre-registered loaders.
 
@@ -32,6 +36,13 @@ import {CSVLoader} from '@loaders.gl/csv';
 registerLoaders(ArrowLoader, CSVLoader);
 
 selectLoader('filename.csv'); // => CSVLoader
+```
+
+Select a loader by specifying MIME type (using unregistered MIME types, see below)
+
+```js
+const data = new Blob([string], {type: 'application/x.csv'});
+selectLoader(blob); // => CSVLoader
 ```
 
 ## Functions
@@ -74,6 +85,10 @@ Peeking into batched input sources is not supported directly by `selectLoader`:
 - `Iterator/AsyncIterator`: it is not possible to peek into an iterator.
 
 Instead use helpers to get access to initialContents and pass it in separately.
+
+## MIME types
+
+If the standard MIME types for each format are not precise enough, loaders.gl also supports [unregistered](https://en.wikipedia.org/wiki/Media_type#Unregistered_tree) MIME types. Each loader will match the `application/x.<id>` where the `<id>` is the documented `id` of the loader, e.g. `application/x.ply`/`application/x.draco`/etc ...
 
 ## Remarks
 

--- a/modules/core/src/javascript-utils/is-type.d.ts
+++ b/modules/core/src/javascript-utils/is-type.d.ts
@@ -8,7 +8,6 @@ export function isResponse(value: any): boolean;
 
 export function isFile(value: any): boolean;
 export function isBlob(value: any): boolean;
-export function isFileReadable(value: any): boolean;
 
 export function isWritableDOMStream(value: any): boolean;
 

--- a/modules/core/src/javascript-utils/is-type.js
+++ b/modules/core/src/javascript-utils/is-type.js
@@ -19,7 +19,6 @@ export const isResponse = x =>
 
 export const isFile = x => typeof File !== 'undefined' && x instanceof File;
 export const isBlob = x => typeof Blob !== 'undefined' && x instanceof Blob;
-export const isFileReadable = x => isFile(x) || isBlob(x); // Blob & File are FileReader compatible
 
 export const isWritableDOMStream = x => {
   return isObject(x) && isFunction(x.abort) && isFunction(x.getWriter);

--- a/modules/core/src/lib/api/load.js
+++ b/modules/core/src/lib/api/load.js
@@ -1,4 +1,4 @@
-import {isFileReadable} from '../../javascript-utils/is-type';
+import {isBlob} from '../../javascript-utils/is-type';
 import {fetchFile} from '../fetch/fetch-file';
 import {isLoaderObject} from '../loader-utils/normalize-loader';
 
@@ -24,7 +24,7 @@ export async function load(url, loaders, options) {
   }
 
   // URL is Blob or File, fetchFile handles it (alt: we could generate ObjectURL here)
-  if (isFileReadable(url)) {
+  if (isBlob(url)) {
     // The fetch response object will contain blob.name
     data = await fetchFile(url, options);
     url = null;

--- a/modules/core/src/lib/api/select-loader.d.ts
+++ b/modules/core/src/lib/api/select-loader.d.ts
@@ -10,7 +10,7 @@ import {LoaderObject, LoaderContext} from '../common';
  * @param context context object
  */
 export function selectLoader(
-  data?: Response | ArrayBuffer | string,
+  data?: Response | Blob | ArrayBuffer | string,
   loaders?: LoaderObject[] | LoaderObject,
   options?: {
     nothrow?: boolean;

--- a/modules/core/src/lib/api/select-loader.js
+++ b/modules/core/src/lib/api/select-loader.js
@@ -78,6 +78,12 @@ function findLoaderByContentType(loaders, mimeType) {
     if (loader.mimeTypes && loader.mimeTypes.includes(mimeType)) {
       return loader;
     }
+
+    // Support referring to loaders using the "unregistered tree"
+    // https://en.wikipedia.org/wiki/Media_type#Unregistered_tree
+    if (mimeType === `application/x.${loader.id}`) {
+      return loader;
+    }
   }
   return null;
 }

--- a/modules/core/src/lib/fetch/fetch-file.js
+++ b/modules/core/src/lib/fetch/fetch-file.js
@@ -1,6 +1,6 @@
 /* global fetch */
 import {resolvePath} from '@loaders.gl/loader-utils';
-import {isFileReadable} from '../../javascript-utils/is-type';
+import {isBlob} from '../../javascript-utils/is-type';
 import fetchFileReadable from './fetch-file.browser';
 import {getErrorMessageFromResponse} from './fetch-error-message';
 
@@ -10,7 +10,7 @@ import {getErrorMessageFromResponse} from './fetch-error-message';
 // * http/http urls
 // * File/Blob objects
 export async function fetchFile(url, options = {}) {
-  if (isFileReadable(url)) {
+  if (isBlob(url)) {
     return fetchFileReadable(url, options);
   }
   url = resolvePath(url);

--- a/modules/core/src/lib/loader-utils/get-data.js
+++ b/modules/core/src/lib/loader-utils/get-data.js
@@ -6,7 +6,6 @@ import {
   isIterable,
   isIterator,
   isBlob,
-  isFileReadable,
   isBuffer
 } from '../../javascript-utils/is-type';
 import {makeIterator} from '../../iterator-utils/make-iterator/make-iterator';
@@ -21,7 +20,7 @@ const ERR_DATA = 'Cannot convert supplied data type';
 export function getUrlFromData(data, url) {
   if (isResponse(data)) {
     url = url || data.url;
-  } else if (isFileReadable(url)) {
+  } else if (isBlob(url)) {
     // File or Blob
     url = url.name;
   }
@@ -79,7 +78,7 @@ export async function getArrayBufferOrStringFromData(data, loader) {
   }
 
   // Blobs and files are FileReader compatible
-  if (isFileReadable(data)) {
+  if (isBlob(data)) {
     data = await fetchFileReadable(data);
   }
 

--- a/modules/core/src/lib/utils/resource-utils.js
+++ b/modules/core/src/lib/utils/resource-utils.js
@@ -1,4 +1,4 @@
-import {isResponse, isBlob, isFile} from '../../javascript-utils/is-type';
+import {isResponse, isBlob} from '../../javascript-utils/is-type';
 import {parseMIMEType, parseMIMETypeFromURL} from './mime-type-utils';
 
 const QUERY_STRING_PATTERN = /\?.*/;

--- a/modules/core/src/lib/utils/resource-utils.js
+++ b/modules/core/src/lib/utils/resource-utils.js
@@ -1,4 +1,4 @@
-import {isResponse, isFileReadable} from '../../javascript-utils/is-type';
+import {isResponse, isBlob, isFile} from '../../javascript-utils/is-type';
 import {parseMIMEType, parseMIMETypeFromURL} from './mime-type-utils';
 
 const QUERY_STRING_PATTERN = /\?.*/;
@@ -12,6 +12,13 @@ export function getResourceUrlAndType(resource) {
     return {
       url: resource.url || '',
       type: contentType || urlType || null
+    };
+  }
+
+  if (isBlob(resource)) {
+    return {
+      url: resource.url || '',
+      type: resource.type || ''
     };
   }
 
@@ -35,7 +42,7 @@ export function getResourceContentLength(resource) {
   if (isResponse(resource)) {
     return resource.headers['content-length'] || -1;
   }
-  if (isFileReadable(resource)) {
+  if (isBlob(resource)) {
     return resource.size;
   }
   if (typeof resource === 'string') {

--- a/modules/core/test/lib/select-loader.spec.js
+++ b/modules/core/test/lib/select-loader.spec.js
@@ -1,6 +1,7 @@
 /* eslint-disable max-len */
+/* global Blob */
 import test from 'tape-promise/tape';
-import {fetchFile, selectLoader} from '@loaders.gl/core';
+import {fetchFile, selectLoader, isBrowser} from '@loaders.gl/core';
 import {ImageLoader} from '@loaders.gl/images';
 import {DracoLoader} from '@loaders.gl/draco';
 import {LASLoader} from '@loaders.gl/las';
@@ -84,5 +85,14 @@ test('selectLoader#data', async t => {
     'find loader by checking magic string in embedded tile data (with offset)'
   );
 
+  t.end();
+});
+
+test('selectLoader#unregistered MIME type', async t => {
+  if (isBrowser) {
+    const blob = new Blob([''], {type: 'application/x.draco'});
+    const loader = selectLoader(blob, [Tiles3DLoader, DracoLoader, LASLoader]);
+    t.is(loader, DracoLoader, 'find loader by unregistered MIME type');
+  }
   t.end();
 });

--- a/modules/core/test/lib/utils/resource-utils.spec.js
+++ b/modules/core/test/lib/utils/resource-utils.spec.js
@@ -11,6 +11,12 @@ const DATA_URL =
 
 test('getResourceUrlAndType', t => {
   t.deepEqual(getResourceUrlAndType(DATA_URL), {type: 'image/png', url: DATA_URL});
+
+  if (isBrowser) {
+    const blob = new Blob(['abc'], {type: 'application/text'});
+    t.deepEqual(getResourceUrlAndType(blob), {type: 'application/text', url: ''});
+  }
+
   t.end();
 });
 


### PR DESCRIPTION
For #783 

Support unregistered mime types for all loaders (`application/x.ply` for PLYLoader etc).