### PR TITLE
Fix: expose the jsonpath property in a consistent shape

### DIFF
--- a/modules/json/src/lib/parse-json-in-batches.js
+++ b/modules/json/src/lib/parse-json-in-batches.js
@@ -22,7 +22,8 @@ export default async function* parseJSONInBatches(asyncIterator, options) {
   for await (const chunk of asyncIterator) {
     const rows = parser.write(chunk);
 
-    const jsonpath = rows.length > 0 && parser.getStreamingJsonPath();
+    const jsonpath =
+      rows.length > 0 && parser.getStreamingJsonPath() && parser.getStreamingJsonPath().toString();
 
     if (rows.length > 0 && isFirstChunk) {
       if (metadata) {
@@ -66,7 +67,7 @@ export default async function* parseJSONInBatches(asyncIterator, options) {
   }
 
   // yield final batch
-  const jsonpath = parser.getStreamingJsonPath();
+  const jsonpath = parser.getStreamingJsonPath() && parser.getStreamingJsonPath().toString();
   const batch = tableBatchBuilder.getBatch({jsonpath});
   if (batch) {
     yield batch;
@@ -76,7 +77,7 @@ export default async function* parseJSONInBatches(asyncIterator, options) {
     const finalBatch = {
       batchType: 'final-result',
       container: parser.getPartialResult(),
-      jsonpath: parser.getStreamingJsonPath(),
+      jsonpath: parser.getStreamingJsonPath() && parser.getStreamingJsonPath().toString(),
       data: [],
       schema: null
     };

--- a/modules/json/src/lib/parse-json-in-batches.js
+++ b/modules/json/src/lib/parse-json-in-batches.js
@@ -22,8 +22,7 @@ export default async function* parseJSONInBatches(asyncIterator, options) {
   for await (const chunk of asyncIterator) {
     const rows = parser.write(chunk);
 
-    const jsonpath =
-      rows.length > 0 && parser.getStreamingJsonPath() && parser.getStreamingJsonPath().toString();
+    const jsonpath = rows.length > 0 && parser.getStreamingJsonPathAsString();
 
     if (rows.length > 0 && isFirstChunk) {
       if (metadata) {
@@ -67,7 +66,7 @@ export default async function* parseJSONInBatches(asyncIterator, options) {
   }
 
   // yield final batch
-  const jsonpath = parser.getStreamingJsonPath() && parser.getStreamingJsonPath().toString();
+  const jsonpath = parser.getStreamingJsonPathAsString();
   const batch = tableBatchBuilder.getBatch({jsonpath});
   if (batch) {
     yield batch;
@@ -77,7 +76,7 @@ export default async function* parseJSONInBatches(asyncIterator, options) {
     const finalBatch = {
       batchType: 'final-result',
       container: parser.getPartialResult(),
-      jsonpath: parser.getStreamingJsonPath() && parser.getStreamingJsonPath().toString(),
+      jsonpath: parser.getStreamingJsonPathAsString(),
       data: [],
       schema: null
     };

--- a/modules/json/src/lib/parser/streaming-json-parser.js
+++ b/modules/json/src/lib/parser/streaming-json-parser.js
@@ -46,6 +46,10 @@ export default class StreamingJSONParser extends JSONParser {
     return this.streamingJsonPath;
   }
 
+  getStreamingJsonPathAsString() {
+    return this.streamingJsonPath && this.streamingJsonPath.toString();
+  }
+
   getJsonPath() {
     return this.jsonpath;
   }

--- a/modules/json/test/json-loader.spec.js
+++ b/modules/json/test/json-loader.spec.js
@@ -73,7 +73,7 @@ test('JSONLoader#loadInBatches(jsonpaths)', async t => {
     batchCount++;
     rowCount += batch.length;
     byteLength = batch.bytesUsed;
-    t.equal(batch.jsonpath, '$.features', 'correct jsonpath on batch');
+    t.equal(batch.jsonpath.toString(), '$.features', 'correct jsonpath on batch');
   }
 
   t.ok(batchCount <= 3, 'Correct number of batches received');

--- a/modules/json/test/json-loader.spec.js
+++ b/modules/json/test/json-loader.spec.js
@@ -73,7 +73,7 @@ test('JSONLoader#loadInBatches(jsonpaths)', async t => {
     batchCount++;
     rowCount += batch.length;
     byteLength = batch.bytesUsed;
-    t.equal(batch.jsonpath.toString(), '$.features', 'correct jsonpath on batch');
+    t.equal(batch.jsonpath, '$.features', 'correct jsonpath on batch');
   }
 
   t.ok(batchCount <= 3, 'Correct number of batches received');


### PR DESCRIPTION
Ensures that `jsonpath` is exposed as a `JSONPath` object for all batch types (used to be a string for some, and an object for others). This will also allow clients to use the JSONPath object for setting/getting fields without an additional import.