### PR TITLE
TerrainLoader Add bounds: null default to prevent warnings

### DIFF
--- a/modules/terrain/src/terrain-loader.js
+++ b/modules/terrain/src/terrain-loader.js
@@ -13,6 +13,7 @@ export const TerrainWorkerLoader = {
   mimeTypes: ['image/png'],
   options: {
     terrain: {
+      bounds: null,
       workerUrl: `https://unpkg.com/@loaders.gl/terrain@${VERSION}/dist/terrain-loader.worker.js`,
       meshMaxError: 10,
       elevationDecoder: {


### PR DESCRIPTION
In 2.2, `validateLoaderOptions` throws a warning because `bounds` isn't defined on the default options object.

By default, `bounds` is `[0, 0, tileSize, tileSize]`, which is used when bounds is falsy.

It might be ideal to add a test for `validateLoaderOptions` to the `validateLoader` test?