### PR TITLE
Improve MIME type regex

### DIFF
--- a/modules/core/src/lib/utils/mime-type-utils.js
+++ b/modules/core/src/lib/utils/mime-type-utils.js
@@ -1,7 +1,7 @@
 // TODO - build/integrate proper MIME type parsing
 // https://mimesniff.spec.whatwg.org/
 
-const DATA_URL_PATTERN = /^data:(.*?)(;|,)/;
+const DATA_URL_PATTERN = /^data:([-\w.]+\/[-\w.+]+)(;|,)/;
 const MIME_TYPE_PATTERN = /^([-\w.]+\/[-\w.+]+)/;
 
 export function parseMIMEType(mimeString) {

--- a/modules/core/src/lib/utils/mime-type-utils.js
+++ b/modules/core/src/lib/utils/mime-type-utils.js
@@ -2,7 +2,7 @@
 // https://mimesniff.spec.whatwg.org/
 
 const DATA_URL_PATTERN = /^data:(.*?)(;|,)/;
-const MIME_TYPE_PATTERN = /^(.*?)(;|,)/;
+const MIME_TYPE_PATTERN = /^([-\w.]+\/[-\w.+]+)/;
 
 export function parseMIMEType(mimeString) {
   if (typeof mimeString !== 'string') {

--- a/modules/core/src/lib/utils/mime-type-utils.js
+++ b/modules/core/src/lib/utils/mime-type-utils.js
@@ -15,7 +15,7 @@ export function parseMIMEType(mimeString) {
     return matches[1];
   }
 
-  return '';
+  return mimeString;
 }
 
 export function parseMIMETypeFromURL(dataUrl) {

--- a/modules/core/test/lib/utils/mime-type-utils.spec.js
+++ b/modules/core/test/lib/utils/mime-type-utils.spec.js
@@ -6,6 +6,7 @@ const DATA_URL =
 
 test('parseMIMEType', t => {
   t.equal(parseMIMEType('image/png;'), 'image/png');
+  t.equal(parseMIMEType('image/png'), 'image/png');
 
   t.end();
 });

--- a/modules/core/test/lib/utils/mime-type-utils.spec.js
+++ b/modules/core/test/lib/utils/mime-type-utils.spec.js
@@ -7,6 +7,9 @@ const DATA_URL =
 test('parseMIMEType', t => {
   t.equal(parseMIMEType('image/png;'), 'image/png');
   t.equal(parseMIMEType('image/png'), 'image/png');
+  t.equal(parseMIMEType('application/octet-stream;'), 'application/octet-stream');
+  t.equal(parseMIMEType('text/csv;'), 'text/csv');
+  t.equal(parseMIMEType('application/zip;'), 'application/zip');
 
   t.end();
 });


### PR DESCRIPTION
Improve regex for detecting MIME type. While not implementing the [full spec](https://mimesniff.spec.whatwg.org/#parsing-a-mime-type) for parsing an arbitrary MIME type, this should be improved over the existing `.+`.

Derived from [this regex](https://www.regextester.com/110183), tested against many common mime type strings.

Should it still return the input if no match found?