### PR TITLE
Add parseInBatches Shapefile method

### DIFF
--- a/modules/shapefile/package.json
+++ b/modules/shapefile/package.json
@@ -32,6 +32,7 @@
     "build-worker": "webpack --entry ./src/shp-loader.worker.js --output ./dist/shp-loader.worker.js --config ../../scripts/worker-webpack-config.js"
   },
   "dependencies": {
+    "@loaders.gl/core": "^2.1.1",
     "@loaders.gl/loader-utils": "^2.1.1"
   }
 }

--- a/modules/shapefile/package.json
+++ b/modules/shapefile/package.json
@@ -32,7 +32,6 @@
     "build-worker": "webpack --entry ./src/shp-loader.worker.js --output ./dist/shp-loader.worker.js --config ../../scripts/worker-webpack-config.js"
   },
   "dependencies": {
-    "@loaders.gl/core": "^2.1.1",
     "@loaders.gl/loader-utils": "^2.1.1"
   }
 }

--- a/modules/shapefile/src/shp-loader.js
+++ b/modules/shapefile/src/shp-loader.js
@@ -1,3 +1,4 @@
+import {concatenateChunksAsync} from '@loaders.gl/core';
 import parseSHP from './lib/parse-shp';
 /** @typedef {import('@loaders.gl/loader-utils').LoaderObject} LoaderObject */
 
@@ -24,5 +25,11 @@ export const SHPWorkerLoader = {
 export const SHPLoader = {
   ...SHPWorkerLoader,
   parse: async (arrayBuffer, options) => parseSHP(arrayBuffer),
-  parseSync: parseSHP
+  parseSync: parseSHP,
+  parseInBatches
 };
+
+async function* parseInBatches(asyncIterator, options) {
+  const arrayBuffer = await concatenateChunksAsync(asyncIterator);
+  yield parseSHP(arrayBuffer);
+}

--- a/modules/shapefile/src/shp-loader.js
+++ b/modules/shapefile/src/shp-loader.js
@@ -29,6 +29,7 @@ export const SHPLoader = {
   parseInBatches
 };
 
+// TODO actually parse .shp file in batches; instead of concatenating chunks
 async function* parseInBatches(asyncIterator, options) {
   const arrayBuffer = await concatenateChunksAsync(asyncIterator);
   yield parseSHP(arrayBuffer);

--- a/modules/shapefile/src/shp-loader.js
+++ b/modules/shapefile/src/shp-loader.js
@@ -1,4 +1,4 @@
-import {concatenateChunksAsync} from '@loaders.gl/core';
+import {concatenateChunksAsync} from '@loaders.gl/loader-utils';
 import parseSHP from './lib/parse-shp';
 /** @typedef {import('@loaders.gl/loader-utils').LoaderObject} LoaderObject */
 

--- a/modules/shapefile/test/index.js
+++ b/modules/shapefile/test/index.js
@@ -1,1 +1,2 @@
+import './shp-loader.spec';
 import './shp/parse-shp.spec';

--- a/modules/shapefile/test/shp-loader.spec.js
+++ b/modules/shapefile/test/shp-loader.spec.js
@@ -1,0 +1,22 @@
+import test from 'tape-promise/tape';
+import {loadInBatches, isIterator, isAsyncIterable} from '@loaders.gl/core';
+import {SHPLoader} from '@loaders.gl/shapefile';
+
+const SHAPEFILE_POLYGON_PATH = '@loaders.gl/shapefile/test/data/shapefile-js/polygons.shp';
+
+test('SHPLoader#loadInBatches polygons', async t => {
+  const iterator = await loadInBatches(SHAPEFILE_POLYGON_PATH, SHPLoader);
+  t.ok(isIterator(iterator) || isAsyncIterable(iterator), 'loadInBatches returned iterator');
+
+  let batch;
+  let batchCount = 0;
+  let rowCount = 0;
+  for await (batch of iterator) {
+    batchCount++;
+    rowCount += batch.features.length;
+  }
+
+  t.equal(batchCount, 1, 'Correct number of batches received');
+  t.equal(rowCount, 3, 'Correct number of row received');
+  t.end();
+});

--- a/modules/shapefile/test/shp-loader.spec.js
+++ b/modules/shapefile/test/shp-loader.spec.js
@@ -8,15 +8,14 @@ test('SHPLoader#loadInBatches polygons', async t => {
   const iterator = await loadInBatches(SHAPEFILE_POLYGON_PATH, SHPLoader);
   t.ok(isIterator(iterator) || isAsyncIterable(iterator), 'loadInBatches returned iterator');
 
-  let batch;
   let batchCount = 0;
   let rowCount = 0;
-  for await (batch of iterator) {
+  for await (const batch of iterator) {
     batchCount++;
     rowCount += batch.features.length;
   }
 
   t.equal(batchCount, 1, 'Correct number of batches received');
-  t.equal(rowCount, 3, 'Correct number of row received');
+  t.equal(rowCount, 3, 'Correct number of rows received');
   t.end();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3674,14 +3674,7 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-debug@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
-  integrity sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=
-  dependencies:
-    ms "0.7.1"
-
-debug@2.6.9, debug@^2.3.3, debug@^2.6.9:
+debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -4147,7 +4140,7 @@ entities@^2.0.0:
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.3.tgz#5c487e5742ab93c15abb5da22759b8590ec03b7f"
   integrity sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==
 
-env-paths@2.2.0:
+env-paths@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.0.tgz#cdca557dc009152917d6166e2febe1f039685e43"
   integrity sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==
@@ -6668,10 +6661,10 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
-macos-release@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.2.0.tgz#ab58d55dd4714f0a05ad4b0e90f4370fef5cdea8"
-  integrity sha512-iV2IDxZaX8dIcM7fG6cI46uNmHUxHE4yN+Z8tKHAW1TBPMZDIKHf/3L+YnOuj/FK9il14UaVdHmiQ1tsi90ltA==
+macos-release@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.3.0.tgz#eb1930b036c0800adebccd5f17bc4c12de8bb71f"
+  integrity sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA==
 
 make-dir@^1.0.0, make-dir@^1.3.0:
   version "1.3.0"
@@ -7065,11 +7058,6 @@ move-concurrently@^1.0.1:
     rimraf "^2.5.4"
     run-queue "^1.0.3"
 
-ms@0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
-  integrity sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=
-
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -7197,10 +7185,10 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-no-case@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.2.0.tgz#1f45c55a7bb30e42942ec74e5282f6b8f4495a40"
-  integrity sha1-H0XFWnuzDkKULsdOUoL2uPRJWkA=
+no-case@^2.2.0:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.2.tgz#60b813396be39b3f1288a4c1ed5d1e7d28b464ac"
+  integrity sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==
   dependencies:
     lower-case "^1.1.1"
 
@@ -7727,13 +7715,6 @@ p-is-promise@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-2.1.0.tgz#918cebaea248a62cf7ffab8e3bca8c5f882fc42e"
   integrity sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==
 
-p-limit@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.0.tgz#417c9941e6027a9abcba5092dd2904e255b5fbc2"
-  integrity sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==
-  dependencies:
-    p-try "^2.0.0"
-
 p-limit@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
@@ -7741,7 +7722,7 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
-p-limit@^2.0.0:
+p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
   integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
@@ -7896,7 +7877,7 @@ parse-github-repo-url@^1.3.0:
   resolved "https://registry.yarnpkg.com/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz#9e7d8bb252a6cb6ba42595060b7bf6df3dbc1f50"
   integrity sha1-nn2LslKmy2ukJZUGC3v23z28H1A=
 
-parse-json@2.2.0:
+parse-json@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
   integrity sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=
@@ -8973,15 +8954,7 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-run-async@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.2.0.tgz#8783abd83c7bb86f41ee0602fc82404b3bd6e8b9"
-  integrity sha1-h4Or2Dx7uG9B7gYC/IJASzvW6Lk=
-  dependencies:
-    is-promise "^2.1.0"
-    pinkie-promise "^2.0.0"
-
-run-async@^2.4.0:
+run-async@^2.2.0, run-async@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
   integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
@@ -9318,13 +9291,6 @@ socks@~2.3.2:
   dependencies:
     ip "1.1.5"
     smart-buffer "^4.1.0"
-
-sort-keys@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-1.1.2.tgz#441b6d4d346798f1b4e49e8920adfba0e543f9ad"
-  integrity sha1-RBttTTRnmPG05J6JIK37oOVD+a0=
-  dependencies:
-    is-plain-obj "^1.0.0"
 
 sort-keys@^2.0.0:
   version "2.0.0"
@@ -10699,16 +10665,16 @@ write-file-atomic@^2.0.0, write-file-atomic@^2.3.0, write-file-atomic@^2.4.2:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
 
-write-json-file@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/write-json-file/-/write-json-file-2.2.0.tgz#51862506bbb3b619eefab7859f1fd6c6d0530876"
-  integrity sha1-UYYlBruzthnu+reFnx/WxtBTCHY=
+write-json-file@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/write-json-file/-/write-json-file-2.3.0.tgz#2b64c8a33004d54b8698c76d585a77ceb61da32f"
+  integrity sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=
   dependencies:
     detect-indent "^5.0.0"
     graceful-fs "^4.1.2"
     make-dir "^1.0.0"
-    pify "^2.0.0"
-    sort-keys "^1.1.1"
+    pify "^3.0.0"
+    sort-keys "^2.0.0"
     write-file-atomic "^2.0.0"
 
 write-json-file@^3.2.0:


### PR DESCRIPTION
This adds a `parseInBatches` method to the `SHPLoader`. For now, this is still non-streaming, but should be streaming in the future.

The output of each batch is:
```
{
  header: {
    length: 676,
    type: 5,
    bbox: {
      minX: 0,
      minY: 0,
      minZ: 0,
      minM: 0,
      maxX: 5,
      maxY: 5,
      maxZ: 0,
      maxM: 0
    }
  },
  features: [
    { positions: [Object], indices: [Object] },
    { positions: [Object], indices: [Object] },
    { positions: [Object], indices: [Object] }
  ]
}
```

Relies on #820. 