### PR TITLE
Shapefile multi-file loading, initial file system support.

### DIFF
--- a/modules/loader-utils/src/index.d.ts
+++ b/modules/loader-utils/src/index.d.ts
@@ -1,4 +1,5 @@
-export {LoaderObject, WriterObject, LoaderContext, DataType, SyncDataType, BatchableDataType} from './types/types';
+export {LoaderObject, WriterObject, LoaderContext, DataType, SyncDataType, BatchableDataType,
+  IFileSystem, IRandomAccessReadFileSystem} from './types';
 
 export {default as createWorker} from './lib/create-worker';
 

--- a/modules/loader-utils/src/types.d.ts
+++ b/modules/loader-utils/src/types.d.ts
@@ -1,0 +1,92 @@
+/**
+ * A loader defintion that can be used with `@loaders.gl/core` functions
+ */
+export type LoaderObject = {
+  id: string,
+  name: string,
+  category?: string;
+  version: string,
+  extensions: string[],
+  mimeTypes: string[],
+  options: object;
+  deprecatedOptions?: object;
+
+  binary?: boolean;
+  text?: boolean;
+
+  test?: ((ArrayBuffer) => boolean) | string | number;
+
+  parse?: (arrayBuffer, options) => Promise<any>;
+  parseSync?: (arrayBuffer, options) => any;
+  parseText?: (string, options) => Promise<any>;
+  parseTextSync?: (string, options) => any;
+  parseInBatches?: (iterator: AsyncIterable<ArrayBuffer> | AsyncIterator<ArrayBuffer>, options: object) => any;
+
+  // TODO - deprecated
+  supported?: boolean;
+  testText?: (string) => boolean;
+};
+
+/**
+ * A writer defintion that can be used with `@loaders.gl/core` functions
+ */
+export type WriterObject = {
+  encode();
+};
+
+export type LoaderContext = {
+  fetch?: any;
+  loaders?: LoaderObject[];
+  url?: string;
+
+  parse?: (data: ArrayBuffer, options?: object) => Promise<any>;
+  parseSync?: (data: ArrayBuffer, options?: object) => any;
+  parseInBatches?: (data: AsyncIterator<any>, options?: object) => AsyncIterator<any>;
+};
+
+/** Types that can be synchronously parsed */
+export type SyncDataType = string | ArrayBuffer; // TODO File | Blob can be read synchronously...
+
+/** Types that can be parsed async */
+export type DataType = string | ArrayBuffer | File | Blob | Response | ReadableStream;
+
+/** Types that can be parsed in batches */
+export type BatchableDataType =
+  DataType |
+  Iterable<ArrayBuffer> |
+  AsyncIterable<ArrayBuffer> |
+  Promise<AsyncIterable<ArrayBuffer>>;
+
+/**
+ * A FileSystem interface can encapsulate a FileList, a ZipFile, a GoogleDrive etc.
+ */
+export interface IFileSystem {
+  /**
+   * Return a list of file names
+   * @param dirname directory name. file system root directory if omitted
+   */
+  readdir(dirname?: string, options?: {recursive?: boolean}): Promise<string[]>;
+
+  /**
+   * Gets information from a local file from the filesystem
+   * @param filename file name to stat
+   * @param options currently unused
+   * @throws if filename is not in local filesystem
+   */
+  stat(filename: string, options?: object): Promise<{size: number}>;
+
+  /**
+   * Fetches a local file from the filesystem (or a URL)
+   * @param filename
+   * @param options
+   */
+  fetch(filename: string, options?: object): Promise<Response>;
+}
+
+type ReadOptions = {buffer?: ArrayBuffer, offset?: number, length?: number, position?: number};
+export interface IRandomAccessReadFileSystem extends IFileSystem {
+  open(path: string, flags, mode?): Promise<any>;
+  close(fd: any): Promise<void>;
+  fstat(fd: any): Promise<object>;
+  read(fd: any, options?: ReadOptions): Promise<{bytesRead: number, buffer: Buffer}>;
+}

--- a/modules/shapefile/package.json
+++ b/modules/shapefile/package.json
@@ -27,9 +27,10 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-worker && npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-shp-worker && npm run build-dbf-worker && npm run build-bundle && npm run build-bundle -- --env.dev",
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js",
-    "build-worker": "webpack --entry ./src/shp-loader.worker.js --output ./dist/shp-loader.worker.js --config ../../scripts/worker-webpack-config.js && webpack --entry ./src/dbf-loader.worker.js --output ./dist/dbf-loader.worker.js --config ../../scripts/worker-webpack-config.js"
+    "build-shp-worker": "webpack --entry ./src/workers/shp-loader.worker.js --output ./dist/shp-loader.worker.js --config ../../scripts/worker-webpack-config.js",
+    "build-dbf-worker": "webpack --entry ./src/workers/dbf-loader.worker.js --output ./dist/dbf-loader.worker.js --config ../../scripts/worker-webpack-config.js"
   },
   "dependencies": {
     "@loaders.gl/loader-utils": "^2.1.1"

--- a/modules/shapefile/src/dbf-loader.js
+++ b/modules/shapefile/src/dbf-loader.js
@@ -15,7 +15,8 @@ export const DBFWorkerLoader = {
   mimeTypes: [],
   options: {
     dbf: {
-      encoding: 'windows-1252',
+      // Default to ASCII or UTF-8?
+      encoding: 'utf-8',
       workerUrl: `https://unpkg.com/@loaders.gl/shapefile@${VERSION}/dist/dbf-loader.worker.js`
     }
   }

--- a/modules/shapefile/src/index.js
+++ b/modules/shapefile/src/index.js
@@ -1,2 +1,7 @@
+export {ShapefileLoader} from './shapefile-loader';
 export {DBFLoader, DBFWorkerLoader} from './dbf-loader';
 export {SHPLoader, SHPWorkerLoader} from './shp-loader';
+
+// EXPERIMENTAL
+export {default as _BrowserFileSystem} from './lib/filesystems/browser-filesystem';
+export {default as _NodeFileSystem} from './lib/filesystems/node-filesystem';

--- a/modules/shapefile/src/lib/api/parse-files.js
+++ b/modules/shapefile/src/lib/api/parse-files.js
@@ -1,0 +1,47 @@
+/*
+import {fetchFile, selectLoader} from "@loaders.gl/core";
+
+/**
+ * Parses files within a list of files, allowing it to load other files against that list
+ * @param {*} files
+ *
+async function parseFiles(files, loaders, options) {
+  let filenames = files;
+  if (files.readdir) {
+    filenames = await files.readdir();
+  }
+
+  const promises = [];
+  for (const filename of filenames) {
+    // Check that this filename has a loader
+    const loader = selectLoader(filename, loaders, options);
+    if (loader) {
+      options = {...files, fetch: files.fetch};
+      const promise = parse(filename, loaders, options);
+      promises.push(promise);
+    }
+  }
+
+  return Promise.all(promises);
+}
+
+async function parseFilesInBatches(files, loaders, options) {
+  let filenames = files;
+  if (files.readdir) {
+    filenames = await files.readdir();
+  }
+
+  const asyncIterators = [];
+  for (const filename of filenames) {
+    // Check that this filename has a loader
+    const loader = selectLoader(filename, loaders, options);
+    if (loader) {
+      options = {...files, fetch: files.fetch};
+      const asyncIterator = await parseInBatches(filename, loaders, options);
+      asyncIterators.push(asyncIterator);
+    }
+  }
+
+  return asyncIterators;
+}
+*/

--- a/modules/shapefile/src/lib/filesystems/browser-filesystem.d.ts
+++ b/modules/shapefile/src/lib/filesystems/browser-filesystem.d.ts
@@ -1,0 +1,24 @@
+import {IFileSystem} from '@loaders.gl/loader-utils';
+
+/**
+ * FileSystem for browser FileList
+ */
+export default class BrowserFileSystem implements IFileSystem {
+  /**
+   * A FileSystem API wrapper around a list of browser 'File' objects
+   * @param files
+   * @param options
+   */
+  constructor(files: FileList | File[], options?: object);
+
+  // implements IFileSystem
+  fetch(filename: string, options?: object): Promise<Response>;
+  readdir(dirname?: string): Promise<string[]>;
+  stat(filename: string, options?: object): Promise<{size: number}>;
+
+  // implements IRandomAccessFileSystem
+  open(path: string, flags, mode?): Promise<number>;
+  close(fd: number): Promise<void>;
+  fstat(fd: number): Promise<object>; // Stat
+  read(fd: number): Promise<any>;
+}

--- a/modules/shapefile/src/lib/filesystems/browser-filesystem.js
+++ b/modules/shapefile/src/lib/filesystems/browser-filesystem.js
@@ -1,0 +1,91 @@
+/* global Response, fetch, FileReader */
+// import {fetchFile} from "../fetch/fetch-file"
+/** @typedef {import('@loaders.gl/loader-utils').IFileSystem} IFileSystem */
+
+/** @implements {IFileSystem} */
+export default class BrowserFileSystem {
+  constructor(files, options = {}) {
+    this._fetch = options.fetch || fetch;
+    this.files = {};
+
+    for (let i = 0; i < files.length; ++i) {
+      const file = files[i];
+      this.files[file.name] = file;
+    }
+
+    this.fetch = this.fetch.bind(this);
+  }
+
+  // FETCH
+
+  async fetch(path, options = {}) {
+    if (path.includes('://')) {
+      // Falls back to handle https:/http:/data: etc fetches
+      const fallbackFetch = options.fetch || this._fetch;
+      return fallbackFetch(path, options);
+    }
+
+    // local fetches are served from the list of files
+    const file = this.files[path];
+    if (file) {
+      // return makeResponse()
+      return new Response(this.files[path]);
+    }
+    return new Response(path, {status: 400, statusText: 'NOT FOUND'});
+  }
+
+  // FS
+
+  async readdir() {
+    const files = [];
+    for (const path in this.files) {
+      files.push(path);
+    }
+    return files;
+  }
+
+  async stat(path, options) {
+    const file = this.files[path];
+    if (!file) {
+      throw new Error(`No such file: ${path}`);
+    }
+    return {size: file.size};
+  }
+
+  // Just removes the file from the list
+  async unlink(pathname) {
+    delete this.files[pathname];
+  }
+
+  // RANDOM ACCESS
+  async open(pathname) {
+    return this.files[pathname];
+  }
+
+  // buffer is the buffer that the data (read from the fd) will be written to.
+  // offset is the offset in the buffer to start writing at.
+  // length is an integer specifying the number of bytes to read.
+  // position is an argument specifying where to begin reading from in the file. If position is null, data will be read from the current file position, and the file position will be updated. If position is an integer, the file position will remain unchanged.
+  async read(fd, {buffer = null, offset = 0, length = buffer.byteLength, position = null}) {
+    const file = fd;
+    const arrayBuffer = await readFileSlice(file, position, position + length);
+    return arrayBuffer;
+  }
+
+  async close(fd) {
+    // NO OP
+  }
+}
+
+// The trick when reading File objects is to read successive "slices" of the File
+// Per spec https://w3c.github.io/FileAPI/, slicing a File should only update the start and end fields
+// Actually reading from file should happen in `readAsArrayBuffer` (and as far we can tell it does)
+async function readFileSlice(file, start, end) {
+  const slice = file.slice(start, end);
+  return await new Promise((resolve, reject) => {
+    const fileReader = new FileReader();
+    fileReader.onloadend = event => resolve(event.target.result);
+    fileReader.onerror = error => reject(error);
+    fileReader.readAsArrayBuffer(slice);
+  });
+}

--- a/modules/shapefile/src/lib/filesystems/node-filesystem.d.ts
+++ b/modules/shapefile/src/lib/filesystems/node-filesystem.d.ts
@@ -1,0 +1,31 @@
+import {IFileSystem, IRandomAccessReadFileSystem} from '@loaders.gl/loader-utils';
+
+type Stat = {
+  size: number,
+  isDirectory: () => boolean;
+};
+
+type ReadOptions = {buffer?: ArrayBuffer, offset?: number, length?: number, position?: number};
+
+/**
+ * FileSystem pass-through for Node.js
+ * - Provides promisified versions of Node `fs` API
+ * - Type compatible with BrowserFileSystem.
+ */
+export default class NodeFileSystem implements IFileSystem, IRandomAccessReadFileSystem {
+  /**
+   * @param options
+   */
+  constructor(options?: object);
+
+  // implements IFileSystem
+  fetch(path: string, options?: object): Promise<Response>;
+  readdir(path?: string): Promise<string[]>;
+  stat(path: string, options?: object): Promise<Stat>;
+
+  // implements IRandomAccessFileSystem
+  open(path: string, flags, mode?): Promise<number>;
+  close(fd: number): Promise<void>;
+  fstat(fd: number): Promise<Stat>;
+  read(fd: number, options: ReadOptions): Promise<{bytesRead: number, buffer: Buffer}>;
+}

--- a/modules/shapefile/src/lib/filesystems/node-filesystem.js
+++ b/modules/shapefile/src/lib/filesystems/node-filesystem.js
@@ -1,0 +1,63 @@
+import fs from 'fs';
+import util from 'util';
+
+// import {fetchFile} from "../fetch/fetch-file"
+// import {selectLoader} from "../api/select-loader";
+/** @typedef {import('@loaders.gl/loader-utils').IFileSystem} IFileSystem */
+
+/** @implements {IFileSystem} */
+export default class NodeFileSystem {
+  constructor(options = {}) {
+    this._fetch = options.fetch;
+  }
+
+  async readdir(path = '.', options) {
+    const readdir = util.promisify(fs.readdir);
+    return await readdir(path, options);
+  }
+
+  async stat(path, options) {
+    const stat = util.promisify(fs.stat);
+    const info = await stat(path, options);
+    return {size: Number(info.size), isDirectory: () => false, info};
+  }
+
+  async fetch(path, options = {}) {
+    // Falls back to handle https:/http:/data: etc fetches
+    const fallbackFetch = options.fetch || this._fetch;
+    return fallbackFetch(path, options);
+  }
+
+  async open(path, flags, mode) {
+    const open = util.promisify(fs.open);
+    return await open(path, flags);
+  }
+
+  async close(fd) {
+    const close = util.promisify(fs.close);
+    return await close(fd);
+  }
+
+  async fstat(fd) {
+    const fstat = util.promisify(fs.fstat);
+    const info = await fstat(fd);
+    return info;
+  }
+
+  async read(fd, {buffer = null, offset = 0, length = buffer.byteLength, position = null}) {
+    const fsRead = util.promisify(fs.read);
+    let totalBytesRead = 0;
+    // Read in loop until we get required number of bytes
+    while (totalBytesRead < length) {
+      const {bytesRead} = await fsRead(
+        fd,
+        buffer,
+        offset + totalBytesRead,
+        length - totalBytesRead,
+        position + totalBytesRead
+      );
+      totalBytesRead += bytesRead;
+    }
+    return {bytesRead: totalBytesRead, buffer};
+  }
+}

--- a/modules/shapefile/src/shapefile-loader.js
+++ b/modules/shapefile/src/shapefile-loader.js
@@ -1,0 +1,123 @@
+import {SHPLoader} from './shp-loader';
+import {parseShx} from './lib/parse-shx';
+/** @typedef {import('@loaders.gl/loader-utils').LoaderObject} LoaderObject */
+
+// __VERSION__ is injected by babel-plugin-version-inline
+// @ts-ignore TS2304: Cannot find name '__VERSION__'.
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+
+/** @type {LoaderObject} */
+export const ShapefileLoader = {
+  id: 'shp',
+  name: 'Shapefile',
+  category: 'geometry',
+  version: VERSION,
+  extensions: ['shp'],
+  mimeTypes: [],
+  options: {
+    shapefile: {}
+  },
+  parse: parseShapefile,
+  parseInBatches: parseShapefileInBatches
+};
+
+async function parseShapefile(arrayBuffer, options, context) {
+  const {parse} = context;
+  const {shx, cpg, prj} = await loadShapefileSidecarfiles(options, context);
+
+  // parse geometries
+  const shapes = await parse(arrayBuffer, SHPLoader); // , {shp: shx});
+
+  // parse properties
+  // const {url} = context;
+  // const baseName = basename(url);
+  // let dbfResponse = fetch(`${baseName}.dbf`);
+  // const properties = await parse(dbfResponse, DBFLoader, {dbf: {cpg});
+
+  return {
+    cpg,
+    prj,
+    shx,
+    shapes
+    // properties
+  };
+}
+
+async function parseShapefileInBatches(asyncIterator, options, context) {
+  const {parseInBatches} = context;
+  const {shx, cpg, prj} = await loadShapefileSidecarfiles(options, context);
+
+  // parse geometries
+  const shapes = parseInBatches(asyncIterator, SHPLoader, {shp: shx});
+
+  // parse properties
+  // let dbfResponse = fetch(`${baseName}.dbf`);
+  // const properties = parseInBatches(dbfResponse, DBFLoader, {dbf: {cpg});
+
+  return {
+    cpg,
+    prj,
+    shx,
+    shapes
+    // properties
+  };
+}
+
+// eslint-disable-next-line max-statements
+async function loadShapefileSidecarfiles(options, context) {
+  const {url} = context;
+  const baseName = basename(url);
+  const extension = extname(url);
+  const upperCase = extension === extension.toUpperCase();
+
+  // Attempt a parallel load of the small sidecar files
+
+  // NOTE: Extensions can be both lower and uppercase
+  // per spec, extensions should be lower case, but that doesn't mean they always are. See:
+  // calvinmetcalf/shapefile-js#64
+  // mapserver/mapserver#4712
+  // https://trac.osgeo.org/mapserver/ticket/166
+  // Match the case of the SHP file extension instead of firing off another request storm
+
+  const shxPromise = context.fetch(`${baseName}${upperCase ? '.SHX' : '.shx'}`);
+  const cpgPromise = context.fetch(`${baseName}${upperCase ? '.CPG' : '.cpg'}`);
+  const prjPromise = context.fetch(`${baseName}${upperCase ? '.PRJ' : '.prj'}`);
+  await Promise.all([shxPromise, cpgPromise, prjPromise]);
+
+  let shx = null;
+  let cpg = null;
+  let prj = null;
+
+  const shxResponse = await shxPromise;
+  if (shxResponse.ok) {
+    const arrayBuffer = await shxResponse.arrayBuffer();
+    shx = parseShx(arrayBuffer);
+  }
+
+  const cpgResponse = await cpgPromise;
+  if (cpgResponse.ok) {
+    cpg = await cpgResponse.text();
+  }
+
+  const prjResponse = await prjPromise;
+  if (prjResponse.ok) {
+    prj = await prjResponse.text();
+  }
+
+  return {
+    shx,
+    cpg,
+    prj
+  };
+}
+
+// NOTE - this gives the entire path minus extension (not same as path.basename)
+function basename(url) {
+  const extIndex = url && url.lastIndexOf('.');
+  return extIndex >= 0 ? url.substr(0, extIndex) : '';
+}
+
+function extname(url) {
+  const extIndex = url && url.lastIndexOf('.');
+  return extIndex >= 0 ? url.substr(extIndex + 1) : '';
+}

--- a/modules/shapefile/src/shp-loader.js
+++ b/modules/shapefile/src/shp-loader.js
@@ -15,7 +15,7 @@ export const SHPWorkerLoader = {
   mimeTypes: [],
   options: {
     shp: {
-      workerUrl: `https://unpkg.com/@loaders.gl/shapefile@${VERSION}/dist/shp-loader.worker.js`
+      // workerUrl: `https://unpkg.com/@loaders.gl/shapefile@${VERSION}/dist/shp-loader.worker.js`
     }
   }
 };

--- a/modules/shapefile/src/workers/dbf-loader.worker.js
+++ b/modules/shapefile/src/workers/dbf-loader.worker.js
@@ -1,0 +1,4 @@
+import {DBFLoader} from '../dbf-loader';
+import {createWorker} from '@loaders.gl/loader-utils';
+
+createWorker(DBFLoader);

--- a/modules/shapefile/src/workers/shp-loader.worker.js
+++ b/modules/shapefile/src/workers/shp-loader.worker.js
@@ -1,0 +1,4 @@
+import {SHPLoader} from '../shp-loader';
+import {createWorker} from '@loaders.gl/loader-utils';
+
+createWorker(SHPLoader);

--- a/modules/shapefile/test/dbf/parse-dbf.spec.js
+++ b/modules/shapefile/test/dbf/parse-dbf.spec.js
@@ -23,10 +23,10 @@ test('Shapefile JS DBF tests', async t => {
   for (const testFileName of SHAPEFILE_JS_TEST_FILES) {
     let response = await fetchFile(`${SHAPEFILE_JS_DATA_FOLDER}/${testFileName}.dbf`);
     const body = await response.arrayBuffer();
-    const options = {worker: false, dbf: {encoding: 'windows-1252'}};
+    const options = {worker: false, dbf: {encoding: 'utf8'}};
 
-    if (testFileName === 'utf8-property') {
-      options.dbf.encoding = 'utf8';
+    if (testFileName === 'latin1-property') {
+      options.dbf.encoding = 'latin1';
     }
     const output = await parse(body, DBFLoader, options);
 

--- a/modules/shapefile/test/index.js
+++ b/modules/shapefile/test/index.js
@@ -2,3 +2,4 @@ import './shp-loader.spec';
 
 import './dbf/parse-dbf.spec';
 import './shp/parse-shp.spec';
+import './shapefile-loader.spec';

--- a/modules/shapefile/test/shapefile-loader.spec.js
+++ b/modules/shapefile/test/shapefile-loader.spec.js
@@ -1,0 +1,108 @@
+/* global File */
+import test from 'tape-promise/tape';
+import {fetchFile, load, isBrowser} from '@loaders.gl/core';
+import {geojsonToBinary} from '@loaders.gl/gis';
+import {ShapefileLoader} from '@loaders.gl/shapefile';
+import {_BrowserFileSystem as BrowserFileSystem} from '@loaders.gl/shapefile';
+
+const SHAPEFILE_JS_DATA_FOLDER = '@loaders.gl/shapefile/test/data/shapefile-js';
+const SHAPEFILE_JS_TEST_FILES = {
+  'boolean-property': null,
+  'date-property': null,
+  empty: null,
+  'ignore-properties': null,
+  'latin1-property': null,
+  'mixed-properties': null,
+  multipointm: null,
+  multipoints: null,
+  null: null,
+  'number-null-property': null,
+  'number-property': null,
+  pointm: null,
+  points: null,
+  polygonm: null,
+  polygons: null,
+  polylinem: null,
+  polylines: null,
+  singleton: null,
+  'string-property': null,
+  'utf8-property': null
+};
+
+test('ShapefileLoader#load (from browser File objects)', async t => {
+  if (isBrowser) {
+    // test `File` load (browser)
+    t.comment('...FILE LOAD STARTING. FAILED FETCHES EXPECTED');
+    for (const testFileName in SHAPEFILE_JS_TEST_FILES) {
+      const fileList = await getFileList(testFileName);
+      SHAPEFILE_JS_TEST_FILES[testFileName] = fileList;
+    }
+    t.comment('...FILE LOAD COMPLETE');
+
+    for (const testFileName in SHAPEFILE_JS_TEST_FILES) {
+      const fileList = SHAPEFILE_JS_TEST_FILES[testFileName];
+      const fileSystem = new BrowserFileSystem(fileList);
+      const {fetch} = fileSystem;
+      const filename = `${testFileName}.shp`;
+      const data = await load(filename, ShapefileLoader, {fetch});
+      t.comment(`${filename}: ${JSON.stringify(data).slice(0, 70)}`);
+
+      testShapefileData(t, testFileName, data);
+    }
+  }
+  t.end();
+});
+
+test('ShapefileLoader#load (from files or URLs)', async t => {
+  // test file load (node) or URL load (browser)
+  for (const testFileName in SHAPEFILE_JS_TEST_FILES) {
+    const filename = `${SHAPEFILE_JS_DATA_FOLDER}/${testFileName}.shp`;
+    const data = await load(filename, ShapefileLoader);
+    t.comment(`${filename}: ${JSON.stringify(data).slice(0, 70)}`);
+
+    await testShapefileData(t, testFileName, data);
+  }
+
+  t.end();
+});
+
+async function getFileList(testFileName) {
+  const EXTENSIONS = ['.shp', '.shx', '.dbf', '.cpg', '.prj'];
+  const fileList = [];
+  for (const extension of EXTENSIONS) {
+    const filename = `${testFileName}${extension}`;
+    const response = await fetchFile(`${SHAPEFILE_JS_DATA_FOLDER}/${filename}`);
+    if (response.ok) {
+      fileList.push(new File([await response.blob()], filename));
+    }
+  }
+  return fileList;
+}
+
+async function testShapefileData(t, testFileName, data) {
+  // Exceptions for files that don't currently pass tests
+  // TODO @kylebarron to fix
+  const EXCEPTIONS = [
+    'multipointm',
+    'null',
+    'pointm',
+    'polygons',
+    'polygonm',
+    'polylines',
+    'polylinem'
+  ];
+  if (EXCEPTIONS.some(exception => testFileName.includes(exception))) {
+    return;
+  }
+
+  // Compare with parsed json
+  const output = data.shapes;
+
+  const response = await fetchFile(`${SHAPEFILE_JS_DATA_FOLDER}/${testFileName}.json`);
+  const json = await response.json();
+
+  for (let i = 0; i < json.features.length; i++) {
+    const expBinary = geojsonToBinary([json.features[i]]).points.positions;
+    t.deepEqual(output.features[i].positions, expBinary);
+  }
+}


### PR DESCRIPTION
This provides filesystems that can hold a group of related files, letting the ShapefileLoader `fetch` sidecar files without caring about whether they were other files in the same drag-and-drop operation or if they are fetched from URLs.

Keeping the new filesystem classes in shapefile for now, to avoid adding too much unproven code to core.