### PR TITLE
WIP Binary to geojson converter

### DIFF
--- a/modules/gis/src/index.js
+++ b/modules/gis/src/index.js
@@ -1,1 +1,2 @@
 export {geojsonToBinary, TEST_EXPORTS} from './lib/geojson-to-binary';
+export {binaryToGeoJson} from './lib/binary-to-geojson';

--- a/modules/gis/src/lib/binary-to-geojson.d.ts
+++ b/modules/gis/src/lib/binary-to-geojson.d.ts
@@ -1,0 +1,1 @@
+export function binaryToGeoJson(data, type, format);

--- a/modules/gis/src/lib/binary-to-geojson.js
+++ b/modules/gis/src/lib/binary-to-geojson.js
@@ -62,8 +62,6 @@ function deduceReturnType(dataArray) {
 function parseFeatureCollection(dataArray) {
   const features = [];
   for (const data of dataArray) {
-    // Not sure how stable this is; even if all properties are numeric, will
-    // there still be a property object for each feature?
     let lastIndex = 0;
     let lastValue = data.featureIds.value[0];
 
@@ -74,8 +72,7 @@ function parseFeatureCollection(dataArray) {
         continue;
       }
 
-      // features.push(parseFeature(data, lastIndex, i));
-      features.push('hi');
+      features.push(parseFeature(data, lastIndex, i));
       lastIndex = i;
       lastValue = currValue;
     }
@@ -93,7 +90,11 @@ function parseFeature(data, startIndex, endIndex) {
 }
 
 function parseProperties(data, startIndex, endIndex) {
-  data;
+  const properties = Object.assign(data.properties[data.featureIds.value[startIndex]]);
+  for (const key in data.numericProps) {
+    properties[key] = data.numericProps[key].value[startIndex];
+  }
+  return properties;
 }
 
 function parseGeometry(data, startIdx, endIdx) {

--- a/modules/gis/src/lib/binary-to-geojson.js
+++ b/modules/gis/src/lib/binary-to-geojson.js
@@ -1,16 +1,46 @@
 /* eslint-disable */
 
-export function binaryToGeoJson(binary, type, options = {}) {
-  switch (type) {
+function binaryToGeoJson(data, type) {
+  var isFeature = Boolean(
+    data.featureIds || data.globalFeatureIds || data.numericProps || data.properties
+  );
+
+  // If not a feature, return only the geometry
+  if (!isFeature) {
+    return parseGeometry(data, type);
+  }
+
+  // TODO parse binary features
+}
+
+function parseFeature(data, type) {
+  var geometry = parseGeometry(data, type);
+  return {type: 'Feature', geometry};
+}
+
+function parseGeometry(data, type) {
+  switch (type || parseType(data)) {
     case 'point':
-      return pointToGeoJson(binary);
+      return pointToGeoJson(data);
     case 'lineString':
-      return lineStringToGeoJson(binary);
+      return lineStringToGeoJson(data);
     case 'polygon':
-      return polygonToGeoJson(binary);
+      return polygonToGeoJson(data);
     default:
       throw new Error('Invalid type');
   }
+}
+
+function parseType(data) {
+  if (data.pathIndices) {
+    return 'lineString';
+  }
+
+  if (data.polygonIndices) {
+    return 'polygon';
+  }
+
+  return 'point';
 }
 
 function polygonToGeoJson(data) {

--- a/modules/gis/src/lib/binary-to-geojson.js
+++ b/modules/gis/src/lib/binary-to-geojson.js
@@ -97,14 +97,14 @@ function parseProperties(data, startIndex, endIndex) {
   return properties;
 }
 
-function parseGeometry(data, startIdx, endIdx) {
+function parseGeometry(data, startIndex, endIndex) {
   switch (data.type) {
     case 'Point':
-      return pointToGeoJson(data);
+      return pointToGeoJson(data, startIndex, endIndex);
     case 'LineString':
-      return lineStringToGeoJson(data);
+      return lineStringToGeoJson(data, startIndex, endIndex);
     case 'Polygon':
-      return polygonToGeoJson(data);
+      return polygonToGeoJson(data, startIndex, endIndex);
     default:
       throw new Error('Invalid type');
   }
@@ -146,15 +146,13 @@ function polygonToGeoJson(data, startIndex, endIndex) {
   return {type: 'MultiPolygon', coordinates};
 }
 
-function lineStringToGeoJson(data) {
-  const {
-    positions,
-    pathIndices: {value: pathIndices}
-  } = data;
+function lineStringToGeoJson(data, startIndex, endIndex) {
+  const {positions} = data;
+  const pathIndices = data.pathIndices.value.filter(x => x >= startIndex && x <= endIndex);
   const multi = pathIndices.length > 2;
 
   if (!multi) {
-    const coordinates = ringToGeoJson(positions);
+    const coordinates = ringToGeoJson(positions, pathIndices[0], pathIndices[1]);
     return {type: 'LineString', coordinates};
   }
 
@@ -167,10 +165,10 @@ function lineStringToGeoJson(data) {
   return {type: 'MultiLineString', coordinates};
 }
 
-function pointToGeoJson(data) {
+function pointToGeoJson(data, startIndex, endIndex) {
   const {positions} = data;
-  const multi = positions.value.length / positions.size > 1;
-  const coordinates = ringToGeoJson(positions);
+  const coordinates = ringToGeoJson(positions, startIndex, endIndex);
+  const multi = coordinates.length > 1;
 
   if (multi) {
     return {type: 'MultiPoint', coordinates};

--- a/modules/gis/src/lib/binary-to-geojson.js
+++ b/modules/gis/src/lib/binary-to-geojson.js
@@ -1,5 +1,10 @@
-export function binaryToGeoJson(data, type) {
-  const dataArray = normalizeInput(data, type);
+
+function binaryToGeoJson(data, type, format) {
+  if (format === 'geometry') {
+    return parseGeometry(data);
+  }
+
+  var dataArray = normalizeInput(data, type);
 
   switch (deduceReturnType(dataArray)) {
     case 'Geometry':
@@ -57,17 +62,41 @@ function deduceReturnType(dataArray) {
 function parseFeatureCollection(dataArray) {
   const features = [];
   for (const data of dataArray) {
-    features.push(parseFeature(data));
+    // Not sure how stable this is; even if all properties are numeric, will
+    // there still be a property object for each feature?
+    let lastIndex = 0;
+    let lastValue = data.featureIds.value[0];
+
+    // Need to deduce start, end indices of each feature
+    for (let i = 0; i < data.featureIds.value.length; i++) {
+      const currValue = data.featureIds.value[i];
+      if (currValue === lastValue) {
+        continue;
+      }
+
+      // features.push(parseFeature(data, lastIndex, i));
+      features.push('hi');
+      lastIndex = i;
+      lastValue = currValue;
+    }
+
+    // Last feature
+    features.push(parseFeature(data, lastIndex, data.featureIds.value.length));
   }
   return features;
 }
 
-function parseFeature(data) {
-  const geometry = parseGeometry(data);
-  return {type: 'Feature', geometry};
+function parseFeature(data, startIndex, endIndex) {
+  const geometry = parseGeometry(data, startIndex, endIndex);
+  const properties = parseProperties(data, startIndex, endIndex);
+  return {type: 'Feature', geometry, properties};
 }
 
-function parseGeometry(data) {
+function parseProperties(data, startIndex, endIndex) {
+  data;
+}
+
+function parseGeometry(data, startIdx, endIdx) {
   switch (data.type) {
     case 'Point':
       return pointToGeoJson(data);

--- a/modules/gis/src/lib/binary-to-geojson.js
+++ b/modules/gis/src/lib/binary-to-geojson.js
@@ -122,22 +122,20 @@ function parseType(data) {
   return 'Point';
 }
 
-function polygonToGeoJson(data) {
-  const {
-    positions,
-    polygonIndices: {value: polygonIndices},
-    primitivePolygonIndices: {value: primitivePolygonIndices}
-  } = data;
+function polygonToGeoJson(data, startIndex, endIndex) {
+  const {positions} = data;
+  const polygonIndices = data.polygonIndices.value.filter(x => x >= startIndex && x <= endIndex);
+  const primitivePolygonIndices = data.primitivePolygonIndices.value.filter(
+    x => x >= startIndex && x <= endIndex
+  );
   const multi = polygonIndices.length > 2;
 
   const coordinates = [];
   if (!multi) {
     for (let i = 0; i < primitivePolygonIndices.length - 1; i++) {
-      const ringCoordinates = ringToGeoJson(
-        positions,
-        primitivePolygonIndices[i],
-        primitivePolygonIndices[i + 1]
-      );
+      const startPolygonIndex = primitivePolygonIndices[i];
+      const endPolygonIndex = primitivePolygonIndices[i + 1];
+      const ringCoordinates = ringToGeoJson(positions, startPolygonIndex, endPolygonIndex);
       coordinates.push(ringCoordinates);
     }
 

--- a/modules/gis/src/lib/binary-to-geojson.js
+++ b/modules/gis/src/lib/binary-to-geojson.js
@@ -60,6 +60,18 @@ function lineStringToGeoJson(data) {
   return {type: 'MultiLineString', coordinates};
 }
 
+function pointToGeoJson(data) {
+  var {positions} = data;
+  var multi = positions.value.length / positions.size > 1;
+  var coordinates = ringToGeoJson(positions);
+
+  if (multi) {
+    return {type: 'MultiPoint', coordinates};
+  }
+
+  return {type: 'Point', coordinates: coordinates[0]};
+}
+
 function ringToGeoJson(positions, startIndex, endIndex) {
   startIndex = startIndex || 0;
   endIndex = endIndex || positions.value.length / positions.size;

--- a/modules/gis/src/lib/binary-to-geojson.js
+++ b/modules/gis/src/lib/binary-to-geojson.js
@@ -4,8 +4,6 @@ export function binaryToGeoJson(data, type) {
   switch (deduceReturnType(dataArray)) {
     case 'Geometry':
       return parseGeometry(dataArray[0]);
-    case 'Feature':
-      return parseFeature(dataArray[0]);
     case 'FeatureCollection':
       return parseFeatureCollection(dataArray);
     default:
@@ -53,14 +51,7 @@ function deduceReturnType(dataArray) {
     return 'Geometry';
   }
 
-  if (
-    (data.globalFeatureIds && data.globalFeatureIds.value.length > 1) ||
-    (data.featureIds && data.featureIds.value.length > 1)
-  ) {
-    return 'FeatureCollection';
-  }
-
-  return 'Feature';
+  return 'FeatureCollection';
 }
 
 function parseFeatureCollection(dataArray) {

--- a/modules/gis/src/lib/binary-to-geojson.js
+++ b/modules/gis/src/lib/binary-to-geojson.js
@@ -1,5 +1,5 @@
 
-function binaryToGeoJson(data, type, format) {
+export function binaryToGeoJson(data, type, format) {
   if (format === 'geometry') {
     return parseGeometry(data);
   }

--- a/modules/gis/src/lib/binary-to-geojson.js
+++ b/modules/gis/src/lib/binary-to-geojson.js
@@ -1,11 +1,10 @@
-
 // Top-level function to convert input of binary arrays to GeoJSON
 export function binaryToGeoJson(data, type, format) {
   if (format === 'geometry') {
     return parseGeometry(data);
   }
 
-  var dataArray = normalizeInput(data, type);
+  const dataArray = normalizeInput(data, type);
 
   switch (deduceReturnType(dataArray)) {
     case 'Geometry':
@@ -72,6 +71,7 @@ function parseFeatureCollection(dataArray) {
     for (let i = 0; i < data.featureIds.value.length; i++) {
       const currValue = data.featureIds.value[i];
       if (currValue === lastValue) {
+        // eslint-disable-next-line no-continue
         continue;
       }
 

--- a/modules/gis/src/lib/binary-to-geojson.js
+++ b/modules/gis/src/lib/binary-to-geojson.js
@@ -14,8 +14,7 @@ export function binaryToGeoJson(binary, type, options = {}) {
 }
 
 function polygonToGeoJson(data) {
-  var positions = data.positions.value;
-  var positionsSize = data.positions.size;
+  var positions = data.positions;
   var polygonIndices = data.polygonIndices.value;
   var primitivePolygonIndices = data.primitivePolygonIndices.value;
   var multi = polygonIndices.length > 2;
@@ -23,16 +22,11 @@ function polygonToGeoJson(data) {
   var coordinates = [];
   if (!multi) {
     for (var i = 0; i < primitivePolygonIndices.length - 1; i++) {
-      var ringCoordinates = [];
-      var primitivePolygonIndex = primitivePolygonIndices[i];
-      var nextPrimitivePolygonIndex = primitivePolygonIndices[i + 1];
-
-      for (var j = primitivePolygonIndex; j < nextPrimitivePolygonIndex; j++) {
-        ringCoordinates.push(
-          Array.from(positions.subarray(j * positionsSize, (j + 1) * positionsSize))
-        );
-      }
-
+      var ringCoordinates = ringToGeoJson(
+        positions,
+        primitivePolygonIndices[i],
+        primitivePolygonIndices[i + 1]
+      );
       coordinates.push(ringCoordinates);
     }
 
@@ -42,3 +36,14 @@ function polygonToGeoJson(data) {
   // TODO handle MultiPolygon
   return {type: 'MultiPolygon', coordinates};
 }
+
+function ringToGeoJson(positions, startIndex, endIndex) {
+  var ringCoordinates = [];
+  for (var j = startIndex; j < endIndex; j++) {
+    ringCoordinates.push(
+      Array.from(positions.value.subarray(j * positions.size, (j + 1) * positions.size))
+    );
+  }
+  return ringCoordinates;
+}
+

--- a/modules/gis/src/lib/binary-to-geojson.js
+++ b/modules/gis/src/lib/binary-to-geojson.js
@@ -1,7 +1,5 @@
-/* eslint-disable */
-
-function binaryToGeoJson(data, type) {
-  var isFeature = Boolean(
+export function binaryToGeoJson(data, type) {
+  const isFeature = Boolean(
     data.featureIds || data.globalFeatureIds || data.numericProps || data.properties
   );
 
@@ -10,11 +8,12 @@ function binaryToGeoJson(data, type) {
     return parseGeometry(data, type);
   }
 
-  // TODO parse binary features
+  // TODO parse binary features, incl properties
+  return parseFeature(data, type);
 }
 
 function parseFeature(data, type) {
-  var geometry = parseGeometry(data, type);
+  const geometry = parseGeometry(data, type);
   return {type: 'Feature', geometry};
 }
 
@@ -44,17 +43,17 @@ function parseType(data) {
 }
 
 function polygonToGeoJson(data) {
-  var {
+  const {
     positions,
     polygonIndices: {value: polygonIndices},
     primitivePolygonIndices: {value: primitivePolygonIndices}
   } = data;
-  var multi = polygonIndices.length > 2;
+  const multi = polygonIndices.length > 2;
 
-  var coordinates = [];
+  const coordinates = [];
   if (!multi) {
-    for (var i = 0; i < primitivePolygonIndices.length - 1; i++) {
-      var ringCoordinates = ringToGeoJson(
+    for (let i = 0; i < primitivePolygonIndices.length - 1; i++) {
+      const ringCoordinates = ringToGeoJson(
         positions,
         primitivePolygonIndices[i],
         primitivePolygonIndices[i + 1]
@@ -70,20 +69,20 @@ function polygonToGeoJson(data) {
 }
 
 function lineStringToGeoJson(data) {
-  var {
+  const {
     positions,
     pathIndices: {value: pathIndices}
   } = data;
-  var multi = pathIndices.length > 2;
+  const multi = pathIndices.length > 2;
 
-  var coordinates = [];
   if (!multi) {
-    coordinates = ringToGeoJson(positions);
+    const coordinates = ringToGeoJson(positions);
     return {type: 'LineString', coordinates};
   }
 
-  for (var i = 0; i < pathIndices.length - 1; i++) {
-    var ringCoordinates = ringToGeoJson(positions, pathIndices[i], pathIndices[i + 1]);
+  const coordinates = [];
+  for (let i = 0; i < pathIndices.length - 1; i++) {
+    const ringCoordinates = ringToGeoJson(positions, pathIndices[i], pathIndices[i + 1]);
     coordinates.push(ringCoordinates);
   }
 
@@ -91,9 +90,9 @@ function lineStringToGeoJson(data) {
 }
 
 function pointToGeoJson(data) {
-  var {positions} = data;
-  var multi = positions.value.length / positions.size > 1;
-  var coordinates = ringToGeoJson(positions);
+  const {positions} = data;
+  const multi = positions.value.length / positions.size > 1;
+  const coordinates = ringToGeoJson(positions);
 
   if (multi) {
     return {type: 'MultiPoint', coordinates};
@@ -106,12 +105,11 @@ function ringToGeoJson(positions, startIndex, endIndex) {
   startIndex = startIndex || 0;
   endIndex = endIndex || positions.value.length / positions.size;
 
-  var ringCoordinates = [];
-  for (var j = startIndex; j < endIndex; j++) {
+  const ringCoordinates = [];
+  for (let j = startIndex; j < endIndex; j++) {
     ringCoordinates.push(
       Array.from(positions.value.subarray(j * positions.size, (j + 1) * positions.size))
     );
   }
   return ringCoordinates;
 }
-

--- a/modules/gis/src/lib/binary-to-geojson.js
+++ b/modules/gis/src/lib/binary-to-geojson.js
@@ -1,0 +1,44 @@
+/* eslint-disable */
+
+export function binaryToGeoJson(binary, type, options = {}) {
+  switch (type) {
+    case 'point':
+      return pointToGeoJson(binary);
+    case 'lineString':
+      return lineStringToGeoJson(binary);
+    case 'polygon':
+      return polygonToGeoJson(binary);
+    default:
+      throw new Error('Invalid type');
+  }
+}
+
+function polygonToGeoJson(data) {
+  var positions = data.positions.value;
+  var positionsSize = data.positions.size;
+  var polygonIndices = data.polygonIndices.value;
+  var primitivePolygonIndices = data.primitivePolygonIndices.value;
+  var multi = polygonIndices.length > 2;
+
+  var coordinates = [];
+  if (!multi) {
+    for (var i = 0; i < primitivePolygonIndices.length - 1; i++) {
+      var ringCoordinates = [];
+      var primitivePolygonIndex = primitivePolygonIndices[i];
+      var nextPrimitivePolygonIndex = primitivePolygonIndices[i + 1];
+
+      for (var j = primitivePolygonIndex; j < nextPrimitivePolygonIndex; j++) {
+        ringCoordinates.push(
+          Array.from(positions.subarray(j * positionsSize, (j + 1) * positionsSize))
+        );
+      }
+
+      coordinates.push(ringCoordinates);
+    }
+
+    return {type: 'Polygon', coordinates};
+  }
+
+  // TODO handle MultiPolygon
+  return {type: 'MultiPolygon', coordinates};
+}

--- a/modules/gis/src/lib/binary-to-geojson.js
+++ b/modules/gis/src/lib/binary-to-geojson.js
@@ -112,7 +112,7 @@ function parseGeometry(data, startIndex, endIndex) {
     case 'Polygon':
       return polygonToGeoJson(data, startIndex, endIndex);
     default:
-      throw new Error('Invalid type');
+      throw new Error(`Unsupported geometry type: ${data.type}`);
   }
 }
 

--- a/modules/gis/src/lib/geojson-to-binary.d.ts
+++ b/modules/gis/src/lib/geojson-to-binary.d.ts
@@ -1,1 +1,2 @@
 export function geojsonToBinary(features, options);
+export const TEST_EXPORTS: any

--- a/modules/gis/src/lib/geojson-to-binary.d.ts
+++ b/modules/gis/src/lib/geojson-to-binary.d.ts
@@ -1,0 +1,1 @@
+export function geojsonToBinary(features, options);

--- a/modules/gis/test/binary-to-geojson.spec.js
+++ b/modules/gis/test/binary-to-geojson.spec.js
@@ -1,16 +1,18 @@
+/* eslint-disable max-depth */
 import test from 'tape-promise/tape';
 import {fetchFile} from '@loaders.gl/core';
 import {binaryToGeoJson} from '@loaders.gl/gis';
 
-const WKB_2D_TEST_CASES = '@loaders.gl/wkt/test/data/wkb-testdata2d.json';
+const FEATURE_COLLECTION_TEST_CASES = '@loaders.gl/gis/test/data/featurecollection.json';
 
-test('binary-to-geojson 2D', async t => {
-  const response = await fetchFile(WKB_2D_TEST_CASES);
-  const TEST_CASES = parseTestCases(await response.json());
+test('binary-to-geojson feature collections', async t => {
+  const response = await fetchFile(FEATURE_COLLECTION_TEST_CASES);
+  const json = await response.json();
+  const TEST_CASES = parseTestCases(json);
 
   for (const testCase of Object.values(TEST_CASES)) {
     if (testCase.geoJSON && testCase.binary) {
-      t.deepEqual(binaryToGeoJson(testCase.binary), testCase.geoJSON);
+      t.deepEqual(binaryToGeoJson(testCase.binary), testCase.geoJSON.features);
     }
   }
 
@@ -19,23 +21,23 @@ test('binary-to-geojson 2D', async t => {
 
 // Mutates input object
 function parseTestCases(testCases) {
-  for (const [key, value] of Object.entries(testCases)) {
+  for (const value of Object.values(testCases)) {
     // Convert `binary`, an object with typed arrays output, into typed arrays
     // from regular arrays
     if (value.binary) {
-      if (value.binary.positions) {
-        value.binary.positions.value = new Float32Array(value.binary.positions.value);
-      }
-      if (value.binary.pathIndices) {
-        value.binary.pathIndices.value = new Uint16Array(value.binary.pathIndices.value);
-      }
-      if (value.binary.primitivePolygonIndices) {
-        value.binary.primitivePolygonIndices.value = new Uint16Array(
-          value.binary.primitivePolygonIndices.value
-        );
-      }
-      if (value.binary.polygonIndices) {
-        value.binary.polygonIndices.value = new Uint16Array(value.binary.polygonIndices.value);
+      for (const data of Object.values(value.binary)) {
+        if (data.positions) {
+          data.positions.value = new Float32Array(data.positions.value);
+        }
+        if (data.pathIndices) {
+          data.pathIndices.value = new Uint16Array(data.pathIndices.value);
+        }
+        if (data.primitivePolygonIndices) {
+          data.primitivePolygonIndices.value = new Uint16Array(data.primitivePolygonIndices.value);
+        }
+        if (data.polygonIndices) {
+          data.polygonIndices.value = new Uint16Array(data.polygonIndices.value);
+        }
       }
     }
   }

--- a/modules/gis/test/binary-to-geojson.spec.js
+++ b/modules/gis/test/binary-to-geojson.spec.js
@@ -1,0 +1,43 @@
+import test from 'tape-promise/tape';
+import {fetchFile} from '@loaders.gl/core';
+import {binaryToGeoJson} from '@loaders.gl/gis';
+
+const WKB_2D_TEST_CASES = '@loaders.gl/wkt/test/data/wkb-testdata2d.json';
+
+test('binary-to-geojson 2D', async t => {
+  const response = await fetchFile(WKB_2D_TEST_CASES);
+  const TEST_CASES = parseTestCases(await response.json());
+
+  for (const testCase of Object.values(TEST_CASES)) {
+    if (testCase.geoJSON && testCase.binary) {
+      t.deepEqual(binaryToGeoJson(testCase.binary), testCase.geoJSON);
+    }
+  }
+
+  t.end();
+});
+
+// Mutates input object
+function parseTestCases(testCases) {
+  for (const [key, value] of Object.entries(testCases)) {
+    // Convert `binary`, an object with typed arrays output, into typed arrays
+    // from regular arrays
+    if (value.binary) {
+      if (value.binary.positions) {
+        value.binary.positions.value = new Float32Array(value.binary.positions.value);
+      }
+      if (value.binary.pathIndices) {
+        value.binary.pathIndices.value = new Uint16Array(value.binary.pathIndices.value);
+      }
+      if (value.binary.primitivePolygonIndices) {
+        value.binary.primitivePolygonIndices.value = new Uint16Array(
+          value.binary.primitivePolygonIndices.value
+        );
+      }
+      if (value.binary.polygonIndices) {
+        value.binary.polygonIndices.value = new Uint16Array(value.binary.polygonIndices.value);
+      }
+    }
+  }
+  return testCases;
+}

--- a/modules/gis/test/binary-to-geojson.spec.js
+++ b/modules/gis/test/binary-to-geojson.spec.js
@@ -10,7 +10,13 @@ test('binary-to-geojson feature collections', async t => {
   const json = await response.json();
   const TEST_CASES = parseTestCases(json);
 
-  for (const testCase of Object.values(TEST_CASES)) {
+  for (const [key, testCase] of Object.entries(TEST_CASES)) {
+    // Skip polygons test until working MultiPolygon parsing
+    if (key === 'polygons') {
+      // eslint-disable-next-line
+      continue;
+    }
+
     if (testCase.geoJSON && testCase.binary) {
       t.deepEqual(binaryToGeoJson(testCase.binary), testCase.geoJSON.features);
     }

--- a/modules/gis/test/data/featurecollection.json
+++ b/modules/gis/test/data/featurecollection.json
@@ -1,0 +1,313 @@
+{
+  "point": {
+    "geoJSON": {
+      "type": "FeatureCollection",
+      "features": [
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [100.0, 0.0]
+          },
+          "properties": {
+            "numeric1": 1,
+            "string1": "a"
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "MultiPoint",
+            "coordinates": [[100.0, 0.0], [101.0, 1.0]]
+          },
+          "properties": {
+            "numeric1": 2,
+            "string1": "b"
+          }
+        }
+      ]
+    },
+    "binary": {
+      "points": {
+        "positions": {"value": [100.0, 0.0, 100.0, 0.0, 101.0, 1.0], "size": 2},
+        "globalFeatureIds": {"value": [0, 1, 1], "size": 1},
+        "featureIds": {"value": [0, 1, 1], "size": 1},
+        "numericProps": {
+          "numeric1": {"value": [1, 2, 2], "size": 1}
+        },
+        "properties": [{"string1": "a"}, {"string1": "b"}]
+      }
+    }
+  },
+  "lines": {
+    "geoJSON": {
+      "type": "FeatureCollection",
+      "features": [
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "LineString",
+            "coordinates": [[100.0, 0.0], [101.0, 1.0]]
+          },
+          "properties": {
+            "numeric1": 3,
+            "string1": "c"
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "MultiLineString",
+            "coordinates": [[[100.0, 0.0], [101.0, 1.0]], [[102.0, 2.0], [103.0, 3.0]]]
+          },
+          "properties": {
+            "numeric1": 4,
+            "string1": "d"
+          }
+        }
+      ]
+    },
+    "binary": {
+      "lines": {
+        "positions": {
+          "value": [100.0, 0.0, 101.0, 1.0, 100.0, 0.0, 101.0, 1.0, 102.0, 2.0, 103.0, 3.0],
+          "size": 2
+        },
+        "globalFeatureIds": {"value": [0, 0, 1, 1, 1, 1], "size": 1},
+        "featureIds": {"value": [0, 0, 1, 1, 1, 1], "size": 1},
+        "numericProps": {
+          "numeric1": {"value": [3, 3, 4, 4, 4, 4], "size": 1}
+        },
+        "properties": [{"string1": "c"}, {"string1": "d"}]
+      }
+    }
+  },
+  "polygons": {
+    "geoJSON": {
+      "type": "FeatureCollection",
+      "features": [
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Polygon",
+            "coordinates": [[[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]]]
+          },
+          "properties": {
+            "numeric1": 3,
+            "string1": "c"
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Polygon",
+            "coordinates": [
+              [[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]],
+              [[100.8, 0.8], [100.8, 0.2], [100.2, 0.2], [100.2, 0.8], [100.8, 0.8]]
+            ]
+          },
+          "properties": {
+            "numeric1": 4,
+            "string1": "d"
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "MultiPolygon",
+            "coordinates": [
+              [[[102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0]]],
+              [
+                [[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]],
+                [[100.2, 0.2], [100.2, 0.8], [100.8, 0.8], [100.8, 0.2], [100.2, 0.2]]
+              ]
+            ]
+          },
+          "properties": {
+            "numeric1": 5,
+            "string1": "e"
+          }
+        }
+      ]
+    },
+    "binary": {
+      "polygons": {
+        "positions": {
+          "value": [
+            100.0,
+            0.0,
+            101.0,
+            0.0,
+            101.0,
+            1.0,
+            100.0,
+            1.0,
+            100.0,
+            0.0,
+            100.0,
+            0.0,
+            101.0,
+            0.0,
+            101.0,
+            1.0,
+            100.0,
+            1.0,
+            100.0,
+            0.0,
+            100.8,
+            0.8,
+            100.8,
+            0.2,
+            100.2,
+            0.2,
+            100.2,
+            0.8,
+            100.8,
+            0.8,
+            102.0,
+            2.0,
+            103.0,
+            2.0,
+            103.0,
+            3.0,
+            102.0,
+            3.0,
+            102.0,
+            2.0,
+            100.0,
+            0.0,
+            101.0,
+            0.0,
+            101.0,
+            1.0,
+            100.0,
+            1.0,
+            100.0,
+            0.0,
+            100.2,
+            0.2,
+            100.2,
+            0.8,
+            100.8,
+            0.8,
+            100.8,
+            0.2,
+            100.2,
+            0.2
+          ],
+          "size": 2
+        },
+        "polygonIndices": {"value": [0, 5, 15, 20, 30], "size": 1},
+        "primitivePolygonIndices": {"value": [0, 5, 15, 20, 25, 30], "size": 1},
+        "globalFeatureIds": {
+          "value": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            2,
+            2,
+            2,
+            2,
+            2,
+            2,
+            2,
+            2,
+            2,
+            2,
+            2,
+            2,
+            2,
+            2,
+            2
+          ],
+          "size": 1
+        },
+        "featureIds": {
+          "value": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            2,
+            2,
+            2,
+            2,
+            2,
+            2,
+            2,
+            2,
+            2,
+            2,
+            2,
+            2,
+            2,
+            2,
+            2
+          ],
+          "size": 1
+        },
+        "numericProps": {
+          "numeric1": {
+            "value": [
+              3,
+              3,
+              3,
+              3,
+              3,
+              4,
+              4,
+              4,
+              4,
+              4,
+              4,
+              4,
+              4,
+              4,
+              4,
+              5,
+              5,
+              5,
+              5,
+              5,
+              5,
+              5,
+              5,
+              5,
+              5,
+              5,
+              5,
+              5,
+              5,
+              5
+            ],
+            "size": 1
+          }
+        },
+        "properties": [{"string1": "c"}, {"string1": "d"}, {"string1": "e"}]
+      }
+    }
+  }
+}

--- a/modules/gis/test/data/featurecollection.json
+++ b/modules/gis/test/data/featurecollection.json
@@ -73,6 +73,7 @@
           "value": [100.0, 0.0, 101.0, 1.0, 100.0, 0.0, 101.0, 1.0, 102.0, 2.0, 103.0, 3.0],
           "size": 2
         },
+        "pathIndices": {"value": [0, 2, 4, 6], "size": 1},
         "globalFeatureIds": {"value": [0, 0, 1, 1, 1, 1], "size": 1},
         "featureIds": {"value": [0, 0, 1, 1, 1, 1], "size": 1},
         "numericProps": {

--- a/modules/gis/test/index.js
+++ b/modules/gis/test/index.js
@@ -1,1 +1,2 @@
+import './binary-to-geojson.spec';
 import './geojson-to-binary.spec';


### PR DESCRIPTION
Right now this only parses single geometries.

Todo: 

- [ ] Parse MultiPolygons
- [x] Parse a collection of features and/or one feature with properties. Right now this only parses single geometries.
- [ ] Fix tests; add more test cases

For now I use the WKB test cases, which contains a mapping between GeoJSON and binary representations, but there are some edge cases that can be described in GeoJSON but not in our binary format. I.e. a geometry of type `MultiPoint` that only has one point. Those cases are assumed to be non-Multi. I'll need to copy some custom test cases for this into the `loaders.gl/gis` module.