### PR TITLE
core: truly global loaders and options

### DIFF
--- a/modules/3d-tiles/docs/api-reference/tiles-3d-loader.md
+++ b/modules/3d-tiles/docs/api-reference/tiles-3d-loader.md
@@ -31,7 +31,7 @@ const tilesetJson = await load(tilesetUrl, Tiles3DLoader);
 To decompress tiles containing Draco compressed glTF models or Draco compressed point clouds:
 
 ```js
-import {load, registerLoaders} from '@loaders.gl/core';
+import {load, s} from '@loaders.gl/core';
 import {Tiles3DLoader} from '@loaders.gl/3d-tiles';
 const tileUrl = 'https://assets.cesium.com/43978/1.pnts';
 const tile = await load(tileUrl, Tiles3DLoader, {decompress: true});

--- a/modules/3d-tiles/docs/api-reference/tiles-3d-loader.md
+++ b/modules/3d-tiles/docs/api-reference/tiles-3d-loader.md
@@ -31,7 +31,7 @@ const tilesetJson = await load(tilesetUrl, Tiles3DLoader);
 To decompress tiles containing Draco compressed glTF models or Draco compressed point clouds:
 
 ```js
-import {load, s} from '@loaders.gl/core';
+import {load, registerLoaders} from '@loaders.gl/core';
 import {Tiles3DLoader} from '@loaders.gl/3d-tiles';
 const tileUrl = 'https://assets.cesium.com/43978/1.pnts';
 const tile = await load(tileUrl, Tiles3DLoader, {decompress: true});

--- a/modules/core/src/lib/api/register-loaders.js
+++ b/modules/core/src/lib/api/register-loaders.js
@@ -1,24 +1,30 @@
+import {global} from '@loaders.gl/loader-utils';
 import {normalizeLoader} from '../loader-utils/normalize-loader';
 
-let registeredLoaders = [];
+// HACK: We store this on a global object to increase the chance of cross-release interop
+global.loaders = global.loaders || {};
+global.loaders._registeredLoaders = global.loaders._registeredLoaders || [];
 
 export function registerLoaders(loaders) {
+  const {_registeredLoaders} = global.loaders;
+
   loaders = Array.isArray(loaders) ? loaders : [loaders];
 
   for (const loader of loaders) {
     const normalizedLoader = normalizeLoader(loader);
-    if (!registeredLoaders.find(registeredLoader => normalizedLoader === registeredLoader)) {
-      // add to the beginning of the registeredLoaders, so the last registeredLoader get picked
-      registeredLoaders.unshift(normalizedLoader);
+    if (!_registeredLoaders.find(registeredLoader => normalizedLoader === registeredLoader)) {
+      // add to the beginning of the _registeredLoaders, so the last registeredLoader get picked
+      _registeredLoaders.unshift(normalizedLoader);
     }
   }
 }
 
 export function getRegisteredLoaders() {
-  return registeredLoaders;
+  const {_registeredLoaders} = global.loaders;
+  return _registeredLoaders;
 }
 
 // For testing
 export function _unregisterLoaders() {
-  registeredLoaders = [];
+  global.loaders._registeredLoaders = [];
 }

--- a/modules/core/src/lib/api/register-loaders.js
+++ b/modules/core/src/lib/api/register-loaders.js
@@ -1,31 +1,34 @@
-import {global} from '@loaders.gl/loader-utils';
 import {normalizeLoader} from '../loader-utils/normalize-loader';
+import {getGlobalLoaderState} from '../loader-utils/merge-options';
 
 // Store global registered loaders on the global object to increase chances of cross loaders-version interoperability
-// NOTE: This use case is not reliable but can help when testing new versions of loaders.gl with existing frameworks
-global.loaders = global.loaders || {};
-global.loaders._registeredLoaders = global.loaders._registeredLoaders || [];
+// This use case is not reliable but can help when testing new versions of loaders.gl with existing frameworks
+const getGlobalLoaderRegistry = () => {
+  const state = getGlobalLoaderState();
+  state.loaderRegistry = state.loaderRegistry || [];
+  return state.loaderRegistry;
+};
 
 export function registerLoaders(loaders) {
-  const {_registeredLoaders} = global.loaders;
+  const loaderRegistry = getGlobalLoaderRegistry();
 
   loaders = Array.isArray(loaders) ? loaders : [loaders];
 
   for (const loader of loaders) {
     const normalizedLoader = normalizeLoader(loader);
-    if (!_registeredLoaders.find(registeredLoader => normalizedLoader === registeredLoader)) {
-      // add to the beginning of the _registeredLoaders, so the last registeredLoader get picked
-      _registeredLoaders.unshift(normalizedLoader);
+    if (!loaderRegistry.find(registeredLoader => normalizedLoader === registeredLoader)) {
+      // add to the beginning of the loaderRegistry, so the last registeredLoader get picked
+      loaderRegistry.unshift(normalizedLoader);
     }
   }
 }
 
 export function getRegisteredLoaders() {
-  const {_registeredLoaders} = global.loaders;
-  return _registeredLoaders;
+  return getGlobalLoaderRegistry();
 }
 
 // For testing
 export function _unregisterLoaders() {
-  global.loaders._registeredLoaders = [];
+  const state = getGlobalLoaderState();
+  state.loaderRegistry = [];
 }

--- a/modules/core/src/lib/api/register-loaders.js
+++ b/modules/core/src/lib/api/register-loaders.js
@@ -1,7 +1,8 @@
 import {global} from '@loaders.gl/loader-utils';
 import {normalizeLoader} from '../loader-utils/normalize-loader';
 
-// HACK: We store this on a global object to increase the chance of cross-release interop
+// Store global registered loaders on the global object to increase chances of cross loaders-version interoperability
+// NOTE: This use case is not reliable but can help when testing new versions of loaders.gl with existing frameworks
 global.loaders = global.loaders || {};
 global.loaders._registeredLoaders = global.loaders._registeredLoaders || [];
 

--- a/modules/core/src/lib/loader-utils/merge-options.d.ts
+++ b/modules/core/src/lib/loader-utils/merge-options.d.ts
@@ -13,3 +13,16 @@ export function setGlobalOptions(options: object): void;
  * @param url 
  */
 export function mergeOptions(loader: LoaderObject, options: object, url?: string): object;
+
+/**
+ * Global state for loaders.gl. Stored on `global.loaders._state`
+ */
+type GlobalLoaderState = {
+  loaderRegistry: LoaderObject[];
+  globalOptions: {[key: string]: any};
+}
+
+/**
+ * Internal helper for safely accessing global loaders.gl variables
+ */
+export function getGlobalLoaderState(): GlobalLoaderState;

--- a/modules/core/src/lib/loader-utils/merge-options.js
+++ b/modules/core/src/lib/loader-utils/merge-options.js
@@ -1,14 +1,24 @@
+import {global} from '@loaders.gl/loader-utils';
 import {DEFAULT_LOADER_OPTIONS} from '../constants';
 import {NullLog} from './loggers';
 
 const isPureObject = value =>
   value && typeof value === 'object' && value.constructor === {}.constructor;
 
-let globalOptions = {...DEFAULT_LOADER_OPTIONS};
+// Store global loader options on the global object to increase chances of cross loaders-version interoperability
+// NOTE: This use case is not reliable but can help when testing new versions of loaders.gl with existing frameworks
+global.loaders = global.loaders || {};
+global.loaders._globalOptions = global.loaders._globalOptions || {};
+// Ensure all default loader options from this library are mentioned
+global.loaders._globalOptions = Object.assign(
+  {},
+  DEFAULT_LOADER_OPTIONS,
+  global.loaders._globalOptions
+);
 
 // Set global loader options
 export function setGlobalOptions(options) {
-  globalOptions = mergeOptionsInternal(globalOptions, options);
+  global.loaders._globalOptions = mergeOptionsInternal(global.loaders._globalOptions, options);
 }
 
 // Merges options with global opts and loader defaults, also injects baseUri
@@ -79,7 +89,7 @@ function mergeOptionsInternal(loader, options, url) {
     mergedOptions.log = new NullLog();
   }
 
-  mergeNestedFields(mergedOptions, globalOptions);
+  mergeNestedFields(mergedOptions, global.loaders._globalOptions);
   mergeNestedFields(mergedOptions, options);
 
   return mergedOptions;


### PR DESCRIPTION
Stores global registered loaders and options on the global object to increase chances of cross loaders-version interoperability
NOTE: This use case is not reliable but can help when testing new versions of loaders.gl with existing frameworks

This is in response to the suggestion that we make loader-utils a peerDependency of core, which after consideration seemed too problematic given how closely dependent core is on loader-utils.