### PR TITLE
polyfills: Improved stream error handling

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -8,6 +8,10 @@ Target Release Date: TBD (alpha releases will be made available)
 
 - `parseInBatches` can now be called on all loaders. Non-batched loaders will just return a single batch.
 
+**@loaders.gl/polyfills**
+
+- Improved robustness and error handling in Node.js when calling the `fetch` polyfill on unreadable or non-existent files. Underlying errors (`ENOEXIST`, `EISDIR` etc) are now caught and reported in `Response.statusText`.
+
 ## v2.2
 
 Release Date: June 18, 2020

--- a/modules/polyfills/src/fetch-node/fetch.node.js
+++ b/modules/polyfills/src/fetch-node/fetch.node.js
@@ -31,7 +31,7 @@ export default async function fetchNode(url, options) {
     return new Response(body, {headers, status, statusText, url});
   } catch (error) {
     // TODO - what error code to use here?
-    return new Response(null, {status: 400, statusText: error, url});
+    return new Response(null, {status: 400, statusText: String(error), url});
   }
 }
 

--- a/modules/polyfills/src/fetch-node/response.node.js
+++ b/modules/polyfills/src/fetch-node/response.node.js
@@ -36,11 +36,10 @@ export default class Response {
     // Check for content-encoding and create a decompression stream
     if (isReadableNodeStream(body)) {
       this._body = decompressReadStream(body, headers);
+    } else if (typeof body === 'string') {
+      this._body = Readable.from([new TextEncoder().encode(body)]);
     } else {
-      if (typeof body === 'string') {
-        body = new TextEncoder().encode(body);
-      }
-      this._body = Readable.from([body]);
+      this._body = Readable.from([body || new ArrayBuffer(0)]);
     }
   }
 
@@ -78,7 +77,7 @@ export default class Response {
 
   async arrayBuffer() {
     if (!isReadableNodeStream(this._body)) {
-      return this._body;
+      return this._body || new ArrayBuffer(0);
     }
     const data = await concatenateReadStream(this._body);
     return data;

--- a/modules/polyfills/src/fetch-node/utils/stream-utils.node.js
+++ b/modules/polyfills/src/fetch-node/utils/stream-utils.node.js
@@ -52,6 +52,10 @@ export async function concatenateReadStream(readStream) {
   return await new Promise((resolve, reject) => {
     readStream.on('error', error => reject(error));
 
+    // Once the readable callback has been added, stream switches to "flowing mode"
+    // In Node 10 (but not 12 and 14) this causes `data` and `end` to never be called unless we read data here
+    readStream.on('readable', () => readStream.read());
+
     readStream.on('data', chunk => {
       if (typeof chunk === 'string') {
         reject(new Error('Read stream not binary'));

--- a/modules/polyfills/src/fetch-node/utils/stream-utils.node.js
+++ b/modules/polyfills/src/fetch-node/utils/stream-utils.node.js
@@ -47,14 +47,12 @@ export function decompressReadStream(readStream, headers) {
 }
 
 export async function concatenateReadStream(readStream) {
-  debugger
   let arrayBuffer = new ArrayBuffer(0);
 
   return await new Promise((resolve, reject) => {
     readStream.on('error', error => reject(error));
 
     readStream.on('data', chunk => {
-      debugger
       if (typeof chunk === 'string') {
         reject(new Error('Read stream not binary'));
       }

--- a/modules/polyfills/test/fetch-node/fetch.node.spec.js
+++ b/modules/polyfills/test/fetch-node/fetch.node.spec.js
@@ -7,7 +7,7 @@ const GITHUB_MASTER = 'https://raw.githubusercontent.com/visgl/loaders.gl/master
 const PLY_CUBE_ATT_URL = `${GITHUB_MASTER}ply/test/data/cube_att.ply`;
 const PLY_CUBE_ATT_SIZE = 853;
 
-test('fetch polyfill (Node.js)#fetch()', async t => {
+test('polyfills#fetch() (NODE)', async t => {
   if (!isBrowser) {
     const response = await fetch(PLY_CUBE_ATT_URL);
     t.ok(response.headers, 'fetch polyfill successfully returned headers under Node.js');
@@ -17,7 +17,7 @@ test('fetch polyfill (Node.js)#fetch()', async t => {
   t.end();
 });
 
-test('fetch polyfill (Node.js)#fetch() ignores url query params when loading file', async t => {
+test('polyfills#fetch() ignores url query params when loading file (NODE)', async t => {
   if (!isBrowser) {
     const response = await fetch(`${PLY_CUBE_ATT_URL}?v=1.2.3`);
     const data = await response.text();
@@ -27,7 +27,22 @@ test('fetch polyfill (Node.js)#fetch() ignores url query params when loading fil
   t.end();
 });
 
-test('fetch polyfill (Node.js)#fetch() able to handle "Accept-Encoding: gzip"', async t => {
+test('polyfills#fetch() error handling (NODE)', async t => {
+  if (!isBrowser) {
+    let response = await fetch('non-existent-file');
+    t.ok(response.statusText.includes('ENOENT'), 'fetch statusText forwards node ENOENT error');
+    t.notOk(response.ok, 'fetch polyfill fails cleanly on non-existent file');
+    t.ok(response.arrayBuffer(), 'Response.arrayBuffer() does not throw');
+
+    response = await fetch('.');
+    t.ok(response.statusText.includes('EISDIR'), 'fetch statusText forwards node EISDIR error');
+    t.notOk(response.ok, 'fetch polyfill fails cleanly on directory');
+    t.ok(response.arrayBuffer(), 'Response.arrayBuffer() does not throw');
+  }
+  t.end();
+});
+
+test('polyfills#fetch() able to handle "Accept-Encoding: gzip" (NODE)', async t => {
   if (!isBrowser) {
     // Github will serve the desired compression
     const headers = {
@@ -43,7 +58,7 @@ test('fetch polyfill (Node.js)#fetch() able to handle "Accept-Encoding: gzip"', 
   t.end();
 });
 
-test('fetch polyfill (Node.js)#fetch() able to handle "Accept-Encoding: br"', async t => {
+test('polyfills#fetch() able to handle "Accept-Encoding: br" (NODE)', async t => {
   if (!isBrowser) {
     // Github will serve the desired compression
     const headers = {
@@ -58,7 +73,7 @@ test('fetch polyfill (Node.js)#fetch() able to handle "Accept-Encoding: br"', as
   t.end();
 });
 
-test('fetch polyfill (Node.js)#fetch() able to handle "Accept-Encoding: deflate"', async t => {
+test('polyfills#fetch() able to handle "Accept-Encoding: deflate"', async t => {
   if (!isBrowser) {
     // Github will serve the desired compression
     const headers = {


### PR DESCRIPTION
Streams no longer crash under Node when opened on invalid files, and now propagate platform error messages to `Response.statusText`.

This turned out to be a big blocker for getting the Node tests working in upcoming multi-file loading PRs, and also generally improves the Node.js support.