### PR TITLE
website: Fix new ocular website

### DIFF
--- a/arrowjs/docs/get-started/installing.md
+++ b/arrowjs/docs/get-started/installing.md
@@ -4,7 +4,7 @@
 
 The Apache Arrow JS bindings are published as an npm module.
 
-```sh
+```shell
 npm install apache-arrow
 # or
 yarn add apache-arrow

--- a/docs/developer-guide/get-started.md
+++ b/docs/developer-guide/get-started.md
@@ -6,7 +6,7 @@ Install loaders.gl core and loader for any modules you would like to use.
 
 Each format is published as a separate npm module.
 
-```bash
+```shell
 yarn add @loaders.gl/core
 yarn add @loaders.gl/gltf
 ...
@@ -41,7 +41,7 @@ const data = await parse(fetch('data.csv'));
 
 ## Building
 
-You can use your bundler of choice such as webpack or rollup. See the [`get-started-...`](https://github.com/visgl/loaders.gl/tree/master/examples) examples for minimal working examples of how to bundle loaders.gl.
+You can use your bundler of choice such as webpack or rollup. See the [`get-started`](https://github.com/visgl/loaders.gl/tree/master/examples) examples for minimal working examples of how to bundle loaders.gl.
 
 ## Supporting Older Browsers
 

--- a/examples/website/pointcloud/app.js
+++ b/examples/website/pointcloud/app.js
@@ -185,12 +185,11 @@ export default class App extends PureComponent {
 
   render() {
     const {viewState} = this.state;
+    // eslint-disable-next-line react/prop-types
     const {panel = true} = this.props;
     return (
       <div style={{position: 'relative', height: '100%'}}>
-        <div style={{visibility: panel ? 'default' : 'hidden'}}>
-          {this._renderControlPanel()}
-        </div>
+        <div style={{visibility: panel ? 'default' : 'hidden'}}>{this._renderControlPanel()}</div>
         <DeckGL
           views={new OrbitView()}
           viewState={viewState}

--- a/examples/website/pointcloud/app.js
+++ b/examples/website/pointcloud/app.js
@@ -185,10 +185,12 @@ export default class App extends PureComponent {
 
   render() {
     const {viewState} = this.state;
-
+    const {panel = true} = this.props;
     return (
       <div style={{position: 'relative', height: '100%'}}>
-        {this._renderControlPanel()}
+        <div style={{visibility: panel ? 'default' : 'hidden'}}>
+          {this._renderControlPanel()}
+        </div>
         <DeckGL
           views={new OrbitView()}
           viewState={viewState}

--- a/modules/core/src/lib/api/parse.js
+++ b/modules/core/src/lib/api/parse.js
@@ -68,6 +68,10 @@ async function parseWithLoader(loader, data, options, context) {
   }
 
   // Check for asynchronous parser
+  if (loader.parseText && typeof data === 'string') {
+    return await loader.parseText(data, options, context, loader);
+  }
+
   if (loader.parse) {
     return await loader.parse(data, options, context, loader);
   }

--- a/modules/core/src/lib/loader-utils/normalize-loader.js
+++ b/modules/core/src/lib/loader-utils/normalize-loader.js
@@ -60,7 +60,7 @@ export function normalizeLoader(loader) {
   // NORMALIZE text and binary flags
 
   // Ensure at least one of text/binary flags are properly set
-  if (loader.parseTextSync) {
+  if (loader.parseTextSync || loader.parseText) {
     loader.text = true;
   }
 

--- a/website/gatsby-config.js
+++ b/website/gatsby-config.js
@@ -8,7 +8,7 @@ module.exports = {
     {
       resolve: `gatsby-theme-ocular`,
       options: {
-        logLevel: 1, // Adjusts amount of debug information from ocular-gatsby
+        logLevel: 4, // Adjusts amount of debug information from ocular-gatsby
 
         // Folders
         DIR_NAME: __dirname,

--- a/website/gatsby-config.js
+++ b/website/gatsby-config.js
@@ -8,7 +8,7 @@ module.exports = {
     {
       resolve: `gatsby-theme-ocular`,
       options: {
-        logLevel: 4, // Adjusts amount of debug information from ocular-gatsby
+        logLevel: 1, // Adjusts amount of debug information from ocular-gatsby
 
         // Folders
         DIR_NAME: __dirname,

--- a/website/package.json
+++ b/website/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "yarn develop",
     "develop": "yarn clean-examples && yarn build:gallery && yarn gatsby develop",
-    "build": "yarn clean && yarn clean-examples && yarn build:gallery && gatsby build",
+    "build": "yarn clean-examples && yarn build:gallery && gatsby build",
     "build-staging": "yarn clean && yarn clean-examples && yarn build:gallery && gatsby build --prefix-paths",
     "serve": "gatsby serve",
     "deploy": "NODE_DEBUG=gh-pages gh-pages -d public",

--- a/website/package.json
+++ b/website/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "babel-plugin-version-inline": "^1.0.0",
-    "gatsby": "^2.22.0",
+    "gatsby": "^2.22.17",
     "gatsby-plugin-no-sourcemaps": "^2.1.2",
     "gatsby-theme-ocular": "^1.2.1",
     "gatsby-plugin-env-variables": "^1.0.1",

--- a/website/src/components/animation-loop-runner.jsx
+++ b/website/src/components/animation-loop-runner.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/control-has-associated-label */
 import React, {Component} from 'react'; // eslint-disable-line
 import PropTypes from 'prop-types';
 import {lumaStats} from '@luma.gl/core';

--- a/website/templates/index.jsx
+++ b/website/templates/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {Home} from 'gatsby-theme-ocular/components';
-import GLTFExample from './example-gltf';
+import Example from '../../examples/website/pointcloud/app';
+// import Example from './example-gltf';
 import styled from 'styled-components';
 
 if (typeof window !== 'undefined') {
@@ -23,7 +24,7 @@ const Bullet = styled.li`
   font: ${props => props.theme.typography.font300};
 `;
 
-const HeroExample = () => <GLTFExample panel={false} />
+const HeroExample = () => <Example panel={false} />
 
 export default class IndexPage extends React.Component {
   render() {


### PR DESCRIPTION
Switching main example from glTF to pointcloud until glTF example is fixed in luma.gl.

Remaining.
- Still the images (example thumbnails and images in the module api reference) are not working.
- Setup looks similar to deck.gl, not yet sure where things go wrong.