### PR TITLE
images: improved ImageWriter

### DIFF
--- a/modules/images/docs/api-reference/image-loader.md
+++ b/modules/images/docs/api-reference/image-loader.md
@@ -6,9 +6,11 @@ An image loader that works under both Node.js (requires `@loaders.gl/polyfills`)
 | -------------- | ---------------------------------------------------------------- |
 | File Extension | `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.bmp`, `.ico`, `.svg` |
 | File Type      | Binary                                                           |
-| File Format    | Image                                                            |
-| Data Format    | `ImageBitmap`, `Image` (older browsers) or `data` (node.js)      |
+| File Format    | JPEG, PNG, ...                                                   |
+| Data Format    | `ImageBitmap`, `Image` or "image data"                           |
 | Supported APIs | `load`, `parse`                                                  |
+| Worker Thread  | No (but may run on separate native thread in browsers)           |
+| Streaming      | No                                                               |
 
 ## Usage
 
@@ -19,6 +21,14 @@ import {load} from '@loaders.gl/core';
 
 const image = await load(url, ImageLoader, options);
 ```
+
+## Data Format
+
+The `ImageLoader` parses binary encoded images (such as JPEG or PNG images) into one of three different in-memory representations:
+
+- `ImageBitmap` (`type: 'imagebitmap`) - Optimized image class on modern browsers.
+- `Image` (`type: 'image`) - Works on all browsers, less performant.
+- An "image data object" (`type: 'data'`) - An `ImageData` like object that can holds the raw bytes to the image and works in both browsers and Node.js
 
 ## Options
 

--- a/modules/images/docs/api-reference/image-writer.md
+++ b/modules/images/docs/api-reference/image-writer.md
@@ -2,15 +2,15 @@
 
 The `ImageWriter` class can encode an image into `ArrayBuffer` both under browser and Node.js
 
-| Loader         | Characteristic          |
-| -------------- | ----------------------- |
-| File Extension | `.png`, `.jpg`, `.jpeg` |
-| File Format    | Binary                  |
-| Data Format    | `ArrayBuffer`           |
-| File Format    | Image                   |
-| Encoder Type   | Asynchronous            |
-| Worker Thread  | No                      |
-| Streaming      | No                      |
+| Loader         | Characteristic                                         |
+| -------------- | ------------------------------------------------------ |
+| File Extension | `.png`, `.jpg`, `.jpeg`                                |
+| File Type      | Binary                                                 |
+| Data Format    | `ImageBitmap`, `Image` or "image data"                 |
+| File Format    | JPEG, PNG, ...                                         |
+| Encoder Type   | Asynchronous                                           |
+| Worker Thread  | No (but may run on separate native thread in browsers) |
+| Streaming      | No                                                     |
 
 ## Usage
 
@@ -19,13 +19,30 @@ import '@loaders.gl/polyfill'; // only if using under Node
 import {ImageWriter} from '@loaders.gl/images';
 import {encode} from '@loaders.gl/core';
 
-const image = await encode(arrayBuffer, ImageWriter, options);
+const image = new Image(...);
+const arrayBuffer = await encode(image, ImageWriter, {image: {mimeType: 'image/jpeg'}});
+fs.writeFileSync('shiny-new-image.jpg', arrayBuffer);
 ```
+
+## Data Format
+
+The `ImageWriter` can encode three different in-memory Image representations into binary image representation (such as JPEG or PNG images) that can then be be saved or uploaded,
+
+The supported image types are:
+
+- `ImageBitmap`- Optimized image class on modern browsers.
+- `Image` - Works on all browsers, less performant.
+- "image data object" - `ImageData` like objects that hold the raw decoded bytes of an image. Works in both browsers and Node.js
 
 ## Options
 
-| Option | Type   | Default | Description   |
-| ------ | ------ | ------- | ------------- |
-| `type` | String | `'png'` | image type \* |
+| Option              | Type            | Default                                | Description                  |
+| ------------------- | --------------- | -------------------------------------- | ---------------------------- |
+| `image.mimeType`    | `string`        | `'image/png'`                          | image type. Depends on brows |
+| `image.jpegQuality` | `number | null` | If provided and supported by browser } |
 
-\* Supported image types (MIME types) depends on the environment. Typically PNG and JPG are supported.
+## Remarks
+
+- Supported image types (MIME types) depend on the browser / environment. As a rule, `image/png` and `image/jpeg` are always supported. (Unfortunately it is not currently clear how to determine what formats are available on any given browser, other than "trial and error").
+- `jpegQuality` argument is not supported on all platforms, in which case it will have reasonable but platform-dependent defaults.
+- The `ImageWriter` currently uses [canvas.toBlob()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob) on browsers, so referring to related documentation might be helpful.

--- a/modules/images/docs/api-reference/image-writer.md
+++ b/modules/images/docs/api-reference/image-writer.md
@@ -36,11 +36,11 @@ The supported image types are:
 
 ## Options
 
-| Option              | Type            | Default                                | Description                  |
-| ------------------- | --------------- | -------------------------------------- | ---------------------------- |
-| `image.mimeType`    | `string`        | `'image/png'`                          | image output format  |
-| `image.jpegQuality` | `number | null` | `image/jpeg: 0.92`, `image/webp: 0.80` | 
- Image quality, between `0-1`. Only applies to `image/jpeg` and `image/webp`. |
+| Option                                                                       | Type            | Default                                | Description         |
+| ---------------------------------------------------------------------------- | --------------- | -------------------------------------- | ------------------- |
+| `image.mimeType`                                                             | `string`        | `'image/png'`                          | image output format |
+| `image.jpegQuality`                                                          | `number | null` | `image/jpeg: 0.92`, `image/webp: 0.80` |
+| Image quality, between `0-1`. Only applies to `image/jpeg` and `image/webp`. |
 
 ## Remarks
 

--- a/modules/images/docs/api-reference/image-writer.md
+++ b/modules/images/docs/api-reference/image-writer.md
@@ -32,17 +32,18 @@ The supported image types are:
 
 - `ImageBitmap`- Optimized image class on modern browsers.
 - `Image` - Works on all browsers, less performant.
-- "image data object" - `ImageData` like objects that hold the raw decoded bytes of an image. Works in both browsers and Node.js
+- "image data object" - an `ImageData` like object that hold the raw decoded bytes of an image. Works in both browsers and Node.js.
 
 ## Options
 
 | Option              | Type            | Default                                | Description                  |
 | ------------------- | --------------- | -------------------------------------- | ---------------------------- |
-| `image.mimeType`    | `string`        | `'image/png'`                          | image type. Depends on brows |
-| `image.jpegQuality` | `number | null` | If provided and supported by browser } |
+| `image.mimeType`    | `string`        | `'image/png'`                          | image output format  |
+| `image.jpegQuality` | `number | null` | `image/jpeg: 0.92`, `image/webp: 0.80` | 
+ Image quality, between `0-1`. Only applies to `image/jpeg` and `image/webp`. |
 
 ## Remarks
 
 - Supported image types (MIME types) depend on the browser / environment. As a rule, `image/png` and `image/jpeg` are always supported. (Unfortunately it is not currently clear how to determine what formats are available on any given browser, other than "trial and error").
-- `jpegQuality` argument is not supported on all platforms, in which case it will have reasonable but platform-dependent defaults.
+- `jpegQuality` argument is not supported on all platforms (in which case it is assumed to have reasonable but platform-dependent defaults).
 - The `ImageWriter` currently uses [canvas.toBlob()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob) on browsers, so referring to related documentation might be helpful.

--- a/modules/images/src/image-loader.js
+++ b/modules/images/src/image-loader.js
@@ -13,7 +13,7 @@ const MIME_TYPES = [
   'image/gif',
   'image/webp',
   'image/bmp',
-  'image/vndmicrosofticon',
+  'image/vnd.microsoft.icon',
   'image/svg+xml'
 ];
 

--- a/modules/images/src/image-writer.js
+++ b/modules/images/src/image-writer.js
@@ -3,9 +3,11 @@ import {encodeImage} from './lib/encoders/encode-image';
 export default {
   name: 'Images',
   extensions: ['jpeg'],
-  // TODO encode is broken, fix...
-  encode: async (image, options) => await encodeImage(image, options.type),
   options: {
-    type: 'png'
-  }
+    image: {
+      mimeType: 'image/png',
+      jpegQuality: null
+    }
+  },
+  encode: encodeImage
 };

--- a/modules/images/src/lib/encoders/encode-image.d.ts
+++ b/modules/images/src/lib/encoders/encode-image.d.ts
@@ -2,8 +2,8 @@
  * Returns data bytes representing a compressed image in PNG or JPG format,
  * This data can be saved using file system (f) methods or used in a request.
  * @param image - ImageBitmap Image or Canvas
- * @param options 
+ * @param options
  * param opt.type='png' - png, jpg or image/png, image/jpg are valid
  * param mimeType= - Whether to include a data URI header
  */
-export function encodeImage(image: any, type?: string): string;
+export function encodeImage(image: any, options?: object): Promise<ArrayBuffer>;

--- a/modules/images/src/lib/encoders/encode-image.js
+++ b/modules/images/src/lib/encoders/encode-image.js
@@ -1,30 +1,82 @@
-// Image loading/saving for browser
-/* global document, HTMLCanvasElement, Image */
-
-import assert from '../utils/assert';
+// Image loading/saving for browser and Node.js
+/* global document, ImageBitmap, ImageData */
 import {global} from '../utils/globals';
+import {getImageSize} from '../category-api/parsed-image-api';
 
 // @ts-ignore TS2339: Property does not exist on type
 const {_encodeImageNode} = global;
 
-export function encodeImage(image, type) {
-  if (_encodeImageNode) {
-    // @ts-ignore TS2339: Property does not exist on type
-    return _encodeImageNode(image, type);
-  }
+export async function encodeImage(image, options) {
+  options = options || {};
+  options.image = options.image || {};
 
-  if (image instanceof HTMLCanvasElement) {
-    const canvas = image;
-    return canvas.toDataURL(type);
-  }
+  return _encodeImageNode
+    ? _encodeImageNode(image, {type: options.image.mimeType})
+    : encodeImageInBrowser(image, options);
+}
 
-  assert(image instanceof Image, 'getImageData accepts image or canvas');
+// In case we get exceptions from canvas.toBlob(resolve, type, quality)
+let qualityParamSupported = true;
+
+/**
+ *
+ * @param image
+ * @param options
+ * @note Based on canvas.toBlob
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob
+ */
+async function encodeImageInBrowser(image, options) {
+  const {mimeType, jpegQuality} = options.image;
+
+  const {width, height} = getImageSize(image);
+
+  // create a canvas and resize it to the size of our image
   const canvas = document.createElement('canvas');
-  canvas.width = image.width;
-  canvas.height = image.height;
-  canvas.getContext('2d').drawImage(image, 0, 0);
+  canvas.width = width;
+  canvas.height = height;
 
-  // Get raw image data
-  const data = canvas.toDataURL(type || 'png').replace(/^data:image\/(png|jpg);base64,/, '');
-  return Promise.resolve(data);
+  drawImageToCanvas(image, canvas);
+
+  // The actual encoding is done asynchronously with `canvas.toBlob()`
+  /** @type {Blob} */
+  const blob = await new Promise((resolve, reject) => {
+    // get it back as a Blob
+    if (jpegQuality && qualityParamSupported) {
+      try {
+        canvas.toBlob(resolve, mimeType, jpegQuality);
+        return;
+      } catch (error) {
+        qualityParamSupported = false;
+      }
+    }
+    canvas.toBlob(resolve, mimeType);
+  });
+
+  return await blob.arrayBuffer();
+}
+
+function drawImageToCanvas(image, canvas, x = 0, y = 0) {
+  // Try optimized path for ImageBitmaps via bitmaprenderer context
+  if (x === 0 && y === 0 && typeof ImageBitmap !== 'undefined' && image instanceof ImageBitmap) {
+    const context = canvas.getContext('bitmaprenderer');
+    if (context) {
+      // transfer the ImageBitmap to it
+      context.transferFromImageBitmap(image);
+      return canvas;
+    }
+  }
+
+  // Available on most platforms, except IE11 and Andriod WebViews...
+  const context = canvas.getContext('2d');
+  if (image.data) {
+    // ImageData constructor expects clamped array even though getImageData does not return a clamped array...
+    const clampedArray = new Uint8ClampedArray(image.data);
+    const imageData = new ImageData(clampedArray, image.width, image.height);
+    context.putImageData(imageData, 0, 0);
+    return canvas;
+  }
+
+  // Fall back to generic image/image bitmap rendering path
+  context.drawImage(image, 0, 0);
+  return canvas;
 }

--- a/modules/images/test/image-writer.spec.js
+++ b/modules/images/test/image-writer.spec.js
@@ -1,60 +1,43 @@
 import test from 'tape-promise/tape';
-// import {isBrowser, encode, load} from '@loaders.gl/core';
-// import {ImageWriter, ImageLoader} from '@loaders.gl/images';
-import {isBrowser, encode} from '@loaders.gl/core';
-import {ImageWriter} from '@loaders.gl/images';
-import fs from 'fs';
-import path from 'path';
-
-// import {promisify} from 'util';
-// import mkdirp from 'mkdirp';
-// const TEST_DIR = path.join(__dirname, '..', 'data');
-
-const TEST_FILE = path.join(__dirname, '../test/data/test.png');
+import {encode, parse} from '@loaders.gl/core';
+import {ImageWriter, ImageLoader, getBinaryImageMetadata} from '@loaders.gl/images';
 
 const IMAGE = {
   width: 2,
   height: 3,
+  // prettier-ignore
   data: new Uint8Array([
-    255,
-    0,
-    0,
-    255,
-    0,
-    255,
-    255,
-    255,
-    0,
-    0,
-    255,
-    255,
-    255,
-    255,
-    0,
-    255,
-    0,
-    255,
-    0,
-    255,
-    255,
-    0,
-    255,
-    255
+    255, 0, 0, 255, 0, 255, 255, 255, 0, 0, 255, 255, 255, 255, 0, 255, 0, 255, 0, 255, 255, 0, 255, 255
   ])
 };
 
 // Test that we can write and read an image, and that result is identical
 test('ImageWriter#write-and-read-image', async t => {
-  if (isBrowser) {
-    t.comment('Skip read/write file in browser');
-    t.end();
-    return;
-  }
+  let arrayBuffer = await encode(IMAGE, ImageWriter, {
+    image: {mimeType: 'image/jpeg', jpegQuality: 90}
+  });
+  let metadata = getBinaryImageMetadata(arrayBuffer);
+  t.equal(metadata.width, IMAGE.width, 'encoded image width is correct');
+  t.equal(metadata.height, IMAGE.height, 'encoded image height is correct');
+  t.equal(metadata.mimeType, 'image/jpeg', 'encoded image mimeType is correct');
 
-  const imageData = await encode(IMAGE, ImageWriter, {type: 'png'});
-  fs.writeFileSync(TEST_FILE, new DataView(imageData));
+  let image = await parse(arrayBuffer, ImageLoader, {image: {type: 'data'}});
+  t.deepEqual(image.width, IMAGE.width, 'encoded and parsed image widths are same');
+  t.deepEqual(image.height, IMAGE.height, 'encoded and parsed image heights are same');
+  // NOTE - encoded and decoded data are expected to be equal due to lossy jpeg compression
+  // TODO - even, so they seems a bit too different, may want to do additional checks
+  // t.deepEqual(image.data, IMAGE.data, 'encoded and parsed image data are same');
 
-  // const image = await load(TEST_FILE, ImageLoader);
-  // t.same(image, IMAGE);
+  arrayBuffer = await encode(IMAGE, ImageWriter, {image: {mimeType: 'image/png'}});
+  metadata = getBinaryImageMetadata(arrayBuffer);
+  t.equal(metadata.width, IMAGE.width, 'encoded image width is correct');
+  t.equal(metadata.height, IMAGE.height, 'encoded image height is correct');
+  t.equal(metadata.mimeType, 'image/png', 'encoded image mimeType is correct');
+
+  image = await parse(arrayBuffer, ImageLoader, {image: {type: 'data'}});
+  t.deepEqual(image.width, IMAGE.width, 'encoded and parsed image widths are same');
+  t.deepEqual(image.height, IMAGE.height, 'encoded and parsed image heightsare same');
+  t.deepEqual(image.data, IMAGE.data, 'encoded and parsed image data are same');
+
   t.end();
 });

--- a/modules/loader-utils/src/types.d.ts
+++ b/modules/loader-utils/src/types.d.ts
@@ -34,7 +34,7 @@ export type WriterObject = {
   options: object;
   deprecatedOptions?: object;
 
-  encode(data: any, options: object): Promise<any>; // TODO Promise<ArrayBuffer>
+  encode(data: any, options: object): Promise<ArrayBuffer>
 };
 
 export type LoaderContext = {


### PR DESCRIPTION
- ImageWriter now works correctly (inverse of ImageLoader, as one would expect) and passes proper tests.
- Image module script size: +387 bytes (11735 -> 12122 bytes).
- In bundlers, writer will be tree shaken if not used.

Note: there are a couple PRs in the works will significantly reduce the image module script size