### PR TITLE
Shapefile fixes

### DIFF
--- a/modules/shapefile/src/lib/parse-shp.js
+++ b/modules/shapefile/src/lib/parse-shp.js
@@ -13,7 +13,7 @@ export default function parseShape(arrayBuffer) {
 
   // index numbering starts at 1
   let currentIndex = 1;
-  const features = [];
+  const geometries = [];
 
   let offset = SHAPE_HEADER_SIZE;
 
@@ -35,7 +35,7 @@ export default function parseShape(arrayBuffer) {
       offset += Int32Array.BYTES_PER_ELEMENT * 2;
 
       const recordView = new DataView(arrayBuffer, offset, byteLength);
-      features.push(parseRecord(recordView));
+      geometries.push(parseRecord(recordView));
       currentIndex++;
       offset += byteLength;
     }
@@ -43,7 +43,7 @@ export default function parseShape(arrayBuffer) {
 
   return {
     header,
-    features
+    geometries
   };
 }
 

--- a/modules/shapefile/src/shapefile-loader.js
+++ b/modules/shapefile/src/shapefile-loader.js
@@ -71,7 +71,7 @@ async function parseShapefile(arrayBuffer, options, context) {
 
   // Join properties and geometries into features
   const features = [];
-  for (var i = 0; i < geojsonGeometries.length; i++) {
+  for (let i = 0; i < geojsonGeometries.length; i++) {
     const geometry = geojsonGeometries[i];
     const feature = {
       type: 'Feature',

--- a/modules/shapefile/test/data/shapefile-js/singleton.json
+++ b/modules/shapefile/test/data/shapefile-js/singleton.json
@@ -2,6 +2,10 @@
   "type": "FeatureCollection",
   "bbox": [1, 2, 1, 2],
   "features": [
-    {"type": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [1, 2]}}
+    {
+      "type": "Feature",
+      "properties": {"FID": 0},
+      "geometry": {"type": "Point", "coordinates": [1, 2]}
+    }
   ]
 }

--- a/modules/shapefile/test/shapefile-loader.spec.js
+++ b/modules/shapefile/test/shapefile-loader.spec.js
@@ -1,7 +1,6 @@
 /* global File */
 import test from 'tape-promise/tape';
 import {fetchFile, load, loadInBatches, isBrowser} from '@loaders.gl/core';
-import {geojsonToBinary} from '@loaders.gl/gis';
 import {ShapefileLoader} from '@loaders.gl/shapefile';
 import {_BrowserFileSystem as BrowserFileSystem} from '@loaders.gl/shapefile';
 

--- a/modules/shapefile/test/shapefile-loader.spec.js
+++ b/modules/shapefile/test/shapefile-loader.spec.js
@@ -117,7 +117,6 @@ async function testShapefileData(t, testFileName, data) {
   const json = await response.json();
 
   for (let i = 0; i < json.features.length; i++) {
-    const expBinary = geojsonToBinary([json.features[i]]).points.positions;
-    t.deepEqual(data.data[i].positions, expBinary);
+    t.deepEqual(data.data[i], json.features[i]);
   }
 }

--- a/modules/shapefile/test/shp-loader.spec.js
+++ b/modules/shapefile/test/shp-loader.spec.js
@@ -12,7 +12,7 @@ test('SHPLoader#loadInBatches polygons', async t => {
   let rowCount = 0;
   for await (const batch of iterator) {
     batchCount++;
-    rowCount += batch.features.length;
+    rowCount += batch.geometries.length;
   }
 
   t.equal(batchCount, 1, 'Correct number of batches received');

--- a/modules/shapefile/test/shp/parse-shp.spec.js
+++ b/modules/shapefile/test/shp/parse-shp.spec.js
@@ -19,7 +19,7 @@ test('Shapefile JS Point tests', async t => {
 
     for (let i = 0; i < json.features.length; i++) {
       const expBinary = geojsonToBinary([json.features[i]]).points.positions;
-      t.deepEqual(output.features[i].positions, expBinary);
+      t.deepEqual(output.geometries[i].positions, expBinary);
     }
   }
 
@@ -37,8 +37,8 @@ test('Shapefile JS Polyline tests', async t => {
 
     for (let i = 0; i < json.features.length; i++) {
       const expBinary = geojsonToBinary([json.features[i]]).lines;
-      t.deepEqual(output.features[i].positions, expBinary.positions);
-      t.deepEqual(output.features[i].indices, expBinary.pathIndices);
+      t.deepEqual(output.geometries[i].positions, expBinary.positions);
+      t.deepEqual(output.geometries[i].indices, expBinary.pathIndices);
     }
   }
 
@@ -56,8 +56,8 @@ test('Shapefile JS Polygon tests', async t => {
 
     for (let i = 0; i < json.features.length; i++) {
       const expBinary = geojsonToBinary([json.features[i]]).polygons;
-      t.deepEqual(output.features[i].positions, expBinary.positions);
-      t.deepEqual(output.features[i].indices, expBinary.primitivePolygonIndices);
+      t.deepEqual(output.geometries[i].positions, expBinary.positions);
+      t.deepEqual(output.geometries[i].indices, expBinary.primitivePolygonIndices);
     }
   }
 


### PR DESCRIPTION
The output of the `SHPLoader` is an _array of binary objects_, each of which corresponds to a single geometry. This modifies the `ShapefileLoader` to first convert each of these geometries to GeoJSON, then combine with the properties output of the `DBFLoader` into an array of GeoJSON `Feature`s.