### PR TITLE
csv: List out supported options to avoid incorrect warnings

### DIFF
--- a/modules/csv/src/csv-loader.js
+++ b/modules/csv/src/csv-loader.js
@@ -12,10 +12,20 @@ const CSVLoaderOptions = {
   csv: {
     TableBatch: RowTableBatch,
     batchSize: 10,
+    // CSV options
     header: 'auto',
     rowFormat: 'auto',
     columnPrefix: 'column',
-    dynamicTyping: true
+    // delimiter: auto
+    // newline: auto
+    quoteChar: '"',
+    escapeChar: '"',
+    dynamicTyping: true,
+    comments: false,
+    skipEmptyLines: false,
+    // transform: null?
+    delimitersToGuess: [',', '\t', '|', ';']
+    // fastMode: auto
   }
 };
 


### PR DESCRIPTION
- v2.2 introduced a helpful warnings system to draw the user's attention to unsupported options.
- the system depends on loaders listing out all supported options, otherwise false warnings may be flagged.
- this adds all the papaparse options to CSVLoader, expect the auto-detect/function valued ones that require more investigation as it is not clear if the presence of a default value here affects the auto detection.

