### PR TITLE
[Bug/Enhancement] Pass actual resource so inference can be done via getResouceUrlAndType

### DIFF
--- a/modules/core/src/lib/api/parse-in-batches.js
+++ b/modules/core/src/lib/api/parse-in-batches.js
@@ -1,7 +1,6 @@
 import {concatenateChunksAsync} from '@loaders.gl/loader-utils';
 import {isLoaderObject} from '../loader-utils/normalize-loader';
 import {normalizeOptions} from '../loader-utils/option-utils';
-import {getUrlFromData} from '../loader-utils/get-data';
 import {getLoaderContext} from '../loader-utils/context-utils';
 import {getAsyncIteratorFromData} from '../loader-utils/get-data';
 import {selectLoader} from './select-loader';
@@ -29,12 +28,9 @@ export async function parseInBatches(data, loaders, options, context) {
     context = null;
   }
 
-  // Extract a url for auto detection
-  const autoUrl = getUrlFromData(data, url);
-
   // Chooses a loader and normalizes it
   // TODO - only uses URL, need a selectLoader variant that peeks at first stream chunk...
-  const loader = selectLoader(null, loaders, options, {url: autoUrl});
+  const loader = selectLoader(data, loaders, options, {url});
   // Note: if nothrow option was set, it is possible that no loader was found, if so just return null
   if (!loader) {
     return null;

--- a/modules/core/src/lib/api/parse-in-batches.js
+++ b/modules/core/src/lib/api/parse-in-batches.js
@@ -1,6 +1,7 @@
 import {concatenateChunksAsync} from '@loaders.gl/loader-utils';
 import {isLoaderObject} from '../loader-utils/normalize-loader';
 import {normalizeOptions} from '../loader-utils/option-utils';
+import {getUrlFromData} from '../loader-utils/get-data';
 import {getLoaderContext} from '../loader-utils/context-utils';
 import {getAsyncIteratorFromData} from '../loader-utils/get-data';
 import {selectLoader} from './select-loader';
@@ -28,18 +29,21 @@ export async function parseInBatches(data, loaders, options, context) {
     context = null;
   }
 
+  // Extract a url for auto detection
+  const autoUrl = getUrlFromData(data, url);
+
   // Chooses a loader and normalizes it
   // TODO - only uses URL, need a selectLoader variant that peeks at first stream chunk...
-  const loader = selectLoader(data, loaders, options, {url});
+  const loader = selectLoader(data, loaders, options, {url: autoUrl});
   // Note: if nothrow option was set, it is possible that no loader was found, if so just return null
   if (!loader) {
     return null;
   }
 
   // Normalize options
-  options = normalizeOptions(options, loader, loaders, url);
+  options = normalizeOptions(options, loader, loaders, autoUrl);
 
-  context = getLoaderContext({url, parseInBatches, parse, loaders}, options, context);
+  context = getLoaderContext({url: autoUrl, parseInBatches, parse, loaders}, options, context);
 
   return await parseWithLoaderInBatches(loader, data, options, context);
 }

--- a/modules/core/src/lib/utils/resource-utils.js
+++ b/modules/core/src/lib/utils/resource-utils.js
@@ -15,9 +15,12 @@ export function getResourceUrlAndType(resource) {
     };
   }
 
+  // If the resource is a Blob or a File (subclass of Blob)
   if (isBlob(resource)) {
     return {
-      url: stripQueryString(resource.url || ''),
+      // File objects have a "name" property. Blob objects don't have any
+      // url/name information
+      url: stripQueryString(resource.name || ''),
       type: resource.type || ''
     };
   }

--- a/modules/core/test/lib/utils/resource-utils.spec.js
+++ b/modules/core/test/lib/utils/resource-utils.spec.js
@@ -1,4 +1,4 @@
-/* global Blob */
+/* global Blob, File, Response */
 import test from 'tape-promise/tape';
 import {isBrowser} from '@loaders.gl/core';
 import {
@@ -15,6 +15,24 @@ test('getResourceUrlAndType', t => {
   if (isBrowser) {
     const blob = new Blob(['abc'], {type: 'application/text'});
     t.deepEqual(getResourceUrlAndType(blob), {type: 'application/text', url: ''});
+
+    const file = new File(['abc'], 'filename.csv', {type: 'text/csv'});
+    t.deepEqual(getResourceUrlAndType(file), {type: 'text/csv', url: 'filename.csv'});
+
+    const response = new Response(new Blob(['abc']), {
+      status: 200,
+      statusText: 'Success',
+      headers: {
+        'content-type': 'application/json'
+      }
+    });
+    // Inject a url property for testing, since url is read only property for the Response class
+    Object.defineProperty(response, 'url', {value: 'https://abc.com/file.json?variable=value'});
+
+    t.deepEqual(getResourceUrlAndType(response), {
+      type: 'application/json',
+      url: 'https://abc.com/file.json'
+    });
   }
 
   t.end();


### PR DESCRIPTION
For some reason, `null` was passed instead of the resource to `selectLoaders` which skipped much of the logic to get the resource type and url based on it's class type. 