### PR TITLE
Perf: prevent iterating through typed array if using SharedArrayBuffer

### DIFF
--- a/modules/loader-utils/src/lib/worker-utils/get-transfer-list.js
+++ b/modules/loader-utils/src/lib/worker-utils/get-transfer-list.js
@@ -16,6 +16,9 @@ export function getTransferList(object, recursive = true, transfers) {
   } else if (isTransferable(object.buffer)) {
     // Typed array
     transfersSet.add(object.buffer);
+  } else if (ArrayBuffer.isView(object)) {
+    // object is a TypeArray viewing into a SharedArrayBuffer (not transferable)
+    // Do not iterate through the content in this case
   } else if (recursive && typeof object === 'object') {
     for (const key in object) {
       // Avoid perf hit - only go one level deep


### PR DESCRIPTION
A [SharedArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) is very useful when splitting a single job among multiple workers. `TypedArray.buffer: <SharedArrayBuffer>` is not transferrable, and in the current implementation `getTransferList` recursively looks into the typed array's content which kills the perf.

This PR is intended to be a quick patch. In my mind we need better rules in determining what objects need to be traversed, e.g. we could skip an array if the first element is a number/string.