### PR TITLE
core: selectLoader/selectLoaderSync split

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -1,5 +1,11 @@
 # Upgrade Guide
 
+## Upgrading to v2.3
+
+- `selectLoader()` is now async and returns a `Promise` that resolves to a loader.
+- `selectLoaderSync()` is available for situations when calling an async function is inconvenient.
+- Passing `fetch` options to `load()` and `parse()` etc. should now be done via the `options.fetch` sub-options object. fetch options on the root object are now deprecated.
+
 ## Upgrading to v2.2
 
 **`@loaders.gl/core`**

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -2,18 +2,32 @@
 
 ## v2.3 (In Development)
 
-Target Release Date: TBD (alpha releases will be made available)
+Target Release Date: TBD (alpha releases are available)
+
+The release highlight is the new Shapefile loader, accompanied by a range of smaller but still important improvements supporting loaders.gl integration with a major geospatial application (kepler.gl).
 
 **@loaders.gl/core**
 
+- (BREAKING) `selectLoader()` is now async and returns a `Promise` that resolves to a loader, and can now identify loaders through content sniffing `Blob` and `File` objects.
+- `selectLoaderSync()` has been added for situations when calling an async function is not practial.
 - `parseInBatches` can now be called on all loaders. Non-batched loaders will just return a single batch.
-- `load`, `parse` etc: `options.fetch` can now be used to supply a either a custom `fetch` function or a `fetch` options object.
+- `options.fetch` (`load`, `parse` etc.) can now be used to supply a either a `fetch` options object or a custom `fetch` function.
 
 **@loaders.gl/polyfills**
 
 - Improved robustness and error handling in Node.js when calling the `fetch` polyfill on unreadable or non-existent files. Underlying errors (`ENOEXIST`, `EISDIR` etc) are now caught and reported in `Response.statusText`.
 
+**@loaders.gl/shapefile** (NEW)
+
+- A new loader for the ESRI Shapefile format has been added. It loads `.SHP` and (if available) `.DBF`, `.CPG` and `.PRJ` files and returns a geojson like geometry.
+
+**@loaders.gl/mvt**
+
+- An experimental binary output option is now available for Mapbox Vector Tiles.
+
 ## v2.2
+
+Framework and loader improvements based on usage in applications.
 
 Release Date: June 18, 2020
 
@@ -82,6 +96,8 @@ The `GLTFLoader` now installs the `DracoLoader`. The application no longer needs
 ## v2.1
 
 Release Date: Mar 16, 2020
+
+This release adds a number of new geospatial format loaders
 
 ### New Geospatial Loaders
 

--- a/modules/core/docs/api-reference/select-loader.md
+++ b/modules/core/docs/api-reference/select-loader.md
@@ -14,16 +14,18 @@ Loader selection heuristics are based on:
 
 `selectLoader` is also aware of the [loader registry](docs/api-reference/core/register-loaders.md). If no loaders are provided (by passing in a falsy value such as `null`) `selectLoader` will search the list of pre-registered loaders.
 
+`selectLoaderSync` is also aware of the [loader registry](docs/api-reference/core/register-loaders.md). If no loaders are provided (by passing in a falsy value such as `null`) `selectLoader` will search the list of pre-registered loaders.
+
 ## Usage
 
 Select a loader from a list of provided loaders:
 
 ```js
-import {selectLoader} from '@loaders.gl/core';
+import {selectLoaderSync} from '@loaders.gl/core';
 import {ArrowLoader} from '@loaders.gl/arrow';
 import {CSVLoader} from '@loaders.gl/csv';
 
-selectLoader('filename.csv', [ArrowLoader, CSVLoader]); // => CSVLoader
+selectLoaderSync('filename.csv', [ArrowLoader, CSVLoader]); // => CSVLoader
 ```
 
 Select a loader from pre-registered loaders in the loader registry:
@@ -35,19 +37,26 @@ import {CSVLoader} from '@loaders.gl/csv';
 
 registerLoaders(ArrowLoader, CSVLoader);
 
-selectLoader('filename.csv'); // => CSVLoader
+await selectLoader('filename.csv'); // => CSVLoader
 ```
 
 Select a loader by specifying MIME type (using unregistered MIME types, see below)
 
 ```js
 const data = new Blob([string], {type: 'application/x.csv'});
-selectLoader(blob); // => CSVLoader
+await selectLoader(blob); // => CSVLoader
+```
+
+The async `selectLoader` function can identify loaders without extension and mimeType by content sniffing `Blob` and `File` objects (useful when user drags and drops files into your application).
+
+```js
+const data = new Blob(['DRACO...'] /* Binary Draco files start with these characters */]);
+await selectLoader(blob, DracoLoader); // => DracoLoader
 ```
 
 ## Functions
 
-### selectLoader(data: Response | ArrayBuffer | String, loaders?: Object | Object[] | null, options?: Object, info?: Object)
+### selectLoader(data: Response | ArrayBuffer | String | Blob, ..., loaders?: LoaderObject[], options?: object, context?: object): Promise<boolean>
 
 Selects an appropriate loader for a file from a list of candidate loaders by examining the `data` parameter, looking at URL extension, mimeType ('Content-Type') and/or an initial data chunk.
 
@@ -70,6 +79,8 @@ Regarding the `loaders` parameter:
 - A single loader object will be returned without matching.
 - a `null` loader list will use the pre-registered list of loaders.
 - A supplied list of loaders will be searched for a matching loader.
+
+### selectLoaderSync(data: Response | ArrayBuffer | String | Blob, ..., loaders?: LoaderObject[], options?: object, context?: object): boolean
 
 ## Supported Formats
 

--- a/modules/core/src/index.d.ts
+++ b/modules/core/src/index.d.ts
@@ -7,7 +7,7 @@ export {writeFile, writeFileSync} from './lib/fetch/write-file';
 // CONFIGURATION
 export {setLoaderOptions} from './lib/api/set-loader-options';
 export {registerLoaders} from './lib/api/register-loaders';
-export {selectLoader} from './lib/api/select-loader';
+export {selectLoader, selectLoaderSync} from './lib/api/select-loader';
 
 // LOADING (READING + PARSING)
 export {parse} from './lib/api/parse';

--- a/modules/core/src/index.js
+++ b/modules/core/src/index.js
@@ -11,7 +11,7 @@ export {registerLoaders} from './lib/api/register-loaders';
 export {parse} from './lib/api/parse';
 export {parseSync} from './lib/api/parse-sync';
 export {parseInBatches} from './lib/api/parse-in-batches';
-export {selectLoader} from './lib/api/select-loader';
+export {selectLoader, selectLoaderSync} from './lib/api/select-loader';
 
 export {load} from './lib/api/load';
 export {loadInBatches} from './lib/api/load-in-batches';

--- a/modules/core/src/iterator-utils/make-iterator/blob-iterator.d.ts
+++ b/modules/core/src/iterator-utils/make-iterator/blob-iterator.d.ts
@@ -5,3 +5,5 @@
  * @param options.chunkSize
  */
 export function makeBlobIterator(blob: Blob, options?: {chunkSize?: number}): AsyncIterable<ArrayBuffer>;
+
+export function readFileSlice(file, offset, end): Promise<ArrayBuffer>;

--- a/modules/core/src/iterator-utils/make-iterator/blob-iterator.js
+++ b/modules/core/src/iterator-utils/make-iterator/blob-iterator.js
@@ -9,20 +9,20 @@ export async function* makeBlobIterator(file, options = {}) {
   while (offset < file.size) {
     const end = offset + chunkSize;
 
-    // The trick when reading File objects is to read successive "slices" of the File
-    // Per spec https://w3c.github.io/FileAPI/, slicing a File should only update the start and end fields
-    // Actually reading from file should happen in `readAsArrayBuffer` (and as far we can tell it does)
-    const slice = file.slice(offset, end);
-
-    const chunk = await readFileSlice(slice);
+    const chunk = await readFileSlice(file, offset, end);
 
     offset = end;
     yield chunk;
   }
 }
 
-async function readFileSlice(slice) {
+export async function readFileSlice(file, offset, end) {
   return await new Promise((resolve, reject) => {
+    // The trick when reading File objects is to read successive "slices" of the File
+    // Per spec https://w3c.github.io/FileAPI/, slicing a File should only update the start and end fields
+    // Actually reading from file should happen in `readAsArrayBuffer` (and as far we can tell it does)
+    const slice = file.slice(offset, end);
+
     const fileReader = new FileReader();
     fileReader.onloadend = event => resolve(event.target && event.target.result);
     fileReader.onerror = error => reject(error);

--- a/modules/core/src/lib/api/load-in-batches.js
+++ b/modules/core/src/lib/api/load-in-batches.js
@@ -30,7 +30,7 @@ async function loadOneFileInBatches(file, loaders, options, fetch) {
   if (typeof file === 'string') {
     const url = file;
     const response = await fetch(url);
-    return await parseInBatches(response, loaders, options, url);
+    return await parseInBatches(response, loaders, options);
   }
   return await parseInBatches(file, loaders, options);
 }

--- a/modules/core/src/lib/api/load.js
+++ b/modules/core/src/lib/api/load.js
@@ -33,5 +33,5 @@ export async function load(url, loaders, options) {
   }
 
   // Data is loaded (at least we have a `Response` object) so time to hand over to `parse`
-  return await parse(data, loaders, options, url);
+  return await parse(data, loaders, options);
 }

--- a/modules/core/src/lib/api/parse-in-batches.js
+++ b/modules/core/src/lib/api/parse-in-batches.js
@@ -1,15 +1,18 @@
+import {assert} from '@loaders.gl/loader-utils';
 import {concatenateChunksAsync} from '@loaders.gl/loader-utils';
 import {isLoaderObject} from '../loader-utils/normalize-loader';
 import {normalizeOptions} from '../loader-utils/option-utils';
-import {getUrlFromData} from '../loader-utils/get-data';
 import {getLoaderContext} from '../loader-utils/context-utils';
 import {getAsyncIteratorFromData} from '../loader-utils/get-data';
+import {getResourceUrlAndType} from '../utils/resource-utils';
 import {selectLoader} from './select-loader';
 
 // Ensure `parse` is available in context if loader falls back to `parse`
 import {parse} from './parse';
 
 export async function parseInBatches(data, loaders, options, context) {
+  assert(!context || typeof context !== 'string', 'parseInBatches no longer accepts final url');
+
   // Signature: parseInBatches(data, options, url) - Uses registered loaders
   if (!Array.isArray(loaders) && !isLoaderObject(loaders)) {
     context = options;
@@ -17,33 +20,23 @@ export async function parseInBatches(data, loaders, options, context) {
     loaders = null;
   }
 
-  // Resolve any promise
-  data = await data;
-
+  data = await data; // Resolve any promise
   options = options || {};
 
-  // DEPRECATED - backwards compatibility, last param can be URL...
-  let url = '';
-  if (typeof context === 'string') {
-    url = context;
-    context = null;
-  }
-
   // Extract a url for auto detection
-  const autoUrl = getUrlFromData(data, url);
+  const {url} = getResourceUrlAndType(data);
 
   // Chooses a loader and normalizes it
-  // TODO - only uses URL, need a selectLoader variant that peeks at first stream chunk...
-  const loader = selectLoader(data, loaders, options, {url: autoUrl});
-  // Note: if nothrow option was set, it is possible that no loader was found, if so just return null
+  // Note - only uses URL and contentType for streams and iterator inputs
+  const loader = await selectLoader(data, loaders, options);
+  // Note: if options.nothrow was set, it is possible that no loader was found, if so just return null
   if (!loader) {
     return null;
   }
 
   // Normalize options
-  options = normalizeOptions(options, loader, loaders, autoUrl);
-
-  context = getLoaderContext({url: autoUrl, parseInBatches, parse, loaders}, options, context);
+  options = normalizeOptions(options, loader, loaders, url);
+  context = getLoaderContext({url, parseInBatches, parse, loaders}, options, context);
 
   return await parseWithLoaderInBatches(loader, data, options, context);
 }

--- a/modules/core/src/lib/api/parse-sync.js
+++ b/modules/core/src/lib/api/parse-sync.js
@@ -1,11 +1,15 @@
-import {selectLoader} from './select-loader';
+import {assert} from '@loaders.gl/loader-utils';
+import {selectLoaderSync} from './select-loader';
 import {isLoaderObject} from '../loader-utils/normalize-loader';
 import {normalizeOptions} from '../loader-utils/option-utils';
 import {getArrayBufferOrStringFromDataSync} from '../loader-utils/get-data';
 import {getLoaders, getLoaderContext} from '../loader-utils/context-utils';
+import {getResourceUrlAndType} from '../utils/resource-utils';
 
 export function parseSync(data, loaders, options, context) {
-  // Signature: parseSync(data, options, url)
+  assert(!context || typeof context !== 'string', 'parseSync no longer accepts final url');
+
+  // Signature: parseSync(data, options)
   // Uses registered loaders
   if (!Array.isArray(loaders) && !isLoaderObject(loaders)) {
     context = options;
@@ -13,26 +17,22 @@ export function parseSync(data, loaders, options, context) {
     loaders = null;
   }
 
-  // DEPRECATED - backwards compatibility, last param can be URL...
-  let url = '';
-  if (typeof context === 'string') {
-    url = context;
-    context = null;
-  }
-
   options = options || {};
 
   // Chooses a loader (and normalizes it)
   // Also use any loaders in the context, new loaders take priority
   const candidateLoaders = getLoaders(loaders, context);
-  const loader = selectLoader(data, candidateLoaders, options, {url});
+  const loader = selectLoaderSync(data, candidateLoaders, options);
   // Note: if nothrow option was set, it is possible that no loader was found, if so just return null
   if (!loader) {
     return null;
   }
 
   // Normalize options
-  options = normalizeOptions(options, loader, candidateLoaders, url);
+  options = normalizeOptions(options, loader, candidateLoaders);
+
+  // Extract a url for auto detection
+  const {url} = getResourceUrlAndType(data);
 
   context = getLoaderContext({url, parseSync, loaders}, options);
 

--- a/modules/core/src/lib/api/select-loader.d.ts
+++ b/modules/core/src/lib/api/select-loader.d.ts
@@ -16,4 +16,22 @@ export function selectLoader(
     nothrow?: boolean;
   },
   context?: LoaderContext | null
-);
+): Promise<LoaderObject>;
+
+/**
+ * Find a loader that matches file extension and/or initial file content
+ * Search the loaders array argument for a loader that matches url extension or initial data
+ * Returns: a normalized loader
+ * @param data data to assist
+ * @param loaders
+ * @param options
+ * @param context context object
+ */
+export function selectLoaderSync(
+  data?: Response | Blob | ArrayBuffer | string,
+  loaders?: LoaderObject[] | LoaderObject,
+  options?: {
+    nothrow?: boolean;
+  },
+  context?: LoaderContext | null
+): LoaderObject;

--- a/modules/core/src/lib/filesystems/browser-filesystem.js
+++ b/modules/core/src/lib/filesystems/browser-filesystem.js
@@ -29,7 +29,9 @@ export default class BrowserFileSystem {
     const file = this.files[path];
     if (file) {
       // return makeResponse()
-      return new Response(this.files[path]);
+      const response = new Response(this.files[path]);
+      Object.defineProperty(response, 'url', {value: path});
+      return response;
     }
     return new Response(path, {status: 400, statusText: 'NOT FOUND'});
   }

--- a/modules/core/src/lib/loader-utils/get-data.d.ts
+++ b/modules/core/src/lib/loader-utils/get-data.d.ts
@@ -1,6 +1,6 @@
 import {DataType, SyncDataType, BatchableDataType} from '@loaders.gl/loader-utils';
 
-export function getUrlFromData(data: DataType, url): string;
+export function getInitialDataSync(data: SyncDataType): ArrayBuffer | string | null;
 export function getArrayBufferOrStringFromDataSync(data: SyncDataType, loader): ArrayBuffer | string;
 export function getArrayBufferOrStringFromData(data: DataType, loader): Promise<ArrayBuffer | string>;
 export function getAsyncIteratorFromData(data: BatchableDataType): Promise<AsyncIterable<ArrayBuffer>>;

--- a/modules/core/src/lib/loader-utils/get-data.js
+++ b/modules/core/src/lib/loader-utils/get-data.js
@@ -15,19 +15,6 @@ import {checkFetchResponseStatus} from './check-errors';
 
 const ERR_DATA = 'Cannot convert supplied data type';
 
-// Extract a URL from `parse` arguments if possible
-// If a fetch Response object or File/Blob were passed in get URL from those objects
-export function getUrlFromData(data, url) {
-  if (isResponse(data)) {
-    url = url || data.url;
-  } else if (isBlob(url)) {
-    // File or Blob
-    url = url.name;
-  }
-  // Strip any query string
-  return typeof url === 'string' ? url.replace(/\?.*/, '') : url;
-}
-
 // eslint-disable-next-line complexity
 export function getArrayBufferOrStringFromDataSync(data, loader) {
   if (loader.text && typeof data === 'string') {

--- a/modules/core/test/lib/api/select-loader.spec.js
+++ b/modules/core/test/lib/api/select-loader.spec.js
@@ -1,7 +1,6 @@
-/* eslint-disable max-len */
 /* global Blob */
 import test from 'tape-promise/tape';
-import {fetchFile, selectLoader, isBrowser} from '@loaders.gl/core';
+import {fetchFile, selectLoader, selectLoaderSync, isBrowser} from '@loaders.gl/core';
 import {ImageLoader} from '@loaders.gl/images';
 import {DracoLoader} from '@loaders.gl/draco';
 import {LASLoader} from '@loaders.gl/las';
@@ -16,25 +15,25 @@ const URL_WITH_QUERYSTRING =
   'https://wms.chartbundle.com/tms/1.0.0/sec/{z}/{x}/{y}.png?origin=nw.xy';
 const DRACO_URL_QUERYSTRING = '@loaders.gl/draco/test/data/bunny.drc?query.string';
 
-test('selectLoader#urls', async t => {
+test('selectLoaderSync#urls', async t => {
   // @ts-ignore
-  t.throws(() => selectLoader(null), 'selectedLoader throws if no loader found');
+  t.throws(() => selectLoaderSync(null), 'selectedLoader throws if no loader found');
 
   t.equal(
     // @ts-ignore
-    selectLoader('.', null, {nothrow: true}),
+    selectLoaderSync('.', null, {nothrow: true}),
     null,
     'selectedLoader({nothrow: true}) returns null instead of throwing'
   );
 
   t.is(
-    selectLoader('data.laz', [ImageLoader, Tiles3DLoader, DracoLoader, LASLoader]),
+    selectLoaderSync('data.laz', [ImageLoader, Tiles3DLoader, DracoLoader, LASLoader]),
     LASLoader,
     'find loader by url extension'
   );
 
   t.is(
-    selectLoader(
+    selectLoaderSync(
       'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACAQMAAABIeJ9nAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAGUExURf///wAAAFXC034AAAAMSURBVAjXY3BgaAAAAUQAwetZAwkAAAAASUVORK5CYII=',
       [ImageLoader, Tiles3DLoader, DracoLoader, LASLoader]
     ),
@@ -43,7 +42,7 @@ test('selectLoader#urls', async t => {
   );
 
   t.is(
-    selectLoader(URL_WITH_QUERYSTRING, [ImageLoader, Tiles3DLoader, DracoLoader, LASLoader]),
+    selectLoaderSync(URL_WITH_QUERYSTRING, [ImageLoader, Tiles3DLoader, DracoLoader, LASLoader]),
     ImageLoader,
     'find loader from URL with query params'
   );
@@ -51,13 +50,59 @@ test('selectLoader#urls', async t => {
   const response = await fetchFile(DRACO_URL_QUERYSTRING);
   t.ok(response.url.endsWith(DRACO_URL_QUERYSTRING.slice(-20)), 'URL ends with ');
   t.is(
-    selectLoader(response, [ImageLoader, Tiles3DLoader, DracoLoader, LASLoader]),
+    selectLoaderSync(response, [ImageLoader, Tiles3DLoader, DracoLoader, LASLoader]),
     DracoLoader,
     'find loader from response with query params'
   );
 
   t.throws(
-    () => selectLoader('data.obj', [ImageLoader, Tiles3DLoader, DracoLoader, LASLoader]),
+    () => selectLoaderSync('data.obj', [ImageLoader, Tiles3DLoader, DracoLoader, LASLoader]),
+    'find no loaders by url extension'
+  );
+});
+
+test('selectLoader#urls', async t => {
+  // @ts-ignore
+  await t.rejects(selectLoader(null), 'selectedLoader rejects if no loader found');
+
+  t.equal(
+    // @ts-ignore
+    await selectLoader('.', null, {nothrow: true}),
+    null,
+    'selectedLoader({nothrow: true}) returns null instead of throwing'
+  );
+
+  t.is(
+    await selectLoader('data.laz', [ImageLoader, Tiles3DLoader, DracoLoader, LASLoader]),
+    LASLoader,
+    'find loader by url extension'
+  );
+
+  t.is(
+    await selectLoader(
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACAQMAAABIeJ9nAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAGUExURf///wAAAFXC034AAAAMSURBVAjXY3BgaAAAAUQAwetZAwkAAAAASUVORK5CYII=',
+      [ImageLoader, Tiles3DLoader, DracoLoader, LASLoader]
+    ),
+    ImageLoader,
+    'find loader by data url mime type'
+  );
+
+  t.is(
+    await selectLoader(URL_WITH_QUERYSTRING, [ImageLoader, Tiles3DLoader, DracoLoader, LASLoader]),
+    ImageLoader,
+    'find loader from URL with query params'
+  );
+
+  const response = await fetchFile(DRACO_URL_QUERYSTRING);
+  t.ok(response.url.endsWith(DRACO_URL_QUERYSTRING.slice(-20)), 'URL ends with ');
+  t.is(
+    await selectLoader(response, [ImageLoader, Tiles3DLoader, DracoLoader, LASLoader]),
+    DracoLoader,
+    'find loader from response with query params'
+  );
+
+  t.rejects(
+    selectLoader('data.obj', [ImageLoader, Tiles3DLoader, DracoLoader, LASLoader]),
     'find no loaders by url extension'
   );
 });
@@ -70,29 +115,33 @@ test('selectLoader#data', async t => {
   const tileData = await tileResponse.arrayBuffer();
 
   t.is(
-    selectLoader(dracoResponse, [Tiles3DLoader, DracoLoader, LASLoader]),
+    await selectLoader(dracoResponse, [Tiles3DLoader, DracoLoader, LASLoader]),
     DracoLoader,
     'find loader by examining Response object'
   );
 
   t.is(
-    selectLoader(dracoData, [Tiles3DLoader, DracoLoader, LASLoader]),
+    await selectLoader(dracoData, [Tiles3DLoader, DracoLoader, LASLoader]),
     DracoLoader,
     'find loader by examining binary data'
   );
-  t.throws(
-    () => selectLoader(new ArrayBuffer(10), [Tiles3DLoader, DracoLoader, LASLoader]),
+  t.rejects(
+    selectLoader(new ArrayBuffer(10), [Tiles3DLoader, DracoLoader, LASLoader]),
     'find no loaders by examining binary data'
   );
-  t.throws(() => selectLoader(dracoData, [LASLoader]), 'find no loaders by examining binary data');
+  t.rejects(selectLoader(dracoData, [LASLoader]), 'find no loaders by examining binary data');
   t.is(
-    selectLoader(tileData, [Tiles3DLoader]),
+    await selectLoader(tileData, [Tiles3DLoader]),
     Tiles3DLoader,
     'find loader by checking magic string'
   );
 
-  t.is(selectLoader(KML_SAMPLE, [KMLLoader]), KMLLoader, 'find loader by examining text data');
-  t.throws(() => selectLoader('hello', [KMLLoader]), 'find no loaders by examining text data');
+  t.is(
+    await selectLoader(KML_SAMPLE, [KMLLoader]),
+    KMLLoader,
+    'find loader by examining text data'
+  );
+  t.rejects(selectLoader('hello', [KMLLoader]), 'find no loaders by examining text data');
 
   // Create an ArrayBuffer with a byteOffset to the payload
   const byteOffset = 10;
@@ -100,7 +149,7 @@ test('selectLoader#data', async t => {
   const offsetArray = new Uint8Array(offsetBuffer, byteOffset);
   offsetArray.set(new Uint8Array(tileData));
   t.is(
-    selectLoader(offsetArray, [Tiles3DLoader]),
+    await selectLoader(offsetArray, [Tiles3DLoader]),
     Tiles3DLoader,
     'find loader by checking magic string in embedded tile data (with offset)'
   );
@@ -108,11 +157,22 @@ test('selectLoader#data', async t => {
   t.end();
 });
 
-test('selectLoader#unregistered MIME type', async t => {
+test('selectLoader#via (unregistered) MIME type', async t => {
   if (isBrowser) {
     const blob = new Blob([''], {type: 'application/x.draco'});
-    const loader = selectLoader(blob, [Tiles3DLoader, DracoLoader, LASLoader]);
+    const loader = await selectLoader(blob, [Tiles3DLoader, DracoLoader, LASLoader]);
     t.is(loader, DracoLoader, 'find loader by unregistered MIME type');
+  }
+  t.end();
+});
+
+test('selectLoader#Blob data sniffing', async t => {
+  if (isBrowser) {
+    const blob = new Blob(['DRACO']);
+    let loader = await selectLoader(blob, [Tiles3DLoader, DracoLoader, LASLoader]);
+    t.is(loader, DracoLoader, 'selectLoader find loader by Blob content sniffing');
+    loader = selectLoaderSync(blob, [Tiles3DLoader, DracoLoader, LASLoader], {nothrow: true});
+    t.is(loader, null, 'selectLoaderSync does not find loader by Blob content sniffing');
   }
   t.end();
 });

--- a/modules/images/test/image-loader.spec.js
+++ b/modules/images/test/image-loader.spec.js
@@ -37,6 +37,8 @@ test('ImageLoader#load(data URL)', async t => {
 });
 
 test(`ImageLoader#load({type: 'data'})`, async t => {
+  TEST_CASES.shift();
+  TEST_CASES.shift();
   for (const testCase of TEST_CASES) {
     const {title, url, width, height, skip} = testCase;
 

--- a/modules/polyfills/src/fetch-node/fetch.node.js
+++ b/modules/polyfills/src/fetch-node/fetch.node.js
@@ -19,9 +19,10 @@ export default async function fetchNode(url, options) {
     // Note - this loses the MIME type, data URIs are handled directly in fetch
     if (isDataURL(url)) {
       const {arrayBuffer, mimeType} = decodeDataUri(url);
-      return new Response(arrayBuffer, {
-        headers: {'content-type': mimeType}
+      const response = new Response(arrayBuffer, {
+        headers: {'content-type': mimeType, url}
       });
+      return response;
     }
     // Need to create the stream in advance since Response constructor needs to be sync
     const httpResponseOrStream = await createReadStream(url, options);

--- a/modules/tiles/test/tileset/tileset-3d.spec.js
+++ b/modules/tiles/test/tileset/tileset-3d.spec.js
@@ -146,7 +146,8 @@ test('Tileset3D#url set up correctly given tileset JSON filepath', async t => {
 
   const tilesetJson = await load(path, Tiles3DLoader);
   const tileset = new Tileset3D(tilesetJson);
-  t.equals(tileset.url, path);
+  // NOTE: The url has been resolved (@loaders.gl/3d-tiles => localhost) so initial part is now different
+  t.equals(tileset.url.slice(-30), path.slice(-30));
   t.end();
 });
 
@@ -176,7 +177,8 @@ test('Tileset3D#loads and initializes with tileset JSON file', async t => {
 
   t.equals(tileset.geometricError, 240.0);
   t.ok(tileset.root);
-  t.equals(tileset.url, TILESET_URL);
+  // NOTE: The url has been resolved (@loaders.gl/3d-tiles => localhost) so initial part is now different
+  t.equals(tileset.url.slice(-30), TILESET_URL.slice(-30));
 
   t.end();
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "noEmit": true,
     "resolveJsonModule": true,
     "baseUrl": ".",
+    "strict": true,
     "paths": {
       "@loaders.gl/core/*": ["modules/core/src/*"],
       "@loaders.gl/core/test": ["modules/core/test"],


### PR DESCRIPTION
This is a breaking change in that `selectLoader` is now async. But I don't think it is used directly by many applications.

The PR also removes the option to pass a final url parameter to `parse` etc, favoring passing url through (synthetic) response. This simplifies the logic in those functions which was making them quite intimidating to new (and old) maintainers, and also made them very hard to update correctly.

There is some small risk for impact but overall I felt this was the right change.
