### PR TITLE
mvt: Fork @mapbox/vector-tile (prep for optimized binary loading)

### DIFF
--- a/modules/mvt/package.json
+++ b/modules/mvt/package.json
@@ -35,6 +35,10 @@
     "@loaders.gl/gis": "2.3.0-alpha.5",
     "@loaders.gl/loader-utils": "2.3.0-alpha.5",
     "@mapbox/vector-tile": "^1.3.1",
+    "@mapbox/point-geometry": "~0.1.0",
     "pbf": "^3.2.1"
+  },
+  "devDependencies": {
+    "@types/pbf": "^3.0.2"
   }
 }

--- a/modules/mvt/src/lib/mapbox-vector-tile/LICENSE.txt
+++ b/modules/mvt/src/lib/mapbox-vector-tile/LICENSE.txt
@@ -1,0 +1,31 @@
+This code is forked from https://github.com/mapbox/vector-tile-js under BSD 3-clause license.
+
+---
+
+Copyright (c) 2014, Mapbox
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+    * Neither the name of Mapbox nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/modules/mvt/src/lib/mapbox-vector-tile/vector-tile-feature.d.ts
+++ b/modules/mvt/src/lib/mapbox-vector-tile/vector-tile-feature.d.ts
@@ -1,0 +1,15 @@
+import Protobuf from 'pbf';
+
+export default class VectorTileFeature {
+	static types: ['Unknown', 'Point', 'LineString', 'Polygon'];
+
+  properties: object;
+  extent: any;
+  type: number;
+
+	constructor(pbf: Protobuf, end, extent, keys, values);
+
+	loadGeometry(); any;
+  bbox(): [number, number, number, number];
+	toGeoJSON(x, y, z): object;
+}

--- a/modules/mvt/src/lib/mapbox-vector-tile/vector-tile-feature.js
+++ b/modules/mvt/src/lib/mapbox-vector-tile/vector-tile-feature.js
@@ -1,0 +1,239 @@
+// This code is forked from https://github.com/mapbox/vector-tile-js under BSD 3-clause license.
+/* eslint-disable */
+import Point from '@mapbox/point-geometry';
+
+export default class VectorTileFeature {
+  static get types() {
+    return ['Unknown', 'Point', 'LineString', 'Polygon'];
+  }
+
+  constructor(pbf, end, extent, keys, values) {
+    // Public
+    this.properties = {};
+    this.extent = extent;
+    this.type = 0;
+
+    // Private
+    this._pbf = pbf;
+    this._geometry = -1;
+    this._keys = keys;
+    this._values = values;
+
+    pbf.readFields(readFeature, this, end);
+  }
+
+  // eslint-disable-next-line complexity, max-statements
+  loadGeometry() {
+    const pbf = this._pbf;
+    pbf.pos = this._geometry;
+
+    const end = pbf.readVarint() + pbf.pos;
+    let cmd = 1;
+    let length = 0;
+    let x = 0;
+    let y = 0;
+    const lines = [];
+    let line;
+
+    while (pbf.pos < end) {
+      if (length <= 0) {
+        const cmdLen = pbf.readVarint();
+        cmd = cmdLen & 0x7;
+        length = cmdLen >> 3;
+      }
+
+      length--;
+
+      if (cmd === 1 || cmd === 2) {
+        x += pbf.readSVarint();
+        y += pbf.readSVarint();
+
+        if (cmd === 1) {
+          // moveTo
+          if (line) lines.push(line);
+          line = [];
+        }
+        // @ts-ignore
+        line.push(new Point(x, y));
+      } else if (cmd === 7) {
+        // Workaround for https://github.com/mapbox/mapnik-vector-tile/issues/90
+        if (line) {
+          line.push(line[0].clone()); // closePolygon
+        }
+      } else {
+        throw new Error(`unknown command ${cmd}`);
+      }
+    }
+
+    if (line) lines.push(line);
+
+    return lines;
+  }
+
+  // eslint-disable-next-line max-statements
+  bbox() {
+    const pbf = this._pbf;
+    pbf.pos = this._geometry;
+
+    const end = pbf.readVarint() + pbf.pos;
+    let cmd = 1;
+    let length = 0;
+    let x = 0;
+    let y = 0;
+    let x1 = Infinity;
+    let x2 = -Infinity;
+    let y1 = Infinity;
+    let y2 = -Infinity;
+
+    while (pbf.pos < end) {
+      if (length <= 0) {
+        const cmdLen = pbf.readVarint();
+        cmd = cmdLen & 0x7;
+        length = cmdLen >> 3;
+      }
+
+      length--;
+
+      if (cmd === 1 || cmd === 2) {
+        x += pbf.readSVarint();
+        y += pbf.readSVarint();
+        if (x < x1) x1 = x;
+        if (x > x2) x2 = x;
+        if (y < y1) y1 = y;
+        if (y > y2) y2 = y;
+      } else if (cmd !== 7) {
+        throw new Error(`unknown command ${cmd}`);
+      }
+    }
+
+    return [x1, y1, x2, y2];
+  }
+
+  toGeoJSON(x, y, z) {
+    const size = this.extent * Math.pow(2, z);
+    const x0 = this.extent * x;
+    const y0 = this.extent * y;
+    let coords = this.loadGeometry();
+    let type = VectorTileFeature.types[this.type];
+    let i;
+    let j;
+
+    function project(line) {
+      for (let j = 0; j < line.length; j++) {
+        const p = line[j];
+        const y2 = 180 - ((p.y + y0) * 360) / size;
+        line[j] = [
+          ((p.x + x0) * 360) / size - 180,
+          (360 / Math.PI) * Math.atan(Math.exp((y2 * Math.PI) / 180)) - 90
+        ];
+      }
+    }
+
+    switch (this.type) {
+      case 1:
+        var points = [];
+        for (i = 0; i < coords.length; i++) {
+          points[i] = coords[i][0];
+        }
+        coords = points;
+        project(coords);
+        break;
+
+      case 2:
+        for (i = 0; i < coords.length; i++) {
+          project(coords[i]);
+        }
+        break;
+
+      case 3:
+        coords = classifyRings(coords);
+        for (i = 0; i < coords.length; i++) {
+          for (j = 0; j < coords[i].length; j++) {
+            project(coords[i][j]);
+          }
+        }
+        break;
+    }
+
+    if (coords.length === 1) {
+      coords = coords[0];
+    } else {
+      type = `Multi${type}`;
+    }
+
+    const result = {
+      type: 'Feature',
+      geometry: {
+        type,
+        coordinates: coords
+      },
+      properties: this.properties
+    };
+
+    if ('id' in this) {
+      // @ts-igore
+      // result.id = this.id;
+    }
+
+    return result;
+  }
+}
+
+/**
+ * Classifies an array of rings into polygons with outer rings and holes
+ */
+
+function classifyRings(rings) {
+  const len = rings.length;
+
+  if (len <= 1) return [rings];
+
+  const polygons = [];
+  let polygon;
+  let ccw;
+
+  for (let i = 0; i < len; i++) {
+    const area = signedArea(rings[i]);
+    if (area === 0) continue;
+
+    if (ccw === undefined) ccw = area < 0;
+
+    if (ccw === area < 0) {
+      if (polygon) polygons.push(polygon);
+      polygon = [rings[i]];
+    } else {
+      // @ts-ignore
+      polygon.push(rings[i]);
+    }
+  }
+  if (polygon) polygons.push(polygon);
+
+  return polygons;
+}
+
+function signedArea(ring) {
+  let sum = 0;
+  for (let i = 0, j = ring.length - 1, p1, p2; i < ring.length; j = i++) {
+    p1 = ring[i];
+    p2 = ring[j];
+    sum += (p2.x - p1.x) * (p1.y + p2.y);
+  }
+  return sum;
+}
+
+function readFeature(tag, feature, pbf) {
+  if (tag === 1) feature.id = pbf.readVarint();
+  else if (tag === 2) readTag(pbf, feature);
+  else if (tag === 3) feature.type = pbf.readVarint();
+  else if (tag === 4) feature._geometry = pbf.pos;
+}
+
+function readTag(pbf, feature) {
+  const end = pbf.readVarint() + pbf.pos;
+
+  while (pbf.pos < end) {
+    const key = feature._keys[pbf.readVarint()];
+    const value = feature._values[pbf.readVarint()];
+    feature.properties[key] = value;
+  }
+}

--- a/modules/mvt/src/lib/mapbox-vector-tile/vector-tile-layer.d.ts
+++ b/modules/mvt/src/lib/mapbox-vector-tile/vector-tile-layer.d.ts
@@ -1,0 +1,14 @@
+import VectorTileFeature from './vector-tile-feature';
+
+export default class VectorTileLayer{
+  // Public
+  version: number;
+  name: string;
+  extent: number;
+  length: number;
+
+  constructor(pbf, end);
+
+	/** return feature `i` from this layer as a `VectorTileFeature` */
+	feature(i: number): VectorTileFeature;
+}

--- a/modules/mvt/src/lib/mapbox-vector-tile/vector-tile-layer.js
+++ b/modules/mvt/src/lib/mapbox-vector-tile/vector-tile-layer.js
@@ -1,0 +1,72 @@
+// This code is forked from https://github.com/mapbox/vector-tile-js under BSD 3-clause license.
+
+import VectorTileFeature from './vector-tile-feature.js';
+
+export default class VectorTileLayer {
+  constructor(pbf, end) {
+    // Public
+    this.version = 1;
+    this.name = null;
+    this.extent = 4096;
+    this.length = 0;
+
+    // Private
+    this._pbf = pbf;
+    this._keys = [];
+    this._values = [];
+    this._features = [];
+
+    pbf.readFields(readLayer, this, end);
+
+    this.length = this._features.length;
+  }
+
+  // return feature `i` from this layer as a `VectorTileFeature`
+  feature(i) {
+    if (i < 0 || i >= this._features.length) {
+      throw new Error('feature index out of bounds');
+    }
+
+    this._pbf.pos = this._features[i];
+
+    const end = this._pbf.readVarint() + this._pbf.pos;
+    return new VectorTileFeature(this._pbf, end, this.extent, this._keys, this._values);
+  }
+}
+
+function readLayer(tag, layer, pbf) {
+  if (tag === 15) layer.version = pbf.readVarint();
+  else if (tag === 1) layer.name = pbf.readString();
+  else if (tag === 5) layer.extent = pbf.readVarint();
+  else if (tag === 2) layer._features.push(pbf.pos);
+  else if (tag === 3) layer._keys.push(pbf.readString());
+  else if (tag === 4) layer._values.push(readValueMessage(pbf));
+}
+
+function readValueMessage(pbf) {
+  let value = null;
+  const end = pbf.readVarint() + pbf.pos;
+
+  while (pbf.pos < end) {
+    const tag = pbf.readVarint() >> 3;
+
+    value =
+      tag === 1
+        ? pbf.readString()
+        : tag === 2
+          ? pbf.readFloat()
+          : tag === 3
+            ? pbf.readDouble()
+            : tag === 4
+              ? pbf.readVarint64()
+              : tag === 5
+                ? pbf.readVarint()
+                : tag === 6
+                  ? pbf.readSVarint()
+                  : tag === 7
+                    ? pbf.readBoolean()
+                    : null;
+  }
+
+  return value;
+}

--- a/modules/mvt/src/lib/mapbox-vector-tile/vector-tile.d.ts
+++ b/modules/mvt/src/lib/mapbox-vector-tile/vector-tile.d.ts
@@ -1,0 +1,7 @@
+import VectorTileLayer from './vector-tile-layer';
+import Protobuf from 'pbf';
+
+export default class VectorTile {
+  constructor(pbf: Protobuf, end?);
+  layers: VectorTileLayer[];
+}

--- a/modules/mvt/src/lib/mapbox-vector-tile/vector-tile.js
+++ b/modules/mvt/src/lib/mapbox-vector-tile/vector-tile.js
@@ -1,0 +1,18 @@
+// This code is forked from https://github.com/mapbox/vector-tile-js under BSD 3-clause license.
+
+import VectorTileLayer from './vector-tile-layer';
+
+export default class VectorTile {
+  constructor(pbf, end) {
+    this.layers = pbf.readFields(readTile, {}, end);
+  }
+}
+
+function readTile(tag, layers, pbf) {
+  if (tag === 3) {
+    const layer = new VectorTileLayer(pbf, pbf.readVarint() + pbf.pos);
+    if (layer.length) {
+      layers[layer.name] = layer;
+    }
+  }
+}

--- a/modules/mvt/src/lib/parse-mvt.js
+++ b/modules/mvt/src/lib/parse-mvt.js
@@ -1,4 +1,6 @@
-import {VectorTile} from '@mapbox/vector-tile';
+// import {VectorTile} from '@mapbox/vector-tile';
+import VectorTile from './mapbox-vector-tile/vector-tile';
+
 import {geojsonToBinary} from '@loaders.gl/gis';
 import Protobuf from 'pbf';
 import {transformCoordinates, transformToLocalCoordinates} from './transform-to-local-range';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1944,6 +1944,11 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
 
+"@types/pbf@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/pbf/-/pbf-3.0.2.tgz#8d291ad68b4b8c533e96c174a2e3e6399a59ed61"
+  integrity sha512-EDrLIPaPXOZqDjrkzxxbX7UlJSeQVgah3i0aA4pOSzmK9zq3BIh7/MZIQxED7slJByvKM4Gc6Hypyu2lJzh3SQ==
+
 "@types/text-encoding-utf-8@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/text-encoding-utf-8/-/text-encoding-utf-8-1.0.1.tgz#908d884af1114e5d8df47597b1e04f833383d23d"


### PR DESCRIPTION
The current `@mapbox/vector-tile` code parses into binary by first parsing to geojson, creating large amounts of small objects that are immediately thrown away, causing unnecessary memory / garbage collection pressure. 

It seems straightforward to write a binary parsing pass to avoid this step and parse directly to binary buffers. However, this requires modifying the mapbox code.

- Forks `@mapbox/vector-tile` source code
- Lightly modernizes to ES6 style
- Adds minimal typescript typings