### PR TITLE
compression: New module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # loaders.gl
 
-This module contains framework independent visualization focused file format loaders (parsers) with emphasis on 3D and geospatial formats.
+The loaders.gl framework is a collection framework independent visualization focused file format loaders (parsers) with emphasis on 3D and geospatial formats.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # loaders.gl
 
-The loaders.gl framework is a collection framework independent visualization focused file format loaders (parsers) with emphasis on 3D and geospatial formats.
+The loaders.gl framework is a collection of framework-independent visualization focused file format loaders (parsers) with emphasis on 3D and geospatial formats.

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@
 
 loaders.gl is a suite of loaders for file formats focused on visualization of big data, including point clouds, 3D geometries, images, geospatial formats as well as tabular data.
 
-loaders.gl is part of the [vis.gl](https://vis.gl) ecosystem, and frameworks like [deck.gl](https://deck.gl) and [luma.gl](https://luma.gl) come pre-integrated with loaders.gl. However, all the provided loaders and writers are framework independent, and can be used with any application or framework.
+loaders.gl is part of the [vis.gl](https://vis.gl) ecosystem, and frameworks like [deck.gl](https://deck.gl) and [luma.gl](https://luma.gl) come pre-integrated with loaders.gl. However, all the provided loaders and writers are framework-independent, and can be used with any application or framework.
 
 ## Loaders
 

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -137,6 +137,18 @@
           ]
         },
         {
+          "title": "@loaders.gl/compression",
+          "entries": [
+            {"entry": "modules/compression/docs"},
+            {"entry": "modules/compression/docs/api-reference/zlib-deflate-transform"},
+            {"entry": "modules/compression/docs/api-reference/zlib-inflate-transform"},
+            {"entry": "modules/compression/docs/api-reference/lz4-deflate-transform"},
+            {"entry": "modules/compression/docs/api-reference/lz4-inflate-transform"},
+            {"entry": "modules/compression/docs/api-reference/zstd-deflate-transform"},
+            {"entry": "modules/compression/docs/api-reference/zstd-inflate-transform"}
+          ]
+        },
+        {
           "title": "@loaders.gl/draco",
           "entries": [
             {"entry": "modules/draco/docs"}

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -4,7 +4,15 @@
 
 Target Release Date: TBD (alpha releases are available)
 
-This release brings a new Shapefile loader, support for binary output from geospatial loaders, and a range of improvements supporting loaders.gl integration with kepler.gl, a major geospatial application.
+This release brings a new Shapefile loader, compression codecs (Zlib, LZ4, Zstandard), support for binary output from geospatial loaders, and a range of improvements supporting loaders.gl integration with kepler.gl, a major geospatial application.
+
+**@loaders.gl/shapefile** (NEW)
+
+- A new loader for the ESRI Shapefile format has been added. It loads `.SHP` and (if available) `.DBF`, `.CPG` and `.PRJ` files and returns a geojson like geometry.
+
+**@loaders.gl/compression** (NEW)
+
+- A new module with compression/decompression "transforms" for compression codecs (Zlib, LZ4, Zstandard). As always, these work reliably in both the browser and Node.
 
 **@loaders.gl/core**
 
@@ -17,10 +25,6 @@ This release brings a new Shapefile loader, support for binary output from geosp
 
 - `fetch` polyfill: Files with `.gz` extension are automatically decompressed with gzip. The extension reported in the `fetch` response has the `.gz` extension removed.
 - `fetch` polyfill: Improved robustness and error handling in Node.js when opening unreadable or non-existent files. Underlying errors (`ENOEXIST`, `EISDIR` etc) are now caught and reported in `Response.statusText`.
-
-**@loaders.gl/shapefile** (NEW)
-
-- A new loader for the ESRI Shapefile format has been added. It loads `.SHP` and (if available) `.DBF`, `.CPG` and `.PRJ` files and returns a geojson like geometry.
 
 **@loaders.gl/json**
 

--- a/modules/basis/README.md
+++ b/modules/basis/README.md
@@ -1,6 +1,6 @@
 # @loaders.gl/basis
 
-[loaders.gl](https://loaders.gl/docs) is a collection of framework independent 3D and geospatial parsers and encoders.
+[loaders.gl](https://loaders.gl/docs) is a collection of framework-independent 3D and geospatial parsers and encoders.
 
 This module contains loader for [basis universal textures](https://github.com/BinomialLLC/basis_universal).
 

--- a/modules/compression/README.md
+++ b/modules/compression/README.md
@@ -1,0 +1,5 @@
+# @loaders.gl/compression
+
+This module contains compression/decompression "transforms" for loaders.gl, a collection of framework independent 3D and geospatial loaders (parsers).
+
+For documentation please visit the [website](https://loaders.gl).

--- a/modules/compression/README.md
+++ b/modules/compression/README.md
@@ -1,5 +1,5 @@
 # @loaders.gl/compression
 
-This module contains compression/decompression "transforms" for loaders.gl, a collection of framework independent 3D and geospatial loaders (parsers).
+This module contains compression/decompression "transforms" for loaders.gl, a collection of framework-independent 3D and geospatial loaders (parsers).
 
 For documentation please visit the [website](https://loaders.gl).

--- a/modules/compression/docs/README.md
+++ b/modules/compression/docs/README.md
@@ -4,7 +4,7 @@
   <img src="https://img.shields.io/badge/From-v2.3-blue.svg?style=flat-square" alt="From-v2.3" /> 
 </p>
 
-The `@loaders.gl/decompress` module provides a small selection of lossless, legally unencumbered compression/decompression (aka deflate/inflate) "transforms" that work as plugins for loaders.gl
+The `@loaders.gl/compression` module provides a small selection of lossless, legally unencumbered compression/decompression (aka deflate/inflate) "transforms" that work as plugins for loaders.gl
 
 ## Compression Formats
 

--- a/modules/compression/docs/README.md
+++ b/modules/compression/docs/README.md
@@ -1,0 +1,28 @@
+# Overview
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v2.3-blue.svg?style=flat-square" alt="From-v2.3" /> 
+</p>
+
+The `@loaders.gl/decompress` module provides a small selection of lossless, legally unencumbered compression/decompression (aka deflate/inflate) "transforms" that work as plugins for loaders.gl
+
+## Compression Formats
+
+| Format                                        | Intended usage              | Notes                                                   |
+| --------------------------------------------- | --------------------------- | ------------------------------------------------------- |
+| [zlib](https://zlib.net/)                     | gzip(`.gz`) and Zip(`.zip`) | Essentially the `deflate' method in PKWARE's PKZIP 2.x) |
+| [lz4](https://github.com/lz4/lz4)             | Arrow Feather               | Optimized for speed (real-time compression)             |
+| [Zstandard](https://facebook.github.io/zstd/) | Arrow Feather               | Optimized for speed (real-time compression)             |
+
+## Decompression API
+
+The API offers "transforms" that can inflate/deflate data.
+
+| Transforms                                                                              | Sync | Description                      |
+| --------------------------------------------------------------------------------------- | ---- | -------------------------------- |
+| [`ZlibDeflateTransform`](modules/compression/docs/api-reference/zlib-deflate-transform) | Y    | Compress using Zlib codec        |
+| [`ZlibInflateTransform`](modules/compression/docs/api-reference/zlib-inflate-transform) | Y    | Decompress using Zlib codec      |
+| [`LZ4DeflateTransform`](modules/compression/docs/api-reference/lz4-deflate-transform)   | Y    | Compress using LZ4 codec         |
+| [`LZ4InflateTransform`](modules/compression/docs/api-reference/lz4-inflate-transform)   | Y    | Decompress using LZ4 codec       |
+| [`ZstdDeflateTransform`](modules/compression/docs/api-reference/lz4-deflate-transform)  | N    | Compress using Zstandard codec   |
+| [`ZstdInflateTransform`](modules/compression/docs/api-reference/lz4-inflate-transform)  | N    | Decompress using Zstandard codec |

--- a/modules/compression/docs/api-reference/lz4-deflate-transform.md
+++ b/modules/compression/docs/api-reference/lz4-deflate-transform.md
@@ -1,0 +1,11 @@
+# LZ4DeflateTransform
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v2.3-blue.svg?style=flat-square" alt="From-v2.3" /> 
+</p>
+
+## Static Methods
+
+#### `LZ4DeflateTransform.deflate(data: ArrayBuffer, options?: object): Promise<ArrayBuffer>`
+
+#### `LZ4DeflateTransform.deflateSync(data: ArrayBuffer, options?: object): ArrayBuffer`

--- a/modules/compression/docs/api-reference/lz4-inflate-transform.md
+++ b/modules/compression/docs/api-reference/lz4-inflate-transform.md
@@ -1,0 +1,13 @@
+# LZ4InflateTransform
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v2.3-blue.svg?style=flat-square" alt="From-v2.3" /> 
+</p>
+
+## Static Methods
+
+#### `LZ4InflateTransform.deflate(data: ArrayBuffer, options?: object): Promise<ArrayBuffer>`
+
+#### `LZ4InflateTransform.deflateSync(data: ArrayBuffer, options?: object): ArrayBuffer`
+
+Note: options are passed through to the underlying `pako` library.

--- a/modules/compression/docs/api-reference/lz4-inflate-transform.md
+++ b/modules/compression/docs/api-reference/lz4-inflate-transform.md
@@ -6,8 +6,8 @@
 
 ## Static Methods
 
-#### `LZ4InflateTransform.deflate(data: ArrayBuffer, options?: object): Promise<ArrayBuffer>`
+#### `LZ4InflateTransform.inflate(data: ArrayBuffer, options?: object): Promise<ArrayBuffer>`
 
-#### `LZ4InflateTransform.deflateSync(data: ArrayBuffer, options?: object): ArrayBuffer`
+#### `LZ4InflateTransform.inflateSync(data: ArrayBuffer, options?: object): ArrayBuffer`
 
 Note: options are passed through to the underlying `pako` library.

--- a/modules/compression/docs/api-reference/zlib-deflate-transform.md
+++ b/modules/compression/docs/api-reference/zlib-deflate-transform.md
@@ -1,0 +1,13 @@
+# ZlibDeflateTransform
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v2.3-blue.svg?style=flat-square" alt="From-v2.3" /> 
+</p>
+
+## Static Methods
+
+#### `ZlibDeflateTransform.deflate(data: ArrayBuffer, options?: object): Promise<ArrayBuffer>`
+
+#### `ZlibDeflateTransform.deflateSync(data: ArrayBuffer, options?: object): ArrayBuffer`
+
+Note: options are passed through to the underlying `pako` library.

--- a/modules/compression/docs/api-reference/zlib-inflate-transform.md
+++ b/modules/compression/docs/api-reference/zlib-inflate-transform.md
@@ -6,8 +6,8 @@
 
 ## Static Methods
 
-### `ZlibInflateTransform.deflate(data: ArrayBuffer, options?: object): Promise<ArrayBuffer>`
+### `ZlibInflateTransform.inflate(data: ArrayBuffer, options?: object): Promise<ArrayBuffer>`
 
-### `ZlibInflateTransform.deflateSync(data: ArrayBuffer, options?: object): ArrayBuffer`
+### `ZlibInflateTransform.inflateSync(data: ArrayBuffer, options?: object): ArrayBuffer`
 
 Note: options are passed through to the underlying `pako` library.

--- a/modules/compression/docs/api-reference/zlib-inflate-transform.md
+++ b/modules/compression/docs/api-reference/zlib-inflate-transform.md
@@ -1,0 +1,13 @@
+# ZlibInflateTransform
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v2.3-blue.svg?style=flat-square" alt="From-v2.3" /> 
+</p>
+
+## Static Methods
+
+### `ZlibInflateTransform.deflate(data: ArrayBuffer, options?: object): Promise<ArrayBuffer>`
+
+### `ZlibInflateTransform.deflateSync(data: ArrayBuffer, options?: object): ArrayBuffer`
+
+Note: options are passed through to the underlying `pako` library.

--- a/modules/compression/docs/api-reference/zstd-deflate-transform.md
+++ b/modules/compression/docs/api-reference/zstd-deflate-transform.md
@@ -1,0 +1,9 @@
+# ZstdDeflateTransform
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v2.3-blue.svg?style=flat-square" alt="From-v2.3" /> 
+</p>
+
+## Static Methods
+
+#### `ZstdDeflateTransform.deflate(data: ArrayBuffer, options?: object): Promise<ArrayBuffer>`

--- a/modules/compression/docs/api-reference/zstd-inflate-transform.md
+++ b/modules/compression/docs/api-reference/zstd-inflate-transform.md
@@ -6,6 +6,6 @@
 
 ## Static Methods
 
-#### `ZstdInflateTransform.deflate(data: ArrayBuffer, options?: object): Promise<ArrayBuffer>`
+#### `ZstdInflateTransform.inflate(data: ArrayBuffer, options?: object): Promise<ArrayBuffer>`
 
-#### `ZstdInflateTransform.deflateSync(data: ArrayBuffer, options?: object): ArrayBuffer`
+#### `ZstdInflateTransform.inflateSync(data: ArrayBuffer, options?: object): ArrayBuffer`

--- a/modules/compression/docs/api-reference/zstd-inflate-transform.md
+++ b/modules/compression/docs/api-reference/zstd-inflate-transform.md
@@ -1,0 +1,11 @@
+# ZstdInflateTransform
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v2.3-blue.svg?style=flat-square" alt="From-v2.3" /> 
+</p>
+
+## Static Methods
+
+#### `ZstdInflateTransform.deflate(data: ArrayBuffer, options?: object): Promise<ArrayBuffer>`
+
+#### `ZstdInflateTransform.deflateSync(data: ArrayBuffer, options?: object): ArrayBuffer`

--- a/modules/compression/package.json
+++ b/modules/compression/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@loaders.gl/compression",
+  "version": "2.3.0-alpha.6",
+  "description": "Decompression and compression plugins for loaders.gl",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/visgl/loaders.gl"
+  },
+  "keywords": [
+    "webgl",
+    "loader",
+    "3d",
+    "mesh",
+    "point cloud"
+  ],
+  "types": "src/index.d.ts",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
+  "esnext": "dist/es6/index.js",
+  "sideEffects": false,
+  "files": [
+    "src",
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "pre-build": "npm run build-bundle && npm run build-bundle -- --env.dev",
+    "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.3.1",
+    "@loaders.gl/loader-utils": "2.3.0-alpha.6",
+    "pako": "^1.0.11",
+    "lz4js": "^0.2.0",
+    "zstd-codec": "^0.1"
+  }
+}

--- a/modules/compression/src/bundle.js
+++ b/modules/compression/src/bundle.js
@@ -1,0 +1,7 @@
+/* global window, global */
+const moduleExports = require('./index');
+const _global = typeof window === 'undefined' ? global : window;
+// @ts-ignore
+_global.loaders = _global.loaders || {};
+// @ts-ignore
+module.exports = Object.assign(_global.loaders, moduleExports);

--- a/modules/compression/src/index.d.ts
+++ b/modules/compression/src/index.d.ts
@@ -1,0 +1,11 @@
+// Zlib (via Pako)
+export {default as ZlibDeflateTransform} from './lib/zlib/zlib-deflate-transform';
+export {default as ZlibInflateTransform} from './lib/zlib/zlib-inflate-transform';
+
+// LZ4
+export {default as LZ4DeflateTransform} from './lib/lz4/lz4-deflate-transform';
+export {default as LZ4InflateTransform} from './lib/lz4/lz4-inflate-transform';
+
+// Zstd
+export {default as ZstdDeflateTransform} from './lib/zstd/zstd-deflate-transform';
+export {default as ZstdInflateTransform} from './lib/zstd/zstd-inflate-transform';

--- a/modules/compression/src/index.js
+++ b/modules/compression/src/index.js
@@ -1,0 +1,8 @@
+export {default as ZlibDeflateTransform} from './lib/zlib/zlib-deflate-transform';
+export {default as ZlibInflateTransform} from './lib/zlib/zlib-inflate-transform';
+
+export {default as LZ4DeflateTransform} from './lib/lz4/lz4-deflate-transform';
+export {default as LZ4InflateTransform} from './lib/lz4/lz4-inflate-transform';
+
+export {default as ZstdDeflateTransform} from './lib/zstd/zstd-deflate-transform';
+export {default as ZstdInflateTransform} from './lib/zstd/zstd-inflate-transform';

--- a/modules/compression/src/lib/lz4/lz4-deflate-transform.d.ts
+++ b/modules/compression/src/lib/lz4/lz4-deflate-transform.d.ts
@@ -1,0 +1,12 @@
+// import pako from 'pako';
+
+/**
+ * A transform that LZ4 compresses / deflates input bytes
+ */
+export default class LZ4DeflateTransform {
+  /**
+   * Atomic deflate
+   */
+  static deflate(input: ArrayBuffer, options?: object): Promise<ArrayBuffer>;
+  static deflateSync(input: ArrayBuffer, options?: object): ArrayBuffer;
+}

--- a/modules/compression/src/lib/lz4/lz4-deflate-transform.js
+++ b/modules/compression/src/lib/lz4/lz4-deflate-transform.js
@@ -1,0 +1,13 @@
+import lz4 from 'lz4js';
+
+export default class LZ4DeflateTransform {
+  static async deflate(input, options) {
+    return LZ4DeflateTransform.deflateSync(input, options);
+  }
+
+  static deflateSync(input, options) {
+    const inputArray = new Uint8Array(input);
+    const output = lz4.compress(inputArray);
+    return output.buffer;
+  }
+}

--- a/modules/compression/src/lib/lz4/lz4-inflate-transform.d.ts
+++ b/modules/compression/src/lib/lz4/lz4-inflate-transform.d.ts
@@ -1,7 +1,7 @@
 /**
  * A transform that decompresses / inflates LZ4 compressed input bytes
  */
-export default class LZ4InlateTransform {
+export default class LZ4InflateTransform {
   /**
    * Atomic inflate
    */

--- a/modules/compression/src/lib/lz4/lz4-inflate-transform.d.ts
+++ b/modules/compression/src/lib/lz4/lz4-inflate-transform.d.ts
@@ -1,0 +1,10 @@
+/**
+ * A transform that decompresses / inflates LZ4 compressed input bytes
+ */
+export default class LZ4InlateTransform {
+  /**
+   * Atomic inflate
+   */
+  static inflate(input: ArrayBuffer, options?: object): Promise<ArrayBuffer>;
+  static inflateSync(input: ArrayBuffer, options?: object): ArrayBuffer;
+}

--- a/modules/compression/src/lib/lz4/lz4-inflate-transform.js
+++ b/modules/compression/src/lib/lz4/lz4-inflate-transform.js
@@ -1,0 +1,13 @@
+import lz4 from 'lz4js';
+
+export default class LZ4InflateTransform {
+  static async inflate(input, options) {
+    return LZ4InflateTransform.inflateSync(input, options);
+  }
+
+  static inflateSync(input, options) {
+    const inputArray = new Uint8Array(input);
+    const output = lz4.decompress(inputArray);
+    return output.buffer;
+  }
+}

--- a/modules/compression/src/lib/zlib/zlib-deflate-transform.d.ts
+++ b/modules/compression/src/lib/zlib/zlib-deflate-transform.d.ts
@@ -1,0 +1,10 @@
+/**
+ * A transform that incrementally zlib compresses / deflates input byte chunks
+ */
+export default class ZlibDeflateTransform {
+  /**
+   * Deflate
+   */
+  static deflate(input: ArrayBuffer, options?: object): Promise<ArrayBuffer>;
+  static deflateSync(input: ArrayBuffer, options?: object): ArrayBuffer;
+}

--- a/modules/compression/src/lib/zlib/zlib-deflate-transform.js
+++ b/modules/compression/src/lib/zlib/zlib-deflate-transform.js
@@ -1,0 +1,13 @@
+import pako from 'pako';
+
+export default class ZlibDeflateTransform {
+  static async deflate(input, options) {
+    return ZlibDeflateTransform.deflateSync(input, options);
+  }
+
+  static deflateSync(input, options) {
+    const uint8Array = new Uint8Array(input);
+    const output = pako.deflate(uint8Array, options);
+    return output.buffer;
+  }
+}

--- a/modules/compression/src/lib/zlib/zlib-inflate-transform.d.ts
+++ b/modules/compression/src/lib/zlib/zlib-inflate-transform.d.ts
@@ -1,0 +1,10 @@
+/**
+ * A transform that incrementally decompresses / inflates zlib compressed input
+ */
+export default class ZlibInflateTransform {
+  /**
+   * Inflate
+   */
+  static inflate(input: ArrayBuffer, options?: object): Promise<ArrayBuffer>;
+  static inflateSync(input: ArrayBuffer, options?: object): ArrayBuffer;
+}

--- a/modules/compression/src/lib/zlib/zlib-inflate-transform.js
+++ b/modules/compression/src/lib/zlib/zlib-inflate-transform.js
@@ -1,0 +1,13 @@
+import pako from 'pako';
+
+export default class ZlibInflateTransform {
+  static async inflate(input, options) {
+    return ZlibInflateTransform.inflateSync(input, options);
+  }
+
+  static inflateSync(input, options) {
+    const compressed = new Uint8Array(input);
+    const output = pako.inflate(compressed, options);
+    return output.buffer;
+  }
+}

--- a/modules/compression/src/lib/zstd/zstd-deflate-transform.d.ts
+++ b/modules/compression/src/lib/zstd/zstd-deflate-transform.d.ts
@@ -1,0 +1,9 @@
+/**
+ * A transform that Zstd compresses / deflates input byte chunks
+ */
+export default class ZstdDeflateTransform {
+  /**
+   * Atomic deflate convenience
+   */
+  static deflate(input: ArrayBuffer, options?: object): Promise<ArrayBuffer>;
+}

--- a/modules/compression/src/lib/zstd/zstd-deflate-transform.js
+++ b/modules/compression/src/lib/zstd/zstd-deflate-transform.js
@@ -1,0 +1,17 @@
+import {ZstdCodec} from 'zstd-codec';
+
+export default class ZstdDeflateTransform {
+  static deflate(input, options) {
+    const inputArray = new Uint8Array(input);
+
+    return new Promise(resolve => {
+      ZstdCodec.run(zstd => {
+        const simple = new zstd.Simple();
+        const output = simple.compress(inputArray);
+        // var ddict = new zstd.Dict.Decompression(dictData);
+        // var jsonBytes = simple.decompressUsingDict(jsonZstData, ddict);
+        resolve(output.buffer);
+      });
+    });
+  }
+}

--- a/modules/compression/src/lib/zstd/zstd-inflate-transform.d.ts
+++ b/modules/compression/src/lib/zstd/zstd-inflate-transform.d.ts
@@ -1,0 +1,9 @@
+/**
+ * A transform that decompresses / inflates Zstd compressed input byte chunks
+ */
+export default class ZstdInlateTransform {
+  /**
+   * Atomic deflate convenience
+   */
+  static inflate(input: ArrayBuffer, options?: object): Promise<ArrayBuffer>;
+}

--- a/modules/compression/src/lib/zstd/zstd-inflate-transform.d.ts
+++ b/modules/compression/src/lib/zstd/zstd-inflate-transform.d.ts
@@ -1,7 +1,7 @@
 /**
  * A transform that decompresses / inflates Zstd compressed input byte chunks
  */
-export default class ZstdInlateTransform {
+export default class ZstdInflateTransform {
   /**
    * Atomic deflate convenience
    */

--- a/modules/compression/src/lib/zstd/zstd-inflate-transform.js
+++ b/modules/compression/src/lib/zstd/zstd-inflate-transform.js
@@ -1,0 +1,15 @@
+import {ZstdCodec} from 'zstd-codec';
+
+export default class ZstdInflateTransform {
+  static inflate(input, options) {
+    const inputArray = new Uint8Array(input);
+
+    return new Promise(resolve => {
+      ZstdCodec.run(zstd => {
+        const simple = new zstd.Simple();
+        const output = simple.decompress(inputArray);
+        resolve(output.buffer);
+      });
+    });
+  }
+}

--- a/modules/compression/src/types.d.ts
+++ b/modules/compression/src/types.d.ts
@@ -1,0 +1,4 @@
+export interface IncrementalTransform {
+  write(chunk: any): any;
+  end(): any;
+}

--- a/modules/compression/test/index.js
+++ b/modules/compression/test/index.js
@@ -1,0 +1,3 @@
+import './zlib/zlib.spec';
+import './lz4/lz4.spec';
+import './zstd/zstd.spec';

--- a/modules/compression/test/lz4/lz4.spec.js
+++ b/modules/compression/test/lz4/lz4.spec.js
@@ -1,0 +1,22 @@
+import test from 'tape-promise/tape';
+import {LZ4DeflateTransform, LZ4InflateTransform} from '@loaders.gl/compression';
+import {generateRandomArrayBuffer, compareArrayBuffers} from '../utils/test-utils';
+
+const SIZE = 100 * 1000;
+const binaryData = generateRandomArrayBuffer({size: SIZE});
+const repeatedData = generateRandomArrayBuffer({size: SIZE / 10, repetitions: 10});
+
+test('lz4#defaults', t => {
+  let deflatedData = LZ4DeflateTransform.deflateSync(binaryData);
+  let inflatedData = LZ4InflateTransform.inflateSync(deflatedData);
+  t.ok(compareArrayBuffers(binaryData, inflatedData), 'deflate/inflate default options');
+
+  t.equal(repeatedData.byteLength, 100000, 'Repeated data length is correct');
+  deflatedData = LZ4DeflateTransform.deflateSync(repeatedData);
+  t.equal(deflatedData.byteLength, 10422, 'Repeated data compresses well');
+  inflatedData = LZ4InflateTransform.inflateSync(deflatedData);
+  t.equal(inflatedData.byteLength, 100000, 'Inflated data length is correct');
+  t.ok(compareArrayBuffers(repeatedData, inflatedData), 'deflate/inflate default options');
+
+  t.end();
+});

--- a/modules/compression/test/utils/random-number-generator.js
+++ b/modules/compression/test/utils/random-number-generator.js
@@ -1,0 +1,42 @@
+/**
+ * Seedable Random number generator
+ * Useful for testing as it can generated identical sequences on each run
+ * @see https://stackoverflow.com/questions/424292/seedable-javascript-random-number-generator
+ */
+export default class RandomNumberGenerator {
+  constructor(seed = 1000) {
+    // LCG using GCC's constants
+    this.m = 0x80000000; // 2**31;
+    this.a = 1103515245;
+    this.c = 12345;
+    this.state = seed ? seed : Math.floor(Math.random() * (this.m - 1));
+  }
+
+  getInt() {
+    this.state = (this.a * this.state + this.c) % this.m;
+    return this.state;
+  }
+
+  /**
+   * returns in range [0,1]
+   */
+  getFloat() {
+    return this.getInt() / (this.m - 1);
+  }
+  /**
+   * returns in range [start, end): including start, excluding end
+   * can't modulu getInt because of weak randomness in lower bits
+   * @param {number} start
+   * @param {number} end
+   * @returns {number}
+   */
+  getRange(start, end) {
+    const rangeSize = end - start;
+    const randomUnder1 = this.getInt() / this.m;
+    return start + Math.floor(randomUnder1 * rangeSize);
+  }
+
+  choice(array) {
+    return array[this.getRange(0, array.length)];
+  }
+}

--- a/modules/compression/test/utils/test-utils.js
+++ b/modules/compression/test/utils/test-utils.js
@@ -1,0 +1,33 @@
+// Helper functions
+
+import {concatenateArrayBuffers} from '@loaders.gl/loader-utils';
+import RandomNumberGenerator from './random-number-generator';
+
+const random = new RandomNumberGenerator();
+
+export function generateRandomArrayBuffer({size, repetitions = 1}) {
+  const binaryArray = new Uint8Array(size);
+
+  for (let i = binaryArray.byteLength - 1; i >= 0; i--) {
+    binaryArray[i] = random.getRange(0, 256) & 0xff;
+  }
+
+  const repeatedBuffers = new Array(repetitions).fill(binaryArray);
+  const arrayBuffer = concatenateArrayBuffers(...repeatedBuffers);
+
+  return arrayBuffer;
+}
+
+export function compareArrayBuffers(a, b) {
+  a = new Uint8Array(a);
+  b = new Uint8Array(b);
+  if (a.byteLength !== b.byteLength) {
+    return false;
+  }
+  for (let i = 0, l = a.byteLength; i < l; i++) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/modules/compression/test/zlib/zlib.spec.js
+++ b/modules/compression/test/zlib/zlib.spec.js
@@ -1,0 +1,50 @@
+import test from 'tape-promise/tape';
+import {ZlibDeflateTransform, ZlibInflateTransform} from '@loaders.gl/compression';
+import {generateRandomArrayBuffer, compareArrayBuffers} from '../utils/test-utils';
+
+const SIZE = 100 * 1000;
+const binaryData = generateRandomArrayBuffer({size: SIZE});
+const repeatedData = generateRandomArrayBuffer({size: SIZE / 10, repetitions: 10});
+
+test('lz4#defaults', t => {
+  let deflatedData = ZlibDeflateTransform.deflateSync(binaryData);
+  let inflatedData = ZlibInflateTransform.inflateSync(deflatedData);
+  t.ok(compareArrayBuffers(binaryData, inflatedData), 'deflate/inflate default options');
+
+  t.equal(repeatedData.byteLength, 100000, 'Repeated data length is correct');
+  deflatedData = ZlibDeflateTransform.deflateSync(repeatedData);
+  t.equal(deflatedData.byteLength, 10904, 'Repeated data compresses well');
+  inflatedData = ZlibInflateTransform.inflateSync(deflatedData);
+  t.equal(inflatedData.byteLength, 100000, 'Inflated data length is correct');
+  t.ok(compareArrayBuffers(repeatedData, inflatedData), 'deflate/inflate default options');
+
+  t.end();
+});
+
+test('zlib#0', t => {
+  const deflatedData = ZlibDeflateTransform.deflateSync(binaryData, {level: 0});
+  const inflatedData = ZlibInflateTransform.inflateSync(deflatedData);
+  t.ok(compareArrayBuffers(binaryData, inflatedData), 'deflate/inflate level 0');
+  t.end();
+});
+
+test('zlib#1', t => {
+  const deflatedData = ZlibDeflateTransform.deflateSync(binaryData, {level: 1});
+  const inflatedData = ZlibInflateTransform.inflateSync(deflatedData);
+  t.ok(compareArrayBuffers(binaryData, inflatedData), 'deflate/inflate level 1');
+  t.end();
+});
+
+test('zlib#4', t => {
+  const deflatedData = ZlibDeflateTransform.deflateSync(binaryData, {level: 4});
+  const inflatedData = ZlibInflateTransform.inflateSync(deflatedData);
+  t.ok(compareArrayBuffers(binaryData, inflatedData), 'deflate/inflate level 4');
+  t.end();
+});
+
+test('zlib#6', t => {
+  const deflatedData = ZlibDeflateTransform.deflateSync(binaryData, {level: 6});
+  const inflatedData = ZlibInflateTransform.inflateSync(deflatedData);
+  t.ok(compareArrayBuffers(binaryData, inflatedData), 'deflate/inflate level 6');
+  t.end();
+});

--- a/modules/compression/test/zstd/zstd.spec.js
+++ b/modules/compression/test/zstd/zstd.spec.js
@@ -1,0 +1,22 @@
+import test from 'tape-promise/tape';
+import {ZstdDeflateTransform, ZstdInflateTransform} from '@loaders.gl/compression';
+import {generateRandomArrayBuffer, compareArrayBuffers} from '../utils/test-utils';
+
+const SIZE = 100 * 1000;
+const binaryData = generateRandomArrayBuffer({size: SIZE});
+const repeatedData = generateRandomArrayBuffer({size: SIZE / 10, repetitions: 10});
+
+test('lz4#defaults', async t => {
+  let deflatedData = await ZstdDeflateTransform.deflate(binaryData);
+  let inflatedData = await ZstdInflateTransform.inflate(deflatedData);
+  t.ok(compareArrayBuffers(binaryData, inflatedData), 'deflate/inflate default options');
+
+  t.equal(repeatedData.byteLength, 100000, 'Repeated data length is correct');
+  deflatedData = await ZstdDeflateTransform.deflate(repeatedData);
+  t.equal(deflatedData.byteLength, 10025, 'Repeated data compresses well');
+  inflatedData = await ZstdInflateTransform.inflate(deflatedData);
+  t.equal(inflatedData.byteLength, 100000, 'Inflated data length is correct');
+  t.ok(compareArrayBuffers(repeatedData, inflatedData), 'deflate/inflate default options');
+
+  t.end();
+});

--- a/modules/core/README.md
+++ b/modules/core/README.md
@@ -1,5 +1,5 @@
 # @loaders.gl/core
 
-This module contains shared utilities for loaders.gl, a collection of framework independent 3D and geospatial loaders (parsers).
+This module contains shared utilities for loaders.gl, a collection of framework-independent 3D and geospatial loaders (parsers).
 
 For documentation please visit the [website](https://loaders.gl).

--- a/modules/csv/README.md
+++ b/modules/csv/README.md
@@ -2,4 +2,4 @@
 
 This module contains a table loader for the CSV and DSV formats.
 
-[loaders.gl](https://loaders.gl/docs) is a collection of framework independent visualization-focused loaders (parsers).
+[loaders.gl](https://loaders.gl/docs) is a collection of framework-independent visualization-focused loaders (parsers).

--- a/modules/draco/README.md
+++ b/modules/draco/README.md
@@ -1,6 +1,6 @@
 # @loaders.gl/draco
 
-[loaders.gl](https://loaders.gl/docs) is a collection of framework independent 3D and geospatial parsers and encoders.
+[loaders.gl](https://loaders.gl/docs) is a collection of framework-independent 3D and geospatial parsers and encoders.
 
 This module contains loader and writer for Draco compressed meshes and point clouds.
 

--- a/modules/gis/README.md
+++ b/modules/gis/README.md
@@ -2,4 +2,4 @@
 
 This module contains helper classes for the GIS category of loaders.
 
-[loaders.gl](https://loaders.gl/docs) is a collection of framework independent visualization-focused loaders (parsers).
+[loaders.gl](https://loaders.gl/docs) is a collection of framework-independent visualization-focused loaders (parsers).

--- a/modules/gltf/README.md
+++ b/modules/gltf/README.md
@@ -1,6 +1,6 @@
 # @loaders.gl/gltf
 
-[loaders.gl](https://loaders.gl/docs) is a collection of framework independent 3D and geospatial parsers and encoders.
+[loaders.gl](https://loaders.gl/docs) is a collection of framework-independent 3D and geospatial parsers and encoders.
 
 This module contains loader and writers for the glTF format.
 

--- a/modules/images/README.md
+++ b/modules/images/README.md
@@ -1,6 +1,6 @@
 # @loaders.gl/images
 
-[loaders.gl](https://loaders.gl/docs) is a collection of framework independent 3D and geospatial parsers and encoders.
+[loaders.gl](https://loaders.gl/docs) is a collection of framework-independent 3D and geospatial parsers and encoders.
 
 This module contains loader and writers for images that follow loaders.gl conventions and work under both node and browser.
 

--- a/modules/json/README.md
+++ b/modules/json/README.md
@@ -2,4 +2,4 @@
 
 This module contains a table loader for the JSON and line delimited JSON formats.
 
-[loaders.gl](https://loaders.gl/docs) is a collection of framework independent visualization-focused loaders (parsers).
+[loaders.gl](https://loaders.gl/docs) is a collection of framework-independent visualization-focused loaders (parsers).

--- a/modules/kml/README.md
+++ b/modules/kml/README.md
@@ -1,6 +1,6 @@
 # @loaders.gl/kml
 
-[loaders.gl](https://loaders.gl/docs) is a collection of framework independent 3D and geospatial parsers and encoders.
+[loaders.gl](https://loaders.gl/docs) is a collection of framework-independent 3D and geospatial parsers and encoders.
 
 This module contains loaders for the KML format.
 

--- a/modules/las/README.md
+++ b/modules/las/README.md
@@ -1,6 +1,6 @@
 # @loaders.gl/las
 
-[loaders.gl](https://loaders.gl/docs) is a collection of framework independent 3D and geospatial parsers and encoders.
+[loaders.gl](https://loaders.gl/docs) is a collection of framework-independent 3D and geospatial parsers and encoders.
 
 This module contains loaders and writers for the LAS and LAZ formats.
 

--- a/modules/loader-utils/README.md
+++ b/modules/loader-utils/README.md
@@ -1,5 +1,5 @@
 # @loaders.gl/core
 
-This module contains shared utilities for loaders.gl, a collection of framework independent 3D and geospatial loaders (parsers).
+This module contains shared utilities for loaders.gl, a collection of framework-independent 3D and geospatial loaders (parsers).
 
 For documentation please visit the [website](https://loaders.gl).

--- a/modules/loader-utils/src/index.d.ts
+++ b/modules/loader-utils/src/index.d.ts
@@ -35,6 +35,7 @@ export {toArrayBuffer, toBuffer} from './lib/binary-utils/binary-utils';
 export {
   padTo4Bytes,
   copyToArray,
+  concatenateArrayBuffers,
   copyArrayBuffer,
   getZeroOffsetArrayBuffer
 } from './lib/binary-utils/memory-copy-utils';

--- a/modules/loader-utils/src/index.js
+++ b/modules/loader-utils/src/index.js
@@ -32,6 +32,7 @@ export {toArrayBuffer, toBuffer} from './lib/binary-utils/binary-utils';
 export {
   padTo4Bytes,
   copyToArray,
+  concatenateArrayBuffers,
   copyArrayBuffer,
   getZeroOffsetArrayBuffer
 } from './lib/binary-utils/memory-copy-utils';

--- a/modules/loader-utils/src/lib/binary-utils/memory-copy-utils.d.ts
+++ b/modules/loader-utils/src/lib/binary-utils/memory-copy-utils.d.ts
@@ -13,14 +13,11 @@ export function padTo4Bytes(byteLength);
 export function getZeroOffsetArrayBuffer(arrayBuffer, byteOffset, byteLength);
 
 /**
- * Concatenate two ArrayBuffers
- * @param source1 The first ArrayBuffer.
- * @param source2 The second ArrayBuffer.
+ * Concatenate a sequence of ArrayBuffers
  * @return A concatenated ArrayBuffer
  */
 export function concatenateArrayBuffers(
-  source1: ArrayBuffer | Uint8Array,
-  source2: ArrayBuffer | Uint8Array
+  ...sources: (ArrayBuffer | Uint8Array)[]
 ): ArrayBuffer;
 
 /**

--- a/modules/loader-utils/src/lib/binary-utils/memory-copy-utils.js
+++ b/modules/loader-utils/src/lib/binary-utils/memory-copy-utils.js
@@ -11,14 +11,28 @@ export function getZeroOffsetArrayBuffer(arrayBuffer, byteOffset, byteLength) {
   return arrayCopy.buffer;
 }
 
-// Concatenate two ArrayBuffers
-export function concatenateArrayBuffers(source1, source2) {
-  const sourceArray1 = source1 instanceof ArrayBuffer ? new Uint8Array(source1) : source1;
-  const sourceArray2 = source2 instanceof ArrayBuffer ? new Uint8Array(source2) : source2;
-  const temp = new Uint8Array(sourceArray1.byteLength + sourceArray2.byteLength);
-  temp.set(sourceArray1, 0);
-  temp.set(sourceArray2, sourceArray1.byteLength);
-  return temp.buffer;
+// Concatenate ArrayBuffers
+export function concatenateArrayBuffers(...sources) {
+  // Make sure all inputs are wrapped in typed arrays
+  const sourceArrays = sources.map(
+    source2 => (source2 instanceof ArrayBuffer ? new Uint8Array(source2) : source2)
+  );
+
+  // Get length of all inputs
+  const byteLength = sourceArrays.reduce((length, typedArray) => length + typedArray.byteLength, 0);
+
+  // Allocate array with space for all inputs
+  const result = new Uint8Array(byteLength);
+
+  // Copy the subarrays
+  let offset = 0;
+  for (const sourceArray of sourceArrays) {
+    result.set(sourceArray, offset);
+    offset += sourceArray.byteLength;
+  }
+
+  // We work with ArrayBuffers, discard the typed array wrapper
+  return result.buffer;
 }
 
 /* Creates a new Uint8Array based on two different ArrayBuffers

--- a/modules/loader-utils/test/lib/binary-utils/memory-copy-utils.spec.js
+++ b/modules/loader-utils/test/lib/binary-utils/memory-copy-utils.spec.js
@@ -1,5 +1,10 @@
 import test from 'tape-promise/tape';
-import {padTo4Bytes, copyArrayBuffer, copyToArray} from '@loaders.gl/loader-utils';
+import {
+  padTo4Bytes,
+  copyArrayBuffer,
+  copyToArray,
+  concatenateArrayBuffers
+} from '@loaders.gl/loader-utils';
 
 test('padTo4Bytes', t => {
   t.ok(padTo4Bytes, 'padTo4Bytes defined');
@@ -13,5 +18,25 @@ test('toBuffer', t => {
 
 test('copyToArray', t => {
   t.ok(copyToArray, 'copyToArray defined');
+  t.end();
+});
+
+test('concatenateArrayBuffers', t => {
+  const input1 = new Uint8Array([1, 2, 3]);
+  const input2 = new Uint8Array([4, 5, 6]);
+  const expected = new Uint8Array([1, 2, 3, 4, 5, 6]).buffer;
+
+  let result = concatenateArrayBuffers(input1, input2);
+  t.deepEquals(result, expected, 'types arrays concatenated as expected');
+
+  result = concatenateArrayBuffers(input1.buffer, input2.buffer);
+  t.deepEquals(result, expected, 'array buffers concatenated as expected');
+
+  result = concatenateArrayBuffers();
+  t.deepEquals(result, new ArrayBuffer(0), 'zero array buffers concatenated as expected');
+
+  result = concatenateArrayBuffers(input1);
+  t.deepEquals(result, input1.buffer, 'single array buffer concatenated as expected');
+
   t.end();
 });

--- a/modules/math/README.md
+++ b/modules/math/README.md
@@ -1,6 +1,6 @@
 # @loaders.gl/math (Experimental, Temporary)
 
-[loaders.gl](https://loaders.gl/docs) is a collection of framework independent 3D and geospatial parsers and encoders.
+[loaders.gl](https://loaders.gl/docs) is a collection of framework-independent 3D and geospatial parsers and encoders.
 
 This module contains math utilities for the `@loaders.gl3d-tiles` module. As they mature, these will likely be moved to a math framework (e.g. math.gl).
 

--- a/modules/mvt/README.md
+++ b/modules/mvt/README.md
@@ -2,4 +2,4 @@
 
 This module contains a geometry loader for Mapbox Vector Tiles (MVT).
 
-[loaders.gl](https://loaders.gl/docs) is a collection of framework independent visualization-focused loaders (parsers).
+[loaders.gl](https://loaders.gl/docs) is a collection of framework-independent visualization-focused loaders (parsers).

--- a/modules/obj/README.md
+++ b/modules/obj/README.md
@@ -1,6 +1,6 @@
 # @loaders.gl/obj
 
-[loaders.gl](https://loaders.gl/docs) is a collection of framework independent 3D and geospatial parsers and encoders.
+[loaders.gl](https://loaders.gl/docs) is a collection of framework-independent 3D and geospatial parsers and encoders.
 
 This module contains loader for the OBJ format.
 

--- a/modules/pcd/README.md
+++ b/modules/pcd/README.md
@@ -1,6 +1,6 @@
 # @loaders.gl/pcd
 
-[loaders.gl](https://loaders.gl/docs) is a collection of framework independent 3D and geospatial parsers and encoders.
+[loaders.gl](https://loaders.gl/docs) is a collection of framework-independent 3D and geospatial parsers and encoders.
 
 This module contains loaders for the PCD format.
 

--- a/modules/polyfills/README.md
+++ b/modules/polyfills/README.md
@@ -1,6 +1,6 @@
 # @loaders.gl/polyfills
 
-[loaders.gl](https://loaders.gl/docs) is a collection of framework independent 3D and geospatial parsers and encoders.
+[loaders.gl](https://loaders.gl/docs) is a collection of framework-independent 3D and geospatial parsers and encoders.
 
 This module contains polyfills for running on older browsers (mainly Edge and IE11) as well as Node.
 

--- a/modules/potree/README.md
+++ b/modules/potree/README.md
@@ -2,6 +2,6 @@
 
 This module contains loaders for the [potree](https://github.com/potree/potree) format.
 
-[loaders.gl](https://loaders.gl/docs) is a collection of framework independent 3D and geospatial loaders (parsers).
+[loaders.gl](https://loaders.gl/docs) is a collection of framework-independent 3D and geospatial loaders (parsers).
 
 For documentation please visit the [website](https://loaders.gl).

--- a/modules/shapefile/README.md
+++ b/modules/shapefile/README.md
@@ -2,4 +2,4 @@
 
 This module contains a geometry loader for the ESRI Shapefile format.
 
-[loaders.gl](https://loaders.gl/docs) is a collection of framework independent visualization-focused loaders (parsers).
+[loaders.gl](https://loaders.gl/docs) is a collection of framework-independent visualization-focused loaders (parsers).

--- a/modules/tables/README.md
+++ b/modules/tables/README.md
@@ -4,6 +4,6 @@ This module contains:
 
 - Classes and APIs for manipulating tabular data output from loaders.gl table category loaders (CSV, JSON, ...).
 
-[loaders.gl](https://loaders.gl/docs) is a collection of framework independent 3D and geospatial parsers and encoders.
+[loaders.gl](https://loaders.gl/docs) is a collection of framework-independent 3D and geospatial parsers and encoders.
 
 Please visit the [website](https://loaders.gl).

--- a/modules/terrain/README.md
+++ b/modules/terrain/README.md
@@ -1,6 +1,6 @@
 # @loaders.gl/terrain
 
-[loaders.gl](https://loaders.gl/docs) is a collection of framework independent 3D and geospatial parsers and encoders.
+[loaders.gl](https://loaders.gl/docs) is a collection of framework-independent 3D and geospatial parsers and encoders.
 
 This module reconstructs mesh surfaces from height map images, e.g. [Mapzen Terrain Tiles](https://github.com/tilezen/joerd/blob/master/docs/formats.md), which encodes elevation into R,G,B values.
 

--- a/modules/video/README.md
+++ b/modules/video/README.md
@@ -1,6 +1,6 @@
 # @loaders.gl/video
 
-[loaders.gl](https://loaders.gl/docs) is a collection of framework independent 3D and geospatial parsers and encoders.
+[loaders.gl](https://loaders.gl/docs) is a collection of framework-independent 3D and geospatial parsers and encoders.
 
 This module contains loader and writers for video that follow loaders.gl conventions and work under both node and browser.
 

--- a/modules/wkt/README.md
+++ b/modules/wkt/README.md
@@ -2,4 +2,4 @@
 
 This module contains a geometry loader for the Well-Known Text (WKT) and Well-Known Binary (WKB) formats.
 
-[loaders.gl](https://loaders.gl/docs) is a collection of framework independent visualization-focused loaders (parsers).
+[loaders.gl](https://loaders.gl/docs) is a collection of framework-independent visualization-focused loaders (parsers).

--- a/modules/zip/README.md
+++ b/modules/zip/README.md
@@ -1,6 +1,6 @@
 # @loaders.gl/zip
 
-[loaders.gl](https://loaders.gl/docs) is a collection of framework independent 3D and geospatial parsers and encoders.
+[loaders.gl](https://loaders.gl/docs) is a collection of framework-independent 3D and geospatial parsers and encoders.
 
 This module contains loaders and writers for the Zip Archive format.
 

--- a/test/aliases.js
+++ b/test/aliases.js
@@ -28,6 +28,7 @@ function makeAliases(basename = __dirname) {
     '@loaders.gl/3d-tiles/test': path.resolve(basename, '../modules/3d-tiles/test'),
     '@loaders.gl/arrow/test': path.resolve(basename, '../modules/arrow/test'),
     '@loaders.gl/basis/test': path.resolve(basename, '../modules/basis/test'),
+    '@loaders.gl/compression/test': path.resolve(basename, '../modules/compression/test'),
     '@loaders.gl/core/test': path.resolve(basename, '../modules/core/test'),
     '@loaders.gl/csv/test': path.resolve(basename, '../modules/csv/test'),
     '@loaders.gl/draco/test': path.resolve(basename, '../modules/draco/test'),

--- a/test/modules.js
+++ b/test/modules.js
@@ -75,5 +75,6 @@ if (TEST_TABLES) {
 
 // Archive Formats
 if (TEST_ARCHIVES) {
-  require('@loaders.gl/zip/test');
+  require('@loaders.gl/compression/test');
+  // require('@loaders.gl/zip/test');
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,10 +12,11 @@
     "noEmit": true,
     "resolveJsonModule": true,
     "baseUrl": ".",
-    "strict": true,
     "paths": {
       "@loaders.gl/core/*": ["modules/core/src/*"],
       "@loaders.gl/core/test": ["modules/core/test"],
+      "@loaders.gl/compression/*": ["modules/compression/src/*"],
+      "@loaders.gl/compression/test": ["modules/compression/test"],
       "@loaders.gl/loader-utils/*": ["modules/loader-utils/src/*"],
       "@loaders.gl/loader-utils/test": ["modules/loader-utils/test"],
       "@loaders.gl/polyfills/*": ["modules/polyfills/src/*"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -6689,6 +6689,11 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+lz4js@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/lz4js/-/lz4js-0.2.0.tgz#09f1a397cb2158f675146c3351dde85058cb322f"
+  integrity sha1-CfGjl8shWPZ1FGwzUd3oUFjLMi8=
+
 macos-release@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.3.0.tgz#eb1930b036c0800adebccd5f17bc4c12de8bb71f"
@@ -7848,7 +7853,7 @@ pad-left@^2.1.0:
   dependencies:
     repeat-string "^1.5.4"
 
-pako@~1.0.2, pako@~1.0.5:
+pako@^1.0.11, pako@~1.0.2, pako@~1.0.5:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
@@ -10861,3 +10866,8 @@ yauzl@^2.10.0:
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
+
+zstd-codec@^0.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/zstd-codec/-/zstd-codec-0.1.2.tgz#6a13b7e666d9066d5236cbab760862a44f2660a0"
+  integrity sha512-t1gdk33h1wT7YcBPebyGWGJTWodKsJVfDeVN0q2x/htPGLEX3BAuBvOFsU4W3BplbmTXwvH8c/TUZ/DPTXOFfg==


### PR DESCRIPTION
Add a new optional module with browser compatible compression codecs for Zlib, LZ4, Zstandard:
- Zlib for '.gz' files @isaacbrodsky @manassra 
- LZ4, Zstandard for Apache Arrow feather format @trxcllnt @isaacbrodsky 

This PR brings basic atomic encode/decode. Coming PR will add streaming encode/decode.