### PR TITLE
Fix name of indices returned from SHPLoader

### DIFF
--- a/modules/shapefile/src/lib/parse-geometry.js
+++ b/modules/shapefile/src/lib/parse-geometry.js
@@ -143,9 +143,19 @@ function parsePoly(view, offset, dim, type) {
 
   const positions = concatPositions(xyPositions, mPositions, zPositions);
 
+  if (type === 'LineString') {
+    return {
+      positions: {value: positions, size: dim},
+      pathIndices: {value: indices, size: 1},
+      type
+    };
+  }
+
   return {
     positions: {value: positions, size: dim},
-    indices: {value: indices, size: 1},
+    primitivePolygonIndices: {value: indices, size: 1},
+    // Shapefiles can only hold non-Multi-Polygons
+    polygonIndices: {value: new Uint16Array([0, nPoints]), size: 1},
     type
   };
 }

--- a/modules/shapefile/src/lib/parse-geometry.js
+++ b/modules/shapefile/src/lib/parse-geometry.js
@@ -143,6 +143,7 @@ function parsePoly(view, offset, dim, type) {
 
   const positions = concatPositions(xyPositions, mPositions, zPositions);
 
+  // parsePoly only accepts type = LineString or Polygon
   if (type === 'LineString') {
     return {
       positions: {value: positions, size: dim},
@@ -151,6 +152,7 @@ function parsePoly(view, offset, dim, type) {
     };
   }
 
+  // type is Polygon
   return {
     positions: {value: positions, size: dim},
     primitivePolygonIndices: {value: indices, size: 1},

--- a/modules/shapefile/src/shapefile-loader.js
+++ b/modules/shapefile/src/shapefile-loader.js
@@ -55,7 +55,7 @@ async function parseShapefile(arrayBuffer, options, context) {
   // Convert binary geometries to GeoJSON
   const geojsonGeometries = [];
   for (const geom of geometries) {
-    geojsonGeometries.push(binaryToGeoJson(geom));
+    geojsonGeometries.push(binaryToGeoJson(geom, geom.type, 'geometry'));
   }
 
   // parse properties

--- a/modules/shapefile/test/shp/parse-shp.spec.js
+++ b/modules/shapefile/test/shp/parse-shp.spec.js
@@ -42,7 +42,7 @@ test('Shapefile JS Polyline tests', async t => {
       // @ts-ignore
       t.deepEqual(output.geometries[i].positions, expBinary.positions);
       // @ts-ignore
-      t.deepEqual(output.geometries[i].indices, expBinary.pathIndices);
+      t.deepEqual(output.geometries[i].pathIndices, expBinary.pathIndices);
     }
   }
 
@@ -63,7 +63,7 @@ test('Shapefile JS Polygon tests', async t => {
       // @ts-ignore
       t.deepEqual(output.geometries[i].positions, expBinary.positions);
       // @ts-ignore
-      t.deepEqual(output.geometries[i].indices, expBinary.primitivePolygonIndices);
+      t.deepEqual(output.geometries[i].primitivePolygonIndices, expBinary.primitivePolygonIndices);
     }
   }
 


### PR DESCRIPTION
The SHP polyline parsing previously returned an `indices` key. According to the [binary format "spec"](https://github.com/visgl/loaders.gl/blob/master/modules/gis/docs/api-reference/geojson-to-binary.md#outputs) only `Point` output should have an `indices` key. `LineString` output should instead have a `pathIndices` key, and `Polygon` output should have both `polygonIndices` and `primitivePolygonIndices` keys.

The above alone fixes the binary-to-geojson's auto-deduction, since it sniffs for that index:
https://github.com/visgl/loaders.gl/blob/782ee05169c1c329b9a9a564e9a38c5e3113e938/modules/gis/src/lib/binary-to-geojson.js#L201-L211

But this PR also updates to pass the geometry type to `binaryToGeoJson` explicitly, so that no sniffing is needed.