### PR TITLE
json: rebuild json payload based on streamed json path

### DIFF
--- a/modules/json/src/index.ts
+++ b/modules/json/src/index.ts
@@ -8,3 +8,5 @@ export {
 // EXPERIMENTAL EXPORTS - WARNING: MAY BE REMOVED WIHTOUT NOTICE IN FUTURE RELEASES
 export {default as _JSONPath} from './lib/jsonpath/jsonpath';
 export {default as _ClarinetParser} from './lib/clarinet/clarinet';
+
+export {rebuildJsonObject as _rebuildJsonObject} from './lib/parse-json-in-batches';


### PR DESCRIPTION
Based on feedback from https://github.com/keplergl/kepler.gl/pull/1212.

Kepler is currently just using the streaming system to drive progress bars and remain interactive while parsing large files. It does yet not take advantage from the partial data delivery to start early processing or visualization of the data.

The final stitching of data gets quite complicated when supporting multiple jsonpaths and it makes sense that loaders.gl provides a utiliity to take care of this.

Still a WIP: This PR needs some test cases before it lands. Once it lands it could be back ported to 2.2.