### PR TITLE
Remove duplicate shapefile worker loader files

### DIFF
--- a/modules/shapefile/src/dbf-loader.worker.js
+++ b/modules/shapefile/src/dbf-loader.worker.js
@@ -1,4 +1,0 @@
-import {DBFLoader} from './dbf-loader';
-import {createWorker} from '@loaders.gl/loader-utils';
-
-createWorker(DBFLoader);

--- a/modules/shapefile/src/shp-loader.worker.js
+++ b/modules/shapefile/src/shp-loader.worker.js
@@ -1,4 +1,0 @@
-import {SHPLoader} from './shp-loader';
-import {createWorker} from '@loaders.gl/loader-utils';
-
-createWorker(SHPLoader);


### PR DESCRIPTION
It looks like in `modules/shapefile`, there are duplicate `dbf-loader.worker.js` and `shp-loader.worker.js` files. This PR keeps the files in `src/workers` and removes the files in `src/`.