### PR TITLE
[Bug] Fix incorrect text/json mimeType for JSON Loader

### DIFF
--- a/modules/gltf/docs/api-reference/gltf-loader.md
+++ b/modules/gltf/docs/api-reference/gltf-loader.md
@@ -1,6 +1,6 @@
 # GLTFLoader
 
-Parses a glTF file. Can load both the `.glb` (binary) and `.gltf` (text/json) file format variants.
+Parses a glTF file. Can load both the `.glb` (binary) and `.gltf` (application/json) file format variants.
 
 A glTF file contains a hierarchical scenegraph description that can be used to instantiate corresponding hierarcy of actual `Scenegraph` related classes in most WebGL libraries.
 

--- a/modules/json/src/json-loader.js
+++ b/modules/json/src/json-loader.js
@@ -24,7 +24,7 @@ export const JSONLoader = {
   name: 'JSON',
   version: VERSION,
   extensions: ['json', 'geojson'],
-  mimeTypes: ['text/json'],
+  mimeTypes: ['application/json'],
   // TODO - support various line based JSON formats
   /*
   extensions: {


### PR DESCRIPTION
`text/json` isn't really a valid mime-type, and `application/json` is the more standard type usually used. This will also make loaders consistent with heavily used mime type databases and packages such as [`mime-db`](https://github.com/jshttp/mime-db/blob/master/db.json#L519) and [`mime-types`](https://www.npmjs.com/package/mime-types)