### PR TITLE
shapefile: dbf state parser

### DIFF
--- a/modules/shapefile/src/dbf-loader.js
+++ b/modules/shapefile/src/dbf-loader.js
@@ -1,6 +1,7 @@
 /** @typedef {import('@loaders.gl/loader-utils').LoaderObject} LoaderObject */
 /** @typedef {import('@loaders.gl/loader-utils').WorkerLoaderObject} WorkerLoaderObject */
-import parseDBF from './lib/parsers/parse-dbf';
+// import parseDBF from './lib/parsers/parse-dbf';
+import parseDBF from './lib/parsers/parse-dbf-state';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.

--- a/modules/shapefile/src/lib/parsers/parse-dbf-state.js
+++ b/modules/shapefile/src/lib/parsers/parse-dbf-state.js
@@ -1,0 +1,239 @@
+/* global TextDecoder */
+import BinaryReader from '../streaming/binary-reader';
+
+const LITTLE_ENDIAN = true;
+const DBF_HEADER_SIZE = 32;
+
+const STATE = {
+  START: 0, // Expecting header
+  FIELD_DESCRIPTORS: 1,
+  FIELD_PROPERTIES: 2,
+  END: 3,
+  ERROR: 4
+}
+
+class DBFParser {
+  constructor(encoding) {
+    this.binaryReader = new BinaryReader();
+    this.textDecoder = new TextDecoder(encoding);
+    this.state = STATE.START;
+    this.result = {};
+  }
+
+  write(arrayBuffer) {
+    this.binaryReader.write(arrayBuffer);
+    this.state = parse(this.state, this.result, this.binaryReader, this.textDecoder);
+
+    // important events:
+    // - schema available
+    // - first rows available
+    // - all rows available
+  }
+  end() {
+    this.binaryReader.end();
+    this.state = parse(this.state, this.result, this.binaryReader, this.textDecoder);
+  }
+}
+
+function parse(state, result = {}, binaryReader, textDecoder) {
+  // https://www.dbase.com/Knowledgebase/INT/db7_file_fmt.htm
+  try {
+    switch (state) {
+      case STATE.ERROR:
+      case STATE.END:
+          break;
+
+      case STATE.START:
+        // Parse initial file header
+        const dataView = binaryReader.getDataView(DBF_HEADER_SIZE, 'DBF header');
+        if (!dataView) {
+          break;
+        }
+        result.dbfHeader = parseDBFHeader(dataView);
+        result.data = [];
+        result.progress = {
+          bytesUsed: 0,
+          rowsTotal: result.dbfHeader.nRecords,
+          rows: 0
+        };
+        state = STATE.FIELD_DESCRIPTORS;
+        break;
+
+      case STATE.FIELD_DESCRIPTORS:
+        // Parse DBF field descriptors (schema)
+        const fieldDescriptorView =
+          binaryReader.getDataView(result.dbfHeader.headerLength - DBF_HEADER_SIZE, 'DBF field descriptors');
+        if (!fieldDescriptorView) {
+          break;
+        }
+
+        result.dbfFields = parseFieldDescriptors(fieldDescriptorView, textDecoder);
+        state = state.FIELD_PROPERTIES;
+
+        // TODO(kyle) Not exactly sure why start offset needs to be headerLength + 1?
+        // parsedbf uses ((fields.length + 1) << 5) + 2;
+        binaryReader.skip(1);
+        break;
+
+      case STATE.FIELD_PROPERTIES:
+        const {headerLength, recordLength, nRecords} = result.dbfHeader;
+        while (result.data.length < result.dbfHeader.nRecords) {
+          const recordView = binaryReader.getDataView(recordLength - 1);
+          if (!recordView) {
+            break;
+          }
+          // Note: Avoid actually reading the last byte, which may not be present
+          binaryReader.skip(1);
+
+          const row = parseRow(recordView, result.dbfFields, textDecoder);
+          result.data.push(row);
+          result.progress.rows = result.data.length;
+        }
+        state = STATE.END;
+        break;
+
+      default:
+        state = STATE.ERROR;
+        result.error = `illegal parser state ${state}`;
+    }
+  } catch (error) {
+    state = STATE.ERROR;
+    result.error = `DBF parsing failed: ${error.message}`;
+  }
+
+  result.progress.bytesUsed = binaryReader.bytesUsed();
+  return state;
+}
+
+export default function parseDbf(arrayBuffer, options) {
+  const binaryReader = new BinaryReader(arrayBuffer);
+
+  const loaderOptions = options.dbf || {};
+  const {encoding} = loaderOptions;
+
+  const dbfParser = new DBFParser();
+  dbfParser.write(arrayBuffer);
+  dbfParser.end();
+  return dbfParser.result.data;
+}
+
+/**
+ * @param {DataView} headerView
+ */
+function parseDBFHeader(headerView) {
+  return {
+    // Last updated date
+    year: headerView.getUint8(1) + 1900,
+    month: headerView.getUint8(2),
+    day: headerView.getUint8(3),
+    // Number of records in data file
+    nRecords: headerView.getUint32(4, LITTLE_ENDIAN),
+    // Length of header in bytes
+    headerLength: headerView.getUint16(8, LITTLE_ENDIAN),
+    // Length of each record
+    recordLength: headerView.getUint16(10, LITTLE_ENDIAN),
+    // Not sure if this is usually set
+    languageDriver: headerView.getUint8(29)
+  };
+}
+
+/**
+ * @param {DataView} view
+ */
+function parseFieldDescriptors(view, textDecoder) {
+  // NOTE: this might overestimate the number of fields if the "Database
+  // Container" container exists and is included in the headerLength
+  const nFields = (view.byteLength - 1) / 32;
+  const fields = [];
+  let offset = 0;
+  for (let i = 0; i < nFields; i++) {
+    const name = textDecoder
+      .decode(new Uint8Array(view.buffer, view.byteOffset + offset, 11))
+      // eslint-disable-next-line no-control-regex
+      .replace(/\u0000/g, '');
+
+    fields.push({
+      name,
+      dataType: String.fromCharCode(view.getUint8(offset + 11)),
+      fieldLength: view.getUint8(offset + 16),
+      decimal: view.getUint8(offset + 17)
+    });
+    offset += 32;
+  }
+  return fields;
+}
+
+/**
+ * @param {BinaryReader} binaryReader
+ */
+function parseRows(binaryReader, fields, nRecords, recordLength, textDecoder) {
+  const rows = [];
+  for (let i = 0; i < nRecords; i++) {
+    const recordView = binaryReader.getDataView(recordLength - 1);
+    binaryReader.skip(1);
+    rows.push(parseRow(recordView, fields, textDecoder));
+  }
+  return rows;
+}
+
+/**
+ * @param {DataView} view
+ */
+function parseRow(view, fields, textDecoder) {
+  const out = {};
+  let offset = 0;
+  for (const field of fields) {
+    const text = textDecoder.decode(
+      new Uint8Array(view.buffer, view.byteOffset + offset, field.fieldLength)
+    );
+    out[field.name] = parseField(text, field.dataType);
+    offset += field.fieldLength;
+  }
+
+  return out;
+}
+
+// Should NaN be coerced to null?
+function parseField(text, dataType) {
+  switch (dataType) {
+    case 'B':
+      return parseNumber(text);
+    case 'C':
+      return parseCharacter(text);
+    case 'F':
+      return parseNumber(text);
+    case 'N':
+      return parseNumber(text);
+    case 'O':
+      return parseNumber(text);
+    case 'D':
+      return parseDate(text);
+    case 'L':
+      return parseBoolean(text);
+    default:
+      throw new Error('Unsupported data type');
+  }
+}
+
+// Parse YYYYMMDD to date in milliseconds
+function parseDate(str) {
+  return Date.UTC(str.slice(0, 4), parseInt(str.slice(4, 6), 10) - 1, str.slice(6, 8));
+}
+
+// Read boolean value
+// any of Y, y, T, t coerce to true
+// any of N, n, F, f coerce to false
+// otherwise null
+function parseBoolean(value) {
+  return /^[nf]$/i.test(value) ? false : /^[yt]$/i.test(value) ? true : null;
+}
+
+// Return null instead of NaN
+function parseNumber(text) {
+  const number = parseFloat(text);
+  return isNaN(number) ? null : number;
+}
+
+function parseCharacter(text) {
+  return text.trim() || null;
+}

--- a/modules/shapefile/src/lib/parsers/parse-dbf-state.js
+++ b/modules/shapefile/src/lib/parsers/parse-dbf-state.js
@@ -10,7 +10,7 @@ const STATE = {
   FIELD_PROPERTIES: 2,
   END: 3,
   ERROR: 4
-}
+};
 
 class DBFParser {
   constructor({encoding}) {
@@ -43,13 +43,15 @@ class DBFParser {
 }
 
 // https://www.dbase.com/Knowledgebase/INT/db7_file_fmt.htm
+/* eslint-disable complexity, max-depth */
 function parseState(state, result = {}, binaryReader, textDecoder) {
+  // eslint-disable-next-line no-constant-condition
   while (true) {
     try {
       switch (state) {
         case STATE.ERROR:
         case STATE.END:
-            return state;
+          return state;
 
         case STATE.START:
           // Parse initial file header
@@ -69,8 +71,10 @@ function parseState(state, result = {}, binaryReader, textDecoder) {
 
         case STATE.FIELD_DESCRIPTORS:
           // Parse DBF field descriptors (schema)
-          const fieldDescriptorView =
-            binaryReader.getDataView(result.dbfHeader.headerLength - DBF_HEADER_SIZE, 'DBF field descriptors');
+          const fieldDescriptorView = binaryReader.getDataView(
+            result.dbfHeader.headerLength - DBF_HEADER_SIZE,
+            'DBF field descriptors'
+          );
           if (!fieldDescriptorView) {
             return state;
           }
@@ -84,7 +88,7 @@ function parseState(state, result = {}, binaryReader, textDecoder) {
           break;
 
         case STATE.FIELD_PROPERTIES:
-          const {headerLength, recordLength, nRecords} = result.dbfHeader;
+          const {recordLength} = result.dbfHeader;
           while (result.data.length < result.dbfHeader.nRecords) {
             const recordView = binaryReader.getDataView(recordLength - 1);
             if (!recordView) {
@@ -170,18 +174,19 @@ function parseFieldDescriptors(view, textDecoder) {
   return fields;
 }
 
-/**
- * @param {BinaryReader} binaryReader
- */
+/*
+ * @param {BinaryChunkReader} binaryReader
 function parseRows(binaryReader, fields, nRecords, recordLength, textDecoder) {
   const rows = [];
   for (let i = 0; i < nRecords; i++) {
     const recordView = binaryReader.getDataView(recordLength - 1);
     binaryReader.skip(1);
+    // @ts-ignore
     rows.push(parseRow(recordView, fields, textDecoder));
   }
   return rows;
 }
+ */
 
 /**
  * @param {DataView} view

--- a/modules/shapefile/src/lib/streaming/binary-chunk-reader.d.ts
+++ b/modules/shapefile/src/lib/streaming/binary-chunk-reader.d.ts
@@ -1,0 +1,11 @@
+export default class BinaryChunkReader {
+  constructor(arrayBuffer: ArrayBuffer);
+
+  hasAvailableBytes(bytes: number): boolean;
+
+  /** Get the required number of bytes from the iterator */
+  getDataView(bytes?: number): DataView;
+
+  skip(bytes: number);
+  rewind(bytes: number);
+}

--- a/modules/shapefile/src/lib/streaming/binary-chunk-reader.d.ts
+++ b/modules/shapefile/src/lib/streaming/binary-chunk-reader.d.ts
@@ -1,10 +1,13 @@
 export default class BinaryChunkReader {
-  constructor(arrayBuffer: ArrayBuffer);
+  constructor();
+
+  write(arrayBuffer: ArrayBuffer);
+  end();
 
   hasAvailableBytes(bytes: number): boolean;
 
   /** Get the required number of bytes from the iterator */
-  getDataView(bytes?: number): DataView;
+  getDataView(bytes?: number): DataView | null;
 
   skip(bytes: number);
   rewind(bytes: number);

--- a/modules/shapefile/src/lib/streaming/binary-chunk-reader.js
+++ b/modules/shapefile/src/lib/streaming/binary-chunk-reader.js
@@ -1,14 +1,31 @@
+import {concatenateArrayBuffers} from "@loaders.gl/loader-utils";
+
 export default class BinaryChunkReader {
   constructor() {
-    /** current global (stream) offset */
+    /** current global offset into current array buffer*/
     this.offset = 0;
     /** current buffer from iterator */
-    this.arrayBuffer = arrayBuffer;
+    this.arrayBuffers = [];
+    this.ended = false;
+  }
 
+  write(arrayBuffer) {
+    this.arrayBuffers.push(arrayBuffer);
+  }
+
+  end() {
+    this.ended = true;
   }
 
   hasAvailableBytes(bytes) {
-    return this.arrayBuffer.byteLength - this.offset >= bytes;
+    let bytesAvailable = -this.offset;
+    for (const arrayBuffer of this.arrayBuffers) {
+      bytesAvailable += arrayBuffer.byteLength;
+      if (bytesAvailable >= bytes) {
+        return true;
+      }
+    }
+    return false;
   }
 
   // Get the required number of bytes from the iterator
@@ -17,11 +34,34 @@ export default class BinaryChunkReader {
       throw new Error('binary data exhausted');
     }
 
-    const dataView = bytes
-      ? new DataView(this.arrayBuffer, this.offset, bytes)
-      : new DataView(this.arrayBuffer, this.offset);
-    this.offset += bytes;
+    const arrayBuffer = this.getArrayBuffer(bytes);
+    const dataView = new DataView(arrayBuffer);
     return dataView;
+  }
+
+  getArrayBuffer(bytes) {
+    const chunks = [];
+    while (bytes > 0) {
+      const chunk = this._getChunk(bytes);
+      chunks.push(chunk);
+      bytes -= chunk.byteLength;
+    }
+    return concatenateArrayBuffers(...chunks);
+  }
+
+  _getChunk(bytes) {
+    const arrayBuffer = this.arrayBuffers[0];
+    const remainingBytes = arrayBuffer.byteLength - this.offset;
+    let chunk;
+    if (bytes <= remainingBytes) {
+      chunk = new Uint8Array(arrayBuffer, this.offset, bytes);
+      this.offset += bytes;
+    } else if (remainingBytes > 0) {
+      chunk = new Uint8Array(arrayBuffer, this.offset, remainingBytes);
+      this.arrayBuffers.shift();
+      this.offset = 0;
+    }
+    return chunk;
   }
 
   skip(bytes) {
@@ -29,6 +69,7 @@ export default class BinaryChunkReader {
   }
 
   rewind(bytes) {
+    // TODO - only works if offset is already set
     this.offset -= bytes;
   }
 }

--- a/modules/shapefile/src/lib/streaming/binary-chunk-reader.js
+++ b/modules/shapefile/src/lib/streaming/binary-chunk-reader.js
@@ -1,4 +1,4 @@
-import {concatenateArrayBuffers} from "@loaders.gl/loader-utils";
+import {concatenateArrayBuffers} from '@loaders.gl/loader-utils';
 
 export default class BinaryChunkReader {
   constructor() {
@@ -35,14 +35,17 @@ export default class BinaryChunkReader {
     }
 
     const arrayBuffer = this.getArrayBuffer(bytes);
-    const dataView = new DataView(arrayBuffer);
-    return dataView;
+    return arrayBuffer && new DataView(arrayBuffer);
   }
 
   getArrayBuffer(bytes) {
     const chunks = [];
     while (bytes > 0) {
       const chunk = this._getChunk(bytes);
+      if (!chunk) {
+        // push back chunks?
+        return null;
+      }
       chunks.push(chunk);
       bytes -= chunk.byteLength;
     }

--- a/modules/shapefile/src/lib/streaming/binary-chunk-reader.js
+++ b/modules/shapefile/src/lib/streaming/binary-chunk-reader.js
@@ -1,0 +1,34 @@
+export default class BinaryChunkReader {
+  constructor() {
+    /** current global (stream) offset */
+    this.offset = 0;
+    /** current buffer from iterator */
+    this.arrayBuffer = arrayBuffer;
+
+  }
+
+  hasAvailableBytes(bytes) {
+    return this.arrayBuffer.byteLength - this.offset >= bytes;
+  }
+
+  // Get the required number of bytes from the iterator
+  getDataView(bytes) {
+    if (bytes && !this.hasAvailableBytes(bytes)) {
+      throw new Error('binary data exhausted');
+    }
+
+    const dataView = bytes
+      ? new DataView(this.arrayBuffer, this.offset, bytes)
+      : new DataView(this.arrayBuffer, this.offset);
+    this.offset += bytes;
+    return dataView;
+  }
+
+  skip(bytes) {
+    this.offset += bytes;
+  }
+
+  rewind(bytes) {
+    this.offset -= bytes;
+  }
+}

--- a/modules/shapefile/test/dbf-loader.spec.js
+++ b/modules/shapefile/test/dbf-loader.spec.js
@@ -19,7 +19,7 @@ const SHAPEFILE_JS_TEST_FILES = [
   'utf8-property'
 ];
 
-test('Shapefile JS DBF tests', async t => {
+test.only('Shapefile JS DBF tests', async t => {
   for (const testFileName of SHAPEFILE_JS_TEST_FILES) {
     let response = await fetchFile(`${SHAPEFILE_JS_DATA_FOLDER}/${testFileName}.dbf`);
     const body = await response.arrayBuffer();

--- a/modules/shapefile/test/index.js
+++ b/modules/shapefile/test/index.js
@@ -1,3 +1,5 @@
+import './streaming/binary-chunk-reader.spec';
+
 import './parsers/parse-shp.spec';
 
 import './shp-loader.spec';

--- a/modules/shapefile/test/streaming/binary-chunk-reader.spec.js
+++ b/modules/shapefile/test/streaming/binary-chunk-reader.spec.js
@@ -1,0 +1,8 @@
+import test from 'tape-promise/tape';
+import BinaryChunkReader from '@loaders.gl/shapefile/lib/streaming/binary-chunk-reader';
+
+test.only('BinaryChunkReader', async t => {
+  const reader = new BinaryChunkReader();
+  t.ok(reader);
+  t.end();
+});


### PR DESCRIPTION
This is a WIP showing how state based binary parsers can work. I currently think this will be the best approach for streaming binary data.

Starting with DBF parser since it is easier than the SHP parser (no rewinding of input stream).