### PR TITLE
loader-utils: concatenateChunksAsync perf increase

### DIFF
--- a/modules/loader-utils/src/lib/binary-utils/array-buffer-utils.js
+++ b/modules/loader-utils/src/lib/binary-utils/array-buffer-utils.js
@@ -29,6 +29,7 @@ export function toArrayBuffer(data) {
   return assert(false);
 }
 
+/** @type {types['compareArrayBuffers']} */
 export function compareArrayBuffers(arrayBuffer1, arrayBuffer2, byteLength) {
   byteLength = byteLength || arrayBuffer1.byteLength;
   if (arrayBuffer1.byteLength < byteLength || arrayBuffer2.byteLength < byteLength) {
@@ -45,6 +46,7 @@ export function compareArrayBuffers(arrayBuffer1, arrayBuffer2, byteLength) {
 }
 
 // Concatenate ArrayBuffers
+/** @type {types['concatenateArrayBuffers']} */
 export function concatenateArrayBuffers(...sources) {
   // Make sure all inputs are wrapped in typed arrays
   const sourceArrays = sources.map(

--- a/modules/loader-utils/src/lib/iterator-utils/async-iteration.js
+++ b/modules/loader-utils/src/lib/iterator-utils/async-iteration.js
@@ -1,4 +1,5 @@
 import {concatenateArrayBuffers} from '../binary-utils/array-buffer-utils';
+import assert from '../env-utils/assert';
 
 // GENERAL UTILITIES
 
@@ -38,8 +39,10 @@ export async function forEach(iterator, visitor) {
  * This function can e.g. be used to enable atomic parsers to work on (async) iterator inputs
  */
 export async function concatenateChunksAsync(asyncIterator) {
-  const arrayBuffers = [new ArrayBuffer(0)];
-  const strings = [''];
+  /** @type {ArrayBuffer[]} */
+  const arrayBuffers = [];
+  /** @type {string[]} */
+  const strings = [];
   for await (const chunk of asyncIterator) {
     if (typeof chunk === 'string') {
       strings.push(chunk);
@@ -48,13 +51,10 @@ export async function concatenateChunksAsync(asyncIterator) {
     }
   }
 
-  if (arrayBuffers.length > 1) {
-    return concatenateArrayBuffers(...arrayBuffers);
-  }
-
-  if (strings.length > 1) {
+  if (strings.length > 0) {
+    assert(arrayBuffers.length === 0);
     return strings.join('');
   }
 
-  return arrayBuffers[0];
+  return concatenateArrayBuffers(...arrayBuffers);
 }

--- a/modules/loader-utils/src/lib/iterator-utils/async-iteration.js
+++ b/modules/loader-utils/src/lib/iterator-utils/async-iteration.js
@@ -38,14 +38,23 @@ export async function forEach(iterator, visitor) {
  * This function can e.g. be used to enable atomic parsers to work on (async) iterator inputs
  */
 export async function concatenateChunksAsync(asyncIterator) {
-  let arrayBuffer = new ArrayBuffer(0);
-  let string = '';
+  const arrayBuffers = [new ArrayBuffer(0)];
+  const strings = [''];
   for await (const chunk of asyncIterator) {
     if (typeof chunk === 'string') {
-      string += chunk;
+      strings.push(chunk);
     } else {
-      arrayBuffer = concatenateArrayBuffers(arrayBuffer, chunk);
+      arrayBuffers.push(chunk);
     }
   }
-  return string || arrayBuffer;
+
+  if (arrayBuffers.length > 1) {
+    return concatenateArrayBuffers(...arrayBuffers);
+  }
+
+  if (strings.length > 1) {
+    return strings.join('');
+  }
+
+  return arrayBuffers[0];
 }

--- a/modules/loader-utils/test/loader-utils.bench.js
+++ b/modules/loader-utils/test/loader-utils.bench.js
@@ -1,0 +1,33 @@
+/* global File */
+import {concatenateChunksAsync, concatenateArrayBuffers} from '@loaders.gl/loader-utils';
+
+export default async function loaderUtilsBench(suite) {
+  const hundredMegabytes = new Array(100).fill(new ArrayBuffer(1e6));
+
+  suite.group('@loaders.gl/loader-utils');
+
+  const options = {multiplier: 0.1, unit: 'gigabytes'};
+
+  suite.add('concatenateArrayBuffers(100x1MB chunks)', options, () => {
+    concatenateArrayBuffers(...hundredMegabytes);
+  });
+
+  suite.addAsync('concatenateChunksAsync(100x1MB chunks)', options, async () => {
+    // @ts-ignore
+    await concatenateChunksAsync(hundredMegabytes);
+  });
+
+  if (typeof File !== 'undefined') {
+    suite.add('new File(100x1MB chunks)', options, () => new File(hundredMegabytes, 'filename'));
+
+    suite.add('new File(10x1MB TEXT chunks) SLOW!', {...options, multiplier: 0.01}, () => {
+      let bigString = 'a';
+      for (let i = 0; i < 20; ++i) {
+        bigString += bigString;
+      }
+
+      const tenMegabytesText = new Array(10).fill(bigString);
+      return new File(tenMegabytesText, 'filename');
+    });
+  }
+}

--- a/test/bench/modules.js
+++ b/test/bench/modules.js
@@ -23,6 +23,7 @@
 import ALIASES from '../../test/aliases';
 import {_addAliases} from '@loaders.gl/loader-utils';
 
+import loaderUtilsBench from '@loaders.gl/loader-utils/test/loader-utils.bench';
 import imageBench from '@loaders.gl/images/test/images.bench';
 import coreBench from '@loaders.gl/core/test/core.bench';
 import csvBench from '@loaders.gl/csv/test/csv.bench';
@@ -35,6 +36,8 @@ _addAliases(ALIASES);
 
 export async function addModuleBenchmarksToSuite(suite) {
   // add tests
+  await loaderUtilsBench(suite);
+
   await imageBench(suite);
   await cryptoBench(suite);
 


### PR DESCRIPTION
Repeated concatenation of big chunks is very slow. Replace with a single concatenation at the end.