### PR TITLE
gltf: partial support for GLBv1 and glTFv1

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -12,11 +12,11 @@ This release brings a new Shapefile loader, compression codecs (Zlib, LZ4, Zstan
 
 **@loaders.gl/compression** (NEW)
 
-- A new module with compression/decompression "transforms" for compression codecs (Zlib, LZ4, Zstandard). As always, these work reliably in both the browser and Node.
+- A new module with compression/decompression transforms for compression codecs (Zlib, LZ4, Zstandard). As always, these work reliably in both browsers and Node.js.
 
 **@loaders.gl/crypto** (NEW)
 
-- A new module with "transforms" for calculating cryptographic hashes (MD5, SHA256 etc) incrementally, e.g. on incoming binary chunks while streaming data into `parseInBatches`.
+- A new module for calculating cryptographic hashes (MD5, SHA256 etc). Provided transforms enables hashes to be calculated incrementally, e.g. on incoming binary chunks while streaming data into `parseInBatches`.
 
 **@loaders.gl/core**
 
@@ -32,6 +32,11 @@ This release brings a new Shapefile loader, compression codecs (Zlib, LZ4, Zstan
 - `fetch` polyfill: Files with `.gz` extension are automatically decompressed with gzip. The extension reported in the `fetch` response has the `.gz` extension removed.
 - `fetch` polyfill: Improved robustness and error handling in Node.js when opening unreadable or non-existent files. Underlying errors (`ENOEXIST`, `EISDIR` etc) are now caught and reported in `Response.statusText`.
 - `Blob` and `File`, new experimental polyfills.
+
+**@loaders.gl/gltf**
+
+- `GLBLoader` can now read older GLB v1 files in addition to GLB v2.
+- `GLTFLoader` now offers optional, partial support for reading older glTF v1 files and automatically converting them to glTF v2 format (via `options.glt.normalize`).
 
 **@loaders.gl/json**
 

--- a/modules/gltf/docs/api-reference/glb-loader.md
+++ b/modules/gltf/docs/api-reference/glb-loader.md
@@ -1,17 +1,19 @@
 # GLBLoader
 
-The `GLBLoader` parses a GLB binary "envelope".
+The `GLBLoader` parses a GLB binary "envelope" extracting the embedded JSON and binary chunks.
 
-Note: applications that want to parse GLB-formatted glTF files use the `GLTFLoader` instead. The `GLBLoader` is intended to be used to load custom data that combines JSON and binary resources.
+Note: applications that want to parse GLB-formatted glTF files would normally use the `GLTFLoader` instead. The `GLBLoader` can be used to load custom data that combines JSON and binary resources.
 
-| Loader          | Characteristic                                                                                          |
-| --------------- | ------------------------------------------------------------------------------------------------------- |
-| File Extensions | `.glb`                                                                                                  |
-| File Type       | Binary                                                                                                  |
-| File Format     | [GLB](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#glb-file-format-specification) |
-| Data Format     | See below                                                                                               |
-| Supported APIs  | `load`, `parse`, `parseSync`                                                                            |
+| Loader          | Characteristic                                                                                                                                                                                                   |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| File Extensions | `.glb`                                                                                                                                                                                                           |
+| File Type       | Binary                                                                                                                                                                                                           |
+| File Format     | [GLB v2](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#glb-file-format-specification), [GLB v1](https://github.com/KhronosGroup/glTF/tree/master/extensions/1.0/Khronos/KHR_binary_glTF) \* |
+| Data Format     | See below                                                                                                                                                                                                        |
+| Supported APIs  | `load`, `parse`, `parseSync`                                                                                                                                                                                     |
 |                 |
+
+\* From [![Website shields.io](https://img.shields.io/badge/v2.3-blue.svg?style=flat-square)](http://shields.io), the `GLBLoader` can also load GLB v1 formatted files, returning a normalized GLB v2 compatible data structure, but with the `version` field set to `1`.
 
 ## Usage
 

--- a/modules/gltf/docs/api-reference/glb-writer.md
+++ b/modules/gltf/docs/api-reference/glb-writer.md
@@ -1,16 +1,16 @@
 # GLBWriter
 
-The `GLBWriter` is a writer for the GLB binary "envelope".
+The `GLBWriter` is a writer for the GLB binary "envelope" format.
 
-Note: applications that want to encode GLB-formatted glTF files use the `GLTFWriter` instead. The `GLBWriter` is intended to be used to save custom data that combines JSON and binary resources.
+Note: applications that want to encode GLB-formatted glTF files should normally use the `GLTFWriter` instead. The `GLBWriter` enables applications to save custom data that combines JSON and binary resources.
 
-| Loader          | Characteristic                                                                                          |
-| --------------- | ------------------------------------------------------------------------------------------------------- |
-| File Extensions | `.glb`                                                                                                  |
-| File Type       | Binary                                                                                                  |
-| Data Format     | See below                                                                                               |
-| File Format     | [GLB](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#glb-file-format-specification) |
-| Supported APIs  | `encode`, `encodeSync`                                                                                  |
+| Loader          | Characteristic                                                                                             |
+| --------------- | ---------------------------------------------------------------------------------------------------------- |
+| File Extensions | `.glb`                                                                                                     |
+| File Type       | Binary                                                                                                     |
+| Data Format     | See below                                                                                                  |
+| File Format     | [GLB v2](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#glb-file-format-specification) |
+| Supported APIs  | `encode`, `encodeSync`                                                                                     |
 
 ## Usage
 
@@ -30,3 +30,7 @@ const arrayBuffer = encodeSync(gltf, GLBWriter, options);
 ## Data Format
 
 See [`GLBLoader`](/modules/gltf/docs/api-reference/glb-loader.md).
+
+## Remarks
+
+- While the `GLBLoader` supports reading both GLB v1 and v2, only GLB v2 can be written.

--- a/modules/gltf/docs/api-reference/gltf-loader.md
+++ b/modules/gltf/docs/api-reference/gltf-loader.md
@@ -4,14 +4,16 @@ Parses a glTF file. Can load both the `.glb` (binary) and `.gltf` (application/j
 
 A glTF file contains a hierarchical scenegraph description that can be used to instantiate corresponding hierarcy of actual `Scenegraph` related classes in most WebGL libraries.
 
-| Loader          | Characteristic                                                             |
-| --------------- | -------------------------------------------------------------------------- |
-| File Extensions | `.glb`, `.gltf`                                                            |
-| File Type       | Binary, JSON, Linked Assets                                                |
-| File Format     | [glTF](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0) |
-| Data Format     | [Scenegraph](/docs/specifications/category-scenegraph)                     |
-| Supported APIs  | `load`, `parse`, `parseSync`                                               |
-| Subloaders      | `DracoLoader`, `ImageLoader`                                               |  |
+| Loader          | Characteristic                                                                                                                                                  |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| File Extensions | `.glb`, `.gltf`                                                                                                                                                 |
+| File Type       | Binary, JSON, Linked Assets                                                                                                                                     |
+| File Format     | [glTF v2](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0), [GLTF v1](https://github.com/KhronosGroup/glTF/tree/master/specification/1.0) \* |
+| Data Format     | [Scenegraph](/docs/specifications/category-scenegraph)                                                                                                          |
+| Supported APIs  | `load`, `parse`                                                                                                                                                 |
+| Subloaders      | `DracoLoader`, `ImageLoader`                                                                                                                                    |  |
+
+\* From [![Website shields.io](https://img.shields.io/badge/v2.3-blue.svg?style=flat-square)](http://shields.io), the `GLTFLoader` offers optional, best-effort support for converting older glTF v1 files to glTF v2 format (`options.gltf.normalize: true`). This conversion has a number of limitations and the parsed data structure may be only partially converted to glTF v2, causing issues to show up later e.g. when attempting to render the scenegraphs.
 
 ## Usage
 
@@ -49,16 +51,17 @@ Note: while supported, synchronous parsing of glTF (e.g. using `parseSync()`) ha
 
 ## Options
 
-| Option                  | Type    | Default |                                                                                | Description |
-| ----------------------- | ------- | ------- | ------------------------------------------------------------------------------ | ----------- |
-| `gltf.fetchImages`      | Boolean | `false` | Fetch any referenced image files (and decode base64 encoded URIS). Async only. |
-| `gltf.parseImages`      | Boolean | `false` |
-| `gltf.decompressMeshes` | Boolean | `true`  | Decompress Draco compressed meshes (if DracoLoader available).                 |
-| `gltf.postProcess`      | Boolean | `true`  | Perform additional post processing on the loaded glTF data.                    |
+| Option                  | Type    | Default |                                                                            | Description |
+| ----------------------- | ------- | ------- | -------------------------------------------------------------------------- | ----------- |
+| `gltf.loadBuffers`      | Boolean | `false` | Fetch any referenced binary buffer files (and decode base64 encoded URIS). |
+| `gltf.loadImages`       | Boolean | `false` | Load any referenced image files (and decode base64 encoded URIS).          |
+| `gltf.decompressMeshes` | Boolean | `true`  | Decompress Draco compressed meshes (if DracoLoader available).             |
+| `gltf.postProcess`      | Boolean | `true`  | Perform additional post processing on the loaded glTF data.                |
+| `gltf.normalize`        | Boolean | `false` | Optional, best-effort attempt at converting glTF v1 files to glTF2 format. |
 
 Remarks:
 
-- The `gltf.postProcess` option activates additional [post processing](docs/api-reference/post-process-gltf) that transforms parts of JSON structure in the loaded glTF data, to make glTF data easier use in applications and WebGL libraries, however this changes the format of the data returned by the `GLTFLoader`.
+- The `gltf.postProcess` option activates additional [post processing](docs/api-reference/post-process-gltf) that transforms parts of JSON structure in the loaded glTF data, to make glTF data easier use in applications and WebGL libraries (e.g replacing indices with links to the indexed objects). However, the data structure returned by the `GLTFLoader` will no longer be fully glTF compatible.
 
 ## Data Format
 

--- a/modules/gltf/src/gltf-loader.js
+++ b/modules/gltf/src/gltf-loader.js
@@ -20,6 +20,7 @@ const GLTFLoader = {
 
   options: {
     gltf: {
+      normalize: false, // Normalize glTF v1 to glTF v2 format (not yet stable)
       loadBuffers: true, // Fetch any linked .BIN buffers, decode base64
       loadImages: true, // Create image objects
       decompressMeshes: true, // Decompress Draco encoded meshes

--- a/modules/gltf/src/lib/extensions/KHR_binary_gltf.js
+++ b/modules/gltf/src/lib/extensions/KHR_binary_gltf.js
@@ -1,0 +1,39 @@
+// GLTF 1.0 EXTENSION: KHR_binary_glTF
+// https://github.com/KhronosGroup/glTF/tree/master/extensions/1.0/Khronos/KHR_binary_glTF
+
+import GLTFScenegraph from '../gltf-scenegraph';
+import {KHR_BINARY_GLTF} from '../gltf-constants';
+
+export function decode(gltfData, options) {
+  const gltfScenegraph = new GLTFScenegraph(gltfData);
+  const {json} = gltfScenegraph;
+
+  // Note: json.buffers.binary_glTF also needs to be replaced
+  // This is currently done during gltf normalization
+
+  // Image and shader nodes can have the extension
+  // https://github.com/KhronosGroup/glTF/blob/master/extensions/1.0/Khronos/KHR_binary_glTF/schema/image.KHR_binary_glTF.schema.json
+  for (const node of json.images || []) {
+    const extension = gltfScenegraph.removeObjectExtension(node, KHR_BINARY_GLTF);
+    // The data in the extension is valid as glTF 2.0 data inside the object, so just copy it in
+    if (extension) {
+      Object.assign(node, extension);
+    }
+  }
+
+  // TODO shaders
+  // https://github.com/KhronosGroup/glTF/blob/master/extensions/1.0/Khronos/KHR_binary_glTF/schema/shader.KHR_binary_glTF.schema.json
+
+  // glTF v1 one files have a partially formed URI field that is not expected in (and causes problems in) 2.0
+  if (json.buffers && json.buffers[0]) {
+    delete json.buffers[0].uri;
+  }
+
+  // Remove the top-level extension as it has now been removed from all nodes
+  gltfScenegraph.removeExtension(KHR_BINARY_GLTF);
+}
+
+// KHR_binary_gltf is a 1.0 extension that is supported natively by 2.0
+export function encode(gltfData, options) {
+  throw new Error(KHR_BINARY_GLTF);
+}

--- a/modules/gltf/src/lib/extensions/gltf-extensions.js
+++ b/modules/gltf/src/lib/extensions/gltf-extensions.js
@@ -1,11 +1,23 @@
 /* eslint-disable camelcase */
+
+// GLTF 1.0 extensions (read only)
+// Note: KHR_binary_gltf needs to be processed before other loading starts
+// import * as KHR_binary_gltf from './KHR_draco_mesh_compression';
+
+// GLTF 2.0 extensions (read/write)
 import * as KHR_draco_mesh_compression from './KHR_draco_mesh_compression';
 import * as KHR_lights_punctual from './KHR_lights_punctual';
 import * as KHR_materials_unlit from './KHR_materials_unlit';
-// import UBER_POINT_CLOUD_COMPRESSION from './KHR_draco_mesh_compression';
 import * as KHR_techniques_webgl from './KHR_techniques_webgl';
 
+// other extensions
+// import UBER_POINT_CLOUD_COMPRESSION from './KHR_draco_mesh_compression';
+
 export const EXTENSIONS = {
+  // 1.0
+  // KHR_binary_gltf,
+
+  // 2.0
   KHR_draco_mesh_compression,
   KHR_lights_punctual,
   KHR_materials_unlit,

--- a/modules/gltf/src/lib/gltf-constants.js
+++ b/modules/gltf/src/lib/gltf-constants.js
@@ -1,11 +1,14 @@
-// GLTF extension
+// GLTF 1.0 extensions
+export const KHR_BINARY_GLTF = 'KHR_binary_glTF';
 
-// Ideally we should just use KHR_draco_mesh_compression, but it does not support point clouds
+// GLTF 2.0 extensions
 export const KHR_DRACO_MESH_COMPRESSION = 'KHR_draco_mesh_compression';
-export const UBER_POINT_CLOUD_EXTENSION = 'UBER_draco_point_cloud_compression';
 export const KHR_LIGHTS_PUNCTUAL = 'KHR_lights_punctual';
 export const KHR_MATERIALS_UNLIT = 'KHR_materials_unlit';
 export const KHR_TECHNIQUES_WEBGL = 'KHR_techniques_webgl';
+
+// Ideally we should just use KHR_draco_mesh_compression, but it does not support point clouds
+export const UBER_POINT_CLOUD_EXTENSION = 'UBER_draco_point_cloud_compression';
 
 const COMPONENTS = {
   SCALAR: 1,

--- a/modules/gltf/src/lib/gltf-scenegraph.d.ts
+++ b/modules/gltf/src/lib/gltf-scenegraph.d.ts
@@ -71,7 +71,7 @@ export default class GLTFScenegraph {
 
   addObjectExtension(object: object, extensionName: string, data: object): GLTFScenegraph;
 
-  removeObjectExtension(object: object, extensionName: string): GLTFScenegraph;
+  removeObjectExtension(object: object, extensionName: string): object;
 
   // Add to standard GLTF top level extension object, mark as used
   addExtension(extensionName: string, extensionData?: object): object;
@@ -80,15 +80,15 @@ export default class GLTFScenegraph {
   addRequiredExtension(extensionName, extensionData?: object): object;
 
   // Add extensionName to list of used extensions
-  registerUsedExtension(extensionName: string);
+  registerUsedExtension(extensionName: string): void;
 
   // Add extensionName to list of required extensions
-  registerRequiredExtension(extensionName: string);
+  registerRequiredExtension(extensionName: string): void;
 
   // Removes an extension from the top-level list
-  removeExtension(extensionName: string);
+  removeExtension(extensionName: string): void;
 
-  setObjectExtension(object: object, extensionName: string, data: object);
+  setObjectExtension(object: object, extensionName: string, data: object): void;
 
   addMesh(attributes: object, indices: object, mode?: number): number;
 

--- a/modules/gltf/src/lib/gltf-scenegraph.js
+++ b/modules/gltf/src/lib/gltf-scenegraph.js
@@ -20,7 +20,10 @@ export default class GLTFScenegraph {
     if (!gltf) {
       gltf = {
         json: {
-          version: 2,
+          asset: {
+            version: '2.0',
+            generator: 'loaders.gl'
+          },
           buffers: []
         },
         buffers: []
@@ -200,10 +203,17 @@ export default class GLTFScenegraph {
     return this;
   }
 
+  setObjectExtension(object, extensionName, data) {
+    const extensions = object.extensions || {};
+    extensions[extensionName] = data;
+    // TODO - add to usedExtensions...
+  }
+
   removeObjectExtension(object, extensionName) {
     const extensions = object.extensions || {};
+    const extension = extensions[extensionName];
     delete extensions[extensionName];
-    return this;
+    return extension;
   }
 
   // Add to standard GLTF top level extension object, mark as used
@@ -251,12 +261,6 @@ export default class GLTFScenegraph {
     if (this.json.extensions) {
       delete this.json.extensions[extensionName];
     }
-  }
-
-  setObjectExtension(object, extensionName, data) {
-    const extensions = object.extensions || {};
-    extensions[extensionName] = data;
-    // TODO - add to usedExtensions...
   }
 
   addMesh(attributes, indices, mode = 4) {

--- a/modules/gltf/src/lib/normalize-gltf-v1.js
+++ b/modules/gltf/src/lib/normalize-gltf-v1.js
@@ -1,0 +1,280 @@
+/* eslint-disable camelcase */
+import * as KHR_binary_glTF from './extensions/KHR_binary_gltf';
+
+// Binary format changes (mainly implemented by GLBLoader)
+// https://github.com/KhronosGroup/glTF/tree/master/extensions/1.0/Khronos/KHR_binary_glTF
+
+// JSON format changes:
+// https://github.com/khronosgroup/gltf/issues/605
+
+// - [x] Top-level JSON objects are arrays now
+// - [ ] Removed indirection from animation: sampler now refers directly to accessors, #712
+// - [ ] material.parameter.value and technique.parameter.value must be an array, #690
+// - [ ] Node can have only one mesh #821
+// - [ ] Added reqs on JSON encoding
+// - [ ] Added reqs on binary data alignment #802 (comment)
+
+// Additions:
+// - [ ] Added accessor.normalized, #691, #706
+// - [ ] Added glExtensionsUsed property and 5125 (UNSIGNED_INT) accessor.componentType value, #619
+// - [ ] Added extensionsRequired property, #720, #721
+// - [ ] Added "STEP" as valid animation.sampler.interpolation value, #712
+
+// Removals:
+// - [x] Removed buffer.type, #786, #629
+// - [ ] Removed revision number from profile.version, #709
+// - [ ] Removed technique.functions.scissor and removed 3089 (SCISSOR_TEST) as a valid value for technique.states.enable, #681
+// - [ ] Techniques, programs, and shaders were moved out to KHR_technique_webgl extension.
+
+// Other edits:
+// - [x] asset is now required, #642
+// - [ ] buffer.byteLength and bufferView.byteLength are now required, #560.
+// - [ ] accessor.min and accessor.max are now required, #593, and clarified that the JSON value and binary data must be the same, #628.
+// - [ ] Clarified animation.sampler and animation.channel restrictions, #712
+// - [ ] skin.inverseBindMatrices is now optional, #461.
+// - [ ] Attribute parameters can't have a value defined in the technique or parameter, #563 (comment).
+// - [ ] Only TEXCOORD and COLOR attribute semantics can be written in the form [semantic]_[set_index], #563 (comment).
+// - [ ] TEXCOORD and COLOR attribute semantics must be written in the form [semantic]_[set_index], e.g., just TEXCOORD should be TEXCOORD_0, and just COLOR should be COLOR_0, #649
+// - [ ] camera.perspective.aspectRatio and camera.perspective.yfov must now be > 0, not >= 0, #563 (comment).
+// - [ ] Application-specific parameter semantics must start with an underscore, e.g., _TEMPERATURE and _SIMULATION_TIME, #563 (comment).
+// - [ ] Properties in technique.parameters must be defined in technique.uniforms or technique.attributes,
+
+// #563 (comment).
+// - [ ] technique.parameter.count can only be defined when the semantic is JOINTMATRIX or an application-specific semantic is used. It can never be defined for attribute parameters; only uniforms, d2f6945
+// - [ ] technique.parameter.semantic is required when the parameter is an attribute, 28e113d
+// - [ ] Mesh-only models are allowed, e.g., without materials, #642
+// - [ ] Skeleton hierarchies (nodes containing jointName) must be separated from non-skeleton hierarchies., #647
+// - [ ] technique.states.functions.blendColor and technique.states.functions.depthRange parameters now must match WebGL function min/max, #707
+
+const GLTF_ARRAYS = {
+  accessors: 'accessor',
+  animations: 'animation',
+  buffers: 'buffer',
+  bufferViews: 'bufferView',
+  images: 'image',
+  materials: 'material',
+  meshes: 'mesh',
+  nodes: 'node',
+  samplers: 'sampler',
+  scenes: 'scene',
+  skins: 'skin',
+  textures: 'texture'
+};
+
+const GLTF_KEYS = {
+  accessor: 'accessors',
+  animations: 'animation',
+  buffer: 'buffers',
+  bufferView: 'bufferViews',
+  image: 'images',
+  material: 'materials',
+  mesh: 'meshes',
+  node: 'nodes',
+  sampler: 'samplers',
+  scene: 'scenes',
+  skin: 'skins',
+  texture: 'textures'
+};
+
+/**
+ * Converts (normalizes) glTF v1 to v2
+ */
+class GLTFV1Normalizer {
+  constructor(gltf) {
+    this.idToIndexMap = {
+      animations: {},
+      accessors: {},
+      buffers: {},
+      bufferViews: {},
+      images: {},
+      materials: {},
+      meshes: {},
+      nodes: {},
+      samplers: {},
+      scenes: {},
+      skins: {},
+      textures: {}
+    };
+  }
+
+  /**
+   * Convert (normalize) glTF < 2.0 to glTF 2.0
+   * @param {*} gltf - object with json and binChunks
+   * @param {object} options
+   * @param {boolean} [options.normalize] Whether to actually normalize
+   */
+  normalize(gltf, options) {
+    this.json = gltf.json;
+    const json = gltf.json;
+
+    // Check version
+    switch (json.asset && json.asset.version) {
+      // We are converting to v2 format. Return if there is nothing to do
+      case '2.0':
+        return;
+
+      // This class is written to convert 1.0
+      case undefined:
+      case '1.0':
+        break;
+
+      default:
+        // eslint-disable-next-line no-undef, no-console
+        console.warn(`glTF: Unknown version ${json.asset.version}`);
+        return;
+    }
+
+    if (!options.normalize) {
+      // We are still missing a few conversion tricks, remove once addressed
+      throw new Error('glTF v1 is not supported.');
+    }
+
+    // eslint-disable-next-line no-undef, no-console
+    console.warn('Converting glTF v1 to glTF v2 format. This is experimental and may fail.');
+
+    this._addAsset(json);
+
+    // In glTF2 top-level fields are Arrays not Object maps
+    this._convertTopLevelObjectsToArrays(json);
+
+    // Extract bufferView indices for images
+    // (this extension needs to be invoked early in the normalization process)
+    KHR_binary_glTF.decode(gltf, options);
+
+    // Convert object references from ids to indices
+    this._convertObjectIdsToArrayIndices(json);
+
+    this._updateObjects(json);
+  }
+
+  // asset is now required, #642 https://github.com/KhronosGroup/glTF/issues/639
+  _addAsset(json) {
+    json.asset = json.asset || {};
+    // We are normalizing to glTF v2, so change version to "2.0"
+    json.asset.version = '2.0';
+    json.asset.generator = json.asset.generator || 'Normalized to glTF 2.0 by loaders.gl';
+  }
+
+  _convertTopLevelObjectsToArrays(json) {
+    // TODO check that all arrays are covered
+    for (const arrayName in GLTF_ARRAYS) {
+      this._convertTopLevelObjectToArray(json, arrayName);
+    }
+  }
+
+  /** Convert one top level object to array */
+  _convertTopLevelObjectToArray(json, mapName) {
+    const objectMap = json[mapName];
+    if (!objectMap || Array.isArray(objectMap)) {
+      return;
+    }
+
+    // Rewrite the top-level field as an array
+    json[mapName] = [];
+    // Copy the map key into object.id
+    for (const id in objectMap) {
+      const object = objectMap[id];
+      object.id = object.id || id; // Mutates the loaded object
+      const index = json[mapName].length;
+      json[mapName].push(object);
+      this.idToIndexMap[mapName][id] = index;
+    }
+  }
+
+  /** Go through all objects in all top-level arrays and replace ids with indices */
+  _convertObjectIdsToArrayIndices(json) {
+    for (const arrayName in GLTF_ARRAYS) {
+      this._convertIdsToIndices(json, arrayName);
+    }
+    if ('scene' in json) {
+      json.scene = this._convertIdToIndex(json.scene, 'scene');
+    }
+
+    // Convert any index references that are not using array names
+
+    // texture.source (image)
+    for (const texture of json.textures) {
+      this._convertTextureIds(texture);
+    }
+    for (const mesh of json.meshes) {
+      this._convertMeshIds(mesh);
+    }
+    for (const node of json.nodes) {
+      this._convertNodeIds(node);
+    }
+    for (const node of json.scenes) {
+      this._convertSceneIds(node);
+    }
+  }
+
+  _convertTextureIds(texture) {
+    if (texture.source) {
+      texture.source = this._convertIdToIndex(texture.source, 'image');
+    }
+  }
+
+  _convertMeshIds(mesh) {
+    for (const primitive of mesh.primitives) {
+      const {attributes, indices, material} = primitive;
+      for (const attributeName in attributes) {
+        attributes[attributeName] = this._convertIdToIndex(attributes[attributeName], 'accessor');
+      }
+      if (indices) {
+        primitive.indices = this._convertIdToIndex(indices, 'accessor');
+      }
+      if (material) {
+        primitive.material = this._convertIdToIndex(material, 'material');
+      }
+    }
+  }
+
+  _convertNodeIds(node) {
+    if (node.children) {
+      node.children = node.children.map(child => this._convertIdToIndex(child, 'node'));
+    }
+  }
+
+  _convertSceneIds(scene) {
+    if (scene.nodes) {
+      scene.nodes = scene.nodes.map(node => this._convertIdToIndex(node, 'node'));
+    }
+  }
+
+  /** Go through all objects in a top-level array and replace ids with indices */
+  _convertIdsToIndices(json, topLevelArrayName) {
+    for (const object of json[topLevelArrayName]) {
+      for (const key in object) {
+        const id = object[key];
+        const index = this._convertIdToIndex(id, key);
+        object[key] = index;
+      }
+    }
+  }
+
+  _convertIdToIndex(id, key) {
+    const arrayName = GLTF_KEYS[key];
+    if (arrayName in this.idToIndexMap) {
+      const index = this.idToIndexMap[arrayName][id];
+      if (!Number.isFinite(index)) {
+        throw new Error(`gltf v1: failed to resolve ${key} with id ${id}`);
+      }
+      return index;
+    }
+    return id;
+  }
+
+  /**
+   *
+   * @param {*} json
+   */
+  _updateObjects(json) {
+    for (const buffer of this.json.buffers) {
+      // - [x] Removed buffer.type, #786, #629
+      delete buffer.type;
+    }
+  }
+}
+
+export default function normalizeGLTFV1(gltf, options = {}) {
+  return new GLTFV1Normalizer().normalize(gltf, options);
+}

--- a/modules/gltf/src/lib/parse-gltf.js
+++ b/modules/gltf/src/lib/parse-gltf.js
@@ -7,6 +7,7 @@ import {resolveUrl} from './gltf-utils/resolve-url';
 import {getTypedArrayForBufferView} from './gltf-utils/get-typed-array';
 import {decodeExtensions} from './extensions/gltf-extensions';
 import parseGLBSync, {isGLB} from './parse-glb';
+import normalizeGLTFV1 from './normalize-gltf-v1';
 import postProcessGLTF from './post-process-gltf';
 
 export function isGLTF(arrayBuffer, options = {}) {
@@ -17,6 +18,8 @@ export function isGLTF(arrayBuffer, options = {}) {
 
 export async function parseGLTF(gltf, arrayBufferOrString, byteOffset = 0, options, context) {
   parseGLTFContainerSync(gltf, arrayBufferOrString, byteOffset, options);
+
+  normalizeGLTFV1(gltf, {normalize: options.gltf.normalize});
 
   /** @type {Promise[]} */
   const promises = [];

--- a/modules/gltf/test/glb-loader.spec.js
+++ b/modules/gltf/test/glb-loader.spec.js
@@ -6,23 +6,33 @@ import {load, parseSync, fetchFile} from '@loaders.gl/core';
 import {GLBLoader} from '@loaders.gl/gltf';
 
 const GLTF_BINARY_URL = '@loaders.gl/gltf/test/data/gltf-2.0/2CylinderEngine.glb';
+const GLB_V1_TILE_CESIUM_AIR_URL = '@loaders.gl/gltf/test/data/3d-tiles/Cesium_Air.glb';
 
 test('GLBLoader#loader conformance', t => {
   validateLoader(t, GLBLoader, 'GLBLoader');
   t.end();
 });
 
-test('GLBLoader#parseSync(binary)', async t => {
+test('GLBLoader#parseSync(v2)', async t => {
   const response = await fetchFile(GLTF_BINARY_URL);
   const data = await response.arrayBuffer();
-  const gltf = parseSync(data, GLBLoader);
-  t.ok(gltf, 'GLBLoader returned parsed data');
+  const glbv2 = parseSync(data, GLBLoader);
+  t.equal(glbv2.version, 2, 'GLBLoader returned correct glb version');
+  t.equal(glbv2.json.asset.version, '2.0', 'GLBLoader returned correct gltf version');
 
   t.end();
 });
 
-test('GLBLoader#load(binary)', async t => {
-  const data = await load(GLTF_BINARY_URL, GLBLoader);
-  t.ok(data.json.asset, 'GLBLoader returned parsed data');
+test('GLBLoader#load(v2)', async t => {
+  const glbv2 = await load(GLTF_BINARY_URL, GLBLoader);
+  t.equal(glbv2.version, 2, 'GLBLoader returned correct glb version');
+  t.equal(glbv2.json.asset.version, '2.0', 'GLBLoader returned correct gltf version');
+  t.end();
+});
+
+test('GLBLoader#load(v1)', async t => {
+  const glbv1 = await load(GLB_V1_TILE_CESIUM_AIR_URL, GLBLoader);
+  t.equal(glbv1.version, 1, 'GLBLoader returned correct glb version');
+  t.equal(glbv1.json.asset.version, '1.0', 'GLBLoader returned parsed data');
   t.end();
 });

--- a/modules/gltf/test/gltf-loader.spec.js
+++ b/modules/gltf/test/gltf-loader.spec.js
@@ -12,7 +12,7 @@ const GLTF_JSON_URL = '@loaders.gl/gltf/test/data/gltf-2.0/2CylinderEngine.gltf'
 
 // Extracted from Cesium 3D Tiles
 const GLB_TILE_WITH_DRACO_URL = '@loaders.gl/gltf/test/data/3d-tiles/143.glb';
-const GLB_TILE_CESIUM_AIR_URL = '@loaders.gl/gltf/test/data/3d-tiles/Cesium_Air.glb';
+const GLB_V1_TILE_CESIUM_AIR_URL = '@loaders.gl/gltf/test/data/3d-tiles/Cesium_Air.glb';
 const GLB_TILE_URL = '@loaders.gl/gltf/test/data/3d-tiles/tile.glb';
 
 test('GLTFLoader#loader conformance', t => {
@@ -53,16 +53,23 @@ test('GLTFLoader#load(3d tile GLB)', async t => {
   // TODO - prone to flakiness since we have async unregisterLoaders calls
   registerLoaders([DracoLoader, ImageLoader]);
 
-  t.ok(
-    await load(GLB_TILE_WITH_DRACO_URL, GLTFLoader),
-    `Parses Draco GLB with registered DracoLoader`
+  const gltf2 = await load(GLB_TILE_WITH_DRACO_URL, GLTFLoader);
+  t.ok(gltf2, `Parses Draco GLB with defaultregistered DracoLoader`);
+
+  t.end();
+});
+
+test('GLTFLoader#load(glTF v1)', async t => {
+  await t.rejects(
+    load(GLB_V1_TILE_CESIUM_AIR_URL, GLTFLoader),
+    /glTF v1 is not supported/,
+    'glTF v1 generates error message'
   );
 
-  t.rejects(
-    async () => await load(GLB_TILE_CESIUM_AIR_URL, GLTFLoader),
-    /Invalid GLB version 1/,
-    `GLB v1 is rejected with a user-friendly message`
-  );
+  const gltf1 = await load(GLB_V1_TILE_CESIUM_AIR_URL, GLTFLoader, {gltf: {normalize: true}});
+  t.ok(gltf1, `glTF v1 was normalized without errors`);
+
+  t.end();
 });
 
 // Check load options

--- a/yarn.lock
+++ b/yarn.lock
@@ -4129,7 +4129,7 @@ dotignore@~0.1.2:
   dependencies:
     minimatch "^3.0.4"
 
-draco3d@^1.3.4:
+draco3d@1.3.4, draco3d@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/draco3d/-/draco3d-1.3.4.tgz#b17e4fedd4b4b946c9eb8df2e1d2f470a953cdb8"
   integrity sha512-I7kAKyiSIb++K5VdWGeIC9xXWkoQ1HZ8wSCQhaRMf41KKxYX5jYmy+rRna/o7o3CrunxvCGbZBl6d6bdWVcJXw==
@@ -8514,7 +8514,7 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-puppeteer@^1.16.0:
+puppeteer@1.16.0, puppeteer@^1.16.0:
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.16.0.tgz#4b763d9ff4e69a4bb7a031c3393534214d54f27e"
   integrity sha512-7hcmbUw+6INffSPBdnO8KSjJRg2bLRoI7EeZMf5MHdV5kpyYMeoMR5w8AIiZbKIhYGwrXlbgvO7gFTsXNHShuQ==


### PR DESCRIPTION
Optional support for automatically converting glTF v1 to glTF v2 on load. 

The logic is in a new file `normalize-gltf-v1.js` which is only invoked when the new option `options.gltf.normalize` is set to true.

This should not affect existing apps.

The main use case for adding support for the older glTF format is currently to support older 3D tiles tilesets that were tiled before glTF v2 was available.
