### PR TITLE
Include tsc in pre commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test": "ocular-test",
     "metrics": "./scripts/metrics.sh && ocular-metrics",
     "version": "yarn build",
-    "pre-commit": "ocular-lint",
+    "pre-commit": "yarn lint",
     "pre-push": "ocular-test fast"
   },
   "devDependencies": {


### PR DESCRIPTION
Currently the pre-commit hook calls `ocular-lint`, but not `tsc`, which means that a commit can pass the commit and push hooks, but still fail CI.