### PR TITLE
Shapefile: Parse SHP/DBF in batches

### DIFF
--- a/modules/shapefile/src/dbf-loader.js
+++ b/modules/shapefile/src/dbf-loader.js
@@ -1,7 +1,7 @@
 /** @typedef {import('@loaders.gl/loader-utils').LoaderObject} LoaderObject */
 /** @typedef {import('@loaders.gl/loader-utils').WorkerLoaderObject} WorkerLoaderObject */
-import parseDBF from './lib/parsers/parse-dbf';
-// import parseDBF from './lib/parsers/parse-dbf-state';
+// import parseDBF from './lib/parsers/parse-dbf';
+import {parseDBF, parseDBFInBatches} from './lib/parsers/parse-dbf-state';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
@@ -28,5 +28,6 @@ export const DBFWorkerLoader = {
 export const DBFLoader = {
   ...DBFWorkerLoader,
   parse: async (arrayBuffer, options) => parseDBF(arrayBuffer, options),
-  parseSync: parseDBF
+  parseSync: parseDBF,
+  parseInBatches: parseDBFInBatches
 };

--- a/modules/shapefile/src/lib/parsers/parse-shp-state.js
+++ b/modules/shapefile/src/lib/parsers/parse-shp-state.js
@@ -29,8 +29,8 @@ class SHPParser {
     this.state = parseState(this.state, this.result, this.binaryReader);
   }
 
-  /** Return current geometries then discard internal copy */
-  geometries() {
+  /** Return current data (geometries) then discard internal copy */
+  data() {
     const geometries = this.result.geometries;
     this.result.geometries = [];
     return geometries;
@@ -60,7 +60,7 @@ export async function* parseSHPInBatches(asyncIterator, options) {
 
   for await (const chunk of asyncIterator) {
     shpParser.write(chunk);
-    const geometries = shpParser.geometries();
+    const geometries = shpParser.data();
     const header = shpParser.result.header();
     yield {geometries, header};
   }

--- a/modules/shapefile/src/shp-loader.js
+++ b/modules/shapefile/src/shp-loader.js
@@ -1,7 +1,7 @@
 /** @typedef {import('@loaders.gl/loader-utils').LoaderObject} LoaderObject */
 /** @typedef {import('@loaders.gl/loader-utils').WorkerLoaderObject} WorkerLoaderObject */
-import parseSHP from './lib/parsers/parse-shp';
-// import parseSHP from './lib/parsers/parse-shp-state';
+// import parseSHP from './lib/parsers/parse-shp';
+import {parseSHP, parseSHPInBatches} from './lib/parsers/parse-shp-state';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
@@ -29,5 +29,6 @@ export const SHPWorkerLoader = {
 export const SHPLoader = {
   ...SHPWorkerLoader,
   parse: async (arrayBuffer, options) => parseSHP(arrayBuffer),
-  parseSync: parseSHP
+  parseSync: parseSHP,
+  parseInBatches: parseSHPInBatches
 };


### PR DESCRIPTION
- I haven't figured out yet how to integrate batched parsing into the top-level `ShapefileLoader`. It seems I need to set a specific `batchSize` so that the returned geometries and attributes represent the same number of rows?
- There are some SHP tests already for loading in batches, but more fine-grained tests seem ideal
