### PR TITLE
Fix fetch returning `ok` for missing local files

### DIFF
--- a/modules/polyfills/src/fetch-node/utils/stream-utils.node.js
+++ b/modules/polyfills/src/fetch-node/utils/stream-utils.node.js
@@ -13,10 +13,24 @@ export async function createReadStream(url, options) {
   // Handle file streams in node
   if (!isRequestURL(url)) {
     const noqueryUrl = url.split('?')[0];
+    let fileExists = true;
+    try {
+      await fs.promises.access(noqueryUrl);
+    } catch (error) {
+      fileExists = false;
+    }
+
     // Now open the stream
     return await new Promise((resolve, reject) => {
       // @ts-ignore
       const stream = fs.createReadStream(noqueryUrl, {encoding: null});
+      if (!fileExists) {
+        // @ts-ignore
+        stream.statusCode = 400;
+        // @ts-ignore
+        stream.statusMessage = 'File does not exist';
+      }
+
       stream.once('readable', () => resolve(stream));
       stream.on('error', error => reject(error));
     });


### PR DESCRIPTION
Maybe there's a better way to do this? Throw an error? As it is, `statusCode` is read by the calling function.

Ref: https://github.com/visgl/loaders.gl/issues/915