### PR TITLE
las: parse two-bytes colors

### DIFF
--- a/modules/las/docs/api-reference/las-loader.md
+++ b/modules/las/docs/api-reference/las-loader.md
@@ -23,7 +23,8 @@ const data = await load(url, LASLoader, options);
 
 ## Options
 
-| Option               | Type     | Default | Description                                                               |
-| -------------------- | -------- | ------- | ------------------------------------------------------------------------- |
-| `options.las.skip`   | Number   | `1`     | Read one from every _n_ points.                                           |
-| `options.onProgress` | Function | -       | Callback when a new chunk of data is read. Only works on the main thread. |
+| Option                   | Type             | Default | Description                                                                                                    |
+| ------------------------ | ---------------- | ------- | -------------------------------------------------------------------------------------------------------------- |
+| `options.las.skip`       | Number           | `1`     | Read one from every _n_ points.                                                                                |
+| `options.las.colorDepth` | Number or string | `8`     | Whether colors encoded using 8 or 16 bits? Can be set to `'auto'`. Note: LAS specification recommends 16 bits. |
+| `options.onProgress`     | Function         | -       | Callback when a new chunk of data is read. Only works on the main thread.                                      |

--- a/modules/las/src/las-loader.js
+++ b/modules/las/src/las-loader.js
@@ -20,7 +20,8 @@ export const LASWorkerLoader = {
   options: {
     las: {
       workerUrl: `https://unpkg.com/@loaders.gl/las@${VERSION}/dist/las-loader.worker.js`,
-      skip: 1
+      skip: 1,
+      colorDepth: 8
     }
   }
 };


### PR DESCRIPTION
Before this commit, colors were assumed to be encoded on one byte.
However, the [LAS specification says otherwise, at least since 1.3][0]
(description of Point Data Record Format 2):
>  Red, Green, Blue values should always be normalized to 16 bit values.

As final colors are stored in a Uint8Array, a division by 256 has been
added. However, to ensure retrocompability, this division is done only
if a value of R, G or B is greater than 255. It is assumed that their
won't be a case of colors being scaled in the 0-255 range, even for
10 bits or greater range of camera color.

This assumption is subject to a debate, I just copy the way [it is done
in Potree.](https://github.com/potree/potree/blob/develop/src/workers/EptLaszipDecoderWorker.js#L68)

[0]: http://www.asprs.org/a/society/committees/standards/asprs_las_spec_v13.pdf#page=11