### PR TITLE
draco: Add draco3d types

### DIFF
--- a/modules/core/src/lib/api/load.d.ts
+++ b/modules/core/src/lib/api/load.d.ts
@@ -1,4 +1,4 @@
-import {DataType, LoaderObject} from '@loaders.gl/loader-utils';
+import {DataType, WorkerLoaderObject} from '@loaders.gl/loader-utils';
 /**
  * Parses `data` using a specified loader
  * @param data
@@ -6,4 +6,4 @@ import {DataType, LoaderObject} from '@loaders.gl/loader-utils';
  * @param options
  * @param context
  */
-export function load(url: string | DataType, loaders: LoaderObject | LoaderObject[], options?: object, context?: object): Promise<any>;
+export function load(url: string | DataType, loaders: WorkerLoaderObject | WorkerLoaderObject[], options?: object, context?: object): Promise<any>;

--- a/modules/draco/package.json
+++ b/modules/draco/package.json
@@ -18,6 +18,7 @@
     "point cloud",
     "draco"
   ],
+  "types": "src/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "esnext": "dist/es6/index.js",

--- a/modules/draco/src/index.d.ts
+++ b/modules/draco/src/index.d.ts
@@ -1,0 +1,2 @@
+export {DracoLoader, DracoWorkerLoader} from './draco-loader';
+export {default as DracoWriter} from './draco-writer';

--- a/modules/draco/src/lib/draco-builder.d.ts
+++ b/modules/draco/src/lib/draco-builder.d.ts
@@ -1,0 +1,16 @@
+export default class DracoBuilder {
+  // draco - the draco decoder, either import `draco3d` or load dynamically
+  constructor(draco, options?: object);
+
+  destroy(): void;
+
+  // TBD - when does this need to be called?
+  destroyEncodedObject(object): void;
+
+  /**
+   * Encode mesh or point cloud
+   * @param mesh =({})
+   * @param options
+   */
+  encodeSync(mesh: object, options?: object): ArrayBuffer;
+}

--- a/modules/draco/src/lib/draco-parser.d.ts
+++ b/modules/draco/src/lib/draco-parser.d.ts
@@ -1,0 +1,22 @@
+export default class DracoParser {
+  // draco - the draco decoder, either import `draco3d` or load dynamically
+  constructor(draco);
+
+  /**
+   * Destroy draco resources
+   */
+  destroy(): void;
+
+  /**
+   *
+   * @param dracoGeometry
+   */
+  destroyGeometry(dracoGeometry);
+
+  /**
+   * NOTE: caller must call `destroyGeometry` on the return value after using it
+   * @param arrayBuffer
+   * @param options
+   */
+  parseSync(arrayBuffer: ArrayBuffer, options?);
+}

--- a/modules/draco/src/types/draco-types.d.ts
+++ b/modules/draco/src/types/draco-types.d.ts
@@ -1,0 +1,66 @@
+// A set of typescript types manually adapted from the Draco web IDL
+// Draco JS is a bit tricky to work with due to the C++ emscripten code base
+// sparse documentation, so these types provide an extra safety net.
+
+export type TypedArray =
+  | Int8Array
+  | Uint8Array
+  | Int16Array
+  | Uint16Array
+  | Int32Array
+  | Uint32Array
+  | Uint8ClampedArray
+  | Float32Array
+  | Float64Array;
+
+export {
+  DecoderBuffer,
+  AttributeTransformData,
+  GeometryAttribute,
+  PointAttribute,
+  AttributeQuantizationTransform,
+  AttributeOctahedronTransform,
+  PointCloud,
+  Mesh,
+  Metadata,
+  Status,
+  DracoFloat32Array,
+  DracoInt8Array,
+  DracoUInt8Array,
+  DracoInt16Array,
+  DracoUInt16Array,
+  DracoInt32Array,
+  DracoUInt32Array,
+  MetadataQuerier,
+  Decoder
+} from './draco-web-decoder';
+
+export {
+  // GeometryAttribute,
+  // PointAttribute,
+  // PointCloud,
+  // Mesh,
+  // Metadata,
+  // DracoInt8Array,
+  PointCloudBuilder,
+  MeshBuilder,
+  Encoder,
+  ExpertEncoder
+} from './draco-web-encoder';
+
+export function destroy(resource: any): void;
+
+// ENUMS
+
+// draco_EncodedGeometryType
+export const INVALID_GEOMETRY_TYPE: number;
+export const POINT_CLOUD: number;
+export const TRIANGULAR_MESH: number;
+
+// enum draco_GeometryAttribute_Type
+export const INVALID: number;
+export const POSITION: number;
+export const NORMAL: number;
+export const COLOR: number;
+export const TEX_COORD: number;
+export const GENERIC: number;

--- a/modules/draco/src/types/draco-web-decoder.d.ts
+++ b/modules/draco/src/types/draco-web-decoder.d.ts
@@ -1,0 +1,261 @@
+// Typescript defs adapted from draco3d emscripten IDL
+// https://raw.githubusercontent.com/google/draco/master/src/draco/javascript/emscripten/draco_web_decoder.idl
+// Interface exposed to emscripten's WebIDL Binder.
+// http://kripken.github.io/emscripten-site/docs/porting/connecting_cpp_and_javascript/WebIDL-Binder.html
+
+// TODO
+type VoidPtr = any;
+
+type draco_AttributeTransformType = number;
+type draco_GeometryAttribute_Type = number;
+type draco_EncodedGeometryType = number;
+type draco_DataType = number;
+type draco_StatusCode = number;
+
+  /*
+// TODO(fgalligan): Can we remove this?
+enum draco_AttributeTransformType {
+  "draco::ATTRIBUTE_INVALID_TRANSFORM",
+  "draco::ATTRIBUTE_NO_TRANSFORM",
+  "draco::ATTRIBUTE_QUANTIZATION_TRANSFORM",
+  "draco::ATTRIBUTE_OCTAHEDRON_TRANSFORM"
+};
+
+enum draco_GeometryAttribute_Type {
+  "draco_GeometryAttribute::INVALID",
+  "draco_GeometryAttribute::POSITION",
+  "draco_GeometryAttribute::NORMAL",
+  "draco_GeometryAttribute::COLOR",
+  "draco_GeometryAttribute::TEX_COORD",
+  "draco_GeometryAttribute::GENERIC"
+};
+
+enum draco_EncodedGeometryType {
+  "draco::INVALID_GEOMETRY_TYPE",
+  "draco::POINT_CLOUD",
+  "draco::TRIANGULAR_MESH"
+};
+
+enum draco_DataType {
+  "draco::DT_INVALID",
+  "draco::DT_INT8",
+  "draco::DT_UINT8",
+  "draco::DT_INT16",
+  "draco::DT_UINT16",
+  "draco::DT_INT32",
+  "draco::DT_UINT32",
+  "draco::DT_INT64",
+  "draco::DT_UINT64",
+  "draco::DT_FLOAT32",
+  "draco::DT_FLOAT64",
+  "draco::DT_BOOL",
+  "draco::DT_TYPES_COUNT"
+};
+
+enum draco_StatusCode {
+  "draco_Status::OK",
+  "draco_Status::DRACO_ERROR",
+  "draco_Status::IO_ERROR",
+  "draco_Status::INVALID_PARAMETER",
+  "draco_Status::UNSUPPORTED_VERSION",
+  "draco_Status::UNKNOWN_VERSION",
+};
+*/
+
+/** A memory buffer to decode Draco meshes from */
+export class DecoderBuffer {
+  constructor();
+  Init(data: Int8Array, data_size: number): void;
+}
+
+export class AttributeTransformData {
+  constructor();
+  transform_type(): number;
+}
+
+export class GeometryAttribute {
+  constructor();
+}
+
+export class PointAttribute {
+  constructor();
+  size(): number;
+  GetAttributeTransformData(): AttributeTransformData;
+
+  // From GeometryAttribute
+  attribute_type(): number;
+  data_type(): number;
+  num_components(): number;
+  normalized(): boolean;
+  byte_stride(): number;
+  byte_offset(): number;
+  unique_id(): number;
+}
+
+export class AttributeQuantizationTransform {
+  constructor();
+  InitFromAttribute(att: PointAttribute): boolean;
+  quantization_bits(): number;
+  min_value(axis: number): number;
+  range(): number;
+}
+
+export class AttributeOctahedronTransform {
+  constructor();
+  InitFromAttribute(att: PointAttribute): boolean;
+  quantization_bits(): number;
+}
+
+
+export class PointCloud {
+  constructor();
+  num_attributes(): number;
+  num_points(): number;
+}
+
+export class Mesh extends PointCloud {
+  constructor();
+
+  num_faces(): number;
+
+  // From PointCloud
+  // num_attributes(): number;
+  // num_points(): number;
+}
+
+export class Metadata {
+  constructor();
+}
+
+export class Status {
+  constructor();
+  code(): draco_StatusCode;
+  ok(): boolean;
+  error_msg(): string;
+}
+
+// Draco version of typed arrays. The memory of these arrays is allocated on the
+// emscripten heap.
+export class DracoFloat32Array {
+  constructor();
+  GetValue(index: number): number;
+  size(): number;
+}
+
+export class DracoInt8Array {
+  constructor();
+  GetValue(index: number): number;
+  size(): number;
+}
+
+export class DracoUInt8Array {
+  GetValue(index: number): number;
+  size(): number;
+}
+
+export class DracoInt16Array {
+  constructor();
+  GetValue(index: number): number;
+  size(): number;
+}
+
+export class DracoUInt16Array {
+  constructor();
+  GetValue(index: number): number;
+  size(): number;
+}
+
+export class DracoInt32Array {
+  constructor();
+  GetValue(index: number): number;
+  size(): number;
+}
+
+export class DracoUInt32Array {
+  constructor();
+  GetValue(index: number): number;
+  size(): number;
+}
+
+export class MetadataQuerier {
+  constructor();
+
+  HasEntry(metadata: Metadata, entry_name: string): string;
+  GetIntEntry(metadata: Metadata, entry_name: string);
+  GetIntEntryArray(metadata: Metadata, entry_name: string, out_values: DracoInt32Array);
+  GetDoubleEntry(metadata: Metadata, entry_name: string): number;
+  GetStringEntry(metadata: Metadata, entry_name: string): string;
+
+  NumEntries(metadata: Metadata): number;
+  GetEntryName(metadata: Metadata, entry_id: number): string;
+}
+
+/**
+ * Main Decoder class
+ */
+export class Decoder {
+  constructor();
+
+  GetEncodedGeometryType(in_buffer: DecoderBuffer): draco_EncodedGeometryType;
+
+  DecodeBufferToPointCloud(in_buffer: DecoderBuffer, out_point_cloud: PointCloud): Status;
+  DecodeBufferToMesh(in_buffer: DecoderBuffer, out_mesh: Mesh): Status;
+
+  GetAttributeId(pc: PointCloud, type: draco_GeometryAttribute_Type): number;
+  GetAttributeIdByName(pc: PointCloud, name: string): number;
+  GetAttributeIdByMetadataEntry(pc: PointCloud, name: string, value: string): number;
+
+  GetAttribute(pc: PointCloud, att_id: number): PointAttribute;
+  GetAttributeByUniqueId(pc: PointCloud, unique_id: number): PointAttribute;
+
+  GetMetadata(pc: PointCloud): Metadata;
+  GetAttributeMetadata(pc: PointCloud, att_id: number): Metadata;
+
+  GetFaceFromMesh(m: Mesh, face_id: number, out_values: DracoInt32Array): boolean;
+  GetTriangleStripsFromMesh(m: Mesh, strip_values: DracoInt32Array);
+
+  GetTrianglesUInt16Array(m: Mesh, out_size: number, out_values: VoidPtr): boolean;
+  GetTrianglesUInt32Array(m: Mesh, out_size: number, out_values: VoidPtr): boolean;
+
+  GetAttributeFloat(pa: PointAttribute,
+                    att_index: number,
+                    out_values: DracoFloat32Array): boolean;
+
+  GetAttributeFloatForAllPoints(pc: PointCloud,
+                                pa: PointAttribute,
+                                out_values: DracoFloat32Array ): boolean;
+
+  // Deprecated, use GetAttributeInt32ForAllPoints instead.
+  GetAttributeIntForAllPoints(pc: PointCloud,
+                              pa: PointAttribute,
+                              out_values: DracoInt32Array): boolean;
+
+  GetAttributeInt8ForAllPoints(pc: PointCloud,
+                               pa: PointAttribute,
+                               out_values: DracoInt8Array): boolean;
+  GetAttributeUInt8ForAllPoints(pc: PointCloud,
+                                pa: PointAttribute,
+                                out_values: DracoUInt8Array): boolean;
+  GetAttributeInt16ForAllPoints(pc: PointCloud,
+                                pa: PointAttribute,
+                                out_values: DracoInt16Array): boolean;
+  GetAttributeUInt16ForAllPoints(pc: PointCloud,
+                                pa: PointAttribute,
+                                out_values: DracoUInt16Array): boolean;
+  GetAttributeInt32ForAllPoints(pc: PointCloud,
+                                pa: PointAttribute,
+                                out_values: DracoInt32Array): boolean;
+  GetAttributeUInt32ForAllPoints(pc: PointCloud,
+                                pa: PointAttribute,
+                                out_values: DracoUInt32Array): boolean;
+
+  GetAttributeDataArrayForAllPoints(
+    pc: PointCloud,
+    pa: PointAttribute,
+    data_type: draco_DataType,
+    out_size: number,
+    out_values: VoidPtr,
+  ): boolean;
+
+  SkipAttributeTransform(att_type: draco_GeometryAttribute_Type): void;
+}

--- a/modules/draco/src/types/draco-web-encoder.d.ts
+++ b/modules/draco/src/types/draco-web-encoder.d.ts
@@ -1,0 +1,251 @@
+// Interface exposed to emscripten's WebIDL Binder.
+// http://kripken.github.io/emscripten-site/docs/porting/connecting_cpp_and_javascript/WebIDL-Binder.html
+/* eslint-disable camelcase */
+
+import {
+  // GeometryAttribute,
+  // PointAttribute,
+  PointCloud,
+  Mesh,
+  Metadata,
+  DracoInt8Array
+} from './draco-web-decoder';
+
+
+type draco_GeometryAttribute_Type = number;
+type draco_EncodedGeometryType = number;
+type draco_MeshEncoderMethod = number;
+
+/*
+enum draco_GeometryAttribute_Type {
+  "draco_GeometryAttribute::INVALID",
+  "draco_GeometryAttribute::POSITION",
+  "draco_GeometryAttribute::NORMAL",
+  "draco_GeometryAttribute::COLOR",
+  "draco_GeometryAttribute::TEX_COORD",
+  "draco_GeometryAttribute::GENERIC"
+
+};
+
+enum draco_EncodedGeometryType {
+  "draco::INVALID_GEOMETRY_TYPE",
+  "draco::POINT_CLOUD",
+  "draco::TRIANGULAR_MESH"
+
+};
+
+enum draco_MeshEncoderMethod {
+  "draco::MESH_SEQUENTIAL_ENCODING",
+  "draco::MESH_EDGEBREAKER_ENCODING"
+};
+*/
+
+/*
+export class GeometryAttribute {
+  constructor();
+}
+
+export class PointAttribute {
+  constructor();
+  size(): number;
+
+  // From GeometryAttribute
+  attribute_type(): number;
+  data_type(): number;
+  num_components(): number;
+  normalized(): boolean;
+  byte_stride(): number;
+  byte_offset(): number;
+  unique_id(): number;
+}
+
+export class PointCloud {
+  constructor();
+  num_attributes(): number;
+  num_points(): number;
+}
+
+export class Mesh extends PointCloud {
+  constructor();
+  num_faces(): number;
+
+  // From PointCloud
+  num_attributes(): number;
+  num_points(): number;
+  set_num_points(num_points: number): void;
+}
+
+export class Metadata {
+  constructor();
+}
+
+export class DracoInt8Array {
+  constructor();
+  GetValue(index: number): number;
+  size(): number;
+}
+*/
+
+interface MetadataBuilder {
+  AddStringEntry(metadata: Metadata,
+                         entry_name: string,
+                         entry_value: string);
+  AddIntEntry(metadata: Metadata,
+                      entry_name: string,
+                      entry_value: number);
+  AddDoubleEntry(metadata: Metadata,
+      entry_name: string,
+      entry_value: number);
+}
+
+export class PointCloudBuilder {
+  constructor();
+  PointCloudBuilder(): void;
+  AddFloatAttribute(
+    pc: PointCloud,
+    type: draco_GeometryAttribute_Type,
+    num_vertices: number,
+    num_components: number,
+    att_values: Float32Array);
+  AddInt8Attribute(
+    pc: PointCloud,
+    type: draco_GeometryAttribute_Type,
+    num_vertices: number,
+    num_components: number,
+    att_values: Int8Array);
+  AddUInt8Attribute(
+    pc: PointCloud,
+    type: draco_GeometryAttribute_Type,
+    num_vertices: number,
+    num_components: number,
+    att_values: Uint8Array);
+  AddInt16Attribute(
+    pc: PointCloud,
+    type: draco_GeometryAttribute_Type,
+    num_vertices: number, num_components: number,
+    att_values: Int16Array);
+  AddUInt16Attribute(
+    pc: PointCloud,
+    type: draco_GeometryAttribute_Type,
+    num_vertices: number, num_components: number,
+    att_values: Uint16Array);
+  AddInt32Attribute(
+    pc: PointCloud,
+    type: draco_GeometryAttribute_Type,
+    num_vertices: number, num_components: number,
+    att_values: Int32Array);
+  AddUInt32Attribute(
+    pc: PointCloud,
+    type: draco_GeometryAttribute_Type,
+    num_vertices: number, num_components: number,
+    att_values: Uint32Array);
+
+  AddMetadata(pc: PointCloud, metadata: Metadata): boolean;
+  SetMetadataForAttribute(pc: PointCloud, attribute_id: number, metadata: Metadata);
+}
+
+export class MeshBuilder extends PointCloudBuilder {
+  constructor();
+  AddFacesToMesh(mesh: Mesh, num_faces: number, faces: number[]): boolean;
+
+  // From PointCloudBuilder
+  /*
+  AddFloatAttribute(
+    pc: PointCloud,
+    type: draco_GeometryAttribute_Type,
+    num_vertices: number, num_components: number,
+    att_values: number[]);
+  AddInt8Attribute(
+    pc: PointCloud,
+    type: draco_GeometryAttribute_Type,
+    num_vertices: number, num_components: number,
+    att_values: number[]);
+  AddUInt8Attribute(
+    pc: PointCloud,
+    type: draco_GeometryAttribute_Type,
+    num_vertices: number, num_components: number,
+    att_values: number[]);
+  AddInt16Attribute(
+    pc: PointCloud,
+    type: draco_GeometryAttribute_Type,
+    num_vertices: number, num_components: number,
+    att_values: number[]);
+  AddUInt16Attribute(
+    pc: PointCloud,
+    type: draco_GeometryAttribute_Type,
+    num_vertices: number, num_components: number,
+
+    att_values: number[]);
+  AddInt32Attribute(
+    pc: PointCloud,
+    type: draco_GeometryAttribute_Type,
+    num_vertices: number, num_components: number,
+    att_values: number[]);
+  AddUInt32Attribute(
+    pc: PointCloud,
+    type: draco_GeometryAttribute_Type,
+    num_vertices: number, num_components: number,
+    unsigned long[] att_values: number[]);
+
+  AddMetadata(pc: PointCloud, metadata: Metadata): boolean;
+  SetMetadataForAttribute(pc: PointCloud, attribute_id: number,
+                                  metadata: Metadata);
+  */
+}
+
+export class Encoder {
+  constructor();
+  Encoder(): void;
+  SetEncodingMethod(method: number): void;
+  SetAttributeQuantization(
+    type: draco_GeometryAttribute_Type,
+    quantization_bits: number);
+  SetAttributeExplicitQuantization(
+    type: draco_GeometryAttribute_Type,
+    quantization_bits: number,
+    num_components: number,
+    origin: number[],
+    range: number);
+  SetSpeedOptions(encoding_speed: number, decoding_speed: number): void;
+  SetTrackEncodedProperties(flag: boolean): void;
+
+  EncodeMeshToDracoBuffer(
+    mesh: Mesh,
+    encoded_data: DracoInt8Array
+  );
+  EncodePointCloudToDracoBuffer(
+    pc: PointCloud,
+    deduplicate_values: boolean,
+    encoded_data: DracoInt8Array
+  );
+
+  // Returns the number of encoded points or faces from the last Encode
+  // operation. Returns 0 if SetTrackEncodedProperties was not set to true.
+  GetNumberOfEncodedPoints(): number;
+  GetNumberOfEncodedFaces(): number;
+}
+
+export class ExpertEncoder {
+  constructor();
+  ExpertEncoder(pc: PointCloud): void;
+  SetEncodingMethod(method: number): void;
+  SetAttributeQuantization(att_id: number, quantization_bits: number);
+  SetAttributeExplicitQuantization(
+    att_id: number,
+    quantization_bits: number,
+    num_components: number,
+    origin: number[],
+    range: number);
+  SetSpeedOptions(encoding_speed: number, decoding_speed: number): void;
+  SetTrackEncodedProperties(flag: boolean): void;
+
+  EncodeToDracoBuffer(
+    deduplicate_values: boolean,
+    encoded_data: DracoInt8Array
+  );
+
+  // Returns the number of encoded points or faces from the last Encode
+  // operation. Returns 0 if SetTrackEncodedProperties was not set to true.
+  GetNumberOfEncodedPoints(): number;
+  GetNumberOfEncodedFaces(): number;
+}


### PR DESCRIPTION
- Introduce typescript types for the underlying draco3d library, semi-manually extracted from Web IDL.
- No functional changes
