### PR TITLE
draco: Custom attributes

### DIFF
--- a/modules/draco/src/draco-loader.js
+++ b/modules/draco/src/draco-loader.js
@@ -22,7 +22,7 @@ export const DracoWorkerLoader = {
       libraryPath: `libs/`,
       workerUrl: `https://unpkg.com/@loaders.gl/draco@${VERSION}/dist/draco-loader.worker.js`,
       localWorkerUrl: `modules/draco/dist/draco-loader.worker.dev.js`,
-      extraAttributes: null
+      extraAttributes: {}
     }
   }
 };

--- a/modules/draco/src/lib/draco-builder.js
+++ b/modules/draco/src/lib/draco-builder.js
@@ -218,7 +218,7 @@ export default class DracoBuilder {
       this.log(`Adding attribute ${attributeName}, size ${numFaces}`);
 
       // @ts-ignore assumes mesh is a Mesh, not a point cloud
-      this.meshBuilder.AddFacesToMesh(mesh, numFaces, attribute);
+      this.dracoMeshBuilder.AddFacesToMesh(mesh, numFaces, attribute);
       return -1;
     }
 

--- a/modules/draco/src/lib/draco-builder.js
+++ b/modules/draco/src/lib/draco-builder.js
@@ -47,9 +47,12 @@ export default class DracoBuilder {
   }
 
   // Encode mesh=({})
-  encodeSync(mesh, options) {
+  encodeSync(mesh, options = {}) {
     this._setOptions(options);
-    return options.pointcloud ? this._encodePointCloud(mesh) : this._encodeMesh(mesh);
+
+    return options.pointcloud
+      ? this._encodePointCloud(mesh, options)
+      : this._encodeMesh(mesh, options);
   }
 
   // PRIVATE
@@ -64,11 +67,11 @@ export default class DracoBuilder {
     return attributes;
   }
 
-  _encodePointCloud(pointcloud) {
+  _encodePointCloud(pointcloud, options) {
     const attributes = this._getAttributesFromMesh(pointcloud);
 
     // Build a `DracoPointCloud` from the input data
-    const dracoPointCloud = this._createDracoPointCloud(attributes);
+    const dracoPointCloud = this._createDracoPointCloud(attributes, options);
 
     const dracoData = new this.draco.DracoInt8Array();
 
@@ -93,10 +96,11 @@ export default class DracoBuilder {
     }
   }
 
-  _encodeMesh(mesh) {
+  _encodeMesh(mesh, options) {
     const attributes = this._getAttributesFromMesh(mesh);
+
     // Build a `DracoMesh` from the input data
-    const dracoMesh = this._createDracoMesh(attributes);
+    const dracoMesh = this._createDracoMesh(attributes, options);
 
     const dracoData = new this.draco.DracoInt8Array();
 
@@ -143,7 +147,7 @@ export default class DracoBuilder {
    * @param {object} attributes
    * @returns {Mesh}
    */
-  _createDracoMesh(attributes) {
+  _createDracoMesh(attributes, options) {
     const dracoMesh = new this.draco.Mesh();
 
     try {
@@ -170,7 +174,7 @@ export default class DracoBuilder {
    * @param {object} attributes
    * @returns {PointCloud}
    */
-  _createDracoPointCloud(attributes) {
+  _createDracoPointCloud(attributes, options) {
     const dracoPointCloud = new this.draco.PointCloud();
 
     try {
@@ -194,103 +198,57 @@ export default class DracoBuilder {
   }
 
   /**
-   * @param {PointCloud} dracoMesh
+   * @param {PointCloud} mesh
    * @param {string} attributeName
    * @param {TypedArray} attribute
    * @param {number} vertexCount
    */
-  _addAttributeToMesh(dracoMesh, attributeName, attribute, vertexCount) {
+  _addAttributeToMesh(mesh, attributeName, attribute, vertexCount) {
     if (!ArrayBuffer.isView(attribute)) {
-      return;
+      return -1;
     }
 
-    const dracoAttributeType = this._getDracoAttributeType(attributeName);
+    const type = this._getDracoAttributeType(attributeName);
     // @ts-ignore TODO/fix types
     const size = attribute.length / vertexCount;
 
-    if (dracoAttributeType === 'indices') {
+    if (type === 'indices') {
       // @ts-ignore TODO/fix types
       const numFaces = attribute.length / 3;
       this.log(`Adding attribute ${attributeName}, size ${numFaces}`);
 
       // @ts-ignore assumes mesh is a Mesh, not a point cloud
-      this.dracoMeshBuilder.AddFacesToMesh(dracoMesh, numFaces, attribute);
-      return;
+      this.meshBuilder.AddFacesToMesh(mesh, numFaces, attribute);
+      return -1;
     }
 
     this.log(`Adding attribute ${attributeName}, size ${size}`);
 
+    const builder = this.dracoMeshBuilder;
+    const {buffer} = attribute;
+
     switch (attribute.constructor) {
       case Int8Array:
-        this.dracoMeshBuilder.AddInt8Attribute(
-          dracoMesh,
-          dracoAttributeType,
-          vertexCount,
-          size,
-          new Int8Array(attribute.buffer)
-        );
-        break;
+        return builder.AddInt8Attribute(mesh, type, vertexCount, size, new Int8Array(buffer));
 
       case Int16Array:
-        this.dracoMeshBuilder.AddInt16Attribute(
-          dracoMesh,
-          dracoAttributeType,
-          vertexCount,
-          size,
-          new Int16Array(attribute.buffer)
-        );
-        break;
+        return builder.AddInt16Attribute(mesh, type, vertexCount, size, new Int16Array(buffer));
 
       case Int32Array:
-        this.dracoMeshBuilder.AddInt32Attribute(
-          dracoMesh,
-          dracoAttributeType,
-          vertexCount,
-          size,
-          new Int32Array(attribute.buffer)
-        );
-        break;
-
+        return builder.AddInt32Attribute(mesh, type, vertexCount, size, new Int32Array(buffer));
       case Uint8Array:
       case Uint8ClampedArray:
-        this.dracoMeshBuilder.AddUInt8Attribute(
-          dracoMesh,
-          dracoAttributeType,
-          vertexCount,
-          size,
-          new Uint8Array(attribute.buffer)
-        );
-        break;
+        return builder.AddUInt8Attribute(mesh, type, vertexCount, size, new Uint8Array(buffer));
 
       case Uint16Array:
-        this.dracoMeshBuilder.AddUInt16Attribute(
-          dracoMesh,
-          dracoAttributeType,
-          vertexCount,
-          size,
-          new Uint16Array(attribute.buffer)
-        );
-        break;
+        return builder.AddUInt16Attribute(mesh, type, vertexCount, size, new Uint16Array(buffer));
 
       case Uint32Array:
-        this.dracoMeshBuilder.AddUInt32Attribute(
-          dracoMesh,
-          dracoAttributeType,
-          vertexCount,
-          size,
-          new Uint32Array(attribute.buffer)
-        );
-        break;
+        return builder.AddUInt32Attribute(mesh, type, vertexCount, size, new Uint32Array(buffer));
 
       case Float32Array:
       default:
-        this.dracoMeshBuilder.AddFloatAttribute(
-          dracoMesh,
-          dracoAttributeType,
-          vertexCount,
-          size,
-          new Float32Array(attribute.buffer)
-        );
+        return builder.AddFloatAttribute(mesh, type, vertexCount, size, new Float32Array(buffer));
     }
   }
 
@@ -335,7 +293,10 @@ export default class DracoBuilder {
 
 // HELPER FUNCTIONS
 
-// Copy encoded data to buffer
+/**
+ * Copy encoded data to buffer
+ * @param {*} dracoData
+ */
 function dracoInt8ArrayToArrayBuffer(dracoData) {
   const byteLength = dracoData.size();
   const outputBuffer = new ArrayBuffer(byteLength);

--- a/modules/draco/src/lib/draco-parser.js
+++ b/modules/draco/src/lib/draco-parser.js
@@ -43,7 +43,7 @@ export default class DracoParser {
   }
 
   // NOTE: caller must call `destroyGeometry` on the return value after using it
-  parseSync(arrayBuffer, options) {
+  parseSync(arrayBuffer, options = {}) {
     const buffer = new this.draco.DecoderBuffer();
     buffer.Init(new Int8Array(arrayBuffer), arrayBuffer.byteLength);
 
@@ -116,15 +116,12 @@ export default class DracoParser {
    * @param {object} options
    */
   _extractDRACOGeometry(decoder, dracoGeometry, geometryType, geometry, options) {
-    // Structure for converting to WebGL framework specific attributes later
-    const attributes = this.getAttributes(decoder, dracoGeometry, options);
+    const attributes = this._getAttributes(decoder, dracoGeometry, options);
 
     const positionAttribute = attributes.POSITION;
     if (!positionAttribute) {
       throw new Error('DRACO decompressor: No position attribute found.');
     }
-
-    this.getPositionAttributeMetadata(positionAttribute);
 
     // For meshes, we need indices to define the faces.
     if (geometryType === this.draco.TRIANGULAR_MESH) {
@@ -154,26 +151,44 @@ export default class DracoParser {
     return geometry;
   }
 
-  getPositionAttributeMetadata(positionAttribute) {
-    this.metadata = this.metadata || {};
-    this.metadata.attributes = this.metadata.attributes || {};
+  _getAttributes(decoder, dracoGeometry, options) {
+    const attributes = {};
+    const numPoints = dracoGeometry.num_points();
+    // const attributeUniqueIdMap = {};
 
-    const posTransform = new this.draco.AttributeQuantizationTransform();
-    if (posTransform.InitFromAttribute(positionAttribute)) {
-      // Quantized attribute. Store the quantization parameters into the attribute
-      this.metadata.attributes.position.isQuantized = true;
-      this.metadata.attributes.position.maxRange = posTransform.range();
-      this.metadata.attributes.position.numQuantizationBits = posTransform.quantization_bits();
-      this.metadata.attributes.position.minValues = new Float32Array(3);
-      for (let i = 0; i < 3; ++i) {
-        this.metadata.attributes.position.minValues[i] = posTransform.min_value(i);
-      }
+    // Note: Draco docs do not seem clear on `GetAttribute` accepting a zero-based index,
+    // but it seems to work this way
+    for (let attributeId = 0; attributeId < dracoGeometry.num_attributes(); attributeId++) {
+      const dracoAttribute = decoder.GetAttribute(dracoGeometry, attributeId);
+      const attributeData = {
+        uniqueId: dracoAttribute.unique_id(),
+        attributeType: dracoAttribute.attribute_type(),
+        dataType: DRACO_DATA_TYPE_TO_TYPED_ARRAY_MAP[dracoAttribute.data_type()],
+        size: dracoAttribute.size(),
+        numComponents: dracoAttribute.num_components(),
+        byteOffset: dracoAttribute.byte_offset(),
+        byteStride: dracoAttribute.byte_stride(),
+        normalized: dracoAttribute.normalized()
+      };
+
+      // DRACO does not save attribute names - We need to deduce an attribute name
+      const attributeName = this._deduceAttributeName(attributeData, options);
+      const {typedArray} = this._getAttributeTypedArray(
+        decoder,
+        dracoGeometry,
+        dracoAttribute,
+        attributeName
+      );
+      attributes[attributeName] = {
+        value: typedArray,
+        size: typedArray.length / numPoints
+      };
     }
-    this.draco.destroy(posTransform);
+
+    return attributes;
   }
 
   /**
-   *
    * @param {Decoder} decoder
    * @param {*} dracoGeometry
    */
@@ -349,6 +364,37 @@ export default class DracoParser {
     this.draco.destroy(dracoArray);
 
     return {typedArray, components: numComponents};
+  }
+
+  /**
+   * Deduce an attribute name.
+   * @note DRACO does not save attribute names, just general type (POSITION, COLOR)
+   * to help optimize compression. We generate GLTF compatible names for the Draco-recognized
+   * types
+   * @param {object} attributeData
+   */
+  _deduceAttributeName(attributeData, options) {
+    const {extraAttributes = {}} = options;
+    for (const [attributeName, attributeUniqueId] of Object.entries(extraAttributes)) {
+      if (attributeUniqueId === attributeData.uniqueId) {
+        return attributeName;
+      }
+    }
+
+    for (const dracoAttributeConstant in DRACO_TO_GLTF_ATTRIBUTE_NAME_MAP) {
+      const attributeType = this.draco[dracoAttributeConstant];
+      if (attributeData.attributeType === attributeType) {
+        // TODO - Return unique names if there multiple attributes per type
+        // (e.g. multiple TEX_COORDS or COLORS)
+        return DRACO_TO_GLTF_ATTRIBUTE_NAME_MAP[dracoAttributeConstant];
+      }
+    }
+
+    // TODO look for name in metadata?
+    // The loaders.gl DracoEncoder could write a name into metadata...
+
+    // Attribute of "GENERIC" type, we need to assign some name
+    return `CUSTOM_ATTRIBUTE_${attributeData.uniqueId}`;
   }
 
   // DEPRECATED

--- a/modules/draco/src/lib/draco-parser.js
+++ b/modules/draco/src/lib/draco-parser.js
@@ -189,63 +189,6 @@ export default class DracoParser {
   }
 
   /**
-   * @param {Decoder} decoder
-   * @param {*} dracoGeometry
-   */
-  getAttributes(decoder, dracoGeometry, options) {
-    const attributes = {};
-    const numPoints = dracoGeometry.num_points();
-    // const attributeUniqueIdMap = {};
-
-    for (const attributeName in DRACO_TO_GLTF_ATTRIBUTE_NAME_MAP) {
-      // The native attribute type is only used when no unique Id is provided.
-      // For example, loading .drc files.
-      // if (attributeUniqueIdMap[attributeName] === undefined) {
-      const attributeType = this.draco[attributeName];
-      const attributeId = decoder.GetAttributeId(dracoGeometry, attributeType);
-
-      if (attributeId !== -1) {
-        const dracoAttribute = decoder.GetAttribute(dracoGeometry, attributeId);
-        const {typedArray} = this._getAttributeTypedArray(
-          decoder,
-          dracoGeometry,
-          dracoAttribute,
-          attributeName
-        );
-        attributes[DRACO_TO_GLTF_ATTRIBUTE_NAME_MAP[attributeName]] = {
-          value: typedArray,
-          size: typedArray.length / numPoints
-        };
-      }
-    }
-    if (options.extraAttributes) {
-      for (const [attributeName, attributeUniqueId] of Object.entries(options.extraAttributes)) {
-        const dracoAttribute = decoder.GetAttributeByUniqueId(dracoGeometry, attributeUniqueId);
-
-        const {typedArray} = this._getAttributeTypedArray(
-          decoder,
-          dracoGeometry,
-          dracoAttribute,
-          attributeName
-        );
-        attributes[attributeName] = {
-          value: typedArray,
-          size: typedArray.length / numPoints
-        };
-      }
-    }
-    // // Add attributes of user specified unique id. E.g. GLTF models.
-    // for (const attributeName in attributeUniqueIdMap) {
-    //   const attributeType = attributeTypeMap[attributeName] || Float32Array;
-    //   const attributeId = attributeUniqueIdMap[attributeName];
-    //   const attribute = decoder.GetAttributeByUniqueId(dracoGeometry, attributeId);
-    //   this._getAttributeTypedArray(decoder, dracoGeometry, attribute,attributeName,attributeType);
-    // }
-
-    return attributes;
-  }
-
-  /**
    * For meshes, we need indices to define the faces.
    * @param {Decoder} decoder
    * @param {*} dracoGeometry

--- a/modules/draco/test/draco-loader.spec.js
+++ b/modules/draco/test/draco-loader.spec.js
@@ -27,8 +27,22 @@ test('DracoLoader#parse(mainthread)', async t => {
   t.end();
 });
 
-test('DracoLoader#parse extra attributes(mainthread)', async t => {
-  const data = await load(CESIUM_TILE_URL, DracoLoader, {
+test('DracoLoader#parse custom attributes(mainthread)', async t => {
+  let data = await load(CESIUM_TILE_URL, DracoLoader, {
+    worker: false
+  });
+  t.equal(
+    data.attributes.CUSTOM_ATTRIBUTE_2.value.length,
+    173210,
+    'Custom (Intensity) attribute was found'
+  );
+  t.equal(
+    data.attributes.CUSTOM_ATTRIBUTE_3.value.length,
+    173210,
+    'Custom (Classification) attribute was found'
+  );
+
+  data = await load(CESIUM_TILE_URL, DracoLoader, {
     worker: false,
     draco: {
       extraAttributes: {
@@ -43,6 +57,7 @@ test('DracoLoader#parse extra attributes(mainthread)', async t => {
     173210,
     'Classification attribute was found'
   );
+
   t.end();
 });
 


### PR DESCRIPTION
An improvement from @Avnerus PR #940:
- the DracoLoader now automatically detects custom attributes (giving them default names unless provided in `options.draco.extraAttributes`).