### PR TITLE
Set isTileset to 'auto' in tile-3d to enable loading an external tileset json within a tile

### DIFF
--- a/modules/tiles/src/tileset/tile-3d.js
+++ b/modules/tiles/src/tileset/tile-3d.js
@@ -208,7 +208,7 @@ export default class TileHeader {
         [loader.id]: {
           tile: this.header,
           tileset: this.tileset.tileset,
-          isTileset: false,
+          isTileset: 'auto',
           isTileHeader: false
         }
       };


### PR DESCRIPTION
Hi!
As I mentioned earlier, external tileset JSONs within tiles were not loading from my Cesium ION data.  
It seems like all I had to do was change the `isTileset` to `auto`.
Unfortunately, I don't have a public test case available with external tilesets, because they are only used by Cesium in larger datasets (~5Gb or more), but perhaps you have one available that you can test this on?
I have confirmed on my ION account that before the enclosed fix I get the following error:
`A 3D tile failed to load: undefined 3DTileLoader: unknown type {"as` because the JSON is attempting to load as a binary tile.
After the fix it seems to work! Looks like that `false` was set in [this PR](https://github.com/visgl/loaders.gl/pull/827/commits).
Let me know if this is OK, or if you need alarge data to test on I can try to arrange an ION account that I can share. 
Thank you! 
/Avner