### PR TITLE
Draco: Fix for the case that extraAttriutes are provided in options but are null.

### DIFF
--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile-point-cloud.js
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile-point-cloud.js
@@ -206,7 +206,7 @@ export async function loadDraco(tile, dracoData, options, context) {
   const {parse} = context;
   const data = await parse(dracoData.buffer, DracoLoader, {
     draco: {
-      extraAttributes: dracoData.batchTableProperties
+      extraAttributes: dracoData.batchTableProperties || {}
     }
   });
 

--- a/modules/draco/src/lib/draco-parser.js
+++ b/modules/draco/src/lib/draco-parser.js
@@ -318,9 +318,11 @@ export default class DracoParser {
    */
   _deduceAttributeName(attributeData, options) {
     const {extraAttributes = {}} = options;
-    for (const [attributeName, attributeUniqueId] of Object.entries(extraAttributes)) {
-      if (attributeUniqueId === attributeData.uniqueId) {
-        return attributeName;
+    if (extraAttributes && typeof extraAttributes === 'object') {
+      for (const [attributeName, attributeUniqueId] of Object.entries(extraAttributes)) {
+        if (attributeUniqueId === attributeData.uniqueId) {
+          return attributeName;
+        }
       }
     }
 


### PR DESCRIPTION
Hi,
It looks like the recent fixes broke the cases in which there is no batch table json, such as in the Melbourne example on the loaders.gl website. The `extraAttirbutes` key was present in `options`, but was `null` which caused the loader to crash. 
I added a check both in `DracoLoader`,  and in the point cloud parser.
/Avner