### PR TITLE
Set worker url to local file for shapefile tests

### DIFF
--- a/modules/shapefile/test/dbf-loader.spec.js
+++ b/modules/shapefile/test/dbf-loader.spec.js
@@ -1,6 +1,12 @@
 import test from 'tape-promise/tape';
-import {fetchFile, parse} from '@loaders.gl/core';
+import {setLoaderOptions, fetchFile, parse} from '@loaders.gl/core';
 import {DBFLoader} from '@loaders.gl/shapefile';
+
+setLoaderOptions({
+  dbf: {
+    workerUrl: 'modules/shapefile/dist/dbf-loader.worker.js'
+  }
+});
 
 const SHAPEFILE_JS_DATA_FOLDER = '@loaders.gl/shapefile/test/data/shapefile-js';
 const SHAPEFILE_JS_TEST_FILES = [

--- a/modules/shapefile/test/shapefile-loader.spec.js
+++ b/modules/shapefile/test/shapefile-loader.spec.js
@@ -1,10 +1,25 @@
 /* global File */
 import test from 'tape-promise/tape';
-import {fetchFile, load, loadInBatches, selectLoader} from '@loaders.gl/core';
-import {_BrowserFileSystem as BrowserFileSystem} from '@loaders.gl/core';
+import {
+  setLoaderOptions,
+  fetchFile,
+  load,
+  loadInBatches,
+  selectLoader,
+  _BrowserFileSystem as BrowserFileSystem
+} from '@loaders.gl/core';
 import {ShapefileLoader} from '@loaders.gl/shapefile';
 import {Proj4Projection} from '@math.gl/proj4';
 import {tapeEqualsEpsilon} from 'test/utils/tape-assertions';
+
+setLoaderOptions({
+  dbf: {
+    workerUrl: 'modules/shapefile/dist/dbf-loader.worker.js'
+  },
+  shp: {
+    workerUrl: 'modules/shapefile/dist/shp-loader.worker.js'
+  }
+});
 
 const SHAPEFILE_JS_DATA_FOLDER = '@loaders.gl/shapefile/test/data/shapefile-js';
 const SHAPEFILE_JS_TEST_FILES = {

--- a/modules/shapefile/test/shp-loader.spec.js
+++ b/modules/shapefile/test/shp-loader.spec.js
@@ -1,5 +1,5 @@
 import test from 'tape-promise/tape';
-import {load, fetchFile} from '@loaders.gl/core';
+import {setLoaderOptions, load, fetchFile} from '@loaders.gl/core';
 import {geojsonToBinary} from '@loaders.gl/gis';
 import {SHPLoader} from '@loaders.gl/shapefile';
 
@@ -8,6 +8,12 @@ const SHAPEFILE_JS_DATA_FOLDER = '@loaders.gl/shapefile/test/data/shapefile-js';
 const SHAPEFILE_JS_POINT_TEST_FILES = ['points', 'multipoints'];
 const SHAPEFILE_JS_POLYLINE_TEST_FILES = ['polylines'];
 const SHAPEFILE_JS_POLYGON_TEST_FILES = ['polygons'];
+
+setLoaderOptions({
+  shp: {
+    workerUrl: 'modules/shapefile/dist/shp-loader.worker.js'
+  }
+});
 
 test('SHPLoader#load polygons', async t => {
   const result = await load(SHAPEFILE_POLYGON_PATH, SHPLoader);


### PR DESCRIPTION
Tests were unreliable/failing because shapefile tests were trying to use remote worker bundles.