### PR TITLE
Option to use float64 for LAS positions

### DIFF
--- a/modules/las/docs/api-reference/las-loader.md
+++ b/modules/las/docs/api-reference/las-loader.md
@@ -26,5 +26,6 @@ const data = await load(url, LASLoader, options);
 | Option                   | Type             | Default | Description                                                                                                    |
 | ------------------------ | ---------------- | ------- | -------------------------------------------------------------------------------------------------------------- |
 | `options.las.skip`       | Number           | `1`     | Read one from every _n_ points.                                                                                |
+| `options.las.fp64`       | Number           | `false` | If `true`, positions are stored in 64-bit floats instead of 32-bit.                                            |
 | `options.las.colorDepth` | Number or string | `8`     | Whether colors encoded using 8 or 16 bits? Can be set to `'auto'`. Note: LAS specification recommends 16 bits. |
 | `options.onProgress`     | Function         | -       | Callback when a new chunk of data is read. Only works on the main thread.                                      |

--- a/modules/las/src/las-loader.js
+++ b/modules/las/src/las-loader.js
@@ -20,6 +20,7 @@ export const LASWorkerLoader = {
   options: {
     las: {
       workerUrl: `https://unpkg.com/@loaders.gl/las@${VERSION}/dist/las-loader.worker.js`,
+      fp64: false,
       skip: 1,
       colorDepth: 8
     }

--- a/modules/las/src/lib/parse-las.js
+++ b/modules/las/src/lib/parse-las.js
@@ -49,7 +49,7 @@ export default function parseLAS(arraybuffer, options = {}) {
       originalHeader = header;
       const total = header.totalToRead;
 
-      positions = new Float32Array(total * 3);
+      positions = new Float64Array(total * 3);
       // laslaz-decoder.js `pointFormatReaders`
       colors = header.pointsFormatId >= 2 ? new Uint8Array(total * 4) : null;
       intensities = new Uint16Array(total);

--- a/modules/las/src/lib/parse-las.js
+++ b/modules/las/src/lib/parse-las.js
@@ -42,14 +42,15 @@ export default function parseLAS(arraybuffer, options = {}) {
 
   const result = {};
   const {onProgress} = options;
-  const {skip, colorDepth} = options.las || {};
+  const {skip, colorDepth, fp64} = options.las || {};
 
   parseLASChunked(arraybuffer, skip, (decoder, header) => {
     if (!originalHeader) {
       originalHeader = header;
       const total = header.totalToRead;
 
-      positions = new Float64Array(total * 3);
+      const PositionsType = fp64 ? Float64Array : Float32Array;
+      positions = new PositionsType(total * 3);
       // laslaz-decoder.js `pointFormatReaders`
       colors = header.pointsFormatId >= 2 ? new Uint8Array(total * 4) : null;
       intensities = new Uint16Array(total);

--- a/modules/las/test/las-loader.spec.js
+++ b/modules/las/test/las-loader.spec.js
@@ -33,6 +33,28 @@ test('LASLoader#parse(binary)', async t => {
   t.end();
 });
 
+test('LASLoader#options', async t => {
+  const data = await parse(fetchFile(LAS_BINARY_URL), LASLoader, {
+    las: {skip: 100, fp64: false},
+    worker: false
+  });
+  t.ok(
+    data.attributes.POSITION.value instanceof Float32Array,
+    'POSITION attribute is Float32Array'
+  );
+
+  const data64 = await parse(fetchFile(LAS_BINARY_URL), LASLoader, {
+    las: {skip: 100, fp64: true},
+    worker: false
+  });
+  t.ok(
+    data64.attributes.POSITION.value instanceof Float64Array,
+    'POSITION attribute is Float64Array'
+  );
+
+  t.end();
+});
+
 test('LASWorker#parse(binary) extra bytes', async t => {
   const data = await parse(fetchFile(LAS_EXTRABYTES_BINARY_URL), LASLoader, {
     las: {skip: 10},

--- a/modules/pcd/src/lib/parse-pcd.js
+++ b/modules/pcd/src/lib/parse-pcd.js
@@ -66,7 +66,8 @@ function getNormalizedHeader(PCDheader, attributes) {
 function getNormalizedAttributes(attributes) {
   const normalizedAttributes = {
     POSITION: {
-      value: new Float64Array(attributes.position),
+      // Binary PCD is only 32 bit
+      value: new Float32Array(attributes.position),
       size: 3
     }
   };

--- a/modules/pcd/src/lib/parse-pcd.js
+++ b/modules/pcd/src/lib/parse-pcd.js
@@ -66,7 +66,7 @@ function getNormalizedHeader(PCDheader, attributes) {
 function getNormalizedAttributes(attributes) {
   const normalizedAttributes = {
     POSITION: {
-      value: new Float32Array(attributes.position),
+      value: new Float64Array(attributes.position),
       size: 3
     }
   };


### PR DESCRIPTION
https://github.com/visgl/deck.gl/issues/3914

Open for discussion: should we provide options for 64-bit positions in all modules?
- Point clouds (this PR): I think 64-bit should be the default, so that users do not have to worry about the precision.
- More advanced formats like glTF and Draco have built-in data types.
- Simple meshes (OBJ, PLY etc.): it has not come up as an issue, since deck's SimpleMeshLayer only supports 32-bit mesh positions. However the users may want to do custom rendering.