### PR TITLE
Add browser excludes for shapefile

### DIFF
--- a/modules/shapefile/package.json
+++ b/modules/shapefile/package.json
@@ -21,6 +21,10 @@
   "module": "dist/esm/index.js",
   "esnext": "dist/es6/index.js",
   "sideEffects": false,
+  "browser": {
+    "./src/lib/filesystems/node-filesystem.js": false,
+    "fs": false
+  },
   "files": [
     "src",
     "dist",


### PR DESCRIPTION
Closes #988 

Does the file itself need an exclude, or just `fs`? If so does it need paths in `dist/` as well like 

https://github.com/visgl/loaders.gl/blob/3e7a4f8b8bb1ddcef7c2e26c7cc8e07d3b0cf546/modules/core/package.json#L25-L35