### PR TITLE
Change Draco modules to be created asynchronously

### DIFF
--- a/modules/draco/src/lib/draco-module-loader.js
+++ b/modules/draco/src/lib/draco-module-loader.js
@@ -15,10 +15,8 @@ export async function loadDracoDecoderModule(options) {
     loadDecoderPromise =
       loadDecoderPromise ||
       new Promise(resolve => {
-        const draco = modules.draco3d.createDecoderModule({
-          onModuleLoaded() {
-            resolve({draco});
-          }
+        modules.draco3d.createDecoderModule({}).then(function(module) {
+          resolve(module);
         });
       });
   } else {
@@ -36,10 +34,8 @@ export async function loadDracoEncoderModule(options) {
     loadEncoderPromise =
       loadEncoderPromise ||
       new Promise(resolve => {
-        const draco = modules.draco3d.createEncoderModule({
-          onModuleLoaded() {
-            resolve({draco});
-          }
+        modules.draco3d.createEncoderModule({}).then(function(module) {
+          resolve(module);
         });
       });
   } else {


### PR DESCRIPTION
In general Draco npm modules have always been created asynchronously.

We are planning to release Draco 1.4.0, which uses a new version of emscripten and causes applications to fail more often if they were getting created synchronously as the timing has changed.

Will this change work in your code?