### PR TITLE
Row based parsing: Option to enable memory usage optimizations.

### DIFF
--- a/modules/tables/src/lib/table/row-table-batch.js
+++ b/modules/tables/src/lib/table/row-table-batch.js
@@ -43,7 +43,7 @@ export default class RowTableBatch {
     this.rows[this.length] = convertToObject ? convertRowToObject(row, this._headers) : row;
 
     if (this.optimizeMemoryUsage) {
-      // A workaround to allocate new strings and don't retain retain pointers to original strings.
+      // A workaround to allocate new strings and don't retain pointers to original strings.
       // https://bugs.chromium.org/p/v8/issues/detail?id=2869
       this.rows[this.length] = JSON.parse(JSON.stringify(this.rows[this.length]));
     }

--- a/modules/tables/src/lib/table/row-table-batch.js
+++ b/modules/tables/src/lib/table/row-table-batch.js
@@ -1,6 +1,8 @@
 const DEFAULT_OPTIONS = {
   batchSize: 'auto',
-  convertToObject: true
+  convertToObject: true,
+  // optimizes memory usage but increases parsing time.
+  optimizeMemoryUsage: false
 };
 
 export default class RowTableBatch {
@@ -10,6 +12,7 @@ export default class RowTableBatch {
     this.schema = schema;
     this.batchSize = options.batchSize;
     this.convertToObject = options.convertToObject;
+    this.optimizeMemoryUsage = options.optimizeMemoryUsage;
 
     this.rows = null;
     this.length = 0;
@@ -38,6 +41,13 @@ export default class RowTableBatch {
     // We can only convert if we were given a schema
     const convertToObject = this.convertToObject && this.schema;
     this.rows[this.length] = convertToObject ? convertRowToObject(row, this._headers) : row;
+
+    if (this.optimizeMemoryUsage) {
+      // A workaround to allocate new strings and don't retain retain pointers to original strings.
+      // https://bugs.chromium.org/p/v8/issues/detail?id=2869
+      this.rows[this.length] = JSON.parse(JSON.stringify(this.rows[this.length]));
+    }
+
     this.length++;
   }
 


### PR DESCRIPTION
An optional fix to decrease memory usage during and after parsing of row based datasets.
The issue was caused by following "feature" of JS implementation: https://bugs.chromium.org/p/v8/issues/detail?id=2869

Example of string views in Chrome's memory profiler. For some of our datasets the profiler found 1000+ levels of views which caused memory explosions.
![concatenated-string-memory](https://user-images.githubusercontent.com/8210766/98699045-60654380-237f-11eb-97df-4d8f8d4cf4d4.png)

Summary from testings:
- 480 Mb dataset, with long rows. The dataset was crashing during parsing (used around 4+Gb). With the fix the dataset is parsed without issues and fits in 600Mb memory.
- 636 Mb dataset (timestamp and h3 index per row). 58% longer parsing time, 338 Mb less memory used (12-17% less)
- 280 Mb dataset (timestamp and h3 index per row). 58% longer parsing	time, 100 Mb less memory used (15-20% less)
- 25 Mb dataset (10 columns per row). 60%-80% longer parsing time, 39 Mb less memory used (43-49% less)
- 25.7 Mb dataset (many columns, mostly numbers) 120% longer parsing	time, 64 Mb less memory used (52-61% less)
- 5.1 Mb dataset ("regular dataset) 55% longer parsing, 12.5 Mb less memery used (27-48% less)
- 1 line csv file: Small dataset to test how an almost empty dataset impacts memory > minor effect	

Note: I used `row = JSON.parse(JSON.stringify(this.rows)) ` as it was the only consistent way to force JS implementation to create strings unrelated to original strings that were used during parsing. `(' ' + s).substr(1);` workaround doesn't work in all cases, and causes memory expolosion for datasets with a lot of short strings.

