### PR TITLE
Fix polygonIndices uint16 overflow with large rings

### DIFF
--- a/modules/shapefile/src/lib/parsers/parse-shp-geometry.js
+++ b/modules/shapefile/src/lib/parsers/parse-shp-geometry.js
@@ -208,7 +208,7 @@ function parsePoly(view, offset, dim, type) {
   return {
     positions: {value: positions, size: dim},
     primitivePolygonIndices: {value: ringIndices, size: 1},
-    polygonIndices: {value: new Uint16Array(polygonIndices), size: 1},
+    polygonIndices: {value: new Uint32Array(polygonIndices), size: 1},
     type
   };
 }

--- a/modules/shapefile/src/lib/parsers/parse-shp-geometry.js
+++ b/modules/shapefile/src/lib/parsers/parse-shp-geometry.js
@@ -208,6 +208,10 @@ function parsePoly(view, offset, dim, type) {
   return {
     positions: {value: positions, size: dim},
     primitivePolygonIndices: {value: ringIndices, size: 1},
+    // TODO: Dynamically choose Uint32Array over Uint16Array only when
+    // necessary. I believe the implementation requires nPoints to be the
+    // largest value in the array, so you should be able to use Uint32Array only
+    // when nPoints > 65535.
     polygonIndices: {value: new Uint32Array(polygonIndices), size: 1},
     type
   };


### PR DESCRIPTION
When a Shapefile has a Polygon geometry with a very large number of positions, indices for polygon rings can be greater than 65535.