### PR TITLE
Fix shapefile batch parsing when options.metadata: true

### DIFF
--- a/modules/shapefile/src/lib/parsers/parse-dbf.js
+++ b/modules/shapefile/src/lib/parsers/parse-dbf.js
@@ -72,8 +72,14 @@ export async function* parseDBFInBatches(asyncIterator, options) {
   const {encoding} = loaderOptions;
 
   const parser = new DBFParser({encoding});
+  let headerReturned = false;
   for await (const arrayBuffer of asyncIterator) {
     parser.write(arrayBuffer);
+    if (!headerReturned && parser.result.dbfHeader) {
+      headerReturned = true;
+      yield parser.result.dbfHeader;
+    }
+
     if (parser.result.data.length > 0) {
       yield parser.result.data;
       parser.result.data = [];

--- a/modules/shapefile/src/lib/parsers/parse-shapefile.js
+++ b/modules/shapefile/src/lib/parsers/parse-shapefile.js
@@ -66,7 +66,7 @@ export async function* parseShapefileInBatches(asyncIterator, options, context) 
       encoding: cpg,
       prj,
       shx,
-      header: {shp: shapeHeader, dbf: dbfHeader},
+      header: shapeHeader,
       data: features
     };
   }

--- a/modules/shapefile/test/shapefile-loader.spec.js
+++ b/modules/shapefile/test/shapefile-loader.spec.js
@@ -167,6 +167,20 @@ test('ShapefileLoader#loadInBatches(File)', async t => {
   t.end();
 });
 
+test('ShapefileLoader#loadInBatches when options.metadata: true', async t => {
+  const testFileName = Object.keys(SHAPEFILE_JS_TEST_FILES)[0];
+  const filename = `${SHAPEFILE_JS_DATA_FOLDER}/${testFileName}.shp`;
+  const batches = await loadInBatches(filename, ShapefileLoader, {metadata: true});
+  let data;
+  for await (const batch of batches) {
+    data = batch;
+    // t.comment(`${filename}: ${JSON.stringify(data).slice(0, 70)}`);
+  }
+  await testShapefileData(t, testFileName, data);
+
+  t.end();
+});
+
 async function getFileList(testFileName) {
   const EXTENSIONS = ['.shp', '.shx', '.dbf', '.cpg', '.prj'];
   const fileList = [];


### PR DESCRIPTION
When `options.metadata` is `true`, an extra initial batch of metadata is returned when using `loadInBatches`. Since the `ShapefileLoader` creates the `SHPLoader` and `DBFLoader` under the hood and then iterates over them together using `zipBatchIterator`, it needs to understand the format of batches returned by each of them. `zipBatchIterator` currently expects batches to be an `Array` and will fail when either is not an array.