### PR TITLE
Add pull_request_target event to github actions template

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: test
 
-on: [push]
+on: [push, pull_request_target]
 
 jobs:
   test:


### PR DESCRIPTION
As noted in #1015, Github Actions currently doesn't run for a pull request from a fork. I believe `pull_request_target` needs to be added for this to happen.

Note that `pull_request_target` [is safer than](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/) `pull_request` because:

> instead of running against the workflow and code from the merge commit, the event runs against the workflow and code from the base of the pull request. This means the workflow is running from a trusted source and is given access to a read/write token as well as secrets enabling the maintainer to safely comment on or label a pull request

Full `pull_request_target` docs: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#pull_request_target