### PR TITLE
Deduplicate gh actions on pull request

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,11 @@
 name: test
 
-on: [push, pull_request_target]
+# On every pull request, but only on push to master
+on:
+  push:
+    branches:
+    - master
+  pull_request_target:
 
 jobs:
   test:


### PR DESCRIPTION
The PR #1016 was necessary to allow CI to run on PRs from forks. However this now duplicates tests on pull requests made from a branch of the `visgl/loaders.gl` repository, since it counts as a `push` and a `pull_request_target`. Apparently [the standard way to prevent both from happening](https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662) this should be something like:

```yaml
on:
  push:
    branches:
    - master
  pull_request_target:
```

So that every pull request runs CI but `push` only runs separately for new commits to master