### PR TITLE
Fix options table rendering in parse.md

### DIFF
--- a/modules/core/docs/api-reference/parse.md
+++ b/modules/core/docs/api-reference/parse.md
@@ -90,12 +90,12 @@ Note that additional data types can be converted to `Response` objects and used 
 
 Top-level options
 
-| Option                           | Type                                 | Default    | Description                                                                                                                                           |
-| -------------------------------- | ------------------------------------ | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `options.fetch`                  | `object | (url: string) => Response` | `{}`       | Specifies either an object with options to pass to `fetchFile`, or a function that is called in place of `fetchFile` to fetch data in any subloaders. |
-| `options.metadata`               | boolean                              | `false`    | Currently only implemented for `parseInBatches`, adds initial metadata batch                                                                          |
-| `options.log`                    | object                               | `console`  | By default set to a `console` wrapper. Setting log to `null` will turn off logging.                                                                   |
-| `options.worker`                 | boolean                              | `true`     | If the selected loader is equipped with a worker url (and the runtime environment supports it) parse on a worker thread.                              |
-| `options.<loader-id>.workerUrl`  | string                               | per-loader | If the corresponding loader can parse on a worker, the url to the worker script can be controller with this option.                                   |
-| `options.modules` (experimental) | object                               | -          | Supply bundled modules (like draco3d) instead of loading from CDN.                                                                                    |
-| `options.CDN` (experimental)     | string                               | -          | Controls certain script loading from CDN. `true` loads from `unpkg.com/@loaders.gl`. `false` load from local urls. `string` alternate CDN url.        |
+| Option                           | Type               | Default    | Description                                                                                                                                           |
+| -------------------------------- | ------------------ | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `options.fetch`                  | object or function | `{}`       | Specifies either an object with options to pass to `fetchFile`, or a function that is called in place of `fetchFile` to fetch data in any subloaders. |
+| `options.metadata`               | boolean            | `false`    | Currently only implemented for `parseInBatches`, adds initial metadata batch                                                                          |
+| `options.log`                    | object             | `console`  | By default set to a `console` wrapper. Setting log to `null` will turn off logging.                                                                   |
+| `options.worker`                 | boolean            | `true`     | If the selected loader is equipped with a worker url (and the runtime environment supports it) parse on a worker thread.                              |
+| `options.<loader-id>.workerUrl`  | string             | per-loader | If the corresponding loader can parse on a worker, the url to the worker script can be controller with this option.                                   |
+| `options.modules` (experimental) | object             | -          | Supply bundled modules (like draco3d) instead of loading from CDN.                                                                                    |
+| `options.CDN` (experimental)     | string             | -          | Controls certain script loading from CDN. `true` loads from `unpkg.com/@loaders.gl`. `false` load from local urls. `string` alternate CDN url.        |


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/2059298/100554619-a446bc80-324a-11eb-9130-f4e366d98728.png)

https://loaders.gl/modules/core/docs/api-reference/parse#options