### PR TITLE
Fix basemaps

### DIFF
--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -90,6 +90,12 @@
       ]
     },
     {
+      "title": "Command-Line Reference",
+      "entries": [
+        {"entry": "modules/tile-converter/docs/cli-reference/tile-converter"}
+      ]
+    },
+    {
       "title": "API Reference",
       "chapters": [
         {
@@ -262,7 +268,6 @@
           "title": "@loaders.gl/tile-converter",
           "entries": [
             {"entry": "modules/tile-converter/docs"},
-            {"entry": "modules/tile-converter/docs/cli-reference/tile-converter"},
             {"entry": "modules/tile-converter/docs/api-reference/3d-tiles-converter"},
             {"entry": "modules/tile-converter/docs/api-reference/i3s-converter"}
           ]
@@ -286,12 +291,6 @@
             {"entry": "modules/zip/docs"}
           ]
         }
-      ]
-    },
-    {
-      "title": "Command-Line Reference",
-      "entries": [
-        {"entry": "modules/tile-converter/docs/cli-reference/tile-converter"}
       ]
     }
   ]

--- a/examples/webpack.config.local.js
+++ b/examples/webpack.config.local.js
@@ -108,7 +108,6 @@ const LOCAL_DEVELOPMENT_CONFIG = {
   },
 
   plugins: [
-    new webpack.EnvironmentPlugin(['MapboxAccessToken']),
     new webpack.DefinePlugin({
       __VERSION__: JSON.stringify(LERNA_INFO.version)
     })

--- a/examples/website/3d-tiles/app.js
+++ b/examples/website/3d-tiles/app.js
@@ -16,9 +16,6 @@ import ControlPanel from './components/control-panel';
 import {loadExampleIndex, INITIAL_EXAMPLE_CATEGORY, INITIAL_EXAMPLE_NAME} from './examples';
 import {INITIAL_MAP_STYLE} from './constants';
 
-// Set your mapbox token here
-const MAPBOX_TOKEN = process.env.MapboxAccessToken; // eslint-disable-line
-
 const TILESET_SERVER_URL = 'https://assets.cesium.com';
 
 const TRANSITION_DURAITON = 4000;
@@ -264,11 +261,7 @@ export default class App extends PureComponent {
           controller={{type: MapController, maxPitch: 85}}
           onAfterRender={() => this._updateStatWidgets()}
         >
-          <StaticMap
-            mapStyle={selectedMapStyle}
-            mapboxApiAccessToken={MAPBOX_TOKEN}
-            preventStyleDiffing
-          />
+          <StaticMap mapStyle={selectedMapStyle} preventStyleDiffing />
         </DeckGL>
       </div>
     );

--- a/examples/website/3d-tiles/constants.js
+++ b/examples/website/3d-tiles/constants.js
@@ -1,7 +1,7 @@
 export const MAP_STYLES = {
-  'Base Map: Satellite': 'mapbox://styles/mapbox/satellite-v9',
-  'Base Map: Light': 'mapbox://styles/mapbox/light-v9',
-  'Base Map: Dark': 'mapbox://styles/mapbox/dark-v9'
+  'Base Map: Satellite': 'https://basemaps.cartocdn.com/gl/voyager-nolabels-gl-style/style.json',
+  'Base Map: Light': 'https://basemaps.cartocdn.com/gl/positron-nolabels-gl-style/style.json',
+  'Base Map: Dark': 'https://basemaps.cartocdn.com/gl/dark-matter-nolabels-gl-style/style.json'
 };
 
 export const INITIAL_MAP_STYLE = MAP_STYLES['Base Map: Dark'];

--- a/examples/website/i3s/app.js
+++ b/examples/website/i3s/app.js
@@ -14,8 +14,7 @@ import {StatsWidget} from '@probe.gl/stats-widget';
 import {INITIAL_EXAMPLE_NAME, EXAMPLES} from './examples';
 import ControlPanel from './components/control-panel';
 
-// Set your mapbox token here
-const MAPBOX_TOKEN = process.env.MapboxAccessToken; // eslint-disable-line
+const MAP_STYLE = 'https://basemaps.cartocdn.com/gl/dark-matter-nolabels-gl-style/style.json';
 
 const TRANSITION_DURAITON = 4000;
 
@@ -190,11 +189,7 @@ export default class App extends PureComponent {
           controller={{type: MapController, maxPitch: 85}}
           onAfterRender={() => this._updateStatWidgets()}
         >
-          <StaticMap
-            mapStyle={'mapbox://styles/mapbox/dark-v9'}
-            mapboxApiAccessToken={MAPBOX_TOKEN}
-            preventStyleDiffing
-          />
+          <StaticMap mapStyle={MAP_STYLE} preventStyleDiffing />
         </DeckGL>
       </div>
     );

--- a/modules/tile-converter/docs/README.md
+++ b/modules/tile-converter/docs/README.md
@@ -43,3 +43,11 @@ Note: the command line tools are implemented using this API and offer the same f
 - [3D Tiles Specification](https://github.com/AnalyticalGraphicsInc/3d-tiles) - The living specification.
 - [OGC I3S Indexed Scene Layer Standard](http://www.ogc.org/standards/i3s) - The official standard from [OGC](https://www.opengeospatial.org/), the Open Geospatial Consortium.
 - [OGC 3D Tiles Standard](https://www.opengeospatial.org/standards/3DTiles) - The official standard from [OGC](https://www.opengeospatial.org/), the Open Geospatial Consortium.
+
+## Attribution
+
+The tile-converter module represents a major development effort and was funded and contributed to loaders.gl by Esri.
+
+![logo](../images/esri.jpeg)
+
+MIT License.

--- a/modules/tile-converter/docs/api-reference/3d-tiles-converter.md
+++ b/modules/tile-converter/docs/api-reference/3d-tiles-converter.md
@@ -4,7 +4,7 @@
   <img src="https://img.shields.io/badge/From-v3.0-blue.svg?style=flat-square" alt="From-v3.0" />
 </p>
 
-The `Tiles3DConverter` class converts an I3S layer.
+The `Tiles3DConverter` class converts an 3D Tiles tileset. It converts between the OGC 3D Tiles and the I3S formats.
 
 ## Usage
 
@@ -29,7 +29,7 @@ The converted tiles are written to the specified output path.
 
 ### constructor()
 
-Constructs a new `I3SConverter` instance.
+Constructs a new `3DTilesConverter` instance.
 
 ### convert(options: object): object
 

--- a/modules/tile-converter/docs/api-reference/i3s-converter.md
+++ b/modules/tile-converter/docs/api-reference/i3s-converter.md
@@ -4,7 +4,7 @@
   <img src="https://img.shields.io/badge/From-v3.0-blue.svg?style=flat-square" alt="From-v3.0" />
 </p>
 
-The `I3SConverter` class converts a 3D Tiles tileset.
+The `I3SConverter` class converts an I3S Tileset to 3D Tiles.
 
 ## Usage
 

--- a/modules/tile-converter/docs/cli-reference/tile-converter.md
+++ b/modules/tile-converter/docs/cli-reference/tile-converter.md
@@ -4,10 +4,9 @@
   <img src="https://img.shields.io/badge/From-v3.0-blue.svg?style=flat-square" alt="From-v3.0" />
 </p>
 
-![logo](../images/esri.jpeg) ![logo](../images/ogc.png)
-The tile-converter code was contributed by Esri. It converts between the OGC 3D Tiles and the I3S formats.
+The `tile-converter` is a command line utility (CLI) for two-way batch conversion between the OGC 3D Tiles and the I3S formats. It can load the tileset to be converted directly fromn
 
-`converter` is a command line utility for converting 3d-tiles to i3s and backward - i3s to 3d-tiles.
+## Installation
 
 Installing `@loaders.gl/tile-converter` makes the `converter` command line tool available. It can be run using `npx`.
 
@@ -19,7 +18,7 @@ $ npx tile-converter --input-type <I3S | 3DTILES> --tileset <tileset> --name <ti
 $ npx tile-converter --help
 ```
 
-### Options
+## Options
 
 | Option     | 3DTiles to I3S conversion | I3S to 3DTiles conversion | Description                                                                                                                                                                                                                      |
 | ---------- | ------------------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/website/gatsby-config.js
+++ b/website/gatsby-config.js
@@ -110,12 +110,6 @@ module.exports = {
         ]
       }
     },
-    {resolve: 'gatsby-plugin-no-sourcemaps'},
-    {
-      resolve: 'gatsby-plugin-env-variables',
-      options: {
-        whitelist: ['MapboxAccessToken']
-      }
-    }
+    {resolve: 'gatsby-plugin-no-sourcemaps'}
   ]
 };


### PR DESCRIPTION
The basemaps for the examples were broken in the published documentation since the mapbox token was not set. 

Updated the examples to use different map styles.

A few fixes to the docs.