### PR TITLE
polyfills: test 302 redirect

### DIFF
--- a/modules/core/src/lib/loader-utils/option-utils.js
+++ b/modules/core/src/lib/loader-utils/option-utils.js
@@ -13,8 +13,7 @@ const DEFAULT_LOADER_OPTIONS = {
   transforms: [],
   attributeName: null, // Used by i3s-attribute-loader to define attribute name.
   attributeType: null, // Used by i3s-attribute-loader to define attribute type.
-  reuseWorkers: true, // By default reuse workers
-  followRedirect: false // Follow 30X redirect during loading (implemented only for polyfills)
+  reuseWorkers: true // By default reuse workers
 };
 
 const DEPRECATED_LOADER_OPTIONS = {

--- a/modules/polyfills/docs/api-reference/README.md
+++ b/modules/polyfills/docs/api-reference/README.md
@@ -53,6 +53,8 @@ The Node.js `fetch`, `Response` and `Headers` polyfills supports a large subset 
 - automatic gzip, brotli and deflate decompression support for responses with `content-encoding` headers.
 - Files ending with `.gz` are automatically decompressed with gzip decompression (this is only done on Node.js, in the browser the content-encoding header must be set).
 
+The Node.js `fetch` is able to follow 30X redirect: if `Response` has status 300-399 and `location` header is set, the `fetch` polyfill re-requests data from `location`.
+
 # TextEncoder and TextDecoder Polyfills
 
 `TextEncoder` and `TextDecoder` polyfills are provided to ensure these APIs are always available. In modern browsers these will evaluate to the built-in objects of the same name, however under Node.js polyfills are transparently installed.

--- a/modules/polyfills/src/fetch-node/fetch.node.js
+++ b/modules/polyfills/src/fetch-node/fetch.node.js
@@ -38,7 +38,7 @@ export default async function fetchNode(url, options) {
     const headers = getHeaders(url, body, syntheticResponseHeaders);
     const {status, statusText} = getStatus(body);
 
-    if (status >= 300 && status < 400 && headers.has('location') && options.followRedirect) {
+    if (status >= 300 && status < 400 && headers.has('location')) {
       // Redirect
       return await fetchNode(headers.get('location'), options);
     }

--- a/modules/polyfills/test/fetch-node/fetch.node.spec.js
+++ b/modules/polyfills/test/fetch-node/fetch.node.spec.js
@@ -9,6 +9,9 @@ const PLY_CUBE_ATT_SIZE = 853;
 const TEXT_URL = `@loaders.gl/polyfills/test/data/data.txt`;
 const TEXT_URL_GZIPPED = `@loaders.gl/polyfills/test/data/data.txt.gz`;
 
+const REDIRECT_URL =
+  'https://github.com/visgl/deck.gl-data/raw/master/3d-tiles/RoyalExhibitionBuilding/1/1.pnts';
+
 test('polyfills#fetch() (NODE)', async t => {
   if (!isBrowser) {
     const response = await fetch(PLY_CUBE_ATT_URL);
@@ -101,6 +104,14 @@ test('polyfills#fetch() able to decompress .gz extension (NODE)', async t => {
     t.ok(response.ok, response.statusText);
     data = await response.text();
     t.equal(data, '123456', 'fetch polyfill correctly decompressed gzipped ".gz" file');
+  }
+  t.end();
+});
+
+test('polyfills#fetch() should follow redirect if `followRedirect` option is true', async t => {
+  if (!isBrowser) {
+    const response = await fetch(REDIRECT_URL);
+    t.equal(response.status, 200);
   }
   t.end();
 });


### PR DESCRIPTION
+ test case for redirect;
+ documentation;
- followRedirect option. I found comment that passing options into `fetch` function is deprecated https://github.com/visgl/loaders.gl/blob/e54cff4b680024b66b23684ab1b411337b4afc57/modules/core/src/lib/loader-utils/option-utils.js#L99. 