### PR TITLE
WIP: Add parsed byte length to Shapefile parseInBatches

### DIFF
--- a/modules/shapefile/src/lib/parsers/parse-dbf.js
+++ b/modules/shapefile/src/lib/parsers/parse-dbf.js
@@ -28,7 +28,6 @@ class DBFParser {
   write(arrayBuffer) {
     this.binaryReader.write(arrayBuffer);
     this.state = parseState(this.state, this.result, this.binaryReader, this.textDecoder);
-    // this.result.progress.bytesUsed = this.binaryReader.bytesUsed();
 
     // important events:
     // - schema available
@@ -39,7 +38,7 @@ class DBFParser {
   end() {
     this.binaryReader.end();
     this.state = parseState(this.state, this.result, this.binaryReader, this.textDecoder);
-    // this.result.progress.bytesUsed = this.binaryReader.bytesUsed();
+
     if (this.state !== STATE.END) {
       this.state = STATE.ERROR;
       this.result.error = 'DBF incomplete file';

--- a/modules/shapefile/src/lib/parsers/parse-shapefile.js
+++ b/modules/shapefile/src/lib/parsers/parse-shapefile.js
@@ -43,7 +43,7 @@ export async function* parseShapefileInBatches(asyncIterator, options, context) 
 
   let iterator;
   if (propertyIterator) {
-    iterator = await zipBatchIterators(shapeIterator, propertyIterator);
+    iterator = await zipBatchIterators(shapeIterator, propertyIterator, {key1: 'data'});
   } else {
     iterator = shapeIterator;
   }
@@ -51,10 +51,13 @@ export async function* parseShapefileInBatches(asyncIterator, options, context) 
   for await (const item of iterator) {
     let geometries;
     let properties;
+    let progress;
     if (!propertyIterator) {
-      geometries = item;
+      geometries = item.data;
+      progress = item.progress;
     } else {
-      [geometries, properties] = item;
+      [geometries, properties] = item.data;
+      progress = item.progress;
     }
 
     const geojsonGeometries = parseGeometries(geometries);
@@ -67,7 +70,9 @@ export async function* parseShapefileInBatches(asyncIterator, options, context) 
       prj,
       shx,
       header: shapeHeader,
-      data: features
+      data: features,
+      bytesUsed: progress.bytesUsed,
+      bytesTotal: progress.bytesTotal
     };
   }
 }

--- a/modules/shapefile/src/lib/streaming/zip-batch-iterators.js
+++ b/modules/shapefile/src/lib/streaming/zip-batch-iterators.js
@@ -1,7 +1,8 @@
 /**
  * Zip two iterators together
  */
-export async function* zipBatchIterators(iterator1, iterator2) {
+// eslint-disable-next-line complexity
+export async function* zipBatchIterators(iterator1, iterator2, options) {
   let batch1 = [];
   let batch2 = [];
   let iterator1Done = false;
@@ -10,14 +11,14 @@ export async function* zipBatchIterators(iterator1, iterator2) {
   // TODO - one could let all iterators flow at full speed using `Promise.race`
   // however we might end up with a big temporary buffer
   while (!iterator1Done && !iterator2Done) {
-    if (batch1.length === 0 && !iterator1Done) {
+    if (!iterator1Done) {
       const {value, done} = await iterator1.next();
       if (done) {
         iterator1Done = true;
       } else {
         batch1 = value;
       }
-    } else if (batch2.length === 0 && !iterator2Done) {
+    } else if (!iterator2Done) {
       const {value, done} = await iterator2.next();
       if (done) {
         iterator2Done = true;
@@ -26,7 +27,7 @@ export async function* zipBatchIterators(iterator1, iterator2) {
       }
     }
 
-    const batch = extractBatch(batch1, batch2);
+    const batch = extractBatch(batch1, batch2, options);
     if (batch) {
       yield batch;
     }
@@ -36,21 +37,50 @@ export async function* zipBatchIterators(iterator1, iterator2) {
 /**
  * Extract batch of same length from two batches
  *
- * @param  {Array} batch1
- * @param  {Array} batch2
- * @return {Array?}
+ * @param  {array | object} batch1
+ * @param  {array | object} batch2
+ * @return {array?}
  */
-function extractBatch(batch1, batch2) {
-  const batchLength = Math.min(batch1.length, batch2.length);
+function extractBatch(batch1, batch2, options) {
+  const {key1, key2, resultKey = 'data'} = options || {};
+
+  const iterable1 = key1 ? batch1[key1] : batch1;
+  const iterable2 = key2 ? batch2[key2] : batch2;
+  const batchLength = Math.min(iterable1.length, iterable2.length);
   if (batchLength === 0) {
     return null;
   }
 
   // Non interleaved arrays
-  const batch = [batch1.slice(0, batchLength), batch2.slice(0, batchLength)];
+  const batch = [iterable1.slice(0, batchLength), iterable2.slice(0, batchLength)];
 
   // Modify the 2 batches
-  batch1.splice(0, batchLength);
-  batch2.splice(0, batchLength);
-  return batch;
+  // This should modify the linked arrays in batch1 and batch2
+  iterable1.splice(0, batchLength);
+  iterable2.splice(0, batchLength);
+
+  // Include non-data keys in result batch
+  let keepKeys1 = [];
+  if (!Array.isArray(batch1)) {
+    keepKeys1 = Object.keys(batch1).filter(x => x !== key1 && x !== resultKey);
+  }
+
+  let keepKeys2 = [];
+  if (!Array.isArray(batch2)) {
+    keepKeys2 = Object.keys(batch2).filter(x => x !== key2 && x !== resultKey);
+  }
+
+  const result = {
+    [resultKey]: batch
+  };
+
+  for (const keepKey of keepKeys1) {
+    result[keepKey] = batch1[keepKey];
+  }
+
+  for (const keepKey of keepKeys2) {
+    result[keepKey] = batch2[keepKey];
+  }
+
+  return result;
 }


### PR DESCRIPTION
The Shapefile Loader's `parseInBatches` function currently emits batches that don't include metadata about progress. It looks like a `bytesUsed` key is necessary on each batch. The main impediment to this is the `zipBatchIterator`, since that currently requires that the input iterators emit plain arrays, instead of objects that include an array in a key.

I figured I'd post this draft PR for feedback. Maybe there's an easier way forward than rewriting `zipBatchIterator`... better to intercept the batches from the `SHPLoader`, extract the progress metadata, and then pass normal arrays to `zipBatchIterator`?