### PR TITLE
Add MVT MIME type

### DIFF
--- a/modules/mvt/src/mvt-loader.js
+++ b/modules/mvt/src/mvt-loader.js
@@ -12,7 +12,7 @@ export const MVTWorkerLoader = {
   name: 'Mapbox Vector Tile',
   version: VERSION,
   extensions: ['mvt'],
-  mimeTypes: ['application/x-protobuf'],
+  mimeTypes: ['application/x-protobuf', 'application/vnd.mapbox-vector-tile'],
   category: 'geometry',
   options: {
     mvt: {


### PR DESCRIPTION
Add standard [MIME Type](https://github.com/mapbox/vector-tile-spec/tree/master/2.1#22-multipurpose-internet-mail-extensions-mime) to MVTLoader 