### PR TITLE
gltf: pass only minimal options to DracoLoader to avoid messaging ove…

### DIFF
--- a/modules/gltf/src/lib/extensions/KHR_draco_mesh_compression.js
+++ b/modules/gltf/src/lib/extensions/KHR_draco_mesh_compression.js
@@ -59,7 +59,9 @@ async function decompressPrimitive(primitive, scenegraph, options, context) {
 
   // this will generate an exception if DracoLoader is not installed
   const {parse} = context;
-  const dracoOptions = {
+  const dracoOptions = {...options};
+  // The entire tileset might be included, too expensive to serialize
+  delete options['3d-tiles'];
     draco: {
       ...options.draco
     },

--- a/modules/gltf/src/lib/extensions/KHR_draco_mesh_compression.js
+++ b/modules/gltf/src/lib/extensions/KHR_draco_mesh_compression.js
@@ -59,7 +59,15 @@ async function decompressPrimitive(primitive, scenegraph, options, context) {
 
   // this will generate an exception if DracoLoader is not installed
   const {parse} = context;
-  const decodedData = await parse(bufferCopy, DracoLoader, options, context);
+  const dracoOptions = {
+    draco: {
+      ...options.draco
+    },
+    ...(options.worker && {worker: options.worker}),
+    ...(options.reuseWorkers && {reuseWorkers: options.reuseWorkers}),
+    ...(options.maxConcurrency && {maxConcurrency: options.maxConcurrency})
+  };
+  const decodedData = await parse(bufferCopy, DracoLoader, dracoOptions, context);
 
   primitive.attributes = getGLTFAccessors(decodedData.attributes);
   if (decodedData.indices) {


### PR DESCRIPTION
Hi!
When testing loaders.gl with Cesium 3d-tiles and photogrammetry, I experienced immense slowdown whenever workers were being used to decode _Draco_ meshes.
I traced the slowdown to the fact that `GLTFLoader` passes the full option object to `DracoLoader`. In the case of 3d-tiles, the option object contains the [entire tileset](https://github.com/visgl/loaders.gl/blob/master/modules/tiles/src/tileset/tile-3d.js#L212), which was then attempted to get serialized over to the worker thread. The following fix passes only `draco` and `worker` options to DracoLoader, which fixed the slowdown for me. 
Let me know if you get the same results!
/Avner