### PR TITLE
feat(textures): Add texture format utils

### DIFF
--- a/modules/textures/src/index.d.ts
+++ b/modules/textures/src/index.d.ts
@@ -1,10 +1,21 @@
+// Loaders
 export {BasisLoader, BasisWorkerLoader} from './basis-loader';
 export {CompressedTextureLoader} from './compressed-texture-loader';
 export {CrunchLoader, CrunchWorkerLoader} from './crunch-loader';
+export {NPYLoader, NPYWorkerLoader} from './npy-loader';
 
+// Writers
 export {CompressedTextureWriter} from './compressed-texture-writer';
 
 // Texture Loading API
 export {loadImageTexture} from './lib/texture-api/load-image';
 export {loadImageTextureArray} from './lib/texture-api/load-image-array';
 export {loadImageTextureCube} from './lib/texture-api/load-image-cube';
+
+// Types
+export {GPUTextureFormat} from './lib/utils/texture-formats';
+
+// Utilities
+export {GL as GL_CONSTANTS} from './lib/gl-constants';
+
+export {getSupportedGPUTextureFormats} from './lib/utils/texture-formats';

--- a/modules/textures/src/index.js
+++ b/modules/textures/src/index.js
@@ -1,8 +1,10 @@
+// Loaders
 export {BasisLoader, BasisWorkerLoader} from './basis-loader';
 export {CompressedTextureLoader} from './compressed-texture-loader';
 export {CrunchLoader} from './crunch-loader';
 export {NPYLoader, NPYWorkerLoader} from './npy-loader';
 
+// Writers
 export {CompressedTextureWriter} from './compressed-texture-writer';
 
 // Texture Loading API
@@ -10,4 +12,7 @@ export {loadImageTexture} from './lib/texture-api/load-image';
 export {loadImageTextureArray} from './lib/texture-api/load-image-array';
 export {loadImageTextureCube} from './lib/texture-api/load-image-cube';
 
+// Utils
 export {GL as GL_CONSTANTS} from './lib/gl-constants';
+
+export {getSupportedGPUTextureFormats} from './lib/utils/texture-formats';

--- a/modules/textures/src/lib/utils/texture-formats.d.ts
+++ b/modules/textures/src/lib/utils/texture-formats.d.ts
@@ -1,0 +1,22 @@
+/**
+ * These represent the main compressed texture formats
+ * Each format typically has a number of more specific subformats
+ */
+export type GPUTextureFormat = 
+  'dxt' |
+  'dxt-srgb' |
+  'etc1' |
+  'etc2' |
+  'pvrtc' |
+  'atc' |
+  'astc' |
+  'rgtc'
+  ;
+
+/**
+ * Returns a list of formats.
+ * Creates a temporary WebGLRenderingContext if none is provided.
+ * 
+ * @param gl - Optional context. 
+ */
+export function getSupportedGPUTextureFormats(gl?: WebGL2RenderingContext): string[];

--- a/modules/textures/src/lib/utils/texture-formats.d.ts
+++ b/modules/textures/src/lib/utils/texture-formats.d.ts
@@ -19,4 +19,4 @@ export type GPUTextureFormat =
  * 
  * @param gl - Optional context. 
  */
-export function getSupportedGPUTextureFormats(gl?: WebGL2RenderingContext): string[];
+export function getSupportedGPUTextureFormats(gl?: WebGL2RenderingContext): Set<String>;

--- a/modules/textures/src/lib/utils/texture-formats.js
+++ b/modules/textures/src/lib/utils/texture-formats.js
@@ -1,0 +1,53 @@
+/** @typedef {import('./texture-formats').GPUTextureFormat} GPUTextureFormat */
+
+const BROWSER_PREFIXES = ['', 'WEBKIT_', 'MOZ_'];
+
+/** @type {{[key: string]: GPUTextureFormat}} */
+const WEBGL_EXTENSIONS = {
+  /* eslint-disable camelcase */
+  WEBGL_compressed_texture_s3tc: 'dxt',
+  WEBGL_compressed_texture_s3tc_srgb: 'dxt-srgb',
+  WEBGL_compressed_texture_etc1: 'etc1',
+  WEBGL_compressed_texture_etc: 'etc2',
+  WEBGL_compressed_texture_pvrtc: 'pvrtc',
+  WEBGL_compressed_texture_atc: 'atc',
+  WEBGL_compressed_texture_astc: 'astc',
+  EXT_texture_compression_rgtc: 'rgtc'
+  /* eslint-enable camelcase */
+};
+
+/** @type {Set<GPUTextureFormat>?} */
+let formats = null;
+
+export function getSupportedGPUTextureFormats(gl) {
+  if (!formats) {
+    gl = gl || getWebGLContext();
+
+    formats = new Set();
+
+    for (const prefix of BROWSER_PREFIXES) {
+      for (const extension in WEBGL_EXTENSIONS) {
+        // eslint-disable-next-line max-depth
+        if (gl && gl.getExtension(`${prefix}${extension}`)) {
+          const gpuTextureFormat = WEBGL_EXTENSIONS[extension];
+          formats.add(gpuTextureFormat);
+        }
+      }
+    }
+  }
+
+  return formats;
+}
+
+/**
+ * @returns {WebGLRenderingContext?}
+ */
+function getWebGLContext() {
+  try {
+    /* global document */
+    const canvas = document.createElement('canvas');
+    return canvas.getContext('webgl');
+  } catch {
+    return null;
+  }
+}

--- a/modules/textures/src/lib/utils/texture-formats.js
+++ b/modules/textures/src/lib/utils/texture-formats.js
@@ -47,7 +47,7 @@ function getWebGLContext() {
     /* global document */
     const canvas = document.createElement('canvas');
     return canvas.getContext('webgl');
-  } catch {
+  } catch (error) {
     return null;
   }
 }

--- a/modules/textures/test/index.js
+++ b/modules/textures/test/index.js
@@ -1,9 +1,11 @@
+import './utils/format-utils.spec';
+
+import './texture-api/async-deep-map.spec';
+import './texture-api/load-image.spec';
+
 import './basis-loader.spec';
 // import './crunch-loader.spec';
 import './compressed-texture-loader.spec';
 import './compressed-texture-writer.spec';
-
-import './texture-api/async-deep-map.spec';
-import './texture-api/load-image.spec';
 
 import './npy-loader.spec';

--- a/modules/textures/test/utils/format-utils.spec.js
+++ b/modules/textures/test/utils/format-utils.spec.js
@@ -1,10 +1,17 @@
 import test from 'tape-promise/tape';
 
 import {getSupportedGPUTextureFormats} from '@loaders.gl/textures';
+import {isBrowser} from '@loaders.gl/core';
 
 test('getSupportedGPUTextureFormats', t => {
-  // Minimal test as this is WebGL dependent
-  const formats = getSupportedGPUTextureFormats();
-  t.ok(formats.every(format => typeof format === 'string'));
-  t.end();
+  if (isBrowser) {
+    // Minimal test as this is WebGL dependent
+    const formats = getSupportedGPUTextureFormats();
+    t.ok(formats.forEach(format => typeof format === 'string'));
+    t.end();
+  } else {
+    const formats = getSupportedGPUTextureFormats();
+    t.equal(formats.size, 0);
+    t.end();
+  }
 });

--- a/modules/textures/test/utils/format-utils.spec.js
+++ b/modules/textures/test/utils/format-utils.spec.js
@@ -1,0 +1,10 @@
+import test from 'tape-promise/tape';
+
+import {getSupportedGPUTextureFormats} from '@loaders.gl/textures';
+
+test('getSupportedGPUTextureFormats', t => {
+  // Minimal test as this is WebGL dependent
+  const formats = getSupportedGPUTextureFormats();
+  t.ok(formats.every(format => typeof format === 'string'));
+  t.end();
+});


### PR DESCRIPTION
- [x] Add `getSupportedGPUTextureFormats()` to discover which formats are available. 
- [ ] Use `getSupportedGPUTextureFormats()` in `textures` example
- [ ] Use `getSupportedGPUTextureFormats()` in `basis` decoder, align constants and code

@dryabinin-actionengine Please take over and land