### PR TITLE
textures: loader workers

### DIFF
--- a/modules/textures/package.json
+++ b/modules/textures/package.json
@@ -36,7 +36,7 @@
     "pre-build": "npm run copy-libs && npm run build-worker && npm run build-bundle && npm run build-bundle -- --env.dev",
     "copy-libs": "cp -rf ./src/libs ./dist/libs",
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js",
-    "build-worker": "webpack --entry ./src/workers/basis-loader.worker.js --output ./dist/basis-loader.worker.js --config ../../scripts/worker-webpack-config.js && webpack --entry ./src/npy-loader.worker.js --output ./dist/npy-loader.worker.js --config ../../scripts/worker-webpack-config.js"
+    "build-worker": "webpack --entry ./src/workers/basis-loader.worker.js --output ./dist/basis-loader.worker.js --config ../../scripts/worker-webpack-config.js && webpack --entry ./src/workers/npy-loader.worker.js --output ./dist/npy-loader.worker.js --config ../../scripts/worker-webpack-config.js && webpack --entry ./src/workers/compressed-texture-loader.worker.js --output ./dist/compressed-texture-loader.worker.js --config ../../scripts/worker-webpack-config.js && webpack --entry ./src/workers/crunch-loader.worker.js --output ./dist/crunch-loader.worker.js --config ../../scripts/worker-webpack-config.js"
   },
   "dependencies": {
     "@loaders.gl/core": "3.0.0-alpha.3",

--- a/modules/textures/src/compressed-texture-loader.js
+++ b/modules/textures/src/compressed-texture-loader.js
@@ -20,13 +20,12 @@ export const CompressedTextureWorkerLoader = {
     'dds', // WEBGL_compressed_texture_s3tc, WEBGL_compressed_texture_atc
     'pvr' // WEBGL_compressed_texture_pvrtc
   ],
-  mimeTypes: ['application/octet-stream'],
-  // tests: [new Uint8Array(PVR_MAGIC_BYTES).buffer],
+  mimeTypes: ['application/octet-stream', 'image/vnd-ms.dds'],
   binary: true,
   options: {
-    basis: {
+    'compressed-texture': {
       libraryPath: `libs/`
-      // workerUrl: `https://unpkg.com/@loaders.gl/textures@${VERSION}/dist/basis-loader.worker.js`
+      // workerUrl: `https://unpkg.com/@loaders.gl/textures@${VERSION}/dist/compressed-texture-loader.worker.js`
     }
   }
 };

--- a/modules/textures/src/crunch-loader.js
+++ b/modules/textures/src/crunch-loader.js
@@ -19,7 +19,7 @@ export const CrunchWorkerLoader = {
   mimeTypes: ['application/octet-stream'],
   binary: true,
   options: {
-    basis: {
+    crunch: {
       libraryPath: `libs/`
       // workerUrl: `https://unpkg.com/@loaders.gl/textures@${VERSION}/dist/crunch-loader.worker.js`
     }

--- a/modules/textures/src/workers/compressed-texture-loader.worker.js
+++ b/modules/textures/src/workers/compressed-texture-loader.worker.js
@@ -1,0 +1,4 @@
+import {createWorker} from '@loaders.gl/loader-utils';
+import {CompressedTextureLoader} from '../compressed-texture-loader';
+
+createWorker(CompressedTextureLoader);

--- a/modules/textures/src/workers/crunch-loader.worker.js
+++ b/modules/textures/src/workers/crunch-loader.worker.js
@@ -1,0 +1,4 @@
+import {createWorker} from '@loaders.gl/loader-utils';
+import {CrunchLoader} from '../crunch-loader';
+
+createWorker(CrunchLoader);

--- a/modules/textures/src/workers/npy-loader.worker.js
+++ b/modules/textures/src/workers/npy-loader.worker.js
@@ -1,4 +1,4 @@
-import {NPYLoader} from './npy-loader';
+import {NPYLoader} from '../npy-loader';
 import {createWorker} from '@loaders.gl/loader-utils';
 
 createWorker(NPYLoader);


### PR DESCRIPTION
- Created workers for `crunch` and `compressed-textures`;
- Moved `npy` worker into `workers` path.