### PR TITLE
Fix binary-geojson transformations for empty objects

### DIFF
--- a/modules/gis/src/lib/binary-to-geojson.js
+++ b/modules/gis/src/lib/binary-to-geojson.js
@@ -73,7 +73,6 @@ function parseFeatureCollection(dataArray) {
     // Need to deduce start, end indices of each feature
     for (let i = 0; i < data.featureIds.value.length; i++) {
       const currValue = data.featureIds.value[i];
-      // eslint-disable-next-line max-depth
       if (currValue === lastValue) {
         // eslint-disable-next-line no-continue
         continue;

--- a/modules/gis/src/lib/binary-to-geojson.js
+++ b/modules/gis/src/lib/binary-to-geojson.js
@@ -63,24 +63,27 @@ function deduceReturnType(dataArray) {
 function parseFeatureCollection(dataArray) {
   const features = [];
   for (const data of dataArray) {
-    let lastIndex = 0;
-    let lastValue = data.featureIds.value[0];
+    if (data.featureIds.value.length) {
+      let lastIndex = 0;
+      let lastValue = data.featureIds.value[0];
 
-    // Need to deduce start, end indices of each feature
-    for (let i = 0; i < data.featureIds.value.length; i++) {
-      const currValue = data.featureIds.value[i];
-      if (currValue === lastValue) {
-        // eslint-disable-next-line no-continue
-        continue;
+      // Need to deduce start, end indices of each feature
+      for (let i = 0; i < data.featureIds.value.length; i++) {
+        const currValue = data.featureIds.value[i];
+        // eslint-disable-next-line max-depth
+        if (currValue === lastValue) {
+          // eslint-disable-next-line no-continue
+          continue;
+        }
+
+        features.push(parseFeature(data, lastIndex, i));
+        lastIndex = i;
+        lastValue = currValue;
       }
 
-      features.push(parseFeature(data, lastIndex, i));
-      lastIndex = i;
-      lastValue = currValue;
+      // Last feature
+      features.push(parseFeature(data, lastIndex, data.featureIds.value.length));
     }
-
-    // Last feature
-    features.push(parseFeature(data, lastIndex, data.featureIds.value.length));
   }
   return features;
 }
@@ -94,7 +97,7 @@ function parseFeature(data, startIndex, endIndex) {
 
 /** Parse input binary data and return an object of properties */
 function parseProperties(data, startIndex, endIndex) {
-  const properties = Object.assign(data.properties[data.featureIds.value[startIndex]]);
+  const properties = Object.assign({}, data.properties[data.featureIds.value[startIndex]]);
   for (const key in data.numericProps) {
     properties[key] = data.numericProps[key].value[startIndex];
   }

--- a/modules/gis/src/lib/binary-to-geojson.js
+++ b/modules/gis/src/lib/binary-to-geojson.js
@@ -63,27 +63,29 @@ function deduceReturnType(dataArray) {
 function parseFeatureCollection(dataArray) {
   const features = [];
   for (const data of dataArray) {
-    if (data.featureIds.value.length) {
-      let lastIndex = 0;
-      let lastValue = data.featureIds.value[0];
+    if (data.featureIds.value.length === 0) {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+    let lastIndex = 0;
+    let lastValue = data.featureIds.value[0];
 
-      // Need to deduce start, end indices of each feature
-      for (let i = 0; i < data.featureIds.value.length; i++) {
-        const currValue = data.featureIds.value[i];
-        // eslint-disable-next-line max-depth
-        if (currValue === lastValue) {
-          // eslint-disable-next-line no-continue
-          continue;
-        }
-
-        features.push(parseFeature(data, lastIndex, i));
-        lastIndex = i;
-        lastValue = currValue;
+    // Need to deduce start, end indices of each feature
+    for (let i = 0; i < data.featureIds.value.length; i++) {
+      const currValue = data.featureIds.value[i];
+      // eslint-disable-next-line max-depth
+      if (currValue === lastValue) {
+        // eslint-disable-next-line no-continue
+        continue;
       }
 
-      // Last feature
-      features.push(parseFeature(data, lastIndex, data.featureIds.value.length));
+      features.push(parseFeature(data, lastIndex, i));
+      lastIndex = i;
+      lastValue = currValue;
     }
+
+    // Last feature
+    features.push(parseFeature(data, lastIndex, data.featureIds.value.length));
   }
   return features;
 }
@@ -97,7 +99,7 @@ function parseFeature(data, startIndex, endIndex) {
 
 /** Parse input binary data and return an object of properties */
 function parseProperties(data, startIndex, endIndex) {
-  const properties = Object.assign({}, data.properties[data.featureIds.value[startIndex]]);
+  const properties = Object.assign(data.properties[data.featureIds.value[startIndex]]);
   for (const key in data.numericProps) {
     properties[key] = data.numericProps[key].value[startIndex];
   }

--- a/modules/gis/src/lib/geojson-to-binary.js
+++ b/modules/gis/src/lib/geojson-to-binary.js
@@ -216,7 +216,7 @@ function secondPass(features, firstPassData = {}, options = {}) {
 
   for (const feature of features) {
     const geometry = feature.geometry;
-    const properties = feature.properties;
+    const properties = feature.properties || {};
 
     switch (geometry.type) {
       case 'Point':

--- a/modules/gis/test/binary-to-geojson.spec.js
+++ b/modules/gis/test/binary-to-geojson.spec.js
@@ -5,6 +5,7 @@ import {fetchFile} from '@loaders.gl/core';
 import {binaryToGeoJson} from '@loaders.gl/gis';
 
 import GEOMETRY_TEST_CASES from '@loaders.gl/gis/test/data/geometry';
+import EMPTY_BINARY_DATA from '@loaders.gl/gis/test/data/empty_binary';
 
 const FEATURE_COLLECTION_TEST_CASES = '@loaders.gl/gis/test/data/featurecollection.json';
 
@@ -29,6 +30,14 @@ test('binary-to-geojson geometries', t => {
     const binaryData = testCase.binary;
     t.deepEqual(binaryToGeoJson(binaryData, binaryData.type, 'geometry'), testCase.geoJSON);
   }
+
+  t.end();
+});
+
+test('binary-to-geojson from empty binary object returns empty features array', t => {
+  const geojson = binaryToGeoJson(EMPTY_BINARY_DATA);
+  t.ok(Array.isArray(geojson));
+  t.equal(geojson.length, 0);
 
   t.end();
 });

--- a/modules/gis/test/data/empty_binary.js
+++ b/modules/gis/test/data/empty_binary.js
@@ -1,25 +1,25 @@
 export default {
   points: {
-    positions: {value: {}, size: null},
-    globalFeatureIds: {value: {}, size: 1},
-    featureIds: {value: {}, size: 1},
+    positions: {value: new Float32Array(), size: -Infinity},
+    globalFeatureIds: {value: new Uint16Array(), size: 1},
+    featureIds: {value: new Uint16Array(), size: 1},
     numericProps: {},
     properties: []
   },
   lines: {
-    pathIndices: {value: {0: 0}, size: 1},
-    positions: {value: {}, size: null},
-    globalFeatureIds: {value: {}, size: 1},
-    featureIds: {value: {}, size: 1},
+    pathIndices: {value: new Uint16Array(1), size: 1},
+    positions: {value: new Float32Array(), size: -Infinity},
+    globalFeatureIds: {value: new Uint16Array(), size: 1},
+    featureIds: {value: new Uint16Array(), size: 1},
     numericProps: {},
     properties: []
   },
   polygons: {
-    polygonIndices: {value: {0: 0}, size: 1},
-    primitivePolygonIndices: {value: {0: 0}, size: 1},
-    positions: {value: {}, size: null},
-    globalFeatureIds: {value: {}, size: 1},
-    featureIds: {value: {}, size: 1},
+    polygonIndices: {value: new Uint16Array(1), size: 1},
+    primitivePolygonIndices: {value: new Uint16Array(1), size: 1},
+    positions: {value: new Float32Array(), size: -Infinity},
+    globalFeatureIds: {value: new Uint16Array(), size: 1},
+    featureIds: {value: new Uint16Array(), size: 1},
     numericProps: {},
     properties: []
   }

--- a/modules/gis/test/data/empty_binary.js
+++ b/modules/gis/test/data/empty_binary.js
@@ -1,0 +1,26 @@
+export default {
+  points: {
+    positions: {value: {}, size: null},
+    globalFeatureIds: {value: {}, size: 1},
+    featureIds: {value: {}, size: 1},
+    numericProps: {},
+    properties: []
+  },
+  lines: {
+    pathIndices: {value: {0: 0}, size: 1},
+    positions: {value: {}, size: null},
+    globalFeatureIds: {value: {}, size: 1},
+    featureIds: {value: {}, size: 1},
+    numericProps: {},
+    properties: []
+  },
+  polygons: {
+    polygonIndices: {value: {0: 0}, size: 1},
+    primitivePolygonIndices: {value: {0: 0}, size: 1},
+    positions: {value: {}, size: null},
+    globalFeatureIds: {value: {}, size: 1},
+    featureIds: {value: {}, size: 1},
+    numericProps: {},
+    properties: []
+  }
+};

--- a/modules/gis/test/data/geojson_no_properties.json
+++ b/modules/gis/test/data/geojson_no_properties.json
@@ -1,0 +1,23 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "geometry": {
+        "type": "Point",
+        "coordinates": [100, 0]
+      }
+    },
+    {
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [[100, 0], [101, 1]]
+      }
+    },
+    {
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[[100, 0], [101, 0], [101, 10], [100, 10], [100, 0]]]
+      }
+    }
+  ]
+}

--- a/modules/gis/test/data/geojson_no_properties.json
+++ b/modules/gis/test/data/geojson_no_properties.json
@@ -2,22 +2,28 @@
   "type": "FeatureCollection",
   "features": [
     {
+      "type": "Feature",
       "geometry": {
         "type": "Point",
         "coordinates": [100, 0]
-      }
+      },
+      "properties": null
     },
     {
+      "type": "Feature",
       "geometry": {
         "type": "LineString",
         "coordinates": [[100, 0], [101, 1]]
-      }
+      },
+      "properties": null
     },
     {
+      "type": "Feature",
       "geometry": {
         "type": "Polygon",
         "coordinates": [[[100, 0], [101, 0], [101, 10], [100, 10], [100, 0]]]
-      }
+      },
+      "properties": null
     }
   ]
 }

--- a/modules/gis/test/geojson-to-binary.spec.js
+++ b/modules/gis/test/geojson-to-binary.spec.js
@@ -17,6 +17,9 @@ const FEATURES_3D = '@loaders.gl/gis/test/data/3d_features.json';
 // All features have 3D coordinates
 const FEATURES_MIXED = '@loaders.gl/gis/test/data/mixed_features.json';
 
+// Example GeoJSON with no properties
+const GEOJSON_NO_PROPERTIES = '@loaders.gl/gis/test/data/geojson_no_properties.json';
+
 test('gis#geojson-to-binary firstPass 2D features, no properties', async t => {
   const response = await fetchFile(FEATURES_2D);
   const {features} = await response.json();
@@ -416,6 +419,18 @@ test('gis#geojson-to-binary position, featureId data types', async t => {
   t.ok(polygons && polygons.featureIds.value instanceof Uint16Array);
   t.ok(polygons && polygons.polygonIndices.value instanceof Uint32Array);
   t.ok(polygons && polygons.primitivePolygonIndices.value instanceof Uint32Array);
+  t.end();
+});
+
+test('gis#geojson-to-binary with empty properties', async t => {
+  const response = await fetchFile(GEOJSON_NO_PROPERTIES);
+  const {features} = await response.json();
+  const {points, lines, polygons} = geojsonToBinary(features);
+
+  t.equal(points.properties[0].toString(), '[object Object]');
+  t.equal(lines.properties[0].toString(), '[object Object]');
+  t.equal(polygons.properties[0].toString(), '[object Object]');
+
   t.end();
 });
 

--- a/modules/gis/test/geojson-to-binary.spec.js
+++ b/modules/gis/test/geojson-to-binary.spec.js
@@ -427,9 +427,9 @@ test('gis#geojson-to-binary with empty properties', async t => {
   const {features} = await response.json();
   const {points, lines, polygons} = geojsonToBinary(features);
 
-  t.equal(points.properties[0].toString(), '[object Object]');
-  t.equal(lines.properties[0].toString(), '[object Object]');
-  t.equal(polygons.properties[0].toString(), '[object Object]');
+  t.ok(points.properties[0] instanceof Object && points.properties[0].length === undefined);
+  t.ok(lines.properties[0] instanceof Object && lines.properties[0].length === undefined);
+  t.ok(polygons.properties[0] instanceof Object && polygons.properties[0].length === undefined);
 
   t.end();
 });

--- a/modules/mvt/src/lib/parse-mvt.js
+++ b/modules/mvt/src/lib/parse-mvt.js
@@ -13,10 +13,6 @@ import Protobuf from 'pbf';
 export default function parseMVT(arrayBuffer, options) {
   options = normalizeOptions(options);
 
-  if (arrayBuffer.byteLength === 0) {
-    return [];
-  }
-
   const features = [];
 
   if (arrayBuffer.byteLength > 0) {

--- a/modules/mvt/src/lib/parse-mvt.js
+++ b/modules/mvt/src/lib/parse-mvt.js
@@ -17,29 +17,32 @@ export default function parseMVT(arrayBuffer, options) {
     return [];
   }
 
-  const tile = new VectorTile(new Protobuf(arrayBuffer));
-  const loaderOptions = options.mvt;
   const features = [];
 
-  const selectedLayers = Array.isArray(loaderOptions.layers)
-    ? loaderOptions.layers
-    : Object.keys(tile.layers);
+  if (arrayBuffer.byteLength > 0) {
+    const tile = new VectorTile(new Protobuf(arrayBuffer));
+    const loaderOptions = options.mvt;
 
-  selectedLayers.forEach(layerName => {
-    const vectorTileLayer = tile.layers[layerName];
-    const featureOptions = {...loaderOptions, layerName};
+    const selectedLayers = Array.isArray(loaderOptions.layers)
+      ? loaderOptions.layers
+      : Object.keys(tile.layers);
 
-    if (!vectorTileLayer) {
-      return;
-    }
+    selectedLayers.forEach(layerName => {
+      const vectorTileLayer = tile.layers[layerName];
+      const featureOptions = {...loaderOptions, layerName};
 
-    for (let i = 0; i < vectorTileLayer.length; i++) {
-      const vectorTileFeature = vectorTileLayer.feature(i);
+      if (!vectorTileLayer) {
+        return;
+      }
 
-      const decodedFeature = getDecodedFeature(vectorTileFeature, featureOptions);
-      features.push(decodedFeature);
-    }
-  });
+      for (let i = 0; i < vectorTileLayer.length; i++) {
+        const vectorTileFeature = vectorTileLayer.feature(i);
+
+        const decodedFeature = getDecodedFeature(vectorTileFeature, featureOptions);
+        features.push(decodedFeature);
+      }
+    });
+  }
 
   if (options.gis.format === 'binary') {
     const data = geojsonToBinary(features);
@@ -49,6 +52,7 @@ export default function parseMVT(arrayBuffer, options) {
     data.byteLength = arrayBuffer.byteLength;
     return data;
   }
+
   return features;
 }
 

--- a/modules/mvt/test/mvt-loader.spec.js
+++ b/modules/mvt/test/mvt-loader.spec.js
@@ -200,3 +200,13 @@ test('Polygon MVT to local coordinates binary', async t => {
 
   t.end();
 });
+
+test('Empty MVT must return empty binary format', async t => {
+  const emptyMVTArrayBuffer = new Uint8Array();
+  const geometryBinary = await parse(emptyMVTArrayBuffer, MVTLoader, {gis: {format: 'binary'}});
+  t.ok(geometryBinary.points);
+  t.ok(geometryBinary.lines);
+  t.ok(geometryBinary.polygons);
+
+  t.end();
+});


### PR DESCRIPTION
Fixes some issues related to transformation for empty objects (eg. when a tile has no data) or geojson data without properties.