### PR TITLE
Avoid mutating input object in geojsonToBinary function

### DIFF
--- a/modules/gis/docs/api-reference/geojson-to-binary.md
+++ b/modules/gis/docs/api-reference/geojson-to-binary.md
@@ -110,4 +110,5 @@ corresponds to 3D coordinates, where each vertex is defined by three numbers.
 | coordLength      | `number` | Derived from data | Number of dimensions per coordinate.                                                                                                                    |
 
 ## Notes
+
 In the case of the source geoJson features having an object as a property, it would not be deep cloned, so it would be linked from the output object (be careful on further mutations).

--- a/modules/gis/docs/api-reference/geojson-to-binary.md
+++ b/modules/gis/docs/api-reference/geojson-to-binary.md
@@ -108,3 +108,6 @@ corresponds to 3D coordinates, where each vertex is defined by three numbers.
 | PositionDataType | `class`  | `Float32Array`    | Data type used for positions arrays.                                                                                                                    |
 | numericPropKeys  | `Array`  | Derived from data | Names of feature properties that should be converted to numeric `TypedArray`s. Passing `[]` will force all properties to be returned as normal objects. |
 | coordLength      | `number` | Derived from data | Number of dimensions per coordinate.                                                                                                                    |
+
+## Notes
+In the case of the source geoJson features having an object as a property, it would not be deep cloned, so it would be linked from the output object (be careful on further mutations).

--- a/modules/gis/src/lib/geojson-to-binary.js
+++ b/modules/gis/src/lib/geojson-to-binary.js
@@ -391,14 +391,14 @@ function fillNumericProperties(object, properties, index, length) {
 }
 
 // Keep string properties in object
-// Note: this mutates the properties object
 function keepStringProperties(properties, numericKeys) {
-  for (const key in properties) {
+  const props = {...properties};
+  for (const key in props) {
     if (numericKeys.includes(key)) {
-      delete properties[key];
+      delete props[key];
     }
   }
-  return properties;
+  return props;
 }
 
 // coords is expected to be a list of arrays, each with length 2-3

--- a/modules/gis/src/lib/geojson-to-binary.js
+++ b/modules/gis/src/lib/geojson-to-binary.js
@@ -392,10 +392,10 @@ function fillNumericProperties(object, properties, index, length) {
 
 // Keep string properties in object
 function keepStringProperties(properties, numericKeys) {
-  const props = {...properties};
-  for (const key in props) {
-    if (numericKeys.includes(key)) {
-      delete props[key];
+  const props = {};
+  for (const key in properties) {
+    if (!numericKeys.includes(key)) {
+      props[key] = properties[key];
     }
   }
   return props;

--- a/modules/gis/test/geojson-to-binary.spec.js
+++ b/modules/gis/test/geojson-to-binary.spec.js
@@ -16,7 +16,6 @@ const FEATURES_2D = '@loaders.gl/gis/test/data/2d_features.json';
 const FEATURES_3D = '@loaders.gl/gis/test/data/3d_features.json';
 // All features have 3D coordinates
 const FEATURES_MIXED = '@loaders.gl/gis/test/data/mixed_features.json';
-const FEATURE_COLLECTION = '@loaders.gl/gis/test/data/featurecollection.json';
 
 // Example GeoJSON with no properties
 const GEOJSON_NO_PROPERTIES = '@loaders.gl/gis/test/data/geojson_no_properties.json';

--- a/modules/gis/test/geojson-to-binary.spec.js
+++ b/modules/gis/test/geojson-to-binary.spec.js
@@ -16,6 +16,7 @@ const FEATURES_2D = '@loaders.gl/gis/test/data/2d_features.json';
 const FEATURES_3D = '@loaders.gl/gis/test/data/3d_features.json';
 // All features have 3D coordinates
 const FEATURES_MIXED = '@loaders.gl/gis/test/data/mixed_features.json';
+const FEATURE_COLLECTION = '@loaders.gl/gis/test/data/featurecollection.json';
 
 // Example GeoJSON with no properties
 const GEOJSON_NO_PROPERTIES = '@loaders.gl/gis/test/data/geojson_no_properties.json';
@@ -430,7 +431,16 @@ test('gis#geojson-to-binary with empty properties', async t => {
   t.ok(points.properties[0] instanceof Object && points.properties[0].length === undefined);
   t.ok(lines.properties[0] instanceof Object && lines.properties[0].length === undefined);
   t.ok(polygons.properties[0] instanceof Object && polygons.properties[0].length === undefined);
+  t.end();
+});
 
+test("gis#geojson-to-binary doesn't mutate properties from input object", async t => {
+  const response = await fetchFile(FEATURE_COLLECTION);
+  const json = await response.json();
+  geojsonToBinary(json.point.geoJSON.features);
+
+  t.equal(json.point.geoJSON.features[0].properties.numeric1, 1);
+  t.equal(json.point.geoJSON.features[0].properties.string1, 'a');
   t.end();
 });
 

--- a/modules/gis/test/geojson-to-binary.spec.js
+++ b/modules/gis/test/geojson-to-binary.spec.js
@@ -434,16 +434,6 @@ test('gis#geojson-to-binary with empty properties', async t => {
   t.end();
 });
 
-test("gis#geojson-to-binary doesn't mutate properties from input object", async t => {
-  const response = await fetchFile(FEATURE_COLLECTION);
-  const json = await response.json();
-  geojsonToBinary(json.point.geoJSON.features);
-
-  t.equal(json.point.geoJSON.features[0].properties.numeric1, 1);
-  t.equal(json.point.geoJSON.features[0].properties.string1, 'a');
-  t.end();
-});
-
 function flatten(arr) {
   return arr.reduce(function(flat, toFlatten) {
     return flat.concat(Array.isArray(toFlatten) ? flatten(toFlatten) : toFlatten);


### PR DESCRIPTION
This fix is intended to avoid mutating the properties of the geoJSON object used as input for `geojsonToBinary` function as it currently removes all the numeric properties from the original geoJSON features.