### PR TITLE
Change babel config to fix es5 modules transpilation

### DIFF
--- a/modules/csv/src/libs/papaparse.js
+++ b/modules/csv/src/libs/papaparse.js
@@ -37,7 +37,7 @@ var global = (function() {
 var IS_PAPA_WORKER = false;
 
 var Papa = {};
-export default Papa;
+module.exports = Papa;
 Papa.parse = CsvToJson;
 Papa.unparse = JsonToCsv;
 

--- a/modules/las/src/libs/laz-perf.js
+++ b/modules/las/src/libs/laz-perf.js
@@ -23,7 +23,7 @@
  */
 
 // laz-perf.js
-export default function getModule() {
+module.exports = function getModule() {
   var Module = typeof Module !== "undefined" ? Module : {};
   var moduleOverrides = {};
   var key;

--- a/modules/polyfills/src/libs/encoding.js
+++ b/modules/polyfills/src/libs/encoding.js
@@ -3081,4 +3081,4 @@ decoders['x-user-defined'] = function(options) {
 // if (!global['TextEncoder']) global['TextEncoder'] = TextEncoder;
 // if (!global['TextDecoder']) global['TextDecoder'] = TextDecoder;
 // babel.config.js skip transpiling files in `libs/`
-export {TextEncoder, TextDecoder};
+module.exports = {TextEncoder, TextDecoder};

--- a/scripts/bundle.config.js
+++ b/scripts/bundle.config.js
@@ -48,6 +48,7 @@ const BABEL_CONFIG = {
   ],
   plugins: [
     '@babel/transform-runtime',
+    ["@babel/plugin-transform-modules-commonjs", { allowTopLevelThis: true }],
     'version-inline'
   ]
 };


### PR DESCRIPTION
Previous [fix](https://github.com/visgl/loaders.gl/pull/1134) was bad. It breaks `dist/es5 `files. Just because we should not transpile` /libs/` folder using babel because it stores external already transpiled and minified libraries and scripts. So all files in `/libs` folder have `ES5` syntax and we can't add `ES6` syntax there.
To avoid error in `dist.min.js` file I also tried to replace `import` with `require` syntax for modules which we get from `/libs` folder, but it doesn't help because somehow webpack logic change `module` object to another `module` object with `read-only ` exports filed.

So the easiest way to fix that is to use `commonJs` plugin to align all the code using only one standard.

