### PR TITLE
feat(compression): worker compression

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -23,6 +23,14 @@
 
 Target Release Date: Q1 2021. (Alpha releases are available).
 
+**@loaders.gl/core**
+
+- New `processOnWorker()` function allows applications to run certain non-loader tasks (such as compression and decompression) on workers.
+
+**@loaders.gl/compression**
+
+- The new `ZlibWorker` and `LZ4Worker` objects enable compression and decompression of data to be done on worker threads using the new `processOnWorker()` function.
+
 **@loaders.gl/tile-converter** (NEW)
 
 - A major new module contributed by ESRI, that implements conversion between the OGC 3D tiles and the OGC I3S tileset formats. A `tile-converter` CLI tool is avaible for automated batch conversion of multi-terabyte tilesets. A converter class API is also available for programmatic use.

--- a/modules/compression/package.json
+++ b/modules/compression/package.json
@@ -28,8 +28,11 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-bundle -- --env.dev",
-    "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js"
+    "pre-build": "npm run build-bundle && npm run build-workers && npm run build-bundle -- --env.dev",
+    "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
+    "build-workers": "npm run build-zlib-worker && npm run build-lz4-worker",
+    "build-zlib-worker": "webpack --entry ./src/workers/zlib.worker.js --output ./dist/zlib.worker.js --env.dev --config ../../scripts/webpack/worker.js",
+    "build-lz4-worker": "webpack --entry ./src/workers/lz4.worker.js --output ./dist/lz4.worker.js --env.dev --config ../../scripts/webpack/worker.js"
   },
   "dependencies": {
     "@babel/runtime": "^7.3.1",

--- a/modules/compression/package.json
+++ b/modules/compression/package.json
@@ -31,8 +31,8 @@
     "pre-build": "npm run build-bundle && npm run build-workers && npm run build-bundle -- --env.dev",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-workers": "npm run build-zlib-worker && npm run build-lz4-worker",
-    "build-zlib-worker": "webpack --entry ./src/workers/zlib.worker.js --output ./dist/zlib.worker.js --env.dev --config ../../scripts/webpack/worker.js",
-    "build-lz4-worker": "webpack --entry ./src/workers/lz4.worker.js --output ./dist/lz4.worker.js --env.dev --config ../../scripts/webpack/worker.js"
+    "build-zlib-worker": "webpack --entry ./src/workers/zlib-worker.js --output ./dist/zlib-worker.js --env.dev --config ../../scripts/webpack/worker.js",
+    "build-lz4-worker": "webpack --entry ./src/workers/lz4-worker.js --output ./dist/lz4-worker.js --env.dev --config ../../scripts/webpack/worker.js"
   },
   "dependencies": {
     "@babel/runtime": "^7.3.1",

--- a/modules/compression/src/index.d.ts
+++ b/modules/compression/src/index.d.ts
@@ -1,3 +1,5 @@
+import {WorkerObject} from '@loaders.gl/loader-utils';
+
 // Zlib (via Pako)
 export {default as ZlibDeflateTransform} from './lib/zlib/zlib-deflate-transform';
 export {default as ZlibInflateTransform} from './lib/zlib/zlib-inflate-transform';
@@ -9,3 +11,5 @@ export {default as LZ4InflateTransform} from './lib/lz4/lz4-inflate-transform';
 // Zstd
 // export {default as ZstdDeflateTransform} from './lib/zstd/zstd-deflate-transform';
 // export {default as ZstdInflateTransform} from './lib/zstd/zstd-inflate-transform';
+
+export const ZlibWorker: WorkerObject;

--- a/modules/compression/src/index.js
+++ b/modules/compression/src/index.js
@@ -1,3 +1,5 @@
+/** @typedef {import('@loaders.gl/loader-utils').WorkerObject} WorkerObject */
+
 export {default as ZlibDeflateTransform} from './lib/zlib/zlib-deflate-transform';
 export {default as ZlibInflateTransform} from './lib/zlib/zlib-inflate-transform';
 
@@ -7,3 +9,19 @@ export {default as LZ4InflateTransform} from './lib/lz4/lz4-inflate-transform';
 // Move to WIP due to enormous dependency size
 // export {default as ZstdDeflateTransform} from './lib/zstd/zstd-deflate-transform';
 // export {default as ZstdInflateTransform} from './lib/zstd/zstd-inflate-transform';
+
+// __VERSION__ is injected by babel-plugin-version-inline
+// @ts-ignore TS2304: Cannot find name '__VERSION__'.
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+
+export const ZlibWorker = {
+  id: 'zlib',
+  name: 'zlib',
+  version: VERSION,
+  options: {
+    zlib: {
+      localWorkerUrl: 'modules/compression/dist/zlib.worker.js',
+      workerUrl: `https://unpkg.com/@loaders.gl/compression@${VERSION}/dist/zlip.worker.js`
+    }
+  }
+};

--- a/modules/compression/src/index.js
+++ b/modules/compression/src/index.js
@@ -8,7 +8,7 @@ export {default as LZ4InflateTransform} from './lib/lz4/lz4-inflate-transform';
 
 // Move to WIP due to enormous dependency size
 // export {default as ZstdDeflateTransform} from './lib/zstd/zstd-deflate-transform';
-// export {default as ZstdInflateTransform} from './lib/zstd/zstd-inflate-transform';
+// export {default as ZstdInflateTransform} from './lib/zstd/zstd-inflate-transform';\
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
@@ -17,11 +17,11 @@ const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 export const ZlibWorker = {
   id: 'zlib',
   name: 'zlib',
+  module: 'compression',
   version: VERSION,
   options: {
     zlib: {
-      localWorkerUrl: 'modules/compression/dist/zlib.worker.js',
-      workerUrl: `https://unpkg.com/@loaders.gl/compression@${VERSION}/dist/zlip.worker.js`
+      // level
     }
   }
 };

--- a/modules/compression/src/lib/lz4/lz4-inflate-transform.d.ts
+++ b/modules/compression/src/lib/lz4/lz4-inflate-transform.d.ts
@@ -8,7 +8,7 @@ export default class LZ4InflateTransform implements IncrementalTransform {
    * Atomic inflate
    */
   static run(input: ArrayBuffer, options?: object): Promise<ArrayBuffer>;
-  
+
   /**
    * Alternate interface for chunking & without exceptions
    * @param options

--- a/modules/compression/src/workers/lz4-worker.js
+++ b/modules/compression/src/workers/lz4-worker.js
@@ -6,7 +6,7 @@ export {LZ4DeflateTransform, LZ4InflateTransform};
 
 createWorker(async ({data, options = {}}) => {
   // @ts-ignore
-  switch (options.transform) {
+  switch (options.operation) {
     case 'deflate':
       return await LZ4DeflateTransform.run(data);
     case 'inflate':

--- a/modules/compression/src/workers/lz4.worker.js
+++ b/modules/compression/src/workers/lz4.worker.js
@@ -1,0 +1,17 @@
+import {createWorker} from '@loaders.gl/loader-utils';
+import LZ4DeflateTransform from '../lib/zlib/zlib-deflate-transform';
+import LZ4InflateTransform from '../lib/zlib/zlib-inflate-transform';
+
+export {LZ4DeflateTransform, LZ4InflateTransform};
+
+createWorker(async ({data, options = {}}) => {
+  // @ts-ignore
+  switch (options.transform) {
+    case 'deflate':
+      return await LZ4DeflateTransform.run(data);
+    case 'inflate':
+      return await LZ4InflateTransform.run(data);
+    default:
+      throw new Error('invalid option');
+  }
+});

--- a/modules/compression/src/workers/zlib-worker.js
+++ b/modules/compression/src/workers/zlib-worker.js
@@ -6,7 +6,7 @@ export {ZlibDeflateTransform, ZlibInflateTransform};
 
 createWorker(async ({data, options = {}}) => {
   // @ts-ignore
-  switch (options.transform) {
+  switch (options.operation) {
     case 'deflate':
       return await ZlibDeflateTransform.run(data);
     case 'inflate':

--- a/modules/compression/src/workers/zlib.worker.js
+++ b/modules/compression/src/workers/zlib.worker.js
@@ -1,0 +1,17 @@
+import {createWorker} from '@loaders.gl/loader-utils';
+import ZlibDeflateTransform from '../lib/zlib/zlib-deflate-transform';
+import ZlibInflateTransform from '../lib/zlib/zlib-inflate-transform';
+
+export {ZlibDeflateTransform, ZlibInflateTransform};
+
+createWorker(async ({data, options = {}}) => {
+  // @ts-ignore
+  switch (options.transform) {
+    case 'deflate':
+      return await ZlibDeflateTransform.run(data);
+    case 'inflate':
+      return await ZlibInflateTransform.run(data);
+    default:
+      throw new Error('invalid option');
+  }
+});

--- a/modules/compression/test/zlib/zlib.spec.js
+++ b/modules/compression/test/zlib/zlib.spec.js
@@ -103,17 +103,21 @@ test('zlib#worker', async t => {
   t.equal(binaryData.byteLength, 100000, 'Length correct');
 
   const deflatedData = await processOnWorker(ZlibWorker, binaryData.slice(), {
-    transform: 'deflate',
-    worker: 'local',
-    zlib: {level: 6}
+    operation: 'deflate',
+    zlib: {
+      workerUrl: 'test',
+      level: 6
+    }
   });
 
   t.equal(deflatedData.byteLength, 12813, 'Length correct');
 
   const inflatedData = await processOnWorker(ZlibWorker, deflatedData, {
-    transform: 'inflate',
-    worker: 'local',
-    zlib: {level: 6}
+    operation: 'inflate',
+    zlib: {
+      workerUrl: 'test',
+      level: 6
+    }
   });
 
   t.equal(inflatedData.byteLength, 100000, 'Length correct');

--- a/modules/compression/wip/zstd/zstd-deflate-transform.md
+++ b/modules/compression/wip/zstd/zstd-deflate-transform.md
@@ -1,7 +1,7 @@
 # ZstdDeflateTransform
 
 <p class="badges">
-  <img src="https://img.shields.io/badge/From-v2.3-blue.svg?style=flat-square" alt="From-v2.3" /> 
+  <img src="https://img.shields.io/badge/From-v2.3-blue.svg?style=flat-square" alt="From-v2.3" />
 </p>
 
 ## Static Methods

--- a/modules/core/src/index.d.ts
+++ b/modules/core/src/index.d.ts
@@ -31,6 +31,9 @@ export {makeIterator} from './iterator-utils/make-iterator/make-iterator';
 // CORE LOADERS
 export {NullLoader} from './null-loader';
 
+// WORKERS
+export {processOnWorker} from '@loaders.gl/loader-utils';
+
 // EXPERIMENTAL
 export {default as _fetchProgress} from './lib/progress/fetch-progress';
 export {default as _BrowserFileSystem} from './lib/filesystems/browser-filesystem';

--- a/modules/core/src/index.js
+++ b/modules/core/src/index.js
@@ -33,6 +33,9 @@ export {NullLoader} from './null-loader';
 export {setPathPrefix, getPathPrefix, resolvePath} from '@loaders.gl/loader-utils';
 export {RequestScheduler} from '@loaders.gl/loader-utils';
 
+// WORKERS
+export {processOnWorker} from '@loaders.gl/loader-utils';
+
 // EXPERIMENTAL
 export {default as _fetchProgress} from './lib/progress/fetch-progress';
 export {default as _BrowserFileSystem} from './lib/filesystems/browser-filesystem';

--- a/modules/loader-utils/README.md
+++ b/modules/loader-utils/README.md
@@ -1,4 +1,4 @@
-# @loaders.gl/core
+# @loaders.gl/loader-utils
 
 This module contains shared utilities for loaders.gl, a collection of framework-independent 3D and geospatial loaders (parsers).
 

--- a/modules/loader-utils/package.json
+++ b/modules/loader-utils/package.json
@@ -39,8 +39,10 @@
     "child_process": false
   },
   "scripts": {
-    "pre-build-disabled": "npm run build-bundle && npm run build-bundle -- --env.dev",
-    "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js"
+    "pre-build": "npm run build-workers",
+    "pre-build-disabled": "npm run build-bundle && npm run build-workers && npm run build-bundle -- --env.dev",
+    "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
+    "build-workers": "webpack --entry ./src/workers/null-worker.js --output ./dist/null-worker.js --env.dev --config ../../scripts/webpack/worker.js"
   },
   "dependencies": {
     "@babel/runtime": "^7.3.1",

--- a/modules/loader-utils/src/index.d.ts
+++ b/modules/loader-utils/src/index.d.ts
@@ -90,7 +90,7 @@ export {default as ChildProcessProxy} from './lib/process-utils/child-process-pr
 // Note: Should move to category specific module if code size increases
 export {getMeshSize as _getMeshSize, getMeshBoundingBox} from './categories/mesh/mesh-utils';
 
-import {WorkerObject} from '@loaders.gl/loader-utils';
+import {WorkerObject} from './types';
 
 /** A null worker to test that worker processing is functional */
 export const NullWorker: WorkerObject;

--- a/modules/loader-utils/src/index.d.ts
+++ b/modules/loader-utils/src/index.d.ts
@@ -1,5 +1,6 @@
 // TYPES
 export {
+  WorkerObject,
   WorkerLoaderObject,
   LoaderObject,
   WriterObject,
@@ -31,6 +32,8 @@ export {makeTransformIterator} from './lib/iterator-utils/make-transform-iterato
 
 // WORKER UTILS
 export {getTransferList} from './lib/worker-utils/get-transfer-list';
+export {processOnWorker} from './lib/worker-utils/process-on-worker';
+export {createWorker} from './lib/worker-utils/create-worker';
 export {default as _WorkerFarm} from './lib/worker-utils/worker-farm';
 export {default as _WorkerPool} from './lib/worker-utils/worker-pool';
 export {default as _WorkerThread} from './lib/worker-utils/worker-thread';

--- a/modules/loader-utils/src/index.d.ts
+++ b/modules/loader-utils/src/index.d.ts
@@ -90,5 +90,10 @@ export {default as ChildProcessProxy} from './lib/process-utils/child-process-pr
 // Note: Should move to category specific module if code size increases
 export {getMeshSize as _getMeshSize, getMeshBoundingBox} from './categories/mesh/mesh-utils';
 
+import {WorkerObject} from '@loaders.gl/loader-utils';
+
+/** A null worker to test that worker processing is functional */
+export const NullWorker: WorkerObject;
+
 // DEPRECATED IN 2.3
 export {getZeroOffsetArrayBuffer} from './lib/binary-utils/memory-copy-utils';

--- a/modules/loader-utils/src/index.js
+++ b/modules/loader-utils/src/index.js
@@ -1,3 +1,5 @@
+/** @typedef {import('@loaders.gl/loader-utils').WorkerObject} WorkerObject */
+
 // GENERAL UTILS
 export {default as assert} from './lib/env-utils/assert';
 export {
@@ -76,6 +78,20 @@ export {default as ChildProcessProxy} from './lib/process-utils/child-process-pr
 // MESH CATEGORY UTILS
 // Note: Should move to category specific module if code size increases
 export {getMeshSize as _getMeshSize, getMeshBoundingBox} from './categories/mesh/mesh-utils';
+
+// __VERSION__ is injected by babel-plugin-version-inline
+// @ts-ignore TS2304: Cannot find name '__VERSION__'.
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+
+export const NullWorker = {
+  id: 'null',
+  name: 'null',
+  module: 'loader-utils',
+  version: VERSION,
+  options: {
+    null: {}
+  }
+};
 
 // DEPRECATED IN 2.3
 export {getZeroOffsetArrayBuffer} from './lib/binary-utils/memory-copy-utils';

--- a/modules/loader-utils/src/index.js
+++ b/modules/loader-utils/src/index.js
@@ -16,6 +16,8 @@ export {validateLoaderVersion} from './lib/worker-loader-utils/validate-loader-v
 export {makeTransformIterator} from './lib/iterator-utils/make-transform-iterator';
 
 // WORKER UTILS
+export {processOnWorker} from './lib/worker-utils/process-on-worker';
+export {createWorker} from './lib/worker-utils/create-worker';
 export {getTransferList} from './lib/worker-utils/get-transfer-list';
 export {default as _WorkerFarm} from './lib/worker-utils/worker-farm';
 export {default as _WorkerPool} from './lib/worker-utils/worker-pool';

--- a/modules/loader-utils/src/lib/path-utils/path.d.ts
+++ b/modules/loader-utils/src/lib/path-utils/path.d.ts
@@ -6,6 +6,6 @@ export function dirname(url: string): string;
 
 /**
  * Replacement for Node.js path.join
- * @param parts 
+ * @param parts
  */
 export function join(...parts: string[]): string

--- a/modules/loader-utils/src/lib/worker-utils/create-worker.d.ts
+++ b/modules/loader-utils/src/lib/worker-utils/create-worker.d.ts
@@ -1,0 +1,5 @@
+/**
+ * Set up a WebWorkerGlobalScope to talk with the main thread
+ * @param loader
+ */
+export function createWorker(func: Function): void;

--- a/modules/loader-utils/src/lib/worker-utils/create-worker.js
+++ b/modules/loader-utils/src/lib/worker-utils/create-worker.js
@@ -1,0 +1,36 @@
+/* eslint-disable no-restricted-globals */
+/* global self */
+
+import {getTransferList} from './get-transfer-list';
+
+export function createWorker(processFunc) {
+  // Check that we are actually in a worker thread
+  if (typeof self === 'undefined') {
+    return;
+  }
+
+  self.onmessage = async evt => {
+    const {data} = evt;
+
+    try {
+      if (!isKnownMessage(data)) {
+        return;
+      }
+
+      const result = await processFunc(data);
+
+      const transferList = getTransferList(result);
+
+      // @ts-ignore self is WorkerGlobalScope
+      self.postMessage({type: 'done', result}, transferList);
+    } catch (error) {
+      // @ts-ignore self is WorkerGlobalScope
+      self.postMessage({type: 'error', message: error.message});
+    }
+  };
+}
+
+// Filter out noise messages sent to workers
+function isKnownMessage(data, type = 'parse') {
+  return data && data.type === type && data.source && data.source.startsWith('loaders.gl');
+}

--- a/modules/loader-utils/src/lib/worker-utils/get-worker-url.js
+++ b/modules/loader-utils/src/lib/worker-utils/get-worker-url.js
@@ -45,5 +45,6 @@ try {
   importScripts('${workerUrl}');
 } catch (error) {
   console.error(error);
+  throw error;
 }`;
 }

--- a/modules/loader-utils/src/lib/worker-utils/process-on-worker.d.ts
+++ b/modules/loader-utils/src/lib/worker-utils/process-on-worker.d.ts
@@ -1,0 +1,7 @@
+import {WorkerObject} from '../../types';
+/**
+ * This function expects that the worker thread sends certain messages,
+ * Creating such a worker can be automated if the worker is wrapper by a call to
+ * createLoaderWorker in @loaders.gl/loader-utils.
+ */
+export function processOnWorker(worker: WorkerObject, data: any): Promise<any>;

--- a/modules/loader-utils/src/lib/worker-utils/process-on-worker.js
+++ b/modules/loader-utils/src/lib/worker-utils/process-on-worker.js
@@ -1,0 +1,60 @@
+import assert from '../env-utils/assert';
+import WorkerFarm from './worker-farm';
+
+// __VERSION__ is injected by babel-plugin-version-inline
+// @ts-ignore TS2304: Cannot find name '__VERSION__'.
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+
+/**
+ * this function expects that the worker function sends certain messages,
+ * this can be automated if the worker is wrapper by a call to createLoaderWorker in @loaders.gl/loader-utils.
+ */
+export function processOnWorker(worker, data, options = {}) {
+  const workerOptions = {...worker.options[worker.id], ...options[worker.id]};
+  const workerUrl =
+    options.worker === 'local' ? workerOptions.localWorkerUrl : workerOptions.workerUrl;
+  assert(workerUrl, 'processOnWorker: Empty worker URL');
+
+  // Mark as URL
+  const workerSource = `url(${workerUrl})`;
+  const workerName = worker.name;
+
+  const workerFarm = getWorkerFarm(options);
+
+  // options.log object contains functions which cannot be transferred
+  // TODO - decide how to handle logging on workers
+  options = JSON.parse(JSON.stringify(options));
+
+  const warning = worker.version !== VERSION ? `(core version ${VERSION})` : '';
+
+  return workerFarm.process(workerSource, `${workerName}-worker@${worker.version}${warning}`, {
+    data,
+    options,
+    source: `loaders.gl@${VERSION}`, // Lets worker ignore unrelated messages
+    type: 'parse' // TODO - For future extension
+  });
+}
+
+let _workerFarm = null;
+
+// Create a single instance of a worker farm
+export function getWorkerFarm(options = {}) {
+  const props = {};
+  if (options.maxConcurrency) {
+    props.maxConcurrency = options.maxConcurrency;
+  }
+  if (options.onDebug) {
+    props.onDebug = options.onDebug;
+  }
+  if ('reuseWorkers' in options) {
+    // @ts-ignore
+    props.reuseWorkers = options.reuseWorkers;
+  }
+
+  if (!_workerFarm) {
+    _workerFarm = new WorkerFarm({});
+  }
+  _workerFarm.setProps(props);
+
+  return _workerFarm;
+}

--- a/modules/loader-utils/src/lib/worker-utils/worker-thread.js
+++ b/modules/loader-utils/src/lib/worker-utils/worker-thread.js
@@ -14,6 +14,7 @@ export default class WorkerThread {
     const url = getWorkerURL(source, name);
     this.worker = new Worker(url, {name});
     this.name = name;
+    this.url = url;
     this.onMessage = onMessage || defaultOnMessage;
   }
 
@@ -32,6 +33,8 @@ export default class WorkerThread {
         let message = `${this.name}: WorkerThread.process() failed`;
         if (error.message) {
           message += ` ${error.message} ${error.filename}:${error.lineno}:${error.colno}`;
+        } else {
+          message += ` ${this.url.slice(0, 100)}`;
         }
         const betterError = new Error(message);
         console.error(error); // eslint-disable-line

--- a/modules/loader-utils/src/types.d.ts
+++ b/modules/loader-utils/src/types.d.ts
@@ -1,7 +1,19 @@
 /**
+ * A worker description
+ */
+export type WorkerObject = {
+  id: string,
+  name: string,
+  version: string,
+  options: object;
+  deprecatedOptions?: object;
+};
+
+/**
  * A worker loader defintion that can be used with `@loaders.gl/core` functions
  */
 export type WorkerLoaderObject = {
+  // WorkerObject
   id: string,
   name: string,
   version: string,

--- a/modules/loader-utils/src/types.d.ts
+++ b/modules/loader-utils/src/types.d.ts
@@ -2,9 +2,10 @@
  * A worker description
  */
 export type WorkerObject = {
-  id: string,
-  name: string,
-  version: string,
+  id: string;
+  name: string;
+  module: string;
+  version: string;
   options: object;
   deprecatedOptions?: object;
 };

--- a/modules/loader-utils/src/workers/null-worker.js
+++ b/modules/loader-utils/src/workers/null-worker.js
@@ -1,4 +1,4 @@
-import {createWorker} from '@loaders.gl/loader-utils';
+import {createWorker} from '../lib/worker-utils/create-worker';
 
 createWorker(async ({data, options = {}}) => {
   // @ts-ignore

--- a/modules/loader-utils/src/workers/null-worker.js
+++ b/modules/loader-utils/src/workers/null-worker.js
@@ -1,0 +1,6 @@
+import {createWorker} from '@loaders.gl/loader-utils';
+
+createWorker(async ({data, options = {}}) => {
+  // @ts-ignore
+  return data;
+});

--- a/modules/loader-utils/test/index.js
+++ b/modules/loader-utils/test/index.js
@@ -15,6 +15,7 @@ import './lib/request-utils/request-scheduler.spec';
 
 import './lib/worker-utils/get-transfer-list.spec';
 import './lib/worker-utils/worker-farm.spec';
+import './lib/worker-utils/process-on-worker.spec';
 
 import './lib/worker-loader-utils/validate-loader-version.spec';
 import './lib/worker-loader-utils/create-worker.spec';

--- a/modules/loader-utils/test/lib/worker-utils/process-on-worker.spec.js
+++ b/modules/loader-utils/test/lib/worker-utils/process-on-worker.spec.js
@@ -1,0 +1,19 @@
+import test from 'tape-promise/tape';
+import {NullWorker, isBrowser} from '@loaders.gl/loader-utils';
+import {processOnWorker} from '@loaders.gl/loader-utils';
+
+test('processOnWorker', async t => {
+  if (!isBrowser) {
+    t.end();
+    return;
+  }
+
+  const nullData = await processOnWorker(NullWorker, 'abc', {
+    null: {
+      workerUrl: 'test'
+    }
+  });
+
+  t.equal(nullData, 'abc', 'Null verified');
+  t.end();
+});

--- a/scripts/webpack/worker.js
+++ b/scripts/webpack/worker.js
@@ -25,7 +25,7 @@ const BABEL_CONFIG = {
     ['@babel/preset-env', {modules: false}]
   ],
   plugins: [
-    ['@babel/plugin-transform-runtime', {useESModules: false}], 
+    ['@babel/plugin-transform-runtime', {useESModules: false}],
     'version-inline'
   ]
 };


### PR DESCRIPTION
Compression should be done on workers but our existing worker support was specific to loaders. This generalizes things so that arbitrary tasks can be bundled up and packaged as loadable workers.

- Adds `createWorker()` and `processOnWorker()` APIs for running non-loader pre-bundled worker tasks
- Adds `WorkerObject` type
- Adds `ZlibWorker` and `LZ4Worker` worker objects that support compression and decompression on worker threads. 
- Importing these objects does not add compression library dependencies to main bundle size.
