### PR TITLE
Change sharedResource href structure as per spec

### DIFF
--- a/modules/tile-converter/src/i3s-converter/i3s-converter.js
+++ b/modules/tile-converter/src/i3s-converter/i3s-converter.js
@@ -463,7 +463,7 @@ export default class I3SConverter {
 
     if (nodeInPage.mesh) {
       node.geometryData = [{href: './geometries/0'}];
-      node.sharedResource = [{href: './shared'}];
+      node.sharedResource = {href: './shared'};
 
       if (resources.texture) {
         node.textureData = [{href: './textures/0'}];


### PR DESCRIPTION
`sharedResouce` should be an `object`
https://github.com/Esri/i3s-spec/blob/master/docs/1.7/3DNodeIndexDocument.cmn.md