### PR TITLE
gltf: when resolving accessors in post-processing, take into account accessor.byteOffset

### DIFF
--- a/modules/gltf/src/lib/post-process-gltf.js
+++ b/modules/gltf/src/lib/post-process-gltf.js
@@ -301,7 +301,8 @@ class GLTFPostProcessor {
     if (accessor.bufferView) {
       const buffer = accessor.bufferView.buffer;
       const {ArrayType, byteLength} = getAccessorArrayTypeAndLength(accessor, accessor.bufferView);
-      const byteOffset = (accessor.bufferView.byteOffset || 0) + buffer.byteOffset;
+      const byteOffset =
+        (accessor.bufferView.byteOffset || 0) + (accessor.byteOffset || 0) + buffer.byteOffset;
       const cutBufffer = buffer.arrayBuffer.slice(byteOffset, byteOffset + byteLength);
       accessor.value = new ArrayType(cutBufffer);
     }


### PR DESCRIPTION
Hi!
When testing out some Cesium 3d-tiles, one model loaded seemingly fine, but the normals were off and the geometry had some holes in it.
After doing some digging, I found that some accessor buffers were not loaded correctly because of this line:
```
const byteOffset = (accessor.bufferView.byteOffset || 0) + buffer.byteOffset;
```
where it was not taking into account `accessor.byteOffset`, which looks to be part of the [gLTF standard](https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/schema/accessor.schema.json#L13-L19).

Once I added `+ (accessor.byteOffset || 0)` to the sum, it fixed my model.

/Avner 
