### PR TITLE
feat: Build source maps on CDN to enable script and worker debugging.

### DIFF
--- a/scripts/webpack/bundle.js
+++ b/scripts/webpack/bundle.js
@@ -110,7 +110,12 @@ module.exports = (env = {}) => {
     config.output.filename = 'dist/dist.dev.js';
     // Disable transpilation
     config.module.rules = [];
+  } else {
+    // Generate a separate source map
+    // @ts-ignore
+    config.devtool = 'source-map';
   }
+
 
   // NOTE uncomment to display config
   // console.log('webpack config', JSON.stringify(config, null, 2));

--- a/scripts/webpack/worker.js
+++ b/scripts/webpack/worker.js
@@ -118,6 +118,10 @@ module.exports = (env = {}) => {
   if (env.dev) {
     config.mode = 'development';
     config = addESNextSettings(config);
+  } else {
+    // Generate a separate source map
+    // @ts-ignore
+    config.devtool = 'source-map';
   }
   // console.log(JSON.stringify(config, null, 2));
   return config;


### PR DESCRIPTION
Build `.map` source map files in dist folder for script and worker bundles. 

The hope is that the browser debugger will be able to load these from CDN after we publish.