### PR TITLE
fix(mvt): Add extensions/mime types to support ArcGIS server

### DIFF
--- a/modules/mvt/src/mvt-loader.js
+++ b/modules/mvt/src/mvt-loader.js
@@ -15,8 +15,13 @@ export const MVTWorkerLoader = {
   id: 'mvt',
   module: 'mvt',
   version: VERSION,
-  extensions: ['mvt'],
-  mimeTypes: ['application/x-protobuf', 'application/vnd.mapbox-vector-tile'],
+  // Note: ArcGIS uses '.pbf' extension and 'application/octet-stream'
+  extensions: ['mvt', 'pbf'],
+  mimeTypes: [
+    'application/vnd.mapbox-vector-tile',
+    'application/x-protobuf',
+    'application/octet-stream'
+  ],
   category: 'geometry',
   options: {
     mvt: {


### PR DESCRIPTION
Enable vector tiles to be loaded from ArcGIS server.

Per https://github.com/visgl/deck.gl/discussions/5482