### PR TITLE
gltf: when resolving accessors in post-processing, take into account accessor.byteOffset

### DIFF
--- a/modules/gltf/src/lib/post-process-gltf.js
+++ b/modules/gltf/src/lib/post-process-gltf.js
@@ -288,7 +288,8 @@ class GLTFPostProcessor {
     if (accessor.bufferView) {
       const buffer = accessor.bufferView.buffer;
       const {ArrayType, length} = getAccessorArrayTypeAndLength(accessor, accessor.bufferView);
-      const byteOffset = (accessor.bufferView.byteOffset || 0) + buffer.byteOffset;
+      const byteOffset =
+        (accessor.bufferView.byteOffset || 0) + (accessor.byteOffset || 0) + buffer.byteOffset;
       accessor.value = new ArrayType(buffer.arrayBuffer, byteOffset, length);
     }
 


### PR DESCRIPTION
There is conflict while cherry-pick process of [PR](https://github.com/visgl/loaders.gl/pull/1175) to 2.3-release branch.
@Avnerus @ibgreen Please Take a look at thit.