### PR TITLE
tiles: Tile traversal optimizations

### DIFF
--- a/examples/website/i3s/app.js
+++ b/examples/website/i3s/app.js
@@ -144,7 +144,7 @@ export default class App extends PureComponent {
 
   _renderLayers() {
     const {tilesetUrl, token} = this.state;
-    const loadOptions = {throttleRequests: true};
+    const loadOptions = {};
     if (token) {
       loadOptions.token = token;
     }

--- a/modules/tiles/docs/README.md
+++ b/modules/tiles/docs/README.md
@@ -1,4 +1,4 @@
-# Overview
+#s Overview
 
 `@loaders/tiles` exposes handy classes `Tileset3D` and `Tile3D` which can understand the loaded data from tile loaders (`@loaders.gl/3d-tiles`, `@loaders.gl/i3s`, etc.), and provide useful functions for dynamically selecting tiles for rendering under a viewport.
 
@@ -38,7 +38,7 @@
   - `options`: Options object, but not limited to
     Parameters:
     - `modelMatrix`=`Matrix4.IDENTITY` (`Matrix4`) - A 4x4 transformation matrix that transforms the tileset's root tile.
-    - `maximumMemoryUsage`=`512`] (`Number`) - The maximum amount of memory in MB that can be used by the tileset.
+    - `maximumMemoryUsage`=`512` (`Number`) - The maximum amount of memory in MB that can be used by the tileset.
     - `ellipsoid`=`Ellipsoid.WGS84` ([`Ellipsoid`](https://math.gl/modules/geospatial/docs/api-reference/ellipsoid)) - The ellipsoid determining the size and shape of the globe.
       Callbacks:
     - `onTileLoad` (`(tileHeader : Tile3DHeader) : void`) - callback when a tile node is fully loaded during the tileset traversal.

--- a/modules/tiles/docs/README.md
+++ b/modules/tiles/docs/README.md
@@ -1,4 +1,4 @@
-#s Overview
+# Overview
 
 `@loaders/tiles` exposes handy classes `Tileset3D` and `Tile3D` which can understand the loaded data from tile loaders (`@loaders.gl/3d-tiles`, `@loaders.gl/i3s`, etc.), and provide useful functions for dynamically selecting tiles for rendering under a viewport.
 

--- a/modules/tiles/docs/api-reference/tile-3d.md
+++ b/modules/tiles/docs/api-reference/tile-3d.md
@@ -42,9 +42,9 @@ One of
 - `render`: has content to render
 - `tileset`: tileset tile
 
-###### `depth` (Number)
+##### `_selectionDepth` (Number)
 
-The depth of the tile in the tileset tree.
+The depth of the tile in the traversal tree.
 
 ###### `content` (Object)
 

--- a/modules/tiles/docs/api-reference/tileset-3d.md
+++ b/modules/tiles/docs/api-reference/tileset-3d.md
@@ -69,7 +69,8 @@ Parameters:
 - `json`: loaded tileset json object, should follow the format [tiles format](https://loaders.gl/docs/specifications/category-3d-tiles)
 - `options`:
   - `options.ellipsoid`=`Ellipsoid.WGS84` (`Ellipsoid`) - The ellipsoid determining the size and shape of the globe.
-  - `options.throttleRequests`=`true` (`Boolean`) - Determines whether or not to throttle tile fetching requests.
+  - `options.throttleRequests`=`true` (`Boolean`) - Determines whether or not to throttle tile fetching requests. Throttled requests are prioritized according to tile visibility.
+  - `options.maxRequests`=`64` (`Number`) - When throttling tile fetching, the maximum number of simultaneous requests.
   - `options.modelMatrix`=`Matrix4.IDENTITY` (`Matrix4`) - A 4x4 transformation matrix this transforms the entire tileset.
   - `options.maximumMemoryUsage`=`512`] (`Number`) - The maximum amount of memory in MB that can be used by the tileset.
   - `options.fetchOptions` - fetchOptions, i.e. headers, used to load tiles from tiling server


### PR DESCRIPTION
Hi! this is a long one.
As part of our work on Cesium 3d tiles with photogrammetry and three.js I ended up doing some changes to the loaders.gl tiles code which I detail in this PR:

1. Consolidate the tile `getPriority` function:
When working with heavy street-view-style photogrammetry tilesets, I always had to use `requestThrottling`, or the browser could not handle the amount of tiles being loaded. However, the priority function used for the request scheduler was using only `lodMetricValue`, not taking into account the distance to the camera. A priority function which resembles more the [CesiumJS function](https://github.com/CesiumGS/cesium/blob/master/Source/Scene/Cesium3DTile.js#L1660) and takes both sse and camera distance into account was used in the [traversal code](https://github.com/visgl/loaders.gl/blob/master/modules/tiles/src/tileset/traversers/tileset-traverser.js#L270l) when loading the tile, I therefore moved that code to the tile and use that one instead, both on tile load and for request scheduling.

2. Regarding Skip VS Base traversal, we do not yet have a skip traversal implementation in three.js, which requires the use of the stencil buffer for tile depth (do you by the way have an implementation in deck.gl or other?). However, I have done some tests and noticed that there might be some lines in the traversal and priority functions that are specific for either skip or base traversal: 
https://github.com/visgl/loaders.gl/blob/480b38a9a2cc9e3ed19c7ecb0aea9665add8901f/modules/tiles/src/tileset/traversers/tileset-traverser.js#L172-L174
This line breaks the iteration of a parent tile if at least one child is not yet refined. I think this is specific for base traversal because in skip traversal you might want to load a certain child even if siblings are not loaded. This break does not happen in the [original CesiumJS code](https://github.com/CesiumGS/cesium/blob/master/Source/Scene/Cesium3DTilesetTraversal.js#L486-L501). I then changed it to:
```        
refines = refines && childRefines;
if (!refines && !skipLevelOfDetail) {
  return false;
}
```
And then here:
https://github.com/visgl/loaders.gl/blob/480b38a9a2cc9e3ed19c7ecb0aea9665add8901f/modules/tiles/src/tileset/tile-3d.js#L160-L164
This line aborts the loading of a tile if it is not visible, but in base traversal you might need to load invisible tiles or else the parent would not refine. I had to change it to:
```
if (!this.isVisible && traverser.options.skipLevelOfDetail) {
  return -1;
}
```
So I could enable `requestThrottling`.

3. Finally, I added to safety checks related to tile unloading. This is related to the fact that if in order to get the traversal working properly in three.js, I had to intervene in the `contentState` process and decide myself when the tiles are definitely ready once all of the three.js objects are created (can be after an asynchronous gltf parsing operation). This intervening introduced some race conditions in which a tile's content was being accessed even after it was destroyed. Perhaps the proper way to fix this is to support a user defined `Promise` which defers the tile's `contentState` setting of `READY` or `UNLOADED`, but in the meantime I think it is enough to have those race conditions checks.

No urgency on this one as we are using our fork for now, but would appreciate your comments on these fixes.
Thank you!

/Avner
