### PR TITLE
gltf: Preserve original accessor properties in Draco decoded mesh attributes

### DIFF
--- a/modules/gltf/src/lib/extensions/KHR_draco_mesh_compression.js
+++ b/modules/gltf/src/lib/extensions/KHR_draco_mesh_compression.js
@@ -64,9 +64,18 @@ async function decompressPrimitive(primitive, scenegraph, options, context) {
   delete dracoOptions['3d-tiles'];
   const decodedData = await parse(bufferCopy, DracoLoader, dracoOptions, context);
 
-  primitive.attributes = getGLTFAccessors(decodedData.attributes);
+  const originalAccessors = {};
+  for (const [name, index] of [
+    ...Object.entries(primitive.attributes),
+    ['indices', primitive.indices]
+  ]) {
+    originalAccessors[name] = scenegraph.getAccessor(index);
+  }
+
+  primitive.attributes = getGLTFAccessors(decodedData.attributes, originalAccessors);
+
   if (decodedData.indices) {
-    primitive.indices = getGLTFAccessor(decodedData.indices);
+    primitive.indices = getGLTFAccessor(decodedData.indices, originalAccessors.indices || {});
   }
 
   // Extension has been processed, delete it

--- a/modules/gltf/src/lib/gltf-utils/gltf-attribute-utils.js
+++ b/modules/gltf/src/lib/gltf-utils/gltf-attribute-utils.js
@@ -4,12 +4,12 @@ import {getAccessorTypeFromSize, getComponentTypeFromArray} from './gltf-utils';
 // Returns a fresh attributes object with glTF-standardized attributes names
 // Attributes that cannot be identified will not be included
 // Removes `indices` if present, as it should be stored separately from the attributes
-export function getGLTFAccessors(attributes) {
+export function getGLTFAccessors(attributes, jsonAccessors = {}) {
   const accessors = {};
   for (const name in attributes) {
     const attribute = attributes[name];
     if (name !== 'indices') {
-      const glTFAccessor = getGLTFAccessor(attribute);
+      const glTFAccessor = getGLTFAccessor(attribute, jsonAccessors[name] || {});
       accessors[name] = glTFAccessor;
     }
   }
@@ -19,10 +19,11 @@ export function getGLTFAccessors(attributes) {
 // Fix up a single accessor.
 // Input: typed array or a partial accessor object
 // Return: accessor object
-export function getGLTFAccessor(attribute, gltfAttributeName) {
-  const {buffer, size, count} = getAccessorData(attribute, gltfAttributeName);
+export function getGLTFAccessor(attribute, jsonAccessor = {}) {
+  const {buffer, size, count} = getAccessorData(attribute);
 
   const glTFAccessor = {
+    ...jsonAccessor,
     // TODO: Deprecate `value` in favor of bufferView?
     value: buffer,
     size, // Decoded `type` (e.g. SCALAR)
@@ -43,7 +44,7 @@ export function getGLTFAttribute(data, gltfAttributeName) {
   return data.attributes[data.glTFAttributeMap[gltfAttributeName]];
 }
 
-function getAccessorData(attribute, attributeName) {
+function getAccessorData(attribute) {
   let buffer = attribute;
   let size = 1;
   let count = 0;

--- a/modules/gltf/test/lib/gltf-scenegraph-modifiers.spec.js
+++ b/modules/gltf/test/lib/gltf-scenegraph-modifiers.spec.js
@@ -37,3 +37,71 @@ test('GLTFScenegraph#addImage', t => {
 
   t.end();
 });
+<<<<<<< HEAD
+=======
+
+test('GLTFScenegraph#Should be able to write custom attribute', async t => {
+  const inputData = await load(GLTF_BINARY_URL, GLTFLoader, {gltf: {postProcess: true}});
+  const gltfBuilder = new GLTFScenegraph();
+
+  gltfBuilder.addMesh({
+    attributes: {
+      POSITION: inputData.meshes[0].primitives[0].attributes.POSITION,
+      _BATCHID: inputData.meshes[0].primitives[0].attributes.TEXCOORD_0
+    }
+  });
+  t.ok(gltfBuilder.gltf.json.meshes[0]);
+  t.ok(gltfBuilder.gltf.json.meshes[0].primitives[0].attributes._BATCHID);
+
+  t.end();
+});
+
+test('GLTFScenegraph#Should calculate min and max arrays for accessor', async t => {
+  const inputData = await load(GLTF_BINARY_URL, GLTFLoader, {gltf: {postProcess: true}});
+  const gltfBuilder = new GLTFScenegraph();
+
+  delete inputData.meshes[0].primitives[0].attributes.POSITION.min;
+  delete inputData.meshes[0].primitives[0].attributes.POSITION.max;
+
+  gltfBuilder.addMesh({
+    attributes: {
+      POSITION: inputData.meshes[0].primitives[0].attributes.POSITION
+    }
+  });
+  t.ok(gltfBuilder.gltf.json.accessors[0]);
+  t.deepEqual(gltfBuilder.gltf.json.accessors[0].min, [
+    -2316.5927734375,
+    -3864.65771484375,
+    -3551.852294921875
+  ]);
+  t.deepEqual(gltfBuilder.gltf.json.accessors[0].max, [
+    2647.046875,
+    4302.39111328125,
+    3733.835205078125
+  ]);
+
+  t.end();
+});
+
+test('GLTFScenegraph#Nodes should store `matrix` transformation data', async t => {
+  const inputData = await load(GLTF_BINARY_URL, GLTFLoader, {gltf: {postProcess: true}});
+  const gltfBuilder = new GLTFScenegraph();
+
+  const meshIndex = gltfBuilder.addMesh({
+    attributes: {
+      POSITION: inputData.meshes[0].primitives[0].attributes.POSITION
+    }
+  });
+  const inputMatrix = [1, 0, 0, 0, 0, 0, -1, 0, 0, 1, 0, 0, 0, 0, 0, 1];
+  const nodeIndex = gltfBuilder.addNode({meshIndex, matrix: inputMatrix});
+  t.ok(gltfBuilder.gltf.json.nodes[nodeIndex]);
+  const testMatrix = [1, 0, 0, 0, 0, 0, -1, 0, 0, 1, 0, 0, 0, 0, 0, 1];
+  t.deepEqual(gltfBuilder.gltf.json.nodes[nodeIndex].matrix, testMatrix);
+
+  const nodeIndex2 = gltfBuilder.addNode({meshIndex});
+  t.ok(gltfBuilder.gltf.json.nodes[nodeIndex2]);
+  t.notOk(gltfBuilder.gltf.json.nodes[nodeIndex2].matrix);
+
+  t.end();
+});
+>>>>>>> 82ab7b632... gltf: Preserve original accessor properties in Draco decoded mesh attributes


### PR DESCRIPTION
Conflict while `cherry-picking `to `2.3-release`
@ibgreen @Avnerus Please Take a look on `.spec.js` file.