### PR TITLE
Avoid throw exception when a 204 is received

### DIFF
--- a/modules/core/src/lib/api/select-loader.ts
+++ b/modules/core/src/lib/api/select-loader.ts
@@ -27,6 +27,10 @@ export async function selectLoader(
   options?: LoaderOptions,
   context?: LoaderContext
 ): Promise<Loader | null> {
+  if (!validHTTPResponse(data)) {
+    return null;
+  }
+
   // First make a sync attempt, disabling exceptions
   let loader = selectLoaderSync(data, loaders, {...options, nothrow: true}, context);
   if (loader) {
@@ -63,6 +67,10 @@ export function selectLoaderSync(
   options?: LoaderOptions,
   context?: LoaderContext
 ): Loader | null {
+  if (!validHTTPResponse(data)) {
+    return null;
+  }
+
   // eslint-disable-next-line complexity
   // if only a single loader was provided (not as array), force its use
   // TODO - Should this behavior be kept and documented?
@@ -89,6 +97,18 @@ export function selectLoaderSync(
   }
 
   return loader;
+}
+
+/** Check HTTP Response */
+function validHTTPResponse(data: any): boolean {
+  // HANDLE HTTP status
+  if (data instanceof Response) {
+    // 204 - NO CONTENT. This handles cases where e.g. a tile server responds with 204 for a missing tile
+    if (data.status === 204) {
+      return false;
+    }
+  }
+  return true;
 }
 
 function getNoValidLoaderMessage(data): string {

--- a/modules/shapefile/src/lib/parsers/parse-shp.ts
+++ b/modules/shapefile/src/lib/parsers/parse-shp.ts
@@ -1,8 +1,8 @@
+import type {LoaderOptions} from '@loaders.gl/loader-utils';
 import type {BinaryGeometry} from '@loaders.gl/schema';
 import BinaryChunkReader from '../streaming/binary-chunk-reader';
 import {parseSHPHeader} from './parse-shp-header';
 import {parseRecord} from './parse-shp-geometry';
-import {LoaderOptions} from '@loaders.gl/loader-utils/types';
 
 const LITTLE_ENDIAN = true;
 const BIG_ENDIAN = false;


### PR DESCRIPTION
MVTLayer of deck.gl is throwing an exception at versions 8.4.3+:

```
tile-layer.js:18 Error: No valid loader found data: "", contentType: "null" url: http://localhost:8282/user/carto/bigquery/tileset/1/0/0
    at _callee$ (select-loader.js:29)
    at tryCatch (runtime.js:45)
    at Generator.invoke [as _invoke] (runtime.js:271)
    at Generator.prototype.<computed> [as next] (runtime.js:97)
    at asyncGeneratorStep (asyncToGenerator.js:3)
    at _next (asyncToGenerator.js:25)
    at asyncToGenerator.js:32
    at new Promise (<anonymous>)
    at asyncToGenerator.js:21
    at _selectLoader (app.js:56663)
value @ tile-layer.js:18
```

It happens when a 204 is received and there is no Content-Type because of the fact there is no content in the response. [RFC](https://tools.ietf.org/html/rfc2616#section-7.2.1) says the following:

> Any HTTP/1.1 message containing an entity-body SHOULD include a Content-Type header field defining the media type of that body.

So, I think we should avoid the exception when a 204 is received