### PR TITLE
Change I3S example to I3S with picking feature

### DIFF
--- a/examples/experimental/i3s-picking/app.js
+++ b/examples/experimental/i3s-picking/app.js
@@ -205,7 +205,7 @@ export default class App extends PureComponent {
       info.index
     );
     return selectedFeatureAttributes
-      ? JSON.stringify(selectedFeatureAttributes, null, 2).replace(/[\{\}']+/g, '')
+      ? JSON.stringify(selectedFeatureAttributes, null, 2).replace(/[{}']+/g, '')
       : 'loading metadata...';
   }
 

--- a/examples/website/textures/components/compressed-texture.js
+++ b/examples/website/textures/components/compressed-texture.js
@@ -205,7 +205,7 @@ export default class CompressedTexture extends PureComponent {
 
       switch (loader && loader.name) {
         case 'Crunch':
-        case 'CompressedTexture':
+        case 'Texture Containers':
           this.renderEmptyTexture(gl, program);
           this.renderCompressedTexture(gl, program, result, loader.name, src);
           break;

--- a/modules/textures/src/compressed-texture-loader.js
+++ b/modules/textures/src/compressed-texture-loader.js
@@ -1,10 +1,7 @@
 /** @typedef {import('@loaders.gl/loader-utils').LoaderObject} LoaderObject */
 /** @typedef {import('@loaders.gl/loader-utils').WorkerLoaderObject} WorkerLoaderObject */
-// Uncomment this line when latest version will be updated to '3.0.0-alpha.5'
-// import {VERSION} from './lib/utils/version';
+import {VERSION} from './lib/utils/version';
 import {parseCompressedTexture} from './lib/parsers/parse-compressed-texture';
-
-const VERSION = '3.0.0-alpha.5';
 
 /**
  * Worker Loader for KTX, DDS, and PVR texture container formats

--- a/modules/textures/src/crunch-loader.js
+++ b/modules/textures/src/crunch-loader.js
@@ -1,9 +1,6 @@
 /** @typedef {import('@loaders.gl/loader-utils').LoaderObject} LoaderObject */
 /** @typedef {import('@loaders.gl/loader-utils').WorkerLoaderObject} WorkerLoaderObject */
-// Uncomment this line when latest version will be updated to '3.0.0-alpha.5'
-// import {VERSION} from './lib/utils/version';
-
-const VERSION = '3.0.0-alpha.5';
+import {VERSION} from './lib/utils/version';
 
 /**
  * Worker loader for the Crunch compressed texture container format
@@ -12,7 +9,7 @@ const VERSION = '3.0.0-alpha.5';
 export const CrunchWorkerLoader = {
   id: 'crunch',
   name: 'Crunch',
-  module: 'crunch',
+  module: 'textures',
   version: VERSION,
   worker: true,
   extensions: ['crn'],

--- a/modules/textures/src/lib/utils/version.js
+++ b/modules/textures/src/lib/utils/version.js
@@ -1,4 +1,5 @@
 // Version constant cannot be imported, it needs to correspond to the build version of **this** module.
 // __VERSION__ is injected by babel-plugin-version-inline
+// TODO: use 'latest' instead of 'beta' when 3.0.0 version is released as 'latest'
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
-export const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+export const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'beta';

--- a/modules/worker-utils/src/lib/worker-api/worker-object-utils.js
+++ b/modules/worker-utils/src/lib/worker-api/worker-object-utils.js
@@ -1,9 +1,11 @@
 /** @typedef {import('../../types').WorkerObject} WorkerObject */
 import assert from '../env-utils/assert';
 
+const NPM_TAG = 'beta'; // Change to 'latest' on release-branch
+
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
-const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : NPM_TAG;
 
 export function getWorkerObjectURL(worker, options) {
   const topOptions = options || {};
@@ -18,11 +20,16 @@ export function getWorkerObjectURL(worker, options) {
     url = `modules/${worker.module}/dist/${workerFile}`;
   }
 
-  // If url not provided, load from CDN
+  // If url override is not provided, generate a URL to published version on npm CDN unpkg.com
   if (!url) {
     // GENERATE
-    const version = worker.version ? `@${worker.version}` : '';
-    url = `https://unpkg.com/@loaders.gl/${worker.module}${version}/dist/${workerFile}`;
+    let version = worker.version;
+    // On master we need to load npm alpha releases published with the `beta` tag
+    if (version === 'latest') {
+      version = NPM_TAG;
+    }
+    const versionTag = version ? `@${version}` : '';
+    url = `https://unpkg.com/@loaders.gl/${worker.module}${versionTag}/dist/${workerFile}`;
   }
 
   assert(url);

--- a/website/gatsby-config.js
+++ b/website/gatsby-config.js
@@ -117,7 +117,7 @@ module.exports = {
             title: 'I3S Loader',
             category: "Loaders",
             image: 'images/example-i3s.jpg',
-            componentUrl: resolve(__dirname, '../examples/website/i3s/app.js'),
+            componentUrl: resolve(__dirname, '../examples/experimental/i3s-picking/app.js'),
             path: 'examples/i3s'
           },
           {


### PR DESCRIPTION
I run it locally. On San Francisco 1.6 works good. On 1.7 SF and NY we have a draco lib error. Looks like something related to npm versions.

`7398244c-4112-4da5-bff8-dcc5b9c58f54:4 DOMException: Failed to execute 'importScripts' on 'WorkerGlobalScope': The script at 'https://unpkg.com/@loaders.gl/draco@latest/dist/draco-worker.js' failed to load` 