### PR TITLE
Fixes for warnings regarding unresolved options and further separate i3s/3d-tiles options

### DIFF
--- a/modules/3d-tiles/src/tiles-3d-loader.js
+++ b/modules/3d-tiles/src/tiles-3d-loader.js
@@ -24,8 +24,6 @@ export const Tiles3DLoader = {
       loadGLTF: true,
       decodeQuantizedPositions: false,
       isTileset: 'auto',
-      tile: null,
-      tileset: null,
       assetGltfUpAxis: null
     }
   }

--- a/modules/core/src/lib/loader-utils/option-utils.js
+++ b/modules/core/src/lib/loader-utils/option-utils.js
@@ -7,7 +7,9 @@ const DEFAULT_LOADER_OPTIONS = {
   // baseUri
   fetch: null,
   CDN: 'https://unpkg.com/@loaders.gl',
-  worker: true, // By default, use worker if provided by loader
+  worker: true, // By default, use worker if provided by loader.
+  maxConcurrency: 3, // How many worker instances should be created for each loader.
+  maxMobileConcurrency: 1, // How many worker instances should be created for each loader on mobile devices.
   log: new ConsoleLog(), // A probe.gl compatible (`log.log()()` syntax) that just logs to console
   metadata: false, // TODO - currently only implemented for parseInBatches, adds initial metadata batch,
   transforms: [],
@@ -149,7 +151,7 @@ function validateOptionsObject(options, id, log, defaultOptions, deprecatedOptio
   for (const key in options) {
     // If top level option value is an object it could options for a loader, so ignore
     const isSubOptions = !id && isObject(options[key]);
-    if (!(key in defaultOptions)) {
+    if (!(key in defaultOptions) && !(key === 'baseUri' && !id)) {
       // Issue deprecation warnings
       if (key in deprecatedOptions) {
         log.warn(

--- a/modules/gltf/src/gltf-loader.js
+++ b/modules/gltf/src/gltf-loader.js
@@ -29,7 +29,6 @@ export const GLTFLoader = {
     },
 
     // common?
-    uri: '', // base URI
     log: console // eslint-disable-line
   },
   deprecatedOptions: {

--- a/modules/tiles/src/tileset/tile-3d.js
+++ b/modules/tiles/src/tileset/tile-3d.js
@@ -208,10 +208,7 @@ export default class TileHeader {
       const options = {
         ...fetchOptions,
         [loader.id]: {
-          tile: this.header,
-          tileset: this.tileset.tileset,
           isTileset: this.type === 'json',
-          isTileHeader: false,
           ...this._getLoaderSpecificOptions(loader.id)
         }
       };
@@ -536,7 +533,12 @@ export default class TileHeader {
   _getLoaderSpecificOptions(loaderId) {
     switch (loaderId) {
       case 'i3s':
-        return this.tileset.options.i3s || {};
+        return {
+          ...this.tileset.options.i3s,
+          tile: this.header,
+          tileset: this.tileset.tileset,
+          isTileHeader: false
+        };
       case '3d-tiles':
       case 'cesium-ion':
       default:


### PR DESCRIPTION
Hi!
When working with 3d-tiles my console was flooded with a variety of unresolved options. This PR fixes the following warnings:

1. `maxConcurrency`, `maxMobileConcurrency`: I was using those top level options, as specified also in the [docs](https://github.com/visgl/loaders.gl/blob/master/modules/core/docs/api-reference/parse.md), but they were generating warnings. I added them to `DEFAULT_LOADER_OPTIONS`. 
2. `baseUri`: It was generating warnings in the nested `GLTFLoader`. The `option-utils` logic adds `baseUri` if it is not present, but warns when it is. The simplest way I could avoid this without refactoring the logic was to add a specific condition to not warn about a top level `baseUri`.
3. `uri`: It is added to the top level by the `GLTFLoader` but gets warned as deprecated. I found I was able to just remove it from there and all the tests and my use-cases passed.
4. `isTileHeader`: Was added by `tile-3d.js` but not recognized by`Tiles3DLoader`. That options seems to be specific to `i3s` so I moved it to the `_getLoaderSpecificOptions` function. At the same time I also checked and it seems like `Tiles3DLoader` has no use for the `tileset` and `tile` options, so I moved those to `i3s` as well.

Thank you and let me know you comments!

/Avner