### PR TITLE
I3s Picking improve attributes panel

### DIFF
--- a/examples/experimental/i3s-picking/app.js
+++ b/examples/experimental/i3s-picking/app.js
@@ -168,7 +168,6 @@ export default class App extends PureComponent {
         onTilesetLoad: this._onTilesetLoad.bind(this),
         onTileLoad: () => this._updateStatWidgets(),
         onTileUnload: () => this._updateStatWidgets(),
-        onClick: info => this.handleShowAttributesPanel(info),
         pickable: true,
         autoHighlight: true,
         loadOptions
@@ -176,7 +175,12 @@ export default class App extends PureComponent {
     ];
   }
 
-  handleShowAttributesPanel(info) {
+  handleClick(info) {
+    if (!info.object || info.index < 0 || !info.layer) {
+      this.setState({selectedFeatureAttributes: null});
+      return;
+    }
+
     const selectedFeatureAttributes = info.layer.getSelectedFeatureAttributes(
       info.object,
       info.index
@@ -256,6 +260,17 @@ export default class App extends PureComponent {
     this.setState({selectedFeatureAttributes: null});
   }
 
+  renderAttributesPanel() {
+    const {selectedFeatureAttributes} = this.state;
+
+    return (
+      <AttributesPanel
+        handleClosePanel={this.handleClosePanel}
+        attributesObject={selectedFeatureAttributes}
+      />
+    );
+  }
+
   render() {
     const layers = this._renderLayers();
     const {viewState, selectedMapStyle, selectedFeatureAttributes} = this.state;
@@ -263,7 +278,7 @@ export default class App extends PureComponent {
     return (
       <div style={{position: 'relative', height: '100%'}}>
         {this._renderStats()}
-        {this._renderControlPanel()}
+        {selectedFeatureAttributes ? this.renderAttributesPanel() : this._renderControlPanel()}
         <DeckGL
           layers={layers}
           viewState={viewState}
@@ -271,15 +286,10 @@ export default class App extends PureComponent {
           controller={{type: MapController, maxPitch: 85}}
           onAfterRender={() => this._updateStatWidgets()}
           getTooltip={info => this.getTooltip(info)}
+          onClick={info => this.handleClick(info)}
         >
           <StaticMap mapStyle={selectedMapStyle} preventStyleDiffing />
         </DeckGL>
-        {selectedFeatureAttributes && (
-          <AttributesPanel
-            handleClosePanel={this.handleClosePanel}
-            attributesObject={selectedFeatureAttributes}
-          />
-        )}
       </div>
     );
   }

--- a/examples/experimental/i3s-picking/components/attributes-panel.js
+++ b/examples/experimental/i3s-picking/components/attributes-panel.js
@@ -6,11 +6,13 @@ const CONTAINER_STYLE = {
   position: 'absolute',
   backgroundColor: 'white',
   flexFlow: 'column',
-  top: '150px',
-  right: '20px',
+  top: 0,
+  right: 0,
   width: '300px',
   padding: '12px 18px',
-  maxHeight: '50%'
+  maxHeight: '80%',
+  margin: '20px',
+  zIndex: 1000
 };
 
 const STYLED_TH = {
@@ -30,6 +32,22 @@ const TABLE_WRAPPER_STYLE = {
   overflowY: 'auto'
 };
 
+const HEADER_STYLE = {
+  display: 'flex',
+  flexFlow: 'row nowrap',
+  justifyContent: 'space-between',
+  alignItems: 'center'
+};
+
+const CLOSE_BUTTON_STYLE = {
+  height: '30px',
+  color: '#6e6e6e',
+  border: 'none',
+  cursor: 'pointer',
+  outline: 'none',
+  fontSize: '19px'
+};
+
 const propTypes = {
   attributesObject: PropTypes.object,
   attributesHeader: PropTypes.string,
@@ -41,20 +59,21 @@ const defaultProps = {
   attributesHeader: 'NAME',
   handleClosePanel: () => {}
 };
+
+const NO_DATA = 'No Data';
 export default class AttributesPanel extends PureComponent {
   prepareTable() {
-    const {attributesObject, attributesHeader} = this.props;
+    const {attributesObject} = this.props;
     const tableColumns = [];
 
     for (const key in attributesObject) {
-      const value = attributesObject[key];
+      const value = this.formatValue(attributesObject[key]);
       const column = this.createTableColumn(key, value);
       tableColumns.push(column);
     }
 
     return (
       <div style={TABLE_WRAPPER_STYLE}>
-        <h2>{attributesObject[attributesHeader]}</h2>
         <table>
           <tbody>{tableColumns}</tbody>
         </table>
@@ -71,11 +90,27 @@ export default class AttributesPanel extends PureComponent {
     );
   }
 
+  formatValue(value) {
+    return (
+      value
+        .toString()
+        .replace(/[{}']+/g, '')
+        .trim() || NO_DATA
+    );
+  }
+
   render() {
-    const {attributesObject, handleClosePanel} = this.props;
+    const {attributesObject, handleClosePanel, attributesHeader} = this.props;
+
     return (
       <div style={CONTAINER_STYLE}>
-        {attributesObject && this.prepareTable()} <button onClick={handleClosePanel}>Close</button>
+        <div style={HEADER_STYLE}>
+          <h2>{attributesObject[attributesHeader]}</h2>
+          <button style={CLOSE_BUTTON_STYLE} onClick={handleClosePanel}>
+            X
+          </button>
+        </div>
+        {attributesObject && this.prepareTable()}
       </div>
     );
   }


### PR DESCRIPTION
- Added close button at the top of the attributes panel
- Replace Control panel with attributes panel if any building is selected
- Replace empty value with 'No Data' string.
- Close attributes panel if user clicked outside of buildings

![Screenshot from 2021-03-02 13-44-26](https://user-images.githubusercontent.com/70207219/109637144-716bd780-7b5d-11eb-970f-38b07f43b676.png)
