### PR TITLE
I3S picking - Select building using only onclick event

### DIFF
--- a/examples/experimental/i3s-picking/app.js
+++ b/examples/experimental/i3s-picking/app.js
@@ -77,7 +77,8 @@ export default class App extends PureComponent {
       name: INITIAL_EXAMPLE_NAME,
       viewState: INITIAL_VIEW_STATE,
       selectedMapStyle: INITIAL_MAP_STYLE,
-      selectedFeatureAttributes: null
+      selectedFeatureAttributes: null,
+      selectedFeatureIndex: -1
     };
     this._onSelectTileset = this._onSelectTileset.bind(this);
     this.handleClosePanel = this.handleClosePanel.bind(this);
@@ -155,7 +156,7 @@ export default class App extends PureComponent {
   }
 
   _renderLayers() {
-    const {tilesetUrl, token} = this.state;
+    const {tilesetUrl, token, selectedFeatureIndex} = this.state;
     // TODO: support compressed textures in GLTFMaterialParser
     const loadOptions = {throttleRequests: true, loadFeatureAttributes: true};
     if (token) {
@@ -169,15 +170,15 @@ export default class App extends PureComponent {
         onTileLoad: () => this._updateStatWidgets(),
         onTileUnload: () => this._updateStatWidgets(),
         pickable: true,
-        autoHighlight: true,
-        loadOptions
+        loadOptions,
+        highlightedObjectIndex: selectedFeatureIndex
       })
     ];
   }
 
   handleClick(info) {
     if (!info.object || info.index < 0 || !info.layer) {
-      this.setState({selectedFeatureAttributes: null});
+      this.handleClosePanel();
       return;
     }
 
@@ -185,7 +186,7 @@ export default class App extends PureComponent {
       info.object,
       info.index
     );
-    this.setState({selectedFeatureAttributes});
+    this.setState({selectedFeatureAttributes, selectedFeatureIndex: info.index});
   }
 
   _renderStats() {
@@ -257,7 +258,7 @@ export default class App extends PureComponent {
   }
 
   handleClosePanel() {
-    this.setState({selectedFeatureAttributes: null});
+    this.setState({selectedFeatureAttributes: null, selectedFeatureIndex: -1});
   }
 
   renderAttributesPanel() {


### PR DESCRIPTION
- Enabled picking color only when user click on object (building).
- After this changes we get an issue in `I3S v1.7` picking functionality:

In` I3s v1.6 `vesrion we are using `featureIds` which were created by using `id` and `faceRange` data of particular tile.
This `featureIds` represents `OBJECTID` values from `attributeStorageInfo` and they are all unique across all tiles.
So when we encode such `featureIds` to `pickingColors` we have unique color for each building across all tiles on the map.

In `I3S v1.7` version `featureIds` from compressed geometry are like feature indices for every attribute in `attributeStorageInfo`. We can find particular building attributes using `featureId` as index in `attributeStorageInfo` object. So such `featureIds` are not unique across all tiles in tileset. It only unique across only one tile. When we encode such `featureIds` as indices to `pickingColors` we don't have a unique color for each building across all tiles on the map.

The problem is when we want to select only one building on the map in `i3s v1.7`  we can see that all objects which has the same `featureId` are selected.

@ibgreen Upd: [pull request](https://github.com/visgl/loaders.gl/pull/1236) to fix that ^^^

![Screenshot from 2021-03-02 15-56-32](https://user-images.githubusercontent.com/70207219/109651667-e21bef80-7b6f-11eb-8d4a-14cd4290f7c8.png)
