### PR TITLE
I3S-picking - change attribute parsing logic

### DIFF
--- a/modules/i3s/src/lib/parsers/parse-i3s-attribute.js
+++ b/modules/i3s/src/lib/parsers/parse-i3s-attribute.js
@@ -9,11 +9,12 @@ import {STRING_ATTRIBUTE_TYPE, OBJECT_ID_ATTRIBUTE_TYPE, FLOAT_64_TYPE} from './
  */
 export async function parseI3STileAttribute(arrayBuffer, options) {
   const {attributeName, attributeType} = options;
-  if (!attributeName || !attributeType) {
+
+  if (!attributeName) {
     return {};
   }
   return {
-    [attributeName]: parseAttribute(attributeType, arrayBuffer)
+    [attributeName]: attributeType ? parseAttribute(attributeType, arrayBuffer) : null
   };
 }
 

--- a/modules/i3s/test/i3s-attribute-loader.spec.js
+++ b/modules/i3s/test/i3s-attribute-loader.spec.js
@@ -26,7 +26,7 @@ test('I3SAttributeLoader# should return empty object if no attributeType provide
   };
   const attributes = await load(objectIdsUrl, I3SAttributeLoader, options);
   t.ok(attributes);
-  t.deepEqual(attributes, {});
+  t.deepEqual(attributes, {OBJECTID: null});
   t.end();
 });
 


### PR DESCRIPTION
Sometimes in tileset in `attributeStorageinfo` one of attributes has no` attributeValues.valueType `data. We should anyway load such case just without any data.
For example we have such situation in[ New York](https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/NYC_Attributed_v17/SceneServer/layers/0) tilleset.

But if we are looking to [spec](https://github.com/Esri/i3s-spec/blob/master/docs/1.7/value.cmn.md) we should have such value.