### PR TITLE
I3s-picking - fix feature-index parsing in compressed geometry

### DIFF
--- a/modules/i3s/src/lib/parsers/parse-i3s-tile-content.js
+++ b/modules/i3s/src/lib/parsers/parse-i3s-tile-content.js
@@ -27,6 +27,8 @@ const FORMAT_LOADER_MAP = {
   dds: CompressedTextureLoader
 };
 
+const I3S_ATTRIBUTE_TYPE = 'i3s-attribute-type';
+
 export async function parseI3STileContent(arrayBuffer, tile, tileset, options) {
   tile.content = tile.content || {};
 
@@ -69,8 +71,14 @@ async function parseI3SNodeGeometry(arrayBuffer, tile = {}, options) {
   let vertexCount;
   let byteOffset = 0;
   let featureCount = 0;
+
   if (tile.isDracoGeometry) {
-    const decompressedGeometry = await parse(arrayBuffer, DracoLoader);
+    const decompressedGeometry = await parse(arrayBuffer, DracoLoader, {
+      parseOptions: {
+        attributeNameEntry: I3S_ATTRIBUTE_TYPE
+      }
+    });
+
     vertexCount = decompressedGeometry.header.vertexCount;
     const indices = decompressedGeometry.indices.value;
     const {
@@ -78,17 +86,20 @@ async function parseI3SNodeGeometry(arrayBuffer, tile = {}, options) {
       NORMAL,
       COLOR_0,
       TEXCOORD_0,
-      CUSTOM_ATTRIBUTE_3
+      ['feature-index']: featureIndex
     } = decompressedGeometry.attributes;
+
     attributes = {
       position: flattenAttribute(POSITION, indices),
       normal: flattenAttribute(NORMAL, indices),
       color: flattenAttribute(COLOR_0, indices),
       uv0: flattenAttribute(TEXCOORD_0, indices),
-      id: flattenAttribute(CUSTOM_ATTRIBUTE_3, indices)
+      id: flattenAttribute(featureIndex, indices)
     };
 
-    flattenFeatureIdsByFeatureIndices(attributes, tile);
+    if (featureIndex) {
+      flattenFeatureIdsByFeatureIndices(attributes, tile);
+    }
   } else {
     const {
       vertexAttributes,


### PR DESCRIPTION
We should avoid using `CUSTOM_ATTRIBUTES_1`,` CUSTOM_ATTRIBUTES_2` etc by passing parse options to `DracoLoader`