### PR TITLE
Fix lint causing CI to fail

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -13,3 +13,4 @@ public/
 .cache/
 
 modules/potree/test/data/**/cloud.js
+examples/experimental/gltf-with-raw-webgl/

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,5 +8,4 @@ node_modules/
 public
 
 modules/potree/test/data/**/cloud.js
-
-
+examples/experimental/gltf-with-raw-webgl/


### PR DESCRIPTION
As noted [here](https://github.com/visgl/loaders.gl/pull/1235#issuecomment-789600863), merging https://github.com/visgl/loaders.gl/pull/1225 caused CI on master to fail. This PR adds that example directory to `.eslintignore` and `.prettierignore`.