### PR TITLE
I3S - Tile coloring in debug application

### DIFF
--- a/examples/experimental/i3s-17-and-debug/app-debug.js
+++ b/examples/experimental/i3s-17-and-debug/app-debug.js
@@ -14,7 +14,7 @@ import {StatsWidget} from '@probe.gl/stats-widget';
 import {INITIAL_EXAMPLE_NAME, EXAMPLES} from './examples';
 import ControlPanel from './components/control-panel';
 
-import {INITIAL_MAP_STYLE} from './constants';
+import {INITIAL_MAP_STYLE, INITIAL_COLORING_MODE} from './constants';
 import {getFrustumBounds} from './frustum-utils';
 import TileLayer from './tile-layer/tile-layer';
 
@@ -103,6 +103,7 @@ export default class App extends PureComponent {
           bearing: 0
         }
       },
+      selectedColoringMode: INITIAL_COLORING_MODE,
       selectedMapStyle: INITIAL_MAP_STYLE
     };
     this._onSelectTileset = this._onSelectTileset.bind(this);
@@ -205,8 +206,12 @@ export default class App extends PureComponent {
     this.setState({selectedMapStyle});
   }
 
+  _onSelectColoringMode({selectedColoringMode}) {
+    this.setState({selectedColoringMode});
+  }
+
   _renderLayers() {
-    const {tilesetUrl, token, viewState} = this.state;
+    const {tilesetUrl, token, viewState, selectedColoringMode} = this.state;
     const loadOptions = {throttleRequests: true, loadFeatureAttributes: false};
     if (token) {
       loadOptions.token = token;
@@ -222,6 +227,7 @@ export default class App extends PureComponent {
         onTilesetLoad: this._onTilesetLoad.bind(this),
         onTileLoad: () => this._updateStatWidgets(),
         onTileUnload: () => this._updateStatWidgets(),
+        coloredBy: selectedColoringMode,
         loadOptions
       }),
       new LineLayer({
@@ -241,7 +247,7 @@ export default class App extends PureComponent {
   }
 
   _renderControlPanel() {
-    const {name, tileset, token, metadata, selectedMapStyle} = this.state;
+    const {name, tileset, token, metadata, selectedMapStyle, selectedColoringMode} = this.state;
     return (
       <ControlPanel
         tileset={tileset}
@@ -250,7 +256,9 @@ export default class App extends PureComponent {
         token={token}
         onExampleChange={this._onSelectTileset}
         onMapStyleChange={this._onSelectMapStyle.bind(this)}
+        onColoringModeChange={this._onSelectColoringMode.bind(this)}
         selectedMapStyle={selectedMapStyle}
+        selectedColoringMode={selectedColoringMode}
       />
     );
   }

--- a/examples/experimental/i3s-17-and-debug/coloring-utils.js
+++ b/examples/experimental/i3s-17-and-debug/coloring-utils.js
@@ -1,0 +1,52 @@
+export const COLORED_BY = {
+  ORIGINAL: 0,
+  TILE: 1,
+  DEPTH: 2,
+  CUSTOM: 3
+};
+
+export const DEPTH_COLOR_MAP = {
+  1: [197, 78, 90],
+  2: [197, 108, 78],
+  3: [198, 139, 77],
+  4: [199, 170, 75],
+  5: [188, 195, 69],
+  6: [131, 202, 74],
+  7: [85, 194, 69],
+  8: [73, 188, 115],
+  9: [70, 174, 172],
+  10: [68, 118, 182],
+  11: [97, 74, 183],
+  12: [125, 58, 174]
+};
+
+export const DEPTH_MAX_LEVEL = 12;
+
+export function getTileColor(tile, options) {
+  switch (options.coloredBy) {
+    case COLORED_BY.TILE:
+      return getColorByTile(tile.id, options.colorsMap);
+    case COLORED_BY.DEPTH:
+      return getColorByDepth(tile.depth);
+    case COLORED_BY.CUSTOM:
+      return getCustomColor();
+    default:
+      return [255, 255, 255];
+  }
+}
+
+function getColorByDepth(level) {
+  return DEPTH_COLOR_MAP[level] || DEPTH_COLOR_MAP[DEPTH_MAX_LEVEL];
+}
+
+function getCustomColor() {
+  // TODO: implement after tile-selecting feature
+  return [255, 255, 255];
+}
+
+function getColorByTile(id, colorsMap) {
+  const randomColor = Array.from({length: 3}, _ => Math.round(Math.random() * 255));
+
+  colorsMap[id] = colorsMap[id] || randomColor;
+  return colorsMap[id];
+}

--- a/examples/experimental/i3s-17-and-debug/components/control-panel.js
+++ b/examples/experimental/i3s-17-and-debug/components/control-panel.js
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {EXAMPLES} from '../examples';
-import {MAP_STYLES} from '../constants';
+import {MAP_STYLES, MAP_COLORING_MODES} from '../constants';
 
 const Container = styled.div`
   display: flex;
@@ -63,17 +63,21 @@ const propTypes = {
   name: PropTypes.string,
   tileset: PropTypes.object,
   mapStyles: PropTypes.object,
+  coloringModes: PropTypes.object,
   metadata: PropTypes.object,
   token: PropTypes.string,
   onExampleChange: PropTypes.func,
   children: PropTypes.node,
   selectedMapStyle: PropTypes.string,
-  onMapStyleChange: PropTypes.func
+  onMapStyleChange: PropTypes.func,
+  selectedColoringMode: PropTypes.number,
+  onColoringModeChange: PropTypes.func
 };
 
 const defaultProps = {
   droppedFile: null,
-  onChange: () => {}
+  onChange: () => {},
+  onColoringModeChange: () => {}
 };
 const CUSTOM_EXAMPLE = 'Custom example';
 
@@ -81,6 +85,7 @@ export default class ControlPanel extends PureComponent {
   constructor(props) {
     super(props);
     this._renderMapStyles = this._renderMapStyles.bind(this);
+    this._renderColoringModes = this._renderColoringModes.bind(this);
     this.state = {
       showFullInfo: false
     };
@@ -137,6 +142,31 @@ export default class ControlPanel extends PureComponent {
     );
   }
 
+  _renderColoringModes() {
+    const {
+      coloringModes = MAP_COLORING_MODES,
+      selectedColoringMode,
+      onColoringModeChange
+    } = this.props;
+    return (
+      <DropDown
+        value={selectedColoringMode}
+        onChange={evt => {
+          const selected = evt.target.value;
+          onColoringModeChange({selectedColoringMode: parseInt(selected, 10)});
+        }}
+      >
+        {Object.keys(coloringModes).map(key => {
+          return (
+            <option key={key} value={coloringModes[key]}>
+              {key}
+            </option>
+          );
+        })}
+      </DropDown>
+    );
+  }
+
   _renderInfo() {
     const {metadata, token} = this.props;
     const {showFullInfo} = this.state;
@@ -178,6 +208,7 @@ export default class ControlPanel extends PureComponent {
       <Container>
         {this._renderExamples()}
         {this._renderMapStyles()}
+        {this._renderColoringModes()}
         {this._renderInfo()}
         {this.props.children}
       </Container>

--- a/examples/experimental/i3s-17-and-debug/components/control-panel.js
+++ b/examples/experimental/i3s-17-and-debug/components/control-panel.js
@@ -76,8 +76,7 @@ const propTypes = {
 
 const defaultProps = {
   droppedFile: null,
-  onChange: () => {},
-  onColoringModeChange: () => {}
+  onChange: () => {}
 };
 const CUSTOM_EXAMPLE = 'Custom example';
 
@@ -148,6 +147,9 @@ export default class ControlPanel extends PureComponent {
       selectedColoringMode,
       onColoringModeChange
     } = this.props;
+    if (!onColoringModeChange) {
+      return null;
+    }
     return (
       <DropDown
         value={selectedColoringMode}

--- a/examples/experimental/i3s-17-and-debug/constants.js
+++ b/examples/experimental/i3s-17-and-debug/constants.js
@@ -1,4 +1,4 @@
-import {COLORED_BY} from './tile-layer/tile-layer';
+import {COLORED_BY} from './coloring-utils';
 
 export const MAP_STYLES = {
   'Base Map: Satellite': 'https://basemaps.cartocdn.com/gl/voyager-nolabels-gl-style/style.json',

--- a/examples/experimental/i3s-17-and-debug/constants.js
+++ b/examples/experimental/i3s-17-and-debug/constants.js
@@ -1,3 +1,5 @@
+import {COLORED_BY} from './tile-layer/tile-layer';
+
 export const MAP_STYLES = {
   'Base Map: Satellite': 'https://basemaps.cartocdn.com/gl/voyager-nolabels-gl-style/style.json',
   'Base Map: Light': 'https://basemaps.cartocdn.com/gl/positron-nolabels-gl-style/style.json',
@@ -5,3 +7,13 @@ export const MAP_STYLES = {
 };
 
 export const INITIAL_MAP_STYLE = MAP_STYLES['Base Map: Dark'];
+
+export const MAP_COLORING_MODES = {
+  'Tile coloring: Original': COLORED_BY.ORIGINAL,
+  'Tile coloring: By tile': COLORED_BY.TILE,
+  'Tile coloring: By depth': COLORED_BY.DEPTH
+  // TODO: implement after tile-selecting feature
+  // 'Tile coloring: Custom (by selected object)': COLORED_BY.CUSTOM,
+};
+
+export const INITIAL_COLORING_MODE = COLORED_BY.TILE;

--- a/examples/experimental/i3s-17-and-debug/tile-layer/tile-layer.js
+++ b/examples/experimental/i3s-17-and-debug/tile-layer/tile-layer.js
@@ -2,15 +2,84 @@ import GL from '@luma.gl/constants';
 import {Geometry} from '@luma.gl/core';
 import {COORDINATE_SYSTEM} from '@deck.gl/core';
 import {Tile3DLayer} from '@deck.gl/geo-layers';
+import {log} from '@deck.gl/core';
 import MeshLayer from '../mesh-layer/mesh-layer';
 
 const SINGLE_DATA = [0];
+
+export const COLORED_BY = {
+  ORIGINAL: 0,
+  TILE: 1,
+  DEPTH: 2,
+  CUSTOM: 3
+};
+
+export const DEPTH_COLOR_MAP = {
+  1: [197, 78, 90],
+  2: [197, 108, 78],
+  3: [198, 139, 77],
+  4: [199, 170, 75],
+  5: [188, 195, 69],
+  6: [131, 202, 74],
+  7: [85, 194, 69],
+  8: [73, 188, 115],
+  9: [70, 174, 172],
+  10: [68, 118, 182],
+  11: [97, 74, 183],
+  12: [125, 58, 174]
+};
+
+export const DEPTH_MAX_LEVEL = 12;
+
 // Use our custom MeshLayer
 export default class TileLayer extends Tile3DLayer {
+  initializeState() {
+    if ('onTileLoadFail' in this.props) {
+      log.removed('onTileLoadFail', 'onTileError')();
+    }
+
+    this.state = {
+      layerMap: {},
+      colorsMap: {},
+      tileset3d: null
+    };
+  }
+
+  _fetchColorByDepth(level) {
+    return DEPTH_COLOR_MAP[level] || DEPTH_COLOR_MAP[DEPTH_MAX_LEVEL];
+  }
+
+  _fetchCustomColor(id) {
+    // TODO: implement after tile-selecting feature
+    return [255, 255, 255];
+  }
+
+  _fetchColorByTile(id) {
+    const {colorsMap} = this.state;
+    const randomColor = Array.from({length: 3}, _ => Math.round(Math.random() * 255));
+
+    colorsMap[id] = colorsMap[id] || randomColor;
+    return colorsMap[id];
+  }
+
+  _fetchColor(coloredBy, tile) {
+    switch (coloredBy) {
+      case COLORED_BY.TILE:
+        return this._fetchColorByTile(tile.id);
+      case COLORED_BY.DEPTH:
+        return this._fetchColorByDepth(tile.depth);
+      case COLORED_BY.CUSTOM:
+        return this._fetchCustomColor(tile.id);
+      default:
+        throw new Error("TileColoredLayer: coloredBy property can't be ".concat(coloredBy));
+    }
+  }
+
   _makeSimpleMeshLayer(tileHeader, oldLayer) {
     const content = tileHeader.content;
     const {attributes, modelMatrix, cartographicOrigin, texture, material} = content;
-    const {pickable, autoHighlight} = this.props;
+    const {pickable, autoHighlight, coloredBy} = this.props;
+    const getColor = coloredBy ? this._fetchColor(coloredBy, tileHeader) : [255, 255, 255];
 
     const geometry =
       (oldLayer && oldLayer.props.mesh) ||
@@ -28,7 +97,7 @@ export default class TileLayer extends Tile3DLayer {
         mesh: geometry,
         data: SINGLE_DATA,
         getPosition: [0, 0, 0],
-        getColor: [255, 255, 255],
+        getColor,
         texture,
         material,
         modelMatrix,

--- a/examples/experimental/i3s-17-and-debug/tile-layer/tile-layer.js
+++ b/examples/experimental/i3s-17-and-debug/tile-layer/tile-layer.js
@@ -4,32 +4,9 @@ import {COORDINATE_SYSTEM} from '@deck.gl/core';
 import {Tile3DLayer} from '@deck.gl/geo-layers';
 import {log} from '@deck.gl/core';
 import MeshLayer from '../mesh-layer/mesh-layer';
+import {getTileColor} from '../coloring-utils';
 
 const SINGLE_DATA = [0];
-
-export const COLORED_BY = {
-  ORIGINAL: 0,
-  TILE: 1,
-  DEPTH: 2,
-  CUSTOM: 3
-};
-
-export const DEPTH_COLOR_MAP = {
-  1: [197, 78, 90],
-  2: [197, 108, 78],
-  3: [198, 139, 77],
-  4: [199, 170, 75],
-  5: [188, 195, 69],
-  6: [131, 202, 74],
-  7: [85, 194, 69],
-  8: [73, 188, 115],
-  9: [70, 174, 172],
-  10: [68, 118, 182],
-  11: [97, 74, 183],
-  12: [125, 58, 174]
-};
-
-export const DEPTH_MAX_LEVEL = 12;
 
 // Use our custom MeshLayer
 export default class TileLayer extends Tile3DLayer {
@@ -45,41 +22,11 @@ export default class TileLayer extends Tile3DLayer {
     };
   }
 
-  _fetchColorByDepth(level) {
-    return DEPTH_COLOR_MAP[level] || DEPTH_COLOR_MAP[DEPTH_MAX_LEVEL];
-  }
-
-  _fetchCustomColor(id) {
-    // TODO: implement after tile-selecting feature
-    return [255, 255, 255];
-  }
-
-  _fetchColorByTile(id) {
-    const {colorsMap} = this.state;
-    const randomColor = Array.from({length: 3}, _ => Math.round(Math.random() * 255));
-
-    colorsMap[id] = colorsMap[id] || randomColor;
-    return colorsMap[id];
-  }
-
-  _fetchColor(coloredBy, tile) {
-    switch (coloredBy) {
-      case COLORED_BY.TILE:
-        return this._fetchColorByTile(tile.id);
-      case COLORED_BY.DEPTH:
-        return this._fetchColorByDepth(tile.depth);
-      case COLORED_BY.CUSTOM:
-        return this._fetchCustomColor(tile.id);
-      default:
-        throw new Error("TileColoredLayer: coloredBy property can't be ".concat(coloredBy));
-    }
-  }
-
   _makeSimpleMeshLayer(tileHeader, oldLayer) {
     const content = tileHeader.content;
     const {attributes, modelMatrix, cartographicOrigin, texture, material} = content;
     const {pickable, autoHighlight, coloredBy} = this.props;
-    const getColor = coloredBy ? this._fetchColor(coloredBy, tileHeader) : [255, 255, 255];
+    const {colorsMap} = this.state;
 
     const geometry =
       (oldLayer && oldLayer.props.mesh) ||
@@ -97,7 +44,7 @@ export default class TileLayer extends Tile3DLayer {
         mesh: geometry,
         data: SINGLE_DATA,
         getPosition: [0, 0, 0],
-        getColor,
+        getColor: getTileColor(tileHeader, {coloredBy, colorsMap}),
         texture,
         material,
         modelMatrix,

--- a/modules/tiles/src/tileset/tile-3d.js
+++ b/modules/tiles/src/tileset/tile-3d.js
@@ -435,7 +435,7 @@ export default class TileHeader {
 
   // TODO - remove anything not related to basic visibility detection
   _initializeRenderingState(header) {
-    this.depth = this.parent && this.parent.hasOwnProperty('depth') ? this.parent.depth + 1 : 0;
+    this.depth = header.level || this.parent?.depth + 1 || 0;
     this._shouldRefine = false;
 
     // Members this are updated every frame for tree traversal and rendering optimizations:

--- a/modules/tiles/src/tileset/tile-3d.js
+++ b/modules/tiles/src/tileset/tile-3d.js
@@ -435,7 +435,7 @@ export default class TileHeader {
 
   // TODO - remove anything not related to basic visibility detection
   _initializeRenderingState(header) {
-    this.depth = header.level;
+    this.depth = this.parent && this.parent.hasOwnProperty('depth') ? this.parent.depth + 1 : 0;
     this._shouldRefine = false;
 
     // Members this are updated every frame for tree traversal and rendering optimizations:


### PR DESCRIPTION
I added ways to recolor tiles to make them stand out for debugging.
Now user can choose:
- original colors
- coloring by tile id (random)
- coloring by depth

![by_tile](https://user-images.githubusercontent.com/5794637/110830709-8e658080-82aa-11eb-8d8a-804ffd1c980f.png)
![by_depth_1](https://user-images.githubusercontent.com/5794637/110830736-94f3f800-82aa-11eb-8a5d-8e357ff45695.png)
![by_depth_2](https://user-images.githubusercontent.com/5794637/110830757-9a514280-82aa-11eb-835a-fb36ca182c0f.png)
