### PR TITLE
i3s: support texture atlas

### DIFF
--- a/examples/experimental/i3s-17-and-debug/mesh-layer/mesh-layer.js
+++ b/examples/experimental/i3s-17-and-debug/mesh-layer/mesh-layer.js
@@ -107,12 +107,17 @@ export default class MeshLayer extends SimpleMeshLayer {
 
     const shaders = this.getShaders();
 
+    const customDefines = {};
+    if (mesh.attributes.uvRegions) {
+      customDefines.HAS_UV_REGION = 1;
+    }
+
     const model = new Model(
       this.context.gl,
       Object.assign({}, shaders, {
         id: this.props.id,
         geometry: getGeometry(mesh, true),
-        defines: {...shaders.defines, ...materialParser?.defines},
+        defines: {...shaders.defines, ...materialParser?.defines, ...customDefines},
         parameters: materialParser?.parameters,
         isInstanced: true
       })

--- a/examples/experimental/i3s-17-and-debug/mesh-layer/simple-mesh-layer-vertex.glsl.js
+++ b/examples/experimental/i3s-17-and-debug/mesh-layer/simple-mesh-layer-vertex.glsl.js
@@ -10,6 +10,7 @@ in vec3 positions;
 in vec3 normals;
 in vec3 colors;
 in vec2 texCoords;
+in vec4 uvRegions;
 in vec3 pickingColors;
 
 // Instance attributes
@@ -28,8 +29,14 @@ out vec4 position_commonspace;
 out vec4 vColor;
 
 void main(void) {
+  #ifdef HAS_UV_REGION
+    vec2 uv = fract(texCoords) * (uvRegions.zw - uvRegions.xy) + uvRegions.xy;
+  #else
+    vec2 uv = texCoords;
+  #endif
+
   geometry.worldPosition = instancePositions;
-  geometry.uv = texCoords;
+  geometry.uv = uv;
 
   #ifdef INSTANCE_PICKING_MODE
     geometry.pickingColor = instancePickingColors;
@@ -45,14 +52,14 @@ void main(void) {
     #endif
 
     #ifdef HAS_UV
-      pbr_vUV = texCoords;
+      pbr_vUV = uv;
     #else
       pbr_vUV = vec2(0., 0.);
     #endif
     geometry.uv = pbr_vUV;
   #endif
 
-  vTexCoord = texCoords;
+  vTexCoord = uv;
   cameraPosition = project_uCameraPosition;
   normals_commonspace = project_normal(instanceModelMatrix * normals);
   vColor = vec4(colors * instanceColors.rgb, instanceColors.a);

--- a/examples/experimental/i3s-17-and-debug/tile-layer/tile-layer.js
+++ b/examples/experimental/i3s-17-and-debug/tile-layer/tile-layer.js
@@ -95,6 +95,9 @@ function getMeshGeometry(contentAttributes) {
   if (contentAttributes.texCoords) {
     attributes.texCoords = contentAttributes.texCoords;
   }
+  if (contentAttributes.uvRegions) {
+    attributes.uvRegions = contentAttributes.uvRegions;
+  }
   if (contentAttributes.colors) {
     attributes.colors = contentAttributes.colors;
   }

--- a/modules/i3s/src/lib/parsers/parse-i3s-tile-content.js
+++ b/modules/i3s/src/lib/parsers/parse-i3s-tile-content.js
@@ -148,9 +148,9 @@ async function parseI3SNodeGeometry(arrayBuffer, tile = {}, options) {
   content.attributes = {
     positions: attributes.position,
     normals: attributes.normal,
-    colors: normalizeAttribute(attributes.color, 1 / 255), // Normalize from UInt8
+    colors: normalizeAttribute(attributes.color), // Normalize from UInt8
     texCoords: attributes.uv0,
-    uvRegions: normalizeAttribute(attributes.uvRegion, 1 / 65535), // Normalize from UInt16
+    uvRegions: normalizeAttribute(attributes.uvRegion), // Normalize from UInt16
     featureIds: attributes.id,
     faceRange: attributes.faceRange
   };
@@ -207,16 +207,11 @@ function flattenAttribute(attribute, indices) {
  * @param {Object} attribute - geometry attribute
  * @returns {Object} - geometry attribute in right format
  */
-function normalizeAttribute(attribute, multiplyer) {
+function normalizeAttribute(attribute) {
   if (!attribute) {
     return attribute;
   }
-  const normalizedAttribute = new Float32Array(attribute.value.length);
-  for (let index = 0; index < normalizedAttribute.length; index++) {
-    normalizedAttribute[index] = attribute.value[index] * multiplyer;
-  }
-  attribute.value = normalizedAttribute;
-  attribute.type = GL_TYPE_MAP.Float32;
+  attribute.normalized = true;
   return attribute;
 }
 


### PR DESCRIPTION
I implemented support of the texture atlas according to https://github.com/Esri/i3s-spec/blob/master/docs/1.7/geometryUVRegion.cmn.md . But it doesn't work for some reason.
![Screenshot from 2021-03-19 11-46-28](https://user-images.githubusercontent.com/18549629/111754506-21a14600-88a9-11eb-865b-e5c24ab279de.png)

This PR works for San Francisco 1.7:
![image](https://user-images.githubusercontent.com/18549629/113591474-98c23280-963c-11eb-8ff2-1e20cfb02d90.png)
![image](https://user-images.githubusercontent.com/18549629/113591524-a8417b80-963c-11eb-8c42-633a5d21c97d.png)
