### PR TITLE
i3s-debug: LOD validation

### DIFF
--- a/examples/experimental/i3s-17-and-debug/components/semantic-validator.js
+++ b/examples/experimental/i3s-17-and-debug/components/semantic-validator.js
@@ -35,6 +35,7 @@ const NO_ISSUES = 'No Issues';
 
 const WARNING_TYPES = {
   lod: 'LOD metric',
+  parentLod: 'LOD metric',
   boundingVolume: 'Bounding Volume',
   geometryVsTextures: 'Geometry vs Textures'
 };

--- a/examples/experimental/i3s-17-and-debug/constants.js
+++ b/examples/experimental/i3s-17-and-debug/constants.js
@@ -35,4 +35,5 @@ export const INITIAL_OBB_COLOR_MODE = COLORED_BY.ORIGINAL;
 
 export const BOUNDING_VOLUME_WARNING_TYPE = 'boundingVolume';
 export const LOD_WARNING_TYPE = 'lod';
+export const PARENT_LOD_WARNING_TYPE = 'parentLod';
 export const GEMETRY_VS_TEXTURE_WARNING_TYPE = 'geometryVsTextures';

--- a/examples/experimental/i3s-17-and-debug/tile-debug.js
+++ b/examples/experimental/i3s-17-and-debug/tile-debug.js
@@ -1,6 +1,6 @@
 import {OrientedBoundingBox, BoundingSphere} from '@math.gl/culling';
 import {CubeGeometry} from '@luma.gl/engine';
-import {BOUNDING_VOLUME_WARNING_TYPE, LOD_WARNING_TYPE} from './constants';
+import {BOUNDING_VOLUME_WARNING_TYPE, LOD_WARNING_TYPE, PARENT_LOD_WARNING_TYPE} from './constants';
 import {Vector3} from 'math.gl';
 import {Ellipsoid} from '@math.gl/geospatial';
 
@@ -224,16 +224,32 @@ function createBoundingBoxFromTileObb(obb) {
 
 // LOD spec https://github.com/Esri/i3s-spec/blob/master/format/LevelofDetail.md
 function checkLOD(tile, tileWarnings) {
-  const parentLod = tile.parent && tile.parent.lodMetricValue;
+  const divergence = 0.05;
+  const tileLodRatio = tile.lodMetricValue / tile.boundingVolume.radius;
+  const parentLodRatio = tile.parent.lodMetricValue / tile.parent.boundingVolume.radius;
+  const lodRatios = tile.parent.children.map(child => {
+    return child.lodMetricValue / child.boundingVolume.radius;
+  });
+  const meanRatio = lodRatios.reduce((accum, current) => accum + current, 0) / lodRatios.length;
 
-  if (!parentLod || tile.lodMetricValue > parentLod) {
-    return;
+  if (
+    meanRatio < parentLodRatio &&
+    !tileWarnings.find(
+      warning => warning.tileId === tile.parent.id && warning.type === PARENT_LOD_WARNING_TYPE
+    )
+  ) {
+    const title = `Tile (${
+      tile.parent.id
+    }) LOD/Radius ratio "${parentLodRatio}" > mean child LOD/Radius ratio "${meanRatio}"`;
+    tileWarnings.push({type: PARENT_LOD_WARNING_TYPE, title, tileId: tile.parent.id});
   }
 
-  const title = `Tile (${tile.id}) LOD = "${tile.lodMetricValue}" < Parent (${
-    tile.parent.id
-  }) tile LOD = "${tile.parent.lodMetricValue}"`;
-  tileWarnings.push({type: LOD_WARNING_TYPE, title});
+  if (Math.abs(tileLodRatio - meanRatio) > divergence) {
+    const title = `Tile (${
+      tile.id
+    }) LOD/Radius ratio "${tileLodRatio}" has large deviation from mean LOD/Radius ratio of neighbors "${meanRatio}"`;
+    tileWarnings.push({type: LOD_WARNING_TYPE, title, tileId: tile.parent.id});
+  }
 }
 
 function getTextureSize(tile) {


### PR DESCRIPTION
It validates 2 things:
1. The tile is never seen. This can occur when a child lodMetric is so small, that the tile switches to a grandchild;
2. All neighbor tiles are refined at the same moment.

I didn't find tiles with 1st error - it is more critical.
I created some pictures explaining 2nd: https://docs.google.com/document/d/1tQoNLiH0m9bmTBW20TRXGYhDqxIynKm98iiMp5KEyng/edit?usp=sharing