### PR TITLE
tile-converter: fixes issue 1313

### DIFF
--- a/modules/tile-converter/src/i3s-converter/helpers/geometry-converter.js
+++ b/modules/tile-converter/src/i3s-converter/helpers/geometry-converter.js
@@ -266,7 +266,6 @@ function convertMesh(
       outputAttributes = attributesMap.get('default');
     }
     assert(outputAttributes !== null, 'Primitive - material mapping failed');
-    normalizeAttributesByIndicesRange(primitive.attributes, primitive.indices);
     const attributes = primitive.attributes;
 
     outputAttributes.positions = concatenateTypedArrays(
@@ -310,29 +309,6 @@ function convertMesh(
   }
 }
 
-/**
- * Do normalisation of arrtibutes based on indices range.
- * @param {Object} indices - gltf primitive indices array
- * @param {Object} attributes - gltf primitive attributes
- * @returns {void}
- */
-function normalizeAttributesByIndicesRange(attributes, indices) {
-  if (!indices || !indices.min || !indices.max) {
-    return;
-  }
-
-  const maxIndex = indices.max[0];
-  const minIndex = indices.min[0];
-
-  for (const key in attributes) {
-    const attribute = attributes[key];
-    attribute.value = attribute.value.subarray(
-      minIndex * attribute.components,
-      (maxIndex + 1) * attribute.components
-    );
-    attribute.count = maxIndex - minIndex;
-  }
-}
 /**
  * Convert vertices attributes (POSITIONS or NORMALS) to i3s compatible format
  * @param {object} args - source tile (3DTile)


### PR DESCRIPTION
I spent some time analyzing what `normalizeAttributesByIndicesRange` actually does. The case occurs when indices attribute has min and max properties. It looks like the function is legacy and we don't really need it anymore. For this particular tileset it breaks attribute arrays. The tileset is textured partially. It is correct. Some primitives have material without texture.
![image](https://user-images.githubusercontent.com/18549629/114375016-eda9ff80-9b8c-11eb-83ee-eba93dd753e2.png)
