### PR TITLE
I3S-attribute-loader - Fix for attributes loading

### DIFF
--- a/modules/i3s/src/helpers/promises-handler.js
+++ b/modules/i3s/src/helpers/promises-handler.js
@@ -1,0 +1,22 @@
+export const REJECTED_STATUS = 'rejected';
+export const FULFILLED_STATUS = 'fulfilled';
+
+/**
+ * Handle list of promises based on browser compatibility
+ * @param {Promise[]} promises
+ * @returns {Promise}
+ */
+export function handlePromises(promises) {
+  return Promise.allSettled ? Promise.allSettled(promises) : Promise.all(promises.map(reflect));
+}
+
+function reflect(promise) {
+  return promise.then(
+    value => {
+      return {status: FULFILLED_STATUS, value};
+    },
+    error => {
+      return {status: REJECTED_STATUS, reason: error};
+    }
+  );
+}

--- a/modules/i3s/src/i3s-attribute-loader.js
+++ b/modules/i3s/src/i3s-attribute-loader.js
@@ -2,12 +2,12 @@
 import {parseI3STileAttribute} from './lib/parsers/parse-i3s-attribute';
 import {load} from '@loaders.gl/core';
 import {getUrlWithToken} from './lib/parsers/url-utils';
+import {handlePromises, REJECTED_STATUS} from './helpers/promises-handler';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
 const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 const EMPTY_VALUE = '';
-
 /**
  * Loader for I3S attributes
  * @type {LoaderObject}
@@ -28,7 +28,7 @@ async function parse(data, options) {
   data = parseI3STileAttribute(data, options);
   return data;
 }
-// TODO add loaded attributes to cache
+
 /**
  * Load attributes based on feature id
  * @param {Object} tile
@@ -55,7 +55,7 @@ export async function loadFeatureAttributes(tile, featureId, options = {}) {
     attributeLoadPromises.push(promise);
   }
   try {
-    attributes = await Promise.all(attributeLoadPromises);
+    attributes = await handlePromises(attributeLoadPromises);
   } catch (error) {
     // do nothing
   }
@@ -97,13 +97,13 @@ function getAttributeValueType(attribute) {
  * @returns {Object}
  */
 function generateAttributesByFeatureId(attributes, attributeStorageInfo, featureId) {
-  const objectIds = attributes.find(attribute => attribute.OBJECTID);
+  const objectIds = attributes.find(attribute => attribute.value.OBJECTID);
 
   if (!objectIds) {
     return null;
   }
 
-  const attributeIndex = objectIds.OBJECTID.indexOf(featureId);
+  const attributeIndex = objectIds.value.OBJECTID.indexOf(featureId);
 
   if (attributeIndex < 0) {
     return null;
@@ -124,11 +124,27 @@ function getFeatureAttributesByIndex(attributes, featureIdIndex, attributeStorag
 
   for (let index = 0; index < attributeStorageInfo.length; index++) {
     const attributeName = attributeStorageInfo[index].name;
-    const attribute = attributes[index][attributeName];
+    const attribute = getAttributeByIndexAndAttributeName(attributes, index, attributeName);
     attributesObject[attributeName] = formatAttributeValue(attribute, featureIdIndex);
   }
 
   return attributesObject;
+}
+
+/**
+ * Return attribute value if it presents in atrributes list
+ * @param {array} attributes
+ * @param {number} index
+ * @param {string} attributesName
+ */
+function getAttributeByIndexAndAttributeName(attributes, index, attributesName) {
+  const attributeObject = attributes[index];
+
+  if (attributeObject.status === REJECTED_STATUS) {
+    return null;
+  }
+
+  return attributeObject.value[attributesName];
 }
 
 /**

--- a/modules/i3s/test/i3s-attribute-loader.spec.js
+++ b/modules/i3s/test/i3s-attribute-loader.spec.js
@@ -5,6 +5,7 @@ import {load} from '@loaders.gl/core';
 const objectIdsUrl = '@loaders.gl/i3s/test/data/attributes/f_0/0/index.bin';
 const namesUrl = '@loaders.gl/i3s/test/data/attributes/f_1/0/index.bin';
 const heightRoofUrl = '@loaders.gl/i3s/test/data/attributes/f_2/0/index.bin';
+const wrongNamesUrl = '@loaders.gl/i3s/test/data/attributes/f_1/0/wrong.bin';
 
 const name602 = 'West End Building\0';
 const objecId0 = 979297;
@@ -32,6 +33,20 @@ const TILE = {
   },
   header: {
     attributeUrls: [objectIdsUrl, namesUrl, heightRoofUrl]
+  }
+};
+
+const TILE_WITH_WRONG_NAME_ATTRIBUTE_URL = {
+  tileset: {
+    tileset: {
+      attributeStorageInfo: [
+        {key: 'f_0', name: 'OBJECTID', objectIds: []},
+        {key: 'f_1', name: 'NAME', attributeValues: {valueType: 'String'}}
+      ]
+    }
+  },
+  header: {
+    attributeUrls: [objectIdsUrl, wrongNamesUrl, heightRoofUrl]
   }
 };
 
@@ -166,5 +181,15 @@ test('I3SAttributeLoader#loadFeatureAttributes should return attributes object',
 
   const attributes = await loadFeatureAttributes(tile, featureId, options);
   t.deepEqual(attributes, {OBJECTID: '979297', NAME: ' '});
+  t.end();
+});
+
+test('I3SAttributeLoader#loadFeatureAttributes if one of them are failed to fetch', async t => {
+  const tile = TILE_WITH_WRONG_NAME_ATTRIBUTE_URL;
+  const featureId = objecId0;
+  const options = {};
+
+  const attributes = await loadFeatureAttributes(tile, featureId, options);
+  t.deepEqual(attributes, {OBJECTID: '979297', NAME: ''});
   t.end();
 });


### PR DESCRIPTION
This fix allows to load all attributes and doesn't fail all loaded attributes if any of them are not fetched or parsed properly