### PR TITLE
Refactoring in I3S loaders

### DIFF
--- a/examples/experimental/i3s-17-and-debug/app-debug.js
+++ b/examples/experimental/i3s-17-and-debug/app-debug.js
@@ -419,7 +419,6 @@ export default class App extends PureComponent {
         pickable,
         loadTiles,
         autoHighlight: true,
-        isDebugMode: true,
         selectedTileId,
         coloredTilesMap,
         wireframe

--- a/examples/experimental/i3s-17-and-debug/app.js
+++ b/examples/experimental/i3s-17-and-debug/app.js
@@ -149,7 +149,8 @@ export default class App extends PureComponent {
         onTileUnload: () => this._updateStatWidgets(),
         pickable: true,
         loadOptions,
-        highlightedObjectIndex: selectedFeatureIndex
+        highlightedObjectIndex: selectedFeatureIndex,
+        segmentationMode: true
       })
     ];
   }

--- a/examples/experimental/i3s-17-and-debug/mesh-layer/simple-mesh-layer-vertex.glsl.js
+++ b/examples/experimental/i3s-17-and-debug/mesh-layer/simple-mesh-layer-vertex.glsl.js
@@ -11,7 +11,7 @@ in vec3 normals;
 in vec3 colors;
 in vec2 texCoords;
 in vec4 uvRegions;
-in vec3 pickingColors;
+in vec3 segmentationPickingColors;
 
 // Instance attributes
 in vec3 instancePositions;
@@ -38,10 +38,10 @@ void main(void) {
   geometry.worldPosition = instancePositions;
   geometry.uv = uv;
 
-  #ifdef INSTANCE_PICKING_MODE
-    geometry.pickingColor = instancePickingColors;
+  #ifdef SEGMENTATION_MODE
+    geometry.pickingColor = segmentationPickingColors;
   #else
-    geometry.pickingColor = pickingColors;
+    geometry.pickingColor = instancePickingColors;
   #endif
 
   #ifdef MODULE_PBR

--- a/examples/experimental/i3s-17-and-debug/tile-layer/tile-layer.js
+++ b/examples/experimental/i3s-17-and-debug/tile-layer/tile-layer.js
@@ -58,12 +58,14 @@ export default class TileLayer extends Tile3DLayer {
       pickable,
       autoHighlight,
       tileColorMode,
-      isDebugMode,
+      segmentationMode,
       colorsMap,
       selectedTileId,
       coloredTilesMap,
       wireframe
     } = this.props;
+
+    const segmentationData = tileHeader.header.segmentationData;
 
     const geometry =
       (oldLayer && oldLayer.props.mesh) ||
@@ -99,8 +101,9 @@ export default class TileLayer extends Tile3DLayer {
         pickable,
         autoHighlight,
         highlightColor: [0, 0, 255, 150],
-        isDebugMode,
-        wireframe
+        wireframe,
+        segmentationMode,
+        segmentationData
       }
     );
   }

--- a/modules/3d-tiles/src/tiles-3d-loader.js
+++ b/modules/3d-tiles/src/tiles-3d-loader.js
@@ -34,8 +34,10 @@ function getBaseUri(tileset) {
 }
 
 async function parseTile(arrayBuffer, options, context) {
-  const tile = {};
-  tile.content = tile.content || {};
+  const tile = {
+    content: {},
+    segmentationData: null
+  };
   const byteOffset = 0;
   await parse3DTile(arrayBuffer, byteOffset, options, context, tile.content);
   return tile.content;

--- a/modules/i3s/src/i3s-content-loader.js
+++ b/modules/i3s/src/i3s-content-loader.js
@@ -5,9 +5,7 @@ import {parseI3STileContent} from './lib/parsers/parse-i3s-tile-content';
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
 
-// Remove after featureIds replaced with segmentationData in I3S-picking-app
-// const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'beta';
-const VERSION = '3.0.0-alpha.12';
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'beta';
 /**
  * Loader for I3S - Indexed 3D Scene Layer
  * @type {LoaderObject}
@@ -16,7 +14,8 @@ export const I3SContentLoader = {
   name: 'I3S Content (Indexed Scene Layers)',
   id: 'i3s-content',
   module: 'i3s',
-  worker: true,
+  // Return "true" after featureIds replaced with segmentationData in I3S-picking-app
+  worker: false,
   version: VERSION,
   mimeTypes: ['application/octet-stream'],
   parse,
@@ -29,6 +28,7 @@ export const I3SContentLoader = {
 async function parse(data, options) {
   const {tile, tileset} = options.i3s;
   tile.content = tile.content || {};
+  tile.segmentationData = tile.segmentationData || null;
   tile.userData = tile.userData || {};
   await parseI3STileContent(data, tile, tileset, options);
   return tile.content;

--- a/modules/i3s/src/i3s-content-loader.js
+++ b/modules/i3s/src/i3s-content-loader.js
@@ -4,8 +4,10 @@ import {parseI3STileContent} from './lib/parsers/parse-i3s-tile-content';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
-const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'beta';
 
+// Remove after featureIds replaced with segmentationData in I3S-picking-app
+// const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'beta';
+const VERSION = '3.0.0-alpha.12';
 /**
  * Loader for I3S - Indexed 3D Scene Layer
  * @type {LoaderObject}

--- a/modules/i3s/src/lib/parsers/parse-i3s-tile-content.js
+++ b/modules/i3s/src/lib/parsers/parse-i3s-tile-content.js
@@ -30,6 +30,7 @@ const I3S_ATTRIBUTE_TYPE = 'i3s-attribute-type';
 
 export async function parseI3STileContent(arrayBuffer, tile, tileset, options) {
   tile.content = tile.content || {};
+  tile.segmentationData = tile.segmentationData || null;
 
   // construct featureData from defaultGeometrySchema;
   tile.content.featureData = constructFeatureDataStruct(tile, tileset);
@@ -145,10 +146,12 @@ async function parseI3SNodeGeometry(arrayBuffer, tile = {}, options) {
     normals: attributes.normal,
     colors: normalizeAttribute(attributes.color), // Normalize from UInt8
     texCoords: attributes.uv0,
-    uvRegions: normalizeAttribute(attributes.uvRegion), // Normalize from UInt16
-    featureIds: attributes.id,
-    faceRange: attributes.faceRange
+    uvRegions: normalizeAttribute(attributes.uvRegion) // Normalize from UInt16
   };
+
+  if (attributes.id && attributes.id.value) {
+    tile.segmentationData = attributes.id.value;
+  }
 
   // Remove undefined attributes
   for (const attributeIndex in content.attributes) {

--- a/modules/i3s/test/i3s-loader.spec.js
+++ b/modules/i3s/test/i3s-loader.spec.js
@@ -17,12 +17,6 @@ test('I3SLoader#Load tile content', async t => {
   t.ok(content.attributes.texCoords);
   t.equal(content.attributes.texCoords.value.length, 51276);
   t.ok(content.texture);
-  t.ok(content.attributes.faceRange);
-  t.equal(content.attributes.faceRange.value.length, 244);
-  t.ok(content.attributes.featureIds);
-  t.equal(content.attributes.featureIds.value.length, 25638);
-
-  t.ok(content.texture);
   // ImageLoader returns different things on browser and Node
   if (isBrowser) {
     t.ok(content.texture instanceof ImageBitmap || content.texture.compressed);

--- a/modules/i3s/test/lib/parsers/parse-i3s-tile-content.spec.js
+++ b/modules/i3s/test/lib/parsers/parse-i3s-tile-content.spec.js
@@ -86,3 +86,20 @@ test('ParseI3sTileContent#should make PBR material', async t => {
   }
   t.end();
 });
+
+test('ParseI3sTileContent#should has segmentationData', async t => {
+  const i3sTilesetData = TILESET_STUB();
+  const i3SNodePagesTiles = new I3SNodePagesTiles(i3sTilesetData, {});
+  const tile = await i3SNodePagesTiles.formTileFromNodePages(1);
+  const response = await fetchFile(I3S_TILE_CONTENT);
+  const data = await response.arrayBuffer();
+  const result = await parseI3STileContent(data, tile, i3sTilesetData, {
+    i3s: {
+      useDracoGeometry: false
+    }
+  });
+  t.ok(result);
+  t.ok(result.segmentationData);
+  t.equal(result.segmentationData.length, 25638);
+  t.end();
+});

--- a/modules/i3s/test/lib/parsers/parse-i3s-tile-content.spec.js
+++ b/modules/i3s/test/lib/parsers/parse-i3s-tile-content.spec.js
@@ -87,7 +87,7 @@ test('ParseI3sTileContent#should make PBR material', async t => {
   t.end();
 });
 
-test('ParseI3sTileContent#should has segmentationData', async t => {
+test('ParseI3sTileContent#should have segmentationData', async t => {
   const i3sTilesetData = TILESET_STUB();
   const i3SNodePagesTiles = new I3SNodePagesTiles(i3sTilesetData, {});
   const tile = await i3SNodePagesTiles.formTileFromNodePages(1);

--- a/modules/tile-converter/src/3d-tiles-converter/helpers/b3dm-converter.js
+++ b/modules/tile-converter/src/3d-tiles-converter/helpers/b3dm-converter.js
@@ -39,7 +39,6 @@ export default class B3dmConverter {
       positionsValue,
       i3sContent.cartesianOrigin
     );
-    this._replaceFeatureIdsAndFaceRangeWithBatchId(i3sContent);
     if (i3sContent.attributes.normals && !this._checkNormals(i3sContent.attributes.normals.value)) {
       delete i3sContent.attributes.normals;
     }
@@ -110,28 +109,6 @@ export default class B3dmConverter {
     const translateOriginMatrix = new Matrix4().translate(cartesianOrigin);
     const result = translateOriginMatrix.multiplyLeft(Z_UP_TO_Y_UP_MATRIX);
     return result;
-  }
-
-  /**
-   * Do replacement featureIds and faseRange in i3sContent object.
-   * @param {Object} i3sContent - the source object
-   * @returns {void}
-   */
-  _replaceFeatureIdsAndFaceRangeWithBatchId(i3sContent) {
-    const {featureIds, faceRange} = i3sContent.attributes;
-    if (!featureIds || !faceRange) {
-      return;
-    }
-
-    const faceRanges = faceRange.value;
-    const batchId = this._generateBatchId(faceRanges);
-
-    i3sContent.attributes._BATCHID = {
-      ...i3sContent.attributes.featureIds,
-      value: batchId
-    };
-    delete i3sContent.attributes.faceRange;
-    delete i3sContent.attributes.featureIds;
   }
 
   /**

--- a/modules/tile-converter/test/3d-tiles-converter/helpers/b3dm-converter.spec.js
+++ b/modules/tile-converter/test/3d-tiles-converter/helpers/b3dm-converter.spec.js
@@ -58,16 +58,11 @@ test('tile-converter - b3dm converter#should convert i3s node data to b3dm encod
     const attributes = await _loadAttributes(tile, ATTRIBUTES_STORAGE_INFO_STUB);
     const b3dmConverter = new B3dmConverter();
     const encodedContent = await b3dmConverter.convert(tile, attributes);
-    const batchId = b3dmConverter.i3sTile.content.attributes._BATCHID;
+    const batchId = b3dmConverter.i3sTile.header.segmentationData;
 
     t.ok(encodedContent);
     t.ok(batchId);
-    t.notOk(b3dmConverter.i3sTile.content.attributes.featureIds);
-    t.notOk(b3dmConverter.i3sTile.content.attributes.faceRange);
-    t.equal(batchId.value[0], 0);
-    t.equal(batchId.value[batchId.value.length - 1], 121);
-    t.equal(batchId.value[batchId.value.length - 1] + 1, attributes.OBJECTID.length);
-    t.equal(batchId.value[batchId.value.length - 1] + 1, attributes.NAME.length);
+    t.equal(batchId.length, i3sContent.attributes.positions.value.length / 3);
     t.ok(attributes);
     t.equal(attributes.OBJECTID[0], 14238);
     t.equal(attributes.NAME[0], 'Sanfran_island_0197.flt\x00');


### PR DESCRIPTION
The reason of this PR to prepare for moving picking logic to` deck.gl` just using common naming strategy for I3S and 3DTiles.
There are few changes:
1. Rename ` featureIds -> segmentationData` to make it common for `I3S` and `3DTiles`.
2. Delete useless `_replaceFeatureIdsAndFaceRangeWithBatchId` because we don't need to flatten `featureIds` any more because we already do it in `parse-i3s-tile-content.js`.
