### PR TITLE
Add es5 bundle creation for old browsers

### DIFF
--- a/modules/3d-tiles/package.json
+++ b/modules/3d-tiles/package.json
@@ -29,7 +29,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js"
   },
   "dependencies": {

--- a/modules/arrow/package.json
+++ b/modules/arrow/package.json
@@ -30,7 +30,7 @@
     "fs": false
   },
   "scripts": {
-    "pre-build": "npm run build-worker && npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-worker && npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-worker": "webpack --entry ./src/workers/arrow-worker.js --output ./dist/arrow-worker.js --config ../../scripts/webpack/worker.js"
   },

--- a/modules/compression/package.json
+++ b/modules/compression/package.json
@@ -27,7 +27,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-workers && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-bundle && npm run build-workers",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-workers": "npm run build-zlib-worker && npm run build-lz4-worker && npm run build-zstd-worker",
     "build-zlib-worker": "webpack --entry ./src/workers/zlib-worker.js --output ./dist/zlib-worker.js --env.dev --config ../../scripts/webpack/worker.js",

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -38,7 +38,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js"
   },
   "dependencies": {

--- a/modules/crypto/package.json
+++ b/modules/crypto/package.json
@@ -27,7 +27,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-workers && npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-workers && npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-workers": "npm run build-crypto-worker && npm run build-cryptojs-worker",
     "build-crypto-worker": "webpack --entry ./src/workers/crypto-worker.js --output ./dist/crypto-worker.js --env.dev --config ../../scripts/webpack/worker.js",

--- a/modules/csv/package.json
+++ b/modules/csv/package.json
@@ -25,7 +25,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js"
   },
   "dependencies": {

--- a/modules/draco/package.json
+++ b/modules/draco/package.json
@@ -31,7 +31,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-worker && npm run build-worker-dev && npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-worker && npm run build-worker-dev && npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-worker": "webpack --entry ./src/workers/draco-worker.js --output ./dist/draco-worker.js --config ../../scripts/webpack/worker.js",
     "build-worker-dev": "webpack --entry ./src/workers/draco-worker.js --output ./dist/draco-worker.dev.js --config ../../scripts/webpack/worker.js --env.dev"

--- a/modules/excel/package.json
+++ b/modules/excel/package.json
@@ -30,7 +30,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-bundle -- --env.dev && npm run build-worker",
+    "pre-build": "npm run build-bundle && npm run build-worker",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-worker": "webpack --entry ./src/workers/excel-worker.js --output ./dist/excel-worker.js --config ../../scripts/webpack/worker.js"
   },

--- a/modules/flatgeobuf/package.json
+++ b/modules/flatgeobuf/package.json
@@ -26,7 +26,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-worker && npm run build-worker --env.dev && npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-worker && npm run build-worker --env.dev && npm run build-bundle",
     "build-worker": "webpack --entry ./src/workers/flatgeobuf-worker.js --output ./dist/flatgeobuf-worker.js --config ../../scripts/webpack/worker.js",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js"
   },

--- a/modules/gltf/package.json
+++ b/modules/gltf/package.json
@@ -33,7 +33,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bin && npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-bin && npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-bin": "BABEL_ENV=es5 babel scripts --config-file ../../babel.config.js --out-dir dist/scripts"
   },

--- a/modules/i3s/package.json
+++ b/modules/i3s/package.json
@@ -26,7 +26,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-worker && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-bundle && npm run build-worker",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-worker": "webpack --entry ./src/workers/i3s-content-worker.js --output ./dist/i3s-content-worker.js --config ../../scripts/webpack/worker.js"
   },

--- a/modules/images/package.json
+++ b/modules/images/package.json
@@ -28,7 +28,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-bundle",
     "build-bundle": "webpack  --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-worker": "webpack --entry ./src/image-worker.js --output ./dist/image-worker.js --config ../../scripts/webpack/worker.js"
   },

--- a/modules/json/package.json
+++ b/modules/json/package.json
@@ -29,7 +29,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-worker && npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-worker && npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-worker": "webpack --entry ./src/workers/geojson-worker.js --output ./dist/geojson-worker.js --config ../../scripts/webpack/worker.js"
   },

--- a/modules/kml/package.json
+++ b/modules/kml/package.json
@@ -27,7 +27,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js"
   },
   "dependencies": {

--- a/modules/las/package.json
+++ b/modules/las/package.json
@@ -34,8 +34,8 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-worker && npm run build-bundle",
-    "pre-build-disabled": "npm run copy-libs && npm run build-worker && npm run build-worker-dev && npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-worker && npm run build-bundle -- --config-name production && npm run build-bundle -- --config-name es5",
+    "pre-build-disabled": "npm run copy-libs && npm run build-worker && npm run build-worker-dev && npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-worker": "webpack --entry ./src/workers/las-worker.js --output ./dist/las-worker.js --config ../../scripts/webpack/worker.js"
   },

--- a/modules/loader-utils/package.json
+++ b/modules/loader-utils/package.json
@@ -34,7 +34,7 @@
     "fs": false
   },
   "scripts": {
-    "pre-build-disabled": "npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build-disabled": "npm run build-bundle",
     "pre-build": "npm run build-worker",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-worker": "webpack --entry ./src/workers/null-worker.js --output ./dist/null-worker.js --config ../../scripts/webpack/worker.js"

--- a/modules/mvt/package.json
+++ b/modules/mvt/package.json
@@ -26,7 +26,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-worker && npm run build-worker --env.dev && npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-worker && npm run build-worker --env.dev && npm run build-bundle",
     "build-worker": "webpack --entry ./src/workers/mvt-worker.js --output ./dist/mvt-worker.js --config ../../scripts/webpack/worker.js",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js"
   },

--- a/modules/obj/package.json
+++ b/modules/obj/package.json
@@ -27,7 +27,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-worker && npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-worker && npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-worker": "webpack --entry ./src/workers/obj-worker.js --output ./dist/obj-worker.js --config ../../scripts/webpack/worker.js"
   },

--- a/modules/pcd/package.json
+++ b/modules/pcd/package.json
@@ -27,7 +27,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-worker && npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-worker && npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-worker": "webpack --entry ./src/workers/pcd-worker.js --output ./dist/pcd-worker.js --config ../../scripts/webpack/worker.js"
   },

--- a/modules/ply/package.json
+++ b/modules/ply/package.json
@@ -27,7 +27,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-worker && npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-worker && npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-worker": "webpack --entry ./src/workers/ply-worker.js --output ./dist/ply-worker.js --config ../../scripts/webpack/worker.js"
   },

--- a/modules/polyfills/package.json
+++ b/modules/polyfills/package.json
@@ -91,7 +91,7 @@
     "web-streams-polyfill": false
   },
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js"
   },
   "dependencies": {

--- a/modules/potree/package.json
+++ b/modules/potree/package.json
@@ -30,7 +30,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js"
   },
   "dependencies": {

--- a/modules/shapefile/package.json
+++ b/modules/shapefile/package.json
@@ -30,7 +30,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-shp-worker && npm run build-dbf-worker && npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-shp-worker && npm run build-dbf-worker && npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-shp-worker": "webpack --entry ./src/workers/shp-worker.js --output ./dist/shp-worker.js --config ../../scripts/webpack/worker.js",
     "build-dbf-worker": "webpack --entry ./src/workers/dbf-worker.js --output ./dist/dbf-worker.js --config ../../scripts/webpack/worker.js"

--- a/modules/tables/package.json
+++ b/modules/tables/package.json
@@ -28,7 +28,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js"
   },
   "dependencies": {

--- a/modules/terrain/package.json
+++ b/modules/terrain/package.json
@@ -27,7 +27,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-worker && npm run build-worker2 && npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-worker && npm run build-worker2 && npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-worker": "webpack --entry ./src/workers/terrain-worker.js --output ./dist/terrain-worker.js --config ../../scripts/webpack/worker.js",
     "build-worker2": "webpack --entry ./src/workers/quantized-mesh-worker.js --output ./dist/quantized-mesh-worker.js --config ../../scripts/webpack/worker.js"

--- a/modules/textures/package.json
+++ b/modules/textures/package.json
@@ -32,7 +32,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run copy-libs && npm run build-worker && npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run copy-libs && npm run build-worker && npm run build-bundle",
     "copy-libs": "cp -rf ./src/libs ./dist/libs",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-worker": "npm run build-basis-worker && npm run build-npy-worker && npm run build-compressed-texture-worker && npm run build-crunch-worker",

--- a/modules/tile-converter/package.json
+++ b/modules/tile-converter/package.json
@@ -33,7 +33,7 @@
     "fs": false
   },
   "scripts": {
-    "pre-build": "npm run build-bin && npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-bin && npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-bin": "BABEL_ENV=es5 babel scripts --config-file ../../babel.config.js --out-dir dist/scripts",
     "build-converter-bundle": "webpack --config ./converter-webpack/bundle.js"

--- a/modules/tiles/package.json
+++ b/modules/tiles/package.json
@@ -28,7 +28,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js"
   },
   "dependencies": {

--- a/modules/video/package.json
+++ b/modules/video/package.json
@@ -27,7 +27,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-bundle",
     "build-bundle": "webpack  --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-worker": "webpack --entry ./src/image-worker.js --output ./dist/image-worker.js --config ../../scripts/webpack/worker.js"
   },

--- a/modules/wkt/package.json
+++ b/modules/wkt/package.json
@@ -26,7 +26,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-worker && npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-worker && npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-worker": "webpack --entry ./src/workers/wkt-worker.js --output ./dist/wkt-worker.js --config ../../scripts/webpack/worker.js"
   },

--- a/modules/worker-utils/package.json
+++ b/modules/worker-utils/package.json
@@ -34,7 +34,7 @@
   },
   "scripts": {
     "pre-build": "npm run build-workers",
-    "pre-build-disabled": "npm run build-bundle && npm run build-workers && npm run build-bundle -- --env.dev",
+    "pre-build-disabled": "npm run build-bundle && npm run build-workers",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-workers": "webpack --entry ./src/workers/null-worker.js --output ./dist/null-worker.js --env.dev --config ../../scripts/webpack/worker.js"
   },

--- a/modules/zip/package.json
+++ b/modules/zip/package.json
@@ -25,7 +25,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js"
   },
   "dependencies": {

--- a/scripts/webpack/bundle.js
+++ b/scripts/webpack/bundle.js
@@ -7,6 +7,7 @@ const ALIASES = require('ocular-dev-tools/config/ocular.config')({
 }).aliases;
 
 const PACKAGE_ROOT = resolve('.');
+const DIST_PATH = resolve('dist');
 const PACKAGE_INFO = require(resolve(PACKAGE_ROOT, 'package.json'));
 
 /**
@@ -42,7 +43,7 @@ const NODE = {
   crypto: 'empty'
 };
 
-const BABEL_CONFIG = {
+const ES5_BABEL_CONFIG = {
   presets: [
     ['@babel/preset-env', {forceAllTransforms: true}]
   ],
@@ -54,6 +55,7 @@ const BABEL_CONFIG = {
 };
 
 const config = {
+  name: 'production',
   mode: 'production',
 
   entry: {
@@ -62,8 +64,8 @@ const config = {
 
   output: {
     libraryTarget: 'umd',
-    path: PACKAGE_ROOT,
-    filename: 'dist/dist.min.js'
+    path: DIST_PATH,
+    filename: 'dist.min.js'
   },
 
   node: NODE,
@@ -75,12 +77,9 @@ const config = {
   module: {
     rules: [
       {
-        // Compile ES2015 using babel
         test: /\.js$/,
         loader: 'babel-loader',
         include: /src/,
-        // exclude: /transpiled/
-        options: BABEL_CONFIG
       }
     ]
   },
@@ -100,25 +99,33 @@ const config = {
   devtool: false
 };
 
-module.exports = (env = {}) => {
-  // console.log(JSON.stringify(env, null, 2));
-
-  if (env.dev) {
-    // Set development mode (no minification)
-    config.mode = 'development';
-    // Remove .min from the name
-    config.output.filename = 'dist/dist.dev.js';
-    // Disable transpilation
-    config.module.rules = [];
-  } else {
-    // Generate a separate source map
-    // @ts-ignore
-    config.devtool = 'source-map';
+const developmentConfig = {
+  ...config,
+  name: 'development',
+  mode: 'development',
+  output: {
+    filename: 'dist.dev.js'
+  },
+  module: {
+    rules: []
   }
-
-
-  // NOTE uncomment to display config
-  // console.log('webpack config', JSON.stringify(config, null, 2));
-
-  return config;
 };
+
+const es5Config = {
+  ...config,
+  name: 'es5',
+  output: {
+    filename: 'dist.es5.min.js'
+  },
+  module: {
+    rules: [{
+      // Compile ES2015 using babel
+      test: /\.js$/,
+      loader: 'babel-loader',
+      include: /src/,
+      options: ES5_BABEL_CONFIG
+    }]
+  }
+};
+
+module.exports = [config, developmentConfig, es5Config];


### PR DESCRIPTION
1. Return `dist.min.js` bundle creation as it was earlier to decrease bundle sizes
2. Add ES5 configuration to produce fully ES5 transpilled bundle for old browsers usage (IE 11 support as well)
# Minified Scripts OLD
modules/3d-tiles/dist/dist.min.js 419K
modules/arrow/dist/dist.min.js 290K
modules/compression/dist/dist.min.js 124K
modules/core/dist/dist.min.js 123K
modules/crypto/dist/dist.min.js 62K
modules/csv/dist/dist.min.js 61K
modules/draco/dist/dist.min.js 90K
modules/excel/dist/dist.min.js 905K
modules/flatgeobuf/dist/dist.min.js 51K
modules/gltf/dist/dist.min.js 158K
modules/i3s/dist/dist.min.js 395K
modules/images/dist/dist.min.js 88K
modules/json/dist/dist.min.js 141K
modules/kml/dist/dist.min.js 37K
modules/las/dist/dist.min.js 299K
modules/mvt/dist/dist.min.js 39K
modules/obj/dist/dist.min.js 115K
modules/pcd/dist/dist.min.js 107K
modules/ply/dist/dist.min.js 132K
modules/polyfills/dist/dist.min.js 579K
modules/potree/dist/dist.min.js 14K
modules/shapefile/dist/dist.min.js 170K
modules/tables/dist/dist.min.js 44K
modules/terrain/dist/dist.min.js 82K
modules/textures/dist/dist.min.js 131K
modules/tile-converter/dist/dist.min.js 1,4M
modules/tiles/dist/dist.min.js 273K
modules/video/dist/dist.min.js 39K
modules/wkt/dist/dist.min.js 20K
modules/zip/dist/dist.min.js 119K

# Minified Scripts NEW
modules/3d-tiles/dist/dist.min.js 130K
modules/arrow/dist/dist.min.js 240K
modules/compression/dist/dist.min.js 53K
modules/core/dist/dist.min.js 36K
modules/crypto/dist/dist.min.js 23K
modules/csv/dist/dist.min.js 19K
modules/draco/dist/dist.min.js 17K
modules/excel/dist/dist.min.js 896K
modules/flatgeobuf/dist/dist.min.js 41K
modules/gltf/dist/dist.min.js 44K
modules/i3s/dist/dist.min.js 129K
modules/images/dist/dist.min.js 12K
modules/json/dist/dist.min.js 23K
modules/kml/dist/dist.min.js 19K
modules/las/dist/dist.min.js 231K
modules/mvt/dist/dist.min.js 25K
modules/obj/dist/dist.min.js 14K
modules/pcd/dist/dist.min.js 9,2K
modules/ply/dist/dist.min.js 8,5K
modules/polyfills/dist/dist.min.js 569K
modules/potree/dist/dist.min.js 3,1K
modules/shapefile/dist/dist.min.js 105K
modules/tables/dist/dist.min.js 17K
modules/terrain/dist/dist.min.js 9,6K
modules/textures/dist/dist.min.js 35K
modules/tile-converter/dist/dist.min.js 845K
modules/tiles/dist/dist.min.js 119K
modules/video/dist/dist.min.js 28K
modules/wkt/dist/dist.min.js 8,2K
modules/zip/dist/dist.min.js 106K
