### PR TITLE
Website - Remove Basis + Compressed texture duplicated loaders from loaders list

### DIFF
--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -58,8 +58,6 @@
         {"entry": "modules/3d-tiles/docs/api-reference/cesium-ion-loader"},
         {"entry": "modules/arrow/docs/api-reference/arrow-loader"},
         {"entry": "modules/arrow/docs/api-reference/arrow-writer"},
-        {"entry": "modules/basis/docs/api-reference/basis-loader"},
-        {"entry": "modules/basis/docs/api-reference/compressed-texture-loader"},
         {"entry": "modules/csv/docs/api-reference/csv-loader"},
         {"entry": "modules/draco/docs/api-reference/draco-loader"},
         {"entry": "modules/draco/docs/api-reference/draco-writer"},


### PR DESCRIPTION
`Basis loader `and `Compressed texture loader` are moved to texture module.