### PR TITLE
Chore(CSV): fix skipEmptyLines handling for streaming parsing

### DIFF
--- a/modules/csv/src/csv-loader.js
+++ b/modules/csv/src/csv-loader.js
@@ -126,15 +126,32 @@ function parseCSVInBatches(asyncIterator, options) {
     ...options.csv,
     header: false, // Unfortunately, header detection is not automatic and does not infer types
     download: false, // We handle loading, no need for papaparse to do it for us
-    // chunk(results, parser) {
-    //   // TODO batch before adding to queue.
-    //   console.log('Chunk:', results, parser);
-    //   asyncQueue.enqueue(results.data);
-    // },
+    // chunkSize is set to 5MB explicitly (same as Papaparse default) due to a bug where the
+    // streaming parser gets stuck if skipEmptyLines and a step callback are both supplied.
+    // See https://github.com/mholt/PapaParse/issues/465
+    chunkSize: 1024 * 1024 * 5,
+    // skipEmptyLines is set to a boolean value if supplied. Greedy is set to true
+    // skipEmptyLines is handled manually given two bugs where the streaming parser gets stuck if
+    // both of the skipEmptyLines and step callback options are provided:
+    // - true doesn't work unless chunkSize is set: https://github.com/mholt/PapaParse/issues/465
+    // - greedy doesn't work: https://github.com/mholt/PapaParse/issues/825
+    skipEmptyLines: false,
 
     // step is called on every row
     step(results, parser) {
       const row = results.data;
+
+      if (options.csv.skipEmptyLines) {
+        // Manually reject lines that are empty
+        if (
+          row
+            .flat()
+            .join('')
+            .trim() === ''
+        ) {
+          return;
+        }
+      }
       const bytesUsed = results.meta.cursor;
 
       // Check if we need to save a header row

--- a/modules/csv/src/csv-loader.js
+++ b/modules/csv/src/csv-loader.js
@@ -144,9 +144,9 @@ function parseCSVInBatches(asyncIterator, options) {
       if (options.csv.skipEmptyLines) {
         // Manually reject lines that are empty
         const collapsedRow = row
-            .flat()
-            .join('')
-            .trim();
+          .flat()
+          .join('')
+          .trim();
         if (collapsedRow === '') {
           return;
         }

--- a/modules/csv/src/csv-loader.js
+++ b/modules/csv/src/csv-loader.js
@@ -143,12 +143,11 @@ function parseCSVInBatches(asyncIterator, options) {
 
       if (options.csv.skipEmptyLines) {
         // Manually reject lines that are empty
-        if (
-          row
+        const collapsedRow = row
             .flat()
             .join('')
-            .trim() === ''
-        ) {
+            .trim();
+        if (collapsedRow === '') {
           return;
         }
       }

--- a/modules/csv/src/libs/papaparse.js
+++ b/modules/csv/src/libs/papaparse.js
@@ -1233,6 +1233,14 @@ function Parser(config) {
             cursor = quoteSearch + 1 + spacesBetweenQuoteAndDelimiter + delimLen;
             nextDelim = input.indexOf(delim, cursor);
             nextNewline = input.indexOf(newline, cursor);
+
+            if (stepIsFunction) {
+              doStep();
+              if (aborted) return returnable();
+            }
+
+            if (preview && data.length >= preview) return returnable(true);
+
             break;
           }
 
@@ -1269,6 +1277,12 @@ function Parser(config) {
           continue;
         }
 
+        if (stepIsFunction) {
+          doStep();
+          if (aborted) return returnable();
+        }
+
+        if (preview && data.length >= preview) return returnable(true);
         continue;
       }
 

--- a/modules/csv/test/csv-loader.spec.js
+++ b/modules/csv/test/csv-loader.spec.js
@@ -9,6 +9,7 @@ import {CSVLoader} from '@loaders.gl/csv';
 const CSV_SAMPLE_URL = '@loaders.gl/csv/test/data/sample.csv';
 const CSV_SAMPLE_VERY_LONG_URL = '@loaders.gl/csv/test/data/sample-very-long.csv';
 const CSV_SAMPLE_URL_DUPLICATE_COLS = '@loaders.gl/csv/test/data/sample-duplicate-cols.csv';
+const CSV_SAMPLE_URL_EMPTY_LINES = '@loaders.gl/csv/test/data/sample-empty-line.csv';
 const CSV_STATES_URL = '@loaders.gl/csv/test/data/states.csv';
 
 const CSV_NO_HEADER_URL = '@loaders.gl/csv/test/data/numbers-100-no-header.csv';
@@ -297,4 +298,24 @@ test('CSVLoader#loadInBatches(sample.csv, duplicate columns)', async t => {
     [['x', 1, 'y', 'z', 'w', 2], ['y', 29, 'z', 'y', 'w', 19], ['x', 1, 'y', 'z', 'w', 2]],
     'dataset should be parsed correctly in the array rowFormat'
   );
+});
+
+test('CSVLoader#loadInBatches(skipEmptyLines)', async t => {
+  const iterator = await loadInBatches(CSV_SAMPLE_URL_EMPTY_LINES, CSVLoader, {
+    csv: {rowFormat: 'object', skipEmptyLines: true}
+  });
+
+  const rows = [];
+
+  for await (const batch of iterator) {
+    rows.push(...batch.data);
+  }
+
+  t.is(rows.length, 2, 'Got correct table size');
+  t.deepEqual(
+    rows,
+    [{A: 'x', B: 1, C: 'some text'}, {A: 'y', B: 2, C: 'other text'}],
+    'dataset should be parsed with the correct content'
+  );
+  t.end();
 });

--- a/modules/csv/test/data/sample-empty-line.csv
+++ b/modules/csv/test/data/sample-empty-line.csv
@@ -1,0 +1,8 @@
+A,B,C
+x,1,some text
+,,,
+
+,,,
+y,2,other text
+
+


### PR DESCRIPTION
Some CSV include an additional line, and I was trying to see how loaders can ignore such lines correctly using `skipEmptyLines`. 

I noticed that the `skipEmptyLines` option doesn't work for stream parsing. The parser gets stuck in an infinite loop, and no rows get reported if the `skipEmptyLines` is set (to either `true` or `greedy`). After some digging, it turns out to be related to two different bugs in Papaparse:
- `skipEmptyLines = true` hangs the parser if `chunkSize` isn't set, even though Papaparse has a default: https://github.com/mholt/PapaParse/issues/465
- `skipEmptyLines = greedy` hangs the parser when combined with using the `step` callback option (which we do to build the result): https://github.com/mholt/PapaParse/issues/825

I spent a few hours trying to see if this can be fixed in Papaparse itself, but it proved to be a complicated task given how cryptic that library is. This PR adds manual handling of this option within the step function instead.