### PR TITLE
Add ES5 bundle creation for 2.3-release

### DIFF
--- a/modules/3d-tiles/package.json
+++ b/modules/3d-tiles/package.json
@@ -30,7 +30,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js"
   },
   "dependencies": {

--- a/modules/arrow/package.json
+++ b/modules/arrow/package.json
@@ -28,7 +28,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-worker && npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-worker && npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js",
     "build-worker": "webpack --entry ./src/arrow-loader.worker.js --output ./dist/arrow-loader.worker.js --config ../../scripts/worker-webpack-config.js"
   },

--- a/modules/basis/package.json
+++ b/modules/basis/package.json
@@ -28,7 +28,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run copy-libs && npm run build-worker && npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run copy-libs && npm run build-worker && npm run build-bundle",
     "copy-libs": "cp -rf ./src/libs ./dist/libs",
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js",
     "build-worker": "webpack --entry ./src/workers/basis-loader.worker.js --output ./dist/basis-loader.worker.js --config ../../scripts/worker-webpack-config.js"

--- a/modules/compression/package.json
+++ b/modules/compression/package.json
@@ -28,7 +28,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js"
   },
   "dependencies": {

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -39,7 +39,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js"
   },
   "dependencies": {

--- a/modules/crypto/package.json
+++ b/modules/crypto/package.json
@@ -28,7 +28,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js"
   },
   "dependencies": {

--- a/modules/csv/package.json
+++ b/modules/csv/package.json
@@ -26,7 +26,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js"
   },
   "dependencies": {

--- a/modules/draco/package.json
+++ b/modules/draco/package.json
@@ -32,7 +32,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run copy-libs && npm run build-worker && npm run build-worker-dev && npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run copy-libs && npm run build-worker && npm run build-worker-dev && npm run build-bundle",
     "copy-libs": "cp -rf ./src/libs ./dist/libs",
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js",
     "build-worker": "webpack --entry ./src/workers/draco-loader.worker.js --output ./dist/draco-loader.worker.js --config ../../scripts/worker-webpack-config.js",

--- a/modules/flatgeobuf/package.json
+++ b/modules/flatgeobuf/package.json
@@ -27,7 +27,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-worker && npm run build-worker --env.dev && npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-worker && npm run build-worker --env.dev && npm run build-bundle",
     "build-worker": "webpack --entry ./src/workers/flatgeobuf-loader.worker.js --output ./dist/flatgeobuf-loader.worker.js --config ../../scripts/worker-webpack-config.js",
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js"
   },

--- a/modules/gltf/package.json
+++ b/modules/gltf/package.json
@@ -34,7 +34,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bin && npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-bin && npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js",
     "build-bin": "BABEL_ENV=es5 babel scripts --config-file ../../babel.config.js --out-dir dist/scripts"
   },

--- a/modules/i3s/package.json
+++ b/modules/i3s/package.json
@@ -27,7 +27,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js"
   },
   "dependencies": {

--- a/modules/images/package.json
+++ b/modules/images/package.json
@@ -29,7 +29,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-bundle",
     "build-bundle": "webpack  --display=minimal --config ../../scripts/bundle.config.js",
     "build-worker": "webpack --entry ./src/image-loader.worker.js --output ./dist/image-loader.worker.js --config ../../scripts/worker-webpack-config.js"
   },

--- a/modules/json/package.json
+++ b/modules/json/package.json
@@ -30,7 +30,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-worker && npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-worker && npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js",
     "build-worker": "webpack --entry ./src/geojson-loader.worker.js --output ./dist/geojson-loader.worker.js --config ../../scripts/worker-webpack-config.js"
   },

--- a/modules/kml/package.json
+++ b/modules/kml/package.json
@@ -28,7 +28,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js"
   },
   "dependencies": {

--- a/modules/las/package.json
+++ b/modules/las/package.json
@@ -36,7 +36,7 @@
   ],
   "scripts": {
     "pre-build": "npm run build-worker && npm run build-bundle",
-    "pre-build-disabled": "npm run copy-libs && npm run build-worker && npm run build-worker-dev && npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build-disabled": "npm run copy-libs && npm run build-worker && npm run build-worker-dev && npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js",
     "build-worker": "webpack --entry ./src/las-loader.worker.js --output ./dist/las-loader.worker.js --config ../../scripts/worker-webpack-config.js"
   },

--- a/modules/loader-utils/package.json
+++ b/modules/loader-utils/package.json
@@ -39,7 +39,7 @@
     "child_process": false
   },
   "scripts": {
-    "pre-build-disabled": "npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build-disabled": "npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js"
   },
   "dependencies": {

--- a/modules/mvt/package.json
+++ b/modules/mvt/package.json
@@ -27,7 +27,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-worker && npm run build-worker --env.dev && npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-worker && npm run build-worker --env.dev && npm run build-bundle",
     "build-worker": "webpack --entry ./src/workers/mvt-loader.worker.js --output ./dist/mvt-loader.worker.js --config ../../scripts/worker-webpack-config.js",
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js"
   },

--- a/modules/obj/package.json
+++ b/modules/obj/package.json
@@ -28,7 +28,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-worker && npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-worker && npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js",
     "build-worker": "webpack --entry ./src/obj-loader.worker.js --output ./dist/obj-loader.worker.js --config ../../scripts/worker-webpack-config.js"
   },

--- a/modules/pcd/package.json
+++ b/modules/pcd/package.json
@@ -28,7 +28,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-worker && npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-worker && npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js",
     "build-worker": "webpack --entry ./src/pcd-loader.worker.js --output ./dist/pcd-loader.worker.js --config ../../scripts/worker-webpack-config.js"
   },

--- a/modules/ply/package.json
+++ b/modules/ply/package.json
@@ -28,7 +28,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-worker && npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-worker && npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js",
     "build-worker": "webpack --entry ./src/ply-loader.worker.js --output ./dist/ply-loader.worker.js --config ../../scripts/worker-webpack-config.js"
   },

--- a/modules/polyfills/package.json
+++ b/modules/polyfills/package.json
@@ -92,7 +92,7 @@
     "web-streams-polyfill": false
   },
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js"
   },
   "dependencies": {

--- a/modules/potree/package.json
+++ b/modules/potree/package.json
@@ -31,7 +31,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js"
   },
   "dependencies": {

--- a/modules/shapefile/package.json
+++ b/modules/shapefile/package.json
@@ -31,7 +31,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-shp-worker && npm run build-dbf-worker && npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-shp-worker && npm run build-dbf-worker && npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js",
     "build-shp-worker": "webpack --entry ./src/workers/shp-loader.worker.js --output ./dist/shp-loader.worker.js --config ../../scripts/worker-webpack-config.js",
     "build-dbf-worker": "webpack --entry ./src/workers/dbf-loader.worker.js --output ./dist/dbf-loader.worker.js --config ../../scripts/worker-webpack-config.js"

--- a/modules/tables/package.json
+++ b/modules/tables/package.json
@@ -29,7 +29,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js"
   },
   "dependencies": {

--- a/modules/terrain/package.json
+++ b/modules/terrain/package.json
@@ -28,7 +28,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-worker && npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-worker && npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js",
     "build-worker": "webpack --entry ./src/terrain-loader.worker.js --output ./dist/terrain-loader.worker.js --config ../../scripts/worker-webpack-config.js && webpack --entry ./src/quantized-mesh-loader.worker.js --output ./dist/quantized-mesh-loader.worker.js --config ../../scripts/worker-webpack-config.js && webpack --entry ./src/npy-loader.worker.js --output ./dist/npy-loader.worker.js --config ../../scripts/worker-webpack-config.js"
   },

--- a/modules/tiles/package.json
+++ b/modules/tiles/package.json
@@ -29,7 +29,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js"
   },
   "dependencies": {

--- a/modules/video/package.json
+++ b/modules/video/package.json
@@ -28,7 +28,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-bundle",
     "build-bundle": "webpack  --display=minimal --config ../../scripts/bundle.config.js",
     "build-worker": "webpack --entry ./src/image-loader.worker.js --output ./dist/image-loader.worker.js --config ../../scripts/worker-webpack-config.js"
   },

--- a/modules/wkt/package.json
+++ b/modules/wkt/package.json
@@ -27,7 +27,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-worker && npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-worker && npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js",
     "build-worker": "webpack --entry ./src/wkt-loader.worker.js --output ./dist/wkt-loader.worker.js --config ../../scripts/worker-webpack-config.js"
   },

--- a/modules/zip/package.json
+++ b/modules/zip/package.json
@@ -26,7 +26,7 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-bundle -- --env.dev",
+    "pre-build": "npm run build-bundle",
     "build-bundle": "webpack --display=minimal --config ../../scripts/bundle.config.js"
   },
   "dependencies": {

--- a/scripts/bundle.config.js
+++ b/scripts/bundle.config.js
@@ -7,6 +7,7 @@ const ALIASES = require('ocular-dev-tools/config/ocular.config')({
 }).aliases;
 
 const PACKAGE_ROOT = resolve('.');
+const DIST_PATH = resolve('dist');
 const PACKAGE_INFO = require(resolve(PACKAGE_ROOT, 'package.json'));
 
 /**
@@ -42,7 +43,7 @@ const NODE = {
   crypto: 'empty'
 };
 
-const BABEL_CONFIG = {
+const ES5_BABEL_CONFIG = {
   presets: [
     ['@babel/preset-env', {forceAllTransforms: true}]
   ],
@@ -54,6 +55,7 @@ const BABEL_CONFIG = {
 };
 
 const config = {
+  name: 'production',
   mode: 'production',
 
   entry: {
@@ -62,8 +64,8 @@ const config = {
 
   output: {
     libraryTarget: 'umd',
-    path: PACKAGE_ROOT,
-    filename: 'dist/dist.min.js'
+    path: DIST_PATH,
+    filename: 'dist.min.js'
   },
 
   node: NODE,
@@ -75,12 +77,9 @@ const config = {
   module: {
     rules: [
       {
-        // Compile ES2015 using babel
         test: /\.js$/,
         loader: 'babel-loader',
         include: /src/,
-        // exclude: /transpiled/
-        options: BABEL_CONFIG
       }
     ]
   },
@@ -100,20 +99,33 @@ const config = {
   devtool: false
 };
 
-module.exports = (env = {}) => {
-  // console.log(JSON.stringify(env, null, 2));
-
-  if (env.dev) {
-    // Set development mode (no minification)
-    config.mode = 'development';
-    // Remove .min from the name
-    config.output.filename = 'dist/dist.dev.js';
-    // Disable transpilation
-    config.module.rules = [];
+const developmentConfig = {
+  ...config,
+  name: 'development',
+  mode: 'development',
+  output: {
+    filename: 'dist.dev.js'
+  },
+  module: {
+    rules: []
   }
-
-  // NOTE uncomment to display config
-  // console.log('webpack config', JSON.stringify(config, null, 2));
-
-  return config;
 };
+
+const es5Config = {
+  ...config,
+  name: 'es5',
+  output: {
+    filename: 'dist.es5.min.js'
+  },
+  module: {
+    rules: [{
+      // Compile ES2015 using babel
+      test: /\.js$/,
+      loader: 'babel-loader',
+      include: /src/,
+      options: ES5_BABEL_CONFIG
+    }]
+  }
+};
+
+module.exports = [config, developmentConfig, es5Config];


### PR DESCRIPTION
The same changes as [here](https://github.com/visgl/loaders.gl/pull/1352) but for 2.3-release branch
3d-tiles module example:
![image](https://user-images.githubusercontent.com/70207219/117315772-aadbfe80-ae90-11eb-80cd-cfbc525049e0.png)
