### PR TITLE
Tile-converter - Rename "validateBoundingVolumes" -> "validation" flag

### DIFF
--- a/modules/tile-converter/docs/api-reference/i3s-converter.md
+++ b/modules/tile-converter/docs/api-reference/i3s-converter.md
@@ -41,4 +41,11 @@ Converts a tileset to I3S format
 - `options.egmFilePath` location of \*.pgm file to convert heights from ellipsoidal to gravity-related format. A model file can be loaded from GeographicLib https://geographiclib.sourceforge.io/html/geoid.html
 - `options.token` ION token of input tileset
 - `options.draco` Whether the converter create DRACO compressed geometry in path "layers/0/nodes/xxx/geometries/1" along with non-compressed geometry in path "layers/0/nodes/xxx/geometries/0"
-- `options.validateBoundingVolumes` Enable/Disable Bounding Volumes Validation (Check if child bounding volume inside parent bounding volume)
+- `options.validate` Enable Validation
+
+### Validation
+
+By specifying the `--validate` parameter, the tile-converter will perform checks on the tileset data. The following checks are performed:
+
+- Bounding volume validation
+- Refinement type validation

--- a/modules/tile-converter/scripts/converter.js
+++ b/modules/tile-converter/scripts/converter.js
@@ -32,7 +32,7 @@ function printHelp() {
   );
   console.log('--token [Token for Cesium ION tilesets authentication]');
   console.log('--no-draco [Disable draco compression for geometry]');
-  console.log('--validate-bounding-volumes [Enable/Disable Bounding Volumes Validation]');
+  console.log('--validate [Enable validation]');
   process.exit(0); // eslint-disable-line
 }
 
@@ -114,7 +114,7 @@ async function convert(options) {
         egmFilePath: options.egm,
         token: options.token,
         draco: options.draco,
-        validateBoundingVolumes: options.validateBoundingVolumes
+        validate: options.validate
       });
       break;
     default:
@@ -135,7 +135,7 @@ function parseOptions(args) {
     token: null,
     draco: true,
     installDependencies: false,
-    validateBoundingVolumes: false
+    validate: false
   };
 
   const count = args.length;
@@ -184,8 +184,8 @@ function parseOptions(args) {
         case '--no-draco':
           opts.draco = false;
           break;
-        case '--validate-bounding-volumes':
-          opts.validateBoundingVolumes = true;
+        case '--validate':
+          opts.validate = true;
           break;
         case '--install-dependencies':
           opts.installDependencies = true;

--- a/modules/tile-converter/src/i3s-converter/i3s-converter.d.ts
+++ b/modules/tile-converter/src/i3s-converter/i3s-converter.d.ts
@@ -16,7 +16,7 @@ export default class I3SConverter {
    * @param options.egmFilePath location of *.pgm file to convert heights from ellipsoidal to gravity-related format
    * @param options.token Token for Cesium ION tilesets authentication
    * @param options.draco Generate I3S 1.7 draco compressed geometries
-   * @param options.validateBoundingVolumes -enaable/disable bounding volume validation
+   * @param options.validate -enable validation
    */
   convert(options: {
     inputUrl: string;
@@ -27,7 +27,7 @@ export default class I3SConverter {
     maxDepth?: number;
     slpk?: boolean;
     token?: string;
-    draco?: boolean;,
-    validateBoundingVolumes?: boolean
+    draco?: boolean;
+    validate?: boolean;
   }): Promise<any>;
 }

--- a/modules/tile-converter/src/i3s-converter/i3s-converter.js
+++ b/modules/tile-converter/src/i3s-converter/i3s-converter.js
@@ -57,7 +57,7 @@ export default class I3SConverter {
       tilesCount: 0,
       tilesWithAddRefineCount: 0
     };
-    this.validateBoundingVolumes = false;
+    this.validate = false;
     this.boundingVolumeWarnings = null;
   }
 
@@ -72,11 +72,11 @@ export default class I3SConverter {
     egmFilePath,
     token,
     draco,
-    validateBoundingVolumes
+    validate
   }) {
     this.conversionStartTime = process.hrtime();
     this.options = {maxDepth, slpk, sevenZipExe, egmFilePath, draco, token, inputUrl};
-    this.validateBoundingVolumes = validateBoundingVolumes;
+    this.validate = validate;
 
     console.log('Loading egm file...'); // eslint-disable-line
     this.geoidHeightModel = await load(egmFilePath, PGMLoader);
@@ -408,7 +408,10 @@ export default class I3SConverter {
    * @return {Promise<object[]>}
    */
   async _createNode(parentTile, sourceTile, parentId, level) {
-    this._checkAddRefinementTypeForTile(sourceTile);
+    if (this.validate) {
+      this._checkAddRefinementTypeForTile(sourceTile);
+    }
+
     await this._updateTilesetOptions();
     await this.sourceTileset._loadTile(sourceTile);
     const coordinates = convertCommonToI3SCoordinate(sourceTile, this.geoidHeightModel);
@@ -453,7 +456,7 @@ export default class I3SConverter {
         await this._writeResources(resources, node.path);
       }
 
-      if (this.validateBoundingVolumes) {
+      if (this.validate) {
         this.boundingVolumeWarnings = validateNodeBoundingVolumes(node);
 
         if (this.boundingVolumeWarnings && this.boundingVolumeWarnings.length) {

--- a/modules/tile-converter/test/i3s-converter/i3s-converter.spec.js
+++ b/modules/tile-converter/test/i3s-converter/i3s-converter.spec.js
@@ -54,7 +54,7 @@ test('tile-converter - Converters#converts 3d-tiles tileset to i3s tileset with 
       inputType: '3dtiles',
       sevenZipExe: 'C:\\Program Files\\7-Zip\\7z.exe',
       egmFilePath: PGM_FILE_PATH,
-      validateBoundingVolumes: true,
+      validate: true,
       token:
         'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJlYWMxMzcyYy0zZjJkLTQwODctODNlNi01MDRkZmMzMjIxOWIiLCJpZCI6OTYyMCwic2NvcGVzIjpbImFzbCIsImFzciIsImdjIl0sImlhdCI6MTU2Mjg2NjI3M30.1FNiClUyk00YH_nWfSGpiQAjR5V2OvREDq1PJ5QMjWQ'
     });


### PR DESCRIPTION
1. Rename `validateBoundingVolumes` -> `validate` flag.
2. Move `validation of refinement type` under `validate` flag to make converter output cleaner.