### PR TITLE
Add support for legacy B3DM file format

### DIFF
--- a/modules/3d-tiles/src/lib/parsers/helpers/parse-3d-tile-tables.js
+++ b/modules/3d-tiles/src/lib/parsers/helpers/parse-3d-tile-tables.js
@@ -8,20 +8,55 @@ const SIZEOF_UINT32 = 4;
 // eslint-disable-next-line max-statements
 export function parse3DTileTablesHeaderSync(tile, arrayBuffer, byteOffset) {
   const view = new DataView(arrayBuffer);
+  let batchLength;
 
   tile.header = tile.header || {};
 
-  tile.header.featureTableJsonByteLength = view.getUint32(byteOffset, true);
+  let featureTableJsonByteLength = view.getUint32(byteOffset, true);
   byteOffset += SIZEOF_UINT32;
 
-  tile.header.featureTableBinaryByteLength = view.getUint32(byteOffset, true);
+  let featureTableBinaryByteLength = view.getUint32(byteOffset, true);
   byteOffset += SIZEOF_UINT32;
 
-  tile.header.batchTableJsonByteLength = view.getUint32(byteOffset, true);
+  let batchTableJsonByteLength = view.getUint32(byteOffset, true);
   byteOffset += SIZEOF_UINT32;
 
-  tile.header.batchTableBinaryByteLength = view.getUint32(byteOffset, true);
+  let batchTableBinaryByteLength = view.getUint32(byteOffset, true);
   byteOffset += SIZEOF_UINT32;
+
+  // First legacy header format - [batchLength] [batchTableByteLength] ('batchTableJsonByteLength': JSON starts with a quotation mark or the glTF magic)
+  // Second legacy format - [batchTableJsonByteLength] [batchTableBinaryByteLength] [batchLength] (Second legacy format is similar as first but here we check 'batchTableBinaryByteLength' instead)
+  // Current header format - [featureTableJsonByteLength] [featureTableBinaryByteLength] [batchTableJsonByteLength] [batchTableBinaryByteLength]
+  // First byte will be 0x22 or 0x67. The minimum uint32 expected is 0x22000000 = 570425344 = 570MB.
+  if (batchTableJsonByteLength >= 570425344) {
+    byteOffset -= SIZEOF_UINT32 * 2;
+    batchLength = featureTableJsonByteLength;
+    batchTableJsonByteLength = featureTableBinaryByteLength;
+    batchTableBinaryByteLength = 0;
+    featureTableJsonByteLength = 0;
+    featureTableBinaryByteLength = 0;
+
+    const deprecationWarning = `This b3dm header is using the legacy format [batchLength] [batchTableByteLength].
+      The new format spec: https://github.com/CesiumGS/3d-tiles/tree/master/specification/TileFormats/Batched3DModel.`;
+    console.warn(deprecationWarning); // eslint-disable-line
+  } else if (batchTableBinaryByteLength >= 570425344) {
+    byteOffset -= SIZEOF_UINT32;
+    batchLength = batchTableJsonByteLength;
+    batchTableJsonByteLength = featureTableJsonByteLength;
+    batchTableBinaryByteLength = featureTableBinaryByteLength;
+    featureTableJsonByteLength = 0;
+    featureTableBinaryByteLength = 0;
+
+    const deprecationWarning = `This b3dm header is using the legacy format [batchTableJsonByteLength] [batchTableBinaryByteLength] [batchLength].
+      The new format spec: https://github.com/CesiumGS/3d-tiles/tree/master/specification/TileFormats/Batched3DModel.`;
+    console.warn(deprecationWarning); // eslint-disable-line
+  }
+
+  tile.header.featureTableJsonByteLength = featureTableJsonByteLength;
+  tile.header.featureTableBinaryByteLength = featureTableBinaryByteLength;
+  tile.header.batchTableJsonByteLength = batchTableJsonByteLength;
+  tile.header.batchTableBinaryByteLength = batchTableBinaryByteLength;
+  tile.header.batchLength = batchLength;
 
   return byteOffset;
 }
@@ -33,10 +68,10 @@ export function parse3DTileTablesSync(tile, arrayBuffer, byteOffset, options) {
 }
 
 function parse3DTileFeatureTable(tile, arrayBuffer, byteOffset, options) {
-  const {featureTableJsonByteLength, featureTableBinaryByteLength} = tile.header;
+  const {featureTableJsonByteLength, featureTableBinaryByteLength, batchLength} = tile.header;
 
   tile.featureTableJson = {
-    BATCH_LENGTH: 0
+    BATCH_LENGTH: batchLength || 0
   };
 
   if (featureTableJsonByteLength > 0) {

--- a/modules/3d-tiles/test/tiles-3d-loader.spec.js
+++ b/modules/3d-tiles/test/tiles-3d-loader.spec.js
@@ -8,6 +8,12 @@ import {DracoLoader} from '@loaders.gl/draco';
 
 const TILESET_URL = '@loaders.gl/3d-tiles/test/data/Batched/BatchedColors/tileset.json';
 const TILE_B3DM_WITH_DRACO_URL = '@loaders.gl/3d-tiles/test/data/143.b3dm';
+const ACTUAL_B3DM =
+  '@loaders.gl/3d-tiles/test/data/Batched/BatchedWithVertexColors/batchedWithVertexColors.b3dm';
+const DEPRECATED_B3DM_1 =
+  '@loaders.gl/3d-tiles/test/data/Batched/BatchedDeprecated1/batchedDeprecated1.b3dm';
+const DEPRECATED_B3DM_2 =
+  '@loaders.gl/3d-tiles/test/data/Batched/BatchedDeprecated2/batchedDeprecated2.b3dm';
 
 test('Tiles3DLoader#Tileset file', async t => {
   const response = await fetchFile(TILESET_URL);
@@ -44,5 +50,35 @@ test('Tiles3DLoader#Tile with GLB w/ Draco bufferviews', async t => {
   t.ok(tile);
   t.ok(tile.gltf);
   t.equals(tile.type, 'b3dm', 'Should parse the correct tiles type.');
+  t.end();
+});
+
+test('Tiles3DLoader#Tile with actual b3dm file', async t => {
+  const response = await fetchFile(ACTUAL_B3DM);
+  const tile = await parse(response, Tiles3DLoader);
+  t.ok(tile);
+  t.ok(tile.batchTableJson);
+  t.deepEqual(tile.batchTableJson.id, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  t.ok(tile.gltf);
+  t.end();
+});
+
+test('Tiles3DLoader#Tile with deprecated 1 b3dm file', async t => {
+  const response = await fetchFile(DEPRECATED_B3DM_1);
+  const tile = await parse(response, Tiles3DLoader);
+  t.ok(tile);
+  t.ok(tile.batchTableJson);
+  t.deepEqual(tile.batchTableJson.id, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  t.ok(tile.gltf);
+  t.end();
+});
+
+test('Tiles3DLoader#Tile with deprecated 2 b3dm file', async t => {
+  const response = await fetchFile(DEPRECATED_B3DM_2);
+  const tile = await parse(response, Tiles3DLoader);
+  t.ok(tile);
+  t.ok(tile.batchTableJson);
+  t.deepEqual(tile.batchTableJson.id, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  t.ok(tile.gltf);
   t.end();
 });


### PR DESCRIPTION
@ibgreen Please take a look at my idea to validate 28 bytes header to detect legacy or wrong `b3dm` file structure.
To be honest it not really sophisticated method to check that but I didn't find any code which was done for such kind of [test](https://github.com/visgl/loaders.gl/blob/master/modules/3d-tiles/test/lib/parsers/batched-model-3d-tile.spec.js#L44). Please let me know if where was such kind of validation earlier.