### PR TITLE
i3s-debug: fix multiple viewports

### DIFF
--- a/examples/experimental/i3s-17-and-debug/helpers/build-minimap-data.js
+++ b/examples/experimental/i3s-17-and-debug/helpers/build-minimap-data.js
@@ -1,6 +1,5 @@
 import {Vector3} from '@math.gl/core';
 import {Ellipsoid} from '@math.gl/geospatial';
-import {OrientedBoundingBox} from '@math.gl/culling';
 
 export function buildMinimapData(tiles) {
   return tiles
@@ -14,9 +13,9 @@ export function buildMinimapData(tiles) {
       let radius = 10; // Set default radius to 10 meters
       if (boundingVolume.radius) {
         radius = boundingVolume.radius;
-      } else if (boundingVolume instanceof OrientedBoundingBox) {
+      } else if (boundingVolume.halfAxes) {
         const boundingShpere = boundingVolume.getBoundingSphere();
-        radius = boundingShpere.radius();
+        radius = boundingShpere.radius;
       }
       return {
         coordinates: cartographicOrigin,

--- a/modules/i3s/src/i3s-content-loader.js
+++ b/modules/i3s/src/i3s-content-loader.js
@@ -15,7 +15,7 @@ export const I3SContentLoader = {
   id: 'i3s-content',
   module: 'i3s',
   // Return "true" after featureIds replaced with segmentationData in I3S-picking-app
-  worker: false,
+  worker: true,
   version: VERSION,
   mimeTypes: ['application/octet-stream'],
   parse,

--- a/modules/i3s/src/i3s-content-loader.js
+++ b/modules/i3s/src/i3s-content-loader.js
@@ -14,7 +14,6 @@ export const I3SContentLoader = {
   name: 'I3S Content (Indexed Scene Layers)',
   id: 'i3s-content',
   module: 'i3s',
-  // Return "true" after featureIds replaced with segmentationData in I3S-picking-app
   worker: true,
   version: VERSION,
   mimeTypes: ['application/octet-stream'],


### PR DESCRIPTION
- Switch i3s-content-loader worker on;
- Fixes: `TypeError: t.getBoundingSphere(...).radius is not a function`