### PR TITLE
Chore(Arrow): Upgrade apache-arrow to 4.0.0

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -83,6 +83,10 @@ _Benchmarks ran using scripts on a 2012 MacBook Pro, 2.3 GHz Intel Core i7, 8 GB
 
 - New loaders: `GPXLoader` and `TCXLoader` to parse common formats for recorded GPS tracks.
 
+**@loaders.gl/arrow**
+
+- Upgraded `apache-arrow` version to 4.0.0
+
 ## v2.3
 
 Release Date: October 12, 2020

--- a/modules/arrow/package.json
+++ b/modules/arrow/package.json
@@ -38,6 +38,6 @@
     "@loaders.gl/core": "3.0.0-alpha.14",
     "@loaders.gl/loader-utils": "3.0.0-alpha.14",
     "@loaders.gl/tables": "3.0.0-alpha.14",
-    "apache-arrow": "^0.17.0"
+    "apache-arrow": "^4.0.0"
   }
 }

--- a/modules/arrow/package.json
+++ b/modules/arrow/package.json
@@ -35,9 +35,9 @@
     "build-worker": "webpack --entry ./src/workers/arrow-worker.js --output ./dist/arrow-worker.js --config ../../scripts/webpack/worker.js"
   },
   "dependencies": {
-    "@apache-arrow/es5-cjs": "^4.0.0",
     "@loaders.gl/core": "3.0.0-alpha.14",
     "@loaders.gl/loader-utils": "3.0.0-alpha.14",
-    "@loaders.gl/tables": "3.0.0-alpha.14"
+    "@loaders.gl/tables": "3.0.0-alpha.14",
+    "apache-arrow": "^4.0.0"
   }
 }

--- a/modules/arrow/package.json
+++ b/modules/arrow/package.json
@@ -35,9 +35,9 @@
     "build-worker": "webpack --entry ./src/workers/arrow-worker.js --output ./dist/arrow-worker.js --config ../../scripts/webpack/worker.js"
   },
   "dependencies": {
+    "@apache-arrow/es5-cjs": "^4.0.0",
     "@loaders.gl/core": "3.0.0-alpha.14",
     "@loaders.gl/loader-utils": "3.0.0-alpha.14",
-    "@loaders.gl/tables": "3.0.0-alpha.14",
-    "apache-arrow": "^4.0.0"
+    "@loaders.gl/tables": "3.0.0-alpha.14"
   }
 }

--- a/modules/arrow/src/lib/arrow-table-batch.js
+++ b/modules/arrow/src/lib/arrow-table-batch.js
@@ -1,4 +1,4 @@
-import {Schema, Field, RecordBatch, Float32Vector, Float32} from '@apache-arrow/es5-cjs';
+import {Schema, Field, RecordBatch, Float32Vector, Float32} from 'apache-arrow';
 import {ColumnarTableBatch} from '@loaders.gl/tables';
 
 export default class ArrowTableBatch extends ColumnarTableBatch {

--- a/modules/arrow/src/lib/arrow-table-batch.js
+++ b/modules/arrow/src/lib/arrow-table-batch.js
@@ -1,4 +1,4 @@
-import {Schema, Field, RecordBatch, Float32Vector, Float32} from 'apache-arrow';
+import {Schema, Field, RecordBatch, Float32Vector, Float32} from '@apache-arrow/es5-cjs';
 import {ColumnarTableBatch} from '@loaders.gl/tables';
 
 export default class ArrowTableBatch extends ColumnarTableBatch {

--- a/modules/arrow/src/lib/arrow-table-batch.js
+++ b/modules/arrow/src/lib/arrow-table-batch.js
@@ -31,7 +31,7 @@ function getArrowSchema(schema) {
     if (field.type === Float32Array) {
       const metadata = field; // just store the original field as metadata
       // arrow: new Field(name, nullable, metadata)
-      const arrowField = new Field(field.name, Float32, field.nullable, metadata);
+      const arrowField = new Field(field.name, new Float32(), field.nullable, metadata);
       arrowFields.push(arrowField);
     }
   }

--- a/modules/arrow/src/lib/arrow-table-batch.js
+++ b/modules/arrow/src/lib/arrow-table-batch.js
@@ -1,4 +1,4 @@
-import {Schema, Field, RecordBatch, Float32Vector, Float32} from 'apache-arrow/Arrow.es5.min';
+import {Schema, Field, RecordBatch, Float32Vector, Float32} from 'apache-arrow';
 import {ColumnarTableBatch} from '@loaders.gl/tables';
 
 export default class ArrowTableBatch extends ColumnarTableBatch {

--- a/modules/arrow/src/lib/encode-arrow.js
+++ b/modules/arrow/src/lib/encode-arrow.js
@@ -1,4 +1,4 @@
-import {Table, FloatVector, DateVector} from 'apache-arrow/Arrow.es5.min';
+import {Table, FloatVector, DateVector} from 'apache-arrow';
 import {VECTOR_TYPES} from './constants';
 
 export function encodeArrowSync(data, options) {

--- a/modules/arrow/src/lib/encode-arrow.js
+++ b/modules/arrow/src/lib/encode-arrow.js
@@ -1,4 +1,4 @@
-import {Table, FloatVector, DateVector} from '@apache-arrow/es5-cjs';
+import {Table, FloatVector, DateVector} from 'apache-arrow';
 import {VECTOR_TYPES} from './constants';
 
 export function encodeArrowSync(data, options) {

--- a/modules/arrow/src/lib/encode-arrow.js
+++ b/modules/arrow/src/lib/encode-arrow.js
@@ -1,4 +1,4 @@
-import {Table, FloatVector, DateVector} from 'apache-arrow';
+import {Table, FloatVector, DateVector} from '@apache-arrow/es5-cjs';
 import {VECTOR_TYPES} from './constants';
 
 export function encodeArrowSync(data, options) {

--- a/modules/arrow/src/lib/parse-arrow-in-batches.js
+++ b/modules/arrow/src/lib/parse-arrow-in-batches.js
@@ -1,5 +1,5 @@
 // TODO - this import defeats the sophisticated typescript checking in ArrowJS
-import {RecordBatchReader} from 'apache-arrow/Arrow.es5.min';
+import {RecordBatchReader} from 'apache-arrow';
 // import {isIterable} from '@loaders.gl/core';
 
 /**

--- a/modules/arrow/src/lib/parse-arrow-in-batches.js
+++ b/modules/arrow/src/lib/parse-arrow-in-batches.js
@@ -1,5 +1,5 @@
 // TODO - this import defeats the sophisticated typescript checking in ArrowJS
-import {RecordBatchReader} from '@apache-arrow/es5-cjs';
+import {RecordBatchReader} from 'apache-arrow';
 // import {isIterable} from '@loaders.gl/core';
 
 /**

--- a/modules/arrow/src/lib/parse-arrow-in-batches.js
+++ b/modules/arrow/src/lib/parse-arrow-in-batches.js
@@ -1,5 +1,5 @@
 // TODO - this import defeats the sophisticated typescript checking in ArrowJS
-import {RecordBatchReader} from 'apache-arrow';
+import {RecordBatchReader} from '@apache-arrow/es5-cjs';
 // import {isIterable} from '@loaders.gl/core';
 
 /**

--- a/modules/arrow/src/lib/parse-arrow-sync.js
+++ b/modules/arrow/src/lib/parse-arrow-sync.js
@@ -1,4 +1,4 @@
-import {Table} from 'apache-arrow/Arrow.es5.min';
+import {Table} from 'apache-arrow';
 
 // Parses arrow to a columnar table
 export default function parseArrowSync(arrayBuffer, options) {

--- a/modules/arrow/src/lib/parse-arrow-sync.js
+++ b/modules/arrow/src/lib/parse-arrow-sync.js
@@ -1,4 +1,4 @@
-import {Table} from '@apache-arrow/es5-cjs';
+import {Table} from 'apache-arrow';
 
 // Parses arrow to a columnar table
 export default function parseArrowSync(arrayBuffer, options) {

--- a/modules/arrow/src/lib/parse-arrow-sync.js
+++ b/modules/arrow/src/lib/parse-arrow-sync.js
@@ -1,4 +1,4 @@
-import {Table} from 'apache-arrow';
+import {Table} from '@apache-arrow/es5-cjs';
 
 // Parses arrow to a columnar table
 export default function parseArrowSync(arrayBuffer, options) {

--- a/modules/csv/test/csv-loader-arrow.spec.js
+++ b/modules/csv/test/csv-loader-arrow.spec.js
@@ -2,7 +2,7 @@ import test from 'tape-promise/tape';
 import {loadInBatches, isIterator, isAsyncIterable} from '@loaders.gl/core';
 import {CSVLoader} from '@loaders.gl/csv';
 import {ArrowTableBatch} from '@loaders.gl/arrow';
-import {RecordBatch} from 'apache-arrow/Arrow.es5.min';
+import {RecordBatch} from 'apache-arrow';
 // import {Schema, Field, RecordBatch, Float32Vector} from 'apache-arrow';
 
 // Small CSV Sample Files

--- a/modules/csv/test/csv-loader-arrow.spec.js
+++ b/modules/csv/test/csv-loader-arrow.spec.js
@@ -2,7 +2,7 @@ import test from 'tape-promise/tape';
 import {loadInBatches, isIterator, isAsyncIterable} from '@loaders.gl/core';
 import {CSVLoader} from '@loaders.gl/csv';
 import {ArrowTableBatch} from '@loaders.gl/arrow';
-import {RecordBatch} from 'apache-arrow';
+import {RecordBatch} from '@apache-arrow/es5-cjs';
 // import {Schema, Field, RecordBatch, Float32Vector} from 'apache-arrow';
 
 // Small CSV Sample Files

--- a/modules/csv/test/csv-loader-arrow.spec.js
+++ b/modules/csv/test/csv-loader-arrow.spec.js
@@ -2,7 +2,7 @@ import test from 'tape-promise/tape';
 import {loadInBatches, isIterator, isAsyncIterable} from '@loaders.gl/core';
 import {CSVLoader} from '@loaders.gl/csv';
 import {ArrowTableBatch} from '@loaders.gl/arrow';
-import {RecordBatch} from '@apache-arrow/es5-cjs';
+import {RecordBatch} from 'apache-arrow';
 // import {Schema, Field, RecordBatch, Float32Vector} from 'apache-arrow';
 
 // Small CSV Sample Files

--- a/modules/gis/test/geojson-to-binary.spec.js
+++ b/modules/gis/test/geojson-to-binary.spec.js
@@ -393,19 +393,18 @@ test('gis#geojson-to-binary 3D features', async t => {
 // eslint-disable-next-line complexity
 test('gis#geojson-to-binary position, featureId data types', async t => {
   const response = await fetchFile(FEATURES_2D);
-  let {features} = await response.json();
+  const {features} = await response.json();
 
   // Duplicate features so that there are >65535 total features but <65535 of
   // any one geometry type
-  // Dividing by 6 means enough coordinates to test featureIds and path/polygon indices
-  const duplicateCount = Math.ceil(65535 / 6);
-  const origLength = features.length;
+  const duplicateCount = 65535 * 2;
+  const testFeatures = [];
   for (let i = 0; i < duplicateCount; i++) {
-    features = features.concat(features.slice(0, origLength));
+    testFeatures.push(features[i % features.length]);
   }
 
   const options = {PositionDataType: Float64Array};
-  const {points, lines, polygons} = geojsonToBinary(features, options);
+  const {points, lines, polygons} = geojsonToBinary(testFeatures, options);
 
   t.ok(points && points.positions.value instanceof Float64Array);
   t.ok(points && points.globalFeatureIds.value instanceof Uint32Array);

--- a/modules/tables/src/lib/table/table-types.d.ts
+++ b/modules/tables/src/lib/table/table-types.d.ts
@@ -1,4 +1,4 @@
-export type Field = Date | Float32Array | String;
+export type Field = any;
 
 export type Schema = {
   [key: string]: Field;
@@ -8,7 +8,7 @@ export type Batch = {
   data: any;
   schema: Schema;
   length: number;
-  bytesUsed: number;
+  bytesUsed?: number;
 };
 
 export interface IBatchBuilder {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "allowSyntheticDefaultImports": true,
     "noEmit": true,
     "resolveJsonModule": true,
+    "skipLibCheck": true,
     "baseUrl": ".",
     "paths": {
       "@loaders.gl/core/*": ["modules/core/src/*"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,22 @@
 # yarn lockfile v1
 
 
+"@apache-arrow/es5-cjs@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@apache-arrow/es5-cjs/-/es5-cjs-4.0.0.tgz#8bceceb6c6a917bfb55c399e40f61b283c1357fa"
+  integrity sha512-9Ce6pRJGfsvt3JpESdGQSltHw1Vvk2lLxHchoDRXQvTvuTohF+DA9bSkTua0I07OjnCWgu78PQ71PC9tx+NqzQ==
+  dependencies:
+    "@types/flatbuffers" "^1.10.0"
+    "@types/node" "^14.14.37"
+    "@types/text-encoding-utf-8" "^1.0.1"
+    command-line-args "5.1.1"
+    command-line-usage "6.1.1"
+    flatbuffers "1.12.0"
+    json-bignum "^0.0.3"
+    pad-left "^2.1.0"
+    text-encoding-utf-8 "^1.0.2"
+    tslib "^2.2.0"
+
 "@babel/cli@^7.8.7":
   version "7.13.10"
   resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.13.10.tgz#3a9254cbe806639c8ca4ebd49ebe54b4267b88c9"
@@ -2540,22 +2556,6 @@ anymatch@~3.1.1:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
-
-apache-arrow@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/apache-arrow/-/apache-arrow-4.0.0.tgz#29616f5b5959cf0b0a6e49f8aa060ea53d4429ba"
-  integrity sha512-Y1o9UfCVhh7IB+RPVbCx7SgF51SjvT9ZKxCtFU1eaqleFZNxj89mH2gvQia4uA197x158XDemTz9O+Rrv+f5tg==
-  dependencies:
-    "@types/flatbuffers" "^1.10.0"
-    "@types/node" "^14.14.37"
-    "@types/text-encoding-utf-8" "^1.0.1"
-    command-line-args "5.1.1"
-    command-line-usage "6.1.1"
-    flatbuffers "1.12.0"
-    json-bignum "^0.0.3"
-    pad-left "^2.1.0"
-    text-encoding-utf-8 "^1.0.2"
-    tslib "^2.2.0"
 
 append-transform@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,22 +2,6 @@
 # yarn lockfile v1
 
 
-"@apache-arrow/es5-cjs@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@apache-arrow/es5-cjs/-/es5-cjs-4.0.0.tgz#8bceceb6c6a917bfb55c399e40f61b283c1357fa"
-  integrity sha512-9Ce6pRJGfsvt3JpESdGQSltHw1Vvk2lLxHchoDRXQvTvuTohF+DA9bSkTua0I07OjnCWgu78PQ71PC9tx+NqzQ==
-  dependencies:
-    "@types/flatbuffers" "^1.10.0"
-    "@types/node" "^14.14.37"
-    "@types/text-encoding-utf-8" "^1.0.1"
-    command-line-args "5.1.1"
-    command-line-usage "6.1.1"
-    flatbuffers "1.12.0"
-    json-bignum "^0.0.3"
-    pad-left "^2.1.0"
-    text-encoding-utf-8 "^1.0.2"
-    tslib "^2.2.0"
-
 "@babel/cli@^7.8.7":
   version "7.13.10"
   resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.13.10.tgz#3a9254cbe806639c8ca4ebd49ebe54b4267b88c9"
@@ -2556,6 +2540,22 @@ anymatch@~3.1.1:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+apache-arrow@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/apache-arrow/-/apache-arrow-4.0.0.tgz#29616f5b5959cf0b0a6e49f8aa060ea53d4429ba"
+  integrity sha512-Y1o9UfCVhh7IB+RPVbCx7SgF51SjvT9ZKxCtFU1eaqleFZNxj89mH2gvQia4uA197x158XDemTz9O+Rrv+f5tg==
+  dependencies:
+    "@types/flatbuffers" "^1.10.0"
+    "@types/node" "^14.14.37"
+    "@types/text-encoding-utf-8" "^1.0.1"
+    command-line-args "5.1.1"
+    command-line-usage "6.1.1"
+    flatbuffers "1.12.0"
+    json-bignum "^0.0.3"
+    pad-left "^2.1.0"
+    text-encoding-utf-8 "^1.0.2"
+    tslib "^2.2.0"
 
 append-transform@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2120,7 +2120,7 @@
   resolved "https://registry.yarnpkg.com/@types/crypto-js/-/crypto-js-4.0.1.tgz#3a4bd24518b0e6c5940da4e2659eeb2ef0806963"
   integrity sha512-6+OPzqhKX/cx5xh+yO8Cqg3u3alrkhoxhE5ZOdSEv0DOzJ13lwJ6laqGU0Kv6+XDMFmlnGId04LtY22PsFLQUw==
 
-"@types/flatbuffers@^1.9.1":
+"@types/flatbuffers@^1.10.0":
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/@types/flatbuffers/-/flatbuffers-1.10.0.tgz#aa74e30ffdc86445f2f060e1808fc9d56b5603ba"
   integrity sha512-7btbphLrKvo5yl/5CC2OCxUSMx1wV1wvGT1qDXkSt7yi00/YW7E8k6qzXqJHsp+WU0eoG7r6MTQQXI9lIvd0qA==
@@ -2158,10 +2158,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.33.tgz#9e4f8c64345522e4e8ce77b334a8aaa64e2b6c78"
   integrity sha512-oJqcTrgPUF29oUP8AsUqbXGJNuPutsetaa9kTQAQce5Lx5dTYWV02ScBiT/k1BX/Z7pKeqedmvp39Wu4zR7N7g==
 
-"@types/node@^12.0.4":
-  version "12.20.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.5.tgz#4ca82a766f05c359fd6c77505007e5a272f4bb9b"
-  integrity sha512-5Oy7tYZnu3a4pnJ//d4yVvOImExl4Vtwf0D40iKUlU+XlUsyV9iyFWyCFlwy489b72FMAik/EFwRkNLjjOdSPg==
+"@types/node@^14.14.37":
+  version "14.17.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.0.tgz#3ba770047723b3eeb8dc9fca02cce8a7fb6378da"
+  integrity sha512-w8VZUN/f7SSbvVReb9SWp6cJFevxb4/nkG65yLAya//98WgocKm5PLDAtSs5CtJJJM+kHmJjO/6mmYW4MHShZA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -2541,21 +2541,21 @@ anymatch@~3.1.1:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-apache-arrow@^0.17.0:
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/apache-arrow/-/apache-arrow-0.17.0.tgz#8f976fc6ffc18e34b15a0b327061534f6c2a2494"
-  integrity sha512-cbgSx/tzGgnC1qeUySXnAsSsoxhDykNINqr1D3U5pRwf0/Q0ztVccV3/VRW6gUR+lcOFawk6FtyYwmU+KjglbQ==
+apache-arrow@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/apache-arrow/-/apache-arrow-4.0.0.tgz#29616f5b5959cf0b0a6e49f8aa060ea53d4429ba"
+  integrity sha512-Y1o9UfCVhh7IB+RPVbCx7SgF51SjvT9ZKxCtFU1eaqleFZNxj89mH2gvQia4uA197x158XDemTz9O+Rrv+f5tg==
   dependencies:
-    "@types/flatbuffers" "^1.9.1"
-    "@types/node" "^12.0.4"
+    "@types/flatbuffers" "^1.10.0"
+    "@types/node" "^14.14.37"
     "@types/text-encoding-utf-8" "^1.0.1"
-    command-line-args "5.0.2"
-    command-line-usage "5.0.5"
-    flatbuffers "1.11.0"
+    command-line-args "5.1.1"
+    command-line-usage "6.1.1"
+    flatbuffers "1.12.0"
     json-bignum "^0.0.3"
     pad-left "^2.1.0"
     text-encoding-utf-8 "^1.0.2"
-    tslib "^1.9.3"
+    tslib "^2.2.0"
 
 append-transform@^2.0.0:
   version "2.0.0"
@@ -2623,14 +2623,6 @@ argparse@^1.0.10, argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-argv-tools@^0.1.1:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/argv-tools/-/argv-tools-0.1.2.tgz#fc4918a70775b8cc5f8296fa0cfea137bd8a8229"
-  integrity sha512-wxqoymY0BEu9NblZVQiOTOAiJUjPhaa/kbNMjC2h6bnrmUSgnxKgWJo3lzXvi3bHJRwXyqK/dHzMlZVRT89Cxg==
-  dependencies:
-    array-back "^2.0.0"
-    find-replace "^2.0.1"
-
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
@@ -2646,12 +2638,15 @@ arr-union@^3.1.0:
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
 
-array-back@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/array-back/-/array-back-2.0.0.tgz#6877471d51ecc9c9bfa6136fb6c7d5fe69748022"
-  integrity sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==
-  dependencies:
-    typical "^2.6.1"
+array-back@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-3.1.0.tgz#b8859d7a508871c9a7b2cf42f99428f65e96bfb0"
+  integrity sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==
+
+array-back@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-4.0.2.tgz#8004e999a6274586beeb27342168652fdb89fa1e"
+  integrity sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==
 
 array-differ@^2.0.3:
   version "2.1.0"
@@ -3652,26 +3647,25 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-command-line-args@5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/command-line-args/-/command-line-args-5.0.2.tgz#c4e56b016636af1323cf485aa25c3cb203dfbbe4"
-  integrity sha512-/qPcbL8zpqg53x4rAaqMFlRV4opN3pbla7I7k9x8kyOBMQoGT6WltjN6sXZuxOXw6DgdK7Ad+ijYS5gjcr7vlA==
+command-line-args@5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/command-line-args/-/command-line-args-5.1.1.tgz#88e793e5bb3ceb30754a86863f0401ac92fd369a"
+  integrity sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==
   dependencies:
-    argv-tools "^0.1.1"
-    array-back "^2.0.0"
-    find-replace "^2.0.1"
+    array-back "^3.0.1"
+    find-replace "^3.0.0"
     lodash.camelcase "^4.3.0"
-    typical "^2.6.1"
+    typical "^4.0.0"
 
-command-line-usage@5.0.5:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/command-line-usage/-/command-line-usage-5.0.5.tgz#5f25933ffe6dedd983c635d38a21d7e623fda357"
-  integrity sha512-d8NrGylA5oCXSbGoKz05FkehDAzSmIm4K03S5VDh4d5lZAtTWfc3D1RuETtuQCn8129nYfJfDdF7P/lwcz1BlA==
+command-line-usage@6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/command-line-usage/-/command-line-usage-6.1.1.tgz#c908e28686108917758a49f45efb4f02f76bc03f"
+  integrity sha512-F59pEuAR9o1SF/bD0dQBDluhpT4jJQNWUHEuVBqpDmCUo6gPjCi+m9fCWnWZVR/oG6cMTUms4h+3NPl74wGXvA==
   dependencies:
-    array-back "^2.0.0"
-    chalk "^2.4.1"
-    table-layout "^0.4.3"
-    typical "^2.6.1"
+    array-back "^4.0.1"
+    chalk "^2.4.2"
+    table-layout "^1.0.1"
+    typical "^5.2.0"
 
 commander@2, commander@^2.18.0, commander@^2.20.0:
   version "2.20.3"
@@ -5332,13 +5326,12 @@ find-cache-dir@^3.2.0, find-cache-dir@^3.3.1:
     make-dir "^3.0.2"
     pkg-dir "^4.1.0"
 
-find-replace@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/find-replace/-/find-replace-2.0.1.tgz#6d9683a7ca20f8f9aabeabad07e4e2580f528550"
-  integrity sha512-LzDo3Fpa30FLIBsh6DCDnMN1KW2g4QKkqKmejlImgWY67dDFPX/x9Kh/op/GK522DchQXEvDi/wD48HKW49XOQ==
+find-replace@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-replace/-/find-replace-3.0.0.tgz#3e7e23d3b05167a76f770c9fbd5258b0def68c38"
+  integrity sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==
   dependencies:
-    array-back "^2.0.0"
-    test-value "^3.0.0"
+    array-back "^3.0.1"
 
 find-up@^1.0.0:
   version "1.1.2"
@@ -5388,11 +5381,6 @@ flat-cache@^2.0.1:
     flatted "^2.0.0"
     rimraf "2.6.3"
     write "1.0.3"
-
-flatbuffers@1.11.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/flatbuffers/-/flatbuffers-1.11.0.tgz#90a47e584dd7851ad7a913f5a0ee99c1d76ce59f"
-  integrity sha512-0PqFKtXI4MjxomI7jO4g5XfLPm/15g2R+5WGCHBGYGh0ihQiypnHlJ6bMmkkrAe0GzZ4d7PDAfCONKIPUxNF+A==
 
 flatbuffers@1.12.0:
   version "1.12.0"
@@ -7294,11 +7282,6 @@ lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
   integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
-
-lodash.padend@^4.6.1:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.padend/-/lodash.padend-4.6.1.tgz#53ccba047d06e158d311f45da625f4e49e6f166e"
-  integrity sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -9469,10 +9452,10 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
-reduce-flatten@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/reduce-flatten/-/reduce-flatten-1.0.1.tgz#258c78efd153ddf93cb561237f61184f3696e327"
-  integrity sha1-JYx479FT3fk8tWEjf2EYTzaW4yc=
+reduce-flatten@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/reduce-flatten/-/reduce-flatten-2.0.0.tgz#734fd84e65f375d7ca4465c69798c25c9d10ae27"
+  integrity sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==
 
 regenerate-unicode-properties@^8.2.0:
   version "8.2.0"
@@ -10640,16 +10623,15 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-table-layout@^0.4.3:
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/table-layout/-/table-layout-0.4.5.tgz#d906de6a25fa09c0c90d1d08ecd833ecedcb7378"
-  integrity sha512-zTvf0mcggrGeTe/2jJ6ECkJHAQPIYEwDoqsiqBjI24mvRmQbInK5jq33fyypaCBxX08hMkfmdOqj6haT33EqWw==
+table-layout@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/table-layout/-/table-layout-1.0.2.tgz#c4038a1853b0136d63365a734b6931cf4fad4a04"
+  integrity sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==
   dependencies:
-    array-back "^2.0.0"
+    array-back "^4.0.1"
     deep-extend "~0.6.0"
-    lodash.padend "^4.6.1"
-    typical "^2.6.1"
-    wordwrapjs "^3.0.0"
+    typical "^5.2.0"
+    wordwrapjs "^4.0.0"
 
 table@^5.2.3:
   version "5.4.6"
@@ -10795,14 +10777,6 @@ test-exclude@^6.0.0:
     "@istanbuljs/schema" "^0.1.2"
     glob "^7.1.4"
     minimatch "^3.0.4"
-
-test-value@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/test-value/-/test-value-3.0.0.tgz#9168c062fab11a86b8d444dd968bb4b73851ce92"
-  integrity sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==
-  dependencies:
-    array-back "^2.0.0"
-    typical "^2.6.1"
 
 text-encoding-utf-8@^1.0.2:
   version "1.0.2"
@@ -11008,10 +10982,15 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
+  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
 tty-browserify@0.0.0:
   version "0.0.0"
@@ -11087,10 +11066,15 @@ typescript@^4.2.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
   integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
 
-typical@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/typical/-/typical-2.6.1.tgz#5c080e5d661cbbe38259d2e70a3c7253e873881d"
-  integrity sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=
+typical@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/typical/-/typical-4.0.0.tgz#cbeaff3b9d7ae1e2bbfaf5a4e6f11eccfde94fc4"
+  integrity sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==
+
+typical@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/typical/-/typical-5.2.0.tgz#4daaac4f2b5315460804f0acf6cb69c52bb93066"
+  integrity sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==
 
 uglify-js@3.4.x:
   version "3.4.10"
@@ -11628,13 +11612,13 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
-wordwrapjs@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/wordwrapjs/-/wordwrapjs-3.0.0.tgz#c94c372894cadc6feb1a66bff64e1d9af92c5d1e"
-  integrity sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==
+wordwrapjs@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/wordwrapjs/-/wordwrapjs-4.0.1.tgz#d9790bccfb110a0fc7836b5ebce0937b37a8b98f"
+  integrity sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==
   dependencies:
-    reduce-flatten "^1.0.1"
-    typical "^2.6.1"
+    reduce-flatten "^2.0.0"
+    typical "^5.2.0"
 
 worker-farm@^1.7.0:
   version "1.7.0"


### PR DESCRIPTION
Upgrades `apache-arrow` to the latest `4.0.0` version, given that we have been sitting on the old `0.17.1` version for a while now.