### PR TITLE
Extract earcut

### DIFF
--- a/modules/mvt/package.json
+++ b/modules/mvt/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@loaders.gl/gis": "3.0.0-alpha.15",
     "@loaders.gl/loader-utils": "3.0.0-alpha.15",
-    "@math.gl/polygon": "^3.3.0",
+    "@math.gl/polygon": "^3.5.0-alpha.1",
     "pbf": "^3.2.1"
   },
   "devDependencies": {

--- a/modules/mvt/package.json
+++ b/modules/mvt/package.json
@@ -34,7 +34,6 @@
     "@loaders.gl/gis": "3.0.0-alpha.15",
     "@loaders.gl/loader-utils": "3.0.0-alpha.15",
     "@math.gl/polygon": "^3.3.0",
-    "earcut": "^2.0.6",
     "pbf": "^3.2.1"
   },
   "devDependencies": {

--- a/modules/mvt/src/lib/binary-vector-tile/features-to-binary.js
+++ b/modules/mvt/src/lib/binary-vector-tile/features-to-binary.js
@@ -240,6 +240,7 @@ function handlePolygon(geometry, polygons, indexMap, coordLength, properties) {
     const startPosition = indexMap.polygonPosition;
     polygons.polygonIndices[indexMap.polygonObject++] = startPosition;
 
+    const areas = geometry.areas[l];
     const lines = geometry.lines[l];
     const nextLines = geometry.lines[l + 1];
 
@@ -257,14 +258,15 @@ function handlePolygon(geometry, polygons, indexMap, coordLength, properties) {
       indexMap.polygonPosition += (end - start) / coordLength;
     }
 
-    triangulatePolygon(polygons, lines, startPosition, indexMap.polygonPosition, coordLength);
+    const endPosition = indexMap.polygonPosition;
+    triangulatePolygon(polygons, areas, lines, {startPosition, endPosition, coordLength});
   }
 }
 
 /**
  * Triangulate polygon using earcut
  */
-function triangulatePolygon(polygons, lines, startPosition, endPosition, coordLength) {
+function triangulatePolygon(polygons, areas, lines, {startPosition, endPosition, coordLength}) {
   const start = startPosition * coordLength;
   const end = endPosition * coordLength;
 
@@ -276,7 +278,7 @@ function triangulatePolygon(polygons, lines, startPosition, endPosition, coordLe
   const holes = lines.slice(1).map(n => (n - offset) / coordLength);
 
   // Compute triangulation
-  const indices = earcut(polygonPositions, holes, coordLength);
+  const indices = earcut(polygonPositions, holes, coordLength, areas);
 
   // Indices returned by triangulation are relative to start
   // of polygon, so we need to offset

--- a/modules/mvt/src/lib/binary-vector-tile/features-to-binary.js
+++ b/modules/mvt/src/lib/binary-vector-tile/features-to-binary.js
@@ -1,5 +1,6 @@
 // @ts-nocheck
-import earcut from 'earcut';
+import {earcut} from '@math.gl/polygon';
+
 /**
  * Convert binary features to flat binary arrays. Similar to
  * `geojsonToBinary` helper function, except that it expects

--- a/modules/mvt/src/lib/binary-vector-tile/vector-tile-feature.d.ts
+++ b/modules/mvt/src/lib/binary-vector-tile/vector-tile-feature.d.ts
@@ -25,7 +25,7 @@ export default class VectorTileFeature {
   constructor(pbf: Protobuf, end, extent, keys, values, firstPassData);
 
   loadGeometry(); any;
-  classifyRings(geom: {data: [number], lines: [number]}): [[number]];
+  classifyRings(geom: {data: [number], lines: [number]}): {data: [number], areas: [[number]], lines: [[number]]};
   toBinaryCoordinates(options: {x: number, y: number, z: number} | (([number], VectorTileFeature) => void)): object;
 }
 

--- a/modules/mvt/src/lib/binary-vector-tile/vector-tile-feature.js
+++ b/modules/mvt/src/lib/binary-vector-tile/vector-tile-feature.js
@@ -127,18 +127,18 @@ export default class VectorTileFeature {
         break;
 
       case 3: // Polygon
-        const rings = classifyRings(geom);
-        this._firstPassData.polygonFeaturesCount++;
-        this._firstPassData.polygonObjectsCount += rings.length;
+        classifyRings(geom);
 
-        for (const lines of rings) {
+        // Unlike Point & LineString geom.lines is a 2D array, thanks
+        // to the classifyRings method
+        this._firstPassData.polygonFeaturesCount++;
+        this._firstPassData.polygonObjectsCount += geom.lines.length;
+
+        for (const lines of geom.lines) {
           this._firstPassData.polygonRingsCount += lines.length;
         }
         this._firstPassData.polygonPositionsCount += geom.data.length / coordLength;
 
-        // Unlike Point & LineString geom.lines is a 2D array, thanks
-        // to the classifyRings method
-        geom.lines = rings;
         break;
     }
 
@@ -189,7 +189,10 @@ export default class VectorTileFeature {
 function classifyRings(geom) {
   const len = geom.lines.length;
 
-  if (len <= 1) return [geom.lines];
+  if (len <= 1) {
+    geom.lines = [geom.lines];
+    return;
+  }
 
   const polygons = [];
   let polygon;
@@ -230,7 +233,7 @@ function classifyRings(geom) {
   }
   if (polygon) polygons.push(polygon);
 
-  return polygons;
+  geom.lines = polygons;
 }
 
 // All code below is unchanged from the original Mapbox implemenation

--- a/modules/mvt/src/lib/binary-vector-tile/vector-tile-feature.js
+++ b/modules/mvt/src/lib/binary-vector-tile/vector-tile-feature.js
@@ -191,10 +191,13 @@ function classifyRings(geom) {
 
   if (len <= 1) {
     geom.lines = [geom.lines];
+    geom.areas = [[getPolygonSignedArea(geom.data)]];
     return;
   }
 
+  const areas = [];
   const polygons = [];
+  let ringAreas;
   let polygon;
   let ccw;
   let offset = 0;
@@ -224,15 +227,22 @@ function classifyRings(geom) {
     if (ccw === undefined) ccw = area < 0;
 
     if (ccw === area < 0) {
-      if (polygon) polygons.push(polygon);
+      if (polygon) {
+        areas.push(ringAreas);
+        polygons.push(polygon);
+      }
       polygon = [startIndex];
+      ringAreas = [area];
     } else {
       // @ts-ignore
+      ringAreas.push(area);
       polygon.push(startIndex);
     }
   }
+  if (ringAreas) areas.push(ringAreas);
   if (polygon) polygons.push(polygon);
 
+  geom.areas = areas;
   geom.lines = polygons;
 }
 

--- a/modules/mvt/test/mvt-loader.spec.js
+++ b/modules/mvt/test/mvt-loader.spec.js
@@ -276,25 +276,25 @@ test('Triangulation is supported', async t => {
 
 test('Rings - single ring', async t => {
   const geom = {...ringsSingleRing};
-  classifyRings(geom);
-  t.deepEqual(geom.areas, [[-0.02624368667602539]]);
-  t.deepEqual(geom.lines, [[0]]);
+  const classified = classifyRings(geom);
+  t.deepEqual(classified.areas, [[-0.02624368667602539]]);
+  t.deepEqual(classified.lines, [[0]]);
   t.end();
 });
 
 test('Rings - ring and hole', async t => {
   const geom = {...ringsRingAndHole};
-  classifyRings(geom);
-  t.deepEqual(geom.areas, [[-0.02624368667602539, 0.001363515853881836]]);
-  t.deepEqual(geom.lines, [[0, 10]]);
+  const classified = classifyRings(geom);
+  t.deepEqual(classified.areas, [[-0.02624368667602539, 0.001363515853881836]]);
+  t.deepEqual(classified.lines, [[0, 10]]);
   t.end();
 });
 
 test('Rings - two rings', async t => {
   const geom = {...ringsTwoRings};
-  classifyRings(geom);
-  t.deepEqual(geom.areas, [[-0.02624368667602539], [-0.001363515853881836]]);
-  t.deepEqual(geom.lines, [[0], [10]]);
+  const classified = classifyRings(geom);
+  t.deepEqual(classified.areas, [[-0.02624368667602539], [-0.001363515853881836]]);
+  t.deepEqual(classified.lines, [[0], [10]]);
   t.end();
 });
 
@@ -303,9 +303,9 @@ test('Rings - zero sized hole', async t => {
   // verify that the data array is shortened
   const geom = {...ringsZeroSizeHole};
   t.equal(geom.data.length, 20);
-  classifyRings(geom);
-  t.deepEqual(geom.areas, [[-0.44582176208496094]]);
-  t.deepEqual(geom.lines, [[0]]);
-  t.equal(geom.data.length, 12);
+  const classified = classifyRings(geom);
+  t.deepEqual(classified.areas, [[-0.44582176208496094]]);
+  t.deepEqual(classified.lines, [[0]]);
+  t.equal(classified.data.length, 12);
   t.end();
 });

--- a/modules/mvt/test/mvt-loader.spec.js
+++ b/modules/mvt/test/mvt-loader.spec.js
@@ -275,29 +275,33 @@ test('Triangulation is supported', async t => {
 });
 
 test('Rings - single ring', async t => {
-  const result = classifyRings(ringsSingleRing);
-  t.deepEqual(result, [[0]]);
+  const geom = {...ringsSingleRing};
+  classifyRings(geom);
+  t.deepEqual(geom.lines, [[0]]);
   t.end();
 });
 
 test('Rings - ring and hole', async t => {
-  const result = classifyRings(ringsRingAndHole);
-  t.deepEqual(result, [[0, 10]]);
+  const geom = {...ringsRingAndHole};
+  classifyRings(geom);
+  t.deepEqual(geom.lines, [[0, 10]]);
   t.end();
 });
 
 test('Rings - two rings', async t => {
-  const result = classifyRings(ringsTwoRings);
-  t.deepEqual(result, [[0], [10]]);
+  const geom = {...ringsTwoRings};
+  classifyRings(geom);
+  t.deepEqual(geom.lines, [[0], [10]]);
   t.end();
 });
 
 test('Rings - zero sized hole', async t => {
   // In addition to checking the result,
   // verify that the data array is shortened
-  t.equal(ringsZeroSizeHole.data.length, 20);
-  const result = classifyRings(ringsZeroSizeHole);
-  t.deepEqual(result, [[0]]);
-  t.equal(ringsZeroSizeHole.data.length, 12);
+  const geom = {...ringsZeroSizeHole};
+  t.equal(geom.data.length, 20);
+  classifyRings(geom);
+  t.deepEqual(geom.lines, [[0]]);
+  t.equal(geom.data.length, 12);
   t.end();
 });

--- a/modules/mvt/test/mvt-loader.spec.js
+++ b/modules/mvt/test/mvt-loader.spec.js
@@ -277,6 +277,7 @@ test('Triangulation is supported', async t => {
 test('Rings - single ring', async t => {
   const geom = {...ringsSingleRing};
   classifyRings(geom);
+  t.deepEqual(geom.areas, [[-0.02624368667602539]]);
   t.deepEqual(geom.lines, [[0]]);
   t.end();
 });
@@ -284,6 +285,7 @@ test('Rings - single ring', async t => {
 test('Rings - ring and hole', async t => {
   const geom = {...ringsRingAndHole};
   classifyRings(geom);
+  t.deepEqual(geom.areas, [[-0.02624368667602539, 0.001363515853881836]]);
   t.deepEqual(geom.lines, [[0, 10]]);
   t.end();
 });
@@ -291,6 +293,7 @@ test('Rings - ring and hole', async t => {
 test('Rings - two rings', async t => {
   const geom = {...ringsTwoRings};
   classifyRings(geom);
+  t.deepEqual(geom.areas, [[-0.02624368667602539], [-0.001363515853881836]]);
   t.deepEqual(geom.lines, [[0], [10]]);
   t.end();
 });
@@ -301,6 +304,7 @@ test('Rings - zero sized hole', async t => {
   const geom = {...ringsZeroSizeHole};
   t.equal(geom.data.length, 20);
   classifyRings(geom);
+  t.deepEqual(geom.areas, [[-0.44582176208496094]]);
   t.deepEqual(geom.lines, [[0]]);
   t.equal(geom.data.length, 12);
   t.end();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1898,6 +1898,14 @@
     "@babel/runtime" "^7.12.0"
     gl-matrix "^3.0.0"
 
+"@math.gl/core@3.5.0-alpha.1":
+  version "3.5.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@math.gl/core/-/core-3.5.0-alpha.1.tgz#c5c55d8737189f957775fb0b9c23bc526891e1a7"
+  integrity sha512-Hj8ZvWQvRQo/gIeung709KODkhl9kHH75wZHBK7jVwkRxLS1TMq/niB6yL9w1HQtdTNjae4SjOGOH7nzCbAW1g==
+  dependencies:
+    "@babel/runtime" "^7.12.0"
+    gl-matrix "^3.0.0"
+
 "@math.gl/culling@^3.3.0":
   version "3.4.2"
   resolved "https://registry.yarnpkg.com/@math.gl/culling/-/culling-3.4.2.tgz#a3d9a80e3c69c3613591a732515875dbdcf54e6a"
@@ -1916,12 +1924,12 @@
     "@math.gl/core" "3.4.2"
     gl-matrix "^3.0.0"
 
-"@math.gl/polygon@^3.3.0":
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/@math.gl/polygon/-/polygon-3.4.2.tgz#36c327257959c8edcc258c4ddeaecf04b125cb90"
-  integrity sha512-ANbZmcrzavzEe0bHbdEYyiudPdGGV/quB3FxUJa3L1QCcZbnrqvnuwqX+8U8ltIDhbACG1x0Uxefwo8p77aMNw==
+"@math.gl/polygon@^3.5.0-alpha.1":
+  version "3.5.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@math.gl/polygon/-/polygon-3.5.0-alpha.1.tgz#79fece9a082f7cc5250614ccee86f560499e4b48"
+  integrity sha512-3fg/c5XCr92mE9p3eCXoYdecGA359ZwWZPD4P31JlkMHPpX2mSZIC/XJ2QabAvdis2WNBkKrrjZvKBGtQKqvNg==
   dependencies:
-    "@math.gl/core" "3.4.2"
+    "@math.gl/core" "3.5.0-alpha.1"
 
 "@math.gl/proj4@^3.3.0":
   version "3.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4532,11 +4532,6 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
-earcut@^2.0.6:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/earcut/-/earcut-2.2.2.tgz#41b0bc35f63e0fe80da7cddff28511e7e2e80d11"
-  integrity sha512-eZoZPPJcUHnfRZ0PjLvx2qBordSiO8ofC3vt+qACLM95u+4DovnbYNpQtJh0DNsWj8RnxrQytD4WA8gj5cRIaQ==
-
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"


### PR DESCRIPTION
visgl/loaders.gl#1356 implemented polygon triangulation using earcut in loaders.gl however seems more natural to have earcut in math.gl, so as to allow other projects to import it if needed. This PR moves earcut into math.gl, see https://github.com/uber-web/math.gl/pull/219 for more details