### PR TITLE
fix(3d-tiles): Add additional check for batchTableJson

### DIFF
--- a/modules/tile-converter/src/i3s-converter/i3s-converter.js
+++ b/modules/tile-converter/src/i3s-converter/i3s-converter.js
@@ -486,6 +486,7 @@ export default class I3SConverter {
    * @return {void}
    */
   _convertAttributeStorageInfo(sourceTileContent) {
+    // In legacy b3dm files sometimes sourceTileContent is null.
     const batchTable = sourceTileContent && sourceTileContent.batchTableJson;
     if (batchTable && !this.layers0.attributeStorageInfo.length) {
       this._convertBatchTableInfoToNodeAttributes(batchTable);

--- a/modules/tile-converter/src/i3s-converter/i3s-converter.js
+++ b/modules/tile-converter/src/i3s-converter/i3s-converter.js
@@ -486,7 +486,7 @@ export default class I3SConverter {
    * @return {void}
    */
   _convertAttributeStorageInfo(sourceTileContent) {
-    const batchTable = sourceTileContent.batchTableJson;
+    const batchTable = sourceTileContent && sourceTileContent.batchTableJson;
     if (batchTable && !this.layers0.attributeStorageInfo.length) {
       this._convertBatchTableInfoToNodeAttributes(batchTable);
     }


### PR DESCRIPTION
In legacy b3dm files sometimes `sourceTileContent` is null.