### PR TITLE
Set XML-based loaders to default to geojson output

### DIFF
--- a/modules/kml/src/gpx-loader.js
+++ b/modules/kml/src/gpx-loader.js
@@ -28,7 +28,8 @@ export const GPXLoader = {
     parseTextSync(new TextDecoder().decode(arrayBuffer), options),
   parseTextSync,
   options: {
-    gpx: {}
+    gpx: {},
+    gis: {format: 'geojson'}
   }
 };
 

--- a/modules/kml/src/kml-loader.js
+++ b/modules/kml/src/kml-loader.js
@@ -27,7 +27,8 @@ export const KMLLoader = {
     parseTextSync(new TextDecoder().decode(arrayBuffer), options),
   parseTextSync,
   options: {
-    kml: {}
+    kml: {},
+    gis: {format: 'geojson'}
   }
 };
 

--- a/modules/kml/src/tcx-loader.js
+++ b/modules/kml/src/tcx-loader.js
@@ -28,7 +28,8 @@ export const TCXLoader = {
     parseTextSync(new TextDecoder().decode(arrayBuffer), options),
   parseTextSync,
   options: {
-    tcx: {}
+    tcx: {},
+    gis: {format: 'geojson'}
   }
 };
 


### PR DESCRIPTION
Closes #1381 

Each of these three loaders' docs pages already indicates that `geojson` is the default, so the docs don't need to be updated.