### PR TITLE
Fix for dangerouslySetInnerHTML lint error

### DIFF
--- a/examples/website/3d-tiles/components/control-panel.js
+++ b/examples/website/3d-tiles/components/control-panel.js
@@ -140,18 +140,18 @@ export default class ControlPanel extends PureComponent {
     if (!attributions || attributions.length === 0 || !description) {
       return null;
     }
-    /* eslint-disable */
+
     return (
       <InfoContainer>
         {Boolean(attributions && attributions.length) && <b>Tileset Credentials</b>}
         {Boolean(attributions && attributions.length) &&
           attributions.map(attribution => (
+            // eslint-disable-next-line react/no-danger
             <div key={attribution.html} dangerouslySetInnerHTML={{__html: attribution.html}} />
           ))}
         {description && <Description dangerouslySetInnerHTML={{__html: marked(description)}} />}
       </InfoContainer>
     );
-    /* eslint-enable */
   }
 
   render() {

--- a/examples/website/3d-tiles/components/control-panel.js
+++ b/examples/website/3d-tiles/components/control-panel.js
@@ -140,7 +140,7 @@ export default class ControlPanel extends PureComponent {
     if (!attributions || attributions.length === 0 || !description) {
       return null;
     }
-
+    /* eslint-disable */
     return (
       <InfoContainer>
         {Boolean(attributions && attributions.length) && <b>Tileset Credentials</b>}
@@ -151,6 +151,7 @@ export default class ControlPanel extends PureComponent {
         {description && <Description dangerouslySetInnerHTML={{__html: marked(description)}} />}
       </InfoContainer>
     );
+    /* eslint-enable */
   }
 
   render() {


### PR DESCRIPTION
It is not really good practice to use `dangerouslySetInnerHTML` in react. But in the control panel of 3d-tiles example we see the following picture:
![image](https://user-images.githubusercontent.com/70207219/120466930-4ab17d00-c3a8-11eb-99b9-85542b0e96c1.png)
All content under 'Tileset Credentials' header is made by using `dangerouslySetInnerHTML` attribute.

Possible solutions:

1. Transform pure `html` to `jsx` . For that perspective we need additional package which allows such transformation. I am not sure that we really need this.
2. Turn off `react/no-danger` rule in eslint config for files under example folder. I am not sure it is a good solution because we should avoid `dangerouslySetInnerHTML` in the future.
3. Just use /`* eslint-disable */ `comment for these lines. I think this is enough just because we get this html from trusted source and we don't need to be over secure.
@ibgreen  Your thoughts?