### PR TITLE
Fix no-did-mount-set-state eslint error in compressed texture

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,8 +38,7 @@ const config = deepMerge(defaultConfig, {
     {
       files: ['examples/**/*.js'],
       rules: {
-        'import/no-unresolved': 0,
-        'react/no-did-mount-set-state': 0
+        'import/no-unresolved': 0
       }
     }
   ]

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,7 +38,8 @@ const config = deepMerge(defaultConfig, {
     {
       files: ['examples/**/*.js'],
       rules: {
-        'import/no-unresolved': 0
+        'import/no-unresolved': 0,
+        'react/no-did-mount-set-state': 0
       }
     }
   ]

--- a/examples/website/textures/components/compressed-texture.js
+++ b/examples/website/textures/components/compressed-texture.js
@@ -150,6 +150,7 @@ export default class CompressedTexture extends PureComponent {
 
   async componentDidMount() {
     const dataUrl = await this.getTextureDataUrl();
+    // eslint-disable-next-line react/no-did-mount-set-state
     this.setState({dataUrl});
   }
 

--- a/examples/website/textures/components/compressed-texture.js
+++ b/examples/website/textures/components/compressed-texture.js
@@ -135,18 +135,20 @@ export default class CompressedTexture extends PureComponent {
   constructor(props) {
     super(props);
 
+    const supportedFormats = getSupportedGPUTextureFormats(props.gl);
+    const loadOptions = this.getLoadOptions(supportedFormats);
+
     this.state = {
-      supportedFormats: getSupportedGPUTextureFormats(props.gl),
-      loadOptions: {},
+      supportedFormats,
+      loadOptions,
       textureError: null,
       showStats: false,
-      stats: []
+      stats: [],
+      dataUrl: null
     };
   }
 
   async componentDidMount() {
-    await this.setupBasisLoadOptionsIfNeeded();
-
     const dataUrl = await this.getTextureDataUrl();
     this.setState({dataUrl});
   }
@@ -165,20 +167,18 @@ export default class CompressedTexture extends PureComponent {
     return ext;
   }
 
-  setupBasisLoadOptionsIfNeeded() {
-    if (this.state.supportedFormats.has('dxt')) {
-      const loadOptions = {
-        ...this.state.loadOptions,
+  getLoadOptions(supportedFormats) {
+    if (supportedFormats.has('dxt')) {
+      return {
         basis: {
-          ...this.state.loadOptions.basis,
           format: {
             alpha: 'BC3',
             noAlpha: 'BC1'
           }
         }
       };
-      this.setState({loadOptions});
     }
+    return {};
   }
 
   // eslint-disable-next-line max-statements


### PR DESCRIPTION
1. Done some code improvements
2. Turned off `react/no-did-mount-set-state`  checking. If we take a look to the [componentDidMount](https://reactjs.org/docs/react-component.html#componentdidmount) spec it is a normal practice to do `async` operations and call `this.setState()` function there. So I decided to turn off checking for this method in the examples folder.