### PR TITLE
Fix(loader-utils|worker-utils): fix TS type exports for isolated modules

### DIFF
--- a/modules/loader-utils/src/index.ts
+++ b/modules/loader-utils/src/index.ts
@@ -1,16 +1,16 @@
 // TYPES
-export {
-  WorkerLoaderObject,
-  LoaderObject,
-  WriterObject,
-  LoaderContext,
-  DataType,
-  SyncDataType,
-  BatchableDataType,
-  IFileSystem,
-  IRandomAccessReadFileSystem
-} from './types';
-export {IncrementalTransform} from './lib/iterator-utils/incremental-transform';
+export type WorkerLoaderObject = import('./types').WorkerLoaderObject;
+export type LoaderObject = import('./types').LoaderObject;
+export type WriterObject = import('./types').WriterObject;
+export type LoaderContext = import('./types').LoaderContext;
+export type DataType = import('./types').DataType;
+export type SyncDataType = import('./types').SyncDataType;
+export type BatchableDataType = import('./types').BatchableDataType;
+export type IFileSystem = import('./types').IFileSystem;
+export type IRandomAccessReadFileSystem = import('./types').IRandomAccessReadFileSystem;
+
+export type IncrementalTransform =
+  import('./lib/iterator-utils/incremental-transform').IncrementalTransform;
 
 // GENERAL UTILS
 export {assert} from './lib/env-utils/assert';
@@ -73,8 +73,8 @@ export {default as RequestScheduler} from './lib/request-utils/request-scheduler
 
 // MESH CATEGORY UTILS
 // Note: Should move to category specific module if code size increases
-export {Attributes as _Attributes} from './categories/mesh/mesh-utils';
 export {getMeshSize as _getMeshSize, getMeshBoundingBox} from './categories/mesh/mesh-utils';
+export type _Attributes = import('./categories/mesh/mesh-utils').Attributes;
 
 export {NullWorkerLoader, NullLoader} from './null-loader';
 export {JSONLoader} from './json-loader';

--- a/modules/loader-utils/src/lib/request-utils/request-scheduler.ts
+++ b/modules/loader-utils/src/lib/request-utils/request-scheduler.ts
@@ -1,4 +1,3 @@
-import {Status} from '@loaders.gl/draco/types/draco-web-decoder';
 import {Stats} from '@probe.gl/stats';
 
 export type RequestSchedulerProps = {

--- a/modules/worker-utils/src/index.ts
+++ b/modules/worker-utils/src/index.ts
@@ -1,12 +1,8 @@
-import {WorkerObject} from './types';
-
 // TYPES
-export {WorkerObject} from './types';
-export {
-  WorkerMessage,
-  WorkerMessageData,
-  WorkerMessagePayload
-} from './lib/worker-protocol/protocol';
+export type WorkerObject = import('./types').WorkerObject;
+export type WorkerMessage = import('./lib/worker-protocol/protocol').WorkerMessage;
+export type WorkerMessageData = import('./lib/worker-protocol/protocol').WorkerMessageData;
+export type WorkerMessagePayload = import('./lib/worker-protocol/protocol').WorkerMessagePayload;
 
 // GENERAL UTILS
 export {assert} from './lib/env-utils/assert';


### PR DESCRIPTION
When using the latest alpha package (`3.0.0-alpha20`) of loaders currently, the following errors surface when running TS checks:
```sh
$ tsc
node_modules/@loaders.gl/loader-utils/src/index.ts:3:3 - error TS1205: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.

3   WorkerLoaderObject,
    ~~~~~~~~~~~~~~~~~~

node_modules/@loaders.gl/loader-utils/src/index.ts:4:3 - error TS1205: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.

4   LoaderObject,
    ~~~~~~~~~~~~

node_modules/@loaders.gl/loader-utils/src/index.ts:5:3 - error TS1205: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.

5   WriterObject,
    ~~~~~~~~~~~~

node_modules/@loaders.gl/loader-utils/src/index.ts:6:3 - error TS1205: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.

6   LoaderContext,
    ~~~~~~~~~~~~~
```

This PR converts the type exports for the complaining modules to the [following paradigm](https://github.com/microsoft/TypeScript/issues/28481) which works for isolated modules: 
```js
export type MyType = import('./types').MyType;
```

@ibgreen any other places I need to look into to convert as well?