### PR TITLE
Worker-utils: Dynamic maxConcurrency for worker pools

### DIFF
--- a/modules/worker-utils/src/lib/worker-farm/worker-farm.d.ts
+++ b/modules/worker-utils/src/lib/worker-farm/worker-farm.d.ts
@@ -19,7 +19,6 @@ export default class WorkerFarm {
   /** Get the singleton instance of the global worker farm */
   static getWorkerFarm(props: WorkerFarmProps): WorkerFarm;
 
-  readonly maxConcurrency: number;
   readonly onDebug: () => void;
 
   constructor(props: WorkerFarmProps);

--- a/modules/worker-utils/src/lib/worker-farm/worker-farm.d.ts
+++ b/modules/worker-utils/src/lib/worker-farm/worker-farm.d.ts
@@ -19,6 +19,7 @@ export default class WorkerFarm {
   /** Get the singleton instance of the global worker farm */
   static getWorkerFarm(props: WorkerFarmProps): WorkerFarm;
 
+  readonly maxConcurrency: number;
   readonly onDebug: () => void;
 
   constructor(props: WorkerFarmProps);

--- a/modules/worker-utils/src/lib/worker-farm/worker-farm.js
+++ b/modules/worker-utils/src/lib/worker-farm/worker-farm.js
@@ -41,12 +41,20 @@ export default class WorkerFarm {
 
   getWorkerPool({name, source, url}) {
     let workerPool = this.workerPools.get(name);
+
+    const maxConcurrency = isMobile ? this.props.maxMobileConcurrency : this.props.maxConcurrency;
+
+    if (workerPool && workerPool.maxConcurrency !== maxConcurrency) {
+      workerPool.destroy();
+      workerPool = undefined;
+    }
+
     if (!workerPool) {
       workerPool = new WorkerPool({
         name,
         source,
         url,
-        maxConcurrency: isMobile ? this.props.maxMobileConcurrency : this.props.maxConcurrency,
+        maxConcurrency,
         onDebug: this.props.onDebug,
         reuseWorkers: this.props.reuseWorkers
       });

--- a/modules/worker-utils/src/lib/worker-farm/worker-pool.d.ts
+++ b/modules/worker-utils/src/lib/worker-farm/worker-pool.d.ts
@@ -13,6 +13,8 @@ type OnDebugParameters = {
  * Process multiple data messages with small pool of identical workers
  */
 export default class WorkerPool {
+  readonly maxConcurrency: number;
+
   /**
    * @param processor - worker function
    * @param maxConcurrency - max count of workers

--- a/scripts/webpack/worker.js
+++ b/scripts/webpack/worker.js
@@ -113,7 +113,6 @@ function addESNextSettings(config) {
 
 module.exports = (env = {}) => {
   let config = CONFIG;
-  env.dev = true;
   if (env.dev) {
     config.mode = 'development';
     config = addESNextSettings(config);


### PR DESCRIPTION
Hi!
This PR allows the user to change `maxConcurrency` without refreshing the browser.
It was very useful for me to figure out optimal performance paramters.
Additionally, [this line](https://github.com/visgl/loaders.gl/blob/c1f7d7bec911c704a190dbcf6b392a07a555771b/scripts/webpack/worker.js#L116) caused workers to be built only in dev mode (without minification), so I removed it.
Thank you!

/Avner
