### PR TITLE
Resolve typings in null-loader ParseInBatches

### DIFF
--- a/modules/core/src/null-loader.ts
+++ b/modules/core/src/null-loader.ts
@@ -18,6 +18,7 @@ export const NullLoader: LoaderWithParser = {
   parseSync: (arrayBuffer) => arrayBuffer,
   // @ts-ignore
   parseInBatches: async (asyncIterator) =>
+    // @ts-ignore
     (async function* parseInBatches() {
       // @ts-ignore
       yield* asyncIterator;

--- a/modules/core/src/null-loader.ts
+++ b/modules/core/src/null-loader.ts
@@ -16,13 +16,11 @@ export const NullLoader: LoaderWithParser = {
   extensions: ['null'],
   parse: async (arrayBuffer) => arrayBuffer,
   parseSync: (arrayBuffer) => arrayBuffer,
-  // @ts-ignore
-  parseInBatches: async (asyncIterator) =>
-    // @ts-ignore
-    (async function* parseInBatches() {
-      // @ts-ignore
-      yield* asyncIterator;
-    })(),
+  parseInBatches: async function* generator(asyncIterator) {
+    for await (const batch of asyncIterator) {
+      yield batch;
+    }
+  },
   tests: [() => false],
   options: {
     null: {}


### PR DESCRIPTION
Oddly I wasn't able to reproduce this in the main repo (maybe some different in the typescript environment), but I got this error in my project using loaders.gl:
```
node_modules/@loaders.gl/loader-utils/src/null-loader.ts:34:5 - 
error TS2741: Property '[Symbol.asyncIterator]' is missing in 
type 'Promise<AsyncGenerator<ArrayBuffer, void, undefined>>' 
but required in type 'AsyncIterable<any>'.

34     (async function* parseInBatches() {
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
35       // @ts-ignore
   ~~~~~~~~~~~~~~~~~~~
36       yield* asyncIterator;
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~
37     })()
   ~~~~~~~~
```
And I could fix it by adding the following `@ts-ignore` ,