### PR TITLE
Convert i3s-tile-converter to typescript

### DIFF
--- a/modules/loader-utils/src/types.ts
+++ b/modules/loader-utils/src/types.ts
@@ -41,6 +41,10 @@ export type LoaderOptions = {
   // [loaderId: string]: any;
 };
 
+type PreloadOptions = {
+  [key: string]: any;
+};
+
 export type CoreWriterOptions = {
   [key: string]: any;
 };
@@ -82,6 +86,7 @@ export type LoaderWithParser = Loader & {
   testText?: (string) => boolean;
 
   parse: Parse;
+  preload?: Preload;
   parseSync?: ParseSync;
   parseText?: ParseText;
   parseTextSync?: ParseTextSync;
@@ -152,6 +157,7 @@ type EncodeURLtoURL = (
   outputUrl: string,
   options?: CoreWriterOptions
 ) => Promise<string>;
+type Preload = (url: string, options?: PreloadOptions) => any;
 
 /** Types that can be synchronously parsed */
 export type SyncDataType = string | ArrayBuffer; // TODO File | Blob can be read synchronously...

--- a/modules/tile-converter/src/types.ts
+++ b/modules/tile-converter/src/types.ts
@@ -1,0 +1,138 @@
+import type {GLTFMaterial} from '@loaders.gl/gltf';
+
+// Types are based on I3S specification https://github.com/Esri/i3s-spec/tree/master/docs/1.7
+// TODO Add description for each property
+
+export type SceneLayer3D = {
+  id: number;
+  href?: string;
+  layerType: string;
+  spatialReference?: {
+    wkid: number;
+    latestWkid: number;
+    vcsWkid: number;
+    latestVcsWkid: number;
+  };
+  heightModelInfo?: HeightModelInfo;
+  version: string;
+  name?: string;
+  capabilities: string[];
+  store: Store;
+  nodePages?: NodePages;
+  materialDefinitions?: GLTFMaterial[];
+  textureSetDefinitions?: TextureSetDefinition[];
+  geometryDefinitions?: GeometryDefinitions;
+  attributeStorageInfo?: AttributeStorageInfo[];
+  fields?: Field[];
+  popupInfo?: PopupInfo;
+};
+
+type Store = {
+  id: string | number;
+  profile: string;
+  version: number | string;
+  resourcePattern: string[];
+  rootNode: string;
+  extent: number[];
+  indexCRS: string;
+  vertexCRS: string;
+  normalReferenceFrame: string;
+  attributeEncoding: string;
+  textureEncoding: string[];
+  lodType: string;
+  lodModel: string;
+  defaultGeometrySchema: DefaultGeometrySchema;
+};
+
+type DefaultGeometrySchema = {
+  vartexCount: number;
+  featureCount: number;
+  position: Float32Array;
+  normal: Float32Array;
+  uv0: Float32Array;
+  color: Uint8Array;
+  id: Float32Array;
+  faceRange: Uint32Array;
+  region: Uint16Array;
+};
+
+type HeightModelInfo = {
+  heightModel: string;
+  vertCRS: string;
+  heightUnit: string;
+};
+
+type NodePages = {
+  nodesPerPage: number;
+  lodSelectionMetricType: string;
+};
+
+type TextureSetDefinition = {
+  formats: {name: string; format: string}[];
+  atlas?: boolean;
+};
+
+type GeometryDefinitions = {
+  topology: 'triangle' | string;
+  geometryBuffers: GeometryBuffer[];
+};
+
+type GeometryBuffer = {
+  offset?: number;
+  position?: GeometryBufferItem;
+  normal?: GeometryBufferItem;
+  uv0?: GeometryBufferItem;
+  color?: GeometryBufferItem;
+  uvRegion?: GeometryBufferItem;
+  featureId?: GeometryBufferItem;
+  faceRange?: GeometryBufferItem;
+  compressedAttributes?: {encoding: string; attributes: string[]};
+};
+
+type GeometryBufferItem = {type: string; component: number; encoding?: string; binding: string};
+
+type AttributeStorageInfo = {
+  key: string;
+  name: string;
+  header: {property: string; valueType: string}[];
+  ordering?: string[];
+  attributeValues?: AttributeValue;
+  attributeByteCounts?: AttributeValue;
+  objectIds?: AttributeValue;
+};
+
+type AttributeValue = {valueType: string; encoding?: string; valuesPerElement?: number};
+
+type Field = {
+  name: string;
+  type: string;
+  alias?: string;
+  domain?: Domain;
+};
+
+type Domain = {
+  type: string;
+  name: string;
+  description?: string;
+  fieldType?: string;
+  range?: [number, number];
+  codedValues?: {name: string; code: string | number}[];
+  mergePolicy?: string;
+  splitPolicy?: string;
+};
+
+export type PopupInfo = {
+  title?: string;
+  description?: string;
+  expressionInfos?: any[];
+  fieldInfos?: FieldInfo[];
+  mediaInfos?: any[];
+  popupElements?: {text?: string; type?: string; fieldInfos?: FieldInfo[]}[];
+};
+
+type FieldInfo = {
+  fieldName: string;
+  visible: boolean;
+  isEditable: boolean;
+  label: string;
+};


### PR DESCRIPTION
It is first small step to convert i3s-tile-converter to typescript.
Next steps:
1. Remove d.ts file and move all types to i3s-converter.ts file.
2. Enable validation for i3s-converter.ts in ts config.