### PR TITLE
fix(core): fetchFile option handling

### DIFF
--- a/modules/core/docs/api-reference/fetch-file.md
+++ b/modules/core/docs/api-reference/fetch-file.md
@@ -10,6 +10,8 @@ Use the `fetchFile` function as follows:
 import {fetchFile} from '@loaders.gl/core';
 
 const response = await fetchFile(url);
+// or supply any standard `RequestInit` options expected by `fetch`
+const response = await fetchFile(url, {headers: {}});
 
 // Now use standard browser Response APIs
 
@@ -40,7 +42,7 @@ const data = await parse(fetch(url), OBJLoader);
 
 ## Functions
 
-### fetchFile(url : String [, options : Object]) : Promise.Response
+### `fetchFile(url: string | Blob, options?: RequestInit) : Promise<Response>`
 
 A wrapper around the platform [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/fetch) function with some additions:
 
@@ -56,28 +58,11 @@ Returns:
   - `json()`: Promise.String` - Loads the file and decodes it into JSON.
   - `body` : ReadableStream` - A stream that can be used to incrementally read the contents of the file.
 
-Options:
-
-Under Node.js, options include (see [fs.createReadStream](https://nodejs.org/api/fs.html#fs_fs_createreadstream_path_options)):
-
-- `options.highWaterMark` (Number) Default: 64K (64 \* 1024) - Determines the "chunk size" of data read from the file.
-
-### readFileSync(url : String [, options : Object]) : ArrayBuffer | String
-
-> This function only works on Node.js or using data URLs.
-
-Reads the raw data from a file asynchronously.
-
-Notes:
-
-- Any path prefix set by `setPathPrefix` will be appended to relative urls.
-
 ## Remarks
 
-- `fetchFile` will delegate to `fetch` after resolving the URL.
-- For some data sources such as node.js and `File`/`Blob` objects a mock `Response` object will be returned, and not all fields/members may be implemented.
-- When possible, `Content-Length` and `Content-Type` `headers` are also populated for non-request data sources including `File`, `Blob` and Node.js files.
-- `fetchFile` is intended to be a small (in terms of bundle size) function to help applications work with files in a portable way. The `Response` object returned on Node.js does not implement all the functionality the browser does. If you run into the need
-- In fact, the use of any of the file utilities including `readFile` and `readFileAsync` functions with other loaders.gl functions is entirely optional. loader objects can be used with data loaded via any mechanism the application prefers, e.g. directly using `fetch`, `XMLHttpRequest` etc.
-- The "path prefix" support is intentended to be a simple mechanism to support certain work-arounds. It is intended to help e.g. in situations like getting test cases to load data from the right place, but was never intended to support general application use cases.
-- The stream utilities are intended to be small optional helpers that facilitate writing platform independent code that works with streams. This can be valuable as JavaScript Stream APIs are still maturing and there are still significant differences between platforms. However, streams and iterators created directly using platform specific APIs can be used as parameters to loaders.gl functions whenever a stream is expected, allowing the application to take full control when desired.
+- For `string` URLs - `fetchFile` will delegate to `fetch` after resolving the URL.
+- For `File`/`Blob` - a `Response` object will be returned. Any `RequestInit` options are ignored in this case.
+- Under Node.js, `fetchFile` (and `fetch`) works and returns a polyfilled `Response` object if `@loaders.gl/polyfills` has been installed, and `RequestInit` options are used.
+- `Response.headers` (`Content-Length` and `Content-Type`) are populated (on a best effort basis for `File`, `Blob` and under Node.js).
+- Use of `fetchFile` is completely optional. loaders.gl can be used with data loaded via any mechanism the application prefers, e.g. directly using `fetch`, `XMLHttpRequest` etc.
+- The `setPathPrefix()` mechanism is intended to help test cases to load data from the right place, but is not intended to support general application use cases, so use with care.

--- a/modules/core/src/lib/fetch/fetch-file.ts
+++ b/modules/core/src/lib/fetch/fetch-file.ts
@@ -19,7 +19,7 @@ export async function fetchFile(
     url = resolvePath(url);
 
     let fetchOptions: RequestInit = options as RequestInit;
-    if (options?.fetch && typeof options?.fetch !== `function`) {
+    if (options?.fetch && typeof options?.fetch !== 'function') {
       fetchOptions = options.fetch;
     }
 
@@ -27,7 +27,7 @@ export async function fetchFile(
     if (!response.ok && options?.throws) {
       throw new Error(await getErrorMessageFromResponse(response));
     }
-  
+
     return response;
   }
 

--- a/modules/core/src/lib/fetch/fetch-file.ts
+++ b/modules/core/src/lib/fetch/fetch-file.ts
@@ -1,14 +1,15 @@
-import type {LoaderOptions} from '@loaders.gl/loader-utils';
 import {resolvePath} from '@loaders.gl/loader-utils';
 import {makeResponse} from '../utils/response-utils';
 import {getErrorMessageFromResponse} from './fetch-error-message';
 
 /**
- * As fetch but respects pathPrefix and file aliases
+ * fetch compatible function
  * Reads file data from:
- * - data urls
  * - http/http urls
+ * - data urls
  * - File/Blob objects
+ * Leverages `@loaders.gl/polyfills` for Node.js support
+ * Respects pathPrefix and file aliases
  */
 export async function fetchFile(
   url: string | Blob,


### PR DESCRIPTION
For #1538 , #1548

`fetchFile` currently accepts a loaders.gl options object but looks like it would accept a standard `fetch` `RequestInit` object which is confusing and causing bugs.

For now make sure that `fetchFile` accepts both `RequestInit` options and a loaders.gl options object.

I think we could make a case that `fetchFile` should just take a `RequestInit` object (it is named after `fetch` after all), but this is a first non-breaking step in that direction. I see some very few places in loaders that would need to be updated, in CesiumIONLoader.

https://github.com/visgl/loaders.gl/search?q=%22%7Bfetch%3A+headers%22