### PR TITLE
select-loaders type assertion

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,7 +50,8 @@ const config = deepMerge(defaultConfig, {
         '@typescript-eslint/no-unsafe-return': 0,
         '@typescript-eslint/no-unsafe-call': 0,
         '@typescript-eslint/no-empty-interface': 0,
-        '@typescript-eslint/restrict-plus-operands': 0
+        '@typescript-eslint/restrict-plus-operands': 0,
+        '@typescript-eslint/no-unnecessary-type-assertion': 0
       }
     },
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,8 +50,7 @@ const config = deepMerge(defaultConfig, {
         '@typescript-eslint/no-unsafe-return': 0,
         '@typescript-eslint/no-unsafe-call': 0,
         '@typescript-eslint/no-empty-interface': 0,
-        '@typescript-eslint/restrict-plus-operands': 0,
-        '@typescript-eslint/no-unnecessary-type-assertion': 0
+        '@typescript-eslint/restrict-plus-operands': 0
       }
     },
     {

--- a/modules/core/src/lib/api/select-loader.ts
+++ b/modules/core/src/lib/api/select-loader.ts
@@ -76,7 +76,7 @@ export function selectLoaderSync(
   }
 
   // Add registered loaders
-  loaders = [...(loaders || []), ...getRegisteredLoaders()];
+  loaders = [...((loaders as Loader[]) || []), ...getRegisteredLoaders()];
   normalizeLoaders(loaders);
 
   const {url, type} = getResourceUrlAndType(data);

--- a/modules/core/src/lib/api/select-loader.ts
+++ b/modules/core/src/lib/api/select-loader.ts
@@ -76,6 +76,7 @@ export function selectLoaderSync(
   }
 
   // Add registered loaders
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
   loaders = [...((loaders as Loader[]) || []), ...getRegisteredLoaders()];
   normalizeLoaders(loaders);
 


### PR DESCRIPTION
I think this might be related to eslint/typescript version, because again I only had problem in another project that is using loaders.gl and should be using latest typscript and eslint.

```
TS2488: Type 'Loader | Loader[]' must have a '[Symbol.iterator]()' method that returns an iterator.
../../loaders.gl/modules/core/src/lib/api/select-loader.ts: (80:22)

80   loadersArray = [...(loadersArray || []), ...getRegisteredLoaders()];
```
It does make sense if though there is that `return` statement.
When I fixed it to `(loaders as Loader[])` I got the error **only in loaders.gl (not in my project)** from eslint:
```
 79:19  error    This assertion is unnecessary since it does not change the type of the expression  @typescript-eslint/no-unnecessary-type-assertion
```
So I could only disable that in .eslintrc.
Let me know if there is a better fix..!

