### PR TITLE
feat: unbundled loaders

### DIFF
--- a/modules/core/src/lib/api/parse.ts
+++ b/modules/core/src/lib/api/parse.ts
@@ -87,5 +87,5 @@ async function parseWithLoader(loader, data, options, context) {
   assert(!loader.parseSync);
 
   // TBD - If asynchronous parser not available, return null
-  return assert(false);
+  throw new Error(`${loader.id} loader - no parser found and worker is disabled`);
 }

--- a/modules/excel/src/excel-loader.ts
+++ b/modules/excel/src/excel-loader.ts
@@ -35,4 +35,4 @@ export const ExcelLoader = {
   options: DEFAULT_EXCEL_LOADER_OPTIONS
 };
 
-export const _typecheckLASLoader: Loader = ExcelLoader;
+export const _typecheckLoader: Loader = ExcelLoader;

--- a/modules/excel/src/excel-loader.ts
+++ b/modules/excel/src/excel-loader.ts
@@ -1,12 +1,16 @@
+import type {Loader, LoaderOptions} from '@loaders.gl/loader-utils';
+
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
 const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
-export type ExcelLoaderOptions = {
-  sheet?: string; // Load default Sheet
+export type ExcelLoaderOptions = LoaderOptions & {
+  excel?: {
+    sheet?: string; // Load default Sheet
+  };
 };
 
-const DEFAULT_EXCEL_LOADER_OPTIONS: {excel: ExcelLoaderOptions} = {
+const DEFAULT_EXCEL_LOADER_OPTIONS: ExcelLoaderOptions = {
   excel: {
     sheet: undefined // Load default Sheet
   }
@@ -30,3 +34,5 @@ export const ExcelLoader = {
   binary: true,
   options: DEFAULT_EXCEL_LOADER_OPTIONS
 };
+
+export const _typecheckLASLoader: Loader = ExcelLoader;

--- a/modules/excel/src/excel-loader.ts
+++ b/modules/excel/src/excel-loader.ts
@@ -1,6 +1,3 @@
-import type {Loader, LoaderWithParser} from '@loaders.gl/loader-utils';
-import {parseExcel} from './lib/parse-excel';
-
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
 const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
@@ -18,7 +15,7 @@ const DEFAULT_EXCEL_LOADER_OPTIONS: {excel: ExcelLoaderOptions} = {
 /**
  * Worker Loader for Excel files
  */
-export const ExcelWorkerLoader: Loader = {
+export const ExcelLoader = {
   name: 'Excel',
   id: 'excel',
   module: 'excel',
@@ -32,12 +29,4 @@ export const ExcelWorkerLoader: Loader = {
   category: 'table',
   binary: true,
   options: DEFAULT_EXCEL_LOADER_OPTIONS
-};
-
-/**
- * Loader for Excel files
- */
-export const ExcelLoader: LoaderWithParser = {
-  ...ExcelWorkerLoader,
-  parse: (arrayBuffer, options, context) => parseExcel(arrayBuffer, options, context)
 };

--- a/modules/excel/src/index.ts
+++ b/modules/excel/src/index.ts
@@ -1,2 +1,17 @@
+import type {Loader, LoaderWithParser} from '@loaders.gl/loader-utils';
+import {ExcelLoader as ExcelWorkerLoader} from './excel-loader';
+import {parseExcel} from './lib/parse-excel';
+
+// Excel Loader
+
 export type {ExcelLoaderOptions} from './excel-loader';
-export {ExcelWorkerLoader, ExcelLoader} from './excel-loader';
+
+export {ExcelWorkerLoader};
+
+/**
+ * Loader for Excel files
+ */
+export const ExcelLoader = {
+  ...ExcelWorkerLoader,
+  parse: (arrayBuffer, options, context) => parseExcel(arrayBuffer, options, context)
+};

--- a/modules/excel/src/index.ts
+++ b/modules/excel/src/index.ts
@@ -16,4 +16,4 @@ export const ExcelLoader = {
     parseExcel(arrayBuffer, options)
 };
 
-export const _typecheckLASLoader: LoaderWithParser = ExcelLoader;
+export const _typecheckLoader: LoaderWithParser = ExcelLoader;

--- a/modules/excel/src/index.ts
+++ b/modules/excel/src/index.ts
@@ -1,11 +1,10 @@
-import type {Loader, LoaderWithParser} from '@loaders.gl/loader-utils';
-import {ExcelLoader as ExcelWorkerLoader} from './excel-loader';
+import type {LoaderWithParser} from '@loaders.gl/loader-utils';
+import {ExcelLoader as ExcelWorkerLoader, ExcelLoaderOptions} from './excel-loader';
 import {parseExcel} from './lib/parse-excel';
 
 // Excel Loader
 
-export type {ExcelLoaderOptions} from './excel-loader';
-
+export type {ExcelLoaderOptions};
 export {ExcelWorkerLoader};
 
 /**
@@ -13,5 +12,8 @@ export {ExcelWorkerLoader};
  */
 export const ExcelLoader = {
   ...ExcelWorkerLoader,
-  parse: (arrayBuffer, options, context) => parseExcel(arrayBuffer, options, context)
+  parse: (arrayBuffer: ArrayBuffer, options?: ExcelLoaderOptions) =>
+    parseExcel(arrayBuffer, options)
 };
+
+export const _typecheckLASLoader: LoaderWithParser = ExcelLoader;

--- a/modules/excel/src/lib/parse-excel.js
+++ b/modules/excel/src/lib/parse-excel.js
@@ -7,9 +7,8 @@ const dataTableNamesMap = {};
  * Gets local or remote Excel file data.
  * @param arrayBuffer Loaded data
  * @param options Data parse options.
- * @param context Load data callback.
  */
-export async function parseExcel(arrayBuffer, options, context) {
+export async function parseExcel(arrayBuffer, options) {
   const excelOptions = options.excel || {};
 
   const dataUrl = 'dummy';

--- a/modules/excel/src/workers/excel-worker.js
+++ b/modules/excel/src/workers/excel-worker.js
@@ -1,4 +1,4 @@
 import {createLoaderWorker} from '@loaders.gl/loader-utils';
-import {ExcelLoader} from '../excel-loader';
+import {ExcelLoader} from '../index';
 
 createLoaderWorker(ExcelLoader);

--- a/modules/excel/test/excel-loader.spec.js
+++ b/modules/excel/test/excel-loader.spec.js
@@ -9,7 +9,7 @@ const ZIPCODES_CSV_PATH = `@loaders.gl/excel/test/data/zipcodes.csv`;
 
 test('ExcelLoader#load(ZIPCODES)', async (t) => {
   const csvData = await load(ZIPCODES_CSV_PATH, CSVLoader);
-  t.equal(csvData.length, 42049, 'CSV: Correct number of row received');
+  t.equal(csvData.length, 42049, 'CSV (reference): Correct number of row received');
 
   let data = await load(ZIPCODES_XLSB_PATH, ExcelLoader);
   t.equal(data.length, 42049, 'XLSB: Correct number of row received');

--- a/modules/las/src/index.ts
+++ b/modules/las/src/index.ts
@@ -1,17 +1,11 @@
-import type {Loader, LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';
+import type {LoaderWithParser} from '@loaders.gl/loader-utils';
+import type {LASLoaderOptions} from './las-loader';
 import {LASLoader as LASWorkerLoader} from './las-loader';
 import parseLAS from './lib/parse-las';
 
 // LASLoader
 
-export type LASLoaderOptions = LoaderOptions & {
-  las?: {
-    fp64?: boolean;
-    skip?: number;
-    colorDepth?: number;
-  };
-};
-
+export type {LASLoaderOptions};
 export {LASWorkerLoader};
 
 /**
@@ -24,5 +18,4 @@ export const LASLoader = {
   parseSync: parseLAS
 };
 
-export const _typecheckLASWorkerLoader: Loader = LASWorkerLoader;
 export const _typecheckLASLoader: LoaderWithParser = LASLoader;

--- a/modules/las/src/index.ts
+++ b/modules/las/src/index.ts
@@ -1,1 +1,28 @@
-export {LASLoader, LASWorkerLoader} from './las-loader';
+import type {Loader, LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';
+import {LASLoader as LASWorkerLoader} from './las-loader';
+import parseLAS from './lib/parse-las';
+
+// LASLoader
+
+export type LASLoaderOptions = LoaderOptions & {
+  las?: {
+    fp64?: boolean;
+    skip?: number;
+    colorDepth?: number;
+  };
+};
+
+export {LASWorkerLoader};
+
+/**
+ * Loader for the LAS (LASer) point cloud format
+ */
+export const LASLoader = {
+  ...LASWorkerLoader,
+  parse: async (arrayBuffer: ArrayBuffer, options?: LASLoaderOptions) =>
+    parseLAS(arrayBuffer, options),
+  parseSync: parseLAS
+};
+
+export const _typecheckLASWorkerLoader: Loader = LASWorkerLoader;
+export const _typecheckLASLoader: LoaderWithParser = LASLoader;

--- a/modules/las/src/index.ts
+++ b/modules/las/src/index.ts
@@ -15,7 +15,8 @@ export const LASLoader = {
   ...LASWorkerLoader,
   parse: async (arrayBuffer: ArrayBuffer, options?: LASLoaderOptions) =>
     parseLAS(arrayBuffer, options),
-  parseSync: parseLAS
+  parseSync: (arrayBuffer: ArrayBuffer, options?: LASLoaderOptions) =>
+    parseLAS(arrayBuffer, options)
 };
 
-export const _typecheckLASLoader: LoaderWithParser = LASLoader;
+export const _typecheckLoader: LoaderWithParser = LASLoader;

--- a/modules/las/src/las-loader.ts
+++ b/modules/las/src/las-loader.ts
@@ -1,15 +1,21 @@
 // LASER (LAS) FILE FORMAT
-import type {Loader, LoaderWithParser} from '@loaders.gl/loader-utils';
-import parseLAS from './lib/parse-las';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
 const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
+const DEFAULT_LAS_OPTIONS = {
+  las: {
+    fp64: false,
+    skip: 1,
+    colorDepth: 8
+  }
+};
+
 /**
- * Worker loader for the LAS (LASer) point cloud format
+ * Loader for the LAS (LASer) point cloud format
  */
-export const LASWorkerLoader: Loader = {
+export const LASLoader = {
   name: 'LAS',
   id: 'las',
   module: 'las',
@@ -20,20 +26,5 @@ export const LASWorkerLoader: Loader = {
   text: true,
   binary: true,
   tests: ['LAS'],
-  options: {
-    las: {
-      fp64: false,
-      skip: 1,
-      colorDepth: 8
-    }
-  }
-};
-
-/**
- * Loader for the LAS (LASer) point cloud format
- */
-export const LASLoader: LoaderWithParser = {
-  ...LASWorkerLoader,
-  parse: async (arrayBuffer, options) => parseLAS(arrayBuffer, options),
-  parseSync: parseLAS
+  options: DEFAULT_LAS_OPTIONS
 };

--- a/modules/las/src/las-loader.ts
+++ b/modules/las/src/las-loader.ts
@@ -1,10 +1,19 @@
 // LASER (LAS) FILE FORMAT
+import type {Loader, LoaderOptions} from '@loaders.gl/loader-utils';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
 const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
-const DEFAULT_LAS_OPTIONS = {
+export type LASLoaderOptions = LoaderOptions & {
+  las?: {
+    fp64?: boolean;
+    skip?: number;
+    colorDepth?: number;
+  };
+};
+
+const DEFAULT_LAS_OPTIONS: LASLoaderOptions = {
   las: {
     fp64: false,
     skip: 1,
@@ -28,3 +37,5 @@ export const LASLoader = {
   tests: ['LAS'],
   options: DEFAULT_LAS_OPTIONS
 };
+
+export const _typecheckLASLoader: Loader = LASLoader;

--- a/modules/las/src/las-loader.ts
+++ b/modules/las/src/las-loader.ts
@@ -38,4 +38,4 @@ export const LASLoader = {
   options: DEFAULT_LAS_OPTIONS
 };
 
-export const _typecheckLASLoader: Loader = LASLoader;
+export const _typecheckLoader: Loader = LASLoader;

--- a/modules/las/src/lib/parse-las.ts
+++ b/modules/las/src/lib/parse-las.ts
@@ -1,37 +1,11 @@
-import {getMeshBoundingBox} from '@loaders.gl/loader-utils';
 // ported and es6-ified from https://github.com/verma/plasio/
+
+// @ts-nocheck
+import {getMeshBoundingBox} from '@loaders.gl/loader-utils';
 import {LASFile} from './laslaz-decoder';
 
-function detectTwoByteColors(colorDepth, decoder, batchSize) {
-  let twoByteColor;
-  switch (colorDepth) {
-    case 8:
-      twoByteColor = false;
-      break;
-    case 16:
-      twoByteColor = true;
-      break;
-    case 'auto':
-      if (decoder.getPoint(0).color) {
-        for (let i = 0; i < batchSize; i++) {
-          const {color} = decoder.getPoint(i);
-          // eslint-disable-next-line max-depth
-          if (color[0] > 255 || color[1] > 255 || color[2] > 255) {
-            twoByteColor = true;
-          }
-        }
-      }
-      break;
-    default:
-      // eslint-disable-next-line
-      console.warn('las: illegal value for options.las.colorDepth');
-      break;
-  }
-  return twoByteColor;
-}
-
 /* eslint-disable max-statements */
-export default function parseLAS(arraybuffer, options = {}) {
+export default function parseLAS(arrayBuffer: ArrayBuffer, options?: LASLoaderOptions) {
   let pointIndex = 0;
 
   let positions;
@@ -44,7 +18,7 @@ export default function parseLAS(arraybuffer, options = {}) {
   const {onProgress} = options;
   const {skip, colorDepth, fp64} = options.las || {};
 
-  parseLASChunked(arraybuffer, skip, (decoder, header) => {
+  parseLASChunked(arrayBuffer, skip, (decoder, header) => {
     if (!originalHeader) {
       originalHeader = header;
       const total = header.totalToRead;
@@ -174,4 +148,32 @@ export function parseLASChunked(rawData, skip, onParseData) {
   } finally {
     dataHandler.close();
   }
+}
+
+function detectTwoByteColors(colorDepth, decoder, batchSize) {
+  let twoByteColor;
+  switch (colorDepth) {
+    case 8:
+      twoByteColor = false;
+      break;
+    case 16:
+      twoByteColor = true;
+      break;
+    case 'auto':
+      if (decoder.getPoint(0).color) {
+        for (let i = 0; i < batchSize; i++) {
+          const {color} = decoder.getPoint(i);
+          // eslint-disable-next-line max-depth
+          if (color[0] > 255 || color[1] > 255 || color[2] > 255) {
+            twoByteColor = true;
+          }
+        }
+      }
+      break;
+    default:
+      // eslint-disable-next-line
+      console.warn('las: illegal value for options.las.colorDepth');
+      break;
+  }
+  return twoByteColor;
 }

--- a/modules/las/src/workers/las-worker.js
+++ b/modules/las/src/workers/las-worker.js
@@ -1,4 +1,4 @@
-import {LASLoader} from '../las-loader';
 import {createLoaderWorker} from '@loaders.gl/loader-utils';
+import {LASLoader} from '../index';
 
 createLoaderWorker(LASLoader);


### PR DESCRIPTION
Reorganizing the `excel-loader` (1MB) and `las-loader` (700KB) modules so that their `WorkerLoader` objects can be imported (via an admittedly ugly dist subpath) without importing any other dependencies. It is just an object so doesn't matter which dist it comes from.

This should not break any existing code, and if it works will make it possible to import worker loaders without having to first bundle and then "tree shake out" the code.

