### PR TITLE
use loadOptions in i3s-tileset-traverser

### DIFF
--- a/modules/tiles/src/tileset/traversers/i3s-tileset-traverser.ts
+++ b/modules/tiles/src/tileset/traversers/i3s-tileset-traverser.ts
@@ -61,10 +61,10 @@ export default class I3STilesetTraverser extends TilesetTraverser {
     // load metadata
     const options = {
       i3s: {
-        ...tileset.fetchOptions,
         isTileHeader: true,
         loadContent: false
-      }
+      },
+      ...tileset.loadOptions
     };
 
     return await load(nodeUrl, loader, options);


### PR DESCRIPTION
Hi,
This fixed for me the following typescript error:
```
TS2559: Type '{ i3s: any; }' has no properties in common with type 'LoaderOptions'
```
