### PR TITLE
Remove basePath option from TileHeader class

### DIFF
--- a/modules/tiles/src/tileset/tile-3d.ts
+++ b/modules/tiles/src/tileset/tile-3d.ts
@@ -27,7 +27,6 @@ function defined(x) {
  * @param tileset - Tileset3D instance
  * @param header - tile header - JSON loaded from a dataset
  * @param parentHeader - parent TileHeader instance
- * @param basePath - base path / url of the tile
  * @param extendedId - optional ID to separate copies of a tile for different viewports.
  *                              const extendedId = `${tile.id}-${frameState.viewport.id}`;
  */
@@ -35,7 +34,6 @@ export type TileHeaderProps = {
   tileset: Tileset3D;
   header: Object;
   parentHeader: TileHeader;
-  basePath: string;
   extendedId: string;
 };
 
@@ -110,7 +108,6 @@ export default class TileHeader {
    * @param tileset - Tileset3D instance
    * @param header - tile header - JSON loaded from a dataset
    * @param parentHeader - parent TileHeader instance
-   * @param basePath - base path / url of the tile
    * @param extendedId - optional ID to separate copies of a tile for different viewports.
    *    const extendedId = `${tile.id}-${frameState.viewport.id}`;
    */
@@ -118,7 +115,6 @@ export default class TileHeader {
   constructor(
     tileset: Tileset3D,
     header: {[key: string]: any},
-    basePath: string,
     parentHeader?: TileHeader,
     extendedId = ''
   ) {
@@ -383,7 +379,7 @@ export default class TileHeader {
         // Add tile headers for the nested tilset's subtree
         // Async update of the tree should be fine since there would never be edits to the same node
         // TODO - we need to capture the child tileset's URL
-        this.tileset._initializeTileHeaders(this.content, this, path.dirname(this.contentUrl));
+        this.tileset._initializeTileHeaders(this.content, this);
       }
 
       this.contentState = TILE_CONTENT_STATE.READY;

--- a/modules/tiles/src/tileset/tileset-3d.ts
+++ b/modules/tiles/src/tileset/tileset-3d.ts
@@ -424,7 +424,7 @@ export default class Tileset3D {
     for (const viewport of viewports) {
       const id = viewport.id as string;
       if (!this.roots[id]) {
-        this.roots[id] = this._initializeTileHeaders(this.tileset, null, this.basePath);
+        this.roots[id] = this._initializeTileHeaders(this.tileset, null);
       }
 
       if (!viewportsToTraverse.includes(id)) {
@@ -544,7 +544,7 @@ export default class Tileset3D {
   }
 
   _initializeTileSet(tilesetJson) {
-    this.root = this._initializeTileHeaders(tilesetJson, null, this.basePath);
+    this.root = this._initializeTileHeaders(tilesetJson, null);
 
     // TODO CESIUM Specific
     if (this.type === TILESET_TYPE.TILES3D) {
@@ -591,10 +591,10 @@ export default class Tileset3D {
 
   // Installs the main tileset JSON file or a tileset JSON file referenced from a tile.
   // eslint-disable-next-line max-statements
-  _initializeTileHeaders(tilesetJson, parentTileHeader, basePath) {
+  _initializeTileHeaders(tilesetJson, parentTileHeader) {
     // A tileset JSON file referenced from a tile may exist in a different directory than the root tileset.
     // Get the basePath relative to the external tileset.
-    const rootTile = new Tile3D(this, tilesetJson.root, parentTileHeader, basePath); // resource
+    const rootTile = new Tile3D(this, tilesetJson.root, parentTileHeader); // resource
 
     // If there is a parentTileHeader, add the root of the currently loading tileset
     // to parentTileHeader's children, and update its depth.
@@ -613,7 +613,7 @@ export default class Tileset3D {
         this.stats.get(TILES_TOTAL).incrementCount();
         const children = tile.header.children || [];
         for (const childHeader of children) {
-          const childTile = new Tile3D(this, childHeader, basePath, tile);
+          const childTile = new Tile3D(this, childHeader, tile);
           tile.children.push(childTile);
           childTile.depth = tile.depth + 1;
           stack.push(childTile);

--- a/modules/tiles/src/tileset/traversers/i3s-tileset-traverser.ts
+++ b/modules/tiles/src/tileset/traversers/i3s-tileset-traverser.ts
@@ -79,9 +79,8 @@ export default class I3STilesetTraverser extends TilesetTraverser {
    * @return {void}
    */
   _onTileLoad(header, tile, extendedId) {
-    const basePath = this.options.basePath;
     // after child tile is fetched
-    const childTile = new TileHeader(tile.tileset, header, basePath, tile, extendedId);
+    const childTile = new TileHeader(tile.tileset, header, tile, extendedId);
     tile.children.push(childTile);
     const frameState = this._tileManager.find(childTile.id).frameState;
     this.updateTile(childTile, frameState);

--- a/modules/tiles/test/tileset/tile-3d.spec.js
+++ b/modules/tiles/test/tileset/tile-3d.spec.js
@@ -118,7 +118,7 @@ const MOCK_TILESET = {
 
 test('Tile3D#destroys', (t) => {
   // @ts-ignore
-  const tile = new Tile3D(MOCK_TILESET, TILE_HEADER_WITH_BOUNDING_SPHERE, '');
+  const tile = new Tile3D(MOCK_TILESET, TILE_HEADER_WITH_BOUNDING_SPHERE);
   t.equals(tile.isDestroyed(), false);
   tile.destroy();
   t.equals(tile.isDestroyed(), true);
@@ -130,7 +130,7 @@ test('Tile3D#throws if boundingVolume is undefined', (t) => {
 
   delete tileWithoutBoundingVolume.boundingVolume;
   // @ts-ignore
-  t.throws(() => new Tile3D(MOCK_TILESET, tileWithoutBoundingVolume, ''));
+  t.throws(() => new Tile3D(MOCK_TILESET, tileWithoutBoundingVolume));
   t.end();
 });
 
@@ -139,7 +139,7 @@ test('Tile3D#throws if boundingVolume does not contain a sphere, region, or box'
 
   delete tileWithoutBoundingVolume.boundingVolume.sphere;
   // @ts-ignore
-  t.throws(() => new Tile3D(MOCK_TILESET, tileWithoutBoundingVolume, ''));
+  t.throws(() => new Tile3D(MOCK_TILESET, tileWithoutBoundingVolume));
   t.end();
 });
 
@@ -150,15 +150,15 @@ test('Tile3D#geometric error is undefined', (t) => {
   delete lodMetricValueMissing.lodMetricValue;
 
   // @ts-ignore
-  const parent = new Tile3D(MOCK_TILESET, TILE_HEADER_WITH_BOUNDING_SPHERE, '');
+  const parent = new Tile3D(MOCK_TILESET, TILE_HEADER_WITH_BOUNDING_SPHERE);
   // @ts-ignore
-  const child = new Tile3D(MOCK_TILESET, lodMetricValueMissing, '', parent);
+  const child = new Tile3D(MOCK_TILESET, lodMetricValueMissing, parent);
   t.equals(child.lodMetricType, parent.lodMetricType);
   t.equals(child.lodMetricValue, parent.lodMetricValue);
   t.equals(child.lodMetricValue, 1);
 
   // @ts-ignore
-  const tile = new Tile3D(MOCK_TILESET, lodMetricValueMissing, '');
+  const tile = new Tile3D(MOCK_TILESET, lodMetricValueMissing);
   t.equals(tile.lodMetricValue, MOCK_TILESET.lodMetricValue);
   t.equals(tile.lodMetricValue, 2);
 
@@ -181,7 +181,7 @@ test('Tile3D#viewerRequestVolume is camera inside the MBS viewer request volume'
   };
 
   // @ts-ignore
-  const tile = new Tile3D(tileset, tileHeaderWithViewerRequestVolume, '');
+  const tile = new Tile3D(tileset, tileHeaderWithViewerRequestVolume);
   tile.updateVisibility(
     {
       frameNumber: 100,
@@ -214,7 +214,7 @@ test('Tile3D#viewerRequestVolume is camera outside the MBS viewer request volume
   };
 
   // @ts-ignore
-  const tile = new Tile3D(tileset, tileHeaderWithViewerRequestVolume, '');
+  const tile = new Tile3D(tileset, tileHeaderWithViewerRequestVolume);
   tile.updateVisibility(
     {
       frameNumber: 100,
@@ -247,7 +247,7 @@ test('Tile3D#viewerRequestVolume is camera inside the OBB viewer request volume'
   };
 
   // @ts-ignore
-  const tile = new Tile3D(tileset, tileHeaderWithViewerRequestVolume, '');
+  const tile = new Tile3D(tileset, tileHeaderWithViewerRequestVolume);
   tile.updateVisibility(
     {
       frameNumber: 100,
@@ -280,7 +280,7 @@ test('Tile3D#viewerRequestVolume is camera outside the OBB viewer request volume
   };
 
   // @ts-ignore
-  const tile = new Tile3D(tileset, tileHeaderWithViewerRequestVolume, '');
+  const tile = new Tile3D(tileset, tileHeaderWithViewerRequestVolume);
   tile.updateVisibility(
     {
       frameNumber: 100,


### PR DESCRIPTION
I didn't find a place where `basePath` is using in `TileHeader` class.
So I decided to remove it.
Also there were some issues after I changed arguments order in [PR](https://github.com/visgl/loaders.gl/pull/1536/files). I fixed it here as well.