### PR TITLE
Wrong parameter order when creating tiles

### DIFF
--- a/modules/tiles/src/tileset/tileset-3d.ts
+++ b/modules/tiles/src/tileset/tileset-3d.ts
@@ -594,7 +594,7 @@ export default class Tileset3D {
   _initializeTileHeaders(tilesetJson, parentTileHeader, basePath) {
     // A tileset JSON file referenced from a tile may exist in a different directory than the root tileset.
     // Get the basePath relative to the external tileset.
-    const rootTile = new Tile3D(this, tilesetJson.root, parentTileHeader, basePath); // resource
+    const rootTile = new Tile3D(this, tilesetJson.root, basePath, parentTileHeader); // resource
 
     // If there is a parentTileHeader, add the root of the currently loading tileset
     // to parentTileHeader's children, and update its depth.


### PR DESCRIPTION
Hi,
Not sure why this doesn't come up in test, but the wrong order introduced [here](https://github.com/visgl/loaders.gl/pull/1536/files#diff-1b5f6513c3c9b8caf11e101cf1685c34fb87b627fcb57d6901a101d6ec090600R122) breaks 3d tiles functionality in our project.
If this is approved, could you please release a new npm version?
Thank you!

/Avner