### PR TITLE
chore: Fix version injection for node and workers

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,5 @@
 const {getBabelConfig, deepMerge} = require('ocular-dev-tools');
+const __VERSION__ = require('./lerna.json').version;
 
 module.exports = (api) => {
   const defaultConfig = getBabelConfig(api, {react: true});
@@ -6,7 +7,7 @@ module.exports = (api) => {
   const config = deepMerge(defaultConfig, {
     plugins: [
       // inject __VERSION__ from package.json
-      'version-inline'
+      ['babel-plugin-global-define', {__VERSION__}]
     ],
     ignore: [
       // Don't transpile workers, they are transpiled separately

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@luma.gl/test-utils": "^8.3.0",
     "@probe.gl/bench": "^3.3.0",
     "@probe.gl/test-utils": "^3.3.1",
+    "babel-plugin-global-define": "^1.0.3",
     "coveralls": "^3.0.3",
     "ocular-dev-tools": "1.0.0-alpha.6",
     "pre-commit": "^1.2.2",


### PR DESCRIPTION
Version injection via `plugin-version-inline` does not work in cases where we don't build locally in a module directories, for instance when we run node tests, build test bundles or websites.

Since we sync all module versions we should be able to use the version in `lerna,json`.