### PR TITLE
Fix for " Property 'byteLength' is missing in type '{}' but required …

### DIFF
--- a/modules/gltf/src/lib/api/gltf-scenegraph.ts
+++ b/modules/gltf/src/lib/api/gltf-scenegraph.ts
@@ -556,9 +556,11 @@ export default class GLTFScenegraph {
     }
 
     // Update the glTF BIN CHUNK byte length
-    this.json.buffers = this.json.buffers || [];
-    this.json.buffers[0] = this.json.buffers[0] || {};
-    this.json.buffers[0].byteLength = totalByteLength;
+    if (this.json?.buffers?.[0]) {
+      this.json.buffers[0].byteLength = totalByteLength;
+    } else {
+      this.json.buffers = [{byteLength: totalByteLength}];
+    }
 
     // Save generated arrayBuffer
     this.gltf.binary = arrayBuffer;


### PR DESCRIPTION
Hi,
When bundling against the source I had the following typescript error:
```
modules/gltf/src/lib/api/gltf-scenegraph.ts(560,5): semantic error TS2322: Type 'Buffer | {}' is not assignable 
to type 'Buffer'. [0]   Property 'byteLength' is missing in type '{}' but required in type 'Buffer'.
```

Would this work as a fix?
