### PR TITLE
Worker-utils: Fix for runtime error: ReferenceError: __VERSION__ is not defined

### DIFF
--- a/modules/worker-utils/src/lib/env-utils/version.ts
+++ b/modules/worker-utils/src/lib/env-utils/version.ts
@@ -1,8 +1,4 @@
-// import {assert} from './assert';
-
+// Version constant cannot be imported, it needs to correspond to the build version of **this** module.
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
-export const VERSION = __VERSION__;
-if (typeof VERSION !== 'undefined') {
-  console.error('VERSION not injected');
-}
+export const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';

--- a/modules/worker-utils/src/lib/env-utils/version.ts
+++ b/modules/worker-utils/src/lib/env-utils/version.ts
@@ -1,4 +1,9 @@
 // Version constant cannot be imported, it needs to correspond to the build version of **this** module.
 // __VERSION__ is injected by babel-plugin-version-inline
-// @ts-ignore TS2304: Cannot find name '__VERSION__'.
+declare let __VERSION__;
 export const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+if (typeof __VERSION__ === 'undefined') {
+  console.error(
+    'loaders.gl: The __VERSION__ variable is not injected using babel-plugin-version-inline. Latest unstable workers would be fetched from the CDN.'
+  );
+}


### PR DESCRIPTION
When bundling against the source I got a runtime error:
```
Uncaught (in promise) ReferenceError: __VERSION__ is not defined
    at version.ts:5
```
I tried to fix it according to other `version.ts` files.
