### PR TITLE
Remove tileset options that override fetch options

### DIFF
--- a/modules/tiles/src/tileset/tileset-3d.ts
+++ b/modules/tiles/src/tileset/tileset-3d.ts
@@ -54,7 +54,6 @@ import {TILESET_TYPE} from '../constants';
 export type Tileset3DProps = {
   // loading
   token?: string;
-  headers?: any;
   throttleRequests?: boolean;
   maxRequests?: number;
   loadOptions?: {[key: string]: any};
@@ -96,7 +95,6 @@ type Props = {
   viewportTraversersMap: any;
   token: string;
   attributions: string[];
-  headers: any;
   maxRequests: number;
   loadTiles: boolean;
   loadOptions: {[key: string]: any};
@@ -148,7 +146,6 @@ const DEFAULT_PROPS: Props = {
   updateTransforms: true,
   viewportTraversersMap: null,
 
-  headers: {},
   loadOptions: {},
 
   token: '',
@@ -262,20 +259,7 @@ export default class Tileset3D {
     this.lodMetricValue = json.lodMetricValue;
     this.refine = json.root.refine;
 
-    // TODO add to loader context?
     this.loadOptions = this.options.loadOptions || {};
-    if (this.options.headers) {
-      this.loadOptions.fetch = {
-        ...this.loadOptions.fetch,
-        headers: this.options.headers
-      };
-    }
-    if (this.options.token) {
-      this.loadOptions.fetch = {
-        ...this.loadOptions.fetch,
-        token: this.options.token
-      };
-    }
 
     this.root = null;
     this.roots = {};


### PR DESCRIPTION
Hi,
These options were causing unwanted behavior because the default `headers` was `{}`, thus overriding `fetch.headers` regardless of what is sent by the user.
I think it should be OK to just remove these options and require everything to be set at `{fetch: }`?
I kept `token` because I saw it was getting added to `queryParams`, probably i3s related.
