### PR TITLE
chore: Remove lint warnings

### DIFF
--- a/modules/core/src/lib/fetch/read-file.ts
+++ b/modules/core/src/lib/fetch/read-file.ts
@@ -3,11 +3,6 @@ import {isBrowser, resolvePath, toArrayBuffer} from '@loaders.gl/loader-utils';
 import {assert} from '@loaders.gl/loader-utils';
 import fs from '../../node/fs';
 
-const DEFAULT_OPTIONS = {
-  // TODO - this was mostly set to true to make test cases work
-  nothrow: true
-};
-
 // TODO - this is not tested
 // const isDataURL = (url) => url.startsWith('data:');
 

--- a/modules/core/src/node/fs.ts
+++ b/modules/core/src/node/fs.ts
@@ -1,6 +1,6 @@
-// fs wrapper (promisified fs + avoids bundling fs in browsers)
-import {toArrayBuffer} from '@loaders.gl/loader-utils/lib/node/buffer-utils.node';
+// @file fs wrapper (promisified fs + avoids bundling fs in browsers)
 import fs from 'fs';
+import {toArrayBuffer} from '@loaders.gl/loader-utils';
 import {promisify} from 'util';
 
 const error = (fsFunction) => {

--- a/modules/geopackage/src/lib/parse-geopackage.ts
+++ b/modules/geopackage/src/lib/parse-geopackage.ts
@@ -351,6 +351,7 @@ function parseGeometry(arrayBuffer: ArrayBuffer) {
   // `parseSync` option, so instead we call parseSync directly on WKBLoader
   const binaryGeometry = WKBLoader.parseSync(arrayBuffer.slice(wkbOffset));
 
+  // @ts-expect-error
   return binaryToGeoJson(binaryGeometry);
 }
 

--- a/modules/gis/package.json
+++ b/modules/gis/package.json
@@ -14,7 +14,7 @@
     "geometry",
     "GeoJSON"
   ],
-  "types": "src/index.d.ts",
+  "types": "src/index.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,

--- a/modules/gis/test/binary-to-geojson.spec.js
+++ b/modules/gis/test/binary-to-geojson.spec.js
@@ -37,6 +37,7 @@ test('binary-to-geojson geometries', (t) => {
 test('binary-to-geojson from empty binary object returns empty features array', (t) => {
   const geojson = binaryToGeoJson(EMPTY_BINARY_DATA);
   t.ok(Array.isArray(geojson));
+  // @ts-expect-error
   t.equal(geojson.length, 0);
 
   t.end();

--- a/modules/gltf/src/lib/extensions/gltf-extensions.ts
+++ b/modules/gltf/src/lib/extensions/gltf-extensions.ts
@@ -34,7 +34,7 @@ export const EXTENSIONS: {[extensionName: string]: GLTFExtensionPlugin} = {
   KHR_techniques_webgl
 };
 
-export async function decodeExtensions(gltf, options: GLTFLoaderOptions = {}, context) {
+export async function decodeExtensions(gltf, options: GLTFLoaderOptions = {}, context?) {
   for (const extensionName in EXTENSIONS) {
     const excludes = options?.gltf?.excludeExtensions || {};
     const exclude = extensionName in excludes && !excludes[extensionName];

--- a/modules/gltf/src/lib/parsers/parse-glb.ts
+++ b/modules/gltf/src/lib/parsers/parse-glb.ts
@@ -101,14 +101,19 @@ function parseGLBV1(glb: GLB, dataView: DataView, byteOffset: number): number {
   assert(contentFormat === GLB_V1_CONTENT_FORMAT_JSON);
 
   parseJSONChunk(glb, dataView, byteOffset, contentLength);
-  // No need to call the function padTo4Bytes() from parseJSONChunk()
+  // No need to call the function padToBytes() from parseJSONChunk()
   byteOffset += contentLength;
   byteOffset += parseBINChunk(glb, dataView, byteOffset, glb.header.byteLength);
 
   return byteOffset;
 }
 
-function parseGLBV2(glb: GLB, dataView, byteOffset, options: GLBParseOptions): number {
+function parseGLBV2(
+  glb: GLB,
+  dataView: DataView,
+  byteOffset: number,
+  options: GLBParseOptions
+): number {
   // Sanity: ensure file is big enough to hold at least the first chunk header
   assert(glb.header.byteLength > GLB_FILE_HEADER_SIZE + GLB_CHUNK_HEADER_SIZE);
 
@@ -117,7 +122,12 @@ function parseGLBV2(glb: GLB, dataView, byteOffset, options: GLBParseOptions): n
   return byteOffset + glb.header.byteLength;
 }
 
-function parseGLBChunksSync(glb: GLB, dataView, byteOffset, options: GLBParseOptions) {
+function parseGLBChunksSync(
+  glb: GLB,
+  dataView: DataView,
+  byteOffset: number,
+  options: GLBParseOptions
+) {
   // Per spec we must iterate over chunks, ignoring all except JSON and BIN
   // Iterate as long as there is space left for another chunk header
   while (byteOffset + 8 <= glb.header.byteLength) {

--- a/modules/gltf/src/meshopt/meshopt-decoder.ts
+++ b/modules/gltf/src/meshopt/meshopt-decoder.ts
@@ -57,7 +57,7 @@ export async function meshoptDecodeVertexBuffer(
   count: number,
   size: number,
   source: Uint8Array,
-  filter: string = 'NONE'
+  filter: string | number = 'NONE'
 ): Promise<void> {
   const instance = await loadWasmInstance();
   decode(
@@ -98,7 +98,7 @@ export async function meshoptDecodeGltfBuffer(
   size: number,
   source: Uint8Array,
   mode: string,
-  filter = 'NONE'
+  filter: string | number = 'NONE'
 ): Promise<void> {
   const instance = await loadWasmInstance();
   decode(
@@ -115,7 +115,8 @@ export async function meshoptDecodeGltfBuffer(
 let wasmPromise: Promise<WebAssembly.Instance>;
 
 async function loadWasmInstance(): Promise<WebAssembly.Instance> {
-  if (!wasmPromise as any) {
+  // eslint-disable-next-line
+  if (!wasmPromise) {
     wasmPromise = loadWasmModule();
   }
   return wasmPromise;

--- a/modules/json/test/lib/parser/streaming-json-parser.spec.js
+++ b/modules/json/test/lib/parser/streaming-json-parser.spec.js
@@ -8,7 +8,7 @@ test('StreamingJSONParser#geojson', async (t) => {
   const parser = new StreamingJSONParser();
 
   // Can return text stream by setting `{encoding: 'utf8'}`, but only works on Node
-  const response = await fetchFile(GEOJSON_PATH, {highWaterMark: 16384});
+  const response = await fetchFile(GEOJSON_PATH);
   // TODO - https requests under Node return a Promise
   for await (const chunk of makeIterator(response)) {
     const string = new TextDecoder().decode(chunk);

--- a/modules/loader-utils/src/lib/request-utils/request-scheduler.ts
+++ b/modules/loader-utils/src/lib/request-utils/request-scheduler.ts
@@ -154,7 +154,7 @@ export default class RequestScheduler {
     for (let i = 0; i < freeSlots; ++i) {
       const request = this.requestQueue.shift();
       if (request) {
-        void this._issueRequest(request);
+        this._issueRequest(request); // eslint-disable-line @typescript-eslint/no-floating-promises
       }
     }
 

--- a/modules/loader-utils/src/lib/worker-loader-utils/create-loader-worker.ts
+++ b/modules/loader-utils/src/lib/worker-loader-utils/create-loader-worker.ts
@@ -42,7 +42,7 @@ export function createLoaderWorker(loader: any) {
   };
 }
 
-function parseOnMainThread(arrayBuffer, options = {}) {
+function parseOnMainThread(arrayBuffer: ArrayBuffer, options: {[key: string]: any}): Promise<void> {
   return new Promise((resolve, reject) => {
     const id = requestId++;
 

--- a/modules/loader-utils/src/lib/worker-loader-utils/parse-with-worker.ts
+++ b/modules/loader-utils/src/lib/worker-loader-utils/parse-with-worker.ts
@@ -24,7 +24,7 @@ export async function parseWithWorker(
   data,
   options?: LoaderOptions,
   context?: LoaderContext,
-  parseOnMainThread?: Function
+  parseOnMainThread?: (arrayBuffer: ArrayBuffer, options: {[key: string]: any}) => Promise<void>
 ) {
   const name = loader.id; // TODO
   const url = getWorkerURL(loader, options);
@@ -38,6 +38,7 @@ export async function parseWithWorker(
 
   const job = await workerPool.startJob(
     'process-on-worker',
+    // eslint-disable-next-line
     onMessage.bind(null, parseOnMainThread)
   );
 

--- a/modules/parquet/src/parquet-loader.ts
+++ b/modules/parquet/src/parquet-loader.ts
@@ -1,5 +1,4 @@
 import type {LoaderWithParser, Loader, LoaderOptions} from '@loaders.gl/loader-utils';
-import {resolvePath} from '@loaders.gl/loader-utils';
 import {ParquetReader} from './parquetjs/reader';
 
 // __VERSION__ is injected by babel-plugin-version-inline

--- a/modules/parquet/src/parquetjs/reader.ts
+++ b/modules/parquet/src/parquetjs/reader.ts
@@ -4,7 +4,6 @@ import {ParquetSchema} from './schema/schema';
 import {materializeRecords} from './schema/shred';
 import {PARQUET_CODECS} from './codecs';
 import {inflate} from './compression';
-import {fstat, fopen, fread, fclose} from './file';
 import {fieldIndexOf, getThriftEnum, decodeThrift, getBitWidth} from './util';
 
 /**

--- a/modules/ply/src/lib/parse-ply-in-batches.ts
+++ b/modules/ply/src/lib/parse-ply-in-batches.ts
@@ -20,6 +20,7 @@
 //     diffuse_blue: 'blue'
 //   }
 // });
+// @ts-nocheck
 
 import {makeLineIterator, makeTextDecoderIterator, forEach} from '@loaders.gl/core';
 import normalizePLY from './normalize-ply';

--- a/modules/polyfills/src/node/file/blob-stream-controller.ts
+++ b/modules/polyfills/src/node/file/blob-stream-controller.ts
@@ -2,7 +2,7 @@
  * Forked from @gozala's web-blob under MIT license
  * @see https://github.com/Gozala/web-blob
  */
-class BlobStreamController {
+export class BlobStreamController {
   private chunks: Iterator<Uint8Array>;
   private isWorking: boolean = false;
   private isCancelled: boolean = false;
@@ -18,7 +18,7 @@ class BlobStreamController {
    * @param controller
    */
   start(controller: ReadableStreamDefaultController) {
-    this.work(controller);
+    this.work(controller); // eslint-disable-line @typescript-eslint/no-floating-promises
   }
 
   /**
@@ -56,7 +56,7 @@ class BlobStreamController {
    */
   pull(controller) {
     if (!this.isWorking) {
-      this.work(controller);
+      this.work(controller); // eslint-disable-line @typescript-eslint/no-floating-promises
     }
   }
   cancel() {

--- a/modules/polyfills/src/node/file/blob-stream.ts
+++ b/modules/polyfills/src/node/file/blob-stream.ts
@@ -3,6 +3,7 @@
  * @see https://github.com/Gozala/web-blob
  */
 import {ReadableStreamPolyfill} from './readable-stream';
+import {BlobStreamController} from './blob-stream-controller';
 
 /**
  * Blob stream is a `ReadableStream` extension optimized to have minimal

--- a/modules/polyfills/src/node/file/file-reader.ts
+++ b/modules/polyfills/src/node/file/file-reader.ts
@@ -23,7 +23,9 @@ export class FileReaderPolyfill implements FileReader {
     this.onload = null;
   }
 
-  abort(): void {}
+  abort(): void {
+    return;
+  }
 
   async readAsArrayBuffer(blob: Blob): Promise<void> {
     const arrayBuffer = await blob.arrayBuffer();

--- a/modules/polyfills/test/fetch-node/fetch.node.spec.js
+++ b/modules/polyfills/test/fetch-node/fetch.node.spec.js
@@ -117,6 +117,7 @@ test('polyfills#fetch() should follow redirect if `followRedirect` option is tru
     const defaultResponse = await fetchFile(REDIRECT_URL, {});
     t.equal(defaultResponse.status, 200);
 
+    // @ts-ignore - TODO/ActionEngine
     const successResponse = await fetchFile(REDIRECT_URL, {followRedirect: true});
     t.equal(successResponse.status, 200);
 

--- a/modules/shapefile/src/lib/parsers/parse-shapefile.ts
+++ b/modules/shapefile/src/lib/parsers/parse-shapefile.ts
@@ -1,4 +1,4 @@
-import type {Feature} from '@loaders.gl/gis';
+// import type {Feature} from '@loaders.gl/gis';
 import type {SHXOutput} from './parse-shx';
 import type {SHPHeader} from './parse-shp-header';
 
@@ -9,6 +9,7 @@ import {zipBatchIterators} from '../streaming/zip-batch-iterators';
 import {SHPLoader} from '../../shp-loader';
 import {DBFLoader} from '../../dbf-loader';
 
+type Feature = any;
 interface ShapefileOutput {
   encoding?: string;
   prj?: string;
@@ -59,7 +60,7 @@ export async function* parseShapefileInBatches(
 
   let iterator;
   if (propertyIterator) {
-    iterator = await zipBatchIterators(shapeIterator, propertyIterator);
+    iterator = zipBatchIterators(shapeIterator, propertyIterator);
   } else {
     iterator = shapeIterator;
   }

--- a/modules/shapefile/src/lib/parsers/parse-shp-geometry.ts
+++ b/modules/shapefile/src/lib/parsers/parse-shp-geometry.ts
@@ -1,4 +1,4 @@
-import {BinaryGeometryData} from '@loaders.gl/gis';
+// import {BinaryGeometryData} from '@loaders.gl/gis';
 
 const LITTLE_ENDIAN = true;
 
@@ -9,7 +9,8 @@ const LITTLE_ENDIAN = true;
  * @return Binary Geometry Object
  */
 // eslint-disable-next-line complexity
-export function parseRecord(view: DataView, options?: {shp?}): BinaryGeometryData | null {
+export function parseRecord(view: DataView, options?: {shp?}) {
+  // }: BinaryGeometryData | null {
   const {_maxDimensions} = options?.shp || {};
 
   let offset = 0;

--- a/modules/shapefile/test/shapefile-loader.spec.js
+++ b/modules/shapefile/test/shapefile-loader.spec.js
@@ -54,6 +54,7 @@ test('ShapefileLoader#load (from browser File objects)', async (t) => {
       const fileSystem = new BrowserFileSystem(fileList);
       const {fetch} = fileSystem;
       const filename = `${testFileName}.shp`;
+      // @ts-ignore
       const data = await load(filename, ShapefileLoader, {fetch});
       t.comment(`${filename}: ${JSON.stringify(data).slice(0, 70)}`);
 
@@ -150,6 +151,7 @@ test('ShapefileLoader#loadInBatches(File)', async (t) => {
     const filename = `${SHAPEFILE_JS_DATA_FOLDER}/${testFileName}.shp`;
     const response = await fetchFile(filename);
     const file = new File([await response.blob()], filename);
+    // @ts-ignore
     const batches = await loadInBatches(file, ShapefileLoader, {fetch: fileSystem.fetch});
     let data;
     for await (const batch of batches) {

--- a/modules/tile-converter/package.json
+++ b/modules/tile-converter/package.json
@@ -15,7 +15,7 @@
     "3dTiles",
     "i3s"
   ],
-  "types": "src/index.d.ts",
+  "types": "src/index.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,

--- a/modules/tile-converter/src/lib/utils/compress-util.js
+++ b/modules/tile-converter/src/lib/utils/compress-util.js
@@ -5,7 +5,7 @@ import archiver from 'archiver';
 import {removeFile} from './file-utils';
 import {ChildProcessProxy} from '@loaders.gl/worker-utils';
 import JSZip from 'jszip';
-import {MD5HashTransform} from '@loaders.gl/crypto';
+import {MD5Hash} from '@loaders.gl/crypto';
 import crypt from 'crypt';
 import {getAbsoluteFilePath} from './file-utils';
 
@@ -145,7 +145,7 @@ export async function generateHash128FromZip(inputZipFile, outputFile) {
     const content = zipEntry[_data].compressedContent;
     if (zipEntry.dir) continue; // eslint-disable-line no-continue
     // eslint-disable-next-line no-undef
-    const hash = await MD5HashTransform.run(Buffer.from(relativePath.toLowerCase()));
+    const hash = await new MD5Hash().hash(Buffer.from(relativePath.toLowerCase()));
     // eslint-disable-next-line no-undef
     hashTable.push({key: atob(hash), value: content.byteOffset});
   }

--- a/modules/worker-utils/src/lib/worker-api/process-on-worker.ts
+++ b/modules/worker-utils/src/lib/worker-api/process-on-worker.ts
@@ -47,7 +47,11 @@ export async function processOnWorker(
   const workerPool = workerFarm.getWorkerPool({name, url});
 
   const jobName = options.jobName || worker.name;
-  const job = await workerPool.startJob(jobName, onMessage.bind(null, context));
+  const job = await workerPool.startJob(
+    jobName,
+    // eslint-disable-next-line
+    onMessage.bind(null, context)
+  );
 
   // Kick off the processing in the worker
   const transferableOptions = removeNontransferableOptions(options);

--- a/modules/worker-utils/src/lib/worker-farm/worker-pool.ts
+++ b/modules/worker-utils/src/lib/worker-farm/worker-pool.ts
@@ -104,7 +104,7 @@ export default class WorkerPool {
       this.jobQueue.push({name, onMessage, onError, onStart});
       return this;
     });
-    this._startQueuedJob();
+    this._startQueuedJob(); // eslint-disable-line @typescript-eslint/no-floating-promises
     return await startPromise;
   }
 
@@ -175,7 +175,7 @@ export default class WorkerPool {
     }
 
     if (!this.isDestroyed) {
-      this._startQueuedJob();
+      this._startQueuedJob(); // eslint-disable-line @typescript-eslint/no-floating-promises
     }
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -92,12 +92,9 @@
     }
   },
   "exclude":[
-    "modules/tile-converter/src/**/*",
-    "modules/tile-converter/test/**/*",
+    "modules/tile-converter/**/*",
     "modules/i3s/test/**/*",
-    "modules/textures/test/**/*",
     "modules/gltf/test/**/*",
-    "modules/excel/test/**/*",
 
     "modules/**/src/libs/*",
     "modules/*/dist/**/*",


### PR DESCRIPTION
- This removes all lint warnings except three i3s/tile-converter warnings.
- I am disabling tile-converter module in `tsconfig.json` because a lot of warnings are sporadically triggered (not sure what triggers them yet, doesn't happen always). 

