### PR TITLE
tiles: fix i3s LOD selection

### DIFF
--- a/modules/tiles/src/tileset/helpers/i3s-lod.ts
+++ b/modules/tiles/src/tileset/helpers/i3s-lod.ts
@@ -84,7 +84,6 @@ function getDistanceFromLatLon(observer: number[], center: number[]) {
 
 export function getI3ScreenSize(tile, frameState) {
   const viewport = frameState.viewport;
-  // https://stackoverflow.com/questions/21648630/radius-of-projected-sphere-in-screen-space
   const mbsLat = tile.header.mbs[1];
   const mbsLon = tile.header.mbs[0];
   const mbsZ = tile.header.mbs[2];
@@ -99,7 +98,10 @@ export function getI3ScreenSize(tile, frameState) {
   if (d <= 0.0) {
     return 0.5 * fltMax;
   }
-  // Hack: 300 is a Magic number to get the correct LoD
+  // https://stackoverflow.com/questions/21648630/radius-of-projected-sphere-in-screen-space
+  // There is a formula there to calculate projected radius:
+  // return 1.0 / Math.tan(fov) * r / Math.sqrt(d * d - r * r); // Right
+  // Hack: 300 is a Magic number to get the correct LoD. Possibly, d and r are calculated in a wrong way.
   const screenSizeFactor =
     ((getTanOfHalfVFAngle(frameState) * mbsRNormalized) / Math.sqrt(d)) * 300;
   return screenSizeFactor;

--- a/modules/tiles/src/tileset/helpers/i3s-lod.ts
+++ b/modules/tiles/src/tileset/helpers/i3s-lod.ts
@@ -49,7 +49,6 @@ export function lodJudge(tile, frameState) {
   if (screenSize < 0.5) {
     return 'OUT';
   }
-  // Hack: 1000 is a Magic number to get the correct LoD
   if (!tile.header.children || screenSize <= tile.lodMetricValue) {
     return 'DRAW';
   } else if (tile.header.children) {
@@ -100,24 +99,14 @@ export function getI3ScreenSize(tile, frameState) {
   if (d <= 0.0) {
     return 0.5 * fltMax;
   }
-  let screenSizeFactor = calculateScreenSizeFactor(tile, frameState);
-  // viewport changed in deck.gl v8.0
-  screenSizeFactor *= mbsRNormalized / Math.sqrt(d) / viewport.scale;
+  // Hack: 300 is a Magic number to get the correct LoD
+  const screenSizeFactor =
+    ((getTanOfHalfVFAngle(frameState) * mbsRNormalized) / Math.sqrt(d)) * 300;
   return screenSizeFactor;
 }
 
-function calculateScreenSizeFactor(tile, frameState) {
-  const {width, height, pixelProjectionMatrix} = frameState.viewport;
-  const tanOfHalfVFAngle = Math.tan(
-    Math.atan(
-      Math.sqrt(
-        1.0 / (pixelProjectionMatrix[0] * pixelProjectionMatrix[0]) +
-          1.0 / (pixelProjectionMatrix[5] * pixelProjectionMatrix[5])
-      )
-    )
-  );
-
-  const screenCircleFactor = Math.sqrt(height * height + width * width) / tanOfHalfVFAngle;
-
-  return screenCircleFactor;
+function getTanOfHalfVFAngle(frameState) {
+  const {projectionMatrix} = frameState.viewport;
+  const t = projectionMatrix[5];
+  return t;
 }

--- a/modules/tiles/test/tileset/index.js
+++ b/modules/tiles/test/tileset/index.js
@@ -1,3 +1,4 @@
 import './tile-3d.spec';
 import './tileset-3d.spec';
 import './helpers';
+import './traversers';

--- a/modules/tiles/test/tileset/traversers/index.js
+++ b/modules/tiles/test/tileset/traversers/index.js
@@ -1,0 +1,1 @@
+import './tileset-traverser.spec';

--- a/modules/tiles/test/tileset/traversers/tileset-traverser.spec.js
+++ b/modules/tiles/test/tileset/traversers/tileset-traverser.spec.js
@@ -1,0 +1,49 @@
+import test from 'tape-promise/tape';
+import {WebMercatorViewport} from '@deck.gl/core';
+import {load} from '@loaders.gl/core';
+import {Tiles3DLoader} from '@loaders.gl/3d-tiles';
+import {Tileset3D} from '@loaders.gl/tiles';
+
+import TilesetTraverser from '../../../src/tileset/traversers/tileset-traverser';
+import {getFrameState} from '../../../src/tileset/helpers/frame-state';
+
+// Parent tile with content and four child tiles with content
+const TILESET_URL = '@loaders.gl/3d-tiles/test/data/Tilesets/Tileset/tileset.json';
+
+test('Tileset3D#traverser base class', async (t) => {
+  const tilesetJson = await load(TILESET_URL, Tiles3DLoader);
+
+  // Create Tileset3D to have initialized Tile3Ds tree
+  const tileset = new Tileset3D(tilesetJson);
+
+  const traverser = new TilesetTraverser({
+    basePath: tilesetJson.basePath,
+    onTraversalEnd: traversalEnd
+  });
+
+  const viewport = new WebMercatorViewport({
+    altitude: 1.5,
+    bearing: 0,
+    far: 1000,
+    fovy: 50,
+    height: 600,
+    id: 'view0',
+    latitude: 40.049483884253355,
+    longitude: -75.60783109310839,
+    maxPitch: 85,
+    maxZoom: 30,
+    minPitch: 0,
+    minZoom: 2,
+    modelMatrix: null,
+    near: 0.1,
+    pitch: 45,
+    projectionMatrix: null,
+    width: 1848,
+    zoom: 12.660812211760435
+  });
+  traverser.traverse(tileset.root, getFrameState(viewport, 0), {});
+  function traversalEnd() {
+    t.ok(traverser);
+    t.end();
+  }
+});


### PR DESCRIPTION
There is a link in code:
https://stackoverflow.com/questions/21648630/radius-of-projected-sphere-in-screen-space
I found a formula there to calculate projected radius:
`return 1.0 / Math.tan(fov) * r / Math.sqrt(d * d - r * r); // Right`
Now it doesn't work without magic number `300`. Possibly, `d` and `r` are calculated wrong way.
Anyway, refinement works better now.
I checked this Munich and layers from website (SF, NY).

https://user-images.githubusercontent.com/18549629/124549302-a6ec3e80-de37-11eb-9070-2a2e52f4868f.mp4

