### PR TITLE
Remove commented markup from readme.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,6 @@
   <img src="https://img.shields.io/badge/License-MIT-green.svg" />
   <img src="https://badge.fury.io/js/%40loaders.gl%2Fcore.svg" />
   <img src="https://img.shields.io/npm/dm/@loaders.gl/core.svg" />
-  <!-- <img src="https://coveralls.io/repos/github/visgl/loaders.gl/badge.svg?" /> -->
   <br />
 </p>
 


### PR DESCRIPTION
@ibgreen  After this [line](https://github.com/visgl/loaders.gl/pull/1617/files#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R19) was added we get an issue related to parsing such markup via `gatsby-plugin-mdx`
This plugin normally works with comments outside of html markup.
I also tried to add [gatsby-remark-remove-comments](https://www.gatsbyjs.com/plugins/gatsby-remark-remove-comments/?=comments) plugin. It doesn't help.
I decided to just remove it from markup for now.
Please let me know if you have a better solution for that.
