### PR TITLE
fix(i3s): import type TypedArray

### DIFF
--- a/modules/i3s/package.json
+++ b/modules/i3s/package.json
@@ -36,6 +36,7 @@
     "@loaders.gl/draco": "3.0.0-beta.9",
     "@loaders.gl/images": "3.0.0-beta.9",
     "@loaders.gl/loader-utils": "3.0.0-beta.9",
+    "@loaders.gl/schema": "3.0.0-beta.9",
     "@loaders.gl/textures": "3.0.0-beta.9",
     "@loaders.gl/tiles": "3.0.0-beta.9",
     "@luma.gl/constants": "^8.3.0",

--- a/modules/i3s/src/lib/parsers/parse-i3s-tile-content.ts
+++ b/modules/i3s/src/lib/parsers/parse-i3s-tile-content.ts
@@ -1,3 +1,4 @@
+import type {TypedArray} from '@loaders.gl/schema';
 import {Vector3, Matrix4} from '@math.gl/core';
 import {Ellipsoid} from '@math.gl/geospatial';
 


### PR DESCRIPTION
One of three failing typescript errors when importing loaders into an app.