### PR TITLE
fix(i3s): Safari test error

### DIFF
--- a/modules/i3s/test/i3s-loader.spec.js
+++ b/modules/i3s/test/i3s-loader.spec.js
@@ -20,7 +20,7 @@ test('I3SLoader#Load tile content', async (t) => {
   // ImageLoader returns different things on browser and Node
   const texture = content.material.pbrMetallicRoughness.baseColorTexture.texture.source.image;
   if (isBrowser) {
-    t.ok(texture instanceof ImageBitmap || texture);
+    t.ok(texture);
   } else {
     t.equal(texture.data.byteLength, 131072);
   }


### PR DESCRIPTION
- Fixes one of two errors when running `yarn test browser` in Safari.
- The other error in MVT module seems to be a precision issue during deep equal, requires a bit more work.

Neither error would affect apps, but good to have a clean run.

