### PR TITLE
WIP(shapefile): fix context typings

### DIFF
--- a/modules/loader-utils/src/index.ts
+++ b/modules/loader-utils/src/index.ts
@@ -3,6 +3,7 @@ export type {
   Loader,
   LoaderWithParser,
   LoaderContext,
+  LocalContext,
   LoaderOptions,
   Writer,
   WriterOptions,

--- a/modules/loader-utils/src/index.ts
+++ b/modules/loader-utils/src/index.ts
@@ -3,7 +3,6 @@ export type {
   Loader,
   LoaderWithParser,
   LoaderContext,
-  LocalContext,
   LoaderOptions,
   Writer,
   WriterOptions,

--- a/modules/loader-utils/src/types.ts
+++ b/modules/loader-utils/src/types.ts
@@ -184,10 +184,17 @@ export type LoaderContext = {
   parseInBatches?: ParseInBatches;
 };
 
+export type LocalContext = {
+  fetch: NonNullable<LoaderContext['fetch']>;
+  url: NonNullable<LoaderContext['url']>;
+  parse: NonNullable<LoaderContext['parse']> | any;
+  parseInBatches: NonNullable<LoaderContext['parseInBatches']> | any;
+};
+
 type Parse = (
   arrayBuffer: ArrayBuffer,
   options?: LoaderOptions,
-  context?: LoaderContext
+  context?: LoaderContext & LocalContext
 ) => Promise<any>;
 type ParseSync = (
   arrayBuffer: ArrayBuffer,
@@ -196,6 +203,7 @@ type ParseSync = (
 ) => any;
 type ParseText = (text: string, options?: LoaderOptions) => Promise<any>;
 type ParseTextSync = (text: string, options?: LoaderOptions) => any;
+
 type ParseInBatches = (
   iterator: AsyncIterable<ArrayBuffer> | Iterable<ArrayBuffer>,
   options?: LoaderOptions,

--- a/modules/loader-utils/src/types.ts
+++ b/modules/loader-utils/src/types.ts
@@ -184,17 +184,10 @@ export type LoaderContext = {
   parseInBatches?: ParseInBatches;
 };
 
-export type LocalContext = {
-  fetch: NonNullable<LoaderContext['fetch']>;
-  url: NonNullable<LoaderContext['url']>;
-  parse: NonNullable<LoaderContext['parse']> | any;
-  parseInBatches: NonNullable<LoaderContext['parseInBatches']> | any;
-};
-
 type Parse = (
   arrayBuffer: ArrayBuffer,
   options?: LoaderOptions,
-  context?: LoaderContext & LocalContext
+  context?: LoaderContext
 ) => Promise<any>;
 type ParseSync = (
   arrayBuffer: ArrayBuffer,

--- a/modules/shapefile/src/lib/parsers/parse-shp.ts
+++ b/modules/shapefile/src/lib/parsers/parse-shp.ts
@@ -1,5 +1,6 @@
 import type {BinaryGeometry} from '@loaders.gl/schema';
 import type {LoaderOptions} from '@loaders.gl/loader-utils/';
+
 import BinaryChunkReader from '../streaming/binary-chunk-reader';
 import {parseSHPHeader} from './parse-shp-header';
 import {parseRecord} from './parse-shp-geometry';

--- a/modules/shapefile/src/lib/parsers/parse-shp.ts
+++ b/modules/shapefile/src/lib/parsers/parse-shp.ts
@@ -1,8 +1,8 @@
 import type {BinaryGeometry} from '@loaders.gl/schema';
+import type {LoaderOptions} from '@loaders.gl/loader-utils/';
 import BinaryChunkReader from '../streaming/binary-chunk-reader';
 import {parseSHPHeader} from './parse-shp-header';
 import {parseRecord} from './parse-shp-geometry';
-import {LoaderOptions} from '@loaders.gl/loader-utils/types';
 
 const LITTLE_ENDIAN = true;
 const BIG_ENDIAN = false;
@@ -141,7 +141,7 @@ function parseState(
 
         case STATE.EXPECTING_RECORD:
           while (binaryReader.hasAvailableBytes(SHP_RECORD_HEADER_SIZE)) {
-            const recordHeaderView = binaryReader.getDataView(SHP_RECORD_HEADER_SIZE);
+            const recordHeaderView = binaryReader.getDataView(SHP_RECORD_HEADER_SIZE) as DataView;
             const recordHeader = {
               recordNumber: recordHeaderView.getInt32(0, BIG_ENDIAN),
               // 2 byte words; includes the four words of record header
@@ -172,7 +172,7 @@ function parseState(
               // rewind 4 bytes before reading record
               binaryReader.rewind(4);
 
-              const recordView = binaryReader.getDataView(recordHeader.byteLength);
+              const recordView = binaryReader.getDataView(recordHeader.byteLength) as DataView;
               const geometry = parseRecord(recordView, options);
               result.geometries.push(geometry);
 

--- a/modules/shapefile/src/lib/streaming/binary-chunk-reader.ts
+++ b/modules/shapefile/src/lib/streaming/binary-chunk-reader.ts
@@ -19,11 +19,11 @@ export default class BinaryChunkReader {
   /**
    * @param arrayBuffer
    */
-  write(arrayBuffer: ArrayBuffer) {
+  write(arrayBuffer: ArrayBuffer): void {
     this.arrayBuffers.push(arrayBuffer);
   }
 
-  end() {
+  end(): void {
     this.arrayBuffers = [];
     this.ended = true;
   }
@@ -97,7 +97,7 @@ export default class BinaryChunkReader {
    * @param bytes Number of bytes
    * @return DataView with data
    */
-  getDataView(bytes: number): DataView {
+  getDataView(bytes: number): DataView | null {
     const bufferOffsets = this.findBufferOffsets(bytes);
     // return `null` if not enough data, except if end() already called, in
     // which case throw an error.
@@ -106,7 +106,6 @@ export default class BinaryChunkReader {
     }
 
     if (!bufferOffsets) {
-      // @ts-ignore
       return null;
     }
 
@@ -151,7 +150,7 @@ export default class BinaryChunkReader {
    * @param bufferOffsets List of internal array offsets
    * @return New contiguous ArrayBuffer
    */
-  _combineArrayBuffers(bufferOffsets: any[]) {
+  _combineArrayBuffers(bufferOffsets: any[]): ArrayBufferLike {
     let byteLength: number = 0;
     for (const bufferOffset of bufferOffsets) {
       const [start, end] = bufferOffset[1];
@@ -174,13 +173,13 @@ export default class BinaryChunkReader {
   /**
    * @param bytes
    */
-  skip(bytes: number) {
+  skip(bytes: number): void {
     this.offset += bytes;
   }
   /**
    * @param bytes
    */
-  rewind(bytes: number) {
+  rewind(bytes: number): void {
     // TODO - only works if offset is already set
     this.offset -= bytes;
   }

--- a/modules/shapefile/test/streaming/binary-chunk-reader.spec.js
+++ b/modules/shapefile/test/streaming/binary-chunk-reader.spec.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import test from 'tape-promise/tape';
 import BinaryChunkReader from '@loaders.gl/shapefile/lib/streaming/binary-chunk-reader';
 


### PR DESCRIPTION
The problem was that after assignment of **'context'** as the **LoaderContext** type there are many warnings with  **fetch, parse, url** etc. as they are all optional and cannot be invoke as they are possibly undefined.

So my suggestion instead of every time typeof checking is:

I created export type **'LocalContext'** in loader-utils with the utility type **"NonNullable"**, it excludes undefined from LoaderContext's parameters and returns the clean parameter
