### PR TITLE
examples: terraint debug with start-local

### DIFF
--- a/examples/experimental/terrain/package.json
+++ b/examples/experimental/terrain/package.json
@@ -8,8 +8,16 @@
     "start": "webpack-dev-server --progress --hot --open"
   },
   "dependencies": {
-    "deck.gl": "^8.4.0",
-    "@loaders.gl/terrain": "3.0.0-beta.10",
+    "@deck.gl/core": "8.5.0-beta.1",
+    "@deck.gl/extensions": "8.5.0-beta.1",
+    "@deck.gl/geo-layers": "8.5.0-beta.1",
+    "@deck.gl/react": "8.5.0-beta.1",
+    "@deck.gl/mesh-layers": "8.5.0-beta.1",
+    "@deck.gl/layers": "8.5.0-beta.1",
+    "@loaders.gl/core": "^3.0.0-beta.8",
+    "@loaders.gl/loader-utils": "^3.0.0-beta.8",
+    "@loaders.gl/mvt": "^3.0.0-beta.8",
+    "@loaders.gl/terrain": "^3.0.0-beta.8",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
     "react-map-gl": "^5.0.0"


### PR DESCRIPTION
This configuration allows to debug `modules/terrain/src/lib/parse-terrain.js` with `yarn start-local-deck`. I can't setup it to debug with `yarn start-local`. It runs code from `node_modules`.