### PR TITLE
fix(3d-tiles): `const` -> `let` for reassignment in tile-3d-batch-table-hierarchy

### DIFF
--- a/modules/3d-tiles/src/lib/classes/tile-3d-batch-table-hierarchy.js
+++ b/modules/3d-tiles/src/lib/classes/tile-3d-batch-table-hierarchy.js
@@ -37,10 +37,10 @@ function initializeHierarchyValues(hierarchyJson, binaryBody) {
 
   const instancesLength = hierarchyJson.instancesLength;
   const classes = hierarchyJson.classes;
-  const classIds = hierarchyJson.classIds;
-  const parentCounts = hierarchyJson.parentCounts;
-  const parentIds = hierarchyJson.parentIds;
-  const parentIdsLength = instancesLength;
+  let classIds = hierarchyJson.classIds;
+  let parentCounts = hierarchyJson.parentCounts;
+  let parentIds = hierarchyJson.parentIds;
+  let parentIdsLength = instancesLength;
 
   if (defined(classIds.byteOffset)) {
     classIds.componentType = defaultValue(classIds.componentType, GL.UNSIGNED_SHORT);


### PR DESCRIPTION
I came across this bug trying to bundle `deck.gl` with `esbuild`.

```bash
❯ esbuild --bundle --external:util --external:react --external:geotiff --format=esm index.js
 > node_modules/@loaders.gl/3d-tiles/dist/esm/lib/classes/tile-3d-batch-table-hierarchy.js:40:4: error: Cannot assign to "classIds" because it is a constant
    40 │     classIds = binaryAccessor.createArrayBufferView(binaryBody.buffer, binaryBody.byteOffset + classIds.byteOffset, instancesLength);
       ╵     ~~~~~~~~
   node_modules/@loaders.gl/3d-tiles/dist/esm/lib/classes/tile-3d-batch-table-hierarchy.js:31:8: note: "classIds" was declared a constant here
    31 │   const classIds = hierarchyJson.classIds;
       ╵         ~~~~~~~~

 > node_modules/@loaders.gl/3d-tiles/dist/esm/lib/classes/tile-3d-batch-table-hierarchy.js:50:6: error: Cannot assign to "parentCounts" because it is a constant
    50 │       parentCounts = binaryAccessor.createArrayBufferView(binaryBody.buffer, binaryBody.byteOffset + parentCounts.byteOffset, instancesLen...
       ╵       ~~~~~~~~~~~~
   node_modules/@loaders.gl/3d-tiles/dist/esm/lib/classes/tile-3d-batch-table-hierarchy.js:32:8: note: "parentCounts" was declared a constant here
    32 │   const parentCounts = hierarchyJson.parentCounts;
       ╵         ~~~~~~~~~~~~

 > node_modules/@loaders.gl/3d-tiles/dist/esm/lib/classes/tile-3d-batch-table-hierarchy.js:54:4: error: Cannot assign to "parentIdsLength" because it is a constant
    54 │     parentIdsLength = 0;
       ╵     ~~~~~~~~~~~~~~~
   node_modules/@loaders.gl/3d-tiles/dist/esm/lib/classes/tile-3d-batch-table-hierarchy.js:34:8: note: "parentIdsLength" was declared a constant here
    34 │   const parentIdsLength = instancesLength;
       ╵         ~~~~~~~~~~~~~~~

 > node_modules/@loaders.gl/3d-tiles/dist/esm/lib/classes/tile-3d-batch-table-hierarchy.js:58:6: error: Cannot assign to "parentIdsLength" because it is a constant
    58 │       parentIdsLength += parentCounts[i];
       ╵       ~~~~~~~~~~~~~~~
   node_modules/@loaders.gl/3d-tiles/dist/esm/lib/classes/tile-3d-batch-table-hierarchy.js:34:8: note: "parentIdsLength" was declared a constant here
    34 │   const parentIdsLength = instancesLength;
       ╵         ~~~~~~~~~~~~~~~

 > node_modules/@loaders.gl/3d-tiles/dist/esm/lib/classes/tile-3d-batch-table-hierarchy.js:66:4: error: Cannot assign to "parentIds" because it is a constant
    66 │     parentIds = binaryAccessor.createArrayBufferView(binaryBody.buffer, binaryBody.byteOffset + parentIds.byteOffset, parentIdsLength);
       ╵     ~~~~~~~~~
   node_modules/@loaders.gl/3d-tiles/dist/esm/lib/classes/tile-3d-batch-table-hierarchy.js:33:8: note: "parentIds" was declared a constant here
    33 │   const parentIds = hierarchyJson.parentIds;
       ╵
```

removing `// @ts-nocheck` helped to resolve in my editor but has been added back.