### PR TITLE
Revert "Load workers of `latest` versions (#1673)"

### DIFF
--- a/modules/i3s/src/i3s-content-loader.ts
+++ b/modules/i3s/src/i3s-content-loader.ts
@@ -4,7 +4,7 @@ import {parseI3STileContent} from './lib/parsers/parse-i3s-tile-content';
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
 
-const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'beta';
 /**
  * Loader for I3S - Indexed 3D Scene Layer
  */

--- a/modules/worker-utils/src/lib/worker-api/get-worker-url.ts
+++ b/modules/worker-utils/src/lib/worker-api/get-worker-url.ts
@@ -2,7 +2,7 @@ import type {WorkerObject, WorkerOptions} from '../../types';
 import {assert} from '../env-utils/assert';
 import {VERSION as __VERSION__} from '../env-utils/version';
 
-const NPM_TAG = 'latest';
+const NPM_TAG = 'beta'; // Change to 'latest' on release-branch
 const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : NPM_TAG;
 
 /**


### PR DESCRIPTION
This reverts commit 48672a87f617aa37bdc0414694d022294f747692.

We have to use 'beta' workers on master. `latest` are for release branch.