### PR TITLE
fix(worker-utils): Use default import for "child_process"

### DIFF
--- a/modules/worker-utils/src/lib/process-utils/child-process-proxy.ts
+++ b/modules/worker-utils/src/lib/process-utils/child-process-proxy.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-console */
-import ChildProcess from 'child_process';
+import * as ChildProcess from 'child_process';
 import {getAvailablePort} from './process-utils';
-import type {SpawnOptionsWithoutStdio} from 'child_process';
 
 export type ChildProcessProxyProps = {
   command: string;
@@ -16,7 +15,7 @@ export type ChildProcessProxyProps = {
   /** wait: 0 - infinity */
   wait?: number;
   /** Options passed on to Node'.js `spawn` */
-  spawn?: SpawnOptionsWithoutStdio;
+  spawn?: ChildProcess.SpawnOptionsWithoutStdio;
   /** Callback when the  */
   onStart?: (proxy: ChildProcessProxy) => void;
   onSuccess?: (proxy: ChildProcessProxy) => void;
@@ -40,7 +39,7 @@ const DEFAULT_PROPS: ChildProcessProxyProps = {
 export default class ChildProcessProxy {
   id: string;
   props: ChildProcessProxyProps = {...DEFAULT_PROPS};
-  private childProcess: ReturnType<typeof ChildProcess['spawn']> | null = null;
+  private childProcess: ChildProcess.ChildProcess | null = null;
   private port: number = 0;
   private successTimer?;
 

--- a/modules/worker-utils/src/lib/process-utils/child-process-proxy.ts
+++ b/modules/worker-utils/src/lib/process-utils/child-process-proxy.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
-import {spawn, ChildProcess, SpawnOptionsWithoutStdio} from 'child_process';
+import ChildProcess from 'child_process';
 import {getAvailablePort} from './process-utils';
+import type {SpawnOptionsWithoutStdio} from 'child_process';
 
 export type ChildProcessProxyProps = {
   command: string;
@@ -39,7 +40,7 @@ const DEFAULT_PROPS: ChildProcessProxyProps = {
 export default class ChildProcessProxy {
   id: string;
   props: ChildProcessProxyProps = {...DEFAULT_PROPS};
-  private childProcess: ChildProcess | null = null;
+  private childProcess: ReturnType<typeof ChildProcess['spawn']> | null = null;
   private port: number = 0;
   private successTimer?;
 
@@ -74,7 +75,7 @@ export default class ChildProcessProxy {
         });
 
         console.log(`Spawning ${props.command} ${props.arguments.join(' ')}`);
-        const childProcess = spawn(props.command, args, props.spawn);
+        const childProcess = ChildProcess.spawn(props.command, args, props.spawn);
         this.childProcess = childProcess;
 
         childProcess.stdout.on('data', (data) => {

--- a/modules/worker-utils/src/lib/process-utils/child-process-proxy.ts
+++ b/modules/worker-utils/src/lib/process-utils/child-process-proxy.ts
@@ -1,4 +1,7 @@
 /* eslint-disable no-console */
+// Avoid using named imports for Node builtins to help with "empty" resolution
+// for bundlers targeting browser environments. Access imports & types
+// through the `ChildProcess` object (e.g. `ChildProcess.spawn`, `ChildProcess.ChildProcess`).
 import * as ChildProcess from 'child_process';
 import {getAvailablePort} from './process-utils';
 


### PR DESCRIPTION
Further discussion here: https://github.com/hms-dbmi/viv/pull/480#issuecomment-892970913

TL;DR - when `@loaders.gl/worker-utils` [transitioned to TS](visgl/loaders.gl@787271a#diff-653aabc2ef3b70398fe5a382c9f7c6359a5ecdd223901c6b15ea54b6ce418e67), changing 

```javascript
import ChildProcess from 'child_process';
```

to

```typescript
import {spawn, ChildProcess, SpawnOptionsWithoutStdio} from 'child_process';
```

broke our build when we tried to upgrade to deck.gl 8.5. This is because the `"empty"` resolution for some bundlers for node builtins is only a `default` export, so using named imports won't be resolved. This may seem like a bundler/bundler-plugin issue, but bundlers will resolve `package.json` "browser" differently. Using a `default` import for node-builtins will likely reduce friction with using loaders.gl with different bundlers in the future.