### PR TITLE
fix(core): Help browser resolution `make-node-stream`; use default export

### DIFF
--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -30,7 +30,7 @@ export {RequestScheduler} from '@loaders.gl/loader-utils';
 export {makeIterator} from './iterators/make-iterator/make-iterator';
 export {makeStream} from './iterators/make-stream/make-stream';
 export {makeDOMStream} from './iterators/make-stream/make-dom-stream';
-export {makeNodeStream} from './iterators/make-stream/make-node-stream';
+export {default as makeNodeStream} from './iterators/make-stream/make-node-stream';
 
 // CORE LOADERS
 export {NullWorkerLoader, NullLoader} from './null-loader';

--- a/modules/core/src/iterators/make-stream/make-node-stream.ts
+++ b/modules/core/src/iterators/make-stream/make-node-stream.ts
@@ -3,7 +3,7 @@ import {Readable, ReadableOptions} from 'stream';
 export type MakeNodeStreamOptions = ReadableOptions;
 
 /** Builds a node stream from an iterator */
-export function makeNodeStream<ArrayBuffer>(
+function makeNodeStream<ArrayBuffer>(
   source: Iterable<ArrayBuffer> | AsyncIterable<ArrayBuffer>,
   options?: ReadableOptions
 ): Readable {
@@ -63,3 +63,8 @@ class AsyncIterableReadable extends Readable {
     return !this.readable;
   }
 }
+
+// This module is marked `false` in the the "browser" field of the `package.json` for
+// `@loaders.gl/core`. We avoid using named exports so that bundlers have an easier
+// time resolving this "empty" module.
+export default makeNodeStream;

--- a/modules/core/src/iterators/make-stream/make-stream.ts
+++ b/modules/core/src/iterators/make-stream/make-stream.ts
@@ -4,7 +4,7 @@ import type {MakeNodeStreamOptions} from './make-node-stream';
 
 import {isBrowser} from '@loaders.gl/loader-utils';
 import {makeDOMStream} from './make-dom-stream';
-import {makeNodeStream} from './make-node-stream';
+import makeNodeStream from './make-node-stream';
 
 export type MakeStreamOptions = MakeDOMStreamOptions | MakeNodeStreamOptions;
 


### PR DESCRIPTION
Similar issue to #1742 & #1741. Ran into an issue with `rollup` and `vite`.

Not sure if you have a preference for implementing this. I figure that is someone wants to "fix" the import weirdness, they will need to navigate to `make-node-stream.ts` to change the default export and will see the comment.