### PR TITLE
WIP: chore(arrow): bump apache-arrow to 5.0.0

### DIFF
--- a/modules/arrow/package.json
+++ b/modules/arrow/package.json
@@ -39,6 +39,6 @@
     "@loaders.gl/core": "3.0.1",
     "@loaders.gl/loader-utils": "3.0.1",
     "@loaders.gl/schema": "3.0.1",
-    "apache-arrow": "^4.0.0"
+    "apache-arrow": "^5.0.0"
   }
 }

--- a/modules/arrow/src/lib/arrow-table-batch.ts
+++ b/modules/arrow/src/lib/arrow-table-batch.ts
@@ -1,5 +1,5 @@
 import type {ArrowTableBatch} from '@loaders.gl/schema';
-import {Schema, Field, RecordBatch, Float32Vector, Float32} from 'apache-arrow';
+import {Schema, Field, RecordBatch, Float32Vector, Float32} from 'apache-arrow/Arrow.node';
 import {ColumnarTableBatchAggregator} from '@loaders.gl/schema';
 
 export default class ArrowTableBatchAggregator extends ColumnarTableBatchAggregator {

--- a/modules/arrow/src/lib/encode-arrow.ts
+++ b/modules/arrow/src/lib/encode-arrow.ts
@@ -1,4 +1,4 @@
-import {Table, FloatVector, DateVector} from 'apache-arrow';
+import {Table, FloatVector, DateVector} from 'apache-arrow/Arrow.node';
 import {AnyArrayType, VECTOR_TYPES} from '../types';
 
 type ColumnarTable = {

--- a/modules/arrow/src/lib/parse-arrow-in-batches.ts
+++ b/modules/arrow/src/lib/parse-arrow-in-batches.ts
@@ -1,5 +1,5 @@
 // TODO - this import defeats the sophisticated typescript checking in ArrowJS
-import {RecordBatchReader} from 'apache-arrow';
+import {RecordBatchReader} from 'apache-arrow/Arrow.node';
 // import {isIterable} from '@loaders.gl/core';
 
 /**

--- a/modules/arrow/src/lib/parse-arrow-sync.ts
+++ b/modules/arrow/src/lib/parse-arrow-sync.ts
@@ -1,5 +1,5 @@
 import type {ArrowLoaderOptions} from '../arrow-loader';
-import {Table} from 'apache-arrow';
+import {Table} from 'apache-arrow/Arrow.node';
 
 // Parses arrow to a columnar table
 export default function parseArrowSync(arrayBuffer, options?: ArrowLoaderOptions) {

--- a/modules/schema/package.json
+++ b/modules/schema/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@types/geojson": "^7946.0.7",
-    "apache-arrow": "^4.0.0",
+    "apache-arrow": "^5.0.0",
     "d3-dsv": "^1.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2403,10 +2403,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
   integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
 
-"@types/node@^14.14.37":
-  version "14.17.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.3.tgz#6d327abaa4be34a74e421ed6409a0ae2f47f4c3d"
-  integrity sha512-e6ZowgGJmTuXa3GyaPbTGxX17tnThl2aSSizrFthQ7m9uLGZBXiGhgE55cjRZTF5kjZvYn9EOPOMljdjwbflxw==
+"@types/node@^15.6.1":
+  version "15.14.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.14.7.tgz#29fea9a5b14e2b75c19028e1c7a32edd1e89fe92"
+  integrity sha512-FA45p37/mLhpebgbPWWCKfOisTjxGK9lwcHlJ6XVLfu3NgfcazOJHdYUZCWPMK8QX4LhNZdmfo6iMz9FqpUbaw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -2440,11 +2440,6 @@
   dependencies:
     "@types/emscripten" "*"
     "@types/node" "*"
-
-"@types/text-encoding-utf-8@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@types/text-encoding-utf-8/-/text-encoding-utf-8-1.0.1.tgz#908d884af1114e5d8df47597b1e04f833383d23d"
-  integrity sha512-GpIEYaS+yNfYqpowLLziiY42pyaL+lThd/wMh6tTubaKuG4IRkXqqyxK7Nddn3BvpUg2+go3Gv/jbXvAFMRjiQ==
 
 "@types/thrift@^0.10.8":
   version "0.10.11"
@@ -2897,21 +2892,19 @@ anymatch@~3.1.1:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-apache-arrow@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/apache-arrow/-/apache-arrow-4.0.0.tgz#29616f5b5959cf0b0a6e49f8aa060ea53d4429ba"
-  integrity sha512-Y1o9UfCVhh7IB+RPVbCx7SgF51SjvT9ZKxCtFU1eaqleFZNxj89mH2gvQia4uA197x158XDemTz9O+Rrv+f5tg==
+apache-arrow@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/apache-arrow/-/apache-arrow-5.0.0.tgz#8af341f97ed5ce05615cd69c339f81966e96dd9e"
+  integrity sha512-Iogghl8f4cBAXI+kNUoy1carTTCj0Jr8bwlsaFrH2/XGyAHRyuxvkE6j4poRbH/ytW8AiZZ5A8mejRmpYDHSZg==
   dependencies:
     "@types/flatbuffers" "^1.10.0"
-    "@types/node" "^14.14.37"
-    "@types/text-encoding-utf-8" "^1.0.1"
+    "@types/node" "^15.6.1"
     command-line-args "5.1.1"
     command-line-usage "6.1.1"
     flatbuffers "1.12.0"
     json-bignum "^0.0.3"
     pad-left "^2.1.0"
-    text-encoding-utf-8 "^1.0.2"
-    tslib "^2.2.0"
+    tslib "^2.3.0"
 
 append-transform@^2.0.0:
   version "2.0.0"
@@ -3811,9 +3804,9 @@ camelize@^1.0.0:
   integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 caniuse-lite@^1.0.30001219:
-  version "1.0.30001248"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001248.tgz"
-  integrity sha512-NwlQbJkxUFJ8nMErnGtT0QTM2TJ33xgz4KXJSMIrjXIbDVdaYueGyjOrLKRtJC+rTiWfi6j5cnZN1NBiSBJGNw==
+  version "1.0.30001249"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001249.tgz"
+  integrity sha512-vcX4U8lwVXPdqzPWi6cAJ3FnQaqXbBqy/GZseKNQzRj37J7qZdGcBtxq/QLFNLLlfsoXLUdHw8Iwenri86Tagw==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -11480,11 +11473,6 @@ test-exclude@^6.0.0:
     glob "^7.1.4"
     minimatch "^3.0.4"
 
-text-encoding-utf-8@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz#585b62197b0ae437e3c7b5d0af27ac1021e10d13"
-  integrity sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg==
-
 text-extensions@^1.0.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.9.0.tgz#1853e45fee39c945ce6f6c36b2d659b5aabc2a26"
@@ -11719,15 +11707,10 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0:
+tslib@^2.0.0, tslib@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
-
-tslib@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
-  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
 tsutils@^3.21.0:
   version "3.21.0"
@@ -11813,9 +11796,9 @@ typedarray@^0.0.6:
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
 typescript@^4.2.3:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.2.tgz#399ab18aac45802d6f2498de5054fcbbe716a805"
-  integrity sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
+  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
 
 typical@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
There are 2 issues.
1. webpack 4 doesn't support "Package exports": https://webpack.js.org/guides/package-exports . It is solved by fixing imports:
```
import {Schema, Field, RecordBatch, Float32Vector, Float32} from 'apache-arrow/Arrow.node';
```

2. typescript versions are incompatible.
`apache-arrow` has `"typescript": "4.0.2"`;
`@loaders.gl` has `typescript@^4.2.3`.


<details>
  <summary>Using 4.2.3 there are errors on `node_modules`...</summary>
<p>
user@user-XPS-15-9570:~/apps/loaders.gl$ node_modules/.bin/tsc
node_modules/apache-arrow/interfaces.ts:269:5 - error TS2502: '[Type.List                 ]' is referenced directly or indirectly in its own type annotation.

269     [Type.List                 ]: T extends type.List                 ? vecs.ListVector<T['valueType']>                     : never ;
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/apache-arrow/interfaces.ts:272:5 - error TS2502: '[Type.FixedSizeList        ]' is referenced directly or indirectly in its own type annotation.

272     [Type.FixedSizeList        ]: T extends type.FixedSizeList        ? vecs.FixedSizeListVector<T['valueType']>            : never ;
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/apache-arrow/io/adapters.ts:207:25 - error TS2304: Cannot find name 'ReadableStreamBYOBReader'.

207     private byobReader: ReadableStreamBYOBReader | null = null;
                            ~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/apache-arrow/io/adapters.ts:209:21 - error TS2304: Cannot find name 'ReadableStreamBYOBReader'.

209     private reader: ReadableStreamBYOBReader | ReadableStreamDefaultReader<T> | null;
                        ~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/apache-arrow/io/adapters.ts:264:56 - error TS2554: Expected 0 arguments, but got 1.

264             this.byobReader = this.source['getReader']({ mode: 'byob' });
                                                           ~~~~~~~~~~~~~~~~

node_modules/apache-arrow/io/adapters.ts:283:33 - error TS2304: Cannot find name 'ReadableStreamBYOBReader'.

283 async function readInto(reader: ReadableStreamBYOBReader, buffer: ArrayBufferLike, offset: number, size: number): Promise<ReadableStreamReadResult<Uint8Array>> {
                                    ~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/apache-arrow/io/adapters.ts:303:17 - error TS2322: Type '(value: [T, any] | PromiseLike<[T, any]>) => void' is not assignable to type '(value?: [T, any] | PromiseLike<[T, any]> | undefined) => void'.

303         (r) => (resolve = r) && stream['once'](event, handler)
                    ~~~~~~~

node_modules/apache-arrow/io/adapters.ts:303:17 - error TS2322: Type '(value: [T, any] | PromiseLike<[T, any]>) => void' is not assignable to type '(value?: [T, any] | PromiseLike<[T, any]> | undefined) => void'.
  Types of parameters 'value' and 'value' are incompatible.
    Type '[T, any] | PromiseLike<[T, any]> | undefined' is not assignable to type '[T, any] | PromiseLike<[T, any]>'.
      Type 'undefined' is not assignable to type '[T, any] | PromiseLike<[T, any]>'.

303         (r) => (resolve = r) && stream['once'](event, handler)
                    ~~~~~~~

node_modules/apache-arrow/io/adapters.ts:394:45 - error TS2794: Expected 1 arguments, but got 0. Did you forget to include 'void' in your type argument to 'Promise'?

394                 err != null ? reject(err) : resolve();
                                                ~~~~~~~~~

  node_modules/typescript/lib/lib.es2015.promise.d.ts:33:34
    33     new <T>(executor: (resolve: (value: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void): Promise<T>;
                                        ~~~~~~~~~~~~~~~~~~~~~~~~~
    An argument for 'value' was not provided.

node_modules/apache-arrow/io/interfaces.ts:78:58 - error TS2304: Cannot find name 'PipeOptions'.

78     public pipeTo(writable: WritableStream<T>, options?: PipeOptions) { return this._getDOMStream().pipeTo(writable, options); }
                                                            ~~~~~~~~~~~

node_modules/apache-arrow/io/interfaces.ts:79:119 - error TS2304: Cannot find name 'PipeOptions'.

79     public pipeThrough<R extends ReadableStream<any>>(duplex: { writable: WritableStream<T>; readable: R }, options?: PipeOptions) {
                                                                                                                         ~~~~~~~~~~~

node_modules/apache-arrow/io/interfaces.ts:168:39 - error TS2322: Type '(value: IteratorResult<TReadable, any> | PromiseLike<IteratorResult<TReadable, any>>) => void' is not assignable to type '(value?: IteratorResult<TReadable, any> | PromiseLike<IteratorResult<TReadable, any>> | undefined) => void'.
  Types of parameters 'value' and 'value' are incompatible.
    Type 'IteratorResult<TReadable, any> | PromiseLike<IteratorResult<TReadable, any>> | undefined' is not assignable to type 'IteratorResult<TReadable, any> | PromiseLike<IteratorResult<TReadable, any>>'.
      Type 'undefined' is not assignable to type 'IteratorResult<TReadable, any> | PromiseLike<IteratorResult<TReadable, any>>'.

168                 this.resolvers.push({ resolve, reject });
                                          ~~~~~~~

  node_modules/apache-arrow/io/interfaces.ts:95:24
    95 type Resolution<T> = { resolve: (value?: T | PromiseLike<T>) => void; reject: (reason?: any) => void };
                              ~~~~~~~
    The expected type comes from property 'resolve' which is declared here on type 'Resolution<IteratorResult<TReadable, any>>'

node_modules/apache-arrow/io/stream.ts:55:30 - error TS2345: Argument of type 'any' is not assignable to parameter of type 'never'.

55                 buffers.push(chunk);
                                ~~~~~

node_modules/apache-arrow/io/whatwg/writer.ts:33:9 - error TS2322: Type 'string' is not assignable to type 'undefined'.

33         type: 'bytes',
           ~~~~

node_modules/apache-arrow/recordbatch.ts:48:19 - error TS2394: This overload signature is not compatible with its implementation signature.

48     public static from<T extends { [key: string]: DataType } = any, TNull = any>(options: VectorBuilderOptionsAsync<Struct<T>, TNull>): Promise<Table<T>>;
                     ~~~~

  node_modules/apache-arrow/recordbatch.ts:50:19
    50     public static from<T extends { [key: string]: DataType } = any, TNull = any>(options: VectorBuilderOptions<Struct<T>, TNull> | VectorBuilderOptionsAsync<Struct<T>, TNull>) {
                         ~~~~
    The implementation signature is declared here.

node_modules/apache-arrow/util/buffer.ts:90:11 - error TS2304: Cannot find name 'ReadableStreamReadResult'.

90           ReadableStreamReadResult<ArrayBufferView | ArrayBufferLike | ArrayBufferView | Iterable<number> | ArrayLike<number> | ByteBuffer | string | null | undefined> ;
             ~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/apache-arrow/vector/index.ts:88:55 - error TS2502: 'args' is referenced directly or indirectly in its own type annotation.

88 function newVector<T extends DataType>(data: Data<T>, ...args: VectorCtorArgs<V<T>>): V<T> {
                                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/apache-arrow/vector/row.ts:62:19 - error TS2322: Type 'V' is not assignable to type 'undefined'.

62                 ((val = itov[idx]) !== undefined) || (itov[idx] = val = this.getValue(idx));
                     ~~~

node_modules/apache-arrow/vector/row.ts:62:67 - error TS2322: Type 'V' is not assignable to type 'undefined'.

62                 ((val = itov[idx]) !== undefined) || (itov[idx] = val = this.getValue(idx));
                                                                     ~~~

node_modules/apache-arrow/vector/row.ts:66:19 - error TS2322: Type 'V' is not assignable to type 'undefined'.

66                 ((val = itov[idx]) !== undefined) || (itov[idx] = val = this.getValue(idx));
                     ~~~

node_modules/apache-arrow/vector/row.ts:66:67 - error TS2322: Type 'V' is not assignable to type 'undefined'.

66                 ((val = itov[idx]) !== undefined) || (itov[idx] = val = this.getValue(idx));
                                                                     ~~~


Found 21 errors.
</p>
</details>

<details>
<summary>I tried usage `typescript@4.0.2` in `@loaders.gl` but it doesn't support <a href="https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html">Template Literal Types</a>...</summary>
<p>
user@user-XPS-15-9570:~/apps/loaders.gl$ node_modules/.bin/tsc
modules/geotiff/src/lib/ome/omexml.ts:141:42 - error TS1110: Type expected.

141 type PhysicalSize<Name extends string> = `PhysicalSize${Name}`;
                                             ~~~~~~~~~~~~~~~

modules/geotiff/src/lib/ome/omexml.ts:142:46 - error TS1110: Type expected.

142 type PhysicalSizeUnit<Name extends string> = `PhysicalSize${Name}Unit`;
                                                 ~~~~~~~~~~~~~~~

modules/geotiff/src/lib/ome/omexml.ts:143:35 - error TS1110: Type expected.

143 type Size<Names extends string> = `Size${Names}`;
                                      ~~~~~~~

modules/geotiff/src/lib/ome/utils.ts:11:44 - error TS1110: Type expected.

11 type Sel<Dim extends string> = Dim extends `${infer Z}${infer X}${infer A}${infer B}${infer C}`
                                              ~~~

modules/geotiff/src/lib/ome/utils.ts:11:53 - error TS1005: '}' expected.

11 type Sel<Dim extends string> = Dim extends `${infer Z}${infer X}${infer A}${infer B}${infer C}`
                                                       ~

modules/geotiff/src/lib/ome/utils.ts:11:54 - error TS1128: Declaration or statement expected.

11 type Sel<Dim extends string> = Dim extends `${infer Z}${infer X}${infer A}${infer B}${infer C}`
                                                        ~

modules/geotiff/src/lib/ome/utils.ts:11:56 - error TS1005: ';' expected.

11 type Sel<Dim extends string> = Dim extends `${infer Z}${infer X}${infer A}${infer B}${infer C}`
                                                          ~

modules/geotiff/src/lib/ome/utils.ts:11:63 - error TS1005: ';' expected.

11 type Sel<Dim extends string> = Dim extends `${infer Z}${infer X}${infer A}${infer B}${infer C}`
                                                                 ~

modules/geotiff/src/lib/ome/utils.ts:11:66 - error TS1005: ';' expected.

11 type Sel<Dim extends string> = Dim extends `${infer Z}${infer X}${infer A}${infer B}${infer C}`
                                                                    ~

modules/geotiff/src/lib/ome/utils.ts:11:73 - error TS1005: ';' expected.

11 type Sel<Dim extends string> = Dim extends `${infer Z}${infer X}${infer A}${infer B}${infer C}`
                                                                           ~

modules/geotiff/src/lib/ome/utils.ts:11:76 - error TS1005: ';' expected.

11 type Sel<Dim extends string> = Dim extends `${infer Z}${infer X}${infer A}${infer B}${infer C}`
                                                                              ~

modules/geotiff/src/lib/ome/utils.ts:11:83 - error TS1005: ';' expected.

11 type Sel<Dim extends string> = Dim extends `${infer Z}${infer X}${infer A}${infer B}${infer C}`
                                                                                     ~

modules/geotiff/src/lib/ome/utils.ts:11:86 - error TS1005: ';' expected.

11 type Sel<Dim extends string> = Dim extends `${infer Z}${infer X}${infer A}${infer B}${infer C}`
                                                                                        ~

modules/geotiff/src/lib/ome/utils.ts:11:93 - error TS1005: ';' expected.

11 type Sel<Dim extends string> = Dim extends `${infer Z}${infer X}${infer A}${infer B}${infer C}`
                                                                                               ~

modules/geotiff/src/lib/ome/utils.ts:40:1 - error TS1160: Unterminated template literal.

40 
   

modules/geotiff/src/types.ts:4:57 - error TS1005: ']' expected.

4 export type TypedArray = InstanceType<typeof globalThis[`${Dtype}Array`]>;
                                                          ~~~

modules/geotiff/src/types.ts:4:72 - error TS1005: ';' expected.

4 export type TypedArray = InstanceType<typeof globalThis[`${Dtype}Array`]>;
                                                                         ~

modules/geotiff/src/types.ts:4:73 - error TS1109: Expression expected.

4 export type TypedArray = InstanceType<typeof globalThis[`${Dtype}Array`]>;
                                                                          ~

modules/geotiff/src/types.ts:4:74 - error TS1109: Expression expected.

4 export type TypedArray = InstanceType<typeof globalThis[`${Dtype}Array`]>;
                                                                           ~

modules/zarr/src/types.ts:3:66 - error TS1005: ']' expected.

3 export type SupportedTypedArray = InstanceType<typeof globalThis[`${SupportedDtype}Array`]>;
                                                                   ~~~

modules/zarr/src/types.ts:3:90 - error TS1005: ';' expected.

3 export type SupportedTypedArray = InstanceType<typeof globalThis[`${SupportedDtype}Array`]>;
                                                                                           ~

modules/zarr/src/types.ts:3:91 - error TS1109: Expression expected.

3 export type SupportedTypedArray = InstanceType<typeof globalThis[`${SupportedDtype}Array`]>;
                                                                                            ~

modules/zarr/src/types.ts:3:92 - error TS1109: Expression expected.

3 export type SupportedTypedArray = InstanceType<typeof globalThis[`${SupportedDtype}Array`]>;
                                                                                             ~


Found 23 errors.
</p>
</details>