### PR TITLE
Add part of dummy header to LZ4 parquet files

### DIFF
--- a/modules/compression/src/lib/lz4-compression.ts
+++ b/modules/compression/src/lib/lz4-compression.ts
@@ -1,9 +1,16 @@
 // LZ4
+import {concatenateArrayBuffers} from '@loaders.gl/loader-utils/';
 import type {CompressionOptions} from './compression';
 import {Compression} from './compression';
 // import lz4js from 'lz4js'; // https://bundlephobia.com/package/lz4
 
 let lz4js;
+// Numbers are taken from here:
+// https://github.com/Benzinga/lz4js
+const FILE_DESCRIPTOR_VERSION = 0x40;
+const DEFAULT_BLOCK_SIZE = 7;
+const BLOCK_SIZE_SHIFT = 4;
+const LZ4_MAGIC_NUMBER = 0x184d2204;
 
 /**
  * LZ4 compression / decompression
@@ -41,11 +48,44 @@ export class LZ4Compression extends Compression {
     // // remove unnecessary bytes
     // result = result.slice(0, uncompressedSize);
     // return result;
+    const shouldAddHeader = this.checkMagicNumber(input);
+
+    if (shouldAddHeader) {
+      input = this.addHeaderForLZ4file(input);
+    }
+
     const inputArray = new Uint8Array(input);
     try {
       return lz4js.decompress(inputArray, maxSize).buffer;
     } catch (error) {
       throw this.improveError(error);
     }
+  }
+
+  /**
+   * Add dummy header to file if it is missed.
+   * @param input
+   */
+  addHeaderForLZ4file(input: ArrayBuffer): ArrayBuffer {
+    const magic = new Uint32Array([LZ4_MAGIC_NUMBER]);
+    // TODO need to implement descriptor as part of header
+    // https://github.com/Benzinga/lz4js/blob/master/lz4.js#L486
+    const frameDescriptor = Buffer.from([
+      FILE_DESCRIPTOR_VERSION,
+      DEFAULT_BLOCK_SIZE << BLOCK_SIZE_SHIFT
+      // Here should be hash part
+    ]);
+
+    return concatenateArrayBuffers(magic.buffer, frameDescriptor, input);
+  }
+
+  /**
+   * Compare file magic with lz4 magic number
+   * @param input
+   * @returns
+   */
+  checkMagicNumber(input: ArrayBuffer): boolean {
+    const magic = new Uint32Array(input.slice(0, 4));
+    return magic[0] !== LZ4_MAGIC_NUMBER;
   }
 }

--- a/modules/compression/test/compression.spec.js
+++ b/modules/compression/test/compression.spec.js
@@ -254,3 +254,18 @@ test.skip('zstd#worker', async (t) => {
   t.ok(compareArrayBuffers(decompressdData, binaryData), 'compress/decompress level 6');
   t.end();
 });
+
+test('lz4#compresion should add dummy header', async (t) => {
+  if (isBrowser) {
+    t.end();
+    return;
+  }
+
+  const compression = new LZ4Compression({modules});
+  const emptyLz4Buffer = new Uint8Array([4, 34, 77, 24, 64, 112, 223, 0, 0, 0, 0]).buffer;
+  const emptyLz4BufferWithoutMagicAndHashPart = emptyLz4Buffer.slice(6);
+  const result = compression.decompressSync(emptyLz4BufferWithoutMagicAndHashPart);
+
+  t.deepEqual(result, new Uint8Array(0));
+  t.end();
+});

--- a/modules/parquet/src/parquetjs/compression.ts
+++ b/modules/parquet/src/parquetjs/compression.ts
@@ -104,7 +104,7 @@ function addDummyHeaderForLZ4file(value: ArrayBuffer): ArrayBuffer {
   const frameDescriptor = Buffer.from([
     FILE_DESCRIPTOR_VERSION,
     DEFAULT_BLOCK_SIZE << BLOCK_SIZE_SHIFT,
-    100
+    0 // Here should be hash part
   ]);
 
   return concatenateArrayBuffers(magic.buffer, frameDescriptor, value);

--- a/modules/parquet/src/parquetjs/compression.ts
+++ b/modules/parquet/src/parquetjs/compression.ts
@@ -23,6 +23,7 @@ import brotliDecompress from 'brotli/decompress';
 import lz4js from 'lz4js';
 import lzo from 'lzo';
 import {ZstdCodec} from 'zstd-codec';
+import {concatenateArrayBuffers} from '@loaders.gl/loader-utils/';
 
 // Inject large dependencies through Compression constructor options
 const modules = {
@@ -81,9 +82,32 @@ export function decompress(method: ParquetCompression, value: Buffer, size: numb
   if (!compression) {
     throw new Error(`parquet: invalid compression method: ${method}`);
   }
-  const inputArrayBuffer = toArrayBuffer(value);
+
+  let inputArrayBuffer = toArrayBuffer(value);
+
+  if (['LZ4_RAW', 'LZ4'].includes(method)) {
+    inputArrayBuffer = addDummyHeaderForLZ4file(inputArrayBuffer);
+  }
+
   const compressedArrayBuffer = compression.decompressSync(inputArrayBuffer);
   return toBuffer(compressedArrayBuffer);
+}
+
+function addDummyHeaderForLZ4file(value: ArrayBuffer): ArrayBuffer {
+  const FILE_DESCRIPTOR_VERSION = 0x40;
+  const DEFAULT_BLOCK_SIZE = 7;
+  const BLOCK_SIZE_SHIFT = 4;
+  const LZ4_MAGIC_NUMBER = 0x184d2204;
+
+  const magic = new Uint32Array([LZ4_MAGIC_NUMBER]);
+  // TODO need to implement descriptor checksum https://github.com/Benzinga/lz4js/blob/master/lz4.js#L486
+  const frameDescriptor = Buffer.from([
+    FILE_DESCRIPTOR_VERSION,
+    DEFAULT_BLOCK_SIZE << BLOCK_SIZE_SHIFT,
+    100
+  ]);
+
+  return concatenateArrayBuffers(magic.buffer, frameDescriptor, value);
 }
 
 /*


### PR DESCRIPTION
Parquet files with LZ4 compression doesn't have "header" with magic number + frame descriptor part.
The idea is to add dummy header to file buffer.
[Spec](https://android.googlesource.com/platform/external/lz4/+/HEAD/doc/lz4_Frame_format.md)
Here an [example](https://github.com/Benzinga/lz4js/blob/master/lz4.js#L474) of encoding lz4 file from package which we use to decompress such files.