### PR TITLE
DO NOT MERGE: Add LZ4 compression support for Parquet

### DIFF
--- a/modules/compression/package.json
+++ b/modules/compression/package.json
@@ -28,6 +28,7 @@
   ],
   "browser": {
     "lzo": false,
+    "lz4": false,
     "zlib": false,
     "util": false
   },
@@ -42,19 +43,18 @@
     "@loaders.gl/worker-utils": "3.0.1",
     "@types/brotli": "^1.3.0",
     "@types/pako": "^1.0.1",
+    "lz4": "^0.6.5",
     "lzo-wasm": "^0.0.4",
     "pako": "1.0.11",
     "snappyjs": "^0.6.1"
   },
   "optionalDependencies": {
     "brotli": "^1.3.2",
-    "lz4js": "^0.2.0",
     "lzo": "^0.4.11",
     "zstd-codec": "^0.1"
   },
   "devDependencies": {
     "brotli": "^1.3.2",
-    "lz4js": "^0.2.0",
     "lzo": "^0.4.11",
     "zstd-codec": "^0.1"
   }

--- a/modules/compression/src/lib/compression.ts
+++ b/modules/compression/src/lib/compression.ts
@@ -31,9 +31,9 @@ export abstract class Compression {
   }
 
   /** Asynchronously decompress data */
-  async decompress(input: ArrayBuffer): Promise<ArrayBuffer> {
+  async decompress(input: ArrayBuffer, size?: number): Promise<ArrayBuffer> {
     await this.preload();
-    return this.decompressSync(input);
+    return this.decompressSync(input, size);
   }
 
   /** Synchronously compress data */
@@ -42,7 +42,7 @@ export abstract class Compression {
   }
 
   /** Synchronously compress data */
-  decompressSync(input: ArrayBuffer): ArrayBuffer {
+  decompressSync(input: ArrayBuffer, size?: number): ArrayBuffer {
     throw new Error(`${this.name}: sync decompression not supported`);
   }
 
@@ -57,11 +57,12 @@ export abstract class Compression {
 
   /** Decompress batches */
   async *decompressBatches(
-    asyncIterator: AsyncIterable<ArrayBuffer> | Iterable<ArrayBuffer>
+    asyncIterator: AsyncIterable<ArrayBuffer> | Iterable<ArrayBuffer>,
+    size: number
   ): AsyncIterable<ArrayBuffer> {
     // TODO - implement incremental compression
     const input = await this.concatenate(asyncIterator);
-    yield this.decompress(input);
+    yield this.decompress(input, size);
   }
 
   // HELPERS

--- a/modules/compression/src/workers/worker.ts
+++ b/modules/compression/src/workers/worker.ts
@@ -14,7 +14,7 @@ import {ZstdCompression} from '../lib/zstd-compression';
 
 // import brotli from 'brotli'; - brotli has problems with decompress in browsers
 import brotliDecompress from 'brotli/decompress';
-import lz4js from 'lz4js';
+import LZ4 from 'lz4';
 // import lzo from 'lzo';
 import {ZstdCodec} from 'zstd-codec';
 
@@ -27,7 +27,7 @@ const modules = {
       throw new Error('brotli compress');
     }
   },
-  lz4js,
+  LZ4,
   // lzo,
   'zstd-codec': ZstdCodec
 };

--- a/modules/parquet/package.json
+++ b/modules/parquet/package.json
@@ -36,7 +36,8 @@
     "child_process": false,
     "net": false,
     "tls": false,
-    "lzo": false
+    "lzo": false,
+    "lz4": false
   },
   "dependencies": {
     "@loaders.gl/compression": "3.0.1",
@@ -51,7 +52,7 @@
     "thrift": "^0.14.2",
     "varint": "^5.0.0",
     "brotli": "^1.3.2",
-    "lz4js": "^0.2.0",
+    "lz4": "^0.6.5",
     "lzo": "^0.4.11",
     "zstd-codec": "^0.1"
   },

--- a/modules/parquet/src/parquetjs/compression.ts
+++ b/modules/parquet/src/parquetjs/compression.ts
@@ -20,7 +20,7 @@ import {toArrayBuffer, toBuffer} from './utils/buffer-utils';
 
 // import brotli from 'brotli'; - brotli has problems with decompress in browsers
 import brotliDecompress from 'brotli/decompress';
-import lz4js from 'lz4js';
+import LZ4 from 'lz4';
 import lzo from 'lzo';
 import {ZstdCodec} from 'zstd-codec';
 
@@ -33,7 +33,7 @@ const modules = {
       throw new Error('brotli compress');
     }
   },
-  lz4js,
+  LZ4,
   lzo,
   'zstd-codec': ZstdCodec
 };
@@ -82,7 +82,7 @@ export function decompress(method: ParquetCompression, value: Buffer, size: numb
     throw new Error(`parquet: invalid compression method: ${method}`);
   }
   const inputArrayBuffer = toArrayBuffer(value);
-  const compressedArrayBuffer = compression.decompressSync(inputArrayBuffer);
+  const compressedArrayBuffer = compression.decompressSync(inputArrayBuffer, size);
   return toBuffer(compressedArrayBuffer);
 }
 

--- a/modules/parquet/test/data/files.js
+++ b/modules/parquet/test/data/files.js
@@ -1,8 +1,8 @@
 const PARQUET_FILES = [
   // Parquet seems to use LZ4 compression without header so we need to find a way to e.g. add a dummy header.
-  {supported: false, title: 'lz4_raw_compressed', path: 'good/lz4_raw_compressed.parquet'},
-  {supported: false, title: 'lz4_raw_compressed_larger', path: 'good/lz4_raw_compressed_larger.parquet'},
-  {supported: false, title: 'non_hadoop_lz4_compressed', path: 'good/non_hadoop_lz4_compressed.parquet'},
+  {supported: true, title: 'lz4_raw_compressed', path: 'good/lz4_raw_compressed.parquet'},
+  {supported: true, title: 'lz4_raw_compressed_larger', path: 'good/lz4_raw_compressed_larger.parquet'},
+  {supported: true, title: 'non_hadoop_lz4_compressed', path: 'good/non_hadoop_lz4_compressed.parquet'},
   {supported: true, title: 'alltypes_dictionary', path: 'good/alltypes_dictionary.parquet'},
   {supported: true, title: 'alltypes_plain', path: 'good/alltypes_plain.parquet'},
   {supported: true, title: 'alltypes_plain_snappy', path: 'good/alltypes_plain.snappy.parquet'},

--- a/modules/parquet/test/expected.js
+++ b/modules/parquet/test/expected.js
@@ -208,23 +208,23 @@ export const NESTED_LIST_EXPECTED = [
             list:
               [{
                 element: {
-                  list: [{ element: "a" },
-                  { element: "b" }]
+                  list: [{ element: 'a' },
+                  { element: 'b' }]
                 }
               },
               {
-                element: { list: [{ element: "c" }] }
+                element: { list: [{ element: 'c' }] }
               }]
           }
         },
         {
           element: {
-            list: [{}, { element: { list: [{ element: "d" }] } }]
+            list: [{}, { element: { list: [{ element: 'd' }] } }]
           }
         }
       ]
     },
-    b: "1"
+    b: '1'
   },
   {
     a:
@@ -235,18 +235,18 @@ export const NESTED_LIST_EXPECTED = [
           {
             list: [{
               element:
-                { list: [{ element: "a" }, { element: "b" }] }
+                { list: [{ element: 'a' }, { element: 'b' }] }
             },
             {
-              element: { list: [{ element: "c" }, { element: "d" }] }
+              element: { list: [{ element: 'c' }, { element: 'd' }] }
             }]
           }
         },
         {
-          element: { list: [{}, { element: { list: [{ element: "e" }] } }] }
+          element: { list: [{}, { element: { list: [{ element: 'e' }] } }] }
         }]
     },
-    b: "1"
+    b: '1'
   },
   {
     a:
@@ -256,17 +256,17 @@ export const NESTED_LIST_EXPECTED = [
           element:
           {
             list: [
-              { element: { list: [{ element: "a" }, { element: "b" }] } },
-              { element: { list: [{ element: "c" }, { element: "d" }] } },
-              { element: { list: [{ element: "e" }] } }
+              { element: { list: [{ element: 'a' }, { element: 'b' }] } },
+              { element: { list: [{ element: 'c' }, { element: 'd' }] } },
+              { element: { list: [{ element: 'e' }] } }
             ]
           }
         },
         {
-          element: { list: [{}, { element: { list: [{ element: "f" }] } }] }
+          element: { list: [{}, { element: { list: [{ element: 'f' }] } }] }
         }]
     },
-    b: "1"
+    b: '1'
   }
 ];
 
@@ -279,15 +279,15 @@ export const NESTED_MAPS_EXPECTED = [
           key: Buffer.from([97]),
           value: {
             key_value: [
-              { key: "1", value: true },
-              { key: "2", value: false }
+              { key: '1', value: true },
+              { key: '2', value: false }
             ]
           }
         }
       ]
     },
-    b: "1",
-    c: "1"
+    b: '1',
+    c: '1'
   },
   {
     a:
@@ -297,14 +297,14 @@ export const NESTED_MAPS_EXPECTED = [
           key: Buffer.from([98]),
           value: {
             key_value: [
-              { key: "1", value: true }
+              { key: '1', value: true }
             ]
           }
         }
       ]
     },
-    b: "1",
-    c: "1"
+    b: '1',
+    c: '1'
   },
   {
     a: {
@@ -312,8 +312,8 @@ export const NESTED_MAPS_EXPECTED = [
         { key: Buffer.from([99]) }
       ]
     },
-    b: "1",
-    c: "1"
+    b: '1',
+    c: '1'
   },
   {
     a: {
@@ -323,8 +323,8 @@ export const NESTED_MAPS_EXPECTED = [
         }
       ]
     },
-    b: "1",
-    c: "1"
+    b: '1',
+    c: '1'
   },
   {
     a:
@@ -334,14 +334,14 @@ export const NESTED_MAPS_EXPECTED = [
           key: Buffer.from([101]),
           value: {
             key_value: [
-              { key: "1", value: true }
+              { key: '1', value: true }
             ]
           }
         }
       ]
     },
-    b: "1",
-    c: "1"
+    b: '1',
+    c: '1'
   },
   {
     a: {
@@ -350,16 +350,16 @@ export const NESTED_MAPS_EXPECTED = [
           key: Buffer.from([102]),
           value: {
             key_value: [
-              { key: "3", value: true },
-              { key: "4", value: false },
-              { key: "5", value: true }
+              { key: '3', value: true },
+              { key: '4', value: false },
+              { key: '5', value: true }
             ]
           }
         }
       ]
     },
-    b: "1",
-    c: "1"
+    b: '1',
+    c: '1'
   }
 ];
 
@@ -403,26 +403,26 @@ export const NULLABLE_EXPECTED = [
     id: 1,
     int_array: {
       list: [
-        { element: "1" },
-        { element: "2" },
-        { element: "3" }
+        { element: '1' },
+        { element: '2' },
+        { element: '3' }
       ]
     },
     int_array_Array: {
       list: [
-        { element: { list: [{ element: "1" }, { element: "2" }] } },
-        { element: { list: [{ element: "3" }, { element: "4" }] } }
+        { element: { list: [{ element: '1' }, { element: '2' }] } },
+        { element: { list: [{ element: '3' }, { element: '4' }] } }
       ]
     },
     int_map: {
       map: [
-        { key: "k1", value: 1 },
-        { key: "k2", value: 100 }
+        { key: 'k1', value: 1 },
+        { key: 'k2', value: 100 }
       ]
     },
     int_Map_Array: {
       list: [
-        { element: { map: [{ key: "k1", value: "1" }] } }
+        { element: { map: [{ key: 'k1', value: '1' }] } }
       ]
     },
     nested_struct: {
@@ -431,14 +431,14 @@ export const NULLABLE_EXPECTED = [
       C: {
         d: {
           list: [
-            { element: { list: [{ element: { E: "10", F: "aaa" } }, { element: { E: "-10", F: "bbb" } }] } },
-            { element: { list: [{ element: { E: "11", F: "c" } }] } }
+            { element: { list: [{ element: { E: '10', F: 'aaa' } }, { element: { E: '-10', F: 'bbb' } }] } },
+            { element: { list: [{ element: { E: '11', F: 'c' } }] } }
           ]
         }
       },
       g: {
         map: [
-          { key: "foo", value: { H: { "i": { list: [{ element: "1.1" }] } } } }
+          { key: 'foo', value: { H: { 'i': { list: [{ element: '1.1' }] } } } }
         ]
       }
     }
@@ -448,24 +448,24 @@ export const NULLABLE_EXPECTED = [
     int_array: {
       list: [
         {},
-        { element: "1" },
-        { element: "2" },
-        {}, { element: "3" },
+        { element: '1' },
+        { element: '2' },
+        {}, { element: '3' },
         {}
       ]
     },
     int_array_Array: {
       list: [
-        { element: { list: [{}, { element: "1" }, { element: "2" }, {}] } },
-        { element: { list: [{ element: "3" }, {}, { element: "4" }] } },
+        { element: { list: [{}, { element: '1' }, { element: '2' }, {}] } },
+        { element: { list: [{ element: '3' }, {}, { element: '4' }] } },
         { element: {} },
         {}
       ]
     },
-    int_map: { map: [{ key: "k1", value: 2 }, { key: "k2" }] },
+    int_map: { map: [{ key: 'k1', value: 2 }, { key: 'k2' }] },
     int_Map_Array: {
       list: [
-        { element: { map: [{ key: "k3" }, { key: "k1", value: "1" }] } },
+        { element: { map: [{ key: 'k3' }, { key: 'k1', value: '1' }] } },
         {},
         { element: {} }
       ]
@@ -478,14 +478,14 @@ export const NULLABLE_EXPECTED = [
             {
               element: {
                 list: [{ element: {} },
-                { element: { E: "10", F: "aaa" } },
-                { element: {} }, { element: { E: "-10", F: "bbb" } }, { element: {} }]
+                { element: { E: '10', F: 'aaa' } },
+                { element: {} }, { element: { E: '-10', F: 'bbb' } }, { element: {} }]
               }
             },
             {
               element: {
                 list: [
-                  { element: { E: "11", F: "c" } }, {}]
+                  { element: { E: '11', F: 'c' } }, {}]
               }
             },
             { element: {} },
@@ -495,11 +495,11 @@ export const NULLABLE_EXPECTED = [
       },
       g: {
         map: [
-          { key: "g1", value: { H: { "i": { list: [{ element: "2.2" }, {}] } } } },
-          { key: "g2", value: { H: { "i": {} } } },
-          { key: "g3" },
-          { key: "g4", value: { H: {} } },
-          { key: "g5", value: {} }
+          { key: 'g1', value: { H: { 'i': { list: [{ element: '2.2' }, {}] } } } },
+          { key: 'g2', value: { H: { 'i': {} } } },
+          { key: 'g3' },
+          { key: 'g4', value: { H: {} } },
+          { key: 'g5', value: {} }
         ]
       }
     }
@@ -525,7 +525,7 @@ export const NULLABLE_EXPECTED = [
     nested_struct: {
       g: {
         map: [
-          { key: "foo", value: { H: { i: { list: [{ element: "2.2" }, { element: "3.3" }] } } } }
+          { key: 'foo', value: { H: { i: { list: [{ element: '2.2' }, { element: '3.3' }] } } } }
         ]
       }
     }
@@ -535,8 +535,8 @@ export const NULLABLE_EXPECTED = [
   },
   {
     id: 7,
-    int_array_Array: { list: [{}, { element: { list: [{ element: "5" }, { element: "6" }] } }] },
-    int_map: { map: [{ key: "k1" }, { key: "k3" }] },
+    int_array_Array: { list: [{}, { element: { list: [{ element: '5' }, { element: '6' }] } }] },
+    int_map: { map: [{ key: 'k1' }, { key: 'k3' }] },
     nested_struct: {
       A: 7,
       b: { list: [{ element: 2 }, { element: 3 }, {}] },
@@ -559,10 +559,70 @@ export const NULLS_EXPECTED = [
 ];
 
 export const REPEATED_NO_ANNOTATION_EXPECTED = [
-  { id: "1" },
-  { id: "2" },
-  { id: "3", phoneNumbers: {} },
-  { id: "4", phoneNumbers: { phone: [{ number: "5555555555" }] } },
-  { id: "5", phoneNumbers: { phone: [{ number: "1111111111", kind: "home" }] } },
-  { id: "6", phoneNumbers: { phone: [{ number: "1111111111", kind: "home" }, { number: "2222222222" }, { number: "3333333333", kind: "mobile" }] } }
+  { id: '1' },
+  { id: '2' },
+  { id: '3', phoneNumbers: {} },
+  { id: '4', phoneNumbers: { phone: [{ number: '5555555555' }] } },
+  { id: '5', phoneNumbers: { phone: [{ number: '1111111111', kind: 'home' }] } },
+  { id: '6', phoneNumbers: { phone: [{ number: '1111111111', kind: 'home' }, { number: '2222222222' }, { number: '3333333333', kind: 'mobile' }] } }
+];
+
+export const LZ4_RAW_COMPRESSED_LARGER_FIRST_EXPECTED = {
+  a: Buffer.from([
+    99, 55, 99, 101, 54, 98, 101, 102, 45, 100, 53, 98, 48, 45, 52, 56, 54, 51,
+    45, 98, 49, 57, 57, 45, 56, 101, 97, 56, 99, 55, 102, 98, 49, 49, 55, 98
+  ])
+};
+
+export const LZ4_RAW_COMPRESSED_LARGER_LAST_EXPECTED = {
+  a: Buffer.from([
+    56, 53, 52, 52, 48, 55, 55, 56, 45, 52, 54, 48, 97, 45, 52, 49, 97, 99,
+    45, 97, 97, 50, 101, 45, 97, 99, 51, 101, 101, 52, 49, 54, 57, 54, 98, 102
+  ])
+};
+
+export const LZ4_RAW_COMPRESSED_EXPECTED = [
+  {
+    c0: 1593604800,
+    c1: Buffer.from([97, 98, 99]),
+    v11: 42
+  },
+  {
+    c0: 1593604800,
+    c1: Buffer.from([100, 101, 102]),
+    v11: 7.7
+  },
+  {
+    c0: 1593604801,
+    c1: Buffer.from([97, 98, 99]),
+    v11: 42.125
+  },
+  {
+    c0: 1593604801,
+    c1: Buffer.from([100, 101, 102]),
+    v11: 7.7
+  }
+];
+
+export const NON_HADOOP_LZ4_COMPRESSED_EXPECTED = [
+  {
+    c0: '1593604800',
+    c1: 'abc',
+    v11: '42'
+  },
+  {
+    c0: '1593604800',
+    c1: 'def',
+    v11: '7.7'
+  },
+  {
+    c0: '1593604801',
+    c1: 'abc',
+    v11: '42.125'
+  },
+  {
+    c0: '1593604801',
+    c1: 'def',
+    v11: '7.7'
+  }
 ];

--- a/modules/parquet/test/parquet-loader.spec.js
+++ b/modules/parquet/test/parquet-loader.spec.js
@@ -19,7 +19,11 @@ import {
   NO_NULLABLE_EXPECTED,
   NULLABLE_EXPECTED,
   NULLS_EXPECTED,
-  REPEATED_NO_ANNOTATION_EXPECTED
+  REPEATED_NO_ANNOTATION_EXPECTED,
+  LZ4_RAW_COMPRESSED_LARGER_FIRST_EXPECTED,
+  LZ4_RAW_COMPRESSED_LARGER_LAST_EXPECTED,
+  LZ4_RAW_COMPRESSED_EXPECTED,
+  NON_HADOOP_LZ4_COMPRESSED_EXPECTED
 } from './expected';
 
 const PARQUET_DIR = '@loaders.gl/parquet/test/data/apache';
@@ -158,6 +162,35 @@ test('ParquetLoader#load repeated_no_annotation file', async (t) => {
 
   t.equal(data.length, 6);
   t.deepEqual(data, REPEATED_NO_ANNOTATION_EXPECTED);
+  t.end();
+});
+
+test('ParquetLoader#load lz4_raw_compressed file', async (t) => {
+  const url = '@loaders.gl/parquet/test/data/apache/good/lz4_raw_compressed.parquet';
+  const data = await load(url, ParquetLoader, {parquet: {url}, worker: false});
+
+  t.equal(data.length, 4);
+  t.deepEqual(data, LZ4_RAW_COMPRESSED_EXPECTED);
+  t.end();
+});
+
+test('ParquetLoader#load lz4_raw_compressed_larger file', async (t) => {
+  const url = '@loaders.gl/parquet/test/data/apache/good/lz4_raw_compressed_larger.parquet';
+  const data = await load(url, ParquetLoader, {parquet: {url}, worker: false});
+
+  t.equal(data.length, 10000);
+  // Compare only first and last items in data because file is huge.
+  t.deepEqual(data[0], LZ4_RAW_COMPRESSED_LARGER_FIRST_EXPECTED);
+  t.deepEqual(data[9999], LZ4_RAW_COMPRESSED_LARGER_LAST_EXPECTED);
+  t.end();
+});
+
+test('ParquetLoader#load non_hadoop_lz4_compressed file', async (t) => {
+  const url = '@loaders.gl/parquet/test/data/apache/good/non_hadoop_lz4_compressed.parquet';
+  const data = await load(url, ParquetLoader, {parquet: {url}, worker: false});
+
+  t.equal(data.length, 4);
+  t.deepEqual(data, NON_HADOOP_LZ4_COMPRESSED_EXPECTED);
   t.end();
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4559,6 +4559,11 @@ css-what@^5.0.0:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-5.0.1.tgz#3efa820131f4669a8ac2408f9c32e7c7de9f4cad"
   integrity sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==
 
+cuint@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/cuint/-/cuint-0.2.2.tgz#408086d409550c2631155619e9fa7bcadc3b991b"
+  integrity sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -7962,10 +7967,15 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-lz4js@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/lz4js/-/lz4js-0.2.0.tgz#09f1a397cb2158f675146c3351dde85058cb322f"
-  integrity sha1-CfGjl8shWPZ1FGwzUd3oUFjLMi8=
+lz4@^0.6.5:
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/lz4/-/lz4-0.6.5.tgz#ae8b7522681b6ab155023e6c56bf73087090122b"
+  integrity sha512-KSZcJU49QZOlJSItaeIU3p8WoAvkTmD9fJqeahQXNu1iQ/kR0/mQLdbrK8JY9MY8f6AhJoMrihp1nu1xDbscSQ==
+  dependencies:
+    buffer "^5.2.1"
+    cuint "^0.2.2"
+    nan "^2.13.2"
+    xxhashjs "^0.2.2"
 
 lzo-wasm@^0.0.4:
   version "0.0.4"
@@ -8483,6 +8493,11 @@ nan@^2.12.1:
   version "2.14.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
+
+nan@^2.13.2:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
+  integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -12520,6 +12535,13 @@ xtend@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-2.2.0.tgz#eef6b1f198c1c8deafad8b1765a04dad4a01c5a9"
   integrity sha1-7vax8ZjByN6vrYsXZaBNrUoBxak=
+
+xxhashjs@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/xxhashjs/-/xxhashjs-0.2.2.tgz#8a6251567621a1c46a5ae204da0249c7f8caa9d8"
+  integrity sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==
+  dependencies:
+    cuint "^0.2.2"
 
 y18n@^4.0.0:
   version "4.0.3"


### PR DESCRIPTION
Looks like current `lz4js` library can't handle lz4 compressed blocks without lz4 header in parquet file properly.
I just tried to use lz4 module which is suggested in [Apache Parquet repo.](https://github.com/apache/parquet-format/blob/master/Compression.md)
The weakness of LZ4 module that it consumes only Node.js `Buffer` which is not really good if we want to support Parquet loader in browser.
Next step is to compare [lz4js](https://github.com/Benzinga/lz4js) and [lz4](https://github.com/pierrec/node-lz4) realisations and try to make `lz4js` work like `lz4` does.