### PR TITLE
Add LZ4 compression support for Parquet

### DIFF
--- a/modules/compression/src/lib/compression.ts
+++ b/modules/compression/src/lib/compression.ts
@@ -31,9 +31,9 @@ export abstract class Compression {
   }
 
   /** Asynchronously decompress data */
-  async decompress(input: ArrayBuffer): Promise<ArrayBuffer> {
+  async decompress(input: ArrayBuffer, size?: number): Promise<ArrayBuffer> {
     await this.preload();
-    return this.decompressSync(input);
+    return this.decompressSync(input, size);
   }
 
   /** Synchronously compress data */
@@ -42,7 +42,7 @@ export abstract class Compression {
   }
 
   /** Synchronously compress data */
-  decompressSync(input: ArrayBuffer): ArrayBuffer {
+  decompressSync(input: ArrayBuffer, size?: number): ArrayBuffer {
     throw new Error(`${this.name}: sync decompression not supported`);
   }
 

--- a/modules/compression/test/compression.spec.js
+++ b/modules/compression/test/compression.spec.js
@@ -254,18 +254,3 @@ test.skip('zstd#worker', async (t) => {
   t.ok(compareArrayBuffers(decompressdData, binaryData), 'compress/decompress level 6');
   t.end();
 });
-
-test('lz4#compresion should add dummy header', async (t) => {
-  if (isBrowser) {
-    t.end();
-    return;
-  }
-
-  const compression = new LZ4Compression({modules});
-  const emptyLz4Buffer = new Uint8Array([4, 34, 77, 24, 64, 112, 223, 0, 0, 0, 0]).buffer;
-  const emptyLz4BufferWithoutMagicAndHashPart = emptyLz4Buffer.slice(6);
-  const result = compression.decompressSync(emptyLz4BufferWithoutMagicAndHashPart);
-
-  t.deepEqual(result, new Uint8Array(0));
-  t.end();
-});

--- a/modules/parquet/src/parquetjs/compression.ts
+++ b/modules/parquet/src/parquetjs/compression.ts
@@ -82,7 +82,7 @@ export function decompress(method: ParquetCompression, value: Buffer, size: numb
     throw new Error(`parquet: invalid compression method: ${method}`);
   }
   const inputArrayBuffer = toArrayBuffer(value);
-  const compressedArrayBuffer = compression.decompressSync(inputArrayBuffer);
+  const compressedArrayBuffer = compression.decompressSync(inputArrayBuffer, size);
   return toBuffer(compressedArrayBuffer);
 }
 

--- a/modules/parquet/test/data/files.js
+++ b/modules/parquet/test/data/files.js
@@ -1,8 +1,8 @@
 const PARQUET_FILES = [
   // Parquet seems to use LZ4 compression without header so we need to find a way to e.g. add a dummy header.
-  {supported: false, title: 'lz4_raw_compressed', path: 'good/lz4_raw_compressed.parquet'},
-  {supported: false, title: 'lz4_raw_compressed_larger', path: 'good/lz4_raw_compressed_larger.parquet'},
-  {supported: false, title: 'non_hadoop_lz4_compressed', path: 'good/non_hadoop_lz4_compressed.parquet'},
+  {supported: true, title: 'lz4_raw_compressed', path: 'good/lz4_raw_compressed.parquet'},
+  {supported: true, title: 'lz4_raw_compressed_larger', path: 'good/lz4_raw_compressed_larger.parquet'},
+  {supported: true, title: 'non_hadoop_lz4_compressed', path: 'good/non_hadoop_lz4_compressed.parquet'},
   {supported: true, title: 'alltypes_dictionary', path: 'good/alltypes_dictionary.parquet'},
   {supported: true, title: 'alltypes_plain', path: 'good/alltypes_plain.parquet'},
   {supported: true, title: 'alltypes_plain_snappy', path: 'good/alltypes_plain.snappy.parquet'},

--- a/modules/parquet/test/expected.js
+++ b/modules/parquet/test/expected.js
@@ -566,3 +566,63 @@ export const REPEATED_NO_ANNOTATION_EXPECTED = [
   { id: "5", phoneNumbers: { phone: [{ number: "1111111111", kind: "home" }] } },
   { id: "6", phoneNumbers: { phone: [{ number: "1111111111", kind: "home" }, { number: "2222222222" }, { number: "3333333333", kind: "mobile" }] } }
 ];
+
+export const LZ4_RAW_COMPRESSED_LARGER_FIRST_EXPECTED = {
+  a: Buffer.from([
+    99, 55, 99, 101, 54, 98, 101, 102, 45, 100, 53, 98, 48, 45, 52, 56, 54, 51,
+    45, 98, 49, 57, 57, 45, 56, 101, 97, 56, 99, 55, 102, 98, 49, 49, 55, 98
+  ])
+};
+
+export const LZ4_RAW_COMPRESSED_LARGER_LAST_EXPECTED = {
+  a: Buffer.from([
+    56, 53, 52, 52, 48, 55, 55, 56, 45, 52, 54, 48, 97, 45, 52, 49, 97, 99,
+    45, 97, 97, 50, 101, 45, 97, 99, 51, 101, 101, 52, 49, 54, 57, 54, 98, 102
+  ])
+};
+
+export const LZ4_RAW_COMPRESSED_EXPECTED = [
+  {
+    c0: 1593604800,
+    c1: Buffer.from([97, 98, 99]),
+    v11: 42
+  },
+  {
+    c0: 1593604800,
+    c1: Buffer.from([100, 101, 102]),
+    v11: 7.7
+  },
+  {
+    c0: 1593604801,
+    c1: Buffer.from([97, 98, 99]),
+    v11: 42.125
+  },
+  {
+    c0: 1593604801,
+    c1: Buffer.from([100, 101, 102]),
+    v11: 7.7
+  }
+];
+
+export const NON_HADOOP_LZ4_COMPRESSED_EXPECTED = [
+  {
+    c0: '1593604800',
+    c1: 'abc',
+    v11: '42'
+  },
+  {
+    c0: '1593604800',
+    c1: 'def',
+    v11: '7.7'
+  },
+  {
+    c0: '1593604801',
+    c1: 'abc',
+    v11: '42.125'
+  },
+  {
+    c0: '1593604801',
+    c1: 'def',
+    v11: '7.7'
+  }
+];

--- a/modules/parquet/test/parquet-loader.spec.js
+++ b/modules/parquet/test/parquet-loader.spec.js
@@ -19,7 +19,11 @@ import {
   NO_NULLABLE_EXPECTED,
   NULLABLE_EXPECTED,
   NULLS_EXPECTED,
-  REPEATED_NO_ANNOTATION_EXPECTED
+  REPEATED_NO_ANNOTATION_EXPECTED,
+  LZ4_RAW_COMPRESSED_LARGER_FIRST_EXPECTED,
+  LZ4_RAW_COMPRESSED_LARGER_LAST_EXPECTED,
+  LZ4_RAW_COMPRESSED_EXPECTED,
+  NON_HADOOP_LZ4_COMPRESSED_EXPECTED
 } from './expected';
 
 const PARQUET_DIR = '@loaders.gl/parquet/test/data/apache';
@@ -158,6 +162,36 @@ test('ParquetLoader#load repeated_no_annotation file', async (t) => {
 
   t.equal(data.length, 6);
   t.deepEqual(data, REPEATED_NO_ANNOTATION_EXPECTED);
+  t.end();
+});
+
+test('ParquetLoader#load lz4_raw_compressed file', async (t) => {
+  const url = '@loaders.gl/parquet/test/data/apache/good/lz4_raw_compressed.parquet';
+  const data = await load(url, ParquetLoader, {parquet: {url}, worker: false});
+  
+
+  t.equal(data.length, 4);
+  t.deepEqual(data, LZ4_RAW_COMPRESSED_EXPECTED);
+  t.end();
+});
+
+test('ParquetLoader#load lz4_raw_compressed_larger file', async (t) => {
+  const url = '@loaders.gl/parquet/test/data/apache/good/lz4_raw_compressed_larger.parquet';
+  const data = await load(url, ParquetLoader, {parquet: {url}, worker: false});
+
+  t.equal(data.length, 10000);
+  // Compare only first and last items in data because file is huge.
+  t.deepEqual(data[0], LZ4_RAW_COMPRESSED_LARGER_FIRST_EXPECTED);
+  t.deepEqual(data[9999], LZ4_RAW_COMPRESSED_LARGER_LAST_EXPECTED);
+  t.end();
+});
+
+test('ParquetLoader#load non_hadoop_lz4_compressed file', async (t) => {
+  const url = '@loaders.gl/parquet/test/data/apache/good/non_hadoop_lz4_compressed.parquet';
+  const data = await load(url, ParquetLoader, {parquet: {url}, worker: false});
+
+  t.equal(data.length, 4);
+  t.deepEqual(data, NON_HADOOP_LZ4_COMPRESSED_EXPECTED);
   t.end();
 });
 


### PR DESCRIPTION
Added Block Level Decoding for Parquet LZ4 compressed frames.
Solution was found in [Apache Parquet Compression spec](https://github.com/apache/parquet-format/blob/master/Compression.md) and appropriate js lib is  [node-lz4](https://github.com/pierrec/node-lz4) implementation.
It is adapted to work without Node.js `Buffer` object. As a result it can be performed in browser side for parsing.