### PR TITLE
feat(parquet): decimal logic type

### DIFF
--- a/modules/parquet/src/lib/convert-schema.ts
+++ b/modules/parquet/src/lib/convert-schema.ts
@@ -46,7 +46,10 @@ export const PARQUET_TYPE_MAPPING: {[type in ParquetType]: typeof DataType} = {
   JSON: Binary,
   BSON: Binary,
   // TODO check interal type
-  INTERVAL: Binary
+  INTERVAL: Binary,
+  DECIMAL_INT32: Float32,
+  DECIMAL_BYTE_ARRAY: Float32,
+  DECIMAL_INT64: Float64
 };
 
 export function convertParquetToArrowSchema(parquetSchema: ParquetSchema): Schema {

--- a/modules/parquet/src/lib/convert-schema.ts
+++ b/modules/parquet/src/lib/convert-schema.ts
@@ -48,8 +48,9 @@ export const PARQUET_TYPE_MAPPING: {[type in ParquetType]: typeof DataType} = {
   // TODO check interal type
   INTERVAL: Binary,
   DECIMAL_INT32: Float32,
-  DECIMAL_BYTE_ARRAY: Float32,
-  DECIMAL_INT64: Float64
+  DECIMAL_INT64: Float64,
+  DECIMAL_BYTE_ARRAY: Float64,
+  DECIMAL_FIXED_LEN_BYTE_ARRAY: Float64
 };
 
 export function convertParquetToArrowSchema(parquetSchema: ParquetSchema): Schema {

--- a/modules/parquet/src/parquetjs/schema/declare.ts
+++ b/modules/parquet/src/parquetjs/schema/declare.ts
@@ -15,6 +15,9 @@ export type ParquetCompression =
 export type RepetitionType = 'REQUIRED' | 'OPTIONAL' | 'REPEATED';
 export type ParquetType = PrimitiveType | OriginalType;
 
+/**
+ * Physical type
+ */
 export type PrimitiveType =
   // Base Types
   | 'BOOLEAN' // 0
@@ -26,6 +29,9 @@ export type PrimitiveType =
   | 'BYTE_ARRAY' // 6,
   | 'FIXED_LEN_BYTE_ARRAY'; // 7
 
+/**
+ * Logical type
+ */
 export type OriginalType =
   // Converted Types
   | 'UTF8' // 0

--- a/modules/parquet/src/parquetjs/schema/declare.ts
+++ b/modules/parquet/src/parquetjs/schema/declare.ts
@@ -13,7 +13,7 @@ export type ParquetCompression =
   | 'LZ4_RAW'
   | 'ZSTD';
 export type RepetitionType = 'REQUIRED' | 'OPTIONAL' | 'REPEATED';
-export type ParquetType = PrimitiveType | OriginalType | DecimalTypes;
+export type ParquetType = PrimitiveType | OriginalType;
 
 export type PrimitiveType =
   // Base Types
@@ -37,6 +37,7 @@ export type OriginalType =
   | 'DECIMAL_INT32' // 5
   | 'DECIMAL_INT64' // 5
   | 'DECIMAL_BYTE_ARRAY' // 5
+  | 'DECIMAL_FIXED_LEN_BYTE_ARRAY' // 5
   | 'DATE' // 6
   | 'TIME_MILLIS' // 7
   | 'TIME_MICROS' // 8
@@ -53,8 +54,6 @@ export type OriginalType =
   | 'JSON' // 19
   | 'BSON' // 20
   | 'INTERVAL'; // 21
-
-export type DecimalTypes = 'DECIMAL_INT32' | 'DECIMAL_INT64' | 'DECIMAL_BYTE_ARRAY';
 
 export type ParquetDictionary = string[];
 

--- a/modules/parquet/src/parquetjs/schema/declare.ts
+++ b/modules/parquet/src/parquetjs/schema/declare.ts
@@ -13,7 +13,7 @@ export type ParquetCompression =
   | 'LZ4_RAW'
   | 'ZSTD';
 export type RepetitionType = 'REQUIRED' | 'OPTIONAL' | 'REPEATED';
-export type ParquetType = PrimitiveType | OriginalType;
+export type ParquetType = PrimitiveType | OriginalType | DecimalTypes;
 
 export type PrimitiveType =
   // Base Types
@@ -34,6 +34,9 @@ export type OriginalType =
   // | 'LIST' // 3
   // | 'ENUM' // 4
   // | 'DECIMAL' // 5
+  | 'DECIMAL_INT32' // 5
+  | 'DECIMAL_INT64' // 5
+  | 'DECIMAL_BYTE_ARRAY' // 5
   | 'DATE' // 6
   | 'TIME_MILLIS' // 7
   | 'TIME_MICROS' // 8
@@ -51,6 +54,8 @@ export type OriginalType =
   | 'BSON' // 20
   | 'INTERVAL'; // 21
 
+export type DecimalTypes = 'DECIMAL_INT32' | 'DECIMAL_INT64' | 'DECIMAL_BYTE_ARRAY';
+
 export type ParquetDictionary = string[];
 
 export interface SchemaDefinition {
@@ -60,6 +65,8 @@ export interface SchemaDefinition {
 export interface FieldDefinition {
   type?: ParquetType;
   typeLength?: number;
+  presision?: number;
+  scale?: number;
   encoding?: ParquetCodec;
   compression?: ParquetCompression;
   optional?: boolean;
@@ -75,6 +82,8 @@ export interface ParquetField {
   originalType?: OriginalType;
   repetitionType: RepetitionType;
   typeLength?: number;
+  presision?: number;
+  scale?: number;
   encoding?: ParquetCodec;
   compression?: ParquetCompression;
   rLevelMax: number;

--- a/modules/parquet/src/parquetjs/schema/schema.ts
+++ b/modules/parquet/src/parquetjs/schema/schema.ts
@@ -173,6 +173,8 @@ function buildFields(
       encoding: opts.encoding,
       compression: opts.compression,
       typeLength: opts.typeLength || typeDef.typeLength,
+      presision: opts.presision,
+      scale: opts.scale,
       rLevelMax,
       dLevelMax
     };

--- a/modules/parquet/src/parquetjs/schema/shred.ts
+++ b/modules/parquet/src/parquetjs/schema/shred.ts
@@ -204,7 +204,8 @@ function materializeColumn(
       const value = Types.fromPrimitive(
         // @ts-ignore
         field.originalType || field.primitiveType,
-        data.values[vIndex]
+        data.values[vIndex],
+        field
       );
       vIndex++;
       if (field.repetitionType === 'REPEATED') {

--- a/modules/parquet/src/parquetjs/utils/decoders.ts
+++ b/modules/parquet/src/parquetjs/utils/decoders.ts
@@ -169,15 +169,25 @@ export function decodeSchema(
         fields: res.schema
       };
     } else {
-      let logicalType = getThriftEnum(Type, schemaElement.type!);
+      const type = getThriftEnum(Type, schemaElement.type!);
+      let logicalType = type;
 
       if (schemaElement.converted_type) {
         logicalType = getThriftEnum(ConvertedType, schemaElement.converted_type);
       }
 
+      switch (logicalType) {
+        case 'DECIMAL':
+          logicalType = `${logicalType}_${type}` as ParquetType;
+          break;
+        default:
+      }
+
       schema[schemaElement.name] = {
         type: logicalType as ParquetType,
         typeLength: schemaElement.type_length,
+        presision: schemaElement.precision,
+        scale: schemaElement.scale,
         optional,
         repeated
       };

--- a/modules/parquet/test/data/files.js
+++ b/modules/parquet/test/data/files.js
@@ -9,15 +9,15 @@ const PARQUET_FILES = [
   {supported: true, title: 'binary', path: 'good/binary.parquet'},
   // Specialized Dict for very large dictionaries: https://github.com/apache/parquet-format/blob/master/BloomFilter.md
   {supported: false, title: 'bloom_filter', path: 'good/bloom_filter.bin'}, 
-  {supported: false, title: 'byte_array_decimal', path: 'good/byte_array_decimal.parquet'},
+  {supported: true, title: 'byte_array_decimal', path: 'good/byte_array_decimal.parquet'},
   {supported: false, title: 'datapage_v2', path: 'good/datapage_v2.snappy.parquet'}, // Doesn't work on parquet-tools
   {supported: true, title: 'dict', path: 'good/dict-page-offset-zero.parquet'},
   {supported: false, title: 'fixed_length_decimal', path: 'good/fixed_length_decimal.parquet'},
   {supported: false, title: 'fixed_length_decimal_legacy', path: 'good/fixed_length_decimal_legacy.parquet'},
   {supported: false, title: 'hadoop_lz4_compressed', path: 'good/hadoop_lz4_compressed.parquet'},
   {supported: false, title: 'hadoop_lz4_compressed_larger', path: 'good/hadoop_lz4_compressed_larger.parquet'},
-  {supported: false, title: 'int32_decimal', path: 'good/int32_decimal.parquet'},
-  {supported: false, title: 'int64_decimal', path: 'good/int64_decimal.parquet'},
+  {supported: true, title: 'int32_decimal', path: 'good/int32_decimal.parquet'},
+  {supported: true, title: 'int64_decimal', path: 'good/int64_decimal.parquet'},
   {supported: true, title: 'list_columns', path: 'good/list_columns.parquet'},
   {supported: true, title: 'nation', path: 'good/nation.dict-malformed.parquet'}, // Partially works, issue with indices for dictionary values.
   {supported: true, title: 'nested_lists', path: 'good/nested_lists.snappy.parquet'},

--- a/modules/parquet/test/data/files.js
+++ b/modules/parquet/test/data/files.js
@@ -12,8 +12,8 @@ const PARQUET_FILES = [
   {supported: true, title: 'byte_array_decimal', path: 'good/byte_array_decimal.parquet'},
   {supported: false, title: 'datapage_v2', path: 'good/datapage_v2.snappy.parquet'}, // Doesn't work on parquet-tools
   {supported: true, title: 'dict', path: 'good/dict-page-offset-zero.parquet'},
-  {supported: false, title: 'fixed_length_decimal', path: 'good/fixed_length_decimal.parquet'},
-  {supported: false, title: 'fixed_length_decimal_legacy', path: 'good/fixed_length_decimal_legacy.parquet'},
+  {supported: true, title: 'fixed_length_decimal', path: 'good/fixed_length_decimal.parquet'},
+  {supported: true, title: 'fixed_length_decimal_legacy', path: 'good/fixed_length_decimal_legacy.parquet'},
   {supported: false, title: 'hadoop_lz4_compressed', path: 'good/hadoop_lz4_compressed.parquet'},
   {supported: false, title: 'hadoop_lz4_compressed_larger', path: 'good/hadoop_lz4_compressed_larger.parquet'},
   {supported: true, title: 'int32_decimal', path: 'good/int32_decimal.parquet'},

--- a/modules/parquet/test/expected.js
+++ b/modules/parquet/test/expected.js
@@ -566,3 +566,30 @@ export const REPEATED_NO_ANNOTATION_EXPECTED = [
   { id: "5", phoneNumbers: { phone: [{ number: "1111111111", kind: "home" }] } },
   { id: "6", phoneNumbers: { phone: [{ number: "1111111111", kind: "home" }, { number: "2222222222" }, { number: "3333333333", kind: "mobile" }] } }
 ];
+
+export const DECIMAL_EXPECTED = [
+ {value: 1},
+ {value: 2},
+ {value: 3},
+ {value: 4},
+ {value: 5},
+ {value: 6},
+ {value: 7},
+ {value: 8},
+ {value: 9},
+ {value: 10},
+ {value: 11},
+ {value: 12},
+ {value: 13},
+ {value: 14},
+ {value: 15},
+ {value: 16},
+ {value: 17},
+ {value: 18},
+ {value: 19},
+ {value: 20},
+ {value: 21},
+ {value: 22},
+ {value: 23},
+ {value: 24}
+];

--- a/modules/parquet/test/parquet-loader.spec.js
+++ b/modules/parquet/test/parquet-loader.spec.js
@@ -12,6 +12,7 @@ import {
   ALL_TYPES_PLAIN_EXPECTED,
   ALL_TYPES_PLAIN_SNAPPY_EXPECTED,
   BINARY_EXPECTED,
+  DECIMAL_EXPECTED,
   DICT_EXPECTED,
   LIST_COLUMNS_EXPECTED,
   NESTED_LIST_EXPECTED,
@@ -149,6 +150,22 @@ test('ParquetLoader#load nulls file', async (t) => {
 
   t.equal(data.length, 8);
   t.deepEqual(data, NULLS_EXPECTED);
+  t.end();
+});
+
+test('ParquetLoader#decimal files', async (t) => {
+  const urls = [
+    '@loaders.gl/parquet/test/data/apache/good/byte_array_decimal.parquet',
+    '@loaders.gl/parquet/test/data/apache/good/fixed_length_decimal.parquet',
+    '@loaders.gl/parquet/test/data/apache/good/fixed_length_decimal_legacy.parquet',
+    '@loaders.gl/parquet/test/data/apache/good/int32_decimal.parquet',
+    '@loaders.gl/parquet/test/data/apache/good/int64_decimal.parquet'
+  ];
+  for (const url of urls) {
+    const data = await load(url, ParquetLoader, {parquet: {url}, worker: false});
+    t.deepEqual(data, DECIMAL_EXPECTED);
+  }
+  
   t.end();
 });
 


### PR DESCRIPTION
DECIMAL type can annotate different physical types.
Implemented here:
- [x] int32
- [x] int64
- [x] fixed_len_byte_array (only `fromPrimitive` function)
- [x] binary: precision (only `fromPrimitive` function)

`toPrimitive` functions have't been tested.