### PR TITLE
I3S-Debug-App - Disable info picking tooltips for mobile

### DIFF
--- a/examples/website/i3s/app-debug.js
+++ b/examples/website/i3s/app-debug.js
@@ -56,6 +56,7 @@ import {
   selectOriginalTextureForTile,
   selectOriginalTextureForTileset
 } from './utils/texture-selector-utils';
+import {isBrowser} from '@loaders.gl/loader-utils';
 import { Color, Flex, Font } from './components/styles';
 
 const TRANSITION_DURAITON = 4000;
@@ -629,7 +630,7 @@ export default class App extends PureComponent {
   }
 
   getTooltip(info) {
-    if (!info.object || info.index < 0 || !info.layer) {
+    if (!info.object || info.index < 0 || !info.layer || !isBrowser) {
       return null;
     }
     const tileInfo = getShortTileDebugInfo(info.object);

--- a/examples/website/i3s/package.json
+++ b/examples/website/i3s/package.json
@@ -25,6 +25,7 @@
     "@loaders.gl/gltf": "3.0.0-beta.8",
     "@loaders.gl/i3s": "3.0.0-beta.8",
     "@loaders.gl/images": "3.0.0-beta.8",
+    "@loaders.gl/loader-utils": "3.0.0-beta.8",
     "@luma.gl/constants": "^8.5.4",
     "@luma.gl/core": "^8.5.4",
     "@luma.gl/engine": "^8.5.4",


### PR DESCRIPTION
In the mobile version, tooltips are not needed. They just break the layout.