### PR TITLE
chore(parquet): refactor parse function

### DIFF
--- a/modules/parquet/src/lib/parse-parquet.ts
+++ b/modules/parquet/src/lib/parse-parquet.ts
@@ -4,15 +4,7 @@ import type {ParquetLoaderOptions} from '../parquet-loader';
 import {ParquetReader} from '../parquetjs/classes/parquet-reader';
 
 export async function parseParquet(arrayBuffer: ArrayBuffer, options?: ParquetLoaderOptions) {
-  const blob = new Blob([arrayBuffer]);
-  for await (const batch of parseParquetFileInBatches(blob, options)) {
-    return batch;
-  }
-  return null;
-}
-
-export async function* parseParquetFileInBatches(blob: Blob, options?: ParquetLoaderOptions) {
-  const reader = await ParquetReader.openBlob(blob);
+  const reader = await ParquetReader.openArrayBuffer(arrayBuffer);
   const rows: any[][] = [];
   try {
     const cursor = reader.getCursor();
@@ -23,5 +15,18 @@ export async function* parseParquetFileInBatches(blob: Blob, options?: ParquetLo
   } finally {
     await reader.close();
   }
-  yield rows;
+  return rows;
+}
+
+export async function* parseParquetFileInBatches(blob: Blob, options?: ParquetLoaderOptions) {
+  const reader = await ParquetReader.openBlob(blob);
+  try {
+    const cursor = reader.getCursor();
+    let record: any[] | null;
+    while ((record = await cursor.next())) {
+      yield record;
+    }
+  } finally {
+    await reader.close();
+  }
 }


### PR DESCRIPTION
I found out that converting to Blob is not optimal choice because `parquestjs` converts it back to `ArrayBuffer` internally.

I made a test for `parseFileInBatches`. @ibgreen, did you suppose to  create some global function `parseFileInBatches` in `core` module?