### PR TITLE
Use default `util` from node

### DIFF
--- a/modules/compression/src/lib/brotli-compression.ts
+++ b/modules/compression/src/lib/brotli-compression.ts
@@ -5,7 +5,7 @@ import {isBrowser, toArrayBuffer} from '@loaders.gl/loader-utils';
 import type brotliNamespace from 'brotli';
 // import brotli from 'brotli';  // https://bundlephobia.com/package/brotli
 import zlib from 'zlib';
-import {promisify} from 'util';
+import util from 'util';
 
 export type BrotliCompressionOptions = CompressionOptions & {
   brotli?: {
@@ -55,7 +55,7 @@ export class BrotliCompression extends Compression {
   async compress(input: ArrayBuffer): Promise<ArrayBuffer> {
     // On Node.js we can use built-in zlib
     if (!isBrowser && this.options.brotli?.useZlib) {
-      const buffer = await promisify(zlib.brotliCompress)(input);
+      const buffer = await util.promisify(zlib.brotliCompress)(input);
       return toArrayBuffer(buffer);
     }
     return this.compressSync(input);
@@ -76,7 +76,7 @@ export class BrotliCompression extends Compression {
   async decompress(input: ArrayBuffer): Promise<ArrayBuffer> {
     // On Node.js we can use built-in zlib
     if (!isBrowser && this.options.brotli?.useZlib) {
-      const buffer = await promisify(zlib.brotliDecompress)(input);
+      const buffer = await util.promisify(zlib.brotliDecompress)(input);
       return toArrayBuffer(buffer);
     }
     return this.decompressSync(input);

--- a/modules/compression/src/lib/deflate-compression.ts
+++ b/modules/compression/src/lib/deflate-compression.ts
@@ -4,7 +4,7 @@ import {Compression} from './compression';
 import {isBrowser, toArrayBuffer} from '@loaders.gl/loader-utils';
 import pako from 'pako'; // https://bundlephobia.com/package/pako
 import zlib from 'zlib';
-import {promisify} from 'util';
+import util from 'util';
 
 export type DeflateCompressionOptions = CompressionOptions & {
   deflate?: pako.InflateOptions & pako.DeflateOptions & {useZlib?: boolean};
@@ -32,8 +32,8 @@ export class DeflateCompression extends Compression {
     // On Node.js we can use built-in zlib
     if (!isBrowser && this.options.deflate?.useZlib) {
       const buffer = this.options.deflate?.gzip
-        ? await promisify(zlib.gzip)(input)
-        : await promisify(zlib.deflate)(input);
+        ? await util.promisify(zlib.gzip)(input)
+        : await util.promisify(zlib.deflate)(input);
       return toArrayBuffer(buffer);
     }
     return this.compressSync(input);
@@ -43,8 +43,8 @@ export class DeflateCompression extends Compression {
     // On Node.js we can use built-in zlib
     if (!isBrowser && this.options.deflate?.useZlib) {
       const buffer = this.options.deflate?.gzip
-        ? await promisify(zlib.gunzip)(input)
-        : await promisify(zlib.inflate)(input);
+        ? await util.promisify(zlib.gunzip)(input)
+        : await util.promisify(zlib.inflate)(input);
       return toArrayBuffer(buffer);
     }
     return this.decompressSync(input);

--- a/modules/loader-utils/src/lib/node/fs.ts
+++ b/modules/loader-utils/src/lib/node/fs.ts
@@ -1,7 +1,7 @@
 // fs wrapper (promisified fs + avoids bundling fs in browsers)
 import fs from 'fs';
 import {toArrayBuffer} from './buffer-utils.node';
-import {promisify} from 'util';
+import util from 'util';
 
 const error = (fsFunction) => () => {
   throw new Error(`${fsFunction} not available in browser`);
@@ -9,13 +9,13 @@ const error = (fsFunction) => () => {
 
 export const isSupported = Boolean(fs);
 
-export const open = fs?.open ? promisify(fs.open) : error('fs.open');
-export const close = fs?.close ? promisify(fs.close) : error('fs.close');
-export const read = fs?.read ? promisify(fs.read) : error('fs.read');
+export const open = fs?.open ? util.promisify(fs.open) : error('fs.open');
+export const close = fs?.close ? util.promisify(fs.close) : error('fs.close');
+export const read = fs?.read ? util.promisify(fs.read) : error('fs.read');
 
-export const readFile = fs?.readFile ? promisify(fs.readFile) : error('fs.readFile');
+export const readFile = fs?.readFile ? util.promisify(fs.readFile) : error('fs.readFile');
 export const readFileSync = fs?.readFileSync ? fs.readFileSync : error('fs.readFileSync');
-export const writeFile = fs?.writeFile ? promisify(fs.writeFile) : error('fs.writeFile');
+export const writeFile = fs?.writeFile ? util.promisify(fs.writeFile) : error('fs.writeFile');
 export const writeFileSync = fs?.writeFileSync ? fs.writeFileSync : error('fs.writeFileSync');
 
 export async function _readToArrayBuffer(fd: number, start: number, length: number) {


### PR DESCRIPTION
Fixes #1815 (tried to do it in multiple spots).  Ran into this while looking into https://github.com/visgl/deck.gl/issues/6134#issuecomment-907042202:
 ```Uncaught SyntaxError: The requested module '/@id/__vite-browser-external:util' does not provide an export named 'promisify'```