### PR TITLE
fix(i3s): change logic of tileset urls parsing for i3s apps

### DIFF
--- a/examples/website/i3s/url-utils.js
+++ b/examples/website/i3s/url-utils.js
@@ -20,7 +20,8 @@ export function parseTilesetUrlParams(url, options) {
 
 function prepareTilesetUrl(parsedUrl) {
   if (parsedUrl.pathname.includes('layers/0')) {
-    return parsedUrl.href;
+    // Replace useless last "/" character if it presents.
+    return parsedUrl.href.replace(/\/+$/, '');
   }
   // Add '/' to url if needed + layers/0 if not exists in url.
   const replacedPathName = parsedUrl.pathname.replace(/\/?$/, '/').concat('layers/0');

--- a/examples/website/i3s/url-utils.js
+++ b/examples/website/i3s/url-utils.js
@@ -19,7 +19,10 @@ export function parseTilesetUrlParams(url, options) {
 }
 
 function prepareTilesetUrl(parsedUrl) {
-  if (parsedUrl.pathname.includes('layers/0')) {
+  // Try to find particular layer in url.
+  const layer = parsedUrl.pathname.match(/layers\/\d/);
+
+  if (layer) {
     // Replace useless last "/" character if it presents.
     return parsedUrl.href.replace(/\/+$/, '');
   }


### PR DESCRIPTION
Now I**3S App** and **I3S-Debug App** are able to handle the following tileset urls:

1. /?url=https://tiles.arcgis.com/tiles/u0sSNqDXr7puKJrF/arcgis/rest/services/Frankfurt2017_v17/SceneServer
2.  /?url=https://tiles.arcgis.com/tiles/u0sSNqDXr7puKJrF/arcgis/rest/services/Frankfurt2017_v17/SceneServer/
3.  /?url=https://tiles.arcgis.com/tiles/u0sSNqDXr7puKJrF/arcgis/rest/services/Frankfurt2017_v17/SceneServer/layers/0
3.  /?url=https://tiles.arcgis.com/tiles/u0sSNqDXr7puKJrF/arcgis/rest/services/Frankfurt2017_v17/SceneServer/layers/0/

![image](https://user-images.githubusercontent.com/70207219/133425013-46601aa3-5036-41eb-871a-f62b123c5129.png)
