### PR TITLE
chore: Reintroduce ES5 build

### DIFF
--- a/modules/3d-tiles/package.json
+++ b/modules/3d-tiles/package.json
@@ -21,8 +21,8 @@
     "pointcloud"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "files": [
     "src",

--- a/modules/arrow/package.json
+++ b/modules/arrow/package.json
@@ -19,8 +19,8 @@
     "PLY"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "files": [
     "src",

--- a/modules/compression/package.json
+++ b/modules/compression/package.json
@@ -18,8 +18,8 @@
     "point cloud"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "files": [
     "src",

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -18,8 +18,8 @@
     "point cloud"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "browser": {
     "fs": false,

--- a/modules/crypto/package.json
+++ b/modules/crypto/package.json
@@ -18,8 +18,8 @@
     "point cloud"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "files": [
     "src",

--- a/modules/csv/package.json
+++ b/modules/csv/package.json
@@ -17,8 +17,8 @@
     "CSV"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "files": [
     "src",

--- a/modules/draco/package.json
+++ b/modules/draco/package.json
@@ -20,8 +20,8 @@
     "draco"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "browser": {
     "fs": false

--- a/modules/excel/package.json
+++ b/modules/excel/package.json
@@ -21,8 +21,8 @@
     "Spreadsheets"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "files": [
     "src",

--- a/modules/flatgeobuf/package.json
+++ b/modules/flatgeobuf/package.json
@@ -18,8 +18,8 @@
     "Mapbox Vector Tiles"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "files": [
     "src",

--- a/modules/geopackage/package.json
+++ b/modules/geopackage/package.json
@@ -15,8 +15,8 @@
     "GeoPackage"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "files": [
     "src",

--- a/modules/geotiff/package.json
+++ b/modules/geotiff/package.json
@@ -19,8 +19,8 @@
     "geotiff"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "files": [
     "src",

--- a/modules/gis/package.json
+++ b/modules/gis/package.json
@@ -15,8 +15,8 @@
     "GeoJSON"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "files": [
     "src",

--- a/modules/gltf/package.json
+++ b/modules/gltf/package.json
@@ -20,8 +20,8 @@
     "glTF"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "files": [
     "src",

--- a/modules/i3s/package.json
+++ b/modules/i3s/package.json
@@ -18,8 +18,8 @@
     "mesh"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "files": [
     "src",

--- a/modules/images/package.json
+++ b/modules/images/package.json
@@ -19,8 +19,8 @@
     "PLY"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "files": [
     "src",

--- a/modules/json/package.json
+++ b/modules/json/package.json
@@ -21,8 +21,8 @@
     "JSON async iterator"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "files": [
     "src",

--- a/modules/kml/package.json
+++ b/modules/kml/package.json
@@ -19,8 +19,8 @@
     "KML"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "files": [
     "src",

--- a/modules/las/package.json
+++ b/modules/las/package.json
@@ -20,8 +20,8 @@
     "LAZ"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "browser": {
     "fs": false,

--- a/modules/loader-utils/package.json
+++ b/modules/loader-utils/package.json
@@ -18,8 +18,8 @@
     "point cloud"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "files": [
     "src",

--- a/modules/math/package.json
+++ b/modules/math/package.json
@@ -18,8 +18,8 @@
     "glTF"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "files": [
     "src",

--- a/modules/mvt/package.json
+++ b/modules/mvt/package.json
@@ -18,8 +18,8 @@
     "Mapbox Vector Tiles"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "files": [
     "src",

--- a/modules/obj/package.json
+++ b/modules/obj/package.json
@@ -19,8 +19,8 @@
     "OBJ"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "files": [
     "src",

--- a/modules/parquet/package.json
+++ b/modules/parquet/package.json
@@ -19,8 +19,8 @@
     "Apache Parquet"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "files": [
     "src",

--- a/modules/pcd/package.json
+++ b/modules/pcd/package.json
@@ -19,8 +19,8 @@
     "PCD"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "files": [
     "src",

--- a/modules/ply/package.json
+++ b/modules/ply/package.json
@@ -19,8 +19,8 @@
     "PLY"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "files": [
     "src",

--- a/modules/polyfills/package.json
+++ b/modules/polyfills/package.json
@@ -18,8 +18,8 @@
     "TextDecoder"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "files": [
     "src",
     "dist",

--- a/modules/potree/package.json
+++ b/modules/potree/package.json
@@ -22,8 +22,8 @@
     "pointcloud"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "files": [
     "src",

--- a/modules/schema/package.json
+++ b/modules/schema/package.json
@@ -19,8 +19,8 @@
     "PLY"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "files": [
     "src",

--- a/modules/shapefile/package.json
+++ b/modules/shapefile/package.json
@@ -18,8 +18,8 @@
     "shp"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "browser": {
     "./src/lib/filesystems/node-filesystem.js": false,

--- a/modules/terrain/package.json
+++ b/modules/terrain/package.json
@@ -19,8 +19,8 @@
     "OBJ"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "files": [
     "src",

--- a/modules/textures/package.json
+++ b/modules/textures/package.json
@@ -22,8 +22,8 @@
     "basis"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "files": [
     "src",

--- a/modules/tile-converter/package.json
+++ b/modules/tile-converter/package.json
@@ -16,8 +16,8 @@
     "i3s"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "bin": {
     "tile-converter": "./bin/converter.js",

--- a/modules/tiles/package.json
+++ b/modules/tiles/package.json
@@ -20,8 +20,8 @@
     "pointcloud"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "files": [
     "src",

--- a/modules/video/package.json
+++ b/modules/video/package.json
@@ -19,8 +19,8 @@
     "PLY"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "files": [
     "src",

--- a/modules/wkt/package.json
+++ b/modules/wkt/package.json
@@ -18,8 +18,8 @@
     "Well Known Text"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "files": [
     "src",

--- a/modules/worker-utils/package.json
+++ b/modules/worker-utils/package.json
@@ -16,8 +16,8 @@
     "thread"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "files": [
     "src",

--- a/modules/zarr/package.json
+++ b/modules/zarr/package.json
@@ -15,9 +15,9 @@
     "loader",
     "zarr"
   ],
-  "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "types": "src/index.d.ts",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "files": [
     "src",

--- a/modules/zip/package.json
+++ b/modules/zip/package.json
@@ -17,8 +17,8 @@
     "ZIP"
   ],
   "types": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
   "sideEffects": false,
   "files": [
     "src",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "bootstrap": "yarn install-fast && ocular-bootstrap",
     "install-fast": "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true yarn",
     "start": "echo 'Please see loaders.gl website for how to run examples' && open https://loaders.gl/docs",
-    "build": "ocular-clean && ocular-build --dist esm && lerna run pre-build",
+    "build": "ocular-clean && lerna run pre-build && ocular-build",
     "build-workers": "lerna run pre-build",
     "clean": "ocular-clean",
     "cover": "ocular-test cover",


### PR DESCRIPTION
- Dropping ES5 build for Node.js requires introducing ES modules ("type": "module") which is a breaking change.
- Postpone the ES5 drop to 4.0.
