### PR TITLE
WIP: Enable feature picking for Building Scene Layer

### DIFF
--- a/modules/i3s/src/i3s-attribute-loader.ts
+++ b/modules/i3s/src/i3s-attribute-loader.ts
@@ -91,6 +91,12 @@ function getAttributeValueType(attribute) {
   return '';
 }
 
+function getFeatureIdsAttributeName(attributeStorageInfo) {
+  const objectIdsAttribute = attributeStorageInfo.find(attribute => attribute.name.includes('OBJECTID'));
+
+  return objectIdsAttribute?.name;
+}
+
 /**
  * Generates mapping featureId to feature attributes
  * @param {Array} attributes
@@ -99,13 +105,14 @@ function getAttributeValueType(attribute) {
  * @returns {Object}
  */
 function generateAttributesByFeatureId(attributes, attributeStorageInfo, featureId) {
-  const objectIds = attributes.find((attribute) => attribute.value.OBJECTID);
+  const objectIdsAttributeName = getFeatureIdsAttributeName(attributeStorageInfo);
+  const objectIds = attributes.find((attribute) => attribute.value[objectIdsAttributeName]);
 
   if (!objectIds) {
     return null;
   }
 
-  const attributeIndex = objectIds.value.OBJECTID.indexOf(featureId);
+  const attributeIndex = objectIds.value[objectIdsAttributeName].indexOf(featureId);
 
   if (attributeIndex < 0) {
     return null;

--- a/modules/i3s/src/i3s-content-loader.ts
+++ b/modules/i3s/src/i3s-content-loader.ts
@@ -12,13 +12,15 @@ export const I3SContentLoader: LoaderWithParser = {
   name: 'I3S Content (Indexed Scene Layers)',
   id: 'i3s-content',
   module: 'i3s',
-  worker: true,
+  worker: false,
   version: VERSION,
   mimeTypes: ['application/octet-stream'],
   parse,
   extensions: ['bin'],
   options: {
-    'i3s-content': {}
+    'i3s-content': {
+      makeFeatureIdsUniqueAmongTilesets: false
+    }
   }
 };
 

--- a/modules/i3s/src/index.ts
+++ b/modules/i3s/src/index.ts
@@ -2,6 +2,7 @@ export {I3SLoader} from './i3s-loader';
 export {I3SContentLoader} from './i3s-content-loader';
 export {I3SAttributeLoader, loadFeatureAttributes} from './i3s-attribute-loader';
 export {I3SBuildingSceneLayerLoader} from './i3s-building-scene-layer-loader';
+export {invertCantorPairing} from './lib/utils/pairing-function';
 export type {
   BoundingVolumes,
   Mbs,

--- a/modules/i3s/src/lib/utils/pairing-function.ts
+++ b/modules/i3s/src/lib/utils/pairing-function.ts
@@ -1,0 +1,24 @@
+/**
+ *  Pairing function which allows to encode two natural numbers into a single natural number.
+ * https://en.wikipedia.org/wiki/Pairing_function#Cantor_pairing_function
+ * @param x - first natual number
+ * @param y  - second natual number
+ * @returns unique natural number
+ */
+export function cantorPair(x: number, y: number): number {
+  return 0.5 * (x + y) * (x + y + 1) + y;
+}
+
+/**
+ * Invert pairing operation to find initial values.
+ * @param z - result of pairing function
+ * @returns object with initial two natural values.
+ */
+export function invertCantorPairing(z: number): {x: number; y: number} {
+  const w = Math.floor(0.5 * (Math.sqrt(8 * z + 1) - 1));
+  const t = 0.5 * (Math.pow(w, 2) + w);
+  const y = z - t;
+  const x = w - y;
+
+  return {x, y};
+}

--- a/modules/i3s/test/index.js
+++ b/modules/i3s/test/index.js
@@ -6,3 +6,4 @@ import './i3s-node-page-loader.spec';
 import './i3s-attribute-loader.spec';
 import './i3s-content-loader.spec';
 import './i3s-building-scene-layer-loader.spec';
+import './utils/pairing-function.spec';

--- a/modules/i3s/test/utils/pairing-function.spec.js
+++ b/modules/i3s/test/utils/pairing-function.spec.js
@@ -1,0 +1,22 @@
+/* eslint-disable camelcase */
+import test from 'tape-promise/tape';
+import {cantorPair, invertCantorPairing} from '../../src/lib/utils/pairing-function';
+
+test('Cantor Pairing function#should produce natural number from two natural numbers', async (t) => {
+  const first = 10;
+  const second = 5;
+
+  const result = cantorPair(first, second);
+  const {x, y} = invertCantorPairing(result);
+
+  t.equal(x, first);
+  t.equal(y, second);
+
+  const result_2 = cantorPair(second, first);
+  const {x: x_1, y: y_1} = invertCantorPairing(result_2);
+
+  t.equal(x_1, second);
+  t.equal(y_1, first);
+
+  t.end();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3800,9 +3800,9 @@ camelize@^1.0.0:
   integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 caniuse-lite@^1.0.30001219:
-  version "1.0.30001257"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001257.tgz"
-  integrity sha512-JN49KplOgHSXpIsVSF+LUyhD8PUp6xPpAXeRrrcBh4KBeP7W864jHn6RvzJgDlrReyeVjMFJL3PLpPvKIxlIHA==
+  version "1.0.30001259"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001259.tgz"
+  integrity sha512-V7mQTFhjITxuk9zBpI6nYsiTXhcPe05l+364nZjK7MFK/E7ibvYBSAXr4YcA6oPR8j3ZLM/LN+lUqUVAQEUZFg==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
1. Enable feature picking for Building Scene Layer.
2. Make feature ids unique among all provided tilesets.

Usually feature ids are unique values per one tileset. But there are many tilesets in Building Scene Layer. That means it is very likely to meet the same feature id among these tilesets. In this case if user select for example "door" in building it is possible when many other objects like "roof, window", e.t.c can be selected (higlighted) as well. To handle this we need to make such feature ids unique across all provided tilesets in Building Scene Layer. The idea is to get unique feature ids based on existed feature ids and particular tileset. I tried to avoid additional math algorithms just do concatenation of feature id and tileset id, but this method doesn't provide full uniqueness. There are some narrow cases when some handled featureIds becomes the same among multiple tilesets. So I decided to use [pairing function](https://en.wikipedia.org/wiki/Pairing_function#Inverting_the_Cantor_pairing_function)

TODO: Need to avoid additional loader options for making feature ids uniqueness for many tilesets. It should be done by default.
Now we have an issue with cantor pairing for long feature ids which are used in existing tilesets (not Building Scene Layer).
The problem occurs when we call pairing function with long feature ids and tileset ids and when pass this value to the RGB encoder to make picking available in deck.gl layers. After decoding RGB to featureId we get a wrong value which can't properly be inverted from pairing to get initial feature id. I think it is related to digits limitation of picking color encoding/decoding process in layer.js file in deck.gl repo.