### PR TITLE
chore(i3s-picking): disable feature picking for integratedMesh layer type

### DIFF
--- a/examples/website/i3s/app.js
+++ b/examples/website/i3s/app.js
@@ -150,6 +150,18 @@ export default class App extends PureComponent {
     this.setState({selectedMapStyle});
   }
 
+  _isLayerPickable() {
+    const {tileset} = this.state;
+    const layerType = tileset?.tileset?.layerType;
+
+    switch (layerType) {
+      case 'IntegratedMesh':
+        return false;
+      default:
+        return true;
+    }
+  }
+
   _renderLayers() {
     const {tilesetUrl, token, selectedFeatureIndex} = this.state;
     // TODO: support compressed textures in GLTFMaterialParser
@@ -164,7 +176,7 @@ export default class App extends PureComponent {
         onTilesetLoad: this._onTilesetLoad.bind(this),
         onTileLoad: () => this._updateStatWidgets(),
         onTileUnload: () => this._updateStatWidgets(),
-        pickable: true,
+        pickable: this._isLayerPickable(),
         loadOptions,
         highlightedObjectIndex: selectedFeatureIndex
       })


### PR DESCRIPTION
No sense to pick integrated mesh. It is just selected as one object.
![image](https://user-images.githubusercontent.com/70207219/136365290-6d51be15-82c3-452c-b018-67383b2c0428.png)
