### PR TITLE
feat(i3s): decodeTextures option

### DIFF
--- a/modules/i3s/docs/api-reference/i3s-loader.md
+++ b/modules/i3s/docs/api-reference/i3s-loader.md
@@ -36,6 +36,7 @@ A loader for loading an [Indexed 3d Scene (I3S) layer](https://github.com/Esri/i
 | Texture Atlas         | yes       | https://github.com/Esri/i3s-spec/blob/master/docs/1.7/texture.cmn.md#atlas-usage-and-regions |
 
 ## Texture formats
+
 I3S textures specification - https://github.com/Esri/i3s-spec/blob/master/docs/1.7/texture.cmn.md
 
 | Texture                                        | Supported |
@@ -198,6 +199,7 @@ const visibleTiles = tileset3d.tiles.filter(tile => tile.selected);
 | `options.i3s.tile`                  | `Object`         | `null`  | `Tile` object loaded by I3SLoader or follow the data format [Tile Object](#tile-object). It is required when loading i3s geometry content                                                                                                                                                                                       |
 | `options.i3s.useDracoGeometry`      | `Bool`           | `true`  | Use 'Draco' compressed geometry to show if applicable                                                                                                                                                                                                                                                                           |
 | `options.i3s.useCompressedTextures` | `Bool`           | `true`  | Use "Compressed textures" (_.dds or _.ktx) if available and supported by GPU                                                                                                                                                                                                                                                    |
+| `options.i3s.decodeTextures`        | `Bool`           | `true`  | Decode texture image to ImageBitmap or compressed texture object (if supported by GPU)                                                                                                                                                                                                                                          |
 
 ## Data formats
 

--- a/modules/i3s/src/i3s-loader.ts
+++ b/modules/i3s/src/i3s-loader.ts
@@ -31,7 +31,8 @@ export const I3SLoader: LoaderWithParser = {
       tile: null,
       tileset: null,
       useDracoGeometry: true,
-      useCompressedTextures: true
+      useCompressedTextures: true,
+      decodeTextures: true
     }
   }
 };

--- a/modules/i3s/src/lib/parsers/parse-i3s-tile-content.ts
+++ b/modules/i3s/src/lib/parsers/parse-i3s-tile-content.ts
@@ -53,22 +53,26 @@ export async function parseI3STileContent(
     const response = await fetch(url);
     const arrayBuffer = await response.arrayBuffer();
 
-    if (loader === ImageLoader) {
-      const options = {...tile.textureLoaderOptions, image: {type: 'data'}};
-      // @ts-ignore context must be defined
-      // Image constructor is not supported in worker thread.
-      // Do parsing image data on the main thread by using context to avoid worker issues.
-      tile.content.texture = await context.parse(arrayBuffer, options);
-    } else if (loader === CompressedTextureLoader || loader === BasisLoader) {
-      // @ts-ignore context must be defined
-      const texture = await load(arrayBuffer, loader, tile.textureLoaderOptions);
-      tile.content.texture = {
-        compressed: true,
-        mipmaps: false,
-        width: texture[0].width,
-        height: texture[0].height,
-        data: texture
-      };
+    if (options?.i3s.decodeTextures) {
+      if (loader === ImageLoader) {
+        const options = {...tile.textureLoaderOptions, image: {type: 'data'}};
+        // @ts-ignore context must be defined
+        // Image constructor is not supported in worker thread.
+        // Do parsing image data on the main thread by using context to avoid worker issues.
+        tile.content.texture = await context.parse(arrayBuffer, options);
+      } else if (loader === CompressedTextureLoader || loader === BasisLoader) {
+        // @ts-ignore context must be defined
+        const texture = await load(arrayBuffer, loader, tile.textureLoaderOptions);
+        tile.content.texture = {
+          compressed: true,
+          mipmaps: false,
+          width: texture[0].width,
+          height: texture[0].height,
+          data: texture
+        };
+      }
+    } else {
+      tile.content.texture = arrayBuffer;
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3831,9 +3831,9 @@ camelize@^1.0.0:
   integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 caniuse-lite@^1.0.30001219:
-  version "1.0.30001265"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001265.tgz"
-  integrity sha512-YzBnspggWV5hep1m9Z6sZVLOt7vrju8xWooFAgN6BA5qvy98qPAPb7vNUzypFaoh2pb3vlfzbDO8tB57UPGbtw==
+  version "1.0.30001267"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001267.tgz"
+  integrity sha512-r1mjTzAuJ9W8cPBGbbus8E0SKcUP7gn03R14Wk8FlAlqhH9hroy9nLqmpuXlfKEw/oILW+FGz47ipXV2O7x8lg==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
This option is to prevent jpeg/png decoding. We plan to use it in the tile converter. Now the converter decodes jpeg and encodes it back that is not optimal. Also we need jpeg/png as input for Binomial's ktx2+basis encoder.