### PR TITLE
fix(tiles): update i3s lod logic

### DIFF
--- a/modules/tiles/test/data/tile-header-examples.js
+++ b/modules/tiles/test/data/tile-header-examples.js
@@ -652,3 +652,169 @@ export const getTileHeader = () => ({
   type: 'mesh',
   refine: 2
 });
+
+export const getNextAfterRootTileHeader = () => ({
+  id: 41543,
+  lodSelection: [
+    {
+      metricType: 'maxScreenThreshold',
+      maxError: 190.35122760438074
+    },
+    {
+      metricType: 'maxScreenThresholdSQ',
+      maxError: 28457.794921875
+    }
+  ],
+  obb: {
+    center: [-122.40892227790425, 37.79412655271593, 143.70168329402804],
+    halfSize: [946.2178955078125, 966.2469482421875, 136.01101684570312],
+    quaternion: [0.788020670413971, 0.41908901929855347, 0.38250574469566345, -0.23890817165374756]
+  },
+  contentUrl:
+    'https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/SanFrancisco_3DObjects_1_7/SceneServer/layers/0/nodes/41543/geometries/1',
+  textureUrl:
+    'https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/SanFrancisco_3DObjects_1_7/SceneServer/layers/0/nodes/41543/textures/0_0_1',
+  attributeUrls: [
+    'https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/SanFrancisco_3DObjects_1_7/SceneServer/layers/0/nodes/41543/attributes/f_0/0',
+    'https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/SanFrancisco_3DObjects_1_7/SceneServer/layers/0/nodes/41543/attributes/f_1/0'
+  ],
+  materialDefinition: {
+    cullFace: 'back',
+    pbrMetallicRoughness: {
+      baseColorTexture: {
+        textureSetDefinitionId: 0,
+        texCoord: 0
+      },
+      metallicFactor: 0
+    }
+  },
+  textureFormat: 'dds',
+  textureLoaderOptions: {},
+  children: [
+    {
+      id: 41494,
+      obb: {
+        center: [-122.40892227790499, 37.79412655271634, 143.701683296822],
+        halfSize: [946.2178955078125, 966.2469482421875, 136.01101684570312],
+        quaternion: [
+          0.788020670413971, 0.41908901929855347, 0.38250574469566345, -0.23890817165374756
+        ]
+      }
+    }
+  ],
+  isDracoGeometry: true,
+  mbs: [-122.40892227790425, 37.79412655271593, 143.70168329402804, 1359.2131544451538],
+  boundingVolume: {
+    sphere: [-2704755.6799697783, -4260546.326939532, 3887500.0994313606, 1359.2131544451538],
+    box: [
+      -2704755.6799697783, -4260546.326939532, 3887500.0994313606, 946.2178955078125,
+      966.2469482421875, 136.01101684570312, 0.788020670413971, 0.41908901929855347,
+      0.38250574469566345, -0.23890817165374756
+    ]
+  },
+  lodMetricType: 'maxScreenThreshold',
+  lodMetricValue: 190.35122760438074,
+  type: 'mesh',
+  refine: 2
+});
+
+export const getBigLodMetricTileHeader = () => ({
+  id: 2103,
+  lodSelection: [
+    {
+      metricType: 'maxScreenThreshold',
+      maxError: 2545.5409969441134
+    },
+    {
+      metricType: 'maxScreenThresholdSQ',
+      maxError: 5089206.5
+    }
+  ],
+  obb: {
+    center: [-74.01224561539388, 40.689378970323915, 43.68304331135005],
+    halfSize: [2748.5205078125, 1617.2325439453125, 113.44554138183594],
+    quaternion: [0.16726532578468323, -0.4008112847805023, 0.8910421133041382, 0.13197216391563416]
+  },
+  contentUrl:
+    'https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_NewYork_17/SceneServer/layers/0/nodes/2102/geometries/1',
+  textureUrl: null,
+  attributeUrls: [
+    'https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_NewYork_17/SceneServer/layers/0/nodes/2102/attributes/f_0/0',
+    'https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_NewYork_17/SceneServer/layers/0/nodes/2102/attributes/f_1/0',
+    'https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_NewYork_17/SceneServer/layers/0/nodes/2102/attributes/f_2/0',
+    'https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_NewYork_17/SceneServer/layers/0/nodes/2102/attributes/f_3/0',
+    'https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_NewYork_17/SceneServer/layers/0/nodes/2102/attributes/f_4/0',
+    'https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_NewYork_17/SceneServer/layers/0/nodes/2102/attributes/f_5/0',
+    'https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_NewYork_17/SceneServer/layers/0/nodes/2102/attributes/f_6/0',
+    'https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_NewYork_17/SceneServer/layers/0/nodes/2102/attributes/f_7/0',
+    'https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_NewYork_17/SceneServer/layers/0/nodes/2102/attributes/f_8/0',
+    'https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_NewYork_17/SceneServer/layers/0/nodes/2102/attributes/f_9/0',
+    'https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_NewYork_17/SceneServer/layers/0/nodes/2102/attributes/f_10/0',
+    'https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_NewYork_17/SceneServer/layers/0/nodes/2102/attributes/f_11/0',
+    'https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_NewYork_17/SceneServer/layers/0/nodes/2102/attributes/f_12/0',
+    'https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_NewYork_17/SceneServer/layers/0/nodes/2102/attributes/f_13/0',
+    'https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_NewYork_17/SceneServer/layers/0/nodes/2102/attributes/f_14/0',
+    'https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_NewYork_17/SceneServer/layers/0/nodes/2102/attributes/f_15/0'
+  ],
+  materialDefinition: {
+    doubleSided: true
+  },
+  textureFormat: 'jpeg',
+  textureLoaderOptions: {},
+  children: [
+    {
+      id: 2104,
+      obb: {
+        center: [-74.00735794942466, 40.674884685074765, 26.424795985221863],
+        halfSize: [511.4256286621094, 676.6785888671875, 25.632099151611328],
+        quaternion: [
+          0.12048618495464325, 0.9008316993713379, 0.3828689157962799, -0.16552002727985382
+        ]
+      }
+    },
+    {
+      id: 2107,
+      obb: {
+        center: [-74.0034126693549, 40.68115999371559, 21.9132988313213],
+        halfSize: [524.7799682617188, 463.6318054199219, 20.944942474365234],
+        quaternion: [
+          0.09495606273412704, -0.4089607894420624, 0.9068772792816162, -0.03616717830300331
+        ]
+      }
+    },
+    {
+      id: 2112,
+      obb: {
+        center: [-74.0218546582727, 40.694235544803846, 108.91047429759055],
+        halfSize: [1758.814453125, 114.03099060058594, 1599.049072265625],
+        quaternion: [
+          0.902656078338623, 0.026173165068030357, -0.2234274297952652, 0.3668884038925171
+        ]
+      }
+    },
+    {
+      id: 2116,
+      obb: {
+        center: [-73.9916551460206, 40.672573621190736, 15.680643054656684],
+        halfSize: [826.0719604492188, 15.417656898498535, 356.4653625488281],
+        quaternion: [
+          0.14524587988853455, 0.7017393112182617, -0.33847472071647644, -0.6098363995552063
+        ]
+      }
+    }
+  ],
+  isDracoGeometry: true,
+  mbs: [-74.01224561539388, 40.689378970323915, 43.68304331135005, 3191.0310200815197],
+  boundingVolume: {
+    sphere: [1333967.3976591302, -4655852.524170438, 4136356.947935957, 3191.0310200815197],
+    box: [
+      1333967.3976591302, -4655852.524170438, 4136356.947935957, 2748.5205078125,
+      1617.2325439453125, 113.44554138183594, 0.16726532578468323, -0.4008112847805023,
+      0.8910421133041382, 0.13197216391563416
+    ]
+  },
+  lodMetricType: 'maxScreenThreshold',
+  lodMetricValue: 2545.5409969441134,
+  type: 'mesh',
+  refine: 2
+});

--- a/modules/tiles/test/data/viewport-opts-examples.js
+++ b/modules/tiles/test/data/viewport-opts-examples.js
@@ -1,9 +1,9 @@
 export const VIEWPORT_DEFAULT = {
   width: 1848,
   height: 980,
-  latitude: 37.79236722394597,
-  longitude: -122.40126134069325,
-  zoom: 14.079936531679898,
+  latitude: 37.79592258631093,
+  longitude: -122.40750202607084,
+  zoom: 13.902576534944492,
   bearing: 0,
   pitch: 45,
   altitude: 1.5,
@@ -20,19 +20,16 @@ export const VIEWPORT_DEFAULT = {
       smooth: true
     }
   },
-  projectionMatrix: null,
-  fovy: 50,
+  viewMatrix: [
+    15.626671346078382, 0, 0, 0, 0, 11.049725276185539, -11.049725276185537, 0, 0,
+    11.049725276185537, 11.049725276185539, 0, 0, 0, -1.5, 1
+  ],
+  fov: 0.6435011087932844,
+  aspect: 1.8857142857142857,
+  focalDistance: 1.5,
   near: 0.1,
   far: 2.2725,
-  modelMatrix: null,
-  viewMatrix: [
-    17.670838486143424, 0, 0, 0, 0, 12.495169722804242, -12.49516972280424, 0, 0, 12.49516972280424,
-    12.495169722804242, 0, 0, 0, -1.5, 1
-  ],
-  orthographic: false,
-  fovyRadians: 0.6435011087932844,
-  aspect: 1.8857142857142857,
-  focalDistance: 1.5
+  fovy: 36.86989764584402
 };
 
 export const VIEWPORT_ZOOM_OPTS = {
@@ -72,51 +69,14 @@ export const VIEWPORT_ZOOM_OPTS = {
   focalDistance: 1.5
 };
 
-export const VIEWPORT_TOP_RIGHT_CORNER_OPTS = {
-  width: 1848,
-  height: 980,
-  latitude: 37.785888431386894,
-  longitude: -122.42101334588308,
-  zoom: 14.219746634522798,
-  bearing: 0,
-  pitch: 45,
-  altitude: 1.5,
-  maxZoom: 30,
-  minZoom: 2,
-  maxPitch: 60,
-  minPitch: 0,
-  id: 'main',
-  controller: {
-    maxPitch: 60,
-    inertia: true,
-    scrollZoom: {
-      speed: 0.01,
-      smooth: true
-    }
-  },
-  projectionMatrix: null,
-  fovy: 50,
-  near: 0.1,
-  far: 2.2725,
-  modelMatrix: null,
-  viewMatrix: [
-    19.469024518005774, 0, 0, 0, 0, 13.766679259769038, -13.766679259769036, 0, 0,
-    13.766679259769036, 13.766679259769038, 0, 0, 0, -1.5, 1
-  ],
-  orthographic: false,
-  fovyRadians: 0.6435011087932844,
-  aspect: 1.8857142857142857,
-  focalDistance: 1.5
-};
-
 export const VIEWPORT_ROTATED_OPTS = {
   width: 1848,
   height: 980,
-  latitude: 37.79399734821857,
-  longitude: -122.40483899015148,
-  zoom: 13.98515749509245,
-  bearing: -56.405529953917046,
-  pitch: 46.91398827917058,
+  latitude: 37.794091235120504,
+  longitude: -122.4053107273273,
+  zoom: 13.730290492938975,
+  bearing: 77.87337662337663,
+  pitch: 32.869565217391305,
   altitude: 1.5,
   maxZoom: 30,
   minZoom: 2,
@@ -124,24 +84,24 @@ export const VIEWPORT_ROTATED_OPTS = {
   minPitch: 0,
   transitionDuration: 0,
   viewMatrix: [
-    9.155777951142982, -9.415405444299118, 10.066446641794837, 0, 13.783439616896793,
-    6.254270629394156, -6.686730799496388, 0, 0, 12.084937599219788, 11.30335175008899, 0, 0, 0,
+    2.9132194874526927, 11.387656195436083, -7.358427548228088, 0, -13.558214100978631,
+    2.446837149633242, -1.5810868873179618, 0, 0, 7.526373079230847, 11.647563078270027, 0, 0, 0,
     -1.5, 1
   ],
-  orthographic: false,
-  fovyRadians: 0.6435011087932844,
+  fov: 0.6435011087932844,
   aspect: 1.8857142857142857,
   focalDistance: 1.5,
   near: 0.1,
-  far: 2.35388118064461
+  far: 1.930900340159826,
+  fovy: 36.86989764584402
 };
 
 export const VIEWPORT_ZOOM_OUT_OPTS = {
   width: 1848,
-  height: 649,
-  latitude: 38.90449555738972,
-  longitude: -118.90439808306486,
-  zoom: 4.975614492080811,
+  height: 980,
+  latitude: 40.63908134445145,
+  longitude: -121.62588580625729,
+  zoom: 5.159799080775016,
   bearing: 0,
   pitch: 45,
   altitude: 1.5,
@@ -158,17 +118,49 @@ export const VIEWPORT_ZOOM_OUT_OPTS = {
       smooth: true
     }
   },
-  projectionMatrix: null,
-  fovy: 50,
+  viewMatrix: [
+    0.03647776483696709, 0, 0, 0, 0, 0.025793674878747626, -0.025793674878747622, 0, 0,
+    0.025793674878747622, 0.025793674878747626, 0, 0, 0, -1.5, 1
+  ],
+  fov: 0.6435011087932844,
+  aspect: 1.8857142857142857,
+  focalDistance: 1.5,
   near: 0.1,
   far: 2.2725,
-  modelMatrix: null,
+  fovy: 36.86989764584402
+};
+
+export const VIEWPORT_NEW_YORK_OPTS = {
+  width: 1848,
+  height: 980,
+  latitude: 40.6880313516013,
+  longitude: -74.04598836028212,
+  zoom: 15.491678919886628,
+  bearing: 96.59439752702683,
+  pitch: 45.13036023378121,
+  altitude: 1.5,
+  maxZoom: 30,
+  minZoom: 2,
+  maxPitch: 60,
+  minPitch: 0,
+  id: 'main',
+  controller: {
+    maxPitch: 60,
+    inertia: true,
+    scrollZoom: {
+      speed: 0.01,
+      smooth: true
+    }
+  },
   viewMatrix: [
-    0.048480212209835644, 0, 0, 0, 0, 0.034280686806937646, -0.03428068680693764, 0, 0,
-    0.03428068680693764, 0.034280686806937646, 0, 0, 0, -1.5, 1
+    -5.3991725620119455, 32.94926718847123, -33.09954271015278, 0, -46.70368225181495,
+    -3.8090953596165535, 3.8264679399846373, 0, 0, 33.319987762857274, 33.168711396675015, 0, 0, 0,
+    -1.5, 1
   ],
-  orthographic: false,
-  fovyRadians: 0.6435011087932844,
-  aspect: 2.847457627118644,
-  focalDistance: 1.5
+  fov: 0.6435011087932844,
+  aspect: 1.8857142857142857,
+  focalDistance: 1.5,
+  near: 0.1,
+  far: 2.2776940709756763,
+  fovy: 36.86989764584402
 };

--- a/modules/tiles/test/tileset/helpers/i3s-lod.spec.js
+++ b/modules/tiles/test/tileset/helpers/i3s-lod.spec.js
@@ -1,12 +1,17 @@
 import test from 'tape-promise/tape';
-import {Viewport} from '@deck.gl/core';
+import {WebMercatorViewport} from '@deck.gl/core';
 import {TILESET_STUB} from '@loaders.gl/i3s/test/test-utils/load-utils';
 import {getFrameState, Tile3D, Tileset3D, getLodStatus} from '@loaders.gl/tiles';
-import {getTileHeader, ROOT_TILE_HEADER} from '../../data/tile-header-examples';
+import {
+  getBigLodMetricTileHeader,
+  getNextAfterRootTileHeader,
+  getTileHeader,
+  ROOT_TILE_HEADER
+} from '../../data/tile-header-examples';
 import {
   VIEWPORT_DEFAULT,
+  VIEWPORT_NEW_YORK_OPTS,
   VIEWPORT_ROTATED_OPTS,
-  VIEWPORT_TOP_RIGHT_CORNER_OPTS,
   VIEWPORT_ZOOM_OPTS,
   VIEWPORT_ZOOM_OUT_OPTS
 } from '../../data/viewport-opts-examples';
@@ -15,7 +20,7 @@ test('I3S LOD#lodJudge - should return "DIG" if lodMetric is 0 or NaN', (t) => {
   const tilesetHeader = TILESET_STUB();
   tilesetHeader.root = ROOT_TILE_HEADER;
   const tileset = new Tileset3D(tilesetHeader);
-  const viewport = new Viewport(VIEWPORT_DEFAULT);
+  const viewport = new WebMercatorViewport(VIEWPORT_DEFAULT);
   const frameState = getFrameState(viewport, 1);
 
   if (tileset.root) {
@@ -36,7 +41,7 @@ test('I3S LOD#lodJudge - should return "DRAW" if tile size projected on the scre
   const tilesetHeader = TILESET_STUB();
   tilesetHeader.root = ROOT_TILE_HEADER;
   const tileset = new Tileset3D(tilesetHeader);
-  const viewport = new Viewport(VIEWPORT_DEFAULT);
+  const viewport = new WebMercatorViewport(VIEWPORT_DEFAULT);
   const frameState = getFrameState(viewport, 1);
 
   const tileHeader = getTileHeader();
@@ -51,7 +56,7 @@ test('I3S LOD#lodJudge - should return "DIG" when zoom in', (t) => {
   const tilesetHeader = TILESET_STUB();
   tilesetHeader.root = ROOT_TILE_HEADER;
   const tileset = new Tileset3D(tilesetHeader);
-  const viewport = new Viewport(VIEWPORT_ZOOM_OPTS);
+  const viewport = new WebMercatorViewport(VIEWPORT_ZOOM_OPTS);
   const frameState = getFrameState(viewport, 1);
 
   const tileHeader = getTileHeader();
@@ -62,26 +67,11 @@ test('I3S LOD#lodJudge - should return "DIG" when zoom in', (t) => {
   t.end();
 });
 
-test('I3S LOD#lodJudge - should return "DRAW" having "DIG" but dragged the child tiles to the top right corner', (t) => {
-  const tilesetHeader = TILESET_STUB();
-  tilesetHeader.root = ROOT_TILE_HEADER;
-  const tileset = new Tileset3D(tilesetHeader);
-  const viewport = new Viewport(VIEWPORT_TOP_RIGHT_CORNER_OPTS);
-  const frameState = getFrameState(viewport, 1);
-
-  const tileHeader = getTileHeader();
-  const tile2 = new Tile3D(tileset, tileHeader);
-  const lodResult2 = getLodStatus(tile2, frameState);
-  t.equal(lodResult2, 'DRAW');
-
-  t.end();
-});
-
 test('I3S LOD#lodJudge - should return "DRAW" after rotation', (t) => {
   const tilesetHeader = TILESET_STUB();
   tilesetHeader.root = ROOT_TILE_HEADER;
   const tileset = new Tileset3D(tilesetHeader);
-  const viewport = new Viewport(VIEWPORT_ROTATED_OPTS);
+  const viewport = new WebMercatorViewport(VIEWPORT_ROTATED_OPTS);
   const frameState = getFrameState(viewport, 1);
 
   const tileHeader = getTileHeader();
@@ -96,13 +86,28 @@ test('I3S LOD#lodJudge - should return "OUT" if projected size too small', (t) =
   const tilesetHeader = TILESET_STUB();
   tilesetHeader.root = ROOT_TILE_HEADER;
   const tileset = new Tileset3D(tilesetHeader);
-  const viewport = new Viewport(VIEWPORT_ZOOM_OUT_OPTS);
+  const viewport = new WebMercatorViewport(VIEWPORT_ZOOM_OUT_OPTS);
   const frameState = getFrameState(viewport, 1);
 
-  const tileHeader = getTileHeader();
+  const tileHeader = getNextAfterRootTileHeader();
   const tile2 = new Tile3D(tileset, tileHeader);
   const lodResult2 = getLodStatus(tile2, frameState);
   t.equal(lodResult2, 'OUT');
+
+  t.end();
+});
+
+test('I3S LOD#lodJudge - should return "DIG" in the large LOD metric value case', (t) => {
+  const tilesetHeader = TILESET_STUB();
+  tilesetHeader.root = ROOT_TILE_HEADER;
+  const tileset = new Tileset3D(tilesetHeader);
+  const viewport = new WebMercatorViewport(VIEWPORT_NEW_YORK_OPTS);
+  const frameState = getFrameState(viewport, 1);
+
+  const tileHeader = getBigLodMetricTileHeader();
+  const tile = new Tile3D(tileset, tileHeader);
+  const lodResult = getLodStatus(tile, frameState);
+  t.equal(lodResult, 'DIG');
 
   t.end();
 });


### PR DESCRIPTION
We've got an issue on New York layer. Nodes have big LOD metrics, that makes LOD selection unstable on different "pitch" angles.
- LOD selection is made with "pitch===0";
- Update additional vector calculation to form correct radius segment.