### PR TITLE
fix(3dtiles-converter): fix texture parsing for I3S -> 3DTiles conversion

### DIFF
--- a/modules/i3s/src/lib/parsers/parse-i3s-tile-content.ts
+++ b/modules/i3s/src/lib/parsers/parse-i3s-tile-content.ts
@@ -59,7 +59,7 @@ export async function parseI3STileContent(
         // @ts-ignore context must be defined
         // Image constructor is not supported in worker thread.
         // Do parsing image data on the main thread by using context to avoid worker issues.
-        tile.content.texture = await context.parse(arrayBuffer, options);
+        tile.content.texture = await context.parse(arrayBuffer, loader, options);
       } else if (loader === CompressedTextureLoader || loader === BasisLoader) {
         // @ts-ignore context must be defined
         const texture = await load(arrayBuffer, loader, tile.textureLoaderOptions);


### PR DESCRIPTION
While I3S -> 3DTiles conversion context.parse(...) can't find particular loader.
Looks like context object is different in `parseI3STileContent` function between `I3S Application` and `tile-converter` work.
I tried to add a `mimeType` to options but it doesn't help.

