### PR TITLE
fix(i3s): coordinate system option - backward compatibility

### DIFF
--- a/modules/i3s/src/lib/parsers/parse-i3s-tile-content.ts
+++ b/modules/i3s/src/lib/parsers/parse-i3s-tile-content.ts
@@ -167,7 +167,10 @@ async function parseI3SNodeGeometry(
     attributes = concatAttributes(normalizedVertexAttributes, normalizedFeatureAttributes);
   }
 
-  if (options?.i3s?.coordinateSystem === COORDINATE_SYSTEM.METER_OFFSETS) {
+  if (
+    !options?.i3s?.coordinateSystem ||
+    options.i3s.coordinateSystem === COORDINATE_SYSTEM.METER_OFFSETS
+  ) {
     const {enuMatrix} = parsePositions(attributes.position, tile);
     content.modelMatrix = enuMatrix.invert();
     content.coordinateSystem = COORDINATE_SYSTEM.METER_OFFSETS;


### PR DESCRIPTION
Use METER_OFFSETS when option is not set, in older @loaders.gl versions.