### PR TITLE
feat(build): generate d.ts files

### DIFF
--- a/modules/3d-tiles/package.json
+++ b/modules/3d-tiles/package.json
@@ -20,7 +20,7 @@
     "point cloud",
     "pointcloud"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -31,6 +31,7 @@
   ],
   "scripts": {
     "pre-build": "npm run build-bundle",
+    "post-build": "tsc",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js"
   },
   "dependencies": {

--- a/modules/3d-tiles/tsconfig.json
+++ b/modules/3d-tiles/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/arrow/package.json
+++ b/modules/arrow/package.json
@@ -18,7 +18,7 @@
     "point cloud",
     "PLY"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -32,6 +32,7 @@
   },
   "scripts": {
     "pre-build": "npm run build-worker && npm run build-bundle",
+    "post-build": "tsc",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-worker": "webpack --entry ./src/workers/arrow-worker.ts --output ./dist/arrow-worker.js --config ../../scripts/webpack/worker.js"
   },

--- a/modules/arrow/tsconfig.json
+++ b/modules/arrow/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/compression/package.json
+++ b/modules/compression/package.json
@@ -17,7 +17,7 @@
     "mesh",
     "point cloud"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -33,6 +33,7 @@
   },
   "scripts": {
     "pre-build": "npm run build-bundle && npm run build-worker",
+    "post-build": "tsc",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-worker": "webpack --entry ./src/workers/worker.ts --output ./dist/compression-worker.js --config ../../scripts/webpack/worker.js"
   },

--- a/modules/compression/tsconfig.json
+++ b/modules/compression/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/crypto/package.json
+++ b/modules/crypto/package.json
@@ -17,7 +17,7 @@
     "mesh",
     "point cloud"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -28,6 +28,7 @@
   ],
   "scripts": {
     "pre-build": "npm run build-worker && npm run build-bundle",
+    "post-build": "tsc",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-worker": "webpack --entry ./src/workers/worker.ts --output ./dist/worker.js --env.dev --config ../../scripts/webpack/worker.js"
   },

--- a/modules/crypto/tsconfig.json
+++ b/modules/crypto/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/draco/package.json
+++ b/modules/draco/package.json
@@ -19,7 +19,7 @@
     "draco3d",
     "draco"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -33,6 +33,7 @@
   ],
   "scripts": {
     "pre-build": "npm run build-bundle && npm run build-worker",
+    "post-build": "tsc",
     "build-bundle": "webpack --config ../../scripts/webpack/bundle.js",
     "build-worker": "webpack --entry ./src/workers/draco-worker.ts --output ./dist/draco-worker.js --config ../../scripts/webpack/worker.js"
   },

--- a/modules/draco/tsconfig.json
+++ b/modules/draco/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/excel/package.json
+++ b/modules/excel/package.json
@@ -20,7 +20,7 @@
     "Worksheets",
     "Spreadsheets"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -31,6 +31,7 @@
   ],
   "scripts": {
     "pre-build": "npm run build-bundle && npm run build-worker",
+    "post-build": "tsc",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-worker": "webpack --entry ./src/workers/excel-worker.ts --output ./dist/excel-worker.js --config ../../scripts/webpack/worker.js"
   },

--- a/modules/excel/tsconfig.json
+++ b/modules/excel/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/flatgeobuf/package.json
+++ b/modules/flatgeobuf/package.json
@@ -17,7 +17,7 @@
     "MVT",
     "Mapbox Vector Tiles"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -28,6 +28,7 @@
   ],
   "scripts": {
     "pre-build": "npm run build-worker && npm run build-worker --env.dev && npm run build-bundle",
+    "post-build": "tsc",
     "build-worker": "webpack --entry ./src/workers/flatgeobuf-worker.ts --output ./dist/flatgeobuf-worker.js --config ../../scripts/webpack/worker.js",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js"
   },

--- a/modules/flatgeobuf/tsconfig.json
+++ b/modules/flatgeobuf/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/geopackage/package.json
+++ b/modules/geopackage/package.json
@@ -14,7 +14,7 @@
     "sql",
     "GeoPackage"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -23,6 +23,9 @@
     "dist",
     "README.md"
   ],
+  "scripts": {
+    "post-build": "tsc"
+  },
   "dependencies": {
     "@babel/runtime": "^7.3.1",
     "@loaders.gl/gis": "3.1.0-alpha.4",

--- a/modules/geopackage/tsconfig.json
+++ b/modules/geopackage/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/geotiff/package.json
+++ b/modules/geotiff/package.json
@@ -18,7 +18,7 @@
     "tiff",
     "geotiff"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -30,6 +30,7 @@
   ],
   "scripts": {
     "pre-build": "npm run build-bundle",
+    "post-build": "tsc",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js"
   },
   "dependencies-disabled": {

--- a/modules/geotiff/tsconfig.json
+++ b/modules/geotiff/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/gis/package.json
+++ b/modules/gis/package.json
@@ -14,7 +14,7 @@
     "geometry",
     "GeoJSON"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -23,6 +23,9 @@
     "dist",
     "README.md"
   ],
+  "scripts": {
+    "post-build": "tsc"
+  },
   "dependencies": {
     "@loaders.gl/loader-utils": "3.1.0-alpha.4",
     "@loaders.gl/schema": "3.1.0-alpha.4",

--- a/modules/gis/src/lib/binary-to-geojson.ts
+++ b/modules/gis/src/lib/binary-to-geojson.ts
@@ -112,7 +112,7 @@ export function binaryToGeometry(
     case 'Polygon':
       return polygonToGeoJson(data, startIndex, endIndex);
     default:
-      const unexpectedInput: never = data;
+      const unexpectedInput = data;
       throw new Error(`Unsupported geometry type: ${(unexpectedInput as any)?.type}`);
   }
 }
@@ -126,8 +126,6 @@ function normalizeInput(data: BinaryFeatures, type?: BinaryGeometryType): Binary
   const isHeterogeneousType = Boolean(data.points || data.lines || data.polygons);
 
   if (!isHeterogeneousType) {
-    // @ts-expect-error This is a legacy check which allowed `data` to be an instance of the values
-    // here. Aka the new data.points, data.lines, or data.polygons.
     data.type = type || parseType(data);
     return [data] as BinaryFeaturesArray;
   }

--- a/modules/gis/tsconfig.json
+++ b/modules/gis/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/gltf/package.json
+++ b/modules/gltf/package.json
@@ -19,7 +19,7 @@
     "GLB",
     "glTF"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -31,6 +31,7 @@
   ],
   "scripts": {
     "pre-build": "npm run build-bundle",
+    "post-build": "tsc",
     "build-bundle": "webpack --config ../../scripts/webpack/bundle.js"
   },
   "dependencies": {

--- a/modules/gltf/tsconfig.json
+++ b/modules/gltf/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/i3s/package.json
+++ b/modules/i3s/package.json
@@ -17,7 +17,7 @@
     "tile",
     "mesh"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -28,6 +28,7 @@
   ],
   "scripts": {
     "pre-build": "npm run build-bundle && npm run build-worker",
+    "post-build": "tsc",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-worker": "webpack --entry ./src/workers/i3s-content-worker.ts --output ./dist/i3s-content-worker.js --config ../../scripts/webpack/worker.js"
   },

--- a/modules/i3s/tsconfig.json
+++ b/modules/i3s/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/images/package.json
+++ b/modules/images/package.json
@@ -18,7 +18,7 @@
     "point cloud",
     "PLY"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -29,6 +29,7 @@
   ],
   "scripts": {
     "pre-build": "npm run build-bundle",
+    "post-build": "tsc",
     "build-bundle": "webpack  --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-worker": "webpack --entry ./src/image-worker.js --output ./dist/image-worker.js --config ../../scripts/webpack/worker.js"
   },

--- a/modules/images/tsconfig.json
+++ b/modules/images/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/json/package.json
+++ b/modules/json/package.json
@@ -20,7 +20,7 @@
     "JSON stream",
     "JSON async iterator"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -31,6 +31,7 @@
   ],
   "scripts": {
     "pre-build": "npm run build-bundle && npm run build-worker",
+    "post-build": "tsc",
     "build-bundle": "webpack --config ../../scripts/webpack/bundle.js",
     "build-worker": "webpack --entry ./src/workers/geojson-worker.ts --output ./dist/geojson-worker.js --config ../../scripts/webpack/worker.js"
   },

--- a/modules/json/tsconfig.json
+++ b/modules/json/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/kml/package.json
+++ b/modules/kml/package.json
@@ -18,7 +18,7 @@
     "point cloud",
     "KML"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -29,6 +29,7 @@
   ],
   "scripts": {
     "pre-build": "npm run build-bundle",
+    "post-build": "tsc",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js"
   },
   "dependencies": {

--- a/modules/kml/tsconfig.json
+++ b/modules/kml/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/las/package.json
+++ b/modules/las/package.json
@@ -19,7 +19,7 @@
     "LAS",
     "LAZ"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -36,6 +36,7 @@
   ],
   "scripts": {
     "pre-build": "npm run build-bundle && npm run build-worker",
+    "post-build": "tsc",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-worker": "webpack --entry ./src/workers/las-worker.js --output ./dist/las-worker.js --config ../../scripts/webpack/worker.js"
   },

--- a/modules/las/tsconfig.json
+++ b/modules/las/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/loader-utils/package.json
+++ b/modules/loader-utils/package.json
@@ -17,7 +17,7 @@
     "mesh",
     "point cloud"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -44,6 +44,7 @@
   },
   "scripts": {
     "pre-build-disabled": "npm run build-bundle",
+    "post-build": "tsc",
     "build-bundle": "webpack --config ../../scripts/webpack/bundle.js"
   },
   "dependencies": {

--- a/modules/loader-utils/tsconfig.json
+++ b/modules/loader-utils/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/math/package.json
+++ b/modules/math/package.json
@@ -17,7 +17,7 @@
     "GLB",
     "glTF"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,

--- a/modules/math/package.json
+++ b/modules/math/package.json
@@ -28,7 +28,8 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "echo \"Nothing to build in @loaders.gl/math\""
+    "pre-build": "echo \"Nothing to build in @loaders.gl/math\"",
+    "post-build": "tsc"
   },
   "dependencies": {
     "@loaders.gl/images": "3.1.0-alpha.4",

--- a/modules/math/tsconfig.json
+++ b/modules/math/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/mvt/package.json
+++ b/modules/mvt/package.json
@@ -17,7 +17,7 @@
     "MVT",
     "Mapbox Vector Tiles"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -28,6 +28,7 @@
   ],
   "scripts": {
     "pre-build": "npm run build-worker && npm run build-worker --env.dev && npm run build-bundle",
+    "post-build": "tsc",
     "build-worker": "webpack --entry ./src/workers/mvt-worker.ts --output ./dist/mvt-worker.js --config ../../scripts/webpack/worker.js",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js"
   },

--- a/modules/mvt/tsconfig.json
+++ b/modules/mvt/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/netcdf/package.json
+++ b/modules/netcdf/package.json
@@ -16,7 +16,7 @@
     "parser",
     "NetCDF"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "sideEffects": false,
@@ -27,6 +27,7 @@
   ],
   "scripts": {
     "pre-build-disabled": "npm run build-bundle",
+    "post-build": "tsc",
     "build-worker": "webpack --entry ./src/workers/mvt-worker.ts --output ./dist/mvt-worker.js --config ../../scripts/webpack/worker.js",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js"
   },

--- a/modules/netcdf/tsconfig.json
+++ b/modules/netcdf/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/obj/package.json
+++ b/modules/obj/package.json
@@ -18,7 +18,7 @@
     "point cloud",
     "OBJ"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -29,6 +29,7 @@
   ],
   "scripts": {
     "pre-build": "npm run build-worker && npm run build-bundle",
+    "post-build": "tsc",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-worker": "webpack --entry ./src/workers/obj-worker.js --output ./dist/obj-worker.js --config ../../scripts/webpack/worker.js"
   },

--- a/modules/obj/tsconfig.json
+++ b/modules/obj/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/parquet/package.json
+++ b/modules/parquet/package.json
@@ -18,7 +18,7 @@
     "Parquet",
     "Apache Parquet"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -29,6 +29,7 @@
   ],
   "scripts": {
     "pre-build": "npm run build-worker && npm run build-bundle",
+    "post-build": "tsc",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-worker": "webpack --entry ./src/workers/parquet-worker.ts --output ./dist/parquet-worker.js --config ../../scripts/webpack/worker.js"
   },

--- a/modules/parquet/src/parquetjs/codecs/rle.ts
+++ b/modules/parquet/src/parquetjs/codecs/rle.ts
@@ -63,7 +63,7 @@ export function encodeValues(
   }
 
   const envelope = Buffer.alloc(buf.length + 4);
-  envelope.writeUInt32LE(buf.length, undefined);
+  envelope.writeUInt32LE(buf.length, 0);
   buf.copy(envelope, 4);
 
   return envelope;

--- a/modules/parquet/tsconfig.json
+++ b/modules/parquet/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/pcd/package.json
+++ b/modules/pcd/package.json
@@ -18,7 +18,7 @@
     "point cloud",
     "PCD"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -29,6 +29,7 @@
   ],
   "scripts": {
     "pre-build": "npm run build-worker && npm run build-bundle",
+    "post-build": "tsc",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-worker": "webpack --entry ./src/workers/pcd-worker.ts --output ./dist/pcd-worker.js --config ../../scripts/webpack/worker.js"
   },

--- a/modules/pcd/tsconfig.json
+++ b/modules/pcd/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/ply/package.json
+++ b/modules/ply/package.json
@@ -18,7 +18,7 @@
     "point cloud",
     "PLY"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -29,6 +29,7 @@
   ],
   "scripts": {
     "pre-build": "npm run build-worker && npm run build-bundle",
+    "post-build": "tsc",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-worker": "webpack --entry ./src/workers/ply-worker.ts --output ./dist/ply-worker.js --config ../../scripts/webpack/worker.js"
   },

--- a/modules/ply/tsconfig.json
+++ b/modules/ply/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/polyfills/package.json
+++ b/modules/polyfills/package.json
@@ -17,7 +17,7 @@
     "TextEncoder",
     "TextDecoder"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "files": [
@@ -93,6 +93,7 @@
   },
   "scripts": {
     "pre-build": "npm run build-bundle",
+    "post-build": "tsc",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js"
   },
   "dependencies": {

--- a/modules/polyfills/tsconfig.json
+++ b/modules/polyfills/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/potree/package.json
+++ b/modules/potree/package.json
@@ -21,7 +21,7 @@
     "point cloud",
     "pointcloud"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -32,6 +32,7 @@
   ],
   "scripts": {
     "pre-build": "npm run build-bundle",
+    "post-build": "tsc",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js"
   },
   "dependencies": {

--- a/modules/potree/tsconfig.json
+++ b/modules/potree/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/schema/package.json
+++ b/modules/schema/package.json
@@ -18,7 +18,7 @@
     "point cloud",
     "PLY"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -29,6 +29,7 @@
   ],
   "scripts": {
     "pre-build": "npm run build-bundle",
+    "post-build": "tsc",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js"
   },
   "dependencies": {

--- a/modules/schema/src/category/gis.ts
+++ b/modules/schema/src/category/gis.ts
@@ -55,6 +55,7 @@ export type BinaryPolygonFeatures = BinaryPolygonGeometry & BinaryProperties;
  * Represent a collection of Features, similar to a GeoJSON FeatureCollection
  */
 export type BinaryFeatures = {
+  type?: BinaryGeometryType;
   points?: BinaryPointFeatures;
   lines?: BinaryLineFeatures;
   polygons?: BinaryPolygonFeatures;

--- a/modules/schema/tsconfig.json
+++ b/modules/schema/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/shapefile/package.json
+++ b/modules/shapefile/package.json
@@ -17,7 +17,7 @@
     "shapefile",
     "shp"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -32,6 +32,7 @@
   ],
   "scripts": {
     "pre-build": "npm run build-shp-worker && npm run build-dbf-worker && npm run build-bundle",
+    "post-build": "tsc",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-shp-worker": "webpack --entry ./src/workers/shp-worker.js --output ./dist/shp-worker.js --config ../../scripts/webpack/worker.js",
     "build-dbf-worker": "webpack --entry ./src/workers/dbf-worker.js --output ./dist/dbf-worker.js --config ../../scripts/webpack/worker.js"

--- a/modules/shapefile/tsconfig.json
+++ b/modules/shapefile/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/terrain/package.json
+++ b/modules/terrain/package.json
@@ -18,7 +18,7 @@
     "point cloud",
     "OBJ"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -29,6 +29,7 @@
   ],
   "scripts": {
     "pre-build": "npm run build-worker && npm run build-worker2 && npm run build-bundle",
+    "post-build": "tsc",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-worker": "webpack --entry ./src/workers/terrain-worker.js --output ./dist/terrain-worker.js --config ../../scripts/webpack/worker.js",
     "build-worker2": "webpack --entry ./src/workers/quantized-mesh-worker.js --output ./dist/quantized-mesh-worker.js --config ../../scripts/webpack/worker.js"

--- a/modules/terrain/src/lib/helpers/skirt.js
+++ b/modules/terrain/src/lib/helpers/skirt.js
@@ -78,7 +78,7 @@ function getOutsideEdgesFromTriangles(triangles) {
 /**
  * Get geometry edges that located on a border of the mesh
  * @param {object} indices - edge indices from quantized mesh data
- * @param {TypedArray} position - position attribute geometry data
+ * @param {import('modules/schema').TypedArray} position - position attribute geometry data
  * @returns {number[][]} - outside edges data
  */
 function getOutsideEdgesFromIndices(indices, position) {
@@ -107,9 +107,9 @@ function getOutsideEdgesFromIndices(indices, position) {
  * @param {number} args.edgeIndex - edge index in outsideEdges array
  * @param {object} args.attributes - POSITION and TEXCOORD_0 attributes
  * @param {number} args.skirtHeight - height of the skirt geometry
- * @param {TypedArray} args.newPosition - POSITION array for skirt data
- * @param {TypedArray} args.newTexcoord0 - TEXCOORD_0 array for skirt data
- * @param {TypedArray | Array} args.newTriangles - trinagle indices array for skirt data
+ * @param {import('modules/schema').TypedArray} args.newPosition - POSITION array for skirt data
+ * @param {import('modules/schema').TypedArray} args.newTexcoord0 - TEXCOORD_0 array for skirt data
+ * @param {import('modules/schema').TypedArray | Array} args.newTriangles - trinagle indices array for skirt data
  * @returns {void}
  */
 function updateAttributesForNewEdge({

--- a/modules/terrain/tsconfig.json
+++ b/modules/terrain/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/textures/package.json
+++ b/modules/textures/package.json
@@ -21,7 +21,7 @@
     "ETC",
     "basis"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -33,6 +33,7 @@
   ],
   "scripts": {
     "pre-build": "npm run copy-libs && npm run build-worker && npm run build-bundle",
+    "post-build": "tsc",
     "copy-libs": "cp -rf ./src/libs ./dist/libs",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-worker": "npm run build-basis-worker && npm run build-npy-worker && npm run build-compressed-texture-worker && npm run build-crunch-worker",

--- a/modules/textures/tsconfig.json
+++ b/modules/textures/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "src/libs"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/tiles/package.json
+++ b/modules/tiles/package.json
@@ -19,7 +19,7 @@
     "point cloud",
     "pointcloud"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -30,6 +30,7 @@
   ],
   "scripts": {
     "pre-build": "npm run build-bundle",
+    "post-build": "tsc",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js"
   },
   "dependencies": {

--- a/modules/tiles/tsconfig.json
+++ b/modules/tiles/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/video/package.json
+++ b/modules/video/package.json
@@ -18,7 +18,7 @@
     "point cloud",
     "PLY"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -29,6 +29,7 @@
   ],
   "scripts": {
     "pre-build": "npm run build-bundle",
+    "post-build": "tsc",
     "build-bundle": "webpack  --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-worker": "webpack --entry ./src/image-worker.js --output ./dist/image-worker.js --config ../../scripts/webpack/worker.js"
   },

--- a/modules/video/tsconfig.json
+++ b/modules/video/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/wkt/package.json
+++ b/modules/wkt/package.json
@@ -17,7 +17,7 @@
     "WKT",
     "Well Known Text"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -28,6 +28,7 @@
   ],
   "scripts": {
     "pre-build": "npm run build-worker && npm run build-bundle",
+    "post-build": "tsc",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js",
     "build-worker": "webpack --entry ./src/workers/wkt-worker.ts --output ./dist/wkt-worker.js --config ../../scripts/webpack/worker.js"
   },

--- a/modules/wkt/tsconfig.json
+++ b/modules/wkt/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/worker-utils/package.json
+++ b/modules/worker-utils/package.json
@@ -15,7 +15,7 @@
     "process",
     "thread"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -36,6 +36,7 @@
   },
   "scripts": {
     "pre-build": "npm run build-workers",
+    "post-build": "tsc",
     "pre-build-disabled": "npm run build-bundle && npm run build-workers",
     "build-bundle": "webpack --config ../../scripts/webpack/bundle.ts",
     "build-workers": "webpack --entry ./src/workers/null-worker.ts --output ./dist/null-worker.js --env.dev --config ../../scripts/webpack/worker.js"

--- a/modules/worker-utils/tsconfig.json
+++ b/modules/worker-utils/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/zarr/package.json
+++ b/modules/zarr/package.json
@@ -15,7 +15,7 @@
     "loader",
     "zarr"
   ],
-  "types": "src/index.d.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -27,6 +27,7 @@
   ],
   "scripts": {
     "pre-build": "npm run build-bundle",
+    "post-build": "tsc",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js"
   },
   "dependencies": {

--- a/modules/zarr/tsconfig.json
+++ b/modules/zarr/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/modules/zip/package.json
+++ b/modules/zip/package.json
@@ -16,7 +16,7 @@
     "archive",
     "ZIP"
   ],
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "main": "dist/es5/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -27,6 +27,7 @@
   ],
   "scripts": {
     "pre-build": "npm run build-bundle",
+    "post-build": "tsc",
     "build-bundle": "webpack --display=minimal --config ../../scripts/webpack/bundle.js"
   },
   "dependencies": {

--- a/modules/zip/tsconfig.json
+++ b/modules/zip/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,14 @@
+// This is a base TS config for the individual packages, mainly for building .d.ts files
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    // "declarationMap": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    // "listEmittedFiles": true,
+    "module": "commonjs",
+    "resolveJsonModule": true,
+    "esModuleInterop": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -95,6 +95,7 @@
     }
   },
   "exclude":[
+    "modules/3d-tiles/test/**/*",
     "modules/tile-converter/**/*",
     "modules/i3s/test/**/*",
     "modules/gltf/test/**/*",


### PR DESCRIPTION
@ibgreen , I used your #1907 to make these changes to 3.1-release branch.
test application #1908 doesn't work with #1907 because esbuild can't build code to es5.

I could not create d.ts for some modules:
* core [core.errors.log](https://github.com/visgl/loaders.gl/files/7486720/core.errors.log)
* csv [csv.errors.log](https://github.com/visgl/loaders.gl/files/7486706/csv.errors.log)
* tile-converter (85 ts errors) - I suppose we can leave this module without typing.

Test application #1908 work good with this PR. It uses shapefile module.