### PR TITLE
build(deps): bump xmldom 0.5.0 to @xmldom/xmldom 0.7.5

### DIFF
--- a/modules/i3s/src/lib/parsers/constants.ts
+++ b/modules/i3s/src/lib/parsers/constants.ts
@@ -1,14 +1,24 @@
 import GL from '@luma.gl/constants';
+import {DATA_TYPE} from '../../types';
 
-export const TYPE_ARRAY_MAP = {
-  UInt8: Uint8Array,
-  UInt16: Uint16Array,
-  UInt32: Uint32Array,
-  Float32: Float32Array,
-  UInt64: Float64Array
-};
+export function getConstructorForDataFormat(dataType: string) {
+  switch (dataType) {
+    case DATA_TYPE.UInt8:
+      return Uint8Array;
+    case DATA_TYPE.UInt16:
+      return Uint16Array;
+    case DATA_TYPE.UInt32:
+      return Uint32Array;
+    case DATA_TYPE.Float32:
+      return Float32Array;
+    case DATA_TYPE.UInt64:
+      return Float64Array;
+    default:
+      return null;
+  }
+}
 
-export const GL_TYPE_MAP = {
+export const GL_TYPE_MAP: {[key: string]: number} = {
   UInt8: GL.UNSIGNED_BYTE,
   UInt16: GL.UNSIGNED_INT,
   Float32: GL.FLOAT,
@@ -29,20 +39,36 @@ export const I3S_NAMED_GEOMETRY_ATTRIBUTES = {
   featureAttributeOrder: 'featureAttributeOrder',
   featureAttributes: 'featureAttributes'
 };
-
+// TODO Remove Named Attributes and replase with Typescipt types
 export const I3S_NAMED_HEADER_ATTRIBUTES = {
-  header: 'header',
+  // header: 'header',
   vertexCount: 'vertexCount',
   featureCount: 'featureCount'
 };
-
-export const SIZEOF = {
-  UInt8: 1,
-  UInt16: 2,
-  UInt32: 4,
-  Float32: 4,
-  UInt64: 8
-};
+/**
+ * Returns how many bytes a type occupies
+ * @param dataType
+ * @returns
+ */
+export function sizeOf(dataType: string): number {
+  switch (dataType) {
+    case DATA_TYPE.UInt8:
+      return 1;
+    case DATA_TYPE.UInt16:
+    case DATA_TYPE.Int16:
+      return 2;
+    case DATA_TYPE.UInt32:
+    case DATA_TYPE.Int32:
+    case DATA_TYPE.Float32:
+      return 4;
+    case DATA_TYPE.UInt64:
+    case DATA_TYPE.Int64:
+    case DATA_TYPE.Float64:
+      return 8;
+    default:
+      return NaN;
+  }
+}
 
 export const STRING_ATTRIBUTE_TYPE = 'String';
 export const OBJECT_ID_ATTRIBUTE_TYPE = 'Oid32';
@@ -51,21 +77,28 @@ export const INT_16_ATTRIBUTE_TYPE = 'Int16';
 
 // https://github.com/visgl/deck.gl/blob/9548f43cba2234a1f4877b6b17f6c88eb35b2e08/modules/core/src/lib/constants.js#L27
 // Describes the format of positions
-export const COORDINATE_SYSTEM = {
-  // `LNGLAT` if rendering into a geospatial viewport, `CARTESIAN` otherwise
-  DEFAULT: -1,
-  // Positions are interpreted as [lng, lat, elevation]
-  // lng lat are degrees, elevation is meters. distances as meters.
-  LNGLAT: 1,
-
-  // Positions are interpreted as meter offsets, distances as meters
-  METER_OFFSETS: 2,
-
-  // Positions are interpreted as lng lat offsets: [deltaLng, deltaLat, elevation]
-  // deltaLng, deltaLat are delta degrees, elevation is meters.
-  // distances as meters.
-  LNGLAT_OFFSETS: 3,
-
-  // Non-geospatial
-  CARTESIAN: 0
-};
+export enum COORDINATE_SYSTEM {
+  /**
+   * `LNGLAT` if rendering into a geospatial viewport, `CARTESIAN` otherwise
+   */
+  DEFAULT = -1,
+  /**
+   * Positions are interpreted as [lng, lat, elevation]
+   * lng lat are degrees, elevation is meters. distances as meters.
+   */
+  LNGLAT = 1,
+  /**
+   * Positions are interpreted as meter offsets, distances as meters
+   */
+  METER_OFFSETS = 2,
+  /**
+   * Positions are interpreted as lng lat offsets: [deltaLng, deltaLat, elevation]
+   * deltaLng, deltaLat are delta degrees, elevation is meters.
+   * distances as meters.
+   */
+  LNGLAT_OFFSETS = 3,
+  /**
+   * Non-geospatial
+   */
+  CARTESIAN = 0
+}

--- a/modules/i3s/src/lib/utils/url-utils.ts
+++ b/modules/i3s/src/lib/utils/url-utils.ts
@@ -6,7 +6,7 @@ import {Tile} from '../../types';
  * @param {any} token
  * @returns {string}
  */
-export function getUrlWithToken(url, token = null) {
+export function getUrlWithToken(url: string, token = null): string {
   return token ? `${url}?token=${token}` : url;
 }
 


### PR DESCRIPTION
Bumping `xmldom` to `@xmldom/xmldom` as documented here: https://github.com/xmldom/xmldom/issues/271

I have a project failing a Dependabot security alert for the `xmldom` package. The suggested patch is this:

```
Update to one of the fixed versions of @xmldom/xmldom (^0.5.1 || ^0.6.1 || >=0.7.0). ❗ Users of xmldom should switch to @xmldom/xmldom to not be affected by this vulnerability.

See issue #271 for the status of publishing xmldom to npm or join #270 for Q&A/discussion until it's resolved.
```

The new `@xmldom/xmldom` package looks to be just a fork that's now being maintained, so we shouldn't have any upgrade issues.

The new package for reference - https://github.com/xmldom/xmldom