### PR TITLE
Allow top-level workerUrl for CompressionWorker

### DIFF
--- a/modules/worker-utils/src/lib/worker-api/get-worker-url.ts
+++ b/modules/worker-utils/src/lib/worker-api/get-worker-url.ts
@@ -27,7 +27,7 @@ export function getWorkerURL(worker: WorkerObject, options: WorkerOptions = {}):
 
   let url = workerOptions.workerUrl;
 
-  // Allow for non-nested workerUrl for the CompressionWorker.
+  // HACK: Allow for non-nested workerUrl for the CompressionWorker.
   // For the compression worker, workerOptions is currently not nested correctly. For most loaders,
   // you'd have options within an object, i.e. `{mvt: {coordinates: ...}}` but the CompressionWorker
   // puts options at the top level, not within a `compression` key (its `id`). For this reason, the

--- a/modules/worker-utils/src/lib/worker-api/get-worker-url.ts
+++ b/modules/worker-utils/src/lib/worker-api/get-worker-url.ts
@@ -27,6 +27,16 @@ export function getWorkerURL(worker: WorkerObject, options: WorkerOptions = {}):
 
   let url = workerOptions.workerUrl;
 
+  // Allow for non-nested workerUrl for the CompressionWorker.
+  // For the compression worker, workerOptions is currently not nested correctly. For most loaders,
+  // you'd have options within an object, i.e. `{mvt: {coordinates: ...}}` but the CompressionWorker
+  // puts options at the top level, not within a `compression` key (its `id`). For this reason, the
+  // above `workerOptions` will always be a string (i.e. `'gzip'`) for the CompressionWorker. To not
+  // break backwards compatibility, we allow the CompressionWorker to have options at the top level.
+  if (!url && worker.id === 'compression') {
+    url = options.workerUrl;
+  }
+
   // If URL is test, generate local loaders.gl url
   // @ts-ignore _workerType
   if (options._workerType === 'test') {

--- a/modules/worker-utils/src/types.ts
+++ b/modules/worker-utils/src/types.ts
@@ -9,6 +9,7 @@ export type WorkerOptions = {
   maxMobileConcurrency?: number;
   reuseWorkers?: boolean;
   _workerType?: string;
+  workerUrl?: string;
   [key: string]: any; // TODO
 };
 


### PR DESCRIPTION
This PR allows for a non-nested `workerUrl` option for the `CompressionWorker`.

For the `CompressionWorker`, `workerOptions` is currently not nested correctly. For most loaders, you'd have options within an object where the key is the loader's `id`:
```js
{
	mvt: {
		coordinates: ...
	}
}
```
but the `CompressionWorker` overrides this and uses the top level `compression` key to hold the _type of compression_ not an options object. To not break backwards compatibility, this allows the `CompressionWorker` to have a `workerUrl` option at the top level.

Should this be documented in the `processOnWorker` page? The `CompressionWorker` page?