### PR TITLE
Detect when 64 bit precision is required for a numericProp in MVTLoader

### DIFF
--- a/modules/gis/src/lib/geojson-to-binary.ts
+++ b/modules/gis/src/lib/geojson-to-binary.ts
@@ -30,7 +30,7 @@ type PropArrayConstructor = Float32ArrayConstructor | Float64ArrayConstructor | 
 type FirstPassData = {
   coordLength: number;
   numericPropKeys: string[];
-  propArrayConstructors: {[key: string]: PropArrayConstructor};
+  propArrayTypes: {[key: string]: PropArrayConstructor};
 
   pointPositionsCount: number;
   pointFeaturesCount: number;
@@ -61,7 +61,7 @@ function firstPass(features: Feature[]): FirstPassData {
   let polygonRingsCount = 0;
   let polygonFeaturesCount = 0;
   const coordLengths = new Set<number>();
-  const propArrayConstructors = {};
+  const propArrayTypes = {};
 
   for (const feature of features) {
     const geometry = feature.geometry;
@@ -134,7 +134,7 @@ function firstPass(features: Feature[]): FirstPassData {
         // in all previous features, check if numeric in this feature
         // If not numeric, Array is stored to prevent rechecking in the future
         // Additionally, detects if 64 bit precision is required
-        propArrayConstructors[key] = deduceArrayType(val, propArrayConstructors[key]);
+        propArrayTypes[key] = deduceArrayType(val, propArrayTypes[key]);
       }
     }
   }
@@ -153,10 +153,8 @@ function firstPass(features: Feature[]): FirstPassData {
     polygonFeaturesCount,
 
     // Array of keys whose values are always numeric
-    numericPropKeys: Object.keys(propArrayConstructors).filter(
-      (k) => propArrayConstructors[k] !== Array
-    ),
-    propArrayConstructors
+    numericPropKeys: Object.keys(propArrayTypes).filter((k) => propArrayTypes[k] !== Array),
+    propArrayTypes
   };
 }
 
@@ -179,7 +177,7 @@ function secondPass(
     polygonPositionsCount,
     polygonObjectsCount,
     polygonRingsCount,
-    propArrayConstructors,
+    propArrayTypes,
     polygonFeaturesCount
   } = firstPassData;
   const {coordLength, numericPropKeys, PositionDataType = Float32Array} = options;
@@ -238,7 +236,7 @@ function secondPass(
     for (const propName of numericPropKeys || []) {
       // If property has been numeric in all previous features in which the property existed, check
       // if numeric in this feature
-      const TypedArray = propArrayConstructors[propName];
+      const TypedArray = propArrayTypes[propName];
       object.numericProps[propName] = new TypedArray(object.positions.length / coordLength);
     }
   }

--- a/modules/gis/test/geojson-to-binary.spec.js
+++ b/modules/gis/test/geojson-to-binary.spec.js
@@ -168,6 +168,13 @@ test('gis#geojson-to-binary properties', async (t) => {
     feature.properties.int2 = 1;
   }
 
+  // Mixed 32/64bit ints
+  const LARGE = 80650000088;
+  for (const feature of features) {
+    feature.properties.int3 = 1;
+  }
+  features[1].properties.int3 = LARGE;
+
   // Uniform float, missing in some features
   features[0].properties.float1 = 3.14;
   features[1].properties.float1 = 2.14;
@@ -189,7 +196,15 @@ test('gis#geojson-to-binary properties', async (t) => {
 
   const firstPassData = firstPass(features);
   const {numericPropKeys} = firstPassData;
-  const expectedNumericPropKeys = ['int1', 'int2', 'float1', 'float2', 'numeric1', 'numeric2'];
+  const expectedNumericPropKeys = [
+    'int1',
+    'int2',
+    'int3',
+    'float1',
+    'float2',
+    'numeric1',
+    'numeric2'
+  ];
   t.deepEquals(numericPropKeys, expectedNumericPropKeys);
 
   const options = {
@@ -216,7 +231,8 @@ test('gis#geojson-to-binary properties', async (t) => {
 
   // Verify selected values
   t.deepEquals(points.numericProps.int2.value, new Float32Array(3).fill(1));
-  t.deepEquals(points.numericProps.float2.value, new Float32Array(3).fill(3.14));
+  t.deepEquals(points.numericProps.int3.value, new Float64Array([1, LARGE, LARGE]));
+  t.deepEquals(points.numericProps.float2.value, new Float64Array(3).fill(3.14));
 
   // Verify point string property objects
   t.deepEquals(points.properties, [

--- a/modules/mvt/src/lib/binary-vector-tile/features-to-binary.ts
+++ b/modules/mvt/src/lib/binary-vector-tile/features-to-binary.ts
@@ -4,6 +4,7 @@ import {
   MvtBinaryCoordinates,
   MvtBinaryGeometry,
   MvtBinaryOptions,
+  MvtNumericArrayConstructor,
   MvtFirstPassedData,
   MvtLines,
   MvtPoints,
@@ -28,14 +29,18 @@ export function featuresToBinary(
   firstPassData: MvtFirstPassedData,
   options?: MvtBinaryOptions
 ) {
+  const numericPropTypes = extractNumericPropTypes(features);
+  const numericPropKeys = Object.keys(numericPropTypes).filter(
+    (k) => numericPropTypes[k] !== Array
+  );
   return fillArrays(features, firstPassData, {
-    numericPropKeys: options ? options.numericPropKeys : extractNumericPropKeys(features),
+    numericPropKeys: options ? options.numericPropKeys : numericPropKeys,
+    numericPropTypes,
     PositionDataType: options ? options.PositionDataType : Float32Array
   });
 }
 
 export const TEST_EXPORTS = {
-  extractNumericPropKeys,
   fillArrays
 };
 
@@ -43,26 +48,26 @@ export const TEST_EXPORTS = {
  * Extracts properties that are always numeric
  *
  * @param features
- * @returns object with numeric keys
+ * @returns object with numeric types
  */
-function extractNumericPropKeys(features: MvtBinaryCoordinates[]): string[] {
-  const numericPropKeys = {};
+function extractNumericPropTypes(features: MvtBinaryCoordinates[]): {
+  [key: string]: MvtNumericArrayConstructor;
+} {
+  const numericPropTypes = {};
   for (const feature of features) {
     if (feature.properties) {
       for (const key in feature.properties) {
         // If property has not been seen before, or if property has been numeric
         // in all previous features, check if numeric in this feature
-        // If not numeric, false is stored to prevent rechecking in the future
-        const numericSoFar = numericPropKeys[key];
-        if (numericSoFar || numericSoFar === undefined) {
-          const val = feature.properties[key];
-          numericPropKeys[key] = isNumeric(val);
-        }
+        // If not numeric, Array is stored to prevent rechecking in the future
+        // Additionally, detects if 64 bit precision is required
+        const val = feature.properties[key];
+        numericPropTypes[key] = deduceArrayType(val, numericPropTypes[key]);
       }
     }
   }
 
-  return Object.keys(numericPropKeys).filter((k) => numericPropKeys[k]);
+  return numericPropTypes;
 }
 
 /**
@@ -90,7 +95,7 @@ function fillArrays(
     polygonRingsCount,
     polygonFeaturesCount
   } = firstPassData;
-  const {numericPropKeys, PositionDataType = Float32Array} = options;
+  const {numericPropKeys, numericPropTypes, PositionDataType = Float32Array} = options;
   const hasGlobalId = features[0] && 'id' in features[0];
   const coordLength = 2;
   const GlobalFeatureIdsDataType = features.length > 65535 ? Uint32Array : Uint16Array;
@@ -146,7 +151,8 @@ function fillArrays(
     for (const propName of numericPropKeys) {
       // If property has been numeric in all previous features in which the property existed, check
       // if numeric in this feature
-      object.numericProps[propName] = new Float32Array(object.positions.length / coordLength);
+      const TypedArray = numericPropTypes[propName];
+      object.numericProps[propName] = new TypedArray(object.positions.length / coordLength);
     }
   }
 
@@ -513,6 +519,14 @@ function keepStringProperties(
   return props;
 }
 
-function isNumeric(x: unknown) {
-  return Number.isFinite(x);
+function deduceArrayType(
+  x: any,
+  constructor: MvtNumericArrayConstructor
+): MvtNumericArrayConstructor {
+  if (constructor === Array || !Number.isFinite(x)) {
+    return Array;
+  }
+
+  // If this or previous value required 64bits use Float64Array
+  return constructor === Float64Array || Math.fround(x) !== x ? Float64Array : Float32Array;
 }

--- a/modules/mvt/src/lib/binary-vector-tile/features-to-binary.ts
+++ b/modules/mvt/src/lib/binary-vector-tile/features-to-binary.ts
@@ -29,13 +29,11 @@ export function featuresToBinary(
   firstPassData: MvtFirstPassedData,
   options?: MvtBinaryOptions
 ) {
-  const propArrayConstructors = extractNumericPropTypes(features);
-  const numericPropKeys = Object.keys(propArrayConstructors).filter(
-    (k) => propArrayConstructors[k] !== Array
-  );
+  const propArrayTypes = extractNumericPropTypes(features);
+  const numericPropKeys = Object.keys(propArrayTypes).filter((k) => propArrayTypes[k] !== Array);
   return fillArrays(features, firstPassData, {
     numericPropKeys: options ? options.numericPropKeys : numericPropKeys,
-    propArrayConstructors,
+    propArrayTypes,
     PositionDataType: options ? options.PositionDataType : Float32Array
   });
 }
@@ -53,7 +51,7 @@ export const TEST_EXPORTS = {
 function extractNumericPropTypes(features: MvtBinaryCoordinates[]): {
   [key: string]: MvtPropArrayConstructor;
 } {
-  const propArrayConstructors = {};
+  const propArrayTypes = {};
   for (const feature of features) {
     if (feature.properties) {
       for (const key in feature.properties) {
@@ -62,12 +60,12 @@ function extractNumericPropTypes(features: MvtBinaryCoordinates[]): {
         // If not numeric, Array is stored to prevent rechecking in the future
         // Additionally, detects if 64 bit precision is required
         const val = feature.properties[key];
-        propArrayConstructors[key] = deduceArrayType(val, propArrayConstructors[key]);
+        propArrayTypes[key] = deduceArrayType(val, propArrayTypes[key]);
       }
     }
   }
 
-  return propArrayConstructors;
+  return propArrayTypes;
 }
 
 /**
@@ -95,7 +93,7 @@ function fillArrays(
     polygonRingsCount,
     polygonFeaturesCount
   } = firstPassData;
-  const {numericPropKeys, propArrayConstructors, PositionDataType = Float32Array} = options;
+  const {numericPropKeys, propArrayTypes, PositionDataType = Float32Array} = options;
   const hasGlobalId = features[0] && 'id' in features[0];
   const coordLength = 2;
   const GlobalFeatureIdsDataType = features.length > 65535 ? Uint32Array : Uint16Array;
@@ -151,7 +149,7 @@ function fillArrays(
     for (const propName of numericPropKeys) {
       // If property has been numeric in all previous features in which the property existed, check
       // if numeric in this feature
-      const TypedArray = propArrayConstructors[propName];
+      const TypedArray = propArrayTypes[propName];
       object.numericProps[propName] = new TypedArray(object.positions.length / coordLength);
     }
   }

--- a/modules/mvt/src/lib/types.ts
+++ b/modules/mvt/src/lib/types.ts
@@ -44,7 +44,7 @@ export type MvtPropArrayConstructor =
 
 export type MvtBinaryOptions = {
   numericPropKeys: string[];
-  propArrayConstructors: {[key: string]: MvtPropArrayConstructor};
+  propArrayTypes: {[key: string]: MvtPropArrayConstructor};
   PositionDataType: Float32ArrayConstructor;
 };
 

--- a/modules/mvt/src/lib/types.ts
+++ b/modules/mvt/src/lib/types.ts
@@ -37,8 +37,14 @@ export type MvtMapboxCoordinates = {
   id?: number;
 };
 
+export type MvtNumericArrayConstructor =
+  | Float32ArrayConstructor
+  | Float64ArrayConstructor
+  | ArrayConstructor;
+
 export type MvtBinaryOptions = {
   numericPropKeys: string[];
+  numericPropTypes: {[key: string]: MvtNumericArrayConstructor};
   PositionDataType: Float32ArrayConstructor;
 };
 

--- a/modules/mvt/src/lib/types.ts
+++ b/modules/mvt/src/lib/types.ts
@@ -37,14 +37,14 @@ export type MvtMapboxCoordinates = {
   id?: number;
 };
 
-export type MvtNumericArrayConstructor =
+export type MvtPropArrayConstructor =
   | Float32ArrayConstructor
   | Float64ArrayConstructor
   | ArrayConstructor;
 
 export type MvtBinaryOptions = {
   numericPropKeys: string[];
-  numericPropTypes: {[key: string]: MvtNumericArrayConstructor};
+  propArrayConstructors: {[key: string]: MvtPropArrayConstructor};
   PositionDataType: Float32ArrayConstructor;
 };
 


### PR DESCRIPTION
Fix for https://github.com/visgl/loaders.gl/issues/1951