### PR TITLE
fix(i3s-app, i3s-debug-app): set max zoom property for terrain layer

### DIFF
--- a/examples/website/i3s/app-debug.js
+++ b/examples/website/i3s/app-debug.js
@@ -324,6 +324,7 @@ export default class App extends PureComponent {
     // https://github.com/tilezen/joerd/blob/master/docs/use-service.md#additional-amazon-s3-endpoints
     const MAPZEN_TERRAIN_IMAGE = `https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png`
     const ARCGIS_STREET_MAP_SURFACE_IMAGE = 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}';
+    const MAX_ZOOM = 15;
 
     // https://github.com/tilezen/joerd/blob/master/docs/formats.md#terrarium
     const MAPZEN_ELEVATION_DECODER = {
@@ -336,8 +337,9 @@ export default class App extends PureComponent {
     return {
       elevationData: MAPZEN_TERRAIN_IMAGE,
       texture: ARCGIS_STREET_MAP_SURFACE_IMAGE,
-      elevationDecoder: MAPZEN_ELEVATION_DECODER
-    }
+      elevationDecoder: MAPZEN_ELEVATION_DECODER,
+      maxZoom: MAX_ZOOM
+    };
   }
 
   // Updates stats, called every frame
@@ -522,11 +524,12 @@ export default class App extends PureComponent {
   }
 
   _renderTerrainLayer() {
-    const {elevationDecoder, texture, elevationData} = this.getTerrainLayerData();
+    const {elevationDecoder, texture, elevationData, maxZoom} = this.getTerrainLayerData();
 
     return new TerrainLayer({
       id: 'terrain',
       elevationDecoder,
+      maxZoom,
       elevationData,
       texture,
       color: [255, 255, 255]

--- a/examples/website/i3s/app.js
+++ b/examples/website/i3s/app.js
@@ -131,6 +131,7 @@ export default class App extends PureComponent {
     // https://github.com/tilezen/joerd/blob/master/docs/use-service.md#additional-amazon-s3-endpoints
     const MAPZEN_TERRAIN_IMAGE = `https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png`
     const ARCGIS_STREET_MAP_SURFACE_IMAGE = 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}';
+    const MAX_ZOOM = 15;
 
     // https://github.com/tilezen/joerd/blob/master/docs/formats.md#terrarium
     const MAPZEN_ELEVATION_DECODER = {
@@ -143,8 +144,9 @@ export default class App extends PureComponent {
     return {
       elevationData: MAPZEN_TERRAIN_IMAGE,
       texture: ARCGIS_STREET_MAP_SURFACE_IMAGE,
-      elevationDecoder: MAPZEN_ELEVATION_DECODER
-    }
+      elevationDecoder: MAPZEN_ELEVATION_DECODER,
+      maxZoom: MAX_ZOOM
+    };
   }
 
   /**
@@ -227,10 +229,11 @@ export default class App extends PureComponent {
   }
 
   _renderTerrainLayer() {
-    const {elevationDecoder, texture, elevationData} = this.getTerrainLayerData();
+    const {elevationDecoder, texture, elevationData, maxZoom} = this.getTerrainLayerData();
 
     return new TerrainLayer({
       id: 'terrain',
+      maxZoom,
       elevationDecoder,
       elevationData,
       texture,


### PR DESCRIPTION
Terrain data source has only 15 levels available. It is described [here](https://github.com/tilezen/joerd/blob/master/docs/use-service.md#specify-z-x-and-y-tile-coordinates).