### PR TITLE
fix: load workers of latest version

### DIFF
--- a/modules/3d-tiles/package.json
+++ b/modules/3d-tiles/package.json
@@ -43,6 +43,6 @@
     "@math.gl/geospatial": "^3.5.1"
   },
   "peerDependencies": {
-    "@loaders.gl/core": "3.1.0-beta.1"
+    "@loaders.gl/core": "3.1.0"
   }
 }

--- a/modules/arrow/package.json
+++ b/modules/arrow/package.json
@@ -41,6 +41,6 @@
     "apache-arrow": "^4.0.0"
   },
   "peerDependencies": {
-    "@loaders.gl/core": "3.1.0-beta.1"
+    "@loaders.gl/core": "3.1.0"
   }
 }

--- a/modules/gltf/package.json
+++ b/modules/gltf/package.json
@@ -40,6 +40,6 @@
     "@loaders.gl/textures": "3.1.0"
   },
   "peerDependencies": {
-    "@loaders.gl/core": "3.1.0-beta.1"
+    "@loaders.gl/core": "3.1.0"
   }
 }

--- a/modules/i3s/package.json
+++ b/modules/i3s/package.json
@@ -45,6 +45,6 @@
     "probe.gl": "^3.4.0"
   },
   "peerDependencies": {
-    "@loaders.gl/core": "3.1.0-beta.1"
+    "@loaders.gl/core": "3.1.0"
   }
 }

--- a/modules/i3s/src/i3s-building-scene-layer-loader.ts
+++ b/modules/i3s/src/i3s-building-scene-layer-loader.ts
@@ -6,7 +6,7 @@ import {parseBuildingSceneLayer} from './lib/parsers/parse-i3s-building-scene-la
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
 
-const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'beta';
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 /**
  * Loader for I3S - Building Scene Layer
  */

--- a/modules/i3s/src/i3s-content-loader.ts
+++ b/modules/i3s/src/i3s-content-loader.ts
@@ -4,7 +4,7 @@ import {parseI3STileContent} from './lib/parsers/parse-i3s-tile-content';
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
 
-const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'beta';
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 /**
  * Loader for I3S - Indexed 3D Scene Layer
  */

--- a/modules/ply/package.json
+++ b/modules/ply/package.json
@@ -38,6 +38,6 @@
     "@loaders.gl/schema": "3.1.0"
   },
   "peerDependencies": {
-    "@loaders.gl/core": "3.1.0-beta.1"
+    "@loaders.gl/core": "3.1.0"
   }
 }

--- a/modules/polyfills/test/fetch-node/fetch.node.spec.js
+++ b/modules/polyfills/test/fetch-node/fetch.node.spec.js
@@ -9,7 +9,7 @@ const TEXT_URL = `@loaders.gl/polyfills/test/data/data.txt`;
 const TEXT_URL_GZIPPED = `@loaders.gl/polyfills/test/data/data.txt.gz`;
 // Request of this url returns location like "/@loaders.gl/textures@[VERSION]/dist/libs/basis_encoder.js"
 // So we get an error when trying to fetch such redirect url without protocol and origin.
-const TEXT_URL_WITH_REDIRECT = `https://unpkg.com/@loaders.gl/textures@beta/dist/libs/basis_encoder.js`;
+const TEXT_URL_WITH_REDIRECT = `https://unpkg.com/@loaders.gl/textures@latest/dist/libs/basis_encoder.js`;
 
 // This type of links on github works via 302 redirect
 // ("https://github.com/repository/raw/branch-name/path/to/file/file-name.extension")

--- a/modules/textures/src/lib/parsers/basis-module-loader.ts
+++ b/modules/textures/src/lib/parsers/basis-module-loader.ts
@@ -1,6 +1,6 @@
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
-const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'beta';
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
 // @ts-nocheck
 import {loadLibrary} from '@loaders.gl/worker-utils';

--- a/modules/textures/src/lib/utils/version.ts
+++ b/modules/textures/src/lib/utils/version.ts
@@ -1,5 +1,4 @@
 // Version constant cannot be imported, it needs to correspond to the build version of **this** module.
 // __VERSION__ is injected by babel-plugin-version-inline
-// TODO: use 'latest' instead of 'beta' when 3.0.0 version is released as 'latest'
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
-export const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'beta';
+export const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';

--- a/modules/tile-converter/package.json
+++ b/modules/tile-converter/package.json
@@ -69,6 +69,6 @@
     "uuid": "^8.1.0"
   },
   "peerDependencies": {
-    "@loaders.gl/core": "3.1.0-beta.1"
+    "@loaders.gl/core": "3.1.0"
   }
 }

--- a/modules/tiles/package.json
+++ b/modules/tiles/package.json
@@ -42,6 +42,6 @@
     "@probe.gl/stats": "^3.4.0"
   },
   "peerDependencies": {
-    "@loaders.gl/core": "3.1.0-beta.1"
+    "@loaders.gl/core": "3.1.0"
   }
 }

--- a/modules/worker-utils/src/lib/env-utils/version.ts
+++ b/modules/worker-utils/src/lib/env-utils/version.ts
@@ -2,7 +2,7 @@
 // __VERSION__ is injected by babel-plugin-version-inline
 
 // Change to `latest` on production branches
-const DEFAULT_VERSION = 'beta';
+const DEFAULT_VERSION = 'latest';
 declare let __VERSION__: string;
 export const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : DEFAULT_VERSION;
 if (typeof __VERSION__ === 'undefined') {

--- a/modules/worker-utils/src/lib/library-utils/library-utils.ts
+++ b/modules/worker-utils/src/lib/library-utils/library-utils.ts
@@ -5,7 +5,7 @@ import {assert} from '../env-utils/assert';
 import {VERSION as __VERSION__} from '../env-utils/version';
 
 // TODO - unpkg.com doesn't seem to have a `latest` specifier for alpha releases...
-const LATEST = 'beta';
+const LATEST = 'latest';
 const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : LATEST;
 
 const loadLibraryPromises: Record<string, Promise<any>> = {}; // promises

--- a/modules/worker-utils/src/lib/worker-api/get-worker-url.ts
+++ b/modules/worker-utils/src/lib/worker-api/get-worker-url.ts
@@ -2,7 +2,7 @@ import type {WorkerObject, WorkerOptions} from '../../types';
 import {assert} from '../env-utils/assert';
 import {VERSION as __VERSION__} from '../env-utils/version';
 
-const NPM_TAG = 'beta'; // Change to 'latest' on release-branch
+const NPM_TAG = 'latest'; // Change to 'latest' on release-branch
 const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : NPM_TAG;
 
 /**

--- a/modules/zip/package.json
+++ b/modules/zip/package.json
@@ -33,6 +33,6 @@
     "jszip": "^3.1.5"
   },
   "peerDependencies": {
-    "@loaders.gl/core": "3.1.0-beta.1"
+    "@loaders.gl/core": "3.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1888,26 +1888,6 @@
     npmlog "^4.1.2"
     write-file-atomic "^2.3.0"
 
-"@loaders.gl/core@^3.0":
-  version "3.0.11"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/core/-/core-3.0.11.tgz#ad8bf8b7da4e73957a9f68f97851926ed5d8ff36"
-  integrity sha512-yOoUPGDBr6r57ktUT2kzmINM4lFmuN+pP2DsbZ5uc7upq8BEp5EIX14X4Nrh4b9HDWLN424zby4xOsncSHofpQ==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
-    "@loaders.gl/loader-utils" "3.0.11"
-    "@loaders.gl/worker-utils" "3.0.11"
-    probe.gl "^3.4.0"
-
-"@loaders.gl/core@^3.0.6":
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/core/-/core-3.0.6.tgz#6d22d0618edf4bb3df53ea631a437d01fa270d5e"
-  integrity sha512-my1qpSguc6dcxAIxbCHNmi5QTVgBt7Z/PJ/6AWVqZPrq/OPucxN3apU39vnz18kZUgznTEDkjaS2uW22CLk9lw==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
-    "@loaders.gl/loader-utils" "3.0.6"
-    "@loaders.gl/worker-utils" "3.0.6"
-    probe.gl "^3.4.0"
-
 "@loaders.gl/gis@4.0.0-alpha.1":
   version "4.0.0-alpha.1"
   resolved "https://registry.yarnpkg.com/@loaders.gl/gis/-/gis-4.0.0-alpha.1.tgz#1080c76e0e8d8e5b5764bbf9d9d1e0dbda57539d"
@@ -1917,38 +1897,6 @@
     "@loaders.gl/schema" "4.0.0-alpha.1"
     "@mapbox/vector-tile" "^1.3.1"
     pbf "^3.2.1"
-
-"@loaders.gl/images@3.0.11", "@loaders.gl/images@^3.0":
-  version "3.0.11"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/images/-/images-3.0.11.tgz#5a7fe814da4995cd5df5bfec90b2815132eb6eca"
-  integrity sha512-uCRvZTtyWkAPAt0+b8bcGVy3s31nnlJAIxbe1c94yHPQbiQT2GD3NGuRwgIaLTXU9Y96zAw+WPUG9F74g34w2g==
-  dependencies:
-    "@loaders.gl/loader-utils" "3.0.11"
-
-"@loaders.gl/images@^3.0.6":
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/images/-/images-3.0.6.tgz#038fad37e0ee0c8319cbd440481f92576891c6d0"
-  integrity sha512-vRNayX5X4VNG+hVCE7u2nMwqpe0uu0YVOfxFduOs2XfS3Cqp7v9R7OBtYQbJ2B2yhVSk6Hz1LW1mzS4jJrmyrA==
-  dependencies:
-    "@loaders.gl/loader-utils" "3.0.6"
-
-"@loaders.gl/loader-utils@3.0.11":
-  version "3.0.11"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/loader-utils/-/loader-utils-3.0.11.tgz#99a3ad8dae57747a85f36825388da958cc508dc9"
-  integrity sha512-AdaEIfkOsUQZFPp6EbdZLxzXadiBESXvP8sMWwCZuPqQuBeq8YvwBHk58YtiKII8LRpbq75zT9CGdsB1ruCN5g==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
-    "@loaders.gl/worker-utils" "3.0.11"
-    "@probe.gl/stats" "^3.4.0"
-
-"@loaders.gl/loader-utils@3.0.6":
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/loader-utils/-/loader-utils-3.0.6.tgz#bef5d09a026c0855db0f509117a6e68ab5517150"
-  integrity sha512-0kbBz3kIrx7BBWmTwVEhLA081S/043NCdahgxqrzanpB2o7BDeNZ+HLPybfBWGhUwbgbm77OpvUT7ALbZLFx4w==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
-    "@loaders.gl/worker-utils" "3.0.6"
-    "@probe.gl/stats" "^3.4.0"
 
 "@loaders.gl/loader-utils@4.0.0-alpha.1":
   version "4.0.0-alpha.1"
@@ -1966,31 +1914,6 @@
   dependencies:
     "@types/geojson" "^7946.0.7"
     apache-arrow "^4.0.0"
-
-"@loaders.gl/textures@^3.0":
-  version "3.0.11"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/textures/-/textures-3.0.11.tgz#132d9ee0ded3460f04d016ec869e41f103a86456"
-  integrity sha512-KXMB949YTrFz/LHHhs0pezhp0Er85uQJ+JIZuXPcar8OdOBNwMUXEhSDlyQkLjEkRmn7y0lhApvodM4Wxnt79w==
-  dependencies:
-    "@loaders.gl/images" "3.0.11"
-    "@loaders.gl/loader-utils" "3.0.11"
-    "@loaders.gl/worker-utils" "3.0.11"
-    ktx-parse "^0.0.4"
-    texture-compressor "^1.0.2"
-
-"@loaders.gl/worker-utils@3.0.11":
-  version "3.0.11"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/worker-utils/-/worker-utils-3.0.11.tgz#6418032e0a0a89d6988ab8a822eaa2e6f8ea56c5"
-  integrity sha512-zJZtc+EQUKDRL+Xz7uMWfFLARn9gAgG38GZXdPJAGOKD+H7QQ9f72csPqb6/cxrjDyF7ryv02tMF3Ry/40a8fw==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
-
-"@loaders.gl/worker-utils@3.0.6":
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/worker-utils/-/worker-utils-3.0.6.tgz#c7fdeae5c74c6fd83daf76bdeaf34d4b9e9f72a0"
-  integrity sha512-fEWXC/ImKqfwhAQW/EGN+UAk/FkH8nEZ8BoWRmkfNwUZ1ZeQHTItpVgZp9F0WYdN7Pz1j2KIqTa27W10afnhmQ==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
 
 "@loaders.gl/worker-utils@4.0.0-alpha.1":
   version "4.0.0-alpha.1"


### PR DESCRIPTION
- replace `beta` with `latest`;
- fix peer-dependency version: `"@loaders.gl/core": "3.1.0"`;
- yarn.lock