### PR TITLE
chore(examples): Update get-started-rollup example dependencies.

### DIFF
--- a/examples/get-started/get-started-rollup/package.json
+++ b/examples/get-started/get-started-rollup/package.json
@@ -15,9 +15,9 @@
     "@loaders.gl/obj": "^3.1.0"
   },
   "devDependencies": {
-    "rollup": "^1.16.2",
+    "rollup": "^2.61.0",
     "rollup-plugin-commonjs": "^10.0.0",
     "rollup-plugin-node-resolve": "^5.1.0",
-    "serve": "^11.0.2"
+    "serve": "^13.0.2"
   }
 }

--- a/examples/get-started/get-started-rollup/package.json
+++ b/examples/get-started/get-started-rollup/package.json
@@ -11,8 +11,8 @@
     "serve": "serve public"
   },
   "dependencies": {
-    "@loaders.gl/core": "2.2.0",
-    "@loaders.gl/obj": "2.2.0"
+    "@loaders.gl/core": "^3.1.0",
+    "@loaders.gl/obj": "^3.1.0"
   },
   "devDependencies": {
     "rollup": "^1.16.2",

--- a/examples/get-started/get-started-rollup/package.json
+++ b/examples/get-started/get-started-rollup/package.json
@@ -15,9 +15,9 @@
     "@loaders.gl/obj": "^3.1.0"
   },
   "devDependencies": {
+    "@rollup/plugin-commonjs": "^21.0.1",
+    "@rollup/plugin-node-resolve": "^13.0.6",
     "rollup": "^2.61.0",
-    "rollup-plugin-commonjs": "^10.0.0",
-    "rollup-plugin-node-resolve": "^5.1.0",
     "serve": "^13.0.2"
   }
 }

--- a/examples/get-started/get-started-rollup/rollup.config.js
+++ b/examples/get-started/get-started-rollup/rollup.config.js
@@ -1,5 +1,5 @@
-import resolve from 'rollup-plugin-node-resolve';
-import commonjs from 'rollup-plugin-commonjs';
+import resolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
 
 export default {
   input: 'app.js',


### PR DESCRIPTION
For #2000 

- Latest loaders.gl libraries
- Latest rollup