### PR TITLE
Added __VERSION__ definitions to build-worker scripts 

### DIFF
--- a/modules/arrow/package.json
+++ b/modules/arrow/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "pre-build": "npm run build-worker && npm run build-bundle",
     "build-bundle": "esbuild src/bundle.ts --bundle --outfile=dist/dist.min.js",
-    "build-worker": "esbuild src/workers/arrow-worker.ts --bundle --outfile=dist/arrow-worker.js"
+    "build-worker": "esbuild src/workers/arrow-worker.ts --bundle --outfile=dist/arrow-worker.js --define:__VERSION__=\\\"$npm_package_version\\\""
   },
   "dependencies": {
     "@loaders.gl/loader-utils": "4.0.0-alpha.4",

--- a/modules/compression/package.json
+++ b/modules/compression/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "pre-build": "npm run build-bundle && npm run build-worker",
     "build-bundle": "esbuild src/bundle.ts --outfile=dist/dist.min.js --bundle --minify --sourcemap --external:{fs,path,crypto}",
-    "build-worker": "esbuild src/workers/worker.ts --outfile=dist/compression-worker.js --bundle --minify --sourcemap --external:{fs,path,crypto}"
+    "build-worker": "esbuild src/workers/worker.ts --outfile=dist/compression-worker.js --bundle --minify --sourcemap --external:{fs,path,crypto} --define:__VERSION__=\\\"$npm_package_version\\\""
   },
   "dependencies": {
     "@babel/runtime": "^7.3.1",

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "pre-build": "npm run build-bundle && npm run build-worker",
     "build-bundle": "esbuild src/bundle.ts --bundle --outfile=dist/dist.min.js",
-    "build-worker": "esbuild src/workers/null-worker.ts --bundle --outfile=dist/null-worker.js"
+    "build-worker": "esbuild src/workers/null-worker.ts --bundle --outfile=dist/null-worker.js --define:__VERSION__=\\\"$npm_package_version\\\""
   },
   "dependencies": {
     "@babel/runtime": "^7.3.1",

--- a/modules/crypto/package.json
+++ b/modules/crypto/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "pre-build": "npm run build-worker && npm run build-bundle",
     "build-bundle": "esbuild src/bundle.ts --outfile=dist/dist.min.js --bundle --minify --sourcemap",
-    "build-worker": "esbuild src/workers/worker.ts --outfile=dist/worker.js --bundle --minify --sourcemap"
+    "build-worker": "esbuild src/workers/worker.ts --outfile=dist/worker.js --bundle --minify --sourcemap --define:__VERSION__=\\\"$npm_package_version\\\""
   },
   "dependencies": {
     "@babel/runtime": "^7.3.1",

--- a/modules/draco/package.json
+++ b/modules/draco/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "pre-build": "npm run build-bundle && npm run build-worker",
     "build-bundle": "esbuild src/bundle.ts --outfile=dist/dist.min.js --bundle --minify --sourcemap",
-    "build-worker": "esbuild src/workers/draco-worker.ts --outfile=dist/draco-worker.js --bundle --minify --sourcemap"
+    "build-worker": "esbuild src/workers/draco-worker.ts --outfile=dist/draco-worker.js --bundle --minify --sourcemap --define:__VERSION__=\\\"$npm_package_version\\\""
   },
   "dependencies": {
     "@babel/runtime": "^7.3.1",

--- a/modules/excel/package.json
+++ b/modules/excel/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "pre-build": "npm run build-bundle && npm run build-worker",
     "build-bundle": "esbuild src/bundle.ts --bundle --outfile=dist/dist.min.js",
-    "build-worker": "esbuild src/workers/excel-worker.ts --bundle --outfile=dist/excel-worker.js"
+    "build-worker": "esbuild src/workers/excel-worker.ts --bundle --outfile=dist/excel-worker.js --define:__VERSION__=\\\"$npm_package_version\\\""
   },
   "dependencies": {
     "@loaders.gl/loader-utils": "4.0.0-alpha.4",

--- a/modules/flatgeobuf/package.json
+++ b/modules/flatgeobuf/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "pre-build": "npm run build-worker && npm run build-worker --env.dev && npm run build-bundle",
     "build-bundle": "esbuild src/bundle.ts --bundle --outfile=dist/dist.min.js",
-    "build-worker": "esbuild src/workers/flatgeobuf-worker.ts --bundle --outfile=dist/flatgeobuf-worker.js"
+    "build-worker": "esbuild src/workers/flatgeobuf-worker.ts --bundle --outfile=dist/flatgeobuf-worker.js --define:__VERSION__=\\\"$npm_package_version\\\""
   },
   "dependencies": {
     "@loaders.gl/loader-utils": "4.0.0-alpha.4",

--- a/modules/i3s/package.json
+++ b/modules/i3s/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "pre-build": "npm run build-bundle && npm run build-worker",
     "build-bundle": "esbuild src/bundle.ts --bundle --outfile=dist/dist.min.js",
-    "build-worker": "esbuild src/workers/i3s-content-worker.ts --bundle --outfile=dist/i3s-content-worker.js"
+    "build-worker": "esbuild src/workers/i3s-content-worker.ts --bundle --outfile=dist/i3s-content-worker.js --define:__VERSION__=\\\"$npm_package_version\\\""
   },
   "dependencies": {
     "@loaders.gl/draco": "4.0.0-alpha.4",

--- a/modules/json/package.json
+++ b/modules/json/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "pre-build": "npm run build-bundle && npm run build-worker",
     "build-bundle": "esbuild src/bundle.ts --bundle --outfile=dist/dist.min.js",
-    "build-worker": "esbuild src/workers/geojson-worker.ts --bundle --outfile=dist/geojson-worker.js"
+    "build-worker": "esbuild src/workers/geojson-worker.ts --bundle --outfile=dist/geojson-worker.js --define:__VERSION__=\\\"$npm_package_version\\\""
   },
   "dependencies": {
     "@loaders.gl/gis": "4.0.0-alpha.4",

--- a/modules/las/package.json
+++ b/modules/las/package.json
@@ -37,7 +37,7 @@
   "scripts": {
     "pre-build": "npm run build-bundle && npm run build-worker",
     "build-bundle": "esbuild src/bundle.ts --bundle --outfile=dist/dist.min.js",
-    "build-worker": "esbuild src/workers/las-worker.ts --bundle --outfile=dist/las-worker.js"
+    "build-worker": "esbuild src/workers/las-worker.ts --bundle --outfile=dist/las-worker.js --define:__VERSION__=\\\"$npm_package_version\\\""
   },
   "dependencies": {
     "@babel/runtime": "^7.3.1",

--- a/modules/mvt/package.json
+++ b/modules/mvt/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "pre-build": "npm run build-worker && npm run build-worker --env.dev && npm run build-bundle",
     "build-bundle": "esbuild src/bundle.ts --bundle --outfile=dist/dist.min.js",
-    "build-worker": "esbuild src/workers/mvt-worker.ts --bundle --outfile=dist/mvt-worker.js"
+    "build-worker": "esbuild src/workers/mvt-worker.ts --bundle --outfile=dist/mvt-worker.js --define:__VERSION__=\\\"$npm_package_version\\\""
   },
   "dependencies": {
     "@loaders.gl/gis": "4.0.0-alpha.4",

--- a/modules/obj/package.json
+++ b/modules/obj/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "pre-build": "npm run build-worker && npm run build-bundle",
     "build-bundle": "esbuild src/bundle.ts --bundle --outfile=dist/dist.min.js",
-    "build-worker": "esbuild src/workers/obj-worker.ts --bundle --outfile=dist/obj-worker.js"
+    "build-worker": "esbuild src/workers/obj-worker.ts --bundle --outfile=dist/obj-worker.js --define:__VERSION__=\\\"$npm_package_version\\\""
   },
   "dependencies": {
     "@babel/runtime": "^7.3.1",

--- a/modules/parquet/package.json
+++ b/modules/parquet/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "pre-build": "npm run build-worker && npm run build-bundle",
     "build-bundle": "esbuild src/bundle.ts --outfile=dist/dist.min.js --bundle --minify --sourcemap --external:{util,fs,path,crypto}",
-    "build-worker": "esbuild src/workers/parquet-worker.ts --outfile=dist/parquet-worker.js --bundle --minify --sourcemap --external:{util,fs,path,crypto}"
+    "build-worker": "esbuild src/workers/parquet-worker.ts --outfile=dist/parquet-worker.js --bundle --minify --sourcemap --external:{util,fs,path,crypto} --define:__VERSION__=\\\"$npm_package_version\\\""
   },
   "browser": {
     "child_process": false,

--- a/modules/pcd/package.json
+++ b/modules/pcd/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "pre-build": "npm run build-worker && npm run build-bundle",
     "build-bundle": "esbuild src/bundle.ts --bundle --outfile=dist/dist.min.js",
-    "build-worker": "esbuild src/workers/pcd-worker.ts --bundle --outfile=dist/pcd-worker.js"
+    "build-worker": "esbuild src/workers/pcd-worker.ts --bundle --outfile=dist/pcd-worker.js --define:__VERSION__=\\\"$npm_package_version\\\""
   },
   "dependencies": {
     "@loaders.gl/loader-utils": "4.0.0-alpha.4",

--- a/modules/ply/package.json
+++ b/modules/ply/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "pre-build": "npm run build-worker && npm run build-bundle",
     "build-bundle": "esbuild src/bundle.ts --bundle --outfile=dist/dist.min.js",
-    "build-worker": "esbuild src/workers/ply-worker.ts --bundle --outfile=dist/ply-worker.js"
+    "build-worker": "esbuild src/workers/ply-worker.ts --bundle --outfile=dist/ply-worker.js --define:__VERSION__=\\\"$npm_package_version\\\""
   },
   "dependencies": {
     "@babel/runtime": "^7.3.1",

--- a/modules/shapefile/package.json
+++ b/modules/shapefile/package.json
@@ -33,8 +33,8 @@
   "scripts": {
     "pre-build": "npm run build-worker-shp && npm run build-worker-dbf && npm run build-bundle",
     "build-bundle": "esbuild src/bundle.ts --bundle --outfile=dist/dist.min.js",
-    "build-worker-shp": "esbuild src/workers/shp-worker.ts --bundle --outfile=dist/shp-worker.js",
-    "build-worker-dbf": "esbuild src/workers/dbf-worker.ts --bundle --outfile=dist/dbf-worker.js"
+    "build-worker-shp": "esbuild src/workers/shp-worker.ts --bundle --outfile=dist/shp-worker.js --define:__VERSION__=\\\"$npm_package_version\\\"",
+    "build-worker-dbf": "esbuild src/workers/dbf-worker.ts --bundle --outfile=dist/dbf-worker.js --define:__VERSION__=\\\"$npm_package_version\\\""
   },
   "dependencies": {
     "@loaders.gl/gis": "4.0.0-alpha.4",

--- a/modules/terrain/package.json
+++ b/modules/terrain/package.json
@@ -30,8 +30,8 @@
   "scripts": {
     "pre-build": "npm run build-worker && npm run build-worker2 && npm run build-bundle",
     "build-bundle": "esbuild src/bundle.ts --bundle --outfile=dist/dist.min.js",
-    "build-worker": "esbuild src/workers/terrain-worker.js --bundle --outfile=dist/terrain-worker.js",
-    "build-worker2": "esbuild src/workers/quantized-mesh-worker.js --bundle --outfile=dist/quantized-mesh-worker.js"
+    "build-worker": "esbuild src/workers/terrain-worker.js --bundle --outfile=dist/terrain-worker.js --define:__VERSION__=\\\"$npm_package_version\\\"",
+    "build-worker2": "esbuild src/workers/quantized-mesh-worker.js --bundle --outfile=dist/quantized-mesh-worker.js --define:__VERSION__=\\\"$npm_package_version\\\""
   },
   "dependencies": {
     "@babel/runtime": "^7.3.1",

--- a/modules/textures/package.json
+++ b/modules/textures/package.json
@@ -36,10 +36,10 @@
     "copy-libs": "cp -rf ./src/libs ./dist/libs",
     "build-bundle": "esbuild src/bundle.ts --bundle --outfile=dist/dist.min.js",
     "build-worker": "npm run build-basis-worker && npm run build-npy-worker && npm run build-compressed-texture-worker && npm run build-crunch-worker",
-    "build-basis-worker": "esbuild src/workers/basis-worker.ts --bundle --outfile=dist/basis-worker.js",
-    "build-npy-worker": "esbuild src/workers/npy-worker.ts --bundle --outfile=dist/npy-worker.js",
-    "build-compressed-texture-worker": "esbuild src/workers/compressed-texture-worker.ts --bundle --outfile=dist/compressed-texture-worker.js",
-    "build-crunch-worker": "esbuild src/workers/crunch-worker.ts --bundle --outfile=dist/crunch-worker.js"
+    "build-basis-worker": "esbuild src/workers/basis-worker.ts --bundle --outfile=dist/basis-worker.js --define:__VERSION__=\\\"$npm_package_version\\\"",
+    "build-npy-worker": "esbuild src/workers/npy-worker.ts --bundle --outfile=dist/npy-worker.js --define:__VERSION__=\\\"$npm_package_version\\\"",
+    "build-compressed-texture-worker": "esbuild src/workers/compressed-texture-worker.ts --bundle --outfile=dist/compressed-texture-worker.js --define:__VERSION__=\\\"$npm_package_version\\\"",
+    "build-crunch-worker": "esbuild src/workers/crunch-worker.ts --bundle --outfile=dist/crunch-worker.js --define:__VERSION__=\\\"$npm_package_version\\\""
   },
   "dependencies": {
     "@loaders.gl/images": "4.0.0-alpha.4",

--- a/modules/wkt/package.json
+++ b/modules/wkt/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "pre-build": "npm run build-worker && npm run build-bundle",
     "build-bundle": "esbuild src/bundle.ts --bundle --outfile=dist/dist.min.js",
-    "build-worker": "esbuild src/workers/wkt-worker.ts --bundle --outfile=dist/wkt-worker.js"
+    "build-worker": "esbuild src/workers/wkt-worker.ts --bundle --outfile=dist/wkt-worker.js --define:__VERSION__=\\\"$npm_package_version\\\""
   },
   "devDependencies": {
     "fuzzer": "^0.2.1"

--- a/modules/worker-utils/package.json
+++ b/modules/worker-utils/package.json
@@ -40,7 +40,7 @@
     "pre-build": "npm run build-workers",
     "pre-build-disabled": "npm run build-bundle && npm run build-workers",
     "build-bundle": "esbuild src/bundle.ts --outfile=dist/dist.min.js",
-    "build-workers": "esbuild src/workers/null-worker.ts --outfile=dist/null-worker.js --bundle --sourcemap"
+    "build-workers": "esbuild src/workers/null-worker.ts --outfile=dist/null-worker.js --bundle --sourcemap --define:__VERSION__=\\\"$npm_package_version\\\""
   },
   "dependencies": {
     "@babel/runtime": "^7.3.1"


### PR DESCRIPTION
For issue #2014, I ran the following script in the `modules` folder:

```
grep "\"build-worker\": \"esbuild" * -Rl | xargs sed -i -r 's/(\"build-worker\".*)\"$/\1 --define:__VERSION__=\\\\\\\"\$npm_package_version\\\\\\\""/g'
```
Then I noticed it still missed a few scripts that were named differently so I fixed those manually.

Note that there are two issues with this:

1.  Does not work on Windows traditional cmd.  I tested this on a traditional Windows cmd and it didn't work. It requires using `%npm_package_version%`. It can be fixed for example using [cross-var](https://github.com/elijahmanor/cross-var), but I noticed that also `yarn bootstrap` and `build` failed with various errors, so I figure this is not really maintained on Windows?

2. As @ibgreen noted: 
```
I suspect this might still have a problem in that lerna builds the library before bumping the version. 
But it should work as it did before. Being one patch version off is mostly not a problem.
```
This might be something to take care of in a separate issue, to have the workers build only after the version is set?

Alternatives for this method would be the use of a node script to build using esbuild, or [esbuild-config](https://github.com/bpierre/esbuild-config)

Other than those issues, this provides a quick solution for the console error that appears when using workers that are built using esbuild.