### PR TITLE
fix(tile-converter,i3s-app): default value of pbr + app picking

### DIFF
--- a/modules/i3s/src/i3s-attribute-loader.ts
+++ b/modules/i3s/src/i3s-attribute-loader.ts
@@ -39,7 +39,7 @@ async function parse(data, options) {
 export async function loadFeatureAttributes(tile, featureId, options = {}) {
   const {attributeStorageInfo, attributeUrls, tilesetFields} = getAttributesData(tile);
 
-  if (!attributeStorageInfo || !attributeUrls || !featureId) {
+  if (!attributeStorageInfo || !attributeUrls || featureId < 0) {
     return null;
   }
 

--- a/modules/tile-converter/src/i3s-converter/helpers/geometry-converter.js
+++ b/modules/tile-converter/src/i3s-converter/helpers/geometry-converter.js
@@ -662,7 +662,7 @@ function convertGLTFMaterialToI3sSharedResources(gltfMaterial, nodeId) {
  * @param {number} metallicFactor - "metallicFactor" attribute of gltf material object
  * @returns {Object}
  */
-function extractSharedResourcesMaterialInfo(baseColorFactor, metallicFactor = 0) {
+function extractSharedResourcesMaterialInfo(baseColorFactor, metallicFactor = 1) {
   const matDielectricColorComponent = 0.04 / 255; // Color from rgb (255) to 0..1 resolution
   // All color resolutions are 0..1
   const black = new Vector4(0, 0, 0, 1);

--- a/modules/tile-converter/src/i3s-converter/helpers/geometry-converter.js
+++ b/modules/tile-converter/src/i3s-converter/helpers/geometry-converter.js
@@ -8,6 +8,10 @@ import md5 from 'md5';
 import {generateAttributes} from './geometry-attributes';
 import {createBoundingVolumesFromGeometry} from './coordinate-converter';
 
+// Spec - https://github.com/Esri/i3s-spec/blob/master/docs/1.7/pbrMetallicRoughness.cmn.md
+const DEFAULT_ROUGHNESS_FACTOR = 1;
+const DEFAULT_METALLIC_FACTOR = 1;
+
 const VALUES_PER_VERTEX = 3;
 const VALUES_PER_TEX_COORD = 2;
 const VALUES_PER_COLOR_ELEMENT = 4;
@@ -549,13 +553,15 @@ function convertMaterial(sourceMaterial) {
     // But it is in lower case in I3S: https://github.com/Esri/i3s-spec/blob/master/docs/1.7/materialDefinitions.cmn.md
     alphaMode: (sourceMaterial.alphaMode || 'OPAQUE').toLowerCase(),
     pbrMetallicRoughness: {
-      roughnessFactor: sourceMaterial.pbrMetallicRoughness.roughnessFactor,
-      metallicFactor: sourceMaterial.pbrMetallicRoughness.metallicFactor
+      roughnessFactor:
+        sourceMaterial?.pbrMetallicRoughness?.roughnessFactor || DEFAULT_ROUGHNESS_FACTOR,
+      metallicFactor:
+        sourceMaterial?.pbrMetallicRoughness?.metallicFactor || DEFAULT_METALLIC_FACTOR
     }
   };
 
   let texture;
-  if (sourceMaterial.pbrMetallicRoughness.baseColorTexture) {
+  if (sourceMaterial?.pbrMetallicRoughness?.baseColorTexture) {
     texture = sourceMaterial.pbrMetallicRoughness.baseColorTexture.texture.source;
     material.pbrMetallicRoughness.baseColorTexture = {
       textureSetDefinitionId: 0
@@ -571,7 +577,7 @@ function convertMaterial(sourceMaterial) {
   if (!texture) {
     // Should use default baseColorFactor if it is not present in source material
     // https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#reference-pbrmetallicroughness
-    const baseColorFactor = sourceMaterial.pbrMetallicRoughness.baseColorFactor;
+    const baseColorFactor = sourceMaterial?.pbrMetallicRoughness?.baseColorFactor;
     material.pbrMetallicRoughness.baseColorFactor =
       (baseColorFactor && baseColorFactor.map((c) => Math.round(c * 255))) || undefined;
   }
@@ -622,12 +628,12 @@ function getSharedResources(tileContent, nodeId) {
  */
 function convertGLTFMaterialToI3sSharedResources(gltfMaterial, nodeId) {
   const texture =
-    gltfMaterial.pbrMetallicRoughness.baseColorTexture || gltfMaterial.emissiveTexture;
+    gltfMaterial?.pbrMetallicRoughness?.baseColorTexture || gltfMaterial.emissiveTexture;
   let textureDefinitionInfo = null;
   if (texture) {
     textureDefinitionInfo = extractSharedResourcesTextureInfo(texture.texture, nodeId);
   }
-  const {baseColorFactor, metallicFactor} = gltfMaterial.pbrMetallicRoughness;
+  const {baseColorFactor, metallicFactor} = gltfMaterial?.pbrMetallicRoughness || {};
   let colorFactor = baseColorFactor;
   // If alpha channel is 0 try to get emissive factor from gltf material.
   if ((!baseColorFactor || baseColorFactor[3] === 0) && gltfMaterial.emissiveFactor) {

--- a/modules/tile-converter/test/i3s-converter/i3s-converter.spec.js
+++ b/modules/tile-converter/test/i3s-converter/i3s-converter.spec.js
@@ -17,7 +17,7 @@ const TEST_TEXTURE_MATERIAL = {
   alphaMode: 'opaque',
   pbrMetallicRoughness: {
     roughnessFactor: 1,
-    metallicFactor: 0,
+    metallicFactor: 1,
     baseColorTexture: {
       textureSetDefinitionId: 0
     }


### PR DESCRIPTION
1. Added default values for `roughnessFactor` and `metallicFactor` based on [spec](https://github.com/Esri/i3s-spec/blob/master/docs/1.7/pbrMetallicRoughness.cmn.md)
2. Fix for loading `picking attributes `in` I3S-App `
