### PR TITLE
fix(parse-i3s-tile-content): I3S conversion issue without draco

### DIFF
--- a/modules/tile-converter/src/i3s-converter/i3s-converter.ts
+++ b/modules/tile-converter/src/i3s-converter/i3s-converter.ts
@@ -229,7 +229,7 @@ export default class I3SConverter {
 
     this.layers0!.materialDefinitions = this.materialDefinitions;
 
-    if (!this.layersHasTexture) {
+    if (this.layersHasTexture === false) {
       this.layers0!.store.defaultGeometrySchema.ordering =
         this.layers0!.store.defaultGeometrySchema.ordering.filter(
           (attribute) => attribute !== 'uv0'
@@ -566,7 +566,7 @@ export default class I3SConverter {
     };
 
     for (const resources of resourcesData || [emptyResources]) {
-      this.layersHasTexture = this.layersHasTexture || !!resources.texture;
+      this.layersHasTexture = this.layersHasTexture || Boolean(resources.texture);
 
       if (this.generateBoundingVolumes && resources.boundingVolumes) {
         boundingVolumes = resources.boundingVolumes;

--- a/modules/tile-converter/src/i3s-converter/i3s-converter.ts
+++ b/modules/tile-converter/src/i3s-converter/i3s-converter.ts
@@ -566,9 +566,7 @@ export default class I3SConverter {
     };
 
     for (const resources of resourcesData || [emptyResources]) {
-      if (!this.layersHasTexture && resources.texture) {
-        this.layersHasTexture = true;
-      }
+      this.layersHasTexture = this.layersHasTexture || !!resources.texture;
 
       if (this.generateBoundingVolumes && resources.boundingVolumes) {
         boundingVolumes = resources.boundingVolumes;

--- a/modules/tile-converter/src/i3s-converter/i3s-converter.ts
+++ b/modules/tile-converter/src/i3s-converter/i3s-converter.ts
@@ -96,6 +96,7 @@ export default class I3SConverter {
   Loader: LoaderWithParser = Tiles3DLoader;
   generateTextures: boolean;
   generateBoundingVolumes: boolean;
+  layersHasTexture: boolean;
 
   constructor() {
     this.nodePages = new NodePages(writeFile, HARDCODED_NODES_PER_PAGE);
@@ -114,6 +115,7 @@ export default class I3SConverter {
     this.validate = false;
     this.generateTextures = false;
     this.generateBoundingVolumes = false;
+    this.layersHasTexture = false;
   }
 
   /**
@@ -226,6 +228,14 @@ export default class I3SConverter {
     await this._convertNodesTree(root0, sourceRootTile, parentId, boundingVolumes);
 
     this.layers0!.materialDefinitions = this.materialDefinitions;
+
+    if (!this.layersHasTexture) {
+      this.layers0!.store.defaultGeometrySchema.ordering =
+        this.layers0!.store.defaultGeometrySchema.ordering.filter(
+          (attribute) => attribute !== 'uv0'
+        );
+    }
+
     await this._writeLayers0();
     createSceneServerPath(tilesetName, this.layers0!, tilesetPath);
     await this._writeNodeIndexDocument(root0, 'root', join(this.layers0Path, 'nodes', 'root'));
@@ -556,6 +566,10 @@ export default class I3SConverter {
     };
 
     for (const resources of resourcesData || [emptyResources]) {
+      if (!this.layersHasTexture && resources.texture) {
+        this.layersHasTexture = true;
+      }
+
       if (this.generateBoundingVolumes && resources.boundingVolumes) {
         boundingVolumes = resources.boundingVolumes;
       }


### PR DESCRIPTION
An error occurred when a scene with materials without textures was parsed. When trying to get a uv0 buffer, we went beyond the buffer boundary. Parsing 'Geometry buffer' depends on 'ordering'. In one scene some materials may have texture while others may not. Because of this, we cannot guarantee to remove the error by affecting only the 'ordering', removing the uv0 from it. Therefore, we will simply skip the step with getting uv0 if getting it goes beyond the boundaries of the buffer.

spec: https://github.com/Esri/i3s-spec/blob/master/docs/1.8/defaultGeometrySchema.cmn.md 