### PR TITLE
return dbfHeader from shapefile parser

### DIFF
--- a/modules/shapefile/src/lib/parsers/parse-dbf.ts
+++ b/modules/shapefile/src/lib/parsers/parse-dbf.ts
@@ -8,7 +8,7 @@ interface DBFTableOutput {
   rows: DBFRowsOutput;
 }
 
-type DBFHeader = {
+export type DBFHeader = {
   // Last updated date
   year: number;
   month: number;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4137,9 +4137,9 @@ camelize@^1.0.0:
   integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 caniuse-lite@^1.0.30001219:
-  version "1.0.30001303"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001303.tgz"
-  integrity sha512-/Mqc1oESndUNszJP0kx0UaQU9kEv9nNtJ7Kn8AdA0mNnH8eR1cj0kG+NbNuC1Wq/b21eA8prhKRA3bbkjONegQ==
+  version "1.0.30001302"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001302.tgz"
+  integrity sha512-YYTMO+tfwvgUN+1ZnRViE53Ma1S/oETg+J2lISsqi/ZTNThj3ZYBOKP2rHwJc37oCsPqAzJ3w2puZHn0xlLPPw==
 
 caseless@~0.12.0:
   version "0.12.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4137,9 +4137,9 @@ camelize@^1.0.0:
   integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 caniuse-lite@^1.0.30001219:
-  version "1.0.30001302"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001302.tgz"
-  integrity sha512-YYTMO+tfwvgUN+1ZnRViE53Ma1S/oETg+J2lISsqi/ZTNThj3ZYBOKP2rHwJc37oCsPqAzJ3w2puZHn0xlLPPw==
+  version "1.0.30001303"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001303.tgz"
+  integrity sha512-/Mqc1oESndUNszJP0kx0UaQU9kEv9nNtJ7Kn8AdA0mNnH8eR1cj0kG+NbNuC1Wq/b21eA8prhKRA3bbkjONegQ==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
This PR updates shapefile parser to return dbfHeader. For my usecase, it is useful to return dbfHeader from parseShapefileInBatches so that dbfHeader.nRecords is available. I am using dbfHeader.nRecords to track stream processing progress and want to avoid having to read header of dbf file in a separate call.