### PR TITLE
Add progress to `parseShapefileInBatches`.

### DIFF
--- a/modules/shapefile/src/lib/parsers/parse-dbf.ts
+++ b/modules/shapefile/src/lib/parsers/parse-dbf.ts
@@ -5,7 +5,7 @@ type DBFRowsOutput = object[];
 
 interface DBFTableOutput {
   schema?: Schema;
-  rows: DBFRowsOutput;
+  data: DBFRowsOutput;
 }
 
 type DBFHeader = {
@@ -111,7 +111,7 @@ export function parseDBF(
   switch (options.tables && options.tables.format) {
     case 'table':
       // TODO - parse columns
-      return {schema, rows: data};
+      return {schema, data};
 
     case 'rows':
     default:
@@ -139,13 +139,17 @@ export async function* parseDBFInBatches(
     }
 
     if (parser.result.data.length > 0) {
-      yield parser.result.data;
+      yield {
+        data: parser.result.data
+      };
       parser.result.data = [];
     }
   }
   parser.end();
   if (parser.result.data.length > 0) {
-    yield parser.result.data;
+    yield {
+      data: parser.result.data
+    };
   }
 }
 /**

--- a/modules/shapefile/src/lib/parsers/parse-shapefile.ts
+++ b/modules/shapefile/src/lib/parsers/parse-shapefile.ts
@@ -17,6 +17,8 @@ interface ShapefileOutput {
   shx?: SHXOutput;
   header: SHPHeader;
   data: object[];
+  bytesUsed?: number;
+  bytesTotal?: number;
 }
 /**
  * Parsing of file in batches
@@ -77,10 +79,11 @@ export async function* parseShapefileInBatches(
   for await (const item of iterator) {
     let geometries: any;
     let properties: any;
+    const {bytesUsed, bytesTotal} = item.progress;
     if (!propertyIterable) {
-      geometries = item;
+      geometries = item.data;
     } else {
-      [geometries, properties] = item;
+      [geometries, properties] = item.data;
     }
 
     const geojsonGeometries = parseGeometries(geometries);
@@ -94,7 +97,9 @@ export async function* parseShapefileInBatches(
       prj,
       shx,
       header: shapeHeader,
-      data: features
+      data: features,
+      bytesUsed,
+      bytesTotal
     };
   }
 }


### PR DESCRIPTION
Based on the work in #1105. This modifies `zipBatchIterators` to return an object with keys `progress` and `data` rather than an array so we can return parsing progress for the `parseShapefileInBatches` function.

This will be useful for returning a progress indicator in a UI when loading large shapefiles.