### PR TITLE
fix(tile-converter): simultaneous file writing

### DIFF
--- a/modules/tile-converter/src/i3s-converter/helpers/node-pages.ts
+++ b/modules/tile-converter/src/i3s-converter/helpers/node-pages.ts
@@ -194,13 +194,15 @@ export default class NodePages {
    * @return {promise}
    */
   async save(layers0Path: string, fileMap: Object, slpk: boolean = false): Promise<void> {
-    const promises: Promise<any>[] = [];
     if (slpk) {
       for (const [index, nodePage] of this.nodePages.entries()) {
         const nodePageStr = JSON.stringify(nodePage);
         const slpkPath = join(layers0Path, 'nodepages');
-        promises.push(this.writeFile(slpkPath, nodePageStr, `${index.toString()}.json`));
-        fileMap[`nodePages/${index.toString()}.json.gz`] = `${slpkPath}.json.gz`;
+        fileMap[`nodePages/${index.toString()}.json.gz`] = await this.writeFile(
+          slpkPath,
+          nodePageStr,
+          `${index.toString()}.json`
+        );
       }
       const metadata = transform({nodeCount: this.nodesCounter}, metadataTemplate());
       const compress = false;
@@ -214,10 +216,8 @@ export default class NodePages {
       for (const [index, nodePage] of this.nodePages.entries()) {
         const nodePageStr = JSON.stringify(nodePage);
         const nodePagePath = join(layers0Path, 'nodepages', index.toString());
-        promises.push(this.writeFile(nodePagePath, nodePageStr));
+        await this.writeFile(nodePagePath, nodePageStr);
       }
     }
-
-    await Promise.all(promises);
   }
 }


### PR DESCRIPTION
We have the report from @Tamrat-B. I hope this PR will fix it. @Tamrat-B  could you check it on your big dataset.
```
.

..

Z:\slpk_loaders_315\Krimpen\SceneServer\layers\0\nodepages\6403.json saved.

z:\slpk_loaders_315\Krimpen\SceneServer\layers\0\nodepages\6404.json saved.

z:\slpk_loaders_315\Krimpen\SceneServer\layers\0\nodepages\6407.json saved.

z:\slpk_loaders_315\Krimpen\SceneServer\layers\0\nodepages\6406.json saved.

z:\slpk_loaders_315\Krimpen\SceneServer\layers\0\nodepages\6405.json saved.

z:\slpk_loaders_315\Krimpen\SceneServer\layers\0\nodepages\4094.json.gz: compression error!

node:internal/process/promises:246

triggerUncaughtException(err, true /* fromPromise */);

^

[Error: EMFILE: too many open files, open 'z:\slpk_loaders_315\Krimpen\SceneServer\layers\0\nodepages\4094.json'] {

errno: -4066,

code: 'EMFILE',

syscall: 'open',

path: 'z\\slpk_loaders_315\\Krimpen\\SceneServer\\layers\\0\\nodepages
4094.json'

}

Node.js v17.1.0
```