### PR TITLE
fix(tiles): Tileset3D.update types

### DIFF
--- a/modules/tiles/src/tileset/tileset-3d.ts
+++ b/modules/tiles/src/tileset/tileset-3d.ts
@@ -384,7 +384,7 @@ export default class Tileset3D {
    * @param viewports - list of viewports
    */
   // eslint-disable-next-line max-statements, complexity
-  update(viewports: any[]): void {
+  update(viewports: any[] | null = null): void {
     if ('loadTiles' in this.options && !this.options.loadTiles) {
       return;
     }


### PR DESCRIPTION
`Tileset3D` saves the last used `viewport` and `update` can be called with no arguments