### PR TITLE
fix(terrain): swap winding order of skirts to match winding order of terrain

### DIFF
--- a/examples/experimental/terrain/package.json
+++ b/examples/experimental/terrain/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
-    "start-local": "webpack-dev-server --env.local--env.esnext --progress --hot --open",
+    "start-local": "webpack-dev-server --env.local --env.esnext --progress --hot --open",
     "start-local-deck": "webpack-dev-server --env.local --env.esnext --env.deck --progress --hot --open",
     "start": "webpack-dev-server --progress --hot --open"
   },

--- a/modules/terrain/src/lib/helpers/skirt.ts
+++ b/modules/terrain/src/lib/helpers/skirt.ts
@@ -159,10 +159,10 @@ function updateAttributesForNewEdge({
   // Define new triangles
   const triangle1Offset = edgeIndex * 2 * 3;
   newTriangles[triangle1Offset] = edge[0];
-  newTriangles[triangle1Offset + 1] = edge[1];
-  newTriangles[triangle1Offset + 2] = positionsLength / 3 + vertex2Offset;
+  newTriangles[triangle1Offset + 1] = positionsLength / 3 + vertex2Offset;
+  newTriangles[triangle1Offset + 2] = edge[1];
 
   newTriangles[triangle1Offset + 3] = positionsLength / 3 + vertex2Offset;
-  newTriangles[triangle1Offset + 4] = positionsLength / 3 + vertex1Offset;
-  newTriangles[triangle1Offset + 5] = edge[0];
+  newTriangles[triangle1Offset + 4] = edge[0];
+  newTriangles[triangle1Offset + 5] = positionsLength / 3 + vertex1Offset;
 }

--- a/modules/terrain/test/lib/helpers/skirt.spec.js
+++ b/modules/terrain/test/lib/helpers/skirt.spec.js
@@ -12,7 +12,7 @@ test('TerrainLoader-skirting#addSkirt', (t) => {
     }
   };
   const triangles = new Uint16Array([0, 1, 2, 0, 2, 3]);
-  addSkirt(attributes, triangles, 20);
+  const addSkirtResult = addSkirt(attributes, triangles, 20);
   // prettier-ignore
   t.deepEqual(attributes.POSITION.value, 
     [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 2, -17, 4, 5, -14, 10, 11, -8, 1, 2, -17, 4, 5, -14, 7, 8, -11, 7, 8, -11, 10, 11, -8], 
@@ -21,6 +21,11 @@ test('TerrainLoader-skirting#addSkirt', (t) => {
     attributes.TEXCOORD_0.value,
     [1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 7, 8, 1, 2, 3, 4, 5, 6, 5, 6, 7, 8],
     'Make correct TEXCOORD_0 attribute'
+  );
+  t.deepEqual(
+    addSkirtResult.triangles,
+    [0, 1, 2, 0, 2, 3, 0, 5, 1, 5, 0, 4, 3, 7, 0, 7, 3, 6, 1, 9, 2, 9, 1, 8, 2, 11, 3, 11, 2, 10],
+    'Make correct indices array of the mesh geometry'
   );
   t.end();
 });


### PR DESCRIPTION
- swap winding order of triangles during skirts generation
- test for resulting indices
- fix for terrain yarn start-local

Skirts aren't visible when culling is enabled in <Deck parameters={{cull: true}} ...>
<img width="1208" alt="image" src="https://user-images.githubusercontent.com/8210766/154176723-9325b7b5-3365-4267-bba2-a0ec967e9e1b.png">
