### PR TITLE
Add Geopackage to geospatial example

### DIFF
--- a/examples/website/geospatial/app.js
+++ b/examples/website/geospatial/app.js
@@ -80,22 +80,48 @@ export default class App extends PureComponent {
 
   _renderLayer() {
     const {selectedExample, selectedLoader, uploadedFile} = this.state;
+
+    let layerData;
+    if (uploadedFile) {
+      layerData = uploadedFile;
+    } else if (EXAMPLES[selectedLoader][selectedExample]) {
+      layerData = EXAMPLES[selectedLoader][selectedExample].data;
+    } else {
+      layerData = EXAMPLES[INITIAL_LOADER_NAME][INITIAL_EXAMPLE_NAME].data;
+    }
+
     return [
       new GeoJsonLayer({
         id: `geojson-${selectedExample}(${selectedLoader})`,
-        data: uploadedFile
-          ? uploadedFile
-          : EXAMPLES[selectedLoader][selectedExample]
-          ? EXAMPLES[selectedLoader][selectedExample].data
-          : EXAMPLES[INITIAL_LOADER_NAME][INITIAL_EXAMPLE_NAME].data,
+        data: layerData,
         opacity: 0.8,
         stroked: false,
         filled: true,
         extruded: true,
         wireframe: true,
         getElevation: (f) => Math.sqrt(f.properties.valuePerSqm) * 10,
-        getLineColor: [255, 255, 255],
-        pickable: true
+        getLineColor: [255, 0, 0],
+        getLineWidth: 3,
+        lineWidthUnits: 'pixels',
+        pickable: true,
+        // TODO: Why aren't these loadOptions aren't passed for an uploaded file???
+        loadOptions: {
+          geopackage: {
+            sqlJsCDN: 'https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.5.0/'
+          },
+          gis: {
+            format: 'geojson',
+            reproject: true,
+            _targetCrs: 'WGS84'
+          }
+        },
+        dataTransform: (data, previousData) => {
+          if (typeof data === 'object' && !Array.isArray(data) && !data.type) {
+            return Object.values(data).flat();
+          }
+
+          return data;
+        }
       })
     ];
   }

--- a/examples/website/geospatial/examples.js
+++ b/examples/website/geospatial/examples.js
@@ -18,6 +18,17 @@ const VIEW_STATE = {
 };
 
 export const EXAMPLES = {
+  GeoPackage: {
+    Rivers: {
+      data: 'https://raw.githubusercontent.com/ngageoint/geopackage-js/master/test/fixtures/rivers.gpkg',
+      viewState: {
+        ...VIEW_STATE,
+        longitude: -4.65,
+        latitude: 0,
+        zoom: 1.76
+      }
+    }
+  },
   GeoJSON: {
     Vancouver: {
       data: 'https://raw.githubusercontent.com/visgl/deck.gl-data/master/examples/geojson/vancouver-blocks.json',

--- a/examples/website/geospatial/package.json
+++ b/examples/website/geospatial/package.json
@@ -32,5 +32,8 @@
     "webpack": "^4.39.1",
     "webpack-cli": "^3.1.2",
     "webpack-dev-server": "^3.1.11"
+  },
+  "resolutions": {
+    "sql.js": "1.5.0"
   }
 }

--- a/examples/website/geospatial/webpack.config.js
+++ b/examples/website/geospatial/webpack.config.js
@@ -1,6 +1,11 @@
 const CONFIG = {
   mode: 'development',
 
+  // Necessary for sql.js
+  externals: {
+    fs: 'fs'
+  },
+
   entry: {
     app: './app.js'
   },

--- a/modules/geopackage/src/lib/parse-geopackage.ts
+++ b/modules/geopackage/src/lib/parse-geopackage.ts
@@ -30,7 +30,8 @@ import {
   DataColumnsRow,
   DataColumnsMapping,
   PragmaTableInfoRow,
-  SQLiteTypes
+  SQLiteTypes,
+  GeoPackageGeometryTypes
 } from './types';
 
 // https://www.geopackage.org/spec121/#flags_layout
@@ -47,7 +48,7 @@ const ENVELOPE_BYTE_LENGTHS = {
 };
 
 // Documentation: https://www.geopackage.org/spec130/index.html#table_column_data_types
-const SQL_TYPE_MAPPING: {[type in SQLiteTypes]: typeof DataType} = {
+const SQL_TYPE_MAPPING: {[type in SQLiteTypes | GeoPackageGeometryTypes]: typeof DataType} = {
   BOOLEAN: Bool,
   TINYINT: Int8,
   SMALLINT: Int16,
@@ -61,7 +62,14 @@ const SQL_TYPE_MAPPING: {[type in SQLiteTypes]: typeof DataType} = {
   BLOB: Binary,
   DATE: Utf8,
   DATETIME: Utf8,
-  GEOMETRY: Binary
+  GEOMETRY: Binary,
+  POINT: Binary,
+  LINESTRING: Binary,
+  POLYGON: Binary,
+  MULTIPOINT: Binary,
+  MULTILINESTRING: Binary,
+  MULTIPOLYGON: Binary,
+  GEOMETRYCOLLECTION: Binary,
 };
 
 export default async function parseGeoPackage(
@@ -463,7 +471,8 @@ function getArrowSchema(db: Database, tableName: string): Schema {
   while (stmt.step()) {
     const pragmaTableInfo = stmt.getAsObject() as unknown as PragmaTableInfoRow;
     const {name, type, notnull} = pragmaTableInfo;
-    const field = new Field(name, new SQL_TYPE_MAPPING[type](), !notnull);
+    const schemaType = SQL_TYPE_MAPPING[type] && new SQL_TYPE_MAPPING[type]();
+    const field = new Field(name, schemaType, !notnull);
     fields.push(field);
   }
 

--- a/modules/geopackage/src/lib/types.ts
+++ b/modules/geopackage/src/lib/types.ts
@@ -21,8 +21,23 @@ export type SQLiteTypes =
   | 'TEXT'
   | 'BLOB'
   | 'DATE'
-  | 'DATETIME'
-  | 'GEOMETRY';
+  | 'DATETIME';
+
+/** Type names for geopackage geometries
+ *
+ * As defined in https://www.geopackage.org/spec130/index.html#table_column_data_types, geometries
+ * can be stored with any geometry name listed here:
+ * https://www.geopackage.org/spec130/index.html#geometry_types
+ */
+export type GeoPackageGeometryTypes =
+  | 'GEOMETRY'
+  | 'POINT'
+  | 'LINESTRING'
+  | 'POLYGON'
+  | 'MULTIPOINT'
+  | 'MULTILINESTRING'
+  | 'MULTIPOLYGON'
+  | 'GEOMETRYCOLLECTION'
 
 /**
  * https://www.geopackage.org/spec121/#spatial_ref_sys


### PR DESCRIPTION
### Change list

- Add geopackage support to geospatial example. Points to an example data file [here](https://github.com/ngageoint/geopackage-js/blob/master/test/fixtures/rivers.gpkg) which we might want to put in our own repo; `deck.gl-data`?
- Fix creating arrow schema. Update possible type names and try not to fail if the schema type can't be found.
- Change style to make something visible. Probably want to revisit styling choices in the app.


https://user-images.githubusercontent.com/15164633/156437548-95c36b6c-679c-43e7-b8aa-a8b6cd7cdced.mov
