### PR TITLE
Pin sql.js 1.5.0 in GeoPackageLoader

### DIFF
--- a/examples/website/geospatial/app.js
+++ b/examples/website/geospatial/app.js
@@ -107,9 +107,6 @@ export default class App extends PureComponent {
         pickable: true,
         // TODO: Why aren't these loadOptions aren't passed for an uploaded file???
         loadOptions: {
-          geopackage: {
-            sqlJsCDN: 'https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.5.0/'
-          },
           gis: {
             format: 'geojson',
             reproject: true,

--- a/examples/website/geospatial/package.json
+++ b/examples/website/geospatial/package.json
@@ -32,8 +32,5 @@
     "webpack": "^4.39.1",
     "webpack-cli": "^3.1.2",
     "webpack-dev-server": "^3.1.11"
-  },
-  "resolutions": {
-    "sql.js": "1.5.0"
   }
 }

--- a/modules/geopackage/docs/api-reference/geopackage-loader.md
+++ b/modules/geopackage/docs/api-reference/geopackage-loader.md
@@ -25,7 +25,7 @@ import {Tables, ObjectRowTable, Feature} from '@loaders.gl/schema';
 
 const optionsAsTable: GeoPackageLoaderOptions = {
   geopackage: {
-    sqlJsCDN: 'https://sql.js.org/dist/'
+    sqlJsCDN: 'https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.5.0/'
   },
   gis: {
     format: 'tables'
@@ -35,7 +35,7 @@ const tablesData: Tables<ObjectRowTable> = await load(url, GeoPackageLoader, opt
 
 const optionsAsGeoJson: GeoPackageLoaderOptions = {
   geopackage: {
-    sqlJsCDN: 'https://sql.js.org/dist/'
+    sqlJsCDN: 'https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.5.0/'
   },
   gis: {
     format: 'geojson'
@@ -46,10 +46,12 @@ const geoJsonData: Record<string, Feature[]> = await load(url, GeoPackageLoader,
 
 ## Options
 
-| Option                | Type   | Default                      | Description                                                                                                            |
-| --------------------- | ------ | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `geopackage.sqlJsCDN` | String | `'https://sql.js.org/dist/'` | CDN from which to load the SQL.js bundle. This is loaded asynchronously when the GeoPackageLoader is called on a file. |
-| `options.gis.format`  | String | `'tables'`                   | Output format for data. If set to `geojson`                                                                            |
+| Option                | Type   | Default                                                  | Description                                                                                                            |
+| --------------------- | ------ | -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `geopackage.sqlJsCDN` | String | `'https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.5.0/'` | CDN from which to load the SQL.js bundle. This is loaded asynchronously when the GeoPackageLoader is called on a file. |
+| `options.gis.format`  | String | `'tables'`                                               | Output format for data. If set to `geojson`                                                                            |
+
+- `geopackage.sqlJsCDN`: As of March 2022, SQL.js versions 1.6.0, 1.6.1, and 1.6.2 were tested as not working. Therefore this library pins to use of SQL.js version 1.5.0, and requires the WASM bundle from the same version.
 
 ## Output
 

--- a/modules/geopackage/package.json
+++ b/modules/geopackage/package.json
@@ -30,6 +30,6 @@
     "@loaders.gl/wkt": "4.0.0-alpha.5",
     "@math.gl/proj4": "^3.5.1",
     "@types/sql.js": "^1.4.2",
-    "sql.js": "^1.5.0"
+    "sql.js": "1.5.0"
   }
 }

--- a/modules/geopackage/src/geopackage-loader.ts
+++ b/modules/geopackage/src/geopackage-loader.ts
@@ -1,5 +1,5 @@
 import type {LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';
-import parseGeoPackage from './lib/parse-geopackage';
+import parseGeoPackage, {DEFAULT_SQLJS_CDN} from './lib/parse-geopackage';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
@@ -30,7 +30,7 @@ export const GeoPackageLoader: LoaderWithParser = {
   parse: parseGeoPackage,
   options: {
     geopackage: {
-      sqlJsCDN: 'https://sql.js.org/dist/'
+      sqlJsCDN: DEFAULT_SQLJS_CDN
     },
     gis: {
       format: 'tables'

--- a/modules/geopackage/src/lib/parse-geopackage.ts
+++ b/modules/geopackage/src/lib/parse-geopackage.ts
@@ -33,6 +33,10 @@ import {
   SQLiteTypes
 } from './types';
 
+// We pin to the same version as sql.js that we use.
+// As of March 2022, versions 1.6.0, 1.6.1, and 1.6.2 of sql.js appeared not to work.
+export const DEFAULT_SQLJS_CDN = 'https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.5.0/';
+
 // https://www.geopackage.org/spec121/#flags_layout
 const ENVELOPE_BYTE_LENGTHS = {
   0: 0,
@@ -68,7 +72,7 @@ export default async function parseGeoPackage(
   arrayBuffer: ArrayBuffer,
   options?: GeoPackageLoaderOptions
 ): Promise<Tables<ObjectRowTable> | Record<string, Feature[]>> {
-  const {sqlJsCDN = 'https://sql.js.org/dist/'} = options?.geopackage || {};
+  const {sqlJsCDN = DEFAULT_SQLJS_CDN} = options?.geopackage || {};
   const {reproject = false, _targetCrs = 'WGS84', format = 'tables'} = options?.gis || {};
 
   const db = await loadDatabase(arrayBuffer, sqlJsCDN);

--- a/yarn.lock
+++ b/yarn.lock
@@ -11893,7 +11893,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-sql.js@^1.5.0:
+sql.js@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/sql.js/-/sql.js-1.5.0.tgz#6625c3e41115194f6bfab80a5e53647f1378c3fb"
   integrity sha512-Qqr6HgX/hCDpLFWdN0BNoNpYQ2c1tOl1c3HGI0cshjaFSAWszKICuLZ9CyFUvRFPpEGW8RzHzwuXWWvXVGTKBg==


### PR DESCRIPTION
- sql.js 1.6.2 doesn't seem to have worker files published at `https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.6.2/`
- sql.js 1.6.1 fails to load with error `LinkError: WebAssembly.instantiate(): Import #0 module="a" function="a" error: function import requires a callable`
- sql.js 1.6.0 makes the page hang when testing with the Geospatial example app in `examples/website/`.

sql.js 1.5.0 seems to work.