### PR TITLE
fix some postProcessGLTF and glTF Extensions urls

### DIFF
--- a/modules/gltf/docs/README.md
+++ b/modules/gltf/docs/README.md
@@ -37,7 +37,7 @@ const arrayBuffer = encode(gltfScenegraph, GLTFWriter);
 
 ## GLTF Post Processing
 
-The [`postProcessGLTF`](docs/api-reference/gltf/post-process-gltf) function implements a number of transformations on the loaded glTF data that would typically need to be performed by the application after loading the data, and is provided as an optional function that applications can call after loading glTF data. Refer to the reference page for details on what transformations are performed.
+The [`postProcessGLTF`](api-reference/post-process-gltf) function implements a number of transformations on the loaded glTF data that would typically need to be performed by the application after loading the data, and is provided as an optional function that applications can call after loading glTF data. Refer to the reference page for details on what transformations are performed.
 
 Context: the glTF data object returned by the GLTF loader contains the "raw" glTF JSON structure (to ensure generality and "data fidelity" reasons). However, most applications that are going to use the glTF data to visualize it in (typically in WebGL) will need to do some processing of the loaded data before using it.
 
@@ -49,7 +49,7 @@ To allow for this (and also to generally improve the glTF code structure), the `
 
 ## glTF Extension Support
 
-Certain glTF extensions are fully or partially supported by the glTF classes. For details on which extensions are supported, see [glTF Extensions](docs/api-reference/gltf-loaders/gltf-extensions).
+Certain glTF extensions are fully or partially supported by the glTF classes. For details on which extensions are supported, see [glTF Extensions](api-reference/gltf-extensions).
 
 ## Draco Mesh and Point Cloud Compression
 

--- a/modules/gltf/docs/api-reference/gltf-loader.md
+++ b/modules/gltf/docs/api-reference/gltf-loader.md
@@ -38,9 +38,9 @@ The `GLTFLoader` aims to take care of as much processing as possible, while rema
 
 The GLTF Loader returns an object with a `json` field containing the glTF Scenegraph. In its basic mode, the `GLTFLoader` does not modify the loaded JSON in any way. Instead, the results of additional processing are placed in parallel top-level fields such as `buffers` and `images`. This ensures that applications that want to work with the standard glTF data structure can do so.
 
-Optionally, the loaded gltf can be "post processed", which lightly annotates and transforms the loaded JSON structure to make it easier to use. Refer to [postProcessGLTF](docs/api-reference/gltf-loaders/gltf-extensions.md) for details.
+Optionally, the loaded gltf can be "post processed", which lightly annotates and transforms the loaded JSON structure to make it easier to use. Refer to [postProcessGLTF](post-process-gltf) for details.
 
-In addition, certain glTF extensions, in particular Draco mesh encoding, can be fully or partially processed during loading. When possible (and extension processing is enabled), such extensions will be resolved/decompressed and replaced with standards conformant representations. See [glTF Extensions](docs/api-reference/gltf-loaders/gltf-extensions.md) for more information.
+In addition, certain glTF extensions, in particular Draco mesh encoding, can be fully or partially processed during loading. When possible (and extension processing is enabled), such extensions will be resolved/decompressed and replaced with standards conformant representations. See [glTF Extensions](gltf-extensions) for more information.
 
 Note: while supported, synchronous parsing of glTF (e.g. using `parseSync()`) has significant limitations. When parsed asynchronously (using `await parse()` or `await load()`), the following additional capabilities are enabled:
 
@@ -61,13 +61,13 @@ Note: while supported, synchronous parsing of glTF (e.g. using `parseSync()`) ha
 
 Remarks:
 
-- The `gltf.postProcess` option activates additional [post processing](docs/api-reference/post-process-gltf) that transforms parts of JSON structure in the loaded glTF data, to make glTF data easier use in applications and WebGL libraries (e.g replacing indices with links to the indexed objects). However, the data structure returned by the `GLTFLoader` will no longer be fully glTF compatible.
+- The `gltf.postProcess` option activates additional [post processing](post-process-gltf) that transforms parts of JSON structure in the loaded glTF data, to make glTF data easier use in applications and WebGL libraries (e.g replacing indices with links to the indexed objects). However, the data structure returned by the `GLTFLoader` will no longer be fully glTF compatible.
 
 ## Data Format
 
 ### With Post Processing
 
-When the `GLTFLoader` is called with `gltf.postProcess` option set to `true` (the default),the parsed JSON chunk will be returned, and [post processing](docs/api-reference/post-process-gltf) will have been performed, which will link data from binary buffers into the parsed JSON structure using non-standard fields, and also modify the data in other ways to make it easier to use.
+When the `GLTFLoader` is called with `gltf.postProcess` option set to `true` (the default),the parsed JSON chunk will be returned, and [post processing](post-process-gltf) will have been performed, which will link data from binary buffers into the parsed JSON structure using non-standard fields, and also modify the data in other ways to make it easier to use.
 
 At the top level, this will look like a standard glTF JSON structure:
 
@@ -80,7 +80,7 @@ At the top level, this will look like a standard glTF JSON structure:
 }
 ```
 
-However, the objects inside these arrays will have been pre-processed to simplify usage. For details on changes and extra fields added to the various glTF objects, see [post processing](docs/api-reference/post-process-gltf).
+However, the objects inside these arrays will have been pre-processed to simplify usage. For details on changes and extra fields added to the various glTF objects, see [post processing](post-process-gltf).
 
 ### Without Post Processing
 


### PR DESCRIPTION
fixes https://github.com/visgl/loaders.gl/issues/2120

The new md urls do not include the .md extension. Please let me know if this is incorrect.