### PR TITLE
fix(gltf): meshopt compression extension

### DIFF
--- a/modules/gltf/src/lib/parsers/parse-gltf.ts
+++ b/modules/gltf/src/lib/parsers/parse-gltf.ts
@@ -144,6 +144,12 @@ async function loadBuffers(gltf: GLTFWithBuffers, options, context: LoaderContex
       };
 
       delete buffer.uri;
+    } else if (gltf.buffers[i] === null) {
+      gltf.buffers[i] = {
+        arrayBuffer: new ArrayBuffer(buffer.byteLength),
+        byteOffset: 0,
+        byteLength: buffer.byteLength
+      };
     }
   }
 }


### PR DESCRIPTION
This code is dedicated from https://github.com/visgl/loaders.gl/pull/2035 . 
I checked it with 3DTiles dataset:
![image](https://user-images.githubusercontent.com/18549629/162437507-4280ef4b-43f6-4f94-b638-2c19375d9d7e.png)
Textures are in black because of KHR_texture_transform extension that is not supported by @loaders.gl