### PR TITLE
fix(tile-converter): node transformation order

### DIFF
--- a/modules/tile-converter/src/i3s-converter/helpers/geometry-converter.ts
+++ b/modules/tile-converter/src/i3s-converter/helpers/geometry-converter.ts
@@ -371,16 +371,16 @@ function getCompositeTransformationMatrix(node, matrix) {
     transformationMatrix = matrix.multiplyRight(nodeMatrix);
   }
 
+  if (translation) {
+    transformationMatrix = transformationMatrix.translate(translation);
+  }
+
   if (rotation) {
     transformationMatrix = transformationMatrix.rotateXYZ(rotation);
   }
 
   if (scale) {
     transformationMatrix = transformationMatrix.scale(scale);
-  }
-
-  if (translation) {
-    transformationMatrix = transformationMatrix.translate(translation);
   }
 
   return transformationMatrix;


### PR DESCRIPTION
Fix the transformation order per spec:
https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-node

Should be `translation * rotation * scale`