### PR TITLE
fix(tile-converter): import polyfills

### DIFF
--- a/modules/tile-converter/src/converter-cli.ts
+++ b/modules/tile-converter/src/converter-cli.ts
@@ -1,8 +1,8 @@
 /* eslint-disable no-console */
+import '@loaders.gl/polyfills';
 import {join} from 'path';
 import {I3SConverter, Tiles3DConverter} from '@loaders.gl/tile-converter';
 import {DepsInstaller} from './deps-installer/deps-installer';
-import '@loaders.gl/polyfills';
 
 const TILESET_TYPE = {
   I3S: 'I3S',


### PR DESCRIPTION
Fixes regression of https://github.com/visgl/loaders.gl/pull/2157

```
A 3D tile failed to load: undefined Install '@loaders.gl/polyfills' to parse images under Node.js
A 3D tile failed to load: undefined Install '@loaders.gl/polyfills' to parse images under Node.js
```