### PR TITLE
fix(RequestScheduler): Fix&improve GetPriorityFun signature

### DIFF
--- a/modules/loader-utils/src/lib/request-utils/request-scheduler.ts
+++ b/modules/loader-utils/src/lib/request-utils/request-scheduler.ts
@@ -2,7 +2,7 @@ import {Stats} from '@probe.gl/stats';
 
 type Handle = any;
 type DoneFunction = () => any;
-type GetPriorityFunction = () => number;
+type GetPriorityFunction<T = Handle> = (handle: T) => number;
 type RequestResult = {
   done: DoneFunction;
 } | null;
@@ -78,9 +78,9 @@ export default class RequestScheduler {
    *   - resolves to `null` if the request has been cancelled (by the callback return < 0).
    *     In this case the application should not issue the request
    */
-  scheduleRequest(
-    handle: Handle,
-    getPriority: GetPriorityFunction = () => 0
+  scheduleRequest<T extends Handle = Handle>(
+    handle: T,
+    getPriority: GetPriorityFunction<T> = () => 0
   ): Promise<RequestResult> {
     // Allows throttling to be disabled
     if (!this.props.throttleRequests) {

--- a/modules/loader-utils/test/lib/request-utils/request-scheduler.spec.js
+++ b/modules/loader-utils/test/lib/request-utils/request-scheduler.spec.js
@@ -21,7 +21,7 @@ test('RequestScheduler#scheduleRequest', async (t) => {
     requestToken.done();
     t.is(requestScheduler.activeRequestCount, 0, 'active request count');
 
-    requestToken = await requestScheduler.scheduleRequest({id: 2}, () => -1);
+    requestToken = await requestScheduler.scheduleRequest({id: -1}, (x) => x.id);
     t.notOk(requestToken, 'should not issue request with negative priority');
     t.is(requestScheduler.activeRequestCount, 0, 'active request count');
   }


### PR DESCRIPTION
Fix and then improve type signature of `getPriority` parameter of `RequestScheduler.scheduleRequest`, so it accepts `generic` Handle.

See: https://github.com/visgl/deck.gl/pull/6841/files#r866184522