### PR TITLE
fix(schema): failing imports from apache-arrow

### DIFF
--- a/modules/schema/src/index.ts
+++ b/modules/schema/src/index.ts
@@ -41,7 +41,8 @@ export type {
 } from './category/mesh/mesh-types';
 
 export {getMeshSize, getMeshBoundingBox} from './category/mesh/mesh-utils';
-export {convertMesh} from './category/mesh/convert-mesh';
+// Commented out due to https://github.com/visgl/deck.gl/issues/6906 and https://github.com/visgl/loaders.gl/issues/2177
+// export {convertMesh} from './category/mesh/convert-mesh';
 export {
   deduceMeshSchema,
   deduceMeshField,


### PR DESCRIPTION
Import from root of `apache-arrow` fails build with errors kind of:
```
ERROR in /home/user/apps/loaders.gl/node_modules/apache-arrow/Arrow.dom.mjs 33:0-2582
Can't reexport the named export 'Visitor' from non EcmaScript module (only default export is available)
```
Originally `convertMesh` was done for `LASLoader` but related code was commented due to issue on the website:
https://github.com/visgl/loaders.gl/blob/7d8300f78deca9dd688b5605ecc8f38ff28f768e/modules/las/src/lib/parse-las.ts#L28
Possibly the root cause is the same.