### PR TITLE
chore(polyfills): add export for fetchNode

### DIFF
--- a/modules/polyfills/src/index.ts
+++ b/modules/polyfills/src/index.ts
@@ -20,7 +20,7 @@ export {BlobPolyfill} from './node/file/blob';
 export {FileReaderPolyfill} from './node/file/file-reader';
 export {FilePolyfill} from './node/file/file';
 export {installFilePolyfills} from './node/file/install-file-polyfills';
-export {default as fetchNode} from './node/fetch/fetch.node';
+export {default as _fetchNode} from './node/fetch/fetch.node';
 
 // POLYFILLS: TextEncoder, TextDecoder
 // - Recent Node versions have these classes but virtually no encodings unless special build.

--- a/modules/polyfills/src/index.ts
+++ b/modules/polyfills/src/index.ts
@@ -20,6 +20,7 @@ export {BlobPolyfill} from './node/file/blob';
 export {FileReaderPolyfill} from './node/file/file-reader';
 export {FilePolyfill} from './node/file/file';
 export {installFilePolyfills} from './node/file/install-file-polyfills';
+export {default as fetchNode} from './node/fetch/fetch.node';
 
 // POLYFILLS: TextEncoder, TextDecoder
 // - Recent Node versions have these classes but virtually no encodings unless special build.


### PR DESCRIPTION
I just had the situation where I didn't want to use the whole set of polyfills, but wanted to pass fetchNode to load like this:
```typescript
const batches = await loadInBatches(shapeFilePath, ShapefileLoader, {
    fetch: fetchNode,
});
```

Sadly I think the only way currently is via a file import from `dist`: `@loaders.gl/polyfills/dist/node/fetch/fetch.node`. I'd say we could add an export to make that easier.