### PR TITLE
fix(3d-tiles): add support for absolute content-uris

### DIFF
--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile-header.ts
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile-header.ts
@@ -37,13 +37,27 @@ function getRefine(refine) {
   }
 }
 
+function resolveUri(uri, basePath) {
+  // url scheme per RFC3986
+  const urlSchemeRegex = /^[a-z][0-9a-z+.-]*:/i;
+
+  if (urlSchemeRegex.test(basePath)) {
+    const url = new URL(uri, `${basePath}/`);
+    return decodeURI(url.toString());
+  } else if (uri.startsWith('/')) {
+    return uri;
+  }
+
+  return `${basePath}/${uri}`;
+}
+
 export function normalizeTileData(tile, options) {
   if (!tile) {
     return null;
   }
   if (tile.content) {
     const contentUri = tile.content.uri || tile.content.url;
-    tile.contentUrl = `${options.basePath}/${contentUri}`;
+    tile.contentUrl = resolveUri(contentUri, options.basePath);
   }
   tile.id = tile.contentUrl;
   tile.lodMetricType = LOD_METRIC_TYPE.GEOMETRIC_ERROR;
@@ -94,9 +108,9 @@ export async function normalizeImplicitTileHeaders(tileset: Tileset3D) {
     subtrees: {uri: subtreesUriTemplate}
   } = implicitTilingExtension;
   const subtreeUrl = replaceContentUrlTemplate(subtreesUriTemplate, 0, 0, 0, 0);
-  const rootSubtreeUrl = `${basePath}/${subtreeUrl}`;
+  const rootSubtreeUrl = resolveUri(subtreeUrl, basePath);
   const rootSubtree = await load(rootSubtreeUrl, Tile3DSubtreeLoader);
-  const contentUrlTemplate = `${basePath}/${tileset.root.content.uri}`;
+  const contentUrlTemplate = resolveUri(tileset.root.content.uri, basePath);
   const refine = tileset.root.refine;
   // @ts-ignore
   const rootLodMetricValue = tileset.root.geometricError;

--- a/modules/3d-tiles/test/index.js
+++ b/modules/3d-tiles/test/index.js
@@ -5,6 +5,7 @@ import './lib/parsers/batched-model-3d-tile.spec';
 import './lib/parsers/instanced-model-3d-tile.spec';
 import './lib/parsers/point-cloud-3d-tile.spec';
 import './lib/parsers/composite-3d-tile.spec';
+import './lib/parsers/parse-3d-tile-header.spec.js';
 import './lib/parsers/helpers/normalize-3d-tile-colors.spec';
 
 // import './styles/expression.spec';

--- a/modules/3d-tiles/test/lib/parsers/parse-3d-tile-header.spec.js
+++ b/modules/3d-tiles/test/lib/parsers/parse-3d-tile-header.spec.js
@@ -1,0 +1,50 @@
+import test from 'tape-promise/tape';
+
+import {normalizeTileData} from '../../../src/lib/parsers/parse-3d-tile-header';
+
+const TESTS = [
+  // relative paths - different notations
+  ['test.glb', 'https://example.tld/a/b/c', 'https://example.tld/a/b/c/test.glb'],
+  ['d/test.glb', 'https://example.tld/a/b/c', 'https://example.tld/a/b/c/d/test.glb'],
+  ['./d/test.glb', 'https://example.tld/a/b/c', 'https://example.tld/a/b/c/d/test.glb'],
+  ['../d/test.glb', 'https://example.tld/a/b/c', 'https://example.tld/a/b/d/test.glb'],
+  // absolute path
+  [
+    '/absolute-path/test.glb',
+    'https://example.tld/a/b/c',
+    'https://example.tld/absolute-path/test.glb'
+  ],
+  // fully qualified url
+  [
+    'https://other.example.tld/other-domain/test.glb',
+    'https://example.tld/a/b/c',
+    'https://other.example.tld/other-domain/test.glb'
+  ],
+  // data-url
+  [
+    'data:model/gltf-binary;base64,Z2xURg==',
+    'https://example.tld/a/b/c',
+    'data:model/gltf-binary;base64,Z2xURg=='
+  ],
+  // non-url basePath
+  ['c/file.glb', '/a/b', '/a/b/c/file.glb'],
+
+  // template-urls
+  [
+    '/implicit-tiling/{level}/{x}/{y}/{z}.glb',
+    'https://example.tld/a/b',
+    'https://example.tld/implicit-tiling/{level}/{x}/{y}/{z}.glb'
+  ]
+];
+
+test('normalizeTileData#corectly resolves different styles of URLs', async (t) => {
+  for (const [contentUri, basePath, resolvedUrl] of TESTS) {
+    const tile = {content: {uri: contentUri}};
+    const options = {basePath};
+    const normalizedTile = normalizeTileData(tile, options);
+
+    t.equals(normalizedTile.contentUrl, resolvedUrl, 'url should be resolved correctly');
+  }
+
+  t.end();
+});


### PR DESCRIPTION
Tilesets can use absolute paths or even fully qualified URLs in the
content.uri field. This patch adds support for all of those cases.

How would I best go about testing this? Would it be ok to add a new Tileset to `test/data/Tilesets` specifically to test the url-handling? Or add some unit-tests just for the normalize-functions?