### PR TITLE
fix(3d-tiles): prevent crash when cartographic center is undefined

### DIFF
--- a/modules/3d-tiles/test/data/Tilesets/TilesetGlobal/tileset.json
+++ b/modules/3d-tiles/test/data/Tilesets/TilesetGlobal/tileset.json
@@ -1,0 +1,11 @@
+{
+  "asset": {"version": "1.0"},
+  "geometricError": 1e6,
+  "root": {
+    "transform": [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+    "boundingVolume": {
+      "box": [0, 0, 0, 8000000, 0, 0, 0, 8000000, 0, 0, 0, 8000000]
+    },
+    "geometricError": 1e6
+  }
+}

--- a/modules/tiles/src/tileset/tileset-3d.ts
+++ b/modules/tiles/src/tileset/tileset-3d.ts
@@ -673,7 +673,13 @@ export default class Tileset3D {
       this.zoom = 1;
       return;
     }
-    this.cartographicCenter = Ellipsoid.WGS84.cartesianToCartographic(center, new Vector3());
+
+    // cartographic coordinates are undefined at the center of the ellipsoid
+    if (center[0] !== 0 || center[1] !== 0 || center[2] !== 0) {
+      this.cartographicCenter = Ellipsoid.WGS84.cartesianToCartographic(center, new Vector3());
+    } else {
+      this.cartographicCenter = new Vector3(0, 0, -Ellipsoid.WGS84.radii[0]);
+    }
     this.cartesianCenter = center;
     this.zoom = getZoomFromBoundingVolume(root.boundingVolume, this.cartographicCenter);
   }

--- a/modules/tiles/test/tileset/tileset-3d.spec.js
+++ b/modules/tiles/test/tileset/tileset-3d.spec.js
@@ -10,6 +10,7 @@ import {Tiles3DLoader} from '@loaders.gl/3d-tiles';
 
 // Parent tile with content and four child tiles with content
 const TILESET_URL = '@loaders.gl/3d-tiles/test/data/Tilesets/Tileset/tileset.json';
+const TILESET_GLOBAL_URL = '@loaders.gl/3d-tiles/test/data/Tilesets/TilesetGlobal/tileset.json';
 
 /*
 // Parent tile with no content and four child tiles with content
@@ -228,6 +229,24 @@ test('Tileset3D#gets root tile', async (t) => {
   const tileset = new Tileset3D(tilesetJson);
 
   t.ok(tileset.root);
+  t.end();
+});
+
+test('Tileset3D#handles global tilesets without error', async (t) => {
+  const tilesetJson = await load(TILESET_GLOBAL_URL, Tiles3DLoader);
+
+  try {
+    const tileset = new Tileset3D(tilesetJson);
+    await tileset.tilesetInitializationPromise;
+
+    t.deepEqual(
+      tileset.cartographicCenter ? tileset.cartographicCenter.toArray() : null,
+      [0, 0, -6378137]
+    );
+  } catch (e) {
+    t.fail('exception thrown when loading tileset with bbox-center at [0,0,0]');
+  }
+
   t.end();
 });
 


### PR DESCRIPTION
Fixes the crash occuring in Tileset3D when the bounding-box center is at
the cartesian center and thus the cartographic center can not be
unambiguously computed.

fixes #2196