### PR TITLE
fix(tile-converter): remove batchIds extensions warning

### DIFF
--- a/modules/tile-converter/src/i3s-converter/helpers/batch-ids-extensions.ts
+++ b/modules/tile-converter/src/i3s-converter/helpers/batch-ids-extensions.ts
@@ -36,7 +36,6 @@ export function handleBatchIdsExtensions(
         console.warn('EXT_mesh_features extension is not supported yet');
         return [];
       default:
-        console.warn(`Can't handle unsupported batchIds '${extensionName}' extension`);
         return [];
     }
   }


### PR DESCRIPTION
Remove warning because some extensions (not related to batch ids) occurs such unsupported message. 
For example - `Can't handle unsupported batchIds 'KHR_draco_mesh_compression' extension`