### PR TITLE
docs(pcd): fix pcd-loader example `PCDloader` spell

### DIFF
--- a/modules/pcd/docs/api-reference/pcd-loader.md
+++ b/modules/pcd/docs/api-reference/pcd-loader.md
@@ -20,7 +20,7 @@ Note: Currently supports `ascii`, `binary` and compressed binary files.
 import {PCDLoader} from '@loaders.gl/pcd';
 import {load} from '@loaders.gl/core';
 
-const data = await load(url, PCSLoader, options);
+const data = await load(url, PCDLoader, options);
 ```
 
 ## Options


### PR DESCRIPTION
It's to fix the spell of `PCDLoader`  in the PCD module example.

Since only the markdown file is changed, I think this PR won't affect any current features.