### PR TITLE
fix(implicit-tiling): handle child tiles

### DIFF
--- a/modules/3d-tiles/src/index.ts
+++ b/modules/3d-tiles/src/index.ts
@@ -13,4 +13,4 @@ export {default as Tile3DBatchTable} from './lib/classes/tile-3d-batch-table';
 // EXPERIMENTAL
 export {TILE3D_TYPE} from './lib/constants';
 export {getIonTilesetMetadata as _getIonTilesetMetadata} from './lib/ion/ion';
-export type {FeatureTableJson, B3DMContent, Node3D} from './types';
+export type {FeatureTableJson, B3DMContent, Node3D, ImplicitTilingExtension} from './types';

--- a/modules/3d-tiles/src/lib/parsers/helpers/parse-3d-implicit-tiles.ts
+++ b/modules/3d-tiles/src/lib/parsers/helpers/parse-3d-implicit-tiles.ts
@@ -75,15 +75,6 @@ export async function parseImplicitTiles(params: {
   let childTileY = concatBits(parentData.y, childY);
   let childTileZ = concatBits(parentData.z, childZ);
 
-  // TODO Remove after real implicit tileset will be tested.
-  // Degug data
-  // tile.level = level + globalData.level;
-  // tile.x = concatBits(globalData.x, childTileX);
-  // tile.y = concatBits(globalData.y, childTileY);
-  // tile.z = concatBits(globalData.z, childTileZ);
-  // tile.mortonIndex = childTileMortonIndex;
-  // End of debug data
-
   let isChildSubtreeAvailable = false;
 
   if (level + 1 > subtreeLevels) {
@@ -214,11 +205,6 @@ function formatTileData(
     geometricError: lodMetricValue,
     transform: tile.transform,
     boundingVolume
-    // Temp debug values. Remove when real implicit tileset will be tested.
-    // x: tile.x,
-    // y: tile.y,
-    // z: tile.z,
-    // level: tile.level
   };
 }
 

--- a/modules/3d-tiles/src/lib/parsers/helpers/parse-3d-implicit-tiles.ts
+++ b/modules/3d-tiles/src/lib/parsers/helpers/parse-3d-implicit-tiles.ts
@@ -211,6 +211,8 @@ function formatTileData(
     type: getTileType(tile),
     lodMetricType,
     lodMetricValue,
+    geometricError: lodMetricValue,
+    transform: tile.transform,
     boundingVolume
     // Temp debug values. Remove when real implicit tileset will be tested.
     // x: tile.x,

--- a/modules/3d-tiles/src/lib/parsers/helpers/parse-3d-tile-subtree.ts
+++ b/modules/3d-tiles/src/lib/parsers/helpers/parse-3d-tile-subtree.ts
@@ -1,5 +1,5 @@
 import type {Subtree, ExplicitBitstream} from '../../../types';
-import {fetchFile} from '@loaders.gl/core';
+import type {LoaderContext, LoaderOptions} from '@loaders.gl/loader-utils';
 
 const SUBTREE_FILE_MAGIC = 0x74627573;
 const SUBTREE_FILE_VERSION = 1;
@@ -11,7 +11,11 @@ const SUBTREE_FILE_VERSION = 1;
  * @returns
  */
 // eslint-disable-next-line max-statements
-export default async function parse3DTilesSubtree(data: ArrayBuffer, options): Promise<Subtree> {
+export default async function parse3DTilesSubtree(
+  data: ArrayBuffer,
+  options: LoaderOptions | undefined,
+  context: LoaderContext | undefined
+): Promise<Subtree> {
   const magic = new Uint32Array(data.slice(0, 4));
 
   if (magic[0] !== SUBTREE_FILE_MAGIC) {
@@ -43,7 +47,7 @@ export default async function parse3DTilesSubtree(data: ArrayBuffer, options): P
       subtree,
       'tileAvailability',
       internalBinaryBuffer,
-      options.basePath
+      context
     );
   }
 
@@ -52,7 +56,7 @@ export default async function parse3DTilesSubtree(data: ArrayBuffer, options): P
       subtree,
       'contentAvailability',
       internalBinaryBuffer,
-      options.basePath
+      context
     );
   }
 
@@ -61,28 +65,37 @@ export default async function parse3DTilesSubtree(data: ArrayBuffer, options): P
       subtree,
       'childSubtreeAvailability',
       internalBinaryBuffer,
-      options.basePath
+      context
     );
   }
 
   return subtree;
 }
 
-function resolveUri(uri, basePath) {
-  // url scheme per RFC3986
-  const urlSchemeRegex = /^[a-z][0-9a-z+.-]*:/i;
+/**
+ * Get url for bitstream downloading
+ * @param bitstreamRelativeUri
+ * @param baseUri
+ * @returns
+ */
+function resolveBufferUri(bitstreamRelativeUri: string, basePath: string): string {
+  const hasProtocol = basePath.startsWith('http');
 
-  if (urlSchemeRegex.test(basePath)) {
-    const url = new URL(uri, `${basePath}/`);
-    return decodeURI(url.toString());
-  } else if (uri.startsWith('/')) {
-    return uri;
-  } else if (uri.startsWith('../')) {
-    // Remove all relative paths.
-    return `${basePath}/${uri.replace(/\..\//g, '')}`;
+  if (hasProtocol) {
+    const resolvedUri = new URL(bitstreamRelativeUri, basePath);
+    return decodeURI(resolvedUri.toString());
   }
 
-  return `${basePath}/${uri}`;
+  /**
+   * Adding http protocol only for new URL constructor usage.
+   * It allows to resolve relative paths like ../../example with basePath.
+   */
+  const basePathWithProtocol = `http://${basePath}`;
+  const resolvedUri = new URL(bitstreamRelativeUri, basePathWithProtocol);
+  /**
+   * Drop protocol and use just relative path.
+   */
+  return `/${resolvedUri.host}${resolvedUri.pathname}`;
 }
 
 /**
@@ -95,16 +108,24 @@ async function getExplicitBitstream(
   subtree: Subtree,
   name: string,
   internalBinaryBuffer: ArrayBuffer,
-  basePath: string
+  context: LoaderContext | undefined
 ): Promise<ExplicitBitstream> {
   const bufferViewIndex = subtree[name].bufferView;
   const bufferView = subtree.bufferViews[bufferViewIndex];
   const buffer = subtree.buffers[bufferView.buffer];
 
+  if (!context?.url || !context.fetch) {
+    throw new Error('Url is not provided');
+  }
+
+  if (!context.fetch) {
+    throw new Error('fetch is not provided');
+  }
+
   // External bitstream loading
   if (buffer.uri) {
-    const bufferUri = resolveUri(buffer.uri, basePath);
-    const response = await fetchFile(bufferUri);
+    const bufferUri = resolveBufferUri(buffer.uri, context?.url);
+    const response = await context.fetch(bufferUri);
     const data = await response.arrayBuffer();
     // Return view of bitstream.
     return new Uint8Array(data, bufferView.byteOffset, bufferView.byteLength);

--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile-header.ts
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile-header.ts
@@ -70,9 +70,9 @@ export function normalizeTileData(tile, options) {
 }
 
 // normalize tile headers
-export async function normalizeTileHeaders(tileset: Tileset3D) {
+export async function normalizeTileHeaders(tileset: Tileset3D): Promise<Tileset3D> {
   const basePath = tileset.basePath;
-  let root;
+  let root: Tileset3D;
 
   const rootImplicitTilingExtension = getImplicitTilingExtensionData(tileset?.root);
   if (rootImplicitTilingExtension && tileset.root) {
@@ -123,9 +123,9 @@ export async function normalizeImplicitTileHeaders(
     subtreeLevels,
     subtrees: {uri: subtreesUriTemplate}
   } = implicitTilingExtension;
-  const subtreeUrl = replaceContentUrlTemplate(subtreesUriTemplate, 0, 0, 0, 0);
-  const rootSubtreeUrl = resolveUri(subtreeUrl, basePath);
-  const rootSubtree = await load(rootSubtreeUrl, Tile3DSubtreeLoader, {basePath});
+  const replacedUrlTemplate = replaceContentUrlTemplate(subtreesUriTemplate, 0, 0, 0, 0);
+  const subtreeUrl = resolveUri(replacedUrlTemplate, basePath);
+  const subtree = await load(subtreeUrl, Tile3DSubtreeLoader);
   const contentUrlTemplate = resolveUri(tile.content.uri, basePath);
   const refine = tileset?.root?.refine;
   // @ts-ignore
@@ -147,7 +147,7 @@ export async function normalizeImplicitTileHeaders(
     getRefine
   };
 
-  return await normalizeImplicitTileData(tile, rootSubtree, options);
+  return await normalizeImplicitTileData(tile, subtree, options);
 }
 
 /**
@@ -181,6 +181,13 @@ export async function normalizeImplicitTileData(tile, rootSubtree: Subtree, opti
   return tile;
 }
 
+/**
+ * Implicit Tiling data can be in 3DTILES_implicit_tiling for 3DTiles v.Next or directly in implicitTiling object for 3DTiles v1.1.
+ * Spec 3DTiles v.Next - https://github.com/CesiumGS/3d-tiles/tree/main/extensions/3DTILES_implicit_tiling
+ * Spec 3DTiles v.1.1 - https://github.com/CesiumGS/3d-tiles/tree/draft-1.1/specification/ImplicitTiling
+ * @param tile
+ * @returns
+ */
 function getImplicitTilingExtensionData(tile: Tile3D | null): ImplicitTilingExtension {
   return tile?.extensions?.['3DTILES_implicit_tiling'] || tile?.implicitTiling;
 }

--- a/modules/3d-tiles/src/tile-3d-subtree-loader.ts
+++ b/modules/3d-tiles/src/tile-3d-subtree-loader.ts
@@ -15,5 +15,5 @@ export const Tile3DSubtreeLoader: LoaderWithParser = {
   mimeTypes: ['application/octet-stream'],
   tests: ['subtree'],
   parse: parse3DTilesSubtree,
-  options: {}
+  options: {basePath: ''}
 };

--- a/modules/3d-tiles/src/tile-3d-subtree-loader.ts
+++ b/modules/3d-tiles/src/tile-3d-subtree-loader.ts
@@ -15,5 +15,5 @@ export const Tile3DSubtreeLoader: LoaderWithParser = {
   mimeTypes: ['application/octet-stream'],
   tests: ['subtree'],
   parse: parse3DTilesSubtree,
-  options: {basePath: ''}
+  options: {}
 };

--- a/modules/3d-tiles/src/tiles-3d-loader.ts
+++ b/modules/3d-tiles/src/tiles-3d-loader.ts
@@ -3,12 +3,7 @@ import {path} from '@loaders.gl/loader-utils';
 import {TILESET_TYPE, LOD_METRIC_TYPE} from '@loaders.gl/tiles';
 import {VERSION} from './lib/utils/version';
 import {parse3DTile} from './lib/parsers/parse-3d-tile';
-import {
-  normalizeTileHeaders,
-  normalizeImplicitTileHeaders
-} from './lib/parsers/parse-3d-tile-header';
-
-const IMPLICIT_TILING_EXTENSION_NAME = '3DTILES_implicit_tiling';
+import {normalizeTileHeaders} from './lib/parsers/parse-3d-tile-header';
 
 /**
  * Loader for 3D Tiles
@@ -54,9 +49,7 @@ async function parseTileset(data, options, context) {
   tilesetJson.url = context.url;
   // base path that non-absolute paths in tileset are relative to.
   tilesetJson.basePath = getBaseUri(tilesetJson);
-  tilesetJson.root = hasImplicitTilingExtension(tilesetJson)
-    ? await normalizeImplicitTileHeaders(tilesetJson)
-    : normalizeTileHeaders(tilesetJson);
+  tilesetJson.root = await normalizeTileHeaders(tilesetJson);
 
   tilesetJson.type = TILESET_TYPE.TILES3D;
 
@@ -83,11 +76,4 @@ async function parse(data, options, context) {
   }
 
   return data;
-}
-
-function hasImplicitTilingExtension(tilesetJson) {
-  return (
-    tilesetJson?.extensionsRequired?.includes(IMPLICIT_TILING_EXTENSION_NAME) &&
-    tilesetJson?.extensionsUsed?.includes(IMPLICIT_TILING_EXTENSION_NAME)
-  );
 }

--- a/modules/3d-tiles/src/types.ts
+++ b/modules/3d-tiles/src/types.ts
@@ -88,3 +88,18 @@ type BufferView = {
   byteOffset: number;
   byteLength: number;
 };
+
+/**
+ * Spec - https://github.com/CesiumGS/3d-tiles/tree/main/extensions/3DTILES_implicit_tiling
+ */
+export type ImplicitTilingExtension = {
+  subdivisionScheme: 'QUADTREE' | 'OCTREE';
+  maximumLevel?: number;
+  availableLevels: number;
+  subtreeLevels: number;
+  subtrees: SubtreeUri;
+};
+
+type SubtreeUri = {
+  uri: string;
+};

--- a/modules/gltf/src/index.ts
+++ b/modules/gltf/src/index.ts
@@ -40,3 +40,4 @@ export {default as GLTFScenegraph} from './lib/api/gltf-scenegraph';
 export {postProcessGLTF} from './lib/api/post-process-gltf';
 export type {Mesh} from './lib/types/gltf-json-schema';
 export type {GLTFObject} from './lib/types/gltf-types';
+export type {Node, Accessor, Image} from './lib/types/gltf-postprocessed-schema';

--- a/modules/gltf/src/lib/parsers/parse-gltf.ts
+++ b/modules/gltf/src/lib/parsers/parse-gltf.ts
@@ -201,10 +201,13 @@ async function loadImage(
 
   let arrayBuffer;
 
-  if (image.uri) {
+  if (image.uri && !image.bufferView) {
     const uri = resolveUrl(image.uri, options);
     const response = await fetch(uri);
     arrayBuffer = await response.arrayBuffer();
+    image.bufferView = {
+      data: arrayBuffer
+    };
   }
 
   if (Number.isFinite(image.bufferView)) {

--- a/modules/tile-converter/src/i3s-attributes-worker.ts
+++ b/modules/tile-converter/src/i3s-attributes-worker.ts
@@ -15,7 +15,7 @@ export type I3SAttributesWorkerOptions = {
 
 export type B3DMAttributesData = {
   gltfMaterials?: {id: string}[];
-  nodes: any;
+  nodes: any[];
   cartographicOrigin: Vector3;
   cartesianModelMatrix: Matrix4;
 };

--- a/modules/tile-converter/src/i3s-attributes-worker.ts
+++ b/modules/tile-converter/src/i3s-attributes-worker.ts
@@ -1,6 +1,7 @@
 import type {WorkerObject} from '@loaders.gl/worker-utils';
 import type {ConvertedAttributes} from './i3s-converter/types';
 import type {Matrix4, Vector3} from '@math.gl/core';
+import type {Node} from '@loaders.gl/gltf';
 
 import {processOnWorker} from '@loaders.gl/worker-utils';
 
@@ -15,7 +16,7 @@ export type I3SAttributesWorkerOptions = {
 
 export type B3DMAttributesData = {
   gltfMaterials?: {id: string}[];
-  nodes: any[];
+  nodes: Node[];
   cartographicOrigin: Vector3;
   cartesianModelMatrix: Matrix4;
 };

--- a/modules/tile-converter/src/i3s-converter/helpers/batch-ids-extensions.ts
+++ b/modules/tile-converter/src/i3s-converter/helpers/batch-ids-extensions.ts
@@ -151,6 +151,10 @@ function generateBatchIdsFromTexture(
   textureCoordinates: Float32Array,
   images: Image[]
 ) {
+  if (!images?.length) {
+    return [];
+  }
+
   const CHANNELS_MAP = {
     r: 0,
     g: 1,

--- a/modules/tile-converter/src/i3s-converter/helpers/gltf-attributes.ts
+++ b/modules/tile-converter/src/i3s-converter/helpers/gltf-attributes.ts
@@ -1,5 +1,5 @@
 import type {B3DMContent} from '@loaders.gl/3d-tiles';
-import type {Accessor, Image, Node} from 'modules/gltf/src/lib/types/gltf-postprocessed-schema';
+import type {Accessor, Image, Node} from '@loaders.gl/gltf';
 import type {B3DMAttributesData} from '../../i3s-attributes-worker';
 
 type AttributesObject = {
@@ -63,7 +63,7 @@ export function prepareDataForAttributesConversion(tileContent: B3DMContent): B3
 }
 
 /**
- * Traverse all nodes to replace all sensible data with copy.
+ * Traverse all nodes to replace all sensible data with copy to avoid data corruption in worker.
  * @param nodes
  * @param images
  */

--- a/modules/tiles/src/tileset/tile-3d.ts
+++ b/modules/tiles/src/tileset/tile-3d.ts
@@ -61,6 +61,7 @@ export default class TileHeader {
   viewportIds: any[];
   transform: Matrix4;
   extensions: any;
+  implicitTiling?: any;
 
   // Container to store application specific data
   userData: {[key: string]: any};
@@ -205,6 +206,7 @@ export default class TileHeader {
     // TODO Cesium 3d tiles specific
     this._expireDate = null;
     this._expiredContent = null;
+    this.implicitTiling = null;
 
     Object.seal(this);
   }


### PR DESCRIPTION
In 3DTiles, not only the root tile can be implicit, but also the child tile. We have to deal with this as well.