### PR TITLE
fix(3d-tiles): add options to normalizeTileHeaders

### DIFF
--- a/modules/3d-tiles/src/tiles-3d-loader.ts
+++ b/modules/3d-tiles/src/tiles-3d-loader.ts
@@ -49,7 +49,7 @@ async function parseTileset(data, options, context) {
   tilesetJson.url = context.url;
   // base path that non-absolute paths in tileset are relative to.
   tilesetJson.basePath = getBaseUri(tilesetJson);
-  tilesetJson.root = await normalizeTileHeaders(tilesetJson);
+  tilesetJson.root = await normalizeTileHeaders(tilesetJson, options);
 
   tilesetJson.type = TILESET_TYPE.TILES3D;
 


### PR DESCRIPTION
To download implicit tiling subtrees from cesium we need to pass token in options. 