### PR TITLE
fix(tile-converter): install deps test

### DIFF
--- a/modules/tile-converter/src/deps-installer/deps-installer.ts
+++ b/modules/tile-converter/src/deps-installer/deps-installer.ts
@@ -4,7 +4,7 @@ import {writeFile} from '../lib/utils/file-utils';
 import {join} from 'path';
 
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
-const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'beta';
 
 const PGM_LINK = 'https://raw.githubusercontent.com/visgl/deck.gl-data/master/egm/egm2008-5.zip';
 

--- a/modules/tile-converter/src/deps-installer/deps-installer.ts
+++ b/modules/tile-converter/src/deps-installer/deps-installer.ts
@@ -18,7 +18,9 @@ export class DepsInstaller {
   /**
    * Run instalation
    * @param path destination folder
-   * @param workersPath destination folder for workers
+   * @param workersPath destination folder for workers.
+   *    This path is '' by default and is not used by tile-converter.
+   *    It is used in tests to prevent rewriting actual workers during tests running
    */
   async install(path: string = '', workersPath: string = ''): Promise<void> {
     console.log('Installing "EGM2008-5" model...'); // eslint-disable-line no-console

--- a/modules/tile-converter/src/deps-installer/deps-installer.ts
+++ b/modules/tile-converter/src/deps-installer/deps-installer.ts
@@ -18,8 +18,9 @@ export class DepsInstaller {
   /**
    * Run instalation
    * @param path destination folder
+   * @param workersPath destination folder for workers
    */
-  async install(path: string = ''): Promise<void> {
+  async install(path: string = '', workersPath: string = ''): Promise<void> {
     console.log('Installing "EGM2008-5" model...'); // eslint-disable-line no-console
     const fileMap = await load(PGM_LINK, ZipLoader, {});
 
@@ -31,18 +32,18 @@ export class DepsInstaller {
     await writeFile(depsPath, new Uint8Array(fileMap['geoids/egm2008-5.pgm']), 'egm2008-5.pgm');
 
     console.log('Installing "I3S Content Loader worker"'); // eslint-disable-line no-console
-    await this.installWorker('i3s', 'i3s-content-nodejs-worker.js');
+    await this.installWorker('i3s', 'i3s-content-nodejs-worker.js', workersPath);
 
     console.log('Installing "Draco Loader worker"'); // eslint-disable-line no-console
-    await this.installWorker('draco', 'draco-nodejs-worker.js');
+    await this.installWorker('draco', 'draco-nodejs-worker.js', workersPath);
 
     console.log('Installing "Basis Loader worker"'); // eslint-disable-line no-console
-    await this.installWorker('textures', 'basis-nodejs-worker.js');
+    await this.installWorker('textures', 'basis-nodejs-worker.js', workersPath);
 
     console.log('All dependencies were installed succesfully.'); // eslint-disable-line no-console
   }
 
-  private async installWorker(module: string, name: string) {
+  private async installWorker(module: string, name: string, extraPath: string) {
     const fileResponse = await fetchFile(
       `https://unpkg.com/@loaders.gl/${module}@${VERSION}/dist/${name}`
     );
@@ -50,7 +51,7 @@ export class DepsInstaller {
     if (!fileData) {
       return;
     }
-    const path = join(process.cwd(), 'modules', module, 'dist');
+    const path = join(process.cwd(), extraPath, 'modules', module, 'dist');
     await writeFile(path, fileData, name);
   }
 }

--- a/modules/tile-converter/test/deps-installer/deps-installer.spec.js
+++ b/modules/tile-converter/test/deps-installer/deps-installer.spec.js
@@ -7,10 +7,14 @@ import {cleanUpPath, isFileExists} from '../utils/file-utils';
 test('tile-converter Install dependencies', async (t) => {
   if (!isBrowser) {
     const depsInstaller = new DepsInstaller();
-    await depsInstaller.install('tmp');
+    await depsInstaller.install('tmp', 'tmp-workers');
 
     t.ok(await isFileExists('tmp/egm2008-5.pgm'));
+    t.ok(await isFileExists('tmp-workers/modules/i3s/dist/i3s-content-nodejs-worker.js'));
+    t.ok(await isFileExists('tmp-workers/modules/draco/dist/draco-nodejs-worker.js'));
+    t.ok(await isFileExists('tmp-workers/modules/textures/dist/basis-nodejs-worker.js'));
   }
   await cleanUpPath('tmp');
+  await cleanUpPath('tmp-workers');
   t.end();
 });


### PR DESCRIPTION
Prevent `install-dependencies` from rewriting actual workers during tests