### PR TITLE
Tiles3DLoader: pass query parameters used on tileset request onto tile requests

### DIFF
--- a/docs/developer-guide/creating-loaders-and-writers.md
+++ b/docs/developer-guide/creating-loaders-and-writers.md
@@ -66,6 +66,10 @@ Remarks:
 
 - While a loader could potentially import `parse` from `@loaders.gl/core` to invoke a sub-loader, it is discouraged, not only from a dependency management reasons, but it prevents loaders.gl from properly handling parameters and allow worker-loaders to call other loaders.
 
+## LoaderContext
+
+When a loader is being called (i.e. one of its `parse*()` functions is being called), a `LoaderContext` object is supplied.
+
 ## Accessing the Response object
 
 Loaders will often use the [fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) to retrieve data. In most cases, a loader will only be concerned with the data payload, but in some cases it may be desirable to access the underlying [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) object, available on the `context` parameter.

--- a/docs/modules/3d-tiles/api-reference/tiles-3d-loader.md
+++ b/docs/modules/3d-tiles/api-reference/tiles-3d-loader.md
@@ -73,7 +73,7 @@ const visibleTiles = tileset3d.tiles.filter(tile => tile.selected);
 | Option               | Type             | Default | Description                                                                                                                                                           |
 | -------------------- | ---------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `3d-tiles.isTileset` | `Bool` or `auto` | `auto`  | Whether to load a `Tileset` file. If `auto`, will infer based on url extension.                                                                                       |
-| `3d-tiles.headers`   | Object           | null    | Used to load data from server                                                                                                                                         |
+| `3d-tiles.headers`   | `Object`         | `null`  | Used to load data from server                                                                                                                                         |
 | `3d-tiles.tileset`   | `Object`         | `null`  | `Tileset` object loaded by `Tiles3DLoader` or follow the data format specified in [Tileset Object](#tileset-object). It is required when loading i3s geometry content |
 | `3d-tiles.tile`      | `Object`         | `null`  | `Tile` object loaded by `Tiles3DLoader` or follow the data format [Tile Object](#tile-object). It is required when loading i3s geometry content                       |
 

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -113,6 +113,14 @@ Target Release Date: April, 2023.
 
 - Support TRIANGLE_STRIP mesh topology type during 3DTiles -> I3S conversion
 
+**@loaders.gl/tiles**
+
+-  Now passes "query string" parameters from the URL passed to `Tiles3DLoader` etc to subloaders, enabling query string based authentication of 3D tilesets (`https://tileset-url?apiToken=...`).
+
+**@loaders.gl/core**
+
+- `LoaderContext` now provides a `queryString` field, primarily intended to make it easier for subloaders to access query string based authentication paramets.
+
 ## v3.3
 
 Release Date: February 17, 2023.

--- a/modules/3d-tiles/src/lib/parsers/helpers/parse-3d-tile-subtree.ts
+++ b/modules/3d-tiles/src/lib/parsers/helpers/parse-3d-tile-subtree.ts
@@ -75,7 +75,7 @@ export default async function parse3DTilesSubtree(
 /**
  * Get url for bitstream downloading
  * @param bitstreamRelativeUri
- * @param baseUri
+ * @param basePath
  * @returns
  */
 function resolveBufferUri(bitstreamRelativeUri: string, basePath: string): string {

--- a/modules/3d-tiles/src/tiles-3d-loader.ts
+++ b/modules/3d-tiles/src/tiles-3d-loader.ts
@@ -47,6 +47,8 @@ async function parseTileset(data, options, context) {
   // eslint-disable-next-line no-use-before-define
   tilesetJson.loader = options.loader || Tiles3DLoader;
   tilesetJson.url = context.url;
+  tilesetJson.queryString = context.queryString;
+
   // base path that non-absolute paths in tileset are relative to.
   tilesetJson.basePath = getBaseUri(tilesetJson);
   tilesetJson.root = await normalizeTileHeaders(tilesetJson, options);

--- a/modules/core/src/lib/api/parse-sync.ts
+++ b/modules/core/src/lib/api/parse-sync.ts
@@ -11,7 +11,7 @@ import {isLoaderObject} from '../loader-utils/normalize-loader';
 import {normalizeOptions} from '../loader-utils/option-utils';
 import {getArrayBufferOrStringFromDataSync} from '../loader-utils/get-data';
 import {getLoaderContext, getLoadersFromContext} from '../loader-utils/loader-context';
-import {getResourceUrlAndType} from '../utils/resource-utils';
+import {getResourceUrl} from '../utils/resource-utils';
 
 /**
  * Parses `data` synchronously using a specified loader
@@ -52,12 +52,16 @@ export function parseSync(
   options = normalizeOptions(options, loader, candidateLoaders);
 
   // Extract a url for auto detection
-  const {url} = getResourceUrlAndType(data);
+  const url = getResourceUrl(data);
 
   const parse = () => {
-    throw new Error('parseSync called parse');
+    throw new Error('parseSync called parse (which is async');
   };
-  context = getLoaderContext({url, parseSync, parse, loaders: loaders as Loader[]}, options);
+  context = getLoaderContext(
+    {url, parseSync, parse, loaders: loaders as Loader[]},
+    options,
+    context || null
+  );
 
   return parseWithLoaderSync(loader as LoaderWithParser, data, options, context);
 }

--- a/modules/core/src/lib/api/parse.ts
+++ b/modules/core/src/lib/api/parse.ts
@@ -6,7 +6,7 @@ import {isResponse} from '../../javascript-utils/is-type';
 import {normalizeOptions} from '../loader-utils/option-utils';
 import {getArrayBufferOrStringFromData} from '../loader-utils/get-data';
 import {getLoaderContext, getLoadersFromContext} from '../loader-utils/loader-context';
-import {getResourceUrlAndType} from '../utils/resource-utils';
+import {getResourceUrl} from '../utils/resource-utils';
 import {selectLoader} from './select-loader';
 
 /**
@@ -36,7 +36,7 @@ export async function parse(
   options = options || {};
 
   // Extract a url for auto detection
-  const {url} = getResourceUrlAndType(data);
+  const url = getResourceUrl(data);
 
   // Chooses a loader (and normalizes it)
   // Also use any loaders in the context, new loaders take priority
@@ -53,7 +53,7 @@ export async function parse(
   options = normalizeOptions(options, loader, candidateLoaders, url);
 
   // Get a context (if already present, will be unchanged)
-  context = getLoaderContext({url, parse, loaders: candidateLoaders}, options, context);
+  context = getLoaderContext({url, parse, loaders: candidateLoaders}, options, context || null);
 
   return await parseWithLoader(loader, data, options, context);
 }

--- a/modules/core/src/lib/api/select-loader.ts
+++ b/modules/core/src/lib/api/select-loader.ts
@@ -2,9 +2,10 @@ import type {LoaderContext, LoaderOptions, Loader} from '@loaders.gl/loader-util
 import {compareArrayBuffers, path} from '@loaders.gl/loader-utils';
 import {normalizeLoader} from '../loader-utils/normalize-loader';
 import {log} from '../utils/log';
-import {getResourceUrlAndType} from '../utils/resource-utils';
+import {getResourceUrl, getResourceMIMEType} from '../utils/resource-utils';
 import {getRegisteredLoaders} from './register-loaders';
 import {isBlob} from '../../javascript-utils/is-type';
+import {stripQueryString} from '../utils/url-utils';
 
 const EXT_PATTERN = /\.([^.]+)$/;
 
@@ -111,9 +112,10 @@ function selectLoaderInternal(
   options?: LoaderOptions,
   context?: LoaderContext
 ) {
-  const {url, type} = getResourceUrlAndType(data);
+  const url = getResourceUrl(data);
+  const type = getResourceMIMEType(data);
 
-  const testUrl = url || context?.url;
+  const testUrl = stripQueryString(url) || context?.url;
 
   let loader: Loader | null = null;
   let reason: string = '';
@@ -161,7 +163,8 @@ function validHTTPResponse(data: any): boolean {
 
 /** Generate a helpful message to help explain why loader selection failed. */
 function getNoValidLoaderMessage(data): string {
-  const {url, type} = getResourceUrlAndType(data);
+  const url = getResourceUrl(data);
+  const type = getResourceMIMEType(data);
 
   let message = 'No valid loader found (';
   message += url ? `${path.filename(url)}, ` : 'no url provided, ';

--- a/modules/core/src/lib/utils/response-utils.ts
+++ b/modules/core/src/lib/utils/response-utils.ts
@@ -1,5 +1,5 @@
 import {isResponse} from '../../javascript-utils/is-type';
-import {getResourceContentLength, getResourceUrlAndType} from './resource-utils';
+import {getResourceContentLength, getResourceUrl, getResourceMIMEType} from './resource-utils';
 
 /**
  * Returns a Response object
@@ -22,7 +22,8 @@ export async function makeResponse(resource: any): Promise<Response> {
 
   // `new Response(File)` does not preserve content-type and URL
   // so we add them here
-  const {url, type} = getResourceUrlAndType(resource);
+  const url = getResourceUrl(resource);
+  const type = getResourceMIMEType(resource);
   if (type) {
     headers['content-type'] = type;
   }

--- a/modules/core/src/lib/utils/url-utils.ts
+++ b/modules/core/src/lib/utils/url-utils.ts
@@ -1,0 +1,12 @@
+// loaders.gl, MIT license
+
+const QUERY_STRING_PATTERN = /\?.*/;
+
+export function extractQueryString(url): string {
+  const matches = url.match(QUERY_STRING_PATTERN);
+  return matches && matches[0];
+}
+
+export function stripQueryString(url): string {
+  return url.replace(QUERY_STRING_PATTERN, '');
+}

--- a/modules/core/test/lib/utils/resource-utils.spec.js
+++ b/modules/core/test/lib/utils/resource-utils.spec.js
@@ -1,22 +1,17 @@
 import test from 'tape-promise/tape';
 import {isBrowser} from '@loaders.gl/core';
 import {
-  getResourceUrlAndType,
+  getResourceUrl,
+  getResourceMIMEType,
   getResourceContentLength
 } from '@loaders.gl/core/lib/utils/resource-utils';
 
 const DATA_URL =
   'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACAQMAAABIeJ9nAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAGUExURf///wAAAFXC034AAAAMSURBVAjXY3BgaAAAAUQAwetZAwkAAAAASUVORK5CYII=';
 
-test('getResourceUrlAndType', (t) => {
-  t.deepEqual(getResourceUrlAndType(DATA_URL), {type: 'image/png', url: DATA_URL});
-
+test('getResourceUrl', (t) => {
   const blob = new Blob(['abc'], {type: 'application/text'});
-  t.deepEqual(getResourceUrlAndType(blob), {type: 'application/text', url: ''});
-
   const file = new File(['abc'], 'filename.csv', {type: 'text/csv'});
-  t.deepEqual(getResourceUrlAndType(file), {type: 'text/csv', url: 'filename.csv'});
-
   const response = new Response(new Blob(['abc']), {
     status: 200,
     statusText: 'Success',
@@ -27,10 +22,33 @@ test('getResourceUrlAndType', (t) => {
   // Inject a url property for testing, since url is read only property for the Response class
   Object.defineProperty(response, 'url', {value: 'https://abc.com/file.json?variable=value'});
 
-  t.deepEqual(getResourceUrlAndType(response), {
-    type: 'application/json',
-    url: 'https://abc.com/file.json'
+  t.deepEqual(getResourceUrl(DATA_URL), DATA_URL);
+  t.deepEqual(getResourceUrl(blob), '');
+  t.deepEqual(getResourceUrl(file), 'filename.csv');
+
+  t.deepEqual(getResourceUrl(response), 'https://abc.com/file.json?variable=value');
+
+  t.end();
+});
+
+test('getResourceMIMEType', (t) => {
+  const blob = new Blob(['abc'], {type: 'application/text'});
+  const file = new File(['abc'], 'filename.csv', {type: 'text/csv'});
+  const response = new Response(new Blob(['abc']), {
+    status: 200,
+    statusText: 'Success',
+    headers: {
+      'content-type': 'application/json'
+    }
   });
+  // Inject a url property for testing, since url is read only property for the Response class
+  Object.defineProperty(response, 'url', {value: 'https://abc.com/file.json?variable=value'});
+
+  t.deepEqual(getResourceMIMEType(DATA_URL), 'image/png');
+  t.deepEqual(getResourceMIMEType(blob), 'application/text');
+  t.deepEqual(getResourceMIMEType(file), 'text/csv');
+
+  t.deepEqual(getResourceMIMEType(response), 'application/json');
 
   t.end();
 });

--- a/modules/loader-utils/src/types.ts
+++ b/modules/loader-utils/src/types.ts
@@ -118,15 +118,22 @@ type PreloadOptions = {
 export type Loader = {
   // Worker
   name: string;
+  /** id should be the same as the field used in LoaderOptions */
   id: string;
+  /** module is used to generate worker threads, need to be the module directory name */
   module: string;
+  /** Version should be injected by build tools */
   version: string;
+  /** A boolean, or a URL */
   worker?: string | boolean;
+  /** Default Options */
   options: LoaderOptions;
+  /** Deprecated Options */
   deprecatedOptions?: object;
-  // end Worker
 
+  /** Which category does this loader belong to */
   category?: string;
+  /** What extensions does this loader generate */
   extensions: string[];
   mimeTypes: string[];
 
@@ -192,24 +199,48 @@ export type Writer = {
   encodeText?: EncodeText;
 };
 
+/**
+ * A Loader context is provided as a third parameters to a loader object's
+ * parse functions when that loader is called by other loaders rather then
+ * directly by the application.
+ *
+ * - The context object allows the subloaders to be aware of the parameters and
+ *   options that the application provided in the top level call.
+ * - The context also providedsaccess to parse functions so that the subloader
+ *   does not need to include the core module.
+ * - In addition, the context's parse functions may also redirect loads from worker
+ *   threads back to main thread.
+ */
 export type LoaderContext = {
   loaders?: Loader[] | null;
+  /** If URL is available.  */
   url?: string;
+  /** the file name component of the URL (leading path and query string removed) */
+  filename?: string;
+  /** the directory name component of the URL (leading path excluding file name and query string) */
+  baseUrl?: string;
+  /** Query string (characters after `?`) */
+  queryString?: string;
 
+  /** Provides access to any application overrides of fetch() */
   fetch: typeof fetch | FetchLike;
+  /** TBD */
   response?: Response;
+  /** Parse function. Use instead of importing `core`. In workers, may redirect to main thread */
   parse: (
     arrayBuffer: ArrayBuffer,
     loaders?: Loader | Loader[] | LoaderOptions,
     options?: LoaderOptions,
     context?: LoaderContext
   ) => Promise<any>;
+  /** ParseSync function. Use instead of importing `core`. In workers, may redirect to main thread */
   parseSync?: (
     arrayBuffer: ArrayBuffer,
     loaders?: Loader | Loader[] | LoaderOptions,
     options?: LoaderOptions,
     context?: LoaderContext
   ) => any;
+  /** ParseInBatches function. Use instead of importing `core`.  */
   parseInBatches?: (
     iterator: AsyncIterable<ArrayBuffer> | Iterable<ArrayBuffer>,
     loaders?: Loader | Loader[] | LoaderOptions,

--- a/modules/tiles/src/tileset/tileset-3d.ts
+++ b/modules/tiles/src/tileset/tileset-3d.ts
@@ -361,7 +361,7 @@ export class Tileset3D {
   }
 
   get queryParams(): string {
-    const search = new URLSearchParams(this._queryParams).toString()
+    const search = new URLSearchParams(this._queryParams).toString();
     return search ? `?${search}` : search;
   }
 
@@ -963,7 +963,7 @@ export class Tileset3D {
 
   _initializeI3STileset() {
     if (this.loadOptions.i3s && 'token' in this.loadOptions.i3s) {
-      this._queryParams.token = this.loadOptions.i3s.token
+      this._queryParams.token = this.loadOptions.i3s.token;
     }
   }
 }

--- a/modules/tiles/src/tileset/tileset-3d.ts
+++ b/modules/tiles/src/tileset/tileset-3d.ts
@@ -244,8 +244,7 @@ export class Tileset3D {
   _requestScheduler: RequestScheduler;
 
   _frameNumber: number;
-  private _queryParamsString: string;
-  private _queryParams: any;
+  private _queryParams: Record<string, string> = {};
   private _extensionsUsed: any;
   private _tiles: {[id: string]: Tile3D};
 
@@ -321,9 +320,6 @@ export class Tileset3D {
     this.frameStateData = {};
     this.lastUpdatedVieports = null;
 
-    this._queryParams = {};
-    this._queryParamsString = '';
-
     // METRICS
     // The maximum amount of GPU memory (in MB) that may be used to cache tiles.
     // Tiles not in view are unloaded to enforce this.
@@ -365,10 +361,8 @@ export class Tileset3D {
   }
 
   get queryParams(): string {
-    if (!this._queryParamsString) {
-      this._queryParamsString = new URLSearchParams(this._queryParams).toString();
-    }
-    return this._queryParamsString;
+    const search = new URLSearchParams(this._queryParams).toString()
+    return search ? `?${search}` : search;
   }
 
   setProps(props: Tileset3DProps): void {
@@ -930,6 +924,12 @@ export class Tileset3D {
   }
 
   _initializeTiles3DTileset(tilesetJson) {
+    if (tilesetJson.queryString) {
+      const searchParams = new URLSearchParams(tilesetJson.queryString);
+      const queryParams = Object.fromEntries(searchParams.entries());
+      this._queryParams = {...this._queryParams, ...queryParams};
+    }
+
     this.asset = tilesetJson.asset;
     if (!this.asset) {
       throw new Error('Tileset must have an asset property.');
@@ -960,7 +960,7 @@ export class Tileset3D {
 
   _initializeI3STileset() {
     if (this.loadOptions.i3s && 'token' in this.loadOptions.i3s) {
-      this._queryParams.token = this.loadOptions.i3s.token;
+      this._queryParams.token = this.loadOptions.i3s.token
     }
   }
 }

--- a/modules/tiles/src/tileset/tileset-3d.ts
+++ b/modules/tiles/src/tileset/tileset-3d.ts
@@ -728,11 +728,14 @@ export class Tileset3D {
         for (const childHeader of children) {
           const childTile = new Tile3D(this, childHeader, tile);
 
-          // Special handling for Google 3D tiles
+          // Special handling for Google
           // A session key must be used for all tile requests
           if (childTile.contentUrl?.includes('?session=')) {
             const url = new URL(childTile.contentUrl);
-            this._queryParams.session = url.searchParams.get('session');
+            const session = url.searchParams.get('session');
+            if (session) {
+              this._queryParams.session = session;
+            }
           }
 
           tile.children.push(childTile);

--- a/modules/tiles/test/tileset/tileset-3d.spec.js
+++ b/modules/tiles/test/tileset/tileset-3d.spec.js
@@ -216,6 +216,13 @@ test('Tileset3D#hasExtension returns true if the tileset JSON file uses the spec
   t.end();
 });
 
+test('Tileset3D#passes query parameters onto child requests', async (t) => {
+  const queryString = '?a=123&b=abc';
+  const tilesetJson = await load(TILESET_URL + queryString, Tiles3DLoader);
+  const tileset = new Tileset3D(tilesetJson);
+  t.equals(tileset.queryParams, '?a=123&b=abc&v=1.2.3');
+  t.end();
+});
 /*
 test('Tileset3D#passes version in query string to tiles', async t => {
   const tilesetJson = await load(TILESET_URL, Tiles3DLoader);


### PR DESCRIPTION
Some tile servers require query parameters to be appended to requests when requesting 3D tiles, a common one being adding an API key. Currently, this is only achievable in deck.gl by using `onTilesetLoad` in a rather hacky way:

```js
new Tile3DLayer({
  id: 'tile-3d-layer',
  data: "http://www.tileserver.com/tileset.json?key=KEY",
  onTilesetLoad: tileset3d => {
     tileset3d._queryParams = {key: "KEY"};
  }
});
```

This PR enhances Tileset3D so that it passes the query parameters on to tile requests as well as the initial tileset request, thus removing the need for the above hack. 

This is in line with how Cesium works: https://github.com/CesiumGS/3d-tiles/issues/484