### PR TITLE
fix(tiles): Viewport type

### DIFF
--- a/modules/tiles/src/tileset/helpers/frame-state.ts
+++ b/modules/tiles/src/tileset/helpers/frame-state.ts
@@ -175,7 +175,7 @@ function closestPointOnPlane(
 
 function worldToCartesian(
   viewport: Viewport,
-  point: [number, number, number] | Vector3,
+  point: number[] | Vector3,
   out: Vector3 = new Vector3()
 ): Vector3 {
   const cartographicPos = viewport.unprojectPosition(point);

--- a/modules/tiles/src/types.ts
+++ b/modules/tiles/src/types.ts
@@ -9,16 +9,17 @@ export type BoundingRectangle = {
  * We can't import it from Deck.gl to avoid circular reference */
 export type Viewport = {
   id: string;
-  cameraPosition: [number, number, number];
+  cameraPosition: number[] | Vector3;
   height: number;
   width: number;
   zoom: number;
   distanceScales: {
-    metersPerUnit: number;
+    unitsPerMeter: number[];
+    metersPerUnit: number[];
   };
-  center: [number, number, number];
-  unprojectPosition: (position: [number, number, number] | Vector3) => Vector3;
-  project: (coorinates: [number, number, number] | Vector3) => Vector3;
+  center: number[] | Vector3;
+  unprojectPosition: (position: number[] | Vector3) => [number, number, number];
+  project: (coorinates: number[] | Vector3) => number[];
 };
 
 /**


### PR DESCRIPTION
Follow-up to https://github.com/visgl/loaders.gl/pull/2258

The previous fix still didn't work in deck.gl (try linking in a local copy of `@loaders.gl/tiles` and running `yarn tsbuild`). With the changes below the build succeeds in both loaders and deck.