### PR TITLE
parquet: slightly simpler arrow api

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -21,7 +21,15 @@
 
 See [roadmap](./roadmap) for more details on planned development.
 
-## v3.2 (In development)
+## v3.3 (In Development)
+
+Release Date: TBD, Q1-2022
+
+**@loaders.gl/arrow**
+
+- Now uses `apache-arrow` v9
+
+## v3.2
 
 Target Release Date: Q1 2022.
 
@@ -58,7 +66,6 @@ Target Release Date: Q1 2022.
 **@loaders.gl/textures**
 
 - Upgrade `basis_universal` libraries to [v1.16.3](https://github.com/BinomialLLC/basis_universal/releases/tag/1.16.3).
-
 ## v3.1
 
 Release Date: Dec 7, 2021.

--- a/modules/arrow/package.json
+++ b/modules/arrow/package.json
@@ -32,12 +32,15 @@
   },
   "scripts": {
     "pre-build": "npm run build-worker && npm run build-bundle",
-    "build-bundle": "esbuild src/bundle.ts --bundle --outfile=dist/dist.min.js",
-    "build-worker": "esbuild src/workers/arrow-worker.ts --bundle --outfile=dist/arrow-worker.js --define:__VERSION__=\\\"$npm_package_version\\\""
+    "build-bundle": "esbuild src/bundle.ts --bundle --outfile=dist/dist.min.js --platform=browser --external:{stream}",
+    "build-worker": "esbuild src/workers/arrow-worker.ts --bundle --outfile=dist/arrow-worker.js  --platform=browser --external:{stream} --define:__VERSION__=\\\"$npm_package_version\\\"",
+    "pre-build2": "cp fixed-package.json ../../node_modules/apache-arrow/package.json && npm run build-bundle && npm run build-worker",
+    "build-bundle2": "esbuild src/bundle.ts --bundle --outfile=dist/bundle.js --platform=browser --external:{stream}",
+    "build-worker2": "esbuild src/workers/arrow-worker.ts --bundle --outfile=dist/arrow-worker.js --platform=browser --external:{stream}"
   },
   "dependencies": {
     "@loaders.gl/loader-utils": "3.3.0-alpha.5",
     "@loaders.gl/schema": "3.3.0-alpha.5",
-    "apache-arrow": "^4.0.0"
+    "apache-arrow": "^9.0.0"
   }
 }

--- a/modules/arrow/src/arrow-loader.ts
+++ b/modules/arrow/src/arrow-loader.ts
@@ -22,7 +22,7 @@ export const ArrowLoader = {
   id: 'arrow',
   module: 'arrow',
   version: VERSION,
-  worker: true,
+  // worker: true,
   category: 'table',
   extensions: ['arrow', 'feather'],
   mimeTypes: [

--- a/modules/arrow/src/lib/arrow-table-batch.ts
+++ b/modules/arrow/src/lib/arrow-table-batch.ts
@@ -1,5 +1,14 @@
 import type {ArrowTableBatch} from '@loaders.gl/schema';
-import {Schema, Field, RecordBatch, Float32Vector, Float32} from 'apache-arrow';
+import {
+  Schema,
+  Field,
+  RecordBatch,
+  Struct,
+  makeVector,
+  makeData,
+  Vector,
+  Float32
+} from 'apache-arrow';
 import {ColumnarTableBatchAggregator} from '@loaders.gl/schema';
 
 export default class ArrowTableBatchAggregator extends ColumnarTableBatchAggregator {
@@ -15,11 +24,19 @@ export default class ArrowTableBatchAggregator extends ColumnarTableBatchAggrega
     if (batch) {
       // Get the arrow schema
       this.arrowSchema = this.arrowSchema || getArrowSchema(batch.schema);
+
       // Get arrow format vectors
       const arrowVectors = getArrowVectors(this.arrowSchema, batch.data);
+
       // Create the record batch
-      // new RecordBatch(schema, numRows, vectors, ...);
-      const recordBatch = new RecordBatch(this.arrowSchema, batch.length, arrowVectors);
+      const recordBatch = new RecordBatch(
+        this.arrowSchema,
+        makeData({
+          type: new Struct(this.arrowSchema.fields),
+          children: arrowVectors.map(({data}) => data[0])
+        })
+      );
+
       return {
         shape: 'arrow-table',
         batchType: 'data',
@@ -33,12 +50,13 @@ export default class ArrowTableBatchAggregator extends ColumnarTableBatchAggrega
 }
 
 // Convert from a simple loaders.gl schema to an Arrow schema
-function getArrowSchema(schema) {
+function getArrowSchema(schema): Schema {
   const arrowFields: Field[] = [];
   for (const key in schema) {
     const field = schema[key];
     if (field.type === Float32Array) {
-      const metadata = field; // just store the original field as metadata
+      // TODO - just store the original field as metadata?
+      const metadata = new Map(); // field;
       // arrow: new Field(name, nullable, metadata)
       const arrowField = new Field(field.name, new Float32(), field.nullable, metadata);
       arrowFields.push(arrowField);
@@ -52,12 +70,12 @@ function getArrowSchema(schema) {
 }
 
 // Convert from simple loaders.gl arrays to arrow vectors
-function getArrowVectors(arrowSchema, data) {
+function getArrowVectors(arrowSchema, data): Vector[] {
   const arrowVectors: any[] = [];
   for (const field of arrowSchema.fields) {
     const vector = data[field.name];
     if (vector instanceof Float32Array) {
-      const arrowVector = Float32Vector.from(vector);
+      const arrowVector = makeVector(vector);
       arrowVectors.push(arrowVector);
     }
   }

--- a/modules/arrow/src/lib/encode-arrow.ts
+++ b/modules/arrow/src/lib/encode-arrow.ts
@@ -1,4 +1,4 @@
-import {Table, FloatVector, DateVector} from 'apache-arrow';
+import {Table, Vector, tableToIPC, vectorFromArray} from 'apache-arrow';
 import {AnyArrayType, VECTOR_TYPES} from '../types';
 
 type ColumnarTable = {
@@ -15,15 +15,13 @@ type ColumnarTable = {
  * @returns - encoded ArrayBuffer
  */
 export function encodeArrowSync(data: ColumnarTable): ArrayBuffer {
-  const vectors: any[] = [];
-  const arrayNames: string[] = [];
+  const vectors: Record<string, Vector> = {};
   for (const arrayData of data) {
-    arrayNames.push(arrayData.name);
     const arrayVector = createVector(arrayData.array, arrayData.type);
-    vectors.push(arrayVector);
+    vectors[arrayData.name] = arrayVector;
   }
-  const table = Table.new(vectors, arrayNames);
-  const arrowBuffer = table.serialize();
+  const table = new Table(vectors);
+  const arrowBuffer = tableToIPC(table);
   return arrowBuffer;
 }
 
@@ -33,12 +31,12 @@ export function encodeArrowSync(data: ColumnarTable): ArrayBuffer {
  * @param type {number} - the writer options
  * @return a vector of one of vector's types defined in the Apache Arrow library
  */
-function createVector(array, type) {
+function createVector(array, type): Vector {
   switch (type) {
     case VECTOR_TYPES.DATE:
-      return DateVector.from(array);
+      return vectorFromArray(array);
     case VECTOR_TYPES.FLOAT:
     default:
-      return FloatVector.from(array);
+      return vectorFromArray(array);
   }
 }

--- a/modules/arrow/src/lib/parse-arrow-in-batches.ts
+++ b/modules/arrow/src/lib/parse-arrow-in-batches.ts
@@ -26,7 +26,6 @@ export function parseArrowInBatches(
   */
 
   async function* makeArrowAsyncIterator() {
-    // @ts-expect-error Fixed in arrow 9
     const readers = RecordBatchReader.readAll(asyncIterator);
     for await (const reader of readers) {
       for await (const batch of reader) {

--- a/modules/arrow/src/lib/parse-arrow-sync.ts
+++ b/modules/arrow/src/lib/parse-arrow-sync.ts
@@ -1,9 +1,9 @@
 import type {ArrowLoaderOptions} from '../arrow-loader';
-import {Table} from 'apache-arrow';
+import {tableFromIPC} from 'apache-arrow';
 
 // Parses arrow to a columnar table
 export default function parseArrowSync(arrayBuffer, options?: ArrowLoaderOptions) {
-  const arrowTable = Table.from([new Uint8Array(arrayBuffer)]);
+  const arrowTable = tableFromIPC([new Uint8Array(arrayBuffer)]);
 
   // Extract columns
 
@@ -11,12 +11,12 @@ export default function parseArrowSync(arrayBuffer, options?: ArrowLoaderOptions
   // Add options object?
   const columnarTable = {};
 
-  arrowTable.schema.fields.forEach((field) => {
+  for (const field of arrowTable.schema.fields) {
     // This (is intended to) coalesce all record batches into a single typed array
-    const arrowColumn = arrowTable.getColumn(field.name);
-    const values = arrowColumn.toArray();
+    const arrowColumn = arrowTable.getChild(field.name);
+    const values = arrowColumn?.toArray();
     columnarTable[field.name] = values;
-  });
+  }
 
   switch (options?.arrow?.shape) {
     case 'arrow-table':

--- a/modules/arrow/test/arrow-loader.spec.js
+++ b/modules/arrow/test/arrow-loader.spec.js
@@ -1,9 +1,11 @@
 import test from 'tape-promise/tape';
 import {validateLoader} from 'test/common/conformance';
 
-import {ArrowLoader, ArrowWorkerLoader} from '@loaders.gl/arrow';
+import {ArrowLoader} from '@loaders.gl/arrow';
 import {isBrowser, makeIterator, resolvePath} from '@loaders.gl/core';
 import {setLoaderOptions, fetchFile, parse, parseInBatches} from '@loaders.gl/core';
+
+const ArrowWorkerLoader = ArrowLoader;
 
 // Small Arrow Sample Files
 const ARROW_SIMPLE = '@loaders.gl/arrow/test/data/simple.arrow';

--- a/modules/las/package.json
+++ b/modules/las/package.json
@@ -43,6 +43,6 @@
     "@babel/runtime": "^7.3.1",
     "@loaders.gl/loader-utils": "3.3.0-alpha.5",
     "@loaders.gl/schema": "3.3.0-alpha.5",
-    "apache-arrow": "^4.0.0"
+    "apache-arrow": "^9.0.0"
   }
 }

--- a/modules/parquet/package.json
+++ b/modules/parquet/package.json
@@ -58,7 +58,7 @@
     "zstd-codec": "^0.1"
   },
   "peerDependencies": {
-    "apache-arrow": "^4.0.0"
+    "apache-arrow": "^9.0.0"
   },
   "devDependencies": {
     "@types/bson": "^4.0.0",
@@ -66,6 +66,6 @@
     "@types/node-int64": "^0.4.29",
     "@types/thrift": "^0.10.8",
     "@types/varint": "^5.0.0",
-    "apache-arrow": "^4.0.0"
+    "apache-arrow": "^9.0.0"
   }
 }

--- a/modules/parquet/src/lib/wasm/encode-parquet-wasm.ts
+++ b/modules/parquet/src/lib/wasm/encode-parquet-wasm.ts
@@ -1,7 +1,7 @@
 import type {Table} from 'apache-arrow';
 import type {WriterOptions} from '@loaders.gl/loader-utils';
 
-import {RecordBatchStreamWriter} from 'apache-arrow';
+import {tableToIPC} from 'apache-arrow';
 import {loadWasm} from './load-wasm';
 
 export type ParquetWriterOptions = WriterOptions & {
@@ -17,7 +17,7 @@ export async function encode(table: Table, options?: ParquetWriterOptions): Prom
   const wasmUrl = options?.parquet?.wasmUrl;
   const wasm = await loadWasm(wasmUrl);
 
-  const arrowIPCBytes = tableToIPC(table);
+  const arrowIPCBytes = tableToIPC(table, 'stream');
   // TODO: provide options for how to write table.
   const writerProperties = new wasm.WriterPropertiesBuilder().build();
   const parquetBytes = wasm.writeParquet(arrowIPCBytes, writerProperties);
@@ -25,16 +25,4 @@ export async function encode(table: Table, options?: ParquetWriterOptions): Prom
     parquetBytes.byteOffset,
     parquetBytes.byteLength + parquetBytes.byteOffset
   );
-}
-
-/**
- * Serialize a {@link Table} to the IPC format. This function is a convenience
- * wrapper for {@link RecordBatchStreamWriter} and {@link RecordBatchFileWriter}.
- * Opposite of {@link tableFromIPC}.
- *
- * @param table The Table to serialize.
- * @param type Whether to serialize the Table as a file or a stream.
- */
-export function tableToIPC(table: Table): Uint8Array {
-  return RecordBatchStreamWriter.writeAll(table).toUint8Array(true);
 }

--- a/modules/parquet/src/lib/wasm/parse-parquet-wasm.ts
+++ b/modules/parquet/src/lib/wasm/parse-parquet-wasm.ts
@@ -1,7 +1,6 @@
 // eslint-disable
-import type {RecordBatch} from 'apache-arrow';
 import type {LoaderOptions} from '@loaders.gl/loader-utils';
-import {Table, RecordBatchStreamReader} from 'apache-arrow';
+import {Table, tableFromIPC} from 'apache-arrow';
 import {loadWasm} from './load-wasm/load-wasm-node';
 
 export type ParquetLoaderOptions = LoaderOptions & {
@@ -26,17 +25,4 @@ export async function parseParquet(
   );
   const arrowTable = tableFromIPC(arrowIPCBuffer);
   return arrowTable;
-}
-
-/**
- * Deserialize the IPC format into a {@link Table}. This function is a
- * convenience wrapper for {@link RecordBatchReader}. Opposite of {@link tableToIPC}.
- */
-function tableFromIPC(input: ArrayBuffer): Table {
-  const reader = RecordBatchStreamReader.from(input);
-  const recordBatches: RecordBatch[] = [];
-  for (const recordBatch of reader) {
-    recordBatches.push(recordBatch);
-  }
-  return new Table(recordBatches);
 }

--- a/modules/parquet/test/parquet-wasm-loader.spec.ts
+++ b/modules/parquet/test/parquet-wasm-loader.spec.ts
@@ -3,7 +3,7 @@ import test from 'tape-promise/tape';
 
 import {ParquetWasmLoader, ParquetWasmWriter} from '@loaders.gl/parquet';
 import {load, encode, setLoaderOptions} from '@loaders.gl/core';
-import {Table, Int32Vector, Utf8Vector, BoolVector, Uint8Vector} from 'apache-arrow';
+import {Table, vectorFromArray, Utf8, Bool, Uint8, Uint32} from 'apache-arrow';
 import {WASM_SUPPORTED_FILES} from './data/files';
 
 const PARQUET_DIR = '@loaders.gl/parquet/test/data';
@@ -28,7 +28,7 @@ test('Load Parquet file', async (t) => {
     }
   });
 
-  t.equal(table.length, 5);
+  t.equal(table.numRows, 5);
   t.deepEqual(table.schema.fields.map(f => f.name),
     [ 'pop_est', 'continent', 'name', 'iso_a3', 'gdp_md_est', 'geometry' ]);
   t.end();
@@ -68,11 +68,11 @@ test('ParquetWasmWriterLoader round trip', async (t) => {
 })
 
 function createArrowTable() {
-  const utf8Vector = Utf8Vector.from(['a', 'b', 'c', 'd']);
-  const boolVector = BoolVector.from([true, true, false, false])
-  const uint8Vector = Uint8Vector.from([1, 2, 3, 4])
-  const int32Vector = Int32Vector.from([0, -2147483638, 2147483637, 1])
+  const utf8Vector = vectorFromArray(['a', 'b', 'c', 'd'], new Utf8);
+  const boolVector = vectorFromArray([true, true, false, false], new Bool)
+  const uint8Vector = vectorFromArray([1, 2, 3, 4], new Uint8)
+  const int32Vector = vectorFromArray([0, -2147483638, 2147483637, 1], new Uint32)
 
-  const table = Table.new([utf8Vector, uint8Vector, int32Vector, boolVector], ['str', 'uint8', 'int32', 'bool']);
+  const table = new Table({utf8Vector, uint8Vector, int32Vector, boolVector});
   return table;
 }

--- a/modules/schema/src/category/mesh/convert-mesh.ts
+++ b/modules/schema/src/category/mesh/convert-mesh.ts
@@ -1,6 +1,6 @@
 import type {Mesh} from './mesh-types';
 import type {ColumnarTable, ArrowTable} from '../table/table-types';
-import {convertMeshToArrowTable} from './mesh-to-arrow-table';
+// import {convertMeshToArrowTable} from './mesh-to-arrow-table';
 
 type TargetShape = 'mesh' | 'columnar-table' | 'arrow-table';
 
@@ -17,11 +17,11 @@ export function convertMesh(
       return mesh;
     case 'columnar-table':
       return convertMeshToColumnarTable(mesh);
-    case 'arrow-table':
-      return {
-        shape: 'arrow-table',
-        data: convertMeshToArrowTable(mesh)
-      };
+    // case 'arrow-table':
+    //   return {
+    //     shape: 'arrow-table',
+    //     data: convertMeshToArrowTable(mesh)
+    //   };
     default:
       throw new Error(`Unsupported shape ${options?.shape}`);
   }

--- a/modules/schema/src/category/mesh/mesh-to-arrow-table.ts
+++ b/modules/schema/src/category/mesh/mesh-to-arrow-table.ts
@@ -1,3 +1,4 @@
+/* Problem with arrow dependency...
 import {
   Table,
   Schema,
@@ -6,7 +7,7 @@ import {
   Field,
   Data,
   FixedSizeListVector
-} from 'apache-arrow/Arrow.dom';
+} from 'apache-arrow';
 import {AbstractVector} from 'apache-arrow/vector';
 import {getArrowType, getArrowVector} from '../../lib/arrow/arrow-type-utils';
 import type {Mesh} from './mesh-types';
@@ -18,7 +19,7 @@ import {makeMeshAttributeMetadata} from './deduce-mesh-schema';
  * @param metadata
  * @param batchSize
  * @returns
- */
+ *
 export function convertMeshToArrowTable(mesh: Mesh, batchSize?: number): Table {
   const vectors: AbstractVector[] = [];
   const fields: Field[] = [];
@@ -39,3 +40,4 @@ export function convertMeshToArrowTable(mesh: Mesh, batchSize?: number): Table {
   const table = new Table(schema, recordBatch);
   return table;
 }
+*/

--- a/modules/schema/src/category/table/table-types.ts
+++ b/modules/schema/src/category/table/table-types.ts
@@ -1,8 +1,13 @@
 import type {Schema} from '../../lib/schema/schema';
-import type {Table as ApacheArrowTable, RecordBatch} from 'apache-arrow/Arrow.dom';
 import type {AnyArray} from '../../types';
 import type {Batch} from '../common';
 import type {Feature} from '../gis';
+
+// Idea was to just import types, but it seems
+// Seems this triggers more bundling and build issues than it is worth...
+// import type {Table as ApacheArrowTable, RecordBatch} from 'apache-arrow';
+type ApacheArrowTable = any;
+type RecordBatch = any;
 
 /** A general table */
 export interface Table {

--- a/modules/schema/src/lib/arrow/arrow-type-utils.ts
+++ b/modules/schema/src/lib/arrow/arrow-type-utils.ts
@@ -1,3 +1,4 @@
+/*
 import type {TypedArray} from '../../types';
 import {
   DataType,
@@ -17,7 +18,7 @@ import {
   Uint32Vector,
   Float32Vector,
   Float64Vector
-} from 'apache-arrow/Arrow.dom';
+} from 'apache-arrow';
 import {AbstractVector} from 'apache-arrow/vector';
 
 export function getArrowType(array: TypedArray): DataType {
@@ -65,3 +66,4 @@ export function getArrowVector(array: TypedArray): AbstractVector {
       throw new Error('array type not supported');
   }
 }
+*/

--- a/yarn.lock
+++ b/yarn.lock
@@ -2440,6 +2440,16 @@
   dependencies:
     bson "*"
 
+"@types/command-line-args@5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@types/command-line-args/-/command-line-args-5.2.0.tgz#adbb77980a1cc376bb208e3f4142e907410430f6"
+  integrity sha512-UuKzKpJJ/Ief6ufIaIzr3A/0XnluX7RvFgwkV89Yzvm77wCh1kFaFmqN8XEnGcN62EuHdedQjEMb8mYxFLGPyA==
+
+"@types/command-line-usage@5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@types/command-line-usage/-/command-line-usage-5.0.2.tgz#ba5e3f6ae5a2009d466679cc431b50635bf1a064"
+  integrity sha512-n7RlEEJ+4x4TS7ZQddTmNSxP+zziEG0TNsMfiRIxcIVXt71ENJ9ojeXmGO3wPoTdn7pJcU2xc3CJYMktNT6DPg==
+
 "@types/crypto-js@^4.0.1":
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/@types/crypto-js/-/crypto-js-4.1.1.tgz#602859584cecc91894eb23a4892f38cfa927890d"
@@ -2450,7 +2460,7 @@
   resolved "https://registry.yarnpkg.com/@types/emscripten/-/emscripten-1.39.6.tgz#698b90fe60d44acf93c31064218fbea93fbfd85a"
   integrity sha512-H90aoynNhhkQP6DRweEjJp5vfUVdIj7tdPLsu7pq89vODD/lcugKfZOsfgwpvM6XUewEp2N5dCg1Uf3Qe55Dcg==
 
-"@types/flatbuffers@^1.10.0":
+"@types/flatbuffers@*", "@types/flatbuffers@^1.10.0":
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/@types/flatbuffers/-/flatbuffers-1.10.0.tgz#aa74e30ffdc86445f2f060e1808fc9d56b5603ba"
   integrity sha512-7btbphLrKvo5yl/5CC2OCxUSMx1wV1wvGT1qDXkSt7yi00/YW7E8k6qzXqJHsp+WU0eoG7r6MTQQXI9lIvd0qA==
@@ -2527,6 +2537,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.32.tgz#8074f7106731f1a12ba993fe8bad86ee73905014"
   integrity sha512-Y6S38pFr04yb13qqHf8uk1nHE3lXgQ30WZbv1mLliV9pt0NjvqdWttLcrOYLnXbOafknVYRHZGoMSpR9UwfYow==
 
+"@types/node@^17.0.36":
+  version "17.0.45"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.45.tgz#2c0fafd78705e7a18b7906b5201a522719dc5190"
+  integrity sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
@@ -2536,6 +2551,11 @@
   version "2019.7.0"
   resolved "https://registry.yarnpkg.com/@types/offscreencanvas/-/offscreencanvas-2019.7.0.tgz#e4a932069db47bb3eabeb0b305502d01586fa90d"
   integrity sha512-PGcyveRIpL1XIqK8eBsmRBt76eFgtzuPiSTyKHZxnGemp2yzGzWpjYKAfK3wIMiU7eH+851yEpiuP8JZerTmWg==
+
+"@types/pad-left@2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@types/pad-left/-/pad-left-2.1.1.tgz#17d906fc75804e1cc722da73623f1d978f16a137"
+  integrity sha512-Xd22WCRBydkGSApl5Bw0PhAOHKSVjNL3E3AwzKaps96IMraPqy5BvZIsBVK6JLwdybUzjHnuWVwpDd0JjTfHXA==
 
 "@types/pako@^1.0.1":
   version "1.0.4"
@@ -3164,6 +3184,23 @@ apache-arrow@^4.0.0:
     text-encoding-utf-8 "^1.0.2"
     tslib "^2.2.0"
 
+apache-arrow@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/apache-arrow/-/apache-arrow-9.0.0.tgz#c2308e5b9723aef75f7a56d9339c2523736a31f6"
+  integrity sha512-Myt0vtm7eRtg4dYQp1hb2A77jbPhCYZcPeNp1F0u7te3rWQtcDI3EOSLxToFywdLQ1hfPzhzdLfDL0tPQObJjw==
+  dependencies:
+    "@types/command-line-args" "5.2.0"
+    "@types/command-line-usage" "5.0.2"
+    "@types/flatbuffers" "*"
+    "@types/node" "^17.0.36"
+    "@types/pad-left" "2.1.1"
+    command-line-args "5.2.1"
+    command-line-usage "6.1.3"
+    flatbuffers "2.0.4"
+    json-bignum "^0.0.3"
+    pad-left "^2.1.0"
+    tslib "^2.4.0"
+
 append-transform@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-2.0.0.tgz#99d9d29c7b38391e6f428d28ce136551f0b77e12"
@@ -3263,12 +3300,12 @@ arr-union@^3.1.0:
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==
 
-array-back@^3.0.1:
+array-back@^3.0.1, array-back@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/array-back/-/array-back-3.1.0.tgz#b8859d7a508871c9a7b2cf42f99428f65e96bfb0"
   integrity sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==
 
-array-back@^4.0.1:
+array-back@^4.0.1, array-back@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/array-back/-/array-back-4.0.2.tgz#8004e999a6274586beeb27342168652fdb89fa1e"
   integrity sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==
@@ -4364,6 +4401,16 @@ command-line-args@5.1.1:
     lodash.camelcase "^4.3.0"
     typical "^4.0.0"
 
+command-line-args@5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/command-line-args/-/command-line-args-5.2.1.tgz#c44c32e437a57d7c51157696893c5909e9cec42e"
+  integrity sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==
+  dependencies:
+    array-back "^3.1.0"
+    find-replace "^3.0.0"
+    lodash.camelcase "^4.3.0"
+    typical "^4.0.0"
+
 command-line-usage@6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/command-line-usage/-/command-line-usage-6.1.1.tgz#c908e28686108917758a49f45efb4f02f76bc03f"
@@ -4372,6 +4419,16 @@ command-line-usage@6.1.1:
     array-back "^4.0.1"
     chalk "^2.4.2"
     table-layout "^1.0.1"
+    typical "^5.2.0"
+
+command-line-usage@6.1.3:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/command-line-usage/-/command-line-usage-6.1.3.tgz#428fa5acde6a838779dfa30e44686f4b6761d957"
+  integrity sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==
+  dependencies:
+    array-back "^4.0.2"
+    chalk "^2.4.2"
+    table-layout "^1.0.2"
     typical "^5.2.0"
 
 commander@2, commander@^2.18.0, commander@^2.20.0:
@@ -6450,6 +6507,11 @@ flatbuffers@1.12.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/flatbuffers/-/flatbuffers-1.12.0.tgz#72e87d1726cb1b216e839ef02658aa87dcef68aa"
   integrity sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ==
+
+flatbuffers@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/flatbuffers/-/flatbuffers-2.0.4.tgz#034456e29ec480de48bad34f7fc18c03f20c9768"
+  integrity sha512-4rUFVDPjSoP0tOII34oQf+72NKU7E088U5oX7kwICahft0UB2kOQ9wUzzCp+OHxByERIfxRDCgX5mP8Pjkfl0g==
 
 flatgeobuf@3.6.5:
   version "3.6.5"
@@ -12075,7 +12137,7 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-table-layout@^1.0.1:
+table-layout@^1.0.1, table-layout@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/table-layout/-/table-layout-1.0.2.tgz#c4038a1853b0136d63365a734b6931cf4fad4a04"
   integrity sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==
@@ -12493,7 +12555,7 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.2.0:
+tslib@^2.0.0, tslib@^2.2.0, tslib@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==


### PR DESCRIPTION
I saw https://github.com/visgl/loaders.gl/pull/2276 and thought I should adapt the code to use the upstream `tableFromIPC` and `tableToIPC` while I'm thinking about it