### PR TITLE
fix(tile-converter): i3s - fix fullExtent calculation

### DIFF
--- a/modules/tile-converter/src/i3s-converter/helpers/coordinate-converter.ts
+++ b/modules/tile-converter/src/i3s-converter/helpers/coordinate-converter.ts
@@ -126,6 +126,8 @@ export function convertBoundingVolumeToI3SFullExtent(
     new Vector3()
   );
 
+  // Converter sometimes returns min values that are bigger then max,
+  // so we should check and take bigger value from max and smaller for nim
   return {
     xmin: Math.min(vertexMin[0], vertexMax[0]),
     xmax: Math.max(vertexMin[0], vertexMax[0]),

--- a/modules/tile-converter/src/i3s-converter/helpers/coordinate-converter.ts
+++ b/modules/tile-converter/src/i3s-converter/helpers/coordinate-converter.ts
@@ -127,12 +127,12 @@ export function convertBoundingVolumeToI3SFullExtent(
   );
 
   return {
-    xmin: vertexMin[0],
-    xmax: vertexMax[0],
-    ymin: vertexMin[1],
-    ymax: vertexMax[1],
-    zmin: vertexMin[2],
-    zmax: vertexMax[2]
+    xmin: Math.min(vertexMin[0], vertexMax[0]),
+    xmax: Math.max(vertexMin[0], vertexMax[0]),
+    ymin: Math.min(vertexMin[1], vertexMax[1]),
+    ymax: Math.max(vertexMin[1], vertexMax[1]),
+    zmin: Math.min(vertexMin[2], vertexMax[2]),
+    zmax: Math.max(vertexMin[2], vertexMax[2])
   };
 }
 

--- a/modules/tile-converter/src/i3s-converter/i3s-converter.ts
+++ b/modules/tile-converter/src/i3s-converter/i3s-converter.ts
@@ -207,7 +207,11 @@ export default class I3SConverter {
       // console.log(tilesetJson); // eslint-disable-line
       this.sourceTileset = new Tileset3D(sourceTilesetJson, tilesetOptions);
 
-      await this._createAndSaveTileset(outputPath, tilesetName);
+      await this._createAndSaveTileset(
+        outputPath,
+        tilesetName,
+        sourceTilesetJson?.root?.boundingVolume?.region
+      );
       await this._finishConversion({slpk: Boolean(slpk), outputPath, tilesetName});
       return sourceTilesetJson;
     } catch (error) {
@@ -224,7 +228,11 @@ export default class I3SConverter {
    * @param outputPath - path to save output data
    * @param tilesetName - new tileset path
    */
-  private async _createAndSaveTileset(outputPath: string, tilesetName: string): Promise<void> {
+  private async _createAndSaveTileset(
+    outputPath: string,
+    tilesetName: string,
+    boundingVolumeRegion?: number[]
+  ): Promise<void> {
     const tilesetPath = join(`${outputPath}`, `${tilesetName}`);
     // Removing the tilesetPath needed to exclude erroneous files after conversion
     try {
@@ -235,7 +243,7 @@ export default class I3SConverter {
 
     this.layers0Path = join(tilesetPath, 'SceneServer', 'layers', '0');
 
-    this._formLayers0(tilesetName);
+    this._formLayers0(tilesetName, boundingVolumeRegion);
 
     this.materialDefinitions = [];
     this.materialMap = new Map();
@@ -275,10 +283,14 @@ export default class I3SConverter {
    * Form object of 3DSceneLayer https://github.com/Esri/i3s-spec/blob/master/docs/1.7/3DSceneLayer.cmn.md
    * @param  tilesetName - Name of layer
    */
-  private _formLayers0(tilesetName: string): void {
+  private _formLayers0(tilesetName: string, boundingVolumeRegion?: number[]): void {
     const fullExtent = convertBoundingVolumeToI3SFullExtent(
       this.sourceTileset?.boundingVolume || this.sourceTileset?.root?.boundingVolume
     );
+    if (boundingVolumeRegion) {
+      fullExtent.zmin = boundingVolumeRegion[4];
+      fullExtent.zmax = boundingVolumeRegion[5];
+    }
     const extent = [fullExtent.xmin, fullExtent.ymin, fullExtent.xmax, fullExtent.ymax];
     const layers0data = {
       version: `{${uuidv4().toUpperCase()}}`,

--- a/modules/tile-converter/test/i3s-converter/helpers/coordinate-converter.spec.js
+++ b/modules/tile-converter/test/i3s-converter/helpers/coordinate-converter.spec.js
@@ -13,8 +13,8 @@ test('#tile-converter#i3s-converter#coordinate-converter#convertBoundingVolumeTo
     xmax: -122.39761505291817,
     ymin: 37.620194593759,
     ymax: 37.90522864642682,
-    zmin: 4754.999977323874,
-    zmax: -4505.453647678357
+    zmin: -4505.453647678357,
+    zmax: 4754.999977323874
   });
 
   const obb = new OrientedBoundingBox().fromCenterHalfSizeQuaternion(
@@ -28,7 +28,7 @@ test('#tile-converter#i3s-converter#coordinate-converter#convertBoundingVolumeTo
     xmax: -122.39672756380504,
     ymin: 37.61647458074144,
     ymax: 37.908958954561705,
-    zmin: 4877.104767145071,
-    zmax: -4625.401184284537
+    zmin: -4625.401184284537,
+    zmax: 4877.104767145071
   });
 });

--- a/modules/tile-converter/test/i3s-converter/i3s-converter.spec.js
+++ b/modules/tile-converter/test/i3s-converter/i3s-converter.spec.js
@@ -30,8 +30,8 @@ const TEST_FULL_EXTENT = {
   ymin: 40.04095693133301,
   xmax: -75.6100663747417,
   ymax: 40.04410425830655,
-  zmin: -3.0828418561956057,
-  zmax: 23.089174197650973
+  zmin: 0,
+  zmax: 20
 };
 
 setLoaderOptions({


### PR DESCRIPTION
The issue is reproduced for Japanese dataset (Eastern semisphere). We can't disclose the actual dataset.

Expected result:
"fullExtent":{**"xmin":136.8512835031769**,**"xmax":136.92452109055998**,"ymin":35.121734280476964,"ymax":35.15768129440385,"zmin":48.7547465655491,"zmax":2361.049808624967} 
z values are taken from the root node bounding volume

Actual result:
"fullExtent":{**"xmin":136.92452109055998**,"ymin":35.121734280476964,**"xmax":136.8512835031769**,"ymax":35.15768129440385,"zmin":-1181.3147795024154,"zmax":1356.6865765038197} where z values are extremely big

Another issue - zmin and zmax. Now they are calculated from MBS. If original tileset has region, it will convert to MBS. So zmin and zmax could be not relevant to the actual extent.
Now, if the original dataset has region bounding volume, we take z-values directly from the bounding volume.