### PR TITLE
fix(tile-converter): always calculate refinement percentage

### DIFF
--- a/modules/tile-converter/src/i3s-converter/i3s-converter.ts
+++ b/modules/tile-converter/src/i3s-converter/i3s-converter.ts
@@ -639,9 +639,7 @@ export default class I3SConverter {
     parentId: number,
     level: number
   ): Promise<Node3DIndexDocument[]> {
-    if (this.validate) {
-      this._checkAddRefinementTypeForTile(sourceTile);
-    }
+    this._checkAddRefinementTypeForTile(sourceTile);
 
     await this._updateTilesetOptions();
     await this.sourceTileset!._loadTile(sourceTile);


### PR DESCRIPTION
We always show statistics about 'ADD' refinement percentage, but calculate it only with validate flag. Now calculation will be performed always. 