### PR TITLE
fix(i3s-converter): fix default arrays in shared-resources.ts

### DIFF
--- a/modules/tile-converter/src/i3s-converter/json-templates/shared-resources.ts
+++ b/modules/tile-converter/src/i3s-converter/json-templates/shared-resources.ts
@@ -15,15 +15,15 @@ const MATERIAL_DEFINITION_INFO_PARAMS = () => ({
   },
   ambient: {
     path: 'ambient',
-    default: [1, 1, 1, 1]
+    default: [1, 1, 1]
   },
   diffuse: {
     path: 'diffuse',
-    default: [1, 1, 1, 1]
+    default: [1, 1, 1]
   },
   specular: {
     path: 'specular',
-    default: [0, 0, 0, 0]
+    default: [0, 0, 0]
   },
   useVertexColorAlpha: {
     path: 'useVertexColorAlpha',

--- a/modules/tile-converter/test/i3s-converter/helpers/shared-resources.spec.js
+++ b/modules/tile-converter/test/i3s-converter/helpers/shared-resources.spec.js
@@ -3,7 +3,7 @@ import transform from 'json-map-transform';
 
 import {SHARED_RESOURCES as sharedResourcesTemplate} from '../../../src/i3s-converter/json-templates/shared-resources';
 
-test('#SHARED_RESOURCES - Should have arrays with three elements like [1, 1, 1]', async (t) => {
+test('#tile-converter#i3s-converter#json-templates#shared-resources#default-data - Verify the default shared data', async (t) => {
   const SHARED_RESOURCES_ENTRY = {
     materialDefinitionInfos: [
       {
@@ -12,24 +12,26 @@ test('#SHARED_RESOURCES - Should have arrays with three elements like [1, 1, 1]'
     ],
     nodePath: '1'
   };
-  const PARAM_NAMES = ['ambient', 'diffuse', 'specular'];
-  const EXPECTED_LENGTH = 3;
 
-  const checkParam = (val) => !!val && val.length === EXPECTED_LENGTH;
-
-  let r = false;
-  const sharedData = transform(SHARED_RESOURCES_ENTRY, sharedResourcesTemplate());
-  for (const [_i1, materialDefinitionInfo] of Object.entries(sharedData || {})) {
-    for (const [_i2, info] of Object.entries(materialDefinitionInfo || {})) {
-      const params = info.params || {};
-      for (const p of PARAM_NAMES) {
-        r = checkParam(params[p]);
-        if (!r) break;
+  const EXPECTED_DATA = {
+    Mat10: {
+      name: 'standard',
+      type: 'standard',
+      params: {
+        renderMode: 'solid',
+        shininess: 1,
+        reflectivity: 0,
+        ambient: [1, 1, 1],
+        diffuse: [1, 1, 1],
+        specular: [0, 0, 0],
+        useVertexColorAlpha: false,
+        vertexRegions: false,
+        vertexColors: true
       }
-      if (!r) break;
     }
-    if (!r) break;
-  }
-  t.ok(r);
+  };
+
+  const sharedData = transform(SHARED_RESOURCES_ENTRY, sharedResourcesTemplate());
+  t.deepEquals(sharedData ? sharedData.materialDefinitions : {}, EXPECTED_DATA);
   t.end();
 });

--- a/modules/tile-converter/test/i3s-converter/helpers/shared-resources.spec.js
+++ b/modules/tile-converter/test/i3s-converter/helpers/shared-resources.spec.js
@@ -1,0 +1,39 @@
+import test from 'tape-promise/tape';
+import transform from 'json-map-transform';
+
+import {
+	SHARED_RESOURCES as sharedResourcesTemplate
+} from '../../../src/i3s-converter/json-templates/shared-resources';
+
+test.only('#SHARED_RESOURCES - Should have arrays with three elements like [1, 1, 1]', async (t) => {
+
+	const SHARED_RESOURCES_ENTRY = {
+		materialDefinitionInfos: [{
+			params: {
+			}
+		}
+		],
+		nodePath: "1"
+	};
+	const PARAM_NAMES = ["ambient", "diffuse", "specular"];
+	const EXPECTED_LENGTH = 3;
+
+	const checkParam = (val) => !!val && val.length === EXPECTED_LENGTH;
+
+	let r = false;
+	const sharedData = transform(SHARED_RESOURCES_ENTRY, sharedResourcesTemplate());
+	for (const [i1, materialDefinitionInfo] of Object.entries(sharedData || {})) {
+		for (const [i2, info] of Object.entries(materialDefinitionInfo || {})) {
+			const params = info.params || {};
+			for (const p of PARAM_NAMES) {
+				r = checkParam(params[p]);
+				if (!r) break;
+			}
+			if (!r) break;
+		}
+		if (!r) break;
+	}
+	t.ok(r);
+	t.end();
+});
+

--- a/modules/tile-converter/test/i3s-converter/helpers/shared-resources.spec.js
+++ b/modules/tile-converter/test/i3s-converter/helpers/shared-resources.spec.js
@@ -1,39 +1,35 @@
 import test from 'tape-promise/tape';
 import transform from 'json-map-transform';
 
-import {
-	SHARED_RESOURCES as sharedResourcesTemplate
-} from '../../../src/i3s-converter/json-templates/shared-resources';
+import {SHARED_RESOURCES as sharedResourcesTemplate} from '../../../src/i3s-converter/json-templates/shared-resources';
 
-test.only('#SHARED_RESOURCES - Should have arrays with three elements like [1, 1, 1]', async (t) => {
+test('#SHARED_RESOURCES - Should have arrays with three elements like [1, 1, 1]', async (t) => {
+  const SHARED_RESOURCES_ENTRY = {
+    materialDefinitionInfos: [
+      {
+        params: {}
+      }
+    ],
+    nodePath: '1'
+  };
+  const PARAM_NAMES = ['ambient', 'diffuse', 'specular'];
+  const EXPECTED_LENGTH = 3;
 
-	const SHARED_RESOURCES_ENTRY = {
-		materialDefinitionInfos: [{
-			params: {
-			}
-		}
-		],
-		nodePath: "1"
-	};
-	const PARAM_NAMES = ["ambient", "diffuse", "specular"];
-	const EXPECTED_LENGTH = 3;
+  const checkParam = (val) => !!val && val.length === EXPECTED_LENGTH;
 
-	const checkParam = (val) => !!val && val.length === EXPECTED_LENGTH;
-
-	let r = false;
-	const sharedData = transform(SHARED_RESOURCES_ENTRY, sharedResourcesTemplate());
-	for (const [i1, materialDefinitionInfo] of Object.entries(sharedData || {})) {
-		for (const [i2, info] of Object.entries(materialDefinitionInfo || {})) {
-			const params = info.params || {};
-			for (const p of PARAM_NAMES) {
-				r = checkParam(params[p]);
-				if (!r) break;
-			}
-			if (!r) break;
-		}
-		if (!r) break;
-	}
-	t.ok(r);
-	t.end();
+  let r = false;
+  const sharedData = transform(SHARED_RESOURCES_ENTRY, sharedResourcesTemplate());
+  for (const [_i1, materialDefinitionInfo] of Object.entries(sharedData || {})) {
+    for (const [_i2, info] of Object.entries(materialDefinitionInfo || {})) {
+      const params = info.params || {};
+      for (const p of PARAM_NAMES) {
+        r = checkParam(params[p]);
+        if (!r) break;
+      }
+      if (!r) break;
+    }
+    if (!r) break;
+  }
+  t.ok(r);
+  t.end();
 });
-

--- a/modules/tile-converter/test/index.js
+++ b/modules/tile-converter/test/index.js
@@ -6,6 +6,7 @@ import './i3s-converter/helpers/coordinate-converter.spec';
 import './i3s-converter/helpers/batch-ids-extensions.spec';
 import './i3s-converter/helpers/feature-attributes.spec';
 import './i3s-converter/helpers/geometry-converter.spec';
+import './i3s-converter/helpers/shared-resources.spec';
 
 import './i3s-converter/i3s-converter.spec';
 


### PR DESCRIPTION
According to https://github.com/Esri/i3s-spec/blob/master/docs/1.7/sharedResource.cmn.md
arrays for MaterialDefinitions are expected to have 3 elements (r, g, b).