### PR TITLE
fix(i3s): parse not compressed attributes

### DIFF
--- a/modules/i3s/src/lib/parsers/constants.ts
+++ b/modules/i3s/src/lib/parsers/constants.ts
@@ -20,7 +20,7 @@ export function getConstructorForDataFormat(dataType: string) {
 
 export const GL_TYPE_MAP: {[key: string]: number} = {
   UInt8: GL.UNSIGNED_BYTE,
-  UInt16: GL.UNSIGNED_INT,
+  UInt16: GL.UNSIGNED_SHORT,
   Float32: GL.FLOAT,
   UInt32: GL.UNSIGNED_INT,
   UInt64: GL.DOUBLE

--- a/modules/i3s/src/lib/parsers/parse-i3s-tile-content.ts
+++ b/modules/i3s/src/lib/parsers/parse-i3s-tile-content.ts
@@ -214,7 +214,7 @@ async function parseI3SNodeGeometry(
     normals: attributes.normal,
     colors: normalizeAttribute(attributes.color), // Normalize from UInt8
     texCoords: attributes.uv0,
-    uvRegions: normalizeAttribute(attributes.uvRegion) // Normalize from UInt16
+    uvRegions: normalizeAttribute(attributes.uvRegion || attributes.region) // Normalize from UInt16
   };
   content.indices = indices || null;
 


### PR DESCRIPTION
Fix loading of tilesets with UVRegions like https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/SanFrancisco_Bldgs/SceneServer/layers/0
with not compressed textures and not compressed geometry.