### PR TITLE
feat: Improve Loader typing (v4)

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -4,7 +4,7 @@
 
 **Apache Arrow** 
 
-loaders.gl now uses `apache-arrow` v9. Apache Arrow JS v9 is a major breaking change compared with v4 which is used by loaders.gl v3.
+loaders.gl now uses `apache-arrow` v9. Apache Arrow JS v9 is a breaking change compared with v4 which is used by loaders.gl v3. 
 
 **Table Schemas** 
 

--- a/modules/core/src/lib/api/load.ts
+++ b/modules/core/src/lib/api/load.ts
@@ -1,13 +1,7 @@
 // loaders.gl, MIT license
 
-import type {
-  DataType,
-  Loader,
-  LoaderContext,
-  LoaderOptions,
-  LoaderOptionsType
-} from '@loaders.gl/loader-utils';
-// import type {LoaderOptionsType, LoaderReturnType} from '@loaders.gl/loader-utils';
+import type {DataType, Loader, LoaderContext, LoaderOptions} from '@loaders.gl/loader-utils';
+import type {LoaderOptionsType, LoaderReturnType} from '@loaders.gl/loader-utils';
 import {isBlob} from '../../javascript-utils/is-type';
 import {isLoaderObject} from '../loader-utils/normalize-loader';
 import {getFetchFunction} from '../loader-utils/option-utils';
@@ -29,7 +23,7 @@ export async function load<LoaderT extends Loader>(
   loader: LoaderT,
   options?: LoaderOptionsType<LoaderT>,
   context?: LoaderContext
-): Promise<any>; // Promise<LoaderReturnType<LoaderT>>;
+): Promise<LoaderReturnType<LoaderT>>;
 
 export async function load<
   LoaderT extends Loader,

--- a/modules/core/src/lib/api/parse.ts
+++ b/modules/core/src/lib/api/parse.ts
@@ -1,13 +1,7 @@
 // loaders.gl, MIT license
 
-import type {
-  DataType,
-  Loader,
-  LoaderContext,
-  LoaderOptions,
-  LoaderOptionsType
-} from '@loaders.gl/loader-utils';
-// import type {LoaderOptionsType, LoaderReturnType} from '@loaders.gl/loader-utils';
+import type {DataType, Loader, LoaderContext, LoaderOptions} from '@loaders.gl/loader-utils';
+import type {LoaderOptionsType, LoaderReturnType} from '@loaders.gl/loader-utils';
 import {assert, validateWorkerVersion} from '@loaders.gl/worker-utils';
 import {parseWithWorker, canParseWithWorker} from '@loaders.gl/loader-utils';
 import {isLoaderObject} from '../loader-utils/normalize-loader';
@@ -28,7 +22,7 @@ export async function parse<
   loader: LoaderT,
   options?: OptionsT,
   context?: LoaderContext
-): Promise<any>; // Promise<LoaderReturnType<LoaderT>>;
+): Promise<LoaderReturnType<LoaderT>>;
 
 export async function parse(
   data: DataType | Promise<DataType>,

--- a/modules/csv/src/csv-loader.ts
+++ b/modules/csv/src/csv-loader.ts
@@ -1,6 +1,7 @@
+// loaders.gl, MIT license
+
 import type {LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';
-import type {Batch} from '@loaders.gl/schema';
-type Schema = any;
+import type {Batch, TableBatch} from '@loaders.gl/schema';
 
 import {
   AsyncQueue,
@@ -10,6 +11,10 @@ import {
 } from '@loaders.gl/schema';
 import Papa from './papaparse/papaparse';
 import AsyncIteratorStreamer from './papaparse/async-iterator-streamer';
+import {Table} from 'modules/schema/src/lib/table/arrow-api';
+
+type ObjectField = {name: string; index: number; type: any};
+type ObjectSchema = {[key: string]: ObjectField} | ObjectField[];
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
@@ -59,7 +64,7 @@ const DEFAULT_CSV_LOADER_OPTIONS = {
   }
 };
 
-export const CSVLoader = {
+export const CSVLoader: LoaderWithParser<Table, TableBatch, CSVLoaderOptions> = {
   id: 'csv',
   module: 'csv',
   name: 'CSV',
@@ -147,7 +152,7 @@ function parseCSVInBatches(
   let isFirstRow: boolean = true;
   let headerRow: string[] | null = null;
   let tableBatchBuilder: TableBatchBuilder | null = null;
-  let schema: Schema | null = null;
+  let schema: ObjectSchema | null = null;
 
   const config = {
     // dynamicTyping: true, // Convert numbers and boolean values in rows from strings,
@@ -207,11 +212,14 @@ function parseCSVInBatches(
       // Add the row
       tableBatchBuilder =
         tableBatchBuilder ||
-        new TableBatchBuilder(schema, {
-          // @ts-expect-error
-          shape: csvOptions.shape || 'array-row-table',
-          ...options
-        });
+        new TableBatchBuilder(
+          // @ts-expect-error TODO this is not a proper schema
+          schema,
+          {
+            shape: csvOptions.shape || 'array-row-table',
+            ...options
+          }
+        );
 
       try {
         tableBatchBuilder.addRow(row);
@@ -306,8 +314,8 @@ function generateHeader(columnPrefix: string, count: number = 0): string[] {
   return headers;
 }
 
-function deduceSchema(row, headerRow) {
-  const schema = headerRow ? {} : [];
+function deduceSchema(row, headerRow): ObjectSchema {
+  const schema: ObjectSchema = headerRow ? {} : [];
   for (let i = 0; i < row.length; i++) {
     const columnName = (headerRow && headerRow[i]) || i;
     const value = row[i];
@@ -326,5 +334,3 @@ function deduceSchema(row, headerRow) {
   }
   return schema;
 }
-
-export const _typecheckCSVLoader: LoaderWithParser = CSVLoader;

--- a/modules/draco/test/draco-writer.spec.ts
+++ b/modules/draco/test/draco-writer.spec.ts
@@ -60,7 +60,7 @@ test('DracoWriter#encode(bunny.drc)', async (t) => {
     attributes: {
       POSITION: data.attributes.POSITION.value
     },
-    indices: data.indices.value
+    indices: data.indices?.value
   };
   const POINTCLOUD = {
     attributes: {
@@ -109,7 +109,7 @@ test.skip('DracoWriter#Worker$encode(bunny.drc)', async (t) => {
     attributes: {
       POSITION: data.attributes.POSITION.value
     },
-    indices: data.indices.value
+    indices: data.indices?.value
   };
   const POINTCLOUD = {
     attributes: {
@@ -163,7 +163,7 @@ test('DracoWriter#WorkerNodeJS#encode(bunny.drc)', async (t) => {
     if (!tc.options.draco?.pointcloud) {
       // Copy indices buffer because it won't be available after being sent to the worker
       // @ts-expect-error
-      mesh.indices = cloneTypeArray(data.indices.value);
+      mesh.indices = cloneTypeArray(data.indices?.value);
     }
     const meshSize = getMeshSize(mesh.attributes);
 
@@ -206,7 +206,7 @@ test('DracoWriter#encode via draco3d npm package (bunny.drc)', async (t) => {
     attributes: {
       POSITION: data.attributes.POSITION.value
     },
-    indices: data.indices.value
+    indices: data.indices?.value
   };
   const POINTCLOUD = {
     attributes: {
@@ -255,7 +255,7 @@ test('DracoWriter#encode(bunny.drc)', async (t) => {
 
   const meshAttributes = {
     POSITION: data.attributes.POSITION.value,
-    indices: data.indices.value
+    indices: data.indices?.value
   };
   const pointCloudAttributes = {
     POSITION: data.attributes.POSITION.value
@@ -299,7 +299,7 @@ test('DracoWriter#should encode texCoord/texCoords attribute as TEX_COORD attrib
   const meshAttributes = {
     POSITION: data.attributes.POSITION.value,
     texCoord,
-    indices: data.indices.value
+    indices: data.indices?.value
   };
 
   const compressedMesh = await encode(meshAttributes, DracoWriter);
@@ -314,7 +314,7 @@ test('DracoWriter#should encode texCoord/texCoords attribute as TEX_COORD attrib
   const meshAttributes2 = {
     POSITION: data.attributes.POSITION.value,
     texCoords: texCoord,
-    indices: data.indices.value
+    indices: data.indices?.value
   };
 
   const compressedMesh2 = await encode(meshAttributes2, DracoWriter);
@@ -336,7 +336,7 @@ test('DracoWriter#geometry metadata', async (t) => {
 
   const attributes = {
     POSITION: data.attributes.POSITION.value,
-    indices: data.indices.value
+    indices: data.indices?.value
   };
 
   let compressedMesh = await encode(attributes, DracoWriter, {
@@ -396,7 +396,7 @@ test('DracoWriter#attributes metadata', async (t) => {
 
   const attributes = {
     POSITION: data.attributes.POSITION.value,
-    indices: data.indices.value
+    indices: data.indices?.value
   };
 
   let compressedMesh = await encode(attributes, DracoWriter, {
@@ -431,7 +431,7 @@ test('DracoWriter#attributes metadata', async (t) => {
   validateMeshCategoryData(t, data2);
   validatePositionMetadata(t, data2);
   t.equals(
-    Object.keys(data2.schema.fields[0].metadata).length,
+    Object.keys(data2.schema.fields[0]?.metadata || {}).length,
     7,
     'Schema: Attribute metadata correct number of keys'
   );
@@ -449,7 +449,7 @@ test('DracoWriter#metadata - should be able to define optional "name entry" for 
   const attributes = {
     POSITION: data.attributes.POSITION.value,
     featureId: data.attributes.POSITION.value,
-    indices: data.indices.value
+    indices: data.indices?.value
   };
   const compressedMesh = await encode(attributes, DracoWriter, {
     draco: {

--- a/modules/excel/src/excel-loader.ts
+++ b/modules/excel/src/excel-loader.ts
@@ -1,4 +1,7 @@
+// loaders.gl, MIT license
+
 import type {Loader, LoaderOptions} from '@loaders.gl/loader-utils';
+import type {ObjectRowTable} from '@loaders.gl/schema';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
@@ -21,7 +24,7 @@ const DEFAULT_EXCEL_LOADER_OPTIONS: ExcelLoaderOptions = {
 /**
  * Worker Loader for Excel files
  */
-export const ExcelLoader = {
+export const ExcelLoader: Loader<ObjectRowTable, never, ExcelLoaderOptions> = {
   name: 'Excel',
   id: 'excel',
   module: 'excel',

--- a/modules/excel/src/index.ts
+++ b/modules/excel/src/index.ts
@@ -1,5 +1,9 @@
+// loaders.gl, MIT license
+
 import type {LoaderWithParser} from '@loaders.gl/loader-utils';
-import {ExcelLoader as ExcelWorkerLoader, ExcelLoaderOptions} from './excel-loader';
+import type {ObjectRowTable} from '@loaders.gl/schema';
+import type {ExcelLoaderOptions} from './excel-loader';
+import {ExcelLoader as ExcelWorkerLoader} from './excel-loader';
 import {parseExcel} from './lib/parse-excel';
 
 // Excel Loader
@@ -10,10 +14,10 @@ export {ExcelWorkerLoader};
 /**
  * Loader for Excel files
  */
-export const ExcelLoader = {
+export const ExcelLoader: LoaderWithParser<ObjectRowTable, never, ExcelLoaderOptions> = {
   ...ExcelWorkerLoader,
-  parse: (arrayBuffer: ArrayBuffer, options?: ExcelLoaderOptions) =>
-    parseExcel(arrayBuffer, options)
+  async parse(arrayBuffer: ArrayBuffer, options?: ExcelLoaderOptions): Promise<ObjectRowTable> {
+    const data = parseExcel(arrayBuffer, options);
+    return {shape: 'object-row-table', data};
+  }
 };
-
-export const _typecheckLoader: LoaderWithParser = ExcelLoader;

--- a/modules/excel/src/lib/parse-excel.ts
+++ b/modules/excel/src/lib/parse-excel.ts
@@ -10,7 +10,10 @@ const dataTableNamesMap = {};
  * @param arrayBuffer Loaded data
  * @param options Data parse options.
  */
-export async function parseExcel(arrayBuffer: ArrayBuffer, options?: ExcelLoaderOptions) {
+export function parseExcel(
+  arrayBuffer: ArrayBuffer,
+  options?: ExcelLoaderOptions
+): {[key: string]: unknown}[] {
   const dataUrl = 'dummy';
   // const dataFileType: string = dataUrl.substr(dataUrl.lastIndexOf('.')); // file extension
 
@@ -21,7 +24,7 @@ export async function parseExcel(arrayBuffer: ArrayBuffer, options?: ExcelLoader
   });
 
   // load data sheets
-  let dataRows = [];
+  let dataRows: {[key: string]: unknown}[] = [];
   dataTableNamesMap[dataUrl] = [];
   if (workbook.SheetNames.length > 0) {
     if (workbook.SheetNames.length > 1) {

--- a/modules/excel/test/excel-loader.spec.js
+++ b/modules/excel/test/excel-loader.spec.js
@@ -28,7 +28,7 @@ test('ExcelLoader#loadInBatches (on worker)', async (t) => {
   // Workers are not supported under Node at the moment.
   const batches = await loadInBatches(ZIPCODES_XLSX_PATH, ExcelLoader);
   for await (const batch of batches) {
-    t.equal(batch.data.length, 42049, 'XLSX: Correct number of row received');
+    t.equal(batch.data.data.length, 42049, 'XLSX: Correct number of row received');
   }
   t.end();
 });

--- a/modules/excel/test/excel-loader.spec.js
+++ b/modules/excel/test/excel-loader.spec.js
@@ -1,6 +1,6 @@
 import test from 'tape-promise/tape';
-import {load, loadInBatches, isBrowser} from '@loaders.gl/core';
-import {ExcelLoader, ExcelWorkerLoader} from '@loaders.gl/excel';
+import {load, loadInBatches} from '@loaders.gl/core';
+import {ExcelLoader} from '@loaders.gl/excel';
 import {CSVLoader} from '@loaders.gl/csv';
 
 const ZIPCODES_XLSX_PATH = `@loaders.gl/excel/test/data/zipcodes.xlsx`;
@@ -13,21 +13,20 @@ test('ExcelLoader#load(ZIPCODES)', async (t) => {
   });
   t.equal(csvData.length, 42049, 'CSV (reference): Correct number of row received');
 
-  let data = await load(ZIPCODES_XLSB_PATH, ExcelLoader);
-  t.equal(data.length, 42049, 'XLSB: Correct number of row received');
-  t.deepEqual(data[0], csvData[0], 'XLSB: Data corresponds to CSV');
+  let table = await load(ZIPCODES_XLSB_PATH, ExcelLoader);
+  t.equal(table.data.length, 42049, 'XLSB: Correct number of row received');
+  t.deepEqual(table.data[0], csvData[0], 'XLSB: Data corresponds to CSV');
 
-  data = await load(ZIPCODES_XLSX_PATH, ExcelLoader);
-  t.equal(data.length, 42049, 'XLSX: Correct number of row received');
-  t.deepEqual(data[100], csvData[100], 'XLSX: Data corresponds to CSV');
+  table = await load(ZIPCODES_XLSX_PATH, ExcelLoader);
+  t.equal(table.data.length, 42049, 'XLSX: Correct number of row received');
+  t.deepEqual(table.data[100], csvData[100], 'XLSX: Data corresponds to CSV');
 
   t.end();
 });
 
 test('ExcelLoader#loadInBatches (on worker)', async (t) => {
   // Workers are not supported under Node at the moment.
-  const loader = isBrowser ? ExcelWorkerLoader : ExcelLoader;
-  const batches = await loadInBatches(ZIPCODES_XLSX_PATH, loader);
+  const batches = await loadInBatches(ZIPCODES_XLSX_PATH, ExcelLoader);
   for await (const batch of batches) {
     t.equal(batch.data.length, 42049, 'XLSX: Correct number of row received');
   }

--- a/modules/gis/test/gis.bench.js
+++ b/modules/gis/test/gis.bench.js
@@ -8,6 +8,7 @@ const GEOJSON_URL = '@loaders.gl/json/test/data/geojson-big.json';
 export default async function gisBench(suite) {
   suite.group('geojson-to-binary');
 
+  // @ts-expect-error
   const {features} = await load(GEOJSON_URL, JSONLoader);
   const options = {multiplier: 308, unit: 'features'};
 

--- a/modules/i3s/src/i3s-attribute-loader.ts
+++ b/modules/i3s/src/i3s-attribute-loader.ts
@@ -1,5 +1,6 @@
-import type {LoaderWithParser} from '@loaders.gl/loader-utils';
+import type {LoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';
 import {load} from '@loaders.gl/core';
+import type {I3STileAttributes} from './lib/parsers/parse-i3s-attribute';
 import {parseI3STileAttribute} from './lib/parsers/parse-i3s-attribute';
 import {getUrlWithToken} from './lib/utils/url-utils';
 
@@ -8,25 +9,24 @@ import {getUrlWithToken} from './lib/utils/url-utils';
 const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 const EMPTY_VALUE = '';
 const REJECTED_STATUS = 'rejected';
+
 /**
  * Loader for I3S attributes
  */
-export const I3SAttributeLoader: LoaderWithParser = {
+export const I3SAttributeLoader: LoaderWithParser<I3STileAttributes, never, LoaderOptions> = {
   name: 'I3S Attribute',
   id: 'i3s-attribute',
   module: 'i3s',
   version: VERSION,
   mimeTypes: ['application/binary'],
-  parse,
+  parse: async (arrayBuffer: ArrayBuffer, options?: LoaderOptions) => parseI3STileAttribute(arrayBuffer, options),
   extensions: ['bin'],
   options: {},
   binary: true
 };
 
-async function parse(data, options) {
-  data = parseI3STileAttribute(data, options);
-  return data;
-}
+
+// TODO - these seem to use the loader rather than being part of the loader. Move to different file...
 
 /**
  * Load attributes based on feature id

--- a/modules/i3s/src/i3s-node-page-loader.ts
+++ b/modules/i3s/src/i3s-node-page-loader.ts
@@ -1,28 +1,24 @@
-import type {LoaderWithParser} from '@loaders.gl/loader-utils';
+import type {LoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';
+import type {NodePage} from './types';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
 const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
-async function parseNodePage(data) {
-  return JSON.parse(new TextDecoder().decode(data));
+async function parseNodePage(data: ArrayBuffer, options?: LoaderOptions): Promise<NodePage> {
+  return JSON.parse(new TextDecoder().decode(data)) as NodePage;
 }
 
 /**
  * Loader for I3S node pages
  */
-export const I3SNodePageLoader: LoaderWithParser = {
+export const I3SNodePageLoader: LoaderWithParser<NodePage, never, LoaderOptions> = {
   name: 'I3S Node Page',
   id: 'i3s-node-page',
   module: 'i3s',
   version: VERSION,
   mimeTypes: ['application/json'],
-  parse,
+  parse: parseNodePage,
   extensions: ['json'],
   options: {}
 };
-
-async function parse(data) {
-  data = parseNodePage(data);
-  return data;
-}

--- a/modules/i3s/src/index.ts
+++ b/modules/i3s/src/index.ts
@@ -1,8 +1,5 @@
-export {I3SLoader} from './i3s-loader';
-export {I3SContentLoader} from './i3s-content-loader';
-export {I3SAttributeLoader, loadFeatureAttributes} from './i3s-attribute-loader';
-export {I3SBuildingSceneLayerLoader} from './i3s-building-scene-layer-loader';
-export {ArcGisWebSceneLoader} from './arcgis-webscene-loader';
+// loaders.gl, MIT license
+
 export type {
   BoundingVolumes,
   Mbs,
@@ -35,4 +32,13 @@ export type {
   DATA_TYPE,
   OperationalLayer
 } from './types';
+
 export {COORDINATE_SYSTEM} from './lib/parsers/constants';
+
+export {I3SLoader} from './i3s-loader';
+export {I3SContentLoader} from './i3s-content-loader';
+export {I3SAttributeLoader, loadFeatureAttributes} from './i3s-attribute-loader';
+export {I3SNodePageLoader} from './i3s-node-page-loader';
+export {I3SBuildingSceneLayerLoader} from './i3s-building-scene-layer-loader';
+
+export {ArcGisWebSceneLoader} from './arcgis-webscene-loader';

--- a/modules/i3s/src/lib/parsers/parse-arcgis-webscene.ts
+++ b/modules/i3s/src/lib/parsers/parse-arcgis-webscene.ts
@@ -90,6 +90,7 @@ async function parseOperationalLayers(
 async function checkSupportedIndexCRS(layer: OperationalLayer) {
   try {
     const layerJson = await load(layer.url, JSONLoader);
+    // @ts-expect-error
     const wkid = layerJson?.spatialReference?.wkid;
 
     if (wkid !== SUPPORTED_WKID) {

--- a/modules/i3s/src/lib/parsers/parse-i3s-attribute.ts
+++ b/modules/i3s/src/lib/parsers/parse-i3s-attribute.ts
@@ -1,3 +1,7 @@
+// loaders.gl, MIT license
+
+import {TypedArray} from '@loaders.gl/schema';
+
 import {
   STRING_ATTRIBUTE_TYPE,
   OBJECT_ID_ATTRIBUTE_TYPE,
@@ -5,13 +9,16 @@ import {
   INT_16_ATTRIBUTE_TYPE
 } from './constants';
 
+type Attribute = string[] | TypedArray | null;
+export type I3STileAttributes = Record<string, Attribute>;
+
 /**
  * Get particular tile and creates attribute object inside.
- * @param {ArrayBuffer} arrayBuffer
+ * @param  arrayBuffer
  * @param {Object} options
  * @returns {Promise<object>}
  */
-export async function parseI3STileAttribute(arrayBuffer, options) {
+export function parseI3STileAttribute(arrayBuffer: ArrayBuffer, options): I3STileAttributes {
   const {attributeName, attributeType} = options;
 
   if (!attributeName) {
@@ -25,10 +32,10 @@ export async function parseI3STileAttribute(arrayBuffer, options) {
 /**
  * Parse attributes based on attribute type.
  * @param {String} attributeType
- * @param {ArrayBuffer} arrayBuffer
- * @returns {any}
+ * @param  arrayBuffer
+ * @returns
  */
-function parseAttribute(attributeType, arrayBuffer) {
+function parseAttribute(attributeType, arrayBuffer: ArrayBuffer): Attribute {
   switch (attributeType) {
     case STRING_ATTRIBUTE_TYPE:
       return parseStringsAttribute(arrayBuffer);
@@ -46,10 +53,10 @@ function parseAttribute(attributeType, arrayBuffer) {
 /**
  * Parse short number attribute.
  * Short Integer spec - https://github.com/Esri/i3s-spec/blob/master/docs/1.7/attributeStorageInfo.cmn.md
- * @param {ArrayBuffer} arrayBuffer
- * @returns {Uint32Array}
+ * @param  arrayBuffer
+ * @returns
  */
-function parseShortNumberAttribute(arrayBuffer) {
+function parseShortNumberAttribute(arrayBuffer: ArrayBuffer): Uint32Array {
   const countOffset = 4;
   return new Uint32Array(arrayBuffer, countOffset);
 }
@@ -57,10 +64,10 @@ function parseShortNumberAttribute(arrayBuffer) {
 /**
  * Parse Int16 short number attribute.
  * Parsing of such data is not documented. Added to handle Building Scene Layer Tileset attributes data.
- * @param {ArrayBuffer} arrayBuffer
- * @returns {Int16Array}
+ * @param  arrayBuffer
+ * @returns
  */
-function parseInt16ShortNumberAttribute(arrayBuffer) {
+function parseInt16ShortNumberAttribute(arrayBuffer: ArrayBuffer): Int16Array {
   const countOffset = 4;
   return new Int16Array(arrayBuffer, countOffset);
 }
@@ -68,10 +75,10 @@ function parseInt16ShortNumberAttribute(arrayBuffer) {
 /**
  * Parse float attribute.
  * Double Spec - https://github.com/Esri/i3s-spec/blob/master/docs/1.7/attributeStorageInfo.cmn.md
- * @param {ArrayBuffer} arrayBuffer
- * @returns {Float64Array}
+ * @param  arrayBuffer
+ * @returns
  */
-function parseFloatAttribute(arrayBuffer) {
+function parseFloatAttribute(arrayBuffer: ArrayBuffer): Float64Array {
   const countOffset = 8;
   return new Float64Array(arrayBuffer, countOffset);
 }

--- a/modules/i3s/src/lib/parsers/parse-i3s-tile-content.ts
+++ b/modules/i3s/src/lib/parsers/parse-i3s-tile-content.ts
@@ -78,18 +78,23 @@ export async function parseI3STileContent(
         } catch (e) {
           // context object is different between worker and node.js conversion script.
           // To prevent error we parse data in ordinary way if it is not parsed by using context.
+          // @ts-expect-error
           content.texture = await parse(arrayBuffer, loader, options);
         }
       } else if (loader === CompressedTextureLoader || loader === BasisLoader) {
         let texture = await load(arrayBuffer, loader, tileOptions.textureLoaderOptions);
         if (loader === BasisLoader) {
+          // @ts-expect-error
           texture = texture[0];
         }
         content.texture = {
           compressed: true,
           mipmaps: false,
+          // @ts-expect-error
           width: texture[0].width,
+          // @ts-expect-error
           height: texture[0].height,
+          // @ts-expect-error
           data: texture
         };
       }

--- a/modules/i3s/src/lib/utils/customizeColors.ts
+++ b/modules/i3s/src/lib/utils/customizeColors.ts
@@ -64,8 +64,11 @@ export async function customizeColors(
   }
 
   const attributeValuesMap: {[key: number]: COLOR} = {};
+  // @ts-expect-error
   for (let i = 0; i < objectIdAttributeData[objectIdField.name].length; i++) {
+    // @ts-expect-error
     attributeValuesMap[objectIdAttributeData[objectIdField.name][i]] = calculateColorForAttribute(
+      // @ts-expect-error
       colorizeAttributeData[colorizeAttributeField.name][i] as number,
       options
     );
@@ -114,7 +117,7 @@ async function loadFeatureAttributeData(
   {attributeUrls}: I3STileOptions,
   {attributeStorageInfo}: I3STilesetOptions,
   options?: I3SLoaderOptions
-): Promise<{[key: string]: string[] | Uint32Array | Uint16Array | Float64Array} | null> {
+): Promise<{[key: string]: string[] | Uint32Array | Uint16Array | Float64Array | null} | null> {
   const attributeIndex = attributeStorageInfo.findIndex(({name}) => attributeName === name);
   if (attributeIndex === -1) {
     return null;
@@ -125,5 +128,7 @@ async function loadFeatureAttributeData(
     attributeName,
     attributeType
   });
+
+  // @ts-expect-error TODO action engine
   return objectIdAttributeData;
 }

--- a/modules/i3s/test/i3s-attribute-loader.spec.js
+++ b/modules/i3s/test/i3s-attribute-loader.spec.js
@@ -1,7 +1,9 @@
 import test from 'tape-promise/tape';
-// @ts-expect-error
-import {I3SAttributeLoader, loadFeatureAttributes} from '@loaders.gl/i3s/i3s-attribute-loader';
+
 import {load} from '@loaders.gl/core';
+import {I3SAttributeLoader} from '@loaders.gl/i3s';
+// @ts-expect-error
+import {loadFeatureAttributes} from '@loaders.gl/i3s/i3s-attribute-loader';
 
 const objectIdsUrl = '@loaders.gl/i3s/test/data/attributes/f_0/0/index.bin';
 const namesUrl = '@loaders.gl/i3s/test/data/attributes/f_1/0/index.bin';
@@ -180,7 +182,7 @@ test('I3SAttributeLoader# should load OBJECTID attribute', async (t) => {
   const attributes = await load(objectIdsUrl, I3SAttributeLoader, options);
   t.ok(attributes);
   t.ok(attributes.OBJECTID);
-  t.equal(attributes.OBJECTID[0], objecId0);
+  t.equal(attributes.OBJECTID?.[0], objecId0);
   t.end();
 });
 
@@ -192,7 +194,7 @@ test('I3SAttributeLoader# should load string attribute', async (t) => {
   const attributes = await load(namesUrl, I3SAttributeLoader, options);
   t.ok(attributes);
   t.ok(attributes.NAME);
-  t.equal(attributes.NAME[602], name602);
+  t.equal(attributes.NAME?.[602], name602);
   t.end();
 });
 
@@ -204,7 +206,7 @@ test('I3SAttributeLoader# should load float attribute', async (t) => {
   const attributes = await load(heightRoofUrl, I3SAttributeLoader, options);
   t.ok(attributes);
   t.ok(attributes.HEIGHTROOF);
-  t.equal(attributes.HEIGHTROOF[0], heightRoof0);
+  t.equal(attributes.HEIGHTROOF?.[0], heightRoof0);
   t.end();
 });
 

--- a/modules/i3s/test/i3s-node-page-loader.spec.js
+++ b/modules/i3s/test/i3s-node-page-loader.spec.js
@@ -1,7 +1,6 @@
 import test from 'tape-promise/tape';
 import {parse, fetchFile} from '@loaders.gl/core';
-// @ts-expect-error
-import {I3SNodePageLoader} from '@loaders.gl/i3s/i3s-node-page-loader';
+import {I3SNodePageLoader} from '@loaders.gl/i3s';
 
 const NODEPAGE_URL =
   '@loaders.gl/i3s/test/data/SanFrancisco_3DObjects_1_7/SceneServer/layers/0/nodepages/0';

--- a/modules/images/src/types.ts
+++ b/modules/images/src/types.ts
@@ -11,7 +11,7 @@ export type ImageDataType = {
 /**
  * Supported Image Types
  */
-export type ImageType = ImageBitmap | ImageDataType | typeof Image;
+export type ImageType = ImageBitmap | ImageDataType | HTMLImageElement;
 
 /**
  * Image type string used to control or determine the type of images returned from ImageLoader

--- a/modules/images/test/image-loader.spec.ts
+++ b/modules/images/test/image-loader.spec.ts
@@ -62,6 +62,7 @@ test('ImageLoader#load({type: \'data\'})', async (t) => {
     t.equal(getImageType(imageData), 'data', `${title} image type is data`);
     t.equal(imageData.width, width, `${title} image has correct width`);
     t.equal(imageData.height, height, `${title} image has correct height`);
+    // @ts-expect-error
     t.ok(ArrayBuffer.isView(imageData.data), `${title} image data is TypedArray`);
   }
 

--- a/modules/images/test/image-writer.spec.ts
+++ b/modules/images/test/image-writer.spec.ts
@@ -43,6 +43,7 @@ test('ImageWriter#write-and-read-image', async (t) => {
   image = await parse(arrayBuffer, ImageLoader, {image: {type: 'data'}});
   t.deepEqual(image.width, IMAGE.width, 'encoded and parsed image widths are same');
   t.deepEqual(image.height, IMAGE.height, 'encoded and parsed image heightsare same');
+  // @ts-expect-error
   t.deepEqual(image.data, IMAGE.data, 'encoded and parsed image data are same');
 
   t.end();

--- a/modules/json/src/geojson-loader.ts
+++ b/modules/json/src/geojson-loader.ts
@@ -5,6 +5,7 @@ import type {JSONLoaderOptions} from './json-loader';
 import {geojsonToBinary} from '@loaders.gl/gis';
 import {parseJSONSync} from './lib/parsers/parse-json';
 import {parseJSONInBatches} from './lib/parsers/parse-json-in-batches';
+import {GeoJSONRowTable} from '@loaders.gl/schema';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
@@ -63,12 +64,13 @@ function parseTextSync(text, options) {
   options = {...DEFAULT_GEOJSON_LOADER_OPTIONS, ...options};
   options.json = {...DEFAULT_GEOJSON_LOADER_OPTIONS.geojson, ...options.geojson};
   options.gis = options.gis || {};
-  const json = parseJSONSync(text, options);
+  const table = parseJSONSync(text, options) as GeoJSONRowTable;
+  table.shape = 'geojson-row-table';
   switch (options.gis.format) {
     case 'binary':
-      return geojsonToBinary(json);
+      return geojsonToBinary(table.data);
     default:
-      return json;
+      return table;
   }
 }
 

--- a/modules/json/src/geojson-loader.ts
+++ b/modules/json/src/geojson-loader.ts
@@ -3,8 +3,8 @@
 import type {Loader, LoaderWithParser} from '@loaders.gl/loader-utils';
 import type {JSONLoaderOptions} from './json-loader';
 import {geojsonToBinary} from '@loaders.gl/gis';
-import parseJSONSync from './lib/parsers/parse-json';
-import parseJSONInBatches from './lib/parsers/parse-json-in-batches';
+import {parseJSONSync} from './lib/parsers/parse-json';
+import {parseJSONInBatches} from './lib/parsers/parse-json-in-batches';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.

--- a/modules/json/src/json-loader.ts
+++ b/modules/json/src/json-loader.ts
@@ -2,8 +2,8 @@
 
 import type {Table, TableBatch} from '@loaders.gl/schema';
 import type {LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';
-import parseJSONSync from './lib/parsers/parse-json';
-import parseJSONInBatches from './lib/parsers/parse-json-in-batches';
+import {parseJSONSync} from './lib/parsers/parse-json';
+import {parseJSONInBatches} from './lib/parsers/parse-json-in-batches';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.

--- a/modules/json/src/lib/parsers/parse-json-in-batches.ts
+++ b/modules/json/src/lib/parsers/parse-json-in-batches.ts
@@ -7,7 +7,7 @@ import JSONPath from '../jsonpath/jsonpath';
 
 // TODO - support batch size 0 = no batching/single batch?
 // eslint-disable-next-line max-statements, complexity
-export default async function* parseJSONInBatches(
+export async function* parseJSONInBatches(
   binaryAsyncIterator: AsyncIterable<ArrayBuffer> | Iterable<ArrayBuffer>,
   options: JSONLoaderOptions
 ): AsyncIterable<TableBatch> {

--- a/modules/json/src/lib/parsers/parse-json.ts
+++ b/modules/json/src/lib/parsers/parse-json.ts
@@ -2,7 +2,7 @@
 
 import type {JSONLoaderOptions} from '../../json-loader';
 
-export default function parseJSONSync(jsonText: string, options: JSONLoaderOptions) {
+export function parseJSONSync(jsonText: string, options: JSONLoaderOptions) {
   try {
     const json = JSON.parse(jsonText);
     if (options.json?.table) {

--- a/modules/json/src/lib/parsers/parse-json.ts
+++ b/modules/json/src/lib/parsers/parse-json.ts
@@ -1,8 +1,7 @@
 // loaders.gl, MIT license
-import type { RowTable } from '@loaders.gl/schema';
-import { makeTableFromArray } from '@loaders.gl/schema';
+import type {RowTable} from '@loaders.gl/schema';
+import {makeTableFromArray} from '@loaders.gl/schema';
 import type {JSONLoaderOptions} from '../../json-loader';
-
 
 export function parseJSONSync(jsonText: string, options: JSONLoaderOptions): RowTable {
   try {

--- a/modules/json/src/lib/parsers/parse-json.ts
+++ b/modules/json/src/lib/parsers/parse-json.ts
@@ -1,12 +1,15 @@
 // loaders.gl, MIT license
-
+import type { RowTable } from '@loaders.gl/schema';
+import { makeTableFromArray } from '@loaders.gl/schema';
 import type {JSONLoaderOptions} from '../../json-loader';
 
-export function parseJSONSync(jsonText: string, options: JSONLoaderOptions) {
+
+export function parseJSONSync(jsonText: string, options: JSONLoaderOptions): RowTable {
   try {
     const json = JSON.parse(jsonText);
     if (options.json?.table) {
-      return getFirstArray(json) || json;
+      const data = getFirstArray(json) || json;
+      return makeTableFromArray(data);
     }
     return json;
   } catch (error) {

--- a/modules/json/src/lib/parsers/parse-ndjson-in-batches.ts
+++ b/modules/json/src/lib/parsers/parse-ndjson-in-batches.ts
@@ -7,7 +7,7 @@ import {
   makeTextDecoderIterator
 } from '@loaders.gl/loader-utils';
 
-export default async function* parseNDJSONInBatches(
+export async function* parseNDJSONInBatches(
   binaryAsyncIterator: AsyncIterable<ArrayBuffer> | Iterable<ArrayBuffer>,
   options?: LoaderOptions
 ): AsyncIterable<Batch> {

--- a/modules/json/src/lib/parsers/parse-ndjson.ts
+++ b/modules/json/src/lib/parsers/parse-ndjson.ts
@@ -1,4 +1,5 @@
-import {ArrayRowTable, ObjectRowTable} from '@loaders.gl/schema';
+import type {ArrayRowTable, ObjectRowTable} from '@loaders.gl/schema';
+import {makeTableFromArray} from '@loaders.gl/schema';
 
 export function parseNDJSONSync(ndjsonText: string): ArrayRowTable | ObjectRowTable {
   const lines = ndjsonText.trim().split('\n');
@@ -9,19 +10,6 @@ export function parseNDJSONSync(ndjsonText: string): ArrayRowTable | ObjectRowTa
       throw new Error(`NDJSONLoader: failed to parse JSON on line ${counter + 1}`);
     }
   });
-  if (parsedLines.length === 0) {
-    return {shape: 'array-row-table', schema: {fields: [], metadata: {}}, data: []};
-  }
-  const firstRow = parsedLines[0];
-  if (firstRow && typeof firstRow === 'object') {
-    return {shape: 'object-row-table', data: parsedLines};
-  }
-  if (Array.isArray(firstRow)) {
-    return {shape: 'array-row-table', data: parsedLines};
-  }
 
-  // TODO - deduce schema
-
-  // TODO - we could wrap JS primitive in array?
-  throw new Error('ndjson not a table');
+  return makeTableFromArray(parsedLines);
 }

--- a/modules/json/src/lib/parsers/parse-ndjson.ts
+++ b/modules/json/src/lib/parsers/parse-ndjson.ts
@@ -1,10 +1,27 @@
-export default function parseNDJSONSync(ndjsonText: string) {
+import {ArrayRowTable, ObjectRowTable} from '@loaders.gl/schema';
+
+export function parseNDJSONSync(ndjsonText: string): ArrayRowTable | ObjectRowTable {
   const lines = ndjsonText.trim().split('\n');
-  return lines.map((line, counter) => {
+  const parsedLines = lines.map((line, counter) => {
     try {
       return JSON.parse(line);
     } catch (error) {
       throw new Error(`NDJSONLoader: failed to parse JSON on line ${counter + 1}`);
     }
   });
+  if (parsedLines.length === 0) {
+    return {shape: 'array-row-table', schema: {fields: [], metadata: {}}, data: []};
+  }
+  const firstRow = parsedLines[0];
+  if (firstRow && typeof firstRow === 'object') {
+    return {shape: 'object-row-table', data: parsedLines};
+  }
+  if (Array.isArray(firstRow)) {
+    return {shape: 'array-row-table', data: parsedLines};
+  }
+
+  // TODO - deduce schema
+
+  // TODO - we could wrap JS primitive in array?
+  throw new Error('ndjson not a table');
 }

--- a/modules/json/src/ndgeoson-loader.ts
+++ b/modules/json/src/ndgeoson-loader.ts
@@ -1,6 +1,6 @@
 import type {LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';
-import parseNDJSONSync from './lib/parsers/parse-ndjson';
-import parseNDJSONInBatches from './lib/parsers/parse-ndjson-in-batches';
+import {parseNDJSONSync} from './lib/parsers/parse-ndjson';
+import {parseNDJSONInBatches} from './lib/parsers/parse-ndjson-in-batches';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.

--- a/modules/json/src/ndjson-loader.ts
+++ b/modules/json/src/ndjson-loader.ts
@@ -1,13 +1,19 @@
 // loaders.gl, MIT license
 
-import parseNDJSONSync from './lib/parsers/parse-ndjson';
-import parseNDJSONInBatches from './lib/parsers/parse-ndjson-in-batches';
+import {LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';
+import {ObjectRowTable, ArrayRowTable, TableBatch} from '@loaders.gl/schema';
+import {parseNDJSONSync} from './lib/parsers/parse-ndjson';
+import {parseNDJSONInBatches} from './lib/parsers/parse-ndjson-in-batches';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
 const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
-export const NDJSONLoader = {
+export const NDJSONLoader: LoaderWithParser<
+  ObjectRowTable | ArrayRowTable,
+  TableBatch,
+  LoaderOptions
+> = {
   name: 'NDJSON',
   id: 'ndjson',
   module: 'json',

--- a/modules/json/test/json-loader.spec.ts
+++ b/modules/json/test/json-loader.spec.ts
@@ -6,8 +6,12 @@ const GEOJSON_PATH = '@loaders.gl/json/test/data/geojson-big.json';
 const GEOJSON_KEPLER_DATASET_PATH = '@loaders.gl/json/test/data/kepler-dataset-sf-incidents.json';
 
 test('JSONLoader#load(geojson.json)', async (t) => {
-  const data = await load(GEOJSON_PATH, JSONLoader, {json: {table: true}});
-  t.equal(data.length, 308, 'Correct number of row received');
+  const table = await load(GEOJSON_PATH, JSONLoader, {json: {table: true}});
+  t.equal(
+    table.shape === 'object-row-table' && table.data.length,
+    308,
+    'Correct number of row received'
+  );
   t.end();
 });
 

--- a/modules/json/test/ndjson-loader.spec.ts
+++ b/modules/json/test/ndjson-loader.spec.ts
@@ -6,8 +6,8 @@ const NDJSON_PATH = '@loaders.gl/json/test/data/ndjson.ndjson';
 const NDJSON_INVALID_PATH = '@loaders.gl/json/test/data/ndjson-invalid.ndjson';
 
 test('NDJSONLoader#load(ndjson.ndjson)', async (t) => {
-  const data = await load(NDJSON_PATH, NDJSONLoader);
-  t.equal(data.length, 11, 'Correct number of rows received');
+  const table = await load(NDJSON_PATH, NDJSONLoader);
+  t.equal(table.data.length, 11, 'Correct number of rows received');
   t.end();
 });
 

--- a/modules/las/src/index.ts
+++ b/modules/las/src/index.ts
@@ -1,5 +1,6 @@
 import type {LoaderWithParser} from '@loaders.gl/loader-utils';
 import type {LASLoaderOptions} from './las-loader';
+import type {LASMesh} from './lib/las-types';
 import {LASLoader as LASWorkerLoader} from './las-loader';
 import {parseLAS} from './lib/parse-las';
 
@@ -8,13 +9,10 @@ import {parseLAS} from './lib/parse-las';
 export type {LASLoaderOptions};
 export {LASWorkerLoader};
 
-type PromiseType<T> = T extends Promise<infer Return> ? Return : T;
-type Type = PromiseType<ReturnType<typeof parseLAS>>;
-
 /**
  * Loader for the LAS (LASer) point cloud format
  */
-export const LASLoader: LoaderWithParser<Type, never, LASLoaderOptions> = {
+export const LASLoader: LoaderWithParser<LASMesh, never, LASLoaderOptions> = {
   ...LASWorkerLoader,
   parse: async (arrayBuffer: ArrayBuffer, options?: LASLoaderOptions) =>
     parseLAS(arrayBuffer, options),

--- a/modules/las/src/las-loader.ts
+++ b/modules/las/src/las-loader.ts
@@ -1,6 +1,6 @@
 // LASER (LAS) FILE FORMAT
 import type {Loader, LoaderOptions} from '@loaders.gl/loader-utils';
-import {parseLAS} from './lib/parse-las';
+import type {LASMesh} from './lib/las-types';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
@@ -24,13 +24,10 @@ const DEFAULT_LAS_OPTIONS: LASLoaderOptions = {
   }
 };
 
-type PromiseType<T> = T extends Promise<infer Return> ? Return : T;
-type Type = PromiseType<ReturnType<typeof parseLAS>>;
-
 /**
  * Loader for the LAS (LASer) point cloud format
  */
-export const LASLoader: Loader<Type, never, LASLoaderOptions> = {
+export const LASLoader: Loader<LASMesh, never, LASLoaderOptions> = {
   name: 'LAS',
   id: 'las',
   module: 'las',

--- a/modules/las/src/lib/parse-las.ts
+++ b/modules/las/src/lib/parse-las.ts
@@ -1,5 +1,5 @@
 // ported and es6-ified from https://github.com/verma/plasio/
-import type {ArrowTable, ColumnarTable} from '@loaders.gl/schema';
+// import type {ArrowTable, ColumnarTable} from '@loaders.gl/schema';
 import type {LASLoaderOptions} from '../las-loader';
 import type {LASMesh, LASHeader} from './las-types';
 import {getMeshBoundingBox /* , convertMesh */} from '@loaders.gl/schema';
@@ -20,10 +20,7 @@ type LASChunk = {
  * @param options
  * @returns LASHeader
  */
-export function parseLAS(
-  arrayBuffer: ArrayBuffer,
-  options?: LASLoaderOptions
-): LASMesh | ArrowTable | ColumnarTable {
+export function parseLAS(arrayBuffer: ArrayBuffer, options?: LASLoaderOptions): LASMesh {
   return parseLASMesh(arrayBuffer, options);
   // This code breaks pointcloud example on the website
   // const mesh = parseLASMesh(arrayBuffer, options);

--- a/modules/las/test/las-loader.spec.js
+++ b/modules/las/test/las-loader.spec.js
@@ -8,7 +8,7 @@ import {
 
 import {LASLoader, LASWorkerLoader} from '@loaders.gl/las';
 import {setLoaderOptions, fetchFile, parse, load} from '@loaders.gl/core';
-import {ArrowLoader} from '@loaders.gl/arrow';
+// import {ArrowLoader} from '@loaders.gl/arrow';
 
 const LAS_BINARY_URL = '@loaders.gl/las/test/data/indoor.laz';
 const LAS_EXTRABYTES_BINARY_URL = '@loaders.gl/las/test/data/extrabytes.laz';
@@ -27,7 +27,7 @@ test('LASLoader#parse(binary)', async (t) => {
   const data = await parse(fetchFile(LAS_BINARY_URL), LASLoader, {las: {skip: 10}, worker: false});
   validateMeshCategoryData(t, data);
 
-  t.is(data.header.vertexCount, data.loaderData.totalRead, 'Original header was found');
+  t.is(data.header?.vertexCount, data.loaderData.totalRead, 'Original header was found');
   t.equal(data.mode, 0, 'mode is POINTS (0)');
 
   t.notOk(data.indices, 'INDICES attribute was not preset');
@@ -65,7 +65,7 @@ test('LASWorker#parse(binary) extra bytes', async (t) => {
   });
   validateMeshCategoryData(t, data);
 
-  t.is(data.header.vertexCount, data.loaderData.totalRead, 'Original header was found');
+  t.is(data.header?.vertexCount, data.loaderData.totalRead, 'Original header was found');
   t.equal(data.mode, 0, 'mode is POINTS (0)');
 
   t.notOk(data.indices, 'INDICES attribute was not preset');
@@ -104,6 +104,7 @@ test.skip('LASLoader#shape="columnar-table"', async (t) => {
 });
 
 // Related code was commented due to breaking pointcloud example on the website
+/*
 test.skip('LAS#shape="arrow-table"', async (t) => {
   const result = await parse(fetchFile(LAS_BINARY_URL), LASLoader, {
     las: {shape: 'arrow-table', skip: 10},
@@ -143,3 +144,4 @@ test.skip('LAS#shape="arrow-table"', async (t) => {
   t.equals(arrowData.POSITION[0].data.values.length, 3);
   t.end();
 });
+*/

--- a/modules/loader-utils/test/lib/iterators/async-iteration.spec.ts
+++ b/modules/loader-utils/test/lib/iterators/async-iteration.spec.ts
@@ -11,7 +11,7 @@ import {
 
 import {NDJSONLoader} from '@loaders.gl/json';
 
-const parseNDJSONInBatches = NDJSONLoader.parseInBatches;
+const parseNDJSONInBatches = NDJSONLoader.parseInBatches!;
 
 const setTimeoutPromise = (timeout) => new Promise((resolve) => setTimeout(resolve, timeout));
 

--- a/modules/loader-utils/test/lib/iterators/make-iterator.spec.ts
+++ b/modules/loader-utils/test/lib/iterators/make-iterator.spec.ts
@@ -18,7 +18,7 @@ function asyncArrayBuffers() {
 }
 
 test('concatenateArrayBuffersAsync', async (t) => {
-  const RESULT = `line 1\nline 2\nline 3\nline 4`;
+  const RESULT = 'line 1\nline 2\nline 3\nline 4';
 
   // const text = await concatenateArrayBuffersAsync(asyncTexts());
   // t.is(text, RESULT, 'returns concatenated string');

--- a/modules/loader-utils/test/lib/iterators/make-transform-iterator.spec.ts
+++ b/modules/loader-utils/test/lib/iterators/make-transform-iterator.spec.ts
@@ -34,7 +34,7 @@ test('byteLengthTransform', async (t) => {
     }
   });
 
-  const transformedChunks = [];
+  const transformedChunks: ArrayBuffer[] = [];
   for await (const chunk of transformIterator) {
     transformedChunks.push(chunk);
   }

--- a/modules/obj/src/lib/get-obj-schema.ts
+++ b/modules/obj/src/lib/get-obj-schema.ts
@@ -1,11 +1,10 @@
-import {Schema, Field, getArrowType} from '@loaders.gl/schema';
+import {Schema, SchemaMetadata, Field, getArrowType} from '@loaders.gl/schema';
 
-export function getOBJSchema(attributes, metadata = {}): Schema {
-  let metadataMap;
+export function getOBJSchema(attributes, metadata: Record<string, unknown> = {}): Schema {
+  const stringMetadata: SchemaMetadata = {};
   for (const key in metadata) {
-    metadataMap = metadataMap || new Map();
     if (key !== 'value') {
-      metadataMap.set(key, JSON.stringify(metadata[key]));
+      stringMetadata[key] = JSON.stringify(metadata[key]);
     }
   }
 
@@ -15,7 +14,8 @@ export function getOBJSchema(attributes, metadata = {}): Schema {
     const field = getArrowFieldFromAttribute(attributeName, attribute);
     fields.push(field);
   }
-  return {fields, metadata: metadataMap};
+
+  return {fields, metadata: stringMetadata};
 }
 
 function getArrowFieldFromAttribute(name: string, attribute): Field {

--- a/modules/obj/test/obj-loader.spec.js
+++ b/modules/obj/test/obj-loader.spec.js
@@ -36,16 +36,18 @@ test('OBJLoader#parse(SCHEMA)', async (t) => {
   validateMeshCategoryData(t, data);
 
   t.equal(data.schema.fields.length, 3, 'schema field count is correct');
-  t.equal(data.schema.metadata.get('mode'), '4', 'schema metadata is correct');
-  t.ok(data.schema.metadata.get('boundingBox'), 'schema metadata is correct');
+  t.equal(data.schema.metadata.mode, '4', 'schema metadata is correct');
+  t.ok(data.schema.metadata.boundingBox, 'schema metadata is correct');
 
   const positionField = data.schema.fields.find((field) => field.name === 'POSITION');
-  t.equal(positionField.type.listSize, 3, 'schema size correct');
+  // @ts-expect-error
+  t.equal(positionField?.type.listSize, 3, 'schema size correct');
   // TODO/ActionEngine - restore this test
   // t.equal(positionField.type.valueType.precision, 32, 'schema type correct');
 
   const colorField = data.schema.fields.find((field) => field.name === 'TEXCOORD_0');
-  t.equal(colorField.type.listSize, 2, 'schema size correct');
+  // @ts-expect-error
+  t.equal(colorField?.type.listSize, 2, 'schema size correct');
 
   t.equal(data.mode, 4, 'mode is correct');
   t.notOk(data.indices, 'INDICES attribute was not found');
@@ -70,7 +72,7 @@ test('OBJLoader#parseText - multi-part object', async (t) => {
   const data = await load(OBJ_MULTI_PART_URL, OBJLoader);
   validateMeshCategoryData(t, data);
 
-  t.equal(data.header.vertexCount, 1372 * 3, 'Vertices are loaded');
+  t.equal(data.header?.vertexCount, 1372 * 3, 'Vertices are loaded');
   t.end();
 });
 

--- a/modules/parquet/src/index.ts
+++ b/modules/parquet/src/index.ts
@@ -1,22 +1,25 @@
+// loaders.gl, MIT license
+
 import type {LoaderWithParser} from '@loaders.gl/loader-utils';
+import {Table as ArrowTable} from 'apache-arrow';
 
 // ParquetLoader
 
 import {ParquetWasmLoader as ParquetWasmWorkerLoader} from './parquet-wasm-loader';
-import {ParquetLoader as ParquetWorkerLoader} from './parquet-loader';
+import {ParquetLoader as ParquetWorkerLoader, ParquetLoaderOptions} from './parquet-loader';
 import {parseParquet, parseParquetFileInBatches} from './lib/parse-parquet';
-import {parseParquet as parseParquetWasm} from './lib/wasm/parse-parquet-wasm';
+import {parseParquetWasm, ParquetWasmLoaderOptions} from './lib/wasm/parse-parquet-wasm';
 
 export {ParquetWorkerLoader, ParquetWasmWorkerLoader};
 
 /** ParquetJS table loader */
-export const ParquetLoader = {
+export const ParquetLoader: LoaderWithParser<any[][], any[][], ParquetLoaderOptions> = {
   ...ParquetWorkerLoader,
   parse: parseParquet,
   parseFileInBatches: parseParquetFileInBatches
 };
 
-export const ParquetWasmLoader = {
+export const ParquetWasmLoader: LoaderWithParser<ArrowTable, never, ParquetWasmLoaderOptions> = {
   ...ParquetWasmWorkerLoader,
   parse: parseParquetWasm
 };

--- a/modules/parquet/src/lib/parse-parquet.ts
+++ b/modules/parquet/src/lib/parse-parquet.ts
@@ -3,15 +3,22 @@ import type {ParquetLoaderOptions} from '../parquet-loader';
 
 import {ParquetReader} from '../parquetjs/parser/parquet-reader';
 
-export async function parseParquet(arrayBuffer: ArrayBuffer, options?: ParquetLoaderOptions) {
+export async function parseParquet(
+  arrayBuffer: ArrayBuffer,
+  options?: ParquetLoaderOptions
+): Promise<any[][]> {
   const blob = new Blob([arrayBuffer]);
   for await (const batch of parseParquetFileInBatches(blob, options)) {
+    // we have only one input batch so return
     return batch;
   }
-  return null;
+  return [];
 }
 
-export async function* parseParquetFileInBatches(blob: Blob, options?: ParquetLoaderOptions) {
+export async function* parseParquetFileInBatches(
+  blob: Blob,
+  options?: ParquetLoaderOptions
+): AsyncIterable<any[][]> {
   const reader = await ParquetReader.openBlob(blob);
   const rows: any[][] = [];
   try {

--- a/modules/parquet/src/lib/wasm/parse-parquet-wasm.ts
+++ b/modules/parquet/src/lib/wasm/parse-parquet-wasm.ts
@@ -1,20 +1,20 @@
 // eslint-disable
 import type {RecordBatch} from 'apache-arrow';
 import type {LoaderOptions} from '@loaders.gl/loader-utils';
-import {Table, RecordBatchStreamReader} from 'apache-arrow';
+import {Table as ArrowTable, RecordBatchStreamReader} from 'apache-arrow';
 import {loadWasm} from './load-wasm/load-wasm-node';
 
-export type ParquetLoaderOptions = LoaderOptions & {
+export type ParquetWasmLoaderOptions = LoaderOptions & {
   parquet?: {
     type?: 'arrow-table';
     wasmUrl?: string;
   };
 };
 
-export async function parseParquet(
+export async function parseParquetWasm(
   arrayBuffer: ArrayBuffer,
-  options?: ParquetLoaderOptions
-): Promise<Table> {
+  options?: ParquetWasmLoaderOptions
+): Promise<ArrowTable> {
   const wasmUrl = options?.parquet?.wasmUrl;
   const wasm = await loadWasm(wasmUrl);
 
@@ -32,11 +32,11 @@ export async function parseParquet(
  * Deserialize the IPC format into a {@link Table}. This function is a
  * convenience wrapper for {@link RecordBatchReader}. Opposite of {@link tableToIPC}.
  */
-function tableFromIPC(input: ArrayBuffer): Table {
+function tableFromIPC(input: ArrayBuffer): ArrowTable {
   const reader = RecordBatchStreamReader.from(input);
   const recordBatches: RecordBatch[] = [];
   for (const recordBatch of reader) {
     recordBatches.push(recordBatch);
   }
-  return new Table(recordBatches);
+  return new ArrowTable(recordBatches);
 }

--- a/modules/parquet/src/parquet-loader.ts
+++ b/modules/parquet/src/parquet-loader.ts
@@ -19,7 +19,7 @@ const DEFAULT_PARQUET_LOADER_OPTIONS: ParquetLoaderOptions = {
 };
 
 /** ParquetJS table loader */
-export const ParquetLoader = {
+export const ParquetLoader: Loader<any[][], any[][], ParquetLoaderOptions> = {
   name: 'Apache Parquet',
   id: 'parquet',
   module: 'parquet',
@@ -32,5 +32,3 @@ export const ParquetLoader = {
   tests: ['PAR1', 'PARE'],
   options: DEFAULT_PARQUET_LOADER_OPTIONS
 };
-
-export const _typecheckParquetLoader: Loader = ParquetLoader;

--- a/modules/pcd/test/pcd-loader.spec.js
+++ b/modules/pcd/test/pcd-loader.spec.js
@@ -27,12 +27,16 @@ test('PCDLoader#parse(text)', async (t) => {
   t.ok(data.schema.metadata.boundingBox, 'schema metadata is correct');
 
   const positionField = data.schema.fields.find((field) => field.name === 'POSITION');
+  // @ts-expect-error
   t.equal(positionField?.type?.listSize, 3, 'schema size correct');
+  // @ts-expect-error
   t.equal(positionField?.type?.children[0]?.type, 'float32', 'schema type correct');
   // t.equal(positionField.type.valueType.precision, 32, 'schema type correct');
 
   const colorField = data.schema.fields.find((field) => field.name === 'COLOR_0');
+  // @ts-expect-error
   t.equal(colorField?.type?.listSize, 3, 'schema size correct');
+  // @ts-expect-error
   t.equal(colorField?.type?.children[0]?.type, 'uint8', 'schema type correct');
   // t.equal(colorField.type.valueType.bitWidth, 8, 'schema type correct');
   // t.equal(colorField.type.valueType.isSigned, false, 'schema type correct');

--- a/modules/schema/src/index.ts
+++ b/modules/schema/src/index.ts
@@ -1,11 +1,12 @@
 // COMMON CATEGORY
 export type {TypedArray, NumberArray, AnyArray} from './types/types';
 
-export type {Schema, Field, DataType, Batch} from './types/schema';
+export type {Schema, Field, DataType, Batch, SchemaMetadata, FieldMetadata} from './types/schema';
 
 // TABLE CATEGORY TYPES
 export type {
   Table,
+  RowTable,
   ArrayRowTable,
   ObjectRowTable,
   GeoJSONRowTable,
@@ -45,6 +46,8 @@ export {
 export {ArrowLikeTable} from './lib/table/arrow-api/arrow-like-table';
 
 export {convertToObjectRow, convertToArrayRow} from './lib/table/utilities/row-utils';
+
+export {makeTableFromArray} from './lib/table/utilities/make-table';
 
 // MESH CATEGORY
 export type {

--- a/modules/schema/src/lib/table/utilities/deduce-column-type.ts
+++ b/modules/schema/src/lib/table/utilities/deduce-column-type.ts
@@ -1,6 +1,6 @@
 // loaders.gl, MIT license
 
-import {DataType} from '../../../types/schema';
+import {DataType, Field} from '../../../types/schema';
 
 export function getTypeFromTypedArray(arrayBufferView: ArrayBufferView): DataType {
   switch (arrayBufferView.constructor) {
@@ -32,17 +32,20 @@ export function getTypeFromTypedArray(arrayBufferView: ArrayBufferView): DataTyp
   // }
 }
 
-export function getTypeFromValue(value: unknown): DataType {
+export function getTypeFromValue(value: unknown, defaultNumberType: 'float32' = 'float32'): Omit<Field, 'name'> {
   if (value instanceof Date) {
-    return 'date-millisecond';
+    return {type: 'date-millisecond'};
   }
   if (value instanceof Number) {
-    return 'float64';
+    return {type: defaultNumberType};
   }
   if (typeof value === 'string') {
-    return 'utf8';
+    return {type: 'utf8'};
   }
-  return 'null';
+  if (value === null || value === 'undefined') {
+    return {type: 'null'};
+  }
+  return {type: 'null'};
 }
 
 /*

--- a/modules/schema/src/lib/table/utilities/deduce-column-type.ts
+++ b/modules/schema/src/lib/table/utilities/deduce-column-type.ts
@@ -32,7 +32,10 @@ export function getTypeFromTypedArray(arrayBufferView: ArrayBufferView): DataTyp
   // }
 }
 
-export function getTypeFromValue(value: unknown, defaultNumberType: 'float32' = 'float32'): Omit<Field, 'name'> {
+export function getTypeFromValue(
+  value: unknown,
+  defaultNumberType: 'float32' = 'float32'
+): Omit<Field, 'name'> {
   if (value instanceof Date) {
     return {type: 'date-millisecond'};
   }

--- a/modules/schema/src/lib/table/utilities/deduce-table-schema.ts
+++ b/modules/schema/src/lib/table/utilities/deduce-table-schema.ts
@@ -68,21 +68,21 @@ function deduceFieldFromColumn(column: unknown, name: string): Field {
     // TODO - support nested schemas?
     return {
       name,
-      type,
       nullable: true,
-      metadata: {}
+      metadata: {},
+      ...type
     };
   }
 
   throw new Error('empty table');
 }
 
-function deduceFieldFromValue(value: unknown, name: string) {
+function deduceFieldFromValue(value: unknown, name: string): Field {
   const type = getTypeFromValue(value);
   return {
     name,
-    type,
     nullable: true,
-    metadata: {}
+    metadata: {},
+    ...type
   };
 }

--- a/modules/schema/src/lib/table/utilities/make-table.ts
+++ b/modules/schema/src/lib/table/utilities/make-table.ts
@@ -1,11 +1,11 @@
 import {Table, ArrayRowTable, ObjectRowTable} from '../../../types/category-table';
-import { deduceTableSchema } from './deduce-table-schema';
+import {deduceTableSchema} from './deduce-table-schema';
 
 /** Helper that wraps an array a loaders.gl Table object and deduces shape and schema */
 export function makeTableFromArray(
-  array: unknown[], 
+  array: unknown[],
   defaultShape: 'array-row-table' | 'object-row-table' = 'array-row-table'
-):  ArrayRowTable | ObjectRowTable {
+): ArrayRowTable | ObjectRowTable {
   if (array.length === 0) {
     return {shape: defaultShape, schema: {fields: [], metadata: {}}, data: []};
   }

--- a/modules/schema/src/lib/table/utilities/make-table.ts
+++ b/modules/schema/src/lib/table/utilities/make-table.ts
@@ -1,0 +1,27 @@
+import {Table, ArrayRowTable, ObjectRowTable} from '../../../types/category-table';
+import { deduceTableSchema } from './deduce-table-schema';
+
+/** Helper that wraps an array a loaders.gl Table object and deduces shape and schema */
+export function makeTableFromArray(
+  array: unknown[], 
+  defaultShape: 'array-row-table' | 'object-row-table' = 'array-row-table'
+):  ArrayRowTable | ObjectRowTable {
+  if (array.length === 0) {
+    return {shape: defaultShape, schema: {fields: [], metadata: {}}, data: []};
+  }
+
+  // Deduce the table shape from the first row
+  const firstRow = array[0];
+  if (firstRow && typeof firstRow === 'object') {
+    const table: Table = {shape: 'object-row-table', data: array as {[key: string]: unknown}[]};
+    const schema = deduceTableSchema(table);
+    return {...table, schema};
+  }
+  if (Array.isArray(firstRow)) {
+    const table: Table = {shape: 'array-row-table', data: array as unknown[][]};
+    const schema = deduceTableSchema(table);
+    return {...table, schema};
+  }
+
+  throw new Error('invalid table');
+}

--- a/modules/textures/test/basis-loader.spec.js
+++ b/modules/textures/test/basis-loader.spec.js
@@ -64,14 +64,15 @@ test('BasisLoader#auto-select a target format', async (t) => {
 
   if (isBrowser) {
     t.ok(
-      [
-        GL_EXTENSIONS_CONSTANTS.COMPRESSED_RGBA_ASTC_4X4_KHR,
-        GL_EXTENSIONS_CONSTANTS.COMPRESSED_RGB_S3TC_DXT1_EXT,
-        GL_EXTENSIONS_CONSTANTS.COMPRESSED_RGBA_S3TC_DXT5_EXT,
-        GL_EXTENSIONS_CONSTANTS.COMPRESSED_RGB_PVRTC_4BPPV1_IMG,
-        GL_EXTENSIONS_CONSTANTS.COMPRESSED_RGBA_PVRTC_4BPPV1_IMG,
-        GL_EXTENSIONS_CONSTANTS.COMPRESSED_RGB_ETC1_WEBGL
-      ].includes(image.format),
+      typeof image.format === 'number' &&
+        [
+          GL_EXTENSIONS_CONSTANTS.COMPRESSED_RGBA_ASTC_4X4_KHR,
+          GL_EXTENSIONS_CONSTANTS.COMPRESSED_RGB_S3TC_DXT1_EXT,
+          GL_EXTENSIONS_CONSTANTS.COMPRESSED_RGBA_S3TC_DXT5_EXT,
+          GL_EXTENSIONS_CONSTANTS.COMPRESSED_RGB_PVRTC_4BPPV1_IMG,
+          GL_EXTENSIONS_CONSTANTS.COMPRESSED_RGBA_PVRTC_4BPPV1_IMG,
+          GL_EXTENSIONS_CONSTANTS.COMPRESSED_RGB_ETC1_WEBGL
+        ].includes(image.format),
       'Browser supports one of GPU textures formats'
     );
     t.ok(image.compressed, 'Basis transcodes to compressed texture');

--- a/yarn.lock
+++ b/yarn.lock
@@ -4197,9 +4197,9 @@ camelize@^1.0.0:
   integrity sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==
 
 caniuse-lite@^1.0.30001400:
-  version "1.0.30001447"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001447.tgz"
-  integrity sha512-bdKU1BQDPeEXe9A39xJnGtY0uRq/z5osrnXUw0TcK+EYno45Y+U7QU9HhHEyzvMDffpYadFXi3idnSNkcwLkTw==
+  version "1.0.30001448"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001448.tgz"
+  integrity sha512-tq2YI+MJnooG96XpbTRYkBxLxklZPOdLmNIOdIhvf7SNJan6u5vCKum8iT7ZfCt70m1GPkuC7P3TtX6UuhupuA==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
- Use TypeScript type inference to extract return type and options types from loader objects, so that `load` and `parse` calls (at least against a single specific loader) will be properly typed.
- Start adding the necessary typings to loader objects
- Deal with resulting typing issues in test cases etc.