### PR TITLE
feat(wms): AdHocImageSource - initial URL template support

### DIFF
--- a/examples/website/wms/app.tsx
+++ b/examples/website/wms/app.tsx
@@ -28,6 +28,7 @@ export default class App extends PureComponent {
     selectedExample: string;
     loading: true;
     metadata: string | '';
+    error: string | '';
   } = {
     // CURRENT VIEW POINT / CAMERA POSITIO
     viewState: INITIAL_VIEW_STATE,
@@ -58,7 +59,7 @@ export default class App extends PureComponent {
   }
 
   _renderControlPanel() {
-    const {selectedExample, viewState, selectedCategory, loading, metadata} = this.state;
+    const {selectedExample, viewState, selectedCategory, loading, metadata, error} = this.state;
 
     return (
       <ControlPanel
@@ -69,6 +70,9 @@ export default class App extends PureComponent {
         loading={loading}
         metadata={metadata}
       >
+        {
+          error ? <div style={{color: 'red'}}>{error}</div> : ''
+        }
         <div style={{textAlign: 'center'}}>
           long/lat: {viewState.longitude.toFixed(5)},{viewState.latitude.toFixed(5)}, zoom:
           {viewState.zoom.toFixed(2)}
@@ -86,11 +90,13 @@ export default class App extends PureComponent {
       return
     }
 
-    const {serviceUrl, layers, opacity = 1} = EXAMPLES[selectedCategory][selectedExample];
+    const {service, serviceType, 
+      layers, opacity = 1} = EXAMPLES[selectedCategory][selectedExample];
 
     return [
       new ImageryLayer({
-        service: serviceUrl,
+        service,
+        serviceType, 
         layers,
 
         pickable: true,
@@ -141,7 +147,7 @@ export default class App extends PureComponent {
           layers={this._renderLayer()}
           viewState={viewState}
           onViewStateChange={this._onViewStateChange}
-          onError={(error) => console.error(`deck.gl: ${error}`)}
+          onError={(error: Error) => this.setState({error: error.message})}
           controller={{type: MapController, maxPitch: 85}}
           getTooltip ={({object}) => object && {
             html: `<h2>${object.name}</h2><div>${object.message}</div>`,

--- a/examples/website/wms/examples.js
+++ b/examples/website/wms/examples.js
@@ -28,36 +28,36 @@ export const EXAMPLES = {
       viewState: {...VIEW_STATE}
     },
     'Canadian Weather': {
-      serviceUrl: 'https://geo.weather.gc.ca/geomet',
+      service: 'https://geo.weather.gc.ca/geomet',
       serviceType: 'wsm',
       layers: ['GDPS.ETA_TT'], // 'RDPS.CONV_KINDEX.PT3H'],
       viewState: {...VIEW_STATE, longitude: -100, latitude: 55, zoom: 3},
       opacity: 0.5
     },
     'Deutscher Wetterdienst': {
-      serviceUrl: 'https://maps.dwd.de/geoserver/dwd/wms',
+      service: 'https://maps.dwd.de/geoserver/dwd/wms',
       layers: ['Cwam_reg025_fd_sl_DD10M'],
       viewState: {...VIEW_STATE, longitude: 16, latitude: 54, zoom: 3.6},
       opacity: 0.5
     },
     'Trigger Error (No Layer)': {
-      serviceUrl: 'https://geo.weather.gc.ca/geomet',
+      service: 'https://geo.weather.gc.ca/geomet',
       layers: [],
       viewState: {...VIEW_STATE, longitude: -100, latitude: 55, zoom: 3}
     },
   },
   ImageServer: {
     NLCDLandCover2001: {
-      service: 'https://sampleserver6.arcgisonline.com/arcgis/rest/services/NLCDLandCover2001/ImageServer',
+      service: 'https://sampleserver6.arcgisonline.com/arcgis/rest/services/NLCDLandCover2001/ImageServer/exportImage?bbox=${east},${north},${west},${south}&bboxSR=4326&size=${width},${height}&imageSR=102100&time=&format=jpgpng&pixelType=U8&noData=&noDataInterpretation=esriNoDataMatchAny&interpolation=+RSP_NearestNeighbor&compression=&compressionQuality=&bandIds=&mosaicRule=&renderingRule=&f=image',
       serviceType: 'template',
       viewState: {...VIEW_STATE}
     },
     ArcGISSampleImageryLayer: {
-      serviceUrl: 'https://developers.arcgis.com/javascript/latest/sample-code/layers-imagerylayer/',
+      service: 'https://developers.arcgis.com/javascript/latest/sample-code/layers-imagerylayer/',
       viewState: {...VIEW_STATE}
     },
     ArcGISExportedImage: {
-      serviceUrl: 'https://developers.arcgis.com/rest/services-reference/enterprise/export-image.htm',
+      service: 'https://developers.arcgis.com/rest/services-reference/enterprise/export-image.htm',
       viewState: {...VIEW_STATE}
     }
   }

--- a/examples/website/wms/examples.js
+++ b/examples/website/wms/examples.js
@@ -22,12 +22,14 @@ export const EXAMPLES = {
       // const imageUrl = `https://ows.terrestris.de/osm/service?width=${width}&height=${height}&bbox=${bounds[0]},${bounds[1]},${bounds[2]},${bounds[3]}&srs=EPSG:4326&format=image%2Fpng&request=GetMap&service=WMS&styles=&transparent=TRUE&version=1.1.1&layers=OSM-WMS`;
       // TODO: change in the URL `srs=EPSG:4326` to `srs=EPSG:900913`
       // once we can change the TileLayer bounds from lat/lon to web mercator coordinates
-      serviceUrl: `https://ows.terrestris.de/osm/service`,
+      service: `https://ows.terrestris.de/osm/service`,
+      serviceType: 'wsm',
       layers: ['OSM-WMS'],
       viewState: {...VIEW_STATE}
     },
     'Canadian Weather': {
       serviceUrl: 'https://geo.weather.gc.ca/geomet',
+      serviceType: 'wsm',
       layers: ['GDPS.ETA_TT'], // 'RDPS.CONV_KINDEX.PT3H'],
       viewState: {...VIEW_STATE, longitude: -100, latitude: 55, zoom: 3},
       opacity: 0.5
@@ -46,7 +48,8 @@ export const EXAMPLES = {
   },
   ImageServer: {
     NLCDLandCover2001: {
-      serviceUrl: 'https://sampleserver6.arcgisonline.com/arcgis/rest/services/NLCDLandCover2001/ImageServer',
+      service: 'https://sampleserver6.arcgisonline.com/arcgis/rest/services/NLCDLandCover2001/ImageServer',
+      serviceType: 'template',
       viewState: {...VIEW_STATE}
     },
     ArcGISSampleImageryLayer: {

--- a/modules/wms/src/index.ts
+++ b/modules/wms/src/index.ts
@@ -16,7 +16,7 @@ export {WMSService} from './lib/data-sources/wms-service';
 export type {ImageSourceMetadata as _ImageSourceMetadata} from './lib/data-sources/image-source';
 export {ImageSource as _ImageSource} from './lib/data-sources/image-source';
 
-export {ImageService as _ImageService} from './lib/data-sources/image-service';
+export {AdHocImageService as _AdHocImageService} from './lib/data-sources/adhoc-image-service';
 
 // WIP /////////////////////////////////////////////////////////////////
 // Plumbing set up but details of parsing and typing not yet completed

--- a/modules/wms/src/index.ts
+++ b/modules/wms/src/index.ts
@@ -16,6 +16,8 @@ export {WMSService} from './lib/data-sources/wms-service';
 export type {ImageSourceMetadata as _ImageSourceMetadata} from './lib/data-sources/image-source';
 export {ImageSource as _ImageSource} from './lib/data-sources/image-source';
 
+export {ImageService as _ImageService} from './lib/data-sources/image-service';
+
 // WIP /////////////////////////////////////////////////////////////////
 // Plumbing set up but details of parsing and typing not yet completed
 

--- a/modules/wms/src/lib/data-sources/image-service.ts
+++ b/modules/wms/src/lib/data-sources/image-service.ts
@@ -1,0 +1,48 @@
+// loaders.gl, MIT license
+
+import type {ImageType} from '@loaders.gl/images';
+import {ImageLoader} from '@loaders.gl/images';
+
+import type {ImageSourceMetadata, GetImageParameters} from './image-source';
+import {ImageSource} from './image-source';
+
+/** Accepts a template string and builds requests URLs */
+export class ImageService extends ImageSource {
+  template: string;
+
+  constructor(props: {template: string}) {
+    super();
+    this.template = props.template;
+  }
+
+  // IMAGE SOURCE API
+
+  async getMetadata(): Promise<ImageSourceMetadata> {
+    throw new Error('ImageSource.getMetadata not implemented');
+  }
+
+  async getImage(parameters: GetImageParameters): Promise<ImageType> {
+    const granularParameters = this.getGranularParameters(parameters);
+    const url = this.getURLFromTemplate(granularParameters);
+    const response = await fetch(url);
+    const arrayBuffer = await response.arrayBuffer();
+    return await ImageLoader.parse(arrayBuffer);
+  }
+
+  // HELPERS
+
+  /** Break up bounding box in east, north, south, west */
+  protected getGranularParameters(parameters: GetImageParameters): Record<string, unknown> {
+    const [east, north, south, west] = parameters.bbox;
+    return {...parameters, east, north, south, west};
+  }
+
+  protected getURLFromTemplate(parameters: Record<string, unknown>): string {
+    let url = this.template;
+    for (const [key, value] of Object.keys(parameters)) {
+      const regex = new RegExp(`{${key}}`, 'g');
+      url = url.replace(regex, String(value));
+    }
+    return this.template;
+  }
+}

--- a/modules/wms/src/lib/data-sources/image-source.ts
+++ b/modules/wms/src/lib/data-sources/image-source.ts
@@ -47,6 +47,30 @@ export type GetImageParameters = {
   format?: 'image/png';
 };
 
+// Attempt to break down GetImageParameters
+export type ImageFilters = {
+  /** Layers to render */
+  layers: string | string[];
+  /** Styling */
+  styles?: unknown;
+};
+
+export type ImageRegion = {
+  /** bounding box of the requested map image */
+  bbox: [number, number, number, number];
+};
+
+export type ImageFormat = {
+  /** pixel width of returned image */
+  width: number;
+  /** pixels */
+  height: number;
+  /** srs for the image (not the bounding box) */
+  srs?: string;
+  /** requested format for the return image */
+  format?: 'image/png';
+};
+
 /**
  * MapImageSource - data sources that allow data to be queried by (geospatial) extents
  * @note

--- a/modules/wms/src/lib/data-sources/image-source.ts
+++ b/modules/wms/src/lib/data-sources/image-source.ts
@@ -1,8 +1,6 @@
 // loaders.gl, MIT license
 
-import {ImageType} from '@loaders.gl/images';
-
-// ImageSource
+import type {ImageType} from '@loaders.gl/images';
 
 /**
  * Normalized capabilities of an Image service
@@ -32,7 +30,7 @@ export type ImageSourceLayer = {
   layers: ImageSourceLayer[];
 };
 
-export type ImageSourceGetImageParameters = {
+export type GetImageParameters = {
   /** Layers to render */
   layers: string | string[];
   /** Styling */
@@ -56,5 +54,5 @@ export type ImageSourceGetImageParameters = {
  */
 export abstract class ImageSource {
   abstract getMetadata(): Promise<ImageSourceMetadata>;
-  abstract getImage(parameters: ImageSourceGetImageParameters): Promise<ImageType>;
+  abstract getImage(parameters: GetImageParameters): Promise<ImageType>;
 }

--- a/modules/wms/src/lib/data-sources/wms-service.ts
+++ b/modules/wms/src/lib/data-sources/wms-service.ts
@@ -91,7 +91,7 @@ export type WMSGetLegendGraphicParameters = WMSCommonParameters & {
 /** Properties that can be specified when creating a new WMS service */
 export type WMSServiceProps = {
   /** Base URL to the service */
-  url: string;
+  serviceUrl: string;
   /** Any load options to the loaders.gl Loaders used by the WMSService methods */
   loadOptions?: LoaderOptions;
   /** Override the fetch function if required */
@@ -106,7 +106,7 @@ export type WMSServiceProps = {
  * @note Only the URL parameter conversion is supported. XML posts are not supported.
  */
 export class WMSService extends ImageSource {
-  url: string;
+  serviceUrl: string;
   loadOptions: LoaderOptions = {
     // We want error responses to throw exceptions, the WMSErrorLoader can do this
     wms: {throwOnError: true}
@@ -125,7 +125,7 @@ export class WMSService extends ImageSource {
   /** Create a WMSService */
   constructor(props: WMSServiceProps) {
     super();
-    this.url = props.url;
+    this.serviceUrl = props.serviceUrl;
     // TODO Need an options merge function from loaders.gl to merge subobjects
     Object.assign(this.loadOptions, props.loadOptions);
     this.fetch = props.fetch || fetch;
@@ -316,7 +316,7 @@ export class WMSService extends ImageSource {
     options: Record<string, unknown>,
     vendorParameters?: Record<string, unknown>
   ): string {
-    let url = `${this.url}`;
+    let url = `${this.serviceUrl}`;
     let first = true;
     for (const [key, value] of Object.entries(options)) {
       url += first ? '?' : '&';

--- a/modules/wms/src/lib/data-sources/wms-service.ts
+++ b/modules/wms/src/lib/data-sources/wms-service.ts
@@ -2,21 +2,18 @@
 
 /* eslint-disable camelcase */
 
-import type {
-  WMSCapabilities,
-  _WMSFeatureInfo as WMSFeatureInfo,
-  _WMSLayerDescription as WMSLayerDescription
-} from '@loaders.gl/wms';
-import {
-  WMSCapabilitiesLoader,
-  _WMSFeatureInfoLoader as WMSFeatureInfoLoader,
-  _WMSLayerDescriptionLoader as WMSLayerDescriptionLoader,
-  WMSErrorLoader
-} from '@loaders.gl/wms';
-import {ImageLoader, ImageType} from '@loaders.gl/images';
+import type {ImageType} from '@loaders.gl/images';
+import {ImageLoader} from '@loaders.gl/images';
 import {LoaderOptions} from '@loaders.gl/loader-utils';
 
-import {ImageSource, ImageSourceMetadata, ImageSourceGetImageParameters} from './image-source';
+import type {ImageSourceMetadata, GetImageParameters} from './image-source';
+import {ImageSource} from './image-source';
+
+import type {WMSCapabilities, WMSFeatureInfo, WMSLayerDescription} from '../wms/wms-types';
+import {WMSCapabilitiesLoader} from '../../wms-capabilities-loader';
+import {WMSFeatureInfoLoader} from '../../wip/wms-feature-info-loader';
+import {WMSLayerDescriptionLoader} from '../../wip/wms-layer-description-loader';
+import {WMSErrorLoader} from '../../wms-error-loader';
 
 type FetchLike = (url: string, options?: RequestInit) => Promise<Response>;
 
@@ -139,8 +136,8 @@ export class WMSService extends ImageSource {
     return this.getCapabilities();
   }
 
-  getImage(parameters: ImageSourceGetImageParameters): Promise<ImageType> {
-    return this.getImage(parameters);
+  getImage(parameters: GetImageParameters): Promise<ImageType> {
+    return this.getMap(parameters);
   }
 
   // WMS Service API Stubs

--- a/modules/wms/test/data-sources/wms-service.spec.ts
+++ b/modules/wms/test/data-sources/wms-service.spec.ts
@@ -7,7 +7,7 @@ import {WMSService} from '@loaders.gl/wms';
 const WMS_SERVICE_URL = 'https:/mock-wms-service';
 
 test('WMSService#', async (t) => {
-  const wmsService = new WMSService({url: WMS_SERVICE_URL});
+  const wmsService = new WMSService({serviceUrl: WMS_SERVICE_URL});
   const getCapabilitiesUrl = wmsService.getCapabilitiesURL();
 
   t.equal(
@@ -19,7 +19,7 @@ test('WMSService#', async (t) => {
 });
 
 test('WMSService#getMapURL', async (t) => {
-  const wmsService = new WMSService({url: WMS_SERVICE_URL});
+  const wmsService = new WMSService({serviceUrl: WMS_SERVICE_URL});
   const getMapUrl = wmsService.getMapURL({
     width: 800,
     height: 600,
@@ -35,14 +35,14 @@ test('WMSService#getMapURL', async (t) => {
 });
 
 test('WMSService#getFeatureInfoURL', async (t) => {
-  // const wmsService = new WMSService({url: WMS_SERVICE_URL});
+  // const wmsService = new WMSService({serviceUrl: WMS_SERVICE_URL});
   // const getFeatureInfoUrl = wmsService.getFeatureInfoURL({x: 400, y: 300});
   // t.equal(getFeatureInfoUrl, 'https:/mock-wms-service?REQUEST=GetFeatureInfo', 'getFeatureInfoURL');
   t.end();
 });
 
 test('WMSService#describeLayerURL', async (t) => {
-  const wmsService = new WMSService({url: WMS_SERVICE_URL});
+  const wmsService = new WMSService({serviceUrl: WMS_SERVICE_URL});
   const describeLayerUrl = wmsService.describeLayerURL({});
   t.equal(
     describeLayerUrl,
@@ -53,7 +53,7 @@ test('WMSService#describeLayerURL', async (t) => {
 });
 
 test('WMSService#getLegendGraphicURL', async (t) => {
-  const wmsService = new WMSService({url: WMS_SERVICE_URL});
+  const wmsService = new WMSService({serviceUrl: WMS_SERVICE_URL});
   const getLegendGraphicUrl = wmsService.getLegendGraphicURL({});
   t.equal(
     getLegendGraphicUrl,


### PR DESCRIPTION
Add new `AdHocImageSource` that allows URL template strings to be used as data sources to quickly wire up new imagery sources.

Tested with ArcGISImageServer template URL:

<img width="810" alt="Screen Shot 2023-02-03 at 4 19 40 PM" src="https://user-images.githubusercontent.com/7025232/216712848-cdf16ce1-5f84-44ae-9ed9-de042c263b82.png">
