### PR TITLE
fix(wms): Unbundle LERCLoader to unblock esbuild applications

### DIFF
--- a/modules/wms/src/index.ts
+++ b/modules/wms/src/index.ts
@@ -49,5 +49,6 @@ export {GMLLoader as _GMLLoader} from './wip/gml-loader';
 
 // LERC
 
-export type {LERCData} from './lib/lerc/lerc-types';
-export {LERCLoader} from './lerc-loader';
+// TODO - restore once esbuild bundling issues have been resolved
+// export type {LERCData} from './lib/lerc/lerc-types';
+// export {LERCLoader} from './lerc-loader';

--- a/modules/wms/test/lerc/lerc-level2.spec.ts
+++ b/modules/wms/test/lerc/lerc-level2.spec.ts
@@ -7,7 +7,8 @@
 import test from 'tape-promise/tape';
 // import {validateLoader} from 'test/common/conformance';
 
-import {LERCLoader, LERCData} from '@loaders.gl/wms';
+import type {LERCData} from '@loaders.gl/wms/lib/lerc/lerc-types';
+import {LERCLoader} from '@loaders.gl/wms/lerc-loader';
 import {load, isBrowser} from '@loaders.gl/core';
 
 const LERC_FILES = [

--- a/modules/wms/test/lerc/lerc-level2.spec.ts
+++ b/modules/wms/test/lerc/lerc-level2.spec.ts
@@ -7,8 +7,9 @@
 import test from 'tape-promise/tape';
 // import {validateLoader} from 'test/common/conformance';
 
-import type {LERCData} from '@loaders.gl/wms/lib/lerc/lerc-types';
-import {LERCLoader} from '@loaders.gl/wms/lerc-loader';
+// import {LERCLoader, LERCData} from '@loaders.gl/wms';
+import type {LERCData} from '../../src/lib/lerc/lerc-types';
+import {LERCLoader} from '../../src/lerc-loader';
 import {load, isBrowser} from '@loaders.gl/core';
 
 const LERC_FILES = [

--- a/modules/wms/test/lerc/lerc-sanity.spec.ts
+++ b/modules/wms/test/lerc/lerc-sanity.spec.ts
@@ -7,7 +7,9 @@
 import test from 'tape-promise/tape';
 // import {validateLoader} from 'test/common/conformance';
 
-import {LERCLoader, LERCData} from '@loaders.gl/wms';
+// import {LERCLoader, LERCData} from '@loaders.gl/wms';
+import type {LERCData} from '@loaders.gl/wms/lib/lerc/lerc-types';
+import {LERCLoader} from '@loaders.gl/wms/lerc-loader';
 import {parse, isBrowser} from '@loaders.gl/core';
 
 /***************

--- a/modules/wms/test/lerc/lerc-sanity.spec.ts
+++ b/modules/wms/test/lerc/lerc-sanity.spec.ts
@@ -8,8 +8,8 @@ import test from 'tape-promise/tape';
 // import {validateLoader} from 'test/common/conformance';
 
 // import {LERCLoader, LERCData} from '@loaders.gl/wms';
-import type {LERCData} from '@loaders.gl/wms/lib/lerc/lerc-types';
-import {LERCLoader} from '@loaders.gl/wms/lerc-loader';
+import type {LERCData} from '../../src/lib/lerc/lerc-types';
+import {LERCLoader} from '../../src/lerc-loader';
 import {parse, isBrowser} from '@loaders.gl/core';
 
 /***************


### PR DESCRIPTION
Need to fix bundling issues before including this loader.