### PR TITLE
fix(loader-utils): Add missing types

### DIFF
--- a/modules/loader-utils/src/types.ts
+++ b/modules/loader-utils/src/types.ts
@@ -129,11 +129,11 @@ export type Loader = {
   binary?: boolean;
   text?: boolean;
 
-  tests?: (((ArrayBuffer) => boolean) | ArrayBuffer | string)[];
+  tests?: (((ArrayBuffer: ArrayBuffer) => boolean) | ArrayBuffer | string)[];
 
   // TODO - deprecated
   supported?: boolean;
-  testText?: (string) => boolean;
+  testText?: (string: string) => boolean;
 };
 
 /**
@@ -142,7 +142,7 @@ export type Loader = {
  */
 export type LoaderWithParser = Loader & {
   // TODO - deprecated
-  testText?: (string) => boolean;
+  testText?: (string: string) => boolean;
 
   parse: Parse;
   preload?: Preload;
@@ -189,19 +189,19 @@ export type LoaderContext = {
   fetch: typeof fetch;
   parse: (
     arrayBuffer: ArrayBuffer,
-    loaders?,
+    loaders?: Loader | Loader[] | LoaderOptions,
     options?: LoaderOptions,
     context?: LoaderContext
   ) => Promise<any>;
   parseSync?: (
     arrayBuffer: ArrayBuffer,
-    loaders?,
+    loaders?: Loader | Loader[] | LoaderOptions,
     options?: LoaderOptions,
     context?: LoaderContext
   ) => any;
   parseInBatches?: (
     iterator: AsyncIterable<ArrayBuffer> | Iterable<ArrayBuffer>,
-    loaders?,
+    loaders?: Loader | Loader[] | LoaderOptions,
     options?: LoaderOptions,
     context?: LoaderContext
   ) => AsyncIterable<any> | Promise<AsyncIterable<any>>;
@@ -295,7 +295,7 @@ export interface IFileSystem {
 
 type ReadOptions = {buffer?: ArrayBuffer; offset?: number; length?: number; position?: number};
 export interface IRandomAccessReadFileSystem extends IFileSystem {
-  open(path: string, flags, mode?): Promise<any>;
+  open(path: string, flags: string | number, mode?: any): Promise<any>;
   close(fd: any): Promise<void>;
   fstat(fd: any): Promise<object>;
   read(fd: any, options?: ReadOptions): Promise<{bytesRead: number; buffer: Buffer}>;


### PR DESCRIPTION
For https://github.com/visgl/loaders.gl/issues/2372#issue-1598175555

I hope it's fine. I removed `"noImplicitAny": false,` from root `tsconfig.json` to see the issues (there are more in other files). Build passed, everything seems to be fine.

But I don't know the code well, so I got inspired from files implementing fixed interfaces/types. Basically those files were well typed, so I just copied those types to lower level.