### PR TITLE
Fix vite deps + add types to loader-utils/src/types.ts

### DIFF
--- a/examples/get-started/bundle-with-vite/package.json
+++ b/examples/get-started/bundle-with-vite/package.json
@@ -13,7 +13,7 @@
     "@loaders.gl/gltf": "^3.3.1"
   },
   "devDependencies": {
-    "typescript": "^4.3.2",
-    "vite": "^4.9.5"
+    "typescript": "^4.9.5",
+    "vite": "^4.2.1"
   }
 }

--- a/examples/get-started/bundle-with-vite/tsconfig.json
+++ b/examples/get-started/bundle-with-vite/tsconfig.json
@@ -16,5 +16,5 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": ["./app.js"]
+  "include": ["./app.ts"]
 }

--- a/modules/loader-utils/src/lib/path-utils/path.ts
+++ b/modules/loader-utils/src/lib/path-utils/path.ts
@@ -15,7 +15,7 @@ export function filename(url: string): string {
  */
 export function dirname(url: string): string {
   const slashIndex = url ? url.lastIndexOf('/') : -1;
-  return slashIndex >= 0 ? url.substr(0, slashIndex ) : '';
+  return slashIndex >= 0 ? url.substr(0, slashIndex) : '';
 }
 
 /**

--- a/modules/loader-utils/src/types.ts
+++ b/modules/loader-utils/src/types.ts
@@ -133,11 +133,11 @@ export type Loader = {
   binary?: boolean;
   text?: boolean;
 
-  tests?: (((ArrayBuffer) => boolean) | ArrayBuffer | string)[];
+  tests?: (((ArrayBuffer: ArrayBuffer) => boolean) | ArrayBuffer | string)[];
 
   // TODO - deprecated
   supported?: boolean;
-  testText?: (string) => boolean;
+  testText?: (string: string) => boolean;
 };
 
 /**
@@ -146,7 +146,7 @@ export type Loader = {
  */
 export type LoaderWithParser = Loader & {
   // TODO - deprecated
-  testText?: (string) => boolean;
+  testText?: (string: string) => boolean;
 
   parse: Parse;
   preload?: Preload;
@@ -200,19 +200,19 @@ export type LoaderContext = {
   response?: Response;
   parse: (
     arrayBuffer: ArrayBuffer,
-    loaders?,
+    loaders?: Loader | Loader[] | LoaderOptions,
     options?: LoaderOptions,
     context?: LoaderContext
   ) => Promise<any>;
   parseSync?: (
     arrayBuffer: ArrayBuffer,
-    loaders?,
+    loaders?: Loader | Loader[] | LoaderOptions,
     options?: LoaderOptions,
     context?: LoaderContext
   ) => any;
   parseInBatches?: (
     iterator: AsyncIterable<ArrayBuffer> | Iterable<ArrayBuffer>,
-    loaders?,
+    loaders?: Loader | Loader[] | LoaderOptions,
     options?: LoaderOptions,
     context?: LoaderContext
   ) => AsyncIterable<any> | Promise<AsyncIterable<any>>;
@@ -306,7 +306,7 @@ export interface IFileSystem {
 
 type ReadOptions = {buffer?: ArrayBuffer; offset?: number; length?: number; position?: number};
 export interface IRandomAccessReadFileSystem extends IFileSystem {
-  open(path: string, flags, mode?): Promise<any>;
+  open(path: string, flags: string | number, mode?: any): Promise<any>;
   close(fd: any): Promise<void>;
   fstat(fd: any): Promise<object>;
   read(fd: any, options?: ReadOptions): Promise<{bytesRead: number; buffer: Buffer}>;


### PR DESCRIPTION
Hi,

regarding to https://github.com/visgl/loaders.gl/pull/2373.

- (examples/get-started/bundle-with-vite) fixed `vite` version (previous one does not exist)
- (examples/get-started/bundle-with-vite) fixed `tsconfig.json` to use correct `app.ts`
- (modules/loader-utils/src/lib/path-utils/path.ts) added types mentioned in https://github.com/visgl/loaders.gl/issues/2372#issuecomment-1443417094 and my previous PR https://github.com/visgl/loaders.gl/pull/2373

I'm still not able to build `vite` locally, but at least it has correct version and I can continue. There are some TS errors in other modules similar to `loader-utils` ^^ it seems. `app.ts` can be fixed quickly, but I don't know what to do with `apache-arrow`

![image](https://user-images.githubusercontent.com/23722745/229902058-b4f06511-0ba1-4a60-a3dd-2bdb194c015f.png)

 
