### PR TITLE
(feat)tiles: add boundingBox to Tile3D class

### DIFF
--- a/modules/3d-tiles/wip/tile-3d-header.md
+++ b/modules/3d-tiles/wip/tile-3d-header.md
@@ -31,9 +31,9 @@ Get the bounding volume of the tile's contents. This defaults to the
 tile's bounding volume when the content's bounding volume is
 `undefined`.
 
-### boundingSphere : BoundingSphere
+### boundingBox : [number[], number[]]
 
-Get the bounding sphere derived from the tile's bounding volume.
+Get the bounding box in cartographic coordinates. Returns `[min, max]` in `[longitude, latitude, altitude]`.
 
 ### extras : any
 

--- a/modules/tiles/src/tileset/tile-3d.ts
+++ b/modules/tiles/src/tileset/tile-3d.ts
@@ -13,7 +13,7 @@ import type {Tileset3D} from './tileset-3d';
 import {TILE_REFINEMENT, TILE_CONTENT_STATE, TILESET_TYPE} from '../constants';
 
 import {FrameState} from './helpers/frame-state';
-import {createBoundingVolume} from './helpers/bounding-volume';
+import {createBoundingVolume, getCartographicBounds} from './helpers/bounding-volume';
 import {getTiles3DScreenSpaceError} from './helpers/tiles-3d-lod';
 import {getProjectedRadius} from './helpers/i3s-lod';
 import {get3dTilesOptions} from './helpers/3d-tiles-options';
@@ -85,6 +85,8 @@ export class Tile3D {
   private _expiredContent: any;
   // @ts-ignore
   private _shouldRefine: boolean;
+
+  private _boundingBox?: [min: number[], max: number[]];
 
   // Members this are updated every frame for tree traversal and rendering optimizations:
   public _distanceToCamera: number;
@@ -301,6 +303,17 @@ export class Tile3D {
    */
   get screenSpaceError(): number {
     return this._screenSpaceError;
+  }
+
+  /**
+   * Get bounding box in cartographic coordinates
+   * @returns [min, max] each in [longitude, latitude, altitude]
+   */
+  get boundingBox(): [min: number[], max: number[]] {
+    if (!this._boundingBox) {
+      this._boundingBox = getCartographicBounds(this.header.boundingVolume, this.boundingVolume);
+    }
+    return this._boundingBox;
   }
 
   /** Get the tile's screen space error. */

--- a/modules/tiles/src/tileset/tile-3d.ts
+++ b/modules/tiles/src/tileset/tile-3d.ts
@@ -13,7 +13,11 @@ import type {Tileset3D} from './tileset-3d';
 import {TILE_REFINEMENT, TILE_CONTENT_STATE, TILESET_TYPE} from '../constants';
 
 import {FrameState} from './helpers/frame-state';
-import {createBoundingVolume, getCartographicBounds} from './helpers/bounding-volume';
+import {
+  createBoundingVolume,
+  getCartographicBounds,
+  CartographicBounds
+} from './helpers/bounding-volume';
 import {getTiles3DScreenSpaceError} from './helpers/tiles-3d-lod';
 import {getProjectedRadius} from './helpers/i3s-lod';
 import {get3dTilesOptions} from './helpers/3d-tiles-options';
@@ -309,7 +313,7 @@ export class Tile3D {
    * Get bounding box in cartographic coordinates
    * @returns [min, max] each in [longitude, latitude, altitude]
    */
-  get boundingBox(): [min: number[], max: number[]] {
+  get boundingBox(): CartographicBounds {
     if (!this._boundingBox) {
       this._boundingBox = getCartographicBounds(this.header.boundingVolume, this.boundingVolume);
     }

--- a/modules/tiles/src/tileset/tile-3d.ts
+++ b/modules/tiles/src/tileset/tile-3d.ts
@@ -90,7 +90,7 @@ export class Tile3D {
   // @ts-ignore
   private _shouldRefine: boolean;
 
-  private _boundingBox?: [min: number[], max: number[]];
+  private _boundingBox?: CartographicBounds;
 
   // Members this are updated every frame for tree traversal and rendering optimizations:
   public _distanceToCamera: number;

--- a/modules/tiles/test/tileset/tile-3d.spec.js
+++ b/modules/tiles/test/tileset/tile-3d.spec.js
@@ -36,6 +36,7 @@ const TILE_HEADER_WITH_CONTENT_BOUNDING_SPHERE = {
     sphere: [0.0, 0.0, 1.0, 5.0]
   }
 };
+*/
 
 const TILE_HEADER_WITH_BOUNDING_REGION = {
   lodMetricValue: 1,
@@ -46,6 +47,7 @@ const TILE_HEADER_WITH_BOUNDING_REGION = {
   }
 };
 
+/*
 const TILE_HEADER_WITH_CONTENT_BOUNDING_REGION = {
   lodMetricValue: 1,
   refine: 'REPLACE',
@@ -60,6 +62,7 @@ const TILE_HEADER_WITH_CONTENT_BOUNDING_REGION = {
     region: [-1.2, -1.2, 0, 0, -30, -34]
   }
 };
+*/
 
 const TILE_HEADER_WITH_BOUNDING_BOX = {
   lodMetricValue: 1,
@@ -70,6 +73,7 @@ const TILE_HEADER_WITH_BOUNDING_BOX = {
   }
 };
 
+/*
 const TILE_HEADER_WITH_CONTENT_BOUNDING_BOX = {
   lodMetricValue: 1,
   refine: 'REPLACE',
@@ -329,6 +333,36 @@ test.skip('Tile3D#screenSpaceError is calculated correctly', (t) => {
     ['test']
   );
   t.equal(tile.screenSpaceError, 2.7410122234342147);
+  t.end();
+});
+
+test('Tile3D#cartographic bounding box', (t) => {
+  // @ts-ignore
+  let tile = new Tile3D(MOCK_TILESET, TILE_HEADER_WITH_BOUNDING_BOX);
+  t.ok(tile.boundingBox, 'Calculated for bounding box');
+
+  // @ts-ignore
+  tile = new Tile3D(MOCK_TILESET, TILE_HEADER_WITH_BOUNDING_SPHERE);
+  t.ok(tile.boundingBox, 'Calculated for bounding sphere');
+
+  // @ts-ignore
+  tile = new Tile3D(MOCK_TILESET, {
+    ...TILE_HEADER_WITH_BOUNDING_SPHERE,
+    boundingVolume: {sphere: [1, 1, 1, 5]}
+  });
+  t.ok(tile.boundingBox, 'Calculated for bounding sphere');
+
+  // @ts-ignore
+  tile = new Tile3D(MOCK_TILESET, {
+    ...TILE_HEADER_WITH_BOUNDING_SPHERE,
+    boundingVolume: {sphere: [1, 0, 0, 5]}
+  });
+  t.ok(tile.boundingBox, 'Calculated for bounding sphere');
+
+  // @ts-ignore
+  tile = new Tile3D(MOCK_TILESET, TILE_HEADER_WITH_BOUNDING_REGION);
+  t.ok(tile.boundingBox, 'Calculated for bounding region');
+
   t.end();
 });
 


### PR DESCRIPTION
Related: https://github.com/visgl/deck.gl/pull/7795
To support Tile3DLayer + TerrainExtension in deck.gl, I'm proposing a unified API between 2d and 3d tile headers:

`tile.boundingBox: [min: number[], max: number[]]`

#### Change list
- Add `Tile3D.boundingBox` member
- Docs
- Test