### PR TITLE
WMS Example: show capabilities metadata with Monaco editor

### DIFF
--- a/examples/website/wms/app.tsx
+++ b/examples/website/wms/app.tsx
@@ -37,7 +37,7 @@ import {INITIAL_CATEGORY_NAME, INITIAL_EXAMPLE_NAME, INITIAL_MAP_STYLE, EXAMPLES
 //         minZoom: 1,
 //         maxZoom: 20,
 //         pitch: 0,
-//         bearing: 0    
+//         bearing: 0
 //       }
 //     }
 //   }
@@ -108,10 +108,10 @@ export default class App extends PureComponent {
         metadata={metadata}
       >
         {error ? <div style={{color: 'red'}}>{error}</div> : ''}
-        <div style={{textAlign: 'center'}}>
-          long/lat: {viewState.longitude.toFixed(5)},{viewState.latitude.toFixed(5)}, zoom:{' '}
+        <pre style={{textAlign: 'center', margin: 0}}>
+          long/lat: {viewState.longitude.toFixed(5)}, {viewState.latitude.toFixed(5)}, zoom:{' '}
           {viewState.zoom.toFixed(2)}
-        </div>
+        </pre>
       </ControlPanel>
     );
   }

--- a/examples/website/wms/components/control-panel.tsx
+++ b/examples/website/wms/components/control-panel.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
+import MonacoEditor from '@monaco-editor/react';
 import {INITIAL_CATEGORY_NAME, INITIAL_EXAMPLE_NAME} from '../examples';
 
 const Container = styled.div`
@@ -9,7 +10,6 @@ const Container = styled.div`
   position: absolute;
   top: 0;
   right: 0;
-  max-width: 320px;
   background: #fff;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
   padding: 12px 24px;
@@ -19,24 +19,25 @@ const Container = styled.div`
   outline: none;
   z-index: 100;
 
-  h3 {
-    margin: 0.5em 0;
+  h2 {
+    margin: 0 0 0.5rem 0;
   }
-  
+
   .loading-indicator {
-    margin: 0.5em 0;
-    
+    margin: 0;
+    text-align: center;
     transition: opacity 300ms ease-out;
   }
 
-  pre {
-    overflow: auto;
-    max-height: calc(100vh - 225px);
+  .monaco-editor {
+    height: calc(100vh - 200px) !important;
+    width: 500px !important;
   }
 `;
 
 const DropDown = styled.select`
-  margin-bottom: 6px;
+  margin: 0.5rem 0;
+  font-size: 16px;
 `;
 
 const propTypes = {
@@ -118,34 +119,21 @@ export default class ControlPanel extends PureComponent {
     );
   }
 
-  _renderHeader() {
-    const {selectedCategory, selectedExample} = this.props;
-    if (!selectedCategory || !selectedExample) {
-      return null;
-    }
-
-    return (
-      <>
-        <h3>
-          {selectedExample} <b>{selectedCategory}</b>
-        </h3>
-        <p className='loading-indicator' style={{opacity: this.props.loading? 1 : 0}}>Loading image...</p> 
-      </>
-    );
-  }
-
-  
-  
   render() {
     return (
       <Container>
-        {this._renderHeader()}
         {this._renderDropDown()}
         {this.props.children}
-        <h1>WMS Server Capabilities</h1>
-        <pre>
-          {this.props.metadata}
+        <pre className="loading-indicator" style={{opacity: this.props.loading ? 1 : 0}}>
+          loading image...
         </pre>
+        <h2>WMS Server Capabilities</h2>
+        <MonacoEditor
+          language="json"
+          options={{readOnly: true}}
+          theme="vs-dark"
+          value={this.props.metadata}
+        />
       </Container>
     );
   }

--- a/examples/website/wms/package.json
+++ b/examples/website/wms/package.json
@@ -14,6 +14,7 @@
     "@deck.gl/geo-layers": "^8.9.0",
     "@loaders.gl/core": "^3.3.0",
     "@loaders.gl/wms": "^3.3.0",
+    "@monaco-editor/react": "^4.4.6",
     "deck.gl": "^8.9.0",
     "mapbox-gl": "npm:empty-npm-package@1.0.0",
     "maplibre-gl": "^2.4.0",


### PR DESCRIPTION
@ibgreen this is a trial POC for showing the JSON of the GetCapabilities using the Monaco editor in read-only mode. Thus, this replaces the JSON which was in a `<pre>` element, and makes a few other styling changes to the side control panel.

I wanted to give this a go first before looking into the xml 🔄  json side-by-side dual Monaco editors idea. Thoughts?

![Screenshot 2023-04-17 at 11 14 35 PM](https://user-images.githubusercontent.com/4933392/232661738-89ef9a8c-7e65-4fad-9aca-eecf8201343a.png)
