### PR TITLE
fix docusaurus footer links typo

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -213,7 +213,7 @@ const config = {
             items: [
               {
                 label: 'deck.gl',
-                href: 'https:/deck.gl'
+                href: 'https://deck.gl'
               },
               {
                 label: 'luma.gl',


### PR DESCRIPTION
fixes invalid navigation to `https://loaders.gl/deck.gl`