### PR TITLE
fix(website examples): stats widget issue

### DIFF
--- a/examples/website/3d-tiles/app.tsx
+++ b/examples/website/3d-tiles/app.tsx
@@ -2,7 +2,7 @@ import React, {PureComponent} from 'react';
 import {render} from 'react-dom';
 import {Map} from 'react-map-gl';
 import maplibregl from 'maplibre-gl';
-
+import styled from 'styled-components';
 
 import {lumaStats} from '@luma.gl/core';
 import DeckGL from '@deck.gl/react';
@@ -34,6 +34,21 @@ export const INITIAL_VIEW_STATE = {
   maxZoom: 30,
   zoom: 3 // Start zoomed out on US, tileset will center via "fly-to" on load
 };
+
+const Stats = styled.div`
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  max-width: 270px;
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  
+  > div {
+    position: unset !important;
+    z-index: 1 !important;
+  }
+`;
 
 export default class App extends PureComponent {
   constructor(props) {
@@ -206,17 +221,7 @@ export default class App extends PureComponent {
   _renderStats() {
     // TODO - too verbose, get more default styling from stats widget?
     return (
-      <div
-        style={{
-          position: 'absolute',
-          padding: 12,
-          zIndex: '10000',
-          maxWidth: 300,
-          background: '#000',
-          color: '#fff'
-        }}
-        ref={(_) => (this._statsWidgetContainer = _)}
-      />
+      <Stats ref={(_) => (this._statsWidgetContainer = _)} />
     );
   }
 

--- a/examples/website/3d-tiles/app.tsx
+++ b/examples/website/3d-tiles/app.tsx
@@ -35,7 +35,7 @@ export const INITIAL_VIEW_STATE = {
   zoom: 3 // Start zoomed out on US, tileset will center via "fly-to" on load
 };
 
-const Stats = styled.div`
+const StatsWidgetContainer = styled.div`
   position: absolute;
   top: 12px;
   left: 12px;
@@ -221,7 +221,7 @@ export default class App extends PureComponent {
   _renderStats() {
     // TODO - too verbose, get more default styling from stats widget?
     return (
-      <Stats ref={(_) => (this._statsWidgetContainer = _)} />
+      <StatsWidgetContainer ref={(_) => (this._statsWidgetContainer = _)} />
     );
   }
 

--- a/examples/website/3d-tiles/components/control-panel.jsx
+++ b/examples/website/3d-tiles/components/control-panel.jsx
@@ -20,6 +20,7 @@ const Container = styled.div`
   line-height: 2;
   outline: none;
   z-index: 100;
+  color: #121212;
 `;
 
 const DropDown = styled.select`

--- a/examples/website/i3s/src/app.tsx
+++ b/examples/website/i3s/src/app.tsx
@@ -73,7 +73,7 @@ const StatsWidgetContainer = styled.div`
   z-index: 3;
   bottom: 15px;
   word-break: break-word;
-  padding: 24px;
+  padding: 6px;
   border-radius: 8px;
   line-height: 135%;
   bottom: auto;
@@ -81,6 +81,12 @@ const StatsWidgetContainer = styled.div`
   left: 10px;
   max-height: calc(100% - 125px);
   overflow: auto;
+
+  > div {
+    position: unset !important;
+    z-index: 1 !important;
+    background-color: transparent !important;
+  }
 `;
 
 class App extends PureComponent {

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -49,3 +49,9 @@ main .container {
 html[data-theme='dark'] .docusaurus-highlight-code-line {
   background-color: rgba(0, 0, 0, 0.3);
 }
+
+@media (min-width: 1440px) {
+  .container {
+    max-width: 100%;
+  }
+}


### PR DESCRIPTION
1. Width of examples from
![Screenshot from 2023-04-21 19-09-21](https://user-images.githubusercontent.com/53499331/233696030-c6cf0917-d433-4c3f-82e1-634c4dd3f161.png)
to
![Screenshot from 2023-04-21 19-09-55](https://user-images.githubusercontent.com/53499331/233696057-df996a48-2436-4b3e-899f-cb0394fa73c9.png)

2. Stats widget issue (I3s and 3dTiles)
3. 3dTiles: Info panel text color (dark mode)
![Screenshot from 2023-04-21 19-08-10](https://user-images.githubusercontent.com/53499331/233696207-0f991a41-e128-4ec0-b6ba-764863aea2af.png)

![Screenshot from 2023-04-21 19-09-01](https://user-images.githubusercontent.com/53499331/233696202-3cf4cec1-6b93-4661-b8af-d0f964278485.png)
