### PR TITLE
Fix handling of query parameters in 3D tile url

### DIFF
--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile-header.ts
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile-header.ts
@@ -13,7 +13,7 @@ function getTileType(tile) {
     return TILE_TYPE.EMPTY;
   }
 
-  const contentUrl = tile.contentUrl;
+  const contentUrl = tile.contentUrl.split('?')[0]; // Discard query string
   const fileExtension = contentUrl.split('.').pop();
   switch (fileExtension) {
     case 'pnts':


### PR DESCRIPTION
- Format query parameters correctly when path contains query string
- Extract file extension correctly when query string is present
- Google API special handling: retain session parameter for all subsequent requests