### PR TITLE
chore(wkb): TypeError: Cannot use 'in' operator to search for 'wkb' in undefined

### DIFF
--- a/modules/wkt/src/lib/encode-wkb.ts
+++ b/modules/wkt/src/lib/encode-wkb.ts
@@ -51,7 +51,7 @@ interface WKBOptions {
  */
 export default function encodeWKB(
   geometry: Geometry | Feature,
-  options: WKBOptions | {wkb: WKBOptions}
+  options: WKBOptions | {wkb: WKBOptions} = {}
 ): ArrayBuffer {
   if (geometry.type === 'Feature') {
     geometry = geometry.geometry;


### PR DESCRIPTION
`encodeWKB` is assigned to `encodeSync` that has the following type
`encodeSync: (data: any, options?: WriterOptions) = encodeWKB;`

and causes the following error:
```
TypeError: Cannot use 'in' operator to search for 'wkb' in undefined
          at Object.encodeSync (node_modules/@loaders.gl/wkt/src/lib/encode-wkb.ts:62:12)
```