### PR TITLE
fix router to serve on ArcGIS

### DIFF
--- a/modules/i3s/src/lib/parsers/parse-slpk/slpk-archieve.ts
+++ b/modules/i3s/src/lib/parsers/parse-slpk/slpk-archieve.ts
@@ -15,39 +15,37 @@ type HashElement = {
   offset: number;
 };
 
-const layerPrefixRemove = /^layers\/0\/?(.*)$/;
-
 const pathDescriptions = [
   {
-    test: /^layers\/0$/,
+    test: /^$/,
     extensions: ['3dSceneLayer.json.gz']
   },
   {
-    test: /^layers\/0\/nodepages\/\d+$/,
+    test: /^nodepages\/\d+$/,
     extensions: ['.json.gz']
   },
   {
-    test: /^layers\/0\/nodes\/\d+$/,
+    test: /^nodes\/\d+$/,
     extensions: ['/3dNodeIndexDocument.json.gz']
   },
   {
-    test: /^layers\/0\/nodes\/\d+\/textures\/.+$/,
+    test: /^nodes\/\d+\/textures\/.+$/,
     extensions: ['.jpg', '.png', '.bin.dds.gz', '.ktx']
   },
   {
-    test: /^layers\/0\/nodes\/\d+\/geometries\/\d+$/,
+    test: /^nodes\/\d+\/geometries\/\d+$/,
     extensions: ['.bin.gz', '.draco.gz']
   },
   {
-    test: /^layers\/0\/nodes\/\d+\/attributes\/f_\d+\/\d+$/,
+    test: /^nodes\/\d+\/attributes\/f_\d+\/\d+$/,
     extensions: ['.bin.gz']
   },
   {
-    test: /^layers\/0\/statistics\/f_\d+\/\d+$/,
+    test: /^statistics\/f_\d+\/\d+$/,
     extensions: ['.json.gz']
   },
   {
-    test: /^layers\/0\/nodes\/\d+\/shared$/,
+    test: /^nodes\/\d+\/shared$/,
     extensions: ['/sharedResource.json.gz']
   }
 ];
@@ -101,7 +99,7 @@ export class SLPKArchive {
       if (extensions) {
         let data: ArrayBuffer | undefined;
         for (const ext of extensions) {
-          data = await this.getDataByPath(`${layerPrefixRemove.exec(path)?.at(1)}${ext}`);
+          data = await this.getDataByPath(`${path}${ext}`);
           if (data) {
             break;
           }

--- a/modules/i3s/test/parse-slpk.spec.js
+++ b/modules/i3s/test/parse-slpk.spec.js
@@ -23,7 +23,7 @@ test('SLPKLoader#slpk load error', async (t) => {
 test('SLPKLoader#slpk load http nodepage', async (t) => {
   const SLPKUrl = '@loaders.gl/i3s/test/data/DA12_subset.slpk';
   const uncompressedFile = await load(SLPKUrl, SLPKLoader, {
-    path: 'layers/0/nodepages/0',
+    path: 'nodepages/0',
     pathMode: 'http'
   });
   t.deepEqual(uncompressedFile.byteLength, 16153);
@@ -32,7 +32,7 @@ test('SLPKLoader#slpk load http nodepage', async (t) => {
 
 test('SLPKLoader#slpk load http layer', async (t) => {
   const SLPKUrl = '@loaders.gl/i3s/test/data/DA12_subset.slpk';
-  const uncompressedFile = await load(SLPKUrl, SLPKLoader, {path: 'layers/0', pathMode: 'http'});
+  const uncompressedFile = await load(SLPKUrl, SLPKLoader, {path: '', pathMode: 'http'});
   t.deepEqual(uncompressedFile.byteLength, 4780);
   t.end();
 });
@@ -40,7 +40,7 @@ test('SLPKLoader#slpk load http layer', async (t) => {
 test('SLPKLoader#slpk load http node', async (t) => {
   const SLPKUrl = '@loaders.gl/i3s/test/data/DA12_subset.slpk';
   const uncompressedFile = await load(SLPKUrl, SLPKLoader, {
-    path: 'layers/0/nodes/0',
+    path: 'nodes/0',
     pathMode: 'http'
   });
   t.deepEqual(uncompressedFile.byteLength, 1171);
@@ -50,7 +50,7 @@ test('SLPKLoader#slpk load http node', async (t) => {
 test('SLPKLoader#slpk load http geometry', async (t) => {
   const SLPKUrl = '@loaders.gl/i3s/test/data/DA12_subset.slpk';
   const uncompressedFile = await load(SLPKUrl, SLPKLoader, {
-    path: 'layers/0/nodes/0/geometries/0',
+    path: 'nodes/0/geometries/0',
     pathMode: 'http'
   });
   t.deepEqual(uncompressedFile.byteLength, 156280);
@@ -60,7 +60,7 @@ test('SLPKLoader#slpk load http geometry', async (t) => {
 test('SLPKLoader#slpk load http attributes', async (t) => {
   const SLPKUrl = '@loaders.gl/i3s/test/data/DA12_subset.slpk';
   const uncompressedFile = await load(SLPKUrl, SLPKLoader, {
-    path: 'layers/0/nodes/2/attributes/f_2/0',
+    path: 'nodes/2/attributes/f_2/0',
     pathMode: 'http'
   });
   t.deepEqual(uncompressedFile.byteLength, 8);
@@ -70,7 +70,7 @@ test('SLPKLoader#slpk load http attributes', async (t) => {
 test('SLPKLoader#slpk load http statistics', async (t) => {
   const SLPKUrl = '@loaders.gl/i3s/test/data/DA12_subset.slpk';
   const uncompressedFile = await load(SLPKUrl, SLPKLoader, {
-    path: 'layers/0/statistics/f_3/0',
+    path: 'statistics/f_3/0',
     pathMode: 'http'
   });
   t.deepEqual(uncompressedFile.byteLength, 735);
@@ -80,7 +80,7 @@ test('SLPKLoader#slpk load http statistics', async (t) => {
 test('SLPKLoader#slpk load http shared', async (t) => {
   const SLPKUrl = '@loaders.gl/i3s/test/data/DA12_subset.slpk';
   const uncompressedFile = await load(SLPKUrl, SLPKLoader, {
-    path: 'layers/0/nodes/2/shared',
+    path: 'nodes/2/shared',
     pathMode: 'http'
   });
   t.deepEqual(uncompressedFile.byteLength, 333);

--- a/modules/tile-converter/src/i3s-server/README.md
+++ b/modules/tile-converter/src/i3s-server/README.md
@@ -1,0 +1,19 @@
+# I3S server
+
+The http server run on NodeJS ExpressJS framework.
+The server provides I3S Rest endpoints per specification https://github.com/Esri/i3s-spec/blob/master/docs/1.7/3Dobject_ReadMe.md#http-api-overview-17
+
+## Usage
+
+### Serve 3DTiles to I3S converted dataset
+
+- Convert data set from 3DTiles to I3S without `--slpk` option
+- Serve output folder `I3sLayerPath="./data/BatchedTextured" DEBUG=i3s-server:* npx i3s-server`
+
+### Serve SLPK
+
+- Serve slpk file `I3sLayerPath="../datasets/Rancho_Mesh_mesh_v17_1.slpk" DEBUG=i3s-server:* npx i3s-server`
+
+## ENV variables
+
+- `I3sLayerPath` - path to converted data or SLPK file.

--- a/modules/tile-converter/src/i3s-server/app.js
+++ b/modules/tile-converter/src/i3s-server/app.js
@@ -4,7 +4,7 @@ const logger = require('morgan');
 const cors = require('cors');
 
 const indexRouter = require('./routes/index');
-const router = require('./routes/slpk-router');
+const {sceneServerRouter, router} = require('./routes/slpk-router');
 
 const I3S_LAYER_PATH = process.env.I3sLayerPath || ''; // eslint-disable-line no-process-env, no-undef
 const app = express();
@@ -16,7 +16,8 @@ app.use(express.static(path.join(__dirname, 'public')));
 app.use(cors());
 
 if (/\.slpk$/.test(I3S_LAYER_PATH)) {
-  app.use('/', router);
+  app.use('/SceneServer/layers/0', router);
+  app.use('/SceneServer', sceneServerRouter);
 } else {
   app.use('/', indexRouter);
 }

--- a/modules/tile-converter/src/i3s-server/routes/slpk-router.js
+++ b/modules/tile-converter/src/i3s-server/routes/slpk-router.js
@@ -1,10 +1,23 @@
 const express = require('express');
 const {getFileByUrl} = require('../controllers/slpk-controller');
+const createSceneServer = require('../utils/create-scene-server');
 
-/* GET home page. */
+const sceneServerRouter = express.Router();
+sceneServerRouter.get('*', async function (req, res, next) {
+  const file = await getFileByUrl('/');
+  if (file) {
+    const layer = JSON.parse(file.toString());
+    const sceneServerResponse = createSceneServer(layer.name, layer);
+    res.send(sceneServerResponse);
+  } else {
+    res.status(404);
+    res.send('File not found');
+  }
+});
+
 const router = express.Router();
-
 router.get('*', async function (req, res, next) {
+  console.log(req.path);
   const file = await getFileByUrl(req.path);
   if (file) {
     res.send(file);
@@ -14,4 +27,7 @@ router.get('*', async function (req, res, next) {
   }
 });
 
-module.exports = router;
+module.exports = {
+  sceneServerRouter,
+  router
+};

--- a/modules/tile-converter/src/i3s-server/utils/create-scene-server.js
+++ b/modules/tile-converter/src/i3s-server/utils/create-scene-server.js
@@ -1,0 +1,15 @@
+const {v4: uuidv4} = require('uuid');
+
+const createSceneServer = (name, layer) => {
+  return {
+    serviceItemId: uuidv4().replace(/-/gi, ''),
+    serviceName: name,
+    name,
+    currentVersion: '10.7',
+    serviceVersion: '1.8',
+    supportedBindings: ['REST'],
+    layers: [layer]
+  };
+};
+
+module.exports = createSceneServer;


### PR DESCRIPTION
Start server:
`I3sLayerPath="../datasets/Rancho_Mesh_mesh_v17_1.slpk" DEBUG=i3s-server:* npx i3s-server`
Run on ArcGIS:
`https://www.arcgis.com/home/webscene/viewer.html?url=https://localhost/SceneServer`
![Screenshot 2023-05-20 at 00 39 27](https://github.com/visgl/loaders.gl/assets/18549629/c1ac27bb-c582-4bc0-b91a-be4562bdca1b)
Run on I3S Explorer (the tile is floating because no terrain. Switch on terrain to see the layer on appropriate elevation):
`https://i3s.loaders.gl/viewer?tileset=https://localhost/SceneServer`
![Screenshot 2023-05-20 at 00 40 05](https://github.com/visgl/loaders.gl/assets/18549629/fbbfdbfe-fd46-4786-8bbc-9c3e967f7ff1)
