### PR TITLE
WIP: Tile3D getCoordinatesByIndex

### DIFF
--- a/modules/tiles/src/tileset/tile-3d.ts
+++ b/modules/tiles/src/tileset/tile-3d.ts
@@ -5,6 +5,7 @@
 
 import {Vector3, Matrix4} from '@math.gl/core';
 import {CullingVolume} from '@math.gl/culling';
+import {addMetersToLngLat} from '@math.gl/web-mercator';
 
 import {load} from '@loaders.gl/core';
 
@@ -772,5 +773,20 @@ export class Tile3D {
       default:
         return get3dTilesOptions(this.tileset.tileset);
     }
+  }
+  getCoordinatesByIndex(index: number): number[] | null {
+    if (!this.content) {
+      return null;
+    }
+    if (this.tileset.type === TILESET_TYPE.TILES3D) {
+      if (this.content.type === 'pnts') {
+        return addMetersToLngLat(this.content.cartographicOrigin, [
+          this.content.attributes.positions[index * 3],
+          this.content.attributes.positions[index * 3 + 1],
+          this.content.attributes.positions[index * 3 + 2]
+        ]);
+      }
+    }
+    return null;
   }
 }


### PR DESCRIPTION
Hi,

regarding to my previous discussion https://github.com/visgl/loaders.gl/discussions/2425#discussion-5114144 I prepared something which I can improve with your guidance.

My final target is to create cursor similar to [this](https://codesandbox.io/s/dof-forked-v8jl2b?file=/src/App.js:1263-1275).

On meshes it should be simple, maybe another method can return orientation of mesh under cursor + cursor coords and I can render oriented circle under cursor.

On point clouds it's more difficult I think, so I started with picking multiple points around cursor and I want to create plane from those (3?) points, calculate orientation,... So this is the use case where it's useful for me. But it could be usable generally too.

Thanks 