### PR TITLE
chore(i3s): use loaders.gl MD5 hash, avoid Buffer usage

### DIFF
--- a/modules/3d-tiles/src/3d-tiles-archive/3d-tiles-archive-parser.ts
+++ b/modules/3d-tiles/src/3d-tiles-archive/3d-tiles-archive-parser.ts
@@ -1,9 +1,8 @@
 import {FileProvider} from '@loaders.gl/loader-utils';
 import {
-  HashElement,
   cdSignature as cdHeaderSignature,
-  generateHashInfo,
-  parseHashFile,
+  makeHashTableFromZipHeaders,
+  parseHashTable,
   parseZipCDFileHeader,
   parseZipLocalFileHeader,
   searchFromTheEnd
@@ -24,19 +23,20 @@ export const parse3DTilesArchive = async (
 
   const cdFileHeader = await parseZipCDFileHeader(hashCDOffset, fileProvider);
 
-  let hashData: HashElement[];
+  let hashTable: Record<string, bigint>;
   if (cdFileHeader?.fileName !== '@3dtilesIndex1@') {
-    cb?.('3tz doesnt contain hash file');
-    hashData = await generateHashInfo(fileProvider);
-    cb?.('hash info has been composed according to central directory records');
+    hashTable = await makeHashTableFromZipHeaders(fileProvider);
+    cb?.(
+      '3tz doesnt contain hash file, hash info has been composed according to zip archive headers'
+    );
   } else {
-    cb?.('3tz contains hash file');
+    // cb?.('3tz contains hash file');
     const localFileHeader = await parseZipLocalFileHeader(
       cdFileHeader.localHeaderOffset,
       fileProvider
     );
     if (!localFileHeader) {
-      throw new Error('corrupted 3tz');
+      throw new Error('corrupted 3tz zip archive');
     }
 
     const fileDataOffset = localFileHeader.fileDataOffset;
@@ -45,8 +45,8 @@ export const parse3DTilesArchive = async (
       fileDataOffset + localFileHeader.compressedSize
     );
 
-    hashData = parseHashFile(hashFile);
+    hashTable = parseHashTable(hashFile);
   }
 
-  return new Tiles3DArchive(fileProvider, hashData);
+  return new Tiles3DArchive(fileProvider, hashTable);
 };

--- a/modules/3d-tiles/src/lib/filesystems/tiles-3d-archive-file-system.ts
+++ b/modules/3d-tiles/src/lib/filesystems/tiles-3d-archive-file-system.ts
@@ -4,8 +4,7 @@ import {
   cdSignature as cdHeaderSignature,
   searchFromTheEnd,
   parseZipCDFileHeader,
-  HashElement,
-  parseHashFile,
+  parseHashTable,
   parseZipLocalFileHeader
 } from '@loaders.gl/zip';
 import {Tiles3DArchive} from '../../3d-tiles-archive/3d-tiles-archive-archive';
@@ -18,7 +17,7 @@ import {Tiles3DArchive} from '../../3d-tiles-archive/3d-tiles-archive-archive';
  * @see https://github.com/erikdahlstrom/3tz-specification/blob/master/Specification.md
  */
 export class Tiles3DArchiveFileSystem extends ZipFileSystem {
-  hashData?: HashElement[] | null;
+  hashTable?: Record<string, bigint> | null;
 
   /**
    * Constructor
@@ -40,9 +39,9 @@ export class Tiles3DArchiveFileSystem extends ZipFileSystem {
     if (!fileProvider) {
       throw new Error('No data detected in the zip archive');
     }
-    await this.parseHashFile();
-    if (this.hashData) {
-      const archive = new Tiles3DArchive(fileProvider, this.hashData);
+    await this.parseHashTable();
+    if (this.hashTable) {
+      const archive = new Tiles3DArchive(fileProvider, this.hashTable);
 
       const fileData = await archive.getFile(filename);
       const response = new Response(fileData);
@@ -57,8 +56,8 @@ export class Tiles3DArchiveFileSystem extends ZipFileSystem {
    * to files inside the archive
    * @returns void
    */
-  private async parseHashFile(): Promise<void> {
-    if (this.hashData !== undefined) {
+  private async parseHashTable(): Promise<void> {
+    if (this.hashTable !== undefined) {
       return;
     }
 
@@ -89,9 +88,9 @@ export class Tiles3DArchiveFileSystem extends ZipFileSystem {
         fileDataOffset + localFileHeader.compressedSize
       );
 
-      this.hashData = parseHashFile(hashFile);
+      this.hashTable = parseHashTable(hashFile);
     } else {
-      this.hashData = null;
+      this.hashTable = null;
     }
   }
 }

--- a/modules/3d-tiles/src/types.ts
+++ b/modules/3d-tiles/src/types.ts
@@ -301,9 +301,9 @@ export type Tiles3DTileContent = {
  */
 export type Subtree = {
   /** An array of buffers. */
-  buffers: Buffer[];
+  buffers: GLTFStyleBuffer[];
   /** An array of buffer views. */
-  bufferViews: BufferView[];
+  bufferViews: GLTFStyleBufferView[];
   /** The availability of tiles in the subtree. The availability bitstream is a 1D boolean array where tiles are ordered by their level in the subtree and Morton index
    * within that level. A tile's availability is determined by a single bit, 1 meaning a tile exists at that spatial index, and 0 meaning it does not.
    * The number of elements in the array is `(N^subtreeLevels - 1)/(N - 1)` where N is 4 for subdivision scheme `QUADTREE` and 8 for `OCTREE`.
@@ -356,14 +356,14 @@ export type ExplicitBitstream = Uint8Array;
  */
 export type SubdivisionScheme = 'QUADTREE' | 'OCTREE';
 
-type Buffer = {
+type GLTFStyleBuffer = {
   name: string;
   uri?: string;
   byteLength: number;
 };
 
 /** Subtree buffer view */
-export type BufferView = {
+export type GLTFStyleBufferView = {
   buffer: number;
   byteOffset: number;
   byteLength: number;

--- a/modules/i3s/package.json
+++ b/modules/i3s/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@loaders.gl/compression": "4.0.0-beta.2",
+    "@loaders.gl/crypto": "4.0.0-beta.2",
     "@loaders.gl/draco": "4.0.0-beta.2",
     "@loaders.gl/images": "4.0.0-beta.2",
     "@loaders.gl/loader-utils": "4.0.0-beta.2",
@@ -43,8 +44,7 @@
     "@luma.gl/constants": "^8.5.4",
     "@math.gl/core": "^3.5.1",
     "@math.gl/culling": "^3.5.1",
-    "@math.gl/geospatial": "^3.5.1",
-    "md5": "^2.3.0"
+    "@math.gl/geospatial": "^3.5.1"
   },
   "peerDependencies": {
     "@loaders.gl/core": "^4.0.0-alpha.8"

--- a/modules/i3s/src/i3s-slpk-loader.ts
+++ b/modules/i3s/src/i3s-slpk-loader.ts
@@ -1,6 +1,6 @@
 import type {LoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';
 import {DataViewFile} from '@loaders.gl/loader-utils';
-import {parseSLPK as parseSLPKFromProvider} from './lib/parsers/parse-slpk/parse-slpk';
+import {parseSLPKArchive as parseSLPKFromProvider} from './lib/parsers/parse-slpk/parse-slpk';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
@@ -25,7 +25,7 @@ export const SLPKLoader: LoaderWithParser<ArrayBuffer, never, SLPKLoaderOptions>
   module: 'i3s',
   version: VERSION,
   mimeTypes: ['application/octet-stream'],
-  parse: parseSLPK,
+  parse: parseSLPKArchive,
   extensions: ['slpk'],
   options: {}
 };
@@ -37,7 +37,7 @@ export const SLPKLoader: LoaderWithParser<ArrayBuffer, never, SLPKLoaderOptions>
  * @returns requested file
  */
 
-async function parseSLPK(data: ArrayBuffer, options: SLPKLoaderOptions = {}) {
+async function parseSLPKArchive(data: ArrayBuffer, options: SLPKLoaderOptions = {}) {
   return (await parseSLPKFromProvider(new DataViewFile(new DataView(data)))).getFile(
     options.slpk?.path ?? '',
     options.slpk?.pathMode

--- a/modules/i3s/src/index.ts
+++ b/modules/i3s/src/index.ts
@@ -46,4 +46,6 @@ export {I3SAttributeLoader, loadFeatureAttributes} from './i3s-attribute-loader'
 export {I3SBuildingSceneLayerLoader} from './i3s-building-scene-layer-loader';
 export {I3SNodePageLoader} from './i3s-node-page-loader';
 export {ArcGISWebSceneLoader} from './arcgis-webscene-loader';
-export {parseSLPK} from './lib/parsers/parse-slpk/parse-slpk';
+
+export type {SLPKArchive} from './lib/parsers/parse-slpk/slpk-archieve';
+export {parseSLPKArchive} from './lib/parsers/parse-slpk/parse-slpk';

--- a/modules/i3s/src/lib/parsers/parse-slpk/slpk-archieve.ts
+++ b/modules/i3s/src/lib/parsers/parse-slpk/slpk-archieve.ts
@@ -1,6 +1,6 @@
-import md5 from 'md5';
+import {MD5Hash} from '@loaders.gl/crypto';
 import {FileProvider} from '@loaders.gl/loader-utils';
-import {parseZipLocalFileHeader, HashElement, findBin} from '@loaders.gl/zip';
+import {parseZipLocalFileHeader} from '@loaders.gl/zip';
 import {GZipCompression} from '@loaders.gl/compression';
 
 /** Description of real paths for different file types */
@@ -43,11 +43,20 @@ const PATH_DESCRIPTIONS: {test: RegExp; extensions: string[]}[] = [
  * Class for handling information about slpk file
  */
 export class SLPKArchive {
+  /** A DataView representation of the archive */
   private slpkArchive: FileProvider;
-  private hashArray: HashElement[];
-  constructor(slpkArchive: FileProvider, hashFile: HashElement[]) {
+  // Maps hex-encoded md5 hashes to bigint offsets into the archive
+  private hashedOffsetMap: Record<string, bigint>;
+  /** Array of hashes and offsets into archive */
+  // hashToOffsetMap: Record<string, number>;
+
+  protected _textEncoder = new TextEncoder();
+  protected _textDecoder = new TextDecoder();
+  protected _md5Hash = new MD5Hash();
+
+  constructor(slpkArchive: FileProvider, hashedOffsetMap: Record<string, bigint>) {
     this.slpkArchive = slpkArchive;
-    this.hashArray = hashFile;
+    this.hashedOffsetMap = hashedOffsetMap;
   }
 
   /**
@@ -83,7 +92,7 @@ export class SLPKArchive {
       }
     }
 
-    throw new Error('No such file in the archieve');
+    throw new Error(`No such file in the archive: ${path}`);
   }
 
   /**
@@ -111,18 +120,20 @@ export class SLPKArchive {
   }
 
   /**
-   * Trying to get raw file data by adress
+   * Trying to get raw file data by address
    * @param path - path inside the archive
    * @returns buffer with the raw file data
    */
   private async getFileBytes(path: string): Promise<ArrayBuffer | undefined> {
-    const nameHash = Buffer.from(md5(path), 'hex');
-    const fileInfo = findBin(nameHash, this.hashArray); // implement binary search
-    if (!fileInfo) {
+    const binaryPath = this._textEncoder.encode(path);
+    const nameHash = await this._md5Hash.hash(binaryPath.buffer, 'hex');
+
+    const offset = this.hashedOffsetMap[nameHash];
+    if (offset === undefined) {
       return undefined;
     }
 
-    const localFileHeader = await parseZipLocalFileHeader(fileInfo.offset, this.slpkArchive);
+    const localFileHeader = await parseZipLocalFileHeader(offset, this.slpkArchive);
     if (!localFileHeader) {
       return undefined;
     }
@@ -133,8 +144,5 @@ export class SLPKArchive {
     );
 
     return compressedFile;
-  }
-  findBin(nameHash: Buffer) {
-    throw new Error('Method not implemented.');
   }
 }

--- a/modules/i3s/tsconfig.json
+++ b/modules/i3s/tsconfig.json
@@ -10,6 +10,7 @@
   "references": [
     {"path": "../core"},
     {"path": "../compression"},
+    {"path": "../crypto"},
     {"path": "../draco"},
     {"path": "../gltf"},
     {"path": "../images"},

--- a/modules/tile-converter/src/i3s-server/controllers/slpk-controller.ts
+++ b/modules/tile-converter/src/i3s-server/controllers/slpk-controller.ts
@@ -1,32 +1,34 @@
 import '@loaders.gl/polyfills';
-import {parseSLPK} from '@loaders.gl/i3s';
+import {parseSLPKArchive, SLPKArchive} from '@loaders.gl/i3s';
 import {FileHandleFile} from '@loaders.gl/loader-utils';
 
-let slpkArchive;
+let slpkArchive: SLPKArchive;
 
 /**
  * Open SLPK file for reading and load HASH file
  * @param fullLayerPath - full path to SLPK file
  */
-export const loadArchive = async (fullLayerPath: string): Promise<void> => {
-  slpkArchive = await parseSLPK(await FileHandleFile.from(fullLayerPath), (msg) =>
+export async function loadArchive(fullLayerPath: string): Promise<void> {
+  slpkArchive = await parseSLPKArchive(await FileHandleFile.from(fullLayerPath), (msg) =>
     console.log(msg)
   );
   console.log('The server is ready to use');
-};
+}
 
 /**
  * Get a file from SLPK
  * @param url - I3S HTTP URL
  * @returns  - file content
  */
-export async function getFileByUrl(url: string) {
+export async function getFileByUrl(url: string): Promise<Buffer | null> {
   const trimmedPath = /^\/?(.*)\/?$/.exec(url);
   let uncompressedFile: Buffer | null = null;
   if (trimmedPath) {
     try {
-      uncompressedFile = Buffer.from(await slpkArchive.getFile(trimmedPath[1], 'http'));
-    } catch (e) {}
+      uncompressedFile = await slpkArchive.getFile(trimmedPath[1], 'http');
+    } catch {
+      // TODO - log error?
+    }
   }
   return uncompressedFile;
 }

--- a/modules/tile-converter/test/i3s-server/controllers/slpk-controller.spec.ts
+++ b/modules/tile-converter/test/i3s-server/controllers/slpk-controller.spec.ts
@@ -1,6 +1,6 @@
 import test from 'tape-promise/tape';
 import {isBrowser} from '@loaders.gl/core';
-import path from 'path';
+import {path} from '@loaders.gl/loader-utils';
 import {getFileByUrl, loadArchive} from '../../../src/i3s-server/controllers/slpk-controller';
 
 const URL_PREFIX = '';
@@ -32,7 +32,6 @@ test('tile-converter(i3s-server)#getFileByUrl return files content', async (t) =
     t.end();
     return;
   }
-
   const FULL_LAYER_PATH = path.join(process.cwd(), SLPK_URL); // eslint-disable-line no-undef
   await loadArchive(FULL_LAYER_PATH);
 

--- a/modules/zip/package.json
+++ b/modules/zip/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@loaders.gl/compression": "4.0.0-beta.2",
+    "@loaders.gl/crypto": "4.0.0-beta.2",
     "@loaders.gl/loader-utils": "4.0.0-beta.2",
     "jszip": "^3.1.5",
     "md5": "^2.3.0"

--- a/modules/zip/src/filesystems/zip-filesystem.ts
+++ b/modules/zip/src/filesystems/zip-filesystem.ts
@@ -1,7 +1,7 @@
 import {FileSystem, isBrowser} from '@loaders.gl/loader-utils';
 import {FileProvider, isFileProvider} from '@loaders.gl/loader-utils';
 import {FileHandleFile} from '@loaders.gl/loader-utils';
-import {ZipCDFileHeader, zipCDFileHeaderGenerator} from '../parse-zip/cd-file-header';
+import {ZipCDFileHeader, makeZipCDHeaderIterator} from '../parse-zip/cd-file-header';
 import {parseZipLocalFileHeader} from '../parse-zip/local-file-header';
 import {DeflateCompression} from '@loaders.gl/compression';
 
@@ -63,7 +63,7 @@ export class ZipFileSystem implements FileSystem {
       throw new Error('No data detected in the zip archive');
     }
     const fileNames: string[] = [];
-    const zipCDIterator = zipCDFileHeaderGenerator(fileProvider);
+    const zipCDIterator = makeZipCDHeaderIterator(fileProvider);
     for await (const cdHeader of zipCDIterator) {
       fileNames.push(cdHeader.fileName);
     }
@@ -126,7 +126,7 @@ export class ZipFileSystem implements FileSystem {
     if (!fileProvider) {
       throw new Error('No data detected in the zip archive');
     }
-    const zipCDIterator = zipCDFileHeaderGenerator(fileProvider);
+    const zipCDIterator = makeZipCDHeaderIterator(fileProvider);
     let result: ZipCDFileHeader | null = null;
     for await (const cdHeader of zipCDIterator) {
       if (cdHeader.fileName === filename) {

--- a/modules/zip/src/hash-file-utility.ts
+++ b/modules/zip/src/hash-file-utility.ts
@@ -1,101 +1,76 @@
-import md5 from 'md5';
+import {MD5Hash} from '@loaders.gl/crypto';
 import {FileProvider} from '@loaders.gl/loader-utils';
-import {zipCDFileHeaderGenerator} from './parse-zip/cd-file-header';
-
-/** Element of hash array */
-export type HashElement = {
-  /** File name hash */
-  hash: Buffer;
-  /** File offset in the archive */
-  offset: bigint;
-};
-
-/**
- * Comparing md5 hashes according to https://github.com/Esri/i3s-spec/blob/master/docs/2.0/slpk_hashtable.pcsl.md step 5
- * @param hash1 hash to compare
- * @param hash2 hash to compare
- * @returns -1 if hash1 < hash2, 0 of hash1 === hash2, 1 if hash1 > hash2
- */
-export const compareHashes = (hash1: Buffer, hash2: Buffer): number => {
-  const h1 = new BigUint64Array(hash1.buffer, hash1.byteOffset, 2);
-  const h2 = new BigUint64Array(hash2.buffer, hash2.byteOffset, 2);
-
-  const diff = h1[0] === h2[0] ? h1[1] - h2[1] : h1[0] - h2[0];
-
-  if (diff < 0n) {
-    return -1;
-  } else if (diff === 0n) {
-    return 0;
-  }
-  return 1;
-};
+import {makeZipCDHeaderIterator} from './parse-zip/cd-file-header';
 
 /**
  * Reads hash file from buffer and returns it in ready-to-use form
- * @param hashFile - bufer containing hash file
- * @returns Array containing file info
+ * @param arrayBuffer - buffer containing hash file
+ * @returns Map containing hash and offset
  */
-export const parseHashFile = (hashFile: ArrayBuffer): HashElement[] => {
-  const hashFileBuffer = Buffer.from(hashFile);
-  const hashArray: HashElement[] = [];
-  for (let i = 0; i < hashFileBuffer.buffer.byteLength; i = i + 24) {
-    const offsetBuffer = new DataView(
-      hashFileBuffer.buffer.slice(
-        hashFileBuffer.byteOffset + i + 16,
-        hashFileBuffer.byteOffset + i + 24
-      )
-    );
-    const offset = offsetBuffer.getBigUint64(offsetBuffer.byteOffset, true);
-    hashArray.push({
-      hash: Buffer.from(
-        hashFileBuffer.subarray(hashFileBuffer.byteOffset + i, hashFileBuffer.byteOffset + i + 16)
-      ),
-      offset
-    });
-  }
-  return hashArray;
-};
+export function parseHashTable(arrayBuffer: ArrayBuffer): Record<string, bigint> {
+  const dataView = new DataView(arrayBuffer);
 
-/**
- * Binary search in the hash info
- * @param hashToSearch hash that we need to find
- * @returns required hash element or undefined if not found
- */
-export const findBin = (
-  hashToSearch: Buffer,
-  hashArray: HashElement[]
-): HashElement | undefined => {
-  let lowerBorder = 0;
-  let upperBorder = hashArray.length;
+  const hashMap: Record<string, bigint> = {};
 
-  while (upperBorder - lowerBorder > 1) {
-    const middle = lowerBorder + Math.floor((upperBorder - lowerBorder) / 2);
-    const value = compareHashes(hashArray[middle].hash, hashToSearch);
-    if (value === 0) {
-      return hashArray[middle];
-    } else if (value < 0) {
-      lowerBorder = middle;
-    } else {
-      upperBorder = middle;
-    }
+  for (let i = 0; i < arrayBuffer.byteLength; i = i + 24) {
+    const offset = dataView.getBigUint64(i + 16, true);
+    const hash = bufferToHex(arrayBuffer, i, 16);
+    hashMap[hash] = offset;
   }
-  return undefined;
-};
+
+  return hashMap;
+}
+
+function bufferToHex(buffer: ArrayBuffer, start: number, length: number): string {
+  // buffer is an ArrayBuffer
+  return [...new Uint8Array(buffer, start, length)]
+    .map((x) => x.toString(16).padStart(2, '0'))
+    .join('');
+}
 
 /**
  * generates hash info from central directory
  * @param fileProvider - provider of the archive
  * @returns ready to use hash info
  */
-export const generateHashInfo = async (fileProvider: FileProvider): Promise<HashElement[]> => {
-  const zipCDIterator = zipCDFileHeaderGenerator(fileProvider);
-  const hashInfo: HashElement[] = [];
+export async function getHashMapFromZipArchive(
+  fileProvider: FileProvider
+): Promise<Record<string, bigint>> {
+  const zipCDIterator = makeZipCDHeaderIterator(fileProvider);
+  const md5Hash = new MD5Hash();
+  const textEncoder = new TextEncoder();
+
+  const hashMap: Record<string, bigint> = {};
   for await (const cdHeader of zipCDIterator) {
-    hashInfo.push({
-      hash: Buffer.from(md5(cdHeader.fileName.split('\\').join('/').toLocaleLowerCase()), 'hex'),
-      offset: cdHeader.localHeaderOffset
-    });
+    const filename = cdHeader.fileName.split('\\').join('/').toLocaleLowerCase();
+    const arrayBuffer = textEncoder.encode(filename).buffer;
+    const md5 = await md5Hash.hash(arrayBuffer, 'hex');
+    hashMap[md5] = cdHeader.localHeaderOffset;
   }
-  hashInfo.sort((a, b) => compareHashes(a.hash, b.hash));
-  return hashInfo;
-};
+  return hashMap;
+}
+
+//
+/**
+ * generates hash info from zip files "central directory"
+ * @param fileProvider - provider of the archive
+ * @returns ready to use hash info
+ */
+export async function makeHashTableFromZipHeaders(
+  fileProvider: FileProvider
+): Promise<Record<string, bigint>> {
+  const zipCDIterator = makeZipCDHeaderIterator(fileProvider);
+  const md5Hash = new MD5Hash();
+  const textEncoder = new TextEncoder();
+
+  const hashTable: Record<string, bigint> = {};
+
+  for await (const cdHeader of zipCDIterator) {
+    const filename = cdHeader.fileName.split('\\').join('/').toLocaleLowerCase();
+    const arrayBuffer = textEncoder.encode(filename).buffer;
+    const md5 = await md5Hash.hash(arrayBuffer, 'hex');
+    hashTable[md5] = cdHeader.localHeaderOffset;
+  }
+
+  return hashTable;
+}

--- a/modules/zip/src/index.ts
+++ b/modules/zip/src/index.ts
@@ -6,7 +6,7 @@ export {TarBuilder} from './tar-builder';
 
 export {
   parseZipCDFileHeader,
-  zipCDFileHeaderGenerator,
+  makeZipCDHeaderIterator,
   signature as cdSignature
 } from './parse-zip/cd-file-header';
 export {
@@ -16,7 +16,7 @@ export {
 export {parseEoCDRecord} from './parse-zip/end-of-central-directory';
 export {searchFromTheEnd} from './parse-zip/search-from-the-end';
 
-export type {HashElement} from './hash-file-utility';
-export {compareHashes, parseHashFile, findBin, generateHashInfo} from './hash-file-utility';
+// export type {HashElement} from './hash-file-utility';
+export {parseHashTable, makeHashTableFromZipHeaders} from './hash-file-utility';
 
 export {ZipFileSystem} from './filesystems/zip-filesystem';

--- a/modules/zip/src/parse-zip/cd-file-header.ts
+++ b/modules/zip/src/parse-zip/cd-file-header.ts
@@ -101,7 +101,9 @@ export const parseZipCDFileHeader = async (
  * Create iterator over files of zip archive
  * @param fileProvider - file provider that provider random access to the file
  */
-export async function* zipCDFileHeaderGenerator(fileProvider: FileProvider) {
+export async function* makeZipCDHeaderIterator(
+  fileProvider: FileProvider
+): AsyncIterable<ZipCDFileHeader> {
   const {cdStartOffset} = await parseEoCDRecord(fileProvider);
   let cdHeader = await parseZipCDFileHeader(cdStartOffset, fileProvider);
   while (cdHeader) {

--- a/modules/zip/tsconfig.json
+++ b/modules/zip/tsconfig.json
@@ -10,6 +10,7 @@
   "references": [
     {"path": "../loader-utils"},
     {"path": "../core"},
-    {"path": "../compression"}
+    {"path": "../compression"},
+    {"path": "../crypto"}
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4141,9 +4141,9 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caniuse-lite@^1.0.30001449:
-  version "1.0.30001542"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001542.tgz"
-  integrity sha512-UrtAXVcj1mvPBFQ4sKd38daP8dEcXXr5sQe6QNNinaPd0iA/cxg9/l3VrSdL73jgw5sKyuQ6jNgiKO12W3SsVA==
+  version "1.0.30001546"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001546.tgz"
+  integrity sha512-zvtSJwuQFpewSyRrI3AsftF6rM0X80mZkChIt1spBGEvRglCrjTniXvinc8JKRoqTwXAgvqTImaN9igfSMtUBw==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
@dariaterekhovaae 

- Since loaders.gl already has a crypto module I prefer that we use that.
- We should avoid using Node.js `Buffer` class: it pulls in a big polyfill when used in browser and generally I can become confusing to use too many different abstractions for handling binary memory at the same time. Prefer ArrayBuffer and DataView.
- While I was making changes, I noted that your hash/offset data structure could be more efficiently stored as `{[hash: string]; offset}`