### PR TITLE
fix(tile-converter): node workers error

### DIFF
--- a/modules/tile-converter/src/deps-installer/deps-installer.ts
+++ b/modules/tile-converter/src/deps-installer/deps-installer.ts
@@ -50,7 +50,7 @@ export class DepsInstaller {
       // `npm install sharp join-images` works unstable. It fails because installed `sharp` version
       // may be different from the version required by `join-images`. Pointing to specific versions
       // resolve this issue
-      arguments: ['install', 'sharp@^0.30.4', 'join-images@^1.1.3'],
+      arguments: ['install', 'sharp@0.30.4', 'join-images@1.1.3'],
       wait: 0
     });
 

--- a/modules/tile-converter/src/i3s-converter/helpers/geometry-converter.ts
+++ b/modules/tile-converter/src/i3s-converter/helpers/geometry-converter.ts
@@ -515,8 +515,12 @@ function convertMesh(
       outputAttributes = attributesMap.get('default');
     }
     assert(outputAttributes !== null, 'Primitive - material mapping failed');
+    // Per the spec https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#_mesh_primitive_mode
+    // GL.TRIANGLES is default. So in case `mode` is `undefined`, it is 'TRIANGLES'
     assert(
-      primitive.mode === GL.TRIANGLES || primitive.mode === GL.TRIANGLE_STRIP,
+      primitive.mode === undefined ||
+        primitive.mode === GL.TRIANGLES ||
+        primitive.mode === GL.TRIANGLE_STRIP,
       `Primitive - unsupported mode ${primitive.mode}`
     );
     const attributes = primitive.attributes;

--- a/modules/tile-converter/src/i3s-converter/i3s-converter.ts
+++ b/modules/tile-converter/src/i3s-converter/i3s-converter.ts
@@ -218,13 +218,13 @@ export default class I3SConverter {
         loadOptions: {
           _nodeWorkers: true,
           reuseWorkers: true,
-          basis: {format: 'rgba32'}
-          // TODO - should no longer be needed with new Node workers
-          // 'basis-nodejs': {
-          //   format: 'rgba32',
-          //   workerUrl: './modules/textures/dist/basis-worker-node.js'
-          // },
-          // 'draco-nodejs': {workerUrl: './modules/draco/dist/draco-worker-node.js'}
+          basis: {
+            format: 'rgba32',
+            // We need to load local fs workers because nodejs can't load workers from the Internet
+            workerUrl: './modules/textures/dist/basis-worker-node.js'
+          },
+          // We need to load local fs workers because nodejs can't load workers from the Internet
+          draco: {workerUrl: './modules/draco/dist/draco-worker-node.js'}
         }
       };
       if (preloadOptions.headers) {

--- a/modules/tile-converter/src/lib/utils/file-utils.ts
+++ b/modules/tile-converter/src/lib/utils/file-utils.ts
@@ -118,7 +118,8 @@ export async function isFileExists(fileName: string): Promise<boolean> {
  * @param path
  */
 export function removeDir(path: string) {
-  return fs.rmdir(path, {recursive: true});
+  // (node:35607) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
+  return fs.rm(path, {recursive: true});
 }
 
 /**


### PR DESCRIPTION
Related to https://github.com/visgl/loaders.gl/pull/2495
* Use workers from local fs;

Also
* Fix dependencies installer;
* Fix NodeJS deprecation warning.