### PR TITLE
Fix JSONLoader _rootObjectBatches removed but not mentioned in upgrade guide

### DIFF
--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -461,6 +461,12 @@ loaders.gl v3.0 is a major release, that adds a range of new loaders and feature
 - Supports binary array fields in draco metadata.
 - Significant performance improvements for loading and decoding.
 
+**@loaders.gl/json**
+
+- Removed deprecated json parse option `_rootObjectBatches`. Use loader option `metadata` instead.
+- Replaced `batch.batchType` `root-object-batch-partial` with `partial-result`.
+- Replaced `batch.batchType` `root-object-batch-complete` with `final-result`.
+
 **@loaders.gl/kml**
 
 - `KMLLoader` - updated loader, now works under Node.js.


### PR DESCRIPTION
Closes https://github.com/visgl/loaders.gl/issues/2556

PR updates upgrade documentation with changes to json module for 3.0.0 release.