### PR TITLE
Add `triangulate` property to `geojsonToBinary`

### DIFF
--- a/docs/modules/gis/api-reference/geojson-to-binary.md
+++ b/docs/modules/gis/api-reference/geojson-to-binary.md
@@ -20,7 +20,8 @@ const geoJSONfeatures = await load('data.geojson', JSONLoader);
  * {
  *   fixRingWinding: true
  *   numericPropKeys: derived from data
- *   PositionDataType: Float32Array
+ *   PositionDataType: Float32Array,
+ *   triangulate: true
  * }
  */
 const options = {PositionDataType: Float32Array};
@@ -95,8 +96,8 @@ corresponds to 3D coordinates, where each vertex is defined by three numbers.
     polygonIndices: {value: Uint16Array | Uint32Array, size: 1},
     // Indices within positions of the start of each primitive Polygon/ring
     primitivePolygonIndices: {value: Uint16Array | Uint32Array, size: 1},
-    // Triangle indices. Allows deck.gl to skip performing costly triangulation on main thread
-    triangles: {value: Uint32Array, size: 1},
+    // Triangle indices. Allows deck.gl to skip performing costly triangulation on main thread. Not present if `options.triangulate` is `false`
+    triangles?: {value: Uint32Array, size: 1},
     // Array of original feature indexes by vertex
     globalFeatureIds: {value: Uint16Array | Uint32Array, size: 1},
     // Array of Polygon feature indexes by vertex
@@ -121,9 +122,10 @@ corresponds to 3D coordinates, where each vertex is defined by three numbers.
 
 | Option           | Type      | Default           | Description                                                                                                                                             |
 | ---------------- | --------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| fixRingWinding   | `Boolean` | `true`            | Whether the fix incorrect ring winding for polygons. Valid `GeoJSON` polygons have the outer ring coordinates in CCW order and with holes in CW order   |
+| fixRingWinding   | `Boolean` | `true`            | Whether to fix incorrect ring winding for polygons. Valid `GeoJSON` polygons have the outer ring coordinates in CCW order and with holes in CW order    |
 | numericPropKeys  | `Array`   | Derived from data | Names of feature properties that should be converted to numeric `TypedArray`s. Passing `[]` will force all properties to be returned as normal objects. |
 | PositionDataType | `class`   | `Float32Array`    | Data type used for positions arrays.                                                                                                                    |
+| triangulate      | `Boolean` | `true`            | Whether polygons are triangulated as part of the conversion                                                                                             |
 
 ## Notes
 

--- a/docs/modules/gis/api-reference/geojson-to-binary.md
+++ b/docs/modules/gis/api-reference/geojson-to-binary.md
@@ -14,16 +14,7 @@ import {geojsonToBinary} from '@loaders.gl/gis';
 
 const geoJSONfeatures = await load('data.geojson', JSONLoader);
 
-/*
- * Default options are:
- *
- * {
- *   fixRingWinding: true
- *   numericPropKeys: derived from data
- *   PositionDataType: Float32Array,
- *   triangulate: true
- * }
- */
+// See table below for full list of options
 const options = {PositionDataType: Float32Array};
 const binaryFeatures = geojsonToBinary(geoJSONfeatures, options);
 ```
@@ -125,8 +116,10 @@ corresponds to 3D coordinates, where each vertex is defined by three numbers.
 | fixRingWinding   | `Boolean` | `true`            | Whether to fix incorrect ring winding for polygons. Valid `GeoJSON` polygons have the outer ring coordinates in CCW order and with holes in CW order    |
 | numericPropKeys  | `Array`   | Derived from data | Names of feature properties that should be converted to numeric `TypedArray`s. Passing `[]` will force all properties to be returned as normal objects. |
 | PositionDataType | `class`   | `Float32Array`    | Data type used for positions arrays.                                                                                                                    |
-| triangulate      | `Boolean` | `true`            | Whether polygons are triangulated as part of the conversion                                                                                             |
+| triangulate      | `Boolean` | `true`            | Whether polygons are broken into triangles as part of the conversion (generally required for GPU rendering)                                             |
 
 ## Notes
 
 In the case of the source geoJson features having an object as a property, it would not be deep cloned, so it would be linked from the output object (be careful on further mutations).
+
+Triangulation of polygons can be time consuming. If not needed, set the `triangulate` option to `false`.

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -105,6 +105,10 @@ Target Release Date: April, 2023.
 - [`BSONLoader`](/docs/modules/bson/api-reference/bson-loader) - loads BSON encoded binary data into a "JSON like" JavaScript structure
 - [`BSONWriter`](/docs/modules/bson/api-reference/bson-writer) - writes a JSON like JavaScript structure into a BSON encoded binary data block.
 
+**@loaders.gl/gis**
+
+- `triangulate` parameter added to `geojsonToBinary()`.
+
 **@loaders.gl/images**
 
 - `ImageLoader` now supports for loading images in the AVIF image format.

--- a/modules/gis/src/lib/flat-geojson-to-binary-types.ts
+++ b/modules/gis/src/lib/flat-geojson-to-binary-types.ts
@@ -47,7 +47,7 @@ export type Polygons = {
   positions: Float32Array | Float64Array;
   polygonIndices: Uint16Array | Uint32Array;
   primitivePolygonIndices: Uint16Array | Uint32Array;
-  triangles: number[];
+  triangles?: number[];
   globalFeatureIds: Uint16Array | Uint32Array;
   featureIds: Uint16Array | Uint32Array;
   numericProps: {[key: string]: TypedArray};

--- a/modules/gis/src/lib/flat-geojson-to-binary.ts
+++ b/modules/gis/src/lib/flat-geojson-to-binary.ts
@@ -481,7 +481,7 @@ function makeAccessorObjects(
   polygons: Polygons,
   coordLength: number
 ): BinaryFeatures {
-  const out = {
+  return {
     points: {
       ...points,
       positions: {value: points.positions, size: coordLength},
@@ -502,16 +502,12 @@ function makeAccessorObjects(
       positions: {value: polygons.positions, size: coordLength},
       polygonIndices: {value: polygons.polygonIndices, size: 1},
       primitivePolygonIndices: {value: polygons.primitivePolygonIndices, size: 1},
+      ...(polygons.triangles && {triangles: {value: new Uint32Array(polygons.triangles), size: 1}}),
       globalFeatureIds: {value: polygons.globalFeatureIds, size: 1},
       featureIds: {value: polygons.featureIds, size: 1},
       numericProps: wrapProps(polygons.numericProps, 1)
     } as BinaryPolygonFeatures
   };
-  if (polygons.triangles) {
-    out.polygons.triangles = {value: new Uint32Array(polygons.triangles), size: 1};
-  }
-
-  return out;
 }
 
 /**

--- a/modules/gis/src/lib/geojson-to-binary.ts
+++ b/modules/gis/src/lib/geojson-to-binary.ts
@@ -12,6 +12,7 @@ export type GeojsonToBinaryOptions = {
   fixRingWinding: boolean;
   numericPropKeys?: string[];
   PositionDataType?: Float32ArrayConstructor | Float64ArrayConstructor;
+  triangulate?: boolean;
 };
 
 /**
@@ -23,7 +24,7 @@ export type GeojsonToBinaryOptions = {
  */
 export function geojsonToBinary(
   features: Feature[],
-  options: GeojsonToBinaryOptions = {fixRingWinding: true}
+  options: GeojsonToBinaryOptions = {fixRingWinding: true, triangulate: true}
 ): BinaryFeatures {
   const geometryInfo = extractGeometryInfo(features);
   const coordLength = geometryInfo.coordLength;
@@ -31,6 +32,7 @@ export function geojsonToBinary(
   const flatFeatures = geojsonToFlatGeojson(features, {coordLength, fixRingWinding});
   return flatGeojsonToBinary(flatFeatures, geometryInfo, {
     numericPropKeys: options.numericPropKeys,
-    PositionDataType: options.PositionDataType || Float32Array
+    PositionDataType: options.PositionDataType || Float32Array,
+    triangulate: options.triangulate
   });
 }

--- a/modules/gis/test/geojson-to-binary.spec.js
+++ b/modules/gis/test/geojson-to-binary.spec.js
@@ -395,6 +395,19 @@ test('gis#geojson-to-binary with empty properties', async (t) => {
   t.end();
 });
 
+test('gis#geojson-to-binary triangulation', async (t) => {
+  const response = await fetchFile(GEOJSON_NO_PROPERTIES);
+  const {features} = await response.json();
+  const binary = geojsonToBinary(features);
+
+  t.ok(binary.polygons.triangles);
+  t.deepEqual(binary.polygons.triangles.value, [3, 0, 1, 1, 2, 3]);
+
+  const binaryNoTriangles = geojsonToBinary(features, {triangulate: false});
+  t.notOk(binaryNoTriangles.polygons.triangles);
+  t.end();
+});
+
 function flatten(arr) {
   return arr.reduce(function (flat, toFlatten) {
     return flat.concat(Array.isArray(toFlatten) ? flatten(toFlatten) : toFlatten);

--- a/modules/gis/test/gis.bench.js
+++ b/modules/gis/test/gis.bench.js
@@ -3,16 +3,19 @@ import {load} from '@loaders.gl/core';
 
 import {geojsonToBinary} from '@loaders.gl/gis';
 
-const GEOJSON_URL = '@loaders.gl/json/test/data/geojson-big.json';
+// const GEOJSON_URL = '@loaders.gl/json/test/data/geojson-big.json';
+const GEOJSON_POLYGONS_URL = '@loaders.gl/mvt/test/data/geojson-vt/us-states.json';
 
 export default async function gisBench(suite) {
   suite.group('geojson-to-binary');
 
   // @ts-expect-error
-  const {features} = await load(GEOJSON_URL, JSONLoader);
-  const options = {multiplier: 308, unit: 'features'};
-
-  suite.addAsync('geojsonToBinary - GeoJSON to Binary conversion', options, async () => {
-    geojsonToBinary(features);
+  const {features} = await load(GEOJSON_POLYGONS_URL, JSONLoader);
+  const options = {multiplier: features.length, unit: 'features'};
+  suite.addAsync('geojsonToBinary(triangulate=true)', options, async () => {
+    const out = geojsonToBinary(features);
+  });
+  suite.addAsync('geojsonToBinary(triangulate=false)', options, async () => {
+    const out = geojsonToBinary(features, {triangulate: false});
   });
 }

--- a/modules/gis/test/gis.bench.js
+++ b/modules/gis/test/gis.bench.js
@@ -13,9 +13,9 @@ export default async function gisBench(suite) {
   const {features} = await load(GEOJSON_POLYGONS_URL, JSONLoader);
   const options = {multiplier: features.length, unit: 'features'};
   suite.addAsync('geojsonToBinary(triangulate=true)', options, async () => {
-    const out = geojsonToBinary(features);
+    geojsonToBinary(features);
   });
   suite.addAsync('geojsonToBinary(triangulate=false)', options, async () => {
-    const out = geojsonToBinary(features, {triangulate: false});
+    geojsonToBinary(features, {fixRingWinding: true, triangulate: false});
   });
 }


### PR DESCRIPTION
### Background

We have found that the `geojsonToBinary` function can be very slow (multiple seconds) when processing large polygons due to the triangulation done via earcut. This PR adds a new optional parameter to disable the triangulation. By defaulting to `true` we maintain back compatibility but enable fast processing when needed (e.g. for a realtime API).

The result is that the output data structure doesn't include the `polygons.triangles` property. deck.gl is able to cope with this and will perform the tesselation at render time, much like it does when rendering GeoJSON.

### Changelist

- Add new parameter to `geojsonToBinary`
- Implementation in `flat-geojson-to-binary.ts`
- Doc & test update