### PR TITLE
chore(i3s): Hash generation moved to @loader.gl/zip

### DIFF
--- a/modules/zip/src/index.ts
+++ b/modules/zip/src/index.ts
@@ -13,4 +13,4 @@ export {searchFromTheEnd} from './parse-zip/search-from-the-end';
 export {DataViewFile} from './parse-zip/data-view-file';
 
 export type {HashElement} from './hash-file-utility';
-export {compareHashes, parseHashFile, findBin} from './hash-file-utility';
+export {compareHashes, parseHashFile, findBin, generateHashInfo} from './hash-file-utility';


### PR DESCRIPTION
Contains part of https://github.com/visgl/loaders.gl/pull/2578

Moved hash generation to zip module as well