### PR TITLE
chore: Clean up module imports, remove default exports in images module

### DIFF
--- a/modules/gltf/src/index.ts
+++ b/modules/gltf/src/index.ts
@@ -28,7 +28,9 @@ export type {
   GLTF_KHR_texture_basisu,
   GLTF_EXT_meshopt_compression,
   GLTF_EXT_texture_webp,
-  GLTF_EXT_feature_metadata
+  GLTF_EXT_feature_metadata,
+  GLTF_EXT_feature_metadata_primitive,
+  GLTF_EXT_feature_metadata_attribute
 } from './lib/types/gltf-types';
 
 // glTF loader/writer definition objects

--- a/modules/gltf/src/lib/types/gltf-types.ts
+++ b/modules/gltf/src/lib/types/gltf-types.ts
@@ -20,7 +20,9 @@ import type {
   GLTF_KHR_texture_basisu,
   GLTF_EXT_meshopt_compression,
   GLTF_EXT_texture_webp,
-  GLTF_EXT_feature_metadata
+  GLTF_EXT_feature_metadata,
+  GLTF_EXT_feature_metadata_primitive,
+  GLTF_EXT_feature_metadata_attribute
 } from './gltf-json-schema';
 
 import type {
@@ -34,6 +36,7 @@ import type {
   Texture as GLTFTexturePostprocessed
 } from './gltf-postprocessed-schema';
 
+// Source glTF types
 export type {
   GLTF,
   GLTFAccessor,
@@ -53,6 +56,13 @@ export type {
   GLTF_KHR_texture_basisu,
   GLTF_EXT_meshopt_compression,
   GLTF_EXT_texture_webp,
+  GLTF_EXT_feature_metadata,
+  GLTF_EXT_feature_metadata_primitive,
+  GLTF_EXT_feature_metadata_attribute
+};
+
+// Post processed glTF types
+export type {
   GLTFPostprocessed,
   GLTFAccessorPostprocessed,
   GLTFImagePostprocessed,
@@ -60,8 +70,7 @@ export type {
   GLTFMeshPostprocessed,
   GLTFMeshPrimitivePostprocessed,
   GLTFMaterialPostprocessed,
-  GLTFTexturePostprocessed,
-  GLTF_EXT_feature_metadata
+  GLTFTexturePostprocessed
 };
 
 export type GLTFObject =

--- a/modules/images/src/image-loader.ts
+++ b/modules/images/src/image-loader.ts
@@ -1,6 +1,6 @@
 import type {LoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';
 import {VERSION} from './lib/utils/version';
-import parseImage from './lib/parsers/parse-image';
+import {parseImage} from './lib/parsers/parse-image';
 import {getBinaryImageMetadata} from './lib/category-api/binary-image-api';
 
 const EXTENSIONS = ['png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'ico', 'svg', 'avif'];

--- a/modules/images/src/lib/parsers/parse-image.ts
+++ b/modules/images/src/lib/parsers/parse-image.ts
@@ -4,13 +4,13 @@ import type {ImageType} from '../../types';
 import type {ImageLoaderOptions} from '../../image-loader';
 import {isImageTypeSupported, getDefaultImageType} from '../category-api/image-type';
 import {getImageData} from '../category-api/parsed-image-api';
-import parseToImage from './parse-to-image';
-import parseToImageBitmap from './parse-to-image-bitmap';
-import parseToNodeImage from './parse-to-node-image';
+import {parseToImage} from './parse-to-image';
+import {parseToImageBitmap} from './parse-to-image-bitmap';
+import {parseToNodeImage} from './parse-to-node-image';
 
 // Parse to platform defined image type (data on node, ImageBitmap or HTMLImage on browser)
 // eslint-disable-next-line complexity
-export default async function parseImage(
+export async function parseImage(
   arrayBuffer: ArrayBuffer,
   options?: ImageLoaderOptions,
   context?: LoaderContext

--- a/modules/images/src/lib/parsers/parse-to-image-bitmap.ts
+++ b/modules/images/src/lib/parsers/parse-to-image-bitmap.ts
@@ -1,6 +1,6 @@
 import type {ImageLoaderOptions} from '../../image-loader';
 import {isSVG, getBlob} from './svg-utils';
-import parseToImage from './parse-to-image';
+import {parseToImage} from './parse-to-image';
 
 const EMPTY_OBJECT = {};
 
@@ -13,7 +13,7 @@ let imagebitmapOptionsSupported = true;
  *
  * TODO - createImageBitmap supports source rect (5 param overload), pass through?
  */
-export default async function parseToImageBitmap(
+export async function parseToImageBitmap(
   arrayBuffer: ArrayBuffer,
   options: ImageLoaderOptions,
   url?: string

--- a/modules/images/src/lib/parsers/parse-to-image.ts
+++ b/modules/images/src/lib/parsers/parse-to-image.ts
@@ -2,7 +2,7 @@ import type {ImageLoaderOptions} from '../../image-loader';
 import {getBlobOrSVGDataUrl} from './svg-utils';
 
 // Parses html image from array buffer
-export default async function parseToImage(
+export async function parseToImage(
   arrayBuffer: ArrayBuffer,
   options: ImageLoaderOptions,
   url?: string

--- a/modules/images/src/lib/parsers/parse-to-node-image.ts
+++ b/modules/images/src/lib/parsers/parse-to-node-image.ts
@@ -17,7 +17,7 @@ type NDArray = {
 type ParseImageNode = (arrayBuffer: ArrayBuffer, mimeType: string) => Promise<NDArray>;
 
 // Use polyfills if installed to parsed image using get-pixels
-export default async function parseToNodeImage(
+export async function parseToNodeImage(
   arrayBuffer: ArrayBuffer,
   options: ImageLoaderOptions
 ): Promise<ImageDataType> {

--- a/modules/images/src/lib/texture-api/load-image.ts
+++ b/modules/images/src/lib/texture-api/load-image.ts
@@ -1,5 +1,5 @@
 import {assert} from '@loaders.gl/loader-utils';
-import parseImage from '../parsers/parse-image';
+import {parseImage} from '../parsers/parse-image';
 import {getImageSize} from '../category-api/parsed-image-api';
 import {generateUrl} from './generate-url';
 import {deepLoad, shallowLoad} from './deep-load';

--- a/modules/tile-converter/src/i3s-converter/helpers/batch-ids-extensions.ts
+++ b/modules/tile-converter/src/i3s-converter/helpers/batch-ids-extensions.ts
@@ -6,7 +6,7 @@ import {
 import type {
   GLTF_EXT_feature_metadata_attribute,
   GLTF_EXT_feature_metadata_primitive
-} from 'modules/gltf/src/lib/types/gltf-json-schema';
+} from '@loaders.gl/gltf';
 
 const EXT_MESH_FEATURES = 'EXT_mesh_features';
 const EXT_FEATURE_METADATA = 'EXT_feature_metadata';

--- a/modules/tile-converter/src/i3s-converter/helpers/geometry-converter.ts
+++ b/modules/tile-converter/src/i3s-converter/helpers/geometry-converter.ts
@@ -5,11 +5,21 @@ import type {
   GLTFMaterialPostprocessed,
   GLTFNodePostprocessed,
   GLTFImagePostprocessed,
+  GLTFTexturePostprocessed,
   GLTFMeshPrimitivePostprocessed,
-  GLTFMeshPostprocessed,
-  GLTFTexturePostprocessed
+  GLTFMeshPostprocessed
 } from '@loaders.gl/gltf';
 
+import {
+  AttributeStorageInfo,
+  I3SMaterialDefinition,
+  MaterialDefinitionInfo,
+  TextureDefinitionInfo
+} from '@loaders.gl/i3s';
+
+import {TypedArray} from '@loaders.gl/schema';
+import {GL} from '@loaders.gl/math';
+import {Geoid} from '@math.gl/geoid';
 import {Vector3, Matrix4, Vector4} from '@math.gl/core';
 import {Ellipsoid} from '@math.gl/geospatial';
 
@@ -27,21 +37,11 @@ import {
   MergedMaterial,
   SharedResourcesArrays
 } from '../types';
-import {
-  AttributeStorageInfo,
-  I3SMaterialDefinition,
-  MaterialDefinitionInfo,
-  TextureDefinitionInfo
-} from '@loaders.gl/i3s';
-import {TypedArray} from '@loaders.gl/schema';
-import {Geoid} from '@math.gl/geoid';
 /** Usage of worker here brings more overhead than advantage */
 import {B3DMAttributesData /*, transformI3SAttributesOnWorker*/} from '../../i3s-attributes-worker';
 import {prepareDataForAttributesConversion} from './gltf-attributes';
 import {handleBatchIdsExtensions} from './batch-ids-extensions';
 import {checkPropertiesLength, flattenPropertyTableByFeatureIds} from './feature-attributes';
-import {MeshPrimitive} from 'modules/gltf/src/lib/types/gltf-postprocessed-schema';
-import {GL} from '@loaders.gl/math';
 
 /*
   At the moment of writing the type TypedArrayConstructor is not exported in '@math.gl/types'.
@@ -567,10 +567,10 @@ function convertMesh(
 }
 /**
  * Converts TRIANGLE-STRIPS to independent TRIANGLES
- * @param {MeshPrimitive} primitive - the primitive to get the indices from
+ * @param primitive - the primitive to get the indices from
  * @returns indices of vertices of the independent triangles
  */
-function getIndices(primitive: MeshPrimitive): TypedArray {
+function getIndices(primitive: GLTFMeshPrimitivePostprocessed): TypedArray {
   let indices: TypedArray = primitive.indices?.value;
   if (indices && primitive.mode === GL.TRIANGLE_STRIP) {
     /*

--- a/modules/wms/src/lib/services/ogc/wms-service.ts
+++ b/modules/wms/src/lib/services/ogc/wms-service.ts
@@ -190,15 +190,6 @@ export class WMSService extends ImageSource<WMSServiceProps> {
 
   capabilities: WMSCapabilities | null = null;
 
-  /** A list of loaders used by the WMSService methods */
-  readonly loaders = [
-    ImageLoader,
-    WMSErrorLoader,
-    WMSCapabilitiesLoader,
-    WMSFeatureInfoLoader,
-    WMSLayerDescriptionLoader
-  ];
-
   /** Create a WMSService */
   constructor(props: WMSServiceProps) {
     super(props);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4006,9 +4006,9 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caniuse-lite@^1.0.30001449:
-  version "1.0.30001524"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001524.tgz"
-  integrity sha512-Jj917pJtYg9HSJBF95HVX3Cdr89JUyLT4IZ8SvM5aDRni95swKgYi3TgYLH5hnGfPE/U1dg6IfZ50UsIlLkwSA==
+  version "1.0.30001525"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001525.tgz"
+  integrity sha512-/3z+wB4icFt3r0USMwxujAqRvaD/B7rvGTsKhbhSQErVrJvkZCLhgNLJxU8MevahQVH6hCU9FsHdNUFbiwmE7Q==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
Address some issues found when investigating #2615, however root cause not yet understood.

Removing default exports in images may or may not help.