### PR TITLE
fix(zip): @loaders.gl/core dependency

### DIFF
--- a/modules/zip/package.json
+++ b/modules/zip/package.json
@@ -37,7 +37,7 @@
     "jszip": "^3.1.5"
   },
   "peerDependencies": {
-    "@loaders.gl/core": "^4.0.0"
+    "@loaders.gl/core": "^4.0.0-alpha.21"
   },
   "gitHead": "c95a4ff72512668a93d9041ce8636bac09333fd5"
 }


### PR DESCRIPTION
Fixes:

`npm install @loaders.gl/tile-converter@4.0.0-alpha.21` fails