### PR TITLE
fix(parse-i3s): getting root node url for normalizeTilesetData without nodepages

### DIFF
--- a/modules/i3s/src/lib/parsers/parse-i3s.ts
+++ b/modules/i3s/src/lib/parsers/parse-i3s.ts
@@ -10,7 +10,8 @@ import {
   Mbs,
   I3SMinimalNodeData,
   Node3DIndexDocument,
-  SceneLayer3D
+  SceneLayer3D,
+  I3SParseOptions
 } from '../../types';
 import type {LoaderOptions, LoaderContext} from '@loaders.gl/loader-utils';
 import { I3SLoader } from '../../i3s-loader';
@@ -90,8 +91,8 @@ export async function normalizeTilesetData(tileset : SceneLayer3D, options : Loa
     nodePagesTile = new I3SNodePagesTiles(tileset, url, options);
     root = await nodePagesTile.formTileFromNodePages(0);
   } else {
-    // @ts-expect-error options is not properly typed
-    const rootNodeUrl = getUrlWithToken(`${url}/nodes/root`, options.i3s?.token);
+    const parseOptions = options.i3s as I3SParseOptions;
+    const rootNodeUrl = getUrlWithToken(`${url}/nodes/root`, parseOptions.token);
     // eslint-disable-next-line no-use-before-define
     root = await load(rootNodeUrl, I3SLoader, {
       ...options,

--- a/modules/i3s/src/lib/parsers/parse-i3s.ts
+++ b/modules/i3s/src/lib/parsers/parse-i3s.ts
@@ -91,7 +91,7 @@ export async function normalizeTilesetData(tileset : SceneLayer3D, options : Loa
     root = await nodePagesTile.formTileFromNodePages(0);
   } else {
     // @ts-expect-error options is not properly typed
-    const rootNodeUrl = getUrlWithToken(`${tileset.url}/nodes/root`, options.i3s?.token);
+    const rootNodeUrl = getUrlWithToken(`${url}/nodes/root`, options.i3s?.token);
     // eslint-disable-next-line no-use-before-define
     root = await load(rootNodeUrl, I3SLoader, {
       ...options,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4141,9 +4141,9 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caniuse-lite@^1.0.30001449:
-  version "1.0.30001538"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001538.tgz"
-  integrity sha512-HWJnhnID+0YMtGlzcp3T9drmBJUVDchPJ08tpUGFLs9CYlwWPH2uLgpHn8fND5pCgXVtnGS3H4QR9XLMHVNkHw==
+  version "1.0.30001539"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001539.tgz"
+  integrity sha512-hfS5tE8bnNiNvEOEkm8HElUHroYwlqMMENEzELymy77+tJ6m+gA2krtHl5hxJaj71OlpC2cHZbdSMX1/YEqEkA==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
Getting root node url for tilesets without node pages needs to be corrected according to recent changes in the NormalizeTilesetData