### PR TITLE
fix: getting tile url with empty query params

### DIFF
--- a/modules/tiles/src/tileset/tileset-3d.ts
+++ b/modules/tiles/src/tileset/tileset-3d.ts
@@ -348,9 +348,12 @@ export class Tileset3D {
     if (isDataUrl) {
       return tilePath;
     }
-    return `${tilePath}${tilePath.includes('?') ? '&' : this.queryParams.length ? '?' : ''}${
-      this.queryParams
-    }`;
+
+    let tileUrl = tilePath;
+    if (this.queryParams.length) {
+      tileUrl = `${tilePath}${tilePath.includes('?') ? '&' : '?'}${this.queryParams}`;
+    }
+    return tileUrl;
   }
 
   // TODO CESIUM specific

--- a/modules/tiles/src/tileset/tileset-3d.ts
+++ b/modules/tiles/src/tileset/tileset-3d.ts
@@ -348,7 +348,9 @@ export class Tileset3D {
     if (isDataUrl) {
       return tilePath;
     }
-    return `${tilePath}${tilePath.includes('?') ? '&' : '?'}${this.queryParams}`;
+    return `${tilePath}${tilePath.includes('?') ? '&' : this.queryParams.length ? '?' : ''}${
+      this.queryParams
+    }`;
   }
 
   // TODO CESIUM specific

--- a/modules/tiles/test/tileset/tileset-3d.spec.ts
+++ b/modules/tiles/test/tileset/tileset-3d.spec.ts
@@ -162,9 +162,18 @@ test('Tileset3D#url set up correctly given path with query string', async (t) =>
       '/test/data/Tilesets/TilesetOfTilesets/tileset2.json?param3=3&session=sesh&param1=1&param2=2&v=1.2.3',
       'child url content parameters preserved'
     );
+    t.equals(tileset.getTileUrl(tile.contentUrl).endsWith('?'), false);
   } else {
     t.fail('no tile');
   }
+  t.end();
+});
+
+test('Tileset3D#getTileUrl should not ends with sign ?', async (t) => {
+  const path = '@loaders.gl/3d-tiles/test/data/Tilesets/TilesetOfTilesets/tileset2.json';
+  const tilesetJson = await load(path, Tiles3DLoader);
+  const tileset = new Tileset3D(tilesetJson);
+  t.equals(tileset.getTileUrl(tileset.url).endsWith('?'), false);
   t.end();
 });
 

--- a/modules/tiles/test/tileset/tileset-3d.spec.ts
+++ b/modules/tiles/test/tileset/tileset-3d.spec.ts
@@ -162,18 +162,20 @@ test('Tileset3D#url set up correctly given path with query string', async (t) =>
       '/test/data/Tilesets/TilesetOfTilesets/tileset2.json?param3=3&session=sesh&param1=1&param2=2&v=1.2.3',
       'child url content parameters preserved'
     );
-    t.equals(tileset.getTileUrl(tile.contentUrl).endsWith('?'), false);
+    const urlEnds = tileset.getTileUrl(tile.contentUrl).slice(-1);
+    t.equals('?&'.includes(urlEnds), false);
   } else {
     t.fail('no tile');
   }
   t.end();
 });
 
-test('Tileset3D#getTileUrl should not ends with sign ?', async (t) => {
+test('Tileset3D#getTileUrl should not ends with sign ? or &', async (t) => {
   const path = '@loaders.gl/3d-tiles/test/data/Tilesets/TilesetOfTilesets/tileset2.json';
   const tilesetJson = await load(path, Tiles3DLoader);
   const tileset = new Tileset3D(tilesetJson);
-  t.equals(tileset.getTileUrl(tileset.url).endsWith('?'), false);
+  const urlEnds = tileset.getTileUrl(tileset.url).slice(-1);
+  t.equals('?&'.includes(urlEnds), false);
   t.end();
 });
 


### PR DESCRIPTION
We don't need sign '?' at the end of the url if there are no query parameters