### PR TITLE
fix: WMS 1.3.0 compatibility on GetFeatureInfo

### DIFF
--- a/modules/wms/src/services/ogc/wms-service.ts
+++ b/modules/wms/src/services/ogc/wms-service.ts
@@ -363,6 +363,7 @@ export class WMSSource extends ImageSource<WMSSourceProps> {
     wmsParameters: WMSGetFeatureInfoParameters,
     vendorParameters?: Record<string, unknown>
   ): string {
+    wmsParameters = this._getWMS130Parameters(wmsParameters);
     const options: Required<WMSGetFeatureInfoParameters> = {
       version: this.wmsParameters.version,
       // query_layers: [],


### PR DESCRIPTION
`getMapURL` uses the `_getWMS130Parameters` to improve compatibility between WMS 1.3.0 and 1.1.0, but `getFeatureInfoUrl` does not.

This means, for instance if SRS is set to `EPSG:3857` it will be handled incorrectly by `getFeatureInfoUrl` as it would use the default CRS of `EPSG:4326`, causing bbox flipping