### PR TITLE
fix(tiles): convert region to obb

### DIFF
--- a/modules/tiles/test/index.ts
+++ b/modules/tiles/test/index.ts
@@ -8,6 +8,7 @@ import './tileset/tileset-traverser.spec';
 
 import './tileset/helpers/get-frame-state.spec';
 import './tileset/helpers/zoom.spec';
+import './tileset/helpers/bounding-volume.spec';
 
 // I3S Specific tests
 // TODO - deck.gl dependency

--- a/modules/tiles/test/test-utils/compareArrays.ts
+++ b/modules/tiles/test/test-utils/compareArrays.ts
@@ -1,0 +1,14 @@
+const EPSILON = 0.000000001;
+export function areNumberArraysEqual(array1, array2) {
+  let result = true;
+  if (array1.length !== array2.length) {
+    return false;
+  }
+  for (let i = 0; i < array1.length; i++) {
+    if (Math.abs(array1[i] - array2[i]) > EPSILON) {
+      result = false;
+      break;
+    }
+  }
+  return result;
+}

--- a/modules/tiles/test/tileset/helpers/bounding-volume.spec.ts
+++ b/modules/tiles/test/tileset/helpers/bounding-volume.spec.ts
@@ -1,0 +1,33 @@
+import test from 'tape-promise/tape';
+import {createBoundingVolume} from '../../../src/tileset/helpers/bounding-volume';
+import {Matrix4} from '@math.gl/core';
+import {OrientedBoundingBox} from '@math.gl/culling';
+import {areNumberArraysEqual} from '../../test-utils/compareArrays';
+
+test('Tiles bounding-volume#createBoundingVolume - should convert region to obb', (t) => {
+  const result = createBoundingVolume(
+    {
+      region: [
+        0.7853981633974483, 0.22689280275926285, 0.8028514559173916, 0.24434609527920614,
+        -17.29296875, 2493.5625
+      ]
+    },
+    new Matrix4()
+  );
+  t.ok(result instanceof OrientedBoundingBox);
+  t.ok(
+    areNumberArraysEqual(result.center, [4348195.679745842, 4424932.075472673, 1479471.892147189])
+  );
+  t.ok(
+    areNumberArraysEqual(
+      result.halfAxes,
+      // prettier-ignore
+      [
+        -38691.151309899986, 37690.50114047807, -2.3283064365386963e-10, 
+        -9209.347353689373, -9371.872726273723, 53695.496290528914, 
+        1176.6872740909457, 1197.4532991172746, 403.06533637456596
+      ]
+    )
+  );
+  t.end();
+});


### PR DESCRIPTION
We need it in the tile-converter but I decided to use it widely in tiles.
I think, region is better fit to obb then mbs.
Before (region converted to mbs converted to obb):
![image](https://github.com/visgl/loaders.gl/assets/18549629/4f713ab6-4cbc-4353-81b6-54357adbe6bf)
After:
![image](https://github.com/visgl/loaders.gl/assets/18549629/2791cee7-2735-4352-9efa-b602d5d4cd93)
