### PR TITLE
fix(tiles): cartographicToCartesan syntax

### DIFF
--- a/modules/tiles/src/tileset/helpers/zoom.ts
+++ b/modules/tiles/src/tileset/helpers/zoom.ts
@@ -71,14 +71,14 @@ export function getZoomFromFullExtent(
   cartorgraphicCenter: Vector3,
   cartesianCenter: Vector3
 ) {
-  const extentVertex = Ellipsoid.WGS84.cartographicToCartesian(
+  Ellipsoid.WGS84.cartographicToCartesian(
     [fullExtent.xmax, fullExtent.ymax, fullExtent.zmax],
-    new Vector3()
+    scratchVector
   );
   const extentSize = Math.sqrt(
-    Math.pow(extentVertex[0] - cartesianCenter[0], 2) +
-      Math.pow(extentVertex[1] - cartesianCenter[1], 2) +
-      Math.pow(extentVertex[2] - cartesianCenter[2], 2)
+    Math.pow(scratchVector[0] - cartesianCenter[0], 2) +
+      Math.pow(scratchVector[1] - cartesianCenter[1], 2) +
+      Math.pow(scratchVector[2] - cartesianCenter[2], 2)
   );
   return Math.log2(WGS84_RADIUS_Z / (extentSize + cartorgraphicCenter[2]));
 }

--- a/modules/tiles/src/tileset/tileset-3d.ts
+++ b/modules/tiles/src/tileset/tileset-3d.ts
@@ -604,10 +604,8 @@ export class Tileset3D {
         ymin + (ymax - ymin) / 2,
         zmin + (zmax - zmin) / 2
       );
-      this.cartesianCenter = Ellipsoid.WGS84.cartographicToCartesian(
-        this.cartographicCenter,
-        new Vector3()
-      );
+      this.cartesianCenter = new Vector3();
+      Ellipsoid.WGS84.cartographicToCartesian(this.cartographicCenter, this.cartesianCenter);
       this.zoom = getZoomFromFullExtent(fullExtent, this.cartographicCenter, this.cartesianCenter);
       return;
     }
@@ -616,10 +614,8 @@ export class Tileset3D {
     if (extent) {
       const [xmin, ymin, xmax, ymax] = extent;
       this.cartographicCenter = new Vector3(xmin + (xmax - xmin) / 2, ymin + (ymax - ymin) / 2, 0);
-      this.cartesianCenter = Ellipsoid.WGS84.cartographicToCartesian(
-        this.cartographicCenter,
-        new Vector3()
-      );
+      this.cartesianCenter = new Vector3();
+      Ellipsoid.WGS84.cartographicToCartesian(this.cartographicCenter, this.cartesianCenter);
       this.zoom = getZoomFromExtent(extent, this.cartographicCenter, this.cartesianCenter);
       return;
     }
@@ -650,7 +646,8 @@ export class Tileset3D {
 
     // cartographic coordinates are undefined at the center of the ellipsoid
     if (center[0] !== 0 || center[1] !== 0 || center[2] !== 0) {
-      this.cartographicCenter = Ellipsoid.WGS84.cartesianToCartographic(center, new Vector3());
+      this.cartographicCenter = new Vector3();
+      Ellipsoid.WGS84.cartesianToCartographic(center, this.cartographicCenter);
     } else {
       this.cartographicCenter = new Vector3(0, 0, -Ellipsoid.WGS84.radii[0]);
     }


### PR DESCRIPTION
replace
```
const x = Ellipsoid.WGS84.cartographicToCartesian(y, new Vector3());
```
with
```
const x = new Vector3();
Ellipsoid.WGS84.cartographicToCartesian(y, x)
```
Existing syntax fails in JEST tests environment in "I3S Explorer". It uses es5 transpiled code and `cartographicToCartesian` returns `undefined`. The issue occured from NodeJS 16. NodeJS 14 is ok.