### PR TITLE
fix(i3s): handle search params in I3SLoader

### DIFF
--- a/modules/i3s/src/i3s-loader.ts
+++ b/modules/i3s/src/i3s-loader.ts
@@ -5,6 +5,7 @@ import {I3SContentLoader} from './i3s-content-loader';
 import {normalizeTileData, normalizeTilesetData} from './lib/parsers/parse-i3s';
 import {COORDINATE_SYSTEM} from './lib/parsers/constants';
 import {I3SParseOptions} from './types';
+import {getUrlWithoutParams} from './lib/utils/url-utils';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
@@ -58,8 +59,7 @@ async function parseI3S(data, options: I3SLoaderOptions = {}, context): Promise<
     throw new Error('Files with .slpk extention currently are not supported by I3SLoader');
   }
 
-  const urlObj = new URL(url);
-  const urlWithoutParams = `${urlObj.origin}${urlObj.pathname}`;
+  const urlWithoutParams = getUrlWithoutParams(url);
 
   // auto detect file type based on url
   let isTileset;

--- a/modules/i3s/src/i3s-loader.ts
+++ b/modules/i3s/src/i3s-loader.ts
@@ -58,17 +58,20 @@ async function parseI3S(data, options: I3SLoaderOptions = {}, context): Promise<
     throw new Error('Files with .slpk extention currently are not supported by I3SLoader');
   }
 
+  const urlObj = new URL(url);
+  const urlWithoutParams = `${urlObj.origin}${urlObj.pathname}`;
+
   // auto detect file type based on url
   let isTileset;
   if (options.i3s.isTileset === 'auto') {
-    isTileset = TILESET_REGEX.test(url);
+    isTileset = TILESET_REGEX.test(urlWithoutParams);
   } else {
     isTileset = options.i3s.isTileset;
   }
 
   let isTileHeader;
   if (options.isTileHeader === 'auto') {
-    isTileHeader = TILE_HEADER_REGEX.test(url);
+    isTileHeader = TILE_HEADER_REGEX.test(urlWithoutParams);
   } else {
     isTileHeader = options.i3s.isTileHeader;
   }

--- a/modules/i3s/src/lib/parsers/parse-i3s.ts
+++ b/modules/i3s/src/lib/parsers/parse-i3s.ts
@@ -84,7 +84,8 @@ export function normalizeTileNonUrlData(tile : I3SMinimalNodeData): I3STileHeade
 }
 
 export async function normalizeTilesetData(tileset : SceneLayer3D, options : LoaderOptions, context: LoaderContext): Promise<I3STileHeader | I3STilesetHeader> {
-  const url = context.url;
+  const urlObj = new URL(context.url || '');
+  const url = `${urlObj.origin}${urlObj.pathname}`;
   let nodePagesTile: I3SNodePagesTiles | undefined;
   let root: I3STileHeader | I3STilesetHeader;
   if (tileset.nodePages) {

--- a/modules/i3s/src/lib/parsers/parse-i3s.ts
+++ b/modules/i3s/src/lib/parsers/parse-i3s.ts
@@ -3,7 +3,7 @@ import {Ellipsoid} from '@math.gl/geospatial';
 import {load} from '@loaders.gl/core';
 import {TILE_TYPE, TILE_REFINEMENT, TILESET_TYPE} from '@loaders.gl/tiles';
 import I3SNodePagesTiles from '../helpers/i3s-nodepages-tiles';
-import {generateTileAttributeUrls, getUrlWithToken} from '../utils/url-utils';
+import {generateTileAttributeUrls, getUrlWithToken, getUrlWithoutParams} from '../utils/url-utils';
 import {
   I3STilesetHeader,
   I3STileHeader,
@@ -84,8 +84,7 @@ export function normalizeTileNonUrlData(tile : I3SMinimalNodeData): I3STileHeade
 }
 
 export async function normalizeTilesetData(tileset : SceneLayer3D, options : LoaderOptions, context: LoaderContext): Promise<I3STileHeader | I3STilesetHeader> {
-  const urlObj = new URL(context.url || '');
-  const url = `${urlObj.origin}${urlObj.pathname}`;
+  const url = getUrlWithoutParams(context.url || '');
   let nodePagesTile: I3SNodePagesTiles | undefined;
   let root: I3STileHeader | I3STilesetHeader;
   if (tileset.nodePages) {

--- a/modules/i3s/src/lib/utils/url-utils.ts
+++ b/modules/i3s/src/lib/utils/url-utils.ts
@@ -1,6 +1,23 @@
 import {Node3DIndexDocument, SceneLayer3D} from '../../types';
 
 /**
+ * Return URL seperated from search params
+ * @param url - URL that might have search params
+ * @returns url without search params
+ */
+export function getUrlWithoutParams(url: string): string {
+  let urlWithoutParams;
+
+  try {
+    const urlObj = new URL(url);
+    urlWithoutParams = `${urlObj.origin}${urlObj.pathname}`;
+  } catch (e) {
+    // do nothing
+  }
+  return urlWithoutParams || url;
+}
+
+/**
  * Generates url with token if it is exists.
  * @param url
  * @param token

--- a/modules/i3s/test/lib/parsers/url-utils.spec.ts
+++ b/modules/i3s/test/lib/parsers/url-utils.spec.ts
@@ -5,6 +5,16 @@ import {
   generateTilesetAttributeUrls
   // @ts-expect-error
 } from '@loaders.gl/i3s/lib/utils/url-utils';
+import {getUrlWithoutParams} from '../../../src/lib/utils/url-utils';
+
+test('i3s-utils#getUrlWithoutParams', async (t) => {
+  const url = getUrlWithoutParams('http://a.b.c/x/y/z?token=efk');
+  t.equal(url, 'http://a.b.c/x/y/z');
+
+  const url2 = getUrlWithoutParams('@loaders.gl/core/test/data/url');
+  t.equal(url2, '@loaders.gl/core/test/data/url');
+  t.end();
+});
 
 test('i3s-utils#getUrlWithToken Should return URL without token if token null', async (t) => {
   const url = getUrlWithToken('test', null);


### PR DESCRIPTION
It is a regression fix. I3S datasets don't work with ArgGIS token.