### PR TITLE
fix(tile-converter): fixed empty response error

### DIFF
--- a/modules/tile-converter/src/i3s-server/routes/slpk-router.ts
+++ b/modules/tile-converter/src/i3s-server/routes/slpk-router.ts
@@ -2,11 +2,13 @@ import express from 'express';
 import {getFileByUrl} from '../controllers/slpk-controller';
 import {createSceneServer} from '../utils/create-scene-server';
 
+const textDecoder = new TextDecoder();
+
 export const sceneServerRouter = express.Router();
 sceneServerRouter.get('*', async function (req, res, next) {
   const file = await getFileByUrl('/');
   if (file) {
-    const layer = JSON.parse(file.toString());
+    const layer = JSON.parse(textDecoder.decode(file));
     const sceneServerResponse = createSceneServer(layer.name, layer);
     res.send(sceneServerResponse);
   } else {
@@ -17,10 +19,9 @@ sceneServerRouter.get('*', async function (req, res, next) {
 
 export const router = express.Router();
 router.get('*', async function (req, res, next) {
-  console.log(req.path);
   const file = await getFileByUrl(req.path);
   if (file) {
-    res.send(file);
+    res.send(Buffer.from(file));
   } else {
     res.status(404);
     res.send('File not found');


### PR DESCRIPTION
I faced with a problem, that browser receives `{}` for file requests, although data passed to `res.send()` contains the requested file. So there's the fix, it looks like .toString() stopped working correctly for `ArrayBuffer` or some other its implementation