### PR TITLE
Update 3D Tiles Docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ If you consider opening a PR, here is some documentation to get you started:
 
 To contribute, you will likely want to clone the loaders.gl repository and start by making sure you can install, build and run tests.
 
-See the [developer guide](https://loaders.gl/docs/dev-env) on the loaders.gl website for more information on how to get your environment set up for loaders.gl development, including for Linux and Windows.
+See the [developer guide](https://loaders.gl/docs/developer-guide/dev-env) on the loaders.gl website for more information on how to get your environment set up for loaders.gl development, including for Linux and Windows.
 
 ## Community Governance
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ loaders.gl is extensively documented on the [loaders.gl](https://loaders.gl) web
 
 ## Contributing 
 
-See [CONTRIBUTING.md].
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@
 
 loaders.gl is extensively documented on the [loaders.gl](https://loaders.gl) website.
 
+## Contributing 
+
+See [CONTRIBUTING.md].
+
 ## License
 
 loaders.gl is licensed under a permissive open source license, using an MIT umbrella license.

--- a/docs/modules/3d-tiles/README.md
+++ b/docs/modules/3d-tiles/README.md
@@ -52,7 +52,7 @@ const tileset3d = new Tileset3D(tilesetJson, {
 tileset3d.update(viewport);
 
 // Viewport changes (pan zoom etc)
-tileset3d.update(viewport);
+tileset3d.selectTiles(viewport);
 
 // Visible tiles
 const visibleTiles = tileset3d.tiles.filter((tile) => tile.selected);

--- a/docs/modules/3d-tiles/api-reference/cesium-ion-loader.md
+++ b/docs/modules/3d-tiles/api-reference/cesium-ion-loader.md
@@ -31,7 +31,7 @@ const tilesetJson = await load(tilesetUrl, CesiumIonLoader, {
 });
 
 const viewport = new WebMercatorViewport({latitude, longitude, zoom});
-tileset3d.update(viewport);
+tileset3d.selectTiles(viewport);
 
 // visible tiles
 const visibleTiles = tileset3d.tiles.filter((tile) => tile.selected);

--- a/docs/modules/3d-tiles/api-reference/tiles-3d-loader.md
+++ b/docs/modules/3d-tiles/api-reference/tiles-3d-loader.md
@@ -59,13 +59,24 @@ const tileset3d = new Tileset3D(tilesetJson, {
   onTileLoad: tile => console.log(tile)
 });
 
-const viewport = new WebMercatorViewport({latitude, longitude, zoom, ...});
-tileset3d.update(viewport);
+const viewport = new WebMercatorViewport({
+  width: 600,
+  height: 400,
+  latitude: 40.7067584, 
+  longitude: -74.0115413, 
+  zoom: 17
+});
+tileset3d.selectTiles(viewport);
 
 // visible tiles
 const visibleTiles = tileset3d.tiles.filter(tile => tile.selected);
 // Note that visibleTiles will likely not immediately include all tiles
 // tiles will keep loading and file `onTileLoad` callbacks
+
+// To fully load a tileset, repeatedly select tiles until the tileset is loaded
+while (!tileset3d.isLoaded()) {
+  await tileset3d.selectTiles(viewport);
+}
 ```
 
 ## Options

--- a/docs/modules/3d-tiles/api-reference/tiles-3d-loader.md
+++ b/docs/modules/3d-tiles/api-reference/tiles-3d-loader.md
@@ -56,6 +56,7 @@ const tilesetJson = await load(tilesetUrl, Tiles3DLoader);
 const tilesetJson = await load(tilesetUrl, Tiles3DLoader, {'3d-tiles': {isTileset: true}});
 
 const tileset3d = new Tileset3D(tilesetJson, {
+  throttleRequests: false,
   onTileLoad: tile => console.log(tile)
 });
 
@@ -73,7 +74,7 @@ const visibleTiles = tileset3d.tiles.filter(tile => tile.selected);
 // Note that visibleTiles will likely not immediately include all tiles
 // tiles will keep loading and file `onTileLoad` callbacks
 
-// To fully load a tileset, repeatedly select tiles until the tileset is loaded
+// To fully load all tiles in a given view, repeatedly select tiles until the tileset is loaded
 while (!tileset3d.isLoaded()) {
   await tileset3d.selectTiles(viewport);
 }

--- a/docs/modules/i3s/api-reference/i3s-loader.md
+++ b/docs/modules/i3s/api-reference/i3s-loader.md
@@ -178,7 +178,7 @@ const viewport = new WebMercatorViewport({latitude, longitude, zoom, ...})
 tileset3d.update(viewport);
 
 // Viewport changes (pan zoom etc)
-tileset3d.update(viewport);
+tileset3d.selectTiles(viewport);
 
 // Visible tiles
 const visibleTiles = tileset3d.tiles.filter(tile => tile.selected);

--- a/docs/modules/tiles/api-reference/tileset-3d.md
+++ b/docs/modules/tiles/api-reference/tileset-3d.md
@@ -169,13 +169,13 @@ See the [properties schema reference](https://github.com/AnalyticalGraphicsInc/3
 
 ### maximumScreenSpaceError : Number
 
-The maximum screen space error used to drive level of detail refinement. This value helps determine when a tile refines to its descendants, and therefore plays a major role in balancing performance with visual quality.
+Threshold that controls the level of detail of loaded tiles. A higher value means tile traversal stops early, displaying lower quality tiles (but much faster load times & less bandwidth used), because we're using a high "error tolerance". A lower value means lower tolerance for error, so traversal goes deeper in the tree and displays higher quality tiles. 
 
 A tile's screen space error is roughly equivalent to the number of pixels wide that would be drawn if a sphere with a
 radius equal to the tile's <b>geometric error</b> were rendered at the tile's position. If this value exceeds
 `maximumScreenSpaceError` the tile refines to its descendants.
 
-Depending on the tileset, `maximumScreenSpaceError` may need to be tweaked to achieve the right balance. Higher values provide better performance but lower visual quality. \*
+Depending on the tileset, `maximumScreenSpaceError` may need to be tweaked to achieve the right balance between performance with visual quality. \*
 
 ### maximumMemoryUsage : Number
 

--- a/modules/3d-tiles/wip/tileset-3d-full.md
+++ b/modules/3d-tiles/wip/tileset-3d-full.md
@@ -71,15 +71,13 @@ The base path that non-absolute paths in tileset JSON file are relative to.
 
 ### maximumScreenSpaceError
 
-The maximum screen space error used to drive level of detail refinement. This value helps determine when a tile refines to its descendants, and therefore plays a major role in balancing performance with visual quality.
-
+Threshold that controls the level of detail of loaded tiles. A higher value means tile traversal stops early, displaying lower quality tiles (but much faster load times & less bandwidth used), because we're using a high "error tolerance". A lower value means lower tolerance for error, so traversal goes deeper in the tree and displays higher quality tiles. 
 
 A tile's screen space error is roughly equivalent to the number of pixels wide that would be drawn if a sphere with a
 radius equal to the tile's <b>geometric error</b> were rendered at the tile's position. If this value exceeds
 `maximumScreenSpaceError` the tile refines to its descendants.
 
-Depending on the tileset, `maximumScreenSpaceError` may need to be tweaked to achieve the right balance. Higher values provide better performance but lower visual quality.
- *
+Depending on the tileset, `maximumScreenSpaceError` may need to be tweaked to achieve the right balance between performance with visual quality.
 
 ### maximumMemoryUsage : Number
 

--- a/modules/tiles/src/tileset/tile-3d.ts
+++ b/modules/tiles/src/tileset/tile-3d.ts
@@ -161,6 +161,8 @@ export class Tile3D {
     this.type = header.type;
     this.contentUrl = header.contentUrl;
 
+    this.traverser.options.maximumScreenSpaceError = tileset.options.maximumScreenSpaceError;
+
     this._initializeLodMetric(header);
     this._initializeTransforms(header);
     this._initializeBoundingVolumes(header);

--- a/modules/tiles/src/tileset/tile-3d.ts
+++ b/modules/tiles/src/tileset/tile-3d.ts
@@ -161,8 +161,6 @@ export class Tile3D {
     this.type = header.type;
     this.contentUrl = header.contentUrl;
 
-    this.traverser.options.maximumScreenSpaceError = tileset.options?.maximumScreenSpaceError;
-
     this._initializeLodMetric(header);
     this._initializeTransforms(header);
     this._initializeBoundingVolumes(header);

--- a/modules/tiles/src/tileset/tile-3d.ts
+++ b/modules/tiles/src/tileset/tile-3d.ts
@@ -161,7 +161,7 @@ export class Tile3D {
     this.type = header.type;
     this.contentUrl = header.contentUrl;
 
-    this.traverser.options.maximumScreenSpaceError = tileset.options.maximumScreenSpaceError;
+    this.traverser.options.maximumScreenSpaceError = tileset.options?.maximumScreenSpaceError;
 
     this._initializeLodMetric(header);
     this._initializeTransforms(header);


### PR DESCRIPTION
This is a follow up from https://github.com/visgl/loaders.gl/pull/2679 (had some issues with git rebasing there and the PR got automatically closed somehow..)

This PR updates the documentation to (1) better explain how to use `maximumScreenSpaceError` (2) how to correctly load a 3D Tileset for a given view using Loaders.gl, specifically to support 3D Tilesets that have external tilesets, like the Google Photorealistic 3D Tiles.

@justinmanley after a lot of investigating I believe I have answers to all the questions we had in the original PR:

* You are correct in that `maximumScreenSpaceError` is already being passed correctly, and my fix is not necessary. My confusion came from setting SSE to 16 was still loading tiles down to 8. But I think this is due to the structure of the 3D Tileset itself (there's a tile with error 32, and its children end up being 8, so that's the earliest it can stop). 
* However, on the issue of whether a single `selectTiles` call is sufficient to fully load a given view, the answer is no. If you check the 3D Tiles example in deckgl (https://github.com/visgl/deck.gl/blob/master/examples/website/3d-tiles/app.jsx) with a tileset that has external tilesets (https://github.com/visgl/loaders.gl/tree/master/modules/3d-tiles/test/data/Tilesets/TilesetOfTilesets) you'll see it takes multiple selectTiles calls to fully load the view. This is already what DeckGL is doing under the hood!

You can also see this in the source code of [tile-3d-layer]( https://github.com/visgl/deck.gl/blob/master/modules/geo-layers/src/tile-3d-layer/tile-3d-layer.ts.disabled) where it calls `_updateTileset` on every tile load, to repeatedly update the tileset until the view is fully loaded.

So it makes sense that the documentation should provide a code example telling you to repeatedly call `selectTiles()` until the view is fully loaded. If only 1 selectTiles call is needed, then the code will exit after that one call, so there's no harm in this pattern.