### PR TITLE
fix(arrow): fix get map bound from geoarrow samples

### DIFF
--- a/modules/arrow/src/geoarrow/convert-geoarrow-to-binary-geometry.ts
+++ b/modules/arrow/src/geoarrow/convert-geoarrow-to-binary-geometry.ts
@@ -50,7 +50,7 @@ export function getBinaryGeometriesFromArrow(
   };
 
   const chunks = geoColumn.data;
-  const bounds: [number, number, number, number] = [Infinity, Infinity, -Infinity, -Infinity];
+  let bounds: [number, number, number, number] = [Infinity, Infinity, -Infinity, -Infinity];
   let globalFeatureIdOffset = 0;
   const binaryGeometries: BinaryFeatures[] = [];
 
@@ -114,7 +114,7 @@ export function getBinaryGeometriesFromArrow(
       }
     });
 
-    updateBoundsFromGeoArrowSamples(flatCoordinateArray, nDim, bounds);
+    bounds = updateBoundsFromGeoArrowSamples(flatCoordinateArray, nDim, bounds);
   }
 
   return {binaryGeometries, bounds, featureTypes};

--- a/modules/arrow/src/geoarrow/get-arrow-bounds.ts
+++ b/modules/arrow/src/geoarrow/get-arrow-bounds.ts
@@ -23,7 +23,7 @@ export function updateBoundsFromGeoArrowSamples(
   for (let i = 0; i < numberOfFeatures; i += sampleStep) {
     const lng = flatCoords[i * nDim];
     const lat = flatCoords[i * nDim + 1];
-    if (lng < bounds[0]) {
+    if (lng < newBounds[0]) {
       newBounds[0] = lng;
     }
     if (lat < newBounds[1]) {
@@ -36,6 +36,5 @@ export function updateBoundsFromGeoArrowSamples(
       newBounds[3] = lat;
     }
   }
-
   return newBounds;
 }

--- a/modules/arrow/src/index.ts
+++ b/modules/arrow/src/index.ts
@@ -68,3 +68,5 @@ export type {BinaryDataFromGeoArrow} from './geoarrow/convert-geoarrow-to-binary
 export {getBinaryGeometriesFromArrow} from './geoarrow/convert-geoarrow-to-binary-geometry';
 
 export {parseGeometryFromArrow} from './geoarrow/convert-geoarrow-to-geojson';
+
+export {updateBoundsFromGeoArrowSamples} from './geoarrow/get-arrow-bounds';

--- a/modules/arrow/test/geoarrow/get-arrow-bounds.spec.ts
+++ b/modules/arrow/test/geoarrow/get-arrow-bounds.spec.ts
@@ -1,0 +1,57 @@
+import test from 'tape-promise/tape';
+
+import {updateBoundsFromGeoArrowSamples} from '@loaders.gl/arrow';
+
+test('ArrowUtils#updateBoundsFromGeoArrowSamples', (t) => {
+  const testCases = [
+    {
+      coords: [0, 0, 1, 1, 2, 2],
+      nDim: 2,
+      bound: [0, 0, 2, 2],
+      boundSample2: [0, 0, 2, 2]
+    },
+    {
+      coords: [0, 0, 1, 1, 2, 2, 4, 4, 5, 5, 6, 6],
+      nDim: 2,
+      bound: [0, 0, 6, 6],
+      boundSample2: [0, 0, 4, 4]
+    },
+    {
+      coords: [0, 0, 0, 1, 1, 1, 2, 2, 2],
+      nDim: 3,
+      bound: [0, 0, 2, 2],
+      boundSample2: [0, 0, 2, 2]
+    },
+    {
+      coords: [0, 0, 0, 1, 1, 1, 2, 2, 2, 4, 4, 4, 5, 5, 5, 6, 6, 6],
+      nDim: 3,
+      bound: [0, 0, 6, 6],
+      boundSample2: [0, 0, 4, 4]
+    }
+  ];
+
+  testCases.forEach((testCase) => {
+    const initBound: [number, number, number, number] = [Infinity, Infinity, -Infinity, -Infinity];
+
+    const updatedBound = updateBoundsFromGeoArrowSamples(
+      new Float64Array(testCase.coords),
+      testCase.nDim,
+      initBound
+    );
+    t.deepEqual(updatedBound, testCase.bound, 'bounds updated correctly');
+
+    const sampleSize = 2;
+    const updateBoundWith2Samples = updateBoundsFromGeoArrowSamples(
+      new Float64Array(testCase.coords),
+      testCase.nDim,
+      initBound,
+      sampleSize
+    );
+    t.deepEqual(
+      updateBoundWith2Samples,
+      testCase.boundSample2,
+      'bounds updated correctly with 2 samples'
+    );
+  });
+  t.end();
+});

--- a/modules/arrow/test/index.ts
+++ b/modules/arrow/test/index.ts
@@ -6,3 +6,4 @@ import './arrow-writer.spec';
 
 // import './convert-geoarrow-to-binary-geometry.spec';
 import './geoarrow/convert-geoarrow-to-geojson.spec';
+import './geoarrow/get-arrow-bounds.spec';


### PR DESCRIPTION
- Fix a small bug that map bound is not computed correctly from GeoArrow samples. 
- Add test cases for `updateBoundsFromGeoArrowSamples()`