### PR TITLE
chore: Adopt namespace style imports for apache-arrow

### DIFF
--- a/modules/arrow/src/geoarrow/convert-geoarrow-to-binary-geometry.ts
+++ b/modules/arrow/src/geoarrow/convert-geoarrow-to-binary-geometry.ts
@@ -1,7 +1,7 @@
 // loaders.gl, MIT license
 // Copyright (c) vis.gl contributors
 
-import {Data, Vector} from 'apache-arrow';
+import * as arrow from 'apache-arrow';
 import {BinaryFeatureCollection as BinaryFeatures} from '@loaders.gl/schema';
 import {GeoArrowEncoding} from '@loaders.gl/gis';
 import {updateBoundsFromGeoArrowSamples} from './get-arrow-bounds';
@@ -40,7 +40,7 @@ const BINARY_GEOMETRY_TEMPLATE = {
  * @returns BinaryDataFromGeoArrow
  */
 export function getBinaryGeometriesFromArrow(
-  geoColumn: Vector,
+  geoColumn: arrow.Vector,
   geoEncoding: GeoArrowEncoding
 ): BinaryDataFromGeoArrow {
   const featureTypes = {
@@ -127,7 +127,7 @@ export function getBinaryGeometriesFromArrow(
  * @returns BinaryGeometryContent
  */
 function getBinaryGeometriesFromChunk(
-  chunk: Data,
+  chunk: arrow.Data,
   geoEncoding: GeoArrowEncoding
 ): BinaryGeometryContent {
   switch (geoEncoding) {
@@ -151,7 +151,7 @@ function getBinaryGeometriesFromChunk(
  * @param geoEncoding the geo encoding of the geoarrow polygon column
  * @returns BinaryGeometryContent
  */
-function getBinaryPolygonsFromChunk(chunk: Data, geoEncoding: string): BinaryGeometryContent {
+function getBinaryPolygonsFromChunk(chunk: arrow.Data, geoEncoding: string): BinaryGeometryContent {
   const isMultiPolygon = geoEncoding === 'geoarrow.multipolygon';
 
   const polygonData = isMultiPolygon ? chunk.children[0] : chunk;
@@ -193,7 +193,7 @@ function getBinaryPolygonsFromChunk(chunk: Data, geoEncoding: string): BinaryGeo
  * @param geoEncoding the geo encoding of the geoarrow column
  * @returns BinaryGeometryContent
  */
-function getBinaryLinesFromChunk(chunk: Data, geoEncoding: string): BinaryGeometryContent {
+function getBinaryLinesFromChunk(chunk: arrow.Data, geoEncoding: string): BinaryGeometryContent {
   const isMultiLineString = geoEncoding === 'geoarrow.multilinestring';
 
   const lineData = isMultiLineString ? chunk.children[0] : chunk;
@@ -232,7 +232,7 @@ function getBinaryLinesFromChunk(chunk: Data, geoEncoding: string): BinaryGeomet
  * @param geoEncoding  geo encoding of the geoarrow column
  * @returns BinaryGeometryContent
  */
-function getBinaryPointsFromChunk(chunk: Data, geoEncoding: string): BinaryGeometryContent {
+function getBinaryPointsFromChunk(chunk: arrow.Data, geoEncoding: string): BinaryGeometryContent {
   const isMultiPoint = geoEncoding === 'geoarrow.multipoint';
 
   const pointData = isMultiPoint ? chunk.children[0] : chunk;

--- a/modules/arrow/src/geoarrow/convert-geoarrow-to-geojson.ts
+++ b/modules/arrow/src/geoarrow/convert-geoarrow-to-geojson.ts
@@ -1,7 +1,7 @@
 // loaders.gl, MIT license
 // Copyright (c) vis.gl contributors
 
-import {Vector} from 'apache-arrow';
+import * as arrow from 'apache-arrow';
 import {
   Feature,
   MultiPolygon,
@@ -71,7 +71,7 @@ export function parseGeometryFromArrow(rawData: RawArrowFeature): Feature | null
 /**
  * convert Arrow MultiPolygon to geojson Feature
  */
-function arrowMultiPolygonToFeature(arrowMultiPolygon: Vector): MultiPolygon {
+function arrowMultiPolygonToFeature(arrowMultiPolygon: arrow.Vector): MultiPolygon {
   const multiPolygon: Position[][][] = [];
   for (let m = 0; m < arrowMultiPolygon.length; m++) {
     const arrowPolygon = arrowMultiPolygon.get(m);
@@ -98,7 +98,7 @@ function arrowMultiPolygonToFeature(arrowMultiPolygon: Vector): MultiPolygon {
 /**
  * convert Arrow Polygon to geojson Feature
  */
-function arrowPolygonToFeature(arrowPolygon: Vector): Polygon {
+function arrowPolygonToFeature(arrowPolygon: arrow.Vector): Polygon {
   const polygon: Position[][] = [];
   for (let i = 0; arrowPolygon && i < arrowPolygon.length; i++) {
     const arrowRing = arrowPolygon.get(i);
@@ -120,7 +120,7 @@ function arrowPolygonToFeature(arrowPolygon: Vector): Polygon {
 /**
  * convert Arrow MultiPoint to geojson MultiPoint
  */
-function arrowMultiPointToFeature(arrowMultiPoint: Vector): MultiPoint {
+function arrowMultiPointToFeature(arrowMultiPoint: arrow.Vector): MultiPoint {
   const multiPoint: Position[] = [];
   for (let i = 0; arrowMultiPoint && i < arrowMultiPoint.length; i++) {
     const arrowPoint = arrowMultiPoint.get(i);
@@ -139,7 +139,7 @@ function arrowMultiPointToFeature(arrowMultiPoint: Vector): MultiPoint {
 /**
  * convert Arrow Point to geojson Point
  */
-function arrowPointToFeature(arrowPoint: Vector): Point {
+function arrowPointToFeature(arrowPoint: arrow.Vector): Point {
   const point: Position = Array.from(arrowPoint);
   const geometry: Point = {
     type: 'Point',
@@ -151,7 +151,7 @@ function arrowPointToFeature(arrowPoint: Vector): Point {
 /**
  * convert Arrow MultiLineString to geojson MultiLineString
  */
-function arrowMultiLineStringToFeature(arrowMultiLineString: Vector): MultiLineString {
+function arrowMultiLineStringToFeature(arrowMultiLineString: arrow.Vector): MultiLineString {
   const multiLineString: Position[][] = [];
   for (let i = 0; arrowMultiLineString && i < arrowMultiLineString.length; i++) {
     const arrowLineString = arrowMultiLineString.get(i);
@@ -175,7 +175,7 @@ function arrowMultiLineStringToFeature(arrowMultiLineString: Vector): MultiLineS
 /**
  * convert Arrow LineString to geojson LineString
  */
-function arrowLineStringToFeature(arrowLineString: Vector): LineString {
+function arrowLineStringToFeature(arrowLineString: arrow.Vector): LineString {
   const lineString: Position[] = [];
   for (let i = 0; arrowLineString && i < arrowLineString.length; i++) {
     const arrowCoord = arrowLineString.get(i);

--- a/modules/arrow/src/lib/arrow-table.ts
+++ b/modules/arrow/src/lib/arrow-table.ts
@@ -2,7 +2,7 @@
 // Copyright (c) vis.gl contributors
 
 import type {Batch, Schema} from '@loaders.gl/schema';
-import type {Table as ApacheArrowTable} from 'apache-arrow';
+import type * as arrow from 'apache-arrow';
 
 /**
  * A table organized as an Apache Arrow table
@@ -11,7 +11,7 @@ import type {Table as ApacheArrowTable} from 'apache-arrow';
 export type ArrowTable = {
   shape: 'arrow-table';
   schema?: Schema;
-  data: ApacheArrowTable;
+  data: arrow.Table;
 };
 
 /**
@@ -22,6 +22,6 @@ export type ArrowTableBatch = Batch & {
   shape: 'arrow-table';
   schemaType?: 'explicit' | 'deduced';
   schema?: Schema;
-  data: ApacheArrowTable; // ApacheRecordBatch;
+  data: arrow.Table; // ApacheRecordBatch;
   length: number;
 };

--- a/modules/arrow/src/lib/encode-arrow.ts
+++ b/modules/arrow/src/lib/encode-arrow.ts
@@ -1,4 +1,4 @@
-import {Table, Vector, tableToIPC, vectorFromArray} from 'apache-arrow';
+import * as arrow from 'apache-arrow';
 import {AnyArrayType, VECTOR_TYPES} from '../types';
 
 export type ColumnarTable = {
@@ -15,28 +15,28 @@ export type ColumnarTable = {
  * @returns - encoded ArrayBuffer
  */
 export function encodeArrowSync(data: ColumnarTable): ArrayBuffer {
-  const vectors: Record<string, Vector> = {};
+  const vectors: Record<string, arrow.Vector> = {};
   for (const arrayData of data) {
     const arrayVector = createVector(arrayData.array, arrayData.type);
     vectors[arrayData.name] = arrayVector;
   }
-  const table = new Table(vectors);
-  const arrowBuffer = tableToIPC(table);
+  const table = new arrow.Table(vectors);
+  const arrowBuffer = arrow.tableToIPC(table);
   return arrowBuffer;
 }
 
 /**
- * Create Arrow Vector from given data and vector type
+ * Create Arrow arrow.Vector from given data and vector type
  * @param array {import('../types').AnyArrayType} - columns data
  * @param type {number} - the writer options
  * @return a vector of one of vector's types defined in the Apache Arrow library
  */
-function createVector(array, type): Vector {
+function createVector(array, type): arrow.Vector {
   switch (type) {
     case VECTOR_TYPES.DATE:
-      return vectorFromArray(array);
+      return arrow.vectorFromArray(array);
     case VECTOR_TYPES.FLOAT:
     default:
-      return vectorFromArray(array);
+      return arrow.vectorFromArray(array);
   }
 }

--- a/modules/arrow/src/lib/parse-arrow-in-batches.ts
+++ b/modules/arrow/src/lib/parse-arrow-in-batches.ts
@@ -1,6 +1,6 @@
 // TODO - this import defeats the sophisticated typescript checking in ArrowJS
 import type {ArrowTableBatch} from './arrow-table';
-import {RecordBatchReader, Table as ApacheArrowTable} from 'apache-arrow';
+import * as arrow from 'apache-arrow';
 // import {isIterable} from '@loaders.gl/core';
 
 /**
@@ -8,7 +8,7 @@ import {RecordBatchReader, Table as ApacheArrowTable} from 'apache-arrow';
 export function parseArrowInBatches(
   asyncIterator: AsyncIterable<ArrayBuffer> | Iterable<ArrayBuffer>
 ): AsyncIterable<ArrowTableBatch> {
-  // Creates the appropriate RecordBatchReader subclasses from the input
+  // Creates the appropriate arrow.RecordBatchReader subclasses from the input
   // This will also close the underlying source in case of early termination or errors
 
   // As an optimization, return a non-async iterator
@@ -28,13 +28,13 @@ export function parseArrowInBatches(
 
   async function* makeArrowAsyncIterator(): AsyncIterator<ArrowTableBatch> {
     // @ts-ignore
-    const readers = RecordBatchReader.readAll(asyncIterator);
+    const readers = arrow.RecordBatchReader.readAll(asyncIterator);
     for await (const reader of readers) {
       for await (const recordBatch of reader) {
         const arrowTabledBatch: ArrowTableBatch = {
           shape: 'arrow-table',
           batchType: 'data',
-          data: new ApacheArrowTable([recordBatch]),
+          data: new arrow.Table([recordBatch]),
           length: recordBatch.data.length
         };
         // processBatch(recordBatch);

--- a/modules/arrow/src/lib/parse-arrow-sync.ts
+++ b/modules/arrow/src/lib/parse-arrow-sync.ts
@@ -1,7 +1,7 @@
 import type {ColumnarTable, ObjectRowTable} from '@loaders.gl/schema';
 import type {ArrowTable} from './arrow-table';
 import {convertTable} from '@loaders.gl/schema';
-import {tableFromIPC} from 'apache-arrow';
+import * as arrow from 'apache-arrow';
 import type {ArrowLoaderOptions} from '../arrow-loader';
 import {
   convertApacheArrowToArrowTable,
@@ -13,7 +13,7 @@ export default function parseArrowSync(
   arrayBuffer,
   options?: ArrowLoaderOptions
 ): ArrowTable | ColumnarTable | ObjectRowTable {
-  const apacheArrowTable = tableFromIPC([new Uint8Array(arrayBuffer)]);
+  const apacheArrowTable = arrow.tableFromIPC([new Uint8Array(arrayBuffer)]);
   const arrowTable = convertApacheArrowToArrowTable(apacheArrowTable);
 
   const shape = options?.arrow?.shape || 'arrow-table';

--- a/modules/arrow/src/schema/arrow-type-utils.ts
+++ b/modules/arrow/src/schema/arrow-type-utils.ts
@@ -2,46 +2,27 @@
 // Copyright (c) vis.gl contributors
 
 import type {TypedArray} from '@loaders.gl/schema';
-import {
-  DataType,
-  Float32,
-  Float64,
-  Int16,
-  Int32,
-  Int8,
-  Uint16,
-  Uint32,
-  Uint8
-  // Int8Vector,
-  // Uint8Vector,
-  // Int16Vector,
-  // Uint16Vector,
-  // Int32Vector,
-  // Uint32Vector,
-  // Float32Vector,
-  // Float64Vector
-} from 'apache-arrow';
-// import {AbstractVector} from 'apache-arrow/vector';
+import * as arrow from 'apache-arrow';
 
 /** Return an Apache Arrow Type instance that corresponds to the type of the elements in the supplied Typed Array */
-export function getArrowType(array: TypedArray): DataType {
+export function getArrowType(array: TypedArray): arrow.DataType {
   switch (array.constructor) {
     case Int8Array:
-      return new Int8();
+      return new arrow.Int8();
     case Uint8Array:
-      return new Uint8();
+      return new arrow.Uint8();
     case Int16Array:
-      return new Int16();
+      return new arrow.Int16();
     case Uint16Array:
-      return new Uint16();
+      return new arrow.Uint16();
     case Int32Array:
-      return new Int32();
+      return new arrow.Int32();
     case Uint32Array:
-      return new Uint32();
+      return new arrow.Uint32();
     case Float32Array:
-      return new Float32();
+      return new arrow.Float32();
     case Float64Array:
-      return new Float64();
+      return new arrow.Float64();
     default:
       throw new Error('array type not supported');
   }

--- a/modules/arrow/src/schema/convert-arrow-schema.ts
+++ b/modules/arrow/src/schema/convert-arrow-schema.ts
@@ -2,54 +2,10 @@
 // Copyright (c) vis.gl contributors
 
 import type {DataType, Field, Schema, SchemaMetadata} from '@loaders.gl/schema';
-import {
-  Field as ArrowField,
-  Schema as ArrowSchema,
-  DataType as ArrowDataType,
-  Null,
-  Binary,
-  Bool,
-  Int,
-  Int8,
-  Int16,
-  Int32,
-  Int64,
-  Uint8,
-  Uint16,
-  Uint32,
-  Uint64,
-  Float,
-  Float16,
-  Float32,
-  Float64,
-  Precision,
-  Utf8,
-  Date_,
-  DateUnit,
-  DateDay,
-  DateMillisecond,
-  Time,
-  TimeMillisecond,
-  TimeSecond,
-  Timestamp,
-  TimestampSecond,
-  TimestampMillisecond,
-  TimestampMicrosecond,
-  TimestampNanosecond,
-  Interval,
-  IntervalUnit,
-  IntervalDayTime,
-  IntervalYearMonth,
-  FixedSizeList,
-  Struct,
-  TimeUnit,
-  TimeMicrosecond,
-  TimeNanosecond,
-  List
-} from 'apache-arrow';
+import * as arrow from 'apache-arrow';
 
 /** Convert Apache Arrow Schema (class instance) to a serialized Schema (plain data) */
-export function serializeArrowSchema(arrowSchema: ArrowSchema): Schema {
+export function serializeArrowSchema(arrowSchema: arrow.Schema): Schema {
   return {
     fields: arrowSchema.fields.map((arrowField) => serializeArrowField(arrowField)),
     metadata: serializeArrowMetadata(arrowSchema.metadata)
@@ -57,8 +13,8 @@ export function serializeArrowSchema(arrowSchema: ArrowSchema): Schema {
 }
 
 /** Convert a serialized Schema (plain data) to an Apache Arrow Schema (class instance) */
-export function deserializeArrowSchema(schema: Schema): ArrowSchema {
-  return new ArrowSchema(
+export function deserializeArrowSchema(schema: Schema): arrow.Schema {
+  return new arrow.Schema(
     schema.fields.map((field) => deserializeArrowField(field)),
     deserializeArrowMetadata(schema.metadata)
   );
@@ -75,7 +31,7 @@ export function deserializeArrowMetadata(metadata?: SchemaMetadata): Map<string,
 }
 
 /** Convert Apache Arrow Field (class instance) to serialized Field (plain data) */
-export function serializeArrowField(field: ArrowField): Field {
+export function serializeArrowField(field: arrow.Field): Field {
   return {
     name: field.name,
     type: serializeArrowType(field.type),
@@ -85,8 +41,8 @@ export function serializeArrowField(field: ArrowField): Field {
 }
 
 /** Convert a serialized Field (plain data) to an Apache Arrow Field (class instance)*/
-export function deserializeArrowField(field: Field): ArrowField {
-  return new ArrowField(
+export function deserializeArrowField(field: Field): arrow.Field {
+  return new arrow.Field(
     field.name,
     deserializeArrowType(field.type),
     field.nullable,
@@ -96,134 +52,134 @@ export function deserializeArrowField(field: Field): ArrowField {
 
 /** Converts a serializable loaders.gl data type to hydrated arrow data type */
 // eslint-disable-next-line complexity
-export function serializeArrowType(arrowType: ArrowDataType): DataType {
+export function serializeArrowType(arrowType: arrow.DataType): DataType {
   switch (arrowType.constructor) {
-    case Null:
+    case arrow.Null:
       return 'null';
-    case Binary:
+    case arrow.Binary:
       return 'binary';
-    case Bool:
+    case arrow.Bool:
       return 'bool';
-    case Int:
-      const intType = arrowType as Int;
+    case arrow.Int:
+      const intType = arrowType as arrow.Int;
       return `${intType.isSigned ? 'u' : ''}int${intType.bitWidth}`;
-    case Int8:
+    case arrow.Int8:
       return 'int8';
-    case Int16:
+    case arrow.Int16:
       return 'int16';
-    case Int32:
+    case arrow.Int32:
       return 'int32';
-    case Int64:
+    case arrow.Int64:
       return 'int64';
-    case Uint8:
+    case arrow.Uint8:
       return 'uint8';
-    case Uint16:
+    case arrow.Uint16:
       return 'uint16';
-    case Uint32:
+    case arrow.Uint32:
       return 'uint32';
-    case Uint64:
+    case arrow.Uint64:
       return 'uint64';
-    case Float:
-      const precision = (arrowType as Float).precision;
+    case arrow.Float:
+      const precision = (arrowType as arrow.Float).precision;
       // return `float(precision + 1) * 16`;
       switch (precision) {
-        case Precision.HALF:
+        case arrow.Precision.HALF:
           return 'float16';
-        case Precision.SINGLE:
+        case arrow.Precision.SINGLE:
           return 'float32';
-        case Precision.DOUBLE:
+        case arrow.Precision.DOUBLE:
           return 'float64';
         default:
           return 'float16';
       }
-    case Float16:
+    case arrow.Float16:
       return 'float16';
-    case Float32:
+    case arrow.Float32:
       return 'float32';
-    case Float64:
+    case arrow.Float64:
       return 'float64';
-    case Utf8:
+    case arrow.Utf8:
       return 'utf8';
     case Date:
-      const dateUnit = (arrowType as Date_).unit;
-      return dateUnit === DateUnit.DAY ? 'date-day' : 'date-millisecond';
-    case DateDay:
+      const dateUnit = (arrowType as arrow.Date_).unit;
+      return dateUnit === arrow.DateUnit.DAY ? 'date-day' : 'date-millisecond';
+    case arrow.DateDay:
       return 'date-day';
-    case DateMillisecond:
+    case arrow.DateMillisecond:
       return 'date-millisecond';
-    case Time:
-      const timeUnit = (arrowType as Time).unit;
+    case arrow.Time:
+      const timeUnit = (arrowType as arrow.Time).unit;
       switch (timeUnit) {
-        case TimeUnit.SECOND:
+        case arrow.TimeUnit.SECOND:
           return 'time-second';
-        case TimeUnit.MILLISECOND:
+        case arrow.TimeUnit.MILLISECOND:
           return 'time-millisecond';
-        case TimeUnit.MICROSECOND:
+        case arrow.TimeUnit.MICROSECOND:
           return 'time-microsecond';
-        case TimeUnit.NANOSECOND:
+        case arrow.TimeUnit.NANOSECOND:
           return 'time-nanosecond';
         default:
           return 'time-second';
       }
-    case TimeMillisecond:
+    case arrow.TimeMillisecond:
       return 'time-millisecond';
-    case TimeSecond:
+    case arrow.TimeSecond:
       return 'time-second';
-    case TimeMicrosecond:
+    case arrow.TimeMicrosecond:
       return 'time-microsecond';
-    case TimeNanosecond:
+    case arrow.TimeNanosecond:
       return 'time-nanosecond';
-    case Timestamp:
-      const timeStampUnit = (arrowType as Timestamp).unit;
+    case arrow.Timestamp:
+      const timeStampUnit = (arrowType as arrow.Timestamp).unit;
       switch (timeStampUnit) {
-        case TimeUnit.SECOND:
+        case arrow.TimeUnit.SECOND:
           return 'timestamp-second';
-        case TimeUnit.MILLISECOND:
+        case arrow.TimeUnit.MILLISECOND:
           return 'timestamp-millisecond';
-        case TimeUnit.MICROSECOND:
+        case arrow.TimeUnit.MICROSECOND:
           return 'timestamp-microsecond';
-        case TimeUnit.NANOSECOND:
+        case arrow.TimeUnit.NANOSECOND:
           return 'timestamp-nanosecond';
         default:
           return 'timestamp-second';
       }
-    case TimestampSecond:
+    case arrow.TimestampSecond:
       return 'timestamp-second';
-    case TimestampMillisecond:
+    case arrow.TimestampMillisecond:
       return 'timestamp-millisecond';
-    case TimestampMicrosecond:
+    case arrow.TimestampMicrosecond:
       return 'timestamp-microsecond';
-    case TimestampNanosecond:
+    case arrow.TimestampNanosecond:
       return 'timestamp-nanosecond';
-    case Interval:
-      const intervalUnit = (arrowType as Interval).unit;
+    case arrow.Interval:
+      const intervalUnit = (arrowType as arrow.Interval).unit;
       switch (intervalUnit) {
-        case IntervalUnit.DAY_TIME:
+        case arrow.IntervalUnit.DAY_TIME:
           return 'interval-daytime';
-        case IntervalUnit.YEAR_MONTH:
+        case arrow.IntervalUnit.YEAR_MONTH:
           return 'interval-yearmonth';
         default:
           return 'interval-daytime';
       }
-    case IntervalDayTime:
+    case arrow.IntervalDayTime:
       return 'interval-daytime';
-    case IntervalYearMonth:
+    case arrow.IntervalYearMonth:
       return 'interval-yearmonth';
-    case List:
-      const listType = arrowType as List;
+    case arrow.List:
+      const listType = arrowType as arrow.List;
       const listField = listType.valueField;
       return {
         type: 'list',
         children: [serializeArrowField(listField)]
       };
-    case FixedSizeList:
+    case arrow.FixedSizeList:
       return {
         type: 'fixed-size-list',
-        listSize: (arrowType as FixedSizeList).listSize,
-        children: [serializeArrowField((arrowType as FixedSizeList).children[0])]
+        listSize: (arrowType as arrow.FixedSizeList).listSize,
+        children: [serializeArrowField((arrowType as arrow.FixedSizeList).children[0])]
       };
-    // case Struct:
-    //   return {type: 'struct', children: (arrowType as Struct).children};
+    // case arrow.Struct:
+    //   return {type: 'struct', children: (arrowType as arrow.Struct).children};
     default:
       throw new Error('array type not supported');
   }
@@ -231,18 +187,18 @@ export function serializeArrowType(arrowType: ArrowDataType): DataType {
 
 /** Converts a serializable loaders.gl data type to hydrated arrow data type */
 // eslint-disable-next-line complexity
-export function deserializeArrowType(dataType: DataType): ArrowDataType {
+export function deserializeArrowType(dataType: DataType): arrow.DataType {
   if (typeof dataType === 'object') {
     switch (dataType.type) {
       case 'list':
         const field = deserializeArrowField(dataType.children[0]);
-        return new List(field);
+        return new arrow.List(field);
       case 'fixed-size-list':
         const child = deserializeArrowField(dataType.children[0]);
-        return new FixedSizeList(dataType.listSize, child);
+        return new arrow.FixedSizeList(dataType.listSize, child);
       case 'struct':
         const children = dataType.children.map((arrowField) => deserializeArrowField(arrowField));
-        return new Struct(children);
+        return new arrow.Struct(children);
       default:
         throw new Error('array type not supported');
     }
@@ -250,59 +206,59 @@ export function deserializeArrowType(dataType: DataType): ArrowDataType {
 
   switch (dataType) {
     case 'null':
-      return new Null();
+      return new arrow.Null();
     case 'binary':
-      return new Binary();
+      return new arrow.Binary();
     case 'bool':
-      return new Bool();
+      return new arrow.Bool();
     case 'int8':
-      return new Int8();
+      return new arrow.Int8();
     case 'int16':
-      return new Int16();
+      return new arrow.Int16();
     case 'int32':
-      return new Int32();
+      return new arrow.Int32();
     case 'int64':
-      return new Int64();
+      return new arrow.Int64();
     case 'uint8':
-      return new Uint8();
+      return new arrow.Uint8();
     case 'uint16':
-      return new Uint16();
+      return new arrow.Uint16();
     case 'uint32':
-      return new Uint32();
+      return new arrow.Uint32();
     case 'uint64':
-      return new Uint64();
+      return new arrow.Uint64();
     case 'float16':
-      return new Float16();
+      return new arrow.Float16();
     case 'float32':
-      return new Float32();
+      return new arrow.Float32();
     case 'float64':
-      return new Float64();
+      return new arrow.Float64();
     case 'utf8':
-      return new Utf8();
+      return new arrow.Utf8();
     case 'date-day':
-      return new DateDay();
+      return new arrow.DateDay();
     case 'date-millisecond':
-      return new DateMillisecond();
+      return new arrow.DateMillisecond();
     case 'time-second':
-      return new TimeSecond();
+      return new arrow.TimeSecond();
     case 'time-millisecond':
-      return new TimeMillisecond();
+      return new arrow.TimeMillisecond();
     case 'time-microsecond':
-      return new TimeMicrosecond();
+      return new arrow.TimeMicrosecond();
     case 'time-nanosecond':
-      return new TimeNanosecond();
+      return new arrow.TimeNanosecond();
     case 'timestamp-second':
-      return new TimestampSecond();
+      return new arrow.TimestampSecond();
     case 'timestamp-millisecond':
-      return new TimestampMillisecond();
+      return new arrow.TimestampMillisecond();
     case 'timestamp-microsecond':
-      return new TimestampMicrosecond();
+      return new arrow.TimestampMicrosecond();
     case 'timestamp-nanosecond':
-      return new TimestampNanosecond();
+      return new arrow.TimestampNanosecond();
     case 'interval-daytime':
-      return new IntervalDayTime();
+      return new arrow.IntervalDayTime();
     case 'interval-yearmonth':
-      return new IntervalYearMonth();
+      return new arrow.IntervalYearMonth();
     default:
       throw new Error('array type not supported');
   }

--- a/modules/arrow/src/tables/convert-arrow-to-table.ts
+++ b/modules/arrow/src/tables/convert-arrow-to-table.ts
@@ -2,7 +2,7 @@
 // Copyright (c) vis.gl contributors
 
 import type {ColumnarTable, ObjectRowTable} from '@loaders.gl/schema';
-import type {Table as ApacheArrowTable} from 'apache-arrow';
+import type * as arrow from 'apache-arrow';
 import type {ArrowTable} from '../lib/arrow-table';
 
 /**
@@ -11,7 +11,7 @@ import type {ArrowTable} from '../lib/arrow-table';
  * @param arrowTable
  * @returns
  */
-export function convertApacheArrowToArrowTable(arrowTable: ApacheArrowTable): ArrowTable {
+export function convertApacheArrowToArrowTable(arrowTable: arrow.Table): ArrowTable {
   return {
     shape: 'arrow-table',
     data: arrowTable

--- a/modules/csv/test/csv-loader-arrow.spec.ts
+++ b/modules/csv/test/csv-loader-arrow.spec.ts
@@ -1,10 +1,7 @@
 import test from 'tape-promise/tape';
 import {loadInBatches, isIterator, isAsyncIterable} from '@loaders.gl/core';
-import {CSVLoader} from '../src/csv-loader';
-// import {CSVLoader} from '@loaders.gl/csv';
-// import {RecordBatch} from 'apache-arrow';
-import {Table as ApacheArrowTable} from 'apache-arrow';
-// import {Schema, Field, RecordBatch, Float32Vector} from 'apache-arrow';
+import {CSVLoader} from '../src/csv-loader'; // from '@loaders.gl/csv';
+import * as arrow from 'apache-arrow';
 
 // Small CSV Sample Files
 const CSV_NUMBERS_100_URL = '@loaders.gl/csv/test/data/numbers-100.csv';
@@ -22,7 +19,7 @@ test('CSVLoader#loadInBatches(numbers-100.csv, arrow)', async (t) => {
 
   let batchCount = 0;
   for await (const batch of iterator) {
-    t.ok(batch.data instanceof ApacheArrowTable, 'returns arrow RecordBatch');
+    t.ok(batch.data instanceof arrow.Table, 'returns arrow RecordBatch');
     // t.comment(`BATCH: ${batch.length}`);
     batchCount++;
   }
@@ -42,7 +39,7 @@ test('CSVLoader#loadInBatches(numbers-10000.csv, arrow)', async (t) => {
 
   let batchCount = 0;
   for await (const batch of iterator) {
-    t.ok(batch.data instanceof ApacheArrowTable, 'returns arrow RecordBatch');
+    t.ok(batch.data instanceof arrow.Table, 'returns arrow RecordBatch');
     // t.comment(`BATCH: ${batch.length}`);
     batchCount++;
   }

--- a/modules/parquet/src/index.ts
+++ b/modules/parquet/src/index.ts
@@ -12,7 +12,7 @@ import type {
   GeoJSONTable,
   GeoJSONTableBatch
 } from '@loaders.gl/schema';
-// import type {Table as ApacheArrowTable} from 'apache-arrow';
+// import type * as arrow from 'apache-arrow';
 
 // ParquetLoader
 
@@ -59,7 +59,7 @@ export const ParquetColumnarLoader: LoaderWithParser<
 };
 
 // export const ParquetWasmLoader: LoaderWithParser<
-//   ApacheArrowTable,
+//   arrow.Table,
 //   never,
 //   ParquetWasmLoaderOptions
 // > = {

--- a/modules/parquet/src/lib/wasm/encode-parquet-wasm.ts
+++ b/modules/parquet/src/lib/wasm/encode-parquet-wasm.ts
@@ -1,7 +1,6 @@
-import type {Table} from 'apache-arrow';
 import type {WriterOptions} from '@loaders.gl/loader-utils';
 
-import {RecordBatchStreamWriter} from 'apache-arrow';
+import * as arrow from 'apache-arrow';
 import {loadWasm} from './load-wasm';
 
 export type ParquetWriterOptions = WriterOptions & {
@@ -11,9 +10,12 @@ export type ParquetWriterOptions = WriterOptions & {
 };
 
 /**
- * Encode Arrow Table to Parquet buffer
+ * Encode Arrow arrow.Table to Parquet buffer
  */
-export async function encode(table: Table, options?: ParquetWriterOptions): Promise<ArrayBuffer> {
+export async function encode(
+  table: arrow.Table,
+  options?: ParquetWriterOptions
+): Promise<ArrayBuffer> {
   const wasmUrl = options?.parquet?.wasmUrl;
   const wasm = await loadWasm(wasmUrl);
 
@@ -28,13 +30,12 @@ export async function encode(table: Table, options?: ParquetWriterOptions): Prom
 }
 
 /**
- * Serialize a {@link Table} to the IPC format. This function is a convenience
- * wrapper for {@link RecordBatchStreamWriter} and {@link RecordBatchFileWriter}.
+ * Serialize a table to the IPC format. This function is a convenience
  * Opposite of {@link tableFromIPC}.
  *
- * @param table The Table to serialize.
- * @param type Whether to serialize the Table as a file or a stream.
+ * @param table The arrow.Table to serialize.
+ * @param type Whether to serialize the arrow.Table as a file or a stream.
  */
-export function tableToIPC(table: Table): Uint8Array {
-  return RecordBatchStreamWriter.writeAll(table).toUint8Array(true);
+export function tableToIPC(table: arrow.Table): Uint8Array {
+  return arrow.RecordBatchStreamWriter.writeAll(table).toUint8Array(true);
 }

--- a/modules/parquet/src/lib/wasm/parse-parquet-wasm.ts
+++ b/modules/parquet/src/lib/wasm/parse-parquet-wasm.ts
@@ -1,7 +1,6 @@
 // eslint-disable
-import type {RecordBatch} from 'apache-arrow';
 import type {LoaderOptions} from '@loaders.gl/loader-utils';
-import {Table as ArrowTable, RecordBatchStreamReader} from 'apache-arrow';
+import * as arrow from 'apache-arrow';
 import {loadWasm} from './load-wasm/load-wasm-node';
 
 export type ParquetWasmLoaderOptions = LoaderOptions & {
@@ -14,7 +13,7 @@ export type ParquetWasmLoaderOptions = LoaderOptions & {
 export async function parseParquetWasm(
   arrayBuffer: ArrayBuffer,
   options?: ParquetWasmLoaderOptions
-): Promise<ArrowTable> {
+): Promise<arrow.Table> {
   const wasmUrl = options?.parquet?.wasmUrl;
   const wasm = await loadWasm(wasmUrl);
 
@@ -32,11 +31,11 @@ export async function parseParquetWasm(
  * Deserialize the IPC format into a {@link Table}. This function is a
  * convenience wrapper for {@link RecordBatchReader}. Opposite of {@link tableToIPC}.
  */
-function tableFromIPC(input: ArrayBuffer): ArrowTable {
-  const reader = RecordBatchStreamReader.from(input);
-  const recordBatches: RecordBatch[] = [];
+function tableFromIPC(input: ArrayBuffer): arrow.Table {
+  const reader = arrow.RecordBatchStreamReader.from(input);
+  const recordBatches: arrow.RecordBatch[] = [];
   for (const recordBatch of reader) {
     recordBatches.push(recordBatch);
   }
-  return new ArrowTable(recordBatches);
+  return new arrow.Table(recordBatches);
 }

--- a/modules/parquet/src/parquet-wasm-loader.ts
+++ b/modules/parquet/src/parquet-wasm-loader.ts
@@ -2,7 +2,7 @@
 // Copyright (c) vis.gl contributors
 
 import type {Loader, LoaderOptions} from '@loaders.gl/loader-utils';
-import type {Table as ArrowTable} from 'apache-arrow';
+import type * as arrow from 'apache-arrow';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
@@ -17,7 +17,7 @@ export type ParquetWasmLoaderOptions = LoaderOptions & {
 };
 
 /** Parquet WASM table loader */
-export const ParquetWasmLoader: Loader<ArrowTable, never, ParquetWasmLoaderOptions> = {
+export const ParquetWasmLoader: Loader<arrow.Table, never, ParquetWasmLoaderOptions> = {
   name: 'Apache Parquet',
   id: 'parquet-wasm',
   module: 'parquet',

--- a/modules/parquet/src/parquet-wasm-writer.ts
+++ b/modules/parquet/src/parquet-wasm-writer.ts
@@ -3,14 +3,14 @@
 
 import type {Writer} from '@loaders.gl/loader-utils';
 import {encode, ParquetWriterOptions} from './lib/wasm/encode-parquet-wasm';
-import type {Table as ArrowTable} from 'apache-arrow';
+import type * as arrow from 'apache-arrow';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
 const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
 /** Parquet WASM writer */
-export const ParquetWasmWriter: Writer<ArrowTable, never, ParquetWriterOptions> = {
+export const ParquetWasmWriter: Writer<arrow.Table, never, ParquetWriterOptions> = {
   name: 'Apache Parquet',
   id: 'parquet-wasm',
   module: 'parquet',

--- a/modules/parquet/test/geoparquet-loader.spec.ts
+++ b/modules/parquet/test/geoparquet-loader.spec.ts
@@ -8,7 +8,7 @@ import {
 } from '@loaders.gl/parquet';
 import {load, encode, setLoaderOptions} from '@loaders.gl/core';
 import {getTableLength} from '@loaders.gl/schema';
-import {Table as ArrowTable, makeVector, vectorFromArray, Bool, Utf8} from 'apache-arrow';
+import * as arrow from 'apache-arrow';
 
 const PARQUET_DIR = '@loaders.gl/parquet/test/data/geoparquet';
 const GEOPARQUET_EXAMPLE = `${PARQUET_DIR}/example.parquet`;
@@ -67,13 +67,13 @@ test.skip('ParquetWriterLoader round trip', async (t) => {
   t.end();
 });
 
-function createArrowTable(): ArrowTable {
-  const utf8Vector = vectorFromArray<Utf8>(['a', 'b', 'c', 'd']);
-  const boolVector = makeVector({data: [1, 1, 0, 0], type: new Bool()});
-  const uint8Vector = makeVector(new Uint8Array([1, 2, 3, 4]));
-  const int32Vector = makeVector(new Int32Array([0, -2147483638, 2147483637, 1]));
+function createArrowTable(): arrow.Table {
+  const utf8Vector = arrow.vectorFromArray<arrow.Utf8>(['a', 'b', 'c', 'd']);
+  const boolVector = arrow.makeVector({data: [1, 1, 0, 0], type: new arrow.Bool()});
+  const uint8Vector = arrow.makeVector(new Uint8Array([1, 2, 3, 4]));
+  const int32Vector = arrow.makeVector(new Int32Array([0, -2147483638, 2147483637, 1]));
 
-  const table = new ArrowTable({
+  const table = new arrow.Table({
     str: utf8Vector,
     uint8: uint8Vector,
     int32: int32Vector,


### PR DESCRIPTION
I normally prefer explicit imports, but given how many small symbols apache arrow exports, I think this style (inspired by @kylebarron's https://github.com/geoarrow/deck.gl-layers) works better.