### PR TITLE
chore(Arrow): add test cases for geoarrow to binary geometries

### DIFF
--- a/modules/arrow/src/geoarrow/convert-geoarrow-to-binary-geometry.ts
+++ b/modules/arrow/src/geoarrow/convert-geoarrow-to-binary-geometry.ts
@@ -24,7 +24,7 @@ type BinaryGeometryContent = {
 };
 
 // binary geometry template, see deck.gl BinaryGeometry
-const BINARY_GEOMETRY_TEMPLATE = {
+export const BINARY_GEOMETRY_TEMPLATE = {
   globalFeatureIds: {value: new Uint32Array(0), size: 1},
   positions: {value: new Float32Array(0), size: 2},
   properties: [],
@@ -54,10 +54,9 @@ export function getBinaryGeometriesFromArrow(
   let globalFeatureIdOffset = 0;
   const binaryGeometries: BinaryFeatures[] = [];
 
-  for (let c = 0; c < chunks.length; c++) {
-    const geometries = chunks[c];
+  chunks.forEach((chunk) => {
     const {featureIds, flatCoordinateArray, nDim, geomOffset} = getBinaryGeometriesFromChunk(
-      geometries,
+      chunk,
       geoEncoding
     );
 
@@ -74,14 +73,13 @@ export function getBinaryGeometriesFromArrow(
         size: nDim
       },
       featureIds: {value: featureIds, size: 1},
-      // eslint-disable-next-line no-loop-func
-      properties: [...Array(geometries.length).keys()].map((i) => ({
+      properties: [...Array(chunk.length).keys()].map((i) => ({
         index: i + globalFeatureIdOffset
       }))
     };
 
     // TODO: check if chunks are sequentially accessed
-    globalFeatureIdOffset += geometries.length;
+    globalFeatureIdOffset += chunk.length;
 
     // NOTE: deck.gl defines the BinaryFeatures structure must have points, lines, polygons even if they are empty
     binaryGeometries.push({
@@ -115,7 +113,7 @@ export function getBinaryGeometriesFromArrow(
     });
 
     bounds = updateBoundsFromGeoArrowSamples(flatCoordinateArray, nDim, bounds);
-  }
+  });
 
   return {binaryGeometries, bounds, featureTypes};
 }

--- a/modules/arrow/src/index.ts
+++ b/modules/arrow/src/index.ts
@@ -65,7 +65,10 @@ export type {GeoArrowEncoding} from '@loaders.gl/gis';
 // getGeoArrowEncoding
 
 export type {BinaryDataFromGeoArrow} from './geoarrow/convert-geoarrow-to-binary-geometry';
-export {getBinaryGeometriesFromArrow} from './geoarrow/convert-geoarrow-to-binary-geometry';
+export {
+  BINARY_GEOMETRY_TEMPLATE,
+  getBinaryGeometriesFromArrow
+} from './geoarrow/convert-geoarrow-to-binary-geometry';
 
 export {parseGeometryFromArrow} from './geoarrow/convert-geoarrow-to-geojson';
 

--- a/modules/arrow/test/geoarrow/convert-geoarrow-to-binary-geometry.spec.ts
+++ b/modules/arrow/test/geoarrow/convert-geoarrow-to-binary-geometry.spec.ts
@@ -1,0 +1,257 @@
+import test, {Test} from 'tape-promise/tape';
+
+import {Table as ApacheArrowTable} from 'apache-arrow';
+import {getGeometryColumnsFromSchema} from '@loaders.gl/gis';
+import {fetchFile, parse} from '@loaders.gl/core';
+import {
+  BINARY_GEOMETRY_TEMPLATE,
+  ArrowLoader,
+  getBinaryGeometriesFromArrow,
+  serializeArrowSchema
+} from '@loaders.gl/arrow';
+
+import {
+  POINT_ARROW_FILE,
+  MULTIPOINT_ARROW_FILE,
+  LINE_ARROW_FILE,
+  MULTILINE_ARROW_FILE,
+  POLYGON_ARROW_FILE,
+  MULTIPOLYGON_ARROW_FILE
+} from './convert-geoarrow-to-geojson.spec';
+
+const expectedPointBinaryGeometry = {
+  binaryGeometries: [
+    {
+      shape: 'binary-feature-collection',
+      points: {
+        ...BINARY_GEOMETRY_TEMPLATE,
+        type: 'Point',
+        globalFeatureIds: {value: new Uint32Array([0]), size: 1},
+        positions: {value: new Float64Array([1, 1]), size: 2},
+        properties: [{index: 0}],
+        featureIds: {value: new Uint32Array([0]), size: 1}
+      },
+      lines: {
+        ...BINARY_GEOMETRY_TEMPLATE,
+        type: 'LineString',
+        pathIndices: {value: new Uint16Array(0), size: 1}
+      },
+      polygons: {
+        ...BINARY_GEOMETRY_TEMPLATE,
+        type: 'Polygon',
+        polygonIndices: {value: new Uint16Array(0), size: 1},
+        primitivePolygonIndices: {value: new Uint16Array(0), size: 1}
+      }
+    }
+  ],
+  bounds: [1, 1, 1, 1],
+  featureTypes: {polygon: false, point: true, line: false}
+};
+
+const expectedMultiPointBinaryGeometry = {
+  binaryGeometries: [
+    {
+      shape: 'binary-feature-collection',
+      points: {
+        ...BINARY_GEOMETRY_TEMPLATE,
+        type: 'Point',
+        globalFeatureIds: {value: new Uint32Array([0, 0]), size: 1},
+        positions: {value: new Float64Array([1, 1, 2, 2]), size: 2},
+        properties: [{index: 0}],
+        featureIds: {value: new Uint32Array([0, 0]), size: 1}
+      },
+      lines: {
+        ...BINARY_GEOMETRY_TEMPLATE,
+        type: 'LineString',
+        pathIndices: {value: new Uint16Array(0), size: 1}
+      },
+      polygons: {
+        ...BINARY_GEOMETRY_TEMPLATE,
+        type: 'Polygon',
+        polygonIndices: {value: new Uint16Array(0), size: 1},
+        primitivePolygonIndices: {value: new Uint16Array(0), size: 1}
+      }
+    }
+  ],
+  bounds: [1, 1, 2, 2],
+  featureTypes: {polygon: false, point: true, line: false}
+};
+
+const expectedLineBinaryGeometry = {
+  binaryGeometries: [
+    {
+      shape: 'binary-feature-collection',
+      points: {
+        ...BINARY_GEOMETRY_TEMPLATE,
+        type: 'Point'
+      },
+      lines: {
+        ...BINARY_GEOMETRY_TEMPLATE,
+        type: 'LineString',
+        globalFeatureIds: {value: new Uint32Array([0, 0]), size: 1},
+        positions: {value: new Float64Array([0, 0, 1, 1]), size: 2},
+        properties: [{index: 0}],
+        featureIds: {value: new Uint32Array([0, 0]), size: 1},
+        pathIndices: {value: new Int32Array([0, 2]), size: 1}
+      },
+      polygons: {
+        ...BINARY_GEOMETRY_TEMPLATE,
+        type: 'Polygon',
+        polygonIndices: {value: new Uint16Array(0), size: 1},
+        primitivePolygonIndices: {value: new Uint16Array(0), size: 1}
+      }
+    }
+  ],
+  bounds: [0, 0, 1, 1],
+  featureTypes: {polygon: false, point: false, line: true}
+};
+
+const expectedMultiLineBinaryGeometry = {
+  binaryGeometries: [
+    {
+      shape: 'binary-feature-collection',
+      points: {
+        ...BINARY_GEOMETRY_TEMPLATE,
+        type: 'Point'
+      },
+      lines: {
+        ...BINARY_GEOMETRY_TEMPLATE,
+        type: 'LineString',
+        globalFeatureIds: {value: new Uint32Array([0, 0, 0, 0]), size: 1},
+        positions: {value: new Float64Array([1, 1, 2, 2, 3, 3, 4, 4]), size: 2},
+        properties: [{index: 0}],
+        featureIds: {value: new Uint32Array([0, 0, 0, 0]), size: 1},
+        pathIndices: {value: new Int32Array([0, 2, 4]), size: 1}
+      },
+      polygons: {
+        ...BINARY_GEOMETRY_TEMPLATE,
+        type: 'Polygon',
+        polygonIndices: {value: new Uint16Array(0), size: 1},
+        primitivePolygonIndices: {value: new Uint16Array(0), size: 1}
+      }
+    }
+  ],
+  bounds: [1, 1, 4, 4],
+  featureTypes: {polygon: false, point: false, line: true}
+};
+
+const expectedPolygonBinaryGeometry = {
+  binaryGeometries: [
+    {
+      shape: 'binary-feature-collection',
+      points: {
+        ...BINARY_GEOMETRY_TEMPLATE,
+        type: 'Point'
+      },
+      lines: {
+        ...BINARY_GEOMETRY_TEMPLATE,
+        type: 'LineString',
+        pathIndices: {value: new Uint16Array(0), size: 1}
+      },
+      polygons: {
+        ...BINARY_GEOMETRY_TEMPLATE,
+        type: 'Polygon',
+        globalFeatureIds: {
+          value: new Uint32Array([0, 0, 0, 0]),
+          size: 1
+        },
+        positions: {
+          value: new Float64Array([0, 0, 1, 1, 2, 2, 0, 0]),
+          size: 2
+        },
+        properties: [{index: 0}],
+        featureIds: {value: new Uint32Array([0, 0, 0, 0]), size: 1},
+        polygonIndices: {value: new Int32Array([0, 4]), size: 1},
+        primitivePolygonIndices: {value: new Int32Array([0, 4]), size: 1}
+      }
+    }
+  ],
+  bounds: [0, 0, 2, 2],
+  featureTypes: {polygon: true, point: false, line: false}
+};
+
+const expectedMultiPolygonBinaryGeometry = {
+  binaryGeometries: [
+    {
+      shape: 'binary-feature-collection',
+      points: {
+        ...BINARY_GEOMETRY_TEMPLATE,
+        type: 'Point'
+      },
+      lines: {
+        ...BINARY_GEOMETRY_TEMPLATE,
+        type: 'LineString',
+        pathIndices: {value: new Uint16Array(0), size: 1}
+      },
+      polygons: {
+        ...BINARY_GEOMETRY_TEMPLATE,
+        type: 'Polygon',
+        globalFeatureIds: {
+          value: new Uint32Array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+          size: 1
+        },
+        positions: {
+          value: new Float64Array([0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 2, 2, 2, 3, 3, 3, 3, 2, 2, 2]),
+          size: 2
+        },
+        properties: [{index: 0}],
+        featureIds: {
+          value: new Uint32Array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+          size: 1
+        },
+        polygonIndices: {value: new Int32Array([0, 5, 10]), size: 1},
+        primitivePolygonIndices: {value: new Int32Array([0, 5, 10]), size: 1}
+      }
+    }
+  ],
+  bounds: [0, 0, 3, 3],
+  featureTypes: {polygon: true, point: false, line: false}
+};
+
+test('ArrowUtils#getBinaryGeometriesFromArrow', (t) => {
+  const testCases = [
+    [POINT_ARROW_FILE, expectedPointBinaryGeometry],
+    [MULTIPOINT_ARROW_FILE, expectedMultiPointBinaryGeometry],
+    [LINE_ARROW_FILE, expectedLineBinaryGeometry],
+    [MULTILINE_ARROW_FILE, expectedMultiLineBinaryGeometry],
+    [POLYGON_ARROW_FILE, expectedPolygonBinaryGeometry],
+    [MULTIPOLYGON_ARROW_FILE, expectedMultiPolygonBinaryGeometry]
+  ];
+
+  testCases.forEach((testCase) => {
+    testGetBinaryGeometriesFromArrow(t, testCase[0], testCase[1]);
+  });
+
+  t.end();
+});
+
+async function testGetBinaryGeometriesFromArrow(
+  t: Test,
+  arrowFile,
+  expectedBinaryGeometries
+): Promise<void> {
+  const arrowTable = await parse(fetchFile(arrowFile), ArrowLoader, {
+    worker: false,
+    arrow: {
+      shape: 'arrow-table'
+    }
+  });
+
+  t.equal(arrowTable.shape, 'arrow-table');
+
+  const table = arrowTable.data as ApacheArrowTable;
+  const geoColumn = table.getChild('geometry');
+  t.notEqual(geoColumn, null, 'geoColumn is not null');
+
+  const schema = serializeArrowSchema(table.schema);
+  const geometryColumns = getGeometryColumnsFromSchema(schema);
+  const encoding = geometryColumns.geometry.encoding;
+
+  t.notEqual(encoding, undefined, 'encoding is not undefined');
+  if (geoColumn && encoding) {
+    const binaryData = getBinaryGeometriesFromArrow(geoColumn, encoding);
+    t.deepEqual(binaryData, expectedBinaryGeometries, 'binary geometries are correct');
+  }
+
+  return Promise.resolve();
+}

--- a/modules/arrow/test/geoarrow/convert-geoarrow-to-geojson.spec.ts
+++ b/modules/arrow/test/geoarrow/convert-geoarrow-to-geojson.spec.ts
@@ -5,12 +5,12 @@ import {fetchFile} from '@loaders.gl/core';
 import {serializeArrowSchema, parseGeometryFromArrow} from '@loaders.gl/arrow';
 import {getGeometryColumnsFromSchema} from '@loaders.gl/gis';
 
-const POINT_ARROW_FILE = '@loaders.gl/arrow/test/data/point.arrow';
-const MULTIPOINT_ARROW_FILE = '@loaders.gl/arrow/test/data/multipoint.arrow';
-const LINE_ARROW_FILE = '@loaders.gl/arrow/test/data/line.arrow';
-const MULTILINE_ARROW_FILE = '@loaders.gl/arrow/test/data/multiline.arrow';
-const POLYGON_ARROW_FILE = '@loaders.gl/arrow/test/data/polygon.arrow';
-const MULTIPOLYGON_ARROW_FILE = '@loaders.gl/arrow/test/data/multipolygon.arrow';
+export const POINT_ARROW_FILE = '@loaders.gl/arrow/test/data/point.arrow';
+export const MULTIPOINT_ARROW_FILE = '@loaders.gl/arrow/test/data/multipoint.arrow';
+export const LINE_ARROW_FILE = '@loaders.gl/arrow/test/data/line.arrow';
+export const MULTILINE_ARROW_FILE = '@loaders.gl/arrow/test/data/multiline.arrow';
+export const POLYGON_ARROW_FILE = '@loaders.gl/arrow/test/data/polygon.arrow';
+export const MULTIPOLYGON_ARROW_FILE = '@loaders.gl/arrow/test/data/multipolygon.arrow';
 
 /** Array containing all encodings */
 const GEOARROW_ENCODINGS = [

--- a/modules/arrow/test/geoarrow/get-arrow-bounds.spec.ts
+++ b/modules/arrow/test/geoarrow/get-arrow-bounds.spec.ts
@@ -2,6 +2,7 @@ import test from 'tape-promise/tape';
 
 import {updateBoundsFromGeoArrowSamples} from '@loaders.gl/arrow';
 
+// fix a bug that map bounds are not updated correctly from arrow samples
 test('ArrowUtils#updateBoundsFromGeoArrowSamples', (t) => {
   const testCases = [
     {

--- a/modules/arrow/test/index.ts
+++ b/modules/arrow/test/index.ts
@@ -4,6 +4,6 @@
 import './arrow-loader.spec';
 import './arrow-writer.spec';
 
-// import './convert-geoarrow-to-binary-geometry.spec';
+import './geoarrow/convert-geoarrow-to-binary-geometry.spec';
 import './geoarrow/convert-geoarrow-to-geojson.spec';
 import './geoarrow/get-arrow-bounds.spec';


### PR DESCRIPTION
- add test cases for `getBinaryGeometriesFromArrow()`
- Fix lint