### PR TITLE
chore: parseFile accepts `ReadableFile`

### DIFF
--- a/modules/loader-utils/src/loader-types.ts
+++ b/modules/loader-utils/src/loader-types.ts
@@ -5,6 +5,7 @@ import {
   FetchLike,
   TransformBatches /* , DataType, SyncDataType, BatchableDataType */
 } from './types';
+import {ReadableFile} from './lib/files/file';
 
 // LOADERS
 
@@ -161,14 +162,19 @@ export type LoaderWithParser<DataT = any, BatchT = any, LoaderOptionsT = LoaderO
 > & {
   /** Perform actions before load. @deprecated Not officially supported. */
   preload?: Preload;
-  /** Parse atomically from an arraybuffer asynchronously */
+  /** Parse asynchronously and atomically from an arraybuffer */
   parse: (
     arrayBuffer: ArrayBuffer,
     options?: LoaderOptionsT,
     context?: LoaderContext
   ) => Promise<DataT>;
-  parseFile?: (file: Blob, options?: LoaderOptionsT, context?: LoaderContext) => Promise<DataT>;
-  /** Parse atomically from an arraybuffer synchronously */
+  /** Parse asynchronously and atomically from a random access "file like" input */
+  parseFile?: (
+    file: ReadableFile,
+    options?: LoaderOptionsT,
+    context?: LoaderContext
+  ) => Promise<DataT>;
+  /** Parse synchronously and atomically from an arraybuffer */
   parseSync?: (
     arrayBuffer: ArrayBuffer,
     options?: LoaderOptionsT,
@@ -178,15 +184,15 @@ export type LoaderWithParser<DataT = any, BatchT = any, LoaderOptionsT = LoaderO
   parseText?: (text: string, options?: LoaderOptionsT, context?: LoaderContext) => Promise<DataT>;
   /** Parse atomically from a string synchronously */
   parseTextSync?: (text: string, options?: LoaderOptionsT, context?: LoaderContext) => DataT;
-  /** Parse batches of data from an iterator, return an iterator that yield parsed batches. */
+  /** Parse batches of data from an iterator (e.g. fetch stream), return an iterator that yield parsed batches. */
   parseInBatches?: (
     iterator: AsyncIterable<ArrayBuffer> | Iterable<ArrayBuffer>,
     options?: LoaderOptionsT,
     context?: LoaderContext
   ) => AsyncIterable<BatchT>;
-  /** Like `parseInBatches` for loaders that don't integrate with fetch. @deprecated Not officially supported. */
+  /** For random access, file like sources, source that don't integrate with fetch. */
   parseFileInBatches?: (
-    file: Blob,
+    file: ReadableFile,
     options?: LoaderOptionsT,
     context?: LoaderContext
   ) => AsyncIterable<BatchT>;

--- a/modules/parquet/src/index.ts
+++ b/modules/parquet/src/index.ts
@@ -16,14 +16,15 @@ import type {
 
 // ParquetLoader
 
+import {BlobFile} from '@loaders.gl/loader-utils';
 import {
   ParquetLoader as ParquetWorkerLoader,
-  ParquetLoader as ParquetColumnarWorkerLoader,
+  ParquetColumnarLoader as ParquetColumnarWorkerLoader,
   ParquetLoaderOptions
 } from './parquet-loader';
-import {parseParquet, parseParquetFileInBatches} from './lib/parsers/parse-parquet-to-rows';
+import {parseParquetFile, parseParquetFileInBatches} from './lib/parsers/parse-parquet-to-rows';
 import {
-  parseParquetInColumns,
+  parseParquetFileInColumns,
   parseParquetFileInColumnarBatches
 } from './lib/parsers/parse-parquet-to-columns';
 
@@ -41,8 +42,10 @@ export const ParquetLoader: LoaderWithParser<
   ParquetLoaderOptions
 > = {
   ...ParquetWorkerLoader,
-  parse: parseParquet,
-  // @ts-expect-error
+  parse(arrayBuffer: ArrayBuffer, options?: ParquetLoaderOptions) {
+    return parseParquetFile(new BlobFile(arrayBuffer), options);
+  },
+  parseFile: parseParquetFile,
   parseFileInBatches: parseParquetFileInBatches
 };
 
@@ -53,8 +56,10 @@ export const ParquetColumnarLoader: LoaderWithParser<
   ParquetLoaderOptions
 > = {
   ...ParquetColumnarWorkerLoader,
-  parse: parseParquetInColumns,
-  // @ts-expect-error
+  parse(arrayBuffer: ArrayBuffer, options?: ParquetLoaderOptions) {
+    return parseParquetFileInColumns(new BlobFile(arrayBuffer), options);
+  },
+  parseFile: parseParquetFileInColumns,
   parseFileInBatches: parseParquetFileInColumnarBatches
 };
 

--- a/modules/parquet/src/parquet-loader.ts
+++ b/modules/parquet/src/parquet-loader.ts
@@ -5,9 +5,7 @@ import type {
   ObjectRowTable,
   ObjectRowTableBatch,
   ColumnarTable,
-  ColumnarTableBatch,
-  GeoJSONTable,
-  GeoJSONTableBatch
+  ColumnarTableBatch
 } from '@loaders.gl/schema';
 
 export {Buffer} from './buffer-polyfill/install-buffer-polyfill';
@@ -34,11 +32,7 @@ export type ParquetLoaderOptions = LoaderOptions & {
 };
 
 /** ParquetJS table loader */
-export const ParquetLoader: Loader<
-  ObjectRowTable | GeoJSONTable,
-  ObjectRowTableBatch | GeoJSONTableBatch,
-  ParquetLoaderOptions
-> = {
+export const ParquetLoader: Loader<ObjectRowTable, ObjectRowTableBatch, ParquetLoaderOptions> = {
   name: 'Apache Parquet',
   id: 'parquet',
   module: 'parquet',

--- a/test/common/conformance.ts
+++ b/test/common/conformance.ts
@@ -17,7 +17,7 @@ export function validateLoader(t, loader, name = '') {
   } else {
     t.equal(typeof loader.parse, 'function', `Loader ${name} has 'parse' function`);
     // Call parse just to ensure it returns a promise
-    const promise = loader.parse(null, {}).catch((_) => {});
+    const promise = loader.parse(new ArrayBuffer(0), {}).catch((_) => {});
     t.ok(promise.then, `Loader ${name} is async (returns a promise)`);
   }
 }


### PR DESCRIPTION
Standardize random access parsing on `ReadableFile` interface.