### PR TITLE
fix(examples): run 'geospatial' locally

### DIFF
--- a/examples/website/geospatial/app.tsx
+++ b/examples/website/geospatial/app.tsx
@@ -82,7 +82,6 @@ export default class App extends PureComponent<AppProps, AppState> {
       examples = {[props.format]: EXAMPLES[props.format], ...EXAMPLES};
     }
 
-    debugger
     const selectedLoader = props.format || INITIAL_LOADER_NAME;
 
     let selectedExample = INITIAL_EXAMPLE_NAME;

--- a/examples/website/geospatial/package.json
+++ b/examples/website/geospatial/package.json
@@ -19,10 +19,10 @@
     "@loaders.gl/parquet": "^4.0.0",
     "mapbox-gl": "npm:empty-npm-package@^1.0.0",
     "maplibre-gl": "^2.4.0",
+    "node-stdlib-browser": "^1.2.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-map-gl": "^7.0.0",
-    "rollup-plugin-node-builtins": "^2.1.2",
     "styled-components": "^4.2.0"
   },
   "devDependencies": {

--- a/examples/website/geospatial/vite.config.ts
+++ b/examples/website/geospatial/vite.config.ts
@@ -1,27 +1,29 @@
-import { defineConfig } from 'vite';
+import {defineConfig} from 'vite';
 import fs from 'fs';
 
 /** Run against local source */
 const getAliases = async (frameworkName, frameworkRootDir) => {
-  const modules = await fs.promises.readdir(`${frameworkRootDir}/modules`)
-  const aliases = {}
-  modules.forEach(module => {
+  const modules = await fs.promises.readdir(`${frameworkRootDir}/modules`);
+  const aliases = {};
+  modules.forEach((module) => {
     aliases[`${frameworkName}/${module}`] = `${frameworkRootDir}/modules/${module}/src`;
-  })
+  });
   console.log(aliases);
-  return aliases
-}
+  return aliases;
+};
 
 // https://vitejs.dev/config/
-export default defineConfig(async () => ({
-  resolve: {
-    alias: {
-      ...await getAliases('@loaders.gl', `${__dirname}/../../..`),
-      process: '@loaders.gl/polyfills',
-      path: '@loaders.gl/polyfills',
-      fs: '@loaders.gl/polyfills'
-    }
-  },
-  server: {open: true}
-}))
-
+export default defineConfig(async () => {
+  const {default: stdLibBrowser} = await import('node-stdlib-browser');
+  return {
+    resolve: {
+      alias: {
+        ...(await getAliases('@loaders.gl', `${__dirname}/../../..`)),
+        fs: stdLibBrowser.fs,
+        path: stdLibBrowser.path,
+        process: stdLibBrowser.process,
+      }
+    },
+    server: {open: true}
+  };
+});


### PR DESCRIPTION
It still fails because of recently enabled `ParquetWasmLoader`. But now I can comment it to debug the JS loader.