### PR TITLE
fix: Use "latest" version tag when loading from unpkg

### DIFF
--- a/modules/i3s/src/arcgis-webscene-loader.ts
+++ b/modules/i3s/src/arcgis-webscene-loader.ts
@@ -5,7 +5,7 @@ import {parseWebscene} from './lib/parsers/parse-arcgis-webscene';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
-const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'beta';
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
 export type ArcGISWebSceneLoaderOptions = LoaderOptions & {};
 

--- a/modules/i3s/src/i3s-building-scene-layer-loader.ts
+++ b/modules/i3s/src/i3s-building-scene-layer-loader.ts
@@ -7,7 +7,7 @@ import {parseBuildingSceneLayer} from './lib/parsers/parse-i3s-building-scene-la
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
 
-const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'beta';
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 /**
  * Loader for I3S - Building Scene Layer
  */

--- a/modules/i3s/src/i3s-content-loader.ts
+++ b/modules/i3s/src/i3s-content-loader.ts
@@ -6,7 +6,7 @@ import {I3STileContent, I3STileOptions, I3STilesetOptions} from './types';
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
 
-const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'beta';
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
 /**
  * Loader for I3S - Indexed 3D Scene Layer

--- a/modules/textures/src/lib/utils/version.ts
+++ b/modules/textures/src/lib/utils/version.ts
@@ -1,5 +1,4 @@
 // Version constant cannot be imported, it needs to correspond to the build version of **this** module.
 // __VERSION__ is injected by babel-plugin-version-inline
-// TODO: use 'latest' instead of 'beta' when 3.0.0 version is released as 'latest'
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
-export const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'beta';
+export const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';

--- a/modules/tile-converter/src/deps-installer/deps-installer.ts
+++ b/modules/tile-converter/src/deps-installer/deps-installer.ts
@@ -7,7 +7,7 @@ import {DRACO_EXTERNAL_LIBRARIES, DRACO_EXTERNAL_LIBRARY_URLS} from '@loaders.gl
 import {BASIS_EXTERNAL_LIBRARIES} from '@loaders.gl/textures';
 
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
-const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'beta';
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
 const PGM_LINK = 'https://raw.githubusercontent.com/visgl/deck.gl-data/master/egm/egm2008-5.zip';
 

--- a/modules/worker-utils/src/lib/env-utils/version.ts
+++ b/modules/worker-utils/src/lib/env-utils/version.ts
@@ -4,7 +4,7 @@
  * TODO - unpkg.com doesn't seem to have a `latest` specifier for alpha releases...
  * 'beta' on beta branch, 'latest' on prod branch
  */
-export const NPM_TAG = 'beta'; // Change to `latest` on production branches
+export const NPM_TAG = 'latest';
 
 declare let __VERSION__: string;
 


### PR DESCRIPTION
We need to switch from `beta` to `latest` on production releases.