### PR TITLE
chore(worker-utils): worker simplification

### DIFF
--- a/modules/worker-utils/src/lib/node/require-utils.node.ts
+++ b/modules/worker-utils/src/lib/node/require-utils.node.ts
@@ -1,3 +1,6 @@
+// loaders.gl, MIT license
+// Copyright (c) vis.gl contributors
+
 // Fork of https://github.com/floatdrop/require-from-string/blob/master/index.js
 // Copyright (c) Vsevolod Strukchinsky <floatdrop@gmail.com> (github.com/floatdrop)
 // MIT license

--- a/modules/worker-utils/src/lib/node/worker_threads-browser.ts
+++ b/modules/worker-utils/src/lib/node/worker_threads-browser.ts
@@ -1,12 +1,15 @@
-// Browser fills for Node.js built-in `worker_threads` module.
-// These fills are non-functional, and just intended to ensure that
-// `import 'worker_threads` doesn't break browser builds.
-// The replacement is done in package.json browser field
-export class Worker {
+// loaders.gl, MIT license
+// Copyright (c) vis.gl contributors
+
+/** Browser polyfill for Node.js built-in `worker_threads` module.
+ * These fills are non-functional, and just intended to ensure that
+ * `import 'worker_threads` doesn't break browser builds.
+ * The replacement is done in package.json browser field
+ */
+export class NodeWorker {
   terminate() {}
 }
 
-export {Worker as NodeWorker};
-export {Worker as NodeWorkerType};
+export type {NodeWorker as NodeWorkerType};
 
 export const parentPort = null;

--- a/modules/worker-utils/src/lib/node/worker_threads.ts
+++ b/modules/worker-utils/src/lib/node/worker_threads.ts
@@ -3,5 +3,6 @@
 
 import * as WorkerThreads from 'worker_threads';
 export * from 'worker_threads';
+export const parentPort = WorkerThreads?.parentPort;
 export const NodeWorker = WorkerThreads.Worker;
 export type NodeWorkerType = WorkerThreads.Worker;

--- a/modules/worker-utils/src/lib/worker-api/get-worker-url.ts
+++ b/modules/worker-utils/src/lib/worker-api/get-worker-url.ts
@@ -1,6 +1,9 @@
 // loaders.gl, MIT license
 // Copyright (c) vis.gl contributors
 
+// loaders.gl, MIT license
+// Copyright (c) vis.gl contributors
+
 import type {WorkerObject, WorkerOptions} from '../../types';
 import {assert} from '../env-utils/assert';
 import {isBrowser} from '../env-utils/globals';


### PR DESCRIPTION
- Reports of `processOnWorker()` with compression worker failing in Node tests in kepler tools. This is a regression but the confusing thing is that this is a node only test. Looks like this particular browser worker used to work in node in 3.4?

- Regardless, the imported loaders code in kepler is very confusing and hard to debug, with dummy worker object injected instead of worker_threads etc. 
- This is a first attempt to simplify the worker-utils code, step by step.

- I am also just a little bit worried that now that we test node workers from source, and cust the dist tests, we don't get any tests on node workers that have been built.