### PR TITLE
fix: make node workers cjs

### DIFF
--- a/modules/compression/package.json
+++ b/modules/compression/package.json
@@ -43,7 +43,7 @@
     "pre-build": "npm run build-bundle && npm run build-bundle -- --env=dev && npm run build-worker && npm run build-worker-node",
     "build-bundle": "ocular-bundle ./src/index.ts",
     "build-worker": "esbuild src/workers/compression-worker.ts --outfile=dist/compression-worker.js --target=esnext --bundle --minify --sourcemap --external:{fs,path,crypto} --define:__VERSION__=\\\"$npm_package_version\\\"",
-    "build-worker-node": "esbuild src/workers/compression-worker-node.ts --outfile=dist/compression-worker-node.js --platform=node --target=node16 --bundle --minify --sourcemap --define:__VERSION__=\\\"$npm_package_version\\\""
+    "build-worker-node": "esbuild src/workers/compression-worker-node.ts --outfile=dist/compression-worker-node.cjs --platform=node --target=node16 --bundle --minify --sourcemap --define:__VERSION__=\\\"$npm_package_version\\\""
   },
   "dependencies": {
     "@babel/runtime": "^7.3.1",

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -45,7 +45,7 @@
     "pre-build": "npm run build-bundle && npm run build-bundle -- --env=dev && npm run build-worker && npm run build-worker-node",
     "build-bundle": "ocular-bundle ./src/index.ts",
     "build-worker": "esbuild src/workers/null-worker.ts --outfile=dist/null-worker.js --bundle --target=esnext --define:__VERSION__=\\\"$npm_package_version\\\"",
-    "build-worker-node": "esbuild src/workers/null-worker.ts --outfile=dist/null-worker-node.js --bundle --platform=node --target=node16 --define:__VERSION__=\\\"$npm_package_version\\\""
+    "build-worker-node": "esbuild src/workers/null-worker.ts --outfile=dist/null-worker-node.cjs --bundle --platform=node --target=node16 --define:__VERSION__=\\\"$npm_package_version\\\""
   },
   "dependencies": {
     "@babel/runtime": "^7.3.1",

--- a/modules/crypto/package.json
+++ b/modules/crypto/package.json
@@ -38,7 +38,7 @@
     "pre-build": "npm run build-bundle && npm run build-bundle -- --env=dev && npm run build-worker && npm run build-worker-node",
     "build-bundle": "ocular-bundle ./src/index.ts",
     "build-worker": "esbuild src/workers/crypto-worker.ts --outfile=dist/crypto-worker.js --target=esnext --bundle --minify --sourcemap --define:__VERSION__=\\\"$npm_package_version\\\"",
-    "build-worker-node": "esbuild src/workers/crypto-worker-node.ts --outfile=dist/crypto-worker-node.js --platform=node --target=esnext,node16 --bundle --minify --sourcemap --define:__VERSION__=\\\"$npm_package_version\\\""
+    "build-worker-node": "esbuild src/workers/crypto-worker-node.ts --outfile=dist/crypto-worker-node.cjs --platform=node --target=esnext,node16 --bundle --minify --sourcemap --define:__VERSION__=\\\"$npm_package_version\\\""
   },
   "dependencies": {
     "@babel/runtime": "^7.3.1",

--- a/modules/draco/package.json
+++ b/modules/draco/package.json
@@ -45,9 +45,9 @@
     "build-bundle": "ocular-bundle ./src/index.ts",
     "build-workers": "yarn build-loader-worker && yarn build-loader-worker-node && yarn build-writer-worker && yarn build-writer-worker-node",
     "build-loader-worker": "esbuild src/workers/draco-worker.ts --outfile=dist/draco-worker.js --target=esnext --bundle --sourcemap --define:__VERSION__=\\\"$npm_package_version\\\"",
-    "build-loader-worker-node": "esbuild src/workers/draco-worker-node.ts --outfile=dist/draco-worker-node.js --target=node16 --format=esm --platform=node --bundle --sourcemap --define:__VERSION__=\\\"$npm_package_version\\\"",
+    "build-loader-worker-node": "esbuild src/workers/draco-worker-node.ts --outfile=dist/draco-worker-node.cjs --target=node16 --platform=node --bundle --sourcemap --define:__VERSION__=\\\"$npm_package_version\\\"",
     "build-writer-worker": "esbuild src/workers/draco-writer-worker.ts --outfile=dist/draco-writer-worker.js --target=esnext --bundle --sourcemap --define:__VERSION__=\\\"$npm_package_version\\\"",
-    "build-writer-worker-node": "esbuild src/workers/draco-writer-worker-node.ts --outfile=dist/draco-writer-worker-node.js --target=node16 --platform=node --bundle --sourcemap --define:__VERSION__=\\\"$npm_package_version\\\""
+    "build-writer-worker-node": "esbuild src/workers/draco-writer-worker-node.ts --outfile=dist/draco-writer-worker-node.cjs --target=node16 --platform=node --bundle --sourcemap --define:__VERSION__=\\\"$npm_package_version\\\""
   },
   "dependencies": {
     "@babel/runtime": "^7.3.1",

--- a/modules/i3s/package.json
+++ b/modules/i3s/package.json
@@ -38,7 +38,7 @@
     "pre-build": "npm run build-bundle && npm run build-bundle -- --env=dev && npm run build-worker && npm run build-worker-node",
     "build-bundle": "ocular-bundle ./src/index.ts",
     "build-worker": "esbuild src/workers/i3s-content-worker.ts --outfile=dist/i3s-content-worker.js --target=esnext --bundle --define:__VERSION__=\\\"$npm_package_version\\\"",
-    "build-worker-node": "esbuild src/workers/i3s-content-worker-node.ts --outfile=dist/i3s-content-worker-node.js --platform=node --target=node16 --minify --bundle --sourcemap --define:__VERSION__=\\\"$npm_package_version\\\""
+    "build-worker-node": "esbuild src/workers/i3s-content-worker-node.ts --outfile=dist/i3s-content-worker-node.cjs --platform=node --target=node16 --minify --bundle --sourcemap --define:__VERSION__=\\\"$npm_package_version\\\""
   },
   "dependencies": {
     "@loaders.gl/compression": "4.0.3",

--- a/modules/textures/package.json
+++ b/modules/textures/package.json
@@ -45,9 +45,9 @@
     "build-bundle": "ocular-bundle ./src/index.ts",
     "build-workers": "npm run build-basis-worker && npm run build-basis-worker-node && npm run build-npy-worker && npm run build-compressed-texture-worker && npm run build-crunch-worker && npm run build-ktx2-basis-writer-worker && npm run build-ktx2-basis-writer-worker-node",
     "build-basis-worker": "esbuild src/workers/basis-worker.ts --outfile=dist/basis-worker.js --target=esnext --bundle --define:__VERSION__=\\\"$npm_package_version\\\"",
-    "build-basis-worker-node": "esbuild src/workers/basis-worker-node.ts --outfile=dist/basis-worker-node.js --target=node16  --platform=node --bundle --define:__VERSION__=\\\"$npm_package_version\\\"",
+    "build-basis-worker-node": "esbuild src/workers/basis-worker-node.ts --outfile=dist/basis-worker-node.cjs --target=node16  --platform=node --bundle --define:__VERSION__=\\\"$npm_package_version\\\"",
     "build-ktx2-basis-writer-worker": "esbuild src/workers/ktx2-basis-writer-worker.ts --outfile=dist/ktx2-basis-writer-worker.js --target=esnext --bundle --define:__VERSION__=\\\"$npm_package_version\\\"",
-    "build-ktx2-basis-writer-worker-node": "esbuild src/workers/ktx2-basis-writer-worker-node.ts --outfile=dist/ktx2-basis-writer-worker-node.js --target=node16  --platform=node --bundle --define:__VERSION__=\\\"$npm_package_version\\\"",
+    "build-ktx2-basis-writer-worker-node": "esbuild src/workers/ktx2-basis-writer-worker-node.ts --outfile=dist/ktx2-basis-writer-worker-node.cjs --target=node16  --platform=node --bundle --define:__VERSION__=\\\"$npm_package_version\\\"",
     "build-npy-worker": "esbuild src/workers/npy-worker.ts --outfile=dist/npy-worker.js --target=esnext --bundle --define:__VERSION__=\\\"$npm_package_version\\\"",
     "build-compressed-texture-worker": "esbuild src/workers/compressed-texture-worker.ts --target=esnext --bundle --outfile=dist/compressed-texture-worker.js --define:__VERSION__=\\\"$npm_package_version\\\"",
     "build-crunch-worker": "esbuild src/workers/crunch-worker.ts --outfile=dist/crunch-worker.js --target=esnext --bundle --define:__VERSION__=\\\"$npm_package_version\\\""

--- a/modules/tile-converter/src/3d-tiles-converter/3d-tiles-converter.ts
+++ b/modules/tile-converter/src/3d-tiles-converter/3d-tiles-converter.ts
@@ -47,7 +47,7 @@ export default class Tiles3DConverter {
     i3s: {coordinateSystem: COORDINATE_SYSTEM.LNGLAT_OFFSETS, decodeTextures: false},
     // We need to load local fs workers because nodejs can't load workers from the Internet
     'i3s-content': {
-      workerUrl: './modules/i3s/dist/i3s-content-worker-node.js'
+      workerUrl: './modules/i3s/dist/i3s-content-worker-node.cjs'
     }
   };
 

--- a/modules/tile-converter/src/deps-installer/deps-installer.ts
+++ b/modules/tile-converter/src/deps-installer/deps-installer.ts
@@ -37,19 +37,19 @@ export class DepsInstaller {
     await writeFile(depsPath, new Uint8Array(fileMap['geoids/egm2008-5.pgm']), 'egm2008-5.pgm');
 
     console.log('Installing "I3S Content Loader" worker'); // eslint-disable-line no-console
-    await this.installFromNpm('i3s', 'i3s-content-worker-node.js');
+    await this.installFromNpm('i3s', 'i3s-content-worker-node.cjs');
 
     console.log('Installing "Draco Loader" worker'); // eslint-disable-line no-console
-    await this.installFromNpm('draco', 'draco-worker-node.js');
+    await this.installFromNpm('draco', 'draco-worker-node.cjs');
 
     console.log('Installing "Draco Writer" worker'); // eslint-disable-line no-console
-    await this.installFromNpm('draco', 'draco-writer-worker-node.js');
+    await this.installFromNpm('draco', 'draco-writer-worker-node.cjs');
 
     console.log('Installing "Basis Loader" worker'); // eslint-disable-line no-console
-    await this.installFromNpm('textures', 'basis-worker-node.js');
+    await this.installFromNpm('textures', 'basis-worker-node.cjs');
 
     console.log('Installing "KTX2 Basis Writer" worker'); // eslint-disable-line no-console
-    await this.installFromNpm('textures', 'ktx2-basis-writer-worker-node.js');
+    await this.installFromNpm('textures', 'ktx2-basis-writer-worker-node.cjs');
 
     console.log('Installing "Draco decoder" library'); // eslint-disable-line no-console
     await this.installFromUrl(

--- a/modules/tile-converter/src/i3s-converter/helpers/geometry-converter.ts
+++ b/modules/tile-converter/src/i3s-converter/helpers/geometry-converter.ts
@@ -1577,7 +1577,7 @@ async function generateCompressedGeometry(
       },
       ['draco-writer']: {
         // We need to load local fs workers because nodejs can't load workers from the Internet
-        workerUrl: './modules/draco/dist/draco-writer-worker-node.js'
+        workerUrl: './modules/draco/dist/draco-writer-worker-node.cjs'
       }
     }
   );

--- a/modules/tile-converter/src/i3s-converter/i3s-converter.ts
+++ b/modules/tile-converter/src/i3s-converter/i3s-converter.ts
@@ -121,10 +121,10 @@ export default class I3SConverter {
     basis: {
       format: 'rgba32',
       // We need to load local fs workers because nodejs can't load workers from the Internet
-      workerUrl: './modules/textures/dist/basis-worker-node.js'
+      workerUrl: './modules/textures/dist/basis-worker-node.cjs'
     },
     // We need to load local fs workers because nodejs can't load workers from the Internet
-    draco: {workerUrl: './modules/draco/dist/draco-worker-node.js'},
+    draco: {workerUrl: './modules/draco/dist/draco-worker-node.cjs'},
     fetch: {},
     modules: {}
   };
@@ -1027,7 +1027,7 @@ export default class I3SConverter {
                 ...KTX2BasisWriterWorker.options,
                 ['ktx2-basis-writer']: {
                   // We need to load local fs workers because nodejs can't load workers from the Internet
-                  workerUrl: './modules/textures/dist/ktx2-basis-writer-worker-node.js'
+                  workerUrl: './modules/textures/dist/ktx2-basis-writer-worker-node.cjs'
                 },
                 reuseWorkers: true,
                 _nodeWorkers: true,

--- a/modules/worker-utils/package.json
+++ b/modules/worker-utils/package.json
@@ -47,7 +47,7 @@
   "scripts": {
     "pre-build": "npm run build-worker && npm run build-worker-node",
     "build-worker": "esbuild src/workers/null-worker.ts --outfile=dist/null-worker.js --target=esnext --bundle --sourcemap --define:__VERSION__=\\\"$npm_package_version\\\"",
-    "build-worker-node": "esbuild src/workers/null-worker.ts --outfile=dist/null-worker-node.js --platform=node --target=node16 --bundle --sourcemap --define:__VERSION__=\\\"$npm_package_version\\\""
+    "build-worker-node": "esbuild src/workers/null-worker.ts --outfile=dist/null-worker-node.cjs --platform=node --target=node16 --bundle --sourcemap --define:__VERSION__=\\\"$npm_package_version\\\""
   },
   "dependencies": {
     "@babel/runtime": "^7.3.1"

--- a/modules/worker-utils/src/lib/worker-api/get-worker-url.ts
+++ b/modules/worker-utils/src/lib/worker-api/get-worker-url.ts
@@ -27,7 +27,7 @@ export function getWorkerName(worker: WorkerObject): string {
 export function getWorkerURL(worker: WorkerObject, options: WorkerOptions = {}): string {
   const workerOptions = options[worker.id] || {};
 
-  const workerFile = isBrowser ? `${worker.id}-worker.js` : `${worker.id}-worker-node.js`;
+  const workerFile = isBrowser ? `${worker.id}-worker.js` : `${worker.id}-worker-node.cjs`;
 
   let url = workerOptions.workerUrl;
 


### PR DESCRIPTION
Workers fail for the tile-converter after v4.0.3.
```
Worker exception: SyntaxError: Cannot use import statement outside a module
(node:160372) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
```

If we are in the package type: "module", another error come:
```
Worker exception: Error: Dynamic require of "stream" is not supported
```

The solution is to make all node workers with `*.cjs` extension to handle them as common js.