### PR TITLE
Convert GetImageParameters to WMSGetMapParameters

### DIFF
--- a/modules/wms/src/services/ogc/wms-service.ts
+++ b/modules/wms/src/services/ogc/wms-service.ts
@@ -234,8 +234,12 @@ export class WMSSource extends ImageSource<WMSSourceProps> {
   }
 
   async getImage(parameters: GetImageParameters): Promise<ImageType> {
-    // @ts-expect-error
-    return await this.getMap(parameters);
+    const {boundingBox, ...rest} = parameters;
+    const wmsParameters: WMSGetMapParameters = {
+      bbox: [...boundingBox[0], ...boundingBox[1]],
+      ...rest
+    };
+    return await this.getMap(wmsParameters);
   }
 
   normalizeMetadata(capabilities: WMSCapabilities): ImageSourceMetadata {
@@ -495,16 +499,6 @@ export class WMSSource extends ImageSource<WMSSourceProps> {
         // CRS was called SRS before WMS 1.3.0
         if (wmsParameters.version === '1.3.0') {
           key = 'crs';
-        }
-        break;
-
-      case 'boundingBox':
-        // Coordinate order is flipped for certain CRS in WMS 1.3.0
-        const boundingBox = value as [[number, number], [number, number]];
-        let bbox2: number[] | null = [...boundingBox[0], ...boundingBox[1]];
-        bbox2 = this._flipBoundingBox(boundingBox, wmsParameters);
-        if (bbox2) {
-          value = bbox2;
         }
         break;
 

--- a/modules/wms/src/services/ogc/wms-service.ts
+++ b/modules/wms/src/services/ogc/wms-service.ts
@@ -234,6 +234,7 @@ export class WMSSource extends ImageSource<WMSSourceProps> {
   }
 
   async getImage(parameters: GetImageParameters): Promise<ImageType> {
+    // Replace the GetImage `boundingBox` parameter with the WMS flat `bbox` parameter.
     const {boundingBox, ...rest} = parameters;
     const wmsParameters: WMSGetMapParameters = {
       bbox: [...boundingBox[0], ...boundingBox[1]],

--- a/modules/wms/test/services/wms-service.spec.ts
+++ b/modules/wms/test/services/wms-service.spec.ts
@@ -151,3 +151,35 @@ test('WMSSource#fetch override', async (t) => {
     t.end();
   });
 });
+
+test('WMSSource#getImage', async (t) => {
+  const wmsService = new WMSSource({url: WMS_SERVICE_URL});
+  let getMapParameters;
+
+  // @ts-ignore
+  wmsService.getMap = (parameters) => {
+    getMapParameters = parameters;
+  };
+
+  await wmsService.getImage({
+    width: 800,
+    height: 600,
+    boundingBox: [
+      [30, 70],
+      [35, 75]
+    ],
+    layers: ['oms']
+  });
+
+  t.deepEqual(
+    getMapParameters,
+    {
+      width: 800,
+      height: 600,
+      bbox: [30, 70, 35, 75],
+      layers: ['oms']
+    },
+    'boundingBox transformed to bbox'
+  );
+  t.end();
+});


### PR DESCRIPTION
The `WMSLayer` is broken in v9 deck: https://felixpalmer.github.io/deck.gl/examples/wms-layer due to the `ImageSource.getImage` function expecting parameters of the type `GetImageParameters`, while the `WMSService.getImage` function expects `WMSGetMapParameters`. These differ only in the specification of the bounds, with the former using `boundingBox` and the latter `bbox`.

There are different ways this could be resolved but I'm assuming that the intended design is to have a unified `getImage` API and thus here the conversion is being done in `WMSService.getImage`