### PR TITLE
feat(flatgeobuf): Extract arrow compatible schema

### DIFF
--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -9,6 +9,10 @@ Target Release Date: Early 2024
 - New [`GeoArrowLoader`](/docs/modules/arrow/api-reference/geoarrow-loader) supports loading [GeoArrow](/docs/modules/arrow/formats/geoarrow) files.
 - New documentation for [Arrow](/docs/modules/arrow/formats/arrow) and [GeoArrow](/docs/modules/arrow/formats/geoarrow) formats.
 
+**@loaders.gl/flatgeobuf**
+
+- Loading flatgeobuf into a `GeoJSONTable` now extracts a Schema object from the flatgeobuf header, and uses it to infer the types of the columns in the table.
+
 ## v4.0
 
 Release Date: Oct 30, 2023

--- a/modules/flatgeobuf/src/flatgeobuf-loader.ts
+++ b/modules/flatgeobuf/src/flatgeobuf-loader.ts
@@ -1,8 +1,14 @@
+// loaders.gl, MIT license
+// Copyright (c) vis.gl contributors
+
 import type {Loader, LoaderOptions} from '@loaders.gl/loader-utils';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
 const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+
+// FGB\3FGB\1
+const FGB_MAGIC_NUMBER = [0x66, 0x67, 0x62, 0x03, 0x66, 0x67, 0x62, 0x01];
 
 export type FlatGeobufLoaderOptions = LoaderOptions & {
   flatgeobuf?: {
@@ -23,6 +29,7 @@ export const FlatGeobufLoader: Loader<any, any, FlatGeobufLoaderOptions> = {
   extensions: ['fgb'],
   mimeTypes: ['application/octet-stream'],
   category: 'geometry',
+  tests: [new Uint8Array(FGB_MAGIC_NUMBER).buffer],
   options: {
     flatgeobuf: {
       shape: 'geojson-table'

--- a/modules/flatgeobuf/src/index.ts
+++ b/modules/flatgeobuf/src/index.ts
@@ -1,3 +1,6 @@
+// loaders.gl, MIT license
+// Copyright (c) vis.gl contributors
+
 import type {LoaderWithParser} from '@loaders.gl/loader-utils';
 import type {FlatGeobufLoaderOptions} from './flatgeobuf-loader';
 import {FlatGeobufLoader as FlatGeobufWorkerLoader} from './flatgeobuf-loader';

--- a/modules/flatgeobuf/src/lib/get-schema-from-fgb-header.ts
+++ b/modules/flatgeobuf/src/lib/get-schema-from-fgb-header.ts
@@ -1,0 +1,121 @@
+// loaders.gl, MIT license
+// Copyright (c) vis.gl contributors
+
+import type {Schema, Field, DataType} from '@loaders.gl/schema';
+import * as fgb from 'flatgeobuf';
+
+/**
+ * @param fgbHeader
+ * geometryType: GeometryType;
+ * columns: ColumnMeta[] | null;
+ * envelope: Float64Array | null;
+ * featuresCount: number;
+ * indexNodeSize: number;
+ * crs: CrsMeta | null;
+ * title: string | null;
+ * description: string | null;
+ * metadata: string | null;
+ */
+export function getSchemaFromFGBHeader(fgbHeader: fgb.HeaderMeta): Schema {
+  const metadata: Record<string, string> = {
+    title: fgbHeader.title || '',
+    description: fgbHeader.description || '',
+    crs: JSON.stringify(fgbHeader.crs) || '',
+    metadata: fgbHeader.metadata || '',
+    geometryType: String(fgbHeader.geometryType),
+    indexNodeSize: String(fgbHeader.indexNodeSize),
+    featureCount: String(fgbHeader.featuresCount),
+    bounds: fgbHeader.envelope?.join(',') || ''
+  };
+
+  const fields: Field[] = fgbHeader.columns?.map((column) => getFieldFromFGBColumn(column)) || [];
+  return {metadata, fields};
+}
+
+/**
+ * name: string;
+ * type: ColumnType;
+ * title: string | null;
+ * description: string | null;
+ * width: number;
+ * precision: number;
+ * scale: number;
+ * nullable: boolean;
+ * unique: boolean;
+ * primary_key: boolean;
+ */
+function getFieldFromFGBColumn(fgbColumn: fgb.ColumnMeta): Field {
+  const metadata: Record<string, string> = {
+    title: fgbColumn.title || '',
+    description: fgbColumn.description || '',
+    width: String(fgbColumn.width),
+    precision: String(fgbColumn.precision),
+    scale: String(fgbColumn.scale),
+    unique: String(fgbColumn.unique),
+    primary_key: String(fgbColumn.primary_key)
+  };
+
+  return {
+    name: fgbColumn.name,
+    type: getTypeFromFGBType(fgbColumn.type as unknown as fgbColumnType),
+    nullable: fgbColumn.nullable,
+    metadata
+  };
+}
+
+/** Note: fgb.ColumType does not appear to be exported */
+enum fgbColumnType {
+  Byte = 0,
+  UByte = 1,
+  Bool = 2,
+  Short = 3,
+  UShort = 4,
+  Int = 5,
+  UInt = 6,
+  Long = 7,
+  ULong = 8,
+  Float = 9,
+  Double = 10,
+  String = 11,
+  Json = 12,
+  DateTime = 13,
+  Binary = 14
+}
+
+/** Convert FGB types to arrow like types */
+function getTypeFromFGBType(fgbType: fgbColumnType /* fgb.ColumnMeta['type'] */): DataType {
+  switch (fgbType) {
+    case fgbColumnType.Byte:
+      return 'int8';
+    case fgbColumnType.UByte:
+      return 'uint8';
+    case fgbColumnType.Bool:
+      return 'bool';
+    case fgbColumnType.Short:
+      return 'int16';
+    case fgbColumnType.UShort:
+      return 'uint16';
+    case fgbColumnType.Int:
+      return 'int32';
+    case fgbColumnType.UInt:
+      return 'uint32';
+    case fgbColumnType.Long:
+      return 'int64';
+    case fgbColumnType.ULong:
+      return 'uint64';
+    case fgbColumnType.Float:
+      return 'float32';
+    case fgbColumnType.Double:
+      return 'float64';
+    case fgbColumnType.String:
+      return 'utf8';
+    case fgbColumnType.Json:
+      return 'null';
+    case fgbColumnType.DateTime:
+      return 'date-millisecond';
+    case fgbColumnType.Binary:
+      return 'binary';
+    default:
+      return 'null';
+  }
+}

--- a/modules/flatgeobuf/src/lib/parse-flatgeobuf.ts
+++ b/modules/flatgeobuf/src/lib/parse-flatgeobuf.ts
@@ -145,8 +145,8 @@ function parseFlatGeobufInBatchesToBinary(stream, options: FlatGeobufLoaderOptio
 
 /**
  * @todo this does not return proper GeoJSONTable batches
- * @param stream 
- * @param options 
+ * @param stream
+ * @param options
  */
 // eslint-disable-next-line complexity
 async function* parseFlatGeobufInBatchesToGeoJSON(stream, options: FlatGeobufLoaderOptions) {

--- a/modules/flatgeobuf/src/workers/flatgeobuf-worker.ts
+++ b/modules/flatgeobuf/src/workers/flatgeobuf-worker.ts
@@ -1,3 +1,6 @@
+// loaders.gl, MIT license
+// Copyright (c) vis.gl contributors
+
 import {createLoaderWorker} from '@loaders.gl/loader-utils';
 import {FlatGeobufLoader} from '../index';
 

--- a/modules/flatgeobuf/test/flatgeobuf-loader.spec.ts
+++ b/modules/flatgeobuf/test/flatgeobuf-loader.spec.ts
@@ -3,14 +3,17 @@ import {FlatGeobufLoader} from '@loaders.gl/flatgeobuf';
 import {setLoaderOptions, load, loadInBatches} from '@loaders.gl/core';
 
 const FLATGEOBUF_COUNTRIES_DATA_URL = '@loaders.gl/flatgeobuf/test/data/countries.fgb';
+const FGB_METADATA = {"metadata":{"title":"","description":"","crs":"{\"org\":\"EPSG\",\"code\":4326,\"name\":\"WGS 84\",\"description\":null,\"wkt\":\"GEOGCRS[\\\"WGS 84\\\",DATUM[\\\"World Geodetic System 1984\\\",ELLIPSOID[\\\"WGS 84\\\",6378137,298.257223563,LENGTHUNIT[\\\"metre\\\",1]]],PRIMEM[\\\"Greenwich\\\",0,ANGLEUNIT[\\\"degree\\\",0.0174532925199433]],CS[ellipsoidal,2],AXIS[\\\"latitude\\\",north,ORDER[1],ANGLEUNIT[\\\"degree\\\",0.0174532925199433]],AXIS[\\\"longitude\\\",east,ORDER[2],ANGLEUNIT[\\\"degree\\\",0.0174532925199433]],ID[\\\"EPSG\\\",4326]]\",\"code_string\":null}","metadata":"","geometryType":"6","indexNodeSize":"16","featureCount":"179","bounds":""},"fields":[{"name":"id","type":"utf8","nullable":true,"metadata":{"title":"","description":"","width":"-1","precision":"-1","scale":"-1","unique":"false","primary_key":"false"}},{"name":"name","type":"utf8","nullable":true,"metadata":{"title":"","description":"","width":"-1","precision":"-1","scale":"-1","unique":"false","primary_key":"false"}}]}
 
 setLoaderOptions({
   _workerType: 'test'
 });
 
-test('FlatGeobufLoader#load', async (t) => {
+test.only('FlatGeobufLoader#load', async (t) => {
   const geojsonTable = await load(FLATGEOBUF_COUNTRIES_DATA_URL, FlatGeobufLoader, {worker: false});
   t.equal(geojsonTable.features.length, 179);
+  t.equal(geojsonTable.schema.fields.length, 2);
+  t.deepEqual(geojsonTable.schema, FGB_METADATA);
   t.end();
 });
 

--- a/modules/flatgeobuf/test/flatgeobuf-loader.spec.ts
+++ b/modules/flatgeobuf/test/flatgeobuf-loader.spec.ts
@@ -3,7 +3,48 @@ import {FlatGeobufLoader} from '@loaders.gl/flatgeobuf';
 import {setLoaderOptions, load, loadInBatches} from '@loaders.gl/core';
 
 const FLATGEOBUF_COUNTRIES_DATA_URL = '@loaders.gl/flatgeobuf/test/data/countries.fgb';
-const FGB_METADATA = {"metadata":{"title":"","description":"","crs":"{\"org\":\"EPSG\",\"code\":4326,\"name\":\"WGS 84\",\"description\":null,\"wkt\":\"GEOGCRS[\\\"WGS 84\\\",DATUM[\\\"World Geodetic System 1984\\\",ELLIPSOID[\\\"WGS 84\\\",6378137,298.257223563,LENGTHUNIT[\\\"metre\\\",1]]],PRIMEM[\\\"Greenwich\\\",0,ANGLEUNIT[\\\"degree\\\",0.0174532925199433]],CS[ellipsoidal,2],AXIS[\\\"latitude\\\",north,ORDER[1],ANGLEUNIT[\\\"degree\\\",0.0174532925199433]],AXIS[\\\"longitude\\\",east,ORDER[2],ANGLEUNIT[\\\"degree\\\",0.0174532925199433]],ID[\\\"EPSG\\\",4326]]\",\"code_string\":null}","metadata":"","geometryType":"6","indexNodeSize":"16","featureCount":"179","bounds":""},"fields":[{"name":"id","type":"utf8","nullable":true,"metadata":{"title":"","description":"","width":"-1","precision":"-1","scale":"-1","unique":"false","primary_key":"false"}},{"name":"name","type":"utf8","nullable":true,"metadata":{"title":"","description":"","width":"-1","precision":"-1","scale":"-1","unique":"false","primary_key":"false"}}]}
+const FGB_METADATA = {
+  metadata: {
+    title: '',
+    description: '',
+    crs: '{"org":"EPSG","code":4326,"name":"WGS 84","description":null,"wkt":"GEOGCRS[\\"WGS 84\\",DATUM[\\"World Geodetic System 1984\\",ELLIPSOID[\\"WGS 84\\",6378137,298.257223563,LENGTHUNIT[\\"metre\\",1]]],PRIMEM[\\"Greenwich\\",0,ANGLEUNIT[\\"degree\\",0.0174532925199433]],CS[ellipsoidal,2],AXIS[\\"latitude\\",north,ORDER[1],ANGLEUNIT[\\"degree\\",0.0174532925199433]],AXIS[\\"longitude\\",east,ORDER[2],ANGLEUNIT[\\"degree\\",0.0174532925199433]],ID[\\"EPSG\\",4326]]","code_string":null}',
+    metadata: '',
+    geometryType: '6',
+    indexNodeSize: '16',
+    featureCount: '179',
+    bounds: ''
+  },
+  fields: [
+    {
+      name: 'id',
+      type: 'utf8',
+      nullable: true,
+      metadata: {
+        title: '',
+        description: '',
+        width: '-1',
+        precision: '-1',
+        scale: '-1',
+        unique: 'false',
+        primary_key: 'false'
+      }
+    },
+    {
+      name: 'name',
+      type: 'utf8',
+      nullable: true,
+      metadata: {
+        title: '',
+        description: '',
+        width: '-1',
+        precision: '-1',
+        scale: '-1',
+        unique: 'false',
+        primary_key: 'false'
+      }
+    }
+  ]
+};
 
 setLoaderOptions({
   _workerType: 'test'

--- a/modules/flatgeobuf/test/flatgeobuf-loader.spec.ts
+++ b/modules/flatgeobuf/test/flatgeobuf-loader.spec.ts
@@ -50,7 +50,7 @@ setLoaderOptions({
   _workerType: 'test'
 });
 
-test.only('FlatGeobufLoader#load', async (t) => {
+test('FlatGeobufLoader#load', async (t) => {
   const geojsonTable = await load(FLATGEOBUF_COUNTRIES_DATA_URL, FlatGeobufLoader, {worker: false});
   t.equal(geojsonTable.features.length, 179);
   t.equal(geojsonTable.schema.fields.length, 2);


### PR DESCRIPTION
- Extract Schema (metadata and fields) from the FGB HeaderMeta object.
- The geospatial examples on the loaders.gl website will have a schema viewer - gradually making sure that all loaders generate a schema.