### PR TITLE
fix(GeoArrow): handle tessellation error & improve mean centers

### DIFF
--- a/modules/arrow/src/geoarrow/convert-geoarrow-to-binary-geometry.ts
+++ b/modules/arrow/src/geoarrow/convert-geoarrow-to-binary-geometry.ts
@@ -359,7 +359,7 @@ function getBinaryPolygonsFromChunk(
     }
   }
 
-  const triangels = options?.triangulate
+  const triangles = options?.triangulate
     ? getTriangleIndices(geometryIndicies, geomOffset, flatCoordinateArray, nDim)
     : null;
 

--- a/modules/arrow/src/triangulate-on-worker.ts
+++ b/modules/arrow/src/triangulate-on-worker.ts
@@ -22,7 +22,7 @@ export type TriangulateInput = {
 
 /** Result type for operation: 'triangulate' */
 export type TriangulateResult = TriangulateInput & {
-  triangleIndices: Uint32Array;
+  triangleIndices: Uint32Array | null;
 };
 
 /**

--- a/modules/arrow/src/triangulate-on-worker.ts
+++ b/modules/arrow/src/triangulate-on-worker.ts
@@ -22,7 +22,7 @@ export type TriangulateInput = {
 
 /** Result type for operation: 'triangulate' */
 export type TriangulateResult = TriangulateInput & {
-  triangleIndices: Uint32Array | null;
+  triangleIndices?: Uint32Array;
 };
 
 /**

--- a/modules/arrow/src/workers/triangulation-worker.ts
+++ b/modules/arrow/src/workers/triangulation-worker.ts
@@ -35,5 +35,5 @@ function triangulateBatch(data: TriangulateInput): TriangulateResult {
     data.flatCoordinateArray,
     data.nDim
   );
-  return {...data, triangleIndices};
+  return {...data, ...(triangleIndices ? {triangleIndices} : {})};
 }

--- a/modules/arrow/test/geoarrow/convert-geoarrow-to-binary-geometry.spec.ts
+++ b/modules/arrow/test/geoarrow/convert-geoarrow-to-binary-geometry.spec.ts
@@ -342,7 +342,7 @@ async function testGetBinaryGeometriesFromArrow(
 
     t.notEqual(encoding, undefined, 'encoding is not undefined');
     if (geoColumn && encoding) {
-      const options = {calculateCenters: true, triangulate: true};
+      const options = {calculateMeanCenters: true, triangulate: true};
       const binaryData = getBinaryGeometriesFromArrow(geoColumn, encoding, options);
       t.deepEqual(binaryData, expectedBinaryGeometries, 'binary geometries are correct');
     }

--- a/modules/arrow/test/geoarrow/convert-geoarrow-to-binary-geometry.spec.ts
+++ b/modules/arrow/test/geoarrow/convert-geoarrow-to-binary-geometry.spec.ts
@@ -342,7 +342,7 @@ async function testGetBinaryGeometriesFromArrow(
 
     t.notEqual(encoding, undefined, 'encoding is not undefined');
     if (geoColumn && encoding) {
-      const options = {meanCenter: true, triangulate: true};
+      const options = {calculateCenters: true, triangulate: true};
       const binaryData = getBinaryGeometriesFromArrow(geoColumn, encoding, options);
       t.deepEqual(binaryData, expectedBinaryGeometries, 'binary geometries are correct');
     }

--- a/modules/arrow/test/geoarrow/convert-geoarrow-to-binary-geometry.spec.ts
+++ b/modules/arrow/test/geoarrow/convert-geoarrow-to-binary-geometry.spec.ts
@@ -342,7 +342,7 @@ async function testGetBinaryGeometriesFromArrow(
 
     t.notEqual(encoding, undefined, 'encoding is not undefined');
     if (geoColumn && encoding) {
-      const options = {meanCenter: true};
+      const options = {meanCenter: true, triangulate: true};
       const binaryData = getBinaryGeometriesFromArrow(geoColumn, encoding, options);
       t.deepEqual(binaryData, expectedBinaryGeometries, 'binary geometries are correct');
     }


### PR DESCRIPTION
In practice, there are many geoarrow files converted from GeoJson files using `ogr2ogr` containing invalid geometries. For example, polygon ring not closed; self-intersect polygon; multipolygon within `geoarrow.polygon` type arrow file etc. This will cause `earcut()` function to hang or return an empty triangle index. 

Ideally, users should make sure the geoarrow file is correct, and use `ogr2ogr` to fix these invalid geometries e.g. with `-makeValie` or using Sqlite `SELECT ST_MAKEVALID`. However, to prevent hanging or crashing in loader.gl, we catch the possible error in earcut and let deckgl to remove the positions of these invalid polygons for filling polygon props. The option `triangulate: boolean` is also added to allow users to skip polygon tessellation on bulk geometries at loader.gl.

Another fix in this PR is to improve the performance of `getMeanCentersFromGeometry()`, which is too slow on a big dataset for now.