### PR TITLE
GLTF: inline emod function to remove loaders.gl/math dependency

### DIFF
--- a/modules/gltf/package.json
+++ b/modules/gltf/package.json
@@ -45,7 +45,6 @@
     "@loaders.gl/draco": "4.0.4",
     "@loaders.gl/images": "4.0.4",
     "@loaders.gl/loader-utils": "4.0.4",
-    "@loaders.gl/math": "4.0.4",
     "@loaders.gl/textures": "4.0.4",
     "@math.gl/core": "^4.0.0"
   },

--- a/modules/gltf/package.json
+++ b/modules/gltf/package.json
@@ -45,6 +45,7 @@
     "@loaders.gl/draco": "4.0.4",
     "@loaders.gl/images": "4.0.4",
     "@loaders.gl/loader-utils": "4.0.4",
+    "@loaders.gl/math": "4.0.4",
     "@loaders.gl/textures": "4.0.4",
     "@math.gl/core": "^4.0.0"
   },

--- a/modules/gltf/src/lib/extensions/utils/3d-tiles-utils.ts
+++ b/modules/gltf/src/lib/extensions/utils/3d-tiles-utils.ts
@@ -14,7 +14,10 @@ import type {ImageType} from '@loaders.gl/images';
 import {GLTFScenegraph} from '../../api/gltf-scenegraph';
 import {getComponentTypeFromArray} from '../../gltf-utils/gltf-utils';
 import {getImageData} from '@loaders.gl/images';
-import {emod} from '@loaders.gl/math';
+
+function emod(n: number): number {
+  return ((n % 1) + 1) % 1;
+}
 
 export type NumericComponentType =
   | 'INT8'


### PR DESCRIPTION
Without this, importing `@loaders.gl/gltf` fails (e.g. in luma.gl) due to this import: https://github.com/visgl/loaders.gl/blob/master/modules/gltf/src/lib/extensions/utils/3d-tiles-utils.ts#L17