### PR TITLE
fix(tile-converter): trailing slash Removing from path in i3s-server

### DIFF
--- a/modules/tile-converter/src/i3s-server/routes/slpk-router.ts
+++ b/modules/tile-converter/src/i3s-server/routes/slpk-router.ts
@@ -19,7 +19,7 @@ sceneServerRouter.get('*', async function (req, res, next) {
 
 export const router = express.Router();
 router.get('*', async function (req, res, next) {
-  const file = await getFileByUrl(req.path);
+  const file = await getFileByUrl(req.path.replace(/\/+$/, ''));
   if (file) {
     res.send(Buffer.from(file));
   } else {


### PR DESCRIPTION
Some tools request resource using the path with a slash in the end (ex. http://localhost:8081/SceneServer/layers/0/nodepages/0/) and i3s server currently cannot retrieve anything on this path. Current PR contains a small fix for this issue.