### PR TITLE
fix(crypto):  Reuse of Hash instance failures

### DIFF
--- a/modules/crypto/src/lib/crc32-hash.ts
+++ b/modules/crypto/src/lib/crc32-hash.ts
@@ -12,12 +12,10 @@ export class CRC32Hash extends Hash {
   readonly name = 'crc32';
 
   options;
-  private _hash: CRC32;
 
   constructor(options = {}) {
     super();
     this.options = {crypto: {}, ...options};
-    this._hash = new CRC32();
     this.hashBatches = this.hashBatches.bind(this);
   }
 
@@ -30,8 +28,9 @@ export class CRC32Hash extends Hash {
   }
 
   hashSync(input: ArrayBuffer, encoding: 'hex' | 'base64'): string {
-    this._hash.update(input);
-    const digest = this._hash.finalize();
+    const hash = new CRC32();
+    hash.update(input);
+    const digest = hash.finalize();
     return encodeNumber(digest, encoding);
   }
 
@@ -39,12 +38,12 @@ export class CRC32Hash extends Hash {
     asyncIterator: AsyncIterable<ArrayBuffer> | Iterable<ArrayBuffer>,
     encoding: 'hex' | 'base64' = 'base64'
   ): AsyncIterable<ArrayBuffer> {
+    const hash = new CRC32();
     for await (const chunk of asyncIterator) {
-      this._hash.update(chunk);
+      hash.update(chunk);
       yield chunk;
     }
-    const digest = this._hash.finalize();
-    const hash = encodeNumber(digest, encoding);
-    this.options.crypto?.onEnd?.({hash});
+    const digest = hash.finalize();
+    this.options.crypto?.onEnd?.({hash: encodeNumber(digest, encoding)});
   }
 }

--- a/modules/crypto/src/lib/crc32c-hash.ts
+++ b/modules/crypto/src/lib/crc32c-hash.ts
@@ -12,7 +12,6 @@ export class CRC32CHash extends Hash {
   readonly name = 'crc32c';
 
   options;
-  private _hash: CRC32C;
 
   /**
    * Atomic hash calculation
@@ -21,7 +20,6 @@ export class CRC32CHash extends Hash {
   constructor(options = {}) {
     super();
     this.options = {crypto: {}, ...options};
-    this._hash = new CRC32C(options);
   }
 
   /**
@@ -33,8 +31,9 @@ export class CRC32CHash extends Hash {
   }
 
   hashSync(input: ArrayBuffer, encoding: 'hex' | 'base64'): string {
-    this._hash.update(input);
-    const digest = this._hash.finalize();
+    const hash = new CRC32C(this.options);
+    hash.update(input);
+    const digest = hash.finalize();
     return encodeNumber(digest, encoding);
   }
 
@@ -44,12 +43,12 @@ export class CRC32CHash extends Hash {
     asyncIterator: AsyncIterable<ArrayBuffer> | Iterable<ArrayBuffer>,
     encoding: 'hex' | 'base64' = 'base64'
   ): AsyncIterable<ArrayBuffer> {
+    const hash = new CRC32C(this.options);
     for await (const chunk of asyncIterator) {
-      this._hash.update(chunk);
+      hash.update(chunk);
       yield chunk;
     }
-    const digest = this._hash.finalize();
-    const hash = encodeNumber(digest, encoding);
-    this.options.crypto?.onEnd?.({hash});
+    const digest = hash.finalize();
+    this.options.crypto?.onEnd?.({hash: encodeNumber(digest, encoding)});
   }
 }

--- a/modules/crypto/src/lib/crypto-hash.ts
+++ b/modules/crypto/src/lib/crypto-hash.ts
@@ -81,7 +81,7 @@ export class CryptoHash extends Hash {
       hash.update(typedWordArray);
       yield chunk;
     }
-    
+
     // Map our encoding constant to Crypto library
     const enc = encoding === 'base64' ? CryptoJS.enc.Base64 : CryptoJS.enc.Hex;
     const digest = hash.finalize().toString(enc);

--- a/modules/crypto/src/lib/crypto-hash.ts
+++ b/modules/crypto/src/lib/crypto-hash.ts
@@ -18,8 +18,10 @@ export class CryptoHash extends Hash {
   readonly name;
 
   options: CryptoHashOptions;
+  /** Name of digest algorithm */
   private _algorithm;
-  private _hash;
+  /** CryptoJS algorithm */
+  private _algo;
 
   constructor(options: CryptoHashOptions) {
     super();
@@ -38,13 +40,7 @@ export class CryptoHash extends Hash {
     if (!CryptoJS) {
       throw new Error(this.name);
     }
-    if (!this._hash) {
-      const algo = CryptoJS.algo[this._algorithm];
-      this._hash = algo.create();
-    }
-    if (!this._hash) {
-      throw new Error(this.name);
-    }
+    this._algo = CryptoJS.algo[this._algorithm];
   }
 
   /**
@@ -53,12 +49,18 @@ export class CryptoHash extends Hash {
    */
   async hash(input: ArrayBuffer, encoding: 'hex' | 'base64'): Promise<string> {
     await this.preload();
+
+    const hash = this._algo.create();
+    if (!hash) {
+      throw new Error(this.name);
+    }
+
     // arrayBuffer is accepted, even though types and docs say no
     // https://stackoverflow.com/questions/25567468/how-to-decrypt-an-arraybuffer
     const typedWordArray = CryptoJS.lib.WordArray.create(input);
     // Map our encoding constant to Crypto library
     const enc = encoding === 'base64' ? CryptoJS.enc.Base64 : CryptoJS.enc.Hex;
-    return this._hash.update(typedWordArray).finalize().toString(enc);
+    return hash.update(typedWordArray).finalize().toString(enc);
   }
 
   async *hashBatches(
@@ -66,16 +68,23 @@ export class CryptoHash extends Hash {
     encoding: 'hex' | 'base64' = 'base64'
   ): AsyncIterable<ArrayBuffer> {
     await this.preload();
+
+    const hash = this._algo.create();
+    if (!hash) {
+      throw new Error(this.name);
+    }
+
     for await (const chunk of asyncIterator) {
       // arrayBuffer is accepted, even though types and docs say no
       // https://stackoverflow.com/questions/25567468/how-to-decrypt-an-arraybuffer
       const typedWordArray = CryptoJS.lib.WordArray.create(chunk);
-      this._hash.update(typedWordArray);
+      hash.update(typedWordArray);
       yield chunk;
     }
+    
     // Map our encoding constant to Crypto library
     const enc = encoding === 'base64' ? CryptoJS.enc.Base64 : CryptoJS.enc.Hex;
-    const digest = this._hash.finalize().toString(enc);
+    const digest = hash.finalize().toString(enc);
     this.options?.crypto?.onEnd?.({hash: digest});
   }
 }

--- a/modules/crypto/test/crypto.spec.ts
+++ b/modules/crypto/test/crypto.spec.ts
@@ -34,8 +34,7 @@ const TEST_CASES = [
     title: 'binary data (repeated)',
     data: repeatedData,
     digests: {
-      sha256: 'SnGMX2AgkPh21d2sxow8phQa8lh8rjf2Vc7GFCIwj2g='
-      // 'bSCTuOJei5XsmAnqtmm2Aw/2EvUHldNdAxYb3mjSK9s=',
+      sha256: 'bSCTuOJei5XsmAnqtmm2Aw/2EvUHldNdAxYb3mjSK9s='
     }
   }
 ];

--- a/modules/crypto/test/lib/crypto-hash.spec.ts
+++ b/modules/crypto/test/lib/crypto-hash.spec.ts
@@ -69,12 +69,7 @@ test('CryptoHash#hash(MD5 = default)', async (t) => {
   t.equal(hash, 'YnxTb+lyen1CsNkpmLv+qA==', 'binary data MD5 hash is correct');
 
   hash = await cryptoHash.hash(repeatedData, 'base64');
-  t.equal(
-    hash,
-    // '2d4uZUoLXXO/XWJGnrVl5Q==',
-    'uZ5c9e72WDu/VNYYdsg/gg==',
-    'repeated data MD5 hash is correct'
-  );
+  t.equal(hash, '2d4uZUoLXXO/XWJGnrVl5Q==', 'repeated data MD5 hash is correct');
 
   t.end();
 });


### PR DESCRIPTION
Reusing Hash class instances would fail to clear the digest and yield incorrect results.