### PR TITLE
Fix WKT writer encoding

### DIFF
--- a/modules/wkt/src/wkt-writer.ts
+++ b/modules/wkt/src/wkt-writer.ts
@@ -1,7 +1,7 @@
 // loaders.gl, MIT license
 // Copyright (c) vis.gl contributors
 
-import type {Writer, WriterOptions} from '@loaders.gl/loader-utils';
+import type {WriterWithEncoder, WriterOptions} from '@loaders.gl/loader-utils';
 import {VERSION} from './lib/utils/version';
 import {encodeWKT} from './lib/encode-wkt';
 import {Geometry} from '@loaders.gl/schema';
@@ -13,14 +13,15 @@ export type WKTWriterOptions = WriterOptions & {
 /**
  * WKT exporter
  */
-export const WKTWriter: Writer<Geometry, never, WKTWriterOptions> = {
+export const WKTWriter: WriterWithEncoder<Geometry, never, WKTWriterOptions> = {
   name: 'WKT (Well Known Text)',
   id: 'wkt',
   module: 'wkt',
   version: VERSION,
   extensions: ['wkt'],
-  // @ts-expect-error
-  encodeSync: encodeWKT,
+  text: true,
+  encode: async (geometry) => new TextEncoder().encode(encodeWKT(geometry)).buffer,
+  encodeTextSync: encodeWKT,
   options: {
     wkt: {}
   }


### PR DESCRIPTION
The return type of `encodeWKT` is `string`, not `ArrayBuffer` and as a result this encoder wasn't working correctly.