### PR TITLE
chore: Start adopting SPDX license headers

### DIFF
--- a/examples/benchmarks/app-website.tsx
+++ b/examples/benchmarks/app-website.tsx
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import React from 'react';

--- a/examples/benchmarks/app.tsx
+++ b/examples/benchmarks/app.tsx
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import React, {PureComponent} from 'react';

--- a/examples/experimental/3d-tiles-with-cesium/app.js
+++ b/examples/experimental/3d-tiles-with-cesium/app.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /* global Cesium */

--- a/examples/experimental/3d-tiles-with-cesium/tile-parsers.js
+++ b/examples/experimental/3d-tiles-with-cesium/tile-parsers.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /* global Cesium */

--- a/examples/experimental/3d-tiles-with-cesium/tileset-loader.js
+++ b/examples/experimental/3d-tiles-with-cesium/tileset-loader.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /* global Cesium */

--- a/examples/experimental/3d-tiles-with-three.js/app.js
+++ b/examples/experimental/3d-tiles-with-three.js/app.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /* global mapboxgl */ // Imported via <script> tag

--- a/examples/experimental/3d-tiles-with-three.js/mapbox-3d-tiles-layer/mapbox-3d-tiles-layer.js
+++ b/examples/experimental/3d-tiles-with-three.js/mapbox-3d-tiles-layer/mapbox-3d-tiles-layer.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import * as THREE from 'three';

--- a/examples/experimental/3d-tiles-with-three.js/mapbox-3d-tiles-layer/web-mercator.js
+++ b/examples/experimental/3d-tiles-with-three.js/mapbox-3d-tiles-layer/web-mercator.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import * as THREE from 'three';

--- a/examples/experimental/3d-tiles-with-three.js/threejs-3d-tiles/three-tileset.js
+++ b/examples/experimental/3d-tiles-with-three.js/threejs-3d-tiles/three-tileset.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import * as THREE from 'three';

--- a/examples/experimental/3d-tiles-with-three.js/threejs-3d-tiles/tile-header.js
+++ b/examples/experimental/3d-tiles-with-three.js/threejs-3d-tiles/tile-header.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import * as THREE from 'three';

--- a/examples/experimental/3d-tiles-with-three.js/threejs-3d-tiles/tile-parsers.js
+++ b/examples/experimental/3d-tiles-with-three.js/threejs-3d-tiles/tile-parsers.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {load} from '@loaders.gl/core';

--- a/examples/experimental/gltf-with-deck.gl/app.js
+++ b/examples/experimental/gltf-with-deck.gl/app.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import React, {PureComponent} from 'react';

--- a/examples/experimental/gltf-with-deck.gl/environment.js
+++ b/examples/experimental/gltf-with-deck.gl/environment.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {GLTFEnvironment} from '@luma.gl/experimental';

--- a/examples/experimental/gltf-with-deck.gl/file-drop.js
+++ b/examples/experimental/gltf-with-deck.gl/file-drop.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // Add drag and drop functions for given canvas

--- a/examples/experimental/gltf-with-raw-webgl/lib/gl-matrix.js
+++ b/examples/experimental/gltf-with-raw-webgl/lib/gl-matrix.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /**

--- a/examples/experimental/terrain/app.js
+++ b/examples/experimental/terrain/app.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /* eslint-disable max-statements */

--- a/examples/get-started/bundle-with-nextjs/app.ts
+++ b/examples/get-started/bundle-with-nextjs/app.ts
@@ -1,7 +1,9 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 'use client'

--- a/examples/get-started/bundle-with-rollup/app.ts
+++ b/examples/get-started/bundle-with-rollup/app.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {parse} from '@loaders.gl/core';

--- a/examples/get-started/bundle-with-vite/app.ts
+++ b/examples/get-started/bundle-with-vite/app.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {parse} from '@loaders.gl/core';

--- a/examples/get-started/bundle-with-vite/empty.js
+++ b/examples/get-started/bundle-with-vite/empty.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export class Worker {}

--- a/examples/get-started/bundle-with-webpack-4/app.js
+++ b/examples/get-started/bundle-with-webpack-4/app.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {parse} from '@loaders.gl/core';

--- a/examples/get-started/bundle-with-webpack-5/src/index.ts
+++ b/examples/get-started/bundle-with-webpack-5/src/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {parse} from '@loaders.gl/core';

--- a/examples/website/3d-tiles/app.tsx
+++ b/examples/website/3d-tiles/app.tsx
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import React, {PureComponent} from 'react';

--- a/examples/website/3d-tiles/components/control-panel.jsx
+++ b/examples/website/3d-tiles/components/control-panel.jsx
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import styled from 'styled-components';

--- a/examples/website/geospatial/app.tsx
+++ b/examples/website/geospatial/app.tsx
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import React, {useState, useEffect} from 'react';

--- a/examples/website/geospatial/examples.ts
+++ b/examples/website/geospatial/examples.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export const INITIAL_LOADER_NAME = 'GeoParquet';

--- a/examples/website/gltf/app.ts
+++ b/examples/website/gltf/app.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /* eslint-disable camelcase */

--- a/examples/website/gltf/controller.js
+++ b/examples/website/gltf/controller.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {Matrix4} from '@math.gl/core';

--- a/examples/website/gltf/create-gltf-objects.js
+++ b/examples/website/gltf/create-gltf-objects.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // TODO - move to @luma.gl/addons

--- a/examples/website/tiles/app.tsx
+++ b/examples/website/tiles/app.tsx
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import React, {useState, useEffect} from 'react';

--- a/examples/website/tiles/components/control-panel.tsx
+++ b/examples/website/tiles/components/control-panel.tsx
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import styled from 'styled-components';

--- a/examples/website/tiles/components/tile-source-layer.ts
+++ b/examples/website/tiles/components/tile-source-layer.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {CompositeLayer, Layer} from '@deck.gl/core/typed';

--- a/examples/website/tiles/examples.ts
+++ b/examples/website/tiles/examples.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export const LOADERS_URI = 'https://raw.githubusercontent.com/visgl/loaders.gl/master';

--- a/examples/website/wms/app.tsx
+++ b/examples/website/wms/app.tsx
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import React, {PureComponent} from 'react';

--- a/examples/website/wms/examples.ts
+++ b/examples/website/wms/examples.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export const LOADERS_URI = 'https://raw.githubusercontent.com/visgl/loaders.gl/master';

--- a/modules/3d-tiles/src/3d-tiles-archive-loader.ts
+++ b/modules/3d-tiles/src/3d-tiles-archive-loader.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import type {LoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';
 import {DataViewFile} from '@loaders.gl/loader-utils';
 import {parse3DTilesArchive as parse3DTilesArchiveFromProvider} from './3d-tiles-archive/3d-tiles-archive-parser';

--- a/modules/3d-tiles/src/3d-tiles-archive/3d-tiles-archive-archive.ts
+++ b/modules/3d-tiles/src/3d-tiles-archive/3d-tiles-archive-archive.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import {FileProvider} from '@loaders.gl/loader-utils';
 import {MD5Hash} from '@loaders.gl/crypto';
 import {DeflateCompression, NoCompression} from '@loaders.gl/compression';

--- a/modules/3d-tiles/src/3d-tiles-archive/3d-tiles-archive-parser.ts
+++ b/modules/3d-tiles/src/3d-tiles-archive/3d-tiles-archive-parser.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import {FileProvider} from '@loaders.gl/loader-utils';
 import {
   CD_HEADER_SIGNATURE,

--- a/modules/3d-tiles/src/cesium-ion-loader.ts
+++ b/modules/3d-tiles/src/cesium-ion-loader.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import type {LoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';
 import {Tiles3DLoader} from './tiles-3d-loader';
 import {getIonTilesetMetadata} from './lib/ion/ion';

--- a/modules/3d-tiles/src/index.ts
+++ b/modules/3d-tiles/src/index.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 // LOADERS
 export {Tiles3DLoader} from './tiles-3d-loader';
 export {CesiumIonLoader} from './cesium-ion-loader';

--- a/modules/3d-tiles/src/lib/classes/helpers/tile-3d-accessor-utils.ts
+++ b/modules/3d-tiles/src/lib/classes/helpers/tile-3d-accessor-utils.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import {GLType} from '@loaders.gl/math'; // '@math.gl/geometry';
 import {assert} from '@loaders.gl/loader-utils';
 

--- a/modules/3d-tiles/src/lib/classes/tile-3d-batch-table-hierarchy.ts
+++ b/modules/3d-tiles/src/lib/classes/tile-3d-batch-table-hierarchy.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
 // This file is derived from the Cesium code base under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 

--- a/modules/3d-tiles/src/lib/classes/tile-3d-batch-table.ts
+++ b/modules/3d-tiles/src/lib/classes/tile-3d-batch-table.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
 // This file is derived from the Cesium code base under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 

--- a/modules/3d-tiles/src/lib/classes/tile-3d-feature-table.ts
+++ b/modules/3d-tiles/src/lib/classes/tile-3d-feature-table.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
 // This file is derived from the Cesium code base under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 

--- a/modules/3d-tiles/src/lib/constants.ts
+++ b/modules/3d-tiles/src/lib/constants.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 // TILE TYPES
 
 export const TILE3D_TYPE = {

--- a/modules/3d-tiles/src/lib/encoders/encode-3d-tile-batched-model.ts
+++ b/modules/3d-tiles/src/lib/encoders/encode-3d-tile-batched-model.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
 // This file is derived from the Cesium code base under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 

--- a/modules/3d-tiles/src/lib/encoders/encode-3d-tile-composite.ts
+++ b/modules/3d-tiles/src/lib/encoders/encode-3d-tile-composite.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
 // This file is derived from the Cesium code base under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 

--- a/modules/3d-tiles/src/lib/encoders/encode-3d-tile-instanced-model.ts
+++ b/modules/3d-tiles/src/lib/encoders/encode-3d-tile-instanced-model.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
 // This file is derived from the Cesium code base under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 

--- a/modules/3d-tiles/src/lib/encoders/encode-3d-tile-point-cloud.ts
+++ b/modules/3d-tiles/src/lib/encoders/encode-3d-tile-point-cloud.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
 // This file is derived from the Cesium code base under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 

--- a/modules/3d-tiles/src/lib/encoders/encode-3d-tile.ts
+++ b/modules/3d-tiles/src/lib/encoders/encode-3d-tile.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
 // This file is derived from the Cesium code base under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 

--- a/modules/3d-tiles/src/lib/encoders/helpers/encode-3d-tile-header.ts
+++ b/modules/3d-tiles/src/lib/encoders/helpers/encode-3d-tile-header.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 // HELPER ENCODERS
 import {assert} from '@loaders.gl/loader-utils';
 

--- a/modules/3d-tiles/src/lib/filesystems/tiles-3d-archive-file-system.ts
+++ b/modules/3d-tiles/src/lib/filesystems/tiles-3d-archive-file-system.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import {FileProvider} from '@loaders.gl/loader-utils';
 import {
   ZipFileSystem,

--- a/modules/3d-tiles/src/lib/ion/ion.ts
+++ b/modules/3d-tiles/src/lib/ion/ion.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 // Minimal support to load tilsets from the Cesium ION services
 
 import {fetchFile} from '@loaders.gl/core';

--- a/modules/3d-tiles/src/lib/parsers/helpers/normalize-3d-tile-colors.ts
+++ b/modules/3d-tiles/src/lib/parsers/helpers/normalize-3d-tile-colors.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import {Tile3DBatchTable} from '@loaders.gl/3d-tiles';
 import {decodeRGB565, GL} from '@loaders.gl/math';
 import {Tiles3DTileContent} from '../../../types';

--- a/modules/3d-tiles/src/lib/parsers/helpers/normalize-3d-tile-normals.ts
+++ b/modules/3d-tiles/src/lib/parsers/helpers/normalize-3d-tile-normals.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import {Vector3} from '@math.gl/core';
 import {GL, octDecode} from '@loaders.gl/math';
 import {Tiles3DTileContent} from '../../../types';

--- a/modules/3d-tiles/src/lib/parsers/helpers/normalize-3d-tile-positions.ts
+++ b/modules/3d-tiles/src/lib/parsers/helpers/normalize-3d-tile-positions.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import {Vector3} from '@math.gl/core';
 import {GL} from '@loaders.gl/math';
 

--- a/modules/3d-tiles/src/lib/parsers/helpers/parse-3d-implicit-tiles.ts
+++ b/modules/3d-tiles/src/lib/parsers/helpers/parse-3d-implicit-tiles.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import type {Availability, Tile3DBoundingVolume, Subtree} from '../../../types';
 import {Tile3DSubtreeLoader} from '../../../tile-3d-subtree-loader';
 import {load} from '@loaders.gl/core';

--- a/modules/3d-tiles/src/lib/parsers/helpers/parse-3d-tile-gltf-view.ts
+++ b/modules/3d-tiles/src/lib/parsers/helpers/parse-3d-tile-gltf-view.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
 // This file is derived from the Cesium code base under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 

--- a/modules/3d-tiles/src/lib/parsers/helpers/parse-3d-tile-header.ts
+++ b/modules/3d-tiles/src/lib/parsers/helpers/parse-3d-tile-header.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
 // This file is derived from the Cesium code base under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 

--- a/modules/3d-tiles/src/lib/parsers/helpers/parse-3d-tile-subtree.ts
+++ b/modules/3d-tiles/src/lib/parsers/helpers/parse-3d-tile-subtree.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import type {Subtree, Availability} from '../../../types';
 import type {LoaderContext, LoaderOptions} from '@loaders.gl/loader-utils';
 

--- a/modules/3d-tiles/src/lib/parsers/helpers/parse-3d-tile-tables.ts
+++ b/modules/3d-tiles/src/lib/parsers/helpers/parse-3d-tile-tables.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
 // This file is derived from the Cesium code base under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 

--- a/modules/3d-tiles/src/lib/parsers/helpers/parse-utils.ts
+++ b/modules/3d-tiles/src/lib/parsers/helpers/parse-utils.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
 // This file is derived from the Cesium code base under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 

--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile-batched-model.ts
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile-batched-model.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
 // This file is derived from the Cesium code base under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 

--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile-composite.ts
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile-composite.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
 // This file is derived from the Cesium code base under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 

--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile-gltf.ts
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile-gltf.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT license
 // Copyright (c) vis.gl contributors
 
 import {parseFromContext, LoaderContext} from '@loaders.gl/loader-utils';

--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile-header.ts
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile-header.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import type {Tiles3DLoaderOptions} from '../../tiles-3d-loader';
 import type {LoaderOptions} from '@loaders.gl/loader-utils';
 import {path} from '@loaders.gl/loader-utils';

--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile-instanced-model.ts
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile-instanced-model.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
 // This file is derived from the Cesium code base under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 

--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile-point-cloud.ts
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile-point-cloud.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
 // This file is derived from the Cesium code base under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 

--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile.ts
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
 // This file is derived from the Cesium code base under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 

--- a/modules/3d-tiles/src/lib/utils/obb/s2-corners-to-obb.ts
+++ b/modules/3d-tiles/src/lib/utils/obb/s2-corners-to-obb.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import {Vector3} from '@math.gl/core';
 import {OrientedBoundingBox, makeOrientedBoundingBoxFromPoints} from '@math.gl/culling';
 

--- a/modules/3d-tiles/src/lib/utils/s2/converters/s2-to-boundary.ts
+++ b/modules/3d-tiles/src/lib/utils/s2/converters/s2-to-boundary.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import type {S2Cell} from '../s2geometry/s2-geometry';
 import {IJToST, STToUV, FaceUVToXYZ, XYZToLngLat} from '../s2geometry/s2-geometry';
 

--- a/modules/3d-tiles/src/lib/utils/s2/converters/s2-to-obb-points.ts
+++ b/modules/3d-tiles/src/lib/utils/s2/converters/s2-to-obb-points.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import {getS2Cell} from '../s2geometry/s2-cell-utils';
 import {getS2Region} from './s2-to-region';
 import {Vector3} from '@math.gl/core';

--- a/modules/3d-tiles/src/lib/utils/s2/converters/s2-to-region.ts
+++ b/modules/3d-tiles/src/lib/utils/s2/converters/s2-to-region.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import type {S2Cell} from '../s2geometry/s2-geometry';
 import {getS2BoundaryFlatFromS2Cell} from './s2-to-boundary';
 import {getS2Cell} from '../s2geometry/s2-cell-utils';

--- a/modules/3d-tiles/src/lib/utils/s2/index.ts
+++ b/modules/3d-tiles/src/lib/utils/s2/index.ts
@@ -1,4 +1,6 @@
-// math.gl MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
 
 export {getS2CellIdFromToken, getS2TokenFromCellId, getS2ChildCellId} from './s2-token-functions';
 export {getS2BoundaryFlat, getS2LngLat} from './s2-geometry-functions';

--- a/modules/3d-tiles/src/lib/utils/s2/s2-geometry-functions.ts
+++ b/modules/3d-tiles/src/lib/utils/s2/s2-geometry-functions.ts
@@ -1,4 +1,6 @@
-// math.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
 
 import {getS2BoundaryFlatFromS2Cell} from './converters/s2-to-boundary';
 import {getS2LngLatFromS2Cell} from './s2geometry/s2-geometry';

--- a/modules/3d-tiles/src/lib/utils/s2/s2-token-functions.ts
+++ b/modules/3d-tiles/src/lib/utils/s2/s2-token-functions.ts
@@ -1,5 +1,6 @@
-// loaders.gl, MIT license
-// Copyright (c) vis.gl contributors
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
 
 import Long from 'long';
 

--- a/modules/3d-tiles/src/lib/utils/s2/s2geometry/s2-cell-utils.ts
+++ b/modules/3d-tiles/src/lib/utils/s2/s2geometry/s2-cell-utils.ts
@@ -1,4 +1,6 @@
-// math.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
 
 import type {S2Cell} from './s2-geometry';
 import {getS2CellFromQuadKey, getS2QuadkeyFromCellId} from './s2-geometry';

--- a/modules/3d-tiles/src/lib/utils/s2/s2geometry/s2-geometry.ts
+++ b/modules/3d-tiles/src/lib/utils/s2/s2geometry/s2-geometry.ts
@@ -1,4 +1,7 @@
-// math.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT AND ISC
+// Copyright vis.gl contributors
+
 /*
 Adapted from s2-geometry under ISC License (ISC)
 Copyright (c) 2012-2016, Jon Atkins <github@jonatkins.com>

--- a/modules/3d-tiles/src/tile-3d-subtree-loader.ts
+++ b/modules/3d-tiles/src/tile-3d-subtree-loader.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import type {LoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';
 import type {Subtree} from './types';
 import parse3DTilesSubtree from './lib/parsers/helpers/parse-3d-tile-subtree';

--- a/modules/3d-tiles/src/tile-3d-writer.ts
+++ b/modules/3d-tiles/src/tile-3d-writer.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import type {WriterWithEncoder, WriterOptions} from '@loaders.gl/loader-utils';
 import {VERSION} from './lib/utils/version';
 import encode3DTile from './lib/encoders/encode-3d-tile';

--- a/modules/3d-tiles/src/tiles-3d-loader.ts
+++ b/modules/3d-tiles/src/tiles-3d-loader.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import type {LoaderWithParser, LoaderOptions, LoaderContext} from '@loaders.gl/loader-utils';
 // / import type { GLTFLoaderOptions } from '@loaders.gl/gltf';
 import type {DracoLoaderOptions} from '@loaders.gl/draco';

--- a/modules/3d-tiles/src/types.ts
+++ b/modules/3d-tiles/src/types.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import type {GLTFPostprocessed, FeatureTableJson} from '@loaders.gl/gltf';
 export type {FeatureTableJson};
 

--- a/modules/3d-tiles/test/index.ts
+++ b/modules/3d-tiles/test/index.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import './lib/classes/tile-3d-feature-table.spec';
 import './lib/classes/tile-3d-batch-table.spec';
 

--- a/modules/3d-tiles/test/lib/classes/tile-3d-batch-table-hierarchy.spec.ts
+++ b/modules/3d-tiles/test/lib/classes/tile-3d-batch-table-hierarchy.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
 /* eslint-disable camelcase */
 // @ts-nocheck
 import test from 'tape-promise/tape';

--- a/modules/3d-tiles/test/lib/classes/tile-3d-batch-table.spec.ts
+++ b/modules/3d-tiles/test/lib/classes/tile-3d-batch-table.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
 import test from 'tape-promise/tape';
 import {Tile3DBatchTable} from '@loaders.gl/3d-tiles';
 import {concatTypedArrays} from '@loaders.gl/math'; // '@math.gl/geometry';

--- a/modules/3d-tiles/test/lib/classes/tile-3d-feature-table.spec.ts
+++ b/modules/3d-tiles/test/lib/classes/tile-3d-feature-table.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
 import test from 'tape-promise/tape';
 import {Tile3DFeatureTable} from '@loaders.gl/3d-tiles';
 import {GL} from '@loaders.gl/math'; // '@math.gl/geometry';

--- a/modules/3d-tiles/test/lib/parsers/batched-model-3d-tile.spec.ts
+++ b/modules/3d-tiles/test/lib/parsers/batched-model-3d-tile.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
 // This file is derived from the Cesium code base under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 

--- a/modules/3d-tiles/test/lib/parsers/composite-3d-tile.spec.ts
+++ b/modules/3d-tiles/test/lib/parsers/composite-3d-tile.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
 // This file is derived from the Cesium code base under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 

--- a/modules/3d-tiles/test/lib/parsers/helpers/gpu-memory-usage.spec.ts
+++ b/modules/3d-tiles/test/lib/parsers/helpers/gpu-memory-usage.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 /* eslint-disable max-len */
 import test from 'tape-promise/tape';
 import {load} from '@loaders.gl/core';

--- a/modules/3d-tiles/test/lib/parsers/helpers/normalize-3d-tile-colors.spec.ts
+++ b/modules/3d-tiles/test/lib/parsers/helpers/normalize-3d-tile-colors.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 /* eslint-disable max-len */
 import test from 'tape-promise/tape';
 import {GL} from '@loaders.gl/math';

--- a/modules/3d-tiles/test/lib/parsers/instanced-model-3d-tile.spec.ts
+++ b/modules/3d-tiles/test/lib/parsers/instanced-model-3d-tile.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
 // This file is derived from the Cesium code base under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 

--- a/modules/3d-tiles/test/lib/parsers/parse-3d-tile-header.spec.ts
+++ b/modules/3d-tiles/test/lib/parsers/parse-3d-tile-header.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import test from 'tape-promise/tape';
 
 import {normalizeTileData} from '../../../src/lib/parsers/parse-3d-tile-header';

--- a/modules/3d-tiles/test/lib/parsers/point-cloud-3d-tile.spec.ts
+++ b/modules/3d-tiles/test/lib/parsers/point-cloud-3d-tile.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
 // This file is derived from the Cesium code base under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 

--- a/modules/3d-tiles/test/lib/styles/conditions-expression.spec.ts
+++ b/modules/3d-tiles/test/lib/styles/conditions-expression.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
 // This file is derived from the Cesium code base under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 

--- a/modules/3d-tiles/test/lib/styles/expression.spec.ts
+++ b/modules/3d-tiles/test/lib/styles/expression.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
 // This file is derived from the Cesium code base under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 

--- a/modules/3d-tiles/test/lib/styles/index.ts
+++ b/modules/3d-tiles/test/lib/styles/index.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
 import './expression.spec';
 import './conditions-expression.spec';
 import 'tile-3d-style.spec';

--- a/modules/3d-tiles/test/lib/styles/tile-3d-style.spec.ts
+++ b/modules/3d-tiles/test/lib/styles/tile-3d-style.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
 // This file is derived from the Cesium code base under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 

--- a/modules/3d-tiles/test/lib/utils/load-utils.ts
+++ b/modules/3d-tiles/test/lib/utils/load-utils.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
 // This file is derived from the Cesium code base under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 

--- a/modules/3d-tiles/test/tile-3d-subtree-loader.spec.ts
+++ b/modules/3d-tiles/test/tile-3d-subtree-loader.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT and Apache-2.0
+// Copyright vis.gl contributors
+
 // This file is derived from the Cesium code base under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 

--- a/modules/3d-tiles/test/tiles-3d-archive-loaders.spec.js
+++ b/modules/3d-tiles/test/tiles-3d-archive-loaders.spec.js
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import test from 'tape-promise/tape';
 import {load} from '@loaders.gl/core';
 import {Tiles3DArchiveFileLoader} from '../src';

--- a/modules/3d-tiles/test/tiles-3d-loader.spec.ts
+++ b/modules/3d-tiles/test/tiles-3d-loader.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
 // This file is derived from the Cesium code base under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 

--- a/modules/arrow/src/arrow-loader.ts
+++ b/modules/arrow/src/arrow-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Loader, LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/arrow/src/geoarrow-loader.ts
+++ b/modules/arrow/src/geoarrow-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Loader, LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/arrow/src/geoarrow/convert-geoarrow-to-binary-geometry.ts
+++ b/modules/arrow/src/geoarrow/convert-geoarrow-to-binary-geometry.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import * as arrow from 'apache-arrow';

--- a/modules/arrow/src/geoarrow/convert-geoarrow-to-geojson-geometry.ts
+++ b/modules/arrow/src/geoarrow/convert-geoarrow-to-geojson-geometry.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // import * as arrow from 'apache-arrow';

--- a/modules/arrow/src/geoarrow/get-arrow-bounds.ts
+++ b/modules/arrow/src/geoarrow/get-arrow-bounds.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /**

--- a/modules/arrow/src/index.ts
+++ b/modules/arrow/src/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {ArrowLoaderOptions} from './arrow-loader';

--- a/modules/arrow/src/lib/arrow-table-batch.ts
+++ b/modules/arrow/src/lib/arrow-table-batch.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {ColumnarTableBatchAggregator} from '@loaders.gl/schema';

--- a/modules/arrow/src/lib/arrow-table.ts
+++ b/modules/arrow/src/lib/arrow-table.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Batch, Schema} from '@loaders.gl/schema';

--- a/modules/arrow/src/lib/encode-arrow.ts
+++ b/modules/arrow/src/lib/encode-arrow.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import * as arrow from 'apache-arrow';

--- a/modules/arrow/src/lib/encode-geoarrow.ts
+++ b/modules/arrow/src/lib/encode-geoarrow.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import * as arrow from 'apache-arrow';

--- a/modules/arrow/src/parsers/parse-arrow-in-batches.ts
+++ b/modules/arrow/src/parsers/parse-arrow-in-batches.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {ArrowTableBatch} from '../lib/arrow-table';

--- a/modules/arrow/src/parsers/parse-arrow-sync.ts
+++ b/modules/arrow/src/parsers/parse-arrow-sync.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {ArrayRowTable, ColumnarTable, ObjectRowTable} from '@loaders.gl/schema';

--- a/modules/arrow/src/parsers/parse-geoarrow-in-batches.ts
+++ b/modules/arrow/src/parsers/parse-geoarrow-in-batches.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {GeoJSONTableBatch} from '@loaders.gl/schema';

--- a/modules/arrow/src/parsers/parse-geoarrow-sync.ts
+++ b/modules/arrow/src/parsers/parse-geoarrow-sync.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {GeoJSONTable} from '@loaders.gl/schema';

--- a/modules/arrow/src/schema/arrow-type-utils.ts
+++ b/modules/arrow/src/schema/arrow-type-utils.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {TypedArray} from '@loaders.gl/schema';

--- a/modules/arrow/src/schema/convert-arrow-schema.ts
+++ b/modules/arrow/src/schema/convert-arrow-schema.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {DataType, Field, Schema, SchemaMetadata} from '@loaders.gl/schema';

--- a/modules/arrow/src/tables/convert-arrow-to-columnar-table.ts
+++ b/modules/arrow/src/tables/convert-arrow-to-columnar-table.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {ColumnarTable} from '@loaders.gl/schema';

--- a/modules/arrow/src/tables/convert-arrow-to-geojson-table.ts
+++ b/modules/arrow/src/tables/convert-arrow-to-geojson-table.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Feature, GeoJSONTable} from '@loaders.gl/schema';

--- a/modules/arrow/src/tables/convert-columnar-to-row-table.ts
+++ b/modules/arrow/src/tables/convert-columnar-to-row-table.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {ColumnarTable, ObjectRowTable} from '@loaders.gl/schema';

--- a/modules/arrow/src/tables/convert-table-to-arrow.ts
+++ b/modules/arrow/src/tables/convert-table-to-arrow.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // import {

--- a/modules/arrow/src/triangulate-on-worker.ts
+++ b/modules/arrow/src/triangulate-on-worker.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import * as arrow from 'apache-arrow';

--- a/modules/arrow/src/types.ts
+++ b/modules/arrow/src/types.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 type TypedIntArray = Int8Array | Uint8Array | Int16Array | Uint16Array | Int32Array | Uint32Array;

--- a/modules/arrow/src/workers/arrow-worker.ts
+++ b/modules/arrow/src/workers/arrow-worker.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {createLoaderWorker} from '@loaders.gl/loader-utils';

--- a/modules/arrow/src/workers/triangulation-worker-node.ts
+++ b/modules/arrow/src/workers/triangulation-worker-node.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import './triangulation-worker';

--- a/modules/arrow/src/workers/triangulation-worker.ts
+++ b/modules/arrow/src/workers/triangulation-worker.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import * as arrow from 'apache-arrow';

--- a/modules/arrow/test/arrow-loader.spec.ts
+++ b/modules/arrow/test/arrow-loader.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/arrow/test/arrow-writer.spec.ts
+++ b/modules/arrow/test/arrow-writer.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/arrow/test/geoarrow/convert-geoarrow-to-binary-geometry.spec.ts
+++ b/modules/arrow/test/geoarrow/convert-geoarrow-to-binary-geometry.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test, {Test} from 'tape-promise/tape';

--- a/modules/arrow/test/geoarrow/convert-geoarrow-to-geojson.spec.ts
+++ b/modules/arrow/test/geoarrow/convert-geoarrow-to-geojson.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test, {Test} from 'tape-promise/tape';

--- a/modules/arrow/test/geoarrow/get-arrow-bounds.spec.ts
+++ b/modules/arrow/test/geoarrow/get-arrow-bounds.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/arrow/test/index.ts
+++ b/modules/arrow/test/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import './arrow-loader.spec';

--- a/modules/arrow/test/tables/convert-arrow-to-geojson-table.spec.ts
+++ b/modules/arrow/test/tables/convert-arrow-to-geojson-table.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test, {Test} from 'tape-promise/tape';

--- a/modules/arrow/test/triangulate-on-worker.spec.ts
+++ b/modules/arrow/test/triangulate-on-worker.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import * as arrow from 'apache-arrow';

--- a/modules/bson/src/bson-loader.ts
+++ b/modules/bson/src/bson-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 import type {LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';
 import type {ParseBSONOptions} from './lib/parsers/parse-bson';

--- a/modules/bson/src/bson-writer.ts
+++ b/modules/bson/src/bson-writer.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {WriterWithEncoder, WriterOptions} from '@loaders.gl/loader-utils';

--- a/modules/bson/src/index.ts
+++ b/modules/bson/src/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export type {BSONLoaderOptions} from './bson-loader';

--- a/modules/bson/src/lib/encoders/encode-bson.ts
+++ b/modules/bson/src/lib/encoders/encode-bson.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {SerializeOptions} from 'bson';

--- a/modules/bson/src/lib/parsers/parse-bson.ts
+++ b/modules/bson/src/lib/parsers/parse-bson.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {DeserializeOptions} from 'bson';

--- a/modules/bson/test/bson-loader.bench.ts
+++ b/modules/bson/test/bson-loader.bench.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {BSONLoader} from '@loaders.gl/bson';

--- a/modules/bson/test/bson-loader.spec.ts
+++ b/modules/bson/test/bson-loader.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/bson/test/data/js-bson/corrupt.ts
+++ b/modules/bson/test/data/js-bson/corrupt.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 export default {
   description: 'Corrupted BSON',

--- a/modules/core/src/core-addons/write-file-browser.ts
+++ b/modules/core/src/core-addons/write-file-browser.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // A browser implementation of the Node.js `fs` module's `fs.writeFile` method.

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // TYPES

--- a/modules/core/src/iterators/batch-iterators/timed-batch-iterator.ts
+++ b/modules/core/src/iterators/batch-iterators/timed-batch-iterator.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /**

--- a/modules/core/src/iterators/make-iterator/make-array-buffer-iterator.ts
+++ b/modules/core/src/iterators/make-iterator/make-array-buffer-iterator.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {IteratorOptions} from './make-iterator';

--- a/modules/core/src/iterators/make-iterator/make-blob-iterator.ts
+++ b/modules/core/src/iterators/make-iterator/make-blob-iterator.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {IteratorOptions} from './make-iterator';

--- a/modules/core/src/iterators/make-iterator/make-iterator.ts
+++ b/modules/core/src/iterators/make-iterator/make-iterator.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {ReadStream} from 'fs';

--- a/modules/core/src/iterators/make-iterator/make-stream-iterator.ts
+++ b/modules/core/src/iterators/make-iterator/make-stream-iterator.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Readable} from 'stream';

--- a/modules/core/src/iterators/make-iterator/make-string-iterator.ts
+++ b/modules/core/src/iterators/make-iterator/make-string-iterator.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {IteratorOptions} from './make-iterator';

--- a/modules/core/src/iterators/make-stream/make-stream.ts
+++ b/modules/core/src/iterators/make-stream/make-stream.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export type MakeStreamOptions = {

--- a/modules/core/src/javascript-utils/is-type.ts
+++ b/modules/core/src/javascript-utils/is-type.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Readable} from 'stream';

--- a/modules/core/src/lib/api/encode-table.ts
+++ b/modules/core/src/lib/api/encode-table.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Copyright 2022 Foursquare Labs, Inc
 

--- a/modules/core/src/lib/api/encode.ts
+++ b/modules/core/src/lib/api/encode.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {WriterOptions, WriterWithEncoder, canEncodeWithWorker} from '@loaders.gl/loader-utils';

--- a/modules/core/src/lib/api/load-in-batches.ts
+++ b/modules/core/src/lib/api/load-in-batches.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {

--- a/modules/core/src/lib/api/load.ts
+++ b/modules/core/src/lib/api/load.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {DataType, Loader, LoaderContext, LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/core/src/lib/api/loader-options.ts
+++ b/modules/core/src/lib/api/loader-options.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export {setGlobalOptions as setLoaderOptions} from '../loader-utils/option-utils';

--- a/modules/core/src/lib/api/parse-in-batches.ts
+++ b/modules/core/src/lib/api/parse-in-batches.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {isTable, makeBatchFromTable, type Batch} from '@loaders.gl/schema';

--- a/modules/core/src/lib/api/parse-sync.ts
+++ b/modules/core/src/lib/api/parse-sync.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Loader, LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/core/src/lib/api/parse.ts
+++ b/modules/core/src/lib/api/parse.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Loader, LoaderContext, LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/core/src/lib/api/register-loaders.ts
+++ b/modules/core/src/lib/api/register-loaders.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {Loader} from '@loaders.gl/loader-utils';

--- a/modules/core/src/lib/api/select-loader.ts
+++ b/modules/core/src/lib/api/select-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {LoaderContext, LoaderOptions, Loader} from '@loaders.gl/loader-utils';

--- a/modules/core/src/lib/common.ts
+++ b/modules/core/src/lib/common.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export type {LoaderWithParser} from '@loaders.gl/loader-utils';

--- a/modules/core/src/lib/fetch/fetch-error-message.ts
+++ b/modules/core/src/lib/fetch/fetch-error-message.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export function getErrorMessageFromResponseSync(response: Response): string {

--- a/modules/core/src/lib/fetch/fetch-file.ts
+++ b/modules/core/src/lib/fetch/fetch-file.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {resolvePath} from '@loaders.gl/loader-utils';

--- a/modules/core/src/lib/fetch/read-array-buffer.ts
+++ b/modules/core/src/lib/fetch/read-array-buffer.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /**

--- a/modules/core/src/lib/filesystems/browser-filesystem.ts
+++ b/modules/core/src/lib/filesystems/browser-filesystem.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {FileSystem, ReadableFile} from '@loaders.gl/loader-utils';

--- a/modules/core/src/lib/filesystems/read-array-buffer.ts
+++ b/modules/core/src/lib/filesystems/read-array-buffer.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /**

--- a/modules/core/src/lib/init.ts
+++ b/modules/core/src/lib/init.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {log} from './utils/log';

--- a/modules/core/src/lib/loader-utils/check-errors.ts
+++ b/modules/core/src/lib/loader-utils/check-errors.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /**

--- a/modules/core/src/lib/loader-utils/get-data.ts
+++ b/modules/core/src/lib/loader-utils/get-data.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {

--- a/modules/core/src/lib/loader-utils/get-fetch-function.ts
+++ b/modules/core/src/lib/loader-utils/get-fetch-function.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {LoaderContext, LoaderOptions, FetchLike} from '@loaders.gl/loader-utils';

--- a/modules/core/src/lib/loader-utils/loader-context.ts
+++ b/modules/core/src/lib/loader-utils/loader-context.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Loader, LoaderOptions, LoaderContext} from '@loaders.gl/loader-utils';

--- a/modules/core/src/lib/loader-utils/loggers.ts
+++ b/modules/core/src/lib/loader-utils/loggers.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // probe.gl Log compatible loggers

--- a/modules/core/src/lib/loader-utils/normalize-loader.ts
+++ b/modules/core/src/lib/loader-utils/normalize-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Loader} from '@loaders.gl/loader-utils';

--- a/modules/core/src/lib/loader-utils/option-defaults.ts
+++ b/modules/core/src/lib/loader-utils/option-defaults.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/core/src/lib/loader-utils/option-utils.ts
+++ b/modules/core/src/lib/loader-utils/option-utils.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Loader, LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/core/src/lib/progress/fetch-progress.ts
+++ b/modules/core/src/lib/progress/fetch-progress.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // Forked from github AnthumChris/fetch-progress-indicators under MIT license

--- a/modules/core/src/lib/utils/log.ts
+++ b/modules/core/src/lib/utils/log.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {Log} from '@probe.gl/log';

--- a/modules/core/src/lib/utils/mime-type-utils.ts
+++ b/modules/core/src/lib/utils/mime-type-utils.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // TODO - build/integrate proper MIME type parsing

--- a/modules/core/src/lib/utils/resource-utils.ts
+++ b/modules/core/src/lib/utils/resource-utils.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {isResponse, isBlob} from '../../javascript-utils/is-type';

--- a/modules/core/src/lib/utils/response-utils.ts
+++ b/modules/core/src/lib/utils/response-utils.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {isResponse} from '../../javascript-utils/is-type';

--- a/modules/core/src/lib/utils/url-utils.ts
+++ b/modules/core/src/lib/utils/url-utils.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 const QUERY_STRING_PATTERN = /\?.*/;

--- a/modules/core/src/null-loader.ts
+++ b/modules/core/src/null-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // __VERSION__ is injected by babel-plugin-version-inline

--- a/modules/core/src/workers/null-worker-node.ts
+++ b/modules/core/src/workers/null-worker-node.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {createLoaderWorker} from '@loaders.gl/loader-utils';

--- a/modules/core/src/workers/null-worker.ts
+++ b/modules/core/src/workers/null-worker.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {createLoaderWorker} from '@loaders.gl/loader-utils';

--- a/modules/core/test/core.bench.ts
+++ b/modules/core/test/core.bench.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 const LENGTH = 1e3;

--- a/modules/core/test/index-node.ts
+++ b/modules/core/test/index-node.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import './lib/api/load.spec.node';

--- a/modules/core/test/index.ts
+++ b/modules/core/test/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import './javascript-utils/is-type.spec';

--- a/modules/core/test/iterators/make-stream.spec.ts
+++ b/modules/core/test/iterators/make-stream.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /* eslint-disable no-invalid-this, import/no-extraneous-dependencies */

--- a/modules/core/test/javascript-utils/is-type.spec.ts
+++ b/modules/core/test/javascript-utils/is-type.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/core/test/javascript-utils/text-encoder.spec.ts
+++ b/modules/core/test/javascript-utils/text-encoder.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /* eslint-disable max-len */

--- a/modules/core/test/lib/api/load-in-batches.spec.ts
+++ b/modules/core/test/lib/api/load-in-batches.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/core/test/lib/api/load.spec.node.ts
+++ b/modules/core/test/lib/api/load.spec.node.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/core/test/lib/api/load.spec.ts
+++ b/modules/core/test/lib/api/load.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/core/test/lib/api/parse-in-batches.spec.ts
+++ b/modules/core/test/lib/api/parse-in-batches.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/core/test/lib/api/parse.spec.ts
+++ b/modules/core/test/lib/api/parse.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/core/test/lib/api/register-loaders.spec.ts
+++ b/modules/core/test/lib/api/register-loaders.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/core/test/lib/api/select-loader.spec.ts
+++ b/modules/core/test/lib/api/select-loader.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/core/test/lib/api/set-loader-options.spec.ts
+++ b/modules/core/test/lib/api/set-loader-options.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/core/test/lib/fetch/fetch-error-message.spec.ts
+++ b/modules/core/test/lib/fetch/fetch-error-message.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/core/test/lib/fetch/fetch-file.browser.spec.ts
+++ b/modules/core/test/lib/fetch/fetch-file.browser.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/core/test/lib/fetch/fetch-file.node.spec.ts
+++ b/modules/core/test/lib/fetch/fetch-file.node.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/core/test/lib/fetch/fetch-file.spec.ts
+++ b/modules/core/test/lib/fetch/fetch-file.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/core/test/lib/filesystems/browser-filesystem.spec.ts
+++ b/modules/core/test/lib/filesystems/browser-filesystem.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/core/test/lib/init.spec.ts
+++ b/modules/core/test/lib/init.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // /* global loaders */

--- a/modules/core/test/lib/loader-utils/auto-parse.spec.ts
+++ b/modules/core/test/lib/loader-utils/auto-parse.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/core/test/lib/loader-utils/get-data.spec.ts
+++ b/modules/core/test/lib/loader-utils/get-data.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/core/test/lib/loader-utils/loggers.spec.ts
+++ b/modules/core/test/lib/loader-utils/loggers.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/core/test/lib/loader-utils/normalize-loader.spec.ts
+++ b/modules/core/test/lib/loader-utils/normalize-loader.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /* eslint-disable max-len */

--- a/modules/core/test/lib/loader-utils/option-utils.spec.ts
+++ b/modules/core/test/lib/loader-utils/option-utils.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /* eslint-disable max-len */

--- a/modules/core/test/lib/progress/fetch-progress.spec.ts
+++ b/modules/core/test/lib/progress/fetch-progress.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/core/test/lib/utils/mime-type-utils.spec.ts
+++ b/modules/core/test/lib/utils/mime-type-utils.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/core/test/lib/utils/resource-utils.spec.ts
+++ b/modules/core/test/lib/utils/resource-utils.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/core/test/lib/utils/response-utils.spec.ts
+++ b/modules/core/test/lib/utils/response-utils.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/crypto/src/index.ts
+++ b/modules/crypto/src/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // __VERSION__ is injected by babel-plugin-version-inline

--- a/modules/crypto/src/lib/algorithms/crc32.ts
+++ b/modules/crypto/src/lib/algorithms/crc32.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // Inspired by https://gist.github.com/wqli78/1330293/6d85cc967f32cccfcbad94ae7d088a3dcfc14bd9

--- a/modules/crypto/src/lib/algorithms/crc32c.ts
+++ b/modules/crypto/src/lib/algorithms/crc32c.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // From: https://gist.github.com/wqli78/1330293/6d85cc967f32cccfcbad94ae7d088a3dcfc14bd9

--- a/modules/crypto/src/lib/algorithms/md5-wasm.ts
+++ b/modules/crypto/src/lib/algorithms/md5-wasm.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /* eslint-disable */

--- a/modules/crypto/src/lib/crc32-hash.ts
+++ b/modules/crypto/src/lib/crc32-hash.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {Hash} from './hash';

--- a/modules/crypto/src/lib/crc32c-hash.ts
+++ b/modules/crypto/src/lib/crc32c-hash.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {Hash} from './hash';

--- a/modules/crypto/src/lib/hash.ts
+++ b/modules/crypto/src/lib/hash.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {concatenateArrayBuffersAsync} from '@loaders.gl/loader-utils';

--- a/modules/crypto/src/lib/md5-hash.ts
+++ b/modules/crypto/src/lib/md5-hash.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // Fork of https://github.com/briantbutton/md5-wasm under MIT license

--- a/modules/crypto/src/lib/node-hash.ts
+++ b/modules/crypto/src/lib/node-hash.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {Hash} from './hash';

--- a/modules/crypto/src/lib/sha256-hash.ts
+++ b/modules/crypto/src/lib/sha256-hash.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {CryptoHash} from './crypto-hash';

--- a/modules/crypto/src/lib/utils/base64-utils.ts
+++ b/modules/crypto/src/lib/utils/base64-utils.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /**

--- a/modules/crypto/src/lib/utils/digest-utils.ts
+++ b/modules/crypto/src/lib/utils/digest-utils.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {asciiToBase64, base64ToAscii} from './base64-utils';

--- a/modules/crypto/src/types.ts
+++ b/modules/crypto/src/types.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export type CryptoHashOptions = {

--- a/modules/crypto/src/workers/crypto-worker.ts
+++ b/modules/crypto/src/workers/crypto-worker.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {createWorker} from '@loaders.gl/worker-utils';

--- a/modules/crypto/src/workers/cryptojs-worker.ts.disabled
+++ b/modules/crypto/src/workers/cryptojs-worker.ts.disabled
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {CryptoHashOptions} from '../lib/crypto-hash';

--- a/modules/crypto/test/crypto-worker.spec.ts
+++ b/modules/crypto/test/crypto-worker.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/crypto/test/crypto.bench.ts
+++ b/modules/crypto/test/crypto.bench.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {CRC32Hash, CRC32CHash, MD5Hash, SHA256Hash, CryptoHash} from '@loaders.gl/crypto';

--- a/modules/crypto/test/crypto.spec.ts
+++ b/modules/crypto/test/crypto.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/crypto/test/index.ts
+++ b/modules/crypto/test/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // crypto module tests

--- a/modules/crypto/test/lib/crc32c-hash.spec.ts
+++ b/modules/crypto/test/lib/crc32c-hash.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/crypto/test/lib/crypto-hash.spec.ts
+++ b/modules/crypto/test/lib/crypto-hash.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /** eslint-disable @typescript-eslint/unbound-method */

--- a/modules/crypto/test/lib/utils/digest-utils.spec.ts
+++ b/modules/crypto/test/lib/utils/digest-utils.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/crypto/test/test-utils/test-utils.ts
+++ b/modules/crypto/test/test-utils/test-utils.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {generateRandomArrayBuffer} from '@loaders.gl/compression/test/utils/test-utils';

--- a/modules/csv/src/csv-loader.ts
+++ b/modules/csv/src/csv-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/csv/src/csv-writer.ts
+++ b/modules/csv/src/csv-writer.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /* global TextEncoder */

--- a/modules/csv/src/index.ts
+++ b/modules/csv/src/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export type {CSVLoaderOptions} from './csv-loader';

--- a/modules/csv/src/lib/encoders/encode-csv.ts
+++ b/modules/csv/src/lib/encoders/encode-csv.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Copyright 2022 Foursquare Labs, Inc.
 

--- a/modules/csv/test/csv-writer.spec.ts
+++ b/modules/csv/test/csv-writer.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Copyright 2022 Foursquare Labs, Inc.
 

--- a/modules/draco/src/draco-loader.ts
+++ b/modules/draco/src/draco-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Loader, LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/draco/src/index.ts
+++ b/modules/draco/src/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 import type {LoaderWithParser} from '@loaders.gl/loader-utils';
 import type {DracoMesh, DracoLoaderData} from './lib/draco-types';

--- a/modules/draco/test/index.ts
+++ b/modules/draco/test/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import './lib/utils/get-draco-schema.spec';

--- a/modules/excel/src/excel-loader.ts
+++ b/modules/excel/src/excel-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Loader, LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/excel/src/index.ts
+++ b/modules/excel/src/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {LoaderWithParser} from '@loaders.gl/loader-utils';

--- a/modules/flatgeobuf/src/flatgeobuf-loader.ts
+++ b/modules/flatgeobuf/src/flatgeobuf-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Loader, LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/flatgeobuf/src/index.ts
+++ b/modules/flatgeobuf/src/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export type {FlatGeobufLoaderOptions} from './flatgeobuf-loader';

--- a/modules/flatgeobuf/src/lib/binary-geometries.ts
+++ b/modules/flatgeobuf/src/lib/binary-geometries.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {Geometry as FGBGeometry, Feature as FGBFeature} from 'flatgeobuf';

--- a/modules/flatgeobuf/src/lib/get-schema-from-fgb-header.ts
+++ b/modules/flatgeobuf/src/lib/get-schema-from-fgb-header.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Schema, Field, DataType} from '@loaders.gl/schema';

--- a/modules/flatgeobuf/src/lib/parse-flatgeobuf.ts
+++ b/modules/flatgeobuf/src/lib/parse-flatgeobuf.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {Proj4Projection} from '@math.gl/proj4';

--- a/modules/flatgeobuf/src/workers/flatgeobuf-worker.ts
+++ b/modules/flatgeobuf/src/workers/flatgeobuf-worker.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {createLoaderWorker} from '@loaders.gl/loader-utils';

--- a/modules/flatgeobuf/test/flatgeobuf-loader.spec.ts
+++ b/modules/flatgeobuf/test/flatgeobuf-loader.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/geopackage/src/geopackage-loader.ts
+++ b/modules/geopackage/src/geopackage-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/geopackage/src/index.ts
+++ b/modules/geopackage/src/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export {GeoPackageLoader} from './geopackage-loader';

--- a/modules/geopackage/src/workers/geopackage-worker.ts
+++ b/modules/geopackage/src/workers/geopackage-worker.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {createLoaderWorker} from '@loaders.gl/loader-utils';

--- a/modules/geopackage/test/index.ts
+++ b/modules/geopackage/test/index.ts
@@ -1,3 +1,4 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 import './geopackage-loader.spec';

--- a/modules/geotiff/src/index.ts
+++ b/modules/geotiff/src/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export {loadGeoTiff} from './lib/load-geotiff';

--- a/modules/geotiff/src/lib/load-geotiff.ts
+++ b/modules/geotiff/src/lib/load-geotiff.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {fromUrl, fromBlob, GeoTIFF} from 'geotiff';

--- a/modules/geotiff/src/lib/ome/load-ome-tiff.ts
+++ b/modules/geotiff/src/lib/ome/load-ome-tiff.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {GeoTIFF, GeoTIFFImage} from 'geotiff';

--- a/modules/geotiff/src/lib/ome/ome-indexers.ts
+++ b/modules/geotiff/src/lib/ome/ome-indexers.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {GeoTIFFImage, GeoTIFF, ImageFileDirectory} from 'geotiff';

--- a/modules/geotiff/src/lib/ome/ome-utils.ts
+++ b/modules/geotiff/src/lib/ome/ome-utils.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {getDims, getLabels} from './utils';

--- a/modules/geotiff/src/lib/ome/omexml.ts
+++ b/modules/geotiff/src/lib/ome/omexml.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {XMLParser} from 'fast-xml-parser';

--- a/modules/geotiff/src/lib/ome/utils.ts
+++ b/modules/geotiff/src/lib/ome/utils.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {OMEXML} from '../ome/omexml';

--- a/modules/geotiff/src/lib/tiff-pixel-source.ts
+++ b/modules/geotiff/src/lib/tiff-pixel-source.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {GeoTIFFImage, RasterOptions} from 'geotiff';

--- a/modules/geotiff/src/lib/utils/Pool.ts
+++ b/modules/geotiff/src/lib/utils/Pool.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /** eslint-disable */

--- a/modules/geotiff/src/lib/utils/proxies.ts
+++ b/modules/geotiff/src/lib/utils/proxies.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {GeoTIFF} from 'geotiff';

--- a/modules/geotiff/src/lib/utils/tiff-utils.ts
+++ b/modules/geotiff/src/lib/utils/tiff-utils.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {PixelSource} from '../../types';

--- a/modules/geotiff/src/types.ts
+++ b/modules/geotiff/src/types.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {DTYPE_LOOKUP} from './lib/ome/ome-utils';

--- a/modules/geotiff/src/typings/geotiff.ts
+++ b/modules/geotiff/src/typings/geotiff.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {TypedArray} from '../types';

--- a/modules/gis/src/lib/binary-features/binary-to-geojson.ts
+++ b/modules/gis/src/lib/binary-features/binary-to-geojson.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {

--- a/modules/gis/src/lib/geo/geoarrow-metadata.ts
+++ b/modules/gis/src/lib/geo/geoarrow-metadata.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {Schema, Field} from '@loaders.gl/schema';

--- a/modules/gis/src/lib/geo/geoparquet-metadata-schema.ts
+++ b/modules/gis/src/lib/geo/geoparquet-metadata-schema.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /* eslint-disable camelcase */

--- a/modules/gis/src/lib/geo/geoparquet-metadata.ts
+++ b/modules/gis/src/lib/geo/geoparquet-metadata.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 import {Schema, Field} from '@loaders.gl/schema';
 

--- a/modules/gis/src/lib/tables/convert-table-to-geojson.ts
+++ b/modules/gis/src/lib/tables/convert-table-to-geojson.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {LoaderWithParser} from '@loaders.gl/loader-utils';

--- a/modules/gis/test/data/binary-features/geometry-test-cases.ts
+++ b/modules/gis/test/data/binary-features/geometry-test-cases.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 import {BinaryGeometry, Geometry} from '@loaders.gl/schema';
 

--- a/modules/gltf/src/glb-writer.ts
+++ b/modules/gltf/src/glb-writer.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {WriterWithEncoder, WriterOptions} from '@loaders.gl/loader-utils';

--- a/modules/gltf/src/lib/api/gltf-scenegraph.ts
+++ b/modules/gltf/src/lib/api/gltf-scenegraph.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {GLTFWithBuffers} from '../types/gltf-types';

--- a/modules/gltf/src/lib/api/post-process-gltf.ts
+++ b/modules/gltf/src/lib/api/post-process-gltf.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {GLTFWithBuffers} from '../types/gltf-types';

--- a/modules/i3s/src/index.ts
+++ b/modules/i3s/src/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export type {

--- a/modules/i3s/src/lib/parsers/constants.ts
+++ b/modules/i3s/src/lib/parsers/constants.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {GL} from '@loaders.gl/math';

--- a/modules/i3s/src/lib/parsers/parse-i3s-attribute.ts
+++ b/modules/i3s/src/lib/parsers/parse-i3s-attribute.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {TypedArray} from '@loaders.gl/schema';

--- a/modules/images/src/image-writer.ts
+++ b/modules/images/src/image-writer.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {WriterWithEncoder, WriterOptions} from '@loaders.gl/loader-utils';

--- a/modules/images/src/lib/category-api/image-format.ts
+++ b/modules/images/src/lib/category-api/image-format.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {isBrowser} from '@loaders.gl/loader-utils';

--- a/modules/images/src/lib/category-api/parse-isobmff-binary.ts
+++ b/modules/images/src/lib/category-api/parse-isobmff-binary.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // code adapted from https://github.com/sindresorhus/file-type under MIT license
 

--- a/modules/json/src/geojson-loader.ts
+++ b/modules/json/src/geojson-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Loader, LoaderWithParser} from '@loaders.gl/loader-utils';

--- a/modules/json/src/geojson-writer.ts
+++ b/modules/json/src/geojson-writer.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Copyright Foursquare, Inc 20222
 

--- a/modules/json/src/index.ts
+++ b/modules/json/src/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export type {JSONLoaderOptions} from './json-loader';

--- a/modules/json/src/json-loader.ts
+++ b/modules/json/src/json-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Table, TableBatch} from '@loaders.gl/schema';

--- a/modules/json/src/json-writer.ts
+++ b/modules/json/src/json-writer.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Copyright 2022 Foursquare Labs, Inc.
 

--- a/modules/json/src/lib/clarinet/clarinet.ts
+++ b/modules/json/src/lib/clarinet/clarinet.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // This is a fork of the clarinet library, originally BSD license (see LICENSE file)
 // loaders.gl changes:

--- a/modules/json/src/lib/encoder-utils/encode-table-row.ts
+++ b/modules/json/src/lib/encoder-utils/encode-table-row.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Copyright 2022 Foursquare Labs, Inc.
 

--- a/modules/json/src/lib/encoder-utils/encode-utils.ts
+++ b/modules/json/src/lib/encoder-utils/encode-utils.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Copyright 2022 Foursquare Labs, Inc.
 

--- a/modules/json/src/lib/encoder-utils/utf8-encoder.ts
+++ b/modules/json/src/lib/encoder-utils/utf8-encoder.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT License
+// loaders.gl
+// SPDX-License-Identifier: MIT
 
 /* global TextEncoder */
 export class Utf8ArrayBufferEncoder {

--- a/modules/json/src/lib/encoders/geojson-encoder.ts
+++ b/modules/json/src/lib/encoders/geojson-encoder.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Copyright 2022 Foursquare Labs, Inc.
 

--- a/modules/json/src/lib/encoders/json-encoder.ts
+++ b/modules/json/src/lib/encoders/json-encoder.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Copyright 2022 Foursquare Labs, Inc.
 

--- a/modules/json/src/lib/parsers/parse-json.ts
+++ b/modules/json/src/lib/parsers/parse-json.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 import type {RowTable} from '@loaders.gl/schema';
 import {makeTableFromData} from '@loaders.gl/schema';

--- a/modules/json/src/ndjson-loader.ts
+++ b/modules/json/src/ndjson-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/json/test/geojson-writer.spec.ts
+++ b/modules/json/test/geojson-writer.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Copyright 2022 Foursquare Labs, Inc.
 

--- a/modules/json/test/json-writer.spec.ts
+++ b/modules/json/test/json-writer.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Copyright 2022 Foursquare Labs, Inc.
 

--- a/modules/json/test/lib/parser/streaming-json-parser.spec.js
+++ b/modules/json/test/lib/parser/streaming-json-parser.spec.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/kml/src/gpx-loader.ts
+++ b/modules/kml/src/gpx-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {LoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';

--- a/modules/kml/src/index.ts
+++ b/modules/kml/src/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // POLYFILL: DOMParser

--- a/modules/kml/src/kml-loader.ts
+++ b/modules/kml/src/kml-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/kml/src/tcx-loader.ts
+++ b/modules/kml/src/tcx-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/kml/test/gpx-loader.spec.ts
+++ b/modules/kml/test/gpx-loader.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/kml/test/index.ts
+++ b/modules/kml/test/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import './gpx-loader.spec';

--- a/modules/kml/test/kml-loader.spec.ts
+++ b/modules/kml/test/kml-loader.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/kml/test/tcx-loader.spec.ts
+++ b/modules/kml/test/tcx-loader.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/lerc/src/index.ts
+++ b/modules/lerc/src/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // LERC - Limited Error Raster Compression

--- a/modules/lerc/src/lerc-loader.ts
+++ b/modules/lerc/src/lerc-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/lerc/src/lib/parsers/lerc/lerc-types.ts
+++ b/modules/lerc/src/lib/parsers/lerc/lerc-types.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /** Data returned by LERC loader */

--- a/modules/lerc/src/workers/lerc-worker.ts
+++ b/modules/lerc/src/workers/lerc-worker.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {createLoaderWorker} from '@loaders.gl/loader-utils';

--- a/modules/lerc/test/lerc/lerc-level2.spec.ts
+++ b/modules/lerc/test/lerc/lerc-level2.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // Forked from https://github.com/Esri/lerc/blob/master/OtherLanguages/js/tests/

--- a/modules/lerc/test/lerc/lerc-sanity.spec.ts
+++ b/modules/lerc/test/lerc/lerc-sanity.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // Forked from https://github.com/Esri/lerc/blob/master/OtherLanguages/js/tests/

--- a/modules/loader-utils/src/index.ts
+++ b/modules/loader-utils/src/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // TYPES

--- a/modules/loader-utils/src/lib/binary-utils/get-first-characters.ts
+++ b/modules/loader-utils/src/lib/binary-utils/get-first-characters.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /**

--- a/modules/loader-utils/src/lib/binary-utils/memory-conversion-utils.ts
+++ b/modules/loader-utils/src/lib/binary-utils/memory-conversion-utils.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import * as node from '../node/buffer';

--- a/modules/loader-utils/src/lib/file-provider/file-handle-file.ts
+++ b/modules/loader-utils/src/lib/file-provider/file-handle-file.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {FileProvider} from './file-provider';

--- a/modules/loader-utils/src/lib/files/blob-file.ts
+++ b/modules/loader-utils/src/lib/files/blob-file.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {ReadableFile} from './file';

--- a/modules/loader-utils/src/lib/files/file.ts
+++ b/modules/loader-utils/src/lib/files/file.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export type Stat = {

--- a/modules/loader-utils/src/lib/files/http-file.ts
+++ b/modules/loader-utils/src/lib/files/http-file.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {ReadableFile, Stat} from './file';

--- a/modules/loader-utils/src/lib/files/node-file-facade.ts
+++ b/modules/loader-utils/src/lib/files/node-file-facade.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {isBrowser} from '../env-utils/globals';

--- a/modules/loader-utils/src/lib/filesystems/filesystem.ts
+++ b/modules/loader-utils/src/lib/filesystems/filesystem.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {ReadableFile, WritableFile} from '../files/file';

--- a/modules/loader-utils/src/lib/filesystems/node-filesystem-facade.ts
+++ b/modules/loader-utils/src/lib/filesystems/node-filesystem-facade.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {isBrowser} from '../env-utils/globals';

--- a/modules/loader-utils/src/lib/node/buffer.browser.ts
+++ b/modules/loader-utils/src/lib/node/buffer.browser.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // Isolates Buffer references to ensure they are only bundled under Node.js (avoids big webpack polyfill)

--- a/modules/loader-utils/src/lib/node/buffer.ts
+++ b/modules/loader-utils/src/lib/node/buffer.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // Isolates Buffer references to ensure they are only bundled under Node.js (avoids big webpack polyfill)

--- a/modules/loader-utils/src/lib/node/stream.ts
+++ b/modules/loader-utils/src/lib/node/stream.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import * as stream from 'stream';

--- a/modules/loader-utils/src/lib/option-utils/merge-loader-options.ts
+++ b/modules/loader-utils/src/lib/option-utils/merge-loader-options.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {LoaderOptions} from '../../loader-types';

--- a/modules/loader-utils/src/lib/sources/data-source.ts
+++ b/modules/loader-utils/src/lib/sources/data-source.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/loader-utils/src/lib/sources/image-source.ts
+++ b/modules/loader-utils/src/lib/sources/image-source.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {DataSourceProps} from './data-source';

--- a/modules/loader-utils/src/lib/sources/image-tile-source.ts
+++ b/modules/loader-utils/src/lib/sources/image-tile-source.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {ImageType} from './utils/image-type';

--- a/modules/loader-utils/src/lib/sources/tile-source-adapter.ts
+++ b/modules/loader-utils/src/lib/sources/tile-source-adapter.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 
 import {TileSource, GetTileParameters} from './tile-source';
 import {ImageSource, ImageSourceMetadata} from './image-source';

--- a/modules/loader-utils/src/lib/sources/tile-source.ts
+++ b/modules/loader-utils/src/lib/sources/tile-source.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /**

--- a/modules/loader-utils/src/lib/sources/utils/utils.ts
+++ b/modules/loader-utils/src/lib/sources/utils/utils.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/loader-utils/src/lib/sources/vector-tile-source.ts
+++ b/modules/loader-utils/src/lib/sources/vector-tile-source.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {TileSource, TileSourceMetadata} from './tile-source';

--- a/modules/loader-utils/src/loader-types.ts
+++ b/modules/loader-utils/src/loader-types.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {

--- a/modules/loader-utils/src/service-types.ts
+++ b/modules/loader-utils/src/service-types.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {ImageSource, ImageSourceProps} from './lib/sources/image-source';

--- a/modules/loader-utils/src/writer-types.ts
+++ b/modules/loader-utils/src/writer-types.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // WRITERS

--- a/modules/loader-utils/test/index.ts
+++ b/modules/loader-utils/test/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import './lib/binary-utils/array-buffer-utils.spec';

--- a/modules/loader-utils/test/lib/iterators/make-iterator.spec.ts
+++ b/modules/loader-utils/test/lib/iterators/make-iterator.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/loader-utils/test/lib/worker-loader-utils/parse-with-worker.spec.js
+++ b/modules/loader-utils/test/lib/worker-loader-utils/parse-with-worker.spec.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/mvt/src/index.ts
+++ b/modules/mvt/src/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export type {MVTLoaderOptions} from './lib/types';

--- a/modules/mvt/src/lib/geojson-tiler/clip.ts
+++ b/modules/mvt/src/lib/geojson-tiler/clip.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from https://github.com/mapbox/geojson-vt under compatible ISC license
 

--- a/modules/mvt/src/lib/geojson-tiler/convert.ts
+++ b/modules/mvt/src/lib/geojson-tiler/convert.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from https://github.com/mapbox/geojson-vt under compatible ISC license
 

--- a/modules/mvt/src/lib/geojson-tiler/feature.ts
+++ b/modules/mvt/src/lib/geojson-tiler/feature.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from https://github.com/mapbox/geojson-vt under compatible ISC license
 

--- a/modules/mvt/src/lib/geojson-tiler/geojson-tiler.ts
+++ b/modules/mvt/src/lib/geojson-tiler/geojson-tiler.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from https://github.com/mapbox/geojson-vt under compatible ISC license
 

--- a/modules/mvt/src/lib/geojson-tiler/simplify.ts
+++ b/modules/mvt/src/lib/geojson-tiler/simplify.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from https://github.com/mapbox/geojson-vt under compatible ISC license
 

--- a/modules/mvt/src/lib/geojson-tiler/tile.ts
+++ b/modules/mvt/src/lib/geojson-tiler/tile.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from https://github.com/mapbox/geojson-vt under compatible ISC license
 

--- a/modules/mvt/src/lib/geojson-tiler/transform.ts
+++ b/modules/mvt/src/lib/geojson-tiler/transform.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from https://github.com/mapbox/geojson-vt under compatible ISC license
 

--- a/modules/mvt/src/lib/geojson-tiler/wrap.ts
+++ b/modules/mvt/src/lib/geojson-tiler/wrap.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from https://github.com/mapbox/geojson-vt under compatible ISC license
 

--- a/modules/mvt/src/lib/parse-tilejson.ts
+++ b/modules/mvt/src/lib/parse-tilejson.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export type TileJSONOptions = {

--- a/modules/mvt/src/mvt-source.ts
+++ b/modules/mvt/src/mvt-source.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {GetTileParameters, ImageType, DataSourceProps} from '@loaders.gl/loader-utils';

--- a/modules/mvt/src/tilejson-loader.ts
+++ b/modules/mvt/src/tilejson-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/mvt/test/data/tilejson/tilejson.ts
+++ b/modules/mvt/test/data/tilejson/tilejson.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export const TILEJSONS = [

--- a/modules/mvt/test/index.ts
+++ b/modules/mvt/test/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import './mvt-loader.spec';

--- a/modules/mvt/test/lib/geojson-tiler/clip.spec.ts
+++ b/modules/mvt/test/lib/geojson-tiler/clip.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from https://github.com/mapbox/geojson-vt under compatible ISC license
 

--- a/modules/mvt/test/lib/geojson-tiler/full.spec.ts
+++ b/modules/mvt/test/lib/geojson-tiler/full.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from https://github.com/mapbox/geojson-vt under compatible ISC license
 

--- a/modules/mvt/test/lib/geojson-tiler/get-tile.spec.ts
+++ b/modules/mvt/test/lib/geojson-tiler/get-tile.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from https://github.com/mapbox/geojson-vt under compatible ISC license
 

--- a/modules/mvt/test/lib/geojson-tiler/index.ts
+++ b/modules/mvt/test/lib/geojson-tiler/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import './clip.spec';

--- a/modules/mvt/test/lib/geojson-tiler/multi-world.spec.ts
+++ b/modules/mvt/test/lib/geojson-tiler/multi-world.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from https://github.com/mapbox/geojson-vt under compatible ISC license
 

--- a/modules/mvt/test/lib/geojson-tiler/simplify.spec.ts
+++ b/modules/mvt/test/lib/geojson-tiler/simplify.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from https://github.com/mapbox/geojson-vt under compatible ISC license
 

--- a/modules/mvt/test/mvt-loader.bench.ts
+++ b/modules/mvt/test/mvt-loader.bench.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {MVTLoader} from '@loaders.gl/mvt';

--- a/modules/mvt/test/mvt-loader.spec.ts
+++ b/modules/mvt/test/mvt-loader.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // import type {BinaryFeatureCollection} from '@loaders.gl/schema';

--- a/modules/mvt/test/mvt-source.spec.ts
+++ b/modules/mvt/test/mvt-source.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/mvt/test/tilejson-loader.spec.ts
+++ b/modules/mvt/test/tilejson-loader.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/obj/src/lib/get-obj-schema.ts
+++ b/modules/obj/src/lib/get-obj-schema.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Schema, SchemaMetadata, Field, MeshAttribute} from '@loaders.gl/schema';

--- a/modules/obj/src/lib/parse-mtl.ts
+++ b/modules/obj/src/lib/parse-mtl.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from THREE.js under MIT license
 // https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/MTLLoader.js

--- a/modules/obj/src/mtl-loader.ts
+++ b/modules/obj/src/mtl-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 import type {Loader, LoaderOptions} from '@loaders.gl/loader-utils';
 import type {MTLMaterial, ParseMTLOptions} from './lib/parse-mtl';

--- a/modules/parquet/src/constants.ts
+++ b/modules/parquet/src/constants.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // Forked from https://github.com/kbajalc/parquets under MIT license (Copyright (c) 2017 ironSource Ltd.)

--- a/modules/parquet/src/index.ts
+++ b/modules/parquet/src/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export {Buffer} from './polyfills/buffer/install-buffer-polyfill';

--- a/modules/parquet/src/lib/arrow/convert-row-group-to-columns.ts
+++ b/modules/parquet/src/lib/arrow/convert-row-group-to-columns.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {Schema} from '@loaders.gl/schema';

--- a/modules/parquet/src/lib/arrow/convert-schema-from-parquet.ts
+++ b/modules/parquet/src/lib/arrow/convert-schema-from-parquet.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {Schema, Field, DataType} from '@loaders.gl/schema';

--- a/modules/parquet/src/lib/arrow/convert-schema-to-parquet.ts
+++ b/modules/parquet/src/lib/arrow/convert-schema-to-parquet.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // import type {ParquetSchema} from '../../parquetjs/schema/schema';

--- a/modules/parquet/src/lib/parsers/get-parquet-schema.ts
+++ b/modules/parquet/src/lib/parsers/get-parquet-schema.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // loaders.gl

--- a/modules/parquet/src/lib/parsers/parse-geoparquet.ts
+++ b/modules/parquet/src/lib/parsers/parse-geoparquet.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {ReadableFile} from '@loaders.gl/loader-utils';

--- a/modules/parquet/src/lib/parsers/parse-parquet-to-columns.ts
+++ b/modules/parquet/src/lib/parsers/parse-parquet-to-columns.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {ColumnarTable, ColumnarTableBatch, Schema} from '@loaders.gl/schema';

--- a/modules/parquet/src/lib/parsers/parse-parquet.ts
+++ b/modules/parquet/src/lib/parsers/parse-parquet.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {ReadableFile} from '@loaders.gl/loader-utils';

--- a/modules/parquet/src/lib/wasm/encode-parquet-wasm.ts
+++ b/modules/parquet/src/lib/wasm/encode-parquet-wasm.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {WriterOptions} from '@loaders.gl/loader-utils';

--- a/modules/parquet/src/lib/wasm/load-wasm-browser.ts
+++ b/modules/parquet/src/lib/wasm/load-wasm-browser.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import * as wasmEsm from 'parquet-wasm/esm2/arrow1';

--- a/modules/parquet/src/lib/wasm/load-wasm-node.ts
+++ b/modules/parquet/src/lib/wasm/load-wasm-node.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import * as wasmNode from 'parquet-wasm/node/arrow1';

--- a/modules/parquet/src/lib/wasm/load-wasm.ts
+++ b/modules/parquet/src/lib/wasm/load-wasm.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export {loadWasm} from './load-wasm-node';

--- a/modules/parquet/src/lib/wasm/parse-parquet-wasm.ts
+++ b/modules/parquet/src/lib/wasm/parse-parquet-wasm.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // eslint-disable

--- a/modules/parquet/src/parquet-loader.ts
+++ b/modules/parquet/src/parquet-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Loader, LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/parquet/src/parquet-wasm-loader.ts
+++ b/modules/parquet/src/parquet-wasm-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Loader, LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/parquet/src/parquet-wasm-writer.ts
+++ b/modules/parquet/src/parquet-wasm-writer.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {WriterWithEncoder} from '@loaders.gl/loader-utils';

--- a/modules/parquet/src/parquet-writer.ts
+++ b/modules/parquet/src/parquet-writer.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {WriterWithEncoder} from '@loaders.gl/loader-utils';

--- a/modules/parquet/src/polyfills/buffer/buffer-polyfill.browser.ts
+++ b/modules/parquet/src/polyfills/buffer/buffer-polyfill.browser.ts
@@ -1,4 +1,6 @@
-// luma.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
 
 import {Buffer as BufferPolyfill} from './buffer';
 

--- a/modules/parquet/src/polyfills/buffer/buffer-polyfill.node.ts
+++ b/modules/parquet/src/polyfills/buffer/buffer-polyfill.node.ts
@@ -1,4 +1,6 @@
-// luma.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
 
 import {Buffer as BufferPolyfill} from './buffer';
 

--- a/modules/parquet/src/polyfills/buffer/buffer.ts
+++ b/modules/parquet/src/polyfills/buffer/buffer.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // This file is forked from https://github.com/feross/buffer under MIT license
 // The code has primarily been converted to TypeScript.

--- a/modules/parquet/src/polyfills/buffer/index.ts
+++ b/modules/parquet/src/polyfills/buffer/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 export {Buffer as BufferPolyfill} from './buffer';
 export {Buffer} from './install-buffer-polyfill';

--- a/modules/parquet/src/polyfills/util.js
+++ b/modules/parquet/src/polyfills/util.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // Polyfill for Node.js util library

--- a/modules/parquet/src/workers/parquet-worker.ts
+++ b/modules/parquet/src/workers/parquet-worker.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {createLoaderWorker} from '@loaders.gl/loader-utils';

--- a/modules/parquet/test/buffer-polyfill/base64.spec.js
+++ b/modules/parquet/test/buffer-polyfill/base64.spec.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // This file is forked from https://github.com/feross/buffer under MIT license
 import test from 'tape-promise/tape';

--- a/modules/parquet/test/buffer-polyfill/basic.spec.js
+++ b/modules/parquet/test/buffer-polyfill/basic.spec.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // This file is forked from https://github.com/feross/buffer under MIT license
 import test from 'tape-promise/tape';

--- a/modules/parquet/test/buffer-polyfill/compare.spec.js
+++ b/modules/parquet/test/buffer-polyfill/compare.spec.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // This file is forked from https://github.com/feross/buffer under MIT license
 import test from 'tape-promise/tape';

--- a/modules/parquet/test/buffer-polyfill/constructor.spec.js
+++ b/modules/parquet/test/buffer-polyfill/constructor.spec.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // This file is forked from https://github.com/feross/buffer under MIT license
 import test from 'tape-promise/tape';

--- a/modules/parquet/test/buffer-polyfill/from-string.spec.js
+++ b/modules/parquet/test/buffer-polyfill/from-string.spec.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // This file is forked from https://github.com/feross/buffer under MIT license
 import test from 'tape-promise/tape';

--- a/modules/parquet/test/buffer-polyfill/index.ts
+++ b/modules/parquet/test/buffer-polyfill/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import './base64.spec';

--- a/modules/parquet/test/buffer-polyfill/is-buffer.spec.js
+++ b/modules/parquet/test/buffer-polyfill/is-buffer.spec.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // This file is forked from https://github.com/feross/buffer under MIT license
 import test from 'tape-promise/tape';

--- a/modules/parquet/test/buffer-polyfill/methods.spec.js
+++ b/modules/parquet/test/buffer-polyfill/methods.spec.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // This file is forked from https://github.com/feross/buffer under MIT license
 import test from 'tape-promise/tape';

--- a/modules/parquet/test/buffer-polyfill/slice.spec.js
+++ b/modules/parquet/test/buffer-polyfill/slice.spec.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // This file is forked from https://github.com/feross/buffer under MIT license
 import test from 'tape-promise/tape';

--- a/modules/parquet/test/buffer-polyfill/static.spec.js
+++ b/modules/parquet/test/buffer-polyfill/static.spec.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // This file is forked from https://github.com/feross/buffer under MIT license
 import test from 'tape-promise/tape';

--- a/modules/parquet/test/buffer-polyfill/to-string.spec.js
+++ b/modules/parquet/test/buffer-polyfill/to-string.spec.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // This file is forked from https://github.com/feross/buffer under MIT license
 import test from 'tape-promise/tape';

--- a/modules/parquet/test/buffer-polyfill/write-infinity.spec.js
+++ b/modules/parquet/test/buffer-polyfill/write-infinity.spec.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // This file is forked from https://github.com/feross/buffer under MIT license
 import test from 'tape-promise/tape';

--- a/modules/parquet/test/buffer-polyfill/write.spec.js
+++ b/modules/parquet/test/buffer-polyfill/write.spec.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // This file is forked from https://github.com/feross/buffer under MIT license
 import test from 'tape-promise/tape';

--- a/modules/pcd/src/pcd-loader.ts
+++ b/modules/pcd/src/pcd-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Loader, LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/ply/src/index.ts
+++ b/modules/ply/src/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {LoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';

--- a/modules/ply/src/lib/ply-types.ts
+++ b/modules/ply/src/lib/ply-types.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 import type {Mesh} from '@loaders.gl/schema';
 

--- a/modules/pmtiles/src/index.ts
+++ b/modules/pmtiles/src/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export type {PMTilesMetadata} from './lib/parse-pmtiles';

--- a/modules/pmtiles/src/lib/blob-source.ts
+++ b/modules/pmtiles/src/lib/blob-source.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import * as pmtiles from 'pmtiles';

--- a/modules/pmtiles/src/lib/parse-pmtiles.ts
+++ b/modules/pmtiles/src/lib/parse-pmtiles.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {TileJSON} from '@loaders.gl/mvt';

--- a/modules/pmtiles/src/pmtiles-source.ts
+++ b/modules/pmtiles/src/pmtiles-source.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {TileLoadParameters, GetTileParameters} from '@loaders.gl/loader-utils';

--- a/modules/pmtiles/test/data/tilesets.ts
+++ b/modules/pmtiles/test/data/tilesets.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export const PMTILESETS = [

--- a/modules/pmtiles/test/index.ts
+++ b/modules/pmtiles/test/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import './pmtiles-source.spec';

--- a/modules/pmtiles/test/pmtiles-source.spec.ts
+++ b/modules/pmtiles/test/pmtiles-source.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/polyfills/src/fetch/fetch-polyfill.ts
+++ b/modules/polyfills/src/fetch/fetch-polyfill.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import http from 'http';

--- a/modules/polyfills/src/fetch/response-polyfill.ts
+++ b/modules/polyfills/src/fetch/response-polyfill.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {assert} from '../utils/assert';

--- a/modules/polyfills/src/filesystems/fetch-node.ts
+++ b/modules/polyfills/src/filesystems/fetch-node.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import fs from 'fs';

--- a/modules/polyfills/src/filesystems/node-filesystem.ts
+++ b/modules/polyfills/src/filesystems/node-filesystem.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {Stat, RandomAccessFileSystem} from '@loaders.gl/loader-utils';

--- a/modules/polyfills/src/filesystems/stream-utils.node.ts
+++ b/modules/polyfills/src/filesystems/stream-utils.node.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import zlib from 'zlib';

--- a/modules/polyfills/src/images/parse-image-node.ts
+++ b/modules/polyfills/src/images/parse-image-node.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import getPixels from 'get-pixels';

--- a/modules/polyfills/src/images/parse-image.node.ts
+++ b/modules/polyfills/src/images/parse-image.node.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import getPixels from 'get-pixels';

--- a/modules/polyfills/src/index.browser.ts
+++ b/modules/polyfills/src/index.browser.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT License
+// loaders.gl
+// SPDX-License-Identifier: MIT
 
 export function installFilePolyfills() {}
 

--- a/modules/polyfills/src/utils/is-browser.ts
+++ b/modules/polyfills/src/utils/is-browser.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /* eslint-disable no-restricted-globals */

--- a/modules/polyfills/test/filesystems/node-filesystem.spec.ts
+++ b/modules/polyfills/test/filesystems/node-filesystem.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/polyfills/test/load-library/fixture/submodule.js
+++ b/modules/polyfills/test/load-library/fixture/submodule.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 module.exports = {};
 // export const module = {};

--- a/modules/schema/src/index.ts
+++ b/modules/schema/src/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // COMMON CATEGORY

--- a/modules/schema/src/lib/mesh/convert-mesh.ts
+++ b/modules/schema/src/lib/mesh/convert-mesh.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Mesh} from '../../types/category-mesh';

--- a/modules/schema/src/lib/mesh/deduce-mesh-schema.ts
+++ b/modules/schema/src/lib/mesh/deduce-mesh-schema.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {MeshAttribute, MeshAttributes} from '../../types/category-mesh';

--- a/modules/schema/src/lib/mesh/mesh-to-arrow-table.ts
+++ b/modules/schema/src/lib/mesh/mesh-to-arrow-table.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /* Problem with arrow dependency...

--- a/modules/schema/src/lib/table/arrow-api/arrow-like-field.ts
+++ b/modules/schema/src/lib/table/arrow-api/arrow-like-field.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {DataType} from './arrow-like-type';

--- a/modules/schema/src/lib/table/arrow-api/arrow-like-schema.ts
+++ b/modules/schema/src/lib/table/arrow-api/arrow-like-schema.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {SchemaMetadata, Field} from '../../../types/schema';

--- a/modules/schema/src/lib/table/arrow-api/arrow-like-table.ts
+++ b/modules/schema/src/lib/table/arrow-api/arrow-like-table.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {Table} from '../../../types/category-table';

--- a/modules/schema/src/lib/table/arrow-api/arrow-like-type.ts
+++ b/modules/schema/src/lib/table/arrow-api/arrow-like-type.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // This code is adapted from ArrowJS https://github.com/apache/arrow

--- a/modules/schema/src/lib/table/arrow-api/enum.ts
+++ b/modules/schema/src/lib/table/arrow-api/enum.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // This code is adapted from ArrowJS https://github.com/apache/arrow

--- a/modules/schema/src/lib/table/arrow-api/get-type-info.ts
+++ b/modules/schema/src/lib/table/arrow-api/get-type-info.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {Type} from './arrow-like-type';

--- a/modules/schema/src/lib/table/arrow-api/index.ts
+++ b/modules/schema/src/lib/table/arrow-api/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export {ArrowLikeField as Field} from './arrow-like-field';

--- a/modules/schema/src/lib/table/batches/base-table-batch-aggregator.ts
+++ b/modules/schema/src/lib/table/batches/base-table-batch-aggregator.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Schema} from '../../../types/schema';

--- a/modules/schema/src/lib/table/batches/columnar-table-batch-aggregator.ts
+++ b/modules/schema/src/lib/table/batches/columnar-table-batch-aggregator.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Schema} from '../../../types/schema';

--- a/modules/schema/src/lib/table/batches/row-table-batch-aggregator.ts
+++ b/modules/schema/src/lib/table/batches/row-table-batch-aggregator.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Schema} from '../../../types/schema';

--- a/modules/schema/src/lib/table/batches/table-batch-aggregator.ts
+++ b/modules/schema/src/lib/table/batches/table-batch-aggregator.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Schema} from '../../../types/schema';

--- a/modules/schema/src/lib/table/batches/table-batch-builder.ts
+++ b/modules/schema/src/lib/table/batches/table-batch-builder.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Schema} from '../../../types/schema';

--- a/modules/schema/src/lib/table/simple-table/convert-table.ts
+++ b/modules/schema/src/lib/table/simple-table/convert-table.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {

--- a/modules/schema/src/lib/table/simple-table/data-type.ts
+++ b/modules/schema/src/lib/table/simple-table/data-type.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {DataType} from '../../../types/schema';

--- a/modules/schema/src/lib/table/simple-table/make-table-from-batches.ts
+++ b/modules/schema/src/lib/table/simple-table/make-table-from-batches.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {

--- a/modules/schema/src/lib/table/simple-table/make-table.ts
+++ b/modules/schema/src/lib/table/simple-table/make-table.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {Table, ArrayRowTable, ObjectRowTable, ColumnarTable} from '../../../types/category-table';

--- a/modules/schema/src/lib/table/simple-table/row-utils.ts
+++ b/modules/schema/src/lib/table/simple-table/row-utils.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /** Convert an object row to an array row */

--- a/modules/schema/src/lib/table/simple-table/table-accessors.ts
+++ b/modules/schema/src/lib/table/simple-table/table-accessors.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /* eslint-disable no-else-return */

--- a/modules/schema/src/lib/table/simple-table/table-column.ts
+++ b/modules/schema/src/lib/table/simple-table/table-column.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // import type {TypedArray,} from '../../../types/types';

--- a/modules/schema/src/lib/table/simple-table/table-schema.ts
+++ b/modules/schema/src/lib/table/simple-table/table-schema.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // Type deduction

--- a/modules/schema/src/types/batch.ts
+++ b/modules/schema/src/types/batch.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {Schema} from './schema';

--- a/modules/schema/src/types/binary-geometries.ts
+++ b/modules/schema/src/types/binary-geometries.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // GIS

--- a/modules/schema/src/types/category-gis.ts
+++ b/modules/schema/src/types/category-gis.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // GIS

--- a/modules/schema/src/types/category-image.ts
+++ b/modules/schema/src/types/category-image.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /**

--- a/modules/schema/src/types/category-mesh.ts
+++ b/modules/schema/src/types/category-mesh.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Schema} from './schema';

--- a/modules/schema/src/types/category-table.ts
+++ b/modules/schema/src/types/category-table.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Schema} from './schema';

--- a/modules/schema/src/types/category-texture.ts
+++ b/modules/schema/src/types/category-texture.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {ImageType} from './category-image';

--- a/modules/schema/src/types/flat-geometries.ts
+++ b/modules/schema/src/types/flat-geometries.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // FLAT GEOJSON FORMAT GEOMETRY

--- a/modules/schema/src/types/schema.ts
+++ b/modules/schema/src/types/schema.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /** For dictionary type */

--- a/modules/schema/src/types/types.ts
+++ b/modules/schema/src/types/types.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /** Any typed array */

--- a/modules/schema/test/data/table/tables.ts
+++ b/modules/schema/test/data/table/tables.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // These tables are taken from parquet

--- a/modules/schema/test/index.ts
+++ b/modules/schema/test/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import './lib/utils/async-queue.spec';

--- a/modules/schema/test/lib/table/convert-table.spec.ts
+++ b/modules/schema/test/lib/table/convert-table.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/schema/test/lib/table/deduce-table-schema.spec.ts
+++ b/modules/schema/test/lib/table/deduce-table-schema.spec.ts
@@ -1,2 +1,3 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors

--- a/modules/schema/test/lib/table/make-table-from-batches.spec.ts
+++ b/modules/schema/test/lib/table/make-table-from-batches.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/schema/test/lib/table/make-table.spec.ts
+++ b/modules/schema/test/lib/table/make-table.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/schema/test/lib/table/table-accessors.spec.ts
+++ b/modules/schema/test/lib/table/table-accessors.spec.ts
@@ -1,9 +1,11 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // TBA
 
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/schema/test/lib/types/type-utils.spec.ts
+++ b/modules/schema/test/lib/types/type-utils.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // TBA

--- a/modules/schema/test/lib/utils/async-queue.spec.ts
+++ b/modules/schema/test/lib/utils/async-queue.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/schema/test/shared-utils/index.ts
+++ b/modules/schema/test/shared-utils/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Copyright 2023 Foursquare Labs, Inc.
 

--- a/modules/schema/test/shared-utils/table-fixtures.ts
+++ b/modules/schema/test/shared-utils/table-fixtures.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Copyright 2023 Foursquare Labs, Inc.
 

--- a/modules/schema/test/shared-utils/table-utils.ts
+++ b/modules/schema/test/shared-utils/table-utils.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Copyright 2023 Foursquare Labs, Inc.
 

--- a/modules/shapefile/src/lib/streaming/binary-chunk-reader.ts
+++ b/modules/shapefile/src/lib/streaming/binary-chunk-reader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export type BinaryChunkReaderOptions = {

--- a/modules/shapefile/src/lib/streaming/binary-reader.ts
+++ b/modules/shapefile/src/lib/streaming/binary-reader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export class BinaryReader {

--- a/modules/shapefile/src/lib/streaming/zip-batch-iterators.ts
+++ b/modules/shapefile/src/lib/streaming/zip-batch-iterators.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {ObjectRowTableBatch, ArrayRowTableBatch} from '@loaders.gl/schema';

--- a/modules/shapefile/test/index.ts
+++ b/modules/shapefile/test/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import './streaming/binary-chunk-reader.spec';

--- a/modules/terrain/src/index.ts
+++ b/modules/terrain/src/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {LoaderContext, LoaderWithParser} from '@loaders.gl/loader-utils';

--- a/modules/terrain/src/lib/decode-quantized-mesh.ts
+++ b/modules/terrain/src/lib/decode-quantized-mesh.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // Copyright (C) 2018-2019 HERE Europe B.V.

--- a/modules/terrain/src/lib/delatin/index.ts
+++ b/modules/terrain/src/lib/delatin/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // ISC License

--- a/modules/terrain/src/lib/helpers/skirt.ts
+++ b/modules/terrain/src/lib/helpers/skirt.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {concatenateTypedArrays} from '@loaders.gl/loader-utils';

--- a/modules/terrain/src/lib/parse-quantized-mesh.ts
+++ b/modules/terrain/src/lib/parse-quantized-mesh.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {Mesh, getMeshBoundingBox} from '@loaders.gl/schema';

--- a/modules/terrain/src/lib/parse-terrain.ts
+++ b/modules/terrain/src/lib/parse-terrain.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {getMeshBoundingBox} from '@loaders.gl/schema';

--- a/modules/terrain/src/lib/utils/version.ts
+++ b/modules/terrain/src/lib/utils/version.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // Version constant cannot be imported, it needs to correspond to the build version of **this** module.

--- a/modules/terrain/src/quantized-mesh-loader.ts
+++ b/modules/terrain/src/quantized-mesh-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Loader, LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/terrain/src/terrain-loader.ts
+++ b/modules/terrain/src/terrain-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Loader} from '@loaders.gl/loader-utils';

--- a/modules/terrain/src/workers/quantized-mesh-worker.ts
+++ b/modules/terrain/src/workers/quantized-mesh-worker.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {createLoaderWorker} from '@loaders.gl/loader-utils';

--- a/modules/terrain/src/workers/terrain-worker.ts
+++ b/modules/terrain/src/workers/terrain-worker.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {createLoaderWorker} from '@loaders.gl/loader-utils';

--- a/modules/terrain/test/index.js
+++ b/modules/terrain/test/index.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import './quantized-mesh-loader.spec';

--- a/modules/terrain/test/lib/helpers/skirt.spec.js
+++ b/modules/terrain/test/lib/helpers/skirt.spec.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/terrain/test/quantized-mesh-loader.spec.js
+++ b/modules/terrain/test/quantized-mesh-loader.spec.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /* eslint-disable max-len */

--- a/modules/terrain/test/terrain-loader.spec.js
+++ b/modules/terrain/test/terrain-loader.spec.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /* eslint-disable max-len */

--- a/modules/textures/src/basis-loader.ts
+++ b/modules/textures/src/basis-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Loader, LoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';

--- a/modules/textures/src/compressed-texture-loader.ts
+++ b/modules/textures/src/compressed-texture-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Loader, LoaderWithParser} from '@loaders.gl/loader-utils';

--- a/modules/textures/src/compressed-texture-writer.ts
+++ b/modules/textures/src/compressed-texture-writer.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {WriterWithEncoder, WriterOptions} from '@loaders.gl/loader-utils';

--- a/modules/textures/src/crunch-loader.ts
+++ b/modules/textures/src/crunch-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Loader, LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/textures/src/index.ts
+++ b/modules/textures/src/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {VERSION} from './lib/utils/version';

--- a/modules/textures/src/ktx2-basis-writer.ts
+++ b/modules/textures/src/ktx2-basis-writer.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {WriterWithEncoder, WriterOptions} from '@loaders.gl/loader-utils';

--- a/modules/textures/src/lib/encoders/encode-ktx.ts
+++ b/modules/textures/src/lib/encoders/encode-ktx.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {read} from 'ktx-parse';

--- a/modules/textures/src/lib/encoders/encode-ktx2-basis-texture.ts
+++ b/modules/textures/src/lib/encoders/encode-ktx2-basis-texture.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {ImageDataType} from '@loaders.gl/images';

--- a/modules/textures/src/lib/encoders/encode-texture.ts
+++ b/modules/textures/src/lib/encoders/encode-texture.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {ChildProcessProxy} from '@loaders.gl/worker-utils';

--- a/modules/textures/src/lib/gl-extensions.ts
+++ b/modules/textures/src/lib/gl-extensions.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /* eslint-disable camelcase */

--- a/modules/textures/src/lib/parsers/basis-module-loader.ts
+++ b/modules/textures/src/lib/parsers/basis-module-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {loadLibrary} from '@loaders.gl/worker-utils';

--- a/modules/textures/src/lib/parsers/crunch-module-loader.ts
+++ b/modules/textures/src/lib/parsers/crunch-module-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // @ts-nocheck

--- a/modules/textures/src/lib/parsers/parse-basis.ts
+++ b/modules/textures/src/lib/parsers/parse-basis.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /* eslint-disable indent */

--- a/modules/textures/src/lib/parsers/parse-compressed-texture.ts
+++ b/modules/textures/src/lib/parsers/parse-compressed-texture.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {TextureLevel} from '@loaders.gl/schema';

--- a/modules/textures/src/lib/parsers/parse-crunch.ts
+++ b/modules/textures/src/lib/parsers/parse-crunch.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {TextureLevel} from '@loaders.gl/schema';

--- a/modules/textures/src/lib/parsers/parse-dds.ts
+++ b/modules/textures/src/lib/parsers/parse-dds.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {TextureLevel} from '@loaders.gl/schema';

--- a/modules/textures/src/lib/parsers/parse-ktx.ts
+++ b/modules/textures/src/lib/parsers/parse-ktx.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {TextureLevel} from '@loaders.gl/schema';

--- a/modules/textures/src/lib/parsers/parse-npy.ts
+++ b/modules/textures/src/lib/parsers/parse-npy.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // import type {TextureLevel} from '@loaders.gl/schema';

--- a/modules/textures/src/lib/parsers/parse-pvr.ts
+++ b/modules/textures/src/lib/parsers/parse-pvr.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /* eslint-disable camelcase */

--- a/modules/textures/src/lib/texture-api/async-deep-map.ts
+++ b/modules/textures/src/lib/texture-api/async-deep-map.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /*

--- a/modules/textures/src/lib/texture-api/deep-load.ts
+++ b/modules/textures/src/lib/texture-api/deep-load.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {asyncDeepMap} from './async-deep-map';

--- a/modules/textures/src/lib/texture-api/generate-url.ts
+++ b/modules/textures/src/lib/texture-api/generate-url.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {resolvePath} from '@loaders.gl/loader-utils';

--- a/modules/textures/src/lib/texture-api/load-image-array.ts
+++ b/modules/textures/src/lib/texture-api/load-image-array.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {ImageLoader} from '@loaders.gl/images';

--- a/modules/textures/src/lib/texture-api/load-image-cube.ts
+++ b/modules/textures/src/lib/texture-api/load-image-cube.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {ImageLoader} from '@loaders.gl/images';

--- a/modules/textures/src/lib/texture-api/load-image.ts
+++ b/modules/textures/src/lib/texture-api/load-image.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {assert} from '@loaders.gl/loader-utils';

--- a/modules/textures/src/lib/texture-api/texture-api-types.ts
+++ b/modules/textures/src/lib/texture-api/texture-api-types.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export type {ImageType} from '@loaders.gl/images';

--- a/modules/textures/src/lib/utils/extract-mipmap-images.ts
+++ b/modules/textures/src/lib/utils/extract-mipmap-images.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {TextureLevel} from '@loaders.gl/schema';

--- a/modules/textures/src/lib/utils/ktx-format-helper.ts
+++ b/modules/textures/src/lib/utils/ktx-format-helper.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {GL_EXTENSIONS_CONSTANTS} from '../gl-extensions';

--- a/modules/textures/src/lib/utils/texture-formats.ts
+++ b/modules/textures/src/lib/utils/texture-formats.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {GPUTextureFormat} from '@loaders.gl/schema';

--- a/modules/textures/src/lib/utils/version.ts
+++ b/modules/textures/src/lib/utils/version.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // Version constant cannot be imported, it needs to correspond to the build version of **this** module.

--- a/modules/textures/src/npy-loader.ts
+++ b/modules/textures/src/npy-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Loader, LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/textures/src/workers/basis-worker-node.ts
+++ b/modules/textures/src/workers/basis-worker-node.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // Polyfills increases the bundle size significantly. Use it for NodeJS worker only

--- a/modules/textures/src/workers/basis-worker.ts
+++ b/modules/textures/src/workers/basis-worker.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {createLoaderWorker} from '@loaders.gl/loader-utils';

--- a/modules/textures/src/workers/compressed-texture-worker.ts
+++ b/modules/textures/src/workers/compressed-texture-worker.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {createLoaderWorker} from '@loaders.gl/loader-utils';

--- a/modules/textures/src/workers/crunch-worker.ts
+++ b/modules/textures/src/workers/crunch-worker.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {createLoaderWorker} from '@loaders.gl/loader-utils';

--- a/modules/textures/src/workers/ktx2-basis-writer-worker-node.ts
+++ b/modules/textures/src/workers/ktx2-basis-writer-worker-node.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // Polyfills increases the bundle size significantly. Use it for NodeJS worker only

--- a/modules/textures/src/workers/ktx2-basis-writer-worker.ts
+++ b/modules/textures/src/workers/ktx2-basis-writer-worker.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {WorkerBody, WorkerMessagePayload} from '@loaders.gl/worker-utils';

--- a/modules/textures/src/workers/npy-worker.ts
+++ b/modules/textures/src/workers/npy-worker.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {NPYLoader} from '../npy-loader';

--- a/modules/textures/test/basis-loader.spec.ts
+++ b/modules/textures/test/basis-loader.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/textures/test/compressed-texture-loader.spec.ts
+++ b/modules/textures/test/compressed-texture-loader.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/textures/test/compressed-texture-writer.spec.ts
+++ b/modules/textures/test/compressed-texture-writer.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/textures/test/crunch-loader.spec.ts
+++ b/modules/textures/test/crunch-loader.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/textures/test/index.ts
+++ b/modules/textures/test/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import './utils/format-utils.spec';

--- a/modules/textures/test/ktx2-basis-universal-texture-writer.spec.ts
+++ b/modules/textures/test/ktx2-basis-universal-texture-writer.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/textures/test/lib/parsers/parse-dds.spec.ts
+++ b/modules/textures/test/lib/parsers/parse-dds.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/textures/test/lib/parsers/parse-pvr.spec.ts
+++ b/modules/textures/test/lib/parsers/parse-pvr.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/textures/test/npy-loader.spec.ts
+++ b/modules/textures/test/npy-loader.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/textures/test/test-utils/check-compressed-texture.ts
+++ b/modules/textures/test/test-utils/check-compressed-texture.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export function checkCompressedTexture(t, imageData, testCase) {

--- a/modules/textures/test/texture-api/async-deep-map.spec.ts
+++ b/modules/textures/test/texture-api/async-deep-map.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/textures/test/texture-api/load-image.spec.ts
+++ b/modules/textures/test/texture-api/load-image.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/textures/test/utils/format-utils.spec.ts
+++ b/modules/textures/test/utils/format-utils.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/tile-converter/src/i3s-converter/i3s-converter.ts
+++ b/modules/tile-converter/src/i3s-converter/i3s-converter.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {AttributeMetadataInfo} from './helpers/attribute-metadata-info';

--- a/modules/tiles/src/constants.ts
+++ b/modules/tiles/src/constants.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export type TileContentState =

--- a/modules/tiles/src/index.ts
+++ b/modules/tiles/src/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export type {Tileset3DProps} from './tileset/tileset-3d';

--- a/modules/tiles/src/tileset/format-3d-tiles/tileset-3d-traverser.ts
+++ b/modules/tiles/src/tileset/format-3d-tiles/tileset-3d-traverser.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // This file is derived from the Cesium code base under Apache 2 license

--- a/modules/tiles/src/tileset/helpers/i3s-lod.ts
+++ b/modules/tiles/src/tileset/helpers/i3s-lod.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {Matrix4, Vector3} from '@math.gl/core';

--- a/modules/tiles/src/tileset/helpers/tiles-3d-lod.ts
+++ b/modules/tiles/src/tileset/helpers/tiles-3d-lod.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // This file is derived from the Cesium code base under Apache 2 license

--- a/modules/tiles/src/tileset/helpers/transform-utils.ts
+++ b/modules/tiles/src/tileset/helpers/transform-utils.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {Ellipsoid} from '@math.gl/geospatial';

--- a/modules/tiles/src/tileset/helpers/zoom.ts
+++ b/modules/tiles/src/tileset/helpers/zoom.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {Vector3} from '@math.gl/core';

--- a/modules/tiles/src/tileset/tile-3d.ts
+++ b/modules/tiles/src/tileset/tile-3d.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // This file is derived from the Cesium code base under Apache 2 license

--- a/modules/tiles/src/tileset/tileset-3d.ts
+++ b/modules/tiles/src/tileset/tileset-3d.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // This file is derived from the Cesium code base under Apache 2 license

--- a/modules/tiles/src/tileset/tileset-cache.ts
+++ b/modules/tiles/src/tileset/tileset-cache.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // This file is derived from the Cesium code base under Apache 2 license

--- a/modules/tiles/src/tileset/tileset-traverser.ts
+++ b/modules/tiles/src/tileset/tileset-traverser.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Tile3D} from './tile-3d';

--- a/modules/tiles/src/utils/doubly-linked-list-node.ts
+++ b/modules/tiles/src/utils/doubly-linked-list-node.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // This file is derived from the Cesium code base under Apache 2 license

--- a/modules/tiles/test/index.ts
+++ b/modules/tiles/test/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import './utils/doubly-linked-list.spec';

--- a/modules/tiles/test/tileset/helpers/get-frame-state.spec.ts
+++ b/modules/tiles/test/tileset/helpers/get-frame-state.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/video/src/gif-builder.ts
+++ b/modules/video/src/gif-builder.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // A GIFBuilder based on the gifshot module

--- a/modules/video/src/index.ts
+++ b/modules/video/src/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export {VideoLoader} from './video-loader';

--- a/modules/video/src/lib/gifshot/gifshot-loader.ts
+++ b/modules/video/src/lib/gifshot/gifshot-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // @ts-nocheck

--- a/modules/video/src/lib/gifshot/gifshot.ts
+++ b/modules/video/src/lib/gifshot/gifshot.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // @ts-nocheck

--- a/modules/video/src/lib/parsers/parse-video.ts
+++ b/modules/video/src/lib/parsers/parse-video.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // Parse to platform defined video type (HTMLVideoElement in browser)

--- a/modules/video/src/lib/utils/assert.ts
+++ b/modules/video/src/lib/utils/assert.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export function assert(condition: unknown, message: string): void {

--- a/modules/video/src/video-loader.ts
+++ b/modules/video/src/video-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/wkt/src/hex-wkb-loader.ts
+++ b/modules/wkt/src/hex-wkb-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {LoaderWithParser} from '@loaders.gl/loader-utils';

--- a/modules/wkt/src/index.ts
+++ b/modules/wkt/src/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export {WKTCRSLoader} from './wkt-crs-loader';

--- a/modules/wkt/src/lib/encode-twkb.ts
+++ b/modules/wkt/src/lib/encode-twkb.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from https://github.com/cschwarz/wkx under MIT license, Copyright (c) 2013 Christian Schwarz
 

--- a/modules/wkt/src/lib/encode-wkb.ts
+++ b/modules/wkt/src/lib/encode-wkb.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from https://github.com/cschwarz/wkx under MIT license, Copyright (c) 2013 Christian Schwarz
 // Reference: https://www.ogc.org/standards/sfa

--- a/modules/wkt/src/lib/encode-wkt-crs.ts
+++ b/modules/wkt/src/lib/encode-wkt-crs.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // parse-wkt-crs was forked from https://github.com/DanielJDufour/wkt-crs under Creative Commons CC0 1.0 license.
 

--- a/modules/wkt/src/lib/encode-wkt.ts
+++ b/modules/wkt/src/lib/encode-wkt.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Fork of https://github.com/mapbox/wellknown under ISC license (MIT/BSD-2-clause equivalent)
 

--- a/modules/wkt/src/lib/parse-twkb.ts
+++ b/modules/wkt/src/lib/parse-twkb.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from https://github.com/cschwarz/wkx under MIT license, Copyright (c) 2013 Christian Schwarz
 

--- a/modules/wkt/src/lib/parse-wkb-header.ts
+++ b/modules/wkt/src/lib/parse-wkb-header.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 const EWKB_FLAG_Z = 0x80000000;

--- a/modules/wkt/src/lib/parse-wkb.ts
+++ b/modules/wkt/src/lib/parse-wkb.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {

--- a/modules/wkt/src/lib/parse-wkt-crs.ts
+++ b/modules/wkt/src/lib/parse-wkt-crs.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // parse-wkt-crs was forked from https://github.com/DanielJDufour/wkt-crs under Creative Commons CC0 1.0 license.
 

--- a/modules/wkt/src/lib/parse-wkt.ts
+++ b/modules/wkt/src/lib/parse-wkt.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Fork of https://github.com/mapbox/wellknown under ISC license (MIT/BSD-2-clause equivalent)
 

--- a/modules/wkt/src/lib/utils/base64-encoder.ts
+++ b/modules/wkt/src/lib/utils/base64-encoder.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /* 

--- a/modules/wkt/src/lib/utils/binary-reader.ts
+++ b/modules/wkt/src/lib/utils/binary-reader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /** A DataView that tracks byte offset when reading. */

--- a/modules/wkt/src/lib/utils/binary-writer.ts
+++ b/modules/wkt/src/lib/utils/binary-writer.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from https://github.com/cschwarz/wkx under MIT license, Copyright (c) 2013 Christian Schwarz
 

--- a/modules/wkt/src/lib/utils/hex-encoder.ts
+++ b/modules/wkt/src/lib/utils/hex-encoder.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /**

--- a/modules/wkt/src/lib/utils/hex-transcoder.ts
+++ b/modules/wkt/src/lib/utils/hex-transcoder.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // Forked from https://github.com/jessetane/hex-transcoder under MIT license

--- a/modules/wkt/src/lib/utils/version.ts
+++ b/modules/wkt/src/lib/utils/version.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // Version constant cannot be imported, it needs to correspond to the build version of **this** module.

--- a/modules/wkt/src/twkb-loader.ts
+++ b/modules/wkt/src/twkb-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Loader, LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/wkt/src/twkb-writer.ts
+++ b/modules/wkt/src/twkb-writer.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Writer, WriterOptions} from '@loaders.gl/loader-utils';

--- a/modules/wkt/src/wkb-loader.ts
+++ b/modules/wkt/src/wkb-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Loader, LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/wkt/src/wkb-writer.ts
+++ b/modules/wkt/src/wkb-writer.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {WriterWithEncoder, WriterOptions} from '@loaders.gl/loader-utils';

--- a/modules/wkt/src/wkt-crs-loader.ts
+++ b/modules/wkt/src/wkt-crs-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/wkt/src/wkt-crs-writer.ts
+++ b/modules/wkt/src/wkt-crs-writer.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {WriterWithEncoder, WriterOptions} from '@loaders.gl/loader-utils';

--- a/modules/wkt/src/wkt-loader.ts
+++ b/modules/wkt/src/wkt-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Loader, LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/wkt/src/wkt-writer.ts
+++ b/modules/wkt/src/wkt-writer.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Writer, WriterOptions} from '@loaders.gl/loader-utils';

--- a/modules/wkt/src/workers/wkb-worker.ts
+++ b/modules/wkt/src/workers/wkb-worker.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {createLoaderWorker} from '@loaders.gl/loader-utils';

--- a/modules/wkt/src/workers/wkt-worker.ts
+++ b/modules/wkt/src/workers/wkt-worker.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {createLoaderWorker} from '@loaders.gl/loader-utils';

--- a/modules/wkt/test/hex-wkb-loader.spec.ts
+++ b/modules/wkt/test/hex-wkb-loader.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/wkt/test/index.ts
+++ b/modules/wkt/test/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import './lib/utils/hex-transcoder.spec';

--- a/modules/wkt/test/lib/utils/hex-transcoder.spec.ts
+++ b/modules/wkt/test/lib/utils/hex-transcoder.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/wkt/test/twkb-loader.spec.ts
+++ b/modules/wkt/test/twkb-loader.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/wkt/test/twkb-writer.spec.ts
+++ b/modules/wkt/test/twkb-writer.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /**

--- a/modules/wkt/test/utils/parse-test-cases.ts
+++ b/modules/wkt/test/utils/parse-test-cases.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {Geometry, BinaryGeometry} from '@loaders.gl/schema';

--- a/modules/wkt/test/wkb-loader.spec.ts
+++ b/modules/wkt/test/wkb-loader.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/wkt/test/wkb-writer.spec.ts
+++ b/modules/wkt/test/wkb-writer.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/wkt/test/wkt-crs-loader.spec.ts
+++ b/modules/wkt/test/wkt-crs-loader.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // parse-wkt-crs was forked from https://github.com/DanielJDufour/wkt-crs under Creative Commons CC0 1.0 license.
 

--- a/modules/wkt/test/wkt-loader.spec.ts
+++ b/modules/wkt/test/wkt-loader.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // Fork of https://github.com/mapbox/wellknown under ISC license (MIT/BSD-2-clause equivalent)

--- a/modules/wkt/test/wkt-writer.spec.ts
+++ b/modules/wkt/test/wkt-writer.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/wms/src/csw-capabilities-loader.ts
+++ b/modules/wms/src/csw-capabilities-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {LoaderWithParser} from '@loaders.gl/loader-utils';

--- a/modules/wms/src/csw-domain-loader.ts
+++ b/modules/wms/src/csw-domain-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {LoaderWithParser} from '@loaders.gl/loader-utils';

--- a/modules/wms/src/csw-records-loader.ts
+++ b/modules/wms/src/csw-records-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {LoaderWithParser} from '@loaders.gl/loader-utils';

--- a/modules/wms/src/gml-loader.ts
+++ b/modules/wms/src/gml-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/wms/src/index.ts
+++ b/modules/wms/src/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // CSW - Catalog Service for the Web

--- a/modules/wms/src/lib/parsers/csw/parse-csw-capabilities.ts
+++ b/modules/wms/src/lib/parsers/csw/parse-csw-capabilities.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {XMLLoaderOptions} from '@loaders.gl/xml';

--- a/modules/wms/src/lib/parsers/csw/parse-csw-domain.ts
+++ b/modules/wms/src/lib/parsers/csw/parse-csw-domain.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {XMLLoaderOptions} from '@loaders.gl/xml';

--- a/modules/wms/src/lib/parsers/csw/parse-csw-records.ts
+++ b/modules/wms/src/lib/parsers/csw/parse-csw-records.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {XMLLoaderOptions, convertXMLFieldToArrayInPlace} from '@loaders.gl/xml';

--- a/modules/wms/src/lib/parsers/csw/parse-exception-report.ts
+++ b/modules/wms/src/lib/parsers/csw/parse-exception-report.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // import type {XMLLoaderOptions} from '@loaders.gl/xml';

--- a/modules/wms/src/lib/parsers/gml/parse-gml.ts
+++ b/modules/wms/src/lib/parsers/gml/parse-gml.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // Forked from https://github.com/derhuerst/parse-gml-polygon/blob/master/index.js

--- a/modules/wms/src/lib/parsers/wms/parse-wms-capabilities.ts
+++ b/modules/wms/src/lib/parsers/wms/parse-wms-capabilities.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {XMLLoader} from '@loaders.gl/xml';

--- a/modules/wms/src/lib/parsers/wms/parse-wms-error.ts
+++ b/modules/wms/src/lib/parsers/wms/parse-wms-error.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {XMLLoader} from '@loaders.gl/xml';

--- a/modules/wms/src/lib/parsers/wms/parse-wms-features.ts
+++ b/modules/wms/src/lib/parsers/wms/parse-wms-features.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {XMLLoader} from '@loaders.gl/xml';

--- a/modules/wms/src/lib/parsers/wms/parse-wms-layer-description.ts
+++ b/modules/wms/src/lib/parsers/wms/parse-wms-layer-description.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {XMLLoaderOptions} from '@loaders.gl/xml';

--- a/modules/wms/src/lib/parsers/xml/parse-xml-helpers.ts
+++ b/modules/wms/src/lib/parsers/xml/parse-xml-helpers.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /** A single element of an array is not represented as an array in XML */

--- a/modules/wms/src/lib/services/create-image-service.ts
+++ b/modules/wms/src/lib/services/create-image-service.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {ImageSource, Service} from '@loaders.gl/loader-utils';

--- a/modules/wms/src/lib/services/image-service.ts
+++ b/modules/wms/src/lib/services/image-service.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/wms/src/services/arcgis/arcgis-image-service.ts
+++ b/modules/wms/src/services/arcgis/arcgis-image-service.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {ImageType} from '@loaders.gl/images';

--- a/modules/wms/src/services/arcgis/arcgis-server.ts
+++ b/modules/wms/src/services/arcgis/arcgis-server.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export type Service = {name: string; type: string; url: string};

--- a/modules/wms/src/services/create-image-source.ts
+++ b/modules/wms/src/services/create-image-source.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Service, ImageSource} from '@loaders.gl/loader-utils';

--- a/modules/wms/src/services/ogc/csw-service.ts
+++ b/modules/wms/src/services/ogc/csw-service.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /* eslint-disable camelcase */

--- a/modules/wms/src/services/ogc/wms-service.ts
+++ b/modules/wms/src/services/ogc/wms-service.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /* eslint-disable camelcase */

--- a/modules/wms/src/wms-capabilities-loader.ts
+++ b/modules/wms/src/wms-capabilities-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {LoaderWithParser} from '@loaders.gl/loader-utils';

--- a/modules/wms/src/wms-error-loader.ts
+++ b/modules/wms/src/wms-error-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/wms/test/csw/csw-capabilities-loader.spec.ts
+++ b/modules/wms/test/csw/csw-capabilities-loader.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/wms/test/csw/csw-domain-loader.spec.ts
+++ b/modules/wms/test/csw/csw-domain-loader.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // Forked from https://github.com/chrelad/openlayers/blob/master/tests/Format/

--- a/modules/wms/test/csw/csw-records-loader.spec.ts
+++ b/modules/wms/test/csw/csw-records-loader.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // Forked from https://github.com/chrelad/openlayers/blob/master/tests/Format/

--- a/modules/wms/test/data/gml/v3/tests.ts
+++ b/modules/wms/test/data/gml/v3/tests.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // @ts-nocheck

--- a/modules/wms/test/data/wms/errors.ts
+++ b/modules/wms/test/data/wms/errors.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export const ERROR_TEST_CASES: {xml: string; parsed: string}[] = [

--- a/modules/wms/test/gml/gml-loader.spec.ts
+++ b/modules/wms/test/gml/gml-loader.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // Forked from https://github.com/chrelad/openlayers/blob/master/tests/Format/GML/v3.html

--- a/modules/wms/test/index.ts
+++ b/modules/wms/test/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // CSW - Catalog Service for the Web

--- a/modules/wms/test/services/arcgis-server.spec.ts
+++ b/modules/wms/test/services/arcgis-server.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/wms/test/services/wms-service.spec.ts
+++ b/modules/wms/test/services/wms-service.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/wms/test/test-utils/fetch-spy.ts
+++ b/modules/wms/test/test-utils/fetch-spy.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /** Stores a reference to the intercepted requestInit object under the url */

--- a/modules/wms/test/wfs/wfs-capabilities-loader.spec.ts
+++ b/modules/wms/test/wfs/wfs-capabilities-loader.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // Forked from https://github.com/chrelad/openlayers/blob/master/tests/Format/WFSCapabilities/v1_0_0.html

--- a/modules/wms/test/wms/wms-capabilities-loader.spec.ts
+++ b/modules/wms/test/wms/wms-capabilities-loader.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/wms/test/wms/wms-error-loader.spec.ts
+++ b/modules/wms/test/wms/wms-error-loader.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/wms/test/wms/wms-feature-info-loader.spec.ts
+++ b/modules/wms/test/wms/wms-feature-info-loader.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // Forked from https://github.com/chrelad/openlayers/blob/master/tests/Format/WMSGetFeatureInfo.html

--- a/modules/wms/test/wms/wms-layer-description-loader.spec.ts
+++ b/modules/wms/test/wms/wms-layer-description-loader.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // Forked from https://github.com/chrelad/openlayers/blob/master/tests/Format/WMSDescribeLayer.html

--- a/modules/wms/test/wmts/wmts-capabilities-loader.spec.ts
+++ b/modules/wms/test/wmts/wmts-capabilities-loader.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // @ts-nocheck

--- a/modules/worker-utils/src/index.ts
+++ b/modules/worker-utils/src/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {WorkerObject} from './types';

--- a/modules/worker-utils/src/lib/async-queue/async-queue.ts
+++ b/modules/worker-utils/src/lib/async-queue/async-queue.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // From https://github.com/rauschma/async-iter-demo/tree/master/src under MIT license

--- a/modules/worker-utils/src/lib/env-utils/assert.ts
+++ b/modules/worker-utils/src/lib/env-utils/assert.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // Replacement for the external assert method to reduce bundle size

--- a/modules/worker-utils/src/lib/env-utils/globals.ts
+++ b/modules/worker-utils/src/lib/env-utils/globals.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // Purpose: include this in your module to avoids adding dependencies on

--- a/modules/worker-utils/src/lib/env-utils/version.ts
+++ b/modules/worker-utils/src/lib/env-utils/version.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // Version constant cannot be imported, it needs to correspond to the build version of **this** module.

--- a/modules/worker-utils/src/lib/library-utils/library-utils.ts
+++ b/modules/worker-utils/src/lib/library-utils/library-utils.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /* global importScripts */

--- a/modules/worker-utils/src/lib/node/require-utils.node.ts
+++ b/modules/worker-utils/src/lib/node/require-utils.node.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // Fork of https://github.com/floatdrop/require-from-string/blob/master/index.js

--- a/modules/worker-utils/src/lib/node/worker_threads-browser.ts
+++ b/modules/worker-utils/src/lib/node/worker_threads-browser.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /** Browser polyfill for Node.js built-in `worker_threads` module.

--- a/modules/worker-utils/src/lib/node/worker_threads.ts
+++ b/modules/worker-utils/src/lib/node/worker_threads.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import * as WorkerThreads from 'worker_threads';

--- a/modules/worker-utils/src/lib/process-utils/child-process-proxy.ts
+++ b/modules/worker-utils/src/lib/process-utils/child-process-proxy.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /* eslint-disable no-console */

--- a/modules/worker-utils/src/lib/process-utils/process-utils.ts
+++ b/modules/worker-utils/src/lib/process-utils/process-utils.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import ChildProcess from 'child_process';

--- a/modules/worker-utils/src/lib/worker-api/create-worker.ts
+++ b/modules/worker-utils/src/lib/worker-api/create-worker.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {

--- a/modules/worker-utils/src/lib/worker-api/get-worker-url.ts
+++ b/modules/worker-utils/src/lib/worker-api/get-worker-url.ts
@@ -1,7 +1,9 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {WorkerObject, WorkerOptions} from '../../types';

--- a/modules/worker-utils/src/lib/worker-api/process-on-worker.ts
+++ b/modules/worker-utils/src/lib/worker-api/process-on-worker.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {

--- a/modules/worker-utils/src/lib/worker-api/validate-worker-version.ts
+++ b/modules/worker-utils/src/lib/worker-api/validate-worker-version.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {WorkerObject} from '../../types';

--- a/modules/worker-utils/src/lib/worker-farm/worker-body.ts
+++ b/modules/worker-utils/src/lib/worker-farm/worker-body.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {WorkerMessageData, WorkerMessageType, WorkerMessagePayload} from '../../types';

--- a/modules/worker-utils/src/lib/worker-farm/worker-farm.ts
+++ b/modules/worker-utils/src/lib/worker-farm/worker-farm.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import WorkerPool from './worker-pool';

--- a/modules/worker-utils/src/lib/worker-farm/worker-job.ts
+++ b/modules/worker-utils/src/lib/worker-farm/worker-job.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {WorkerMessageType, WorkerMessagePayload} from '../../types';

--- a/modules/worker-utils/src/lib/worker-farm/worker-pool.ts
+++ b/modules/worker-utils/src/lib/worker-farm/worker-pool.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {WorkerMessageType, WorkerMessagePayload} from '../../types';

--- a/modules/worker-utils/src/lib/worker-farm/worker-thread.ts
+++ b/modules/worker-utils/src/lib/worker-farm/worker-thread.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {NodeWorker, NodeWorkerType} from '../node/worker_threads';

--- a/modules/worker-utils/src/lib/worker-utils/get-loadable-worker-url.ts
+++ b/modules/worker-utils/src/lib/worker-utils/get-loadable-worker-url.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {assert} from '../env-utils/assert';

--- a/modules/worker-utils/src/lib/worker-utils/get-transfer-list.ts
+++ b/modules/worker-utils/src/lib/worker-utils/get-transfer-list.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // NOTE - there is a copy of this function is both in core and loader-utils

--- a/modules/worker-utils/src/lib/worker-utils/remove-nontransferable-options.ts
+++ b/modules/worker-utils/src/lib/worker-utils/remove-nontransferable-options.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /**

--- a/modules/worker-utils/src/types.ts
+++ b/modules/worker-utils/src/types.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /**

--- a/modules/worker-utils/src/workers/null-worker.ts
+++ b/modules/worker-utils/src/workers/null-worker.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {createWorker} from '../lib/worker-api/create-worker';

--- a/modules/worker-utils/test/index.ts
+++ b/modules/worker-utils/test/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import './lib/async-queue/async-queue.spec';

--- a/modules/worker-utils/test/lib/async-queue/async-queue.spec.ts
+++ b/modules/worker-utils/test/lib/async-queue/async-queue.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/worker-utils/test/lib/library-utils/library-utils.spec.ts
+++ b/modules/worker-utils/test/lib/library-utils/library-utils.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/worker-utils/test/lib/library-utils/require-utils.spec.ts
+++ b/modules/worker-utils/test/lib/library-utils/require-utils.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // Fork of https://github.com/floatdrop/require-from-string/blob/master/index.js

--- a/modules/worker-utils/test/lib/worker-api/get-worker-url.spec.ts
+++ b/modules/worker-utils/test/lib/worker-api/get-worker-url.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/worker-utils/test/lib/worker-api/process-on-worker.spec.ts
+++ b/modules/worker-utils/test/lib/worker-api/process-on-worker.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/worker-utils/test/lib/worker-api/validate-worker-version.spec.ts
+++ b/modules/worker-utils/test/lib/worker-api/validate-worker-version.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/worker-utils/test/lib/worker-farm/worker-pool.spec.ts
+++ b/modules/worker-utils/test/lib/worker-farm/worker-pool.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/worker-utils/test/lib/worker-farm/worker-thread.spec.ts
+++ b/modules/worker-utils/test/lib/worker-farm/worker-thread.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/worker-utils/test/lib/worker-utils/get-loadable-worker-url.spec.ts
+++ b/modules/worker-utils/test/lib/worker-utils/get-loadable-worker-url.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/worker-utils/test/lib/worker-utils/get-transfer-list.spec.ts
+++ b/modules/worker-utils/test/lib/worker-utils/get-transfer-list.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/xml/src/html-loader.ts
+++ b/modules/xml/src/html-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {LoaderWithParser} from '@loaders.gl/loader-utils';

--- a/modules/xml/src/index.ts
+++ b/modules/xml/src/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // XMLLoader

--- a/modules/xml/src/lib/parsers/parse-xml.ts
+++ b/modules/xml/src/lib/parsers/parse-xml.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {SAXParserOptions} from '../../sax-ts/sax';

--- a/modules/xml/src/lib/parsers/streaming-xml-parser.ts
+++ b/modules/xml/src/lib/parsers/streaming-xml-parser.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // @ts-nocheck

--- a/modules/xml/src/lib/xml-utils/uncapitalize.ts
+++ b/modules/xml/src/lib/xml-utils/uncapitalize.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /**

--- a/modules/xml/src/lib/xml-utils/xml-utils.ts
+++ b/modules/xml/src/lib/xml-utils/xml-utils.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // TODO - these utilities could be moved to the XML parser.

--- a/modules/xml/src/sax-ts/sax.ts
+++ b/modules/xml/src/sax-ts/sax.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // This file is forked from https://github.com/Maxim-Mazurok/sax-ts under ISC license,

--- a/modules/xml/src/xml-loader.ts
+++ b/modules/xml/src/xml-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/xml/test/html-loader.spec.ts
+++ b/modules/xml/test/html-loader.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/xml/test/index.ts
+++ b/modules/xml/test/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // For streaming XML parsing

--- a/modules/xml/test/lib/pretty-print.spec.ts
+++ b/modules/xml/test/lib/pretty-print.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Inspired by a sax-js example under ISC license
 

--- a/modules/xml/test/sax-ts/index.ts
+++ b/modules/xml/test/sax-ts/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import './testcases/attribute-name.spec';

--- a/modules/xml/test/sax-ts/testcases/attribute-name.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/attribute-name.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/attribute-no-space.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/attribute-no-space.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/attribute-unquoted.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/attribute-unquoted.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/bom.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/bom.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/buffer-overrun.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/buffer-overrun.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/case.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/case.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/cdata-chunked.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/cdata-chunked.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/cdata-end-split.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/cdata-end-split.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/cdata-fake-end.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/cdata-fake-end.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/cdata-multiple.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/cdata-multiple.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/cdata.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/cdata.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/cyrillic.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/cyrillic.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/duplicate-attribute.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/duplicate-attribute.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/emoji.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/emoji.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/end_empty_stream.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/end_empty_stream.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/entities.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/entities.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/entity-mega.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/entity-mega.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/entity-nan.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/entity-nan.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/flush.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/flush.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/issue-23.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/issue-23.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/issue-30.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/issue-30.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/issue-35.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/issue-35.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/issue-47.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/issue-47.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/issue-49.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/issue-49.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/issue-84.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/issue-84.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/issue-86.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/issue-86.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/not-string.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/not-string.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/opentagstart.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/opentagstart.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/parser-position.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/parser-position.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/script-close-better.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/script-close-better.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/script.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/script.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/self-closing-child-strict.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/self-closing-child-strict.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/self-closing-child.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/self-closing-child.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/self-closing-tag.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/self-closing-tag.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/stand-alone-comment.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/stand-alone-comment.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/stray-ending.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/stray-ending.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/trailing-attribute-no-value.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/trailing-attribute-no-value.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/trailing-non-whitespace.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/trailing-non-whitespace.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/unclosed-root.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/unclosed-root.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/unquoted.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/unquoted.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/utf8-split.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/utf8-split.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/xml-internal-entities.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/xml-internal-entities.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/xml_entities.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/xml_entities.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/xmlns-as-tag-name.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/xmlns-as-tag-name.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/xmlns-issue-41.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/xmlns-issue-41.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/xmlns-rebinding.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/xmlns-rebinding.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/xmlns-strict.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/xmlns-strict.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/xmlns-unbound-element.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/xmlns-unbound-element.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/xmlns-unbound.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/xmlns-unbound.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/xmlns-xml-default-ns.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/xmlns-xml-default-ns.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/xmlns-xml-default-prefix-attribute.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/xmlns-xml-default-prefix-attribute.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/xmlns-xml-default-prefix.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/xmlns-xml-default-prefix.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/testcases/xmlns-xml-default-redefine.spec.ts
+++ b/modules/xml/test/sax-ts/testcases/xmlns-xml-default-redefine.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/sax-ts/utils/test-utils.ts
+++ b/modules/xml/test/sax-ts/utils/test-utils.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 // Forked from sax-ts & sax under ISC license
 

--- a/modules/xml/test/xml-loader.spec.ts
+++ b/modules/xml/test/xml-loader.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/zarr/src/index.ts
+++ b/modules/zarr/src/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export {loadZarr} from './lib/load-zarr';

--- a/modules/zarr/src/lib/load-zarr.ts
+++ b/modules/zarr/src/lib/load-zarr.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // eslint-disable-next-line import/no-unresolved

--- a/modules/zarr/src/lib/utils.ts
+++ b/modules/zarr/src/lib/utils.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {ZarrArray} from 'zarr';

--- a/modules/zarr/src/lib/zarr-pixel-source.ts
+++ b/modules/zarr/src/lib/zarr-pixel-source.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {ZarrArray} from 'zarr';

--- a/modules/zarr/src/types.ts
+++ b/modules/zarr/src/types.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /* eslint-disable */

--- a/modules/zip/src/filesystems/zip-filesystem.ts
+++ b/modules/zip/src/filesystems/zip-filesystem.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {FileSystem, isBrowser} from '@loaders.gl/loader-utils';

--- a/modules/zip/src/hash-file-utility.ts
+++ b/modules/zip/src/hash-file-utility.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {MD5Hash} from '@loaders.gl/crypto';

--- a/modules/zip/src/index.ts
+++ b/modules/zip/src/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 export {ZipLoader} from './zip-loader';

--- a/modules/zip/src/lib/tar/header.ts
+++ b/modules/zip/src/lib/tar/header.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // This file is derived from the tar-js code base under MIT license

--- a/modules/zip/src/lib/tar/tar.ts
+++ b/modules/zip/src/lib/tar/tar.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // This file is derived from the tar-js code base under MIT license

--- a/modules/zip/src/lib/tar/types.ts
+++ b/modules/zip/src/lib/tar/types.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 /**

--- a/modules/zip/src/lib/tar/utils.ts
+++ b/modules/zip/src/lib/tar/utils.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // This file is derived from the tar-js code base under MIT license

--- a/modules/zip/src/parse-zip/cd-file-header.ts
+++ b/modules/zip/src/parse-zip/cd-file-header.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {FileProvider, compareArrayBuffers, concatenateArrayBuffers} from '@loaders.gl/loader-utils';

--- a/modules/zip/src/parse-zip/end-of-central-directory.ts
+++ b/modules/zip/src/parse-zip/end-of-central-directory.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {FileProvider, compareArrayBuffers} from '@loaders.gl/loader-utils';

--- a/modules/zip/src/parse-zip/local-file-header.ts
+++ b/modules/zip/src/parse-zip/local-file-header.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {FileProvider, compareArrayBuffers} from '@loaders.gl/loader-utils';

--- a/modules/zip/src/parse-zip/search-from-the-end.ts
+++ b/modules/zip/src/parse-zip/search-from-the-end.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {FileProvider} from '@loaders.gl/loader-utils';

--- a/modules/zip/src/tar-builder.ts
+++ b/modules/zip/src/tar-builder.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import Tar from './lib/tar/tar';

--- a/modules/zip/src/zip-loader.ts
+++ b/modules/zip/src/zip-loader.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';

--- a/modules/zip/src/zip-writer.ts
+++ b/modules/zip/src/zip-writer.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import type {Writer, WriterOptions} from '@loaders.gl/loader-utils';

--- a/modules/zip/test/filesystems/zip-filesystem.spec.ts
+++ b/modules/zip/test/filesystems/zip-filesystem.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/zip/test/index.ts
+++ b/modules/zip/test/index.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import './zip-writer-loader.spec';

--- a/modules/zip/test/lib/test-cases.js
+++ b/modules/zip/test/lib/test-cases.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // prettier-ignore

--- a/modules/zip/test/tar-builder.spec.ts
+++ b/modules/zip/test/tar-builder.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/zip/test/zip-utils/cd-file-header.spec.ts
+++ b/modules/zip/test/zip-utils/cd-file-header.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/zip/test/zip-utils/end-of-central-directory.spec.ts
+++ b/modules/zip/test/zip-utils/end-of-central-directory.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/zip/test/zip-utils/local-file-header.spec.ts
+++ b/modules/zip/test/zip-utils/local-file-header.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/zip/test/zip-utils/search-from-the-end.spec.ts
+++ b/modules/zip/test/zip-utils/search-from-the-end.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/modules/zip/test/zip-writer-loader.spec.ts
+++ b/modules/zip/test/zip-writer-loader.spec.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';

--- a/test/bench/browser.js
+++ b/test/bench/browser.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import '@loaders.gl/polyfills';

--- a/test/bench/modules.js
+++ b/test/bench/modules.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 // Override aliases to point to publicly accessible github

--- a/test/browser.ts
+++ b/test/browser.ts
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import './init-browser-test';

--- a/test/render/index.js
+++ b/test/render/index.js
@@ -1,4 +1,5 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import test from 'tape';


### PR DESCRIPTION
 https://github.com/visgl/loaders.gl/issues/2830 Making every file correctly reflect all licenses will require a lot of forensics. This updates the general license and then covers the 3D tiles module only