### PR TITLE
fix: version injection

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,22 +1,27 @@
 // @ts-ignore
 const {getBabelConfig} = require('ocular-dev-tools/configuration');
 
-module.exports = getBabelConfig({
+const config = getBabelConfig({
   react: true,
-  plugins: [
-    // inject __VERSION__ from package.json
-    'version-inline'
-  ],
-  ignore: [
-    // Don't transpile workers, they are transpiled separately
-    '**/*.worker.js',
-    '**/workers/*.js',
-    // Don't transpile files in libs, we use this folder to store external,
-    // already transpiled and minified libraries and scripts.
-    // e.g. draco, basis, las-perf etc.
-    /src\/libs/,
-    // babel can't process .d.ts
-    /\.d\.ts$/
-  ],
+  overrides: {
+    plugins: [
+      // inject __VERSION__ from package.json
+      'version-inline'
+    ],
+    ignore: [
+      // Don't transpile workers, they are transpiled separately
+      '**/*.worker.js',
+      '**/workers/*.js',
+      // Don't transpile files in libs, we use this folder to store external,
+      // already transpiled and minified libraries and scripts.
+      // e.g. draco, basis, las-perf etc.
+      /src\/libs/,
+      // babel can't process .d.ts
+      /\.d\.ts$/
+    ]
+  },
+  // Set to true to print the config to console.
   debug: false
 });
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   ],
   "resolutions": {
     "@typescript-eslint/eslint-plugin": "^6.0.0",
-    "@typescript-eslint/parser" : "^6.0.0",
+    "@typescript-eslint/parser": "^6.0.0",
     "prettier": "3.0.3",
     "typescript": "^5.3.0"
   },


### PR DESCRIPTION
- ocular had moved all babel configs into a subfield, no typings meant no warnings.
- this handles the subset of compilation that still goes through babel
- worker builds e.g. rely on version injection through esbuild parameters.
- scripts esbuild from babel transpiled source so they are OK for now.