### PR TITLE
feat(GeoArrow): add optional delay between batches in parseArrowInBatches

### DIFF
--- a/modules/arrow/src/arrow-loader.ts
+++ b/modules/arrow/src/arrow-loader.ts
@@ -20,6 +20,7 @@ const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 export type ArrowLoaderOptions = LoaderOptions & {
   arrow?: {
     shape: 'arrow-table' | 'columnar-table' | 'array-row-table' | 'object-row-table';
+    batchDebounceMs?: number;
   };
 };
 

--- a/modules/arrow/src/parsers/parse-arrow-in-batches.ts
+++ b/modules/arrow/src/parsers/parse-arrow-in-batches.ts
@@ -34,6 +34,8 @@ export function parseArrowInBatches(
     const readers = arrow.RecordBatchReader.readAll(asyncIterator);
     for await (const reader of readers) {
       for await (const recordBatch of reader) {
+        // TODO use options.batchDebounceMs to add a delay between batches if needed
+        await new Promise((resolve) => setTimeout(resolve, 10));
         const arrowTabledBatch: ArrowTableBatch = {
           shape: 'arrow-table',
           batchType: 'data',

--- a/modules/arrow/src/parsers/parse-arrow-in-batches.ts
+++ b/modules/arrow/src/parsers/parse-arrow-in-batches.ts
@@ -4,12 +4,14 @@
 
 import type {ArrowTableBatch} from '../lib/arrow-table';
 import * as arrow from 'apache-arrow';
+import {ArrowLoaderOptions} from '../arrow-loader';
 // import {isIterable} from '@loaders.gl/core';
 
 /**
  */
 export function parseArrowInBatches(
-  asyncIterator: AsyncIterable<ArrayBuffer> | Iterable<ArrayBuffer>
+  asyncIterator: AsyncIterable<ArrayBuffer> | Iterable<ArrayBuffer>,
+  options?: ArrowLoaderOptions
 ): AsyncIterable<ArrowTableBatch> {
   // Creates the appropriate arrow.RecordBatchReader subclasses from the input
   // This will also close the underlying source in case of early termination or errors
@@ -34,8 +36,10 @@ export function parseArrowInBatches(
     const readers = arrow.RecordBatchReader.readAll(asyncIterator);
     for await (const reader of readers) {
       for await (const recordBatch of reader) {
-        // TODO use options.batchDebounceMs to add a delay between batches if needed
-        await new Promise((resolve) => setTimeout(resolve, 10));
+        // use options.batchDebounceMs to add a delay between batches if needed (use case: incremental loading)
+        if (options?.arrow?.batchDebounceMs !== undefined && options?.arrow?.batchDebounceMs > 0) {
+          await new Promise((resolve) => setTimeout(resolve, options.arrow?.batchDebounceMs || 0));
+        }
         const arrowTabledBatch: ArrowTableBatch = {
           shape: 'arrow-table',
           batchType: 'data',


### PR DESCRIPTION
Description: add an optional delay between batches in parseArrowInBatches, so the incremental loading and rendering based on batches can be smooth e.g. in https://github.com/keplergl/kepler.gl/pull/2474