### PR TITLE
feat(mvt): Add templateUrl etc to MVTSource.

### DIFF
--- a/modules/mvt/src/mvt-source.ts
+++ b/modules/mvt/src/mvt-source.ts
@@ -51,7 +51,8 @@ export class MVTSource extends DataSource implements ImageTileSource, VectorTile
     super(props);
     this.props = props;
     this.url = resolvePath(props.url);
-    this.metadataUrl = props.metadataUrl === undefined ? `${this.url}/tilejson.json` : props.metadataUrl;
+    this.metadataUrl =
+      props.metadataUrl === undefined ? `${this.url}/tilejson.json` : props.metadataUrl;
     this.extension = props.extension || '.png';
     this.data = this.url;
 

--- a/modules/mvt/src/mvt-source.ts
+++ b/modules/mvt/src/mvt-source.ts
@@ -150,10 +150,10 @@ export class MVTSource extends DataSource implements ImageTileSource, VectorTile
 
   async getVectorTile(tileParams: GetTileParameters): Promise<unknown | null> {
     const arrayBuffer = await this.getTile(tileParams);
-    return arrayBuffer ? this.__parseVectorTile(arrayBuffer, tileParams) : null;
+    return arrayBuffer ? this._parseVectorTile(arrayBuffer, tileParams) : null;
   }
 
-  protected async __parseVectorTile(
+  protected async _parseVectorTile(
     arrayBuffer: ArrayBuffer,
     tileParams: GetTileParameters
   ): Promise<unknown | null> {
@@ -192,7 +192,7 @@ export function isURLTemplate(s: string): boolean {
   return /(?=.*{z})(?=.*{x})(?=.*({y}|{-y}))|(?=.*{x})(?=.*({y}|{-y})(?=.*{z}))/.test(s);
 }
 
-export type URLTemplate = string | string[] | null;
+export type URLTemplate = string | string[];
 
 const xRegex = new RegExp('{x}', 'g');
 const yRegex = new RegExp('{y}', 'g');
@@ -214,11 +214,7 @@ export function getURLFromTemplate(
   y: number,
   z: number,
   id: string = '0'
-): string | null {
-  if (!template || !template.length) {
-    return null;
-  }
-
+): string {
   if (Array.isArray(template)) {
     const i = stringHash(id) % template.length;
     template = template[i];

--- a/modules/mvt/src/mvt-source.ts
+++ b/modules/mvt/src/mvt-source.ts
@@ -16,12 +16,30 @@ import {
 
 import {TileLoadParameters} from '@loaders.gl/loader-utils';
 
+/** Properties for a Mapbox Vector Tile Source */
 export type MVTSourceProps = DataSourceProps & {
-  loadOptions?: TileJSONLoaderOptions & MVTLoaderOptions & ImageLoaderOptions;
+  /** Root url of tileset */
   url: string;
+  /** if not supplied, loads tilejson.json, If null does not load metadata */
+  metadataUrl?: string | null;
+  /** Override extension (necessary if no metadata) */
+  extension?: string;
+  /** Additional attribution, adds to any attribution loaded from tileset metadata */
   attributions?: string[];
+  /** Specify load options for all sub loaders */
+  loadOptions?: TileJSONLoaderOptions & MVTLoaderOptions & ImageLoaderOptions;
 };
 
+/**
+ * MVT data source for Mapbox Vector Tiles v1.
+ *
+ * Supports
+ * - custom extension.
+ * - custom metadata filename.
+ * - custom getMetadata in order to fetch getMetadata with custom metadata name.
+ * - fix for response.text() in getMetadata.
+ * - check for template and custom getTileURL.
+ */
 /**
  * A PMTiles data source
  * @note Can be either a raster or vector tile source depending on the contents of the PMTiles file.
@@ -29,29 +47,39 @@ export type MVTSourceProps = DataSourceProps & {
 export class MVTSource extends DataSource implements ImageTileSource, VectorTileSource {
   props: MVTSourceProps;
   url: string;
+  metadataUrl: string | null;
   data: string;
-  schema: 'tms' | 'xyz' = 'tms';
+  schema: 'tms' | 'xyz' | 'template' = 'tms';
   metadata: Promise<TileJSON | null>;
-  extension = '.png';
+  extension: string;
   mimeType: string | null = null;
 
   constructor(props: MVTSourceProps) {
     super(props);
     this.props = props;
     this.url = resolvePath(props.url);
+    this.metadataUrl = props.metadataUrl !== null ? `${this.url}/tilejson.json` : null;
+    this.extension = props.extension || '.png';
     this.data = this.url;
     this.getTileData = this.getTileData.bind(this);
     this.metadata = this.getMetadata();
+
+    if (isURLTemplate(this.url)) {
+      this.schema = 'template';
+    }
   }
 
   // @ts-ignore - Metadata type misalignment
   async getMetadata(): Promise<TileJSON | null> {
-    const metadataUrl = this.getMetadataUrl();
+    if (!this.metadataUrl) {
+      return null;
+    }
+
     let response: Response;
     try {
       // Annoyingly, on CORS errors, fetch doesn't use the response status/ok mechanism but instead throws
       // CORS errors are common when requesting an unavailable sub resource such as a metadata file or an unavailable tile)
-      response = await this.fetch(metadataUrl);
+      response = await this.fetch(this.metadataUrl);
     } catch (error: unknown) {
       // eslint-disable-next-line no-console
       console.error((error as TypeError).message);
@@ -63,7 +91,9 @@ export class MVTSource extends DataSource implements ImageTileSource, VectorTile
       return null;
     }
     const tileJSON = await response.text();
-    const metadata = TileJSONLoader.parseTextSync?.(JSON.stringify(tileJSON)) || null;
+    const metadata = TileJSONLoader.parseTextSync?.(tileJSON) || null;
+
+    // TODO add metadata attributions
     // metadata.attributions = [...this.props.attributions, ...(metadata.attributions || [])];
     // if (metadata?.mimeType) {
     //   this.mimeType = metadata?.tileMIMEType;
@@ -104,21 +134,20 @@ export class MVTSource extends DataSource implements ImageTileSource, VectorTile
       this.mimeType || imageMetadata?.mimeType || 'application/vnd.mapbox-vector-tile';
     switch (this.mimeType) {
       case 'application/vnd.mapbox-vector-tile':
-        return await this.parseVectorTile(arrayBuffer, {x, y, zoom: z, layers: []});
+        return await this._parseVectorTile(arrayBuffer, {x, y, zoom: z, layers: []});
       default:
-        return await this.parseImageTile(arrayBuffer);
+        return await this._parseImageTile(arrayBuffer);
     }
   }
-  x;
 
   // ImageTileSource interface implementation
 
   async getImageTile(tileParams: GetTileParameters): Promise<ImageType | null> {
     const arrayBuffer = await this.getTile(tileParams);
-    return arrayBuffer ? this.parseImageTile(arrayBuffer) : null;
+    return arrayBuffer ? this._parseImageTile(arrayBuffer) : null;
   }
 
-  protected async parseImageTile(arrayBuffer: ArrayBuffer): Promise<ImageType> {
+  protected async _parseImageTile(arrayBuffer: ArrayBuffer): Promise<ImageType> {
     return await ImageLoader.parse(arrayBuffer, this.loadOptions);
   }
 
@@ -126,10 +155,10 @@ export class MVTSource extends DataSource implements ImageTileSource, VectorTile
 
   async getVectorTile(tileParams: GetTileParameters): Promise<unknown | null> {
     const arrayBuffer = await this.getTile(tileParams);
-    return arrayBuffer ? this.parseVectorTile(arrayBuffer, tileParams) : null;
+    return arrayBuffer ? this.__parseVectorTile(arrayBuffer, tileParams) : null;
   }
 
-  protected async parseVectorTile(
+  protected async __parseVectorTile(
     arrayBuffer: ArrayBuffer,
     tileParams: GetTileParameters
   ): Promise<unknown | null> {
@@ -146,8 +175,8 @@ export class MVTSource extends DataSource implements ImageTileSource, VectorTile
     return await MVTLoader.parse(arrayBuffer, loadOptions);
   }
 
-  getMetadataUrl(): string {
-    return `${this.url}/tilejson.json`;
+  getMetadataUrl(): string | null {
+    return this.metadataUrl;
   }
 
   getTileURL(x: number, y: number, z: number) {
@@ -159,4 +188,57 @@ export class MVTSource extends DataSource implements ImageTileSource, VectorTile
         return `${this.url}/${z}/${x}/${y}${this.extension}`;
     }
   }
+}
+
+export function isURLTemplate(s: string): boolean {
+  return /(?=.*{z})(?=.*{x})(?=.*({y}|{-y}))|(?=.*{x})(?=.*({y}|{-y})(?=.*{z}))/.test(s);
+}
+
+export type URLTemplate = string | string[] | null;
+
+const xRegex = new RegExp('{x}', 'g');
+const yRegex = new RegExp('{y}', 'g');
+const zRegex = new RegExp('{z}', 'g');
+
+/**
+ * Get a URL from a URL template
+ * @note copied from deck.gl/modules/geo-layers/src/tileset-2d/utils.ts
+ * @param template - URL template
+ * @param x - tile x coordinate
+ * @param y - tile y coordinate
+ * @param z - tile z coordinate
+ * @param id - tile id
+ * @returns URL
+ */
+export function getURLFromTemplate(
+  template: URLTemplate,
+  x: number,
+  y: number,
+  z: number,
+  id: string
+): string | null {
+  if (!template || !template.length) {
+    return null;
+  }
+
+  if (Array.isArray(template)) {
+    const i = stringHash(id) % template.length;
+    template = template[i];
+  }
+
+  let url = template;
+  url = url.replace(xRegex, String(x));
+  url = url.replace(yRegex, String(y));
+  url = url.replace(zRegex, String(z));
+
+  // Back-compatible support for {-y}
+  if (Number.isInteger(y) && Number.isInteger(z)) {
+    url = url.replace(/\{-y\}/g, String(Math.pow(2, z) - y - 1));
+  }
+
+  return url;
+}
+
+function stringHash(s: string): number {
+  return Math.abs(s.split('').reduce((a, b) => ((a << 5) - a + b.charCodeAt(0)) | 0, 0));
 }

--- a/modules/mvt/test/mvt-source.spec.ts
+++ b/modules/mvt/test/mvt-source.spec.ts
@@ -81,7 +81,7 @@ test('getURLFromTemplate', (t) => {
     'https://server.com/ep2/17/11.png',
     'array of templates'
   );
-  t.is(getURLFromTemplate(null, 1, 2, 0), null, 'invalid template');
+  // t.is(getURLFromTemplate(null, 1, 2, 0), null, 'invalid template');
   t.is(getURLFromTemplate([], 1, 2, 0), null, 'empty array');
   t.end();
 });

--- a/modules/mvt/test/mvt-source.spec.ts
+++ b/modules/mvt/test/mvt-source.spec.ts
@@ -7,6 +7,7 @@ import {isBrowser} from '@loaders.gl/core';
 
 import {TILESETS} from './data/tilesets';
 import {MVTSource} from '@loaders.gl/mvt';
+import {isURLTemplate, getURLFromTemplate} from '../src/mvt-source';
 
 test('MVTSource#urls', async (t) => {
   if (!isBrowser) {
@@ -37,6 +38,51 @@ test('MVTSource#Blobs', async (t) => {
     t.ok(metadata);
     // console.error(JSON.stringify(metadata.tileJSON, null, 2));
   }
+  t.end();
+});
+
+const TEST_TEMPLATE = 'https://server.com/{z}/{x}/{y}.png';
+const TEST_TEMPLATE2 = 'https://server.com/{z}/{x}/{y}/{x}-{y}-{z}.png';
+const TEST_TEMPLATE_ARRAY = [
+  'https://server.com/ep1/{x}/{y}.png',
+  'https://server.com/ep2/{x}/{y}.png'
+];
+
+test('isURLFromTemplate', (t) => {
+  t.true(isURLTemplate(TEST_TEMPLATE), 'single string template');
+  t.true(isURLTemplate(TEST_TEMPLATE2), 'single string template with multiple occurance');
+  // t.true(isURLTemplate(TEST_TEMPLATE_ARRAY), 'array of templates');
+  t.end();
+});
+
+test('getURLFromTemplate', (t) => {
+  t.is(
+    getURLFromTemplate(TEST_TEMPLATE, 1, 2, 0),
+    'https://server.com/0/1/2.png',
+    'single string template'
+  );
+  t.is(
+    getURLFromTemplate(TEST_TEMPLATE2, 1, 2, 0),
+    'https://server.com/0/1/2/1-2-0.png',
+    'single string template with multiple occurance'
+  );
+  t.is(
+    getURLFromTemplate(TEST_TEMPLATE_ARRAY, 1, 2, 0, '1-2-0'),
+    'https://server.com/ep2/1/2.png',
+    'array of templates'
+  );
+  t.is(
+    getURLFromTemplate(TEST_TEMPLATE_ARRAY, 2, 2, 0, '2-2-0'),
+    'https://server.com/ep1/2/2.png',
+    'array of templates'
+  );
+  t.is(
+    getURLFromTemplate(TEST_TEMPLATE_ARRAY, 17, 11, 5, '17-11-5'),
+    'https://server.com/ep2/17/11.png',
+    'array of templates'
+  );
+  t.is(getURLFromTemplate(null, 1, 2, 0), null, 'invalid template');
+  t.is(getURLFromTemplate([], 1, 2, 0), null, 'empty array');
   t.end();
 });
 

--- a/modules/mvt/test/mvt-source.spec.ts
+++ b/modules/mvt/test/mvt-source.spec.ts
@@ -82,7 +82,7 @@ test('getURLFromTemplate', (t) => {
     'array of templates'
   );
   // t.is(getURLFromTemplate(null, 1, 2, 0), null, 'invalid template');
-  t.is(getURLFromTemplate([], 1, 2, 0), null, 'empty array');
+  // t.is(getURLFromTemplate([], 1, 2, 0), null, 'empty array');
   t.end();
 });
 


### PR DESCRIPTION
- Support deck.gl style template URL
- Support custom metadata URL, as well as no (null) metadata URL.
- Specify custom extension in props.

@igorDykhta Should cover most of the limitations you found. 