### PR TITLE
fix(loader-utils): Guard against infinite recursion

### DIFF
--- a/modules/loader-utils/src/lib/option-utils/merge-loader-options.ts
+++ b/modules/loader-utils/src/lib/option-utils/merge-loader-options.ts
@@ -19,14 +19,21 @@ export function mergeLoaderOptions<Options extends LoaderOptions>(
 
 function mergeOptionsRecursively(
   baseOptions: Record<string, unknown>,
-  newOptions: Record<string, unknown>
+  newOptions: Record<string, unknown>, 
+  level = 0
 ): Record<string, unknown> {
+  // Sanity check (jest test runner overwrites the console object which can lead to infinite recursion)
+  if (level > 3) {
+    return baseOptions
+  }
+
   const options = {...baseOptions};
   for (const [key, newValue] of Object.entries(newOptions)) {
     if (newValue && typeof newValue === 'object' && !Array.isArray(newValue)) {
       options[key] = mergeOptionsRecursively(
         (options[key] as Record<string, unknown>) || {},
-        newOptions[key] as Record<string, unknown>
+        newOptions[key] as Record<string, unknown>, 
+        level + 1
       );
       // Object.assign(options[key] as object, newOptions[key]);
     } else {

--- a/modules/loader-utils/src/lib/option-utils/merge-loader-options.ts
+++ b/modules/loader-utils/src/lib/option-utils/merge-loader-options.ts
@@ -24,7 +24,7 @@ function mergeOptionsRecursively(
 ): Record<string, unknown> {
   // Sanity check (jest test runner overwrites the console object which can lead to infinite recursion)
   if (level > 3) {
-    return baseOptions;
+    return newOptions;
   }
 
   const options = {...baseOptions};

--- a/modules/loader-utils/src/lib/option-utils/merge-loader-options.ts
+++ b/modules/loader-utils/src/lib/option-utils/merge-loader-options.ts
@@ -19,12 +19,12 @@ export function mergeLoaderOptions<Options extends LoaderOptions>(
 
 function mergeOptionsRecursively(
   baseOptions: Record<string, unknown>,
-  newOptions: Record<string, unknown>, 
+  newOptions: Record<string, unknown>,
   level = 0
 ): Record<string, unknown> {
   // Sanity check (jest test runner overwrites the console object which can lead to infinite recursion)
   if (level > 3) {
-    return baseOptions
+    return baseOptions;
   }
 
   const options = {...baseOptions};
@@ -32,7 +32,7 @@ function mergeOptionsRecursively(
     if (newValue && typeof newValue === 'object' && !Array.isArray(newValue)) {
       options[key] = mergeOptionsRecursively(
         (options[key] as Record<string, unknown>) || {},
-        newOptions[key] as Record<string, unknown>, 
+        newOptions[key] as Record<string, unknown>,
         level + 1
       );
       // Object.assign(options[key] as object, newOptions[key]);


### PR DESCRIPTION
Don't want to risk breaking the functionality or spend too much time on this right now, so just adding a trivial guard to prevent jest overrides from triggering infinite recursion.

@nrabinowitz