### PR TITLE
feat(geotiff): RGB GeoTIFFLoader

### DIFF
--- a/modules/geotiff/src/index.ts
+++ b/modules/geotiff/src/index.ts
@@ -2,5 +2,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
+export {RGBGeoTiffLoader} from './loaders';
 export {loadGeoTiff} from './lib/load-geotiff';
 export {default as TiffPixelSource} from './lib/tiff-pixel-source';

--- a/modules/geotiff/src/index.ts
+++ b/modules/geotiff/src/index.ts
@@ -2,6 +2,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-export {RGBGeoTiffLoader} from './loaders';
+export {GeoTiffLoader} from './loaders';
 export {loadGeoTiff} from './lib/load-geotiff';
 export {default as TiffPixelSource} from './lib/tiff-pixel-source';

--- a/modules/geotiff/src/loaders.ts
+++ b/modules/geotiff/src/loaders.ts
@@ -1,0 +1,68 @@
+import { fromArrayBuffer } from "geotiff";
+import type {LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';
+
+// __VERSION__ is injected by babel-plugin-version-inline
+// @ts-ignore TS2304: Cannot find name '__VERSION__'.
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+
+// Type definitions
+type GeoTiffData =  {
+    bounds: number[],
+    width: number,
+    height: number,
+    imageData: ImageData,
+}
+
+interface RGBGeoTiffLoaderOptions extends LoaderOptions {
+    enableAlpha: boolean;
+}
+
+/**
+ * Loads a GeoTIFF file containing a RGB image.
+ */
+const loadRgbGeoTiff = async (
+    data: ArrayBuffer, 
+    options?: RGBGeoTiffLoaderOptions
+): Promise<GeoTiffData> => {
+    // Load using Geotiff.js
+    const tiff = await fromArrayBuffer(data);
+
+    // Assumes we only have one image inside TIFF
+    const image = await tiff.getImage();
+
+    // Read image and size 
+    // TODO: Add support for worker pools here.
+    // TODO: Add support for more image formats.
+    const rgbData = await image.readRGB({ 
+        enableAlpha: options?.enableAlpha, 
+    });
+    const width = image.getWidth();
+    const height = image.getHeight();
+
+    // Create a new ImageData object
+    const imageData = new ImageData(width, height);
+    imageData.data.set(new Uint8ClampedArray(rgbData as unknown as Uint8Array));
+
+    // Return GeoJSON data
+    return {
+        // TODO: Add bounds here
+        bounds: [],
+        imageData,
+        width,
+        height,
+    };
+};
+
+// Export loader
+export const RGBGeoTiffLoader: LoaderWithParser<GeoTiffData, never, RGBGeoTiffLoaderOptions> = {
+    id: "geotiff",
+    name: "GeoTIFF",
+    module: "geotiff",
+    version: VERSION,
+    options: {
+        enableAlpha: true,
+    },
+    mimeTypes: ["image/tiff", "image/geotiff"],
+    extensions: ["geotiff", "tiff", "geotif", "tif"],
+    parse: loadRgbGeoTiff,
+};

--- a/modules/geotiff/src/loaders.ts
+++ b/modules/geotiff/src/loaders.ts
@@ -13,16 +13,16 @@ type GeoTiffData =  {
     imageData: ImageData,
 }
 
-interface RGBGeoTiffLoaderOptions extends LoaderOptions {
+interface GeoTiffLoaderOptions extends LoaderOptions {
     enableAlpha: boolean;
 }
 
 /**
  * Loads a GeoTIFF file containing a RGB image.
  */
-const loadRgbGeoTiff = async (
+const loadGeoTiff = async (
     data: ArrayBuffer, 
-    options?: RGBGeoTiffLoaderOptions
+    options?: GeoTiffLoaderOptions
 ): Promise<GeoTiffData> => {
     // Load using Geotiff.js
     const tiff = await fromArrayBuffer(data);
@@ -54,7 +54,7 @@ const loadRgbGeoTiff = async (
 };
 
 // Export loader
-export const RGBGeoTiffLoader: LoaderWithParser<GeoTiffData, never, RGBGeoTiffLoaderOptions> = {
+export const GeoTiffLoader: LoaderWithParser<GeoTiffData, never, GeoTiffLoaderOptions> = {
     id: "geotiff",
     name: "GeoTIFF",
     module: "geotiff",
@@ -64,5 +64,5 @@ export const RGBGeoTiffLoader: LoaderWithParser<GeoTiffData, never, RGBGeoTiffLo
     },
     mimeTypes: ["image/tiff", "image/geotiff"],
     extensions: ["geotiff", "tiff", "geotif", "tif"],
-    parse: loadRgbGeoTiff,
+    parse: loadGeoTiff,
 };


### PR DESCRIPTION
This is an experimental version of a GeoTIFF loader. Its goal is to add native RGB GeoTIFF rendering support for deck.gl to render aerial images, orthophotos and overlays into a deck instance.

**Discussion on:** #1280 

**TODO:**
- [ ] Retrieve bounds/geospatial data from GeoTiff and add them to loader response
- [ ] Add tests
- [ ] Add example to deck.gl (with sample GeoTiff file)
- [ ] Split methods into proper files and folders
- [ ] Write testing instructions

**Testing instructions:**

TBD