### PR TITLE
Fix loadExplicitBitstream by accounting for buffer offset and byte length when extracting from a combined binary blob

### DIFF
--- a/modules/3d-tiles/src/lib/parsers/helpers/parse-3d-tile-subtree.ts
+++ b/modules/3d-tiles/src/lib/parsers/helpers/parse-3d-tile-subtree.ts
@@ -76,7 +76,7 @@ export default async function parse3DTilesSubtree(
  * @param internalBinaryBuffer - subtree binary buffer
  * @param context - loaders.gl context
  */
-async function loadExplicitBitstream(
+export async function loadExplicitBitstream(
   subtree: Subtree,
   availabilityObject: Availability,
   internalBinaryBuffer: ArrayBuffer,
@@ -113,8 +113,13 @@ async function loadExplicitBitstream(
     );
     return;
   }
+
+  const bufferStart = subtree.buffers
+    .slice(0, bufferView.buffer)
+    .reduce((offset, buf) => offset + buf.byteLength, 0);
+
   availabilityObject.explicitBitstream = new Uint8Array(
-    internalBinaryBuffer,
+    internalBinaryBuffer.slice(bufferStart, bufferStart + buffer.byteLength),
     bufferView.byteOffset,
     bufferView.byteLength
   );

--- a/modules/3d-tiles/src/types.ts
+++ b/modules/3d-tiles/src/types.ts
@@ -325,10 +325,10 @@ export type Subtree = {
    */
   childSubtreeAvailability: Availability;
   // TODO: These are unused properties. Improve types when they are required
-  propertyTables: unknown;
-  tileMetadata: unknown;
-  contentMetadata: unknown;
-  subtreeMetadata: unknown;
+  propertyTables?: unknown;
+  tileMetadata?: unknown;
+  contentMetadata?: unknown;
+  subtreeMetadata?: unknown;
 };
 
 export type Availability = {

--- a/modules/3d-tiles/test/index.ts
+++ b/modules/3d-tiles/test/index.ts
@@ -13,6 +13,7 @@ import './lib/parsers/parse-3d-tile-header.spec';
 // TODO v4.0 restore these tests
 // import './lib/parsers/helpers/gpu-memory-usage.spec';
 import './lib/parsers/helpers/normalize-3d-tile-colors.spec';
+import './lib/parsers/helpers/parse-3d-tile-subtree.spec';
 
 // import './styles/expression.spec';
 // import './styles/conditions-expression.spec';

--- a/modules/3d-tiles/test/lib/parsers/helpers/parse-3d-tile-subtree.spec.ts
+++ b/modules/3d-tiles/test/lib/parsers/helpers/parse-3d-tile-subtree.spec.ts
@@ -1,0 +1,82 @@
+import test from 'tape-promise/tape';
+
+import {loadExplicitBitstream} from '../../../../src/lib/parsers/helpers/parse-3d-tile-subtree';
+import {Subtree, Availability} from '../../../../src/types';
+import {LoaderContext} from '@loaders.gl/loader-utils';
+
+const context = (): LoaderContext => ({
+  fetch,
+  _parse: async (arrayBuffer) => arrayBuffer,
+  baseUrl: 'fake/url'
+});
+
+test('loadExplicitBitstream extracts a single buffer to an explicit bitstream', async (t) => {
+  const tileAvailability: Availability = {bitstream: 0};
+  const subtree: Subtree = {
+    buffers: [
+      {
+        name: 'Tile availability',
+        byteLength: 1
+      }
+    ],
+    bufferViews: [
+      {
+        buffer: 0,
+        byteOffset: 0,
+        byteLength: 1
+      }
+    ],
+    tileAvailability,
+    contentAvailability: {constant: 1},
+    childSubtreeAvailability: {constant: 0}
+  };
+  const internalBinaryBuffer = new Uint8Array([255]);
+
+  t.deepEqual(tileAvailability.explicitBitstream, undefined);
+
+  await loadExplicitBitstream(subtree, tileAvailability, internalBinaryBuffer, context());
+
+  t.deepEqual(tileAvailability.explicitBitstream, new Uint8Array([255]));
+});
+
+test('loadExplicitBitstream extracts multiple buffers to explicit bitstreams', async (t) => {
+  const tileAvailability: Availability = {bitstream: 0};
+  const contentAvailability: Availability = {bitstream: 1};
+  const subtree: Subtree = {
+    buffers: [
+      {
+        name: 'Tile availability',
+        byteLength: 1
+      },
+      {
+        name: 'Content availability',
+        byteLength: 1
+      }
+    ],
+    bufferViews: [
+      {
+        buffer: 0,
+        byteOffset: 0,
+        byteLength: 1
+      },
+      {
+        buffer: 1,
+        byteOffset: 0,
+        byteLength: 1
+      }
+    ],
+    tileAvailability,
+    contentAvailability: [contentAvailability],
+    childSubtreeAvailability: {constant: 0}
+  };
+  const internalBinaryBuffer = new Uint8Array([255, 128]);
+
+  t.deepEqual(tileAvailability.explicitBitstream, undefined);
+  t.deepEqual(contentAvailability.explicitBitstream, undefined);
+
+  await loadExplicitBitstream(subtree, tileAvailability, internalBinaryBuffer, context());
+  t.deepEqual(tileAvailability.explicitBitstream, new Uint8Array([255]));
+
+  await loadExplicitBitstream(subtree, contentAvailability, internalBinaryBuffer, context());
+  t.deepEqual(contentAvailability.explicitBitstream, new Uint8Array([128]));
+});


### PR DESCRIPTION
Currently, loadExplicitBitstream works correctly for implicit tilesets containing a single buffer. However, because the implementation ignores both the buffer length and its offset, for tilesets with multiple buffers embedded in a binary subtree (rather than as separate .bin files), loadExplicitBitstream returns the entire binary buffer every time loadExplicitBitstream is called.

In other words: if the buffer B = B0 + B1, loadExplicitBitstream(B, 0) and loadExplicitBitstream(B, 1) currently both return B0 + B1. Instead, loadExplicitBitstream(B, 0) should return only B0 and loadExplicitBitstream(B, 1) should return only B1.

This PR fixes the issue by slicing the main buffer according to the offset and byte-length of the target buffer. This PR also adds unit tests for loadExplicitBitstream which confirm the fix.