### PR TITLE
Update the empty traversal algorithm to match CesiumJS, possible fix for low-res flickering

### DIFF
--- a/modules/tiles/src/tileset/tileset-traverser.ts
+++ b/modules/tiles/src/tileset/tileset-traverser.ts
@@ -335,38 +335,35 @@ export class TilesetTraverser {
   executeEmptyTraversal(root: Tile3D, frameState: FrameState): boolean {
     let allDescendantsLoaded = true;
     const stack = this._emptyTraversalStack;
-
     stack.push(root);
 
-    while (stack.length > 0 && allDescendantsLoaded) {
+    while (stack.length > 0) {
       const tile = stack.pop();
+
+      const traverse = !tile.hasRenderContent && this.canTraverse(tile, frameState, false, false);
+      const emptyLeaf = !tile.hasRenderableContent && tile.children.length === 0;
+
+      // Traversal stops but the tile does not have content yet
+      // There will be holes if the parent tries to refine to its children, so don't refine
+      // One exception: a parent may refine even if one of its descendants is an empty leaf
+      if (!traverse && !tile.contentAvailable && !emptyLeaf) {
+        allDescendantsLoaded = false;
+      }
 
       this.updateTile(tile, frameState);
 
       if (!tile.isVisibleAndInRequestVolume) {
-        // Load tiles that aren't visible since they are still needed for the parent to refine
         this.loadTile(tile, frameState);
+        this.touchTile(tile, frameState);
       }
-
-      this.touchTile(tile, frameState);
-
-      // Only traverse if the tile is empty - traversal stop at descendants with content
-      const traverse = !tile.hasRenderContent && this.canTraverse(tile, frameState, false, true);
 
       if (traverse) {
         const children = tile.children;
         for (const child of children) {
-          // eslint-disable-next-line max-depth
-          if (stack.find(child)) {
-            stack.delete(child);
-          }
           stack.push(child);
         }
-      } else if (!tile.contentAvailable && !tile.hasEmptyContent) {
-        allDescendantsLoaded = false;
       }
     }
-
     return allDescendantsLoaded;
   }
 }

--- a/modules/tiles/src/tileset/tileset-traverser.ts
+++ b/modules/tiles/src/tileset/tileset-traverser.ts
@@ -341,7 +341,7 @@ export class TilesetTraverser {
       const tile = stack.pop();
 
       const traverse = !tile.hasRenderContent && this.canTraverse(tile, frameState, false, false);
-      const emptyLeaf = !tile.hasRenderableContent && tile.children.length === 0;
+      const emptyLeaf = !tile.hasRenderContent && tile.children.length === 0;
 
       // Traversal stops but the tile does not have content yet
       // There will be holes if the parent tries to refine to its children, so don't refine


### PR DESCRIPTION
Hi!
After a year of absence I'm back doing some viz work. 
I'm now updating [nytimes/three-loader-3dtiles](https://github.com/nytimes/three-loader-3dtiles/tree/feature/loadersgl-4) to loaders.gl-4 and support for Google's 3D Tiles (*feature/loadersgl-4* branch).
I noticed one issue where low-res tiles flicker above the high-res tiles during traversals, possible related to [this issue](https://github.com/visgl/loaders.gl/issues/2570). It seemed to have come from some glitch in the "empty" traversal mechanism. I updated the algorithm to match the [latest CesiumJS one](https://github.com/CesiumGS/cesium/blob/66dba4b2e6bef81e5662499921c2eacd35a90dee/packages/engine/Source/Scene/Cesium3DTilesetBaseTraversal.js#L251C25-L251C26) and at least on my tests it seems to fix the issue and does not hinder performance. Could you also run some tests on your side, deck.gl and such?
And if this is good to merge, could you also merge it as a fix to the stable loaders.gl v4?
Thank you!
/Avner

