### PR TITLE
fix(loader-utils): concatenateArrayBuffers bottleneck fix

### DIFF
--- a/modules/loader-utils/src/index.ts
+++ b/modules/loader-utils/src/index.ts
@@ -64,6 +64,7 @@ export {parseJSON} from './lib/parser-utils/parse-json';
 export {
   sliceArrayBuffer,
   concatenateArrayBuffers,
+  concatenateArrayBuffersFromArray,
   concatenateTypedArrays,
   compareArrayBuffers
 } from './lib/binary-utils/array-buffer-utils';

--- a/modules/loader-utils/src/lib/binary-utils/array-buffer-utils.ts
+++ b/modules/loader-utils/src/lib/binary-utils/array-buffer-utils.ts
@@ -26,10 +26,18 @@ export function compareArrayBuffers(
 }
 
 /**
- * Concatenate a sequence of ArrayBuffers
+ * Concatenate a sequence of ArrayBuffers from arguments
  * @return A concatenated ArrayBuffer
  */
-export function concatenateArrayBuffers(...sources: (ArrayBuffer | Uint8Array)[]): ArrayBuffer {
+export function concatenateArrayBuffers(...sources: (ArrayBuffer | Uint8Array)[]): any {
+  return concatenateArrayBuffersFromArray(sources);
+}
+
+/**
+ * Concatenate a sequence of ArrayBuffers from array
+ * @return A concatenated ArrayBuffer
+ */
+export function concatenateArrayBuffersFromArray(sources: (ArrayBuffer | Uint8Array)[]): any {
   // Make sure all inputs are wrapped in typed arrays
   const sourceArrays = sources.map((source2) =>
     source2 instanceof ArrayBuffer ? new Uint8Array(source2) : source2

--- a/modules/zip/src/hash-file-utility.ts
+++ b/modules/zip/src/hash-file-utility.ts
@@ -3,7 +3,11 @@
 // Copyright (c) vis.gl contributors
 
 import {MD5Hash} from '@loaders.gl/crypto';
-import {FileProvider, concatenateArrayBuffers} from '@loaders.gl/loader-utils';
+import {
+  FileProvider,
+  concatenateArrayBuffers,
+  concatenateArrayBuffersFromArray
+} from '@loaders.gl/loader-utils';
 import {makeZipCDHeaderIterator} from './parse-zip/cd-file-header';
 
 /**
@@ -66,7 +70,7 @@ export async function composeHashFile(fileProvider: FileProvider): Promise<Array
   const bufferArray = Object.entries(hashArray)
     .map(([key, value]) => concatenateArrayBuffers(hexStringToBuffer(key), bigintToBuffer(value)))
     .sort(compareHashes);
-  return concatenateArrayBuffers(...bufferArray);
+  return concatenateArrayBuffersFromArray(bufferArray);
 }
 
 /**


### PR DESCRIPTION
I've got the `RangeError: Maximum call stack size exceeded` error for huge slpk creation. So I investigated and found out that we have a bottleneck on the current implementation of concatenateArrayBuffers function in amount of arguments. I haven't found any info about nodejs, but I've found the following article: https://stackoverflow.com/a/22747272 and it looks like node has the same limitation of max 65 535 arguments per function and throw the same error since it use the same V8 engine to interpret JS code. But number of files even in 5gb datasets can reach 800 000, so node can't handle it and throws an error.

To solve this problem I've created another function receiving `ArrayBuffer[]` instead of multiple arguments