### PR TITLE
chore: Update examples to type: module

### DIFF
--- a/examples/benchmarks/package.json
+++ b/examples/benchmarks/package.json
@@ -3,6 +3,7 @@
   "name": "loaders.gl-benchmark-example",
   "version": "1.0.0",
   "license": "MIT",
+  "type": "module",
   "scripts": {
     "start": "webpack-dev-server --progress --hot --open",
     "start-local": "webpack-dev-server --env.local --progress --hot --open"

--- a/examples/experimental/3d-tiles-with-cesium/package.json
+++ b/examples/experimental/3d-tiles-with-cesium/package.json
@@ -4,6 +4,7 @@
   "description": "Minimal example of using loaders.gl with Cesium.",
   "private": true,
   "license": "MIT",
+  "type": "module",
   "scripts": {
     "start": "webpack-dev-server --progress --hot --open -d",
     "start-local": "webpack-dev-server --env.local --env.esnext --progress --hot --open"

--- a/examples/experimental/basis/package.json
+++ b/examples/experimental/basis/package.json
@@ -3,6 +3,7 @@
   "description": "Minimal example of using loaders.gl with basis.",
   "version": "1.0.0",
   "license": "MIT",
+  "type": "module",
   "private": true,
   "scripts": {
     "start": "webpack-dev-server --progress --hot --open -d",

--- a/examples/experimental/gltf-with-deck.gl/package.json
+++ b/examples/experimental/gltf-with-deck.gl/package.json
@@ -3,6 +3,7 @@
   "name": "loadersgl-gltf-with-deckgl-example",
   "version": "1.0.0",
   "license": "MIT",
+  "type": "module",
   "scripts": {
     "start": "webpack-dev-server --progress --hot --open",
     "start-local": "webpack-dev-server --env.local --env.esnext --progress --hot --open"

--- a/examples/experimental/terrain/package.json
+++ b/examples/experimental/terrain/package.json
@@ -2,6 +2,7 @@
   "name": "terrain",
   "version": "0.0.0",
   "license": "MIT",
+  "type": "module",
   "scripts": {
     "start-local": "webpack-dev-server --env.local --env.esnext --progress --hot --open",
     "start-local-deck": "webpack-dev-server --env.local --env.esnext --env.deck --progress --hot --open",

--- a/examples/gallery/package.json
+++ b/examples/gallery/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Gallery of simple HTML page examples for loaders.gl",
   "license": "MIT",
+  "type": "module",
   "private": true,
   "scripts": {
     "start-progress": "open progress.html"

--- a/examples/get-started/bundle-with-nextjs/package.json
+++ b/examples/get-started/bundle-with-nextjs/package.json
@@ -4,6 +4,7 @@
   "description": "Minimal working example of using loaders.gl with Next.js.",
   "private": true,
   "license": "MIT",
+  "type": "module",
   "dependencies": {
     "@deck.gl/geo-layers": "^8.9.28",
     "@deck.gl/layers": "^8.9.28",

--- a/examples/get-started/bundle-with-rollup/package.json
+++ b/examples/get-started/bundle-with-rollup/package.json
@@ -4,6 +4,7 @@
   "description": "Minimal working example of using loaders.gl with rollup.",
   "private": true,
   "license": "MIT",
+  "type": "module",
   "contributors": [
     "@nshen"
   ],

--- a/examples/website/3d-tiles/package.json
+++ b/examples/website/3d-tiles/package.json
@@ -4,6 +4,7 @@
   "description": "Minimal example of using loaders.gl with vite.",
   "version": "0.0.0",
   "license": "MIT",
+  "type": "module",
   "scripts": {
     "start": "vite",
     "build": "tsc && vite build",

--- a/examples/website/geospatial/package.json
+++ b/examples/website/geospatial/package.json
@@ -4,6 +4,7 @@
   "description": "Minimal example of using loaders.gl with vite.",
   "version": "0.0.0",
   "license": "MIT",
+  "type": "module",
   "scripts": {
     "start": "vite",
     "build": "tsc && vite build",

--- a/examples/website/gltf/package.json
+++ b/examples/website/gltf/package.json
@@ -7,6 +7,7 @@
   ],
   "version": "0.0.0",
   "license": "MIT",
+  "type": "module",
   "scripts": {
     "start": "vite",
     "build": "tsc && vite build",

--- a/examples/website/i3s-arcgis/package.json
+++ b/examples/website/i3s-arcgis/package.json
@@ -3,6 +3,7 @@
   "name": "i3s-arcgis-loaders-example",
   "version": "1.0.0",
   "license": "MIT",
+  "type": "module",
   "scripts": {
     "start": "vite",
     "build": "tsc && vite build",

--- a/examples/website/i3s-building-scene-layer/package.json
+++ b/examples/website/i3s-building-scene-layer/package.json
@@ -4,6 +4,7 @@
   "description": "I3S loaders building scene layer",
   "version": "0.0.1",
   "license": "MIT",
+  "type": "module",
   "scripts": {
     "start": "vite",
     "build": "tsc && vite build",

--- a/examples/website/i3s/package.json
+++ b/examples/website/i3s/package.json
@@ -4,6 +4,7 @@
   "description": "I3S loaders.",
   "version": "0.0.0",
   "license": "MIT",
+  "type": "module",
   "scripts": {
     "start": "vite",
     "build": "tsc && vite build",

--- a/examples/website/pointcloud/package.json
+++ b/examples/website/pointcloud/package.json
@@ -3,6 +3,7 @@
   "name": "loaders.gl-example-pointcloud-loaders",
   "version": "3.3.0",
   "license": "MIT",
+  "type": "module",
   "scripts": {
     "start": "vite",
     "build": "tsc && vite build",

--- a/examples/website/textures/package.json
+++ b/examples/website/textures/package.json
@@ -3,6 +3,7 @@
   "name": "loaders.gl-example-textures-tester",
   "version": "3.3.0",
   "license": "MIT",
+  "type": "module",
   "scripts": {
     "start": "vite",
     "build": "tsc && vite build",

--- a/examples/website/tiles/package.json
+++ b/examples/website/tiles/package.json
@@ -4,6 +4,7 @@
   "description": "Minimal example of using loaders.gl with vite.",
   "version": "0.0.0",
   "license": "MIT",
+  "type": "module",
   "scripts": {
     "start": "vite",
     "build": "tsc && vite build",

--- a/examples/website/wms/package.json
+++ b/examples/website/wms/package.json
@@ -4,6 +4,7 @@
   "description": "WMS loaders.",
   "version": "0.0.0",
   "license": "MIT",
+  "type": "module",
   "scripts": {
     "start": "vite",
     "build": "tsc && vite build",


### PR DESCRIPTION
Preparing for Vite 6.0
- The CJS build of Vite's Node API is deprecated. See https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.

@belom88 We need to do some test of the `get-started` examples. They use old bundler versions and I expect them to need some TLC. Is that testing something AE could help with?