### PR TITLE
[Feat] Convert GeoJson Features to GeoArrow (Draft)

### DIFF
--- a/modules/arrow/src/geoarrow/convert-geojson-feature-to-arrow.ts
+++ b/modules/arrow/src/geoarrow/convert-geojson-feature-to-arrow.ts
@@ -1,0 +1,319 @@
+import {
+  Float64 as ArrowFloat,
+  FixedSizeList,
+  Field as ArrowField,
+  List as ArrowList,
+  Vector as ArrowVector,
+  makeBuilder
+} from 'apache-arrow';
+import {
+  Point,
+  MultiPoint,
+  LineString,
+  MultiLineString,
+  Polygon,
+  MultiPolygon,
+  Feature
+} from 'geojson';
+
+/**
+ * Arrow Field and geometry vector
+ */
+export type GeoArrowReturnType = {
+  field: ArrowField;
+  geometry: ArrowVector;
+};
+
+/**
+ * Convert GeoJson Features to GeoArrow
+ * @param name
+ * @param features
+ * @returns GeoArrowReturnType
+ */
+export function geojsonFeaturesToArrow(name: string, features: Feature[]): GeoArrowReturnType {
+  // get the geometry type by iterating all features
+  // if one geometry is multi-, then the whole geometry is multi-
+  let geometryType = '';
+  for (let i = 0; i < features.length; i++) {
+    const {geometry} = features[i];
+    if (i === 0) {
+      geometryType = geometry.type;
+    }
+    if (geometry.type.includes('Multi')) {
+      geometryType = geometry.type;
+      break;
+    }
+  }
+  if (geometryType === 'Point') {
+    return geojsonPointToArrow(name, features);
+  } else if (geometryType === 'MultiPoint') {
+    return geojsonMultiPointToArrow(name, features);
+  } else if (geometryType === 'LineString') {
+    return geojsonLineStringToArrow(name, features);
+  } else if (geometryType === 'MultiLineString') {
+    return geojsonMultiLineStringToArrow(name, features);
+  } else if (geometryType === 'Polygon') {
+    return geojsonPolygonToArrow(name, features);
+  } else if (geometryType === 'MultiPolygon') {
+    return geojsonMultiPolygonToArrow(name, features);
+  }
+  throw new Error('Unsupported geometry type');
+}
+
+/**
+ * convert GeoJSON Point to geoarrow
+ * @param name geometry field name
+ * @param points GeoJSON Points
+ * @returns GeoArrowReturnType
+ */
+export function geojsonPointToArrow(name: string, points: Feature[]): GeoArrowReturnType {
+  // get dimension from the first point
+  const dimension = (points[0].geometry as Point).coordinates.length;
+  const pointFieldName = dimension === 2 ? 'xy' : 'xyz';
+
+  // get point type
+  const nullable = false;
+  const coordType = new ArrowFloat();
+  const pointType = new FixedSizeList(
+    dimension,
+    new ArrowField(pointFieldName, coordType, nullable)
+  );
+
+  // create a field
+  const metaData: Map<string, string> = new Map([['ARROW:extension:name', 'geoarrow.point']]);
+  const field = new ArrowField(name, pointType, nullable, metaData);
+
+  // make geoarrow builder
+  const builder = makeBuilder({
+    type: pointType,
+    nullValues: [null]
+  });
+
+  // fill builder with coordinates
+  for (let i = 0; i < points.length; i++) {
+    const coords = (points[i].geometry as Point).coordinates;
+    // @ts-ignore
+    builder.append(coords);
+  }
+
+  // build geometry vector
+  const geometry = builder.finish().toVector();
+
+  return {
+    field,
+    geometry
+  };
+}
+
+/**
+ * convert GeoJSON Point to arrow.Vector
+ */
+export function geojsonMultiPointToArrow(name: string, points: Feature[]): GeoArrowReturnType {
+  // get dimension from the first multipoint
+  const dimension = (points[0].geometry as MultiPoint).coordinates[0].length;
+  const pointFieldName = dimension === 2 ? 'xy' : 'xyz';
+
+  // get multipoint type
+  const nullable = false;
+  const coordType = new ArrowFloat();
+  const pointType = new FixedSizeList(
+    dimension,
+    new ArrowField(pointFieldName, coordType, nullable)
+  );
+
+  const multiPointType = new ArrowList(new ArrowField('points', pointType, nullable));
+
+  // create a field
+  const metaData: Map<string, string> = new Map([['ARROW:extension:name', 'geoarrow.multipoint']]);
+  const field = new ArrowField(name, multiPointType, nullable, metaData);
+
+  // make geoarrow builder
+  const builder = makeBuilder({
+    type: multiPointType,
+    nullValues: [null]
+  });
+
+  // const pointBuilder = builder.getChildAt(0);
+  for (let i = 0; i < points.length; i++) {
+    const coords = (points[i].geometry as MultiPoint).coordinates;
+    // @ts-ignore
+    builder.append(coords);
+  }
+
+  const geometry = builder.finish().toVector();
+
+  return {
+    field,
+    geometry
+  };
+}
+
+/**
+ * Convert GeoJSON LineString to arrow.Data
+ */
+export function geojsonLineStringToArrow(name: string, lines: Feature[]): GeoArrowReturnType {
+  // get dimension from the first line
+  const dimension = (lines[0].geometry as LineString).coordinates[0].length;
+  const pointFieldName = dimension === 2 ? 'xy' : 'xyz';
+
+  // get line type
+  const nullable = false;
+  const coordType = new ArrowFloat();
+  const pointType = new FixedSizeList(
+    dimension,
+    new ArrowField(pointFieldName, coordType, nullable)
+  );
+  const lineType = new ArrowList(new ArrowField('points', pointType, nullable));
+
+  // create a field
+  const metaData: Map<string, string> = new Map([['ARROW:extension:name', 'geoarrow.linestring']]);
+  const field = new ArrowField(name, lineType, nullable, metaData);
+
+  // make geoarrow builder
+  const builder = makeBuilder({
+    type: lineType,
+    nullValues: [null]
+  });
+
+  for (let i = 0; i < lines.length; i++) {
+    const coords = (lines[i].geometry as LineString).coordinates;
+    // @ts-ignore
+    builder.append(coords);
+  }
+
+  const geometry = builder.finish().toVector();
+
+  return {
+    field,
+    geometry
+  };
+}
+
+/**
+ * Convert GeoJSON MultiLineString to arrow.Vector
+ */
+export function geojsonMultiLineStringToArrow(name: string, lines: Feature[]): GeoArrowReturnType {
+  // get dimension from the first line
+  const dimension = (lines[0].geometry as MultiLineString).coordinates[0].length;
+  const pointFieldName = dimension === 2 ? 'xy' : 'xyz';
+
+  // get multi-line data type
+  const nullable = false;
+  const coordType = new ArrowFloat();
+  const pointType = new FixedSizeList(
+    dimension,
+    new ArrowField(pointFieldName, coordType, nullable)
+  );
+  const lineType = new ArrowList(new ArrowField('points', pointType, nullable));
+  const multiLineType = new ArrowList(new ArrowField('lines', lineType, nullable));
+
+  // create a field
+  const metaData: Map<string, string> = new Map([
+    ['ARROW:extension:name', 'geoarrow.multilinestring']
+  ]);
+  const field = new ArrowField(name, multiLineType, nullable, metaData);
+
+  // make geoarrow builder
+  const builder = makeBuilder({
+    type: multiLineType,
+    nullValues: [null]
+  });
+
+  for (let i = 0; i < lines.length; i++) {
+    const coords = (lines[i].geometry as MultiLineString).coordinates;
+    // @ts-ignore
+    builder.append(coords);
+  }
+
+  const geometry = builder.finish().toVector();
+
+  return {
+    field,
+    geometry
+  };
+}
+
+/**
+ * Convert GeoJSON Polygon to arrow.Data
+ */
+export function geojsonPolygonToArrow(name: string, polygons: Feature[]): GeoArrowReturnType {
+  // get dimension from the first polygon
+  const dimension = (polygons[0].geometry as Polygon).coordinates[0][0].length;
+  const pointFieldName = dimension === 2 ? 'xy' : 'xyz';
+
+  // get polygon data type
+  const nullable = false;
+  const coordType = new ArrowFloat();
+  const pointType = new FixedSizeList(
+    dimension,
+    new ArrowField(pointFieldName, coordType, nullable)
+  );
+  const ringType = new ArrowList(new ArrowField('points', pointType, nullable));
+  const polygonType = new ArrowList(new ArrowField('rings', ringType, nullable));
+
+  // create a field
+  const metaData = new Map<string, string>([['ARROW:extension:name', 'geoarrow.polygon']]);
+  const field = new ArrowField(name, polygonType, nullable, metaData);
+
+  // make geoarrow builder
+  const builder = makeBuilder({
+    type: polygonType,
+    nullValues: [null]
+  });
+
+  for (let i = 0; i < polygons.length; i++) {
+    const coords = (polygons[i].geometry as Polygon).coordinates;
+    // @ts-ignore
+    builder.append(coords);
+  }
+
+  const geometry = builder.finish().toVector();
+
+  return {
+    field,
+    geometry
+  };
+}
+
+/**
+ * Convert GeoJSON MultiPolygon to arrow.Vector
+ */
+export function geojsonMultiPolygonToArrow(name: string, polygons: Feature[]): GeoArrowReturnType {
+  // get dimension from the first polygon
+  const dimension = (polygons[0].geometry as MultiPolygon).coordinates[0][0][0].length;
+  const pointFieldName = dimension === 2 ? 'xy' : 'xyz';
+
+  // get polygon data type
+  const nullable = false;
+  const coordType = new ArrowFloat();
+  const pointType = new FixedSizeList(
+    dimension,
+    new ArrowField(pointFieldName, coordType, nullable)
+  );
+  const ringType = new ArrowList(new ArrowField('points', pointType, nullable));
+  const polygonType = new ArrowList(new ArrowField('rings', ringType, nullable));
+  const multiPolygonType = new ArrowList(new ArrowField('polygons', polygonType, nullable));
+
+  // create a field
+  const metaData = new Map<string, string>([['ARROW:extension:name', 'geoarrow.multipolygon']]);
+  const field = new ArrowField(name, multiPolygonType, nullable, metaData);
+
+  // make geoarrow builder
+  const builder = makeBuilder({
+    type: multiPolygonType,
+    nullValues: [null]
+  });
+
+  for (let i = 0; i < polygons.length; i++) {
+    const coords = (polygons[i].geometry as MultiPolygon).coordinates;
+    // @ts-ignore
+    builder.append(coords);
+  }
+
+  const geometry = builder.finish().toVector();
+
+  return {
+    field,
+    geometry
+  };
+}

--- a/modules/arrow/src/index.ts
+++ b/modules/arrow/src/index.ts
@@ -58,6 +58,15 @@ export {
   getTriangleIndices,
   getMeanCentersFromBinaryGeometries
 } from './geoarrow/convert-geoarrow-to-binary-geometry';
+export {
+  geojsonFeaturesToArrow,
+  geojsonPointToArrow,
+  geojsonMultiPointToArrow,
+  geojsonLineStringToArrow,
+  geojsonMultiLineStringToArrow,
+  geojsonPolygonToArrow,
+  geojsonMultiPolygonToArrow
+} from './geoarrow/convert-geojson-feature-to-arrow';
 
 export {updateBoundsFromGeoArrowSamples} from './geoarrow/get-arrow-bounds';
 

--- a/modules/arrow/test/geoarrow/convert-geojson-feature-to-arrow.spec.ts
+++ b/modules/arrow/test/geoarrow/convert-geojson-feature-to-arrow.spec.ts
@@ -1,0 +1,68 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'tape-promise/tape';
+import {Schema as ArrowSchema, Table as ArrowTable} from 'apache-arrow';
+import {
+  parseGeometryFromArrow,
+  geojsonPointToArrow,
+  geojsonMultiPointToArrow,
+  geojsonMultiPolygonToArrow
+} from '@loaders.gl/arrow';
+
+import {
+  expectedPointGeojson,
+  expectedMultiPointGeoJson,
+  expectedMultiPolygonGeojson
+} from '../data/geoarrow/test-cases';
+
+test('ArrowUtils#geojsonPointToArrow', async (t) => {
+  const points = expectedPointGeojson.features;
+  const geomFieldName = 'geometry';
+  const {field, geometry} = geojsonPointToArrow(geomFieldName, points);
+  const schema = new ArrowSchema([field]);
+  // @ts-ignore
+  const table = new ArrowTable(schema, {geometry});
+
+  const firstArrowGeometry = table.getChild('geometry')?.get(0);
+  const encoding = 'geoarrow.point';
+
+  const firstGeometry = parseGeometryFromArrow(firstArrowGeometry, encoding);
+  t.deepEqual(firstGeometry, points[0].geometry, 'GeoJSON Geometry is correct');
+  t.end();
+});
+
+test('ArrowUtils#geojsonMultiPointToArrow', async (t) => {
+  const points = expectedMultiPointGeoJson.features;
+  const geomFieldName = 'geometry';
+  const {field, geometry} = geojsonMultiPointToArrow(geomFieldName, points);
+
+  const schema = new ArrowSchema([field]);
+  // @ts-ignore
+  const table = new ArrowTable(schema, {geometry});
+
+  const firstArrowGeometry = table.getChild('geometry')?.get(0);
+  const encoding = 'geoarrow.multipoint';
+
+  const firstGeometry = parseGeometryFromArrow(firstArrowGeometry, encoding);
+  t.deepEqual(firstGeometry, points[0].geometry, 'GeoJSON Geometry is correct');
+  t.end();
+});
+
+test('ArrowUtils#geojsonMultiPolygon', async (t) => {
+  const points = expectedMultiPolygonGeojson.features;
+  const geomFieldName = 'geometry';
+  const {field, geometry} = geojsonMultiPolygonToArrow(geomFieldName, points);
+
+  const schema = new ArrowSchema([field]);
+  // @ts-ignore
+  const table = new ArrowTable(schema, {geometry});
+
+  const firstArrowGeometry = table.getChild('geometry')?.get(0);
+  const encoding = 'geoarrow.multipolygon';
+
+  const firstGeometry = parseGeometryFromArrow(firstArrowGeometry, encoding);
+  t.deepEqual(firstGeometry, points[0].geometry, 'GeoJSON Geometry is correct');
+  t.end();
+});

--- a/modules/arrow/test/index.ts
+++ b/modules/arrow/test/index.ts
@@ -7,6 +7,7 @@ import './arrow-writer.spec';
 
 import './geoarrow/convert-geoarrow-to-binary-geometry.spec';
 import './geoarrow/convert-geoarrow-to-geojson.spec';
+import './geoarrow/convert-geojson-feature-to-arrow.spec';
 import './geoarrow/get-arrow-bounds.spec';
 
 import './tables/convert-arrow-to-geojson-table.spec';


### PR DESCRIPTION
This WIP PR is trying to  add functions to convert GeoJson Features to GeoArrow. These functions could be used as:
- [ ] support write GeoArrow file format
- [ ] support `arrow-table` loader's option in other loaders e.g. GeoJson/Csv to load spatial data into Arrow memory
- [ ] support creating GeoArrow table in memory

I am not confident with the implementation in this PR (missing documentation in js apache-arrow). Please help to take a look if you are interested. Thank you!