### PR TITLE
migration info loaders v4

### DIFF
--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -60,6 +60,7 @@ A major release that brings:
 **@loaders.gl/csv**
 
 - New [`CSVWriter`](/docs/modules/csv/api-reference/csv-writer) allows export of tables in CSV format.
+- Migration: The promise of parse() now returns `{ shape: string; data: [] }` instead of `[]`, so you should add `.data` to get the records.
 
 **@laoders.gl/json**
 


### PR DESCRIPTION
I don't know if this belong in /core or /csv, as I've only tried the v4 parse() with the CSVLoader, but I found this to be a breaking change when updating from v3 -> v4 that wasn't mentioned in the release notes which i think belongs there somewhere.