### PR TITLE
fix (parquet): Increased max dictionary size to the max size of ArrayBuffer

### DIFF
--- a/modules/parquet/src/parquetjs/parser/parquet-reader.ts
+++ b/modules/parquet/src/parquetjs/parser/parquet-reader.ts
@@ -36,7 +36,8 @@ export type ParquetIterationProps = {
  */
 export class ParquetReader {
   static defaultProps: Required<ParquetReaderProps> = {
-    defaultDictionarySize: 1e6,
+    //max ArrayBuffer size in js is 2Gb
+    defaultDictionarySize: 2147483648,
     preserveBinary: false
   };
 

--- a/modules/parquet/src/parquetjs/parser/parquet-reader.ts
+++ b/modules/parquet/src/parquetjs/parser/parquet-reader.ts
@@ -36,7 +36,7 @@ export type ParquetIterationProps = {
  */
 export class ParquetReader {
   static defaultProps: Required<ParquetReaderProps> = {
-    //max ArrayBuffer size in js is 2Gb
+    // max ArrayBuffer size in js is 2Gb
     defaultDictionarySize: 2147483648,
     preserveBinary: false
   };


### PR DESCRIPTION
I was trying to fix some compression errors and found out that we're cutting off the data to decompress incorrect. Data in my case was around 6 million byte long but it was cut off at 1 million and it caused error. 

So I propose to set max dictionary length there to 2 Gb which is max possible ArrayBuffer length in JS