### PR TITLE
fix(wkt): Increased amount of memory for polygon indices

### DIFF
--- a/modules/wkt/src/lib/parse-wkb.ts
+++ b/modules/wkt/src/lib/parse-wkb.ts
@@ -317,7 +317,7 @@ function concatenateBinaryPolygonGeometries(
   return {
     type: 'Polygon',
     positions: {value: concatenatedPositions, size: dimension},
-    polygonIndices: {value: new Uint16Array(polygonIndices), size: 1},
+    polygonIndices: {value: new Uint32Array(polygonIndices), size: 1},
     primitivePolygonIndices: {value: new Uint16Array(primitivePolygonIndices), size: 1}
   };
 }

--- a/modules/wkt/src/lib/parse-wkb.ts
+++ b/modules/wkt/src/lib/parse-wkb.ts
@@ -318,7 +318,7 @@ function concatenateBinaryPolygonGeometries(
     type: 'Polygon',
     positions: {value: concatenatedPositions, size: dimension},
     polygonIndices: {value: new Uint32Array(polygonIndices), size: 1},
-    primitivePolygonIndices: {value: new Uint16Array(primitivePolygonIndices), size: 1}
+    primitivePolygonIndices: {value: new Uint32Array(primitivePolygonIndices), size: 1}
   };
 }
 


### PR DESCRIPTION
There are several geoparquet dataset in the examples/website/geospatial where the max polygon indices values are around 68,000, although max unsigned 16-bit value is 65,536. So I increased amount of memory to 32 bits there