### PR TITLE
fix(wkt): multipolygons UInt16 overflow

### DIFF
--- a/examples/website/geospatial/examples.ts
+++ b/examples/website/geospatial/examples.ts
@@ -58,7 +58,7 @@ export const EXAMPLES: Record<string, Record<string, Example>> = {
     },
     Countries: {
       format: 'geojson',
-      data: `${DECKGL_DATA_URL}/examples/geojson/countries.json`,
+      data: `${DECKGL_DATA_URL}/examples/geojson/countries.geojson`,
       viewState: {...VIEW_STATE, longitude: -4.65, latitude: -29.76, zoom: 1.76}
     }
   },

--- a/examples/website/geospatial/examples.ts
+++ b/examples/website/geospatial/examples.ts
@@ -58,7 +58,7 @@ export const EXAMPLES: Record<string, Record<string, Example>> = {
     },
     Countries: {
       format: 'geojson',
-      data: `${LOADERS_URL}/modules/geojson/test/data/countries.json`,
+      data: `${DECKGL_DATA_URL}/examples/geojson/countries.json`,
       viewState: {...VIEW_STATE, longitude: -4.65, latitude: -29.76, zoom: 1.76}
     }
   },

--- a/modules/wkt/src/lib/parse-wkb.ts
+++ b/modules/wkt/src/lib/parse-wkb.ts
@@ -308,12 +308,11 @@ function concatenateBinaryPolygonGeometries(
   const primitivePolygonIndices = [0];
   for (const primitivePolygon of primitivePolygons) {
     for (const value of primitivePolygon) {
-      if (value <= 0) {
-        continue; // eslint-disable-line no-continue
+      if (value > 0) {
+        primitivePolygonIndices.push(
+          value + primitivePolygonIndices[primitivePolygonIndices.length - 1]
+        );
       }
-      primitivePolygonIndices.push(
-        value + primitivePolygonIndices[primitivePolygonIndices.length - 1]
-      );
     }
   }
 

--- a/modules/wkt/src/lib/parse-wkb.ts
+++ b/modules/wkt/src/lib/parse-wkb.ts
@@ -307,11 +307,14 @@ function concatenateBinaryPolygonGeometries(
   // Combine primitivePolygonIndices from each individual polygon
   const primitivePolygonIndices = [0];
   for (const primitivePolygon of primitivePolygons) {
-    primitivePolygonIndices.push(
-      ...primitivePolygon
-        .filter((x: number) => x > 0)
-        .map((x: number) => x + primitivePolygonIndices[primitivePolygonIndices.length - 1])
-    );
+    for (const value of primitivePolygon) {
+      if (value <= 0) {
+        continue; // eslint-disable-line no-continue
+      }
+      primitivePolygonIndices.push(
+        value + primitivePolygonIndices[primitivePolygonIndices.length - 1]
+      );
+    }
   }
 
   return {


### PR DESCRIPTION
* `primitivePolygon` might be a Uint16Array and `.map((x: number) => x + primitivePolygonIndices[primitivePolygonIndices.length - 1])` might cut sum operation result;
* need to upload `countries.json` to @deck.gl-data. Current link doesn't work