### PR TITLE
fix(parquet): zstd decompression

### DIFF
--- a/examples/website/geospatial/app.tsx
+++ b/examples/website/geospatial/app.tsx
@@ -183,9 +183,6 @@ export default function App(props: AppProps) {
         getTooltip={({object}) => {
           const {getTooltipData} =
             state.examples[state.selectedLoader]?.[state.selectedExample] ?? {};
-          if (state.examples[state.selectedExample]) {
-            console.log('found');
-          }
           const {title, properties} = getTooltipData
             ? getTooltipData({object})
             : getDefaultTooltipData({object});

--- a/examples/website/geospatial/app.tsx
+++ b/examples/website/geospatial/app.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import React, {useState, useEffect} from 'react';
+import React, {useState, useEffect, useRef} from 'react';
 import {createRoot} from 'react-dom/client';
 
 import {Map} from 'react-map-gl';
@@ -21,10 +21,11 @@ import {INITIAL_LOADER_NAME, INITIAL_EXAMPLE_NAME, INITIAL_MAP_STYLE, EXAMPLES} 
 import {Table, GeoJSON} from '@loaders.gl/schema';
 import {Loader, load /* registerLoaders */} from '@loaders.gl/core';
 import {GeoArrowLoader} from '@loaders.gl/arrow';
-import {GeoParquetLoader, installBufferPolyfill} from '@loaders.gl/parquet';
+import {GeoParquetLoader, installBufferPolyfill, preloadCompressions} from '@loaders.gl/parquet';
 import {FlatGeobufLoader} from '@loaders.gl/flatgeobuf';
 import {ShapefileLoader} from '@loaders.gl/shapefile';
 import {KMLLoader, GPXLoader, TCXLoader} from '@loaders.gl/kml';
+import {ZstdCodec} from 'zstd-codec';
 
 // GeoPackage depends on sql.js which has bundling issues in docusuarus.
 // import {GeoPackageLoader} from '@loaders.gl/geopackage';
@@ -100,6 +101,7 @@ type AppState = {
  * A Geospatial table map viewer
  */
 export default function App(props: AppProps) {
+  const [isParquetReady, setIsParquetReady] = useState<boolean>(false);
   const [state, setState] = useState<AppState>({
     // EXAMPLE STATE
     examples: EXAMPLES,
@@ -111,6 +113,30 @@ export default function App(props: AppProps) {
     loadedTable: null,
     error: null
   });
+  const stateRef = useRef<string>();
+  stateRef.current = state;
+
+  useEffect(() => {
+    if (isParquetReady) {
+      return;
+    }
+    async function prepareParquet() {
+      await preloadCompressions({modules: {'zstd-codec': ZstdCodec}});
+      const {selectedLoader, selectedExample, examples} = stateRef.current;
+      if (selectedLoader === 'GeoParquet' || selectedLoader === 'GeoParquetTest') {
+        onExampleChange({
+          selectedLoader,
+          selectedExample,
+          example: examples[selectedLoader][selectedExample],
+          isParquetReady: true,
+          state,
+          setState
+        });
+      }
+      setIsParquetReady(true);
+    }
+    prepareParquet();
+  }, [isParquetReady]);
 
   // Initialize the examples (each demo might focus on a different "props.format")
   useEffect(() => {
@@ -129,6 +155,7 @@ export default function App(props: AppProps) {
       selectedLoader,
       selectedExample,
       example: examples[selectedLoader][selectedExample],
+      isParquetReady,
       state,
       setState
     });
@@ -146,7 +173,7 @@ export default function App(props: AppProps) {
         examples={state.examples}
         selectedExample={state.selectedExample}
         selectedLoader={state.selectedLoader}
-        onExampleChange={(props) => onExampleChange({...props, state, setState})}
+        onExampleChange={(props) => onExampleChange({...props, state, isParquetReady, setState})}
       >
         {state.error ? <div style={{color: 'red'}}>{state.error}</div> : ''}
         <div style={{textAlign: 'center'}}>
@@ -175,14 +202,14 @@ export default function App(props: AppProps) {
         onViewStateChange={({viewState}) => setState((state) => ({...state, viewState}))}
         controller={{type: MapController, maxPitch: 85}}
         getTooltip={({object}) => {
-          const {name, ...properties} = object?.properties || {};
+          const {name, ADMIN, ...properties} = object?.properties || {};
           const props = Object.entries(properties)
             .map(([key, value]) => `<div>${key}: ${value}</div>`)
             .join('\n');
           return (
             object && {
               html: `\
-<h2>${name}</h2>
+<h2>${name || ADMIN}</h2>
 ${props}
 <div>Coords: ${object.geometry?.coordinates?.[0]};${object.geometry?.coordinates?.[1]}</div>`,
               style: {
@@ -203,10 +230,15 @@ async function onExampleChange(args: {
   selectedLoader: string;
   selectedExample: string;
   example: Example;
+  isParquetReady: boolean;
   state: AppState;
   setState: Function;
 }) {
-  const {selectedLoader, selectedExample, example, state, setState} = args;
+  const {selectedLoader, selectedExample, example, isParquetReady, state, setState} = args;
+
+  if ((selectedLoader === 'GeoParquet' || selectedLoader === 'GeoParquetTest') && !isParquetReady) {
+    return;
+  }
 
   const url = example.data;
   try {

--- a/examples/website/geospatial/app.tsx
+++ b/examples/website/geospatial/app.tsx
@@ -181,14 +181,21 @@ export default function App(props: AppProps) {
         onViewStateChange={({viewState}) => setState((state) => ({...state, viewState}))}
         controller={{type: MapController, maxPitch: 85}}
         getTooltip={({object}) => {
-          const {name, ADMIN, ...properties} = object?.properties || {};
+          const {getTooltipData} =
+            state.examples[state.selectedLoader]?.[state.selectedExample] ?? {};
+          if (state.examples[state.selectedExample]) {
+            console.log('found');
+          }
+          const {title, properties} = getTooltipData
+            ? getTooltipData({object})
+            : getDefaultTooltipData({object});
           const props = Object.entries(properties)
             .map(([key, value]) => `<div>${key}: ${value}</div>`)
             .join('\n');
           return (
             object && {
               html: `\
-<h2>${name || ADMIN}</h2>
+<h2>${title}</h2>
 ${props}
 <div>Coords: ${object.geometry?.coordinates?.[0]};${object.geometry?.coordinates?.[1]}</div>`,
               style: {
@@ -209,7 +216,6 @@ async function onExampleChange(args: {
   selectedLoader: string;
   selectedExample: string;
   example: Example;
-  // isParquetReady: boolean;
   state: AppState;
   setState: Function;
 }) {
@@ -264,6 +270,14 @@ function renderLayer({selectedExample, selectedLoader, examples, loadedTable}) {
       ...layerProps
     })
   ];
+}
+
+function getDefaultTooltipData({object}) {
+  const {name, ...properties} = object?.properties || {};
+  return {
+    title: name,
+    properties
+  };
 }
 
 export function renderToDOM(container) {

--- a/examples/website/geospatial/app.tsx
+++ b/examples/website/geospatial/app.tsx
@@ -44,6 +44,9 @@ const LOADERS: Loader[] = [
 ];
 const LOADER_OPTIONS = {
   worker: false,
+  modules: {
+    'zstd-codec': ZstdCodec
+  },
   gis: {
     reproject: true,
     _targetCrs: 'WGS84'
@@ -101,7 +104,6 @@ type AppState = {
  * A Geospatial table map viewer
  */
 export default function App(props: AppProps) {
-  const [isParquetReady, setIsParquetReady] = useState<boolean>(false);
   const [state, setState] = useState<AppState>({
     // EXAMPLE STATE
     examples: EXAMPLES,
@@ -115,28 +117,6 @@ export default function App(props: AppProps) {
   });
   const stateRef = useRef<string>();
   stateRef.current = state;
-
-  useEffect(() => {
-    if (isParquetReady) {
-      return;
-    }
-    async function prepareParquet() {
-      await preloadCompressions({modules: {'zstd-codec': ZstdCodec}});
-      const {selectedLoader, selectedExample, examples} = stateRef.current;
-      if (selectedLoader === 'GeoParquet' || selectedLoader === 'GeoParquetTest') {
-        onExampleChange({
-          selectedLoader,
-          selectedExample,
-          example: examples[selectedLoader][selectedExample],
-          isParquetReady: true,
-          state,
-          setState
-        });
-      }
-      setIsParquetReady(true);
-    }
-    prepareParquet();
-  }, [isParquetReady]);
 
   // Initialize the examples (each demo might focus on a different "props.format")
   useEffect(() => {
@@ -155,7 +135,6 @@ export default function App(props: AppProps) {
       selectedLoader,
       selectedExample,
       example: examples[selectedLoader][selectedExample],
-      isParquetReady,
       state,
       setState
     });
@@ -173,7 +152,7 @@ export default function App(props: AppProps) {
         examples={state.examples}
         selectedExample={state.selectedExample}
         selectedLoader={state.selectedLoader}
-        onExampleChange={(props) => onExampleChange({...props, state, isParquetReady, setState})}
+        onExampleChange={(props) => onExampleChange({...props, state, setState})}
       >
         {state.error ? <div style={{color: 'red'}}>{state.error}</div> : ''}
         <div style={{textAlign: 'center'}}>
@@ -230,15 +209,11 @@ async function onExampleChange(args: {
   selectedLoader: string;
   selectedExample: string;
   example: Example;
-  isParquetReady: boolean;
+  // isParquetReady: boolean;
   state: AppState;
   setState: Function;
 }) {
-  const {selectedLoader, selectedExample, example, isParquetReady, state, setState} = args;
-
-  if ((selectedLoader === 'GeoParquet' || selectedLoader === 'GeoParquetTest') && !isParquetReady) {
-    return;
-  }
+  const {selectedLoader, selectedExample, example, state, setState} = args;
 
   const url = example.data;
   try {

--- a/examples/website/geospatial/examples.ts
+++ b/examples/website/geospatial/examples.ts
@@ -27,6 +27,11 @@ export type Example = {
   data: string;
   viewState?: Record<string, number>;
   layerProps?: Record<string, any>;
+  getTooltipData?: (event: {
+    object?: {
+      properties?: Record<string, unknown>;
+    };
+  }) => null | {title: string; properties: Record<string, unknown>};
 };
 
 export const LOADERS_URL = 'https://raw.githubusercontent.com/visgl/loaders.gl/master';
@@ -63,6 +68,13 @@ export const EXAMPLES: Record<string, Record<string, Example>> = {
         zoom: 1.76,
         longitude: -4.65,
         latitude: -29.76
+      },
+      getTooltipData: function ({object}) {
+        const {ADMIN, ...properties} = object?.properties || {};
+        return {
+          title: ADMIN as string,
+          properties
+        };
       }
     }
   },

--- a/examples/website/geospatial/examples.ts
+++ b/examples/website/geospatial/examples.ts
@@ -40,7 +40,7 @@ export const EXAMPLES: Record<string, Record<string, Example>> = {
     multipolygon_hole: {
       format: 'geoarrow',
       data: `${GEOARROW_TEST_DATA}/multipolygon_hole.arrow`,
-      viewState: {...VIEW_STATE, longitude: 10.388, latitude:   1.447, zoom: 4}
+      viewState: {...VIEW_STATE, longitude: 10.388, latitude: 1.447, zoom: 4}
     }
   },
   GeoParquet: {
@@ -48,6 +48,22 @@ export const EXAMPLES: Record<string, Record<string, Example>> = {
       format: 'geoparquet',
       data: `${LOADERS_URL}/modules/parquet/test/data/geoparquet/airports.parquet`,
       viewState: {...VIEW_STATE, longitude: -4.65, latitude: -29.76, zoom: 1.76}
+    },
+    'Countries (zstd)': {
+      format: 'geoparquet',
+      data: 'https://raw.githubusercontent.com/visgl/deck.gl-data/master/formats/geoparquet/countries/countries_zstd.parquet',
+      viewState: {
+        height: 600,
+        width: 800,
+        pitch: 45,
+        maxPitch: 60,
+        bearing: 0,
+        minZoom: 1,
+        maxZoom: 30,
+        zoom: 1.76,
+        longitude: -4.65,
+        latitude: -29.76
+      }
     }
   },
   GeoJSON: {
@@ -220,7 +236,7 @@ function getGeoParquetTestExamples() {
       maxPitch: 89,
       bearing: 0
     }
-  }
+  };
 
   return GeoParquet;
 }

--- a/modules/compression/src/lib/zstd-compression.ts
+++ b/modules/compression/src/lib/zstd-compression.ts
@@ -69,7 +69,7 @@ export class ZstdCompression extends Compression {
 
     const chunks: ArrayBuffer[] = [];
     for (let i = 0; i <= inputArray.length; i += CHUNK_SIZE) {
-      chunks.push(inputArray.slice(i, i + CHUNK_SIZE));
+      chunks.push(inputArray.subarray(i, i + CHUNK_SIZE));
     }
 
     const decompressResult = await simpleZstd.decompressChunks(chunks);

--- a/modules/compression/src/lib/zstd-compression.ts
+++ b/modules/compression/src/lib/zstd-compression.ts
@@ -69,7 +69,7 @@ export class ZstdCompression extends Compression {
 
     const chunks: ArrayBuffer[] = [];
     for (let i = 0; i <= inputArray.length; i += CHUNK_SIZE) {
-      chunks.push(input.slice(i, i + CHUNK_SIZE));
+      chunks.push(inputArray.slice(i, i + CHUNK_SIZE));
     }
 
     const decompressResult = await simpleZstd.decompressChunks(chunks);

--- a/modules/compression/src/lib/zstd-compression.ts
+++ b/modules/compression/src/lib/zstd-compression.ts
@@ -3,6 +3,8 @@ import type {CompressionOptions} from './compression';
 import {Compression} from './compression';
 // import {ZstdCodec} from 'zstd-codec'; // https://bundlephobia.com/package/zstd-codec
 
+const CHUNK_SIZE = 1000000; // Tested value
+
 let ZstdCodec;
 let zstd;
 
@@ -49,5 +51,19 @@ export class ZstdCompression extends Compression {
     // var jsonBytes = simpleZstd.decompressUsingDict(jsonZstData, ddict);
     const inputArray = new Uint8Array(input);
     return simpleZstd.decompress(inputArray).buffer;
+  }
+
+  async decompress(input: ArrayBuffer, size?: number): Promise<ArrayBuffer> {
+    await this.preload();
+    const simpleZstd = new zstd.Streaming();
+    const inputArray = new Uint8Array(input);
+
+    const chunks: ArrayBuffer[] = [];
+    for (let i = 0; i <= inputArray.length; i += CHUNK_SIZE) {
+      chunks.push(input.slice(i, i + CHUNK_SIZE));
+    }
+
+    const decompressResult = await simpleZstd.decompressChunks(chunks);
+    return decompressResult.buffer;
   }
 }

--- a/modules/parquet/src/lib/parsers/parse-parquet-to-columns.ts
+++ b/modules/parquet/src/lib/parsers/parse-parquet-to-columns.ts
@@ -41,7 +41,7 @@ export async function* parseParquetFileInColumnarBatches(
   options?: ParquetLoaderOptions
 ): AsyncIterable<ColumnarTableBatch> {
   installBufferPolyfill();
-  await preloadCompressions();
+  await preloadCompressions(options);
 
   const reader = new ParquetReader(file);
 

--- a/modules/parquet/src/lib/parsers/parse-parquet.ts
+++ b/modules/parquet/src/lib/parsers/parse-parquet.ts
@@ -23,7 +23,7 @@ export async function parseParquetFile(
   options?: ParquetLoaderOptions
 ): Promise<ObjectRowTable> {
   installBufferPolyfill();
-  await preloadCompressions();
+  await preloadCompressions(options);
 
   const reader = new ParquetReader(file, {
     preserveBinary: options?.parquet?.preserveBinary
@@ -60,7 +60,7 @@ export async function* parseParquetFileInBatches(
   options?: ParquetLoaderOptions
 ): AsyncIterable<ObjectRowTableBatch> {
   installBufferPolyfill();
-  await preloadCompressions();
+  await preloadCompressions(options);
 
   const reader = new ParquetReader(file, {
     preserveBinary: options?.parquet?.preserveBinary

--- a/modules/parquet/src/parquetjs/compression.ts
+++ b/modules/parquet/src/parquetjs/compression.ts
@@ -35,7 +35,7 @@ function toArrayBuffer(buffer: Buffer): ArrayBuffer {
 // import brotliDecompress from 'brotli/decompress';
 import lz4js from 'lz4js';
 // import lzo from 'lzo';
-// import {ZstdCodec} from 'zstd-codec';
+import {ZstdCodec} from 'zstd-codec';
 
 // Inject large dependencies through Compression constructor options
 const modules = {
@@ -46,9 +46,9 @@ const modules = {
   //     throw new Error('brotli compress');
   //   }
   // },
-  lz4js
+  lz4js,
   // lzo
-  // 'zstd-codec': ZstdCodec
+  'zstd-codec': ZstdCodec
 };
 
 /**

--- a/modules/parquet/src/parquetjs/compression.ts
+++ b/modules/parquet/src/parquetjs/compression.ts
@@ -35,7 +35,7 @@ function toArrayBuffer(buffer: Buffer): ArrayBuffer {
 // import brotliDecompress from 'brotli/decompress';
 import lz4js from 'lz4js';
 // import lzo from 'lzo';
-import {ZstdCodec} from 'zstd-codec';
+// import {ZstdCodec} from 'zstd-codec';
 
 // Inject large dependencies through Compression constructor options
 const modules = {
@@ -46,9 +46,9 @@ const modules = {
   //     throw new Error('brotli compress');
   //   }
   // },
-  lz4js,
+  lz4js
   // lzo
-  'zstd-codec': ZstdCodec
+  // 'zstd-codec': ZstdCodec
 };
 
 /**
@@ -73,6 +73,14 @@ export const PARQUET_COMPRESSION_METHODS: Record<ParquetCompression, Compression
  * @param options.modules External library dependencies
  */
 export async function preloadCompressions(options?: {modules: {[key: string]: any}}) {
+  // Re-initialize compression instances with new options
+  const mergedOptions = {...options, modules: {...modules, ...options?.modules}};
+  for (const method in PARQUET_COMPRESSION_METHODS) {
+    PARQUET_COMPRESSION_METHODS[method] = new PARQUET_COMPRESSION_METHODS[method].constructor(
+      mergedOptions
+    );
+  }
+
   const compressions = Object.values(PARQUET_COMPRESSION_METHODS);
   return await Promise.all(compressions.map((compression) => compression.preload()));
 }

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -48,6 +48,7 @@ const config = {
         excludeAliases: ['console']
       }
     ],
+    require.resolve('./webpack-plugin'),
     [
       './ocular-docusaurus-plugin',
       {

--- a/website/package.json
+++ b/website/package.json
@@ -64,7 +64,8 @@
     "react-dom": "^18.2.0",
     "react-map-gl": "^7.0.0",
     "sql.js": "1.8.0",
-    "styled-components": "^5.3.3"
+    "styled-components": "^5.3.3",
+    "zstd-codec": "^0.1.4"
   },
   "devDependencies": {
     "@cmfcmf/docusaurus-search-local": "^1.0.0",

--- a/website/webpack-plugin.js
+++ b/website/webpack-plugin.js
@@ -1,0 +1,14 @@
+export default function (context, options) {
+  return {
+    name: 'webpack-docusaurus-plugin',
+    configureWebpack(config, isServer, utils) {
+      return {
+        resolve: {
+          fallback: {
+            fs: false
+          }
+        }
+      };
+    }
+  };
+};

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -13774,7 +13774,7 @@ yocto-queue@^1.0.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
   integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
 
-zstd-codec@^0.1:
+zstd-codec@^0.1, zstd-codec@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/zstd-codec/-/zstd-codec-0.1.4.tgz#6abb311b63cfacbd06e72797ee6c6e1c7c65248c"
   integrity sha512-KYnWoFWgGtWyQEKNnUcb3u8ZtKO8dn5d8u+oGpxPlopqsPyv60U8suDyfk7Z7UtAO6Sk5i1aVcAs9RbaB1n36A==


### PR DESCRIPTION
Custom zstd decompress method to support big buffers. In my case it failed with about 6.8MB input buffer size. 
* use `zstd.Streaming` instead of `zstd.Simple`
* split input buffer on chunks 1MB.
![image](https://github.com/visgl/loaders.gl/assets/18549629/c6768e31-0ae3-4848-90de-a07732da5229)
