### PR TITLE
chore: Use `const satisfies` on Loaders and Writers

### DIFF
--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -4,10 +4,32 @@
 
 Target Release Date: March, 2024
 
+- Tooling upgrades: faster build via tsc/esbuild. yarn 4.
+- Improved developer experience: Preserve loader object information through `as const satisfies` rather than assigning `Loader` types. 
+
+**@loaders.gl/tile-converter**
+
+- Resume conversion from the last tile processed in case of an interruption.
+- Quiet mode.
+
+**@loaders.gl/parquet**
+
+- Many parquet files that previously failed now load correctly. A combination of fixes, increased limits etc. 
+
 **@loaders.gl/pmtiles**
 
 - Now uses [`pmtiles` version 3](https://github.com/protomaps/PMTiles/blob/main/js/CHANGELOG.md).
-- Now supports refreshing the already loaded index if the underlying PMTiles file is rewritten (and the storage backend supports ETag headers, which e.g. Amazon S3 does). 
+- Now can refresh the already loaded index if the underlying PMTiles file is rewritten. 
+
+**@loaders.gl/las**
+
+- A big memory leak plugged.
+
+**@loaders.gl/gltf**
+
+- Support models with more complex use of `KHR_texture_transform` extension.
+
+
 
 ## v4.1
 

--- a/modules/3d-tiles/src/3d-tiles-archive-loader.ts
+++ b/modules/3d-tiles/src/3d-tiles-archive-loader.ts
@@ -21,11 +21,9 @@ export type Tiles3DArchiveFileLoaderOptions = LoaderOptions & {
 /**
  * Loader for 3tz packages
  */
-export const Tiles3DArchiveFileLoader: LoaderWithParser<
-  ArrayBuffer,
-  never,
-  Tiles3DArchiveFileLoaderOptions
-> = {
+export const Tiles3DArchiveFileLoader = {
+  dataType: null as unknown as ArrayBuffer,
+  batchType: null as never,
   name: '3tz',
   id: '3tz',
   module: '3d-tiles',
@@ -34,7 +32,7 @@ export const Tiles3DArchiveFileLoader: LoaderWithParser<
   parse: parse3DTilesArchive,
   extensions: ['3tz'],
   options: {}
-};
+} satisfies LoaderWithParser<ArrayBuffer, never, Tiles3DArchiveFileLoaderOptions>;
 
 /**
  * returns a single file from the 3tz archive

--- a/modules/3d-tiles/src/cesium-ion-loader.ts
+++ b/modules/3d-tiles/src/cesium-ion-loader.ts
@@ -22,7 +22,7 @@ async function preload(url, options = {}) {
 /**
  * Loader for 3D tiles from Cesium ION
  */
-export const CesiumIonLoader: LoaderWithParser<unknown, never, LoaderOptions> = {
+export const CesiumIonLoader = {
   ...Tiles3DLoader,
   id: 'cesium-ion',
   name: 'Cesium Ion',
@@ -41,4 +41,4 @@ export const CesiumIonLoader: LoaderWithParser<unknown, never, LoaderOptions> = 
       accessToken: null
     }
   }
-};
+} as const satisfies LoaderWithParser<unknown, never, LoaderOptions>;

--- a/modules/3d-tiles/src/tile-3d-subtree-loader.ts
+++ b/modules/3d-tiles/src/tile-3d-subtree-loader.ts
@@ -10,7 +10,9 @@ import {VERSION} from './lib/utils/version';
 /**
  * Loader for 3D Tiles Subtree
  */
-export const Tile3DSubtreeLoader: LoaderWithParser<Subtree, never, LoaderOptions> = {
+export const Tile3DSubtreeLoader = {
+  dataType: null as unknown as Subtree,
+  batchType: null as never,
   id: '3d-tiles-subtree',
   name: '3D Tiles Subtree',
   module: '3d-tiles',
@@ -20,4 +22,4 @@ export const Tile3DSubtreeLoader: LoaderWithParser<Subtree, never, LoaderOptions
   tests: ['subtree'],
   parse: parse3DTilesSubtree,
   options: {}
-};
+} as const satisfies LoaderWithParser<Subtree, never, LoaderOptions>;

--- a/modules/3d-tiles/src/tile-3d-writer.ts
+++ b/modules/3d-tiles/src/tile-3d-writer.ts
@@ -9,7 +9,7 @@ import encode3DTile from './lib/encoders/encode-3d-tile';
 /**
  * Exporter for 3D Tiles
  */
-export const Tile3DWriter: WriterWithEncoder<unknown, never, WriterOptions> = {
+export const Tile3DWriter = {
   name: '3D Tile',
   id: '3d-tiles',
   module: '3d-tiles',
@@ -22,7 +22,7 @@ export const Tile3DWriter: WriterWithEncoder<unknown, never, WriterOptions> = {
   },
   encode: async (tile, options) => encodeSync(tile, options),
   encodeSync
-};
+} as const satisfies WriterWithEncoder<unknown, never, WriterOptions>;
 
 function encodeSync(tile, options) {
   return encode3DTile(tile, options);

--- a/modules/3d-tiles/src/tiles-3d-loader.ts
+++ b/modules/3d-tiles/src/tiles-3d-loader.ts
@@ -33,11 +33,9 @@ export type Tiles3DLoaderOptions = LoaderOptions &
 /**
  * Loader for 3D Tiles
  */
-export const Tiles3DLoader: LoaderWithParser<
-  any, // Tiles3DTileContent | Tiles3DTilesetJSONPostprocessed,
-  never,
-  Tiles3DLoaderOptions
-> = {
+export const Tiles3DLoader = {
+  dataType: null as any,
+  batchType: null as never,
   id: '3d-tiles',
   name: '3D Tiles',
   module: '3d-tiles',
@@ -54,7 +52,8 @@ export const Tiles3DLoader: LoaderWithParser<
       assetGltfUpAxis: null
     }
   }
-};
+  // Tiles3DTileContent | Tiles3DTilesetJSONPostprocessed,
+} as const satisfies LoaderWithParser<any, never, Tiles3DLoaderOptions>;
 
 /** Parses a tileset or tile */
 async function parse(

--- a/modules/arrow/src/arrow-loader.ts
+++ b/modules/arrow/src/arrow-loader.ts
@@ -25,7 +25,10 @@ export type ArrowLoaderOptions = LoaderOptions & {
 };
 
 /** ArrowJS table loader */
-export const ArrowWorkerLoader: Loader<ArrowTable, never, ArrowLoaderOptions> = {
+export const ArrowWorkerLoader = {
+  dataType: null as unknown as ArrowTable,
+  batchType: null as never,
+
   name: 'Apache Arrow',
   id: 'arrow',
   module: 'arrow',
@@ -45,18 +48,18 @@ export const ArrowWorkerLoader: Loader<ArrowTable, never, ArrowLoaderOptions> = 
       shape: 'columnar-table'
     }
   }
-};
+} as const satisfies Loader<ArrowTable, never, ArrowLoaderOptions>;
 
 /** ArrowJS table loader */
-export const ArrowLoader: LoaderWithParser<
-  ArrowTable | ColumnarTable | ObjectRowTable | ArrayRowTable,
-  ArrowTableBatch,
-  ArrowLoaderOptions
-> = {
+export const ArrowLoader = {
   ...ArrowWorkerLoader,
   parse: async (arraybuffer: ArrayBuffer, options?: ArrowLoaderOptions) =>
     parseArrowSync(arraybuffer, options?.arrow),
   parseSync: (arraybuffer: ArrayBuffer, options?: ArrowLoaderOptions) =>
     parseArrowSync(arraybuffer, options?.arrow),
   parseInBatches: parseArrowInBatches
-};
+} as const satisfies LoaderWithParser<
+  ArrowTable | ColumnarTable | ObjectRowTable | ArrayRowTable,
+  ArrowTableBatch,
+  ArrowLoaderOptions
+>;

--- a/modules/arrow/src/arrow-writer.ts
+++ b/modules/arrow/src/arrow-writer.ts
@@ -13,7 +13,7 @@ type ArrowWriterOptions = WriterOptions & {
 };
 
 /** Apache Arrow writer */
-export const ArrowWriter: WriterWithEncoder<ColumnarTable, never, ArrowWriterOptions> = {
+export const ArrowWriter = {
   name: 'Apache Arrow',
   id: 'arrow',
   module: 'arrow',
@@ -32,4 +32,4 @@ export const ArrowWriter: WriterWithEncoder<ColumnarTable, never, ArrowWriterOpt
   encodeSync(data, options?) {
     return encodeArrowSync(data);
   }
-};
+} as const satisfies WriterWithEncoder<ColumnarTable, never, ArrowWriterOptions>;

--- a/modules/arrow/src/geoarrow-loader.ts
+++ b/modules/arrow/src/geoarrow-loader.ts
@@ -11,42 +11,34 @@ import {parseGeoArrowInBatches} from './parsers/parse-geoarrow-in-batches';
 
 export type GeoArrowLoaderOptions = LoaderOptions & {
   arrow?: {
-    shape: 'arrow-table' | 'binary-geometry';
+    shape?: 'arrow-table' | 'binary-geometry';
   };
 };
 
 /** ArrowJS table loader */
-export const GeoArrowWorkerLoader: Loader<
-  ArrowTable | BinaryGeometry,
-  never,
-  GeoArrowLoaderOptions
-> = {
+export const GeoArrowWorkerLoader = {
   ...ArrowWorkerLoader,
   options: {
     arrow: {
       shape: 'arrow-table'
     }
   }
-};
+} as const satisfies Loader<ArrowTable | BinaryGeometry, never, GeoArrowLoaderOptions>;
 
 /**
  * GeoArrowLoader loads an Apache Arrow table, parses GeoArrow type extension data
  * to convert it to a GeoJSON table or a BinaryGeometry
  */
-export const GeoArrowLoader: LoaderWithParser<
-  ArrowTable | GeoJSONTable, // | BinaryGeometry,
-  ArrowTableBatch | GeoJSONTableBatch, // | BinaryGeometry,
-  GeoArrowLoaderOptions
-> = {
-  ...ArrowWorkerLoader,
-  options: {
-    arrow: {
-      shape: 'arrow-table'
-    }
-  },
+export const GeoArrowLoader = {
+  ...GeoArrowWorkerLoader,
+
   parse: async (arraybuffer: ArrayBuffer, options?: GeoArrowLoaderOptions) =>
     parseGeoArrowSync(arraybuffer, options?.arrow),
   parseSync: (arraybuffer: ArrayBuffer, options?: GeoArrowLoaderOptions) =>
     parseGeoArrowSync(arraybuffer, options?.arrow),
   parseInBatches: parseGeoArrowInBatches
-};
+} as const satisfies LoaderWithParser<
+  ArrowTable | GeoJSONTable, // | BinaryGeometry,
+  ArrowTableBatch | GeoJSONTableBatch, // | BinaryGeometry,
+  GeoArrowLoaderOptions
+>;

--- a/modules/arrow/src/geoarrow-writer.ts
+++ b/modules/arrow/src/geoarrow-writer.ts
@@ -13,11 +13,7 @@ type ArrowWriterOptions = WriterOptions & {
 };
 
 /** Apache Arrow writer */
-export const GeoArrowWriter: WriterWithEncoder<
-  GeoJSONTable | BinaryGeometry,
-  never,
-  ArrowWriterOptions
-> = {
+export const GeoArrowWriter = {
   name: 'Apache Arrow',
   id: 'arrow',
   module: 'arrow',
@@ -38,4 +34,4 @@ export const GeoArrowWriter: WriterWithEncoder<
     // @ts-expect-error
     return encodeGeoArrowSync(data);
   }
-};
+} as const satisfies WriterWithEncoder<GeoJSONTable | BinaryGeometry, never, ArrowWriterOptions>;

--- a/modules/arrow/src/geoarrow/convert-geoarrow-to-geojson-geometry.ts
+++ b/modules/arrow/src/geoarrow/convert-geoarrow-to-geojson-geometry.ts
@@ -77,14 +77,14 @@ function arrowWKBToFeature(arrowCellValue: any) {
     arrowCellValue.byteOffset,
     arrowCellValue.byteOffset + arrowCellValue.byteLength
   );
-  const binaryGeometry = WKBLoader.parseSync?.(arrayBuffer)! as BinaryGeometry;
+  const binaryGeometry = WKBLoader.parseSync?.(arrayBuffer) as BinaryGeometry;
   const geometry = binaryToGeometry(binaryGeometry);
   return geometry;
 }
 
 function arrowWKTToFeature(arrowCellValue: any) {
   const string: string = arrowCellValue;
-  return WKTLoader.parseTextSync?.(string)!;
+  return WKTLoader.parseTextSync?.(string);
 }
 
 /**

--- a/modules/bson/src/bson-loader.ts
+++ b/modules/bson/src/bson-loader.ts
@@ -17,7 +17,9 @@ export type BSONLoaderOptions = LoaderOptions & {
   bson?: ParseBSONOptions;
 };
 
-export const BSONLoader: LoaderWithParser<Record<string, unknown>, never, BSONLoaderOptions> = {
+export const BSONLoader = {
+  dataType: null as unknown as Record<string, unknown>,
+  batchType: null as never,
   name: 'BSON',
   id: 'bson',
   module: 'bson',
@@ -31,7 +33,7 @@ export const BSONLoader: LoaderWithParser<Record<string, unknown>, never, BSONLo
   options: {
     bson: {}
   }
-};
+} as const satisfies LoaderWithParser<Record<string, unknown>, never, BSONLoaderOptions>;
 
 async function parse(arrayBuffer: ArrayBuffer, options?: BSONLoaderOptions) {
   const bsonOptions = {...BSONLoader.options.bson, ...options?.bson};

--- a/modules/bson/src/bson-writer.ts
+++ b/modules/bson/src/bson-writer.ts
@@ -14,7 +14,7 @@ export type BSONWriterOptions = WriterOptions & {
   bson?: EncodeBSONOptions
 }
 
-export const BSONWriter: WriterWithEncoder<Record<string, unknown>, never, BSONWriterOptions> = {
+export const BSONWriter = {
   name: 'BSON',
   id: 'bson',
   module: 'bson',
@@ -29,4 +29,4 @@ export const BSONWriter: WriterWithEncoder<Record<string, unknown>, never, BSONW
   encodeSync(data: Record<string, unknown>, options?: WriterOptions): ArrayBuffer {
     return encodeBSONSync(data, {}); // options
   }
-};
+} as const satisfies WriterWithEncoder<Record<string, unknown>, never, BSONWriterOptions>;

--- a/modules/core/src/null-loader.ts
+++ b/modules/core/src/null-loader.ts
@@ -16,7 +16,9 @@ export type NullLoaderOptions = LoaderOptions & {
 /**
  * Loads any data and returns null (or optionally passes through data unparsed)
  */
-export const NullWorkerLoader: Loader<null, never, NullLoaderOptions> = {
+export const NullWorkerLoader = {
+  dataType: null,
+  batchType: null as never,
   name: 'Null loader',
   id: 'null',
   module: 'core',
@@ -28,12 +30,15 @@ export const NullWorkerLoader: Loader<null, never, NullLoaderOptions> = {
   options: {
     null: {}
   }
-};
+} as const satisfies Loader<null, never, NullLoaderOptions>;
 
 /**
  * Loads any data and returns null (or optionally passes through data unparsed)
  */
-export const NullLoader: LoaderWithParser<null, null, NullLoaderOptions> = {
+export const NullLoader = {
+  dataType: null,
+  batchType: null,
+
   name: 'Null loader',
   id: 'null',
   module: 'core',
@@ -52,7 +57,7 @@ export const NullLoader: LoaderWithParser<null, null, NullLoaderOptions> = {
   options: {
     null: {}
   }
-};
+} as const satisfies LoaderWithParser<null, null, NullLoaderOptions>;
 
 /**
  * Returns arguments passed to the parse API in a format that can be transferred to a

--- a/modules/csv/src/csv-loader.ts
+++ b/modules/csv/src/csv-loader.ts
@@ -48,7 +48,10 @@ export type CSVLoaderOptions = LoaderOptions & {
   };
 };
 
-export const CSVLoader: LoaderWithParser<Table, TableBatch, CSVLoaderOptions> = {
+export const CSVLoader = {
+  dataType: null as unknown as Table,
+  batchType: null as unknown as TableBatch,
+
   id: 'csv',
   module: 'csv',
   name: 'CSV',
@@ -81,7 +84,7 @@ export const CSVLoader: LoaderWithParser<Table, TableBatch, CSVLoaderOptions> = 
       // fastMode: auto
     }
   }
-};
+} as const satisfies LoaderWithParser<Table, TableBatch, CSVLoaderOptions>;
 
 async function parseCSV(
   csvText: string,
@@ -110,7 +113,7 @@ async function parseCSV(
   const result = Papa.parse(csvText, papaparseConfig);
   const rows = result.data as any[];
 
-  const headerRow = result.meta.fields || generateHeader(csvOptions.columnPrefix!, firstRow.length);
+  const headerRow = result.meta.fields || generateHeader(csvOptions.columnPrefix, firstRow.length);
 
   const shape = csvOptions.shape || DEFAULT_CSV_SHAPE;
   switch (shape) {
@@ -195,7 +198,7 @@ function parseCSVInBatches(
       if (isFirstRow) {
         isFirstRow = false;
         if (!headerRow) {
-          headerRow = generateHeader(csvOptions.columnPrefix!, row.length);
+          headerRow = generateHeader(csvOptions.columnPrefix, row.length);
         }
         schema = deduceSchema(row, headerRow);
       }

--- a/modules/csv/src/csv-writer.ts
+++ b/modules/csv/src/csv-writer.ts
@@ -15,7 +15,7 @@ export type CSVWriterOptions = WriterOptions & {
   useDisplayNames?: never;
 };
 
-export const CSVWriter: WriterWithEncoder<Table, TableBatch, CSVWriterOptions> = {
+export const CSVWriter = {
   id: 'csv',
   version: 'latest',
   module: 'csv',
@@ -31,4 +31,4 @@ export const CSVWriter: WriterWithEncoder<Table, TableBatch, CSVWriterOptions> =
   encode: async (table, options) =>
     new TextEncoder().encode(encodeTableAsCSV(table, options)).buffer,
   encodeTextSync: (table, options) => encodeTableAsCSV(table, options)
-};
+} as const satisfies WriterWithEncoder<Table, TableBatch, CSVWriterOptions>;

--- a/modules/draco/src/draco-loader.ts
+++ b/modules/draco/src/draco-loader.ts
@@ -20,7 +20,9 @@ export type DracoLoaderOptions = LoaderOptions & {
 /**
  * Worker loader for Draco3D compressed geometries
  */
-export const DracoLoader: Loader<DracoMesh, never, DracoLoaderOptions> = {
+export const DracoLoader = {
+  dataType: null as unknown as DracoMesh,
+  batchType: null as never,
   name: 'Draco',
   id: 'draco',
   module: 'draco',
@@ -39,4 +41,4 @@ export const DracoLoader: Loader<DracoMesh, never, DracoLoaderOptions> = {
       attributeNameEntry: undefined
     }
   }
-};
+} as const satisfies Loader<DracoMesh, never, DracoLoaderOptions>;

--- a/modules/draco/src/draco-writer.ts
+++ b/modules/draco/src/draco-writer.ts
@@ -29,7 +29,7 @@ const DEFAULT_DRACO_WRITER_OPTIONS = {
 /**
  * Exporter for Draco3D compressed geometries
  */
-export const DracoWriter: WriterWithEncoder<DracoMesh, unknown, DracoWriterOptions> = {
+export const DracoWriter = {
   name: 'DRACO',
   id: 'draco',
   module: 'draco',
@@ -39,7 +39,7 @@ export const DracoWriter: WriterWithEncoder<DracoMesh, unknown, DracoWriterOptio
     draco: DEFAULT_DRACO_WRITER_OPTIONS
   },
   encode
-};
+} as const satisfies WriterWithEncoder<DracoMesh, unknown, DracoWriterOptions>;
 
 async function encode(data: DracoMesh, options: DracoWriterOptions = {}): Promise<ArrayBuffer> {
   // Dynamically load draco

--- a/modules/draco/src/index.ts
+++ b/modules/draco/src/index.ts
@@ -45,10 +45,10 @@ export {DracoWorkerLoader};
 /**
  * Loader for Draco3D compressed geometries
  */
-export const DracoLoader: LoaderWithParser<DracoMesh, never, DracoLoaderOptions> = {
+export const DracoLoader = {
   ...DracoWorkerLoader,
   parse
-};
+} as const satisfies LoaderWithParser<DracoMesh, never, DracoLoaderOptions>;
 
 async function parse(arrayBuffer: ArrayBuffer, options?: DracoLoaderOptions): Promise<DracoMesh> {
   const {draco} = await loadDracoDecoderModule(options);

--- a/modules/excel/src/excel-loader.ts
+++ b/modules/excel/src/excel-loader.ts
@@ -11,22 +11,17 @@ const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
 export type ExcelLoaderOptions = LoaderOptions & {
   excel?: {
-    shape: /* 'array-row-table' | */ 'object-row-table';
+    shape?: /* 'array-row-table' | */ 'object-row-table';
     sheet?: string; // Load default Sheet
   };
-};
-
-const DEFAULT_EXCEL_LOADER_OPTIONS: ExcelLoaderOptions = {
-  excel: {
-    shape: 'object-row-table',
-    sheet: undefined // Load default Sheet
-  }
 };
 
 /**
  * Worker Loader for Excel files
  */
-export const ExcelLoader: Loader<ObjectRowTable, never, ExcelLoaderOptions> = {
+export const ExcelLoader = {
+  dataType: null as unknown as ObjectRowTable,
+  batchType: null as never,
   name: 'Excel',
   id: 'excel',
   module: 'excel',
@@ -39,5 +34,10 @@ export const ExcelLoader: Loader<ObjectRowTable, never, ExcelLoaderOptions> = {
   ],
   category: 'table',
   binary: true,
-  options: DEFAULT_EXCEL_LOADER_OPTIONS
-};
+  options: {
+    excel: {
+      shape: 'object-row-table',
+      sheet: undefined // Load default Sheet
+    }
+  }
+} as const satisfies Loader<ObjectRowTable, never, ExcelLoaderOptions>;

--- a/modules/excel/src/index.ts
+++ b/modules/excel/src/index.ts
@@ -16,10 +16,10 @@ export {ExcelWorkerLoader};
 /**
  * Loader for Excel files
  */
-export const ExcelLoader: LoaderWithParser<ObjectRowTable, never, ExcelLoaderOptions> = {
+export const ExcelLoader = {
   ...ExcelWorkerLoader,
   async parse(arrayBuffer: ArrayBuffer, options?: ExcelLoaderOptions): Promise<ObjectRowTable> {
     const data = parseExcel(arrayBuffer, options);
     return {shape: 'object-row-table', data};
   }
-};
+} as const satisfies LoaderWithParser<ObjectRowTable, never, ExcelLoaderOptions>;

--- a/modules/flatgeobuf/src/flatgeobuf-loader.ts
+++ b/modules/flatgeobuf/src/flatgeobuf-loader.ts
@@ -22,7 +22,10 @@ export type FlatGeobufLoaderOptions = LoaderOptions & {
   };
 };
 
-export const FlatGeobufWorkerLoader: Loader<any, any, FlatGeobufLoaderOptions> = {
+export const FlatGeobufWorkerLoader = {
+  dataType: null as any,
+  batchType: null as any,
+
   id: 'flatgeobuf',
   name: 'FlatGeobuf',
   module: 'flatgeobuf',
@@ -40,13 +43,13 @@ export const FlatGeobufWorkerLoader: Loader<any, any, FlatGeobufLoaderOptions> =
       reproject: false
     }
   }
-};
+} as const satisfies Loader<any, any, FlatGeobufLoaderOptions>;
 
-export const FlatGeobufLoader: LoaderWithParser<any, any, FlatGeobufLoaderOptions> = {
+export const FlatGeobufLoader = {
   ...FlatGeobufWorkerLoader,
   parse: async (arrayBuffer, options) => parseFlatGeobuf(arrayBuffer, options),
   parseSync: parseFlatGeobuf,
   // @ts-expect-error this is a stream parser not an async iterator parser
   parseInBatchesFromStream: parseFlatGeobufInBatches,
   binary: true
-};
+} as const satisfies LoaderWithParser<any, any, FlatGeobufLoaderOptions>;

--- a/modules/geopackage/src/geopackage-loader.ts
+++ b/modules/geopackage/src/geopackage-loader.ts
@@ -27,11 +27,10 @@ export type GeoPackageLoaderOptions = LoaderOptions & {
   };
 };
 
-export const GeoPackageLoader: LoaderWithParser<
-  GeoJSONTable | Tables<GeoJSONTable>,
-  never,
-  GeoPackageLoaderOptions
-> = {
+export const GeoPackageLoader = {
+  dataType: null as unknown as GeoJSONTable | Tables<GeoJSONTable>,
+  batchType: null as never,
+
   id: 'geopackage',
   name: 'GeoPackage',
   module: 'geopackage',
@@ -47,24 +46,8 @@ export const GeoPackageLoader: LoaderWithParser<
     },
     gis: {}
   }
-};
-
-/** Geopackage loader *
-export const GeoPackageTableLoader: LoaderWithParser<Record<string, Feature[]>, never, GeoPackageLoaderOptions> = {
-  id: 'geopackage',
-  name: 'GeoPackage',
-  module: 'geopackage',
-  version: VERSION,
-  extensions: ['gpkg'],
-  mimeTypes: ['application/geopackage+sqlite3'],
-  category: 'geometry',
-  parse: parseGeoPackage,
-  options: {
-    geopackage: {
-      sqlJsCDN: DEFAULT_SQLJS_CDN,
-    },
-    gis: {
-    }
-  }
-};
-*/
+} as const satisfies LoaderWithParser<
+  GeoJSONTable | Tables<GeoJSONTable>,
+  never,
+  GeoPackageLoaderOptions
+>;

--- a/modules/geotiff/src/geotiff-loader.ts
+++ b/modules/geotiff/src/geotiff-loader.ts
@@ -29,7 +29,10 @@ export type GeoTIFFLoaderOptions = LoaderOptions & {
 };
 
 /** GeoTIFF loader */
-export const GeoTIFFLoader: LoaderWithParser<GeoTIFFData, never, GeoTIFFLoaderOptions> = {
+export const GeoTIFFLoader = {
+  dataType: null as unknown as GeoTIFFData,
+  batchType: null as never,
+
   id: 'geotiff',
   name: 'GeoTIFF',
   module: 'geotiff',
@@ -40,7 +43,7 @@ export const GeoTIFFLoader: LoaderWithParser<GeoTIFFData, never, GeoTIFFLoaderOp
   mimeTypes: ['image/tiff', 'image/geotiff'],
   extensions: ['geotiff', 'tiff', 'geotif', 'tif'],
   parse: parseGeoTIFF
-};
+} as const satisfies LoaderWithParser<GeoTIFFData, never, GeoTIFFLoaderOptions>;
 
 export function isTiff(arrayBuffer: ArrayBuffer): boolean {
   const dataView = new DataView(arrayBuffer);

--- a/modules/geotiff/src/loaders.ts
+++ b/modules/geotiff/src/loaders.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import {fromArrayBuffer} from 'geotiff';
 import type {LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';
 
@@ -53,8 +57,11 @@ const loadGeoTiff = async (
   };
 };
 
-// Export loader
-export const GeoTiffLoader: LoaderWithParser<GeoTiffData, never, GeoTiffLoaderOptions> = {
+// /** @deprecated Double definition */
+export const GeoTiffLoader = {
+  dataType: null as unknown as GeoTiffData,
+  batchType: null as never,
+
   id: 'geotiff',
   name: 'GeoTIFF',
   module: 'geotiff',
@@ -65,4 +72,4 @@ export const GeoTiffLoader: LoaderWithParser<GeoTiffData, never, GeoTiffLoaderOp
   mimeTypes: ['image/tiff', 'image/geotiff'],
   extensions: ['geotiff', 'tiff', 'geotif', 'tif'],
   parse: loadGeoTiff
-};
+} as const satisfies LoaderWithParser<GeoTiffData, never, GeoTiffLoaderOptions>;

--- a/modules/gltf/src/glb-loader.ts
+++ b/modules/gltf/src/glb-loader.ts
@@ -16,7 +16,9 @@ export type GLBLoaderOptions = LoaderOptions & {
  * GLB Loader -
  * GLB is the binary container format for GLTF
  */
-export const GLBLoader: LoaderWithParser<GLB, never, GLBLoaderOptions> = {
+export const GLBLoader = {
+  dataType: null as unknown as GLB,
+  batchType: null as never,
   name: 'GLB',
   id: 'glb',
   module: 'gltf',
@@ -31,7 +33,7 @@ export const GLBLoader: LoaderWithParser<GLB, never, GLBLoaderOptions> = {
       strict: false // Enables deprecated XVIZ support (illegal CHUNK formats)
     }
   }
-};
+} as const satisfies LoaderWithParser<GLB, never, GLBLoaderOptions>;
 
 async function parse(arrayBuffer: ArrayBuffer, options?: GLBLoaderOptions): Promise<GLB> {
   return parseSync(arrayBuffer, options);

--- a/modules/gltf/src/glb-writer.ts
+++ b/modules/gltf/src/glb-writer.ts
@@ -16,7 +16,7 @@ export type GLBWriterOptions = WriterOptions & {
  * GLB exporter
  * GLB is the binary container format for GLTF
  */
-export const GLBWriter: WriterWithEncoder<GLB, never, GLBWriterOptions> = {
+export const GLBWriter = {
   name: 'GLB',
   id: 'glb',
   module: 'gltf',
@@ -31,7 +31,7 @@ export const GLBWriter: WriterWithEncoder<GLB, never, GLBWriterOptions> = {
 
   encode: async (glb, options: GLBWriterOptions = {}) => encodeSync(glb, options),
   encodeSync
-};
+} as const satisfies WriterWithEncoder<GLB, never, GLBWriterOptions>;
 
 function encodeSync(glb, options) {
   const {byteOffset = 0} = options;

--- a/modules/gltf/src/gltf-loader.ts
+++ b/modules/gltf/src/gltf-loader.ts
@@ -22,7 +22,9 @@ export type GLTFLoaderOptions = LoaderOptions &
 /**
  * GLTF loader
  */
-export const GLTFLoader: LoaderWithParser<GLTFWithBuffers, never, GLBLoaderOptions> = {
+export const GLTFLoader = {
+  dataType: null as unknown as GLTFWithBuffers,
+  batchType: null as never,
   name: 'glTF',
   id: 'gltf',
   module: 'gltf',
@@ -46,7 +48,7 @@ export const GLTFLoader: LoaderWithParser<GLTFWithBuffers, never, GLBLoaderOptio
     // common?
     log: console // eslint-disable-line
   }
-};
+} as const satisfies LoaderWithParser<GLTFWithBuffers, never, GLBLoaderOptions>;
 
 export async function parse(
   arrayBuffer,

--- a/modules/gltf/src/gltf-writer.ts
+++ b/modules/gltf/src/gltf-writer.ts
@@ -1,4 +1,4 @@
-import type {Writer, WriterOptions} from '@loaders.gl/loader-utils';
+import type {WriterOptions, WriterWithEncoder} from '@loaders.gl/loader-utils';
 import {VERSION} from './lib/utils/version';
 import {encodeGLTFSync} from './lib/encoders/encode-gltf';
 
@@ -11,6 +11,9 @@ export type GLTFWriterOptions = WriterOptions & {
  * GLTF exporter
  */
 export const GLTFWriter = {
+  dataType: null as unknown as any,
+  batchType: null as never,
+
   name: 'glTF',
   id: 'gltf',
   module: 'gltf',
@@ -25,7 +28,7 @@ export const GLTFWriter = {
 
   encode: async (gltf, options: GLTFWriterOptions = {}) => encodeSync(gltf, options),
   encodeSync
-};
+} as WriterWithEncoder<any, never, GLTFWriterOptions>;
 
 function encodeSync(gltf, options: GLTFWriterOptions = {}) {
   const {byteOffset = 0} = options;
@@ -38,6 +41,3 @@ function encodeSync(gltf, options: GLTFWriterOptions = {}) {
 
   return arrayBuffer;
 }
-
-// TYPE TESTS - TODO find a better way than exporting junk
-export const _TypecheckGLBLoader: Writer = GLTFWriter;

--- a/modules/i3s/src/arcgis-webscene-loader.ts
+++ b/modules/i3s/src/arcgis-webscene-loader.ts
@@ -13,11 +13,9 @@ export type ArcGISWebSceneLoaderOptions = LoaderOptions & {};
  * Loader for ArcGIS WebScene
  * Spec - https://developers.arcgis.com/web-scene-specification/objects/webscene/
  */
-export const ArcGISWebSceneLoader: LoaderWithParser<
-  ArcGISWebSceneData,
-  never,
-  ArcGISWebSceneLoaderOptions
-> = {
+export const ArcGISWebSceneLoader = {
+  dataType: null as unknown as ArcGISWebSceneData,
+  batchType: null as never,
   name: 'ArcGIS Web Scene Loader',
   id: 'arcgis-web-scene',
   module: 'i3s',
@@ -26,7 +24,7 @@ export const ArcGISWebSceneLoader: LoaderWithParser<
   parse,
   extensions: ['json'],
   options: {}
-};
+} as const satisfies LoaderWithParser<ArcGISWebSceneData, never, ArcGISWebSceneLoaderOptions>;
 
 /**
  * Parse ArcGIS webscene

--- a/modules/i3s/src/i3s-attribute-loader.ts
+++ b/modules/i3s/src/i3s-attribute-loader.ts
@@ -14,7 +14,9 @@ const REJECTED_STATUS = 'rejected';
 /**
  * Loader for I3S attributes
  */
-export const I3SAttributeLoader: LoaderWithParser<I3STileAttributes, never, I3SLoaderOptions> = {
+export const I3SAttributeLoader = {
+  dataType: null as unknown as I3STileAttributes,
+  batchType: null as never,
   name: 'I3S Attribute',
   id: 'i3s-attribute',
   module: 'i3s',
@@ -24,7 +26,7 @@ export const I3SAttributeLoader: LoaderWithParser<I3STileAttributes, never, I3SL
   extensions: ['bin'],
   options: {},
   binary: true
-};
+} as const satisfies LoaderWithParser<I3STileAttributes, never, I3SLoaderOptions>;
 
 
 // TODO - these seem to use the loader rather than being part of the loader. Move to different file...

--- a/modules/i3s/src/i3s-building-scene-layer-loader.ts
+++ b/modules/i3s/src/i3s-building-scene-layer-loader.ts
@@ -8,14 +8,14 @@ import {parseBuildingSceneLayer} from './lib/parsers/parse-i3s-building-scene-la
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
 
 const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+
 /**
  * Loader for I3S - Building Scene Layer
  */
-export const I3SBuildingSceneLayerLoader: LoaderWithParser<
-  BuildingSceneLayerTileset,
-  never,
-  I3SLoaderOptions
-> = {
+export const I3SBuildingSceneLayerLoader = {
+  dataType: null as unknown as BuildingSceneLayerTileset,
+  batchType: null as never,
+
   name: 'I3S Building Scene Layer',
   id: 'i3s-building-scene-layer',
   module: 'i3s',
@@ -24,7 +24,7 @@ export const I3SBuildingSceneLayerLoader: LoaderWithParser<
   parse,
   extensions: ['json'],
   options: {}
-};
+} as const satisfies LoaderWithParser<BuildingSceneLayerTileset, never, I3SLoaderOptions>;
 
 async function parse(
   data: ArrayBuffer,

--- a/modules/i3s/src/i3s-content-loader.ts
+++ b/modules/i3s/src/i3s-content-loader.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import type {LoaderWithParser, LoaderContext} from '@loaders.gl/loader-utils';
 import type {I3SLoaderOptions} from './i3s-loader';
 import {parseI3STileContent} from './lib/parsers/parse-i3s-tile-content';
@@ -11,7 +15,10 @@ const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 /**
  * Loader for I3S - Indexed 3D Scene Layer
  */
-export const I3SContentLoader: LoaderWithParser<I3STileContent | null, never, I3SLoaderOptions> = {
+export const I3SContentLoader = {
+  dataType: null as unknown as I3STileContent | null,
+  batchType: null as never,
+
   name: 'I3S Content (Indexed Scene Layers)',
   id: 'i3s-content',
   module: 'i3s',
@@ -23,7 +30,7 @@ export const I3SContentLoader: LoaderWithParser<I3STileContent | null, never, I3
   options: {
     'i3s-content': {}
   }
-};
+} as const satisfies LoaderWithParser<I3STileContent | null, never, I3SLoaderOptions>;
 
 async function parse(data, options?: I3SLoaderOptions, context?: LoaderContext) {
   const {tile, _tileOptions, tileset, _tilesetOptions} = options?.i3s || {};

--- a/modules/i3s/src/i3s-loader.ts
+++ b/modules/i3s/src/i3s-loader.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import type {LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';
 import {parse} from '@loaders.gl/core';
 import type {I3STilesetHeader} from './types';
@@ -24,7 +28,10 @@ export type I3SLoaderOptions = LoaderOptions & {
 /**
  * Loader for I3S - Indexed 3D Scene Layer
  */
-export const I3SLoader: LoaderWithParser<I3STilesetHeader, never, LoaderOptions> = {
+export const I3SLoader = {
+  dataType: null as unknown as I3STilesetHeader,
+  batchType: null as never,
+
   name: 'I3S (Indexed Scene Layers)',
   id: 'i3s',
   module: 'i3s',
@@ -47,7 +54,7 @@ export const I3SLoader: LoaderWithParser<I3STilesetHeader, never, LoaderOptions>
       coordinateSystem: COORDINATE_SYSTEM.METER_OFFSETS
     }
   }
-};
+} as const satisfies LoaderWithParser<I3STilesetHeader, never, LoaderOptions>;
 
 async function parseI3S(data, options: I3SLoaderOptions = {}, context): Promise<I3STilesetHeader> {
   const url = context.url;

--- a/modules/i3s/src/i3s-node-page-loader.ts
+++ b/modules/i3s/src/i3s-node-page-loader.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import type {LoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';
 import type {I3SLoaderOptions} from './i3s-loader';
 import type {NodePage} from './types';
@@ -9,7 +13,10 @@ const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 /**
  * Loader for I3S node pages
  */
-export const I3SNodePageLoader: LoaderWithParser<NodePage, never, I3SLoaderOptions> = {
+export const I3SNodePageLoader = {
+  dataType: null as unknown as NodePage,
+  batchType: null as never,
+
   name: 'I3S Node Page',
   id: 'i3s-node-page',
   module: 'i3s',
@@ -20,7 +27,7 @@ export const I3SNodePageLoader: LoaderWithParser<NodePage, never, I3SLoaderOptio
   options: {
     i3s: {}
   }
-};
+} as const satisfies LoaderWithParser<NodePage, never, I3SLoaderOptions>;
 
 async function parseNodePage(data: ArrayBuffer, options?: LoaderOptions): Promise<NodePage> {
   return JSON.parse(new TextDecoder().decode(data)) as NodePage;

--- a/modules/i3s/src/i3s-slpk-loader.ts
+++ b/modules/i3s/src/i3s-slpk-loader.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import type {LoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';
 import {DataViewFile} from '@loaders.gl/loader-utils';
 import {parseSLPKArchive} from './lib/parsers/parse-slpk/parse-slpk';
@@ -21,7 +25,10 @@ export type SLPKLoaderOptions = LoaderOptions & {
  * @todo - this reloads the entire archive for every tile, should be optimized
  * @todo - this should be updated to use `parseFile` and ReadableFile
  */
-export const SLPKLoader: LoaderWithParser<ArrayBuffer, never, SLPKLoaderOptions> = {
+export const SLPKLoader = {
+  dataType: null as unknown as ArrayBuffer,
+  batchType: null as never,
+
   name: 'I3S SLPK (Scene Layer Package)',
   id: 'slpk',
   module: 'i3s',
@@ -33,4 +40,4 @@ export const SLPKLoader: LoaderWithParser<ArrayBuffer, never, SLPKLoaderOptions>
     const archive = await parseSLPKArchive(new DataViewFile(new DataView(data)));
     return archive.getFile(options.slpk?.path ?? '', options.slpk?.pathMode);
   }
-};
+} as const satisfies LoaderWithParser<ArrayBuffer, never, SLPKLoaderOptions>;

--- a/modules/i3s/src/lib/parsers/parse-i3s-tile-content.ts
+++ b/modules/i3s/src/lib/parsers/parse-i3s-tile-content.ts
@@ -76,17 +76,16 @@ export async function parseI3STileContent(
         try {
           // Image constructor is not supported in worker thread.
           // Do parsing image data on the main thread by using context to avoid worker issues.
-          const texture = await parseFromContext(arrayBuffer, [], options, context!);
-          // @ts-expect-error
+          const texture: any = await parseFromContext(arrayBuffer, [], options, context!);
           content.texture = texture;
         } catch (e) {
           // context object is different between worker and node.js conversion script.
           // To prevent error we parse data in ordinary way if it is not parsed by using context.
-          const texture = await parse(arrayBuffer, loader, options, context);
+          const texture: any = await parse(arrayBuffer, loader, options, context);
           content.texture = texture;
         }
       } else if (loader === CompressedTextureLoader || loader === BasisLoader) {
-        let texture = await load(arrayBuffer, loader, tileOptions.textureLoaderOptions);
+        let texture: any = await load(arrayBuffer, loader, tileOptions.textureLoaderOptions);
         if (loader === BasisLoader) {
           texture = texture[0];
         }

--- a/modules/images/src/image-loader.ts
+++ b/modules/images/src/image-loader.ts
@@ -37,7 +37,9 @@ const DEFAULT_IMAGE_LOADER_OPTIONS: ImageLoaderOptions = {
  * Loads a platform-specific image type
  * Note: This type can be used as input data to WebGL texture creation
  */
-export const ImageLoader: LoaderWithParser<ImageType, never, ImageLoaderOptions> = {
+export const ImageLoader = {
+  dataType: null as unknown as ImageType,
+  batchType: null as never,
   id: 'image',
   module: 'images',
   name: 'Images',
@@ -48,4 +50,4 @@ export const ImageLoader: LoaderWithParser<ImageType, never, ImageLoaderOptions>
   // TODO: byteOffset, byteLength;
   tests: [(arrayBuffer) => Boolean(getBinaryImageMetadata(new DataView(arrayBuffer)))],
   options: DEFAULT_IMAGE_LOADER_OPTIONS
-};
+} as const satisfies LoaderWithParser<ImageType, never, ImageLoaderOptions>;

--- a/modules/images/src/image-writer.ts
+++ b/modules/images/src/image-writer.ts
@@ -15,7 +15,7 @@ export type ImageWriterOptions = WriterOptions & {
 };
 
 /** Writer for image data */
-export const ImageWriter: WriterWithEncoder<ImageDataType, never, ImageWriterOptions> = {
+export const ImageWriter = {
   name: 'Images',
   id: 'image',
   module: 'images',
@@ -28,4 +28,4 @@ export const ImageWriter: WriterWithEncoder<ImageDataType, never, ImageWriterOpt
     }
   },
   encode: encodeImage
-};
+} as const satisfies WriterWithEncoder<ImageDataType, never, ImageWriterOptions>;

--- a/modules/json/src/geojson-loader.ts
+++ b/modules/json/src/geojson-loader.ts
@@ -25,7 +25,10 @@ export type GeoJSONLoaderOptions = JSONLoaderOptions & {
 /**
  * GeoJSON loader
  */
-export const GeoJSONWorkerLoader: Loader<GeoJSON, TableBatch, GeoJSONLoaderOptions> = {
+export const GeoJSONWorkerLoader = {
+  dataType: null as unknown as GeoJSON,
+  batchType: null as unknown as TableBatch,
+
   name: 'GeoJSON',
   id: 'geojson',
   module: 'geojson',
@@ -47,16 +50,16 @@ export const GeoJSONWorkerLoader: Loader<GeoJSON, TableBatch, GeoJSONLoaderOptio
       format: 'geojson'
     }
   }
-};
+} as const satisfies Loader<GeoJSON, TableBatch, GeoJSONLoaderOptions>;
 
-export const GeoJSONLoader: LoaderWithParser<GeoJSON, TableBatch, GeoJSONLoaderOptions> = {
+export const GeoJSONLoader = {
   ...GeoJSONWorkerLoader,
   // @ts-expect-error
   parse,
   // @ts-expect-error
   parseTextSync,
   parseInBatches
-};
+} as const satisfies LoaderWithParser<GeoJSON, TableBatch, GeoJSONLoaderOptions>;
 
 async function parse(arrayBuffer: ArrayBuffer, options?: GeoJSONLoaderOptions) {
   return parseTextSync(new TextDecoder().decode(arrayBuffer), options);

--- a/modules/json/src/geojson-writer.ts
+++ b/modules/json/src/geojson-writer.ts
@@ -19,7 +19,7 @@ export type GeoJSONWriterOptions = WriterOptions & {
   chunkSize?: number;
 };
 
-export const GeoJSONWriter: WriterWithEncoder<Table, TableBatch, GeoJSONWriterOptions> = {
+export const GeoJSONWriter = {
   id: 'geojson',
   version: 'latest',
   module: 'geojson',
@@ -42,4 +42,4 @@ export const GeoJSONWriter: WriterWithEncoder<Table, TableBatch, GeoJSONWriterOp
 
   encodeInBatches: (tableIterator: AsyncIterable<TableBatch> | Iterable<TableBatch>, options) =>
     encodeTableAsGeojsonInBatches(tableIterator, options)
-};
+} as const satisfies WriterWithEncoder<Table, TableBatch, GeoJSONWriterOptions>;

--- a/modules/json/src/json-loader.ts
+++ b/modules/json/src/json-loader.ts
@@ -34,11 +34,10 @@ export type JSONLoaderOptions = LoaderOptions & {
   };
 };
 
-export const JSONLoader: LoaderWithParser<
-  Table,
-  TableBatch | MetadataBatch | JSONBatch,
-  JSONLoaderOptions
-> = {
+export const JSONLoader = {
+  dataType: null as unknown as Table,
+  batchType: null as unknown as TableBatch | MetadataBatch | JSONBatch,
+
   name: 'JSON',
   id: 'json',
   module: 'json',
@@ -58,7 +57,11 @@ export const JSONLoader: LoaderWithParser<
   parse,
   parseTextSync,
   parseInBatches
-};
+} as const satisfies LoaderWithParser<
+  Table,
+  TableBatch | MetadataBatch | JSONBatch,
+  JSONLoaderOptions
+>;
 
 async function parse(arrayBuffer: ArrayBuffer, options?: JSONLoaderOptions) {
   return parseTextSync(new TextDecoder().decode(arrayBuffer), options);

--- a/modules/json/src/json-writer.ts
+++ b/modules/json/src/json-writer.ts
@@ -19,7 +19,7 @@ type RowArray = unknown[];
 type RowObject = {[key: string]: unknown};
 type TableJSON = RowArray[] | RowObject[];
 
-export const JSONWriter: WriterWithEncoder<Table, TableBatch, JSONWriterOptions> = {
+export const JSONWriter = {
   id: 'json',
   version: 'latest',
   module: 'json',
@@ -31,4 +31,4 @@ export const JSONWriter: WriterWithEncoder<Table, TableBatch, JSONWriterOptions>
   encode: async (table: Table, options: JSONWriterOptions) =>
     new TextEncoder().encode(encodeTableAsJSON(table, options)).buffer,
   encodeTextSync: (table: Table, options: JSONWriterOptions) => encodeTableAsJSON(table, options)
-};
+} as const satisfies WriterWithEncoder<Table, TableBatch, JSONWriterOptions>;

--- a/modules/json/src/ndgeoson-loader.ts
+++ b/modules/json/src/ndgeoson-loader.ts
@@ -18,11 +18,10 @@ export type NDGeoJSONLoaderOptions = LoaderOptions & {
 };
 
 /** NDGeoJSONLoader */
-export const NDJSONLoader: LoaderWithParser<
-  ArrayRowTable | ObjectRowTable,
-  Batch,
-  NDGeoJSONLoaderOptions
-> = {
+export const NDJSONLoader = {
+  dataType: null as unknown as ArrayRowTable | ObjectRowTable,
+  batchType: null as unknown as Batch,
+
   name: 'NDJSON',
   id: 'ndjson',
   module: 'json',
@@ -48,4 +47,8 @@ export const NDJSONLoader: LoaderWithParser<
       format: 'geojson'
     }
   }
-};
+} as const satisfies LoaderWithParser<
+  ArrayRowTable | ObjectRowTable,
+  Batch,
+  NDGeoJSONLoaderOptions
+>;

--- a/modules/json/src/ndjson-loader.ts
+++ b/modules/json/src/ndjson-loader.ts
@@ -11,11 +11,10 @@ import {parseNDJSONInBatches} from './lib/parsers/parse-ndjson-in-batches';
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
 const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
-export const NDJSONLoader: LoaderWithParser<
-  ObjectRowTable | ArrayRowTable,
-  TableBatch,
-  LoaderOptions
-> = {
+export const NDJSONLoader = {
+  dataType: null as unknown as ArrayRowTable | ObjectRowTable,
+  batchType: null as unknown as TableBatch,
+
   name: 'NDJSON',
   id: 'ndjson',
   module: 'json',
@@ -32,4 +31,4 @@ export const NDJSONLoader: LoaderWithParser<
   parseTextSync: parseNDJSONSync,
   parseInBatches: parseNDJSONInBatches,
   options: {}
-};
+} as const satisfies LoaderWithParser<ObjectRowTable | ArrayRowTable, TableBatch, LoaderOptions>;

--- a/modules/kml/src/gpx-loader.ts
+++ b/modules/kml/src/gpx-loader.ts
@@ -30,11 +30,10 @@ const GPX_HEADER = `\
 /**
  * Loader for GPX (GPS exchange format)
  */
-export const GPXLoader: LoaderWithParser<
-  ObjectRowTable | GeoJSONTable | BinaryFeatureCollection,
-  never,
-  GPXLoaderOptions
-> = {
+export const GPXLoader = {
+  dataType: null as unknown as ObjectRowTable | GeoJSONTable,
+  batchType: null as never,
+
   name: 'GPX (GPS exchange format)',
   id: 'gpx',
   module: 'kml',
@@ -50,7 +49,11 @@ export const GPXLoader: LoaderWithParser<
     gpx: {shape: 'geojson-table'},
     gis: {}
   }
-};
+} as const satisfies LoaderWithParser<
+  ObjectRowTable | GeoJSONTable | BinaryFeatureCollection,
+  never,
+  GPXLoaderOptions
+>;
 
 function parseTextSync(
   text: string,

--- a/modules/kml/src/kml-loader.ts
+++ b/modules/kml/src/kml-loader.ts
@@ -26,7 +26,10 @@ const KML_HEADER = `\
 /**
  * Loader for KML (Keyhole Markup Language)
  */
-export const KMLLoader: LoaderWithParser<ObjectRowTable | GeoJSONTable, never, KMLLoaderOptions> = {
+export const KMLLoader = {
+  dataType: null as unknown as ObjectRowTable | GeoJSONTable,
+  batchType: null as never,
+
   name: 'KML (Keyhole Markup Language)',
   id: 'kml',
   module: 'kml',
@@ -42,7 +45,7 @@ export const KMLLoader: LoaderWithParser<ObjectRowTable | GeoJSONTable, never, K
     kml: {shape: 'geojson-table'},
     gis: {}
   }
-};
+} as const satisfies LoaderWithParser<ObjectRowTable | GeoJSONTable, never, KMLLoaderOptions>;
 
 function parseTextSync(text: string, options?: KMLLoaderOptions): ObjectRowTable | GeoJSONTable {
   const doc = new DOMParser().parseFromString(text, 'text/xml');

--- a/modules/kml/src/tcx-loader.ts
+++ b/modules/kml/src/tcx-loader.ts
@@ -30,11 +30,10 @@ const TCX_HEADER = `\
 /**
  * Loader for TCX (Training Center XML) - Garmin GPS track format
  */
-export const TCXLoader: LoaderWithParser<
-  ObjectRowTable | GeoJSONTable | BinaryFeatureCollection,
-  never,
-  TCXLoaderOptions
-> = {
+export const TCXLoader = {
+  dataType: null as unknown as ObjectRowTable | GeoJSONTable | BinaryFeatureCollection,
+  batchType: null as never,
+
   name: 'TCX (Training Center XML)',
   id: 'tcx',
   module: 'kml',
@@ -50,7 +49,11 @@ export const TCXLoader: LoaderWithParser<
     tcx: {shape: 'geojson-table'},
     gis: {}
   }
-};
+} as const satisfies LoaderWithParser<
+  ObjectRowTable | GeoJSONTable | BinaryFeatureCollection,
+  never,
+  TCXLoaderOptions
+>;
 
 function parseTextSync(
   text: string,

--- a/modules/las/src/index.ts
+++ b/modules/las/src/index.ts
@@ -13,10 +13,10 @@ export {LASWorkerLoader};
  * Loader for the LAS (LASer) point cloud format
  * @note Does not support LAS v1.4
  */
-export const LASLoader: LoaderWithParser<LASMesh, never, LASLoaderOptions> = {
+export const LASLoader = {
   ...LASWorkerLoader,
   parse: async (arrayBuffer: ArrayBuffer, options?: LASLoaderOptions) =>
     parseLAS(arrayBuffer, options),
   parseSync: (arrayBuffer: ArrayBuffer, options?: LASLoaderOptions) =>
     parseLAS(arrayBuffer, options)
-};
+} as const satisfies LoaderWithParser<LASMesh, never, LASLoaderOptions>;

--- a/modules/las/src/las-loader.ts
+++ b/modules/las/src/las-loader.ts
@@ -20,7 +20,10 @@ export type LASLoaderOptions = LoaderOptions & {
  * Loader for the LAS (LASer) point cloud format
  * @note Does not support LAS v1.4
  */
-export const LASLoader: Loader<LASMesh, never, LASLoaderOptions> = {
+export const LASLoader = {
+  dataType: null as unknown as LASMesh,
+  batchType: null as never,
+
   name: 'LAS',
   id: 'las',
   module: 'las',
@@ -39,4 +42,4 @@ export const LASLoader: Loader<LASMesh, never, LASLoaderOptions> = {
       colorDepth: 8
     }
   }
-};
+} as const satisfies Loader<LASMesh, never, LASLoaderOptions>;

--- a/modules/lerc/src/lerc-loader.ts
+++ b/modules/lerc/src/lerc-loader.ts
@@ -26,7 +26,10 @@ export type LERCLoaderOptions = LoaderOptions & {
 /**
  * Loader for the LERC raster format
  */
-export const LERCLoader: LoaderWithParser<LERCData, never, LERCLoaderOptions> = {
+export const LERCLoader = {
+  dataType: null as unknown as LERCData,
+  batchType: null as never,
+
   id: 'lerc',
   name: 'LERC',
 
@@ -41,7 +44,7 @@ export const LERCLoader: LoaderWithParser<LERCData, never, LERCLoaderOptions> = 
   },
   parse: async (arrayBuffer: ArrayBuffer, options?: LERCLoaderOptions) =>
     parseLERC(arrayBuffer, options)
-};
+} as const satisfies LoaderWithParser<LERCData, never, LERCLoaderOptions>;
 
 async function parseLERC(arrayBuffer: ArrayBuffer, options?: LERCLoaderOptions): Promise<LERCData> {
   // Load the WASM library

--- a/modules/loader-utils/src/json-loader.ts
+++ b/modules/loader-utils/src/json-loader.ts
@@ -11,7 +11,9 @@ export type JSONLoaderOptions = LoaderOptions;
  * A JSON Micro loader (minimal bundle size)
  * Alternative to `@loaders.gl/json`
  */
-export const JSONLoader: LoaderWithParser<Table, TableBatch, JSONLoaderOptions> = {
+export const JSONLoader = {
+  dataType: null as unknown as Table,
+  batchType: null as unknown as TableBatch,
   name: 'JSON',
   id: 'json',
   module: 'json',
@@ -23,7 +25,7 @@ export const JSONLoader: LoaderWithParser<Table, TableBatch, JSONLoaderOptions> 
   parseTextSync,
   parse: async (arrayBuffer) => parseTextSync(new TextDecoder().decode(arrayBuffer)),
   options: {}
-};
+} as const satisfies LoaderWithParser<Table, TableBatch, JSONLoaderOptions>;
 
 // TODO - Better error handling!
 function parseTextSync(text) {

--- a/modules/loader-utils/src/loader-types.ts
+++ b/modules/loader-utils/src/loader-types.ts
@@ -110,9 +110,9 @@ type PreloadOptions = {
  */
 export type Loader<DataT = any, BatchT = any, LoaderOptionsT = LoaderOptions> = {
   /** The result type of this loader  */
-  dataType?: DataT;
+  dataType: DataT;
   /** The batched result type of this loader  */
-  batchType?: BatchT;
+  batchType: BatchT;
 
   /** Default Options */
   options: LoaderOptionsT;

--- a/modules/loader-utils/test/lib/iterators/async-iteration.spec.ts
+++ b/modules/loader-utils/test/lib/iterators/async-iteration.spec.ts
@@ -11,7 +11,7 @@ import {
 
 import {NDJSONLoader} from '@loaders.gl/json';
 
-const parseNDJSONInBatches = NDJSONLoader.parseInBatches!;
+const parseNDJSONInBatches = NDJSONLoader.parseInBatches;
 
 const setTimeoutPromise = (timeout) => new Promise((resolve) => setTimeout(resolve, timeout));
 

--- a/modules/mvt/src/mvt-loader.ts
+++ b/modules/mvt/src/mvt-loader.ts
@@ -16,11 +16,10 @@ const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 /**
  * Worker loader for the Mapbox Vector Tile format
  */
-export const MVTWorkerLoader: Loader<
-  any, // BinaryFeatureCollection | GeoJSONTable | Feature<Geometry, GeoJsonProperties>,
-  never,
-  MVTLoaderOptions
-> = {
+export const MVTWorkerLoader = {
+  dataType: null as any,
+  batchType: null as never,
+
   name: 'Mapbox Vector Tile',
   id: 'mvt',
   module: 'mvt',
@@ -44,18 +43,22 @@ export const MVTWorkerLoader: Loader<
       tileIndex: null
     }
   }
-};
+} as const satisfies Loader<
+  any, // BinaryFeatureCollection | GeoJSONTable | Feature<Geometry, GeoJsonProperties>,
+  never,
+  MVTLoaderOptions
+>;
 
 /**
  * Loader for the Mapbox Vector Tile format
  */
-export const MVTLoader: LoaderWithParser<
-  any, // BinaryFeatureCollection | GeoJSONTable | Feature<Geometry, GeoJsonProperties>,
-  never,
-  MVTLoaderOptions
-> = {
+export const MVTLoader = {
   ...MVTWorkerLoader,
   parse: async (arrayBuffer, options?: MVTLoaderOptions) => parseMVT(arrayBuffer, options),
   parseSync: parseMVT,
   binary: true
-};
+} as const satisfies LoaderWithParser<
+  any, // BinaryFeatureCollection | GeoJSONTable | Feature<Geometry, GeoJsonProperties>,
+  never,
+  MVTLoaderOptions
+>;

--- a/modules/mvt/src/tilejson-loader.ts
+++ b/modules/mvt/src/tilejson-loader.ts
@@ -21,7 +21,10 @@ export type TileJSONLoaderOptions = LoaderOptions & {
 /**
  * Loader for TileJSON metadata
  */
-export const TileJSONLoader: LoaderWithParser<TileJSON, never, TileJSONLoaderOptions> = {
+export const TileJSONLoader = {
+  dataType: null as unknown as TileJSON,
+  batchType: null as never,
+
   name: 'TileJSON',
   id: 'tilejson',
   module: 'pmtiles',
@@ -46,4 +49,4 @@ export const TileJSONLoader: LoaderWithParser<TileJSON, never, TileJSONLoaderOpt
     const tilejsonOptions = {...TileJSONLoader.options.tilejson, ...options?.tilejson};
     return parseTileJSON(json, tilejsonOptions) as TileJSON;
   }
-};
+} as const satisfies LoaderWithParser<TileJSON, never, TileJSONLoaderOptions>;

--- a/modules/netcdf/src/netcdf-loader.ts
+++ b/modules/netcdf/src/netcdf-loader.ts
@@ -21,7 +21,10 @@ export type NetCDFLoaderOptions = LoaderOptions & {
 /**
  * Worker loader for NETCDF
  */
-export const NetCDFWorkerLoader: Loader<NetCDF, never, NetCDFLoaderOptions> = {
+export const NetCDFWorkerLoader = {
+  dataType: null as unknown as NetCDF,
+  batchType: null as never,
+
   name: 'NetCDF',
   id: 'mvt',
   module: 'mvt',
@@ -38,16 +41,16 @@ export const NetCDFWorkerLoader: Loader<NetCDF, never, NetCDFLoaderOptions> = {
       loadVariables: false
     }
   }
-};
+} as const satisfies Loader<NetCDF, never, NetCDFLoaderOptions>;
 
 /**
  * Loader for the NetCDF format
  */
-export const NetCDFLoader: LoaderWithParser<NetCDF, never, NetCDFLoaderOptions> = {
+export const NetCDFLoader = {
   ...NetCDFWorkerLoader,
   parse: async (arrayBuffer, options) => parseNetCDF(arrayBuffer, options),
   binary: true
-};
+} as const satisfies LoaderWithParser<NetCDF, never, NetCDFLoaderOptions>;
 
 function parseNetCDF(arrayBuffer: ArrayBuffer, options?: NetCDFLoaderOptions): NetCDF {
   const reader = new NetCDFReader(arrayBuffer);

--- a/modules/obj/src/index.ts
+++ b/modules/obj/src/index.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import type {LoaderWithParser} from '@loaders.gl/loader-utils';
 import type {Mesh} from '@loaders.gl/schema';
 import {parseOBJ} from './lib/parse-obj';
@@ -16,21 +20,21 @@ export {OBJWorkerLoader};
 /**
  * Loader for the OBJ geometry format
  */
-export const OBJLoader: LoaderWithParser<Mesh, never, OBJLoaderOptions> = {
+export const OBJLoader = {
   ...OBJWorkerLoader,
   parse: async (arrayBuffer: ArrayBuffer, options?: OBJLoaderOptions) =>
     parseOBJ(new TextDecoder().decode(arrayBuffer), options),
   parseTextSync: (text: string, options?: OBJLoaderOptions) => parseOBJ(text, options)
-};
+} as const satisfies LoaderWithParser<Mesh, never, OBJLoaderOptions>;
 
 // MTLLoader
 
 /**
  * Loader for the MTL material format
  */
-export const MTLLoader: LoaderWithParser<MTLMaterial[], never, MTLLoaderOptions> = {
+export const MTLLoader = {
   ...MTLWorkerLoader,
   parse: async (arrayBuffer: ArrayBuffer, options?: MTLLoaderOptions) =>
     parseMTL(new TextDecoder().decode(arrayBuffer), options?.mtl),
   parseTextSync: (text: string, options?: MTLLoaderOptions) => parseMTL(text, options?.mtl)
-};
+} as const satisfies LoaderWithParser<MTLMaterial[], never, MTLLoaderOptions>;

--- a/modules/obj/src/mtl-loader.ts
+++ b/modules/obj/src/mtl-loader.ts
@@ -16,7 +16,10 @@ export type MTLLoaderOptions = LoaderOptions & {
  * Loader for the MTL material format
  * Parses a Wavefront .mtl file specifying materials
  */
-export const MTLLoader: Loader<MTLMaterial[], never, LoaderOptions> = {
+export const MTLLoader = {
+  dataType: null as unknown as MTLMaterial[],
+  batchType: null as never,
+
   name: 'MTL',
   id: 'mtl',
   module: 'mtl',
@@ -28,4 +31,4 @@ export const MTLLoader: Loader<MTLMaterial[], never, LoaderOptions> = {
   options: {
     mtl: {}
   }
-};
+} as const satisfies Loader<MTLMaterial[], never, LoaderOptions>;

--- a/modules/obj/src/obj-loader.ts
+++ b/modules/obj/src/obj-loader.ts
@@ -12,7 +12,10 @@ export type OBJLoaderOptions = LoaderOptions & {
 /**
  * Worker loader for the OBJ geometry format
  */
-export const OBJLoader: Loader<Mesh, never, OBJLoaderOptions> = {
+export const OBJLoader = {
+  dataType: null as unknown as Mesh,
+  batchType: null as never,
+
   name: 'OBJ',
   id: 'obj',
   module: 'obj',
@@ -24,7 +27,7 @@ export const OBJLoader: Loader<Mesh, never, OBJLoaderOptions> = {
   options: {
     obj: {}
   }
-};
+} as const satisfies Loader<Mesh, never, OBJLoaderOptions>;
 
 function testOBJFile(text: string): boolean {
   // TODO - There could be comment line first

--- a/modules/parquet/src/parquet-loader.ts
+++ b/modules/parquet/src/parquet-loader.ts
@@ -46,11 +46,10 @@ export type ParquetLoaderOptions = LoaderOptions & {
 /**
  * ParquetJS table loader
  */
-export const ParquetWorkerLoader: Loader<
-  ObjectRowTable,
-  ObjectRowTableBatch,
-  ParquetLoaderOptions
-> = {
+export const ParquetWorkerLoader = {
+  dataType: null as unknown as ObjectRowTable,
+  batchType: null as unknown as ObjectRowTableBatch,
+
   name: 'Apache Parquet',
   id: 'parquet',
   module: 'parquet',
@@ -70,69 +69,75 @@ export const ParquetWorkerLoader: Loader<
       preserveBinary: false
     }
   }
-};
+} as const satisfies Loader<ObjectRowTable, ObjectRowTableBatch, ParquetLoaderOptions>;
 
 /** ParquetJS table loader */
-export const ParquetLoader: LoaderWithParser<
-  ObjectRowTable | GeoJSONTable,
-  ObjectRowTableBatch | GeoJSONTableBatch,
-  ParquetLoaderOptions
-> = {
+export const ParquetLoader = {
   ...ParquetWorkerLoader,
+
+  dataType: null as unknown as ObjectRowTable | GeoJSONTable,
+  batchType: null as unknown as ObjectRowTableBatch | GeoJSONTableBatch,
+
   parse: (arrayBuffer: ArrayBuffer, options?: ParquetLoaderOptions) =>
     parseParquetFile(new BlobFile(arrayBuffer), options),
 
   parseFile: parseParquetFile,
   parseFileInBatches: parseParquetFileInBatches
-};
+} as const satisfies LoaderWithParser<
+  ObjectRowTable | GeoJSONTable,
+  ObjectRowTableBatch | GeoJSONTableBatch,
+  ParquetLoaderOptions
+>;
 
 // Defeat tree shaking
 // @ts-ignore
 ParquetLoader.Buffer = Buffer;
 
-export const GeoParquetWorkerLoader: Loader<GeoJSONTable, GeoJSONTableBatch, ParquetLoaderOptions> =
-  {
-    name: 'Apache Parquet',
-    id: 'parquet',
-    module: 'parquet',
-    version: VERSION,
-    worker: true,
-    category: 'table',
-    extensions: ['parquet'],
-    mimeTypes: ['application/octet-stream'],
-    binary: true,
-    tests: ['PAR1', 'PARE'],
-    options: {
-      parquet: {
-        shape: 'geojson-table',
-        columnList: [],
-        geoparquet: true,
-        url: undefined,
-        preserveBinary: false
-      }
+export const GeoParquetWorkerLoader = {
+  dataType: null as unknown as GeoJSONTable,
+  batchType: null as unknown as GeoJSONTableBatch,
+
+  name: 'Apache Parquet',
+  id: 'parquet',
+  module: 'parquet',
+  version: VERSION,
+  worker: true,
+  category: 'table',
+  extensions: ['parquet'],
+  mimeTypes: ['application/octet-stream'],
+  binary: true,
+  tests: ['PAR1', 'PARE'],
+  options: {
+    parquet: {
+      shape: 'geojson-table',
+      columnList: [],
+      geoparquet: true,
+      url: undefined,
+      preserveBinary: false
     }
-  };
+  }
+} as const satisfies Loader<GeoJSONTable, GeoJSONTableBatch, ParquetLoaderOptions>;
 
 /** ParquetJS table loader */
-export const GeoParquetLoader: LoaderWithParser<
-  ObjectRowTable | GeoJSONTable,
-  ObjectRowTableBatch | GeoJSONTableBatch,
-  ParquetLoaderOptions
-> = {
+export const GeoParquetLoader = {
   ...GeoParquetWorkerLoader,
+
   parse(arrayBuffer: ArrayBuffer, options?: ParquetLoaderOptions) {
     return parseGeoParquetFile(new BlobFile(arrayBuffer), options);
   },
   parseFile: parseGeoParquetFile,
   parseFileInBatches: parseGeoParquetFileInBatches
-};
+} as const satisfies LoaderWithParser<
+  ObjectRowTable | GeoJSONTable,
+  ObjectRowTableBatch | GeoJSONTableBatch,
+  ParquetLoaderOptions
+>;
 
 /** @deprecated Test to see if we can improve perf of parquetjs loader */
-export const ParquetColumnarWorkerLoader: Loader<
-  ColumnarTable,
-  ColumnarTableBatch,
-  ParquetLoaderOptions
-> = {
+export const ParquetColumnarWorkerLoader = {
+  dataType: null as any as ColumnarTable,
+  batchType: null as any as ColumnarTableBatch,
+
   name: 'Apache Parquet',
   id: 'parquet',
   module: 'parquet',
@@ -144,18 +149,14 @@ export const ParquetColumnarWorkerLoader: Loader<
   binary: true,
   tests: ['PAR1', 'PARE'],
   options: ParquetLoader.options
-};
+} as const satisfies Loader<ColumnarTable, ColumnarTableBatch, ParquetLoaderOptions>;
 
 /** @deprecated Test to see if we can improve perf of parquetjs loader */
-export const ParquetColumnarLoader: LoaderWithParser<
-  ColumnarTable,
-  ColumnarTableBatch,
-  ParquetLoaderOptions
-> = {
+export const ParquetColumnarLoader = {
   ...ParquetColumnarWorkerLoader,
   parse(arrayBuffer: ArrayBuffer, options?: ParquetLoaderOptions) {
     return parseParquetFileInColumns(new BlobFile(arrayBuffer), options);
   },
   parseFile: parseParquetFileInColumns,
   parseFileInBatches: parseParquetFileInColumnarBatches
-};
+} as const satisfies LoaderWithParser<ColumnarTable, ColumnarTableBatch, ParquetLoaderOptions>;

--- a/modules/parquet/src/parquet-wasm-loader.ts
+++ b/modules/parquet/src/parquet-wasm-loader.ts
@@ -17,7 +17,10 @@ export type ParquetWasmLoaderOptions = LoaderOptions & {
 };
 
 /** Parquet WASM table loader */
-export const ParquetWasmWorkerLoader: Loader<ArrowTable, never, ParquetWasmLoaderOptions> = {
+export const ParquetWasmWorkerLoader = {
+  dataType: null as unknown as ArrowTable,
+  batchType: null as never,
+
   name: 'Apache Parquet',
   id: 'parquet-wasm',
   module: 'parquet',
@@ -34,13 +37,13 @@ export const ParquetWasmWorkerLoader: Loader<ArrowTable, never, ParquetWasmLoade
       wasmUrl: PARQUET_WASM_URL
     }
   }
-};
+} as const satisfies Loader<ArrowTable, never, ParquetWasmLoaderOptions>;
 
 /** Parquet WASM table loader */
-export const ParquetWasmLoader: LoaderWithParser<ArrowTable, never, ParquetWasmLoaderOptions> = {
+export const ParquetWasmLoader = {
   ...ParquetWasmWorkerLoader,
   parse(arrayBuffer: ArrayBuffer, options?: ParquetWasmLoaderOptions) {
     options = {parquet: {...ParquetWasmLoader.options.parquet, ...options?.parquet}, ...options};
     return parseParquetWasm(arrayBuffer, options);
   }
-};
+} as const satisfies LoaderWithParser<ArrowTable, never, ParquetWasmLoaderOptions>;

--- a/modules/parquet/src/parquet-wasm-writer.ts
+++ b/modules/parquet/src/parquet-wasm-writer.ts
@@ -16,7 +16,7 @@ export type ParquetWriterOptions = WriterOptions & {
 };
 
 /** Parquet WASM writer */
-export const ParquetWasmWriter: WriterWithEncoder<ArrowTable, never, ParquetWriterOptions> = {
+export const ParquetWasmWriter = {
   name: 'Apache Parquet',
   id: 'parquet-wasm',
   module: 'parquet',
@@ -33,4 +33,4 @@ export const ParquetWasmWriter: WriterWithEncoder<ArrowTable, never, ParquetWrit
     options = {parquet: {...ParquetWasmWriter.options.parquet, ...options?.parquet}, ...options};
     return encode(arrowTable, options);
   }
-};
+} as const satisfies WriterWithEncoder<ArrowTable, never, ParquetWriterOptions>;

--- a/modules/parquet/src/parquet-writer.ts
+++ b/modules/parquet/src/parquet-writer.ts
@@ -11,7 +11,7 @@ const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
 export type ParquetWriterOptions = {};
 
-export const ParquetWriter: WriterWithEncoder<Table, TableBatch, ParquetWriterOptions> = {
+export const ParquetWriter = {
   name: 'Apache Parquet',
   id: 'parquet',
   module: 'parquet',
@@ -22,7 +22,7 @@ export const ParquetWriter: WriterWithEncoder<Table, TableBatch, ParquetWriterOp
   options: {},
   encode: async (data, options) => encodeSync(data, options),
   encodeSync
-};
+} as const satisfies WriterWithEncoder<Table, TableBatch, ParquetWriterOptions>;
 
 function encodeSync(data, options?: ParquetWriterOptions) {
   return new ArrayBuffer(0);

--- a/modules/parquet/src/parquetjs/schema/types.ts
+++ b/modules/parquet/src/parquetjs/schema/types.ts
@@ -340,7 +340,7 @@ function fromPrimitive_JSON(value: any): unknown {
 }
 
 function toPrimitive_BSON(value: any): Buffer {
-  const arrayBuffer = BSONWriter.encodeSync?.(value) as ArrayBuffer;
+  const arrayBuffer = BSONWriter.encodeSync?.(value);
   return Buffer.from(arrayBuffer);
 }
 

--- a/modules/pcd/src/index.ts
+++ b/modules/pcd/src/index.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import type {LoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';
 import parsePCDSync from './lib/parse-pcd';
 import {PCDLoader as PCDWorkerLoader} from './pcd-loader';
@@ -8,8 +12,8 @@ export {PCDWorkerLoader};
 /**
  * Loader for PCD - Point Cloud Data
  */
-export const PCDLoader: LoaderWithParser<PCDMesh, never, LoaderOptions> = {
+export const PCDLoader = {
   ...PCDWorkerLoader,
   parse: async (arrayBuffer) => parsePCDSync(arrayBuffer),
   parseSync: parsePCDSync
-};
+} as const satisfies LoaderWithParser<PCDMesh, never, LoaderOptions>;

--- a/modules/pcd/src/pcd-loader.ts
+++ b/modules/pcd/src/pcd-loader.ts
@@ -12,7 +12,10 @@ const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 /**
  * Worker loader for PCD - Point Cloud Data
  */
-export const PCDLoader: Loader<PCDMesh, never, LoaderOptions> = {
+export const PCDLoader = {
+  dataType: null as unknown as PCDMesh,
+  batchType: null as never,
+
   name: 'PCD (Point Cloud Data)',
   id: 'pcd',
   module: 'pcd',
@@ -23,4 +26,4 @@ export const PCDLoader: Loader<PCDMesh, never, LoaderOptions> = {
   options: {
     pcd: {}
   }
-};
+} as const satisfies Loader<PCDMesh, never, LoaderOptions>;

--- a/modules/ply/src/index.ts
+++ b/modules/ply/src/index.ts
@@ -19,11 +19,11 @@ export type PLYLoaderOptions = LoaderOptions & {
 /**
  * Loader for PLY - Polygon File Format
  */
-export const PLYLoader: LoaderWithParser<PLYMesh, any, PLYLoaderOptions> = {
+export const PLYLoader = {
   ...PLYWorkerLoader,
   // Note: parsePLY supports both text and binary
   parse: async (arrayBuffer, options) => parsePLY(arrayBuffer, options?.ply), // TODO - this may not detect text correctly?
   parseTextSync: (arrayBuffer, options) => parsePLY(arrayBuffer, options?.ply),
   parseSync: (arrayBuffer, options) => parsePLY(arrayBuffer, options?.ply),
   parseInBatches: (arrayBuffer, options) => parsePLYInBatches(arrayBuffer, options?.ply)
-};
+} as const satisfies LoaderWithParser<PLYMesh, any, PLYLoaderOptions>;

--- a/modules/ply/src/ply-loader.ts
+++ b/modules/ply/src/ply-loader.ts
@@ -11,7 +11,10 @@ const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
  * links: ['http://paulbourke.net/dataformats/ply/',
  * 'https://en.wikipedia.org/wiki/PLY_(file_format)']
  */
-export const PLYLoader: Loader<PLYMesh, never, LoaderOptions> = {
+export const PLYLoader = {
+  dataType: null as unknown as PLYMesh,
+  batchType: null as never,
+
   name: 'PLY',
   id: 'ply',
   module: 'ply',
@@ -26,4 +29,4 @@ export const PLYLoader: Loader<PLYMesh, never, LoaderOptions> = {
   options: {
     ply: {}
   }
-};
+} as const satisfies Loader<PLYMesh, never, LoaderOptions>;

--- a/modules/potree/src/potree-bin-loader.ts
+++ b/modules/potree/src/potree-bin-loader.ts
@@ -1,11 +1,17 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import type {LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';
 import {parsePotreeBin} from './parsers/parse-potree-bin';
 
 /**
  * Loader for potree Binary Point Attributes
  * */
-// @ts-ignore
-export const PotreeBinLoader: LoaderWithParser<{}, never, LoaderOptions> = {
+export const PotreeBinLoader = {
+  dataType: null as unknown as {},
+  batchType: null as never,
+
   name: 'potree Binary Point Attributes',
   id: 'potree',
   extensions: ['bin'],
@@ -13,8 +19,10 @@ export const PotreeBinLoader: LoaderWithParser<{}, never, LoaderOptions> = {
   // Unfortunately binary potree files have no header bytes, no test possible
   // test: ['...'],
   parseSync,
-  binary: true
-};
+  binary: true,
+  options: {}
+  // @ts-ignore
+} as const satisfies LoaderWithParser<{}, never, LoaderOptions>;
 
 function parseSync(arrayBuffer: ArrayBuffer, options?: LoaderOptions): {} {
   const index = {};

--- a/modules/potree/src/potree-hierarchy-chunk-loader.ts
+++ b/modules/potree/src/potree-hierarchy-chunk-loader.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import type {LoaderWithParser} from '@loaders.gl/loader-utils';
 import type {POTreeLoaderOptions} from './potree-loader';
 import type {POTreeNode} from './parsers/parse-potree-hierarchy-chunk';
@@ -5,15 +9,18 @@ import {parsePotreeHierarchyChunk} from './parsers/parse-potree-hierarchy-chunk'
 
 /** Potree hierarchy chunk loader */
 // @ts-ignore not a valid loader
-export const PotreeHierarchyChunkLoader: LoaderWithParser<POTreeNode, never, POTreeLoaderOptions> =
-  {
-    id: 'potree',
-    name: 'potree Hierarchy Chunk',
-    extensions: ['hrc'],
-    mimeTypes: ['application/octet-stream'],
-    // binary potree files have no header bytes, no content test function possible
-    // test: ['...'],
-    parse: async (arrayBuffer, options) => parsePotreeHierarchyChunk(arrayBuffer),
-    parseSync: (arrayBuffer, options) => parsePotreeHierarchyChunk(arrayBuffer),
-    binary: true
-  };
+export const PotreeHierarchyChunkLoader = {
+  dataType: null as unknown as POTreeNode,
+  batchType: null as never,
+
+  id: 'potree',
+  name: 'potree Hierarchy Chunk',
+  extensions: ['hrc'],
+  mimeTypes: ['application/octet-stream'],
+  // binary potree files have no header bytes, no content test function possible
+  // test: ['...'],
+  parse: async (arrayBuffer, options) => parsePotreeHierarchyChunk(arrayBuffer),
+  parseSync: (arrayBuffer, options) => parsePotreeHierarchyChunk(arrayBuffer),
+  binary: true
+  // @ts-ignore
+} as const satisfies LoaderWithParser<POTreeNode, never, POTreeLoaderOptions>;

--- a/modules/potree/src/potree-loader.ts
+++ b/modules/potree/src/potree-loader.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import type {LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';
 
 // __VERSION__ is injected by babel-plugin-version-inline
@@ -10,7 +14,10 @@ export type POTreeLoaderOptions = LoaderOptions & {
 
 /** Potree loader */
 // @ts-ignore
-export const PotreeLoader: LoaderWithParser<any, never, POTreeLoaderOptions> = {
+export const PotreeLoader = {
+  dataType: null as unknown as any,
+  batchType: null as never,
+
   name: 'potree',
   id: 'potree',
   module: 'potree',
@@ -22,4 +29,5 @@ export const PotreeLoader: LoaderWithParser<any, never, POTreeLoaderOptions> = {
   options: {
     potree: {}
   }
-};
+  // @ts-ignore
+} as const satisfies LoaderWithParser<any, never, POTreeLoaderOptions>;

--- a/modules/shapefile/src/dbf-loader.ts
+++ b/modules/shapefile/src/dbf-loader.ts
@@ -8,8 +8,11 @@ const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 /**
  * DBFLoader - DBF files are used to contain non-geometry columns in Shapefiles
  */
-export const DBFWorkerLoader: Loader = {
+export const DBFWorkerLoader = {
   name: 'DBF',
+  dataType: null as unknown,
+  batchType: null as never,
+
   id: 'dbf',
   module: 'shapefile',
   version: VERSION,
@@ -22,7 +25,7 @@ export const DBFWorkerLoader: Loader = {
       encoding: 'latin1'
     }
   }
-};
+} as const satisfies Loader;
 
 /** DBF file loader */
 export const DBFLoader: LoaderWithParser = {

--- a/modules/shapefile/src/shapefile-loader.ts
+++ b/modules/shapefile/src/shapefile-loader.ts
@@ -17,7 +17,7 @@ export type ShapefileLoaderOptions = LoaderOptions & {
  * Shapefile loader
  * @note Shapefile is multifile format and requires providing additional files
  */
-export const ShapefileLoader: LoaderWithParser<GeoJSONTable, Batch, ShapefileLoaderOptions> = {
+export const ShapefileLoader = {
   name: 'Shapefile',
   id: 'shapefile',
   module: 'shapefile',
@@ -38,4 +38,4 @@ export const ShapefileLoader: LoaderWithParser<GeoJSONTable, Batch, ShapefileLoa
   parse: parseShapefile,
   // @ts-expect-error
   parseInBatches: parseShapefileInBatches
-};
+} as const satisfies LoaderWithParser<GeoJSONTable, Batch, ShapefileLoaderOptions>;

--- a/modules/shapefile/src/shp-loader.ts
+++ b/modules/shapefile/src/shp-loader.ts
@@ -10,7 +10,10 @@ export const SHP_MAGIC_NUMBER = [0x00, 0x00, 0x27, 0x0a];
 /**
  * SHP file loader
  */
-export const SHPWorkerLoader: Loader = {
+export const SHPWorkerLoader = {
+  dataType: null as unknown,
+  batchType: null as never,
+
   name: 'SHP',
   id: 'shp',
   module: 'shapefile',
@@ -26,7 +29,7 @@ export const SHPWorkerLoader: Loader = {
       _maxDimensions: 4
     }
   }
-};
+} as const satisfies Loader;
 
 /** SHP file loader */
 export const SHPLoader: LoaderWithParser = {

--- a/modules/terrain/src/index.ts
+++ b/modules/terrain/src/index.ts
@@ -17,10 +17,10 @@ import {
 
 export {TerrainWorkerLoader};
 
-export const TerrainLoader: LoaderWithParser<any, never, TerrainLoaderOptions> = {
+export const TerrainLoader = {
   ...TerrainWorkerLoader,
   parse: parseTerrain
-};
+} as const satisfies LoaderWithParser<any, never, TerrainLoaderOptions>;
 
 export async function parseTerrain(
   arrayBuffer: ArrayBuffer,
@@ -46,9 +46,9 @@ export {QuantizedMeshWorkerLoader};
 /**
  * Loader for quantized meshes
  */
-export const QuantizedMeshLoader: LoaderWithParser<any, never, QuantizedMeshLoaderOptions> = {
+export const QuantizedMeshLoader = {
   ...QuantizedMeshWorkerLoader,
   parseSync: (arrayBuffer, options) => parseQuantizedMesh(arrayBuffer, options?.['quantized-mesh']),
   parse: async (arrayBuffer, options) =>
     parseQuantizedMesh(arrayBuffer, options?.['quantized-mesh'])
-};
+} as const satisfies LoaderWithParser<any, never, QuantizedMeshLoaderOptions>;

--- a/modules/terrain/src/quantized-mesh-loader.ts
+++ b/modules/terrain/src/quantized-mesh-loader.ts
@@ -15,7 +15,10 @@ export type QuantizedMeshLoaderOptions = LoaderOptions & {
 /**
  * Worker loader for quantized meshes
  */
-export const QuantizedMeshLoader: Loader<any, never, QuantizedMeshLoaderOptions> = {
+export const QuantizedMeshLoader = {
+  dataType: null as unknown as any, // Mesh,
+  batchType: null as never,
+
   name: 'Quantized Mesh',
   id: 'quantized-mesh',
   module: 'terrain',
@@ -29,4 +32,4 @@ export const QuantizedMeshLoader: Loader<any, never, QuantizedMeshLoaderOptions>
       skirtHeight: null
     }
   }
-};
+} as const satisfies Loader<any, never, QuantizedMeshLoaderOptions>;

--- a/modules/terrain/src/terrain-loader.ts
+++ b/modules/terrain/src/terrain-loader.ts
@@ -16,7 +16,10 @@ export type TerrainLoaderOptions = ImageLoaderOptions & {
 /**
  * Worker loader for image encoded terrain
  */
-export const TerrainLoader: Loader<Mesh, never, TerrainLoaderOptions> = {
+export const TerrainLoader = {
+  dataType: null as unknown as Mesh,
+  batchType: null as never,
+
   name: 'Terrain',
   id: 'terrain',
   module: 'terrain',
@@ -38,4 +41,4 @@ export const TerrainLoader: Loader<Mesh, never, TerrainLoaderOptions> = {
       skirtHeight: undefined
     }
   }
-};
+} as const satisfies Loader<Mesh, never, TerrainLoaderOptions>;

--- a/modules/textures/src/basis-loader.ts
+++ b/modules/textures/src/basis-loader.ts
@@ -10,7 +10,10 @@ import parseBasis from './lib/parsers/parse-basis';
 /**
  * Worker loader for Basis super compressed textures
  */
-export const BasisWorkerLoader: Loader<TextureLevel[][], never, LoaderOptions> = {
+export const BasisWorkerLoader = {
+  dataType: null as unknown as TextureLevel[][],
+  batchType: null as never,
+
   name: 'Basis',
   id: 'basis',
   module: 'textures',
@@ -28,12 +31,12 @@ export const BasisWorkerLoader: Loader<TextureLevel[][], never, LoaderOptions> =
       module: 'transcoder' // 'transcoder' || 'encoder'
     }
   }
-};
+} as const satisfies Loader<TextureLevel[][], never, LoaderOptions>;
 
 /**
  * Loader for Basis super compressed textures
  */
-export const BasisLoader: LoaderWithParser<TextureLevel[][], never, LoaderOptions> = {
+export const BasisLoader = {
   ...BasisWorkerLoader,
   parse: parseBasis
-};
+} as const satisfies LoaderWithParser<TextureLevel[][], never, LoaderOptions>;

--- a/modules/textures/src/compressed-texture-loader.ts
+++ b/modules/textures/src/compressed-texture-loader.ts
@@ -17,7 +17,10 @@ export type TextureLoaderOptions = {
 /**
  * Worker Loader for KTX, DDS, and PVR texture container formats
  */
-export const CompressedTextureWorkerLoader: Loader<any, never, TextureLoaderOptions> = {
+export const CompressedTextureWorkerLoader = {
+  dataType: null as unknown as any,
+  batchType: null as never,
+
   name: 'Texture Containers',
   id: 'compressed-texture',
   module: 'textures',
@@ -43,12 +46,12 @@ export const CompressedTextureWorkerLoader: Loader<any, never, TextureLoaderOpti
       useBasis: false
     }
   }
-};
+} as const satisfies Loader<any, never, TextureLoaderOptions>;
 
 /**
  * Loader for KTX, DDS, and PVR texture container formats
  */
-export const CompressedTextureLoader: LoaderWithParser<any, never, TextureLoaderOptions> = {
+export const CompressedTextureLoader = {
   ...CompressedTextureWorkerLoader,
   parse: async (arrayBuffer: ArrayBuffer, options?: TextureLoaderOptions) => {
     if (options?.['compressed-texture']?.useBasis) {
@@ -68,4 +71,4 @@ export const CompressedTextureLoader: LoaderWithParser<any, never, TextureLoader
     }
     return parseCompressedTexture(arrayBuffer);
   }
-};
+} as const satisfies LoaderWithParser<any, never, TextureLoaderOptions>;

--- a/modules/textures/src/compressed-texture-writer.ts
+++ b/modules/textures/src/compressed-texture-writer.ts
@@ -21,11 +21,7 @@ export type CompressedTextureWriterOptions = WriterOptions & {
 /**
  * DDS Texture Container Exporter
  */
-export const CompressedTextureWriter: WriterWithEncoder<
-  unknown,
-  unknown,
-  CompressedTextureWriterOptions
-> = {
+export const CompressedTextureWriter = {
   name: 'DDS Texture Container',
   id: 'dds',
   module: 'textures',
@@ -48,13 +44,4 @@ export const CompressedTextureWriter: WriterWithEncoder<
   encode() {
     throw new Error('Not implemented');
   }
-};
-
-// TYPE TESTS - TODO find a better way than exporting junk
-// export const _TypecheckCompressedTextureWriter: typeof CompressedTextureWriter & {
-//   encodeURLtoURL: (
-//     inputUrl: string,
-//     outputUrl: string,
-//     options?: CompressedTextureWriterOptions
-//   ) => Promise<string>;
-// } = CompressedTextureWriter;
+} as const satisfies WriterWithEncoder<unknown, unknown, CompressedTextureWriterOptions>;

--- a/modules/textures/src/crunch-loader.ts
+++ b/modules/textures/src/crunch-loader.ts
@@ -16,7 +16,10 @@ export type CrunchLoaderOptions = LoaderOptions & {
  * Worker loader for the Crunch compressed texture container format
  * @note We avoid bundling crunch - it is a rare format and large lib, so we only offer worker loader
  */
-export const CrunchLoader: Loader<TextureLevel[], never, CrunchLoaderOptions> = {
+export const CrunchLoader = {
+  dataType: null as unknown as TextureLevel[],
+  batchType: null as never,
+
   id: 'crunch',
   name: 'Crunch',
   module: 'textures',
@@ -30,4 +33,4 @@ export const CrunchLoader: Loader<TextureLevel[], never, CrunchLoaderOptions> = 
       libraryPath: 'libs/'
     }
   }
-};
+} as const satisfies Loader<TextureLevel[], never, CrunchLoaderOptions>;

--- a/modules/textures/src/ktx2-basis-writer.ts
+++ b/modules/textures/src/ktx2-basis-writer.ts
@@ -21,7 +21,7 @@ export type KTX2BasisWriterOptions = WriterOptions & {
  *  Basis Universal Supercompressed GPU Texture.
  *  Spec - https://github.com/Esri/i3s-spec/blob/master/docs/1.8/textureSetDefinitionFormat.cmn.md
  */
-export const KTX2BasisWriter: WriterWithEncoder<ImageDataType, unknown, KTX2BasisWriterOptions> = {
+export const KTX2BasisWriter = {
   name: 'Basis Universal Supercompressed GPU Texture',
   id: 'ktx2-basis-writer',
   module: 'textures',
@@ -38,4 +38,4 @@ export const KTX2BasisWriter: WriterWithEncoder<ImageDataType, unknown, KTX2Basi
   },
 
   encode: encodeKTX2BasisTexture
-};
+} as const satisfies WriterWithEncoder<ImageDataType, unknown, KTX2BasisWriterOptions>;

--- a/modules/textures/src/npy-loader.ts
+++ b/modules/textures/src/npy-loader.ts
@@ -16,7 +16,10 @@ export type NPYLoaderOptions = LoaderOptions & {
 /**
  * Worker loader for numpy "tiles"
  */
-export const NPYWorkerLoader: Loader<NPYTile, never, NPYLoaderOptions> = {
+export const NPYWorkerLoader = {
+  dataType: null as any as NPYTile,
+  batchType: null as never,
+
   name: 'NPY',
   id: 'npy',
   module: 'textures',
@@ -28,13 +31,13 @@ export const NPYWorkerLoader: Loader<NPYTile, never, NPYLoaderOptions> = {
   options: {
     npy: {}
   }
-};
+} as const satisfies Loader<NPYTile, never, NPYLoaderOptions>;
 
 /**
  * Loader for numpy "tiles"
  */
-export const NPYLoader: LoaderWithParser<any, any, NPYLoaderOptions> = {
+export const NPYLoader = {
   ...NPYWorkerLoader,
   parseSync: parseNPY,
   parse: async (arrayBuffer: ArrayBuffer, options?: LoaderOptions) => parseNPY(arrayBuffer, options)
-};
+} as const satisfies LoaderWithParser<any, any, NPYLoaderOptions>;

--- a/modules/tile-converter/src/deps-installer/deps-installer.ts
+++ b/modules/tile-converter/src/deps-installer/deps-installer.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import {load, fetchFile} from '@loaders.gl/core';
 import {ZipLoader} from '@loaders.gl/zip';
 import {writeFile} from '../lib/utils/file-utils';

--- a/modules/tile-converter/src/pgm-loader.ts
+++ b/modules/tile-converter/src/pgm-loader.ts
@@ -16,7 +16,10 @@ export type PGMLoaderOptions = LoaderOptions & {
 /**
  * Loader for PGM - Netpbm grayscale image format
  */
-export const PGMLoader: LoaderWithParser<Geoid, never, PGMLoaderOptions> = {
+export const PGMLoader = {
+  dataType: null as unknown as Geoid,
+  batchType: null as never,
+
   name: 'PGM - Netpbm grayscale image format',
   id: 'pgm',
   module: 'tile-converter',
@@ -29,4 +32,4 @@ export const PGMLoader: LoaderWithParser<Geoid, never, PGMLoaderOptions> = {
       cubic: false
     }
   }
-};
+} as const satisfies LoaderWithParser<Geoid, never, PGMLoaderOptions>;

--- a/modules/video/src/video-loader.ts
+++ b/modules/video/src/video-loader.ts
@@ -9,29 +9,25 @@ import parseVideo from './lib/parsers/parse-video';
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
 const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
-const EXTENSIONS = ['mp4'];
-const MIME_TYPES = ['video/mp4'];
-
-// Loads a platform-specific image type that can be used as input data to WebGL textures
-
 export type VideoLoaderOptions = LoaderOptions & {
   video: {};
 };
 
-const DEFAULT_LOADER_OPTIONS: VideoLoaderOptions = {
-  video: {}
-};
-
-export const VideoLoader: LoaderWithParser<HTMLVideoElement, never, VideoLoaderOptions> = {
+/**
+ * Loads a platform-specific image type that can be used as input data to WebGL textures
+ */
+export const VideoLoader = {
+  dataType: null as unknown as HTMLVideoElement,
+  batchType: null as never,
   name: 'Video',
   id: 'video',
   module: 'video',
   version: VERSION,
-  extensions: EXTENSIONS,
-  mimeTypes: MIME_TYPES,
-
-  parse: parseVideo,
-
+  extensions: ['mp4'],
+  mimeTypes: ['video/mp4'],
   // tests: arrayBuffer => Boolean(getBinaryImageMetadata(new DataView(arrayBuffer))),
-  options: DEFAULT_LOADER_OPTIONS
-};
+  options: {
+    video: {}
+  },
+  parse: parseVideo
+} as const satisfies LoaderWithParser<HTMLVideoElement, never, VideoLoaderOptions>;

--- a/modules/wkt/src/hex-wkb-loader.ts
+++ b/modules/wkt/src/hex-wkb-loader.ts
@@ -15,7 +15,9 @@ export type HexWKBLoaderOptions = WKBLoaderOptions;
 /**
  * Worker loader for Hex-encoded WKB (Well-Known Binary)
  */
-export const HexWKBLoader: LoaderWithParser<BinaryGeometry, never, HexWKBLoaderOptions> = {
+export const HexWKBLoader = {
+  dataType: null as unknown as BinaryGeometry,
+  batchType: null as never,
   name: 'Hexadecimal WKB',
   id: 'wkb',
   module: 'wkt',
@@ -30,7 +32,7 @@ export const HexWKBLoader: LoaderWithParser<BinaryGeometry, never, HexWKBLoaderO
   // TODO - encoding here seems wasteful - extend hex transcoder?
   parse: async (arrayBuffer: ArrayBuffer) => parseHexWKB(new TextDecoder().decode(arrayBuffer)),
   parseTextSync: parseHexWKB
-};
+} as const satisfies LoaderWithParser<BinaryGeometry, never, HexWKBLoaderOptions>;
 
 function parseHexWKB(text: string, options?: HexWKBLoaderOptions): BinaryGeometry {
   const uint8Array = decodeHex(text);

--- a/modules/wkt/src/twkb-loader.ts
+++ b/modules/wkt/src/twkb-loader.ts
@@ -16,7 +16,10 @@ export type WKBLoaderOptions = LoaderOptions & {
 /**
  * Worker loader for WKB (Well-Known Binary)
  */
-export const TWKBWorkerLoader: Loader<Geometry, never, WKBLoaderOptions> = {
+export const TWKBWorkerLoader = {
+  dataType: null as unknown as Geometry,
+  batchType: null as never,
+
   name: 'TWKB (Tiny Well-Known Binary)',
   id: 'twkb',
   module: 'wkt',
@@ -32,13 +35,13 @@ export const TWKBWorkerLoader: Loader<Geometry, never, WKBLoaderOptions> = {
       shape: 'binary-geometry' // 'geojson-geometry'
     }
   }
-};
+} as const satisfies Loader<Geometry, never, WKBLoaderOptions>;
 
 /**
  * Loader for WKB (Well-Known Binary)
  */
-export const TWKBLoader: LoaderWithParser<BinaryGeometry | Geometry, never, WKBLoaderOptions> = {
+export const TWKBLoader = {
   ...TWKBWorkerLoader,
   parse: async (arrayBuffer: ArrayBuffer) => parseTWKBGeometry(arrayBuffer),
   parseSync: parseTWKBGeometry
-};
+} as const satisfies LoaderWithParser<BinaryGeometry | Geometry, never, WKBLoaderOptions>;

--- a/modules/wkt/src/twkb-writer.ts
+++ b/modules/wkt/src/twkb-writer.ts
@@ -17,7 +17,7 @@ export type TWKBWriterOptions = WriterOptions & {
 /**
  * WKB exporter
  */
-export const TWKBWriter: WriterWithEncoder<Geometry, never, TWKBWriterOptions> = {
+export const TWKBWriter = {
   name: 'TWKB (Tiny Well Known Binary)',
   id: 'twkb',
   module: 'wkt',
@@ -33,4 +33,4 @@ export const TWKBWriter: WriterWithEncoder<Geometry, never, TWKBWriterOptions> =
       hasM: false
     }
   }
-};
+} as const satisfies WriterWithEncoder<Geometry, never, TWKBWriterOptions>;

--- a/modules/wkt/src/wkb-loader.ts
+++ b/modules/wkt/src/wkb-loader.ts
@@ -18,7 +18,9 @@ export type WKBLoaderOptions = LoaderOptions & {
 /**
  * Worker loader for WKB (Well-Known Binary)
  */
-export const WKBWorkerLoader: Loader<Geometry | BinaryGeometry, never, WKBLoaderOptions> = {
+export const WKBWorkerLoader = {
+  dataType: null as unknown as Geometry | BinaryGeometry,
+  batchType: null as never,
   name: 'WKB',
   id: 'wkb',
   module: 'wkt',
@@ -34,13 +36,13 @@ export const WKBWorkerLoader: Loader<Geometry | BinaryGeometry, never, WKBLoader
       shape: 'binary-geometry' // 'geojson-geometry'
     }
   }
-};
+} as const satisfies Loader<Geometry | BinaryGeometry, never, WKBLoaderOptions>;
 
 /**
  * Loader for WKB (Well-Known Binary)
  */
-export const WKBLoader: LoaderWithParser<BinaryGeometry | Geometry, never, WKBLoaderOptions> = {
+export const WKBLoader = {
   ...WKBWorkerLoader,
   parse: async (arrayBuffer: ArrayBuffer) => parseWKB(arrayBuffer),
   parseSync: parseWKB
-};
+} as const satisfies LoaderWithParser<BinaryGeometry | Geometry, never, WKBLoaderOptions>;

--- a/modules/wkt/src/wkb-writer.ts
+++ b/modules/wkt/src/wkb-writer.ts
@@ -23,7 +23,7 @@ export type WKBWriterOptions = WriterOptions & {
 /**
  * WKB exporter
  */
-export const WKBWriter: WriterWithEncoder<Geometry | Feature, never, WriterOptions> = {
+export const WKBWriter = {
   name: 'WKB (Well Known Binary)',
   id: 'wkb',
   module: 'wkt',
@@ -41,4 +41,4 @@ export const WKBWriter: WriterWithEncoder<Geometry | Feature, never, WriterOptio
   encodeSync(data: Geometry | Feature, options?: WriterOptions): ArrayBuffer {
     return encodeWKB(data, options?.wkb);
   }
-};
+} as const satisfies WriterWithEncoder<Geometry | Feature, never, WriterOptions>;

--- a/modules/wkt/src/wkt-crs-loader.ts
+++ b/modules/wkt/src/wkt-crs-loader.ts
@@ -16,7 +16,9 @@ export type WKTCRSLoaderOptions = LoaderOptions & {
  * @see OGC Standard: https://www.ogc.org/standards/wkt-crs
  * @see Wikipedia Page: https://en.wikipedia.org/wiki/Well-known_text_representation_of_coordinate_reference_systems
  */
-export const WKTCRSLoader: LoaderWithParser<WKTCRS, never, WKTCRSLoaderOptions> = {
+export const WKTCRSLoader = {
+  dataType: null as unknown as WKTCRS,
+  batchType: null as never,
   name: 'WKT CRS (Well-Known Text Coordinate Reference System)',
   id: 'wkt-crs',
   module: 'wkt-crs',
@@ -32,4 +34,4 @@ export const WKTCRSLoader: LoaderWithParser<WKTCRS, never, WKTCRSLoaderOptions> 
   parse: async (arrayBuffer, options) =>
     parseWKTCRS(new TextDecoder().decode(arrayBuffer), options?.['wkt-crs']),
   parseTextSync: (string, options) => parseWKTCRS(string, options?.['wkt-crs'])
-};
+} as const satisfies LoaderWithParser<WKTCRS, never, WKTCRSLoaderOptions>;

--- a/modules/wkt/src/wkt-crs-writer.ts
+++ b/modules/wkt/src/wkt-crs-writer.ts
@@ -18,7 +18,7 @@ export type WKTCRSWriterOptions = WriterOptions & {
  * @see OGC Standard: https://www.ogc.org/standards/wkt-crs
  * @see Wikipedia Page: https://en.wikipedia.org/wiki/Well-known_text_representation_of_coordinate_reference_systems
  */
-export const WKTCRSWriter: WriterWithEncoder<WKTCRS, never, WKTCRSWriterOptions> = {
+export const WKTCRSWriter = {
   name: 'WKT CRS (Well-Known Text Coordinate Reference System)',
   id: 'wkt-crs',
   module: 'wkt-crs',
@@ -36,4 +36,4 @@ export const WKTCRSWriter: WriterWithEncoder<WKTCRS, never, WKTCRSWriterOptions>
   encodeSync: (wktcrs, options) =>
     new TextEncoder().encode(encodeWKTCRS(wktcrs, options?.['wkt-crs'])),
   encodeTextSync: (wktcrs, options) => encodeWKTCRS(wktcrs, options?.['wkt-crs'])
-};
+} as const satisfies WriterWithEncoder<WKTCRS, never, WKTCRSWriterOptions>;

--- a/modules/wkt/src/wkt-loader.ts
+++ b/modules/wkt/src/wkt-loader.ts
@@ -20,7 +20,10 @@ export type WKTLoaderOptions = LoaderOptions & {
 /**
  * Well-Known text worker loader
  */
-export const WKTWorkerLoader: Loader<Geometry, never, WKTLoaderOptions> = {
+export const WKTWorkerLoader = {
+  dataType: null as unknown as Geometry,
+  batchType: null as never,
+
   name: 'WKT (Well-Known Text)',
   id: 'wkt',
   module: 'wkt',
@@ -38,13 +41,13 @@ export const WKTWorkerLoader: Loader<Geometry, never, WKTLoaderOptions> = {
       crs: true
     }
   }
-};
+} as const satisfies Loader<Geometry, never, WKTLoaderOptions>;
 
 /**
  * Well-Known text loader
  */
-export const WKTLoader: LoaderWithParser<Geometry, never, WKTLoaderOptions> = {
+export const WKTLoader = {
   ...WKTWorkerLoader,
-  parse: async (arrayBuffer, options) => parseWKT(new TextDecoder().decode(arrayBuffer), options),
-  parseTextSync: parseWKT
-};
+  parse: async (arrayBuffer, options?) => parseWKT(new TextDecoder().decode(arrayBuffer), options),
+  parseTextSync: (string: string, options?) => parseWKT(string, options)
+} as const satisfies LoaderWithParser<Geometry, never, WKTLoaderOptions>;

--- a/modules/wkt/src/wkt-writer.ts
+++ b/modules/wkt/src/wkt-writer.ts
@@ -14,7 +14,7 @@ export type WKTWriterOptions = WriterOptions & {
 /**
  * WKT exporter
  */
-export const WKTWriter: WriterWithEncoder<Geometry, never, WKTWriterOptions> = {
+export const WKTWriter = {
   name: 'WKT (Well Known Text)',
   id: 'wkt',
   module: 'wkt',
@@ -27,7 +27,7 @@ export const WKTWriter: WriterWithEncoder<Geometry, never, WKTWriterOptions> = {
   options: {
     wkt: {}
   }
-};
+} as const satisfies WriterWithEncoder<Geometry, never, WKTWriterOptions>;
 
 function encodeWKTSync(geometry: Geometry): ArrayBuffer {
   return new TextEncoder().encode(encodeWKT(geometry)).buffer;

--- a/modules/wkt/test/lib/utils/hex-transcoder.spec.ts
+++ b/modules/wkt/test/lib/utils/hex-transcoder.spec.ts
@@ -5,7 +5,7 @@
 import test from 'tape-promise/tape';
 import {HexWKBLoader} from '@loaders.gl/wkt';
 
-const isHexWKB = HexWKBLoader.testText!;
+const isHexWKB = HexWKBLoader.testText;
 
 test('datasetUtils.isHexWKB', (t) => {
   t.notOk(isHexWKB(''), 'empty string is not a valid hex wkb');

--- a/modules/wms/src/csw-capabilities-loader.ts
+++ b/modules/wms/src/csw-capabilities-loader.ts
@@ -22,7 +22,10 @@ export type CSWLoaderOptions = XMLLoaderOptions & {
 /**
  * Loader for the response to the CSW GetCapability request
  */
-export const CSWCapabilitiesLoader: LoaderWithParser<CSWCapabilities, never, CSWLoaderOptions> = {
+export const CSWCapabilitiesLoader = {
+  dataType: null as unknown as CSWCapabilities,
+  batchType: null as never,
+
   id: 'csw-capabilities',
   name: 'CSW Capabilities',
   module: 'wms',
@@ -37,7 +40,7 @@ export const CSWCapabilitiesLoader: LoaderWithParser<CSWCapabilities, never, CSW
   parse: async (arrayBuffer: ArrayBuffer, options?: CSWLoaderOptions) =>
     parseCSWCapabilities(new TextDecoder().decode(arrayBuffer), options),
   parseTextSync: (text: string, options?: CSWLoaderOptions) => parseCSWCapabilities(text, options)
-};
+} as const satisfies LoaderWithParser<CSWCapabilities, never, CSWLoaderOptions>;
 
 function testXMLFile(text: string): boolean {
   // TODO - There could be space first.

--- a/modules/wms/src/csw-domain-loader.ts
+++ b/modules/wms/src/csw-domain-loader.ts
@@ -20,7 +20,10 @@ export type CSWLoaderOptions = XMLLoaderOptions & {
 /**
  * Loader for the response to the CSW GetCapability request
  */
-export const CSWDomainLoader: LoaderWithParser<CSWDomain, never, CSWLoaderOptions> = {
+export const CSWDomainLoader = {
+  dataType: null as unknown as CSWDomain,
+  batchType: null as never,
+
   id: 'csw-domain',
   name: 'CSW Domain',
 
@@ -36,7 +39,7 @@ export const CSWDomainLoader: LoaderWithParser<CSWDomain, never, CSWLoaderOption
   parse: async (arrayBuffer: ArrayBuffer, options?: CSWLoaderOptions) =>
     parseCSWDomain(new TextDecoder().decode(arrayBuffer), options),
   parseTextSync: (text: string, options?: CSWLoaderOptions) => parseCSWDomain(text, options)
-};
+} as const satisfies LoaderWithParser<CSWDomain, never, CSWLoaderOptions>;
 
 function testXMLFile(text: string): boolean {
   // TODO - There could be space first.

--- a/modules/wms/src/csw-records-loader.ts
+++ b/modules/wms/src/csw-records-loader.ts
@@ -20,7 +20,10 @@ export type CSWLoaderOptions = XMLLoaderOptions & {
 /**
  * Loader for the response to the CSW GetCapability request
  */
-export const CSWRecordsLoader: LoaderWithParser<CSWRecords, never, CSWLoaderOptions> = {
+export const CSWRecordsLoader = {
+  dataType: null as unknown as CSWRecords,
+  batchType: null as never,
+
   id: 'csw-records',
   name: 'CSW Records',
   module: 'wms',
@@ -35,7 +38,7 @@ export const CSWRecordsLoader: LoaderWithParser<CSWRecords, never, CSWLoaderOpti
   parse: async (arrayBuffer: ArrayBuffer, options?: CSWLoaderOptions) =>
     parseCSWRecords(new TextDecoder().decode(arrayBuffer), options),
   parseTextSync: (text: string, options?: CSWLoaderOptions) => parseCSWRecords(text, options)
-};
+} as const satisfies LoaderWithParser<CSWRecords, never, CSWLoaderOptions>;
 
 function testXMLFile(text: string): boolean {
   // TODO - There could be space first.

--- a/modules/wms/src/gml-loader.ts
+++ b/modules/wms/src/gml-loader.ts
@@ -17,7 +17,10 @@ export type GMLLoaderOptions = LoaderOptions & {
 /**
  * Loader for the response to the GML GetCapability request
  */
-export const GMLLoader: LoaderWithParser<Geometry | null, never, GMLLoaderOptions> = {
+export const GMLLoader = {
+  dataType: null as unknown as Geometry | null,
+  batchType: null as never,
+
   name: 'GML',
   id: 'gml',
 
@@ -33,7 +36,7 @@ export const GMLLoader: LoaderWithParser<Geometry | null, never, GMLLoaderOption
   parse: async (arrayBuffer: ArrayBuffer, options?: GMLLoaderOptions) =>
     parseGML(new TextDecoder().decode(arrayBuffer), options),
   parseTextSync: (text: string, options?: GMLLoaderOptions) => parseGML(text, options)
-};
+} as const satisfies LoaderWithParser<Geometry | null, never, GMLLoaderOptions>;
 
 function testXMLFile(text: string): boolean {
   // TODO - There could be space first.

--- a/modules/wms/src/wip/wcs-capabilities-loader.ts
+++ b/modules/wms/src/wip/wcs-capabilities-loader.ts
@@ -18,6 +18,9 @@ export type WCSLoaderOptions = LoaderOptions & {
  * Loader for the response to the WCS GetCapability request
  */
 export const WCSCapabilitiesLoader = {
+  dataType: null as unknown as WCSCapabilities,
+  batchType: null as never,
+
   id: 'wcs-capabilities',
   name: 'WFS Capabilities',
 
@@ -33,7 +36,7 @@ export const WCSCapabilitiesLoader = {
   parse: async (arrayBuffer: ArrayBuffer, options?: WCSLoaderOptions) =>
     parseWCSCapabilities(new TextDecoder().decode(arrayBuffer), options),
   parseTextSync: (text: string, options?: WCSLoaderOptions) => parseWCSCapabilities(text, options)
-};
+} as const satisfies LoaderWithParser<WCSCapabilities, never, WCSLoaderOptions>;
 
 function testXMLFile(text: string): boolean {
   // TODO - There could be space first.

--- a/modules/wms/src/wip/wfs-capabilities-loader.ts
+++ b/modules/wms/src/wip/wfs-capabilities-loader.ts
@@ -17,7 +17,10 @@ export type WFSLoaderOptions = LoaderOptions & {
 /**
  * Loader for the response to the WFS GetCapability request
  */
-export const WFSCapabilitiesLoader: LoaderWithParser<WFSCapabilities, never, WFSLoaderOptions> = {
+export const WFSCapabilitiesLoader = {
+  dataType: null as unknown as WFSCapabilities,
+  batchType: null as never,
+
   id: 'wfs-capabilities',
   name: 'WFS Capabilities',
 
@@ -33,7 +36,7 @@ export const WFSCapabilitiesLoader: LoaderWithParser<WFSCapabilities, never, WFS
   parse: async (arrayBuffer: ArrayBuffer, options?: WFSLoaderOptions) =>
     parseWFSCapabilities(new TextDecoder().decode(arrayBuffer), options),
   parseTextSync: (text: string, options?: WFSLoaderOptions) => parseWFSCapabilities(text, options)
-};
+} as const satisfies LoaderWithParser<WFSCapabilities, never, WFSLoaderOptions>;
 
 function testXMLFile(text: string): boolean {
   // TODO - There could be space first.

--- a/modules/wms/src/wip/wms-feature-info-loader.ts
+++ b/modules/wms/src/wip/wms-feature-info-loader.ts
@@ -1,4 +1,6 @@
-// loaders.gl, MIT license
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
 
 import type {LoaderWithParser} from '@loaders.gl/loader-utils';
 import type {XMLLoaderOptions} from '@loaders.gl/xml';
@@ -12,9 +14,9 @@ export {WMSFeatureInfo};
 /**
  * Loader for the response to the WMS GetFeatureInfo request
  */
-// @ts-expect-error
-export const WMSFeatureInfoLoader: LoaderWithParser<WMSFeatureInfo, never, XMLLoaderOptions> = {
+export const WMSFeatureInfoLoader = {
   ...WMSCapabilitiesLoader,
+  dataType: null as unknown as WMSFeatureInfo,
 
   id: 'wms-feature-info',
   name: 'WMS FeatureInfo',
@@ -22,6 +24,4 @@ export const WMSFeatureInfoLoader: LoaderWithParser<WMSFeatureInfo, never, XMLLo
   parse: async (arrayBuffer: ArrayBuffer, options?: XMLLoaderOptions) =>
     parseWMSFeatureInfo(new TextDecoder().decode(arrayBuffer), options),
   parseTextSync: (text: string, options?: XMLLoaderOptions) => parseWMSFeatureInfo(text, options)
-};
-
-export const _typecheckWMSFeatureInfoLoader: LoaderWithParser = WMSFeatureInfoLoader;
+} as const satisfies LoaderWithParser<WMSFeatureInfo, never, XMLLoaderOptions>;

--- a/modules/wms/src/wip/wms-layer-description-loader.ts
+++ b/modules/wms/src/wip/wms-layer-description-loader.ts
@@ -14,6 +14,7 @@ export {WMSLayerDescription};
  */
 export const WMSLayerDescriptionLoader = {
   ...WMSCapabilitiesLoader,
+  dataType: null as unknown as WMSLayerDescription,
 
   id: 'wms-layer-description',
   name: 'WMS DescribeLayer',
@@ -21,6 +22,4 @@ export const WMSLayerDescriptionLoader = {
   parse: async (arrayBuffer: ArrayBuffer, options?: XMLLoaderOptions) =>
     parseWMSLayerDescription(new TextDecoder().decode(arrayBuffer), options),
   parseTextSync: (text: string, options?: XMLLoaderOptions) => parseWMSLayerDescription(text, options)
-};
-
-export const _typecheckWMSFeatureInfoLoader: LoaderWithParser = WMSLayerDescriptionLoader;
+} as const satisfies LoaderWithParser<WMSLayerDescription, never, XMLLoaderOptions>;

--- a/modules/wms/src/wip/wmts-capabilities-loader.ts
+++ b/modules/wms/src/wip/wmts-capabilities-loader.ts
@@ -3,7 +3,7 @@
 import type {LoaderWithParser} from '@loaders.gl/loader-utils';
 import type {XMLLoaderOptions} from '@loaders.gl/xml';
 // import type {WMTSCapabilities} from './lib/wmts/parse-wmts-capabilities';
-import {parseWMTSCapabilities} from './lib/wmts/parse-wmts-capabilities';
+import {parseWMTSCapabilities, WMTSCapabilities} from './lib/wmts/parse-wmts-capabilities';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
@@ -19,6 +19,9 @@ export type WMTSLoaderOptions = XMLLoaderOptions & {
  * Loader for the response to the WMTS GetCapability request
  */
 export const WMTSCapabilitiesLoader = {
+  dataType: null as unknown as WMTSCapabilities,
+  batchType: null as never,
+
   id: 'wmts-capabilities',
   name: 'WMTS Capabilities',
 
@@ -34,7 +37,7 @@ export const WMTSCapabilitiesLoader = {
   parse: async (arrayBuffer: ArrayBuffer, options?: WMTSLoaderOptions) =>
     parseWMTSCapabilities(new TextDecoder().decode(arrayBuffer), options),
   parseTextSync: (text: string, options?: WMTSLoaderOptions) => parseWMTSCapabilities(text, options)
-};
+} as const satisfies LoaderWithParser<WMTSCapabilities, never, WMTSLoaderOptions>;
 
 function testXMLFile(text: string): boolean {
   // TODO - There could be space first.

--- a/modules/wms/src/wms-capabilities-loader.ts
+++ b/modules/wms/src/wms-capabilities-loader.ts
@@ -34,11 +34,10 @@ export type WMSCapabilitiesLoaderOptions = XMLLoaderOptions & {
 /**
  * Loader for the response to the WMS GetCapability request
  */
-export const WMSCapabilitiesLoader: LoaderWithParser<
-  WMSCapabilities,
-  never,
-  WMSCapabilitiesLoaderOptions
-> = {
+export const WMSCapabilitiesLoader = {
+  dataType: null as unknown as WMSCapabilities,
+  batchType: null as never,
+
   id: 'wms-capabilities',
   name: 'WMS Capabilities',
 
@@ -57,7 +56,7 @@ export const WMSCapabilitiesLoader: LoaderWithParser<
   parseTextSync: (text: string, options?: WMSCapabilitiesLoaderOptions) =>
     // TODO pass in XML options
     parseWMSCapabilities(text, options?.wms)
-};
+} as const satisfies LoaderWithParser<WMSCapabilities, never, WMSCapabilitiesLoaderOptions>;
 
 function testXMLFile(text: string): boolean {
   // TODO - There could be space first.

--- a/modules/wms/src/wms-error-loader.ts
+++ b/modules/wms/src/wms-error-loader.ts
@@ -21,7 +21,10 @@ export type WMSLoaderOptions = LoaderOptions & {
 /**
  * Loader for the response to the WMS GetCapability request
  */
-export const WMSErrorLoader: LoaderWithParser<string, never, WMSLoaderOptions> = {
+export const WMSErrorLoader = {
+  dataType: null as unknown as string,
+  batchType: null as never,
+
   id: 'wms-error',
   name: 'WMS Error',
 
@@ -41,7 +44,7 @@ export const WMSErrorLoader: LoaderWithParser<string, never, WMSLoaderOptions> =
   parseSync: (arrayBuffer: ArrayBuffer, options?: WMSLoaderOptions): string =>
     parseTextSync(new TextDecoder().decode(arrayBuffer), options),
   parseTextSync: (text: string, options?: WMSLoaderOptions): string => parseTextSync(text, options)
-};
+} as const satisfies LoaderWithParser<string, never, WMSLoaderOptions>;
 
 function testXMLFile(text: string): boolean {
   // TODO - There could be space first.

--- a/modules/wms/test/wms/wms-layer-description-loader.spec.ts
+++ b/modules/wms/test/wms/wms-layer-description-loader.spec.ts
@@ -8,8 +8,8 @@
 
 import test from 'tape-promise/tape';
 import {
-  _WMSLayerDescriptionLoader as WMSLayerDescriptionLoader,
-  _WMSLayerDescription as WMSLayerDescription
+  _WMSLayerDescriptionLoader as WMSLayerDescriptionLoader
+  // _WMSLayerDescription as WMSLayerDescription
 } from '@loaders.gl/wms';
 import {parse} from '@loaders.gl/core';
 
@@ -21,7 +21,7 @@ test.skip('WMSLayerDescriptionLoader#read_WMSDescribeLayer', async (t) => {
     '  </LayerDescription>' +
     '</WMS_DescribeLayerResponse>';
 
-  const description = (await parse(text, WMSLayerDescriptionLoader)) as WMSLayerDescription;
+  const description = await parse(text, WMSLayerDescriptionLoader);
   t.ok(description);
 
   // const res = description.layers;

--- a/modules/xml/src/html-loader.ts
+++ b/modules/xml/src/html-loader.ts
@@ -14,7 +14,7 @@ export type HTMLLoaderOptions = XMLLoaderOptions;
  * This split enables applications can control whether they want HTML responses to be parsed by the XML loader or not.
  * This loader does not have any additional understanding of the structure of HTML or the document.
  */
-export const HTMLLoader: LoaderWithParser<any, never, HTMLLoaderOptions> = {
+export const HTMLLoader = {
   ...XMLLoader,
   name: 'HTML',
   id: 'html',
@@ -24,7 +24,7 @@ export const HTMLLoader: LoaderWithParser<any, never, HTMLLoaderOptions> = {
   parse: async (arrayBuffer: ArrayBuffer, options?: XMLLoaderOptions) =>
     parseTextSync(new TextDecoder().decode(arrayBuffer), options),
   parseTextSync: (text: string, options?: XMLLoaderOptions) => parseTextSync(text, options)
-};
+} as const satisfies LoaderWithParser<any, never, HTMLLoaderOptions>;
 
 function testHTMLFile(text: string): boolean {
   // TODO - There could be space first.

--- a/modules/xml/src/xml-loader.ts
+++ b/modules/xml/src/xml-loader.ts
@@ -17,7 +17,9 @@ export type XMLLoaderOptions = LoaderOptions & {
 /**
  * Loader for XML files
  */
-export const XMLLoader: LoaderWithParser<any, never, XMLLoaderOptions> = {
+export const XMLLoader = {
+  dataType: null as any,
+  batchType: null as never,
   name: 'XML',
   id: 'xml',
   module: 'xml',
@@ -42,7 +44,7 @@ export const XMLLoader: LoaderWithParser<any, never, XMLLoaderOptions> = {
     }),
   parseTextSync: (text: string, options?: XMLLoaderOptions) =>
     parseXMLSync(text, {...XMLLoader.options.xml, ...options?.xml})
-};
+} as const satisfies LoaderWithParser<any, never, XMLLoaderOptions>;
 
 function testXMLFile(text: string): boolean {
   // TODO - There could be space first.

--- a/modules/zip/src/zip-loader.ts
+++ b/modules/zip/src/zip-loader.ts
@@ -11,7 +11,10 @@ const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
 type FileMap = Record<string, ArrayBuffer>;
 
-export const ZipLoader: LoaderWithParser<FileMap, never, LoaderOptions> = {
+export const ZipLoader = {
+  dataType: null as unknown as FileMap,
+  batchType: null as unknown as never,
+
   id: 'zip',
   module: 'zip',
   name: 'Zip Archive',
@@ -22,7 +25,7 @@ export const ZipLoader: LoaderWithParser<FileMap, never, LoaderOptions> = {
   tests: ['PK'],
   options: {},
   parse: parseZipAsync
-};
+} as const satisfies LoaderWithParser<FileMap, never, LoaderOptions>;
 
 // TODO - Could return a map of promises, perhaps as an option...
 async function parseZipAsync(data: any, options = {}): Promise<FileMap> {

--- a/modules/zip/src/zip-writer.ts
+++ b/modules/zip/src/zip-writer.ts
@@ -19,7 +19,7 @@ export type ZipWriterOptions = WriterOptions & {
 /**
  * Zip exporter
  */
-export const ZipWriter: WriterWithEncoder<Record<string, ArrayBuffer>, never, ZipWriterOptions> = {
+export const ZipWriter = {
   name: 'Zip Archive',
   id: 'zip',
   module: 'zip',
@@ -34,7 +34,7 @@ export const ZipWriter: WriterWithEncoder<Record<string, ArrayBuffer>, never, Zi
     jszip: {}
   },
   encode: encodeZipAsync
-};
+} as const satisfies WriterWithEncoder<Record<string, ArrayBuffer>, never, ZipWriterOptions>;
 
 async function encodeZipAsync(
   fileMap: Record<string, ArrayBuffer>,

--- a/test/node.ts
+++ b/test/node.ts
@@ -20,5 +20,4 @@ import '@loaders.gl/polyfills';
 import './modules';
 
 // Tile converter
-// TODO - Action Engine to restore
 import '@loaders.gl/tile-converter/test';


### PR DESCRIPTION
Better developer experience (i.e. inside vscode) as the contents of the loader objects are not lost due to type assignment.