### PR TITLE
chore(compression/parquet): Improved handling of injected modules

### DIFF
--- a/docs/modules/parquet/api-reference/parquet-loader.md
+++ b/docs/modules/parquet/api-reference/parquet-loader.md
@@ -22,6 +22,8 @@ which [Parquet format features](/docs/modules/parquet/formats/parquet) are suppo
 
 ## Usage
 
+Load a Parquet file as a table.
+
 ```typescript
 import {ParquetLoader} from '@loaders.gl/parquet';
 import {load} from '@loaders.gl/core';
@@ -46,6 +48,25 @@ for await (const batch of batches) {
     }
   }
 }
+```
+
+## Compressions
+
+Some compressions are big and need to be imported explicitly by the application
+and passed to the `ParquetLoader`
+
+```typescript
+import {ParquetLoader} from '@loaders.gl/parquet';
+import {load} from '@loaders.gl/core';
+
+import {ZstdCodec} from 'zstd-codec';
+import lz4js from 'lz4js';
+
+const data = await load(url, ParquetLoader, {modules: {
+  'zstd-codec': ZstdCodec,
+  'lz4js': lz4js,
+  // brotli - only needed for compression
+});
 ```
 
 ## Data Format

--- a/modules/arrow/test/geoarrow/convert-geoarrow-to-binary-geometry.spec.ts
+++ b/modules/arrow/test/geoarrow/convert-geoarrow-to-binary-geometry.spec.ts
@@ -38,13 +38,13 @@ const expectedPointBinaryGeometry = {
       lines: {
         ...getBinaryGeometryTemplate(),
         type: 'LineString',
-        pathIndices: {value: new Uint16Array(0), size: 1}
+        pathIndices: {value: new Uint32Array(0), size: 1}
       },
       polygons: {
         ...getBinaryGeometryTemplate(),
         type: 'Polygon',
-        polygonIndices: {value: new Uint16Array(0), size: 1},
-        primitivePolygonIndices: {value: new Uint16Array(0), size: 1}
+        polygonIndices: {value: new Uint32Array(0), size: 1},
+        primitivePolygonIndices: {value: new Uint32Array(0), size: 1}
       }
     }
   ],
@@ -71,13 +71,13 @@ const expectedMultiPointBinaryGeometry = {
       lines: {
         ...getBinaryGeometryTemplate(),
         type: 'LineString',
-        pathIndices: {value: new Uint16Array(0), size: 1}
+        pathIndices: {value: new Uint32Array(0), size: 1}
       },
       polygons: {
         ...getBinaryGeometryTemplate(),
         type: 'Polygon',
-        polygonIndices: {value: new Uint16Array(0), size: 1},
-        primitivePolygonIndices: {value: new Uint16Array(0), size: 1}
+        polygonIndices: {value: new Uint32Array(0), size: 1},
+        primitivePolygonIndices: {value: new Uint32Array(0), size: 1}
       }
     }
   ],
@@ -109,8 +109,8 @@ const expectedLineBinaryGeometry = {
       polygons: {
         ...getBinaryGeometryTemplate(),
         type: 'Polygon',
-        polygonIndices: {value: new Uint16Array(0), size: 1},
-        primitivePolygonIndices: {value: new Uint16Array(0), size: 1}
+        polygonIndices: {value: new Uint32Array(0), size: 1},
+        primitivePolygonIndices: {value: new Uint32Array(0), size: 1}
       }
     }
   ],
@@ -145,8 +145,8 @@ const expectedMultiLineBinaryGeometry = {
       polygons: {
         ...getBinaryGeometryTemplate(),
         type: 'Polygon',
-        polygonIndices: {value: new Uint16Array(0), size: 1},
-        primitivePolygonIndices: {value: new Uint16Array(0), size: 1}
+        polygonIndices: {value: new Uint32Array(0), size: 1},
+        primitivePolygonIndices: {value: new Uint32Array(0), size: 1}
       }
     }
   ],
@@ -169,7 +169,7 @@ const expectedPolygonBinaryGeometry = {
       lines: {
         ...getBinaryGeometryTemplate(),
         type: 'LineString',
-        pathIndices: {value: new Uint16Array(0), size: 1}
+        pathIndices: {value: new Uint32Array(0), size: 1}
       },
       polygons: {
         ...getBinaryGeometryTemplate(),
@@ -211,7 +211,7 @@ const expectedMultiPolygonBinaryGeometry = {
       lines: {
         ...getBinaryGeometryTemplate(),
         type: 'LineString',
-        pathIndices: {value: new Uint16Array(0), size: 1}
+        pathIndices: {value: new Uint32Array(0), size: 1}
       },
       polygons: {
         ...getBinaryGeometryTemplate(),
@@ -251,7 +251,7 @@ const expectedMultiPolygonHolesBinaryGeometry = {
       lines: {
         ...getBinaryGeometryTemplate(),
         type: 'LineString',
-        pathIndices: {value: new Uint16Array(0), size: 1}
+        pathIndices: {value: new Uint32Array(0), size: 1}
       },
       polygons: {
         ...getBinaryGeometryTemplate(),

--- a/modules/compression/src/compress-on-worker.ts
+++ b/modules/compression/src/compress-on-worker.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // import type {WorkerObject} from '@loaders.gl/worker-utils';
 import {processOnWorker} from '@loaders.gl/worker-utils';
 

--- a/modules/compression/src/index.ts
+++ b/modules/compression/src/index.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 export type {CompressionOptions} from './lib/compression';
 
 export {Compression} from './lib/compression';

--- a/modules/compression/src/lib/compression.ts
+++ b/modules/compression/src/lib/compression.ts
@@ -1,5 +1,10 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // Compression interface
 import {concatenateArrayBuffersAsync} from '@loaders.gl/loader-utils';
+import {registerJSModules} from '@loaders.gl/loader-utils';
 
 /** Compression options */
 export type CompressionOptions = {
@@ -20,7 +25,8 @@ export abstract class Compression {
   }
 
   /** Preloads any dynamic libraries. May enable sync functions */
-  async preload(): Promise<void> {
+  async preload(modules: Record<string, any> = {}): Promise<void> {
+    registerJSModules(modules);
     return;
   }
 

--- a/modules/compression/src/lib/deflate-compression.ts
+++ b/modules/compression/src/lib/deflate-compression.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // DEFLATE
 import type {CompressionOptions} from './compression';
 import {Compression} from './compression';

--- a/modules/compression/src/lib/gzip-compression.ts
+++ b/modules/compression/src/lib/gzip-compression.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // GZIP
 // import {isBrowser} from '@loaders.gl/loader-utils';
 import type {CompressionOptions} from './compression';

--- a/modules/compression/src/lib/lz4-compression.ts
+++ b/modules/compression/src/lib/lz4-compression.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // Copyright (c) 2012 Pierre Curto
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -23,12 +27,12 @@
 
 // LZ4
 import {toArrayBuffer} from '@loaders.gl/loader-utils';
+import {registerJSModules, getJSModule} from '@loaders.gl/loader-utils';
 import type {CompressionOptions} from './compression';
 import {Compression} from './compression';
+
 // import lz4js from 'lz4js'; // https://bundlephobia.com/package/lz4
 const LZ4_MAGIC_NUMBER = 0x184d2204;
-
-let lz4js;
 
 /**
  * LZ4 compression / decompression
@@ -44,13 +48,15 @@ export class LZ4Compression extends Compression {
     super(options);
     this.options = options;
 
-    lz4js = lz4js || this.options?.modules?.lz4js;
-    if (!lz4js) {
-      throw new Error(this.name);
-    }
+    registerJSModules(options?.modules);
+  }
+
+  async preload(modules: Record<string, any> = {}): Promise<void> {
+    registerJSModules(modules);
   }
 
   compressSync(input: ArrayBuffer): ArrayBuffer {
+    const lz4js = getJSModule('lz4js', this.name);
     const inputArray = new Uint8Array(input);
     return lz4js.compress(inputArray).buffer;
   }
@@ -62,6 +68,7 @@ export class LZ4Compression extends Compression {
    * If data provided without magic number we will parse it as block
    */
   decompressSync(data: ArrayBuffer, maxSize?: number): ArrayBuffer {
+    const lz4js = getJSModule('lz4js', this.name);
     try {
       const isMagicNumberExists = this.checkMagicNumber(data);
       const inputArray = new Uint8Array(data);

--- a/modules/compression/src/lib/no-compression.ts
+++ b/modules/compression/src/lib/no-compression.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // NO COMPRESSION
 import type {CompressionOptions} from './compression';
 import {Compression} from './compression';

--- a/modules/compression/src/lib/snappy-compression.ts
+++ b/modules/compression/src/lib/snappy-compression.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // SNAPPY (aka ZIPPY)
 import type {CompressionOptions} from './compression';
 import {Compression} from './compression';

--- a/modules/compression/src/lib/zstd-compression.ts
+++ b/modules/compression/src/lib/zstd-compression.ts
@@ -5,7 +5,7 @@
 // ZSTD
 import type {CompressionOptions} from './compression';
 import {Compression} from './compression';
-import {registerJSModules, getJSModule} from '@loaders.gl/loader-utils';
+import {registerJSModules, getJSModule, getJSModuleOrNull} from '@loaders.gl/loader-utils';
 
 // import {ZstdCodec} from 'zstd-codec'; // https://bundlephobia.com/package/zstd-codec
 
@@ -30,12 +30,11 @@ export class ZstdCompression extends Compression {
     super(options);
     this.options = options;
     registerJSModules(options?.modules);
-    getJSModule('zstd-codec', this.name);
   }
 
   async preload(modules: Record<string, any> = {}): Promise<void> {
     registerJSModules(modules);
-    const ZstdCodec = getJSModule('zstd-codec', this.name);
+    const ZstdCodec = getJSModuleOrNull('zstd-codec', this.name);
     // eslint-disable-next-line  @typescript-eslint/no-misused-promises
     if (!zstdPromise && ZstdCodec) {
       zstdPromise = new Promise((resolve) => ZstdCodec.run((zstd) => resolve(zstd)));
@@ -44,12 +43,14 @@ export class ZstdCompression extends Compression {
   }
 
   compressSync(input: ArrayBuffer): ArrayBuffer {
+    getJSModule('zstd-codec', this.name);
     const simpleZstd = new zstd.Simple();
     const inputArray = new Uint8Array(input);
     return simpleZstd.compress(inputArray).buffer;
   }
 
   decompressSync(input: ArrayBuffer): ArrayBuffer {
+    getJSModule('zstd-codec', this.name);
     const simpleZstd = new zstd.Simple();
     // var ddict = new zstd.Dict.Decompression(dictData);
     // var jsonBytes = simpleZstd.decompressUsingDict(jsonZstData, ddict);

--- a/modules/compression/src/lib/zstd-compression.ts
+++ b/modules/compression/src/lib/zstd-compression.ts
@@ -36,6 +36,7 @@ export class ZstdCompression extends Compression {
   async preload(modules: Record<string, any> = {}): Promise<void> {
     registerJSModules(modules);
     const ZstdCodec = getJSModule('zstd-codec', this.name);
+    // eslint-disable-next-line  @typescript-eslint/no-misused-promises
     if (!zstdPromise && ZstdCodec) {
       zstdPromise = new Promise((resolve) => ZstdCodec.run((zstd) => resolve(zstd)));
       zstd = await zstdPromise;

--- a/modules/compression/src/lib/zstd-compression.ts
+++ b/modules/compression/src/lib/zstd-compression.ts
@@ -5,7 +5,8 @@
 // ZSTD
 import type {CompressionOptions} from './compression';
 import {Compression} from './compression';
-import {registerJSModules, getJSModule, getJSModuleOrNull} from '@loaders.gl/loader-utils';
+import {registerJSModules} from '@loaders.gl/loader-utils';
+import {checkJSModule, getJSModule, getJSModuleOrNull} from '@loaders.gl/loader-utils';
 
 // import {ZstdCodec} from 'zstd-codec'; // https://bundlephobia.com/package/zstd-codec
 
@@ -34,7 +35,8 @@ export class ZstdCompression extends Compression {
 
   async preload(modules: Record<string, any> = {}): Promise<void> {
     registerJSModules(modules);
-    const ZstdCodec = getJSModuleOrNull('zstd-codec', this.name);
+    checkJSModule('zstd-codec', this.name);
+    const ZstdCodec = getJSModuleOrNull('zstd-codec');
     // eslint-disable-next-line  @typescript-eslint/no-misused-promises
     if (!zstdPromise && ZstdCodec) {
       zstdPromise = new Promise((resolve) => ZstdCodec.run((zstd) => resolve(zstd)));

--- a/modules/compression/src/types.ts
+++ b/modules/compression/src/types.ts
@@ -1,1 +1,5 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 export type {Compression, CompressionOptions} from './lib/compression';

--- a/modules/compression/src/workers/compression-worker.ts
+++ b/modules/compression/src/workers/compression-worker.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {createWorker} from '@loaders.gl/worker-utils';
 
 // Compressors

--- a/modules/compression/test/compression.bench.ts
+++ b/modules/compression/test/compression.bench.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 /*
 import {
   NoCompression,

--- a/modules/compression/test/compression.spec.ts
+++ b/modules/compression/test/compression.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 /** @typedef {import('@loaders.gl/compression').Compression} Compression */
 import test from 'tape-promise/tape';
 import {

--- a/modules/compression/test/index.js
+++ b/modules/compression/test/index.js
@@ -1,1 +1,0 @@
-import './compression.spec';

--- a/modules/compression/test/index.ts
+++ b/modules/compression/test/index.ts
@@ -2,4 +2,4 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import './compression-worker';
+import './compression.spec';

--- a/modules/compression/test/utils/random-number-generator.ts
+++ b/modules/compression/test/utils/random-number-generator.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 /**
  * Seedable Random number generator
  * Useful for testing as it can generated identical sequences on each run

--- a/modules/compression/test/utils/test-utils.ts
+++ b/modules/compression/test/utils/test-utils.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // Helper functions
 
 import {concatenateArrayBuffers} from '@loaders.gl/loader-utils';

--- a/modules/core/src/lib/loader-utils/option-utils.ts
+++ b/modules/core/src/lib/loader-utils/option-utils.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {Loader, LoaderOptions} from '@loaders.gl/loader-utils';
+import {Loader, LoaderOptions, registerJSModules} from '@loaders.gl/loader-utils';
 import {isPureObject, isObject} from '../../javascript-utils/is-type';
 import {probeLog, NullLog} from './loggers';
 import {DEFAULT_LOADER_OPTIONS, REMOVED_LOADER_OPTIONS} from './option-defaults';
@@ -53,6 +53,8 @@ export function setGlobalOptions(options: LoaderOptions): void {
   const globalOptions = getGlobalLoaderOptions();
   // @ts-expect-error First param looks incorrect
   state.globalOptions = normalizeOptionsInternal(globalOptions, options);
+  // Make sure any new modules are registered
+  registerJSModules(options.modules);
 }
 
 /**

--- a/modules/crypto/src/lib/crypto-hash.ts
+++ b/modules/crypto/src/lib/crypto-hash.ts
@@ -1,3 +1,4 @@
+import {getJSModule, registerJSModules} from '@loaders.gl/loader-utils';
 import {Hash} from './hash';
 
 type CryptoHashOptions = {
@@ -7,8 +8,6 @@ type CryptoHashOptions = {
     onEnd?: (result: {hash: string}) => any;
   };
 };
-
-let CryptoJS: any;
 
 /**
  * A transform that calculates Cryptographic Hash using Crypto JS library
@@ -26,6 +25,8 @@ export class CryptoHash extends Hash {
   constructor(options: CryptoHashOptions) {
     super();
     this.options = options;
+    registerJSModules(options?.modules);
+
     this._algorithm = this.options?.crypto?.algorithm;
     if (!this._algorithm) {
       throw new Error(this.name);
@@ -34,12 +35,7 @@ export class CryptoHash extends Hash {
   }
 
   async preload(): Promise<void> {
-    if (!CryptoJS) {
-      CryptoJS = this.options?.modules?.CryptoJS;
-    }
-    if (!CryptoJS) {
-      throw new Error(this.name);
-    }
+    const CryptoJS = getJSModule('CryptoJS', this.name);
     this._algo = CryptoJS.algo[this._algorithm];
   }
 
@@ -55,6 +51,7 @@ export class CryptoHash extends Hash {
       throw new Error(this.name);
     }
 
+    const CryptoJS = getJSModule('CryptoJS', this.name);
     // arrayBuffer is accepted, even though types and docs say no
     // https://stackoverflow.com/questions/25567468/how-to-decrypt-an-arraybuffer
     const typedWordArray = CryptoJS.lib.WordArray.create(input);
@@ -68,6 +65,7 @@ export class CryptoHash extends Hash {
     encoding: 'hex' | 'base64' = 'base64'
   ): AsyncIterable<ArrayBuffer> {
     await this.preload();
+    const CryptoJS = getJSModule('CryptoJS', this.name);
 
     const hash = this._algo.create();
     if (!hash) {

--- a/modules/draco/src/index.ts
+++ b/modules/draco/src/index.ts
@@ -51,7 +51,7 @@ export const DracoLoader = {
 } as const satisfies LoaderWithParser<DracoMesh, never, DracoLoaderOptions>;
 
 async function parse(arrayBuffer: ArrayBuffer, options?: DracoLoaderOptions): Promise<DracoMesh> {
-  const {draco} = await loadDracoDecoderModule(options || {});
+  const {draco} = await loadDracoDecoderModule(options);
   const dracoParser = new DracoParser(draco);
   try {
     return dracoParser.parseSync(arrayBuffer, options?.draco);

--- a/modules/draco/src/index.ts
+++ b/modules/draco/src/index.ts
@@ -51,7 +51,7 @@ export const DracoLoader = {
 } as const satisfies LoaderWithParser<DracoMesh, never, DracoLoaderOptions>;
 
 async function parse(arrayBuffer: ArrayBuffer, options?: DracoLoaderOptions): Promise<DracoMesh> {
-  const {draco} = await loadDracoDecoderModule(options);
+  const {draco} = await loadDracoDecoderModule(options || {});
   const dracoParser = new DracoParser(draco);
   try {
     return dracoParser.parseSync(arrayBuffer, options?.draco);

--- a/modules/draco/src/lib/draco-module-loader.ts
+++ b/modules/draco/src/lib/draco-module-loader.ts
@@ -2,6 +2,7 @@
 // https://github.com/mrdoob/three.js/blob/398c4f39ebdb8b23eefd4a7a5ec49ec0c96c7462/examples/jsm/loaders/DRACOLoader.js
 // by Don McCurdy / https://www.donmccurdy.com / MIT license
 
+import {getJSModuleOrNull, registerJSModules} from '@loaders.gl/loader-utils';
 import {loadLibrary} from '@loaders.gl/worker-utils';
 
 const DRACO_DECODER_VERSION = '1.5.6';
@@ -30,33 +31,31 @@ export const DRACO_EXTERNAL_LIBRARY_URLS = {
 let loadDecoderPromise;
 let loadEncoderPromise;
 
-export async function loadDracoDecoderModule(options) {
-  const modules = options.modules || {};
+export async function loadDracoDecoderModule(options: {modules?: Record<string, any>}) {
+  registerJSModules(options.modules);
 
   // Check if a bundled draco3d library has been supplied by application
-  if (modules.draco3d) {
-    loadDecoderPromise =
-      loadDecoderPromise ||
-      modules.draco3d.createDecoderModule({}).then((draco) => {
-        return {draco};
-      });
+  const draco3d = getJSModuleOrNull('draco3d');
+  if (draco3d) {
+    loadDecoderPromise ||= draco3d.createDecoderModule({}).then((draco) => {
+      return {draco};
+    });
   } else {
     // If not, dynamically load the WASM script from our CDN
-    loadDecoderPromise = loadDecoderPromise || loadDracoDecoder(options);
+    loadDecoderPromise ||= loadDracoDecoder(options);
   }
   return await loadDecoderPromise;
 }
 
-export async function loadDracoEncoderModule(options) {
-  const modules = options.modules || {};
+export async function loadDracoEncoderModule(options: {modules?: Record<string, any>}) {
+  registerJSModules(options.modules);
 
   // Check if a bundled draco3d library has been supplied by application
-  if (modules.draco3d) {
-    loadEncoderPromise =
-      loadEncoderPromise ||
-      modules.draco3d.createEncoderModule({}).then((draco) => {
-        return {draco};
-      });
+  const draco3d = getJSModuleOrNull('draco3d');
+  if (draco3d) {
+    loadEncoderPromise ||= draco3d.createEncoderModule({}).then((draco) => {
+      return {draco};
+    });
   } else {
     // If not, dynamically load the WASM script from our CDN
     loadEncoderPromise = loadEncoderPromise || loadDracoEncoder(options);

--- a/modules/draco/src/lib/draco-module-loader.ts
+++ b/modules/draco/src/lib/draco-module-loader.ts
@@ -2,7 +2,6 @@
 // https://github.com/mrdoob/three.js/blob/398c4f39ebdb8b23eefd4a7a5ec49ec0c96c7462/examples/jsm/loaders/DRACOLoader.js
 // by Don McCurdy / https://www.donmccurdy.com / MIT license
 
-import {getJSModuleOrNull, registerJSModules} from '@loaders.gl/loader-utils';
 import {loadLibrary} from '@loaders.gl/worker-utils';
 
 const DRACO_DECODER_VERSION = '1.5.6';
@@ -31,31 +30,33 @@ export const DRACO_EXTERNAL_LIBRARY_URLS = {
 let loadDecoderPromise;
 let loadEncoderPromise;
 
-export async function loadDracoDecoderModule(options: {modules?: Record<string, any>}) {
-  registerJSModules(options.modules);
+export async function loadDracoDecoderModule(options) {
+  const modules = options.modules || {};
 
   // Check if a bundled draco3d library has been supplied by application
-  const draco3d = getJSModuleOrNull('draco3d');
-  if (draco3d) {
-    loadDecoderPromise ||= draco3d.createDecoderModule({}).then((draco) => {
-      return {draco};
-    });
+  if (modules.draco3d) {
+    loadDecoderPromise =
+      loadDecoderPromise ||
+      modules.draco3d.createDecoderModule({}).then((draco) => {
+        return {draco};
+      });
   } else {
     // If not, dynamically load the WASM script from our CDN
-    loadDecoderPromise ||= loadDracoDecoder(options);
+    loadDecoderPromise = loadDecoderPromise || loadDracoDecoder(options);
   }
   return await loadDecoderPromise;
 }
 
-export async function loadDracoEncoderModule(options: {modules?: Record<string, any>}) {
-  registerJSModules(options.modules);
+export async function loadDracoEncoderModule(options) {
+  const modules = options.modules || {};
 
   // Check if a bundled draco3d library has been supplied by application
-  const draco3d = getJSModuleOrNull('draco3d');
-  if (draco3d) {
-    loadEncoderPromise ||= draco3d.createEncoderModule({}).then((draco) => {
-      return {draco};
-    });
+  if (modules.draco3d) {
+    loadEncoderPromise =
+      loadEncoderPromise ||
+      modules.draco3d.createEncoderModule({}).then((draco) => {
+        return {draco};
+      });
   } else {
     // If not, dynamically load the WASM script from our CDN
     loadEncoderPromise = loadEncoderPromise || loadDracoEncoder(options);

--- a/modules/gis/test/binary-features/transform.spec.ts
+++ b/modules/gis/test/binary-features/transform.spec.ts
@@ -38,10 +38,10 @@ test('gis#reproject binary', (t) => {
     points: {
       type: 'Point',
       positions: {value: new Float32Array([-74, 41]), size: 2},
-      globalFeatureIds: {value: new Uint16Array([0, 1, 1]), size: 1},
-      featureIds: {value: new Uint16Array([0, 1, 1]), size: 1},
+      globalFeatureIds: {value: new Uint32Array([0, 1, 1]), size: 1},
+      featureIds: {value: new Uint32Array([0, 1, 1]), size: 1},
       numericProps: {
-        numeric1: {value: new Uint16Array([1, 2, 2]), size: 1}
+        numeric1: {value: new Uint32Array([1, 2, 2]), size: 1}
       },
       properties: [{string1: 'a'}, {string1: 'b'}]
     }
@@ -52,10 +52,10 @@ test('gis#reproject binary', (t) => {
     points: {
       type: 'Point',
       positions: {value: new Float32Array([-8237642.318702244, 5012341.663847514]), size: 2},
-      globalFeatureIds: {value: new Uint16Array([0, 1, 1]), size: 1},
-      featureIds: {value: new Uint16Array([0, 1, 1]), size: 1},
+      globalFeatureIds: {value: new Uint32Array([0, 1, 1]), size: 1},
+      featureIds: {value: new Uint32Array([0, 1, 1]), size: 1},
       numericProps: {
-        numeric1: {value: new Uint16Array([1, 2, 2]), size: 1}
+        numeric1: {value: new Uint32Array([1, 2, 2]), size: 1}
       },
       properties: [{string1: 'a'}, {string1: 'b'}]
     }

--- a/modules/gis/test/data/binary-features/empty_binary.ts
+++ b/modules/gis/test/data/binary-features/empty_binary.ts
@@ -5,27 +5,27 @@ export const EMPTY_BINARY_DATA: BinaryFeatureCollection = {
   points: {
     type: 'Point',
     positions: {value: new Float32Array(), size: -Infinity},
-    globalFeatureIds: {value: new Uint16Array(), size: 1},
-    featureIds: {value: new Uint16Array(), size: 1},
+    globalFeatureIds: {value: new Uint32Array(), size: 1},
+    featureIds: {value: new Uint32Array(), size: 1},
     numericProps: {},
     properties: []
   },
   lines: {
     type: 'LineString',
-    pathIndices: {value: new Uint16Array(1), size: 1},
+    pathIndices: {value: new Uint32Array(1), size: 1},
     positions: {value: new Float32Array(), size: -Infinity},
-    globalFeatureIds: {value: new Uint16Array(), size: 1},
-    featureIds: {value: new Uint16Array(), size: 1},
+    globalFeatureIds: {value: new Uint32Array(), size: 1},
+    featureIds: {value: new Uint32Array(), size: 1},
     numericProps: {},
     properties: []
   },
   polygons: {
     type: 'Polygon',
-    polygonIndices: {value: new Uint16Array(1), size: 1},
-    primitivePolygonIndices: {value: new Uint16Array(1), size: 1},
+    polygonIndices: {value: new Uint32Array(1), size: 1},
+    primitivePolygonIndices: {value: new Uint32Array(1), size: 1},
     positions: {value: new Float32Array(), size: -Infinity},
-    globalFeatureIds: {value: new Uint16Array(), size: 1},
-    featureIds: {value: new Uint16Array(), size: 1},
+    globalFeatureIds: {value: new Uint32Array(), size: 1},
+    featureIds: {value: new Uint32Array(), size: 1},
     numericProps: {},
     properties: []
   }

--- a/modules/gis/test/data/binary-features/geometry-test-cases.ts
+++ b/modules/gis/test/data/binary-features/geometry-test-cases.ts
@@ -35,7 +35,7 @@ export const GEOMETRY_TEST_CASES: GeometryTestCase[] = [
   {
     binary: {
       positions: {value: new Float32Array([100, 0, 101, 1]), size: 2},
-      pathIndices: {value: new Uint16Array([0, 2]), size: 1},
+      pathIndices: {value: new Uint32Array([0, 2]), size: 1},
       type: 'LineString'
     },
     geoJSON: {
@@ -52,7 +52,7 @@ export const GEOMETRY_TEST_CASES: GeometryTestCase[] = [
         value: new Float32Array([100, 0, 101, 1, 102, 2, 103, 3]),
         size: 2
       },
-      pathIndices: {value: new Uint16Array([0, 2, 4]), size: 1},
+      pathIndices: {value: new Uint32Array([0, 2, 4]), size: 1},
       type: 'LineString'
     },
     geoJSON: {
@@ -72,8 +72,8 @@ export const GEOMETRY_TEST_CASES: GeometryTestCase[] = [
   {
     binary: {
       positions: {value: new Float32Array([100, 0, 101, 0, 101, 10, 100, 10, 100, 0]), size: 2},
-      polygonIndices: {value: new Uint16Array([0, 5]), size: 1},
-      primitivePolygonIndices: {value: new Uint16Array([0, 5]), size: 1},
+      polygonIndices: {value: new Uint32Array([0, 5]), size: 1},
+      primitivePolygonIndices: {value: new Uint32Array([0, 5]), size: 1},
       type: 'Polygon'
     },
     geoJSON: {
@@ -99,8 +99,8 @@ export const GEOMETRY_TEST_CASES: GeometryTestCase[] = [
         ]),
         size: 2
       },
-      polygonIndices: {value: new Uint16Array([0, 10]), size: 1},
-      primitivePolygonIndices: {value: new Uint16Array([0, 5, 10]), size: 1},
+      polygonIndices: {value: new Uint32Array([0, 10]), size: 1},
+      primitivePolygonIndices: {value: new Uint32Array([0, 5, 10]), size: 1},
       type: 'Polygon'
     },
     geoJSON: {
@@ -133,8 +133,8 @@ export const GEOMETRY_TEST_CASES: GeometryTestCase[] = [
         ]),
         size: 2
       },
-      polygonIndices: {value: new Uint16Array([0, 5, 15]), size: 1},
-      primitivePolygonIndices: {value: new Uint16Array([0, 5, 10, 15]), size: 1},
+      polygonIndices: {value: new Uint32Array([0, 5, 15]), size: 1},
+      primitivePolygonIndices: {value: new Uint32Array([0, 5, 10, 15]), size: 1},
       type: 'Polygon'
     },
     geoJSON: {

--- a/modules/loader-utils/src/index.ts
+++ b/modules/loader-utils/src/index.ts
@@ -50,7 +50,12 @@ export {
   document
 } from './lib/env-utils/globals';
 
+export {log} from './lib/log-utils/log';
+
+// Options and modules
 export {mergeLoaderOptions} from './lib/option-utils/merge-loader-options';
+export {registerJSModules} from './lib/module-utils/js-module-utils';
+export {checkJSModule, getJSModule, getJSModuleOrNull} from './lib/module-utils/js-module-utils';
 
 // LOADERS.GL-SPECIFIC WORKER UTILS
 export {createLoaderWorker} from './lib/worker-loader-utils/create-loader-worker';

--- a/modules/loader-utils/src/lib/log-utils/log.ts
+++ b/modules/loader-utils/src/lib/log-utils/log.ts
@@ -1,0 +1,8 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Log} from '@probe.gl/log';
+
+/** Global log instance */
+export const log: Log = new Log({id: 'loaders.gl'});

--- a/modules/loader-utils/src/lib/module-utils/js-module-utils.ts
+++ b/modules/loader-utils/src/lib/module-utils/js-module-utils.ts
@@ -11,18 +11,17 @@ import {log} from '../log-utils/log';
 export function registerJSModules(modules?: Record<string, any>): void {
   globalThis.loaders ||= {};
   globalThis.loaders.modules ||= {};
-  Object.assign({}, globalThis.loaders.modules, modules);
+  Object.assign(globalThis.loaders.modules, modules);
 }
 
 /**
  * Get a pre-registered application-imported module, warn if not present
  */
-export function checkJSModule<ModuleT = any>(name: string, caller: string): ModuleT {
+export function checkJSModule(name: string, caller: string): void {
   const module = globalThis.loaders?.modules?.[name];
   if (!module) {
     log.warn(`${caller}: ${name} library not installed`)();
   }
-  return module;
 }
 
 /**

--- a/modules/loader-utils/src/lib/module-utils/js-module-utils.ts
+++ b/modules/loader-utils/src/lib/module-utils/js-module-utils.ts
@@ -1,0 +1,45 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {log} from '../log-utils/log';
+
+/**
+ * Register application-imported modules
+ * These modules are typically to big to bundle, or may have issues on some bundlers/environments
+ */
+export function registerJSModules(modules?: Record<string, any>): void {
+  globalThis.loaders ||= {};
+  globalThis.loaders.modules ||= {};
+  Object.assign({}, globalThis.loaders.modules, modules);
+}
+
+/**
+ * Get a pre-registered application-imported module, warn if not present
+ */
+export function checkJSModule<ModuleT = any>(name: string, caller: string): ModuleT {
+  const module = globalThis.loaders?.modules?.[name];
+  if (!module) {
+    log.warn(`${caller}: ${name} library not installed`)();
+  }
+  return module;
+}
+
+/**
+ * Get a pre-registered application-imported module, throw if not present
+ */
+export function getJSModule<ModuleT = any>(name: string, caller: string): ModuleT {
+  const module = globalThis.loaders?.modules?.[name];
+  if (!module) {
+    throw new Error(`${caller}: ${name} library not installed`);
+  }
+  return module;
+}
+
+/**
+ * Get a pre-registered application-imported module, return null if not present
+ */
+export function getJSModuleOrNull<ModuleT = any>(name: string): ModuleT | null {
+  const module = globalThis.loaders?.modules?.[name];
+  return module || null;
+}

--- a/modules/loader-utils/src/loader-types.ts
+++ b/modules/loader-utils/src/loader-types.ts
@@ -29,8 +29,6 @@ export type LoaderOptions = {
   // general
   /** Experimental: Supply a logger to the parser */
   log?: any;
-  /** Force to load WASM libraries from local file system in NodeJS or from loaders.gl CDN in a web browser */
-  useLocalLibraries?: boolean;
 
   // batched parsing
 
@@ -46,6 +44,13 @@ export type LoaderOptions = {
   metadata?: boolean;
   /** Transforms to run on incoming batches */
   transforms?: TransformBatches[];
+
+  // module loading
+
+  /** Any additional JS libraries */
+  modules?: Record<string, any>;
+  /** Force to load WASM libraries from local file system in NodeJS or from loaders.gl CDN in a web browser */
+  useLocalLibraries?: boolean;
 
   // workers
 

--- a/modules/loader-utils/src/writer-types.ts
+++ b/modules/loader-utils/src/writer-types.ts
@@ -8,8 +8,14 @@
 export type WriterOptions = {
   /** worker source. If is set will be used instead of loading worker from the Internet */
   source?: string | null;
+
+  // module loading
+
+  /** Any additional JS libraries */
+  modules?: Record<string, any>;
   /** Force to load WASM libraries from local file system in NodeJS or from loaders.gl CDN in a web browser */
   useLocalLibraries?: boolean;
+
   /** writer-specific options */
   [writerId: string]: any;
 };

--- a/modules/parquet/src/lib/parsers/parse-parquet-to-columns.ts
+++ b/modules/parquet/src/lib/parsers/parse-parquet-to-columns.ts
@@ -11,6 +11,7 @@ import {ParquetSchema} from '../../parquetjs/schema/schema';
 import {materializeColumns} from '../../parquetjs/schema/shred';
 import {getSchemaFromParquetReader} from './get-parquet-schema';
 import {installBufferPolyfill} from '../../polyfills/buffer/index';
+import {preloadCompressions} from '../../parquetjs/compression';
 
 /**
  * @deprecated
@@ -20,6 +21,8 @@ export async function parseParquetFileInColumns(
   options?: ParquetLoaderOptions
 ): Promise<ColumnarTable> {
   installBufferPolyfill();
+  await preloadCompressions(options);
+
   for await (const batch of parseParquetFileInColumnarBatches(file, options)) {
     return {
       shape: 'columnar-table',
@@ -37,6 +40,9 @@ export async function* parseParquetFileInColumnarBatches(
   file: ReadableFile,
   options?: ParquetLoaderOptions
 ): AsyncIterable<ColumnarTableBatch> {
+  installBufferPolyfill();
+  await preloadCompressions();
+
   const reader = new ParquetReader(file);
 
   // Extract schema and geo metadata

--- a/modules/parquet/src/lib/parsers/parse-parquet.ts
+++ b/modules/parquet/src/lib/parsers/parse-parquet.ts
@@ -10,6 +10,7 @@ import type {ParquetRow} from '../../parquetjs/schema/declare';
 import {ParquetReader} from '../../parquetjs/parser/parquet-reader';
 import {getSchemaFromParquetReader} from './get-parquet-schema';
 import {installBufferPolyfill} from '../../polyfills/buffer/index';
+import {preloadCompressions} from '../../parquetjs/compression';
 
 /**
  *  * Parse a parquet file using parquetjs
@@ -22,6 +23,7 @@ export async function parseParquetFile(
   options?: ParquetLoaderOptions
 ): Promise<ObjectRowTable> {
   installBufferPolyfill();
+  await preloadCompressions();
 
   const reader = new ParquetReader(file, {
     preserveBinary: options?.parquet?.preserveBinary
@@ -57,6 +59,9 @@ export async function* parseParquetFileInBatches(
   file: ReadableFile,
   options?: ParquetLoaderOptions
 ): AsyncIterable<ObjectRowTableBatch> {
+  installBufferPolyfill();
+  await preloadCompressions();
+
   const reader = new ParquetReader(file, {
     preserveBinary: options?.parquet?.preserveBinary
   });

--- a/modules/parquet/src/parquetjs/compression.ts
+++ b/modules/parquet/src/parquetjs/compression.ts
@@ -12,6 +12,7 @@ import {
   LZ4Compression,
   ZstdCompression
 } from '@loaders.gl/compression';
+import {registerJSModules} from '@loaders.gl/loader-utils';
 
 import {ParquetCompression} from './schema/declare';
 
@@ -73,6 +74,7 @@ export const PARQUET_COMPRESSION_METHODS: Record<ParquetCompression, Compression
  * @param options.modules External library dependencies
  */
 export async function preloadCompressions(options?: {modules?: {[key: string]: any}}) {
+  registerJSModules(options?.modules);
   const compressions = Object.values(PARQUET_COMPRESSION_METHODS);
   return await Promise.all(
     compressions.map((compression) => compression.preload(options?.modules))

--- a/modules/parquet/src/parquetjs/compression.ts
+++ b/modules/parquet/src/parquetjs/compression.ts
@@ -72,9 +72,11 @@ export const PARQUET_COMPRESSION_METHODS: Record<ParquetCompression, Compression
  * Register compressions that have big external libraries
  * @param options.modules External library dependencies
  */
-export async function preloadCompressions(options?: {modules: {[key: string]: any}}) {
+export async function preloadCompressions(options?: {modules?: {[key: string]: any}}) {
   const compressions = Object.values(PARQUET_COMPRESSION_METHODS);
-  return await Promise.all(compressions.map((compression) => compression.preload()));
+  return await Promise.all(
+    compressions.map((compression) => compression.preload(options?.modules))
+  );
 }
 
 /**

--- a/modules/parquet/src/parquetjs/schema/types.ts
+++ b/modules/parquet/src/parquetjs/schema/types.ts
@@ -340,7 +340,8 @@ function fromPrimitive_JSON(value: any): unknown {
 }
 
 function toPrimitive_BSON(value: any): Buffer {
-  const arrayBuffer: ArrayBuffer = BSONWriter.encodeSync?.(value)!;
+  // @ts-ignore
+  const arrayBuffer: ArrayBuffer = BSONWriter.encodeSync?.(value);
   return Buffer.from(arrayBuffer);
 }
 

--- a/modules/parquet/src/parquetjs/schema/types.ts
+++ b/modules/parquet/src/parquetjs/schema/types.ts
@@ -340,7 +340,7 @@ function fromPrimitive_JSON(value: any): unknown {
 }
 
 function toPrimitive_BSON(value: any): Buffer {
-  const arrayBuffer = BSONWriter.encodeSync?.(value);
+  const arrayBuffer: ArrayBuffer = BSONWriter.encodeSync?.(value)!;
   return Buffer.from(arrayBuffer);
 }
 

--- a/modules/textures/src/lib/parsers/basis-module-loader.ts
+++ b/modules/textures/src/lib/parsers/basis-module-loader.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
+import {registerJSModules, getJSModuleOrNull} from '@loaders.gl/loader-utils';
 import {loadLibrary} from '@loaders.gl/worker-utils';
 
 export const BASIS_EXTERNAL_LIBRARIES = {
@@ -23,12 +24,13 @@ let loadBasisTranscoderPromise;
  * @returns {BasisFile} promise
  */
 export async function loadBasisTranscoderModule(options) {
-  const modules = options.modules || {};
-  if (modules.basis) {
-    return modules.basis;
+  registerJSModules(options.modules);
+  const basis = getJSModuleOrNull('basis');
+  if (basis) {
+    return basis;
   }
 
-  loadBasisTranscoderPromise = loadBasisTranscoderPromise || loadBasisTranscoder(options);
+  loadBasisTranscoderPromise ||= loadBasisTranscoder(options);
   return await loadBasisTranscoderPromise;
 }
 

--- a/modules/textures/src/lib/parsers/crunch-module-loader.ts
+++ b/modules/textures/src/lib/parsers/crunch-module-loader.ts
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 // @ts-nocheck
+import {getJSModuleOrNull, LoaderOptions, registerJSModules} from '@loaders.gl/loader-utils';
 import {loadLibrary} from '@loaders.gl/worker-utils';
 
 export const CRUNCH_EXTERNAL_LIBRARIES = {
@@ -15,10 +16,11 @@ export const CRUNCH_EXTERNAL_LIBRARIES = {
  * @param options - loader options
  * @returns Promise of module object
  */
-export async function loadCrunchModule(options): Promise<any> {
-  const modules = options.modules || {};
-  if (modules.crunch) {
-    return modules.crunch;
+export async function loadCrunchModule(options: LoaderOptions): Promise<any> {
+  registerJSModules(options.modules);
+  const crunch = getJSModuleOrNull('crunch');
+  if (crunch) {
+    return crunch;
   }
 
   return loadCrunch(options);
@@ -31,7 +33,7 @@ let crunchModule;
  * @param {any} options - Loader options
  * @returns {Promise<any>} Promise of Module object
  */
-async function loadCrunch(options) {
+async function loadCrunch(options: LoaderOptions): Promise<any> {
   if (crunchModule) {
     return crunchModule;
   }
@@ -40,7 +42,7 @@ async function loadCrunch(options) {
 
   // Depends on how import happened...
   // @ts-ignore TS2339: Property does not exist on type
-  loadCrunchDecoder = loadCrunchDecoder || globalThis.LoadCrunchDecoder;
+  loadCrunchDecoder ||= globalThis.LoadCrunchDecoder;
   crunchModule = loadCrunchDecoder();
   return crunchModule;
 }

--- a/modules/wkt/src/lib/parse-wkb.ts
+++ b/modules/wkt/src/lib/parse-wkb.ts
@@ -120,7 +120,7 @@ function parseLineString(
     geometry: {
       type: 'LineString',
       positions: {value: positions, size: dimension},
-      pathIndices: {value: new Uint16Array(pathIndices), size: 1}
+      pathIndices: {value: new Uint32Array(pathIndices), size: 1}
     },
     offset
   };
@@ -159,10 +159,10 @@ function parsePolygon(
       type: 'Polygon',
       positions: {value: concatenatedPositions, size: dimension},
       polygonIndices: {
-        value: new Uint16Array(polygonIndices),
+        value: new Uint32Array(polygonIndices),
         size: 1
       },
-      primitivePolygonIndices: {value: new Uint16Array(primitivePolygonIndices), size: 1}
+      primitivePolygonIndices: {value: new Uint32Array(primitivePolygonIndices), size: 1}
     },
     offset
   };
@@ -283,7 +283,7 @@ function concatenateBinaryLineGeometries(
   return {
     type: 'LineString',
     positions: {value: concatenatedPositions, size: dimension},
-    pathIndices: {value: new Uint16Array(pathIndices), size: 1}
+    pathIndices: {value: new Uint32Array(pathIndices), size: 1}
   };
 }
 

--- a/modules/wkt/test/utils/parse-test-cases.ts
+++ b/modules/wkt/test/utils/parse-test-cases.ts
@@ -106,11 +106,11 @@ export function parseTestCases(
       binary.positions.value = new Float64Array(binary.positions.value);
     }
     if (binary && binary.type === 'LineString') {
-      binary.pathIndices.value = new Uint16Array(binary.pathIndices.value);
+      binary.pathIndices.value = new Uint32Array(binary.pathIndices.value);
     }
     if (binary && binary.type === 'Polygon') {
-      binary.polygonIndices.value = new Uint16Array(binary.polygonIndices.value);
-      binary.primitivePolygonIndices.value = new Uint16Array(binary.primitivePolygonIndices.value);
+      binary.polygonIndices.value = new Uint32Array(binary.polygonIndices.value);
+      binary.primitivePolygonIndices.value = new Uint32Array(binary.primitivePolygonIndices.value);
     }
 
     const parsedTestCase: ParsedTestCase = {

--- a/modules/wkt/test/wkb-loader.spec.ts
+++ b/modules/wkt/test/wkb-loader.spec.ts
@@ -14,24 +14,21 @@ test('WKBLoader#2D', async (t) => {
   const response = await fetchFile(WKB_2D_TEST_CASES);
   const TEST_CASES = parseTestCases(await response.json());
 
+  const TEST_CASES2 = {multiPolygonWithTwoPolygons: TEST_CASES.multiPolygonWithTwoPolygons};
   // TODO parseWKB outputs TypedArrays; testCase contains regular arrays
-  for (const testCase of Object.values(TEST_CASES)) {
+  for (const [title, testCase] of Object.entries(TEST_CASES2)) {
     // Little endian
     if (testCase.wkb && testCase.binary) {
       t.ok(isWKB(testCase.wkb), 'isWKB(2D)');
-      t.deepEqual(
-        parseSync(testCase.wkb, WKBLoader, {wkb: {shape: 'binary-geometry'}}),
-        testCase.binary
-      );
+      const result = parseSync(testCase.wkb, WKBLoader, {wkb: {shape: 'binary-geometry'}});
+      t.deepEqual(result, testCase.binary, title);
     }
 
     // Big endian
     if (testCase.wkbXdr && testCase.binary) {
       t.ok(isWKB(testCase.wkbXdr), 'isWKB(2D)');
-      t.deepEqual(
-        parseSync(testCase.wkbXdr, WKBLoader, {wkb: {shape: 'binary-geometry'}}),
-        testCase.binary
-      );
+      const result = parseSync(testCase.wkbXdr, WKBLoader, {wkb: {shape: 'binary-geometry'}});
+      t.deepEqual(result, testCase.binary, title);
     }
   }
 
@@ -43,17 +40,19 @@ test('WKBLoader#Z', async (t) => {
   const TEST_CASES = parseTestCases(await response.json());
 
   // TODO parseWKB outputs TypedArrays; testCase contains regular arrays
-  for (const testCase of Object.values(TEST_CASES)) {
+  for (const [title, testCase] of Object.entries(TEST_CASES)) {
     // Little endian
     if (testCase.wkb && testCase.binary) {
       t.ok(isWKB(testCase.wkb), 'isWKB(Z)');
-      t.deepEqual(parseSync(testCase.wkb, WKBLoader), testCase.binary);
+      const result = parseSync(testCase.wkb, WKBLoader);
+      t.deepEqual(result, testCase.binary, title);
     }
 
     // Big endian
     if (testCase.wkbXdr && testCase.binary) {
       t.ok(isWKB(testCase.wkbXdr), 'isWKB(Z)');
-      t.deepEqual(parseSync(testCase.wkbXdr, WKBLoader), testCase.binary);
+      const result = parseSync(testCase.wkbXdr, WKBLoader);
+      t.deepEqual(result, testCase.binary, title);
     }
 
     // if (testCase.wkbXdr && testCase.binary && testCase.geoJSON) {

--- a/modules/worker-utils/src/lib/library-utils/library-utils.ts
+++ b/modules/worker-utils/src/lib/library-utils/library-utils.ts
@@ -57,6 +57,7 @@ export function getLibraryUrl(
   libraryName = libraryName || library;
 
   // Allow application to import and supply libraries through `options.modules`
+  // TODO - See js-module-utils in loader-utils
   const modules = options.modules || {};
   if (modules[libraryName]) {
     return modules[libraryName];


### PR DESCRIPTION
For #2937
- `Compression.preload()` now accepts JS modules 
- Centralized JS modules handling in loader-utils
- ParquetLoader waits for all Compression preloads.
- ParquetLoader docs explain how to inject modules.