### PR TITLE
feat: Add options.<loader>.workerUrl

### DIFF
--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -6,7 +6,8 @@ Target Release Date: April, 2024
 
 - deck.gl v9: Website and `examples/website/*` updated to deck.gl v9.
 - Internal tooling upgrades: ~10x faster builds via esbuild. ~2x faster installs via yarn 4.
-- Improved developer experience: More loader object information is visible in applications when hovering over a loader object, e.g. in vscode (loader objects are now typed using `as const satisfies Loader<...>`).
+- Types: More loader object information is preserved (e.g. when hovering over a loader object in vscod). loaders are now typed using `as const satisfies Loader<...>`. 
+- Types: Loaders that support workers now declare the `workerUrl` field in their LoaderOptions type removing type errors when overriding.
 
 **@loaders.gl/tile-converter**
 

--- a/modules/arrow/src/arrow-loader.ts
+++ b/modules/arrow/src/arrow-loader.ts
@@ -17,10 +17,16 @@ import {parseArrowInBatches} from './parsers/parse-arrow-in-batches';
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
 const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
+/** ArrowLoader options */
 export type ArrowLoaderOptions = LoaderOptions & {
+  /** ArrowLoader options */
   arrow?: {
+    /** Shape of returned data */
     shape: 'arrow-table' | 'columnar-table' | 'array-row-table' | 'object-row-table';
+    /** Debounce time between batches (prevent excessive numbers of small batches) */
     batchDebounceMs?: number;
+    /** Override the URL to the worker bundle (by default loads from unpkg.com) */
+    workerUrl?: string;
   };
 };
 

--- a/modules/draco/src/draco-loader.ts
+++ b/modules/draco/src/draco-loader.ts
@@ -9,10 +9,11 @@ import {VERSION} from './lib/utils/version';
 
 export type DracoLoaderOptions = LoaderOptions & {
   draco?: DracoParseOptions & {
+    /** @deprecated WASM decoding is faster but JS is more backwards compatible */
     decoderType?: 'wasm' | 'js';
+    /** @deprecated Specify where to load the Draco decoder library */
     libraryPath?: string;
-    extraAttributes?;
-    attributeNameEntry?: string;
+    /** Override the URL to the worker bundle (by default loads from unpkg.com) */
     workerUrl?: string;
   };
 };

--- a/modules/draco/src/lib/draco-parser.ts
+++ b/modules/draco/src/lib/draco-parser.ts
@@ -28,18 +28,17 @@ import type {
 import {getMeshBoundingBox} from '@loaders.gl/schema';
 import {getDracoSchema} from './utils/get-draco-schema';
 
-/**
- * @param topology - How triangle indices should be generated (mesh only)
- * @param attributeNameEntry
- * @param extraAttributes
- * @param quantizedAttributes
- * @param octahedronAttributes
- */
+/** Options to control draco parsing */
 export type DracoParseOptions = {
+  /** How triangle indices should be generated (mesh only) */
   topology?: 'triangle-list' | 'triangle-strip';
+  /** Specify which attribute metadata entry stores the attribute name */
   attributeNameEntry?: string;
+  /** Names and ids of extra attributes to include in the output */
   extraAttributes?: {[uniqueId: string]: number};
+  /** Skip transforms specific quantized attributes */
   quantizedAttributes?: ('POSITION' | 'NORMAL' | 'COLOR' | 'TEX_COORD' | 'GENERIC')[];
+  /** Skip transforms specific octahedron encoded  attributes */
   octahedronAttributes?: ('POSITION' | 'NORMAL' | 'COLOR' | 'TEX_COORD' | 'GENERIC')[];
 };
 

--- a/modules/draco/test/data/README.md
+++ b/modules/draco/test/data/README.md
@@ -3,3 +3,5 @@
 ## DRC
 
 Samples from Google Draco `testdata`:
+
+- `64-bit-attribute/1.pts` From https://storage.googleapis.com/external-geo-projects/GTE464_Crocodile_Lower_LAS/2/1.pnts 

--- a/modules/excel/src/excel-loader.ts
+++ b/modules/excel/src/excel-loader.ts
@@ -10,9 +10,14 @@ import type {ObjectRowTable} from '@loaders.gl/schema';
 const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
 export type ExcelLoaderOptions = LoaderOptions & {
+  /** Options for ExcelLoader */
   excel?: {
+    /** Format of returned data */
     shape?: /* 'array-row-table' | */ 'object-row-table';
-    sheet?: string; // Load default Sheet
+    /** Specify which sheet to load, if omitted loads default sheet */
+    sheet?: string; 
+    /** Override the URL to the worker bundle (by default loads from unpkg.com) */
+    workerUrl?: string;
   };
 };
 

--- a/modules/excel/src/excel-loader.ts
+++ b/modules/excel/src/excel-loader.ts
@@ -15,7 +15,7 @@ export type ExcelLoaderOptions = LoaderOptions & {
     /** Format of returned data */
     shape?: /* 'array-row-table' | */ 'object-row-table';
     /** Specify which sheet to load, if omitted loads default sheet */
-    sheet?: string; 
+    sheet?: string;
     /** Override the URL to the worker bundle (by default loads from unpkg.com) */
     workerUrl?: string;
   };

--- a/modules/flatgeobuf/src/flatgeobuf-loader.ts
+++ b/modules/flatgeobuf/src/flatgeobuf-loader.ts
@@ -15,6 +15,8 @@ const FGB_MAGIC_NUMBER = [0x66, 0x67, 0x62, 0x03, 0x66, 0x67, 0x62, 0x01];
 export type FlatGeobufLoaderOptions = LoaderOptions & {
   flatgeobuf?: {
     shape?: 'geojson-table' | 'columnar-table' | 'binary';
+    /** Override the URL to the worker bundle (by default loads from unpkg.com) */
+    workerUrl?: string;
   };
   gis?: {
     reproject?: boolean;

--- a/modules/geopackage/src/geopackage-loader.ts
+++ b/modules/geopackage/src/geopackage-loader.ts
@@ -20,6 +20,8 @@ export type GeoPackageLoaderOptions = LoaderOptions & {
     table?: string;
     /** Use null in Node */
     sqlJsCDN?: string | null;
+    /** Override the URL to the worker bundle (by default loads from unpkg.com) */
+    workerUrl?: string;
   };
   gis?: {
     reproject?: boolean;

--- a/modules/geopackage/src/index.ts
+++ b/modules/geopackage/src/index.ts
@@ -2,4 +2,5 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
+export type {GeoPackageLoaderOptions} from './geopackage-loader';
 export {GeoPackageLoader} from './geopackage-loader';

--- a/modules/las/src/las-loader.ts
+++ b/modules/las/src/las-loader.ts
@@ -12,6 +12,8 @@ export type LASLoaderOptions = LoaderOptions & {
     fp64?: boolean;
     skip?: number;
     colorDepth?: number | string;
+    /** Override the URL to the worker bundle (by default loads from unpkg.com) */
+    workerUrl?: string;
   };
   onProgress?: Function;
 };

--- a/modules/mvt/src/helpers/binary-util-functions.ts
+++ b/modules/mvt/src/helpers/binary-util-functions.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import Protobuf from 'pbf';
 import {getPolygonSignedArea} from '@math.gl/polygon';
 import {FlatIndexedGeometry, FlatPolygon} from '@loaders.gl/schema';

--- a/modules/mvt/src/helpers/binary-util-functions.ts
+++ b/modules/mvt/src/helpers/binary-util-functions.ts
@@ -5,7 +5,7 @@
 import Protobuf from 'pbf';
 import {getPolygonSignedArea} from '@math.gl/polygon';
 import {FlatIndexedGeometry, FlatPolygon} from '@loaders.gl/schema';
-import VectorTileFeature from '../lib/binary-vector-tile/vector-tile-feature';
+import {BinaryVectorTileFeature} from '../lib/binary-vector-tile/vector-tile-feature';
 
 /**
  * Classifies an array of rings into polygons with outer rings and holes
@@ -101,7 +101,7 @@ export function project(data: number[], x0: number, y0: number, size: number): v
  * @param feature
  * @param pbf
  */
-export function readFeature(tag: number, feature?: VectorTileFeature, pbf?: Protobuf): void {
+export function readFeature(tag: number, feature?: BinaryVectorTileFeature, pbf?: Protobuf): void {
   if (feature && pbf) {
     if (tag === 1) feature.id = pbf.readVarint();
     else if (tag === 2) readTag(pbf, feature);
@@ -114,7 +114,7 @@ export function readFeature(tag: number, feature?: VectorTileFeature, pbf?: Prot
  * @param pbf
  * @param feature
  */
-export function readTag(pbf: Protobuf, feature: VectorTileFeature): void {
+export function readTag(pbf: Protobuf, feature: BinaryVectorTileFeature): void {
   const end = pbf.readVarint() + pbf.pos;
 
   while (pbf.pos < end) {

--- a/modules/mvt/src/helpers/mapbox-util-functions.ts
+++ b/modules/mvt/src/helpers/mapbox-util-functions.ts
@@ -4,7 +4,7 @@
 
 import Protobuf from 'pbf';
 import {MVTMapboxGeometry} from '../lib/types';
-import VectorTileFeature from '../lib/mapbox-vector-tile/vector-tile-feature';
+import {VectorTileFeature} from '../lib/mapbox-vector-tile/vector-tile-feature';
 
 /**
  * Classifies an array of rings into polygons with outer rings and holes

--- a/modules/mvt/src/helpers/mapbox-util-functions.ts
+++ b/modules/mvt/src/helpers/mapbox-util-functions.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import Protobuf from 'pbf';
 import {MVTMapboxGeometry} from '../lib/types';
 import VectorTileFeature from '../lib/mapbox-vector-tile/vector-tile-feature';

--- a/modules/mvt/src/index.ts
+++ b/modules/mvt/src/index.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-export type {MVTLoaderOptions} from './lib/types';
+export type {MVTLoaderOptions} from './mvt-loader';
 export {MVTLoader, MVTWorkerLoader} from './mvt-loader';
 
 export type {TileJSON} from './lib/parse-tilejson';

--- a/modules/mvt/src/lib/binary-vector-tile/vector-tile-feature.ts
+++ b/modules/mvt/src/lib/binary-vector-tile/vector-tile-feature.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 // This code is forked from https://github.com/mapbox/vector-tile-js under BSD 3-clause license.
 
 import Protobuf from 'pbf';

--- a/modules/mvt/src/lib/binary-vector-tile/vector-tile-feature.ts
+++ b/modules/mvt/src/lib/binary-vector-tile/vector-tile-feature.ts
@@ -21,7 +21,7 @@ export const TEST_EXPORTS = {
   classifyRings
 };
 
-export default class VectorTileFeature {
+export class BinaryVectorTileFeature {
   properties: {[x: string]: string | number | boolean | null};
   extent: any;
   type: number;

--- a/modules/mvt/src/lib/binary-vector-tile/vector-tile-layer.ts
+++ b/modules/mvt/src/lib/binary-vector-tile/vector-tile-layer.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 /* eslint-disable indent */
 // This code is forked from https://github.com/mapbox/vector-tile-js under BSD 3-clause license.
 

--- a/modules/mvt/src/lib/binary-vector-tile/vector-tile-layer.ts
+++ b/modules/mvt/src/lib/binary-vector-tile/vector-tile-layer.ts
@@ -5,11 +5,11 @@
 /* eslint-disable indent */
 // This code is forked from https://github.com/mapbox/vector-tile-js under BSD 3-clause license.
 
-import VectorTileFeature from './vector-tile-feature';
+import {BinaryVectorTileFeature} from './vector-tile-feature';
 import Protobuf from 'pbf';
 import {GeojsonGeometryInfo} from '@loaders.gl/schema';
 
-export default class VectorTileLayer {
+export class BinaryVectorTileLayer {
   version: number;
   name: string;
   extent: number;
@@ -37,13 +37,13 @@ export default class VectorTileLayer {
   }
 
   /**
-   * return feature `i` from this layer as a `VectorTileFeature`
+   * return feature `i` from this layer as a `BinaryVectorTileFeature`
    *
    * @param index
    * @param geometryInfo
-   * @returns {VectorTileFeature}
+   * @returns {BinaryVectorTileFeature}
    */
-  feature(i: number, geometryInfo: GeojsonGeometryInfo): VectorTileFeature {
+  feature(i: number, geometryInfo: GeojsonGeometryInfo): BinaryVectorTileFeature {
     if (i < 0 || i >= this._features.length) {
       throw new Error('feature index out of bounds');
     }
@@ -51,7 +51,7 @@ export default class VectorTileLayer {
     this._pbf.pos = this._features[i];
 
     const end = this._pbf.readVarint() + this._pbf.pos;
-    return new VectorTileFeature(
+    return new BinaryVectorTileFeature(
       this._pbf,
       end,
       this.extent,
@@ -68,7 +68,7 @@ export default class VectorTileLayer {
  * @param layer
  * @param pbf
  */
-function readLayer(tag: number, layer?: VectorTileLayer, pbf?: Protobuf): void {
+function readLayer(tag: number, layer?: BinaryVectorTileLayer, pbf?: Protobuf): void {
   if (layer && pbf) {
     if (tag === 15) layer.version = pbf.readVarint();
     else if (tag === 1) layer.name = pbf.readString();

--- a/modules/mvt/src/lib/binary-vector-tile/vector-tile.ts
+++ b/modules/mvt/src/lib/binary-vector-tile/vector-tile.ts
@@ -4,11 +4,11 @@
 
 // This code is forked from https://github.com/mapbox/vector-tile-js under BSD 3-clause license.
 
-import VectorTileLayer from './vector-tile-layer';
+import {BinaryVectorTileLayer} from './vector-tile-layer';
 import Protobuf from 'pbf';
 
-export default class VectorTile {
-  layers: {[x: string]: VectorTileLayer};
+export class BinaryVectorTile {
+  layers: {[x: string]: BinaryVectorTileLayer};
   constructor(pbf: Protobuf, end?: number) {
     this.layers = pbf.readFields(readTile, {}, end);
   }
@@ -20,10 +20,14 @@ export default class VectorTile {
  * @param layers
  * @param pbf
  */
-function readTile(tag: number, layers?: {[x: string]: VectorTileLayer}, pbf?: Protobuf): void {
+function readTile(
+  tag: number,
+  layers?: {[x: string]: BinaryVectorTileLayer},
+  pbf?: Protobuf
+): void {
   if (tag === 3) {
     if (pbf) {
-      const layer = new VectorTileLayer(pbf, pbf.readVarint() + pbf.pos);
+      const layer = new BinaryVectorTileLayer(pbf, pbf.readVarint() + pbf.pos);
       if (layer.length && layers) {
         layers[layer.name] = layer;
       }

--- a/modules/mvt/src/lib/binary-vector-tile/vector-tile.ts
+++ b/modules/mvt/src/lib/binary-vector-tile/vector-tile.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 // This code is forked from https://github.com/mapbox/vector-tile-js under BSD 3-clause license.
 
 import VectorTileLayer from './vector-tile-layer';

--- a/modules/mvt/src/lib/mapbox-vector-tile/vector-tile-feature.ts
+++ b/modules/mvt/src/lib/mapbox-vector-tile/vector-tile-feature.ts
@@ -7,7 +7,7 @@ import Protobuf from 'pbf';
 import {MVTMapboxCoordinates, MVTMapboxGeometry} from '../types';
 import {readFeature, classifyRings} from '../../helpers/mapbox-util-functions';
 
-export default class VectorTileFeature {
+export class VectorTileFeature {
   properties: {[x: string]: string | number | boolean | null};
   extent: any;
   type: number;

--- a/modules/mvt/src/lib/mapbox-vector-tile/vector-tile-feature.ts
+++ b/modules/mvt/src/lib/mapbox-vector-tile/vector-tile-feature.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 // This code is forked from https://github.com/mapbox/vector-tile-js under BSD 3-clause license.
 import Protobuf from 'pbf';
 import {MVTMapboxCoordinates, MVTMapboxGeometry} from '../types';

--- a/modules/mvt/src/lib/mapbox-vector-tile/vector-tile-layer.ts
+++ b/modules/mvt/src/lib/mapbox-vector-tile/vector-tile-layer.ts
@@ -6,7 +6,7 @@
 // This code is forked from https://github.com/mapbox/vector-tile-js under BSD 3-clause license.
 
 import Protobuf from 'pbf';
-import VectorTileFeature from './vector-tile-feature';
+import {VectorTileFeature} from './vector-tile-feature';
 
 export class VectorTileLayer {
   version: number;

--- a/modules/mvt/src/lib/mapbox-vector-tile/vector-tile-layer.ts
+++ b/modules/mvt/src/lib/mapbox-vector-tile/vector-tile-layer.ts
@@ -1,10 +1,14 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 /* eslint-disable indent */
 // This code is forked from https://github.com/mapbox/vector-tile-js under BSD 3-clause license.
 
 import Protobuf from 'pbf';
 import VectorTileFeature from './vector-tile-feature';
 
-export default class VectorTileLayer {
+export class VectorTileLayer {
   version: number;
   name: string;
   extent: number;

--- a/modules/mvt/src/lib/mapbox-vector-tile/vector-tile.ts
+++ b/modules/mvt/src/lib/mapbox-vector-tile/vector-tile.ts
@@ -1,9 +1,13 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 // This code is forked from https://github.com/mapbox/vector-tile-js under BSD 3-clause license.
 
 import VectorTileLayer from './vector-tile-layer';
 import Protobuf from 'pbf';
 
-export default class VectorTile {
+export class VectorTile {
   layers: {[x: string]: VectorTileLayer};
   constructor(pbf: Protobuf, end?: number) {
     this.layers = pbf.readFields(readTile, {}, end);

--- a/modules/mvt/src/lib/mapbox-vector-tile/vector-tile.ts
+++ b/modules/mvt/src/lib/mapbox-vector-tile/vector-tile.ts
@@ -4,7 +4,7 @@
 
 // This code is forked from https://github.com/mapbox/vector-tile-js under BSD 3-clause license.
 
-import VectorTileLayer from './vector-tile-layer';
+import {VectorTileLayer} from './vector-tile-layer';
 import Protobuf from 'pbf';
 
 export class VectorTile {

--- a/modules/mvt/src/lib/parse-mvt.ts
+++ b/modules/mvt/src/lib/parse-mvt.ts
@@ -12,12 +12,13 @@ import type {
 } from '@loaders.gl/schema';
 import Protobuf from 'pbf';
 
-import type {MVTMapboxCoordinates, MVTOptions, MVTLoaderOptions} from '../lib/types';
+import type {MVTMapboxCoordinates, MVTOptions} from '../lib/types';
+import type {MVTLoaderOptions} from '../mvt-loader';
 
-import VectorTile from './mapbox-vector-tile/vector-tile';
-import BinaryVectorTile from './binary-vector-tile/vector-tile';
-import VectorTileFeatureBinary from './binary-vector-tile/vector-tile-feature';
-import VectorTileFeatureMapBox from './mapbox-vector-tile/vector-tile-feature';
+import {VectorTile} from './mapbox-vector-tile/vector-tile';
+import {BinaryVectorTile} from './binary-vector-tile/vector-tile';
+import {BinaryVectorTileFeature} from './binary-vector-tile/vector-tile-feature';
+import {VectorTileFeature as VectorTileFeatureMapBox} from './mapbox-vector-tile/vector-tile-feature';
 
 /**
  * Parse MVT arrayBuffer and return GeoJSON.
@@ -183,12 +184,12 @@ function getDecodedFeature(
  * @returns decoded binary feature
  */
 function getDecodedFeatureBinary(
-  feature: VectorTileFeatureBinary,
+  feature: BinaryVectorTileFeature,
   options: MVTOptions,
   layerName: string
 ): FlatFeature {
   const decodedFeature = feature.toBinaryCoordinates(
-    // @ts-expect-error What is going on here?
+    // @ts-expect-error
     options.coordinates === 'wgs84' ? options.tileIndex : transformToLocalCoordinatesBinary
   );
 

--- a/modules/mvt/src/lib/parse-mvt.ts
+++ b/modules/mvt/src/lib/parse-mvt.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import {flatGeojsonToBinary} from '@loaders.gl/gis';
 import type {
   FlatFeature,
@@ -22,7 +26,7 @@ import VectorTileFeatureMapBox from './mapbox-vector-tile/vector-tile-feature';
  * @param options
  * @returns A GeoJSON geometry object or a binary representation
  */
-export default function parseMVT(arrayBuffer: ArrayBuffer, options?: MVTLoaderOptions) {
+export function parseMVT(arrayBuffer: ArrayBuffer, options?: MVTLoaderOptions) {
   const mvtOptions = normalizeOptions(options);
 
   const shape: string | undefined =

--- a/modules/mvt/src/lib/types.ts
+++ b/modules/mvt/src/lib/types.ts
@@ -1,4 +1,6 @@
-import type {LoaderOptions} from '@loaders.gl/loader-utils';
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
 
 /** For local coordinates, the tileIndex is not required */
 type MVTLocalCoordinatesOptions = {
@@ -54,14 +56,4 @@ export type MVTMapboxCoordinates = {
   };
   properties: {[x: string]: string | number | boolean | null};
   id?: number;
-};
-
-export type MVTLoaderOptions = LoaderOptions & {
-  mvt?: MVTOptions;
-  gis?: {
-    /** `true`: parser will output the data in binary format. Equivalent to loading the data as GeoJSON and then applying geojsonToBinary */
-    binary?: boolean;
-    /** @deprecated. Use options.mvt.shape */
-    format?: 'geojson-table' | 'columnar-table' | 'geojson' | 'binary' | 'binary-geometry';
-  };
 };

--- a/modules/mvt/src/mvt-loader.ts
+++ b/modules/mvt/src/mvt-loader.ts
@@ -13,8 +13,7 @@ const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 export type MVTLoaderOptions = LoaderOptions & {
   mvt?: MVTOptions & {
     /** Override the URL to the worker bundle (by default loads from unpkg.com) */
-    workerUrl?: string;    
-
+    workerUrl?: string;
   };
   gis?: {
     /** `true`: parser will output the data in binary format. Equivalent to loading the data as GeoJSON and then applying geojsonToBinary */

--- a/modules/mvt/src/mvt-loader.ts
+++ b/modules/mvt/src/mvt-loader.ts
@@ -1,17 +1,28 @@
-import type {Loader, LoaderWithParser} from '@loaders.gl/loader-utils';
-import type {MVTLoaderOptions} from './lib/types';
-// import type {
-//   Feature,
-//   BinaryFeatureCollection,
-//   GeoJSONTable,
-//   Geometry,
-//   GeoJsonProperties
-// } from '@loaders.gl/schema';
-import parseMVT from './lib/parse-mvt';
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
+import type {Loader, LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';
+import {parseMVT} from './lib/parse-mvt';
+import type {MVTOptions} from './lib/types';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
 const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+
+export type MVTLoaderOptions = LoaderOptions & {
+  mvt?: MVTOptions & {
+    /** Override the URL to the worker bundle (by default loads from unpkg.com) */
+    workerUrl?: string;    
+
+  };
+  gis?: {
+    /** `true`: parser will output the data in binary format. Equivalent to loading the data as GeoJSON and then applying geojsonToBinary */
+    binary?: boolean;
+    /** @deprecated. Use options.mvt.shape */
+    format?: 'geojson-table' | 'columnar-table' | 'geojson' | 'binary' | 'binary-geometry';
+  };
+};
 
 /**
  * Worker loader for the Mapbox Vector Tile format

--- a/modules/mvt/src/workers/mvt-worker.ts
+++ b/modules/mvt/src/workers/mvt-worker.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
 import {MVTLoader} from '../mvt-loader';
 import {createLoaderWorker} from '@loaders.gl/loader-utils';
 

--- a/modules/obj/src/index.ts
+++ b/modules/obj/src/index.ts
@@ -15,6 +15,8 @@ import {MTLLoader as MTLWorkerLoader} from './mtl-loader';
 
 // OBJLoader
 
+export type {OBJLoaderOptions} from './obj-loader';
+
 export {OBJWorkerLoader};
 
 /**

--- a/modules/obj/src/obj-loader.ts
+++ b/modules/obj/src/obj-loader.ts
@@ -8,7 +8,7 @@ const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 export type OBJLoaderOptions = LoaderOptions & {
   obj?: {
     /** Override the URL to the worker bundle (by default loads from unpkg.com) */
-    workerUrl?: string;    
+    workerUrl?: string;
   };
 };
 

--- a/modules/obj/src/obj-loader.ts
+++ b/modules/obj/src/obj-loader.ts
@@ -6,7 +6,10 @@ import {Mesh} from '@loaders.gl/schema';
 const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
 export type OBJLoaderOptions = LoaderOptions & {
-  obj?: {};
+  obj?: {
+    /** Override the URL to the worker bundle (by default loads from unpkg.com) */
+    workerUrl?: string;    
+  };
 };
 
 /**

--- a/modules/pcd/src/index.ts
+++ b/modules/pcd/src/index.ts
@@ -7,6 +7,8 @@ import parsePCDSync from './lib/parse-pcd';
 import {PCDLoader as PCDWorkerLoader} from './pcd-loader';
 import {PCDMesh} from './lib/pcd-types';
 
+export type {PCDLoaderOptions} from './pcd-loader';
+
 export {PCDWorkerLoader};
 
 /**

--- a/modules/pcd/src/pcd-loader.ts
+++ b/modules/pcd/src/pcd-loader.ts
@@ -9,6 +9,13 @@ import {PCDMesh} from './lib/pcd-types';
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
 const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
+export type PCDLoaderOptions = LoaderOptions & {
+  pcd?: {
+    /** Override the URL to the worker bundle (by default loads from unpkg.com) */
+    workerUrl?: string;
+  };
+};
+
 /**
  * Worker loader for PCD - Point Cloud Data
  */
@@ -26,4 +33,4 @@ export const PCDLoader = {
   options: {
     pcd: {}
   }
-} as const satisfies Loader<PCDMesh, never, LoaderOptions>;
+} as const satisfies Loader<PCDMesh, never, PCDLoaderOptions>;

--- a/modules/ply/src/index.ts
+++ b/modules/ply/src/index.ts
@@ -2,19 +2,17 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {LoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';
+import type {LoaderWithParser} from '@loaders.gl/loader-utils';
 import type {PLYMesh} from './lib/ply-types';
 import {PLYLoader as PLYWorkerLoader} from './ply-loader';
-import {ParsePLYOptions, parsePLY} from './lib/parse-ply';
+import {parsePLY} from './lib/parse-ply';
 import {parsePLYInBatches} from './lib/parse-ply-in-batches';
 
 // PLYLoader
 
-export {PLYWorkerLoader};
+export type {PLYLoaderOptions} from './ply-loader';
 
-export type PLYLoaderOptions = LoaderOptions & {
-  ply?: ParsePLYOptions;
-};
+export {PLYWorkerLoader};
 
 /**
  * Loader for PLY - Polygon File Format

--- a/modules/ply/src/index.ts
+++ b/modules/ply/src/index.ts
@@ -4,13 +4,14 @@
 
 import type {LoaderWithParser} from '@loaders.gl/loader-utils';
 import type {PLYMesh} from './lib/ply-types';
+import type {PLYLoaderOptions} from './ply-loader';
 import {PLYLoader as PLYWorkerLoader} from './ply-loader';
 import {parsePLY} from './lib/parse-ply';
 import {parsePLYInBatches} from './lib/parse-ply-in-batches';
 
 // PLYLoader
 
-export type {PLYLoaderOptions} from './ply-loader';
+export type {PLYLoaderOptions};
 
 export {PLYWorkerLoader};
 

--- a/modules/ply/src/ply-loader.ts
+++ b/modules/ply/src/ply-loader.ts
@@ -1,10 +1,18 @@
 // PLY Loader
 import type {Loader, LoaderOptions} from '@loaders.gl/loader-utils';
 import {PLYMesh} from './lib/ply-types';
+import type {ParsePLYOptions} from './lib/parse-ply';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
 const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+
+export type PLYLoaderOptions = LoaderOptions & {
+  ply?: ParsePLYOptions & {
+    /** Override the URL to the worker bundle (by default loads from unpkg.com) */
+    workerUrl?: string;
+  };
+};
 
 /**
  * Worker loader for PLY - Polygon File Format (aka Stanford Triangle Format)'

--- a/modules/shapefile/src/dbf-loader.ts
+++ b/modules/shapefile/src/dbf-loader.ts
@@ -1,9 +1,21 @@
-import type {Loader, LoaderWithParser} from '@loaders.gl/loader-utils';
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Loader, LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';
 import {parseDBF, parseDBFInBatches} from './lib/parsers/parse-dbf';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
 const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+
+export type DBFLoaderOptions = LoaderOptions & {
+  dbf?: {
+    encoding?: string;
+    /** Override the URL to the worker bundle (by default loads from unpkg.com) */
+    workerUrl?: string;
+  };
+};
 
 /**
  * DBFLoader - DBF files are used to contain non-geometry columns in Shapefiles
@@ -25,7 +37,7 @@ export const DBFWorkerLoader = {
       encoding: 'latin1'
     }
   }
-} as const satisfies Loader;
+} as const satisfies Loader<any, any, DBFLoaderOptions>;
 
 /** DBF file loader */
 export const DBFLoader: LoaderWithParser = {

--- a/modules/shapefile/src/index.ts
+++ b/modules/shapefile/src/index.ts
@@ -1,5 +1,14 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export type {ShapefileLoaderOptions} from './shapefile-loader';
 export {ShapefileLoader} from './shapefile-loader';
+
+export type {DBFLoaderOptions} from './dbf-loader';
 export {DBFLoader, DBFWorkerLoader} from './dbf-loader';
+
+export type {SHPLoaderOptions} from './shp-loader';
 export {SHPLoader, SHPWorkerLoader} from './shp-loader';
 
 // EXPERIMENTAL

--- a/modules/shapefile/src/lib/parsers/parse-dbf.ts
+++ b/modules/shapefile/src/lib/parsers/parse-dbf.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {Field, ObjectRowTable} from '@loaders.gl/schema';
 import {BinaryChunkReader} from '../streaming/binary-chunk-reader';
 import {

--- a/modules/shapefile/src/lib/parsers/parse-shapefile.ts
+++ b/modules/shapefile/src/lib/parsers/parse-shapefile.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // import type {Feature} from '@loaders.gl/gis';
 import {LoaderContext, parseInBatchesFromContext, parseFromContext} from '@loaders.gl/loader-utils';
 import {binaryToGeometry, transformGeoJsonCoords} from '@loaders.gl/gis';

--- a/modules/shapefile/src/lib/parsers/parse-shp-geometry.ts
+++ b/modules/shapefile/src/lib/parsers/parse-shp-geometry.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {BinaryGeometry, BinaryGeometryType} from '@loaders.gl/schema';
 import {SHPLoaderOptions} from './types';
 

--- a/modules/shapefile/src/lib/parsers/parse-shp-header.ts
+++ b/modules/shapefile/src/lib/parsers/parse-shp-header.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 export interface SHPHeader {
   /** SHP Magic number */
   magic: number;

--- a/modules/shapefile/src/lib/parsers/parse-shp.ts
+++ b/modules/shapefile/src/lib/parsers/parse-shp.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import type {BinaryGeometry} from '@loaders.gl/schema';
 import {BinaryChunkReader} from '../streaming/binary-chunk-reader';
 import {parseSHPHeader, SHPHeader} from './parse-shp-header';

--- a/modules/shapefile/src/lib/parsers/parse-shx.ts
+++ b/modules/shapefile/src/lib/parsers/parse-shx.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {parseSHPHeader} from './parse-shp-header';
 
 export interface SHXOutput {

--- a/modules/shapefile/src/lib/parsers/types.ts
+++ b/modules/shapefile/src/lib/parsers/types.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {Schema, ObjectRowTable} from '@loaders.gl/schema';
 import type {LoaderOptions} from '@loaders.gl/loader-utils';
 

--- a/modules/shapefile/src/shapefile-loader.ts
+++ b/modules/shapefile/src/shapefile-loader.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import type {LoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';
 import {SHP_MAGIC_NUMBER} from './shp-loader';
 import {parseShapefile, parseShapefileInBatches} from './lib/parsers/parse-shapefile';
@@ -10,6 +14,8 @@ const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 export type ShapefileLoaderOptions = LoaderOptions & {
   shapefile?: {
     shape?: 'geojson-table' | 'v3';
+    /** @deprecated Worker URLs must be specified with .dbf.workerUrl * .shp.workerUrl */
+    workerUrl?: never;
   };
 };
 

--- a/modules/shapefile/src/shp-loader.ts
+++ b/modules/shapefile/src/shp-loader.ts
@@ -1,4 +1,8 @@
-import type {Loader, LoaderWithParser} from '@loaders.gl/loader-utils';
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Loader, LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';
 import {parseSHP, parseSHPInBatches} from './lib/parsers/parse-shp';
 
 // __VERSION__ is injected by babel-plugin-version-inline
@@ -6,6 +10,15 @@ import {parseSHP, parseSHPInBatches} from './lib/parsers/parse-shp';
 const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
 export const SHP_MAGIC_NUMBER = [0x00, 0x00, 0x27, 0x0a];
+
+/** SHPLoader */
+export type SHPLoaderOptions = LoaderOptions & {
+  dbf?: {
+    _maxDimensions?: number;
+    /** Override the URL to the worker bundle (by default loads from unpkg.com) */
+    workerUrl?: string;
+  };
+};
 
 /**
  * SHP file loader
@@ -29,7 +42,7 @@ export const SHPWorkerLoader = {
       _maxDimensions: 4
     }
   }
-} as const satisfies Loader;
+} as const satisfies Loader<any, any, SHPLoaderOptions>;
 
 /** SHP file loader */
 export const SHPLoader: LoaderWithParser = {

--- a/modules/shapefile/src/workers/dbf-worker.ts
+++ b/modules/shapefile/src/workers/dbf-worker.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {DBFLoader} from '../dbf-loader';
 import {createLoaderWorker} from '@loaders.gl/loader-utils';
 

--- a/modules/shapefile/src/workers/shp-worker.ts
+++ b/modules/shapefile/src/workers/shp-worker.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {SHPLoader} from '../shp-loader';
 import {createLoaderWorker} from '@loaders.gl/loader-utils';
 

--- a/modules/shapefile/test/dbf-loader.spec.ts
+++ b/modules/shapefile/test/dbf-loader.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import test from 'tape-promise/tape';
 import {setLoaderOptions, fetchFile, parse} from '@loaders.gl/core';
 import {DBFLoader} from '@loaders.gl/shapefile';

--- a/modules/shapefile/test/shapefile-loader.spec.ts
+++ b/modules/shapefile/test/shapefile-loader.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import test from 'tape-promise/tape';
 import {
   setLoaderOptions,
@@ -52,6 +56,9 @@ test('ShapefileLoader#load (from browser File objects)', async (t) => {
     for (const testFileName in SHAPEFILE_JS_TEST_FILES) {
       const fileList = SHAPEFILE_JS_TEST_FILES[testFileName];
       const fileSystem = new BrowserFileSystem(fileList);
+      
+      // TODO - should this be bound?
+      // eslint-ignore-next-line
       const {fetch} = fileSystem;
       const filename = `${testFileName}.shp`;
       // @ts-ignore
@@ -185,6 +192,7 @@ async function getFileList(testFileName) {
     const filename = `${testFileName}${extension}`;
     const response = await fetchFile(`${SHAPEFILE_JS_DATA_FOLDER}/${filename}`);
     if (response.ok) {
+      // @ts-expect-error
       fileList.push(new File([await response.blob()], filename));
     }
   }

--- a/modules/shapefile/test/shapefile-loader.spec.ts
+++ b/modules/shapefile/test/shapefile-loader.spec.ts
@@ -56,10 +56,8 @@ test('ShapefileLoader#load (from browser File objects)', async (t) => {
     for (const testFileName in SHAPEFILE_JS_TEST_FILES) {
       const fileList = SHAPEFILE_JS_TEST_FILES[testFileName];
       const fileSystem = new BrowserFileSystem(fileList);
-      
-      // TODO - should this be bound?
-      // eslint-ignore-next-line
-      const {fetch} = fileSystem;
+      // eslint-disable-next-line
+      const fetch = fileSystem.fetch.bind(fileSystem.fetch);
       const filename = `${testFileName}.shp`;
       // @ts-ignore
       const data = await load(filename, ShapefileLoader, {fetch});

--- a/modules/shapefile/test/shapefile.bench.ts
+++ b/modules/shapefile/test/shapefile.bench.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {fetchFile, load} from '@loaders.gl/core';
 import {ShapefileLoader} from '@loaders.gl/shapefile';
 
@@ -12,7 +16,7 @@ export default async function shapefileLoaderBench(suite) {
   suite.group('ShapefileLoader');
 
   suite.addAsync(
-    `parse(ShapefileLoader without worker)`,
+    'parse(ShapefileLoader without worker)',
     {multiplier: 77, unit: 'MB'},
     async () => {
       await load(arrayBuffer.slice(0), ShapefileLoader, {worker: false});

--- a/modules/shapefile/test/shp-loader.spec.ts
+++ b/modules/shapefile/test/shp-loader.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import test from 'tape-promise/tape';
 import {setLoaderOptions, load, fetchFile} from '@loaders.gl/core';
 import {geojsonToBinary} from '@loaders.gl/gis';

--- a/modules/shapefile/test/shp.bench.ts
+++ b/modules/shapefile/test/shp.bench.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {SHPLoader} from '@loaders.gl/shapefile';
 import {parse, parseInBatches, fetchFile} from '@loaders.gl/core';
 
@@ -12,12 +16,12 @@ export default async function shpLoaderBench(suite) {
   suite.group('SHPLoader');
 
   suite.addAsync(
-    `parse(SHPLoader without worker)`,
+    'parse(SHPLoader without worker)',
     {multiplier: 77, unit: 'MB'},
     async () => await parse(arrayBuffer, SHPLoader, {worker: false})
   );
   suite.addAsync(
-    `parseInBatches(SHPLoader without worker)`,
+    'parseInBatches(SHPLoader without worker)',
     {multiplier: 77, unit: 'MB'},
     async () => await parseInBatches(arrayBuffer, SHPLoader, {worker: false})
   );

--- a/modules/shapefile/test/streaming/binary-chunk-reader.spec.ts
+++ b/modules/shapefile/test/streaming/binary-chunk-reader.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import test from 'tape-promise/tape';
 import {_BinaryChunkReader as BinaryChunkReader} from '@loaders.gl/shapefile';
 

--- a/modules/shapefile/test/streaming/zip-batch-iterators.spec.ts
+++ b/modules/shapefile/test/streaming/zip-batch-iterators.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import test from 'tape-promise/tape';
 import type {ObjectRowTableBatch, ArrayRowTableBatch} from '@loaders.gl/schema';
 import {_zipBatchIterators as zipBatchIterators} from '@loaders.gl/shapefile';

--- a/modules/shapefile/wip/parse-dbf-atomic.ts
+++ b/modules/shapefile/wip/parse-dbf-atomic.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import BinaryReader from '../../streaming/binary-reader';
 
 const LITTLE_ENDIAN = true;

--- a/modules/shapefile/wip/parse-shp-atomic.ts
+++ b/modules/shapefile/wip/parse-shp-atomic.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import BinaryReader from '../../streaming/binary-reader';
 import {parseRecord} from '../parse-shp-geometry';
 

--- a/modules/terrain/src/quantized-mesh-loader.ts
+++ b/modules/terrain/src/quantized-mesh-loader.ts
@@ -5,10 +5,14 @@
 import type {Loader, LoaderOptions} from '@loaders.gl/loader-utils';
 import {VERSION} from './lib/utils/version';
 
+/** QuantizedMeshLoader options */
 export type QuantizedMeshLoaderOptions = LoaderOptions & {
+  /** QuantizedMeshLoader options */
   'quantized-mesh'?: {
     bounds?: [number, number, number, number];
     skirtHeight?: number | null;
+    /** Override the URL to the worker bundle (by default loads from unpkg.com) */
+    workerUrl?: string;
   };
 };
 

--- a/modules/terrain/src/terrain-loader.ts
+++ b/modules/terrain/src/terrain-loader.ts
@@ -9,8 +9,13 @@ import {VERSION} from './lib/utils/version';
 import {TerrainOptions} from './lib/parse-terrain';
 import {Mesh} from '@loaders.gl/schema';
 
+/** TerrainLoader options */
 export type TerrainLoaderOptions = ImageLoaderOptions & {
-  terrain?: TerrainOptions;
+  /** TerrainLoader options */
+  terrain?: TerrainOptions & {
+    /** Override the URL to the worker bundle (by default loads from unpkg.com) */
+    workerUrl?: string;
+  };
 };
 
 /**

--- a/modules/textures/src/basis-loader.ts
+++ b/modules/textures/src/basis-loader.ts
@@ -7,6 +7,23 @@ import type {TextureLevel} from '@loaders.gl/schema';
 import {VERSION} from './lib/utils/version';
 import parseBasis from './lib/parsers/parse-basis';
 
+/** Options for the BasisLoader */
+export type BasisLoaderOptions = LoaderOptions & {
+  /** Options for the BasisLoader */
+  basis?: {
+    /** Format for texture data. auto selects based on platform caps (but gl context doesn't exist on a worker thread) */
+    format: 'auto' | 'rgb565' | 'etc1s' | 'etc2' | 'astc' | 'dxt1' | 'dxt3' | 'dxt5';
+    /** @deprecated specify path of basis library */
+    libraryPath?: string;
+    /** What container format is used? */
+    containerFormat: 'auto' | 'ktx2' | 'basis';
+    /** What module to use for transcoding? */
+    module?: 'transcoder' | 'encoder';
+    /** Override the URL to the worker bundle (by default loads from unpkg.com) */
+    workerUrl?: string;
+  };
+};
+
 /**
  * Worker loader for Basis super compressed textures
  */
@@ -25,13 +42,13 @@ export const BasisWorkerLoader = {
   binary: true,
   options: {
     basis: {
-      format: 'auto', // gl context doesn't exist on a worker thread
+      format: 'auto',
       libraryPath: 'libs/',
-      containerFormat: 'auto', // 'basis' || 'ktx2' || 'auto'
-      module: 'transcoder' // 'transcoder' || 'encoder'
+      containerFormat: 'auto',
+      module: 'transcoder'
     }
   }
-} as const satisfies Loader<TextureLevel[][], never, LoaderOptions>;
+} as const satisfies Loader<TextureLevel[][], never, BasisLoaderOptions>;
 
 /**
  * Loader for Basis super compressed textures

--- a/modules/textures/src/compressed-texture-loader.ts
+++ b/modules/textures/src/compressed-texture-loader.ts
@@ -7,10 +7,15 @@ import {VERSION} from './lib/utils/version';
 import {parseCompressedTexture} from './lib/parsers/parse-compressed-texture';
 import parseBasis from './lib/parsers/parse-basis';
 
-export type TextureLoaderOptions = {
+/** Options for the CompressedTextureLoader */
+export type CompressedTextureLoaderOptions = {
   'compressed-texture'?: {
+    /** @deprecated Specify path to libraries */
     libraryPath?: string;
+    /** Whether to use Basis decoding */
     useBasis?: boolean;
+    /** Override the URL to the worker bundle (by default loads from unpkg.com) */
+    workerUrl?: string;
   };
 };
 
@@ -46,14 +51,14 @@ export const CompressedTextureWorkerLoader = {
       useBasis: false
     }
   }
-} as const satisfies Loader<any, never, TextureLoaderOptions>;
+} as const satisfies Loader<any, never, CompressedTextureLoaderOptions>;
 
 /**
  * Loader for KTX, DDS, and PVR texture container formats
  */
 export const CompressedTextureLoader = {
   ...CompressedTextureWorkerLoader,
-  parse: async (arrayBuffer: ArrayBuffer, options?: TextureLoaderOptions) => {
+  parse: async (arrayBuffer: ArrayBuffer, options?: CompressedTextureLoaderOptions) => {
     if (options?.['compressed-texture']?.useBasis) {
       // @ts-expect-error TODO not allowed to modify inputs
       options.basis = {
@@ -71,4 +76,4 @@ export const CompressedTextureLoader = {
     }
     return parseCompressedTexture(arrayBuffer);
   }
-} as const satisfies LoaderWithParser<any, never, TextureLoaderOptions>;
+} as const satisfies LoaderWithParser<any, never, CompressedTextureLoaderOptions>;

--- a/modules/textures/src/compressed-texture-writer.ts
+++ b/modules/textures/src/compressed-texture-writer.ts
@@ -6,8 +6,11 @@ import type {WriterWithEncoder, WriterOptions} from '@loaders.gl/loader-utils';
 import {VERSION} from './lib/utils/version';
 import {encodeImageURLToCompressedTextureURL} from './lib/encoders/encode-texture';
 
+/** Compressed Texture writer options */
 export type CompressedTextureWriterOptions = WriterOptions & {
+  /** @deprecated current working directory */
   cwd?: string;
+  /** Compressed Texture writer options */
   texture?: {
     format: string;
     compression: string;

--- a/modules/textures/src/crunch-loader.ts
+++ b/modules/textures/src/crunch-loader.ts
@@ -6,9 +6,14 @@ import type {Loader, LoaderOptions} from '@loaders.gl/loader-utils';
 import type {TextureLevel} from '@loaders.gl/schema';
 import {VERSION} from './lib/utils/version';
 
+/** CrunchLoader options */
 export type CrunchLoaderOptions = LoaderOptions & {
+  /** CrunchLoader options */
   crunch?: {
+    /** @deprecated Specify where to load the Crunch decoder library */
     libraryPath?: string;
+    /** Override the URL to the worker bundle (by default loads from unpkg.com) */
+    workerUrl?: string;
   };
 };
 

--- a/modules/textures/src/index.ts
+++ b/modules/textures/src/index.ts
@@ -6,12 +6,18 @@ import {VERSION} from './lib/utils/version';
 
 // Types
 export type {GPUTextureFormat} from '@loaders.gl/schema';
-export type {TextureLoaderOptions} from './compressed-texture-loader';
 
 // Loaders
+export type {BasisLoaderOptions} from './basis-loader';
 export {BasisLoader, BasisWorkerLoader} from './basis-loader';
+
+export type {CompressedTextureLoaderOptions} from './compressed-texture-loader';
 export {CompressedTextureLoader, CompressedTextureWorkerLoader} from './compressed-texture-loader';
+
+export type {CrunchLoaderOptions} from './crunch-loader';
 export {CrunchLoader} from './crunch-loader';
+
+export type {NPYLoaderOptions} from './npy-loader';
 export {NPYLoader, NPYWorkerLoader} from './npy-loader';
 
 // Module constants
@@ -48,4 +54,8 @@ export {selectSupportedBasisFormat} from './lib/parsers/parse-basis';
 export {getSupportedGPUTextureFormats} from './lib/utils/texture-formats';
 
 // DEPRECATED
+// @deprecated
 export {CrunchLoader as CrunchWorkerLoader} from './crunch-loader';
+// @deprecated
+export type {CompressedTextureLoaderOptions as TextureLoaderOptions} from './compressed-texture-loader';
+

--- a/modules/textures/src/index.ts
+++ b/modules/textures/src/index.ts
@@ -58,4 +58,3 @@ export {getSupportedGPUTextureFormats} from './lib/utils/texture-formats';
 export {CrunchLoader as CrunchWorkerLoader} from './crunch-loader';
 // @deprecated
 export type {CompressedTextureLoaderOptions as TextureLoaderOptions} from './compressed-texture-loader';
-

--- a/modules/textures/src/npy-loader.ts
+++ b/modules/textures/src/npy-loader.ts
@@ -9,8 +9,13 @@ import {parseNPY, NPYTile} from './lib/parsers/parse-npy';
 // \x93NUMPY
 const NPY_MAGIC_NUMBER = new Uint8Array([147, 78, 85, 77, 80, 89]);
 
+/** NPYLoader for numpy tiles */
 export type NPYLoaderOptions = LoaderOptions & {
-  npy?: {};
+  /** NPYLoader for numpy tiles */
+  npy?: {
+    /** Override the URL to the worker bundle (by default loads from unpkg.com) */
+    workerUrl?: string;
+  };
 };
 
 /**

--- a/modules/wkt/src/wkt-loader.ts
+++ b/modules/wkt/src/wkt-loader.ts
@@ -9,11 +9,14 @@ import {Geometry} from '@loaders.gl/schema';
 import {isWKT, WKT_MAGIC_STRINGS} from './lib/parse-wkt';
 
 export type WKTLoaderOptions = LoaderOptions & {
-  /** Options for the WKT parser */
+  /** Options for the WKTLoader */
   wkt?: {
+    /** Shape of returned geometry */
     shape?: 'geojson-geometry'; // 'binary-geometry'
     /** Whether to add any CRS, if found, as undocumented CRS property on the returned geometry */
     crs?: boolean;
+    /** Override the URL to the worker bundle (by default loads from unpkg.com) */
+    workerUrl?: string;
   };
 };
 


### PR DESCRIPTION
It was pointed out that the LoaderOption types do not include workerUrl field, leading to applications having to add ts-ignores.

This PR selectively adds the prop only to loaders that support workers.