### PR TITLE
feat(textures): Support loading mipmaps in KTX2 textures

### DIFF
--- a/modules/textures/package.json
+++ b/modules/textures/package.json
@@ -59,7 +59,7 @@
     "@loaders.gl/schema": "4.3.0-alpha.1",
     "@loaders.gl/worker-utils": "4.3.0-alpha.1",
     "@math.gl/types": "^4.0.1",
-    "ktx-parse": "^0.0.4",
+    "ktx-parse": "^0.7.0",
     "texture-compressor": "^1.0.2"
   },
   "peerDependencies": {

--- a/modules/textures/src/lib/parsers/parse-basis.ts
+++ b/modules/textures/src/lib/parsers/parse-basis.ts
@@ -204,7 +204,6 @@ function parseKTX2File(KTX2File, data: ArrayBuffer, options): TextureLevel[][] {
 
     for (let levelIndex = 0; levelIndex < levelsCount; levelIndex++) {
       levels.push(transcodeKTX2Image(ktx2File, levelIndex, options));
-      break; // texture app can only show one level for some reason
     }
 
     return [levels];

--- a/modules/textures/test/basis-loader.spec.ts
+++ b/modules/textures/test/basis-loader.spec.ts
@@ -133,6 +133,7 @@ test('BasisLoader#auto-select a decoder format', async (t) => {
   });
   const ktx2Image = ktx2Images[0];
   t.ok(ktx2Image, 'Transcode .ktx2');
+  t.is(ktx2Image.length, 10, 'Transcode .ktx2 mips');
 
   t.end();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2650,7 +2650,7 @@ __metadata:
     "@loaders.gl/schema": "npm:4.3.0-alpha.1"
     "@loaders.gl/worker-utils": "npm:4.3.0-alpha.1"
     "@math.gl/types": "npm:^4.0.1"
-    ktx-parse: "npm:^0.0.4"
+    ktx-parse: "npm:^0.7.0"
     texture-compressor: "npm:^1.0.2"
   peerDependencies:
     "@loaders.gl/core": ^4.0.0
@@ -9770,10 +9770,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ktx-parse@npm:^0.0.4":
-  version: 0.0.4
-  resolution: "ktx-parse@npm:0.0.4"
-  checksum: 10c0/806d5005696c25147dcc9aa6a2033587041fb391c58faaecd88b94ad17b3edfc145d3d69746a218f569600e8e9c7116886e70251c5fd1c813086a093271643b2
+"ktx-parse@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "ktx-parse@npm:0.7.0"
+  checksum: 10c0/5953518c1c895ae05c8f12a22d46aadbd0885b6f018e82198d31085a73b6ffa351ab5d2ae740823a1eb503042a52d7e31cdb5cbf5ddbfcad819663b49f1fbf42
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Someone on the [Web Game Dev](https://www.webgamedev.com/) Discord server reported that loaders.gl doesn't return any mipmaps for KTX2 textures. Appears to be a quick fix, and the returned data looks valid. I've updated `ktx-parse` to a newer version, while I'm here.

![Screenshot 2024-05-10 at 10 42 24 AM](https://github.com/visgl/loaders.gl/assets/1848368/c176d7ad-6c90-411a-981b-bdf3b3cccca4)
