### PR TITLE
fix(loader-utils): add missing dependency on @probe.gl/log

### DIFF
--- a/modules/loader-utils/package.json
+++ b/modules/loader-utils/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "@loaders.gl/schema": "4.3.0-alpha.2",
     "@loaders.gl/worker-utils": "4.3.0-alpha.2",
+    "@probe.gl/log": "^4.0.2",
     "@probe.gl/stats": "^4.0.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
[/modules/loader-utils/src/lib/log-utils/log.ts](https://github.com/visgl/loaders.gl/blob/d9db37097245ce8ea3204c2f4f4d4ed32b5f3c10/modules/loader-utils/src/lib/log-utils/log.ts#L5) depends on `@probe.gl/log`, so this package should be added to package dependencies.

Currently this results in an error when installing `@loaders.gl/loader-utils@4.2.1` with Yarn:
```
Cannot find module '@probe.gl/log' from '[REDACTED]/.yarn/__virtual__/@loaders.gl-loader-utils-virtual-7093831d78/0/cache/@loaders.gl-loader-utils-npm-4.2.1-a254ec9477-03fd9b18c2.zip/node_modules/@loaders.gl/loader-utils/dist'
```

Note: workaround until this PR is merged:
```
# .yarnrc.yml
packageExtensions:
  "@loaders.gl/loader-utils@*":
    dependencies:
      "@probe.gl/log": "*"
```