### PR TITLE
fix(csv): move d3-dsv from devDependencies to dependencies

### DIFF
--- a/modules/csv/package.json
+++ b/modules/csv/package.json
@@ -45,9 +45,7 @@
   },
   "dependencies": {
     "@loaders.gl/loader-utils": "4.3.0-alpha.2",
-    "@loaders.gl/schema": "4.3.0-alpha.2"
-  },
-  "devDependencies": {
+    "@loaders.gl/schema": "4.3.0-alpha.2",
     "d3-dsv": "^1.2.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Note: this PR is similar to #3008

[/modules/csv/src/lib/encoders/encode-csv.ts](https://github.com/visgl/loaders.gl/blob/d9db37097245ce8ea3204c2f4f4d4ed32b5f3c10/modules/csv/src/lib/encoders/encode-csv.ts#L7) depends on `d3-dsv`, so this package should be added to package dependencies.  Previously this import was in `devDependencies` (looks like a test also imports it), but since this is code that runs in production is should be moved to `dependencies`

Currently this results in an error when installing `@loaders.gl/csv@4.2.1` with Yarn:
```
Cannot find module 'd3-dsv' ...
```

Note: workaround until this PR is merged:
```
# .yarnrc.yml
packageExtensions:
  "@loaders.gl/csv@*":
    dependencies:
      "d3-dsv": "*"
```