### PR TITLE
fix(core): checkResponse crash when Request body is already used

### DIFF
--- a/modules/core/src/lib/utils/response-utils.ts
+++ b/modules/core/src/lib/utils/response-utils.ts
@@ -93,9 +93,10 @@ async function getResponseError(response: Response): Promise<Error> {
   // See if we got an error message in the body
   try {
     const contentType = response.headers.get('Content-Type');
-    info.reason = !response.bodyUsed && contentType?.includes('application/json')
-      ? await response.json()
-      : await response.text();
+    info.reason =
+      !response.bodyUsed && contentType?.includes('application/json')
+        ? await response.json()
+        : await response.text();
   } catch (error) {
     // eslint forbids return in a finally statement, so we just catch here
   }

--- a/modules/core/src/lib/utils/response-utils.ts
+++ b/modules/core/src/lib/utils/response-utils.ts
@@ -90,11 +90,12 @@ async function getResponseError(response: Response): Promise<Error> {
     response
   };
 
+  // See if we got an error message in the body
   try {
     const contentType = response.headers.get('Content-Type');
-    info.reason = contentType?.includes('application/json')
+    info.reason = !response.bodyUsed && contentType?.includes('application/json')
       ? await response.json()
-      : response.text();
+      : await response.text();
   } catch (error) {
     // eslint forbids return in a finally statement, so we just catch here
   }

--- a/modules/core/test/lib/utils/response-utils.spec.ts
+++ b/modules/core/test/lib/utils/response-utils.spec.ts
@@ -7,7 +7,8 @@ import {isBrowser} from '@loaders.gl/core';
 import {
   makeResponse,
   checkResponse,
-  checkResponseSync
+  checkResponseSync,
+  getResponseError
 } from '@loaders.gl/core/lib/utils/response-utils';
 
 test('Response', async (t) => {
@@ -65,8 +66,8 @@ test('makeResponse(File)', async (t) => {
 
 test('checkResponseSync', (t) => {
   const response = new Response('{message: "server died"}', {status: 500});
-  t.equal(response.ok, false, 'Check reponse.ok');
-  t.throws(() => checkResponseSync(response), /500/, 'Check reponse throws');
+  t.equal(response.ok, false, 'Check response.ok');
+  t.throws(() => checkResponseSync(response), /500/, 'Check response throws');
   // t.throws()
   t.end();
 });
@@ -76,8 +77,22 @@ test('checkResponse', async (t) => {
   Object.defineProperty(response, 'url', {
     value: 'https://some.url/not/even/very/long'
   });
-  t.equal(response.ok, false, 'Check reponse.ok');
-  t.rejects(() => checkResponse(response), /500/, 'Check reponse throws');
-  // t.throws()
+  
+  t.equal(response.ok, false, 'Check response.ok');
+  t.rejects(() => checkResponse(response), /500/, 'Check response throws');
+
+  t.end();
+});
+
+test('checkResponse(body used)', async (t) => {
+  const response = new Response('{message: "server died"}', {status: 500});
+  await response.text();
+  Object.defineProperty(response, 'url', {
+    value: 'https://some.url/not/even/very/long'
+  });
+  
+  t.equal(response.ok, false, 'Check response.ok');
+  t.rejects(() => checkResponse(response), /500/, 'Check response throws');
+
   t.end();
 });

--- a/modules/core/test/lib/utils/response-utils.spec.ts
+++ b/modules/core/test/lib/utils/response-utils.spec.ts
@@ -77,7 +77,7 @@ test('checkResponse', async (t) => {
   Object.defineProperty(response, 'url', {
     value: 'https://some.url/not/even/very/long'
   });
-  
+
   t.equal(response.ok, false, 'Check response.ok');
   t.rejects(() => checkResponse(response), /500/, 'Check response throws');
 
@@ -90,7 +90,7 @@ test('checkResponse(body used)', async (t) => {
   Object.defineProperty(response, 'url', {
     value: 'https://some.url/not/even/very/long'
   });
-  
+
   t.equal(response.ok, false, 'Check response.ok');
   t.rejects(() => checkResponse(response), /500/, 'Check response throws');
 


### PR DESCRIPTION
For #3025

Added a test case that reproduced the issue together with a fix: 
- add `await` on `response.text()`, causing the error to happen outside of the catch.
- add a check for `response.bodyUsed`:  https://developer.mozilla.org/en-US/docs/Web/API/Response/bodyUsed.

