### PR TITLE
fix(tile-converter): correct Content-Type for json data

### DIFF
--- a/modules/tile-converter/src/i3s-server/routes/slpk-router.ts
+++ b/modules/tile-converter/src/i3s-server/routes/slpk-router.ts
@@ -25,7 +25,12 @@ router.get('*', (req, res, next) => {
   async function routerCallback(req, res, next) {
     const file = await getFileByUrl(req.path.replace(/\/+$/, ''));
     if (file) {
-      res.send(Buffer.from(file));
+      try {
+        const json = JSON.parse(textDecoder.decode(file));
+        res.send(json);
+      } catch (e) {
+        res.send(Buffer.from(file));
+      }
     } else {
       res.status(404);
       res.send('File not found');


### PR DESCRIPTION
We're trying to parse data as JSON and if we're able to do that - we're calling `res.send()` with the object and it automatically set `Content-Type: application/json`. 