### PR TITLE
Tiles traverser: do not check for visibility in `canTraverse`.

### DIFF
--- a/modules/tiles/src/tileset/tileset-traverser.ts
+++ b/modules/tiles/src/tileset/tileset-traverser.ts
@@ -250,12 +250,7 @@ export class TilesetTraverser {
   // tile should be visible
   // tile should have children
   // tile LoD (level of detail) is not sufficient under current viewport
-  canTraverse(
-    tile: Tile3D,
-    frameState: FrameState,
-    useParentMetric: boolean = false,
-    ignoreVisibility: boolean = false
-  ): boolean {
+  canTraverse(tile: Tile3D, frameState: FrameState): boolean {
     if (!tile.hasChildren) {
       return false;
     }
@@ -267,11 +262,7 @@ export class TilesetTraverser {
       return !tile.contentExpired;
     }
 
-    if (!ignoreVisibility && !tile.isVisibleAndInRequestVolume) {
-      return false;
-    }
-
-    return this.shouldRefine(tile, frameState, useParentMetric);
+    return this.shouldRefine(tile, frameState);
   }
 
   shouldLoadTile(tile: Tile3D): boolean {
@@ -338,7 +329,7 @@ export class TilesetTraverser {
     while (stack.length > 0) {
       const tile = stack.pop();
 
-      const traverse = !tile.hasRenderContent && this.canTraverse(tile, frameState, false, false);
+      const traverse = !tile.hasRenderContent && this.canTraverse(tile, frameState);
       const emptyLeaf = !tile.hasRenderContent && tile.children.length === 0;
 
       // Traversal stops but the tile does not have content yet


### PR DESCRIPTION
Hi!
Yet another fix for tile traversal. Bug was noticed while traveling in Google's 3D Tiles.
The `canTraverse` function should not check for visibility in the traversal process, as [shown in the CesiumJS code](https://github.com/CesiumGS/cesium/blob/cbd13cee0959d2de6e01f355dd1cd73342467102/packages/engine/Source/Scene/Cesium3DTilesetTraversal.js#L58-L68). Probably there are cases where a parent in the traversal process is not visible, but the child tile is.
Here is how it looked before the fix:
![canTraverse-bug](https://github.com/visgl/loaders.gl/assets/39962/5ec598f5-b7dd-443e-b145-503c079eb6a7)
And here is how it looks after:
![canTraverse-fix](https://github.com/visgl/loaders.gl/assets/39962/ae77e86e-179d-452d-8dea-a43e72966f2b)
Possibly, this functionality existed previously via the `ignoreVisibility` argument. Now I removed both optional arguments from `canTraverse` since they are not used.

If approved, would it be possible to merge this PR to the current stable branch?

Thank you,
/Avner
