### PR TITLE
fix(mvt): Add mvt-worker.js bundle to exports path

### DIFF
--- a/docs/developer-guide/using-worker-loaders.md
+++ b/docs/developer-guide/using-worker-loaders.md
@@ -57,11 +57,11 @@ async function loadWithoutWorker(url1) {
 
 ## Disabling Reuse of Workers
 
-Applications reuse already created workers by default. To avoid `enlarge memory arrays` error it is really nesessary to disable it if you need to load multiple datasets in a sequence.
+Applications reuse already created workers by default. To avoid `enlarge memory arrays` error it is really necessary to disable it if you need to load multiple datasets in a sequence.
 This functionality can be disabled by `reuseWorkers: false` option:
 
 ```typescript
-async function loadwWithoutWorker(url1) {
+async function loadWithoutWorker(url1) {
   const data = await load(url1, DracoLoader, {worker: true, reuseWorkers: false});
 }
 ```
@@ -70,7 +70,7 @@ async function loadwWithoutWorker(url1) {
 
 Concurrency - The `options.maxConcurrency` and `option.maxMobileConcurrency` options can be adjusted to define how many worker instances should be created for each format. Note that setting this higher than roughly the number CPU cores on your current machine will not provide much benefit and may create extra overhead.
 
-Worker reuse - Workers threads can occupy memoery and
+Worker reuse - Workers threads can occupy memory and
 
 ## ArrayBuffer Neutering
 
@@ -80,17 +80,26 @@ Most applications will not need to do further processing on the raw binary data 
 
 ## Specifying Worker Script URLs (Advanced)
 
-In JavaScript, worker threads are loaded from separate scripts files and are typically not part of the main application bundle. For ease-of-use, loaders.gl provides a default set of pre-built worker threads which are published on loaders.gl npm distribution from `unpck.com` CDN (Content Delivery Network).
+In JavaScript, worker threads are loaded from separate scripts files and are typically not part of the main application bundle. For ease-of-use, loaders.gl provides a default set of pre-built worker threads which are published on loaders.gl npm distribution from `unpkg.com` CDN (Content Delivery Network).
 
 As an advanced option, it is possible to for application to specify alternate URLs for loading a pre-built worker loader instance.
 
 This can be useful e.g. when building applications that cannot access CDNs or when creating highly customized application builds, or doing in-depth debugging.
 
+```typescript
+/**
+ * For instance, with vite.
+ * 
+ * https://vitejs.dev/guide/assets.html#explicit-url-imports
+ */
+import mvtLoaderUrl from '@loaders.gl/mvt/mvt-worker.js?url';
+```
+
 ## Composite Loaders and Workers (Advanced)
 
 loaders.gl supports sub-loader invocation from worker loaders.
 
-A worker loader starts a seperate thread with a javascript bundle that only contains the code for that loader, so a worker loader needs to call the main thread (and indirectly, potentially another worker thread with another worrker loader) to parse using a sub-loader, properly transferring data into and back from the other thread.
+A worker loader starts a separate thread with a javascript bundle that only contains the code for that loader, so a worker loader needs to call the main thread (and indirectly, potentially another worker thread with another worker loader) to parse using a sub-loader, properly transferring data into and back from the other thread.
 
 ## Debugging Worker Loaders (Advanced)
 

--- a/modules/mvt/package.json
+++ b/modules/mvt/package.json
@@ -26,6 +26,9 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./mvt-worker.js": {
+      "import": "./dist/mvt-worker.js"
     }
   },
   "sideEffects": false,


### PR DESCRIPTION
Ref #3034 

This MR exports the bundled worker package via `@loaders.gl/mvt/mvt-worker.js`.

I've also added an example with `vite`, and fixed a bunch of typos.