### PR TITLE
(chore): Implement package.json#packageManager field

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,5 +61,6 @@
   "volta": {
     "node": "18.19.0",
     "yarn": "4.2.2"
-  }
+  },
+  "packageManager": "yarn@4.2.2+sha512.c44e283c54e02de9d1da8687025b030078c1b9648d2895a65aab8e64225bfb7becba87e1809fc0b4b6778bbd47a1e2ab6ac647de4c5e383a53a7c17db6c3ff4b"
 }


### PR DESCRIPTION
Corepack appears to be the emerging tool to pin a specific package manager version.

Corepack is now distributed with node, and uses the `package.json#packageManager` field : https://nodejs.org/api/packages.html#packagemanager

This PR adds the `packageManager` field, aligned with `volta.yarn`.