### PR TITLE
fix(tile-converter): Added flag to size calculation

### DIFF
--- a/modules/tile-converter/src/i3s-converter/i3s-converter.ts
+++ b/modules/tile-converter/src/i3s-converter/i3s-converter.ts
@@ -1526,7 +1526,11 @@ export default class I3SConverter {
     const addRefinementPercentage = tilesWithAddRefineCount
       ? (tilesWithAddRefineCount / tilesCount) * 100
       : 0;
-    const filesSize = await calculateDatasetSize({...params, slpk: true});
+    const filesSize = await calculateDatasetSize({
+      outputPath: params.outputPath,
+      tilesetName: params.tilesetName,
+      slpk: true
+    });
     const diff = process.hrtime(this.conversionStartTime);
     const conversionTime = timeConverter(diff);
     console.log('------------------------------------------------'); // eslint-disable-line no-undef, no-console

--- a/modules/tile-converter/src/i3s-converter/i3s-converter.ts
+++ b/modules/tile-converter/src/i3s-converter/i3s-converter.ts
@@ -1526,7 +1526,7 @@ export default class I3SConverter {
     const addRefinementPercentage = tilesWithAddRefineCount
       ? (tilesWithAddRefineCount / tilesCount) * 100
       : 0;
-    const filesSize = await calculateDatasetSize(params);
+    const filesSize = await calculateDatasetSize({...params, slpk: true});
     const diff = process.hrtime(this.conversionStartTime);
     const conversionTime = timeConverter(diff);
     console.log('------------------------------------------------'); // eslint-disable-line no-undef, no-console


### PR DESCRIPTION
Addition to the previous fix, we need this flag because calculation for one-file dataset isn't a default behaviour now