### PR TITLE
fix(tile-converter): Fix according to new NodeJS security limitations

### DIFF
--- a/modules/tile-converter/src/deps-installer/deps-installer.ts
+++ b/modules/tile-converter/src/deps-installer/deps-installer.ts
@@ -87,14 +87,21 @@ export class DepsInstaller {
     console.log('Installing "join-images" npm package');
     const childProcess = new ChildProcessProxy();
     const nodeDir = dirname(process.execPath);
+    let spaceEscape = '\\ ';
+    let npmBinaryName = 'npm';
+    if (process.platform === 'win32') {
+      spaceEscape = '^ ';
+      npmBinaryName = 'npm.cmd';
+    }
     await childProcess.start({
-      command: `${nodeDir}/${process.platform === 'win32' ? 'npm.cmd' : 'npm'}`,
+      command: `${nodeDir.replaceAll(' ', spaceEscape)}/${npmBinaryName}`,
       // `npm install sharp join-images` works unstable. It fails because installed `sharp` version
       // may be different from the version required by `join-images`. Pointing to specific versions
       // resolve this issue
       arguments: ['install', 'sharp@0.30.4', 'join-images@1.1.3'],
       wait: 0,
-      ignoreStderr: true
+      ignoreStderr: true,
+      spawn: {shell: true}
     });
 
     console.log('All dependencies were installed succesfully.'); // eslint-disable-line no-console

--- a/modules/tile-converter/src/deps-installer/deps-installer.ts
+++ b/modules/tile-converter/src/deps-installer/deps-installer.ts
@@ -87,14 +87,8 @@ export class DepsInstaller {
     console.log('Installing "join-images" npm package');
     const childProcess = new ChildProcessProxy();
     const nodeDir = dirname(process.execPath);
-    let spaceEscape = '\\ ';
-    let npmBinaryName = 'npm';
-    if (process.platform === 'win32') {
-      spaceEscape = '^ ';
-      npmBinaryName = 'npm.cmd';
-    }
     await childProcess.start({
-      command: `${nodeDir.replaceAll(' ', spaceEscape)}/${npmBinaryName}`,
+      command: `"${nodeDir}/${process.platform === 'win32' ? 'npm.cmd' : 'npm'}"`,
       // `npm install sharp join-images` works unstable. It fails because installed `sharp` version
       // may be different from the version required by `join-images`. Pointing to specific versions
       // resolve this issue

--- a/modules/worker-utils/src/lib/process-utils/child-process-proxy.ts
+++ b/modules/worker-utils/src/lib/process-utils/child-process-proxy.ts
@@ -22,7 +22,7 @@ export type ChildProcessProxyProps = {
   /** wait: 0 - infinity */
   wait?: number;
   /** Options passed on to Node'.js `spawn` */
-  spawn?: any; // ChildProcess.SpawnOptionsWithoutStdio;
+  spawn?: ChildProcess.SpawnOptions;
   /** Should proceed if stderr stream recieved data */
   ignoreStderr?: boolean;
   /** Callback when the  */


### PR DESCRIPTION
Fix according to new NodeJS security limitations: https://stackoverflow.com/questions/78420489/error-when-running-npm-script-with-yarn-err-spawn-einval