### PR TITLE
fix(parquet): ParquetLoader worker: false

### DIFF
--- a/modules/parquet/src/parquet-loader.ts
+++ b/modules/parquet/src/parquet-loader.ts
@@ -54,7 +54,7 @@ export const ParquetWorkerLoader = {
   id: 'parquet',
   module: 'parquet',
   version: VERSION,
-  worker: true,
+  worker: false,
   category: 'table',
   extensions: ['parquet'],
   mimeTypes: ['application/octet-stream'],


### PR DESCRIPTION
parquet-loader-worker.js is not built because of CommonJS relationships in code. Make the loader to work without worker by default