### PR TITLE
fix: sizeSum calculation + rgb parsing

### DIFF
--- a/modules/pcd/src/lib/parse-pcd.ts
+++ b/modules/pcd/src/lib/parse-pcd.ts
@@ -240,20 +240,17 @@ function parsePCDHeader(data: string): PCDHeader {
   pcdHeader.offset = {};
 
   let sizeSum = 0;
-  if (pcdHeader.fields !== null && pcdHeader.size !== null) {
-    for (let i = 0; i < pcdHeader.fields.length; i++) {
-      if (pcdHeader.data === 'ascii') {
-        pcdHeader.offset[pcdHeader.fields[i]] = i;
-      } else {
-        pcdHeader.offset[pcdHeader.fields[i]] = sizeSum;
-        sizeSum += pcdHeader.size[i];
-      }
+  for (let i = 0, l = pcdHeader.fields.length; i < l; i++) {
+    if (pcdHeader.data === 'ascii') {
+      pcdHeader.offset[pcdHeader.fields[i]] = i;
+    } else {
+      pcdHeader.offset[pcdHeader.fields[i]] = sizeSum;
+      sizeSum += pcdHeader.size[i] * pcdHeader.count[i];
     }
   }
 
   // for binary only
   pcdHeader.rowSize = sizeSum;
-
   return pcdHeader;
 }
 


### PR DESCRIPTION
## Description

1. **rowSize calculation**
I tried to drop-in replace our `PCDLoader` with the `@loaders.gl` version, but I noticed a difference in the `rowSize` calculation for `binary` PCD's. When comparing to our version which was based on the threejs [example](https://github.com/mrdoob/three.js/blob/dev/examples/jsm/loaders/PCDLoader.js), I noticed a [difference](https://github.com/mrdoob/three.js/blob/1a1e0a45b2e7b331f04e567821a1b30eb0d032ab/examples/jsm/loaders/PCDLoader.js#L198C4-L213C5) in the calculation. Replacing it with that implementation makes this loader work for me as well.

2. **RGB calculation**
In the original three implementation, color need to be normalized between 0 and 1 by dividing by `255.0`. Also the order of RGB needed to be reversed (BGR). This didn't happen for the `binary` version and the order was also wrong for the `binary_compressed` version.

I'll provide 2 binary PCD's that were broken in the original implementation, that are now fixed.

[pcd.zip](https://github.com/user-attachments/files/17161683/pcd.zip)

