### PR TITLE
getIonAssetMetadata struct changed (options.url)

### DIFF
--- a/modules/3d-tiles/src/lib/ion/ion.ts
+++ b/modules/3d-tiles/src/lib/ion/ion.ts
@@ -24,7 +24,8 @@ export async function getIonTilesetMetadata(accessToken, assetId) {
   // Step 2: Query metdatadata for this asset.
   const ionAssetMetadata = await getIonAssetMetadata(accessToken, assetId);
   const type = ionAssetMetadata.type;
-  const url = ionAssetMetadata.options?.url;
+  // As of Oct 2024 ion service now returns the resource URL in an options object
+  const url = ionAssetMetadata.options?.url || ionAssetMetadata.url;
   assert(type === '3DTILES' && url);
 
   // Prepare a headers object for fetch

--- a/modules/3d-tiles/src/lib/ion/ion.ts
+++ b/modules/3d-tiles/src/lib/ion/ion.ts
@@ -23,12 +23,13 @@ export async function getIonTilesetMetadata(accessToken, assetId) {
 
   // Step 2: Query metdatadata for this asset.
   const ionAssetMetadata = await getIonAssetMetadata(accessToken, assetId);
-  const {type, url} = ionAssetMetadata;
+  const type = ionAssetMetadata.type;
+  const url = ionAssetMetadata.options?.url;
   assert(type === '3DTILES' && url);
 
   // Prepare a headers object for fetch
   ionAssetMetadata.headers = {
-    Authorization: `Bearer ${ionAssetMetadata.accessToken}`
+    Authorization: `Bearer ${accessToken}`
   };
   return ionAssetMetadata;
 }

--- a/modules/3d-tiles/src/lib/ion/ion.ts
+++ b/modules/3d-tiles/src/lib/ion/ion.ts
@@ -29,7 +29,8 @@ export async function getIonTilesetMetadata(accessToken, assetId) {
 
   // Prepare a headers object for fetch
   ionAssetMetadata.headers = {
-    Authorization: `Bearer ${accessToken}`
+    // Use provided accessToken if a new token is not provided in the ion response
+    Authorization: `Bearer ${ionAssetMetadata.accessToken || accessToken}`
   };
   return ionAssetMetadata;
 }


### PR DESCRIPTION
It appears Cesium Ion has changed the return value of ${CESIUM_ION_URL}/${assetId}, when getting metadata from CesiumIonLoader.preload.  Now this value has the url inside options.url instead of the top level. 

This also puts the correct bearer token inside the metadata headers, coming from the input arg instead of what is returned by the query to the cesium ion api.