### PR TITLE
fix(tile-converter): Returning --slpk for backward compatibility

### DIFF
--- a/modules/tile-converter/src/converter-cli.ts
+++ b/modules/tile-converter/src/converter-cli.ts
@@ -395,6 +395,10 @@ function parseOptions(args: string[]): TileConversionOptions {
         case '--help':
           printHelp();
           break;
+        // we need this option for backward compatibility
+        // do nothing but don't throw the error
+        case '--slpk':
+          break;
         default:
           console.warn(`Unknown option ${arg}`);
           process.exit(0); // eslint-disable-line


### PR DESCRIPTION
Currently tile-converter will just stop if it found `--slpk` option so we need to ignore it in order to keep backward compatibility. We're  also going to make 4.3.1 version with this fix