### PR TITLE
feat(mvt): Flatten MVT parser logic

### DIFF
--- a/modules/mvt/src/lib/pojo-parser/mvt-constants.ts
+++ b/modules/mvt/src/lib/pojo-parser/mvt-constants.ts
@@ -1,0 +1,135 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
+/**
+ * MVT spec constants
+ * @see https://github.com/mapbox/vector-tile-spec/blob/master/2.1/README.md
+ */
+export enum TileInfo {
+  /** repeated Layer */
+  layers = 3
+}
+
+/**
+ * MVT spec constants
+ * @see https://github.com/mapbox/vector-tile-spec/blob/master/2.1/README.md
+ * @note Layers are described in section 4.1 of the specification
+ */
+export enum LayerInfo {
+  /**
+   * Any compliant implementation must first read the version
+   * number encoded in this message and choose the correct
+   * implementation for this version number before proceeding to
+   * decode other parts of this message.
+   * required uint32  [ default = 1 ];
+   */
+  version = 15,
+
+  /** PBF: required string */
+  name = 1,
+
+  /** The actual features in this tile.
+   * PBF: repeated Feature
+   */
+  features = 2,
+
+  /**
+   * Dictionary encoding for keys
+   * PBF: repeated string
+   */
+  keys = 3,
+
+  /**
+   * Dictionary encoding for values
+   * PBF: repeated Value
+   */
+  values = 4,
+
+  /**
+   * Although this is an "optional" field it is required by the specification.
+   * See https://github.com/mapbox/vector-tile-spec/issues/47
+   * PBF: optional uint32 [ default = 4096 ];
+   */
+  extent = 5
+
+  // extensions 16 to max;
+}
+
+/**
+ * @see https://github.com/mapbox/vector-tile-spec/blob/master/2.1/README.md
+ * Features are described in section 4.2 of the specification
+ */
+export enum FeatureInfo {
+  /** optional uint64 [ default = 0 ]; */
+  id = 1,
+
+  /**
+   * Tags of this feature are encoded as repeated pairs of integers.
+   * A detailed description of tags is located in sections 4.2 and 4.4 of the specification
+   * repeated uint32  [ packed = true ];
+   */
+  tags = 2,
+
+  /**
+   * The type of geometry stored in this feature.
+   * GeomType  [ default = UNKNOWN ];
+   */
+  type = 3,
+
+  /**
+   * Contains a stream of commands and parameters (vertices).
+   * A detailed description on geometry encoding is located in
+   * section 4.3 of the specification.
+   * repeated uint32  [ packed = true ];
+   */
+  geometry = 4
+}
+
+/**
+ * GeomType is described in section 4.3.4 of the specification
+ * @see https://github.com/mapbox/vector-tile-spec/blob/master/2.1/README.md
+ * */
+export enum GeometryType {
+  UNKNOWN = 0,
+  POINT = 1,
+  LINESTRING = 2,
+  POLYGON = 3
+}
+
+/**
+ * Variant type encoding
+ * The use of values is described in section 4.1 of the specification
+ * @note Exactly one of these values must be present in a valid message
+ * @see https://github.com/mapbox/vector-tile-spec/blob/master/2.1/README.md
+ */
+export enum PropertyType {
+  /** string */
+  string_value = 1, //
+  /** float */
+  float_value = 2,
+  /** double */
+  double_value = 3,
+  /** int64 */
+  int_value = 4,
+  /** uint64 */
+  uint_value = 5,
+  /** sint64 */
+  sint_value = 6,
+  /** bool */
+  bool_value = 7
+  // extensions 8 to max;
+}
+
+/**
+ * "Turtle graphics" style geometry commands
+ * @see https://github.com/mapbox/vector-tile-spec/blob/master/2.1/README.md
+ */
+export enum Command {
+  /** 2 Parameters: dX, dY */
+  MoveTo = 1,
+  /** 2 Parameters dX, dY */
+  LineTo = 2,
+  /** No parameters */
+  ClosePath = 7
+}

--- a/modules/mvt/src/lib/pojo-parser/mvt-types.ts
+++ b/modules/mvt/src/lib/pojo-parser/mvt-types.ts
@@ -1,0 +1,34 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
+import type {Schema, GeojsonGeometryInfo} from '@loaders.gl/schema';
+
+export type MVTTile = {
+  layers: Record<string, MVTLayer>;
+};
+
+export type MVTLayer = {
+  version: number;
+  name: string;
+  extent: number;
+  length: number;
+  schema: Schema;
+  columns: Record<string, (string | number | boolean | null)[]>;
+  geometryColumn: unknown[];
+  idColumn: number[];
+  geometryTypeColumn: number[];
+};
+
+export interface MVTFeature {
+  id: number | null;
+  type: number;
+  properties: Record<string, string | number | boolean | null>;
+  extent: any;
+
+  // Temporary values used when building up the feature
+  _geometryPos: number;
+  _keys: string[];
+  _values: (string | number | boolean | null)[];
+  _geometryInfo: GeojsonGeometryInfo;
+}

--- a/modules/mvt/src/lib/pojo-parser/parse-mvt-from-pbf.ts
+++ b/modules/mvt/src/lib/pojo-parser/parse-mvt-from-pbf.ts
@@ -1,0 +1,288 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
+// This code is inspired by https://github.com/mapbox/vector-tile-js under BSD 3-clause license.
+
+import Protobuf from 'pbf';
+import {Schema} from '@loaders.gl/schema';
+import type {MVTTile, MVTLayer} from './mvt-types';
+import * as MVT from './mvt-constants';
+
+export type MVTLayerData = {
+  /** Layer being built */
+  layer: MVTLayer;
+  currentFeature: number;
+  /** list of all keys in layer: Temporary, used when building up the layer */
+  keys: string[];
+  /** single list of all values in all columns - Temporary values used when building up the layer */
+  values: (string | number | boolean | null)[];
+  types: number[];
+  columnTypes: number[];
+  columnNullable: boolean[],
+  /** list of all feature start positions in the PBF - Temporary values used when building up the layer */
+  featurePositions: number[];
+  /** list of all geometry start positions in the PBF - Temporary values used when building up the layer */
+  geometryPositions: number[];
+};
+
+const DEFAULT_LAYER = {
+  version: 1,
+  name: '',
+  extent: 4096,
+  length: 0,
+  schema: {fields: [], metadata: {}},
+  columns: {},
+  idColumn: [],
+  geometryTypeColumn: [],
+  geometryColumn: []
+} as const satisfies MVTLayer;
+
+const DEFAULT_LAYER_DATA = {
+  currentFeature: 0,
+  keys: [],
+  values: [],
+  types: [],
+  columnTypes: [],
+  columnNullable: [],
+  featurePositions: [],
+  geometryPositions: []
+};
+
+/** Parse an MVT tile from an ArrayBuffer */
+export function parseMVT(arrayBuffer: ArrayBuffer | Uint8Array): MVTTile {
+  const pbf = new Protobuf(arrayBuffer);
+  return parseMVTTile(pbf);
+}
+
+/** Parse an MVT tile from a PBF buffer */
+export function parseMVTTile(pbf: Protobuf, end?: number): MVTTile {
+  const tile = {layers: {}} satisfies MVTTile;
+  try {
+    pbf.readFields(readTileFieldFromPBF, tile, end);
+  } catch (error) {
+    console.warn(error);
+  }
+  return tile;
+}
+
+/**
+ * Protobuf read callback for a top-level tile object's PBF tags
+ * @param tag
+ * @param layers
+ * @param pbf
+ */
+function readTileFieldFromPBF(tag: number, tile?: MVTTile, pbf?: Protobuf): void {
+  if (!pbf || !tile) {
+    return;
+  }
+
+  switch (tag as MVT.TileInfo) {
+    case MVT.TileInfo.layers:
+      // get the byte length and end of the layer
+      const byteLength = pbf.readVarint();
+      const end = byteLength + pbf.pos;
+
+      const layer = parseLayer(pbf, end);
+      tile.layers[layer.name] = layer;
+      break;
+    default:
+    // ignore? log?
+  }
+}
+
+/** Parse an MVT layer from BPF at current position */
+export function parseLayer(pbf: Protobuf, end: number): MVTLayer {
+  const layerData: MVTLayerData = {layer: {...DEFAULT_LAYER}, ...DEFAULT_LAYER_DATA};
+  pbf.readFields(readLayerFieldFromPBF, layerData, end);
+
+  // Read features
+  for (let featureIndex = 0; featureIndex < layerData.featurePositions.length; featureIndex++) {
+    // Determine start and end of feature in PBF
+    const featurePosition = layerData.featurePositions[featureIndex];
+
+    pbf.pos = featurePosition;
+    const byteLength = pbf.readVarint();
+    const end = byteLength + pbf.pos;
+
+    layerData.currentFeature = featureIndex;
+    pbf.readFields(readFeatureFieldFromPBF, layerData, end);
+  }
+
+  // Post processing
+  const {layer} = layerData;
+  layer.length = layerData.featurePositions.length;
+  layer.schema = makeMVTSchema(layerData);
+  return layer;
+}
+
+/**
+ *
+ * @param tag
+ * @param layer
+ * @param pbf
+ */
+function readLayerFieldFromPBF(tag: number, layerData?: MVTLayerData, pbf?: Protobuf): void {
+  if (!layerData || !pbf) {
+    return;
+  }
+
+  switch (tag as MVT.LayerInfo) {
+    case MVT.LayerInfo.version:
+      layerData.layer.version = pbf.readVarint();
+      break;
+    case MVT.LayerInfo.name:
+      layerData.layer.name = pbf.readString();
+      break;
+    case MVT.LayerInfo.extent:
+      layerData.layer.extent = pbf.readVarint();
+      break;
+    case MVT.LayerInfo.features:
+      layerData.featurePositions.push(pbf.pos);
+      break;
+    case MVT.LayerInfo.keys:
+      layerData.keys.push(pbf.readString());
+      break;
+    case MVT.LayerInfo.values:
+      const [value, type] = parseValues(pbf);
+      layerData.values.push(value);
+      layerData.types.push(type);
+      break;
+    default:
+    // ignore? Log?
+  }
+}
+
+/**
+ * @param pbf
+ * @returns value
+ */
+function parseValues(pbf: Protobuf): [string | number | boolean | null, MVT.PropertyType] {
+  const end = pbf.readVarint() + pbf.pos;
+
+  let value: string | number | boolean | null = null;
+  // @ts-expect-error
+  let type: MVT.PropertyType = 0;
+
+  // TODO - can we have multiple values?
+  while (pbf.pos < end) {
+    // @ts-expect-error
+    if (type !== 0) {
+      throw new Error('MVT: Multiple values not supported');
+    }
+    type = pbf.readVarint() >> 3;
+    value = readValueFromPBF(pbf, type);
+  }
+  return [value, type];
+}
+
+/** Read a type tagged value from the protobuf at current position */
+function readValueFromPBF(pbf: Protobuf, type: MVT.PropertyType): string | number | boolean | null {
+  switch (type) {
+    case MVT.PropertyType.string_value:
+      return pbf.readString();
+    case MVT.PropertyType.float_value:
+      return pbf.readFloat();
+    case MVT.PropertyType.double_value:
+      return pbf.readDouble();
+    case MVT.PropertyType.int_value:
+      return pbf.readVarint64();
+    case MVT.PropertyType.uint_value:
+      return pbf.readVarint();
+    case MVT.PropertyType.sint_value:
+      return pbf.readSVarint();
+    case MVT.PropertyType.bool_value:
+      return pbf.readBoolean();
+    default:
+      return null;
+  }
+}
+
+/**
+ *
+ * @param tag
+ * @param feature
+ * @param pbf
+ */
+function readFeatureFieldFromPBF(tag: number, layerData?: MVTLayerData, pbf?: Protobuf): void {
+  if (!pbf || !layerData) {
+    return;
+  }
+  switch (tag as MVT.FeatureInfo) {
+    case MVT.FeatureInfo.id:
+      const id = pbf.readVarint();
+      layerData.layer.idColumn[layerData.currentFeature] = id;
+      break;
+    case MVT.FeatureInfo.tags:
+      parseColumnValues(pbf, layerData);
+      break;
+    case MVT.FeatureInfo.type:
+      const type = pbf.readVarint();
+      layerData.layer.geometryTypeColumn[layerData.currentFeature] = type;
+      break;
+    case MVT.FeatureInfo.geometry:
+      layerData.geometryPositions[layerData.currentFeature] = pbf.pos;
+      break;
+    default:
+    // ignore? log?
+  }
+}
+
+/**
+ *
+ * @param pbf
+ * @param feature
+ */
+function parseColumnValues(pbf: Protobuf, layerData: MVTLayerData): void {
+  const end = pbf.readVarint() + pbf.pos;
+
+  while (pbf.pos < end) {
+    const keyIndex = pbf.readVarint();
+    const valueIndex = pbf.readVarint();
+    const columnName = layerData.keys[keyIndex];
+    const value = layerData.values[valueIndex];
+    layerData.columnTypes[columnName] = layerData.types[valueIndex];
+    layerData.columnNullable[columnName] ||= value === null;
+
+    layerData.layer.columns[columnName] ||= [];
+    layerData.layer.columns[columnName].push(value);
+  }
+}
+
+// Schema Builder
+
+function makeMVTSchema(layerData: MVTLayerData): Schema {
+  const {keys, columnTypes, columnNullable} = layerData;
+  const fields: Schema['fields'] = [];
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    const nullable = columnNullable[key];
+    switch (columnTypes[key] as MVT.PropertyType) {
+      case MVT.PropertyType.string_value:
+        fields.push({name: keys[i], type: 'utf8', nullable});
+        break;
+      case MVT.PropertyType.float_value:
+        fields.push({name: keys[i], type: 'float32', nullable});
+        break;
+      case MVT.PropertyType.double_value:
+        fields.push({name: keys[i], type: 'float64', nullable});
+        break;
+      case MVT.PropertyType.int_value:
+        fields.push({name: keys[i], type: 'int32', nullable});
+        break;
+      case MVT.PropertyType.uint_value:
+        fields.push({name: keys[i], type: 'uint32', nullable});
+        break;
+      case MVT.PropertyType.sint_value:
+        fields.push({name: keys[i], type: 'int32', nullable});
+        break;
+      case MVT.PropertyType.bool_value:
+        fields.push({name: keys[i], type: 'bool', nullable});
+        break;
+      default:
+      // ignore?
+    }
+  }
+
+  return {fields, metadata: {}};
+}

--- a/modules/mvt/test/index.ts
+++ b/modules/mvt/test/index.ts
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
+import './lib/parse-mvt-from-pbf.spec';
+
 // geojson-vt
 import './lib/vector-tiler/clip-features.spec';
 import './lib/vector-tiler/simplify-path.spec';

--- a/modules/mvt/test/lib/parse-mvt-from-pbf.spec.ts
+++ b/modules/mvt/test/lib/parse-mvt-from-pbf.spec.ts
@@ -1,0 +1,351 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+// import type {BinaryFeatureCollection} from '@loaders.gl/schema';
+import test from 'tape-promise/tape';
+import {parseMVT} from '../../src/lib/pojo-parser/parse-mvt-from-pbf';
+import {setLoaderOptions, fetchFile} from '@loaders.gl/core';
+// import {geojsonToBinary, binaryToGeojson} from '@loaders.gl/gis';
+
+const MVT_POINTS_DATA_URL = '@loaders.gl/mvt/test/data/mvt/points_4-2-6.mvt';
+// const MVT_LINES_DATA_URL = '@loaders.gl/mvt/test/data/mvt/lines_2-2-1.mvt';
+// const MVT_POLYGONS_DATA_URL = '@loaders.gl/mvt/test/data/mvt/polygons_10-133-325.mvt';
+// const MVT_POLYGON_ZERO_SIZE_HOLE_DATA_URL =
+//   '@loaders.gl/mvt/test/data/mvt/polygon_with_zero_size_hole.mvt';
+// const MVT_MULTIPLE_LAYERS_DATA_URL =
+//   '@loaders.gl/mvt/test/data/mvt/lines_10-501-386_multiplelayers.mvt';
+// const WITH_FEATURE_ID = '@loaders.gl/mvt/test/data/mvt/with_feature_id.mvt';
+
+// Test to sanity check that old method of parsing binary
+// format via an intermediate geojson step produces the
+// same result
+// const TEST_FILES = [
+//   MVT_POINTS_DATA_URL,
+//   MVT_LINES_DATA_URL,
+//   MVT_POLYGONS_DATA_URL,
+//   MVT_POLYGON_ZERO_SIZE_HOLE_DATA_URL,
+//   MVT_MULTIPLE_LAYERS_DATA_URL
+// ];
+
+// Geometry Array Results
+
+// /// GeoJSON Results
+// import decodedPolygonsGeometry from '@loaders.gl/mvt/test/data/mvt-results/decoded_mvt_polygons_array.json' assert {type: 'json'};
+
+// // GeoJSON Results
+// import decodedPointsGeoJSON from '@loaders.gl/mvt/test/data/mvt-results/decoded_mvt_points.json' assert {type: 'json'};
+// import decodedLinesGeoJSON from '@loaders.gl/mvt/test/data/mvt-results/decoded_mvt_lines.json' assert {type: 'json'};
+// import decodedPolygonsGeoJSON from '@loaders.gl/mvt/test/data/mvt-results/decoded_mvt_polygons.json' assert {type: 'json'};
+
+// setLoaderOptions({
+//   _workerType: 'test'
+// });
+
+test('Point MVT to local coordinates JSON', async (t) => {
+  const response = await fetchFile(MVT_POINTS_DATA_URL);
+  const mvtArrayBuffer = await response.arrayBuffer();
+
+  const tile = await parseMVT(mvtArrayBuffer);
+
+  t.deepEqual(tile.layers.layer0.length, 1, 'layer0 has 1 feature');
+  // t.deepEqual(tile.layers.layer0.idColumn[0], 1, 'idColumn is 1');
+  t.deepEqual(tile.layers.layer0.geometryTypeColumn[0], 1, 'geometryTypeColumn is 1');
+  t.deepEqual(tile.layers.layer0.columns.cartodb_id[0], 3, 'cartodb_id is 3');
+  t.deepEqual(tile.layers.layer0.columns._cdb_feature_count[0], 1, '_cdb_feature_count is 1');
+  t.deepEqual(
+    tile.layers.layer0.schema.fields,
+    [
+      {name: 'cartodb_id', type: 'uint32', nullable: false},
+      {name: '_cdb_feature_count', type: 'uint32', nullable: false}
+    ],
+    'schema fields are correct'
+  );
+
+  //   {
+  //     type: 'Feature',
+  //     geometry: {
+  //       type: 'Point',
+  //       coordinates: [0.5576171875, 0.185546875]
+  //     },
+  //     properties: {
+  //       // eslint-disable-next-line camelcase
+  //       cartodb_id: 3,
+  //       // eslint-disable-next-line camelcase
+  //       _cdb_feature_count: 1,
+  //       layerName: 'layer0'
+  //     }
+  //   }
+  // ]);
+
+  t.end();
+});
+
+// test('Line MVT to local coordinates JSON', async (t) => {
+//   const response = await fetchFile(MVT_LINES_DATA_URL);
+//   const mvtArrayBuffer = await response.arrayBuffer();
+
+//   const geometryJSON = await parse(mvtArrayBuffer, MVTLoader);
+//   t.deepEqual(geometryJSON, [
+//     {
+//       type: 'Feature',
+//       geometry: {
+//         type: 'LineString',
+//         coordinates: [
+//           [-0.00390625, 0.48876953125],
+//           [0.0009765625, 0.490234375]
+//         ]
+//       },
+//       properties: {
+//         // eslint-disable-next-line camelcase
+//         cartodb_id: 1,
+//         layerName: 'layer0'
+//       }
+//     }
+//   ]);
+
+//   t.end();
+// });
+
+// test('Polygon MVT to local coordinates JSON', async (t) => {
+//   const response = await fetchFile(MVT_POLYGONS_DATA_URL);
+//   const mvtArrayBuffer = await response.arrayBuffer();
+
+//   const geometryJSON = await parse(mvtArrayBuffer, MVTLoader);
+//   t.deepEqual(geometryJSON, decodedPolygonsGeometry);
+
+//   t.end();
+// });
+
+// test('MVTLoader#Parse Point MVT', async (t) => {
+//   for (const binary of [true, false]) {
+//     const outputFormat = binary ? 'binary' : 'geojson';
+//     const response = await fetchFile(MVT_POINTS_DATA_URL);
+//     const mvtArrayBuffer = await response.arrayBuffer();
+
+//     const loaderOptions: MVTLoaderOptions = {
+//       mvt: {
+//         coordinates: 'wgs84',
+//         tileIndex: {
+//           x: 2,
+//           y: 6,
+//           z: 4
+//         }
+//       }
+//     };
+//     if (binary) {
+//       loaderOptions.gis = {format: 'binary'};
+//     }
+
+//     loaderOptions.worker = false;
+//     const geometry = await parse(mvtArrayBuffer, MVTLoader, loaderOptions);
+//     let expected = decodedPointsGeoJSON;
+//     if (binary) {
+//       // @ts-ignore
+//       expected = geojsonToBinary(expected);
+//       t.ok(geometry.byteLength > 0);
+//       delete geometry.byteLength;
+//     }
+//     t.deepEqual(geometry, expected, `Parsed Point MVT as ${outputFormat}`);
+//   }
+//   t.end();
+// });
+
+// test('MVTLoader#Parse Lines MVT', async (t) => {
+//   for (const binary of [true, false]) {
+//     const outputFormat = binary ? 'binary' : 'geojson';
+
+//     const response = await fetchFile(MVT_LINES_DATA_URL);
+//     const mvtArrayBuffer = await response.arrayBuffer();
+
+//     const loaderOptions: MVTLoaderOptions = {
+//       mvt: {
+//         coordinates: 'wgs84',
+//         tileIndex: {
+//           x: 2,
+//           y: 1,
+//           z: 2
+//         }
+//       }
+//     };
+//     if (binary) {
+//       loaderOptions.gis = {format: 'binary'};
+//     }
+
+//     const geometry = await parse(mvtArrayBuffer, MVTLoader, loaderOptions);
+//     let expected = decodedLinesGeoJSON;
+//     if (binary) {
+//       // @ts-ignore
+//       expected = geojsonToBinary(expected);
+//       t.ok(geometry.byteLength > 0);
+//       delete geometry.byteLength;
+//     }
+//     t.deepEqual(geometry, expected, `Parsed Lines MVT as ${outputFormat}`);
+//   }
+//   t.end();
+// });
+
+// test('MVTLoader#Parse Polygons MVT', async (t) => {
+//   for (const binary of [true, false]) {
+//     const outputFormat = binary ? 'binary' : 'geojson';
+
+//     const response = await fetchFile(MVT_POLYGONS_DATA_URL);
+//     const mvtArrayBuffer = await response.arrayBuffer();
+
+//     const loaderOptions: MVTLoaderOptions = {
+//       mvt: {
+//         coordinates: 'wgs84',
+//         tileIndex: {
+//           x: 133,
+//           y: 325,
+//           z: 10
+//         }
+//       }
+//     };
+//     if (binary) {
+//       loaderOptions.gis = {format: 'binary'};
+//     }
+
+//     const geometry = await parse(mvtArrayBuffer, MVTLoader, loaderOptions);
+//     let expected = decodedPolygonsGeoJSON;
+//     if (binary) {
+//       // @ts-ignore
+//       expected = geojsonToBinary(expected, {fixRingWinding: false});
+//       t.ok(geometry.byteLength > 0);
+//       delete geometry.byteLength;
+//     }
+//     t.deepEqual(geometry, expected, `Parsed Polygons MVT as ${outputFormat}`);
+//   }
+//   t.end();
+// });
+
+// test('Should raise an error when coordinates param is wgs84 and tileIndex is missing', async (t) => {
+//   const response = await fetchFile(MVT_POINTS_DATA_URL);
+//   const mvtArrayBuffer = await response.arrayBuffer();
+
+//   const loaderOptions: MVTLoaderOptions = {
+//     mvt: {coordinates: 'wgs84'}
+//   };
+
+//   t.throws(() => parseSync(mvtArrayBuffer, MVTLoader, loaderOptions));
+
+//   t.end();
+// });
+
+// test('Should add layer name to custom property', async (t) => {
+//   const response = await fetchFile(MVT_POINTS_DATA_URL);
+//   const mvtArrayBuffer = await response.arrayBuffer();
+
+//   const loaderOptions: MVTLoaderOptions = {
+//     mvt: {layerProperty: 'layerSource'}
+//   };
+
+//   const geometryJSON = await parse(mvtArrayBuffer, MVTLoader, loaderOptions);
+//   t.equals(geometryJSON[0].properties.layerSource, 'layer0');
+
+//   t.end();
+// });
+
+// test('Should return features from selected layers when layers property is provided', async (t) => {
+//   const response = await fetchFile(MVT_MULTIPLE_LAYERS_DATA_URL);
+//   const mvtArrayBuffer = await response.arrayBuffer();
+
+//   const loaderOptions: MVTLoaderOptions = {
+//     mvt: {layers: ['layer1']}
+//   };
+
+//   const geometryJSON = await parse(mvtArrayBuffer, MVTLoader, loaderOptions);
+//   const anyFeatureFromAnotherLayer = geometryJSON.some(
+//     (feature) => feature.properties.layerName !== 'layer1'
+//   );
+//   t.false(anyFeatureFromAnotherLayer);
+//   t.equals(geometryJSON[0].properties.layerName, 'layer1');
+
+//   t.end();
+// });
+
+// test('Polygon MVT to local coordinates binary', async (t) => {
+//   const response = await fetchFile(MVT_POLYGONS_DATA_URL);
+//   const mvtArrayBuffer = await response.arrayBuffer();
+
+//   const geometryBinary = await parse(mvtArrayBuffer, MVTLoader, {gis: {format: 'binary'}});
+//   t.ok(geometryBinary.byteLength > 0);
+//   delete geometryBinary.byteLength;
+
+//   // @ts-ignore deduced type of 'Feature' is string...
+//   const expectedBinary = geojsonToBinary(decodedPolygonsGeometry);
+//   t.deepEqual(geometryBinary, expectedBinary);
+//   t.end();
+// });
+
+// test('MVTLoader#Parse geojson-to-binary', async (t) => {
+//   for (const filename of TEST_FILES) {
+//     const response = await fetchFile(filename);
+//     const mvtArrayBuffer = await response.arrayBuffer();
+//     const geojson = await parse(mvtArrayBuffer, MVTLoader);
+
+//     // Pass a fresh response otherwise get CI testing errors
+//     const response2 = await fetchFile(filename);
+//     const mvtArrayBuffer2 = await response2.arrayBuffer();
+//     const binary = await parse(mvtArrayBuffer2, MVTLoader, {gis: {format: 'binary'}});
+//     delete binary.byteLength;
+
+//     const expectedBinary = geojsonToBinary(geojson);
+//     t.deepEqual(expectedBinary, binary);
+//   }
+//   t.end();
+// });
+
+// test('Features with top-level id', async (t) => {
+//   const response = await fetchFile(WITH_FEATURE_ID);
+//   const mvtArrayBuffer = await response.arrayBuffer();
+
+//   const binary = await parse(mvtArrayBuffer, MVTLoader, {mvt: {shape: 'binary'}});
+//   t.ok(binary.points.fields.length, 'feature.id fields are preserved');
+//   t.ok(binary.lines.fields.length, 'feature.id fields are preserved');
+//   t.ok(binary.polygons.fields.length, 'feature.id fields are preserved');
+
+//   const feature = binaryToGeojson(binary, {
+//     globalFeatureId: binary.points.globalFeatureIds.value[0]
+//   });
+//   // @ts-ignore
+//   t.ok(feature.id, 'feature.id is restored');
+
+//   t.end();
+// });
+
+// test('Empty MVT must return empty binary format', async (t) => {
+//   const emptyMVTArrayBuffer = new Uint8Array();
+//   const geometryBinary = await parse(emptyMVTArrayBuffer, MVTLoader, {gis: {format: 'binary'}});
+//   t.ok(geometryBinary.points);
+//   t.ok(geometryBinary.lines);
+//   t.ok(geometryBinary.polygons);
+//   t.ok(geometryBinary.points.positions.size === 2);
+//   t.ok(geometryBinary.lines.positions.size === 2);
+//   t.ok(geometryBinary.polygons.positions.size === 2);
+
+//   t.end();
+// });
+
+// test('Triangulation is supported', async (t) => {
+//   const response = await fetchFile(MVT_POLYGONS_DATA_URL);
+//   const mvtArrayBuffer = await response.arrayBuffer();
+//   const geometry = await parse(mvtArrayBuffer, MVTLoader, {
+//     gis: {format: 'binary'}
+//   });
+
+//   // Closed polygon with 31 vertices (0===30)
+//   t.ok(geometry.polygons.positions);
+//   t.equals(geometry.polygons.positions.value.length, 62);
+
+//   t.ok(geometry.polygons.triangles);
+//   t.equals(geometry.polygons.triangles.value.length, 84);
+
+//   // Basic check that triangulation is valid
+//   const minI = Math.min(...geometry.polygons.triangles.value);
+//   const maxI = Math.max(...geometry.polygons.triangles.value);
+//   t.equals(minI, 0);
+//   t.equals(maxI, 29); // Don't expect to find 30 as closed polygon
+
+//   t.end();
+// });

--- a/modules/schema/src/geometry/flat-geometries.ts
+++ b/modules/schema/src/geometry/flat-geometries.ts
@@ -12,7 +12,32 @@ type RemoveCoordinatesField<Type> = {
   [Property in keyof Type as Exclude<Property, 'coordinates'>]: Type[Property];
 };
 
-/** Generic flat geometry data storage type */
+/**
+ * Generic flat geometry data storage type
+ * (an intermediate "Flat GeoJSON"
+ * data format, which maps closely to the binary data buffers.
+ * It is similar to GeoJSON, but rather than storing the coordinates
+ * in multidimensional arrays, we have a 1D `data` with all the
+ * coordinates, and then index into this using the `indices`
+ * parameter
+ *
+ * Thus the indices member lets us look up the relevant range
+ * from the data array.
+ * The Multi* versions of the above types share the same data
+ * structure, just with multiple elements in the indices array
+ *
+ * @example
+ *
+ * geometry: {
+ *   type: 'Point', data: [1,2], indices: [0]
+ * }
+ * geometry: {
+ *   type: 'LineString', data: [1,2,3,4,...], indices: [0]
+ * }
+ * geometry: {
+ *   type: 'Polygon', data: [1,2,3,4,...], indices: [[0, 2]]
+ * }
+ */
 export type FlatIndexedGeometry = {
   data: number[];
   indices: number[];


### PR DESCRIPTION
- Move MVT PBF parsing logic out of the VectorTile classes to simplify for GeoArrow conversion.