### PR TITLE
Make @types/brotli also optional

### DIFF
--- a/modules/compression/package.json
+++ b/modules/compression/package.json
@@ -52,7 +52,6 @@
   "dependencies": {
     "@loaders.gl/loader-utils": "4.4.0-alpha.0",
     "@loaders.gl/worker-utils": "4.4.0-alpha.0",
-    "@types/brotli": "^1.3.0",
     "@types/pako": "^1.0.1",
     "fflate": "0.7.4",
     "lzo-wasm": "^0.0.4",
@@ -60,6 +59,7 @@
     "snappyjs": "^0.6.1"
   },
   "optionalDependencies": {
+    "@types/brotli": "^1.3.0",
     "brotli": "^1.3.2",
     "lz4js": "^0.2.0",
     "zstd-codec": "^0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4761,6 +4761,8 @@ __metadata:
   peerDependencies:
     "@loaders.gl/core": 4.4.0-alpha.0
   dependenciesMeta:
+    "@types/brotli":
+      optional: true
     brotli:
       optional: true
     lz4js:


### PR DESCRIPTION
The types for `brotli` include a depenency on `@types/node`. For a web-based user of deck.gl, loaders.gl, and which does not use the `brotli` library, this adds the node type globals into the type system. That creates some unfortunate inconsistencies with Web/DOM global types.

Since `brotli` is optional, the types can also be optional so that both can be excluded from environments that don't use them. 