### PR TITLE
perf(las): Bench laz-perf vs laz-rs versions of LasLoader

### DIFF
--- a/modules/las/test/las.bench.ts
+++ b/modules/las/test/las.bench.ts
@@ -1,0 +1,24 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {LAZPerfLoader, LAZRsLoader} from '@loaders.gl/las';
+import {fetchFile, load} from '@loaders.gl/core';
+
+const LAZ_URL = '@loaders.gl/las/test/data/indoor.laz';
+// const GEO_PARQUET_URL = '@loaders.gl/parquet/test/data/geoparquet/airports.parquet';
+
+export async function lazBench(suite) {
+  suite.group('ParquetLoader');
+
+  const response = await fetchFile(LAZ_URL);
+  const arrayBuffer = await response.arrayBuffer();
+
+  suite.addAsync('load(LAZPerfLoader) - LAZ load', {multiplier: 40000, unit: 'rows'}, async () => {
+    await load(arrayBuffer, LAZPerfLoader, {worker: false});
+  });
+
+  suite.addAsync('load(LAZRsLoader) - LAZ load', {multiplier: 40000, unit: 'rows'}, async () => {
+    await load(arrayBuffer, LAZRsLoader, {worker: false});
+  });
+}

--- a/modules/las/test/las.bench.ts
+++ b/modules/las/test/las.bench.ts
@@ -6,19 +6,18 @@ import {LAZPerfLoader, LAZRsLoader} from '@loaders.gl/las';
 import {fetchFile, load} from '@loaders.gl/core';
 
 const LAZ_URL = '@loaders.gl/las/test/data/indoor.laz';
-// const GEO_PARQUET_URL = '@loaders.gl/parquet/test/data/geoparquet/airports.parquet';
 
 export async function lazBench(suite) {
-  suite.group('ParquetLoader');
+  suite.group('LasLoader');
 
   const response = await fetchFile(LAZ_URL);
   const arrayBuffer = await response.arrayBuffer();
 
-  suite.addAsync('load(LAZPerfLoader) - LAZ load', {multiplier: 40000, unit: 'rows'}, async () => {
+  suite.addAsync('load(LAZPerfLoader) - LAZ load', {}, async () => {
     await load(arrayBuffer, LAZPerfLoader, {worker: false});
   });
 
-  suite.addAsync('load(LAZRsLoader) - LAZ load', {multiplier: 40000, unit: 'rows'}, async () => {
+  suite.addAsync('load(LAZRsLoader) - LAZ load', {}, async () => {
     await load(arrayBuffer, LAZRsLoader, {worker: false});
   });
 }

--- a/test/bench/modules.js
+++ b/test/bench/modules.js
@@ -14,6 +14,7 @@ import dracoBench from '@loaders.gl/draco/test/draco.bench';
 import excelBench from '@loaders.gl/excel/test/excel.bench';
 import imageBench from '@loaders.gl/images/test/images.bench';
 import jsonBench from '@loaders.gl/json/test/json-loader.bench';
+import {lazBench} from '@loaders.gl/las/test/las.bench';
 // import mvtBench from '@loaders.gl/mvt/test/mvt-loader.bench';
 import {parquetBench} from '@loaders.gl/parquet/test/parquet.bench';
 // import shapefileBench from '@loaders.gl/shapefile/test/shapefile.bench';
@@ -42,6 +43,7 @@ export async function addModuleBenchmarksToSuite(suite) {
   await dracoBench(suite);
   await csvBench(suite);
   await excelBench(suite);
+  await lazBench(suite);
 
   // await i3sLoaderBench(suite);
 }


### PR DESCRIPTION
Continuation of #3168 
Start of perf testing of two different las versions.
I've added a bench to load the .laz file from the test folder.

I am having problems running it locally, `yarn test bench` fails on the parquet bench, and `yarn test bench-browser` does not run the bench at all, running tests in the browser instead. Do you run `bench` often? Is it possible that it is broken? Or is it a local setup issue?