### PR TITLE
fix(3d-tiles): fix loading tilesets with `availableLevels` = `1` in the implicit tiling scheme

### DIFF
--- a/modules/3d-tiles/src/lib/parsers/helpers/parse-3d-implicit-tiles.ts
+++ b/modules/3d-tiles/src/lib/parsers/helpers/parse-3d-implicit-tiles.ts
@@ -136,7 +136,7 @@ export async function parseImplicitTiles(params: {
   } = implicitOptions;
   const tile = {children: [], lodMetricValue: 0, contentUrl: ''};
 
-  if (!maximumLevel) {
+  if (maximumLevel === undefined) {
     log.once(
       `Missing 'maximumLevel' or 'availableLevels' property. The subtree ${contentUrlTemplate} won't be loaded...`
     );


### PR DESCRIPTION
Fixes #3193 