### PR TITLE
docs: Update GeoPackage options shape

### DIFF
--- a/docs/modules/geopackage/api-reference/geopackage-loader.md
+++ b/docs/modules/geopackage/api-reference/geopackage-loader.md
@@ -45,7 +45,7 @@ To load a specific table named `feature_table` in a geopackage file as GeoJSON:
 ```typescript
 const optionsAsGeoJson: GeoPackageLoaderOptions = {
   geopackage: {
-    shape: 'geojson',
+    shape: 'geojson-table',
     table: 'feature_table',
     sqlJsCDN: 'https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.5.0/'
   }


### PR DESCRIPTION
'geojson' is not supported according to the `GeoPackageLoader` type while `geojson-table` is. I've updated the docs to reflect this.