### PR TITLE
Fixes typo in PMTiles API Reference doc

### DIFF
--- a/docs/modules/pmtiles/api-reference/pmtiles-source.md
+++ b/docs/modules/pmtiles/api-reference/pmtiles-source.md
@@ -16,7 +16,7 @@ The `PMTilesSource` reads individual tiles from a PMTiles archive file.
 ## Usage
 
 ```typescript
-import {createDataSource} from '@loaders.gl/pmtiles';
+import {createDataSource} from '@loaders.gl/core';
 import {PMTilesSource} from '@loaders.gl/pmtiles';
 
 const source = createDataSource(url, [PMTilesSource]);


### PR DESCRIPTION
It does not appear that `createDataSource` is exported by the `pmtiles` module. In comparing it to other examples, it should be from `core`.