### PR TITLE
Remove lzo-wasm dependency and references

### DIFF
--- a/modules/compression/package.json
+++ b/modules/compression/package.json
@@ -54,7 +54,6 @@
     "@loaders.gl/worker-utils": "4.4.0-alpha.2",
     "@types/pako": "^1.0.1",
     "fflate": "0.7.4",
-    "lzo-wasm": "^0.0.4",
     "pako": "1.0.11",
     "snappyjs": "^0.6.1"
   },

--- a/modules/compression/src/lib/lzo-compression.ts
+++ b/modules/compression/src/lib/lzo-compression.ts
@@ -3,18 +3,10 @@
 // Copyright (c) vis.gl contributors
 
 // LZO
-// import {loadLibrary} from '@loaders.gl/worker-utils';
 import {registerJSModules, getJSModule, toBuffer} from '@loaders.gl/loader-utils';
 
 import type {CompressionOptions} from './compression';
 import {Compression} from './compression';
-// import {isBrowser} from '@loaders.gl/loader-utils';
-
-// import lzo from 'lzo'; // https://bundlephobia.com/package/lzo
-// import {decompress} from 'lzo-wasm';
-
-// const LZO_WASM_JS_URL = './node_modules/lzo-wasm/lzo-wasm.js';
-// const LZO_WASM_WASM_URL = './node_modules/lzo-wasm/lzo-wasm.wasm';
 
 /**
  * Lempel-Ziv-Oberheimer compression / decompression
@@ -23,7 +15,7 @@ export class LZOCompression extends Compression {
   readonly name = 'lzo';
   readonly extensions = [];
   readonly contentEncodings = [];
-  readonly isSupported = false; // !isBrowser;
+  readonly isSupported = false;
   readonly options: CompressionOptions;
 
   /**
@@ -38,29 +30,19 @@ export class LZOCompression extends Compression {
 
   async preload(modules: Record<string, any> = {}): Promise<void> {
     registerJSModules(modules);
-    // await loadLibrary(LZO_WASM_JS_URL);
-    // await loadLibrary(LZO_WASM_WASM_URL);
   }
 
   async compress(input: ArrayBuffer): Promise<ArrayBuffer> {
     await this.preload();
     const lzo = getJSModule('lzo', this.name);
-    // const inputArray = new Uint8Array(input);
     const inputBuffer = toBuffer(input);
     return lzo.compress(inputBuffer).buffer;
   }
 
   async decompress(input: ArrayBuffer): Promise<ArrayBuffer> {
-    try {
-      await this.preload();
-      const lzo = getJSModule('lzo', this.name);
-      // const inputArray = new Uint8Array(input);
-      const inputBuffer = toBuffer(input);
-      return lzo.decompress(inputBuffer).buffer;
-    } catch (error) {
-      // TODO - solve SharedArrayBuffer issues
-      // return decompress(input);
-      throw error;
-    }
+    await this.preload();
+    const lzo = getJSModule('lzo', this.name);
+    const inputBuffer = toBuffer(input);
+    return lzo.decompress(inputBuffer).buffer;
   }
 }

--- a/modules/compression/test/compression.bench.ts
+++ b/modules/compression/test/compression.bench.ts
@@ -11,7 +11,6 @@ import {
   ZstdCompression,
   SnappyCompression,
   BrotliCompression,
-  LZOCompression,
   CompressionWorker
 } from '@loaders.gl/compression';
 import {getData} from './utils/test-utils';
@@ -19,7 +18,6 @@ import {getData} from './utils/test-utils';
 // import brotli from 'brotli'; - brotli has problems with decompress in browsers
 import brotliDecompress from 'brotli/decompress';
 import lz4js from 'lz4js';
-import lzo from 'lzo';
 import {ZstdCodec} from 'zstd-codec';
 
 // Inject large dependencies through Compression constructor options
@@ -32,7 +30,6 @@ const modules = {
     }
   },
   lz4js,
-  lzo,
   'zstd-codec': ZstdCodec
 };
 


### PR DESCRIPTION
# Remove lzo-wasm dependency and references

## Summary
This PR removes the outdated and unmaintained `lzo-wasm` dependency that was causing security concerns in secure repositories.

## Changes
- Removed `lzo-wasm` from `modules/compression/package.json` dependencies
- Cleaned up commented lzo-wasm imports and references in `lzo-compression.ts`
- Removed lzo references from benchmark tests
- Maintained LZOCompression class structure for potential future injectable module support

## Background
The `lzo-wasm` package (version 0.0.4) was flagged as outdated and unmaintained, causing loaders.gl to be blocked from secure repositories. Analysis of the codebase showed that:

1. The lzo-wasm functionality was already disabled (`isSupported = false`)
2. All imports were commented out
3. No active code paths depend on this library
4. The compression class is designed to work with injectable modules

## Testing
- [x] Verified no active usage of lzo-wasm in codebase
- [x] Confirmed LZOCompression class maintains structure for future module injection
- [x] All lzo-wasm references removed from package.json and source files

## Fixes
Closes #3072

## Type of Change
- [x] Bug fix (removes security vulnerability)
- [x] Dependency cleanup
- [ ] Breaking change
- [ ] New feature
- [ ] Documentation update

## Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Changes generate no new warnings
- [x] No breaking changes to existing functionality
- [x] Issue reference included in commit message
