### PR TITLE
Pass options to DBF sidecar loader

### DIFF
--- a/modules/shapefile/src/dbf-loader.ts
+++ b/modules/shapefile/src/dbf-loader.ts
@@ -12,6 +12,7 @@ const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 export type DBFLoaderOptions = LoaderOptions & {
   dbf?: {
     encoding?: string;
+    shape?: 'rows' | 'table' | 'object-row-table';
     /** Override the URL to the worker bundle (by default loads from unpkg.com) */
     workerUrl?: string;
   };

--- a/modules/shapefile/src/lib/parsers/parse-shapefile.ts
+++ b/modules/shapefile/src/lib/parsers/parse-shapefile.ts
@@ -61,7 +61,10 @@ export async function* parseShapefileInBatches(
       DBFLoader,
       {
         ...options,
-        dbf: {encoding: cpg || 'latin1'}
+        dbf: {
+          ...options?.dbf,
+          encoding: cpg || 'latin1'
+        }
       },
       context!
     );
@@ -147,12 +150,15 @@ export async function parseShapefile(
 
   const dbfResponse = await context?.fetch(replaceExtension(context?.url!, 'dbf'));
   if (dbfResponse?.ok) {
-    propertyTable = await parseFromContext(
-      dbfResponse as any,
-      DBFLoader,
-      {dbf: {shape: 'object-row-table', encoding: cpg || 'latin1'}},
-      context!
-    );
+    const dbfOptions = {
+      ...options,
+      dbf: {
+        ...options?.dbf,
+        shape: 'object-row-table',
+        encoding: cpg || 'latin1'
+      }
+    };
+    propertyTable = await parseFromContext(dbfResponse as any, DBFLoader, dbfOptions, context!);
   }
 
   let features = joinProperties(geojsonGeometries, propertyTable?.data || []);

--- a/modules/shapefile/src/lib/parsers/types.ts
+++ b/modules/shapefile/src/lib/parsers/types.ts
@@ -8,6 +8,8 @@ import type {LoaderOptions} from '@loaders.gl/loader-utils';
 export type SHPLoaderOptions = LoaderOptions & {
   shp?: {
     _maxDimensions?: number;
+    /** Override the URL to the worker bundle (by default loads from unpkg.com) */
+    workerUrl?: string;
   };
 };
 
@@ -15,13 +17,16 @@ export type DBFLoaderOptions = LoaderOptions & {
   dbf?: {
     encoding?: string;
     shape?: 'rows' | 'table' | 'object-row-table';
+    /** Override the URL to the worker bundle (by default loads from unpkg.com) */
+    workerUrl?: string;
   };
 };
 
 export type ShapefileLoaderOptions = LoaderOptions &
-  SHPLoaderOptions & {
+  SHPLoaderOptions &
+  DBFLoaderOptions & {
     shapefile?: {
-      shape?: 'geojson-table';
+      shape?: 'geojson-table' | 'v3';
     };
     gis?: {
       reproject?: boolean;

--- a/modules/shapefile/src/shapefile-loader.ts
+++ b/modules/shapefile/src/shapefile-loader.ts
@@ -4,20 +4,27 @@
 
 import type {LoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';
 import type {Batch, GeoJSONTable} from '@loaders.gl/schema';
-import {SHP_MAGIC_NUMBER} from './shp-loader';
+import {SHP_MAGIC_NUMBER, SHPLoaderOptions} from './shp-loader';
 import {parseShapefile, parseShapefileInBatches} from './lib/parsers/parse-shapefile';
+import {DBFLoaderOptions} from './dbf-loader';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
 const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
-export type ShapefileLoaderOptions = LoaderOptions & {
-  shapefile?: {
-    shape?: 'geojson-table' | 'v3';
-    /** @deprecated Worker URLs must be specified with .dbf.workerUrl * .shp.workerUrl */
-    workerUrl?: never;
+export type ShapefileLoaderOptions = LoaderOptions &
+  SHPLoaderOptions &
+  DBFLoaderOptions & {
+    shapefile?: {
+      shape?: 'geojson-table' | 'v3';
+      /** @deprecated Worker URLs must be specified with .dbf.workerUrl * .shp.workerUrl */
+      workerUrl?: never;
+    };
+    gis?: {
+      reproject?: boolean;
+      _targetCrs?: string;
+    };
   };
-};
 
 /**
  * Shapefile loader

--- a/modules/shapefile/src/shp-loader.ts
+++ b/modules/shapefile/src/shp-loader.ts
@@ -13,7 +13,7 @@ export const SHP_MAGIC_NUMBER = [0x00, 0x00, 0x27, 0x0a];
 
 /** SHPLoader */
 export type SHPLoaderOptions = LoaderOptions & {
-  dbf?: {
+  shp?: {
     _maxDimensions?: number;
     /** Override the URL to the worker bundle (by default loads from unpkg.com) */
     workerUrl?: string;


### PR DESCRIPTION
This fixes https://github.com/visgl/loaders.gl/issues/3219 by ensuring that `options` are passed to the `DBFLoader` for sidecars.  Other loaders were inspected to make sure that they don't have the same issue.  Additionally, `DBFLoaderOptions` and `SHPLoaderOptions`, and `ShapefileLoaderOptions`  where updated to be in sync between "modules/shapefile/src/*-loader.ts", and "modules/shapefile/src/lib/parsers/types.ts" (I don't know why they are defined in both places..)