### PR TITLE
chore: bump vite to 7.2.7

### DIFF
--- a/examples-experimental/point-tile-source/package.json
+++ b/examples-experimental/point-tile-source/package.json
@@ -26,6 +26,6 @@
   },
   "devDependencies": {
     "typescript": "^5.3.0",
-    "vite": "^5.0.0"
+    "vite": "^7.2.7"
   }
 }

--- a/examples-experimental/slpk-in-browser/package.json
+++ b/examples-experimental/slpk-in-browser/package.json
@@ -28,6 +28,6 @@
   },
   "devDependencies": {
     "typescript": "^5.3.0",
-    "vite": "^5.0.0"
+    "vite": "^7.2.7"
   }
 }

--- a/examples-experimental/slpk-via-range-requests/package.json
+++ b/examples-experimental/slpk-via-range-requests/package.json
@@ -30,6 +30,6 @@
     "@types/react": "^18.2.75",
     "@types/styled-components": "^5.1.34",
     "typescript": "^5.3.0",
-    "vite": "^5.0.0"
+    "vite": "^7.2.7"
   }
 }

--- a/examples/get-started/bundle-with-vite/package.json
+++ b/examples/get-started/bundle-with-vite/package.json
@@ -14,6 +14,6 @@
   },
   "devDependencies": {
     "typescript": "^5.3.0",
-    "vite": "^5.0.0"
+    "vite": "^7.2.7"
   }
 }

--- a/examples/website/3d-tiles/package.json
+++ b/examples/website/3d-tiles/package.json
@@ -33,6 +33,6 @@
   },
   "devDependencies": {
     "typescript": "^5.3.0",
-    "vite": "^5.0.0"
+    "vite": "^7.2.7"
   }
 }

--- a/examples/website/geospatial/package.json
+++ b/examples/website/geospatial/package.json
@@ -32,6 +32,6 @@
   },
   "devDependencies": {
     "typescript": "^5.3.0",
-    "vite": "^5.0.0"
+    "vite": "^7.2.7"
   }
 }

--- a/examples/website/gltf/package.json
+++ b/examples/website/gltf/package.json
@@ -23,6 +23,6 @@
   },
   "devDependencies": {
     "typescript": "^5.3.0",
-    "vite": "^5.0.0"
+    "vite": "^7.2.7"
   }
 }

--- a/examples/website/i3s-arcgis/package.json
+++ b/examples/website/i3s-arcgis/package.json
@@ -25,6 +25,6 @@
   },
   "devDependencies": {
     "typescript": "^5.3.0",
-    "vite": "^5.0.0"
+    "vite": "^7.2.7"
   }
 }

--- a/examples/website/i3s-building-scene-layer/package.json
+++ b/examples/website/i3s-building-scene-layer/package.json
@@ -35,6 +35,6 @@
   },
   "devDependencies": {
     "typescript": "^5.3.0",
-    "vite": "^5.0.0"
+    "vite": "^7.2.7"
   }
 }

--- a/examples/website/i3s-colorization-by-attributes/package.json
+++ b/examples/website/i3s-colorization-by-attributes/package.json
@@ -27,6 +27,6 @@
   },
   "devDependencies": {
     "typescript": "^5.3.0",
-    "vite": "^5.0.0"
+    "vite": "^7.2.7"
   }
 }

--- a/examples/website/i3s-picking/package.json
+++ b/examples/website/i3s-picking/package.json
@@ -34,6 +34,6 @@
   },
   "devDependencies": {
     "typescript": "^5.3.0",
-    "vite": "^5.0.0"
+    "vite": "^7.2.7"
   }
 }

--- a/examples/website/pointcloud/package.json
+++ b/examples/website/pointcloud/package.json
@@ -27,6 +27,6 @@
   },
   "devDependencies": {
     "typescript": "^5.3.0",
-    "vite": "^5.0.0"
+    "vite": "^7.2.7"
   }
 }

--- a/examples/website/textures/package.json
+++ b/examples/website/textures/package.json
@@ -22,6 +22,6 @@
   },
   "devDependencies": {
     "typescript": "^5.4.3",
-    "vite": "^5.0.0"
+    "vite": "^7.2.7"
   }
 }

--- a/examples/website/tiles/package.json
+++ b/examples/website/tiles/package.json
@@ -31,6 +31,6 @@
   },
   "devDependencies": {
     "typescript": "^5.3.0",
-    "vite": "^5.0.0"
+    "vite": "^7.2.7"
   }
 }

--- a/examples/website/wms/package.json
+++ b/examples/website/wms/package.json
@@ -29,6 +29,6 @@
   },
   "devDependencies": {
     "typescript": "^5.0.0",
-    "vite": "^5.0.0"
+    "vite": "^7.2.7"
   }
 }


### PR DESCRIPTION
## Summary
- bump Vite devDependency to ^7.2.7 across example package.json files

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d6563a3988328975f96f8ea31c8c4)