### PR TITLE
chore: Run CI on node 24,22,20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        node-version: [22]
+        node-version: [20, 22, 24]
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Ensure loaders.gl works on all Node LTS releases.