### PR TITLE
Split website build into separate CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,11 +47,38 @@ jobs:
         run: |
           yarn run lint
 
-      - name: Build website
-        run: |
-          cd website; yarn build
-  
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  website-build:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        node-version: [22]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node (with Corepack)
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: |
+          yarn run build
+
+      - name: Build website
+        run: |
+          cd website; yarn build


### PR DESCRIPTION
## Summary
- separate website build into its own CI job running alongside tests
- keep core test and coverage steps in main test job

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ed6d2f10c832885aeb55a1be34980)