### PR TITLE
Add Yarn cache to test workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,14 +19,34 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Enable Corepack
-        run: corepack enable
-
       - name: Setup Node (with Corepack)
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'yarn' # or 'pnpm', 'npm' depending on your package manager
+
+      - name: Enable Corepack / Yarn 4
+        run: |
+          corepack enable
+          corepack prepare yarn@4.10.3 --activate
+          yarn -v
+
+      - name: Cache Yarn 4 artifacts
+        id: yarn-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .yarn/cache
+            .pnp.*
+            .yarn/install-state.gz
+          key: yarn-cache-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            yarn-cache-${{ runner.os }}-
+
+      - name: Print versions
+        run: |
+          node -v
+          yarn -v
+          node -p "process.versions"
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -63,14 +83,28 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Enable Corepack
-        run: corepack enable
-
       - name: Setup Node (with Corepack)
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
+
+      - name: Enable Corepack / Yarn 4
+        run: |
+          corepack enable
+          corepack prepare yarn@4.10.3 --activate
+          yarn -v
+
+      - name: Cache website Yarn artifacts
+        id: website-yarn-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            website/.yarn/cache
+            website/.pnp.*
+            website/.yarn/install-state.gz
+          key: website-yarn-cache-${{ runner.os }}-${{ hashFiles('website/yarn.lock') }}
+          restore-keys: |
+            website-yarn-cache-${{ runner.os }}-
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
## Summary
- enable Yarn 4 with Corepack and add cache for Yarn artifacts in the test workflow
- add Yarn caching and version checks to the website build workflow

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ee443e558832895e75c53e865e55c)