### PR TITLE
Refactor thrift helpers to use typed arrays

### DIFF
--- a/modules/parquet/src/parquetjs/encoder/parquet-encoder.ts
+++ b/modules/parquet/src/parquetjs/encoder/parquet-encoder.ts
@@ -638,7 +638,7 @@ function encodeFooter(
   const metadataEncoded = serializeThrift(metadata);
   const footerEncoded = Buffer.alloc(metadataEncoded.length + 8);
 
-  metadataEncoded.copy(footerEncoded);
+  footerEncoded.set(metadataEncoded, 0);
   footerEncoded.writeUInt32LE(metadataEncoded.length, metadataEncoded.length);
   footerEncoded.write(PARQUET_MAGIC, metadataEncoded.length + 4);
   return footerEncoded;

--- a/modules/parquet/src/parquetjs/utils/read-utils.ts
+++ b/modules/parquet/src/parquetjs/utils/read-utils.ts
@@ -23,10 +23,13 @@ export function serializeThrift(obj: any): Uint8Array {
   const output: Buffer[] = [];
 
   const transport = new TBufferedTransport(undefined, (buf?: Buffer) => {
-    if (!buf) {
+    const fallbackBuffers = (transport as any).outBuffers as Buffer[] | undefined;
+    const payload = buf ?? (fallbackBuffers?.length ? Buffer.concat(fallbackBuffers) : undefined);
+
+    if (!payload) {
       return;
     }
-    output.push(toBuffer(buf));
+    output.push(toBuffer(payload));
   });
 
   const protocol = new TCompactProtocol(transport);

--- a/modules/parquet/src/parquetjs/utils/read-utils.ts
+++ b/modules/parquet/src/parquetjs/utils/read-utils.ts
@@ -34,7 +34,11 @@ export function serializeThrift(obj: any): Uint8Array {
 
   const protocol = new TCompactProtocol(transport);
   obj.write(protocol);
-  transport.flush();
+
+  const flushedBuffer = transport.flush();
+  if (!output.length && flushedBuffer) {
+    output.push(toBuffer(flushedBuffer));
+  }
 
   const combinedBuffer = Buffer.concat(output);
   return new Uint8Array(combinedBuffer.buffer, combinedBuffer.byteOffset, combinedBuffer.byteLength);

--- a/modules/parquet/src/parquetjs/utils/read-utils.ts
+++ b/modules/parquet/src/parquetjs/utils/read-utils.ts
@@ -22,7 +22,10 @@ class UFramedTransport extends TFramedTransport {
 export function serializeThrift(obj: any): Uint8Array {
   const output: Buffer[] = [];
 
-  const transport = new TBufferedTransport(undefined, (buf) => {
+  const transport = new TBufferedTransport(undefined, (buf?: Buffer) => {
+    if (!buf) {
+      return;
+    }
     output.push(toBuffer(buf));
   });
 

--- a/modules/parquet/src/polyfills/buffer/buffer.ts
+++ b/modules/parquet/src/polyfills/buffer/buffer.ts
@@ -52,6 +52,10 @@ type BufferEncoding = string;
 export class Buffer extends Uint8Array {
   static poolSize = 8192; // not used by this implementation
 
+  static byteLength(string, encoding?) {
+    return byteLength(string, encoding)
+  }
+
   // length: number; inherited
 
   get parent() {

--- a/modules/parquet/test/parquetjs/thrift.spec.ts
+++ b/modules/parquet/test/parquetjs/thrift.spec.ts
@@ -6,7 +6,7 @@
 import test from 'tape-promise/tape';
 
 import * as parquetThrift from '@loaders.gl/parquet/parquetjs/parquet-thrift';
-import {serializeThrift} from '@loaders.gl/parquet/parquetjs/utils/read-utils';
+import {decodeThrift, serializeThrift} from '@loaders.gl/parquet/parquetjs/utils/read-utils';
 
 // TODO v4 disabled because of Node.js Buffer dependency
 test.skip('thrift#should correctly en/decode literal zeroes with the CompactProtocol', assert => {
@@ -24,5 +24,57 @@ test.skip('thrift#should correctly en/decode literal zeroes with the CompactProt
   // tslint:disable-next-line:variable-name
   const obj_bin = serializeThrift(obj);
   assert.equal(obj_bin.length, 25);
+  assert.end();
+});
+
+test('thrift helpers#should serialize to Uint8Array and decode from typed inputs', assert => {
+  const columnMetadata = new parquetThrift.ColumnMetaData({
+    type: parquetThrift.Type.BOOLEAN,
+    path_in_schema: ['test'],
+    codec: parquetThrift.CompressionCodec.UNCOMPRESSED,
+    encodings: [parquetThrift.Encoding.PLAIN],
+    num_values: 0,
+    total_uncompressed_size: 100,
+    total_compressed_size: 100,
+    data_page_offset: 0
+  });
+
+  const serialized = serializeThrift(columnMetadata);
+  assert.ok(serialized instanceof Uint8Array, 'serializeThrift should return Uint8Array');
+  assert.false(Buffer.isBuffer(serialized), 'serializeThrift should not return Buffer');
+
+  const decodedFromTypedArray = new parquetThrift.ColumnMetaData();
+  const bytesConsumedFromTypedArray = decodeThrift(decodedFromTypedArray, serialized);
+
+  assert.equal(bytesConsumedFromTypedArray, serialized.length, 'decodeThrift returns consumed byte count');
+  assert.equal(decodedFromTypedArray.type, columnMetadata.type);
+  assert.deepEqual(decodedFromTypedArray.path_in_schema, columnMetadata.path_in_schema);
+  assert.equal(decodedFromTypedArray.codec, columnMetadata.codec);
+  assert.deepEqual(decodedFromTypedArray.encodings, columnMetadata.encodings);
+  assert.equal(decodedFromTypedArray.num_values, columnMetadata.num_values);
+  assert.equal(decodedFromTypedArray.total_uncompressed_size, columnMetadata.total_uncompressed_size);
+  assert.equal(decodedFromTypedArray.total_compressed_size, columnMetadata.total_compressed_size);
+  assert.equal(decodedFromTypedArray.data_page_offset, columnMetadata.data_page_offset);
+
+  const paddedBuffer = new Uint8Array(serialized.length + 4);
+  paddedBuffer.set(serialized, 2);
+
+  const decodedFromArrayBuffer = new parquetThrift.ColumnMetaData();
+  const bytesConsumedFromArrayBuffer = decodeThrift(
+    decodedFromArrayBuffer,
+    paddedBuffer.buffer,
+    2
+  );
+
+  assert.equal(bytesConsumedFromArrayBuffer, serialized.length, 'decodeThrift should honor offset');
+  assert.equal(decodedFromArrayBuffer.type, columnMetadata.type);
+  assert.deepEqual(decodedFromArrayBuffer.path_in_schema, columnMetadata.path_in_schema);
+  assert.equal(decodedFromArrayBuffer.codec, columnMetadata.codec);
+  assert.deepEqual(decodedFromArrayBuffer.encodings, columnMetadata.encodings);
+  assert.equal(decodedFromArrayBuffer.num_values, columnMetadata.num_values);
+  assert.equal(decodedFromArrayBuffer.total_uncompressed_size, columnMetadata.total_uncompressed_size);
+  assert.equal(decodedFromArrayBuffer.total_compressed_size, columnMetadata.total_compressed_size);
+  assert.equal(decodedFromArrayBuffer.data_page_offset, columnMetadata.data_page_offset);
+
   assert.end();
 });


### PR DESCRIPTION
## Summary
- update thrift serialization helpers to emit Uint8Array outputs
- accept ArrayBuffer and Uint8Array inputs when decoding thrift structures while keeping buffered transport support
- add typed-array concatenation and buffer conversion helpers for compatibility

## Testing
- yarn lint fix *(fails: missing node_modules state; install blocked by 403 request errors)*
- yarn test node *(fails: missing node_modules state; install blocked by 403 request errors)*
- yarn install *(fails: RequestError 403 fetching packages)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ef1176de0832898123da224a51b52)