### PR TITLE
Move shapefile whats-new note to v4.4 section

### DIFF
--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -6,6 +6,10 @@ Target Release Date: Q1 2025
 
 See the [v4.4 Roadmap](/docs/roadmap) for more details.
 
+**@loaders.gl/shapefile**
+
+- `ShapefileLoader` - Forwards `dbf` loader options (such as `workerUrl`) when loading sidecar files.
+
 ## v4.3
 
 Release Date: October 16, 2024


### PR DESCRIPTION
## Summary
- move shapefile DBF options bullet to the v4.4 (in development) section and place it at the top of the list

## Testing
- yarn install *(fails: RequestError 403 while downloading dependencies)*
- yarn lint fix *(fails: missing node_modules state file after install failure)*
- yarn test node *(fails: missing node_modules state file after install failure)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f4fd1495c832895910777928f5924)