### PR TITLE
docs(core): registerLoaders deprecation notice

### DIFF
--- a/docs/modules/core/api-reference/register-loaders.md
+++ b/docs/modules/core/api-reference/register-loaders.md
@@ -1,8 +1,21 @@
 # registerLoaders
 
+> **Deprecated** — It is recommended that applications manage loader registration explicitly (for example, by passing loaders directly to `load` and `parse`). This function may be removed in loaders.gl v5.
+
 The loader registry allows applications to cherry-pick which loaders to include in their application bundle by importing just the loaders they need and registering them during initialization.
 
-Applications can then make all those imported loaders available (via format autodetection) to all subsequent `parse` and `load` calls, without those calls having to specify which loaders to use.
+Applications can then make all those imported loaders available (via format autodetection) to all subsequent `parse` and `load` calls, without those calls having to specify which loaders to use. Because `registerLoaders()` mutates global state and erases loader types, prefer managing registration in your application code:
+
+```typescript
+// centralize loader registration in your application instead of relying on the global registry
+import {parse} from '@loaders.gl/core';
+import {CSVLoader} from '@loaders.gl/csv';
+
+export const applicationLoaders = [CSVLoader];
+
+// pass the loaders to each call site
+const result = await parse('data.csv', applicationLoaders);
+```
 
 ## Usage
 


### PR DESCRIPTION
Fixes: https://github.com/visgl/loaders.gl/issues/3190

## Summary
- add deprecation note to the registerLoaders() documentation and outline recommended loader management

## Testing
- yarn lint fix *(fails: missing node_modules)*
- yarn install *(fails: registry responded with 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f59331bc8832880241470ed4d3081)