### PR TITLE
Add worker bundles to package exports

### DIFF
--- a/modules/arrow/package.json
+++ b/modules/arrow/package.json
@@ -36,6 +36,9 @@
     "./exports/*": {
       "types": "./dist/exports/*.d.ts",
       "import": "./dist/exports/*.js"
+    },
+    "./arrow-worker.js": {
+      "import": "./dist/arrow-worker.js"
     }
   },
   "sideEffects": false,

--- a/modules/compression/package.json
+++ b/modules/compression/package.json
@@ -29,6 +29,12 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./compression-worker.js": {
+      "import": "./dist/compression-worker.js"
+    },
+    "./compression-worker-node.js": {
+      "import": "./dist/compression-worker-node.js"
     }
   },
   "sideEffects": false,

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -32,6 +32,12 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./null-worker.js": {
+      "import": "./dist/null-worker.js"
+    },
+    "./null-worker-node.js": {
+      "import": "./dist/null-worker-node.js"
     }
   },
   "sideEffects": false,

--- a/modules/crypto/package.json
+++ b/modules/crypto/package.json
@@ -30,6 +30,12 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./crypto-worker.js": {
+      "import": "./dist/crypto-worker.js"
+    },
+    "./crypto-worker-node.js": {
+      "import": "./dist/crypto-worker-node.js"
     }
   },
   "sideEffects": false,

--- a/modules/draco/package.json
+++ b/modules/draco/package.json
@@ -34,6 +34,18 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./draco-worker.js": {
+      "import": "./dist/draco-worker.js"
+    },
+    "./draco-worker-node.js": {
+      "import": "./dist/draco-worker-node.js"
+    },
+    "./draco-writer-worker.js": {
+      "import": "./dist/draco-writer-worker.js"
+    },
+    "./draco-writer-worker-node.js": {
+      "import": "./dist/draco-writer-worker-node.js"
     }
   },
   "sideEffects": false,

--- a/modules/excel/package.json
+++ b/modules/excel/package.json
@@ -29,6 +29,9 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./excel-worker.js": {
+      "import": "./dist/excel-worker.js"
     }
   },
   "sideEffects": false,

--- a/modules/flatgeobuf/package.json
+++ b/modules/flatgeobuf/package.json
@@ -29,6 +29,9 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./flatgeobuf-worker.js": {
+      "import": "./dist/flatgeobuf-worker.js"
     }
   },
   "sideEffects": false,

--- a/modules/i3s/package.json
+++ b/modules/i3s/package.json
@@ -26,6 +26,12 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./i3s-content-worker.js": {
+      "import": "./dist/i3s-content-worker.js"
+    },
+    "./i3s-content-worker-node.js": {
+      "import": "./dist/i3s-content-worker-node.js"
     }
   },
   "sideEffects": false,

--- a/modules/json/package.json
+++ b/modules/json/package.json
@@ -29,6 +29,9 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./geojson-worker.js": {
+      "import": "./dist/geojson-worker.js"
     }
   },
   "sideEffects": false,

--- a/modules/las/package.json
+++ b/modules/las/package.json
@@ -28,6 +28,9 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./las-worker.js": {
+      "import": "./dist/las-worker.js"
     }
   },
   "sideEffects": false,

--- a/modules/lerc/package.json
+++ b/modules/lerc/package.json
@@ -25,6 +25,9 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./lerc-worker.js": {
+      "import": "./dist/lerc-worker.js"
     }
   },
   "sideEffects": false,

--- a/modules/obj/package.json
+++ b/modules/obj/package.json
@@ -27,6 +27,9 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./obj-worker.js": {
+      "import": "./dist/obj-worker.js"
     }
   },
   "sideEffects": false,

--- a/modules/parquet/package.json
+++ b/modules/parquet/package.json
@@ -30,6 +30,9 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./parquet-worker.js": {
+      "import": "./dist/parquet-worker.js"
     }
   },
   "sideEffects": false,

--- a/modules/pcd/package.json
+++ b/modules/pcd/package.json
@@ -27,6 +27,9 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./pcd-worker.js": {
+      "import": "./dist/pcd-worker.js"
     }
   },
   "sideEffects": false,

--- a/modules/ply/package.json
+++ b/modules/ply/package.json
@@ -27,6 +27,9 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./ply-worker.js": {
+      "import": "./dist/ply-worker.js"
     }
   },
   "sideEffects": false,

--- a/modules/shapefile/package.json
+++ b/modules/shapefile/package.json
@@ -26,6 +26,12 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./shp-worker.js": {
+      "import": "./dist/shp-worker.js"
+    },
+    "./dbf-worker.js": {
+      "import": "./dist/dbf-worker.js"
     }
   },
   "sideEffects": false,

--- a/modules/terrain/package.json
+++ b/modules/terrain/package.json
@@ -30,6 +30,9 @@
     },
     "./terrain-worker.js": {
       "import": "./dist/terrain-worker.js"
+    },
+    "./quantized-mesh-worker.js": {
+      "import": "./dist/quantized-mesh-worker.js"
     }
   },
   "sideEffects": false,

--- a/modules/textures/package.json
+++ b/modules/textures/package.json
@@ -30,6 +30,27 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./basis-worker.js": {
+      "import": "./dist/basis-worker.js"
+    },
+    "./basis-worker-node.js": {
+      "import": "./dist/basis-worker-node.js"
+    },
+    "./npy-worker.js": {
+      "import": "./dist/npy-worker.js"
+    },
+    "./compressed-texture-worker.js": {
+      "import": "./dist/compressed-texture-worker.js"
+    },
+    "./crunch-worker.js": {
+      "import": "./dist/crunch-worker.js"
+    },
+    "./ktx2-basis-writer-worker.js": {
+      "import": "./dist/ktx2-basis-writer-worker.js"
+    },
+    "./ktx2-basis-writer-worker-node.js": {
+      "import": "./dist/ktx2-basis-writer-worker-node.js"
     }
   },
   "sideEffects": false,

--- a/modules/wkt/package.json
+++ b/modules/wkt/package.json
@@ -26,6 +26,9 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./wkt-worker.js": {
+      "import": "./dist/wkt-worker.js"
     }
   },
   "sideEffects": false,

--- a/modules/worker-utils/package.json
+++ b/modules/worker-utils/package.json
@@ -24,6 +24,12 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./null-worker.js": {
+      "import": "./dist/null-worker.js"
+    },
+    "./null-worker-node.js": {
+      "import": "./dist/null-worker-node.js"
     }
   },
   "sideEffects": false,


### PR DESCRIPTION
Fixes https://github.com/visgl/loaders.gl/issues/3034

## Summary
- add explicit exports for worker bundles across loader packages so bundlers can resolve local worker files
- include additional worker variants (node/browser) where available to support airgapped deployments

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f588e98cc8328a157a269dd8c7129)