### PR TITLE
Fix GeoJSON loader batch option merging

### DIFF
--- a/modules/json/src/geojson-loader.ts
+++ b/modules/json/src/geojson-loader.ts
@@ -103,7 +103,8 @@ function parseTextSync(
 function parseInBatches(asyncIterator, options): AsyncIterable<TableBatch> {
   // Apps can call the parse method directly, we so apply default options here
   options = {...GeoJSONLoader.options, ...options};
-  options.json = {...GeoJSONLoader.options.geojson, ...options.geojson};
+  options.json = {...GeoJSONLoader.options.json, ...options.json};
+  options.geojson = {...GeoJSONLoader.options.geojson, ...options.geojson};
 
   const geojsonIterator = parseJSONInBatches(asyncIterator, options);
 

--- a/modules/json/test/json-loader.spec.ts
+++ b/modules/json/test/json-loader.spec.ts
@@ -5,7 +5,7 @@
 import test from 'tape-promise/tape';
 import {load, loadInBatches, isIterator, isAsyncIterable} from '@loaders.gl/core';
 import {ObjectRowTableBatch, getTableLength} from '@loaders.gl/schema-utils';
-import {JSONLoader} from '@loaders.gl/json';
+import {JSONLoader, _GeoJSONLoader as GeoJSONLoader} from '@loaders.gl/json';
 
 const GEOJSON_PATH = '@loaders.gl/json/test/data/geojson-big.json';
 const GEOJSON_KEPLER_DATASET_PATH = '@loaders.gl/json/test/data/kepler-dataset-sf-incidents.json';
@@ -102,6 +102,22 @@ test('JSONLoader#loadInBatches(jsonpaths)', async (t) => {
   }
 
   t.equal(rowCount, 0, 'Correct number of row received');
+  t.end();
+});
+
+test('GeoJSONLoader#loadInBatches(jsonpaths)', async (t) => {
+  const iterator = await loadInBatches(GEOJSON_PATH, GeoJSONLoader, {
+    json: {jsonpaths: ['$.features']}
+  });
+
+  let rowCount = 0;
+  for await (const batch of iterator) {
+    rowCount += batch.length;
+    // @ts-ignore
+    t.equal(batch.jsonpath?.toString(), '$.features', 'correct jsonpath on batch');
+  }
+
+  t.equal(rowCount, 308, 'Correct number of row received');
   t.end();
 });
 


### PR DESCRIPTION
Fixes #3028

## Summary
- correct GeoJSON loader batch option merging so JSON options (including jsonpaths) are preserved
- add a regression test ensuring GeoJSON batch streaming respects jsonpaths and streams all features

## Testing
- yarn install (fails: RequestError 403 while fetching dependencies)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f624b61e883288755f62035ad4e8f)