### PR TITLE
Clarify JSONLoader streaming semantics

### DIFF
--- a/docs/modules/json/api-reference/json-loader.md
+++ b/docs/modules/json/api-reference/json-loader.md
@@ -72,6 +72,16 @@ for await (const batch of batches) {
 }
 ```
 
+### Streaming semantics and avoiding truncated arrays
+
+- `JSONLoader` streams rows from a single JSON array. Every `batch.data` entry in a `data` batch is a complete row that the streaming parser has fully parsed before it is emitted.
+- If `{metadata: true}` is set, the loader also yields `partial-result` and `final-result` batches that intentionally exclude the streamed array from `batch.container`. These batches describe only the surrounding container object; the streamed rows remain in the `data` batches.
+
+To avoid confusion when inspecting batches:
+
+1. Consume `batch.data` only when `batch.batchType === 'data'`; metadata batches will appear “incomplete” by design because they omit the streamed array.
+2. If you need the full root object after streaming, enable `{metadata: true}` and merge the streamed `data` rows back into the container object instead of relying on the metadata batches alone.
+
 ## Data Format
 
 Parsed batches are of the format


### PR DESCRIPTION
## Summary
- document JSONLoader streaming semantics and metadata batch behavior
- add guidance on avoiding apparent truncation when consuming streamed JSON batches

## Testing
- yarn install *(fails: registry request 403 response)*
- yarn lint fix *(fails: missing node_modules state file after install failure)*
- yarn test node *(fails: missing node_modules state file after install failure)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f62f854948328a4d320673e8bfd22)