### PR TITLE
test(mvt): validate Tippecanoe TileJSON parsing

### DIFF
--- a/modules/mvt/test/data/tilejson/tippecanoe.expected.json
+++ b/modules/mvt/test/data/tilejson/tippecanoe.expected.json
@@ -1,294 +1,340 @@
 {
-    "name": "output.pmtiles",
-    "format": "pbf",
-    "type": "overlay",
-    "description": "output.pmtiles",
-    "version": "2",
-    "generator": "tippecanoe v2.35.0",
-    "generator_options": "tippecanoe -zg -o output.pmtiles --drop-densest-as-needed input.geojson",
-    "antimeridian_adjusted_bounds": "-150.112222,-51.895278,179.357778,69.604375",
-    "vector_layers": [
-      {
-        "id": "input",
-        "description": "",
-        "minzoom": 0,
-        "maxzoom": 6,
-        "fields": {
-          "add": "Number",
-          "category": "Number",
-          "continent": "String",
-          "disp_scale": "String",
-          "electric": "Number",
-          "featurecla": "String",
-          "mult_track": "Number",
-          "natlscale": "Number",
-          "other_code": "Number",
-          "part": "String",
-          "rwdb_rr_id": "Number",
-          "scalerank": "Number"
-        }
-      }
-    ],
-    "tilestats": {
-      "layerCount": 1,
-      "layers": [
+  "name": "output.pmtiles",
+  "description": "output.pmtiles",
+  "generator": "tippecanoe v2.35.0",
+  "generatorOptions": "tippecanoe -zg -o output.pmtiles --drop-densest-as-needed input.geojson",
+  "boundingBox": [
+    [-150.112222, -51.895278],
+    [179.357778, 69.604375]
+  ],
+  "center": null,
+  "maxZoom": null,
+  "minZoom": null,
+  "layers": [
+    {
+      "name": "input",
+      "description": "",
+      "minZoom": 0,
+      "maxZoom": 6,
+      "dominantGeometry": "LineString",
+      "fields": [
         {
-          "layer": "input",
-          "count": 25413,
-          "geometry": "LineString",
-          "attributeCount": 12,
-          "attributes": [
-            {
-              "attribute": "add",
-              "count": 2,
-              "type": "number",
-              "values": [
-                -1,
-                0
-              ],
-              "min": -1,
-              "max": 0
-            },
-            {
-              "attribute": "category",
-              "count": 7,
-              "type": "number",
-              "values": [
-                0,
-                1,
-                2,
-                3,
-                6,
-                7,
-                9
-              ],
-              "min": 0,
-              "max": 9
-            },
-            {
-              "attribute": "continent",
-              "count": 6,
-              "type": "string",
-              "values": [
-                "Africa",
-                "Asia",
-                "Europe",
-                "North America",
-                "Oceania",
-                "South America"
-              ]
-            },
-            {
-              "attribute": "disp_scale",
-              "count": 6,
-              "type": "string",
-              "values": [
-                "1:10m",
-                "1:20m",
-                "1:3m",
-                "1:40m",
-                "1:5m",
-                "1:80m"
-              ]
-            },
-            {
-              "attribute": "electric",
-              "count": 3,
-              "type": "number",
-              "values": [
-                0,
-                1,
-                2
-              ],
-              "min": 0,
-              "max": 2
-            },
-            {
-              "attribute": "featurecla",
-              "count": 2,
-              "type": "string",
-              "values": [
-                "Railroad",
-                "Railroad ferry"
-              ]
-            },
-            {
-              "attribute": "mult_track",
-              "count": 3,
-              "type": "number",
-              "values": [
-                0,
-                1,
-                2
-              ],
-              "min": 0,
-              "max": 2
-            },
-            {
-              "attribute": "natlscale",
-              "count": 7,
-              "type": "number",
-              "values": [
-                1,
-                10,
-                150,
-                20,
-                40,
-                5,
-                75
-              ],
-              "min": 1,
-              "max": 150
-            },
-            {
-              "attribute": "other_code",
-              "count": 4,
-              "type": "number",
-              "values": [
-                0,
-                1,
-                6,
-                7
-              ],
-              "min": 0,
-              "max": 7
-            },
-            {
-              "attribute": "part",
-              "count": 2,
-              "type": "string",
-              "values": [
-                "ne_1d4_north_america_dup",
-                "ne_global_not_north_america"
-              ]
-            },
-            {
-              "attribute": "rwdb_rr_id",
-              "count": 1000,
-              "type": "number",
-              "values": [
-                0,
-                1,
-                10,
-                100,
-                1000,
-                10000,
-                10001,
-                10002,
-                10003,
-                10004,
-                10005,
-                10006,
-                10007,
-                10008,
-                10009,
-                1001,
-                10010,
-                10011,
-                10012,
-                10013,
-                10014,
-                10015,
-                10016,
-                10017,
-                10018,
-                10019,
-                1002,
-                10020,
-                10021,
-                10022,
-                10023,
-                10024,
-                10025,
-                10026,
-                10027,
-                10028,
-                10029,
-                1003,
-                10030,
-                10031,
-                10032,
-                10033,
-                10034,
-                10035,
-                10036,
-                10037,
-                10038,
-                10039,
-                1004,
-                10040,
-                10041,
-                10042,
-                10043,
-                10044,
-                10045,
-                10046,
-                10047,
-                10048,
-                10049,
-                1005,
-                10050,
-                10051,
-                10052,
-                10053,
-                10054,
-                10055,
-                10056,
-                10057,
-                10058,
-                10059,
-                1006,
-                10060,
-                10061,
-                10062,
-                10063,
-                10064,
-                10065,
-                10066,
-                10067,
-                10068,
-                10069,
-                1007,
-                10070,
-                10071,
-                10072,
-                10073,
-                10074,
-                10075,
-                10076,
-                10077,
-                10078,
-                10079,
-                1008,
-                10080,
-                10081,
-                10082,
-                10083,
-                10084,
-                10085,
-                10086
-              ],
-              "min": 0,
-              "max": 25407
-            },
-            {
-              "attribute": "scalerank",
-              "count": 7,
-              "type": "number",
-              "values": [
-                10,
-                4,
-                5,
-                6,
-                7,
-                8,
-                9
-              ],
-              "min": 4,
-              "max": 10
-            }
+          "name": "add",
+          "type": "float32",
+          "min": -1,
+          "max": 0,
+          "uniqueValueCount": 2,
+          "values": [-1, 0]
+        },
+        {
+          "name": "category",
+          "type": "float32",
+          "min": 0,
+          "max": 9,
+          "uniqueValueCount": 7,
+          "values": [0, 1, 2, 3, 6, 7, 9]
+        },
+        {
+          "name": "continent",
+          "type": "utf8",
+          "uniqueValueCount": 6,
+          "values": ["Africa", "Asia", "Europe", "North America", "Oceania", "South America"]
+        },
+        {
+          "name": "disp_scale",
+          "type": "utf8",
+          "uniqueValueCount": 6,
+          "values": ["1:10m", "1:20m", "1:3m", "1:40m", "1:5m", "1:80m"]
+        },
+        {
+          "name": "electric",
+          "type": "float32",
+          "min": 0,
+          "max": 2,
+          "uniqueValueCount": 3,
+          "values": [0, 1, 2]
+        },
+        {
+          "name": "featurecla",
+          "type": "utf8",
+          "uniqueValueCount": 2,
+          "values": ["Railroad", "Railroad ferry"]
+        },
+        {
+          "name": "mult_track",
+          "type": "float32",
+          "min": 0,
+          "max": 2,
+          "uniqueValueCount": 3,
+          "values": [0, 1, 2]
+        },
+        {
+          "name": "natlscale",
+          "type": "float32",
+          "min": 1,
+          "max": 150,
+          "uniqueValueCount": 7,
+          "values": [1, 10, 150, 20, 40, 5, 75]
+        },
+        {
+          "name": "other_code",
+          "type": "float32",
+          "min": 0,
+          "max": 7,
+          "uniqueValueCount": 4,
+          "values": [0, 1, 6, 7]
+        },
+        {
+          "name": "part",
+          "type": "utf8",
+          "uniqueValueCount": 2,
+          "values": ["ne_1d4_north_america_dup", "ne_global_not_north_america"]
+        },
+        {
+          "name": "rwdb_rr_id",
+          "type": "float32",
+          "min": 0,
+          "max": 25407,
+          "uniqueValueCount": 1000,
+          "values": [
+            0,
+            1,
+            10,
+            100,
+            1000,
+            10000,
+            10001,
+            10002,
+            10003,
+            10004,
+            10005,
+            10006,
+            10007,
+            10008,
+            10009,
+            1001,
+            10010,
+            10011,
+            10012,
+            10013,
+            10014,
+            10015,
+            10016,
+            10017,
+            10018,
+            10019,
+            1002,
+            10020,
+            10021,
+            10022,
+            10023,
+            10024,
+            10025,
+            10026,
+            10027,
+            10028,
+            10029,
+            1003,
+            10030,
+            10031,
+            10032,
+            10033,
+            10034,
+            10035,
+            10036,
+            10037,
+            10038,
+            10039,
+            1004,
+            10040,
+            10041,
+            10042,
+            10043,
+            10044,
+            10045,
+            10046,
+            10047,
+            10048,
+            10049,
+            1005,
+            10050,
+            10051,
+            10052,
+            10053,
+            10054,
+            10055,
+            10056,
+            10057,
+            10058,
+            10059,
+            1006,
+            10060,
+            10061,
+            10062,
+            10063,
+            10064,
+            10065,
+            10066,
+            10067,
+            10068,
+            10069,
+            1007,
+            10070,
+            10071,
+            10072,
+            10073,
+            10074,
+            10075,
+            10076,
+            10077,
+            10078,
+            10079,
+            1008,
+            10080,
+            10081,
+            10082,
+            10083,
+            10084,
+            10085,
+            10086
           ]
+        },
+        {
+          "name": "scalerank",
+          "type": "float32",
+          "min": 4,
+          "max": 10,
+          "uniqueValueCount": 7,
+          "values": [10, 4, 5, 6, 7, 8, 9]
         }
-      ]
+      ],
+      "schema": {
+        "metadata": {
+          "name": "\"input\"",
+          "maxZoom": "6",
+          "dominantGeometry": "\"LineString\""
+        },
+        "fields": [
+          {
+            "name": "add",
+            "type": "float32",
+            "metadata": {
+              "type": "\"float32\"",
+              "min": "-1",
+              "uniqueValueCount": "2",
+              "values": "[-1,0]"
+            }
+          },
+          {
+            "name": "category",
+            "type": "float32",
+            "metadata": {
+              "type": "\"float32\"",
+              "max": "9",
+              "uniqueValueCount": "7",
+              "values": "[0,1,2,3,6,7,9]"
+            }
+          },
+          {
+            "name": "continent",
+            "type": "utf8",
+            "metadata": {
+              "type": "\"utf8\"",
+              "uniqueValueCount": "6",
+              "values": "[\"Africa\",\"Asia\",\"Europe\",\"North America\",\"Oceania\",\"South America\"]"
+            }
+          },
+          {
+            "name": "disp_scale",
+            "type": "utf8",
+            "metadata": {
+              "type": "\"utf8\"",
+              "uniqueValueCount": "6",
+              "values": "[\"1:10m\",\"1:20m\",\"1:3m\",\"1:40m\",\"1:5m\",\"1:80m\"]"
+            }
+          },
+          {
+            "name": "electric",
+            "type": "float32",
+            "metadata": {
+              "type": "\"float32\"",
+              "max": "2",
+              "uniqueValueCount": "3",
+              "values": "[0,1,2]"
+            }
+          },
+          {
+            "name": "featurecla",
+            "type": "utf8",
+            "metadata": {
+              "type": "\"utf8\"",
+              "uniqueValueCount": "2",
+              "values": "[\"Railroad\",\"Railroad ferry\"]"
+            }
+          },
+          {
+            "name": "mult_track",
+            "type": "float32",
+            "metadata": {
+              "type": "\"float32\"",
+              "max": "2",
+              "uniqueValueCount": "3",
+              "values": "[0,1,2]"
+            }
+          },
+          {
+            "name": "natlscale",
+            "type": "float32",
+            "metadata": {
+              "type": "\"float32\"",
+              "min": "1",
+              "max": "150",
+              "uniqueValueCount": "7",
+              "values": "[1,10,150,20,40,5,75]"
+            }
+          },
+          {
+            "name": "other_code",
+            "type": "float32",
+            "metadata": {
+              "type": "\"float32\"",
+              "max": "7",
+              "uniqueValueCount": "4",
+              "values": "[0,1,6,7]"
+            }
+          },
+          {
+            "name": "part",
+            "type": "utf8",
+            "metadata": {
+              "type": "\"utf8\"",
+              "uniqueValueCount": "2",
+              "values": "[\"ne_1d4_north_america_dup\",\"ne_global_not_north_america\"]"
+            }
+          },
+          {
+            "name": "rwdb_rr_id",
+            "type": "float32",
+            "metadata": {
+              "type": "\"float32\"",
+              "max": "25407",
+              "uniqueValueCount": "1000",
+              "values": "[0,1,10,100,1000,10000,10001,10002,10003,10004,10005,10006,10007,10008,10009,1001,10010,10011,10012,10013,10014,10015,10016,10017,10018,10019,1002,10020,10021,10022,10023,10024,10025,10026,10027,10028,10029,1003,10030,10031,10032,10033,10034,10035,10036,10037,10038,10039,1004,10040,10041,10042,10043,10044,10045,10046,10047,10048,10049,1005,10050,10051,10052,10053,10054,10055,10056,10057,10058,10059,1006,10060,10061,10062,10063,10064,10065,10066,10067,10068,10069,1007,10070,10071,10072,10073,10074,10075,10076,10077,10078,10079,1008,10080,10081,10082,10083,10084,10085,10086]"
+            }
+          },
+          {
+            "name": "scalerank",
+            "type": "float32",
+            "metadata": {
+              "type": "\"float32\"",
+              "min": "4",
+              "max": "10",
+              "uniqueValueCount": "7",
+              "values": "[10,4,5,6,7,8,9]"
+            }
+          }
+        ]
+      }
     }
-  }
+  ]
+}

--- a/modules/mvt/test/data/tilejson/tippecanoe.expected.json
+++ b/modules/mvt/test/data/tilejson/tippecanoe.expected.json
@@ -12,10 +12,11 @@
   "minZoom": null,
   "layers": [
     {
+      "id": "input",
       "name": "input",
       "description": "",
-      "minZoom": 0,
-      "maxZoom": 6,
+      "minzoom": 0,
+      "maxzoom": 6,
       "dominantGeometry": "LineString",
       "fields": [
         {
@@ -210,8 +211,9 @@
       ],
       "schema": {
         "metadata": {
+          "id": "\"input\"",
           "name": "\"input\"",
-          "maxZoom": "6",
+          "maxzoom": "6",
           "dominantGeometry": "\"LineString\""
         },
         "fields": [

--- a/modules/mvt/test/data/tilejson/tippecanoe.tilejson
+++ b/modules/mvt/test/data/tilejson/tippecanoe.tilejson
@@ -286,6 +286,17 @@
             ],
             "min": 4,
             "max": 10
+          },
+          {
+            "attribute": "scalerank|0",
+            "count": 2,
+            "type": "number",
+            "values": [
+              4,
+              5
+            ],
+            "min": 4,
+            "max": 5
           }
         ]
       }

--- a/modules/mvt/test/tilejson-loader.spec.ts
+++ b/modules/mvt/test/tilejson-loader.spec.ts
@@ -6,13 +6,14 @@ import {expect, test} from 'vitest';
 import {validateLoader} from 'test/common/conformance';
 
 import {load} from '@loaders.gl/core';
+import {JSONLoader} from '@loaders.gl/json';
 import {TileJSONLoader} from '@loaders.gl/mvt';
 import {parseTileJSON} from '../src/lib/parse-tilejson';
 
 import {TILEJSONS} from './data/tilejson/tilejson';
 
 const TIPPECANOE_TILEJSON = '@loaders.gl/mvt/test/data/tilejson/tippecanoe.tilejson';
-// const TIPPECANOE_EXPECTED = '@loaders.gl/mvt/test/data/tilejson/tippecanoe.expected.json';
+const TIPPECANOE_EXPECTED = '@loaders.gl/mvt/test/data/tilejson/tippecanoe.expected.json';
 
 test('TileJSONLoader#loader conformance', () => {
   validateLoader(TileJSONLoader, 'TileJSONLoader');
@@ -29,17 +30,22 @@ test('TileJSONLoader#load', async () => {
 });
 
 test('TileJSONLoader#tippecanoe', async () => {
-  // let metadata = await load(TIPPECANOE_TILEJSON, TileJSONLoader);
-  // const expected = await load(TIPPECANOE_EXPECTED, JSONLoader);
-  // t.deepEqual(metadata, expected, 'Tippecanoe TileJSON loaded correctly');
-
   let metadata = await load(TIPPECANOE_TILEJSON, TileJSONLoader);
-  expect(metadata.layers?.[0]?.fields?.[10]?.values?.length, '100 unique values').toBe(100);
+  const expected = await load(TIPPECANOE_EXPECTED, JSONLoader);
+  expect(metadata).toEqual(expected);
+
+  const fields = metadata.layers?.[0]?.fields || [];
+  expect(fields.filter(field => field.name.includes('|'))).toEqual([]);
+  expect(metadata.layers?.[0]?.minzoom).toBe(0);
+  expect(metadata.layers?.[0]?.dominantGeometry).toBe('LineString');
+
+  const attributesField = fields.find(field => field.name === 'rwdb_rr_id');
+  expect(attributesField?.values?.length).toBe(100);
 
   metadata = await load(TIPPECANOE_TILEJSON, TileJSONLoader, {tilejson: {maxValues: 10}});
-  expect(metadata.layers?.[0]?.fields?.[10]?.values?.length, 'maxValue clips unique values').toBe(
-    10
-  );
+  const limitedField = metadata.layers?.[0]?.fields?.find(field => field.name === 'rwdb_rr_id');
+  expect(limitedField?.values?.length).toBe(10);
+  expect(limitedField?.values).toEqual(attributesField?.values?.slice(0, 10));
 });
 
 test('parseTileJSON#rejects non-object metadata', () => {


### PR DESCRIPTION
## Goals

- Strengthen Tippecanoe TileJSON regression coverage against the v5 Zod-validated metadata pipeline.
- Verify indexed Tilestats attributes are ignored.
- Verify `tilejson.maxValues` truncates field values without changing their order.

## Changes

- Replays the original two PR commits onto the current v5 `master` baseline.
- Compares the complete parsed Tippecanoe result with `tippecanoe.expected.json`.
- Adds an indexed `scalerank|0` Tilestats fixture and asserts that no indexed field is emitted.
- Checks merged `minzoom` and dominant-geometry metadata.
- Locates the `rwdb_rr_id` field by name and verifies both the default 100 values and the ordered 10-value limit.
- Updates the expected v5 output to include vector-layer `id` metadata preserved by the current parser.

## Validation

- `yarn install`
- `yarn lint fix`
- `yarn build`
- Focused Node coverage: 2 files, 9 tests passed; `tilejson-zod-schema.ts` remains 100% line-covered.
- Focused headless browser: 2 files, 9 tests passed.
