### PR TITLE
feat(mvt): optionally ignore textual tile responses

### DIFF
--- a/docs/modules/mvt/api-reference/mvt-source-loader.md
+++ b/docs/modules/mvt/api-reference/mvt-source-loader.md
@@ -17,7 +17,7 @@ The `MVTSourceLoader` dynamically loads tiles, typically from big pre-tiled hier
 
 ```typescript
 import {createDataSource} from '@loaders.gl/core';
-import {MVTSourceLoader} from '@loaders.gl/pmtiles';
+import {MVTSourceLoader} from '@loaders.gl/mvt';
 
 const source = createDataSource(url, [MVTSourceLoader]);
 const tile = await source.getTile(...);
@@ -25,5 +25,36 @@ const tile = await source.getTile(...);
 
 ## Options
 
-| Option | Type | Default | Description |
-| ------ | ---- | ------- | ----------- |
+| Option                    | Type      | Default | Description                                                                                                                          |
+| ------------------------- | --------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `mvt.ignoreTextResponses` | `boolean` | `false` | If enabled, reports successful responses with text, JSON, or XML MIME types through `core.onError` and returns `null` for those tiles. |
+
+## Empty Tiles and Error Responses
+
+Tile services do not use one universal response for an empty or unavailable tile:
+
+| Service                                                                                                                   | Typical behavior                                                                                                                         |
+| ------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| [Mapbox Vector Tiles API](https://docs.mapbox.com/api/maps/vector-tiles/#vector-tiles-api-errors)                          | Returns `404` for a missing tile and other non-2xx statuses for authentication, request, and rate-limit errors.                           |
+| [ArcGIS Vector Tile Service](https://developers.arcgis.com/rest/services-reference/enterprise/vector-tile/)               | Returns `404` when a tile is not found.                                                                                                   |
+| [TileServer GL](https://github.com/maptiler/tileserver-gl/blob/master/docs/config.rst#data-source-options)                 | By default returns `204 No Content` for a missing vector tile; its `sparse` option changes this to `404`.                                 |
+| [Martin](https://github.com/maplibre/martin/blob/main/integration-tests/tests/geojson.rs)                                  | Returns `204 No Content` for a tile without features.                                                                                     |
+| [pg_tileserv](https://github.com/CrunchyData/pg_tileserv/blob/master/main.go)                                               | Returns `200` with the MVT MIME type and writes the encoded result; an empty result can therefore be a zero-byte binary response.         |
+| [Tegola](https://github.com/go-spatial/tegola/blob/master/server/handle_map_layer_zxy.go)                                  | Returns `200` with MVT bytes for a valid tile and `404` for requests outside the map bounds or without a layer at the requested zoom.     |
+
+`MVTSourceLoader` preserves these normal cases. A `204` or zero-byte successful response is returned as an empty `ArrayBuffer`, while a non-2xx response is reported through `core.onError` and returned as `null`.
+
+Some proxies, authentication gateways, and custom tile services return an HTML, JSON, or XML error document with a successful HTTP status. Enable the defensive MIME-type check for those services:
+
+```typescript
+const source = createDataSource(url, [MVTSourceLoader], {
+  mvt: {
+    ignoreTextResponses: true
+  },
+  core: {
+    onError: error => console.error(error)
+  }
+});
+```
+
+When enabled, the source reports `text/*`, JSON, and XML responses through `core.onError` and returns `null`. It does not reject unrecognized vendor MIME types, because custom services may use them for valid binary tiles. The check is disabled by default to avoid changing behavior for services that use unusual MIME types.

--- a/modules/loader-utils/src/index.ts
+++ b/modules/loader-utils/src/index.ts
@@ -145,6 +145,7 @@ export {
 
 // REQUEST UTILS
 export {default as RequestScheduler} from './lib/request-utils/request-scheduler';
+export {parseContentType} from './lib/request-utils/parse-content-type';
 export {
   RangeRequestScheduler,
   createRangeStats,

--- a/modules/loader-utils/src/lib/request-utils/parse-content-type.ts
+++ b/modules/loader-utils/src/lib/request-utils/parse-content-type.ts
@@ -1,0 +1,22 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/**
+ * Normalize a Content-Type header into a lowercased media type string.
+ * @param contentTypeHeader - Raw Content-Type header value.
+ * @returns Lowercased media type, or null when not available.
+ */
+export function parseContentType(contentTypeHeader?: string | null): string | null {
+  if (!contentTypeHeader) {
+    return null;
+  }
+
+  const trimmedValue = contentTypeHeader.trim();
+  if (!trimmedValue) {
+    return null;
+  }
+
+  const contentType = trimmedValue.split(';')[0]?.trim().toLowerCase();
+  return contentType || null;
+}

--- a/modules/loader-utils/test/index.ts
+++ b/modules/loader-utils/test/index.ts
@@ -18,6 +18,7 @@ import './lib/path-utils/path.spec';
 
 import './lib/request-utils/request-scheduler.spec';
 import './lib/request-utils/range-request-scheduler.node.spec';
+import './lib/request-utils/parse-content-type.spec';
 import './lib/javascript-utils/is-type.spec';
 import './lib/sources/data-source.spec';
 import './lib/sources/data-source-manager.spec';

--- a/modules/loader-utils/test/lib/request-utils/parse-content-type.spec.ts
+++ b/modules/loader-utils/test/lib/request-utils/parse-content-type.spec.ts
@@ -1,0 +1,15 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {parseContentType} from '@loaders.gl/loader-utils';
+import {expect, test} from 'vitest';
+
+test('parseContentType', () => {
+  expect(parseContentType(null)).toBeNull();
+  expect(parseContentType('')).toBeNull();
+  expect(parseContentType('   ')).toBeNull();
+  expect(parseContentType('; charset=utf-8')).toBeNull();
+  expect(parseContentType('text/html; charset=utf-8')).toBe('text/html');
+  expect(parseContentType(' Application/JSON ')).toBe('application/json');
+});

--- a/modules/mvt/src/mvt-source-loader.ts
+++ b/modules/mvt/src/mvt-source-loader.ts
@@ -15,7 +15,7 @@ import type {
   GetTileDataParameters
 } from '@loaders.gl/loader-utils';
 import type {Schema} from '@loaders.gl/schema';
-import {DataSource} from '@loaders.gl/loader-utils';
+import {DataSource, parseContentType} from '@loaders.gl/loader-utils';
 import {
   ImageBitmapLoader,
   type ImageBitmapLoaderOptions,
@@ -40,6 +40,8 @@ export type MVTSourceLoaderOptions = DataSourceOptions & {
     loadOptions?: TileJSONLoaderOptions & MVTLoaderOptions & ImageBitmapLoaderOptions;
     /** Shape of returned vector tile data. */
     shape?: 'geojson-table' | 'columnar-table' | 'binary-geometry' | 'arrow-table';
+    /** Ignore successful HTTP tile responses with text, JSON or XML MIME types, report an error, and return null. */
+    ignoreTextResponses?: boolean;
   };
 };
 
@@ -165,6 +167,20 @@ export class MVTTileSource
       this.reportError(
         new Error(`${response.status} ${response.statusText}`),
         `Failed to fetch tile ${tileUrl} ${JSON.stringify(parameters)}`
+      );
+      return null;
+    }
+    const contentType = parseContentType(response.headers.get('content-type'));
+    const isTextResponse =
+      contentType?.startsWith('text/') ||
+      contentType === 'application/json' ||
+      contentType?.endsWith('+json') ||
+      contentType === 'application/xml' ||
+      contentType?.endsWith('+xml');
+    if (this.options.mvt?.ignoreTextResponses && isTextResponse) {
+      this.reportError(
+        new Error(`Unexpected tile content type ${contentType}`),
+        `Rejected textual response from ${tileUrl}`
       );
       return null;
     }

--- a/modules/mvt/test/mvt-source.spec.ts
+++ b/modules/mvt/test/mvt-source.spec.ts
@@ -6,7 +6,7 @@ import test from 'test/utils/vitest-tape';
 import {isBrowser} from '@loaders.gl/core';
 
 import {TILESETS} from './data/tilesets';
-import {MVTSourceLoader} from '@loaders.gl/mvt';
+import {MVTSourceLoader, MVTTileSource} from '@loaders.gl/mvt';
 import {isURLTemplate, getURLFromTemplate} from '../src/mvt-source-loader';
 
 test('MVTSourceLoader#urls', async t => {
@@ -85,6 +85,84 @@ test('getURLFromTemplate', t => {
   // t.is(getURLFromTemplate([], 1, 2, 0), null, 'empty array');
   t.end();
 });
+
+test('MVTTileSource#getTileData returns null for text/html responses', async t => {
+  const reportedErrors: Error[] = [];
+  const source = makeContentTypeSource('text/html; charset=utf-8', '<html></html>', true, error =>
+    reportedErrors.push(error)
+  );
+
+  const tileData = await source.getTileData({index: {x: 0, y: 0, z: 0}});
+  await source.metadata;
+  t.equal(tileData, null, 'returns null for non-MVT response before parsing');
+  t.ok(
+    reportedErrors.some(error => error.message.includes('Unexpected tile content type text/html')),
+    'reports ignored text through the source error callback'
+  );
+  t.end();
+});
+
+test('MVTTileSource#getTile filters textual errors without rejecting custom binary types', async t => {
+  const textualContentTypes = [
+    'application/json',
+    'application/problem+json',
+    'application/xml',
+    'application/problem+xml'
+  ];
+  for (const contentType of textualContentTypes) {
+    const source = makeContentTypeSource(contentType, '{}', true);
+    const tile = await source.getTile({x: 0, y: 0, z: 0, layers: []});
+    await source.metadata;
+    t.equal(tile, null, `rejects ${contentType}`);
+  }
+
+  const binarySource = makeContentTypeSource(
+    'application/vnd.example.vector-tile',
+    new Uint8Array([1, 2, 3]),
+    true
+  );
+  const binaryTile = await binarySource.getTile({x: 0, y: 0, z: 0, layers: []});
+  await binarySource.metadata;
+  t.deepEqual(Array.from(new Uint8Array(binaryTile!)), [1, 2, 3], 'accepts custom binary types');
+
+  const emptySource = makeContentTypeSource(null, null, false, undefined, 204);
+  const emptyTile = await emptySource.getTile({x: 0, y: 0, z: 0, layers: []});
+  await emptySource.metadata;
+  t.equal(emptyTile?.byteLength, 0, 'returns a 204 empty tile as an empty ArrayBuffer');
+
+  const permissiveSource = makeContentTypeSource('text/plain', 'mislabeled tile');
+  const permissiveTile = await permissiveSource.getTile({x: 0, y: 0, z: 0, layers: []});
+  await permissiveSource.metadata;
+  t.ok(permissiveTile, 'allows textual content types by default');
+  t.end();
+});
+
+/** Creates an MVT source whose tile request returns a controlled content type and payload. */
+function makeContentTypeSource(
+  contentType: string | null,
+  payload: BodyInit | null,
+  ignoreTextResponses = false,
+  onError?: (error: Error) => void,
+  status = 200
+): MVTTileSource {
+  return new MVTTileSource('https://example.com/{z}/{x}/{y}.pbf', {
+    mvt: {ignoreTextResponses},
+    core: {
+      onError,
+      loadOptions: {
+        core: {
+          fetch: async url =>
+            String(url).endsWith('tilejson.json')
+              ? new Response(null, {status: 404})
+              : new Response(payload, {
+                  status,
+                  headers: contentType ? {'content-type': contentType} : undefined
+                })
+        }
+      }
+    }
+  });
+}
 
 // TBA - TILE LOADING TESTS
 


### PR DESCRIPTION
## Goals

- Let MVT sources defensively ignore successful HTTP responses that are clearly text, JSON, or XML instead of attempting to parse error pages as tiles.
- Preserve existing behavior by making the check a positive opt-in.
- Keep empty/no-data tile responses distinct from ignored error documents.
- Centralize Content-Type normalization for reuse.

## Changes

- Adds and exports `parseContentType()` from `@loaders.gl/loader-utils`.
- Adds `mvt.ignoreTextResponses: true` as an opt-in `MVTSourceLoader` option; the default remains `false`.
- When enabled, `MVTTileSource` reports `text/*`, JSON/`+json`, and XML/`+xml` responses through `core.onError` and returns `null`.
- Continues accepting unknown vendor MIME types so custom binary tile services are not rejected.
- Preserves `204 No Content` and zero-byte successful tile responses as empty `ArrayBuffer` values.
- Documents typical behavior for Mapbox, ArcGIS, TileServer GL, Martin, pg_tileserv, and Tegola, including empty-tile and error-response conventions.
- Adds shared Node/headless tests for normalization, opt-in filtering, callback reporting, custom binary MIME types, default behavior, and 204 empty tiles.
- Rebases the original v4 change onto the current v5 `master` source layout.

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn test-node` — 414 files passed, 1,980 tests passed
- `yarn test-headless` — 414 files passed, 1,941 tests passed
- Focused Node coverage run — `parse-content-type.ts` has 100% line and branch coverage
