### PR TITLE
fix(gltf): support variable-length string arrays in EXT_structural_metadata

### DIFF
--- a/modules/gltf/src/lib/extensions/EXT_structural_metadata.ts
+++ b/modules/gltf/src/lib/extensions/EXT_structural_metadata.ts
@@ -370,7 +370,8 @@ function getPropertyDataFromBinarySource(
   const stringOffsets = getStringOffsetsForProperty(
     scenegraph,
     propertyTableProperty,
-    numberOfElements
+    numberOfElements,
+    arrayOffsets
   );
 
   switch (classProperty.type) {
@@ -448,23 +449,25 @@ function getArrayOffsetsForProperty(
  * @param scenegraph - Instance of the class for structured access to GLTF data.
  * @param propertyTableProperty - propertyTable's property metadata.
  * @param numberOfElements - The number of elements in each property array that propertyTableProperty contains. It's a number of rows in the table.
+ * @param arrayOffsets - Offsets for variable-length arrays. The final offset is the total number of string elements.
  * @returns Typed array with offset values.
  * @see https://github.com/CesiumGS/glTF/blob/2976f1183343a47a29e4059a70961371cd2fcee8/extensions/2.0/Vendor/EXT_structural_metadata/schema/propertyTable.property.schema.json#L29C10-L29C23
  */
 function getStringOffsetsForProperty(
   scenegraph: GLTFScenegraph,
   propertyTableProperty: GLTF_EXT_structural_metadata_PropertyTable_Property,
-  numberOfElements: number
+  numberOfElements: number,
+  arrayOffsets: TypedArray | null
 ): TypedArray | null {
   if (
     typeof propertyTableProperty.stringOffsets !== 'undefined' // `stringOffsets` is an index of the buffer view containing offsets for strings.
   ) {
-    // Data are in a FIXED-length array
+    const numberOfStrings = arrayOffsets ? arrayOffsets[numberOfElements] : numberOfElements;
     return getOffsetsForProperty(
       scenegraph,
       propertyTableProperty.stringOffsets,
       propertyTableProperty.stringOffsetType || 'UINT32',
-      numberOfElements
+      numberOfStrings
     );
   }
   return null;

--- a/modules/gltf/src/lib/extensions/utils/3d-tiles-utils.ts
+++ b/modules/gltf/src/lib/extensions/utils/3d-tiles-utils.ts
@@ -421,9 +421,9 @@ export function getPropertyDataString(
       const endStringIndex = arrayOffsets[featureId + 1];
       const strings: string[] = [];
 
-      for (let i = startStringIndex; i < endStringIndex; i++) {
-        const startByte = stringOffsets[i];
-        const endByte = stringOffsets[i + 1];
+      for (let stringIndex = startStringIndex; stringIndex < endStringIndex; stringIndex++) {
+        const startByte = stringOffsets[stringIndex];
+        const endByte = stringOffsets[stringIndex + 1];
         const stringData = valuesDataBytes.subarray(startByte, endByte);
         strings.push(textDecoder.decode(stringData));
       }

--- a/modules/gltf/test/lib/extensions/EXT_structural_metadata.spec.ts
+++ b/modules/gltf/test/lib/extensions/EXT_structural_metadata.spec.ts
@@ -329,3 +329,108 @@ test('gltf#EXT_structural_metadata - Roundtrip encoding/decoding', async t => {
   }
   t.end();
 });
+
+test('gltf#EXT_structural_metadata - Should decode variable-length string arrays', async (t) => {
+  // 2 features with variable-length string arrays
+  // Feature 0: ["hello", "world"] (2 strings)
+  // Feature 1: ["foo"] (1 string)
+  //
+  // Binary layout:
+  // - values: "helloworldfoo" (13 bytes)
+  // - stringOffsets (UINT8): [0, 5, 10, 13] (4 bytes)
+  // - arrayOffsets (UINT8): [0, 2, 3] (3 bytes)
+
+  const binaryBufferData = [
+    // values: "helloworldfoo" (offset 0, length 13)
+    104,
+    101,
+    108,
+    108,
+    111, // "hello"
+    119,
+    111,
+    114,
+    108,
+    100, // "world"
+    102,
+    111,
+    111, // "foo"
+    // stringOffsets (offset 13, length 4): [0, 5, 10, 13]
+    0,
+    5,
+    10,
+    13,
+    // arrayOffsets (offset 17, length 3): [0, 2, 3]
+    0,
+    2,
+    3
+  ];
+
+  const GLTF_WITH_STRING_ARRAY = {
+    buffers: [
+      {
+        arrayBuffer: new Uint8Array(binaryBufferData).buffer,
+        byteOffset: 0,
+        byteLength: 20
+      }
+    ],
+    json: {
+      extensionsUsed: ['EXT_structural_metadata'],
+      buffers: [{byteLength: 20}],
+      bufferViews: [
+        {buffer: 0, byteOffset: 0, byteLength: 13}, // values
+        {buffer: 0, byteOffset: 13, byteLength: 4}, // stringOffsets
+        {buffer: 0, byteOffset: 17, byteLength: 3} // arrayOffsets
+      ],
+      extensions: {
+        EXT_structural_metadata: {
+          schema: {
+            id: 'schema',
+            classes: {
+              TestClass: {
+                properties: {
+                  tags: {
+                    type: 'STRING',
+                    array: true
+                    // no "count" means variable-length
+                  }
+                }
+              }
+            }
+          },
+          propertyTables: [
+            {
+              name: 'TestTable',
+              class: 'TestClass',
+              count: 2,
+              properties: {
+                tags: {
+                  values: 0,
+                  stringOffsets: 1,
+                  stringOffsetType: 'UINT8',
+                  arrayOffsets: 2,
+                  arrayOffsetType: 'UINT8'
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  };
+
+  const options = {gltf: {loadImages: true, loadBuffers: true}};
+  await decodeExtensions(GLTF_WITH_STRING_ARRAY, options);
+
+  const ext = GLTF_WITH_STRING_ARRAY.json.extensions
+    .EXT_structural_metadata as GLTF_EXT_structural_metadata_GLTF;
+  const tagsData = ext.propertyTables?.[0].properties?.tags.data;
+
+  // Verify variable-length string arrays are correctly decoded
+  t.deepEqual(
+    tagsData,
+    [['hello', 'world'], ['foo']],
+    'Variable-length string arrays decoded correctly'
+  );
+  t.end();
+});

--- a/modules/gltf/test/lib/extensions/EXT_structural_metadata.spec.ts
+++ b/modules/gltf/test/lib/extensions/EXT_structural_metadata.spec.ts
@@ -331,17 +331,18 @@ test('gltf#EXT_structural_metadata - Roundtrip encoding/decoding', async t => {
 });
 
 test('gltf#EXT_structural_metadata - Should decode variable-length string arrays', async (t) => {
-  // 2 features with variable-length string arrays
+  // 3 features with variable-length string arrays
   // Feature 0: ["hello", "world"] (2 strings)
-  // Feature 1: ["foo"] (1 string)
+  // Feature 1: [] (0 strings)
+  // Feature 2: ["foo", "bar"] (2 strings)
   //
   // Binary layout:
-  // - values: "helloworldfoo" (13 bytes)
-  // - stringOffsets (UINT8): [0, 5, 10, 13] (4 bytes)
-  // - arrayOffsets (UINT8): [0, 2, 3] (3 bytes)
+  // - values: "helloworldfoobar" (16 bytes)
+  // - stringOffsets (UINT8): [0, 5, 10, 13, 16] (5 bytes)
+  // - arrayOffsets (UINT8): [0, 2, 2, 4] (4 bytes)
 
   const binaryBufferData = [
-    // values: "helloworldfoo" (offset 0, length 13)
+    // values: "helloworldfoobar" (offset 0, length 16)
     104,
     101,
     108,
@@ -355,15 +356,20 @@ test('gltf#EXT_structural_metadata - Should decode variable-length string arrays
     102,
     111,
     111, // "foo"
-    // stringOffsets (offset 13, length 4): [0, 5, 10, 13]
+    98,
+    97,
+    114, // "bar"
+    // stringOffsets (offset 16, length 5): [0, 5, 10, 13, 16]
     0,
     5,
     10,
     13,
-    // arrayOffsets (offset 17, length 3): [0, 2, 3]
+    16,
+    // arrayOffsets (offset 21, length 4): [0, 2, 2, 4]
     0,
     2,
-    3
+    2,
+    4
   ];
 
   const GLTF_WITH_STRING_ARRAY = {
@@ -371,16 +377,16 @@ test('gltf#EXT_structural_metadata - Should decode variable-length string arrays
       {
         arrayBuffer: new Uint8Array(binaryBufferData).buffer,
         byteOffset: 0,
-        byteLength: 20
+        byteLength: 25
       }
     ],
     json: {
       extensionsUsed: ['EXT_structural_metadata'],
-      buffers: [{byteLength: 20}],
+      buffers: [{byteLength: 25}],
       bufferViews: [
-        {buffer: 0, byteOffset: 0, byteLength: 13}, // values
-        {buffer: 0, byteOffset: 13, byteLength: 4}, // stringOffsets
-        {buffer: 0, byteOffset: 17, byteLength: 3} // arrayOffsets
+        {buffer: 0, byteOffset: 0, byteLength: 16}, // values
+        {buffer: 0, byteOffset: 16, byteLength: 5}, // stringOffsets
+        {buffer: 0, byteOffset: 21, byteLength: 4} // arrayOffsets
       ],
       extensions: {
         EXT_structural_metadata: {
@@ -402,7 +408,7 @@ test('gltf#EXT_structural_metadata - Should decode variable-length string arrays
             {
               name: 'TestTable',
               class: 'TestClass',
-              count: 2,
+              count: 3,
               properties: {
                 tags: {
                   values: 0,
@@ -429,7 +435,7 @@ test('gltf#EXT_structural_metadata - Should decode variable-length string arrays
   // Verify variable-length string arrays are correctly decoded
   t.deepEqual(
     tagsData,
-    [['hello', 'world'], ['foo']],
+    [['hello', 'world'], [], ['foo', 'bar']],
     'Variable-length string arrays decoded correctly'
   );
   t.end();

--- a/modules/gltf/test/lib/extensions/EXT_structural_metadata.spec.ts
+++ b/modules/gltf/test/lib/extensions/EXT_structural_metadata.spec.ts
@@ -330,7 +330,7 @@ test('gltf#EXT_structural_metadata - Roundtrip encoding/decoding', async t => {
   t.end();
 });
 
-test('gltf#EXT_structural_metadata - Should decode variable-length string arrays', async (t) => {
+test('gltf#EXT_structural_metadata - Should decode variable-length string arrays', async t => {
   // 3 features with variable-length string arrays
   // Feature 0: ["hello", "world"] (2 strings)
   // Feature 1: [] (0 strings)


### PR DESCRIPTION
## Summary

Fixed `getPropertyDataString` to support variable-length string arrays in the `EXT_structural_metadata` extension.

Previously, loading 3D Tiles 1.1 tilesets with variable-length string array properties would throw:
```
Error: Not implemented - arrayOffsets for strings is specified
```

## Changes

- Implemented two-tier offset decoding for variable-length string arrays in `getPropertyDataString`
- Added unit test for variable-length string array decoding

### Technical Details

According to the [3D Tiles 1.1 Metadata specification](https://github.com/CesiumGS/3d-tiles/tree/main/specification/Metadata#strings), variable-length string arrays use two offset buffers:

- `arrayOffsets`: indexes into `stringOffsets` (which strings belong to which feature)
- `stringOffsets`: indexes into the byte data (where each string starts/ends)

**Example:**
```
Feature 0: ["hello", "world"]
Feature 1: ["foo"]

valuesDataBytes: "helloworldfoo"
stringOffsets:   [0, 5, 10, 13]  → byte positions of each string
arrayOffsets:    [0, 2, 3]       → feature 0 has strings 0-1, feature 1 has string 2
```

## Test Plan

- [x] Added unit test: `gltf#EXT_structural_metadata - Should decode variable-length string arrays`
- [x] All existing tests pass (`yarn test`)

## Related

- 3D Tiles 1.1 Metadata Spec: https://github.com/CesiumGS/3d-tiles/tree/main/specification/Metadata#strings