### PR TITLE
Add GitHub Actions workflow to build and publish releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node (with Corepack)
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+          always-auth: true
+
+      - name: Enable Corepack / Yarn
+        run: |
+          corepack enable
+          corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
+          yarn -v
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+
+      - name: Build workers
+        run: yarn build-workers
+
+      - name: Publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: yarn publish-prod


### PR DESCRIPTION
### Motivation
- Add an automated release workflow to build and publish packages when a release tag is pushed or when manually triggered.

### Description
- Add `.github/workflows/release.yml` that triggers on `workflow_dispatch` and `push` tags matching `v*`.
- Use `actions/checkout@v4` and `actions/setup-node@v4` with `node-version: 22` and `registry-url: 'https://registry.npmjs.org'` and `always-auth: true`.
- Enable Corepack and activate the repo Yarn version with `corepack prepare "$(node -p "require('./package.json').packageManager")" --activate` before running `yarn install --frozen-lockfile`, `yarn build`, and `yarn build-workers`.
- Publish using `yarn publish-prod` with `NODE_AUTH_TOKEN`/`NPM_TOKEN` from repository secrets and workflow `permissions` set to allow npm publishing.

### Testing
- Ran `yarn install --frozen-lockfile` to validate installs, which failed with a `403` fetching packages from the registry.
- Ran `yarn lint fix`, which failed due to a missing node_modules state file after the install failure.
- Ran `yarn test node`, which failed due to a missing node_modules state file after the install failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972398cc32c83289ace56baa28baf8b)