### PR TITLE
Update dev-tools config imports to @vis.gl/dev-tools

### DIFF
--- a/.ocularrc.js
+++ b/.ocularrc.js
@@ -1,4 +1,4 @@
-/** @typedef {import('ocular-dev-tools').OcularConfig} OcularConfig */
+/** @typedef {import('@vis.gl/dev-tools').OcularConfig} OcularConfig */
 
 import {dirname, join} from 'path';
 import {fileURLToPath} from 'url';

--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,5 +1,5 @@
 // @ts-ignore
-const {getBabelConfig} = require('ocular-dev-tools/configuration');
+const {getBabelConfig} = require('@vis.gl/dev-tools/configuration');
 
 const config = getBabelConfig({
   react: true,

--- a/examples/babel.config.local.js
+++ b/examples/babel.config.local.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
-const {getBabelConfig} = require('ocular-dev-tools');
+const {getBabelConfig} = require('@vis.gl/dev-tools/configuration');
 
 module.exports = (api) => {
   const config = getBabelConfig(api);

--- a/test/apps/babel.config.local.js
+++ b/test/apps/babel.config.local.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
-const {getBabelConfig} = require('ocular-dev-tools');
+const {getBabelConfig} = require('@vis.gl/dev-tools/configuration');
 
 module.exports = (api) => {
   const config = getBabelConfig(api);

--- a/test/apps/webpack.config.local.js
+++ b/test/apps/webpack.config.local.js
@@ -7,7 +7,7 @@
 const webpack = require('webpack');
 const resolve = require('path').resolve;
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
-const {getOcularConfig} = require('ocular-dev-tools');
+const {getOcularConfig} = require('@vis.gl/dev-tools/configuration');
 const ALIASES = getOcularConfig({root: resolve(__dirname, '..')}).aliases;
 const ROOT_DIR = resolve(__dirname, '..');
 const LERNA_INFO = require(resolve(ROOT_DIR, 'lerna.json'));


### PR DESCRIPTION
### Motivation

- Standardize dev-tools imports to the repository's preferred package path (`@vis.gl/dev-tools`) so local tooling and configs resolve consistently. 
- Replace legacy `ocular-dev-tools` usage in runtime config files to avoid ambiguous module resolution and keep configuration import paths uniform. 

### Description

- Replaced the ocular typedef import in `.ocularrc.js` with `/** @typedef {import('@vis.gl/dev-tools').OcularConfig} OcularConfig */`.
- Updated Babel requires to use `@vis.gl/dev-tools/configuration` in `babel.config.cjs`, `examples/babel.config.local.js`, and `test/apps/babel.config.local.js`.
- Updated the test webpack helper to use `getOcularConfig` from `@vis.gl/dev-tools/configuration` in `test/apps/webpack.config.local.js`.
- Verified code imports with `rg` and confirmed remaining `ocular-dev-tools` occurrences are only historical/documentation references (CHANGELOG, dev-docs), not active requires.

### Testing

- Ran `rg "ocular-dev-tools"` which succeeded and showed only documentation/history references, not active requires.
- Ran `yarn lint fix` which failed due to missing `node_modules` state file in the environment.
- Ran `yarn test node` which failed due to missing `node_modules` state file in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697382ecea348328b8e6d60873913f78)