### PR TITLE
chore: mark geoarrow package as public (gis dependency)

### DIFF
--- a/modules/geoarrow/package.json
+++ b/modules/geoarrow/package.json
@@ -4,7 +4,9 @@
   "description": "GeoArrow columnar geometry encoding and decoding",
   "license": "MIT",
   "type": "module",
-  "private": true,
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/visgl/loaders.gl"


### PR DESCRIPTION
### Background

The `gis` package depends on `geoarrow`, so it must be public. Alternatively we would need to remove the new function in `gis` and remove the `geoarrow` dependency.

Other private packages are fine:
- ✅ @loaders.gl/copc - No dependencies
- ✅ @loaders.gl/graphs - No dependencies
- ✅ @loaders.gl/traces - No dependencies
- ✅ @loaders.gl/zarr - No dependencies

