### PR TITLE
chore(las): package WASM using copy-libs

### DIFF
--- a/modules/las/package.json
+++ b/modules/las/package.json
@@ -46,7 +46,8 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-bundle-dev && npm run build-worker",
+    "pre-build": "npm run copy-libs && npm run build-bundle && npm run build-bundle-dev && npm run build-worker",
+    "copy-libs": "cp -rf ./src/libs ./dist/libs",
     "build-bundle": "ocular-bundle ./bundle.ts --output=dist/dist.min.js",
     "build-bundle-dev": "ocular-bundle ./bundle.ts --env=dev --output=dist/dist.dev.js",
     "build-worker": "esbuild src/workers/las-worker.ts --bundle --outfile=dist/las-worker.js --define:__VERSION__=\\\"$npm_package_version\\\""


### PR DESCRIPTION
### Background
The laz_rs_wasm_bg.wasm file existed in src/libs/laz-rs-wasm/ but wasn't being copied to the dist/ directory during the build, so it was missing from published packages.

### Changes
- Add `"copy-libs"` step to `package.json` like we do in `draco` & `textures`