### PR TITLE
fix(tiles): Refine empty tiles

### DIFF
--- a/modules/tiles/src/tileset/tileset-3d.ts
+++ b/modules/tiles/src/tileset/tileset-3d.ts
@@ -574,7 +574,7 @@ export class Tileset3D {
   _loadTiles(): void {
     // Sort requests by priority before making any requests.
     // This makes it less likely this requests will be cancelled after being issued.
-    // requestedTiles.sort((a, b) => a._priority - b._priority);
+    this._requestedTiles.sort((a, b) => a._priority - b._priority);
     for (const tile of this._requestedTiles) {
       if (tile.contentUnloaded) {
         // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/modules/tiles/src/tileset/tileset-traverser.ts
+++ b/modules/tiles/src/tileset/tileset-traverser.ts
@@ -353,6 +353,6 @@ export class TilesetTraverser {
         }
       }
     }
-    return allDescendantsLoaded;
+    return root.hasEmptyContent || allDescendantsLoaded;
   }
 }


### PR DESCRIPTION
For https://github.com/visgl/deck.gl/issues/9860

#### Background

Currently in deck.gl we often get a nasty artifact where a low res tile overlaps the visualization:

<img width="1046" height="647" alt="Screenshot 2026-02-09 at 15 35 58" src="https://github.com/user-attachments/assets/c478be9f-b4ad-496c-9d34-c19cff520075" />

With this fix we enable refinement by checking `root.hasEmptyContent` and the issue disappears:

<img width="1046" height="647" alt="Screenshot 2026-02-09 at 15 36 15" src="https://github.com/user-attachments/assets/abf0d44e-bf4b-4b4a-b9ca-5fb5ac96356c" />

#### Cause:

In executeEmptyTraversal, when checking whether a parent tile with REPLACE refinement can refine to its children, empty content tiles (structural nodes with no geometry) were blocking refinement until all descendants loaded. Since there's nothing to render for these tiles, they should never block refinement. This fix was implemented with reference to what Cesium is doing, not sure why this wasn't included in the code before.

Tested by modifying `examples/website/google-3d-tiles/app.jsx` in deck.gl to start at:

```
const INITIAL_VIEW_STATE = {
  latitude: 36.743,
  longitude: -5.157,
  zoom: 15,
  bearing: 70,
  pitch: 50,
  height: 200,
};

```