### PR TITLE
fix(loader-utils): Avoid option warnings unless log level is increased

### DIFF
--- a/modules/core/src/lib/loader-utils/option-defaults.ts
+++ b/modules/core/src/lib/loader-utils/option-defaults.ts
@@ -66,17 +66,18 @@ export const REMOVED_LOADER_OPTIONS = {
   throws: 'nothrow',
   dataType: '(no longer used)',
   uri: 'baseUri',
+
   // Warn if fetch options are used on toplevel
-  method: 'fetch.method',
-  headers: 'fetch.headers',
-  body: 'fetch.body',
-  mode: 'fetch.mode',
-  credentials: 'fetch.credentials',
-  cache: 'fetch.cache',
-  redirect: 'fetch.redirect',
-  referrer: 'fetch.referrer',
-  referrerPolicy: 'fetch.referrerPolicy',
-  integrity: 'fetch.integrity',
-  keepalive: 'fetch.keepalive',
-  signal: 'fetch.signal'
+  method: 'core.fetch.method',
+  headers: 'core.fetch.headers',
+  body: 'core.fetch.body',
+  mode: 'core.fetch.mode',
+  credentials: 'core.fetch.credentials',
+  cache: 'core.fetch.cache',
+  redirect: 'core.fetch.redirect',
+  referrer: 'core.fetch.referrer',
+  referrerPolicy: 'core.fetch.referrerPolicy',
+  integrity: 'core.fetch.integrity',
+  keepalive: 'core.fetch.keepalive',
+  signal: 'core.fetch.signal'
 };

--- a/modules/core/src/lib/loader-utils/option-utils.ts
+++ b/modules/core/src/lib/loader-utils/option-utils.ts
@@ -175,14 +175,18 @@ function validateOptionsObject(
     if (!(key in defaultOptions) && !isBaseUriOption && !isWorkerUrlOption) {
       // Issue deprecation warnings
       if (key in deprecatedOptions) {
-        probeLog.warn(
-          `${loaderName} loader option \'${prefix}${key}\' no longer supported, use \'${deprecatedOptions[key]}\'`
-        )();
+        if (probeLog.level > 0) {
+          probeLog.warn(
+            `${loaderName} loader option \'${prefix}${key}\' no longer supported, use \'${deprecatedOptions[key]}\'`
+          )();
+        }
       } else if (!isSubOptions) {
-        const suggestion = findSimilarOption(key, loaders);
-        probeLog.warn(
-          `${loaderName} loader option \'${prefix}${key}\' not recognized. ${suggestion}`
-        )();
+        if (probeLog.level > 0) {
+          const suggestion = findSimilarOption(key, loaders);
+          probeLog.warn(
+            `${loaderName} loader option \'${prefix}${key}\' not recognized. ${suggestion}`
+          )();
+        }
       }
     }
   }

--- a/modules/loader-utils/src/lib/log-utils/log.ts
+++ b/modules/loader-utils/src/lib/log-utils/log.ts
@@ -15,11 +15,11 @@ const version = VERSION[0] >= '0' && VERSION[0] <= '9' ? `v${VERSION}` : '';
 function createLog() {
   const log = new Log({id: 'loaders.gl'});
 
-  globalThis.loaders = globalThis.loaders || {};
+  globalThis.loaders ||= {};
   globalThis.loaders.log = log;
   globalThis.loaders.version = version;
 
-  globalThis.probe = globalThis.probe || {};
+  globalThis.probe ||= {};
   globalThis.probe.loaders = log;
 
   return log;


### PR DESCRIPTION
- Addresses concern raised during deck.gl integration around warnings for new depecrated usage being unwelcome.
- This is a quick fix, and will likely hide some warnings related to older, actually removed props. Hopefully those have already been addressed by apps by now.
