### PR TITLE
fix(worker-utils): add missing dist/lib path to browser field for child-process-proxy

### DIFF
--- a/modules/worker-utils/package.json
+++ b/modules/worker-utils/package.json
@@ -34,6 +34,7 @@
   ],
   "browser": {
     "./dist/esm/lib/process-utils/child-process-proxy.js": false,
+    "./dist/lib/process-utils/child-process-proxy.js": false,
     "./dist/lib/node/require-utils.node.js": false,
     "./dist/lib/node/worker_threads.js": "./dist/lib/node/worker_threads-browser.js",
     "./src/lib/node/require-utils.node.ts": false,


### PR DESCRIPTION
## Problem

`@loaders.gl/worker-utils` ships a `child-process-proxy.js` that imports the Node.js `child_process` built-in. The `browser` field in `package.json` is intended to stub this file out (`false`) so bundlers targeting browsers skip it. However the mapped path is:

```
"./dist/esm/lib/process-utils/child-process-proxy.js": false
```

The actual built output lives at:

```
./dist/lib/process-utils/child-process-proxy.js   ← no esm/ subdirectory
```

So the stub never applies. Vite/Rollup include the file in browser bundles and hit:

```
"spawn" is not exported by "__vite-browser-external",
imported by "node_modules/@loaders.gl/worker-utils/dist/lib/process-utils/child-process-proxy.js"
```

(Note: the file itself even has a comment acknowledging this was intentional: *"Avoid using named imports for Node builtins to help with 'empty' resolution for bundlers targeting browser environments."*)

## Fix

Add the correct path to the `browser` field:

```json
"./dist/lib/process-utils/child-process-proxy.js": false,
```

The existing `./dist/esm/lib/...` entry is preserved for compatibility with any previously published releases that may still have that layout.

## Reproduction

Any Vite project that directly or transitively depends on `@loaders.gl/worker-utils` (e.g. via `@loaders.gl/core`) will hit this error during `vite build` or `vite dev`.