### PR TITLE
fix(tiles): Extract rootNode.matrix into cartesianModelMatrix

### DIFF
--- a/modules/tiles/src/tileset/helpers/transform-utils.ts
+++ b/modules/tiles/src/tileset/helpers/transform-utils.ts
@@ -6,7 +6,9 @@ import {Ellipsoid} from '@math.gl/geospatial';
 import {Matrix4, Vector3} from '@math.gl/core';
 import {assert} from '@loaders.gl/loader-utils';
 
-export function calculateTransformProps(tileHeader, tile) {
+import {Tile3D} from '../tile-3d';
+
+export function calculateTransformProps(tileHeader: Tile3D, tile: Tile3D['content']) {
   assert(tileHeader);
   assert(tile);
 
@@ -62,8 +64,46 @@ export function calculateTransformProps(tileHeader, tile) {
   tile.cartographicModelMatrix = toFixedFrameMatrix.multiplyRight(modelMatrix);
   tile.cartographicOrigin = cartographicOrigin;
 
+  // Absorb glTF root node matrix into model matrices for Float32 precision.
+  // The glTF root node matrix (applied as sceneModelMatrix in the shader) may contain
+  // ECEF-scale translations (~millions of meters). When both cartographicModelMatrix
+  // and sceneModelMatrix are applied in the Float32 GPU shader, catastrophic cancellation
+  // occurs causing visible seams between adjacent tiles. By combining them here in Float64,
+  // the result has small ENU-scale values that preserve precision.
+  const rootNode = _getRootNode(tile);
+  if (rootNode) {
+    tile.cartesianModelMatrix = new Matrix4(modelMatrix).multiplyRight(rootNode.matrix);
+    tile.cartographicModelMatrix.multiplyRight(rootNode.matrix);
+    rootNode.matrix = Matrix4.IDENTITY;
+  }
+
   // Deprecated, drop
   if (!tile.coordinateSystem) {
     tile.modelMatrix = tile.cartographicModelMatrix;
   }
+}
+
+const TRANSLATION_LIMIT_SQUARED = 10e5 ** 2; // 100km
+
+/**
+ * Returns the glTF root node if it has a matrix with earth-scale translations (> 100km).
+ * These large translations cause Float32 precision issues when applied in the GPU shader.
+ */
+function _getRootNode(tile: Tile3D['content']): {matrix: number[]} | null {
+  const gltf = tile.gltf;
+  if (!gltf) {
+    return null;
+  }
+
+  const sceneIndex = typeof gltf.scene === 'number' ? gltf.scene : 0;
+  const scene = gltf.scenes?.[sceneIndex];
+  const rootNode = scene?.nodes?.[0];
+  if (!rootNode?.matrix) return null;
+
+  // Extract translation and compare magnitude (meters) to limit
+  const m = rootNode.matrix;
+  const translationMagnitude = m[12] * m[12] + m[13] * m[13] + m[14] * m[14];
+  if (translationMagnitude <= TRANSLATION_LIMIT_SQUARED) return null;
+
+  return rootNode;
 }


### PR DESCRIPTION
### Background

Closes https://github.com/visgl/deck.gl/issues/7938

Google 3D Tiles contain a GLTF scene which has a large translation applied which largely cancels out with the `cartographicModelMatrix` that is computed when positioning the tile. These two matrices [get multiplied in the vertex shader](https://github.com/visgl/deck.gl/blob/master/modules/mesh-layers/src/scenegraph-layer/scenegraph-layer-vertex.glsl.ts#L63), where we run into precision issues as the GPU doesn't give us full 64-bit float accuracy. The result is a random offset of around 1m in the vertex positioning, leading to tiles not lining up and all geometry generally looking warped

### Matrix cancellation example

```ts
tile.cartographicModelMatrix.slice(12, 15) // tile matrix before
  [7.730704965069892e-12, 21059.383773554862, -6365805.334592631]
rootNode.matrix.slice(12,15) // gltf matrix
  [3973765.7745400146, 4866783.320156751, -1021735.4646183369]
tile.cartographicModelMatrix.slice(12, 15)  // tile matrix after multiplying in gltf matrix
  [7.730704965069892e-12, -0.0071746961439203005, -281.461573747918] // translation now in meters rather than 1000s of km!
```

### Results
#### Before
<img width="639" height="469" alt="Screenshot 2026-03-09 at 14 18 59" src="https://github.com/user-attachments/assets/ad4cb98e-9f25-4cf1-98ec-a066414c0578" />

#### After
<img width="639" height="469" alt="Screenshot 2026-03-09 at 14 18 38" src="https://github.com/user-attachments/assets/e432e0c5-2df1-4e2c-9c46-c11c9a5b827a" />

### Changed

- Mutliply in GLTF scene matrix if translation is above 100km
- Replace GLTF scene matrix with identity