### PR TITLE
[example] select url from tileset param

### DIFF
--- a/examples/website/3d-tiles/app.tsx
+++ b/examples/website/3d-tiles/app.tsx
@@ -99,8 +99,6 @@ export default class App extends PureComponent {
     this._tilesetStatsWidget = new StatsWidget(null, {container});
 
     this._loadExampleIndex();
-
-    
   }
 
   // load the index file that lists example tilesets
@@ -112,6 +110,7 @@ export default class App extends PureComponent {
     const {category, name} = this.state;
     const selectedExample = examplesByCategory[category].examples[name];
     this.setState({selectedExample});
+    
     // Check if a tileset is specified in the query params
     if (this._selectTilesetFromQueryParams()) {
       return;

--- a/examples/website/3d-tiles/app.tsx
+++ b/examples/website/3d-tiles/app.tsx
@@ -100,10 +100,7 @@ export default class App extends PureComponent {
 
     this._loadExampleIndex();
 
-    // Check if a tileset is specified in the query params
-    if (this._selectTilesetFromQueryParams()) {
-      return;
-    }
+    
   }
 
   // load the index file that lists example tilesets
@@ -115,6 +112,10 @@ export default class App extends PureComponent {
     const {category, name} = this.state;
     const selectedExample = examplesByCategory[category].examples[name];
     this.setState({selectedExample});
+    // Check if a tileset is specified in the query params
+    if (this._selectTilesetFromQueryParams()) {
+      return;
+    }
   }
 
   // Check URL query params and select the "custom example" if appropriate

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -17,7 +17,7 @@ const config = {
   favicon: '/favicon.png',
   organizationName: 'visgl', // Usually your GitHub org/user name.
   projectName: 'loaders.gl', // Usually your repo name.
-  trailingSlash: false,
+  trailingSlash: undefined,
 
   markdown: {
     hooks: {


### PR DESCRIPTION
fixes #3333

The change to `trailingSlash: undefined` was necessary for serving from the developmental docusaurus server in order to keep the url unchanged by the server. It may not be necessary for serving from the published loaders.gl website. 
