### PR TITLE
feat: MeshArrowLoaders

### DIFF
--- a/docs/modules/draco/README.md
+++ b/docs/modules/draco/README.md
@@ -12,15 +12,16 @@ npm install @loaders.gl/core @loaders.gl/draco
 
 ## Loaders and Writers
 
-| Loader                                                                |
-| --------------------------------------------------------------------- |
-| [`DracoLoader`](/docs/modules/draco/api-reference/draco-loader)       |
-| [`DracoWorkerLoader`](/docs/modules/draco/api-reference/draco-loader) |
-| [`DracoWriter`](/docs/modules/draco/api-reference/draco-writer)       |
+| Loader                                                                | Description                                      |
+| --------------------------------------------------------------------- | ------------------------------------------------ |
+| [`DracoArrowLoader`](/docs/modules/draco/api-reference/draco-loader)  | Loads Draco meshes and point clouds as [Mesh Arrow tables](/docs/specifications/category-mesh#mesh-arrow-tables). |
+| [`DracoLoader`](/docs/modules/draco/api-reference/draco-loader)       | Loads Draco meshes and point clouds as Mesh objects. |
+| [`DracoWorkerLoader`](/docs/modules/draco/api-reference/draco-loader) | Loads Draco meshes and point clouds in a worker. |
+| [`DracoWriter`](/docs/modules/draco/api-reference/draco-writer)       | Encodes Draco meshes and point clouds.           |
 
 ## Additional APIs
 
-See point cloud / mesh category.
+See the [Mesh Arrow table](/docs/specifications/category-mesh#mesh-arrow-tables) and point cloud / mesh category documentation.
 
 ## Dependencies
 

--- a/docs/modules/draco/api-reference/draco-loader.md
+++ b/docs/modules/draco/api-reference/draco-loader.md
@@ -2,12 +2,14 @@
 
 ![logo](../images/draco-small.png)
 
-The `DracoLoader` decodes a mesh or point cloud (maps of attributes) using [DRACO](https://google.github.io/draco/) compression.
+The `DracoArrowLoader` decodes a mesh or point cloud (maps of attributes) using [DRACO](https://google.github.io/draco/) compression and returns a [Mesh Arrow table](/docs/specifications/category-mesh#mesh-arrow-tables).
+
+`DracoLoader` parses the same Draco format and returns the legacy [Mesh](/docs/specifications/category-mesh) object.
 
 | Loader         | Characteristic                             |
 | -------------- | ------------------------------------------ |
 | File Format    | [Draco](/docs/modules/draco/formats/draco) |
-| Data Format    | [Mesh](/docs/specifications/category-mesh) |
+| Data Format    | [Mesh Arrow table](/docs/specifications/category-mesh#mesh-arrow-tables), [Mesh](/docs/specifications/category-mesh) |
 | File Extension | `.drc`                                     |
 | File Type      | Binary                                     |
 | Supported APIs | `parse`                                    |
@@ -35,9 +37,10 @@ Metadata Support:
 ## Usage
 
 ```typescript
-import {DracoLoader} from '@loaders.gl/draco';
+import {DracoArrowLoader, DracoLoader} from '@loaders.gl/draco';
 import {load} from '@loaders.gl/core';
 
+const table = await load(url, DracoArrowLoader, options);
 const data = await load(url, DracoLoader, options);
 ```
 

--- a/docs/modules/las/README.md
+++ b/docs/modules/las/README.md
@@ -13,6 +13,13 @@ For more detail, see the discussion in [Github Issues](https://github.com/visgl/
 npm install @loaders.gl/core @loaders.gl/las
 ```
 
+## Loaders
+
+| Loader                                                        | Description                                  |
+| ------------------------------------------------------------- | -------------------------------------------- |
+| [`LASArrowLoader`](/docs/modules/las/api-reference/las-loader) | Loads LAS/LAZ point clouds as [Mesh Arrow tables](/docs/specifications/category-mesh#mesh-arrow-tables). |
+| [`LASLoader`](/docs/modules/las/api-reference/las-loader)      | Loads LAS/LAZ point clouds as Mesh objects.      |
+
 ## Attribution
 
 LASLoader is a fork of Uday Verma and Howard Butler's [plasio](https://github.com/verma/plasio/) under MIT License.

--- a/docs/modules/las/api-reference/las-loader.md
+++ b/docs/modules/las/api-reference/las-loader.md
@@ -5,14 +5,16 @@ The `@loaders.gl/las` module only supports LAS/lAZ files up to LAS v1.3. It does
 For more detail, see the discussion in [Github Issues](https://github.com/visgl/loaders.gl/issues/591).
 :::
 
-The `LASLoader` parses a point cloud in the LASER file format.
+The `LASArrowLoader` parses a point cloud in the LASER file format and returns a [Mesh Arrow table](/docs/specifications/category-mesh#mesh-arrow-tables).
+
+`LASLoader` parses the same LAS/LAZ format and returns the legacy [PointCloud](/docs/specifications/category-mesh) object.
 
 | Loader                | Characteristic                                                                                                           |
 | --------------------- | ------------------------------------------------------------------------------------------------------------------------ |
 | File Extension        | `.las`, `.laz`                                                                                                           |
 | File Type             | Binary                                                                                                                   |
 | File Format           | [LASER file format](https://www.asprs.org/divisions-committees/lidar-division/laser-las-file-format-exchange-activities) |
-| Data Format           | [PointCloud](/docs/specifications/category-mesh)                                                                         |
+| Data Format           | [Mesh Arrow table](/docs/specifications/category-mesh#mesh-arrow-tables), [PointCloud](/docs/specifications/category-mesh) |
 | Decoder Type          | Synchronous                                                                                                              |
 | Worker Thread Support | Yes                                                                                                                      |
 | Streaming Support     | No                                                                                                                       |
@@ -20,9 +22,10 @@ The `LASLoader` parses a point cloud in the LASER file format.
 ## Usage
 
 ```typescript
-import {LASLoader} from '@loaders.gl/las';
+import {LASArrowLoader, LASLoader} from '@loaders.gl/las';
 import {load} from '@loaders.gl/core';
 
+const table = await load(url, LASArrowLoader, options);
 const data = await load(url, LASLoader, options);
 ```
 

--- a/docs/modules/obj/README.md
+++ b/docs/modules/obj/README.md
@@ -11,9 +11,10 @@ npm install @loaders.gl/core
 
 ## Loaders and Writers
 
-| Loader                                                    |
-| --------------------------------------------------------- |
-| [`OBJLoader`](/docs/modules/obj/api-reference/obj-loader) |
+| Loader                                                         | Description                         |
+| -------------------------------------------------------------- | ----------------------------------- |
+| [`OBJArrowLoader`](/docs/modules/obj/api-reference/obj-loader) | Loads OBJ meshes as [Mesh Arrow tables](/docs/specifications/category-mesh#mesh-arrow-tables). |
+| [`OBJLoader`](/docs/modules/obj/api-reference/obj-loader)      | Loads OBJ meshes as Mesh objects.   |
 
 ## Attribution
 

--- a/docs/modules/obj/api-reference/obj-loader.md
+++ b/docs/modules/obj/api-reference/obj-loader.md
@@ -1,13 +1,15 @@
 # OBJLoader
 
-The `OBJLoader` parses the OBJ half of the classic Wavefront OBJ/MTL format.
+The `OBJArrowLoader` parses the OBJ half of the classic Wavefront OBJ/MTL format and returns a [Mesh Arrow table](/docs/specifications/category-mesh#mesh-arrow-tables).
+
+`OBJLoader` parses the same OBJ format and returns the legacy [Mesh](/docs/specifications/category-mesh) object.
 
 | Loader                | Characteristic                                                          |
 | --------------------- | ----------------------------------------------------------------------- |
 | File Extension        | `.obj`                                                                  |
 | File Type             | Text                                                                    |
 | File Format           | [Wavefront OBJ file](https://en.wikipedia.org/wiki/Wavefront_.obj_file) |
-| Data Format           | [Mesh](/docs/specifications/category-mesh)                              |
+| Data Format           | [Mesh Arrow table](/docs/specifications/category-mesh#mesh-arrow-tables), [Mesh](/docs/specifications/category-mesh) |
 | Decoder Type          | Synchronous                                                             |
 | Worker Thread Support | Yes                                                                     |
 | Streaming Support     | No                                                                      |
@@ -15,9 +17,10 @@ The `OBJLoader` parses the OBJ half of the classic Wavefront OBJ/MTL format.
 ## Usage
 
 ```typescript
-import {OBJLoader} from '@loaders.gl/obj';
+import {OBJArrowLoader, OBJLoader} from '@loaders.gl/obj';
 import {load} from '@loaders.gl/core';
 
+const table = await load(url, OBJArrowLoader, options);
 const data = await load(url, OBJLoader, options);
 ```
 

--- a/docs/modules/pcd/README.md
+++ b/docs/modules/pcd/README.md
@@ -9,6 +9,13 @@ npm install @loaders.gl/pcd
 npm install @loaders.gl/core
 ```
 
+## Loaders
+
+| Loader                                                        | Description                                  |
+| ------------------------------------------------------------- | -------------------------------------------- |
+| [`PCDArrowLoader`](/docs/modules/pcd/api-reference/pcd-loader) | Loads PCD point clouds as [Mesh Arrow tables](/docs/specifications/category-mesh#mesh-arrow-tables). |
+| [`PCDLoader`](/docs/modules/pcd/api-reference/pcd-loader)      | Loads PCD point clouds as Mesh objects.      |
+
 ## Attribution
 
 PCDLoader is a fork of the THREE.js PCDLoader under MIT License. The forked THREE.js source files contained the following attributions:

--- a/docs/modules/pcd/api-reference/pcd-loader.md
+++ b/docs/modules/pcd/api-reference/pcd-loader.md
@@ -1,11 +1,13 @@
 # PCDLoader
 
-The `PCDLoader` loads point cloud in the Point Cloud Data (PCD) format.
+The `PCDArrowLoader` loads point cloud data in the Point Cloud Data (PCD) format and returns a [Mesh Arrow table](/docs/specifications/category-mesh#mesh-arrow-tables).
+
+`PCDLoader` parses the same PCD format and returns the legacy [PointCloud](/docs/specifications/category-mesh) object.
 
 | Loader                | Characteristic                                     |
 | --------------------- | -------------------------------------------------- |
 | File Format           | [Point Cloud Data](/docs/modules/pcd/formats/pcd)) |
-| Data Format           | [PointCloud](/docs/specifications/category-mesh)   |
+| Data Format           | [Mesh Arrow table](/docs/specifications/category-mesh#mesh-arrow-tables), [PointCloud](/docs/specifications/category-mesh) |
 | File Extension        | `.pcd`                                             |
 | File Type             | Text/Binary                                        |
 | Decoder Type          | Synchronous                                        |
@@ -17,9 +19,10 @@ Note: Currently supports `ascii`, `binary` and compressed binary files.
 ## Usage
 
 ```typescript
-import {PCDLoader} from '@loaders.gl/pcd';
+import {PCDArrowLoader, PCDLoader} from '@loaders.gl/pcd';
 import {load} from '@loaders.gl/core';
 
+const table = await load(url, PCDArrowLoader, options);
 const data = await load(url, PCDLoader, options);
 ```
 

--- a/docs/modules/ply/README.md
+++ b/docs/modules/ply/README.md
@@ -8,6 +8,13 @@ The `@loaders.gl/ply` module handles the the [Polygon file format](/docs/modules
 npm install @loaders.gl/core @loaders.gl/ply
 ```
 
+## Loaders
+
+| Loader                                                        | Description                       |
+| ------------------------------------------------------------- | --------------------------------- |
+| [`PLYArrowLoader`](/docs/modules/ply/api-reference/ply-loader) | Loads PLY meshes as [Mesh Arrow tables](/docs/specifications/category-mesh#mesh-arrow-tables). |
+| [`PLYLoader`](/docs/modules/ply/api-reference/ply-loader)      | Loads PLY meshes as Mesh objects.      |
+
 ## Attribution
 
 PLYLoader is a fork of the THREE.js PLYLoader under MIT License. The THREE.js source files contained the following attributions:

--- a/docs/modules/ply/api-reference/ply-loader.md
+++ b/docs/modules/ply/api-reference/ply-loader.md
@@ -1,11 +1,13 @@
 # PLYLoader
 
-The `PLYLoader` parses simple meshes in the Polygon File Format or the Stanford Triangle Format.
+The `PLYArrowLoader` parses simple meshes in the Polygon File Format or the Stanford Triangle Format and returns a [Mesh Arrow table](/docs/specifications/category-mesh#mesh-arrow-tables).
+
+`PLYLoader` parses the same PLY format and returns the legacy [Mesh](/docs/specifications/category-mesh) object.
 
 | Loader                | Characteristic                             |
 | --------------------- | ------------------------------------------ |
 | File Format           | [PLY](/docs/modules/ply/formats/ply)       |
-| Data Format           | [Mesh](/docs/specifications/category-mesh) |
+| Data Format           | [Mesh Arrow table](/docs/specifications/category-mesh#mesh-arrow-tables), [Mesh](/docs/specifications/category-mesh) |
 | File Extension        | `.ply`                                     |
 | File Type             | Binary/Text                                |
 | Decoder Type          | Synchronous                                |
@@ -15,9 +17,10 @@ The `PLYLoader` parses simple meshes in the Polygon File Format or the Stanford 
 ## Usage
 
 ```typescript
-import {PLYLoader} from '@loaders.gl/ply';
+import {PLYArrowLoader, PLYLoader} from '@loaders.gl/ply';
 import {load} from '@loaders.gl/core';
 
+const table = await load(url, PLYArrowLoader, options);
 const data = await load(url, PLYLoader, options);
 ```
 

--- a/docs/modules/terrain/README.md
+++ b/docs/modules/terrain/README.md
@@ -14,6 +14,15 @@ npm install @loaders.gl/terrain
 npm install @loaders.gl/core
 ```
 
+## Loaders
+
+| Loader                     | Description                                         |
+| -------------------------- | --------------------------------------------------- |
+| `TerrainArrowLoader`       | Loads height-map terrain as a [Mesh Arrow table](/docs/specifications/category-mesh#mesh-arrow-tables). |
+| `QuantizedMeshArrowLoader` | Loads quantized mesh terrain as a [Mesh Arrow table](/docs/specifications/category-mesh#mesh-arrow-tables). |
+| `TerrainLoader`            | Loads height-map terrain as a Mesh.                 |
+| `QuantizedMeshLoader`      | Loads quantized mesh terrain as a Mesh.             |
+
 ## Attribution
 
 The `QuantizedMeshLoader` is a fork of

--- a/docs/modules/terrain/api-reference/quantized-mesh-loader.md
+++ b/docs/modules/terrain/api-reference/quantized-mesh-loader.md
@@ -4,17 +4,19 @@
   <img src="https://img.shields.io/badge/From-v2.2-blue.svg?style=flat-square" alt="From-v2.2" /> 
 </p>
 
-The `QuantizedMeshLoader` module reconstructs mesh surfaces from the [quantized
+The `QuantizedMeshArrowLoader` reconstructs mesh surfaces from the [quantized
 mesh][quantized_mesh] format.
 
 [quantized_mesh]: https://github.com/CesiumGS/quantized-mesh
+
+`QuantizedMeshLoader` parses the same quantized mesh format and returns the legacy [Mesh](/docs/specifications/category-mesh) object.
 
 | Loader                | Characteristic                             |
 | --------------------- | ------------------------------------------ |
 | File Extension        | `.terrain`                                 |
 | File Type             | Binary                                     |
 | File Format           | Encoded mesh                               |
-| Data Format           | [Mesh](/docs/specifications/category-mesh) |
+| Data Format           | [Mesh Arrow table](/docs/specifications/category-mesh#mesh-arrow-tables), [Mesh](/docs/specifications/category-mesh) |
 | Supported APIs        | `load`, `parse`, `parseSync`               |
 | Decoder Type          | Synchronous                                |
 | Worker Thread Support | Yes                                        |
@@ -23,7 +25,7 @@ mesh][quantized_mesh] format.
 ## Usage
 
 ```typescript
-import {QuantizedMeshLoader} from '@loaders.gl/terrain';
+import {QuantizedMeshArrowLoader, QuantizedMeshLoader} from '@loaders.gl/terrain';
 import {load} from '@loaders.gl/core';
 
 const options = {
@@ -31,6 +33,7 @@ const options = {
     bounds: [0, 0, 1, 1]
   }
 };
+const table = await load(url, QuantizedMeshArrowLoader, options);
 const data = await load(url, QuantizedMeshLoader, options);
 ```
 

--- a/docs/modules/terrain/api-reference/terrain-loader.md
+++ b/docs/modules/terrain/api-reference/terrain-loader.md
@@ -1,13 +1,15 @@
 # TerrainLoader
 
-The `TerrainLoader` reconstructs mesh surfaces from height map images, e.g. [Mapzen Terrain Tiles](https://github.com/tilezen/joerd/blob/master/docs/formats.md), which encodes elevation into R,G,B values.
+The `TerrainArrowLoader` reconstructs mesh surfaces from height map images, e.g. [Mapzen Terrain Tiles](https://github.com/tilezen/joerd/blob/master/docs/formats.md), which encodes elevation into R,G,B values, and returns a [Mesh Arrow table](/docs/specifications/category-mesh#mesh-arrow-tables).
+
+`TerrainLoader` parses the same height map terrain formats and returns the legacy [Mesh](/docs/specifications/category-mesh) object.
 
 | Loader                | Characteristic                             |
 | --------------------- | ------------------------------------------ |
 | File Extension        | `.png`, `.pngraw`                          |
 | File Type             | Binary                                     |
 | File Format           | Encoded height map                         |
-| Data Format           | [Mesh](/docs/specifications/category-mesh) |
+| Data Format           | [Mesh Arrow table](/docs/specifications/category-mesh#mesh-arrow-tables), [Mesh](/docs/specifications/category-mesh) |
 | Supported APIs        | `load`, `parse`                            |
 | Decoder Type          | Asynchronous                               |
 | Worker Thread Support | Yes                                        |
@@ -17,11 +19,12 @@ The `TerrainLoader` reconstructs mesh surfaces from height map images, e.g. [Map
 
 ```typescript
 import {ImageLoader} from '@loaders.gl/images';
-import {TerrainLoader} from '@loaders.gl/terrain';
+import {TerrainArrowLoader, TerrainLoader} from '@loaders.gl/terrain';
 import {load, registerLoaders} from '@loaders.gl/core';
 
 registerLoaders(ImageLoader);
 
+const table = await load(url, TerrainArrowLoader, options);
 const data = await load(url, TerrainLoader, options);
 ```
 

--- a/docs/specifications/category-mesh.md
+++ b/docs/specifications/category-mesh.md
@@ -4,21 +4,30 @@ The _mesh and pointcloud_ loader category is intended for simpler mesh and point
 
 ## Mesh/PointCloud Category Loaders
 
-| Loader                                                                             | Notes |
-| ---------------------------------------------------------------------------------- | ----- |
-| [`DracoLoader`](/docs/modules/draco/api-reference/draco-loader)                    |       |
-| [`LASLoader`](/docs/modules/las/api-reference/las-loader)                          |       |
-| [`OBJLoader`](/docs/modules/obj/api-reference/obj-loader)                          |       |
-| [`PCDLoader`](/docs/modules/pcd/api-reference/pcd-loader)                          |       |
-| [`PLYLoader`](/docs/modules/ply/api-reference/ply-loader)                          |       |
-| [`QuantizedMeshLoader`](/docs/modules/terrain/api-reference/quantized-mesh-loader) |       |
-| [`TerrainLoader`](/docs/modules/terrain/api-reference/terrain-loader)              |       |
+| Loader                                                                                          | Notes                     |
+| ----------------------------------------------------------------------------------------------- | ------------------------- |
+| [`DracoArrowLoader`](/docs/modules/draco/api-reference/draco-loader)                             | Mesh Arrow table          |
+| [`LASArrowLoader`](/docs/modules/las/api-reference/las-loader)                                   | Mesh Arrow table          |
+| [`OBJArrowLoader`](/docs/modules/obj/api-reference/obj-loader)                                   | Mesh Arrow table          |
+| [`PCDArrowLoader`](/docs/modules/pcd/api-reference/pcd-loader)                                   | Mesh Arrow table          |
+| [`PLYArrowLoader`](/docs/modules/ply/api-reference/ply-loader)                                   | Mesh Arrow table          |
+| [`QuantizedMeshArrowLoader`](/docs/modules/terrain/api-reference/quantized-mesh-loader)          | Mesh Arrow table          |
+| [`TerrainArrowLoader`](/docs/modules/terrain/api-reference/terrain-loader)                       | Mesh Arrow table          |
+| [`DracoLoader`](/docs/modules/draco/api-reference/draco-loader)                                  | Legacy Mesh object        |
+| [`LASLoader`](/docs/modules/las/api-reference/las-loader)                                        | Legacy PointCloud object  |
+| [`OBJLoader`](/docs/modules/obj/api-reference/obj-loader)                                        | Legacy Mesh object        |
+| [`PCDLoader`](/docs/modules/pcd/api-reference/pcd-loader)                                        | Legacy PointCloud object  |
+| [`PLYLoader`](/docs/modules/ply/api-reference/ply-loader)                                        | Legacy Mesh object        |
+| [`QuantizedMeshLoader`](/docs/modules/terrain/api-reference/quantized-mesh-loader)               | Legacy Mesh object        |
+| [`TerrainLoader`](/docs/modules/terrain/api-reference/terrain-loader)                            | Legacy Mesh object        |
 
 ## Data Format
 
 A single mesh is typically defined by a set of attributes, such as `positions`, `colors`, `normals` etc, as well as a draw mode.
 
-The Pointcloud/Mesh loaders output mesh data in a common form that is optimized for use in WebGL frameworks:
+The Mesh/PointCloud category uses Arrow as the primary tabular mesh representation. Arrow loader variants return an Apache Arrow table wrapper (`shape: 'arrow-table'`) whose raw Apache Arrow table data can be typed with `MeshArrowTableData` or `IndexedMeshArrowTableData` from `@loaders.gl/schema`.
+
+Legacy Mesh loader variants return a JavaScript object shape that is optimized for direct use in WebGL frameworks:
 
 - All attributes (and indices if present) are stored as typed arrays of the proper type.
 - All attributes (and indices if present) are wrapped into glTF-style "accessor objects", e.g. `{size: 1-4, value: typedArray}`.
@@ -26,13 +35,64 @@ The Pointcloud/Mesh loaders output mesh data in a common form that is optimized 
 - An `indices` field is added (only if present in the loaded geometry).
 - A primitive drawing `mode` value is added (the numeric value matches WebGL constants, e.g `GL.TRIANGLES`).
 
-| Field        | Type                | Contents                                                                                                    |
-| ------------ | ------------------- | ----------------------------------------------------------------------------------------------------------- |
-| `loaderData` | `Object` (Optional) | Loader and format specific data                                                                             |
-| `header`     | `Object`            | See [Header](#header)                                                                                       |
-| `mode`       | `Number`            | See [Mode](#mode)                                                                                           |
-| `attributes` | `Object`            | Keys are [glTF attribute names](#gltf-attribute-name-mapping) and values are [accessor](#accessor) objects. |
-| `indices`    | `Object` (Optional) | If present, describes the indices (elements) of the geometry as an [accessor](#accessor) object.            |
+| Field        | Type                | Contents                                                                                                      |
+| ------------ | ------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `loaderData` | `Object` (Optional) | Loader and format specific data                                                                               |
+| `header`     | `Object`            | See [Header](#header)                                                                                         |
+| `mode`       | `Number`            | See [Mode](#mode)                                                                                             |
+| `attributes` | `Object`            | Keys are [glTF attribute names](#gltf-attribute-name-mapping) and values are [accessor](#accessor) objects.   |
+| `indices`    | `Object` (Optional) | If present, describes the primitive indices (elements) of the geometry as an [accessor](#accessor) object.    |
+
+## Mesh Arrow Tables
+
+`@loaders.gl/schema` exports predefined schema contracts for common mesh columns:
+
+| Export                       | Description                                                                                 |
+| ---------------------------- | ------------------------------------------------------------------------------------------- |
+| `MeshArrowColumns`           | Column type map for common mesh Arrow tables.                                               |
+| `IndexedMeshArrowColumns`    | Column type map for indexed mesh Arrow tables.                                              |
+| `MeshArrowTableData`         | Raw `arrow.Table<MeshArrowColumns>` alias.                                                   |
+| `IndexedMeshArrowTableData`  | Raw `arrow.Table<IndexedMeshArrowColumns>` alias.                                            |
+| `meshArrowSchema`            | Predefined mesh Arrow schema, starting with `POSITION: FixedSizeList<Float32>[3]`.           |
+| `indexedMeshArrowSchema`     | Predefined indexed mesh Arrow schema with `POSITION` plus nullable `indices: List<Int32>`.   |
+
+`IndexedMesh` uses a lowercase `indices` column because it mirrors glTF's primitive-level `indices` property. It is not an uppercase vertex attribute semantic like `POSITION`, `NORMAL`, or `TEXCOORD_0`.
+
+For indexed meshes, the full index list is stored in the nullable `indices` column at Arrow row `0`; remaining vertex rows store `null`. Vertex attributes are stored as Arrow `FixedSizeList` columns, so `POSITION` is a row-per-vertex `FixedSizeList<Float32>[3]` column.
+
+Consumers can validate common columns with `meshArrowSchema` or `indexedMeshArrowSchema`. Loaders may append loader-specific trailing attribute columns after the predefined fields, such as `NORMAL`, `COLOR_0`, `TEXCOORD_0`, or custom Draco attributes.
+
+### Mesh Arrow Columns
+
+| Column       | Arrow Type                   | Nullable | Description                                                                                                                        |
+| ------------ | ---------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `POSITION`   | `FixedSizeList<Float32>[3]`  | No       | Required predefined vertex position column. Each row is one XYZ vertex position.                                                    |
+| `indices`    | `List<Int32>`                | Yes      | Required only for `IndexedMesh` Arrow tables. Row `0` stores the full primitive index list; remaining vertex rows store `null`.     |
+| `NORMAL`     | `FixedSizeList<T>[3]`        | No       | Optional vertex normal column when present in the source mesh. `T` follows the source attribute typed array when possible.          |
+| `COLOR_0`    | `FixedSizeList<T>[3 or 4]`   | No       | Optional vertex color column when present in the source mesh. `T` follows the source attribute typed array when possible.           |
+| `TEXCOORD_0` | `FixedSizeList<T>[2]`        | No       | Optional first texture coordinate column when present in the source mesh. `T` follows the source attribute typed array when possible. |
+| Custom       | `FixedSizeList<T>[size]`     | No       | Optional loader-specific or source-specific vertex attribute column appended after predefined fields.                               |
+
+### Mesh Arrow Metadata
+
+Arrow schema and field metadata are stored as `Map<string, string>` values. Structured values are JSON-serialized strings.
+
+Schema-level metadata:
+
+| Key           | Value Format                                | Description                                                                                 |
+| ------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `topology`    | String                                      | Mesh topology, such as `point-list`, `triangle-list`, or `triangle-strip`.                   |
+| `mode`        | Numeric string                              | Primitive mode using WebGL/glTF constants, such as `0` for points or `4` for triangles.      |
+| `boundingBox` | JSON string `[[minX, minY, minZ], [maxX, maxY, maxZ]]` | Mesh bounding box when available.                                                           |
+
+Field-level metadata:
+
+| Key             | Value Format   | Description                                                                                       |
+| --------------- | -------------- | ------------------------------------------------------------------------------------------------- |
+| `byteOffset`    | Numeric string | Attribute byte offset when preserved from the source mesh accessor.                                |
+| `byteStride`    | Numeric string | Attribute byte stride when preserved from the source mesh accessor.                                |
+| `normalized`    | Boolean string | Whether integer attribute values should be interpreted as normalized values.                       |
+| Loader-specific | String or JSON string | Loader-specific metadata may be preserved, for example Draco metadata entries encoded as JSON strings. |
 
 ### Header
 

--- a/modules/arrow/src/lib/utils/arrow-schema-utils.ts
+++ b/modules/arrow/src/lib/utils/arrow-schema-utils.ts
@@ -22,8 +22,8 @@ function formatSchemaFieldNames(fields: arrow.Field[]): string {
 }
 
 /**
- * Validates that an Arrow table matches an expected schema by field order, field name, and Arrow
- * type id.
+ * Validates that an Arrow table matches an expected schema by field order, field name, Arrow type,
+ * and field nullability.
  *
  * Extra trailing fields are accepted by default so clients can tolerate additive schema changes.
  * Set `rejectExtraFields` to require an exact field count.
@@ -66,13 +66,34 @@ export function validateArrowTableSchema<T extends arrow.TypeMap>(
       );
     }
     if (expected.type.typeId !== actual.type.typeId) {
+      throw new Error(getFieldTypeValidationError(expected, actual, schemaPrefix));
+    }
+    if (expected.type.toString() !== actual.type.toString()) {
+      throw new Error(getFieldTypeValidationError(expected, actual, schemaPrefix));
+    }
+    if (expected.nullable !== actual.nullable) {
       throw new Error(
-        `${schemaPrefix}${expected.name}: expected type ${expected.type.typeId}, got ${actual.type.typeId}`
+        `${schemaPrefix}${expected.name}: expected nullable=${expected.nullable}, got nullable=${actual.nullable}`
       );
     }
   }
 
   return table as arrow.Table<T>;
+}
+
+/**
+ * Builds a detailed field type validation error for an Arrow field mismatch.
+ */
+function getFieldTypeValidationError(
+  expectedField: arrow.Field,
+  actualField: arrow.Field,
+  schemaPrefix: string
+): string {
+  return (
+    `${schemaPrefix}${expectedField.name}: expected type ${expectedField.type.toString()} ` +
+    `(type id ${expectedField.type.typeId}), got ${actualField.type.toString()} ` +
+    `(type id ${actualField.type.typeId})`
+  );
 }
 
 /**

--- a/modules/arrow/test/arrow-utils.spec.ts
+++ b/modules/arrow/test/arrow-utils.spec.ts
@@ -473,6 +473,53 @@ test('ArrowUtils#validateArrowTableSchema validates expected Arrow schema fields
     /record_id: expected type/,
     'rejects fields with the wrong Arrow type id'
   );
+
+  const wrongNestedTypeTable = createArrowTable(
+    new arrow.Schema([
+      new arrow.Field(
+        RECORD_ID_FIELD,
+        new arrow.List(new arrow.Field('value', new arrow.Float32())),
+        false
+      ),
+      new arrow.Field(DISPLAY_NAME_FIELD, new arrow.Utf8(), true)
+    ]),
+    {
+      [RECORD_ID_FIELD]: arrow.vectorFromArray(
+        [[1]],
+        new arrow.List(new arrow.Field('value', new arrow.Float32()))
+      ),
+      [DISPLAY_NAME_FIELD]: arrow.vectorFromArray(['Example record'], new arrow.Utf8())
+    }
+  );
+  const nestedExpectedSchema = new arrow.Schema([
+    new arrow.Field(
+      RECORD_ID_FIELD,
+      new arrow.List(new arrow.Field('value', new arrow.Int32())),
+      false
+    ),
+    new arrow.Field(DISPLAY_NAME_FIELD, new arrow.Utf8(), true)
+  ]);
+  t.throws(
+    () => validateArrowTableSchema(wrongNestedTypeTable, nestedExpectedSchema),
+    /record_id: expected type List<Int32> .* got List<Float32>/,
+    'rejects fields with the wrong nested Arrow type'
+  );
+
+  const wrongNullabilityTable = createArrowTable(
+    new arrow.Schema([
+      new arrow.Field(RECORD_ID_FIELD, new arrow.Utf8(), true),
+      new arrow.Field(DISPLAY_NAME_FIELD, new arrow.Utf8(), true)
+    ]),
+    {
+      [RECORD_ID_FIELD]: arrow.vectorFromArray(['record-1'], new arrow.Utf8()),
+      [DISPLAY_NAME_FIELD]: arrow.vectorFromArray(['Example record'], new arrow.Utf8())
+    }
+  );
+  t.throws(
+    () => validateArrowTableSchema(wrongNullabilityTable, expectedSchema),
+    /record_id: expected nullable=false, got nullable=true/,
+    'rejects fields with wrong nullability'
+  );
   t.end();
 });
 

--- a/modules/draco/test/draco-arrow-loader.spec.ts
+++ b/modules/draco/test/draco-arrow-loader.spec.ts
@@ -4,6 +4,8 @@ import {validateLoader} from 'test/common/conformance';
 
 import {DracoArrowLoader} from '@loaders.gl/draco';
 import {setLoaderOptions, load, isBrowser} from '@loaders.gl/core';
+import {validateArrowTableSchema} from '@loaders.gl/arrow';
+import {indexedMeshArrowSchema, meshArrowSchema} from '@loaders.gl/schema';
 import draco3d from 'draco3d';
 
 const BUNNY_DRC_URL = '@loaders.gl/draco/test/data/bunny.drc';
@@ -25,6 +27,7 @@ test('DracoArrowLoader#parse(mainthread)', async t => {
   const table = await load(BUNNY_DRC_URL, DracoArrowLoader, {worker: false});
   // validateMeshCategoryData(t, data);
   const {data} = table;
+  validateDracoMeshArrowTable(t, table);
   t.equal(data.numRows, 104502 / 3, 'number of rows is correct');
   const positions = data.getChild('POSITION')!;
   t.ok(positions, 'POSITION attribute was found');
@@ -44,6 +47,7 @@ test('DracoArrowLoader#draco3d npm package', async t => {
   });
   const {data} = table;
   // validateMeshCategoryData(t, data);
+  validateDracoMeshArrowTable(t, table);
   t.ok(data.getChild('POSITION'), 'POSITION attribute was found');
   t.end();
 });
@@ -55,6 +59,7 @@ test('DracoArrowLoader#parse custom attributes(mainthread)', async t => {
   let table = await load(CESIUM_TILE_URL, DracoArrowLoader, {
     worker: false
   });
+  validateDracoMeshArrowTable(t, table);
   const {data} = table;
   t.equal(
     data.getChild('CUSTOM_ATTRIBUTE_2')?.data[0].length,
@@ -76,6 +81,7 @@ test('DracoArrowLoader#parse custom attributes(mainthread)', async t => {
       }
     }
   });
+  validateDracoMeshArrowTable(t, table);
   t.equal(
     table.data.getChild('Intensity')?.data[0].length,
     173210,
@@ -100,4 +106,18 @@ function skipBrowserDracoWasmTest(t) {
     return true;
   }
   return false;
+}
+
+/**
+ * Validates a Draco Arrow mesh table against the shared Mesh or IndexedMesh Arrow schema.
+ */
+function validateDracoMeshArrowTable(t, table) {
+  const expectedSchema = table.data.getChild('indices') ? indexedMeshArrowSchema : meshArrowSchema;
+  t.doesNotThrow(
+    () =>
+      validateArrowTableSchema(table.data, expectedSchema, {
+        schemaName: 'DracoArrowLoader Mesh table'
+      }),
+    'Draco Arrow table matches the expected mesh Arrow schema'
+  );
 }

--- a/modules/pcd/test/pcd-arrow-loader.spec.ts
+++ b/modules/pcd/test/pcd-arrow-loader.spec.ts
@@ -8,6 +8,8 @@ import {validateLoader} from 'test/common/conformance';
 
 import {PCDArrowLoader} from '@loaders.gl/pcd';
 import {setLoaderOptions, fetchFile, parse} from '@loaders.gl/core';
+import {validateArrowTableSchema} from '@loaders.gl/arrow';
+import {meshArrowSchema} from '@loaders.gl/schema';
 
 const PCD_ASCII_URL = '@loaders.gl/pcd/test/data/simple-ascii.pcd';
 // const PCD_BINARY_URL = '@loaders.gl/pcd/test/data/Zaghetto.pcd';
@@ -24,8 +26,9 @@ test('PCDArrowLoader#loader conformance', t => {
 test('PCDArrowLoader#parse(text)', async t => {
   const arrowTable = await parse(fetchFile(PCD_ASCII_URL), PCDArrowLoader);
 
-  // TODO - validate arrow mesh category data?
-  // validateMeshCategoryData(t, arrowTable);
+  validateArrowTableSchema(arrowTable.data, meshArrowSchema, {
+    schemaName: 'PCDArrowLoader Mesh table'
+  });
 
   const {data} = arrowTable;
   t.equal(data.schema.fields.length, 2, 'schema field count is correct');

--- a/modules/ply/test/index.js
+++ b/modules/ply/test/index.js
@@ -1,1 +1,2 @@
 import './ply-loader.spec';
+import './ply-arrow-loader.spec';

--- a/modules/ply/test/ply-arrow-loader.spec.js
+++ b/modules/ply/test/ply-arrow-loader.spec.js
@@ -8,6 +8,8 @@ import {validateLoader} from 'test/common/conformance';
 
 import {PLYArrowLoader} from '@loaders.gl/ply';
 import {fetchFile, parse} from '@loaders.gl/core';
+import {validateArrowTableSchema} from '@loaders.gl/arrow';
+import {indexedMeshArrowSchema} from '@loaders.gl/schema';
 
 const PLY_CUBE_ATT_URL = '@loaders.gl/ply/test/data/cube_att.ply';
 
@@ -20,6 +22,9 @@ test('PLYArrowLoader#parse indexed cube', async t => {
   const table = await parse(fetchFile(PLY_CUBE_ATT_URL), PLYArrowLoader);
 
   t.equal(table.shape, 'arrow-table', 'table has arrow-table shape');
+  validateArrowTableSchema(table.data, indexedMeshArrowSchema, {
+    schemaName: 'PLYArrowLoader IndexedMesh table'
+  });
   t.deepEqual(
     table.data.schema.fields.map(field => field.name),
     ['POSITION', 'indices', 'NORMAL'],

--- a/modules/ply/test/ply-arrow-loader.spec.js
+++ b/modules/ply/test/ply-arrow-loader.spec.js
@@ -1,0 +1,35 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/* eslint-disable max-len */
+import test from 'tape-promise/tape';
+import {validateLoader} from 'test/common/conformance';
+
+import {PLYArrowLoader} from '@loaders.gl/ply';
+import {fetchFile, parse} from '@loaders.gl/core';
+
+const PLY_CUBE_ATT_URL = '@loaders.gl/ply/test/data/cube_att.ply';
+
+test('PLYArrowLoader#loader conformance', t => {
+  validateLoader(t, PLYArrowLoader, 'PLYArrowLoader');
+  t.end();
+});
+
+test('PLYArrowLoader#parse indexed cube', async t => {
+  const table = await parse(fetchFile(PLY_CUBE_ATT_URL), PLYArrowLoader);
+
+  t.equal(table.shape, 'arrow-table', 'table has arrow-table shape');
+  t.deepEqual(
+    table.data.schema.fields.map(field => field.name),
+    ['POSITION', 'indices', 'NORMAL'],
+    'indexed schema fields are first'
+  );
+
+  const indicesColumn = table.data.getChild('indices');
+  t.ok(indicesColumn, 'indices column was found');
+  t.equal(indicesColumn.get(0).length, 36, 'indices were found in row 0');
+  t.equal(indicesColumn.get(1), null, 'indices are null after row 0');
+
+  t.end();
+});

--- a/modules/schema-utils/src/lib/arrow-utils/arrow-fixed-size-list-utils.ts
+++ b/modules/schema-utils/src/lib/arrow-utils/arrow-fixed-size-list-utils.ts
@@ -58,6 +58,6 @@ export function getFixedSizeListData(
 export function getFixedSizeListType(typedArray: TypedArray, stride: number): arrow.FixedSizeList {
   const {type} = getDataTypeFromArray(typedArray);
   const arrowType = deserializeArrowType(type);
-  const listType = new arrow.FixedSizeList(stride, new arrow.Field('value', arrowType));
+  const listType = new arrow.FixedSizeList(stride, new arrow.Field('value', arrowType, false));
   return listType;
 }

--- a/modules/schema-utils/src/lib/mesh/convert-mesh-to-table.ts
+++ b/modules/schema-utils/src/lib/mesh/convert-mesh-to-table.ts
@@ -2,21 +2,40 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {Mesh, ArrowTable, ColumnarTable} from '@loaders.gl/schema';
+import type {
+  Mesh,
+  MeshAttribute,
+  MeshArrowTable,
+  MeshTable,
+  ArrowTable,
+  ColumnarTable
+} from '@loaders.gl/schema';
+import {indexedMeshArrowSchema, meshArrowSchema} from '@loaders.gl/schema';
 import * as arrow from 'apache-arrow';
-import {getFixedSizeListData} from '../arrow-utils/arrow-fixed-size-list-utils';
-import {deserializeArrowSchema} from '../schema/convert-arrow-schema';
+import {getFixedSizeListVector} from '../arrow-utils/arrow-fixed-size-list-utils';
+import {
+  deserializeArrowField,
+  deserializeArrowMetadata,
+  serializeArrowSchema
+} from '../schema/convert-arrow-schema';
 
-export function convertMeshToTable(mesh: Mesh, shape: 'columnar-table'): ColumnarTable;
-export function convertMeshToTable(mesh: Mesh, shape: 'arrow-table'): ArrowTable;
+const MESH_ARROW_ATTRIBUTE_ORDER = ['POSITION'];
+
+/** Convert a mesh to a columnar table. */
+export function convertMeshToTable(mesh: Mesh, shape: 'columnar-table'): MeshTable;
+/** Convert a mesh to an Apache Arrow table. */
+export function convertMeshToTable(mesh: Mesh, shape: 'arrow-table'): MeshArrowTable;
 
 /**
- * Convert a mesh to a specific shape
+ * Convert a mesh to a specific table shape.
+ * @param mesh Mesh to convert.
+ * @param shape Target table shape.
+ * @returns Mesh data in the requested table shape.
  */
 export function convertMeshToTable(
   mesh: Mesh,
   shape: 'columnar-table' | 'arrow-table'
-): Mesh | ColumnarTable | ArrowTable {
+): Mesh | ColumnarTable | ArrowTable | MeshArrowTable {
   switch (shape) {
     case 'columnar-table':
       return convertMeshToColumnarTable(mesh);
@@ -28,12 +47,13 @@ export function convertMeshToTable(
 }
 
 /**
- * Convert a loaders.gl Mesh to a Columnar Table
- * @param mesh
- * @returns
+ * Convert a loaders.gl Mesh to a columnar table.
+ * @param mesh Mesh to convert.
+ * @returns Mesh data as a columnar table.
  */
-export function convertMeshToColumnarTable(mesh: Mesh): ColumnarTable {
+export function convertMeshToColumnarTable(mesh: Mesh): MeshTable {
   const columns = {};
+  const hasIndices = hasMeshIndices(mesh);
 
   for (const [columnName, attribute] of Object.entries(mesh.attributes)) {
     columns[columnName] = attribute.value;
@@ -42,36 +62,144 @@ export function convertMeshToColumnarTable(mesh: Mesh): ColumnarTable {
   return {
     shape: 'columnar-table',
     schema: mesh.schema,
-    data: columns
+    data: columns,
+    topology: mesh.topology,
+    indices: hasIndices ? mesh.indices : undefined
   };
 }
 
 /**
- * * Convert a loaders.gl Mesh to an Apache Arrow Table
- * @param mesh
- * @param metadata
- * @param batchSize
- * @returns
+ * Convert a loaders.gl Mesh to an Apache Arrow table.
+ * @param mesh Mesh to convert.
+ * @param batchSize Reserved for future chunked Arrow conversion.
+ * @returns Mesh data as an Apache Arrow table wrapper.
  */
-export function convertMeshToArrowTable(mesh: Mesh, batchSize?: number): ArrowTable {
-  const {schema} = mesh;
-  const arrowSchema = deserializeArrowSchema(schema);
+export function convertMeshToArrowTable(mesh: Mesh, batchSize?: number): MeshArrowTable {
+  const fields: arrow.Field[] = [];
+  const columns: {[columnName: string]: arrow.Vector} = {};
+  const attributeNames = getOrderedAttributeNames(mesh);
+  const hasIndices = hasMeshIndices(mesh);
 
-  const arrowDatas: arrow.Data[] = [];
-  for (const attributeKey in mesh.attributes) {
-    const attribute = mesh.attributes[attributeKey];
+  for (const attributeName of attributeNames) {
+    const attribute = mesh.attributes[attributeName];
     const {value, size = 1} = attribute;
+    const column = getFixedSizeListVector(value, size);
 
-    const listData = getFixedSizeListData(value, size);
-    arrowDatas.push(listData);
-    // fields.push(field);
+    columns[attributeName] = column;
+    fields.push(getAttributeArrowField(mesh, attributeName, column));
+
+    if (attributeName === 'POSITION' && hasIndices) {
+      const indicesField = indexedMeshArrowSchema.fields.find(field => field.name === 'indices')!;
+      columns.indices = getIndicesVector(mesh.indices.value, column.length, indicesField.type);
+      fields.push(indicesField);
+    }
   }
 
-  const structField = new arrow.Struct(arrowSchema.fields);
-  const length = arrowDatas[0].length;
-  const structData = new arrow.Data(structField, 0, length, 0, undefined, arrowDatas);
-  const recordBatch = new arrow.RecordBatch(arrowSchema, structData);
-  const table = new arrow.Table([recordBatch]);
+  const arrowSchema = new arrow.Schema(fields, getMeshArrowMetadata(mesh));
+  const table = new arrow.Table(arrowSchema, columns);
+  const schema = serializeArrowSchema(table.schema);
 
-  return {shape: 'arrow-table', schema, data: table};
+  return {
+    shape: 'arrow-table',
+    schema,
+    data: table,
+    topology: mesh.topology,
+    indices: hasIndices ? mesh.indices : undefined
+  };
+}
+
+/** Return mesh attribute names with predefined Mesh Arrow fields first. */
+function getOrderedAttributeNames(mesh: Mesh): string[] {
+  const attributeNames = Object.keys(mesh.attributes);
+  const orderedAttributeNames = MESH_ARROW_ATTRIBUTE_ORDER.filter(
+    attributeName => attributeName in mesh.attributes
+  );
+  const remainingAttributeNames = attributeNames.filter(
+    attributeName => !MESH_ARROW_ATTRIBUTE_ORDER.includes(attributeName)
+  );
+
+  return [...orderedAttributeNames, ...remainingAttributeNames];
+}
+
+/** Return true when a mesh has a non-empty top-level index accessor. */
+function hasMeshIndices(mesh: Mesh): mesh is Mesh & {indices: MeshAttribute} {
+  return Boolean(mesh.indices?.value?.length);
+}
+
+/** Return the Arrow field for a mesh attribute column. */
+function getAttributeArrowField(
+  mesh: Mesh,
+  attributeName: string,
+  column: arrow.Vector
+): arrow.Field {
+  if (attributeName === 'POSITION' && isMeshPositionColumn(column)) {
+    return meshArrowSchema.fields[0];
+  }
+
+  const field = mesh.schema.fields.find(schemaField => schemaField.name === attributeName);
+  return field ? deserializeArrowField(field) : new arrow.Field(attributeName, column.type, false);
+}
+
+/** Return true when an Arrow column matches the predefined Mesh POSITION field. */
+function isMeshPositionColumn(column: arrow.Vector): boolean {
+  return (
+    column.type instanceof arrow.FixedSizeList &&
+    column.type.listSize === 3 &&
+    column.type.children[0].type instanceof arrow.Float32
+  );
+}
+
+/** Return an IndexedMesh indices column with the full index list stored in row 0. */
+function getIndicesVector(
+  indices: MeshAttribute['value'],
+  vertexCount: number,
+  type: arrow.DataType
+): arrow.Vector {
+  const indicesType = type as arrow.List<arrow.Int32>;
+  const values = indices instanceof Int32Array ? indices : Int32Array.from(indices);
+  const valueOffsets = new Int32Array(vertexCount + 1);
+  if (vertexCount > 0) {
+    valueOffsets.fill(values.length, 1);
+  }
+
+  const nullBitmap = new Uint8Array(Math.ceil(vertexCount / 8));
+  if (vertexCount > 0) {
+    nullBitmap[0] = 1;
+  }
+
+  const valuesData = new arrow.Data<arrow.Int32>(
+    indicesType.children[0].type,
+    0,
+    values.length,
+    0,
+    {[arrow.BufferType.DATA]: values}
+  );
+  const indicesData = new arrow.Data<arrow.List<arrow.Int32>>(
+    indicesType,
+    0,
+    vertexCount,
+    Math.max(0, vertexCount - 1),
+    {
+      [arrow.BufferType.OFFSET]: valueOffsets,
+      [arrow.BufferType.VALIDITY]: nullBitmap
+    },
+    [valuesData]
+  );
+
+  return new arrow.Vector([indicesData]);
+}
+
+/** Return Arrow schema metadata for mesh-level properties. */
+function getMeshArrowMetadata(mesh: Mesh): Map<string, string> {
+  const metadata = {...mesh.schema?.metadata};
+  if (mesh.topology) {
+    metadata.topology ||= mesh.topology;
+  }
+  if (Number.isFinite(mesh.mode)) {
+    metadata.mode ||= String(mesh.mode);
+  }
+  if (mesh.header?.boundingBox) {
+    metadata.boundingBox ||= JSON.stringify(mesh.header.boundingBox);
+  }
+  return deserializeArrowMetadata(metadata);
 }

--- a/modules/schema-utils/src/lib/mesh/convert-table-to-mesh.ts
+++ b/modules/schema-utils/src/lib/mesh/convert-table-to-mesh.ts
@@ -76,7 +76,10 @@ function getAttributeTypedArray(attributeData: arrow.Vector, size: number): any 
   for (const data of attributeData.data) {
     const child = data.children[0];
     const sourceLength = data.length * size;
-    const source = child.values.subarray(0, sourceLength);
+    const sourceOffset = child.offset || data.offset * size;
+    // Arrow chunks can either slice child values eagerly or retain offsets into the source buffer.
+    const sourceStart = sourceOffset + sourceLength <= child.values.length ? sourceOffset : 0;
+    const source = child.values.subarray(sourceStart, sourceStart + sourceLength);
     typedArray.set(source, targetOffset);
     targetOffset += sourceLength;
   }

--- a/modules/schema-utils/src/lib/mesh/convert-table-to-mesh.ts
+++ b/modules/schema-utils/src/lib/mesh/convert-table-to-mesh.ts
@@ -3,12 +3,15 @@
 // Copyright (c) vis.gl contributors
 
 import type {Mesh, ColumnarTable, ArrowTable, Schema} from '@loaders.gl/schema';
+import * as arrow from 'apache-arrow';
 import {getFixedSizeListSize} from '../arrow-utils/arrow-fixed-size-list-utils';
 import {serializeArrowSchema} from '../schema/convert-arrow-schema';
 // import {makeMeshAttributeMetadata} from './deduce-mesh-schema';
 
 /**
- * Convert a mesh to a specific shape
+ * Convert a table to a mesh.
+ * @param table Table to convert.
+ * @returns Mesh reconstructed from the table.
  */
 export function convertTableToMesh(table: ColumnarTable | ArrowTable): Mesh {
   switch (table.shape) {
@@ -21,6 +24,11 @@ export function convertTableToMesh(table: ColumnarTable | ArrowTable): Mesh {
   }
 }
 
+/**
+ * Convert an Apache Arrow mesh table to a loaders.gl Mesh.
+ * @param table Arrow table wrapper to convert.
+ * @returns Mesh reconstructed from the Arrow table.
+ */
 export function convertArrowTableToMesh(table: ArrowTable): Mesh {
   const arrowTable = table.data;
 
@@ -30,20 +38,70 @@ export function convertArrowTableToMesh(table: ArrowTable): Mesh {
   const attributes: Mesh['attributes'] = {};
   for (const field of fields) {
     const {name} = field;
+    if (name === 'indices') {
+      continue;
+    }
     const attributeData = arrowTable.getChild(name)!;
     const size = getFixedSizeListSize(attributeData);
-    const typedArray = attributeData?.toArray();
+    const typedArray = getAttributeTypedArray(attributeData, size);
     attributes[name] = {value: typedArray, size};
   }
 
   fixMetadata(schema);
   const topology = schema.metadata.topology as any;
+  const mode = getMeshMode(schema);
+  const indices = getIndices(arrowTable);
 
-  return {schema, attributes, topology, mode: 0};
+  return {schema, attributes, topology, mode, indices};
 }
 
+/** Ensure required mesh metadata defaults are present on a schema. */
 function fixMetadata(schema: Schema) {
   schema.metadata ||= {};
   schema.metadata.topology ||= 'point-list';
   schema.metadata.mode ||= '0';
+}
+
+/** Return a typed attribute array from an Arrow attribute column. */
+function getAttributeTypedArray(attributeData: arrow.Vector, size: number): any {
+  if (!(attributeData.type instanceof arrow.FixedSizeList)) {
+    return attributeData.toArray();
+  }
+
+  const values = attributeData.data[0].children[0].values;
+  const TypedArrayConstructor = values.constructor as any;
+  const typedArray = new TypedArrayConstructor(attributeData.length * size);
+  let targetOffset = 0;
+
+  for (const data of attributeData.data) {
+    const child = data.children[0];
+    const sourceLength = data.length * size;
+    const source = child.values.subarray(0, sourceLength);
+    typedArray.set(source, targetOffset);
+    targetOffset += sourceLength;
+  }
+
+  return typedArray;
+}
+
+/** Return the mesh drawing mode stored in Arrow schema metadata. */
+function getMeshMode(schema: Schema): number {
+  const mode = Number(schema.metadata?.mode);
+  return Number.isFinite(mode) ? mode : 0;
+}
+
+/** Return top-level mesh indices from the predefined IndexedMesh Arrow column. */
+function getIndices(arrowTable: arrow.Table): Mesh['indices'] | undefined {
+  const indicesColumn = arrowTable.getChild('indices');
+  if (!indicesColumn?.isValid(0)) {
+    return undefined;
+  }
+
+  const indicesData = indicesColumn.data[0];
+  const valueOffsets = indicesData.valueOffsets;
+  const start = valueOffsets[indicesData.offset];
+  const end = valueOffsets[indicesData.offset + 1];
+  const values = indicesData.children[0].values.subarray(start, end);
+
+  return {value: values, size: 1};
 }

--- a/modules/schema-utils/test/index.ts
+++ b/modules/schema-utils/test/index.ts
@@ -12,3 +12,5 @@ import './lib/table/make-table-from-batches.spec';
 import './lib/table/deduce-table-schema.spec';
 import './lib/table/convert-table.spec';
 import './lib/table/convert-arrow-to-table.spec';
+
+import './lib/mesh/convert-mesh-to-table.spec';

--- a/modules/schema-utils/test/lib/mesh/convert-mesh-to-table.spec.ts
+++ b/modules/schema-utils/test/lib/mesh/convert-mesh-to-table.spec.ts
@@ -91,6 +91,46 @@ test('convertMeshToTable#indexed mesh Arrow table round trip', t => {
   t.end();
 });
 
+test('convertTableToMesh#honors FixedSizeList chunk offsets', t => {
+  const attributes = {
+    POSITION: {
+      value: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+      size: 3
+    }
+  };
+  const mesh: Mesh = {
+    schema: deduceMeshSchema(attributes, {topology: 'point-list', mode: '0'}),
+    attributes,
+    topology: 'point-list',
+    mode: 0
+  };
+  const table = convertMeshToTable(mesh, 'arrow-table');
+  const positionColumn = table.data.getChild('POSITION') as arrow.Vector<arrow.FixedSizeList>;
+  const positionData = positionColumn.data[0];
+  const offsetPositionData = new arrow.Data<arrow.FixedSizeList>(
+    positionData.type,
+    1,
+    2,
+    positionData.nullCount,
+    positionData,
+    positionData.children
+  );
+  const offsetTable = new arrow.Table(table.data.schema, {
+    POSITION: new arrow.Vector([offsetPositionData])
+  });
+
+  const roundTripMesh = convertTableToMesh({...table, data: offsetTable});
+
+  t.deepEqual(
+    Array.from(roundTripMesh.attributes.POSITION.value),
+    [1, 0, 0, 0, 1, 0],
+    'round trip uses the chunk offset when flattening values'
+  );
+  t.equal(roundTripMesh.attributes.POSITION.size, 3, 'round trip preserves position size');
+
+  t.end();
+});
+
 function makeMesh(indices?: Uint16Array): Mesh {
   const attributes = {
     POSITION: {

--- a/modules/schema-utils/test/lib/mesh/convert-mesh-to-table.spec.ts
+++ b/modules/schema-utils/test/lib/mesh/convert-mesh-to-table.spec.ts
@@ -1,0 +1,110 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'tape-promise/tape';
+import * as arrow from 'apache-arrow';
+
+import type {Mesh} from '@loaders.gl/schema';
+import {indexedMeshArrowSchema, meshArrowSchema} from '@loaders.gl/schema';
+import {convertMeshToTable, convertTableToMesh, deduceMeshSchema} from '@loaders.gl/schema-utils';
+
+test('meshArrowSchema', t => {
+  t.equal(meshArrowSchema.fields.length, 1, 'mesh schema has one predefined field');
+
+  const positionField = meshArrowSchema.fields[0];
+  t.equal(positionField.name, 'POSITION', 'position field is first');
+  t.notOk(positionField.nullable, 'position field is required');
+  t.ok(positionField.type instanceof arrow.FixedSizeList, 'position is a fixed-size list');
+  t.equal(positionField.type.listSize, 3, 'position has XYZ tuple size');
+  t.ok(positionField.type.children[0].type instanceof arrow.Float32, 'position values are float32');
+
+  t.end();
+});
+
+test('indexedMeshArrowSchema', t => {
+  t.equal(indexedMeshArrowSchema.fields.length, 2, 'indexed schema has two predefined fields');
+  t.equal(indexedMeshArrowSchema.fields[0].name, 'POSITION', 'position field is first');
+
+  const indicesField = indexedMeshArrowSchema.fields[1];
+  t.equal(indicesField.name, 'indices', 'indices field is second');
+  t.ok(indicesField.nullable, 'indices field is nullable');
+  t.ok(indicesField.type instanceof arrow.List, 'indices is a list');
+  t.ok(indicesField.type.children[0].type instanceof arrow.Int32, 'indices values are int32');
+
+  t.end();
+});
+
+test('convertMeshToTable#unindexed mesh Arrow table round trip', t => {
+  const mesh = makeMesh();
+  const table = convertMeshToTable(mesh, 'arrow-table');
+
+  t.equal(table.shape, 'arrow-table', 'table has arrow-table shape');
+  t.deepEqual(
+    table.data.schema.fields.map(field => field.name),
+    ['POSITION', 'NORMAL'],
+    'predefined position column is first'
+  );
+  t.notOk(table.data.getChild('indices'), 'indices column is absent');
+
+  const roundTripMesh = convertTableToMesh(table);
+  t.notOk(roundTripMesh.indices, 'round trip mesh has no top-level indices');
+  t.deepEqual(
+    Array.from(roundTripMesh.attributes.POSITION.value),
+    Array.from(mesh.attributes.POSITION.value),
+    'round trip preserves positions'
+  );
+  t.equal(roundTripMesh.attributes.POSITION.size, 3, 'round trip preserves position size');
+
+  t.end();
+});
+
+test('convertMeshToTable#indexed mesh Arrow table round trip', t => {
+  const mesh = makeMesh(new Uint16Array([0, 1, 2]));
+  const table = convertMeshToTable(mesh, 'arrow-table');
+
+  t.deepEqual(
+    table.data.schema.fields.map(field => field.name),
+    ['POSITION', 'indices', 'NORMAL'],
+    'indexed schema fields are first'
+  );
+
+  const indicesColumn = table.data.getChild('indices');
+  t.ok(indicesColumn, 'indices column is present');
+  t.deepEqual(Array.from(indicesColumn!.get(0)!), [0, 1, 2], 'indices are stored in row 0');
+  t.equal(indicesColumn!.get(1), null, 'remaining rows have null indices');
+
+  const roundTripMesh = convertTableToMesh(table);
+  t.ok(roundTripMesh.indices, 'round trip mesh restores top-level indices');
+  t.notOk(roundTripMesh.attributes.indices, 'round trip mesh does not create an indices attribute');
+  t.deepEqual(
+    Array.from(roundTripMesh.indices!.value),
+    [0, 1, 2],
+    'round trip mesh preserves indices'
+  );
+
+  t.end();
+});
+
+function makeMesh(indices?: Uint16Array): Mesh {
+  const attributes = {
+    POSITION: {
+      value: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+      size: 3
+    },
+    NORMAL: {
+      value: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+      size: 3
+    }
+  };
+  const topology = indices ? 'triangle-list' : 'point-list';
+  const mode = indices ? 4 : 0;
+
+  return {
+    schema: deduceMeshSchema(attributes, {topology, mode: String(mode)}),
+    attributes,
+    indices: indices ? {value: indices, size: 1} : undefined,
+    topology,
+    mode
+  };
+}

--- a/modules/schema-utils/test/lib/mesh/convert-mesh-to-table.spec.ts
+++ b/modules/schema-utils/test/lib/mesh/convert-mesh-to-table.spec.ts
@@ -8,6 +8,7 @@ import * as arrow from 'apache-arrow';
 import type {Mesh} from '@loaders.gl/schema';
 import {indexedMeshArrowSchema, meshArrowSchema} from '@loaders.gl/schema';
 import {convertMeshToTable, convertTableToMesh, deduceMeshSchema} from '@loaders.gl/schema-utils';
+import {validateArrowTableSchema} from '@loaders.gl/arrow';
 
 test('meshArrowSchema', t => {
   t.equal(meshArrowSchema.fields.length, 1, 'mesh schema has one predefined field');
@@ -40,6 +41,7 @@ test('convertMeshToTable#unindexed mesh Arrow table round trip', t => {
   const table = convertMeshToTable(mesh, 'arrow-table');
 
   t.equal(table.shape, 'arrow-table', 'table has arrow-table shape');
+  validateArrowTableSchema(table.data, meshArrowSchema, {schemaName: 'Mesh Arrow table'});
   t.deepEqual(
     table.data.schema.fields.map(field => field.name),
     ['POSITION', 'NORMAL'],
@@ -62,6 +64,9 @@ test('convertMeshToTable#unindexed mesh Arrow table round trip', t => {
 test('convertMeshToTable#indexed mesh Arrow table round trip', t => {
   const mesh = makeMesh(new Uint16Array([0, 1, 2]));
   const table = convertMeshToTable(mesh, 'arrow-table');
+  validateArrowTableSchema(table.data, indexedMeshArrowSchema, {
+    schemaName: 'IndexedMesh Arrow table'
+  });
 
   t.deepEqual(
     table.data.schema.fields.map(field => field.name),

--- a/modules/schema/src/categories/category-mesh.ts
+++ b/modules/schema/src/categories/category-mesh.ts
@@ -5,6 +5,7 @@
 import type {Schema} from '../types/schema';
 import type {TypedArray} from '../types/types';
 import type {ColumnarTable, ArrowTable} from './category-table';
+import * as arrow from 'apache-arrow';
 
 /** Mesh as columnar table */
 export interface MeshTable extends ColumnarTable {
@@ -16,9 +17,52 @@ export interface MeshTable extends ColumnarTable {
 /** Mesh as arrow table */
 export interface MeshArrowTable extends ArrowTable {
   // shape: 'mesh-arrow-table';
+  /** Mesh topology represented by the Arrow table rows and indices. */
   topology: 'point-list' | 'triangle-list' | 'triangle-strip';
+  /** Optional top-level primitive indices accessor for indexed meshes. */
   indices?: MeshAttribute;
+  /** Raw Apache Arrow table data for Mesh or IndexedMesh columns. */
+  data: MeshArrowTableData | IndexedMeshArrowTableData;
 }
+
+/** Apache Arrow columns for a mesh vertex table. */
+export type MeshArrowColumns = {
+  /** XYZ vertex positions as float32 tuples. */
+  POSITION: arrow.FixedSizeList<arrow.Float32>;
+  /** Loader-specific vertex attribute columns appended after predefined fields. */
+  [attributeName: string]: arrow.DataType;
+};
+
+/** Apache Arrow columns for an indexed mesh vertex table. */
+export type IndexedMeshArrowColumns = MeshArrowColumns & {
+  /** Primitive indices, stored in row 0 and null for remaining vertex rows. */
+  indices: arrow.List<arrow.Int32>;
+};
+
+/** Raw Apache Arrow table data for a mesh vertex table. */
+export type MeshArrowTableData = arrow.Table<MeshArrowColumns>;
+
+/** Raw Apache Arrow table data for an indexed mesh vertex table. */
+export type IndexedMeshArrowTableData = arrow.Table<IndexedMeshArrowColumns>;
+
+/** Predefined Apache Arrow schema for common mesh vertex columns. */
+export const meshArrowSchema = new arrow.Schema<MeshArrowColumns>([
+  new arrow.Field(
+    'POSITION',
+    new arrow.FixedSizeList(3, new arrow.Field('value', new arrow.Float32(), false)),
+    false
+  )
+]);
+
+/** Predefined Apache Arrow schema for indexed mesh vertex tables. */
+export const indexedMeshArrowSchema = new arrow.Schema<IndexedMeshArrowColumns>([
+  ...meshArrowSchema.fields,
+  new arrow.Field(
+    'indices',
+    new arrow.List(new arrow.Field('item', new arrow.Int32(), false)),
+    true
+  )
+]);
 
 /** Geometry part of a Mesh (compatible with a standard luma.gl "mesh") */
 export type MeshGeometry = {

--- a/modules/schema/src/index.ts
+++ b/modules/schema/src/index.ts
@@ -42,11 +42,16 @@ export type {
 export type {
   MeshTable,
   MeshArrowTable,
+  MeshArrowColumns,
+  IndexedMeshArrowColumns,
+  MeshArrowTableData,
+  IndexedMeshArrowTableData,
   Mesh,
   MeshGeometry,
   MeshAttribute,
   MeshAttributes
 } from './categories/category-mesh';
+export {meshArrowSchema, indexedMeshArrowSchema} from './categories/category-mesh';
 
 // TEXTURES
 export type {

--- a/modules/terrain/package.json
+++ b/modules/terrain/package.json
@@ -52,6 +52,7 @@
     "@loaders.gl/images": "4.4.0",
     "@loaders.gl/loader-utils": "4.4.0",
     "@loaders.gl/schema": "4.4.0",
+    "@loaders.gl/schema-utils": "4.4.0",
     "@mapbox/martini": "^0.2.0"
   },
   "peerDependencies": {

--- a/modules/terrain/src/index.ts
+++ b/modules/terrain/src/index.ts
@@ -3,7 +3,9 @@
 // Copyright (c) vis.gl contributors
 
 import type {LoaderContext, LoaderWithParser} from '@loaders.gl/loader-utils';
+import type {Mesh, MeshArrowTable} from '@loaders.gl/schema';
 import {parseFromContext} from '@loaders.gl/loader-utils';
+import {convertMeshToTable} from '@loaders.gl/schema-utils';
 import {parseQuantizedMesh} from './lib/parse-quantized-mesh';
 import {TerrainOptions, makeTerrainMeshFromImage} from './lib/parse-terrain';
 
@@ -17,16 +19,37 @@ import {
 
 export {TerrainWorkerLoader};
 
+/**
+ * Loader for height-map terrain meshes.
+ */
 export const TerrainLoader = {
   ...TerrainWorkerLoader,
   parse: parseTerrain
-} as const satisfies LoaderWithParser<any, never, TerrainLoaderOptions>;
+} as const satisfies LoaderWithParser<Mesh, never, TerrainLoaderOptions>;
 
+/**
+ * Loader for height-map terrain meshes as Apache Arrow tables.
+ */
+export const TerrainArrowLoader = {
+  ...TerrainWorkerLoader,
+  dataType: null as unknown as MeshArrowTable,
+  batchType: null as never,
+  worker: false,
+  parse: parseTerrainArrow
+} as const satisfies LoaderWithParser<MeshArrowTable, never, TerrainLoaderOptions>;
+
+/**
+ * Parse a height-map terrain image as a mesh.
+ * @param arrayBuffer Encoded height-map image bytes.
+ * @param options Terrain loader options.
+ * @param context Loader context used to parse the image payload.
+ * @returns Terrain mesh reconstructed from the image.
+ */
 export async function parseTerrain(
   arrayBuffer: ArrayBuffer,
   options?: TerrainLoaderOptions,
   context?: LoaderContext
-) {
+): Promise<Mesh> {
   const loadImageOptions = {
     ...options,
     core: {...options?.core, mimeType: 'application/x.image'},
@@ -37,6 +60,16 @@ export async function parseTerrain(
   const terrainOptions = {...TerrainLoader.options.terrain, ...options?.terrain} as TerrainOptions;
   // @ts-expect-error TODO - fix typing
   return makeTerrainMeshFromImage(image, terrainOptions);
+}
+
+/** Parse a height-map terrain mesh as an Apache Arrow table. */
+async function parseTerrainArrow(
+  arrayBuffer: ArrayBuffer,
+  options?: TerrainLoaderOptions,
+  context?: LoaderContext
+): Promise<MeshArrowTable> {
+  const mesh = await parseTerrain(arrayBuffer, options, context);
+  return convertMeshToTable(mesh, 'arrow-table');
 }
 
 // QuantizedMeshLoader
@@ -51,4 +84,25 @@ export const QuantizedMeshLoader = {
   parseSync: (arrayBuffer, options) => parseQuantizedMesh(arrayBuffer, options?.['quantized-mesh']),
   parse: async (arrayBuffer, options) =>
     parseQuantizedMesh(arrayBuffer, options?.['quantized-mesh'])
-} as const satisfies LoaderWithParser<any, never, QuantizedMeshLoaderOptions>;
+} as const satisfies LoaderWithParser<Mesh, never, QuantizedMeshLoaderOptions>;
+
+/**
+ * Loader for quantized meshes as Apache Arrow tables.
+ */
+export const QuantizedMeshArrowLoader = {
+  ...QuantizedMeshWorkerLoader,
+  dataType: null as unknown as MeshArrowTable,
+  batchType: null as never,
+  worker: false,
+  parseSync: parseQuantizedMeshArrow,
+  parse: async (arrayBuffer, options) => parseQuantizedMeshArrow(arrayBuffer, options)
+} as const satisfies LoaderWithParser<MeshArrowTable, never, QuantizedMeshLoaderOptions>;
+
+/** Parse a quantized mesh as an Apache Arrow table. */
+function parseQuantizedMeshArrow(
+  arrayBuffer: ArrayBuffer,
+  options?: QuantizedMeshLoaderOptions
+): MeshArrowTable {
+  const mesh = parseQuantizedMesh(arrayBuffer, options?.['quantized-mesh']);
+  return convertMeshToTable(mesh, 'arrow-table');
+}

--- a/modules/terrain/src/lib/parse-quantized-mesh.ts
+++ b/modules/terrain/src/lib/parse-quantized-mesh.ts
@@ -3,15 +3,23 @@
 // Copyright (c) vis.gl contributors
 
 import type {Mesh} from '@loaders.gl/schema';
-import {getMeshBoundingBox} from '@loaders.gl/schema-utils';
+import {deduceMeshSchema, getMeshBoundingBox} from '@loaders.gl/schema-utils';
 import decode, {DECODING_STEPS} from './decode-quantized-mesh';
 import {addSkirt} from './helpers/skirt';
 
 export type ParseQuantizedMeshOptions = {
+  /** Bounds used to map quantized mesh coordinates to x/y positions. */
   bounds?: [number, number, number, number];
+  /** Optional skirt height in meters. */
   skirtHeight?: number | null;
 };
 
+/**
+ * Parse quantized mesh terrain bytes as a mesh.
+ * @param arrayBuffer Quantized mesh terrain bytes.
+ * @param options Quantized mesh parser options.
+ * @returns Terrain mesh decoded from the quantized mesh payload.
+ */
 export function parseQuantizedMesh(
   arrayBuffer: ArrayBuffer,
   options: ParseQuantizedMeshOptions = {}
@@ -51,6 +59,14 @@ export function parseQuantizedMesh(
     triangleIndices = newTriangles;
   }
 
+  const topology = 'triangle-list';
+  const mode = 4; // TRIANGLES
+  const schema = deduceMeshSchema(attributes, {
+    topology,
+    mode: String(mode),
+    boundingBox: JSON.stringify(boundingBox)
+  });
+
   return {
     // Data return by this loader implementation
     loaderData: {
@@ -61,10 +77,9 @@ export function parseQuantizedMesh(
       vertexCount: triangleIndices.length,
       boundingBox
     },
-    // TODO
-    schema: undefined!,
-    topology: 'triangle-list',
-    mode: 4, // TRIANGLES
+    schema,
+    topology,
+    mode,
     indices: {value: triangleIndices, size: 1},
     attributes
   };

--- a/modules/terrain/src/lib/parse-terrain.ts
+++ b/modules/terrain/src/lib/parse-terrain.ts
@@ -2,29 +2,42 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {getMeshBoundingBox} from '@loaders.gl/schema-utils';
+import type {Mesh} from '@loaders.gl/schema';
+import {deduceMeshSchema, getMeshBoundingBox} from '@loaders.gl/schema-utils';
 import Martini from '@mapbox/martini';
 import Delatin from './delatin/index';
 import {addSkirt} from './helpers/skirt';
 
 export type TerrainOptions = {
+  /** Maximum terrain mesh error in meters. */
   meshMaxError: number;
+  /** Bounds used to map terrain image coordinates to x/y positions. */
   bounds: number[];
+  /** Decoder used to convert terrain image channels to elevation values. */
   elevationDecoder: ElevationDecoder;
+  /** Tesselation algorithm used to reconstruct the terrain mesh. */
   tesselator: 'martini' | 'delatin' | 'auto';
+  /** Optional skirt height in meters. */
   skirtHeight?: number;
 };
 
 type TerrainImage = {
+  /** Terrain image pixel data. */
   data: Uint8Array;
+  /** Terrain image width in pixels. */
   width: number;
+  /** Terrain image height in pixels. */
   height: number;
 };
 
 type ElevationDecoder = {
+  /** Red channel elevation scale. */
   rScaler: any;
+  /** Blue channel elevation scale. */
   bScaler: any;
+  /** Green channel elevation scale. */
   gScaler: any;
+  /** Elevation offset added after channel scaling. */
   offset: number;
 };
 
@@ -38,7 +51,7 @@ type ElevationDecoder = {
 export function makeTerrainMeshFromImage(
   terrainImage: TerrainImage,
   terrainOptions: TerrainOptions
-) {
+): Mesh {
   const {meshMaxError, bounds, elevationDecoder} = terrainOptions;
 
   const {data, width, height} = terrainImage;
@@ -83,6 +96,14 @@ export function makeTerrainMeshFromImage(
     triangles = newTriangles;
   }
 
+  const topology = 'triangle-list';
+  const mode = 4; // TRIANGLES
+  const schema = deduceMeshSchema(attributes, {
+    topology,
+    mode: String(mode),
+    boundingBox: JSON.stringify(boundingBox)
+  });
+
   return {
     // Data return by this loader implementation
     loaderData: {
@@ -92,7 +113,9 @@ export function makeTerrainMeshFromImage(
       vertexCount: triangles.length,
       boundingBox
     },
-    mode: 4, // TRIANGLES
+    schema,
+    topology,
+    mode,
     indices: {value: Uint32Array.from(triangles), size: 1},
     attributes
   };

--- a/modules/terrain/test/index.js
+++ b/modules/terrain/test/index.js
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import './quantized-mesh-loader.spec';
+import './terrain-arrow-loader.spec';
 import './terrain-loader.spec';
 
 import './lib/helpers/skirt.spec';

--- a/modules/terrain/test/terrain-arrow-loader.spec.js
+++ b/modules/terrain/test/terrain-arrow-loader.spec.js
@@ -1,0 +1,68 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/* eslint-disable max-len */
+import test from 'tape-promise/tape';
+import {validateLoader} from 'test/common/conformance';
+
+import {TerrainArrowLoader, QuantizedMeshArrowLoader} from '@loaders.gl/terrain';
+import {setLoaderOptions, load, registerLoaders} from '@loaders.gl/core';
+import {ImageLoader} from '@loaders.gl/images';
+
+registerLoaders([ImageLoader]);
+
+const TERRARIUM_TERRAIN_PNG_URL = '@loaders.gl/terrain/test/data/terrarium.png';
+const TILE_WITH_EXTENSIONS_URL = '@loaders.gl/terrain/test/data/tile-with-extensions.terrain';
+
+setLoaderOptions({
+  _workerType: 'test'
+});
+
+test('TerrainArrowLoader#loader objects', t => {
+  validateLoader(t, TerrainArrowLoader, 'TerrainArrowLoader');
+  validateLoader(t, QuantizedMeshArrowLoader, 'QuantizedMeshArrowLoader');
+  t.end();
+});
+
+test('TerrainArrowLoader#parse terrarium martini', async t => {
+  const table = await load(TERRARIUM_TERRAIN_PNG_URL, TerrainArrowLoader, {
+    terrain: {
+      elevationDecoder: {
+        rScaler: 256,
+        gScaler: 1,
+        bScaler: 1 / 256,
+        offset: -32768
+      },
+      meshMaxError: 10.0,
+      bounds: [83, 329.5, 83.125, 329.625],
+      tesselator: 'martini'
+    }
+  });
+
+  t.equal(table.shape, 'arrow-table', 'table has arrow-table shape');
+  t.equal(table.data.numRows, 5696, 'table has one row per vertex');
+  t.ok(table.data.getChild('POSITION'), 'POSITION column was found');
+  t.ok(table.data.getChild('TEXCOORD_0'), 'TEXCOORD_0 column was found');
+  const indicesColumn = table.data.getChild('indices');
+  t.ok(indicesColumn, 'indices column was found');
+  t.equal(indicesColumn.get(0).length, 11188 * 3, 'indices were found in row 0');
+  t.equal(indicesColumn.get(1), null, 'indices are null after row 0');
+
+  t.end();
+});
+
+test('QuantizedMeshArrowLoader#parse tile-with-extensions', async t => {
+  const table = await load(TILE_WITH_EXTENSIONS_URL, QuantizedMeshArrowLoader);
+
+  t.equal(table.shape, 'arrow-table', 'table has arrow-table shape');
+  t.equal(table.data.numRows, 627, 'table has one row per vertex');
+  t.ok(table.data.getChild('POSITION'), 'POSITION column was found');
+  t.ok(table.data.getChild('TEXCOORD_0'), 'TEXCOORD_0 column was found');
+  const indicesColumn = table.data.getChild('indices');
+  t.ok(indicesColumn, 'indices column was found');
+  t.equal(indicesColumn.get(0).length, 1175 * 3, 'indices were found in row 0');
+  t.equal(indicesColumn.get(1), null, 'indices are null after row 0');
+
+  t.end();
+});

--- a/modules/terrain/test/terrain-arrow-loader.spec.js
+++ b/modules/terrain/test/terrain-arrow-loader.spec.js
@@ -9,6 +9,8 @@ import {validateLoader} from 'test/common/conformance';
 import {TerrainArrowLoader, QuantizedMeshArrowLoader} from '@loaders.gl/terrain';
 import {setLoaderOptions, load, registerLoaders} from '@loaders.gl/core';
 import {ImageLoader} from '@loaders.gl/images';
+import {validateArrowTableSchema} from '@loaders.gl/arrow';
+import {indexedMeshArrowSchema} from '@loaders.gl/schema';
 
 registerLoaders([ImageLoader]);
 
@@ -41,6 +43,9 @@ test('TerrainArrowLoader#parse terrarium martini', async t => {
   });
 
   t.equal(table.shape, 'arrow-table', 'table has arrow-table shape');
+  validateArrowTableSchema(table.data, indexedMeshArrowSchema, {
+    schemaName: 'TerrainArrowLoader IndexedMesh table'
+  });
   t.equal(table.data.numRows, 5696, 'table has one row per vertex');
   t.ok(table.data.getChild('POSITION'), 'POSITION column was found');
   t.ok(table.data.getChild('TEXCOORD_0'), 'TEXCOORD_0 column was found');
@@ -56,6 +61,9 @@ test('QuantizedMeshArrowLoader#parse tile-with-extensions', async t => {
   const table = await load(TILE_WITH_EXTENSIONS_URL, QuantizedMeshArrowLoader);
 
   t.equal(table.shape, 'arrow-table', 'table has arrow-table shape');
+  validateArrowTableSchema(table.data, indexedMeshArrowSchema, {
+    schemaName: 'QuantizedMeshArrowLoader IndexedMesh table'
+  });
   t.equal(table.data.numRows, 627, 'table has one row per vertex');
   t.ok(table.data.getChild('POSITION'), 'POSITION column was found');
   t.ok(table.data.getChild('TEXCOORD_0'), 'TEXCOORD_0 column was found');

--- a/yarn.lock
+++ b/yarn.lock
@@ -5107,6 +5107,7 @@ __metadata:
     "@loaders.gl/images": "npm:4.4.0"
     "@loaders.gl/loader-utils": "npm:4.4.0"
     "@loaders.gl/schema": "npm:4.4.0"
+    "@loaders.gl/schema-utils": "npm:4.4.0"
     "@mapbox/martini": "npm:^0.2.0"
   peerDependencies:
     "@loaders.gl/core": ~4.4.0


### PR DESCRIPTION
## Goals

Add schema-first Mesh and IndexedMesh Arrow table contracts, expose Arrow loader variants for the remaining terrain Mesh-category loaders, and document Mesh Arrow as the primary tabular mesh surface across Mesh-category modules.

## Changes

- Added `MeshArrowColumns`, `IndexedMeshArrowColumns`, raw Arrow table aliases, `meshArrowSchema`, and `indexedMeshArrowSchema` to `@loaders.gl/schema`.
- Updated mesh-to-Arrow conversion to emit predefined fields first, append loader-specific attributes, store indexed mesh `indices` in row 0, and attach mesh metadata.
- Updated Arrow-to-mesh conversion to restore top-level `mesh.indices` and avoid creating an `indices` attribute.
- Added `TerrainArrowLoader` and `QuantizedMeshArrowLoader`.
- Made terrain and quantized-mesh parser outputs schema-complete with `deduceMeshSchema`.
- Added schema, round-trip, terrain Arrow loader, quantized mesh Arrow loader, and PLY indexed Arrow coverage.
- Updated Mesh category docs with Arrow columns, metadata, and lowercase `indices` semantics.
- Updated Draco, LAS, OBJ, PCD, PLY, and Terrain module docs to list Arrow loaders first and link to the Mesh Arrow table category docs.
