### PR TITLE
feat(tiles) Add Tile2DSource

### DIFF
--- a/dev-modules/devtools-extensions/biome/lint.mjs
+++ b/dev-modules/devtools-extensions/biome/lint.mjs
@@ -7,7 +7,28 @@ const repoRoot = path.resolve(packageDirectory, '..', '..', '..');
 const biomeArguments = process.argv.slice(2);
 const mode = biomeArguments[0] === 'fix' ? 'fix' : 'check';
 const extraArguments = mode === 'fix' ? biomeArguments.slice(1) : biomeArguments;
-const targetPaths = ['modules', 'apps', 'dev-docs', 'docs', 'test'];
+const targetPaths = [
+  'modules/**/*.js',
+  'modules/**/*.jsx',
+  'modules/**/*.ts',
+  'modules/**/*.tsx',
+  'apps/**/*.js',
+  'apps/**/*.jsx',
+  'apps/**/*.ts',
+  'apps/**/*.tsx',
+  'dev-docs/**/*.js',
+  'dev-docs/**/*.jsx',
+  'dev-docs/**/*.ts',
+  'dev-docs/**/*.tsx',
+  'docs/**/*.js',
+  'docs/**/*.jsx',
+  'docs/**/*.ts',
+  'docs/**/*.tsx',
+  'test/**/*.js',
+  'test/**/*.jsx',
+  'test/**/*.ts',
+  'test/**/*.tsx'
+];
 const sharedArguments = [
   '--config-path=biome.jsonc',
   '--files-ignore-unknown=true',

--- a/docs/README.mdx
+++ b/docs/README.mdx
@@ -2,7 +2,8 @@
 
 <img src="https://badge.fury.io/js/%40loaders.gl%2Fcore.svg" /> &nbsp;
 <img src="https://img.shields.io/badge/License-MIT-green.svg" /> &nbsp;
-<img src="https://img.shields.io/npm/dm/@loaders.gl/core.svg" />  &nbsp; &nbsp; &nbsp;
+<img src="https://img.shields.io/npm/dm/@loaders.gl/core.svg" />  &nbsp;
+<img src="https://img.shields.io/badge/TypeScript-6.0-3178C6.svg?style=flat-square" alt="TypeScript 6.0" /> &nbsp;
 <br />
 <br />
 
@@ -20,10 +21,10 @@
 
 &nbsp;
 
-This documentation describes loaders.gl **v5.0**. See our [**release notes**](/docs/whats-new) to learn what is new.
+This documentation describes loaders.gl **v5**. See our [**release notes**](/docs/whats-new) to learn what is new.
 
 Docs for older versions are available on github:
-**[v4.4](https://github.com/visgl/loaders.gl/blob/3.3-release/docs/README.md)**,
+**[v4.4](https://github.com/visgl/loaders.gl/blob/4.4-release/docs/README.md)**,
 **[v3.3](https://github.com/visgl/loaders.gl/blob/3.3-release/docs/README.md)**,
 **[v2.3](https://github.com/visgl/loaders.gl/blob/2.3-release/docs/README.md)**,
 **[v1.3](https://github.com/visgl/loaders.gl/blob/1.3-release/docs/README.md)**.

--- a/docs/README.mdx
+++ b/docs/README.mdx
@@ -6,6 +6,20 @@
 <br />
 <br />
 
+<center>
+  <a href="https://openvisualization.org">
+    <img
+      style={{height: 80}}
+      src="https://raw.github.com/visgl/deck.gl-data/master/images/logos/openjsf-color-textg.png"
+    />
+  </a>
+</center>
+<center>
+  <i>loaders.gl is an OpenJS Foundation / Linux Foundation project.</i>
+</center>
+
+&nbsp;
+
 This documentation describes loaders.gl **v5.0**. See our [**release notes**](/docs/whats-new) to learn what is new.
 
 Docs for older versions are available on github:
@@ -125,17 +139,19 @@ Organizations that have contributed significantly to the development and mainten
     <img height="80" src="https://raw.githubusercontent.com/visgl/deck.gl-data/master/images/logos/Foursquare.svg" />
   </a>
   <br />
-  <br />
   <a href="https://carto.com">
     <img height="80" src="https://raw.githubusercontent.com/visgl/deck.gl-data/master/images/logos/carto.svg" />
   </a>
+  <br />
   <a href="https://actionengine.com">
     Action Engine
   </a>
+  <br />
   <a href="https://esri.com">
     Esri
   </a>
-  <a href="https://esri.com">
+  <br />
+  <a href="https://uber.com">
     Uber
   </a>
 </p>

--- a/docs/README.mdx
+++ b/docs/README.mdx
@@ -6,9 +6,10 @@
 <br />
 <br />
 
-This documentation describes loaders.gl **v4**. See our [**release notes**](/docs/whats-new) to learn what is new.
+This documentation describes loaders.gl **v5.0**. See our [**release notes**](/docs/whats-new) to learn what is new.
 
 Docs for older versions are available on github:
+**[v4.4](https://github.com/visgl/loaders.gl/blob/3.3-release/docs/README.md)**,
 **[v3.3](https://github.com/visgl/loaders.gl/blob/3.3-release/docs/README.md)**,
 **[v2.3](https://github.com/visgl/loaders.gl/blob/2.3-release/docs/README.md)**,
 **[v1.3](https://github.com/visgl/loaders.gl/blob/1.3-release/docs/README.md)**.
@@ -19,13 +20,12 @@ loaders.gl is a collection of open source loaders and writers for various file f
 primarily focused on supporting visualization and analytics of big data. 
 Tabular, geospatial, and 3D file formats are well covered. 
 
-Published as a suite of composable loader modules with consistent APIs and features, 
-offering advanced features such as worker thread and incremental parsing, 
-loaders.gl aims to be a trusted companion when you need to load data into your application.
+Published as a suite of composable loader modules with consistent APIs, 
+offering advanced features such as threaded and incremental parsing.
 
-While loaders.gl can be used with any JavaScript application or framework,
-[vis.gl frameworks](https://vis.gl/frameworks) such as [**deck.gl**](https://deck.gl) 
-come pre-integrated with loaders.gl.
+loaders.gl can be used with any JavaScript application or framework. In addition,
+other [vis.gl frameworks](https://vis.gl/frameworks) such as [**deck.gl**](https://deck.gl) 
+come are designed to integrate seamlessly loaders.gl.
 
 ## Loaders
 
@@ -102,11 +102,11 @@ loaders.gl supports both browsers and Node.js:
 
 **Multi-Asset Loading** - Formats like glTF, Shapefile, or mip mapped / cube textures can require dozens of separate loads to resolve all linked assets (external buffers, images etc). loaders.gl loads all linked assets before resolving the returned `Promise`.
 
-**Modern JavaScript** - loaders.gl is written in TypeScript 5.0 and standard ES2018, is packaged as ECMAScript modules, and the API emphasizes modern, portable JavaScript constructs, e.g. async iterators instead of streams, `ArrayBuffer` instead of `Buffer`, etc.
+**Modern JavaScript** - loaders.gl is written in TypeScript 6.0 and standard ES2018, is packaged as ECMAScript modules, and the API emphasizes modern, portable JavaScript constructs, e.g. async iterators instead of streams, `ArrayBuffer` instead of `Buffer`, etc.
 
 ## Licenses
 
-loaders.gl itself is MIT licensed, however various modules contain forked code under several permissive, compatible open source licenses, such as ISC, BSD and Apache licenses. Each loader module provides some license notes, so if the distinction matters to you, please check the documentation for each module and decide accordingly. We guarantee that loaders.gl will never include code with non-permissive, commercial or copy-left licenses.
+loaders.gl itself is MIT licensed, however various modules contain forked code under several permissive, compatible open source licenses, such as ISC, BSD and Apache 2 licenses. Each loader module provides license notes, so if the distinction matters to you, please check the documentation for each module and decide accordingly. We guarantee that loaders.gl will never include code with non-permissive, commercial or copy-left licenses.
 
 ## Credits and Attributions
 
@@ -116,9 +116,9 @@ While loaders.gl contains substantial amounts of original code, it also repackag
 
 Even so, we can make mistakes, and we may not have the full history of the code we are reusing. If you think that we have missed something, or that we could do better in regard to attribution, please let us know.
 
-## Primary maintainers
+## Organizational support
 
-Organizations that currently contribute most significantly to the development and maintenance of loaders.gl:
+Organizations that have contributed significantly to the development and maintenance of loaders.gl:
 
 <p style={{marginLeft: 30, marginRight: 'auto'}}>
   <a href="https://studio.foursquare.com">
@@ -128,6 +128,15 @@ Organizations that currently contribute most significantly to the development an
   <br />
   <a href="https://carto.com">
     <img height="80" src="https://raw.githubusercontent.com/visgl/deck.gl-data/master/images/logos/carto.svg" />
+  </a>
+  <a href="https://actionengine.com">
+    Action Engine
+  </a>
+  <a href="https://esri.com">
+    Esri
+  </a>
+  <a href="https://esri.com">
+    Uber
   </a>
 </p>
 

--- a/docs/modules/tiles/README.md
+++ b/docs/modules/tiles/README.md
@@ -1,4 +1,23 @@
-# Overview
+<p align="right">
+  <a href="https://www.npmjs.com/package/@loaders.gl/tiles">
+    <img src="https://img.shields.io/npm/v/@loaders.gl/tiles.svg?style=flat-square&label=npm%20package" alt="npm package version" />
+  </a>
+  <a href="https://github.com/visgl/loaders.gl/blob/master/LICENSE">
+    <img src="https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square" alt="MIT license" />
+  </a>
+  <a href="https://www.npmjs.com/package/@loaders.gl/tiles">
+    <img src="https://img.shields.io/npm/dm/@loaders.gl/tiles.svg?style=flat-square&label=downloads" alt="npm downloads" />
+  </a>
+  <a href="https://www.typescriptlang.org">
+    <img src="https://img.shields.io/badge/TypeScript-6.0-3178C6.svg?style=flat-square" alt="TypeScript 6.0" />
+  </a>
+</p>
+
+<h1 align="center">Tiles | <a href="https://loaders.gl/docs/modules/tiles">Docs</a></h1>
+
+<h5 align="center">Source-backed 2D and 3D tileset loading for loaders.gl</h5>
+
+## Overview
 
 `@loaders/tiles` exposes handy classes `Tileset3D` and `Tile3D` which can understand the loaded data from tile loaders (`@loaders.gl/3d-tiles`, `@loaders.gl/i3s`, etc.), and provide useful functions for dynamically selecting tiles for rendering under a viewport.
 

--- a/docs/modules/tiles/api-reference/i3s-source.md
+++ b/docs/modules/tiles/api-reference/i3s-source.md
@@ -1,5 +1,9 @@
 # I3SSource
 
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v5.0-blue.svg?style=flat-square" alt="From-v5.0" />
+</p>
+
 The `I3SSource` class implements [`Tileset3DSource`](/docs/modules/tiles/api-reference/tileset-3d-source) for datasets loaded with the [I3SLoader](/docs/modules/i3s/api-reference/i3s-loader).
 
 ## Usage

--- a/docs/modules/tiles/api-reference/tiles-3d-source.md
+++ b/docs/modules/tiles/api-reference/tiles-3d-source.md
@@ -1,5 +1,9 @@
 # Tiles3DSource
 
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v5.0-blue.svg?style=flat-square" alt="From-v5.0" />
+</p>
+
 The `Tiles3DSource` class implements [`Tileset3DSource`](/docs/modules/tiles/api-reference/tileset-3d-source) for datasets loaded with the [Tiles3DLoader](/docs/modules/3d-tiles/api-reference/tiles-3d-loader).
 
 ## Usage

--- a/docs/modules/tiles/api-reference/tileset-2d.md
+++ b/docs/modules/tiles/api-reference/tileset-2d.md
@@ -1,5 +1,9 @@
 # Tileset2D
 
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v5.0-blue.svg?style=flat-square" alt="From-v5.0" />
+</p>
+
 `Tileset2D` is the shared runtime for source-backed 2D tile loading in loaders.gl.
 
 It separates:

--- a/docs/modules/tiles/api-reference/tileset-2d.md
+++ b/docs/modules/tiles/api-reference/tileset-2d.md
@@ -1,0 +1,91 @@
+# Tileset2D
+
+`Tileset2D` is the shared runtime for source-backed 2D tile loading in loaders.gl.
+
+It separates:
+
+- shared tile cache entries and request scheduling
+- per-view tile selection and visibility state
+
+That lets multiple consumers reuse the same fetched tile content without duplicating requests or
+overwriting each other's traversal state.
+
+## Usage
+
+```typescript
+import {Tileset2D} from '@loaders.gl/tiles';
+
+const tileset = new Tileset2D({
+  getTileData: async ({index, signal}) => fetchTile(index, signal),
+  minZoom: 0,
+  maxZoom: 14
+});
+```
+
+You can also construct it directly from a loaders.gl `TileSource`.
+
+```typescript
+import {Tileset2D} from '@loaders.gl/tiles';
+
+const tileset = Tileset2D.fromTileSource(tileSource, {
+  maxCacheByteSize: 32 * 1024 * 1024
+});
+```
+
+When constructed from a `TileSource`, `Tileset2D` loads source metadata once and adopts:
+
+- `minZoom`
+- `maxZoom`
+- `boundingBox` as `extent`
+
+Explicit constructor options still take precedence.
+
+## Constructor
+
+```typescript
+new Tileset2D(options)
+```
+
+Key options:
+
+- `getTileData`: async tile loader
+- `minZoom` / `maxZoom`: requested zoom range
+- `extent`: optional bounding box limit
+- `tileSize`: tile size in pixels
+- `maxCacheSize`: maximum retained tile count
+- `maxCacheByteSize`: maximum retained tile bytes
+- `maxRequests`: concurrent request limit
+- `debounceTime`: request scheduling debounce in milliseconds
+- `zoomOffset`: integer zoom adjustment
+- `onTileLoad`: callback after a tile loads successfully
+- `onTileUnload`: callback after a tile is evicted
+- `onTileError`: callback after a tile load fails
+
+## Properties
+
+- `tiles`: current shared tile cache contents
+- `selectedTiles`: selected tiles across attached views
+- `visibleTiles`: visible tiles across attached views
+- `loadingTiles`: cache entries with in-flight requests
+- `unloadedTiles`: cache entries without content
+- `stats`: live counters for cache and consumer state
+
+## Methods
+
+- `attach({id, viewport, modelMatrix})`: attach or update a consumer view
+- `detach(id)`: remove a consumer view
+- `setOptions(options)`: update runtime options
+- `update(id)`: refresh tile selection for a consumer view
+- `reloadAll()`: mark retained tiles stale for reload
+- `subscribe(listener)`: observe tile and metadata events
+- `finalize()`: abort requests and clear the cache
+
+## Failed tile caching
+
+Failed tile requests are cached as settled tile entries with:
+
+- `content = null`
+- `error` set on the corresponding `SharedTile2DHeader`
+
+This prevents repeated requests for the same failing tile until the tileset is explicitly reloaded,
+for example with `reloadAll()`.

--- a/docs/modules/tiles/api-reference/tileset-3d-source.md
+++ b/docs/modules/tiles/api-reference/tileset-3d-source.md
@@ -1,5 +1,9 @@
 # Tileset3DSource
 
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v5.0-blue.svg?style=flat-square" alt="From-v5.0" />
+</p>
+
 The `Tileset3DSource` interface defines the format-specific contract consumed by [`Tileset3D`](/docs/modules/tiles/api-reference/tileset-3d).
 
 `Tileset3D` owns traversal, culling, request scheduling, cache management, and selected-tile state. A `Tileset3DSource` owns the format-specific work required to make those runtime systems operate on a concrete dataset.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 loaders.gl is developed under open governance by multiple contributors working with their own priorities. This page aims to give information about upcoming releases and directions.
 
-## v4.4 (in development)
+## v5.0
 
 loaders.gl v4.4 will focus on cloud-native, binary data.
 A number of modules will expose "ArrowLoaders" will return binary data in the Apache Arrow and Apache GeoArrow formats.
@@ -36,20 +36,11 @@ While no loader support has been removed, the flavor of the loaders.gl framework
 - **`@loaders.gl/gis`**
   - Now provides support for working Apache GeoArrow data.
 
-### Upgrading to v4.4
-
-- The `Source` and `DataSource` APIs have matured leading to some minor breaking changes.
-- TBA...
-
----
-
-## v5.0
 
 - **Cloud native** (raster/data): `GeoTIFFLoader`, `ZarrLoader`, kerchunk, NetCDF4, ...
 - **Cloud native** (point clouds): `COPCService`, `POTreeV2Service`...
 - Unbundled loaders (load non-worker loaders as separate bundle, similar to how workers are loaded today).
 - More comprehensive support for `options.shape` to control the output format of loaders.
-- `ffmpeg` WASM integration for `@loaders.gl/video`
 
 **Single output format per loader**
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -1,5 +1,21 @@
 # Upgrade Guide
 
+## Upgrading to v5.0
+
+These deprecations.removals are being considered for v5
+
+**@loaders.gl/core**
+
+- Top-level loader options are no longer supported
+
+**@loaders.gl/images**
+
+- ImageLoader now only returns ImageBitmap (never Image or data), with a polyfill under Node.js. There is a function to extract data from an ImageBitmap?
+
+**@loaders.gl/tiles**
+
+- `Tileset3D` now requires a `Tile3DSource` and can no longer be instantiated with a JSON payload.
+
 ## Upgrading to v4.4
 
 **@loaders.gl/textures**

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -1,6 +1,6 @@
 # What's New
 
-## v5.0
+## v5.0 (In Development)
 
 Release Date: 2026
 

--- a/examples/website/tiles/app.tsx
+++ b/examples/website/tiles/app.tsx
@@ -23,7 +23,7 @@ import {_GeoJSONLoader as GeoJSONLoader} from '@loaders.gl/json';
 // D\deck.gl + layers
 import DeckGL from '@deck.gl/react';
 import {MapView} from '@deck.gl/core';
-import {SourceLayer} from '@loaders.gl/deck-layers';
+import {Tile2DSourceLayer} from '@loaders.gl/deck-layers';
 
 // Basemap
 import {Map} from 'react-map-gl';
@@ -71,6 +71,7 @@ export default function App(props: AppProps = {}) {
   const [rangeStats, setRangeStats] = useState<RangeStats>(
     getRangeStats(rangeStatsObjectRef.current)
   );
+  const [hideBasemap, setHideBasemap] = useState(false);
   const [currentExample, setCurrentExample] = useState<Example | null>(null);
   const [state, setState] = useState<AppState>({
     tileSource: null,
@@ -86,6 +87,7 @@ export default function App(props: AppProps = {}) {
       currentExample
         ? {
             core: {
+              type: currentExample.sourceType,
               attributions: currentExample.attributions,
               loaders: [GeoJSONLoader],
               loadOptions: {
@@ -110,7 +112,7 @@ export default function App(props: AppProps = {}) {
   const tileLayer =
     currentExample &&
     sourceOptions &&
-    new SourceLayer({
+    new Tile2DSourceLayer({
       data: currentExample.data,
       sources: TILE_SOURCE_FACTORIES,
       sourceOptions,
@@ -131,8 +133,10 @@ export default function App(props: AppProps = {}) {
         examples={EXAMPLES}
         format={props.format}
         hideChrome={props.hideChrome}
+        hideBasemap={hideBasemap}
         initialCategoryName={INITIAL_CATEGORY_NAME}
         initialExampleName={INITIAL_EXAMPLE_NAME}
+        onHideBasemapChange={setHideBasemap}
         onExampleChange={onExampleChange}
       >
         <MetadataViewer metadata={metadata} />
@@ -150,11 +154,17 @@ export default function App(props: AppProps = {}) {
       <DeckGL
         layers={[tileLayer]}
         views={new MapView({repeat: true})}
-        initialViewState={state.viewState}
+        viewState={state.viewState}
         controller={true}
         getTooltip={getTooltip}
+        onViewStateChange={({viewState}) =>
+          setState((state) => ({
+            ...state,
+            viewState: viewState as Record<string, number>
+          }))
+        }
       >
-        <Map mapLib={maplibregl} mapStyle={INITIAL_MAP_STYLE} />
+        {!hideBasemap && <Map mapLib={maplibregl} mapStyle={INITIAL_MAP_STYLE} />}
         {!props.hideChrome && <Attributions attributions={metadata?.attributions} />}
       </DeckGL>
     </div>
@@ -193,7 +203,7 @@ export default function App(props: AppProps = {}) {
 
         setState((state) => ({
           ...state,
-          initialViewState,
+          viewState: initialViewState,
           error: null,
           metadata: metadata ? JSON.stringify(metadata, null, 2) : ''
         }));
@@ -288,6 +298,7 @@ function createTileSource(
     [PMTilesSource, TableTileSource, MVTSource, MLTSource],
     {
       core: {
+        type: example.sourceType,
         attributions: example.attributions,
         loaders: [GeoJSONLoader],
         // Make the Schema more presentable by limiting the number of values per column the field metadata

--- a/examples/website/tiles/components/example-panel.tsx
+++ b/examples/website/tiles/components/example-panel.tsx
@@ -41,6 +41,14 @@ const DropDown = styled.select`
   margin-bottom: 6px;
 `;
 
+const ToggleRow = styled.label`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  line-height: 1.4;
+  margin-bottom: 8px;
+`;
+
 const APP_SOURCE_URL = 'https://github.com/visgl/loaders.gl/tree/master/examples/website/tiles';
 
 export type Example = {
@@ -61,6 +69,8 @@ export type ExamplePanelProps = React.PropsWithChildren<{
   hideChrome?: boolean;
   initialCategoryName?: string | null;
   initialExampleName?: string | null;
+  hideBasemap?: boolean;
+  onHideBasemapChange?: (value: boolean) => void;
   onExampleChange: OnExampleChange;
 }>;
 
@@ -150,6 +160,10 @@ export const ExamplePanel: React.FC<ExamplePanelProps> = (props: ExamplePanelPro
           setState((state) => ({...state, categoryName, exampleName, example}));
         }}
       />
+      <BasemapToggle
+        checked={Boolean(props.hideBasemap)}
+        onChange={(value) => props.onHideBasemapChange?.(value)}
+      />
       {props.children}
     </Container>
   );
@@ -162,6 +176,19 @@ function ExampleSourceLink() {
         View source
       </a>
     </div>
+  );
+}
+
+function BasemapToggle(props: {checked: boolean; onChange: (value: boolean) => void}) {
+  return (
+    <ToggleRow>
+      <input
+        checked={props.checked}
+        onChange={(event) => props.onChange(event.target.checked)}
+        type="checkbox"
+      />
+      <span>Hide basemap</span>
+    </ToggleRow>
   );
 }
 

--- a/modules/deck-layers/README.md
+++ b/modules/deck-layers/README.md
@@ -7,26 +7,11 @@ implementations across example applications in this repository.
 
 Current shared layers include:
 
+- `Tile2DSourceLayer` for source-backed 2D tiles rendered through `Tileset2D`
 - `SourceLayer` for dispatching between tile sources and source-backed 3D tilesets
 - `TileSourceLayer` for loaders.gl `TileSource` rendering through the `data` prop
 - `Tile3DSourceLayer` for source-backed `Tileset3D` rendering
 - `SourceDataDrivenTile3DLayer` for source-backed data-driven 3D tile rendering
 
-Example usage:
-
-```ts
-import {SourceLayer, Tile3DSourceLayer} from '@loaders.gl/deck-layers';
-import {Tiles3DLoader} from '@loaders.gl/3d-tiles';
-import {Tiles3DSource} from '@loaders.gl/tiles';
-
-new Tile3DSourceLayer({
-  id: 'explicit-source',
-  data: new Tiles3DSource({url, loader: Tiles3DLoader})
-});
-
-new SourceLayer({
-  id: 'auto-source',
-  data: url,
-  loaders: [Tiles3DLoader]
-});
-```
+These layers are internal implementation details for examples and repository-local integrations.
+They are intentionally documented only through TSDoc in source.

--- a/modules/deck-layers/src/data-driven-tile-3d-source-layer.ts
+++ b/modules/deck-layers/src/data-driven-tile-3d-source-layer.ts
@@ -8,7 +8,10 @@ import type {LoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';
 import {createSource} from './tile-3d-source-layer';
 
 /**
- * `DataDrivenTile3DLayer` adapter that constructs source-backed `Tileset3D` instances.
+ * Internal `DataDrivenTile3DLayer` adapter that constructs source-backed `Tileset3D` instances.
+ *
+ * This class is exported for internal repository use and examples, and is not documented
+ * beyond these TSDoc comments.
  */
 export class SourceDataDrivenTile3DLayer<
   DataT = any,

--- a/modules/deck-layers/src/index.ts
+++ b/modules/deck-layers/src/index.ts
@@ -4,6 +4,8 @@
 
 export type {TileSourceLayerProps} from './tile-source-layer';
 export {TileSourceLayer} from './tile-source-layer';
+export type {Tile2DSourceLayerProps} from './tile-2d-source-layer';
+export {Tile2DSourceLayer} from './tile-2d-source-layer';
 export type {SourceLayerProps} from './source-layer';
 export {SourceLayer} from './source-layer';
 export type {Tile3DSourceLayerProps} from './tile-3d-source-layer';

--- a/modules/deck-layers/src/shared-tile-2d/deck-tile-traversal.ts
+++ b/modules/deck-layers/src/shared-tile-2d/deck-tile-traversal.ts
@@ -1,0 +1,237 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Viewport, WebMercatorViewport, _GlobeViewport} from '@deck.gl/core';
+import {
+  CullingVolume,
+  Plane,
+  AxisAlignedBoundingBox,
+  makeOrientedBoundingBoxFromPoints
+} from '@math.gl/culling';
+import {lngLatToWorld} from '@math.gl/web-mercator';
+import type {Bounds, TileIndex, ZRange} from '@loaders.gl/tiles';
+
+const TILE_SIZE = 512;
+const MAX_MAPS = 3;
+const REF_POINTS_5 = [
+  [0.5, 0.5],
+  [0, 0],
+  [0, 1],
+  [1, 0],
+  [1, 1]
+];
+const REF_POINTS_9 = REF_POINTS_5.concat([
+  [0, 0.5],
+  [0.5, 0],
+  [1, 0.5],
+  [0.5, 1]
+]);
+const REF_POINTS_11 = REF_POINTS_9.concat([
+  [0.25, 0.5],
+  [0.75, 0.5]
+]);
+
+class OSMNode {
+  x: number;
+  y: number;
+  z: number;
+
+  private childVisible?: boolean;
+  private selected?: boolean;
+  private _children?: OSMNode[];
+
+  constructor(x: number, y: number, z: number) {
+    this.x = x;
+    this.y = y;
+    this.z = z;
+  }
+
+  get children(): OSMNode[] {
+    if (!this._children) {
+      const x = this.x * 2;
+      const y = this.y * 2;
+      const z = this.z + 1;
+      this._children = [
+        new OSMNode(x, y, z),
+        new OSMNode(x, y + 1, z),
+        new OSMNode(x + 1, y, z),
+        new OSMNode(x + 1, y + 1, z)
+      ];
+    }
+    return this._children;
+  }
+
+  update(params: {
+    viewport: Viewport;
+    project: ((xyz: number[]) => number[]) | null;
+    cullingVolume: CullingVolume;
+    elevationBounds: ZRange;
+    minZ: number;
+    maxZ: number;
+    bounds?: Bounds;
+    offset: number;
+  }): boolean {
+    const {viewport, cullingVolume, elevationBounds, minZ, maxZ, bounds, offset, project} = params;
+    const boundingVolume = this.getBoundingVolume(elevationBounds, offset, project);
+
+    if (bounds && !this.insideBounds(bounds)) {
+      return false;
+    }
+
+    const isInside = cullingVolume.computeVisibility(boundingVolume);
+    if (isInside < 0) {
+      return false;
+    }
+
+    if (!this.childVisible) {
+      let {z} = this;
+      if (z < maxZ && z >= minZ) {
+        const distance =
+          (boundingVolume.distanceTo(viewport.cameraPosition) * viewport.scale) / viewport.height;
+        z += Math.floor(Math.log2(distance));
+      }
+      if (z >= maxZ) {
+        this.selected = true;
+        return true;
+      }
+    }
+
+    this.selected = false;
+    this.childVisible = true;
+    for (const child of this.children) {
+      child.update(params);
+    }
+    return true;
+  }
+
+  getSelected(result: OSMNode[] = []): OSMNode[] {
+    if (this.selected) {
+      result.push(this);
+    }
+    if (this._children) {
+      for (const node of this._children) {
+        node.getSelected(result);
+      }
+    }
+    return result;
+  }
+
+  insideBounds([minX, minY, maxX, maxY]: Bounds): boolean {
+    const scale = Math.pow(2, this.z);
+    const extent = TILE_SIZE / scale;
+
+    return (
+      this.x * extent < maxX &&
+      this.y * extent < maxY &&
+      (this.x + 1) * extent > minX &&
+      (this.y + 1) * extent > minY
+    );
+  }
+
+  getBoundingVolume(
+    zRange: ZRange,
+    worldOffset: number,
+    project: ((xyz: number[]) => number[]) | null
+  ) {
+    if (project) {
+      const refPoints = this.z < 1 ? REF_POINTS_11 : this.z < 2 ? REF_POINTS_9 : REF_POINTS_5;
+      const refPointPositions: number[][] = [];
+      for (const point of refPoints) {
+        const lngLat = osmTile2lngLat(this.x + point[0], this.y + point[1], this.z);
+        lngLat[2] = zRange[0];
+        refPointPositions.push(project(lngLat));
+
+        if (zRange[0] !== zRange[1]) {
+          lngLat[2] = zRange[1];
+          refPointPositions.push(project(lngLat));
+        }
+      }
+      return makeOrientedBoundingBoxFromPoints(refPointPositions);
+    }
+
+    const scale = Math.pow(2, this.z);
+    const extent = TILE_SIZE / scale;
+    const originX = this.x * extent + worldOffset * TILE_SIZE;
+    const originY = TILE_SIZE - (this.y + 1) * extent;
+
+    return new AxisAlignedBoundingBox(
+      [originX, originY, zRange[0]],
+      [originX + extent, originY + extent, zRange[1]]
+    );
+  }
+}
+
+/** Converts an OSM tile coordinate to longitude/latitude. */
+export function osmTile2lngLat(x: number, y: number, z: number): [number, number, number] {
+  const scale = Math.pow(2, z);
+  const lng = (x / scale) * 360 - 180;
+  const n = Math.PI - (2 * Math.PI * y) / scale;
+  const lat = (180 / Math.PI) * Math.atan(0.5 * (Math.exp(n) - Math.exp(-n)));
+  return [lng, lat, 0];
+}
+
+/** Computes OSM tile indices for one deck.gl viewport. */
+export function getOSMTileIndices(
+  viewport: Viewport,
+  maxZ: number,
+  zRange: ZRange | null,
+  bounds?: Bounds
+): TileIndex[] {
+  const project: ((xyz: number[]) => number[]) | null =
+    viewport instanceof _GlobeViewport && viewport.resolution
+      ? viewport.projectPosition.bind(viewport)
+      : null;
+
+  const planes: Plane[] = Object.values(viewport.getFrustumPlanes()).map(
+    ({normal, distance}) => new Plane(normal.clone().negate(), distance)
+  );
+  const cullingVolume = new CullingVolume(planes);
+
+  const unitsPerMeter = viewport.distanceScales.unitsPerMeter[2];
+  const elevationMin = (zRange && zRange[0] * unitsPerMeter) || 0;
+  const elevationMax = (zRange && zRange[1] * unitsPerMeter) || 0;
+  const minZ = viewport instanceof WebMercatorViewport && viewport.pitch <= 60 ? maxZ : 0;
+
+  if (bounds) {
+    const [minLng, minLat, maxLng, maxLat] = bounds;
+    const topLeft = lngLatToWorld([minLng, maxLat]);
+    const bottomRight = lngLatToWorld([maxLng, minLat]);
+    bounds = [topLeft[0], TILE_SIZE - topLeft[1], bottomRight[0], TILE_SIZE - bottomRight[1]];
+  }
+
+  const root = new OSMNode(0, 0, 0);
+  const traversalParams = {
+    viewport,
+    project,
+    cullingVolume,
+    elevationBounds: [elevationMin, elevationMax] as ZRange,
+    minZ,
+    maxZ,
+    bounds,
+    offset: 0
+  };
+
+  root.update(traversalParams);
+
+  if (
+    viewport instanceof WebMercatorViewport &&
+    viewport.subViewports &&
+    viewport.subViewports.length > 1
+  ) {
+    traversalParams.offset = -1;
+    while (root.update(traversalParams)) {
+      if (--traversalParams.offset < -MAX_MAPS) {
+        break;
+      }
+    }
+    traversalParams.offset = 1;
+    while (root.update(traversalParams)) {
+      if (++traversalParams.offset > MAX_MAPS) {
+        break;
+      }
+    }
+  }
+
+  return root.getSelected();
+}

--- a/modules/deck-layers/src/shared-tile-2d/deck-tileset-adapter.ts
+++ b/modules/deck-layers/src/shared-tile-2d/deck-tileset-adapter.ts
@@ -1,0 +1,259 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Viewport} from '@deck.gl/core';
+import {Matrix4} from '@math.gl/core';
+import type {
+  Bounds,
+  GeoBoundingBox,
+  Tileset2DAdapter,
+  Tileset2DTileContext,
+  Tileset2DTraversalContext,
+  TileBoundingBox,
+  TileIndex,
+  ZRange
+} from '@loaders.gl/tiles';
+import {getOSMTileIndices, osmTile2lngLat} from './deck-tile-traversal';
+
+const TILE_SIZE = 512;
+const DEFAULT_EXTENT: Bounds = [-Infinity, -Infinity, Infinity, Infinity];
+
+/** Applies a model transform to an axis-aligned bounding box. */
+export function transformBox(bbox: Bounds, modelMatrix: Matrix4): Bounds {
+  const transformedCoords = [
+    modelMatrix.transformAsPoint([bbox[0], bbox[1]]),
+    modelMatrix.transformAsPoint([bbox[2], bbox[1]]),
+    modelMatrix.transformAsPoint([bbox[0], bbox[3]]),
+    modelMatrix.transformAsPoint([bbox[2], bbox[3]])
+  ];
+  return [
+    Math.min(...transformedCoords.map(item => item[0])),
+    Math.min(...transformedCoords.map(item => item[1])),
+    Math.max(...transformedCoords.map(item => item[0])),
+    Math.max(...transformedCoords.map(item => item[1]))
+  ];
+}
+
+function getBoundingBox(viewport: Viewport, zRange: number[] | null, extent: Bounds): Bounds {
+  let bounds;
+  if (zRange && zRange.length === 2) {
+    const [minZ, maxZ] = zRange;
+    const bounds0 = viewport.getBounds({z: minZ});
+    const bounds1 = viewport.getBounds({z: maxZ});
+    bounds = [
+      Math.min(bounds0[0], bounds1[0]),
+      Math.min(bounds0[1], bounds1[1]),
+      Math.max(bounds0[2], bounds1[2]),
+      Math.max(bounds0[3], bounds1[3])
+    ];
+  } else {
+    bounds = viewport.getBounds();
+  }
+
+  if (!viewport.isGeospatial) {
+    return [
+      Math.max(Math.min(bounds[0], extent[2]), extent[0]),
+      Math.max(Math.min(bounds[1], extent[3]), extent[1]),
+      Math.min(Math.max(bounds[2], extent[0]), extent[2]),
+      Math.min(Math.max(bounds[3], extent[1]), extent[3])
+    ];
+  }
+
+  return [
+    Math.max(bounds[0], extent[0]),
+    Math.max(bounds[1], extent[1]),
+    Math.min(bounds[2], extent[2]),
+    Math.min(bounds[3], extent[3])
+  ];
+}
+
+/** Computes cull bounds in projected/world coordinates for one deck viewport. */
+export function getCullBounds({
+  viewport,
+  z,
+  cullRect
+}: {
+  viewport: Viewport;
+  z: ZRange | number | null;
+  cullRect: {x: number; y: number; width: number; height: number};
+}): [number, number, number, number][] {
+  const subViewports = viewport.subViewports || [viewport];
+  return subViewports.map(subViewport => getCullBoundsInViewport(subViewport, z || 0, cullRect));
+}
+
+function getCullBoundsInViewport(
+  viewport: Viewport,
+  z: ZRange | number,
+  cullRect: {x: number; y: number; width: number; height: number}
+): [number, number, number, number] {
+  if (!Array.isArray(z)) {
+    const x = cullRect.x - viewport.x;
+    const y = cullRect.y - viewport.y;
+    const {width, height} = cullRect;
+    const unprojectOption = {targetZ: z};
+
+    const topLeft = viewport.unproject([x, y], unprojectOption);
+    const topRight = viewport.unproject([x + width, y], unprojectOption);
+    const bottomLeft = viewport.unproject([x, y + height], unprojectOption);
+    const bottomRight = viewport.unproject([x + width, y + height], unprojectOption);
+
+    return [
+      Math.min(topLeft[0], topRight[0], bottomLeft[0], bottomRight[0]),
+      Math.min(topLeft[1], topRight[1], bottomLeft[1], bottomRight[1]),
+      Math.max(topLeft[0], topRight[0], bottomLeft[0], bottomRight[0]),
+      Math.max(topLeft[1], topRight[1], bottomLeft[1], bottomRight[1])
+    ];
+  }
+
+  const bounds0 = getCullBoundsInViewport(viewport, z[0], cullRect);
+  const bounds1 = getCullBoundsInViewport(viewport, z[1], cullRect);
+  return [
+    Math.min(bounds0[0], bounds1[0]),
+    Math.min(bounds0[1], bounds1[1]),
+    Math.max(bounds0[2], bounds1[2]),
+    Math.max(bounds0[3], bounds1[3])
+  ];
+}
+
+function getIndexingCoords(
+  bbox: Bounds,
+  scale: number,
+  modelMatrixInverse?: Matrix4 | null
+): Bounds {
+  if (modelMatrixInverse) {
+    return transformBox(bbox, modelMatrixInverse).map(item => (item * scale) / TILE_SIZE) as Bounds;
+  }
+  return bbox.map(item => (item * scale) / TILE_SIZE) as Bounds;
+}
+
+function getScale(z: number, tileSize: number): number {
+  return (Math.pow(2, z) * TILE_SIZE) / tileSize;
+}
+
+function tile2XY(x: number, y: number, z: number, tileSize: number): [number, number] {
+  const scale = getScale(z, tileSize);
+  return [(x / scale) * TILE_SIZE, (y / scale) * TILE_SIZE];
+}
+
+function tileToBoundingBox(
+  viewport: Viewport,
+  x: number,
+  y: number,
+  z: number,
+  tileSize: number = TILE_SIZE
+): TileBoundingBox {
+  if (viewport.isGeospatial) {
+    const [west, north] = osmTile2lngLat(x, y, z);
+    const [east, south] = osmTile2lngLat(x + 1, y + 1, z);
+    return {west, north, east, south};
+  }
+  const [left, top] = tile2XY(x, y, z, tileSize);
+  const [right, bottom] = tile2XY(x + 1, y + 1, z, tileSize);
+  return {left, top, right, bottom};
+}
+
+function getIdentityTileIndices(
+  viewport: Viewport,
+  z: number,
+  tileSize: number,
+  extent: Bounds,
+  modelMatrixInverse?: Matrix4 | null
+): TileIndex[] {
+  const bbox = getBoundingBox(viewport, null, extent);
+  const scale = getScale(z, tileSize);
+  const [minX, minY, maxX, maxY] = getIndexingCoords(bbox, scale, modelMatrixInverse);
+  const indices: TileIndex[] = [];
+
+  for (let x = Math.floor(minX); x < maxX; x++) {
+    for (let y = Math.floor(minY); y < maxY; y++) {
+      indices.push({x, y, z});
+    }
+  }
+  return indices;
+}
+
+function getTileZoomForViewport(viewport: Viewport, tileSize: number, zoomOffset: number): number {
+  return viewport.isGeospatial
+    ? Math.round(viewport.zoom + Math.log2(TILE_SIZE / tileSize)) + zoomOffset
+    : Math.ceil(viewport.zoom) + zoomOffset;
+}
+
+function applyZoomBounds(
+  z: number,
+  minZoom: number | undefined,
+  maxZoom: number | undefined,
+  extent?: Bounds | null
+): number | null {
+  if (typeof minZoom === 'number' && Number.isFinite(minZoom) && z < minZoom) {
+    if (!extent) {
+      return null;
+    }
+    z = minZoom;
+  }
+  if (typeof maxZoom === 'number' && Number.isFinite(maxZoom) && z > maxZoom) {
+    z = maxZoom;
+  }
+  return z;
+}
+
+function getDeckTileIndices(context: Tileset2DTraversalContext<Viewport>): TileIndex[] {
+  const {
+    viewState: viewport,
+    maxZoom,
+    minZoom,
+    zRange = null,
+    extent,
+    tileSize = TILE_SIZE,
+    modelMatrix,
+    modelMatrixInverse,
+    zoomOffset = 0
+  } = context;
+  const zoom = applyZoomBounds(
+    getTileZoomForViewport(viewport, tileSize, zoomOffset),
+    minZoom,
+    maxZoom,
+    extent
+  );
+  if (zoom === null) {
+    return [];
+  }
+
+  let transformedExtent = extent || undefined;
+  if (modelMatrix && modelMatrixInverse && extent && !viewport.isGeospatial) {
+    transformedExtent = transformBox(extent, modelMatrix);
+  }
+
+  return viewport.isGeospatial
+    ? getOSMTileIndices(viewport, zoom, zRange, extent || undefined)
+    : getIdentityTileIndices(
+        viewport,
+        zoom,
+        tileSize,
+        transformedExtent || DEFAULT_EXTENT,
+        modelMatrixInverse
+      );
+}
+
+function getDeckTileBoundingBox(
+  context: Tileset2DTileContext<Viewport>,
+  index: TileIndex
+): TileBoundingBox {
+  return tileToBoundingBox(context.viewState, index.x, index.y, index.z, context.tileSize);
+}
+
+/** Deck.gl adapter used by {@link Tileset2D} for viewport traversal and tile bounds. */
+export const sharedTile2DDeckAdapter: Tileset2DAdapter<Viewport> = {
+  getTileIndices: getDeckTileIndices,
+  getTileBoundingBox: getDeckTileBoundingBox
+};
+
+/** Type guard for geographic tile bounds. */
+export function isGeoBoundingBox(value: any): value is GeoBoundingBox {
+  return (
+    Number.isFinite(value.west) &&
+    Number.isFinite(value.north) &&
+    Number.isFinite(value.east) &&
+    Number.isFinite(value.south)
+  );
+}

--- a/modules/deck-layers/src/shared-tile-2d/shared-tile-2d-view.ts
+++ b/modules/deck-layers/src/shared-tile-2d/shared-tile-2d-view.ts
@@ -1,0 +1,308 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Viewport} from '@deck.gl/core';
+import {Matrix4, equals, type NumericArray} from '@math.gl/core';
+import {
+  STRATEGY_DEFAULT,
+  STRATEGY_NEVER,
+  STRATEGY_REPLACE,
+  SharedTile2DHeader,
+  type Tileset2D
+} from '@loaders.gl/tiles';
+import {getCullBounds, transformBox} from './deck-tileset-adapter';
+
+const TILE_STATE_VISITED = 1;
+const TILE_STATE_VISIBLE = 2;
+
+const STRATEGIES = {
+  [STRATEGY_DEFAULT]: updateTileStateDefault,
+  [STRATEGY_REPLACE]: updateTileStateReplace,
+  [STRATEGY_NEVER]: () => {}
+};
+
+type TileViewState = {
+  isSelected: boolean;
+  isVisible: boolean;
+  state: number;
+};
+
+/** Per-viewport traversal state for the deck-facing shared tile layer. */
+export class SharedTile2DView<DataT = any> {
+  /** Unique consumer identifier used by the shared tileset cache. */
+  readonly id = Symbol('tile-2d-view');
+
+  private _tileset: Tileset2D<DataT, Viewport>;
+  private _selectedTiles: SharedTile2DHeader<DataT>[] | null = null;
+  private _frameNumber = 0;
+  private _viewport: Viewport | null = null;
+  private _zRange: [number, number] | null = null;
+  private _modelMatrix = new Matrix4();
+  private _modelMatrixInverse = new Matrix4();
+  private _state = new Map<SharedTile2DHeader<DataT>, TileViewState>();
+
+  /** Creates a viewport-specific view of a shared tileset. */
+  constructor(tileset: Tileset2D<DataT, Viewport>) {
+    this._tileset = tileset;
+    this._tileset.attachConsumer(this.id);
+  }
+
+  /** Releases this view and detaches it from the shared tileset. */
+  finalize(): void {
+    this._tileset.detachConsumer(this.id);
+    this._selectedTiles = null;
+    this._state.clear();
+  }
+
+  /** Tiles selected for the last viewport update. */
+  get selectedTiles(): SharedTile2DHeader<DataT>[] | null {
+    return this._selectedTiles;
+  }
+
+  /** Indicates whether all selected tiles are fully loaded for this view. */
+  get isLoaded(): boolean {
+    return this._selectedTiles !== null && this._selectedTiles.every(tile => tile.isLoaded);
+  }
+
+  /** Indicates whether any selected tile needs to be re-requested. */
+  get needsReload(): boolean {
+    return this._selectedTiles !== null && this._selectedTiles.some(tile => tile.needsReload);
+  }
+
+  /** Updates tile selection and visibility for a viewport and returns the current frame number. */
+  update(
+    viewport: Viewport,
+    {
+      zRange,
+      modelMatrix
+    }: {
+      zRange: [number, number] | null;
+      modelMatrix: NumericArray | null;
+    } = {zRange: null, modelMatrix: null}
+  ): number {
+    const modelMatrixAsMatrix4 = modelMatrix ? new Matrix4(modelMatrix) : new Matrix4();
+    const isModelMatrixNew = !modelMatrixAsMatrix4.equals(this._modelMatrix);
+
+    if (
+      !this._viewport ||
+      !viewport.equals(this._viewport) ||
+      !equals(this._zRange, zRange) ||
+      isModelMatrixNew
+    ) {
+      if (isModelMatrixNew) {
+        this._modelMatrixInverse = modelMatrixAsMatrix4.clone().invert();
+        this._modelMatrix = modelMatrixAsMatrix4;
+      }
+      this._viewport = viewport;
+      this._zRange = zRange;
+      const tileIndices = this._tileset.getTileIndices({
+        viewState: viewport,
+        maxZoom: this._tileset.maxZoom,
+        minZoom: this._tileset.minZoom,
+        zRange,
+        modelMatrix: this._modelMatrix,
+        modelMatrixInverse: this._modelMatrixInverse
+      });
+      this._selectedTiles = tileIndices.map(index => this._tileset.getTile(index, true));
+      this._tileset.prepareTiles();
+    } else if (this.needsReload) {
+      this._selectedTiles = (this._selectedTiles || []).map(tile =>
+        this._tileset.getTile(tile.index, true)
+      );
+      this._tileset.prepareTiles();
+    }
+
+    const changed = this._updateTileStates();
+    this._tileset.updateConsumer(this.id, this._selectedTiles || [], this._getVisibleTiles());
+
+    if (changed) {
+      this._frameNumber++;
+    }
+    return this._frameNumber;
+  }
+
+  /** Tests whether a tile should render in the current viewport and culling rectangle. */
+  isTileVisible(
+    tile: SharedTile2DHeader<DataT>,
+    cullRect?: {x: number; y: number; width: number; height: number},
+    modelMatrix?: Matrix4 | null
+  ): boolean {
+    const state = this._state.get(tile);
+    if (!state?.isVisible) {
+      return false;
+    }
+
+    if (!cullRect || !this._viewport) {
+      return true;
+    }
+    const boundsArray = getCullBounds({
+      viewport: this._viewport,
+      z: this._zRange,
+      cullRect
+    });
+    return boundsArray.some(bounds => this._tileOverlapsBounds(tile, bounds, modelMatrix));
+  }
+
+  private _getVisibleTiles(): SharedTile2DHeader<DataT>[] {
+    const result: SharedTile2DHeader<DataT>[] = [];
+    for (const tile of this._tileset.tiles) {
+      if (this._state.get(tile)?.isVisible) {
+        result.push(tile);
+      }
+    }
+    return result;
+  }
+
+  private _updateTileStates(): boolean {
+    const refinementStrategy = this._tileset.refinementStrategy || STRATEGY_DEFAULT;
+    const allTiles = this._tileset.tiles;
+    const previousVisibility = new Map<SharedTile2DHeader<DataT>, boolean>();
+
+    for (const tile of allTiles) {
+      const existing = this._state.get(tile);
+      previousVisibility.set(tile, existing?.isVisible || false);
+      this._state.set(tile, {isSelected: false, isVisible: false, state: 0});
+    }
+
+    for (const tile of this._selectedTiles || []) {
+      const state = this._state.get(tile) || {isSelected: false, isVisible: false, state: 0};
+      state.isSelected = true;
+      state.isVisible = true;
+      this._state.set(tile, state);
+    }
+
+    if (typeof refinementStrategy === 'function') {
+      refinementStrategy(allTiles);
+    } else {
+      STRATEGIES[refinementStrategy](allTiles, this._state);
+    }
+
+    let changed = false;
+    for (const tile of allTiles) {
+      const state = this._state.get(tile);
+      if (state && state.isVisible !== previousVisibility.get(tile)) {
+        changed = true;
+      }
+    }
+    return changed;
+  }
+
+  private _tileOverlapsBounds(
+    tile: SharedTile2DHeader<DataT>,
+    [minX, minY, maxX, maxY]: [number, number, number, number],
+    modelMatrix?: Matrix4 | null
+  ): boolean {
+    const bbox = this._getTileBoundingBox(tile, modelMatrix);
+    if ('west' in bbox) {
+      return bbox.west < maxX && bbox.east > minX && bbox.south < maxY && bbox.north > minY;
+    }
+    const y0 = Math.min(bbox.top, bbox.bottom);
+    const y1 = Math.max(bbox.top, bbox.bottom);
+    return bbox.left < maxX && bbox.right > minX && y0 < maxY && y1 > minY;
+  }
+
+  private _getTileBoundingBox(tile: SharedTile2DHeader<DataT>, modelMatrix?: Matrix4 | null) {
+    const {bbox} = tile;
+    if ('west' in bbox || !modelMatrix || Matrix4.IDENTITY.equals(modelMatrix)) {
+      return bbox;
+    }
+    const [left, top, right, bottom] = transformBox(
+      [bbox.left, bbox.top, bbox.right, bbox.bottom],
+      modelMatrix
+    );
+    return {left, top, right, bottom};
+  }
+}
+
+function updateTileStateDefault(
+  allTiles: SharedTile2DHeader[],
+  stateMap: Map<SharedTile2DHeader, TileViewState>
+) {
+  for (const tile of allTiles) {
+    getTileState(stateMap, tile).state = 0;
+  }
+  for (const tile of allTiles) {
+    if (getTileState(stateMap, tile).isSelected && !getPlaceholderInAncestors(tile, stateMap)) {
+      getPlaceholderInChildren(tile, stateMap);
+    }
+  }
+  for (const tile of allTiles) {
+    const state = getTileState(stateMap, tile);
+    state.isVisible = Boolean(state.state & TILE_STATE_VISIBLE);
+  }
+}
+
+function updateTileStateReplace(
+  allTiles: SharedTile2DHeader[],
+  stateMap: Map<SharedTile2DHeader, TileViewState>
+) {
+  for (const tile of allTiles) {
+    getTileState(stateMap, tile).state = 0;
+  }
+  for (const tile of allTiles) {
+    if (getTileState(stateMap, tile).isSelected) {
+      getPlaceholderInAncestors(tile, stateMap);
+    }
+  }
+  const sortedTiles = Array.from(allTiles).sort((tile1, tile2) => tile1.zoom - tile2.zoom);
+  for (const tile of sortedTiles) {
+    const tileState = getTileState(stateMap, tile);
+    tileState.isVisible = Boolean(tileState.state & TILE_STATE_VISIBLE);
+
+    if (tile.children && (tileState.isVisible || tileState.state & TILE_STATE_VISITED)) {
+      for (const child of tile.children) {
+        getTileState(stateMap, child).state = TILE_STATE_VISITED;
+      }
+    } else if (tileState.isSelected) {
+      getPlaceholderInChildren(tile, stateMap);
+    }
+  }
+}
+
+function getPlaceholderInAncestors(
+  startTile: SharedTile2DHeader,
+  stateMap: Map<SharedTile2DHeader, TileViewState>
+): boolean {
+  let tile: SharedTile2DHeader | null = startTile;
+  while (tile?.parent) {
+    tile = tile.parent;
+    const state = getTileState(stateMap, tile);
+    state.state |= TILE_STATE_VISIBLE | TILE_STATE_VISITED;
+    if (tile.isLoaded || tile.content) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function getPlaceholderInChildren(
+  tile: SharedTile2DHeader,
+  stateMap: Map<SharedTile2DHeader, TileViewState>
+): void {
+  const state = getTileState(stateMap, tile);
+  state.state |= TILE_STATE_VISIBLE | TILE_STATE_VISITED;
+
+  if (!tile.children || !tile.children.length || tile.isLoaded || tile.content) {
+    return;
+  }
+
+  for (const child of tile.children) {
+    const childState = getTileState(stateMap, child);
+    if (!(childState.state & TILE_STATE_VISITED)) {
+      getPlaceholderInChildren(child, stateMap);
+    }
+  }
+}
+
+function getTileState(
+  stateMap: Map<SharedTile2DHeader, TileViewState>,
+  tile: SharedTile2DHeader
+): TileViewState {
+  let tileState = stateMap.get(tile);
+  if (!tileState) {
+    tileState = {isSelected: false, isVisible: false, state: 0};
+    stateMap.set(tile, tileState);
+  }
+  return tileState;
+}

--- a/modules/deck-layers/src/shared-tile-2d/shared-tile-2d-view.ts
+++ b/modules/deck-layers/src/shared-tile-2d/shared-tile-2d-view.ts
@@ -173,7 +173,10 @@ export class SharedTile2DView<DataT = any> {
     }
 
     if (typeof refinementStrategy === 'function') {
-      refinementStrategy(allTiles);
+      refinementStrategy(allTiles, (tile, isVisible) => {
+        const state = getTileState(this._state, tile);
+        state.isVisible = isVisible;
+      });
     } else {
       STRATEGIES[refinementStrategy](allTiles, this._state);
     }

--- a/modules/deck-layers/src/source-layer.ts
+++ b/modules/deck-layers/src/source-layer.ts
@@ -49,7 +49,10 @@ type ResolvedSourceData =
   | null;
 
 /**
- * Generic layer that dispatches to the appropriate source-backed layer based on its input.
+ * Internal deck.gl dispatcher that selects the appropriate source-backed layer for an input.
+ *
+ * This class is exported for internal repository use and examples, and is not documented
+ * beyond these TSDoc comments.
  */
 export class SourceLayer<
   DataT = any,

--- a/modules/deck-layers/src/tile-2d-source-layer.ts
+++ b/modules/deck-layers/src/tile-2d-source-layer.ts
@@ -1,0 +1,772 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {
+  CompositeLayer,
+  type CompositeLayerProps,
+  Layer,
+  type LayersList,
+  type PickingInfo,
+  type GetPickingInfoParams,
+  _flatten as flatten
+} from '@deck.gl/core';
+import {MVTLayer, TileLayer, type TileLayerProps} from '@deck.gl/geo-layers';
+import {BitmapLayer, GeoJsonLayer, PathLayer} from '@deck.gl/layers';
+import {createDataSource} from '@loaders.gl/core';
+import type {
+  DataSourceOptions,
+  GetTileDataParameters,
+  Source,
+  TileSource,
+  TileSourceMetadata
+} from '@loaders.gl/loader-utils';
+import {SharedTile2DHeader, Tileset2D, type Tileset2DProps} from '@loaders.gl/tiles';
+import {Matrix4, type NumericArray} from '@math.gl/core';
+import {sharedTile2DDeckAdapter} from './shared-tile-2d/deck-tileset-adapter';
+import {SharedTile2DView} from './shared-tile-2d/shared-tile-2d-view';
+
+/** Runtime shape used by loaders.gl source-backed tile layers. */
+export type TileSourceRuntime = TileSource & {
+  /** Indicates that vector tiles can be rendered in local coordinates. */
+  localCoordinates?: boolean;
+  /** MIME type that identifies vector or image payload handling. */
+  mimeType: string | null;
+  /** Mutable source options forwarded to loaders.gl tile fetches. */
+  options: {
+    table?: {
+      coordinates?: string;
+    };
+  };
+  /** Source URL used for stable layer ids. */
+  url?: string;
+};
+
+type Tile2DSourceLayerData = string | Blob | TileSourceRuntime;
+
+/** Props for {@link Tile2DSourceLayer}. */
+export type Tile2DSourceLayerProps<DataT = unknown> = CompositeLayerProps &
+  Partial<Omit<TileLayerProps, 'data' | 'renderSubLayers'>> & {
+    /** URL/blob input or a fully constructed loaders.gl tile source. */
+    data: Tile2DSourceLayerData;
+    /** Source factories used to auto-create tile sources from URL/blob inputs. */
+    sources?: Readonly<Source[]>;
+    /** Options forwarded to `createDataSource` when `sources` are supplied. */
+    sourceOptions?: DataSourceOptions;
+    /** Optional metadata used by the example overlay and zoom bounds. */
+    metadata?: TileSourceMetadata | null;
+    /** Show borders around tiles in the generic shared-tile rendering path. */
+    showTileBorders?: boolean;
+    /** Called when a tile payload cannot be fetched or parsed. */
+    onTileError?: (error: unknown, tileParameters?: unknown) => void;
+    /** Called when the viewport's currently selected tiles are loaded. */
+    onTilesLoad?: (tiles: SharedTile2DHeader<DataT>[]) => void;
+    /** Custom sub-layer factory for non-local shared-tile rendering. */
+    renderSubLayers?: (
+      props: Tile2DSourceLayerProps<DataT> & {
+        id: string;
+        data: DataT;
+        _offset: number;
+        tile: SharedTile2DHeader<DataT>;
+        tileSource: TileSourceRuntime;
+      }
+    ) => Layer | null | LayersList;
+    /** Maximum tile count kept in cache. */
+    maxCacheSize?: number | null;
+    /** Maximum tile cache byte size. */
+    maxCacheByteSize?: number | null;
+    /** Minimum zoom level to request. */
+    minZoom?: number | null;
+    /** Maximum zoom level to request. */
+    maxZoom?: number | null;
+    /** Maximum concurrent requests issued by the shared tileset. */
+    maxRequests?: number;
+    /** Debounce interval before issuing queued tile requests. */
+    debounceTime?: number;
+    /** Integer zoom offset applied during tile selection. */
+    zoomOffset?: number;
+    /** Tile size in pixels. */
+    tileSize?: number;
+    /** Bounding box limiting tile generation. */
+    extent?: number[] | null;
+    /** Elevation range used during tile selection. */
+    zRange?: [number, number] | null;
+    /** Optional model matrix applied by the surrounding layer stack. */
+    modelMatrix?: NumericArray | null;
+  };
+
+/** Picking info returned from {@link Tile2DSourceLayer}. */
+export type Tile2DSourceLayerPickingInfo<
+  DataT = any,
+  SubLayerPickingInfo = PickingInfo
+> = SubLayerPickingInfo & {
+  /** Picked tile when a tile sub-layer is hit. */
+  tile?: SharedTile2DHeader<DataT>;
+  /** Tile that produced the picked sub-layer. */
+  sourceTile: SharedTile2DHeader<DataT>;
+  /** Concrete sub-layer instance that handled the pick. */
+  sourceTileSubLayer: Layer;
+};
+
+type Tile2DSourceLayerState<DataT> = {
+  resolvedData: TileSourceRuntime | null;
+  tileset: Tileset2D<DataT, any> | null;
+  tilesetViews: Map<string, SharedTile2DView<DataT>>;
+  isLoaded: boolean;
+  frameNumbers: Map<string, number>;
+  tileLayers: Map<string, any[]>;
+  unsubscribeTilesetEvents: (() => void) | null;
+};
+
+const TILE2D_LAYER_DEFAULT_OPTION_VALUES = {
+  maxCacheSize: null,
+  maxCacheByteSize: null,
+  maxZoom: null,
+  minZoom: null,
+  tileSize: 256,
+  extent: null,
+  maxRequests: 6,
+  debounceTime: 0,
+  zoomOffset: 0
+} as const;
+
+/**
+ * Internal deck.gl MVT helper used by `Tile2DSourceLayer`.
+ *
+ * This class is not part of the supported public API and is documented only through TSDoc.
+ */
+class MVTSourceLayer extends MVTLayer<any> {
+  /** Sync the cached vector tile source whenever deck.gl reports a data change. */
+  updateState(params: any): void {
+    super.updateState(params);
+
+    const {props, changeFlags} = params;
+    if (changeFlags.dataChanged && props.data) {
+      this.setState({
+        vectorTileSource: props.data,
+        binary: false
+      });
+    }
+  }
+
+  /** Fetch tile payloads directly from the wrapped loaders.gl tile source. */
+  async getTileData(parameters: GetTileDataParameters): Promise<any> {
+    try {
+      const vectorTileSource = (this.state as any).vectorTileSource as TileSourceRuntime | null;
+      return vectorTileSource ? await vectorTileSource.getTileData(parameters) : null;
+    } catch (error) {
+      this.props.onTileError?.(error, parameters);
+      return null;
+    }
+  }
+}
+
+/**
+ * Internal deck.gl layer that renders loaders.gl tile sources through a shared 2D tileset.
+ *
+ * It resolves URL/blob inputs using loaders.gl source factories, uses `Tileset2D`
+ * for shared raster and non-local vector traversal, and falls back to `MVTLayer` for
+ * local-coordinate vector tile sources.
+ *
+ * This class is exported for internal repository use and examples, and is not documented
+ * beyond these TSDoc comments.
+ */
+export class Tile2DSourceLayer<DataT = any> extends CompositeLayer<Tile2DSourceLayerProps<DataT>> {
+  /** deck.gl layer name used in debugging output. */
+  static layerName = 'Tile2DSourceLayer';
+
+  /** Default props shared by the vector and raster rendering paths. */
+  static defaultProps = {
+    ...TileLayer.defaultProps,
+    tileSize: 256,
+    minZoom: null,
+    maxZoom: null,
+    maxCacheSize: null,
+    maxCacheByteSize: null,
+    maxRequests: 6,
+    debounceTime: 0,
+    zoomOffset: 0,
+    showTileBorders: true,
+    renderSubLayers: defaultRenderSubLayers
+  };
+
+  /** Viewports tracked by id so shared tileset views stay stable across renders. */
+  private _knownViewports: Map<string, any> = new Map();
+  /** Typed deck.gl state for source resolution, traversal views, and tile sublayers. */
+  state = null as unknown as Tile2DSourceLayerState<DataT>;
+
+  /** Initializes local state before props are first rendered. */
+  initializeState(): void {
+    this._knownViewports.clear();
+    if (this.context.viewport) {
+      this._knownViewports.set(this._getViewportKey(), this.context.viewport);
+    }
+    this.state = {
+      resolvedData: null,
+      tileset: null,
+      tilesetViews: new Map(),
+      isLoaded: false,
+      frameNumbers: new Map(),
+      tileLayers: new Map(),
+      unsubscribeTilesetEvents: null
+    };
+  }
+
+  /** Finalizes owned resources and detaches from the shared tileset. */
+  finalizeState(): void {
+    this._releaseTileset();
+  }
+
+  /** Returns whether all visible sub-layers for all tracked views are loaded. */
+  get isLoaded(): boolean {
+    const {tilesetViews, tileLayers} = this.state;
+    if (!tilesetViews.size) {
+      return false;
+    }
+    return Boolean(
+      Array.from(tilesetViews.values()).every(tilesetView =>
+        tilesetView.selectedTiles?.every(tile => {
+          const cachedLayers = tileLayers.get(tile.id);
+          return (
+            tile.isLoaded &&
+            (!tile.content || !cachedLayers || cachedLayers.every(layer => layer.isLoaded))
+          );
+        })
+      )
+    );
+  }
+
+  /** Triggers updates whenever props, data, or update triggers change. */
+  shouldUpdateState({changeFlags}: any): boolean {
+    return changeFlags.somethingChanged;
+  }
+
+  /** Resolves sources and keeps the shared tileset in sync with current props. */
+  updateState({props, oldProps, changeFlags}: any): void {
+    if (this.context.viewport) {
+      this._knownViewports.set(this._getViewportKey(), this.context.viewport);
+    }
+
+    const previousResolvedData = this.state.resolvedData;
+    let resolvedData = previousResolvedData;
+    const dataChanged =
+      changeFlags.dataChanged ||
+      props.sources !== oldProps.sources ||
+      props.sourceOptions !== oldProps.sourceOptions;
+
+    if (dataChanged) {
+      resolvedData = this._resolveData(props);
+      this.setState({resolvedData});
+    }
+
+    if (!resolvedData || this.sourceSupportsMVTLayer(resolvedData)) {
+      this._releaseTileset();
+      return;
+    }
+
+    const resolvedDataChanged = resolvedData !== previousResolvedData;
+    const tileset = this._getOrCreateTileset(resolvedData, resolvedDataChanged);
+    if (tileset !== this.state.tileset) {
+      this.setState({tileset});
+    } else {
+      tileset.setOptions(this._getTilesetOptions(resolvedData));
+      if (dataChanged) {
+        tileset.reloadAll();
+      } else if (changeFlags.propsOrDataChanged || changeFlags.updateTriggersChanged) {
+        this.state.tileLayers.clear();
+      }
+    }
+
+    this._updateTileset();
+  }
+
+  /** Adds tile references to picking info returned from sub-layers. */
+  getPickingInfo(params: GetPickingInfoParams): Tile2DSourceLayerPickingInfo<DataT> {
+    const {sourceLayer} = params;
+    if (!sourceLayer) {
+      throw new Error('Tile2DSourceLayer picking info requires a source layer.');
+    }
+    const sourceTile: SharedTile2DHeader<DataT> = (sourceLayer.props as any).tile;
+    const info = params.info as Tile2DSourceLayerPickingInfo<DataT>;
+    if (info.picked) {
+      info.tile = sourceTile;
+    }
+    info.sourceTile = sourceTile;
+    info.sourceTileSubLayer = sourceLayer;
+    return info;
+  }
+
+  /** Forwards auto-highlight updates to the picked sub-layer. */
+  protected _updateAutoHighlight(info: Tile2DSourceLayerPickingInfo<DataT>): void {
+    info.sourceTileSubLayer.updateAutoHighlight(info);
+  }
+
+  /** Registers additional viewports in multi-view rendering scenarios. */
+  activateViewport(viewport: any): void {
+    const viewportKey = viewport.id || 'default';
+    const previousViewport = this._knownViewports.get(viewportKey);
+    this._knownViewports.set(viewportKey, viewport);
+    if (!previousViewport || !viewport.equals(previousViewport)) {
+      this.setNeedsUpdate();
+    }
+    super.activateViewport(viewport);
+  }
+
+  /** Filters tile sub-layers based on the active view-specific visibility state. */
+  filterSubLayer({layer, cullRect}: any) {
+    if (!this.state.tileset) {
+      return true;
+    }
+    const {tile} = (layer as Layer<{tile: SharedTile2DHeader<DataT>}>).props;
+    const tilesetView = this._getOrCreateTilesetView(this._getViewportKey());
+    return tilesetView.isTileVisible(
+      tile,
+      cullRect,
+      this.props.modelMatrix ? new Matrix4(this.props.modelMatrix) : null
+    );
+  }
+
+  /** Render either the local-coordinate MVT path or the shared raster/vector path. */
+  renderLayers(): Layer | null | LayersList {
+    const {resolvedData, tileset, tileLayers} = this.state;
+    if (!resolvedData) {
+      return null;
+    }
+
+    if (this.sourceSupportsMVTLayer(resolvedData)) {
+      resolvedData.options.table = resolvedData.options.table || {};
+      resolvedData.options.table.coordinates = 'local';
+      return this.renderMVTLayer(resolvedData);
+    }
+
+    if (!tileset) {
+      return null;
+    }
+
+    resolvedData.options.table = resolvedData.options.table || {};
+    resolvedData.options.table.coordinates = 'wgs84';
+
+    return tileset.tiles.map(tile => {
+      let layers = tileLayers.get(tile.id);
+      if (!tile.isLoaded && !tile.content) {
+        return layers;
+      }
+      if (!layers) {
+        const rendered = this.props.renderSubLayers
+          ? this.props.renderSubLayers({
+              ...this.props,
+              ...this.getSubLayerProps({
+                id: tile.id,
+                updateTriggers: this.props.updateTriggers
+              }),
+              data: tile.content as DataT,
+              _offset: 0,
+              tile,
+              tileSource: resolvedData
+            } as any)
+          : null;
+        layers = this._flattenTileLayers(rendered);
+        tileLayers.set(tile.id, layers);
+      }
+      return layers;
+    });
+  }
+
+  /** Check if the current source supports MVT layer rendering with local coordinates. */
+  sourceSupportsMVTLayer(tileSource: TileSourceRuntime): boolean {
+    return (
+      tileSource.mimeType === 'application/vnd.mapbox-vector-tile' &&
+      Boolean(tileSource.localCoordinates)
+    );
+  }
+
+  /** Render vector tiles through `MVTLayer` when local coordinate support is required. */
+  renderMVTLayer(tileSource: TileSourceRuntime) {
+    const {showTileBorders, metadata, onTilesLoad, onTileError} = this.props;
+    const minZoom = metadata?.minZoom || 0;
+    const maxZoom = metadata?.maxZoom || 30;
+    const devicePixelRatio = this.context.device.getCanvasContext().getDevicePixelRatio();
+
+    return [
+      new MVTSourceLayer({
+        id: `${this.props.id}-mvt`,
+        data: tileSource as any,
+        getLineColor: [0, 0, 0],
+        getLineWidth: 1,
+        getFillColor: [100, 120, 140],
+        lineWidthUnits: 'pixels',
+        pickable: true,
+        autoHighlight: true,
+        onViewportLoad: onTilesLoad,
+        onTileError,
+        minZoom,
+        maxZoom,
+        tileSize: 256,
+        zoomOffset: devicePixelRatio === 1 ? -1 : 0,
+        showTileBorders
+      } as any)
+    ];
+  }
+
+  /** Resolves the shared tileset configuration from current layer props. */
+  private _getTilesetOptions(
+    tileSource: TileSourceRuntime
+  ): Omit<Tileset2DProps<DataT, any>, 'tileSource'> & {tileSource: TileSourceRuntime} {
+    const {
+      tileSize,
+      maxCacheSize,
+      maxCacheByteSize,
+      extent,
+      maxZoom,
+      minZoom,
+      maxRequests,
+      debounceTime,
+      zoomOffset
+    } = this.props;
+    const devicePixelRatio = this.context.device.getCanvasContext().getDevicePixelRatio();
+    const effectiveZoomOffset = this._isDefaultOptionValue(
+      zoomOffset,
+      TILE2D_LAYER_DEFAULT_OPTION_VALUES.zoomOffset
+    )
+      ? devicePixelRatio === 1
+        ? -1
+        : 0
+      : zoomOffset;
+
+    const options = {
+      tileSource,
+      adapter: sharedTile2DDeckAdapter,
+      tileSize,
+      zoomOffset: effectiveZoomOffset,
+      onTileLoad: () => {},
+      onTileError: () => {},
+      onTileUnload: () => {}
+    } as Omit<Tileset2DProps<DataT, any>, 'getTileData'>;
+
+    this._assignTilesetOptionIfExplicit(
+      options,
+      'maxCacheSize',
+      maxCacheSize,
+      TILE2D_LAYER_DEFAULT_OPTION_VALUES.maxCacheSize
+    );
+    this._assignTilesetOptionIfExplicit(
+      options,
+      'maxCacheByteSize',
+      maxCacheByteSize,
+      TILE2D_LAYER_DEFAULT_OPTION_VALUES.maxCacheByteSize
+    );
+    this._assignTilesetOptionIfExplicit(
+      options,
+      'maxZoom',
+      maxZoom,
+      TILE2D_LAYER_DEFAULT_OPTION_VALUES.maxZoom
+    );
+    this._assignTilesetOptionIfExplicit(
+      options,
+      'minZoom',
+      minZoom,
+      TILE2D_LAYER_DEFAULT_OPTION_VALUES.minZoom
+    );
+    this._assignTilesetOptionIfExplicit(
+      options,
+      'extent',
+      extent,
+      TILE2D_LAYER_DEFAULT_OPTION_VALUES.extent
+    );
+    this._assignTilesetOptionIfExplicit(
+      options,
+      'maxRequests',
+      maxRequests,
+      TILE2D_LAYER_DEFAULT_OPTION_VALUES.maxRequests
+    );
+    this._assignTilesetOptionIfExplicit(
+      options,
+      'debounceTime',
+      debounceTime,
+      TILE2D_LAYER_DEFAULT_OPTION_VALUES.debounceTime
+    );
+    return options as Omit<Tileset2DProps<DataT, any>, 'getTileData'> & {
+      tileSource: TileSourceRuntime;
+    };
+  }
+
+  /** Creates or reuses the internal shared tileset for the current source. */
+  private _getOrCreateTileset(
+    tileSource: TileSourceRuntime,
+    resolvedDataChanged: boolean
+  ): Tileset2D<DataT, any> {
+    if (!this.state.tileset || resolvedDataChanged) {
+      this._releaseTileset();
+      const tileset = Tileset2D.fromTileSource<DataT>(
+        tileSource,
+        this._getTilesetOptions(tileSource)
+      );
+      this.setState({
+        tileset,
+        tilesetViews: new Map(),
+        tileLayers: new Map(),
+        frameNumbers: new Map(),
+        unsubscribeTilesetEvents: tileset.subscribe({
+          onTileLoad: this._onTileLoad.bind(this),
+          onTileError: this._onTileError.bind(this),
+          onTileUnload: this._onTileUnload.bind(this),
+          onUpdate: () => this.setNeedsUpdate(),
+          onError: error => this.raiseError(error, 'loading TileSource metadata')
+        })
+      });
+      return tileset;
+    }
+
+    return this.state.tileset;
+  }
+
+  /** Tears down subscriptions and per-view state for the outgoing tileset. */
+  private _releaseTileset(): void {
+    this.state?.unsubscribeTilesetEvents?.();
+    for (const tilesetView of this.state?.tilesetViews?.values?.() || []) {
+      tilesetView.finalize();
+    }
+    this.setState?.({
+      tileset: null,
+      tilesetViews: new Map(),
+      tileLayers: new Map(),
+      frameNumbers: new Map(),
+      unsubscribeTilesetEvents: null
+    });
+  }
+
+  /** Updates per-view traversal state for all known viewports. */
+  private _updateTileset(): void {
+    const {tileset} = this.state;
+    if (!tileset) {
+      return;
+    }
+
+    const {zRange = null, modelMatrix = null} = this.props;
+    let anyTilesetChanged = false;
+
+    for (const [viewportKey, viewport] of this._knownViewports) {
+      const tilesetView = this._getOrCreateTilesetView(viewportKey);
+      const frameNumber = tilesetView.update(viewport, {zRange, modelMatrix});
+      const previousFrameNumber = this.state.frameNumbers.get(viewportKey);
+      const tilesetChanged = previousFrameNumber !== frameNumber;
+      anyTilesetChanged ||= tilesetChanged;
+
+      if (tilesetView.isLoaded && tilesetChanged) {
+        this._onViewportLoad(tilesetView);
+      }
+      if (tilesetChanged) {
+        this.state.frameNumbers.set(viewportKey, frameNumber);
+      }
+    }
+
+    const nextIsLoaded = this.isLoaded;
+    const loadingStateChanged = this.state.isLoaded !== nextIsLoaded;
+    if (loadingStateChanged) {
+      for (const tilesetView of this.state.tilesetViews.values()) {
+        if (tilesetView.isLoaded) {
+          this._onViewportLoad(tilesetView);
+        }
+      }
+    }
+
+    if (anyTilesetChanged) {
+      this.setState({frameNumbers: new Map(this.state.frameNumbers)});
+    }
+    this.state.isLoaded = nextIsLoaded;
+  }
+
+  /** Emits the viewport-load callback for one view. */
+  private _onViewportLoad(tilesetView: SharedTile2DView<DataT>): void {
+    if (tilesetView.selectedTiles) {
+      this.props.onTilesLoad?.(tilesetView.selectedTiles);
+    }
+  }
+
+  /** Clears cached sub-layers when a tile loads. */
+  private _onTileLoad(tile: SharedTile2DHeader<DataT>): void {
+    this.state.tileLayers.delete(tile.id);
+    this.setNeedsUpdate();
+  }
+
+  /** Clears cached sub-layers when a tile errors. */
+  private _onTileError(error: any, tile: SharedTile2DHeader<DataT>): void {
+    this.state.tileLayers.delete(tile.id);
+    this.props.onTileError?.(error, tile);
+    this.setNeedsUpdate();
+  }
+
+  /** Removes cached sub-layers when a tile is evicted. */
+  private _onTileUnload(tile: SharedTile2DHeader<DataT>): void {
+    this.state.tileLayers.delete(tile.id);
+  }
+
+  /** Returns the active viewport key used to isolate per-view traversal state. */
+  private _getViewportKey(): string {
+    return this.context.viewport?.id || 'default';
+  }
+
+  /** Returns the per-viewport traversal state, creating it on demand. */
+  private _getOrCreateTilesetView(viewportKey: string): SharedTile2DView<DataT> {
+    let tilesetView = this.state.tilesetViews.get(viewportKey);
+    if (!tilesetView) {
+      const tileset = this.state.tileset;
+      if (!tileset) {
+        throw new Error('Tile2DSourceLayer tileset was not initialized.');
+      }
+      tilesetView = new SharedTile2DView(tileset);
+      this.state.tilesetViews.set(viewportKey, tilesetView);
+    }
+    return tilesetView;
+  }
+
+  /** Resolves the `data` prop to a concrete loaders.gl tile source. */
+  private _resolveData(props: Tile2DSourceLayerProps<DataT>): TileSourceRuntime | null {
+    const {data, sources, sourceOptions = {}} = props;
+    if (isTileSourceRuntime(data)) {
+      return data;
+    }
+    if ((typeof data === 'string' || data instanceof Blob) && sources?.length) {
+      return createDataSource(data, sources, sourceOptions) as unknown as TileSourceRuntime;
+    }
+    throw new Error('Tile2DSourceLayer requires `sources` for URL/blob inputs.');
+  }
+
+  /** Copies a tileset option only when the layer prop was explicitly set. */
+  private _assignTilesetOptionIfExplicit(
+    options: Record<string, unknown>,
+    key: string,
+    value: unknown,
+    defaultValue: unknown
+  ): void {
+    if (!this._isDefaultOptionValue(value, defaultValue)) {
+      options[key] = value;
+    }
+  }
+
+  /** Tests whether a layer prop still has its default value. */
+  private _isDefaultOptionValue(value: unknown, defaultValue: unknown): boolean {
+    if (Array.isArray(value) || Array.isArray(defaultValue)) {
+      return (
+        Array.isArray(value) &&
+        Array.isArray(defaultValue) &&
+        value.length === defaultValue.length &&
+        value.every((entry, index) => entry === defaultValue[index])
+      );
+    }
+    return value === defaultValue;
+  }
+
+  /** Normalizes nested render output into a flat tile sub-layer array. */
+  private _flattenTileLayers(rendered: Layer | null | LayersList): any[] {
+    return flatten(rendered as any, Boolean) as any[];
+  }
+}
+
+/**
+ * Default sublayer render callback for the shared raster/vector tile path.
+ *
+ * Renders vector tiles with `GeoJsonLayer`, image tiles with `BitmapLayer`, and
+ * optional debug tile borders with `PathLayer`.
+ */
+function defaultRenderSubLayers<DataT>(
+  props: Tile2DSourceLayerProps<DataT> & {
+    id: string;
+    data: DataT;
+    _offset: number;
+    tile: SharedTile2DHeader<DataT>;
+    tileSource: TileSourceRuntime;
+  }
+) {
+  const {tileSource, showTileBorders, minZoom, maxZoom, tile} = props;
+  const {
+    index: {z: zoom}
+  } = tile;
+
+  const layers: any[] = [];
+  const resolvedMinZoom = minZoom ?? 0;
+  const resolvedMaxZoom = maxZoom ?? 30;
+  const borderColor =
+    zoom <= resolvedMinZoom || zoom >= resolvedMaxZoom ? [255, 0, 0, 255] : [0, 0, 255, 255];
+
+  switch (tileSource.mimeType) {
+    case 'application/vnd.mapbox-vector-tile':
+    case 'application/vnd.maplibre-tile':
+      layers.push(
+        new GeoJsonLayer(
+          props as any,
+          {
+            id: `${props.id}-geojson`,
+            data: props.data as any,
+            pickable: true,
+            autoHighlight: true,
+            lineWidthScale: 500,
+            lineWidthMinPixels: 0.5,
+            getFillColor: [100, 120, 140, 255],
+            highlightColor: [0, 0, 200, 255]
+          } as any
+        )
+      );
+      break;
+
+    case 'image/png':
+    case 'image/jpeg':
+    case 'image/webp':
+    case 'image/avif':
+      if ('west' in tile.bbox) {
+        layers.push(
+          new BitmapLayer(
+            props as any,
+            {
+              data: null as any,
+              image: props.data,
+              bounds: [tile.bbox.west, tile.bbox.south, tile.bbox.east, tile.bbox.north],
+              pickable: true
+            } as any
+          )
+        );
+      }
+      break;
+
+    default:
+      break;
+  }
+
+  if (showTileBorders && 'west' in tile.bbox) {
+    layers.push(
+      new PathLayer(
+        props as any,
+        {
+          id: `${props.id}-border`,
+          data: [
+            {
+              path: [
+                [tile.bbox.west, tile.bbox.south],
+                [tile.bbox.west, tile.bbox.north],
+                [tile.bbox.east, tile.bbox.north],
+                [tile.bbox.east, tile.bbox.south],
+                [tile.bbox.west, tile.bbox.south]
+              ]
+            }
+          ],
+          getPath: (d: any) => d.path,
+          getColor: borderColor as any,
+          getWidth: 1,
+          widthMinPixels: 1
+        } as any
+      )
+    );
+  }
+
+  return layers;
+}
+
+function isTileSourceRuntime(value: unknown): value is TileSourceRuntime {
+  return Boolean(
+    value &&
+      typeof value === 'object' &&
+      'getTileData' in value &&
+      'getMetadata' in value &&
+      !('initialize' in value)
+  );
+}

--- a/modules/deck-layers/src/tile-3d-source-layer.ts
+++ b/modules/deck-layers/src/tile-3d-source-layer.ts
@@ -22,7 +22,10 @@ export type Tile3DSourceLayerProps<DataT = unknown> = Omit<Tile3DLayerProps<Data
 };
 
 /**
- * deck.gl `Tile3DLayer` adapter that constructs source-backed `Tileset3D` instances.
+ * Internal deck.gl `Tile3DLayer` adapter that constructs source-backed `Tileset3D` instances.
+ *
+ * This class is exported for internal repository use and examples, and is not documented
+ * beyond these TSDoc comments.
  */
 export class Tile3DSourceLayer<
   DataT = any,

--- a/modules/deck-layers/src/tile-source-layer.ts
+++ b/modules/deck-layers/src/tile-source-layer.ts
@@ -30,7 +30,11 @@ export type TileSourceRuntime = TileSource & {
   url?: string;
 };
 
-/** Internal helper layer for routing tile fetches through a `VectorTileSource`. */
+/**
+ * Internal deck.gl MVT helper used by `TileSourceLayer`.
+ *
+ * This class is not part of the supported public API and is documented only through TSDoc.
+ */
 class MVTSourceLayer extends MVTLayer<any> {
   /** Sync the cached vector tile source whenever deck.gl reports a data change. */
   updateState(params: any): void {
@@ -85,10 +89,13 @@ export type TileSourceLayerProps = Omit<TileLayerProps, 'data'> & {
 };
 
 /**
- * A deck.gl layer that renders a loaders.gl tile source.
+ * Internal deck.gl layer that renders a loaders.gl tile source.
  *
  * It automatically switches between vector-tile and bitmap rendering paths and
  * can draw debug tile borders.
+ *
+ * This class is exported for internal repository use and examples, and is not documented
+ * beyond these TSDoc comments.
  */
 export class TileSourceLayer extends CompositeLayer<TileSourceLayerProps> {
   /** deck.gl layer name used in debugging output. */

--- a/modules/deck-layers/test/shared-tile-2d-view.spec.ts
+++ b/modules/deck-layers/test/shared-tile-2d-view.spec.ts
@@ -1,0 +1,77 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'tape-promise/tape';
+import {Tileset2D, type Tileset2DAdapter} from '@loaders.gl/tiles';
+import {SharedTile2DView} from '../src/shared-tile-2d/shared-tile-2d-view';
+
+const TEST_ADAPTER: Tileset2DAdapter<any> = {
+  getTileIndices: () => [
+    {x: 0, y: 0, z: 0},
+    {x: 1, y: 0, z: 0}
+  ],
+  getTileBoundingBox: (_context, index) => ({
+    west: index.x,
+    south: index.y,
+    east: index.x + 1,
+    north: index.y + 1
+  })
+};
+
+const TEST_VIEWPORT = {
+  id: 'test-viewport',
+  equals(other) {
+    return other === this;
+  }
+} as any;
+
+test('SharedTile2DView#custom refinement strategies can control visibility', t => {
+  const tileset = new Tileset2D({
+    adapter: TEST_ADAPTER,
+    getTileData: async () => null,
+    refinementStrategy: (tiles, setVisible) => {
+      setVisible(tiles[0], true);
+      setVisible(tiles[1], false);
+    }
+  });
+  const view = new SharedTile2DView(tileset as any);
+
+  view.update(TEST_VIEWPORT);
+
+  const [firstTile, secondTile] = view.selectedTiles || [];
+  t.ok(firstTile);
+  t.ok(secondTile);
+  t.ok(view.isTileVisible(firstTile), 'custom refinement keeps the first tile visible');
+  t.notOk(view.isTileVisible(secondTile), 'custom refinement can hide placeholder tiles');
+
+  view.finalize();
+  tileset.finalize();
+  t.end();
+});
+
+test('SharedTile2DView#same-viewport updates reload only stale selected tiles', async t => {
+  let requestCount = 0;
+  const tileset = new Tileset2D({
+    adapter: TEST_ADAPTER,
+    getTileData: async ({id}) => {
+      requestCount++;
+      return {id, byteLength: 1};
+    }
+  });
+  const view = new SharedTile2DView(tileset as any);
+
+  view.update(TEST_VIEWPORT);
+  await Promise.all((view.selectedTiles || []).map(tile => tile.data));
+  t.equal(requestCount, 2, 'initial viewport update loads both selected tiles');
+
+  const [firstTile] = view.selectedTiles || [];
+  firstTile.setNeedsReload();
+  view.update(TEST_VIEWPORT);
+  await Promise.all((view.selectedTiles || []).map(tile => tile.data));
+  t.equal(requestCount, 3, 'same-viewport reload only refreshes the stale tile');
+
+  view.finalize();
+  tileset.finalize();
+  t.end();
+});

--- a/modules/deck-layers/test/tile-2d-source-layer.spec.ts
+++ b/modules/deck-layers/test/tile-2d-source-layer.spec.ts
@@ -67,3 +67,50 @@ test('Tile2DSourceLayer#detects local-coordinate MVT sources', t => {
   t.notOk(layer.sourceSupportsMVTLayer(TEST_TILE_SOURCE));
   t.end();
 });
+
+test('Tile2DSourceLayer#default render path creates GeoJsonLayer for vector tiles', t => {
+  const layer = createLayer();
+  const renderedLayers = (layer.props as any).renderSubLayers({
+    ...layer.props,
+    id: 'vector-tile',
+    data: [],
+    _offset: 0,
+    tile: {
+      index: {x: 0, y: 0, z: 0},
+      bbox: {west: 0, south: 0, east: 1, north: 1},
+      boundingBox: [
+        [0, 0],
+        [1, 1]
+      ]
+    },
+    tileSource: {
+      ...TEST_TILE_SOURCE,
+      mimeType: 'application/vnd.mapbox-vector-tile'
+    }
+  });
+
+  t.equal(renderedLayers[0].constructor.layerName, 'GeoJsonLayer');
+  t.end();
+});
+
+test('Tile2DSourceLayer#default render path creates BitmapLayer for raster tiles', t => {
+  const layer = createLayer();
+  const renderedLayers = (layer.props as any).renderSubLayers({
+    ...layer.props,
+    id: 'raster-tile',
+    data: {} as any,
+    _offset: 0,
+    tile: {
+      index: {x: 0, y: 0, z: 0},
+      bbox: {west: 0, south: 0, east: 1, north: 1},
+      boundingBox: [
+        [0, 0],
+        [1, 1]
+      ]
+    },
+    tileSource: TEST_TILE_SOURCE
+  });
+
+  t.equal(renderedLayers[0].constructor.layerName, 'BitmapLayer');
+  t.end();
+});

--- a/modules/deck-layers/test/tile-2d-source-layer.spec.ts
+++ b/modules/deck-layers/test/tile-2d-source-layer.spec.ts
@@ -1,0 +1,69 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'tape-promise/tape';
+import {Tile2DSourceLayer, type Tile2DSourceLayerProps} from '@loaders.gl/deck-layers';
+
+const TEST_TILE_SOURCE = {
+  mimeType: 'image/png',
+  options: {},
+  async getMetadata() {
+    return {minZoom: 0, maxZoom: 1};
+  },
+  async getTileData() {
+    return null;
+  }
+};
+
+const TEST_SOURCE_FACTORY = {
+  name: 'TestSource',
+  id: 'test-source',
+  module: 'test',
+  version: '0.0.0',
+  extensions: ['test'],
+  mimeTypes: ['application/test'],
+  type: 'tile',
+  fromUrl: true,
+  fromBlob: true,
+  testURL: () => true,
+  createDataSource() {
+    return TEST_TILE_SOURCE as any;
+  }
+};
+
+function createLayer(props: Tile2DSourceLayerProps = {id: 'test', data: TEST_TILE_SOURCE as any}) {
+  return new Tile2DSourceLayer(props as any) as any;
+}
+
+test('Tile2DSourceLayer#resolves URL inputs with sources', t => {
+  const layer = createLayer({
+    id: 'test',
+    data: 'https://example.com/tiles',
+    sources: [TEST_SOURCE_FACTORY as any]
+  });
+
+  const resolvedData = layer._resolveData(layer.props);
+  t.equal(resolvedData, TEST_TILE_SOURCE);
+  t.end();
+});
+
+test('Tile2DSourceLayer#accepts direct TileSource inputs', t => {
+  const layer = createLayer();
+  const resolvedData = layer._resolveData(layer.props);
+  t.equal(resolvedData, TEST_TILE_SOURCE);
+  t.end();
+});
+
+test('Tile2DSourceLayer#detects local-coordinate MVT sources', t => {
+  const layer = createLayer();
+  t.ok(
+    layer.sourceSupportsMVTLayer({
+      ...TEST_TILE_SOURCE,
+      mimeType: 'application/vnd.mapbox-vector-tile',
+      localCoordinates: true
+    })
+  );
+  t.notOk(layer.sourceSupportsMVTLayer(TEST_TILE_SOURCE));
+  t.end();
+});

--- a/modules/loader-utils/src/lib/sources/data-source.ts
+++ b/modules/loader-utils/src/lib/sources/data-source.ts
@@ -6,6 +6,7 @@ import type {Loader, StrictLoaderOptions} from '../../loader-types';
 import type {RequiredOptions} from '../option-utils/merge-options';
 import {mergeOptions} from '../option-utils/merge-options';
 import {resolvePath} from '../path-utils/file-aliases';
+import {log} from '../log-utils/log';
 
 /** Common properties for all data sources */
 export type DataSourceOptions = Partial<{
@@ -18,6 +19,8 @@ export type DataSourceOptions = Partial<{
     loadOptions?: StrictLoaderOptions;
     /** Make additional loaders available to the data source */
     loaders?: Loader[];
+    /** Called when source-level initialization or metadata loading fails. */
+    onError?: (error: Error, source: DataSource<any, any>) => void;
   };
   [key: string]: Record<string, unknown>;
 }>;
@@ -29,7 +32,8 @@ export abstract class DataSource<DataT, OptionsT extends DataSourceOptions> {
       type: 'auto',
       attributions: [],
       loadOptions: {},
-      loaders: []
+      loaders: [],
+      onError: undefined!
     }
   };
 
@@ -83,6 +87,18 @@ export abstract class DataSource<DataT, OptionsT extends DataSourceOptions> {
       this._needsRefresh = false;
     }
     return needsRefresh;
+  }
+
+  /** Reports a source-level failure through the configured callback or the shared logger. */
+  protected reportError(error: unknown, message: string): Error {
+    const normalizedError = normalizeError(error, message);
+    const callback = this.options.core?.onError;
+    if (callback) {
+      callback(normalizedError, this);
+    } else {
+      log.warn(`${this.constructor.name}: ${normalizedError.message}`)();
+    }
+    return normalizedError;
   }
 }
 
@@ -146,4 +162,15 @@ function normalizeDirectLoaderOptions(options?: StrictLoaderOptions): StrictLoad
   }
 
   return loadOptions;
+}
+
+/** Normalizes arbitrary thrown values to `Error` instances for source-level reporting. */
+function normalizeError(error: unknown, message: string): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+  if (typeof error === 'string') {
+    return new Error(error);
+  }
+  return new Error(message);
 }

--- a/modules/mlt/src/mlt-source.ts
+++ b/modules/mlt/src/mlt-source.ts
@@ -95,7 +95,10 @@ export class MLTTileSource
     try {
       const response = await this.fetch(this.metadataUrl);
       if (!response.ok) {
-        console.error(response.statusText);
+        this.reportError(
+          new Error(`${response.status} ${response.statusText}`),
+          `Failed to fetch metadata from ${this.metadataUrl}`
+        );
         return {minZoom: 0, maxZoom: 30, attributions};
       }
 
@@ -118,7 +121,7 @@ export class MLTTileSource
         attributions: [...attributions, ...((metadataJson?.attributions as string[]) || [])]
       };
     } catch (error) {
-      console.error((error as Error).message);
+      this.reportError(error, `Failed to fetch metadata from ${this.metadataUrl}`);
       return {minZoom: 0, maxZoom: 30, attributions};
     }
   }
@@ -127,6 +130,10 @@ export class MLTTileSource
     const tileUrl = this.getTileURL(parameters.x, parameters.y, parameters.z);
     const response = await this.fetch(tileUrl);
     if (!response.ok) {
+      this.reportError(
+        new Error(`${response.status} ${response.statusText}`),
+        `Failed to fetch tile ${tileUrl} ${JSON.stringify(parameters)}`
+      );
       return null;
     }
     return response.arrayBuffer();

--- a/modules/mvt/src/mvt-source.ts
+++ b/modules/mvt/src/mvt-source.ts
@@ -99,13 +99,14 @@ export class MVTTileSource
       // CORS errors are common when requesting an unavailable sub resource such as a metadata file or an unavailable tile)
       response = await this.fetch(this.metadataUrl);
     } catch (error: unknown) {
-      // eslint-disable-next-line no-console
-      console.error((error as TypeError).message);
+      this.reportError(error, `Failed to fetch metadata from ${this.metadataUrl}`);
       return null;
     }
     if (!response.ok) {
-      // eslint-disable-next-line no-console
-      console.error(response.statusText);
+      this.reportError(
+        new Error(`${response.status} ${response.statusText}`),
+        `Failed to fetch metadata from ${this.metadataUrl}`
+      );
       return null;
     }
     const tileJSON = await response.text();
@@ -129,6 +130,10 @@ export class MVTTileSource
     const tileUrl = this.getTileURL(x, y, z);
     const response = await this.fetch(tileUrl);
     if (!response.ok) {
+      this.reportError(
+        new Error(`${response.status} ${response.statusText}`),
+        `Failed to fetch tile ${tileUrl} ${JSON.stringify(parameters)}`
+      );
       return null;
     }
     const arrayBuffer = await response.arrayBuffer();

--- a/modules/pmtiles/src/pmtiles-source.ts
+++ b/modules/pmtiles/src/pmtiles-source.ts
@@ -121,10 +121,19 @@ export class PMTilesTileSource
 
   async getTile(tileParams: GetTileParameters): Promise<ArrayBuffer | null> {
     const {x, y, z} = tileParams;
-    const rangeResponse = await this.getZxyBatched(z, x, y);
+    let rangeResponse;
+    try {
+      rangeResponse = await this.getZxyBatched(z, x, y, (tileParams as any).signal);
+    } catch (error) {
+      this.reportError(error, `Failed to fetch tile ${this.url} ${JSON.stringify(tileParams)}`);
+      return null;
+    }
     const arrayBuffer = rangeResponse?.data;
     if (!arrayBuffer) {
-      // console.error('No arrayBuffer', tileParams);
+      this.reportError(
+        new Error('Empty tile response'),
+        `Failed to fetch tile ${this.url} ${JSON.stringify(tileParams)}`
+      );
       return null;
     }
     return arrayBuffer;

--- a/modules/tiles/README.md
+++ b/modules/tiles/README.md
@@ -35,3 +35,78 @@ The shared `Tileset3DSource` contract owns:
 `Tileset3D` remains responsible for traversal, culling, request scheduling, selection, and cache management.
 
 For broader documentation please visit the [website](https://loaders.gl).
+
+## Tileset2D
+
+`Tileset2D` is the shared cache and loading engine for source-backed 2D tile rendering.
+
+API reference: [`Tileset2D`](../../docs/modules/tiles/api-reference/tileset-2d.md)
+
+Its purpose is to separate:
+
+- shared tile content, request scheduling, and cache eviction
+- per-view selection and visibility state
+
+That lets multiple layers and views reuse the same tile cache without duplicating requests or
+overwriting each other's traversal state.
+
+### Installation
+
+```ts
+import {
+  Tileset2D,
+  type Tileset2DProps,
+  type TileLoadProps
+} from '@loaders.gl/tiles';
+```
+
+### Construct from `getTileData`
+
+```ts
+const tileset = new Tileset2D({
+  getTileData: async ({id, bbox}: TileLoadProps) => fetchTile(id, bbox),
+  maxZoom: 14,
+  maxCacheSize: 256
+});
+```
+
+### Construct from a loaders.gl `TileSource`
+
+```ts
+import type {TileSource} from '@loaders.gl/loader-utils';
+import {Tileset2D} from '@loaders.gl/tiles';
+
+const tileSource: TileSource = createTileSourceSomehow();
+const tileset = Tileset2D.fromTileSource(tileSource, {
+  maxCacheByteSize: 32 * 1024 * 1024
+});
+```
+
+When backed by a `TileSource`, the tileset reads metadata once and adopts:
+
+- `minZoom`
+- `maxZoom`
+- `boundingBox` mapped to `extent`
+
+Explicit options still override source metadata.
+
+### Key API
+
+- `tiles`: current contents of the shared tile cache
+- `selectedTiles` / `visibleTiles`: union views across all attached consumers
+- `loadingTiles` / `unloadedTiles`: current loading and unloaded cache subsets
+- `stats`: live `@probe.gl/stats` counters for cache size, selection, visibility, and consumers
+- `subscribe(listener)`: tile lifecycle, metadata update, and stats callbacks
+- `setOptions(opts)`: update runtime configuration
+- `reloadAll()`: mark retained tiles stale for reload
+- `finalize()`: abort requests and clear the cache
+
+The shared stats currently populate:
+
+- `Tiles In Cache`
+- `Cache Size`
+- `Visible Tiles`
+- `Selected Tiles`
+- `Loading Tiles`
+- `Unloaded Tiles`
+- `Consumers`

--- a/modules/tiles/src/index.ts
+++ b/modules/tiles/src/index.ts
@@ -22,6 +22,36 @@ export {I3SSource} from './tileset-3d/format-i3s/i3s-source';
 export {TilesetTraverser} from './tileset-3d/common/tileset-traverser';
 export {TilesetCache} from './tileset-3d/common/tileset-cache';
 
+export type {
+  Bounds,
+  GeoBoundingBox,
+  NonGeoBoundingBox,
+  TileBoundingBox,
+  TileIndex,
+  TileLoadProps,
+  ZRange
+} from './tileset-2d';
+export type {
+  Tileset2DAdapter,
+  Tileset2DTileContext,
+  Tileset2DTraversalContext
+} from './tileset-2d';
+export type {
+  RefinementStrategy,
+  RefinementStrategyFunction,
+  Tileset2DBaseProps,
+  Tileset2DProps,
+  Tile2DListener,
+  Tile2DLoadDataProps
+} from './tileset-2d';
+export {
+  SharedTile2DHeader,
+  Tileset2D,
+  STRATEGY_DEFAULT,
+  STRATEGY_NEVER,
+  STRATEGY_REPLACE
+} from './tileset-2d';
+
 export {createBoundingVolume} from './tileset-3d/helpers/bounding-volume';
 export {calculateTransformProps} from './tileset-3d/helpers/transform-utils';
 

--- a/modules/tiles/src/tileset-2d.ts
+++ b/modules/tiles/src/tileset-2d.ts
@@ -1,0 +1,5 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export * from './tileset-2d/index';

--- a/modules/tiles/src/tileset-2d/adapter.ts
+++ b/modules/tiles/src/tileset-2d/adapter.ts
@@ -1,0 +1,47 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Matrix4} from '@math.gl/core';
+import type {Bounds, TileBoundingBox, TileIndex, ZRange} from './types';
+
+/** Traversal inputs required by a {@link Tileset2DAdapter}. */
+export type Tileset2DTraversalContext<ViewStateT> = {
+  /** Consumer-defined view state used by the adapter. */
+  viewState: ViewStateT;
+  /** Tile size in pixels. */
+  tileSize: number;
+  /** Bounding box limiting tile generation. */
+  extent?: Bounds | null;
+  /** Minimum zoom level to request. */
+  minZoom?: number;
+  /** Maximum zoom level to request. */
+  maxZoom?: number;
+  /** Integer zoom offset applied during tile selection. */
+  zoomOffset?: number;
+  /** Elevation range used during geospatial tile selection. */
+  zRange?: ZRange | null;
+  /** Optional model matrix applied by the surrounding layer stack. */
+  modelMatrix?: Matrix4 | null;
+  /** Inverse of the current model matrix. */
+  modelMatrixInverse?: Matrix4 | null;
+};
+
+/** Minimal tile metadata inputs required by a {@link Tileset2DAdapter}. */
+export type Tileset2DTileContext<ViewStateT> = {
+  /** Consumer-defined view state used by the adapter. */
+  viewState: ViewStateT;
+  /** Tile size in pixels. */
+  tileSize: number;
+};
+
+/** Adapter used by {@link Tileset2D} to compute traversal and tile bounds. */
+export type Tileset2DAdapter<ViewStateT> = {
+  /** Returns tile indices that should be selected for one traversal context. */
+  getTileIndices: (context: Tileset2DTraversalContext<ViewStateT>) => TileIndex[];
+  /** Returns the structured bounding box for one tile index. */
+  getTileBoundingBox: (
+    context: Tileset2DTileContext<ViewStateT>,
+    index: TileIndex
+  ) => TileBoundingBox;
+};

--- a/modules/tiles/src/tileset-2d/index.ts
+++ b/modules/tiles/src/tileset-2d/index.ts
@@ -1,0 +1,33 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export type {
+  Bounds,
+  GeoBoundingBox,
+  NonGeoBoundingBox,
+  TileBoundingBox,
+  TileIndex,
+  TileLoadProps,
+  ZRange
+} from './types';
+export type {
+  Tileset2DAdapter,
+  Tileset2DTileContext,
+  Tileset2DTraversalContext
+} from './adapter';
+export type {Tile2DLoadDataProps} from './tile-2d-header';
+export {SharedTile2DHeader} from './tile-2d-header';
+export type {
+  RefinementStrategy,
+  RefinementStrategyFunction,
+  Tileset2DBaseProps,
+  Tileset2DProps,
+  Tile2DListener
+} from './tileset-2d';
+export {
+  Tileset2D,
+  STRATEGY_DEFAULT,
+  STRATEGY_NEVER,
+  STRATEGY_REPLACE
+} from './tileset-2d';

--- a/modules/tiles/src/tileset-2d/tile-2d-header.ts
+++ b/modules/tiles/src/tileset-2d/tile-2d-header.ts
@@ -1,0 +1,224 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/* eslint-env browser */
+import {RequestScheduler} from '@loaders.gl/loader-utils';
+import type {TileBoundingBox, TileIndex, TileLoadProps} from './types';
+
+/** Parameters used by {@link SharedTile2DHeader.loadData}. */
+export type Tile2DLoadDataProps<DataT = any> = {
+  /** Shared request scheduler for throttling tile fetches. */
+  requestScheduler: RequestScheduler;
+  /** Application-provided tile data loader. */
+  getData: (props: TileLoadProps) => Promise<DataT | null> | DataT | null;
+  /** Callback fired after tile content resolves successfully. */
+  onLoad: (tile: SharedTile2DHeader<DataT>) => void;
+  /** Callback fired after tile content fails to load. */
+  onError: (error: any, tile: SharedTile2DHeader<DataT>) => void;
+};
+
+/** Shared tile cache entry used by {@link Tileset2D}. */
+export class SharedTile2DHeader<DataT = any> {
+  /** x/y/z tile coordinate. */
+  index: TileIndex;
+  /** Closest cached ancestor tile in the current tree. */
+  parent: SharedTile2DHeader | null;
+  /** Cached child tiles beneath this tile. */
+  children: SharedTile2DHeader[] | null;
+  /** Loaded tile payload. */
+  content: DataT | null;
+  /** Cached tile load error, if the last request failed. */
+  error: Error | null;
+  /** Stable tile cache id. */
+  id!: string;
+  /** Resolved zoom level for the tile. */
+  zoom!: number;
+  /** Optional application data associated with the tile. */
+  userData?: Record<string, any>;
+  /** Bounds represented as `[[minX, minY], [maxX, maxY]]` for loaders.gl compatibility. */
+  boundingBox!: [min: number[], max: number[]];
+
+  private _abortController: AbortController | null;
+  private _loader: Promise<void> | undefined;
+  private _loaderId: number;
+  private _isLoaded: boolean;
+  private _isCancelled: boolean;
+  private _needsReload: boolean;
+  private _bbox!: TileBoundingBox;
+
+  /** Creates a tile header for a specific tile index. */
+  constructor(index: TileIndex) {
+    this.index = index;
+    this.parent = null;
+    this.children = [];
+    this.content = null;
+    this.error = null;
+    this._loader = undefined;
+    this._abortController = null;
+    this._loaderId = 0;
+    this._isLoaded = false;
+    this._isCancelled = false;
+    this._needsReload = false;
+  }
+
+  /** Structured bounds for the tile in the active coordinate system. */
+  get bbox(): TileBoundingBox {
+    return this._bbox;
+  }
+
+  /** Initializes the tile bounds once during tile creation. */
+  set bbox(value: TileBoundingBox) {
+    if (this._bbox) {
+      return;
+    }
+
+    this._bbox = value;
+    if ('west' in value) {
+      this.boundingBox = [
+        [value.west, value.south],
+        [value.east, value.north]
+      ];
+    } else {
+      this.boundingBox = [
+        [value.left, value.top],
+        [value.right, value.bottom]
+      ];
+    }
+  }
+
+  /** Resolves to loaded content while a request is in flight, otherwise returns cached content. */
+  get data(): Promise<DataT | null> | DataT | null {
+    const loader = this._loader;
+    if (!this._isCancelled && loader !== undefined) {
+      return loader.then(() => this.data);
+    }
+    return this.content;
+  }
+
+  /** Indicates whether tile content is available and up to date. */
+  get isLoaded(): boolean {
+    return this._isLoaded && !this._needsReload;
+  }
+
+  /** Indicates whether a tile request is currently in flight. */
+  get isLoading(): boolean {
+    return Boolean(this._loader) && !this._isCancelled;
+  }
+
+  /** Indicates whether the tile is cached in a failed state. */
+  get hasError(): boolean {
+    return Boolean(this.error);
+  }
+
+  /** Indicates whether the tile should be requested again. */
+  get needsReload(): boolean {
+    return this._needsReload || this._isCancelled;
+  }
+
+  /** Estimated byte size of the cached payload. */
+  get byteLength(): number {
+    const result = this.content ? (this.content as any).byteLength : 0;
+    return Number.isFinite(result) ? result : 0;
+  }
+
+  /** Internal request pipeline used by {@link loadData}. */
+  private async _loadData({
+    getData,
+    requestScheduler,
+    onLoad,
+    onError
+  }: Tile2DLoadDataProps<DataT>): Promise<void> {
+    const completeLoad = (tileData: DataT | null, error: unknown, loaderId: number): void => {
+      if (loaderId !== this._loaderId) {
+        return;
+      }
+
+      this._loader = undefined;
+      this.content = tileData;
+      this.error = error ? normalizeTileError(error) : null;
+
+      if (this._isCancelled && !tileData) {
+        this._isLoaded = false;
+        return;
+      }
+
+      this._isLoaded = true;
+      this._isCancelled = false;
+
+      if (error) {
+        onError(error, this);
+        return;
+      }
+      onLoad(this);
+    };
+
+    const {index, id, bbox, userData, zoom} = this;
+    const loaderId = this._loaderId;
+
+    this._abortController = new AbortController();
+    const {signal} = this._abortController;
+    const requestToken = await requestScheduler.scheduleRequest(this, () => 1);
+
+    if (!requestToken) {
+      this._isCancelled = true;
+      return;
+    }
+    if (this._isCancelled) {
+      requestToken.done();
+      return;
+    }
+
+    let tileData: DataT | null = null;
+    let error;
+    try {
+      tileData = await getData({index, id, bbox, userData, zoom, signal});
+    } catch (err) {
+      error = err || true;
+    } finally {
+      requestToken.done();
+    }
+
+    completeLoad(tileData, error, loaderId);
+  }
+
+  /** Loads tile data through the shared scheduler. */
+  loadData(opts: Tile2DLoadDataProps<DataT>): Promise<void> {
+    this._isLoaded = false;
+    this._isCancelled = false;
+    this._needsReload = false;
+    this.error = null;
+    this._loaderId++;
+    this._loader = this._loadData(opts);
+    return this._loader;
+  }
+
+  /** Marks the tile stale so it is refreshed on the next traversal. */
+  setNeedsReload(): void {
+    if (this.isLoading) {
+      this.abort();
+      this._loader = undefined;
+    }
+    this._needsReload = true;
+  }
+
+  /** Cancels an in-flight tile request. */
+  abort(): void {
+    if (this.isLoaded) {
+      return;
+    }
+    this._isCancelled = true;
+    this._abortController?.abort();
+  }
+}
+
+/** Normalizes arbitrary thrown values to `Error` instances for tile cache bookkeeping. */
+function normalizeTileError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+  if (typeof error === 'string') {
+    return new Error(error);
+  }
+  return new Error('Tile request failed');
+}

--- a/modules/tiles/src/tileset-2d/tileset-2d.ts
+++ b/modules/tiles/src/tileset-2d/tileset-2d.ts
@@ -16,8 +16,16 @@ export const STRATEGY_REPLACE = 'no-overlap';
 /** Prefer the best currently available loaded ancestor or descendant tiles. */
 export const STRATEGY_DEFAULT = 'best-available';
 
-/** Function form of a refinement strategy. */
-export type RefinementStrategyFunction = (tiles: SharedTile2DHeader[]) => void;
+/**
+ * Function form of a refinement strategy.
+ *
+ * The callback receives the current cached tiles and a visibility setter that can be used
+ * to control placeholder visibility for individual tiles.
+ */
+export type RefinementStrategyFunction = (
+  tiles: SharedTile2DHeader[],
+  setVisible: (tile: SharedTile2DHeader, isVisible: boolean) => void
+) => void;
 
 /** Strategy controlling how parent and child placeholder tiles are displayed while content loads. */
 export type RefinementStrategy =
@@ -268,7 +276,19 @@ export class Tileset2D<DataT = any, ViewStateT = unknown> {
   setOptions(opts: Partial<Tileset2DProps<DataT, ViewStateT>>): void {
     this._rememberExplicitOptions(opts);
     this._baseOpts = {...this._baseOpts, ...opts};
+    const previousMaxRequests = this.opts.maxRequests;
+    const previousDebounceTime = this.opts.debounceTime;
     this._applyResolvedOptions();
+    if (
+      previousMaxRequests !== this.opts.maxRequests ||
+      previousDebounceTime !== this.opts.debounceTime
+    ) {
+      this._requestScheduler = new RequestScheduler({
+        throttleRequests: this.opts.maxRequests > 0 || this.opts.debounceTime > 0,
+        maxRequests: this.opts.maxRequests,
+        debounceTime: this.opts.debounceTime
+      });
+    }
   }
 
   /** Aborts in-flight requests and clears the shared cache. */
@@ -293,6 +313,8 @@ export class Tileset2D<DataT = any, ViewStateT = unknown> {
       const tile = this._cache.get(id);
       if (tile && !selectedTiles.has(tile)) {
         this._cache.delete(id);
+        this._handleTileUnload(tile);
+        this._dirty = true;
       } else if (tile) {
         tile.setNeedsReload();
       }
@@ -410,7 +432,7 @@ export class Tileset2D<DataT = any, ViewStateT = unknown> {
       this._touchTile(id, tile);
     }
 
-    if (tile && needsReload) {
+    if (tile && needsReload && create) {
       tile
         .loadData({
           getData: this.opts.getTileData,

--- a/modules/tiles/src/tileset-2d/tileset-2d.ts
+++ b/modules/tiles/src/tileset-2d/tileset-2d.ts
@@ -1,0 +1,694 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {RequestScheduler, type TileSource, type TileSourceMetadata} from '@loaders.gl/loader-utils';
+import type {Matrix4} from '@math.gl/core';
+import {Stats} from '@probe.gl/stats';
+import {SharedTile2DHeader} from './tile-2d-header';
+import type {Tileset2DAdapter, Tileset2DTileContext} from './adapter';
+import type {TileIndex, TileLoadProps, ZRange} from './types';
+
+/** Never show ancestor or descendant placeholder tiles. */
+export const STRATEGY_NEVER = 'never';
+/** Prefer non-overlapping loaded tiles while replacements stream in. */
+export const STRATEGY_REPLACE = 'no-overlap';
+/** Prefer the best currently available loaded ancestor or descendant tiles. */
+export const STRATEGY_DEFAULT = 'best-available';
+
+/** Function form of a refinement strategy. */
+export type RefinementStrategyFunction = (tiles: SharedTile2DHeader[]) => void;
+
+/** Strategy controlling how parent and child placeholder tiles are displayed while content loads. */
+export type RefinementStrategy =
+  | typeof STRATEGY_NEVER
+  | typeof STRATEGY_REPLACE
+  | typeof STRATEGY_DEFAULT
+  | RefinementStrategyFunction;
+
+/** Core configuration shared by all {@link Tileset2D} instances. */
+export type Tileset2DBaseProps<DataT = any, ViewStateT = unknown> = {
+  /** Callback used to load tile payloads. */
+  getTileData: (props: TileLoadProps) => Promise<DataT | null> | DataT | null;
+  /** Adapter used to compute tile traversal and tile metadata. */
+  adapter?: Tileset2DAdapter<ViewStateT> | null;
+  /** Bounding box limiting tile generation. */
+  extent?: number[] | null;
+  /** Tile size in pixels. */
+  tileSize?: number;
+  /** Maximum zoom level to request. */
+  maxZoom?: number | null;
+  /** Minimum zoom level to request. */
+  minZoom?: number | null;
+  /** Maximum number of tiles kept in cache. */
+  maxCacheSize?: number | null;
+  /** Maximum bytes kept in cache. */
+  maxCacheByteSize?: number | null;
+  /** Placeholder refinement strategy. */
+  refinementStrategy?: RefinementStrategy;
+  /** Elevation range used by geospatial tile selection. */
+  zRange?: ZRange | null;
+  /** Maximum concurrent tile requests. */
+  maxRequests?: number;
+  /** Debounce interval applied before issuing queued requests. */
+  debounceTime?: number;
+  /** Integer zoom offset applied when choosing tile levels. */
+  zoomOffset?: number;
+  /** Callback fired when a tile loads successfully. */
+  onTileLoad?: (tile: SharedTile2DHeader<DataT>) => void;
+  /** Callback fired when a tile is evicted from cache. */
+  onTileUnload?: (tile: SharedTile2DHeader<DataT>) => void;
+  /** Callback fired when a tile request fails. */
+  onTileError?: (err: any, tile: SharedTile2DHeader<DataT>) => void;
+};
+
+/** Options for creating a shared tile cache that can be reused by multiple layers and views. */
+export type Tileset2DProps<DataT = any, ViewStateT = unknown> = Omit<
+  Tileset2DBaseProps<DataT, ViewStateT>,
+  'getTileData'
+> & {
+  /** Optional tile loader used when not sourcing data from a loaders.gl TileSource. */
+  getTileData?: (props: TileLoadProps) => Promise<DataT | null> | DataT | null;
+  /** Optional loaders.gl TileSource backing this shared tileset. */
+  tileSource?: TileSource | null;
+};
+
+/** Subscription callbacks emitted by {@link Tileset2D}. */
+export type Tile2DListener<DataT = any> = {
+  /** Fired after a tile loads successfully. */
+  onTileLoad?: (tile: SharedTile2DHeader<DataT>) => void;
+  /** Fired after a tile request fails. */
+  onTileError?: (error: any, tile: SharedTile2DHeader<DataT>) => void;
+  /** Fired after a tile is evicted from cache. */
+  onTileUnload?: (tile: SharedTile2DHeader<DataT>) => void;
+  /** Fired when metadata or effective configuration changes. */
+  onUpdate?: () => void;
+  /** Fired when asynchronous metadata initialization fails. */
+  onError?: (error: Error) => void;
+  /** Fired after live tileset counters are recomputed. */
+  onStatsChange?: (stats: Stats) => void;
+};
+
+type ConsumerState<DataT = any> = {
+  selectedTiles: Set<SharedTile2DHeader<DataT>>;
+  visibleTiles: Set<SharedTile2DHeader<DataT>>;
+};
+
+const DEFAULT_TILESET2D_PROPS: Omit<Required<Tileset2DProps>, 'getTileData'> = {
+  adapter: null,
+  extent: null,
+  tileSize: 512,
+  maxZoom: null,
+  minZoom: null,
+  maxCacheSize: 100,
+  maxCacheByteSize: null,
+  refinementStrategy: STRATEGY_DEFAULT,
+  zRange: null,
+  maxRequests: 6,
+  debounceTime: 0,
+  zoomOffset: 0,
+  onTileLoad: () => {},
+  onTileUnload: () => {},
+  onTileError: () => {},
+  tileSource: null
+};
+
+/** Shared tile cache and loading engine for one or more consumers. */
+export class Tileset2D<DataT = any, ViewStateT = unknown> {
+  /** Live counters describing shared tileset state. */
+  readonly stats: Stats;
+  /** Cached metadata returned by the backing TileSource, if any. */
+  sourceMetadata: TileSourceMetadata | null = null;
+
+  protected opts: Required<Tileset2DProps<DataT, ViewStateT>>;
+
+  private _requestScheduler: RequestScheduler;
+  private _cache: Map<string, SharedTile2DHeader<DataT>>;
+  private _dirty: boolean;
+  private _tiles: SharedTile2DHeader<DataT>[];
+  private _cacheByteSize: number;
+  private _unloadedTileCount: number;
+  private _listeners = new Set<Tile2DListener<DataT>>();
+  private _consumers = new Map<symbol, ConsumerState<DataT>>();
+  private _explicitOptionKeys = new Set<string>();
+  private _baseOpts: Partial<Tileset2DProps<DataT, ViewStateT>> = {};
+  private _sourceMetadataOverrides: Partial<Tileset2DProps<DataT, ViewStateT>> = {};
+  private _maxZoom?: number;
+  private _minZoom?: number;
+  private _lastTileContext: Tileset2DTileContext<ViewStateT> | null = null;
+
+  /** Creates a tileset from either `getTileData` or a loaders.gl `TileSource`. */
+  constructor(opts: Tileset2DProps<DataT, ViewStateT>) {
+    this.stats = new Stats({
+      id: 'Tileset2D',
+      stats: [
+        {name: 'Tiles In Cache'},
+        {name: 'Cache Size'},
+        {name: 'Visible Tiles'},
+        {name: 'Selected Tiles'},
+        {name: 'Loading Tiles'},
+        {name: 'Unloaded Tiles'},
+        {name: 'Consumers'}
+      ]
+    });
+    this.opts = {
+      ...DEFAULT_TILESET2D_PROPS,
+      ...opts,
+      getTileData: opts.getTileData || (() => null),
+      tileSource: opts.tileSource
+    } as Required<Tileset2DProps<DataT, ViewStateT>>;
+
+    this._requestScheduler = new RequestScheduler({
+      throttleRequests: this.opts.maxRequests > 0 || this.opts.debounceTime > 0,
+      maxRequests: this.opts.maxRequests,
+      debounceTime: this.opts.debounceTime
+    });
+
+    this._cache = new Map();
+    this._tiles = [];
+    this._dirty = false;
+    this._cacheByteSize = 0;
+    this._unloadedTileCount = 0;
+
+    if (!this.opts.tileSource && !opts.getTileData) {
+      throw new Error('Tileset2D requires either `getTileData` or `tileSource`.');
+    }
+
+    this.setOptions(opts);
+    this._updateStats();
+
+    if (this.opts.tileSource) {
+      this._initializeTileSource(this.opts.tileSource).catch(() => {});
+    }
+  }
+
+  /** Convenience factory for wrapping a loaders.gl `TileSource`. */
+  static fromTileSource<DataT = any>(
+    tileSource: TileSource,
+    opts: Omit<Tileset2DProps<DataT>, 'tileSource' | 'getTileData'> = {}
+  ): Tileset2D<DataT> {
+    return new Tileset2D<DataT>({...opts, tileSource});
+  }
+
+  /** All tiles currently present in the shared cache. */
+  get tiles(): SharedTile2DHeader<DataT>[] {
+    return this._tiles;
+  }
+
+  /** Estimated byte size of all tile content currently retained in cache. */
+  get cacheByteSize(): number {
+    return this._cacheByteSize;
+  }
+
+  /** Union of tiles selected by all attached consumers. */
+  get selectedTiles(): SharedTile2DHeader<DataT>[] {
+    return Array.from(this._getSelectedTilesUnion());
+  }
+
+  /** Union of tiles contributing to the visible result across all consumers and views. */
+  get visibleTiles(): SharedTile2DHeader<DataT>[] {
+    const union = this._getVisibleTilesUnion();
+    for (const tile of this._getSelectedTilesUnion()) {
+      union.add(tile);
+    }
+    return Array.from(union);
+  }
+
+  /** Tiles currently loading anywhere in the shared cache. */
+  get loadingTiles(): SharedTile2DHeader<DataT>[] {
+    return Array.from(this._cache.values()).filter(tile => tile.isLoading);
+  }
+
+  /** Tiles retained in cache that do not currently have loaded content. */
+  get unloadedTiles(): SharedTile2DHeader<DataT>[] {
+    return Array.from(this._cache.values()).filter(tile => !tile.isLoaded);
+  }
+
+  /** Maximum resolved zoom level after applying metadata and explicit options. */
+  get maxZoom(): number | undefined {
+    return this._maxZoom;
+  }
+
+  /** Minimum resolved zoom level after applying metadata and explicit options. */
+  get minZoom(): number | undefined {
+    return this._minZoom;
+  }
+
+  /** Active refinement strategy for placeholder handling. */
+  get refinementStrategy(): RefinementStrategy {
+    return this.opts.refinementStrategy || STRATEGY_DEFAULT;
+  }
+
+  /** Adapter currently used for traversal and tile metadata. */
+  get adapter(): Tileset2DAdapter<ViewStateT> | null {
+    return this.opts.adapter;
+  }
+
+  /** Subscribes to tileset lifecycle events. */
+  subscribe(listener: Tile2DListener<DataT>): () => void {
+    this._listeners.add(listener);
+    return () => this._listeners.delete(listener);
+  }
+
+  /** Registers a consumer so cache pruning can account for its selected tiles. */
+  attachConsumer(id: symbol): void {
+    this._consumers.set(id, {selectedTiles: new Set(), visibleTiles: new Set()});
+    this._updateStats();
+  }
+
+  /** Unregisters a consumer and prunes unused requests and tiles. */
+  detachConsumer(id: symbol): void {
+    this._consumers.delete(id);
+    this._pruneRequests();
+    this._resizeCache();
+    this._updateStats();
+  }
+
+  /** Updates tileset options and reapplies TileSource metadata overrides. */
+  setOptions(opts: Partial<Tileset2DProps<DataT, ViewStateT>>): void {
+    this._rememberExplicitOptions(opts);
+    this._baseOpts = {...this._baseOpts, ...opts};
+    this._applyResolvedOptions();
+  }
+
+  /** Aborts in-flight requests and clears the shared cache. */
+  finalize(): void {
+    for (const tile of this._cache.values()) {
+      if (tile.isLoading) {
+        tile.abort();
+      }
+    }
+    this._cache.clear();
+    this._tiles = [];
+    this._consumers.clear();
+    this._cacheByteSize = 0;
+    this._unloadedTileCount = 0;
+    this._updateStats();
+  }
+
+  /** Marks all retained tiles stale and drops unused cached tiles. */
+  reloadAll(): void {
+    const selectedTiles = this._getSelectedTilesUnion();
+    for (const id of this._cache.keys()) {
+      const tile = this._cache.get(id);
+      if (tile && !selectedTiles.has(tile)) {
+        this._cache.delete(id);
+      } else if (tile) {
+        tile.setNeedsReload();
+      }
+    }
+    this._cacheByteSize = this._getCacheByteSize();
+    this.prepareTiles();
+    this._updateStats();
+  }
+
+  /** Updates the selected and visible tile sets for one consumer. */
+  updateConsumer(
+    id: symbol,
+    selectedTiles: SharedTile2DHeader<DataT>[],
+    visibleTiles: SharedTile2DHeader<DataT>[]
+  ): void {
+    this._consumers.set(id, {
+      selectedTiles: new Set(selectedTiles),
+      visibleTiles: new Set(visibleTiles)
+    });
+    this._pruneRequests();
+    this._resizeCache();
+    this._updateStats();
+  }
+
+  /** Rebuilds parent/child links if the cache changed since the last traversal. */
+  prepareTiles(): void {
+    if (this._dirty) {
+      this._rebuildTree();
+      this._syncTiles();
+      this._dirty = false;
+    }
+  }
+
+  /** Returns tile indices needed to cover a viewport. */
+  getTileIndices({
+    viewState,
+    maxZoom,
+    minZoom,
+    zRange,
+    modelMatrix,
+    modelMatrixInverse
+  }: {
+    viewState: ViewStateT;
+    maxZoom?: number;
+    minZoom?: number;
+    zRange: ZRange | null;
+    modelMatrix?: Matrix4 | null;
+    modelMatrixInverse?: Matrix4 | null;
+  }): TileIndex[] {
+    const {adapter, tileSize, extent, zoomOffset} = this.opts;
+    if (!adapter) {
+      throw new Error('Tileset2D requires an adapter before tile traversal can be used.');
+    }
+    this._lastTileContext = {viewState, tileSize};
+    return adapter.getTileIndices({
+      viewState,
+      maxZoom,
+      minZoom,
+      zRange,
+      tileSize,
+      extent: normalizeBounds(extent),
+      modelMatrix,
+      modelMatrixInverse,
+      zoomOffset
+    });
+  }
+
+  /** Returns the stable cache id for a tile index. */
+  getTileId(index: TileIndex): string {
+    return `${index.x}-${index.y}-${index.z}`;
+  }
+
+  /** Returns the zoom level represented by a tile index. */
+  getTileZoom(index: TileIndex): number {
+    return index.z;
+  }
+
+  /** Returns derived metadata used to initialize a tile header. */
+  getTileMetadata(index: TileIndex): Record<string, any> {
+    if (!this._lastTileContext) {
+      throw new Error('Tileset2D metadata requested before traversal context was set.');
+    }
+    if (!this.opts.adapter) {
+      throw new Error('Tileset2D requires an adapter before tile metadata can be derived.');
+    }
+    return {bbox: this.opts.adapter.getTileBoundingBox(this._lastTileContext, index)};
+  }
+
+  /** Returns the parent tile index in the quadtree. */
+  getParentIndex(index: TileIndex): TileIndex {
+    return {x: Math.floor(index.x / 2), y: Math.floor(index.y / 2), z: index.z - 1};
+  }
+
+  /** Returns a cached tile and optionally creates and loads it on demand. */
+  getTile(index: TileIndex, create: true): SharedTile2DHeader<DataT>;
+  getTile(index: TileIndex, create?: false): SharedTile2DHeader<DataT> | undefined;
+  getTile(index: TileIndex, create?: boolean): SharedTile2DHeader<DataT> | undefined {
+    const id = this.getTileId(index);
+    let tile = this._cache.get(id);
+    let needsReload = false;
+
+    if (!tile && create) {
+      tile = new SharedTile2DHeader(index);
+      Object.assign(tile, this.getTileMetadata(tile.index));
+      Object.assign(tile, {id, zoom: this.getTileZoom(tile.index)});
+      needsReload = true;
+      this._cache.set(id, tile);
+      this._dirty = true;
+      this._updateStats();
+    } else if (tile && tile.needsReload) {
+      needsReload = true;
+    }
+
+    if (tile) {
+      this._touchTile(id, tile);
+    }
+
+    if (tile && needsReload) {
+      tile
+        .loadData({
+          getData: this.opts.getTileData,
+          requestScheduler: this._requestScheduler,
+          onLoad: this._handleTileLoad.bind(this),
+          onError: this._handleTileError.bind(this)
+        })
+        .catch(() => {});
+      this._updateStats();
+    }
+
+    return tile;
+  }
+
+  /** Loads metadata from a TileSource and reapplies derived option overrides. */
+  private async _initializeTileSource(tileSource: TileSource): Promise<void> {
+    try {
+      this.sourceMetadata = await tileSource.getMetadata();
+      this._sourceMetadataOverrides = this._getMetadataOverrides(this.sourceMetadata);
+      this._applyResolvedOptions();
+      this._notifyUpdate();
+    } catch (error: any) {
+      const normalizedError =
+        error instanceof Error ? error : new Error(`TileSource metadata error: ${String(error)}`);
+      this._notifyError(normalizedError);
+    }
+  }
+
+  /** Tracks which options were explicitly set by the caller. */
+  private _rememberExplicitOptions(opts: Partial<Tileset2DProps<DataT, ViewStateT>>): void {
+    for (const key of Object.keys(opts)) {
+      this._explicitOptionKeys.add(key);
+    }
+  }
+
+  /** Resolves defaults, metadata overrides, and caller options into runtime settings. */
+  private _applyResolvedOptions(): void {
+    const resolvedOpts = {
+      ...DEFAULT_TILESET2D_PROPS,
+      ...this._sourceMetadataOverrides,
+      ...this._baseOpts
+    } as Required<Tileset2DProps<DataT, ViewStateT>>;
+
+    if (resolvedOpts.tileSource) {
+      const tileSource = resolvedOpts.tileSource;
+      resolvedOpts.getTileData = (loadProps: TileLoadProps) =>
+        tileSource.getTileData(loadProps) as Promise<DataT | null> | DataT | null;
+    }
+
+    this.opts = resolvedOpts;
+    this._maxZoom =
+      typeof this.opts.maxZoom === 'number' && Number.isFinite(this.opts.maxZoom)
+        ? Math.floor(this.opts.maxZoom)
+        : undefined;
+    this._minZoom =
+      typeof this.opts.minZoom === 'number' && Number.isFinite(this.opts.minZoom)
+        ? Math.ceil(this.opts.minZoom)
+        : undefined;
+  }
+
+  /** Maps TileSource metadata into supported tileset options. */
+  private _getMetadataOverrides(
+    metadata: TileSourceMetadata | null
+  ): Partial<Tileset2DProps<DataT, ViewStateT>> {
+    if (!metadata) {
+      return {};
+    }
+    const overrides: Partial<Tileset2DProps<DataT, ViewStateT>> = {};
+    if (!this._explicitOptionKeys.has('minZoom') && Number.isFinite(metadata.minZoom)) {
+      overrides.minZoom = metadata.minZoom;
+    }
+    if (!this._explicitOptionKeys.has('maxZoom') && Number.isFinite(metadata.maxZoom)) {
+      overrides.maxZoom = metadata.maxZoom;
+    }
+    if (!this._explicitOptionKeys.has('extent') && metadata.boundingBox) {
+      overrides.extent = [
+        metadata.boundingBox[0][0],
+        metadata.boundingBox[0][1],
+        metadata.boundingBox[1][0],
+        metadata.boundingBox[1][1]
+      ];
+    }
+    return overrides;
+  }
+
+  /** Handles successful tile loads. */
+  private _handleTileLoad(tile: SharedTile2DHeader<DataT>): void {
+    this.opts.onTileLoad?.(tile);
+    this._cacheByteSize = this._getCacheByteSize();
+    this._resizeCache();
+    for (const listener of this._listeners) {
+      listener.onTileLoad?.(tile);
+    }
+    this._updateStats();
+  }
+
+  /** Handles tile load failures. */
+  private _handleTileError(error: any, tile: SharedTile2DHeader<DataT>): void {
+    this.opts.onTileError?.(error, tile);
+    for (const listener of this._listeners) {
+      listener.onTileError?.(error, tile);
+    }
+    this._updateStats();
+  }
+
+  /** Handles tile eviction from cache. */
+  private _handleTileUnload(tile: SharedTile2DHeader<DataT>): void {
+    this._unloadedTileCount++;
+    this.opts.onTileUnload?.(tile);
+    for (const listener of this._listeners) {
+      listener.onTileUnload?.(tile);
+    }
+    this._updateStats();
+  }
+
+  /** Notifies listeners that metadata or effective options changed. */
+  private _notifyUpdate(): void {
+    for (const listener of this._listeners) {
+      listener.onUpdate?.();
+    }
+  }
+
+  /** Notifies listeners about asynchronous metadata errors. */
+  private _notifyError(error: Error): void {
+    for (const listener of this._listeners) {
+      listener.onError?.(error);
+    }
+  }
+
+  /** Recomputes absolute counter stats and notifies listeners. */
+  private _updateStats(): void {
+    this._setStatCount('Tiles In Cache', this._cache.size);
+    this._setStatCount('Cache Size', this.cacheByteSize);
+    this._setStatCount('Visible Tiles', this.visibleTiles.length);
+    this._setStatCount('Selected Tiles', this.selectedTiles.length);
+    this._setStatCount('Loading Tiles', this.loadingTiles.length);
+    this._setStatCount('Unloaded Tiles', this._unloadedTileCount);
+    this._setStatCount('Consumers', this._consumers.size);
+
+    for (const listener of this._listeners) {
+      listener.onStatsChange?.(this.stats);
+    }
+  }
+
+  /** Writes an absolute count into a probe.gl stat. */
+  private _setStatCount(name: string, value: number): void {
+    this.stats.get(name).reset().addCount(value);
+  }
+
+  /** Returns the union of selected tiles across all consumers. */
+  private _getSelectedTilesUnion(): Set<SharedTile2DHeader<DataT>> {
+    const union = new Set<SharedTile2DHeader<DataT>>();
+    for (const consumer of this._consumers.values()) {
+      for (const tile of consumer.selectedTiles) {
+        union.add(tile);
+      }
+    }
+    return union;
+  }
+
+  /** Returns the union of visible tiles across all consumers. */
+  private _getVisibleTilesUnion(): Set<SharedTile2DHeader<DataT>> {
+    const union = new Set<SharedTile2DHeader<DataT>>();
+    for (const consumer of this._consumers.values()) {
+      for (const tile of consumer.visibleTiles) {
+        union.add(tile);
+      }
+    }
+    return union;
+  }
+
+  /** Moves a touched tile to the back of the cache map for LRU eviction ordering. */
+  private _touchTile(id: string, tile: SharedTile2DHeader<DataT>): void {
+    this._cache.delete(id);
+    this._cache.set(id, tile);
+  }
+
+  /** Computes the total byte size of all cached tile content. */
+  private _getCacheByteSize(): number {
+    let byteLength = 0;
+    for (const tile of this._cache.values()) {
+      byteLength += tile.byteLength;
+    }
+    return byteLength;
+  }
+
+  /** Cancels low-priority requests when consumers no longer need them. */
+  private _pruneRequests(): void {
+    const {maxRequests = 0} = this.opts;
+    const selectedTiles = this._getSelectedTilesUnion();
+    const visibleTiles = this._getVisibleTilesUnion();
+    const abortCandidates: SharedTile2DHeader<DataT>[] = [];
+    let ongoingRequestCount = 0;
+
+    for (const tile of this._cache.values()) {
+      if (tile.isLoading) {
+        ongoingRequestCount++;
+        if (!selectedTiles.has(tile) && !visibleTiles.has(tile)) {
+          abortCandidates.push(tile);
+        }
+      }
+    }
+
+    while (maxRequests > 0 && ongoingRequestCount > maxRequests && abortCandidates.length > 0) {
+      const tile = abortCandidates.shift();
+      if (tile) {
+        tile.abort();
+      }
+      ongoingRequestCount--;
+    }
+  }
+
+  /** Rebuilds parent and child links for all cached tiles. */
+  private _rebuildTree(): void {
+    for (const tile of this._cache.values()) {
+      tile.parent = null;
+      if (tile.children) {
+        tile.children.length = 0;
+      }
+    }
+    for (const tile of this._cache.values()) {
+      const parent = this._getNearestAncestor(tile);
+      tile.parent = parent;
+      if (parent?.children) {
+        parent.children.push(tile);
+      }
+    }
+  }
+
+  /** Updates the sorted tile list used by traversal and rendering. */
+  private _syncTiles(): void {
+    this._tiles = Array.from(this._cache.values()).sort((tile1, tile2) => tile1.zoom - tile2.zoom);
+  }
+
+  /** Evicts unused cached tiles when configured cache limits are exceeded. */
+  private _resizeCache(): void {
+    const maxCacheSize = this.opts.maxCacheSize ?? 100;
+    const maxCacheByteSize = this.opts.maxCacheByteSize ?? Infinity;
+    const visibleTiles = this._getVisibleTilesUnion();
+    const selectedTiles = this._getSelectedTilesUnion();
+    const overflown = this._cache.size > maxCacheSize || this._cacheByteSize > maxCacheByteSize;
+
+    if (overflown) {
+      for (const [id, tile] of this._cache) {
+        if (!visibleTiles.has(tile) && !selectedTiles.has(tile)) {
+          this._cache.delete(id);
+          this._cacheByteSize = this._getCacheByteSize();
+          this._handleTileUnload(tile);
+        }
+        if (this._cache.size <= maxCacheSize && this._cacheByteSize <= maxCacheByteSize) {
+          break;
+        }
+      }
+      this._dirty = true;
+    }
+
+    if (this._dirty) {
+      this._rebuildTree();
+      this._syncTiles();
+      this._dirty = false;
+    }
+  }
+
+  /** Finds the nearest cached ancestor tile for placeholder rendering. */
+  private _getNearestAncestor(tile: SharedTile2DHeader<DataT>): SharedTile2DHeader<DataT> | null {
+    const {_minZoom = 0} = this;
+    let index = tile.index;
+    while (this.getTileZoom(index) > _minZoom) {
+      index = this.getParentIndex(index);
+      const parent = this.getTile(index);
+      if (parent) {
+        return parent;
+      }
+    }
+    return null;
+  }
+}
+
+function normalizeBounds(extent: number[] | null | undefined) {
+  return extent && extent.length === 4 ? (extent as [number, number, number, number]) : undefined;
+}

--- a/modules/tiles/src/tileset-2d/types.ts
+++ b/modules/tiles/src/tileset-2d/types.ts
@@ -1,0 +1,39 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** Inclusive minimum and maximum elevation bounds used during tile selection. */
+export type ZRange = [minZ: number, maxZ: number];
+
+/** Axis-aligned bounding box represented as `[minX, minY, maxX, maxY]`. */
+export type Bounds = [minX: number, minY: number, maxX: number, maxY: number];
+
+/** Geographic tile bounds in longitude/latitude coordinates. */
+export type GeoBoundingBox = {west: number; north: number; east: number; south: number};
+
+/** Cartesian tile bounds in layer/world coordinates. */
+export type NonGeoBoundingBox = {left: number; top: number; right: number; bottom: number};
+
+/** Tile bounds for either geospatial or cartesian views. */
+export type TileBoundingBox = NonGeoBoundingBox | GeoBoundingBox;
+
+/** Tile coordinate in an x/y/z pyramid. */
+export type TileIndex = {x: number; y: number; z: number};
+
+/** Information passed to a tile loader for fetching tile content. */
+export type TileLoadProps = {
+  /** x/y/z tile coordinate. */
+  index: TileIndex;
+  /** Stable cache identifier for the tile. */
+  id: string;
+  /** Bounds covered by the tile in the active coordinate system. */
+  bbox: TileBoundingBox;
+  /** URL derived from a URL template, if applicable. */
+  url?: string | null;
+  /** Abort signal for cancelling an in-flight tile request. */
+  signal?: AbortSignal;
+  /** Optional application metadata associated with the tile. */
+  userData?: Record<string, any>;
+  /** Resolved zoom level used to request this tile. */
+  zoom?: number;
+};

--- a/modules/tiles/test/index.ts
+++ b/modules/tiles/test/index.ts
@@ -6,6 +6,7 @@ import './utils/doubly-linked-list.spec';
 
 import './tileset/tile-3d.spec';
 import './tileset/tileset-3d.spec';
+import './tileset/tileset-3d-source.spec';
 import './tileset/tileset-traverser.spec';
 
 import './tileset/helpers/get-frame-state.spec';

--- a/modules/tiles/test/index.ts
+++ b/modules/tiles/test/index.ts
@@ -11,6 +11,7 @@ import './tileset/tileset-traverser.spec';
 import './tileset/helpers/get-frame-state.spec';
 import './tileset/helpers/zoom.spec';
 import './tileset/helpers/bounding-volume.spec';
+import './tileset/tileset-2d.spec';
 
 // I3S Specific tests
 // TODO - deck.gl dependency

--- a/modules/tiles/test/tileset/tileset-2d.spec.ts
+++ b/modules/tiles/test/tileset/tileset-2d.spec.ts
@@ -1,0 +1,137 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'tape-promise/tape';
+import {Tileset2D, type Tileset2DAdapter} from '@loaders.gl/tiles';
+
+const TEST_ADAPTER: Tileset2DAdapter<null> = {
+  getTileIndices: () => [
+    {x: 0, y: 0, z: 0},
+    {x: 1, y: 0, z: 0}
+  ],
+  getTileBoundingBox: (_context, index) => ({
+    west: index.x,
+    south: index.y,
+    east: index.x + 1,
+    north: index.y + 1
+  })
+};
+
+test('Tileset2D#applies TileSource metadata overrides', async t => {
+  const tileset = Tileset2D.fromTileSource(
+    {
+      async getMetadata() {
+        return {
+          minZoom: 2,
+          maxZoom: 5,
+          boundingBox: [
+            [1, 2],
+            [3, 4]
+          ]
+        };
+      },
+      async getTileData() {
+        return [];
+      }
+    } as any,
+    {adapter: TEST_ADAPTER}
+  );
+
+  await new Promise(resolve => setTimeout(resolve, 0));
+  t.equal(tileset.minZoom, 2);
+  t.equal(tileset.maxZoom, 5);
+  const indices = tileset.getTileIndices({viewState: null, zRange: null});
+  t.equal(indices.length, 2);
+  tileset.finalize();
+  t.end();
+});
+
+test('Tileset2D#tracks consumer visibility unions', async t => {
+  const tileset = new Tileset2D({
+    adapter: TEST_ADAPTER,
+    getTileData: async () => ({byteLength: 1})
+  });
+
+  const indices = tileset.getTileIndices({viewState: null, zRange: null});
+  const firstTile = tileset.getTile(indices[0], true);
+  const secondTile = tileset.getTile(indices[1], true);
+  await Promise.all([firstTile.data, secondTile.data]);
+  tileset.prepareTiles();
+
+  const firstConsumer = Symbol('first');
+  const secondConsumer = Symbol('second');
+  tileset.attachConsumer(firstConsumer);
+  tileset.attachConsumer(secondConsumer);
+  tileset.updateConsumer(firstConsumer, [firstTile], [firstTile]);
+  tileset.updateConsumer(secondConsumer, [secondTile], []);
+
+  t.equal(tileset.selectedTiles.length, 2);
+  t.equal(tileset.visibleTiles.length, 2);
+
+  tileset.detachConsumer(secondConsumer);
+  t.equal(tileset.selectedTiles.length, 1);
+  t.equal(tileset.visibleTiles.length, 1);
+
+  tileset.finalize();
+  t.end();
+});
+
+test('Tileset2D#reloadAll keeps selected tiles and drops unused cached tiles', async t => {
+  const tileset = new Tileset2D({
+    adapter: TEST_ADAPTER,
+    getTileData: async ({id}) => ({id, byteLength: 1})
+  });
+
+  const indices = tileset.getTileIndices({viewState: null, zRange: null});
+  const firstTile = tileset.getTile(indices[0], true);
+  const secondTile = tileset.getTile(indices[1], true);
+  await Promise.all([firstTile.data, secondTile.data]);
+  tileset.prepareTiles();
+
+  const consumerId = Symbol('consumer');
+  tileset.attachConsumer(consumerId);
+  tileset.updateConsumer(consumerId, [firstTile], [firstTile]);
+
+  tileset.reloadAll();
+
+  t.ok(tileset.getTile(firstTile.index));
+  t.ok(tileset.getTile(firstTile.index)?.needsReload);
+  t.notOk(tileset.getTile(secondTile.index));
+
+  tileset.finalize();
+  t.end();
+});
+
+test('Tileset2D#caches failed tiles until reloadAll', async t => {
+  let requestCount = 0;
+  const tileset = new Tileset2D({
+    adapter: TEST_ADAPTER,
+    getTileData: async () => {
+      requestCount++;
+      throw new Error('boom');
+    }
+  });
+
+  const [firstIndex] = tileset.getTileIndices({viewState: null, zRange: null});
+  const failedTile = tileset.getTile(firstIndex, true);
+  await failedTile.data;
+
+  t.equal(requestCount, 1, 'first request failed once');
+  t.ok(failedTile.hasError, 'failed tile stores its error');
+  t.equal(failedTile.error?.message, 'boom', 'failed tile stores the error message');
+  t.equal(failedTile.content, null, 'failed tile keeps null content');
+
+  const cachedTile = tileset.getTile(firstIndex, true);
+  await cachedTile.data;
+  t.equal(requestCount, 1, 'cached failed tile is not re-requested immediately');
+  t.ok(cachedTile.hasError, 'cached failed tile remains failed');
+
+  tileset.reloadAll();
+  const reloadedTile = tileset.getTile(firstIndex, true);
+  await reloadedTile.data;
+  t.equal(requestCount, 2, 'reloadAll allows failed tiles to be requested again');
+
+  tileset.finalize();
+  t.end();
+});

--- a/modules/tiles/test/tileset/tileset-2d.spec.ts
+++ b/modules/tiles/test/tileset/tileset-2d.spec.ts
@@ -98,6 +98,41 @@ test('Tileset2D#reloadAll keeps selected tiles and drops unused cached tiles', a
   t.ok(tileset.getTile(firstTile.index));
   t.ok(tileset.getTile(firstTile.index)?.needsReload);
   t.notOk(tileset.getTile(secondTile.index));
+  t.notOk(
+    tileset.tiles.some(tile => tile.id === secondTile.id),
+    'removed tiles no longer remain in the prepared tile list'
+  );
+
+  tileset.finalize();
+  t.end();
+});
+
+test('Tileset2D#setOptions recreates the request scheduler when throttling changes', t => {
+  const tileset = new Tileset2D({
+    adapter: TEST_ADAPTER,
+    getTileData: async () => null,
+    maxRequests: 4,
+    debounceTime: 0
+  });
+
+  const initialScheduler = (tileset as any)._requestScheduler;
+  tileset.setOptions({maxRequests: 2});
+  const updatedScheduler = (tileset as any)._requestScheduler;
+  t.notEqual(updatedScheduler, initialScheduler, 'scheduler recreated for maxRequests updates');
+
+  tileset.setOptions({tileSize: 512});
+  t.equal(
+    (tileset as any)._requestScheduler,
+    updatedScheduler,
+    'scheduler is reused when throttling options are unchanged'
+  );
+
+  tileset.setOptions({debounceTime: 10});
+  t.notEqual(
+    (tileset as any)._requestScheduler,
+    updatedScheduler,
+    'scheduler recreated for debounceTime updates'
+  );
 
   tileset.finalize();
   t.end();

--- a/modules/tiles/test/tileset/tileset-3d-source.spec.ts
+++ b/modules/tiles/test/tileset/tileset-3d-source.spec.ts
@@ -1,0 +1,94 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'tape-promise/tape';
+import {I3SLoader} from '@loaders.gl/i3s';
+import {Tiles3DLoader} from '@loaders.gl/3d-tiles';
+import {
+  I3SSource,
+  Tiles3DSource,
+  isTileset3DSource,
+  type TilesetJSON
+} from '@loaders.gl/tiles';
+
+test('isTileset3DSource recognizes explicit source implementations', t => {
+  const tiles3DSource = new Tiles3DSource({
+    url: 'https://example.com/tileset.json',
+    loader: Tiles3DLoader,
+    root: {refine: 'ADD'},
+    asset: {version: '1.0'}
+  } as any);
+  const i3sSource = new I3SSource({
+    url: 'https://example.com/layers/0',
+    loader: I3SLoader,
+    root: {refine: 'ADD'}
+  } as any);
+
+  t.ok(isTileset3DSource(tiles3DSource));
+  t.ok(isTileset3DSource(i3sSource));
+  t.notOk(
+    isTileset3DSource({
+      initialize: async () => {},
+      getRootTileset: async () => ({}),
+      loadTileContent: async () => ({loaded: true})
+    }),
+    'partial lookalikes without initializeTileHeaders are rejected'
+  );
+  t.end();
+});
+
+test('Tiles3DSource initializes metadata and merges source query parameters', async t => {
+  const tilesetJson: TilesetJSON = {
+    type: 'tileset',
+    url: 'https://example.com/root/tileset.json',
+    loader: Tiles3DLoader,
+    asset: {version: '1.0', tilesetVersion: '42'},
+    root: {refine: 'ADD'},
+    lodMetricType: 'geometricError',
+    lodMetricValue: 16,
+    queryString: 'session=abc123',
+    extensionsUsed: ['KHR_texture_basisu']
+  };
+  const source = new Tiles3DSource(tilesetJson);
+
+  await source.initialize();
+
+  const metadata = source.getMetadata();
+  t.equal(metadata.basePath, 'https://example.com/root');
+  t.equal(metadata.refine, 'ADD');
+  t.ok(source.hasExtension('KHR_texture_basisu'));
+  t.equal(
+    source.getTileUrl('https://example.com/root/tile.b3dm?existing=1'),
+    'https://example.com/root/tile.b3dm?existing=1&session=abc123&v=42'
+  );
+  t.equal(source.getTileUrl('data:application/octet-stream;base64,AA=='), 'data:application/octet-stream;base64,AA==');
+  t.end();
+});
+
+test('I3SSource initializes promised roots and appends auth tokens to tile urls', async t => {
+  const source = new I3SSource(
+    {
+      type: 'tileset',
+      url: 'https://example.com/SceneServer/layers/0',
+      loader: I3SLoader,
+      root: Promise.resolve({id: 'root-node', refine: 'ADD'}),
+      lodMetricType: 'maxScreenThresholdSQ',
+      lodMetricValue: 4,
+      nodePagesTile: {nodesInNodePages: 7},
+      store: {extent: [0, 0, 1, 1]}
+    } as any,
+    {i3s: {token: 'secret-token'}}
+  );
+
+  await source.initialize();
+
+  const metadata = source.getMetadata();
+  t.equal(metadata.tileset.root.id, 'root-node', 'promised roots are awaited during initialization');
+  t.equal(
+    source.getTileUrl('https://example.com/SceneServer/layers/0/nodes/1'),
+    'https://example.com/SceneServer/layers/0/nodes/1?token=secret-token'
+  );
+  t.equal(source.getTilesTotalCount(), 7);
+  t.end();
+});

--- a/website/src/components/home/concepts.jsx
+++ b/website/src/components/home/concepts.jsx
@@ -202,7 +202,7 @@ const sourceTabs = [
     outputCategory: 'VectorTileTables',
     outputDetail: 'Tables<ArrowTable>',
     loadingManager: 'Tileset2D',
-    deckLayers: ['MVTLayer', 'GeoJsonLayer']
+    deckLayers: ['Tile2DSourceLayer', 'MVTLayer', 'GeoJsonLayer']
   },
   {
     id: 'image-tile-source',
@@ -213,7 +213,7 @@ const sourceTabs = [
     outputCategory: 'ImageTile',
     outputDetail: 'ImageType',
     loadingManager: 'Tileset2D',
-    deckLayers: ['BitmapLayer']
+    deckLayers: ['Tile2DSourceLayer', 'BitmapLayer']
   },
   {
     id: 'image-source',
@@ -229,22 +229,24 @@ const sourceTabs = [
   {
     id: 'tile-source',
     label: '3D Tiles',
-    sources: ['COPCSource'],
+    sources: ['COPCSource', 'Tiles3DSource', 'I3SSource'],
     dataSource: 'TileDataSource',
     methods: ['getMetadata()', 'getTile()'],
     outputCategory: 'PointTile',
     outputDetail: 'Point cloud tile',
     loadingManager: 'Tileset3D',
-    deckLayers: ['PointCloudLayer']
+    deckLayers: ['Tile3DSourceLayer', 'PointCloudLayer', 'ScenegraphLayer']
   }
 ];
 
 const sourceTags = {
   COPCSource: 'Cloud Archive',
+  I3SSource: 'Tileset',
   MLTSource: 'Web Service',
   MVTSource: 'Cloud Archive',
   PMTilesSource: 'Cloud Archive',
   TableTileSource: 'Generated',
+  Tiles3DSource: 'Tileset',
   WMSSource: 'Web Service'
 };
 
@@ -345,18 +347,26 @@ const writerDocumentationLinks = {
 
 const sourceDocumentationLinks = {
   COPCSource: '/docs/modules/copc/api-reference/copc-source',
+  I3SSource: '/docs/modules/tiles/api-reference/i3s-source',
   MLTSource: '/docs/modules/mlt/api-reference/mlt-source',
   MVTSource: '/docs/modules/mvt/api-reference/mvt-source',
   PMTilesSource: '/docs/modules/pmtiles/api-reference/pmtiles-source',
   TableTileSource: '/docs/modules/mvt/api-reference/table-tile-source',
+  Tiles3DSource: '/docs/modules/tiles/api-reference/tiles-3d-source',
   WMSSource: '/docs/modules/wms/api-reference/wms-source'
+};
+
+const loadingManagerDocumentationLinks = {
+  Tileset2D: '/docs/modules/tiles/api-reference/tileset-2d',
+  Tileset3D: '/docs/modules/tiles/api-reference/tileset-3d'
 };
 
 const deckLayerDocumentationLinks = {
   BitmapLayer: 'https://deck.gl/docs/api-reference/layers/bitmap-layer',
   GeoJsonLayer: 'https://deck.gl/docs/api-reference/layers/geojson-layer',
   MVTLayer: 'https://deck.gl/docs/api-reference/geo-layers/mvt-layer',
-  PointCloudLayer: 'https://deck.gl/docs/api-reference/layers/point-cloud-layer'
+  PointCloudLayer: 'https://deck.gl/docs/api-reference/layers/point-cloud-layer',
+  ScenegraphLayer: 'https://deck.gl/docs/api-reference/mesh-layers/scenegraph-layer'
 };
 
 const streamingLoaders = ['CSVLoader', 'JSONLoader', 'GeoJSONLoader', 'ParquetLoader'];
@@ -614,7 +624,7 @@ const StageLabel = styled.p`
   font-size: 11px;
   font-weight: 800;
   line-height: 1;
-  margin: 0;
+  margin: 8px 0 -2px;
   text-align: center;
   text-transform: uppercase;
 `;
@@ -629,7 +639,7 @@ const SourceInstruction = styled.p`
   font-size: 11px;
   font-weight: 800;
   line-height: 1;
-  margin: 0;
+  margin: 6px 0 0;
   text-align: center;
   text-transform: uppercase;
 `;
@@ -770,8 +780,19 @@ const DataSourceNode = styled(CategoryNode)`
   justify-content: stretch;
 `;
 
+const CenteredDataSourceNode = styled(CategoryNode)`
+  justify-content: center;
+  text-align: center;
+`;
+
 const LabelOnlyNode = styled(CategoryNode)`
-  justify-content: flex-end;
+  justify-content: flex-start;
+`;
+
+const CenteredNodeContent = styled.div`
+  display: flex;
+  justify-content: center;
+  width: 100%;
 `;
 
 const MethodGrid = styled.div`
@@ -781,6 +802,62 @@ const MethodGrid = styled.div`
 
   @media screen and (max-width: 420px) {
     grid-template-columns: 1fr;
+  }
+`;
+
+const LayerPreviewStack = styled.div`
+  display: grid;
+  gap: 8px;
+  width: 100%;
+`;
+
+const LayerPreviewNode = styled(CompactNode)`
+  max-width: min(100%, 560px);
+  width: fit-content;
+`;
+
+const LayerPreviewParentRow = styled.div`
+  display: flex;
+  justify-content: center;
+  width: 100%;
+`;
+
+const LayerPreviewConnectorRow = styled.div`
+  display: flex;
+  justify-content: center;
+  width: 100%;
+`;
+
+const LayerPreviewChildren = styled.div`
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(2, minmax(180px, 1fr));
+  width: min(100%, 420px);
+
+  @media screen and (max-width: 520px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const LayerPreviewChildrenRow = styled.div`
+  display: flex;
+  justify-content: center;
+  width: 100%;
+`;
+
+const LayerPreviewConnector = styled.div`
+  height: 10px;
+  position: relative;
+  width: 18px;
+
+  &::before {
+    border-left: 9px solid transparent;
+    border-right: 9px solid transparent;
+    border-top: 10px solid var(--ifm-color-primary-darkest);
+    content: '';
+    display: block;
+    height: 0;
+    width: 0;
   }
 `;
 
@@ -853,7 +930,9 @@ const Connector = styled.div`
 `;
 
 const VerticalConnector = styled(Connector)`
-  min-height: 18px;
+  align-items: flex-end;
+  min-height: 28px;
+  padding-bottom: 2px;
 
   &::before {
     border: 0;
@@ -894,6 +973,11 @@ export default function Concepts() {
   const selectedCategory = categoryTabs.find((category) => category.id === selectedCategoryId);
   const selectedRepresentation = selectedCategory.representations[selectedRepresentationId];
   const selectedSourceTab = sourceTabs.find((sourceTab) => sourceTab.id === selectedSourceTabId);
+  const previewLayer =
+    selectedSourceTab.deckLayers.find((layer) => !deckLayerDocumentationLinks[layer]) || null;
+  const renderedDeckLayers = previewLayer
+    ? selectedSourceTab.deckLayers.filter((layer) => layer !== previewLayer)
+    : selectedSourceTab.deckLayers;
 
   return (
     <ConceptsSection>
@@ -1065,12 +1149,14 @@ export default function Concepts() {
                   </SourceBox>
                 </SourceStage>
                 <VerticalConnector $label="Create a Data Source" />
-                <DataSourceNode $background="rgba(53, 173, 107, 0.12)" $border="rgba(53, 173, 107, 0.55)">
+                <CenteredDataSourceNode
+                  $background="rgba(53, 173, 107, 0.12)"
+                  $border="rgba(53, 173, 107, 0.55)"
+                >
                   <span>createDataSource()</span>
-                  <TinyLabel>{selectedSourceTab.dataSource}</TinyLabel>
-                </DataSourceNode>
+                </CenteredDataSourceNode>
                 <VerticalConnector $label="Incrementally Load Data" />
-                <DataSourceNode $background="rgba(0, 173, 230, 0.1)" $border="rgba(0, 173, 230, 0.45)">
+                <DataSourceNode $background="rgba(53, 173, 107, 0.1)" $border="rgba(53, 173, 107, 0.45)">
                   {selectedSourceTab.dataSource}
                   <MethodGrid>
                     {selectedSourceTab.methods.map((method) => (
@@ -1078,25 +1164,62 @@ export default function Concepts() {
                     ))}
                   </MethodGrid>
                 </DataSourceNode>
+                <StageLabel>Manage loading</StageLabel>
+                <CategoryNode $background="rgba(255, 196, 57, 0.2)" $border="rgba(184, 122, 0, 0.42)">
+                  <CenteredNodeContent>
+                    {loadingManagerDocumentationLinks[selectedSourceTab.loadingManager] ? (
+                      <LinkedCompactNode href={loadingManagerDocumentationLinks[selectedSourceTab.loadingManager]}>
+                        <span>{selectedSourceTab.loadingManager}</span>
+                        <LinkMark aria-hidden="true">↗</LinkMark>
+                      </LinkedCompactNode>
+                    ) : (
+                      selectedSourceTab.loadingManager
+                    )}
+                  </CenteredNodeContent>
+                </CategoryNode>
                 <StageLabel>Loaded data</StageLabel>
                 <CategoryNode $background="rgba(0, 173, 230, 0.1)" $border="rgba(0, 173, 230, 0.45)">
                   <span>{selectedSourceTab.outputCategory}</span>
                   <TinyLabel>{selectedSourceTab.outputDetail}</TinyLabel>
                 </CategoryNode>
-                <StageLabel>Manage loading</StageLabel>
-                <CategoryNode $background="rgba(255, 196, 57, 0.2)" $border="rgba(184, 122, 0, 0.42)">
-                  {selectedSourceTab.loadingManager}
-                </CategoryNode>
                 <StageLabel>Render with deck.gl (optional)</StageLabel>
-                <CategoryNode $background="rgba(255, 196, 57, 0.16)" $border="rgba(184, 122, 0, 0.36)">
-                  <MethodGrid>
-                    {selectedSourceTab.deckLayers.map((layer) => (
-                      <LinkedCompactNode key={layer} href={deckLayerDocumentationLinks[layer]}>
-                        <span>{layer}</span>
-                        <LinkMark aria-hidden="true">↗</LinkMark>
-                      </LinkedCompactNode>
-                    ))}
-                  </MethodGrid>
+                <CategoryNode $background="rgba(0, 173, 230, 0.08)" $border="rgba(0, 173, 230, 0.32)">
+                  <CenteredNodeContent>
+                    {previewLayer ? (
+                      <LayerPreviewStack>
+                        <LayerPreviewParentRow>
+                          <LayerPreviewNode>
+                            <span>{previewLayer}</span>
+                            <NodeMeta>
+                              <SourceTag>Preview</SourceTag>
+                            </NodeMeta>
+                          </LayerPreviewNode>
+                        </LayerPreviewParentRow>
+                        <LayerPreviewConnectorRow>
+                          <LayerPreviewConnector />
+                        </LayerPreviewConnectorRow>
+                        <LayerPreviewChildrenRow>
+                          <LayerPreviewChildren>
+                            {renderedDeckLayers.map((layer) => (
+                              <LinkedCompactNode key={layer} href={deckLayerDocumentationLinks[layer]}>
+                                <span>{layer}</span>
+                                <LinkMark aria-hidden="true">↗</LinkMark>
+                              </LinkedCompactNode>
+                            ))}
+                          </LayerPreviewChildren>
+                        </LayerPreviewChildrenRow>
+                      </LayerPreviewStack>
+                    ) : (
+                      <MethodGrid>
+                        {renderedDeckLayers.map((layer) => (
+                          <LinkedCompactNode key={layer} href={deckLayerDocumentationLinks[layer]}>
+                            <span>{layer}</span>
+                            <LinkMark aria-hidden="true">↗</LinkMark>
+                          </LinkedCompactNode>
+                        ))}
+                      </MethodGrid>
+                    )}
+                  </CenteredNodeContent>
                 </CategoryNode>
               </SourceFlow>
             </Diagram>
@@ -1139,7 +1262,7 @@ export default function Concepts() {
                   </Stack>
                   <VerticalConnector $label="returns" />
                   <LabelOnlyNode $background="rgba(181, 79, 73, 0.1)" $border="rgba(181, 79, 73, 0.5)">
-                    <TinyLabel>Return</TinyLabel>
+                    <span>glTF data</span>
                   </LabelOnlyNode>
                 </CompactFlow>
                 <Note $color="#B54F49">

--- a/website/src/examples/home-demo.jsx
+++ b/website/src/examples/home-demo.jsx
@@ -6,7 +6,7 @@ import 'maplibre-gl/dist/maplibre-gl.css';
 
 import DeckGL from '@deck.gl/react';
 
-import {Tile3DLayer} from '@deck.gl/geo-layers';
+import {Tile3DSourceLayer} from '@loaders.gl/deck-layers';
 import {COORDINATE_SYSTEM, I3SLoader} from '@loaders.gl/i3s';
 
 const INITIAL_VIEW_STATE = {
@@ -22,7 +22,7 @@ export default function App() {
 
   function renderLayers() {
     const loadOptions = {i3s: {coordinateSystem: COORDINATE_SYSTEM.LNGLAT_OFFSETS}};
-    const layers = new Tile3DLayer({
+    const layers = new Tile3DSourceLayer({
       data: 'https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/SanFrancisco_Bldgs/SceneServer/layers/0',
       loader: I3SLoader,
       loadOptions


### PR DESCRIPTION
## Goals
- Add `Tileset2D`.
- Keep the 2D source-backed deck.gl integration and homepage concepts aligned with the final naming.
- Update docs, examples, tests, and file names to match the `Tileset2D` API.

## Changes
- Renamed the public `@loaders.gl/tiles` 2D shared tileset API:
  - `SharedTileset2D` → `Tileset2D`
  - `SharedTileset2DProps` → `Tileset2DProps`
  - `SharedTileset2DAdapter` → `Tileset2DAdapter`
  - `SharedTileset2DTileContext` → `Tileset2DTileContext`
  - `SharedTileset2DTraversalContext` → `Tileset2DTraversalContext`
- Updated the 2D tileset implementation and exports to use the new `Tileset2D` naming throughout the module.
- Updated `Tile2DSourceLayer` and the deck-facing shared-tile view/adapter code to consume `Tileset2D`.
- Renamed the 2D tileset API reference doc file:
  - `docs/modules/tiles/api-reference/shared-tileset-2d.md` → `docs/modules/tiles/api-reference/tileset-2d.md`
- Renamed the 2D tileset test file:
  - `modules/tiles/test/tileset/shared-tileset-2d.spec.ts` → `modules/tiles/test/tileset/tileset-2d.spec.ts`
- Updated user-facing docs and README content to refer to `Tileset2D` instead of `SharedTileset2D`.
- Updated the homepage concepts flow to:
  - show `Tileset2D` as the 2D loading manager
  - include `Tiles3DSource` and `I3SSource` in the 3D Tiles source tab
  - include `ScenegraphLayer` in the 3D Tiles render row
  - improve render-row layout and stage spacing
  - reorder the source flow so `Manage loading` appears before `Loaded data`
  - simplify and normalize concept-flow coloring

## Verification
- `yarn build`
- `cd website && yarn build`

## Notes
- `yarn lint fix` hit an existing Biome/configuration issue while scanning a missing `modules/polyfills/dist` path, so formatting could not be completed in this pass.