### PR TITLE
feat: new VectorSource

### DIFF
--- a/examples/website/wms/app.tsx
+++ b/examples/website/wms/app.tsx
@@ -4,15 +4,18 @@
 
 import React, {useState} from 'react';
 import {createRoot} from 'react-dom/client';
-// import {StaticMap} from 'react-map-gl';
 
 import DeckGL from '@deck.gl/react';
-import {MapView, MapController} from '@deck.gl/core';
-import {_WMSLayer as WMSLayer} from '@deck.gl/geo-layers';
+import {MapController} from '@deck.gl/core';
 
-import type {ImageSource, ImageSourceMetadata} from '@loaders.gl/loader-utils';
+import {ImageSourceLayer, VectorSourceLayer} from '@loaders.gl/deck-layers';
 import {createDataSource} from '@loaders.gl/core';
-import {_ArcGISImageServerSource, WMSSource} from '@loaders.gl/wms';
+import {
+  _ArcGISFeatureServerSource,
+  _ArcGISImageServerSource,
+  WFSSource,
+  WMSSource
+} from '@loaders.gl/wms';
 
 import {Map} from 'react-map-gl';
 import maplibregl from 'maplibre-gl';
@@ -49,61 +52,60 @@ type AppProps = {
   children?: React.Children;
 };
 
+const SOURCE_FACTORIES = [
+  WMSSource,
+  _ArcGISImageServerSource,
+  _ArcGISFeatureServerSource,
+  WFSSource
+];
+
+type SourceData = any;
+
 /** Application state */
 type AppState = {
-  /** Currently active tile source */
-  imageSource: ImageSource;
-  /** Metadata loaded from active tile source */
+  /** Currently selected example. */
+  example: Example | null;
+  /** Currently active source instance. */
+  source: SourceData | null;
+  /** Metadata loaded from the active source. */
   metadata: string;
-  /**Current view state */
+  /** Current view state. */
   viewState: Record<string, number>;
   loading: boolean;
   error: string | null;
-  featureInfo: any;
-  example: Example;
 };
 
 export default function App(props: AppProps = {}) {
   const [state, setState] = useState<AppState>({
-    imageSource: null,
+    example: null,
+    source: null,
     metadata: '',
     viewState: INITIAL_VIEW_STATE,
-    // TODO - handle errors
     loading: true,
-    error: null
+    error: null,
   });
 
-  const {imageSource, metadata} = state;
-  const wmsLayer = renderLayer(state.example);
+  const layers = renderLayer(state.example, state.source);
 
   return (
     <div style={{position: 'relative', height: '100%'}}>
       <DeckGL
-        layers={wmsLayer}
+        layers={layers}
         viewState={state.viewState}
         onViewStateChange={onViewStateChange}
         onError={(error: Error) => setState((state) => ({...state, error: error.message}))}
+        getTooltip={getTooltip}
         controller={{type: MapController, maxPitch: 85}}
-        getTooltip={({object}) =>
-          state?.featureInfo && {
-            html: `<h2>Feature Info</h2><div>${state.featureInfo}</div>`,
-            style: {
-              color: '#EEE',
-              backgroundColor: '#000',
-              fontSize: '0.8em',
-              whiteSpace: 'pre-line'
-            }
-          }
-        }
       >
         <ExamplePanel
           examples={EXAMPLES}
+          format={props.format}
           initialCategoryName={INITIAL_CATEGORY_NAME}
           initialExampleName={INITIAL_EXAMPLE_NAME}
           onExampleChange={onExampleChange}
           loading={state.loading}
         >
-          <MetadataViewer metadata={metadata} />
+          <MetadataViewer metadata={state.metadata} />
           {state.error ? <div style={{color: 'red'}}>{state.error}</div> : ''}
           <LngLatZoomView viewState={state.viewState} />
         </ExamplePanel>
@@ -113,61 +115,104 @@ export default function App(props: AppProps = {}) {
   );
 
   function onViewStateChange({viewState}) {
-    setState((state) => ({...state, viewState}));
+    setState((state) => ({
+      ...state,
+      viewState
+    }));
   }
 
-  function onExampleChange({example}) {
-    const {viewState} = example;
-    const newViewState = {...state.viewState, ...viewState};
-
-    const imageSource = createDataSource<ImageSource>(
-      example.url,
-      [WMSSource, _ArcGISImageServerSource],
-      {type: 'wms'}
-    );
-
-    setState((state) => ({...state, example, viewState: newViewState, imageSource}));
-  }
-
-  function renderLayer(example: Example) {
-    if (!example) {
+  function getTooltip({object}) {
+    if (!object || !object.properties) {
       return null;
     }
 
-    // @ts-expect-error
-    const {url, type, layers, opacity = 1} = example;
+    const entries = Object.entries(object.properties).filter(
+      ([, value]) => value !== null && value !== ''
+    );
+    if (!entries.length) {
+      return null;
+    }
+
+    return {
+      text: entries
+        .slice(0, 5)
+        .map(([key, value]) => `${formatLabel(key)}: ${String(value)}`)
+        .join('\n')
+    };
+  }
+
+  async function onExampleChange({example}) {
+    const {viewState} = example;
+    const newViewState = {...state.viewState, ...viewState};
+    const source = createDataSource(example.url, SOURCE_FACTORIES, {
+      type: example.type
+    });
+
+    setState((state) => ({
+      ...state,
+      example,
+      source,
+      viewState: newViewState,
+      metadata: 'Loading metadata...',
+      loading: true,
+      error: null
+    }));
+
+    try {
+      const metadata = await source.getMetadata({formatSpecificMetadata: false});
+      const title = metadata?.title || metadata?.name || example.url;
+      globalThis.document.title = String(title);
+      setState((state) => ({
+        ...state,
+        metadata: JSON.stringify(metadata, null, 2)
+      }));
+    } catch (error) {
+      setState((state) => ({
+        ...state,
+        metadata: '',
+        error: `Could not load metadata: ${error instanceof Error ? error.message : String(error)}`
+      }));
+    }
+  }
+
+  function renderLayer(example: Example | null, source: SourceData | null) {
+    if (!example || !source) {
+      return null;
+    }
+
+    if (example.type === 'arcgis-feature-server' || example.type === 'wfs') {
+      return [
+        new VectorSourceLayer({
+          id: `${example.type}-${example.url}`,
+          data: source,
+          layers: example.layers || [],
+          onLoadingStateChange: isLoading =>
+            setState((state) => ({...state, loading: isLoading})),
+          onError: (error: Error) =>
+            setState((state) => ({...state, loading: false, error: error.message})),
+          geoJsonLayerProps: {
+            pickable: true,
+            autoHighlight: true,
+            ...example.layerProps
+          }
+        })
+      ];
+    }
 
     return [
-      new WMSLayer({
-        data: url, // new WMSSource({url: service, wmsParameters: {transparent: true}}),
-        serviceType: type,
-        layers,
-
-        pickable: true,
-        opacity,
-
-        onImageLoadStart: () => setState((state) => ({...state, loading: true})),
-        onImageLoad: () => setState((state) => ({...state, loading: false})),
-
-        onMetadataLoadStart: () =>
-          setState((state) => ({...state, metadata: 'Loading metadata...'})),
-        onMetadataLoad: (metadata: ImageSourceMetadata) => {
-          globalThis.document.title = metadata.title || 'WMS';
-          setState((state) => ({...state, metadata: JSON.stringify(metadata, null, 2)}));
-        },
-
-        // @ts-expect-error
-        onClick: async ({bitmap, layer}) => {
-          if (this.state.featureInfo) {
-            setState((state) => ({...state, featureInfo: null}));
-          } else if (bitmap) {
-            const x = bitmap.pixel[0];
-            const y = bitmap.pixel[1];
-            const featureInfo = await layer.getFeatureInfoText(x, y);
-            console.log('Click in imagery layer', x, y, featureInfo);
-            setState((state) => ({...state, featureInfo}));
-          }
-        }
+      new ImageSourceLayer({
+        id: `${example.type}-${example.url}`,
+        data: source,
+        layers: example.layers || [],
+        srs:
+          example.type === 'wms' || example.type === 'arcgis-image-server'
+            ? 'EPSG:4326'
+            : 'auto',
+        onLoadingStateChange: isLoading =>
+          setState((state) => ({...state, loading: isLoading})),
+        onImageLoadError: (_requestId: number, error: Error) =>
+          setState((state) => ({...state, loading: false, error: error.message})),
+        ...example.layerProps
       })
     ];
   }
@@ -188,6 +233,12 @@ function LngLatZoomView({viewState}) {
 
 export function renderToDOM(container = document.body) {
   createRoot(container).render(<App />);
+}
+
+function formatLabel(value: string): string {
+  return value
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (character) => character.toUpperCase());
 }
 
 /*

--- a/examples/website/wms/components/example-panel.tsx
+++ b/examples/website/wms/components/example-panel.tsx
@@ -41,12 +41,35 @@ const DropDown = styled.select`
   margin-bottom: 6px;
 `;
 
+const LoadingIndicator = styled.div`
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  margin: 0 0 8px;
+`;
+
+const Spinner = styled.div`
+  animation: spin 0.8s linear infinite;
+  border: 2px solid rgba(0, 0, 0, 0.15);
+  border-radius: 50%;
+  border-top-color: #121212;
+  height: 14px;
+  width: 14px;
+
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+`;
+
 export type Example = {
-  sourceType: 'mvt' | 'pmtiles' | 'table';
-  data: string;
-  attributions?: string[];
-  viewState?: Record<string, unknown>;
-  tileSize?: number[];
+  type: 'wms' | 'arcgis-image-server' | 'arcgis-feature-server' | 'wfs';
+  url: string;
+  description?: string;
+  layers?: string[];
+  viewState?: Record<string, number>;
+  layerProps?: Record<string, unknown>;
 };
 
 export type ExamplePanelProps = React.PropsWithChildren<{
@@ -54,6 +77,7 @@ export type ExamplePanelProps = React.PropsWithChildren<{
   examples: Record<string, Record<string, Example>>;
   /** format of examples to show (filters out other formats if supplied) */
   format?: string;
+  loading?: boolean;
   initialCategoryName?: string | null;
   initialExampleName?: string | null;
   onExampleChange: OnExampleChange;
@@ -139,6 +163,12 @@ export const ExamplePanel: React.FC<ExamplePanelProps> = (props: ExamplePanelPro
           setState((state) => ({...state, categoryName, exampleName, example}));
         }}
       />
+      {props.loading ? (
+        <LoadingIndicator>
+          <Spinner />
+          <span>Loading…</span>
+        </LoadingIndicator>
+      ) : null}
       {props.children}
     </Container>
   );
@@ -183,10 +213,12 @@ const ExampleHeader: React.FC = ({categoryName, exampleName}) => {
     return null;
   }
 
+  const showCategoryName = !exampleName.includes(categoryName);
+
   return (
     <div>
       <h3>
-        {exampleName} <b>{categoryName}</b>{' '}
+        {exampleName} {showCategoryName ? <b>{categoryName}</b> : null}{' '}
       </h3>
     </div>
   );

--- a/examples/website/wms/examples.ts
+++ b/examples/website/wms/examples.ts
@@ -77,21 +77,54 @@ export const EXAMPLES: Record<string, Record<string, Example>> = {
       viewState: {longitude: -100, latitude: 55, zoom: 3}
     },
   },
-  /*
-  ImageServer: {
-    NLCDLandCover2001: {
-      url: 'https://sampleserver6.arcgisonline.com/arcgis/rest/services/NLCDLandCover2001/ImageServer/exportImage?bbox={east},{north},{west},{south}&bboxSR=4326&size={width},{height}&imageSR=102100&time=&format=jpgpng&pixelType=U8&noData=&noDataInterpretation=esriNoDataMatchAny&interpolation=+RSP_NearestNeighbor&compression=&compressionQuality=&bandIds=&mosaicRule=&renderingRule=&f=image',
-      type: 'template',
-      viewState: {...VIEW_STATE}
+  'ArcGIS Image Server': {
+    'NLCD Land Cover 2001': {
+      type: 'arcgis-image-server',
+      url: 'https://sampleserver6.arcgisonline.com/arcgis/rest/services/NLCDLandCover2001/ImageServer',
+      description: 'ArcGIS sample imagery service rendered through loaders.gl ImageSourceLayer.',
+      viewState: {longitude: -96, latitude: 38.5, zoom: 4},
+      layerProps: {
+        opacity: 0.75
+      }
     },
-    ArcGISSampleImageryLayer: {
-      url: 'https://developers.arcgis.com/javascript/latest/sample-code/layers-imagerylayer/',
-      viewState: {...VIEW_STATE}
-    },
-    ArcGISExportedImage: {
-      url: 'https://developers.arcgis.com/rest/services-reference/enterprise/export-image.htm',
-      viewState: {...VIEW_STATE}
+  },
+  'ArcGIS Feature Server': {
+    'Kentucky Bicycle Routes FeatureServer': {
+      type: 'arcgis-feature-server',
+      url: 'https://services2.arcgis.com/CcI36Pduqd0OR4W9/ArcGIS/rest/services/Bicycle_Routes_Public/FeatureServer/0',
+      description: 'ArcGIS FeatureServer viewport queries rendered through loaders.gl VectorSourceLayer.',
+      layers: ['0'],
+      viewState: {longitude: -85.75, latitude: 37.75, zoom: 6},
+      layerProps: {
+        pickable: true,
+        stroked: true,
+        filled: false,
+        lineWidthMinPixels: 4,
+        lineWidthMaxPixels: 8,
+        getLineColor: [0, 80, 255, 220]
+      }
+    }
+  },
+  WFS: {
+    'Redon Reuse Sites': {
+      type: 'wfs',
+      url: 'https://geobretagne.fr/geoserver/ows',
+      description: 'GeoServer WFS features queried by viewport and rendered through loaders.gl VectorSourceLayer.',
+      layers: ['caredon:acteur_reemploi_redon_agglo'],
+      viewState: {longitude: -2.2, latitude: 47.65, zoom: 9},
+      layerProps: {
+        pickable: true,
+        pointType: 'circle',
+        stroked: true,
+        filled: true,
+        pointRadiusMinPixels: 14,
+        pointRadiusMaxPixels: 22,
+        getPointRadius: 10,
+        lineWidthMinPixels: 3,
+        lineWidthMaxPixels: 6,
+        getLineColor: [255, 255, 255, 255],
+        getFillColor: [220, 30, 30, 230]
+      }
     }
   }
-  */
 };

--- a/modules/deck-layers/src/image-source-layer.ts
+++ b/modules/deck-layers/src/image-source-layer.ts
@@ -36,6 +36,8 @@ export type ImageSourceLayerProps = CompositeLayerProps & {
   layers?: string[];
   /** Output CRS for the requested image. */
   srs?: 'EPSG:4326' | 'EPSG:3857' | 'auto';
+  /** Debounce interval applied before viewport image requests are issued. */
+  debounceTime?: number;
   /** Source factories used to auto-create image sources from URL/blob inputs. */
   sources?: Readonly<Source[]>;
   /** Options forwarded to `createDataSource` when `sources` are supplied. */
@@ -50,6 +52,8 @@ export type ImageSourceLayerProps = CompositeLayerProps & {
   onImageLoad?: (requestId: number) => void;
   /** Called when an image request fails. */
   onImageLoadError?: (requestId: number, error: Error) => void;
+  /** Called when metadata/image loading starts or stops. */
+  onLoadingStateChange?: (isLoading: boolean) => void;
 };
 
 type ImageSourceLayerState = {
@@ -63,6 +67,7 @@ const defaultProps: DefaultProps<ImageSourceLayerProps> = {
   data: '',
   serviceType: 'auto',
   srs: 'auto',
+  debounceTime: 200,
   layers: {type: 'array', compare: true, value: []},
   sources: {type: 'array', compare: false, value: []},
   sourceOptions: {type: 'object', compare: false, value: {}},
@@ -81,7 +86,8 @@ const defaultProps: DefaultProps<ImageSourceLayerProps> = {
       // eslint-disable-next-line no-console
       console.error(error, requestId);
     }
-  }
+  },
+  onLoadingStateChange: {type: 'function', value: () => {}}
 };
 
 /**
@@ -153,7 +159,8 @@ export class ImageSourceLayer extends CompositeLayer<ImageSourceLayerProps> {
       return;
     }
 
-    if (!deepEqual(props.layers, oldProps.layers, 1)) {
+    if (!deepEqual(props.layers, oldProps.layers, 1) || props.debounceTime !== oldProps.debounceTime) {
+      this.state.imageSet.setOptions({imageSource: this.state.resolvedData, debounceTime: props.debounceTime});
       this.loadImage(this.context.viewport, 0);
     } else if (changeFlags.viewportChanged) {
       this.loadImage(this.context.viewport);
@@ -268,7 +275,9 @@ export class ImageSourceLayer extends CompositeLayer<ImageSourceLayerProps> {
       this._releaseImageSet();
 
       const imageSet = ImageSet.fromImageSource(imageSource);
+      imageSet.setOptions({imageSource, debounceTime: this.props.debounceTime});
       const unsubscribeImageSetEvents = imageSet.subscribe({
+        onLoadingStateChange: isLoading => this.props.onLoadingStateChange?.(isLoading),
         onMetadataLoad: metadata => this.props.onMetadataLoad?.(metadata),
         onMetadataLoadError: error => this.props.onMetadataLoadError?.(error),
         onImageLoadStart: requestId => this.props.onImageLoadStart?.(requestId),

--- a/modules/deck-layers/src/index.ts
+++ b/modules/deck-layers/src/index.ts
@@ -10,6 +10,8 @@ export type {SourceLayerProps} from './source-layer';
 export {SourceLayer} from './source-layer';
 export type {ImageSourceLayerProps} from './image-source-layer';
 export {ImageSourceLayer} from './image-source-layer';
+export type {VectorSourceLayerProps} from './vector-source-layer';
+export {VectorSourceLayer} from './vector-source-layer';
 export type {Tile3DSourceLayerProps} from './tile-3d-source-layer';
 export {Tile3DSourceLayer} from './tile-3d-source-layer';
 export {SourceDataDrivenTile3DLayer} from './data-driven-tile-3d-source-layer';

--- a/modules/deck-layers/src/vector-source-layer.ts
+++ b/modules/deck-layers/src/vector-source-layer.ts
@@ -1,0 +1,214 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {
+  CompositeLayer,
+  type CompositeLayerProps,
+  type DefaultProps,
+  type Layer,
+  type UpdateParameters,
+  _deepEqual as deepEqual
+} from '@deck.gl/core';
+import type {GeoJsonLayerProps} from '@deck.gl/layers';
+import {GeoJsonLayer} from '@deck.gl/layers';
+import type {BinaryFeatureCollection, GeoJSONTable} from '@loaders.gl/schema';
+import type {VectorSource} from '@loaders.gl/loader-utils';
+import {VectorSet} from './vector-source-layer/vector-set';
+
+/** Props for {@link VectorSourceLayer}. */
+export type VectorSourceLayerProps = CompositeLayerProps & {
+  /** Fully constructed loaders.gl vector source. */
+  data: VectorSource;
+  /** Named source layers forwarded to `VectorSource#getFeatures`. */
+  layers: string | string[];
+  /** Output CRS forwarded to `VectorSource#getFeatures`. */
+  crs?: string;
+  /** Debounce interval applied before viewport requests are issued. */
+  debounceTime?: number;
+  /** Called when the current viewport request resolves successfully. */
+  onDataLoad?: (table: GeoJSONTable | BinaryFeatureCollection) => void;
+  /** Called when metadata or viewport requests fail. */
+  onError?: (error: Error) => void;
+  /** Called when metadata/viewport loading starts or stops. */
+  onLoadingStateChange?: (isLoading: boolean) => void;
+  /** Optional props forwarded into the default `GeoJsonLayer`. */
+  geoJsonLayerProps?: Partial<GeoJsonLayerProps>;
+};
+
+type VectorSourceLayerState = {
+  vectorSet: VectorSet | null;
+  unsubscribeVectorSetEvents: (() => void) | null;
+};
+
+const defaultProps: DefaultProps<VectorSourceLayerProps> = {
+  id: 'vector-source-layer',
+  crs: 'EPSG:4326',
+  debounceTime: 200,
+  geoJsonLayerProps: {type: 'object', compare: false, value: {}},
+  onDataLoad: {type: 'function', value: () => {}},
+  onError: {
+    type: 'function',
+    compare: false,
+    value: (error: Error) => {
+      // eslint-disable-next-line no-console
+      console.error(error);
+    }
+  },
+  onLoadingStateChange: {type: 'function', value: () => {}}
+};
+
+/**
+ * Internal deck.gl layer that renders a source-backed vector table for the active viewport.
+ *
+ * This class is exported for internal repository use and examples, and is not documented
+ * beyond these TSDoc comments.
+ */
+export class VectorSourceLayer extends CompositeLayer<VectorSourceLayerProps> {
+  /** deck.gl layer name used in debugging output. */
+  static layerName = 'VectorSourceLayer';
+
+  /** Default props shared across source-backed vector layers. */
+  static defaultProps: DefaultProps = defaultProps;
+
+  /** Typed deck.gl state for the owned vector runtime. */
+  state = null as unknown as VectorSourceLayerState;
+
+  /** Returns true when the current vector runtime has accepted data. */
+  get isLoaded(): boolean {
+    return Boolean(this.state?.vectorSet?.isLoaded) && super.isLoaded;
+  }
+
+  /** Lets deck.gl know that viewport changes should trigger updates. */
+  shouldUpdateState(): boolean {
+    return true;
+  }
+
+  /** Initializes state on first render. */
+  initializeState(): void {
+    this.state = {
+      vectorSet: null,
+      unsubscribeVectorSetEvents: null
+    };
+  }
+
+  /** Finalizes subscriptions and owned vector state. */
+  finalizeState(): void {
+    this._releaseVectorSet();
+  }
+
+  /** Keeps the owned vector runtime in sync with the current source props and viewport. */
+  updateState({changeFlags, props, oldProps}: UpdateParameters<this>): void {
+    const dataChanged = changeFlags.dataChanged;
+
+    if (dataChanged) {
+      const vectorSet = this._getOrCreateVectorSet(props.data, true);
+      vectorSet.setOptions(this._getVectorSetOptions(props));
+      void vectorSet.loadMetadata().catch(() => {});
+      void this._updateViewport();
+      return;
+    }
+
+    if (!this.state.vectorSet) {
+      return;
+    }
+
+    if (!deepEqual(props.layers, oldProps.layers, 1) || props.crs !== oldProps.crs) {
+      this.state.vectorSet.setOptions(this._getVectorSetOptions(props));
+      void this._updateViewport();
+      return;
+    }
+
+    if (props.debounceTime !== oldProps.debounceTime) {
+      this.state.vectorSet.setOptions(this._getVectorSetOptions(props));
+      void this._updateViewport();
+      return;
+    }
+
+    if (changeFlags.viewportChanged) {
+      void this._updateViewport();
+    }
+  }
+
+  /** Renders the current accepted vector table through `GeoJsonLayer`. */
+  renderLayers(): Layer | null {
+    const table = this.state.vectorSet?.data;
+    if (!table) {
+      return null;
+    }
+
+    const geoJsonData = isGeoJSONTable(table)
+      ? {
+          type: table.type,
+          features: table.features
+        }
+      : table;
+
+    return new GeoJsonLayer({
+      ...this.getSubLayerProps({id: 'geojson'}),
+      ...this.props.geoJsonLayerProps,
+      data: geoJsonData
+    }) as unknown as Layer;
+  }
+
+  /** Creates or reuses the shared vector runtime for the current source. */
+  private _getOrCreateVectorSet(vectorSource: VectorSource, sourceChanged: boolean): VectorSet {
+    if (!this.state.vectorSet || sourceChanged) {
+      this._releaseVectorSet();
+
+      const vectorSet = VectorSet.fromVectorSource(vectorSource, {
+        layers: this.props.layers,
+        crs: this.props.crs,
+        debounceTime: this.props.debounceTime
+      });
+      const unsubscribeVectorSetEvents = vectorSet.subscribe({
+        onLoadingStateChange: isLoading => this.props.onLoadingStateChange?.(isLoading),
+        onUpdate: () => this.setNeedsUpdate(),
+        onDataLoad: table => this.props.onDataLoad?.(table),
+        onError: error => this.props.onError?.(error)
+      });
+
+      this.setState({vectorSet, unsubscribeVectorSetEvents});
+      return vectorSet;
+    }
+
+    return this.state.vectorSet;
+  }
+
+  /** Tears down subscriptions and owned vector runtime state. */
+  private _releaseVectorSet(): void {
+    this.state?.unsubscribeVectorSetEvents?.();
+    this.state?.vectorSet?.finalize();
+    this.setState?.({
+      vectorSet: null,
+      unsubscribeVectorSetEvents: null
+    });
+  }
+
+  /** Builds runtime options from the current layer props. */
+  private _getVectorSetOptions(props: VectorSourceLayerProps) {
+    return {
+      vectorSource: props.data,
+      layers: props.layers,
+      crs: props.crs,
+      debounceTime: props.debounceTime
+    };
+  }
+
+  /** Requests the current viewport table when a viewport is available. */
+  private async _updateViewport(): Promise<void> {
+    const viewport = this.context.viewport;
+    const vectorSet = this.state.vectorSet;
+    if (!viewport || !vectorSet) {
+      return;
+    }
+
+    await vectorSet.updateViewport(viewport);
+  }
+}
+
+function isGeoJSONTable(
+  data: GeoJSONTable | BinaryFeatureCollection
+): data is GeoJSONTable {
+  return (data as GeoJSONTable).shape === 'geojson-table';
+}

--- a/modules/deck-layers/src/vector-source-layer/vector-set.ts
+++ b/modules/deck-layers/src/vector-source-layer/vector-set.ts
@@ -1,0 +1,367 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Viewport} from '@deck.gl/core';
+import type {BinaryFeatureCollection, GeoJSONTable, Schema} from '@loaders.gl/schema';
+import type {GetFeaturesParameters, VectorSource, VectorSourceMetadata} from '@loaders.gl/loader-utils';
+
+/** Mutable fetch options consumed by {@link VectorSet}. */
+export type VectorSetOptions = {
+  /** Source used to resolve viewport feature requests. */
+  vectorSource: VectorSource;
+  /** Named source layers included in each request. */
+  layers: string | string[];
+  /** Output CRS forwarded to the vector source. */
+  crs?: string;
+  /** Debounce interval applied before issuing viewport requests. */
+  debounceTime?: number;
+};
+
+/** Readable snapshot of the current vector-set state. */
+export type VectorSetState = {
+  /** True after metadata/schema resolve successfully and a current table is available. */
+  isLoaded: boolean;
+  /** True while the latest viewport request is in flight. */
+  isLoading: boolean;
+  /** Latest accepted viewport table. */
+  data: GeoJSONTable | BinaryFeatureCollection | null;
+  /** Resolved source schema when available. */
+  schema: Schema | null;
+  /** Resolved source metadata when available. */
+  metadata: VectorSourceMetadata | null;
+  /** Latest accepted error, if any. */
+  error: Error | null;
+};
+
+/** Subscription callbacks emitted by {@link VectorSet}. */
+export type VectorSetEvents = {
+  /** Called when metadata/viewport loading starts or stops. */
+  onLoadingStateChange?: (isLoading: boolean) => void;
+  /** Called whenever any public state changes. */
+  onUpdate?: () => void;
+  /** Called when a viewport request resolves and becomes current. */
+  onDataLoad?: (table: GeoJSONTable | BinaryFeatureCollection) => void;
+  /** Called when metadata resolves. */
+  onMetadataLoad?: (metadata: VectorSourceMetadata) => void;
+  /** Called when schema resolves. */
+  onSchemaLoad?: (schema: Schema) => void;
+  /** Called when the current metadata or viewport request fails. */
+  onError?: (error: Error) => void;
+};
+
+/**
+ * Small runtime helper that keeps the latest vector table in sync with the active viewport.
+ *
+ * `VectorSet` only accepts the most recent viewport request result and ignores stale responses.
+ */
+export class VectorSet {
+  /** Current source and request options. */
+  vectorSource: VectorSource;
+  /** Layers forwarded to `VectorSource#getFeatures`. */
+  layers: string | string[];
+  /** Output CRS forwarded to `VectorSource#getFeatures`. */
+  crs?: string;
+  /** Debounce interval applied before issuing viewport requests. */
+  debounceTime: number;
+
+  /** True once the latest accepted viewport request completes successfully. */
+  isLoaded = false;
+  /** True while the latest viewport request is in flight. */
+  isLoading = false;
+  /** Latest accepted viewport table. */
+  data: GeoJSONTable | BinaryFeatureCollection | null = null;
+  /** Resolved source schema. */
+  schema: Schema | null = null;
+  /** Resolved source metadata. */
+  metadata: VectorSourceMetadata | null = null;
+  /** Latest accepted error. */
+  error: Error | null = null;
+
+  private readonly subscriptions = new Set<VectorSetEvents>();
+  private metadataPromise: Promise<void> | null = null;
+  private requestSequenceNumber = 0;
+  private lastRequestKey: string | null = null;
+  private loadCounter = 0;
+  private timeoutId: ReturnType<typeof setTimeout> | null = null;
+  private abortController: AbortController | null = null;
+
+  /** Creates a new viewport-driven vector runtime for a source. */
+  constructor(options: VectorSetOptions) {
+    this.vectorSource = options.vectorSource;
+    this.layers = options.layers;
+    this.crs = options.crs;
+    this.debounceTime = options.debounceTime ?? 200;
+  }
+
+  /** Creates a `VectorSet` from a vector source instance. */
+  static fromVectorSource(vectorSource: VectorSource, options: Omit<VectorSetOptions, 'vectorSource'>) {
+    return new VectorSet({vectorSource, ...options});
+  }
+
+  /** Returns a readable snapshot for tests and consumers. */
+  getState(): VectorSetState {
+    return {
+      isLoaded: this.isLoaded,
+      isLoading: this.isLoading,
+      data: this.data,
+      schema: this.schema,
+      metadata: this.metadata,
+      error: this.error
+    };
+  }
+
+  /** Updates the source or request options used for subsequent viewport fetches. */
+  setOptions(options: VectorSetOptions): void {
+    const sourceChanged = options.vectorSource !== this.vectorSource;
+    const layersChanged = !areLayerSelectionsEqual(options.layers, this.layers);
+    const crsChanged = options.crs !== this.crs;
+
+    this.vectorSource = options.vectorSource;
+    this.layers = options.layers;
+    this.crs = options.crs;
+    this.debounceTime = options.debounceTime ?? this.debounceTime;
+
+    if (sourceChanged) {
+      this._cancelScheduledRequest();
+      this.metadataPromise = null;
+      this.schema = null;
+      this.metadata = null;
+      this.data = null;
+      this.error = null;
+      this.isLoaded = false;
+      this.isLoading = false;
+      this.loadCounter = 0;
+      this.lastRequestKey = null;
+      this.requestSequenceNumber++;
+      this.emitUpdate();
+      return;
+    }
+
+    if (layersChanged || crsChanged) {
+      this.lastRequestKey = null;
+    }
+  }
+
+  /** Loads metadata and schema once for the current source. */
+  async loadMetadata(): Promise<void> {
+    this.metadataPromise ||= this._loadMetadata();
+    await this.metadataPromise;
+  }
+
+  /** Requests features for the supplied viewport when inputs changed. */
+  async updateViewport(viewport: Viewport): Promise<void> {
+    const requestParameters = this._getRequestParameters(viewport);
+    const requestKey = getRequestKey(requestParameters);
+
+    if (requestKey === this.lastRequestKey) {
+      return;
+    }
+
+    this._cancelScheduledRequest();
+    this._abortActiveRequest();
+
+    if (this.debounceTime > 0) {
+      await new Promise<void>(resolve => {
+        this.timeoutId = setTimeout(() => {
+          this.timeoutId = null;
+          void this._loadFeatures(requestParameters, requestKey).finally(resolve);
+        }, this.debounceTime);
+      });
+      return;
+    }
+
+    await this._loadFeatures(requestParameters, requestKey);
+  }
+
+  /** Subscribes to runtime state changes. */
+  subscribe(events: VectorSetEvents): () => void {
+    this.subscriptions.add(events);
+    return () => this.subscriptions.delete(events);
+  }
+
+  /** Releases references and cancels acceptance of any in-flight request. */
+  finalize(): void {
+    this.requestSequenceNumber++;
+    this._cancelScheduledRequest();
+    this._abortActiveRequest();
+    this.subscriptions.clear();
+  }
+
+  private async _loadMetadata(): Promise<void> {
+    this._startLoading();
+    try {
+      const [metadata, schema] = await Promise.all([
+        this.vectorSource.getMetadata({formatSpecificMetadata: false}),
+        this.vectorSource.getSchema()
+      ]);
+
+      this.metadata = metadata;
+      this.schema = schema;
+      this.emitMetadataLoad(metadata);
+      this.emitSchemaLoad(schema);
+      this.emitUpdate();
+    } catch (error) {
+      this.error = normalizeError(error);
+      this.emitError(this.error);
+      this.emitUpdate();
+      throw this.error;
+    } finally {
+      this._finishLoading();
+    }
+  }
+
+  /** Issues the actual vector source request after debounce completes. */
+  private async _loadFeatures(
+    requestParameters: GetFeaturesParameters,
+    requestKey: string
+  ): Promise<void> {
+    this.lastRequestKey = requestKey;
+    const requestSequenceNumber = ++this.requestSequenceNumber;
+
+    this._startLoading();
+    this.error = null;
+    this.emitUpdate();
+
+    try {
+      const abortController = new AbortController();
+      this.abortController = abortController;
+      const table = await this.vectorSource.getFeatures({
+        ...requestParameters,
+        signal: abortController.signal
+      });
+      if (requestSequenceNumber !== this.requestSequenceNumber) {
+        return;
+      }
+
+      this.data = table;
+      this.error = null;
+      this.isLoaded = true;
+      this.emitDataLoad(table);
+      this.emitUpdate();
+    } catch (error) {
+      if (isAbortError(error)) {
+        return;
+      }
+      if (requestSequenceNumber !== this.requestSequenceNumber) {
+        return;
+      }
+
+      this.error = normalizeError(error);
+      this.emitError(this.error);
+      this.emitUpdate();
+    } finally {
+      if (requestSequenceNumber === this.requestSequenceNumber) {
+        this._finishLoading();
+      }
+    }
+  }
+
+  /** Derives generic feature request parameters from the active deck.gl viewport. */
+  private _getRequestParameters(viewport: Viewport): GetFeaturesParameters {
+    const bounds = viewport.getBounds();
+
+    return {
+      layers: this.layers,
+      boundingBox: [
+        [bounds[0], bounds[1]],
+        [bounds[2], bounds[3]]
+      ],
+      crs: this.crs
+    };
+  }
+
+  private emitUpdate(): void {
+    for (const subscription of this.subscriptions) {
+      subscription.onUpdate?.();
+    }
+  }
+
+  private emitLoadingStateChange(isLoading: boolean): void {
+    for (const subscription of this.subscriptions) {
+      subscription.onLoadingStateChange?.(isLoading);
+    }
+  }
+
+  private emitDataLoad(table: GeoJSONTable | BinaryFeatureCollection): void {
+    for (const subscription of this.subscriptions) {
+      subscription.onDataLoad?.(table);
+    }
+  }
+
+  private emitMetadataLoad(metadata: VectorSourceMetadata): void {
+    for (const subscription of this.subscriptions) {
+      subscription.onMetadataLoad?.(metadata);
+    }
+  }
+
+  private emitSchemaLoad(schema: Schema): void {
+    for (const subscription of this.subscriptions) {
+      subscription.onSchemaLoad?.(schema);
+    }
+  }
+
+  private emitError(error: Error): void {
+    for (const subscription of this.subscriptions) {
+      subscription.onError?.(error);
+    }
+  }
+
+  /** Increments the active load count and emits loading-state transitions. */
+  private _startLoading(): void {
+    const wasLoading = this.loadCounter > 0;
+    this.loadCounter++;
+    this.isLoading = true;
+    if (!wasLoading) {
+      this.emitLoadingStateChange(true);
+      this.emitUpdate();
+    }
+  }
+
+  /** Decrements the active load count and emits loading-state transitions. */
+  private _finishLoading(): void {
+    const wasLoading = this.loadCounter > 0;
+    this.loadCounter = Math.max(0, this.loadCounter - 1);
+    this.isLoading = this.loadCounter > 0;
+    if (wasLoading && !this.isLoading) {
+      this.emitLoadingStateChange(false);
+      this.emitUpdate();
+    }
+  }
+
+  /** Clears any pending debounced viewport request before it hits the network. */
+  private _cancelScheduledRequest(): void {
+    if (this.timeoutId !== null) {
+      clearTimeout(this.timeoutId);
+      this.timeoutId = null;
+    }
+  }
+
+  /** Aborts the current in-flight vector request, if any. */
+  private _abortActiveRequest(): void {
+    this.abortController?.abort();
+    this.abortController = null;
+  }
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}
+
+function getRequestKey(parameters: GetFeaturesParameters): string {
+  const layers = Array.isArray(parameters.layers) ? parameters.layers.join(',') : parameters.layers;
+  const crs = parameters.crs || '';
+  const boundingBox = parameters.boundingBox.flat().join(',');
+  return `${layers}|${crs}|${boundingBox}`;
+}
+
+function areLayerSelectionsEqual(left: string | string[], right: string | string[]): boolean {
+  if (Array.isArray(left) && Array.isArray(right)) {
+    return left.length === right.length && left.every((layerName, index) => layerName === right[index]);
+  }
+  return left === right;
+}
+
+function normalizeError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}

--- a/modules/deck-layers/src/vector-source-layer/vector-set.ts
+++ b/modules/deck-layers/src/vector-source-layer/vector-set.ts
@@ -84,6 +84,7 @@ export class VectorSet {
   private lastRequestKey: string | null = null;
   private loadCounter = 0;
   private timeoutId: ReturnType<typeof setTimeout> | null = null;
+  private pendingTimeoutResolve: (() => void) | null = null;
   private abortController: AbortController | null = null;
 
   /** Creates a new viewport-driven vector runtime for a source. */
@@ -163,8 +164,10 @@ export class VectorSet {
 
     if (this.debounceTime > 0) {
       await new Promise<void>(resolve => {
+        this.pendingTimeoutResolve = resolve;
         this.timeoutId = setTimeout(() => {
           this.timeoutId = null;
+          this.pendingTimeoutResolve = null;
           void this._loadFeatures(requestParameters, requestKey).finally(resolve);
         }, this.debounceTime);
       });
@@ -335,6 +338,8 @@ export class VectorSet {
       clearTimeout(this.timeoutId);
       this.timeoutId = null;
     }
+    this.pendingTimeoutResolve?.();
+    this.pendingTimeoutResolve = null;
   }
 
   /** Aborts the current in-flight vector request, if any. */

--- a/modules/deck-layers/test/image-source-layer.spec.ts
+++ b/modules/deck-layers/test/image-source-layer.spec.ts
@@ -133,3 +133,24 @@ test('ImageSourceLayer#keeps auto-SRS request shaping behavior', t => {
   ]);
   t.end();
 });
+
+test('ImageSourceLayer#passes debounceTime into ImageSet', t => {
+  const layer = createLayer({
+    id: 'test',
+    data: TEST_IMAGE_SOURCE as any,
+    debounceTime: 25
+  });
+
+  layer.state = {
+    resolvedData: null,
+    imageSet: null,
+    unsubscribeImageSetEvents: null
+  };
+
+  const imageSet = layer._getOrCreateImageSet(TEST_IMAGE_SOURCE as any, true);
+
+  t.equal(imageSet._opts.debounceTime, 25);
+
+  layer._releaseImageSet();
+  t.end();
+});

--- a/modules/deck-layers/test/vector-source-layer.spec.ts
+++ b/modules/deck-layers/test/vector-source-layer.spec.ts
@@ -1,0 +1,266 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'tape-promise/tape';
+import {VectorSourceLayer, type VectorSourceLayerProps} from '@loaders.gl/deck-layers';
+import {VectorSet} from '../src/vector-source-layer/vector-set';
+
+function createDeferredPromise<T>() {
+  let resolvePromise!: (value: T) => void;
+  let rejectPromise!: (error?: Error) => void;
+  const promise = new Promise<T>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+  return {promise, resolvePromise, rejectPromise};
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+const TABLE_A = {
+  shape: 'geojson-table',
+  type: 'FeatureCollection',
+  features: [{type: 'Feature', geometry: null, properties: {name: 'a'}}]
+} as const;
+
+const TABLE_B = {
+  shape: 'geojson-table',
+  type: 'FeatureCollection',
+  features: [{type: 'Feature', geometry: null, properties: {name: 'b'}}]
+} as const;
+
+const TEST_VECTOR_SOURCE = {
+  async getMetadata() {
+    return {name: 'test', keywords: [], layers: []};
+  },
+  async getSchema() {
+    return {metadata: {}, fields: []};
+  },
+  async getFeatures() {
+    return TABLE_A as any;
+  }
+};
+
+function createLayer(
+  props: VectorSourceLayerProps = {id: 'test', data: TEST_VECTOR_SOURCE as any, layers: ['roads']}
+) {
+  return new VectorSourceLayer(props as any) as any;
+}
+
+function createViewport(bounds: [number, number, number, number]) {
+  return {
+    getBounds: () => bounds
+  };
+}
+
+test('VectorSet#keeps only the latest viewport request and skips identical requests', async t => {
+  const firstRequest = createDeferredPromise<any>();
+  const secondRequest = createDeferredPromise<any>();
+  const requestedParameters: any[] = [];
+  const vectorSource = {
+    async getMetadata() {
+      return {name: 'roads', keywords: [], layers: []};
+    },
+    async getSchema() {
+      return {metadata: {}, fields: []};
+    },
+    async getFeatures(parameters: any) {
+      requestedParameters.push(parameters);
+      return requestedParameters.length === 1 ? firstRequest.promise : secondRequest.promise;
+    }
+  };
+
+  const vectorSet = new VectorSet({
+    vectorSource: vectorSource as any,
+    layers: ['roads'],
+    crs: 'EPSG:4326'
+  });
+
+  const firstViewport = createViewport([0, 1, 2, 3]);
+  const secondViewport = createViewport([10, 11, 12, 13]);
+
+  const firstPromise = vectorSet.updateViewport(firstViewport as any);
+  const secondPromise = vectorSet.updateViewport(secondViewport as any);
+
+  secondRequest.resolvePromise(TABLE_B as any);
+  await secondPromise;
+  firstRequest.resolvePromise(TABLE_A as any);
+  await firstPromise;
+
+  t.equal(requestedParameters.length, 2, 'issued one request per changed viewport');
+  t.equal(vectorSet.data, TABLE_B, 'keeps the latest resolved table');
+
+  await vectorSet.updateViewport(secondViewport as any);
+  t.equal(requestedParameters.length, 2, 'does not refetch identical viewport parameters');
+  t.end();
+});
+
+test('VectorSet#emits loading state changes', async t => {
+  const loadingStates: boolean[] = [];
+  let resolveRequest;
+  const vectorSet = new VectorSet({
+    vectorSource: {
+      async getMetadata() {
+        return {name: 'roads', keywords: [], layers: []};
+      },
+      async getSchema() {
+        return {metadata: {}, fields: []};
+      },
+      getFeatures() {
+        return new Promise(resolve => {
+          resolveRequest = () => resolve(TABLE_A as any);
+        }) as Promise<any>;
+      }
+    } as any,
+    layers: ['roads'],
+    crs: 'EPSG:4326'
+  });
+
+  vectorSet.subscribe({
+    onLoadingStateChange: isLoading => loadingStates.push(isLoading)
+  });
+
+  vectorSet.updateViewport(createViewport([0, 1, 2, 3]) as any);
+  await flushMicrotasks();
+  resolveRequest?.();
+  await flushMicrotasks();
+
+  t.deepEqual(loadingStates, [true, false]);
+  t.end();
+});
+
+test('VectorSet#debounces viewport requests', async t => {
+  const requestedParameters: any[] = [];
+  const vectorSet = new VectorSet({
+    vectorSource: {
+      async getMetadata() {
+        return {name: 'roads', keywords: [], layers: []};
+      },
+      async getSchema() {
+        return {metadata: {}, fields: []};
+      },
+      async getFeatures(parameters: any) {
+        requestedParameters.push(parameters);
+        return TABLE_A as any;
+      }
+    } as any,
+    layers: ['roads'],
+    crs: 'EPSG:4326',
+    debounceTime: 5
+  });
+
+  vectorSet.updateViewport(createViewport([0, 1, 2, 3]) as any);
+  vectorSet.updateViewport(createViewport([10, 11, 12, 13]) as any);
+  await new Promise(resolve => setTimeout(resolve, 20));
+
+  t.equal(requestedParameters.length, 1, 'only issues the last debounced viewport request');
+  t.deepEqual(requestedParameters[0].boundingBox, [
+    [10, 11],
+    [12, 13]
+  ]);
+  t.end();
+});
+
+test('VectorSourceLayer#fetches for initial and changed viewports and renders GeoJsonLayer', async t => {
+  const requestedParameters: any[] = [];
+  const loadedTables: any[] = [];
+  const source = {
+    async getMetadata() {
+      return {name: 'roads', keywords: [], layers: [{name: 'roads'}]};
+    },
+    async getSchema() {
+      return {metadata: {}, fields: []};
+    },
+    async getFeatures(parameters: any) {
+      requestedParameters.push(parameters);
+      return {
+        shape: 'geojson-table',
+        type: 'FeatureCollection',
+        features: [{type: 'Feature', geometry: null, properties: {requestCount: requestedParameters.length}}]
+      };
+    }
+  };
+
+  const layer = createLayer({
+    id: 'vector-layer',
+    data: source as any,
+    layers: ['roads'],
+    onDataLoad: table => loadedTables.push(table),
+    geoJsonLayerProps: {pickable: true}
+  });
+
+  layer.initializeState();
+  layer.context = {viewport: createViewport([0, 1, 2, 3])};
+
+  layer.updateState({
+    props: layer.props,
+    oldProps: {...layer.props, data: null},
+    changeFlags: {dataChanged: true, viewportChanged: true}
+  });
+  await flushMicrotasks();
+
+  t.equal(requestedParameters.length, 1, 'requests the initial viewport');
+  t.equal(loadedTables.length, 1, 'forwards successful table loads');
+
+  layer.context = {viewport: createViewport([10, 11, 12, 13])};
+  layer.updateState({
+    props: layer.props,
+    oldProps: layer.props,
+    changeFlags: {dataChanged: false, viewportChanged: true}
+  });
+  await flushMicrotasks();
+
+  t.equal(requestedParameters.length, 2, 'requests changed viewports');
+
+  const renderedLayer = layer.renderLayers();
+  t.equal(renderedLayer.constructor.layerName, 'GeoJsonLayer', 'renders the default GeoJsonLayer');
+  t.equal(renderedLayer.props.pickable, true, 'forwards GeoJsonLayer props');
+  t.deepEqual(
+    renderedLayer.props.data,
+    {
+      type: 'FeatureCollection',
+      features: [{type: 'Feature', geometry: null, properties: {requestCount: 2}}]
+    },
+    'passes GeoJsonLayer a plain FeatureCollection'
+  );
+  t.end();
+});
+
+test('VectorSourceLayer#forwards request errors', async t => {
+  const errors: Error[] = [];
+  const source = {
+    async getMetadata() {
+      return {name: 'roads', keywords: [], layers: []};
+    },
+    async getSchema() {
+      return {metadata: {}, fields: []};
+    },
+    async getFeatures() {
+      throw new Error('request failed');
+    }
+  };
+
+  const layer = createLayer({
+    id: 'vector-layer',
+    data: source as any,
+    layers: ['roads'],
+    onError: error => errors.push(error)
+  });
+
+  layer.initializeState();
+  layer.context = {viewport: createViewport([0, 1, 2, 3])};
+  layer.updateState({
+    props: layer.props,
+    oldProps: {...layer.props, data: null},
+    changeFlags: {dataChanged: true, viewportChanged: true}
+  });
+  await flushMicrotasks();
+
+  t.equal(errors.length, 1, 'forwards fetch errors');
+  t.equal(errors[0]?.message, 'request failed');
+  t.end();
+});

--- a/modules/deck-layers/test/vector-source-layer.spec.ts
+++ b/modules/deck-layers/test/vector-source-layer.spec.ts
@@ -46,7 +46,12 @@ const TEST_VECTOR_SOURCE = {
 };
 
 function createLayer(
-  props: VectorSourceLayerProps = {id: 'test', data: TEST_VECTOR_SOURCE as any, layers: ['roads']}
+  props: VectorSourceLayerProps = {
+    id: 'test',
+    data: TEST_VECTOR_SOURCE as any,
+    layers: ['roads'],
+    debounceTime: 0
+  }
 ) {
   return new VectorSourceLayer(props as any) as any;
 }
@@ -77,7 +82,8 @@ test('VectorSet#keeps only the latest viewport request and skips identical reque
   const vectorSet = new VectorSet({
     vectorSource: vectorSource as any,
     layers: ['roads'],
-    crs: 'EPSG:4326'
+    crs: 'EPSG:4326',
+    debounceTime: 0
   });
 
   const firstViewport = createViewport([0, 1, 2, 3]);
@@ -117,7 +123,8 @@ test('VectorSet#emits loading state changes', async t => {
       }
     } as any,
     layers: ['roads'],
-    crs: 'EPSG:4326'
+    crs: 'EPSG:4326',
+    debounceTime: 0
   });
 
   vectorSet.subscribe({
@@ -165,6 +172,42 @@ test('VectorSet#debounces viewport requests', async t => {
   t.end();
 });
 
+test('VectorSet#resolves canceled debounced viewport updates', async t => {
+  const requestedParameters: any[] = [];
+  const vectorSet = new VectorSet({
+    vectorSource: {
+      async getMetadata() {
+        return {name: 'roads', keywords: [], layers: []};
+      },
+      async getSchema() {
+        return {metadata: {}, fields: []};
+      },
+      async getFeatures(parameters: any) {
+        requestedParameters.push(parameters);
+        return TABLE_A as any;
+      }
+    } as any,
+    layers: ['roads'],
+    crs: 'EPSG:4326',
+    debounceTime: 20
+  });
+
+  const firstPromise = vectorSet.updateViewport(createViewport([0, 1, 2, 3]) as any);
+  const secondPromise = vectorSet.updateViewport(createViewport([10, 11, 12, 13]) as any);
+
+  await Promise.race([
+    Promise.all([firstPromise, secondPromise]),
+    new Promise((_, reject) => setTimeout(() => reject(new Error('timed out')), 100))
+  ]);
+
+  t.equal(requestedParameters.length, 1, 'only the latest debounced request reaches the source');
+  t.deepEqual(requestedParameters[0].boundingBox, [
+    [10, 11],
+    [12, 13]
+  ]);
+  t.end();
+});
+
 test('VectorSourceLayer#fetches for initial and changed viewports and renders GeoJsonLayer', async t => {
   const requestedParameters: any[] = [];
   const loadedTables: any[] = [];
@@ -189,6 +232,7 @@ test('VectorSourceLayer#fetches for initial and changed viewports and renders Ge
     id: 'vector-layer',
     data: source as any,
     layers: ['roads'],
+    debounceTime: 0,
     onDataLoad: table => loadedTables.push(table),
     geoJsonLayerProps: {pickable: true}
   });
@@ -248,6 +292,7 @@ test('VectorSourceLayer#forwards request errors', async t => {
     id: 'vector-layer',
     data: source as any,
     layers: ['roads'],
+    debounceTime: 0,
     onError: error => errors.push(error)
   });
 

--- a/modules/loader-utils/src/lib/sources/image-source.ts
+++ b/modules/loader-utils/src/lib/sources/image-source.ts
@@ -65,4 +65,6 @@ export type GetImageParameters = {
   crs?: string;
   /** requested format for the return image */
   format?: 'image/png';
+  /** Abort signal for canceling in-flight requests. */
+  signal?: AbortSignal;
 };

--- a/modules/loader-utils/src/lib/sources/vector-source.ts
+++ b/modules/loader-utils/src/lib/sources/vector-source.ts
@@ -67,4 +67,6 @@ export type GetFeaturesParameters = {
   crs?: string;
   /** @deprecated requested format for the return image */
   format?: 'geojson' | 'binary';
+  /** Abort signal for canceling in-flight requests. */
+  signal?: AbortSignal;
 };

--- a/modules/mvt/src/map-style-loader.ts
+++ b/modules/mvt/src/map-style-loader.ts
@@ -35,11 +35,11 @@ export const MapStyleLoader = {
     mapStyle: {}
   },
   parse: async (
-    arrayBuffer: ArrayBuffer,
+    data: ArrayBuffer | ArrayBufferView | string,
     options?: MapStyleLoadOptions,
     context?: LoaderContext
   ) => {
-    const text = new TextDecoder().decode(arrayBuffer);
+    const text = typeof data === 'string' ? data : new TextDecoder().decode(data);
     const style = JSON.parse(text) as MapStyle;
     const resolvedStyle = await resolveMapStyle(style, {
       ...options,

--- a/modules/mvt/test/map-style-loader.spec.ts
+++ b/modules/mvt/test/map-style-loader.spec.ts
@@ -3,9 +3,9 @@
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';
-import {readFile} from 'fs/promises';
 import {parse} from '@loaders.gl/core';
 import {validateLoader} from 'test/common/conformance';
+import inlineStyleText from './data/map-style/inline.style.json?raw';
 import {
   MapStyleLoader,
   resolveMapStyle,
@@ -34,8 +34,7 @@ test('MapStyleLoader#loader conformance', (t) => {
 });
 
 test('MapStyleLoader#parse inline style fixture', async (t) => {
-  const styleText = await readFile(INLINE_STYLE_URL, 'utf8');
-  const style = await parse(styleText, MapStyleLoader, {
+  const style = await parse(inlineStyleText, MapStyleLoader, {
     mapStyle: {baseUrl: INLINE_STYLE_URL.href}
   });
 

--- a/modules/tiles/src/image-set.ts
+++ b/modules/tiles/src/image-set.ts
@@ -37,6 +37,8 @@ export type ImageSetProps<DataT = ImageType> = Partial<ImageSetBaseProps<DataT>>
 
 /** Subscription callbacks emitted by {@link ImageSet}. */
 export type ImageSetListener<DataT = ImageType> = {
+  /** Fired when metadata/image loading starts or stops. */
+  onLoadingStateChange?: (isLoading: boolean) => void;
   /** Fired when source metadata resolves successfully. */
   onMetadataLoad?: (metadata: ImageSourceMetadata) => void;
   /** Fired when metadata loading fails. */
@@ -69,6 +71,7 @@ export class ImageSet<DataT = ImageType> {
   private _nextRequestId = 0;
   private _loadCounter = 0;
   private _timeoutId: ReturnType<typeof setTimeout> | null = null;
+  private _abortController: AbortController | null = null;
   private _finalized = false;
 
   /** Creates an image manager from a source or direct callbacks. */
@@ -136,7 +139,7 @@ export class ImageSet<DataT = ImageType> {
 
   /** Loads metadata from the current image source or callbacks. */
   async loadMetadata(): Promise<ImageSourceMetadata> {
-    this._loadCounter++;
+    this._startLoading();
     try {
       const metadata = await this._opts.getMetadata();
       if (this._finalized) {
@@ -157,7 +160,7 @@ export class ImageSet<DataT = ImageType> {
       }
       throw normalizedError;
     } finally {
-      this._loadCounter--;
+      this._finishLoading();
     }
   }
 
@@ -165,6 +168,7 @@ export class ImageSet<DataT = ImageType> {
   requestImage(parameters: GetImageParameters, debounceTime = this._opts.debounceTime): number {
     const requestId = this._nextRequestId++;
     this._cancelScheduledImage();
+    this._abortActiveRequest();
 
     if (debounceTime > 0) {
       this._timeoutId = setTimeout(() => {
@@ -182,6 +186,7 @@ export class ImageSet<DataT = ImageType> {
   finalize(): void {
     this._finalized = true;
     this._cancelScheduledImage();
+    this._abortActiveRequest();
     this._listeners.clear();
   }
 
@@ -191,13 +196,15 @@ export class ImageSet<DataT = ImageType> {
       return;
     }
 
-    this._loadCounter++;
+    this._startLoading();
     for (const listener of this._listeners) {
       listener.onImageLoadStart?.(requestId, parameters);
     }
 
     try {
-      const image = await this._opts.getImage(parameters);
+      const abortController = new AbortController();
+      this._abortController = abortController;
+      const image = await this._opts.getImage({...parameters, signal: abortController.signal});
       if (this._finalized || requestId <= this._lastAcceptedRequestId) {
         return;
       }
@@ -210,6 +217,9 @@ export class ImageSet<DataT = ImageType> {
       }
       this._emitUpdate();
     } catch (error) {
+      if (isAbortError(error)) {
+        return;
+      }
       const normalizedError = normalizeImageSetError(error, 'Image request failed');
       if (!this._finalized) {
         for (const listener of this._listeners) {
@@ -217,7 +227,10 @@ export class ImageSet<DataT = ImageType> {
         }
       }
     } finally {
-      this._loadCounter--;
+      if (this._abortController?.signal === parameters.signal) {
+        this._abortController = null;
+      }
+      this._finishLoading();
     }
   }
 
@@ -255,6 +268,33 @@ export class ImageSet<DataT = ImageType> {
     }
   }
 
+  /** Increments the active load count and emits loading changes. */
+  private _startLoading(): void {
+    const wasLoading = this._loadCounter > 0;
+    this._loadCounter++;
+    if (!wasLoading) {
+      this._emitLoadingStateChange(true);
+      this._emitUpdate();
+    }
+  }
+
+  /** Decrements the active load count and emits loading changes. */
+  private _finishLoading(): void {
+    const wasLoading = this._loadCounter > 0;
+    this._loadCounter = Math.max(0, this._loadCounter - 1);
+    if (wasLoading && this._loadCounter === 0) {
+      this._emitLoadingStateChange(false);
+      this._emitUpdate();
+    }
+  }
+
+  /** Notifies listeners when the overall loading state changes. */
+  private _emitLoadingStateChange(isLoading: boolean): void {
+    for (const listener of this._listeners) {
+      listener.onLoadingStateChange?.(isLoading);
+    }
+  }
+
   /** Clears any pending debounced image request. */
   private _cancelScheduledImage(): void {
     if (this._timeoutId !== null) {
@@ -262,6 +302,16 @@ export class ImageSet<DataT = ImageType> {
       this._timeoutId = null;
     }
   }
+
+  /** Aborts the current in-flight image request, if any. */
+  private _abortActiveRequest(): void {
+    this._abortController?.abort();
+    this._abortController = null;
+  }
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
 }
 
 /** Normalizes arbitrary thrown values to `Error` instances for bookkeeping. */

--- a/modules/tiles/test/image-set.spec.ts
+++ b/modules/tiles/test/image-set.spec.ts
@@ -133,3 +133,32 @@ test('ImageSet#debounces image requests', async t => {
   imageSet.finalize();
   t.end();
 });
+
+test('ImageSet#emits loading state changes', async t => {
+  let resolveImage;
+  const loadingStates: boolean[] = [];
+  const imageSet = new ImageSet({
+    async getMetadata() {
+      return {name: 'test', keywords: [], layers: []};
+    },
+    getImage() {
+      return new Promise(resolve => {
+        resolveImage = () => resolve({name: 'image'});
+      }) as Promise<any>;
+    }
+  });
+
+  imageSet.subscribe({
+    onLoadingStateChange: isLoading => loadingStates.push(isLoading)
+  });
+
+  imageSet.requestImage({layers: [], boundingBox: [[0, 0], [1, 1]], width: 1, height: 1});
+  await new Promise(resolve => setTimeout(resolve, 0));
+  resolveImage?.();
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  t.deepEqual(loadingStates, [true, false]);
+
+  imageSet.finalize();
+  t.end();
+});

--- a/modules/tiles/test/tileset/tileset-3d-traversal.spec.ts
+++ b/modules/tiles/test/tileset/tileset-3d-traversal.spec.ts
@@ -190,11 +190,9 @@ test('Tileset3D#onTraversalComplete', async t => {
   t.plan(1);
   const tilesetJson = await load(TILESET_URL, Tiles3DLoader);
   const viewport = VIEWPORTS[1];
-  let tileLoadCounter = 0;
   const tileset = new Tileset3D(new Tiles3DSource(tilesetJson), {
     onTileLoad: () => {
       tileset.update(viewport);
-      tileLoadCounter++;
     },
     onTraversalComplete: selectedTiles => {
       return selectedTiles.filter(tile => tile.depth === 1);
@@ -202,8 +200,8 @@ test('Tileset3D#onTraversalComplete', async t => {
   });
   tileset.update(viewport);
 
-  t.timeoutAfter(1000);
-  await waitForCondition(() => tileLoadCounter > 0, 1000);
+  t.timeoutAfter(1500);
+  await waitForCondition(() => tileset.selectedTiles.length === 4, 1500);
   tileset.update(viewport);
   t.equals(tileset.selectedTiles.length, 4);
 });

--- a/modules/wms/src/arcgis/arcgis-feature-source.ts
+++ b/modules/wms/src/arcgis/arcgis-feature-source.ts
@@ -124,7 +124,7 @@ export class ArcGISVectorSource
   /** Requests features from the ArcGIS FeatureServer query endpoint. */
   async getFeatures(parameters: GetFeaturesParameters): Promise<GeoJSONTable> {
     const url = this.getFeaturesURL(parameters);
-    const response = await this.fetch(url);
+    const response = await this.fetch(url, parameters.signal ? {signal: parameters.signal} : undefined);
     await this.checkResponse(response);
     return parseGeoJSONTable(await response.json());
   }
@@ -152,12 +152,13 @@ export class ArcGISVectorSource
   /** Builds a query URL from generic vector source parameters. */
   getFeaturesURL(parameters: GetFeaturesParameters): string {
     const defaultParameters = this.options['arcgis-feature-server']?.queryParameters || {};
+    const spatialReference = normalizeArcGISSpatialReference(parameters.crs) || 4326;
     const queryParameters: ArcGISFeatureServiceQueryOptions = {
       returnGeometry: true,
       where: '1=1',
       outFields: '*',
-      outSR: parameters.crs || 4326,
-      inSR: parameters.crs || 4326,
+      outSR: spatialReference,
+      inSR: spatialReference,
       f: 'geojson',
       ...defaultParameters
     };
@@ -215,6 +216,19 @@ function parseArcGISFeatureServerMetadata(json: any): VectorSourceMetadata {
     // crs: 'EPSG:4326',
     layers
   };
+}
+
+/** Normalizes EPSG-prefixed CRS strings to ArcGIS WKID values. */
+function normalizeArcGISSpatialReference(
+  spatialReference: string | number | undefined
+): string | number | undefined {
+  if (typeof spatialReference === 'string') {
+    const match = /^EPSG:(\d+)$/i.exec(spatialReference);
+    if (match) {
+      return match[1];
+    }
+  }
+  return spatialReference;
 }
 
 /** Builds a schema from ArcGIS FeatureServer metadata fields. */

--- a/modules/wms/src/arcgis/arcgis-image-source.ts
+++ b/modules/wms/src/arcgis/arcgis-image-source.ts
@@ -98,16 +98,17 @@ export class ArcGISImageSource
 
   /** Requests an image from generic ImageSource parameters. */
   async getImage(parameters: GetImageParameters): Promise<ImageType> {
-    const {boundingBox, bbox, width, height, crs, format} = parameters;
+    const {boundingBox, bbox, width, height, crs, format, signal} = parameters;
+    const spatialReference = normalizeArcGISSpatialReference(crs) || '4326';
     const imageParameters: ArcGISExportImageParameters = {
       bbox: boundingBox ? [...boundingBox[0], ...boundingBox[1]] : bbox!,
-      bboxSR: crs || '4326',
-      imageSR: crs || '4326',
+      bboxSR: spatialReference,
+      imageSR: spatialReference,
       width,
       height,
       format: format === 'image/png' ? 'png' : undefined
     };
-    return await this.exportImage(imageParameters);
+    return await this.exportImage(imageParameters, signal);
   }
 
   /** Requests the ArcGIS ImageServer metadata document. */
@@ -118,8 +119,8 @@ export class ArcGISImageSource
   }
 
   /** Requests an exported image from the ArcGIS ImageServer endpoint. */
-  async exportImage(options: ArcGISExportImageParameters): Promise<ImageType> {
-    const response = await this.fetch(this.exportImageURL(options));
+  async exportImage(options: ArcGISExportImageParameters, signal?: AbortSignal): Promise<ImageType> {
+    const response = await this.fetch(this.exportImageURL(options), signal ? {signal} : undefined);
     await this.checkResponse(response);
     const arrayBuffer = await response.arrayBuffer();
     return await ImageLoader.parse(arrayBuffer, this.loadOptions);
@@ -178,6 +179,19 @@ function encodeArcGISParameters(parameters: Record<string, unknown>): string {
 /** Converts an ArcGIS REST parameter value to a query string value. */
 function getArcGISParameterValue(value: unknown): string {
   return typeof value === 'object' ? JSON.stringify(value) : String(value);
+}
+
+/** Normalizes EPSG-prefixed CRS strings to ArcGIS WKID values. */
+function normalizeArcGISSpatialReference(
+  spatialReference: string | number | undefined
+): string | number | undefined {
+  if (typeof spatialReference === 'string') {
+    const match = /^EPSG:(\d+)$/i.exec(spatialReference);
+    if (match) {
+      return match[1];
+    }
+  }
+  return spatialReference;
 }
 
 /** Normalizes ArcGIS ImageServer metadata to the generic ImageSource metadata shape. */

--- a/modules/wms/src/index.ts
+++ b/modules/wms/src/index.ts
@@ -58,6 +58,7 @@ export {GMLLoader as _GMLLoader} from './gml-loader';
 
 // export {CSWSource} from './csw-source';
 export {WMSSource, WMSImageSource} from './wms-source';
+export {WFSSource, WFSVectorSource} from './wfs-source';
 
 // ArcGIS SourceLoaders
 

--- a/modules/wms/src/wfs-source.ts
+++ b/modules/wms/src/wfs-source.ts
@@ -118,6 +118,22 @@ export type WFSGetMapParameters = {
   elevation?: string;
 };
 
+/** Parameters for GetFeature. */
+export type WFSGetFeatureParameters = {
+  /** In case the endpoint supports multiple WFS versions. */
+  version?: '1.3.0' | '1.1.1';
+  /** Requested feature types. */
+  typeName?: string | string[];
+  /** Bounding box filter, optionally suffixed with the bbox CRS. */
+  bbox: [number, number, number, number] | [number, number, number, number, string];
+  /** Output CRS for returned features. */
+  crs?: string;
+  /** Output CRS for returned features. */
+  srsName?: string;
+  /** Requested output format. */
+  outputFormat?: 'application/json' | 'application/geo+json';
+};
+
 // /** GetMap parameters that are specific to the current view */
 // export type WFSGetMapViewParameters = {
 //   /** pixel width of returned image */
@@ -222,13 +238,12 @@ export class WFSVectorSource extends DataSource<string, WFSourceOptions> impleme
   }
 
   async getFeatures(parameters: GetFeaturesParameters): Promise<GeoJSONTable> {
-    // Replace the GetImage `boundingBox` parameter with the WFS flat `bbox` parameter.
-    // const {boundingBox, bbox, ...rest} = parameters;
-    // const wfsParameters: WFSGetMapParameters = {
-    //   bbox: boundingBox ? [...boundingBox[0], ...boundingBox[1]] : bbox!,
-    //   ...rest
-    // };
-    return {shape: 'geojson-table', type: 'FeatureCollection', features: []};
+    const url = this.getFeaturesURL(parameters);
+    const response = await this.fetch(url, parameters.signal ? {signal: parameters.signal} : undefined);
+    const arrayBuffer = await response.arrayBuffer();
+    this._checkResponse(response, arrayBuffer);
+    const text = new TextDecoder().decode(arrayBuffer);
+    return parseGeoJSONTable(JSON.parse(text));
   }
 
   normalizeMetadata(capabilities: WFSCapabilities): VectorSourceMetadata {
@@ -328,9 +343,8 @@ export class WFSVectorSource extends DataSource<string, WFSourceOptions> impleme
     wfsParameters?: WFSGetCapabilitiesParameters,
     vendorParameters?: Record<string, unknown>
   ): string {
-    // @ts-expect-error
     const options: Required<WFSGetCapabilitiesParameters> = {
-      // version: this.wfsParameters.version,
+      version: wfsParameters?.version || this.options.wfs?.wfsParameters?.version || '1.3.0',
       ...wfsParameters
     };
     return this._getWFSUrl('GetCapabilities', options, vendorParameters);
@@ -358,6 +372,22 @@ export class WFSVectorSource extends DataSource<string, WFSourceOptions> impleme
       ...wfsParameters
     };
     return this._getWFSUrl('GetMap', options, vendorParameters);
+  }
+
+  /** Generate a URL for the GetFeature request. */
+  getFeaturesURL(
+    parameters: GetFeaturesParameters | WFSGetFeatureParameters,
+    vendorParameters?: Record<string, unknown>
+  ): string {
+    const requestParameters = this._normalizeGetFeatureParameters(parameters);
+    const options: WFSGetFeatureParameters & {version: '1.3.0' | '1.1.1'} = {
+      version: requestParameters.version || '1.3.0',
+      typeName: requestParameters.typeName,
+      bbox: requestParameters.bbox,
+      srsName: requestParameters.srsName || requestParameters.crs || 'EPSG:4326',
+      outputFormat: requestParameters.outputFormat || 'application/json'
+    };
+    return this._getWFSUrl('GetFeature', options, vendorParameters);
   }
 
   /** Generate a URL for the GetFeatureInfo request */
@@ -510,6 +540,10 @@ export class WFSVectorSource extends DataSource<string, WFSourceOptions> impleme
         }
         break;
 
+      case 'srsName':
+        key = 'srsName';
+        break;
+
       case 'x':
         // i is the parameter used in WFS 1.3
         // TODO - change parameter to `i` and convert to `x` if not 1.3
@@ -541,9 +575,9 @@ export class WFSVectorSource extends DataSource<string, WFSourceOptions> impleme
   _flipBoundingBox(
     bboxValue: unknown,
     wfsParameters: WFSParameters
-  ): [number, number, number, number] | null {
+  ): [number, number, number, number] | [number, number, number, number, string] | null {
     // Sanity checks
-    if (!Array.isArray(bboxValue) || bboxValue.length !== 4) {
+    if (!Array.isArray(bboxValue) || (bboxValue.length !== 4 && bboxValue.length !== 5)) {
       return null;
     }
 
@@ -555,8 +589,14 @@ export class WFSVectorSource extends DataSource<string, WFSourceOptions> impleme
     // // Don't flip if we are substituting EPSG:4326 with CRS:84
     // !(this.substituteCRS84 && wfsParameters.crs === 'EPSG:4326');
 
-    const bbox = bboxValue as [number, number, number, number];
-    return flipCoordinates ? [bbox[1], bbox[0], bbox[3], bbox[2]] : bbox;
+    const bbox = bboxValue as [number, number, number, number] | [number, number, number, number, string];
+    if (!flipCoordinates) {
+      return bbox;
+    }
+
+    return bbox.length === 5
+      ? [bbox[1], bbox[0], bbox[3], bbox[2], bbox[4]]
+      : [bbox[1], bbox[0], bbox[3], bbox[2]];
   }
 
   /** Fetches an array buffer and checks the response (boilerplate reduction) */
@@ -585,4 +625,42 @@ export class WFSVectorSource extends DataSource<string, WFSourceOptions> impleme
     const error = WMSErrorLoader.parseSync?.(arrayBuffer, this.loadOptions);
     return new Error(error);
   }
+
+  /** Maps generic viewport parameters onto WFS GetFeature parameters. */
+  private _normalizeGetFeatureParameters(
+    parameters: GetFeaturesParameters | WFSGetFeatureParameters
+  ): WFSGetFeatureParameters {
+    if ('boundingBox' in parameters) {
+      const crs = parameters.crs || 'EPSG:4326';
+      return {
+        version: this.options.wfs?.wfsParameters?.version || '1.3.0',
+        typeName: parameters.layers,
+        bbox: [
+          parameters.boundingBox[0][0],
+          parameters.boundingBox[0][1],
+          parameters.boundingBox[1][0],
+          parameters.boundingBox[1][1],
+          crs
+        ],
+        crs,
+        srsName: crs,
+        outputFormat: 'application/json'
+      };
+    }
+
+    return parameters;
+  }
+}
+
+/** Parses a GeoJSON FeatureCollection into the loaders.gl GeoJSON table shape. */
+function parseGeoJSONTable(json: any): GeoJSONTable {
+  if (json?.type === 'FeatureCollection' && Array.isArray(json.features)) {
+    return {
+      shape: 'geojson-table',
+      type: 'FeatureCollection',
+      features: json.features
+    };
+  }
+
+  throw new Error('WFS GetFeature did not return a GeoJSON FeatureCollection');
 }

--- a/modules/wms/src/wms-source.ts
+++ b/modules/wms/src/wms-source.ts
@@ -251,12 +251,12 @@ export class WMSImageSource extends DataSource<string, WMSSourceOptions> impleme
 
   async getImage(parameters: GetImageParameters): Promise<ImageType> {
     // Replace the GetImage `boundingBox` parameter with the WMS flat `bbox` parameter.
-    const {boundingBox, bbox, ...rest} = parameters;
+    const {boundingBox, bbox, signal, ...rest} = parameters;
     const wmsParameters: WMSGetMapParameters = {
       bbox: boundingBox ? [...boundingBox[0], ...boundingBox[1]] : bbox!,
       ...rest
     };
-    return await this.getMap(wmsParameters);
+    return await this.getMap(wmsParameters, undefined, signal);
   }
 
   normalizeMetadata(capabilities: WMSCapabilities): ImageSourceMetadata {
@@ -282,10 +282,11 @@ export class WMSImageSource extends DataSource<string, WMSSourceOptions> impleme
   /** Get a map image */
   async getMap(
     wmsParameters: WMSGetMapParameters,
-    vendorParameters?: Record<string, unknown>
+    vendorParameters?: Record<string, unknown>,
+    signal?: AbortSignal
   ): Promise<ImageType> {
     const url = this.getMapURL(wmsParameters, vendorParameters);
-    const response = await this.fetch(url);
+    const response = await this.fetch(url, signal ? {signal} : undefined);
     const arrayBuffer = await response.arrayBuffer();
     this._checkResponse(response, arrayBuffer);
     try {

--- a/modules/wms/test/arcgis/arcgis-server.spec.ts
+++ b/modules/wms/test/arcgis/arcgis-server.spec.ts
@@ -100,6 +100,37 @@ test('ArcGISImageSource#getImage maps generic parameters', async t => {
   t.end();
 });
 
+test('ArcGISImageSource#getImage normalizes EPSG-prefixed spatial references', async t => {
+  const source = ArcGISImageServerSource.createDataSource(IMAGE_SERVER_URL, {});
+  let exportImageParameters;
+  source.exportImage = async parameters => {
+    exportImageParameters = parameters;
+    return {} as never;
+  };
+
+  await source.getImage({
+    boundingBox: [
+      [1, 2],
+      [3, 4]
+    ],
+    width: 512,
+    height: 256,
+    crs: 'EPSG:3857',
+    format: 'image/png',
+    layers: []
+  });
+
+  t.deepEqual(exportImageParameters, {
+    bbox: [1, 2, 3, 4],
+    bboxSR: '3857',
+    imageSR: '3857',
+    width: 512,
+    height: 256,
+    format: 'png'
+  });
+  t.end();
+});
+
 test('ArcGISFeatureServerSource#testURL', t => {
   t.ok(ArcGISFeatureServerSource);
   t.ok(
@@ -141,6 +172,24 @@ test('ArcGISVectorSource#getFeaturesURL', t => {
   t.equal(featuresUrl.searchParams.get('geometryType'), 'esriGeometryEnvelope');
   t.equal(featuresUrl.searchParams.get('spatialRel'), 'esriSpatialRelIntersects');
   t.equal(featuresUrl.searchParams.get('f'), 'geojson');
+  t.end();
+});
+
+test('ArcGISVectorSource#getFeaturesURL normalizes EPSG-prefixed spatial references', t => {
+  const source = ArcGISFeatureServerSource.createDataSource(FEATURE_SERVER_URL, {});
+  const featuresUrl = new URL(
+    source.getFeaturesURL({
+      boundingBox: [
+        [1, 2],
+        [3, 4]
+      ],
+      layers: [],
+      crs: 'EPSG:3857'
+    })
+  );
+
+  t.equal(featuresUrl.searchParams.get('outSR'), '3857');
+  t.equal(featuresUrl.searchParams.get('inSR'), '3857');
   t.end();
 });
 

--- a/modules/wms/test/index.ts
+++ b/modules/wms/test/index.ts
@@ -23,6 +23,7 @@ import './wmts/wmts-capabilities-loader.spec';
 // WMS - Web Feature Service
 
 import './wfs/wfs-capabilities-loader.spec';
+import './wfs/wfs-source.spec';
 
 // GML - Geographic Markup Language
 

--- a/modules/wms/test/wfs/wfs-source.spec.ts
+++ b/modules/wms/test/wfs/wfs-source.spec.ts
@@ -1,0 +1,73 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'tape-promise/tape';
+import {WFSSource} from '@loaders.gl/wms';
+
+const WFS_URL = 'https://example.com/geoserver/wfs';
+
+test('WFSSource#getFeaturesURL', t => {
+  const source = WFSSource.createDataSource(WFS_URL, {});
+  const featuresUrl = new URL(
+    source.getFeaturesURL({
+      boundingBox: [
+        [1, 2],
+        [3, 4]
+      ],
+      layers: ['roads', 'bridges'],
+      crs: 'EPSG:4326'
+    })
+  );
+
+  t.equal(featuresUrl.origin + featuresUrl.pathname, WFS_URL, 'keeps the base WFS URL');
+  t.equal(featuresUrl.searchParams.get('SERVICE'), 'WFS');
+  t.equal(featuresUrl.searchParams.get('REQUEST'), 'GetFeature');
+  t.equal(featuresUrl.searchParams.get('VERSION'), '1.3.0');
+  t.equal(featuresUrl.searchParams.get('TYPENAME'), 'roads,bridges');
+  t.equal(featuresUrl.searchParams.get('BBOX'), '1,2,3,4,EPSG:4326');
+  t.equal(featuresUrl.searchParams.get('SRSNAME'), 'EPSG:4326');
+  t.equal(featuresUrl.searchParams.get('OUTPUTFORMAT'), 'application/json');
+  t.end();
+});
+
+test('WFSSource#getCapabilitiesURL defaults version', t => {
+  const source = WFSSource.createDataSource(WFS_URL, {});
+  const capabilitiesUrl = new URL(source.getCapabilitiesURL());
+
+  t.equal(capabilitiesUrl.origin + capabilitiesUrl.pathname, WFS_URL, 'keeps the base WFS URL');
+  t.equal(capabilitiesUrl.searchParams.get('SERVICE'), 'WFS');
+  t.equal(capabilitiesUrl.searchParams.get('REQUEST'), 'GetCapabilities');
+  t.equal(capabilitiesUrl.searchParams.get('VERSION'), '1.3.0');
+  t.end();
+});
+
+test('WFSSource#getFeatures', async t => {
+  const source = WFSSource.createDataSource(WFS_URL, {});
+  const featureCollection = {
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        geometry: {type: 'Point', coordinates: [1, 2]},
+        properties: {name: 'Road'}
+      }
+    ]
+  };
+  source.fetch = async () => new Response(JSON.stringify(featureCollection));
+
+  const table = await source.getFeatures({
+    boundingBox: [
+      [1, 2],
+      [3, 4]
+    ],
+    layers: ['roads'],
+    crs: 'EPSG:4326'
+  });
+
+  t.deepEqual(table, {
+    shape: 'geojson-table',
+    ...featureCollection
+  });
+  t.end();
+});

--- a/website/src/components/example/examples-index.tsx
+++ b/website/src/components/example/examples-index.tsx
@@ -11,13 +11,25 @@ import {
   ExampleTitle
 } from './styled';
 
-function renderItem(item, getThumbnail) {
+const DEFAULT_EXAMPLE_THUMBNAIL = '/images/maps.jpg';
+
+function renderItem(item, getThumbnail, defaultThumbnail) {
   const imageUrl = useBaseUrl(getThumbnail(item));
+  const fallbackImageUrl = useBaseUrl(defaultThumbnail);
   const {label, href} = item;
 
   return (
     <ExampleCard key={label} href={href}>
-      <img width="100%" src={imageUrl} alt={label} />
+      <img
+        width="100%"
+        src={imageUrl}
+        alt={label}
+        onError={(event) => {
+          const image = event.currentTarget;
+          image.onerror = null;
+          image.src = fallbackImageUrl;
+        }}
+      />
       <ExampleTitle>
         <span>{label}</span>
       </ExampleTitle>
@@ -25,22 +37,25 @@ function renderItem(item, getThumbnail) {
   );
 }
 
-function renderCategory({label, items}, getThumbnail) {
+function renderCategory({label, items}, getThumbnail, defaultThumbnail) {
   return [
     <ExampleHeader key={`${label}-header`}>{label}</ExampleHeader>,
     <ExamplesGroup key={label}>
-      {items.map(item => renderItem(item, getThumbnail))}
+      {items.map(item => renderItem(item, getThumbnail, defaultThumbnail))}
     </ExamplesGroup>
   ];
 }
 
-export default function ExamplesIndex({getThumbnail}) {
+export default function ExamplesIndex({
+  getThumbnail,
+  defaultThumbnail = DEFAULT_EXAMPLE_THUMBNAIL
+}) {
   const mainSidebar = useDocsSidebar();
   const sidebar = mainSidebar.items[0];
   return <MainExamples>
     {sidebar.items.map(item => {
       if (item.type === 'category' && item.items && item.label) {
-        return renderCategory(item, getThumbnail);
+        return renderCategory(item, getThumbnail, defaultThumbnail);
       }
       return null;
     })}

--- a/website/src/examples-sidebar.js
+++ b/website/src/examples-sidebar.js
@@ -33,7 +33,17 @@ export const sidebars = {
     {
       type: 'category',
       label: 'Geospatial Tile Formats',
-      items: ['tiles/mvt', 'tiles/pmtiles', 'tiles/table-tiler', 'tiles/wms', 'tiles/mlt']
+      items: ['tiles/mvt', 'tiles/pmtiles', 'tiles/table-tiler', 'tiles/mlt']
+    },
+    {
+      type: 'category',
+      label: 'Image and Vector Services',
+      items: [
+        'tiles/wms',
+        'tiles/wfs',
+        'tiles/arcgis-image-server',
+        'tiles/arcgis-feature-server'
+      ]
     },
     {
       type: 'category',

--- a/website/src/examples/tiles/arcgis-feature-server.mdx
+++ b/website/src/examples/tiles/arcgis-feature-server.mdx
@@ -1,0 +1,7 @@
+# ArcGIS Feature Server
+
+import Demo from 'examples/website/wms/app';
+
+<div style={{height: 'calc(100vh - var(--ifm-navbar-height))'}}>
+  <Demo format="ArcGIS Feature Server" />
+</div>

--- a/website/src/examples/tiles/arcgis-image-server.mdx
+++ b/website/src/examples/tiles/arcgis-image-server.mdx
@@ -1,0 +1,7 @@
+# ArcGIS Image Server
+
+import Demo from 'examples/website/wms/app';
+
+<div style={{height: 'calc(100vh - var(--ifm-navbar-height))'}}>
+  <Demo format="ArcGIS Image Server" />
+</div>

--- a/website/src/examples/tiles/wfs.mdx
+++ b/website/src/examples/tiles/wfs.mdx
@@ -1,0 +1,7 @@
+# WFS (OGC Web Feature Service)
+
+import Demo from 'examples/website/wms/app';
+
+<div style={{height: 'calc(100vh - var(--ifm-navbar-height))'}}>
+  <Demo format="WFS" />
+</div>

--- a/website/src/examples/tiles/wms.mdx
+++ b/website/src/examples/tiles/wms.mdx
@@ -1,10 +1,10 @@
 
-# WMS
+# WMS (OGC Web Map Service)
 
 import Demo from 'examples/website/wms/app';
 
-<div style={{height: 'calc(100vh - var(--ifm-navbar-height))'}}> 
-  <Demo >
-    [**`WMSSource`**](/docs/modules/wms/api-reference/wms-source) dynamically loads viewports from an OGC Web Map Service.
+<div style={{height: 'calc(100vh - var(--ifm-navbar-height))'}}>
+  <Demo format="WMS">
+    [**`WMSSource`**](/docs/modules/wms/api-reference/wms-source) loads imagery through `ImageSourceLayer`.
   </Demo>
 </div>


### PR DESCRIPTION
## Goals

- Add viewport-driven vector service support alongside the existing image-service runtime.
- Enable end-to-end WFS and ArcGIS Feature Server examples through a new `VectorSourceLayer`.
- Improve service examples and example-site UX for image and vector services.

## Changes

- Added `VectorSet` in `modules/deck-layers` to manage viewport-driven vector fetches with latest-request-wins behavior, loading/error state, and source metadata/schema caching.
- Added `VectorSourceLayer` in `modules/deck-layers` to render vector-service responses through `GeoJsonLayer`.
- Exported `VectorSourceLayer` from `@loaders.gl/deck-layers`.
- Implemented WFS `GetFeature` support in `modules/wms/src/wfs-source.ts`.
- Added `WFSGetFeatureParameters` and `getFeaturesURL()` for WFS vector requests.
- Updated WFS feature requests to send `SRSNAME` and CRS-qualified `BBOX`, fixing GeoServer responses that otherwise fell back to native projected coordinates.
- Parsed WFS GeoJSON `FeatureCollection` responses into loaders.gl `GeoJSONTable`.
- Kept ArcGIS Feature Server support aligned with the vector runtime and normalized ArcGIS spatial reference handling.
- Updated ArcGIS Image Server request handling to normalize EPSG-prefixed spatial references.
- Added loading-state callback support and abort-signal plumbing across source-backed image/vector fetch paths.
- Added debouncing and abandoned-request cancellation in `ImageSet` and `VectorSet`.
- Updated the example app to use `ImageSourceLayer` and `VectorSourceLayer`.
- Added separate example entries and website pages for:
  - WMS (OGC Web Map Service)
  - WFS (OGC Web Feature Service)
  - ArcGIS Image Server
  - ArcGIS Feature Server
- Added an `Image and Vector Services` section in the examples sidebar.
- Added example-page filtering so each MDX page can restrict the dropdown to matching services.
- Replaced the previous non-CORS-friendly WFS example endpoint with a CORS-friendly GeoBretagne WFS service.
- Tuned service example styling so WFS points and ArcGIS Feature Server lines are visible by default.
- Added hover tooltip and highlight support in the example app for vector-service features.
- Fixed forwarded `GeoJsonLayer` props in `VectorSourceLayer` so example props like `pickable` are preserved.
- Added and updated tests for:
  - `VectorSet`
  - `VectorSourceLayer`
  - WFS source URL generation and GeoJSON parsing
  - ArcGIS image/feature source URL generation and CRS normalization
  - `ImageSet` loading behavior
