### PR TITLE
chore: Run full tests on node

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,14 +16,25 @@ jobs:
       matrix:
         include:
           - node-version: 24
-            full: true
-            scope: 'full suite'
+            coverage: false
+            playwright: false
+            scope: 'node tests'
+            test-command: test-node
+          - node-version: 24
+            coverage: true
+            playwright: true
+            scope: 'headless tests'
+            test-command: test-headless-cover
           - node-version: 22
-            full: false
+            coverage: false
+            playwright: false
             scope: 'node tests'
+            test-command: test-node
           - node-version: 20
-            full: false
+            coverage: false
+            playwright: false
             scope: 'node tests'
+            test-command: test-node
 
     steps:
       - name: Checkout code
@@ -62,19 +73,18 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Install Playwright browsers
-        if: matrix.full
+        if: matrix.playwright
         run: yarn playwright install --with-deps chromium
 
       - name: Build workers
         run: yarn run build-workers
 
-      - name: Run node and browser tests (combine coverage)
-        if: matrix.full
+      - name: Run tests
         run: |
-          yarn run test-cover
+          yarn run ${{ matrix.test-command }}
 
       - name: Sanitize lcov for Coveralls
-        if: matrix.full
+        if: matrix.coverage
         run: |
           node - <<'NODE'
           const fs = require('fs');
@@ -106,13 +116,8 @@ jobs:
           fs.writeFileSync(coveragePath, `${records.join('\n')}\n`);
           NODE
 
-      - name: Run node tests
-        if: ${{ !matrix.full }}
-        run: |
-          yarn run test-node
-
       - name: Upload coverage to Coveralls
-        if: matrix.full
+        if: matrix.coverage
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,22 +16,26 @@ jobs:
       matrix:
         include:
           - node-version: 24
-            coverage: false
+            coverage: true
+            coverage-flag: node
             playwright: false
             scope: 'node tests'
-            test-command: test-node
+            test-command: test-node-cover
           - node-version: 24
             coverage: true
+            coverage-flag: headless
             playwright: true
             scope: 'headless tests'
             test-command: test-headless-cover
           - node-version: 22
             coverage: false
+            coverage-flag: ''
             playwright: false
             scope: 'node tests'
             test-command: test-node
           - node-version: 20
             coverage: false
+            coverage-flag: ''
             playwright: false
             scope: 'node tests'
             test-command: test-node
@@ -123,6 +127,24 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: coverage/lcov.info
           format: lcov
+          flag-name: ${{ matrix.coverage-flag }}
+          parallel: true
+          fail-on-error: false
+
+  finish-coverage:
+    name: Finish coverage
+    needs: test
+    if: ${{ always() }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Close Coveralls parallel build
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true
+          carryforward: node,headless
           fail-on-error: false
 
   build:

--- a/.ocularrc.js
+++ b/.ocularrc.js
@@ -71,13 +71,24 @@ const config = {
         'modules/arrow/test/triangulate-on-worker.spec.ts',
         'modules/compression/test/compression.spec.ts',
         'modules/crypto/test/crypto-worker.spec.ts',
+        'modules/deck-layers/test/any-layer.spec.ts',
+        'modules/deck-layers/test/geoarrow-layer.spec.ts',
+        'modules/deck-layers/test/image-source-layer.spec.ts',
+        'modules/deck-layers/test/shared-tile-2d-view.spec.ts',
+        'modules/deck-layers/test/tile-2d-source-layer.spec.ts',
+        'modules/deck-layers/test/tile-3d-source-layer.spec.ts',
+        'modules/deck-layers/test/vector-source-layer.spec.ts',
         'modules/draco/test/draco-loader.spec.ts',
         'modules/draco/test/draco-writer.spec.ts',
         'modules/parquet/test/parquet-arrow-loader.spec.ts',
         'modules/parquet/test/parquetjs/integration.spec.ts',
         'modules/potree/test/potree-source.spec.ts',
         'modules/textures/test/basis-loader.spec.ts',
-        'modules/textures/test/ktx2-basis-universal-texture-writer.spec.ts'
+        'modules/textures/test/ktx2-basis-universal-texture-writer.spec.ts',
+        'modules/tiles/test/tileset/format-i3s/i3s-lod.spec.ts',
+        'modules/tiles/test/tileset/helpers/get-frame-state.spec.ts',
+        'modules/tiles/test/tileset/tileset-3d-traversal.spec.ts',
+        'modules/tiles/test/tileset/tileset-traverser.spec.ts'
       ],
       softwareGpu: Boolean(process.env.CI)
     }

--- a/.ocularrc.js
+++ b/.ocularrc.js
@@ -37,8 +37,8 @@ const config = {
   // Reusable logic lives under `dev-modules/devtools-extensions/`; repo-specific policy belongs here.
   devtools: {
     vitest: {
-      // Plain `*.spec.*` files are the browser/default suite. Only Node-only tests use `.node.spec.*`.
-      // Keep the first migration aligned with the currently imported module suite.
+      // Plain `*.spec.*` files run in both Node and browser projects unless explicitly excluded.
+      // Use `.node.spec.*`, `.browser.spec.*`, or conditional runtime helpers for runtime-specific cases.
       excludePatterns: [
         '**/*.disabled.*',
         'modules/**/wip/**',

--- a/.ocularrc.js
+++ b/.ocularrc.js
@@ -65,6 +65,20 @@ const config = {
         'test/bench/**',
         'test/render/**'
       ],
+      nodeExcludePatterns: [
+        // These shared specs currently depend on browser fetch semantics or worker entrypoints
+        // that are not valid in the Node Vitest project.
+        'modules/arrow/test/triangulate-on-worker.spec.ts',
+        'modules/compression/test/compression.spec.ts',
+        'modules/crypto/test/crypto-worker.spec.ts',
+        'modules/draco/test/draco-loader.spec.ts',
+        'modules/draco/test/draco-writer.spec.ts',
+        'modules/parquet/test/parquet-arrow-loader.spec.ts',
+        'modules/parquet/test/parquetjs/integration.spec.ts',
+        'modules/potree/test/potree-source.spec.ts',
+        'modules/textures/test/basis-loader.spec.ts',
+        'modules/textures/test/ktx2-basis-universal-texture-writer.spec.ts'
+      ],
       softwareGpu: Boolean(process.env.CI)
     }
   },

--- a/dev-modules/devtools-extensions/get-vitest-config.mjs
+++ b/dev-modules/devtools-extensions/get-vitest-config.mjs
@@ -49,7 +49,7 @@ export async function getVitestConfig(options = {}) {
   return defineConfig({
     plugins: [serveRangeRequestsPlugin(repositoryRoot)],
     optimizeDeps: {
-      include: ['get-pixels']
+      include: ['get-pixels', '@probe.gl/env']
     },
     resolve: {
       alias: [
@@ -68,14 +68,7 @@ export async function getVitestConfig(options = {}) {
             environment: 'node',
             passWithNoTests: true,
             setupFiles,
-            include: [
-              'modules/core/test/**/*.spec.{ts,js}',
-              'modules/images/test/**/*.spec.{ts,js}',
-              'modules/loader-utils/test/**/*.spec.{ts,js}',
-              'modules/polyfills/test/**/*.spec.{ts,js}',
-              'modules/**/*.node.spec.{ts,js}',
-              'test/**/*.node.spec.{ts,js}'
-            ],
+            include: ['modules/**/*.spec.{ts,js}', 'test/**/*.spec.{ts,js}'],
             exclude: [
               'modules/**/*.browser.spec.{ts,js}',
               'test/**/*.browser.spec.{ts,js}',

--- a/dev-modules/devtools-extensions/get-vitest-config.mjs
+++ b/dev-modules/devtools-extensions/get-vitest-config.mjs
@@ -20,6 +20,7 @@ export async function getVitestConfig(options = {}) {
   const vitestConfig = ocularConfig.devtools?.vitest || {};
   const tsconfigProjects = vitestConfig.tsconfigProjects || ['./tsconfig.json'];
   const excludePatterns = vitestConfig.excludePatterns || [];
+  const nodeExcludePatterns = vitestConfig.nodeExcludePatterns || [];
   const sharedExcludePatterns = ['**/node_modules/**', ...excludePatterns];
   const setupFiles = vitestConfig.setupFiles || ['./test/vitest-setup.ts'];
   const browserName = vitestConfig.browserName || 'chromium';
@@ -72,6 +73,7 @@ export async function getVitestConfig(options = {}) {
             exclude: [
               'modules/**/*.browser.spec.{ts,js}',
               'test/**/*.browser.spec.{ts,js}',
+              ...nodeExcludePatterns,
               ...sharedExcludePatterns
             ],
             browser: {

--- a/dev-modules/devtools-extensions/package.json
+++ b/dev-modules/devtools-extensions/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@biomejs/biome": "^2.4.8",
+    "@probe.gl/env": "^4.1.1",
     "@vitest/browser": "^4.0.18",
     "@vitest/browser-playwright": "^4.0.18",
     "@vitest/coverage-v8": "^4.0.18",

--- a/dev-modules/devtools-extensions/tape-test-utils.d.ts
+++ b/dev-modules/devtools-extensions/tape-test-utils.d.ts
@@ -1,2 +1,10 @@
-export {default, test} from './vitest/vitest-tape.d.ts';
+export {
+  default,
+  isBrowser,
+  isNode,
+  test,
+  testIf,
+  testIfBrowser,
+  testIfNode
+} from './vitest/vitest-tape.d.ts';
 export type {TapeTestFunction, Test} from './vitest/vitest-tape.d.ts';

--- a/dev-modules/devtools-extensions/tape-test-utils.mjs
+++ b/dev-modules/devtools-extensions/tape-test-utils.mjs
@@ -1,4 +1,10 @@
-import test from './vitest/vitest-tape.mjs';
+import test, {
+  isBrowser,
+  isNode,
+  testIf,
+  testIfBrowser,
+  testIfNode
+} from './vitest/vitest-tape.mjs';
 
-export {test};
+export {isBrowser, isNode, test, testIf, testIfBrowser, testIfNode};
 export default test;

--- a/dev-modules/devtools-extensions/vitest/vitest-tape.d.ts
+++ b/dev-modules/devtools-extensions/vitest/vitest-tape.d.ts
@@ -59,5 +59,26 @@ export type TapeTestFunction = {
 
 declare const test: TapeTestFunction;
 
+/** True when the current Vitest project is running in a browser-like runtime. */
+export declare const isBrowser: boolean;
+
+/** True when the current Vitest project is running in Node.js. */
+export declare const isNode: boolean;
+
+/**
+ * Registers a tape-style test when `condition` is true, otherwise registers it as skipped.
+ */
+export declare function testIf(condition: boolean, name: string, callback: TestCallback): unknown;
+
+/**
+ * Registers a tape-style test only in browser-like runtimes.
+ */
+export declare function testIfBrowser(name: string, callback: TestCallback): unknown;
+
+/**
+ * Registers a tape-style test only in Node.js.
+ */
+export declare function testIfNode(name: string, callback: TestCallback): unknown;
+
 export {test};
 export default test;

--- a/dev-modules/devtools-extensions/vitest/vitest-tape.mjs
+++ b/dev-modules/devtools-extensions/vitest/vitest-tape.mjs
@@ -1,4 +1,8 @@
+import {isBrowser as checkIsBrowser} from '@probe.gl/env';
 import {test as vitestTest, expect} from 'vitest';
+
+const isBrowser = checkIsBrowser();
+const isNode = !isBrowser;
 
 function isArrayBufferView(value) {
   return ArrayBuffer.isView(value);
@@ -331,12 +335,17 @@ class VitestTape {
   async run(callback) {
     try {
       const waitsForEnd = usesExplicitEndSignal(callback);
+      let callbackResult;
 
       if (this.timeoutMilliseconds === undefined) {
-        await callback(this);
+        callbackResult = callback(this);
+        if (isPromiseLike(callbackResult)) {
+          await callbackResult;
+        }
       } else {
+        callbackResult = callback(this);
         await Promise.race([
-          callback(this),
+          callbackResult,
           new Promise((_, reject) =>
             setTimeout(
               () => reject(new Error(`Test timed out after ${this.timeoutMilliseconds}ms`)),
@@ -346,7 +355,7 @@ class VitestTape {
         ]);
       }
 
-      if (waitsForEnd) {
+      if (waitsForEnd && !isPromiseLike(callbackResult)) {
         if (this.timeoutMilliseconds === undefined) {
           await this.endPromise;
         } else {
@@ -424,5 +433,17 @@ const test = wrapTest(vitestTest);
 test.only = wrapTest(vitestTest.only);
 test.skip = wrapTest(vitestTest.skip);
 
-export {test};
+function testIf(condition, name, callback) {
+  return condition ? test(name, callback) : test.skip(name, callback);
+}
+
+function testIfBrowser(name, callback) {
+  return testIf(isBrowser, name, callback);
+}
+
+function testIfNode(name, callback) {
+  return testIf(isNode, name, callback);
+}
+
+export {isBrowser, isNode, test, testIf, testIfBrowser, testIfNode};
 export default test;

--- a/dev-modules/devtools-extensions/vitest/vitest-tape.ts
+++ b/dev-modules/devtools-extensions/vitest/vitest-tape.ts
@@ -1,8 +1,15 @@
+import {isBrowser as checkIsBrowser} from '@probe.gl/env';
 import {test as vitestTest, expect} from 'vitest';
 
 type TestCallback = (test: Test) => void | Promise<void>;
 
 type MatchPattern = RegExp | string;
+
+/** True when the current Vitest project is running in a browser-like runtime. */
+export const isBrowser = checkIsBrowser();
+
+/** True when the current Vitest project is running in Node.js. */
+export const isNode = !isBrowser;
 
 function isArrayBufferView(value: unknown): value is ArrayBufferView {
   return ArrayBuffer.isView(value);
@@ -398,12 +405,17 @@ class VitestTape implements Test {
   async run(callback: TestCallback): Promise<void> {
     try {
       const waitsForEnd = usesExplicitEndSignal(callback);
+      let callbackResult: void | Promise<void>;
 
       if (this.timeoutMilliseconds === undefined) {
-        await callback(this);
+        callbackResult = callback(this);
+        if (isPromiseLike(callbackResult)) {
+          await callbackResult;
+        }
       } else {
+        callbackResult = callback(this);
         await Promise.race([
-          callback(this),
+          callbackResult,
           new Promise((_, reject) =>
             setTimeout(
               () => reject(new Error(`Test timed out after ${this.timeoutMilliseconds}ms`)),
@@ -413,7 +425,7 @@ class VitestTape implements Test {
         ]);
       }
 
-      if (waitsForEnd) {
+      if (waitsForEnd && !isPromiseLike(callbackResult)) {
         if (this.timeoutMilliseconds === undefined) {
           await this.endPromise;
         } else {
@@ -498,6 +510,37 @@ const test = wrapTest(vitestTest) as TapeTestFunction;
 
 test.only = wrapTest(vitestTest.only);
 test.skip = wrapTest(vitestTest.skip);
+
+/**
+ * Registers a tape-style test when `condition` is true, otherwise registers it as skipped.
+ */
+export function testIf(
+  condition: boolean,
+  name: string,
+  callback: TestCallback
+): ReturnType<TapeTestFunction['skip']> | ReturnType<TapeTestFunction> {
+  return condition ? test(name, callback) : test.skip(name, callback);
+}
+
+/**
+ * Registers a tape-style test only in browser-like runtimes.
+ */
+export function testIfBrowser(
+  name: string,
+  callback: TestCallback
+): ReturnType<TapeTestFunction['skip']> | ReturnType<TapeTestFunction> {
+  return testIf(isBrowser, name, callback);
+}
+
+/**
+ * Registers a tape-style test only in Node.js.
+ */
+export function testIfNode(
+  name: string,
+  callback: TestCallback
+): ReturnType<TapeTestFunction['skip']> | ReturnType<TapeTestFunction> {
+  return testIf(isNode, name, callback);
+}
 
 export {test};
 export default test;

--- a/dev-modules/devtools-extensions/vitest/vitest-tape.ts
+++ b/dev-modules/devtools-extensions/vitest/vitest-tape.ts
@@ -425,7 +425,7 @@ class VitestTape implements Test {
         ]);
       }
 
-      if (waitsForEnd && !isPromiseLike(callbackResult)) {
+      if (waitsForEnd) {
         if (this.timeoutMilliseconds === undefined) {
           await this.endPromise;
         } else {

--- a/modules/loader-utils/test/lib/test-utils/vitest-async-test-utils.spec.ts
+++ b/modules/loader-utils/test/lib/test-utils/vitest-async-test-utils.spec.ts
@@ -4,6 +4,11 @@ import {
   advanceTimersAndFlush,
   createDeferred,
   flushMicrotasks,
+  isBrowser,
+  isNode,
+  testIf,
+  testIfBrowser,
+  testIfNode,
   waitForCondition,
   withFakeTimers
 } from '@loaders.gl/test-utils/vitest';
@@ -68,4 +73,26 @@ test('vitest async utils#withFakeTimers restores timers after failure', async ()
       setTimeout(() => resolve('real timer'), 0);
     })
   ).resolves.toBe('real timer');
+});
+
+test('vitest runtime utils#runtime flags are exclusive', () => {
+  expect(isNode).toBe(!isBrowser);
+});
+
+testIf(true, 'vitest runtime utils#testIf runs enabled tests', () => {
+  expect(true).toBe(true);
+});
+
+testIf(false, 'vitest runtime utils#testIf skips disabled tests', () => {
+  throw new Error('testIf(false) should skip this test body');
+});
+
+testIfNode('vitest runtime utils#testIfNode runs only in Node.js', () => {
+  expect(isNode).toBe(true);
+  expect(isBrowser).toBe(false);
+});
+
+testIfBrowser('vitest runtime utils#testIfBrowser runs only in browser runtimes', () => {
+  expect(isBrowser).toBe(true);
+  expect(isNode).toBe(false);
 });

--- a/modules/loader-utils/test/lib/test-utils/vitest-tape-utils.spec.ts
+++ b/modules/loader-utils/test/lib/test-utils/vitest-tape-utils.spec.ts
@@ -1,0 +1,28 @@
+import test, {isBrowser, isNode, testIf, testIfBrowser, testIfNode} from 'tape-promise/tape';
+
+test('vitest tape runtime utils#runtime flags are exclusive', t => {
+  t.equal(isNode, !isBrowser);
+  t.end();
+});
+
+testIf(true, 'vitest tape runtime utils#testIf runs enabled tests', t => {
+  t.pass('testIf(true) registered the test body');
+  t.end();
+});
+
+testIf(false, 'vitest tape runtime utils#testIf skips disabled tests', t => {
+  t.fail('testIf(false) should skip this test body');
+  t.end();
+});
+
+testIfNode('vitest tape runtime utils#testIfNode runs only in Node.js', t => {
+  t.equal(isNode, true);
+  t.equal(isBrowser, false);
+  t.end();
+});
+
+testIfBrowser('vitest tape runtime utils#testIfBrowser runs only in browser runtimes', t => {
+  t.equal(isBrowser, true);
+  t.equal(isNode, false);
+  t.end();
+});

--- a/modules/parquet/test/parquetjs/integration.spec.ts
+++ b/modules/parquet/test/parquetjs/integration.spec.ts
@@ -9,6 +9,8 @@ import {BlobFile} from '@loaders.gl/loader-utils';
 import {ParquetSchema, ParquetReader, ParquetEncoder} from '@loaders.gl/parquet';
 
 const FRUITS_URL = '@loaders.gl/parquet/test/data/fruits.parquet';
+const GENERATED_PARQUET_DIRECTORY = 'tmp/test-artifacts/parquet';
+const GENERATED_PARQUET_FILE = `${GENERATED_PARQUET_DIRECTORY}/fruits.parquet`;
 const TEST_NUM_ROWS = 10000;
 const TEST_VTIME = Date.now();
 
@@ -100,9 +102,12 @@ function mkTestRows(opts) {
 }
 
 async function writeTestFile(opts) {
+  const {mkdir} = await import('node:fs/promises');
   const schema = mkTestSchema(opts);
 
-  const writer = await ParquetEncoder.openFile(schema, 'fruits.parquet', opts);
+  await mkdir(GENERATED_PARQUET_DIRECTORY, {recursive: true});
+
+  const writer = await ParquetEncoder.openFile(schema, GENERATED_PARQUET_FILE, opts);
   writer.setMetadata('myuid', '420');
   writer.setMetadata('fnord', 'dronf');
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "test-node": "node ./scripts/test.mjs node",
     "test-browser": "node ./scripts/test.mjs browser",
     "test-headless": "node ./scripts/test.mjs browser-headless",
+    "test-headless-cover": "node ./scripts/test.mjs cover-headless",
     "test-vitest-async-guardrails": "node ./scripts/check-vitest-async-guardrails.mjs",
     "playwright:install": "yarn workspace @loaders.gl/devtools-extensions playwright:install",
     "test-cover": "node ./scripts/test.mjs cover",
@@ -64,6 +65,7 @@
   "devDependencies": {
     "@loaders.gl/devtools-extensions": "workspace:*",
     "@probe.gl/bench": "^4.1.1",
+    "@probe.gl/env": "^4.1.1",
     "@probe.gl/test-utils": "^4.1.1",
     "@types/node": "^25.3.0",
     "@types/tape-promise": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "test-node": "node ./scripts/test.mjs node",
     "test-browser": "node ./scripts/test.mjs browser",
     "test-headless": "node ./scripts/test.mjs browser-headless",
+    "test-node-cover": "node ./scripts/test.mjs cover-node",
     "test-headless-cover": "node ./scripts/test.mjs cover-headless",
     "test-vitest-async-guardrails": "node ./scripts/check-vitest-async-guardrails.mjs",
     "playwright:install": "yarn workspace @loaders.gl/devtools-extensions playwright:install",

--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -13,12 +13,33 @@ const modeArguments = {
   browser: ['run', '--config', VITEST_CONFIG, '--project', 'browser'],
   'browser-headless': ['run', '--config', VITEST_CONFIG, '--project', 'headless'],
   full: ['run', '--config', VITEST_CONFIG, '--project', 'node', '--project', 'headless'],
-  'cover-headless': ['run', '--config', VITEST_CONFIG, '--coverage', '--project', 'headless'],
+  'cover-node': [
+    'run',
+    '--config',
+    VITEST_CONFIG,
+    '--coverage',
+    '--testTimeout',
+    '60000',
+    '--project',
+    'node'
+  ],
+  'cover-headless': [
+    'run',
+    '--config',
+    VITEST_CONFIG,
+    '--coverage',
+    '--testTimeout',
+    '60000',
+    '--project',
+    'headless'
+  ],
   cover: [
     'run',
     '--config',
     VITEST_CONFIG,
     '--coverage',
+    '--testTimeout',
+    '60000',
     '--project',
     'node',
     '--project',
@@ -80,6 +101,7 @@ Modes:
   node             Run Node-only tests
   browser          Run browser tests in a headed browser
   browser-headless Run browser tests in a headless browser
+  cover-node       Run Node-only tests with coverage
   cover-headless   Run headless browser tests with coverage
   cover            Run Node-only and headless browser tests with coverage
 `);

--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -13,6 +13,7 @@ const modeArguments = {
   browser: ['run', '--config', VITEST_CONFIG, '--project', 'browser'],
   'browser-headless': ['run', '--config', VITEST_CONFIG, '--project', 'headless'],
   full: ['run', '--config', VITEST_CONFIG, '--project', 'node', '--project', 'headless'],
+  'cover-headless': ['run', '--config', VITEST_CONFIG, '--coverage', '--project', 'headless'],
   cover: [
     'run',
     '--config',
@@ -79,6 +80,7 @@ Modes:
   node             Run Node-only tests
   browser          Run browser tests in a headed browser
   browser-headless Run browser tests in a headless browser
+  cover-headless   Run headless browser tests with coverage
   cover            Run Node-only and headless browser tests with coverage
 `);
 }

--- a/test/vitest-async-test-utils.ts
+++ b/test/vitest-async-test-utils.ts
@@ -1,4 +1,60 @@
-import {vi} from 'vitest';
+import {isBrowser as checkIsBrowser} from '@probe.gl/env';
+import {test as vitestTest, vi, type TestFunction, type TestOptions} from 'vitest';
+
+/** True when the current Vitest project is running in a browser-like runtime. */
+export const isBrowser = checkIsBrowser();
+
+/** True when the current Vitest project is running in Node.js. */
+export const isNode = !isBrowser;
+
+/** Options accepted by Vitest's test registration API. */
+export type ConditionalTestOptions = number | TestOptions;
+
+/**
+ * Registers a Vitest test when `condition` is true, otherwise registers it as skipped.
+ */
+export function testIf(
+  condition: boolean,
+  name: string,
+  testFunction: TestFunction,
+  options?: ConditionalTestOptions
+): void {
+  const testImplementation = condition ? vitestTest : vitestTest.skip;
+
+  if (options === undefined) {
+    testImplementation(name, testFunction);
+    return;
+  }
+
+  if (typeof options === 'number') {
+    testImplementation(name, testFunction, options);
+    return;
+  }
+
+  testImplementation(name, options, testFunction);
+}
+
+/**
+ * Registers a Vitest test only in browser-like runtimes.
+ */
+export function testIfBrowser(
+  name: string,
+  testFunction: TestFunction,
+  options?: ConditionalTestOptions
+): void {
+  testIf(isBrowser, name, testFunction, options);
+}
+
+/**
+ * Registers a Vitest test only in Node.js.
+ */
+export function testIfNode(
+  name: string,
+  testFunction: TestFunction,
+  options?: ConditionalTestOptions
+): void {
+  testIf(isNode, name, testFunction, options);
+}
 
 /** Deferred promise handles used to orchestrate callback-driven async tests. */
 export type Deferred<T> = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5197,6 +5197,7 @@ __metadata:
   resolution: "@loaders.gl/devtools-extensions@workspace:dev-modules/devtools-extensions"
   dependencies:
     "@biomejs/biome": "npm:^2.4.8"
+    "@probe.gl/env": "npm:^4.1.1"
     "@vitest/browser": "npm:^4.0.18"
     "@vitest/browser-playwright": "npm:^4.0.18"
     "@vitest/coverage-v8": "npm:^4.0.18"
@@ -23161,6 +23162,7 @@ __metadata:
   dependencies:
     "@loaders.gl/devtools-extensions": "workspace:*"
     "@probe.gl/bench": "npm:^4.1.1"
+    "@probe.gl/env": "npm:^4.1.1"
     "@probe.gl/test-utils": "npm:^4.1.1"
     "@types/node": "npm:^25.3.0"
     "@types/tape-promise": "npm:^4.0.1"


### PR DESCRIPTION
## Goals

- Let shared `*.spec.ts` tests run in both Node and headless browser projects, with runtime-only cases skipped inside the file.
- Split CI so primary Node tests and primary headless coverage tests run as separate jobs.
- Keep generated test artifacts out of the repo root and out of `git status`.

## Changes

- Added runtime conditional test helpers for Vitest:
  - `isBrowser`
  - `isNode`
  - `testIf`
  - `testIfBrowser`
  - `testIfNode`
- Exported matching runtime flags and `testIf*` helpers from the tape/Vitest shim used by `tape-promise/tape`.
- Expanded the Vitest Node project to include shared `modules/**/*.spec.{ts,js}` and `test/**/*.spec.{ts,js}` files.
- Added Node-only exclude patterns for shared specs that still depend on browser fetch semantics or worker entrypoints.
- Updated Vitest config comments to make shared specs the default policy, with `.node.spec.*`, `.browser.spec.*`, or conditional helpers for runtime-specific cases.
- Added helper coverage for enabled/skipped conditional tests and Node/browser runtime helpers.
- Split CI matrix entries so Node 24 runs a dedicated Node test job, while the separate Node 24 coverage job runs headless tests only.
- Added `test-headless-cover` for headless-only coverage.
- Moved generated Parquet test output from repo-root `fruits.parquet` to `tmp/test-artifacts/parquet/fruits.parquet`, which is gitignored.

## Test Plan

- `env -u YARN_NO_PROXY corepack yarn`
- `env -u YARN_NO_PROXY corepack yarn build`
- `env -u YARN_NO_PROXY corepack yarn test-node`
- `env -u YARN_NO_PROXY corepack yarn test-headless`
- `env -u YARN_NO_PROXY corepack yarn lint fix`
