### PR TITLE
fix(json) Only emit batches when we have complete elements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,25 +17,25 @@ jobs:
         include:
           - node-version: 24
             coverage: true
-            coverage-flag: node
+            coverage-artifact: coverage-node
             playwright: false
             scope: 'node tests'
             test-command: test-node-cover
           - node-version: 24
             coverage: true
-            coverage-flag: headless
+            coverage-artifact: coverage-headless
             playwright: true
             scope: 'headless tests'
             test-command: test-headless-cover
           - node-version: 22
             coverage: false
-            coverage-flag: ''
+            coverage-artifact: ''
             playwright: false
             scope: 'node tests'
             test-command: test-node
           - node-version: 20
             coverage: false
-            coverage-flag: ''
+            coverage-artifact: ''
             playwright: false
             scope: 'node tests'
             test-command: test-node
@@ -120,31 +120,37 @@ jobs:
           fs.writeFileSync(coveragePath, `${records.join('\n')}\n`);
           NODE
 
-      - name: Upload coverage to Coveralls
+      - name: Upload coverage artifact
         if: matrix.coverage
-        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
+        uses: actions/upload-artifact@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          file: coverage/lcov.info
-          format: lcov
-          flag-name: ${{ matrix.coverage-flag }}
-          parallel: true
-          fail-on-error: false
+          name: ${{ matrix.coverage-artifact }}
+          path: coverage/lcov.info
+          if-no-files-found: error
 
-  finish-coverage:
-    name: Finish coverage
+  upload-coverage:
+    name: Upload coverage
     needs: test
-    if: ${{ always() }}
     runs-on: ubuntu-22.04
     timeout-minutes: 5
 
     steps:
-      - name: Close Coveralls parallel build
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-*
+          merge-multiple: false
+          path: coverage-artifacts
+
+      - name: Upload combined coverage to Coveralls
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel-finished: true
-          carryforward: node,headless
+          files: coverage-artifacts/coverage-node/lcov.info coverage-artifacts/coverage-headless/lcov.info
+          format: lcov
           fail-on-error: false
 
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,11 +145,128 @@ jobs:
           merge-multiple: false
           path: coverage-artifacts
 
+      - name: Merge coverage reports
+        run: |
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+
+          const coverageFiles = [
+            'coverage-artifacts/coverage-node/lcov.info',
+            'coverage-artifacts/coverage-headless/lcov.info'
+          ];
+
+          const reports = new Map();
+          for (const coverageFile of coverageFiles) {
+            const records = fs.readFileSync(coverageFile, 'utf8').split('end_of_record');
+            for (const recordText of records) {
+              const lines = recordText.split(/\r?\n/).filter(Boolean);
+              const sourceFileLine = lines.find(line => line.startsWith('SF:'));
+              if (!sourceFileLine) {
+                continue;
+              }
+
+              const sourceFile = sourceFileLine.slice(3);
+              const report = reports.get(sourceFile) || {
+                sourceFile,
+                testName: '',
+                functions: new Map(),
+                functionData: new Map(),
+                branches: new Map(),
+                lines: new Map()
+              };
+
+              for (const line of lines) {
+                if (line.startsWith('TN:') && !report.testName) {
+                  report.testName = line.slice(3);
+                } else if (line.startsWith('FN:')) {
+                  const [, lineNumber, functionName] = line.match(/^FN:(\d+),(.+)$/) || [];
+                  if (lineNumber && functionName) {
+                    report.functions.set(functionName, Number(lineNumber));
+                  }
+                } else if (line.startsWith('FNDA:')) {
+                  const [, hits, functionName] = line.match(/^FNDA:(\d+),(.+)$/) || [];
+                  if (hits && functionName) {
+                    report.functionData.set(
+                      functionName,
+                      (report.functionData.get(functionName) || 0) + Number(hits)
+                    );
+                  }
+                } else if (line.startsWith('BRDA:')) {
+                  const [, block, branch, branchIndex, hits] =
+                    line.match(/^BRDA:(\d+),(\d+),(\d+),(.+)$/) || [];
+                  if (block && branch && branchIndex && hits) {
+                    const branchKey = `${block},${branch},${branchIndex}`;
+                    const hitCount = hits === '-' ? 0 : Number(hits);
+                    report.branches.set(branchKey, (report.branches.get(branchKey) || 0) + hitCount);
+                  }
+                } else if (line.startsWith('DA:')) {
+                  const [, lineNumber, hits] = line.match(/^DA:(\d+),(\d+)$/) || [];
+                  if (lineNumber && hits) {
+                    report.lines.set(
+                      Number(lineNumber),
+                      (report.lines.get(Number(lineNumber)) || 0) + Number(hits)
+                    );
+                  }
+                }
+              }
+
+              reports.set(sourceFile, report);
+            }
+          }
+
+          const output = [];
+          for (const report of [...reports.values()].sort((left, right) =>
+            left.sourceFile.localeCompare(right.sourceFile)
+          )) {
+            output.push(`TN:${report.testName}`, `SF:${report.sourceFile}`);
+
+            for (const [functionName, lineNumber] of [...report.functions.entries()].sort(
+              (left, right) => left[1] - right[1] || left[0].localeCompare(right[0])
+            )) {
+              output.push(`FN:${lineNumber},${functionName}`);
+            }
+            for (const [functionName, hits] of [...report.functionData.entries()].sort(
+              (left, right) => left[0].localeCompare(right[0])
+            )) {
+              output.push(`FNDA:${hits},${functionName}`);
+            }
+            output.push(
+              `FNF:${report.functions.size}`,
+              `FNH:${[...report.functionData.values()].filter(hits => hits > 0).length}`
+            );
+
+            for (const [branchKey, hits] of [...report.branches.entries()].sort((left, right) =>
+              left[0].localeCompare(right[0], undefined, {numeric: true})
+            )) {
+              output.push(`BRDA:${branchKey},${hits}`);
+            }
+            output.push(
+              `BRF:${report.branches.size}`,
+              `BRH:${[...report.branches.values()].filter(hits => hits > 0).length}`
+            );
+
+            for (const [lineNumber, hits] of [...report.lines.entries()].sort(
+              (left, right) => left[0] - right[0]
+            )) {
+              output.push(`DA:${lineNumber},${hits}`);
+            }
+            output.push(
+              `LF:${report.lines.size}`,
+              `LH:${[...report.lines.values()].filter(hits => hits > 0).length}`,
+              'end_of_record'
+            );
+          }
+
+          fs.mkdirSync('coverage', {recursive: true});
+          fs.writeFileSync(path.join('coverage', 'lcov.info'), `${output.join('\n')}\n`);
+          NODE
+
       - name: Upload combined coverage to Coveralls
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          files: coverage-artifacts/coverage-node/lcov.info coverage-artifacts/coverage-headless/lcov.info
+          file: coverage/lcov.info
           format: lcov
           fail-on-error: false
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,25 +17,25 @@ jobs:
         include:
           - node-version: 24
             coverage: true
-            coverage-artifact: coverage-node
+            coverage-flag: node
             playwright: false
             scope: 'node tests'
             test-command: test-node-cover
           - node-version: 24
             coverage: true
-            coverage-artifact: coverage-headless
+            coverage-flag: headless
             playwright: true
             scope: 'headless tests'
             test-command: test-headless-cover
           - node-version: 22
             coverage: false
-            coverage-artifact: ''
+            coverage-flag: ''
             playwright: false
             scope: 'node tests'
             test-command: test-node
           - node-version: 20
             coverage: false
-            coverage-artifact: ''
+            coverage-flag: ''
             playwright: false
             scope: 'node tests'
             test-command: test-node
@@ -120,154 +120,14 @@ jobs:
           fs.writeFileSync(coveragePath, `${records.join('\n')}\n`);
           NODE
 
-      - name: Upload coverage artifact
+      - name: Upload coverage to Coveralls
         if: matrix.coverage
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.coverage-artifact }}
-          path: coverage/lcov.info
-          if-no-files-found: error
-
-  upload-coverage:
-    name: Upload coverage
-    needs: test
-    runs-on: ubuntu-22.04
-    timeout-minutes: 5
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Download coverage artifacts
-        uses: actions/download-artifact@v4
-        with:
-          pattern: coverage-*
-          merge-multiple: false
-          path: coverage-artifacts
-
-      - name: Merge coverage reports
-        run: |
-          node - <<'NODE'
-          const fs = require('fs');
-          const path = require('path');
-
-          const coverageFiles = [
-            'coverage-artifacts/coverage-node/lcov.info',
-            'coverage-artifacts/coverage-headless/lcov.info'
-          ];
-
-          const reports = new Map();
-          for (const coverageFile of coverageFiles) {
-            const records = fs.readFileSync(coverageFile, 'utf8').split('end_of_record');
-            for (const recordText of records) {
-              const lines = recordText.split(/\r?\n/).filter(Boolean);
-              const sourceFileLine = lines.find(line => line.startsWith('SF:'));
-              if (!sourceFileLine) {
-                continue;
-              }
-
-              const sourceFile = sourceFileLine.slice(3);
-              const report = reports.get(sourceFile) || {
-                sourceFile,
-                testName: '',
-                functions: new Map(),
-                functionData: new Map(),
-                branches: new Map(),
-                lines: new Map()
-              };
-
-              for (const line of lines) {
-                if (line.startsWith('TN:') && !report.testName) {
-                  report.testName = line.slice(3);
-                } else if (line.startsWith('FN:')) {
-                  const [, lineNumber, functionName] = line.match(/^FN:(\d+),(.+)$/) || [];
-                  if (lineNumber && functionName) {
-                    report.functions.set(functionName, Number(lineNumber));
-                  }
-                } else if (line.startsWith('FNDA:')) {
-                  const [, hits, functionName] = line.match(/^FNDA:(\d+),(.+)$/) || [];
-                  if (hits && functionName) {
-                    report.functionData.set(
-                      functionName,
-                      (report.functionData.get(functionName) || 0) + Number(hits)
-                    );
-                  }
-                } else if (line.startsWith('BRDA:')) {
-                  const [, block, branch, branchIndex, hits] =
-                    line.match(/^BRDA:(\d+),(\d+),(\d+),(.+)$/) || [];
-                  if (block && branch && branchIndex && hits) {
-                    const branchKey = `${block},${branch},${branchIndex}`;
-                    const hitCount = hits === '-' ? 0 : Number(hits);
-                    report.branches.set(branchKey, (report.branches.get(branchKey) || 0) + hitCount);
-                  }
-                } else if (line.startsWith('DA:')) {
-                  const [, lineNumber, hits] = line.match(/^DA:(\d+),(\d+)$/) || [];
-                  if (lineNumber && hits) {
-                    report.lines.set(
-                      Number(lineNumber),
-                      (report.lines.get(Number(lineNumber)) || 0) + Number(hits)
-                    );
-                  }
-                }
-              }
-
-              reports.set(sourceFile, report);
-            }
-          }
-
-          const output = [];
-          for (const report of [...reports.values()].sort((left, right) =>
-            left.sourceFile.localeCompare(right.sourceFile)
-          )) {
-            output.push(`TN:${report.testName}`, `SF:${report.sourceFile}`);
-
-            for (const [functionName, lineNumber] of [...report.functions.entries()].sort(
-              (left, right) => left[1] - right[1] || left[0].localeCompare(right[0])
-            )) {
-              output.push(`FN:${lineNumber},${functionName}`);
-            }
-            for (const [functionName, hits] of [...report.functionData.entries()].sort(
-              (left, right) => left[0].localeCompare(right[0])
-            )) {
-              output.push(`FNDA:${hits},${functionName}`);
-            }
-            output.push(
-              `FNF:${report.functions.size}`,
-              `FNH:${[...report.functionData.values()].filter(hits => hits > 0).length}`
-            );
-
-            for (const [branchKey, hits] of [...report.branches.entries()].sort((left, right) =>
-              left[0].localeCompare(right[0], undefined, {numeric: true})
-            )) {
-              output.push(`BRDA:${branchKey},${hits}`);
-            }
-            output.push(
-              `BRF:${report.branches.size}`,
-              `BRH:${[...report.branches.values()].filter(hits => hits > 0).length}`
-            );
-
-            for (const [lineNumber, hits] of [...report.lines.entries()].sort(
-              (left, right) => left[0] - right[0]
-            )) {
-              output.push(`DA:${lineNumber},${hits}`);
-            }
-            output.push(
-              `LF:${report.lines.size}`,
-              `LH:${[...report.lines.values()].filter(hits => hits > 0).length}`,
-              'end_of_record'
-            );
-          }
-
-          fs.mkdirSync('coverage', {recursive: true});
-          fs.writeFileSync(path.join('coverage', 'lcov.info'), `${output.join('\n')}\n`);
-          NODE
-
-      - name: Upload combined coverage to Coveralls
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: coverage/lcov.info
           format: lcov
+          flag-name: ${{ matrix.coverage-flag }}
           fail-on-error: false
 
   build:

--- a/modules/json/src/lib/json-parser/streaming-json-parser.ts
+++ b/modules/json/src/lib/json-parser/streaming-json-parser.ts
@@ -10,9 +10,15 @@ import JSONPath from '../jsonpath/jsonpath';
  * and emits an array of chunks
  */
 export default class StreamingJSONParser extends JSONParser {
+  /** JSONPaths that identify arrays eligible for streaming. */
   private jsonPaths: JSONPath[];
+  /** JSONPath of the selected streaming array. */
   private streamingJsonPath: JSONPath | null = null;
+  /** Parser-owned array for the selected streaming rows. */
   private streamingArray: any[] | null = null;
+  /** Number of direct streaming-array children that are fully parsed and ready to emit. */
+  private completedStreamingRowCount: number = 0;
+  /** Root object used by metadata batches when streaming an embedded array. */
   private topLevelObject: object | null = null;
 
   constructor(options: {[key: string]: any} = {}) {
@@ -42,6 +48,30 @@ export default class StreamingJSONParser extends JSONParser {
         if (typeof name !== 'undefined') {
           this.parser.emit('onkey', name);
         }
+      },
+
+      oncloseobject: () => {
+        const directStreamingChild = this._isClosingDirectStreamingChild();
+        this._closeObject();
+        if (directStreamingChild) {
+          this.completedStreamingRowCount++;
+        }
+      },
+
+      onclosearray: () => {
+        const directStreamingChild = this._isClosingDirectStreamingChild();
+        this._closeArray();
+        if (directStreamingChild) {
+          this.completedStreamingRowCount++;
+        }
+      },
+
+      onvalue: value => {
+        const directStreamingValue = this._isInStreamingArray();
+        this._pushOrSet(value);
+        if (directStreamingValue) {
+          this.completedStreamingRowCount++;
+        }
       }
     });
     const jsonpaths = options.jsonpaths || [];
@@ -57,12 +87,7 @@ export default class StreamingJSONParser extends JSONParser {
    */
   write(chunk) {
     super.write(chunk);
-    let array: any[] = [];
-    if (this.streamingArray) {
-      array = [...this.streamingArray];
-      this.streamingArray.length = 0;
-    }
-    return array;
+    return this._drainCompletedRows();
   }
 
   /**
@@ -87,6 +112,41 @@ export default class StreamingJSONParser extends JSONParser {
   }
 
   // PRIVATE METHODS
+
+  /**
+   * Returns completed rows and removes them from the parser-owned streaming array.
+   */
+  _drainCompletedRows(): any[] {
+    if (!this.streamingArray || this.completedStreamingRowCount === 0) {
+      return [];
+    }
+
+    const rows = this.streamingArray.slice(0, this.completedStreamingRowCount);
+    this.streamingArray.splice(0, this.completedStreamingRowCount);
+    this.completedStreamingRowCount = 0;
+    return rows;
+  }
+
+  /**
+   * Checks whether the parser is currently writing a direct value into the streaming array.
+   */
+  _isInStreamingArray(): boolean {
+    return Boolean(this.streamingArray && this.currentState.container === this.streamingArray);
+  }
+
+  /**
+   * Checks whether the current close event completes a direct streaming-array child.
+   */
+  _isClosingDirectStreamingChild(): boolean {
+    if (!this.streamingArray || this.currentState.container === this.streamingArray) {
+      return false;
+    }
+
+    const parentState = (this.previousStates as Array<{container: unknown}>)[
+      this.previousStates.length - 1
+    ];
+    return parentState?.container === this.streamingArray;
+  }
 
   /**
    * Checks is this.getJsonPath matches the jsonpaths provided in options

--- a/modules/json/test/json-loader.spec.ts
+++ b/modules/json/test/json-loader.spec.ts
@@ -84,6 +84,45 @@ test('JSONLoader#loadInBatches(geojson.json, rows, batchSize = 10)', async t => 
   t.end();
 });
 
+test('JSONLoader#parseInBatches(complete rows with nested arrays)', async t => {
+  const valueCount = 2048;
+  const rows = Array.from({length: 3}, (_, rowIndex) => ({
+    text: `row-${rowIndex}`,
+    values: Array.from({length: valueCount}, (_, valueIndex) => rowIndex * valueCount + valueIndex)
+  }));
+
+  const iterator = JSONLoader.parseInBatches?.(makeChunkedTextIterator(JSON.stringify(rows), 128), {
+    batchSize: 1
+  });
+
+  t.ok(iterator, 'parseInBatches returned iterator');
+  if (!iterator) {
+    t.end();
+    return;
+  }
+
+  let emittedRowCount = 0;
+  for await (const batch of iterator) {
+    if (batch.batchType === 'data') {
+      t.equal(batch.length, 1, 'fixed-size batch contains one complete row');
+      for (const row of batch.data) {
+        const expectedFirstValue = emittedRowCount * valueCount;
+        emittedRowCount++;
+        t.equal(row.values.length, valueCount, 'nested values array is complete when emitted');
+        t.equal(row.values[0], expectedFirstValue, 'first nested value is preserved');
+        t.equal(
+          row.values[valueCount - 1],
+          expectedFirstValue + valueCount - 1,
+          'last nested value is preserved'
+        );
+      }
+    }
+  }
+
+  t.equal(emittedRowCount, rows.length, 'all rows were emitted');
+  t.end();
+});
+
 test('JSONLoader#loadInBatches(jsonpaths)', async t => {
   let iterator = await loadInBatches(GEOJSON_PATH, JSONLoader, {
     json: {jsonpaths: ['$.features']}
@@ -247,3 +286,11 @@ test('JSONLoader#loadInBatches(streaming array of arrays)', async t => {
 
   t.end();
 });
+
+/** Emits UTF-8 JSON text chunks for streaming parser tests. */
+async function* makeChunkedTextIterator(text: string, chunkSize: number) {
+  const textEncoder = new TextEncoder();
+  for (let index = 0; index < text.length; index += chunkSize) {
+    yield textEncoder.encode(text.slice(index, index + chunkSize));
+  }
+}


### PR DESCRIPTION
## Goals

Fix JSON streaming so `JSONLoader.parseInBatches` only emits complete elements from the selected streaming array, resolving cases where nested arrays could appear truncated when rows were emitted at chunk boundaries.

Fixes #2274

## Changes

- Track completed direct children of the selected streaming array in `StreamingJSONParser`.
- Drain only fully parsed direct array elements into `data` batches.
- Preserve memory cleanup by removing emitted rows from the parser-owned streaming array.
- Add regression coverage for chunked root-array streaming with nested 2048-value arrays and `batchSize: 1`.

## Validation

- `corepack yarn`
- `corepack yarn build`
- `corepack yarn test-node`
- `corepack yarn test-headless`
- `corepack yarn lint fix`
- `git diff --check`
