### PR TITLE
chore: Standardize and optimize geospatial loaders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,9 @@
 - Keep the upgrade guide focused on deleted or deprecated functionality. New feature documentation belongs in the module docs and release notes instead.
 - Running module- or file-scoped commands such as `tsc` tends to generate `.js` and `.d.ts` files in this repo. After such commands, check for generated files and remove them before finishing.
 - Running tests that use workers requires `yarn build` first so the worker bundles exist before the tests run.
+- `@loaders.gl/gis` should expose the minimal helper set loaders need to create returned geometries, in particular `geoarrow.wkb` geometry columns.
+- `@loaders.gl/geoarrow` should provide the richer converter and processing APIs for geospatial tables, especially GeoArrow-formatted Arrow tables.
+- Loaders should not import the larger `@loaders.gl/geoarrow` module; applications can install and use it when they need more extensive geospatial processing.
 
 ## Loader module structure
 

--- a/docs/modules/csv/api-reference/csv-loader.md
+++ b/docs/modules/csv/api-reference/csv-loader.md
@@ -69,6 +69,10 @@ const typedTable = await load(url, CSVLoader, {
 
 For the default `csv.dynamicTyping: false` Arrow path, `CSVLoader.parse(ArrayBuffer)` uses a byte-oriented parser for supported CSV options and creates Arrow `Utf8` columns without materializing per-cell JavaScript strings. `CSVLoader.parseText` encodes text to UTF-8 and uses the same byte-oriented path when possible. `CSVLoader.parseInBatches` uses the byte-oriented path when the input can be emitted as one batch, and keeps the streaming string parser for explicit batch sizes.
 
+### Geometry Columns
+
+`CSVLoader` can detect WKT and hex-encoded WKB geometry columns when `csv.detectGeometryColumns` is enabled. Detected geometries are emitted as `geoarrow.wkb` by default. Set `csv.geometryEncoding: 'source'` to preserve WKT columns as `geoarrow.wkt`.
+
 ## CSVLoader Options
 
 | Option                      | Type                                                                                       | Default                       | Description                                                                                                                  |
@@ -83,6 +87,7 @@ For the default `csv.dynamicTyping: false` Arrow path, `CSVLoader.parse(ArrayBuf
 | `csv.comments`              | `boolean`                                                                                  | `false`                       | Skip lines that start with a comment indicator.                                                                              |
 | `csv.skipEmptyLines`        | `boolean \| 'greedy'`                                                                      | `true`                        | Skip empty lines; `'greedy'` also skips lines that only contain whitespace.                                                  |
 | `csv.detectGeometryColumns` | `boolean`                                                                                  | `false`                       | Detect geometry columns when producing geospatial table output.                                                              |
+| `csv.geometryEncoding`      | `'wkb' \| 'source'`                                                                        | `wkb`                         | Output encoding for detected geometry columns. `wkb` normalizes WKT and WKB to `geoarrow.wkb`; `source` preserves WKT.       |
 | `csv.delimitersToGuess`     | `string[]`                                                                                 | `[',', '\t', '\|', ';']`      | Delimiters to try when no delimiter is specified.                                                                            |
 
 ## Remarks

--- a/docs/modules/flatgeobuf/api-reference/flatgeobuf-loader.md
+++ b/docs/modules/flatgeobuf/api-reference/flatgeobuf-loader.md
@@ -38,7 +38,7 @@ const arrowTable = await load(url, FlatGeobufLoader, {
 | `geojson-table`    | loaders.gl GeoJSON table              |
 | `arrow-table`      | loaders.gl `ArrowTable` with WKB geometry |
 | `columnar-table`   | loaders.gl columnar table             |
-| `binary`           | loaders.gl binary feature collection  |
+| `binary-geometry`  | loaders.gl binary feature collection  |
 
 ### GeoJSONTable
 
@@ -52,7 +52,7 @@ Set `flatgeobuf.shape` to `'arrow-table'` to return an Apache Arrow table that p
 
 | Option             | Type                                                     | Default           | Description                                                       |
 | ------------------ | -------------------------------------------------------- | ----------------- | ----------------------------------------------------------------- |
-| flatgeobuf.shape   | `string`                                                 | `'geojson-table'` | Output shape: `'geojson-table'`, `'arrow-table'`, `'columnar-table'`, or `'binary'`. |
+| flatgeobuf.shape   | `string`                                                 | `'geojson-table'` | Output shape: `'geojson-table'`, `'arrow-table'`, `'columnar-table'`, or `'binary-geometry'`. |
 | gis.reproject      | boolean                                                  | `false`           | Whether to reproject input data into the WGS84 coordinate system. |
 
 ## Remarks

--- a/docs/modules/kml/api-reference/gpx-loader.md
+++ b/docs/modules/kml/api-reference/gpx-loader.md
@@ -30,7 +30,7 @@ const data = await load(url, GPXLoader, options);
 | `geojson-table`      | loaders.gl GeoJSON table                     |
 | `object-row-table`   | loaders.gl row table with GeoJSON features   |
 | `arrow-table`        | loaders.gl `ArrowTable` with WKB geometry    |
-| `binary`             | loaders.gl binary feature collection         |
+| `binary-geometry`    | loaders.gl binary feature collection         |
 
 ## Options
 

--- a/docs/modules/kml/api-reference/tcx-loader.md
+++ b/docs/modules/kml/api-reference/tcx-loader.md
@@ -30,7 +30,7 @@ const data = await load(url, TCXLoader, options);
 | `geojson-table`      | loaders.gl GeoJSON table                     |
 | `object-row-table`   | loaders.gl row table with GeoJSON features   |
 | `arrow-table`        | loaders.gl `ArrowTable` with WKB geometry    |
-| `binary`             | loaders.gl binary feature collection         |
+| `binary-geometry`    | loaders.gl binary feature collection         |
 
 ## Options
 

--- a/docs/modules/mlt/api-reference/mlt-loader.md
+++ b/docs/modules/mlt/api-reference/mlt-loader.md
@@ -67,15 +67,14 @@ const geoJSONfeatures = await load(url, MLTLoader, {
 
 | `shape` option        | Output                    |
 | --------------------- | ------------------------- |
-| `'geojson'` (default) | `Feature[]`               |
-| `'geojson-table'`     | `GeoJSONTable`            |
-| `'binary'`            | binary feature collection |
+| `'geojson-table'` (default) | `GeoJSONTable`            |
+| `'binary-geometry'`         | binary feature collection |
 
 ## Options
 
 | Option              | Type                                       | Default     | Description                                                    |
 | ------------------- | ------------------------------------------ | ----------- | -------------------------------------------------------------- |
-| `mlt.shape`         | `'geojson-table' \| 'geojson' \| 'binary'` | `geojson`   | Output shape: GeoJSON array, GeoJSON table, or binary features |
+| `mlt.shape`         | `'geojson-table' \| 'binary-geometry'` | `geojson-table` | Output shape: GeoJSON table or binary geometry |
 | `mlt.coordinates`   | `'local' \| 'wgs84'`                       | `local`     | Coordinate system for returned geometries                      |
 | `mlt.tileIndex`     | `{x: number, y: number, z: number}`        | N/A         | Required when `coordinates` is `wgs84`                         |
 | `mlt.layerProperty` | `string`                                   | `layerName` | Name of layer property added to feature properties             |
@@ -90,4 +89,4 @@ const geoJSONfeatures = await load(url, MLTLoader, {
 
 ## Attribution
 
-`MLTLoader` implements loaders.gl integration, GeoJSON/binary shaping, and coordinate projection around the [@maplibre/mlt](https://github.com/maplibre/mlt) decoder and the [MapLibre Tile specification](https://github.com/maplibre/maplibre-tile-spec).
+`MLTLoader` implements loaders.gl integration, GeoJSON table and binary geometry shaping, and coordinate projection around the [@maplibre/mlt](https://github.com/maplibre/mlt) decoder and the [MapLibre Tile specification](https://github.com/maplibre/maplibre-tile-spec).

--- a/docs/modules/mlt/api-reference/mlt-source-loader.md
+++ b/docs/modules/mlt/api-reference/mlt-source-loader.md
@@ -25,13 +25,13 @@ const features = await source.getTile({x: 0, y: 0, z: 0});
 
 ## Options
 
-| Option            | Type                | Default      | Description                                     |
-| ----------------- | ------------------- | ------------ | ----------------------------------------------- | ----------------------------------------------------------------------- | ------------------------ |
-| `mlt.extension`   | `string`            | `.mlt`       | Tile URL extension.                             |
-| `mlt.metadataUrl` | `string \\          | null`        | `null`                                          | Optional metadata URL override (`tile.json` by default is not assumed). |
-| `mlt.coordinates` | `'wgs84' \\         | 'local'`     | `wgs84`                                         | Coordinates output from parsed tiles.                                   |
-| `mlt.shape`       | `'geojson-table' \\ | 'geojson' \\ | 'binary'`                                       | `geojson`                                                               | Returned geometry shape. |
-| `mlt.layers`      | `string[]`          | `N/A`        | Optional layer filter before decoding geometry. |
+| Option            | Type                                      | Default           | Description                                                        |
+| ----------------- | ----------------------------------------- | ----------------- | ------------------------------------------------------------------ |
+| `mlt.extension`   | `string`                                  | `.mlt`            | Tile URL extension.                                                |
+| `mlt.metadataUrl` | `string \| null`                          | `null`            | Optional metadata URL override (`tile.json` by default is not assumed). |
+| `mlt.coordinates` | `'wgs84' \| 'local'`                      | `wgs84`           | Coordinates output from parsed tiles.                              |
+| `mlt.shape`       | `'geojson-table' \| 'binary-geometry'`    | `geojson-table`   | Returned geometry shape.                                           |
+| `mlt.layers`      | `string[]`                                | `N/A`             | Optional layer filter before decoding geometry.                    |
 
 ## Additional references
 

--- a/docs/modules/mlt/formats/mlt.md
+++ b/docs/modules/mlt/formats/mlt.md
@@ -13,7 +13,7 @@ import {TileDocsTabs} from '@site/src/components/docs/tile-docs-tabs';
 A MapLibre Tile (MLT) file is a binary geospatial tile format used by vector tile services and tooling.
 
 The format stores one or more named feature tables, each containing geometry and attributes for a tile.
-`MLTLoader` decodes these tables into GeoJSON features, or binary data when `shape: 'binary'` is selected.
+`MLTLoader` decodes these tables into GeoJSON tables, or binary geometry data when `shape: 'binary-geometry'` is selected.
 
 ## File format
 

--- a/docs/modules/mvt/api-reference/mvt-loader.md
+++ b/docs/modules/mvt/api-reference/mvt-loader.md
@@ -87,13 +87,13 @@ const geoJSONfeatures = await load(url, MVTLoader);
 
 ## Options
 
-| Option            | Type                                | Default       | Description                                                                                                                                             |
-| ----------------- | ----------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| mvt.shape         | `'geojson'                          | `binary`      | `geojson`: returns GeoJSON objects. `binary`: returns binary data.                                                                                      |
-| mvt.coordinates   | `'local'                            | `local`       | `wgs84`: returns coordinates in longitude, latitude using the provided tile index. `local` returns local `0-1` coordinates relative to the tile origin. |
-| mvt.tileIndex     | `{x: number, y: number, z: number}` | N/A           | When the `wgs84` coordinates option, the index of the tile being loaded (`x`, `y`, `z`) must be supplied.                                               |
-| mvt.layerProperty | `string \| null`                    | `'layerName'` | When non-`null`, the layer name of each feature is added to `feature.properties[layerProperty]`. If `null`, a layer name property will not be added.    |
-| mvt.layers        | `string[]`                          | N/A           | If provided, only features belonging to the named layers will be included, otherwise features from all layers are returned.                             |
+| Option            | Type                                                | Default           | Description                                                                                                                                             |
+| ----------------- | --------------------------------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| mvt.shape         | `'geojson-table' \| 'columnar-table' \| 'binary-geometry'` | `geojson-table`   | Returned tile shape. Use `binary-geometry` for binary geometry output.                                                                                  |
+| mvt.coordinates   | `'local' \| 'wgs84'`                                | `local`           | `wgs84`: returns coordinates in longitude, latitude using the provided tile index. `local` returns local `0-1` coordinates relative to the tile origin. |
+| mvt.tileIndex     | `{x: number, y: number, z: number}`                 | N/A               | When the `wgs84` coordinates option, the index of the tile being loaded (`x`, `y`, `z`) must be supplied.                                               |
+| mvt.layerProperty | `string \| null`                                    | `'layerName'`     | When non-`null`, the layer name of each feature is added to `feature.properties[layerProperty]`. If `null`, a layer name property will not be added.    |
+| mvt.layers        | `string[]`                                          | N/A               | If provided, only features belonging to the named layers will be included, otherwise features from all layers are returned.                             |
 
 If you want to know more about how geometries are encoded into MVT tiles, please read [this documentation section](https://docs.mapbox.com/vector-tiles/specification/#encoding-geometry).
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -240,6 +240,14 @@ Loader module changes, in order of estimated impact to applications:
 - `options.kml.shape` replaces all other mechanisms for specifying format of returned data (`.format` etc), and aligns with the `geojson-table` table shape as this is compatible with a GeoJSON `FeatureCollection`.
 - `options.gpx.shape` applies the same changes as `options.kml.shape`.
 - `options.tcx.shape` applies the same changes as `options.kml.shape`.
+- `options.gpx.shape: 'binary'` and `options.tcx.shape: 'binary'` have been removed. Use `shape: 'binary-geometry'` instead.
+
+**@loaders.gl/mvt, @loaders.gl/mlt, @loaders.gl/flatgeobuf**
+
+- Geospatial loader shapes now use `geojson-table` for GeoJSON feature table output and `binary-geometry` for binary geometry output.
+- The old `geojson` shape has been removed from `MVTLoader` and `MLTLoader`. Use `geojson-table` instead.
+- The old `binary` shape has been removed from `MVTLoader`, `MLTLoader`, and `FlatGeobufLoader`. Use `binary-geometry` instead.
+- `MVTLoader` and `MLTLoader` now default to `geojson-table`.
 
 ## Upgrading to v3.4
 

--- a/modules/csv/src/csv-loader-options.ts
+++ b/modules/csv/src/csv-loader-options.ts
@@ -24,6 +24,7 @@ export type CSVLoaderOptions = LoaderOptions & {
     comments?: boolean;
     skipEmptyLines?: boolean | 'greedy';
     detectGeometryColumns?: boolean;
+    geometryEncoding?: 'wkb' | 'source';
     delimitersToGuess?: string[];
   };
 };
@@ -40,6 +41,7 @@ export const CSV_LOADER_OPTIONS = {
     comments: false,
     skipEmptyLines: true,
     detectGeometryColumns: false,
+    geometryEncoding: 'wkb',
     delimitersToGuess: [',', '\t', '|', ';']
   }
 } as const satisfies CSVLoaderOptions;

--- a/modules/csv/src/csv-loader-with-parser.ts
+++ b/modules/csv/src/csv-loader-with-parser.ts
@@ -124,7 +124,8 @@ function parseCSVTextSync(
   const detectedGeometryColumns = csvOptions.detectGeometryColumns
     ? detectGeometryColumns(
         headerRow,
-        rows.map(row => (Array.isArray(row) ? row : convertToArrayRow(row, headerRow)))
+        rows.map(row => (Array.isArray(row) ? row : convertToArrayRow(row, headerRow))),
+        csvOptions.geometryEncoding
       )
     : [];
 
@@ -240,7 +241,11 @@ function parseCSVInBatches(
           MAX_GEOMETRY_SNIFF_ROWS
         );
         if (geometryDetectionFinalized) {
-          detectedGeometryColumns = detectGeometryColumns(headerRow, sniffedRows);
+          detectedGeometryColumns = detectGeometryColumns(
+            headerRow,
+            sniffedRows,
+            csvOptions.geometryEncoding
+          );
           const normalizedSniffedRows = sniffedRows.map(sniffedRow =>
             normalizeGeometryArrayRow(sniffedRow, detectedGeometryColumns)
           );
@@ -278,7 +283,11 @@ function parseCSVInBatches(
     complete(results) {
       try {
         if (!geometryDetectionFinalized && headerRow) {
-          detectedGeometryColumns = detectGeometryColumns(headerRow, sniffedRows);
+          detectedGeometryColumns = detectGeometryColumns(
+            headerRow,
+            sniffedRows,
+            csvOptions.geometryEncoding
+          );
           const normalizedSniffedRows = sniffedRows.map(row =>
             normalizeGeometryArrayRow(row, detectedGeometryColumns)
           );

--- a/modules/csv/src/lib/csv-geometry.ts
+++ b/modules/csv/src/lib/csv-geometry.ts
@@ -4,6 +4,7 @@
 
 import type {DataType, Field, Geometry, Schema} from '@loaders.gl/schema';
 import {
+  convertGeometryToWKB,
   convertWKBToGeometry,
   convertWKTToGeometry,
   decodeHex,
@@ -19,6 +20,9 @@ export const MAX_GEOMETRY_SNIFF_ROWS = 50;
 
 /** Geometry encodings supported by CSV geometry detection. */
 export type CSVGeometryEncoding = 'geoarrow.wkb' | 'geoarrow.wkt';
+
+/** Output encoding policy for detected CSV geometry columns. */
+export type CSVGeometryOutputEncoding = 'wkb' | 'source';
 
 /** One detected geometry column definition. */
 export type DetectedGeometryColumn = {
@@ -70,7 +74,8 @@ export function shouldFinalizeGeometryDetection(
 /** Detects geometry columns from buffered CSV array rows and header names. */
 export function detectGeometryColumns(
   headerRow: string[],
-  rows: unknown[][]
+  rows: unknown[][],
+  geometryEncoding: CSVGeometryOutputEncoding = 'wkb'
 ): DetectedGeometryColumn[] {
   const detectedGeometryColumns: DetectedGeometryColumn[] = [];
 
@@ -85,7 +90,7 @@ export function detectGeometryColumns(
       detectedGeometryColumns.push({
         columnName: headerRow[columnIndex],
         columnIndex,
-        encoding: 'geoarrow.wkt',
+        encoding: geometryEncoding === 'source' ? 'geoarrow.wkt' : 'geoarrow.wkb',
         geometryTypes: inferGeoParquetGeometryTypes(wktGeometries)
       });
       continue;
@@ -206,7 +211,12 @@ export function normalizeGeometryValue(
     if (typeof value !== 'string') {
       return value;
     }
-    return decodeHex(value.trim());
+    const trimmedValue = value.trim();
+    if (isHexWKBString(trimmedValue)) {
+      return decodeHex(trimmedValue);
+    }
+    const geometry = convertWKTToGeometry(trimmedValue);
+    return geometry ? new Uint8Array(convertGeometryToWKB(geometry)) : null;
   }
 
   return typeof value === 'string' ? value : String(value);

--- a/modules/csv/test/csv-loader.spec.ts
+++ b/modules/csv/test/csv-loader.spec.ts
@@ -124,18 +124,41 @@ test('CSVLoader#load(geospatial-points-wkt.csv, detectGeometryColumns)', async t
     const geometryField = table.schema?.fields.find(field => field.name === 'geometry');
     const geoMetadata = getGeoMetadata(table.schema?.metadata);
 
+    t.equal(geometryField?.type, 'binary', 'WKT geometry field is converted to a binary column');
+    t.equal(
+      geometryField?.metadata?.['ARROW:extension:name'],
+      'geoarrow.wkb',
+      'WKT geometry field is annotated as WKB'
+    );
+    t.equal(geoMetadata?.primary_column, 'geometry', 'Geo metadata primary column is set');
+    t.equal(geoMetadata?.columns.geometry.encoding, 'wkb', 'Geo metadata includes WKB encoding');
+    t.equal(
+      geoMetadata?.columns.geometry.geometry_types[0],
+      'Point',
+      'Geo metadata includes inferred geometry type'
+    );
+    t.ok(table.data[0].geometry instanceof Uint8Array, 'WKT geometry value is encoded as WKB');
+  }
+  t.end();
+});
+
+test('CSVLoader#load(geospatial-points-wkt.csv, detectGeometryColumns, source geometry)', async t => {
+  const table = await load(CSV_GEOSPATIAL_WKT_URL, CSVLoader, {
+    csv: {shape: 'object-row-table', detectGeometryColumns: true, geometryEncoding: 'source'}
+  });
+
+  t.equal(table.shape, 'object-row-table', 'Got correct table shape');
+  if (table.shape === 'object-row-table') {
+    const geometryField = table.schema?.fields.find(field => field.name === 'geometry');
+    const geoMetadata = getGeoMetadata(table.schema?.metadata);
+
     t.equal(geometryField?.type, 'utf8', 'WKT geometry field is a string column');
     t.equal(
       geometryField?.metadata?.['ARROW:extension:name'],
       'geoarrow.wkt',
       'WKT geometry field is annotated'
     );
-    t.equal(geoMetadata?.primary_column, 'geometry', 'Geo metadata primary column is set');
-    t.equal(
-      geoMetadata?.columns.geometry.geometry_types[0],
-      'Point',
-      'Geo metadata includes inferred geometry type'
-    );
+    t.equal(geoMetadata?.columns.geometry.encoding, 'wkt', 'Geo metadata includes WKT encoding');
     t.equal(table.data[0].geometry, 'POINT (-122.3933 37.7955)', 'WKT geometry value is preserved');
   }
   t.end();
@@ -331,16 +354,36 @@ test('CSVLoader#loadInBatches(geospatial-points-wkt.csv, detectGeometryColumns)'
     t.equal(firstBatch.length, 3, 'Got correct batch size');
     t.equal(
       geometryField?.metadata?.['ARROW:extension:name'],
-      'geoarrow.wkt',
-      'WKT batch geometry field is annotated'
+      'geoarrow.wkb',
+      'WKT batch geometry field is annotated as WKB'
     );
-    t.equal(geoMetadata?.columns.geometry.encoding, 'wkt', 'Batch geo metadata includes encoding');
-    t.equal(
-      firstBatch.data.geometry[0],
-      'POINT (-122.3933 37.7955)',
-      'WKT batch geometry value is preserved'
-    );
+    t.equal(geoMetadata?.columns.geometry.encoding, 'wkb', 'Batch geo metadata includes encoding');
+    t.ok(firstBatch.data.geometry[0] instanceof Uint8Array, 'WKT batch geometry value is encoded');
   }
+  t.end();
+});
+
+test('CSVLoader#load(geospatial-points-wkt.csv, arrow-table, detectGeometryColumns)', async t => {
+  const table = await load(CSV_GEOSPATIAL_WKT_URL, CSVLoader, {
+    csv: {shape: 'arrow-table', detectGeometryColumns: true}
+  });
+
+  t.equal(table.shape, 'arrow-table', 'Got correct table shape');
+  const geometryField = table.schema?.fields.find(field => field.name === 'geometry');
+  const geoMetadata = getGeoMetadata(table.schema?.metadata);
+
+  t.equal(geometryField?.type, 'binary', 'WKT Arrow geometry field is binary');
+  t.equal(
+    geometryField?.metadata?.['ARROW:extension:name'],
+    'geoarrow.wkb',
+    'WKT Arrow geometry field is annotated as WKB'
+  );
+  t.equal(
+    geoMetadata?.columns.geometry.encoding,
+    'wkb',
+    'Arrow geo metadata includes WKB encoding'
+  );
+  t.ok(table.data.getChild('geometry')?.get(0) instanceof Uint8Array, 'Arrow geometry is WKB');
   t.end();
 });
 

--- a/modules/flatgeobuf/src/flatgeobuf-loader.ts
+++ b/modules/flatgeobuf/src/flatgeobuf-loader.ts
@@ -20,7 +20,7 @@ const FGB_MAGIC_NUMBER = [0x66, 0x67, 0x62, 0x03, 0x66, 0x67, 0x62, 0x01];
 
 export type FlatGeobufLoaderOptions = LoaderOptions & {
   flatgeobuf?: {
-    shape?: 'geojson-table' | 'columnar-table' | 'binary' | 'arrow-table';
+    shape?: 'geojson-table' | 'columnar-table' | 'binary-geometry' | 'arrow-table';
     /** Override the URL to the worker bundle (by default loads from unpkg.com) */
     workerUrl?: string;
     boundingBox?: [[number, number], [number, number]];

--- a/modules/flatgeobuf/src/lib/parse-flatgeobuf.ts
+++ b/modules/flatgeobuf/src/lib/parse-flatgeobuf.ts
@@ -4,7 +4,7 @@
 
 import {Proj4Projection} from '@math.gl/proj4';
 import {
-  convertGeometryToWKB,
+  encodeWKBGeometryValue,
   type GeoParquetGeometryType,
   makeWKBGeometryField,
   setWKBGeometrySchemaMetadata,
@@ -40,7 +40,7 @@ const deserializeGeneric = generic.deserialize;
 const GEOMETRY_COLUMN_NAME = 'geometry';
 
 export type ParseFlatGeobufOptions = {
-  shape?: 'geojson-table' | 'columnar-table' | 'binary' | 'arrow-table';
+  shape?: 'geojson-table' | 'columnar-table' | 'binary-geometry' | 'arrow-table';
   /** If supplied, only loads features within the bounding box */
   boundingBox?: [[number, number], [number, number]];
   /** Desired output CRS */
@@ -68,7 +68,7 @@ export function parseFlatGeobuf(arrayBuffer: ArrayBuffer, options: ParseFlatGeob
       // @ts-expect-error
       return {shape: 'columnar-table', data: binary};
 
-    case 'binary':
+    case 'binary-geometry':
       // @ts-expect-error
       return parseFlatGeobufToBinary(arrayBuffer, options);
 
@@ -173,7 +173,7 @@ function parseFlatGeobufToArrowTable(
 export function parseFlatGeobufInBatches(stream, options: ParseFlatGeobufOptions) {
   const shape = options.shape;
   switch (shape) {
-    case 'binary':
+    case 'binary-geometry':
       return parseFlatGeobufInBatchesToBinary(stream, options);
     case 'geojson-table':
       return parseFlatGeobufInBatchesToGeoJSON(stream, options);
@@ -338,9 +338,7 @@ export function makeArrowRow(
   const normalizedGeometry = feature.geometry
     ? normalizeGeometryForHeader(feature.geometry, fgbHeader?.geometryType)
     : null;
-  row[GEOMETRY_COLUMN_NAME] = normalizedGeometry
-    ? new Uint8Array(convertGeometryToWKB(normalizedGeometry))
-    : null;
+  row[GEOMETRY_COLUMN_NAME] = encodeWKBGeometryValue(normalizedGeometry);
   return row;
 }
 

--- a/modules/flatgeobuf/test/flatgeobuf.bench.ts
+++ b/modules/flatgeobuf/test/flatgeobuf.bench.ts
@@ -1,0 +1,30 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {fetchFile, load} from '@loaders.gl/core';
+import {FlatGeobufLoader} from '@loaders.gl/flatgeobuf';
+
+const FLATGEOBUF_COUNTRIES_DATA_URL = '@loaders.gl/flatgeobuf/test/data/countries.fgb';
+const ROW_BENCHMARK_OPTIONS = {multiplier: 179, unit: 'rows'};
+
+export default async function flatgeobufBench(suite) {
+  const response = await fetchFile(FLATGEOBUF_COUNTRIES_DATA_URL);
+  const arrayBuffer = await response.arrayBuffer();
+
+  suite = suite.group('FlatGeobufLoader');
+
+  suite.addAsync('load arrow-table geoarrow.wkb', ROW_BENCHMARK_OPTIONS, async () => {
+    await load(arrayBuffer.slice(0), FlatGeobufLoader, {
+      core: {worker: false},
+      flatgeobuf: {shape: 'arrow-table'}
+    });
+  });
+
+  suite.addAsync('load geojson-table', ROW_BENCHMARK_OPTIONS, async () => {
+    await load(arrayBuffer.slice(0), FlatGeobufLoader, {
+      core: {worker: false},
+      flatgeobuf: {shape: 'geojson-table'}
+    });
+  });
+}

--- a/modules/geopackage/src/lib/parse-geopackage.ts
+++ b/modules/geopackage/src/lib/parse-geopackage.ts
@@ -13,10 +13,10 @@ import type {
 import {ArrowTableBuilder} from '@loaders.gl/schema-utils';
 import {
   type GeoParquetGeometryType,
-  encodeWKBGeometryValue,
   makeWKBGeometryField,
   setWKBGeometrySchemaMetadata,
   convertWKBToGeometry,
+  reprojectWKBInPlace,
   transformGeoJsonCoords
 } from '@loaders.gl/gis';
 import {Proj4Projection} from '@math.gl/proj4';
@@ -360,9 +360,11 @@ function constructArrowRow(
     const value = row[columnIndex];
 
     if (columnName === geometryColumnName) {
-      const geometry = parseGeometry(value);
-      const projectedGeometry = projection ? reprojectGeometry(geometry, projection) : geometry;
-      arrowRow[GEOMETRY_OUTPUT_COLUMN_NAME] = encodeWKBGeometryValue(projectedGeometry);
+      const wkb = parseGeometryWKB(value);
+      if (wkb && projection) {
+        reprojectWKBInPlace(wkb, coordinate => projection.project(coordinate));
+      }
+      arrowRow[GEOMETRY_OUTPUT_COLUMN_NAME] = wkb;
       continue;
     }
 
@@ -409,6 +411,13 @@ function reprojectGeometry(
  * GeoPackage vector geometries are slightly extended past the WKB standard.
  */
 function parseGeometry(geometryValue: unknown): Geometry | null {
+  const wkb = parseGeometryWKB(geometryValue);
+  return wkb
+    ? convertWKBToGeometry(wkb.buffer.slice(wkb.byteOffset, wkb.byteOffset + wkb.byteLength))
+    : null;
+}
+
+function parseGeometryWKB(geometryValue: unknown): Uint8Array | null {
   if (!geometryValue) {
     return null;
   }
@@ -422,8 +431,7 @@ function parseGeometry(geometryValue: unknown): Geometry | null {
   }
 
   const wkbOffset = 8 + envelopeLength;
-  const wkbBytes = arrayBuffer.slice(wkbOffset);
-  return convertWKBToGeometry(wkbBytes);
+  return new Uint8Array(arrayBuffer, wkbOffset);
 }
 
 function parseGeometryBitFlags(byte: number): GeometryBitFlags {

--- a/modules/geopackage/test/geopackage.bench.ts
+++ b/modules/geopackage/test/geopackage.bench.ts
@@ -1,0 +1,30 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {fetchFile, load} from '@loaders.gl/core';
+import {GeoPackageLoader} from '@loaders.gl/geopackage';
+
+const GPKG_RIVERS = '@loaders.gl/geopackage/test/data/rivers_small.gpkg';
+const ROW_BENCHMARK_OPTIONS = {multiplier: 1, unit: 'rows'};
+
+export default async function geopackageLoaderBench(suite) {
+  const response = await fetchFile(GPKG_RIVERS);
+  const arrayBuffer = await response.arrayBuffer();
+
+  suite = suite.group('GeoPackageLoader');
+
+  suite.addAsync('load arrow-table geoarrow.wkb', ROW_BENCHMARK_OPTIONS, async () => {
+    await load(arrayBuffer.slice(0), GeoPackageLoader, {
+      core: {worker: false},
+      geopackage: {shape: 'arrow-table'}
+    });
+  });
+
+  suite.addAsync('load geojson-table', ROW_BENCHMARK_OPTIONS, async () => {
+    await load(arrayBuffer.slice(0), GeoPackageLoader, {
+      core: {worker: false},
+      geopackage: {shape: 'geojson-table'}
+    });
+  });
+}

--- a/modules/gis/src/index.ts
+++ b/modules/gis/src/index.ts
@@ -45,6 +45,19 @@ export {
   getGeometrySampleCoordinates
 } from './lib/geoarrow/wkb-geoarrow-utils';
 export type {
+  WKBArrowGeometryValueOptions,
+  WKBArrowGeometryWriterOptions,
+  WKBGeometryValue
+} from './lib/geoarrow/wkb-arrow-utils';
+export {
+  makeWKBGeometryArrowTable,
+  makeWKBGeometryArrowTableFromData,
+  makeWKBGeometryArrowTableFromWriters,
+  makeWKBGeometryData,
+  makeWKBGeometryDataFromArray,
+  makeWKBGeometryDataFromWriters
+} from './lib/geoarrow/wkb-arrow-utils';
+export type {
   GeoArrowBuilderEncoding,
   GeoArrowCoordinateTransform,
   GeoArrowBuilderTarget,

--- a/modules/gis/src/lib/geoarrow/wkb-arrow-utils.ts
+++ b/modules/gis/src/lib/geoarrow/wkb-arrow-utils.ts
@@ -1,0 +1,205 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import * as arrow from 'apache-arrow';
+import type {ArrowTable, Schema as TableSchema} from '@loaders.gl/schema';
+import {convertSchemaToArrow} from '@loaders.gl/schema-utils';
+import {
+  reprojectWKBInPlace,
+  type CoordinateTransform
+} from '../geometry-converters/wkb/convert-binary-geometry-to-wkb';
+import {
+  WKBBuilder,
+  type WKBBuilderBaseOptions,
+  type WKBGeometryArray,
+  type WKBGeometryWriter
+} from '../geometry-converters/wkb/wkb-builder';
+
+/** WKB bytes accepted by shared GeoArrow WKB builders. */
+export type WKBGeometryValue = ArrayBuffer | ArrayBufferView | Uint8Array;
+
+/** Options for creating Arrow WKB buffers from existing WKB byte values. */
+export type WKBArrowGeometryValueOptions = {
+  /** Optional coordinate transform applied in-place after copying each WKB value. */
+  transform?: CoordinateTransform;
+};
+
+/** Options for creating Arrow WKB buffers from incremental writer callbacks. */
+export type WKBArrowGeometryWriterOptions = WKBBuilderBaseOptions;
+
+/**
+ * Creates a loaders.gl Arrow table containing one `geoarrow.wkb` geometry column.
+ *
+ * @param geometries - WKB geometry byte values, with nullish values encoded as null rows.
+ * @param schema - Table schema containing the WKB geometry field.
+ * @param options - WKB value options.
+ * @returns Arrow table with one WKB geometry column.
+ */
+export function makeWKBGeometryArrowTable(
+  geometries: (WKBGeometryValue | null | undefined)[],
+  schema: TableSchema,
+  options: WKBArrowGeometryValueOptions = {}
+): ArrowTable {
+  return makeWKBGeometryArrowTableFromData(schema, makeWKBGeometryData(geometries, options));
+}
+
+/**
+ * Creates a loaders.gl Arrow table from incremental WKB writer callbacks.
+ *
+ * @param geometryWriters - Writer callbacks, with nullish values encoded as null rows.
+ * @param schema - Table schema containing the WKB geometry field.
+ * @param options - WKB writer options.
+ * @returns Arrow table with one WKB geometry column.
+ */
+export function makeWKBGeometryArrowTableFromWriters(
+  geometryWriters: (WKBGeometryWriter | null | undefined)[],
+  schema: TableSchema,
+  options: WKBArrowGeometryWriterOptions = {}
+): ArrowTable {
+  return makeWKBGeometryArrowTableFromData(
+    schema,
+    makeWKBGeometryDataFromWriters(geometryWriters, options)
+  );
+}
+
+/**
+ * Wraps Arrow WKB geometry data in a loaders.gl Arrow table.
+ *
+ * @param schema - Table schema containing the WKB geometry field.
+ * @param geometryData - Arrow Binary data for the WKB geometry column.
+ * @returns Arrow table with one WKB geometry column.
+ */
+export function makeWKBGeometryArrowTableFromData(
+  schema: TableSchema,
+  geometryData: arrow.Data<arrow.Binary>
+): ArrowTable {
+  const arrowSchema = convertSchemaToArrow(schema);
+  const structField = new arrow.Struct(arrowSchema.fields);
+  const structData = new arrow.Data(structField, 0, geometryData.length, 0, undefined, [
+    geometryData
+  ]);
+  const recordBatch = new arrow.RecordBatch(arrowSchema, structData);
+
+  return {
+    shape: 'arrow-table',
+    schema,
+    data: new arrow.Table(arrowSchema, [recordBatch])
+  };
+}
+
+/**
+ * Creates Arrow Binary buffers containing WKB geometries.
+ *
+ * @param geometries - WKB geometry byte values, with nullish values encoded as null rows.
+ * @param options - WKB value options.
+ * @returns Arrow Binary data for one `geoarrow.wkb` column.
+ */
+export function makeWKBGeometryData(
+  geometries: (WKBGeometryValue | null | undefined)[],
+  options: WKBArrowGeometryValueOptions = {}
+): arrow.Data<arrow.Binary> {
+  const valueOffsets = measureWKBGeometryOffsets(geometries);
+  const values = new Uint8Array(valueOffsets[valueOffsets.length - 1]);
+  const {nullBitmap, nullCount} = writeWKBGeometryValues(geometries, valueOffsets, values, options);
+
+  return makeWKBGeometryDataFromArray({valueOffsets, values, nullBitmap, nullCount});
+}
+
+/**
+ * Creates Arrow Binary buffers from incremental WKB writer callbacks.
+ *
+ * @param geometryWriters - Writer callbacks, with nullish values encoded as null rows.
+ * @param options - WKB writer options.
+ * @returns Arrow Binary data for one `geoarrow.wkb` column.
+ */
+export function makeWKBGeometryDataFromWriters(
+  geometryWriters: (WKBGeometryWriter | null | undefined)[],
+  options: WKBArrowGeometryWriterOptions = {}
+): arrow.Data<arrow.Binary> {
+  return makeWKBGeometryDataFromArray(
+    WKBBuilder.buildGeometryArray(normalizeGeometryWriters(geometryWriters), options)
+  );
+}
+
+/**
+ * Wraps prebuilt WKB offsets, values and null buffers as Arrow Binary data.
+ *
+ * @param geometryArray - WKB geometry array buffers.
+ * @returns Arrow Binary data for one `geoarrow.wkb` column.
+ */
+export function makeWKBGeometryDataFromArray(
+  geometryArray: WKBGeometryArray
+): arrow.Data<arrow.Binary> {
+  return new arrow.Data(
+    new arrow.Binary(),
+    0,
+    geometryArray.valueOffsets.length - 1,
+    geometryArray.nullCount,
+    [
+      geometryArray.valueOffsets,
+      geometryArray.values,
+      geometryArray.nullCount > 0 ? geometryArray.nullBitmap : undefined
+    ]
+  );
+}
+
+function measureWKBGeometryOffsets(
+  geometries: (WKBGeometryValue | null | undefined)[]
+): Int32Array {
+  const valueOffsets = new Int32Array(geometries.length + 1);
+  for (let geometryIndex = 0; geometryIndex < geometries.length; geometryIndex++) {
+    const geometry = geometries[geometryIndex];
+    valueOffsets[geometryIndex + 1] =
+      valueOffsets[geometryIndex] + (geometry ? getWKBGeometryByteLength(geometry) : 0);
+  }
+  return valueOffsets;
+}
+
+function writeWKBGeometryValues(
+  geometries: (WKBGeometryValue | null | undefined)[],
+  valueOffsets: Int32Array,
+  values: Uint8Array,
+  options: WKBArrowGeometryValueOptions
+): {nullBitmap: Uint8Array; nullCount: number} {
+  const nullBitmap = new Uint8Array(Math.ceil(geometries.length / 8));
+  let nullCount = 0;
+
+  for (let geometryIndex = 0; geometryIndex < geometries.length; geometryIndex++) {
+    const geometry = geometries[geometryIndex];
+    if (!geometry) {
+      nullCount++;
+      continue;
+    }
+
+    nullBitmap[geometryIndex >> 3] |= 1 << (geometryIndex & 7);
+    const startOffset = valueOffsets[geometryIndex];
+    const endOffset = valueOffsets[geometryIndex + 1];
+    values.set(getWKBGeometryBytes(geometry), startOffset);
+    if (options.transform) {
+      reprojectWKBInPlace(values.subarray(startOffset, endOffset), options.transform);
+    }
+  }
+
+  return {nullBitmap, nullCount};
+}
+
+function getWKBGeometryByteLength(geometry: WKBGeometryValue): number {
+  return geometry instanceof ArrayBuffer ? geometry.byteLength : geometry.byteLength;
+}
+
+function getWKBGeometryBytes(geometry: WKBGeometryValue): Uint8Array {
+  if (geometry instanceof Uint8Array) {
+    return geometry;
+  }
+  if (geometry instanceof ArrayBuffer) {
+    return new Uint8Array(geometry);
+  }
+  return new Uint8Array(geometry.buffer, geometry.byteOffset, geometry.byteLength);
+}
+
+function normalizeGeometryWriters(
+  geometryWriters: (WKBGeometryWriter | null | undefined)[]
+): (WKBGeometryWriter | null)[] {
+  return geometryWriters.map(geometryWriter => geometryWriter || null);
+}

--- a/modules/gis/test/geoarrow/wkb-geoarrow-utils.spec.ts
+++ b/modules/gis/test/geoarrow/wkb-geoarrow-utils.spec.ts
@@ -6,9 +6,12 @@ import test from 'tape-promise/tape';
 
 import type {Geometry, Schema} from '@loaders.gl/schema';
 import {
+  convertWKBToGeometry,
   encodeWKBGeometryValue,
   getGeoMetadata,
   inferGeoParquetGeometryTypes,
+  makeWKBGeometryData,
+  makeWKBGeometryDataFromWriters,
   makeWKBGeometryField,
   setGeoMetadata,
   setWKBGeometrySchemaMetadata,
@@ -41,6 +44,81 @@ test('geoarrow WKB helpers round-trip metadata for object and Map containers', t
   objectMetadata.pandas = JSON.stringify({index_columns: ['id']});
   unpackJSONStringMetadata(objectMetadata, 'pandas');
   t.equal(objectMetadata['pandas.index_columns'], '["id"]', 'unpacks arbitrary JSON metadata keys');
+  t.end();
+});
+
+test('geoarrow WKB helpers build Arrow Binary buffers from WKB values', t => {
+  const firstPoint = encodeWKBGeometryValue({type: 'Point', coordinates: [1, 2]})!;
+  const secondPoint = encodeWKBGeometryValue({type: 'Point', coordinates: [3, 4]})!;
+  const geometryData = makeWKBGeometryData([firstPoint, null, secondPoint]);
+
+  t.deepEqual(
+    [...geometryData.valueOffsets],
+    [
+      0,
+      firstPoint.byteLength,
+      firstPoint.byteLength,
+      firstPoint.byteLength + secondPoint.byteLength
+    ],
+    'offsets account for null rows without adding bytes'
+  );
+  t.deepEqual(
+    geometryData.nullBitmap,
+    new Uint8Array([0b00000101]),
+    'null bitmap marks valid rows'
+  );
+  t.equal(geometryData.nullCount, 1, 'null count is set');
+  t.equal(
+    geometryData.values.byteLength,
+    firstPoint.byteLength + secondPoint.byteLength,
+    'values contain contiguous WKB bytes'
+  );
+  t.deepEqual(
+    convertWKBToGeometry(
+      geometryData.values.buffer.slice(
+        geometryData.valueOffsets[2],
+        geometryData.valueOffsets[3]
+      ) as ArrayBuffer
+    ),
+    {type: 'Point', coordinates: [3, 4]},
+    'second non-null geometry decodes from contiguous values'
+  );
+  t.end();
+});
+
+test('geoarrow WKB helpers build Arrow Binary buffers from writer callbacks', t => {
+  const geometryData = makeWKBGeometryDataFromWriters([
+    builder => {
+      builder.beginPoint();
+      builder.writeCoordinate(1, 2);
+    },
+    null,
+    builder => {
+      builder.beginLineString(2);
+      builder.writeCoordinate(3, 4);
+      builder.writeCoordinate(5, 6);
+    }
+  ]);
+
+  t.deepEqual([...geometryData.valueOffsets], [0, 21, 21, 62], 'writer offsets are measured');
+  t.deepEqual(geometryData.nullBitmap, new Uint8Array([0b00000101]), 'writer null bitmap is set');
+  t.equal(geometryData.nullCount, 1, 'writer null count is set');
+  t.deepEqual(
+    convertWKBToGeometry(
+      geometryData.values.buffer.slice(
+        geometryData.valueOffsets[2],
+        geometryData.valueOffsets[3]
+      ) as ArrayBuffer
+    ),
+    {
+      type: 'LineString',
+      coordinates: [
+        [3, 4],
+        [5, 6]
+      ]
+    },
+    'writer output decodes from contiguous values'
+  );
   t.end();
 });
 

--- a/modules/kml/src/gpx-loader-with-parser.ts
+++ b/modules/kml/src/gpx-loader-with-parser.ts
@@ -23,7 +23,7 @@ const {preload: _GPXLoaderPreload, ...GPXLoaderMetadataWithoutPreload} = GPXLoad
 
 export type GPXLoaderOptions = LoaderOptions & {
   gpx?: {
-    shape?: 'object-row-table' | 'geojson-table' | 'arrow-table' | 'binary' | 'raw';
+    shape?: 'object-row-table' | 'geojson-table' | 'arrow-table' | 'binary-geometry' | 'raw';
   };
 };
 
@@ -87,7 +87,7 @@ function parseTextSync(
     }
     case 'arrow-table':
       return convertFeatureCollectionToArrowTable(geojson.features);
-    case 'binary':
+    case 'binary-geometry':
       return geojsonToBinary(geojson.features);
 
     default:

--- a/modules/kml/src/gpx-loader.ts
+++ b/modules/kml/src/gpx-loader.ts
@@ -17,7 +17,7 @@ const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
 export type GPXLoaderOptions = LoaderOptions & {
   gpx?: {
-    shape?: 'object-row-table' | 'geojson-table' | 'arrow-table' | 'binary' | 'raw';
+    shape?: 'object-row-table' | 'geojson-table' | 'arrow-table' | 'binary-geometry' | 'raw';
   };
 };
 

--- a/modules/kml/src/kml-loader-with-parser.ts
+++ b/modules/kml/src/kml-loader-with-parser.ts
@@ -18,7 +18,7 @@ const {preload: _KMLLoaderPreload, ...KMLLoaderMetadataWithoutPreload} = KMLLoad
 
 export type KMLLoaderOptions = LoaderOptions & {
   kml?: {
-    shape?: 'object-row-table' | 'geojson-table' | 'arrow-table' | 'binary' | 'raw';
+    shape?: 'object-row-table' | 'geojson-table' | 'arrow-table' | 'raw';
   };
 };
 
@@ -75,10 +75,6 @@ function parseTextSync(
     }
     case 'arrow-table':
       return convertFeatureCollectionToArrowTable(geojson.features);
-    // case 'geojson':
-    //   return geojson;
-    // case 'binary':
-    //   return geojsonToBinary(geojson.features);
     // case 'raw':
     //   return doc;
     case 'object-row-table':

--- a/modules/kml/src/kml-loader.ts
+++ b/modules/kml/src/kml-loader.ts
@@ -14,7 +14,7 @@ const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
 export type KMLLoaderOptions = LoaderOptions & {
   kml?: {
-    shape?: 'object-row-table' | 'geojson-table' | 'arrow-table' | 'binary' | 'raw';
+    shape?: 'object-row-table' | 'geojson-table' | 'arrow-table' | 'raw';
   };
 };
 

--- a/modules/kml/src/tcx-loader-with-parser.ts
+++ b/modules/kml/src/tcx-loader-with-parser.ts
@@ -23,7 +23,7 @@ const {preload: _TCXLoaderPreload, ...TCXLoaderMetadataWithoutPreload} = TCXLoad
 
 export type TCXLoaderOptions = LoaderOptions & {
   tcx?: {
-    shape?: 'object-row-table' | 'geojson-table' | 'arrow-table' | 'binary' | 'raw';
+    shape?: 'object-row-table' | 'geojson-table' | 'arrow-table' | 'binary-geometry' | 'raw';
   };
 };
 
@@ -87,7 +87,7 @@ function parseTextSync(
     }
     case 'arrow-table':
       return convertFeatureCollectionToArrowTable(geojson.features);
-    case 'binary':
+    case 'binary-geometry':
       return geojsonToBinary(geojson.features);
 
     default:

--- a/modules/kml/src/tcx-loader.ts
+++ b/modules/kml/src/tcx-loader.ts
@@ -17,7 +17,7 @@ const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
 export type TCXLoaderOptions = LoaderOptions & {
   tcx?: {
-    shape?: 'object-row-table' | 'geojson-table' | 'arrow-table' | 'binary' | 'raw';
+    shape?: 'object-row-table' | 'geojson-table' | 'arrow-table' | 'binary-geometry' | 'raw';
   };
 };
 

--- a/modules/kml/test/kml.bench.ts
+++ b/modules/kml/test/kml.bench.ts
@@ -1,0 +1,39 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {fetchFile, load} from '@loaders.gl/core';
+import {GPXLoader, KMLLoader, TCXLoader} from '@loaders.gl/kml';
+
+const KML_URL = '@loaders.gl/kml/test/data/kml/KML_Samples.kml';
+const GPX_URL = '@loaders.gl/kml/test/data/gpx/trek.gpx';
+const TCX_URL = '@loaders.gl/kml/test/data/tcx/tcx_sample.tcx';
+const ROW_BENCHMARK_OPTIONS = {multiplier: 1, unit: 'rows'};
+
+export default async function kmlBench(suite) {
+  suite = suite.group('KMLLoader');
+  await addLoaderBenchmarks(suite, KMLLoader, KML_URL, 'kml');
+
+  suite = suite.group('GPXLoader');
+  await addLoaderBenchmarks(suite, GPXLoader, GPX_URL, 'gpx');
+
+  suite = suite.group('TCXLoader');
+  await addLoaderBenchmarks(suite, TCXLoader, TCX_URL, 'tcx');
+}
+
+async function addLoaderBenchmarks(suite, loader, url, optionName) {
+  const response = await fetchFile(url);
+  const text = await response.text();
+
+  suite.addAsync('load arrow-table geoarrow.wkb', ROW_BENCHMARK_OPTIONS, async () => {
+    await load(text, loader, {
+      [optionName]: {shape: 'arrow-table'}
+    });
+  });
+
+  suite.addAsync('load geojson-table', ROW_BENCHMARK_OPTIONS, async () => {
+    await load(text, loader, {
+      [optionName]: {shape: 'geojson-table'}
+    });
+  });
+}

--- a/modules/mlt/src/lib/parse-mlt.ts
+++ b/modules/mlt/src/lib/parse-mlt.ts
@@ -52,16 +52,16 @@ type MLTFeatureTable = {
 };
 
 /**
- * Parse an MLT ArrayBuffer and return GeoJSON or binary data.
+ * Parse an MLT ArrayBuffer and return GeoJSON table or binary geometry data.
  *
  * @param arrayBuffer An MLT tile as an ArrayBuffer
  * @param options
- * @returns GeoJSON features, a GeoJSON table, or a binary feature collection
+ * @returns GeoJSON table or binary feature collection
  */
 export function parseMLT(
   arrayBuffer: ArrayBuffer,
   options?: MLTLoaderOptions
-): Feature[] | GeoJSONTable | BinaryFeatureCollection {
+): GeoJSONTable | BinaryFeatureCollection {
   const mltOptions = checkOptions(options);
 
   const shape = mltOptions.shape;
@@ -74,16 +74,15 @@ export function parseMLT(
       };
       return table;
     }
-    case 'binary': {
+    case 'binary-geometry': {
       const geojsonFeatures = parseToGeojsonFeatures(arrayBuffer, mltOptions);
       const binaryData = geojsonToBinary(geojsonFeatures);
       // @ts-ignore
       binaryData.byteLength = arrayBuffer.byteLength;
       return binaryData;
     }
-    case 'geojson':
     default:
-      return parseToGeojsonFeatures(arrayBuffer, mltOptions);
+      throw new Error(shape || 'undefined shape');
   }
 }
 

--- a/modules/mlt/src/mlt-loader-with-parser.ts
+++ b/modules/mlt/src/mlt-loader-with-parser.ts
@@ -14,7 +14,7 @@ const {preload: _MLTLoaderPreload, ...MLTLoaderMetadataWithoutPreload} = MLTLoad
 export type MLTLoaderOptions = LoaderOptions & {
   mlt?: {
     /** Shape of returned data */
-    shape?: 'geojson-table' | 'geojson' | 'binary';
+    shape?: 'geojson-table' | 'binary-geometry';
     /** `wgs84`: coordinates in longitude/latitude. `local` coordinates are `0-1` from tile origin */
     coordinates?: 'wgs84' | 'local';
     /** An object containing tile index values (`x`, `y`, `z`) to reproject features' coordinates into WGS84. Mandatory with `wgs84` coordinates option. */
@@ -28,7 +28,7 @@ export type MLTLoaderOptions = LoaderOptions & {
 
 /** Default options for the MLT loader */
 export const MLT_DEFAULT_OPTIONS = {
-  shape: 'geojson' as const,
+  shape: 'geojson-table' as const,
   coordinates: 'local' as const,
   layerProperty: 'layerName' as const
 };

--- a/modules/mlt/src/mlt-loader.ts
+++ b/modules/mlt/src/mlt-loader.ts
@@ -12,7 +12,7 @@ const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 export type MLTLoaderOptions = LoaderOptions & {
   mlt?: {
     /** Shape of returned data */
-    shape?: 'geojson-table' | 'geojson' | 'binary';
+    shape?: 'geojson-table' | 'binary-geometry';
     /** `wgs84`: coordinates in longitude/latitude. `local` coordinates are `0-1` from tile origin */
     coordinates?: 'wgs84' | 'local';
     /** An object containing tile index values (`x`, `y`, `z`) to reproject features' coordinates into WGS84. Mandatory with `wgs84` coordinates option. */
@@ -26,7 +26,7 @@ export type MLTLoaderOptions = LoaderOptions & {
 
 /** Default options for the MLT loader */
 export const MLT_DEFAULT_OPTIONS = {
-  shape: 'geojson' as const,
+  shape: 'geojson-table' as const,
   coordinates: 'local' as const,
   layerProperty: 'layerName' as const
 };

--- a/modules/mlt/src/mlt-source-loader.ts
+++ b/modules/mlt/src/mlt-source-loader.ts
@@ -24,7 +24,7 @@ export type MLTSourceLoaderOptions = DataSourceOptions & {
     /** Coordinates for parsed tile geometries. */
     coordinates?: 'wgs84' | 'local';
     /** Shape of returned data. */
-    shape?: 'geojson-table' | 'geojson' | 'binary';
+    shape?: 'geojson-table' | 'binary-geometry';
     /** Optional layer filter. */
     layers?: string[];
   };
@@ -176,7 +176,7 @@ export class MLTTileSource
   ): Promise<Feature[] | BinaryFeatureCollection | null> {
     const options: MLTSourceLoaderOptions = this.options;
     const coordinates = options.mlt?.coordinates || 'wgs84';
-    const shape = options.mlt?.shape || 'geojson';
+    const shape = options.mlt?.shape || 'geojson-table';
     const tileIndex =
       coordinates === 'wgs84'
         ? {x: tileParameters.x, y: tileParameters.y, z: tileParameters.z}
@@ -197,11 +197,10 @@ export class MLTTileSource
       return (parsed as {features: Feature[]}).features || null;
     }
 
-    if (shape === 'binary') {
+    if (shape === 'binary-geometry') {
       return parsed as BinaryFeatureCollection;
     }
-
-    return parsed as Feature[];
+    return (parsed as {features: Feature[]}).features || null;
   }
 
   getTileURL(x: number, y: number, z: number) {

--- a/modules/mlt/test/mlt-loader.spec.ts
+++ b/modules/mlt/test/mlt-loader.spec.ts
@@ -15,7 +15,7 @@ test('MLTLoader#metadata', t => {
 });
 
 test('MLTLoader#options defaults', t => {
-  t.equal(MLTLoader.options.mlt.shape, 'geojson', 'default shape is geojson');
+  t.equal(MLTLoader.options.mlt.shape, 'geojson-table', 'default shape is geojson-table');
   t.equal(MLTLoader.options.mlt.coordinates, 'local', 'default coordinates are local');
   t.equal(MLTLoader.options.mlt.layerProperty, 'layerName', 'default layerProperty is layerName');
   t.end();
@@ -23,9 +23,9 @@ test('MLTLoader#options defaults', t => {
 
 test('MLTLoader#parse empty tile', async t => {
   const emptyBuffer = new ArrayBuffer(0);
-  const result = await MLTLoader.parse(emptyBuffer, {mlt: {shape: 'geojson'}});
-  t.ok(Array.isArray(result), 'empty tile returns an array');
-  t.equal((result as any[]).length, 0, 'empty tile returns empty array');
+  const result = await MLTLoader.parse(emptyBuffer, {mlt: {shape: 'geojson-table'}});
+  t.equal(result.shape, 'geojson-table', 'empty tile returns a GeoJSON table');
+  t.equal(result.features.length, 0, 'empty tile returns empty features');
   t.end();
 });
 

--- a/modules/mlt/test/mlt-source.spec.ts
+++ b/modules/mlt/test/mlt-source.spec.ts
@@ -68,7 +68,7 @@ test('MLTTileSource#getTileData returns Feature[] by default', async t => {
 
   MLTLoader.parse = (async (arrayBuffer: ArrayBuffer, options?: unknown) => {
     parseOptions.options = options;
-    return [feature];
+    return {shape: 'geojson-table', type: 'FeatureCollection', features: [feature]};
   }) as unknown as typeof MLTLoader.parse;
 
   const source = MLTSourceLoader.createDataSource('https://example.com/tiles', {});
@@ -79,7 +79,7 @@ test('MLTTileSource#getTileData returns Feature[] by default', async t => {
       id: '1/2/3',
       bbox: {west: 0, north: 0, east: 0, south: 0}
     });
-    t.equal((parseOptions.options as {mlt?: {shape?: string}})?.mlt?.shape, 'geojson');
+    t.equal((parseOptions.options as {mlt?: {shape?: string}})?.mlt?.shape, 'geojson-table');
     t.equal((parseOptions.options as {mlt?: {coordinates?: string}})?.mlt?.coordinates, 'wgs84');
     t.deepEqual(tile, [feature]);
   } finally {

--- a/modules/mvt/src/lib/parse-mvt.ts
+++ b/modules/mvt/src/lib/parse-mvt.ts
@@ -38,11 +38,7 @@ export function parseMVT(arrayBuffer: ArrayBuffer, options?: MVTLoaderOptions) {
       };
       return table;
     }
-    case 'geojson':
-      return parseToGeojsonFeatures(arrayBuffer, mvtOptions);
     case 'binary-geometry':
-      return parseToBinary(arrayBuffer, mvtOptions);
-    case 'binary':
       return parseToBinary(arrayBuffer, mvtOptions);
     default:
       throw new Error(shape || 'undefined shape');

--- a/modules/mvt/src/lib/types.ts
+++ b/modules/mvt/src/lib/types.ts
@@ -26,7 +26,7 @@ type MVTWgs84CoordinatesOptions = {
 };
 
 export type MVTOptions = (MVTLocalCoordinatesOptions | MVTWgs84CoordinatesOptions) & {
-  shape?: 'geojson-table' | 'columnar-table' | 'geojson' | 'binary' | 'binary-geometry';
+  shape?: 'geojson-table' | 'columnar-table' | 'binary-geometry';
   /**
    * When non-`null`, the layer name of each feature is added to
    * `feature.properties[layerProperty]`. (A `feature.properties` object is created if the feature

--- a/modules/mvt/src/mvt-loader-with-parser.ts
+++ b/modules/mvt/src/mvt-loader-with-parser.ts
@@ -15,7 +15,7 @@ const {preload: _MVTLoaderPreload, ...MVTLoaderMetadataWithoutPreload} = MVTLoad
 export type MVTLoaderOptions = LoaderOptions & {
   mvt?: {
     /** Shape of returned data */
-    shape?: 'geojson-table' | 'columnar-table' | 'geojson' | 'binary' | 'binary-geometry';
+    shape?: 'geojson-table' | 'columnar-table' | 'binary-geometry';
     /** `wgs84`: coordinates in long, lat (`tileIndex` must be provided. `local` coordinates are `0-1` from tile origin */
     coordinates?: 'wgs84' | 'local';
     /** An object containing tile index values (`x`, `y`, `z`) to reproject features' coordinates into WGS84. Mandatory with `wgs84` coordinates option. */
@@ -28,10 +28,8 @@ export type MVTLoaderOptions = LoaderOptions & {
     workerUrl?: string;
   };
   gis?: {
-    /** @deprecated Use options.mvt.shape === 'binary-geometry' */
-    binary?: boolean;
     /** @deprecated. Use options.mvt.shape */
-    format?: 'geojson-table' | 'columnar-table' | 'geojson' | 'binary' | 'binary-geometry';
+    format?: 'geojson-table' | 'columnar-table' | 'binary-geometry';
   };
 };
 

--- a/modules/mvt/src/mvt-loader.ts
+++ b/modules/mvt/src/mvt-loader.ts
@@ -13,7 +13,7 @@ const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 export type MVTLoaderOptions = LoaderOptions & {
   mvt?: {
     /** Shape of returned data */
-    shape?: 'geojson-table' | 'columnar-table' | 'geojson' | 'binary' | 'binary-geometry';
+    shape?: 'geojson-table' | 'columnar-table' | 'binary-geometry';
     /** `wgs84`: coordinates in long, lat (`tileIndex` must be provided. `local` coordinates are `0-1` from tile origin */
     coordinates?: 'wgs84' | 'local';
     /** An object containing tile index values (`x`, `y`, `z`) to reproject features' coordinates into WGS84. Mandatory with `wgs84` coordinates option. */
@@ -26,10 +26,8 @@ export type MVTLoaderOptions = LoaderOptions & {
     workerUrl?: string;
   };
   gis?: {
-    /** @deprecated Use options.mvt.shape === 'binary-geometry' */
-    binary?: boolean;
     /** @deprecated. Use options.mvt.shape */
-    format?: 'geojson-table' | 'columnar-table' | 'geojson' | 'binary' | 'binary-geometry';
+    format?: 'geojson-table' | 'columnar-table' | 'binary-geometry';
   };
 };
 
@@ -48,7 +46,7 @@ export const MVTWorkerLoader = {
   worker: true,
   options: {
     mvt: {
-      shape: 'geojson',
+      shape: 'geojson-table',
       coordinates: 'local',
       layerProperty: 'layerName',
       layers: undefined!,

--- a/modules/mvt/test/lib/parse-mvt-from-pbf.spec.ts
+++ b/modules/mvt/test/lib/parse-mvt-from-pbf.spec.ts
@@ -300,7 +300,7 @@ test('Point MVT to local coordinates JSON', async t => {
 //   const response = await fetchFile(WITH_FEATURE_ID);
 //   const mvtArrayBuffer = await response.arrayBuffer();
 
-//   const binary = await parse(mvtArrayBuffer, MVTLoader, {mvt: {shape: 'binary'}});
+//   const binary = await parse(mvtArrayBuffer, MVTLoader, {mvt: {shape: 'binary-geometry'}});
 //   t.ok(binary.points.fields.length, 'feature.id fields are preserved');
 //   t.ok(binary.lines.fields.length, 'feature.id fields are preserved');
 //   t.ok(binary.polygons.fields.length, 'feature.id fields are preserved');

--- a/modules/mvt/test/mvt-loader.bench.ts
+++ b/modules/mvt/test/mvt-loader.bench.ts
@@ -33,18 +33,19 @@ export default async function mvtLoaderBench(suite) {
     const mvtArrayBuffer = await response.arrayBuffer();
 
     // Actually define perf test
-    suite.addAsync(`${name} MVT -> geojson`, options, async () => {
-      // Conversion to geojson only
+    suite.addAsync(`${name} MVT -> geojson-table`, options, async () => {
+      // Conversion to geojson-table only
       await parse(mvtArrayBuffer.slice(0), MVTLoader, {worker: true});
     });
-    suite.addAsync(`${name} MVT -> binary (legacy)`, options, async () => {
-      // Conversion to binary, via intermediate geojson
-      const geometryJSON = await parse(mvtArrayBuffer.slice(0), MVTLoader, {worker: true});
-      geojsonToBinary(geometryJSON);
+    suite.addAsync(`${name} MVT -> binary-geometry (via geojson-table)`, options, async () => {
+      const geometryTable = await parse(mvtArrayBuffer.slice(0), MVTLoader, {worker: true});
+      geojsonToBinary(geometryTable.features);
     });
-    suite.addAsync(`${name} MVT -> binary`, options, async () => {
-      // Conversion to binary directly
-      await parse(mvtArrayBuffer.slice(0), MVTLoader, {mvt: {shape: 'binary'}, worker: true});
+    suite.addAsync(`${name} MVT -> binary-geometry`, options, async () => {
+      await parse(mvtArrayBuffer.slice(0), MVTLoader, {
+        mvt: {shape: 'binary-geometry'},
+        worker: true
+      });
     });
   }
 }

--- a/modules/mvt/test/mvt-loader.spec.ts
+++ b/modules/mvt/test/mvt-loader.spec.ts
@@ -47,8 +47,9 @@ test('Point MVT to local coordinates JSON', async t => {
   const response = await fetchFile(MVT_POINTS_DATA_URL);
   const mvtArrayBuffer = await response.arrayBuffer();
 
-  const geometryJSON = await parse(mvtArrayBuffer, MVTLoader);
-  t.deepEqual(geometryJSON, [
+  const geometryTable = await parse(mvtArrayBuffer, MVTLoader);
+  t.equal(geometryTable.shape, 'geojson-table');
+  t.deepEqual(geometryTable.features, [
     {
       type: 'Feature',
       geometry: {
@@ -72,8 +73,9 @@ test('Line MVT to local coordinates JSON', async t => {
   const response = await fetchFile(MVT_LINES_DATA_URL);
   const mvtArrayBuffer = await response.arrayBuffer();
 
-  const geometryJSON = await parse(mvtArrayBuffer, MVTLoader);
-  t.deepEqual(geometryJSON, [
+  const geometryTable = await parse(mvtArrayBuffer, MVTLoader);
+  t.equal(geometryTable.shape, 'geojson-table');
+  t.deepEqual(geometryTable.features, [
     {
       type: 'Feature',
       geometry: {
@@ -98,22 +100,23 @@ test('Polygon MVT to local coordinates JSON', async t => {
   const response = await fetchFile(MVT_POLYGONS_DATA_URL);
   const mvtArrayBuffer = await response.arrayBuffer();
 
-  const geometryJSON = await parse(mvtArrayBuffer, MVTLoader);
-  t.deepEqual(geometryJSON, decodedPolygonsGeometry);
+  const geometryTable = await parse(mvtArrayBuffer, MVTLoader);
+  t.equal(geometryTable.shape, 'geojson-table');
+  t.deepEqual(geometryTable.features, decodedPolygonsGeometry);
 
   t.end();
 });
 
 test('MVTLoader#Parse Point MVT', async t => {
   for (const binary of [true, false]) {
-    const outputFormat = binary ? 'binary' : 'geojson';
+    const outputFormat = binary ? 'binary-geometry' : 'geojson-table';
     const response = await fetchFile(MVT_POINTS_DATA_URL);
     const mvtArrayBuffer = await response.arrayBuffer();
 
     const loaderOptions: MVTLoaderOptions = {
       mvt: {
         coordinates: 'wgs84',
-        shape: binary ? 'binary' : 'geojson',
+        shape: binary ? 'binary-geometry' : 'geojson-table',
         tileIndex: {
           x: 2,
           y: 6,
@@ -124,7 +127,9 @@ test('MVTLoader#Parse Point MVT', async t => {
 
     loaderOptions.worker = false;
     const geometry = await parse(mvtArrayBuffer, MVTLoader, loaderOptions);
-    let expected = decodedPointsGeoJSON;
+    let expected = binary
+      ? decodedPointsGeoJSON
+      : {shape: 'geojson-table', type: 'FeatureCollection', features: decodedPointsGeoJSON};
     if (binary) {
       // @ts-ignore
       expected = geojsonToBinary(expected);
@@ -138,7 +143,7 @@ test('MVTLoader#Parse Point MVT', async t => {
 
 test('MVTLoader#Parse Lines MVT', async t => {
   for (const binary of [true, false]) {
-    const outputFormat = binary ? 'binary' : 'geojson';
+    const outputFormat = binary ? 'binary-geometry' : 'geojson-table';
 
     const response = await fetchFile(MVT_LINES_DATA_URL);
     const mvtArrayBuffer = await response.arrayBuffer();
@@ -146,7 +151,7 @@ test('MVTLoader#Parse Lines MVT', async t => {
     const loaderOptions: MVTLoaderOptions = {
       mvt: {
         coordinates: 'wgs84',
-        shape: binary ? 'binary' : 'geojson',
+        shape: binary ? 'binary-geometry' : 'geojson-table',
         tileIndex: {
           x: 2,
           y: 1,
@@ -156,7 +161,9 @@ test('MVTLoader#Parse Lines MVT', async t => {
     };
 
     const geometry = await parse(mvtArrayBuffer, MVTLoader, loaderOptions);
-    let expected = decodedLinesGeoJSON;
+    let expected = binary
+      ? decodedLinesGeoJSON
+      : {shape: 'geojson-table', type: 'FeatureCollection', features: decodedLinesGeoJSON};
     if (binary) {
       // @ts-ignore
       expected = geojsonToBinary(expected);
@@ -170,7 +177,7 @@ test('MVTLoader#Parse Lines MVT', async t => {
 
 test('MVTLoader#Parse Polygons MVT', async t => {
   for (const binary of [true, false]) {
-    const outputFormat = binary ? 'binary' : 'geojson';
+    const outputFormat = binary ? 'binary-geometry' : 'geojson-table';
 
     const response = await fetchFile(MVT_POLYGONS_DATA_URL);
     const mvtArrayBuffer = await response.arrayBuffer();
@@ -178,7 +185,7 @@ test('MVTLoader#Parse Polygons MVT', async t => {
     const loaderOptions: MVTLoaderOptions = {
       mvt: {
         coordinates: 'wgs84',
-        shape: binary ? 'binary' : 'geojson',
+        shape: binary ? 'binary-geometry' : 'geojson-table',
         tileIndex: {
           x: 133,
           y: 325,
@@ -188,7 +195,9 @@ test('MVTLoader#Parse Polygons MVT', async t => {
     };
 
     const geometry = await parse(mvtArrayBuffer, MVTLoader, loaderOptions);
-    let expected = decodedPolygonsGeoJSON;
+    let expected = binary
+      ? decodedPolygonsGeoJSON
+      : {shape: 'geojson-table', type: 'FeatureCollection', features: decodedPolygonsGeoJSON};
     if (binary) {
       // @ts-ignore
       expected = geojsonToBinary(expected, {fixRingWinding: false});
@@ -221,8 +230,8 @@ test('Should add layer name to custom property', async t => {
     mvt: {layerProperty: 'layerSource'}
   };
 
-  const geometryJSON = await parse(mvtArrayBuffer, MVTLoader, loaderOptions);
-  t.equals(geometryJSON[0].properties.layerSource, 'layer0');
+  const geometryTable = await parse(mvtArrayBuffer, MVTLoader, loaderOptions);
+  t.equals(geometryTable.features[0].properties.layerSource, 'layer0');
 
   t.end();
 });
@@ -235,12 +244,12 @@ test('Should return features from selected layers when layers property is provid
     mvt: {layers: ['layer1']}
   };
 
-  const geometryJSON = await parse(mvtArrayBuffer, MVTLoader, loaderOptions);
-  const anyFeatureFromAnotherLayer = geometryJSON.some(
+  const geometryTable = await parse(mvtArrayBuffer, MVTLoader, loaderOptions);
+  const anyFeatureFromAnotherLayer = geometryTable.features.some(
     feature => feature.properties.layerName !== 'layer1'
   );
   t.false(anyFeatureFromAnotherLayer);
-  t.equals(geometryJSON[0].properties.layerName, 'layer1');
+  t.equals(geometryTable.features[0].properties.layerName, 'layer1');
 
   t.end();
 });
@@ -249,7 +258,9 @@ test('Polygon MVT to local coordinates binary', async t => {
   const response = await fetchFile(MVT_POLYGONS_DATA_URL);
   const mvtArrayBuffer = await response.arrayBuffer();
 
-  const geometryBinary = await parse(mvtArrayBuffer, MVTLoader, {mvt: {shape: 'binary'}});
+  const geometryBinary = await parse(mvtArrayBuffer, MVTLoader, {
+    mvt: {shape: 'binary-geometry'}
+  });
   t.ok(geometryBinary.byteLength > 0);
   delete geometryBinary.byteLength;
 
@@ -274,15 +285,15 @@ test('MVTLoader#Parse geojson-to-binary', async t => {
   for (const filename of TEST_FILES) {
     const response = await fetchFile(filename);
     const mvtArrayBuffer = await response.arrayBuffer();
-    const geojson = await parse(mvtArrayBuffer, MVTLoader);
+    const geojsonTable = await parse(mvtArrayBuffer, MVTLoader);
 
     // Pass a fresh response otherwise get CI testing errors
     const response2 = await fetchFile(filename);
     const mvtArrayBuffer2 = await response2.arrayBuffer();
-    const binary = await parse(mvtArrayBuffer2, MVTLoader, {mvt: {shape: 'binary'}});
+    const binary = await parse(mvtArrayBuffer2, MVTLoader, {mvt: {shape: 'binary-geometry'}});
     delete binary.byteLength;
 
-    const expectedBinary = geojsonToBinary(geojson);
+    const expectedBinary = geojsonToBinary(geojsonTable.features);
     t.deepEqual(expectedBinary, binary);
   }
   t.end();
@@ -292,7 +303,7 @@ test('Features with top-level id', async t => {
   const response = await fetchFile(WITH_FEATURE_ID);
   const mvtArrayBuffer = await response.arrayBuffer();
 
-  const binary = await parse(mvtArrayBuffer, MVTLoader, {mvt: {shape: 'binary'}});
+  const binary = await parse(mvtArrayBuffer, MVTLoader, {mvt: {shape: 'binary-geometry'}});
   t.ok(binary.points.fields.length, 'feature.id fields are preserved');
   t.ok(binary.lines.fields.length, 'feature.id fields are preserved');
   t.ok(binary.polygons.fields.length, 'feature.id fields are preserved');
@@ -308,7 +319,9 @@ test('Features with top-level id', async t => {
 
 test('Empty MVT must return empty binary format', async t => {
   const emptyMVTArrayBuffer = new Uint8Array();
-  const geometryBinary = await parse(emptyMVTArrayBuffer, MVTLoader, {mvt: {shape: 'binary'}});
+  const geometryBinary = await parse(emptyMVTArrayBuffer, MVTLoader, {
+    mvt: {shape: 'binary-geometry'}
+  });
   t.ok(geometryBinary.points);
   t.ok(geometryBinary.lines);
   t.ok(geometryBinary.polygons);
@@ -323,7 +336,7 @@ test('Triangulation is supported', async t => {
   const response = await fetchFile(MVT_POLYGONS_DATA_URL);
   const mvtArrayBuffer = await response.arrayBuffer();
   const geometry = await parse(mvtArrayBuffer, MVTLoader, {
-    mvt: {shape: 'binary'}
+    mvt: {shape: 'binary-geometry'}
   });
 
   // Closed polygon with 31 vertices (0===30)

--- a/modules/mvt/test/mvt-writer.spec.ts
+++ b/modules/mvt/test/mvt-writer.spec.ts
@@ -36,12 +36,14 @@ test('MVTWriter#roundtrip', async t => {
   const sourceTile = await response.arrayBuffer();
 
   const loaderOptions = {mvt: {coordinates: 'local'}};
-  const geojson = await parse(sourceTile, MVTLoader, loaderOptions);
+  const geojsonTable = await parse(sourceTile, MVTLoader, loaderOptions);
 
-  const roundtripBuffer = await encode(geojson, MVTWriter, {mvt: {layerName: 'layer0', tileIndex}});
-  const roundtripGeojson = await parse(roundtripBuffer, MVTLoader, loaderOptions);
+  const roundtripBuffer = await encode(geojsonTable.features, MVTWriter, {
+    mvt: {layerName: 'layer0', tileIndex}
+  });
+  const roundtripGeojsonTable = await parse(roundtripBuffer, MVTLoader, loaderOptions);
 
-  t.deepEqual(roundtripGeojson, geojson, 'Roundtrip preserves GeoJSON features');
+  t.deepEqual(roundtripGeojsonTable, geojsonTable, 'Roundtrip preserves GeoJSON features');
 
   t.end();
 });

--- a/modules/parquet/src/lib/geo/geospatial-metadata.ts
+++ b/modules/parquet/src/lib/geo/geospatial-metadata.ts
@@ -7,18 +7,50 @@ import * as arrow from 'apache-arrow';
 import type {Field, Schema} from '@loaders.gl/schema';
 import {
   getGeoMetadata,
+  getMetadataValue,
   setGeoMetadata,
   setMetadataValue,
   type GeoColumnMetadata,
   type GeoMetadata,
   type GeoParquetGeometryType
 } from '@loaders.gl/gis';
-import {getGeometryColumnsFromSchema, type GeoArrowEncoding} from '@loaders.gl/geoarrow';
 import {convertArrowToSchema} from '@loaders.gl/schema-utils';
 
 const GEOARROW_EXTENSION_NAME_KEY = 'ARROW:extension:name';
 const GEOARROW_EXTENSION_METADATA_KEY = 'ARROW:extension:metadata';
 const GEOPARQUET_VERSION = '1.1.0';
+
+type GeoArrowEncoding =
+  | 'geoarrow.geometry'
+  | 'geoarrow.geometrycollection'
+  | 'geoarrow.multipolygon'
+  | 'geoarrow.polygon'
+  | 'geoarrow.multilinestring'
+  | 'geoarrow.linestring'
+  | 'geoarrow.multipoint'
+  | 'geoarrow.point'
+  | 'geoarrow.wkb'
+  | 'geoarrow.wkt';
+
+type GeoArrowMetadata = {
+  encoding?: GeoArrowEncoding;
+  crs?: Record<string, unknown>;
+  edges?: 'spherical';
+  [key: string]: unknown;
+};
+
+const GEOARROW_ENCODINGS = [
+  'geoarrow.geometry',
+  'geoarrow.geometrycollection',
+  'geoarrow.multipolygon',
+  'geoarrow.polygon',
+  'geoarrow.multilinestring',
+  'geoarrow.linestring',
+  'geoarrow.multipoint',
+  'geoarrow.point',
+  'geoarrow.wkb',
+  'geoarrow.wkt'
+] as const satisfies GeoArrowEncoding[];
 
 const GEOPARQUET_TO_GEOARROW_ENCODINGS = {
   wkb: 'geoarrow.wkb',
@@ -48,6 +80,53 @@ const GEOARROW_TO_GEOMETRY_TYPE = {
   'geoarrow.multilinestring': 'MultiLineString',
   'geoarrow.multipolygon': 'MultiPolygon'
 } as const satisfies Record<string, GeoParquetGeometryType>;
+
+/** Returns GeoArrow geometry field metadata keyed by column name. */
+function getGeometryColumnsFromSchema(schema: Schema): Record<string, GeoArrowMetadata> {
+  const geometryColumns: Record<string, GeoArrowMetadata> = {};
+  for (const field of schema.fields || []) {
+    const metadata = getGeometryMetadataForField(field.metadata || {});
+    if (metadata) {
+      geometryColumns[field.name] = metadata;
+    }
+  }
+  return geometryColumns;
+}
+
+/** Extracts GeoArrow metadata from one schema field metadata object. */
+function getGeometryMetadataForField(
+  fieldMetadata: Record<string, string>
+): GeoArrowMetadata | null {
+  let metadata: GeoArrowMetadata | null = null;
+  let geoEncoding = getMetadataValue(fieldMetadata, GEOARROW_EXTENSION_NAME_KEY);
+  if (geoEncoding) {
+    geoEncoding = geoEncoding.toLowerCase();
+    if (geoEncoding === 'wkb') {
+      geoEncoding = 'geoarrow.wkb';
+    }
+    if (geoEncoding === 'wkt') {
+      geoEncoding = 'geoarrow.wkt';
+    }
+    if (GEOARROW_ENCODINGS.includes(geoEncoding as GeoArrowEncoding)) {
+      metadata ||= {};
+      metadata.encoding = geoEncoding as GeoArrowEncoding;
+    }
+  }
+
+  const columnMetadata = getMetadataValue(fieldMetadata, GEOARROW_EXTENSION_METADATA_KEY);
+  if (columnMetadata) {
+    try {
+      metadata = {
+        ...(metadata || {}),
+        ...(JSON.parse(columnMetadata) as GeoArrowMetadata)
+      };
+    } catch {
+      return metadata;
+    }
+  }
+
+  return metadata;
+}
 
 /**
  * Applies GeoParquet schema metadata to matching geometry fields as GeoArrow field metadata.

--- a/modules/parquet/test/parquet.bench.ts
+++ b/modules/parquet/test/parquet.bench.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {ParquetJSLoader, ParquetLoader, ParquetArrowLoader} from '@loaders.gl/parquet';
+import {ParquetJSLoader, ParquetLoader, ParquetArrowLoader, GeoParquetLoader} from '@loaders.gl/parquet';
 import {fetchFile, load} from '@loaders.gl/core';
 
 // const PARQUET_URL = '@loaders.gl/parquet/test/data/apache/good/alltypes_plain.parquet';
@@ -47,6 +47,29 @@ export async function parquetBench(suite) {
     {multiplier: 40000, unit: 'rows'},
     async () => {
       await load(geoArrayBuffer, ParquetArrowLoader, {
+        core: {worker: false}
+      });
+    }
+  );
+
+  suite = suite.group('GeoParquetLoader');
+
+  suite.addAsync(
+    'load arrow-table geoarrow.wkb',
+    {multiplier: 40000, unit: 'rows'},
+    async () => {
+      await load(geoArrayBuffer.slice(0), GeoParquetLoader, {
+        core: {worker: false},
+        parquet: {shape: 'arrow-table'}
+      });
+    }
+  );
+
+  suite.addAsync(
+    'load geojson-table',
+    {multiplier: 40000, unit: 'rows'},
+    async () => {
+      await load(geoArrayBuffer.slice(0), GeoParquetLoader, {
         core: {worker: false}
       });
     }

--- a/modules/shapefile/src/lib/parsers/build-wkb-geometry-arrow.ts
+++ b/modules/shapefile/src/lib/parsers/build-wkb-geometry-arrow.ts
@@ -4,8 +4,13 @@
 
 import * as arrow from 'apache-arrow';
 import type {ArrowTable, Schema as TableSchema} from '@loaders.gl/schema';
-import {convertSchemaToArrow} from '@loaders.gl/schema-utils';
-import {type CoordinateTransform, WKBBuilder, reprojectWKBInPlace} from '@loaders.gl/gis';
+import {
+  type CoordinateTransform,
+  WKBBuilder,
+  makeWKBGeometryArrowTable as makeSharedWKBGeometryArrowTable,
+  makeWKBGeometryArrowTableFromData,
+  makeWKBGeometryDataFromArray
+} from '@loaders.gl/gis';
 import type {SHPLoaderOptions} from './types';
 import {getRecordWKBOptions, writeRecordToWKB} from './parse-shp-geometry';
 
@@ -28,19 +33,7 @@ export function makeWKBGeometryArrowTable(
   schema: TableSchema,
   transform?: CoordinateTransform
 ): ArrowTable {
-  const arrowSchema = convertSchemaToArrow(schema);
-  const geometryData = makeWKBGeometryData(geometries, transform);
-  const structField = new arrow.Struct(arrowSchema.fields);
-  const structData = new arrow.Data(structField, 0, geometries.length, 0, undefined, [
-    geometryData
-  ]);
-  const recordBatch = new arrow.RecordBatch(arrowSchema, structData);
-
-  return {
-    shape: 'arrow-table',
-    schema,
-    data: new arrow.Table(arrowSchema, [recordBatch])
-  };
+  return makeSharedWKBGeometryArrowTable(geometries, schema, {transform});
 }
 
 /** Creates an Arrow table by writing SHP records directly into one WKB values buffer. */
@@ -50,19 +43,8 @@ export function makeSHPWKBGeometryArrowTable(
   options?: SHPLoaderOptions,
   transform?: CoordinateTransform
 ): ArrowTable {
-  const arrowSchema = convertSchemaToArrow(schema);
   const geometryData = makeSHPWKBGeometryData(arrayBuffer, options, transform);
-  const structField = new arrow.Struct(arrowSchema.fields);
-  const structData = new arrow.Data(structField, 0, geometryData.length, 0, undefined, [
-    geometryData
-  ]);
-  const recordBatch = new arrow.RecordBatch(arrowSchema, structData);
-
-  return {
-    shape: 'arrow-table',
-    schema,
-    data: new arrow.Table(arrowSchema, [recordBatch])
-  };
+  return makeWKBGeometryArrowTableFromData(schema, geometryData);
 }
 
 /** Creates Arrow Binary buffers by writing SHP records directly as WKB. */
@@ -81,74 +63,7 @@ export function makeSHPWKBGeometryData(
     transform
   );
 
-  return new arrow.Data(new arrow.Binary(), 0, valueOffsets.length - 1, nullCount, [
-    valueOffsets,
-    values,
-    nullCount > 0 ? nullBitmap : undefined
-  ]);
-}
-
-/** Creates Arrow Binary buffers containing WKB geometries. */
-export function makeWKBGeometryData(
-  geometries: (SHPWKBGeometry | null | undefined)[],
-  transform?: CoordinateTransform
-): arrow.Data<arrow.Binary> {
-  const valueOffsets = measureWKBGeometryOffsets(geometries);
-  const values = new Uint8Array(valueOffsets[valueOffsets.length - 1]);
-  const {nullBitmap, nullCount} = writeWKBGeometryValues(
-    geometries,
-    valueOffsets,
-    values,
-    transform
-  );
-
-  return new arrow.Data(new arrow.Binary(), 0, geometries.length, nullCount, [
-    valueOffsets,
-    values,
-    nullCount > 0 ? nullBitmap : undefined
-  ]);
-}
-
-function measureWKBGeometryOffsets(geometries: (SHPWKBGeometry | null | undefined)[]): Int32Array {
-  const valueOffsets = new Int32Array(geometries.length + 1);
-  for (let geometryIndex = 0; geometryIndex < geometries.length; geometryIndex++) {
-    const geometry = geometries[geometryIndex];
-    if (!geometry) {
-      valueOffsets[geometryIndex + 1] = valueOffsets[geometryIndex];
-      continue;
-    }
-
-    valueOffsets[geometryIndex + 1] = valueOffsets[geometryIndex] + geometry.byteLength;
-  }
-  return valueOffsets;
-}
-
-function writeWKBGeometryValues(
-  geometries: (SHPWKBGeometry | null | undefined)[],
-  valueOffsets: Int32Array,
-  values: Uint8Array,
-  transform?: CoordinateTransform
-): {nullBitmap: Uint8Array; nullCount: number} {
-  const nullBitmap = new Uint8Array(Math.ceil(geometries.length / 8));
-  let nullCount = 0;
-
-  for (let geometryIndex = 0; geometryIndex < geometries.length; geometryIndex++) {
-    const geometry = geometries[geometryIndex];
-    if (!geometry) {
-      nullCount++;
-      continue;
-    }
-
-    nullBitmap[geometryIndex >> 3] |= 1 << (geometryIndex & 7);
-    const startOffset = valueOffsets[geometryIndex];
-    const endOffset = valueOffsets[geometryIndex + 1];
-    values.set(geometry, startOffset);
-    if (transform) {
-      reprojectWKBInPlace(values.subarray(startOffset, endOffset), transform);
-    }
-  }
-
-  return {nullBitmap, nullCount};
+  return makeWKBGeometryDataFromArray({valueOffsets, values, nullBitmap, nullCount});
 }
 
 function measureSHPWKBGeometryOffsets(

--- a/modules/shapefile/test/shapefile.bench.ts
+++ b/modules/shapefile/test/shapefile.bench.ts
@@ -20,27 +20,19 @@ export default async function shapefileLoaderBench(suite) {
   // Add the tests
   suite.group('ShapefileLoader');
 
-  suite.addAsync(
-    'parse(ShapefileLoader without worker) to GeoArrow',
-    rowBenchmarkOptions,
-    async () => {
-      await load(arrayBuffer.slice(0), ShapefileLoader, {
-        core: {worker: false},
-        shapefile: {shape: 'arrow-table'}
-      });
-    }
-  );
+  suite.addAsync('load arrow-table geoarrow.wkb', rowBenchmarkOptions, async () => {
+    await load(arrayBuffer.slice(0), ShapefileLoader, {
+      core: {worker: false},
+      shapefile: {shape: 'arrow-table', geoarrowEncoding: 'geoarrow.wkb'}
+    });
+  });
 
-  suite.addAsync(
-    'parse(ShapefileLoader without worker) to GeoJSON',
-    rowBenchmarkOptions,
-    async () => {
-      await load(arrayBuffer.slice(0), ShapefileLoader, {
-        core: {worker: false},
-        shapefile: {shape: 'geojson-table'}
-      });
-    }
-  );
+  suite.addAsync('load geojson-table', rowBenchmarkOptions, async () => {
+    await load(arrayBuffer.slice(0), ShapefileLoader, {
+      core: {worker: false},
+      shapefile: {shape: 'geojson-table'}
+    });
+  });
 }
 
 /** Counts SHP records so benchmark throughput is reported as rows per second. */

--- a/test/bench/modules.js
+++ b/test/bench/modules.js
@@ -15,6 +15,9 @@ import excelBench from '@loaders.gl/excel/test/excel.bench';
 import imageBench from '@loaders.gl/images/test/images.bench';
 import jsonBench from '@loaders.gl/json/test/json-loader.bench';
 // import mvtBench from '@loaders.gl/mvt/test/mvt-loader.bench';
+import flatgeobufBench from '@loaders.gl/flatgeobuf/test/flatgeobuf.bench';
+import geopackageBench from '@loaders.gl/geopackage/test/geopackage.bench';
+import kmlBench from '@loaders.gl/kml/test/kml.bench';
 import {parquetBench} from '@loaders.gl/parquet/test/parquet.bench';
 import shapefileBench from '@loaders.gl/shapefile/test/shapefile.bench';
 import shpBench from '@loaders.gl/shapefile/test/shp.bench';
@@ -32,6 +35,9 @@ _addAliases(ALIASES);
 export async function addModuleBenchmarksToSuite(suite) {
   await shapefileBench(suite);
   await shpBench(suite);
+  await geopackageBench(suite);
+  await flatgeobufBench(suite);
+  await kmlBench(suite);
 
   await csvBench(suite);
 


### PR DESCRIPTION
## Goals

Make `geoarrow.wkb` the canonical loader-side geometry interchange for geospatial table outputs, keep loader geometry generation lightweight, and standardize geospatial output shape names.

## Changes

- Added shared `@loaders.gl/gis` helpers for constructing Arrow `geoarrow.wkb` geometry columns from WKB values or `WKBBuilder` writer callbacks.
- Refactored Shapefile WKB Arrow output to use shared GIS WKB Arrow builders.
- Updated GeoPackage `arrow-table` output to strip GeoPackage headers and preserve embedded WKB bytes directly, with shared WKB reprojection when requested.
- Routed FlatGeobuf WKB output through shared GIS WKB helpers.
- Added `csv.geometryEncoding: 'wkb' | 'source'`; detected CSV WKT now emits `geoarrow.wkb` by default while `source` preserves `geoarrow.wkt`.
- Standardized geospatial shapes on `geojson-table` and `binary-geometry`; removed `geojson`/`binary` shape aliases from affected loaders.
- Added benchmarks for geospatial loaders covering `arrow-table` GeoArrow/WKB and `geojson-table` outputs.
- Updated docs, upgrade guide, and AGENTS module-boundary guidance.
- Removed geospatial loader source dependency on the larger `@loaders.gl/geoarrow` module.

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn test-headless`
- Focused node tests for touched CSV, GIS, geospatial loader, MVT/MLT, and parquet paths
