### PR TITLE
fix(geoparquet): restore GeoJSON output

### DIFF
--- a/modules/parquet/src/lib/parsers/parse-geoparquet-to-geojson.ts
+++ b/modules/parquet/src/lib/parsers/parse-geoparquet-to-geojson.ts
@@ -20,7 +20,7 @@ export async function parseGeoParquetFile(
   options?: ParquetJSONLoaderOptions
 ): Promise<ObjectRowTable | GeoJSONTable> {
   const table = await parseParquetFile(file, {...options, shape: 'object-row-table'});
-  return convertWKBTableToGeoJSON(table as ObjectRowTable, table.schema!);
+  return convertWKBTableToGeoJSON(table, table.schema!);
 }
 
 export async function* parseGeoParquetFileInBatches(

--- a/modules/parquet/src/lib/parsers/parse-geoparquet-to-geojson.ts
+++ b/modules/parquet/src/lib/parsers/parse-geoparquet-to-geojson.ts
@@ -9,7 +9,7 @@ import type {
   ObjectRowTable,
   ObjectRowTableBatch
 } from '@loaders.gl/schema';
-// import {convertGeoArrowToTable} from '@loaders.gl/gis';
+import {convertWKBTableToGeoJSON} from '@loaders.gl/gis';
 
 import type {ParquetJSONLoaderOptions} from '../../parquet-json-loader';
 
@@ -20,8 +20,7 @@ export async function parseGeoParquetFile(
   options?: ParquetJSONLoaderOptions
 ): Promise<ObjectRowTable | GeoJSONTable> {
   const table = await parseParquetFile(file, {...options, shape: 'object-row-table'});
-  // return convertGeoArrowToTable(table, 'geojson-table');
-  return table;
+  return convertWKBTableToGeoJSON(table as ObjectRowTable, table.schema!);
 }
 
 export async function* parseGeoParquetFileInBatches(
@@ -31,6 +30,7 @@ export async function* parseGeoParquetFileInBatches(
   const tableBatches = parseParquetFileInBatches(file, {...options, shape: 'object-row-table'});
 
   for await (const batch of tableBatches) {
-    yield batch; // convertGeoArrowToTable(batch, 'geojson-table');
+    const geojson = convertWKBTableToGeoJSON(batch as ObjectRowTable, batch.schema!);
+    yield {...batch, ...geojson};
   }
 }


### PR DESCRIPTION
### Background

4.4 introduced a regression where the geoparquet loader no longer outpus geojson as it previously did. `master` has diverged a lot, so applying only as a patch to `4.4-release`.

### Changes

- Use `convertWKBTableToGeoJSON` to re-instate previous behavior