### PR TITLE
feat(json) Fast streaming JSON loader backend

### DIFF
--- a/dev-modules/devtools-extensions/docs/README.md
+++ b/dev-modules/devtools-extensions/docs/README.md
@@ -4,7 +4,7 @@
 
 Current support:
 - Biome base config and root lint wrapper used by `yarn lint` / `yarn lint fix`
-- Benchmark resolver used by `yarn test bench`
+- Benchmark resolver used by `yarn test bench`, including source-first workspace resolution and TypeScript transpilation so Node benchmarks do not require prebuilt `dist`
 - Browser benchmark runner used by `yarn test bench-browser` / `yarn test bench-headless`
 
 Boundary:

--- a/docs/modules/json/README.md
+++ b/docs/modules/json/README.md
@@ -9,6 +9,8 @@ The `@loaders.gl/json` module parses JSON. It can parse arbitrary JSON data but 
 The JSON loaders also support batched parsing which can be useful when loading very large tabular JSON files
 to avoid blocking for tens of seconds.
 
+`JSONLoader` exposes `json.backend: 'fast'` as an experimental opt-in backend for streaming extraction. This keeps atomic JSON parsing on the standard `JSON.parse` path while using the faster streaming parser for `loadInBatches`.
+
 ## Installation
 
 ```bash

--- a/docs/modules/json/api-reference/json-loader.md
+++ b/docs/modules/json/api-reference/json-loader.md
@@ -40,6 +40,14 @@ for await (const batch of batches) {
 
 If no JSONPath is specified, the loader streams the first array it encounters in the JSON payload.
 
+For faster opt-in streaming extraction, set `json.backend: 'fast'`. This affects streaming parsing only; atomic JSON parsing still uses `JSON.parse`.
+
+```typescript
+const batches = await loadInBatches('geojson.json', JSONLoader, {
+  json: {backend: 'fast', jsonpaths: ['$.features']}
+});
+```
+
 ### Metadata Batches
 
 When batch parsing an embedded JSON array as a table, set `metadata: true` to access the containing object. The loader yields an initial and final batch with `batch.container` providing the container object and `batch.batchType` set to `partial-result` and `final-result`.
@@ -97,6 +105,7 @@ Supports table category options such as `batchType` and `batchSize`.
 | Option                 | From                                                                                  | Type       | Default                                                                                                                                          | Description                                                                                                                           |
 | ---------------------- | ------------------------------------------------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
 | `json.table`           | [![Website shields.io](https://img.shields.io/badge/v2.0-blue.svg?style=flat-square)] | `boolean`  | `false`                                                                                                                                          | Parses non-streaming JSON as table, i.e. return the first embedded array in the JSON. Always `true` during batched/streaming parsing. |
+| `json.backend`         | [![Website shields.io](https://img.shields.io/badge/Experimental-orange.svg?style=flat-square)] | `'clarinet' \| 'fast'` | `'clarinet'` | Selects the streaming parser backend. Set to `'fast'` to opt into the faster streaming extractor. |
 | `json.shape`           | [![Website shields.io](https://img.shields.io/badge/From-v5.0-blue.svg?style=flat-square)](http://shields.io) | `'object-row-table' \| 'array-row-table' \| 'arrow-table'` | `object-row-table` | Selects row-table output or Apache Arrow output for tabular JSON results. |
 | `json.jsonpaths`       | [![Website shields.io](https://img.shields.io/badge/v2.2-blue.svg?style=flat-square)] | `string[]` | `[]`                                                                                                                                             | A list of JSON paths indicating the array that can be streamed.                                                                       |
 | `metadata` (top level) | [![Website shields.io](https://img.shields.io/badge/v2.2-blue.svg?style=flat-square)] | `boolean`  | If `true`, yields an initial and final batch containing the partial and final result, i.e. the root object excluding the array being streamed. |

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -83,6 +83,10 @@ Release Date: 2026
 - [`GeoTIFFSourceLoader`](/docs/modules/geotiff/api-reference/geotiff-source-loader) NEW - viewport-driven GeoTIFF / COG source that returns typed raster payloads plus CRS and bounds metadata.
 - [`OMETiffSourceLoader`](/docs/modules/geotiff/api-reference/ometiff-source-loader) NEW - non-geospatial OME-TIFF source for channel-aware 2D plane reads from image pyramids.
 
+**@loaders.gl/json**
+
+- [`JSONLoader`](/docs/modules/json/api-reference/json-loader) adds experimental `json.backend: 'fast'` for opt-in faster streaming extraction while keeping atomic JSON parsing on the standard `JSON.parse` path.
+
 **@loaders.gl/tiles**
 
 - `RasterSet` NEW - loading manager for `RasterSource` implementations with metadata caching, debounced viewport requests, and loading lifecycle callbacks.

--- a/modules/json/src/fast-json-loader.ts
+++ b/modules/json/src/fast-json-loader.ts
@@ -1,0 +1,75 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Table, TableBatch} from '@loaders.gl/schema';
+import type {LoaderWithParser} from '@loaders.gl/loader-utils';
+import type {JSONBatch, JSONLoaderOptions, MetadataBatch} from './json-loader';
+import {parseJSONSync} from './lib/parsers/parse-json';
+import {parseJSONInBatches} from './lib/parsers/parse-json-in-batches';
+import FastStreamingJSONParser from './lib/json-parser/fast-streaming-json-parser';
+
+// __VERSION__ is injected by babel-plugin-version-inline
+// @ts-ignore TS2304: Cannot find name '__VERSION__'.
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+
+/**
+ * Experimental JSON loader that uses the fast streaming parser backend.
+ */
+export const FastJSONLoader = {
+  dataType: null as unknown as Table,
+  batchType: null as unknown as TableBatch | MetadataBatch | JSONBatch,
+
+  name: 'Fast JSON',
+  id: 'fast-json',
+  module: 'json',
+  version: VERSION,
+  extensions: ['json', 'geojson'],
+  mimeTypes: ['application/json'],
+  category: 'table',
+  text: true,
+  options: {
+    json: {
+      shape: undefined,
+      table: false,
+      jsonpaths: []
+    }
+  },
+  parse,
+  parseTextSync,
+  parseInBatches
+} as const satisfies LoaderWithParser<
+  Table,
+  TableBatch | MetadataBatch | JSONBatch,
+  JSONLoaderOptions
+>;
+
+/**
+ * Parses JSON from an ArrayBuffer.
+ */
+async function parse(arrayBuffer: ArrayBuffer, options?: JSONLoaderOptions) {
+  return parseTextSync(new TextDecoder().decode(arrayBuffer), options);
+}
+
+/**
+ * Parses JSON text synchronously with the standard JSON.parse code path.
+ */
+function parseTextSync(text: string, options?: JSONLoaderOptions) {
+  const jsonOptions = {...options, json: {...FastJSONLoader.options.json, ...options?.json}};
+  return parseJSONSync(text, jsonOptions as JSONLoaderOptions);
+}
+
+/**
+ * Parses JSON in batches using the fast streaming parser backend.
+ */
+function parseInBatches(
+  asyncIterator:
+    | AsyncIterable<ArrayBufferLike | ArrayBufferView>
+    | Iterable<ArrayBufferLike | ArrayBufferView>,
+  options?: JSONLoaderOptions
+): AsyncIterable<TableBatch | MetadataBatch | JSONBatch> {
+  const jsonOptions = {...options, json: {...FastJSONLoader.options.json, ...options?.json}};
+  return parseJSONInBatches(asyncIterator, jsonOptions as JSONLoaderOptions, {
+    parserFactory: parserOptions => new FastStreamingJSONParser(parserOptions)
+  });
+}

--- a/modules/json/src/fast-json-loader.ts
+++ b/modules/json/src/fast-json-loader.ts
@@ -30,6 +30,7 @@ export const FastJSONLoader = {
   text: true,
   options: {
     json: {
+      backend: 'fast',
       shape: undefined,
       table: false,
       jsonpaths: []
@@ -46,6 +47,10 @@ export const FastJSONLoader = {
 
 /**
  * Parses JSON from an ArrayBuffer.
+ *
+ * @param arrayBuffer - UTF-8 encoded JSON payload.
+ * @param options - JSON loader options.
+ * @returns Parsed JSON data using the atomic JSON parser path.
  */
 async function parse(arrayBuffer: ArrayBuffer, options?: JSONLoaderOptions) {
   return parseTextSync(new TextDecoder().decode(arrayBuffer), options);
@@ -53,6 +58,10 @@ async function parse(arrayBuffer: ArrayBuffer, options?: JSONLoaderOptions) {
 
 /**
  * Parses JSON text synchronously with the standard JSON.parse code path.
+ *
+ * @param text - JSON text to parse.
+ * @param options - JSON loader options.
+ * @returns Parsed JSON data or table output.
  */
 function parseTextSync(text: string, options?: JSONLoaderOptions) {
   const jsonOptions = {...options, json: {...FastJSONLoader.options.json, ...options?.json}};
@@ -61,6 +70,10 @@ function parseTextSync(text: string, options?: JSONLoaderOptions) {
 
 /**
  * Parses JSON in batches using the fast streaming parser backend.
+ *
+ * @param asyncIterator - Iterable or async iterable of binary JSON chunks.
+ * @param options - JSON loader options.
+ * @returns Async iterable of parsed JSON batches.
  */
 function parseInBatches(
   asyncIterator:

--- a/modules/json/src/index.ts
+++ b/modules/json/src/index.ts
@@ -17,9 +17,11 @@ export {GeoJSONLoader as _GeoJSONLoader} from './geojson-loader';
 
 export type {GeoJSONWriterOptions as _GeoJSONWriterOptions} from './geojson-writer';
 export {GeoJSONWriter as _GeoJSONWriter} from './geojson-writer';
+export {FastJSONLoader as _FastJSONLoader} from './fast-json-loader';
 
 export {default as _JSONPath} from './lib/jsonpath/jsonpath';
 export {default as _ClarinetParser} from './lib/clarinet/clarinet';
+export {default as _FastStreamingJSONParser} from './lib/json-parser/fast-streaming-json-parser';
 
 export {rebuildJsonObject as _rebuildJsonObject} from './lib/parsers/parse-json-in-batches';
 

--- a/modules/json/src/json-loader-with-parser.ts
+++ b/modules/json/src/json-loader-with-parser.ts
@@ -15,10 +15,12 @@ import {makeTableFromData} from '@loaders.gl/schema-utils';
 import type {LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';
 import {parseJSONSync} from './lib/parsers/parse-json';
 import {parseJSONInBatches} from './lib/parsers/parse-json-in-batches';
+import FastStreamingJSONParser from './lib/json-parser/fast-streaming-json-parser';
 import {
   convertRowTableToArrowTable,
   convertTableBatchesToArrow
 } from './lib/parsers/convert-row-table-to-arrow';
+import type {StreamingJSONParserFactory} from './lib/json-parser/streaming-json-parser-types';
 import {JSONLoader as JSONLoaderMetadata} from './json-loader';
 
 const {preload: _JSONLoaderPreload, ...JSONLoaderMetadataWithoutPreload} = JSONLoaderMetadata;
@@ -38,6 +40,8 @@ export type JSONBatch = Batch & {
 /** Options for parsing JSON documents and tabular selections. */
 export type JSONLoaderOptions = LoaderOptions & {
   json?: {
+    /** Selects the streaming JSON parser backend. */
+    backend?: 'clarinet' | 'fast';
     /** Selects row-table output or Apache Arrow output for tabular JSON. */
     shape?: 'object-row-table' | 'array-row-table' | 'arrow-table';
     /** Enables table extraction from non-streaming JSON. */
@@ -59,10 +63,24 @@ export const JSONLoaderWithParser = {
   JSONLoaderOptions
 >;
 
+/**
+ * Parses JSON from an ArrayBuffer using the configured JSON loader options.
+ *
+ * @param arrayBuffer - UTF-8 encoded JSON payload.
+ * @param options - JSON loader options.
+ * @returns Parsed JSON, row table, or Arrow table output.
+ */
 async function parse(arrayBuffer: ArrayBuffer, options?: JSONLoaderOptions) {
   return parseTextSync(new TextDecoder().decode(arrayBuffer), options);
 }
 
+/**
+ * Parses JSON text synchronously using the atomic JSON parser path.
+ *
+ * @param text - JSON text to parse.
+ * @param options - JSON loader options.
+ * @returns Parsed JSON, row table, or Arrow table output.
+ */
 function parseTextSync(text: string, options?: JSONLoaderOptions) {
   const jsonOptions = {...options, json: {...JSONLoaderWithParser.options.json, ...options?.json}};
   const json = parseJSONSync(text, jsonOptions as JSONLoaderOptions);
@@ -74,6 +92,13 @@ function parseTextSync(text: string, options?: JSONLoaderOptions) {
   return table ? convertRowTableToArrowTable(table) : json;
 }
 
+/**
+ * Parses JSON incrementally and yields table or metadata batches.
+ *
+ * @param asyncIterator - Iterable or async iterable of binary JSON chunks.
+ * @param options - JSON loader options, including the optional streaming backend.
+ * @returns Async iterable of parsed JSON batches.
+ */
 function parseInBatches(
   asyncIterator:
     | AsyncIterable<ArrayBufferLike | ArrayBufferView>
@@ -81,8 +106,21 @@ function parseInBatches(
   options?: JSONLoaderOptions
 ): AsyncIterable<TableBatch | ArrowTableBatch | MetadataBatch | JSONBatch> {
   const jsonOptions = {...options, json: {...JSONLoaderWithParser.options.json, ...options?.json}};
-  const batches = parseJSONInBatches(asyncIterator, jsonOptions as JSONLoaderOptions);
+  const parseOptions =
+    jsonOptions.json?.backend === 'fast'
+      ? {parserFactory: getFastStreamingJSONParserFactory()}
+      : undefined;
+  const batches = parseJSONInBatches(asyncIterator, jsonOptions as JSONLoaderOptions, parseOptions);
   return jsonOptions.json?.shape === 'arrow-table' ? convertTableBatchesToArrow(batches) : batches;
+}
+
+/**
+ * Returns a factory for the fast streaming JSON parser backend.
+ *
+ * @returns Parser factory that constructs `FastStreamingJSONParser` instances.
+ */
+function getFastStreamingJSONParserFactory(): StreamingJSONParserFactory {
+  return parserOptions => new FastStreamingJSONParser(parserOptions);
 }
 
 /**

--- a/modules/json/src/json-loader.ts
+++ b/modules/json/src/json-loader.ts
@@ -25,6 +25,8 @@ export type JSONBatch = Batch & {
 /** Options for parsing JSON documents and tabular selections. */
 export type JSONLoaderOptions = LoaderOptions & {
   json?: {
+    /** Selects the streaming JSON parser backend. */
+    backend?: 'clarinet' | 'fast';
     /** Selects row-table output or Apache Arrow output for tabular JSON. */
     shape?: 'object-row-table' | 'array-row-table' | 'arrow-table';
     /** Enables table extraction from non-streaming JSON. */
@@ -49,6 +51,7 @@ export const JSONLoader = {
   version: VERSION,
   options: {
     json: {
+      backend: 'clarinet',
       shape: undefined,
       table: false,
       jsonpaths: []

--- a/modules/json/src/lib/json-parser/fast-streaming-json-parser.ts
+++ b/modules/json/src/lib/json-parser/fast-streaming-json-parser.ts
@@ -1,0 +1,651 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import JSONPath from '../jsonpath/jsonpath';
+import type {
+  StreamingJSONParserLike,
+  StreamingJSONParserOptions
+} from './streaming-json-parser-types';
+
+type ObjectFrame = {
+  type: 'object';
+  path: string[];
+  expecting: 'keyOrEnd' | 'colon' | 'value' | 'commaOrEnd';
+  currentKey: string | null;
+};
+
+type ArrayFrame = {
+  type: 'array';
+  path: string[];
+  expecting: 'valueOrEnd' | 'commaOrEnd';
+};
+
+type Frame = ObjectFrame | ArrayFrame;
+
+type StringContext = {
+  forKey: boolean;
+  escape: boolean;
+  unicodeDigitsRemaining: number;
+  unicodeHex: string;
+  keyText: string;
+};
+
+/**
+ * Streaming JSON parser optimized for extracting one matching array from the input.
+ */
+export default class FastStreamingJSONParser implements StreamingJSONParserLike {
+  private readonly allowedJsonPaths: string[][];
+  private readonly trackMetadata: boolean;
+
+  private mode: 'seek' | 'stream' | 'after' = 'seek';
+  private streamingJsonPath: JSONPath | null = null;
+  private partialResult: unknown = null;
+  private finalResult: unknown = null;
+  private emittedRows: unknown[] = [];
+
+  private readonly seekFrames: Frame[] = [];
+  private seekStringContext: StringContext | null = null;
+  private seekPrimitiveActive = false;
+  private seekRootComplete = false;
+
+  private streamBuffer = '';
+  private streamElementType: 'none' | 'string' | 'primitive' | 'complex' = 'none';
+  private streamElementBuffer = '';
+  private streamElementDepth = 0;
+  private streamInString = false;
+  private streamEscape = false;
+  private streamUnicodeDigitsRemaining = 0;
+  private targetArrayClosed = false;
+
+  private fullText = '';
+
+  constructor(options: StreamingJSONParserOptions = {}) {
+    this.allowedJsonPaths = (options.jsonpaths || []).map(jsonpath => new JSONPath(jsonpath).path);
+    this.trackMetadata = Boolean(options.metadata);
+  }
+
+  /** @inheritdoc */
+  write(chunk: string): unknown[] {
+    const chunkStartOffset = this.fullText.length;
+
+    if (this.trackMetadata) {
+      this.fullText += chunk;
+    }
+
+    let streamChunk = '';
+
+    if (this.mode === 'seek') {
+      const streamStartIndex = this.scanForStreamingArray(chunk, chunkStartOffset);
+      if (streamStartIndex !== null) {
+        streamChunk = chunk.slice(streamStartIndex);
+      }
+    } else if (this.mode === 'stream') {
+      streamChunk = chunk;
+    }
+
+    if (streamChunk) {
+      this.streamBuffer += streamChunk;
+      this.parseStreamBuffer();
+    }
+
+    const rows = this.emittedRows;
+    this.emittedRows = [];
+    return rows;
+  }
+
+  /** @inheritdoc */
+  close(): void {
+    if (this.mode === 'stream') {
+      this.parseStreamBuffer();
+    }
+
+    if (!this.trackMetadata || this.streamingJsonPath) {
+      return;
+    }
+
+    try {
+      this.finalResult = JSON.parse(this.fullText);
+    } catch {
+      this.finalResult = this.partialResult;
+    }
+  }
+
+  /** @inheritdoc */
+  getPartialResult(): unknown {
+    if (this.streamingJsonPath) {
+      return this.partialResult;
+    }
+    return this.finalResult ?? this.partialResult;
+  }
+
+  /** @inheritdoc */
+  getStreamingJsonPath(): JSONPath | null {
+    return this.streamingJsonPath;
+  }
+
+  /** @inheritdoc */
+  getStreamingJsonPathAsString(): string | null {
+    return this.streamingJsonPath?.toString() || null;
+  }
+
+  /**
+   * Scans input until the matching array start is found.
+   */
+  private scanForStreamingArray(chunk: string, chunkStartOffset: number): number | null {
+    let index = 0;
+
+    while (index < chunk.length && !this.seekRootComplete) {
+      const character = chunk[index];
+
+      if (this.seekStringContext) {
+        this.consumeSeekStringCharacter(character);
+        index++;
+        continue;
+      }
+
+      if (this.seekPrimitiveActive) {
+        if (isValueDelimiter(character)) {
+          this.seekPrimitiveActive = false;
+          this.finishSeekValue();
+          continue;
+        }
+        index++;
+        continue;
+      }
+
+      const frame = this.seekFrames[this.seekFrames.length - 1];
+
+      if (!frame) {
+        if (isWhitespace(character)) {
+          index++;
+          continue;
+        }
+        const streamStartIndex = this.handleSeekValueStart(
+          ['$'],
+          character,
+          chunkStartOffset + index
+        );
+        if (streamStartIndex !== null) {
+          return streamStartIndex - chunkStartOffset;
+        }
+        index++;
+        continue;
+      }
+
+      if (frame.type === 'object') {
+        switch (frame.expecting) {
+          case 'keyOrEnd':
+            if (isWhitespace(character)) {
+              index++;
+              continue;
+            }
+            if (character === '"') {
+              this.seekStringContext = createStringContext(true);
+            } else if (character === '}') {
+              this.seekFrames.pop();
+              this.finishSeekValue();
+            }
+            index++;
+            continue;
+
+          case 'colon':
+            if (isWhitespace(character)) {
+              index++;
+              continue;
+            }
+            if (character === ':') {
+              frame.expecting = 'value';
+            }
+            index++;
+            continue;
+
+          case 'value':
+            if (isWhitespace(character)) {
+              index++;
+              continue;
+            }
+            if (frame.currentKey) {
+              const streamStartIndex = this.handleSeekValueStart(
+                [...frame.path, frame.currentKey],
+                character,
+                chunkStartOffset + index
+              );
+              if (streamStartIndex !== null) {
+                return streamStartIndex - chunkStartOffset;
+              }
+            }
+            index++;
+            continue;
+
+          case 'commaOrEnd':
+            if (isWhitespace(character)) {
+              index++;
+              continue;
+            }
+            if (character === ',') {
+              frame.currentKey = null;
+              frame.expecting = 'keyOrEnd';
+            } else if (character === '}') {
+              this.seekFrames.pop();
+              this.finishSeekValue();
+            }
+            index++;
+            continue;
+        }
+      }
+
+      switch (frame.expecting) {
+        case 'valueOrEnd':
+          if (isWhitespace(character)) {
+            index++;
+            continue;
+          }
+          if (character === ']') {
+            this.seekFrames.pop();
+            this.finishSeekValue();
+            index++;
+            continue;
+          }
+          const streamStartIndex = this.handleSeekValueStart(
+            [...frame.path],
+            character,
+            chunkStartOffset + index
+          );
+          if (streamStartIndex !== null) {
+            return streamStartIndex - chunkStartOffset;
+          }
+          index++;
+          continue;
+
+        case 'commaOrEnd':
+          if (isWhitespace(character)) {
+            index++;
+            continue;
+          }
+          if (character === ',') {
+            frame.expecting = 'valueOrEnd';
+          } else if (character === ']') {
+            this.seekFrames.pop();
+            this.finishSeekValue();
+          }
+          index++;
+          continue;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Handles the start of a value while seeking the streaming array.
+   */
+  private handleSeekValueStart(
+    valuePath: string[],
+    character: string,
+    absoluteIndex: number
+  ): number | null {
+    if (character === '{') {
+      this.seekFrames.push({
+        type: 'object',
+        path: valuePath,
+        expecting: 'keyOrEnd',
+        currentKey: null
+      });
+      return null;
+    }
+
+    if (character === '[') {
+      if (!this.streamingJsonPath && this.matchesPath(valuePath)) {
+        this.streamingJsonPath = new JSONPath(valuePath.slice(1));
+        this.mode = 'stream';
+        this.buildPartialResult(absoluteIndex);
+        return absoluteIndex + 1;
+      }
+
+      this.seekFrames.push({
+        type: 'array',
+        path: valuePath,
+        expecting: 'valueOrEnd'
+      });
+      return null;
+    }
+
+    if (character === '"') {
+      this.seekStringContext = createStringContext(false);
+      return null;
+    }
+
+    this.seekPrimitiveActive = true;
+    return null;
+  }
+
+  /**
+   * Consumes one character while scanning a JSON string in seek mode.
+   */
+  private consumeSeekStringCharacter(character: string): void {
+    const context = this.seekStringContext;
+
+    if (!context) {
+      return;
+    }
+
+    if (context.unicodeDigitsRemaining > 0) {
+      context.unicodeHex += character;
+      context.unicodeDigitsRemaining--;
+      if (context.unicodeDigitsRemaining === 0 && context.forKey) {
+        context.keyText += String.fromCharCode(Number.parseInt(context.unicodeHex, 16));
+        context.unicodeHex = '';
+      }
+      return;
+    }
+
+    if (context.escape) {
+      context.escape = false;
+      if (character === 'u') {
+        context.unicodeDigitsRemaining = 4;
+        context.unicodeHex = '';
+        return;
+      }
+      if (context.forKey) {
+        context.keyText += decodeEscapedCharacter(character);
+      }
+      return;
+    }
+
+    if (character === '\\') {
+      context.escape = true;
+      return;
+    }
+
+    if (character === '"') {
+      this.seekStringContext = null;
+      if (context.forKey) {
+        const frame = this.seekFrames[this.seekFrames.length - 1];
+        if (frame?.type === 'object') {
+          frame.currentKey = context.keyText;
+          frame.expecting = 'colon';
+        }
+      } else {
+        this.finishSeekValue();
+      }
+      return;
+    }
+
+    if (context.forKey) {
+      context.keyText += character;
+    }
+  }
+
+  /**
+   * Marks the current value as complete in seek mode.
+   */
+  private finishSeekValue(): void {
+    const frame = this.seekFrames[this.seekFrames.length - 1];
+
+    if (!frame) {
+      this.seekRootComplete = true;
+      return;
+    }
+
+    if (frame.type === 'object') {
+      frame.currentKey = null;
+      frame.expecting = 'commaOrEnd';
+      return;
+    }
+
+    frame.expecting = 'commaOrEnd';
+  }
+
+  /**
+   * Parses the target array contents and emits complete top-level rows.
+   */
+  private parseStreamBuffer(): void {
+    let index = 0;
+
+    while (index < this.streamBuffer.length && !this.targetArrayClosed) {
+      const character = this.streamBuffer[index];
+
+      if (this.streamElementType === 'none') {
+        if (isWhitespace(character) || character === ',') {
+          index++;
+          continue;
+        }
+        if (character === ']') {
+          this.targetArrayClosed = true;
+          this.mode = 'after';
+          index++;
+          continue;
+        }
+
+        if (character === '"') {
+          this.streamElementType = 'string';
+          this.streamElementBuffer = '"';
+          this.streamInString = true;
+          this.streamEscape = false;
+          this.streamUnicodeDigitsRemaining = 0;
+          index++;
+          continue;
+        }
+
+        if (character === '{' || character === '[') {
+          this.streamElementType = 'complex';
+          this.streamElementBuffer = character;
+          this.streamElementDepth = 1;
+          this.streamInString = false;
+          this.streamEscape = false;
+          this.streamUnicodeDigitsRemaining = 0;
+          index++;
+          continue;
+        }
+
+        this.streamElementType = 'primitive';
+        this.streamElementBuffer = character;
+        index++;
+        continue;
+      }
+
+      if (this.streamElementType === 'primitive') {
+        if (isStreamElementDelimiter(character)) {
+          this.emitStreamElement();
+          continue;
+        }
+        this.streamElementBuffer += character;
+        index++;
+        continue;
+      }
+
+      this.streamElementBuffer += character;
+
+      if (this.streamUnicodeDigitsRemaining > 0) {
+        this.streamUnicodeDigitsRemaining--;
+        index++;
+        continue;
+      }
+
+      if (this.streamEscape) {
+        this.streamEscape = false;
+        if (character === 'u') {
+          this.streamUnicodeDigitsRemaining = 4;
+        }
+        index++;
+        continue;
+      }
+
+      if (character === '\\') {
+        this.streamEscape = true;
+        index++;
+        continue;
+      }
+
+      if (character === '"') {
+        this.streamInString = !this.streamInString;
+        if (this.streamElementType === 'string' && !this.streamInString) {
+          this.emitStreamElement();
+        }
+        index++;
+        continue;
+      }
+
+      if (!this.streamInString && this.streamElementType === 'complex') {
+        if (character === '{' || character === '[') {
+          this.streamElementDepth++;
+        } else if (character === '}' || character === ']') {
+          this.streamElementDepth--;
+          if (this.streamElementDepth === 0) {
+            this.emitStreamElement();
+          }
+        }
+      }
+
+      index++;
+    }
+
+    this.streamBuffer = this.targetArrayClosed ? '' : this.streamBuffer.slice(index);
+  }
+
+  /**
+   * Emits the currently buffered stream element.
+   */
+  private emitStreamElement(): void {
+    if (!this.streamElementBuffer) {
+      this.resetStreamElement();
+      return;
+    }
+
+    try {
+      this.emittedRows.push(JSON.parse(this.streamElementBuffer));
+    } catch {
+      // Ignore incomplete elements until more data arrives.
+    }
+
+    this.resetStreamElement();
+  }
+
+  /**
+   * Resets per-element stream parsing state.
+   */
+  private resetStreamElement(): void {
+    this.streamElementType = 'none';
+    this.streamElementBuffer = '';
+    this.streamElementDepth = 0;
+    this.streamInString = false;
+    this.streamEscape = false;
+    this.streamUnicodeDigitsRemaining = 0;
+  }
+
+  /**
+   * Builds the partial wrapper object for metadata batches.
+   */
+  private buildPartialResult(targetArrayStartOffset: number): void {
+    if (!this.trackMetadata) {
+      return;
+    }
+
+    if (!this.streamingJsonPath || this.streamingJsonPath.path.length === 1) {
+      this.partialResult = [];
+      return;
+    }
+
+    const prefix = this.fullText.slice(0, targetArrayStartOffset);
+    const suffix = this.seekFrames
+      .slice()
+      .reverse()
+      .map(frame => (frame.type === 'object' ? '}' : ']'))
+      .join('');
+
+    try {
+      this.partialResult = JSON.parse(`${prefix}[]${suffix}`);
+    } catch {
+      this.partialResult = null;
+    }
+  }
+
+  /**
+   * Checks whether the current path matches one of the configured JSON paths.
+   */
+  private matchesPath(path: string[]): boolean {
+    if (this.allowedJsonPaths.length === 0) {
+      return true;
+    }
+
+    return this.allowedJsonPaths.some(jsonPath => pathsEqual(jsonPath, path));
+  }
+}
+
+/**
+ * Creates string parsing state for seek mode.
+ */
+function createStringContext(forKey: boolean): StringContext {
+  return {
+    forKey,
+    escape: false,
+    unicodeDigitsRemaining: 0,
+    unicodeHex: '',
+    keyText: ''
+  };
+}
+
+/**
+ * Compares two JSON path arrays.
+ */
+function pathsEqual(left: string[], right: string[]): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  for (let index = 0; index < left.length; index++) {
+    if (left[index] !== right[index]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Decodes a single escaped JSON character.
+ */
+function decodeEscapedCharacter(character: string): string {
+  switch (character) {
+    case '"':
+      return '"';
+    case '\\':
+      return '\\';
+    case '/':
+      return '/';
+    case 'b':
+      return '\b';
+    case 'f':
+      return '\f';
+    case 'n':
+      return '\n';
+    case 'r':
+      return '\r';
+    case 't':
+      return '\t';
+    default:
+      return character;
+  }
+}
+
+/**
+ * Checks whether a character is JSON whitespace.
+ */
+function isWhitespace(character: string): boolean {
+  return character === ' ' || character === '\n' || character === '\r' || character === '\t';
+}
+
+/**
+ * Checks whether a character terminates a primitive JSON value.
+ */
+function isValueDelimiter(character: string): boolean {
+  return isWhitespace(character) || character === ',' || character === '}' || character === ']';
+}
+
+/**
+ * Checks whether a character terminates a streamed top-level array element.
+ */
+function isStreamElementDelimiter(character: string): boolean {
+  return isWhitespace(character) || character === ',' || character === ']';
+}

--- a/modules/json/src/lib/json-parser/streaming-json-parser-types.ts
+++ b/modules/json/src/lib/json-parser/streaming-json-parser-types.ts
@@ -1,0 +1,31 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type JSONPath from '../jsonpath/jsonpath';
+
+/**
+ * Options shared by streaming JSON parser backends.
+ */
+export type StreamingJSONParserOptions = {
+  jsonpaths?: string[];
+  metadata?: boolean;
+};
+
+/**
+ * Interface implemented by streaming JSON parser backends.
+ */
+export interface StreamingJSONParserLike {
+  write(chunk: string): unknown[];
+  close(): void;
+  getPartialResult(): unknown;
+  getStreamingJsonPath(): JSONPath | null;
+  getStreamingJsonPathAsString(): string | null;
+}
+
+/**
+ * Factory type for streaming JSON parser backends.
+ */
+export type StreamingJSONParserFactory = (
+  options?: StreamingJSONParserOptions
+) => StreamingJSONParserLike;

--- a/modules/json/src/lib/json-parser/streaming-json-parser.ts
+++ b/modules/json/src/lib/json-parser/streaming-json-parser.ts
@@ -4,6 +4,7 @@
 
 import {default as JSONParser} from './json-parser';
 import JSONPath from '../jsonpath/jsonpath';
+import type {StreamingJSONParserOptions} from './streaming-json-parser-types';
 
 /**
  * The `StreamingJSONParser` looks for the first array in the JSON structure.
@@ -21,7 +22,7 @@ export default class StreamingJSONParser extends JSONParser {
   /** Root object used by metadata batches when streaming an embedded array. */
   private topLevelObject: object | null = null;
 
-  constructor(options: {[key: string]: any} = {}) {
+  constructor(options: StreamingJSONParserOptions = {}) {
     super({
       onopenarray: () => {
         if (!this.streamingArray) {

--- a/modules/json/src/lib/parsers/parse-json-in-batches.ts
+++ b/modules/json/src/lib/parsers/parse-json-in-batches.ts
@@ -8,7 +8,15 @@ import type {JSONLoaderOptions, MetadataBatch, JSONBatch} from '../../json-loade
 import {TableBatchBuilder} from '@loaders.gl/schema-utils';
 import {assert, makeTextDecoderIterator, toArrayBufferIterator} from '@loaders.gl/loader-utils';
 import StreamingJSONParser from '../json-parser/streaming-json-parser';
+import type {
+  StreamingJSONParserFactory,
+  StreamingJSONParserOptions
+} from '../json-parser/streaming-json-parser-types';
 import JSONPath from '../jsonpath/jsonpath';
+
+type ParseJSONInBatchesOptions = {
+  parserFactory?: StreamingJSONParserFactory;
+};
 
 // TODO - support batch size 0 = no batching/single batch?
 // eslint-disable-next-line max-statements, complexity
@@ -22,7 +30,8 @@ export async function* parseJSONInBatches(
   binaryAsyncIterator:
     | AsyncIterable<ArrayBufferLike | ArrayBufferView>
     | Iterable<ArrayBufferLike | ArrayBufferView>,
-  options: JSONLoaderOptions
+  options: JSONLoaderOptions,
+  parseOptions: ParseJSONInBatchesOptions = {}
 ): AsyncIterable<TableBatch | MetadataBatch | JSONBatch> {
   const asyncIterator = makeTextDecoderIterator(toArrayBufferIterator(binaryAsyncIterator));
   const shape = options?.json?.shape;
@@ -42,7 +51,10 @@ export async function* parseJSONInBatches(
     shape: tableBatchBuilderShape
   });
 
-  const parser = new StreamingJSONParser({jsonpaths});
+  const parserFactory =
+    parseOptions.parserFactory ||
+    ((parserOptions: StreamingJSONParserOptions) => new StreamingJSONParser(parserOptions));
+  const parser = parserFactory({jsonpaths, metadata});
 
   for await (const chunk of asyncIterator) {
     const rows = parser.write(chunk);
@@ -84,6 +96,8 @@ export async function* parseJSONInBatches(
       yield batch;
     }
   }
+
+  parser.close();
 
   // yield final batch
   const jsonpath = parser.getStreamingJsonPathAsString();

--- a/modules/json/test/index.ts
+++ b/modules/json/test/index.ts
@@ -10,6 +10,7 @@ import './lib/clarinet';
 
 // JSON Parsers
 import './lib/parser/json-parser.spec';
+import './lib/parser/fast-streaming-json-parser.spec';
 import './lib/parser/streaming-json-parser.spec';
 
 // Loaders

--- a/modules/json/test/json-loader.bench.ts
+++ b/modules/json/test/json-loader.bench.ts
@@ -2,17 +2,19 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {JSONLoader} from '@loaders.gl/json';
-import {load, loadInBatches} from '@loaders.gl/core';
+import {JSONLoader, _FastJSONLoader as FastJSONLoader} from '@loaders.gl/json';
+import {load, loadInBatches, parse} from '@loaders.gl/core';
 
 import clarinetBench from './lib/clarinet/clarinet.bench';
 
 const GEOJSON_URL = '@loaders.gl/json/test/data/geojson-big.json';
+const GEOJSON_FEATURE_COUNT = 308;
+const GEOJSON_TEXT = await loadText('./data/geojson-big.json');
 
 export default async function jsonLoaderBench(suite) {
   suite.group('JSONLoader');
 
-  const options = {multiplier: 308, unit: 'features'};
+  const options = {multiplier: GEOJSON_FEATURE_COUNT, unit: 'features'};
 
   suite.addAsync('loadInBatches(JSONLoader) - Streaming GeoJSON load', options, async () => {
     const asyncIterator = await loadInBatches(GEOJSON_URL, JSONLoader);
@@ -25,10 +27,51 @@ export default async function jsonLoaderBench(suite) {
     }
   });
 
+  suite.addAsync('loadInBatches(FastJSONLoader) - Streaming GeoJSON load', options, async () => {
+    const asyncIterator = await loadInBatches(GEOJSON_URL, FastJSONLoader);
+    const data: unknown[] = [];
+    for await (const batch of asyncIterator) {
+      if (batch.shape === 'object-row-table') {
+        data.push(...batch.data);
+      }
+    }
+  });
+
   suite.addAsync('load(JSONLoader) - Atomic GeoJSON load (JSON.parse)', options, async () => {
     await load(GEOJSON_URL, JSONLoader);
   });
 
+  suite.addAsync('load(FastJSONLoader) - Atomic GeoJSON load (JSON.parse)', options, async () => {
+    await load(GEOJSON_URL, FastJSONLoader);
+  });
+
+  suite.addAsync('parse(JSONLoader) - Atomic GeoJSON parse (JSON.parse)', options, async () => {
+    await parse(GEOJSON_TEXT, JSONLoader);
+  });
+
+  suite.addAsync('parse(FastJSONLoader) - Atomic GeoJSON parse (JSON.parse)', options, async () => {
+    await parse(GEOJSON_TEXT, FastJSONLoader);
+  });
+
+  suite.add('JSON.parse - Atomic GeoJSON parse from string', options, () => {
+    JSON.parse(GEOJSON_TEXT);
+  });
+
   // Test underlying clarinet library
   clarinetBench(suite);
+}
+
+/**
+ * Loads benchmark fixture text in both Node and browser environments.
+ */
+async function loadText(relativePath: string): Promise<string> {
+  const url = new URL(relativePath, import.meta.url);
+
+  if (url.protocol === 'file:' && typeof window === 'undefined') {
+    const {readFile} = await import('fs/promises');
+    return await readFile(url, 'utf8');
+  }
+
+  const response = await fetch(url);
+  return await response.text();
 }

--- a/modules/json/test/json-loader.spec.ts
+++ b/modules/json/test/json-loader.spec.ts
@@ -5,11 +5,19 @@
 import test from 'tape-promise/tape';
 import {load, loadInBatches, isIterator, isAsyncIterable} from '@loaders.gl/core';
 import {ObjectRowTableBatch, getTableLength} from '@loaders.gl/schema-utils';
-import {JSONLoader, _GeoJSONLoader as GeoJSONLoader} from '@loaders.gl/json';
+import {
+  JSONLoader,
+  _FastJSONLoader as FastJSONLoader,
+  _GeoJSONLoader as GeoJSONLoader
+} from '@loaders.gl/json';
 import {JSONLoader as BundledJSONLoader} from '@loaders.gl/json/bundled';
 
 const GEOJSON_PATH = '@loaders.gl/json/test/data/geojson-big.json';
 const GEOJSON_KEPLER_DATASET_PATH = '@loaders.gl/json/test/data/kepler-dataset-sf-incidents.json';
+const STREAMING_LOADERS = [
+  {name: 'JSONLoader', loader: JSONLoader},
+  {name: 'FastJSONLoader', loader: FastJSONLoader}
+];
 
 test('JSONLoader#load(geojson.json)', async t => {
   const table = await load(GEOJSON_PATH, JSONLoader, {json: {table: true}});
@@ -31,59 +39,55 @@ test('JSONLoader#load(geojson.json, shape: arrow-table)', async t => {
   t.end();
 });
 
-test('JSONLoader#loadInBatches(geojson.json, rows, batchSize = auto)', async t => {
-  const iterator = await loadInBatches(GEOJSON_PATH, JSONLoader);
-  t.ok(isIterator(iterator) || isAsyncIterable(iterator), 'loadInBatches returned iterator');
+for (const {name, loader} of STREAMING_LOADERS) {
+  test(`${name}#loadInBatches(geojson.json, rows, batchSize = auto)`, async t => {
+    const iterator = await loadInBatches(GEOJSON_PATH, loader);
+    t.ok(isIterator(iterator) || isAsyncIterable(iterator), 'loadInBatches returned iterator');
 
-  let batch;
-  let batchCount = 0;
-  let rowCount = 0;
-  // TODO - incorrect length read after 2.3 polyfills upgrade, investigate!
-  // let byteLength = 0;
-  for await (batch of iterator) {
-    batchCount++;
-    rowCount += batch.length;
-    // byteLength = batch.bytesUsed;
-  }
-
-  // t.comment(JSON.stringify(batchCount));
-  t.ok(batchCount <= 4, 'Correct number of batches received');
-  t.equal(rowCount, 308, 'Correct number of row received');
-  // t.equal(byteLength, 135910, 'Correct number of bytes received');
-  t.end();
-});
-
-test('JSONLoader#loadInBatches(geojson.json, rows, batchSize = 10)', async t => {
-  const iterator = await loadInBatches(GEOJSON_PATH, JSONLoader, {
-    batchSize: 10
-  });
-  t.ok(isIterator(iterator) || isAsyncIterable(iterator), 'loadInBatches returned iterator');
-
-  let batch;
-  let batchCount = 0;
-  let rowCount = 0;
-  for await (batch of iterator) {
-    // t.comment(`BATCH ${batch.count}: ${batch.length} ${JSON.stringify(batch.data).slice(0, 200)}`);
-    if (batchCount < 30) {
-      t.equal(batch.length, 10, `Got correct batch size for batch ${batchCount}`);
+    let batch;
+    let batchCount = 0;
+    let rowCount = 0;
+    for await (batch of iterator) {
+      batchCount++;
+      rowCount += batch.length;
     }
 
-    const feature = batch.data[0];
-    t.equal(feature.type, 'Feature', 'row 0 valid');
-    t.equal(feature.geometry.type, 'Point', 'row 0 valid');
+    t.ok(batchCount <= 4, 'Correct number of batches received');
+    t.equal(rowCount, 308, 'Correct number of row received');
+    t.end();
+  });
 
-    batchCount++;
-    rowCount += batch.length;
-  }
+  test(`${name}#loadInBatches(geojson.json, rows, batchSize = 10)`, async t => {
+    const iterator = await loadInBatches(GEOJSON_PATH, loader, {
+      batchSize: 10
+    });
+    t.ok(isIterator(iterator) || isAsyncIterable(iterator), 'loadInBatches returned iterator');
 
-  const lastFeature = batch.data[batch.data.length - 1];
-  t.equal(lastFeature.type, 'Feature', 'row 0 valid');
-  t.equal(lastFeature.properties.name, 'West Oakland (WOAK)', 'row 0 valid');
+    let batch;
+    let batchCount = 0;
+    let rowCount = 0;
+    for await (batch of iterator) {
+      if (batchCount < 30) {
+        t.equal(batch.length, 10, `Got correct batch size for batch ${batchCount}`);
+      }
 
-  t.equal(batchCount, 31, 'Correct number of batches received');
-  t.equal(rowCount, 308, 'Correct number of row received');
-  t.end();
-});
+      const feature = batch.data[0];
+      t.equal(feature.type, 'Feature', 'row 0 valid');
+      t.equal(feature.geometry.type, 'Point', 'row 0 valid');
+
+      batchCount++;
+      rowCount += batch.length;
+    }
+
+    const lastFeature = batch.data[batch.data.length - 1];
+    t.equal(lastFeature.type, 'Feature', 'row 0 valid');
+    t.equal(lastFeature.properties.name, 'West Oakland (WOAK)', 'row 0 valid');
+
+    t.equal(batchCount, 31, 'Correct number of batches received');
+    t.equal(rowCount, 308, 'Correct number of row received');
+    t.end();
+  });
+}
 
 test('JSONLoader#parseInBatches(complete rows with nested arrays)', async t => {
   const valueCount = 2048;
@@ -127,36 +131,32 @@ test('JSONLoader#parseInBatches(complete rows with nested arrays)', async t => {
   t.end();
 });
 
-test('JSONLoader#loadInBatches(jsonpaths)', async t => {
-  let iterator = await loadInBatches(GEOJSON_PATH, JSONLoader, {
-    json: {jsonpaths: ['$.features']}
+for (const {name, loader} of STREAMING_LOADERS) {
+  test(`${name}#loadInBatches(jsonpaths)`, async t => {
+    let iterator = await loadInBatches(GEOJSON_PATH, loader, {
+      json: {jsonpaths: ['$.features']}
+    });
+
+    let rowCount = 0;
+    for await (const batch of iterator) {
+      rowCount += batch.length;
+      // @ts-ignore
+      t.equal(batch.jsonpath?.toString(), '$.features', 'correct jsonpath on batch');
+    }
+
+    t.equal(rowCount, 308, 'Correct number of row received');
+
+    iterator = await loadInBatches(GEOJSON_PATH, loader, {json: {jsonpaths: ['$.featureTypo']}});
+
+    rowCount = 0;
+    for await (const batch of iterator) {
+      rowCount += batch.length;
+    }
+
+    t.equal(rowCount, 0, 'Correct number of row received');
+    t.end();
   });
-
-  // let batchCount = 0;
-  let rowCount = 0;
-  // let byteLength = 0;
-  for await (const batch of iterator) {
-    // batchCount++;
-    rowCount += batch.length;
-    // byteLength = batch.bytesUsed;
-    // @ts-ignore
-    t.equal(batch.jsonpath?.toString(), '$.features', 'correct jsonpath on batch');
-  }
-
-  // t.skip(batchCount <= 3, 'Correct number of batches received');
-  t.equal(rowCount, 308, 'Correct number of row received');
-  // t.equal(byteLength, 135910, 'Correct number of bytes received');
-
-  iterator = await loadInBatches(GEOJSON_PATH, JSONLoader, {json: {jsonpaths: ['$.featureTypo']}});
-
-  rowCount = 0;
-  for await (const batch of iterator) {
-    rowCount += batch.length;
-  }
-
-  t.equal(rowCount, 0, 'Correct number of row received');
-  t.end();
-});
+}
 
 test('JSONLoader#loadInBatches(jsonpaths, shape: arrow-table)', async t => {
   const iterator = await loadInBatches(GEOJSON_PATH, JSONLoader, {
@@ -242,54 +242,55 @@ async function testContainerBatches(t, iterator, expectedCount) {
   t.equal(closecontainerBatchCount, expectedCount, 'final-result batch as expected');
 }
 
-test('JSONLoader#loadInBatches(geojson.json, {metadata: true})', async t => {
-  let iterator = await loadInBatches(GEOJSON_PATH, JSONLoader, {
-    metadata: true,
-    json: {table: true}
+for (const {name, loader} of STREAMING_LOADERS) {
+  test(`${name}#loadInBatches(geojson.json, {metadata: true})`, async t => {
+    let iterator = await loadInBatches(GEOJSON_PATH, loader, {
+      metadata: true,
+      json: {table: true}
+    });
+    await testContainerBatches(t, iterator, 1);
+
+    iterator = await loadInBatches(GEOJSON_PATH, loader, {
+      metadata: false,
+      json: {table: true}
+    });
+    await testContainerBatches(t, iterator, 0);
+
+    t.end();
   });
-  await testContainerBatches(t, iterator, 1);
 
-  iterator = await loadInBatches(GEOJSON_PATH, JSONLoader, {
-    metadata: false,
-    json: {table: true}
-  });
-  await testContainerBatches(t, iterator, 0);
+  test(`${name}#loadInBatches(streaming array of arrays)`, async t => {
+    const iterator = await loadInBatches(GEOJSON_KEPLER_DATASET_PATH, loader, {
+      metadata: true,
+      json: {
+        table: true,
+        jsonpaths: ['$.data.allData']
+      }
+    });
 
-  t.end();
-});
-
-test('JSONLoader#loadInBatches(streaming array of arrays)', async t => {
-  const iterator = await loadInBatches(GEOJSON_KEPLER_DATASET_PATH, JSONLoader, {
-    metadata: true,
-    json: {
-      table: true,
-      jsonpaths: ['$.data.allData']
+    let rowCount = 0;
+    for await (const batch of iterator) {
+      switch (batch.batchType) {
+        case 'metadata':
+        case 'partial-result':
+          break;
+        case 'data':
+          const rowBatch = batch as ObjectRowTableBatch;
+          rowCount += getTableLength(rowBatch);
+          break;
+        case 'final-result':
+          if (batch.shape === 'json') {
+            t.ok(batch.container, 'final batch contains json');
+          }
+          break;
+        default:
+      }
     }
+    t.equal(rowCount, 247, '247 rows found');
+
+    t.end();
   });
-
-  let rowCount = 0;
-  for await (const batch of iterator) {
-    switch (batch.batchType) {
-      case 'metadata':
-      case 'partial-result':
-        break;
-      case 'data':
-        const rowBatch = batch as ObjectRowTableBatch;
-        rowCount += getTableLength(rowBatch);
-        // t.equal(rowBatch?.data?.[0].length, 10);
-        break;
-      case 'final-result':
-        if (batch.shape === 'json') {
-          t.ok(batch.container, 'final batch contains json');
-        }
-        break;
-      default:
-    }
-  }
-  t.equal(rowCount, 247, '247 rows found');
-
-  t.end();
-});
+}
 
 /** Emits UTF-8 JSON text chunks for streaming parser tests. */
 async function* makeChunkedTextIterator(text: string, chunkSize: number) {

--- a/modules/json/test/json-loader.spec.ts
+++ b/modules/json/test/json-loader.spec.ts
@@ -5,18 +5,15 @@
 import test from 'tape-promise/tape';
 import {load, loadInBatches, isIterator, isAsyncIterable} from '@loaders.gl/core';
 import {ObjectRowTableBatch, getTableLength} from '@loaders.gl/schema-utils';
-import {
-  JSONLoader,
-  _FastJSONLoader as FastJSONLoader,
-  _GeoJSONLoader as GeoJSONLoader
-} from '@loaders.gl/json';
+import {JSONLoader, _GeoJSONLoader as GeoJSONLoader} from '@loaders.gl/json';
+import type {JSONLoaderOptions} from '@loaders.gl/json';
 import {JSONLoader as BundledJSONLoader} from '@loaders.gl/json/bundled';
 
 const GEOJSON_PATH = '@loaders.gl/json/test/data/geojson-big.json';
 const GEOJSON_KEPLER_DATASET_PATH = '@loaders.gl/json/test/data/kepler-dataset-sf-incidents.json';
-const STREAMING_LOADERS = [
-  {name: 'JSONLoader', loader: JSONLoader},
-  {name: 'FastJSONLoader', loader: FastJSONLoader}
+const STREAMING_LOADER_CONFIGS: {name: string; options?: JSONLoaderOptions}[] = [
+  {name: 'JSONLoader'},
+  {name: 'JSONLoader json.backend=fast', options: {json: {backend: 'fast'}}}
 ];
 
 test('JSONLoader#load(geojson.json)', async t => {
@@ -39,9 +36,13 @@ test('JSONLoader#load(geojson.json, shape: arrow-table)', async t => {
   t.end();
 });
 
-for (const {name, loader} of STREAMING_LOADERS) {
-  test(`${name}#loadInBatches(geojson.json, rows, batchSize = auto)`, async t => {
-    const iterator = await loadInBatches(GEOJSON_PATH, loader);
+for (const config of STREAMING_LOADER_CONFIGS) {
+  test(`${config.name}#loadInBatches(geojson.json, rows, batchSize = auto)`, async t => {
+    const iterator = await loadInBatches(
+      GEOJSON_PATH,
+      JSONLoader,
+      getStreamingLoaderOptions(config)
+    );
     t.ok(isIterator(iterator) || isAsyncIterable(iterator), 'loadInBatches returned iterator');
 
     let batch;
@@ -57,10 +58,14 @@ for (const {name, loader} of STREAMING_LOADERS) {
     t.end();
   });
 
-  test(`${name}#loadInBatches(geojson.json, rows, batchSize = 10)`, async t => {
-    const iterator = await loadInBatches(GEOJSON_PATH, loader, {
-      batchSize: 10
-    });
+  test(`${config.name}#loadInBatches(geojson.json, rows, batchSize = 10)`, async t => {
+    const iterator = await loadInBatches(
+      GEOJSON_PATH,
+      JSONLoader,
+      getStreamingLoaderOptions(config, {
+        batchSize: 10
+      })
+    );
     t.ok(isIterator(iterator) || isAsyncIterable(iterator), 'loadInBatches returned iterator');
 
     let batch;
@@ -131,11 +136,15 @@ test('JSONLoader#parseInBatches(complete rows with nested arrays)', async t => {
   t.end();
 });
 
-for (const {name, loader} of STREAMING_LOADERS) {
-  test(`${name}#loadInBatches(jsonpaths)`, async t => {
-    let iterator = await loadInBatches(GEOJSON_PATH, loader, {
-      json: {jsonpaths: ['$.features']}
-    });
+for (const config of STREAMING_LOADER_CONFIGS) {
+  test(`${config.name}#loadInBatches(jsonpaths)`, async t => {
+    let iterator = await loadInBatches(
+      GEOJSON_PATH,
+      JSONLoader,
+      getStreamingLoaderOptions(config, {
+        json: {jsonpaths: ['$.features']}
+      })
+    );
 
     let rowCount = 0;
     for await (const batch of iterator) {
@@ -146,7 +155,11 @@ for (const {name, loader} of STREAMING_LOADERS) {
 
     t.equal(rowCount, 308, 'Correct number of row received');
 
-    iterator = await loadInBatches(GEOJSON_PATH, loader, {json: {jsonpaths: ['$.featureTypo']}});
+    iterator = await loadInBatches(
+      GEOJSON_PATH,
+      JSONLoader,
+      getStreamingLoaderOptions(config, {json: {jsonpaths: ['$.featureTypo']}})
+    );
 
     rowCount = 0;
     for await (const batch of iterator) {
@@ -158,26 +171,32 @@ for (const {name, loader} of STREAMING_LOADERS) {
   });
 }
 
-test('JSONLoader#loadInBatches(jsonpaths, shape: arrow-table)', async t => {
-  const iterator = await loadInBatches(GEOJSON_PATH, JSONLoader, {
-    json: {jsonpaths: ['$.features'], shape: 'arrow-table'}
-  });
+for (const config of STREAMING_LOADER_CONFIGS) {
+  test(`${config.name}#loadInBatches(jsonpaths, shape: arrow-table)`, async t => {
+    const iterator = await loadInBatches(
+      GEOJSON_PATH,
+      JSONLoader,
+      getStreamingLoaderOptions(config, {
+        json: {jsonpaths: ['$.features'], shape: 'arrow-table'}
+      })
+    );
 
-  let rowCount = 0;
-  let dataBatchCount = 0;
-  for await (const batch of iterator) {
-    if (batch.shape === 'arrow-table') {
-      dataBatchCount++;
-      rowCount += batch.data.numRows;
-      // @ts-ignore
-      t.equal(batch.jsonpath?.toString(), '$.features', 'correct jsonpath on Arrow batch');
+    let rowCount = 0;
+    let dataBatchCount = 0;
+    for await (const batch of iterator) {
+      if (batch.shape === 'arrow-table') {
+        dataBatchCount++;
+        rowCount += batch.data.numRows;
+        // @ts-ignore
+        t.equal(batch.jsonpath?.toString(), '$.features', 'correct jsonpath on Arrow batch');
+      }
     }
-  }
 
-  t.ok(dataBatchCount > 0, 'received Arrow data batches');
-  t.equal(rowCount, 308, 'Correct number of Arrow rows received');
-  t.end();
-});
+    t.ok(dataBatchCount > 0, 'received Arrow data batches');
+    t.equal(rowCount, 308, 'Correct number of Arrow rows received');
+    t.end();
+  });
+}
 
 test('GeoJSONLoader#loadInBatches(jsonpaths)', async t => {
   const iterator = await loadInBatches(GEOJSON_PATH, GeoJSONLoader, {
@@ -242,31 +261,43 @@ async function testContainerBatches(t, iterator, expectedCount) {
   t.equal(closecontainerBatchCount, expectedCount, 'final-result batch as expected');
 }
 
-for (const {name, loader} of STREAMING_LOADERS) {
-  test(`${name}#loadInBatches(geojson.json, {metadata: true})`, async t => {
-    let iterator = await loadInBatches(GEOJSON_PATH, loader, {
-      metadata: true,
-      json: {table: true}
-    });
+for (const config of STREAMING_LOADER_CONFIGS) {
+  test(`${config.name}#loadInBatches(geojson.json, {metadata: true})`, async t => {
+    let iterator = await loadInBatches(
+      GEOJSON_PATH,
+      JSONLoader,
+      getStreamingLoaderOptions(config, {
+        metadata: true,
+        json: {table: true}
+      })
+    );
     await testContainerBatches(t, iterator, 1);
 
-    iterator = await loadInBatches(GEOJSON_PATH, loader, {
-      metadata: false,
-      json: {table: true}
-    });
+    iterator = await loadInBatches(
+      GEOJSON_PATH,
+      JSONLoader,
+      getStreamingLoaderOptions(config, {
+        metadata: false,
+        json: {table: true}
+      })
+    );
     await testContainerBatches(t, iterator, 0);
 
     t.end();
   });
 
-  test(`${name}#loadInBatches(streaming array of arrays)`, async t => {
-    const iterator = await loadInBatches(GEOJSON_KEPLER_DATASET_PATH, loader, {
-      metadata: true,
-      json: {
-        table: true,
-        jsonpaths: ['$.data.allData']
-      }
-    });
+  test(`${config.name}#loadInBatches(streaming array of arrays)`, async t => {
+    const iterator = await loadInBatches(
+      GEOJSON_KEPLER_DATASET_PATH,
+      JSONLoader,
+      getStreamingLoaderOptions(config, {
+        metadata: true,
+        json: {
+          table: true,
+          jsonpaths: ['$.data.allData']
+        }
+      })
+    );
 
     let rowCount = 0;
     for await (const batch of iterator) {
@@ -290,6 +321,18 @@ for (const {name, loader} of STREAMING_LOADERS) {
 
     t.end();
   });
+}
+
+/** Merges scenario options with the streaming parser backend under test. */
+function getStreamingLoaderOptions(
+  config: {options?: JSONLoaderOptions},
+  options: JSONLoaderOptions = {}
+): JSONLoaderOptions {
+  return {
+    ...config.options,
+    ...options,
+    json: {...config.options?.json, ...options.json}
+  };
 }
 
 /** Emits UTF-8 JSON text chunks for streaming parser tests. */

--- a/modules/json/test/json-loader.spec.ts
+++ b/modules/json/test/json-loader.spec.ts
@@ -5,7 +5,11 @@
 import test from 'tape-promise/tape';
 import {load, loadInBatches, isIterator, isAsyncIterable} from '@loaders.gl/core';
 import {ObjectRowTableBatch, getTableLength} from '@loaders.gl/schema-utils';
-import {JSONLoader, _GeoJSONLoader as GeoJSONLoader} from '@loaders.gl/json';
+import {
+  JSONLoader,
+  _FastJSONLoader as FastJSONLoader,
+  _GeoJSONLoader as GeoJSONLoader
+} from '@loaders.gl/json';
 import type {JSONLoaderOptions} from '@loaders.gl/json';
 import {JSONLoader as BundledJSONLoader} from '@loaders.gl/json/bundled';
 
@@ -33,6 +37,55 @@ test('JSONLoader#load(geojson.json, shape: arrow-table)', async t => {
   t.equal(arrowTable.shape, 'arrow-table', 'Correct Arrow table type received');
   t.equal(arrowTable.data.numRows, 308, 'Correct number of Arrow rows received');
   t.equal(arrowTable.data.getChild('type')?.get(0), 'Feature', 'Arrow field values are preserved');
+  t.end();
+});
+
+test('BundledJSONLoader#parse(ArrayBuffer, shape: arrow-table)', async t => {
+  const arrayBuffer = new TextEncoder().encode(
+    JSON.stringify({metadata: {name: 'features'}, features: [{id: 1}, {id: 2}]})
+  ).buffer;
+  const arrowTable = await BundledJSONLoader.parse(arrayBuffer, {
+    json: {table: true, shape: 'arrow-table'}
+  });
+
+  t.equal(arrowTable.shape, 'arrow-table', 'Correct Arrow table type received');
+  t.equal(arrowTable.data.numRows, 2, 'Correct number of Arrow rows received');
+  t.equal(arrowTable.data.getChild('id')?.get(0), 1, 'Arrow field values are preserved');
+  t.end();
+});
+
+test('FastJSONLoader#load(geojson.json)', async t => {
+  const table = await load(GEOJSON_PATH, FastJSONLoader, {json: {table: true}});
+  t.equal(
+    table.shape === 'object-row-table' && table.data.length,
+    308,
+    'Correct number of rows received'
+  );
+  t.end();
+});
+
+test('FastJSONLoader#parse(ArrayBuffer)', async t => {
+  const arrayBuffer = new TextEncoder().encode('[{"id": 1}, {"id": 2}]').buffer;
+  const table = await FastJSONLoader.parse(arrayBuffer, {json: {table: true}});
+
+  t.equal(table.shape, 'object-row-table', 'parsed JSON array as row table');
+  t.equal(table.data.length, 2, 'parsed both rows');
+  t.end();
+});
+
+test('FastJSONLoader#loadInBatches(jsonpaths)', async t => {
+  const iterator = await loadInBatches(GEOJSON_PATH, FastJSONLoader, {
+    json: {jsonpaths: ['$.features']}
+  });
+
+  let rowCount = 0;
+  for await (const batch of iterator) {
+    rowCount += batch.length;
+    // @ts-ignore
+    t.equal(batch.jsonpath?.toString(), '$.features', 'correct jsonpath on batch');
+  }
+
+  t.equal(rowCount, 308, 'Correct number of row received');
   t.end();
 });
 

--- a/modules/json/test/lib/clarinet/clarinet.bench.js
+++ b/modules/json/test/lib/clarinet/clarinet.bench.js
@@ -1,4 +1,6 @@
 import {_ClarinetParser} from '@loaders.gl/json';
+import StreamingJSONParser from '../../../src/lib/json-parser/streaming-json-parser';
+import FastStreamingJSONParser from '../../../src/lib/json-parser/fast-streaming-json-parser';
 
 const loadJSON = async relativePath => {
   const url = new URL(relativePath, import.meta.url);
@@ -11,19 +13,62 @@ const loadJSON = async relativePath => {
 };
 
 const BASIC = await loadJSON('../../data/clarinet/basic.json');
+const GEOJSON = await loadJSON('../../data/geojson-big.json');
+
+const STREAMING_CHUNK_SIZE = 1024;
+const STREAMING_JSON_PATHS = ['$.features'];
 
 export default function clarinetBench(bench) {
   const STRING = JSON.stringify(BASIC);
+  const geojsonString = JSON.stringify(GEOJSON);
+  const geojsonChunks = splitIntoChunks(geojsonString, STREAMING_CHUNK_SIZE);
 
-  const parser = new _ClarinetParser();
-
-  bench.group('Clarinet - JSON parsing from string');
+  bench.group('Clarinet internals - JSON parsing from string');
 
   bench.add('ClarinetParser', {multiplier: STRING.length, unit: 'bytes'}, () => {
+    const parser = new _ClarinetParser();
     parser.write(STRING);
   });
 
   bench.add('JSON.parse', {multiplier: STRING.length, unit: 'bytes'}, () => {
     JSON.parse(STRING);
   });
+
+  bench.group('Streaming JSON parser backends - chunked GeoJSON extraction');
+
+  bench.add('StreamingJSONParser', {multiplier: geojsonString.length, unit: 'bytes'}, () => {
+    runStreamingParser(StreamingJSONParser, geojsonChunks, STREAMING_JSON_PATHS);
+  });
+
+  bench.add('FastStreamingJSONParser', {multiplier: geojsonString.length, unit: 'bytes'}, () => {
+    runStreamingParser(FastStreamingJSONParser, geojsonChunks, STREAMING_JSON_PATHS);
+  });
+}
+
+/**
+ * Runs one streaming parser backend against a chunked JSON workload.
+ */
+function runStreamingParser(Parser, chunks, jsonpaths) {
+  const parser = new Parser({jsonpaths});
+  const rows = [];
+
+  for (const chunk of chunks) {
+    rows.push(...parser.write(chunk));
+  }
+
+  parser.close();
+  return rows;
+}
+
+/**
+ * Splits a string into equal-sized chunks.
+ */
+function splitIntoChunks(text, chunkSize) {
+  const chunks = [];
+
+  for (let index = 0; index < text.length; index += chunkSize) {
+    chunks.push(text.slice(index, index + chunkSize));
+  }
+
+  return chunks;
 }

--- a/modules/json/test/lib/parser/fast-streaming-json-parser.spec.ts
+++ b/modules/json/test/lib/parser/fast-streaming-json-parser.spec.ts
@@ -1,0 +1,168 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'tape-promise/tape';
+import StreamingJSONParser from '../../../src/lib/json-parser/streaming-json-parser';
+import FastStreamingJSONParser from '../../../src/lib/json-parser/fast-streaming-json-parser';
+
+type StreamingParserConstructor = new (options?: {
+  jsonpaths?: string[];
+  metadata?: boolean;
+}) => {
+  write(chunk: string): unknown[];
+  close(): void;
+  getPartialResult(): unknown;
+  getStreamingJsonPathAsString(): string | null;
+};
+
+const PARSERS = [
+  {name: 'StreamingJSONParser', Parser: StreamingJSONParser},
+  {name: 'FastStreamingJSONParser', Parser: FastStreamingJSONParser}
+];
+
+const FEATURE_COLLECTION_JSON = JSON.stringify({
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      properties: {
+        name: 'Snowman ☃',
+        description: 'line\\nbreak',
+        emoji: '😀'
+      }
+    },
+    {
+      type: 'Feature',
+      properties: {
+        name: 'Escaped "quote"',
+        unicode: '\u2028 kept as text'
+      }
+    }
+  ]
+});
+
+const NESTED_ARRAY_JSON = JSON.stringify({
+  data: {
+    allData: [
+      ['alpha', 'beta'],
+      ['line\nbreak', 'emoji 😀'],
+      ['unicode', '\u00E9']
+    ]
+  }
+});
+
+const ROOT_ARRAY_JSON = JSON.stringify([
+  {id: 1, name: 'one'},
+  {id: 2, name: 'two'},
+  {id: 3, name: 'three'}
+]);
+const STRING_ARRAY_JSON = JSON.stringify(['alpha', 'emoji 😀', 'line\nbreak', 'escaped "quote"']);
+
+test('FastStreamingJSONParser matches current parser for $.features across chunk sizes', t => {
+  for (const chunkSize of [1, 2, 3, 5, 13]) {
+    const expected = collectParserOutput(StreamingJSONParser, FEATURE_COLLECTION_JSON, chunkSize, [
+      '$.features'
+    ]);
+    const actual = collectParserOutput(
+      FastStreamingJSONParser,
+      FEATURE_COLLECTION_JSON,
+      chunkSize,
+      ['$.features']
+    );
+
+    t.deepEqual(actual.rows, expected.rows, `rows match at chunk size ${chunkSize}`);
+    t.deepEqual(
+      actual.partialResult,
+      expected.partialResult,
+      `partial result matches at chunk size ${chunkSize}`
+    );
+    t.deepEqual(
+      actual.finalResult,
+      expected.finalResult,
+      `final result matches at chunk size ${chunkSize}`
+    );
+    t.equal(actual.jsonpath, '$.features', `jsonpath matches at chunk size ${chunkSize}`);
+  }
+
+  t.end();
+});
+
+test('Streaming parsers match for nested array rows across chunk sizes', t => {
+  for (const {name, Parser} of PARSERS) {
+    const output = collectParserOutput(Parser, NESTED_ARRAY_JSON, 1, ['$.data.allData']);
+    t.equal(output.rows.length, 3, `${name} found all rows`);
+    t.deepEqual(
+      output.finalResult,
+      JSON.parse(NESTED_ARRAY_JSON),
+      `${name} final result is correct`
+    );
+    t.equal(output.jsonpath, '$.data.allData', `${name} jsonpath is correct`);
+  }
+
+  t.end();
+});
+
+test('Streaming parsers match for root array chunk boundaries', t => {
+  const expected = collectParserOutput(StreamingJSONParser, ROOT_ARRAY_JSON, 2);
+  const actual = collectParserOutput(FastStreamingJSONParser, ROOT_ARRAY_JSON, 2);
+
+  t.deepEqual(actual.rows, expected.rows, 'rows match for root array');
+  t.equal(actual.jsonpath, '$', 'jsonpath is root array');
+
+  t.end();
+});
+
+test('Streaming parsers match for scalar string array chunk boundaries', t => {
+  const expected = collectParserOutput(StreamingJSONParser, STRING_ARRAY_JSON, 1);
+  const actual = collectParserOutput(FastStreamingJSONParser, STRING_ARRAY_JSON, 1);
+
+  t.deepEqual(actual.rows, expected.rows, 'rows match for string array');
+  t.equal(actual.jsonpath, '$', 'jsonpath is root array');
+
+  t.end();
+});
+
+/**
+ * Collects rows and metadata from a streaming parser for comparison.
+ */
+function collectParserOutput(
+  Parser: StreamingParserConstructor,
+  json: string,
+  chunkSize: number,
+  jsonpaths?: string[]
+) {
+  const parser = new Parser({jsonpaths, metadata: true});
+  const rows: unknown[] = [];
+  let partialResult: unknown = null;
+
+  for (const chunk of splitIntoChunks(json, chunkSize)) {
+    const chunkRows = parser.write(chunk);
+    if (chunkRows.length > 0 && partialResult === null) {
+      partialResult = parser.getPartialResult();
+    }
+    rows.push(...chunkRows);
+  }
+
+  parser.close();
+
+  return {
+    rows,
+    partialResult,
+    finalResult: parser.getPartialResult(),
+    jsonpath: parser.getStreamingJsonPathAsString()
+  };
+}
+
+/**
+ * Splits a string into equal-sized chunks.
+ */
+function splitIntoChunks(text: string, chunkSize: number): string[] {
+  const chunks: string[] = [];
+
+  for (let index = 0; index < text.length; index += chunkSize) {
+    chunks.push(text.slice(index, index + chunkSize));
+  }
+
+  return chunks;
+}

--- a/modules/json/test/lib/parser/fast-streaming-json-parser.spec.ts
+++ b/modules/json/test/lib/parser/fast-streaming-json-parser.spec.ts
@@ -123,6 +123,45 @@ test('Streaming parsers match for scalar string array chunk boundaries', t => {
   t.end();
 });
 
+test('FastStreamingJSONParser handles primitive array rows', t => {
+  const output = collectParserOutput(FastStreamingJSONParser, '[1, true, null, -2.5]', 2);
+
+  t.deepEqual(output.rows, [1, true, null, -2.5], 'primitive rows are emitted');
+  t.equal(output.jsonpath, '$', 'jsonpath is root array');
+  t.ok(output.rawJsonPath, 'raw JSONPath object is available');
+  t.end();
+});
+
+test('FastStreamingJSONParser handles escaped keys and unicode stream strings', t => {
+  const json = '{"\\u0066eatures":["\\u2603", "line\\nbreak"],"line\\nbreak":[1]}';
+  const output = collectParserOutput(FastStreamingJSONParser, json, 1, ['$.features']);
+
+  t.deepEqual(output.rows, ['☃', 'line\nbreak'], 'escaped string rows are decoded');
+  t.deepEqual(output.partialResult, {features: []}, 'partial result preserves escaped key path');
+  t.equal(output.jsonpath, '$.features', 'jsonpath matches escaped key');
+  t.end();
+});
+
+test('FastStreamingJSONParser handles unmatched paths and non-streaming close', t => {
+  const json = '  {"empty": {}, "nested": [[], {"value": 1}], "flag": true}';
+  const output = collectParserOutput(FastStreamingJSONParser, json, 3, ['$.missing']);
+
+  t.deepEqual(output.rows, [], 'no rows are emitted without a matching path');
+  t.deepEqual(output.finalResult, JSON.parse(json), 'complete JSON is available after close');
+  t.equal(output.jsonpath, null, 'no streaming jsonpath is selected');
+  t.end();
+});
+
+test('FastStreamingJSONParser tolerates incomplete trailing JSON', t => {
+  const parser = new FastStreamingJSONParser({metadata: true});
+
+  t.deepEqual(parser.write('[1'), [], 'incomplete primitive is held until more data arrives');
+  parser.close();
+  t.deepEqual(parser.write(''), [], 'closed incomplete input does not emit partial rows');
+  t.deepEqual(parser.getPartialResult(), [], 'root streaming metadata is initialized');
+  t.end();
+});
+
 /**
  * Collects rows and metadata from a streaming parser for comparison.
  */
@@ -150,6 +189,7 @@ function collectParserOutput(
     rows,
     partialResult,
     finalResult: parser.getPartialResult(),
+    rawJsonPath: parser.getStreamingJsonPath(),
     jsonpath: parser.getStreamingJsonPathAsString()
   };
 }

--- a/modules/schema-utils/test/lib/schema/convert-arrow-schema.node.spec.ts
+++ b/modules/schema-utils/test/lib/schema/convert-arrow-schema.node.spec.ts
@@ -1,0 +1,36 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'tape-promise/tape';
+import * as arrow from 'apache-arrow';
+
+import {convertArrowToSchema, convertSchemaToArrow} from '@loaders.gl/schema-utils';
+
+test('convertArrowSchema handles FixedSizeBinary fields', t => {
+  const arrowSchema = new arrow.Schema([
+    new arrow.Field('id', new arrow.Int32(), false),
+    new arrow.Field('hash', new arrow.FixedSizeBinary(16), true)
+  ]);
+
+  const schema = convertArrowToSchema(arrowSchema);
+
+  t.deepEqual(
+    schema.fields[1].type,
+    {type: 'fixed-size-binary', byteWidth: 16},
+    'serializes fixed-size binary fields'
+  );
+
+  const roundTrippedSchema = convertSchemaToArrow(schema);
+  t.equal(
+    roundTrippedSchema.fields[1].type.constructor,
+    arrow.FixedSizeBinary,
+    'deserializes fixed-size binary fields'
+  );
+  t.equal(
+    (roundTrippedSchema.fields[1].type as arrow.FixedSizeBinary).byteWidth,
+    16,
+    'preserves byte width'
+  );
+  t.end();
+});

--- a/output/pdf/loaders-gl-one-page-summary.pdf
+++ b/output/pdf/loaders-gl-one-page-summary.pdf
@@ -1,0 +1,74 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 612 792 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260410183305-04'00') /Creator (anonymous) /Keywords () /ModDate (D:20260410183305-04'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (unspecified) /Title (loaders.gl One-Page Summary) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3870
+>>
+stream
+Gb!l!=``@V&q8H9^glAmiK+1<X*/:G=AH5=7p/D9f2h!e6UESf395aJ%fcCm"5n^<,YM:SD4K%Y$)5i6YIi3<TI4">kL&17-cFb4Z$PjFcPMpL_@)l!>^d53QUd(*\m?9]#QD5Q+rlH8-ecfW:%<q(iY:9o&j6EdH^_S=JPdD5:*_H9ieOPU$Is=FVYX.prZNn$d0_Z&_]T[hJ4mZb6(A)KY_"58LSRP5,kuP>+A&(GN+%uRYB![EjZ_EIdAhU>\m`(kg3\1_P[D6u-2n.a@?a/XSH!utM;+e/9.a*#[hE2/^J%Ye!Yc7oM'%88OWOfOr(9c)'#c^a]uU4K7`#B:`7:o$kV,GRKAJc3ImAp#5[:.7^X'[-\J1t2s+U,DUT-XijJ'd65gT2A#h82!g*!l.f:?C3]&-m@b"cKTB_JGA>r/ju>)94;gSrr)]j@"ITjXZmFY>B9pZ`r@bC./%B6KL/-"t$ZQ"[=RAdQZgESJ?)\@u]]EDq$J<g@$t^23(Ge!@dB(#l6p'TVXf^0=9<E?]IgUhFflo530!L"bq'=U-]@[FhFTgB633=pXqA+o6"<<*?gEjUM\$BNV!2O?i,P,DrSK"MWDde_G>.D(FL44,SI5q:oXRZ)b,nA#RBDZh&t1p=M1\Qba\n_]\i#l:+bR0EAC"b,QlUNEEZ_"4[_Ykgu\.c6(jV-raDOh=kL;/\Y9X;eQ>sPO^f7p!4^\L!$U8a;/6Ujk!m1$X>BhR\<j#l8N:W7(1uSAPS/,U>KRrW"mt*^1dUDYRuHrN=3[RC1S8s4"9L0&c4%._5c+:W4Zc4m(n&WOgT%Ls&/@"'GNYkp^f\-T3ol-Mp!nrror$IMKL13cuS3%nA[OW6r)ql!XS&0Bacq00H1m[_t.Gg,c(So?"q<S,7jC55`YIZ'5le;CK:F!TK2"CIUoQM@n&#<GE=OD!i9U@Nh%k7CNcK9>'&Vr^0IZ1FcI'K@&)RE1jMeB/H5W-iOb,:3%h`?(;eaQf%-Rs]0<9qk9A4*$r]Q-B8Fq)Ct7O)QkdH(Q>6(0.WCou"EN"l%9&)R[VG>eB/iKfl`_:eYp=YP6,m&,)l>eiKrTQZnNlN1@]39#RPdVj"9%pY/bKc1e7p0tSL+@!7&NTV,-V:8dafk.OljkM9oKubI./ssUPUp=7$k>OH&Uk3o8J(gkVI4$'`@]%k1?>/?#R*,f:iIr4Vh*d<H7m+o`HksCQ,6Zd4FW`EhZ^HO_RV;V6*lA,7U)e9HZj#gXsKc/`"8QK,%\G]&bZ47*ds930/6X'_<F'@lhgta<k8P*"idrF%iSr[Oh-+)N?GYg)YukU=%%<JWMO%NUdqNc-.ts5AE$.rF)GJ0GuU>93\/R7Zs-a#8u^PBLjQVB_56$+C\eH#huXCaK-f.57S"[.W8]2gfFSoX#bg\!<[AYHn2L?qK-rQ8A`/8#DmU=$J@FmC>/#/hX%SW;_J96o6F'G$<("3gel=<B`lCc"HSs@"E?96alFsRJ/cKCkgBZqa&oF]EWs^-%cCm!?/^10CJ'rIVWe[T!?5Nq^Mca$++&NQJ1LuA`JATZcOmmq5IN]i!186b@FYQNPBTfRk9kT55c8sX;AI/G*(TTJeIlU#B'`9-W-;l%(XFua#ZO"Y!+5?EOt8X[UO]9YV3$^*Vu[40.)f&X!.:I<0H!@o-aMo=2!sfX%=1G60XIIq9b+gmJu?l94?CW]k>(+;?`cu@+_suB&0J\7XO=6b]<&`=e8SeVD)6":,&_Z%VF+R8,[34/K30MfomS8pS5>U)PunH!0S+<@2G>m6<CrDYP9/7.R(4H4E,Zn5YZi%nTRD`BbRo;/R79]Wo\>;YZbZd`:I)MhWO]i+O%Q<aiMMNBM?mI=/]:D,gW.Gs_qN/_+<Sp0XYt%)hf;FcjY`B;:qin<QM,e/5VIkZBE8AFHt3=M`Rh&!U+?<;W!:>e*U/rD]L@0*J5Chd(@R&(rO=VB>&npIJ=?4+!.(>^L>U_IVC]O#BUaGAgM$mI40Jjgg+bE;G[F\eEE^-%qL#=bD4qgGDPT?Y2#/g7[YYue;+?eSj<i6sJIL#[OVX$e$C-t^,glp/1N`]GN&"5igl[VBD]NPj=tLkJ[Q*"ad`<i!Si)XT/dS`;@n1f#oZa[?'t#)V>O8A,G*!hTZNIie#BcB+DSUP]*cGj3ed5iamX!N]WB9_Ao]$7c1oR0Ieg3Af=Prk&"h>I3&JfD,li]4enKEMD[=qe#@:Wu0FMqbB842rX@g7$_nI9aG*S7+7;'J/I,4TKj`IW2m$c&ZS!B&=I6a&3BZ$*)C&gF3G7c`3o3k>"qGYtDL1[f=aP7&IL)dW@&:kd:B.m_n78j^T./>Wtj_50XZ+D.cFgK@)bL6J\a$j18qA]b(57n:,,8QK;FcNI>e9]<jkY2Y$6_^)[].7(4cdTLd$k=b/7B786X#I>Q"iHU?%ddX?DG,*FA]"V1t%W>juHo['\#M;U@#huhZ["QrP*&UHTKq]X=.%.Uj*DVc`&;h,_BgLI^GR'G.7?<IL"d>b$n=BqTW1k-L;qg.D(6k1c/G#`n/-_1K5CGLsJYQ%-K*^rPL-W"ErN/ujGC];f*L'9eC2-`D:0bY>C`B;Ciaj_#d)E+smZqhU)RI>I0GH.3cd)PJWEdk"!KdKf6W^-Kr[,>fNHLq9#9GaV3MnN2*FWcMOW!8u/dXH(b%RU'aI!<4=3kAK3ai^._^.i@iY'V*DAhKo9N4Ma%ne]JqD'TYiURt\"HI^:'.f>Z^uAPdPojkjpmsJ"qnH"G`A:1?`eHK7VuP,+.U$'gS("dk&43'kaJ&UZm[Ko"rTuTZ'E[@^$*nuNYBuA_\umE_L!Hsn!"3("3<IqbG]KL\ar3D45M1t*20/3NTrnc)Y8.rWkdOAI9C'$tbBEai;ctSG\H1oMbH3rHL60eqA^)Oe_pQ>aP1sAf"7)3a[c=5$[RfcTY9F`Q3=R8jJ4(\H=*Im_bQCW"3>$-L#Q@2p=F7-\2IGG=n!sPhZW0Y@a."Y^rJL?gL#-;CkIZtJ;MhZQ/fl?"Gk_LSlYELZE9Cc[/ifRoe[r0?WX@'&$.FYa3sb<?*Y]t&X*W,E7)W_U,bSo8/aFG"N<dQ]5p76t4l9EChr+5NL:/iUrr#>f3nPUO+/m"Ok8ub/7c%1jHM&?(YUZi]J%Hg!"TX,ZT:l'ViKLji"-b]CG2O5eoiLqo!:H<@"pPX$KeVU]VH7,\)E6$Cr1Y7s#`c+HV`L;bp2m7F64\atKdA/5S*$0KHFV"R"*Z8J6PA75nhki*Fr\3J3Ae1o(hR@eH>_`XQ4[<D]XRe!LEm"lirW`K!Y;/tgP+9Zr=pHHJa)W@HLdms#M&/6%G[5f&gIlIMhF<%b.S:44,?\f3tU4SjlKL1)`LlemkO$N*MV12p#\PZf6$-=0HJ'Ig^qPk203f9ncA-2MIQoGF)=$9+hD]!`fA]!\V*t`cBRC/Z-?INb]Pn_d^iZA,>_ODmW]B8fiTg1FqLIm$QW1C*8BemU0RlZ_9W]7gOllK8YS#lm%u4iNlo]0LaY-6DRTt6@%+5KfA(p7"m_%@_RVQndI1_'%4Z;^W-CbORIeB`ch3g\O$[V&aqm,8fEdrm8t>#<Q-\`JC?s*d&bqk,>Tt9$*d]JbMY.)mZZ7c+ogI['+=/FXifHHB/FY_82'rq3jBFi-dGtrIW;-u/59S<U,n]cPflt/^o0pT)_*P6u!!6DO"F>ircQEo_I%@;CeGgepABO2uc+B#acE:QE?&eKI^/:7nLmFM2(0k]U^SGoq<?,V!r=F+[QJ,K#qg@SkZ*Lec4L3pB&fp:>G`X;EZdXeT^3M7N9lh?mWljuagQrU2Spl:#;ga6ReS/?7;!F0^j6F+!LkGX9[P<Z7rrSft<tt~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000061 00000 n 
+0000000102 00000 n 
+0000000209 00000 n 
+0000000321 00000 n 
+0000000514 00000 n 
+0000000582 00000 n 
+0000000862 00000 n 
+0000000921 00000 n 
+trailer
+<<
+/ID 
+[<a85436c49ffdc89cca20a59eb3773fac><a85436c49ffdc89cca20a59eb3773fac>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+4882
+%%EOF

--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -49,7 +49,7 @@ const modeArguments = {
 
 if (mode === 'bench') {
   const benchLoaderRegistration =
-    'data:text/javascript,import { register } from "node:module"; import { pathToFileURL } from "node:url"; register("@loaders.gl/devtools-extensions/bench-loader", pathToFileURL("./"));';
+    'data:text/javascript,import { register } from "node:module"; import { pathToFileURL } from "node:url"; register("ts-node/esm", pathToFileURL("./")); register("@loaders.gl/devtools-extensions/bench-loader", pathToFileURL("./"));';
   process.exitCode = await runProcess(
     'node',
     ['--import', benchLoaderRegistration, './test/bench/node.js', ...passthroughArgs]

--- a/test/bench-loader.node.spec.ts
+++ b/test/bench-loader.node.spec.ts
@@ -1,0 +1,51 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'tape-promise/tape';
+import {resolve as resolveBenchmarkSpecifier} from '../dev-modules/devtools-extensions/bench-loader.mjs';
+
+test('bench-loader resolves workspace benchmark entries from test sources', async t => {
+  const resolution = await resolveBenchmarkSpecifier(
+    '@loaders.gl/json/test/json-loader.bench',
+    {},
+    () => {
+      throw new Error('nextResolve should not be called for workspace benchmark entries');
+    }
+  );
+
+  t.ok(
+    resolution.url.endsWith('/modules/json/test/json-loader.bench.ts'),
+    'benchmark entry resolves to test source'
+  );
+  t.ok(resolution.shortCircuit, 'benchmark entry short-circuits Node resolution');
+  t.end();
+});
+
+test('bench-loader resolves workspace package roots from src', async t => {
+  const resolution = await resolveBenchmarkSpecifier('@loaders.gl/json', {}, () => {
+    throw new Error('nextResolve should not be called for workspace package roots');
+  });
+
+  t.ok(
+    resolution.url.endsWith('/modules/json/src/index.ts'),
+    'package root resolves to src/index.ts'
+  );
+  t.ok(resolution.shortCircuit, 'package root short-circuits Node resolution');
+  t.end();
+});
+
+test('bench-loader delegates third-party resolution to Node', async t => {
+  let nextResolveCalled = false;
+  const delegatedResolution = {url: 'node:fs', shortCircuit: false};
+
+  const resolution = await resolveBenchmarkSpecifier('node:fs', {}, async specifier => {
+    nextResolveCalled = true;
+    t.equal(specifier, 'node:fs', 'third-party specifier is delegated unchanged');
+    return delegatedResolution;
+  });
+
+  t.ok(nextResolveCalled, 'third-party resolution is delegated');
+  t.equal(resolution, delegatedResolution, 'delegate result is returned');
+  t.end();
+});

--- a/test/bench/modules.js
+++ b/test/bench/modules.js
@@ -36,6 +36,8 @@ _addAliases(ALIASES);
  * @returns {Promise<void>} Resolves after all compatible benchmarks have been added.
  */
 export async function addModuleBenchmarksToSuite(suite) {
+  await jsonBench(suite);
+
   await lasBench(suite);
 
   await gisBench(suite);
@@ -53,7 +55,7 @@ export async function addModuleBenchmarksToSuite(suite) {
   await parquetBench(suite);
   await plyBench(suite);
 
-  await jsonBench(suite);
+  // await shapefileBench(suite);
 
   // await mvtBench(suite);
   await loaderUtilsBench(suite);


### PR DESCRIPTION
## Goals

Add an opt-in faster streaming backend for `JSONLoader` while preserving the current default parser and atomic `JSON.parse` behavior.

## Changes

- Added `json.backend: 'clarinet' | 'fast'` to `JSONLoaderOptions`, defaulting to `'clarinet'`.
- Wired `json.backend: 'fast'` through `JSONLoader.parseInBatches()` to use the fast streaming parser backend.
- Set `_FastJSONLoader` to use the same `json.backend: 'fast'` option path.
- Updated streaming JSON tests to cover both default and fast backends through `JSONLoader`.
- Added TSDoc for the new backend option and parser-backend helper paths.
- Documented the fast backend in JSON module docs, JSONLoader API docs, and `whats-new`.