### PR TITLE
feat(json) Preserve source Utf8 for nested fields

### DIFF
--- a/modules/json/README.md
+++ b/modules/json/README.md
@@ -3,3 +3,16 @@
 This module contains a table loader for the JSON and line delimited JSON formats.
 
 [loaders.gl](https://loaders.gl/docs) is a collection of framework-independent visualization-focused loaders (parsers).
+
+## Fast Arrow Utf8 capture
+
+`JSONTableLoader` can preserve row-level nested JSON values as exact source text while streaming
+Arrow batches with `json.backend: 'fast'`. Supply `json.shape: 'arrow-table'` plus a schema whose
+row-level field type is `utf8`; when the source value for that field is an object or array, the
+Utf8 Arrow value keeps that JSON slice exactly, including whitespace, key order, and escape spelling.
+
+This optimization applies only to streamed fast-backend Arrow parsing. Direct or synchronous parsing,
+non-fast streaming, and nested schema descendants keep their existing conversion behavior.
+
+Arrow conversion can also opt into `json.arrowConversion.utf8Conversion: 'number-to-string'`
+when a schema intentionally stores numeric source values in Utf8 columns.

--- a/modules/json/src/json-table-loader-with-parser.ts
+++ b/modules/json/src/json-table-loader-with-parser.ts
@@ -18,7 +18,8 @@ import {parseJSONSync} from './lib/parsers/parse-json';
 import {parseJSONInBatches} from './lib/parsers/parse-json-in-batches';
 import {
   convertRowTableToArrowTable,
-  convertTableBatchesToArrow
+  convertTableBatchesToArrow,
+  normalizeJSONArrowSchema
 } from './lib/parsers/convert-row-table-to-arrow';
 import type {JSONBatch, JSONLoaderOptions, MetadataBatch} from './json-loader';
 import {
@@ -101,9 +102,10 @@ function parseInBatches(
   options?: JSONTableLoaderOptions
 ): AsyncIterable<TableBatch | ArrowTableBatch | MetadataBatch | JSONBatch> {
   const jsonOptions = normalizeJSONTableLoaderOptions(options);
+  const rawJsonUtf8Fields = getRawJsonUtf8Fields(jsonOptions);
   const parseOptions =
     jsonOptions.json?.backend === 'fast'
-      ? {parserFactory: getFastStreamingJSONParserFactory()}
+      ? {parserFactory: getFastStreamingJSONParserFactory(rawJsonUtf8Fields)}
       : undefined;
   validateJSONTableArrowOptions(jsonOptions);
 
@@ -249,8 +251,25 @@ function getFirstArray(json: unknown): unknown[] | null {
  *
  * @returns Streaming parser factory used by the `fast` backend.
  */
-function getFastStreamingJSONParserFactory(): StreamingJSONParserFactory {
-  return parserOptions => new FastStreamingJSONParser(parserOptions);
+function getFastStreamingJSONParserFactory(
+  rawJsonUtf8Fields: string[]
+): StreamingJSONParserFactory {
+  return parserOptions => new FastStreamingJSONParser({...parserOptions, rawJsonUtf8Fields});
+}
+
+/**
+ * Resolves row-level Utf8 schema fields eligible for fast raw JSON source capture.
+ *
+ * @param options - Normalized JSON table loader options.
+ * @returns Row-level Utf8 field names for streamed fast Arrow parsing.
+ */
+function getRawJsonUtf8Fields(options: JSONTableLoaderOptions): string[] {
+  if (options.json?.shape !== 'arrow-table' || !options.json.schema) {
+    return [];
+  }
+
+  const schema = normalizeJSONArrowSchema(options.json.schema);
+  return schema.fields.filter(field => field.type === 'utf8').map(field => field.name);
 }
 
 /**

--- a/modules/json/src/lib/json-parser/fast-streaming-json-parser.ts
+++ b/modules/json/src/lib/json-parser/fast-streaming-json-parser.ts
@@ -37,6 +37,8 @@ type StringContext = {
 export default class FastStreamingJSONParser implements StreamingJSONParserLike {
   private readonly allowedJsonPaths: string[][];
   private readonly trackMetadata: boolean;
+  /** Row-level fields that keep nested object or array JSON source as Utf8 text. */
+  private readonly rawJsonUtf8Fields: Set<string>;
 
   private mode: 'seek' | 'stream' | 'after' = 'seek';
   private streamingJsonPath: JSONPath | null = null;
@@ -63,6 +65,7 @@ export default class FastStreamingJSONParser implements StreamingJSONParserLike 
   constructor(options: StreamingJSONParserOptions = {}) {
     this.allowedJsonPaths = (options.jsonpaths || []).map(jsonpath => new JSONPath(jsonpath).path);
     this.trackMetadata = Boolean(options.metadata);
+    this.rawJsonUtf8Fields = new Set(options.rawJsonUtf8Fields || []);
   }
 
   /** @inheritdoc */
@@ -514,7 +517,7 @@ export default class FastStreamingJSONParser implements StreamingJSONParserLike 
     }
 
     try {
-      this.emittedRows.push(JSON.parse(this.streamElementBuffer));
+      this.emittedRows.push(parseStreamElement(this.streamElementBuffer, this.rawJsonUtf8Fields));
     } catch {
       // Ignore incomplete elements until more data arrives.
     }
@@ -584,6 +587,241 @@ function createStringContext(forKey: boolean): StringContext {
     unicodeHex: '',
     keyText: ''
   };
+}
+
+/**
+ * Parses one streamed top-level array element while preserving configured raw JSON Utf8 fields.
+ *
+ * @param jsonText - Complete JSON source for one streamed row.
+ * @param rawJsonUtf8Fields - Row-level object fields eligible for source-preserving capture.
+ * @returns Parsed row value with selected nested object or array fields materialized as strings.
+ */
+function parseStreamElement(jsonText: string, rawJsonUtf8Fields: Set<string>): unknown {
+  if (rawJsonUtf8Fields.size === 0) {
+    return JSON.parse(jsonText);
+  }
+
+  return JSON.parse(rewriteRawJsonUtf8ObjectFields(jsonText, rawJsonUtf8Fields));
+}
+
+/**
+ * Rewrites selected top-level object or array field values into JSON strings containing source text.
+ *
+ * @param jsonText - Complete JSON source for one streamed row.
+ * @param rawJsonUtf8Fields - Row-level field names eligible for raw JSON capture.
+ * @returns JSON text safe for normal parsing without materializing selected nested values.
+ */
+function rewriteRawJsonUtf8ObjectFields(jsonText: string, rawJsonUtf8Fields: Set<string>): string {
+  const objectStartIndex = skipWhitespace(jsonText, 0);
+  if (jsonText[objectStartIndex] !== '{') {
+    return jsonText;
+  }
+
+  const replacements: {start: number; end: number; text: string}[] = [];
+  let index = objectStartIndex + 1;
+
+  while (index < jsonText.length) {
+    index = skipWhitespace(jsonText, index);
+
+    if (jsonText[index] === '}') {
+      break;
+    }
+    if (jsonText[index] !== '"') {
+      return jsonText;
+    }
+
+    const keyEndIndex = findJSONStringEnd(jsonText, index);
+    if (keyEndIndex === null) {
+      return jsonText;
+    }
+
+    let fieldName: string;
+    try {
+      fieldName = JSON.parse(jsonText.slice(index, keyEndIndex));
+    } catch {
+      return jsonText;
+    }
+
+    index = skipWhitespace(jsonText, keyEndIndex);
+    if (jsonText[index] !== ':') {
+      return jsonText;
+    }
+
+    const valueStartIndex = skipWhitespace(jsonText, index + 1);
+    const valueEndIndex = findJSONValueEnd(jsonText, valueStartIndex);
+    if (valueEndIndex === null) {
+      return jsonText;
+    }
+
+    const valueStartCharacter = jsonText[valueStartIndex];
+    if (
+      rawJsonUtf8Fields.has(fieldName) &&
+      (valueStartCharacter === '{' || valueStartCharacter === '[')
+    ) {
+      const rawJsonText = jsonText.slice(valueStartIndex, valueEndIndex);
+      replacements.push({
+        start: valueStartIndex,
+        end: valueEndIndex,
+        text: JSON.stringify(rawJsonText)
+      });
+    }
+
+    index = skipWhitespace(jsonText, valueEndIndex);
+    if (jsonText[index] === ',') {
+      index++;
+      continue;
+    }
+    if (jsonText[index] === '}') {
+      break;
+    }
+    return jsonText;
+  }
+
+  if (replacements.length === 0) {
+    return jsonText;
+  }
+
+  let rewrittenText = '';
+  let sourceIndex = 0;
+  for (const replacement of replacements) {
+    rewrittenText += jsonText.slice(sourceIndex, replacement.start);
+    rewrittenText += replacement.text;
+    sourceIndex = replacement.end;
+  }
+  rewrittenText += jsonText.slice(sourceIndex);
+  return rewrittenText;
+}
+
+/**
+ * Returns the first non-whitespace offset at or after the supplied index.
+ *
+ * @param jsonText - JSON source text.
+ * @param startIndex - Offset where scanning begins.
+ * @returns First non-whitespace offset, or `jsonText.length`.
+ */
+function skipWhitespace(jsonText: string, startIndex: number): number {
+  let index = startIndex;
+  while (index < jsonText.length && isWhitespace(jsonText[index])) {
+    index++;
+  }
+  return index;
+}
+
+/**
+ * Finds the end offset for one JSON value.
+ *
+ * @param jsonText - JSON source text.
+ * @param valueStartIndex - Offset where the JSON value begins.
+ * @returns Exclusive end offset, or `null` when the value is incomplete.
+ */
+function findJSONValueEnd(jsonText: string, valueStartIndex: number): number | null {
+  const character = jsonText[valueStartIndex];
+  if (character === '"') {
+    return findJSONStringEnd(jsonText, valueStartIndex);
+  }
+  if (character === '{' || character === '[') {
+    return findJSONContainerEnd(jsonText, valueStartIndex);
+  }
+
+  let index = valueStartIndex;
+  while (index < jsonText.length && jsonText[index] !== ',' && jsonText[index] !== '}') {
+    index++;
+  }
+  return index < jsonText.length ? index : null;
+}
+
+/**
+ * Finds the exclusive end offset for one quoted JSON string.
+ *
+ * @param jsonText - JSON source text.
+ * @param stringStartIndex - Offset of the opening quote.
+ * @returns Exclusive end offset, or `null` when the string is incomplete.
+ */
+function findJSONStringEnd(jsonText: string, stringStartIndex: number): number | null {
+  let escaped = false;
+
+  for (let index = stringStartIndex + 1; index < jsonText.length; index++) {
+    const character = jsonText[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (character === '"') {
+      return index + 1;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Finds the exclusive end offset for one balanced JSON object or array.
+ *
+ * @param jsonText - JSON source text.
+ * @param containerStartIndex - Offset of the opening brace or bracket.
+ * @returns Exclusive end offset, or `null` when the container is incomplete.
+ */
+function findJSONContainerEnd(jsonText: string, containerStartIndex: number): number | null {
+  const containerStack = [jsonText[containerStartIndex]];
+  let inString = false;
+  let escaped = false;
+
+  for (let index = containerStartIndex + 1; index < jsonText.length; index++) {
+    const character = jsonText[index];
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (character === '\\') {
+        escaped = true;
+        continue;
+      }
+      if (character === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (character === '"') {
+      inString = true;
+      continue;
+    }
+    if (character === '{' || character === '[') {
+      containerStack.push(character);
+      continue;
+    }
+    if (character === '}' || character === ']') {
+      const openingCharacter = containerStack.pop();
+      if (!openingCharacter || !isMatchingContainerPair(openingCharacter, character)) {
+        return null;
+      }
+      if (containerStack.length === 0) {
+        return index + 1;
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Returns whether one opening and closing JSON container delimiter pair matches.
+ *
+ * @param openingCharacter - Opening brace or bracket.
+ * @param closingCharacter - Closing brace or bracket.
+ * @returns `true` for `{}` and `[]` pairs.
+ */
+function isMatchingContainerPair(openingCharacter: string, closingCharacter: string): boolean {
+  return (
+    (openingCharacter === '{' && closingCharacter === '}') ||
+    (openingCharacter === '[' && closingCharacter === ']')
+  );
 }
 
 /**

--- a/modules/json/src/lib/json-parser/streaming-json-parser-types.ts
+++ b/modules/json/src/lib/json-parser/streaming-json-parser-types.ts
@@ -10,6 +10,8 @@ import type JSONPath from '../jsonpath/jsonpath';
 export type StreamingJSONParserOptions = {
   jsonpaths?: string[];
   metadata?: boolean;
+  /** Row-level object fields whose object or array JSON source should stay as raw Utf8 text. */
+  rawJsonUtf8Fields?: string[];
 };
 
 /**

--- a/modules/json/src/lib/parsers/convert-row-table-to-arrow.ts
+++ b/modules/json/src/lib/parsers/convert-row-table-to-arrow.ts
@@ -52,6 +52,8 @@ export type ArrowConversionOptions = {
   onExtraField?: 'error' | 'drop';
   /** Behavior when a number must be converted to an integer Arrow field. */
   integerConversion?: 'clamp-and-round' | 'null' | 'warn' | 'error';
+  /** Behavior when a number must be converted to a Utf8 Arrow field. */
+  utf8Conversion?: 'number-to-string' | 'error';
   /** Whether recovered conversion issues should be logged once per issue kind and field path. */
   logRecoveries?: boolean;
 };
@@ -93,6 +95,7 @@ const DEFAULT_ARROW_CONVERSION_OPTIONS: NormalizedArrowConversionOptions = {
   onMissingField: 'error',
   onExtraField: 'error',
   integerConversion: 'error',
+  utf8Conversion: 'error',
   logRecoveries: true
 };
 
@@ -730,6 +733,13 @@ function normalizeValueForArrow(
   if (typeof field.type === 'string') {
     if (isPrimitiveValueCompatible(value, field.type)) {
       return value;
+    }
+    if (
+      field.type === 'utf8' &&
+      typeof value === 'number' &&
+      conversionOptions.utf8Conversion === 'number-to-string'
+    ) {
+      return String(value);
     }
     if (isIntegerFieldType(field.type) && typeof value === 'number') {
       return recoverIntegerConversion(field, value, path, conversionOptions, conversionLogger);

--- a/modules/json/test/json-loader.spec.ts
+++ b/modules/json/test/json-loader.spec.ts
@@ -813,6 +813,46 @@ test('JSONTableLoader#parse(arrow-table integer conversion policy)', async t => 
   t.end();
 });
 
+test('JSONTableLoader#parse(arrow-table Utf8 numeric conversion policy)', async t => {
+  const schema: Schema = {
+    fields: [{name: 'id', type: 'utf8', nullable: false}],
+    metadata: {}
+  };
+
+  t.throws(
+    () =>
+      BundledJSONTableLoader.parseTextSync?.(JSON.stringify([{id: 7}]), {
+        json: {shape: 'arrow-table', schema}
+      }),
+    /expected string/,
+    'strict mode rejects numeric Utf8 values by default'
+  );
+
+  const table = BundledJSONTableLoader.parseTextSync?.(JSON.stringify([{id: 7}, {id: '8'}]), {
+    json: {
+      shape: 'arrow-table',
+      schema,
+      arrowConversion: {utf8Conversion: 'number-to-string'}
+    }
+  });
+  t.equal(table.data.getChild('id')?.get(0), '7', 'numeric Utf8 values can coerce to strings');
+  t.equal(table.data.getChild('id')?.get(1), '8', 'string Utf8 values remain unchanged');
+
+  t.throws(
+    () =>
+      BundledJSONTableLoader.parseTextSync?.(JSON.stringify([{id: true}]), {
+        json: {
+          shape: 'arrow-table',
+          schema,
+          arrowConversion: {utf8Conversion: 'number-to-string'}
+        }
+      }),
+    /expected string/,
+    'non-numeric primitive values still reject Utf8 coercion'
+  );
+  t.end();
+});
+
 test('JSONTableLoader#parse(arrow-table schema options require Arrow shape)', async t => {
   const schema: Schema = {
     fields: [{name: 'id', type: 'float64', nullable: true}],
@@ -904,6 +944,87 @@ test('JSONTableLoader#parseInBatches(arrow-table with supplied schema)', async t
   }
 
   t.equal(rowCount, 2, 'converts all streamed rows');
+  t.end();
+});
+
+test('JSONTableLoader#parseInBatches(fast arrow-table preserves raw Utf8 JSON fields)', async t => {
+  const schema: Schema = {
+    fields: [
+      {name: 'id', type: 'float64', nullable: false},
+      {name: 'metadata', type: 'utf8', nullable: true},
+      {name: 'tags', type: 'utf8', nullable: true},
+      {name: 'label', type: 'utf8', nullable: false}
+    ],
+    metadata: {}
+  };
+  const jsonText =
+    '{"items":[{"id":1,"metadata": { "nested" : [1, {"escaped":"\\u2603"}] }, "tags": [ "alpha" , {"value":2} ], "label":"line\\nbreak"},{"id":2,"metadata":null,"label":"plain"}]}';
+  const iterator = BundledJSONTableLoader.parseInBatches?.(makeChunkedTextIterator(jsonText, 3), {
+    batchSize: 1,
+    json: {
+      backend: 'fast',
+      shape: 'arrow-table',
+      jsonpaths: ['$.items'],
+      schema,
+      arrowConversion: {onMissingField: 'null'}
+    }
+  });
+
+  const metadataValues: (string | null)[] = [];
+  const tagValues: (string | null)[] = [];
+  const labelValues: string[] = [];
+  for await (const batch of iterator) {
+    if (batch.batchType === 'data') {
+      metadataValues.push(batch.data.getChild('metadata')?.get(0) as string | null);
+      tagValues.push(batch.data.getChild('tags')?.get(0) as string | null);
+      labelValues.push(batch.data.getChild('label')?.get(0) as string);
+    }
+  }
+
+  t.deepEqual(
+    metadataValues,
+    ['{ "nested" : [1, {"escaped":"\\u2603"}] }', null],
+    'object values keep their exact JSON source or null'
+  );
+  t.deepEqual(
+    tagValues,
+    ['[ "alpha" , {"value":2} ]', null],
+    'array values keep their exact JSON source or recovered missing null'
+  );
+  t.deepEqual(labelValues, ['line\nbreak', 'plain'], 'ordinary Utf8 strings still decode');
+  t.end();
+});
+
+test('JSONTableLoader raw Utf8 capture is limited to fast streaming Arrow parsing', async t => {
+  const schema: Schema = {
+    fields: [{name: 'metadata', type: 'utf8', nullable: false}],
+    metadata: {}
+  };
+  const jsonText = '{"items":[{"metadata":{"nested":true}}]}';
+
+  t.throws(
+    () =>
+      BundledJSONTableLoader.parseTextSync?.(jsonText, {
+        json: {shape: 'arrow-table', schema}
+      }),
+    /expected string/,
+    'sync parsing still rejects object values for Utf8 schema fields'
+  );
+
+  const iterator = BundledJSONTableLoader.parseInBatches?.(makeChunkedTextIterator(jsonText, 8), {
+    batchSize: 1,
+    json: {shape: 'arrow-table', jsonpaths: ['$.items'], schema}
+  });
+
+  await t.rejects(
+    async () => {
+      for await (const _batch of iterator) {
+        // Consume batches until Arrow conversion reaches the nested object value.
+      }
+    },
+    /expected string/,
+    'clarinet streaming still rejects object values for Utf8 schema fields'
+  );
   t.end();
 });
 

--- a/modules/json/test/lib/parser/fast-streaming-json-parser.spec.ts
+++ b/modules/json/test/lib/parser/fast-streaming-json-parser.spec.ts
@@ -9,6 +9,7 @@ import FastStreamingJSONParser from '../../../src/lib/json-parser/fast-streaming
 type StreamingParserConstructor = new (options?: {
   jsonpaths?: string[];
   metadata?: boolean;
+  rawJsonUtf8Fields?: string[];
 }) => {
   write(chunk: string): unknown[];
   close(): void;
@@ -58,6 +59,8 @@ const ROOT_ARRAY_JSON = JSON.stringify([
   {id: 3, name: 'three'}
 ]);
 const STRING_ARRAY_JSON = JSON.stringify(['alpha', 'emoji 😀', 'line\nbreak', 'escaped "quote"']);
+const RAW_UTF8_ROW_JSON =
+  '[{"metadata": { "nested" : [1, {"escaped":"\\u2603"}] }, "tags": [ "alpha" , {"value":2} ], "label":"line\\nbreak"}]';
 
 test('FastStreamingJSONParser matches current parser for $.features across chunk sizes', t => {
   for (const chunkSize of [1, 2, 3, 5, 13]) {
@@ -129,6 +132,31 @@ test('FastStreamingJSONParser handles primitive array rows', t => {
   t.deepEqual(output.rows, [1, true, null, -2.5], 'primitive rows are emitted');
   t.equal(output.jsonpath, '$', 'jsonpath is root array');
   t.ok(output.rawJsonPath, 'raw JSONPath object is available');
+  t.end();
+});
+
+test('FastStreamingJSONParser preserves configured raw Utf8 object and array fields', t => {
+  const parser = new FastStreamingJSONParser({
+    rawJsonUtf8Fields: ['metadata', 'tags']
+  });
+  const rows: unknown[] = [];
+
+  for (const chunk of splitIntoChunks(RAW_UTF8_ROW_JSON, 1)) {
+    rows.push(...parser.write(chunk));
+  }
+  parser.close();
+
+  t.deepEqual(
+    rows,
+    [
+      {
+        metadata: '{ "nested" : [1, {"escaped":"\\u2603"}] }',
+        tags: '[ "alpha" , {"value":2} ]',
+        label: 'line\nbreak'
+      }
+    ],
+    'selected nested values remain exact JSON source while strings decode normally'
+  );
   t.end();
 });
 

--- a/modules/traces/README.md
+++ b/modules/traces/README.md
@@ -11,4 +11,8 @@ The `@loaders.gl/traces` module hosts trace format parsers for Chrome Trace and 
 - `streamChromeTraceEventChunks(...)`, `streamChromeTraceArrowChunks(...)`, and `streamChromeTraceFileChunks(...)`
 - `createTraceStreamSession(...)` and the Chrome trace stream consumers
 
+Streamed `ChromeTraceLoader` Arrow parsing uses the fast JSON table parser over `traceEvents`.
+It emits direct Chrome trace event columns, converts numeric id-like fields to Utf8, and preserves
+nested `args` and `id2` JSON payloads as source-faithful Utf8 text.
+
 For documentation please visit the [website](https://loaders.gl).

--- a/modules/traces/package.json
+++ b/modules/traces/package.json
@@ -36,6 +36,7 @@
     "pre-build": "echo \"Nothing to build in @loaders.gl/traces\""
   },
   "dependencies": {
+    "@loaders.gl/json": "4.4.0",
     "@loaders.gl/loader-utils": "4.4.0",
     "apache-arrow": ">= 17.0.0",
     "zod": "^4.1.12"

--- a/modules/traces/src/chrome-trace-arrow-adapter.ts
+++ b/modules/traces/src/chrome-trace-arrow-adapter.ts
@@ -6,7 +6,8 @@ import {parseChromeTraceArrowSchemaMetadata} from './chrome-trace-arrow-parser';
 
 import type {
   ChromeTraceEventArrowRecordBatch,
-  ChromeTraceEventArrowTable
+  ChromeTraceEventArrowTable,
+  ChromeTraceEventStreamArrowRecordBatch
 } from './chrome-trace-arrow-schema';
 import type {ChromeTraceEventPhase, ChromeTraceEventSchema} from './chrome-trace-schema';
 
@@ -15,6 +16,7 @@ import type {ChromeTraceEventPhase, ChromeTraceEventSchema} from './chrome-trace
  */
 export type ChromeTraceArrowSourceItem =
   | ChromeTraceEventArrowRecordBatch
+  | ChromeTraceEventStreamArrowRecordBatch
   | ChromeTraceEventArrowTable;
 
 /**
@@ -58,18 +60,30 @@ export function decodeChromeTraceArrowSource(
       event.bind_id = bindIdValue;
     }
 
+    const eventScopeValue = getOptionalChromeTraceString(row.s);
+    if (eventScopeValue) {
+      event.s = eventScopeValue as 'g' | 'p' | 't';
+    }
+
     const scopeValue = getOptionalChromeTraceString(row.scope);
-    if (scopeValue) {
+    if (scopeValue && !eventScopeValue) {
       if (phase === 'b' || phase === 'e' || phase === 'n') {
         event.s = scopeValue as 'g' | 'p' | 't';
       } else {
         event.scope = scopeValue as 'g' | 'p' | 't';
       }
+    } else if (scopeValue) {
+      event.scope = scopeValue as 'g' | 'p' | 't';
     }
 
     const argsValue = parseChromeTraceArrowJson(row.args);
     if (argsValue != null) {
       event.args = argsValue as Record<string, unknown>;
+    }
+
+    const id2Value = parseChromeTraceArrowJson(row.id2);
+    if (id2Value != null) {
+      event.id2 = id2Value as ChromeTraceEventSchema['id2'];
     }
 
     if (extra) {

--- a/modules/traces/src/chrome-trace-arrow-parser.ts
+++ b/modules/traces/src/chrome-trace-arrow-parser.ts
@@ -258,7 +258,7 @@ function buildChromeTraceEventArrowSchema(
 /**
  * Builds Arrow schema metadata for one Chrome trace file.
  */
-function buildChromeTraceArrowSchemaMetadata(
+export function buildChromeTraceArrowSchemaMetadata(
   traceFile: Pick<ChromeTraceFileSchema, 'displayTimeUnit' | 'metadata'>
 ): Map<string, string> {
   const metadata = new Map<string, string>();

--- a/modules/traces/src/chrome-trace-arrow-schema.ts
+++ b/modules/traces/src/chrome-trace-arrow-schema.ts
@@ -54,6 +54,48 @@ export type ChromeTraceEventArrowTable = arrow.Table<ChromeTraceEventArrowColumn
 export type ChromeTraceEventArrowRecordBatch = arrow.RecordBatch<ChromeTraceEventArrowColumns>;
 
 /**
+ * Direct Arrow column map for streamed Chrome trace events.
+ */
+export type ChromeTraceEventStreamArrowColumns = {
+  /** Event name from the source row. */
+  name: arrow.Utf8;
+  /** Chrome trace phase discriminator. */
+  ph: arrow.Utf8;
+  /** Raw timestamp in the source file's declared time unit. */
+  ts: arrow.Float64;
+  /** Process identifier normalized to a string. */
+  pid: arrow.Utf8;
+  /** Thread identifier normalized to a string. */
+  tid: arrow.Utf8;
+  /** Optional category label. */
+  cat: arrow.Utf8;
+  /** Optional duration value. */
+  dur: arrow.Float64;
+  /** Optional thread-local duration. */
+  tdur: arrow.Float64;
+  /** Optional thread-local timestamp. */
+  tts: arrow.Float64;
+  /** Optional async or flow identifier normalized to a string. */
+  id: arrow.Utf8;
+  /** Optional bind identifier normalized to a string. */
+  bind_id: arrow.Utf8;
+  /** Optional async scope field from Chrome trace events. */
+  s: arrow.Utf8;
+  /** Optional instant-event scope field from Chrome trace events. */
+  scope: arrow.Utf8;
+  /** Optional JSON-encoded args payload preserved from source text. */
+  args: arrow.Utf8;
+  /** Optional JSON-encoded secondary identifier payload preserved from source text. */
+  id2: arrow.Utf8;
+};
+
+/**
+ * Typed Arrow record batch for direct streamed Chrome trace events.
+ */
+export type ChromeTraceEventStreamArrowRecordBatch =
+  arrow.RecordBatch<ChromeTraceEventStreamArrowColumns>;
+
+/**
  * Ordered Arrow fields for the Chrome trace event schema.
  */
 export const CHROME_TRACE_EVENT_ARROW_FIELDS = [
@@ -79,3 +121,25 @@ export const CHROME_TRACE_EVENT_ARROW_FIELDS = [
 export const chromeTraceEventArrowSchema = new arrow.Schema<ChromeTraceEventArrowColumns>([
   ...CHROME_TRACE_EVENT_ARROW_FIELDS
 ]);
+
+/**
+ * Direct streamed Arrow schema for Chrome trace events parsed through JSONTableLoader.
+ */
+export const chromeTraceEventStreamArrowSchema =
+  new arrow.Schema<ChromeTraceEventStreamArrowColumns>([
+    new arrow.Field('name', new arrow.Utf8(), false),
+    new arrow.Field('ph', new arrow.Utf8(), false),
+    new arrow.Field('ts', new arrow.Float64(), true),
+    new arrow.Field('pid', new arrow.Utf8(), true),
+    new arrow.Field('tid', new arrow.Utf8(), true),
+    new arrow.Field('cat', new arrow.Utf8(), true),
+    new arrow.Field('dur', new arrow.Float64(), true),
+    new arrow.Field('tdur', new arrow.Float64(), true),
+    new arrow.Field('tts', new arrow.Float64(), true),
+    new arrow.Field('id', new arrow.Utf8(), true),
+    new arrow.Field('bind_id', new arrow.Utf8(), true),
+    new arrow.Field('s', new arrow.Utf8(), true),
+    new arrow.Field('scope', new arrow.Utf8(), true),
+    new arrow.Field('args', new arrow.Utf8(), true),
+    new arrow.Field('id2', new arrow.Utf8(), true)
+  ]);

--- a/modules/traces/src/chrome-trace-loader.ts
+++ b/modules/traces/src/chrome-trace-loader.ts
@@ -3,17 +3,21 @@
 // Copyright (c) vis.gl contributors
 
 import type {LoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';
+import {JSONTableLoader} from '@loaders.gl/json';
+import * as arrow from 'apache-arrow';
 
 import {
-  parseChromeTraceToArrowRecordBatches,
+  buildChromeTraceArrowSchemaMetadata,
   parseChromeTraceToArrowTable
 } from './chrome-trace-arrow-parser';
+import {tryParseChromeTraceFileText} from './chrome-trace-json-stream';
 import {validateChromeTraceFile} from './chrome-trace-schema';
 
 import type {
-  ChromeTraceEventArrowRecordBatch,
-  ChromeTraceEventArrowTable
+  ChromeTraceEventArrowTable,
+  ChromeTraceEventStreamArrowRecordBatch
 } from './chrome-trace-arrow-schema';
+import {chromeTraceEventStreamArrowSchema} from './chrome-trace-arrow-schema';
 import type {ChromeTraceFileSchema, ChromeTraceValidationOptions} from './chrome-trace-schema';
 
 const CHROME_TRACE_LOADER_VERSION = '4.4.0';
@@ -69,15 +73,12 @@ export const ChromeTraceLoader = {
       throw new Error('ChromeTraceLoader.parseInBatches currently requires shape: "arrow-table".');
     }
 
-    yield* parseChromeTraceToArrowRecordBatches(iterator, {
-      batchSize: resolveChromeTraceLoaderBatchSize(options),
-      maxLength: options?.maxLength
-    });
+    yield* parseChromeTraceArrowBatchesWithJSONTable(iterator, options);
   },
   tests: [testChromeTraceLoader]
 } as const satisfies LoaderWithParser<
   ChromeTraceFileSchema | ChromeTraceEventArrowTable,
-  ChromeTraceEventArrowRecordBatch,
+  ChromeTraceEventStreamArrowRecordBatch,
   ChromeTraceLoaderOptions
 >;
 
@@ -158,6 +159,144 @@ function resolveChromeTraceValidationOptions(
   return {
     maxLength: options?.maxLength
   };
+}
+
+/**
+ * Streams Chrome trace events through JSONTableLoader and emits direct Arrow record batches.
+ */
+async function* parseChromeTraceArrowBatchesWithJSONTable(
+  iterator:
+    | AsyncIterable<ArrayBufferLike | ArrayBufferView>
+    | Iterable<ArrayBufferLike | ArrayBufferView>,
+  options?: ChromeTraceLoaderOptions
+): AsyncIterable<ChromeTraceEventStreamArrowRecordBatch> {
+  let rawText = '';
+  let streamedMetadata: Pick<ChromeTraceFileSchema, 'displayTimeUnit' | 'metadata'> = {};
+  let deferredBatch: ChromeTraceEventStreamArrowRecordBatch | null = null;
+
+  const JSONTableLoaderWithParser = await JSONTableLoader.preload();
+  const batches = JSONTableLoaderWithParser.parseInBatches(
+    captureChromeTraceText(iterator, text => {
+      rawText += text;
+    }),
+    {
+      metadata: true,
+      core: {
+        batchSize: resolveChromeTraceLoaderBatchSize(options)
+      },
+      json: {
+        backend: 'fast',
+        shape: 'arrow-table',
+        jsonpaths: ['$.traceEvents'],
+        schema: chromeTraceEventStreamArrowSchema,
+        arrowConversion: {
+          onExtraField: 'drop',
+          onMissingField: 'null',
+          utf8Conversion: 'number-to-string'
+        }
+      }
+    }
+  );
+
+  for await (const batch of batches) {
+    if (batch.batchType === 'partial-result' || batch.batchType === 'final-result') {
+      streamedMetadata = getChromeTraceMetadataFromContainer(batch.container) ?? streamedMetadata;
+      continue;
+    }
+
+    if (batch.batchType !== 'data' || batch.shape !== 'arrow-table') {
+      continue;
+    }
+
+    for (const recordBatch of batch.data.batches) {
+      const metadataBatch = attachChromeTraceMetadataToRecordBatch(
+        recordBatch as ChromeTraceEventStreamArrowRecordBatch,
+        streamedMetadata
+      );
+
+      if (deferredBatch) {
+        yield deferredBatch;
+      }
+      deferredBatch = metadataBatch;
+    }
+  }
+
+  const completeTraceFile = tryParseChromeTraceFileText(rawText);
+  const finalMetadata = completeTraceFile
+    ? {
+        displayTimeUnit: completeTraceFile.displayTimeUnit,
+        metadata: completeTraceFile.metadata
+      }
+    : streamedMetadata;
+
+  if (deferredBatch) {
+    yield attachChromeTraceMetadataToRecordBatch(deferredBatch, finalMetadata);
+  }
+}
+
+/**
+ * Captures UTF-8 text alongside the binary iterator forwarded to JSONTableLoader.
+ */
+async function* captureChromeTraceText(
+  iterator:
+    | AsyncIterable<ArrayBufferLike | ArrayBufferView>
+    | Iterable<ArrayBufferLike | ArrayBufferView>,
+  onText: (text: string) => void
+): AsyncIterable<ArrayBufferLike | ArrayBufferView> {
+  for await (const chunk of iterator) {
+    onText(decodeChromeTraceChunk(chunk));
+    yield chunk;
+  }
+}
+
+/**
+ * Reads top-level Chrome trace stream metadata from a JSON parser container.
+ */
+function getChromeTraceMetadataFromContainer(
+  container: unknown
+): Pick<ChromeTraceFileSchema, 'displayTimeUnit' | 'metadata'> | null {
+  if (!container || typeof container !== 'object') {
+    return null;
+  }
+
+  const traceFile = container as Partial<ChromeTraceFileSchema>;
+  return {
+    ...(typeof traceFile.displayTimeUnit === 'string'
+      ? {displayTimeUnit: traceFile.displayTimeUnit}
+      : {}),
+    ...(traceFile.metadata && typeof traceFile.metadata === 'object'
+      ? {metadata: traceFile.metadata}
+      : {})
+  };
+}
+
+/**
+ * Rebuilds one direct Chrome trace record batch with top-level trace metadata on its schema.
+ */
+function attachChromeTraceMetadataToRecordBatch(
+  batch: ChromeTraceEventStreamArrowRecordBatch,
+  traceFile: Pick<ChromeTraceFileSchema, 'displayTimeUnit' | 'metadata'>
+): ChromeTraceEventStreamArrowRecordBatch {
+  const metadata = buildChromeTraceArrowSchemaMetadata(traceFile);
+  if (metadata.size === 0) {
+    return batch;
+  }
+
+  const schema = new arrow.Schema(batch.schema.fields, metadata);
+  return new arrow.RecordBatch(schema, batch.data) as ChromeTraceEventStreamArrowRecordBatch;
+}
+
+/**
+ * Decodes one Chrome trace binary stream chunk into text for metadata recovery.
+ */
+function decodeChromeTraceChunk(chunk: ArrayBufferLike | ArrayBufferView): string {
+  if (ArrayBuffer.isView(chunk)) {
+    return new TextDecoder().decode(
+      new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength)
+    );
+  }
+
+  return new TextDecoder().decode(new Uint8Array(chunk));
 }
 
 /**

--- a/modules/traces/src/index.ts
+++ b/modules/traces/src/index.ts
@@ -8,7 +8,8 @@ export {
 } from './chrome-trace-loader';
 export {
   type ChromeTraceEventArrowRecordBatch,
-  type ChromeTraceEventArrowTable
+  type ChromeTraceEventArrowTable,
+  type ChromeTraceEventStreamArrowRecordBatch
 } from './chrome-trace-arrow-schema';
 export type {
   ChromeTraceEventSchema,

--- a/modules/traces/test/chrome-trace-loader.spec.ts
+++ b/modules/traces/test/chrome-trace-loader.spec.ts
@@ -75,13 +75,93 @@ function encodeChromeTraceFixture(traceFile: ChromeTraceFileSchema): ArrayBuffer
 async function* streamChromeTraceFixture(
   traceFile: ChromeTraceFileSchema
 ): AsyncIterable<ArrayBuffer> {
-  const text = JSON.stringify(traceFile);
+  yield* streamChromeTraceText(JSON.stringify(traceFile), 37);
+}
 
-  for (let startIndex = 0; startIndex < text.length; startIndex += 37) {
-    const slice = text.slice(startIndex, startIndex + 37);
+/**
+ * Splits one Chrome trace JSON string into ArrayBuffer chunks.
+ */
+async function* streamChromeTraceText(text: string, chunkSize: number): AsyncIterable<ArrayBuffer> {
+  for (let startIndex = 0; startIndex < text.length; startIndex += chunkSize) {
+    const slice = text.slice(startIndex, startIndex + chunkSize);
     const bytes = new TextEncoder().encode(slice);
     yield bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
   }
+}
+
+/**
+ * Builds a larger streamed trace fixture with heterogeneous id-like values and payload shapes.
+ */
+function createLargeStreamedChromeTraceFixture() {
+  const metadata = {
+    source: 'generated-stream-test',
+    eventCount: 257
+  };
+  const traceEvents: Record<string, unknown>[] = [];
+
+  for (let eventIndex = 0; eventIndex < metadata.eventCount; eventIndex++) {
+    const event: Record<string, unknown> = {
+      name: `event-${eventIndex}`,
+      ph: 'X',
+      ts: eventIndex * 10,
+      dur: eventIndex + 0.5,
+      pid: eventIndex % 2 === 0 ? eventIndex : `process-${eventIndex}`,
+      tid: eventIndex % 3 === 0 ? eventIndex + 1000 : `thread-${eventIndex}`,
+      cat: eventIndex % 2 === 0 ? 'render' : 'worker',
+      ignored_extra_field: {eventIndex}
+    };
+
+    if (eventIndex % 4 === 0) {
+      event.id = eventIndex * 100;
+    } else if (eventIndex % 4 === 1) {
+      event.id = `id-${eventIndex}`;
+    }
+
+    if (eventIndex % 5 === 0) {
+      event.bind_id = eventIndex + 500;
+    } else if (eventIndex % 5 === 1) {
+      event.bind_id = `bind-${eventIndex}`;
+    }
+
+    if (eventIndex % 11 === 0) {
+      event.args = null;
+    } else if (eventIndex % 7 !== 0) {
+      event.args = {
+        eventIndex,
+        nested: {
+          alternating: eventIndex % 2 === 0,
+          labels: [`label-${eventIndex}`, {depth: eventIndex % 5}]
+        },
+        escaped: `line\n${eventIndex}`
+      };
+    }
+
+    if (eventIndex % 13 === 0) {
+      event.id2 = null;
+    } else if (eventIndex % 6 === 0) {
+      event.id2 = {
+        global: eventIndex,
+        local: `local-${eventIndex}`
+      };
+    }
+
+    traceEvents.push(event);
+  }
+
+  const expectedArgsJson = JSON.stringify(traceEvents[5].args);
+  const expectedId2Json = JSON.stringify(traceEvents[12].id2);
+
+  return {
+    jsonText: JSON.stringify({
+      displayTimeUnit: 'us',
+      metadata,
+      traceEvents
+    }),
+    metadata,
+    eventCount: metadata.eventCount,
+    expectedArgsJson,
+    expectedId2Json
+  };
 }
 
 describe('ChromeTraceLoader', () => {
@@ -175,15 +255,8 @@ describe('ChromeTraceLoader', () => {
     });
   });
 
-  it('emits Arrow record batches whose concatenation matches the full Arrow table rows', async () => {
+  it('emits direct streamed Arrow record batches through fast JSON table parsing', async () => {
     const traceFile = createChromeTraceFixture();
-    const parsed = await parse(encodeChromeTraceFixture(traceFile), ChromeTraceLoader, {
-      chromeTrace: {
-        shape: 'arrow-table'
-      }
-    });
-    const table = parsed as arrow.Table;
-
     const batchIterable = await parseInBatches(
       streamChromeTraceFixture(traceFile),
       ChromeTraceLoader,
@@ -203,20 +276,99 @@ describe('ChromeTraceLoader', () => {
     expect(batches).toHaveLength(2);
 
     const combinedTable = new arrow.Table(batches[0].schema, batches);
-    expect(combinedTable.numRows).toBe(table.numRows);
-
-    for (const fieldName of table.schema.fields.map(field => field.name)) {
-      const expectedValues = Array.from({length: table.numRows}, (_, rowIndex) =>
-        table.getChild(fieldName)?.get(rowIndex)
-      );
-      const actualValues = Array.from({length: combinedTable.numRows}, (_, rowIndex) =>
-        combinedTable.getChild(fieldName)?.get(rowIndex)
-      );
-      expect(actualValues).toEqual(expectedValues);
-    }
+    expect(combinedTable.numRows).toBe(4);
+    expect(combinedTable.schema.fields.map(field => field.name)).toEqual([
+      'name',
+      'ph',
+      'ts',
+      'pid',
+      'tid',
+      'cat',
+      'dur',
+      'tdur',
+      'tts',
+      'id',
+      'bind_id',
+      's',
+      'scope',
+      'args',
+      'id2'
+    ]);
+    expect(combinedTable.getChild('pid')?.get(0)).toBe('7');
+    expect(combinedTable.getChild('tid')?.get(2)).toBe('9');
+    expect(combinedTable.getChild('bind_id')?.get(2)).toBe('42');
+    expect(combinedTable.getChild('args')?.get(1)).toBe('{"nested":{"ok":true}}');
+    expect(combinedTable.getChild('id2')?.get(1)).toBe('{"global":"g-1"}');
+    expect(combinedTable.getChild('extraJson')).toBeNull();
 
     expect(batches[1].schema.metadata.get('chromeTrace.metadataJson')).toBe(
       JSON.stringify(traceFile.metadata)
+    );
+  });
+
+  it('preserves exact streamed Chrome trace args and id2 JSON text across chunk boundaries', async () => {
+    const jsonText =
+      '{"displayTimeUnit":"us","metadata":{"source":"raw"},"traceEvents":[{"name":"raw","ph":"X","ts":1,"pid":7,"tid":8,"args": { "nested" : ["\\\\u2603", {"ok":true}] }, "id2": { "global" : 9 }}]}';
+    const batchIterable = await parseInBatches(
+      streamChromeTraceText(jsonText, 5),
+      ChromeTraceLoader,
+      {
+        chromeTrace: {
+          shape: 'arrow-table',
+          batchSize: 1
+        }
+      }
+    );
+
+    const batches: arrow.RecordBatch[] = [];
+    for await (const batch of batchIterable) {
+      batches.push(batch as arrow.RecordBatch);
+    }
+
+    const table = new arrow.Table(batches[0].schema, batches);
+    expect(table.getChild('pid')?.get(0)).toBe('7');
+    expect(table.getChild('tid')?.get(0)).toBe('8');
+    expect(table.getChild('args')?.get(0)).toBe('{ "nested" : ["\\\\u2603", {"ok":true}] }');
+    expect(table.getChild('id2')?.get(0)).toBe('{ "global" : 9 }');
+  });
+
+  it('streams a large mixed Chrome trace fixture across multiple Arrow batches', async () => {
+    const fixture = createLargeStreamedChromeTraceFixture();
+    const batchIterable = await parseInBatches(
+      streamChromeTraceText(fixture.jsonText, 29),
+      ChromeTraceLoader,
+      {
+        chromeTrace: {
+          shape: 'arrow-table',
+          batchSize: 32
+        }
+      }
+    );
+
+    const batches: arrow.RecordBatch[] = [];
+    for await (const batch of batchIterable) {
+      batches.push(batch as arrow.RecordBatch);
+    }
+
+    expect(batches).toHaveLength(Math.ceil(fixture.eventCount / 32));
+
+    const table = new arrow.Table(batches[0].schema, batches);
+    expect(table.numRows).toBe(fixture.eventCount);
+    expect(table.getChild('pid')?.get(12)).toBe('12');
+    expect(table.getChild('tid')?.get(12)).toBe('1012');
+    expect(table.getChild('id')?.get(12)).toBe('1200');
+    expect(table.getChild('pid')?.get(13)).toBe('process-13');
+    expect(table.getChild('id')?.get(13)).toBe('id-13');
+    expect(table.getChild('bind_id')?.get(10)).toBe('510');
+    expect(table.getChild('bind_id')?.get(11)).toBe('bind-11');
+    expect(table.getChild('args')?.get(5)).toBe(fixture.expectedArgsJson);
+    expect(table.getChild('args')?.get(7)).toBeNull();
+    expect(table.getChild('args')?.get(11)).toBeNull();
+    expect(table.getChild('id2')?.get(12)).toBe(fixture.expectedId2Json);
+    expect(table.getChild('id2')?.get(13)).toBeNull();
+    expect(table.getChild('ignored_extra_field')).toBeNull();
+    expect(batches.at(-1)?.schema.metadata.get('chromeTrace.metadataJson')).toBe(
+      JSON.stringify(fixture.metadata)
     );
   });
 });

--- a/modules/traces/test/chrome-trace-stream.spec.ts
+++ b/modules/traces/test/chrome-trace-stream.spec.ts
@@ -200,7 +200,7 @@ describe('chrome-trace-stream', () => {
     expect(summarizeChunks(fileChunks)).toEqual(summarizeChunks(arrowChunks));
   });
 
-  it('publishes equivalent snapshots for file and Arrow stream consumption', async () => {
+  it('publishes equivalent trace summaries for file and Arrow stream consumption', async () => {
     const traceFile = createChromeTraceFixture();
     const fileSession = createTraceStreamSession({publishIntervalMs: 0});
     const arrowSession = createTraceStreamSession({publishIntervalMs: 0});
@@ -227,7 +227,20 @@ describe('chrome-trace-stream', () => {
       publishEveryEvents: 1
     });
 
-    expect(arrowSnapshot).toEqual(fileSnapshot);
+    expect(arrowSnapshot?.trace.metadata).toEqual(fileSnapshot?.trace.metadata);
+    expect(arrowSnapshot?.trace.processes).toEqual(fileSnapshot?.trace.processes);
+    const summarizeEvents = (events: ChromeTraceEventSchema[] | undefined) =>
+      events?.map(event => ({
+        name: event.name,
+        ph: event.ph,
+        ...(event.ts != null ? {ts: event.ts} : {}),
+        ...(event.dur != null ? {dur: event.dur} : {}),
+        ...(event.cat != null ? {cat: event.cat} : {}),
+        ...(event.args != null ? {args: event.args} : {})
+      })) || [];
+    expect(summarizeEvents(arrowSnapshot?.traceFile.traceEvents)).toEqual(
+      summarizeEvents(fileSnapshot?.traceFile.traceEvents)
+    );
   });
 
   it('pipes parseInBatches output from ChromeTraceLoader into streamChromeTraceArrowChunks', async () => {

--- a/modules/traces/tsconfig.json
+++ b/modules/traces/tsconfig.json
@@ -8,6 +8,7 @@
     "outDir": "dist"
   },
   "references": [
+    {"path": "../json"},
     {"path": "../loader-utils"}
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5499,7 +5499,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@loaders.gl/json@workspace:*, @loaders.gl/json@workspace:modules/json":
+"@loaders.gl/json@npm:4.4.0, @loaders.gl/json@workspace:*, @loaders.gl/json@workspace:modules/json":
   version: 0.0.0-use.local
   resolution: "@loaders.gl/json@workspace:modules/json"
   dependencies:
@@ -5890,6 +5890,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@loaders.gl/traces@workspace:modules/traces"
   dependencies:
+    "@loaders.gl/json": "npm:4.4.0"
     "@loaders.gl/loader-utils": "npm:4.4.0"
     apache-arrow: "npm:>= 17.0.0"
     zod: "npm:^4.1.12"


### PR DESCRIPTION
## Goals

- Speed up streamed Chrome trace Arrow ingestion by routing it through the fast JSON table parser.
- Preserve nested JSON payloads such as `args` and `id2` as exact source Utf8 text without materializing them first.
- Keep streamed Chrome trace batches focused on direct trace-event fields instead of legacy compatibility payload columns.

## Changes

- Added fast streamed raw-Utf8 capture support for schema-declared `utf8` Arrow fields in `JSONTableLoader`.
- Preserved exact source JSON slices for streamed object/array values, including chunk-boundary cases, whitespace, ordering, and escape spelling.
- Added narrow Arrow Utf8 conversion support for numeric source values via `utf8Conversion: 'number-to-string'`.
- Routed streamed `ChromeTraceLoader` Arrow parsing through `JSONTableLoader` with:
  - `backend: 'fast'`
  - `shape: 'arrow-table'`
  - `jsonpaths: ['$.traceEvents']`
  - an explicit streamed Chrome trace event schema
- Added a direct streamed Chrome trace Arrow schema covering event fields such as:
  - `name`, `ph`, `ts`, `pid`, `tid`, `cat`, `dur`, `tdur`, `tts`
  - `id`, `bind_id`, `s`, `scope`
  - raw Utf8 `args` and `id2`
- Dropped the old streamed `extraJson` compatibility column from the new streamed Arrow contract.
- Preserved top-level Chrome trace metadata on streamed Arrow output for downstream consumers.
- Updated the Arrow adapter to consume the new direct streamed schema while retaining compatibility with existing full-file Arrow handling.
- Added docs for:
  - streamed fast raw-Utf8 capture
  - numeric-to-Utf8 conversion
  - streamed Chrome trace Arrow behavior
- Added coverage for:
  - JSON raw-Utf8 preservation and numeric Utf8 conversion
  - Chrome trace streamed direct schema output
  - exact raw `args` / `id2` preservation across hostile chunk splits
  - streamed metadata retention
  - downstream Chrome trace stream adapters
  - a generated 257-event mixed-type Chrome trace stress fixture spanning multiple Arrow batches

## Validation

- `env -u YARN_NO_PROXY corepack yarn`
- `env -u YARN_NO_PROXY corepack yarn lint fix`
- `env -u YARN_NO_PROXY corepack yarn build`
- `env -u YARN_NO_PROXY corepack yarn test-node`
- `env -u YARN_NO_PROXY corepack yarn test-headless`
- `git diff --check`