### PR TITLE
feat(splats) Add SPZ and RAD splat loaders

### DIFF
--- a/docs/modules/splats/README.md
+++ b/docs/modules/splats/README.md
@@ -5,7 +5,8 @@
   <img src="https://img.shields.io/badge/Status-Experimental-orange.svg?style=flat-square" alt="Status: Experimental" />
 </p>
 
-The `@loaders.gl/splats` module loads binary Gaussian splat files for rendering or processing as Mesh Arrow tables.
+The `@loaders.gl/splats` module loads binary Gaussian splat files for rendering,
+processing, or paged level-of-detail streaming.
 
 ## Installation
 
@@ -19,9 +20,12 @@ npm install @loaders.gl/core @loaders.gl/splats
 | ------------------------------------------------------------- | ---------------------------------------------------------- |
 | [`SPLATLoader`](/docs/modules/splats/api-reference/splat-loader)   | Loads raw `.splat` Gaussian splat files.                   |
 | [`KSPLATLoader`](/docs/modules/splats/api-reference/ksplat-loader) | Loads GaussianSplats3D `.ksplat` files from full buffers. |
+| [`SPZLoader`](/docs/modules/splats/api-reference/spz-loader)       | Loads Niantic Spatial `.spz` files from full buffers.     |
+| [`RADLoader`](/docs/modules/splats/api-reference/rad-source-loader) | Loads Spark `.rad` metadata from full buffers.            |
+| [`RADSourceLoader`](/docs/modules/splats/api-reference/rad-source-loader) | Creates a source for Spark `.rad` metadata and chunks. |
 
 ## Formats
 
 | Format                                      | Description                                          |
 | ------------------------------------------- | ---------------------------------------------------- |
-| [SPLAT / KSPLAT](/docs/modules/splats/formats/splats) | Binary Gaussian splat formats for real-time scenes. |
+| [SPLAT / KSPLAT / SPZ / RAD](/docs/modules/splats/formats/splats) | Binary Gaussian splat formats for real-time scenes. |

--- a/docs/modules/splats/api-reference/rad-source-loader.md
+++ b/docs/modules/splats/api-reference/rad-source-loader.md
@@ -1,0 +1,78 @@
+# RADLoader and RADSourceLoader
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v5.0-blue.svg?style=flat-square" alt="From-v5.0" />
+  <img src="https://img.shields.io/badge/Status-Experimental-orange.svg?style=flat-square" alt="Status: Experimental" />
+</p>
+
+`RADLoader` parses Spark `.rad` metadata. `RADSourceLoader` creates a runtime
+source for range-fetching Spark `.rad` headers, RADC chunks, and decoded chunk
+tables.
+
+| Property   | Value                                      |
+| ---------- | ------------------------------------------ |
+| File format | [RAD](/docs/modules/splats/formats/splats) |
+| Extensions | `.rad`                                    |
+| Worker     | No                                        |
+| Input type | `ArrayBuffer`, URL, or `Blob`             |
+| Output     | RAD metadata or `RADSource`               |
+
+## Usage
+
+Use `RADSourceLoader` when working with remote LoD assets:
+
+```typescript
+import {load} from '@loaders.gl/core';
+import {RADSourceLoader} from '@loaders.gl/splats';
+
+const source = await load(url, RADSourceLoader);
+const metadata = await source.getMetadata();
+const firstChunk = await source.getChunk(0);
+const firstChunkTable = await source.getChunkTable(0);
+
+for await (const chunkTable of source.getChunkTables({
+  maxChunks: 8,
+  pruneLoadedLoDParents: true
+})) {
+  // Append each decoded chunk table to a renderer-owned page cache.
+}
+```
+
+For full buffers, `RADLoader` returns just the top-level metadata:
+
+```typescript
+import {parse} from '@loaders.gl/core';
+import {RADLoader} from '@loaders.gl/splats';
+
+const metadata = await parse(arrayBuffer, RADLoader);
+```
+
+## Format Support
+
+`RADLoader` and `RADSourceLoader` support Spark RAD version 1 files with `type:
+'gsplat'`. The source understands:
+
+- top-level `RAD0` metadata headers
+- inline RADC chunks stored after the RAD header
+- sidecar chunk filenames relative to the RAD URL
+- RADC chunk metadata headers
+- chunk range fetching through HTTP `Range` requests
+- RADC payload decoding for centers, alpha, RGB, scales, orientations, LoD child
+  arrays, and optional spherical harmonics
+- Mesh Arrow table construction for individual chunks
+
+RAD is a paged LoD format, so exact Spark-style rendering still requires a
+renderer to drive page selection, LoD tree traversal, and GPU residency. The
+source exposes chunk decoding so renderers and examples can bridge RAD pages into
+the standard loaders.gl Gaussian splat Arrow table shape.
+
+## Options
+
+| Option | Type | Default | Description |
+| ------ | ---- | ------- | ----------- |
+| `rad.headers` | `object` | `undefined` | Request headers forwarded to RAD and RADC fetches. |
+| `rad.withCredentials` | `boolean` | `false` | Includes credentials for remote RAD and RADC fetches. |
+| `rad.headerByteLengths` | `number[]` | `[65536, 262144, 1048576]` | Header probe sizes used while range-fetching remote RAD metadata. |
+| `pruneLoadedLoDParents` | `boolean` | `false` | When iterating chunk tables, removes parent LoD splats whose children are included in the loaded chunk range. |
+| `radChunk.includeLoDTree` | `boolean` | `true` | Keeps decoded `child_count` and `child_start` arrays in chunk `loaderData`. |
+| `radChunk.includeSphericalHarmonics` | `boolean` | `false` | Adds decoded SH rest coefficients to chunk Arrow tables. |

--- a/docs/modules/splats/api-reference/spz-loader.md
+++ b/docs/modules/splats/api-reference/spz-loader.md
@@ -20,6 +20,8 @@
 SPZ version 4 uses ZSTD-compressed attribute streams. Inject `zstd-codec` through loader options so applications that only use `SPLATLoader` or `KSPLATLoader` do not pay the ZSTD dependency cost.
 
 ```typescript
+// npm install @loaders.gl/core @loaders.gl/splats zstd-codec
+
 import {load} from '@loaders.gl/core';
 import {SPZLoader} from '@loaders.gl/splats';
 import {ZstdCodec} from 'zstd-codec';

--- a/docs/modules/splats/api-reference/spz-loader.md
+++ b/docs/modules/splats/api-reference/spz-loader.md
@@ -1,0 +1,73 @@
+# SPZLoader
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v5.0-blue.svg?style=flat-square" alt="From-v5.0" />
+  <img src="https://img.shields.io/badge/Status-Experimental-orange.svg?style=flat-square" alt="Status: Experimental" />
+</p>
+
+`SPZLoader` parses Niantic Spatial `.spz` Gaussian splat files and returns a [Mesh Arrow table](/docs/specifications/category-mesh#mesh-arrow-tables).
+
+| Property     | Value                                      |
+| ------------ | ------------------------------------------ |
+| File format  | [SPZ](/docs/modules/splats/formats/splats) |
+| Extensions   | `.spz`                                     |
+| Worker       | No                                         |
+| Input type   | `ArrayBuffer`                              |
+| Output shape | `arrow-table`                              |
+
+## Usage
+
+SPZ version 4 uses ZSTD-compressed attribute streams. Inject `zstd-codec` through loader options so applications that only use `SPLATLoader` or `KSPLATLoader` do not pay the ZSTD dependency cost.
+
+```typescript
+import {load} from '@loaders.gl/core';
+import {SPZLoader} from '@loaders.gl/splats';
+import {ZstdCodec} from 'zstd-codec';
+
+const table = await load(url, SPZLoader, {
+  modules: {'zstd-codec': ZstdCodec}
+});
+```
+
+The parser-bearing subpath can also be imported directly:
+
+```typescript
+import {SPZLoaderWithParser} from '@loaders.gl/splats/spz-loader';
+```
+
+## Format support
+
+`SPZLoader` supports SPZ version 4 files that start with the `NGSP` magic value and use the plaintext 32-byte header, table of contents, and independent ZSTD-compressed attribute streams.
+
+The loader decodes:
+
+- 24-bit fixed-point positions
+- 8-bit alpha values into linear opacity
+- 8-bit color values into SH DC coefficients
+- 8-bit log-encoded scales into linear scale standard deviations
+- smallest-three quaternion rotations into `rot_0`, `rot_1`, `rot_2`, `rot_3`
+- 8-bit spherical harmonic rest coefficients for SPZ degrees 1 through 4
+
+Legacy SPZ versions 1 through 3 use a gzip-compressed single-stream layout and are not supported.
+
+## Output
+
+The loader returns a [Mesh Arrow table](/docs/specifications/category-mesh#mesh-arrow-tables) with the existing Gaussian splat columns:
+
+- `POSITION`
+- `f_dc_0`, `f_dc_1`, `f_dc_2`
+- `opacity`
+- `scale_0`, `scale_1`, `scale_2`
+- `rot_0`, `rot_1`, `rot_2`, `rot_3`
+- `f_rest_*` when spherical harmonics are present
+
+Schema metadata includes `loaders_gl.semantic_type = gaussian-splats` and `loaders_gl.gaussian_splats.source_format = spz`.
+
+`loaderData` includes the SPZ header fields, `antialiased`, `extensionByteLength`, and `extensionBytes` when plaintext extension records are present.
+
+## Options
+
+| Option         | Type            | Default         | Description                              |
+| -------------- | --------------- | --------------- | ---------------------------------------- |
+| `splats.shape` | `'arrow-table'` | `'arrow-table'` | Selects Mesh Arrow table output. V1 only supports `arrow-table`. |
+| `modules`      | `object`        | `{}`            | Must include `{'zstd-codec': ZstdCodec}` to decode SPZ version 4 streams. |

--- a/docs/modules/splats/formats/splats.md
+++ b/docs/modules/splats/formats/splats.md
@@ -1,4 +1,4 @@
-# SPLAT and KSPLAT
+# SPLAT, KSPLAT, SPZ, and RAD
 
 <p class="badges">
   <img src="https://img.shields.io/badge/From-v5.0-blue.svg?style=flat-square" alt="From-v5.0" />
@@ -30,9 +30,40 @@ The format has no header, so loader selection depends on the file extension or e
 
 The v1 loader supports complete in-memory `.ksplat` files and decodes compression levels 0, 1, and 2. Progressive section loading is intentionally not part of the initial API.
 
+## SPZ
+
+`.spz` is Niantic Spatial's compressed 3D Gaussian splat interchange format. SPZ version 4 stores a 32-byte plaintext header, optional extension records, a table of contents, and independent ZSTD-compressed attribute streams for positions, alphas, colors, scales, rotations, and spherical harmonics.
+
+`SPZLoader` decodes complete in-memory SPZ version 4 files into the same Mesh Arrow table shape as `SPLATLoader` and `KSPLATLoader`, preserving SPZ header fields and extension bytes in `loaderData` where practical.
+
+Legacy SPZ versions 1 through 3 use a gzip-compressed single-stream layout and are not supported by `SPZLoader`.
+
+See the [SPZLoader](/docs/modules/splats/api-reference/spz-loader) API reference for usage and ZSTD module requirements.
+
+## RAD
+
+`.rad` is Spark's paged level-of-detail Gaussian splat container. A RAD file starts
+with the `RAD0` magic value, a JSON metadata block, and then either inline RADC
+chunks or chunk table entries that point to sidecar `.radc` files.
+
+`RADLoader` parses the top-level RAD metadata from a full buffer. `RADSourceLoader`
+is the preferred entry point for applications because it can range-fetch the
+header, expose the chunk table, and fetch inline or sidecar RADC chunk bytes on
+demand.
+
+`RADSourceLoader` can also decode individual RADC chunks into the same Gaussian
+splat Mesh Arrow table shape used by the full-buffer loaders. RAD remains a paged
+LoD format, so large scenes should still be rendered with chunk paging, LoD tree
+traversal, and GPU residency management instead of eagerly decoding every chunk.
+
+See the [RADSourceLoader](/docs/modules/splats/api-reference/rad-source-loader)
+API reference for usage.
+
 ## Output
 
-Both loaders return a [Mesh Arrow table](/docs/specifications/category-mesh#mesh-arrow-tables) with Gaussian splat metadata:
+`SPLATLoader`, `KSPLATLoader`, and `SPZLoader` return a
+[Mesh Arrow table](/docs/specifications/category-mesh#mesh-arrow-tables) with
+Gaussian splat metadata:
 
 - `POSITION`
 - `f_dc_0`, `f_dc_1`, `f_dc_2`

--- a/modules/compression/src/lib/zstd-compression.ts
+++ b/modules/compression/src/lib/zstd-compression.ts
@@ -47,6 +47,8 @@ export class ZstdCompression extends Compression {
     // eslint-disable-next-line  @typescript-eslint/no-misused-promises
     if (!zstdPromise && ZstdCodec) {
       zstdPromise = new Promise(resolve => ZstdCodec.run(zstd => resolve(zstd)));
+    }
+    if (zstdPromise) {
       zstd = await zstdPromise;
     }
   }

--- a/modules/splats/package.json
+++ b/modules/splats/package.json
@@ -37,6 +37,18 @@
       "types": "./dist/ksplat-loader.d.ts",
       "import": "./dist/ksplat-loader.js"
     },
+    "./spz-loader": {
+      "types": "./dist/spz-loader.d.ts",
+      "import": "./dist/spz-loader.js"
+    },
+    "./rad-loader": {
+      "types": "./dist/rad-loader.d.ts",
+      "import": "./dist/rad-loader.js"
+    },
+    "./rad-source-loader": {
+      "types": "./dist/rad-source-loader.d.ts",
+      "import": "./dist/rad-source-loader.js"
+    },
     "./unbundled": {
       "types": "./dist/unbundled.d.ts",
       "import": "./dist/unbundled.js"
@@ -58,9 +70,13 @@
     "build-bundle-dev": "ocular-bundle ./bundle.ts --env=dev --output=dist/dist.dev.js"
   },
   "dependencies": {
+    "@loaders.gl/compression": "4.4.0",
     "@loaders.gl/loader-utils": "4.4.0",
     "@loaders.gl/schema": "4.4.0",
     "apache-arrow": ">= 17.0.0"
+  },
+  "devDependencies": {
+    "zstd-codec": "^0.1.0"
   },
   "peerDependencies": {
     "@loaders.gl/core": "~4.4.0"

--- a/modules/splats/src/bundled.ts
+++ b/modules/splats/src/bundled.ts
@@ -2,4 +2,4 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-export {SPLATLoader, KSPLATLoader} from './index';
+export {SPLATLoader, KSPLATLoader, SPZLoader, RADLoader, RADSourceLoader} from './index';

--- a/modules/splats/src/index.ts
+++ b/modules/splats/src/index.ts
@@ -2,7 +2,31 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-export type {SplatsLoaderOptions} from './types';
-export {SPLATFormat, KSPLATFormat} from './splats-format';
+export type {GaussianSplats, SplatsLoaderOptions} from './types';
+export type {
+  RADChunkMetadata,
+  RADChunkProperty,
+  RADChunkPropertyCompression,
+  RADChunkPropertyEncoding,
+  RADChunkPropertyName,
+  RADChunkRange,
+  RADMetadata,
+  RADSplatEncoding
+} from './lib/parse-rad';
+export {parseRADChunkHeader, parseRADHeader, tryParseRADHeader} from './lib/parse-rad';
+export {
+  parseRADChunk,
+  parseRADChunkToGaussianSplats,
+  type RADChunkDecodeOptions
+} from './lib/parse-rad-chunk';
+export {SPLATFormat, KSPLATFormat, SPZFormat, RADFormat} from './splats-format';
 export {SPLATLoader} from './splat-loader-types';
 export {KSPLATLoader} from './ksplat-loader-types';
+export {SPZLoader} from './spz-loader-types';
+export {RADLoader} from './rad-loader-types';
+export type {
+  RADChunkRequestOptions,
+  RADChunkTableIteratorOptions,
+  RADSourceLoaderOptions
+} from './rad-source-loader';
+export {RADSource, RADSourceLoader, resolveRADChunkUrl} from './rad-source-loader';

--- a/modules/splats/src/index.ts
+++ b/modules/splats/src/index.ts
@@ -13,12 +13,6 @@ export type {
   RADMetadata,
   RADSplatEncoding
 } from './lib/parse-rad';
-export {parseRADChunkHeader, parseRADHeader, tryParseRADHeader} from './lib/parse-rad';
-export {
-  parseRADChunk,
-  parseRADChunkToGaussianSplats,
-  type RADChunkDecodeOptions
-} from './lib/parse-rad-chunk';
 export {SPLATFormat, KSPLATFormat, SPZFormat, RADFormat} from './splats-format';
 export {SPLATLoader} from './splat-loader-types';
 export {KSPLATLoader} from './ksplat-loader-types';

--- a/modules/splats/src/lib/parse-rad-chunk.ts
+++ b/modules/splats/src/lib/parse-rad-chunk.ts
@@ -9,7 +9,8 @@ import {
   parseRADChunkHeader,
   roundUpToEight,
   type RADChunkMetadata,
-  type RADChunkProperty
+  type RADChunkProperty,
+  type RADSplatEncoding
 } from './parse-rad';
 import {makeGaussianSplatsArrowTable} from './splats-arrow-table';
 import {decodeFloat16, normalizeQuaternion, SH_C0} from './splat-utils';
@@ -20,6 +21,8 @@ const RAD_PROPERTY_RAW_DEFLATE = new DeflateCompression({raw: true});
 /** Options for decoding one Spark RADC chunk payload. */
 export type RADChunkDecodeOptions = SplatsLoaderOptions & {
   radChunk?: {
+    /** Optional source-level splat encoding metadata used as a fallback for chunk-local metadata. */
+    splatEncoding?: RADSplatEncoding;
     /** Whether decoded LoD child metadata is retained in `loaderData`. */
     includeLoDTree?: boolean;
     /** Whether decoded SH rest coefficients are included in Arrow table columns. */
@@ -41,7 +44,7 @@ export function parseRADChunkToGaussianSplats(
   options?: RADChunkDecodeOptions
 ): GaussianSplats {
   const bytes = getUint8Array(data);
-  const metadata = parseRADChunkHeader(bytes);
+  const metadata = getRADChunkDecodeMetadata(parseRADChunkHeader(bytes), options);
   if (bytes.byteLength < metadata.chunkByteLength) {
     throw new Error('RADLoader: RADC chunk payload is incomplete.');
   }
@@ -249,28 +252,38 @@ function decodeRADFloatProperty(
         propertyBytes,
         dimensions,
         metadata.count,
-        getPropertyMin(property),
-        getPropertyMax(property)
+        getPropertyMin(metadata, property),
+        getPropertyMax(metadata, property)
       );
     case 'r8_delta':
       return decodeR8Delta(
         propertyBytes,
         dimensions,
         metadata.count,
-        getPropertyMin(property),
-        getPropertyMax(property)
+        getPropertyMin(metadata, property),
+        getPropertyMax(metadata, property)
       );
     case 's8':
-      return decodeS8(propertyBytes, dimensions, metadata.count, getPropertyMax(property));
+      return decodeS8(
+        propertyBytes,
+        dimensions,
+        metadata.count,
+        getPropertyMax(metadata, property)
+      );
     case 's8_delta':
-      return decodeS8Delta(propertyBytes, dimensions, metadata.count, getPropertyMax(property));
+      return decodeS8Delta(
+        propertyBytes,
+        dimensions,
+        metadata.count,
+        getPropertyMax(metadata, property)
+      );
     case 'ln_0r8':
       return decodeScaleR8(
         propertyBytes,
         dimensions,
         metadata.count,
-        getPropertyMin(property),
-        getPropertyMax(property)
+        getPropertyMin(metadata, property),
+        getPropertyMax(metadata, property)
       );
     case 'ln_f16':
       return decodeLogFloat16(propertyBytes, dimensions, metadata.count);
@@ -610,20 +623,82 @@ function findRADProperty(
   return metadata.properties.find(property => property.property === propertyName);
 }
 
+/** Merges source-level splat encoding with chunk-local encoding. */
+function getRADChunkDecodeMetadata(
+  metadata: RADChunkMetadata,
+  options?: RADChunkDecodeOptions
+): RADChunkMetadata {
+  const splatEncoding = options?.radChunk?.splatEncoding;
+  if (!splatEncoding) {
+    return metadata;
+  }
+  return {
+    ...metadata,
+    splatEncoding: {
+      ...splatEncoding,
+      ...metadata.splatEncoding
+    }
+  };
+}
+
 /** Returns a required quantization minimum. */
-function getPropertyMin(property: RADChunkProperty): number {
+function getPropertyMin(metadata: RADChunkMetadata, property: RADChunkProperty): number {
   if (property.min === undefined) {
+    const fallback = getSplatEncodingMinimum(metadata.splatEncoding, property.property);
+    if (fallback !== undefined) {
+      return fallback;
+    }
     throw new Error(`RADLoader: RADC property ${property.property} is missing min.`);
   }
   return property.min;
 }
 
 /** Returns a required quantization maximum. */
-function getPropertyMax(property: RADChunkProperty): number {
+function getPropertyMax(metadata: RADChunkMetadata, property: RADChunkProperty): number {
   if (property.max === undefined) {
+    const fallback = getSplatEncodingMaximum(metadata.splatEncoding, property.property);
+    if (fallback !== undefined) {
+      return fallback;
+    }
     throw new Error(`RADLoader: RADC property ${property.property} is missing max.`);
   }
   return property.max;
+}
+
+/** Returns a source-level minimum value for a quantized RAD property. */
+function getSplatEncodingMinimum(
+  splatEncoding: RADSplatEncoding | undefined,
+  propertyName: string
+): number | undefined {
+  switch (propertyName) {
+    case 'rgb':
+      return splatEncoding?.rgbMin;
+    case 'scales':
+      return splatEncoding?.lnScaleMin;
+    default:
+      return undefined;
+  }
+}
+
+/** Returns a source-level maximum value for a quantized RAD property. */
+function getSplatEncodingMaximum(
+  splatEncoding: RADSplatEncoding | undefined,
+  propertyName: string
+): number | undefined {
+  switch (propertyName) {
+    case 'rgb':
+      return splatEncoding?.rgbMax;
+    case 'scales':
+      return splatEncoding?.lnScaleMax;
+    case 'sh1':
+      return splatEncoding?.sh1Max;
+    case 'sh2':
+      return splatEncoding?.sh2Max;
+    case 'sh3':
+      return splatEncoding?.sh3Max;
+    default:
+      return undefined;
+  }
 }
 
 /** Clamps a normalized color component into an unorm8 byte. */

--- a/modules/splats/src/lib/parse-rad-chunk.ts
+++ b/modules/splats/src/lib/parse-rad-chunk.ts
@@ -1,0 +1,646 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {DeflateCompression} from '@loaders.gl/compression';
+import type {MeshArrowTable} from '@loaders.gl/schema';
+import type {GaussianSplats, SplatsLoaderOptions} from '../types';
+import {
+  parseRADChunkHeader,
+  roundUpToEight,
+  type RADChunkMetadata,
+  type RADChunkProperty
+} from './parse-rad';
+import {makeGaussianSplatsArrowTable} from './splats-arrow-table';
+import {decodeFloat16, normalizeQuaternion, SH_C0} from './splat-utils';
+
+const RAD_PROPERTY_DEFLATE = new DeflateCompression();
+const RAD_PROPERTY_RAW_DEFLATE = new DeflateCompression({raw: true});
+
+/** Options for decoding one Spark RADC chunk payload. */
+export type RADChunkDecodeOptions = SplatsLoaderOptions & {
+  radChunk?: {
+    /** Whether decoded LoD child metadata is retained in `loaderData`. */
+    includeLoDTree?: boolean;
+    /** Whether decoded SH rest coefficients are included in Arrow table columns. */
+    includeSphericalHarmonics?: boolean;
+  };
+};
+
+/** Parses a Spark `.radc` chunk into a Mesh Arrow table. */
+export function parseRADChunk(
+  data: ArrayBuffer | ArrayBufferView,
+  options?: RADChunkDecodeOptions
+): MeshArrowTable {
+  return makeGaussianSplatsArrowTable(parseRADChunkToGaussianSplats(data, options));
+}
+
+/** Parses a Spark `.radc` chunk into decoded Gaussian splat values. */
+export function parseRADChunkToGaussianSplats(
+  data: ArrayBuffer | ArrayBufferView,
+  options?: RADChunkDecodeOptions
+): GaussianSplats {
+  const bytes = getUint8Array(data);
+  const metadata = parseRADChunkHeader(bytes);
+  if (bytes.byteLength < metadata.chunkByteLength) {
+    throw new Error('RADLoader: RADC chunk payload is incomplete.');
+  }
+
+  const splatCount = metadata.count;
+  const positions = decodeRADFloatProperty(
+    bytes,
+    metadata,
+    requireRADProperty(metadata, 'center'),
+    3
+  );
+  const opacities = decodeRADAlpha(bytes, metadata, splatCount);
+  const rgb = decodeRADRgb(bytes, metadata, splatCount);
+  const scales = decodeRADScales(bytes, metadata, splatCount);
+  const rotations = decodeRADRotations(bytes, metadata, splatCount);
+  const {colors, sphericalHarmonicDcs} = convertRgbToColorColumns(rgb);
+  const includeLoDTree = options?.radChunk?.includeLoDTree ?? true;
+  const childCounts = includeLoDTree
+    ? decodeOptionalRADUint16(bytes, metadata, 'child_count')
+    : null;
+  const childStarts = includeLoDTree
+    ? decodeOptionalRADUint32(bytes, metadata, 'child_start')
+    : null;
+  const includeSphericalHarmonics = options?.radChunk?.includeSphericalHarmonics ?? false;
+  const sphericalHarmonics = includeSphericalHarmonics
+    ? decodeRADSphericalHarmonics(bytes, metadata)
+    : null;
+
+  return {
+    format: 'rad',
+    splatCount,
+    positions,
+    scales,
+    rotations,
+    colors,
+    sphericalHarmonicDcs,
+    opacities,
+    sphericalHarmonics: sphericalHarmonics?.values,
+    sphericalHarmonicsComponentCount: sphericalHarmonics?.componentCount,
+    loaderData: {
+      format: 'rad',
+      base: metadata.base,
+      count: metadata.count,
+      maxSh: metadata.maxSh ?? 0,
+      lodTree: metadata.lodTree ?? false,
+      splatEncoding: metadata.splatEncoding,
+      childCounts: childCounts ?? undefined,
+      childStarts: childStarts ?? undefined
+    }
+  };
+}
+
+/** Decodes the chunk alpha property, falling back to fully opaque splats. */
+function decodeRADAlpha(
+  bytes: Uint8Array,
+  metadata: RADChunkMetadata,
+  splatCount: number
+): Float32Array {
+  const property = findRADProperty(metadata, 'alpha');
+  if (!property) {
+    return new Float32Array(splatCount).fill(1);
+  }
+  const opacities = decodeRADFloatProperty(bytes, metadata, property, 1);
+  for (let splatIndex = 0; splatIndex < opacities.length; splatIndex++) {
+    opacities[splatIndex] = decodeRADOpacity(opacities[splatIndex], metadata, property);
+  }
+  return opacities;
+}
+
+/** Decodes normal or Spark LoD opacity into the renderer opacity domain. */
+function decodeRADOpacity(
+  opacity: number,
+  metadata: RADChunkMetadata,
+  property: RADChunkProperty
+): number {
+  const normalizedOpacity = Math.max(opacity, 0);
+  if (
+    !metadata.splatEncoding?.lodOpacity ||
+    (property.encoding !== 'r8' && property.encoding !== 'r8_delta')
+  ) {
+    return normalizedOpacity;
+  }
+
+  return normalizedOpacity * 2;
+}
+
+/** Decodes the chunk RGB property, falling back to white splats. */
+function decodeRADRgb(
+  bytes: Uint8Array,
+  metadata: RADChunkMetadata,
+  splatCount: number
+): Float32Array {
+  const property = findRADProperty(metadata, 'rgb');
+  if (!property) {
+    return new Float32Array(splatCount * 3).fill(1);
+  }
+  return decodeRADFloatProperty(bytes, metadata, property, 3);
+}
+
+/** Decodes the chunk scale property, falling back to unit splats. */
+function decodeRADScales(
+  bytes: Uint8Array,
+  metadata: RADChunkMetadata,
+  splatCount: number
+): Float32Array {
+  const property = findRADProperty(metadata, 'scales');
+  if (!property) {
+    return new Float32Array(splatCount * 3).fill(1);
+  }
+  return decodeRADFloatProperty(bytes, metadata, property, 3);
+}
+
+/** Decodes the chunk orientation property, falling back to identity rotations. */
+function decodeRADRotations(
+  bytes: Uint8Array,
+  metadata: RADChunkMetadata,
+  splatCount: number
+): Float32Array {
+  const property = findRADProperty(metadata, 'orientation');
+  if (!property) {
+    return makeIdentityRotations(splatCount);
+  }
+
+  const propertyBytes = getRADPropertyBytes(bytes, metadata, property);
+  switch (property.encoding) {
+    case 'oct88r8':
+      return decodeRADOct88R8Rotations(propertyBytes, splatCount);
+    case 'f32':
+    case 'f16': {
+      const xyz = decodeRADFloatProperty(bytes, metadata, property, 3);
+      const rotations = new Float32Array(splatCount * 4);
+      for (let splatIndex = 0; splatIndex < splatCount; splatIndex++) {
+        const xyzOffset = splatIndex * 3;
+        const rotationOffset = splatIndex * 4;
+        const x = xyz[xyzOffset + 0];
+        const y = xyz[xyzOffset + 1];
+        const z = xyz[xyzOffset + 2];
+        const w = Math.sqrt(Math.max(0, 1 - x * x - y * y - z * z));
+        const normalized = normalizeQuaternion(w, x, y, z);
+        rotations.set(normalized, rotationOffset);
+      }
+      return rotations;
+    }
+    default:
+      throw new Error(`RADLoader: unsupported orientation encoding ${property.encoding}.`);
+  }
+}
+
+/** Decodes optional spherical harmonic rest properties from a chunk. */
+function decodeRADSphericalHarmonics(
+  bytes: Uint8Array,
+  metadata: RADChunkMetadata
+): {values: Float32Array; componentCount: number} | null {
+  const shProperties = [
+    {property: findRADProperty(metadata, 'sh1'), dimensions: 9},
+    {property: findRADProperty(metadata, 'sh2'), dimensions: 15},
+    {property: findRADProperty(metadata, 'sh3'), dimensions: 21}
+  ].filter(
+    (entry): entry is {property: RADChunkProperty; dimensions: number} =>
+      entry.property !== undefined
+  );
+  if (shProperties.length === 0) {
+    return null;
+  }
+
+  const decodedProperties = shProperties.map(entry => ({
+    values: decodeRADFloatProperty(bytes, metadata, entry.property, entry.dimensions),
+    dimensions: entry.dimensions
+  }));
+  const componentCount = decodedProperties.reduce((total, entry) => total + entry.dimensions, 0);
+  const values = new Float32Array(metadata.count * componentCount);
+  for (let splatIndex = 0; splatIndex < metadata.count; splatIndex++) {
+    let outputOffset = splatIndex * componentCount;
+    for (const decodedProperty of decodedProperties) {
+      const inputOffset = splatIndex * decodedProperty.dimensions;
+      values.set(
+        decodedProperty.values.subarray(inputOffset, inputOffset + decodedProperty.dimensions),
+        outputOffset
+      );
+      outputOffset += decodedProperty.dimensions;
+    }
+  }
+  return {values, componentCount};
+}
+
+/** Decodes one numeric RADC property into row-major Float32 values. */
+function decodeRADFloatProperty(
+  bytes: Uint8Array,
+  metadata: RADChunkMetadata,
+  property: RADChunkProperty,
+  dimensions: number
+): Float32Array {
+  const propertyBytes = getRADPropertyBytes(bytes, metadata, property);
+  switch (property.encoding) {
+    case 'f32':
+      return decodePlanarFloat32(propertyBytes, dimensions, metadata.count);
+    case 'f16':
+      return decodePlanarFloat16(propertyBytes, dimensions, metadata.count);
+    case 'f32_lebytes':
+      return decodeLeBytesFloat32(propertyBytes, dimensions, metadata.count);
+    case 'f16_lebytes':
+      return decodeLeBytesFloat16(propertyBytes, dimensions, metadata.count);
+    case 'r8':
+      return decodeR8(
+        propertyBytes,
+        dimensions,
+        metadata.count,
+        getPropertyMin(property),
+        getPropertyMax(property)
+      );
+    case 'r8_delta':
+      return decodeR8Delta(
+        propertyBytes,
+        dimensions,
+        metadata.count,
+        getPropertyMin(property),
+        getPropertyMax(property)
+      );
+    case 's8':
+      return decodeS8(propertyBytes, dimensions, metadata.count, getPropertyMax(property));
+    case 's8_delta':
+      return decodeS8Delta(propertyBytes, dimensions, metadata.count, getPropertyMax(property));
+    case 'ln_0r8':
+      return decodeScaleR8(
+        propertyBytes,
+        dimensions,
+        metadata.count,
+        getPropertyMin(property),
+        getPropertyMax(property)
+      );
+    case 'ln_f16':
+      return decodeLogFloat16(propertyBytes, dimensions, metadata.count);
+    default:
+      throw new Error(`RADLoader: unsupported ${property.property} encoding ${property.encoding}.`);
+  }
+}
+
+/** Decodes one optional unsigned 16-bit RADC property. */
+function decodeOptionalRADUint16(
+  bytes: Uint8Array,
+  metadata: RADChunkMetadata,
+  propertyName: string
+): Uint16Array | null {
+  const property = findRADProperty(metadata, propertyName);
+  if (!property) {
+    return null;
+  }
+  if (property.encoding !== 'u16') {
+    throw new Error(`RADLoader: unsupported ${propertyName} encoding ${property.encoding}.`);
+  }
+  const propertyBytes = getRADPropertyBytes(bytes, metadata, property);
+  const values = new Uint16Array(metadata.count);
+  for (let splatIndex = 0; splatIndex < metadata.count; splatIndex++) {
+    values[splatIndex] = propertyBytes[splatIndex * 2] | (propertyBytes[splatIndex * 2 + 1] << 8);
+  }
+  return values;
+}
+
+/** Decodes one optional unsigned 32-bit RADC property. */
+function decodeOptionalRADUint32(
+  bytes: Uint8Array,
+  metadata: RADChunkMetadata,
+  propertyName: string
+): Uint32Array | null {
+  const property = findRADProperty(metadata, propertyName);
+  if (!property) {
+    return null;
+  }
+  if (property.encoding !== 'u32') {
+    throw new Error(`RADLoader: unsupported ${propertyName} encoding ${property.encoding}.`);
+  }
+  const propertyBytes = getRADPropertyBytes(bytes, metadata, property);
+  const dataView = new DataView(
+    propertyBytes.buffer,
+    propertyBytes.byteOffset,
+    propertyBytes.byteLength
+  );
+  const values = new Uint32Array(metadata.count);
+  for (let splatIndex = 0; splatIndex < metadata.count; splatIndex++) {
+    values[splatIndex] = dataView.getUint32(splatIndex * 4, true);
+  }
+  return values;
+}
+
+/** Returns decompressed bytes for one RADC property. */
+function getRADPropertyBytes(
+  bytes: Uint8Array,
+  metadata: RADChunkMetadata,
+  property: RADChunkProperty
+): Uint8Array {
+  const paddedByteLength = roundUpToEight(property.bytes);
+  const byteOffset = metadata.payloadByteOffset + property.offset;
+  const byteEnd = byteOffset + paddedByteLength;
+  if (byteEnd > bytes.byteLength || property.offset + paddedByteLength > metadata.payloadBytes) {
+    throw new Error(`RADLoader: property ${property.property} exceeds RADC payload byte length.`);
+  }
+
+  const propertyBytes = bytes.subarray(byteOffset, byteOffset + property.bytes);
+  if (!property.compression) {
+    return propertyBytes;
+  }
+  if (property.compression !== 'gz') {
+    throw new Error(`RADLoader: unsupported property compression ${property.compression}.`);
+  }
+  return decompressRADProperty(propertyBytes, property.property);
+}
+
+/** Inflates one Spark RADC property payload. */
+function decompressRADProperty(bytes: Uint8Array, propertyName: string): Uint8Array {
+  const arrayBuffer = copyToArrayBuffer(bytes);
+  try {
+    return new Uint8Array(RAD_PROPERTY_DEFLATE.decompressSync(arrayBuffer));
+  } catch {
+    try {
+      return new Uint8Array(RAD_PROPERTY_RAW_DEFLATE.decompressSync(arrayBuffer));
+    } catch {
+      throw new Error(`RADLoader: failed to decompress RADC property ${propertyName}.`);
+    }
+  }
+}
+
+/** Decodes planar Float32 values emitted by Spark RADC. */
+function decodePlanarFloat32(bytes: Uint8Array, dimensions: number, count: number): Float32Array {
+  const dataView = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const values = new Float32Array(count * dimensions);
+  for (let rowIndex = 0; rowIndex < count; rowIndex++) {
+    for (let dimension = 0; dimension < dimensions; dimension++) {
+      values[rowIndex * dimensions + dimension] = dataView.getFloat32(
+        (dimension * count + rowIndex) * 4,
+        true
+      );
+    }
+  }
+  return values;
+}
+
+/** Decodes planar Float16 values emitted by Spark RADC. */
+function decodePlanarFloat16(bytes: Uint8Array, dimensions: number, count: number): Float32Array {
+  const values = new Float32Array(count * dimensions);
+  for (let rowIndex = 0; rowIndex < count; rowIndex++) {
+    for (let dimension = 0; dimension < dimensions; dimension++) {
+      const byteOffset = (dimension * count + rowIndex) * 2;
+      values[rowIndex * dimensions + dimension] = decodeFloat16(
+        bytes[byteOffset] | (bytes[byteOffset + 1] << 8)
+      );
+    }
+  }
+  return values;
+}
+
+/** Decodes Spark's byte-plane reordered Float32 values. */
+function decodeLeBytesFloat32(bytes: Uint8Array, dimensions: number, count: number): Float32Array {
+  const values = new Float32Array(count * dimensions);
+  const stride = count * dimensions;
+  const scratch = new Uint8Array(4);
+  const scratchView = new DataView(scratch.buffer);
+  for (let rowIndex = 0; rowIndex < count; rowIndex++) {
+    for (let dimension = 0; dimension < dimensions; dimension++) {
+      const byteOffset = dimension * count + rowIndex;
+      for (let byteIndex = 0; byteIndex < 4; byteIndex++) {
+        scratch[byteIndex] = bytes[byteOffset + stride * byteIndex];
+      }
+      values[rowIndex * dimensions + dimension] = scratchView.getFloat32(0, true);
+    }
+  }
+  return values;
+}
+
+/** Decodes Spark's byte-plane reordered Float16 values. */
+function decodeLeBytesFloat16(bytes: Uint8Array, dimensions: number, count: number): Float32Array {
+  const values = new Float32Array(count * dimensions);
+  const stride = count * dimensions;
+  for (let rowIndex = 0; rowIndex < count; rowIndex++) {
+    for (let dimension = 0; dimension < dimensions; dimension++) {
+      const byteOffset = dimension * count + rowIndex;
+      values[rowIndex * dimensions + dimension] = decodeFloat16(
+        bytes[byteOffset] | (bytes[byteOffset + stride] << 8)
+      );
+    }
+  }
+  return values;
+}
+
+/** Decodes R8 quantized planar float values. */
+function decodeR8(
+  bytes: Uint8Array,
+  dimensions: number,
+  count: number,
+  min: number,
+  max: number
+): Float32Array {
+  const values = new Float32Array(count * dimensions);
+  const range = max - min;
+  for (let rowIndex = 0; rowIndex < count; rowIndex++) {
+    for (let dimension = 0; dimension < dimensions; dimension++) {
+      values[rowIndex * dimensions + dimension] =
+        (bytes[dimension * count + rowIndex] / 255) * range + min;
+    }
+  }
+  return values;
+}
+
+/** Decodes delta-compressed R8 quantized planar float values. */
+function decodeR8Delta(
+  bytes: Uint8Array,
+  dimensions: number,
+  count: number,
+  min: number,
+  max: number
+): Float32Array {
+  const values = new Float32Array(count * dimensions);
+  const range = max - min;
+  const last = new Uint8Array(dimensions);
+  for (let rowIndex = 0; rowIndex < count; rowIndex++) {
+    for (let dimension = 0; dimension < dimensions; dimension++) {
+      const byteOffset = dimension * count + rowIndex;
+      const value = (last[dimension] + bytes[byteOffset]) & 0xff;
+      last[dimension] = value;
+      values[rowIndex * dimensions + dimension] = (value / 255) * range + min;
+    }
+  }
+  return values;
+}
+
+/** Decodes S8 quantized planar float values. */
+function decodeS8(bytes: Uint8Array, dimensions: number, count: number, max: number): Float32Array {
+  const values = new Float32Array(count * dimensions);
+  for (let rowIndex = 0; rowIndex < count; rowIndex++) {
+    for (let dimension = 0; dimension < dimensions; dimension++) {
+      const byte = bytes[dimension * count + rowIndex];
+      values[rowIndex * dimensions + dimension] = (((byte << 24) >> 24) / 127) * max;
+    }
+  }
+  return values;
+}
+
+/** Decodes delta-compressed S8 quantized planar float values. */
+function decodeS8Delta(
+  bytes: Uint8Array,
+  dimensions: number,
+  count: number,
+  max: number
+): Float32Array {
+  const values = new Float32Array(count * dimensions);
+  const last = new Uint8Array(dimensions);
+  for (let rowIndex = 0; rowIndex < count; rowIndex++) {
+    for (let dimension = 0; dimension < dimensions; dimension++) {
+      const byteOffset = dimension * count + rowIndex;
+      const value = (last[dimension] + bytes[byteOffset]) & 0xff;
+      last[dimension] = value;
+      values[rowIndex * dimensions + dimension] = (((value << 24) >> 24) / 127) * max;
+    }
+  }
+  return values;
+}
+
+/** Decodes Spark scale8 values to linear Gaussian standard deviations. */
+function decodeScaleR8(
+  bytes: Uint8Array,
+  dimensions: number,
+  count: number,
+  min: number,
+  max: number
+): Float32Array {
+  const values = new Float32Array(count * dimensions);
+  for (let rowIndex = 0; rowIndex < count; rowIndex++) {
+    for (let dimension = 0; dimension < dimensions; dimension++) {
+      values[rowIndex * dimensions + dimension] = decodeScale8(
+        bytes[dimension * count + rowIndex],
+        min,
+        max
+      );
+    }
+  }
+  return values;
+}
+
+/** Decodes Spark log-Float16 scale values to linear Gaussian standard deviations. */
+function decodeLogFloat16(bytes: Uint8Array, dimensions: number, count: number): Float32Array {
+  const logValues = decodePlanarFloat16(bytes, dimensions, count);
+  for (let valueIndex = 0; valueIndex < logValues.length; valueIndex++) {
+    logValues[valueIndex] = Math.exp(logValues[valueIndex]);
+  }
+  return logValues;
+}
+
+/** Decodes Spark oct88r8 quaternion values into `[w, x, y, z]` rotations. */
+function decodeRADOct88R8Rotations(bytes: Uint8Array, count: number): Float32Array {
+  const rotations = new Float32Array(count * 4);
+  for (let splatIndex = 0; splatIndex < count; splatIndex++) {
+    const byteOffset = splatIndex * 3;
+    const [x, y, z, w] = decodeQuatOct888(
+      bytes[byteOffset],
+      bytes[byteOffset + 1],
+      bytes[byteOffset + 2]
+    );
+    rotations.set(normalizeQuaternion(w, x, y, z), splatIndex * 4);
+  }
+  return rotations;
+}
+
+/** Converts decoded RGB floats to loaders.gl color and SH DC columns. */
+function convertRgbToColorColumns(rgb: Float32Array): {
+  colors: Uint8Array;
+  sphericalHarmonicDcs: Float32Array;
+} {
+  const colors = new Uint8Array(rgb.length);
+  const sphericalHarmonicDcs = new Float32Array(rgb.length);
+  for (let componentIndex = 0; componentIndex < rgb.length; componentIndex++) {
+    const component = rgb[componentIndex];
+    colors[componentIndex] = normalizeColorByte(component);
+    sphericalHarmonicDcs[componentIndex] = (component - 0.5) / SH_C0;
+  }
+  return {colors, sphericalHarmonicDcs};
+}
+
+/** Returns an identity rotation array. */
+function makeIdentityRotations(count: number): Float32Array {
+  const rotations = new Float32Array(count * 4);
+  for (let splatIndex = 0; splatIndex < count; splatIndex++) {
+    rotations[splatIndex * 4] = 1;
+  }
+  return rotations;
+}
+
+/** Decodes Spark's scale8 byte encoding. */
+function decodeScale8(scale: number, min: number, max: number): number {
+  if (scale === 0) {
+    return 0;
+  }
+  const logScaleStep = (max - min) / 254;
+  return Math.exp(min + (scale - 1) * logScaleStep);
+}
+
+/** Decodes Spark's oct888 quaternion encoding into `[x, y, z, w]`. */
+function decodeQuatOct888(u: number, v: number, r: number): [number, number, number, number] {
+  let x = (u / 255) * 2 - 1;
+  let y = (v / 255) * 2 - 1;
+  const z = 1 - Math.abs(x) - Math.abs(y);
+  const t = Math.max(-z, 0);
+  x = x >= 0 ? x - t : x + t;
+  y = y >= 0 ? y - t : y + t;
+  const length = Math.hypot(x, y, z);
+  const axisX = length > Number.EPSILON ? x / length : 1;
+  const axisY = length > Number.EPSILON ? y / length : 0;
+  const axisZ = length > Number.EPSILON ? z / length : 0;
+  const halfTheta = (r / 255) * 0.5 * Math.PI;
+  const sinHalfTheta = Math.sin(halfTheta);
+  return [axisX * sinHalfTheta, axisY * sinHalfTheta, axisZ * sinHalfTheta, Math.cos(halfTheta)];
+}
+
+/** Returns a named property or throws. */
+function requireRADProperty(metadata: RADChunkMetadata, propertyName: string): RADChunkProperty {
+  const property = findRADProperty(metadata, propertyName);
+  if (!property) {
+    throw new Error(`RADLoader: RADC chunk is missing ${propertyName} property.`);
+  }
+  return property;
+}
+
+/** Returns a named property when present. */
+function findRADProperty(
+  metadata: RADChunkMetadata,
+  propertyName: string
+): RADChunkProperty | undefined {
+  return metadata.properties.find(property => property.property === propertyName);
+}
+
+/** Returns a required quantization minimum. */
+function getPropertyMin(property: RADChunkProperty): number {
+  if (property.min === undefined) {
+    throw new Error(`RADLoader: RADC property ${property.property} is missing min.`);
+  }
+  return property.min;
+}
+
+/** Returns a required quantization maximum. */
+function getPropertyMax(property: RADChunkProperty): number {
+  if (property.max === undefined) {
+    throw new Error(`RADLoader: RADC property ${property.property} is missing max.`);
+  }
+  return property.max;
+}
+
+/** Clamps a normalized color component into an unorm8 byte. */
+function normalizeColorByte(value: number): number {
+  return Math.round(Math.min(Math.max(value, 0), 1) * 255);
+}
+
+/** Copies a byte view into a standalone ArrayBuffer. */
+function copyToArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy.buffer;
+}
+
+/** Converts an ArrayBuffer-like value into a Uint8Array view. */
+function getUint8Array(data: ArrayBuffer | ArrayBufferView): Uint8Array {
+  return data instanceof ArrayBuffer
+    ? new Uint8Array(data)
+    : new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+}

--- a/modules/splats/src/lib/parse-rad.ts
+++ b/modules/splats/src/lib/parse-rad.ts
@@ -1,0 +1,439 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+const RAD_MAGIC = 0x30444152;
+const RAD_CHUNK_MAGIC = 0x43444152;
+const RAD_HEADER_BYTE_LENGTH = 8;
+const RAD_CHUNK_PAYLOAD_LENGTH_BYTE_LENGTH = 8;
+const TEXT_DECODER = new TextDecoder();
+
+/** Spark RAD splat quantization and shader decode range metadata. */
+export type RADSplatEncoding = {
+  /** Minimum RGB value encoded into quantized color properties. */
+  rgbMin?: number;
+  /** Maximum RGB value encoded into quantized color properties. */
+  rgbMax?: number;
+  /** Minimum natural log scale encoded into quantized scale properties. */
+  lnScaleMin?: number;
+  /** Maximum natural log scale encoded into quantized scale properties. */
+  lnScaleMax?: number;
+  /** Maximum absolute SH degree-1 coefficient value. */
+  sh1Max?: number;
+  /** Maximum absolute SH degree-2 coefficient value. */
+  sh2Max?: number;
+  /** Maximum absolute SH degree-3 coefficient value. */
+  sh3Max?: number;
+  /** Whether opacity is encoded for LoD blending. */
+  lodOpacity?: boolean;
+};
+
+/** One RAD chunk location in the top-level RAD chunk table. */
+export type RADChunkRange = {
+  /** Chunk byte offset relative to the top-level RAD chunk payload area. */
+  offset: number;
+  /** Chunk byte length. */
+  bytes: number;
+  /** Optional first splat index represented by this chunk. */
+  base?: number;
+  /** Optional number of splats represented by this chunk. */
+  count?: number;
+  /** Optional sidecar `.radc` filename relative to the RAD file URL. */
+  filename?: string;
+};
+
+/** Parsed Spark RAD top-level metadata with loader-derived byte offsets. */
+export type RADMetadata = {
+  /** RAD container version. Version 1 is currently supported. */
+  version: number;
+  /** RAD payload type. Spark currently writes `gsplat`. */
+  type: string;
+  /** Total splat count represented by the RAD source. */
+  count: number;
+  /** Maximum spherical harmonics degree present in the chunks. */
+  maxSh?: number;
+  /** Whether the source includes LoD tree child-count and child-start properties. */
+  lodTree?: boolean;
+  /** Nominal number of splats per chunk. */
+  chunkSize?: number;
+  /** Total inline chunk byte length when present in the RAD metadata. */
+  allChunkBytes?: number;
+  /** RAD chunk table. */
+  chunks: RADChunkRange[];
+  /** Optional shared splat encoding metadata for chunk decoding. */
+  splatEncoding?: RADSplatEncoding;
+  /** Optional spherical harmonics codebook count. */
+  shCodeCount?: number;
+  /** Optional RAD writer comment. */
+  comment?: string;
+  /** Byte length of the JSON metadata block. */
+  headerJsonByteLength: number;
+  /** Byte offset where inline RAD chunks begin. */
+  chunksByteOffset: number;
+};
+
+/** Known RAD chunk property names. */
+export type RADChunkPropertyName =
+  | 'center'
+  | 'alpha'
+  | 'rgb'
+  | 'scales'
+  | 'orientation'
+  | 'sh1'
+  | 'sh2'
+  | 'sh3'
+  | 'child_count'
+  | 'child_start'
+  | 'sh1_code'
+  | 'sh2_code'
+  | 'sh3_code'
+  | 'sh_label';
+
+/** Known RAD chunk property encodings. */
+export type RADChunkPropertyEncoding =
+  | 'f32'
+  | 'f16'
+  | 'f32_lebytes'
+  | 'f16_lebytes'
+  | 'r8'
+  | 'r8_delta'
+  | 's8'
+  | 's8_delta'
+  | 'ln_0r8'
+  | 'ln_f16'
+  | 'oct88r8'
+  | 'u16'
+  | 'u32';
+
+/** Known RAD chunk property compression modes. */
+export type RADChunkPropertyCompression = 'gz';
+
+/** One property payload entry inside a RAD chunk. */
+export type RADChunkProperty = {
+  /** Property byte offset relative to the chunk payload area. */
+  offset: number;
+  /** Property byte length before 8-byte payload padding. */
+  bytes: number;
+  /** Property semantic name. */
+  property: RADChunkPropertyName | string;
+  /** Property encoding name. */
+  encoding: RADChunkPropertyEncoding | string;
+  /** Optional property compression mode. */
+  compression?: RADChunkPropertyCompression | string;
+  /** Optional decode minimum for quantized properties. */
+  min?: number;
+  /** Optional decode maximum for quantized properties. */
+  max?: number;
+};
+
+/** Parsed Spark RADC chunk metadata with loader-derived byte offsets. */
+export type RADChunkMetadata = {
+  /** RAD chunk version. Version 1 is currently supported. */
+  version: number;
+  /** First global splat index represented by this chunk. */
+  base: number;
+  /** Number of splats represented by this chunk. */
+  count: number;
+  /** Byte length of the padded property payload. */
+  payloadBytes: number;
+  /** Maximum spherical harmonics degree present in this chunk. */
+  maxSh?: number;
+  /** Whether this chunk contains LoD tree properties. */
+  lodTree?: boolean;
+  /** Optional chunk-local splat encoding metadata. */
+  splatEncoding?: RADSplatEncoding;
+  /** Property table for the chunk payload. */
+  properties: RADChunkProperty[];
+  /** Byte length of the chunk JSON metadata block. */
+  headerJsonByteLength: number;
+  /** Byte offset where the chunk payload begins. */
+  payloadByteOffset: number;
+  /** Byte length of the RADC header and payload. */
+  chunkByteLength: number;
+};
+
+/** Returns true when the input begins with the Spark RAD magic bytes. */
+export function isRAD(data: ArrayBuffer | ArrayBufferView): boolean {
+  const bytes = getUint8Array(data);
+  if (bytes.byteLength < 4) {
+    return false;
+  }
+  return (
+    new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).getUint32(0, true) === RAD_MAGIC
+  );
+}
+
+/** Parses a complete or header-prefix Spark `.rad` buffer. */
+export function parseRADHeader(data: ArrayBuffer | ArrayBufferView): RADMetadata {
+  const metadata = tryParseRADHeader(data);
+  if (!metadata) {
+    throw new Error('RADLoader: file must contain a complete RAD metadata header.');
+  }
+  return metadata;
+}
+
+/** Parses a Spark `.rad` header when enough bytes are available. */
+export function tryParseRADHeader(data: ArrayBuffer | ArrayBufferView): RADMetadata | null {
+  const bytes = getUint8Array(data);
+  if (bytes.byteLength < RAD_HEADER_BYTE_LENGTH) {
+    return null;
+  }
+
+  const dataView = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const magic = dataView.getUint32(0, true);
+  if (magic !== RAD_MAGIC) {
+    throw new Error(`RADLoader: RAD0 magic header not found, received 0x${magic.toString(16)}.`);
+  }
+
+  const headerJsonByteLength = dataView.getUint32(4, true);
+  const headerJsonEnd = RAD_HEADER_BYTE_LENGTH + headerJsonByteLength;
+  if (bytes.byteLength < headerJsonEnd) {
+    return null;
+  }
+
+  const rawMetadata = parseJSONRecord(
+    bytes.subarray(RAD_HEADER_BYTE_LENGTH, headerJsonEnd),
+    'RADLoader: failed to parse RAD metadata JSON.'
+  );
+  return normalizeRADMetadata(rawMetadata, headerJsonByteLength);
+}
+
+/** Parses the metadata header from one Spark `.radc` chunk buffer. */
+export function parseRADChunkHeader(data: ArrayBuffer | ArrayBufferView): RADChunkMetadata {
+  const bytes = getUint8Array(data);
+  if (bytes.byteLength < RAD_HEADER_BYTE_LENGTH) {
+    throw new Error('RADLoader: RADC chunk must contain an 8-byte metadata header.');
+  }
+
+  const dataView = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const magic = dataView.getUint32(0, true);
+  if (magic !== RAD_CHUNK_MAGIC) {
+    throw new Error(`RADLoader: RADC magic header not found, received 0x${magic.toString(16)}.`);
+  }
+
+  const headerJsonByteLength = dataView.getUint32(4, true);
+  const headerJsonEnd = RAD_HEADER_BYTE_LENGTH + headerJsonByteLength;
+  const payloadByteLengthOffset = RAD_HEADER_BYTE_LENGTH + roundUpToEight(headerJsonByteLength);
+  const payloadByteOffset = payloadByteLengthOffset + RAD_CHUNK_PAYLOAD_LENGTH_BYTE_LENGTH;
+  if (bytes.byteLength < payloadByteOffset) {
+    throw new Error('RADLoader: RADC chunk must contain a complete metadata header.');
+  }
+
+  const rawMetadata = parseJSONRecord(
+    bytes.subarray(RAD_HEADER_BYTE_LENGTH, headerJsonEnd),
+    'RADLoader: failed to parse RADC metadata JSON.'
+  );
+  const payloadBytes = readSafeUint64(
+    dataView,
+    payloadByteLengthOffset,
+    'RADC payload byte length'
+  );
+  return normalizeRADChunkMetadata(
+    rawMetadata,
+    headerJsonByteLength,
+    payloadByteOffset,
+    payloadBytes
+  );
+}
+
+/** Rounds a byte length to Spark RAD's 8-byte alignment. */
+export function roundUpToEight(byteLength: number): number {
+  return (byteLength + 7) & ~7;
+}
+
+function normalizeRADMetadata(
+  rawMetadata: Record<string, unknown>,
+  headerJsonByteLength: number
+): RADMetadata {
+  const version = requireSafeInteger(rawMetadata.version, 'RAD version');
+  if (version !== 1) {
+    throw new Error(`RADLoader: version ${version} is not supported.`);
+  }
+
+  const type = requireString(rawMetadata.type, 'RAD type');
+  if (type !== 'gsplat') {
+    throw new Error(`RADLoader: RAD type ${type} is not supported.`);
+  }
+
+  const chunks = requireArray(rawMetadata.chunks, 'RAD chunks').map((chunk, chunkIndex) =>
+    normalizeRADChunkRange(chunk, chunkIndex)
+  );
+  const metadata: RADMetadata = {
+    version,
+    type,
+    count: requireSafeInteger(rawMetadata.count, 'RAD count'),
+    maxSh: optionalSafeInteger(rawMetadata.maxSh, 'RAD maxSh'),
+    lodTree: optionalBoolean(rawMetadata.lodTree, 'RAD lodTree'),
+    chunkSize: optionalSafeInteger(rawMetadata.chunkSize, 'RAD chunkSize'),
+    allChunkBytes: optionalSafeInteger(rawMetadata.allChunkBytes, 'RAD allChunkBytes'),
+    chunks,
+    splatEncoding: optionalSplatEncoding(rawMetadata.splatEncoding, 'RAD splatEncoding'),
+    shCodeCount: optionalSafeInteger(rawMetadata.shCodeCount, 'RAD shCodeCount'),
+    comment: optionalString(rawMetadata.comment, 'RAD comment'),
+    headerJsonByteLength,
+    chunksByteOffset: RAD_HEADER_BYTE_LENGTH + roundUpToEight(headerJsonByteLength)
+  };
+
+  return metadata;
+}
+
+function normalizeRADChunkRange(rawChunk: unknown, chunkIndex: number): RADChunkRange {
+  const chunk = requireRecord(rawChunk, `RAD chunk ${chunkIndex}`);
+  return {
+    offset: requireSafeInteger(chunk.offset, `RAD chunk ${chunkIndex} offset`),
+    bytes: requireSafeInteger(chunk.bytes, `RAD chunk ${chunkIndex} bytes`),
+    base: optionalSafeInteger(chunk.base, `RAD chunk ${chunkIndex} base`),
+    count: optionalSafeInteger(chunk.count, `RAD chunk ${chunkIndex} count`),
+    filename: optionalString(chunk.filename, `RAD chunk ${chunkIndex} filename`)
+  };
+}
+
+function normalizeRADChunkMetadata(
+  rawMetadata: Record<string, unknown>,
+  headerJsonByteLength: number,
+  payloadByteOffset: number,
+  payloadBytes: number
+): RADChunkMetadata {
+  const version = requireSafeInteger(rawMetadata.version, 'RADC version');
+  if (version !== 1) {
+    throw new Error(`RADLoader: RADC version ${version} is not supported.`);
+  }
+
+  const metadataPayloadBytes = requireSafeInteger(rawMetadata.payloadBytes, 'RADC payloadBytes');
+  if (metadataPayloadBytes !== payloadBytes) {
+    throw new Error('RADLoader: RADC metadata payload byte length does not match binary header.');
+  }
+
+  return {
+    version,
+    base: requireSafeInteger(rawMetadata.base, 'RADC base'),
+    count: requireSafeInteger(rawMetadata.count, 'RADC count'),
+    payloadBytes,
+    maxSh: optionalSafeInteger(rawMetadata.maxSh, 'RADC maxSh'),
+    lodTree: optionalBoolean(rawMetadata.lodTree, 'RADC lodTree'),
+    splatEncoding: optionalSplatEncoding(rawMetadata.splatEncoding, 'RADC splatEncoding'),
+    properties: requireArray(rawMetadata.properties, 'RADC properties').map((property, index) =>
+      normalizeRADChunkProperty(property, index)
+    ),
+    headerJsonByteLength,
+    payloadByteOffset,
+    chunkByteLength: payloadByteOffset + payloadBytes
+  };
+}
+
+function normalizeRADChunkProperty(rawProperty: unknown, propertyIndex: number): RADChunkProperty {
+  const property = requireRecord(rawProperty, `RADC property ${propertyIndex}`);
+  return {
+    offset: requireSafeInteger(property.offset, `RADC property ${propertyIndex} offset`),
+    bytes: requireSafeInteger(property.bytes, `RADC property ${propertyIndex} bytes`),
+    property: requireString(property.property, `RADC property ${propertyIndex} name`),
+    encoding: requireString(property.encoding, `RADC property ${propertyIndex} encoding`),
+    compression: optionalString(property.compression, `RADC property ${propertyIndex} compression`),
+    min: optionalFiniteNumber(property.min, `RADC property ${propertyIndex} min`),
+    max: optionalFiniteNumber(property.max, `RADC property ${propertyIndex} max`)
+  };
+}
+
+function optionalSplatEncoding(value: unknown, fieldName: string): RADSplatEncoding | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const encoding = requireRecord(value, fieldName);
+  return {
+    rgbMin: optionalFiniteNumber(encoding.rgbMin, `${fieldName}.rgbMin`),
+    rgbMax: optionalFiniteNumber(encoding.rgbMax, `${fieldName}.rgbMax`),
+    lnScaleMin: optionalFiniteNumber(encoding.lnScaleMin, `${fieldName}.lnScaleMin`),
+    lnScaleMax: optionalFiniteNumber(encoding.lnScaleMax, `${fieldName}.lnScaleMax`),
+    sh1Max: optionalFiniteNumber(encoding.sh1Max, `${fieldName}.sh1Max`),
+    sh2Max: optionalFiniteNumber(encoding.sh2Max, `${fieldName}.sh2Max`),
+    sh3Max: optionalFiniteNumber(encoding.sh3Max, `${fieldName}.sh3Max`),
+    lodOpacity: optionalBoolean(encoding.lodOpacity, `${fieldName}.lodOpacity`)
+  };
+}
+
+function parseJSONRecord(bytes: Uint8Array, message: string): Record<string, unknown> {
+  try {
+    return requireRecord(JSON.parse(TEXT_DECODER.decode(bytes)), message);
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith('RADLoader:')) {
+      throw error;
+    }
+    throw new Error(message);
+  }
+}
+
+function requireRecord(value: unknown, fieldName: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`RADLoader: ${fieldName} must be an object.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireArray(value: unknown, fieldName: string): unknown[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`RADLoader: ${fieldName} must be an array.`);
+  }
+  return value;
+}
+
+function requireString(value: unknown, fieldName: string): string {
+  if (typeof value !== 'string') {
+    throw new Error(`RADLoader: ${fieldName} must be a string.`);
+  }
+  return value;
+}
+
+function optionalString(value: unknown, fieldName: string): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return requireString(value, fieldName);
+}
+
+function optionalBoolean(value: unknown, fieldName: string): boolean | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== 'boolean') {
+    throw new Error(`RADLoader: ${fieldName} must be a boolean.`);
+  }
+  return value;
+}
+
+function requireSafeInteger(value: unknown, fieldName: string): number {
+  if (!Number.isSafeInteger(value) || Number(value) < 0) {
+    throw new Error(`RADLoader: ${fieldName} must be a non-negative safe integer.`);
+  }
+  return Number(value);
+}
+
+function optionalSafeInteger(value: unknown, fieldName: string): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return requireSafeInteger(value, fieldName);
+}
+
+function optionalFiniteNumber(value: unknown, fieldName: string): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new Error(`RADLoader: ${fieldName} must be a finite number.`);
+  }
+  return value;
+}
+
+function readSafeUint64(dataView: DataView, byteOffset: number, fieldName: string): number {
+  const value = dataView.getBigUint64(byteOffset, true);
+  if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error(`RADLoader: ${fieldName} exceeds Number.MAX_SAFE_INTEGER.`);
+  }
+  return Number(value);
+}
+
+function getUint8Array(data: ArrayBuffer | ArrayBufferView): Uint8Array {
+  return data instanceof ArrayBuffer
+    ? new Uint8Array(data)
+    : new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+}

--- a/modules/splats/src/lib/parse-spz.ts
+++ b/modules/splats/src/lib/parse-spz.ts
@@ -1,0 +1,368 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {ZstdCompression} from '@loaders.gl/compression';
+import type {MeshArrowTable} from '@loaders.gl/schema';
+import type {GaussianSplats, SplatsLoaderOptions} from '../types';
+import {makeGaussianSplatsArrowTable} from './splats-arrow-table';
+import {normalizeQuaternion} from './splat-utils';
+
+const SPZ_HEADER_BYTE_LENGTH = 32;
+const SPZ_MAGIC = 0x5053474e;
+const SPZ_VERSION = 4;
+const SPZ_EXTENSION_FLAG = 0x2;
+const SPZ_COLOR_SCALE = 0.15;
+const SPZ_ROTATION_COMPONENT_SCALE = Math.SQRT1_2;
+const SPZ_ROTATION_COMPONENT_MASK = (1 << 9) - 1;
+
+type SPZHeader = {
+  magic: number;
+  version: number;
+  numPoints: number;
+  shDegree: number;
+  fractionalBits: number;
+  flags: number;
+  numStreams: number;
+  tocByteOffset: number;
+};
+
+type SPZStreamInfo = {
+  compressedSize: number;
+  uncompressedSize: number;
+  compressedOffset: number;
+};
+
+/** Parses a Niantic Spatial `.spz` ArrayBuffer into a Mesh Arrow table. */
+export async function parseSPZ(
+  data: ArrayBuffer,
+  options?: SplatsLoaderOptions
+): Promise<MeshArrowTable> {
+  return makeGaussianSplatsArrowTable(await parseSPZToGaussianSplats(data, options));
+}
+
+/** Parses a Niantic Spatial `.spz` ArrayBuffer into decoded Gaussian splat values. */
+export async function parseSPZToGaussianSplats(
+  data: ArrayBuffer,
+  options?: SplatsLoaderOptions
+): Promise<GaussianSplats> {
+  const header = parseSPZHeader(data);
+  const streamInfos = parseSPZStreamInfos(data, header, getSPZStreamByteLengths(header));
+  const compressedStreams = streamInfos.map(streamInfo =>
+    data.slice(streamInfo.compressedOffset, streamInfo.compressedOffset + streamInfo.compressedSize)
+  );
+  const compression = new ZstdCompression({modules: options?.modules});
+  const streams = await Promise.all(
+    compressedStreams.map((compressedStream, streamIndex) =>
+      compression.decompress(compressedStream, streamInfos[streamIndex].uncompressedSize)
+    )
+  );
+
+  validateSPZStreamLengths(streams, streamInfos);
+  return decodeSPZStreams(header, streams, data);
+}
+
+/** Parses and validates the SPZ v4 plaintext header. */
+function parseSPZHeader(data: ArrayBuffer): SPZHeader {
+  if (data.byteLength < SPZ_HEADER_BYTE_LENGTH) {
+    throw new Error(`SPZLoader: file must contain a ${SPZ_HEADER_BYTE_LENGTH}-byte header.`);
+  }
+
+  const dataView = new DataView(data);
+  const header: SPZHeader = {
+    magic: dataView.getUint32(0, true),
+    version: dataView.getUint32(4, true),
+    numPoints: dataView.getUint32(8, true),
+    shDegree: dataView.getUint8(12),
+    fractionalBits: dataView.getUint8(13),
+    flags: dataView.getUint8(14),
+    numStreams: dataView.getUint8(15),
+    tocByteOffset: dataView.getUint32(16, true)
+  };
+
+  if (header.magic !== SPZ_MAGIC) {
+    throw new Error('SPZLoader: NGSP magic header not found.');
+  }
+  if (header.version !== SPZ_VERSION) {
+    throw new Error(`SPZLoader: version ${header.version} is not supported.`);
+  }
+  if (header.shDegree > 4) {
+    throw new Error(`SPZLoader: spherical harmonics degree ${header.shDegree} is not supported.`);
+  }
+  if (header.tocByteOffset < SPZ_HEADER_BYTE_LENGTH || header.tocByteOffset > data.byteLength) {
+    throw new Error('SPZLoader: invalid table of contents byte offset.');
+  }
+
+  return header;
+}
+
+/** Parses the SPZ stream table of contents and validates expected stream sizes. */
+function parseSPZStreamInfos(
+  data: ArrayBuffer,
+  header: SPZHeader,
+  expectedUncompressedSizes: number[]
+): SPZStreamInfo[] {
+  if (header.numStreams !== expectedUncompressedSizes.length) {
+    throw new Error(
+      `SPZLoader: expected ${expectedUncompressedSizes.length} streams, found ${header.numStreams}.`
+    );
+  }
+
+  const tocByteLength = header.numStreams * 16;
+  const tocEnd = header.tocByteOffset + tocByteLength;
+  if (tocEnd > data.byteLength) {
+    throw new Error('SPZLoader: table of contents exceeds file byte length.');
+  }
+
+  const dataView = new DataView(data);
+  let compressedOffset = tocEnd;
+  const streamInfos: SPZStreamInfo[] = [];
+  for (let streamIndex = 0; streamIndex < header.numStreams; streamIndex++) {
+    const tocOffset = header.tocByteOffset + streamIndex * 16;
+    const compressedSize = readSafeUint64(dataView, tocOffset);
+    const uncompressedSize = readSafeUint64(dataView, tocOffset + 8);
+    const expectedUncompressedSize = expectedUncompressedSizes[streamIndex];
+
+    if (uncompressedSize !== expectedUncompressedSize) {
+      throw new Error(
+        `SPZLoader: stream ${streamIndex} has ${uncompressedSize} uncompressed bytes, expected ${expectedUncompressedSize}.`
+      );
+    }
+    if (compressedOffset + compressedSize > data.byteLength) {
+      throw new Error(`SPZLoader: stream ${streamIndex} exceeds file byte length.`);
+    }
+
+    streamInfos.push({compressedSize, uncompressedSize, compressedOffset});
+    compressedOffset += compressedSize;
+  }
+
+  if (compressedOffset !== data.byteLength) {
+    throw new Error('SPZLoader: compressed stream byte lengths do not match file byte length.');
+  }
+
+  return streamInfos;
+}
+
+/** Converts a little-endian uint64 to a safe JavaScript number. */
+function readSafeUint64(dataView: DataView, byteOffset: number): number {
+  const value = dataView.getBigUint64(byteOffset, true);
+  if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error('SPZLoader: stream byte length exceeds Number.MAX_SAFE_INTEGER.');
+  }
+  return Number(value);
+}
+
+/** Returns expected SPZ v4 stream byte lengths, skipping zero-length SH data. */
+function getSPZStreamByteLengths(header: SPZHeader): number[] {
+  return [
+    header.numPoints * 9,
+    header.numPoints,
+    header.numPoints * 3,
+    header.numPoints * 3,
+    header.numPoints * 4,
+    header.numPoints * getSphericalHarmonicsComponentCount(header.shDegree)
+  ].filter(byteLength => byteLength > 0);
+}
+
+/** Validates that decompressed stream lengths match the TOC. */
+function validateSPZStreamLengths(streams: ArrayBuffer[], streamInfos: SPZStreamInfo[]): void {
+  for (let streamIndex = 0; streamIndex < streams.length; streamIndex++) {
+    if (streams[streamIndex].byteLength !== streamInfos[streamIndex].uncompressedSize) {
+      throw new Error(`SPZLoader: decompressed stream ${streamIndex} has unexpected byte length.`);
+    }
+  }
+}
+
+/** Decodes decompressed SPZ streams into shared Gaussian splat arrays. */
+function decodeSPZStreams(
+  header: SPZHeader,
+  streams: ArrayBuffer[],
+  sourceData: ArrayBuffer
+): GaussianSplats {
+  const splatCount = header.numPoints;
+  const positions = new Float32Array(splatCount * 3);
+  const scales = new Float32Array(splatCount * 3);
+  const rotations = new Float32Array(splatCount * 4);
+  const colors = new Uint8Array(splatCount * 3);
+  const sphericalHarmonicDcs = new Float32Array(splatCount * 3);
+  const opacities = new Float32Array(splatCount);
+  const sphericalHarmonicsComponentCount = getSphericalHarmonicsComponentCount(header.shDegree);
+  const sphericalHarmonics = sphericalHarmonicsComponentCount
+    ? new Float32Array(splatCount * sphericalHarmonicsComponentCount)
+    : undefined;
+  const [
+    positionStream,
+    alphaStream,
+    colorStream,
+    scaleStream,
+    rotationStream,
+    sphericalHarmonicsStream
+  ] = streams.map(stream => new Uint8Array(stream));
+
+  decodeSPZPositions(positionStream, positions, header.fractionalBits);
+  decodeSPZScales(scaleStream, scales);
+  decodeSPZRotations(rotationStream, rotations);
+  decodeSPZColors(colorStream, colors, sphericalHarmonicDcs);
+  decodeSPZOpacities(alphaStream, opacities);
+  if (sphericalHarmonics && sphericalHarmonicsStream) {
+    decodeSPZSphericalHarmonics(sphericalHarmonicsStream, sphericalHarmonics);
+  }
+
+  return {
+    format: 'spz',
+    splatCount,
+    positions,
+    scales,
+    rotations,
+    colors,
+    sphericalHarmonicDcs,
+    opacities,
+    sphericalHarmonics,
+    sphericalHarmonicsComponentCount,
+    loaderData: {
+      format: 'spz',
+      ...header,
+      antialiased: Boolean(header.flags & 0x1),
+      extensionByteLength: getSPZExtensionByteLength(header),
+      extensionBytes: getSPZExtensionBytes(sourceData, header)
+    }
+  };
+}
+
+/** Decodes 24-bit signed fixed-point SPZ positions. */
+function decodeSPZPositions(
+  positionStream: Uint8Array,
+  positions: Float32Array,
+  fractionalBits: number
+): void {
+  const scale = 1 / 2 ** fractionalBits;
+  for (let componentIndex = 0; componentIndex < positions.length; componentIndex++) {
+    const byteOffset = componentIndex * 3;
+    let fixed32 =
+      positionStream[byteOffset] |
+      (positionStream[byteOffset + 1] << 8) |
+      (positionStream[byteOffset + 2] << 16);
+    fixed32 |= fixed32 & 0x800000 ? 0xff000000 : 0;
+    positions[componentIndex] = fixed32 * scale;
+  }
+}
+
+/** Decodes SPZ log-encoded scales to linear standard deviations. */
+function decodeSPZScales(scaleStream: Uint8Array, scales: Float32Array): void {
+  for (let componentIndex = 0; componentIndex < scales.length; componentIndex++) {
+    scales[componentIndex] = Math.exp(scaleStream[componentIndex] / 16 - 10);
+  }
+}
+
+/** Decodes SPZ smallest-three quaternion rotations into `[w, x, y, z]` order. */
+function decodeSPZRotations(rotationStream: Uint8Array, rotations: Float32Array): void {
+  for (let splatIndex = 0; splatIndex < rotations.length / 4; splatIndex++) {
+    const byteOffset = splatIndex * 4;
+    const component =
+      rotationStream[byteOffset] |
+      (rotationStream[byteOffset + 1] << 8) |
+      (rotationStream[byteOffset + 2] << 16) |
+      (rotationStream[byteOffset + 3] << 24);
+    const xyzw = decodeSPZQuaternion(component >>> 0);
+    const [w, x, y, z] = normalizeQuaternion(xyzw[3], xyzw[0], xyzw[1], xyzw[2]);
+    const rotationOffset = splatIndex * 4;
+    rotations[rotationOffset + 0] = w;
+    rotations[rotationOffset + 1] = x;
+    rotations[rotationOffset + 2] = y;
+    rotations[rotationOffset + 3] = z;
+  }
+}
+
+/** Decodes one SPZ smallest-three quaternion into `[x, y, z, w]` order. */
+function decodeSPZQuaternion(component: number): [number, number, number, number] {
+  const rotation: [number, number, number, number] = [0, 0, 0, 0];
+  const largestComponent = component >>> 30;
+  let remainingBits = component;
+  let sumSquares = 0;
+
+  for (let componentIndex = 3; componentIndex >= 0; componentIndex--) {
+    if (componentIndex !== largestComponent) {
+      const magnitude = remainingBits & SPZ_ROTATION_COMPONENT_MASK;
+      const isNegative = (remainingBits >>> 9) & 0x1;
+      remainingBits >>>= 10;
+      let value = (SPZ_ROTATION_COMPONENT_SCALE * magnitude) / SPZ_ROTATION_COMPONENT_MASK;
+      if (isNegative) {
+        value = -value;
+      }
+      rotation[componentIndex] = value;
+      sumSquares += value * value;
+    }
+  }
+
+  rotation[largestComponent] = Math.sqrt(Math.max(0, 1 - sumSquares));
+  return rotation;
+}
+
+/** Decodes SPZ color bytes into display RGB bytes and direct SH DC coefficients. */
+function decodeSPZColors(
+  colorStream: Uint8Array,
+  colors: Uint8Array,
+  sphericalHarmonicDcs: Float32Array
+): void {
+  for (let componentIndex = 0; componentIndex < colors.length; componentIndex++) {
+    sphericalHarmonicDcs[componentIndex] =
+      (colorStream[componentIndex] / 255 - 0.5) / SPZ_COLOR_SCALE;
+    colors[componentIndex] = normalizeColorByte(sphericalHarmonicDcs[componentIndex]);
+  }
+}
+
+/** Decodes SPZ alpha bytes into linear opacity. */
+function decodeSPZOpacities(alphaStream: Uint8Array, opacities: Float32Array): void {
+  for (let splatIndex = 0; splatIndex < opacities.length; splatIndex++) {
+    opacities[splatIndex] = alphaStream[splatIndex] / 255;
+  }
+}
+
+/** Decodes SPZ quantized SH rest coefficients. */
+function decodeSPZSphericalHarmonics(
+  sphericalHarmonicsStream: Uint8Array,
+  sphericalHarmonics: Float32Array
+): void {
+  for (let componentIndex = 0; componentIndex < sphericalHarmonics.length; componentIndex++) {
+    sphericalHarmonics[componentIndex] = (sphericalHarmonicsStream[componentIndex] - 128) / 128;
+  }
+}
+
+/** Converts an SH DC coefficient to a fallback RGB byte for preview paths. */
+function normalizeColorByte(sphericalHarmonicDc: number): number {
+  return Math.min(
+    Math.max(Math.round((sphericalHarmonicDc * SPZ_COLOR_SCALE + 0.5) * 255), 0),
+    255
+  );
+}
+
+/** Returns the number of SH rest coefficients per splat for an SPZ degree. */
+function getSphericalHarmonicsComponentCount(shDegree: number): number {
+  switch (shDegree) {
+    case 0:
+      return 0;
+    case 1:
+      return 9;
+    case 2:
+      return 24;
+    case 3:
+      return 45;
+    case 4:
+      return 72;
+    default:
+      throw new Error(`SPZLoader: spherical harmonics degree ${shDegree} is not supported.`);
+  }
+}
+
+/** Returns the plaintext SPZ extension byte count. */
+function getSPZExtensionByteLength(header: SPZHeader): number {
+  return header.flags & SPZ_EXTENSION_FLAG ? header.tocByteOffset - SPZ_HEADER_BYTE_LENGTH : 0;
+}
+
+/** Returns a copy of plaintext SPZ extension bytes when extension records are present. */
+function getSPZExtensionBytes(data: ArrayBuffer, header: SPZHeader): Uint8Array | undefined {
+  const extensionByteLength = getSPZExtensionByteLength(header);
+  return extensionByteLength
+    ? new Uint8Array(data.slice(SPZ_HEADER_BYTE_LENGTH, header.tocByteOffset))
+    : undefined;
+}

--- a/modules/splats/src/lib/splats-arrow-table.ts
+++ b/modules/splats/src/lib/splats-arrow-table.ts
@@ -26,7 +26,7 @@ export function makeGaussianSplatsArrowTable(splats: GaussianSplats): MeshArrowT
     }
   );
 
-  const colorCoefficients = getColorCoefficients(splats.colors);
+  const colorCoefficients = getColorCoefficients(splats);
   addScalarColumn(columns, fields, schemaFields, 'f_dc_0', colorCoefficients[0], {
     'loaders_gl.gaussian_splats.semantic': 'spherical_harmonic_dc',
     'loaders_gl.gaussian_splats.component': '0',
@@ -167,16 +167,22 @@ function makeFixedSizeListVector(value: Float32Array, size: number): arrow.Vecto
   return new arrow.Vector([data]);
 }
 
-/** Converts interleaved RGB bytes to separate SH DC coefficient arrays. */
-function getColorCoefficients(colors: Uint8Array): [Float32Array, Float32Array, Float32Array] {
-  const rowCount = colors.length / 3;
+/** Returns separate SH DC coefficient arrays from direct coefficients or RGB bytes. */
+function getColorCoefficients(splats: GaussianSplats): [Float32Array, Float32Array, Float32Array] {
+  const rowCount = splats.splatCount;
   const fdc0 = new Float32Array(rowCount);
   const fdc1 = new Float32Array(rowCount);
   const fdc2 = new Float32Array(rowCount);
   for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
-    fdc0[rowIndex] = convertColorByteToSphericalHarmonicDc(colors[rowIndex * 3 + 0]);
-    fdc1[rowIndex] = convertColorByteToSphericalHarmonicDc(colors[rowIndex * 3 + 1]);
-    fdc2[rowIndex] = convertColorByteToSphericalHarmonicDc(colors[rowIndex * 3 + 2]);
+    if (splats.sphericalHarmonicDcs) {
+      fdc0[rowIndex] = splats.sphericalHarmonicDcs[rowIndex * 3 + 0];
+      fdc1[rowIndex] = splats.sphericalHarmonicDcs[rowIndex * 3 + 1];
+      fdc2[rowIndex] = splats.sphericalHarmonicDcs[rowIndex * 3 + 2];
+    } else {
+      fdc0[rowIndex] = convertColorByteToSphericalHarmonicDc(splats.colors[rowIndex * 3 + 0]);
+      fdc1[rowIndex] = convertColorByteToSphericalHarmonicDc(splats.colors[rowIndex * 3 + 1]);
+      fdc2[rowIndex] = convertColorByteToSphericalHarmonicDc(splats.colors[rowIndex * 3 + 2]);
+    }
   }
   return [fdc0, fdc1, fdc2];
 }

--- a/modules/splats/src/rad-loader-types.ts
+++ b/modules/splats/src/rad-loader-types.ts
@@ -1,0 +1,27 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Loader, LoaderOptions} from '@loaders.gl/loader-utils';
+import {RADFormat} from './splats-format';
+import type {RADMetadata} from './lib/parse-rad';
+
+// __VERSION__ is injected by babel-plugin-version-inline
+// @ts-ignore TS2304: Cannot find name '__VERSION__'.
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+
+/** Preloads the parser-bearing RAD loader implementation. */
+async function preload() {
+  const {RADLoaderWithParser} = await import('./rad-loader');
+  return RADLoaderWithParser;
+}
+
+/** Metadata-only loader for Spark `.rad` paged LoD Gaussian splat containers. */
+export const RADLoader = {
+  dataType: null as unknown as RADMetadata,
+  batchType: null as never,
+  ...RADFormat,
+  version: VERSION,
+  options: {},
+  preload
+} as const satisfies Loader<RADMetadata, never, LoaderOptions>;

--- a/modules/splats/src/rad-loader.ts
+++ b/modules/splats/src/rad-loader.ts
@@ -7,6 +7,13 @@ import {parseRADHeader} from './lib/parse-rad';
 import type {RADMetadata} from './lib/parse-rad';
 import {RADLoader as RADLoaderMetadata} from './rad-loader-types';
 
+export {parseRADChunkHeader, parseRADHeader, tryParseRADHeader} from './lib/parse-rad';
+export {
+  parseRADChunk,
+  parseRADChunkToGaussianSplats,
+  type RADChunkDecodeOptions
+} from './lib/parse-rad-chunk';
+
 const {preload: _RADLoaderPreload, ...RADLoaderMetadataWithoutPreload} = RADLoaderMetadata;
 
 /** Parser-bearing loader for Spark `.rad` paged LoD Gaussian splat container metadata. */

--- a/modules/splats/src/rad-loader.ts
+++ b/modules/splats/src/rad-loader.ts
@@ -1,0 +1,17 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {LoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';
+import {parseRADHeader} from './lib/parse-rad';
+import type {RADMetadata} from './lib/parse-rad';
+import {RADLoader as RADLoaderMetadata} from './rad-loader-types';
+
+const {preload: _RADLoaderPreload, ...RADLoaderMetadataWithoutPreload} = RADLoaderMetadata;
+
+/** Parser-bearing loader for Spark `.rad` paged LoD Gaussian splat container metadata. */
+export const RADLoaderWithParser = {
+  ...RADLoaderMetadataWithoutPreload,
+  parse: async (arrayBuffer: ArrayBuffer) => parseRADHeader(arrayBuffer),
+  parseSync: (arrayBuffer: ArrayBuffer) => parseRADHeader(arrayBuffer)
+} as const satisfies LoaderWithParser<RADMetadata, never, LoaderOptions>;

--- a/modules/splats/src/rad-source-loader.ts
+++ b/modules/splats/src/rad-source-loader.ts
@@ -189,7 +189,11 @@ export class RADSource extends DataSource<string | Blob, RADSourceLoaderOptions>
     chunkIndex: number,
     options: RADChunkRequestOptions = {}
   ): Promise<GaussianSplats> {
-    return parseRADChunkToGaussianSplats(await this.getChunk(chunkIndex, options), options);
+    const metadata = await this.getMetadata();
+    return parseRADChunkToGaussianSplats(
+      await this.getChunk(chunkIndex, options),
+      this._getChunkDecodeOptions(metadata, options)
+    );
   }
 
   /** Fetches and decodes one RADC chunk into a Mesh Arrow table. */
@@ -197,7 +201,11 @@ export class RADSource extends DataSource<string | Blob, RADSourceLoaderOptions>
     chunkIndex: number,
     options: RADChunkRequestOptions = {}
   ): Promise<MeshArrowTable> {
-    return parseRADChunk(await this.getChunk(chunkIndex, options), options);
+    const metadata = await this.getMetadata();
+    return parseRADChunk(
+      await this.getChunk(chunkIndex, options),
+      this._getChunkDecodeOptions(metadata, options)
+    );
   }
 
   /** Iterates decoded RADC chunks as Mesh Arrow tables. */
@@ -264,6 +272,20 @@ export class RADSource extends DataSource<string | Blob, RADSourceLoaderOptions>
     const workerCount = Math.min(maxConcurrentChunkRequests, chunkIndices.length);
     await Promise.all(Array.from({length: workerCount}, () => loadNextChunk(this)));
     return splatChunks;
+  }
+
+  /** Adds source-level RAD decode metadata to chunk decode options. */
+  private _getChunkDecodeOptions(
+    metadata: RADMetadata,
+    options: RADChunkRequestOptions
+  ): RADChunkRequestOptions {
+    return {
+      ...options,
+      radChunk: {
+        splatEncoding: metadata.splatEncoding,
+        ...options.radChunk
+      }
+    };
   }
 
   /** Loads and parses the top-level RAD metadata. */

--- a/modules/splats/src/rad-source-loader.ts
+++ b/modules/splats/src/rad-source-loader.ts
@@ -1,0 +1,482 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {CoreAPI, DataSourceOptions, SourceLoader} from '@loaders.gl/loader-utils';
+import {DataSource} from '@loaders.gl/loader-utils';
+import type {MeshArrowTable} from '@loaders.gl/schema';
+import {RADFormat} from './splats-format';
+import {
+  parseRADChunkHeader,
+  tryParseRADHeader,
+  type RADChunkMetadata,
+  type RADChunkRange,
+  type RADMetadata
+} from './lib/parse-rad';
+import {
+  parseRADChunk,
+  parseRADChunkToGaussianSplats,
+  type RADChunkDecodeOptions
+} from './lib/parse-rad-chunk';
+import {makeGaussianSplatsArrowTable} from './lib/splats-arrow-table';
+import type {GaussianSplats} from './types';
+
+const DEFAULT_RAD_HEADER_BYTE_LENGTHS = [64 * 1024, 256 * 1024, 1024 * 1024];
+const DEFAULT_RAD_MAX_CONCURRENT_CHUNK_REQUESTS = 4;
+
+// __VERSION__ is injected by babel-plugin-version-inline
+// @ts-ignore TS2304: Cannot find name '__VERSION__'.
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+
+/** Options for creating a Spark RAD source. */
+export type RADSourceLoaderOptions = DataSourceOptions & {
+  rad?: {
+    /** Optional request headers forwarded to RAD and RADC fetches. */
+    headers?: Record<string, string>;
+    /** Whether remote RAD and RADC fetches should include credentials. */
+    withCredentials?: boolean;
+    /** Header byte lengths to try while probing remote RAD metadata. */
+    headerByteLengths?: number[];
+  };
+};
+
+/** Optional parameters for fetching RAD chunk bytes or metadata. */
+export type RADChunkRequestOptions = {
+  /** Abort signal forwarded to the underlying fetch. */
+  signal?: AbortSignal;
+} & RADChunkDecodeOptions;
+
+/** Options for iterating decoded RAD chunk tables. */
+export type RADChunkTableIteratorOptions = RADChunkRequestOptions & {
+  /** First chunk index to decode. */
+  startChunkIndex?: number;
+  /** Maximum number of chunks to decode. */
+  maxChunks?: number;
+  /** Maximum number of splats to decode before stopping. */
+  maxSplats?: number;
+  /** Maximum number of RAD chunks to fetch and decode at once when the iterator must inspect a chunk window before yielding. */
+  maxConcurrentChunkRequests?: number;
+  /** Whether loaded child splats should replace parent LoD splats in returned tables. */
+  pruneLoadedLoDParents?: boolean;
+};
+
+/** Source factory for Spark `.rad` paged LoD Gaussian splat containers. */
+export const RADSourceLoader = {
+  dataType: null as unknown as RADSource,
+  batchType: null as never,
+  ...RADFormat,
+  name: 'RADSourceLoader',
+  version: VERSION,
+  type: 'rad',
+  fromUrl: true,
+  fromBlob: true,
+
+  options: {
+    rad: {
+      headers: undefined!,
+      withCredentials: false,
+      headerByteLengths: undefined!
+    }
+  },
+
+  defaultOptions: {
+    rad: {
+      headers: undefined!,
+      withCredentials: false,
+      headerByteLengths: undefined!
+    }
+  },
+
+  testURL: (url: string): boolean => /\.rad(?:$|[?#])/i.test(url),
+  createDataSource: (
+    data: string | Blob,
+    options: RADSourceLoaderOptions,
+    coreApi?: CoreAPI
+  ): RADSource => new RADSource(data, options, coreApi)
+} as const satisfies SourceLoader<RADSource>;
+
+/** Runtime source for RAD metadata and chunk-byte access. */
+export class RADSource extends DataSource<string | Blob, RADSourceLoaderOptions> {
+  /** Shared metadata promise exposed for source-style integrations. */
+  metadata: Promise<RADMetadata>;
+
+  /** Lazily initialized RAD header promise. */
+  private _metadataPromise: Promise<RADMetadata> | null = null;
+  /** Lazily initialized per-chunk metadata promises. */
+  private _chunkMetadataPromises: Map<number, Promise<RADChunkMetadata>> = new Map();
+
+  constructor(data: string | Blob, options: RADSourceLoaderOptions, coreApi?: CoreAPI) {
+    super(data, options, RADSourceLoader.defaultOptions, coreApi);
+    this.metadata = this.getMetadata();
+  }
+
+  /** Ensures the RAD header metadata has been loaded. */
+  async initialize(): Promise<void> {
+    await this.getMetadata();
+  }
+
+  /** Returns parsed Spark RAD top-level metadata. */
+  async getMetadata(): Promise<RADMetadata> {
+    if (!this._metadataPromise) {
+      this._metadataPromise = this._loadMetadata();
+    }
+    return await this._metadataPromise;
+  }
+
+  /** Returns the number of chunks declared by the RAD metadata. */
+  async getChunkCount(): Promise<number> {
+    const metadata = await this.getMetadata();
+    return metadata.chunks.length;
+  }
+
+  /** Returns the URL used for a chunk, or `null` for Blob-backed inline chunks. */
+  async getChunkUrl(chunkIndex: number): Promise<string | null> {
+    const metadata = await this.getMetadata();
+    const chunk = this._getChunkRange(metadata, chunkIndex);
+    if (chunk.filename) {
+      return resolveRADChunkUrl(this.url, chunk.filename);
+    }
+    return typeof this.data === 'string' ? this.url : null;
+  }
+
+  /** Fetches one raw RADC chunk by index. */
+  async getChunk(chunkIndex: number, options: RADChunkRequestOptions = {}): Promise<ArrayBuffer> {
+    const metadata = await this.getMetadata();
+    const chunk = this._getChunkRange(metadata, chunkIndex);
+
+    if (chunk.filename) {
+      if (typeof this.data !== 'string') {
+        throw new Error('RADSource: sidecar RADC chunks require a URL-backed RAD source.');
+      }
+      return await this._fetchArrayBuffer(resolveRADChunkUrl(this.url, chunk.filename), undefined, {
+        signal: options.signal
+      });
+    }
+
+    if (chunk.bytes === 0) {
+      return new ArrayBuffer(0);
+    }
+
+    const byteOffset = metadata.chunksByteOffset + chunk.offset;
+    if (typeof this.data !== 'string') {
+      return await this.data.slice(byteOffset, byteOffset + chunk.bytes).arrayBuffer();
+    }
+
+    return await this._fetchArrayBuffer(
+      this.url,
+      {offset: byteOffset, bytes: chunk.bytes},
+      {signal: options.signal}
+    );
+  }
+
+  /** Fetches and parses metadata for one RADC chunk. */
+  async getChunkMetadata(
+    chunkIndex: number,
+    options: RADChunkRequestOptions = {}
+  ): Promise<RADChunkMetadata> {
+    let chunkMetadataPromise = this._chunkMetadataPromises.get(chunkIndex);
+    if (!chunkMetadataPromise) {
+      chunkMetadataPromise = this.getChunk(chunkIndex, options).then(chunk =>
+        parseRADChunkHeader(chunk)
+      );
+      this._chunkMetadataPromises.set(chunkIndex, chunkMetadataPromise);
+    }
+    return await chunkMetadataPromise;
+  }
+
+  /** Fetches and decodes one RADC chunk into raw Gaussian splat arrays. */
+  async getChunkSplats(
+    chunkIndex: number,
+    options: RADChunkRequestOptions = {}
+  ): Promise<GaussianSplats> {
+    return parseRADChunkToGaussianSplats(await this.getChunk(chunkIndex, options), options);
+  }
+
+  /** Fetches and decodes one RADC chunk into a Mesh Arrow table. */
+  async getChunkTable(
+    chunkIndex: number,
+    options: RADChunkRequestOptions = {}
+  ): Promise<MeshArrowTable> {
+    return parseRADChunk(await this.getChunk(chunkIndex, options), options);
+  }
+
+  /** Iterates decoded RADC chunks as Mesh Arrow tables. */
+  async *getChunkTables(options: RADChunkTableIteratorOptions = {}): AsyncIterable<MeshArrowTable> {
+    const metadata = await this.getMetadata();
+    const startChunkIndex = options.startChunkIndex ?? 0;
+    const maxChunks = options.maxChunks ?? Number.POSITIVE_INFINITY;
+    const maxSplats = options.maxSplats ?? Number.POSITIVE_INFINITY;
+    let chunkCount = 0;
+    let splatCount = 0;
+
+    if (options.pruneLoadedLoDParents) {
+      const chunkIndices = getRADChunkTableIteratorIndices(
+        metadata,
+        startChunkIndex,
+        maxChunks,
+        maxSplats
+      );
+      const splatChunks = await this._getChunkSplatsConcurrently(chunkIndices, options);
+      let loadedGlobalSplatEnd = 0;
+      for (const splats of splatChunks) {
+        chunkCount++;
+        splatCount += splats.splatCount;
+        const base = getRADChunkSplatBase(splats);
+        loadedGlobalSplatEnd = Math.max(loadedGlobalSplatEnd, base + splats.splatCount);
+      }
+      for (const splats of splatChunks) {
+        yield makeGaussianSplatsArrowTable(pruneLoadedLoDParents(splats, loadedGlobalSplatEnd));
+      }
+      return;
+    }
+
+    for (
+      let chunkIndex = startChunkIndex;
+      chunkIndex < metadata.chunks.length && chunkCount < maxChunks && splatCount < maxSplats;
+      chunkIndex++
+    ) {
+      const table = await this.getChunkTable(chunkIndex, options);
+      chunkCount++;
+      splatCount += table.data.numRows;
+      yield table;
+    }
+  }
+
+  /** Fetches and decodes RAD chunks with bounded concurrency while preserving chunk order. */
+  private async _getChunkSplatsConcurrently(
+    chunkIndices: number[],
+    options: RADChunkTableIteratorOptions
+  ): Promise<GaussianSplats[]> {
+    const splatChunks = new Array<GaussianSplats>(chunkIndices.length);
+    const maxConcurrentChunkRequests = getRADMaxConcurrentChunkRequests(
+      options.maxConcurrentChunkRequests
+    );
+    let nextResultIndex = 0;
+
+    async function loadNextChunk(source: RADSource): Promise<void> {
+      while (nextResultIndex < chunkIndices.length) {
+        const resultIndex = nextResultIndex++;
+        const chunkIndex = chunkIndices[resultIndex];
+        splatChunks[resultIndex] = await source.getChunkSplats(chunkIndex, options);
+      }
+    }
+
+    const workerCount = Math.min(maxConcurrentChunkRequests, chunkIndices.length);
+    await Promise.all(Array.from({length: workerCount}, () => loadNextChunk(this)));
+    return splatChunks;
+  }
+
+  /** Loads and parses the top-level RAD metadata. */
+  private async _loadMetadata(): Promise<RADMetadata> {
+    const headerByteLengths = this.options.rad?.headerByteLengths?.length
+      ? this.options.rad.headerByteLengths
+      : DEFAULT_RAD_HEADER_BYTE_LENGTHS;
+
+    if (typeof this.data !== 'string') {
+      const byteLength = Math.min(this.data.size, Math.max(...headerByteLengths));
+      const metadata = tryParseRADHeader(await this.data.slice(0, byteLength).arrayBuffer());
+      if (metadata) {
+        return metadata;
+      }
+      throw new Error('RADSource: Blob does not contain a complete RAD metadata header.');
+    }
+
+    for (const byteLength of headerByteLengths) {
+      const metadata = tryParseRADHeader(
+        await this._fetchArrayBuffer(this.url, {offset: 0, bytes: byteLength})
+      );
+      if (metadata) {
+        return metadata;
+      }
+    }
+
+    throw new Error('RADSource: failed to load a complete RAD metadata header.');
+  }
+
+  /** Returns a validated chunk table entry. */
+  private _getChunkRange(metadata: RADMetadata, chunkIndex: number): RADChunkRange {
+    if (!Number.isInteger(chunkIndex) || chunkIndex < 0 || chunkIndex >= metadata.chunks.length) {
+      throw new Error(
+        `RADSource: chunk index ${chunkIndex} is outside 0-${metadata.chunks.length - 1}.`
+      );
+    }
+    return metadata.chunks[chunkIndex];
+  }
+
+  /** Fetches a full or ranged ArrayBuffer while tolerating non-206 range fallbacks. */
+  private async _fetchArrayBuffer(
+    url: string,
+    range?: {offset: number; bytes: number},
+    options: RADChunkRequestOptions = {}
+  ): Promise<ArrayBuffer> {
+    const response = await this._fetchResponse(url, this._getRequestInit(range, options));
+    if (!response.ok) {
+      throw new Error(
+        `RADSource: failed to fetch ${url}: ${response.status} ${response.statusText}`
+      );
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    if (range && response.status !== 206 && arrayBuffer.byteLength >= range.offset + range.bytes) {
+      return arrayBuffer.slice(range.offset, range.offset + range.bytes);
+    }
+    if (range && arrayBuffer.byteLength > range.bytes) {
+      return arrayBuffer.slice(0, range.bytes);
+    }
+    return arrayBuffer;
+  }
+
+  /** Fetches through custom source fetch hooks or the injected core fetchFile helper. */
+  private async _fetchResponse(url: string, requestInit: RequestInit): Promise<Response> {
+    if (this._hasCustomFetch()) {
+      return await this.fetch(url, requestInit);
+    }
+    return this.hasCoreApi
+      ? await this.coreApi.fetchFile(url, requestInit)
+      : await this.fetch(url, requestInit);
+  }
+
+  /** Returns true when source options supplied an explicit fetch override. */
+  private _hasCustomFetch(): boolean {
+    return Boolean(this.loadOptions?.core?.fetch || this.loadOptions?.fetch);
+  }
+
+  /** Builds request options for RAD fetches. */
+  private _getRequestInit(
+    range?: {offset: number; bytes: number},
+    options: RADChunkRequestOptions = {}
+  ): RequestInit {
+    const headers = new Headers(this.options.rad?.headers);
+    if (range && range.bytes > 0) {
+      headers.set('Range', `bytes=${range.offset}-${range.offset + range.bytes - 1}`);
+    }
+
+    return {
+      headers,
+      credentials: this.options.rad?.withCredentials ? 'include' : 'same-origin',
+      signal: options.signal
+    };
+  }
+}
+
+/** Returns the RAD chunk indices requested by a chunk-table iterator. */
+function getRADChunkTableIteratorIndices(
+  metadata: RADMetadata,
+  startChunkIndex: number,
+  maxChunks: number,
+  maxSplats: number
+): number[] {
+  const chunkIndices: number[] = [];
+  let estimatedSplatCount = 0;
+  for (
+    let chunkIndex = startChunkIndex;
+    chunkIndex < metadata.chunks.length &&
+    chunkIndices.length < maxChunks &&
+    estimatedSplatCount < maxSplats;
+    chunkIndex++
+  ) {
+    const chunk = metadata.chunks[chunkIndex];
+    chunkIndices.push(chunkIndex);
+    estimatedSplatCount += chunk?.count ?? metadata.chunkSize ?? 0;
+  }
+  return chunkIndices;
+}
+
+/** Returns a positive integer chunk request concurrency limit. */
+function getRADMaxConcurrentChunkRequests(maxConcurrentChunkRequests?: number): number {
+  return Number.isFinite(maxConcurrentChunkRequests) && maxConcurrentChunkRequests! > 0
+    ? Math.floor(maxConcurrentChunkRequests!)
+    : DEFAULT_RAD_MAX_CONCURRENT_CHUNK_REQUESTS;
+}
+
+/** Returns the first global splat index represented by decoded RAD chunk data. */
+function getRADChunkSplatBase(splats: GaussianSplats): number {
+  return typeof splats.loaderData?.base === 'number' ? splats.loaderData.base : 0;
+}
+
+/** Remove parent LoD rows when their children are present in the loaded chunk range. */
+function pruneLoadedLoDParents(
+  splats: GaussianSplats,
+  loadedGlobalSplatEnd: number
+): GaussianSplats {
+  const childCounts = splats.loaderData?.childCounts;
+  const childStarts = splats.loaderData?.childStarts;
+  if (!(childCounts instanceof Uint16Array) || !(childStarts instanceof Uint32Array)) {
+    return splats;
+  }
+
+  const keepRows = new Uint32Array(splats.splatCount);
+  let keepCount = 0;
+  for (let rowIndex = 0; rowIndex < splats.splatCount; rowIndex++) {
+    const childCount = childCounts[rowIndex];
+    const childStart = childStarts[rowIndex];
+    if (childCount > 0 && childStart < loadedGlobalSplatEnd) {
+      continue;
+    }
+    keepRows[keepCount++] = rowIndex;
+  }
+  if (keepCount === splats.splatCount) {
+    return splats;
+  }
+
+  const keptRows = keepRows.subarray(0, keepCount);
+  const sphericalHarmonicsComponentCount = splats.sphericalHarmonicsComponentCount ?? 0;
+  return {
+    ...splats,
+    splatCount: keepCount,
+    positions: copyInterleavedRows(splats.positions, 3, keptRows),
+    scales: copyInterleavedRows(splats.scales, 3, keptRows),
+    rotations: copyInterleavedRows(splats.rotations, 4, keptRows),
+    colors: copyInterleavedRows(splats.colors, 3, keptRows),
+    sphericalHarmonicDcs: splats.sphericalHarmonicDcs
+      ? copyInterleavedRows(splats.sphericalHarmonicDcs, 3, keptRows)
+      : undefined,
+    opacities: copyInterleavedRows(splats.opacities, 1, keptRows),
+    sphericalHarmonics:
+      splats.sphericalHarmonics && sphericalHarmonicsComponentCount
+        ? copyInterleavedRows(splats.sphericalHarmonics, sphericalHarmonicsComponentCount, keptRows)
+        : undefined,
+    loaderData: {
+      ...splats.loaderData,
+      count: keepCount,
+      childCounts: copyInterleavedRows(childCounts, 1, keptRows),
+      childStarts: copyInterleavedRows(childStarts, 1, keptRows)
+    }
+  };
+}
+
+/** Copy selected rows from an interleaved typed array. */
+function copyInterleavedRows<T extends Float32Array | Uint8Array | Uint16Array | Uint32Array>(
+  values: T,
+  itemSize: number,
+  rows: Uint32Array
+): T {
+  const copiedValues = new (values.constructor as {new (length: number): T})(
+    rows.length * itemSize
+  );
+  for (let outputRowIndex = 0; outputRowIndex < rows.length; outputRowIndex++) {
+    const inputOffset = rows[outputRowIndex] * itemSize;
+    const outputOffset = outputRowIndex * itemSize;
+    copiedValues.set(values.subarray(inputOffset, inputOffset + itemSize), outputOffset);
+  }
+  return copiedValues;
+}
+
+/** Resolves a sidecar RADC chunk filename relative to its parent RAD URL. */
+export function resolveRADChunkUrl(rootUrl: string, chunkFilename: string): string {
+  if (/^[a-z][a-z0-9+.-]*:/i.test(chunkFilename) || chunkFilename.startsWith('/')) {
+    return chunkFilename;
+  }
+  if (!rootUrl) {
+    throw new Error('RADSource: cannot resolve a sidecar RADC chunk without a RAD URL.');
+  }
+
+  try {
+    return new URL(chunkFilename, rootUrl).toString();
+  } catch {
+    const [rootPath, suffix = ''] = rootUrl.split(/([?#].*)/, 2);
+    const lastSlashIndex = Math.max(rootPath.lastIndexOf('/'), rootPath.lastIndexOf('\\'));
+    const rootDirectory = lastSlashIndex >= 0 ? rootPath.slice(0, lastSlashIndex + 1) : '';
+    return `${rootDirectory}${chunkFilename}${suffix}`;
+  }
+}

--- a/modules/splats/src/splats-format.ts
+++ b/modules/splats/src/splats-format.ts
@@ -25,3 +25,27 @@ export const KSPLATFormat = {
   mimeTypes: ['application/octet-stream'],
   binary: true
 } as const satisfies Format;
+
+/** SPZ - Niantic Spatial compressed Gaussian splat format. */
+export const SPZFormat = {
+  name: 'SPZ',
+  id: 'spz',
+  module: 'splats',
+  format: 'spz',
+  extensions: ['spz'],
+  mimeTypes: ['application/octet-stream'],
+  binary: true,
+  tests: [new Uint8Array([0x4e, 0x47, 0x53, 0x50]).buffer]
+} as const satisfies Format;
+
+/** RAD - Spark paged level-of-detail Gaussian splat container. */
+export const RADFormat = {
+  name: 'RAD',
+  id: 'rad',
+  module: 'splats',
+  format: 'rad',
+  extensions: ['rad'],
+  mimeTypes: ['application/octet-stream'],
+  binary: true,
+  tests: [new Uint8Array([0x52, 0x41, 0x44, 0x30]).buffer]
+} as const satisfies Format;

--- a/modules/splats/src/spz-loader-types.ts
+++ b/modules/splats/src/spz-loader-types.ts
@@ -1,0 +1,32 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Loader} from '@loaders.gl/loader-utils';
+import type {MeshArrowTable} from '@loaders.gl/schema';
+import type {SplatsLoaderOptions} from './types';
+import {SPZFormat} from './splats-format';
+
+// __VERSION__ is injected by babel-plugin-version-inline
+// @ts-ignore TS2304: Cannot find name '__VERSION__'.
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+
+/** Preloads the parser-bearing SPZ loader implementation. */
+async function preload() {
+  const {SPZLoaderWithParser} = await import('./spz-loader');
+  return SPZLoaderWithParser;
+}
+
+/** Metadata-only loader for Niantic Spatial `.spz` Gaussian splat files. */
+export const SPZLoader = {
+  dataType: null as unknown as MeshArrowTable,
+  batchType: null as never,
+  ...SPZFormat,
+  version: VERSION,
+  options: {
+    splats: {
+      shape: 'arrow-table'
+    }
+  },
+  preload
+} as const satisfies Loader<MeshArrowTable, never, SplatsLoaderOptions>;

--- a/modules/splats/src/spz-loader.ts
+++ b/modules/splats/src/spz-loader.ts
@@ -1,0 +1,18 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {LoaderWithParser} from '@loaders.gl/loader-utils';
+import type {MeshArrowTable} from '@loaders.gl/schema';
+import type {SplatsLoaderOptions} from './types';
+import {parseSPZ} from './lib/parse-spz';
+import {SPZLoader as SPZLoaderMetadata} from './spz-loader-types';
+
+const {preload: _SPZLoaderPreload, ...SPZLoaderMetadataWithoutPreload} = SPZLoaderMetadata;
+
+/** Parser-bearing loader for Niantic Spatial `.spz` Gaussian splat files. */
+export const SPZLoaderWithParser = {
+  ...SPZLoaderMetadataWithoutPreload,
+  parse: async (arrayBuffer: ArrayBuffer, options?: SplatsLoaderOptions) =>
+    parseSPZ(arrayBuffer, options)
+} as const satisfies LoaderWithParser<MeshArrowTable, never, SplatsLoaderOptions>;

--- a/modules/splats/src/types.ts
+++ b/modules/splats/src/types.ts
@@ -15,7 +15,7 @@ export type SplatsLoaderOptions = LoaderOptions & {
 /** Linear Gaussian splat values before Arrow table construction. */
 export type GaussianSplats = {
   /** Source format identifier. */
-  format: 'splat' | 'ksplat';
+  format: 'splat' | 'ksplat' | 'spz' | 'rad';
   /** Number of decoded splats. */
   splatCount: number;
   /** Interleaved xyz positions. */
@@ -26,7 +26,9 @@ export type GaussianSplats = {
   rotations: Float32Array;
   /** Interleaved RGB colors as unorm8 values. */
   colors: Uint8Array;
-  /** Linear opacity values in the `[0, 1]` range. */
+  /** Optional interleaved RGB spherical harmonic DC coefficients. */
+  sphericalHarmonicDcs?: Float32Array;
+  /** Linear opacity values. Some LoD formats intentionally store values above 1. */
   opacities: Float32Array;
   /** Optional spherical harmonic rest coefficients. */
   sphericalHarmonics?: Float32Array;

--- a/modules/splats/src/unbundled.ts
+++ b/modules/splats/src/unbundled.ts
@@ -2,4 +2,4 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-export {SPLATLoader, KSPLATLoader} from './index';
+export {SPLATLoader, KSPLATLoader, SPZLoader, RADLoader, RADSourceLoader} from './index';

--- a/modules/splats/test/index.ts
+++ b/modules/splats/test/index.ts
@@ -4,3 +4,5 @@
 
 import './splat-loader.spec';
 import './ksplat-loader.spec';
+import './spz-loader.spec';
+import './rad-source-loader.spec';

--- a/modules/splats/test/rad-source-loader.spec.ts
+++ b/modules/splats/test/rad-source-loader.spec.ts
@@ -5,16 +5,14 @@
 import test from 'tape-promise/tape';
 import {DeflateCompression} from '@loaders.gl/compression';
 import {load, parse, parseSync} from '@loaders.gl/core';
+import {RADLoader, RADSourceLoader, resolveRADChunkUrl} from '@loaders.gl/splats';
+import type {RADSource} from '@loaders.gl/splats';
+import type {MeshArrowTable} from '@loaders.gl/schema';
 import {
   parseRADChunkHeader,
   parseRADChunkToGaussianSplats,
-  RADLoader,
-  RADSourceLoader,
-  resolveRADChunkUrl
-} from '@loaders.gl/splats';
-import type {RADSource} from '@loaders.gl/splats';
-import type {MeshArrowTable} from '@loaders.gl/schema';
-import {RADLoaderWithParser} from '@loaders.gl/splats/rad-loader';
+  RADLoaderWithParser
+} from '@loaders.gl/splats/rad-loader';
 
 test('RADLoader parses Spark RAD metadata', async t => {
   const data = makeRADFixture();
@@ -84,6 +82,38 @@ test('parseRADChunkToGaussianSplats expands Spark LoD opacity bytes', t => {
 
   t.ok(Math.abs(splats.opacities[0] - (64 / 255) * 2) < 1e-6, 'decodes opacity below one');
   t.ok(Math.abs(splats.opacities[1] - (191 / 255) * 2) < 1e-6, 'decodes opacity above one');
+  t.end();
+});
+
+test('RADSourceLoader uses source-level splat encoding for chunk decoding', async t => {
+  const source = (await load(
+    new Blob([
+      makeRADFixture({
+        splatEncoding: {
+          rgbMin: 0,
+          rgbMax: 1,
+          lnScaleMin: -12,
+          lnScaleMax: 9,
+          lodOpacity: true
+        },
+        chunkOptions: {
+          alphaEncoding: 'r8',
+          omitPropertyRanges: true
+        }
+      })
+    ]),
+    RADSourceLoader
+  )) as RADSource;
+
+  const splats = await source.getChunkSplats(0);
+
+  t.ok(Math.abs(splats.scales[0] - 0.02) < 0.003, 'decodes top-level scale range');
+  t.deepEqual(
+    Array.from(splats.colors),
+    [64, 128, 191, 128, 191, 255],
+    'decodes top-level RGB range'
+  );
+  t.ok(Math.abs(splats.opacities[1] - (191 / 255) * 2) < 1e-6, 'uses top-level LoD opacity');
   t.end();
 });
 
@@ -189,11 +219,15 @@ type RADFixtureOptions = {
   chunkFilenames?: string[];
   /** Whether to append chunk bytes inline after the RAD header. */
   inlineChunk?: boolean;
+  /** Optional top-level RAD splat encoding metadata. */
+  splatEncoding?: Record<string, unknown>;
+  /** Optional deterministic RADC chunk fixture options. */
+  chunkOptions?: RADChunkFixtureOptions;
 };
 
 /** Builds a deterministic single-chunk Spark RAD fixture. */
 function makeRADFixture(options: RADFixtureOptions = {}): ArrayBuffer {
-  const chunk = makeRADChunkFixture();
+  const chunk = makeRADChunkFixture(options.chunkOptions);
   const inlineChunk = options.inlineChunk ?? true;
   const chunkFilenames =
     options.chunkFilenames || (options.chunkFilename ? [options.chunkFilename] : undefined);
@@ -210,7 +244,7 @@ function makeRADFixture(options: RADFixtureOptions = {}): ArrayBuffer {
       bytes: chunk.byteLength,
       filename: chunkFilenames?.[chunkIndex]
     })),
-    splatEncoding: {lodOpacity: true}
+    splatEncoding: options.splatEncoding ?? {lodOpacity: true}
   };
 
   const metadataBytes = new TextEncoder().encode(JSON.stringify(metadata));
@@ -236,6 +270,8 @@ type RADChunkFixtureOptions = {
   alphaEncoding?: 'f32' | 'r8';
   /** Optional chunk-local splat encoding metadata. */
   splatEncoding?: Record<string, unknown>;
+  /** Whether quantized property min/max values should be omitted from property metadata. */
+  omitPropertyRanges?: boolean;
 };
 
 /** Builds a deterministic Spark RADC chunk fixture. */
@@ -258,13 +294,13 @@ function makeRADChunkFixture(options: RADChunkFixtureOptions = {}): ArrayBuffer 
       'rgb',
       'r8_delta',
       encodeR8Delta(new Float32Array([0.25, 0.5, 0.75, 0.5, 0.75, 1]), 3, 2, 0, 1),
-      {min: 0, max: 1}
+      options.omitPropertyRanges ? {} : {min: 0, max: 1}
     ),
     makeRADChunkPayload(
       'scales',
       'ln_0r8',
       encodeScaleR8(new Float32Array([0.02, 0.03, 0.04, 0.05, 0.06, 0.07]), 3, 2, -12, 9),
-      {min: -12, max: 9}
+      options.omitPropertyRanges ? {} : {min: -12, max: 9}
     ),
     makeRADChunkPayload('orientation', 'oct88r8', new Uint8Array([128, 128, 0, 128, 128, 0])),
     makeRADChunkPayload('child_count', 'u16', new Uint8Array([0, 0, 2, 0])),

--- a/modules/splats/test/rad-source-loader.spec.ts
+++ b/modules/splats/test/rad-source-loader.spec.ts
@@ -1,0 +1,438 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'tape-promise/tape';
+import {DeflateCompression} from '@loaders.gl/compression';
+import {load, parse, parseSync} from '@loaders.gl/core';
+import {
+  parseRADChunkHeader,
+  parseRADChunkToGaussianSplats,
+  RADLoader,
+  RADSourceLoader,
+  resolveRADChunkUrl
+} from '@loaders.gl/splats';
+import type {RADSource} from '@loaders.gl/splats';
+import type {MeshArrowTable} from '@loaders.gl/schema';
+import {RADLoaderWithParser} from '@loaders.gl/splats/rad-loader';
+
+test('RADLoader parses Spark RAD metadata', async t => {
+  const data = makeRADFixture();
+  const metadata = await parse(data, RADLoader);
+
+  t.equal(metadata.version, 1, 'parses version');
+  t.equal(metadata.type, 'gsplat', 'parses RAD type');
+  t.equal(metadata.count, 2, 'parses splat count');
+  t.equal(metadata.chunks.length, 1, 'parses chunk table');
+  t.equal(metadata.chunks[0].bytes, makeRADChunkFixture().byteLength, 'parses chunk byte length');
+  t.equal(metadata.splatEncoding?.lodOpacity, true, 'parses splat encoding');
+
+  const syncMetadata = parseSync(data, RADLoaderWithParser);
+  t.equal(
+    syncMetadata.chunksByteOffset,
+    metadata.chunksByteOffset,
+    'parser subpath supports parseSync'
+  );
+  t.end();
+});
+
+test('RADSourceLoader reads inline RAD chunk metadata from a Blob', async t => {
+  const data = makeRADFixture();
+  const source = (await load(new Blob([data]), RADSourceLoader)) as RADSource;
+  const metadata = await source.getMetadata();
+  const chunk = await source.getChunk(0);
+  const chunkMetadata = await source.getChunkMetadata(0);
+  const chunkTables: MeshArrowTable[] = [];
+  for await (const table of source.getChunkTables({maxChunks: 1})) {
+    chunkTables.push(table);
+  }
+
+  t.equal(await source.getChunkCount(), 1, 'reports chunk count');
+  t.equal(metadata.count, 2, 'loads metadata from Blob');
+  t.equal(chunk.byteLength, makeRADChunkFixture().byteLength, 'reads inline chunk bytes');
+  t.equal(chunkMetadata.base, 0, 'parses chunk base');
+  t.equal(chunkMetadata.count, 2, 'parses chunk count');
+  t.ok(chunkMetadata.payloadBytes > 0, 'parses chunk payload byte length');
+  t.equal(chunkTables[0].data.numRows, 2, 'iterates decoded chunk tables');
+  t.end();
+});
+
+test('parseRADChunkToGaussianSplats decodes Spark RADC chunk payloads', t => {
+  const splats = parseRADChunkToGaussianSplats(makeRADChunkFixture());
+  const childCounts = splats.loaderData?.childCounts as Uint16Array;
+  const childStarts = splats.loaderData?.childStarts as Uint32Array;
+
+  t.equal(splats.format, 'rad', 'reports RAD source format');
+  t.equal(splats.splatCount, 2, 'decodes splat count');
+  t.deepEqual(Array.from(splats.positions), [1, 2, 3, 4, 5, 6], 'decodes f32_lebytes centers');
+  t.deepEqual(Array.from(splats.opacities), [0.25, 0.75], 'decodes alpha values');
+  t.ok(Math.abs(splats.scales[0] - 0.02) < 0.003, 'decodes ln_0r8 scales');
+  t.deepEqual(Array.from(splats.rotations), [1, 0, 0, 0, 1, 0, 0, 0], 'decodes rotations');
+  t.deepEqual(Array.from(splats.colors), [64, 128, 191, 128, 191, 255], 'decodes RGB bytes');
+  t.deepEqual(Array.from(childCounts), [0, 2], 'decodes LoD child counts');
+  t.deepEqual(Array.from(childStarts), [0, 42], 'decodes LoD child starts');
+  t.end();
+});
+
+test('parseRADChunkToGaussianSplats expands Spark LoD opacity bytes', t => {
+  const splats = parseRADChunkToGaussianSplats(
+    makeRADChunkFixture({
+      alphaEncoding: 'r8',
+      splatEncoding: {lodOpacity: true}
+    })
+  );
+
+  t.ok(Math.abs(splats.opacities[0] - (64 / 255) * 2) < 1e-6, 'decodes opacity below one');
+  t.ok(Math.abs(splats.opacities[1] - (191 / 255) * 2) < 1e-6, 'decodes opacity above one');
+  t.end();
+});
+
+test('RADSourceLoader resolves and fetches sidecar RADC chunks', async t => {
+  const chunk = makeRADChunkFixture();
+  const rad = makeRADFixture({chunkFilename: 'chunks/scene-0.radc', inlineChunk: false});
+  const fetchedUrls: string[] = [];
+  const source = RADSourceLoader.createDataSource('https://example.com/assets/scene.rad', {
+    core: {
+      loadOptions: {
+        core: {
+          fetch: async (url: string | RequestInfo | URL) => {
+            const urlString = String(url);
+            fetchedUrls.push(urlString);
+            return new Response(urlString.endsWith('.radc') ? chunk : rad);
+          }
+        }
+      }
+    }
+  });
+
+  const metadata = await source.getMetadata();
+  const chunkUrl = await source.getChunkUrl(0);
+  const sidecarChunk = await source.getChunk(0);
+
+  t.equal(metadata.chunks[0].filename, 'chunks/scene-0.radc', 'parses sidecar chunk filename');
+  t.equal(chunkUrl, 'https://example.com/assets/chunks/scene-0.radc', 'resolves sidecar chunk URL');
+  t.deepEqual(
+    fetchedUrls,
+    ['https://example.com/assets/scene.rad', 'https://example.com/assets/chunks/scene-0.radc'],
+    'fetches RAD header and sidecar chunk'
+  );
+  t.equal(sidecarChunk.byteLength, chunk.byteLength, 'loads sidecar chunk bytes');
+  t.end();
+});
+
+test('RADSourceLoader bounds concurrent pruned chunk table reads', async t => {
+  const chunk = makeRADChunkFixture();
+  const rad = makeRADFixture({
+    chunkFilenames: [
+      'chunks/scene-0.radc',
+      'chunks/scene-1.radc',
+      'chunks/scene-2.radc',
+      'chunks/scene-3.radc'
+    ],
+    inlineChunk: false
+  });
+  let activeChunkFetchCount = 0;
+  let maxActiveChunkFetchCount = 0;
+  const source = RADSourceLoader.createDataSource('https://example.com/assets/scene.rad', {
+    core: {
+      loadOptions: {
+        core: {
+          fetch: async (url: string | RequestInfo | URL) => {
+            const urlString = String(url);
+            if (!urlString.endsWith('.radc')) {
+              return new Response(rad);
+            }
+            activeChunkFetchCount++;
+            maxActiveChunkFetchCount = Math.max(maxActiveChunkFetchCount, activeChunkFetchCount);
+            await new Promise(resolve => setTimeout(resolve, 10));
+            activeChunkFetchCount--;
+            return new Response(chunk);
+          }
+        }
+      }
+    }
+  });
+
+  const chunkTables: MeshArrowTable[] = [];
+  for await (const table of source.getChunkTables({
+    maxChunks: 4,
+    maxConcurrentChunkRequests: 2,
+    pruneLoadedLoDParents: true
+  })) {
+    chunkTables.push(table);
+  }
+
+  t.equal(chunkTables.length, 4, 'iterates all selected pruned chunk tables');
+  t.equal(maxActiveChunkFetchCount, 2, 'limits concurrent chunk fetches');
+  t.end();
+});
+
+test('RAD parsing validates magic headers', t => {
+  t.throws(
+    () => parseRADChunkHeader(new ArrayBuffer(16)),
+    /RADC magic header/,
+    'rejects invalid RADC chunk magic'
+  );
+  t.equal(
+    resolveRADChunkUrl('https://example.com/path/scene.rad', '0.radc'),
+    'https://example.com/path/0.radc',
+    'resolves relative chunk URLs'
+  );
+  t.end();
+});
+
+/** Options for building deterministic RAD fixtures. */
+type RADFixtureOptions = {
+  /** Optional sidecar chunk filename. */
+  chunkFilename?: string;
+  /** Optional sidecar chunk filenames. */
+  chunkFilenames?: string[];
+  /** Whether to append chunk bytes inline after the RAD header. */
+  inlineChunk?: boolean;
+};
+
+/** Builds a deterministic single-chunk Spark RAD fixture. */
+function makeRADFixture(options: RADFixtureOptions = {}): ArrayBuffer {
+  const chunk = makeRADChunkFixture();
+  const inlineChunk = options.inlineChunk ?? true;
+  const chunkFilenames =
+    options.chunkFilenames || (options.chunkFilename ? [options.chunkFilename] : undefined);
+  const chunkCount = chunkFilenames?.length || 1;
+  const metadata = {
+    version: 1,
+    type: 'gsplat',
+    count: chunkCount * 2,
+    maxSh: 0,
+    chunkSize: 2,
+    allChunkBytes: inlineChunk ? chunk.byteLength * chunkCount : 0,
+    chunks: Array.from({length: chunkCount}, (_, chunkIndex) => ({
+      offset: inlineChunk ? chunk.byteLength * chunkIndex : 0,
+      bytes: chunk.byteLength,
+      filename: chunkFilenames?.[chunkIndex]
+    })),
+    splatEncoding: {lodOpacity: true}
+  };
+
+  const metadataBytes = new TextEncoder().encode(JSON.stringify(metadata));
+  const chunksByteOffset = 8 + roundUpToEight(metadataBytes.byteLength);
+  const data = new ArrayBuffer(chunksByteOffset + (inlineChunk ? chunk.byteLength : 0));
+  const dataView = new DataView(data);
+  const bytes = new Uint8Array(data);
+
+  dataView.setUint32(0, 0x30444152, true);
+  dataView.setUint32(4, metadataBytes.byteLength, true);
+  bytes.set(metadataBytes, 8);
+  if (inlineChunk) {
+    for (let chunkIndex = 0; chunkIndex < chunkCount; chunkIndex++) {
+      bytes.set(new Uint8Array(chunk), chunksByteOffset + chunk.byteLength * chunkIndex);
+    }
+  }
+  return data;
+}
+
+/** Options for building deterministic RADC chunk fixtures. */
+type RADChunkFixtureOptions = {
+  /** Encoding used for the alpha property. */
+  alphaEncoding?: 'f32' | 'r8';
+  /** Optional chunk-local splat encoding metadata. */
+  splatEncoding?: Record<string, unknown>;
+};
+
+/** Builds a deterministic Spark RADC chunk fixture. */
+function makeRADChunkFixture(options: RADChunkFixtureOptions = {}): ArrayBuffer {
+  const alphaPayload =
+    options.alphaEncoding === 'r8'
+      ? makeRADChunkPayload('alpha', 'r8', new Uint8Array([64, 191]), {min: 0, max: 1})
+      : makeRADChunkPayload('alpha', 'f32', encodeF32(new Float32Array([0.25, 0.75]), 1, 2));
+  const propertyPayloads = [
+    makeRADChunkPayload(
+      'center',
+      'f32_lebytes',
+      encodeF32LeBytes(new Float32Array([1, 2, 3, 4, 5, 6]), 3, 2),
+      {
+        compression: 'gz'
+      }
+    ),
+    alphaPayload,
+    makeRADChunkPayload(
+      'rgb',
+      'r8_delta',
+      encodeR8Delta(new Float32Array([0.25, 0.5, 0.75, 0.5, 0.75, 1]), 3, 2, 0, 1),
+      {min: 0, max: 1}
+    ),
+    makeRADChunkPayload(
+      'scales',
+      'ln_0r8',
+      encodeScaleR8(new Float32Array([0.02, 0.03, 0.04, 0.05, 0.06, 0.07]), 3, 2, -12, 9),
+      {min: -12, max: 9}
+    ),
+    makeRADChunkPayload('orientation', 'oct88r8', new Uint8Array([128, 128, 0, 128, 128, 0])),
+    makeRADChunkPayload('child_count', 'u16', new Uint8Array([0, 0, 2, 0])),
+    makeRADChunkPayload('child_start', 'u32', new Uint8Array([0, 0, 0, 0, 42, 0, 0, 0]))
+  ];
+  let payloadBytes = 0;
+  const properties = propertyPayloads.map(payload => {
+    const property = {
+      offset: payloadBytes,
+      bytes: payload.bytes.byteLength,
+      property: payload.property,
+      encoding: payload.encoding,
+      compression: payload.compression,
+      min: payload.min,
+      max: payload.max
+    };
+    payloadBytes += roundUpToEight(payload.bytes.byteLength);
+    return property;
+  });
+  const metadata = {
+    version: 1,
+    base: 0,
+    count: 2,
+    payloadBytes,
+    maxSh: 0,
+    lodTree: true,
+    splatEncoding: options.splatEncoding,
+    properties
+  };
+  const metadataBytes = new TextEncoder().encode(JSON.stringify(metadata));
+  const payloadByteLengthOffset = 8 + roundUpToEight(metadataBytes.byteLength);
+  const payloadByteOffset = payloadByteLengthOffset + 8;
+  const data = new ArrayBuffer(payloadByteOffset + payloadBytes);
+  const dataView = new DataView(data);
+  const bytes = new Uint8Array(data);
+
+  dataView.setUint32(0, 0x43444152, true);
+  dataView.setUint32(4, metadataBytes.byteLength, true);
+  bytes.set(metadataBytes, 8);
+  dataView.setBigUint64(payloadByteLengthOffset, BigInt(payloadBytes), true);
+  for (const payload of propertyPayloads) {
+    bytes.set(
+      payload.bytes,
+      payloadByteOffset + properties[propertyPayloads.indexOf(payload)].offset
+    );
+  }
+  return data;
+}
+
+/** One encoded RADC property fixture payload. */
+type RADChunkPayload = {
+  /** Property semantic name. */
+  property: string;
+  /** Property encoding name. */
+  encoding: string;
+  /** Encoded bytes. */
+  bytes: Uint8Array;
+  /** Optional property compression. */
+  compression?: string;
+  /** Optional quantization minimum. */
+  min?: number;
+  /** Optional quantization maximum. */
+  max?: number;
+};
+
+/** Builds one encoded RADC property fixture payload. */
+function makeRADChunkPayload(
+  property: string,
+  encoding: string,
+  bytes: Uint8Array,
+  options: {compression?: string; min?: number; max?: number} = {}
+): RADChunkPayload {
+  const encodedBytes =
+    options.compression === 'gz'
+      ? new Uint8Array(new DeflateCompression().compressSync(bytes.buffer.slice(0)))
+      : bytes;
+  return {property, encoding, bytes: encodedBytes, ...options};
+}
+
+/** Encodes row-major Float32 values into Spark planar f32 bytes. */
+function encodeF32(values: Float32Array, dimensions: number, count: number): Uint8Array {
+  const bytes = new Uint8Array(values.byteLength);
+  const dataView = new DataView(bytes.buffer);
+  for (let dimension = 0; dimension < dimensions; dimension++) {
+    for (let rowIndex = 0; rowIndex < count; rowIndex++) {
+      dataView.setFloat32(
+        (dimension * count + rowIndex) * 4,
+        values[rowIndex * dimensions + dimension],
+        true
+      );
+    }
+  }
+  return bytes;
+}
+
+/** Encodes row-major Float32 values into Spark byte-plane f32 bytes. */
+function encodeF32LeBytes(values: Float32Array, dimensions: number, count: number): Uint8Array {
+  const bytes = new Uint8Array(values.byteLength);
+  const scratch = new Uint8Array(4);
+  const scratchView = new DataView(scratch.buffer);
+  const stride = dimensions * count;
+  for (let byteIndex = 0; byteIndex < 4; byteIndex++) {
+    for (let dimension = 0; dimension < dimensions; dimension++) {
+      for (let rowIndex = 0; rowIndex < count; rowIndex++) {
+        scratchView.setFloat32(0, values[rowIndex * dimensions + dimension], true);
+        bytes[byteIndex * stride + dimension * count + rowIndex] = scratch[byteIndex];
+      }
+    }
+  }
+  return bytes;
+}
+
+/** Encodes row-major Float32 values into Spark delta R8 bytes. */
+function encodeR8Delta(
+  values: Float32Array,
+  dimensions: number,
+  count: number,
+  min: number,
+  max: number
+): Uint8Array {
+  const bytes = new Uint8Array(values.length);
+  for (let dimension = 0; dimension < dimensions; dimension++) {
+    let last = 0;
+    for (let rowIndex = 0; rowIndex < count; rowIndex++) {
+      const value = Math.round(
+        Math.min(
+          Math.max(((values[rowIndex * dimensions + dimension] - min) / (max - min)) * 255, 0),
+          255
+        )
+      );
+      bytes[dimension * count + rowIndex] = (value - last) & 0xff;
+      last = value;
+    }
+  }
+  return bytes;
+}
+
+/** Encodes row-major linear scales into Spark scale8 bytes. */
+function encodeScaleR8(
+  values: Float32Array,
+  dimensions: number,
+  count: number,
+  min: number,
+  max: number
+): Uint8Array {
+  const bytes = new Uint8Array(values.length);
+  for (let dimension = 0; dimension < dimensions; dimension++) {
+    for (let rowIndex = 0; rowIndex < count; rowIndex++) {
+      bytes[dimension * count + rowIndex] = encodeScale8(
+        values[rowIndex * dimensions + dimension],
+        min,
+        max
+      );
+    }
+  }
+  return bytes;
+}
+
+/** Encodes one linear scale into Spark scale8. */
+function encodeScale8(scale: number, min: number, max: number): number {
+  if (scale <= 0) {
+    return 0;
+  }
+  const normalized = (Math.log(scale) - min) / (max - min);
+  return 1 + Math.round(Math.min(Math.max(normalized, 0), 1) * 254);
+}
+
+/** Rounds fixture byte lengths to RAD's 8-byte alignment. */
+function roundUpToEight(byteLength: number): number {
+  return (byteLength + 7) & ~7;
+}

--- a/modules/splats/test/spz-loader.spec.ts
+++ b/modules/splats/test/spz-loader.spec.ts
@@ -1,0 +1,176 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'tape-promise/tape';
+import {parse} from '@loaders.gl/core';
+import {ZstdCompression} from '@loaders.gl/compression';
+import {SPZLoader} from '@loaders.gl/splats';
+import {SPZLoaderWithParser} from '@loaders.gl/splats/spz-loader';
+import {ZstdCodec} from 'zstd-codec';
+
+const modules = {'zstd-codec': ZstdCodec};
+
+test('SPZLoader parses Niantic Spatial v4 Gaussian splats', async t => {
+  const data = await makeSPZFixture();
+  const table = await parse(data, SPZLoader, {modules});
+
+  t.equal(table.shape, 'arrow-table', 'returns MeshArrowTable');
+  t.equal(table.topology, 'point-list', 'returns point-list topology');
+  t.equal(table.data.numRows, 2, 'parses row count');
+  t.equal(
+    table.data.schema.metadata.get('loaders_gl.gaussian_splats.source_format'),
+    'spz',
+    'adds source format metadata'
+  );
+  t.deepEqual(table.data.getChild('POSITION')?.get(0)?.toArray(), [1, 2, -3], 'parses position');
+  t.ok(Math.abs(Number(table.data.getChild('scale_1')?.get(0)) - 1) < 1e-6, 'decodes scale');
+  t.ok(
+    Math.abs(Number(table.data.getChild('opacity')?.get(1)) - 64 / 255) < 1e-6,
+    'decodes linear opacity'
+  );
+  t.ok(
+    Math.abs(Number(table.data.getChild('f_dc_0')?.get(0)) - (140 / 255 - 0.5) / 0.15) < 1e-6,
+    'decodes SPZ DC coefficient'
+  );
+  t.ok(Math.abs(Number(table.data.getChild('rot_0')?.get(0)) - 1) < 1e-6, 'decodes rotation');
+
+  const directTable = await SPZLoaderWithParser.parse(data, {modules});
+  t.equal(directTable.data.numRows, 2, 'parser subpath supports async parse');
+  t.end();
+});
+
+test('SPZLoader validates header', async t => {
+  await t.rejects(
+    () => SPZLoaderWithParser.parse(new ArrayBuffer(8), {modules}),
+    /32-byte header/,
+    'rejects missing header'
+  );
+
+  const data = await makeSPZFixture();
+  new DataView(data).setUint32(4, 3, true);
+  await t.rejects(
+    () => SPZLoaderWithParser.parse(data, {modules}),
+    /version 3 is not supported/,
+    'rejects unsupported version'
+  );
+  t.end();
+});
+
+/** Builds a deterministic two-row SPZ v4 fixture with compressed streams. */
+async function makeSPZFixture(): Promise<ArrayBuffer> {
+  const streams = [
+    makePositionStream(),
+    new Uint8Array([128, 64]),
+    new Uint8Array([140, 128, 128, 128, 255, 0]),
+    makeScaleStream(),
+    makeRotationStream()
+  ];
+  const compression = new ZstdCompression({modules});
+  await compression.preload(modules);
+  const compressedStreams = streams.map(
+    stream => new Uint8Array(compression.compressSync(stream.buffer))
+  );
+  const headerByteLength = 32;
+  const tocByteLength = compressedStreams.length * 16;
+  const byteLength =
+    headerByteLength +
+    tocByteLength +
+    compressedStreams.reduce((length, stream) => length + stream.byteLength, 0);
+  const data = new ArrayBuffer(byteLength);
+  const dataView = new DataView(data);
+  const bytes = new Uint8Array(data);
+
+  dataView.setUint32(0, 0x5053474e, true);
+  dataView.setUint32(4, 4, true);
+  dataView.setUint32(8, 2, true);
+  dataView.setUint8(12, 0);
+  dataView.setUint8(13, 12);
+  dataView.setUint8(14, 0);
+  dataView.setUint8(15, compressedStreams.length);
+  dataView.setUint32(16, headerByteLength, true);
+
+  let compressedOffset = headerByteLength + tocByteLength;
+  for (let streamIndex = 0; streamIndex < compressedStreams.length; streamIndex++) {
+    const tocOffset = headerByteLength + streamIndex * 16;
+    dataView.setBigUint64(tocOffset, BigInt(compressedStreams[streamIndex].byteLength), true);
+    dataView.setBigUint64(tocOffset + 8, BigInt(streams[streamIndex].byteLength), true);
+    bytes.set(compressedStreams[streamIndex], compressedOffset);
+    compressedOffset += compressedStreams[streamIndex].byteLength;
+  }
+
+  return data;
+}
+
+/** Builds packed 24-bit fixed-point position fixture bytes. */
+function makePositionStream(): Uint8Array {
+  const positions = new Uint8Array(18);
+  writeFixed24(positions, 0, 1 * 4096);
+  writeFixed24(positions, 3, 2 * 4096);
+  writeFixed24(positions, 6, -3 * 4096);
+  writeFixed24(positions, 9, 4 * 4096);
+  writeFixed24(positions, 12, 5 * 4096);
+  writeFixed24(positions, 15, 6 * 4096);
+  return positions;
+}
+
+/** Writes one signed little-endian 24-bit fixture value. */
+function writeFixed24(bytes: Uint8Array, byteOffset: number, value: number): void {
+  bytes[byteOffset + 0] = value & 0xff;
+  bytes[byteOffset + 1] = (value >> 8) & 0xff;
+  bytes[byteOffset + 2] = (value >> 16) & 0xff;
+}
+
+/** Builds packed log-scale fixture bytes. */
+function makeScaleStream(): Uint8Array {
+  return new Uint8Array([
+    encodeScale(2),
+    encodeScale(1),
+    encodeScale(0.5),
+    encodeScale(3),
+    encodeScale(4),
+    encodeScale(5)
+  ]);
+}
+
+/** Encodes a linear scale fixture value as an SPZ log-scale byte. */
+function encodeScale(value: number): number {
+  return Math.round((Math.log(value) + 10) * 16);
+}
+
+/** Builds packed smallest-three quaternion fixture bytes. */
+function makeRotationStream(): Uint8Array {
+  const rotations = new Uint8Array(8);
+  rotations.set(encodeQuaternionSmallestThree([0, 0, 0, 1]), 0);
+  rotations.set(encodeQuaternionSmallestThree([1, 0, 0, 0]), 4);
+  return rotations;
+}
+
+/** Encodes one `[x, y, z, w]` quaternion as SPZ smallest-three bytes. */
+function encodeQuaternionSmallestThree(quaternion: [number, number, number, number]): Uint8Array {
+  let largestComponent = 0;
+  for (let component = 1; component < 4; component++) {
+    if (Math.abs(quaternion[component]) > Math.abs(quaternion[largestComponent])) {
+      largestComponent = component;
+    }
+  }
+
+  const negate = quaternion[largestComponent] < 0;
+  let packed = largestComponent;
+  for (let component = 0; component < 4; component++) {
+    if (component !== largestComponent) {
+      const isNegative = quaternion[component] < 0 !== negate;
+      const magnitude = Math.round(
+        (((1 << 9) - 1) * Math.abs(quaternion[component])) / Math.SQRT1_2
+      );
+      packed = (packed << 10) | (Number(isNegative) << 9) | magnitude;
+    }
+  }
+
+  return new Uint8Array([
+    packed & 0xff,
+    (packed >>> 8) & 0xff,
+    (packed >>> 16) & 0xff,
+    (packed >>> 24) & 0xff
+  ]);
+}

--- a/modules/splats/tsconfig.json
+++ b/modules/splats/tsconfig.json
@@ -8,6 +8,7 @@
     "outDir": "dist"
   },
   "references": [
+    {"path": "../compression"},
     {"path": "../loader-utils"},
     {"path": "../schema"}
   ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -5771,9 +5771,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@loaders.gl/splats@workspace:modules/splats"
   dependencies:
+    "@loaders.gl/compression": "npm:4.4.0"
     "@loaders.gl/loader-utils": "npm:4.4.0"
     "@loaders.gl/schema": "npm:4.4.0"
     apache-arrow: "npm:>= 17.0.0"
+    zstd-codec: "npm:^0.1.0"
   peerDependencies:
     "@loaders.gl/core": ~4.4.0
   languageName: unknown
@@ -35696,7 +35698,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zstd-codec@npm:^0.1, zstd-codec@npm:^0.1.4":
+"zstd-codec@npm:^0.1, zstd-codec@npm:^0.1.0, zstd-codec@npm:^0.1.4":
   version: 0.1.5
   resolution: "zstd-codec@npm:0.1.5"
   checksum: 10c0/8b7e6d9ce86f00fc4ea16c949aab5538505a1f3f1a9c7c095b2a7308b4ed894deec7bdb2c614e1486a337abdce09a6e56282dc0e39fe9f880953b094f8c7810b


### PR DESCRIPTION
## Goals

Add SPZ and RAD splat loader support in a reviewable loader-only PR, separate from the renderer/demo changes.

Keep the package root aligned with the loader module split pattern: metadata loaders at the root, parser-bearing loaders behind explicit subpath entry points.

## Actual changes

- Adds SPZ loader metadata, parser entry point, options, tests, and documentation.
- Adds RAD loader/source support, options, tests, and documentation.
- Adds shared splat loader helpers and package exports for parser-bearing subpaths.
- Adds zstd decompression support needed by the RAD path.
- Updates splats module docs and lockfile entries.

## Validation

- `yarn`
- `yarn test-node modules/splats`
- `yarn lint fix`
- `yarn build`

`yarn build` completes with existing bundle warnings around LAS/Potree worker/dynamic import behavior.
