### PR TITLE
Fix tile LOD transitions: improve REPLACE refinement handling

### DIFF
--- a/modules/tiles/src/tileset-3d/common/tileset-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tileset-3d.ts
@@ -14,7 +14,7 @@ import {FrameState, getFrameState, limitSelectedTiles} from '../helpers/frame-st
 
 import type {GeospatialViewport, Viewport} from '../../types';
 import {Tile3D} from './tile-3d';
-import {TILESET_TYPE} from '../../constants';
+import {TILESET_TYPE, TILE_REFINEMENT} from '../../constants';
 
 import {TilesetTraverser} from './tileset-traverser';
 import {
@@ -200,7 +200,6 @@ export class Tileset3D {
   _cache = new TilesetCache();
   _requestScheduler: RequestScheduler;
 
-  private _heldTiles: Set<string> = new Set();
   private updatePromise: Promise<number> | null = null;
   tilesetInitializationPromise: Promise<void>;
 
@@ -410,31 +409,35 @@ export class Tileset3D {
 
     this.selectedTiles = this.options.onTraversalComplete(this.selectedTiles);
 
+    // Transition hold: keep parent tiles visible until their REPLACE children have drawn
+    // This prevents single-frame flashes during refinement transitions
     const selectedIds = new Set(this.selectedTiles.map(tile => tile.id));
-    const hasUndrawnTiles = this.selectedTiles.some(tile => !tile.tileDrawn);
+    const tilesToHoldBack: Tile3D[] = [];
 
-    let heldBackCount = 0;
-    if (hasUndrawnTiles) {
-      for (const tileId of selectedIds) {
-        this._heldTiles.add(tileId);
-      }
-      for (const tileId of this._heldTiles) {
-        if (selectedIds.has(tileId)) continue;
-
-        const tile = this._tiles[tileId];
-        if (tile && tile.contentAvailable) {
-          tile._selectedFrame = this._frameNumber;
-          this.selectedTiles.push(tile);
-          heldBackCount++;
-        } else {
-          this._heldTiles.delete(tileId);
+    // Check tiles that need REPLACE refinement transition hold
+    for (const tile of this.selectedTiles) {
+      // For tiles with REPLACE parents that were recently visible
+      if (
+        tile.parent &&
+        tile.parent.refine === TILE_REFINEMENT.REPLACE &&
+        tile.parent.contentAvailable &&
+        !tile.tileDrawn &&
+        !selectedIds.has(tile.parent.id)
+      ) {
+        // Hold the parent until this child (and any other selected siblings) have drawn
+        const parentTile = tile.parent;
+        if (!tilesToHoldBack.find(t => t.id === parentTile.id)) {
+          parentTile._selectedFrame = this._frameNumber;
+          tilesToHoldBack.push(parentTile);
         }
       }
-    } else {
-      this._heldTiles = selectedIds;
     }
 
-    if (heldBackCount > 0) {
+    // Add held tiles back to selection
+    if (tilesToHoldBack.length > 0) {
+      this.selectedTiles.push(...tilesToHoldBack);
+
+      // Schedule another update once tiles have drawn
       setTimeout(() => {
         this.selectTiles();
       }, 0);

--- a/modules/tiles/test/tileset/tileset-3d.spec.ts
+++ b/modules/tiles/test/tileset/tileset-3d.spec.ts
@@ -3,7 +3,7 @@
 
 import test from 'tape-promise/tape';
 import {coreApi, load} from '@loaders.gl/core';
-import {I3SSource, Tile3D, Tiles3DSource, Tileset3D} from '@loaders.gl/tiles';
+import {I3SSource, Tile3D, Tiles3DSource, Tileset3D, TILE_REFINEMENT} from '@loaders.gl/tiles';
 import {Tiles3DLoader} from '@loaders.gl/3d-tiles';
 import {getI3sTileHeader} from '@loaders.gl/i3s/test/test-utils/load-utils';
 // import {loadTileset} from '../utils/load-utils';
@@ -477,6 +477,8 @@ test('Tileset3D#transition hold keeps tiles visible until replacements draw', as
   const root = tileset.root as Tile3D;
   t.ok(root, 'root tile exists');
   t.ok(root.children.length > 0, 'root has children');
+
+  root.refine = TILE_REFINEMENT.REPLACE;
 
   // Load root content so contentAvailable becomes true
   // @ts-ignore


### PR DESCRIPTION
### Summary

Replace aggressive tile holding mechanism with precise REPLACE-only transitions:
- Remove global _heldTiles set that was holding all previously selected tiles
- Only hold parent tiles during REPLACE refinement when their selected children haven't drawn yet
- Prevents low LOD tiles from inappropriately blocking high LOD models
- Maintains smooth transitions without single-frame flashes

### Background

I found that from loaders.gl 9.3 onwards, LOD refinement wasn't working properly, at least on certain datasets.
The culprit seems to be https://github.com/visgl/loaders.gl/commit/bc88c2ebaaecdca9ab264ca203d083b78998bd1a
That commit does indeed get rid of the white flashes that happen when lower-LOD tiles are dropped before higher LOD tiles are ready, but it seems to be too aggressive in holding onto lower-LOD tiles. For the dataset I've been testing with, the lower LOD tiles never go away and are shown alongside the higher LODs, sometime occluding them and sometimes not, giving a mottled, mixed-LOD view.

Making the logic stateless - getting rid of the longer-lasting _heldTiles variable and instead just expanding the list of selectedTiles somewhat right after the list of selectedTiles is generated - seems to fix the issue.

Unfortunately, I don't own the datasets I've been testing with so I can't attach them to the PR - hopefully you can find another dataset with the same issue, let me know how this goes.

### Before this fix:

<img width="1070" height="815" alt="before-fix" src="https://github.com/user-attachments/assets/82e2030a-d435-4709-ad41-b5729d96529d" />

### After this fix:

<img width="1072" height="819" alt="after-fix" src="https://github.com/user-attachments/assets/34ef4728-4dd4-4933-822f-227e5d5cc667" />
