### PR TITLE
fix(i3s): Use string coordinate system constants for deck.gl 9.3+

### DIFF
--- a/modules/i3s/src/lib/parsers/constants.ts
+++ b/modules/i3s/src/lib/parsers/constants.ts
@@ -58,30 +58,31 @@ export const OBJECT_ID_ATTRIBUTE_TYPE = 'Oid32';
 export const FLOAT_64_TYPE = 'Float64';
 export const INT_16_ATTRIBUTE_TYPE = 'Int16';
 
-// https://github.com/visgl/deck.gl/blob/9548f43cba2234a1f4877b6b17f6c88eb35b2e08/modules/core/src/lib/constants.js#L27
-// Describes the format of positions
-export enum COORDINATE_SYSTEM {
+// deck.gl coordinate system constants as string literals.
+export const COORDINATE_SYSTEM = {
   /**
-   * `LNGLAT` if rendering into a geospatial viewport, `CARTESIAN` otherwise
+   * `LNGLAT` if rendering into a geospatial viewport, `CARTESIAN` otherwise.
    */
-  DEFAULT = -1,
+  DEFAULT: 'default',
   /**
-   * Positions are interpreted as [lng, lat, elevation]
-   * lng lat are degrees, elevation is meters. distances as meters.
+   * Positions are interpreted as [lng, lat, elevation].
+   * lng/lat are degrees, elevation is meters, distances are meters.
    */
-  LNGLAT = 1,
+  LNGLAT: 'lnglat',
   /**
-   * Positions are interpreted as meter offsets, distances as meters
+   * Positions are interpreted as meter offsets, distances as meters.
    */
-  METER_OFFSETS = 2,
+  METER_OFFSETS: 'meter-offsets',
   /**
-   * Positions are interpreted as lng lat offsets: [deltaLng, deltaLat, elevation]
-   * deltaLng, deltaLat are delta degrees, elevation is meters.
-   * distances as meters.
+   * Positions are interpreted as lng/lat offsets: [deltaLng, deltaLat, elevation].
+   * deltaLng/deltaLat are delta degrees, elevation is meters, distances are meters.
    */
-  LNGLAT_OFFSETS = 3,
+  LNGLAT_OFFSETS: 'lnglat-offsets',
   /**
-   * Non-geospatial
+   * Non-geospatial.
    */
-  CARTESIAN = 0
-}
+  CARTESIAN: 'cartesian'
+} as const;
+
+/** String coordinate systems shared with deck.gl layer props. */
+export type CoordinateSystem = (typeof COORDINATE_SYSTEM)[keyof typeof COORDINATE_SYSTEM];

--- a/modules/i3s/src/lib/parsers/parse-i3s-tile-content.ts
+++ b/modules/i3s/src/lib/parsers/parse-i3s-tile-content.ts
@@ -55,7 +55,7 @@ export async function parseI3STileContent(
     featureIds: [],
     vertexCount: 0,
     modelMatrix: new Matrix4(),
-    coordinateSystem: 0,
+    coordinateSystem: 'meter-offsets',
     byteLength: 0,
     texture: null
   };
@@ -195,15 +195,14 @@ async function parseI3SNodeGeometry(
 
   if (
     !options?.i3s?.coordinateSystem ||
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
     options.i3s.coordinateSystem === COORDINATE_SYSTEM.METER_OFFSETS
   ) {
     const enuMatrix = parsePositions(attributes.position, tileOptions);
     content.modelMatrix = enuMatrix.invert();
-    content.coordinateSystem = COORDINATE_SYSTEM.METER_OFFSETS;
+    content.coordinateSystem = 'meter-offsets';
   } else {
     content.modelMatrix = getModelMatrix(attributes.position);
-    content.coordinateSystem = COORDINATE_SYSTEM.LNGLAT_OFFSETS;
+    content.coordinateSystem = 'lnglat-offsets';
   }
 
   content.attributes = {

--- a/modules/i3s/src/types.ts
+++ b/modules/i3s/src/types.ts
@@ -3,6 +3,7 @@ import type {TypedArray, MeshAttribute, TextureLevel} from '@loaders.gl/schema';
 import {TILESET_TYPE, TILE_REFINEMENT, TILE_TYPE, Tile3D, Tileset3D} from '@loaders.gl/tiles';
 import I3SNodePagesTiles from './lib/helpers/i3s-nodepages-tiles';
 import {LoaderWithParser} from '@loaders.gl/loader-utils';
+import type {CoordinateSystem} from './lib/parsers/constants';
 
 export type COLOR = [number, number, number, number];
 
@@ -149,9 +150,9 @@ export type I3SParseOptions = {
   decodeTextures?: boolean;
   /** deck.gl compatible coordinate system.
    * https://github.com/visgl/deck.gl/blob/master/docs/developer-guide/coordinate-systems.md
-   * Supported coordinate systems: METER_OFFSETS, LNGLAT_OFFSETS
+   * Supported coordinate systems: `meter-offsets`, `lnglat-offsets`
    */
-  coordinateSystem?: number;
+  coordinateSystem?: CoordinateSystem;
   /** Options to colorize 3DObjects by attribute value */
   colorsByAttribute?: {
     /** Feature attribute name */
@@ -198,7 +199,7 @@ export type I3STileContent = {
   featureIds: number[] | TypedArray;
   vertexCount: number;
   modelMatrix: Matrix4;
-  coordinateSystem: number;
+  coordinateSystem: CoordinateSystem;
   byteLength: number;
   texture: TileContentTexture;
   [key: string]: any;


### PR DESCRIPTION
## Summary

- Replace numeric `COORDINATE_SYSTEM` enum with string literal values (`'meter-offsets'`, `'lnglat-offsets'`, etc.) matching deck.gl 9.3's expected format
- Fixes `Invalid coordinateSystem: 2` errors when using `@loaders.gl/i3s` with deck.gl 9.3+
- Backport of the coordinate system changes from master (originally landed in #3386) isolated to just the 3 affected files

Fixes #3449

## Test plan

- [ ] CI passes (lint, tests)
- [ ] Verify with deck.gl 9.3 that `Tile3DLayer` with an I3S tileset no longer throws `Invalid coordinateSystem: 2`
- [ ] Confirm backward compatibility — the `coordinateSystem` option on `I3SLoader` still accepts `'meter-offsets'` / `'lnglat-offsets'` strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public shape of `coordinateSystem` on I3S loader output and options (numbers → strings), which can break callers still expecting numeric deck.gl constants but is required for deck.gl 9.3+ rendering.
> 
> **Overview**
> **Fixes deck.gl 9.3+ `Invalid coordinateSystem: 2` errors** by emitting string coordinate systems on parsed I3S tile content instead of legacy numeric deck.gl constants.
> 
> `COORDINATE_SYSTEM` is changed from a numeric **enum** to a **const object** of string literals (`'meter-offsets'`, `'lnglat-offsets'`, etc.), with a new `CoordinateSystem` type. `parse-i3s-tile-content` now sets `content.coordinateSystem` to those strings (default `'meter-offsets'`), and `I3SParseOptions` / `I3STileContent` typings are updated from `number` to `CoordinateSystem`. The unsafe enum comparison eslint suppression is removed because comparisons use the string constants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c5f5ef600599753627237b5005ac850d9befabf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->