### PR TITLE
fix(tiles): Add groundHeightDatum option to fix culling of high-altitude region tilesets

### DIFF
--- a/docs/modules/tiles/api-reference/tileset-3d.md
+++ b/docs/modules/tiles/api-reference/tileset-3d.md
@@ -78,6 +78,7 @@ Parameters:
   - `options.loadOptions` - _loaders.gl_ options used when loading tiles from the tiling server. Includes `fetch` options such as authentication `headers`, worker options such as `maxConcurrency`, and options to other loaders such as `3d-tiles`, `gltf`, and `draco`.
   - `options.contentLoader` = `null` (`Promise`) - An optional external async content loader for the tile. Once the promise resolves, a tile is regarded as _READY_ to be displayed on the viewport.
   - `options.loadTiles`=`true` (`Boolean`) - Whether the tileset traverse and update tiles. Set this options to `false` during the run time to freeze the scene.
+  - `options.groundHeightDatum`=`'auto'` (`Number | 'auto'`) - Elevation in meters of the viewport's ground plane (z = 0) above the WGS84 ellipsoid, used to align the culling frustum with content whose bounding volumes carry absolute heights (3D Tiles `region` volumes at high altitude, e.g. alpine cities). `'auto'` derives it from the minimum height of the deepest loaded `region` containing the viewport center. Set an explicit number to override (e.g. the terrain height at the camera target), or `0` to disable. With deck.gl's `Tile3DLayer`, override via `onTilesetLoad: (tileset) => tileset.setProps({groundHeightDatum: 408})`.
 
 Callbacks:
 

--- a/modules/tiles/src/index.ts
+++ b/modules/tiles/src/index.ts
@@ -83,7 +83,8 @@ export {PointCloudTile} from './point-cloud/point-cloud-tile';
 export {createBoundingVolume} from './tileset-3d/helpers/bounding-volume';
 export {calculateTransformProps} from './tileset-3d/helpers/transform-utils';
 
-export {getFrameState} from './tileset-3d/helpers/frame-state';
+export {getFrameState, resolveGroundHeightDatum} from './tileset-3d/helpers/frame-state';
+export type {GetFrameStateOptions} from './tileset-3d/helpers/frame-state';
 export {getLodStatus} from './tileset-3d/helpers/i3s-lod';
 
 export {

--- a/modules/tiles/src/tileset-3d/common/tileset-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tileset-3d.ts
@@ -10,7 +10,12 @@ import {Stats} from '@probe.gl/stats';
 import {RequestScheduler, LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';
 import {TilesetCache} from './tileset-cache';
 import {calculateTransformProps} from '../helpers/transform-utils';
-import {FrameState, getFrameState, limitSelectedTiles} from '../helpers/frame-state';
+import {
+  FrameState,
+  getFrameState,
+  limitSelectedTiles,
+  resolveGroundHeightDatum
+} from '../helpers/frame-state';
 
 import type {GeospatialViewport, Viewport} from '../../types';
 import {Tile3D} from './tile-3d';
@@ -50,6 +55,15 @@ export type Tileset3DProps = {
   viewportTraversersMap?: any;
   updateTransforms?: boolean;
   viewDistanceScale?: number;
+  /**
+   * Elevation in meters of the viewport's ground plane (z = 0) above the WGS84 ellipsoid,
+   * used to align the culling frustum with content whose bounding volumes carry absolute
+   * heights (3D Tiles `region` volumes). `'auto'` (default) derives it from the minimum
+   * height of the deepest loaded `region` containing the viewport center (seeded by the
+   * root region); tilesets without region volumes resolve to 0. Set an explicit number
+   * to override, or 0 to disable.
+   */
+  groundHeightDatum?: number | 'auto';
 
   onTileLoad?: (tile: Tile3D) => any;
   onTileUnload?: (tile: Tile3D) => any;
@@ -83,6 +97,7 @@ type Props = {
   maximumScreenSpaceError: number;
   memoryAdjustedScreenSpaceError: boolean;
   viewportTraversersMap: Record<string, any> | null;
+  groundHeightDatum: number | 'auto';
   attributions: string[];
   loadTiles: boolean;
   loadOptions: LoaderOptions;
@@ -117,6 +132,7 @@ const DEFAULT_PROPS: Props = {
   loadTiles: true,
   updateTransforms: true,
   viewportTraversersMap: null,
+  groundHeightDatum: 'auto',
   loadOptions: {fetch: {}},
   attributions: [],
   basePath: '',
@@ -354,7 +370,13 @@ export class Tileset3D {
       if (!viewportsToTraverse.includes(id)) {
         continue;
       }
-      const frameState = getFrameState(viewport as GeospatialViewport, this._frameNumber);
+      const frameState = getFrameState(viewport as GeospatialViewport, this._frameNumber, {
+        groundHeightDatum: resolveGroundHeightDatum(
+          this.options.groundHeightDatum,
+          this.roots[id],
+          viewport as GeospatialViewport
+        )
+      });
       this._traverser.traverse(this.roots[id], frameState, this.options);
     }
   }

--- a/modules/tiles/src/tileset-3d/helpers/frame-state.ts
+++ b/modules/tiles/src/tileset-3d/helpers/frame-state.ts
@@ -18,6 +18,18 @@ export type FrameState = {
   sseDenominator: number; // Assumes fovy = 60 degrees
 };
 
+/** Options for {@link getFrameState}. */
+export type GetFrameStateOptions = {
+  /**
+   * Elevation in meters of the viewport's ground plane (z = 0) above the WGS84 ellipsoid.
+   * The viewport's `unprojectPosition` returns heights above the ground plane, while
+   * `region` bounding volumes carry absolute ellipsoidal heights, so the culling camera and
+   * frustum planes are lifted by this amount to align the culling frame with the content.
+   * Defaults to 0 (ground plane on the ellipsoid).
+   */
+  groundHeightDatum?: number;
+};
+
 const scratchVector = new Vector3();
 const scratchPosition = new Vector3();
 const cullingVolume = new CullingVolume([
@@ -31,18 +43,24 @@ const cullingVolume = new CullingVolume([
 
 // Extracts a frame state appropriate for tile culling from a deck.gl viewport
 // TODO - this could likely be generalized and merged back into deck.gl for other culling scenarios
-export function getFrameState(viewport: GeospatialViewport, frameNumber: number): FrameState {
+export function getFrameState(
+  viewport: GeospatialViewport,
+  frameNumber: number,
+  options: GetFrameStateOptions = {}
+): FrameState {
   // Traverse and and request. Update _selectedTiles so that we know what to render.
   // Traverse and and request. Update _selectedTiles so that we know what to render.
   const {cameraDirection, cameraUp, height} = viewport;
   const {metersPerUnit} = viewport.distanceScales;
+  const groundHeightDatum = options.groundHeightDatum ?? 0;
 
   // TODO - Ellipsoid.eastNorthUpToFixedFrame() breaks on raw array, create a Vector.
   // TODO - Ellipsoid.eastNorthUpToFixedFrame() takes a cartesian, is that intuitive?
-  const viewportCenterCartesian = worldToCartesian(viewport, viewport.center);
+  const viewportCenterCartesian = worldToCartesian(viewport, viewport.center, groundHeightDatum);
   const enuToFixedTransform = Ellipsoid.WGS84.eastNorthUpToFixedFrame(viewportCenterCartesian);
 
   const cameraPositionCartographic = viewport.unprojectPosition(viewport.cameraPosition);
+  cameraPositionCartographic[2] += groundHeightDatum;
   const cameraPositionCartesian = Ellipsoid.WGS84.cartographicToCartesian(
     cameraPositionCartographic,
     new Vector3()
@@ -58,7 +76,7 @@ export function getFrameState(viewport: GeospatialViewport, frameNumber: number)
     enuToFixedTransform.transformAsVector(new Vector3(cameraUp).scale(metersPerUnit))
   ).normalize();
 
-  commonSpacePlanesToWGS84(viewport);
+  commonSpacePlanesToWGS84(viewport, groundHeightDatum);
 
   const ViewportClass = viewport.constructor;
   const {longitude, latitude, width, bearing, zoom} = viewport;
@@ -129,14 +147,19 @@ export function limitSelectedTiles(
   return [selectedTiles, unselectedTiles];
 }
 
-function commonSpacePlanesToWGS84(viewport) {
+function commonSpacePlanesToWGS84(viewport, groundHeightDatum: number) {
   // Extract frustum planes based on current view.
   const frustumPlanes = viewport.getFrustumPlanes();
 
   // Get the near/far plane centers
   const nearCenterCommon = closestPointOnPlane(frustumPlanes.near, viewport.cameraPosition);
-  const nearCenterCartesian = worldToCartesian(viewport, nearCenterCommon);
-  const cameraCartesian = worldToCartesian(viewport, viewport.cameraPosition, scratchPosition);
+  const nearCenterCartesian = worldToCartesian(viewport, nearCenterCommon, groundHeightDatum);
+  const cameraCartesian = worldToCartesian(
+    viewport,
+    viewport.cameraPosition,
+    groundHeightDatum,
+    scratchPosition
+  );
 
   let i = 0;
   cullingVolume.planes[i++].fromPointNormal(
@@ -150,7 +173,7 @@ function commonSpacePlanesToWGS84(viewport) {
     }
     const plane = frustumPlanes[dir];
     const posCommon = closestPointOnPlane(plane, nearCenterCommon, scratchPosition);
-    const cartesianPos = worldToCartesian(viewport, posCommon, scratchPosition);
+    const cartesianPos = worldToCartesian(viewport, posCommon, groundHeightDatum, scratchPosition);
 
     cullingVolume.planes[i++].fromPointNormal(
       cartesianPos,
@@ -176,8 +199,89 @@ function closestPointOnPlane(
 function worldToCartesian(
   viewport: Viewport,
   point: number[] | Vector3,
+  groundHeightDatum: number,
   out: Vector3 = new Vector3()
 ): Vector3 {
   const cartographicPos = viewport.unprojectPosition(point);
+  // `unprojectPosition` heights are relative to the viewport's ground plane, but
+  // `cartographicToCartesian` expects heights above the ellipsoid.
+  cartographicPos[2] += groundHeightDatum;
   return Ellipsoid.WGS84.cartographicToCartesian(cartographicPos, out);
+}
+
+/** Minimal tile-tree shape needed for ground-height derivation (structural subset of Tile3D). */
+type RegionTileNode = {
+  header?: {boundingVolume?: {region?: number[]}} | null;
+  children?: RegionTileNode[] | null;
+};
+
+/**
+ * Resolves the `groundHeightDatum` tileset option to a concrete elevation in meters.
+ * @param groundHeightDatum Elevation in meters of the viewport's ground plane above the
+ *   WGS84 ellipsoid, or `'auto'` to derive it from `region` bounding volumes.
+ * @param rootTile Root of the (partially loaded) tile tree used for `'auto'` derivation:
+ *   the minimum height of the deepest loaded `region` containing the viewport center wins,
+ *   seeded by the root region's minimum height. Tilesets without region volumes
+ *   (`box`/`sphere`/I3S) resolve to 0.
+ * @param viewportCenter Viewport center in degrees, used to pick the containing regions.
+ * @returns The ground plane elevation in meters (0 when nothing can be derived).
+ */
+export function resolveGroundHeightDatum(
+  groundHeightDatum: number | 'auto',
+  rootTile?: RegionTileNode | null,
+  viewportCenter?: {longitude: number; latitude: number} | null
+): number {
+  if (typeof groundHeightDatum === 'number') {
+    return Number.isFinite(groundHeightDatum) ? groundHeightDatum : 0;
+  }
+  let datum = getRegionMinimumHeight(rootTile?.header?.boundingVolume?.region) ?? 0;
+  if (!rootTile || !viewportCenter) {
+    return datum;
+  }
+
+  // Descend to the deepest loaded region containing the viewport center. The tree deepens
+  // as external tilesets load, so successive frames converge on the local ground height.
+  const longitudeRadians = (viewportCenter.longitude * Math.PI) / 180;
+  const latitudeRadians = (viewportCenter.latitude * Math.PI) / 180;
+  let currentTile: RegionTileNode | null = rootTile;
+  const visitedTiles = new Set<RegionTileNode>();
+  while (currentTile && !visitedTiles.has(currentTile)) {
+    visitedTiles.add(currentTile);
+    let nextTile: RegionTileNode | null = null;
+    for (const childTile of currentTile.children || []) {
+      const region = childTile?.header?.boundingVolume?.region;
+      if (!regionContains(region, longitudeRadians, latitudeRadians)) {
+        continue; // eslint-disable-line no-continue
+      }
+      const minimumHeight = getRegionMinimumHeight(region);
+      if (minimumHeight !== null) {
+        datum = Math.max(datum, minimumHeight);
+      }
+      nextTile = nextTile || childTile;
+    }
+    currentTile = nextTile;
+  }
+  return datum;
+}
+
+function getRegionMinimumHeight(region: number[] | undefined | null): number | null {
+  const minimumHeight = region?.[4];
+  return typeof minimumHeight === 'number' && Number.isFinite(minimumHeight) ? minimumHeight : null;
+}
+
+function regionContains(
+  region: number[] | undefined | null,
+  longitudeRadians: number,
+  latitudeRadians: number
+): boolean {
+  if (!Array.isArray(region) || region.length < 6) {
+    return false;
+  }
+  const [west, south, east, north] = region;
+  return (
+    west <= longitudeRadians &&
+    longitudeRadians <= east &&
+    south <= latitudeRadians &&
+    latitudeRadians <= north
+  );
 }

--- a/modules/tiles/test/index.ts
+++ b/modules/tiles/test/index.ts
@@ -10,6 +10,7 @@ import './tileset/tileset-3d-source.spec';
 import './tileset/tileset-traverser.spec';
 
 import './tileset/helpers/get-frame-state.spec';
+import './tileset/helpers/ground-height-datum.spec';
 import './tileset/helpers/zoom.spec';
 import './tileset/helpers/bounding-volume.spec';
 import './tileset/tileset-2d.spec';

--- a/modules/tiles/test/tileset/helpers/get-frame-state.spec.ts
+++ b/modules/tiles/test/tileset/helpers/get-frame-state.spec.ts
@@ -5,8 +5,10 @@
 import test from 'tape-promise/tape';
 import {getFrameState} from '@loaders.gl/tiles';
 import {WebMercatorViewport, FirstPersonView} from '@deck.gl/core';
-import {equals, Vector3} from '@math.gl/core';
+import {equals, radians, Matrix4, Vector3} from '@math.gl/core';
+import {CullingVolume} from '@math.gl/culling';
 import {Ellipsoid} from '@math.gl/geospatial';
+import {createBoundingVolume} from '../../../src/tileset-3d/helpers/bounding-volume';
 
 const EPSILON = 1e-5;
 const expected = {
@@ -56,6 +58,99 @@ test('getFrameState', t => {
       'viewport center is on the inside of the frustum plane'
     );
   }
+
+  t.end();
+});
+
+test('getFrameState#groundHeightDatum lifts the culling frame uniformly', t => {
+  const viewport = new WebMercatorViewport({
+    width: 793,
+    height: 775,
+    latitude: 50.751537058389985,
+    longitude: 42.42694203247012,
+    pitch: 30,
+    bearing: -120,
+    zoom: 15.5
+  });
+
+  // getFrameState returns a module-level singleton cullingVolume, so extract everything
+  // needed from one call before making the next.
+  const base = getFrameState(viewport, 1);
+  const baseCartographic = Ellipsoid.WGS84.cartesianToCartographic(
+    new Vector3(base.camera.position),
+    new Vector3()
+  );
+
+  const shifted = getFrameState(viewport, 2, {groundHeightDatum: 500});
+  const shiftedCartographic = Ellipsoid.WGS84.cartesianToCartographic(
+    new Vector3(shifted.camera.position),
+    new Vector3()
+  );
+
+  t.ok(
+    Math.abs(shiftedCartographic[2] - baseCartographic[2] - 500) < 1e-3,
+    'camera cartographic height shifts by exactly the datum'
+  );
+  t.ok(
+    Math.abs(shiftedCartographic[0] - baseCartographic[0]) < 1e-9 &&
+      Math.abs(shiftedCartographic[1] - baseCartographic[1]) < 1e-9,
+    'camera longitude/latitude are unchanged'
+  );
+
+  const liftedCenterCartesian = Ellipsoid.WGS84.cartographicToCartesian(
+    [viewport.longitude, viewport.latitude, 500],
+    new Vector3()
+  );
+  for (const plane of shifted.cullingVolume.planes) {
+    t.ok(
+      plane.getPointDistance(liftedCenterCartesian) >= 0,
+      'viewport center at datum altitude is on the inside of the frustum plane'
+    );
+  }
+
+  t.end();
+});
+
+test('getFrameState#groundHeightDatum un-culls high-altitude region tiles (#3475)', t => {
+  // Bahnhofstrasse, Zürich: swisstopo swissBUILDINGS3D leaf regions sit at 405-438 m
+  // above the ellipsoid. At street zoom the camera is only ~194 m above deck's z=0
+  // plane, so a sea-level culling frame places the volumes above the frustum entirely.
+  const viewport = new WebMercatorViewport({
+    width: 898,
+    height: 320,
+    longitude: 8.5391,
+    latitude: 47.3686,
+    zoom: 17,
+    pitch: 0,
+    bearing: 0
+  });
+  const region = [radians(8.5381), radians(47.3676), radians(8.5401), radians(47.3696), 405, 438];
+  const boundingVolume = createBoundingVolume({region}, new Matrix4());
+
+  const seaLevelFrame = getFrameState(viewport, 1);
+  const seaLevelMask = seaLevelFrame.cullingVolume.computeVisibilityWithPlaneMask(
+    boundingVolume,
+    CullingVolume.MASK_INDETERMINATE
+  );
+
+  // 405 = the local ground height at the viewport center — what the 'auto' derivation
+  // converges to once the leaf-level regions are loaded.
+  const datumFrame = getFrameState(viewport, 2, {groundHeightDatum: 405});
+  const datumMask = datumFrame.cullingVolume.computeVisibilityWithPlaneMask(
+    boundingVolume,
+    CullingVolume.MASK_INDETERMINATE
+  );
+
+  t.equals(
+    seaLevelMask,
+    CullingVolume.MASK_OUTSIDE,
+    'sea-level culling frame culls the high-altitude volume (bug precondition)'
+  );
+  t.notEqual(
+    datumMask,
+    CullingVolume.MASK_OUTSIDE,
+    'ground-datum culling frame keeps the high-altitude volume'
+  );
 
   t.end();
 });

--- a/modules/tiles/test/tileset/helpers/ground-height-datum.spec.ts
+++ b/modules/tiles/test/tileset/helpers/ground-height-datum.spec.ts
@@ -1,0 +1,161 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'tape-promise/tape';
+import {resolveGroundHeightDatum} from '../../../src/tileset-3d/helpers/frame-state';
+
+// Root region of the swisstopo swissBUILDINGS3D tileset (issue #3475):
+// [west, south, east, north, minimumHeight, maximumHeight], angles in radians, heights in meters.
+const SWISS_ROOT_REGION = [
+  0.10401182679403116, 0.7996693586576467, 0.18312399144408265, 0.8343189318329005, 149.268,
+  4563.933
+];
+
+// Bahnhofstrasse, Zürich — inside the root region.
+const ZURICH = {longitude: 8.5391, latitude: 47.3686};
+const ZURICH_LON_RAD = (ZURICH.longitude * Math.PI) / 180;
+const ZURICH_LAT_RAD = (ZURICH.latitude * Math.PI) / 180;
+
+function regionAroundZurich(minimumHeight: number, maximumHeight: number, paddingRadians = 0.001) {
+  return [
+    ZURICH_LON_RAD - paddingRadians,
+    ZURICH_LAT_RAD - paddingRadians,
+    ZURICH_LON_RAD + paddingRadians,
+    ZURICH_LAT_RAD + paddingRadians,
+    minimumHeight,
+    maximumHeight
+  ];
+}
+
+const SWISS_ROOT_TILE = {header: {boundingVolume: {region: SWISS_ROOT_REGION}}};
+
+test('resolveGroundHeightDatum#explicit number overrides auto derivation', t => {
+  t.equals(
+    resolveGroundHeightDatum(250, SWISS_ROOT_TILE, ZURICH),
+    250,
+    'explicit datum wins over region-derived heights'
+  );
+  t.equals(
+    resolveGroundHeightDatum(0, SWISS_ROOT_TILE, ZURICH),
+    0,
+    'explicit 0 disables auto derivation'
+  );
+  t.equals(
+    resolveGroundHeightDatum(-100, SWISS_ROOT_TILE, ZURICH),
+    -100,
+    'negative explicit datum is preserved'
+  );
+  t.equals(
+    resolveGroundHeightDatum(NaN, SWISS_ROOT_TILE, ZURICH),
+    0,
+    'non-finite explicit datum resolves to 0'
+  );
+  t.end();
+});
+
+test('resolveGroundHeightDatum#auto derives the root region minimum height', t => {
+  t.equals(
+    resolveGroundHeightDatum('auto', SWISS_ROOT_TILE, ZURICH),
+    149.268,
+    'auto resolves to the root region minimumHeight when no children are loaded'
+  );
+  t.equals(
+    resolveGroundHeightDatum(
+      'auto',
+      {header: {boundingVolume: {region: [0, 0, 1, 1, -100, 50]}}},
+      {longitude: 28.6, latitude: 28.6}
+    ),
+    -100,
+    'below-sea-level region minimum is preserved'
+  );
+  t.end();
+});
+
+test('resolveGroundHeightDatum#auto refines to the deepest loaded region containing the viewport center', t => {
+  const rootTile = {
+    header: {boundingVolume: {region: SWISS_ROOT_REGION}},
+    children: [
+      {
+        // Contains Zürich — should be descended.
+        header: {boundingVolume: {region: regionAroundZurich(395, 493, 0.01)}},
+        children: [
+          {
+            // Leaf region around the viewport center: local ground ≈ 405 m.
+            header: {boundingVolume: {region: regionAroundZurich(405, 438)}}
+          },
+          {
+            // Does NOT contain the viewport center — must be ignored despite higher minimum.
+            header: {boundingVolume: {region: [0.11, 0.8, 0.112, 0.802, 1600, 1900]}}
+          }
+        ]
+      },
+      {
+        // Sibling not containing Zürich.
+        header: {boundingVolume: {region: [0.17, 0.82, 0.18, 0.83, 900, 1200]}}
+      }
+    ]
+  };
+
+  t.equals(
+    resolveGroundHeightDatum('auto', rootTile, ZURICH),
+    405,
+    'auto resolves to the deepest loaded containing region minimumHeight'
+  );
+  t.equals(
+    resolveGroundHeightDatum('auto', rootTile, {longitude: 120, latitude: -30}),
+    149.268,
+    'viewport center outside all child regions falls back to the root region minimumHeight'
+  );
+  t.end();
+});
+
+test('resolveGroundHeightDatum#auto falls back to 0 without a usable region', t => {
+  t.equals(
+    resolveGroundHeightDatum(
+      'auto',
+      {header: {boundingVolume: {box: [0, 0, 0, 8000000, 0, 0, 0, 8000000, 0, 0, 0, 8000000]}}},
+      ZURICH
+    ),
+    0,
+    'box bounding volume resolves to 0'
+  );
+  t.equals(
+    resolveGroundHeightDatum('auto', {header: {boundingVolume: {sphere: [0, 0, 0, 5000]}}}, ZURICH),
+    0,
+    'sphere bounding volume resolves to 0'
+  );
+  t.equals(
+    resolveGroundHeightDatum('auto', {header: {}}, ZURICH),
+    0,
+    'header without bounding volume resolves to 0'
+  );
+  t.equals(resolveGroundHeightDatum('auto', null, ZURICH), 0, 'null tile resolves to 0');
+  t.equals(resolveGroundHeightDatum('auto', undefined, ZURICH), 0, 'missing tile resolves to 0');
+  t.equals(
+    resolveGroundHeightDatum('auto', {header: {boundingVolume: {region: [0, 0, 1, 1]}}}, ZURICH),
+    0,
+    'truncated region resolves to 0'
+  );
+  t.equals(
+    resolveGroundHeightDatum(
+      'auto',
+      {header: {boundingVolume: {region: [0, 0, 1, 1, NaN, 50]}}},
+      ZURICH
+    ),
+    0,
+    'non-finite region minimum resolves to 0'
+  );
+  t.end();
+});
+
+test('resolveGroundHeightDatum#auto terminates on cyclic tile graphs', t => {
+  const cyclic: any = {header: {boundingVolume: {region: regionAroundZurich(400, 450)}}};
+  cyclic.children = [cyclic];
+  t.equals(
+    resolveGroundHeightDatum('auto', cyclic, ZURICH),
+    400,
+    'cyclic children do not hang the derivation'
+  );
+  t.end();
+});

--- a/modules/tiles/test/tileset/tileset-3d-traversal.spec.ts
+++ b/modules/tiles/test/tileset/tileset-3d-traversal.spec.ts
@@ -253,6 +253,36 @@ test('Tileset3D#viewportTraversersMap (one viewport shows tiles selected for ano
   t.equals(tileset.selectedTiles.filter(tile => tile.viewportIds.includes('view1')).length, 5);
 });
 
+test('Tileset3D#groundHeightDatum option reaches the culling frame', async t => {
+  const tilesetJson = await load(TILESET_URL, Tiles3DLoader);
+  const viewport = VIEWPORTS[0];
+
+  // An extreme datum lifts the culling frame ~1000 km above the tileset, so everything culls.
+  const lifted = new Tileset3D(new Tiles3DSource({...tilesetJson, coreApi}), {
+    groundHeightDatum: 1_000_000
+  });
+  await lifted.selectTiles(viewport);
+  t.equals(
+    lifted.roots[viewport.id].isVisible,
+    false,
+    'root is culled under an extreme ground-height datum'
+  );
+  t.equals(
+    lifted.selectedTiles.length,
+    0,
+    'no tiles are selected under an extreme ground-height datum'
+  );
+
+  const control = new Tileset3D(new Tiles3DSource({...tilesetJson, coreApi}), {});
+  await control.selectTiles(viewport);
+  t.equals(
+    control.roots[viewport.id].isVisible,
+    true,
+    'root stays visible with default options (auto datum, sea-level fixture)'
+  );
+  t.end();
+});
+
 test('Tileset3D#loadTiles option', async t => {
   t.plan(2);
   const tilesetJson = await load(TILESET_URL, Tiles3DLoader);


### PR DESCRIPTION
Fixes #3475

## Goals

`Tileset3D` (and therefore deck.gl's `Tile3DLayer`) culls **all content tiles** of a 3D Tiles dataset whose geometry sits at real altitude (e.g. Switzerland, ~400–1500 m a.s.l.) whenever the viewport is zoomed to street level — the tileset JSON hierarchy loads, but no `.b3dm` is ever requested.

Root cause (diagnosed in #3475): `getFrameState()` builds the culling camera and all six frustum planes by feeding `viewport.unprojectPosition(point)` — whose z is metres above deck's z=0 map plane — directly into `Ellipsoid.WGS84.cartographicToCartesian(...)`, which interprets that z as metres above the WGS84 ellipsoid. No ground datum exists, so the culling frame is always built at sea level. `region` bounding volumes are spec-absolute (they ignore transforms), so for high-altitude content the tight leaf volumes fall outside the street-zoom frustum and are culled before any content request. No `modelMatrix` workaround exists.

This PR aligns the culling frame with the content by introducing a **ground-height datum**: the elevation of the viewport's ground plane above the ellipsoid, applied as a uniform vertical re-anchor of the whole culling frame — auto-derived from the tileset's `region` volumes by default, overridable via a new public option.

## Changes

- **`modules/tiles/src/tileset-3d/helpers/frame-state.ts`**
  - `getFrameState(viewport, frameNumber, options?)` — new optional third parameter (`GetFrameStateOptions`) with `groundHeightDatum` (metres). The datum is added to the z of the camera cartographic and every `worldToCartesian` conversion (ENU origin + all six culling-plane anchor points). Default `0` → output identical to before (backward compatible for the existing 2-arg public call signature).
  - New exported `resolveGroundHeightDatum(option, rootTile, viewportCenter)` — resolves the tileset option: an explicit number wins; `'auto'` derives the minimum height of the **deepest loaded `region` containing the viewport center**, seeded by the root region's `minimumHeight`. The tile tree deepens as external tilesets load, so successive traversal frames converge on the local ground height (root-region-only derivation is not sufficient for country-scale tilesets: the swisstopo root spans 149–4564 m while Zürich's local ground is ~408 m). Tilesets without `region` volumes (box/sphere/I3S) resolve to `0` → exact no-op.
- **`modules/tiles/src/tileset-3d/common/tileset-3d.ts`** — new `groundHeightDatum?: number | 'auto'` option (default `'auto'`), resolved per viewport per frame in `doUpdate()`, so `tileset.setProps({groundHeightDatum})` works at runtime — that is also the override path for deck.gl `Tile3DLayer` users: `onTilesetLoad: (tileset) => tileset.setProps({groundHeightDatum: 408})`.
- **`modules/tiles/src/index.ts`** — export `resolveGroundHeightDatum` + `GetFrameStateOptions`.
- **`docs/modules/tiles/api-reference/tileset-3d.md`** — option documented.
- **Tests**
  - `modules/tiles/test/tileset/helpers/ground-height-datum.spec.ts` (new, node + browser): resolver unit tests — explicit override (incl. explicit `0` to disable), root-region derivation, deepest-containing-region refinement, non-region fallbacks, cyclic-graph termination.
  - `modules/tiles/test/tileset/helpers/get-frame-state.spec.ts`: datum shifts the camera cartographic height by exactly the datum with lon/lat unchanged and all six planes lifted; regression test reproducing #3475 (Zürich street-zoom viewport + a 405–438 m region OBB: culled at sea level, kept with the local-ground datum).
  - `modules/tiles/test/tileset/tileset-3d-traversal.spec.ts`: option wiring — an extreme datum culls the whole (sea-level) fixture; default options leave it visible.

## Verification

The issue's standalone node repro (adapted only for the 5.0 `Tiles3DSource` constructor), swisstopo swissBUILDINGS3D over Zürich, **no options passed** (pure default `'auto'`):

Before (master `f7a4b32`):

```
SUMMARY: zoomed-out b3dm requests = 6; street-zoom b3dm requests = 0
REPRODUCED: identical tileset + identical code path; only the viewport differs.
```

After:

```
=== street zoom (898x320 zoom 17)
.b3dm content tiles REQUESTED: 6  e.g. 11/1165/1601.b3dm
leaf->root visibility (leaf first): vis=true dist=161 hmin=405 hmax=438  <-  vis=true dist=158 ...
SUMMARY: zoomed-out b3dm requests = 20; street-zoom b3dm requests = 6
not reproduced in this environment
```

`yarn test-node` and `yarn test-headless` fully green; `yarn build` and `yarn lint fix` clean.

## Behavior notes

- Sea-level `region` tilesets (minimumHeight ≈ 0), box/sphere tilesets and I3S resolve to datum 0 — default-path output is unchanged (the untouched existing suites are the regression net).
- High-altitude `region` tilesets see two intended changes: content stops being wrongly culled, and camera-to-tile distances now match the content frame, so SSE refines slightly more (the zoomed-out Zürich viewport goes from 6 to 20 b3dm requests because distances are no longer inflated by the missing ~400 m).
- `'auto'` is best-effort and converges as region headers load; for degenerate cases (extreme relief inside one leaf region, unusual viewports) the explicit option is the escape hatch.
- I3S's `getProjectedRadius` performs its own datum-less conversion; `'auto'` resolves to 0 for I3S so I3S defaults are consistent (pre-existing gap, out of scope here).
- Happy to backport to `4.4-release` if wanted — we hit this in production on 4.4.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
