### PR TITLE
chore(kml): update xmldom to 0.8.12

### DIFF
--- a/modules/kml/package.json
+++ b/modules/kml/package.json
@@ -45,7 +45,7 @@
     "@loaders.gl/loader-utils": "4.4.3",
     "@loaders.gl/schema": "4.4.3",
     "@tmcw/togeojson": "^4.5.0",
-    "@xmldom/xmldom": "^0.7.13"
+    "@xmldom/xmldom": "^0.8.12"
   },
   "peerDependencies": {
     "@loaders.gl/core": "~4.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4703,7 +4703,7 @@ __metadata:
     "@loaders.gl/loader-utils": "npm:4.4.3"
     "@loaders.gl/schema": "npm:4.4.3"
     "@tmcw/togeojson": "npm:^4.5.0"
-    "@xmldom/xmldom": "npm:^0.7.13"
+    "@xmldom/xmldom": "npm:^0.8.12"
   peerDependencies:
     "@loaders.gl/core": ~4.4.0
   languageName: unknown
@@ -9817,10 +9817,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmldom/xmldom@npm:^0.7.13":
-  version: 0.7.13
-  resolution: "@xmldom/xmldom@npm:0.7.13"
-  checksum: 10c0/cb02e4e8d986acf18578a5f25d1bce5e18d08718f40d8a0cdd922a4c112c8e00daf94de4e43f9556ed147c696b135f2ab81fa9a2a8a0416f60af15d156b60e40
+"@xmldom/xmldom@npm:^0.8.12":
+  version: 0.8.12
+  resolution: "@xmldom/xmldom@npm:0.8.12"
+  checksum: 10c0/b733c84292d1bee32ef21a05aba8f9063456b51a54068d0b4a1abf5545156ee0b9894b7ae23775b5881b11c35a8a03871d1b514fb7e1b11654cdbee57e1c2707
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Backports the KML dependency update from `master` to the 4.4 patch line.

- updates `@xmldom/xmldom` from 0.7.13 to 0.8.12
- refreshes the Yarn lock entry
- preserves the original commit provenance in the commit message

Original commit: b26c9d3c083ae482a0d0cc5c0517cfaf99518614

## Validation

- `yarn test node`: 6,543 passing
- `yarn lint fix`: ran, but the repository-wide check remains blocked by 12 pre-existing `BufferPolyfill not found in @loaders.gl/parquet` errors in parquet tests; no unrelated files changed