### PR TITLE
fix(schema-utils): declare @math.gl/types explicitly

### DIFF
--- a/modules/schema-utils/package.json
+++ b/modules/schema-utils/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@loaders.gl/schema": "4.4.3",
+    "@math.gl/types": "^4.1.0",
     "@types/geojson": "^7946.0.7",
     "apache-arrow": ">= 17.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4917,6 +4917,7 @@ __metadata:
   resolution: "@loaders.gl/schema-utils@workspace:modules/schema-utils"
   dependencies:
     "@loaders.gl/schema": "npm:4.4.3"
+    "@math.gl/types": "npm:^4.1.0"
     "@types/geojson": "npm:^7946.0.7"
     apache-arrow: "npm:>= 17.0.0"
   peerDependencies:


### PR DESCRIPTION
## Summary

Backports the explicit `@math.gl/types` dependency declaration from `master` to the 4.4 patch line.

`schema-utils` imports types from this package directly, so declaring it avoids relying on transitive dependency layout.

Original commit: fed90d8ae5f496cc75424ef77cff7c1c16dc594b

## Validation

- `yarn test node`: 6,543 passing
- `yarn lint fix`: ran, but the repository-wide check remains blocked by 12 pre-existing `BufferPolyfill not found in @loaders.gl/parquet` errors in parquet tests; no unrelated files changed