### PR TITLE
fix(json): emit only complete streaming elements

### DIFF
--- a/modules/json/src/lib/json-parser/streaming-json-parser.ts
+++ b/modules/json/src/lib/json-parser/streaming-json-parser.ts
@@ -10,9 +10,15 @@ import JSONPath from '../jsonpath/jsonpath';
  * and emits an array of chunks
  */
 export default class StreamingJSONParser extends JSONParser {
+  /** JSONPaths that identify arrays eligible for streaming. */
   private jsonPaths: JSONPath[];
+  /** JSONPath of the selected streaming array. */
   private streamingJsonPath: JSONPath | null = null;
+  /** Parser-owned array for the selected streaming rows. */
   private streamingArray: any[] | null = null;
+  /** Number of direct streaming-array children that are fully parsed and ready to emit. */
+  private completedStreamingRowCount: number = 0;
+  /** Root object used by metadata batches when streaming an embedded array. */
   private topLevelObject: object | null = null;
 
   constructor(options: {[key: string]: any} = {}) {
@@ -42,6 +48,30 @@ export default class StreamingJSONParser extends JSONParser {
         if (typeof name !== 'undefined') {
           this.parser.emit('onkey', name);
         }
+      },
+
+      oncloseobject: () => {
+        const directStreamingChild = this._isClosingDirectStreamingChild();
+        this._closeObject();
+        if (directStreamingChild) {
+          this.completedStreamingRowCount++;
+        }
+      },
+
+      onclosearray: () => {
+        const directStreamingChild = this._isClosingDirectStreamingChild();
+        this._closeArray();
+        if (directStreamingChild) {
+          this.completedStreamingRowCount++;
+        }
+      },
+
+      onvalue: (value) => {
+        const directStreamingValue = this._isInStreamingArray();
+        this._pushOrSet(value);
+        if (directStreamingValue) {
+          this.completedStreamingRowCount++;
+        }
       }
     });
     const jsonpaths = options.jsonpaths || [];
@@ -57,12 +87,7 @@ export default class StreamingJSONParser extends JSONParser {
    */
   write(chunk) {
     super.write(chunk);
-    let array: any[] = [];
-    if (this.streamingArray) {
-      array = [...this.streamingArray];
-      this.streamingArray.length = 0;
-    }
-    return array;
+    return this._drainCompletedRows();
   }
 
   /**
@@ -87,6 +112,41 @@ export default class StreamingJSONParser extends JSONParser {
   }
 
   // PRIVATE METHODS
+
+  /**
+   * Returns completed rows and removes them from the parser-owned streaming array.
+   */
+  _drainCompletedRows(): any[] {
+    if (!this.streamingArray || this.completedStreamingRowCount === 0) {
+      return [];
+    }
+
+    const rows = this.streamingArray.slice(0, this.completedStreamingRowCount);
+    this.streamingArray.splice(0, this.completedStreamingRowCount);
+    this.completedStreamingRowCount = 0;
+    return rows;
+  }
+
+  /**
+   * Checks whether the parser is currently writing a direct value into the streaming array.
+   */
+  _isInStreamingArray(): boolean {
+    return Boolean(this.streamingArray && this.currentState.container === this.streamingArray);
+  }
+
+  /**
+   * Checks whether the current close event completes a direct streaming-array child.
+   */
+  _isClosingDirectStreamingChild(): boolean {
+    if (!this.streamingArray || this.currentState.container === this.streamingArray) {
+      return false;
+    }
+
+    const parentState = (this.previousStates as Array<{container: unknown}>)[
+      this.previousStates.length - 1
+    ];
+    return parentState?.container === this.streamingArray;
+  }
 
   /**
    * Checks is this.getJsonPath matches the jsonpaths provided in options

--- a/modules/json/test/json-loader.spec.ts
+++ b/modules/json/test/json-loader.spec.ts
@@ -74,6 +74,45 @@ test('JSONLoader#loadInBatches(geojson.json, rows, batchSize = 10)', async (t) =
   t.end();
 });
 
+test('JSONLoader#parseInBatches(complete rows with nested arrays)', async (t) => {
+  const valueCount = 2048;
+  const rows = Array.from({length: 3}, (_, rowIndex) => ({
+    text: `row-${rowIndex}`,
+    values: Array.from({length: valueCount}, (_, valueIndex) => rowIndex * valueCount + valueIndex)
+  }));
+
+  const iterator = JSONLoader.parseInBatches?.(makeChunkedTextIterator(JSON.stringify(rows), 128), {
+    batchSize: 1
+  });
+
+  t.ok(iterator, 'parseInBatches returned iterator');
+  if (!iterator) {
+    t.end();
+    return;
+  }
+
+  let emittedRowCount = 0;
+  for await (const batch of iterator) {
+    if (batch.batchType === 'data') {
+      t.equal(batch.length, 1, 'fixed-size batch contains one complete row');
+      for (const row of batch.data) {
+        const expectedFirstValue = emittedRowCount * valueCount;
+        emittedRowCount++;
+        t.equal(row.values.length, valueCount, 'nested values array is complete when emitted');
+        t.equal(row.values[0], expectedFirstValue, 'first nested value is preserved');
+        t.equal(
+          row.values[valueCount - 1],
+          expectedFirstValue + valueCount - 1,
+          'last nested value is preserved'
+        );
+      }
+    }
+  }
+
+  t.equal(emittedRowCount, rows.length, 'all rows were emitted');
+  t.end();
+});
+
 test('JSONLoader#loadInBatches(jsonpaths)', async (t) => {
   let iterator = await loadInBatches(GEOJSON_PATH, JSONLoader, {
     json: {jsonpaths: ['$.features']}
@@ -104,6 +143,14 @@ test('JSONLoader#loadInBatches(jsonpaths)', async (t) => {
   t.equal(rowCount, 0, 'Correct number of row received');
   t.end();
 });
+
+/** Emits UTF-8 JSON text chunks for streaming parser tests. */
+async function* makeChunkedTextIterator(text: string, chunkSize: number) {
+  const textEncoder = new TextEncoder();
+  for (let index = 0; index < text.length; index += chunkSize) {
+    yield textEncoder.encode(text.slice(index, index + chunkSize));
+  }
+}
 
 test('GeoJSONLoader#loadInBatches(jsonpaths)', async (t) => {
   const iterator = await loadInBatches(GEOJSON_PATH, GeoJSONLoader, {


### PR DESCRIPTION
## Summary

Selectively backports the JSON streaming parser fix from `master` to the 4.4 patch line.

Previously a chunk boundary inside a nested object or array could cause a partially parsed row to be emitted. This tracks completed direct children and drains only rows whose closing token has been received.

The regression test streams rows with large nested arrays through small chunks and verifies that every emitted row is complete. The unrelated workflow deletion in the original commit is intentionally omitted.

Original commit: 0750ce04ea7fd47d1e5b911ab9f55b6fda49f999

## Validation

- rebased onto `4.4-release` at 81df7786c68fa75c97d8b9c474076df1822dd672
- `yarn test node`: 6,557 passing, including the new regression assertions
- targeted ESLint and Prettier checks on both changed files: passing
- `yarn lint fix`: passing with the existing warnings