### PR TITLE
fix(mvt): declare schema-utils dependency

### DIFF
--- a/modules/mvt/package.json
+++ b/modules/mvt/package.json
@@ -48,6 +48,7 @@
     "@loaders.gl/images": "4.4.3",
     "@loaders.gl/loader-utils": "4.4.3",
     "@loaders.gl/schema": "4.4.3",
+    "@loaders.gl/schema-utils": "4.4.3",
     "@math.gl/polygon": "^4.1.0",
     "@probe.gl/stats": "^4.1.1",
     "pbf": "^3.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4774,6 +4774,7 @@ __metadata:
     "@loaders.gl/images": "npm:4.4.3"
     "@loaders.gl/loader-utils": "npm:4.4.3"
     "@loaders.gl/schema": "npm:4.4.3"
+    "@loaders.gl/schema-utils": "npm:4.4.3"
     "@math.gl/polygon": "npm:^4.1.0"
     "@probe.gl/stats": "npm:^4.1.1"
     "@types/pbf": "npm:^3.0.2"


### PR DESCRIPTION
## Summary

Addresses #3458 for the 4.4 patch line.

`modules/mvt/src/table-tile-source.ts` imports `deduceTableSchema` directly from `@loaders.gl/schema-utils`, but the MVT package did not declare that package as a dependency. This adds the matching 4.4.3 dependency and lockfile workspace entry, avoiding reliance on hoisting or another package's transitive dependencies.

## Validation

- `yarn test node`: 6,543 passing
- `yarn lint fix`: ran, but the repository-wide check remains blocked by 12 pre-existing `BufferPolyfill not found in @loaders.gl/parquet` errors in parquet tests; no unrelated files changed