### PR TITLE
fix(3d-tiles): support single-level implicit tilesets

### DIFF
--- a/modules/3d-tiles/src/lib/parsers/helpers/parse-3d-implicit-tiles.ts
+++ b/modules/3d-tiles/src/lib/parsers/helpers/parse-3d-implicit-tiles.ts
@@ -136,7 +136,7 @@ export async function parseImplicitTiles(params: {
   } = implicitOptions;
   const tile = {children: [], lodMetricValue: 0, contentUrl: ''};
 
-  if (!maximumLevel) {
+  if (typeof maximumLevel !== 'number' || !Number.isFinite(maximumLevel)) {
     log.once(
       `Missing 'maximumLevel' or 'availableLevels' property. The subtree ${contentUrlTemplate} won't be loaded...`
     );

--- a/modules/3d-tiles/test/index.ts
+++ b/modules/3d-tiles/test/index.ts
@@ -10,6 +10,7 @@ import './lib/parsers/instanced-model-3d-tile.spec';
 import './lib/parsers/point-cloud-3d-tile.spec';
 import './lib/parsers/composite-3d-tile.spec';
 import './lib/parsers/parse-3d-tile-header.spec';
+import './lib/parsers/parse-3d-implicit-tiles.spec';
 // TODO v4.0 restore these tests
 // import './lib/parsers/helpers/gpu-memory-usage.spec';
 import './lib/parsers/helpers/normalize-3d-tile-colors.spec';

--- a/modules/3d-tiles/test/lib/parsers/parse-3d-implicit-tiles.spec.ts
+++ b/modules/3d-tiles/test/lib/parsers/parse-3d-implicit-tiles.spec.ts
@@ -1,0 +1,44 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
+import test from 'tape-promise/tape';
+import type {Subtree} from '../../../src/types';
+import type {ImplicitOptions} from '../../../src/lib/parsers/parse-3d-tile-header';
+import {parseImplicitTiles} from '../../../src/lib/parsers/helpers/parse-3d-implicit-tiles';
+import {LOD_METRIC_TYPE, TILE_REFINEMENT, TILE_TYPE} from '@loaders.gl/tiles';
+
+test('parseImplicitTiles#supports a single available level', async (t) => {
+  const subtree: Subtree = {
+    buffers: [],
+    bufferViews: [],
+    tileAvailability: {constant: 1},
+    contentAvailability: {constant: 1},
+    childSubtreeAvailability: {constant: 0}
+  };
+  const implicitOptions: ImplicitOptions = {
+    contentUrlTemplate: 'https://example.com/content/{level}/{x}/{y}.b3dm',
+    subtreesUriTemplate: 'subtrees/{level}/{x}/{y}.subtree',
+    subdivisionScheme: 'QUADTREE',
+    subtreeLevels: 1,
+    maximumLevel: 0,
+    refine: 'REPLACE',
+    basePath: 'https://example.com',
+    lodMetricType: LOD_METRIC_TYPE.GEOMETRIC_ERROR,
+    rootLodMetricValue: 500,
+    rootBoundingVolume: {region: [0, 0, 1, 1, 0, 100]},
+    getTileType: () => TILE_TYPE.SCENEGRAPH,
+    getRefine: () => TILE_REFINEMENT.REPLACE
+  };
+
+  const tile = await parseImplicitTiles({
+    subtree,
+    implicitOptions,
+    loaderOptions: {}
+  });
+
+  t.equal(tile.contentUrl, 'https://example.com/content/0/0/0.b3dm');
+  t.equal(tile.children.length, 0);
+  t.equal(tile.lodMetricValue, 500);
+  t.end();
+});


### PR DESCRIPTION
## Summary

Addresses #3193 for the 4.4 patch line.

`availableLevels: 1` normalizes to `maximumLevel: 0`, which is valid: the root is the only available implicit level. The previous falsy check treated zero as missing and returned an empty tile. This uses an explicit numeric type guard so zero remains valid while missing or non-finite values are rejected, and adds a direct regression test for a one-level quadtree.

## Validation

- rebased onto `4.4-release` at 81df7786c68fa75c97d8b9c474076df1822dd672
- `yarn build`: passing
- `yarn lint`: passing with 26 existing warnings and no errors; Prettier clean
- `yarn test node`: 6,546 passing, including 3 new regression assertions