### PR TITLE
fix(gltf): resolve Basis formats before workers

### DIFF
--- a/modules/gltf/src/gltf-loader.ts
+++ b/modules/gltf/src/gltf-loader.ts
@@ -2,7 +2,7 @@ import type {LoaderWithParser, StrictLoaderOptions} from '@loaders.gl/loader-uti
 import type {DracoLoaderOptions} from '@loaders.gl/draco';
 import {VERSION} from './lib/utils/version';
 import type {ImageLoaderOptions} from '@loaders.gl/images';
-import type {TextureLoaderOptions} from '@loaders.gl/textures';
+import type {BasisLoaderOptions, TextureLoaderOptions} from '@loaders.gl/textures';
 import type {ParseGLTFOptions} from './lib/parsers/parse-gltf';
 import type {GLTFWithBuffers} from './lib/types/gltf-types';
 import type {GLBLoaderOptions} from './glb-loader';
@@ -13,6 +13,7 @@ import {parseGLTF} from './lib/parsers/parse-gltf';
  */
 export type GLTFLoaderOptions = StrictLoaderOptions &
   ImageLoaderOptions &
+  Pick<BasisLoaderOptions, 'basis'> &
   TextureLoaderOptions &
   GLBLoaderOptions &
   DracoLoaderOptions & {

--- a/modules/gltf/src/lib/parsers/parse-gltf.ts
+++ b/modules/gltf/src/lib/parsers/parse-gltf.ts
@@ -8,7 +8,7 @@ import type {ParseGLBOptions} from './parse-glb';
 import type {ImageType, TextureLevel} from '@loaders.gl/schema';
 import {parseJSON, sliceArrayBuffer, parseFromContext} from '@loaders.gl/loader-utils';
 import {ImageLoader} from '@loaders.gl/images';
-import {BasisLoader} from '@loaders.gl/textures';
+import {BasisLoader, selectSupportedBasisFormat} from '@loaders.gl/textures';
 
 import {assert} from '../utils/assert';
 import {isGLB, parseGLBSync} from './parse-glb';
@@ -27,6 +27,33 @@ export type ParseGLTFOptions = ParseGLBOptions & {
   /** @deprecated not supported in v4. `postProcessGLTF()` must be called by the application */
   postProcess?: never;
 };
+
+/**
+ * Creates options for parsing an image referenced by a glTF asset.
+ * Resolves automatic Basis format selection before the image is delegated to a worker.
+ * @param options - glTF loader options.
+ * @param mimeType - MIME type declared by the glTF image.
+ * @returns Loader options for the referenced image.
+ */
+export function getGLTFImageOptions(
+  options: GLTFLoaderOptions,
+  mimeType?: string
+): GLTFLoaderOptions {
+  const basisOptions = options.basis;
+  const basisFormat = basisOptions?.format;
+
+  return {
+    ...options,
+    core: {...options.core, mimeType},
+    basis: {
+      ...basisOptions,
+      format:
+        basisFormat && basisFormat !== 'auto'
+          ? basisFormat
+          : selectSupportedBasisFormat(basisOptions?.supportedTextureFormats)
+    }
+  };
+}
 
 /** Check if an array buffer appears to contain GLTF data */
 export function isGLTF(arrayBuffer: ArrayBuffer, options?: ParseGLTFOptions): boolean {
@@ -219,12 +246,7 @@ async function loadImage(
 
   assert(arrayBuffer, 'glTF image has no data');
 
-  const strictOptions = options;
-
-  const gltfOptions = {
-    ...strictOptions,
-    core: {...strictOptions?.core, mimeType: image.mimeType}
-  } satisfies StrictLoaderOptions;
+  const gltfOptions = getGLTFImageOptions(options, image.mimeType) satisfies StrictLoaderOptions;
 
   // Call `parse`
   let parsedImage = (await parseFromContext(

--- a/modules/gltf/test/gltf-loader.spec.ts
+++ b/modules/gltf/test/gltf-loader.spec.ts
@@ -3,9 +3,10 @@ import test from 'tape-promise/tape';
 import {validateLoader} from 'test/common/conformance';
 
 import {registerLoaders, load, parseSync, fetchFile} from '@loaders.gl/core';
-import {GLTFLoader, postProcessGLTF} from '@loaders.gl/gltf';
+import {GLTFLoader, postProcessGLTF, type GLTFLoaderOptions} from '@loaders.gl/gltf';
 import {DracoLoader} from '@loaders.gl/draco';
 import {ImageLoader} from '@loaders.gl/images';
+import {getGLTFImageOptions} from '../src/lib/parsers/parse-gltf';
 
 const GLTF_BINARY_URL = '@loaders.gl/gltf/test/data/gltf-2.0/2CylinderEngine.glb';
 const GLTF_JSON_URL = '@loaders.gl/gltf/test/data/gltf-2.0/2CylinderEngine.gltf';
@@ -50,6 +51,32 @@ test('GLTFLoader#load(binary)', async (t) => {
 test('GLTFLoader#load(text)', async (t) => {
   const data = await load(GLTF_JSON_URL, GLTFLoader, {gltf: {loadImages: false}});
   t.ok(data.json.asset, 'GLTFLoader returned parsed data');
+  t.end();
+});
+
+test('GLTFLoader#Basis image options', (t) => {
+  const loaderOptions: GLTFLoaderOptions = {
+    core: {worker: true},
+    basis: {
+      supportedTextureFormats: ['bc3-rgba-unorm'],
+      containerFormat: 'ktx2'
+    }
+  };
+
+  const imageOptions = getGLTFImageOptions(loaderOptions, 'image/ktx2');
+
+  t.deepEqual(
+    imageOptions.basis,
+    {
+      supportedTextureFormats: ['bc3-rgba-unorm'],
+      containerFormat: 'ktx2',
+      format: {alpha: 'bc3', noAlpha: 'bc1'}
+    },
+    'selects a concrete format while preserving partial Basis options'
+  );
+  t.equal(imageOptions.core?.worker, true, 'preserves core options');
+  t.equal(imageOptions.core?.mimeType, 'image/ktx2', 'sets the image MIME type');
+  t.notOk(loaderOptions.basis?.format, 'does not mutate the supplied options');
   t.end();
 });
 

--- a/modules/textures/src/index.ts
+++ b/modules/textures/src/index.ts
@@ -43,6 +43,9 @@ export {TextureCubeArrayLoader} from './texture-cube-array-loader';
 export {BASIS_EXTERNAL_LIBRARIES} from './lib/parsers/basis-module-loader';
 export {CRUNCH_EXTERNAL_LIBRARIES} from './lib/parsers/crunch-module-loader';
 
+// Basis format selection
+export {selectSupportedBasisFormat} from './lib/parsers/parse-basis';
+
 // Writers
 export {CompressedTextureWriter} from './compressed-texture-writer';
 export {KTX2BasisWriter} from './ktx2-basis-writer';


### PR DESCRIPTION
## Summary

Minimal 4.4 backport of the Basis worker-format fix from #3423.

- Resolve automatic Basis texture format selection on the main thread before glTF image parsing is delegated to a worker.
- Preserve partial `basis` options, caller-supplied supported formats, and explicit format overrides.
- Add Basis options to the public GLTF loader option type.
- Export the existing 4.4 format-selection helper and add a focused regression test.

This intentionally does **not** backport the parser-free utility and dynamic-loader restructuring from the master/5.0 change.

## Root cause

Basis automatic format selection can run in a worker, where no WebGL context is available. Capability detection then returns an empty format list and selects the `rgb565` fallback. That can reach the compressed texture/mipmap path and trigger the production hang described in visgl/deck.gl#9912.

## Impact

glTF Basis/KTX2 images now receive a concrete GPU format before crossing the worker boundary, while existing caller options remain intact.

## Validation

- `yarn lint fix`
- `yarn test node` — 6,547 passed
- `yarn build`

Related: #3423