### PR TITLE
test: stabilize headless browser CI

### DIFF
--- a/dev-modules/devtools-extensions/get-playwright-launch-options.mjs
+++ b/dev-modules/devtools-extensions/get-playwright-launch-options.mjs
@@ -1,5 +1,9 @@
 const DEFAULT_PLAYWRIGHT_CHANNEL = 'chromium';
-const DEFAULT_PLAYWRIGHT_ARGS = ['--enable-unsafe-webgpu', '--ignore-gpu-blocklist'];
+const DEFAULT_PLAYWRIGHT_ARGS = [
+  '--disable-dev-shm-usage',
+  '--enable-unsafe-webgpu',
+  '--ignore-gpu-blocklist'
+];
 const SOFTWARE_GPU_ARGS = ['--use-angle=swiftshader', '--enable-unsafe-swiftshader'];
 
 export function getPlaywrightLaunchOptions(options = {}) {

--- a/modules/mvt/test/mvt-loader.spec.ts
+++ b/modules/mvt/test/mvt-loader.spec.ts
@@ -209,16 +209,25 @@ test('MVTLoader#Parse Polygons MVT', async t => {
     };
 
     const geometry = await parse(mvtArrayBuffer, MVTLoader, loaderOptions);
-    let expected = binary
-      ? decodedPolygonsGeoJSON
-      : {shape: 'geojson-table', type: 'FeatureCollection', features: decodedPolygonsGeoJSON};
     if (binary) {
-      // @ts-ignore
-      expected = geojsonToBinary(expected, {fixRingWinding: false});
+      const expected = geojsonToBinary(structuredClone(decodedPolygonsGeoJSON), {
+        fixRingWinding: false
+      });
       t.ok(geometry.byteLength > 0);
       delete geometry.byteLength;
+      t.deepEqual(geometry, expected, `Parsed Polygons MVT as ${outputFormat}`);
+    } else {
+      const expected = {
+        shape: 'geojson-table',
+        type: 'FeatureCollection',
+        features: normalizeGeoJsonFeatures(decodedPolygonsGeoJSON)
+      };
+      const normalizedGeometry = {
+        ...geometry,
+        features: normalizeGeoJsonFeatures(geometry.features)
+      };
+      t.deepEqual(normalizedGeometry, expected, `Parsed Polygons MVT as ${outputFormat}`);
     }
-    t.deepEqual(geometry, expected, `Parsed Polygons MVT as ${outputFormat}`);
   }
   t.end();
 });
@@ -368,3 +377,32 @@ test('Triangulation is supported', async t => {
 
   t.end();
 });
+
+/**
+ * Copies GeoJSON features while normalizing projected coordinate precision for stable comparisons.
+ *
+ * @param features GeoJSON features to normalize.
+ * @returns Feature copies with rounded geometry coordinates.
+ */
+function normalizeGeoJsonFeatures(features: any[]): any[] {
+  return features.map(feature => ({
+    ...feature,
+    geometry: {
+      ...feature.geometry,
+      coordinates: roundCoordinates(feature.geometry.coordinates)
+    }
+  }));
+}
+
+/**
+ * Rounds nested coordinates to avoid browser-specific floating-point projection drift.
+ *
+ * @param coordinates Nested GeoJSON coordinate values.
+ * @returns Coordinates rounded to stable sub-millimeter precision.
+ */
+function roundCoordinates(coordinates: any): any {
+  if (Array.isArray(coordinates)) {
+    return coordinates.map(value => roundCoordinates(value));
+  }
+  return typeof coordinates === 'number' ? Number(coordinates.toFixed(9)) : coordinates;
+}


### PR DESCRIPTION
## Summary

- Normalize projected GeoJSON polygon coordinates before comparing headless-browser output.
- Launch Chromium with `--disable-dev-shm-usage` so the full browser suite does not crash when CI shared memory is constrained.
- Preserve the existing assertions and test coverage.

## Root cause

The headless workflow exposed two independent stability problems while testing the unrelated Thrift dependency update in #3463:

1. Chromium projection results can differ at insignificant floating-point precision, making the MVT polygon deep-equality assertion brittle.
2. After that assertion was stabilized, Chromium exited partway through the full suite under CI shared-memory pressure, leaving Vitest with only a browser-disconnect error.

## Validation

- The two changed files are identical to stabilization commits `9a970cb7b9` and `a06bf852d9`.
- Those changes previously passed the full Actions workflow on #3461.
- The first #3484 run confirmed that the MVT assertion now passes; it progressed to 1,502 passing tests before the browser process disconnected.
- CI is rerunning on this focused two-file draft.