### PR TITLE
fix(mvt): declare schema-utils dependency

### DIFF
--- a/modules/mvt/package.json
+++ b/modules/mvt/package.json
@@ -57,6 +57,7 @@
     "@loaders.gl/images": "5.0.0-alpha.1",
     "@loaders.gl/loader-utils": "5.0.0-alpha.1",
     "@loaders.gl/schema": "5.0.0-alpha.1",
+    "@loaders.gl/schema-utils": "5.0.0-alpha.1",
     "@math.gl/polygon": "^4.1.0",
     "@probe.gl/stats": "^4.1.1",
     "pbf": "^3.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5596,6 +5596,7 @@ __metadata:
     "@loaders.gl/images": "npm:5.0.0-alpha.1"
     "@loaders.gl/loader-utils": "npm:5.0.0-alpha.1"
     "@loaders.gl/schema": "npm:5.0.0-alpha.1"
+    "@loaders.gl/schema-utils": "npm:5.0.0-alpha.1"
     "@math.gl/polygon": "npm:^4.1.0"
     "@probe.gl/stats": "npm:^4.1.1"
     "@types/pbf": "npm:^3.0.2"


### PR DESCRIPTION
## Summary
- declare `@loaders.gl/schema-utils` as a runtime dependency of `@loaders.gl/mvt`
- regenerate the Yarn lockfile
- forward-port the equivalent 4.4 fix from #3481

Fixes #3458

## Validation
- `yarn install --immutable`
- `yarn lint fix`
- `yarn build`
- `yarn test node` (1,614 passed, 75 skipped)