### PR TITLE
fix(website): label examples sidebar

### DIFF
--- a/website/src/examples-sidebar.js
+++ b/website/src/examples-sidebar.js
@@ -9,7 +9,7 @@
  Create as many sidebars as you want.
  */
 const sidebars = {
-  examplesSidebar: [
+  Examples: [
     {
       type: 'doc',
       label: 'Overview',


### PR DESCRIPTION
## Summary
- rename the Docusaurus sidebar identifier to the human-readable `Examples` heading

Fixes #3187

## Validation
- `yarn lint fix`
- `yarn test node` (1,614 passed, 75 skipped)
- `cd website && yarn && yarn build`
- inspected the rendered sidebar heading