### PR TITLE
fix(3d-tiles): preserve query-selected tilesets

### DIFF
--- a/examples/website/3d-tiles/app.tsx
+++ b/examples/website/3d-tiles/app.tsx
@@ -121,17 +121,17 @@ export default class App extends PureComponent<AppProps> {
     }
 
     this._loadExampleIndex();
-
-    // Check if a tileset is specified in the query params
-    if (this._selectTilesetFromQueryParams()) {
-      return;
-    }
   }
 
   // load the index file that lists example tilesets
   async _loadExampleIndex() {
     const examplesByCategory = await loadExampleIndex();
     this.setState({examplesByCategory});
+
+    // Check if a tileset is specified in the query params
+    if (this._selectTilesetFromQueryParams()) {
+      return;
+    }
 
     // if not, select the default example tileset
     const {category, name} = this.state;


### PR DESCRIPTION
## Summary
- wait for the example index before processing query-parameter selection
- return before applying the default when a custom URL or Cesium ION query succeeds
- preserve the no-query default path

Fixes #3333

## Validation
- `yarn lint fix`
- `yarn build`
- `yarn test node` (1,614 passed, 75 skipped)
- `yarn workspace 3d-tiles-loaders-example vite build`
- manually verified no-query default, custom URL request, and Cesium ION selection/request

Note: the workspace's configured `tsc && vite build` script still stops at the pre-existing master `tsconfig.json` include of `app.js`; the Vite build itself passes.