### PR TITLE
docs(tile-converter): correct I3S SLPK routes

### DIFF
--- a/docs/modules/tile-converter/cli-reference/i3s-server.md
+++ b/docs/modules/tile-converter/cli-reference/i3s-server.md
@@ -43,16 +43,16 @@ PORT=8080 HTTPS_PORT=4443 I3sLayerPath="./data/NewTileset.slpk" DEBUG=i3s-server
 
 #### The layer should be available on URLs
 
-- `http://localhost:8080/NewTileset/SceneServer/layers/0`
-- `https://localhost:4443/NewTileset/SceneServer/layers/0`
+- `http://localhost:8080/SceneServer/layers/0`
+- `https://localhost:4443/SceneServer/layers/0`
 
 #### Open in ArcGIS
 
-`https://www.arcgis.com/home/webscene/viewer.html?url=http://localhost:8080/NewTileset/SceneServer`
+`https://www.arcgis.com/home/webscene/viewer.html?url=http://localhost:8080/SceneServer`
 
 #### Open in I3S Explorer
 
-`https://i3s.loaders.gl/viewer?tileset=http://localhost:8080/NewTileset/SceneServer/layers/0`
+`https://i3s.loaders.gl/viewer?tileset=http://localhost:8080/SceneServer/layers/0`
 
 ## ENV variables
 


### PR DESCRIPTION
## Summary
- remove the obsolete `NewTileset/` prefix from public SLPK examples
- document `/SceneServer/layers/0` for layer/viewer URLs
- document `/SceneServer` for the ArcGIS service URL
- leave the already-correct internal server README unchanged

Fixes #3218

## Validation
- `yarn lint fix`
- `yarn test node` (1,614 passed, 75 skipped)
- `cd website && yarn && yarn build`
- inspected the rendered I3S URLs