### PR TITLE
test: stabilize Node test timeouts

### DIFF
--- a/dev-modules/devtools-extensions/get-vitest-config.mjs
+++ b/dev-modules/devtools-extensions/get-vitest-config.mjs
@@ -130,6 +130,7 @@ export async function getVitestConfig(options = {}) {
             color: 'blue',
             environment: 'node',
             passWithNoTests: true,
+            testTimeout,
             setupFiles,
             include: ['modules/**/*.spec.{ts,js}', 'test/**/*.spec.{ts,js}'],
             exclude: [


### PR DESCRIPTION
## Summary

- Apply the configured Vitest `testTimeout` to the Node test project as well as the browser project.
- Preserve test coverage and assertions while allowing slower CI runners to use the repository-wide timeout setting.

## Root cause

PR #3463 now passes its Parquet tests and the previously failing headless-browser checks, but Actions run 6494 failed because the LAS TypeScript-backend comparison exceeded Vitest's implicit 5-second Node-project timeout. The shared timeout was already calculated but was not forwarded to that project.

## Validation

- This is the same one-line configuration change as commit `b08e80e2e3`, previously validated by the successful full Actions workflow on #3461.
- The draft changes only `dev-modules/devtools-extensions/get-vitest-config.mjs`.
- Actions run 6511 passed all jobs, including Node 22 and the full headless-browser suite.