### PR TITLE
Add draft GLB v3 parsing

### DIFF
--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -20,6 +20,10 @@ Release Date: 2026
 
 - [`DracoWriter`](/docs/modules/draco/api-reference/draco-writer) now accepts plain `Mesh` data and Mesh Arrow tables in addition to existing Draco attribute-map input.
 
+**@loaders.gl/gltf**
+
+- `GLBLoader` adds draft GLB v3 parsing with 64-bit file and chunk lengths, multi-chunk traversal, and reserved chunk-encoding validation, advancing glTF 2.1 readiness.
+
 **@loaders.gl/las** 
 
 - [`LASWriter`](/docs/modules/las/api-reference/las-writer) NEW -writes uncompressed LAS point cloud data.

--- a/modules/gltf/src/lib/parsers/parse-glb.ts
+++ b/modules/gltf/src/lib/parsers/parse-glb.ts
@@ -1,8 +1,9 @@
 /* eslint-disable camelcase, max-statements */
 // https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#glb-file-format-specification
+// Draft GLB v3 layout: https://github.com/KhronosGroup/glTF/issues/2594
 // https://github.com/KhronosGroup/glTF/tree/master/extensions/1.0/Khronos/KHR_binary_glTF
 import type {GLB} from '../types/glb-types';
-import {padToNBytes, assert} from '@loaders.gl/loader-utils';
+import {assert} from '@loaders.gl/loader-utils';
 
 /** Options for parsing a GLB */
 export type ParseGLBOptions = {
@@ -17,8 +18,10 @@ const LITTLE_ENDIAN = true;
 
 /** 'glTF' in Big-Endian ASCII */
 const MAGIC_glTF = 0x676c5446;
-const GLB_FILE_HEADER_SIZE = 12;
-const GLB_CHUNK_HEADER_SIZE = 8;
+const GLB_V1_V2_FILE_HEADER_SIZE = 12;
+const GLB_V3_FILE_HEADER_SIZE = 16;
+const GLB_V1_V2_CHUNK_HEADER_SIZE = 8;
+const GLB_V3_CHUNK_HEADER_SIZE = 16;
 const GLB_CHUNK_TYPE_JSON = 0x4e4f534a;
 const GLB_CHUNK_TYPE_BIN = 0x004e4942;
 const GLB_V1_CONTENT_FORMAT_JSON = 0x0;
@@ -68,8 +71,11 @@ export function parseGLBSync(
 
   // Compare format with GLBLoader documentation
   const type = getMagicString(dataView, byteOffset + 0);
-  const version = dataView.getUint32(byteOffset + 4, LITTLE_ENDIAN); // Version 2 of binary glTF container format
-  const byteLength = dataView.getUint32(byteOffset + 8, LITTLE_ENDIAN); // Total byte length of binary file
+  const version = dataView.getUint32(byteOffset + 4, LITTLE_ENDIAN);
+  const byteLength =
+    version === 3
+      ? getSafeUint64(dataView, byteOffset + 8, 'GLB byte length')
+      : dataView.getUint32(byteOffset + 8, LITTLE_ENDIAN);
 
   Object.assign(glb, {
     // Put less important stuff in a header, to avoid clutter
@@ -86,15 +92,15 @@ export function parseGLBSync(
     binChunks: []
   } as GLB);
 
-  byteOffset += GLB_FILE_HEADER_SIZE;
-
   switch (glb.version) {
     case 1:
-      return parseGLBV1(glb, dataView, byteOffset);
+      return parseGLBV1(glb, dataView, byteOffset + GLB_V1_V2_FILE_HEADER_SIZE);
     case 2:
-      return parseGLBV2(glb, dataView, byteOffset, options);
+      return parseGLBV2(glb, dataView, byteOffset + GLB_V1_V2_FILE_HEADER_SIZE, options);
+    case 3:
+      return parseGLBV3(glb, dataView, byteOffset + GLB_V3_FILE_HEADER_SIZE, options);
     default:
-      throw new Error(`Invalid GLB version ${glb.version}. Only supports version 1 and 2.`);
+      throw new Error(`Invalid GLB version ${glb.version}. Only supports versions 1, 2 and 3.`);
   }
 }
 
@@ -107,13 +113,13 @@ export function parseGLBSync(
  */
 function parseGLBV1(glb: GLB, dataView: DataView, byteOffset: number): number {
   // Sanity: ensure file is big enough to hold at least the headers
-  assert(glb.header.byteLength > GLB_FILE_HEADER_SIZE + GLB_CHUNK_HEADER_SIZE);
+  assert(glb.header.byteLength > GLB_V1_V2_FILE_HEADER_SIZE + GLB_V1_V2_CHUNK_HEADER_SIZE);
 
   // Explanation of GLB structure:
   // https://cloud.githubusercontent.com/assets/3479527/22600725/36b87122-ea55-11e6-9d40-6fd42819fcab.png
   const contentLength = dataView.getUint32(byteOffset + 0, LITTLE_ENDIAN); // Byte length of chunk
   const contentFormat = dataView.getUint32(byteOffset + 4, LITTLE_ENDIAN); // Chunk format as uint32
-  byteOffset += GLB_CHUNK_HEADER_SIZE;
+  byteOffset += GLB_V1_V2_CHUNK_HEADER_SIZE;
 
   // GLB v1 only supports a single chunk type
   assert(contentFormat === GLB_V1_CONTENT_FORMAT_JSON);
@@ -140,11 +146,25 @@ function parseGLBV2(
   options: ParseGLBOptions
 ): number {
   // Sanity: ensure file is big enough to hold at least the first chunk header
-  assert(glb.header.byteLength > GLB_FILE_HEADER_SIZE + GLB_CHUNK_HEADER_SIZE);
+  assert(glb.header.byteLength > GLB_V1_V2_FILE_HEADER_SIZE + GLB_V1_V2_CHUNK_HEADER_SIZE);
 
-  parseGLBChunksSync(glb, dataView, byteOffset, options);
+  parseGLBChunksSync(glb, dataView, byteOffset, GLB_V1_V2_CHUNK_HEADER_SIZE, options);
 
-  return byteOffset + glb.header.byteLength;
+  return glb.header.byteOffset + glb.header.byteLength;
+}
+
+/** Parse a draft V3 GLB with 64-bit file and chunk lengths. */
+function parseGLBV3(
+  glb: GLB,
+  dataView: DataView,
+  byteOffset: number,
+  options: ParseGLBOptions
+): number {
+  assert(glb.header.byteLength >= GLB_V3_FILE_HEADER_SIZE + GLB_V3_CHUNK_HEADER_SIZE);
+
+  parseGLBChunksSync(glb, dataView, byteOffset, GLB_V3_CHUNK_HEADER_SIZE, options);
+
+  return glb.header.byteOffset + glb.header.byteLength;
 }
 
 /** Iterate over GLB chunks and parse them */
@@ -152,14 +172,29 @@ function parseGLBChunksSync(
   glb: GLB,
   dataView: DataView,
   byteOffset: number,
+  chunkHeaderSize: number,
   options: ParseGLBOptions
 ) {
+  const fileEndByteOffset = glb.header.byteOffset + glb.header.byteLength;
+  assert(fileEndByteOffset <= dataView.byteLength);
+
   // Per spec we must iterate over chunks, ignoring all except JSON and BIN
   // Iterate as long as there is space left for another chunk header
-  while (byteOffset + 8 <= glb.header.byteLength) {
-    const chunkLength = dataView.getUint32(byteOffset + 0, LITTLE_ENDIAN); // Byte length of chunk
-    const chunkFormat = dataView.getUint32(byteOffset + 4, LITTLE_ENDIAN); // Chunk format as uint32
-    byteOffset += GLB_CHUNK_HEADER_SIZE;
+  while (byteOffset + chunkHeaderSize <= fileEndByteOffset) {
+    const isVersion3 = glb.version === 3;
+    const chunkFormat = dataView.getUint32(byteOffset + (isVersion3 ? 0 : 4), LITTLE_ENDIAN);
+    const chunkEncoding = isVersion3 ? dataView.getUint32(byteOffset + 4, LITTLE_ENDIAN) : 0;
+    const chunkLength = isVersion3
+      ? getSafeUint64(dataView, byteOffset + 8, 'GLB chunk length')
+      : dataView.getUint32(byteOffset + 0, LITTLE_ENDIAN);
+    byteOffset += chunkHeaderSize;
+
+    if (chunkEncoding !== 0) {
+      throw new Error(`Unsupported GLB chunk encoding ${chunkEncoding}.`);
+    }
+    if (byteOffset + chunkLength > fileEndByteOffset) {
+      throw new Error('GLB chunk extends beyond the declared file length.');
+    }
 
     // Per spec we must iterate over chunks, ignoring all except JSON and BIN
     switch (chunkFormat) {
@@ -188,7 +223,7 @@ function parseGLBChunksSync(
         break;
     }
 
-    byteOffset += padToNBytes(chunkLength, 4);
+    byteOffset += padToFourBytes(chunkLength);
   }
 
   return byteOffset;
@@ -206,7 +241,7 @@ function parseJSONChunk(glb: GLB, dataView: DataView, byteOffset: number, chunkL
   // 3. Parse the JSON text into a JavaScript data structure
   glb.json = JSON.parse(jsonText);
 
-  return padToNBytes(chunkLength, 4);
+  return padToFourBytes(chunkLength);
 }
 
 /** Parse a GLB BIN chunk */
@@ -220,5 +255,19 @@ function parseBINChunk(glb: GLB, dataView, byteOffset, chunkLength) {
     // TODO - copy, or create typed array view?
   });
 
-  return padToNBytes(chunkLength, 4);
+  return padToFourBytes(chunkLength);
+}
+
+/** Read a uint64 that can be represented exactly by JavaScript offsets and lengths. */
+function getSafeUint64(dataView: DataView, byteOffset: number, label: string): number {
+  const value = dataView.getBigUint64(byteOffset, LITTLE_ENDIAN);
+  if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error(`${label} exceeds JavaScript's safe integer range.`);
+  }
+  return Number(value);
+}
+
+/** Round a byte length up to the four-byte alignment required by GLB chunks. */
+function padToFourBytes(byteLength: number): number {
+  return Math.ceil(byteLength / 4) * 4;
 }

--- a/modules/gltf/src/lib/types/glb-types.ts
+++ b/modules/gltf/src/lib/types/glb-types.ts
@@ -6,7 +6,8 @@ export type GLBBinChunk = {
 
 export type GLB = {
   type: string;
-  version: number; // Version 2 of binary glTF container format
+  /** Binary glTF container version. */
+  version: number;
 
   // Put less important stuff in a header, to avoid clutter
   header: {

--- a/modules/gltf/test/glb-loader.spec.ts
+++ b/modules/gltf/test/glb-loader.spec.ts
@@ -36,3 +36,71 @@ test('GLBLoader#load(v1)', async t => {
   t.equal(glbv1.json.asset.version, '1.0', 'GLBLoader returned parsed data');
   t.end();
 });
+
+test('GLBLoader#parseSync(v3)', t => {
+  const data = createGLBV3({asset: {version: '2.1'}}, new Uint8Array([1, 2, 3, 4]));
+  const glbv3 = parseSync(data, GLBLoader);
+
+  t.equal(glbv3.version, 3, 'GLBLoader returned correct glb version');
+  t.equal(glbv3.header.byteLength, data.byteLength, 'GLBLoader read the 64-bit file length');
+  t.equal(glbv3.json.asset.version, '2.1', 'GLBLoader returned correct gltf version');
+  t.equal(glbv3.binChunks.length, 1, 'GLBLoader returned the BIN chunk');
+  t.equal(glbv3.binChunks[0].byteLength, 4, 'GLBLoader read the 64-bit chunk length');
+
+  t.end();
+});
+
+test('GLBLoader#parseSync(v3) rejects unsupported chunk encoding', t => {
+  const data = createGLBV3({asset: {version: '2.1'}});
+  const dataView = new DataView(data);
+  dataView.setUint32(20, 1, true);
+
+  t.throws(() => parseSync(data, GLBLoader), /Unsupported GLB chunk encoding 1/);
+  t.end();
+});
+
+test('GLBLoader#parseSync(v3) rejects unsafe 64-bit lengths', t => {
+  const data = new ArrayBuffer(16);
+  const dataView = new DataView(data);
+  dataView.setUint32(0, 0x46546c67, true);
+  dataView.setUint32(4, 3, true);
+  dataView.setBigUint64(8, BigInt(Number.MAX_SAFE_INTEGER) + 1n, true);
+
+  t.throws(
+    () => parseSync(data, GLBLoader),
+    /GLB byte length exceeds JavaScript's safe integer range/
+  );
+  t.end();
+});
+
+/** Create a GLB v3 fixture using the draft Khronos binary layout. */
+function createGLBV3(json: Record<string, unknown>, binary?: Uint8Array): ArrayBuffer {
+  const textEncoder = new TextEncoder();
+  const jsonBytes = textEncoder.encode(JSON.stringify(json));
+  const jsonByteLength = Math.ceil(jsonBytes.byteLength / 4) * 4;
+  const binaryByteLength = binary ? Math.ceil(binary.byteLength / 4) * 4 : 0;
+  const fileByteLength = 16 + 16 + jsonByteLength + (binary ? 16 + binaryByteLength : 0);
+  const arrayBuffer = new ArrayBuffer(fileByteLength);
+  const dataView = new DataView(arrayBuffer);
+  const bytes = new Uint8Array(arrayBuffer);
+
+  dataView.setUint32(0, 0x46546c67, true);
+  dataView.setUint32(4, 3, true);
+  dataView.setBigUint64(8, BigInt(fileByteLength), true);
+
+  dataView.setUint32(16, 0x4e4f534a, true);
+  dataView.setUint32(20, 0, true);
+  dataView.setBigUint64(24, BigInt(jsonByteLength), true);
+  bytes.fill(0x20, 32, 32 + jsonByteLength);
+  bytes.set(jsonBytes, 32);
+
+  if (binary) {
+    const binaryHeaderByteOffset = 32 + jsonByteLength;
+    dataView.setUint32(binaryHeaderByteOffset, 0x004e4942, true);
+    dataView.setUint32(binaryHeaderByteOffset + 4, 0, true);
+    dataView.setBigUint64(binaryHeaderByteOffset + 8, BigInt(binaryByteLength), true);
+    bytes.set(binary, binaryHeaderByteOffset + 16);
+  }
+
+  return arrayBuffer;
+}


### PR DESCRIPTION
## Goals

- Add preliminary parsing support for the GLB binary container version 3 announced for glTF 2.1.
- Preserve existing GLB v1 and v2 behavior while preparing loaders.gl for 64-bit file and chunk lengths.

## Changes

- Parse the draft 16-byte GLB v3 file header and 16-byte chunk headers described in KhronosGroup/glTF#2594.
- Read v3 file and chunk lengths as little-endian `uint64` values.
- Reject lengths outside JavaScript's safe integer range, chunks extending beyond the declared file length, and nonzero reserved chunk encodings.
- Keep v1/v2 parsing on their existing 32-bit layouts and make chunk boundary checks work for embedded GLBs with nonzero starting offsets.
- Add generated GLB v3 JSON/BIN coverage and malformed-input tests.
- Generalize the public `GLB.version` documentation beyond version 2.

## Draft-format note

Khronos has announced GLB v3, but normative specification text and official test assets are not yet published. This implementation follows the illustrative binary layout in [KhronosGroup/glTF#2594](https://github.com/KhronosGroup/glTF/issues/2594). The tests generate a minimal fixture locally so they can be updated when Khronos publishes conformance assets.

This PR adds parsing only; GLB v3 writing remains out of scope.

## Validation

- `yarn build`
- `yarn test-node` — 1,635 passed, 75 skipped
- `yarn test-headless` — 1,631 passed, 60 skipped
- `yarn lint fix`
