### PR TITLE
chore: drop Node 20 CI and update Yarn

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,13 +39,6 @@ jobs:
             playwright: false
             scope: 'node tests'
             test-command: test-node
-          - node-version: 20
-            coverage: false
-            coverage-flag: ''
-            playwright: false
-            scope: 'node tests'
-            test-command: test-node
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -58,7 +51,7 @@ jobs:
       - name: Enable Corepack / Yarn 4
         run: |
           corepack enable
-          corepack prepare yarn@4.10.3 --activate
+          corepack prepare yarn@4.17.1 --activate
           yarn -v
 
       - name: Cache Yarn 4 artifacts
@@ -155,7 +148,7 @@ jobs:
       - name: Enable Corepack / Yarn 4
         run: |
           corepack enable
-          corepack prepare yarn@4.10.3 --activate
+          corepack prepare yarn@4.17.1 --activate
           yarn -v
 
       - name: Cache Yarn 4 artifacts
@@ -207,7 +200,7 @@ jobs:
       - name: Enable Corepack / Yarn 4
         run: |
           corepack enable
-          corepack prepare yarn@4.10.3 --activate
+          corepack prepare yarn@4.17.1 --activate
           yarn -v
 
       - name: Cache website Yarn artifacts

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Enable Corepack / Yarn 4
         run: |
           corepack enable
-          corepack prepare yarn@4.10.3 --activate
+          corepack prepare yarn@4.17.1 --activate
           yarn -v
 
       - name: Cache website Yarn artifacts

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,29 +1,35 @@
-nodeLinker: node-modules
+approvedGitRepositories:
+  - "**"
+
+enableScripts: true
+
 logFilters:
   - code: YN0057
-    pattern: '*Resolutions field will be ignored*'
     level: discard
+    pattern: "*Resolutions field will be ignored*"
   - code: YN0060
-    pattern: '*@loaders.gl/core is listed by your project with version 4.4.0*'
     level: discard
+    pattern: "*@loaders.gl/core is listed by your project with version 4.4.0*"
   - code: YN0060
-    pattern: '*@types/react is listed by your project with version 19.2.14*'
     level: discard
+    pattern: "*@types/react is listed by your project with version 19.2.14*"
   - code: YN0060
-    pattern: '*react is listed by your project with version 19.2.5*'
     level: discard
+    pattern: "*react is listed by your project with version 19.2.5*"
   - code: YN0060
-    pattern: '*react-dom is listed by your project with version 19.2.5*'
     level: discard
+    pattern: "*react-dom is listed by your project with version 19.2.5*"
   - code: YN0002
-    pattern: '*doesn''t provide @loaders.gl/core*'
     level: discard
+    pattern: "*doesn't provide @loaders.gl/core*"
   - code: YN0002
-    pattern: '*doesn''t provide ol*'
     level: discard
+    pattern: "*doesn't provide ol*"
   - code: YN0002
-    pattern: '*doesn''t provide ws*'
     level: discard
+    pattern: "*doesn't provide ws*"
   - code: YN0086
-    pattern: '*Some peer dependencies are incorrectly met*'
     level: discard
+    pattern: "*Some peer dependencies are incorrectly met*"
+
+nodeLinker: node-modules

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "type": "module",
   "private": true,
-  "packageManager": "yarn@4.12.0",
+  "packageManager": "yarn@4.17.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/visgl/loaders.gl"

--- a/website/package.json
+++ b/website/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "description": "Website for vis.gl project",
-  "packageManager": "yarn@4.10.3",
+  "packageManager": "yarn@4.17.1",
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 10
   cacheKey: 10c0
 
 "3d-tiles-loaders-example@workspace:examples/website/3d-tiles":
@@ -30311,20 +30311,20 @@ __metadata:
 
 "resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.11#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A~1.22.6#optional!builtin<compat/resolve>":
   version: 1.22.11
-  resolution: "resolve@patch:resolve@npm%3A1.22.11#optional!builtin<compat/resolve>::version=1.22.11&hash=c3c19d"
+  resolution: "resolve@patch:resolve@npm%3A1.22.11#optional!builtin<compat/resolve>::version=1.22.11&hash=9bd1a5"
   dependencies:
     is-core-module: "npm:^2.16.1"
     path-parse: "npm:^1.0.7"
     supports-preserve-symlinks-flag: "npm:^1.0.0"
   bin:
     resolve: bin/resolve
-  checksum: 10c0/ee5b182f2e37cb1165465e58c6abc797fec0a80b5ba3231607beb4677db0c9291ac010c47cf092b6daa2b7f518d69a0e21888e7e2b633f68d501a874212a8c63
+  checksum: 10c0/55f7a298977b1aacf6dbec6dcfc81100ba98675bced193b57d3ac58ced65acc40c3a38927853cea86b7f75edb3c20e1f099a09d48b0d8ceccc25d466993eec47
   languageName: node
   linkType: hard
 
 "resolve@patch:resolve@npm%3A^1.17.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>":
   version: 1.22.12
-  resolution: "resolve@patch:resolve@npm%3A1.22.12#optional!builtin<compat/resolve>::version=1.22.12&hash=c3c19d"
+  resolution: "resolve@patch:resolve@npm%3A1.22.12#optional!builtin<compat/resolve>::version=1.22.12&hash=9bd1a5"
   dependencies:
     es-errors: "npm:^1.3.0"
     is-core-module: "npm:^2.16.1"
@@ -30332,13 +30332,13 @@ __metadata:
     supports-preserve-symlinks-flag: "npm:^1.0.0"
   bin:
     resolve: bin/resolve
-  checksum: 10c0/fc6519984ae1f894d877c0060ba8b1f5ba3bc0e85a02f74e141929c118c23d74d9735619a9cc2965397387e514884245c65d72a40731dcb6cfc84c7bcdc8321e
+  checksum: 10c0/e12af106e16e652bd83060e8afacece4ee3dcbd0f4cf028e3d9ad178e6ced9ecb1c87ee60158b239582313902a717f8adc57a9b76ea54b1994141ba15f420c65
   languageName: node
   linkType: hard
 
 "resolve@patch:resolve@npm%3A^2.0.0-next.5#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^2.0.0-next.6#optional!builtin<compat/resolve>":
   version: 2.0.0-next.6
-  resolution: "resolve@patch:resolve@npm%3A2.0.0-next.6#optional!builtin<compat/resolve>::version=2.0.0-next.6&hash=c3c19d"
+  resolution: "resolve@patch:resolve@npm%3A2.0.0-next.6#optional!builtin<compat/resolve>::version=2.0.0-next.6&hash=9bd1a5"
   dependencies:
     es-errors: "npm:^1.3.0"
     is-core-module: "npm:^2.16.1"
@@ -30348,7 +30348,7 @@ __metadata:
     supports-preserve-symlinks-flag: "npm:^1.0.0"
   bin:
     resolve: bin/resolve
-  checksum: 10c0/dca533e38820b0d8d636f269824cef3b7435802ab7401211c6f10af03be0e2f7e216047234e1623046c0a6791577079767e0c04f0d36e42c7f567b1bff7b0742
+  checksum: 10c0/f59a0b355000ae2626fbf62c652c87312ccd213be7a81f4135fd23ecb7a22df48b7b42358fa42f1ad26b8380a71a53413a3a5b123d8fb255fedc25739416efda
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Goals

- Stop spending CI capacity on Node.js 20 now that the project tests newer supported runtimes.
- Standardize the repository and CI on Yarn 4.17.1 through Corepack.

## Changes

- Removed the Node.js 20 entry from the test matrix.
- Updated root, website, test, and deployment Yarn pins to 4.17.1.
- Applied Yarn's generated configuration migration so install scripts retain their prior behavior.
- Refreshed the lockfile format and built-in compatibility patch hashes.
- Confirmed there are no active Volta dependencies or setup steps; Corepack is already used throughout CI and release workflows.

## Validation

- `yarn install --immutable`
- `yarn build`
- `yarn lint fix`
- Node and headless test runs were attempted, but the local runner's network-approval request was canceled before execution completed; PR CI will run both suites.
