### PR TITLE
Add glTF Zod and JSON schemas

### DIFF
--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -83,6 +83,10 @@ Release Date: 2026
 - [`GeoTIFFSourceLoader`](/docs/modules/geotiff/api-reference/geotiff-source-loader) NEW - viewport-driven GeoTIFF / COG source that returns typed raster payloads plus CRS and bounds metadata.
 - [`OMETiffSourceLoader`](/docs/modules/geotiff/api-reference/ometiff-source-loader) NEW - non-geospatial OME-TIFF source for channel-aware 2D plane reads from image pyramids.
 
+**@loaders.gl/gltf**
+
+- `GLTFSchema` and schemas for individual glTF JSON objects provide Zod-based runtime validation. A generated Draft-07 JSON Schema is published at the `gltf.schema.json` package subpath for Monaco and other editor integrations.
+
 **@loaders.gl/json**
 
 - [`JSONLoader`](/docs/modules/json/api-reference/json-loader) adds experimental `json.backend: 'fast'` for opt-in faster streaming extraction while keeping atomic JSON parsing on the standard `JSON.parse` path.

--- a/modules/gltf/README.md
+++ b/modules/gltf/README.md
@@ -1,5 +1,21 @@
 # @loaders.gl/gltf
 
+The module exports `GLTFSchema` and schemas for the individual glTF JSON objects. These are
+[Zod](https://zod.dev/) schemas and can be used to validate a parsed document:
+
+```ts
+import {GLTFSchema} from '@loaders.gl/gltf';
+
+const gltf = GLTFSchema.parse(json);
+```
+
+The same schema is published as JSON Schema at the `gltf.schema.json` package subpath. This can
+be referenced by editors and other browser tools without bundling the JavaScript module:
+
+```text
+https://unpkg.com/@loaders.gl/gltf@5/gltf.schema.json
+```
+
 [loaders.gl](https://loaders.gl/docs) is a collection of framework-independent 3D and geospatial parsers and encoders.
 
 This module contains loader and writers for the glTF format.

--- a/modules/gltf/package.json
+++ b/modules/gltf/package.json
@@ -36,7 +36,8 @@
     "./bundled": {
       "types": "./dist/bundled.d.ts",
       "import": "./dist/bundled.js"
-    }
+    },
+    "./gltf.schema.json": "./dist/gltf.schema.json"
   },
   "sideEffects": false,
   "files": [
@@ -46,7 +47,8 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-bundle-dev",
+    "pre-build": "npm run generate-json-schema && npm run build-bundle && npm run build-bundle-dev",
+    "generate-json-schema": "node scripts/generate-json-schema.mjs",
     "build-bundle": "ocular-bundle ./bundle.ts --output=dist/dist.min.js",
     "build-bundle-dev": "ocular-bundle ./bundle.ts --env=dev --output=dist/dist.dev.js"
   },
@@ -56,7 +58,8 @@
     "@loaders.gl/loader-utils": "5.0.0-alpha.1",
     "@loaders.gl/schema": "5.0.0-alpha.1",
     "@loaders.gl/textures": "5.0.0-alpha.1",
-    "@math.gl/core": "^4.1.0"
+    "@math.gl/core": "^4.1.0",
+    "zod": "^4.1.12"
   },
   "peerDependencies": {
     "@loaders.gl/core": "~5.0.0-alpha.0"

--- a/modules/gltf/scripts/generate-json-schema.mjs
+++ b/modules/gltf/scripts/generate-json-schema.mjs
@@ -1,0 +1,19 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {writeFile} from 'node:fs/promises';
+import {fileURLToPath} from 'node:url';
+import {z} from 'zod';
+import {GLTFSchema} from '../dist/lib/types/gltf-zod-schema.js';
+
+const outputUrl = new URL('../dist/gltf.schema.json', import.meta.url);
+const jsonSchema = z.toJSONSchema(GLTFSchema, {
+  target: 'draft-7',
+  reused: 'ref'
+});
+
+jsonSchema.$id = 'https://unpkg.com/@loaders.gl/gltf/gltf.schema.json';
+jsonSchema.title = 'glTF 2.0';
+
+await writeFile(fileURLToPath(outputUrl), `${JSON.stringify(jsonSchema, null, 2)}\n`);

--- a/modules/gltf/src/index.ts
+++ b/modules/gltf/src/index.ts
@@ -78,6 +78,45 @@ export type {
 } from './lib/types/gltf-postprocessed-schema';
 
 export type {GLTFWithBuffers, FeatureTableJson} from './lib/types/gltf-types';
+export {
+  GLTFSchema,
+  GLTFIdSchema,
+  GLTFObjectSchema,
+  GLTFAccessorSchema,
+  GLTFAccessorSparseSchema,
+  GLTFAccessorSparseIndicesSchema,
+  GLTFAccessorSparseValuesSchema,
+  GLTFAnimationSchema,
+  GLTFAnimationChannelSchema,
+  GLTFAnimationChannelTargetSchema,
+  GLTFAnimationSamplerSchema,
+  GLTFAssetSchema,
+  GLTFBufferSchema,
+  GLTFBufferViewSchema,
+  GLTFCameraSchema,
+  GLTFCameraOrthographicSchema,
+  GLTFCameraPerspectiveSchema,
+  GLTFImageSchema,
+  GLTFMaterialSchema,
+  GLTFMaterialNormalTextureInfoSchema,
+  GLTFMaterialOcclusionTextureInfoSchema,
+  GLTFMaterialPbrMetallicRoughnessSchema,
+  GLTFMeshSchema,
+  GLTFMeshPrimitiveSchema,
+  GLTFNodeSchema,
+  GLTFSamplerSchema,
+  GLTFSceneSchema,
+  GLTFSkinSchema,
+  GLTFTextureSchema,
+  GLTFTextureInfoSchema,
+  GLTFTextureInfoMetadataSchema,
+  GLTFKHRBinarySchema,
+  GLTFKHRDracoMeshCompressionSchema,
+  GLTFKHRTextureBasisuSchema,
+  GLTFEXTMeshoptCompressionSchema,
+  GLTFEXTTextureWebpSchema,
+  GLTFMSFTTextureDdsSchema
+} from './lib/types/gltf-zod-schema';
 export {GLTFFormat, GLBFormat} from './gltf-format';
 
 // glTF loader/writer definition objects

--- a/modules/gltf/src/lib/types/gltf-zod-schema.ts
+++ b/modules/gltf/src/lib/types/gltf-zod-schema.ts
@@ -1,0 +1,428 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {z} from 'zod';
+
+/** Zod schema for an index into a top-level glTF array. */
+export const GLTFIdSchema = z.number().int().nonnegative();
+const GLTF_EXTENSIONS_SCHEMA = z.record(z.string(), z.unknown());
+const GLTF_PROPERTY_SHAPE = {
+  extensions: GLTF_EXTENSIONS_SCHEMA.optional(),
+  extras: z.unknown().optional()
+};
+const GLTF_NAMED_PROPERTY_SHAPE = {
+  ...GLTF_PROPERTY_SHAPE,
+  name: z.string().optional()
+};
+
+/** Zod schema for sparse accessor indices. */
+export const GLTFAccessorSparseIndicesSchema = z
+  .object({
+    bufferView: GLTFIdSchema,
+    byteOffset: z.number().int().nonnegative().optional(),
+    componentType: z.union([z.literal(5121), z.literal(5123), z.literal(5125)]),
+    ...GLTF_PROPERTY_SHAPE
+  })
+  .catchall(z.unknown());
+
+/** Zod schema for sparse accessor values. */
+export const GLTFAccessorSparseValuesSchema = z
+  .object({
+    bufferView: GLTFIdSchema,
+    byteOffset: z.number().int().nonnegative().optional(),
+    ...GLTF_PROPERTY_SHAPE
+  })
+  .catchall(z.unknown());
+
+/** Zod schema for sparse accessor storage. */
+export const GLTFAccessorSparseSchema = z
+  .object({
+    count: z.number().int().positive(),
+    indices: GLTFAccessorSparseIndicesSchema,
+    values: GLTFAccessorSparseValuesSchema,
+    ...GLTF_PROPERTY_SHAPE
+  })
+  .catchall(z.unknown());
+
+/** Zod schema for a glTF accessor. */
+export const GLTFAccessorSchema = z
+  .object({
+    bufferView: GLTFIdSchema.optional(),
+    byteOffset: z.number().int().nonnegative().optional(),
+    componentType: z.union([
+      z.literal(5120),
+      z.literal(5121),
+      z.literal(5122),
+      z.literal(5123),
+      z.literal(5125),
+      z.literal(5126)
+    ]),
+    normalized: z.boolean().optional(),
+    count: z.number().int().positive(),
+    type: z.enum(['SCALAR', 'VEC2', 'VEC3', 'VEC4', 'MAT2', 'MAT3', 'MAT4']),
+    max: z.array(z.number()).min(1).max(16).optional(),
+    min: z.array(z.number()).min(1).max(16).optional(),
+    sparse: GLTFAccessorSparseSchema.optional(),
+    ...GLTF_NAMED_PROPERTY_SHAPE
+  })
+  .catchall(z.unknown());
+
+/** Zod schema for an animation channel target. */
+export const GLTFAnimationChannelTargetSchema = z
+  .object({
+    node: GLTFIdSchema.optional(),
+    path: z.enum(['translation', 'rotation', 'scale', 'weights']),
+    ...GLTF_PROPERTY_SHAPE
+  })
+  .catchall(z.unknown());
+
+/** Zod schema for an animation channel. */
+export const GLTFAnimationChannelSchema = z
+  .object({
+    sampler: GLTFIdSchema,
+    target: GLTFAnimationChannelTargetSchema,
+    ...GLTF_PROPERTY_SHAPE
+  })
+  .catchall(z.unknown());
+
+/** Zod schema for an animation sampler. */
+export const GLTFAnimationSamplerSchema = z
+  .object({
+    input: GLTFIdSchema,
+    interpolation: z.enum(['LINEAR', 'STEP', 'CUBICSPLINE']).optional(),
+    output: GLTFIdSchema,
+    ...GLTF_PROPERTY_SHAPE
+  })
+  .catchall(z.unknown());
+
+/** Zod schema for a glTF animation. */
+export const GLTFAnimationSchema = z
+  .object({
+    channels: z.array(GLTFAnimationChannelSchema).min(1),
+    samplers: z.array(GLTFAnimationSamplerSchema).min(1),
+    ...GLTF_NAMED_PROPERTY_SHAPE
+  })
+  .catchall(z.unknown());
+
+/** Zod schema for glTF asset metadata. */
+export const GLTFAssetSchema = z
+  .object({
+    copyright: z.string().optional(),
+    generator: z.string().optional(),
+    version: z.string(),
+    minVersion: z.string().optional(),
+    ...GLTF_PROPERTY_SHAPE
+  })
+  .catchall(z.unknown());
+
+/** Zod schema for a glTF buffer. */
+export const GLTFBufferSchema = z
+  .object({
+    uri: z.string().optional(),
+    byteLength: z.number().int().positive(),
+    ...GLTF_NAMED_PROPERTY_SHAPE
+  })
+  .catchall(z.unknown());
+
+/** Zod schema for a glTF buffer view. */
+export const GLTFBufferViewSchema = z
+  .object({
+    buffer: GLTFIdSchema,
+    byteOffset: z.number().int().nonnegative().optional(),
+    byteLength: z.number().int().positive(),
+    byteStride: z.number().int().min(4).max(252).optional(),
+    target: z.number().int().optional(),
+    ...GLTF_NAMED_PROPERTY_SHAPE
+  })
+  .catchall(z.unknown());
+
+/** Zod schema for an orthographic glTF camera. */
+export const GLTFCameraOrthographicSchema = z
+  .object({
+    xmag: z.number(),
+    ymag: z.number(),
+    zfar: z.number(),
+    znear: z.number().nonnegative(),
+    ...GLTF_PROPERTY_SHAPE
+  })
+  .catchall(z.unknown());
+
+/** Zod schema for a perspective glTF camera. */
+export const GLTFCameraPerspectiveSchema = z
+  .object({
+    aspectRatio: z.number().positive().optional(),
+    yfov: z.number().positive(),
+    zfar: z.number().positive().optional(),
+    znear: z.number().positive(),
+    ...GLTF_PROPERTY_SHAPE
+  })
+  .catchall(z.unknown());
+
+/** Zod schema for a glTF camera. */
+export const GLTFCameraSchema = z
+  .object({
+    orthographic: GLTFCameraOrthographicSchema.optional(),
+    perspective: GLTFCameraPerspectiveSchema.optional(),
+    type: z.enum(['perspective', 'orthographic']),
+    ...GLTF_NAMED_PROPERTY_SHAPE
+  })
+  .catchall(z.unknown());
+
+/** Zod schema for a glTF image. */
+export const GLTFImageSchema = z
+  .object({
+    uri: z.string().optional(),
+    mimeType: z.string().optional(),
+    bufferView: GLTFIdSchema.optional(),
+    ...GLTF_NAMED_PROPERTY_SHAPE
+  })
+  .catchall(z.unknown());
+
+/** Zod schema for a glTF texture reference. */
+export const GLTFTextureInfoSchema = z
+  .object({
+    index: GLTFIdSchema,
+    texCoord: z.number().int().nonnegative().optional(),
+    ...GLTF_PROPERTY_SHAPE
+  })
+  .catchall(z.unknown());
+
+/** Zod schema for a metadata texture reference. */
+export const GLTFTextureInfoMetadataSchema = GLTFTextureInfoSchema.extend({
+  channels: z.union([z.array(z.number().int().nonnegative()), z.string()]),
+  data: z.unknown().optional()
+});
+
+/** Zod schema for a metallic-roughness PBR material definition. */
+export const GLTFMaterialPbrMetallicRoughnessSchema = z
+  .object({
+    baseColorFactor: z.array(z.number()).length(4).optional(),
+    baseColorTexture: GLTFTextureInfoSchema.optional(),
+    metallicFactor: z.number().min(0).max(1).optional(),
+    roughnessFactor: z.number().min(0).max(1).optional(),
+    metallicRoughnessTexture: GLTFTextureInfoSchema.optional(),
+    ...GLTF_PROPERTY_SHAPE
+  })
+  .catchall(z.unknown());
+
+/** Zod schema for a normal texture reference. */
+export const GLTFMaterialNormalTextureInfoSchema = z
+  .object({
+    index: GLTFIdSchema,
+    texCoord: z.number().int().nonnegative().optional(),
+    scale: z.number().optional(),
+    ...GLTF_PROPERTY_SHAPE
+  })
+  .catchall(z.unknown());
+
+/** Zod schema for an occlusion texture reference. */
+export const GLTFMaterialOcclusionTextureInfoSchema = z
+  .object({
+    index: GLTFIdSchema,
+    texCoord: z.number().int().nonnegative().optional(),
+    strength: z.number().min(0).max(1).optional(),
+    ...GLTF_PROPERTY_SHAPE
+  })
+  .catchall(z.unknown());
+
+/** Zod schema for a glTF material. */
+export const GLTFMaterialSchema = z
+  .object({
+    pbrMetallicRoughness: GLTFMaterialPbrMetallicRoughnessSchema.optional(),
+    normalTexture: GLTFMaterialNormalTextureInfoSchema.optional(),
+    occlusionTexture: GLTFMaterialOcclusionTextureInfoSchema.optional(),
+    emissiveTexture: GLTFTextureInfoSchema.optional(),
+    emissiveFactor: z.array(z.number()).length(3).optional(),
+    alphaMode: z.enum(['OPAQUE', 'MASK', 'BLEND']).optional(),
+    alphaCutoff: z.number().optional(),
+    doubleSided: z.boolean().optional(),
+    ...GLTF_NAMED_PROPERTY_SHAPE
+  })
+  .catchall(z.unknown());
+
+/** Zod schema for a glTF mesh primitive. */
+export const GLTFMeshPrimitiveSchema = z
+  .object({
+    attributes: z.record(z.string(), GLTFIdSchema),
+    indices: GLTFIdSchema.optional(),
+    material: GLTFIdSchema.optional(),
+    mode: z
+      .union([
+        z.literal(0),
+        z.literal(1),
+        z.literal(2),
+        z.literal(3),
+        z.literal(4),
+        z.literal(5),
+        z.literal(6)
+      ])
+      .optional(),
+    targets: z.array(z.record(z.string(), GLTFIdSchema)).min(1).optional(),
+    ...GLTF_PROPERTY_SHAPE
+  })
+  .catchall(z.unknown());
+
+/** Zod schema for a glTF mesh. */
+export const GLTFMeshSchema = z
+  .object({
+    id: z.string().optional(),
+    primitives: z.array(GLTFMeshPrimitiveSchema).min(1),
+    weights: z.array(z.number()).min(1).optional(),
+    ...GLTF_NAMED_PROPERTY_SHAPE
+  })
+  .catchall(z.unknown());
+
+/** Zod schema for a glTF node. */
+export const GLTFNodeSchema = z
+  .object({
+    camera: GLTFIdSchema.optional(),
+    children: z.array(GLTFIdSchema).min(1).optional(),
+    skin: GLTFIdSchema.optional(),
+    matrix: z.array(z.number()).length(16).optional(),
+    mesh: GLTFIdSchema.optional(),
+    rotation: z.array(z.number()).length(4).optional(),
+    scale: z.array(z.number()).length(3).optional(),
+    translation: z.array(z.number()).length(3).optional(),
+    weights: z.array(z.number()).min(1).optional(),
+    ...GLTF_NAMED_PROPERTY_SHAPE
+  })
+  .catchall(z.unknown());
+
+/** Zod schema for a glTF texture sampler. */
+export const GLTFSamplerSchema = z
+  .object({
+    magFilter: z.union([z.literal(9728), z.literal(9729)]).optional(),
+    minFilter: z
+      .union([
+        z.literal(9728),
+        z.literal(9729),
+        z.literal(9984),
+        z.literal(9985),
+        z.literal(9986),
+        z.literal(9987)
+      ])
+      .optional(),
+    wrapS: z.union([z.literal(33071), z.literal(33648), z.literal(10497)]).optional(),
+    wrapT: z.union([z.literal(33071), z.literal(33648), z.literal(10497)]).optional(),
+    ...GLTF_NAMED_PROPERTY_SHAPE
+  })
+  .catchall(z.unknown());
+
+/** Zod schema for a glTF scene. */
+export const GLTFSceneSchema = z
+  .object({
+    nodes: z.array(GLTFIdSchema).min(1).optional(),
+    ...GLTF_NAMED_PROPERTY_SHAPE
+  })
+  .catchall(z.unknown());
+
+/** Zod schema for a glTF skin. */
+export const GLTFSkinSchema = z
+  .object({
+    id: z.string().optional(),
+    inverseBindMatrices: GLTFIdSchema.optional(),
+    skeleton: GLTFIdSchema.optional(),
+    joints: z.array(GLTFIdSchema).min(1),
+    ...GLTF_NAMED_PROPERTY_SHAPE
+  })
+  .catchall(z.unknown());
+
+/** Zod schema for a glTF texture. */
+export const GLTFTextureSchema = z
+  .object({
+    sampler: GLTFIdSchema.optional(),
+    source: GLTFIdSchema.optional(),
+    ...GLTF_NAMED_PROPERTY_SHAPE
+  })
+  .catchall(z.unknown());
+
+/** Zod schema for a complete glTF 2.0 JSON document. */
+export const GLTFSchema = z
+  .object({
+    extensionsUsed: z.array(z.string()).min(1).optional(),
+    extensionsRequired: z.array(z.string()).min(1).optional(),
+    accessors: z.array(GLTFAccessorSchema).min(1).optional(),
+    animations: z.array(GLTFAnimationSchema).min(1).optional(),
+    asset: GLTFAssetSchema,
+    buffers: z.array(GLTFBufferSchema).min(1).optional(),
+    bufferViews: z.array(GLTFBufferViewSchema).min(1).optional(),
+    cameras: z.array(GLTFCameraSchema).min(1).optional(),
+    images: z.array(GLTFImageSchema).min(1).optional(),
+    materials: z.array(GLTFMaterialSchema).min(1).optional(),
+    meshes: z.array(GLTFMeshSchema).min(1).optional(),
+    nodes: z.array(GLTFNodeSchema).min(1).optional(),
+    samplers: z.array(GLTFSamplerSchema).min(1).optional(),
+    scene: GLTFIdSchema.optional(),
+    scenes: z.array(GLTFSceneSchema).min(1).optional(),
+    skins: z.array(GLTFSkinSchema).min(1).optional(),
+    textures: z.array(GLTFTextureSchema).min(1).optional(),
+    ...GLTF_PROPERTY_SHAPE
+  })
+  .catchall(z.unknown())
+  .describe('The root object for a glTF 2.0 asset.');
+
+/** Zod schema for any core glTF object. */
+export const GLTFObjectSchema = z.union([
+  GLTFAccessorSchema,
+  GLTFBufferSchema,
+  GLTFBufferViewSchema,
+  GLTFMeshPrimitiveSchema,
+  GLTFMeshSchema,
+  GLTFNodeSchema,
+  GLTFMaterialSchema,
+  GLTFSamplerSchema,
+  GLTFSceneSchema,
+  GLTFSkinSchema,
+  GLTFTextureSchema,
+  GLTFImageSchema
+]);
+
+/** Zod schema for the KHR_binary_glTF extension. */
+export const GLTFKHRBinarySchema = z
+  .object({
+    bufferView: GLTFIdSchema,
+    mimeType: z.string().optional(),
+    height: z.number().optional(),
+    width: z.number().optional(),
+    extras: z.unknown().optional()
+  })
+  .catchall(z.unknown());
+
+/** Zod schema for the KHR_draco_mesh_compression extension. */
+export const GLTFKHRDracoMeshCompressionSchema = z
+  .object({
+    bufferView: GLTFIdSchema,
+    attributes: z.record(z.string(), GLTFIdSchema),
+    extras: z.unknown().optional()
+  })
+  .catchall(z.unknown());
+
+/** Zod schema for the KHR_texture_basisu extension. */
+export const GLTFKHRTextureBasisuSchema = z
+  .object({source: GLTFIdSchema, extras: z.unknown().optional()})
+  .catchall(z.unknown());
+
+/** Zod schema for the EXT_meshopt_compression extension. */
+export const GLTFEXTMeshoptCompressionSchema = z
+  .object({
+    buffer: GLTFIdSchema,
+    byteOffset: z.number().int().nonnegative().optional(),
+    byteLength: z.number().int().positive(),
+    byteStride: z.number().int().positive(),
+    count: z.number().int().positive(),
+    mode: z.enum(['ATTRIBUTES', 'TRIANGLES', 'INDICES']),
+    filter: z.enum(['NONE', 'OCTAHEDRAL', 'QUATERNION', 'EXPONENTIAL']).optional(),
+    extras: z.unknown().optional()
+  })
+  .catchall(z.unknown());
+
+/** Zod schema for the EXT_texture_webp extension. */
+export const GLTFEXTTextureWebpSchema = z
+  .object({source: GLTFIdSchema, extras: z.unknown().optional()})
+  .catchall(z.unknown());
+
+/** Zod schema for the MSFT_texture_dds extension. */
+export const GLTFMSFTTextureDdsSchema = z
+  .object({source: GLTFIdSchema, extras: z.unknown().optional()})
+  .catchall(z.unknown());

--- a/modules/gltf/src/lib/types/gltf-zod-schema.ts
+++ b/modules/gltf/src/lib/types/gltf-zod-schema.ts
@@ -72,7 +72,7 @@ export const GLTFAccessorSchema = z
 export const GLTFAnimationChannelTargetSchema = z
   .object({
     node: GLTFIdSchema.optional(),
-    path: z.enum(['translation', 'rotation', 'scale', 'weights']),
+    path: z.union([z.enum(['translation', 'rotation', 'scale', 'weights']), z.string()]),
     ...GLTF_PROPERTY_SHAPE
   })
   .catchall(z.unknown());
@@ -160,24 +160,44 @@ export const GLTFCameraPerspectiveSchema = z
   .catchall(z.unknown());
 
 /** Zod schema for a glTF camera. */
-export const GLTFCameraSchema = z
-  .object({
-    orthographic: GLTFCameraOrthographicSchema.optional(),
-    perspective: GLTFCameraPerspectiveSchema.optional(),
-    type: z.enum(['perspective', 'orthographic']),
-    ...GLTF_NAMED_PROPERTY_SHAPE
-  })
-  .catchall(z.unknown());
+export const GLTFCameraSchema = z.discriminatedUnion('type', [
+  z
+    .object({
+      type: z.literal('orthographic'),
+      orthographic: GLTFCameraOrthographicSchema,
+      perspective: z.never().optional(),
+      ...GLTF_NAMED_PROPERTY_SHAPE
+    })
+    .catchall(z.unknown()),
+  z
+    .object({
+      type: z.literal('perspective'),
+      perspective: GLTFCameraPerspectiveSchema,
+      orthographic: z.never().optional(),
+      ...GLTF_NAMED_PROPERTY_SHAPE
+    })
+    .catchall(z.unknown())
+]);
 
 /** Zod schema for a glTF image. */
-export const GLTFImageSchema = z
-  .object({
-    uri: z.string().optional(),
-    mimeType: z.string().optional(),
-    bufferView: GLTFIdSchema.optional(),
-    ...GLTF_NAMED_PROPERTY_SHAPE
-  })
-  .catchall(z.unknown());
+export const GLTFImageSchema = z.union([
+  z
+    .object({
+      uri: z.string(),
+      mimeType: z.string().optional(),
+      bufferView: z.never().optional(),
+      ...GLTF_NAMED_PROPERTY_SHAPE
+    })
+    .catchall(z.unknown()),
+  z
+    .object({
+      bufferView: GLTFIdSchema,
+      mimeType: z.string(),
+      uri: z.never().optional(),
+      ...GLTF_NAMED_PROPERTY_SHAPE
+    })
+    .catchall(z.unknown())
+]);
 
 /** Zod schema for a glTF texture reference. */
 export const GLTFTextureInfoSchema = z

--- a/modules/gltf/test/gltf-zod-schema.spec.ts
+++ b/modules/gltf/test/gltf-zod-schema.spec.ts
@@ -21,4 +21,52 @@ describe('GLTFSchema', () => {
     expect(GLTFSchema.safeParse({asset: {version: 2}}).success).toBe(false);
     expect(GLTFSchema.safeParse({asset: {version: '2.0'}, scene: -1}).success).toBe(false);
   });
+
+  it('accepts extension-defined animation target paths', () => {
+    const document = {
+      asset: {version: '2.0'},
+      animations: [
+        {
+          channels: [{sampler: 0, target: {path: 'pointer'}}],
+          samplers: [{input: 0, output: 1}]
+        }
+      ]
+    };
+
+    expect(GLTFSchema.safeParse(document).success).toBe(true);
+  });
+
+  it('requires the camera projection matching its type', () => {
+    const asset = {version: '2.0'};
+    const perspective = {yfov: 1, znear: 0.1};
+    const orthographic = {xmag: 1, ymag: 1, zfar: 100, znear: 0};
+
+    expect(
+      GLTFSchema.safeParse({asset, cameras: [{type: 'perspective', perspective}]}).success
+    ).toBe(true);
+    expect(GLTFSchema.safeParse({asset, cameras: [{type: 'perspective'}]}).success).toBe(false);
+    expect(
+      GLTFSchema.safeParse({
+        asset,
+        cameras: [{type: 'perspective', perspective, orthographic}]
+      }).success
+    ).toBe(false);
+  });
+
+  it('requires exactly one valid image source', () => {
+    const asset = {version: '2.0'};
+
+    expect(GLTFSchema.safeParse({asset, images: [{uri: 'image.png'}]}).success).toBe(true);
+    expect(
+      GLTFSchema.safeParse({asset, images: [{bufferView: 0, mimeType: 'image/png'}]}).success
+    ).toBe(true);
+    expect(GLTFSchema.safeParse({asset, images: [{}]}).success).toBe(false);
+    expect(GLTFSchema.safeParse({asset, images: [{bufferView: 0}]}).success).toBe(false);
+    expect(
+      GLTFSchema.safeParse({
+        asset,
+        images: [{uri: 'image.png', bufferView: 0, mimeType: 'image/png'}]
+      }).success
+    ).toBe(false);
+  });
 });

--- a/modules/gltf/test/gltf-zod-schema.spec.ts
+++ b/modules/gltf/test/gltf-zod-schema.spec.ts
@@ -1,0 +1,24 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {GLTFSchema} from '@loaders.gl/gltf';
+import {describe, expect, it} from 'vitest';
+
+describe('GLTFSchema', () => {
+  it('accepts a glTF document and preserves extension properties', () => {
+    const document = {
+      asset: {version: '2.0'},
+      extensionsUsed: ['EXT_meshopt_compression'],
+      extensions: {EXT_example: {enabled: true}},
+      customProperty: 'preserved'
+    };
+
+    expect(GLTFSchema.parse(document)).toEqual(document);
+  });
+
+  it('rejects malformed core properties', () => {
+    expect(GLTFSchema.safeParse({asset: {version: 2}}).success).toBe(false);
+    expect(GLTFSchema.safeParse({asset: {version: '2.0'}, scene: -1}).success).toBe(false);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5454,6 +5454,7 @@ __metadata:
     "@loaders.gl/schema": "npm:5.0.0-alpha.1"
     "@loaders.gl/textures": "npm:5.0.0-alpha.1"
     "@math.gl/core": "npm:^4.1.0"
+    zod: "npm:^4.1.12"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
   languageName: unknown


### PR DESCRIPTION
## Goals

Add runtime validation schemas for glTF JSON and publish a JSON Schema suitable for Monaco and other browser-based editors.

## Changes

- Add Zod schemas for the glTF root document, core objects, and supported extensions
- Export the schemas from `@loaders.gl/gltf`
- Generate a Draft-07 JSON Schema during the package build
- Export the generated artifact as `@loaders.gl/gltf/gltf.schema.json`
- Document the unpkg URL for browser and editor integrations
- Add Node and browser validation coverage
- Add Zod as a runtime dependency

## Validation

- `yarn build`
- `yarn lint fix`
- `yarn test-node modules/gltf/test/gltf-zod-schema.spec.ts`
- `yarn test-headless modules/gltf/test/gltf-zod-schema.spec.ts`
- Verified the generated schema resolves through the package export and is included in the package tarball