### PR TITLE
Add draft glTF 2.1 accessor component types

### DIFF
--- a/docs/modules/gltf/api-reference/gltf-loader.md
+++ b/docs/modules/gltf/api-reference/gltf-loader.md
@@ -12,7 +12,7 @@ A glTF file contains a hierarchical scenegraph description that can be used to i
 | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
 | File Extensions | `.glb`, `.gltf`                                                                                                                                                 |
 | File Type       | Binary, JSON, Linked Assets                                                                                                                                     |
-| File Format     | [glTF v2](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0), [GLTF v1](https://github.com/KhronosGroup/glTF/tree/master/specification/1.0) \* |
+| File Format     | [glTF v2.1 (draft)](/docs/modules/gltf/formats/gltf#gltf-21-draft), [glTF v2](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0), [GLTF v1](https://github.com/KhronosGroup/glTF/tree/master/specification/1.0) \* |
 | Data Format     | [Scenegraph](/docs/specifications/category-scenegraph)                                                                                                          |
 | Supported APIs  | `load`, `parse`                                                                                                                                                 |
 | Subloaders      | `DracoLoader`, `ImageBitmapLoader`                                                                                                                              |     |
@@ -39,6 +39,8 @@ const gltf = load(url, GLTFLoader, {DracoLoader, decompress: true});
 ## Overview
 
 The `GLTFLoader` aims to take care of as much processing as possible, while remaining framework-independent.
+
+Draft glTF 2.1 readiness includes the [new accessor component type definitions](/docs/modules/gltf/formats/gltf#accessor-component-types). `GLTFScenegraph` and `postProcessGLTF` expose these values through the corresponding JavaScript typed arrays.
 
 The GLTF Loader returns an object with a `json` field containing the glTF Scenegraph. In its basic mode, the `GLTFLoader` does not modify the loaded JSON in any way. Instead, the results of additional processing are placed in parallel top-level fields such as `buffers` and `images`. This ensures that applications that want to work with the standard glTF data structure can do so.
 

--- a/docs/modules/gltf/api-reference/post-process-gltf.md
+++ b/docs/modules/gltf/api-reference/post-process-gltf.md
@@ -92,6 +92,8 @@ The accessor parameters which are textual strings in glTF will be resolved into 
 
 - `accessor.value` - This will be set to a typed array that is a view into the underlying bufferView.
 
+Draft glTF 2.1 accessor component types are represented by `Int32Array`, `Float64Array`, `Uint16Array` (raw IEEE-754 binary16 words), `BigInt64Array`, or `BigUint64Array` as appropriate. See [Accessor Component Types](/docs/modules/gltf/formats/gltf#accessor-component-types).
+
 Remarks:
 
 - While it can be very convenient to initialize WebGL buffers from `accessor.value`, this approach will defeat any memory sharing on the GPU that the glTF file specifies through accessors sharing `bufferViews`. The canonical way of instantitating a glTF model is for an application to create one WebGL buffer for each `bufferView` and then use accessors to reference data chunks inside those WebGL buffers with `offset` and `stride`.

--- a/docs/modules/gltf/formats/gltf.md
+++ b/docs/modules/gltf/formats/gltf.md
@@ -14,9 +14,27 @@ A glTF file uses one of two possible file extensions: .gltf (JSON/ASCII) or .glb
 
 ## Version History
 
+### glTF 2.1 (Draft)
+
+Khronos has [announced glTF 2.1](https://www.khronos.org/blog/introducing-gltf-2.1-with-complex-scenes) as a backwards-compatible update focused on complex scenes and quality-of-life improvements. The specification remains under development.
+
+#### Accessor Component Types
+
+glTF 2.1 defines additional accessor component type constants for extensions and future core features to reference. Defining a type does not automatically make it valid for every existing accessor use; each feature still specifies the component types it accepts.
+
+| `componentType` | Data type            | loaders.gl representation |
+| --------------- | -------------------- | ------------------------- |
+| `5124`          | Signed 32-bit integer | `Int32Array`              |
+| `5130`          | 64-bit float          | `Float64Array`            |
+| `5131`          | 16-bit float          | `Uint16Array`             |
+| `5134`          | Signed 64-bit integer | `BigInt64Array`           |
+| `5135`          | Unsigned 64-bit integer | `BigUint64Array`         |
+
+JavaScript runtimes supported by loaders.gl do not yet consistently provide `Float16Array`. The loader therefore preserves 16-bit floating-point payloads in a `Uint16Array`; `componentType: 5131` records that the words contain IEEE-754 binary16 values rather than unsigned integers.
+
 ### glTF 2.0
 
--GLB was incorporated directly into glTF 2.0.
+- GLB was incorporated directly into glTF 2.0.
 
 ### glTF 1.0
 

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -24,6 +24,7 @@ Release Date: 2026
 **@loaders.gl/gltf**
 
 - `GLBLoader` adds draft GLB v3 parsing with 64-bit file and chunk lengths, multi-chunk traversal, and reserved chunk-encoding validation, advancing glTF 2.1 readiness.
+- [`GLTFLoader`](/docs/modules/gltf/api-reference/gltf-loader) adds draft [glTF 2.1 accessor component types](/docs/modules/gltf/formats/gltf#accessor-component-types), including signed 32-bit integers, 16- and 64-bit floats, and signed and unsigned 64-bit integers.
 
 **@loaders.gl/las** 
 

--- a/modules/gltf/src/lib/api/post-process-gltf.ts
+++ b/modules/gltf/src/lib/api/post-process-gltf.ts
@@ -66,8 +66,13 @@ const BYTES = {
   5121: 1, // UNSIGNED_BYTE
   5122: 2, // SHORT
   5123: 2, // UNSIGNED_SHORT
+  5124: 4, // INT
   5125: 4, // UNSIGNED_INT
-  5126: 4 // FLOAT
+  5126: 4, // FLOAT
+  5130: 8, // DOUBLE
+  5131: 2, // HALF_FLOAT
+  5134: 8, // INT64
+  5135: 8 // UNSIGNED_INT64
 };
 
 const GL_SAMPLER = {

--- a/modules/gltf/src/lib/gltf-utils/get-typed-array.ts
+++ b/modules/gltf/src/lib/gltf-utils/get-typed-array.ts
@@ -1,6 +1,6 @@
 // TODO - GLTFScenegraph should use these
 import {assert} from '../utils/assert';
-import type {TypedArray} from '@loaders.gl/schema';
+import type {BigTypedArray} from '@loaders.gl/schema';
 import type {GLTF, GLTFExternalBuffer, GLTFAccessor} from '../types/gltf-types';
 import {getAccessorArrayTypeAndLength} from './gltf-utils';
 
@@ -32,14 +32,14 @@ export function getTypedArrayForImageData(json, buffers, imageIndex) {
  * @param json - json part of gltf content of a GLTF tile.
  * @param buffers - Array containing buffers of data.
  * @param accessor - accepts accessor index or accessor object.
- * @returns {TypedArray} Typed array with type matching the type of data poited by the accessor.
+ * @returns Typed array with type matching the accessor component type.
  */
 // eslint-disable-next-line complexity
 export function getTypedArrayForAccessor(
   json: GLTF,
   buffers: GLTFExternalBuffer[],
   accessor: GLTFAccessor | number
-): TypedArray {
+): BigTypedArray {
   const gltfAccessor = typeof accessor === 'number' ? json.accessors?.[accessor] : accessor;
   if (!gltfAccessor) {
     throw new Error(`No gltf accessor ${JSON.stringify(accessor)}`);
@@ -63,11 +63,11 @@ export function getTypedArrayForAccessor(
   // Creare an array of component's type where all components (not just elements) will reside
   if (typeof bufferView.byteStride === 'undefined' || bufferView.byteStride === elementByteSize) {
     // No iterleaving
-    const result: TypedArray = new ArrayType(arrayBuffer, byteOffset, length);
+    const result: BigTypedArray = new ArrayType(arrayBuffer, byteOffset, length);
     return result;
   }
   // Iterleaving
-  const result: TypedArray = new ArrayType(length);
+  const result: BigTypedArray = new ArrayType(length);
   for (let i = 0; i < gltfAccessor.count; i++) {
     const values = new ArrayType(
       arrayBuffer,

--- a/modules/gltf/src/lib/gltf-utils/gltf-constants.ts
+++ b/modules/gltf/src/lib/gltf-utils/gltf-constants.ts
@@ -13,8 +13,13 @@ export const BYTES = {
   5121: 1, // UNSIGNED_BYTE
   5122: 2, // SHORT
   5123: 2, // UNSIGNED_SHORT
+  5124: 4, // INT
   5125: 4, // UNSIGNED_INT
-  5126: 4 // FLOAT
+  5126: 4, // FLOAT
+  5130: 8, // DOUBLE
+  5131: 2, // HALF_FLOAT
+  5134: 8, // INT64
+  5135: 8 // UNSIGNED_INT64
 };
 
 // ENUM LOOKUP

--- a/modules/gltf/src/lib/gltf-utils/gltf-utils.ts
+++ b/modules/gltf/src/lib/gltf-utils/gltf-utils.ts
@@ -52,7 +52,11 @@ const ATTRIBUTE_COMPONENT_TYPE_TO_BYTE_SIZE = {
   5123: 2,
   5124: 4,
   5125: 4,
-  5126: 4
+  5126: 4,
+  5130: 8,
+  5131: 2,
+  5134: 8,
+  5135: 8
 };
 
 const ATTRIBUTE_COMPONENT_TYPE_TO_ARRAY = {
@@ -62,7 +66,13 @@ const ATTRIBUTE_COMPONENT_TYPE_TO_ARRAY = {
   5123: Uint16Array,
   5124: Int32Array,
   5125: Uint32Array,
-  5126: Float32Array
+  5126: Float32Array,
+  5130: Float64Array,
+  // JavaScript does not yet provide Float16Array across supported runtimes.
+  // Preserve binary16 payloads in Uint16Array while componentType retains their semantics.
+  5131: Uint16Array,
+  5134: BigInt64Array,
+  5135: BigUint64Array
 };
 
 export function getAccessorTypeFromSize(size) {

--- a/modules/gltf/src/lib/types/gltf-json-schema.ts
+++ b/modules/gltf/src/lib/types/gltf-json-schema.ts
@@ -77,7 +77,19 @@ export type GLTFAccessor = {
   /**
    * The datatype of components in the attribute.
    */
-  componentType: 5120 | 5121 | 5122 | 5123 | 5125 | 5126 | number;
+  componentType:
+    | 5120
+    | 5121
+    | 5122
+    | 5123
+    | 5124
+    | 5125
+    | 5126
+    | 5130
+    | 5131
+    | 5134
+    | 5135
+    | number;
   /**
    * Specifies whether integer data values should be normalized.
    */

--- a/modules/gltf/src/lib/types/gltf-postprocessed-schema.ts
+++ b/modules/gltf/src/lib/types/gltf-postprocessed-schema.ts
@@ -1,7 +1,7 @@
 // Types forked from https://github.com/bwasty/gltf-loader-ts under MIT license
 // Generated from official JSON schema using `npm run generate-type` = on 2018-02-24
 
-import type {TypedArray} from '@loaders.gl/loader-utils';
+import type {BigTypedArray} from '@loaders.gl/loader-utils';
 
 export type GlTfId = number;
 
@@ -83,7 +83,7 @@ export type GLTFAccessorPostprocessed = {
   components: number;
   bytesPerComponent: number;
   bytesPerElement: number;
-  value: TypedArray;
+  value: BigTypedArray;
 
   // GLTF attributes (possibly overridden)
   /**
@@ -97,7 +97,19 @@ export type GLTFAccessorPostprocessed = {
   /**
    * The datatype of components in the attribute.
    */
-  componentType: 5120 | 5121 | 5122 | 5123 | 5125 | 5126 | number;
+  componentType:
+    | 5120
+    | 5121
+    | 5122
+    | 5123
+    | 5124
+    | 5125
+    | 5126
+    | 5130
+    | 5131
+    | 5134
+    | 5135
+    | number;
   /**
    * Specifies whether integer data values should be normalized.
    */

--- a/modules/gltf/test/index.ts
+++ b/modules/gltf/test/index.ts
@@ -5,6 +5,7 @@ import './lib/glb/glb-encoder-decoder.spec';
 import './lib/glb/glb-custom-payload.spec';
 
 import './lib/gltf-utils/gltf-attribute-utils.spec';
+import './lib/gltf-utils/gltf-accessor-component-types.spec';
 import './lib/gltf-utils/resolve-url.spec';
 
 import './lib/api/gltf-scenegraph-modifiers.spec';

--- a/modules/gltf/test/lib/gltf-utils/gltf-accessor-component-types.spec.ts
+++ b/modules/gltf/test/lib/gltf-utils/gltf-accessor-component-types.spec.ts
@@ -1,0 +1,74 @@
+import test from 'tape-promise/tape';
+
+import {GLTFScenegraph, postProcessGLTF} from '@loaders.gl/gltf';
+import type {BigTypedArray} from '@loaders.gl/schema';
+
+const TEST_CASES: {
+  name: string;
+  componentType: number;
+  source: BigTypedArray;
+}[] = [
+  {name: 'INT', componentType: 5124, source: new Int32Array([-123456789, 123456789])},
+  {name: 'DOUBLE', componentType: 5130, source: new Float64Array([Math.PI, -0.25])},
+  {name: 'HALF_FLOAT', componentType: 5131, source: new Uint16Array([0x3c00, 0xc000])},
+  {
+    name: 'INT64',
+    componentType: 5134,
+    source: new BigInt64Array([-9007199254740993n, 9223372036854775807n])
+  },
+  {
+    name: 'UNSIGNED_INT64',
+    componentType: 5135,
+    source: new BigUint64Array([9007199254740993n, 18446744073709551615n])
+  }
+];
+
+test('glTF 2.1 accessor component types', t => {
+  for (const testCase of TEST_CASES) {
+    const gltf = {
+      json: {
+        asset: {version: '2.1'},
+        buffers: [{byteLength: testCase.source.byteLength}],
+        bufferViews: [{buffer: 0, byteLength: testCase.source.byteLength}],
+        accessors: [
+          {
+            bufferView: 0,
+            componentType: testCase.componentType,
+            count: testCase.source.length,
+            type: 'SCALAR' as const
+          }
+        ]
+      },
+      buffers: [
+        {
+          arrayBuffer: testCase.source.buffer as ArrayBuffer,
+          byteOffset: testCase.source.byteOffset,
+          byteLength: testCase.source.byteLength
+        }
+      ]
+    };
+
+    const scenegraph = new GLTFScenegraph(gltf);
+    const scenegraphValues = scenegraph.getTypedArrayForAccessor(0);
+    t.equal(scenegraphValues.constructor, testCase.source.constructor, `${testCase.name} type`);
+    t.deepEqual(
+      Array.from(scenegraphValues),
+      Array.from(testCase.source),
+      `${testCase.name} values`
+    );
+
+    const processed = postProcessGLTF(gltf);
+    const processedValues = processed.accessors[0].value;
+    t.equal(
+      processedValues.constructor,
+      testCase.source.constructor,
+      `${testCase.name} postprocessed type`
+    );
+    t.deepEqual(
+      Array.from(processedValues),
+      Array.from(testCase.source),
+      `${testCase.name} postprocessed values`
+    );
+  }
+  t.end();
+});


### PR DESCRIPTION
## Goals

Prepare `@loaders.gl/gltf` for the accessor component type definitions announced for glTF 2.1 while preserving exact 64-bit integer data and maintaining compatibility with supported JavaScript runtimes.

## Changes

- Add accessor decoding for `INT` (5124), `DOUBLE` (5130), `HALF_FLOAT` (5131), `INT64` (5134), and `UNSIGNED_INT64` (5135).
- Return signed and unsigned 64-bit values through BigInt typed arrays, and preserve binary16 payloads as raw `Uint16Array` words where `Float16Array` is unavailable.
- Extend public glTF accessor result types for BigInt typed arrays.
- Add shared Node and headless-browser coverage for both `GLTFScenegraph` and `postProcessGLTF`.
- Document the draft component types in the glTF format, loader reference, post-processing reference, and v5 release notes.

## Validation

- `yarn build`
- `yarn test-node`
- `yarn test-headless`
- `yarn lint fix`