### PR TITLE
fix(3d-tiles): integrate dynamic screen-space error

### DIFF
--- a/docs/modules/3d-tiles/concepts/screen-space-error-and-lod.md
+++ b/docs/modules/3d-tiles/concepts/screen-space-error-and-lod.md
@@ -64,6 +64,59 @@ perspectiveSSE = (8 * 900) / (600 * 1.15) = 10.43 px
 
 With `maximumScreenSpaceError: 8`, the tile exceeds the tolerance and should refine. With a threshold of `16`, the tile is acceptable. Moving the camera to `300 m` doubles SSE to approximately `20.87 px`, making refinement more likely.
 
+## Dynamic Perspective SSE
+
+Perspective views can spend substantial bandwidth and memory refining distant tiles near the
+horizon. At street level, those tiles cover a large traversal distance but their finest details
+often contribute little to the final image. Dynamic screen-space error (dynamic SSE) applies a
+fog-like reduction after the normal perspective calculation:
+
+```text
+fogStrength = 1 - exp(-((distanceToCamera * effectiveDensity) ^ 2))
+dynamicReduction = fogStrength * dynamicScreenSpaceErrorFactor
+adjustedPerspectiveSSE = perspectiveSSE - dynamicReduction
+```
+
+`effectiveDensity` starts with `dynamicScreenSpaceErrorDensity` and is attenuated by two
+view-dependent factors:
+
+- **Camera direction:** a horizontal, horizon-facing view receives the strongest reduction. The
+  reduction fades to zero as the camera points vertically.
+- **Camera height:** the reduction is strongest near the lower part of the root tileset volume. It
+  fades to zero as the camera rises above the volume. `dynamicScreenSpaceErrorHeightFalloff`
+  controls where that fade begins.
+
+The calculation uses geodetic heights for a root `region` and earth-scale bounding volumes. Local
+tilesets use their root transform and source-space z-up height. Density is recalculated for every
+viewport and traversal frame, so multiple views do not share camera-dependent state.
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `dynamicScreenSpaceError` | `true` | Enables the optimization for perspective 3D Tiles traversal. |
+| `dynamicScreenSpaceErrorDensity` | `0.0002` | Base fog density in inverse meters. Higher values reduce distant SSE sooner. |
+| `dynamicScreenSpaceErrorFactor` | `24` | Maximum SSE reduction in logical pixels. |
+| `dynamicScreenSpaceErrorHeightFalloff` | `0.25` | Fraction of root height where density begins to fade, clamped to `[0, 1]`. |
+
+These defaults follow Cesium's tuned street-level behavior. Dynamic SSE does not change the base
+perspective formula, its fixed denominator, or `viewDistanceScale`; it only subtracts the
+view-dependent reduction afterward. Set `dynamicScreenSpaceError: false` when exact unadjusted
+perspective SSE is required or when comparing traversal results with an older loaders.gl release.
+
+### Dynamic SSE Example
+
+Assume the normal perspective calculation produces `30 px` SSE for a horizon tile at `3,000 m`.
+The camera is low and horizontal, so the effective density equals its default `0.0002`:
+
+```text
+fogStrength = 1 - exp(-((3000 * 0.0002) ^ 2)) = 0.3023
+dynamicReduction = 0.3023 * 24 = 7.26 px
+adjustedPerspectiveSSE = 30 - 7.26 = 22.74 px
+```
+
+With `maximumScreenSpaceError: 16`, this tile still refines. More distant horizon tiles receive a
+larger reduction and stop earlier. Looking downward or moving above the tileset drives effective
+density toward zero, restoring the unadjusted `30 px` result.
+
 ## Orthographic SSE
 
 Orthographic projection does not make geometry smaller with camera distance. Its LOD calculation therefore uses the viewport's world-space pixel size directly:
@@ -130,6 +183,12 @@ The two primary controls are:
 
 Start with `maximumScreenSpaceError`. It has an intuitive interpretation as tolerated logical pixels and is easier to compare across tilesets. Use `viewDistanceScale` when an application needs a global quality multiplier without replacing its chosen threshold.
 
+Tune dynamic SSE only after choosing those global quality controls. Increase
+`dynamicScreenSpaceErrorDensity` when distant horizon tiles refine too deeply, or increase
+`dynamicScreenSpaceErrorFactor` when the maximum reduction is too small. Lower either value when
+distant structures appear too coarse. Height falloff is mainly useful for local tilesets whose
+street-level and aerial views need different traversal depth.
+
 Changing either value affects more than visual sharpness. Deeper traversal can increase request count, decode work, GPU memory, cache churn, and draw calls. Tile availability, network latency, refinement mode, and `maximumMemoryUsage` can delay or limit the visible effect of an SSE change.
 
 ## Runtime Inspection
@@ -141,6 +200,8 @@ The following `Tile3D` properties are useful when diagnosing selection:
 - `tile.screenSpaceError`: most recently calculated SSE.
 - `tile.selected`: whether the tile was selected for the current traversal frame.
 - `tile.refine`: whether descendants add to or replace the tile.
+- `tileset.dynamicScreenSpaceErrorComputedDensity`: effective density for the most recently
+  traversed viewport; zero means the current view receives no dynamic reduction.
 
 Compare a tile's `screenSpaceError` with the tileset's `maximumScreenSpaceError`. If refinement is expected but does not occur, also check that descendants exist, their content is available, the tile is inside the culling and request volumes, and traversal has run again after asynchronous content loading.
 
@@ -150,6 +211,9 @@ Compare a tile's `screenSpaceError` with the tileset's `maximumScreenSpaceError`
 | --- | --- | --- |
 | Tiles stay visibly coarse | SSE threshold is high, `viewDistanceScale` is low, or child content is unavailable. | Lower `maximumScreenSpaceError`, restore `viewDistanceScale` toward `1`, and inspect child requests. |
 | Too many tiles load | SSE threshold is low or `viewDistanceScale` is high. | Raise `maximumScreenSpaceError` and monitor requests and memory. |
+| Distant horizon tiles refine too deeply | Dynamic SSE is disabled, its density is too low, or the camera is above the root volume. | Enable dynamic SSE, inspect the computed density, and tune density or height falloff. |
+| Distant buildings look too coarse | Dynamic density or factor is too high for the dataset. | Lower `dynamicScreenSpaceErrorDensity` or `dynamicScreenSpaceErrorFactor`. |
+| Aerial and street-level views select the same deep LOD | The root height range or height falloff does not distinguish the camera positions. | Inspect the root bounding volume and lower `dynamicScreenSpaceErrorHeightFalloff`. |
 | A scaled-up model under-refines | Geometric error is not using the model's world scale. | Confirm the model matrix reaches `Tileset3D` and inspect `tile.lodMetricValue`. |
 | LOD changes after repeated transform updates | A derived error is being scaled repeatedly. | Ensure updates start from the source geometric error; loaders.gl does this automatically. |
 | Orthographic LOD changes with camera distance | The viewport is missing `orthographic: true` or valid `metersPerPixel`. | Inspect the viewport contract and its scale units. |
@@ -161,6 +225,7 @@ Compare a tile's `screenSpaceError` with the tileset's `maximumScreenSpaceError`
 
 - The perspective denominator is currently fixed at `1.15`, corresponding approximately to the established 60-degree field-of-view assumption. Perspective behavior is intentionally preserved for compatibility rather than derived from every possible projection matrix.
 - Orthographic SSE requires `metersPerPixel`; invalid values use the perspective-compatible fallback.
-- Dynamic SSE remains a perspective optimization and is not subtracted from orthographic SSE.
+- Dynamic SSE is a perspective optimization. It is not subtracted from orthographic SSE, including
+  the perspective-compatible fallback used when an orthographic viewport has an invalid pixel scale.
 - 3D Tiles geometric error is measured in meters. I3S uses a different `maxScreenThreshold` LOD metric that is already screen-oriented and is not transform-scaled by this logic.
 - SSE controls refinement after visibility and request-volume checks. It cannot make a culled tile visible or provide descendants that are missing from the tileset.

--- a/docs/modules/tiles/api-reference/tileset-3d.md
+++ b/docs/modules/tiles/api-reference/tileset-3d.md
@@ -96,6 +96,17 @@ For format-specific source behavior, see:
 Cesium 3D tiles specific options:
 
 - `options.maximumScreenSpaceError`=`8` (`Number`) - The maximum screen-space error used to drive level-of-detail refinement. See [Screen-space error and level of detail](/docs/modules/3d-tiles/concepts/screen-space-error-and-lod).
+- `options.dynamicScreenSpaceError`=`true` (`Boolean`) - Reduces refinement for distant,
+  horizon-facing tiles in perspective views. Orthographic traversal is unaffected.
+- `options.dynamicScreenSpaceErrorDensity`=`0.0002` (`Number`) - Base fog density, in inverse
+  meters, used by dynamic SSE. Higher values reduce distant refinement sooner.
+- `options.dynamicScreenSpaceErrorFactor`=`24` (`Number`) - Maximum dynamic SSE reduction in
+  logical/CSS pixels.
+- `options.dynamicScreenSpaceErrorHeightFalloff`=`0.25` (`Number`) - Fraction of the root tileset
+  height at which dynamic SSE starts to fade as the camera rises. Values are clamped to `[0, 1]`.
+
+See [Screen-space error and level of detail](/docs/modules/3d-tiles/concepts/screen-space-error-and-lod#dynamic-perspective-sse)
+for the formulas, worked example, projection boundaries, and tuning guidance.
 
 ## Properties
 

--- a/modules/tiles/src/tileset-3d/common/tileset-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tileset-3d.ts
@@ -11,6 +11,7 @@ import {RequestScheduler, LoaderWithParser, LoaderOptions} from '@loaders.gl/loa
 import {TilesetCache} from './tileset-cache';
 import {calculateTransformProps} from '../helpers/transform-utils';
 import {FrameState, getFrameState, limitSelectedTiles} from '../helpers/frame-state';
+import {calculateDynamicScreenSpaceErrorDensity} from '../helpers/tiles-3d-lod';
 
 import type {GeospatialViewport, Viewport} from '../../types';
 import {Tile3D} from './tile-3d';
@@ -46,6 +47,14 @@ export type Tileset3DProps = {
   modelMatrix?: Matrix4;
 
   maximumScreenSpaceError?: number;
+  /** Enables perspective dynamic SSE to reduce distant, horizon-facing refinement. */
+  dynamicScreenSpaceError?: boolean;
+  /** Base dynamic SSE fog density in inverse meters. */
+  dynamicScreenSpaceErrorDensity?: number;
+  /** Maximum dynamic SSE reduction in logical/CSS pixels. */
+  dynamicScreenSpaceErrorFactor?: number;
+  /** Fraction of tileset height at which dynamic SSE begins to fade, clamped to `[0, 1]`. */
+  dynamicScreenSpaceErrorHeightFalloff?: number;
   memoryAdjustedScreenSpaceError?: boolean;
   viewportTraversersMap?: any;
   updateTransforms?: boolean;
@@ -81,6 +90,14 @@ type Props = {
   onTraversalComplete: (selectedTiles: Tile3D[]) => Tile3D[];
   onUpdate: () => void;
   maximumScreenSpaceError: number;
+  /** Whether perspective dynamic SSE is enabled. */
+  dynamicScreenSpaceError: boolean;
+  /** Base dynamic SSE fog density in inverse meters. */
+  dynamicScreenSpaceErrorDensity: number;
+  /** Maximum dynamic SSE reduction in logical/CSS pixels. */
+  dynamicScreenSpaceErrorFactor: number;
+  /** Fraction of tileset height at which dynamic SSE begins to fade. */
+  dynamicScreenSpaceErrorHeightFalloff: number;
   memoryAdjustedScreenSpaceError: boolean;
   viewportTraversersMap: Record<string, any> | null;
   attributions: string[];
@@ -113,6 +130,10 @@ const DEFAULT_PROPS: Props = {
   contentLoader: undefined,
   viewDistanceScale: 1.0,
   maximumScreenSpaceError: 8,
+  dynamicScreenSpaceError: true,
+  dynamicScreenSpaceErrorDensity: 2.0e-4,
+  dynamicScreenSpaceErrorFactor: 24,
+  dynamicScreenSpaceErrorHeightFalloff: 0.25,
   memoryAdjustedScreenSpaceError: false,
   loadTiles: true,
   updateTransforms: true,
@@ -174,7 +195,8 @@ export class Tileset3D {
   zoom = 1;
   boundingVolume: any = null;
 
-  dynamicScreenSpaceErrorComputedDensity = 0.0;
+  /** Effective dynamic SSE density calculated for the most recently traversed viewport. */
+  dynamicScreenSpaceErrorComputedDensity = 0;
 
   maximumMemoryUsage = 32;
   gpuMemoryUsageInBytes = 0;
@@ -355,7 +377,16 @@ export class Tileset3D {
         continue;
       }
       const frameState = getFrameState(viewport as GeospatialViewport, this._frameNumber);
-      this._traverser.traverse(this.roots[id], frameState, this.options);
+      const root = this.roots[id];
+      frameState.dynamicScreenSpaceErrorDensity =
+        this.type === TILESET_TYPE.TILES3D &&
+        this.options.dynamicScreenSpaceError &&
+        !frameState.viewport.orthographic
+          ? calculateDynamicScreenSpaceErrorDensity(root, frameState, this.options)
+          : 0;
+      // Keep the legacy diagnostic field, but traversal reads the per-viewport frame value above.
+      this.dynamicScreenSpaceErrorComputedDensity = frameState.dynamicScreenSpaceErrorDensity;
+      this._traverser.traverse(root, frameState, this.options);
     }
   }
 

--- a/modules/tiles/src/tileset-3d/helpers/frame-state.ts
+++ b/modules/tiles/src/tileset-3d/helpers/frame-state.ts
@@ -6,9 +6,14 @@ import {GeospatialViewport, Viewport} from '../../types';
 
 export type FrameState = {
   camera: {
+    /** Camera position in WGS84 Cartesian meters. */
     position: number[];
+    /** Normalized camera direction in WGS84 Cartesian coordinates. */
     direction: number[];
+    /** Normalized camera up direction in WGS84 Cartesian coordinates. */
     up: number[];
+    /** Camera position as `[longitude, latitude, height]`, with height in meters. */
+    cartographicPosition: [number, number, number];
   };
   viewport: GeospatialViewport;
   topDownViewport: GeospatialViewport; // Use it to calculate projected radius for a tile
@@ -16,6 +21,8 @@ export type FrameState = {
   cullingVolume: CullingVolume;
   frameNumber: number; // TODO: This can be the same between updates, what number is unique for between updates?
   sseDenominator: number; // Assumes fovy = 60 degrees
+  /** View-dependent density used by perspective dynamic screen-space error for this traversal. */
+  dynamicScreenSpaceErrorDensity: number;
 };
 
 const scratchVector = new Vector3();
@@ -78,14 +85,17 @@ export function getFrameState(viewport: GeospatialViewport, frameNumber: number)
     camera: {
       position: cameraPositionCartesian,
       direction: cameraDirectionCartesian,
-      up: cameraUpCartesian
+      up: cameraUpCartesian,
+      cartographicPosition: cameraPositionCartographic
     },
     viewport,
     topDownViewport,
     height,
     cullingVolume,
     frameNumber, // TODO: This can be the same between updates, what number is unique for between updates?
-    sseDenominator: 1.15 // Assumes fovy = 60 degrees
+    sseDenominator: 1.15, // Assumes fovy = 60 degrees
+    // Tileset3D fills this immediately before traversal because it depends on the root volume.
+    dynamicScreenSpaceErrorDensity: 0
   };
 }
 

--- a/modules/tiles/src/tileset-3d/helpers/tiles-3d-lod.ts
+++ b/modules/tiles/src/tileset-3d/helpers/tiles-3d-lod.ts
@@ -5,162 +5,180 @@
 // This file is derived from the Cesium code base under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 
-// TODO - Dynamic screen space error provides an optimization when looking at
-// tilesets from above
-
-/* eslint-disable */
-// @ts-nocheck
 import {Matrix4, Vector3, clamp} from '@math.gl/core';
+import {Ellipsoid} from '@math.gl/geospatial';
+import type {Tile3D} from '../common/tile-3d';
+import type {FrameState} from './frame-state';
+
+/** Options that control the perspective dynamic screen-space error optimization. */
+export type DynamicScreenSpaceErrorOptions = {
+  /** Base fog density used to reduce distant, horizon-facing screen-space error. */
+  dynamicScreenSpaceErrorDensity: number;
+  /** Maximum number of logical pixels subtracted from perspective screen-space error. */
+  dynamicScreenSpaceErrorFactor: number;
+  /** Fraction of the tileset height at which the optimization begins to fade. */
+  dynamicScreenSpaceErrorHeightFalloff: number;
+};
+
+type TileBoundingVolumeHeader = {
+  box?: number[];
+  region?: number[];
+  sphere?: number[];
+};
+
+type TilesetHeightRange = {
+  cameraHeight: number;
+  minimumHeight: number;
+  maximumHeight: number;
+  cameraDirection: Vector3;
+  upDirection: Vector3;
+};
 
 const scratchPositionNormal = new Vector3();
 const scratchCartographic = new Vector3();
-const scratchMatrix = new Matrix4();
 const scratchCenter = new Vector3();
 const scratchPosition = new Vector3();
 const scratchDirection = new Vector3();
+const unitZDirection = new Vector3(0, 0, 1);
 
-// eslint-disable-next-line max-statements, complexity
-export function calculateDynamicScreenSpaceError(root, {camera, mapProjection}, options = {}) {
-  const {dynamicScreenSpaceErrorHeightFalloff = 0.25, dynamicScreenSpaceErrorDensity = 0.00278} =
-    options;
-
-  let up;
-  let direction;
-  let height;
-  let minimumHeight;
-  let maximumHeight;
-
-  const tileBoundingVolume = root.contentBoundingVolume;
-
-  if (tileBoundingVolume instanceof TileBoundingRegion) {
-    up = Cartesian3.normalize(camera.positionWC, scratchPositionNormal);
-    direction = camera.directionWC;
-    height = camera.positionCartographic.height;
-    minimumHeight = tileBoundingVolume.minimumHeight;
-    maximumHeight = tileBoundingVolume.maximumHeight;
-  } else {
-    // Transform camera position and direction into the local coordinate system of the tileset
-    const transformLocal = Matrix4.inverseTransformation(root.computedTransform, scratchMatrix);
-    const ellipsoid = mapProjection.ellipsoid;
-    const boundingVolume = tileBoundingVolume.boundingVolume;
-    const centerLocal = Matrix4.multiplyByPoint(
-      transformLocal,
-      boundingVolume.center,
-      scratchCenter
-    );
-    if (Cartesian3.magnitude(centerLocal) > ellipsoid.minimumRadius) {
-      // The tileset is defined in WGS84. Approximate the minimum and maximum height.
-      const centerCartographic = Cartographic.fromCartesian(
-        centerLocal,
-        ellipsoid,
-        scratchCartographic
-      );
-      up = Cartesian3.normalize(camera.positionWC, scratchPositionNormal);
-      direction = camera.directionWC;
-      height = camera.positionCartographic.height;
-      minimumHeight = 0.0;
-      maximumHeight = centerCartographic.height * 2.0;
-    } else {
-      // The tileset is defined in local coordinates (z-up)
-      const positionLocal = Matrix4.multiplyByPoint(
-        transformLocal,
-        camera.positionWC,
-        scratchPosition
-      );
-      up = Cartesian3.UNIT_Z;
-      direction = Matrix4.multiplyByPointAsVector(
-        transformLocal,
-        camera.directionWC,
-        scratchDirection
-      );
-      direction = Cartesian3.normalize(direction, direction);
-      height = positionLocal.z;
-      if (tileBoundingVolume instanceof TileOrientedBoundingBox) {
-        // Assuming z-up, the last component stores the half-height of the box
-        const boxHeight = root._header.boundingVolume.box[11];
-        minimumHeight = centerLocal.z - boxHeight;
-        maximumHeight = centerLocal.z + boxHeight;
-      } else if (tileBoundingVolume instanceof TileBoundingSphere) {
-        const radius = boundingVolume.radius;
-        minimumHeight = centerLocal.z - radius;
-        maximumHeight = centerLocal.z + radius;
-      }
-    }
+/**
+ * Calculates the effective dynamic screen-space error density for one viewport and frame.
+ *
+ * Dynamic SSE is a perspective-only optimization for street-level views. It reduces refinement
+ * for distant tiles near the horizon, where loading every geometric detail is expensive and has
+ * limited visual benefit. Density fades to zero as the camera rises above the tileset or points
+ * vertically. The returned value belongs to the supplied frame state; callers must not reuse it
+ * for another viewport because camera height and direction are view dependent.
+ *
+ * @param root - Root tile whose transform and source bounding volume define the tileset space.
+ * @param frameState - Current camera measurements in WGS84 and logical viewport space.
+ * @param options - Dynamic SSE density and height-falloff controls.
+ * @returns Effective fog density for this viewport, or zero when it cannot be calculated.
+ */
+export function calculateDynamicScreenSpaceErrorDensity(
+  root: Tile3D,
+  frameState: FrameState,
+  options: DynamicScreenSpaceErrorOptions
+): number {
+  if (
+    !Number.isFinite(options.dynamicScreenSpaceErrorDensity) ||
+    options.dynamicScreenSpaceErrorDensity <= 0
+  ) {
+    return 0;
   }
 
-  // The range where the density starts to lessen. Start at the quarter height of the tileset.
-  const heightFalloff = dynamicScreenSpaceErrorHeightFalloff;
-  const heightClose = minimumHeight + (maximumHeight - minimumHeight) * heightFalloff;
-  const heightFar = maximumHeight;
+  const boundingVolumeHeader = getContentBoundingVolumeHeader(root);
+  const heightRange = boundingVolumeHeader.region
+    ? getRegionHeightRange(boundingVolumeHeader.region, frameState)
+    : getCartesianHeightRange(root, boundingVolumeHeader, frameState);
 
-  const t = clamp((height - heightClose) / (heightFar - heightClose), 0.0, 1.0);
+  if (!heightRange) {
+    return 0;
+  }
 
-  // Increase density as the camera tilts towards the horizon
-  const dot = Math.abs(Cartesian3.dot(direction, up));
+  const heightFalloff = clamp(options.dynamicScreenSpaceErrorHeightFalloff, 0, 1);
+  const heightClose =
+    heightRange.minimumHeight +
+    (heightRange.maximumHeight - heightRange.minimumHeight) * heightFalloff;
+  const heightSpan = heightRange.maximumHeight - heightClose;
+  const heightPercentage =
+    heightSpan > 0
+      ? clamp((heightRange.cameraHeight - heightClose) / heightSpan, 0, 1)
+      : heightRange.cameraHeight >= heightRange.maximumHeight
+        ? 1
+        : 0;
 
-  let horizonFactor = 1.0 - dot;
+  // A horizontal view has a dot product near zero and receives the strongest optimization.
+  // A vertical view has a dot product near one and keeps the unmodified perspective SSE.
+  const verticalAlignment = clamp(
+    Math.abs(heightRange.cameraDirection.dot(heightRange.upDirection)),
+    0,
+    1
+  );
+  const horizonFactor = (1 - verticalAlignment) * (1 - heightPercentage);
 
-  // Weaken the horizon factor as the camera height increases, implying the camera is further away from the tileset.
-  // The goal is to increase density for the "street view", not when viewing the tileset from a distance.
-  horizonFactor = horizonFactor * (1.0 - t);
-
-  return dynamicScreenSpaceErrorDensity * horizonFactor;
+  return options.dynamicScreenSpaceErrorDensity * horizonFactor;
 }
 
-export function fog(distanceToCamera, density) {
+/**
+ * Calculates exponential fog strength for a camera distance and density.
+ * @param distanceToCamera - Distance from the camera to the tile bounding volume in meters.
+ * @param density - Effective dynamic SSE density in inverse meters.
+ * @returns Unitless strength in the inclusive range from zero to one.
+ */
+export function getDynamicScreenSpaceErrorFog(distanceToCamera: number, density: number): number {
   const scalar = distanceToCamera * density;
-  return 1.0 - Math.exp(-(scalar * scalar));
+  return 1 - Math.exp(-(scalar * scalar));
 }
 
-export function getDynamicScreenSpaceError(tileset, distanceToCamera) {
-  if (tileset.dynamicScreenSpaceError && tileset.dynamicScreenSpaceErrorComputedDensity) {
-    const density = tileset.dynamicScreenSpaceErrorComputedDensity;
-    const factor = tileset.dynamicScreenSpaceErrorFactor;
-    // TODO: Refined screen space error that minimizes tiles in non-first-person
-    const dynamicError = fog(distanceToCamera, density) * factor;
-    return dynamicError;
+/**
+ * Calculates the perspective SSE reduction for a tile.
+ * @param distanceToCamera - Distance from the camera to the tile bounding volume in meters.
+ * @param density - View-dependent fog density calculated for the current frame.
+ * @param factor - Maximum reduction in logical/CSS pixels.
+ * @returns Number of logical pixels to subtract from perspective SSE.
+ */
+export function getDynamicScreenSpaceError(
+  distanceToCamera: number,
+  density: number,
+  factor: number
+): number {
+  if (density <= 0 || factor <= 0 || !Number.isFinite(density) || !Number.isFinite(factor)) {
+    return 0;
   }
 
-  return 0;
+  return getDynamicScreenSpaceErrorFog(distanceToCamera, density) * factor;
 }
 
 /**
  * Calculates 3D Tiles screen-space error (SSE) for the current projection.
  *
  * Perspective SSE projects the tile's world-space geometric error through the existing viewport
- * height and frustum denominator. Orthographic projection has no perspective distance falloff, so
- * its error is divided directly by the viewport's world-space meters per logical pixel.
+ * height and frustum denominator. Dynamic SSE may then reduce distant horizon refinement using
+ * the density calculated specifically for this frame and viewport. Orthographic projection has
+ * no perspective distance falloff, so its error is divided directly by the viewport's world-space
+ * meters per logical pixel and is never adjusted by perspective dynamic SSE.
  *
  * @param tile - Tile containing the transform-scaled geometric error and camera distance.
  * @param frameState - Current camera and viewport measurements.
  * @param useParentLodMetric - Whether request prioritization should use the parent's error.
  * @returns Estimated error in logical/CSS pixels.
  */
-export function getTiles3DScreenSpaceError(tile, frameState, useParentLodMetric) {
+export function getTiles3DScreenSpaceError(
+  tile: Tile3D,
+  frameState: FrameState,
+  useParentLodMetric: boolean
+): number {
   const tileset = tile.tileset;
   const parentLodMetricValue = (tile.parent && tile.parent.lodMetricValue) || tile.lodMetricValue;
   const lodMetricValue = useParentLodMetric ? parentLodMetricValue : tile.lodMetricValue;
 
-  // Leaf tiles do not have any error so save the computation
-  if (lodMetricValue === 0.0) {
-    return 0.0;
+  // Leaf tiles do not have any error so save the computation.
+  if (lodMetricValue === 0) {
+    return 0;
   }
 
   const {viewDistanceScale} = tileset.options;
-  const lodScale = viewDistanceScale || 1.0;
+  const lodScale = viewDistanceScale || 1;
   const orthographicError = getOrthographicScreenSpaceError(lodMetricValue, frameState, lodScale);
   if (orthographicError !== null) {
     return orthographicError;
   }
 
-  // Avoid divide by zero when viewer is inside the tile
-  const distance = Math.max(tile._distanceToCamera, 1e-7);
+  // Avoid divide by zero when viewer is inside the tile.
+  const distanceToCamera = Math.max(tile._distanceToCamera, 1e-7);
   const {height, sseDenominator} = frameState;
-  let error = (lodMetricValue * height * lodScale) / (distance * sseDenominator);
+  let screenSpaceError = (lodMetricValue * height * lodScale) / (distanceToCamera * sseDenominator);
 
-  error -= getDynamicScreenSpaceError(tileset, distance);
+  if (tileset.options.dynamicScreenSpaceError && !frameState.viewport.orthographic) {
+    screenSpaceError -= getDynamicScreenSpaceError(
+      distanceToCamera,
+      frameState.dynamicScreenSpaceErrorDensity,
+      tileset.options.dynamicScreenSpaceErrorFactor
+    );
+  }
 
-  return error;
+  return screenSpaceError;
 }
 
 /**
@@ -176,16 +194,115 @@ export function getTiles3DScreenSpaceError(tile, frameState, useParentLodMetric)
  * @param lodScale - Application refinement scale from `viewDistanceScale`.
  * @returns SSE in logical pixels, or `null` when orthographic SSE cannot be calculated.
  */
-function getOrthographicScreenSpaceError(lodMetricValue, frameState, lodScale) {
+function getOrthographicScreenSpaceError(
+  lodMetricValue: number,
+  frameState: FrameState,
+  lodScale: number
+): number | null {
   const viewport = frameState.viewport;
   if (!viewport?.orthographic) {
     return null;
   }
 
   const metersPerPixel = viewport.metersPerPixel;
-  if (!Number.isFinite(metersPerPixel) || metersPerPixel <= 0) {
+  if (!Number.isFinite(metersPerPixel) || !metersPerPixel || metersPerPixel <= 0) {
     return null;
   }
 
   return (lodMetricValue * lodScale) / metersPerPixel;
+}
+
+/** Returns the content bounding volume header, falling back to the traversal volume. */
+function getContentBoundingVolumeHeader(root: Tile3D): TileBoundingVolumeHeader {
+  return root.header.content?.boundingVolume || root.header.boundingVolume;
+}
+
+/** Calculates camera and tileset heights for a geodetic region bounding volume. */
+function getRegionHeightRange(region: number[], frameState: FrameState): TilesetHeightRange {
+  const upDirection = scratchPositionNormal.copy(frameState.camera.position).normalize();
+  const cameraDirection = scratchDirection.copy(frameState.camera.direction).normalize();
+
+  return {
+    cameraHeight: frameState.camera.cartographicPosition[2],
+    minimumHeight: region[4],
+    maximumHeight: region[5],
+    cameraDirection,
+    upDirection
+  };
+}
+
+/**
+ * Calculates camera and tileset heights for box and sphere volumes.
+ *
+ * The root transform is inverted so that both camera height and source volume dimensions use the
+ * same coordinate system. Small coordinates are treated as local z-up. Earth-scale coordinates
+ * are treated as WGS84 and use cartographic height, matching Cesium's conservative approximation.
+ */
+function getCartesianHeightRange(
+  root: Tile3D,
+  boundingVolumeHeader: TileBoundingVolumeHeader,
+  frameState: FrameState
+): TilesetHeightRange | null {
+  const halfHeight = getBoundingVolumeCenterAndHalfHeight(boundingVolumeHeader, scratchCenter);
+  if (halfHeight === null) {
+    return null;
+  }
+
+  const localTransform = new Matrix4(root.computedTransform).invert();
+  const ellipsoid = root.tileset.ellipsoid as Ellipsoid;
+  const centerMagnitude = Math.hypot(scratchCenter[0], scratchCenter[1], scratchCenter[2]);
+
+  if (centerMagnitude > ellipsoid.minimumRadius) {
+    const centerCartographic = ellipsoid.cartesianToCartographic(
+      scratchCenter,
+      scratchCartographic
+    );
+    const upDirection = scratchPositionNormal.copy(frameState.camera.position).normalize();
+    const cameraDirection = scratchDirection.copy(frameState.camera.direction).normalize();
+
+    return {
+      cameraHeight: frameState.camera.cartographicPosition[2],
+      minimumHeight: 0,
+      maximumHeight: centerCartographic[2] * 2,
+      cameraDirection,
+      upDirection
+    };
+  }
+
+  localTransform.transformAsPoint(frameState.camera.position, scratchPosition);
+  localTransform.transformAsVector(frameState.camera.direction, scratchDirection);
+  scratchDirection.normalize();
+
+  return {
+    cameraHeight: scratchPosition[2],
+    minimumHeight: scratchCenter[2] - halfHeight,
+    maximumHeight: scratchCenter[2] + halfHeight,
+    cameraDirection: scratchDirection,
+    upDirection: unitZDirection
+  };
+}
+
+/**
+ * Copies the source volume center and returns its conservative z-up half-height.
+ * @param boundingVolumeHeader - Root content or traversal volume from tileset JSON.
+ * @param result - Scratch vector that receives the source-space center.
+ * @returns Half-height in source-space meters, or `null` for an unsupported volume.
+ */
+function getBoundingVolumeCenterAndHalfHeight(
+  boundingVolumeHeader: TileBoundingVolumeHeader,
+  result: Vector3
+): number | null {
+  if (boundingVolumeHeader.box) {
+    const box = boundingVolumeHeader.box;
+    result.set(box[0], box[1], box[2]);
+    return box.length === 10 ? box[5] : Math.hypot(box[9], box[10], box[11]);
+  }
+
+  if (boundingVolumeHeader.sphere) {
+    const sphere = boundingVolumeHeader.sphere;
+    result.set(sphere[0], sphere[1], sphere[2]);
+    return sphere[3];
+  }
+
+  return null;
 }

--- a/modules/tiles/test/tileset/helpers/get-frame-state.spec.ts
+++ b/modules/tiles/test/tileset/helpers/get-frame-state.spec.ts
@@ -43,6 +43,19 @@ test('getFrameState', t => {
     'camera.direction should match.'
   );
   t.ok(equals(results.camera.up, expected.camera.up, EPSILON), 'camera.up should match.');
+  t.ok(
+    equals(
+      results.camera.cartographicPosition,
+      viewport.unprojectPosition(viewport.cameraPosition),
+      EPSILON
+    ),
+    'camera.cartographicPosition should retain the viewport height used by dynamic SSE.'
+  );
+  t.equals(
+    results.dynamicScreenSpaceErrorDensity,
+    0,
+    'dynamic SSE density should be initialized for the tileset traversal.'
+  );
   t.equals(results.sseDenominator, results.sseDenominator, 'sseDenominator should match.');
   t.equals(results.cullingVolume.planes.length, 6, 'Should have 6 planes.');
 

--- a/modules/tiles/test/tileset/tiles-3d-lod.spec.ts
+++ b/modules/tiles/test/tileset/tiles-3d-lod.spec.ts
@@ -6,8 +6,15 @@
 
 import test from 'tape-promise/tape';
 import {Matrix4} from '@math.gl/core';
+import {Ellipsoid} from '@math.gl/geospatial';
 import {Tile3D} from '@loaders.gl/tiles';
-import {getTiles3DScreenSpaceError} from '../../src/tileset-3d/helpers/tiles-3d-lod';
+import type {FrameState} from '../../src/tileset-3d/helpers/frame-state';
+import {
+  calculateDynamicScreenSpaceErrorDensity,
+  getDynamicScreenSpaceError,
+  getDynamicScreenSpaceErrorFog,
+  getTiles3DScreenSpaceError
+} from '../../src/tileset-3d/helpers/tiles-3d-lod';
 import {LOD_METRIC_TYPE, TILESET_TYPE} from '../../src/constants';
 
 const TILE_HEADER = {
@@ -24,18 +31,39 @@ const TILESET = {
   lodMetricValue: 10,
   lodMetricType: LOD_METRIC_TYPE.GEOMETRIC_ERROR,
   type: TILESET_TYPE.TILES3D,
-  options: {viewDistanceScale: 1},
-  dynamicScreenSpaceError: false
+  ellipsoid: Ellipsoid.WGS84,
+  options: {
+    viewDistanceScale: 1,
+    dynamicScreenSpaceError: false,
+    dynamicScreenSpaceErrorFactor: 24
+  }
+};
+
+const DYNAMIC_SCREEN_SPACE_ERROR_OPTIONS = {
+  dynamicScreenSpaceErrorDensity: 2.0e-4,
+  dynamicScreenSpaceErrorFactor: 24,
+  dynamicScreenSpaceErrorHeightFalloff: 0.25
 };
 
 /** Creates the minimal frame state used by the 3D Tiles SSE calculation. */
-function createFrameState(overrides: {[key: string]: any} = {}) {
-  return {
+function createFrameState(overrides: {[key: string]: any} = {}): FrameState {
+  const camera = {
+    position: [0, 0, 5],
+    direction: [1, 0, 0],
+    up: [0, 0, 1],
+    cartographicPosition: [0, 0, 5]
+  };
+  const frameState = {
+    camera,
     height: 1000,
     sseDenominator: 2,
     viewport: {orthographic: false},
+    dynamicScreenSpaceErrorDensity: 0,
     ...overrides
   };
+  frameState.camera = {...camera, ...overrides.camera};
+  // Tests exercise calculations that do not require culling or the top-down viewport.
+  return frameState as unknown as FrameState;
 }
 
 /** Creates a Tile3D with a controlled camera distance for SSE tests. */
@@ -157,6 +185,143 @@ test('getTiles3DScreenSpaceError#returns zero for zero-error leaves', t => {
     ),
     0,
     'skips projection work for zero error'
+  );
+  t.end();
+});
+
+test('dynamic screen-space error#uses exponential fog', t => {
+  t.equals(getDynamicScreenSpaceErrorFog(0, 0.01), 0, 'zero distance has no fog');
+  t.ok(
+    getDynamicScreenSpaceErrorFog(200, 0.01) > getDynamicScreenSpaceErrorFog(100, 0.01),
+    'fog strength increases with camera distance'
+  );
+  t.equals(
+    getDynamicScreenSpaceError(100, 0, 24),
+    0,
+    'zero effective density disables the reduction'
+  );
+  t.end();
+});
+
+test('calculateDynamicScreenSpaceErrorDensity#local box responds to view and height', t => {
+  const root = createTile({
+    ...TILE_HEADER,
+    boundingVolume: {box: [0, 0, 10, 10, 0, 0, 0, 10, 0, 0, 0, 10]}
+  });
+
+  t.equals(
+    calculateDynamicScreenSpaceErrorDensity(
+      root,
+      createFrameState(),
+      DYNAMIC_SCREEN_SPACE_ERROR_OPTIONS
+    ),
+    DYNAMIC_SCREEN_SPACE_ERROR_OPTIONS.dynamicScreenSpaceErrorDensity,
+    'a street-level horizontal view receives the full configured density'
+  );
+  t.equals(
+    calculateDynamicScreenSpaceErrorDensity(
+      root,
+      createFrameState({camera: {direction: [0, 0, -1]}}),
+      DYNAMIC_SCREEN_SPACE_ERROR_OPTIONS
+    ),
+    0,
+    'a vertical view does not reduce refinement'
+  );
+  t.ok(
+    calculateDynamicScreenSpaceErrorDensity(
+      root,
+      createFrameState({camera: {position: [0, 0, 15]}}),
+      DYNAMIC_SCREEN_SPACE_ERROR_OPTIONS
+    ) < DYNAMIC_SCREEN_SPACE_ERROR_OPTIONS.dynamicScreenSpaceErrorDensity,
+    'density fades as the camera rises through the tileset height range'
+  );
+  t.end();
+});
+
+test('calculateDynamicScreenSpaceErrorDensity#uses the root transform without changing units', t => {
+  const root = createTile({
+    ...TILE_HEADER,
+    transform: new Matrix4().translate([0, 0, 100]),
+    boundingVolume: {sphere: [0, 0, 10, 10]}
+  });
+  const translatedFrameState = createFrameState({camera: {position: [0, 0, 105]}});
+
+  t.equals(
+    calculateDynamicScreenSpaceErrorDensity(
+      root,
+      translatedFrameState,
+      DYNAMIC_SCREEN_SPACE_ERROR_OPTIONS
+    ),
+    DYNAMIC_SCREEN_SPACE_ERROR_OPTIONS.dynamicScreenSpaceErrorDensity,
+    'camera and source volume are compared in the same local coordinate system'
+  );
+  t.end();
+});
+
+test('calculateDynamicScreenSpaceErrorDensity#uses geodetic region heights', t => {
+  const root = createTile({
+    ...TILE_HEADER,
+    boundingVolume: {region: [-1, -1, 1, 1, 0, 100]}
+  });
+  const frameState = createFrameState({
+    camera: {
+      position: [Ellipsoid.WGS84.maximumRadius + 25, 0, 0],
+      direction: [0, 1, 0],
+      cartographicPosition: [0, 0, 25]
+    }
+  });
+
+  t.equals(
+    calculateDynamicScreenSpaceErrorDensity(root, frameState, DYNAMIC_SCREEN_SPACE_ERROR_OPTIONS),
+    DYNAMIC_SCREEN_SPACE_ERROR_OPTIONS.dynamicScreenSpaceErrorDensity,
+    'region minimum and maximum heights control the falloff'
+  );
+  t.end();
+});
+
+test('getTiles3DScreenSpaceError#applies dynamic SSE only to perspective views', t => {
+  const tile = createTile();
+  tile.tileset.options.dynamicScreenSpaceError = true;
+  const dynamicFrameState = createFrameState({dynamicScreenSpaceErrorDensity: 0.01});
+  const expectedReduction = getDynamicScreenSpaceError(100, 0.01, 24);
+
+  t.equals(
+    getTiles3DScreenSpaceError(tile, dynamicFrameState, false),
+    50 - expectedReduction,
+    'subtracts the view-dependent reduction from perspective SSE'
+  );
+
+  tile.tileset.options.dynamicScreenSpaceError = false;
+  t.equals(
+    getTiles3DScreenSpaceError(tile, dynamicFrameState, false),
+    50,
+    'the option restores the established perspective formula when disabled'
+  );
+
+  tile.tileset.options.dynamicScreenSpaceError = true;
+  t.equals(
+    getTiles3DScreenSpaceError(
+      tile,
+      createFrameState({
+        dynamicScreenSpaceErrorDensity: 0.01,
+        viewport: {orthographic: true, metersPerPixel: 2}
+      }),
+      false
+    ),
+    5,
+    'orthographic SSE is never reduced by the perspective optimization'
+  );
+  t.equals(
+    getTiles3DScreenSpaceError(
+      tile,
+      createFrameState({
+        dynamicScreenSpaceErrorDensity: 0.01,
+        viewport: {orthographic: true, metersPerPixel: 0}
+      }),
+      false
+    ),
+    50,
+    'an invalid orthographic scale falls back without applying dynamic SSE'
   );
   t.end();
 });

--- a/modules/tiles/test/tileset/tileset-3d.spec.ts
+++ b/modules/tiles/test/tileset/tileset-3d.spec.ts
@@ -133,6 +133,18 @@ test('Tileset3D#exports source-backed construction helpers', async t => {
   t.ok(i3sSource);
   t.equals(tileset.url.slice(-30), TILESET_URL.slice(-30));
   t.equals(tileset.asset.version, '1.0');
+  t.equals(tileset.options.dynamicScreenSpaceError, true, 'dynamic SSE defaults to enabled');
+  t.equals(
+    tileset.options.dynamicScreenSpaceErrorDensity,
+    2.0e-4,
+    'uses the tuned default density'
+  );
+  t.equals(tileset.options.dynamicScreenSpaceErrorFactor, 24, 'uses the tuned default factor');
+  t.equals(
+    tileset.options.dynamicScreenSpaceErrorHeightFalloff,
+    0.25,
+    'uses the tuned default height falloff'
+  );
   t.end();
 });
 


### PR DESCRIPTION
## Summary

- replace the dormant Cesium-only dynamic SSE port with typed loaders.gl/math.gl code
- calculate a camera-dependent density for every 3D Tiles viewport and traversal frame
- adopt Cesium's tuned defaults: enabled, density `0.0002`, factor `24`, height falloff `0.25`
- keep orthographic SSE and I3S LOD metrics isolated from the perspective optimization
- expand the SSE/LOD guide with formulas, a worked example, tuning guidance, and diagnostics

## Problem

The existing helper was an uncalled `@ts-nocheck` port that referenced Cesium runtime classes not present in loaders.gl. As a result, dynamic SSE could not participate in traversal even though fragments of the algorithm remained in the module.

## Implementation

Dynamic SSE now:

- derives height ranges from root region, box, or sphere headers
- compares local tilesets and cameras in the same inverse-root-transform coordinate system
- uses geodetic heights for regions and earth-scale Cartesian roots
- attenuates density by camera height and horizon alignment
- stores effective density on `FrameState`, preventing state leakage between viewports
- subtracts the fog-based reduction only after the established perspective SSE calculation
- leaves orthographic SSE unchanged, including invalid-pixel-scale fallback behavior
- can be disabled with `dynamicScreenSpaceError: false` to restore the unadjusted perspective formula

## Impact

Street-level perspective views can stop refining distant horizon tiles earlier, reducing traversal depth, requests, decode work, and memory pressure. The optimization is enabled by default to match current Cesium behavior; applications that require legacy selection can opt out.

## Documentation

The 3D Tiles SSE/LOD guide and `Tileset3D` API now document:

- all four dynamic SSE options and units
- the fog and adjusted-SSE formulas
- a numerical example
- local versus geodetic height handling
- per-viewport behavior and orthographic boundaries
- tuning and troubleshooting guidance

## Validation

- `yarn lint fix`
- `yarn test node` — 1,648 passed, 75 skipped
- focused dynamic SSE tests — 12 passed
- `yarn build`
- `cd website && yarn install && yarn build`
- generated navigation, dynamic-SSE anchor, and API cross-link inspected

Partially addresses #1245; this PR does not close the broader tracker.

Related correctness foundation: #3485.