### PR TITLE
Support GLB v3 buffer chunk references

### DIFF
--- a/docs/modules/gltf/api-reference/gltf-loader.md
+++ b/docs/modules/gltf/api-reference/gltf-loader.md
@@ -104,7 +104,7 @@ However, the objects inside these arrays will have been pre-processed to simplif
   json: Object, // Contains the unmodified parsed glTF JSON (the parsed GLB JSON chunk)
 
   // Length and indices of this array will match `json.buffers`
-  // The GLB bin chunk, if present, will be found in buffer 0.
+  // GLB v1/v2's bin chunk, or GLB v3 chunks selected by json.buffers[*].chunk.
   // Additional glTF json `buffers` are fetched and base64 decoded from the JSON uri:s.
   buffers: [{
     arrayBuffer: ArrayBuffer,
@@ -121,6 +121,10 @@ However, the objects inside these arrays will have been pre-processed to simplif
   _glb?: Object
 }
 ```
+
+For draft GLB v3 files, `GLTFLoader` resolves each `json.buffers[*].chunk` index to the
+corresponding BIN chunk. See the [GLB format documentation](../formats/glb) for indexing and
+legacy fallback rules.
 
 | Field                     | Type          | Default | Description                                                      |
 | ------------------------- | ------------- | ------- | ---------------------------------------------------------------- |

--- a/docs/modules/gltf/formats/glb.md
+++ b/docs/modules/gltf/formats/glb.md
@@ -13,3 +13,32 @@ The GLB file format is a binary form of glTF that includes textures instead of r
 GLB was introduced as an extension to glTF 1.0
 
 GLB was incorporated directly into glTF 2.0.
+
+GLB version 3 is being developed for glTF 2.1. In addition to 64-bit file and chunk lengths,
+the draft format permits multiple BIN chunks and allows the glTF JSON chunk to follow custom
+chunks. The first JSON chunk contains the glTF document.
+
+## GLB Version 3 Buffer Chunks
+
+In draft glTF 2.1 JSON, a buffer may use `chunk` instead of `uri` to select a BIN chunk in a
+GLB v3 container:
+
+```json
+{
+  "buffers": [
+    {"byteLength": 1024, "chunk": 2},
+    {"byteLength": 2048, "chunk": 4}
+  ]
+}
+```
+
+Chunk indices are zero-based positions in the complete GLB chunk sequence. JSON, BIN, and custom
+chunks all count toward the index, so `chunk: 2` refers to the third chunk in the file. The target
+must be a BIN chunk, and a buffer cannot define both `uri` and `chunk`.
+
+For compatibility, a GLB v3 document may omit `chunk` for buffer 0 only when it uses the classic
+layout: the JSON chunk is chunk 0, the BIN chunk is chunk 1, and buffer 0 is the only buffer without
+a `uri`. GLB versions 1 and 2 retain their existing implicit buffer behavior.
+
+This support follows the Khronos [Multiple Binary Chunks in GLB draft](https://github.com/KhronosGroup/glTF/issues/2611)
+and may evolve while glTF 2.1 is finalized.

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -23,7 +23,7 @@ Release Date: 2026
 
 **@loaders.gl/gltf**
 
-- `GLBLoader` adds draft GLB v3 parsing with 64-bit file and chunk lengths, multi-chunk traversal, and reserved chunk-encoding validation, advancing glTF 2.1 readiness.
+- [`GLBLoader`](/docs/modules/gltf/api-reference/glb-loader) and [`GLTFLoader`](/docs/modules/gltf/api-reference/gltf-loader) add draft [GLB v3](/docs/modules/gltf/formats/glb) support for 64-bit lengths, multi-chunk traversal, reserved chunk-encoding validation, and explicit `buffer.chunk` references, advancing glTF 2.1 readiness.
 
 **@loaders.gl/las** 
 

--- a/modules/gltf/src/lib/parsers/parse-glb.ts
+++ b/modules/gltf/src/lib/parsers/parse-glb.ts
@@ -89,6 +89,7 @@ export function parseGLBSync(
     version,
 
     json: {},
+    jsonChunkIndex: -1,
     binChunks: []
   } as GLB);
 
@@ -124,10 +125,10 @@ function parseGLBV1(glb: GLB, dataView: DataView, byteOffset: number): number {
   // GLB v1 only supports a single chunk type
   assert(contentFormat === GLB_V1_CONTENT_FORMAT_JSON);
 
-  parseJSONChunk(glb, dataView, byteOffset, contentLength);
+  parseJSONChunk(glb, dataView, byteOffset, contentLength, 0);
   // No need to call the function padToBytes() from parseJSONChunk()
   byteOffset += contentLength;
-  byteOffset += parseBINChunk(glb, dataView, byteOffset, glb.header.byteLength);
+  byteOffset += parseBINChunk(glb, dataView, byteOffset, glb.header.byteLength, 1);
 
   return byteOffset;
 }
@@ -177,6 +178,7 @@ function parseGLBChunksSync(
 ) {
   const fileEndByteOffset = glb.header.byteOffset + glb.header.byteLength;
   assert(fileEndByteOffset <= dataView.byteLength);
+  let chunkIndex = 0;
 
   // Per spec we must iterate over chunks, ignoring all except JSON and BIN
   // Iterate as long as there is space left for another chunk header
@@ -199,21 +201,24 @@ function parseGLBChunksSync(
     // Per spec we must iterate over chunks, ignoring all except JSON and BIN
     switch (chunkFormat) {
       case GLB_CHUNK_TYPE_JSON:
-        parseJSONChunk(glb, dataView, byteOffset, chunkLength);
+        // GLB v3 defines the first JSON chunk as the glTF JSON chunk.
+        if (glb.version !== 3 || glb.jsonChunkIndex === -1) {
+          parseJSONChunk(glb, dataView, byteOffset, chunkLength, chunkIndex);
+        }
         break;
       case GLB_CHUNK_TYPE_BIN:
-        parseBINChunk(glb, dataView, byteOffset, chunkLength);
+        parseBINChunk(glb, dataView, byteOffset, chunkLength, chunkIndex);
         break;
 
       // Backward compatibility for very old xviz files
       case GLB_CHUNK_TYPE_JSON_XVIZ_DEPRECATED:
         if (!options.strict) {
-          parseJSONChunk(glb, dataView, byteOffset, chunkLength);
+          parseJSONChunk(glb, dataView, byteOffset, chunkLength, chunkIndex);
         }
         break;
       case GLB_CHUNK_TYPE_BIX_XVIZ_DEPRECATED:
         if (!options.strict) {
-          parseBINChunk(glb, dataView, byteOffset, chunkLength);
+          parseBINChunk(glb, dataView, byteOffset, chunkLength, chunkIndex);
         }
         break;
 
@@ -224,13 +229,20 @@ function parseGLBChunksSync(
     }
 
     byteOffset += padToFourBytes(chunkLength);
+    chunkIndex++;
   }
 
   return byteOffset;
 }
 
 /* Parse a GLB JSON chunk */
-function parseJSONChunk(glb: GLB, dataView: DataView, byteOffset: number, chunkLength: number) {
+function parseJSONChunk(
+  glb: GLB,
+  dataView: DataView,
+  byteOffset: number,
+  chunkLength: number,
+  chunkIndex: number
+) {
   // 1. Create a "view" of the binary encoded JSON data inside the GLB
   const jsonChunk = new Uint8Array(dataView.buffer, byteOffset, chunkLength);
 
@@ -240,15 +252,17 @@ function parseJSONChunk(glb: GLB, dataView: DataView, byteOffset: number, chunkL
 
   // 3. Parse the JSON text into a JavaScript data structure
   glb.json = JSON.parse(jsonText);
+  glb.jsonChunkIndex = chunkIndex;
 
   return padToFourBytes(chunkLength);
 }
 
 /** Parse a GLB BIN chunk */
-function parseBINChunk(glb: GLB, dataView, byteOffset, chunkLength) {
+function parseBINChunk(glb: GLB, dataView, byteOffset, chunkLength, chunkIndex: number) {
   // Note: BIN chunk can be optional
   glb.header.hasBinChunk = true;
   glb.binChunks.push({
+    chunkIndex,
     byteOffset,
     byteLength: chunkLength,
     arrayBuffer: dataView.buffer

--- a/modules/gltf/src/lib/parsers/parse-gltf.ts
+++ b/modules/gltf/src/lib/parsers/parse-gltf.ts
@@ -128,20 +128,70 @@ function parseGLTFContainerSync(gltf, data, byteOffset, options: GLTFLoaderOptio
   // Populate buffers
   // Create an external buffers array to hold binary data
   const buffers = gltf.json.buffers || [];
+  const bufferDefinitions = Array.isArray(buffers) ? buffers : [];
   gltf.buffers = new Array(buffers.length).fill(null);
 
-  // Populates JSON and some bin chunk info
-  if (gltf._glb && gltf._glb.header.hasBinChunk) {
+  // Resolve GLB chunks into the parallel buffers array.
+  if (gltf._glb) {
     const {binChunks} = gltf._glb;
-    gltf.buffers[0] = {
-      arrayBuffer: binChunks[0].arrayBuffer,
-      byteOffset: binChunks[0].byteOffset,
-      byteLength: binChunks[0].byteLength
-    };
+
+    for (let bufferIndex = 0; bufferIndex < bufferDefinitions.length; bufferIndex++) {
+      const buffer = bufferDefinitions[bufferIndex];
+      if (buffer.chunk === undefined) {
+        continue;
+      }
+
+      assert(gltf._glb.version === 3, 'glTF buffer.chunk requires a GLB v3 container.');
+      assert(
+        buffer.uri === undefined,
+        `glTF buffer ${bufferIndex} cannot define both uri and chunk.`
+      );
+      const binChunk = binChunks.find(chunk => chunk.chunkIndex === buffer.chunk);
+      assert(
+        binChunk,
+        `glTF buffer ${bufferIndex} references missing GLB BIN chunk ${buffer.chunk}.`
+      );
+      assert(
+        buffer.byteLength <= binChunk.byteLength,
+        `glTF buffer ${bufferIndex} is larger than GLB BIN chunk ${buffer.chunk}.`
+      );
+      gltf.buffers[bufferIndex] = {
+        arrayBuffer: binChunk.arrayBuffer,
+        byteOffset: binChunk.byteOffset,
+        byteLength: buffer.byteLength
+      };
+    }
+
+    const uriLessBufferIndices = bufferDefinitions
+      .map((buffer, bufferIndex) => (buffer.uri === undefined ? bufferIndex : -1))
+      .filter(bufferIndex => bufferIndex !== -1);
+    const implicitBinChunk = binChunks.find(chunk => chunk.chunkIndex === 1);
+    const usesLegacyImplicitBuffer =
+      gltf._glb.version < 3 ||
+      (gltf._glb.jsonChunkIndex === 0 &&
+        bufferDefinitions[0]?.chunk === undefined &&
+        uriLessBufferIndices.length === 1 &&
+        uriLessBufferIndices[0] === 0 &&
+        Boolean(implicitBinChunk));
+
+    if (usesLegacyImplicitBuffer && (gltf._glb.version < 3 || bufferDefinitions[0])) {
+      const binChunk = gltf._glb.version < 3 ? binChunks[0] : implicitBinChunk;
+      assert(binChunk);
+      gltf.buffers[0] = {
+        arrayBuffer: binChunk.arrayBuffer,
+        byteOffset: binChunk.byteOffset,
+        byteLength: binChunk.byteLength
+      };
+    }
 
     // TODO - this modifies JSON and is a post processing thing
     // gltf.json.buffers[0].data = gltf.buffers[0].arrayBuffer;
     // gltf.json.buffers[0].byteOffset = gltf.buffers[0].byteOffset;
+  }
+
+  if (!gltf._glb) {
+    const chunkBufferIndex = bufferDefinitions.findIndex(buffer => buffer.chunk !== undefined);
+    assert(chunkBufferIndex === -1, `glTF buffer ${chunkBufferIndex} uses chunk outside a GLB.`);
   }
 
   // Populate images

--- a/modules/gltf/src/lib/types/glb-types.ts
+++ b/modules/gltf/src/lib/types/glb-types.ts
@@ -1,4 +1,6 @@
 export type GLBBinChunk = {
+  /** Zero-based index of this chunk in the GLB container. */
+  chunkIndex: number;
   byteOffset: number;
   byteLength: number;
   arrayBuffer: ArrayBuffer;
@@ -18,5 +20,7 @@ export type GLB = {
 
   // Per spec we must iterate over chunks, ignoring all except JSON and BIN
   json: Record<string, any>;
+  /** Zero-based index of the glTF JSON chunk in the GLB container. */
+  jsonChunkIndex: number;
   binChunks: GLBBinChunk[];
 };

--- a/modules/gltf/src/lib/types/gltf-json-schema.ts
+++ b/modules/gltf/src/lib/types/gltf-json-schema.ts
@@ -215,6 +215,11 @@ export type GLTFBuffer = {
    */
   uri?: string;
   /**
+   * The zero-based index of the GLB v3 chunk containing the buffer.
+   * Draft glTF 2.1 property; mutually exclusive with `uri`.
+   */
+  chunk?: number;
+  /**
    * The length of the buffer in bytes.
    */
   byteLength: number;

--- a/modules/gltf/src/lib/types/gltf-postprocessed-schema.ts
+++ b/modules/gltf/src/lib/types/gltf-postprocessed-schema.ts
@@ -249,6 +249,8 @@ export type GLTFBufferPostprocessed = {
 
   /** The uri of the buffer. */
   uri?: string;
+  /** The zero-based GLB v3 chunk index selected by this buffer. */
+  chunk?: number;
   name?: any;
   extensions?: any;
   extras?: any;

--- a/modules/gltf/test/glb-loader.spec.ts
+++ b/modules/gltf/test/glb-loader.spec.ts
@@ -4,6 +4,7 @@ import {validateLoader} from 'test/common/conformance';
 
 import {load, parseSync, fetchFile} from '@loaders.gl/core';
 import {GLBLoader} from '@loaders.gl/gltf/bundled';
+import {createGLBV3} from './test-utils/create-glb-v3';
 
 const GLTF_BINARY_URL = '@loaders.gl/gltf/test/data/gltf-2.0/2CylinderEngine.glb';
 const GLB_V1_TILE_CESIUM_AIR_URL = '@loaders.gl/gltf/test/data/3d-tiles/Cesium_Air.glb';
@@ -38,15 +39,34 @@ test('GLBLoader#load(v1)', async t => {
 });
 
 test('GLBLoader#parseSync(v3)', t => {
-  const data = createGLBV3({asset: {version: '2.1'}}, new Uint8Array([1, 2, 3, 4]));
+  const data = createGLBV3({asset: {version: '2.1'}}, [new Uint8Array([1, 2, 3, 4])]);
   const glbv3 = parseSync(data, GLBLoader);
 
   t.equal(glbv3.version, 3, 'GLBLoader returned correct glb version');
   t.equal(glbv3.header.byteLength, data.byteLength, 'GLBLoader read the 64-bit file length');
   t.equal(glbv3.json.asset.version, '2.1', 'GLBLoader returned correct gltf version');
+  t.equal(glbv3.jsonChunkIndex, 0, 'GLBLoader records the JSON chunk index');
   t.equal(glbv3.binChunks.length, 1, 'GLBLoader returned the BIN chunk');
+  t.equal(glbv3.binChunks[0].chunkIndex, 1, 'GLBLoader records the BIN chunk index');
   t.equal(glbv3.binChunks[0].byteLength, 4, 'GLBLoader read the 64-bit chunk length');
 
+  t.end();
+});
+
+test('GLBLoader#parseSync(v3) preserves absolute chunk indices', t => {
+  const data = createGLBV3(
+    {asset: {version: '2.1'}},
+    [new Uint8Array([1, 2, 3, 4]), new Uint8Array([5, 6, 7, 8])],
+    [{type: 0x54534554, data: new Uint8Array([9, 10, 11, 12])}]
+  );
+  const glbv3 = parseSync(data, GLBLoader);
+
+  t.equal(glbv3.jsonChunkIndex, 1, 'finds the first JSON chunk after a custom chunk');
+  t.deepEqual(
+    glbv3.binChunks.map(chunk => chunk.chunkIndex),
+    [2, 3],
+    'records BIN indices in the full chunk sequence'
+  );
   t.end();
 });
 
@@ -72,35 +92,3 @@ test('GLBLoader#parseSync(v3) rejects unsafe 64-bit lengths', t => {
   );
   t.end();
 });
-
-/** Create a GLB v3 fixture using the draft Khronos binary layout. */
-function createGLBV3(json: Record<string, unknown>, binary?: Uint8Array): ArrayBuffer {
-  const textEncoder = new TextEncoder();
-  const jsonBytes = textEncoder.encode(JSON.stringify(json));
-  const jsonByteLength = Math.ceil(jsonBytes.byteLength / 4) * 4;
-  const binaryByteLength = binary ? Math.ceil(binary.byteLength / 4) * 4 : 0;
-  const fileByteLength = 16 + 16 + jsonByteLength + (binary ? 16 + binaryByteLength : 0);
-  const arrayBuffer = new ArrayBuffer(fileByteLength);
-  const dataView = new DataView(arrayBuffer);
-  const bytes = new Uint8Array(arrayBuffer);
-
-  dataView.setUint32(0, 0x46546c67, true);
-  dataView.setUint32(4, 3, true);
-  dataView.setBigUint64(8, BigInt(fileByteLength), true);
-
-  dataView.setUint32(16, 0x4e4f534a, true);
-  dataView.setUint32(20, 0, true);
-  dataView.setBigUint64(24, BigInt(jsonByteLength), true);
-  bytes.fill(0x20, 32, 32 + jsonByteLength);
-  bytes.set(jsonBytes, 32);
-
-  if (binary) {
-    const binaryHeaderByteOffset = 32 + jsonByteLength;
-    dataView.setUint32(binaryHeaderByteOffset, 0x004e4942, true);
-    dataView.setUint32(binaryHeaderByteOffset + 4, 0, true);
-    dataView.setBigUint64(binaryHeaderByteOffset + 8, BigInt(binaryByteLength), true);
-    bytes.set(binary, binaryHeaderByteOffset + 16);
-  }
-
-  return arrayBuffer;
-}

--- a/modules/gltf/test/gltf-loader.spec.ts
+++ b/modules/gltf/test/gltf-loader.spec.ts
@@ -2,11 +2,12 @@
 import test from 'tape-promise/tape';
 import {validateLoader} from 'test/common/conformance';
 
-import {registerLoaders, load, parseSync, fetchFile} from '@loaders.gl/core';
+import {registerLoaders, load, parse, parseSync, fetchFile} from '@loaders.gl/core';
 import {GLTFLoader, postProcessGLTF, type GLTFLoaderOptions} from '@loaders.gl/gltf';
 import {DracoLoader} from '@loaders.gl/draco';
 import {ImageBitmapLoader} from '@loaders.gl/images';
 import {getGLTFImageOptions} from '../src/lib/parsers/parse-gltf';
+import {createGLBV3} from './test-utils/create-glb-v3';
 
 const GLTF_BINARY_URL = '@loaders.gl/gltf/test/data/gltf-2.0/2CylinderEngine.glb';
 const GLTF_JSON_URL = '@loaders.gl/gltf/test/data/gltf-2.0/2CylinderEngine.gltf';
@@ -34,6 +35,65 @@ test('GLTFLoader#load(binary)', async t => {
   const data = await load(GLTF_BINARY_URL, GLTFLoader);
   t.ok(data.json.asset, 'GLTFLoader returned parsed data');
 
+  t.end();
+});
+
+test('GLTFLoader#parse(v3) resolves explicit buffer chunk indices', async t => {
+  const data = createGLBV3(
+    {
+      asset: {version: '2.1'},
+      buffers: [
+        {byteLength: 4, chunk: 3},
+        {byteLength: 4, chunk: 2}
+      ]
+    },
+    [new Uint8Array([1, 2, 3, 4]), new Uint8Array([5, 6, 7, 8])],
+    [{type: 0x54534554, data: new Uint8Array([9, 10, 11, 12])}]
+  );
+
+  const gltf = await parse(data, GLTFLoader, {gltf: {loadBuffers: true, loadImages: false}});
+  const firstBuffer = new Uint8Array(
+    gltf.buffers[0].arrayBuffer,
+    gltf.buffers[0].byteOffset,
+    gltf.buffers[0].byteLength
+  );
+  const secondBuffer = new Uint8Array(
+    gltf.buffers[1].arrayBuffer,
+    gltf.buffers[1].byteOffset,
+    gltf.buffers[1].byteLength
+  );
+
+  t.deepEqual(Array.from(firstBuffer), [5, 6, 7, 8], 'resolves buffer 0 from chunk 3');
+  t.deepEqual(Array.from(secondBuffer), [1, 2, 3, 4], 'resolves buffer 1 from chunk 2');
+  t.end();
+});
+
+test('GLTFLoader#parse(v3) preserves legacy implicit buffer mapping', async t => {
+  const data = createGLBV3({asset: {version: '2.1'}, buffers: [{byteLength: 4}]}, [
+    new Uint8Array([1, 2, 3, 4])
+  ]);
+  const gltf = await parse(data, GLTFLoader, {gltf: {loadBuffers: true, loadImages: false}});
+  const buffer = new Uint8Array(
+    gltf.buffers[0].arrayBuffer,
+    gltf.buffers[0].byteOffset,
+    gltf.buffers[0].byteLength
+  );
+
+  t.deepEqual(Array.from(buffer), [1, 2, 3, 4], 'maps the classic JSON-then-BIN layout');
+  t.end();
+});
+
+test('GLTFLoader#parse(v3) rejects missing buffer chunks', async t => {
+  const data = createGLBV3({
+    asset: {version: '2.1'},
+    buffers: [{byteLength: 4, chunk: 2}]
+  });
+
+  await t.rejects(
+    parse(data, GLTFLoader, {gltf: {loadBuffers: true, loadImages: false}}),
+    /buffer 0 references missing GLB BIN chunk 2/,
+    'rejects a chunk index that does not select a BIN chunk'
+  );
   t.end();
 });
 

--- a/modules/gltf/test/test-utils/create-glb-v3.ts
+++ b/modules/gltf/test/test-utils/create-glb-v3.ts
@@ -1,0 +1,58 @@
+/** A chunk to place before the JSON chunk in a draft GLB v3 fixture. */
+export type GLBV3PrefixChunk = {
+  /** Four-byte GLB chunk type. */
+  type: number;
+  /** Unpadded chunk payload. */
+  data: Uint8Array;
+};
+
+/**
+ * Create a GLB v3 fixture using the draft Khronos binary layout.
+ * @param json - glTF JSON payload.
+ * @param binaryChunks - BIN chunk payloads placed after the JSON chunk.
+ * @param prefixChunks - Custom chunks placed before the JSON chunk.
+ * @returns Encoded GLB v3 fixture.
+ */
+export function createGLBV3(
+  json: Record<string, unknown>,
+  binaryChunks: Uint8Array[] = [],
+  prefixChunks: GLBV3PrefixChunk[] = []
+): ArrayBuffer {
+  const textEncoder = new TextEncoder();
+  const jsonBytes = textEncoder.encode(JSON.stringify(json));
+  const chunks = [
+    ...prefixChunks,
+    {type: 0x4e4f534a, data: jsonBytes},
+    ...binaryChunks.map(data => ({type: 0x004e4942, data}))
+  ];
+  const fileByteLength = chunks.reduce(
+    (byteLength, chunk) => byteLength + 16 + padToFourBytes(chunk.data.byteLength),
+    16
+  );
+  const arrayBuffer = new ArrayBuffer(fileByteLength);
+  const dataView = new DataView(arrayBuffer);
+  const bytes = new Uint8Array(arrayBuffer);
+
+  dataView.setUint32(0, 0x46546c67, true);
+  dataView.setUint32(4, 3, true);
+  dataView.setBigUint64(8, BigInt(fileByteLength), true);
+
+  let byteOffset = 16;
+  for (const chunk of chunks) {
+    const chunkByteLength = padToFourBytes(chunk.data.byteLength);
+    dataView.setUint32(byteOffset, chunk.type, true);
+    dataView.setUint32(byteOffset + 4, 0, true);
+    dataView.setBigUint64(byteOffset + 8, BigInt(chunkByteLength), true);
+    const paddingByte = chunk.type === 0x4e4f534a ? 0x20 : 0;
+    bytes.fill(paddingByte, byteOffset + 16, byteOffset + 16 + chunkByteLength);
+    bytes.set(chunk.data, byteOffset + 16);
+    byteOffset += 16 + chunkByteLength;
+  }
+
+  return arrayBuffer;
+}
+
+/** Round a byte length up to the four-byte alignment required by GLB chunks. */
+function padToFourBytes(byteLength: number): number {
+  return Math.ceil(byteLength / 4) * 4;
+}


### PR DESCRIPTION
## Goals

Add the draft glTF 2.1 `buffer.chunk` mechanism so `@loaders.gl/gltf` can resolve multiple GLB v3 BIN chunks by their absolute chunk indices while preserving the narrowly defined legacy implicit-buffer layout.

Draft proposal: https://github.com/KhronosGroup/glTF/issues/2611

## Changes

- Add `chunk?: number` to JSON and postprocessed buffer definitions.
- Record absolute chunk indices for parsed BIN chunks and the selected glTF JSON chunk.
- Treat the first JSON chunk as the glTF document in GLB v3, allowing custom chunks before it.
- Resolve each explicit `buffer.chunk` reference to its corresponding BIN chunk, including reordered buffer definitions.
- Validate the container version, `uri`/`chunk` exclusivity, target chunk type, and declared buffer length.
- Preserve implicit buffer-0 resolution for GLB v1/v2 and the draft’s compatible GLB v3 JSON-at-0/BIN-at-1 layout.
- Add shared GLB v3 fixtures and Node/headless tests for absolute indices, explicit resolution, legacy fallback, and missing chunks.
- Expand the GLB format and loader documentation and link them from the v5 release notes.

## Impact

Applications can load draft glTF 2.1 assets that distribute buffer data across multiple GLB v3 BIN chunks. Existing GLB v1/v2 behavior remains unchanged.

## Validation

- `yarn build`
- `yarn test-node` — 385 files passed, 4 skipped; 1,647 tests passed, 75 skipped
- `yarn test-headless` — 389 files passed, 3 skipped; 1,643 tests passed, 60 skipped
- `yarn lint fix`