### PR TITLE
fix: run supported tests in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,8 +82,11 @@ jobs:
       - name: Build workers
         run: yarn build-workers
 
-      - name: Run tests from transpiled code
-        run: yarn test-modules dist
+      - name: Run Node tests
+        run: yarn test-node
+
+      - name: Run headless browser tests
+        run: yarn test-headless
 
       - name: Login to NPM
         run: npm config set "//registry.npmjs.org/:_authToken=${NPM_ACCESS_TOKEN}"


### PR DESCRIPTION
## Goals

Unblock the initial loaders.gl 5.0.0 alpha release by making the tag-triggered release workflow run supported test commands.

## Changes

- Replace the removed `test-modules dist` mode with the canonical `test-node` and `test-headless` scripts.
- Split Node and browser coverage into separate workflow steps so failures identify the affected suite.
- Remove the stale claim that the Vitest suites exercise transpiled output.

## Validation

- `yarn install --immutable`
- `yarn build`
- `yarn build-workers`
- Node Vitest project: 1,643 passed, 75 skipped
- Headless Vitest project: 1,639 passed, 60 skipped
- `yarn lint fix`
- `git diff --check`