### PR TITLE
chore: upgrade TypeScript to 6.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   ],
   "resolutions": {
     "apache-arrow": "^21.0.0",
-    "typescript": "^5.6.0",
+    "typescript": "^6.0.3",
     "@loaders.gl/3d-tiles": "^5.0.0-alpha.0",
     "@loaders.gl/compression": "^5.0.0-alpha.0",
     "@loaders.gl/core": "^5.0.0-alpha.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,8 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "noUnusedLocals": true,
+    "types": ["node"],
+    "ignoreDeprecations": "6.0",
     // This must be specified if "paths" is.
     "baseUrl": ".",
     "paths": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -34155,23 +34155,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.6.0":
-  version: 5.9.3
-  resolution: "typescript@npm:5.9.3"
+"typescript@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "typescript@npm:6.0.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/6bd7552ce39f97e711db5aa048f6f9995b53f1c52f7d8667c1abdc1700c68a76a308f579cd309ce6b53646deb4e9a1be7c813a93baaf0a28ccd536a30270e1c5
+  checksum: 10c0/4a25ff5045b984370f48f196b3a0120779b1b343d40b9a68d114ea5e5fff099809b2bb777576991a63a5cd59cf7bffd96ff6fe10afcefbcb8bd6fb96ad4b6606
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.6.0#optional!builtin<compat/typescript>":
-  version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
+"typescript@patch:typescript@npm%3A^6.0.3#optional!builtin<compat/typescript>":
+  version: 6.0.3
+  resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
+  checksum: 10c0/2f25c74e65663c248fa1ade2b8459d9ce5372ff9dad07067310f132966ebec1d93f6c42f0baf77a6b6a7a91460463f708e6887013aaade22111037457c6b25df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Goals

Upgrade loaders.gl's centrally resolved TypeScript compiler to the latest TypeScript 6 release while preserving the current build and module-resolution behavior.

## Changes

- update the root TypeScript resolution to `^6.0.3` and refresh `yarn.lock`
- explicitly include Node ambient types now that TypeScript 6 defaults `types` to an empty list
- set `ignoreDeprecations` to `6.0` so the existing `baseUrl` and Node 10 module-resolution configuration remain supported during the TypeScript 6 transition

## Validation

- `yarn install --immutable`
- `yarn test-vitest-async-guardrails`
- `yarn build`
- `yarn lint fix`
- `yarn test-node` (1,647 passed, 75 skipped)
- `yarn test-headless` (1,643 passed, 60 skipped)
- `cd website && yarn && yarn build`
