### PR TITLE
Add draft glTF 2.1 unified file references

### DIFF
--- a/docs/modules/gltf/api-reference/gltf-loader.md
+++ b/docs/modules/gltf/api-reference/gltf-loader.md
@@ -61,9 +61,21 @@ Note: while supported, synchronous parsing of glTF (e.g. using `parseSync()`) ha
 | Option                  | Type    | Default |                                                                            | Description |
 | ----------------------- | ------- | ------- | -------------------------------------------------------------------------- | ----------- |
 | `gltf.loadBuffers`      | Boolean | `false` | Fetch any referenced binary buffer files (and decode base64 encoded URIS). |
+| `gltf.loadFiles`        | Boolean | `false` | Resolve draft glTF 2.1 `files` entries from URIs or buffer views.           |
 | `gltf.loadImages`       | Boolean | `false` | Load any referenced image files (and decode base64 encoded URIS).          |
 | `gltf.decompressMeshes` | Boolean | `true`  | Decompress Draco compressed meshes (if DracoLoader available).             |
 | `gltf.normalize`        | Boolean | `false` | Optional, best-effort attempt at converting glTF v1 files to glTF2 format. |
+
+## Draft glTF 2.1 File Resolution
+
+`resolveGLTFFile(gltf, fileReference, options, context)` resolves one entry from the draft glTF 2.1
+`files` array. `fileReference` can be an array index, a package name matching `files[*].name`, or an
+original URI matching `files[*].uri`. URI-backed files are fetched relative to the containing asset;
+buffer-view-backed files return a view of the already loaded buffer without copying it. Resolved
+entries are cached in the parallel `gltf.files` array.
+
+`findGLTFFileIndex(gltf, reference)` performs only the virtual package lookup and returns `-1` when
+there is no matching entry. Ambiguous package names are rejected.
 
 ## Working with GLTF data
 
@@ -112,6 +124,16 @@ However, the objects inside these arrays will have been pre-processed to simplif
     arrayBuffer: ArrayBuffer,
     byteOffset: Number,
     byteLength: Number
+  }],
+
+  // Draft glTF 2.1 generic files. Length and indices match json.files.
+  files: [{
+    arrayBuffer: ArrayBuffer,
+    byteOffset: Number,
+    byteLength: Number,
+    mimeType: String,
+    name: String, // optional virtual package name
+    url: String  // optional resolved URL
   }],
 
   // Images can optionally be loaded and decoded, they will be stored here.

--- a/docs/modules/gltf/formats/gltf.md
+++ b/docs/modules/gltf/formats/gltf.md
@@ -8,6 +8,22 @@ glTF is a standard file format for three-dimensional scenes and models, intended
 
 An open standard developed and maintained by the Khronos Group, it supports 3D model geometry, appearance, scene graph hierarchy, and animation.
 
+## Draft glTF 2.1 Unified File References
+
+Draft glTF 2.1 adds a top-level `files` array for generic dependencies beyond buffers and images.
+Each file has a required `mimeType` and exactly one source: an external or data `uri`, or an
+embedded `bufferView`. `GLTFLoader` can resolve these entries into its parallel `files` result
+array with `gltf.loadFiles: true`.
+
+For packaged assets, [`resolveGLTFFile()`](/docs/modules/gltf/api-reference/gltf-loader) also accepts
+a string reference. It looks up `files[*].name` or the original `files[*].uri`, providing the virtual
+file-system primitive needed to resolve dependencies from an embedded glTF asset. Recursive
+`externalAssets` parsing is intentionally separate from this file-resolution layer.
+
+This support follows the Khronos [Unified File References draft](https://github.com/KhronosGroup/glTF/issues/2590)
+and [Packaging External Assets draft](https://github.com/KhronosGroup/glTF/issues/2589), and may
+evolve while glTF 2.1 is finalized.
+
 ## Variants
 
 A glTF file uses one of two possible file extensions: .gltf (JSON/ASCII) or .glb (binary). Both .gltf and .glb files may reference external binary and texture resources. Alternatively, both formats may be self-contained by directly embedding binary data buffers (as base64-encoded strings in .gltf files or as raw byte arrays in .glb files).

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -26,6 +26,7 @@ Release Date: 2026
 - [`GLBLoader`](/docs/modules/gltf/api-reference/glb-loader) adds draft GLB v3 parsing with 64-bit file and chunk lengths, multi-chunk traversal, and reserved chunk-encoding validation, advancing glTF 2.1 readiness.
 - [`GLBLoader`](/docs/modules/gltf/api-reference/glb-loader) and [`GLTFLoader`](/docs/modules/gltf/api-reference/gltf-loader) add draft [GLB v3](/docs/modules/gltf/formats/glb) support for 64-bit lengths, multi-chunk traversal, reserved chunk-encoding validation, and explicit `buffer.chunk` references, advancing glTF 2.1 readiness.
 - [`GLTFLoader`](/docs/modules/gltf/api-reference/gltf-loader) adds draft [glTF 2.1 accessor component types](/docs/modules/gltf/formats/gltf#accessor-component-types), including signed 32-bit integers, 16- and 64-bit floats, and signed and unsigned 64-bit integers.
+- [`GLTFLoader`](/docs/modules/gltf/api-reference/gltf-loader) adds opt-in loading of draft glTF 2.1 [unified file references](/docs/modules/gltf/formats/gltf) from URIs or buffer views, plus virtual package lookup through `resolveGLTFFile()`.
 
 **@loaders.gl/las** 
 

--- a/modules/gltf/src/gltf-loader.ts
+++ b/modules/gltf/src/gltf-loader.ts
@@ -38,6 +38,7 @@ export const GLTFLoader = {
     gltf: {
       normalize: true, // Normalize glTF v1 to glTF v2 format (not yet stable)
       loadBuffers: true, // Fetch any linked .BIN buffers, decode base64
+      loadFiles: false, // Resolve generic glTF 2.1 file references on demand
       loadImages: true, // Create image objects
       decompressMeshes: true // Decompress Draco encoded meshes
     }

--- a/modules/gltf/src/index.ts
+++ b/modules/gltf/src/index.ts
@@ -16,6 +16,7 @@ export type {
   GLTFSkin,
   GLTFTexture,
   GLTFImage,
+  GLTFFile,
   GLTFObject,
   // The following extensions are handled by the GLTFLoader and removed from the parsed glTF (disable via options.gltf.excludeExtensions)
   GLTF_KHR_binary_glTF,
@@ -77,7 +78,11 @@ export type {
   GLTFTexturePostprocessed
 } from './lib/types/gltf-postprocessed-schema';
 
-export type {GLTFWithBuffers, FeatureTableJson} from './lib/types/gltf-types';
+export type {
+  GLTFWithBuffers,
+  GLTFExternalFile,
+  FeatureTableJson
+} from './lib/types/gltf-types';
 export {
   GLTFSchema,
   GLTFIdSchema,
@@ -131,6 +136,10 @@ export {GLBWriter} from './glb-writer';
 export {GLTFScenegraph} from './lib/api/gltf-scenegraph';
 export {postProcessGLTF} from './lib/api/post-process-gltf';
 export {getMemoryUsageGLTF as _getMemoryUsageGLTF} from './lib/gltf-utils/gltf-utils';
+export {
+  findGLTFFileIndex,
+  resolveGLTFFile
+} from './lib/gltf-utils/resolve-gltf-file';
 
 export {
   createExtStructuralMetadata,

--- a/modules/gltf/src/lib/gltf-utils/resolve-gltf-file.ts
+++ b/modules/gltf/src/lib/gltf-utils/resolve-gltf-file.ts
@@ -1,0 +1,91 @@
+import type {LoaderContext, StrictLoaderOptions} from '@loaders.gl/loader-utils';
+import type {GLTFExternalFile, GLTFWithBuffers} from '../types/gltf-types';
+import {getTypedArrayForBufferView} from './get-typed-array';
+import {resolveUrl} from './resolve-url';
+import {assert} from '../utils/assert';
+
+/**
+ * Find a draft glTF 2.1 file definition by package name or original URI.
+ * @param gltf - Parsed glTF container.
+ * @param reference - Package-relative file reference.
+ * @returns File index, or `-1` when no definition matches.
+ */
+export function findGLTFFileIndex(gltf: GLTFWithBuffers, reference: string): number {
+  const files = gltf.json.files || [];
+  const matches: number[] = [];
+
+  for (let fileIndex = 0; fileIndex < files.length; fileIndex++) {
+    const file = files[fileIndex];
+    if (file.name === reference || file.uri === reference) {
+      matches.push(fileIndex);
+    }
+  }
+
+  assert(matches.length <= 1, `glTF package file reference ${reference} is ambiguous.`);
+  return matches[0] ?? -1;
+}
+
+/**
+ * Resolve a draft glTF 2.1 file from a URI or embedded buffer view.
+ * String references are matched against `files[*].name` and `files[*].uri`, enabling this
+ * function to serve as the virtual file-system lookup for packaged assets.
+ * @param gltf - Parsed glTF container with buffers loaded when embedded files are used.
+ * @param fileReference - File array index, package name, or original URI.
+ * @param options - Loader options used for relative URL resolution.
+ * @param context - Loader context supplying base URL and fetch implementation.
+ * @returns Resolved file bytes and metadata.
+ */
+export async function resolveGLTFFile(
+  gltf: GLTFWithBuffers,
+  fileReference: number | string,
+  options: StrictLoaderOptions,
+  context: LoaderContext
+): Promise<GLTFExternalFile> {
+  const files = gltf.json.files || [];
+  const fileIndex =
+    typeof fileReference === 'number' ? fileReference : findGLTFFileIndex(gltf, fileReference);
+  assert(Number.isInteger(fileIndex) && fileIndex >= 0 && fileIndex < files.length);
+
+  gltf.files = gltf.files || new Array(files.length).fill(null);
+  const loadedFile = gltf.files[fileIndex];
+  if (loadedFile) {
+    return loadedFile;
+  }
+
+  const file = files[fileIndex];
+  assert(file.mimeType, `glTF file ${fileIndex} must define mimeType.`);
+  const hasUri = file.uri !== undefined;
+  const hasBufferView = file.bufferView !== undefined;
+  assert(
+    hasUri !== hasBufferView,
+    `glTF file ${fileIndex} must define exactly one of uri or bufferView.`
+  );
+
+  let resolvedFile: GLTFExternalFile;
+  if (file.uri !== undefined) {
+    const url = resolveUrl(file.uri, options, context);
+    const response = await context.fetch(url);
+    assert(response, `Failed to fetch glTF file ${file.uri}.`);
+    const arrayBuffer = await response.arrayBuffer();
+    resolvedFile = {
+      arrayBuffer,
+      byteOffset: 0,
+      byteLength: arrayBuffer.byteLength,
+      mimeType: file.mimeType,
+      name: file.name,
+      url
+    };
+  } else {
+    const data = getTypedArrayForBufferView(gltf.json, gltf.buffers, file.bufferView);
+    resolvedFile = {
+      arrayBuffer: data.buffer as ArrayBuffer,
+      byteOffset: data.byteOffset,
+      byteLength: data.byteLength,
+      mimeType: file.mimeType,
+      name: file.name
+    };
+  }
+
+  gltf.files[fileIndex] = resolvedFile;
+  return resolvedFile;
+}

--- a/modules/gltf/src/lib/parsers/parse-gltf.ts
+++ b/modules/gltf/src/lib/parsers/parse-gltf.ts
@@ -13,6 +13,7 @@ import {BasisLoader, selectSupportedBasisFormat} from '@loaders.gl/textures';
 import {assert} from '../utils/assert';
 import {isGLB, parseGLBSync} from './parse-glb';
 import {resolveUrl} from '../gltf-utils/resolve-url';
+import {resolveGLTFFile} from '../gltf-utils/resolve-gltf-file';
 import {getTypedArrayForBufferView} from '../gltf-utils/get-typed-array';
 import {preprocessExtensions, decodeExtensions} from '../api/gltf-extensions';
 import {normalizeGLTFV1} from '../api/normalize-gltf-v1';
@@ -22,6 +23,8 @@ export type ParseGLTFOptions = ParseGLBOptions & {
   normalize?: boolean;
   loadImages?: boolean;
   loadBuffers?: boolean;
+  /** Resolve draft glTF 2.1 `files` entries. */
+  loadFiles?: boolean;
   decompressMeshes?: boolean;
   excludeExtensions?: string[];
   /** @deprecated not supported in v4. `postProcessGLTF()` must be called by the application */
@@ -77,6 +80,10 @@ export async function parseGLTF(
   // Load linked buffers asynchronously and decodes base64 buffers in parallel
   if (options?.gltf?.loadBuffers && gltf.json.buffers) {
     await loadBuffers(gltf, options, context);
+  }
+
+  if (options?.gltf?.loadFiles && gltf.json.files) {
+    await loadFiles(gltf, options, context);
   }
 
   // loadImages and decodeExtensions should not be running in parallel, because
@@ -197,6 +204,21 @@ function parseGLTFContainerSync(gltf, data, byteOffset, options: GLTFLoaderOptio
   // Populate images
   const images = gltf.json.images || [];
   gltf.images = new Array(images.length).fill({});
+
+  const files = gltf.json.files || [];
+  gltf.files = new Array(files.length).fill(null);
+}
+
+/** Resolve all draft glTF 2.1 unified file references. */
+async function loadFiles(
+  gltf: GLTFWithBuffers,
+  options: GLTFLoaderOptions,
+  context: LoaderContext
+): Promise<void> {
+  const files = gltf.json.files || [];
+  await Promise.all(
+    files.map((_, fileIndex) => resolveGLTFFile(gltf, fileIndex, options, context))
+  );
 }
 
 /** Asynchronously fetch and parse buffers, store in buffers array outside of json

--- a/modules/gltf/src/lib/types/gltf-json-schema.ts
+++ b/modules/gltf/src/lib/types/gltf-json-schema.ts
@@ -366,6 +366,22 @@ export type GLTFImage = {
 };
 
 /**
+ * A draft glTF 2.1 reference to a file stored at a URI or in a buffer view.
+ */
+export type GLTFFile = {
+  /** URI of the file. Mutually exclusive with `bufferView`. */
+  uri?: string;
+  /** Index of the buffer view containing the file. Mutually exclusive with `uri`. */
+  bufferView?: GLTFId;
+  /** MIME type of the referenced file. */
+  mimeType: string;
+  /** Name used to resolve references from embedded packaged assets. */
+  name?: string;
+  extensions?: Record<string, any>;
+  extras?: any;
+};
+
+/**
  * Reference to a texture.
  */
 export type GLTFTextureInfo = {
@@ -708,6 +724,10 @@ export type GLTF = {
    */
   images?: GLTFImage[];
   /**
+   * Draft glTF 2.1 unified file references.
+   */
+  files?: GLTFFile[];
+  /**
    * An array of materials.
    */
   materials?: GLTFMaterial[];
@@ -756,7 +776,8 @@ export type GLTFObject =
   | GLTFScene
   | GLTFSkin
   | GLTFTexture
-  | GLTFImage;
+  | GLTFImage
+  | GLTFFile;
 
 // GLTF Extensions
 /* eslint-disable camelcase */

--- a/modules/gltf/src/lib/types/gltf-types.ts
+++ b/modules/gltf/src/lib/types/gltf-types.ts
@@ -11,12 +11,24 @@ export type GLTFWithBuffers = {
   binary?: ArrayBuffer;
   buffers: GLTFExternalBuffer[];
   images?: GLTFExternalImage[];
+  /** Resolved draft glTF 2.1 unified file references, parallel to `json.files`. */
+  files?: GLTFExternalFile[];
 };
 
 export type GLTFExternalBuffer = {
   arrayBuffer: ArrayBuffer;
   byteOffset: number;
   byteLength: number;
+};
+
+/** Raw bytes and metadata for a resolved draft glTF 2.1 file reference. */
+export type GLTFExternalFile = GLTFExternalBuffer & {
+  /** MIME type declared by the file definition. */
+  mimeType: string;
+  /** Optional package lookup name declared by the file definition. */
+  name?: string;
+  /** Resolved URL for URI-backed files. */
+  url?: string;
 };
 
 type GLTFExternalImage =
@@ -48,6 +60,7 @@ export type {
   GLTFSkin,
   GLTFTexture,
   GLTFImage,
+  GLTFFile,
   GLTF_KHR_binary_glTF,
   GLTF_KHR_draco_mesh_compression,
   GLTF_KHR_texture_basisu,

--- a/modules/gltf/test/gltf-loader.spec.ts
+++ b/modules/gltf/test/gltf-loader.spec.ts
@@ -97,6 +97,35 @@ test('GLTFLoader#parse(v3) rejects missing buffer chunks', async t => {
   t.end();
 });
 
+test('GLTFLoader#parse(v3) loads embedded glTF 2.1 files', async t => {
+  const data = createGLBV3(
+    {
+      asset: {version: '2.1'},
+      buffers: [{byteLength: 4}],
+      bufferViews: [{buffer: 0, byteLength: 4}],
+      files: [{name: 'nested.glb', mimeType: 'model/gltf-binary', bufferView: 0}]
+    },
+    [new Uint8Array([1, 2, 3, 4])]
+  );
+  const gltf = await parse(data, GLTFLoader, {
+    gltf: {loadBuffers: true, loadFiles: true, loadImages: false}
+  });
+  const file = gltf.files?.[0];
+  t.ok(file, 'returns a parallel resolved file entry');
+  if (!file) {
+    t.end();
+    return;
+  }
+
+  t.equal(file.name, 'nested.glb', 'preserves the virtual package name');
+  t.deepEqual(
+    Array.from(new Uint8Array(file.arrayBuffer, file.byteOffset, file.byteLength)),
+    [1, 2, 3, 4],
+    'loads file bytes from its buffer view'
+  );
+  t.end();
+});
+
 test('GLTFLoader#load(binary)', async t => {
   const data = await load(GLTF_BINARY_URL, GLTFLoader);
   t.ok(data.buffers, 'GLTFLoader without post-processing returned data.buffers');

--- a/modules/gltf/test/index.ts
+++ b/modules/gltf/test/index.ts
@@ -7,6 +7,7 @@ import './lib/glb/glb-custom-payload.spec';
 import './lib/gltf-utils/gltf-attribute-utils.spec';
 import './lib/gltf-utils/gltf-accessor-component-types.spec';
 import './lib/gltf-utils/resolve-url.spec';
+import './lib/gltf-utils/resolve-gltf-file.spec';
 
 import './lib/api/gltf-scenegraph-modifiers.spec';
 import './lib/api/gltf-scenegraph-accessors.spec';

--- a/modules/gltf/test/lib/gltf-utils/resolve-gltf-file.spec.ts
+++ b/modules/gltf/test/lib/gltf-utils/resolve-gltf-file.spec.ts
@@ -1,0 +1,114 @@
+import test from 'tape-promise/tape';
+import type {LoaderContext} from '@loaders.gl/loader-utils';
+import type {GLTFWithBuffers} from '@loaders.gl/gltf';
+import {findGLTFFileIndex, resolveGLTFFile} from '@loaders.gl/gltf';
+
+test('resolveGLTFFile#resolves embedded package files by name', async t => {
+  const arrayBuffer = new Uint8Array([0, 1, 2, 3, 4, 5]).buffer;
+  const gltf = {
+    json: {
+      asset: {version: '2.1'},
+      bufferViews: [{buffer: 0, byteOffset: 1, byteLength: 4}],
+      files: [{name: 'nested/model.glb', mimeType: 'model/gltf-binary', bufferView: 0}]
+    },
+    buffers: [{arrayBuffer, byteOffset: 0, byteLength: 6}],
+    files: [null]
+  } as unknown as GLTFWithBuffers;
+
+  const file = await resolveGLTFFile(
+    gltf,
+    'nested/model.glb',
+    {},
+    createLoaderContext(() => {
+      throw new Error('embedded files must not fetch');
+    })
+  );
+
+  t.equal(file.mimeType, 'model/gltf-binary', 'preserves the declared MIME type');
+  t.equal(file.byteOffset, 1, 'preserves the buffer view byte offset');
+  t.deepEqual(
+    Array.from(new Uint8Array(file.arrayBuffer, file.byteOffset, file.byteLength)),
+    [1, 2, 3, 4],
+    'returns the embedded bytes without copying'
+  );
+  t.equal(gltf.files?.[0], file, 'caches the resolved file in the parallel files array');
+  t.end();
+});
+
+test('resolveGLTFFile#fetches URI files relative to the containing asset', async t => {
+  let fetchedUrl = '';
+  const gltf = {
+    json: {
+      asset: {version: '2.1'},
+      files: [{mimeType: 'audio/mpeg', uri: 'media/audio.mp3'}]
+    },
+    buffers: [],
+    files: [null]
+  } as unknown as GLTFWithBuffers;
+  const context = createLoaderContext(async url => {
+    fetchedUrl = String(url);
+    return new Response(new Uint8Array([7, 8, 9]));
+  });
+  context.baseUrl = 'https://example.com/models';
+
+  const file = await resolveGLTFFile(gltf, 'media/audio.mp3', {}, context);
+
+  t.equal(fetchedUrl, 'https://example.com/models/media/audio.mp3', 'resolves the relative URI');
+  t.equal(file.url, fetchedUrl, 'records the resolved source URL');
+  t.deepEqual(
+    Array.from(new Uint8Array(file.arrayBuffer)),
+    [7, 8, 9],
+    'returns fetched file bytes'
+  );
+  t.end();
+});
+
+test('findGLTFFileIndex#rejects ambiguous virtual package references', t => {
+  const gltf = {
+    json: {
+      asset: {version: '2.1'},
+      files: [
+        {name: 'shared.bin', mimeType: 'application/octet-stream', bufferView: 0},
+        {uri: 'shared.bin', mimeType: 'application/octet-stream'}
+      ]
+    },
+    buffers: [],
+    files: [null, null]
+  } as unknown as GLTFWithBuffers;
+
+  t.throws(
+    () => findGLTFFileIndex(gltf, 'shared.bin'),
+    /package file reference shared.bin is ambiguous/,
+    'requires a unique package mapping'
+  );
+  t.end();
+});
+
+test('resolveGLTFFile#requires exactly one file source', async t => {
+  const gltf = {
+    json: {
+      asset: {version: '2.1'},
+      files: [
+        {
+          mimeType: 'application/octet-stream',
+          uri: 'data.bin',
+          bufferView: 0
+        }
+      ]
+    },
+    buffers: [],
+    files: [null]
+  } as unknown as GLTFWithBuffers;
+
+  await t.rejects(
+    resolveGLTFFile(gltf, 0, {}, createLoaderContext(globalThis.fetch)),
+    /must define exactly one of uri or bufferView/,
+    'rejects conflicting URI and buffer view sources'
+  );
+  t.end();
+});
+
+/** Create the minimum loader context needed by the file resolver. */
+function createLoaderContext(fetch: typeof globalThis.fetch): LoaderContext {
+  return {fetch} as LoaderContext;
+}


### PR DESCRIPTION
## Goals

- Establish the first loader-side tranche for draft glTF 2.1 external assets.
- Support unified `files` definitions without coupling file resolution to recursive child-asset parsing.
- Provide the virtual package lookup primitive needed by a later `externalAssets` tranche.

## Changes

- Add public `GLTFFile` and `GLTFExternalFile` types for URI-backed and buffer-view-backed file definitions.
- Add opt-in `gltf.loadFiles` loading while preserving the original JSON definitions and storing resolved data in a parallel `gltf.files` array.
- Add `resolveGLTFFile()` for URI fetches, zero-copy embedded buffer views, result caching, and lookup by file index, package name, or original URI.
- Add `findGLTFFileIndex()` with ambiguous-reference validation.
- Add shared resolver coverage and a GLB v3 integration test.
- Document unified file references in the glTF format guide, loader API, and v5 release notes.

Recursive parsing of draft `externalAssets` is intentionally left for a later tranche.

## Validation

- `yarn build`
- `yarn lint fix`
- `yarn test-headless` — 1,648 passed, 60 skipped
- `yarn vitest run --project node modules/gltf/test` — 72 passed
- `yarn test-node` — 1,651 passed, 75 skipped; one unrelated LAS backend comparison timed out after 15 seconds