### PR TITLE
Load draft glTF 2.1 external assets

### DIFF
--- a/docs/modules/gltf/api-reference/gltf-loader.md
+++ b/docs/modules/gltf/api-reference/gltf-loader.md
@@ -58,13 +58,14 @@ Note: while supported, synchronous parsing of glTF (e.g. using `parseSync()`) ha
 
 ## Options
 
-| Option                  | Type    | Default |                                                                            | Description |
-| ----------------------- | ------- | ------- | -------------------------------------------------------------------------- | ----------- |
-| `gltf.loadBuffers`      | Boolean | `false` | Fetch any referenced binary buffer files (and decode base64 encoded URIS). |
-| `gltf.loadFiles`        | Boolean | `false` | Resolve draft glTF 2.1 `files` entries from URIs or buffer views.           |
-| `gltf.loadImages`       | Boolean | `false` | Load any referenced image files (and decode base64 encoded URIS).          |
-| `gltf.decompressMeshes` | Boolean | `true`  | Decompress Draco compressed meshes (if DracoLoader available).             |
-| `gltf.normalize`        | Boolean | `false` | Optional, best-effort attempt at converting glTF v1 files to glTF2 format. |
+| Option                    | Type    | Default | Description                                                                  |
+| ------------------------- | ------- | ------- | ---------------------------------------------------------------------------- |
+| `gltf.loadBuffers`        | Boolean | `false` | Fetch any referenced binary buffer files (and decode base64 encoded URIS).   |
+| `gltf.loadFiles`          | Boolean | `false` | Resolve draft glTF 2.1 `files` entries from URIs or buffer views.             |
+| `gltf.loadExternalAssets` | Boolean | `false` | Recursively parse draft glTF 2.1 external assets instantiated by scene nodes. |
+| `gltf.loadImages`         | Boolean | `false` | Load any referenced image files (and decode base64 encoded URIS).            |
+| `gltf.decompressMeshes`   | Boolean | `true`  | Decompress Draco compressed meshes (if DracoLoader available).               |
+| `gltf.normalize`          | Boolean | `false` | Optional, best-effort attempt at converting glTF v1 files to glTF2 format.   |
 
 ## Draft glTF 2.1 File Resolution
 
@@ -76,6 +77,17 @@ entries are cached in the parallel `gltf.files` array.
 
 `findGLTFFileIndex(gltf, reference)` performs only the virtual package lookup and returns `-1` when
 there is no matching entry. Ambiguous package names are rejected.
+
+## Draft glTF 2.1 External Assets
+
+With `gltf.loadExternalAssets: true`, `GLTFLoader` parses external assets referenced by
+`json.nodes[*].externalAsset`. Parsed children are stored in `gltf.externalAssets` at the same index
+as their `json.externalAssets` definition. Repeated references to the same URI share one parsed
+result, and cyclical references are rejected.
+
+Dependencies of URI-backed children resolve relative to the child URI. Dependencies of embedded
+children resolve through the containing asset's `files` array, allowing an unmodified nested glTF
+and its buffers or textures to be packaged together. Unreferenced definitions remain unloaded.
 
 ## Working with GLTF data
 
@@ -135,6 +147,10 @@ However, the objects inside these arrays will have been pre-processed to simplif
     name: String, // optional virtual package name
     url: String  // optional resolved URL
   }],
+
+  // Recursively parsed glTF 2.1 assets. Indices match json.externalAssets.
+  // Unreferenced definitions remain null.
+  externalAssets: Array<GLTFWithBuffers | null>,
 
   // Images can optionally be loaded and decoded, they will be stored here.
   // Standard raster images are decoded through ImageBitmapLoader.

--- a/docs/modules/gltf/api-reference/gltf-loader.md
+++ b/docs/modules/gltf/api-reference/gltf-loader.md
@@ -42,6 +42,8 @@ The `GLTFLoader` aims to take care of as much processing as possible, while rema
 
 Draft glTF 2.1 readiness includes the [new accessor component type definitions](/docs/modules/gltf/formats/gltf#accessor-component-types). `GLTFScenegraph` and `postProcessGLTF` expose these values through the corresponding JavaScript typed arrays.
 
+The loader also supports draft glTF 2.1 [thumbnails](/docs/modules/gltf/formats/gltf#draft-gltf-21-thumbnails). When `asset.thumbnail` references an image, `gltf.loadImages: true` loads that image even if it is not used by a texture.
+
 The GLTF Loader returns an object with a `json` field containing the glTF Scenegraph. In its basic mode, the `GLTFLoader` does not modify the loaded JSON in any way. Instead, the results of additional processing are placed in parallel top-level fields such as `buffers` and `images`. This ensures that applications that want to work with the standard glTF data structure can do so.
 
 Optionally, the loaded gltf can be "post processed", which lightly annotates and transforms the loaded JSON structure to make it easier to use. Refer to [postProcessGLTF](post-process-gltf) for details.
@@ -63,7 +65,7 @@ Note: while supported, synchronous parsing of glTF (e.g. using `parseSync()`) ha
 | `gltf.loadBuffers`        | Boolean | `false` | Fetch any referenced binary buffer files (and decode base64 encoded URIS).   |
 | `gltf.loadFiles`          | Boolean | `false` | Resolve draft glTF 2.1 `files` entries from URIs or buffer views.             |
 | `gltf.loadExternalAssets` | Boolean | `false` | Recursively parse draft glTF 2.1 external assets instantiated by scene nodes. |
-| `gltf.loadImages`         | Boolean | `false` | Load any referenced image files (and decode base64 encoded URIS).            |
+| `gltf.loadImages`         | Boolean | `false` | Load images referenced by textures or the draft glTF 2.1 thumbnail.          |
 | `gltf.decompressMeshes`   | Boolean | `true`  | Decompress Draco compressed meshes (if DracoLoader available).               |
 | `gltf.normalize`          | Boolean | `false` | Optional, best-effort attempt at converting glTF v1 files to glTF2 format.   |
 

--- a/docs/modules/gltf/api-reference/post-process-gltf.md
+++ b/docs/modules/gltf/api-reference/post-process-gltf.md
@@ -102,6 +102,7 @@ Remarks:
 
 - `image.image` - Populated from the supplied `gltf.images` array. This array is populated by the `GLTFLoader` via `options.loadImages: true`):
 - `image.uri` - If the loaded image in the `images` array is not available, uses `gltf.baseUri` to resolve a relative URI and replaces this value.
+- `asset.thumbnail` - A draft glTF 2.1 thumbnail index is replaced by the corresponding processed image object.
 
 ### Materials
 

--- a/docs/modules/gltf/formats/gltf.md
+++ b/docs/modules/gltf/formats/gltf.md
@@ -38,6 +38,18 @@ rejects cyclical asset graphs.
 
 This support follows the Khronos [External Assets draft](https://github.com/KhronosGroup/glTF/issues/2586).
 
+## Draft glTF 2.1 Thumbnails
+
+Draft glTF 2.1 adds `asset.thumbnail`, an index into the top-level `images` array. The referenced
+image provides an optional preview that applications can display without rendering the scene.
+
+`GLTFLoader` treats the thumbnail as a referenced image, so `gltf.loadImages: true` loads it even
+when no texture uses that image. The unmodified index remains available at
+`gltf.json.asset.thumbnail`; [`postProcessGLTF()`](/docs/modules/gltf/api-reference/post-process-gltf)
+resolves it to the corresponding processed image object.
+
+This support follows the Khronos [Thumbnails draft](https://github.com/KhronosGroup/glTF/issues/2593).
+
 ## Variants
 
 A glTF file uses one of two possible file extensions: .gltf (JSON/ASCII) or .glb (binary). Both .gltf and .glb files may reference external binary and texture resources. Alternatively, both formats may be self-contained by directly embedding binary data buffers (as base64-encoded strings in .gltf files or as raw byte arrays in .glb files).

--- a/docs/modules/gltf/formats/gltf.md
+++ b/docs/modules/gltf/formats/gltf.md
@@ -18,11 +18,25 @@ array with `gltf.loadFiles: true`.
 For packaged assets, [`resolveGLTFFile()`](/docs/modules/gltf/api-reference/gltf-loader) also accepts
 a string reference. It looks up `files[*].name` or the original `files[*].uri`, providing the virtual
 file-system primitive needed to resolve dependencies from an embedded glTF asset. Recursive
-`externalAssets` parsing is intentionally separate from this file-resolution layer.
+`externalAssets` parsing builds on this file-resolution layer.
 
 This support follows the Khronos [Unified File References draft](https://github.com/KhronosGroup/glTF/issues/2590)
 and [Packaging External Assets draft](https://github.com/KhronosGroup/glTF/issues/2589), and may
 evolve while glTF 2.1 is finalized.
+
+## Draft glTF 2.1 External Assets
+
+The top-level `externalAssets` array references glTF files through `externalAssets[*].file`, and a
+scene node instantiates one of those models with `node.externalAsset`. Set
+`gltf.loadExternalAssets: true` to recursively parse referenced models into the parallel
+`gltf.externalAssets` result array.
+
+URI-backed models resolve their own dependencies relative to their URI. For models embedded in a
+data URI or buffer view, dependency URIs are looked up by name in the containing asset's `files`
+array. The loader caches repeated URI references, leaves unreferenced definitions unloaded, and
+rejects cyclical asset graphs.
+
+This support follows the Khronos [External Assets draft](https://github.com/KhronosGroup/glTF/issues/2586).
 
 ## Variants
 

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -27,6 +27,7 @@ Release Date: 2026
 - [`GLBLoader`](/docs/modules/gltf/api-reference/glb-loader) and [`GLTFLoader`](/docs/modules/gltf/api-reference/gltf-loader) add draft [GLB v3](/docs/modules/gltf/formats/glb) support for 64-bit lengths, multi-chunk traversal, reserved chunk-encoding validation, and explicit `buffer.chunk` references, advancing glTF 2.1 readiness.
 - [`GLTFLoader`](/docs/modules/gltf/api-reference/gltf-loader) adds draft [glTF 2.1 accessor component types](/docs/modules/gltf/formats/gltf#accessor-component-types), including signed 32-bit integers, 16- and 64-bit floats, and signed and unsigned 64-bit integers.
 - [`GLTFLoader`](/docs/modules/gltf/api-reference/gltf-loader) adds opt-in loading of draft glTF 2.1 [unified file references](/docs/modules/gltf/formats/gltf) from URIs or buffer views, plus virtual package lookup through `resolveGLTFFile()`.
+- [`GLTFLoader`](/docs/modules/gltf/api-reference/gltf-loader) can recursively load draft glTF 2.1 [external assets](/docs/modules/gltf/formats/gltf), including relative dependencies, embedded virtual packages, shared-reference caching, and cycle detection.
 
 **@loaders.gl/las** 
 

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -28,6 +28,7 @@ Release Date: 2026
 - [`GLTFLoader`](/docs/modules/gltf/api-reference/gltf-loader) adds draft [glTF 2.1 accessor component types](/docs/modules/gltf/formats/gltf#accessor-component-types), including signed 32-bit integers, 16- and 64-bit floats, and signed and unsigned 64-bit integers.
 - [`GLTFLoader`](/docs/modules/gltf/api-reference/gltf-loader) adds opt-in loading of draft glTF 2.1 [unified file references](/docs/modules/gltf/formats/gltf) from URIs or buffer views, plus virtual package lookup through `resolveGLTFFile()`.
 - [`GLTFLoader`](/docs/modules/gltf/api-reference/gltf-loader) can recursively load draft glTF 2.1 [external assets](/docs/modules/gltf/formats/gltf), including relative dependencies, embedded virtual packages, shared-reference caching, and cycle detection.
+- [`GLTFLoader`](/docs/modules/gltf/api-reference/gltf-loader) loads draft glTF 2.1 [thumbnail images](/docs/modules/gltf/formats/gltf#draft-gltf-21-thumbnails) referenced by `asset.thumbnail`, and [`postProcessGLTF()`](/docs/modules/gltf/api-reference/post-process-gltf) resolves the thumbnail index to the processed image.
 
 **@loaders.gl/las** 
 

--- a/modules/gltf/src/gltf-loader.ts
+++ b/modules/gltf/src/gltf-loader.ts
@@ -39,6 +39,7 @@ export const GLTFLoader = {
       normalize: true, // Normalize glTF v1 to glTF v2 format (not yet stable)
       loadBuffers: true, // Fetch any linked .BIN buffers, decode base64
       loadFiles: false, // Resolve generic glTF 2.1 file references on demand
+      loadExternalAssets: false, // Recursively parse glTF 2.1 external assets
       loadImages: true, // Create image objects
       decompressMeshes: true // Decompress Draco encoded meshes
     }

--- a/modules/gltf/src/index.ts
+++ b/modules/gltf/src/index.ts
@@ -17,6 +17,7 @@ export type {
   GLTFTexture,
   GLTFImage,
   GLTFFile,
+  GLTFExternalAsset,
   GLTFObject,
   // The following extensions are handled by the GLTFLoader and removed from the parsed glTF (disable via options.gltf.excludeExtensions)
   GLTF_KHR_binary_glTF,

--- a/modules/gltf/src/lib/api/post-process-gltf.ts
+++ b/modules/gltf/src/lib/api/post-process-gltf.ts
@@ -8,6 +8,7 @@ import type {ParseGLTFOptions} from '../parsers/parse-gltf';
 import type {
   GLTF,
   GLTFAccessor,
+  GLTFAsset,
   GLTFBufferView,
   GLTFCamera,
   GLTFImage,
@@ -22,6 +23,7 @@ import type {
 
 import type {
   GLTFPostprocessed,
+  Asset,
   GLTFAccessorPostprocessed,
   GLTFBufferPostprocessed,
   GLTFBufferViewPostprocessed,
@@ -162,6 +164,7 @@ class GLTFPostProcessor {
     if (gltf.images) {
       json.images = gltf.images.map((image, i) => this._resolveImage(image, i));
     }
+    json.asset = this._resolveAsset(gltf.asset);
     if (gltf.samplers) {
       json.samplers = gltf.samplers.map((sampler, i) => this._resolveSampler(sampler, i));
     }
@@ -255,6 +258,14 @@ class GLTFPostProcessor {
   }
 
   // PARSING HELPERS
+
+  /** Resolve the draft glTF 2.1 thumbnail image reference in asset metadata. */
+  _resolveAsset(gltfAsset: GLTFAsset): Asset {
+    return {
+      ...gltfAsset,
+      thumbnail: gltfAsset.thumbnail !== undefined ? this.getImage(gltfAsset.thumbnail) : undefined
+    };
+  }
 
   _resolveScene(scene: GLTFScene, index: number): GLTFScenePostprocessed {
     return {

--- a/modules/gltf/src/lib/parsers/parse-gltf.ts
+++ b/modules/gltf/src/lib/parsers/parse-gltf.ts
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase, max-statements, no-restricted-globals */
 import type {LoaderContext} from '@loaders.gl/loader-utils';
 import type {GLTFLoaderOptions} from '../../gltf-loader';
-import type {GLTFWithBuffers} from '../types/gltf-types';
+import type {GLTFExternalFile, GLTFWithBuffers} from '../types/gltf-types';
 import type {GLB} from '../types/glb-types';
 import type {ParseGLBOptions} from './parse-glb';
 
@@ -13,7 +13,7 @@ import {BasisLoader, selectSupportedBasisFormat} from '@loaders.gl/textures';
 import {assert} from '../utils/assert';
 import {isGLB, parseGLBSync} from './parse-glb';
 import {resolveUrl} from '../gltf-utils/resolve-url';
-import {resolveGLTFFile} from '../gltf-utils/resolve-gltf-file';
+import {findGLTFFileIndex, resolveGLTFFile} from '../gltf-utils/resolve-gltf-file';
 import {getTypedArrayForBufferView} from '../gltf-utils/get-typed-array';
 import {preprocessExtensions, decodeExtensions} from '../api/gltf-extensions';
 import {normalizeGLTFV1} from '../api/normalize-gltf-v1';
@@ -25,6 +25,8 @@ export type ParseGLTFOptions = ParseGLBOptions & {
   loadBuffers?: boolean;
   /** Resolve draft glTF 2.1 `files` entries. */
   loadFiles?: boolean;
+  /** Recursively parse draft glTF 2.1 external assets referenced by nodes. */
+  loadExternalAssets?: boolean;
   decompressMeshes?: boolean;
   excludeExtensions?: string[];
   /** @deprecated not supported in v4. `postProcessGLTF()` must be called by the application */
@@ -71,6 +73,18 @@ export async function parseGLTF(
   options: GLTFLoaderOptions,
   context: LoaderContext
 ): Promise<GLTFWithBuffers> {
+  return await parseGLTFWithExternalAssets(gltf, arrayBufferOrString, byteOffset, options, context);
+}
+
+/** Parse glTF data while carrying recursion state through nested external assets. */
+async function parseGLTFWithExternalAssets(
+  gltf: GLTFWithBuffers,
+  arrayBufferOrString,
+  byteOffset: number,
+  options: GLTFLoaderOptions,
+  context: LoaderContext,
+  externalAssetLoadState?: ExternalAssetLoadState
+): Promise<GLTFWithBuffers> {
   parseGLTFContainerSync(gltf, arrayBufferOrString, byteOffset, options);
 
   normalizeGLTFV1(gltf, {normalize: options?.gltf?.normalize});
@@ -84,6 +98,10 @@ export async function parseGLTF(
 
   if (options?.gltf?.loadFiles && gltf.json.files) {
     await loadFiles(gltf, options, context);
+  }
+
+  if (options?.gltf?.loadExternalAssets && gltf.json.externalAssets) {
+    await loadExternalAssets(gltf, options, context, externalAssetLoadState);
   }
 
   // loadImages and decodeExtensions should not be running in parallel, because
@@ -207,6 +225,161 @@ function parseGLTFContainerSync(gltf, data, byteOffset, options: GLTFLoaderOptio
 
   const files = gltf.json.files || [];
   gltf.files = new Array(files.length).fill(null);
+
+  const externalAssets = gltf.json.externalAssets || [];
+  gltf.externalAssets = new Array(externalAssets.length).fill(null);
+}
+
+type ExternalAssetLoadState = {
+  /** Parsed assets keyed by their resolved URI. */
+  cache: Map<string, Promise<GLTFWithBuffers>>;
+  /** Resolved URIs in the current recursion chain. */
+  ancestors: Set<string>;
+  /** Shared counter used to isolate virtual package URL namespaces. */
+  packageIds: {next: number};
+};
+
+const PACKAGE_URL_PREFIX = 'gltf-package:';
+
+/** Recursively resolve external assets instantiated by nodes. */
+async function loadExternalAssets(
+  gltf: GLTFWithBuffers,
+  options: GLTFLoaderOptions,
+  context: LoaderContext,
+  inheritedState?: ExternalAssetLoadState
+): Promise<void> {
+  const externalAssets = gltf.json.externalAssets || [];
+  const referencedIndices = new Set<number>();
+  for (const node of gltf.json.nodes || []) {
+    if (node.externalAsset !== undefined) {
+      assert(
+        node.externalAsset >= 0 && node.externalAsset < externalAssets.length,
+        `glTF node references missing external asset ${node.externalAsset}.`
+      );
+      referencedIndices.add(node.externalAsset);
+    }
+  }
+
+  const state =
+    inheritedState ||
+    createExternalAssetLoadState(context.url ? new Set([context.url]) : new Set());
+  for (const externalAssetIndex of referencedIndices) {
+    await loadExternalAsset(gltf, externalAssetIndex, options, context, state);
+  }
+}
+
+/** Parse one external asset and cache repeated file references. */
+async function loadExternalAsset(
+  gltf: GLTFWithBuffers,
+  externalAssetIndex: number,
+  options: GLTFLoaderOptions,
+  context: LoaderContext,
+  state: ExternalAssetLoadState
+): Promise<void> {
+  const externalAsset = gltf.json.externalAssets?.[externalAssetIndex];
+  if (!externalAsset) {
+    throw new Error(`Missing glTF external asset ${externalAssetIndex}.`);
+  }
+  assert(
+    Number.isInteger(externalAsset.file) &&
+      externalAsset.file >= 0 &&
+      externalAsset.file < (gltf.json.files?.length || 0),
+    `glTF external asset ${externalAssetIndex} references missing file ${externalAsset.file}.`
+  );
+
+  const file = await resolveGLTFFile(gltf, externalAsset.file, options, context);
+  const assetKey = file.url;
+  assert(
+    !assetKey || !state.ancestors.has(assetKey),
+    `glTF external asset cycle detected at ${assetKey}.`
+  );
+
+  let parsedAsset = assetKey ? state.cache.get(assetKey) : undefined;
+  if (!parsedAsset) {
+    const childContext = createExternalAssetContext(gltf, file, options, context, state);
+    const childState: ExternalAssetLoadState = {
+      ...state,
+      ancestors: new Set(state.ancestors)
+    };
+    if (assetKey) {
+      childState.ancestors.add(assetKey);
+    }
+    const data = sliceArrayBuffer(file.arrayBuffer, file.byteOffset, file.byteLength);
+    parsedAsset = parseGLTFWithExternalAssets(
+      {} as GLTFWithBuffers,
+      data,
+      0,
+      options,
+      childContext,
+      childState
+    );
+    if (assetKey) {
+      state.cache.set(assetKey, parsedAsset);
+    }
+  }
+
+  gltf.externalAssets = gltf.externalAssets || [];
+  gltf.externalAssets[externalAssetIndex] = await parsedAsset;
+}
+
+/** Create recursive loading state for an external-asset tree. */
+function createExternalAssetLoadState(ancestors: Set<string>): ExternalAssetLoadState {
+  return {cache: new Map(), ancestors, packageIds: {next: 0}};
+}
+
+/** Create URL and fetch semantics for a nested external asset. */
+function createExternalAssetContext(
+  parent: GLTFWithBuffers,
+  file: GLTFExternalFile,
+  options: GLTFLoaderOptions,
+  context: LoaderContext,
+  state: ExternalAssetLoadState
+): LoaderContext {
+  if (file.url && !file.url.startsWith('data:')) {
+    return {
+      ...context,
+      url: file.url,
+      filename: getUrlFilename(file.url),
+      baseUrl: getUrlBase(file.url)
+    };
+  }
+
+  const packageBaseUrl = `${PACKAGE_URL_PREFIX}${state.packageIds.next++}`;
+  const packageUrlPrefix = `${packageBaseUrl}/`;
+  return {
+    ...context,
+    url: file.name,
+    filename: file.name,
+    baseUrl: packageBaseUrl,
+    fetch: async (resource: string, init?: RequestInit) => {
+      const url = resource;
+      if (url.startsWith('data:')) {
+        return await context.fetch(resource, init);
+      }
+      const reference = url.startsWith(packageUrlPrefix) ? url.slice(packageUrlPrefix.length) : url;
+      const fileIndex = findGLTFFileIndex(parent, reference);
+      assert(fileIndex >= 0, `glTF package does not contain file ${reference}.`);
+      const resolvedFile = await resolveGLTFFile(parent, fileIndex, options, context);
+      const data = sliceArrayBuffer(
+        resolvedFile.arrayBuffer,
+        resolvedFile.byteOffset,
+        resolvedFile.byteLength
+      );
+      return new Response(data, {headers: {'content-type': resolvedFile.mimeType}});
+    }
+  };
+}
+
+/** Return the containing directory for a URL. */
+function getUrlBase(url: string): string {
+  const slashIndex = url.lastIndexOf('/');
+  return slashIndex >= 0 ? url.slice(0, slashIndex) : '';
+}
+
+/** Return the file name component for a URL. */
+function getUrlFilename(url: string): string {
+  const slashIndex = url.lastIndexOf('/');
+  return slashIndex >= 0 ? url.slice(slashIndex + 1) : url;
 }
 
 /** Resolve all draft glTF 2.1 unified file references. */

--- a/modules/gltf/src/lib/parsers/parse-gltf.ts
+++ b/modules/gltf/src/lib/parsers/parse-gltf.ts
@@ -448,9 +448,13 @@ async function loadImages(gltf: GLTFWithBuffers, options, context: LoaderContext
   return await Promise.all(promises);
 }
 
-/** Make sure we only load images that are actually referenced by textures */
+/** Return image indices referenced by textures or draft glTF 2.1 asset metadata. */
 function getReferencesImageIndices(gltf: GLTFWithBuffers): number[] {
   const imageIndices = new Set<number>();
+
+  if (gltf.json.asset.thumbnail !== undefined) {
+    imageIndices.add(gltf.json.asset.thumbnail);
+  }
 
   const textures = gltf.json.textures || [];
   for (const texture of textures) {

--- a/modules/gltf/src/lib/types/gltf-json-schema.ts
+++ b/modules/gltf/src/lib/types/gltf-json-schema.ts
@@ -382,6 +382,18 @@ export type GLTFFile = {
 };
 
 /**
+ * A draft glTF 2.1 model dependency sourced from the top-level `files` array.
+ */
+export type GLTFExternalAsset = {
+  /** Index of the file containing the external glTF asset. */
+  file: GLTFId;
+  /** Optional application-facing name for this external asset. */
+  name?: string;
+  extensions?: Record<string, any>;
+  extras?: any;
+};
+
+/**
  * Reference to a texture.
  */
 export type GLTFTextureInfo = {
@@ -586,6 +598,8 @@ export type GLTFNode = {
    * The index of the mesh in this node.
    */
   mesh?: GLTFId;
+  /** Index of the draft glTF 2.1 external asset instantiated by this node. */
+  externalAsset?: GLTFId;
   /**
    * The node's unit quaternion rotation in the order (x, y, z, w), where w is the scalar.
    */
@@ -728,6 +742,10 @@ export type GLTF = {
    */
   files?: GLTFFile[];
   /**
+   * Draft glTF 2.1 external glTF assets.
+   */
+  externalAssets?: GLTFExternalAsset[];
+  /**
    * An array of materials.
    */
   materials?: GLTFMaterial[];
@@ -777,7 +795,8 @@ export type GLTFObject =
   | GLTFSkin
   | GLTFTexture
   | GLTFImage
-  | GLTFFile;
+  | GLTFFile
+  | GLTFExternalAsset;
 
 // GLTF Extensions
 /* eslint-disable camelcase */

--- a/modules/gltf/src/lib/types/gltf-json-schema.ts
+++ b/modules/gltf/src/lib/types/gltf-json-schema.ts
@@ -213,6 +213,11 @@ export type GLTFAsset = {
    * The minimum glTF version that this asset targets.
    */
   minVersion?: string;
+  /**
+   * The index of an image that provides a preview of this glTF asset.
+   * Draft glTF 2.1.
+   */
+  thumbnail?: GLTFId;
   extensions?: Record<string, any>;
   extras?: any;
   // [k: string]: any;

--- a/modules/gltf/src/lib/types/gltf-postprocessed-schema.ts
+++ b/modules/gltf/src/lib/types/gltf-postprocessed-schema.ts
@@ -242,6 +242,11 @@ export type Asset = {
    * The minimum glTF version that this asset targets.
    */
   minVersion?: string;
+  /**
+   * The image that provides a preview of this glTF asset.
+   * Draft glTF 2.1.
+   */
+  thumbnail?: GLTFImagePostprocessed;
   extensions?: any;
   extras?: any;
   // [k: string]: any;

--- a/modules/gltf/src/lib/types/gltf-postprocessed-schema.ts
+++ b/modules/gltf/src/lib/types/gltf-postprocessed-schema.ts
@@ -629,6 +629,8 @@ export type GLTFNodePostprocessed = {
    * The index of the mesh in this node.
    */
   mesh?: GLTFMeshPostprocessed;
+  /** Index of the draft glTF 2.1 external asset instantiated by this node. */
+  externalAsset?: GlTfId;
   /**
    * The node's unit quaternion rotation in the order (x, y, z, w), where w is the scalar.
    */

--- a/modules/gltf/src/lib/types/gltf-types.ts
+++ b/modules/gltf/src/lib/types/gltf-types.ts
@@ -13,6 +13,8 @@ export type GLTFWithBuffers = {
   images?: GLTFExternalImage[];
   /** Resolved draft glTF 2.1 unified file references, parallel to `json.files`. */
   files?: GLTFExternalFile[];
+  /** Parsed draft glTF 2.1 external assets, parallel to `json.externalAssets`. */
+  externalAssets?: Array<GLTFWithBuffers | null>;
 };
 
 export type GLTFExternalBuffer = {
@@ -61,6 +63,7 @@ export type {
   GLTFTexture,
   GLTFImage,
   GLTFFile,
+  GLTFExternalAsset,
   GLTF_KHR_binary_glTF,
   GLTF_KHR_draco_mesh_compression,
   GLTF_KHR_texture_basisu,

--- a/modules/gltf/src/lib/types/gltf-zod-schema.ts
+++ b/modules/gltf/src/lib/types/gltf-zod-schema.ts
@@ -112,6 +112,7 @@ export const GLTFAssetSchema = z
     generator: z.string().optional(),
     version: z.string(),
     minVersion: z.string().optional(),
+    thumbnail: GLTFIdSchema.optional(),
     ...GLTF_PROPERTY_SHAPE
   })
   .catchall(z.unknown());

--- a/modules/gltf/test/gltf-loader.spec.ts
+++ b/modules/gltf/test/gltf-loader.spec.ts
@@ -11,6 +11,8 @@ import {createGLBV3} from './test-utils/create-glb-v3';
 
 const GLTF_BINARY_URL = '@loaders.gl/gltf/test/data/gltf-2.0/2CylinderEngine.glb';
 const GLTF_JSON_URL = '@loaders.gl/gltf/test/data/gltf-2.0/2CylinderEngine.gltf';
+const PNG_DATA_URL =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACAQMAAABIeJ9nAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAGUExURf///wAAAFXC034AAAAMSURBVAjXY3BgaAAAAUQAwetZAwkAAAAASUVORK5CYII=';
 
 // Extracted from Cesium 3D Tiles
 const GLB_TILE_WITH_DRACO_URL = '@loaders.gl/gltf/test/data/3d-tiles/143.glb';
@@ -35,6 +37,19 @@ test('GLTFLoader#load(binary)', async t => {
   const data = await load(GLTF_BINARY_URL, GLTFLoader);
   t.ok(data.json.asset, 'GLTFLoader returned parsed data');
 
+  t.end();
+});
+
+test('GLTFLoader#parse() loads a draft glTF 2.1 thumbnail image', async t => {
+  const gltf = await parse(
+    JSON.stringify({
+      asset: {version: '2.1', thumbnail: 0},
+      images: [{uri: PNG_DATA_URL}]
+    }),
+    GLTFLoader
+  );
+
+  t.ok(gltf.images?.[0], 'loads an image referenced only by asset.thumbnail');
   t.end();
 });
 

--- a/modules/gltf/test/gltf-zod-schema.spec.ts
+++ b/modules/gltf/test/gltf-zod-schema.spec.ts
@@ -22,6 +22,17 @@ describe('GLTFSchema', () => {
     expect(GLTFSchema.safeParse({asset: {version: '2.0'}, scene: -1}).success).toBe(false);
   });
 
+  it('validates draft glTF 2.1 thumbnail references', () => {
+    expect(
+      GLTFSchema.safeParse({
+        asset: {version: '2.1', thumbnail: 0},
+        images: [{uri: 'thumbnail.png'}]
+      }).success
+    ).toBe(true);
+    expect(GLTFSchema.safeParse({asset: {version: '2.1', thumbnail: -1}}).success).toBe(false);
+    expect(GLTFSchema.safeParse({asset: {version: '2.1', thumbnail: 0.5}}).success).toBe(false);
+  });
+
   it('accepts extension-defined animation target paths', () => {
     const document = {
       asset: {version: '2.0'},

--- a/modules/gltf/test/index.ts
+++ b/modules/gltf/test/index.ts
@@ -8,6 +8,7 @@ import './lib/gltf-utils/gltf-attribute-utils.spec';
 import './lib/gltf-utils/gltf-accessor-component-types.spec';
 import './lib/gltf-utils/resolve-url.spec';
 import './lib/gltf-utils/resolve-gltf-file.spec';
+import './lib/gltf-utils/external-assets.spec';
 
 import './lib/api/gltf-scenegraph-modifiers.spec';
 import './lib/api/gltf-scenegraph-accessors.spec';

--- a/modules/gltf/test/lib/api/post-process-gltf.spec.ts
+++ b/modules/gltf/test/lib/api/post-process-gltf.spec.ts
@@ -52,3 +52,18 @@ test('gltf#postProcessGLTF', t => {
   }
   t.end();
 });
+
+test('gltf#postProcessGLTF resolves a draft glTF 2.1 thumbnail', t => {
+  const json = postProcessGLTF({
+    json: {
+      asset: {version: '2.1', thumbnail: 0},
+      images: [{uri: 'thumbnail.png'}]
+    },
+    buffers: [],
+    images: [{width: 2, height: 2}]
+  } as unknown as GLTFWithBuffers);
+
+  t.equal(json.asset.thumbnail, json.images[0], 'resolves the thumbnail to the processed image');
+  t.equal(json.asset.thumbnail?.image.width, 2, 'preserves the decoded thumbnail image');
+  t.end();
+});

--- a/modules/gltf/test/lib/gltf-utils/external-assets.spec.ts
+++ b/modules/gltf/test/lib/gltf-utils/external-assets.spec.ts
@@ -1,0 +1,120 @@
+import test from 'tape-promise/tape';
+import {parse} from '@loaders.gl/core';
+import {GLTFLoader} from '@loaders.gl/gltf';
+import {createGLBV3} from '../../test-utils/create-glb-v3';
+
+test('GLTFLoader#loads URI external assets and their relative dependencies', async t => {
+  const fetchedUrls: string[] = [];
+  const child = {
+    asset: {version: '2.1'},
+    buffers: [{byteLength: 4, uri: 'child.bin'}]
+  };
+  const root = {
+    asset: {version: '2.1'},
+    files: [{mimeType: 'model/gltf+json', uri: 'child/child.gltf'}],
+    externalAssets: [
+      {name: 'child-a', file: 0},
+      {name: 'child-b', file: 0}
+    ],
+    nodes: [{externalAsset: 0}, {externalAsset: 1}]
+  };
+
+  const gltf = await parse(new TextEncoder().encode(JSON.stringify(root)), GLTFLoader, {
+    core: {
+      baseUrl: 'https://example.com/models/root.gltf',
+      fetch: async url => {
+        fetchedUrls.push(url);
+        if (url.endsWith('child.gltf')) {
+          return new Response(JSON.stringify(child));
+        }
+        if (url.endsWith('child.bin')) {
+          return new Response(new Uint8Array([1, 2, 3, 4]));
+        }
+        throw new Error(`Unexpected URL ${url}`);
+      }
+    },
+    gltf: {loadExternalAssets: true, loadImages: false}
+  });
+
+  const childAsset = gltf.externalAssets?.[0];
+  t.ok(childAsset, 'parses the referenced child asset');
+  t.equal(gltf.externalAssets?.[1], childAsset, 'caches repeated references to the same file');
+  t.deepEqual(
+    fetchedUrls,
+    ['https://example.com/models/child/child.gltf', 'https://example.com/models/child/child.bin'],
+    'resolves child dependencies relative to the child asset URI'
+  );
+  t.deepEqual(
+    Array.from(new Uint8Array(childAsset!.buffers[0].arrayBuffer)),
+    [1, 2, 3, 4],
+    'loads the child buffer'
+  );
+  t.end();
+});
+
+test('GLTFLoader#resolves embedded external asset dependencies from the package', async t => {
+  const child = new TextEncoder().encode(
+    JSON.stringify({
+      asset: {version: '2.1'},
+      buffers: [{byteLength: 4, uri: 'child.bin'}]
+    })
+  );
+  const childBuffer = new Uint8Array([5, 6, 7, 8]);
+  const binary = new Uint8Array(child.byteLength + childBuffer.byteLength);
+  binary.set(child);
+  binary.set(childBuffer, child.byteLength);
+
+  const data = createGLBV3(
+    {
+      asset: {version: '2.1'},
+      buffers: [{byteLength: binary.byteLength}],
+      bufferViews: [
+        {buffer: 0, byteOffset: 0, byteLength: child.byteLength},
+        {buffer: 0, byteOffset: child.byteLength, byteLength: childBuffer.byteLength}
+      ],
+      files: [
+        {name: 'child.gltf', mimeType: 'model/gltf+json', bufferView: 0},
+        {name: 'child.bin', mimeType: 'application/octet-stream', bufferView: 1}
+      ],
+      externalAssets: [{file: 0}],
+      nodes: [{externalAsset: 0}]
+    },
+    [binary]
+  );
+
+  const gltf = await parse(data, GLTFLoader, {
+    gltf: {loadBuffers: true, loadExternalAssets: true, loadImages: false}
+  });
+  const childAsset = gltf.externalAssets?.[0];
+
+  t.ok(childAsset, 'parses the child JSON from its buffer view');
+  t.deepEqual(
+    Array.from(new Uint8Array(childAsset!.buffers[0].arrayBuffer)),
+    [5, 6, 7, 8],
+    'resolves the child URI through the containing files array'
+  );
+  t.ok(gltf.files?.[1], 'caches the package dependency in the parent files array');
+  t.end();
+});
+
+test('GLTFLoader#rejects cyclical external assets', async t => {
+  const recursiveAsset = JSON.stringify({
+    asset: {version: '2.1'},
+    files: [{mimeType: 'model/gltf+json', uri: 'child.gltf'}],
+    externalAssets: [{file: 0}],
+    nodes: [{externalAsset: 0}]
+  });
+
+  await t.rejects(
+    parse(new TextEncoder().encode(recursiveAsset), GLTFLoader, {
+      core: {
+        baseUrl: 'https://example.com/root.gltf',
+        fetch: async () => new Response(recursiveAsset)
+      },
+      gltf: {loadExternalAssets: true, loadImages: false}
+    }),
+    /external asset cycle detected at https:\/\/example.com\/child.gltf/,
+    'rejects recursive references before awaiting the cached parse'
+  );
+  t.end();
+});


### PR DESCRIPTION
## Goals

- Complete the next glTF 2.1 external-assets tranche on top of #3507.
- Recursively load glTF models referenced through `externalAssets` while preserving each child as a separate glTF object.
- Support both ordinary URI hierarchies and self-contained virtual packages.

## Changes

- Add public `GLTFExternalAsset`, `GLTF.externalAssets`, and `GLTFNode.externalAsset` schema types.
- Add opt-in `gltf.loadExternalAssets` handling for external assets instantiated by scene nodes.
- Store parsed children in a parallel `gltf.externalAssets` array while leaving unreferenced definitions unloaded.
- Resolve URI-backed child dependencies relative to the child model URL.
- Resolve dependencies of buffer-view and data-URI children through the containing asset's `files` array.
- Cache repeated URI references and reject cyclical external-asset graphs.
- Add shared Node/browser tests for relative dependencies, embedded virtual packages, caching, and cycle detection.
- Document the loader option, returned data, format behavior, and v5 release note.

This is a stacked PR based on `codex/gltf-21-files` / #3507. It should be retargeted to `master` after #3507 merges.

## Validation

- `yarn build`
- `yarn test-node` — 1,655 passed, 75 skipped
- `yarn test-headless` — 1,651 passed, 60 skipped
- `yarn vitest run --project node modules/gltf/test` — 75 passed
- `yarn lint fix`