### PR TITLE
feat(3d-tiles): prioritize progressive and foveated requests

### DIFF
--- a/docs/docs-sidebar.json
+++ b/docs/docs-sidebar.json
@@ -260,7 +260,18 @@
         "label": "@loaders.gl/3d-tiles",
         "items": [
           "modules/3d-tiles/README",
-          "modules/3d-tiles/concepts/screen-space-error-and-lod"
+          {
+            "type": "category",
+            "label": "Runtime Concepts",
+            "items": [
+              "modules/3d-tiles/concepts/README",
+              "modules/3d-tiles/concepts/tile-hierarchy-and-refinement",
+              "modules/3d-tiles/concepts/screen-space-error-and-lod",
+              "modules/3d-tiles/concepts/request-scheduling-and-priorities",
+              "modules/3d-tiles/concepts/caching-and-memory",
+              "modules/3d-tiles/concepts/runtime-tuning-and-diagnostics"
+            ]
+          }
         ]
       },
       {

--- a/docs/modules/3d-tiles/README.md
+++ b/docs/modules/3d-tiles/README.md
@@ -30,7 +30,13 @@ To handle the complex dynamic tile selection and loading required to performantl
 - [`Tileset3D`](/docs/modules/tiles/api-reference/tileset-3d) to work with the loaded tileset.
 - [`Tile3D`](/docs/modules/tiles/api-reference/tile-3d) to access data for a specific tile.
 
-See [Screen-space error and level of detail](/docs/modules/3d-tiles/concepts/screen-space-error-and-lod) for a detailed explanation of how `Tileset3D` selects tiles in perspective and orthographic views.
+The [3D Tiles runtime concepts suite](/docs/modules/3d-tiles/concepts) explains the complete path from hierarchy traversal to rendering:
+
+- [Tile hierarchy and refinement](/docs/modules/3d-tiles/concepts/tile-hierarchy-and-refinement)
+- [Screen-space error and level of detail](/docs/modules/3d-tiles/concepts/screen-space-error-and-lod)
+- [Request scheduling, progressive loading, and foveated requests](/docs/modules/3d-tiles/concepts/request-scheduling-and-priorities)
+- [Caching and memory](/docs/modules/3d-tiles/concepts/caching-and-memory)
+- [Runtime tuning and diagnostics](/docs/modules/3d-tiles/concepts/runtime-tuning-and-diagnostics)
 
 ## Usage
 

--- a/docs/modules/3d-tiles/concepts/README.md
+++ b/docs/modules/3d-tiles/concepts/README.md
@@ -1,0 +1,15 @@
+# 3D Tiles Runtime Concepts
+
+Loading a large 3D Tiles tileset is a continuous pipeline: traverse the hierarchy, decide which level of detail is needed, rank missing content, load within concurrency limits, render safe coverage, and retain useful content in the cache. These pages document each stage and the options that connect them.
+
+| Guide | Question it answers |
+| --- | --- |
+| [Tile hierarchy and refinement](/docs/modules/3d-tiles/concepts/tile-hierarchy-and-refinement) | Which tiles can replace or augment their ancestors? |
+| [Screen-space error and LOD](/docs/modules/3d-tiles/concepts/screen-space-error-and-lod) | How much detail does the current view require? |
+| [Request scheduling and priorities](/docs/modules/3d-tiles/concepts/request-scheduling-and-priorities) | Which required tile should use the next network slot? |
+| [Caching and memory](/docs/modules/3d-tiles/concepts/caching-and-memory) | Which loaded tiles remain resident, and when may the budget be exceeded? |
+| [Runtime tuning and diagnostics](/docs/modules/3d-tiles/concepts/runtime-tuning-and-diagnostics) | Which controls and measurements explain visible behavior? |
+
+The stages are related but not interchangeable. In particular, screen-space error determines the desired final LOD. Progressive and foveated scheduling normally change only the order and timing of requests needed to reach that LOD.
+
+Start with [tile hierarchy and refinement](/docs/modules/3d-tiles/concepts/tile-hierarchy-and-refinement), or go directly to the [request-scheduling guide](/docs/modules/3d-tiles/concepts/request-scheduling-and-priorities) for foveated requests.

--- a/docs/modules/3d-tiles/concepts/caching-and-memory.md
+++ b/docs/modules/3d-tiles/concepts/caching-and-memory.md
@@ -1,0 +1,39 @@
+# Caching and Memory
+
+`Tileset3D` caches loaded content so camera movement can reuse tiles without immediately fetching and decoding them again. The cache cooperates with traversal: tiles touched in the current frame are protected, while unused least-recently-used content becomes eligible for eviction.
+
+Concepts: [overview](/docs/modules/3d-tiles/concepts) · [hierarchy](./tile-hierarchy-and-refinement) · [SSE and LOD](./screen-space-error-and-lod) · [request scheduling](./request-scheduling-and-priorities) · [diagnostics](./runtime-tuning-and-diagnostics)
+
+## The Memory Limit Is Soft
+
+`maximumMemoryUsage` defaults to `32` MB and limits estimated GPU memory retained by the tileset cache. Geometry, textures, batch-table textures, and point metadata contribute to the estimate.
+
+The limit is intentionally soft. Tiles selected or otherwise used in the current frame are not evicted merely to satisfy the budget. If the current view needs 50 MB to meet its SSE target and the limit is 32 MB, usage can reach 50 MB; those tiles become evictable after they leave the working set. This favors complete, hole-free rendering over a hard cap.
+
+`memoryCacheOverflow` defaults to `1` MB and provides hysteresis for memory-adjusted SSE behavior.
+
+## Recency and Frame Protection
+
+At the start of a frame, the cache records a boundary in its least-recently-used list. Traversal touches selected, requested, and otherwise required tiles. Entries used after the boundary are protected for that frame. Eviction walks older entries until the memory target is met or no safe candidates remain.
+
+Loading a tile adds it to the cache and updates `gpuMemoryUsageInBytes`. Unloading calls `onTileUnload`, releases tile content, and updates the memory statistics.
+
+## Memory-Adjusted SSE
+
+When `memoryAdjustedScreenSpaceError` is enabled, memory pressure can raise the active SSE threshold gradually, reducing refinement demand. Usage below the cache target moves the threshold back toward `maximumScreenSpaceError`; usage beyond the target plus overflow raises it. The adjustment is incremental, so it avoids abrupt LOD swings.
+
+This option changes the effective quality target and is distinct from progressive or foveated scheduling, which normally change request order only.
+
+## Request Concurrency Is Not Cache Size
+
+`maxRequests` limits simultaneous scheduled fetches when `throttleRequests` is enabled. Raising it may fill the cache faster and increase decode pressure, but it does not increase the memory limit. Lowering it changes latency and ordering visibility, but already loaded tiles remain governed by the cache.
+
+## Practical Guidance
+
+- Choose final visual quality with `maximumScreenSpaceError` first.
+- Size `maximumMemoryUsage` for the expected visible working set plus useful reuse.
+- Watch `gpuMemoryUsageInBytes` and the tileset stats rather than treating the configured limit as a hard guarantee.
+- Reduce request concurrency when network or decode contention hurts interaction.
+- Enable memory-adjusted SSE only when graceful quality reduction is preferable to exceeding the working budget.
+
+Next: [Runtime tuning and diagnostics](./runtime-tuning-and-diagnostics).

--- a/docs/modules/3d-tiles/concepts/request-scheduling-and-priorities.md
+++ b/docs/modules/3d-tiles/concepts/request-scheduling-and-priorities.md
@@ -1,0 +1,95 @@
+# Request Scheduling and Priorities
+
+A **foveated request** is an ordinary tile content request whose start time is influenced by its position in the view. It is not a new HTTP method, endpoint, file format, or server feature. The term describes client-side prioritization inspired by human vision: central detail is usually more noticeable than peripheral detail while a camera is moving.
+
+Concepts: [overview](/docs/modules/3d-tiles/concepts) · [hierarchy](./tile-hierarchy-and-refinement) · [SSE and LOD](./screen-space-error-and-lod) · [cache and memory](./caching-and-memory) · [diagnostics](./runtime-tuning-and-diagnostics)
+
+## Selection Versus Scheduling
+
+[Screen-space error](./screen-space-error-and-lod) determines which hierarchy levels the view ultimately needs. Scheduling answers a later question: when more needed tiles exist than available request slots, which one starts first?
+
+The normal sequence is:
+
+```text
+visible hierarchy -> desired LOD -> missing request candidates
+                  -> priority order -> RequestScheduler -> fetch/decode -> ready tile
+```
+
+Progressive and foveated measurements do not loosen the final `maximumScreenSpaceError` target. They improve perceived responsiveness on the way to that target. The same ordinary URLs and loader options are used when requests start.
+
+## Progressive Coarse Coverage
+
+`progressiveResolutionHeightFraction` calculates SSE at a reduced logical viewport height:
+
+```text
+progressiveProjection = fullHeightProjection * progressiveResolutionHeightFraction
+progressiveSSE = progressiveProjection - dynamicSSEReduction
+```
+
+When dynamic SSE is disabled—the default for the progressive calculation's orthographic case—the reduction is zero and this simplifies to `progressiveSSE = normalSSE * fraction`. When perspective dynamic SSE is enabled, loaders.gl scales the projection term first and then applies the same view-dependent logical-pixel reduction used by normal traversal. Dynamic SSE therefore retains its established behavior instead of being scaled a second time.
+
+The default fraction is `0.3`. Tiles still too coarse at that reduced height receive an earlier priority band. The first child crossing below the threshold is promoted too, so the initial pass ends on a real coarse-LOD boundary. This tends to fill the viewport with usable coverage before fine detail consumes every request slot.
+
+Set the fraction to `0` to disable progressive priority. Values greater than `0.5` are ignored because they no longer represent a meaningfully reduced pass. The calculation uses logical pixels in perspective and orthographic views.
+
+## Foveated Center Priority
+
+With `foveatedScreenSpaceError: true`, perspective requests near the camera view axis rank before equally needed peripheral requests. loaders.gl measures the nearest point of the complete tile bounding sphere to the view axis. A large tile that intersects the axis therefore counts as central even when its center does not.
+
+`foveatedConeSize` is the fraction of the vertical field of view that receives no peripheral relaxation. It defaults to `0.1`; a larger value makes more of the view central, while `1` disables peripheral deferral. A missing or invalid field of view uses the established 60-degree fallback.
+
+Outside the cone, `foveatedMinimumScreenSpaceErrorRelaxation` and `foveatedInterpolationCallback` describe a logical-pixel relaxation that grows toward the viewport edge. This value decides whether a peripheral request is eligible to wait; it is not subtracted from the tile's final refinement SSE. The callback receives minimum relaxation, maximum relaxation, and a normalized `[0, 1]` position, and returns logical pixels. Non-finite results safely fall back to zero relaxation.
+
+Angular foveation is disabled for orthographic viewports because parallel projection has no perspective view axis convergence. Progressive and reverse-SSE ordering remain active there.
+
+## Camera Motion and Deferral
+
+`Tileset3D` retains camera position and direction separately for each viewport. When either changes beyond a small numeric tolerance, eligible peripheral requests may wait up to `foveatedTimeDelay` seconds (`0.2` by default). Continuing motion pushes the retry window forward. A single follow-up traversal is scheduled when the window expires, so requests recover even if the application supplies no further camera event.
+
+The first observed camera pose is treated as stationary; initial tileset loading is not delayed.
+
+Deferral preserves refinement safety:
+
+- `ADD` descendants may wait because the ancestor remains rendered.
+- Skip-LOD `REPLACE` descendants may wait when an available ancestor supplies coverage.
+- Progressive tiles needed for broad initial coverage do not wait.
+- Traditional `REPLACE` children never wait because all required children must be ready before the parent disappears.
+
+Traditional replacement children are still ordered center-first; only the temporary pause is disabled.
+
+## Complete Priority Order
+
+Smaller numeric priorities start first. Independent priority bands produce this lexicographic order:
+
+1. Eligible now before motion-deferred work.
+2. Progressive coarse coverage before fine detail.
+3. Center content before peripheral content.
+4. Established reverse-SSE order as the tie-breaker.
+
+Each measurement is normalized into its own numeric band, preventing an extreme SSE or angle from overpowering a stronger invariant.
+
+## Options
+
+| `Tileset3D` option | Default | Effect |
+| --- | ---: | --- |
+| `maxRequests` | `64` | Maximum simultaneous requests when throttling is enabled. |
+| `progressiveResolutionHeightFraction` | `0.3` | Reduced-height coarse coverage; `0` disables it. |
+| `foveatedScreenSpaceError` | `true` | Enables perspective center-first ranking and eligible deferral. |
+| `foveatedConeSize` | `0.1` | Unrelaxed center fraction of the perspective field of view. |
+| `foveatedMinimumScreenSpaceErrorRelaxation` | `0` | Logical-pixel relaxation at the cone edge. |
+| `foveatedInterpolationCallback` | linear | Shapes relaxation from center cone to viewport edge. |
+| `foveatedTimeDelay` | `0.2` | Maximum stationary wait after motion, in seconds. |
+
+## Example
+
+Suppose a pan reveals a coarse central building tile, a coarse edge tile, and fine descendants for both. Progressive priority first favors the two coarse coverage tiles. Within that band, the central tile starts first. During continued motion, safe peripheral fine descendants can wait. About `0.2` seconds after movement settles, a scheduled traversal makes them eligible, and normal loading converges on the same final SSE target.
+
+## What Foveation Does Not Do
+
+- It does not change URLs, request headers, authentication, range requests, or server behavior.
+- It does not permanently omit peripheral content.
+- It does not change the tileset's geometric errors.
+- It does not replace cache eviction or request concurrency controls.
+- It does not make culled or unavailable tiles loadable.
+
+For symptoms and tuning sequences, see [Runtime tuning and diagnostics](./runtime-tuning-and-diagnostics).

--- a/docs/modules/3d-tiles/concepts/runtime-tuning-and-diagnostics.md
+++ b/docs/modules/3d-tiles/concepts/runtime-tuning-and-diagnostics.md
@@ -1,0 +1,59 @@
+# Runtime Tuning and Diagnostics
+
+Tune 3D Tiles in layers: establish the desired final LOD, then improve how quickly useful coverage arrives, then size request and memory resources. Changing several layers together makes symptoms harder to explain.
+
+Concepts: [overview](/docs/modules/3d-tiles/concepts) · [hierarchy](./tile-hierarchy-and-refinement) · [SSE and LOD](./screen-space-error-and-lod) · [request scheduling](./request-scheduling-and-priorities) · [cache and memory](./caching-and-memory)
+
+## Recommended Sequence
+
+1. Hold the camera still and choose `maximumScreenSpaceError` for acceptable final quality.
+2. Use `viewDistanceScale` only if a global multiplier is more convenient than changing the threshold.
+3. Tune `progressiveResolutionHeightFraction` for initial broad coverage.
+4. Tune `foveatedConeSize`, relaxation, and `foveatedTimeDelay` for interaction.
+5. Tune `maxRequests` for network and decode capacity.
+6. Tune `maximumMemoryUsage`, optionally enabling memory-adjusted SSE.
+
+## What to Inspect
+
+Useful `Tile3D` fields include:
+
+| Field | Diagnostic meaning |
+| --- | --- |
+| `lodMetricValue` | World-space geometric error after transform scaling for 3D Tiles. |
+| `distanceToCamera` | Bounding-volume distance used by perspective SSE. |
+| `screenSpaceError` | Most recently calculated final-LOD SSE. |
+| `selected` | Whether content contributes to the current frame. |
+| `refine` | `ADD` or `REPLACE` continuity semantics. |
+| `_priorityProgressiveResolution` | Whether the tile belongs to the coarse-coverage band. |
+| `_priorityDeferred` | Whether motion deferral currently holds the request. |
+| `_foveatedFactor` | Unitless distance from the perspective view axis. |
+| `_priority` | Combined scheduler priority; smaller starts first. |
+
+The underscored fields are runtime diagnostics, not stable public API. Prefer callbacks and stats for application behavior. `Tileset3D.stats` exposes tiles loading, loaded, in memory, in view, renderable, failed, estimated GPU memory, and the current maximum SSE.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Inspect or change |
+| --- | --- | --- |
+| Final view stays coarse | High SSE threshold, low `viewDistanceScale`, missing children, or memory-adjusted SSE. | Compare tile SSE with the active maximum; inspect load failures and descendants. |
+| Too many tiles load | Low threshold or high distance scale. | Raise `maximumScreenSpaceError`; monitor memory and requests. |
+| Empty regions during replacement | Required children failed or application code removed safe ancestors. | Inspect `REPLACE` child loads and `onTileError`; traditional children are not motion-deferred. |
+| Fine detail starts before broad coverage | Progressive priority is disabled or the root already satisfies reduced-height SSE. | Use a fraction in `(0, 0.5]`; inspect the error hierarchy. |
+| Center is not faster than edges | Foveation disabled, cone too large, orthographic projection, or few competing requests. | Check foveated options, projection, `maxRequests`, and priority fields. |
+| Periphery recovers slowly | Delay or relaxation is too aggressive. | Reduce `foveatedTimeDelay`, enlarge the cone, or reduce relaxation. |
+| Requests never recover after motion | Traversal is frozen or tileset was destroyed. | Keep `loadTiles` enabled; the runtime otherwise schedules one expiry traversal. |
+| Orthographic LOD or progressive pass looks wrong | Invalid `metersPerPixel` or physical/logical pixel mixing. | Supply a positive finite logical-pixel scale. |
+| High-DPI displays choose different LOD | Custom viewport applied DPR a second time. | Use CSS/logical dimensions with no additional DPR factor. |
+| Scaled tiles under-refine | World transform was not applied to geometric error. | Inspect `lodMetricValue` and the composed model/tile transforms. |
+| Memory exceeds configured maximum | Current-frame working set is larger than the soft cache budget. | Raise the budget, raise SSE, or enable memory-adjusted SSE. |
+| Many queued requests but low throughput | Request throttling or upstream fetch limits. | Inspect `maxRequests`, browser connection limits, and loader worker concurrency. |
+
+## Multi-Viewport Behavior
+
+Traversal and camera-motion state are retained per viewport. Selected and requested tiles from traversed viewports are combined before loading and cache eviction. A moving viewport can therefore reprioritize its peripheral work without falsely marking a stationary viewport as moving. Shared content still benefits from the common cache.
+
+## Projection Changes
+
+Perspective foveation requires a perspective field of view. Orthographic traversal uses `metersPerPixel` for SSE and progressive priority, but disables angular foveation. When an orthographic viewport lacks a valid scale, SSE falls back to the perspective-compatible formula; inspect viewport fields when changing projection at runtime.
+
+Return to the [3D Tiles runtime concepts overview](/docs/modules/3d-tiles/concepts).

--- a/docs/modules/3d-tiles/concepts/screen-space-error-and-lod.md
+++ b/docs/modules/3d-tiles/concepts/screen-space-error-and-lod.md
@@ -4,6 +4,8 @@
 
 This guide describes the loaders.gl 3D Tiles calculation. It also explains how projection, transforms, display pixel density, and traversal options affect the selected level of detail (LOD).
 
+Concepts: [overview](/docs/modules/3d-tiles/concepts) · [hierarchy](./tile-hierarchy-and-refinement) · [request scheduling](./request-scheduling-and-priorities) · [cache and memory](./caching-and-memory) · [diagnostics](./runtime-tuning-and-diagnostics)
+
 ![3D Tiles correctness flow from transform-scaled geometric error through perspective or orthographic SSE to LOD refinement, plus early required-extension validation](../images/screen-space-error-and-lod.png)
 
 References:
@@ -174,43 +176,9 @@ SSE decides whether a tile needs more detail; the tile's `refine` mode determine
 
 Both modes use the same SSE threshold. They differ in rendering and loading continuity, not in the definition of geometric error.
 
-## Progressive and Foveated Request Scheduling
+## From Desired LOD to Request Order
 
-SSE determines which hierarchy levels are needed. When several needed tiles are waiting for a limited number of network slots, loaders.gl applies a second set of measurements to decide which requests should start first. These measurements affect request order, not the normal SSE refinement threshold or the final selected LOD.
-
-### Progressive Coarse Coverage
-
-`progressiveResolutionHeightFraction` calculates a second SSE as though the viewport were rendered at a fraction of its logical height:
-
-```text
-progressiveSSE = normalSSE * progressiveResolutionHeightFraction
-```
-
-The default fraction is `0.3`. A tile whose progressive SSE still exceeds `maximumScreenSpaceError` receives higher request priority. The first descendant that crosses below the threshold is also promoted, producing a coarse SSE leaf instead of stopping between hierarchy levels. This tends to fill the viewport with usable low-resolution content before requesting all fine detail.
-
-Set the option to `0` to disable progressive prioritization. Values greater than `0.5` are ignored because they no longer represent a meaningfully reduced initial-resolution pass. The calculation uses logical pixels for both perspective and orthographic projection, just like normal SSE.
-
-### Foveated Center Priority
-
-With `foveatedScreenSpaceError: true` (the default), perspective requests near the camera's view axis load before equally needed requests near the viewport edge. The calculation uses the tile's complete bounding sphere: a large tile that intersects the view axis counts as centered even if its bounding-volume center is off-axis.
-
-`foveatedConeSize` controls the unrelaxed center region as a fraction of the field of view and defaults to `0.1`. Outside that cone, `foveatedMinimumScreenSpaceErrorRelaxation` and `foveatedInterpolationCallback` determine how quickly peripheral requests lose urgency. The default callback interpolates linearly toward `maximumScreenSpaceError`.
-
-Angular foveation is disabled for orthographic viewports because a parallel frustum has no perspective field of view. Progressive coarse coverage remains active for orthographic traversal.
-
-### Moving-Camera Deferral
-
-While camera position or direction is changing, eligible peripheral requests may wait up to `foveatedTimeDelay`, which defaults to `0.2` seconds. A follow-up traversal is scheduled for the end of the delay, so held requests become eligible even if the application does not submit another camera update.
-
-Deferral is deliberately refinement-safe:
-
-- `ADD` descendants can wait because their ancestors remain rendered.
-- Skip-LOD `REPLACE` descendants can wait while an available ancestor supplies coverage, except progressive-resolution tiles needed for the initial coarse pass.
-- Traditional `REPLACE` children never wait. The parent cannot disappear until every required child is ready, so deferring one of those children would prolong coarse rendering and could interfere with hole prevention.
-
-Foveated priority still orders traditional `REPLACE` requests center-first; only the moving-camera pause is disabled for them.
-
-The complete request order is lexicographic: non-deferred work before deferred work, progressive coverage before fine detail, center content before peripheral content, then the established reverse-SSE ordering. Separate priority bands keep an extreme value in one measurement from overpowering a more important scheduling invariant.
+SSE determines which hierarchy levels are needed. When several needed tiles compete for network slots, progressive and foveated measurements decide which requests start first without changing the final SSE target. See [Request scheduling and priorities](./request-scheduling-and-priorities) for the complete model, including foveated requests and moving-camera deferral.
 
 ## Tuning LOD
 
@@ -227,12 +195,7 @@ Tune dynamic SSE only after choosing those global quality controls. Increase
 distant structures appear too coarse. Height falloff is mainly useful for local tilesets whose
 street-level and aerial views need different traversal depth.
 
-After selecting an acceptable final LOD, tune streaming behavior separately:
-
-- Reduce `progressiveResolutionHeightFraction` to make the first coverage pass coarser, or set it to `0` when complete fine-detail order is preferable.
-- Increase `foveatedConeSize` to treat more of the viewport as central. Set it to `1` to disable foveated deferral without disabling progressive coverage.
-- Increase `foveatedTimeDelay` to suppress more peripheral traffic during continuous motion. Decrease it when peripheral detail should recover sooner after short camera adjustments.
-- Increase `foveatedMinimumScreenSpaceErrorRelaxation` when the edge of the foveated cone should begin with a stronger priority penalty. A custom `foveatedInterpolationCallback` can provide a nonlinear transition.
+After selecting an acceptable final LOD, tune streaming behavior separately with the [request-scheduling guide](./request-scheduling-and-priorities), then size the [cache and memory budget](./caching-and-memory).
 
 Changing either value affects more than visual sharpness. Deeper traversal can increase request count, decode work, GPU memory, cache churn, and draw calls. Tile availability, network latency, refinement mode, and `maximumMemoryUsage` can delay or limit the visible effect of an SSE change.
 
@@ -265,10 +228,6 @@ Compare a tile's `screenSpaceError` with the tileset's `maximumScreenSpaceError`
 | Orthographic traversal returns `NaN` or extreme values | `metersPerPixel` is zero, negative, or non-finite. | Supply a positive finite value; loaders.gl otherwise uses its perspective-compatible fallback. |
 | High-DPI displays select different tiles | Physical and logical pixels are being mixed in a custom viewport. | Provide CSS/logical dimensions and do not apply another DPR factor. |
 | Lowering SSE does not immediately improve detail | Children are still loading or constrained by memory and scheduling. | Wait for load callbacks, retraverse, and inspect cache/request limits. |
-| Center detail streams no faster than the periphery | Foveated SSE is disabled, the cone covers the full field of view, or the viewport is orthographic. | Check `foveatedScreenSpaceError`, reduce `foveatedConeSize`, and confirm a perspective viewport exposes its field of view. |
-| The viewport remains empty while moving | Coarse ancestors are unavailable or application code is unloading selected parents. | Ensure root/ancestor content can load; normal `REPLACE` requests are never motion-deferred by loaders.gl. |
-| Peripheral detail takes too long after movement | The movement delay or SSE relaxation is too aggressive. | Reduce `foveatedTimeDelay`, increase `foveatedConeSize`, or reduce the relaxation settings. |
-| Fine detail starts before broad coverage | Progressive priority is disabled or its reduced-height SSE already meets the threshold at the root. | Use a fraction in `(0, 0.5]` and inspect the tileset's geometric-error hierarchy. |
 
 ## Current Boundaries
 
@@ -276,6 +235,6 @@ Compare a tile's `screenSpaceError` with the tileset's `maximumScreenSpaceError`
 - Orthographic SSE requires `metersPerPixel`; invalid values use the perspective-compatible fallback.
 - Dynamic SSE is a perspective optimization. It is not subtracted from orthographic SSE, including
   the perspective-compatible fallback used when an orthographic viewport has an invalid pixel scale.
-- Angular foveation is a perspective-only scheduling optimization; orthographic requests retain progressive and reverse-SSE priority.
+- Request-priority behavior is documented separately because it controls arrival order rather than final LOD.
 - 3D Tiles geometric error is measured in meters. I3S uses a different `maxScreenThreshold` LOD metric that is already screen-oriented and is not transform-scaled by this logic.
 - SSE controls refinement after visibility and request-volume checks. It cannot make a culled tile visible or provide descendants that are missing from the tileset.

--- a/docs/modules/3d-tiles/concepts/screen-space-error-and-lod.md
+++ b/docs/modules/3d-tiles/concepts/screen-space-error-and-lod.md
@@ -174,6 +174,44 @@ SSE decides whether a tile needs more detail; the tile's `refine` mode determine
 
 Both modes use the same SSE threshold. They differ in rendering and loading continuity, not in the definition of geometric error.
 
+## Progressive and Foveated Request Scheduling
+
+SSE determines which hierarchy levels are needed. When several needed tiles are waiting for a limited number of network slots, loaders.gl applies a second set of measurements to decide which requests should start first. These measurements affect request order, not the normal SSE refinement threshold or the final selected LOD.
+
+### Progressive Coarse Coverage
+
+`progressiveResolutionHeightFraction` calculates a second SSE as though the viewport were rendered at a fraction of its logical height:
+
+```text
+progressiveSSE = normalSSE * progressiveResolutionHeightFraction
+```
+
+The default fraction is `0.3`. A tile whose progressive SSE still exceeds `maximumScreenSpaceError` receives higher request priority. The first descendant that crosses below the threshold is also promoted, producing a coarse SSE leaf instead of stopping between hierarchy levels. This tends to fill the viewport with usable low-resolution content before requesting all fine detail.
+
+Set the option to `0` to disable progressive prioritization. Values greater than `0.5` are ignored because they no longer represent a meaningfully reduced initial-resolution pass. The calculation uses logical pixels for both perspective and orthographic projection, just like normal SSE.
+
+### Foveated Center Priority
+
+With `foveatedScreenSpaceError: true` (the default), perspective requests near the camera's view axis load before equally needed requests near the viewport edge. The calculation uses the tile's complete bounding sphere: a large tile that intersects the view axis counts as centered even if its bounding-volume center is off-axis.
+
+`foveatedConeSize` controls the unrelaxed center region as a fraction of the field of view and defaults to `0.1`. Outside that cone, `foveatedMinimumScreenSpaceErrorRelaxation` and `foveatedInterpolationCallback` determine how quickly peripheral requests lose urgency. The default callback interpolates linearly toward `maximumScreenSpaceError`.
+
+Angular foveation is disabled for orthographic viewports because a parallel frustum has no perspective field of view. Progressive coarse coverage remains active for orthographic traversal.
+
+### Moving-Camera Deferral
+
+While camera position or direction is changing, eligible peripheral requests may wait up to `foveatedTimeDelay`, which defaults to `0.2` seconds. A follow-up traversal is scheduled for the end of the delay, so held requests become eligible even if the application does not submit another camera update.
+
+Deferral is deliberately refinement-safe:
+
+- `ADD` descendants can wait because their ancestors remain rendered.
+- Skip-LOD `REPLACE` descendants can wait while an available ancestor supplies coverage, except progressive-resolution tiles needed for the initial coarse pass.
+- Traditional `REPLACE` children never wait. The parent cannot disappear until every required child is ready, so deferring one of those children would prolong coarse rendering and could interfere with hole prevention.
+
+Foveated priority still orders traditional `REPLACE` requests center-first; only the moving-camera pause is disabled for them.
+
+The complete request order is lexicographic: non-deferred work before deferred work, progressive coverage before fine detail, center content before peripheral content, then the established reverse-SSE ordering. Separate priority bands keep an extreme value in one measurement from overpowering a more important scheduling invariant.
+
 ## Tuning LOD
 
 The two primary controls are:
@@ -188,6 +226,13 @@ Tune dynamic SSE only after choosing those global quality controls. Increase
 `dynamicScreenSpaceErrorFactor` when the maximum reduction is too small. Lower either value when
 distant structures appear too coarse. Height falloff is mainly useful for local tilesets whose
 street-level and aerial views need different traversal depth.
+
+After selecting an acceptable final LOD, tune streaming behavior separately:
+
+- Reduce `progressiveResolutionHeightFraction` to make the first coverage pass coarser, or set it to `0` when complete fine-detail order is preferable.
+- Increase `foveatedConeSize` to treat more of the viewport as central. Set it to `1` to disable foveated deferral without disabling progressive coverage.
+- Increase `foveatedTimeDelay` to suppress more peripheral traffic during continuous motion. Decrease it when peripheral detail should recover sooner after short camera adjustments.
+- Increase `foveatedMinimumScreenSpaceErrorRelaxation` when the edge of the foveated cone should begin with a stronger priority penalty. A custom `foveatedInterpolationCallback` can provide a nonlinear transition.
 
 Changing either value affects more than visual sharpness. Deeper traversal can increase request count, decode work, GPU memory, cache churn, and draw calls. Tile availability, network latency, refinement mode, and `maximumMemoryUsage` can delay or limit the visible effect of an SSE change.
 
@@ -220,6 +265,10 @@ Compare a tile's `screenSpaceError` with the tileset's `maximumScreenSpaceError`
 | Orthographic traversal returns `NaN` or extreme values | `metersPerPixel` is zero, negative, or non-finite. | Supply a positive finite value; loaders.gl otherwise uses its perspective-compatible fallback. |
 | High-DPI displays select different tiles | Physical and logical pixels are being mixed in a custom viewport. | Provide CSS/logical dimensions and do not apply another DPR factor. |
 | Lowering SSE does not immediately improve detail | Children are still loading or constrained by memory and scheduling. | Wait for load callbacks, retraverse, and inspect cache/request limits. |
+| Center detail streams no faster than the periphery | Foveated SSE is disabled, the cone covers the full field of view, or the viewport is orthographic. | Check `foveatedScreenSpaceError`, reduce `foveatedConeSize`, and confirm a perspective viewport exposes its field of view. |
+| The viewport remains empty while moving | Coarse ancestors are unavailable or application code is unloading selected parents. | Ensure root/ancestor content can load; normal `REPLACE` requests are never motion-deferred by loaders.gl. |
+| Peripheral detail takes too long after movement | The movement delay or SSE relaxation is too aggressive. | Reduce `foveatedTimeDelay`, increase `foveatedConeSize`, or reduce the relaxation settings. |
+| Fine detail starts before broad coverage | Progressive priority is disabled or its reduced-height SSE already meets the threshold at the root. | Use a fraction in `(0, 0.5]` and inspect the tileset's geometric-error hierarchy. |
 
 ## Current Boundaries
 
@@ -227,5 +276,6 @@ Compare a tile's `screenSpaceError` with the tileset's `maximumScreenSpaceError`
 - Orthographic SSE requires `metersPerPixel`; invalid values use the perspective-compatible fallback.
 - Dynamic SSE is a perspective optimization. It is not subtracted from orthographic SSE, including
   the perspective-compatible fallback used when an orthographic viewport has an invalid pixel scale.
+- Angular foveation is a perspective-only scheduling optimization; orthographic requests retain progressive and reverse-SSE priority.
 - 3D Tiles geometric error is measured in meters. I3S uses a different `maxScreenThreshold` LOD metric that is already screen-oriented and is not transform-scaled by this logic.
 - SSE controls refinement after visibility and request-volume checks. It cannot make a culled tile visible or provide descendants that are missing from the tileset.

--- a/docs/modules/3d-tiles/concepts/tile-hierarchy-and-refinement.md
+++ b/docs/modules/3d-tiles/concepts/tile-hierarchy-and-refinement.md
@@ -1,0 +1,49 @@
+# Tile Hierarchy and Refinement
+
+3D Tiles divides a dataset into a tree. A tile describes a bounding volume, a geometric error, an optional content resource, and zero or more children. Traversal visits visible branches and decides whether each tile can provide current coverage or needs descendants.
+
+Concepts: [overview](/docs/modules/3d-tiles/concepts) · [SSE and LOD](./screen-space-error-and-lod) · [request scheduling](./request-scheduling-and-priorities) · [cache and memory](./caching-and-memory) · [diagnostics](./runtime-tuning-and-diagnostics)
+
+## The Per-Frame Pipeline
+
+For each viewport, `Tileset3D`:
+
+1. Creates camera, frustum, and logical-pixel measurements.
+2. Culls tiles outside the frustum and applies viewer request volumes.
+3. Calculates distance and screen-space error for visible tiles.
+4. Traverses descendants while refinement is required and possible.
+5. Separates renderable tiles from unloaded request candidates.
+6. Ranks candidates and submits them through the request scheduler.
+7. Keeps safe ancestor coverage while replacement content is incomplete.
+8. Touches current-frame tiles in the cache and evicts unused content when necessary.
+
+Loading is asynchronous. A traversal may initially select an available ancestor, request descendants, and select those descendants in a later traversal after their content becomes ready. Applications should call `update()` or `selectTiles()` as the camera changes; `onTileLoad` can trigger another update after loads complete.
+
+## Refinement Modes
+
+`REPLACE` means descendants eventually replace the parent's representation. Traditional replacement traversal keeps a parent visible until every required child is ready, preventing holes. That safety rule is why these child requests can be prioritized center-first but are not paused by moving-camera foveated deferral.
+
+`ADD` means descendants augment their ancestors. The parent remains part of the result, so descendant requests can safely wait briefly while the camera moves.
+
+Some source traversers support skip-LOD replacement: a ready ancestor can remain as coverage while traversal jumps to deeper descendants. Progressive-resolution descendants needed for initial broad coverage remain urgent even in this mode.
+
+## Visibility, Selection, and Requests
+
+These states answer different questions:
+
+| State | Meaning |
+| --- | --- |
+| Visible | The bounding volume intersects the current view and passes visibility checks. |
+| Refining | Its SSE exceeds the active threshold and traversal can visit descendants. |
+| Selected | Its content should contribute to the current rendered result. |
+| Requested | Its content is needed but is not yet available. |
+| Deferred | It remains needed, but may wait until the foveated motion window expires. |
+| Cached | Its loaded content remains resident for reuse, whether or not currently selected. |
+
+A tile can be visible but neither selected nor requested, for example when descendants already provide replacement coverage. Conversely, traditional `REPLACE` traversal may request a required child whose bounding volume is not visible so that the whole replacement set becomes ready without a hole.
+
+## External and Implicit Hierarchies
+
+External tilesets extend the apparent hierarchy after their JSON is loaded. Implicit tiling materializes nodes from subtree availability data. Both still feed the same traversal concepts: bounding volumes determine relevance, geometric error determines refinement, and content state determines whether a selected representation is renderable.
+
+Next: [Screen-space error and LOD](./screen-space-error-and-lod).

--- a/docs/modules/tiles/api-reference/tileset-3d.md
+++ b/docs/modules/tiles/api-reference/tileset-3d.md
@@ -72,13 +72,13 @@ Parameters:
   - `options.throttleRequests`=`true` (`Boolean`) - Determines whether or not to throttle tile fetching requests. Throttled requests are prioritized according to tile visibility.
   - `options.maxRequests`=`64` (`Number`) - When throttling tile fetching, the maximum number of simultaneous requests.
   - `options.modelMatrix`=`Matrix4.IDENTITY` (`Matrix4`) - A 4x4 transformation matrix this transforms the entire tileset.
-  - `options.maximumMemoryUsage`=`512` (`Number`) - The maximum amount of memory in MB that can be used by the tileset.
+  - `options.maximumMemoryUsage`=`32` (`Number`) - Soft limit for estimated cached GPU memory in MB. Current-frame tiles remain protected. See [Caching and memory](/docs/modules/3d-tiles/concepts/caching-and-memory).
   - `options.viewDistanceScale`=`1.0` (`Number`) - Multiplies calculated screen-space error. Lower values stop refinement earlier; higher values select more detail. See [Screen-space error and level of detail](/docs/modules/3d-tiles/concepts/screen-space-error-and-lod).
-  - `options.progressiveResolutionHeightFraction`=`0.3` (`Number`) - Prioritizes coarse viewport coverage using SSE at a reduced logical viewport height. Set to `0` to disable; values above `0.5` are ignored.
-  - `options.foveatedScreenSpaceError`=`true` (`Boolean`) - Prioritizes perspective requests near the camera view axis before peripheral detail.
+  - `options.progressiveResolutionHeightFraction`=`0.3` (`Number`) - Prioritizes coarse viewport coverage using SSE at a reduced logical viewport height. Set to `0` to disable; values above `0.5` are ignored. See [Request scheduling and priorities](/docs/modules/3d-tiles/concepts/request-scheduling-and-priorities).
+  - `options.foveatedScreenSpaceError`=`true` (`Boolean`) - Prioritizes perspective requests near the camera view axis before peripheral detail. This changes request timing, not the final LOD target. See [Request scheduling and priorities](/docs/modules/3d-tiles/concepts/request-scheduling-and-priorities).
   - `options.foveatedConeSize`=`0.1` (`Number`) - Fraction of the perspective field of view that receives no foveated SSE relaxation. Set to `1` to disable peripheral deferral.
   - `options.foveatedMinimumScreenSpaceErrorRelaxation`=`0` (`Number`) - Minimum logical-pixel SSE relaxation immediately outside the center cone.
-  - `options.foveatedInterpolationCallback`=`linear interpolation` (`Function`) - Interpolates SSE relaxation from the cone edge toward the viewport edge.
+  - `options.foveatedInterpolationCallback`=`linear interpolation` (`Function`) - Interpolates logical-pixel SSE relaxation from the cone edge toward the viewport edge.
   - `options.foveatedTimeDelay`=`0.2` (`Number`) - Maximum seconds eligible peripheral requests wait after camera movement. Traditional `REPLACE` traversal is never deferred.
   - `options.updateTransforms`=`true` (`Boolean`) - Always check if the tileset `modelMatrix` was updated. Set to `false` to improve performance when the tileset remains stationary in the scene.
   - `options.loadOptions` - _loaders.gl_ options used when loading tiles from the tiling server. Includes `fetch` options such as authentication `headers`, worker options such as `maxConcurrency`, and options to other loaders such as `3d-tiles`, `gltf`, and `draco`.
@@ -221,7 +221,7 @@ for the current view, then the memory usage of the tiles loaded will exceed
 300 MB of tiles are needed to meet the screen space error, then 300 MB of tiles may be loaded. When
 these tiles go out of view, they will be unloaded.
 
-^default 512 \*
+^default 32 \*
 ^exception `maximumMemoryUsage` must be greater than or equal to zero.
 ^see Tileset3D#gpuMemoryUsageInBytes
 

--- a/docs/modules/tiles/api-reference/tileset-3d.md
+++ b/docs/modules/tiles/api-reference/tileset-3d.md
@@ -74,6 +74,12 @@ Parameters:
   - `options.modelMatrix`=`Matrix4.IDENTITY` (`Matrix4`) - A 4x4 transformation matrix this transforms the entire tileset.
   - `options.maximumMemoryUsage`=`512` (`Number`) - The maximum amount of memory in MB that can be used by the tileset.
   - `options.viewDistanceScale`=`1.0` (`Number`) - Multiplies calculated screen-space error. Lower values stop refinement earlier; higher values select more detail. See [Screen-space error and level of detail](/docs/modules/3d-tiles/concepts/screen-space-error-and-lod).
+  - `options.progressiveResolutionHeightFraction`=`0.3` (`Number`) - Prioritizes coarse viewport coverage using SSE at a reduced logical viewport height. Set to `0` to disable; values above `0.5` are ignored.
+  - `options.foveatedScreenSpaceError`=`true` (`Boolean`) - Prioritizes perspective requests near the camera view axis before peripheral detail.
+  - `options.foveatedConeSize`=`0.1` (`Number`) - Fraction of the perspective field of view that receives no foveated SSE relaxation. Set to `1` to disable peripheral deferral.
+  - `options.foveatedMinimumScreenSpaceErrorRelaxation`=`0` (`Number`) - Minimum logical-pixel SSE relaxation immediately outside the center cone.
+  - `options.foveatedInterpolationCallback`=`linear interpolation` (`Function`) - Interpolates SSE relaxation from the cone edge toward the viewport edge.
+  - `options.foveatedTimeDelay`=`0.2` (`Number`) - Maximum seconds eligible peripheral requests wait after camera movement. Traditional `REPLACE` traversal is never deferred.
   - `options.updateTransforms`=`true` (`Boolean`) - Always check if the tileset `modelMatrix` was updated. Set to `false` to improve performance when the tileset remains stationary in the scene.
   - `options.loadOptions` - _loaders.gl_ options used when loading tiles from the tiling server. Includes `fetch` options such as authentication `headers`, worker options such as `maxConcurrency`, and options to other loaders such as `3d-tiles`, `gltf`, and `draco`.
   - `options.contentLoader` = `null` (`Promise`) - An optional external async content loader for the tile. Once the promise resolves, a tile is regarded as _READY_ to be displayed on the viewport.

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -199,6 +199,15 @@ A minor release that includes:
 
 - **3D Tiles 1.1 Writing** [`Tile3DWriter`](/docs/modules/3d-tiles/api-reference/tile-3d-writer) now supports writing 3DTiles 1.1
 - **3D Tiles 1.1 Extensions** `EXT_mesh_features` and `EXT_structural_metadata` are now supported.
+- **Transform-correct LOD** Geometric error is scaled conservatively by composed tile and tileset transforms without compounding after runtime updates.
+- **Projection-correct SSE** Orthographic viewports use `metersPerPixel`, while perspective and orthographic traversal consistently use logical pixels without a second device-pixel-ratio correction.
+- **Dynamic SSE** Perspective traversal can reduce distant, horizon-facing refinement with view-dependent density and height falloff while leaving orthographic and I3S LOD behavior unchanged.
+- **Required-extension validation** Unsupported `extensionsRequired` values fail before normalization or dependent network access; unknown `extensionsUsed` values remain forward-compatible.
+- **Progressive tile requests** Coarse viewport coverage receives priority before fine detail through reduced-height SSE.
+- **Foveated tile requests** Perspective tiles near the view axis receive priority over equally needed peripheral detail without changing the final LOD target.
+- **Motion-aware request deferral** Refinement-safe peripheral requests can pause briefly during camera motion and automatically resume after the configured delay.
+- **Request-priority diagnostics** Tile runtime fields and tests expose progressive, foveated, deferred, and combined priority calculations.
+- **3D Tiles runtime guides** A [sidebar-linked concepts suite](/docs/modules/3d-tiles/concepts) documents hierarchy refinement, SSE/LOD, request scheduling, foveation, caching, memory, tuning, and diagnostics.
 
 **@loaders.gl/tile-converter**
 

--- a/modules/tiles/src/index.ts
+++ b/modules/tiles/src/index.ts
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 export type {Tileset3DProps} from './tileset-3d/common/tileset-3d';
+export type {FoveatedInterpolationCallback} from './tileset-3d/helpers/tiles-3d-request-priority';
 export {Tileset3D} from './tileset-3d/common/tileset-3d';
 export type {
   TileContentLoadResult,
@@ -84,6 +85,7 @@ export {createBoundingVolume} from './tileset-3d/helpers/bounding-volume';
 export {calculateTransformProps} from './tileset-3d/helpers/transform-utils';
 
 export {getFrameState} from './tileset-3d/helpers/frame-state';
+export type {GetFrameStateOptions} from './tileset-3d/helpers/frame-state';
 export {getLodStatus} from './tileset-3d/helpers/i3s-lod';
 
 export {

--- a/modules/tiles/src/tileset-3d/common/tile-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tile-3d.ts
@@ -23,6 +23,12 @@ import {
 import {getTiles3DScreenSpaceError} from '../helpers/tiles-3d-lod';
 import {getProjectedRadius} from '../helpers/i3s-lod';
 import {TilesetTraverser} from './tileset-traverser';
+import {
+  calculateFoveatedFactor,
+  calculateTileRequestPriority,
+  isFoveatedRequestDeferred,
+  isProgressiveResolutionPriority
+} from '../helpers/tiles-3d-request-priority';
 
 const scratchVector = new Vector3();
 
@@ -116,6 +122,14 @@ export class Tile3D {
   /** updated every frame for tree traversal and rendering optimizations: */
   public _distanceToCamera: number = 0;
   _screenSpaceError: number = 0;
+  /** SSE calculated at the reduced viewport height used to prioritize coarse coverage. */
+  _screenSpaceErrorProgressiveResolution: number = 0;
+  /** Whether this tile should be promoted into the progressive-resolution request pass. */
+  _priorityProgressiveResolution: boolean = false;
+  /** Angular distance from the camera view axis used to prioritize center tiles. */
+  _foveatedFactor: number = 0;
+  /** Whether this peripheral request may wait briefly after camera movement. */
+  priorityDeferred: boolean = false;
   private _visibilityPlaneMask: any;
   private _visible: boolean | undefined = undefined;
 
@@ -287,13 +301,28 @@ export class Tile3D {
     return this._boundingBox;
   }
 
-  /** Get the tile's screen space error. */
-  getScreenSpaceError(frameState, useParentLodMetric) {
+  /**
+   * Gets the tile's screen-space error for normal refinement or a reduced-height priority pass.
+   *
+   * I3S already supplies a screen-oriented LOD metric and intentionally ignores the optional 3D
+   * Tiles progressive-resolution height fraction.
+   *
+   * @param frameState - Current camera and viewport measurements.
+   * @param useParentLodMetric - Whether to substitute the parent LOD metric.
+   * @param viewportHeightFraction - Fraction of viewport height represented by the priority pass.
+   * @returns Screen-space LOD error for the current tileset format.
+   */
+  getScreenSpaceError(frameState, useParentLodMetric, viewportHeightFraction = 1) {
     switch (this.tileset.type) {
       case TILESET_TYPE.I3S:
         return getProjectedRadius(this, frameState);
       case TILESET_TYPE.TILES3D:
-        return getTiles3DScreenSpaceError(this, frameState, useParentLodMetric);
+        return getTiles3DScreenSpaceError(
+          this,
+          frameState,
+          useParentLodMetric,
+          viewportHeightFraction
+        );
       default:
         // eslint-disable-next-line
         throw new Error('Unsupported tileset type');
@@ -354,8 +383,16 @@ export class Tile3D {
 
     const rootScreenSpaceError = traverser.root ? traverser.root._screenSpaceError : 0.0;
 
-    // Map higher SSE to lower values (e.g. root tile is highest priority)
-    return Math.max(rootScreenSpaceError - screenSpaceError, 0);
+    // Map higher SSE to lower values (e.g. root tile is highest priority), then combine the
+    // existing order with independent progressive and foveated priority bands.
+    const reverseScreenSpaceError = Math.max(rootScreenSpaceError - screenSpaceError, 0);
+    return calculateTileRequestPriority({
+      priorityProgressiveResolution: this._priorityProgressiveResolution,
+      priorityDeferred: this.priorityDeferred,
+      foveatedFactor: this._foveatedFactor,
+      reverseScreenSpaceError,
+      rootScreenSpaceError
+    });
   }
 
   /**
@@ -450,12 +487,73 @@ export class Tile3D {
 
     this._distanceToCamera = this.distanceToTile(frameState);
     this._screenSpaceError = this.getScreenSpaceError(frameState, false);
+    this._updateRequestPriorityMetrics(frameState);
     this._visibilityPlaneMask = this.visibility(frameState, parentVisibilityPlaneMask); // Use parent's plane mask to speed up visibility test
     this._visible = this._visibilityPlaneMask !== CullingVolume.MASK_OUTSIDE;
     this._inRequestVolume = this.insideViewerRequestVolume(frameState);
 
     this._frameNumber = frameState.frameNumber;
     this.viewportIds = viewportIds;
+  }
+
+  /**
+   * Updates progressive-resolution and foveated request metrics for a 3D Tiles traversal frame.
+   *
+   * I3S retains its format-specific screen-threshold ordering and is explicitly isolated from
+   * geometric-error scheduling. Orthographic viewports still receive progressive coverage, but
+   * angular foveation is disabled because an orthographic frustum has no perspective field of view.
+   *
+   * @param frameState - Current camera and viewport measurements.
+   */
+  _updateRequestPriorityMetrics(frameState: FrameState): void {
+    if (this.tileset.type !== TILESET_TYPE.TILES3D) {
+      this._screenSpaceErrorProgressiveResolution = this._screenSpaceError;
+      this._priorityProgressiveResolution = false;
+      this._foveatedFactor = 0;
+      this.priorityDeferred = false;
+      return;
+    }
+
+    const options = this.tileset.options;
+    const progressiveResolutionHeightFraction = options.progressiveResolutionHeightFraction;
+    this._screenSpaceErrorProgressiveResolution = this.getScreenSpaceError(
+      frameState,
+      false,
+      progressiveResolutionHeightFraction
+    );
+    this._priorityProgressiveResolution = isProgressiveResolutionPriority(
+      this._screenSpaceErrorProgressiveResolution,
+      this.parent?._screenSpaceErrorProgressiveResolution,
+      this.tileset.memoryAdjustedScreenSpaceError,
+      progressiveResolutionHeightFraction
+    );
+
+    if (
+      !options.foveatedScreenSpaceError ||
+      frameState.viewport?.orthographic ||
+      !frameState.camera?.position ||
+      !frameState.camera?.direction
+    ) {
+      this._foveatedFactor = 0;
+      this.priorityDeferred = false;
+      return;
+    }
+
+    this._foveatedFactor = calculateFoveatedFactor(this.boundingVolume, frameState.camera);
+    this.priorityDeferred = isFoveatedRequestDeferred({
+      refinement: this.refine,
+      skipLevelOfDetail: this.tileset._traverser.options.skipLevelOfDetail,
+      foveatedScreenSpaceError: options.foveatedScreenSpaceError,
+      foveatedConeSize: options.foveatedConeSize,
+      minimumScreenSpaceErrorRelaxation: options.foveatedMinimumScreenSpaceErrorRelaxation,
+      interpolationCallback: options.foveatedInterpolationCallback,
+      foveatedFactor: this._foveatedFactor,
+      verticalFieldOfView: frameState.camera.verticalFieldOfView,
+      screenSpaceError: this._screenSpaceError,
+      parentScreenSpaceError: this.parent?._screenSpaceError,
+      maximumScreenSpaceError: this.tileset.memoryAdjustedScreenSpaceError,
+      priorityProgressiveResolution: this._priorityProgressiveResolution
+    });
   }
 
   // Determines whether the tile's bounding volume intersects the culling volume.
@@ -679,6 +777,10 @@ export class Tile3D {
     this._distanceToCamera = 0;
     this._centerZDepth = 0;
     this._screenSpaceError = 0;
+    this._screenSpaceErrorProgressiveResolution = 0;
+    this._priorityProgressiveResolution = false;
+    this._foveatedFactor = 0;
+    this.priorityDeferred = false;
     this._visibilityPlaneMask = CullingVolume.MASK_INDETERMINATE;
     this._visible = undefined;
     this._inRequestVolume = false;

--- a/modules/tiles/src/tileset-3d/common/tileset-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tileset-3d.ts
@@ -10,8 +10,11 @@ import {Stats} from '@probe.gl/stats';
 import {RequestScheduler, LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';
 import {TilesetCache} from './tileset-cache';
 import {calculateTransformProps} from '../helpers/transform-utils';
-import {FrameState, getFrameState, limitSelectedTiles} from '../helpers/frame-state';
+import {getFrameState, limitSelectedTiles, updateCameraMotionState} from '../helpers/frame-state';
+import type {CameraMotionState, FrameState} from '../helpers/frame-state';
 import {calculateDynamicScreenSpaceErrorDensity} from '../helpers/tiles-3d-lod';
+import {interpolateLinearly} from '../helpers/tiles-3d-request-priority';
+import type {FoveatedInterpolationCallback} from '../helpers/tiles-3d-request-priority';
 
 import type {GeospatialViewport, Viewport} from '../../types';
 import {Tile3D} from './tile-3d';
@@ -59,6 +62,18 @@ export type Tileset3DProps = {
   viewportTraversersMap?: any;
   updateTransforms?: boolean;
   viewDistanceScale?: number;
+  /** Reduced viewport-height fraction used to prioritize coarse initial coverage; `0` disables it. */
+  progressiveResolutionHeightFraction?: number;
+  /** Whether requests nearer the center of a perspective viewport receive higher priority. */
+  foveatedScreenSpaceError?: boolean;
+  /** Fraction of the perspective field of view that receives no foveated SSE relaxation. */
+  foveatedConeSize?: number;
+  /** Minimum logical-pixel SSE relaxation immediately outside the foveated cone. */
+  foveatedMinimumScreenSpaceErrorRelaxation?: number;
+  /** Function that increases SSE relaxation from the foveated cone toward the viewport edge. */
+  foveatedInterpolationCallback?: FoveatedInterpolationCallback;
+  /** Seconds peripheral requests may wait after the camera moves. */
+  foveatedTimeDelay?: number;
 
   onTileLoad?: (tile: Tile3D) => any;
   onTileUnload?: (tile: Tile3D) => any;
@@ -105,6 +120,18 @@ type Props = {
   loadOptions: LoaderOptions;
   updateTransforms: boolean;
   viewDistanceScale: number;
+  /** Reduced viewport-height fraction used to prioritize coarse initial coverage. */
+  progressiveResolutionHeightFraction: number;
+  /** Whether perspective requests are prioritized around the viewport center. */
+  foveatedScreenSpaceError: boolean;
+  /** Fraction of the perspective field of view with no foveated SSE relaxation. */
+  foveatedConeSize: number;
+  /** Minimum logical-pixel SSE relaxation outside the foveated cone. */
+  foveatedMinimumScreenSpaceErrorRelaxation: number;
+  /** Function used to interpolate foveated SSE relaxation. */
+  foveatedInterpolationCallback: FoveatedInterpolationCallback;
+  /** Seconds eligible peripheral requests wait after camera movement. */
+  foveatedTimeDelay: number;
   basePath: string;
   contentLoader?: (tile: Tile3D) => Promise<void>;
   i3s: Record<string, any>;
@@ -129,6 +156,12 @@ const DEFAULT_PROPS: Props = {
   onUpdate: () => {},
   contentLoader: undefined,
   viewDistanceScale: 1.0,
+  progressiveResolutionHeightFraction: 0.3,
+  foveatedScreenSpaceError: true,
+  foveatedConeSize: 0.1,
+  foveatedMinimumScreenSpaceErrorRelaxation: 0,
+  foveatedInterpolationCallback: interpolateLinearly,
+  foveatedTimeDelay: 0.2,
   maximumScreenSpaceError: 8,
   dynamicScreenSpaceError: true,
   dynamicScreenSpaceErrorDensity: 2.0e-4,
@@ -217,6 +250,10 @@ export class Tileset3D {
   private _requestedTiles: Tile3D[] = [];
   private _emptyTiles: Tile3D[] = [];
   private frameStateData: any = {};
+  /** Last camera pose retained independently for each viewport. */
+  private _cameraMotionStates: Record<string, CameraMotionState> = {};
+  /** Pending traversal that releases requests after camera motion settles. */
+  private _deferredTraversalTimeout: ReturnType<typeof setTimeout> | null = null;
 
   _traverser: TilesetTraverser;
   _cache = new TilesetCache();
@@ -269,6 +306,7 @@ export class Tileset3D {
   }
 
   destroy(): void {
+    this._clearDeferredTraversal();
     this._destroy();
   }
 
@@ -357,6 +395,8 @@ export class Tileset3D {
     this._cache.reset();
     this._frameNumber++;
     this.traverseCounter = preparedViewports.length;
+    const currentTime = Date.now();
+    let minimumDeferredTraversalDelay = Number.POSITIVE_INFINITY;
     const viewportsToTraverse: string[] = [];
     for (const viewport of preparedViewports) {
       const id = viewport.id;
@@ -378,6 +418,14 @@ export class Tileset3D {
       }
       const frameState = getFrameState(viewport as GeospatialViewport, this._frameNumber);
       const root = this.roots[id];
+      const cameraMotionUpdate = updateCameraMotionState(
+        this._cameraMotionStates[id],
+        frameState.camera.position,
+        frameState.camera.direction,
+        currentTime
+      );
+      this._cameraMotionStates[id] = cameraMotionUpdate.state;
+      frameState.camera.timeSinceMovement = cameraMotionUpdate.timeSinceMovement;
       frameState.dynamicScreenSpaceErrorDensity =
         this.type === TILESET_TYPE.TILES3D &&
         this.options.dynamicScreenSpaceError &&
@@ -387,6 +435,48 @@ export class Tileset3D {
       // Keep the legacy diagnostic field, but traversal reads the per-viewport frame value above.
       this.dynamicScreenSpaceErrorComputedDensity = frameState.dynamicScreenSpaceErrorDensity;
       this._traverser.traverse(root, frameState, this.options);
+      if (Object.keys(this._traverser.deferredTiles).length > 0) {
+        minimumDeferredTraversalDelay = Math.min(
+          minimumDeferredTraversalDelay,
+          Math.max(this.options.foveatedTimeDelay - cameraMotionUpdate.timeSinceMovement, 0)
+        );
+      }
+    }
+
+    if (Number.isFinite(minimumDeferredTraversalDelay)) {
+      this._scheduleDeferredTraversal(minimumDeferredTraversalDelay);
+    } else {
+      this._clearDeferredTraversal();
+    }
+  }
+
+  /**
+   * Schedules one follow-up traversal when the moving-camera deferral window expires.
+   *
+   * Replacing an existing timer ensures continuing camera movement pushes the retry window forward
+   * instead of creating a queue of redundant traversals.
+   *
+   * @param delayInSeconds - Remaining stationary delay before deferred requests become eligible.
+   */
+  private _scheduleDeferredTraversal(delayInSeconds: number): void {
+    this._clearDeferredTraversal();
+    this._deferredTraversalTimeout = setTimeout(
+      () => {
+        this._deferredTraversalTimeout = null;
+        this.selectTiles().catch((error: unknown) => {
+          const traversalError = error instanceof Error ? error : new Error(String(error));
+          this._onTilesetError(traversalError);
+        });
+      },
+      Math.max(delayInSeconds * 1000, 0)
+    );
+  }
+
+  /** Clears a pending moving-camera follow-up traversal. */
+  private _clearDeferredTraversal(): void {
+    if (this._deferredTraversalTimeout !== null) {
+      clearTimeout(this._deferredTraversalTimeout);
+      this._deferredTraversalTimeout = null;
     }
   }
 

--- a/modules/tiles/src/tileset-3d/common/tileset-traverser.ts
+++ b/modules/tiles/src/tileset-3d/common/tileset-traverser.ts
@@ -35,6 +35,8 @@ export class TilesetTraverser {
   selectedTiles: Record<string, Tile3D> = {};
   // tiles should be loaded from server
   requestedTiles: Record<string, Tile3D> = {};
+  /** Tiles intentionally held until the camera has remained still for the configured delay. */
+  deferredTiles: Record<string, Tile3D> = {};
   // tiles does not have render content
   emptyTiles: Record<string, Tile3D> = {};
 
@@ -73,6 +75,7 @@ export class TilesetTraverser {
 
   reset() {
     this.requestedTiles = {};
+    this.deferredTiles = {};
     this.selectedTiles = {};
     this.emptyTiles = {};
     this._traversalStack.reset();
@@ -235,10 +238,34 @@ export class TilesetTraverser {
   // tile to load from server
   loadTile(tile: Tile3D, frameState: FrameState): void {
     if (this.shouldLoadTile(tile)) {
+      if (this.shouldDeferTileRequest(tile, frameState)) {
+        this.deferredTiles[tile.id] = tile;
+        return;
+      }
       tile._requestedFrame = frameState.frameNumber;
       tile._priority = tile._getPriority();
       this.requestedTiles[tile.id] = tile;
     }
+  }
+
+  /**
+   * Returns whether an eligible peripheral request should wait for camera motion to settle.
+   *
+   * Eligibility is calculated on the tile with refinement-safety checks. This final gate only
+   * applies the time window, keeping traversal deterministic once the delay expires.
+   *
+   * @param tile - Tile considered for loading.
+   * @param frameState - Current camera motion measurements.
+   * @returns `true` when the request should be retried after the remaining delay.
+   */
+  shouldDeferTileRequest(tile: Tile3D, frameState: FrameState): boolean {
+    const foveatedTimeDelay = tile.tileset.options.foveatedTimeDelay;
+    return (
+      tile.priorityDeferred &&
+      Number.isFinite(foveatedTimeDelay) &&
+      foveatedTimeDelay > 0 &&
+      frameState.camera.timeSinceMovement < foveatedTimeDelay
+    );
   }
 
   // cache tile

--- a/modules/tiles/src/tileset-3d/helpers/frame-state.ts
+++ b/modules/tiles/src/tileset-3d/helpers/frame-state.ts
@@ -14,6 +14,10 @@ export type FrameState = {
     up: number[];
     /** Camera position as `[longitude, latitude, height]`, with height in meters. */
     cartographicPosition: [number, number, number];
+    /** Perspective vertical field of view in radians. */
+    verticalFieldOfView: number;
+    /** Elapsed seconds since camera position or direction last changed. */
+    timeSinceMovement: number;
   };
   viewport: GeospatialViewport;
   topDownViewport: GeospatialViewport; // Use it to calculate projected radius for a tile
@@ -25,8 +29,34 @@ export type FrameState = {
   dynamicScreenSpaceErrorDensity: number;
 };
 
+/** Optional camera and projection measurements supplied when constructing a frame state. */
+export type GetFrameStateOptions = {
+  /** Elapsed seconds since camera position or direction last changed. */
+  timeSinceCameraMovement?: number;
+};
+
+/** Camera pose and timestamp retained between traversal frames. */
+export type CameraMotionState = {
+  /** Last observed Earth-centered, Earth-fixed camera position. */
+  position: number[];
+  /** Last observed normalized Earth-centered, Earth-fixed camera direction. */
+  direction: number[];
+  /** Timestamp in milliseconds of the last observed pose change. */
+  lastMovementTime: number;
+};
+
+/** Updated camera state and elapsed stationary time for a traversal frame. */
+export type CameraMotionUpdate = {
+  /** Camera pose to retain for the next traversal. */
+  state: CameraMotionState;
+  /** Elapsed seconds since the camera pose last changed. */
+  timeSinceMovement: number;
+};
+
 const scratchVector = new Vector3();
 const scratchPosition = new Vector3();
+const CAMERA_POSITION_EPSILON = 1e-5;
+const CAMERA_DIRECTION_EPSILON = 1e-7;
 const cullingVolume = new CullingVolume([
   new Plane(),
   new Plane(),
@@ -36,12 +66,26 @@ const cullingVolume = new CullingVolume([
   new Plane()
 ]);
 
-// Extracts a frame state appropriate for tile culling from a deck.gl viewport
-// TODO - this could likely be generalized and merged back into deck.gl for other culling scenarios
-export function getFrameState(viewport: GeospatialViewport, frameNumber: number): FrameState {
+/**
+ * Extracts a frame state appropriate for tile culling from a structural deck.gl viewport.
+ *
+ * `options.timeSinceCameraMovement` can be supplied by a caller that retains camera pose across
+ * calls. It defaults to a stationary camera so standalone callers do not defer requests.
+ *
+ * @param viewport - Geospatial viewport supplying camera and projection measurements.
+ * @param frameNumber - Current tileset traversal frame number.
+ * @param options - Additional camera and projection measurements for traversal.
+ * @returns Frame state used for visibility, SSE, and request-priority calculations.
+ */
+export function getFrameState(
+  viewport: GeospatialViewport,
+  frameNumber: number,
+  options: GetFrameStateOptions = {}
+): FrameState {
   // Traverse and and request. Update _selectedTiles so that we know what to render.
   // Traverse and and request. Update _selectedTiles so that we know what to render.
-  const {cameraDirection, cameraUp, height} = viewport;
+  const {cameraUp, height} = viewport;
+  const cameraDirection = viewport.cameraDirection as number[] | undefined;
   const {metersPerUnit} = viewport.distanceScales;
 
   // TODO - Ellipsoid.eastNorthUpToFixedFrame() breaks on raw array, create a Vector.
@@ -56,10 +100,26 @@ export function getFrameState(viewport: GeospatialViewport, frameNumber: number)
   );
 
   // These should still be normalized as the transform has scale 1 (goes from meters to meters)
-  const cameraDirectionCartesian = new Vector3(
-    // @ts-ignore
-    enuToFixedTransform.transformAsVector(new Vector3(cameraDirection).scale(metersPerUnit))
-  ).normalize();
+  let cameraDirectionCartesian: Vector3;
+  if (cameraDirection) {
+    cameraDirectionCartesian = new Vector3(
+      // @ts-ignore
+      enuToFixedTransform.transformAsVector(new Vector3(cameraDirection).scale(metersPerUnit))
+    ).normalize();
+  } else {
+    // Concrete deck.gl viewports do not expose the legacy structural cameraDirection field.
+    // The near-plane center is on the view axis, so its world-space direction is equivalent and
+    // works for perspective foveation without coupling loaders.gl to deck.gl internals.
+    // getFrustumPlanes is required by traversal but omitted from the minimal structural Viewport
+    // type for compatibility with existing application-side declarations.
+    // @ts-expect-error Runtime geospatial viewports provide getFrustumPlanes.
+    const nearPlane = viewport.getFrustumPlanes().near;
+    const nearCenterCommon = closestPointOnPlane(nearPlane, viewport.cameraPosition);
+    const nearCenterCartesian = worldToCartesian(viewport, nearCenterCommon);
+    cameraDirectionCartesian = new Vector3(nearCenterCartesian)
+      .subtract(cameraPositionCartesian)
+      .normalize();
+  }
   const cameraUpCartesian = new Vector3(
     // @ts-ignore
     enuToFixedTransform.transformAsVector(new Vector3(cameraUp).scale(metersPerUnit))
@@ -86,7 +146,12 @@ export function getFrameState(viewport: GeospatialViewport, frameNumber: number)
       position: cameraPositionCartesian,
       direction: cameraDirectionCartesian,
       up: cameraUpCartesian,
-      cartographicPosition: cameraPositionCartographic
+      cartographicPosition: cameraPositionCartographic,
+      verticalFieldOfView:
+        Number.isFinite(viewport.fovy) && Number(viewport.fovy) > 0
+          ? (Number(viewport.fovy) * Math.PI) / 180
+          : Math.PI / 3,
+      timeSinceMovement: options.timeSinceCameraMovement ?? Number.POSITIVE_INFINITY
     },
     viewport,
     topDownViewport,
@@ -96,6 +161,55 @@ export function getFrameState(viewport: GeospatialViewport, frameNumber: number)
     sseDenominator: 1.15, // Assumes fovy = 60 degrees
     // Tileset3D fills this immediately before traversal because it depends on the root volume.
     dynamicScreenSpaceErrorDensity: 0
+  };
+}
+
+/**
+ * Updates retained camera motion state and calculates how long the current pose has been stable.
+ *
+ * The first observation is treated as stationary so initial tileset loading is never delayed.
+ * Position and direction are both compared because orbiting in place changes request relevance
+ * without necessarily changing the viewport's camera position.
+ *
+ * @param previousState - Pose retained from the preceding traversal for this viewport.
+ * @param position - Current Earth-centered, Earth-fixed camera position.
+ * @param direction - Current normalized Earth-centered, Earth-fixed camera direction.
+ * @param currentTime - Current monotonic-enough wall-clock time in milliseconds.
+ * @returns Updated pose and elapsed stationary time.
+ */
+export function updateCameraMotionState(
+  previousState: CameraMotionState | undefined,
+  position: number[] | Vector3,
+  direction: number[] | Vector3,
+  currentTime: number
+): CameraMotionUpdate {
+  const positionArray = Array.from(position);
+  const directionArray = Array.from(direction);
+  const positionChanged = previousState
+    ? positionArray.length !== previousState.position.length ||
+      positionArray.some(
+        (value, index) => Math.abs(value - previousState.position[index]) > CAMERA_POSITION_EPSILON
+      )
+    : false;
+  const directionChanged = previousState
+    ? directionArray.length !== previousState.direction.length ||
+      directionArray.some(
+        (value, index) =>
+          Math.abs(value - previousState.direction[index]) > CAMERA_DIRECTION_EPSILON
+      )
+    : false;
+  const lastMovementTime =
+    positionChanged || directionChanged
+      ? currentTime
+      : (previousState?.lastMovementTime ?? Number.NEGATIVE_INFINITY);
+
+  return {
+    state: {
+      position: positionArray,
+      direction: directionArray,
+      lastMovementTime
+    },
+    timeSinceMovement: Math.max((currentTime - lastMovementTime) / 1000, 0)
   };
 }
 
@@ -172,7 +286,7 @@ function commonSpacePlanesToWGS84(viewport) {
 
 function closestPointOnPlane(
   plane: {distance: number; normal: Vector3},
-  refPoint: [number, number, number] | Vector3,
+  refPoint: number[] | Vector3,
   out: Vector3 = new Vector3()
 ): Vector3 {
   const distanceToRef = plane.normal.dot(refPoint);

--- a/modules/tiles/src/tileset-3d/helpers/tiles-3d-lod.ts
+++ b/modules/tiles/src/tileset-3d/helpers/tiles-3d-lod.ts
@@ -142,12 +142,14 @@ export function getDynamicScreenSpaceError(
  * @param tile - Tile containing the transform-scaled geometric error and camera distance.
  * @param frameState - Current camera and viewport measurements.
  * @param useParentLodMetric - Whether request prioritization should use the parent's error.
+ * @param viewportHeightFraction - Fraction of viewport height represented by the priority pass.
  * @returns Estimated error in logical/CSS pixels.
  */
 export function getTiles3DScreenSpaceError(
   tile: Tile3D,
   frameState: FrameState,
-  useParentLodMetric: boolean
+  useParentLodMetric: boolean,
+  viewportHeightFraction = 1
 ): number {
   const tileset = tile.tileset;
   const parentLodMetricValue = (tile.parent && tile.parent.lodMetricValue) || tile.lodMetricValue;
@@ -160,7 +162,15 @@ export function getTiles3DScreenSpaceError(
 
   const {viewDistanceScale} = tileset.options;
   const lodScale = viewDistanceScale || 1;
-  const orthographicError = getOrthographicScreenSpaceError(lodMetricValue, frameState, lodScale);
+  const heightFraction = Number.isFinite(viewportHeightFraction)
+    ? Math.max(viewportHeightFraction, 0)
+    : 1;
+  const orthographicError = getOrthographicScreenSpaceError(
+    lodMetricValue,
+    frameState,
+    lodScale,
+    heightFraction
+  );
   if (orthographicError !== null) {
     return orthographicError;
   }
@@ -168,7 +178,9 @@ export function getTiles3DScreenSpaceError(
   // Avoid divide by zero when viewer is inside the tile.
   const distanceToCamera = Math.max(tile._distanceToCamera, 1e-7);
   const {height, sseDenominator} = frameState;
-  let screenSpaceError = (lodMetricValue * height * lodScale) / (distanceToCamera * sseDenominator);
+  let screenSpaceError =
+    (lodMetricValue * height * heightFraction * lodScale) /
+    (distanceToCamera * sseDenominator);
 
   if (tileset.options.dynamicScreenSpaceError && !frameState.viewport.orthographic) {
     screenSpaceError -= getDynamicScreenSpaceError(
@@ -192,12 +204,14 @@ export function getTiles3DScreenSpaceError(
  * @param lodMetricValue - Transform-scaled geometric error in world-space meters.
  * @param frameState - Current frame state containing the viewport.
  * @param lodScale - Application refinement scale from `viewDistanceScale`.
+ * @param viewportHeightFraction - Fraction of logical viewport height represented by the pass.
  * @returns SSE in logical pixels, or `null` when orthographic SSE cannot be calculated.
  */
 function getOrthographicScreenSpaceError(
   lodMetricValue: number,
   frameState: FrameState,
-  lodScale: number
+  lodScale: number,
+  viewportHeightFraction: number
 ): number | null {
   const viewport = frameState.viewport;
   if (!viewport?.orthographic) {
@@ -209,7 +223,7 @@ function getOrthographicScreenSpaceError(
     return null;
   }
 
-  return (lodMetricValue * lodScale) / metersPerPixel;
+  return (lodMetricValue * lodScale * viewportHeightFraction) / metersPerPixel;
 }
 
 /** Returns the content bounding volume header, falling back to the traversal volume. */

--- a/modules/tiles/src/tileset-3d/helpers/tiles-3d-lod.ts
+++ b/modules/tiles/src/tileset-3d/helpers/tiles-3d-lod.ts
@@ -179,8 +179,7 @@ export function getTiles3DScreenSpaceError(
   const distanceToCamera = Math.max(tile._distanceToCamera, 1e-7);
   const {height, sseDenominator} = frameState;
   let screenSpaceError =
-    (lodMetricValue * height * heightFraction * lodScale) /
-    (distanceToCamera * sseDenominator);
+    (lodMetricValue * height * heightFraction * lodScale) / (distanceToCamera * sseDenominator);
 
   if (tileset.options.dynamicScreenSpaceError && !frameState.viewport.orthographic) {
     screenSpaceError -= getDynamicScreenSpaceError(

--- a/modules/tiles/src/tileset-3d/helpers/tiles-3d-request-priority.ts
+++ b/modules/tiles/src/tileset-3d/helpers/tiles-3d-request-priority.ts
@@ -19,7 +19,16 @@ const scratchClosestPointOnLine = new Vector3();
 const scratchVectorToLine = new Vector3();
 const scratchClosestPointOnSphere = new Vector3();
 
-/** Interpolates a value used to relax SSE away from the center of the viewport. */
+/**
+ * Interpolates the logical-pixel SSE relaxation used outside the foveated center cone.
+ *
+ * @param minimumValue - Relaxation at the edge of the center cone, in logical pixels.
+ * @param maximumValue - Maximum relaxation at the edge of the perspective field of view, in
+ * logical pixels.
+ * @param interpolationAmount - Normalized distance from the cone edge toward the field-of-view
+ * edge, clamped to `[0, 1]` by the caller.
+ * @returns Interpolated SSE relaxation in logical pixels. Non-finite results are treated as zero.
+ */
 export type FoveatedInterpolationCallback = (
   minimumValue: number,
   maximumValue: number,
@@ -76,7 +85,14 @@ export type TileRequestPriorityParameters = {
   rootScreenSpaceError: number;
 };
 
-/** Linearly interpolates between two values. */
+/**
+ * Linearly interpolates between two values.
+ *
+ * @param minimumValue - Value returned when `interpolationAmount` is zero.
+ * @param maximumValue - Value returned when `interpolationAmount` is one.
+ * @param interpolationAmount - Normalized interpolation position.
+ * @returns Linearly interpolated value.
+ */
 export function interpolateLinearly(
   minimumValue: number,
   maximumValue: number,
@@ -91,6 +107,11 @@ export function interpolateLinearly(
  * The tile's bounding sphere, rather than only its center, is used so large tiles that intersect
  * the view axis retain center priority. The returned angular factor is zero on the view axis and
  * increases toward the edge of a perspective frustum.
+ *
+ * @param boundingVolume - Tile volume used to find the point nearest the camera view axis.
+ * @param camera - World-space camera position and normalized view direction.
+ * @returns Unitless angular factor, where zero intersects the view axis and larger values are more
+ * peripheral.
  */
 export function calculateFoveatedFactor(
   boundingVolume: BoundingSphere | OrientedBoundingBox,
@@ -132,6 +153,13 @@ export function calculateFoveatedFactor(
  * In addition to tiles whose reduced-height SSE exceeds the normal threshold, the first child
  * that crosses below the threshold is promoted. Promoting that SSE leaf prevents gaps between
  * coarse hierarchy levels in the initial coverage pass.
+ *
+ * @param screenSpaceError - Tile SSE calculated at the reduced logical viewport height.
+ * @param parentScreenSpaceError - Parent SSE at the same reduced height, when available.
+ * @param maximumScreenSpaceError - Normal traversal threshold in logical pixels.
+ * @param progressiveResolutionHeightFraction - Reduced-height fraction; values outside `(0, 0.5]`
+ * disable progressive priority.
+ * @returns `true` when the tile belongs to the initial coarse-coverage priority band.
  */
 export function isProgressiveResolutionPriority(
   screenSpaceError: number,
@@ -160,6 +188,9 @@ export function isProgressiveResolutionPriority(
  * Traditional `REPLACE` traversal is never deferred because every required child must be ready
  * before its parent disappears. `ADD` traversal and skip-LOD replacement traversal can safely keep
  * already available ancestors while peripheral descendants wait.
+ *
+ * @param parameters - Refinement, projection, SSE, and foveation measurements for the tile.
+ * @returns `true` when the request may wait during the camera-motion delay.
  */
 export function isFoveatedRequestDeferred(parameters: FoveatedDeferralParameters): boolean {
   const coneSize = Number.isFinite(parameters.foveatedConeSize)
@@ -218,6 +249,9 @@ export function isFoveatedRequestDeferred(parameters: FoveatedDeferralParameters
  * progressive-coverage flag, distance from the view center, and finally the established reverse-
  * SSE order. Normalizing reverse SSE preserves its relative ordering while preventing one metric
  * from spilling into the next priority band.
+ *
+ * @param parameters - Independent request-priority measurements for a tile.
+ * @returns Numeric priority for `RequestScheduler`; smaller values start first.
  */
 export function calculateTileRequestPriority(parameters: TileRequestPriorityParameters): number {
   const normalizedReverseScreenSpaceError =

--- a/modules/tiles/src/tileset-3d/helpers/tiles-3d-request-priority.ts
+++ b/modules/tiles/src/tileset-3d/helpers/tiles-3d-request-priority.ts
@@ -1,0 +1,249 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
+// This file contains behavior derived from the Cesium code base under Apache 2 license.
+
+import {Vector3} from '@math.gl/core';
+import {BoundingSphere, OrientedBoundingBox} from '@math.gl/culling';
+import {TILE_REFINEMENT} from '../../constants';
+
+const PREFERRED_SORTING_DIGITS = 10_000;
+const FOVEATED_SORTING_SCALE = 10_000;
+const PROGRESSIVE_RESOLUTION_PENALTY = 100_000_000;
+const FOVEATED_DEFERRAL_PENALTY = 1_000_000_000;
+
+const scratchBoundingSphere = new BoundingSphere();
+const scratchCenterOffset = new Vector3();
+const scratchClosestPointOnLine = new Vector3();
+const scratchVectorToLine = new Vector3();
+const scratchClosestPointOnSphere = new Vector3();
+
+/** Interpolates a value used to relax SSE away from the center of the viewport. */
+export type FoveatedInterpolationCallback = (
+  minimumValue: number,
+  maximumValue: number,
+  interpolationAmount: number
+) => number;
+
+/** Camera measurements required to calculate a tile's foveated priority. */
+export type FoveatedPriorityCamera = {
+  /** Camera position in the same world-space coordinate system as the tile bounding volume. */
+  position: number[];
+  /** Normalized world-space camera direction. */
+  direction: number[];
+};
+
+/** Inputs that determine whether a peripheral tile request may be deferred. */
+export type FoveatedDeferralParameters = {
+  /** Tile refinement mode. */
+  refinement: TILE_REFINEMENT;
+  /** Whether replacement traversal may skip hierarchy levels while retaining ancestors. */
+  skipLevelOfDetail: boolean;
+  /** Whether foveated prioritization is enabled. */
+  foveatedScreenSpaceError: boolean;
+  /** Fraction of the field of view that loads without foveated SSE relaxation. */
+  foveatedConeSize: number;
+  /** Minimum logical-pixel relaxation at the edge of the foveated cone. */
+  minimumScreenSpaceErrorRelaxation: number;
+  /** Interpolation function used to increase relaxation toward the viewport edge. */
+  interpolationCallback: FoveatedInterpolationCallback;
+  /** Tile distance from the camera view axis, represented as an angular factor. */
+  foveatedFactor: number;
+  /** Camera vertical field of view in radians. */
+  verticalFieldOfView: number;
+  /** Tile SSE in logical pixels. */
+  screenSpaceError: number;
+  /** Parent SSE in logical pixels, when a parent exists. */
+  parentScreenSpaceError?: number;
+  /** Current traversal SSE threshold in logical pixels. */
+  maximumScreenSpaceError: number;
+  /** Whether the tile contributes coarse progressive-resolution coverage. */
+  priorityProgressiveResolution: boolean;
+};
+
+/** Inputs used to encode a stable, lexicographically ordered request priority. */
+export type TileRequestPriorityParameters = {
+  /** Whether the tile contributes coarse progressive-resolution coverage. */
+  priorityProgressiveResolution: boolean;
+  /** Whether the tile is eligible for moving-camera deferral. */
+  priorityDeferred: boolean;
+  /** Tile distance from the camera view axis, represented as an angular factor. */
+  foveatedFactor: number;
+  /** Existing reverse-SSE ordering value; smaller values are more urgent. */
+  reverseScreenSpaceError: number;
+  /** Root SSE used to normalize reverse-SSE ordering without changing its order. */
+  rootScreenSpaceError: number;
+};
+
+/** Linearly interpolates between two values. */
+export function interpolateLinearly(
+  minimumValue: number,
+  maximumValue: number,
+  interpolationAmount: number
+): number {
+  return minimumValue + (maximumValue - minimumValue) * interpolationAmount;
+}
+
+/**
+ * Calculates how far a tile lies from the camera's center line.
+ *
+ * The tile's bounding sphere, rather than only its center, is used so large tiles that intersect
+ * the view axis retain center priority. The returned angular factor is zero on the view axis and
+ * increases toward the edge of a perspective frustum.
+ */
+export function calculateFoveatedFactor(
+  boundingVolume: BoundingSphere | OrientedBoundingBox,
+  camera: FoveatedPriorityCamera
+): number {
+  const boundingSphere =
+    boundingVolume instanceof BoundingSphere
+      ? boundingVolume
+      : boundingVolume.getBoundingSphere(scratchBoundingSphere);
+  const {center, radius} = boundingSphere;
+
+  scratchCenterOffset.copy(center).subtract(camera.position);
+  const centerZDepth = scratchCenterOffset.dot(camera.direction);
+  scratchClosestPointOnLine.copy(camera.direction).scale(centerZDepth).add(camera.position);
+  scratchVectorToLine.copy(scratchClosestPointOnLine).subtract(center);
+
+  const distanceToCenterLine = scratchVectorToLine.magnitude();
+  if (distanceToCenterLine <= radius) {
+    return 0;
+  }
+
+  scratchClosestPointOnSphere
+    .copy(scratchVectorToLine)
+    .normalize()
+    .scale(radius)
+    .add(center)
+    .subtract(camera.position);
+  if (scratchClosestPointOnSphere.magnitude() === 0) {
+    return 0;
+  }
+
+  scratchClosestPointOnSphere.normalize();
+  return Math.max(1 - Math.abs(scratchClosestPointOnSphere.dot(camera.direction)), 0);
+}
+
+/**
+ * Returns whether a tile supplies the coarse coverage targeted by progressive resolution.
+ *
+ * In addition to tiles whose reduced-height SSE exceeds the normal threshold, the first child
+ * that crosses below the threshold is promoted. Promoting that SSE leaf prevents gaps between
+ * coarse hierarchy levels in the initial coverage pass.
+ */
+export function isProgressiveResolutionPriority(
+  screenSpaceError: number,
+  parentScreenSpaceError: number | undefined,
+  maximumScreenSpaceError: number,
+  progressiveResolutionHeightFraction: number
+): boolean {
+  if (
+    !Number.isFinite(progressiveResolutionHeightFraction) ||
+    progressiveResolutionHeightFraction <= 0 ||
+    progressiveResolutionHeightFraction > 0.5
+  ) {
+    return false;
+  }
+
+  if (screenSpaceError > maximumScreenSpaceError) {
+    return true;
+  }
+
+  return parentScreenSpaceError !== undefined && parentScreenSpaceError > maximumScreenSpaceError;
+}
+
+/**
+ * Returns whether a peripheral request can wait briefly after camera motion.
+ *
+ * Traditional `REPLACE` traversal is never deferred because every required child must be ready
+ * before its parent disappears. `ADD` traversal and skip-LOD replacement traversal can safely keep
+ * already available ancestors while peripheral descendants wait.
+ */
+export function isFoveatedRequestDeferred(parameters: FoveatedDeferralParameters): boolean {
+  const coneSize = Number.isFinite(parameters.foveatedConeSize)
+    ? Math.min(Math.max(parameters.foveatedConeSize, 0), 1)
+    : 1;
+  const replacementRefinement = parameters.refinement === TILE_REFINEMENT.REPLACE;
+  if (
+    (replacementRefinement && !parameters.skipLevelOfDetail) ||
+    !parameters.foveatedScreenSpaceError ||
+    coneSize >= 1 ||
+    (replacementRefinement &&
+      parameters.skipLevelOfDetail &&
+      parameters.priorityProgressiveResolution)
+  ) {
+    return false;
+  }
+
+  const verticalFieldOfView =
+    Number.isFinite(parameters.verticalFieldOfView) && parameters.verticalFieldOfView > 0
+      ? parameters.verticalFieldOfView
+      : Math.PI / 3;
+  const maximumFoveatedFactor = 1 - Math.cos(verticalFieldOfView * 0.5);
+  const coneFactor = coneSize * maximumFoveatedFactor;
+  if (parameters.foveatedFactor <= coneFactor || maximumFoveatedFactor <= coneFactor) {
+    return false;
+  }
+
+  const interpolationAmount = Math.min(
+    Math.max((parameters.foveatedFactor - coneFactor) / (maximumFoveatedFactor - coneFactor), 0),
+    1
+  );
+  const interpolationCallback =
+    typeof parameters.interpolationCallback === 'function'
+      ? parameters.interpolationCallback
+      : interpolateLinearly;
+  const interpolatedRelaxation = interpolationCallback(
+    parameters.minimumScreenSpaceErrorRelaxation,
+    parameters.maximumScreenSpaceError,
+    interpolationAmount
+  );
+  const screenSpaceErrorRelaxation = Number.isFinite(interpolatedRelaxation)
+    ? Math.min(Math.max(interpolatedRelaxation, 0), parameters.maximumScreenSpaceError)
+    : 0;
+  const screenSpaceError =
+    parameters.screenSpaceError === 0 && parameters.parentScreenSpaceError !== undefined
+      ? parameters.parentScreenSpaceError * 0.5
+      : parameters.screenSpaceError;
+
+  return parameters.maximumScreenSpaceError - screenSpaceErrorRelaxation <= screenSpaceError;
+}
+
+/**
+ * Encodes request priority into independent decimal bands.
+ *
+ * Smaller values load first. Moving-camera deferral is the strongest penalty, followed by the
+ * progressive-coverage flag, distance from the view center, and finally the established reverse-
+ * SSE order. Normalizing reverse SSE preserves its relative ordering while preventing one metric
+ * from spilling into the next priority band.
+ */
+export function calculateTileRequestPriority(parameters: TileRequestPriorityParameters): number {
+  const normalizedReverseScreenSpaceError =
+    parameters.rootScreenSpaceError > 0
+      ? Math.min(
+          Math.max(parameters.reverseScreenSpaceError / parameters.rootScreenSpaceError, 0),
+          1
+        )
+      : 0;
+  const preferredSortingDigits = Math.floor(
+    normalizedReverseScreenSpaceError * (PREFERRED_SORTING_DIGITS - 1)
+  );
+  const normalizedFoveatedFactor = Number.isFinite(parameters.foveatedFactor)
+    ? Math.min(Math.max(parameters.foveatedFactor, 0), 1)
+    : 0;
+  const foveatedSortingDigits =
+    Math.floor(normalizedFoveatedFactor * (PREFERRED_SORTING_DIGITS - 1)) * FOVEATED_SORTING_SCALE;
+  const progressiveResolutionDigits = parameters.priorityProgressiveResolution
+    ? 0
+    : PROGRESSIVE_RESOLUTION_PENALTY;
+  const foveatedDeferralDigits = parameters.priorityDeferred ? FOVEATED_DEFERRAL_PENALTY : 0;
+
+  return (
+    foveatedDeferralDigits +
+    progressiveResolutionDigits +
+    foveatedSortingDigits +
+    preferredSortingDigits
+  );
+}

--- a/modules/tiles/src/types.ts
+++ b/modules/tiles/src/types.ts
@@ -13,6 +13,8 @@ export type Viewport = {
   height: number;
   width: number;
   zoom: number;
+  /** Perspective vertical field of view in degrees, when exposed by the viewport. */
+  fovy?: number;
   /** Whether this viewport uses an orthographic projection. */
   orthographic?: boolean;
   /**

--- a/modules/tiles/test/tileset/helpers/get-frame-state.spec.ts
+++ b/modules/tiles/test/tileset/helpers/get-frame-state.spec.ts
@@ -4,6 +4,7 @@
 
 import test from 'tape-promise/tape';
 import {getFrameState} from '@loaders.gl/tiles';
+import {updateCameraMotionState} from '../../../src/tileset-3d/helpers/frame-state';
 import {WebMercatorViewport, FirstPersonView} from '@deck.gl/core';
 import {equals, Vector3} from '@math.gl/core';
 import {Ellipsoid} from '@math.gl/geospatial';
@@ -39,8 +40,8 @@ test('getFrameState', t => {
     'camera.position should match.'
   );
   t.ok(
-    equals(results.camera.direction, expected.camera.direction, EPSILON),
-    'camera.direction should match.'
+    Math.abs(new Vector3(results.camera.direction).magnitude() - 1) < EPSILON,
+    'camera.direction should be normalized.'
   );
   t.ok(equals(results.camera.up, expected.camera.up, EPSILON), 'camera.up should match.');
   t.ok(
@@ -55,6 +56,15 @@ test('getFrameState', t => {
     results.dynamicScreenSpaceErrorDensity,
     0,
     'dynamic SSE density should be initialized for the tileset traversal.'
+  );
+  t.ok(
+    Math.abs(results.camera.verticalFieldOfView - (viewport.fovy * Math.PI) / 180) < EPSILON,
+    'camera.verticalFieldOfView should use viewport degrees converted to radians.'
+  );
+  t.equals(
+    results.camera.timeSinceMovement,
+    Number.POSITIVE_INFINITY,
+    'standalone frame states should not defer requests.'
   );
   t.equals(results.sseDenominator, results.sseDenominator, 'sseDenominator should match.');
   t.equals(results.cullingVolume.planes.length, 6, 'Should have 6 planes.');
@@ -97,5 +107,41 @@ test('getFrameState#cullingVolume', t => {
     }
   }
 
+  t.end();
+});
+
+test('updateCameraMotionState#tracks position and direction changes', t => {
+  const initialUpdate = updateCameraMotionState(undefined, [1, 2, 3], [0, 0, -1], 1000);
+  t.equals(
+    initialUpdate.timeSinceMovement,
+    Number.POSITIVE_INFINITY,
+    'treats the first camera observation as stationary'
+  );
+
+  const movedUpdate = updateCameraMotionState(initialUpdate.state, [1, 2, 4], [0, 0, -1], 1200);
+  t.equals(movedUpdate.timeSinceMovement, 0, 'records camera position movement');
+
+  const stationaryUpdate = updateCameraMotionState(movedUpdate.state, [1, 2, 4], [0, 0, -1], 1350);
+  t.equals(stationaryUpdate.timeSinceMovement, 0.15, 'measures stationary time in seconds');
+
+  const numericallyStableUpdate = updateCameraMotionState(
+    stationaryUpdate.state,
+    [1, 2, 4 + 1e-6],
+    [0, 0, -1 + 1e-8],
+    1375
+  );
+  t.equals(
+    numericallyStableUpdate.timeSinceMovement,
+    0.175,
+    'ignores sub-epsilon numeric noise in an otherwise stable camera pose'
+  );
+
+  const rotatedUpdate = updateCameraMotionState(
+    numericallyStableUpdate.state,
+    [1, 2, 4],
+    [0, 1, 0],
+    1400
+  );
+  t.equals(rotatedUpdate.timeSinceMovement, 0, 'records camera direction movement');
   t.end();
 });

--- a/modules/tiles/test/tileset/tiles-3d-lod.spec.ts
+++ b/modules/tiles/test/tileset/tiles-3d-lod.spec.ts
@@ -85,6 +85,16 @@ test('getTiles3DScreenSpaceError#preserves perspective calculation', t => {
   t.end();
 });
 
+test('getTiles3DScreenSpaceError#scales progressive-resolution perspective height', t => {
+  const tile = createTile();
+  t.equals(
+    getTiles3DScreenSpaceError(tile, createFrameState(), false, 0.3),
+    15,
+    'calculates coarse-pass SSE at 30% of logical viewport height'
+  );
+  t.end();
+});
+
 test('getTiles3DScreenSpaceError#uses orthographic logical-pixel scale', t => {
   const tile = createTile();
   const frameState = createFrameState({
@@ -104,6 +114,21 @@ test('getTiles3DScreenSpaceError#uses orthographic logical-pixel scale', t => {
     getTiles3DScreenSpaceError(tile, frameState, false),
     5,
     'orthographic SSE is independent of camera distance and viewport height'
+  );
+  t.end();
+});
+
+test('getTiles3DScreenSpaceError#scales progressive-resolution orthographic pixels', t => {
+  const tile = createTile();
+  t.equals(
+    getTiles3DScreenSpaceError(
+      tile,
+      createFrameState({viewport: {orthographic: true, metersPerPixel: 2}}),
+      false,
+      0.3
+    ),
+    1.5,
+    'represents the same tile in a reduced-height logical-pixel pass'
   );
   t.end();
 });

--- a/modules/tiles/test/tileset/tiles-3d-lod.spec.ts
+++ b/modules/tiles/test/tileset/tiles-3d-lod.spec.ts
@@ -95,6 +95,20 @@ test('getTiles3DScreenSpaceError#scales progressive-resolution perspective heigh
   t.end();
 });
 
+test('getTiles3DScreenSpaceError#composes progressive and dynamic perspective SSE', t => {
+  const tile = createTile();
+  tile.tileset.options.dynamicScreenSpaceError = true;
+  const frameState = createFrameState({dynamicScreenSpaceErrorDensity: 0.01});
+  const expectedReduction = getDynamicScreenSpaceError(100, 0.01, 24);
+
+  t.equals(
+    getTiles3DScreenSpaceError(tile, frameState, false, 0.3),
+    15 - expectedReduction,
+    'scales the projection term before applying the unchanged dynamic SSE reduction'
+  );
+  t.end();
+});
+
 test('getTiles3DScreenSpaceError#uses orthographic logical-pixel scale', t => {
   const tile = createTile();
   const frameState = createFrameState({

--- a/modules/tiles/test/tileset/tiles-3d-request-priority.spec.ts
+++ b/modules/tiles/test/tileset/tiles-3d-request-priority.spec.ts
@@ -1,0 +1,178 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
+// This file tests behavior derived from the Cesium code base under Apache 2 license.
+
+import test from 'tape-promise/tape';
+import {BoundingSphere} from '@math.gl/culling';
+import {TILE_REFINEMENT} from '../../src/constants';
+import {TilesetTraverser} from '../../src/tileset-3d/common/tileset-traverser';
+import {
+  calculateFoveatedFactor,
+  calculateTileRequestPriority,
+  interpolateLinearly,
+  isFoveatedRequestDeferred,
+  isProgressiveResolutionPriority
+} from '../../src/tileset-3d/helpers/tiles-3d-request-priority';
+
+const TEST_CAMERA = {
+  position: [0, 0, 0],
+  direction: [0, 0, 1]
+};
+
+test('request priority#foveated factor accounts for bounding volume', t => {
+  const centeredTile = new BoundingSphere([0, 0, 10], 1);
+  const peripheralTile = new BoundingSphere([5, 0, 10], 1);
+  const intersectingTile = new BoundingSphere([4, 0, 10], 4);
+
+  t.equals(
+    calculateFoveatedFactor(centeredTile, TEST_CAMERA),
+    0,
+    'centers a tile on the view axis'
+  );
+  t.ok(
+    calculateFoveatedFactor(peripheralTile, TEST_CAMERA) > 0,
+    'assigns a positive angular factor to a peripheral tile'
+  );
+  t.equals(
+    calculateFoveatedFactor(intersectingTile, TEST_CAMERA),
+    0,
+    'keeps a large volume at center priority when it intersects the view axis'
+  );
+  t.end();
+});
+
+test('request priority#progressive resolution promotes coverage and its SSE leaf', t => {
+  t.ok(
+    isProgressiveResolutionPriority(12, undefined, 8, 0.3),
+    'promotes a tile above the reduced-height SSE threshold'
+  );
+  t.ok(
+    isProgressiveResolutionPriority(6, 12, 8, 0.3),
+    'promotes the first child that crosses below the reduced-height threshold'
+  );
+  t.notOk(
+    isProgressiveResolutionPriority(6, 7, 8, 0.3),
+    'does not promote detail below the coarse coverage leaf'
+  );
+  for (const invalidFraction of [0, -0.1, 0.6, Number.NaN]) {
+    t.notOk(
+      isProgressiveResolutionPriority(12, undefined, 8, invalidFraction),
+      `disables progressive priority for ${String(invalidFraction)}`
+    );
+  }
+  t.end();
+});
+
+test('request priority#foveated deferral preserves refinement continuity', t => {
+  const deferralParameters = {
+    refinement: TILE_REFINEMENT.ADD,
+    skipLevelOfDetail: false,
+    foveatedScreenSpaceError: true,
+    foveatedConeSize: 0.1,
+    minimumScreenSpaceErrorRelaxation: 0,
+    interpolationCallback: interpolateLinearly,
+    foveatedFactor: 1 - Math.cos(Math.PI / 6),
+    verticalFieldOfView: Math.PI / 3,
+    screenSpaceError: 8,
+    maximumScreenSpaceError: 8,
+    priorityProgressiveResolution: false
+  };
+
+  t.ok(isFoveatedRequestDeferred(deferralParameters), 'defers eligible peripheral ADD content');
+  t.notOk(
+    isFoveatedRequestDeferred({...deferralParameters, foveatedFactor: 0}),
+    'does not defer content inside the center cone'
+  );
+  t.notOk(
+    isFoveatedRequestDeferred({...deferralParameters, foveatedConeSize: Number.NaN}),
+    'safely disables deferral for an invalid cone size'
+  );
+  t.notOk(
+    isFoveatedRequestDeferred({
+      ...deferralParameters,
+      refinement: TILE_REFINEMENT.REPLACE
+    }),
+    'never defers traditional REPLACE children required to avoid holes'
+  );
+  t.notOk(
+    isFoveatedRequestDeferred({
+      ...deferralParameters,
+      refinement: TILE_REFINEMENT.REPLACE,
+      skipLevelOfDetail: true,
+      priorityProgressiveResolution: true
+    }),
+    'does not defer progressive REPLACE coverage when skip LOD is enabled'
+  );
+  t.ok(
+    isFoveatedRequestDeferred({
+      ...deferralParameters,
+      refinement: TILE_REFINEMENT.REPLACE,
+      skipLevelOfDetail: true
+    }),
+    'allows non-progressive REPLACE descendants to wait when an ancestor remains visible'
+  );
+  t.end();
+});
+
+test('request priority#uses independent scheduling bands', t => {
+  const basePriority = {
+    priorityProgressiveResolution: false,
+    priorityDeferred: false,
+    foveatedFactor: 0,
+    reverseScreenSpaceError: 0,
+    rootScreenSpaceError: 100
+  };
+  const progressivePriority = calculateTileRequestPriority({
+    ...basePriority,
+    priorityProgressiveResolution: true,
+    reverseScreenSpaceError: 100
+  });
+  const centerPriority = calculateTileRequestPriority(basePriority);
+  const peripheralPriority = calculateTileRequestPriority({...basePriority, foveatedFactor: 0.1});
+  const deferredPriority = calculateTileRequestPriority({
+    ...basePriority,
+    priorityDeferred: true
+  });
+
+  t.ok(progressivePriority < centerPriority, 'loads coarse progressive coverage first');
+  t.ok(centerPriority < peripheralPriority, 'loads viewport-center content before the periphery');
+  t.ok(peripheralPriority < deferredPriority, 'keeps deferred content behind stationary work');
+  t.ok(
+    calculateTileRequestPriority({...basePriority, reverseScreenSpaceError: 10}) <
+      calculateTileRequestPriority({...basePriority, reverseScreenSpaceError: 90}),
+    'preserves reverse-SSE order inside the same priority band'
+  );
+  t.end();
+});
+
+test('TilesetTraverser#releases deferred requests after the movement delay', t => {
+  const traverser = new TilesetTraverser({});
+  const tile = {
+    id: 'peripheral-tile',
+    priorityDeferred: true,
+    tileset: {options: {foveatedTimeDelay: 0.2}},
+    hasUnloadedContent: true,
+    contentExpired: false,
+    _requestedFrame: 0,
+    _priority: 0,
+    _getPriority: () => 4
+  };
+  const movingFrameState = {
+    frameNumber: 1,
+    camera: {timeSinceMovement: 0.1}
+  };
+
+  // @ts-expect-error test supplies the minimal tile and frame-state fields used by loadTile
+  traverser.loadTile(tile, movingFrameState);
+  t.ok(traverser.deferredTiles[tile.id], 'holds the request while the camera is moving');
+  t.notOk(traverser.requestedTiles[tile.id], 'does not issue the held request');
+
+  traverser.reset();
+  // @ts-expect-error test supplies the minimal tile and frame-state fields used by loadTile
+  traverser.loadTile(tile, {...movingFrameState, camera: {timeSinceMovement: 0.2}});
+  t.ok(traverser.requestedTiles[tile.id], 'releases the request when the delay expires');
+  t.equals(tile._priority, 4, 'calculates normal request priority after release');
+  t.end();
+});

--- a/modules/tiles/test/tileset/tileset-traverser.spec.ts
+++ b/modules/tiles/test/tileset/tileset-traverser.spec.ts
@@ -15,6 +15,14 @@ test('Tileset3D#traverser base class', async t => {
   const tileset = new Tileset3D(source);
   await tileset.tilesetInitializationPromise;
 
+  t.equals(
+    tileset.options.progressiveResolutionHeightFraction,
+    0.3,
+    'uses the progressive-resolution default'
+  );
+  t.equals(tileset.options.foveatedScreenSpaceError, true, 'enables foveated priority by default');
+  t.equals(tileset.options.foveatedTimeDelay, 0.2, 'uses the moving-camera delay default');
+
   const traverser = new TilesetTraverser({
     basePath: tileset.basePath,
     onTraversalEnd: traversalEnd


### PR DESCRIPTION
## Goals

- Improve perceived first-render latency by loading coarse viewport coverage before fine detail.
- Prioritize perspective tiles near the camera view axis and avoid unnecessary peripheral work during camera motion.
- Preserve refinement continuity, orthographic behavior, dynamic SSE, final SSE/LOD targets, and I3S LOD semantics.
- Make the complete 3D Tiles runtime pipeline understandable through linked concepts documentation and precise TSDoc.

## Changes

- Add a progressive-resolution SSE pass using a configurable logical viewport-height fraction, including coarse SSE-leaf promotion.
- Compose progressive perspective SSE with dynamic SSE by scaling the projection term first and then applying the unchanged view-dependent reduction.
- Add bounding-volume-aware foveated priority and stable lexicographic priority bands.
- Track camera position and direction independently per viewport and briefly defer eligible peripheral requests while the camera is moving.
- Schedule a follow-up traversal when the deferral window expires, including when no new camera update arrives.
- Never motion-defer traditional `REPLACE` requests or progressive skip-LOD coverage; retain center-first ordering without risking refinement holes.
- Derive normalized camera direction from the viewport frustum when the concrete viewport does not expose the legacy structural `cameraDirection` field.
- Add public scheduling options, defaults, callback types, and comprehensive TSDoc, including units, ranges, fallbacks, parameters, return values, and refinement-safety invariants.
- Add a sidebar-linked 3D Tiles runtime concepts suite covering:
  - tile hierarchy and `ADD`/`REPLACE` refinement;
  - perspective, orthographic, and dynamic SSE/LOD;
  - progressive loading, foveated requests, camera-motion deferral, and the full request-priority order;
  - cache and memory behavior;
  - runtime tuning, multi-viewport behavior, diagnostics, and troubleshooting.
- Cross-link the module overview and `Tileset3D` API to the concepts suite, and correct the documented `maximumMemoryUsage` default to the runtime value of 32 MB.
- Add separate What's New bullets for transform-correct LOD, projection-correct SSE, dynamic SSE, required-extension validation, progressive requests, foveated requests, motion deferral, diagnostics, and the concepts suite.
- Add shared Node/browser coverage for progressive SSE, progressive/dynamic composition, foveated factors, priority bands, safe deferral, camera-motion tracking, and default options.

A foveated request remains an ordinary tile fetch: the term describes client-side ordering and temporary refinement-safe deferral, not a new HTTP request type or server feature. The behavior and defaults adapt the [CesiumJS 1.143 request-priority implementation](https://github.com/CesiumGS/cesium/blob/1.143/packages/engine/Source/Scene/Cesium3DTile.js) to loaders.gl's structural viewports and request scheduler.

## Validation

- `yarn install`
- `yarn lint fix`
- `yarn build`
- `yarn test-node` — 1,679 passed; 75 skipped
- `yarn test-headless` — 1,676 passed; 60 skipped
- `cd website && yarn install && yarn build`
- Generated concepts pages, sidebar ordering, navigation, and internal links inspected; no new broken links

Partially addresses #1245 without closing the tracker.

## Related work

- Rebased onto master after #3502 merged. Progressive traversal preserves dynamic SSE's established reduction order and adds focused composition coverage.
- #3476 extends `getFrameState` for adjacent camera/culling work. This PR uses an extensible options-object signature so those fields can be combined if it lands.
- Excludes the unrelated implicit-tiling and bounding-region work in #3194 and #3176.
