### PR TITLE
Add draft glTF 2.1 thumbnail support

### DIFF
--- a/docs/modules/gltf/api-reference/gltf-loader.md
+++ b/docs/modules/gltf/api-reference/gltf-loader.md
@@ -42,6 +42,8 @@ The `GLTFLoader` aims to take care of as much processing as possible, while rema
 
 Draft glTF 2.1 readiness includes the [new accessor component type definitions](/docs/modules/gltf/formats/gltf#accessor-component-types). `GLTFScenegraph` and `postProcessGLTF` expose these values through the corresponding JavaScript typed arrays.
 
+The loader also supports draft glTF 2.1 [thumbnails](/docs/modules/gltf/formats/gltf#draft-gltf-21-thumbnails). When `asset.thumbnail` references an image, `gltf.loadImages: true` loads that image even if it is not used by a texture.
+
 The GLTF Loader returns an object with a `json` field containing the glTF Scenegraph. In its basic mode, the `GLTFLoader` does not modify the loaded JSON in any way. Instead, the results of additional processing are placed in parallel top-level fields such as `buffers` and `images`. This ensures that applications that want to work with the standard glTF data structure can do so.
 
 Optionally, the loaded gltf can be "post processed", which lightly annotates and transforms the loaded JSON structure to make it easier to use. Refer to [postProcessGLTF](post-process-gltf) for details.
@@ -63,7 +65,7 @@ Note: while supported, synchronous parsing of glTF (e.g. using `parseSync()`) ha
 | `gltf.loadBuffers`        | Boolean | `false` | Fetch any referenced binary buffer files (and decode base64 encoded URIS).   |
 | `gltf.loadFiles`          | Boolean | `false` | Resolve draft glTF 2.1 `files` entries from URIs or buffer views.             |
 | `gltf.loadExternalAssets` | Boolean | `false` | Recursively parse draft glTF 2.1 external assets instantiated by scene nodes. |
-| `gltf.loadImages`         | Boolean | `false` | Load any referenced image files (and decode base64 encoded URIS).            |
+| `gltf.loadImages`         | Boolean | `false` | Load images referenced by textures or the draft glTF 2.1 thumbnail.          |
 | `gltf.decompressMeshes`   | Boolean | `true`  | Decompress Draco compressed meshes (if DracoLoader available).               |
 | `gltf.normalize`          | Boolean | `false` | Optional, best-effort attempt at converting glTF v1 files to glTF2 format.   |
 

--- a/docs/modules/gltf/api-reference/post-process-gltf.md
+++ b/docs/modules/gltf/api-reference/post-process-gltf.md
@@ -102,6 +102,7 @@ Remarks:
 
 - `image.image` - Populated from the supplied `gltf.images` array. This array is populated by the `GLTFLoader` via `options.loadImages: true`):
 - `image.uri` - If the loaded image in the `images` array is not available, uses `gltf.baseUri` to resolve a relative URI and replaces this value.
+- `asset.thumbnail` - A draft glTF 2.1 thumbnail index is replaced by the corresponding processed image object.
 
 ### Materials
 

--- a/docs/modules/gltf/formats/gltf.md
+++ b/docs/modules/gltf/formats/gltf.md
@@ -38,6 +38,18 @@ rejects cyclical asset graphs.
 
 This support follows the Khronos [External Assets draft](https://github.com/KhronosGroup/glTF/issues/2586).
 
+## Draft glTF 2.1 Thumbnails
+
+Draft glTF 2.1 adds `asset.thumbnail`, an index into the top-level `images` array. The referenced
+image provides an optional preview that applications can display without rendering the scene.
+
+`GLTFLoader` treats the thumbnail as a referenced image, so `gltf.loadImages: true` loads it even
+when no texture uses that image. The unmodified index remains available at
+`gltf.json.asset.thumbnail`; [`postProcessGLTF()`](/docs/modules/gltf/api-reference/post-process-gltf)
+resolves it to the corresponding processed image object.
+
+This support follows the Khronos [Thumbnails draft](https://github.com/KhronosGroup/glTF/issues/2593).
+
 ## Variants
 
 A glTF file uses one of two possible file extensions: .gltf (JSON/ASCII) or .glb (binary). Both .gltf and .glb files may reference external binary and texture resources. Alternatively, both formats may be self-contained by directly embedding binary data buffers (as base64-encoded strings in .gltf files or as raw byte arrays in .glb files).

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -28,6 +28,7 @@ Release Date: 2026
 - [`GLTFLoader`](/docs/modules/gltf/api-reference/gltf-loader) adds draft [glTF 2.1 accessor component types](/docs/modules/gltf/formats/gltf#accessor-component-types), including signed 32-bit integers, 16- and 64-bit floats, and signed and unsigned 64-bit integers.
 - [`GLTFLoader`](/docs/modules/gltf/api-reference/gltf-loader) adds opt-in loading of draft glTF 2.1 [unified file references](/docs/modules/gltf/formats/gltf) from URIs or buffer views, plus virtual package lookup through `resolveGLTFFile()`.
 - [`GLTFLoader`](/docs/modules/gltf/api-reference/gltf-loader) can recursively load draft glTF 2.1 [external assets](/docs/modules/gltf/formats/gltf), including relative dependencies, embedded virtual packages, shared-reference caching, and cycle detection.
+- [`GLTFLoader`](/docs/modules/gltf/api-reference/gltf-loader) loads draft glTF 2.1 [thumbnail images](/docs/modules/gltf/formats/gltf#draft-gltf-21-thumbnails) referenced by `asset.thumbnail`, and [`postProcessGLTF()`](/docs/modules/gltf/api-reference/post-process-gltf) resolves the thumbnail index to the processed image.
 
 **@loaders.gl/las** 
 

--- a/modules/gltf/src/lib/api/post-process-gltf.ts
+++ b/modules/gltf/src/lib/api/post-process-gltf.ts
@@ -8,6 +8,7 @@ import type {ParseGLTFOptions} from '../parsers/parse-gltf';
 import type {
   GLTF,
   GLTFAccessor,
+  GLTFAsset,
   GLTFBufferView,
   GLTFCamera,
   GLTFImage,
@@ -22,6 +23,7 @@ import type {
 
 import type {
   GLTFPostprocessed,
+  Asset,
   GLTFAccessorPostprocessed,
   GLTFBufferPostprocessed,
   GLTFBufferViewPostprocessed,
@@ -162,6 +164,7 @@ class GLTFPostProcessor {
     if (gltf.images) {
       json.images = gltf.images.map((image, i) => this._resolveImage(image, i));
     }
+    json.asset = this._resolveAsset(gltf.asset);
     if (gltf.samplers) {
       json.samplers = gltf.samplers.map((sampler, i) => this._resolveSampler(sampler, i));
     }
@@ -255,6 +258,14 @@ class GLTFPostProcessor {
   }
 
   // PARSING HELPERS
+
+  /** Resolve the draft glTF 2.1 thumbnail image reference in asset metadata. */
+  _resolveAsset(gltfAsset: GLTFAsset): Asset {
+    return {
+      ...gltfAsset,
+      thumbnail: gltfAsset.thumbnail !== undefined ? this.getImage(gltfAsset.thumbnail) : undefined
+    };
+  }
 
   _resolveScene(scene: GLTFScene, index: number): GLTFScenePostprocessed {
     return {

--- a/modules/gltf/src/lib/parsers/parse-gltf.ts
+++ b/modules/gltf/src/lib/parsers/parse-gltf.ts
@@ -448,9 +448,13 @@ async function loadImages(gltf: GLTFWithBuffers, options, context: LoaderContext
   return await Promise.all(promises);
 }
 
-/** Make sure we only load images that are actually referenced by textures */
+/** Return image indices referenced by textures or draft glTF 2.1 asset metadata. */
 function getReferencesImageIndices(gltf: GLTFWithBuffers): number[] {
   const imageIndices = new Set<number>();
+
+  if (gltf.json.asset.thumbnail !== undefined) {
+    imageIndices.add(gltf.json.asset.thumbnail);
+  }
 
   const textures = gltf.json.textures || [];
   for (const texture of textures) {

--- a/modules/gltf/src/lib/types/gltf-json-schema.ts
+++ b/modules/gltf/src/lib/types/gltf-json-schema.ts
@@ -213,6 +213,11 @@ export type GLTFAsset = {
    * The minimum glTF version that this asset targets.
    */
   minVersion?: string;
+  /**
+   * The index of an image that provides a preview of this glTF asset.
+   * Draft glTF 2.1.
+   */
+  thumbnail?: GLTFId;
   extensions?: Record<string, any>;
   extras?: any;
   // [k: string]: any;

--- a/modules/gltf/src/lib/types/gltf-postprocessed-schema.ts
+++ b/modules/gltf/src/lib/types/gltf-postprocessed-schema.ts
@@ -242,6 +242,11 @@ export type Asset = {
    * The minimum glTF version that this asset targets.
    */
   minVersion?: string;
+  /**
+   * The image that provides a preview of this glTF asset.
+   * Draft glTF 2.1.
+   */
+  thumbnail?: GLTFImagePostprocessed;
   extensions?: any;
   extras?: any;
   // [k: string]: any;

--- a/modules/gltf/src/lib/types/gltf-zod-schema.ts
+++ b/modules/gltf/src/lib/types/gltf-zod-schema.ts
@@ -112,6 +112,7 @@ export const GLTFAssetSchema = z
     generator: z.string().optional(),
     version: z.string(),
     minVersion: z.string().optional(),
+    thumbnail: GLTFIdSchema.optional(),
     ...GLTF_PROPERTY_SHAPE
   })
   .catchall(z.unknown());

--- a/modules/gltf/test/gltf-loader.spec.ts
+++ b/modules/gltf/test/gltf-loader.spec.ts
@@ -11,6 +11,8 @@ import {createGLBV3} from './test-utils/create-glb-v3';
 
 const GLTF_BINARY_URL = '@loaders.gl/gltf/test/data/gltf-2.0/2CylinderEngine.glb';
 const GLTF_JSON_URL = '@loaders.gl/gltf/test/data/gltf-2.0/2CylinderEngine.gltf';
+const PNG_DATA_URL =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACAQMAAABIeJ9nAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAGUExURf///wAAAFXC034AAAAMSURBVAjXY3BgaAAAAUQAwetZAwkAAAAASUVORK5CYII=';
 
 // Extracted from Cesium 3D Tiles
 const GLB_TILE_WITH_DRACO_URL = '@loaders.gl/gltf/test/data/3d-tiles/143.glb';
@@ -35,6 +37,19 @@ test('GLTFLoader#load(binary)', async t => {
   const data = await load(GLTF_BINARY_URL, GLTFLoader);
   t.ok(data.json.asset, 'GLTFLoader returned parsed data');
 
+  t.end();
+});
+
+test('GLTFLoader#parse() loads a draft glTF 2.1 thumbnail image', async t => {
+  const gltf = await parse(
+    JSON.stringify({
+      asset: {version: '2.1', thumbnail: 0},
+      images: [{uri: PNG_DATA_URL}]
+    }),
+    GLTFLoader
+  );
+
+  t.ok(gltf.images?.[0], 'loads an image referenced only by asset.thumbnail');
   t.end();
 });
 

--- a/modules/gltf/test/gltf-zod-schema.spec.ts
+++ b/modules/gltf/test/gltf-zod-schema.spec.ts
@@ -22,6 +22,17 @@ describe('GLTFSchema', () => {
     expect(GLTFSchema.safeParse({asset: {version: '2.0'}, scene: -1}).success).toBe(false);
   });
 
+  it('validates draft glTF 2.1 thumbnail references', () => {
+    expect(
+      GLTFSchema.safeParse({
+        asset: {version: '2.1', thumbnail: 0},
+        images: [{uri: 'thumbnail.png'}]
+      }).success
+    ).toBe(true);
+    expect(GLTFSchema.safeParse({asset: {version: '2.1', thumbnail: -1}}).success).toBe(false);
+    expect(GLTFSchema.safeParse({asset: {version: '2.1', thumbnail: 0.5}}).success).toBe(false);
+  });
+
   it('accepts extension-defined animation target paths', () => {
     const document = {
       asset: {version: '2.0'},

--- a/modules/gltf/test/lib/api/post-process-gltf.spec.ts
+++ b/modules/gltf/test/lib/api/post-process-gltf.spec.ts
@@ -52,3 +52,18 @@ test('gltf#postProcessGLTF', t => {
   }
   t.end();
 });
+
+test('gltf#postProcessGLTF resolves a draft glTF 2.1 thumbnail', t => {
+  const json = postProcessGLTF({
+    json: {
+      asset: {version: '2.1', thumbnail: 0},
+      images: [{uri: 'thumbnail.png'}]
+    },
+    buffers: [],
+    images: [{width: 2, height: 2}]
+  } as unknown as GLTFWithBuffers);
+
+  t.equal(json.asset.thumbnail, json.images[0], 'resolves the thumbnail to the processed image');
+  t.equal(json.asset.thumbnail?.image.width, 2, 'preserves the decoded thumbnail image');
+  t.end();
+});


### PR DESCRIPTION
## Goals

- Add the next focused glTF 2.1 readiness tranche on top of the external-assets work.
- Support first-class asset thumbnails without requiring applications to render the scene.
- Reuse the existing glTF image loading and postprocessing paths.

## Changes

- Add the draft `asset.thumbnail` image index to the public TypeScript and Zod schemas.
- Treat thumbnails as referenced images so `gltf.loadImages: true` loads them even when no texture uses the image.
- Resolve `asset.thumbnail` to the corresponding processed image in `postProcessGLTF()`.
- Add shared coverage for schema validation, data-URI thumbnail loading, and postprocessed image resolution.
- Document thumbnail behavior in the glTF format guide, loader API, postprocessing reference, and v5 release notes.

This is a stacked PR based on `codex/gltf-21-external-assets` / #3508. It should be retargeted to `master` after #3508 merges.

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn vitest run --project node modules/gltf/test` — 84 passed
- `yarn test-node` — 1,664 passed, 75 skipped
- `yarn test-headless` — 1,660 passed, 60 skipped