### PR TITLE
perf(las): selectively decode PDRF 7 into Arrow

### DIFF
--- a/docs/modules/las/api-reference/las-loader.md
+++ b/docs/modules/las/api-reference/las-loader.md
@@ -42,3 +42,9 @@ const table = await load(url, LASLoader, {
 | `options.las.fp64`       | `number`             | `false`    | If `true`, positions are stored in 64-bit floats instead of 32-bit.                                                                                              |
 | `options.las.colorDepth` | `number` or `string` | `8`        | Whether colors encoded using 8 or 16 bits? Can be set to `'auto'`. Note: LAS specification recommends 16 bits.                                                   |
 | `options.onProgress`     | `function`           | -          | Callback when a new chunk of data is read. Only works on the main thread.                                                                                        |
+
+## TypeScript LAZ Streaming
+
+With `las.backend: 'typescript'`, `parseInBatches` consumes compressed LAZ input incrementally and emits Arrow table batches after complete LAZ chunks are available. PDRF 7 table parsing selectively decodes the LAZ 1.4 field layers represented by the returned Arrow schema. The raw chunk decoder remains available when complete LAS point records, including currently unexposed fields, are required.
+
+This is chunk-streaming rather than point-streaming: an individual compressed LAZ chunk must be available before its point rows can be emitted. See the [LAS/LAZ format implementation limits](/docs/modules/las/formats/las#current-implementation-limits) for supported point formats and remaining limitations.

--- a/docs/modules/las/formats/las.md
+++ b/docs/modules/las/formats/las.md
@@ -64,9 +64,17 @@ LAS is the uncompressed exchange format. LAZ is the losslessly compressed form d
 | LAZ 1.4 point formats 6, 7, 8 | Supported for COPC-style chunks and fixed-size full-file LAZ chunks. |
 | LAZ point formats 4, 5, 9, 10 | Not supported. These add waveform packet references. |
 | Extra bytes in LAZ 1.4 chunks | Supported at the raw byte level when metadata supplies the record length. |
-| Selective decompression | Not implemented. |
+| Selective decompression | Supported for PDRF 7 Arrow output. The decoder skips independent LAZ 1.4 layers that are not represented in the returned table while preserving complete raw-record decoding through the chunk APIs. |
 | True streaming decode | Partial. Full-file LAZ `parseInBatches` can consume incoming bytes and emit raw point batches after complete compressed chunks are available. Point-level arithmetic decode inside a compressed chunk is not implemented yet. |
 | LAZ encoding | Not implemented. |
+
+#### Selective LAZ 1.4 Decoding
+
+The TypeScript parser writes positions, intensity, classification, and RGB values directly into Arrow column buffers. PDRF 7 stores groups of fields in independent compressed layers. The parser therefore avoids arithmetic decoding for scan flags, scan angle, user data, point source ID, GPS time, and Extra Bytes layers that are not currently exposed in the returned table, using a specialized batch loop for its common XYZ, intensity, classification, and RGB output.
+
+This optimization applies only to table parsing. `decodeLAZChunk()` and the raw cursor API continue to decode every field and return complete LAS point records byte-for-byte. A cursor cannot switch between selective table output and raw-record output after decoding starts because skipped arithmetic streams cannot be resumed at the corresponding point.
+
+PDRF 6 and 8 continue to decode complete records before populating Arrow columns. Their selective paths should be enabled only after dedicated fixtures cover their unique fields, especially PDRF 8 NIR values.
 
 ### TypeScript COPC Path
 

--- a/modules/las/test/las-loader.spec.ts
+++ b/modules/las/test/las-loader.spec.ts
@@ -609,6 +609,79 @@ test('TypeScriptLAZ#cursor decodes batches smaller and larger than chunk', async
   t.end();
 });
 
+test('TypeScriptLAZ#cursor point-data output matches full PDRF 7 records', async t => {
+  const {compressed, metadata} = await getCOPCRootChunk();
+  const rawPointData = decodeLAZChunk(compressed, metadata);
+  const rawPointDataView = new DataView(
+    rawPointData.buffer,
+    rawPointData.byteOffset,
+    rawPointData.byteLength
+  );
+  const positions = new Float64Array(metadata.pointCount * 3);
+  const intensities = new Uint16Array(metadata.pointCount);
+  const classifications = new Uint8Array(metadata.pointCount);
+  const rawColors = new Uint16Array(metadata.pointCount * 3);
+  const target = {
+    positions,
+    intensities,
+    classifications,
+    rawColors,
+    pointOffset: 0,
+    scale: [1, 1, 1] as [number, number, number],
+    offset: [0, 0, 0] as [number, number, number]
+  };
+  const cursor = createLAZChunkDecoderCursor(compressed, metadata);
+
+  while (cursor.remainingPointCount > 0) {
+    target.pointOffset = metadata.pointCount - cursor.remainingPointCount;
+    cursor.decodeIntoPointData(target, 17);
+  }
+
+  const expectedPositions = new Float64Array(metadata.pointCount * 3);
+  const expectedIntensities = new Uint16Array(metadata.pointCount);
+  const expectedClassifications = new Uint8Array(metadata.pointCount);
+  const expectedRawColors = new Uint16Array(metadata.pointCount * 3);
+  for (let pointIndex = 0; pointIndex < metadata.pointCount; pointIndex++) {
+    const pointOffset = pointIndex * metadata.pointDataRecordLength;
+    const positionOffset = pointIndex * 3;
+    expectedPositions[positionOffset] = rawPointDataView.getInt32(pointOffset, true);
+    expectedPositions[positionOffset + 1] = rawPointDataView.getInt32(pointOffset + 4, true);
+    expectedPositions[positionOffset + 2] = rawPointDataView.getInt32(pointOffset + 8, true);
+    expectedIntensities[pointIndex] = rawPointDataView.getUint16(pointOffset + 12, true);
+    expectedClassifications[pointIndex] = rawPointDataView.getUint8(pointOffset + 16);
+    expectedRawColors[positionOffset] = rawPointDataView.getUint16(pointOffset + 30, true);
+    expectedRawColors[positionOffset + 1] = rawPointDataView.getUint16(pointOffset + 32, true);
+    expectedRawColors[positionOffset + 2] = rawPointDataView.getUint16(pointOffset + 34, true);
+  }
+
+  t.deepEqual(positions, expectedPositions, 'selected positions match full point records');
+  t.deepEqual(intensities, expectedIntensities, 'selected intensities match full point records');
+  t.deepEqual(
+    classifications,
+    expectedClassifications,
+    'selected classifications match full point records'
+  );
+  t.deepEqual(rawColors, expectedRawColors, 'selected colors match full point records');
+
+  target.pointOffset = 0;
+  const pointDataFirstCursor = createLAZChunkDecoderCursor(compressed, metadata);
+  pointDataFirstCursor.decodeIntoPointData(target, 1);
+  t.throws(
+    () => pointDataFirstCursor.decodeInto(new Uint8Array(metadata.pointDataRecordLength), 0, 1),
+    /Cannot mix raw and point-data decoding/,
+    'cursor rejects switching from selected to raw output'
+  );
+
+  const rawFirstCursor = createLAZChunkDecoderCursor(compressed, metadata);
+  rawFirstCursor.decodeInto(new Uint8Array(metadata.pointDataRecordLength), 0, 1);
+  t.throws(
+    () => rawFirstCursor.decodeIntoPointData(target, 1),
+    /Cannot mix raw and point-data decoding/,
+    'cursor rejects switching from raw to selected output'
+  );
+  t.end();
+});
+
 test('TypeScriptLAZ#decodes single-point legacy point format 0 chunk', t => {
   const expected = createPointFormat0Record();
   const compressed = new Uint8Array(expected.byteLength + 4);

--- a/modules/loader-utils/src/lib/laz/laz-chunk-decoder.ts
+++ b/modules/loader-utils/src/lib/laz/laz-chunk-decoder.ts
@@ -43,6 +43,9 @@ export type LAZChunkTableEntry = {
   byteLength: number;
 };
 
+/** Output mode selected for one stateful LAZ chunk decoder. */
+type LAZChunkDecoderOutputMode = 'raw' | 'point-data';
+
 /** Error raised when a feedable decoder needs more compressed bytes. */
 export class NeedsMoreData extends Error {
   constructor(message: string = 'LAZ chunk decoder needs more compressed data') {
@@ -155,6 +158,8 @@ export class LAZChunkDecoderCursor {
   private stream: ByteReader;
   private decoder: PointDecompressor;
   private pointIndex = 0;
+  /** Output mode selected by the first decode call. */
+  private outputMode: LAZChunkDecoderOutputMode | null = null;
 
   constructor(compressed: ArrayBuffer | ArrayBufferView, metadata: LAZChunkMetadata) {
     this.metadata = metadata;
@@ -175,6 +180,7 @@ export class LAZChunkDecoderCursor {
   /** Decode up to `pointCount` points into `output` at `outputOffset`. */
   decodeInto(output: Uint8Array, outputOffset: number, pointCount: number): number {
     const pointsToDecode = Math.min(pointCount, this.remainingPointCount);
+    this.selectOutputMode('raw', pointsToDecode);
     let targetOffset = outputOffset;
 
     for (let pointIndex = 0; pointIndex < pointsToDecode; pointIndex++) {
@@ -194,6 +200,7 @@ export class LAZChunkDecoderCursor {
         `TypeScript LAZ decoder does not support direct point-data output for point format ${this.metadata.pointDataRecordFormat}`
       );
     }
+    this.selectOutputMode('point-data', pointsToDecode);
 
     if (this.decoder.decompressPointDataBatch) {
       this.decoder.decompressPointDataBatch(target, pointsToDecode);
@@ -205,6 +212,17 @@ export class LAZChunkDecoderCursor {
 
     this.pointIndex += pointsToDecode;
     return pointsToDecode;
+  }
+
+  /** Lock this cursor to one output mode so skipped layered streams cannot be read later. */
+  private selectOutputMode(mode: LAZChunkDecoderOutputMode, pointCount: number): void {
+    if (pointCount === 0) {
+      return;
+    }
+    if (this.outputMode && this.outputMode !== mode) {
+      throw new Error('Cannot mix raw and point-data decoding in one LAZ chunk cursor');
+    }
+    this.outputMode = mode;
   }
 }
 
@@ -1198,6 +1216,14 @@ class Point14Context {
   gpsTimeChange = false;
 }
 
+/** Determines whether Point14 decoding preserves every field or only returned point data. */
+enum Point14DecompressionMode {
+  /** Preserve every field in the raw LAS point record. */
+  Full,
+  /** Decode only fields represented by {@link LAZPointDataTarget}. */
+  PointData
+}
+
 class Point14Decompressor {
   private stream: ByteReader;
   private contexts = Array.from({length: 4}, () => new Point14Context());
@@ -1244,7 +1270,12 @@ class Point14Decompressor {
     return outputOffset + 30;
   }
 
-  decompressPoint(output?: Uint8Array, outputOffset: number = 0): Point14 {
+  decompressPoint(
+    output?: Uint8Array,
+    outputOffset: number = 0,
+    mode: Point14DecompressionMode = Point14DecompressionMode.Full
+  ): Point14 {
+    const decompressOptionalFields = mode === Point14DecompressionMode.Full;
     if (this.lastChannel === -1) {
       const point = this.contexts[0].last;
       if (output) {
@@ -1352,7 +1383,7 @@ class Point14Decompressor {
       );
     }
 
-    if (this.flags.valid) {
+    if (decompressOptionalFields && this.flags.valid) {
       const mergedFlags = mergeFlags(context.last);
       const flags = this.flags.decodeSymbol(context.flagModel[mergedFlags]);
       setEdgeOfFlightLine(context.last, (flags >> 5) & 1);
@@ -1374,24 +1405,24 @@ class Point14Decompressor {
       context.last.intensity = intensity & 0xffff;
     }
 
-    if (scanAngleChanged) {
+    if (decompressOptionalFields && scanAngleChanged) {
       context.last.scanAngle = toInt16(
         context.scanAngle.decompress(this.scanAngle, context.last.scanAngle, gpsTimeChanged ? 1 : 0)
       );
     }
 
-    if (this.userData.valid) {
+    if (decompressOptionalFields && this.userData.valid) {
       const userDataContext = context.last.userData >> 2;
       context.last.userData = this.userData.decodeSymbol(context.userDataModel[userDataContext]);
     }
 
-    if (pointSourceChanged) {
+    if (decompressOptionalFields && pointSourceChanged) {
       context.last.pointSourceId =
         context.pointSourceId.decompress(this.pointSourceId, context.last.pointSourceId, 0) &
         0xffff;
     }
 
-    if (gpsTimeChanged) {
+    if (decompressOptionalFields && gpsTimeChanged) {
       this.decodeGpsTime(context);
     }
     context.gpsTimeChange = gpsTimeChanged;
@@ -2151,9 +2182,14 @@ class PointFormat7Decompressor implements PointDecompressor {
   }
 
   decompressPointData(target: LAZPointDataTarget, targetPointIndex: number): void {
-    const point = this.point.decompressPoint(this.pointScratch, 0);
+    const point = this.point.decompressPoint(
+      this.pointScratch,
+      0,
+      Point14DecompressionMode.PointData
+    );
     this.rgb.decompressRgb(this.point.scannerChannel);
-    if (this.bytes) {
+    // The first point stores extra bytes before the layered stream metadata.
+    if (this.first && this.bytes) {
       this.bytes.decompress(this.extraByteScratch, 0, this.point.scannerChannel);
     }
     this.readFirstMetadata();
@@ -2177,10 +2213,15 @@ class PointFormat7Decompressor implements PointDecompressor {
     const offset = target.offset;
     let targetPointIndex = target.pointOffset;
 
+    // The first point stores extra bytes before the layered stream metadata.
     for (let pointIndex = 0; pointIndex < pointCount; pointIndex++) {
-      const point = this.point.decompressPoint(this.pointScratch, 0);
+      const point = this.point.decompressPoint(
+        this.pointScratch,
+        0,
+        Point14DecompressionMode.PointData
+      );
       this.rgb.decompressRgb(this.point.scannerChannel);
-      if (this.bytes) {
+      if (this.first && this.bytes) {
         this.bytes.decompress(this.extraByteScratch, 0, this.point.scannerChannel);
       }
       this.readFirstMetadata();


### PR DESCRIPTION
## Goals

- Bring TypeScript streaming LAZ PDRF 7 performance into practical range of the WASM/Rust backends.
- Avoid decoding LAZ 1.4 field layers that are not represented in the Arrow output.
- Preserve complete, byte-for-byte raw point-record decoding and keep the optimization boundary explicit.

## Changes

- Add a selective PDRF 7 decoder mode that arithmetic-decodes XYZ, intensity, classification, and RGB directly into typed Arrow target arrays.
- Skip independent scan flags, scan angle, user data, point source ID, GPS time, and Extra Bytes layers on the selective table path.
- Keep `decodeLAZChunk()` and raw cursor decoding complete and unchanged.
- Lock a stateful chunk cursor to either raw or selective output after decoding starts, because skipped arithmetic streams cannot later be resumed at the corresponding point.
- Add a specialized PDRF 7 batch loop to reduce repeated capability checks and target-property lookups.
- Compare selective output against complete decoded records for positions, intensity, classification, and color, including small cursor batches and output-mode guards.
- Document the chunk-streaming boundary, selective-decode behavior, raw API guarantee, and why PDRF 6/8 remain conservative pending dedicated fixtures.

## Performance

Representative clean local PDRF 7 runs:

- Streaming `parseInBatches`: approximately 2.06M points/s, up from approximately 1.28M points/s.
- Selective point-data cursor: approximately 2.11M points/s.
- Complete raw cursor: approximately 1.43M points/s.

The selective approach is intentionally less general than the raw decoder. The complexity is isolated behind an explicit mode and a PDRF 7-specific loop; raw decoding remains the correctness reference.

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn test-node`: 388 files passed, 1,661 tests passed
- `yarn test-headless`: 392 files passed, 1,656 tests passed
- `yarn test-node modules/las/test/las-loader.spec.ts`: 38 tests passed
- PDRF 7 selective columns compared against complete TypeScript records; existing LAS tests compare TypeScript output with laz-perf/COPC and laz-rs backends.
