### PR TITLE
Make the default glTF JSON schema version-inclusive

### DIFF
--- a/modules/gltf/README.md
+++ b/modules/gltf/README.md
@@ -14,7 +14,8 @@ registry status, extension name, and schema fragment because an extension may au
 different glTF object types.
 
 Standalone JSON Schemas are published per version for Monaco and other editor integrations.
-`gltf.schema.json` remains the glTF 2.0 alias, while `gltf-all.schema.json` is an opt-in union:
+`gltf.schema.json` accepts every supported glTF version, so its validation contract only broadens as
+new versions are added. `gltf-all.schema.json` is an explicit alias for the same version union:
 
 ```text
 https://unpkg.com/@loaders.gl/gltf@5/gltf.schema.json

--- a/modules/gltf/scripts/generate-json-schema.mjs
+++ b/modules/gltf/scripts/generate-json-schema.mjs
@@ -58,16 +58,22 @@ const gltf21Schema = withIdentity(
   '2.1'
 );
 
-await writeSchema('gltf.schema.json', gltf2Schema);
 await writeSchema('gltf-1.schema.json', gltf1Schema);
 await writeSchema('gltf-2.schema.json', gltf2Schema);
 await writeSchema('gltf-2.1.schema.json', gltf21Schema);
-await writeSchema('gltf-all.schema.json', {
-  $schema: 'https://json-schema.org/draft/2020-12/schema',
-  $id: 'https://unpkg.com/@loaders.gl/gltf/gltf-all.schema.json',
-  title: 'glTF JSON',
-  oneOf: [gltf1Schema, gltf2Schema, gltf21Schema]
-});
+
+/** Returns the schema union for every supported glTF version. */
+function getVersionUnionSchema(id) {
+  return {
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    $id: `https://unpkg.com/@loaders.gl/gltf/${id}`,
+    title: 'glTF JSON',
+    oneOf: [gltf1Schema, gltf2Schema, gltf21Schema]
+  };
+}
+
+await writeSchema('gltf.schema.json', getVersionUnionSchema('gltf.schema.json'));
+await writeSchema('gltf-all.schema.json', getVersionUnionSchema('gltf-all.schema.json'));
 
 async function writeExtensionSchemas(value, pathParts = []) {
   for (const [key, item] of Object.entries(value)) {


### PR DESCRIPTION
## Goals

- Keep the unqualified `gltf.schema.json` URL stable as new glTF versions are added.
- Ensure adding a supported version broadens default validation instead of changing the single version selected by that URL.

## Changes

- generate `gltf.schema.json` as the union of every supported glTF version
- retain `gltf-all.schema.json` as an explicit alias for the same union
- keep `gltf-1.schema.json`, `gltf-2.schema.json`, and `gltf-2.1.schema.json` pinned to their respective versions
- document the stability contract

## Validation

- `yarn build`
- `yarn lint fix`
- verified both union outputs contain the 1.0, 2.0, and 2.1 branches with distinct canonical `$id` values