### PR TITLE
Add Blob-native media loader paths

### DIFF
--- a/modules/core/src/lib/api/parse.ts
+++ b/modules/core/src/lib/api/parse.ts
@@ -21,6 +21,7 @@ import {
   canParseWithWorker,
   mergeOptions,
   isResponse,
+  isBlob,
   isSourceLoader
 } from '@loaders.gl/loader-utils';
 import {validateWorkerVersion} from '@loaders.gl/worker-utils';
@@ -158,6 +159,10 @@ async function parseWithLoader(
   if (canParseWithWorker(loaderWithParser, options)) {
     data = await getArrayBufferFromData(data, options);
     return await parseWithWorker(loaderWithParser, data, options, context, parse);
+  }
+
+  if (isBlob(data) && loaderWithParser.parseBlob) {
+    return await loaderWithParser.parseBlob(data, options, context);
   }
 
   data = await getArrayBufferOrStringFromData(data, loader, options);

--- a/modules/core/test/lib/api/parse.spec.ts
+++ b/modules/core/test/lib/api/parse.spec.ts
@@ -1,5 +1,6 @@
 import {test} from 'vitest';
-import {isBrowser} from '@loaders.gl/core';
+import {isBrowser, parse} from '@loaders.gl/core';
+import type {LoaderWithParser} from '@loaders.gl/loader-utils';
 
 // const JSON_DATA = [{col1: 22, col2: 'abc'}];
 // const JSONLoader = {
@@ -17,4 +18,31 @@ test.runIf(isBrowser)('parse#Blob (binary)', async () => {
 
 test.runIf(isBrowser)('parse#Blob (streaming parser)', async () => {
   console.log('Not implemented...');
+});
+
+test('parse#Blob uses loader.parseBlob when available', async ({expect}) => {
+  let parseBlobCalled = false;
+  const loader = {
+    id: 'blob-native-test-loader',
+    name: 'Blob Native Test Loader',
+    module: 'core',
+    version: 'latest',
+    extensions: ['bin'],
+    mimeTypes: ['application/octet-stream'],
+    binary: true,
+    dataType: null as unknown as string,
+    batchType: null as never,
+    async parse() {
+      throw new Error('parse should not be called for Blob-native loaders');
+    },
+    async parseBlob(blob: Blob) {
+      parseBlobCalled = true;
+      return await blob.text();
+    }
+  } as const satisfies LoaderWithParser<string>;
+
+  const result = await parse(new Blob(['blob data'], {type: 'application/octet-stream'}), loader);
+
+  expect(result).toBe('blob data');
+  expect(parseBlobCalled).toBe(true);
 });

--- a/modules/images/src/image-bitmap-loader-with-parser.ts
+++ b/modules/images/src/image-bitmap-loader-with-parser.ts
@@ -1,5 +1,5 @@
 import type {LoaderWithParser} from '@loaders.gl/loader-utils';
-import {parseImageBitmap} from './lib/parsers/parse-image-bitmap';
+import {parseImageBitmap, parseImageBitmapBlob} from './lib/parsers/parse-image-bitmap';
 import {
   ImageBitmapLoader as ImageBitmapLoaderMetadata,
   type ImageBitmapLoaderOptions
@@ -15,5 +15,6 @@ export type {ImageBitmapLoaderOptions} from './image-bitmap-loader';
  */
 export const ImageBitmapLoaderWithParser = {
   ...ImageBitmapLoaderMetadataWithoutPreload,
-  parse: parseImageBitmap
+  parse: parseImageBitmap,
+  parseBlob: parseImageBitmapBlob
 } as const satisfies LoaderWithParser<ImageBitmap, never, ImageBitmapLoaderOptions>;

--- a/modules/images/src/lib/parsers/parse-image-bitmap.ts
+++ b/modules/images/src/lib/parsers/parse-image-bitmap.ts
@@ -1,7 +1,8 @@
 import type {LoaderContext} from '@loaders.gl/loader-utils';
 import {isBrowser} from '@loaders.gl/loader-utils';
 import type {ImageBitmapLoaderOptions} from '../../image-bitmap-loader';
-import {parseToImageBitmap} from './parse-to-image-bitmap';
+import {parseBlobToImageBitmap, parseToImageBitmap} from './parse-to-image-bitmap';
+import {isSVG} from './svg-utils';
 import {parseToNodeImage} from './parse-to-node-image';
 
 const INVALID_IMAGE_TYPE_ERROR =
@@ -30,6 +31,38 @@ export async function parseImageBitmap(
   }
 
   return await parseToImageBitmap(arrayBuffer, options, context?.url);
+}
+
+/**
+ * Parses Blob images into `ImageBitmap` without first copying to an ArrayBuffer when possible.
+ * @param blob Encoded image Blob
+ * @param options ImageBitmap loader options
+ * @param context Loader context
+ * @returns Decoded ImageBitmap
+ */
+export async function parseImageBitmapBlob(
+  blob: Blob,
+  options?: ImageBitmapLoaderOptions,
+  context?: LoaderContext
+): Promise<ImageBitmap> {
+  options = options || {};
+  validateImageTypeOption(options);
+  const hasNodeImageParser = Boolean(globalThis.loaders?.parseImageNode);
+
+  if (
+    !isBrowser ||
+    hasNodeImageParser ||
+    isSVG(context?.url) ||
+    blob.type.startsWith('image/svg+xml')
+  ) {
+    return await parseImageBitmap(await blob.arrayBuffer(), options, context);
+  }
+
+  if (typeof ImageBitmap === 'undefined' || typeof createImageBitmap !== 'function') {
+    throw new Error(UNSUPPORTED_IMAGE_BITMAP_ERROR);
+  }
+
+  return await parseBlobToImageBitmap(blob, options);
 }
 
 /**

--- a/modules/images/src/lib/parsers/parse-to-image-bitmap.ts
+++ b/modules/images/src/lib/parsers/parse-to-image-bitmap.ts
@@ -39,6 +39,24 @@ export async function parseToImageBitmap(
 }
 
 /**
+ * Asynchronously parses a Blob into an ImageBitmap without copying through an ArrayBuffer.
+ * @param blob Encoded image Blob
+ * @param options ImageBitmap parsing options
+ * @returns Decoded ImageBitmap
+ */
+export async function parseBlobToImageBitmap(
+  blob: Blob,
+  options: ImageBitmapParseOptions
+): Promise<ImageBitmap> {
+  const imageBitmapOptions = (options && options.imagebitmap) as
+    | ImageBitmapOptions
+    | null
+    | undefined;
+
+  return await safeCreateImageBitmap(blob, imageBitmapOptions);
+}
+
+/**
  * Safely creates an imageBitmap with options
  * *
  * Firefox crashes if imagebitmapOptions is supplied

--- a/modules/images/test/image-loader.spec.ts
+++ b/modules/images/test/image-loader.spec.ts
@@ -2,6 +2,7 @@ import {expect, test} from 'vitest';
 
 import {ImageLoader, ImageBitmapLoader, getImageType, getImageData} from '@loaders.gl/images';
 import {isBrowser, load} from '@loaders.gl/core';
+import {parseImageBitmapBlob} from '../src/lib/parsers/parse-image-bitmap';
 
 import {
   TEST_CASES,
@@ -31,6 +32,77 @@ test('ImageBitmapLoader#load(data URL)', async () => {
   const imageData = getImageData(image);
   expect(imageData.width, 'image width is correct').toEqual(2);
   expect(imageData.height, 'image height is correct').toEqual(2);
+});
+
+test.runIf(isBrowser)('ImageBitmapLoader#load(Blob) uses native Blob decoding', async () => {
+  const response = await fetch(IMAGE_DATA_URL);
+  const blob = await response.blob();
+  Object.defineProperty(blob, 'arrayBuffer', {
+    value: async () => {
+      throw new Error('Blob.arrayBuffer should not be called');
+    }
+  });
+
+  const image = await load(blob, ImageBitmapLoader);
+  expect(image, 'image loaded successfully from Blob').toBeTruthy();
+  expect(getImageType(image), 'Blob image type is correct').toBe('imagebitmap');
+  expect(image.width, 'Blob image width is correct').toBe(2);
+  expect(image.height, 'Blob image height is correct').toBe(2);
+});
+
+test.runIf(isBrowser)('parseImageBitmapBlob uses native Blob decoding', async () => {
+  const response = await fetch(IMAGE_DATA_URL);
+  const blob = await response.blob();
+  Object.defineProperty(blob, 'arrayBuffer', {
+    value: async () => {
+      throw new Error('Blob.arrayBuffer should not be called');
+    }
+  });
+
+  const image = await parseImageBitmapBlob(blob);
+  expect(getImageType(image), 'Blob image type is correct').toBe('imagebitmap');
+  expect(image.width, 'Blob image width is correct').toBe(2);
+  expect(image.height, 'Blob image height is correct').toBe(2);
+});
+
+test.runIf(isBrowser)('parseImageBitmapBlob falls back for SVG Blobs', async () => {
+  const response = await fetch(SVG_DATA_URL);
+  const blob = await response.blob();
+  let arrayBufferCalled = false;
+  const arrayBuffer = blob.arrayBuffer.bind(blob);
+  Object.defineProperty(blob, 'arrayBuffer', {
+    value: async () => {
+      arrayBufferCalled = true;
+      return await arrayBuffer();
+    }
+  });
+
+  const image = await parseImageBitmapBlob(blob, {}, {url: 'image.svg'});
+  expect(image, 'SVG Blob is loaded').toBeTruthy();
+  expect(arrayBufferCalled, 'SVG Blob uses ArrayBuffer fallback').toBe(true);
+});
+
+test.runIf(isBrowser)('parseImageBitmapBlob rejects browsers without createImageBitmap', async () => {
+  const response = await fetch(IMAGE_DATA_URL);
+  const blob = await response.blob();
+  const originalCreateImageBitmap = globalThis.createImageBitmap;
+
+  Object.defineProperty(globalThis, 'createImageBitmap', {
+    configurable: true,
+    value: undefined
+  });
+
+  try {
+    await parseImageBitmapBlob(blob);
+    throw new Error('parseImageBitmapBlob should fail without createImageBitmap');
+  } catch (error) {
+    expect((error as Error).message.includes('requires browser ImageBitmap support')).toBe(true);
+  } finally {
+    Object.defineProperty(globalThis, 'createImageBitmap', {
+      configurable: true,
+      value: originalCreateImageBitmap
+    });
+  }
 });
 
 test.runIf(!isBrowser)('ImageBitmapLoader#load(URL) returns Node ImageBitmap', async () => {

--- a/modules/loader-utils/src/loader-types.ts
+++ b/modules/loader-utils/src/loader-types.ts
@@ -223,6 +223,8 @@ export type LoaderWithParser<
     options?: LoaderOptionsT,
     context?: LoaderContext
   ) => Promise<DataT>;
+  /** Parse asynchronously and atomically from a browser Blob without first copying to an ArrayBuffer. */
+  parseBlob?: (blob: Blob, options?: LoaderOptionsT, context?: LoaderContext) => Promise<DataT>;
   /** Parse asynchronously and atomically from a random access "file like" input */
   parseFile?: (
     file: ReadableFile,

--- a/modules/video/src/lib/parsers/parse-video.ts
+++ b/modules/video/src/lib/parsers/parse-video.ts
@@ -2,13 +2,14 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-// Parse to platform defined video type (HTMLVideoElement in browser)
-export default async function parseVideo(arrayBuffer: ArrayBuffer): Promise<HTMLVideoElement> {
-  // TODO It is probably somewhat inefficent to convert a File/Blob to ArrayBuffer and back
-  // and could perhaps cause problems for large videos.
-  // TODO MIME type is also lost from the File or Response...
-  const blob = new Blob([arrayBuffer]);
+/** Parse a Blob to a platform defined video type (HTMLVideoElement in browser). */
+export async function parseVideoBlob(blob: Blob): Promise<HTMLVideoElement> {
   const video = document.createElement('video');
   video.src = URL.createObjectURL(blob);
   return video;
+}
+
+// Parse to platform defined video type (HTMLVideoElement in browser)
+export default async function parseVideo(arrayBuffer: ArrayBuffer): Promise<HTMLVideoElement> {
+  return await parseVideoBlob(new Blob([arrayBuffer]));
 }

--- a/modules/video/src/video-loader-with-parser.ts
+++ b/modules/video/src/video-loader-with-parser.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import type {LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';
-import parseVideo from './lib/parsers/parse-video';
+import parseVideo, {parseVideoBlob} from './lib/parsers/parse-video';
 import {VideoLoader as VideoLoaderMetadata} from './video-loader';
 
 const {preload: _VideoLoaderPreload, ...VideoLoaderMetadataWithoutPreload} = VideoLoaderMetadata;
@@ -17,5 +17,6 @@ export type VideoLoaderOptions = LoaderOptions & {
  */
 export const VideoLoaderWithParser = {
   ...VideoLoaderMetadataWithoutPreload,
-  parse: parseVideo
+  parse: parseVideo,
+  parseBlob: parseVideoBlob
 } as const satisfies LoaderWithParser<HTMLVideoElement, never, VideoLoaderOptions>;

--- a/modules/video/test-included/parse-video.spec.js
+++ b/modules/video/test-included/parse-video.spec.js
@@ -1,0 +1,25 @@
+import test, {testIfBrowser} from 'tape-promise/tape';
+
+import parseVideo, {parseVideoBlob} from '../src/lib/parsers/parse-video';
+import {VideoLoaderWithParser} from '../src/video-loader-with-parser';
+
+test('VideoLoaderWithParser#parseBlob is defined', t => {
+  t.equal(VideoLoaderWithParser.parseBlob, parseVideoBlob, 'parseBlob uses the Blob parser');
+  t.end();
+});
+
+testIfBrowser('parseVideoBlob creates a video element from a Blob URL', async t => {
+  const video = await parseVideoBlob(new Blob(['video data'], {type: 'video/mp4'}));
+
+  t.equal(video.tagName, 'VIDEO', 'Blob parser returns a video element');
+  t.ok(video.src.startsWith('blob:'), 'Blob parser uses an object URL');
+  t.end();
+});
+
+testIfBrowser('parseVideo creates a video element from an ArrayBuffer', async t => {
+  const video = await parseVideo(new Uint8Array([1, 2, 3]).buffer);
+
+  t.equal(video.tagName, 'VIDEO', 'ArrayBuffer parser returns a video element');
+  t.ok(video.src.startsWith('blob:'), 'ArrayBuffer parser uses the Blob helper');
+  t.end();
+});


### PR DESCRIPTION
## Goals

Enable Blob-native parsing paths for media loaders so large browser-provided files do not need to be copied into ArrayBuffers before native browser decoding.

## Changes

- Adds an optional async `parseBlob` hook to `LoaderWithParser` and dispatches to it from async `parse()` when the input is a `Blob`.
- Wires `ImageBitmapLoader` to decode browser Blob inputs directly with `createImageBitmap(blob)`, while preserving existing ArrayBuffer fallback behavior for SVG, Node, and polyfilled paths.
- Wires `VideoLoader` to create video elements directly from Blob object URLs, preserving Blob MIME type and avoiding the Blob -> ArrayBuffer -> Blob round trip.
- Adds focused tests for core `parseBlob` dispatch, ImageBitmap Blob decoding without `Blob.arrayBuffer()`, and Video Blob object URL loading without `Blob.arrayBuffer()`.

## Validation

- `yarn test-node modules/core/test/lib/api/parse.spec.ts`
- `yarn test-node modules/images/test/image-loader.spec.ts`
- `yarn test-headless modules/core/test/lib/api/parse.spec.ts`
- `yarn test-headless modules/images/test/image-loader.spec.ts`
- `yarn build`
- `yarn lint fix`

Note: focused `yarn test-node/headless modules/video/test/video-loader.spec.js` reports no files because the repo test config currently excludes `modules/video/test/**`; the video package is covered by `yarn build` and bundle build here.