### PR TITLE
Add Zod and JSON schemas for texture manifests

### DIFF
--- a/modules/potree/README.md
+++ b/modules/potree/README.md
@@ -2,6 +2,8 @@
 
 This module contains loaders for the [potree](https://github.com/potree/potree) format.
 
+`PotreeMetadataSchema` is available from the `@loaders.gl/potree/potree-metadata-schema` subpath for runtime validation. The package root exports the corresponding `PotreeMetadata` TypeScript type without loading Zod. The equivalent generated JSON Schema is available from `@loaders.gl/potree/potree-metadata.schema.json`.
+
 [loaders.gl](https://loaders.gl/docs) is a collection of framework-independent 3D and geospatial loaders (parsers).
 
 For documentation please visit the [website](https://loaders.gl).

--- a/modules/potree/package.json
+++ b/modules/potree/package.json
@@ -31,6 +31,11 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
+    "./potree-metadata-schema": {
+      "types": "./dist/potree-metadata-schema.d.ts",
+      "import": "./dist/potree-metadata-schema.js",
+      "require": "./dist/potree-metadata-schema.cjs"
+    },
     "./unbundled": {
       "types": "./dist/unbundled.d.ts",
       "import": "./dist/unbundled.js"
@@ -38,7 +43,8 @@
     "./bundled": {
       "types": "./dist/bundled.d.ts",
       "import": "./dist/bundled.js"
-    }
+    },
+    "./potree-metadata.schema.json": "./dist/potree-metadata.schema.json"
   },
   "sideEffects": false,
   "files": [
@@ -47,7 +53,8 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-bundle-dev",
+    "pre-build": "npm run generate-json-schema && npm run build-bundle && npm run build-bundle-dev",
+    "generate-json-schema": "node ../../scripts/generate-json-schema.mjs --schema ./dist/potree-metadata-schema.js --export PotreeMetadataSchema --output ./dist/potree-metadata.schema.json --id https://unpkg.com/@loaders.gl/potree/potree-metadata.schema.json --title 'Potree 1.x cloud.js metadata'",
     "build-bundle": "ocular-bundle ./bundle.ts --output=dist/dist.min.js",
     "build-bundle-dev": "ocular-bundle ./bundle.ts --env=dev --output=dist/dist.dev.js"
   },
@@ -58,7 +65,8 @@
     "@loaders.gl/schema": "5.0.0-alpha.1",
     "@loaders.gl/schema-utils": "5.0.0-alpha.1",
     "@math.gl/core": "^4.1.0",
-    "@math.gl/proj4": "^4.1.0"
+    "@math.gl/proj4": "^4.1.0",
+    "zod": "^4.1.12"
   },
   "peerDependencies": {
     "@loaders.gl/core": "~5.0.0-alpha.0"

--- a/modules/potree/src/index.ts
+++ b/modules/potree/src/index.ts
@@ -4,4 +4,11 @@ export {PotreeHierarchyChunkLoader} from './potree-hierarchy-chunk-loader';
 export {PotreeBinLoader} from './potree-bin-loader';
 export {PotreeSourceLoader} from './potree-source-loader';
 
+export type {
+  HierarchyItem,
+  PotreeAttribute,
+  PotreeBoundingBox,
+  PotreeMetadata
+} from './potree-metadata-schema';
+
 export {type POTreeNode} from './parsers/parse-potree-hierarchy-chunk';

--- a/modules/potree/src/lib/potree-node-source.ts
+++ b/modules/potree/src/lib/potree-node-source.ts
@@ -14,7 +14,6 @@ import {
   buildPotreeHierarchyFromMetadata
 } from '../parsers/parse-potree-hierarchy-chunk';
 import {PotreeHierarchyChunkLoaderWithParser} from '../potree-hierarchy-chunk-loader-with-parser';
-import {PotreeLoaderWithParser} from '../potree-loader-with-parser';
 import {PotreeBinLoaderWithParser} from '../potree-bin-loader-with-parser';
 import {parseVersion} from '../utils/parse-version';
 import {Proj4Projection} from '@math.gl/proj4';
@@ -93,6 +92,7 @@ export class PotreeNodesSource extends DataSource<string, PotreeSourceLoaderOpti
       await this.initPromise;
       return;
     }
+    const {PotreeLoaderWithParser} = await import('../potree-loader-with-parser');
     this.metadata = await this.loadWithCoreApi(this.metadataUrl, PotreeLoaderWithParser);
     this.projection = createProjection(this.metadata?.projection);
     this.parseBoundingVolume();

--- a/modules/potree/src/potree-loader-with-parser.ts
+++ b/modules/potree/src/potree-loader-with-parser.ts
@@ -4,6 +4,7 @@
 
 import type {LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';
 import {PotreeLoader as PotreeLoaderMetadata} from './potree-loader';
+import {PotreeMetadataSchema, type PotreeMetadata} from './types/potree-metadata';
 
 const {preload: _PotreeLoaderPreload, ...PotreeLoaderMetadataWithoutPreload} = PotreeLoaderMetadata;
 
@@ -14,6 +15,11 @@ export type POTreeLoaderOptions = LoaderOptions & {
 /** Potree loader */
 export const PotreeLoaderWithParser = {
   ...PotreeLoaderMetadataWithoutPreload,
-  parse: (data: ArrayBuffer) => JSON.parse(new TextDecoder().decode(data)),
-  parseTextSync: text => JSON.parse(text)
-} as const satisfies LoaderWithParser<any, never, POTreeLoaderOptions>;
+  parse: async (data: ArrayBuffer) => parsePotreeMetadata(new TextDecoder().decode(data)),
+  parseTextSync: parsePotreeMetadata
+} as const satisfies LoaderWithParser<PotreeMetadata, never, POTreeLoaderOptions>;
+
+/** Parses and validates one Potree `cloud.js` metadata document. */
+function parsePotreeMetadata(text: string): PotreeMetadata {
+  return PotreeMetadataSchema.parse(JSON.parse(text));
+}

--- a/modules/potree/src/potree-loader.ts
+++ b/modules/potree/src/potree-loader.ts
@@ -3,6 +3,7 @@
 // Copyright vis.gl contributors
 
 import type {Loader, LoaderOptions} from '@loaders.gl/loader-utils';
+import type {PotreeMetadata} from './types/potree-metadata';
 
 import {PotreeFormat} from './potree-format';
 // __VERSION__ is injected by babel-plugin-version-inline
@@ -22,7 +23,7 @@ async function preload() {
 /** Metadata-only Potree loader. */
 export const PotreeLoader = {
   ...PotreeFormat,
-  dataType: null as unknown as any,
+  dataType: null as unknown as PotreeMetadata,
   batchType: null as never,
 
   name: 'potree metadata',
@@ -37,4 +38,4 @@ export const PotreeLoader = {
     potree: {}
   },
   preload
-} as const satisfies Loader<any, never, POTreeLoaderOptions>;
+} as const satisfies Loader<PotreeMetadata, never, POTreeLoaderOptions>;

--- a/modules/potree/src/potree-metadata-schema.ts
+++ b/modules/potree/src/potree-metadata-schema.ts
@@ -1,0 +1,17 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export {
+  PotreeAttributeSchema,
+  PotreeBoundingBoxSchema,
+  PotreeHierarchyItemSchema,
+  PotreeMetadataSchema
+} from './types/potree-metadata';
+
+export type {
+  HierarchyItem,
+  PotreeAttribute,
+  PotreeBoundingBox,
+  PotreeMetadata
+} from './types/potree-metadata';

--- a/modules/potree/src/types/potree-metadata.ts
+++ b/modules/potree/src/types/potree-metadata.ts
@@ -2,93 +2,143 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-/** Bounding box */
+import {z} from 'zod';
+
+/** Potree axis-aligned bounding box metadata. */
 export interface PotreeBoundingBox {
-  /** Min X */
+  /** Minimum X coordinate. */
   lx: number;
-  /** Min Y */
+  /** Minimum Y coordinate. */
   ly: number;
-  /** Min Z */
+  /** Minimum Z coordinate. */
   lz: number;
-  /** Max X */
+  /** Maximum X coordinate. */
   ux: number;
-  /** Max Y */
+  /** Maximum Y coordinate. */
   uy: number;
-  /** Max Z */
+  /** Maximum Z coordinate. */
   uz: number;
+  /** Additional bounding-box properties are preserved verbatim. */
+  [key: string]: unknown;
 }
 
-/** Attribute types for *.bin content */
+/** Attribute types for Potree `*.bin` content. */
 export type PotreeAttribute =
-  /** 3 (uint32) numbers: x, y, z */
+  /** Three `uint32` position components: x, y, z. */
   | 'POSITION_CARTESIAN'
-  /** 4 x (uint8) numbers for the color: r, g, b, a */
+  /** Four `uint8` color components: r, g, b, a. */
   | 'RGBA_PACKED'
-  /** 4 x (uint8) numbers for the color: r, g, b, a */
+  /** Four `uint8` color components: r, g, b, a. */
   | 'COLOR_PACKED'
-  /** 3 x (uint8) numbers for the color: r, g, b */
+  /** Three `uint8` color components: r, g, b. */
   | 'RGB_PACKED'
-  /** 3 x (float) numbers: x', y', z'  */
+  /** Three floating-point normal components: x, y, z. */
   | 'NORMAL_FLOATS'
-  /** (uint8) number */
+  /** One byte of padding. */
   | 'FILLER_1B'
-  /** (uint16) number specifying the point's intensity */
+  /** One `uint16` point-intensity value. */
   | 'INTENSITY'
-  /** (uint8) id for the class used */
+  /** One `uint8` classification identifier. */
   | 'CLASSIFICATION'
-  /** Note: might need to be revisited, best don't use */
+  /** A sphere-mapped normal representation; support may be incomplete. */
   | 'NORMAL_SPHEREMAPPED'
-  /** Note: might need to be revisited, best don't use */
+  /** An octahedral 16-bit normal representation; support may be incomplete. */
   | 'NORMAL_OCT16'
-  /** 3 x (float) numbers: x', y', z' */
+  /** Three floating-point normal components: x, y, z. */
   | 'NORMAL';
 
-/** Hierarchy item: [node name leading with 'r', points count
- * @example [r043, 145]
-] */
+/** Legacy inline hierarchy entry containing a node name and point count.
+ * @example ['r043', 145]
+ */
 export type HierarchyItem = [string, number];
 
 /**
- * Potree data set format metadata (cloud.js)
+ * Potree data set format metadata from `cloud.js`.
  * @version 1.7
- * @link https://github.com/potree/potree/blob/1.7/docs/potree-file-format.md
- * */
+ * @see https://github.com/potree/potree/blob/1.7/docs/potree-file-format.md
+ */
 export interface PotreeMetadata {
-  /** Version number in which this file is written */
+  /** Potree format version in which this file was written. */
   version: string;
-  /** Folder that is used to load additional data */
+  /** Folder used to load additional octree data. */
   octreeDir: string;
-  /** Amount of points contained in the whole pointcloud data */
-  points: number;
-  /**
-   * This parameter is used to transform the point data
-   * to the projection system used while visualizing the points. It has to be
-   * in a format that is parsable by [proj.4][proj4].
-   * */
-  projection: string;
-  /** Bounding box of the world used to limit the initial POV. */
+  /** Number of points contained in the complete point cloud. */
+  points?: number;
+  /** Proj.4-compatible definition of the point cloud's projection. */
+  projection?: string;
+  /** World bounding box used to limit the initial point of view. */
   boundingBox: PotreeBoundingBox;
-  /** Bounding box of the actual points in the data */
+  /** Tight bounding box around the actual points. */
   tightBoundingBox: PotreeBoundingBox;
-  /** Description of point attributes in data files */
+  /** Description of the attributes stored in point-data files. */
   pointAttributes: 'LAS' | 'LAZ' | PotreeAttribute[];
-  /**
-   * Space between points at the root node.
-   * This value is halved at each octree level.
-   * */
+  /** Root-node point spacing, halved at each octree level. */
   spacing: number;
   /**
-   * Scale applied to convert POSITION_CARTESIAN components
-   * from uint32 values to floating point values. The full transformation
-   * to world coordinates is
-   * position = (POSITION_CARTESIAN * scale) + boundingBox.min
-   * */
+   * Scale applied to `POSITION_CARTESIAN` components before adding the bounding-box minimum.
+   */
   scale: number;
-  /** Amount of Octree levels before a new folder hierarchy is expected. */
+  /** Number of octree levels before another hierarchy folder is expected. */
   hierarchyStepSize: number;
   /**
-   * The hierarchy of files, now loaded through index files.
+   * Legacy inline file hierarchy, superseded by hierarchy index files.
    * @deprecated
-   * */
+   */
   hierarchy?: HierarchyItem[];
+  /** Additional metadata properties are preserved verbatim. */
+  [key: string]: unknown;
 }
+
+/** Zod schema for a Potree axis-aligned bounding box. */
+export const PotreeBoundingBoxSchema = z
+  .object({
+    lx: z.number(),
+    ly: z.number(),
+    lz: z.number(),
+    ux: z.number(),
+    uy: z.number(),
+    uz: z.number()
+  })
+  .passthrough() satisfies z.ZodType<PotreeBoundingBox>;
+
+/** Zod schema for the point attributes supported by the Potree binary loader. */
+export const PotreeAttributeSchema = z.enum([
+  'POSITION_CARTESIAN',
+  'RGBA_PACKED',
+  'COLOR_PACKED',
+  'RGB_PACKED',
+  'NORMAL_FLOATS',
+  'FILLER_1B',
+  'INTENSITY',
+  'CLASSIFICATION',
+  'NORMAL_SPHEREMAPPED',
+  'NORMAL_OCT16',
+  'NORMAL'
+]) satisfies z.ZodType<PotreeAttribute>;
+
+/** Zod schema for one legacy inline hierarchy entry. */
+export const PotreeHierarchyItemSchema = z.tuple([
+  z.string().regex(/^r[0-7]*$/),
+  z.number().int().nonnegative()
+]) satisfies z.ZodType<HierarchyItem>;
+
+/** Zod schema for Potree 1.7 `cloud.js` metadata. */
+export const PotreeMetadataSchema = z
+  .object({
+    version: z.string().min(1),
+    octreeDir: z.string().min(1),
+    points: z.number().int().nonnegative().optional(),
+    projection: z.string().optional(),
+    boundingBox: PotreeBoundingBoxSchema,
+    tightBoundingBox: PotreeBoundingBoxSchema,
+    pointAttributes: z.union([
+      z.literal('LAS'),
+      z.literal('LAZ'),
+      z.array(PotreeAttributeSchema).min(1)
+    ]),
+    spacing: z.number().positive(),
+    scale: z.number().positive(),
+    hierarchyStepSize: z.number().int().positive(),
+    hierarchy: z.array(PotreeHierarchyItemSchema).optional()
+  })
+  .passthrough() satisfies z.ZodType<PotreeMetadata>;

--- a/modules/potree/test/index.ts
+++ b/modules/potree/test/index.ts
@@ -1,4 +1,5 @@
 import './potree-hierarchy-chunk-loader.spec';
 import './potree-source.spec';
+import './potree-metadata-schema.spec';
 import './utils/projection-utils.spec';
 import './utils/bounding-box-utils.spec';

--- a/modules/potree/test/potree-metadata-schema.spec.ts
+++ b/modules/potree/test/potree-metadata-schema.spec.ts
@@ -1,0 +1,41 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {fetchFile, parse} from '@loaders.gl/core';
+import {PotreeLoader} from '@loaders.gl/potree';
+import {PotreeMetadataSchema} from '@loaders.gl/potree/potree-metadata-schema';
+import {describe, expect, it} from 'vitest';
+import {z} from 'zod';
+
+const POTREE_METADATA_URL = '@loaders.gl/potree/test/data/lion_takanawa/cloud.js';
+
+describe('PotreeMetadataSchema', () => {
+  it('validates the Potree 1.7 fixture through the loader', async () => {
+    const metadata = await parse(await fetchFile(POTREE_METADATA_URL), PotreeLoader);
+
+    expect(metadata.version).toBe('1.7');
+    expect(metadata.pointAttributes).toContain('POSITION_CARTESIAN');
+  });
+
+  it('rejects malformed required metadata', () => {
+    expect(
+      PotreeMetadataSchema.safeParse({
+        version: '1.7',
+        octreeDir: 'data',
+        boundingBox: {},
+        tightBoundingBox: {},
+        pointAttributes: [],
+        spacing: 0,
+        scale: 0,
+        hierarchyStepSize: 0
+      }).success
+    ).toBe(false);
+  });
+
+  it('can be exported as JSON Schema', () => {
+    const jsonSchema = z.toJSONSchema(PotreeMetadataSchema, {target: 'draft-7'});
+    expect(jsonSchema.required).toContain('version');
+    expect(jsonSchema.required).toContain('pointAttributes');
+  });
+});

--- a/modules/textures/README.md
+++ b/modules/textures/README.md
@@ -60,6 +60,8 @@ The `textures` module also exports JSON manifest loaders for image-based composi
 - `TextureCubeLoader` for cubemaps
 - `TextureCubeArrayLoader` for cube arrays
 
+The `@loaders.gl/textures/texture-manifest-schema` subpath exports `CompositeImageManifestSchema` and the schemas for each individual manifest shape for runtime validation. The package root exports the corresponding TypeScript types without loading Zod. The equivalent generated JSON Schema is available from `@loaders.gl/textures/texture-manifest.schema.json`.
+
 Each manifest includes a `shape` discriminator and resolves relative member URLs against the manifest URL.
 Member assets are parsed with `ImageLoader` by default, and additional loaders passed to top-level `load()` are also available for manifest members.
 These loaders return schema `Texture` objects rather than raw image trees.

--- a/modules/textures/package.json
+++ b/modules/textures/package.json
@@ -31,6 +31,11 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
+    "./texture-manifest-schema": {
+      "types": "./dist/texture-manifest-schema.d.ts",
+      "import": "./dist/texture-manifest-schema.js",
+      "require": "./dist/texture-manifest-schema.cjs"
+    },
     "./unbundled": {
       "types": "./dist/unbundled.d.ts",
       "import": "./dist/unbundled.js"
@@ -59,7 +64,8 @@
     },
     "./ktx2-basis-writer-worker-node.js": {
       "import": "./dist/ktx2-basis-writer-worker-node.js"
-    }
+    },
+    "./texture-manifest.schema.json": "./dist/texture-manifest.schema.json"
   },
   "sideEffects": false,
   "files": [
@@ -69,7 +75,8 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run copy-libs && npm run build-bundle && npm run build-bundle-dev && npm run build-workers",
+    "pre-build": "npm run generate-json-schema && npm run copy-libs && npm run build-bundle && npm run build-bundle-dev && npm run build-workers",
+    "generate-json-schema": "node ../../scripts/generate-json-schema.mjs --schema ./dist/texture-manifest-schema.js --export CompositeImageManifestSchema --output ./dist/texture-manifest.schema.json --id https://unpkg.com/@loaders.gl/textures/texture-manifest.schema.json --title 'loaders.gl composite image texture manifest'",
     "copy-libs": "cp -rf ./src/libs ./dist/libs",
     "build-bundle": "ocular-bundle ./bundle.ts --output=dist/dist.min.js",
     "build-bundle-dev": "ocular-bundle ./bundle.ts --env=dev --output=dist/dist.dev.js",
@@ -88,7 +95,8 @@
     "@loaders.gl/schema": "5.0.0-alpha.1",
     "@loaders.gl/worker-utils": "5.0.0-alpha.1",
     "@math.gl/types": "^4.1.0",
-    "ktx-parse": "^0.7.0"
+    "ktx-parse": "^0.7.0",
+    "zod": "^4.1.12"
   },
   "peerDependencies": {
     "@loaders.gl/core": "~5.0.0-alpha.0",

--- a/modules/textures/src/index.ts
+++ b/modules/textures/src/index.ts
@@ -49,6 +49,18 @@ export type {
 } from './texture-cube-array-loader';
 export {TextureCubeArrayLoader} from './texture-cube-array-loader';
 
+export type {
+  CompositeImageManifest,
+  ImageTextureArrayManifest,
+  ImageTextureCubeArrayLayer,
+  ImageTextureCubeArrayManifest,
+  ImageTextureCubeFaces,
+  ImageTextureCubeManifest,
+  ImageTextureManifest,
+  ImageTextureSource,
+  ImageTextureTemplateSource
+} from './texture-manifest-schema';
+
 // Module constants
 export {BASIS_EXTERNAL_LIBRARIES} from './lib/parsers/basis-module-loader';
 export {CRUNCH_EXTERNAL_LIBRARIES} from './lib/parsers/crunch-module-loader';

--- a/modules/textures/src/lib/composite-image/composite-image-manifest-schema.ts
+++ b/modules/textures/src/lib/composite-image/composite-image-manifest-schema.ts
@@ -1,0 +1,247 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {z} from 'zod';
+import type {ImageTextureCubeDirectionAlias, ImageTextureCubeFace} from './image-texture-cube';
+
+/** A template-backed texture source. */
+export type ImageTextureTemplateSource = {
+  /** Number of mip levels to generate, or `auto` to infer the complete mip chain. */
+  mipLevels: number | 'auto';
+  /** URL template used to resolve each texture image. */
+  template: string;
+  /** Additional source properties are preserved verbatim. */
+  [key: string]: unknown;
+};
+
+/** A URL, explicit mip chain, or template-backed texture source. */
+export type ImageTextureSource = string | string[] | ImageTextureTemplateSource;
+
+/** Properties shared by every two-dimensional image texture manifest. */
+type ImageTextureManifestBase = {
+  /** Discriminator identifying a two-dimensional texture manifest. */
+  shape: 'image-texture';
+  /** Number of template-backed mip levels, or `auto` to infer the complete mip chain. */
+  mipLevels?: number | 'auto';
+  /** Additional manifest properties are preserved verbatim. */
+  [key: string]: unknown;
+};
+
+/** A two-dimensional image texture manifest with exactly one image source. */
+export type ImageTextureManifest = ImageTextureManifestBase &
+  (
+    | {
+        /** URL of a single texture image. */
+        image: string;
+        /** Explicit mip chains cannot be combined with a single image. */
+        mipmaps?: never;
+        /** URL templates cannot be combined with a single image. */
+        template?: never;
+      }
+    | {
+        /** A single image cannot be combined with an explicit mip chain. */
+        image?: never;
+        /** URLs of an explicit mip chain, ordered from largest to smallest. */
+        mipmaps: string[];
+        /** URL templates cannot be combined with an explicit mip chain. */
+        template?: never;
+      }
+    | {
+        /** A single image cannot be combined with a URL template. */
+        image?: never;
+        /** Explicit mip chains cannot be combined with a URL template. */
+        mipmaps?: never;
+        /** URL template used to resolve each mip level. */
+        template: string;
+      }
+  );
+
+/** An image texture array manifest. */
+export type ImageTextureArrayManifest = {
+  /** Discriminator identifying a texture array manifest. */
+  shape: 'image-texture-array';
+  /** Ordered texture sources for the array layers. */
+  layers: ImageTextureSource[];
+  /** Additional manifest properties are preserved verbatim. */
+  [key: string]: unknown;
+};
+
+/** A cube face supplied under its canonical name, direction alias, or both. */
+type ImageTextureCubeFacePair<
+  CanonicalFace extends ImageTextureCubeFace,
+  DirectionAlias extends ImageTextureCubeDirectionAlias
+> =
+  | (Record<CanonicalFace, ImageTextureSource> &
+      Partial<Record<DirectionAlias, ImageTextureSource>>)
+  | (Partial<Record<CanonicalFace, ImageTextureSource>> &
+      Record<DirectionAlias, ImageTextureSource>);
+
+/** Image sources containing every cube face under a canonical name or direction alias. */
+export type ImageTextureCubeFaces = ImageTextureCubeFacePair<'+X', 'right'> &
+  ImageTextureCubeFacePair<'-X', 'left'> &
+  ImageTextureCubeFacePair<'+Y', 'top'> &
+  ImageTextureCubeFacePair<'-Y', 'bottom'> &
+  ImageTextureCubeFacePair<'+Z', 'front'> &
+  ImageTextureCubeFacePair<'-Z', 'back'> & {
+    /** Additional face properties are preserved verbatim. */
+    [key: string]: unknown;
+  };
+
+/** An image texture cube manifest. */
+export type ImageTextureCubeManifest = {
+  /** Discriminator identifying a cube texture manifest. */
+  shape: 'image-texture-cube';
+  /** Texture source for each cube face. */
+  faces: ImageTextureCubeFaces;
+  /** Additional manifest properties are preserved verbatim. */
+  [key: string]: unknown;
+};
+
+/** One layer in an image texture cube array manifest. */
+export type ImageTextureCubeArrayLayer = {
+  /** Texture source for each cube face in this layer. */
+  faces: ImageTextureCubeFaces;
+  /** Additional layer properties are preserved verbatim. */
+  [key: string]: unknown;
+};
+
+/** An image texture cube array manifest. */
+export type ImageTextureCubeArrayManifest = {
+  /** Discriminator identifying a cube texture array manifest. */
+  shape: 'image-texture-cube-array';
+  /** Ordered cube texture layers. */
+  layers: ImageTextureCubeArrayLayer[];
+  /** Additional manifest properties are preserved verbatim. */
+  [key: string]: unknown;
+};
+
+/** Every composite image manifest supported by the texture loaders. */
+export type CompositeImageManifest =
+  | ImageTextureManifest
+  | ImageTextureArrayManifest
+  | ImageTextureCubeManifest
+  | ImageTextureCubeArrayManifest;
+
+const imageUrlSchema = z.string().min(1);
+const mipLevelsSchema = z.union([z.literal('auto'), z.number().int().positive()]);
+
+/** Zod schema for a template-backed texture source. */
+export const ImageTextureTemplateSourceSchema = z
+  .object({
+    mipLevels: mipLevelsSchema,
+    template: imageUrlSchema
+  })
+  .passthrough() satisfies z.ZodType<ImageTextureTemplateSource>;
+
+/** Zod schema for a URL, explicit mip chain, or template-backed texture source. */
+export const ImageTextureSourceSchema = z.union([
+  imageUrlSchema,
+  z.array(imageUrlSchema).min(1),
+  ImageTextureTemplateSourceSchema
+]) satisfies z.ZodType<ImageTextureSource>;
+
+const imageTextureCubeFacesSchema = z
+  .union([
+    z.object({'+X': ImageTextureSourceSchema}).passthrough(),
+    z.object({right: ImageTextureSourceSchema}).passthrough()
+  ])
+  .and(
+    z.union([
+      z.object({'-X': ImageTextureSourceSchema}).passthrough(),
+      z.object({left: ImageTextureSourceSchema}).passthrough()
+    ])
+  )
+  .and(
+    z.union([
+      z.object({'+Y': ImageTextureSourceSchema}).passthrough(),
+      z.object({top: ImageTextureSourceSchema}).passthrough()
+    ])
+  )
+  .and(
+    z.union([
+      z.object({'-Y': ImageTextureSourceSchema}).passthrough(),
+      z.object({bottom: ImageTextureSourceSchema}).passthrough()
+    ])
+  )
+  .and(
+    z.union([
+      z.object({'+Z': ImageTextureSourceSchema}).passthrough(),
+      z.object({front: ImageTextureSourceSchema}).passthrough()
+    ])
+  )
+  .and(
+    z.union([
+      z.object({'-Z': ImageTextureSourceSchema}).passthrough(),
+      z.object({back: ImageTextureSourceSchema}).passthrough()
+    ])
+  ) satisfies z.ZodType<ImageTextureCubeFaces>;
+
+const imageTextureManifestBaseSchema = z.object({
+  shape: z.literal('image-texture'),
+  mipLevels: mipLevelsSchema.optional()
+});
+
+/** Zod schema for a two-dimensional image texture manifest. */
+export const ImageTextureManifestSchema = z.union([
+  imageTextureManifestBaseSchema
+    .extend({
+      image: imageUrlSchema,
+      mipmaps: z.never().optional(),
+      template: z.never().optional()
+    })
+    .passthrough(),
+  imageTextureManifestBaseSchema
+    .extend({
+      image: z.never().optional(),
+      mipmaps: z.array(imageUrlSchema).min(1),
+      template: z.never().optional()
+    })
+    .passthrough(),
+  imageTextureManifestBaseSchema
+    .extend({
+      image: z.never().optional(),
+      mipmaps: z.never().optional(),
+      template: imageUrlSchema
+    })
+    .passthrough()
+]) satisfies z.ZodType<ImageTextureManifest>;
+
+/** Zod schema for an image texture array manifest. */
+export const ImageTextureArrayManifestSchema = z
+  .object({
+    shape: z.literal('image-texture-array'),
+    layers: z.array(ImageTextureSourceSchema).min(1)
+  })
+  .passthrough() satisfies z.ZodType<ImageTextureArrayManifest>;
+
+/** Zod schema for an image texture cube manifest. */
+export const ImageTextureCubeManifestSchema = z
+  .object({
+    shape: z.literal('image-texture-cube'),
+    faces: imageTextureCubeFacesSchema
+  })
+  .passthrough() satisfies z.ZodType<ImageTextureCubeManifest>;
+
+/** Zod schema for one layer in an image texture cube array manifest. */
+export const ImageTextureCubeArrayLayerSchema = z
+  .object({
+    faces: imageTextureCubeFacesSchema
+  })
+  .passthrough() satisfies z.ZodType<ImageTextureCubeArrayLayer>;
+
+/** Zod schema for an image texture cube array manifest. */
+export const ImageTextureCubeArrayManifestSchema = z
+  .object({
+    shape: z.literal('image-texture-cube-array'),
+    layers: z.array(ImageTextureCubeArrayLayerSchema).min(1)
+  })
+  .passthrough() satisfies z.ZodType<ImageTextureCubeArrayManifest>;
+
+/** Zod schema for every composite image manifest supported by the texture loaders. */
+export const CompositeImageManifestSchema = z.union([
+  ImageTextureManifestSchema,
+  ImageTextureArrayManifestSchema,
+  ImageTextureCubeManifestSchema,
+  ImageTextureCubeArrayManifestSchema
+]) satisfies z.ZodType<CompositeImageManifest>;

--- a/modules/textures/src/lib/composite-image/parse-composite-image.ts
+++ b/modules/textures/src/lib/composite-image/parse-composite-image.ts
@@ -8,56 +8,26 @@ import type {Texture, TextureFormat, TextureLevel} from '@loaders.gl/schema';
 import {ImageBitmapLoader, getImageSize, isImage, type ImageType} from '@loaders.gl/images';
 import {asyncDeepMap} from '../texture-api/async-deep-map';
 import type {TextureLoaderOptions} from '../texture-api/texture-api-types';
-import {
-  IMAGE_TEXTURE_CUBE_FACES,
-  type ImageCubeTexture,
-  type ImageTextureCubeDirectionAlias,
-  type ImageTextureCubeFace
-} from './image-texture-cube';
+import {IMAGE_TEXTURE_CUBE_FACES, type ImageCubeTexture} from './image-texture-cube';
+import type {
+  CompositeImageManifest,
+  ImageTextureCubeManifest,
+  ImageTextureManifest,
+  ImageTextureSource,
+  ImageTextureTemplateSource
+} from './composite-image-manifest-schema';
 
-export type ImageTextureTemplateSource = {
-  mipLevels: number | 'auto';
-  template: string;
-};
-
-export type ImageTextureSource = string | string[] | ImageTextureTemplateSource;
-
-export type ImageTextureManifest = {
-  shape: 'image-texture';
-  image?: string;
-  mipLevels?: number | 'auto';
-  template?: string;
-  mipmaps?: string[];
-};
-
-export type ImageTextureArrayManifest = {
-  shape: 'image-texture-array';
-  layers: ImageTextureSource[];
-};
-
-export type ImageTextureCubeFaces = Partial<
-  Record<ImageTextureCubeFace | ImageTextureCubeDirectionAlias, ImageTextureSource>
->;
-
-export type ImageTextureCubeManifest = {
-  shape: 'image-texture-cube';
-  faces: ImageTextureCubeFaces;
-};
-
-export type ImageTextureCubeArrayLayer = {
-  faces: ImageTextureCubeFaces;
-};
-
-export type ImageTextureCubeArrayManifest = {
-  shape: 'image-texture-cube-array';
-  layers: ImageTextureCubeArrayLayer[];
-};
-
-export type CompositeImageManifest =
-  | ImageTextureManifest
-  | ImageTextureArrayManifest
-  | ImageTextureCubeManifest
-  | ImageTextureCubeArrayManifest;
+export type {
+  CompositeImageManifest,
+  ImageTextureArrayManifest,
+  ImageTextureCubeArrayLayer,
+  ImageTextureCubeArrayManifest,
+  ImageTextureCubeFaces,
+  ImageTextureCubeManifest,
+  ImageTextureManifest,
+  ImageTextureSource,
+  ImageTextureTemplateSource
+} from './composite-image-manifest-schema';
 
 export type CompositeImageUrlTree =
   | ImageTextureSource
@@ -71,7 +41,8 @@ export async function parseCompositeImageManifest(
   options: TextureLoaderOptions = {},
   context?: LoaderContext
 ): Promise<any> {
-  const manifest = parseCompositeImageManifestJSON(text);
+  const {CompositeImageManifestSchema} = await import('./composite-image-manifest-schema');
+  const manifest = CompositeImageManifestSchema.parse(JSON.parse(text));
   if (manifest.shape !== expectedShape) {
     throw new Error(`Expected ${expectedShape} manifest, got ${manifest.shape}`);
   }
@@ -83,7 +54,7 @@ export function testCompositeImageManifestShape(
   shape: CompositeImageManifest['shape']
 ): boolean {
   try {
-    return parseCompositeImageManifestJSON(text).shape === shape;
+    return JSON.parse(text)?.shape === shape;
   } catch {
     return false;
   }
@@ -214,14 +185,6 @@ export function resolveCompositeImageUrl(
   }
 
   return resolvePath(joinCompositeImageUrl(baseUrl, url));
-}
-
-function parseCompositeImageManifestJSON(text: string): CompositeImageManifest {
-  const manifest = JSON.parse(text) as CompositeImageManifest;
-  if (!manifest?.shape) {
-    throw new Error('Composite image manifest must contain a shape field');
-  }
-  return manifest;
 }
 
 async function getImageTextureSource(

--- a/modules/textures/src/texture-manifest-schema.ts
+++ b/modules/textures/src/texture-manifest-schema.ts
@@ -1,0 +1,26 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export {
+  CompositeImageManifestSchema,
+  ImageTextureArrayManifestSchema,
+  ImageTextureCubeArrayLayerSchema,
+  ImageTextureCubeArrayManifestSchema,
+  ImageTextureCubeManifestSchema,
+  ImageTextureManifestSchema,
+  ImageTextureSourceSchema,
+  ImageTextureTemplateSourceSchema
+} from './lib/composite-image/composite-image-manifest-schema';
+
+export type {
+  CompositeImageManifest,
+  ImageTextureArrayManifest,
+  ImageTextureCubeArrayLayer,
+  ImageTextureCubeArrayManifest,
+  ImageTextureCubeFaces,
+  ImageTextureCubeManifest,
+  ImageTextureManifest,
+  ImageTextureSource,
+  ImageTextureTemplateSource
+} from './lib/composite-image/composite-image-manifest-schema';

--- a/modules/textures/test/composite-image-manifest-schema.spec.ts
+++ b/modules/textures/test/composite-image-manifest-schema.spec.ts
@@ -1,0 +1,132 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {
+  CompositeImageManifestSchema,
+  ImageTextureManifestSchema
+} from '@loaders.gl/textures/texture-manifest-schema';
+import {describe, expect, it} from 'vitest';
+import {z} from 'zod';
+
+describe('CompositeImageManifestSchema', () => {
+  it('accepts every supported manifest shape', () => {
+    const manifests = [
+      {shape: 'image-texture', image: 'image.png'},
+      {shape: 'image-texture-array', layers: ['layer.png']},
+      {
+        shape: 'image-texture-cube',
+        faces: {
+          '+X': 'right.png',
+          '-X': 'left.png',
+          '+Y': 'top.png',
+          '-Y': 'bottom.png',
+          '+Z': 'front.png',
+          '-Z': 'back.png'
+        }
+      },
+      {
+        shape: 'image-texture-cube-array',
+        layers: [
+          {
+            faces: {
+              right: 'right.png',
+              left: 'left.png',
+              top: 'top.png',
+              bottom: 'bottom.png',
+              front: 'front.png',
+              back: 'back.png'
+            }
+          }
+        ]
+      }
+    ];
+
+    for (const manifest of manifests) {
+      expect(CompositeImageManifestSchema.safeParse(manifest).success).toBe(true);
+    }
+  });
+
+  it('rejects malformed sources and empty collections', () => {
+    expect(ImageTextureManifestSchema.safeParse({shape: 'image-texture', image: 1}).success).toBe(
+      false
+    );
+    expect(
+      CompositeImageManifestSchema.safeParse({shape: 'image-texture-array', layers: []}).success
+    ).toBe(false);
+    expect(
+      CompositeImageManifestSchema.safeParse({
+        shape: 'image-texture-cube-array',
+        layers: [
+          {
+            faces: {
+              '+X': 'right.png',
+              '-X': 'left.png',
+              '+Y': 'top.png',
+              '-Y': 'bottom.png',
+              '+Z': 'front.png',
+              '-Z': []
+            }
+          }
+        ]
+      }).success
+    ).toBe(false);
+  });
+
+  it('requires exactly one two-dimensional image source', () => {
+    expect(ImageTextureManifestSchema.safeParse({shape: 'image-texture'}).success).toBe(false);
+    expect(
+      ImageTextureManifestSchema.safeParse({
+        shape: 'image-texture',
+        image: 'image.png',
+        mipmaps: ['mipmap.png']
+      }).success
+    ).toBe(false);
+    expect(
+      ImageTextureManifestSchema.safeParse({
+        shape: 'image-texture',
+        mipmaps: ['mipmap.png'],
+        template: 'mipmap-{level}.png'
+      }).success
+    ).toBe(false);
+  });
+
+  it('requires all six cube faces using canonical names or aliases', () => {
+    expect(
+      CompositeImageManifestSchema.safeParse({
+        shape: 'image-texture-cube',
+        faces: {
+          right: 'right.png',
+          left: 'left.png',
+          top: 'top.png',
+          bottom: 'bottom.png',
+          front: 'front.png'
+        }
+      }).success
+    ).toBe(false);
+    expect(
+      CompositeImageManifestSchema.safeParse({
+        shape: 'image-texture-cube',
+        faces: {
+          '+X': 'right.png',
+          left: 'left.png',
+          '+Y': 'top.png',
+          bottom: 'bottom.png',
+          '+Z': 'front.png',
+          back: 'back.png'
+        }
+      }).success
+    ).toBe(true);
+  });
+
+  it('can be exported as JSON Schema', () => {
+    const jsonSchema = z.toJSONSchema(CompositeImageManifestSchema, {target: 'draft-7'});
+    const serializedJsonSchema = JSON.stringify(jsonSchema);
+
+    expect(serializedJsonSchema).toContain('"required":["shape","image"]');
+    expect(serializedJsonSchema).toContain('"required":["shape","mipmaps"]');
+    expect(serializedJsonSchema).toContain('"required":["shape","template"]');
+    expect(serializedJsonSchema).toContain('"required":["+X"]');
+    expect(serializedJsonSchema).toContain('"required":["right"]');
+  });
+});

--- a/modules/textures/test/index.ts
+++ b/modules/textures/test/index.ts
@@ -7,6 +7,7 @@ import './utils/format-utils.spec';
 import './texture-api/async-deep-map.spec';
 import './texture-api/load-image.spec';
 import './texture-loader.spec';
+import './composite-image-manifest-schema.spec';
 
 import './basis-loader.spec';
 import './crunch-loader.spec';

--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
     "pre-commit": "^1.2.2",
     "pre-push": "^0.1.1",
     "vite": "^8.0.0",
-    "vitest": "^4.0.18"
+    "vitest": "^4.0.18",
+    "zod": "^4.1.12"
   },
   "pre-commit": "pre-commit",
   "pre-push": "pre-push",

--- a/scripts/generate-json-schema.mjs
+++ b/scripts/generate-json-schema.mjs
@@ -1,0 +1,43 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {writeFile} from 'node:fs/promises';
+import {resolve} from 'node:path';
+import {pathToFileURL} from 'node:url';
+import {parseArgs} from 'node:util';
+import {z} from 'zod';
+
+const {values} = parseArgs({
+  options: {
+    schema: {type: 'string'},
+    export: {type: 'string'},
+    output: {type: 'string'},
+    id: {type: 'string'},
+    title: {type: 'string'}
+  },
+  strict: true
+});
+
+for (const option of ['schema', 'export', 'output', 'id', 'title']) {
+  if (!values[option]) {
+    throw new Error(`Missing required --${option} option`);
+  }
+}
+
+const schemaModule = await import(pathToFileURL(resolve(values.schema)).href);
+const schema = schemaModule[values.export];
+
+if (!schema) {
+  throw new Error(`Module ${values.schema} does not export ${values.export}`);
+}
+
+const jsonSchema = z.toJSONSchema(schema, {
+  target: 'draft-7',
+  reused: 'ref'
+});
+
+jsonSchema.$id = values.id;
+jsonSchema.title = values.title;
+
+await writeFile(resolve(values.output), `${JSON.stringify(jsonSchema, null, 2)}\n`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5746,6 +5746,7 @@ __metadata:
     "@loaders.gl/schema-utils": "npm:5.0.0-alpha.1"
     "@math.gl/core": "npm:^4.1.0"
     "@math.gl/proj4": "npm:^4.1.0"
+    zod: "npm:^4.1.12"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
   languageName: unknown
@@ -5849,6 +5850,7 @@ __metadata:
     "@loaders.gl/worker-utils": "npm:5.0.0-alpha.1"
     "@math.gl/types": "npm:^4.1.0"
     ktx-parse: "npm:^0.7.0"
+    zod: "npm:^4.1.12"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
     texture-compressor: ^1.0.2
@@ -23393,6 +23395,7 @@ __metadata:
     pre-push: "npm:^0.1.1"
     vite: "npm:^8.0.0"
     vitest: "npm:^4.0.18"
+    zod: "npm:^4.1.12"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Goals

- Define the supported texture-manifest and Potree metadata formats once for runtime validation and JSON Schema tooling.
- Reject manifests that the loaders cannot consume.
- Preserve readable, handwritten TypeScript contracts with field-level TSDoc.
- Keep package-root imports lightweight by loading runtime schemas only through explicit subpaths or parser use.

## Changes

- Add handwritten, TSDoc-documented TypeScript contracts for 2D, array, cube, and cube-array texture manifests and Potree `cloud.js` metadata.
- Add Zod schemas checked against those public contracts with `satisfies z.ZodType<...>`.
- Expose runtime schemas from `@loaders.gl/textures/texture-manifest-schema` and `@loaders.gl/potree/potree-metadata-schema`; package roots retain type-only exports.
- Load schema-backed parser validation lazily so root imports do not evaluate Zod.
- Require exactly one of `image`, `mipmaps`, or `template` for 2D manifests.
- Require all six cube-face pairs, accepting either canonical names or direction aliases.
- Validate Potree metadata in asynchronous and synchronous parsing paths.
- Add a repository-level JSON Schema generator and publish package JSON Schema entry points.
- Document the schema APIs and cover valid, invalid, and generated-schema behavior.

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn test-node` — 407 files passed, 3 skipped; 1,946 tests passed
- `yarn test-headless` — 407 files passed, 3 skipped; 1,908 tests passed
- Package-root CommonJS smoke check confirmed neither root evaluates Zod
- Generated texture JSON Schema validated with AJV against valid and invalid 2D/cube cases