### PR TITLE
docs: add glTF and 3D Tiles page tabs

### DIFF
--- a/docs/modules/3d-tiles/README.md
+++ b/docs/modules/3d-tiles/README.md
@@ -1,4 +1,8 @@
+import {Tiles3DDocsTabs} from '@site/src/components/docs/tiles-3d-docs-tabs';
+
 # Overview
+
+<Tiles3DDocsTabs active="module" />
 
 ![ogc-logo](../../images/logos/ogc-logo-60.png)
 &nbsp;

--- a/docs/modules/3d-tiles/concepts/README.md
+++ b/docs/modules/3d-tiles/concepts/README.md
@@ -1,4 +1,8 @@
+import {Tiles3DDocsTabs} from '@site/src/components/docs/tiles-3d-docs-tabs';
+
 # 3D Tiles Runtime Concepts
+
+<Tiles3DDocsTabs active="runtime" />
 
 Loading a large 3D Tiles tileset is a continuous pipeline: traverse the hierarchy, decide which level of detail is needed, rank missing content, load within concurrency limits, render safe coverage, and retain useful content in the cache. These pages document each stage and the options that connect them.
 

--- a/docs/modules/3d-tiles/concepts/caching-and-memory.md
+++ b/docs/modules/3d-tiles/concepts/caching-and-memory.md
@@ -1,8 +1,10 @@
+import {Tiles3DDocsTabs} from '@site/src/components/docs/tiles-3d-docs-tabs';
+
 # Caching and Memory
 
-`Tileset3D` caches loaded content so camera movement can reuse tiles without immediately fetching and decoding them again. The cache cooperates with traversal: tiles touched in the current frame are protected, while unused least-recently-used content becomes eligible for eviction.
+<Tiles3DDocsTabs active="cache" />
 
-Concepts: [overview](/docs/modules/3d-tiles/concepts) · [hierarchy](./tile-hierarchy-and-refinement) · [SSE and LOD](./screen-space-error-and-lod) · [request scheduling](./request-scheduling-and-priorities) · [diagnostics](./runtime-tuning-and-diagnostics)
+`Tileset3D` caches loaded content so camera movement can reuse tiles without immediately fetching and decoding them again. The cache cooperates with traversal: tiles touched in the current frame are protected, while unused least-recently-used content becomes eligible for eviction.
 
 ## The Memory Limit Is Soft
 

--- a/docs/modules/3d-tiles/concepts/request-scheduling-and-priorities.md
+++ b/docs/modules/3d-tiles/concepts/request-scheduling-and-priorities.md
@@ -1,8 +1,10 @@
+import {Tiles3DDocsTabs} from '@site/src/components/docs/tiles-3d-docs-tabs';
+
 # Request Scheduling and Priorities
 
-A **foveated request** is an ordinary tile content request whose start time is influenced by its position in the view. It is not a new HTTP method, endpoint, file format, or server feature. The term describes client-side prioritization inspired by human vision: central detail is usually more noticeable than peripheral detail while a camera is moving.
+<Tiles3DDocsTabs active="requests" />
 
-Concepts: [overview](/docs/modules/3d-tiles/concepts) · [hierarchy](./tile-hierarchy-and-refinement) · [SSE and LOD](./screen-space-error-and-lod) · [cache and memory](./caching-and-memory) · [diagnostics](./runtime-tuning-and-diagnostics)
+A **foveated request** is an ordinary tile content request whose start time is influenced by its position in the view. It is not a new HTTP method, endpoint, file format, or server feature. The term describes client-side prioritization inspired by human vision: central detail is usually more noticeable than peripheral detail while a camera is moving.
 
 ## Selection Versus Scheduling
 

--- a/docs/modules/3d-tiles/concepts/runtime-tuning-and-diagnostics.md
+++ b/docs/modules/3d-tiles/concepts/runtime-tuning-and-diagnostics.md
@@ -1,8 +1,10 @@
+import {Tiles3DDocsTabs} from '@site/src/components/docs/tiles-3d-docs-tabs';
+
 # Runtime Tuning and Diagnostics
 
-Tune 3D Tiles in layers: establish the desired final LOD, then improve how quickly useful coverage arrives, then size request and memory resources. Changing several layers together makes symptoms harder to explain.
+<Tiles3DDocsTabs active="diagnostics" />
 
-Concepts: [overview](/docs/modules/3d-tiles/concepts) · [hierarchy](./tile-hierarchy-and-refinement) · [SSE and LOD](./screen-space-error-and-lod) · [request scheduling](./request-scheduling-and-priorities) · [cache and memory](./caching-and-memory)
+Tune 3D Tiles in layers: establish the desired final LOD, then improve how quickly useful coverage arrives, then size request and memory resources. Changing several layers together makes symptoms harder to explain.
 
 ## Recommended Sequence
 

--- a/docs/modules/3d-tiles/concepts/screen-space-error-and-lod.md
+++ b/docs/modules/3d-tiles/concepts/screen-space-error-and-lod.md
@@ -1,10 +1,12 @@
+import {Tiles3DDocsTabs} from '@site/src/components/docs/tiles-3d-docs-tabs';
+
 # Screen-Space Error and Level of Detail
+
+<Tiles3DDocsTabs active="sse-lod" />
 
 3D Tiles organizes content in a spatial hierarchy. A parent tile provides a coarser representation of an area, while its descendants provide progressively more detail. `Tileset3D` traverses this hierarchy for every viewport and uses **screen-space error (SSE)** to decide whether a tile is detailed enough to render or should refine to its children.
 
 This guide describes the loaders.gl 3D Tiles calculation. It also explains how projection, transforms, display pixel density, and traversal options affect the selected level of detail (LOD).
-
-Concepts: [overview](/docs/modules/3d-tiles/concepts) · [hierarchy](./tile-hierarchy-and-refinement) · [request scheduling](./request-scheduling-and-priorities) · [cache and memory](./caching-and-memory) · [diagnostics](./runtime-tuning-and-diagnostics)
 
 ![3D Tiles correctness flow from transform-scaled geometric error through perspective or orthographic SSE to LOD refinement, plus early required-extension validation](../images/screen-space-error-and-lod.png)
 

--- a/docs/modules/3d-tiles/concepts/tile-hierarchy-and-refinement.md
+++ b/docs/modules/3d-tiles/concepts/tile-hierarchy-and-refinement.md
@@ -1,8 +1,10 @@
+import {Tiles3DDocsTabs} from '@site/src/components/docs/tiles-3d-docs-tabs';
+
 # Tile Hierarchy and Refinement
 
-3D Tiles divides a dataset into a tree. A tile describes a bounding volume, a geometric error, an optional content resource, and zero or more children. Traversal visits visible branches and decides whether each tile can provide current coverage or needs descendants.
+<Tiles3DDocsTabs active="hierarchy" />
 
-Concepts: [overview](/docs/modules/3d-tiles/concepts) · [SSE and LOD](./screen-space-error-and-lod) · [request scheduling](./request-scheduling-and-priorities) · [cache and memory](./caching-and-memory) · [diagnostics](./runtime-tuning-and-diagnostics)
+3D Tiles divides a dataset into a tree. A tile describes a bounding volume, a geometric error, an optional content resource, and zero or more children. Traversal visits visible branches and decides whether each tile can provide current coverage or needs descendants.
 
 ## The Per-Frame Pipeline
 

--- a/docs/modules/gltf/README.md
+++ b/docs/modules/gltf/README.md
@@ -1,4 +1,8 @@
+import {GltfDocsTabs} from '@site/src/components/docs/gltf-docs-tabs';
+
 # Overview
+
+<GltfDocsTabs active="overview" />
 
 ![logo](./images/gltf-small.png)
 

--- a/docs/modules/gltf/api-reference/gltf-loader.md
+++ b/docs/modules/gltf/api-reference/gltf-loader.md
@@ -1,4 +1,8 @@
+import {GltfDocsTabs} from '@site/src/components/docs/gltf-docs-tabs';
+
 # GLTFLoader
+
+<GltfDocsTabs active="gltf-loader" />
 
 <p class="badges">
   <img src="https://img.shields.io/badge/From-v1.0-blue.svg?style=flat-square" alt="From-v1.0" />

--- a/docs/modules/gltf/api-reference/post-process-gltf.md
+++ b/docs/modules/gltf/api-reference/post-process-gltf.md
@@ -1,4 +1,8 @@
+import {GltfDocsTabs} from '@site/src/components/docs/gltf-docs-tabs';
+
 # postProcessGLTF
+
+<GltfDocsTabs active="post-processing" />
 
 The `postProcessGLTF` function transforms standards-compliant glTF JSON
 into an inter-linked JavaScript data structure that it significantly easier to work with.

--- a/docs/modules/gltf/formats/gltf.md
+++ b/docs/modules/gltf/formats/gltf.md
@@ -1,4 +1,8 @@
+import {GltfDocsTabs} from '@site/src/components/docs/gltf-docs-tabs';
+
 # glTF - gl Transfer Format
+
+<GltfDocsTabs active="format" />
 
 - _[`@loaders.gl/gltf`](/docs/modules/gltf)_
 - _[glTF specification](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html)_

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -208,7 +208,7 @@ A minor release that includes:
 - **Foveated tile requests** Perspective tiles near the view axis receive priority over equally needed peripheral detail without changing the final LOD target.
 - **Motion-aware request deferral** Refinement-safe peripheral requests can pause briefly during camera motion and automatically resume after the configured delay.
 - **Request-priority diagnostics** Tile runtime fields and tests expose progressive, foveated, deferred, and combined priority calculations.
-- **3D Tiles runtime guides** A [sidebar-linked concepts suite](/docs/modules/3d-tiles/concepts) documents hierarchy refinement, SSE/LOD, request scheduling, foveation, caching, memory, tuning, and diagnostics.
+- **3D Tiles runtime guides** A [sidebar- and tab-linked concepts suite](/docs/modules/3d-tiles/concepts) documents hierarchy refinement, SSE/LOD, request scheduling, foveation, caching, memory, tuning, and diagnostics.
 
 **@loaders.gl/tile-converter**
 

--- a/website/src/components/docs/gltf-docs-tabs.tsx
+++ b/website/src/components/docs/gltf-docs-tabs.tsx
@@ -1,0 +1,52 @@
+import React, {type ReactNode} from 'react';
+import Link from '@docusaurus/Link';
+
+type GltfDocsTab = {
+  /** Stable tab identifier. */
+  id: GltfDocsTabId;
+  /** User-facing tab label. */
+  label: string;
+  /** Documentation page URL. */
+  href: string;
+};
+
+/** glTF documentation tab identifiers. */
+export type GltfDocsTabId = 'overview' | 'format' | 'gltf-loader' | 'post-processing';
+
+const GLTF_DOCS_TABS: GltfDocsTab[] = [
+  {id: 'overview', label: 'Overview', href: '/docs/modules/gltf'},
+  {id: 'format', label: 'glTF Format', href: '/docs/modules/gltf/formats/gltf'},
+  {id: 'gltf-loader', label: 'GLTFLoader', href: '/docs/modules/gltf/api-reference/gltf-loader'},
+  {
+    id: 'post-processing',
+    label: 'Post-processing',
+    href: '/docs/modules/gltf/api-reference/post-process-gltf'
+  }
+];
+
+/** Renders links between the glTF pages that describe loading and mesh decompression. */
+export function GltfDocsTabs({
+  active
+}: {
+  /** Active tab identifier. */
+  active: GltfDocsTabId;
+}): ReactNode {
+  return (
+    <nav className="docs-page-tabs" aria-label="glTF documentation sections">
+      {GLTF_DOCS_TABS.map(tab => (
+        <Link
+          key={tab.id}
+          className={
+            tab.id === active
+              ? 'docs-page-tabs__tab docs-page-tabs__tab--active'
+              : 'docs-page-tabs__tab'
+          }
+          to={tab.href}
+          aria-current={tab.id === active ? 'page' : undefined}
+        >
+          {tab.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/website/src/components/docs/tiles-3d-docs-tabs.tsx
+++ b/website/src/components/docs/tiles-3d-docs-tabs.tsx
@@ -1,0 +1,78 @@
+import React, {type ReactNode} from 'react';
+import Link from '@docusaurus/Link';
+
+type Tiles3DDocsTab = {
+  /** Stable tab identifier. */
+  id: Tiles3DDocsTabId;
+  /** User-facing tab label. */
+  label: string;
+  /** Documentation page URL. */
+  href: string;
+};
+
+/** 3D Tiles documentation tab identifiers. */
+export type Tiles3DDocsTabId =
+  | 'module'
+  | 'runtime'
+  | 'hierarchy'
+  | 'sse-lod'
+  | 'requests'
+  | 'cache'
+  | 'diagnostics';
+
+const TILES_3D_DOCS_TABS: Tiles3DDocsTab[] = [
+  {id: 'module', label: 'Module', href: '/docs/modules/3d-tiles'},
+  {id: 'runtime', label: 'Runtime', href: '/docs/modules/3d-tiles/concepts'},
+  {
+    id: 'hierarchy',
+    label: 'Hierarchy',
+    href: '/docs/modules/3d-tiles/concepts/tile-hierarchy-and-refinement'
+  },
+  {
+    id: 'sse-lod',
+    label: 'SSE / LOD',
+    href: '/docs/modules/3d-tiles/concepts/screen-space-error-and-lod'
+  },
+  {
+    id: 'requests',
+    label: 'Requests',
+    href: '/docs/modules/3d-tiles/concepts/request-scheduling-and-priorities'
+  },
+  {
+    id: 'cache',
+    label: 'Cache',
+    href: '/docs/modules/3d-tiles/concepts/caching-and-memory'
+  },
+  {
+    id: 'diagnostics',
+    label: 'Diagnostics',
+    href: '/docs/modules/3d-tiles/concepts/runtime-tuning-and-diagnostics'
+  }
+];
+
+/** Renders links between the 3D Tiles module and runtime-concepts documentation pages. */
+export function Tiles3DDocsTabs({
+  active
+}: {
+  /** Active tab identifier. */
+  active: Tiles3DDocsTabId;
+}): ReactNode {
+  return (
+    <nav className="docs-page-tabs" aria-label="3D Tiles documentation sections">
+      {TILES_3D_DOCS_TABS.map(tab => (
+        <Link
+          key={tab.id}
+          className={
+            tab.id === active
+              ? 'docs-page-tabs__tab docs-page-tabs__tab--active'
+              : 'docs-page-tabs__tab'
+          }
+          to={tab.href}
+          aria-current={tab.id === active ? 'page' : undefined}
+        >
+          {tab.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}


### PR DESCRIPTION
## Goals

- Make the related glTF loading and mesh-compression documentation directly navigable without returning to the sidebar.
- Make the complete 3D Tiles runtime-concepts suite behave as one connected documentation set.
- Reuse the website's established accessible page-tab pattern.

## Changes

- Add a dedicated glTF tab group linking the module overview, glTF format guide, `GLTFLoader`, and `postProcessGLTF` pages.
- Add a dedicated 3D Tiles tab group linking the module overview, runtime overview, hierarchy, SSE/LOD, request scheduling, caching, and diagnostics pages.
- Render each group immediately below the page title with a typed active-tab identifier, `aria-current="page"`, and module-specific navigation label.
- Replace the repeated inline 3D Tiles concept-link rows with the persistent tab group.
- Add TSDoc for each new component, exported tab identifier, field, and prop.
- Update What's New to describe the 3D Tiles concepts suite as sidebar- and tab-linked.

## Validation

- `yarn install`
- `yarn lint fix`
- `yarn build`
- `yarn test-node` — 1,687 passed; 75 skipped
- `yarn test-headless` — 1,683 passed; 60 skipped
- `cd website && yarn && yarn build`
- Inspected generated HTML for all 11 pages; every page renders the expected accessible navigation and exactly one active tab

The website build emits only the repository's existing dependency, bundler, and static-generation warnings.

## Related work

- Follows the merged 3D Tiles runtime documentation in #3509.
- Follows the merged KHR/EXT meshopt documentation in #3511.
