### PR TITLE
Fix glTF 2.1 review findings

### DIFF
--- a/modules/gltf/README.md
+++ b/modules/gltf/README.md
@@ -4,7 +4,12 @@ The module exports [Zod](https://zod.dev/) schemas for glTF 1.0, glTF 2.0, draft
 all Khronos extension schema fragments, and the individual glTF 2.0 JSON objects:
 
 ```ts
-import {GLTF1Schema, GLTF2Schema, GLTF21Schema, GLTFVersionSchema} from '@loaders.gl/gltf';
+import {
+  GLTF1Schema,
+  GLTF2Schema,
+  GLTF21Schema,
+  GLTFVersionSchema
+} from '@loaders.gl/gltf/schema';
 
 const gltf = GLTF2Schema.parse(json);
 ```

--- a/modules/gltf/package.json
+++ b/modules/gltf/package.json
@@ -29,6 +29,10 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
+    "./schema": {
+      "types": "./dist/schema.d.ts",
+      "import": "./dist/schema.js"
+    },
     "./unbundled": {
       "types": "./dist/unbundled.d.ts",
       "import": "./dist/unbundled.js"

--- a/modules/gltf/src/index.ts
+++ b/modules/gltf/src/index.ts
@@ -104,6 +104,7 @@ export {
   GLTFCameraOrthographicSchema,
   GLTFCameraPerspectiveSchema,
   GLTFImageSchema,
+  GLTFExternalAssetSchema,
   GLTFMaterialSchema,
   GLTFMaterialNormalTextureInfoSchema,
   GLTFMaterialOcclusionTextureInfoSchema,
@@ -125,20 +126,6 @@ export {
   GLTFEXTTextureWebpSchema,
   GLTFMSFTTextureDdsSchema
 } from './lib/types/gltf-zod-schema';
-export {
-  GLTF1Schema,
-  GLTF2Schema,
-  GLTF21Schema,
-  GLTFVersionSchema,
-  GLTFExtensionSchemas,
-  GLTF1ExtensionSchemas,
-  GLTF2ExtensionSchemas,
-  GLTF1_JSON_SCHEMA,
-  GLTF2_JSON_SCHEMA,
-  GLTF21_JSON_SCHEMA,
-  GLTF_EXTENSION_JSON_SCHEMAS,
-  GLTF_SCHEMA_SOURCE_COMMITS
-} from './lib/types/gltf-version-zod-schemas';
 export {GLTFFormat, GLBFormat} from './gltf-format';
 
 // glTF loader/writer definition objects

--- a/modules/gltf/src/lib/gltf-utils/gltf-utils.ts
+++ b/modules/gltf/src/lib/gltf-utils/gltf-utils.ts
@@ -19,7 +19,9 @@ type TypedArrayConstructor =
   | Int32ArrayConstructor
   | Uint32ArrayConstructor
   | Float32ArrayConstructor
-  | Float64ArrayConstructor;
+  | Float64ArrayConstructor
+  | BigInt64ArrayConstructor
+  | BigUint64ArrayConstructor;
 
 const ARRAY_CONSTRUCTOR_TO_WEBGL_CONSTANT: [TypedArrayConstructor, number][] = [
   [Int8Array, 5120],
@@ -29,7 +31,9 @@ const ARRAY_CONSTRUCTOR_TO_WEBGL_CONSTANT: [TypedArrayConstructor, number][] = [
   [Int32Array, 5124],
   [Uint32Array, 5125],
   [Float32Array, 5126],
-  [Float64Array, 5130]
+  [Float64Array, 5130],
+  [BigInt64Array, 5134],
+  [BigUint64Array, 5135]
 ];
 const ARRAY_TO_COMPONENT_TYPE = new Map<TypedArrayConstructor, number>(
   ARRAY_CONSTRUCTOR_TO_WEBGL_CONSTANT

--- a/modules/gltf/src/lib/gltf-utils/resolve-gltf-file.ts
+++ b/modules/gltf/src/lib/gltf-utils/resolve-gltf-file.ts
@@ -65,7 +65,7 @@ export async function resolveGLTFFile(
   if (file.uri !== undefined) {
     const url = resolveUrl(file.uri, options, context);
     const response = await context.fetch(url);
-    assert(response, `Failed to fetch glTF file ${file.uri}.`);
+    assert(response?.ok, `Failed to fetch glTF file ${file.uri}: HTTP ${response?.status}.`);
     const arrayBuffer = await response.arrayBuffer();
     resolvedFile = {
       arrayBuffer,

--- a/modules/gltf/src/lib/gltf-utils/resolve-url.ts
+++ b/modules/gltf/src/lib/gltf-utils/resolve-url.ts
@@ -6,13 +6,28 @@ export function resolveUrl(url: string, options?: StrictLoaderOptions, context?:
   // TODO: Use better logic to handle all protocols plus not delay on data
   const absolute = url.startsWith('data:') || url.startsWith('http:') || url.startsWith('https:');
   if (absolute) {
-    return url;
+    return canonicalizeUrl(url);
   }
   const baseUrl = context?.baseUrl || getResolveBaseUrl(options?.core?.baseUrl);
   if (!baseUrl) {
     throw new Error(`'baseUrl' must be provided to resolve relative url ${url}`);
   }
-  return baseUrl.endsWith('/') ? `${baseUrl}${url}` : `${baseUrl}/${url}`;
+  const resolvedUrl = baseUrl.endsWith('/') ? `${baseUrl}${url}` : `${baseUrl}/${url}`;
+  return canonicalizeUrl(resolvedUrl);
+}
+
+/**
+ * Normalize equivalent absolute URLs for cache and cycle-detection keys.
+ * Non-URL paths are returned unchanged so local and virtual file-system resolution remains intact.
+ * @param url - URL to normalize.
+ * @returns Canonical URL when the input has a supported absolute scheme.
+ */
+export function canonicalizeUrl(url: string): string {
+  try {
+    return new URL(url).href;
+  } catch {
+    return url;
+  }
 }
 
 function getResolveBaseUrl(baseUrl?: string): string | undefined {

--- a/modules/gltf/src/lib/parsers/parse-gltf.ts
+++ b/modules/gltf/src/lib/parsers/parse-gltf.ts
@@ -12,7 +12,7 @@ import {BasisLoader, selectSupportedBasisFormat} from '@loaders.gl/textures';
 
 import {assert} from '../utils/assert';
 import {isGLB, parseGLBSync} from './parse-glb';
-import {resolveUrl} from '../gltf-utils/resolve-url';
+import {canonicalizeUrl, resolveUrl} from '../gltf-utils/resolve-url';
 import {findGLTFFileIndex, resolveGLTFFile} from '../gltf-utils/resolve-gltf-file';
 import {getTypedArrayForBufferView} from '../gltf-utils/get-typed-array';
 import {preprocessExtensions, decodeExtensions} from '../api/gltf-extensions';
@@ -211,6 +211,15 @@ function parseGLTFContainerSync(gltf, data, byteOffset, options: GLTFLoaderOptio
       };
     }
 
+    if (gltf._glb.version === 3) {
+      for (const bufferIndex of uriLessBufferIndices) {
+        assert(
+          gltf.buffers[bufferIndex],
+          `glTF buffer ${bufferIndex} without a uri must define a valid GLB v3 chunk.`
+        );
+      }
+    }
+
     // TODO - this modifies JSON and is a post processing thing
     // gltf.json.buffers[0].data = gltf.buffers[0].arrayBuffer;
     // gltf.json.buffers[0].byteOffset = gltf.buffers[0].byteOffset;
@@ -264,7 +273,7 @@ async function loadExternalAssets(
 
   const state =
     inheritedState ||
-    createExternalAssetLoadState(context.url ? new Set([context.url]) : new Set());
+    createExternalAssetLoadState(context.url ? new Set([canonicalizeUrl(context.url)]) : new Set());
   for (const externalAssetIndex of referencedIndices) {
     await loadExternalAsset(gltf, externalAssetIndex, options, context, state);
   }

--- a/modules/gltf/src/lib/types/gltf-version-zod-schemas.ts
+++ b/modules/gltf/src/lib/types/gltf-version-zod-schemas.ts
@@ -13,6 +13,8 @@ import {
 import {GLTFSchema} from './gltf-zod-schema';
 
 type JsonSchema = Parameters<typeof z.fromJSONSchema>[0];
+type JsonSchemaRecord = Record<string, unknown>;
+type JsonSchemaTarget = 'draft-4' | 'draft-2020-12';
 type ExtensionFragmentSchemas = Record<string, z.ZodType>;
 type NamedExtensionSchemas = Record<string, ExtensionFragmentSchemas>;
 type ExtensionStatusSchemas = Record<string, NamedExtensionSchemas>;
@@ -24,10 +26,13 @@ const UNSUPPORTED_ZOD_JSON_SCHEMA_KEYWORDS = new Set([
   'dependentSchemas',
   'if',
   'then',
-  'else',
-  'unevaluatedItems',
-  'unevaluatedProperties'
+  'else'
 ]);
+
+type JsonSchemaConstraintIssue = {
+  message: string;
+  path: PropertyKey[];
+};
 
 /** Creates a Zod-compatible copy of an authoritative Khronos JSON Schema. */
 function prepareJsonSchemaForZod(value: unknown): unknown {
@@ -39,6 +44,16 @@ function prepareJsonSchemaForZod(value: unknown): unknown {
   }
   const prepared: Record<string, unknown> = {};
   for (const [key, item] of Object.entries(value)) {
+    // JSON Schema defaults are annotations, not mutations performed during validation.
+    if (key === 'default') {
+      continue;
+    }
+    // Zod's exclusive union conversion rejects required-only branches. Convert the supported
+    // shape as an inclusive union; findBranchConstraintIssue enforces oneOf exclusivity.
+    if (key === 'oneOf') {
+      prepared.anyOf = prepareJsonSchemaForZod(item);
+      continue;
+    }
     if (UNSUPPORTED_ZOD_JSON_SCHEMA_KEYWORDS.has(key)) {
       continue;
     }
@@ -48,6 +63,379 @@ function prepareJsonSchemaForZod(value: unknown): unknown {
     prepared[key] = prepareJsonSchemaForZod(item);
   }
   return prepared;
+}
+
+/** Convert an authoritative JSON Schema while retaining constraints unsupported by Zod. */
+function createConstrainedZodSchema(
+  schema: JsonSchemaRecord,
+  defaultTarget: JsonSchemaTarget
+): z.ZodType {
+  const convertedSchema = z.fromJSONSchema(prepareJsonSchemaForZod(schema) as JsonSchema, {
+    defaultTarget
+  });
+  return convertedSchema.superRefine((value, context) => {
+    const issue = findJsonSchemaConstraintIssue(value, schema, schema, defaultTarget, []);
+    if (issue) {
+      context.addIssue({code: 'custom', message: issue.message, path: issue.path});
+    }
+  });
+}
+
+/** Find the first violation of a JSON Schema keyword omitted during Zod conversion. */
+function findJsonSchemaConstraintIssue(
+  value: unknown,
+  schemaValue: unknown,
+  rootSchema: JsonSchemaRecord,
+  defaultTarget: JsonSchemaTarget,
+  path: PropertyKey[]
+): JsonSchemaConstraintIssue | null {
+  if (typeof schemaValue === 'boolean') {
+    return schemaValue ? null : {message: 'Value is forbidden by the JSON Schema.', path};
+  }
+  if (!isJsonSchemaRecord(schemaValue)) {
+    return null;
+  }
+
+  const reference = schemaValue.$ref;
+  if (typeof reference === 'string' && reference.startsWith('#/')) {
+    const referencedSchema = resolveLocalJsonSchemaReference(rootSchema, reference);
+    const issue = findJsonSchemaConstraintIssue(
+      value,
+      referencedSchema,
+      rootSchema,
+      defaultTarget,
+      path
+    );
+    if (issue) {
+      return issue;
+    }
+  }
+
+  const dependencyIssue = findDependencyIssue(value, schemaValue, rootSchema, defaultTarget, path);
+  if (dependencyIssue) {
+    return dependencyIssue;
+  }
+
+  if (
+    schemaValue.not &&
+    matchesPreparedJsonSchema(value, schemaValue.not, rootSchema, defaultTarget) &&
+    !findJsonSchemaConstraintIssue(value, schemaValue.not, rootSchema, defaultTarget, path)
+  ) {
+    return {message: 'Value matches a forbidden JSON Schema.', path};
+  }
+
+  const conditionalIssue = findConditionalIssue(
+    value,
+    schemaValue,
+    rootSchema,
+    defaultTarget,
+    path
+  );
+  if (conditionalIssue) {
+    return conditionalIssue;
+  }
+
+  for (const allOfSchema of getSchemaArray(schemaValue.allOf)) {
+    const issue = findJsonSchemaConstraintIssue(
+      value,
+      allOfSchema,
+      rootSchema,
+      defaultTarget,
+      path
+    );
+    if (issue) {
+      return issue;
+    }
+  }
+
+  const anyOfIssue = findBranchConstraintIssue(
+    value,
+    schemaValue.anyOf,
+    rootSchema,
+    defaultTarget,
+    path,
+    false
+  );
+  if (anyOfIssue) {
+    return anyOfIssue;
+  }
+  const oneOfIssue = findBranchConstraintIssue(
+    value,
+    schemaValue.oneOf,
+    rootSchema,
+    defaultTarget,
+    path,
+    true
+  );
+  if (oneOfIssue) {
+    return oneOfIssue;
+  }
+
+  if (isJsonSchemaRecord(value)) {
+    const properties = isJsonSchemaRecord(schemaValue.properties) ? schemaValue.properties : {};
+    const patternProperties = isJsonSchemaRecord(schemaValue.patternProperties)
+      ? schemaValue.patternProperties
+      : {};
+    for (const [propertyName, propertySchema] of Object.entries(properties)) {
+      if (propertyName in value) {
+        const issue = findJsonSchemaConstraintIssue(
+          value[propertyName],
+          propertySchema,
+          rootSchema,
+          defaultTarget,
+          [...path, propertyName]
+        );
+        if (issue) {
+          return issue;
+        }
+      }
+    }
+    for (const [propertyName, propertyValue] of Object.entries(value)) {
+      if (propertyName in properties) {
+        continue;
+      }
+      let matchedPattern = false;
+      for (const [pattern, propertySchema] of Object.entries(patternProperties)) {
+        if (new RegExp(pattern).test(propertyName)) {
+          matchedPattern = true;
+          const issue = findJsonSchemaConstraintIssue(
+            propertyValue,
+            propertySchema,
+            rootSchema,
+            defaultTarget,
+            [...path, propertyName]
+          );
+          if (issue) {
+            return issue;
+          }
+        }
+      }
+      if (!matchedPattern && isJsonSchemaRecord(schemaValue.additionalProperties)) {
+        const issue = findJsonSchemaConstraintIssue(
+          propertyValue,
+          schemaValue.additionalProperties,
+          rootSchema,
+          defaultTarget,
+          [...path, propertyName]
+        );
+        if (issue) {
+          return issue;
+        }
+      }
+    }
+  }
+
+  if (Array.isArray(value)) {
+    const prefixItems = getSchemaArray(schemaValue.prefixItems);
+    for (let index = 0; index < prefixItems.length && index < value.length; index++) {
+      const issue = findJsonSchemaConstraintIssue(
+        value[index],
+        prefixItems[index],
+        rootSchema,
+        defaultTarget,
+        [...path, index]
+      );
+      if (issue) {
+        return issue;
+      }
+    }
+    if (schemaValue.items && !Array.isArray(schemaValue.items)) {
+      for (let index = prefixItems.length; index < value.length; index++) {
+        const issue = findJsonSchemaConstraintIssue(
+          value[index],
+          schemaValue.items,
+          rootSchema,
+          defaultTarget,
+          [...path, index]
+        );
+        if (issue) {
+          return issue;
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+/** Validate property dependency keywords from draft-04 and draft-2020-12. */
+function findDependencyIssue(
+  value: unknown,
+  schema: JsonSchemaRecord,
+  rootSchema: JsonSchemaRecord,
+  defaultTarget: JsonSchemaTarget,
+  path: PropertyKey[]
+): JsonSchemaConstraintIssue | null {
+  if (!isJsonSchemaRecord(value)) {
+    return null;
+  }
+  const dependencyGroups = [schema.dependencies, schema.dependentRequired];
+  for (const dependencyGroup of dependencyGroups) {
+    if (!isJsonSchemaRecord(dependencyGroup)) {
+      continue;
+    }
+    for (const [propertyName, requiredProperties] of Object.entries(dependencyGroup)) {
+      if (!(propertyName in value)) {
+        continue;
+      }
+      if (Array.isArray(requiredProperties)) {
+        for (const requiredProperty of requiredProperties) {
+          if (typeof requiredProperty === 'string' && !(requiredProperty in value)) {
+            return {
+              message: `${requiredProperty} is required when ${propertyName} is defined.`,
+              path
+            };
+          }
+        }
+      } else if (!matchesPreparedJsonSchema(value, requiredProperties, rootSchema, defaultTarget)) {
+        return {message: `Dependency for ${propertyName} is not satisfied.`, path};
+      } else {
+        const issue = findJsonSchemaConstraintIssue(
+          value,
+          requiredProperties,
+          rootSchema,
+          defaultTarget,
+          path
+        );
+        if (issue) {
+          return {
+            message: `Dependency for ${propertyName} is not satisfied: ${issue.message}`,
+            path: issue.path
+          };
+        }
+      }
+    }
+  }
+  const dependentSchemas = isJsonSchemaRecord(schema.dependentSchemas)
+    ? schema.dependentSchemas
+    : {};
+  for (const [propertyName, dependentSchema] of Object.entries(dependentSchemas)) {
+    if (!(propertyName in value)) {
+      continue;
+    }
+    if (!matchesPreparedJsonSchema(value, dependentSchema, rootSchema, defaultTarget)) {
+      return {message: `Dependency for ${propertyName} is not satisfied.`, path};
+    }
+    const issue = findJsonSchemaConstraintIssue(
+      value,
+      dependentSchema,
+      rootSchema,
+      defaultTarget,
+      path
+    );
+    if (issue) {
+      return issue;
+    }
+  }
+  return null;
+}
+
+/** Validate draft conditional keywords omitted during Zod conversion. */
+function findConditionalIssue(
+  value: unknown,
+  schema: JsonSchemaRecord,
+  rootSchema: JsonSchemaRecord,
+  defaultTarget: JsonSchemaTarget,
+  path: PropertyKey[]
+): JsonSchemaConstraintIssue | null {
+  if (!schema.if) {
+    return null;
+  }
+  const branch = matchesPreparedJsonSchema(value, schema.if, rootSchema, defaultTarget)
+    ? schema.then
+    : schema.else;
+  if (!branch) {
+    return null;
+  }
+  if (!matchesPreparedJsonSchema(value, branch, rootSchema, defaultTarget)) {
+    return {message: 'Value violates a conditional JSON Schema branch.', path};
+  }
+  return findJsonSchemaConstraintIssue(value, branch, rootSchema, defaultTarget, path);
+}
+
+/** Validate unsupported constraints inside matching anyOf and oneOf branches. */
+function findBranchConstraintIssue(
+  value: unknown,
+  schemaValue: unknown,
+  rootSchema: JsonSchemaRecord,
+  defaultTarget: JsonSchemaTarget,
+  path: PropertyKey[],
+  requireExactlyOne: boolean
+): JsonSchemaConstraintIssue | null {
+  const schemas = getSchemaArray(schemaValue);
+  if (!schemas.length) {
+    return null;
+  }
+  const matchingSchemas = schemas.filter(schema =>
+    matchesPreparedJsonSchema(value, schema, rootSchema, defaultTarget)
+  );
+  const issues = matchingSchemas.map(schema =>
+    findJsonSchemaConstraintIssue(value, schema, rootSchema, defaultTarget, path)
+  );
+  const validBranchCount = issues.filter(issue => !issue).length;
+  if (validBranchCount === 0 && issues.length) {
+    return issues.find(Boolean) || {message: 'Value violates a JSON Schema branch.', path};
+  }
+  if (requireExactlyOne && validBranchCount > 1) {
+    return {message: 'Value matches more than one exclusive JSON Schema branch.', path};
+  }
+  return null;
+}
+
+/** Test the supported portion of a schema while retaining its local definitions. */
+function matchesPreparedJsonSchema(
+  value: unknown,
+  schemaValue: unknown,
+  rootSchema: JsonSchemaRecord,
+  defaultTarget: JsonSchemaTarget
+): boolean {
+  if (!isJsonSchemaRecord(schemaValue)) {
+    return schemaValue !== false;
+  }
+  if (Array.isArray(schemaValue.required)) {
+    if (!isJsonSchemaRecord(value)) {
+      return false;
+    }
+    for (const requiredProperty of schemaValue.required) {
+      if (typeof requiredProperty === 'string' && !(requiredProperty in value)) {
+        return false;
+      }
+    }
+  }
+  const schema = {
+    ...schemaValue,
+    ...(rootSchema.definitions ? {definitions: rootSchema.definitions} : {}),
+    ...(rootSchema.$defs ? {$defs: rootSchema.$defs} : {})
+  };
+  try {
+    return z
+      .fromJSONSchema(prepareJsonSchemaForZod(schema) as JsonSchema, {defaultTarget})
+      .safeParse(value).success;
+  } catch {
+    return false;
+  }
+}
+
+/** Resolve a local JSON Pointer reference within a bundled schema. */
+function resolveLocalJsonSchemaReference(rootSchema: JsonSchemaRecord, reference: string): unknown {
+  return reference
+    .slice(2)
+    .split('/')
+    .map(segment => segment.replace(/~1/g, '/').replace(/~0/g, '~'))
+    .reduce<unknown>(
+      (value, segment) => (isJsonSchemaRecord(value) ? value[segment] : undefined),
+      rootSchema
+    );
+}
+
+/** Return an unknown value as a schema array when possible. */
+function getSchemaArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+/** Check whether a value is a non-array JSON object. */
+function isJsonSchemaRecord(value: unknown): value is JsonSchemaRecord {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
 
 /** Converts nested Khronos extension JSON Schemas into an equivalent nested Zod schema map. */
@@ -62,9 +450,9 @@ function createExtensionSchemaMap(value: Record<string, unknown>): VersionedExte
       )) {
         result[version][status][extensionName] = {};
         for (const [fragmentName, schema] of Object.entries(fragments as Record<string, unknown>)) {
-          result[version][status][extensionName][fragmentName] = z.fromJSONSchema(
-            prepareJsonSchemaForZod(schema) as JsonSchema,
-            {defaultTarget: 'draft-4'}
+          result[version][status][extensionName][fragmentName] = createConstrainedZodSchema(
+            schema as JsonSchemaRecord,
+            'draft-4'
           );
         }
       }
@@ -74,15 +462,11 @@ function createExtensionSchemaMap(value: Record<string, unknown>): VersionedExte
 }
 
 /** Zod schema for a glTF 1.0 JSON document. */
-export const GLTF1Schema = z
-  .fromJSONSchema(prepareJsonSchemaForZod(GLTF1_JSON_SCHEMA) as JsonSchema, {
-    defaultTarget: 'draft-4'
-  })
-  .and(
-    z
-      .object({asset: z.object({version: z.literal('1.0')}).catchall(z.unknown())})
-      .catchall(z.unknown())
-  );
+export const GLTF1Schema = createConstrainedZodSchema(GLTF1_JSON_SCHEMA, 'draft-4').and(
+  z
+    .object({asset: z.object({version: z.literal('1.0')}).catchall(z.unknown())})
+    .catchall(z.unknown())
+);
 
 /** Zod schema for a glTF 2.0 JSON document. */
 export const GLTF2Schema = GLTFSchema.and(
@@ -92,15 +476,11 @@ export const GLTF2Schema = GLTFSchema.and(
 );
 
 /** Zod schema for a draft glTF 2.1 JSON document. */
-export const GLTF21Schema = z
-  .fromJSONSchema(prepareJsonSchemaForZod(GLTF21_JSON_SCHEMA) as JsonSchema, {
-    defaultTarget: 'draft-2020-12'
-  })
-  .and(
-    z
-      .object({asset: z.object({version: z.literal('2.1')}).catchall(z.unknown())})
-      .catchall(z.unknown())
-  );
+export const GLTF21Schema = createConstrainedZodSchema(GLTF21_JSON_SCHEMA, 'draft-2020-12').and(
+  z
+    .object({asset: z.object({version: z.literal('2.1')}).catchall(z.unknown())})
+    .catchall(z.unknown())
+);
 
 /** Zod schema accepting glTF 1.0, glTF 2.0, or draft glTF 2.1 JSON documents. */
 export const GLTFVersionSchema = z.union([GLTF1Schema, GLTF2Schema, GLTF21Schema]);

--- a/modules/gltf/src/lib/types/gltf-zod-schema.ts
+++ b/modules/gltf/src/lib/types/gltf-zod-schema.ts
@@ -306,6 +306,15 @@ export const GLTFNodeSchema = z
     scale: z.array(z.number()).length(3).optional(),
     translation: z.array(z.number()).length(3).optional(),
     weights: z.array(z.number()).min(1).optional(),
+    externalAsset: GLTFIdSchema.optional(),
+    ...GLTF_NAMED_PROPERTY_SHAPE
+  })
+  .catchall(z.unknown());
+
+/** Zod schema for a draft glTF 2.1 external asset definition. */
+export const GLTFExternalAssetSchema = z
+  .object({
+    file: GLTFIdSchema,
     ...GLTF_NAMED_PROPERTY_SHAPE
   })
   .catchall(z.unknown());
@@ -369,6 +378,7 @@ export const GLTFSchema = z
     buffers: z.array(GLTFBufferSchema).min(1).optional(),
     bufferViews: z.array(GLTFBufferViewSchema).min(1).optional(),
     cameras: z.array(GLTFCameraSchema).min(1).optional(),
+    externalAssets: z.array(GLTFExternalAssetSchema).min(1).optional(),
     images: z.array(GLTFImageSchema).min(1).optional(),
     materials: z.array(GLTFMaterialSchema).min(1).optional(),
     meshes: z.array(GLTFMeshSchema).min(1).optional(),
@@ -396,7 +406,8 @@ export const GLTFObjectSchema = z.union([
   GLTFSceneSchema,
   GLTFSkinSchema,
   GLTFTextureSchema,
-  GLTFImageSchema
+  GLTFImageSchema,
+  GLTFExternalAssetSchema
 ]);
 
 /** Zod schema for the KHR_binary_glTF extension. */

--- a/modules/gltf/src/schema.ts
+++ b/modules/gltf/src/schema.ts
@@ -1,0 +1,19 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** Official versioned glTF Zod schemas and their bundled JSON Schema sources. */
+export {
+  GLTF1Schema,
+  GLTF2Schema,
+  GLTF21Schema,
+  GLTFVersionSchema,
+  GLTFExtensionSchemas,
+  GLTF1ExtensionSchemas,
+  GLTF2ExtensionSchemas,
+  GLTF1_JSON_SCHEMA,
+  GLTF2_JSON_SCHEMA,
+  GLTF21_JSON_SCHEMA,
+  GLTF_EXTENSION_JSON_SCHEMAS,
+  GLTF_SCHEMA_SOURCE_COMMITS
+} from './lib/types/gltf-version-zod-schemas';

--- a/modules/gltf/test/gltf-loader.spec.ts
+++ b/modules/gltf/test/gltf-loader.spec.ts
@@ -98,6 +98,21 @@ test('GLTFLoader#parse(v3) preserves legacy implicit buffer mapping', async t =>
   t.end();
 });
 
+test('GLTFLoader#parse(v3) rejects implicit buffers outside the legacy layout', async t => {
+  const data = createGLBV3(
+    {asset: {version: '2.1'}, buffers: [{byteLength: 4}]},
+    [new Uint8Array([1, 2, 3, 4])],
+    [{type: 0x54534554, data: new Uint8Array([9, 10, 11, 12])}]
+  );
+
+  await t.rejects(
+    parse(data, GLTFLoader, {gltf: {loadBuffers: true, loadImages: false}}),
+    /buffer 0 without a uri must define a valid GLB v3 chunk/,
+    'does not replace an unresolved buffer with zero-filled bytes'
+  );
+  t.end();
+});
+
 test('GLTFLoader#parse(v3) rejects missing buffer chunks', async t => {
   const data = createGLBV3({
     asset: {version: '2.1'},

--- a/modules/gltf/test/gltf-zod-schema.spec.ts
+++ b/modules/gltf/test/gltf-zod-schema.spec.ts
@@ -3,16 +3,18 @@
 // Copyright (c) vis.gl contributors
 
 import {
-  GLTF1Schema,
-  GLTF2Schema,
-  GLTF21Schema,
   GLTFSchema,
-  GLTFVersionSchema,
-  GLTF1ExtensionSchemas,
-  GLTF2ExtensionSchemas,
   GLTFEXTMeshoptCompressionSchema,
   GLTFKHRMeshoptCompressionSchema
 } from '@loaders.gl/gltf';
+import {
+  GLTF1Schema,
+  GLTF2Schema,
+  GLTF21Schema,
+  GLTFVersionSchema,
+  GLTF1ExtensionSchemas,
+  GLTF2ExtensionSchemas
+} from '@loaders.gl/gltf/schema';
 import {describe, expect, it} from 'vitest';
 
 describe('GLTFSchema', () => {
@@ -48,6 +50,29 @@ describe('GLTFSchema', () => {
     expect(Object.keys(GLTF2ExtensionSchemas.Vendor)).toContain('EXT_mesh_gpu_instancing');
   });
 
+  it('preserves constraints unsupported by Zod JSON Schema conversion', () => {
+    const perspective = {yfov: 1, znear: 0.1};
+    const orthographic = {xmag: 1, ymag: 1, zfar: 100, znear: 0};
+    const iesProfileSchema = GLTF2ExtensionSchemas.Vendor.EXT_lights_ies.lightProfile;
+
+    expect(
+      GLTF21Schema.safeParse({
+        asset: {version: '2.1'},
+        cameras: [{type: 'perspective', perspective, orthographic}]
+      }).success
+    ).toBe(false);
+    expect(GLTF21Schema.safeParse({asset: {version: '2.1'}, nodes: [{skin: 0}]}).success).toBe(
+      false
+    );
+    expect(GLTF1Schema.safeParse({asset: {version: '1.0'}, scene: 'default'}).success).toBe(false);
+    expect(iesProfileSchema.safeParse({bufferView: 0}).success).toBe(false);
+    const validProfile = iesProfileSchema.safeParse({
+      bufferView: 0,
+      mimeType: 'application/x-ies-lm-63'
+    });
+    expect(validProfile.success, validProfile.error?.message).toBe(true);
+  });
+
   it('accepts a glTF document and preserves extension properties', () => {
     const document = {
       asset: {version: '2.0'},
@@ -62,6 +87,21 @@ describe('GLTFSchema', () => {
   it('rejects malformed core properties', () => {
     expect(GLTFSchema.safeParse({asset: {version: 2}}).success).toBe(false);
     expect(GLTFSchema.safeParse({asset: {version: '2.0'}, scene: -1}).success).toBe(false);
+  });
+
+  it('validates draft glTF 2.1 external asset references', () => {
+    const asset = {version: '2.1'};
+
+    expect(
+      GLTFSchema.safeParse({
+        asset,
+        externalAssets: [{file: 0}],
+        nodes: [{externalAsset: 0}]
+      }).success
+    ).toBe(true);
+    expect(GLTFSchema.safeParse({asset, externalAssets: {file: 0}}).success).toBe(false);
+    expect(GLTFSchema.safeParse({asset, externalAssets: [{file: '0'}]}).success).toBe(false);
+    expect(GLTFSchema.safeParse({asset, nodes: [{externalAsset: '0'}]}).success).toBe(false);
   });
 
   it('validates draft glTF 2.1 thumbnail references', () => {

--- a/modules/gltf/test/lib/gltf-utils/external-assets.spec.ts
+++ b/modules/gltf/test/lib/gltf-utils/external-assets.spec.ts
@@ -100,7 +100,7 @@ test('GLTFLoader#resolves embedded external asset dependencies from the package'
 test('GLTFLoader#rejects cyclical external assets', async t => {
   const recursiveAsset = JSON.stringify({
     asset: {version: '2.1'},
-    files: [{mimeType: 'model/gltf+json', uri: 'child.gltf'}],
+    files: [{mimeType: 'model/gltf+json', uri: './child.gltf'}],
     externalAssets: [{file: 0}],
     nodes: [{externalAsset: 0}]
   });

--- a/modules/gltf/test/lib/gltf-utils/gltf-accessor-component-types.spec.ts
+++ b/modules/gltf/test/lib/gltf-utils/gltf-accessor-component-types.spec.ts
@@ -72,3 +72,26 @@ test('glTF 2.1 accessor component types', t => {
   }
   t.end();
 });
+
+test('GLTFScenegraph#addBinaryBuffer accepts 64-bit integer arrays', t => {
+  const gltf = {json: {asset: {version: '2.1'}}, buffers: []};
+  const scenegraph = new GLTFScenegraph(gltf);
+
+  scenegraph.addBinaryBuffer(new BigInt64Array([-1n, 1n]), {
+    size: 1,
+    min: [-1n],
+    max: [1n]
+  });
+  scenegraph.addBinaryBuffer(new BigUint64Array([0n, 2n]), {
+    size: 1,
+    min: [0n],
+    max: [2n]
+  });
+
+  t.deepEqual(
+    gltf.json.accessors?.map(accessor => accessor.componentType),
+    [5134, 5135],
+    'maps signed and unsigned 64-bit constructors to glTF component types'
+  );
+  t.end();
+});

--- a/modules/gltf/test/lib/gltf-utils/resolve-gltf-file.spec.ts
+++ b/modules/gltf/test/lib/gltf-utils/resolve-gltf-file.spec.ts
@@ -63,6 +63,30 @@ test('resolveGLTFFile#fetches URI files relative to the containing asset', async
   t.end();
 });
 
+test('resolveGLTFFile#rejects unsuccessful URI responses', async t => {
+  const gltf = {
+    json: {
+      asset: {version: '2.1'},
+      files: [{mimeType: 'application/octet-stream', uri: 'missing.bin'}]
+    },
+    buffers: [],
+    files: [null]
+  } as unknown as GLTFWithBuffers;
+
+  await t.rejects(
+    resolveGLTFFile(
+      gltf,
+      0,
+      {core: {baseUrl: 'https://example.com/model.gltf'}},
+      createLoaderContext(async () => new Response('not found', {status: 404}))
+    ),
+    /Failed to fetch glTF file missing.bin: HTTP 404/,
+    'does not cache an HTTP error body as a resolved file'
+  );
+  t.equal(gltf.files?.[0], null, 'leaves the file cache empty');
+  t.end();
+});
+
 test('findGLTFFileIndex#rejects ambiguous virtual package references', t => {
   const gltf = {
     json: {


### PR DESCRIPTION
## Goals

- Address all unresolved actionable review feedback from the landed glTF 2.1 PR stack, including #3508.
- Harden glTF 2.1 loading and schema validation without adding the versioned Khronos schemas to the normal package-root import.

## Changes

- Add reverse constructor mappings for signed and unsigned 64-bit accessor arrays.
- Reject unresolved URI-less buffers in GLB v3 instead of silently substituting empty data.
- Reject unsuccessful unified-file fetches and canonicalize external-asset URLs used for caching and cycle detection.
- Validate `externalAssets` and `nodes[*].externalAsset` in the public Zod schema.
- Preserve official JSON Schema dependencies, exclusive branches, conditionals, and nested constraints that Zod's converter does not support directly.
- Move versioned and official Khronos schemas to the explicit `@loaders.gl/gltf/schema` subpath and document the new import.

## Validation

- `yarn`
- `yarn lint fix`
- `yarn build`
- `yarn test-node` — 1,692 passed
- `yarn test-headless` — 1,688 passed
- Focused glTF regression suite — 37 passed
