### PR TITLE
feat(3d-tiles): add byte-native cache and memory-aware LOD

### DIFF
--- a/docs/modules/3d-tiles/concepts/caching-and-memory.md
+++ b/docs/modules/3d-tiles/concepts/caching-and-memory.md
@@ -6,36 +6,125 @@ import {Tiles3DDocsTabs} from '@site/src/components/docs/tiles-3d-docs-tabs';
 
 `Tileset3D` caches loaded content so camera movement can reuse tiles without immediately fetching and decoding them again. The cache cooperates with traversal: tiles touched in the current frame are protected, while unused least-recently-used content becomes eligible for eviction.
 
-## The Memory Limit Is Soft
+## Two Byte Budgets
 
-`maximumMemoryUsage` defaults to `32` MB and limits estimated GPU memory retained by the tileset cache. Geometry, textures, batch-table textures, and point metadata contribute to the estimate.
+Cache policy is controlled by two byte-native values:
 
-The limit is intentionally soft. Tiles selected or otherwise used in the current frame are not evicted merely to satisfy the budget. If the current view needs 50 MB to meet its SSE target and the limit is 32 MB, usage can reach 50 MB; those tiles become evictable after they leave the working set. This favors complete, hole-free rendering over a hard cap.
+| Option | Default | Purpose |
+| --- | ---: | --- |
+| `cacheBytes` | `536870912` (512 MiB) | Soft target used to evict content that was not needed in the current frame. |
+| `maximumCacheOverflowBytes` | `536870912` (512 MiB) | Additional current-frame headroom before memory-adjusted screen-space error (SSE) starts reducing LOD demand. |
 
-`memoryCacheOverflow` defaults to `1` MB and provides hysteresis for memory-adjusted SSE behavior.
+The pressure ceiling is:
+
+```text
+cache pressure ceiling = cacheBytes + maximumCacheOverflowBytes
+```
+
+Both values are byte counts, not decimal megabytes. Multiply a desired mebibyte value by `1024 * 1024`.
+
+## The Base Budget Is Soft
+
+`cacheBytes` is intentionally a soft target. Tiles selected, requested, or otherwise touched in the current frame are protected from eviction even if the visible working set exceeds the target. If the current view needs 700 MiB to meet its SSE target and `cacheBytes` is 512 MiB, usage may reach 700 MiB. Once some of those tiles are no longer needed, least-recently-used content is evicted toward 512 MiB.
+
+This policy favors complete, hole-free rendering over a hard cap. `cacheBytes` should therefore not be interpreted as a process, JavaScript heap, or GPU allocation limit.
+
+## What the Estimate Includes
+
+`gpuMemoryUsageInBytes` tracks the runtime's best estimate for loaded tile content. Geometry, textures, batch-table textures, and point metadata contribute when their loaders report byte lengths. The value does not include every allocation made by the application, browser, renderer, decoder, or network stack.
+
+Use it to compare tileset configurations and diagnose cache behavior, not as an exact measurement of total device memory.
 
 ## Recency and Frame Protection
 
-At the start of a frame, the cache records a boundary in its least-recently-used list. Traversal touches selected, requested, and otherwise required tiles. Entries used after the boundary are protected for that frame. Eviction walks older entries until the memory target is met or no safe candidates remain.
+At the start of a frame, the cache records a boundary in its least-recently-used (LRU) list. Traversal touches selected, requested, and otherwise required tiles. Entries used after the boundary are protected for that frame. Eviction walks older entries until estimated usage is at or below `cacheBytes`, or until no safe candidates remain.
 
 Loading a tile adds it to the cache and updates `gpuMemoryUsageInBytes`. Unloading calls `onTileUnload`, releases tile content, and updates the memory statistics.
 
 ## Memory-Adjusted SSE
 
-When `memoryAdjustedScreenSpaceError` is enabled, memory pressure can raise the active SSE threshold gradually, reducing refinement demand. Usage below the cache target moves the threshold back toward `maximumScreenSpaceError`; usage beyond the target plus overflow raises it. The adjustment is incremental, so it avoids abrupt LOD swings.
+`memoryAdjustedScreenSpaceError` defaults to `true`. When enabled, the active SSE threshold responds to the two byte budgets:
 
-This option changes the effective quality target and is distinct from progressive or foveated scheduling, which normally change request order only.
+| Estimated usage | Active SSE response |
+| --- | --- |
+| Below `cacheBytes` | Moves down toward `maximumScreenSpaceError`, restoring requested detail. |
+| From `cacheBytes` through the pressure ceiling | Holds steady. The overflow window provides headroom and prevents rapid quality oscillation. |
+| Above the pressure ceiling | Moves upward, stopping traversal at coarser tiles and reducing future memory demand. |
+
+Each adjustment is two percent, so quality changes converge instead of jumping abruptly. The effective logical-pixel threshold is exposed as `memoryAdjustedScreenSpaceError`; `maximumScreenSpaceError` remains the application's preferred quality target.
+
+Memory-adjusted SSE changes the selected final LOD under pressure. This is different from progressive and foveated scheduling, which normally change request order and timing without changing the final target. See [Screen-space error and LOD](./screen-space-error-and-lod) for the refinement calculation.
+
+Set `memoryAdjustedScreenSpaceError: false` when stable LOD is more important than adapting to a constrained cache. Eviction still uses `cacheBytes`, and the visible working set can still exceed it.
+
+These defaults apply to 3D Tiles. The shared `Tileset3D` runtime preserves I3S's existing 32 MiB base target, 1 MiB overflow, and disabled memory adjustment so this Cesium-alignment tranche does not change I3S LOD behavior.
+
+## Runtime Updates
+
+The public `cacheBytes` and `maximumCacheOverflowBytes` properties can be changed after construction. `setProps()` accepts the same values. All paths update the byte thresholds directly, so repeated changes do not accumulate unit conversions or leave stale internal limits.
+
+Reducing `cacheBytes` makes old, unused tiles eligible for eviction during the next traversal. Reducing overflow headroom can raise the active SSE after subsequent load or cache activity if usage is already above the new pressure ceiling.
+
+```ts
+const MEBIBYTE = 1024 * 1024;
+
+const tileset = new Tileset3D(source, {
+  cacheBytes: 256 * MEBIBYTE,
+  maximumCacheOverflowBytes: 64 * MEBIBYTE
+});
+
+// Adapt to a device or application memory mode later.
+tileset.setProps({cacheBytes: 128 * MEBIBYTE});
+```
+
+## Migrating from MiB Options
+
+The older options remain available for compatibility but are deprecated:
+
+| Deprecated option | Replacement | Conversion |
+| --- | --- | --- |
+| `maximumMemoryUsage` | `cacheBytes` | `maximumMemoryUsage * 1024 * 1024` |
+| `memoryCacheOverflow` | `maximumCacheOverflowBytes` | `memoryCacheOverflow * 1024 * 1024` |
+
+If both forms are supplied, the byte-native option wins independently for its budget. The deprecated `maximumMemoryUsage` property remains synchronized with `cacheBytes`, allowing applications to migrate without a flag day.
+
+The default policy changed from a 32 MiB target, 1 MiB overflow, and disabled memory adjustment to Cesium-compatible 512 MiB budgets with memory adjustment enabled. To retain the previous policy explicitly:
+
+```ts
+const MEBIBYTE = 1024 * 1024;
+
+const tileset = new Tileset3D(source, {
+  cacheBytes: 32 * MEBIBYTE,
+  maximumCacheOverflowBytes: 1 * MEBIBYTE,
+  memoryAdjustedScreenSpaceError: false
+});
+```
+
+## Tuning Tradeoffs
+
+| Change | Likely benefit | Likely cost |
+| --- | --- | --- |
+| Increase `cacheBytes` | More reuse after camera reversals; fewer repeated requests and decodes. | More retained content memory. |
+| Decrease `cacheBytes` | Lower idle cache footprint. | More load/evict cycles and network reuse misses. |
+| Increase overflow headroom | Preserves the requested LOD through short memory peaks. | Allows a larger current-view working set. |
+| Decrease overflow headroom | Adapts LOD sooner on constrained devices. | Coarser detail under pressure and potentially deeper quality changes. |
+| Disable memory-adjusted SSE | Stable final LOD target. | The visible working set may exceed the base budget without adaptive relief. |
 
 ## Request Concurrency Is Not Cache Size
 
 `maxRequests` limits simultaneous scheduled fetches when `throttleRequests` is enabled. Raising it may fill the cache faster and increase decode pressure, but it does not increase the memory limit. Lowering it changes latency and ordering visibility, but already loaded tiles remain governed by the cache.
 
-## Practical Guidance
+## Troubleshooting
 
-- Choose final visual quality with `maximumScreenSpaceError` first.
-- Size `maximumMemoryUsage` for the expected visible working set plus useful reuse.
-- Watch `gpuMemoryUsageInBytes` and the tileset stats rather than treating the configured limit as a hard guarantee.
-- Reduce request concurrency when network or decode contention hurts interaction.
-- Enable memory-adjusted SSE only when graceful quality reduction is preferable to exceeding the working budget.
+| Symptom | Explanation | Inspect or change |
+| --- | --- | --- |
+| Usage exceeds `cacheBytes` | Current-frame tiles are protected, or no unused entries are eligible. | Compare `gpuMemoryUsageInBytes` with the visible working set; increase SSE or allow adaptation if needed. |
+| Detail becomes coarser over time | Usage crossed the base-plus-overflow ceiling. | Inspect `memoryAdjustedScreenSpaceError`; increase a budget or reduce other content pressure. |
+| Detail stays coarse after moving away | The active SSE restores incrementally as usage drops. | Confirm usage is below `cacheBytes` and allow subsequent traversal/cache updates. |
+| Tiles repeatedly reload when reversing the camera | The base cache target is too small for useful reuse. | Increase `cacheBytes` or reduce the target detail level. |
+| Changing an old MiB option appears ignored | The corresponding byte-native option was also supplied and has precedence. | Configure only `cacheBytes` and `maximumCacheOverflowBytes`. |
+| Memory metrics differ from browser or GPU tools | `gpuMemoryUsageInBytes` is a tile-content estimate, not whole-process memory. | Compare trends and include renderer/application allocations separately. |
+
+Choose final visual quality with `maximumScreenSpaceError` first, then size `cacheBytes` for the expected visible working set plus useful reuse. Tune overflow headroom last, using `gpuMemoryUsageInBytes`, active SSE, request counts, and camera interaction together.
 
 Next: [Runtime tuning and diagnostics](./runtime-tuning-and-diagnostics).

--- a/docs/modules/3d-tiles/concepts/request-scheduling-and-priorities.md
+++ b/docs/modules/3d-tiles/concepts/request-scheduling-and-priorities.md
@@ -36,7 +36,7 @@ Set the fraction to `0` to disable progressive priority. Values greater than `0.
 
 ## Foveated Center Priority
 
-With `foveatedScreenSpaceError: true`, perspective requests near the camera view axis rank before equally needed peripheral requests. loaders.gl measures the nearest point of the complete tile bounding sphere to the view axis. A large tile that intersects the axis therefore counts as central even when its center does not.
+With `foveatedScreenSpaceError: true`, perspective requests near the camera's forward view ray rank before equally needed peripheral requests. loaders.gl measures the nearest point of the complete tile bounding sphere to that ray. A large tile that intersects the ray therefore counts as central even when its center does not. A volume entirely behind the camera is treated as maximally peripheral instead of projecting onto the backward half of an infinite line and competing with visible center content.
 
 `foveatedConeSize` is the fraction of the vertical field of view that receives no peripheral relaxation. It defaults to `0.1`; a larger value makes more of the view central, while `1` disables peripheral deferral. A missing or invalid field of view uses the established 60-degree fallback.
 
@@ -47,6 +47,8 @@ Angular foveation is disabled for orthographic viewports because parallel projec
 ## Camera Motion and Deferral
 
 `Tileset3D` retains camera position and direction separately for each viewport. When either changes beyond a small numeric tolerance, eligible peripheral requests may wait up to `foveatedTimeDelay` seconds (`0.2` by default). Continuing motion pushes the retry window forward. A single follow-up traversal is scheduled when the window expires, so requests recover even if the application supplies no further camera event.
+
+Deferral is applied both to new candidates and to requests already waiting for a concurrency slot. If camera motion makes a queued request deferrable, its scheduler callback cancels that queue entry before network access begins. The follow-up traversal submits it again after the delay. Requests whose fetch has already started are not interrupted. Once the delay expires, the active deferral flag and its priority effect are removed together, so released work cannot remain artificially penalized while the camera is stationary.
 
 The first observed camera pose is treated as stationary; initial tileset loading is not delayed.
 
@@ -61,14 +63,13 @@ Traditional replacement children are still ordered center-first; only the tempor
 
 ## Complete Priority Order
 
-Smaller numeric priorities start first. Independent priority bands produce this lexicographic order:
+Deferred work is kept out of the scheduler queue until it becomes eligible. Among requests that may start, smaller numeric priorities produce this lexicographic order:
 
-1. Eligible now before motion-deferred work.
-2. Progressive coarse coverage before fine detail.
-3. Center content before peripheral content.
-4. Established reverse-SSE order as the tie-breaker.
+1. Progressive coarse coverage before fine detail.
+2. Center content before peripheral content.
+3. Established reverse-SSE order as the tie-breaker.
 
-Each measurement is normalized into its own numeric band, preventing an extreme SSE or angle from overpowering a stronger invariant.
+Each queued measurement is normalized into its own numeric band, preventing an extreme SSE or angle from overpowering a stronger invariant.
 
 ## Options
 

--- a/docs/modules/3d-tiles/concepts/runtime-tuning-and-diagnostics.md
+++ b/docs/modules/3d-tiles/concepts/runtime-tuning-and-diagnostics.md
@@ -27,8 +27,8 @@ Useful `Tile3D` fields include:
 | `selected` | Whether content contributes to the current frame. |
 | `refine` | `ADD` or `REPLACE` continuity semantics. |
 | `_priorityProgressiveResolution` | Whether the tile belongs to the coarse-coverage band. |
-| `_priorityDeferred` | Whether motion deferral currently holds the request. |
-| `_foveatedFactor` | Unitless distance from the perspective view axis. |
+| `priorityDeferred` | Whether motion deferral currently holds the request, including its active time window. |
+| `_foveatedFactor` | Unitless distance from the perspective forward view ray. |
 | `_priority` | Combined scheduler priority; smaller starts first. |
 
 The underscored fields are runtime diagnostics, not stable public API. Prefer callbacks and stats for application behavior. `Tileset3D.stats` exposes tiles loading, loaded, in memory, in view, renderable, failed, estimated GPU memory, and the current maximum SSE.

--- a/docs/modules/3d-tiles/concepts/runtime-tuning-and-diagnostics.md
+++ b/docs/modules/3d-tiles/concepts/runtime-tuning-and-diagnostics.md
@@ -13,7 +13,7 @@ Tune 3D Tiles in layers: establish the desired final LOD, then improve how quick
 3. Tune `progressiveResolutionHeightFraction` for initial broad coverage.
 4. Tune `foveatedConeSize`, relaxation, and `foveatedTimeDelay` for interaction.
 5. Tune `maxRequests` for network and decode capacity.
-6. Tune `maximumMemoryUsage`, optionally enabling memory-adjusted SSE.
+6. Tune byte-native `cacheBytes` and `maximumCacheOverflowBytes`; memory-adjusted SSE is enabled by default.
 
 ## What to Inspect
 
@@ -47,7 +47,7 @@ The underscored fields are runtime diagnostics, not stable public API. Prefer ca
 | Orthographic LOD or progressive pass looks wrong | Invalid `metersPerPixel` or physical/logical pixel mixing. | Supply a positive finite logical-pixel scale. |
 | High-DPI displays choose different LOD | Custom viewport applied DPR a second time. | Use CSS/logical dimensions with no additional DPR factor. |
 | Scaled tiles under-refine | World transform was not applied to geometric error. | Inspect `lodMetricValue` and the composed model/tile transforms. |
-| Memory exceeds configured maximum | Current-frame working set is larger than the soft cache budget. | Raise the budget, raise SSE, or enable memory-adjusted SSE. |
+| Memory exceeds `cacheBytes` | Current-frame working set is larger than the soft eviction target. | Compare usage with the base-plus-overflow ceiling; raise a budget, raise SSE, or keep memory-adjusted SSE enabled. |
 | Many queued requests but low throughput | Request throttling or upstream fetch limits. | Inspect `maxRequests`, browser connection limits, and loader worker concurrency. |
 
 ## Multi-Viewport Behavior

--- a/docs/modules/3d-tiles/concepts/screen-space-error-and-lod.md
+++ b/docs/modules/3d-tiles/concepts/screen-space-error-and-lod.md
@@ -94,6 +94,12 @@ The calculation uses geodetic heights for a root `region` and earth-scale boundi
 tilesets use their root transform and source-space z-up height. Density is recalculated for every
 viewport and traversal frame, so multiple views do not share camera-dependent state.
 
+For local box and sphere tilesets, the root transform is refreshed before density is calculated,
+so an animated `modelMatrix` affects height falloff in the same frame as traversal. A tilted
+oriented box uses the sum of the absolute vertical projections of all three half axes. The
+half-size/quaternion representation is rotated into the same conservative extent; using only its
+nominal z half-size would make tilted datasets appear artificially short.
+
 | Option | Default | Meaning |
 | --- | --- | --- |
 | `dynamicScreenSpaceError` | `true` | Enables the optimization for perspective 3D Tiles traversal. |

--- a/docs/modules/3d-tiles/concepts/screen-space-error-and-lod.md
+++ b/docs/modules/3d-tiles/concepts/screen-space-error-and-lod.md
@@ -199,7 +199,7 @@ street-level and aerial views need different traversal depth.
 
 After selecting an acceptable final LOD, tune streaming behavior separately with the [request-scheduling guide](./request-scheduling-and-priorities), then size the [cache and memory budget](./caching-and-memory).
 
-Changing either value affects more than visual sharpness. Deeper traversal can increase request count, decode work, GPU memory, cache churn, and draw calls. Tile availability, network latency, refinement mode, and `maximumMemoryUsage` can delay or limit the visible effect of an SSE change.
+Changing either value affects more than visual sharpness. Deeper traversal can increase request count, decode work, GPU memory, cache churn, and draw calls. Tile availability, network latency, refinement mode, byte-native cache budgets, and memory-adjusted SSE can delay or limit the visible effect of an SSE change. See [Caching and memory](./caching-and-memory).
 
 ## Runtime Inspection
 

--- a/docs/modules/3d-tiles/concepts/tile-hierarchy-and-refinement.md
+++ b/docs/modules/3d-tiles/concepts/tile-hierarchy-and-refinement.md
@@ -48,4 +48,6 @@ A tile can be visible but neither selected nor requested, for example when desce
 
 External tilesets extend the apparent hierarchy after their JSON is loaded. Implicit tiling materializes nodes from subtree availability data. Both still feed the same traversal concepts: bounding volumes determine relevance, geometric error determines refinement, and content state determines whether a selected representation is renderable.
 
+Required extensions are validated before normalization or dependent network access. The supported `3DTILES_bounding_volume_S2` extension is normalized to the oriented-box representation consumed by traversal for explicit tile, content, and viewer-request volumes as well as implicit roots. The original S2 metadata remains available where implicit subdivision needs its token and height range. Unknown optional names in `extensionsUsed` remain forward-compatible.
+
 Next: [Screen-space error and LOD](./screen-space-error-and-lod).

--- a/docs/modules/tiles/README.md
+++ b/docs/modules/tiles/README.md
@@ -42,7 +42,9 @@ viewport.
 - `cartesianCenter` (`Number[3]`): Center of tileset in fixed frame coordinates.
 - `cartographicCenter` (`Number[3]`): Center of tileset in cartographic coordinates `[long, lat, elevation]`
 - `ellipsoid` ([`Ellipsoid`](https://math.gl/modules/geospatial/docs/api-reference/ellipsoid)): Gets an ellipsoid describing the shape of the globe.
-- `maximumMemoryUsage` (`Number`): If tiles sized more than `maximumMemoryUsage` are needed to for the current view, when these tiles go out of view, they will be unloaded.`maximumMemoryUsage` must be greater than or equal to zero.
+- `cacheBytes` (`Number`): Soft byte target for cached tile content that is not needed by the current frame. Current-frame tiles remain protected.
+- `maximumCacheOverflowBytes` (`Number`): Additional byte headroom before cache pressure raises the active screen-space-error threshold.
+- `maximumMemoryUsage` (`Number`, deprecated): MiB compatibility alias for `cacheBytes`.
 - `modelMatrix` (`Matrix4: A [Matrix4](https://math.gl/modules/core/docs/api-reference/matrix4) instance (4x4 transformation matrix) that transforms the entire tileset.
 - `root` (`Tile3DHeader`): The root tile header.
 - `tiles`: (`Array<Tile3DHeader>`): All the tiles that have been traversed.
@@ -60,7 +62,8 @@ viewport.
   - `options`: Options object, but not limited to
     Parameters:
     - `modelMatrix`=`Matrix4.IDENTITY` (`Matrix4`) - A 4x4 transformation matrix that transforms the tileset's root tile.
-    - `maximumMemoryUsage`=`512` (`Number`) - The maximum amount of memory in MB that can be used by the tileset.
+    - `cacheBytes`=`536870912` (`Number`) - Soft target in bytes for evictable cached content.
+    - `maximumCacheOverflowBytes`=`536870912` (`Number`) - Additional current-view headroom in bytes before LOD adapts.
     - `ellipsoid`=`Ellipsoid.WGS84` ([`Ellipsoid`](https://math.gl/modules/geospatial/docs/api-reference/ellipsoid)) - The ellipsoid determining the size and shape of the globe.
       Callbacks:
     - `onTileLoad` (`(tileHeader : Tile3DHeader) : void`) - callback when a tile node is fully loaded during the tileset traversal.

--- a/docs/modules/tiles/api-reference/tileset-3d.md
+++ b/docs/modules/tiles/api-reference/tileset-3d.md
@@ -72,7 +72,11 @@ Parameters:
   - `options.throttleRequests`=`true` (`Boolean`) - Determines whether or not to throttle tile fetching requests. Throttled requests are prioritized according to tile visibility.
   - `options.maxRequests`=`64` (`Number`) - When throttling tile fetching, the maximum number of simultaneous requests.
   - `options.modelMatrix`=`Matrix4.IDENTITY` (`Matrix4`) - A 4x4 transformation matrix this transforms the entire tileset.
-  - `options.maximumMemoryUsage`=`32` (`Number`) - Soft limit for estimated cached GPU memory in MB. Current-frame tiles remain protected. See [Caching and memory](/docs/modules/3d-tiles/concepts/caching-and-memory).
+  - `options.cacheBytes`=`536870912` (`Number`) - Soft target in bytes for estimated cached 3D Tiles content. Current-frame tiles remain protected. I3S retains a `33554432` default. See [Caching and memory](/docs/modules/3d-tiles/concepts/caching-and-memory).
+  - `options.maximumCacheOverflowBytes`=`536870912` (`Number`) - Additional current-frame headroom in bytes before cache pressure raises the active SSE threshold. I3S retains a `1048576` default.
+  - `options.memoryAdjustedScreenSpaceError`=`true` (`Boolean`) - Adapts the active SSE threshold when estimated usage exceeds `cacheBytes + maximumCacheOverflowBytes`. I3S retains its `false` default.
+  - `options.maximumMemoryUsage` (`Number`, deprecated) - MiB compatibility alias for `cacheBytes`; the byte-native option wins when both are supplied.
+  - `options.memoryCacheOverflow` (`Number`, deprecated) - MiB compatibility alias for `maximumCacheOverflowBytes`; the byte-native option wins when both are supplied.
   - `options.viewDistanceScale`=`1.0` (`Number`) - Multiplies calculated screen-space error. Lower values stop refinement earlier; higher values select more detail. See [Screen-space error and level of detail](/docs/modules/3d-tiles/concepts/screen-space-error-and-lod).
   - `options.progressiveResolutionHeightFraction`=`0.3` (`Number`) - Prioritizes coarse viewport coverage using SSE at a reduced logical viewport height. Set to `0` to disable; values above `0.5` are ignored. See [Request scheduling and priorities](/docs/modules/3d-tiles/concepts/request-scheduling-and-priorities).
   - `options.foveatedScreenSpaceError`=`true` (`Boolean`) - Prioritizes perspective requests near the camera view axis before peripheral detail. This changes request timing, not the final LOD target. See [Request scheduling and priorities](/docs/modules/3d-tiles/concepts/request-scheduling-and-priorities).
@@ -204,26 +208,41 @@ For formulas, projection-specific behavior, transform scaling, and tuning guidan
 ^default 8 \*
 ^exception `maximumScreenSpaceError` must be greater than or equal to zero.
 
-### maximumMemoryUsage : Number
+### cacheBytes : Number
 
-The maximum amount of GPU memory (in MB) that may be used to cache tiles. This value is estimated from
+The soft target in bytes for estimated tile content retained by the cache. The estimate includes
 geometry, textures, and batch table textures of loaded tiles. For point clouds, this value also
 includes per-point metadata.
 
-Tiles not in view are unloaded to enforce this.
+Tiles not needed in the current frame are unloaded in least-recently-used order to approach this target.
+Tiles used by the current frame remain protected.
 
 If decreasing this value results in unloading tiles, the tiles are unloaded the next frame.
 
-If tiles sized more than `maximumMemoryUsage` are needed
+If tiles sized more than `cacheBytes` are needed
 to meet the desired screen space error, determined by `Tileset3D.maximumScreenSpaceError`,
 for the current view, then the memory usage of the tiles loaded will exceed
-`maximumMemoryUsage`. For example, if the maximum is 256 MB, but
-300 MB of tiles are needed to meet the screen space error, then 300 MB of tiles may be loaded. When
-these tiles go out of view, they will be unloaded.
+`cacheBytes` by up to `maximumCacheOverflowBytes` before memory-adjusted SSE raises the active
+threshold. When current-frame tiles go out of use, they become eligible for eviction.
 
-^default 32 \*
-^exception `maximumMemoryUsage` must be greater than or equal to zero.
+^default 536870912 \*
+^exception `cacheBytes` must be a finite number greater than or equal to zero.
 ^see Tileset3D#gpuMemoryUsageInBytes
+
+### maximumCacheOverflowBytes : Number
+
+Additional current-frame memory headroom in bytes. When estimated usage exceeds
+`cacheBytes + maximumCacheOverflowBytes` and memory adjustment is enabled,
+`memoryAdjustedScreenSpaceError` rises incrementally to reduce future LOD demand. This value does
+not change the base target used to evict unused tiles.
+
+^default 536870912 \*
+^exception `maximumCacheOverflowBytes` must be a finite number greater than or equal to zero.
+
+### maximumMemoryUsage : Number (Deprecated)
+
+Compatibility property and constructor option that expresses `cacheBytes` in mebibytes. Assignments
+remain synchronized with `cacheBytes`. Use the byte-native API for new code.
 
 ### root : Tile3D
 
@@ -250,8 +269,6 @@ tileset.readyPromise.then(function (tileset) {
 
 A 4x4 transformation matrix that transforms the entire tileset.
 
-### maximumMemoryUsage : Number
-
 ### gpuMemoryUsageInBytes : Number
 
 The total amount of GPU memory in bytes used by the tileset. This value is estimated from
@@ -277,7 +294,7 @@ See [Extras](https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/master/speci
 
 Unloads all tiles that weren't selected the previous frame. This can be used to
 explicitly manage the tile cache and reduce the total number of tiles loaded below
-`Tileset3D.maximumMemoryUsage`.
+`Tileset3D.cacheBytes` when unused content is available for eviction.
 
 Tile unloads occur at the next frame to keep all the WebGL delete calls
 within the render loop.

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -4,6 +4,14 @@
 
 These deprecations.removals are being considered for v5
 
+**@loaders.gl/tiles**
+
+- `Tileset3D.maximumMemoryUsage` and the `maximumMemoryUsage` constructor option are deprecated. Use byte-native `cacheBytes`; convert MiB with `maximumMemoryUsage * 1024 * 1024`.
+- `memoryCacheOverflow` is deprecated. Use byte-native `maximumCacheOverflowBytes`; the byte-native option takes precedence when both forms are supplied.
+- The default 3D Tiles cache policy is now a 512 MiB base target plus 512 MiB of current-view overflow headroom, with memory-adjusted SSE enabled. To preserve the previous 32 MiB/1 MiB policy, configure both byte budgets explicitly and set `memoryAdjustedScreenSpaceError: false`.
+
+See [Caching and memory](/docs/modules/3d-tiles/concepts/caching-and-memory) for migration examples and runtime behavior.
+
 **@loaders.gl/core**
 
 - Top-level loader options are no longer supported

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -203,10 +203,14 @@ A minor release that includes:
 - **Transform-correct LOD** Geometric error is scaled conservatively by composed tile and tileset transforms without compounding after runtime updates.
 - **Projection-correct SSE** Orthographic viewports use `metersPerPixel`, while perspective and orthographic traversal consistently use logical pixels without a second device-pixel-ratio correction.
 - **Dynamic SSE** Perspective traversal can reduce distant, horizon-facing refinement with view-dependent density and height falloff while leaving orthographic and I3S LOD behavior unchanged.
+- **Same-frame dynamic SSE transforms** Animated local tilesets refresh the root transform before density calculation, and tilted oriented boxes derive height from every rotated half axis.
 - **Required-extension validation** Unsupported `extensionsRequired` values fail before normalization or dependent network access; unknown `extensionsUsed` values remain forward-compatible.
+- **Explicit S2 bounding volumes** `3DTILES_bounding_volume_S2` tile, content, and viewer-request volumes are converted to traversal-ready oriented boxes outside implicit tiling as well.
 - **Progressive tile requests** Coarse viewport coverage receives priority before fine detail through reduced-height SSE.
 - **Foveated tile requests** Perspective tiles near the view axis receive priority over equally needed peripheral detail without changing the final LOD target.
+- **Forward-ray foveation** Volumes behind the camera are classified as peripheral instead of competing with visible center content through the backward half of an infinite view line.
 - **Motion-aware request deferral** Refinement-safe peripheral requests can pause briefly during camera motion and automatically resume after the configured delay.
+- **Queued-request deferral** Peripheral work already waiting for a scheduler slot is canceled before network access when motion makes it deferrable, then resubmitted without a stale penalty after the delay.
 - **Request-priority diagnostics** Tile runtime fields and tests expose progressive, foveated, deferred, and combined priority calculations.
 - **Byte-native cache budgets** `Tileset3D.cacheBytes` and `maximumCacheOverflowBytes` replace ambiguous MiB-era controls with exact byte thresholds and Cesium-compatible 512 MiB 3D Tiles defaults while leaving I3S defaults unchanged.
 - **Memory-aware LOD** Cache pressure above the base-plus-overflow ceiling raises the active SSE incrementally, while usage below the base target restores the configured quality and unused tiles still evict at the base budget.

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -208,6 +208,10 @@ A minor release that includes:
 - **Foveated tile requests** Perspective tiles near the view axis receive priority over equally needed peripheral detail without changing the final LOD target.
 - **Motion-aware request deferral** Refinement-safe peripheral requests can pause briefly during camera motion and automatically resume after the configured delay.
 - **Request-priority diagnostics** Tile runtime fields and tests expose progressive, foveated, deferred, and combined priority calculations.
+- **Byte-native cache budgets** `Tileset3D.cacheBytes` and `maximumCacheOverflowBytes` replace ambiguous MiB-era controls with exact byte thresholds and Cesium-compatible 512 MiB 3D Tiles defaults while leaving I3S defaults unchanged.
+- **Memory-aware LOD** Cache pressure above the base-plus-overflow ceiling raises the active SSE incrementally, while usage below the base target restores the configured quality and unused tiles still evict at the base budget.
+- **Cache migration and diagnostics** Deprecated MiB aliases remain synchronized, runtime budget updates avoid stale conversions, and the cache guide documents precedence, tuning, memory estimates, and troubleshooting.
+- **Reliable 3D Tiles example dispatch** The internal `SourceLayer` now preserves URL and Blob inputs for its 3D loader instead of allowing deck.gl's inherited asynchronous `data` prop to replace them before dispatch.
 - **3D Tiles runtime guides** A [sidebar- and tab-linked concepts suite](/docs/modules/3d-tiles/concepts) documents hierarchy refinement, SSE/LOD, request scheduling, foveation, caching, memory, tuning, and diagnostics.
 
 **@loaders.gl/tile-converter**

--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile-header.ts
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile-header.ts
@@ -111,8 +111,19 @@ export function normalizeTileData(
       tileContentUrl = resolveUri(contentUri, basePath);
     }
   }
+  const boundingVolume = normalizeS2BoundingVolume(tile.boundingVolume) as Tile3DBoundingVolume;
+  const content = tile.content
+    ? {
+        ...tile.content,
+        boundingVolume: normalizeS2BoundingVolume(tile.content.boundingVolume)
+      }
+    : undefined;
+  const viewerRequestVolume = normalizeS2BoundingVolume(tile.viewerRequestVolume);
   const tilePostprocessed: Tiles3DTileJSONPostprocessed = {
     ...tile,
+    boundingVolume,
+    content,
+    viewerRequestVolume,
     id: tileContentUrl,
     contentUrl: tileContentUrl,
     lodMetricType: LOD_METRIC_TYPE.GEOMETRIC_ERROR,
@@ -123,6 +134,35 @@ export function normalizeTileData(
   };
 
   return tilePostprocessed;
+}
+
+/**
+ * Converts an S2-only bounding volume into the oriented-box representation used by traversal.
+ *
+ * `3DTILES_bounding_volume_S2` may appear on explicit or implicit tile, content, and viewer-request
+ * volumes. Keeping the source extension metadata beside the derived box lets implicit subdivision
+ * retain its S2 token while ensuring every explicit volume reaches runtime with a supported
+ * `box`, `region`, or `sphere` shape.
+ *
+ * @param boundingVolume - Source bounding volume, if the owning property is present.
+ * @returns The original volume when it does not use S2, or a cloned volume with a derived box.
+ */
+function normalizeS2BoundingVolume(
+  boundingVolume?: Tile3DBoundingVolume
+): Tile3DBoundingVolume | undefined {
+  const extensions = boundingVolume?.extensions as
+    | Record<string, S2VolumeInfo | undefined>
+    | undefined;
+  const s2VolumeInfo = extensions?.['3DTILES_bounding_volume_S2'];
+  if (!boundingVolume || !s2VolumeInfo) {
+    return boundingVolume;
+  }
+
+  return {
+    ...boundingVolume,
+    box: convertS2BoundingVolumetoOBB(s2VolumeInfo),
+    s2VolumeInfo
+  } as Tile3DBoundingVolume & S2VolumeBox;
 }
 
 // normalize tile headers
@@ -195,6 +235,17 @@ export async function normalizeImplicitTileHeaders(
   options: Tiles3DLoaderOptions,
   context?: LoaderContext
 ): Promise<Tiles3DTileJSONPostprocessed | null> {
+  const normalizedTile: Tiles3DTileJSON = {
+    ...tile,
+    boundingVolume: normalizeS2BoundingVolume(tile.boundingVolume) as Tile3DBoundingVolume,
+    content: tile.content
+      ? {
+          ...tile.content,
+          boundingVolume: normalizeS2BoundingVolume(tile.content.boundingVolume)
+        }
+      : undefined,
+    viewerRequestVolume: normalizeS2BoundingVolume(tile.viewerRequestVolume)
+  };
   const {
     subdivisionScheme,
     maximumLevel,
@@ -220,21 +271,12 @@ export async function normalizeImplicitTileHeaders(
     options,
     context
   )) as Subtree;
-  const tileContentUri = tile.content?.uri;
+  const tileContentUri = normalizedTile.content?.uri;
   const contentUrlTemplate = tileContentUri ? resolveUri(tileContentUri, basePath) : '';
   const refine = tileset?.root?.refine;
   // @ts-ignore
-  const rootLodMetricValue = tile.geometricError;
-
-  // Replace tile.boundingVolume with the the bounding volume specified by the extensions['3DTILES_bounding_volume_S2']
-  const s2VolumeInfo: S2VolumeInfo = tile.boundingVolume.extensions?.['3DTILES_bounding_volume_S2'];
-  if (s2VolumeInfo) {
-    const box = convertS2BoundingVolumetoOBB(s2VolumeInfo);
-    const s2VolumeBox: S2VolumeBox = {box, s2VolumeInfo};
-    tile.boundingVolume = s2VolumeBox;
-  }
-
-  const rootBoundingVolume = tile.boundingVolume;
+  const rootLodMetricValue = normalizedTile.geometricError;
+  const rootBoundingVolume = normalizedTile.boundingVolume;
 
   const implicitOptions: ImplicitOptions = {
     contentUrlTemplate,
@@ -252,7 +294,7 @@ export async function normalizeImplicitTileHeaders(
   };
 
   return await normalizeImplicitTileData(
-    tile,
+    normalizedTile,
     basePath,
     subtree,
     implicitOptions,

--- a/modules/3d-tiles/src/types.ts
+++ b/modules/3d-tiles/src/types.ts
@@ -103,8 +103,8 @@ export type Tiles3DTilesetJSONPostprocessed = Omit<Tiles3DTilesetJSON, 'root'> &
 export type Tiles3DTileJSON = {
   /** A bounding volume that encloses a tile or its content. */
   boundingVolume: Tile3DBoundingVolume;
-  /** A bounding volume that encloses a tile or its content. */
-  viewerRequestVolume?: object;
+  /** A bounding volume that limits requests to cameras inside the volume. */
+  viewerRequestVolume?: Tile3DBoundingVolume;
   /** The error, in meters, introduced if this tile is rendered and its children are not. At runtime, the geometric error is used to compute screen space error (SSE), i.e., the error measured in pixels. */
   geometricError: number;
   /**

--- a/modules/3d-tiles/test/tiles-3d-loader.spec.ts
+++ b/modules/3d-tiles/test/tiles-3d-loader.spec.ts
@@ -108,6 +108,45 @@ test('Tiles3DLoader#accepts supported required extensions', async t => {
   t.end();
 });
 
+test('Tiles3DLoader#normalizes explicit S2 bounding volumes', async t => {
+  const s2VolumeInfo = {token: '1', minimumHeight: 0, maximumHeight: 10};
+  const s2BoundingVolume = {
+    extensions: {'3DTILES_bounding_volume_S2': s2VolumeInfo}
+  };
+  const tileset = await parse(
+    encodeTilesetJson({
+      extensionsRequired: ['3DTILES_bounding_volume_S2'],
+      root: {
+        geometricError: 0,
+        refine: 'REPLACE',
+        boundingVolume: s2BoundingVolume,
+        viewerRequestVolume: s2BoundingVolume,
+        content: {uri: 'tile.glb', boundingVolume: s2BoundingVolume}
+      }
+    }),
+    Tiles3DLoader,
+    {worker: false, '3d-tiles': {isTileset: true}}
+  );
+
+  t.equal(tileset.root.boundingVolume.box.length, 12, 'normalizes the tile traversal volume');
+  t.equal(
+    tileset.root.content.boundingVolume.box.length,
+    12,
+    'normalizes the explicit content volume'
+  );
+  t.equal(
+    tileset.root.viewerRequestVolume.box.length,
+    12,
+    'normalizes the explicit viewer request volume'
+  );
+  t.deepEqual(
+    tileset.root.boundingVolume.s2VolumeInfo,
+    s2VolumeInfo,
+    'retains S2 metadata for implicit subdivision and diagnostics'
+  );
+  t.end();
+});
+
 test('Tiles3DLoader#allows unknown extensionsUsed entries', async t => {
   const tileset = await parse(
     encodeTilesetJson({extensionsUsed: ['VENDOR_optional_extension']}),

--- a/modules/deck-layers/src/source-layer.ts
+++ b/modules/deck-layers/src/source-layer.ts
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {CompositeLayer, type CompositeLayerProps, type LayersList} from '@deck.gl/core';
+import {
+  CompositeLayer,
+  type CompositeLayerProps,
+  type DefaultProps,
+  type LayersList
+} from '@deck.gl/core';
 import type {Tile3DLayerProps} from '@deck.gl/geo-layers';
 import {createDataSource} from '@loaders.gl/core';
 import type {
@@ -50,6 +55,20 @@ type ResolvedSourceData =
   | null;
 
 /**
+ * Synchronous prop definitions for source dispatch.
+ *
+ * deck.gl's inherited `data` prop is asynchronous and replaces URL inputs with an empty array while
+ * it loads them. `SourceLayer` must retain the original URL or Blob so that the selected child layer
+ * can resolve it with the supplied source factories or 3D loader.
+ */
+const defaultProps: DefaultProps<SourceLayerProps> = {
+  id: 'source-layer',
+  data: '',
+  sources: {type: 'array', compare: false, value: []},
+  sourceOptions: {type: 'object', compare: false, value: {}}
+};
+
+/**
  * Internal deck.gl dispatcher that selects the appropriate source-backed layer for an input.
  *
  * This class is exported for internal repository use and examples, and is not documented
@@ -61,6 +80,9 @@ export class SourceLayer<
 > extends CompositeLayer<SourceLayerProps<DataT> & ExtraProps> {
   /** deck.gl layer name used in debugging output. */
   static layerName = 'SourceLayer';
+
+  /** Synchronous prop definitions that preserve URL and Blob inputs for source dispatch. */
+  static defaultProps: DefaultProps = defaultProps;
 
   /** Initialize resolved source state. */
   initializeState(): void {
@@ -74,6 +96,8 @@ export class SourceLayer<
     if (
       changeFlags.dataChanged ||
       props.sources !== oldProps.sources ||
+      props.loader !== oldProps.loader ||
+      props.loaders !== oldProps.loaders ||
       props.sourceOptions !== oldProps.sourceOptions
     ) {
       this.setState({
@@ -92,19 +116,25 @@ export class SourceLayer<
     const {sources, sourceOptions, metadata, ...layerProps} = this.props;
     if (isTileSourceRuntime(resolvedData)) {
       return [
-        new TileSourceLayer({
-          ...layerProps,
-          data: resolvedData,
-          metadata
-        } as unknown as TileSourceLayerProps)
+        new TileSourceLayer(
+          this.getSubLayerProps({
+            ...layerProps,
+            id: 'tile-source',
+            data: resolvedData,
+            metadata
+          }) as unknown as TileSourceLayerProps
+        )
       ];
     }
 
     return [
-      new Tile3DSourceLayer({
-        ...layerProps,
-        data: resolvedData
-      } as any)
+      new Tile3DSourceLayer(
+        this.getSubLayerProps({
+          ...layerProps,
+          id: 'tiles-3d',
+          data: resolvedData
+        }) as any
+      )
     ];
   }
 

--- a/modules/deck-layers/test/source-layer.browser.spec.ts
+++ b/modules/deck-layers/test/source-layer.browser.spec.ts
@@ -17,7 +17,7 @@ function createSourceLayer(props: SourceLayerProps): SourceLayer {
   return new SourceLayer(props as any);
 }
 
-test('SourceLayer#preserves URL inputs for 3D loader dispatch', t => {
+test('SourceLayer#preserves URL inputs for browser 3D loader dispatch', t => {
   const tilesetUrl = 'https://example.com/tileset.json';
   const layer = createSourceLayer({
     id: 'tiles-3d',

--- a/modules/deck-layers/test/source-layer.spec.ts
+++ b/modules/deck-layers/test/source-layer.spec.ts
@@ -1,0 +1,39 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'tape-promise/tape';
+import {SourceLayer, type SourceLayerProps} from '@loaders.gl/deck-layers';
+
+const TEST_3D_LOADER = {
+  id: '3d-tiles',
+  name: '3D Tiles',
+  module: '3d-tiles',
+  version: '0.0.0'
+};
+
+/** Creates a source dispatcher without requiring a deck.gl rendering context. */
+function createSourceLayer(props: SourceLayerProps): SourceLayer {
+  return new SourceLayer(props as any);
+}
+
+test('SourceLayer#preserves URL inputs for 3D loader dispatch', t => {
+  const tilesetUrl = 'https://example.com/tileset.json';
+  const layer = createSourceLayer({
+    id: 'tiles-3d',
+    data: tilesetUrl,
+    loaders: [TEST_3D_LOADER as any]
+  });
+
+  t.equal(layer.props.data, tilesetUrl, 'data is not replaced by deck.gl async prop handling');
+
+  const resolvedData = (layer as any)._resolveData(layer.props);
+  (layer as any).state = {resolvedData};
+  const renderedLayers = layer.renderLayers() as any[];
+
+  t.equal(resolvedData, tilesetUrl, 'URL is retained for the 3D child layer');
+  t.equal(renderedLayers[0].constructor.layerName, 'Tile3DSourceLayer');
+  t.equal(renderedLayers[0].id, 'tiles-3d-tiles-3d', 'child layer has a unique sublayer id');
+  t.equal(renderedLayers[0].props.loaders[0], TEST_3D_LOADER);
+  t.end();
+});

--- a/modules/tiles/src/tileset-3d/common/tile-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tile-3d.ts
@@ -26,6 +26,7 @@ import {TilesetTraverser} from './tileset-traverser';
 import {
   calculateFoveatedFactor,
   calculateTileRequestPriority,
+  isFoveatedRequestDelayActive,
   isFoveatedRequestDeferred,
   isProgressiveResolutionPriority
 } from '../helpers/tiles-3d-request-priority';
@@ -128,7 +129,7 @@ export class Tile3D {
   _priorityProgressiveResolution: boolean = false;
   /** Angular distance from the camera view axis used to prioritize center tiles. */
   _foveatedFactor: number = 0;
-  /** Whether this peripheral request may wait briefly after camera movement. */
+  /** Whether this peripheral request is currently inside the camera-motion deferral window. */
   priorityDeferred: boolean = false;
   private _visibilityPlaneMask: any;
   private _visible: boolean | undefined = undefined;
@@ -369,6 +370,12 @@ export class Tile3D {
     if (this.tileset._frameNumber - this._touchedFrame >= 1) {
       return -1;
     }
+    // RequestScheduler re-evaluates this callback before a queued request receives a slot. A
+    // negative priority cancels work that became deferred after it was queued; the scheduled
+    // follow-up traversal submits it again after the motion delay expires.
+    if (this.priorityDeferred) {
+      return -1;
+    }
     if (this.contentState === TILE_CONTENT_STATE.UNLOADED) {
       return -1;
     }
@@ -388,7 +395,6 @@ export class Tile3D {
     const reverseScreenSpaceError = Math.max(rootScreenSpaceError - screenSpaceError, 0);
     return calculateTileRequestPriority({
       priorityProgressiveResolution: this._priorityProgressiveResolution,
-      priorityDeferred: this.priorityDeferred,
       foveatedFactor: this._foveatedFactor,
       reverseScreenSpaceError,
       rootScreenSpaceError
@@ -540,7 +546,7 @@ export class Tile3D {
     }
 
     this._foveatedFactor = calculateFoveatedFactor(this.boundingVolume, frameState.camera);
-    this.priorityDeferred = isFoveatedRequestDeferred({
+    const deferralEligible = isFoveatedRequestDeferred({
       refinement: this.refine,
       skipLevelOfDetail: this.tileset._traverser.options.skipLevelOfDetail,
       foveatedScreenSpaceError: options.foveatedScreenSpaceError,
@@ -554,6 +560,11 @@ export class Tile3D {
       maximumScreenSpaceError: this.tileset.memoryAdjustedScreenSpaceError,
       priorityProgressiveResolution: this._priorityProgressiveResolution
     });
+    this.priorityDeferred = isFoveatedRequestDelayActive(
+      deferralEligible,
+      frameState.camera.timeSinceMovement,
+      options.foveatedTimeDelay
+    );
   }
 
   // Determines whether the tile's bounding volume intersects the culling volume.

--- a/modules/tiles/src/tileset-3d/common/tileset-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tileset-3d.ts
@@ -12,7 +12,10 @@ import {TilesetCache} from './tileset-cache';
 import {calculateTransformProps} from '../helpers/transform-utils';
 import {getFrameState, limitSelectedTiles, updateCameraMotionState} from '../helpers/frame-state';
 import type {CameraMotionState, FrameState} from '../helpers/frame-state';
-import {calculateDynamicScreenSpaceErrorDensity} from '../helpers/tiles-3d-lod';
+import {
+  calculateDynamicScreenSpaceErrorDensity,
+  updateRootTransformForDynamicScreenSpaceError
+} from '../helpers/tiles-3d-lod';
 import {interpolateLinearly} from '../helpers/tiles-3d-request-priority';
 import type {FoveatedInterpolationCallback} from '../helpers/tiles-3d-request-priority';
 
@@ -623,6 +626,10 @@ export class Tileset3D {
       );
       this._cameraMotionStates[id] = cameraMotionUpdate.state;
       frameState.camera.timeSinceMovement = cameraMotionUpdate.timeSinceMovement;
+      // Dynamic SSE reads the root's inverse computed transform before traversal updates tile
+      // visibility. Refresh it from the current tileset model matrix here so animated local
+      // box/sphere tilesets never calculate their height falloff one transform behind the frame.
+      updateRootTransformForDynamicScreenSpaceError(root, this.modelMatrix);
       frameState.dynamicScreenSpaceErrorDensity =
         this.type === TILESET_TYPE.TILES3D &&
         this.options.dynamicScreenSpaceError &&

--- a/modules/tiles/src/tileset-3d/common/tileset-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tileset-3d.ts
@@ -38,7 +38,28 @@ export type Tileset3DProps = {
   loadOptions?: LoaderOptions;
   loadTiles?: boolean;
   basePath?: string;
+  /**
+   * Soft target, in bytes, for cached tile content that is not required by the current frame.
+   * The listed default applies to 3D Tiles; I3S retains its existing 32 MiB default.
+   * @default 536870912
+   */
+  cacheBytes?: number;
+  /**
+   * Additional bytes that the current-frame working set may use before memory-adjusted SSE rises.
+   * The listed default applies to 3D Tiles; I3S retains its existing 1 MiB default.
+   * @default 536870912
+   */
+  maximumCacheOverflowBytes?: number;
+  /**
+   * Soft cache target in mebibytes.
+   * @deprecated Use {@link Tileset3DProps.cacheBytes}; when both are supplied, `cacheBytes` wins.
+   */
   maximumMemoryUsage?: number;
+  /**
+   * Cache overflow headroom in mebibytes.
+   * @deprecated Use {@link Tileset3DProps.maximumCacheOverflowBytes}; when both are supplied, the
+   * byte-native option wins.
+   */
   memoryCacheOverflow?: number;
   maximumTilesSelected?: number;
   debounceTime?: number;
@@ -58,6 +79,10 @@ export type Tileset3DProps = {
   dynamicScreenSpaceErrorFactor?: number;
   /** Fraction of tileset height at which dynamic SSE begins to fade, clamped to `[0, 1]`. */
   dynamicScreenSpaceErrorHeightFalloff?: number;
+  /**
+   * Enables adaptive LOD reduction when estimated tile memory exceeds the overflow ceiling.
+   * Defaults to `true` for 3D Tiles and retains the existing `false` default for I3S.
+   */
   memoryAdjustedScreenSpaceError?: boolean;
   viewportTraversersMap?: any;
   updateTransforms?: boolean;
@@ -93,7 +118,13 @@ type Props = {
   modelMatrix: Matrix4;
   throttleRequests: boolean;
   maxRequests: number;
+  /** Soft target, in bytes, for evictable cached tile content. */
+  cacheBytes: number;
+  /** Current-frame headroom, in bytes, before memory-adjusted SSE rises. */
+  maximumCacheOverflowBytes: number;
+  /** @deprecated Byte-native code should use `cacheBytes`. */
   maximumMemoryUsage: number;
+  /** @deprecated Byte-native code should use `maximumCacheOverflowBytes`. */
   memoryCacheOverflow: number;
   maximumTilesSelected: number;
   debounceTime: number;
@@ -113,6 +144,7 @@ type Props = {
   dynamicScreenSpaceErrorFactor: number;
   /** Fraction of tileset height at which dynamic SSE begins to fade. */
   dynamicScreenSpaceErrorHeightFalloff: number;
+  /** Whether cache pressure may adapt the active SSE threshold. */
   memoryAdjustedScreenSpaceError: boolean;
   viewportTraversersMap: Record<string, any> | null;
   attributions: string[];
@@ -137,14 +169,80 @@ type Props = {
   i3s: Record<string, any>;
 };
 
+const BYTES_PER_MEBIBYTE = 1024 * 1024;
+const DEFAULT_CACHE_BYTES = 512 * BYTES_PER_MEBIBYTE;
+const DEFAULT_MAXIMUM_CACHE_OVERFLOW_BYTES = 512 * BYTES_PER_MEBIBYTE;
+const DEFAULT_I3S_CACHE_BYTES = 32 * BYTES_PER_MEBIBYTE;
+const DEFAULT_I3S_MAXIMUM_CACHE_OVERFLOW_BYTES = BYTES_PER_MEBIBYTE;
+
+/**
+ * Validates a byte-based tile-cache budget.
+ *
+ * Fractions are accepted because JavaScript memory estimates are numbers, but negative, infinite,
+ * and `NaN` values cannot define a stable cache threshold.
+ *
+ * @param value - Proposed cache budget in bytes.
+ * @param optionName - Public option name used in an actionable error message.
+ * @returns The validated byte budget.
+ */
+function validateCacheByteLength(value: number, optionName: string): number {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`${optionName} must be a finite number greater than or equal to 0`);
+  }
+  return value;
+}
+
+/**
+ * Resolves the base cache target from byte-native or deprecated mebibyte options.
+ *
+ * The byte-native option takes precedence so mixed migration configurations are deterministic.
+ * The fallback is already expressed in bytes and is used for both construction and runtime updates.
+ *
+ * @param options - Options that may contain byte-native or deprecated cache values.
+ * @param fallbackCacheBytes - Existing or default cache target in bytes.
+ * @returns The resolved and validated cache target in bytes.
+ */
+function resolveCacheBytes(options: Tileset3DProps, fallbackCacheBytes: number): number {
+  const cacheBytes =
+    options.cacheBytes ??
+    (options.maximumMemoryUsage !== undefined
+      ? options.maximumMemoryUsage * BYTES_PER_MEBIBYTE
+      : fallbackCacheBytes);
+  return validateCacheByteLength(cacheBytes, 'cacheBytes');
+}
+
+/**
+ * Resolves cache overflow headroom from byte-native or deprecated mebibyte options.
+ *
+ * The byte-native option takes precedence so callers can migrate the two cache controls
+ * independently without unit ambiguity.
+ *
+ * @param options - Options that may contain byte-native or deprecated overflow values.
+ * @param fallbackOverflowBytes - Existing or default overflow headroom in bytes.
+ * @returns The resolved and validated overflow headroom in bytes.
+ */
+function resolveMaximumCacheOverflowBytes(
+  options: Tileset3DProps,
+  fallbackOverflowBytes: number
+): number {
+  const maximumCacheOverflowBytes =
+    options.maximumCacheOverflowBytes ??
+    (options.memoryCacheOverflow !== undefined
+      ? options.memoryCacheOverflow * BYTES_PER_MEBIBYTE
+      : fallbackOverflowBytes);
+  return validateCacheByteLength(maximumCacheOverflowBytes, 'maximumCacheOverflowBytes');
+}
+
 const DEFAULT_PROPS: Props = {
   description: '',
   ellipsoid: Ellipsoid.WGS84,
   modelMatrix: new Matrix4(),
   throttleRequests: true,
   maxRequests: 64,
-  maximumMemoryUsage: 32,
-  memoryCacheOverflow: 1,
+  cacheBytes: DEFAULT_CACHE_BYTES,
+  maximumCacheOverflowBytes: DEFAULT_MAXIMUM_CACHE_OVERFLOW_BYTES,
+  maximumMemoryUsage: DEFAULT_CACHE_BYTES / BYTES_PER_MEBIBYTE,
+  memoryCacheOverflow: DEFAULT_MAXIMUM_CACHE_OVERFLOW_BYTES / BYTES_PER_MEBIBYTE,
   maximumTilesSelected: 0,
   debounceTime: 0,
   onTileLoad: () => {},
@@ -167,7 +265,7 @@ const DEFAULT_PROPS: Props = {
   dynamicScreenSpaceErrorDensity: 2.0e-4,
   dynamicScreenSpaceErrorFactor: 24,
   dynamicScreenSpaceErrorHeightFalloff: 0.25,
-  memoryAdjustedScreenSpaceError: false,
+  memoryAdjustedScreenSpaceError: true,
   loadTiles: true,
   updateTransforms: true,
   viewportTraversersMap: null,
@@ -231,12 +329,13 @@ export class Tileset3D {
   /** Effective dynamic SSE density calculated for the most recently traversed viewport. */
   dynamicScreenSpaceErrorComputedDensity = 0;
 
-  maximumMemoryUsage = 32;
+  /** Estimated bytes currently retained by loaded tile content. */
   gpuMemoryUsageInBytes = 0;
+  /** Active SSE threshold after optional cache-pressure adjustment, in logical/CSS pixels. */
   memoryAdjustedScreenSpaceError = 0.0;
 
-  private _cacheBytes = 0;
-  private _cacheOverflowBytes = 0;
+  private _cacheBytes = DEFAULT_CACHE_BYTES;
+  private _maximumCacheOverflowBytes = DEFAULT_MAXIMUM_CACHE_OVERFLOW_BYTES;
 
   _frameNumber = 0;
   private _tiles: Record<string, Tile3D> = {};
@@ -269,12 +368,34 @@ export class Tileset3D {
    * @param options Traversal and runtime options.
    */
   constructor(source: Tileset3DSource, options?: Tileset3DProps) {
-    this.options = {...DEFAULT_PROPS, ...options};
-    this.loadOptions = this.options.loadOptions || {};
-
     if (!isTileset3DSource(source)) {
       throw new Error('Tileset3D requires a Tileset3DSource instance');
     }
+
+    const suppliedOptions = options || {};
+    const usesTiles3DCacheDefaults = source.type === TILESET_TYPE.TILES3D;
+    const defaultCacheBytes = usesTiles3DCacheDefaults
+      ? DEFAULT_PROPS.cacheBytes
+      : DEFAULT_I3S_CACHE_BYTES;
+    const defaultMaximumCacheOverflowBytes = usesTiles3DCacheDefaults
+      ? DEFAULT_PROPS.maximumCacheOverflowBytes
+      : DEFAULT_I3S_MAXIMUM_CACHE_OVERFLOW_BYTES;
+    const cacheBytes = resolveCacheBytes(suppliedOptions, defaultCacheBytes);
+    const maximumCacheOverflowBytes = resolveMaximumCacheOverflowBytes(
+      suppliedOptions,
+      defaultMaximumCacheOverflowBytes
+    );
+    this.options = {
+      ...DEFAULT_PROPS,
+      ...suppliedOptions,
+      cacheBytes,
+      maximumCacheOverflowBytes,
+      maximumMemoryUsage: cacheBytes / BYTES_PER_MEBIBYTE,
+      memoryCacheOverflow: maximumCacheOverflowBytes / BYTES_PER_MEBIBYTE,
+      memoryAdjustedScreenSpaceError:
+        suppliedOptions.memoryAdjustedScreenSpaceError ?? usesTiles3DCacheDefaults
+    };
+    this.loadOptions = this.options.loadOptions || {};
     this.source = source;
 
     this.tileset = null;
@@ -296,8 +417,8 @@ export class Tileset3D {
     });
 
     this.memoryAdjustedScreenSpaceError = this.options.maximumScreenSpaceError;
-    this._cacheBytes = this.options.maximumMemoryUsage * 1024 * 1024;
-    this._cacheOverflowBytes = this.options.memoryCacheOverflow * 1024 * 1024;
+    this._cacheBytes = cacheBytes;
+    this._maximumCacheOverflowBytes = maximumCacheOverflowBytes;
 
     this.stats = new Stats({id: this.url});
     this._initializeStats();
@@ -322,14 +443,83 @@ export class Tileset3D {
     return this._frameNumber;
   }
 
+  /**
+   * Gets or sets the soft target, in bytes, for cached tile content not needed this frame.
+   *
+   * Current-frame tiles remain protected even when their estimated memory exceeds this target.
+   * Reducing the value makes unused least-recently-used tiles eligible for eviction on the next
+   * traversal.
+   * @default 536870912 for 3D Tiles; 33554432 for I3S
+   */
+  get cacheBytes(): number {
+    return this._cacheBytes;
+  }
+
+  set cacheBytes(value: number) {
+    this._cacheBytes = validateCacheByteLength(value, 'cacheBytes');
+    this.options.cacheBytes = this._cacheBytes;
+    this.options.maximumMemoryUsage = this._cacheBytes / BYTES_PER_MEBIBYTE;
+  }
+
+  /**
+   * Gets or sets the additional current-frame headroom, in bytes, before memory-adjusted SSE rises.
+   *
+   * The pressure ceiling is `cacheBytes + maximumCacheOverflowBytes`. This value does not change
+   * the base target used to evict tiles that were not touched in the current frame.
+   * @default 536870912 for 3D Tiles; 1048576 for I3S
+   */
+  get maximumCacheOverflowBytes(): number {
+    return this._maximumCacheOverflowBytes;
+  }
+
+  set maximumCacheOverflowBytes(value: number) {
+    this._maximumCacheOverflowBytes = validateCacheByteLength(value, 'maximumCacheOverflowBytes');
+    this.options.maximumCacheOverflowBytes = this._maximumCacheOverflowBytes;
+    this.options.memoryCacheOverflow = this._maximumCacheOverflowBytes / BYTES_PER_MEBIBYTE;
+  }
+
+  /**
+   * Gets or sets the soft cache target in mebibytes.
+   * @deprecated Use {@link Tileset3D.cacheBytes}. Assignments remain synchronized for compatibility.
+   */
+  get maximumMemoryUsage(): number {
+    return this.cacheBytes / BYTES_PER_MEBIBYTE;
+  }
+
+  set maximumMemoryUsage(value: number) {
+    this.cacheBytes = validateCacheByteLength(value * BYTES_PER_MEBIBYTE, 'maximumMemoryUsage');
+  }
+
   get queryParams(): string {
     const rootUrl = this.source.getTileUrl(this.url);
     const queryIndex = rootUrl.indexOf('?');
     return queryIndex >= 0 ? rootUrl.slice(queryIndex + 1) : '';
   }
 
+  /**
+   * Updates traversal and runtime options, synchronizing byte-native and deprecated cache values.
+   *
+   * For each budget, the byte-native option takes precedence when both unit forms are supplied.
+   * Unspecified budgets retain their current byte values, avoiding repeated MiB conversion.
+   *
+   * @param props - Partial runtime options to apply.
+   */
   setProps(props: Tileset3DProps): void {
-    this.options = {...this.options, ...props};
+    const cacheBytes = resolveCacheBytes(props, this.cacheBytes);
+    const maximumCacheOverflowBytes = resolveMaximumCacheOverflowBytes(
+      props,
+      this.maximumCacheOverflowBytes
+    );
+    this.options = {
+      ...this.options,
+      ...props,
+      cacheBytes,
+      maximumCacheOverflowBytes,
+      maximumMemoryUsage: cacheBytes / BYTES_PER_MEBIBYTE,
+      memoryCacheOverflow: maximumCacheOverflowBytes / BYTES_PER_MEBIBYTE
+    };
+    this._cacheBytes = cacheBytes;
+    this._maximumCacheOverflowBytes = maximumCacheOverflowBytes;
   }
 
   getTileUrl(tilePath: string): string {
@@ -372,13 +562,20 @@ export class Tileset3D {
     return this.updatePromise;
   }
 
+  /**
+   * Moves the active LOD threshold toward the configured SSE or away from cache pressure.
+   *
+   * Usage below {@link Tileset3D.cacheBytes} restores quality in two-percent steps. Usage above
+   * `cacheBytes + maximumCacheOverflowBytes` reduces refinement in two-percent steps. Values in
+   * the overflow window leave the threshold unchanged, preventing rapid load/evict oscillation.
+   */
   adjustScreenSpaceError(): void {
-    if (this.gpuMemoryUsageInBytes < this._cacheBytes) {
+    if (this.gpuMemoryUsageInBytes < this.cacheBytes) {
       this.memoryAdjustedScreenSpaceError = Math.max(
         this.memoryAdjustedScreenSpaceError / 1.02,
         this.options.maximumScreenSpaceError
       );
-    } else if (this.gpuMemoryUsageInBytes > this._cacheBytes + this._cacheOverflowBytes) {
+    } else if (this.gpuMemoryUsageInBytes > this.cacheBytes + this.maximumCacheOverflowBytes) {
       this.memoryAdjustedScreenSpaceError *= 1.02;
     }
   }
@@ -596,6 +793,9 @@ export class Tileset3D {
 
   _unloadTiles(): void {
     this._cache.unloadTiles(this, (tileset, tile) => tileset._unloadTile(tile));
+    if (this.options.memoryAdjustedScreenSpaceError) {
+      this.adjustScreenSpaceError();
+    }
   }
 
   _updateStats(): void {

--- a/modules/tiles/src/tileset-3d/common/tileset-cache.ts
+++ b/modules/tiles/src/tileset-3d/common/tileset-cache.ts
@@ -71,13 +71,24 @@ export class TilesetCache {
     }
   }
 
-  unloadTiles(tileset, unloadCallback): void {
+  /**
+   * Unloads least-recently-used tiles until the byte-native cache target is met.
+   *
+   * Tiles touched after the frame sentinel remain protected, so {@link Tileset3D.cacheBytes} is a
+   * soft target rather than a hard cap on the visible working set. Overflow headroom affects
+   * memory-adjusted SSE, not eviction of unused tiles.
+   *
+   * @param tileset - Tileset that owns the cache and reports estimated content memory.
+   * @param unloadCallback - Callback that releases content and decrements the memory estimate.
+   */
+  unloadTiles(
+    tileset: Tileset3D,
+    unloadCallback?: (tileset: Tileset3D, tile: Tile3D) => void
+  ): void {
     const trimTiles = this._trimTiles;
     this._trimTiles = false;
 
     const list = this._list;
-
-    const maximumMemoryUsageInBytes = tileset.maximumMemoryUsage * 1024 * 1024;
 
     // Traverse the list only to the sentinel since tiles/nodes to the
     // right of the sentinel were used this frame.
@@ -85,10 +96,7 @@ export class TilesetCache {
     const sentinel = this._sentinel;
     let node = list.head;
 
-    while (
-      node !== sentinel &&
-      (tileset.gpuMemoryUsageInBytes > maximumMemoryUsageInBytes || trimTiles)
-    ) {
+    while (node !== sentinel && (tileset.gpuMemoryUsageInBytes > tileset.cacheBytes || trimTiles)) {
       // @ts-expect-error
       const tile = node.item;
       // @ts-expect-error

--- a/modules/tiles/src/tileset-3d/common/tileset-traverser.ts
+++ b/modules/tiles/src/tileset-3d/common/tileset-traverser.ts
@@ -238,7 +238,7 @@ export class TilesetTraverser {
   // tile to load from server
   loadTile(tile: Tile3D, frameState: FrameState): void {
     if (this.shouldLoadTile(tile)) {
-      if (this.shouldDeferTileRequest(tile, frameState)) {
+      if (this.shouldDeferTileRequest(tile)) {
         this.deferredTiles[tile.id] = tile;
         return;
       }
@@ -251,21 +251,15 @@ export class TilesetTraverser {
   /**
    * Returns whether an eligible peripheral request should wait for camera motion to settle.
    *
-   * Eligibility is calculated on the tile with refinement-safety checks. This final gate only
-   * applies the time window, keeping traversal deterministic once the delay expires.
+   * Eligibility and the current time window are calculated together when tile visibility updates.
+   * Keeping the active state on the tile also lets a queued scheduler callback cancel work that
+   * became deferred after its original traversal.
    *
    * @param tile - Tile considered for loading.
-   * @param frameState - Current camera motion measurements.
    * @returns `true` when the request should be retried after the remaining delay.
    */
-  shouldDeferTileRequest(tile: Tile3D, frameState: FrameState): boolean {
-    const foveatedTimeDelay = tile.tileset.options.foveatedTimeDelay;
-    return (
-      tile.priorityDeferred &&
-      Number.isFinite(foveatedTimeDelay) &&
-      foveatedTimeDelay > 0 &&
-      frameState.camera.timeSinceMovement < foveatedTimeDelay
-    );
+  shouldDeferTileRequest(tile: Tile3D): boolean {
+    return tile.priorityDeferred;
   }
 
   // cache tile

--- a/modules/tiles/src/tileset-3d/helpers/tiles-3d-lod.ts
+++ b/modules/tiles/src/tileset-3d/helpers/tiles-3d-lod.ts
@@ -5,7 +5,7 @@
 // This file is derived from the Cesium code base under Apache 2 license
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 
-import {Matrix4, Vector3, clamp} from '@math.gl/core';
+import {Matrix4, Quaternion, Vector3, clamp} from '@math.gl/core';
 import {Ellipsoid} from '@math.gl/geospatial';
 import type {Tile3D} from '../common/tile-3d';
 import type {FrameState} from './frame-state';
@@ -39,7 +39,30 @@ const scratchCartographic = new Vector3();
 const scratchCenter = new Vector3();
 const scratchPosition = new Vector3();
 const scratchDirection = new Vector3();
+const scratchBoxXAxis = new Vector3();
+const scratchBoxYAxis = new Vector3();
+const scratchBoxZAxis = new Vector3();
+const scratchBoxQuaternion = new Quaternion();
 const unitZDirection = new Vector3(0, 0, 1);
+
+/**
+ * Refreshes the root transform before calculating transform-dependent dynamic SSE density.
+ *
+ * Traversal normally updates transforms while visiting tile visibility, but density is calculated
+ * immediately before traversal. Performing the root update at that earlier boundary keeps local
+ * box and sphere height falloff synchronized with an animated tileset model matrix in the same
+ * frame. {@link Tile3D._updateTransform} also recalculates world-space geometric error from its raw
+ * source value, so repeated calls do not compound scale.
+ *
+ * @param root - Root tile whose computed transform feeds dynamic SSE height calculations.
+ * @param modelMatrix - Current tileset-to-world transform for this frame.
+ */
+export function updateRootTransformForDynamicScreenSpaceError(
+  root: Tile3D,
+  modelMatrix: Matrix4
+): void {
+  root._updateTransform(modelMatrix);
+}
 
 /**
  * Calculates the effective dynamic screen-space error density for one viewport and frame.
@@ -308,7 +331,7 @@ function getBoundingVolumeCenterAndHalfHeight(
   if (boundingVolumeHeader.box) {
     const box = boundingVolumeHeader.box;
     result.set(box[0], box[1], box[2]);
-    return box.length === 10 ? box[5] : Math.hypot(box[9], box[10], box[11]);
+    return getBoxHalfHeight(box);
   }
 
   if (boundingVolumeHeader.sphere) {
@@ -318,4 +341,30 @@ function getBoundingVolumeCenterAndHalfHeight(
   }
 
   return null;
+}
+
+/**
+ * Returns the conservative source-z extent of an oriented box.
+ *
+ * A 12-component 3D Tiles box stores three half-axis vectors, so every vector can contribute to
+ * vertical height after rotation. The alternate 10-component representation stores half sizes and
+ * a quaternion; rotating its three scaled basis vectors produces the same sum of absolute z
+ * projections. Using only the nominal z axis would underestimate tilted volumes and fade dynamic
+ * SSE too early while the camera is still within the tileset's height range.
+ *
+ * @param box - Source-space oriented box in half-axis or half-size/quaternion form.
+ * @returns Conservative source-z half-height in the box coordinate system's distance units.
+ */
+function getBoxHalfHeight(box: number[]): number {
+  if (box.length === 10) {
+    scratchBoxQuaternion.fromArray(box, 6);
+    scratchBoxXAxis.set(box[3], 0, 0).transformByQuaternion(scratchBoxQuaternion);
+    scratchBoxYAxis.set(0, box[4], 0).transformByQuaternion(scratchBoxQuaternion);
+    scratchBoxZAxis.set(0, 0, box[5]).transformByQuaternion(scratchBoxQuaternion);
+    return (
+      Math.abs(scratchBoxXAxis[2]) + Math.abs(scratchBoxYAxis[2]) + Math.abs(scratchBoxZAxis[2])
+    );
+  }
+
+  return Math.abs(box[5]) + Math.abs(box[8]) + Math.abs(box[11]);
 }

--- a/modules/tiles/src/tileset-3d/helpers/tiles-3d-request-priority.ts
+++ b/modules/tiles/src/tileset-3d/helpers/tiles-3d-request-priority.ts
@@ -11,7 +11,6 @@ import {TILE_REFINEMENT} from '../../constants';
 const PREFERRED_SORTING_DIGITS = 10_000;
 const FOVEATED_SORTING_SCALE = 10_000;
 const PROGRESSIVE_RESOLUTION_PENALTY = 100_000_000;
-const FOVEATED_DEFERRAL_PENALTY = 1_000_000_000;
 
 const scratchBoundingSphere = new BoundingSphere();
 const scratchCenterOffset = new Vector3();
@@ -75,8 +74,6 @@ export type FoveatedDeferralParameters = {
 export type TileRequestPriorityParameters = {
   /** Whether the tile contributes coarse progressive-resolution coverage. */
   priorityProgressiveResolution: boolean;
-  /** Whether the tile is eligible for moving-camera deferral. */
-  priorityDeferred: boolean;
   /** Tile distance from the camera view axis, represented as an angular factor. */
   foveatedFactor: number;
   /** Existing reverse-SSE ordering value; smaller values are more urgent. */
@@ -102,11 +99,13 @@ export function interpolateLinearly(
 }
 
 /**
- * Calculates how far a tile lies from the camera's center line.
+ * Calculates how far a tile lies from the camera's forward center ray.
  *
  * The tile's bounding sphere, rather than only its center, is used so large tiles that intersect
- * the view axis retain center priority. The returned angular factor is zero on the view axis and
- * increases toward the edge of a perspective frustum.
+ * the view axis retain center priority. Clamping the nearest point to the forward ray prevents
+ * volumes behind the camera from receiving the same priority as centered visible content. The
+ * returned angular factor is zero on the view axis and increases toward the edge of a perspective
+ * frustum, reaching one for volumes entirely behind the camera.
  *
  * @param boundingVolume - Tile volume used to find the point nearest the camera view axis.
  * @param camera - World-space camera position and normalized view direction.
@@ -124,7 +123,7 @@ export function calculateFoveatedFactor(
   const {center, radius} = boundingSphere;
 
   scratchCenterOffset.copy(center).subtract(camera.position);
-  const centerZDepth = scratchCenterOffset.dot(camera.direction);
+  const centerZDepth = Math.max(scratchCenterOffset.dot(camera.direction), 0);
   scratchClosestPointOnLine.copy(camera.direction).scale(centerZDepth).add(camera.position);
   scratchVectorToLine.copy(scratchClosestPointOnLine).subtract(center);
 
@@ -144,7 +143,7 @@ export function calculateFoveatedFactor(
   }
 
   scratchClosestPointOnSphere.normalize();
-  return Math.max(1 - Math.abs(scratchClosestPointOnSphere.dot(camera.direction)), 0);
+  return Math.min(Math.max(1 - scratchClosestPointOnSphere.dot(camera.direction), 0), 1);
 }
 
 /**
@@ -243,12 +242,38 @@ export function isFoveatedRequestDeferred(parameters: FoveatedDeferralParameters
 }
 
 /**
+ * Returns whether an eligible foveated request is inside the current camera-motion delay.
+ *
+ * Eligibility describes geometry and refinement safety; this function adds time. Keeping the
+ * active state separate ensures the scheduler removes the temporary hold as soon as the configured
+ * delay expires, while invalid timing inputs safely disable the hold.
+ *
+ * @param deferralEligible - Whether refinement and foveation permit this request to wait.
+ * @param timeSinceMovement - Seconds since the current viewport last changed pose.
+ * @param foveatedTimeDelay - Maximum delay after motion, in seconds.
+ * @returns `true` only while an eligible request remains inside a positive finite delay.
+ */
+export function isFoveatedRequestDelayActive(
+  deferralEligible: boolean,
+  timeSinceMovement: number,
+  foveatedTimeDelay: number
+): boolean {
+  return (
+    deferralEligible &&
+    Number.isFinite(timeSinceMovement) &&
+    Number.isFinite(foveatedTimeDelay) &&
+    foveatedTimeDelay > 0 &&
+    timeSinceMovement < foveatedTimeDelay
+  );
+}
+
+/**
  * Encodes request priority into independent decimal bands.
  *
- * Smaller values load first. Moving-camera deferral is the strongest penalty, followed by the
- * progressive-coverage flag, distance from the view center, and finally the established reverse-
- * SSE order. Normalizing reverse SSE preserves its relative ordering while preventing one metric
- * from spilling into the next priority band.
+ * Smaller values load first. Requests inside the moving-camera delay are kept out of this queue;
+ * eligible requests are ordered by the progressive-coverage flag, distance from the view center,
+ * and finally the established reverse-SSE order. Normalizing reverse SSE preserves its relative
+ * ordering while preventing one metric from spilling into the next priority band.
  *
  * @param parameters - Independent request-priority measurements for a tile.
  * @returns Numeric priority for `RequestScheduler`; smaller values start first.
@@ -272,12 +297,5 @@ export function calculateTileRequestPriority(parameters: TileRequestPriorityPara
   const progressiveResolutionDigits = parameters.priorityProgressiveResolution
     ? 0
     : PROGRESSIVE_RESOLUTION_PENALTY;
-  const foveatedDeferralDigits = parameters.priorityDeferred ? FOVEATED_DEFERRAL_PENALTY : 0;
-
-  return (
-    foveatedDeferralDigits +
-    progressiveResolutionDigits +
-    foveatedSortingDigits +
-    preferredSortingDigits
-  );
+  return progressiveResolutionDigits + foveatedSortingDigits + preferredSortingDigits;
 }

--- a/modules/tiles/test/tileset/tiles-3d-lod.spec.ts
+++ b/modules/tiles/test/tileset/tiles-3d-lod.spec.ts
@@ -13,7 +13,8 @@ import {
   calculateDynamicScreenSpaceErrorDensity,
   getDynamicScreenSpaceError,
   getDynamicScreenSpaceErrorFog,
-  getTiles3DScreenSpaceError
+  getTiles3DScreenSpaceError,
+  updateRootTransformForDynamicScreenSpaceError
 } from '../../src/tileset-3d/helpers/tiles-3d-lod';
 import {LOD_METRIC_TYPE, TILESET_TYPE} from '../../src/constants';
 
@@ -293,6 +294,64 @@ test('calculateDynamicScreenSpaceErrorDensity#uses the root transform without ch
     ),
     DYNAMIC_SCREEN_SPACE_ERROR_OPTIONS.dynamicScreenSpaceErrorDensity,
     'camera and source volume are compared in the same local coordinate system'
+  );
+  t.end();
+});
+
+test('dynamic screen-space error#refreshes an animated root before density calculation', t => {
+  const root = createTile({
+    ...TILE_HEADER,
+    boundingVolume: {sphere: [0, 0, 10, 10]}
+  });
+  const currentModelMatrix = new Matrix4().translate([0, 0, 100]);
+
+  updateRootTransformForDynamicScreenSpaceError(root, currentModelMatrix);
+
+  t.ok(
+    root.computedTransform.equals(currentModelMatrix),
+    'uses the current-frame tileset transform before traversal'
+  );
+  t.equals(root.lodMetricValue, 10, 'does not compound the source geometric error');
+  t.equals(
+    calculateDynamicScreenSpaceErrorDensity(
+      root,
+      createFrameState({camera: {position: [0, 0, 105]}}),
+      DYNAMIC_SCREEN_SPACE_ERROR_OPTIONS
+    ),
+    DYNAMIC_SCREEN_SPACE_ERROR_OPTIONS.dynamicScreenSpaceErrorDensity,
+    'calculates density from the refreshed transform in the same frame'
+  );
+  t.end();
+});
+
+test('calculateDynamicScreenSpaceErrorDensity#includes every oriented-box axis in height', t => {
+  const halfAxesRoot = createTile({
+    ...TILE_HEADER,
+    boundingVolume: {box: [0, 0, 10, 10, 0, 10, 0, 2, 0, 0, 0, 1]}
+  });
+  const halfSizeQuaternionRoot = createTile({
+    ...TILE_HEADER,
+    boundingVolume: {
+      box: [0, 0, 10, 10, 2, 1, 0, Math.sin(Math.PI / 4), 0, Math.cos(Math.PI / 4)]
+    }
+  });
+  const frameState = createFrameState({camera: {position: [0, 0, 15]}});
+
+  t.ok(
+    calculateDynamicScreenSpaceErrorDensity(
+      halfAxesRoot,
+      frameState,
+      DYNAMIC_SCREEN_SPACE_ERROR_OPTIONS
+    ) > 0,
+    'includes tilted half-axis z projections'
+  );
+  t.ok(
+    calculateDynamicScreenSpaceErrorDensity(
+      halfSizeQuaternionRoot,
+      frameState,
+      DYNAMIC_SCREEN_SPACE_ERROR_OPTIONS
+    ) > 0,
+    'includes quaternion-rotated half-size z projections'
   );
   t.end();
 });

--- a/modules/tiles/test/tileset/tiles-3d-request-priority.spec.ts
+++ b/modules/tiles/test/tileset/tiles-3d-request-priority.spec.ts
@@ -6,12 +6,14 @@
 
 import test from 'tape-promise/tape';
 import {BoundingSphere} from '@math.gl/culling';
-import {TILE_REFINEMENT} from '../../src/constants';
+import {TILE_CONTENT_STATE, TILE_REFINEMENT} from '../../src/constants';
+import {Tile3D} from '../../src/tileset-3d/common/tile-3d';
 import {TilesetTraverser} from '../../src/tileset-3d/common/tileset-traverser';
 import {
   calculateFoveatedFactor,
   calculateTileRequestPriority,
   interpolateLinearly,
+  isFoveatedRequestDelayActive,
   isFoveatedRequestDeferred,
   isProgressiveResolutionPriority
 } from '../../src/tileset-3d/helpers/tiles-3d-request-priority';
@@ -25,6 +27,7 @@ test('request priority#foveated factor accounts for bounding volume', t => {
   const centeredTile = new BoundingSphere([0, 0, 10], 1);
   const peripheralTile = new BoundingSphere([5, 0, 10], 1);
   const intersectingTile = new BoundingSphere([4, 0, 10], 4);
+  const behindCameraTile = new BoundingSphere([0, 0, -10], 1);
 
   t.equals(
     calculateFoveatedFactor(centeredTile, TEST_CAMERA),
@@ -39,6 +42,11 @@ test('request priority#foveated factor accounts for bounding volume', t => {
     calculateFoveatedFactor(intersectingTile, TEST_CAMERA),
     0,
     'keeps a large volume at center priority when it intersects the view axis'
+  );
+  t.equals(
+    calculateFoveatedFactor(behindCameraTile, TEST_CAMERA),
+    1,
+    'assigns maximum peripheral priority to a volume behind the camera'
   );
   t.end();
 });
@@ -119,7 +127,6 @@ test('request priority#foveated deferral preserves refinement continuity', t => 
 test('request priority#uses independent scheduling bands', t => {
   const basePriority = {
     priorityProgressiveResolution: false,
-    priorityDeferred: false,
     foveatedFactor: 0,
     reverseScreenSpaceError: 0,
     rootScreenSpaceError: 100
@@ -131,19 +138,56 @@ test('request priority#uses independent scheduling bands', t => {
   });
   const centerPriority = calculateTileRequestPriority(basePriority);
   const peripheralPriority = calculateTileRequestPriority({...basePriority, foveatedFactor: 0.1});
-  const deferredPriority = calculateTileRequestPriority({
-    ...basePriority,
-    priorityDeferred: true
-  });
 
   t.ok(progressivePriority < centerPriority, 'loads coarse progressive coverage first');
   t.ok(centerPriority < peripheralPriority, 'loads viewport-center content before the periphery');
-  t.ok(peripheralPriority < deferredPriority, 'keeps deferred content behind stationary work');
   t.ok(
     calculateTileRequestPriority({...basePriority, reverseScreenSpaceError: 10}) <
       calculateTileRequestPriority({...basePriority, reverseScreenSpaceError: 90}),
     'preserves reverse-SSE order inside the same priority band'
   );
+  t.end();
+});
+
+test('request priority#limits deferral to the active motion window', t => {
+  t.ok(isFoveatedRequestDelayActive(true, 0.1, 0.2), 'holds eligible work during the delay');
+  t.notOk(isFoveatedRequestDelayActive(true, 0.2, 0.2), 'removes the hold when the delay expires');
+  t.notOk(
+    isFoveatedRequestDelayActive(false, 0.1, 0.2),
+    'does not hold refinement-ineligible work'
+  );
+  for (const invalidDelay of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+    t.notOk(
+      isFoveatedRequestDelayActive(true, 0.1, invalidDelay),
+      `disables the hold for delay ${String(invalidDelay)}`
+    );
+  }
+  t.end();
+});
+
+test('Tile3D#scheduler callback cancels a request that became deferred while queued', t => {
+  const tile = Object.assign(Object.create(Tile3D.prototype), {
+    refine: TILE_REFINEMENT.ADD,
+    tileset: {
+      _frameNumber: 1,
+      _traverser: {
+        options: {skipLevelOfDetail: false},
+        root: {_screenSpaceError: 100}
+      }
+    },
+    parent: null,
+    _visible: true,
+    _touchedFrame: 1,
+    _screenSpaceError: 10,
+    _priorityProgressiveResolution: false,
+    _foveatedFactor: 0.1,
+    contentState: TILE_CONTENT_STATE.LOADING,
+    priorityDeferred: true
+  }) as Tile3D;
+
+  t.equals(tile._getPriority(), -1, 'cancels the queued scheduler entry during motion');
+  tile.priorityDeferred = false;
+  t.ok(tile._getPriority() >= 0, 'restores normal priority after the delay expires');
   t.end();
 });
 
@@ -170,6 +214,7 @@ test('TilesetTraverser#releases deferred requests after the movement delay', t =
   t.notOk(traverser.requestedTiles[tile.id], 'does not issue the held request');
 
   traverser.reset();
+  tile.priorityDeferred = isFoveatedRequestDelayActive(true, 0.2, 0.2);
   // @ts-expect-error test supplies the minimal tile and frame-state fields used by loadTile
   traverser.loadTile(tile, {...movingFrameState, camera: {timeSinceMovement: 0.2}});
   t.ok(traverser.requestedTiles[tile.id], 'releases the request when the delay expires');

--- a/modules/tiles/test/tileset/tileset-3d-traversal.spec.ts
+++ b/modules/tiles/test/tileset/tileset-3d-traversal.spec.ts
@@ -210,17 +210,15 @@ test('Tileset3D#two viewports traversal', async t => {
   t.plan(3);
   const tilesetJson = await load(TILESET_URL, Tiles3DLoader);
   const viewports = VIEWPORTS;
-  let tileLoadCounter = 0;
   const tileset = new Tileset3D(new Tiles3DSource({...tilesetJson, coreApi}), {
     onTileLoad: () => {
       tileset.update(viewports);
-      tileLoadCounter++;
     }
   });
   tileset.update(viewports);
 
   t.timeoutAfter(1000);
-  await waitForCondition(() => tileLoadCounter > 2, 1000);
+  await waitForCondition(() => tileset.selectedTiles.length === 6, 1000);
   tileset.update(viewports);
   t.equals(tileset.selectedTiles.length, 6);
   t.equals(tileset.selectedTiles.filter(tile => tile.viewportIds.includes('view0')).length, 1);

--- a/modules/tiles/test/tileset/tileset-cache.spec.ts
+++ b/modules/tiles/test/tileset/tileset-cache.spec.ts
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'tape-promise/tape';
+import {coreApi} from '@loaders.gl/core';
+import {Tiles3DLoader} from '@loaders.gl/3d-tiles';
+import {getI3sTileHeader} from '@loaders.gl/i3s/test/test-utils/load-utils';
+import {I3SSource, Tile3D, Tiles3DSource, Tileset3D} from '@loaders.gl/tiles';
+import type {Tileset3DProps} from '../../src/tileset-3d/common/tileset-3d';
+
+const TILESET_URL = '@loaders.gl/3d-tiles/test/data/CesiumJS/Tilesets/Tileset/tileset.json';
+const BYTES_PER_MEBIBYTE = 1024 * 1024;
+
+/**
+ * Creates a source-backed test tileset with the requested cache options.
+ * @param options - Runtime options under test.
+ * @returns A tileset whose initialization can be awaited by the test.
+ */
+function createTestTileset(options: Tileset3DProps = {}): Tileset3D {
+  const source = new Tiles3DSource({url: TILESET_URL, loader: Tiles3DLoader, coreApi});
+  return new Tileset3D(source, options);
+}
+
+test('Tileset3D#cache byte budgets use Cesium-compatible defaults', async t => {
+  const tileset = createTestTileset();
+  await tileset.tilesetInitializationPromise;
+
+  t.equals(tileset.cacheBytes, 512 * BYTES_PER_MEBIBYTE, 'defaults to a 512 MiB cache');
+  t.equals(
+    tileset.maximumCacheOverflowBytes,
+    512 * BYTES_PER_MEBIBYTE,
+    'defaults to 512 MiB of current-view headroom'
+  );
+  t.equals(
+    tileset.options.memoryAdjustedScreenSpaceError,
+    true,
+    'memory-adjusted SSE is enabled by default'
+  );
+  t.end();
+});
+
+test('Tileset3D#cache defaults leave I3S behavior unchanged', async t => {
+  const i3sTilesetHeader = await getI3sTileHeader();
+  const tileset = new Tileset3D(new I3SSource({...i3sTilesetHeader, coreApi}));
+  await tileset.tilesetInitializationPromise;
+
+  t.equals(tileset.cacheBytes, 32 * BYTES_PER_MEBIBYTE, 'retains the 32 MiB I3S cache');
+  t.equals(
+    tileset.maximumCacheOverflowBytes,
+    BYTES_PER_MEBIBYTE,
+    'retains the 1 MiB I3S overflow window'
+  );
+  t.equals(
+    tileset.options.memoryAdjustedScreenSpaceError,
+    false,
+    'does not enable adaptive I3S LOD by default'
+  );
+  t.end();
+});
+
+test('Tileset3D#cache byte options take precedence over deprecated MiB options', async t => {
+  const tileset = createTestTileset({
+    cacheBytes: 1234,
+    maximumCacheOverflowBytes: 5678,
+    maximumMemoryUsage: 2,
+    memoryCacheOverflow: 3
+  });
+  await tileset.tilesetInitializationPromise;
+
+  t.equals(tileset.cacheBytes, 1234, 'uses the byte-native cache target exactly');
+  t.equals(tileset.maximumCacheOverflowBytes, 5678, 'uses the byte-native overflow value exactly');
+  t.equals(
+    tileset.maximumMemoryUsage,
+    1234 / BYTES_PER_MEBIBYTE,
+    'keeps the deprecated property synchronized'
+  );
+  t.equals(
+    tileset.options.memoryCacheOverflow,
+    5678 / BYTES_PER_MEBIBYTE,
+    'keeps the deprecated option synchronized'
+  );
+  t.end();
+});
+
+test('Tileset3D#deprecated MiB cache options remain compatible', async t => {
+  const tileset = createTestTileset({maximumMemoryUsage: 2, memoryCacheOverflow: 3});
+  await tileset.tilesetInitializationPromise;
+
+  t.equals(tileset.cacheBytes, 2 * BYTES_PER_MEBIBYTE, 'converts the base budget to bytes');
+  t.equals(
+    tileset.maximumCacheOverflowBytes,
+    3 * BYTES_PER_MEBIBYTE,
+    'converts overflow headroom to bytes'
+  );
+
+  tileset.maximumMemoryUsage = 4;
+  t.equals(tileset.cacheBytes, 4 * BYTES_PER_MEBIBYTE, 'synchronizes legacy assignments');
+  t.equals(tileset.options.cacheBytes, 4 * BYTES_PER_MEBIBYTE, 'synchronizes public options');
+  t.end();
+});
+
+test('Tileset3D#setProps updates byte budgets without stale derived state', async t => {
+  const tileset = createTestTileset({cacheBytes: 100, maximumCacheOverflowBytes: 20});
+  await tileset.tilesetInitializationPromise;
+
+  tileset.setProps({maximumMemoryUsage: 2, maximumCacheOverflowBytes: 30});
+  t.equals(tileset.cacheBytes, 2 * BYTES_PER_MEBIBYTE, 'updates from the deprecated base option');
+  t.equals(tileset.maximumCacheOverflowBytes, 30, 'updates the byte-native overflow option');
+
+  tileset.setProps({cacheBytes: 40, maximumMemoryUsage: 9, memoryCacheOverflow: 4});
+  t.equals(tileset.cacheBytes, 40, 'byte-native base option wins during runtime updates');
+  t.equals(
+    tileset.maximumCacheOverflowBytes,
+    4 * BYTES_PER_MEBIBYTE,
+    'an independently supplied legacy overflow option still converts correctly'
+  );
+  t.end();
+});
+
+test('Tileset3D#cache byte budgets reject unstable thresholds', async t => {
+  t.throws(
+    () => createTestTileset({cacheBytes: -1}),
+    /cacheBytes must be a finite number greater than or equal to 0/,
+    'rejects negative construction values'
+  );
+  t.throws(
+    () => createTestTileset({maximumCacheOverflowBytes: Number.POSITIVE_INFINITY}),
+    /maximumCacheOverflowBytes must be a finite number greater than or equal to 0/,
+    'rejects infinite construction values'
+  );
+
+  const tileset = createTestTileset();
+  await tileset.tilesetInitializationPromise;
+  t.throws(() => {
+    tileset.cacheBytes = Number.NaN;
+  }, /cacheBytes must be a finite number greater than or equal to 0/);
+  t.throws(() => {
+    tileset.maximumMemoryUsage = -1;
+  }, /maximumMemoryUsage must be a finite number greater than or equal to 0/);
+  t.end();
+});
+
+test('Tileset3D#memory-adjusted SSE uses base plus overflow as its pressure ceiling', async t => {
+  const tileset = createTestTileset({
+    cacheBytes: 100,
+    maximumCacheOverflowBytes: 20,
+    maximumScreenSpaceError: 10
+  });
+  await tileset.tilesetInitializationPromise;
+
+  tileset.gpuMemoryUsageInBytes = 120;
+  tileset.adjustScreenSpaceError();
+  t.equals(
+    tileset.memoryAdjustedScreenSpaceError,
+    10,
+    'does not adjust inside the overflow window'
+  );
+
+  tileset.gpuMemoryUsageInBytes = 121;
+  tileset.adjustScreenSpaceError();
+  t.equals(tileset.memoryAdjustedScreenSpaceError, 10.2, 'reduces LOD demand above the ceiling');
+
+  tileset.gpuMemoryUsageInBytes = 99;
+  tileset.adjustScreenSpaceError();
+  t.equals(tileset.memoryAdjustedScreenSpaceError, 10, 'restores the configured SSE below base');
+  t.end();
+});
+
+test('TilesetCache#unloadTiles evicts by exact bytes and protects current-frame tiles', async t => {
+  const tileset = createTestTileset({cacheBytes: 150});
+  await tileset.tilesetInitializationPromise;
+
+  const firstTile = {_cacheNode: null} as Tile3D;
+  const secondTile = {_cacheNode: null} as Tile3D;
+  const protectedTile = {_cacheNode: null} as Tile3D;
+  const unloadedTiles: Tile3D[] = [];
+
+  tileset._cache.add(tileset, firstTile);
+  tileset._cache.add(tileset, secondTile);
+  tileset._cache.add(tileset, protectedTile);
+  tileset._cache.reset();
+  tileset._cache.touch(protectedTile);
+  tileset.gpuMemoryUsageInBytes = 300;
+
+  tileset._cache.unloadTiles(tileset, (_tileset, tile) => {
+    unloadedTiles.push(tile);
+    tileset.gpuMemoryUsageInBytes -= 100;
+  });
+
+  t.deepEquals(unloadedTiles, [firstTile, secondTile], 'evicts eligible tiles in LRU order');
+  t.equals(tileset.gpuMemoryUsageInBytes, 100, 'stops after reaching the exact byte target');
+  t.ok(protectedTile._cacheNode, 'retains the tile touched in the current frame');
+  t.end();
+});


### PR DESCRIPTION
## Goals

- Align the 3D Tiles cache with Cesium's byte-native two-threshold policy.
- Make cache pressure adapt LOD predictably without changing I3S defaults.
- Preserve the 3D Tiles example's URL/Blob inputs through source dispatch.
- Carry forward and fix all actionable review findings from the preceding 3D Tiles PR stack.
- Ship complete API, migration, tuning, diagnostics, and release-note documentation.

## Actual changes

- Added `Tileset3D.cacheBytes` and `maximumCacheOverflowBytes` with 512 MiB 3D Tiles defaults.
- Preserved the existing 32 MiB/1 MiB I3S budgets and disabled-by-default I3S memory adjustment.
- Kept `maximumMemoryUsage` and `memoryCacheOverflow` as synchronized deprecated MiB aliases; byte-native values win when both forms are supplied.
- Evict unused LRU tiles at the exact base byte target while protecting current-frame content.
- Raise active SSE above the base-plus-overflow ceiling and restore it below the base target in incremental steps.
- Added construction, runtime update, validation, eviction, frame-protection, SSE, alias, and I3S-isolation tests.
- Fixed the internal `SourceLayer` prop contract so deck.gl does not replace URL/Blob inputs before 3D dispatch, assigned unique sublayer IDs, and kept its deck.gl regression coverage in the browser test matrix.
- Expanded the cache/memory guide and cross-links, updated the API reference and v5 migration guide, and added separate What’s New bullets for every improvement.

## Earlier stack review fixes

- Normalize explicit tile, content, and viewer-request `3DTILES_bounding_volume_S2` volumes, while retaining S2 metadata for implicit subdivision.
- Refresh the root transform before dynamic-SSE density calculations and derive oriented-box height from all rotated half axes.
- Measure foveated distance from the camera's forward ray, so volumes behind the camera cannot receive center priority.
- Cancel motion-deferred requests that are still queued before they receive a network slot; resubmit them after the delay without retaining a stale priority penalty.
- Wait for the two-viewport traversal's actual six-tile steady state, eliminating its timing-dependent browser assertion.

## Impact

Applications can configure unambiguous byte budgets and get graceful LOD reduction under memory pressure. Existing MiB configurations continue to work, while I3S behavior remains unchanged. The loaders.gl 3D Tiles example loads URL-backed tilesets again. Dynamic SSE, S2 bounds, and foveated request scheduling now remain correct across transform, projection, camera-motion, and queue-state changes.

## Root cause of the example failure

`SourceLayer` inherited deck.gl's asynchronous `data` prop definition. During initialization deck.gl exposed the inherited empty-array placeholder instead of the URL, so dispatch failed before the 3D loader ran. The dispatcher now declares synchronous data props, preserves the original input, and creates uniquely identified child layers.

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn test-node` — 394 files passed; 1,707 tests passed
- `yarn test-headless` — 398 files passed; 1,710 tests passed
- `cd website && yarn && yarn build`
- Focused Node and headless S2, SSE/LOD, foveation, cache, and source-dispatch suites
- Production Vite build and browser smoke test of the 3D Tiles example; Royal Exhibition Building loaded and centered with no console errors

Partially addresses #1245.

The two-threshold semantics follow [CesiumGS/cesium#11310](https://github.com/CesiumGS/cesium/pull/11310).