### PR TITLE
test(parquet): add backend compatibility matrix

### DIFF
--- a/modules/parquet/package.json
+++ b/modules/parquet/package.json
@@ -87,7 +87,9 @@
   "devDependencies": {
     "@types/node-int64": "^0.4.29",
     "@types/thrift": "^0.10.8",
-    "@types/varint": "^5.0.0"
+    "@types/varint": "^5.0.0",
+    "hyparquet": "1.27.1",
+    "hyparquet-compressors": "1.1.1"
   },
   "peerDependencies": {
     "@loaders.gl/core": "~5.0.0-alpha.0",

--- a/modules/parquet/test/data/files.ts
+++ b/modules/parquet/test/data/files.ts
@@ -2,58 +2,322 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-const PARQUET_FILES = [
-  // Parquet seems to use LZ4 compression without header so we need to find a way to e.g. add a dummy header.
-  {supportedJs: true, supportedWasm: false, title: 'lz4_raw_compressed', path: 'good/lz4_raw_compressed.parquet'},
-  {supportedJs: true, supportedWasm: false, title: 'lz4_raw_compressed_larger', path: 'good/lz4_raw_compressed_larger.parquet'},
-  {supportedJs: true, supportedWasm: false, title: 'non_hadoop_lz4_compressed', path: 'good/non_hadoop_lz4_compressed.parquet'},
-  {supportedJs: true, supportedWasm: true, title: 'alltypes_dictionary', path: 'good/alltypes_dictionary.parquet'},
-  {supportedJs: true, supportedWasm: true, title: 'alltypes_plain', path: 'good/alltypes_plain.parquet'},
-  {supportedJs: true, supportedWasm: true, title: 'alltypes_plain_snappy', path: 'good/alltypes_plain.snappy.parquet'},
-  {supportedJs: true, supportedWasm: true, title: 'binary', path: 'good/binary.parquet'},
-  // Specialized Dict for very large dictionaries: https://github.com/apache/parquet-format/blob/master/BloomFilter.md
-  {supportedJs: false, supportedWasm: false, title: 'bloom_filter', path: 'good/bloom_filter.bin'},
-  {supportedJs: true, supportedWasm: false, title: 'byte_array_decimal', path: 'good/byte_array_decimal.parquet'},
-  {supportedJs: false, supportedWasm: true, title: 'datapage_v2', path: 'good/datapage_v2.snappy.parquet'}, // Doesn't work on parquet-tools
-  {supportedJs: true, supportedWasm: false, title: 'dict', path: 'good/dict-page-offset-zero.parquet'},
-  {supportedJs: true, supportedWasm: true, title: 'fixed_length_decimal', path: 'good/fixed_length_decimal.parquet'},
-  {supportedJs: true, supportedWasm: true, title: 'fixed_length_decimal_legacy', path: 'good/fixed_length_decimal_legacy.parquet'},
-  {supportedJs: false, supportedWasm: false, title: 'hadoop_lz4_compressed', path: 'good/hadoop_lz4_compressed.parquet'},
-  {supportedJs: false, supportedWasm: false, title: 'hadoop_lz4_compressed_larger', path: 'good/hadoop_lz4_compressed_larger.parquet'},
-  {supportedJs: true, supportedWasm: true, title: 'int32_decimal', path: 'good/int32_decimal.parquet'},
-  {supportedJs: true, supportedWasm: true, title: 'int64_decimal', path: 'good/int64_decimal.parquet'},
-  {supportedJs: true, supportedWasm: true, title: 'list_columns', path: 'good/list_columns.parquet'},
-  {supportedJs: true, supportedWasm: false, title: 'nation', path: 'good/nation.dict-malformed.parquet'}, // Partially works, issue with indices for dictionary values.
-  {supportedJs: true, supportedWasm: false, title: 'nested_lists', path: 'good/nested_lists.snappy.parquet'},
-  {supportedJs: true, supportedWasm: true, title: 'nested_maps', path: 'good/nested_maps.snappy.parquet'},
-  {supportedJs: false, supportedWasm: true, title: 'nested_structs', path: 'good/nested_structs.rust.parquet'},
-  {supportedJs: true, supportedWasm: false, title: 'nonnullable', path: 'good/nonnullable.impala.parquet'},
-  {supportedJs: true, supportedWasm: false, title: 'nullable', path: 'good/nullable.impala.parquet'},
-  {supportedJs: true, supportedWasm: true, title: 'nulls', path: 'good/nulls.snappy.parquet'},
-  {supportedJs: true, supportedWasm: false, title: 'repeated_no_annotation', path: 'good/repeated_no_annotation.parquet'},
-  {supportedJs: false, supportedWasm: true, title: 'single_nan', path: 'good/single_nan.parquet'},
+/** One Apache Parquet compatibility fixture and its expected backend support. */
+export type ParquetTestFile = {
+  /** Stable fixture name used in test output. */
+  title: string;
+  /** Fixture path relative to the Apache Parquet test-data directory. */
+  path: string;
+  /** Whether the loaders.gl TypeScript backend currently reads this fixture. */
+  supportedJs: boolean;
+  /** Whether the loaders.gl parquet-wasm backend currently reads this fixture. */
+  supportedWasm: boolean;
+  /** Whether the pinned hyparquet reference currently reads this fixture. */
+  supportedHyparquet: boolean;
+  /** Whether the fixture uses Parquet modular encryption. */
+  encrypted?: boolean;
+  /** Whether the fixture is intentionally malformed. */
+  bad?: boolean;
+  /** Whether the wasm assertion is safe to execute in the shared test process. */
+  testWasm?: boolean;
+};
 
-  {supportedJs: false, supportedWasm: true, title: 'data_index_bloom_encoding_stats', path: 'good/data_index_bloom_encoding_stats.parquet'},
-  {supportedJs: false, supportedWasm: true, title: 'delta_binary_packed', path: 'good/delta_binary_packed.parquet'},
-  {supportedJs: false, supportedWasm: true, title: 'delta_byte_array', path: 'good/delta_byte_array.parquet'},
-  {supportedJs: false, supportedWasm: true, title: 'delta_encoding_optional_column', path: 'good/delta_encoding_optional_column.parquet'},
-  {supportedJs: false, supportedWasm: true, title: 'delta_encoding_required_column', path: 'good/delta_encoding_required_column.parquet'},
-
-  // Encrypted
-  {supportedJs: false, encrypted: true, supportedWasm: false, title: 'uniform_encryption', path: 'good/uniform_encryption.parquet.encrypted'},
-  {supportedJs: false, encrypted: true, supportedWasm: false, title: 'encrypt_columns_and_footer', path: 'encrypted/encrypt_columns_and_footer.parquet.encrypted'},
-  {supportedJs: false, encrypted: true, supportedWasm: false, title: 'encrypt_columns_and_footer_aad', path: 'encrypted/encrypt_columns_and_footer_aad.parquet.encrypted'},
-  {supportedJs: false, encrypted: true, supportedWasm: false, title: 'encrypt_columns_and_footer_ctr', path: 'encrypted/encrypt_columns_and_footer_ctr.parquet.encrypted'},
-  {supportedJs: false, encrypted: true, supportedWasm: false, title: 'encrypt_columns_and_footer_disable_aad_storage', path: 'encrypted/encrypt_columns_and_footer_disable_aad_storage.parquet.encrypted'},
-  {supportedJs: false, encrypted: true, supportedWasm: false, title: 'encrypt_columns_plaintext_footer', path: 'encrypted/encrypt_columns_plaintext_footer.parquet.encrypted'},
-
-  // Illegal
-  {supportedJs: false, bad: true, supportedWasm: false, title: 'PARQUET-1481', path: 'illegal/PARQUET-1481.parquet'},
+/**
+ * Executable backend compatibility matrix.
+ *
+ * Keep classifications aligned with `parquet-compatibility.spec.ts`. A backend
+ * improvement intentionally fails that test until this matrix is updated.
+ */
+export const PARQUET_FILES: ParquetTestFile[] = [
+  {
+    title: 'lz4_raw_compressed',
+    path: 'good/lz4_raw_compressed.parquet',
+    supportedJs: true,
+    supportedWasm: true,
+    supportedHyparquet: true
+  },
+  {
+    title: 'lz4_raw_compressed_larger',
+    path: 'good/lz4_raw_compressed_larger.parquet',
+    supportedJs: true,
+    supportedWasm: true,
+    supportedHyparquet: true
+  },
+  {
+    title: 'non_hadoop_lz4_compressed',
+    path: 'good/non_hadoop_lz4_compressed.parquet',
+    supportedJs: true,
+    supportedWasm: true,
+    supportedHyparquet: true
+  },
+  {
+    title: 'alltypes_dictionary',
+    path: 'good/alltypes_dictionary.parquet',
+    supportedJs: true,
+    supportedWasm: true,
+    supportedHyparquet: true
+  },
+  {
+    title: 'alltypes_plain',
+    path: 'good/alltypes_plain.parquet',
+    supportedJs: true,
+    supportedWasm: true,
+    supportedHyparquet: true
+  },
+  {
+    title: 'alltypes_plain_snappy',
+    path: 'good/alltypes_plain.snappy.parquet',
+    supportedJs: true,
+    supportedWasm: true,
+    supportedHyparquet: true
+  },
+  {
+    title: 'binary',
+    path: 'good/binary.parquet',
+    supportedJs: true,
+    supportedWasm: true,
+    supportedHyparquet: true
+  },
+  {
+    title: 'bloom_filter',
+    path: 'good/bloom_filter.bin',
+    supportedJs: false,
+    supportedWasm: false,
+    supportedHyparquet: false
+  },
+  {
+    title: 'byte_array_decimal',
+    path: 'good/byte_array_decimal.parquet',
+    supportedJs: true,
+    supportedWasm: true,
+    supportedHyparquet: true
+  },
+  {
+    title: 'datapage_v2',
+    path: 'good/datapage_v2.snappy.parquet',
+    supportedJs: false,
+    supportedWasm: true,
+    supportedHyparquet: true
+  },
+  {
+    title: 'dict',
+    path: 'good/dict-page-offset-zero.parquet',
+    supportedJs: true,
+    supportedWasm: false,
+    supportedHyparquet: true
+  },
+  {
+    title: 'fixed_length_decimal',
+    path: 'good/fixed_length_decimal.parquet',
+    supportedJs: true,
+    supportedWasm: true,
+    supportedHyparquet: true
+  },
+  {
+    title: 'fixed_length_decimal_legacy',
+    path: 'good/fixed_length_decimal_legacy.parquet',
+    supportedJs: true,
+    supportedWasm: true,
+    supportedHyparquet: true
+  },
+  {
+    title: 'hadoop_lz4_compressed',
+    path: 'good/hadoop_lz4_compressed.parquet',
+    supportedJs: false,
+    supportedWasm: true,
+    supportedHyparquet: true
+  },
+  {
+    title: 'hadoop_lz4_compressed_larger',
+    path: 'good/hadoop_lz4_compressed_larger.parquet',
+    supportedJs: true,
+    supportedWasm: true,
+    supportedHyparquet: true
+  },
+  {
+    title: 'int32_decimal',
+    path: 'good/int32_decimal.parquet',
+    supportedJs: true,
+    supportedWasm: true,
+    supportedHyparquet: true
+  },
+  {
+    title: 'int64_decimal',
+    path: 'good/int64_decimal.parquet',
+    supportedJs: true,
+    supportedWasm: true,
+    supportedHyparquet: true
+  },
+  {
+    title: 'list_columns',
+    path: 'good/list_columns.parquet',
+    supportedJs: true,
+    supportedWasm: true,
+    supportedHyparquet: true
+  },
+  {
+    title: 'nation',
+    path: 'good/nation.dict-malformed.parquet',
+    supportedJs: true,
+    supportedWasm: false,
+    supportedHyparquet: false,
+    testWasm: false
+  },
+  {
+    title: 'nested_lists',
+    path: 'good/nested_lists.snappy.parquet',
+    supportedJs: true,
+    supportedWasm: true,
+    supportedHyparquet: true
+  },
+  {
+    title: 'nested_maps',
+    path: 'good/nested_maps.snappy.parquet',
+    supportedJs: true,
+    supportedWasm: true,
+    supportedHyparquet: true
+  },
+  {
+    title: 'nested_structs',
+    path: 'good/nested_structs.rust.parquet',
+    supportedJs: false,
+    supportedWasm: true,
+    supportedHyparquet: true
+  },
+  {
+    title: 'nonnullable',
+    path: 'good/nonnullable.impala.parquet',
+    supportedJs: true,
+    supportedWasm: true,
+    supportedHyparquet: true
+  },
+  {
+    title: 'nullable',
+    path: 'good/nullable.impala.parquet',
+    supportedJs: true,
+    supportedWasm: true,
+    supportedHyparquet: true
+  },
+  {
+    title: 'nulls',
+    path: 'good/nulls.snappy.parquet',
+    supportedJs: true,
+    supportedWasm: true,
+    supportedHyparquet: true
+  },
+  {
+    title: 'repeated_no_annotation',
+    path: 'good/repeated_no_annotation.parquet',
+    supportedJs: true,
+    supportedWasm: true,
+    supportedHyparquet: true
+  },
+  {
+    title: 'single_nan',
+    path: 'good/single_nan.parquet',
+    supportedJs: true,
+    supportedWasm: true,
+    supportedHyparquet: true
+  },
+  {
+    title: 'data_index_bloom_encoding_stats',
+    path: 'good/data_index_bloom_encoding_stats.parquet',
+    supportedJs: true,
+    supportedWasm: true,
+    supportedHyparquet: true
+  },
+  {
+    title: 'delta_binary_packed',
+    path: 'good/delta_binary_packed.parquet',
+    supportedJs: false,
+    supportedWasm: true,
+    supportedHyparquet: true
+  },
+  {
+    title: 'delta_byte_array',
+    path: 'good/delta_byte_array.parquet',
+    supportedJs: false,
+    supportedWasm: true,
+    supportedHyparquet: true
+  },
+  {
+    title: 'delta_encoding_optional_column',
+    path: 'good/delta_encoding_optional_column.parquet',
+    supportedJs: false,
+    supportedWasm: true,
+    supportedHyparquet: true
+  },
+  {
+    title: 'delta_encoding_required_column',
+    path: 'good/delta_encoding_required_column.parquet',
+    supportedJs: false,
+    supportedWasm: true,
+    supportedHyparquet: true
+  },
+  {
+    title: 'uniform_encryption',
+    path: 'good/uniform_encryption.parquet.encrypted',
+    supportedJs: false,
+    supportedWasm: false,
+    supportedHyparquet: false,
+    encrypted: true
+  },
+  {
+    title: 'encrypt_columns_and_footer',
+    path: 'encrypted/encrypt_columns_and_footer.parquet.encrypted',
+    supportedJs: false,
+    supportedWasm: false,
+    supportedHyparquet: false,
+    encrypted: true
+  },
+  {
+    title: 'encrypt_columns_and_footer_aad',
+    path: 'encrypted/encrypt_columns_and_footer_aad.parquet.encrypted',
+    supportedJs: false,
+    supportedWasm: false,
+    supportedHyparquet: false,
+    encrypted: true
+  },
+  {
+    title: 'encrypt_columns_and_footer_ctr',
+    path: 'encrypted/encrypt_columns_and_footer_ctr.parquet.encrypted',
+    supportedJs: false,
+    supportedWasm: false,
+    supportedHyparquet: false,
+    encrypted: true
+  },
+  {
+    title: 'encrypt_columns_and_footer_disable_aad_storage',
+    path: 'encrypted/encrypt_columns_and_footer_disable_aad_storage.parquet.encrypted',
+    supportedJs: false,
+    supportedWasm: false,
+    supportedHyparquet: false,
+    encrypted: true
+  },
+  {
+    title: 'encrypt_columns_plaintext_footer',
+    path: 'encrypted/encrypt_columns_plaintext_footer.parquet.encrypted',
+    supportedJs: false,
+    supportedWasm: false,
+    supportedHyparquet: false,
+    encrypted: true,
+    testWasm: false
+  },
+  {
+    title: 'PARQUET-1481',
+    path: 'illegal/PARQUET-1481.parquet',
+    supportedJs: false,
+    supportedWasm: false,
+    supportedHyparquet: false,
+    bad: true
+  }
 ];
 
 export const SUPPORTED_FILES = PARQUET_FILES.filter(file => file.supportedJs);
-export const UNSUPPORTED_FILES = PARQUET_FILES.filter(file => !file.supportedJs && !file.encrypted && !file.bad);
+export const UNSUPPORTED_FILES = PARQUET_FILES.filter(
+  file => !file.supportedJs && !file.encrypted && !file.bad
+);
 export const ENCRYPTED_FILES = PARQUET_FILES.filter(file => !file.supportedJs && file.encrypted);
-export const BAD_FILES = PARQUET_FILES.filter(file => file.bad)
-
+export const BAD_FILES = PARQUET_FILES.filter(file => file.bad);
 export const WASM_SUPPORTED_FILES = PARQUET_FILES.filter(file => file.supportedWasm);
+export const HYPARQUET_SUPPORTED_FILES = PARQUET_FILES.filter(file => file.supportedHyparquet);

--- a/modules/parquet/test/index.ts
+++ b/modules/parquet/test/index.ts
@@ -22,3 +22,4 @@ import './parquet-arrow-writer.spec';
 import './parquet-loader.spec';
 import './geoparquet-loader.spec';
 import './parquet-typed-array.spec';
+import './parquet-compatibility.spec';

--- a/modules/parquet/test/parquet-compatibility.spec.ts
+++ b/modules/parquet/test/parquet-compatibility.spec.ts
@@ -1,0 +1,95 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'tape-promise/tape';
+import type {Test} from 'tape';
+
+import {fetchFile, load} from '@loaders.gl/core';
+import {ParquetLoader} from '@loaders.gl/parquet';
+import {parquetReadObjects} from 'hyparquet';
+import {compressors} from 'hyparquet-compressors';
+
+import {PARQUET_FILES, type ParquetTestFile} from './data/files';
+
+const PARQUET_DIRECTORY = '@loaders.gl/parquet/test/data/apache';
+
+type CompatibilityResult = {
+  supported: boolean;
+  error?: string;
+};
+
+type LoadersGlBackend = 'typescript' | 'wasm';
+
+for (const backend of ['typescript', 'wasm'] as const) {
+  const supportProperty = backend === 'typescript' ? 'supportedJs' : 'supportedWasm';
+  for (const fixture of PARQUET_FILES) {
+    if (backend === 'wasm' && fixture.testWasm === false) {
+      continue;
+    }
+    test(`Parquet compatibility matrix#${backend}#${fixture.title}`, async (t) => {
+      const url = `${PARQUET_DIRECTORY}/${fixture.path}`;
+      const result = await readWithLoadersGl(url, backend);
+      assertCompatibilityResult(t, fixture, backend, fixture[supportProperty], result);
+      t.end();
+    });
+  }
+}
+
+for (const fixture of PARQUET_FILES) {
+  test(`Parquet compatibility matrix#hyparquet#${fixture.title}`, async (t) => {
+    const url = `${PARQUET_DIRECTORY}/${fixture.path}`;
+    const result = await readWithHyparquet(url);
+    assertCompatibilityResult(t, fixture, 'hyparquet', fixture.supportedHyparquet, result);
+    t.end();
+  });
+}
+
+/** Read one compatibility fixture through a loaders.gl backend. */
+async function readWithLoadersGl(
+  url: string,
+  backend: LoadersGlBackend
+): Promise<CompatibilityResult> {
+  try {
+    await load(url, ParquetLoader, {
+      core: {worker: false},
+      parquet: {backend}
+    });
+    return {supported: true};
+  } catch (error) {
+    return {supported: false, error: getErrorMessage(error)};
+  }
+}
+
+/** Read one compatibility fixture through the external hyparquet reference implementation. */
+async function readWithHyparquet(url: string): Promise<CompatibilityResult> {
+  try {
+    const response = await fetchFile(url);
+    const file = await response.arrayBuffer();
+    await parquetReadObjects({file, compressors});
+    return {supported: true};
+  } catch (error) {
+    return {supported: false, error: getErrorMessage(error)};
+  }
+}
+
+/** Assert one observed backend result against the executable matrix. */
+function assertCompatibilityResult(
+  t: Test,
+  fixture: ParquetTestFile,
+  backend: LoadersGlBackend | 'hyparquet',
+  expectedSupport: boolean,
+  result: CompatibilityResult
+): void {
+  const errorSuffix = result.error ? ` (${result.error})` : '';
+  t.equal(
+    result.supported,
+    expectedSupport,
+    `${backend} ${fixture.title}: support classification matches${errorSuffix}`
+  );
+}
+
+/** Convert an unknown thrown value into a stable diagnostic string. */
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5708,6 +5708,8 @@ __metadata:
     "@types/varint": "npm:^5.0.0"
     async-mutex: "npm:^0.2.2"
     brotli: "npm:^1.3.2"
+    hyparquet: "npm:1.27.1"
+    hyparquet-compressors: "npm:1.1.1"
     isomorphic-ws: "npm:^5.0.0"
     lz4js: "npm:^0.2.0"
     node-int64: "npm:^0.4.0"
@@ -20103,6 +20105,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fzstd@npm:0.1.1":
+  version: 0.1.1
+  resolution: "fzstd@npm:0.1.1"
+  checksum: 10c0/c4ae25a4b9e7ac58e9716fcb0c4ec19f3e678d90a67a59e97ce361beb27e4aa4b8666b58b4dc2d715e92db4b65b189c978186a5fedba6fccb5ec9765717dd1cd
+  languageName: node
+  linkType: hard
+
 "generator-function@npm:^2.0.0":
   version: 2.0.1
   resolution: "generator-function@npm:2.0.1"
@@ -21505,6 +21514,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hyparquet-compressors@npm:1.1.1":
+  version: 1.1.1
+  resolution: "hyparquet-compressors@npm:1.1.1"
+  dependencies:
+    fzstd: "npm:0.1.1"
+    hysnappy: "npm:1.0.0"
+  checksum: 10c0/f8521cfeac7afc3da474f00881dd226dd6dde573ff5241f325fefde91d790866fbf087cecd3721223cdcc3fc2fec6b1a8c8163fbd394fb3f5812250a6ed49371
+  languageName: node
+  linkType: hard
+
+"hyparquet@npm:1.27.1":
+  version: 1.27.1
+  resolution: "hyparquet@npm:1.27.1"
+  checksum: 10c0/5a63c12d6dd1c8c48d2ad5b65bb4012aff342e000edccdae856973b142d2763255e4988198ce924bca1d6a0ef26bdf280efc5713fb752dbfa99cabff6eec5501
+  languageName: node
+  linkType: hard
+
 "hyperdyperid@npm:^1.2.0":
   version: 1.2.0
   resolution: "hyperdyperid@npm:1.2.0"
@@ -21516,6 +21542,13 @@ __metadata:
   version: 1.1.0
   resolution: "hyphenate-style-name@npm:1.1.0"
   checksum: 10c0/bfe88deac2414a41a0d08811e277c8c098f23993d6a1eb17f14a0f11b54c4d42865a63d3cfe1914668eefb9a188e2de58f38b55a179a238fd1fef606893e194f
+  languageName: node
+  linkType: hard
+
+"hysnappy@npm:1.0.0":
+  version: 1.0.0
+  resolution: "hysnappy@npm:1.0.0"
+  checksum: 10c0/f7d920290832b34d0582bd0e3fdac60df8399ceab740722311c7dbd845c69c38c8e448fbc50e58315c000bcad04365e3f461dc785432cb890540406040724ecc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Goals

- Establish an executable Parquet compatibility baseline before changing either loaders.gl decoder.
- Compare the TypeScript and parquet-wasm backends against a pinned hyparquet reference on the same Apache fixtures.
- Turn support gains and regressions into visible CI changes for the improvement program in #3525.

## Changes

- expands the existing fixture catalog into a typed three-backend capability matrix
- adds 115 isolated compatibility assertions that run in both Node and headless-browser projects
- pins `hyparquet` and `hyparquet-compressors` as test-only reference dependencies
- updates stale loaders.gl classifications found by the executable probe
- records two parquet-wasm inputs whose asynchronous traps are unsafe in the shared test process while retaining their unsupported status

## Validation

- `yarn build`
- `yarn test-node modules/parquet/test/parquet-compatibility.spec.ts` (115 passed)
- `yarn test-headless modules/parquet/test/parquet-compatibility.spec.ts` (115 passed)
- `yarn test-node` (395 files passed, 3 skipped)
- `yarn test-headless` (399 files passed, 3 skipped)
- `yarn lint fix`

## Stack

1. This PR: executable compatibility baseline
2. Range-backed Parquet source and metadata lifecycle
3. Selective row-group/column reads, cancellation, and provenance
4. TypeScript decoder format-correctness improvements
5. Planner, pruning, workers, telemetry, and packaging