### PR TITLE
perf(3d-tiles): streamline resource intake

### DIFF
--- a/docs/modules/3d-tiles/README.md
+++ b/docs/modules/3d-tiles/README.md
@@ -36,6 +36,7 @@ To handle the complex dynamic tile selection and loading required to performantl
 
 The [3D Tiles runtime concepts suite](/docs/modules/3d-tiles/concepts) explains the complete path from hierarchy traversal to rendering:
 
+- [Resource resolution and content detection](/docs/modules/3d-tiles/concepts/resource-resolution-and-content-detection)
 - [Tile hierarchy and refinement](/docs/modules/3d-tiles/concepts/tile-hierarchy-and-refinement)
 - [Screen-space error and level of detail](/docs/modules/3d-tiles/concepts/screen-space-error-and-lod)
 - [Request scheduling, progressive loading, and foveated requests](/docs/modules/3d-tiles/concepts/request-scheduling-and-priorities)

--- a/docs/modules/3d-tiles/api-reference/tiles-3d-loader.md
+++ b/docs/modules/3d-tiles/api-reference/tiles-3d-loader.md
@@ -52,9 +52,6 @@ import {WebMercatorViewport} from '@deck.gl/core';
 const tilesetUrl = 'https://assets.cesium.ion.com/43978/tileset.json';
 const tilesetJson = await load(tilesetUrl, Tiles3DLoader);
 
-// if your tileset file doesn't have the .json extension, set `3d-tiles.isTileset` to true
-const tilesetJson = await load(tilesetUrl, Tiles3DLoader, {'3d-tiles': {isTileset: true}});
-
 const tileset3d = new Tileset3D(tilesetJson, {
   throttleRequests: false,
   onTileLoad: (tile) => console.log(tile)
@@ -100,7 +97,7 @@ Both schemas enforce the same structural constraints, including that a tileset c
 
 | Option               | Type             | Default | Description                                                                                                                                                           |
 | -------------------- | ---------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `3d-tiles.isTileset` | `Bool` or `auto` | `auto`  | Whether to load a `Tileset` file. If `auto`, will infer based on url extension.                                                                                       |
+| `3d-tiles.isTileset` | `Boolean` or `auto` | `auto` | Selects tileset-header or render-content parsing. `auto` inspects binary magic and JSON structure, independent of the URL extension or MIME type. Explicit `true` or `false` asserts the expected category and rejects a mismatch. |
 | `3d-tiles.headers`   | `Object`         | `null`  | Used to load data from server                                                                                                                                         |
 | `3d-tiles.tileset`   | `Object`         | `null`  | `Tileset` object loaded by `Tiles3DLoader` or follow the data format specified in [Tileset Object](#tileset-object). It is required when loading i3s geometry content |
 | `3d-tiles.tile`      | `Object`         | `null`  | `Tile` object loaded by `Tiles3DLoader` or follow the data format [Tile Object](#tile-object). It is required when loading i3s geometry content                       |
@@ -118,6 +115,8 @@ For i3dm and b3dm tiles:
 | `3d-tiles.loadGLTF` | Boolean | `true`  | Fetch and parse any linked glTF files |
 
 If `options['3d-tiles'].loadGLTF` is `true`, GLTF loading can be controlled by providing [`GLTFLoader` options](/docs/modules/gltf/api-reference/gltf-loader) via the `options.gltf` sub options. Standard linked raster images are decoded through [`ImageBitmapLoader`](/docs/modules/images/api-reference/image-bitmap-loader).
+
+See [Resource resolution and content detection](/docs/modules/3d-tiles/concepts/resource-resolution-and-content-detection) for extensionless and signed URLs, nested tilesets, inherited query parameters, archive sources, validation behavior, and troubleshooting.
 
 ## Notes about Tile Types
 

--- a/docs/modules/3d-tiles/concepts/README.md
+++ b/docs/modules/3d-tiles/concepts/README.md
@@ -8,6 +8,7 @@ Loading a large 3D Tiles tileset is a continuous pipeline: traverse the hierarch
 
 | Guide | Question it answers |
 | --- | --- |
+| [Resource resolution and content detection](/docs/modules/3d-tiles/concepts/resource-resolution-and-content-detection) | How are relative references, inherited queries, and extensionless content handled? |
 | [Tile hierarchy and refinement](/docs/modules/3d-tiles/concepts/tile-hierarchy-and-refinement) | Which tiles can replace or augment their ancestors? |
 | [Screen-space error and LOD](/docs/modules/3d-tiles/concepts/screen-space-error-and-lod) | How much detail does the current view require? |
 | [Request scheduling and priorities](/docs/modules/3d-tiles/concepts/request-scheduling-and-priorities) | Which required tile should use the next network slot? |
@@ -16,4 +17,4 @@ Loading a large 3D Tiles tileset is a continuous pipeline: traverse the hierarch
 
 The stages are related but not interchangeable. In particular, screen-space error determines the desired final LOD. Progressive and foveated scheduling normally change only the order and timing of requests needed to reach that LOD.
 
-Start with [tile hierarchy and refinement](/docs/modules/3d-tiles/concepts/tile-hierarchy-and-refinement), or go directly to the [request-scheduling guide](/docs/modules/3d-tiles/concepts/request-scheduling-and-priorities) for foveated requests.
+Start with [resource resolution and content detection](/docs/modules/3d-tiles/concepts/resource-resolution-and-content-detection) to understand how a tileset enters the runtime, continue with [tile hierarchy and refinement](/docs/modules/3d-tiles/concepts/tile-hierarchy-and-refinement), or go directly to the [request-scheduling guide](/docs/modules/3d-tiles/concepts/request-scheduling-and-priorities) for foveated requests.

--- a/docs/modules/3d-tiles/concepts/resource-resolution-and-content-detection.md
+++ b/docs/modules/3d-tiles/concepts/resource-resolution-and-content-detection.md
@@ -1,0 +1,102 @@
+import {Tiles3DDocsTabs} from '@site/src/components/docs/tiles-3d-docs-tabs';
+
+# Resource Resolution and Content Detection
+
+<Tiles3DDocsTabs active="resources" />
+
+A 3D Tiles runtime repeatedly turns references in tileset metadata into fetchable resources. The reference may be relative, signed, extensionless, or stored inside a 3TZ archive. After fetching it, loaders.gl must distinguish another tileset from renderable content without trusting a filename. This page describes that resource boundary and the caches used to keep it inexpensive.
+
+## Resource-intake pipeline
+
+For an explicit tileset, the pipeline is:
+
+1. Resolve each relative `content.uri` against the tileset base URI.
+2. Inherit source query parameters that are not already present on the content URI.
+3. Fetch the resource through the configured source resolver.
+4. Inspect its first four bytes for supported binary magic.
+5. If no supported magic is present, decode and parse JSON once.
+6. Classify JSON from its top-level structure, then normalize a nested tileset or parse render content.
+
+Detection happens after fetching. It removes naming assumptions from parsing; it does not discover a resource URL before the tileset supplies one.
+
+## Structure-first content detection
+
+`Tiles3DLoader` uses the resource itself as the authority:
+
+| Detected data | Classification | Downstream behavior |
+| --- | --- | --- |
+| `b3dm`, `i3dm`, `cmpt`, or `pnts` four-byte magic | Legacy 3D Tiles binary content | Uses the matching tile parser. Composite children inspect their own embedded magic. |
+| `glTF` four-byte magic | Binary glTF (`glb`) | Uses the glTF tile-content path. |
+| JSON with object-valued `asset` and `root` properties | External tileset | Validates required extensions, normalizes headers, and attaches the nested hierarchy. |
+| JSON with an object-valued `asset` property and no tileset `root` | JSON glTF (`gltf`) | Uses the glTF tile-content path. |
+
+This makes signed URLs such as `content/42?token=...`, extensionless endpoints, and misleading filename extensions behave consistently. The server MIME type is not used to choose between tileset and tile parsing.
+
+Unsupported binary magic, malformed JSON, non-object JSON, and JSON without a supported structure fail at the resource boundary. External tileset JSON is reused after classification rather than parsed a second time.
+
+### The `isTileset` option
+
+The default `options['3d-tiles'].isTileset` value is `auto`:
+
+```typescript
+const resource = await load(url, Tiles3DLoader, {
+  '3d-tiles': {isTileset: 'auto'}
+});
+```
+
+`auto` follows the classification table above. An explicit boolean is an assertion, not a filename hint:
+
+- `true` accepts an external tileset and rejects render content.
+- `false` accepts render content and rejects an external tileset.
+
+Assertions are useful when an application-level protocol promises one category and a mismatch should be reported immediately. They are not required for extensionless tilesets.
+
+## Relative URI resolution
+
+Relative tile and subtree references are resolved against the directory containing their tileset. HTTP(S) bases use standard URL resolution, including `..` path segments. Filesystem-like bases keep loaders.gl path semantics. Absolute paths, absolute URLs, and `data:` URLs remain independent resources.
+
+One metadata parse shares a `CachedUriResolver`. It parses a URL base once and memoizes derived strings by the exact source spelling. The cache is deliberately scoped to the parse: it avoids repeated URL work in a large hierarchy without retaining resources from unrelated tilesets or users.
+
+This cache stores strings only. It does not cache response bodies, decoded content, authorization results, or failed network requests. Tile-content residency is governed separately by the [3D Tiles cache](/docs/modules/3d-tiles/concepts/caching-and-memory).
+
+## Query-parameter inheritance
+
+`Tiles3DSource` can inherit query state from the root tileset, including a tileset version and server-provided session parameter. For each content URL:
+
+- Parameters already present on the content URL win.
+- Missing inherited parameters are appended.
+- `data:` URLs are returned unchanged.
+- The completed URL is cached by its source tile path.
+- Changing inherited query state clears that completed-URL cache before the next lookup.
+
+The invalidation rule is important for rotating tokens and session changes: a derived URL must never survive after its source query value changes. Applications should still avoid embedding long-lived secrets in logs or diagnostics.
+
+## Nested and archived tilesets
+
+A loaded resource is considered a nested tileset when its parsed result has the normalized `tileset3d` shape. The URL no longer needs to contain `.json`. Nested roots therefore work through signed endpoints and content-addressed storage.
+
+3TZ and other archive-backed sources inject a resolver that reads resources from the archive. They use the same `isTileset: 'auto'` classification and parsed-shape check, so archive member names do not become a second format-detection rule.
+
+## Capability and validation boundaries
+
+Structure detection answers “what category is this payload?” It does not imply support for every feature inside that category. For an external tileset, unsupported names in `extensionsRequired` fail before header normalization or dependent subtree requests. Unknown `extensionsUsed` names remain forward-compatible because they are not declared necessary to interpret the tileset.
+
+Implicit subtree payloads have their own `Tile3DSubtreeLoader` and availability model. Lazy subtree materialization is a runtime concern rather than a content-filename heuristic.
+
+## Troubleshooting
+
+| Symptom | Likely cause | What to inspect |
+| --- | --- | --- |
+| “Expected supported binary magic or JSON object” | Truncated response, HTML error page, unsupported binary type, or malformed JSON | Response status, byte length, first bytes, authentication redirects |
+| “JSON must describe a tileset … or a glTF asset” | Valid JSON with no supported 3D Tiles or glTF structure | Top-level `asset` and `root` objects; endpoint response contract |
+| Explicit mode mismatch | `isTileset: true` received render content, or `false` received a tileset | Remove the assertion or correct the application protocol |
+| Relative content resolves under the wrong directory | Incorrect loader context URL or tileset base path | Root URL, redirects, archive resolver base |
+| Authentication query disappears | The content URI already supplies that key, or the source was created without root query state | Root query string and the final URL returned by `getTileUrl()` |
+| Old token appears after rotation | Query state was mutated outside the source API | Recreate/update the source through supported options so derived URLs are invalidated |
+| Nested hierarchy is treated as render content | Custom resolver returned unnormalized JSON instead of a `Tiles3DLoader` result | Resolver loader argument and returned `shape` |
+
+## Runtime inspection
+
+When diagnosing resource loading, record the original content URI, resolved URL, detected content type, normalized result shape, and whether the source is archive-backed. Keep credentials redacted. Follow the resource into [hierarchy refinement](/docs/modules/3d-tiles/concepts/tile-hierarchy-and-refinement), [request scheduling](/docs/modules/3d-tiles/concepts/request-scheduling-and-priorities), and [runtime diagnostics](/docs/modules/3d-tiles/concepts/runtime-tuning-and-diagnostics) to distinguish address/classification failures from traversal or cache behavior.
+
+See the [`Tiles3DLoader` API](/docs/modules/3d-tiles/api-reference/tiles-3d-loader), [`Tileset3D` API](/docs/modules/tiles/api-reference/tileset-3d), and [3D Tiles specification](https://docs.ogc.org/cs/22-025r4/22-025r4.html) for the surrounding data model.

--- a/docs/modules/loader-utils/README.md
+++ b/docs/modules/loader-utils/README.md
@@ -2,10 +2,11 @@
 
 The `@loaders.gl/loader-utils` contains utilities for creating loaders.
 
-## API reference
+## API
 
 - [`ReadableFile`](/docs/modules/loader-utils/api-reference/readable-file) provides the common random-access file contract.
 - [`ArrayBufferFile`](/docs/modules/loader-utils/api-reference/readable-file#adapting-an-arraybuffer) provides direct random access to in-memory data.
 - [`HttpFile`](/docs/modules/loader-utils/api-reference/http-file) validates random-access HTTP reads and remote object identity.
 - [`RequestScheduler`](/docs/modules/loader-utils/api-reference/request-scheduler) limits asynchronous request concurrency.
 - [`RangeRequestScheduler`](/docs/modules/loader-utils/api-reference/range-request-scheduler) coalesces compatible byte ranges.
+- [`CachedUriResolver`](/docs/modules/loader-utils/api-reference/cached-uri-resolver) resolves resource references against one stable base and memoizes repeated derivations for a caller-controlled lifetime.

--- a/docs/modules/loader-utils/api-reference/cached-uri-resolver.md
+++ b/docs/modules/loader-utils/api-reference/cached-uri-resolver.md
@@ -1,0 +1,34 @@
+# CachedUriResolver
+
+`CachedUriResolver` resolves relative resource references against one stable URL or filesystem-like base. It parses a URL base once and memoizes resolved strings by their exact input spelling.
+
+```typescript
+import {CachedUriResolver} from '@loaders.gl/loader-utils';
+
+const resolver = new CachedUriResolver('https://example.com/tiles/root');
+
+resolver.resolve('../content/tile.glb');
+// https://example.com/tiles/content/tile.glb
+```
+
+## Constructor
+
+### `new CachedUriResolver(basePath)`
+
+- `basePath: string` — directory path or absolute base URI used for relative references.
+
+URL bases use the platform `URL` implementation. Filesystem-like bases use loaders.gl path semantics. Absolute paths and absolute URIs remain absolute.
+
+## Methods
+
+### `resolve(uri): string`
+
+Resolves a relative path, absolute path, data URL, or absolute URI. Repeated calls with the same source string return the cached derivation.
+
+The cache contains strings only; it does not fetch or retain resource bodies. Scope the resolver to one metadata parse or data source so unrelated datasets and authentication contexts do not share derived URLs.
+
+### `clear(): void`
+
+Clears derived strings while retaining the parsed base URL. Call this when state outside the URI spelling changes how a caller interprets the result.
+
+The [3D Tiles resource guide](/docs/modules/3d-tiles/concepts/resource-resolution-and-content-detection) describes how this helper is scoped during tileset-header normalization and how the separate source query cache is invalidated.

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -264,6 +264,11 @@ A minor release that includes:
 - **Dynamic SSE** Perspective traversal can reduce distant, horizon-facing refinement with view-dependent density and height falloff while leaving orthographic and I3S LOD behavior unchanged.
 - **Same-frame dynamic SSE transforms** Animated local tilesets refresh the root transform before density calculation, and tilted oriented boxes derive height from every rotated half axis.
 - **Required-extension validation** Unsupported `extensionsRequired` values fail before normalization or dependent network access; unknown `extensionsUsed` values remain forward-compatible.
+- **Structure-first content detection** `Tiles3DLoader` classifies legacy binary tiles, GLB, JSON glTF, and external tilesets from payload bytes and JSON structure instead of URL extensions or MIME types.
+- **Extensionless nested tilesets** Signed, extensionless, and misleadingly named external tilesets are recognized from their parsed shape throughout the `Tiles3DSource` loading path.
+- **Single-pass JSON preprocessing** External tileset and JSON glTF payloads are decoded and parsed once, with stable diagnostics for truncated, malformed, or unsupported content.
+- **Cached resource derivation** Relative content references reuse a parse-scoped URI resolver, while inherited-query tile URLs are cached and invalidated whenever source query state changes.
+- **3D Tiles resource guide** A new [Resources tab](/docs/modules/3d-tiles/concepts/resource-resolution-and-content-detection) documents content detection, URI resolution, query inheritance, cache scope, archive behavior, and troubleshooting.
 - **Explicit S2 bounding volumes** `3DTILES_bounding_volume_S2` tile, content, and viewer-request volumes are converted to traversal-ready oriented boxes outside implicit tiling as well.
 - **Progressive tile requests** Coarse viewport coverage receives priority before fine detail through reduced-height SSE.
 - **Foveated tile requests** Perspective tiles near the view axis receive priority over equally needed peripheral detail without changing the final LOD target.

--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile-gltf.ts
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile-gltf.ts
@@ -69,6 +69,6 @@ async function parseParsedJsonGltf(
   options: Tiles3DLoaderOptions | undefined,
   context: LoaderContext
 ) {
-  const gltfLoaderWithParser = await GLTFLoader.preload('', options);
+  const gltfLoaderWithParser = await GLTFLoader.preload();
   return await gltfLoaderWithParser.parse(jsonPayload, options, context);
 }

--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile-gltf.ts
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile-gltf.ts
@@ -7,11 +7,25 @@ import {_getMemoryUsageGLTF, GLTFLoader, postProcessGLTF} from '@loaders.gl/gltf
 import type {Tiles3DLoaderOptions} from '../../tiles-3d-loader';
 import {Tiles3DTileContent} from '../../types';
 
+/**
+ * Parses glTF content embedded in a 3D Tiles resource.
+ *
+ * JSON glTF can provide its already parsed payload from the resource-boundary classifier. Binary
+ * glTF and legacy tile containers continue to pass bytes, preserving the normal parser path.
+ *
+ * @param tile - Mutable tile result populated with glTF metadata and optional parsed content.
+ * @param arrayBuffer - Original content bytes retained for byte accounting and deferred parsing.
+ * @param options - 3D Tiles and delegated glTF loader options.
+ * @param context - Loader context used to load glTF external resources.
+ * @param jsonPayload - Parsed JSON glTF object from resource preprocessing, when available.
+ * @returns Number of input bytes consumed.
+ */
 export async function parseGltf3DTile(
   tile: Tiles3DTileContent,
   arrayBuffer: ArrayBuffer,
   options?: Tiles3DLoaderOptions,
-  context?: LoaderContext
+  context?: LoaderContext,
+  jsonPayload?: Record<string, unknown>
 ): Promise<number> {
   // Set flags
   // glTF models need to be rotated from Y to Z up
@@ -26,11 +40,35 @@ export async function parseGltf3DTile(
     if (!context) {
       return arrayBuffer.byteLength;
     }
-    const gltfWithBuffers = await parseFromContext(arrayBuffer, GLTFLoader, options, context);
+    const gltfWithBuffers = jsonPayload
+      ? await parseParsedJsonGltf(jsonPayload, options, context)
+      : await parseFromContext(arrayBuffer, GLTFLoader, options, context);
     tile.gltf = postProcessGLTF(gltfWithBuffers);
     tile.gpuMemoryUsageInBytes = _getMemoryUsageGLTF(tile.gltf);
   } else {
     tile.gltfArrayBuffer = arrayBuffer;
   }
   return arrayBuffer.byteLength;
+}
+
+/**
+ * Parses a JSON glTF object already decoded at the 3D Tiles resource boundary.
+ *
+ * The core parsing API normalizes all nested input to bytes before dispatching it to a loader.
+ * Calling the parser-bearing glTF loader directly is therefore necessary to retain this parsed
+ * object and avoid repeating `TextDecoder` and `JSON.parse`. The normal context is still passed
+ * through so external buffers, images, and extensions retain their standard loading behavior.
+ *
+ * @param jsonPayload - Parsed JSON glTF object from resource preprocessing.
+ * @param options - 3D Tiles and delegated glTF loader options.
+ * @param context - Loader context used to load glTF external resources.
+ * @returns Parsed glTF with any requested external resources.
+ */
+async function parseParsedJsonGltf(
+  jsonPayload: Record<string, unknown>,
+  options: Tiles3DLoaderOptions | undefined,
+  context: LoaderContext
+) {
+  const gltfLoaderWithParser = await GLTFLoader.preload('', options);
+  return await gltfLoaderWithParser.parse(jsonPayload, options, context);
 }

--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile-header.ts
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile-header.ts
@@ -4,7 +4,7 @@
 
 import type {Tiles3DLoaderOptions} from '../../tiles-3d-loader';
 import type {LoaderContext, StrictLoaderOptions} from '@loaders.gl/loader-utils';
-import {parseFromContext, path} from '@loaders.gl/loader-utils';
+import {CachedUriResolver, parseFromContext} from '@loaders.gl/loader-utils';
 import {Tile3DSubtreeLoaderWithParser} from '../../tile-3d-subtree-loader-with-parser';
 import {LOD_METRIC_TYPE, TILE_REFINEMENT, TILE_TYPE} from '@loaders.gl/tiles';
 import {
@@ -82,23 +82,18 @@ function getRefine(refine?: string): TILE_REFINEMENT | string | undefined {
   }
 }
 
-function resolveUri(uri: string, basePath: string): string {
-  // url scheme per RFC3986
-  const urlSchemeRegex = /^[a-z][0-9a-z+.-]*:/i;
-
-  if (urlSchemeRegex.test(basePath)) {
-    const url = new URL(uri, `${basePath}/`);
-    return decodeURI(url.toString());
-  } else if (uri.startsWith('/')) {
-    return uri;
-  }
-
-  return path.resolve(basePath, uri);
-}
-
+/**
+ * Normalizes one explicit tile header into the runtime representation.
+ *
+ * @param tile - Source tile header, or `null` for an unavailable implicit tile.
+ * @param basePath - Directory used for relative resource resolution.
+ * @param resourceResolver - Parse-scoped resolver that caches the parsed base and repeated URIs.
+ * @returns Normalized runtime header, or `null` when no source tile is available.
+ */
 export function normalizeTileData(
   tile: Tiles3DTileJSON | null,
-  basePath: string
+  basePath: string,
+  resourceResolver: CachedUriResolver = new CachedUriResolver(basePath)
 ): Tiles3DTileJSONPostprocessed | null {
   if (!tile) {
     return null;
@@ -108,7 +103,7 @@ export function normalizeTileData(
     const contentUri = tile.content.uri || tile.content?.url;
     if (typeof contentUri !== 'undefined') {
       // sparse implicit tilesets may not define content for all nodes
-      tileContentUrl = resolveUri(contentUri, basePath);
+      tileContentUrl = resourceResolver.resolve(contentUri);
     }
   }
   const boundingVolume = normalizeS2BoundingVolume(tile.boundingVolume) as Tile3DBoundingVolume;
@@ -165,7 +160,18 @@ function normalizeS2BoundingVolume(
   } as Tile3DBoundingVolume & S2VolumeBox;
 }
 
-// normalize tile headers
+/**
+ * Normalizes the complete explicit header tree and any eagerly expanded implicit roots.
+ *
+ * One {@link CachedUriResolver} is shared for the parse so repeated external resource references
+ * reuse their derived URL without retaining data after the tileset parse completes.
+ *
+ * @param tileset - Parsed source tileset JSON.
+ * @param basePath - Directory used for relative resource resolution.
+ * @param options - Loader options forwarded to implicit subtree parsing.
+ * @param context - Loader context used for implicit subtree requests.
+ * @returns Normalized root tile, or `null` when the source has no root.
+ */
 export async function normalizeTileHeaders(
   tileset: Tiles3DTilesetJSON,
   basePath: string,
@@ -173,6 +179,9 @@ export async function normalizeTileHeaders(
   context?: LoaderContext
 ): Promise<Tiles3DTileJSONPostprocessed | null> {
   let root: Tiles3DTileJSONPostprocessed | null = null;
+  // One parse-scoped resolver retains the parsed base URL and repeated derived resources without
+  // leaking URLs between unrelated tilesets.
+  const resourceResolver = new CachedUriResolver(basePath);
 
   const rootImplicitTilingExtension = getImplicitTilingExtensionData(tileset.root);
   if (rootImplicitTilingExtension && tileset.root) {
@@ -182,10 +191,11 @@ export async function normalizeTileHeaders(
       basePath,
       rootImplicitTilingExtension,
       options,
-      context
+      context,
+      resourceResolver
     );
   } else {
-    root = normalizeTileData(tileset.root, basePath);
+    root = normalizeTileData(tileset.root, basePath, resourceResolver);
   }
 
   const stack: any[] = [];
@@ -205,10 +215,11 @@ export async function normalizeTileHeaders(
           basePath,
           childImplicitTilingExtension,
           options,
-          context
+          context,
+          resourceResolver
         );
       } else {
-        childHeaderPostprocessed = normalizeTileData(childHeader, basePath);
+        childHeaderPostprocessed = normalizeTileData(childHeader, basePath, resourceResolver);
       }
 
       if (childHeaderPostprocessed) {
@@ -223,9 +234,16 @@ export async function normalizeTileHeaders(
 }
 
 /**
- * Do normalisation of implicit tile headers
- * TODO Check if Tile3D class can be a return type here.
- * @param tileset
+ * Creates the currently eager implicit tile hierarchy from its root subtree.
+ *
+ * @param tile - Source tile carrying the implicit-tiling declaration.
+ * @param tileset - Owning tileset JSON.
+ * @param basePath - Directory used for subtree and content resolution.
+ * @param implicitTilingExtension - Normalized implicit-tiling declaration.
+ * @param options - Loader options forwarded to subtree parsing.
+ * @param context - Loader context used to fetch subtree resources.
+ * @param resourceResolver - Parse-scoped resolver shared with explicit header normalization.
+ * @returns Normalized implicit root, or `null` when unavailable.
  */
 export async function normalizeImplicitTileHeaders(
   tile: Tiles3DTileJSON,
@@ -233,7 +251,8 @@ export async function normalizeImplicitTileHeaders(
   basePath: string,
   implicitTilingExtension: ImplicitTilingExensionData,
   options: Tiles3DLoaderOptions,
-  context?: LoaderContext
+  context?: LoaderContext,
+  resourceResolver: CachedUriResolver = new CachedUriResolver(basePath)
 ): Promise<Tiles3DTileJSONPostprocessed | null> {
   const normalizedTile: Tiles3DTileJSON = {
     ...tile,
@@ -259,7 +278,7 @@ export async function normalizeImplicitTileHeaders(
     );
   }
   const replacedUrlTemplate = replaceContentUrlTemplate(subtreesUriTemplate, 0, 0, 0, 0);
-  const subtreeUrl = resolveUri(replacedUrlTemplate, basePath);
+  const subtreeUrl = resourceResolver.resolve(replacedUrlTemplate);
   const response = await context.fetch(subtreeUrl);
   if (!response.ok) {
     throw new Error(`Failed to load 3D Tiles subtree: ${response.status} ${response.statusText}`);
@@ -272,7 +291,7 @@ export async function normalizeImplicitTileHeaders(
     context
   )) as Subtree;
   const tileContentUri = normalizedTile.content?.uri;
-  const contentUrlTemplate = tileContentUri ? resolveUri(tileContentUri, basePath) : '';
+  const contentUrlTemplate = tileContentUri ? resourceResolver.resolve(tileContentUri) : '';
   const refine = tileset?.root?.refine;
   // @ts-ignore
   const rootLodMetricValue = normalizedTile.geometricError;

--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile.ts
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile.ts
@@ -16,17 +16,33 @@ import {parseGltf3DTile} from './parse-3d-tile-gltf';
 import {LoaderContext} from '@loaders.gl/loader-utils';
 import {Tiles3DLoaderOptions} from '../../tiles-3d-loader';
 import {Tiles3DTileContent} from '../../types';
+import type {Tiles3DBinaryContentType, Tiles3DContentType} from './preprocess-3d-tile-content';
 
-// Extracts
+/**
+ * Parses one binary or JSON glTF 3D Tiles content payload.
+ *
+ * Composite children omit `contentType` and continue to identify themselves from their embedded
+ * magic. Top-level payloads pass the structure-first label so JSON glTF and normalized `glb`
+ * content can share the established glTF parser.
+ *
+ * @param arrayBuffer - Complete resource or enclosing composite bytes.
+ * @param byteOffset - First byte of the content inside `arrayBuffer`.
+ * @param options - 3D Tiles and delegated glTF loader options.
+ * @param context - Loader context used for nested glTF resources.
+ * @param tile - Mutable result object populated by the format parser.
+ * @param contentType - Optional resource-boundary classification from preprocessing.
+ * @returns Number of bytes consumed by the parsed content.
+ */
 export async function parse3DTile(
   arrayBuffer: ArrayBuffer,
   byteOffset = 0,
   options: Tiles3DLoaderOptions | undefined,
   context: LoaderContext | undefined,
-  tile: Tiles3DTileContent = {shape: 'tile3d'}
+  tile: Tiles3DTileContent = {shape: 'tile3d'},
+  contentType?: Tiles3DContentType
 ): Promise<number> {
   tile.byteOffset = byteOffset;
-  tile.type = getMagicString(arrayBuffer, byteOffset);
+  tile.type = getParserContentType(contentType) || getMagicString(arrayBuffer, byteOffset);
 
   switch (tile.type) {
     case TILE3D_TYPE.COMPOSITE:
@@ -55,4 +71,25 @@ export async function parse3DTile(
     default:
       throw new Error(`3DTileLoader: unknown type ${tile.type}`); // eslint-disable-line
   }
+}
+
+/**
+ * Maps the structure-first preprocessor label to the historical parser magic.
+ *
+ * Binary glTF uses `glTF` as its on-wire magic, while preprocessing calls it `glb` to distinguish
+ * it from JSON glTF. Both glTF representations use the same downstream glTF parser.
+ *
+ * @param contentType - Preprocessed content label, when parsing starts at the resource boundary.
+ * @returns Parser type or `undefined` when nested composite parsing should read its own magic.
+ */
+function getParserContentType(
+  contentType?: Tiles3DContentType
+): Tiles3DBinaryContentType | 'glTF' | undefined {
+  if (contentType === 'glb' || contentType === 'gltf') {
+    return TILE3D_TYPE.GLTF as 'glTF';
+  }
+  if (contentType === 'externalTileset' || !contentType) {
+    return undefined;
+  }
+  return contentType as Tiles3DBinaryContentType;
 }

--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile.ts
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile.ts
@@ -31,6 +31,7 @@ import type {Tiles3DBinaryContentType, Tiles3DContentType} from './preprocess-3d
  * @param context - Loader context used for nested glTF resources.
  * @param tile - Mutable result object populated by the format parser.
  * @param contentType - Optional resource-boundary classification from preprocessing.
+ * @param jsonPayload - Parsed JSON glTF payload from preprocessing, when available.
  * @returns Number of bytes consumed by the parsed content.
  */
 export async function parse3DTile(
@@ -39,7 +40,8 @@ export async function parse3DTile(
   options: Tiles3DLoaderOptions | undefined,
   context: LoaderContext | undefined,
   tile: Tiles3DTileContent = {shape: 'tile3d'},
-  contentType?: Tiles3DContentType
+  contentType?: Tiles3DContentType,
+  jsonPayload?: Record<string, unknown>
 ): Promise<number> {
   tile.byteOffset = byteOffset;
   tile.type = getParserContentType(contentType) || getMagicString(arrayBuffer, byteOffset);
@@ -60,7 +62,7 @@ export async function parse3DTile(
       return await parseBatchedModel3DTile(tile, arrayBuffer, byteOffset, options, context);
 
     case TILE3D_TYPE.GLTF:
-      return await parseGltf3DTile(tile, arrayBuffer, options, context);
+      return await parseGltf3DTile(tile, arrayBuffer, options, context, jsonPayload);
 
     case TILE3D_TYPE.INSTANCED_3D_MODEL:
       return await parseInstancedModel3DTile(tile, arrayBuffer, byteOffset, options, context);

--- a/modules/3d-tiles/src/lib/parsers/preprocess-3d-tile-content.ts
+++ b/modules/3d-tiles/src/lib/parsers/preprocess-3d-tile-content.ts
@@ -1,0 +1,124 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
+// This file is derived from the Cesium code base under Apache 2 license
+// See LICENSE.md and https://github.com/CesiumGS/cesium/blob/main/LICENSE.md
+
+import {TILE3D_TYPE} from '../constants';
+
+/** Binary 3D Tiles content types supported by {@link preprocess3DTileContent}. */
+export type Tiles3DBinaryContentType = 'b3dm' | 'i3dm' | 'cmpt' | 'pnts' | 'glb';
+
+/** JSON 3D Tiles content types supported by {@link preprocess3DTileContent}. */
+export type Tiles3DJsonContentType = 'externalTileset' | 'gltf';
+
+/** Content categories returned by {@link preprocess3DTileContent}. */
+export type Tiles3DContentType = Tiles3DBinaryContentType | Tiles3DJsonContentType;
+
+/** Structure-first classification of a binary 3D Tiles resource. */
+export type Preprocessed3DTileContent =
+  | {
+      /** Detected binary format. `glTF` magic is normalized to the unambiguous `glb` label. */
+      contentType: Tiles3DBinaryContentType;
+      /** Original binary payload. */
+      binaryPayload: ArrayBuffer;
+    }
+  | {
+      /** External tileset JSON detected from `asset` and `root` objects. */
+      contentType: 'externalTileset';
+      /** Parsed JSON payload, reused by the downstream parser. */
+      jsonPayload: Record<string, any>;
+    }
+  | {
+      /** JSON glTF detected from an `asset` object without a tileset root. */
+      contentType: 'gltf';
+      /** Parsed JSON payload, reused by the downstream parser. */
+      jsonPayload: Record<string, any>;
+    };
+
+const BINARY_CONTENT_TYPES: ReadonlySet<string> = new Set([
+  TILE3D_TYPE.BATCHED_3D_MODEL,
+  TILE3D_TYPE.INSTANCED_3D_MODEL,
+  TILE3D_TYPE.COMPOSITE,
+  TILE3D_TYPE.POINT_CLOUD,
+  TILE3D_TYPE.GLTF
+]);
+
+/**
+ * Detects a supported 3D Tiles payload from its bytes rather than its URL or MIME type.
+ *
+ * Binary formats use their four-byte magic. The historical binary glTF magic is `glTF`; the
+ * returned type is normalized to `glb` so it cannot be confused with JSON glTF. Payloads without
+ * supported binary magic are decoded once as JSON and classified by required top-level structure.
+ * This allows signed, extensionless, and misleadingly named resources to load consistently.
+ *
+ * @param arrayBuffer - Complete resource payload beginning at byte zero.
+ * @returns Detected content type and either the original binary bytes or parsed JSON.
+ * @throws If the payload is truncated, malformed, or not a supported 3D Tiles content structure.
+ */
+export function preprocess3DTileContent(arrayBuffer: ArrayBuffer): Preprocessed3DTileContent {
+  if (arrayBuffer.byteLength >= 4) {
+    const magic = getMagic(arrayBuffer);
+    if (BINARY_CONTENT_TYPES.has(magic)) {
+      return {
+        contentType: magic === TILE3D_TYPE.GLTF ? 'glb' : (magic as Tiles3DBinaryContentType),
+        binaryPayload: arrayBuffer
+      };
+    }
+  }
+
+  const jsonPayload = parseJsonContent(arrayBuffer);
+  if (isRecord(jsonPayload.root) && isRecord(jsonPayload.asset)) {
+    return {contentType: 'externalTileset', jsonPayload};
+  }
+  if (isRecord(jsonPayload.asset)) {
+    return {contentType: 'gltf', jsonPayload};
+  }
+
+  throw new Error(
+    'Invalid 3D Tiles content: JSON must describe a tileset with root and asset objects or a glTF asset'
+  );
+}
+
+/**
+ * Reads the first four payload bytes as an ASCII magic string.
+ *
+ * @param arrayBuffer - Payload containing at least four bytes.
+ * @returns Four-character magic string.
+ */
+function getMagic(arrayBuffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(arrayBuffer, 0, 4);
+  return String.fromCharCode(bytes[0], bytes[1], bytes[2], bytes[3]);
+}
+
+/**
+ * Decodes and parses a JSON candidate with a stable 3D Tiles diagnostic.
+ *
+ * @param arrayBuffer - Payload not recognized as a supported binary format.
+ * @returns Parsed JSON object.
+ * @throws If the bytes are not valid JSON or the JSON root is not an object.
+ */
+function parseJsonContent(arrayBuffer: ArrayBuffer): Record<string, any> {
+  try {
+    const text = new TextDecoder('utf-8', {fatal: true}).decode(arrayBuffer).replace(/^\uFEFF/, '');
+    const jsonPayload = JSON.parse(text);
+    if (isRecord(jsonPayload)) {
+      return jsonPayload;
+    }
+  } catch {
+    // A single public diagnostic keeps malformed text and binary failures deterministic.
+  }
+
+  throw new Error('Invalid 3D Tiles content: expected supported binary magic or JSON object');
+}
+
+/**
+ * Tests whether a value is a non-null, non-array object.
+ *
+ * @param value - Candidate JSON value.
+ * @returns `true` when the value can provide named JSON properties.
+ */
+function isRecord(value: unknown): value is Record<string, any> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}

--- a/modules/3d-tiles/src/tiles-3d-loader-with-parser.ts
+++ b/modules/3d-tiles/src/tiles-3d-loader-with-parser.ts
@@ -16,7 +16,6 @@ import {Tiles3DLoader as Tiles3DLoaderMetadata} from './tiles-3d-loader';
 import {
   preprocess3DTileContent,
   type Preprocessed3DTileContent,
-  type Tiles3DContentType
 } from './lib/parsers/preprocess-3d-tile-content';
 
 /**
@@ -86,7 +85,7 @@ async function parse(
   if (getIsTileset(preprocessedContent, loaderOptions.isTileset)) {
     return parseTileset(preprocessedContent.jsonPayload as Tiles3DTilesetJSON, options, context);
   }
-  return parseTile(data, preprocessedContent.contentType, options, context);
+  return parseTile(data, preprocessedContent, options, context);
 }
 
 /**
@@ -183,27 +182,33 @@ function validateRequiredExtensions(tilesetJson: Tiles3DTilesetJSON): void {
  * Parses renderable content using its structure-first type classification.
  *
  * @param arrayBuffer - Original resource bytes.
- * @param contentType - Detected binary or JSON glTF type.
+ * @param preprocessedContent - Detected payload category and, for JSON, its parsed object.
  * @param options - Loader options forwarded to tile and glTF parsers.
  * @param context - Loader context used for external glTF resources.
  * @returns Parsed renderable tile content.
  */
 async function parseTile(
   arrayBuffer: ArrayBuffer,
-  contentType: Tiles3DContentType,
+  preprocessedContent: Exclude<Preprocessed3DTileContent, {contentType: 'externalTileset'}>,
   options?: Tiles3DLoaderOptions,
   context?: LoaderContext
 ): Promise<Tiles3DTileContent> {
-  const tile = {
+  const tile: {content: Tiles3DTileContent} = {
     content: {
       shape: 'tile3d',
       featureIds: null
     }
   };
   const byteOffset = 0;
-  // @ts-expect-error
-  await parse3DTile(arrayBuffer, byteOffset, options, context, tile.content, contentType);
-  // @ts-expect-error
+  await parse3DTile(
+    arrayBuffer,
+    byteOffset,
+    options,
+    context,
+    tile.content,
+    preprocessedContent.contentType,
+    preprocessedContent.contentType === 'gltf' ? preprocessedContent.jsonPayload : undefined
+  );
   return tile.content;
 }
 

--- a/modules/3d-tiles/src/tiles-3d-loader-with-parser.ts
+++ b/modules/3d-tiles/src/tiles-3d-loader-with-parser.ts
@@ -41,7 +41,9 @@ export type Tiles3DLoaderOptions = StrictLoaderOptions &
   DracoLoaderOptions &
   ImageBitmapLoaderOptions & {
     '3d-tiles'?: {
-      /** Whether to parse any embedded glTF binaries (or extract memory for independent glTF parsing) */
+      /**
+       * Whether to parse embedded glTF binaries or retain their bytes for independent parsing.
+       */
       loadGLTF?: boolean;
       /** If renderer doesn't support quantized positions, loader can decode them on CPU */
       decodeQuantizedPositions?: boolean;

--- a/modules/3d-tiles/src/tiles-3d-loader-with-parser.ts
+++ b/modules/3d-tiles/src/tiles-3d-loader-with-parser.ts
@@ -189,7 +189,10 @@ function validateRequiredExtensions(tilesetJson: Tiles3DTilesetJSON): void {
  */
 async function parseTile(
   arrayBuffer: ArrayBuffer,
-  preprocessedContent: Exclude<Preprocessed3DTileContent, {contentType: 'externalTileset'}>,
+  preprocessedContent: Exclude<
+    Preprocessed3DTileContent,
+    {contentType: 'externalTileset'}
+  >,
   options?: Tiles3DLoaderOptions,
   context?: LoaderContext
 ): Promise<Tiles3DTileContent> {

--- a/modules/3d-tiles/src/tiles-3d-loader-with-parser.ts
+++ b/modules/3d-tiles/src/tiles-3d-loader-with-parser.ts
@@ -15,7 +15,7 @@ import {Tiles3DTilesetJSON, Tiles3DTileContent, Tiles3DTilesetJSONPostprocessed}
 import {Tiles3DLoader as Tiles3DLoaderMetadata} from './tiles-3d-loader';
 import {
   preprocess3DTileContent,
-  type Preprocessed3DTileContent,
+  type Preprocessed3DTileContent
 } from './lib/parsers/preprocess-3d-tile-content';
 
 /**
@@ -191,10 +191,7 @@ function validateRequiredExtensions(tilesetJson: Tiles3DTilesetJSON): void {
  */
 async function parseTile(
   arrayBuffer: ArrayBuffer,
-  preprocessedContent: Exclude<
-    Preprocessed3DTileContent,
-    {contentType: 'externalTileset'}
-  >,
+  preprocessedContent: Exclude<Preprocessed3DTileContent, {contentType: 'externalTileset'}>,
   options?: Tiles3DLoaderOptions,
   context?: LoaderContext
 ): Promise<Tiles3DTileContent> {

--- a/modules/3d-tiles/src/tiles-3d-loader-with-parser.ts
+++ b/modules/3d-tiles/src/tiles-3d-loader-with-parser.ts
@@ -13,7 +13,11 @@ import {parse3DTile} from './lib/parsers/parse-3d-tile';
 import {normalizeTileHeaders} from './lib/parsers/parse-3d-tile-header';
 import {Tiles3DTilesetJSON, Tiles3DTileContent, Tiles3DTilesetJSONPostprocessed} from './types';
 import {Tiles3DLoader as Tiles3DLoaderMetadata} from './tiles-3d-loader';
-import {Tiles3DTilesetSchema} from './tileset-zod-schema';
+import {
+  preprocess3DTileContent,
+  type Preprocessed3DTileContent,
+  type Tiles3DContentType
+} from './lib/parsers/preprocess-3d-tile-content';
 
 /**
  * Required 3D Tiles extensions that this loader can process completely enough to load content.
@@ -42,7 +46,10 @@ export type Tiles3DLoaderOptions = StrictLoaderOptions &
       loadGLTF?: boolean;
       /** If renderer doesn't support quantized positions, loader can decode them on CPU */
       decodeQuantizedPositions?: boolean;
-      /** Whether this is a tileset or a tile */
+      /**
+       * Selects tileset-header or render-content parsing. `auto` detects the payload from its
+       * bytes and JSON structure; explicit booleans assert the expected category.
+       */
       isTileset?: boolean | 'auto';
       /** Controls which axis is "up" in glTF files */
       assetGltfUpAxis?: 'x' | 'y' | 'z' | null;
@@ -61,33 +68,67 @@ export const Tiles3DLoaderWithParser = {
   Tiles3DLoaderOptions
 >;
 
-/** Parses a tileset or tile */
+/**
+ * Preprocesses and parses a tileset, legacy tile format, GLB, or JSON glTF payload.
+ *
+ * @param data - Complete fetched resource bytes.
+ * @param options - Loader options, including optional explicit content mode.
+ * @param context - Loader context used for base paths and nested resources.
+ * @returns Parsed external tileset or renderable tile content.
+ */
 async function parse(
-  data,
+  data: ArrayBuffer,
   options: Tiles3DLoaderOptions = {},
   context?: LoaderContext
 ): Promise<Tiles3DTileContent | Tiles3DTilesetJSONPostprocessed> {
-  // auto detect file type
   const loaderOptions = options['3d-tiles'] || {};
-  let isTileset;
-  if (loaderOptions.isTileset === 'auto') {
-    isTileset = context?.url && context.url.indexOf('.json') !== -1;
-  } else {
-    isTileset = loaderOptions.isTileset;
+  const preprocessedContent = preprocess3DTileContent(data);
+  if (getIsTileset(preprocessedContent, loaderOptions.isTileset)) {
+    return parseTileset(preprocessedContent.jsonPayload as Tiles3DTilesetJSON, options, context);
   }
-
-  return isTileset ? parseTileset(data, options, context) : parseTile(data, options, context);
+  return parseTile(data, preprocessedContent.contentType, options, context);
 }
 
-/** Parse a tileset */
+/**
+ * Resolves the tileset mode while retaining explicit caller assertions.
+ *
+ * `auto` follows the payload structure and therefore works for extensionless and signed URLs.
+ * Explicit `true` remains useful for callers that want the loader to reject non-tileset payloads
+ * at the boundary; explicit `false` likewise rejects an external tileset where render content was
+ * expected.
+ *
+ * @param content - Structure-first content classification.
+ * @param isTilesetOption - Caller mode, including the public `auto` default.
+ * @returns Whether to parse the JSON payload as an external tileset.
+ * @throws If an explicit mode contradicts the detected payload.
+ */
+function getIsTileset(
+  content: Preprocessed3DTileContent,
+  isTilesetOption: boolean | 'auto' | undefined
+): content is Extract<Preprocessed3DTileContent, {contentType: 'externalTileset'}> {
+  const detectedTileset = content.contentType === 'externalTileset';
+  if (isTilesetOption === true && !detectedTileset) {
+    throw new Error(`Expected 3D Tiles tileset JSON; detected ${content.contentType}`);
+  }
+  if (isTilesetOption === false && detectedTileset) {
+    throw new Error('Expected 3D tile render content; detected external tileset JSON');
+  }
+  return isTilesetOption === true || (isTilesetOption !== false && detectedTileset);
+}
+
+/**
+ * Normalizes a pre-parsed external tileset JSON payload.
+ *
+ * @param tilesetJson - JSON object classified as an external tileset.
+ * @param options - Loader options forwarded to header normalization.
+ * @param context - Loader context providing resource URL and subtree fetch.
+ * @returns Normalized tileset runtime metadata.
+ */
 async function parseTileset(
-  data: ArrayBuffer,
+  tilesetJson: Tiles3DTilesetJSON,
   options?: Tiles3DLoaderOptions,
   context?: LoaderContext
 ): Promise<Tiles3DTilesetJSONPostprocessed> {
-  const tilesetJson: Tiles3DTilesetJSON = Tiles3DTilesetSchema.parse(
-    JSON.parse(new TextDecoder().decode(data))
-  );
   validateRequiredExtensions(tilesetJson);
 
   const tilesetUrl = context?.url || '';
@@ -138,9 +179,18 @@ function validateRequiredExtensions(tilesetJson: Tiles3DTilesetJSON): void {
   );
 }
 
-/** Parse a tile */
+/**
+ * Parses renderable content using its structure-first type classification.
+ *
+ * @param arrayBuffer - Original resource bytes.
+ * @param contentType - Detected binary or JSON glTF type.
+ * @param options - Loader options forwarded to tile and glTF parsers.
+ * @param context - Loader context used for external glTF resources.
+ * @returns Parsed renderable tile content.
+ */
 async function parseTile(
   arrayBuffer: ArrayBuffer,
+  contentType: Tiles3DContentType,
   options?: Tiles3DLoaderOptions,
   context?: LoaderContext
 ): Promise<Tiles3DTileContent> {
@@ -152,7 +202,7 @@ async function parseTile(
   };
   const byteOffset = 0;
   // @ts-expect-error
-  await parse3DTile(arrayBuffer, byteOffset, options, context, tile.content);
+  await parse3DTile(arrayBuffer, byteOffset, options, context, tile.content, contentType);
   // @ts-expect-error
   return tile.content;
 }

--- a/modules/3d-tiles/src/tiles-3d-loader.ts
+++ b/modules/3d-tiles/src/tiles-3d-loader.ts
@@ -20,7 +20,10 @@ export type Tiles3DLoaderOptions = StrictLoaderOptions &
       loadGLTF?: boolean;
       /** If renderer doesn't support quantized positions, loader can decode them on CPU */
       decodeQuantizedPositions?: boolean;
-      /** Whether this is a tileset or a tile */
+      /**
+       * Selects tileset-header or render-content parsing. `auto` detects the payload from its
+       * bytes and JSON structure; explicit booleans assert the expected category.
+       */
       isTileset?: boolean | 'auto';
       /** Controls which axis is "up" in glTF files */
       assetGltfUpAxis?: 'x' | 'y' | 'z' | null;

--- a/modules/3d-tiles/test/index.ts
+++ b/modules/3d-tiles/test/index.ts
@@ -10,6 +10,7 @@ import './lib/parsers/instanced-model-3d-tile.spec';
 import './lib/parsers/point-cloud-3d-tile.spec';
 import './lib/parsers/composite-3d-tile.spec';
 import './lib/parsers/parse-3d-tile-header.spec';
+import './lib/parsers/preprocess-3d-tile-content.spec';
 import './lib/parsers/parse-3d-implicit-tiles.spec';
 // TODO v4.0 restore these tests
 // import './lib/parsers/helpers/gpu-memory-usage.spec';

--- a/modules/3d-tiles/test/lib/parsers/preprocess-3d-tile-content.spec.ts
+++ b/modules/3d-tiles/test/lib/parsers/preprocess-3d-tile-content.spec.ts
@@ -1,0 +1,63 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
+import test from 'tape-promise/tape';
+import {preprocess3DTileContent} from '../../../src/lib/parsers/preprocess-3d-tile-content';
+
+/** Encodes a JSON object as an independent ArrayBuffer. */
+function encodeJson(json: Record<string, any>): ArrayBuffer {
+  const bytes = new TextEncoder().encode(JSON.stringify(json));
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
+/** Encodes four-character binary magic and optional trailing bytes. */
+function encodeMagic(magic: string, trailingByteLength = 0): ArrayBuffer {
+  const bytes = new Uint8Array(4 + trailingByteLength);
+  for (let index = 0; index < 4; index++) {
+    bytes[index] = magic.charCodeAt(index);
+  }
+  return bytes.buffer;
+}
+
+test('preprocess3DTileContent detects supported binary magic', t => {
+  for (const contentType of ['b3dm', 'i3dm', 'cmpt', 'pnts'] as const) {
+    const arrayBuffer = encodeMagic(contentType, 8);
+    const content = preprocess3DTileContent(arrayBuffer);
+    t.equal(content.contentType, contentType);
+    t.equal('binaryPayload' in content && content.binaryPayload, arrayBuffer, 'preserves payload');
+  }
+
+  const glbContent = preprocess3DTileContent(encodeMagic('glTF', 8));
+  t.equal(glbContent.contentType, 'glb', 'normalizes binary glTF magic');
+  t.end();
+});
+
+test('preprocess3DTileContent classifies tileset and glTF JSON by structure', t => {
+  const tileset = preprocess3DTileContent(
+    encodeJson({asset: {version: '1.1'}, root: {geometricError: 0}})
+  );
+  t.equal(tileset.contentType, 'externalTileset');
+  t.equal('jsonPayload' in tileset && tileset.jsonPayload.asset.version, '1.1');
+
+  const gltf = preprocess3DTileContent(encodeJson({asset: {version: '2.0'}, meshes: []}));
+  t.equal(gltf.contentType, 'gltf');
+  t.equal('jsonPayload' in gltf && gltf.jsonPayload.asset.version, '2.0');
+  t.end();
+});
+
+test('preprocess3DTileContent rejects truncated, malformed, and unsupported payloads', t => {
+  t.throws(
+    () => preprocess3DTileContent(new Uint8Array([1, 2, 3]).buffer),
+    /expected supported binary magic or JSON object/
+  );
+  t.throws(
+    () => preprocess3DTileContent(new TextEncoder().encode('{broken').buffer),
+    /expected supported binary magic or JSON object/
+  );
+  t.throws(
+    () => preprocess3DTileContent(encodeJson({hello: 'world'})),
+    /JSON must describe a tileset.*or a glTF asset/
+  );
+  t.end();
+});

--- a/modules/3d-tiles/test/lib/parsers/preprocess-3d-tile-content.spec.ts
+++ b/modules/3d-tiles/test/lib/parsers/preprocess-3d-tile-content.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT AND Apache-2.0
 // Copyright vis.gl contributors
 
-import test from 'tape-promise/tape';
+import {expect, test} from 'vitest';
 import {preprocess3DTileContent} from '../../../src/lib/parsers/preprocess-3d-tile-content';
 
 /** Encodes a JSON object as an independent ArrayBuffer. */
@@ -20,44 +20,38 @@ function encodeMagic(magic: string, trailingByteLength = 0): ArrayBuffer {
   return bytes.buffer;
 }
 
-test('preprocess3DTileContent detects supported binary magic', t => {
+test('preprocess3DTileContent detects supported binary magic', () => {
   for (const contentType of ['b3dm', 'i3dm', 'cmpt', 'pnts'] as const) {
     const arrayBuffer = encodeMagic(contentType, 8);
     const content = preprocess3DTileContent(arrayBuffer);
-    t.equal(content.contentType, contentType);
-    t.equal('binaryPayload' in content && content.binaryPayload, arrayBuffer, 'preserves payload');
+    expect(content.contentType).toBe(contentType);
+    expect('binaryPayload' in content && content.binaryPayload).toBe(arrayBuffer);
   }
 
   const glbContent = preprocess3DTileContent(encodeMagic('glTF', 8));
-  t.equal(glbContent.contentType, 'glb', 'normalizes binary glTF magic');
-  t.end();
+  expect(glbContent.contentType).toBe('glb');
 });
 
-test('preprocess3DTileContent classifies tileset and glTF JSON by structure', t => {
+test('preprocess3DTileContent classifies tileset and glTF JSON by structure', () => {
   const tileset = preprocess3DTileContent(
     encodeJson({asset: {version: '1.1'}, root: {geometricError: 0}})
   );
-  t.equal(tileset.contentType, 'externalTileset');
-  t.equal('jsonPayload' in tileset && tileset.jsonPayload.asset.version, '1.1');
+  expect(tileset.contentType).toBe('externalTileset');
+  expect('jsonPayload' in tileset && tileset.jsonPayload.asset.version).toBe('1.1');
 
   const gltf = preprocess3DTileContent(encodeJson({asset: {version: '2.0'}, meshes: []}));
-  t.equal(gltf.contentType, 'gltf');
-  t.equal('jsonPayload' in gltf && gltf.jsonPayload.asset.version, '2.0');
-  t.end();
+  expect(gltf.contentType).toBe('gltf');
+  expect('jsonPayload' in gltf && gltf.jsonPayload.asset.version).toBe('2.0');
 });
 
-test('preprocess3DTileContent rejects truncated, malformed, and unsupported payloads', t => {
-  t.throws(
-    () => preprocess3DTileContent(new Uint8Array([1, 2, 3]).buffer),
+test('preprocess3DTileContent rejects truncated, malformed, and unsupported payloads', () => {
+  expect(() => preprocess3DTileContent(new Uint8Array([1, 2, 3]).buffer)).toThrow(
     /expected supported binary magic or JSON object/
   );
-  t.throws(
-    () => preprocess3DTileContent(new TextEncoder().encode('{broken').buffer),
+  expect(() => preprocess3DTileContent(new TextEncoder().encode('{broken').buffer)).toThrow(
     /expected supported binary magic or JSON object/
   );
-  t.throws(
-    () => preprocess3DTileContent(encodeJson({hello: 'world'})),
+  expect(() => preprocess3DTileContent(encodeJson({hello: 'world'}))).toThrow(
     /JSON must describe a tileset.*or a glTF asset/
   );
-  t.end();
 });

--- a/modules/3d-tiles/test/tiles-3d-loader.bench.ts
+++ b/modules/3d-tiles/test/tiles-3d-loader.bench.ts
@@ -1,0 +1,56 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
+import {CachedUriResolver} from '@loaders.gl/loader-utils';
+import {preprocess3DTileContent} from '../src/lib/parsers/preprocess-3d-tile-content';
+
+const CONTENT_REFERENCE_COUNT = 10_000;
+const UNIQUE_CONTENT_COUNT = 250;
+const CONTENT_URIS = Array.from(
+  {length: CONTENT_REFERENCE_COUNT},
+  (_, index) => `level-${index % 10}/content-${index % UNIQUE_CONTENT_COUNT}.glb`
+);
+const LARGE_TILESET_BYTES = createLargeTilesetBytes(CONTENT_REFERENCE_COUNT);
+
+/** Adds resource-intake benchmarks for large explicit 3D Tiles hierarchies. */
+export default async function tiles3DLoaderBench(suite) {
+  suite.group('@loaders.gl/3d-tiles resource intake');
+
+  suite.add(
+    'CachedUriResolver - resolve 10,000 repeated content references',
+    {multiplier: CONTENT_REFERENCE_COUNT, unit: 'content references'},
+    () => {
+      const resolver = new CachedUriResolver('https://example.com/city/tiles');
+      for (const contentUri of CONTENT_URIS) {
+        resolver.resolve(contentUri);
+      }
+    }
+  );
+
+  suite.add(
+    'preprocess3DTileContent - classify large explicit tileset JSON',
+    {multiplier: CONTENT_REFERENCE_COUNT, unit: 'tile headers'},
+    () => preprocess3DTileContent(LARGE_TILESET_BYTES)
+  );
+}
+
+/** Creates a broad explicit tileset whose content references exercise JSON preprocessing. */
+function createLargeTilesetBytes(tileCount: number): ArrayBuffer {
+  const children = Array.from({length: tileCount}, (_, index) => ({
+    boundingVolume: {sphere: [index, 0, 0, 1]},
+    geometricError: 0,
+    content: {uri: CONTENT_URIS[index]}
+  }));
+  const tileset = {
+    asset: {version: '1.1'},
+    geometricError: 1,
+    root: {
+      boundingVolume: {sphere: [0, 0, 0, tileCount]},
+      geometricError: 1,
+      children
+    }
+  };
+  const bytes = new TextEncoder().encode(JSON.stringify(tileset));
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}

--- a/modules/3d-tiles/test/tiles-3d-loader.spec.ts
+++ b/modules/3d-tiles/test/tiles-3d-loader.spec.ts
@@ -90,6 +90,51 @@ test('Tiles3DLoader#Tileset file', async t => {
   t.end();
 });
 
+test('Tiles3DLoader#detects extensionless tileset JSON from structure', async t => {
+  const tileset = await parse(encodeTilesetJson(), Tiles3DLoader, {worker: false});
+
+  t.equal(tileset.shape, 'tileset3d');
+  t.equal(tileset.asset.version, '1.1');
+  t.equal(tileset.root.lodMetricValue, 0);
+  t.end();
+});
+
+test('Tiles3DLoader#detects JSON glTF tile content from structure', async t => {
+  const gltfJson = new TextEncoder().encode(
+    JSON.stringify({asset: {version: '2.0'}, scenes: [{nodes: []}], scene: 0})
+  );
+  const gltfArrayBuffer = gltfJson.buffer.slice(
+    gltfJson.byteOffset,
+    gltfJson.byteOffset + gltfJson.byteLength
+  ) as ArrayBuffer;
+  const tile = await parse(gltfArrayBuffer, Tiles3DLoader, {
+    worker: false,
+    '3d-tiles': {loadGLTF: false}
+  });
+
+  t.equal(tile.type, 'glTF', 'routes JSON glTF through the shared glTF content parser');
+  t.equal(tile.gltfArrayBuffer, gltfArrayBuffer, 'preserves JSON glTF bytes for deferred parsing');
+  t.end();
+});
+
+test('Tiles3DLoader#reports explicit content-mode mismatches', async t => {
+  await t.rejects(
+    parse(encodeTilesetJson(), Tiles3DLoader, {
+      worker: false,
+      '3d-tiles': {isTileset: false}
+    }),
+    /Expected 3D tile render content; detected external tileset JSON/
+  );
+  await t.rejects(
+    parse(new TextEncoder().encode(JSON.stringify({asset: {version: '2.0'}})), Tiles3DLoader, {
+      worker: false,
+      '3d-tiles': {isTileset: true}
+    }),
+    /Expected 3D Tiles tileset JSON; detected gltf/
+  );
+  t.end();
+});
+
 test('Tiles3DLoader#accepts supported required extensions', async t => {
   const extensionsRequired = [
     '3DTILES_implicit_tiling',

--- a/modules/3d-tiles/test/tiles-3d-loader.spec.ts
+++ b/modules/3d-tiles/test/tiles-3d-loader.spec.ts
@@ -131,7 +131,7 @@ test('Tiles3DLoader#reuses preprocessed JSON glTF when parsing is enabled', asyn
   });
 
   t.equal(tile.type, 'glTF');
-  t.equal(tile.gltf?.json.asset.version, '2.0', 'parses the preprocessed JSON glTF object');
+  t.equal(tile.gltf?.asset.version, '2.0', 'parses the preprocessed JSON glTF object');
   t.end();
 });
 

--- a/modules/3d-tiles/test/tiles-3d-loader.spec.ts
+++ b/modules/3d-tiles/test/tiles-3d-loader.spec.ts
@@ -257,8 +257,8 @@ test('Tiles3DLoader#rejects unknown binary tile types', async t => {
       worker: false,
       '3d-tiles': {isTileset: false}
     }),
-    /3DTileLoader: unknown type nope/,
-    'reports the unrecognized tile magic'
+    /Invalid 3D Tiles content: expected supported binary magic or JSON object/,
+    'reports an unsupported resource-boundary payload'
   );
   t.end();
 });

--- a/modules/3d-tiles/test/tiles-3d-loader.spec.ts
+++ b/modules/3d-tiles/test/tiles-3d-loader.spec.ts
@@ -117,6 +117,24 @@ test('Tiles3DLoader#detects JSON glTF tile content from structure', async t => {
   t.end();
 });
 
+test('Tiles3DLoader#reuses preprocessed JSON glTF when parsing is enabled', async t => {
+  const gltfJson = new TextEncoder().encode(
+    JSON.stringify({asset: {version: '2.0'}, scenes: [{nodes: []}], scene: 0})
+  );
+  const gltfArrayBuffer = gltfJson.buffer.slice(
+    gltfJson.byteOffset,
+    gltfJson.byteOffset + gltfJson.byteLength
+  ) as ArrayBuffer;
+  const tile = await parse(gltfArrayBuffer, Tiles3DLoader, {
+    worker: false,
+    '3d-tiles': {loadGLTF: true}
+  });
+
+  t.equal(tile.type, 'glTF');
+  t.equal(tile.gltf?.json.asset.version, '2.0', 'parses the preprocessed JSON glTF object');
+  t.end();
+});
+
 test('Tiles3DLoader#reports explicit content-mode mismatches', async t => {
   await t.rejects(
     parse(encodeTilesetJson(), Tiles3DLoader, {

--- a/modules/gltf/src/lib/parsers/parse-gltf.ts
+++ b/modules/gltf/src/lib/parsers/parse-gltf.ts
@@ -152,8 +152,12 @@ function parseGLTFContainerSync(gltf, data, byteOffset, options: GLTFLoaderOptio
 
     gltf._glb = glb;
     gltf.json = glb.json;
+  } else if (data && typeof data === 'object') {
+    // Callers that already decoded JSON can retain the parsed object. This avoids a second
+    // serialization/parsing pass while preserving the normal extension and external-asset flow.
+    gltf.json = data;
   } else {
-    assert(false, 'GLTF: must be ArrayBuffer or string');
+    assert(false, 'GLTF: must be ArrayBuffer, string, or parsed JSON object');
   }
 
   // Populate buffers

--- a/modules/loader-utils/src/index.ts
+++ b/modules/loader-utils/src/index.ts
@@ -184,6 +184,7 @@ export type {FeedableLAZChunkEncoder} from './lib/laz/laz-chunk-encoder';
 
 // PATH HELPERS
 export {setPathPrefix, getPathPrefix, resolvePath} from './lib/path-utils/file-aliases';
+export {CachedUriResolver} from './lib/path-utils/cached-uri-resolver';
 export {addAliases as _addAliases} from './lib/path-utils/file-aliases';
 
 // MICRO LOADERS

--- a/modules/loader-utils/src/lib/path-utils/cached-uri-resolver.ts
+++ b/modules/loader-utils/src/lib/path-utils/cached-uri-resolver.ts
@@ -1,0 +1,69 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
+import * as path from './path';
+
+const URI_SCHEME_PATTERN = /^[a-z][0-9a-z+.-]*:/i;
+
+/**
+ * Resolves resource URIs against one stable base while caching repeated derivations.
+ *
+ * The base URL is parsed once. Resolved strings are cached for the lifetime of the resolver, which
+ * is intended to match one source or metadata parse. This avoids repeated base parsing for large
+ * resource trees without introducing a process-wide cache or retaining unrelated datasets.
+ */
+export class CachedUriResolver {
+  /** Original filesystem path or URI base used for non-URL resolution. */
+  private readonly basePath: string;
+  /** Parsed URL base, retained when the base uses an RFC 3986 scheme. */
+  private readonly baseUrl?: URL;
+  /** Resolved URI strings keyed by their source-relative spelling. */
+  private readonly resolvedUris: Map<string, string> = new Map();
+
+  /**
+   * Creates a resolver scoped to one resource hierarchy.
+   *
+   * @param basePath - Directory path or absolute base URI.
+   */
+  constructor(basePath: string) {
+    this.basePath = basePath;
+    if (URI_SCHEME_PATTERN.test(basePath)) {
+      this.baseUrl = new URL(basePath.endsWith('/') ? basePath : `${basePath}/`);
+    }
+  }
+
+  /**
+   * Resolves a relative or absolute resource identifier.
+   *
+   * URL bases follow the platform `URL` implementation and are decoded to preserve the existing
+   * loaders.gl 3D Tiles behavior. Filesystem-like bases continue to use loaders.gl path semantics.
+   * Repeated calls with the same source string return the previously resolved string.
+   *
+   * @param uri - Relative path, absolute path, data URL, or absolute URI.
+   * @returns Absolute or base-relative resource identifier.
+   */
+  resolve(uri: string): string {
+    const cachedUri = this.resolvedUris.get(uri);
+    if (cachedUri) {
+      return cachedUri;
+    }
+
+    let resolvedUri: string;
+    if (this.baseUrl) {
+      resolvedUri = decodeURI(new URL(uri, this.baseUrl).toString());
+    } else if (uri.startsWith('/')) {
+      resolvedUri = uri;
+    } else {
+      resolvedUri = path.resolve(this.basePath, uri);
+    }
+
+    this.resolvedUris.set(uri, resolvedUri);
+    return resolvedUri;
+  }
+
+  /** Clears derived URI strings while retaining the parsed base URL. */
+  clear(): void {
+    this.resolvedUris.clear();
+  }
+}

--- a/modules/loader-utils/src/lib/path-utils/cached-uri-resolver.ts
+++ b/modules/loader-utils/src/lib/path-utils/cached-uri-resolver.ts
@@ -52,7 +52,7 @@ export class CachedUriResolver {
     let resolvedUri: string;
     if (this.baseUrl) {
       resolvedUri = decodeURI(new URL(uri, this.baseUrl).toString());
-    } else if (uri.startsWith('/')) {
+    } else if (uri.startsWith('/') || URI_SCHEME_PATTERN.test(uri)) {
       resolvedUri = uri;
     } else {
       resolvedUri = path.resolve(this.basePath, uri);

--- a/modules/loader-utils/test/index.ts
+++ b/modules/loader-utils/test/index.ts
@@ -14,6 +14,7 @@ import './lib/iterators/make-transform-iterator.spec';
 import './lib/option-utils/merge-loader-options.spec';
 
 import './lib/path-utils/file-aliases.spec';
+import './lib/path-utils/cached-uri-resolver.spec';
 
 import './lib/request-utils/request-scheduler.spec';
 import './lib/request-utils/range-request-scheduler.node.spec';

--- a/modules/loader-utils/test/lib/path-utils/cached-uri-resolver.spec.ts
+++ b/modules/loader-utils/test/lib/path-utils/cached-uri-resolver.spec.ts
@@ -1,0 +1,39 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
+import test from 'tape-promise/tape';
+import {CachedUriResolver} from '@loaders.gl/loader-utils';
+
+test('CachedUriResolver resolves URL and filesystem bases', t => {
+  const urlResolver = new CachedUriResolver('https://example.com/root/content');
+  t.equal(
+    urlResolver.resolve('../models/tile.glb?token=one'),
+    'https://example.com/root/models/tile.glb?token=one'
+  );
+  t.equal(
+    urlResolver.resolve('data:model/gltf-binary;base64,Z2xURg=='),
+    'data:model/gltf-binary;base64,Z2xURg=='
+  );
+
+  const pathResolver = new CachedUriResolver('/tmp/tiles');
+  t.equal(pathResolver.resolve('models/tile.glb'), '/tmp/tiles/models/tile.glb');
+  t.equal(pathResolver.resolve('/absolute/tile.glb'), '/absolute/tile.glb');
+  t.end();
+});
+
+test('CachedUriResolver caches derived strings and can clear them', t => {
+  const resolver = new CachedUriResolver('https://example.com/root');
+  const firstResolvedUri = resolver.resolve('tile name.glb');
+  const secondResolvedUri = resolver.resolve('tile name.glb');
+
+  t.equal(firstResolvedUri, 'https://example.com/root/tile name.glb');
+  t.equal(secondResolvedUri, firstResolvedUri, 'returns the cached derivation');
+  resolver.clear();
+  t.equal(
+    resolver.resolve('tile name.glb'),
+    firstResolvedUri,
+    'retains the parsed base after clearing'
+  );
+  t.end();
+});

--- a/modules/loader-utils/test/lib/path-utils/cached-uri-resolver.spec.ts
+++ b/modules/loader-utils/test/lib/path-utils/cached-uri-resolver.spec.ts
@@ -2,38 +2,36 @@
 // SPDX-License-Identifier: MIT
 // Copyright vis.gl contributors
 
-import test from 'tape-promise/tape';
+import {expect, test} from 'vitest';
 import {CachedUriResolver} from '@loaders.gl/loader-utils';
 
-test('CachedUriResolver resolves URL and filesystem bases', t => {
+test('CachedUriResolver resolves URL and filesystem bases', () => {
   const urlResolver = new CachedUriResolver('https://example.com/root/content');
-  t.equal(
-    urlResolver.resolve('../models/tile.glb?token=one'),
+  expect(urlResolver.resolve('../models/tile.glb?token=one')).toBe(
     'https://example.com/root/models/tile.glb?token=one'
   );
-  t.equal(
-    urlResolver.resolve('data:model/gltf-binary;base64,Z2xURg=='),
+  expect(urlResolver.resolve('data:model/gltf-binary;base64,Z2xURg==')).toBe(
     'data:model/gltf-binary;base64,Z2xURg=='
   );
 
   const pathResolver = new CachedUriResolver('/tmp/tiles');
-  t.equal(pathResolver.resolve('models/tile.glb'), '/tmp/tiles/models/tile.glb');
-  t.equal(pathResolver.resolve('/absolute/tile.glb'), '/absolute/tile.glb');
-  t.end();
+  expect(pathResolver.resolve('models/tile.glb')).toBe('/tmp/tiles/models/tile.glb');
+  expect(pathResolver.resolve('/absolute/tile.glb')).toBe('/absolute/tile.glb');
+  expect(pathResolver.resolve('https://cdn.example.com/models/tile.glb')).toBe(
+    'https://cdn.example.com/models/tile.glb'
+  );
+  expect(pathResolver.resolve('data:model/gltf+json;base64,e30=')).toBe(
+    'data:model/gltf+json;base64,e30='
+  );
 });
 
-test('CachedUriResolver caches derived strings and can clear them', t => {
+test('CachedUriResolver caches derived strings and can clear them', () => {
   const resolver = new CachedUriResolver('https://example.com/root');
   const firstResolvedUri = resolver.resolve('tile name.glb');
   const secondResolvedUri = resolver.resolve('tile name.glb');
 
-  t.equal(firstResolvedUri, 'https://example.com/root/tile name.glb');
-  t.equal(secondResolvedUri, firstResolvedUri, 'returns the cached derivation');
+  expect(firstResolvedUri).toBe('https://example.com/root/tile name.glb');
+  expect(secondResolvedUri).toBe(firstResolvedUri);
   resolver.clear();
-  t.equal(
-    resolver.resolve('tile name.glb'),
-    firstResolvedUri,
-    'retains the parsed base after clearing'
-  );
-  t.end();
+  expect(resolver.resolve('tile name.glb')).toBe(firstResolvedUri);
 });

--- a/modules/tiles/src/tileset-3d/common/tile-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tile-3d.ts
@@ -813,8 +813,15 @@ export class Tile3D {
     return refine || (this.parent && this.parent.refine) || TILE_REFINEMENT.REPLACE;
   }
 
-  _isTileset() {
-    return this.contentUrl.indexOf('.json') !== -1;
+  /**
+   * Returns whether loaded content is an external tileset.
+   *
+   * Parsed shape is authoritative because valid external resources may be extensionless, signed,
+   * or use a misleading filename. This method is called only after source loading has populated
+   * `content`.
+   */
+  _isTileset(): boolean {
+    return this.content?.shape === 'tileset3d';
   }
 
   _onContentLoaded() {

--- a/modules/tiles/src/tileset-3d/format-3d-tiles/tiles-3d-source.ts
+++ b/modules/tiles/src/tileset-3d/format-3d-tiles/tiles-3d-source.ts
@@ -65,6 +65,8 @@ export class Tiles3DSource implements Tileset3DSource {
   metadata?: TilesetSourceMetadata;
 
   private readonly queryParams: Record<string, string> = {};
+  /** Final request URLs cached by unmodified tile content URL. */
+  private readonly tileUrlCache: Map<string, string> = new Map();
   private readonly extensionsUsed: string[] = [];
   private readonly resolver?: TilesetSourceResolver;
   private rootTileset: TilesetJSON;
@@ -104,7 +106,9 @@ export class Tiles3DSource implements Tileset3DSource {
 
     if (this.rootTileset.queryString) {
       const searchParams = new URLSearchParams(this.rootTileset.queryString);
-      Object.assign(this.queryParams, Object.fromEntries(searchParams.entries()));
+      for (const [parameterName, parameterValue] of searchParams.entries()) {
+        this.setQueryParameter(parameterName, parameterValue);
+      }
     }
 
     this.asset = this.rootTileset.asset;
@@ -120,7 +124,7 @@ export class Tiles3DSource implements Tileset3DSource {
     }
 
     if ('tilesetVersion' in this.asset) {
-      this.queryParams.v = this.asset.tilesetVersion;
+      this.setQueryParameter('v', this.asset.tilesetVersion);
     }
 
     this.properties = this.rootTileset.properties;
@@ -186,7 +190,7 @@ export class Tiles3DSource implements Tileset3DSource {
           const url = new URL(childTile.contentUrl);
           const session = url.searchParams.get('session');
           if (session) {
-            this.queryParams.session = session;
+            this.setQueryParameter('session', session);
           }
         }
         tile.children.push(childTile);
@@ -216,7 +220,9 @@ export class Tiles3DSource implements Tileset3DSource {
       ...this.loadOptions,
       [this.loader.id]: {
         ...tilesetLoaderOptions,
-        isTileset: tile.type === 'json',
+        // Content bytes, rather than URL suffixes, distinguish external tilesets from renderable
+        // payloads. This is required for signed and extensionless resources.
+        isTileset: 'auto',
         assetGltfUpAxis: (this.asset && this.asset.gltfUpAxis) || 'Y'
       }
     };
@@ -226,19 +232,32 @@ export class Tiles3DSource implements Tileset3DSource {
 
     return {
       loaded: true,
-      nestedTileset: tile.contentUrl.includes('.json') ? content : undefined
+      nestedTileset: content?.shape === 'tileset3d' ? content : undefined
     };
   }
 
   /**
    * Resolves a tile content URL with source-managed query parameters.
+   *
+   * Existing per-resource parameters take precedence over inherited root, version, and session
+   * values. Completed URLs are cached by the original tile path; {@link setQueryParameter}
+   * invalidates the cache before changed source state can be observed.
+   *
+   * @param tilePath - Unmodified absolute content URL or data URL from the tile header.
+   * @returns Content URL with any missing source parameters appended.
    */
   getTileUrl(tilePath: string): string {
     if (tilePath.startsWith('data:')) {
       return tilePath;
     }
 
+    const cachedTileUrl = this.tileUrlCache.get(tilePath);
+    if (cachedTileUrl) {
+      return cachedTileUrl;
+    }
+
     if (!Object.keys(this.queryParams).length) {
+      this.tileUrlCache.set(tilePath, tilePath);
       return tilePath;
     }
 
@@ -252,7 +271,27 @@ export class Tiles3DSource implements Tileset3DSource {
     }
 
     const queryParams = mergedQueryParams.toString();
-    return queryParams ? `${pathWithoutQuery}?${queryParams}` : pathWithoutQuery;
+    const tileUrl = queryParams ? `${pathWithoutQuery}?${queryParams}` : pathWithoutQuery;
+    this.tileUrlCache.set(tilePath, tileUrl);
+    return tileUrl;
+  }
+
+  /**
+   * Updates an inherited source query parameter and invalidates derived request URLs.
+   *
+   * Root tokens and tileset versions normally settle during initialization. Some providers expose
+   * a session parameter on a child URL, so invalidation is required to prevent URLs cached earlier
+   * in header construction from retaining stale authentication state.
+   *
+   * @param parameterName - Query parameter name.
+   * @param parameterValue - Query parameter value.
+   */
+  private setQueryParameter(parameterName: string, parameterValue: string): void {
+    if (this.queryParams[parameterName] === parameterValue) {
+      return;
+    }
+    this.queryParams[parameterName] = parameterValue;
+    this.tileUrlCache.clear();
   }
 
   /**

--- a/modules/tiles/test/tileset/tileset-3d-source.spec.ts
+++ b/modules/tiles/test/tileset/tileset-3d-source.spec.ts
@@ -117,14 +117,16 @@ test('Tiles3DSource uses injected resolvers for root metadata and tile content',
   const tileContent = {content: 'from-resolver'};
   let rootLoadCount = 0;
   let resourceLoadCount = 0;
+  let resourceTilesetMode: unknown;
 
   const resolver: TilesetSourceResolver = {
     async loadRoot() {
       rootLoadCount++;
       return rootTileset;
     },
-    async loadResource() {
+    async loadResource(_url, _loader, loadOptions) {
       resourceLoadCount++;
+      resourceTilesetMode = (loadOptions['3d-tiles'] as Record<string, unknown>)?.isTileset;
       return tileContent;
     }
   };
@@ -144,8 +146,62 @@ test('Tiles3DSource uses injected resolvers for root metadata and tile content',
 
   t.equal(rootLoadCount, 1, 'root metadata goes through the injected resolver');
   t.equal(resourceLoadCount, 1, 'tile content goes through the injected resolver');
+  t.equal(resourceTilesetMode, 'auto', 'content kind is detected from bytes rather than URL');
   t.equal(tile.content, tileContent);
   t.notOk(loadResult.nestedTileset);
+  t.end();
+});
+
+test('Tiles3DSource recognizes extensionless nested tilesets from parsed shape', async t => {
+  const nestedTileset = {shape: 'tileset3d', asset: {version: '1.1'}, root: {}};
+  const resolver: TilesetSourceResolver = {
+    async loadRoot() {
+      return {
+        asset: {version: '1.1'},
+        root: {refine: 'REPLACE'},
+        lodMetricType: 'geometricError',
+        lodMetricValue: 1
+      };
+    },
+    async loadResource() {
+      return nestedTileset;
+    }
+  };
+  const source = new Tiles3DSource({
+    url: 'https://example.com/root',
+    loader: Tiles3DLoader,
+    resolver
+  });
+  await source.initialize();
+
+  const tile = {contentUrl: 'https://example.com/nested/signed-resource?token=one'} as any;
+  const loadResult = await source.loadTileContent(tile);
+  t.equal(loadResult.nestedTileset, nestedTileset);
+  t.equal(tile.content, nestedTileset);
+  t.end();
+});
+
+test('Tiles3DSource invalidates cached URLs when inherited query state changes', async t => {
+  const source = new Tiles3DSource({
+    type: 'tileset',
+    url: 'https://example.com/tileset.json',
+    loader: Tiles3DLoader,
+    asset: {version: '1.1'},
+    root: {refine: 'REPLACE'},
+    lodMetricType: 'geometricError',
+    lodMetricValue: 1,
+    queryString: 'token=one'
+  } as any);
+  await source.initialize();
+
+  const tilePath = 'https://example.com/tile.b3dm';
+  t.equal(source.getTileUrl(tilePath), `${tilePath}?token=one`);
+  (source as any).setQueryParameter('token', 'two');
+  t.equal(
+    source.getTileUrl(tilePath),
+    `${tilePath}?token=two`,
+    'does not return a stale cached URL'
+  );
   t.end();
 });
 

--- a/test/bench/modules.js
+++ b/test/bench/modules.js
@@ -6,7 +6,6 @@
 // TODO maybe setPathPrefix is enough?
 import ALIASES from '../../test/aliases';
 import {_addAliases} from '@loaders.gl/loader-utils';
-
 _addAliases(ALIASES);
 
 /**
@@ -71,6 +70,12 @@ export async function addModuleBenchmarksToSuite(suite, filters = []) {
     await jsonBench(suite);
   }
 
+  if (shouldRunBenchmark('3d-tiles')) {
+    const {default: tiles3dBench} = await import('@loaders.gl/3d-tiles/test/tiles-3d-loader.bench');
+    await tiles3dBench(suite);
+  }
+
+  // await mvtBench(suite);
   if (shouldRunBenchmark('loader-utils')) {
     const {default: loaderUtilsBench} = await import(
       '@loaders.gl/loader-utils/test/loader-utils.bench'

--- a/website/src/components/docs/tiles-3d-docs-tabs.tsx
+++ b/website/src/components/docs/tiles-3d-docs-tabs.tsx
@@ -14,6 +14,7 @@ type Tiles3DDocsTab = {
 export type Tiles3DDocsTabId =
   | 'module'
   | 'runtime'
+  | 'resources'
   | 'hierarchy'
   | 'sse-lod'
   | 'requests'
@@ -23,6 +24,11 @@ export type Tiles3DDocsTabId =
 const TILES_3D_DOCS_TABS: Tiles3DDocsTab[] = [
   {id: 'module', label: 'Module', href: '/docs/modules/3d-tiles'},
   {id: 'runtime', label: 'Runtime', href: '/docs/modules/3d-tiles/concepts'},
+  {
+    id: 'resources',
+    label: 'Resources',
+    href: '/docs/modules/3d-tiles/concepts/resource-resolution-and-content-detection'
+  },
   {
     id: 'hierarchy',
     label: 'Hierarchy',


### PR DESCRIPTION
## Goals

- Make 3D Tiles resource classification independent of URL extensions and MIME types.
- Reduce repeated URI parsing and query-string construction in large explicit hierarchies.
- Preserve signed, extensionless, nested, and archive-backed resource behavior with clear validation boundaries.
- Document the complete resource-intake path and add a repeatable large-tileset benchmark.

## Actual changes

- Added a single-pass content preprocessor that detects `b3dm`, `i3dm`, `cmpt`, `pnts`, GLB, JSON glTF, and external tilesets from bytes and JSON structure.
- Changed `3d-tiles.isTileset: 'auto'` to use detected structure; explicit booleans now assert the expected category and produce mismatch diagnostics.
- Reused parsed external-tileset JSON and recognized nested tilesets from normalized `shape`, enabling signed, extensionless, and misleadingly named resources.
- Added `CachedUriResolver` with full TSDoc and API documentation; explicit header normalization shares one resolver per tileset parse.
- Cached final source-managed tile URLs and invalidated them whenever inherited root, version, or session query state changes.
- Added focused shared tests for binary/JSON classification, malformed inputs, explicit-mode mismatches, extensionless root and nested tilesets, URI semantics, query precedence, and cache invalidation.
- Added a benchmark for 10,000 repeated content references and large explicit tileset JSON preprocessing.
- Added a tab-linked 3D Tiles Resources guide, loader API cross-links, loader-utils API docs, and separate What's New bullets.

## Validation

- `yarn install`
- `yarn lint fix`
- `yarn build`
- `yarn test-node` — 396 files / 1,717 tests passed
- `yarn test-headless` — 400 files / 1,720 tests passed
- `cd website && yarn install && yarn build`
- Verified the generated Resources page, active tab, module overview link, and runtime-suite link in emitted HTML
- `yarn.lock` remains unchanged

The repository's plain `yarn node test/bench/node.js` entry point currently fails on its existing extensionless ESM import before loading any benchmark. The new benchmark is registered in the shared runner and build/lint checked, without a timing assertion.

## Related work

Partially addresses #1245.

The resource-cache scope follows the repeated URI parsing concern reported in [Cesium issue #11197](https://github.com/CesiumGS/cesium/issues/11197), adapted to loaders.gl's source model. Per-server scheduler keys are intentionally excluded because loaders.gl's current `RequestScheduler` has a global concurrency model and no server-key lookup path.

Follow-up XL work will address lazy implicit-subtree materialization and refinement correctness in #3291 and #3440.