### PR TITLE
feat(parquet): add reusable ParquetSource foundation

### DIFF
--- a/docs/docs-sidebar.json
+++ b/docs/docs-sidebar.json
@@ -198,6 +198,7 @@
           "modules/geotiff/api-reference/geotiff-source-loader",
           "modules/tiles/api-reference/i3s-source",
           "modules/geotiff/api-reference/ometiff-source-loader",
+          "modules/parquet/api-reference/parquet-source-loader",
           "modules/pmtiles/api-reference/pmtiles-source-loader",
           "modules/potree/api-reference/potree-source-loader",
           "modules/tiles/api-reference/raster-set",

--- a/docs/modules/parquet/README.md
+++ b/docs/modules/parquet/README.md
@@ -9,6 +9,7 @@
 Experimental loader and writer for the Apache Parquet format.
 
 - `ParquetLoader` and `ParquetWriter` are the default wasm-backed plain-row APIs.
+- [`ParquetSourceLoader`](/docs/modules/parquet/api-reference/parquet-source-loader) provides reusable, selective Arrow reads with cached schema and footer metadata. <img src="https://img.shields.io/badge/From-v5.0-blue.svg?style=flat-square" alt="From-v5.0" />
 - [`ParquetJSLoader`](/docs/modules/parquet/api-reference/parquet-js-loader) and [`ParquetJSWriter`](/docs/modules/parquet/api-reference/parquet-js-writer) provide the experimental parquetjs plain-row and plain-table APIs. <img src="https://img.shields.io/badge/From-v5.0-blue.svg?style=flat-square" alt="From-v5.0" />
 - `ParquetLoader` supports Arrow output with `parquet.shape: 'arrow-table'`, and `ParquetWriter` accepts loaders.gl Arrow tables.
 

--- a/docs/modules/parquet/api-reference/parquet-source-loader.md
+++ b/docs/modules/parquet/api-reference/parquet-source-loader.md
@@ -1,0 +1,113 @@
+# ParquetSourceLoader
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v5.0-blue.svg?style=flat-square" alt="From-v5.0" />
+  &nbsp;
+  <img src="https://img.shields.io/badge/Status-Experimental-orange.svg?style=flat-square" alt="Status: Experimental" />
+</p>
+
+`ParquetSourceLoader` creates a reusable `ParquetSource` for selective access to a Parquet file.
+The source opens the file lazily, caches its schema and footer metadata, and can stream selected row
+groups and columns as Arrow batches without reopening the file for each read.
+
+## Usage
+
+```ts
+import {createDataSource} from '@loaders.gl/core';
+import {ParquetSourceLoader} from '@loaders.gl/parquet';
+
+const source = createDataSource(
+  'https://example.com/trips.parquet',
+  [ParquetSourceLoader],
+  {}
+);
+
+try {
+  const metadata = await source.getMetadata();
+  console.log(metadata.rowCount, metadata.rowGroups.length);
+
+  for await (const batch of source.read({
+    rowGroups: [2, 3],
+    columns: ['pickup_longitude', 'pickup_latitude'],
+    batchSize: 65_536
+  })) {
+    console.log(batch.data, batch.metadata);
+  }
+} finally {
+  await source.close();
+}
+```
+
+Both URL and `Blob` inputs are supported. `createDataSource()` returns immediately; file access and
+WASM initialization begin when `getSchema()`, `getMetadata()`, or `read()` is first called.
+
+## API
+
+### `getSchema(): Promise<Schema>`
+
+Returns the cached Arrow-compatible loaders.gl schema. Compatible GeoParquet metadata is normalized
+to GeoArrow field metadata in the same way as Arrow output from `ParquetLoader`.
+
+### `getMetadata(): Promise<ParquetSourceMetadata>`
+
+Returns cached, plain JavaScript metadata copied from the Parquet footer:
+
+- `schema`: Arrow-compatible loaders.gl schema.
+- `version`: Parquet format version.
+- `rowCount`: total file row count.
+- `createdBy`: optional writer identifier.
+- `keyValueMetadata`: file-level key/value metadata.
+- `rowGroups`: row count, absolute source-row offset, compressed and uncompressed size, and column
+  chunks for every row group.
+
+Each column chunk includes its nested `path`, optional `filePath`, `fileOffset`, value count,
+compression and encoding names, and compressed and uncompressed size. `fileOffset` is a `bigint`.
+
+The returned schema and metadata objects are reused for the lifetime of the source.
+
+### `read(options?: ParquetSourceReadOptions): AsyncIterable<ParquetSourceBatch>`
+
+Streams Arrow batches for the selected row groups and columns. Omitting `rowGroups` reads every row
+group in file order. Explicit row-group indexes are read in the supplied order and must be unique and
+in range.
+
+Each batch includes provenance in `batch.metadata`:
+
+| Field | Description |
+| --- | --- |
+| `sourceId` | Resolved URL, file name, or stable Blob label. |
+| `rowGroupIndex` | Zero-based source row-group index. |
+| `rowOffset` | Absolute offset of the first batch row in the source file. |
+| `rowGroupRowOffset` | Offset of the first batch row within its row group. |
+
+### `close(): Promise<void>`
+
+Releases the cached WASM file handle and prevents additional operations. Calling `close()` more than
+once is safe. A source supports one active `read()` at a time; finish or cancel that iterator before
+starting another read or calling `close()`. Overlapping operations reject instead of waiting behind a
+paused consumer.
+
+## Options
+
+Source defaults are configured under `parquet` when the source is created. `read()` accepts the first
+four options again and uses them to override the source defaults for that read.
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `parquet.rowGroups` | `number[]` | all row groups | Row-group indexes to read. |
+| `parquet.columns` | `string[]` | all columns | Column paths to project. |
+| `parquet.batchSize` | `number` | backend default | Target number of rows per Arrow batch. |
+| `parquet.concurrency` | `number` | backend default | Concurrent reads used by `parquet-wasm`. |
+| `parquet.wasmUrl` | `ParquetWasm.InitInput \| Promise<ParquetWasm.InitInput>` | external URL | Overrides the `parquet-wasm` binary location. |
+
+## Current limitations
+
+- Decoding runs on the caller thread; worker-backed decoding and transferable Arrow buffers are not
+  implemented yet.
+- URL and Blob access use the transport built into `parquet-wasm`. A custom fetch or range-request
+  transport, `AbortSignal`, and ETag/Last-Modified consistency checks are not exposed yet. Remote
+  reads depend on the server's CORS and byte-range behavior.
+- The default WASM binary is loaded from an external URL. Set `parquet.wasmUrl` to self-host the
+  binary; a bundler-resolved packaged default is not implemented yet.
+- Downloaded-byte, request-count, network-time, and decode-time telemetry are not reported yet.
+- Row-group and column-chunk sizes and offsets are available, but min/max/null statistics are not.

--- a/docs/modules/parquet/format.md
+++ b/docs/modules/parquet/format.md
@@ -14,9 +14,10 @@ import {ParquetDocsTabs} from '@site/src/components/docs/parquet-docs-tabs';
 | Loader APIs          | `load`, `parse`, `parseInBatches`                                                          |
 | Loader Worker Thread | No                                                                                         |
 | Loader Streaming     | Yes                                                                                        |
+| Source APIs          | `createDataSource`, `getMetadata`, `getSchema`, `read`, `close`                            |
 | Writer APIs          | `encode`, `encodeSync`                                                                     |
 
-## Loaders and Writers
+## Loaders, Sources and Writers
 
 <div className="docs-api-card-grid">
   <a className="docs-api-card" href="/docs/modules/parquet/api-reference/parquet-loader">
@@ -32,6 +33,13 @@ import {ParquetDocsTabs} from '@site/src/components/docs/parquet-docs-tabs';
     <span>Loads GeoParquet files as GeoJSON tables or Arrow tables with geospatial metadata.</span>
     <span className="docs-api-card__meta">Output: GeoJSONTable, ArrowTable</span>
     <span className="docs-api-card__meta">APIs: load, parse, parseInBatches</span>
+  </a>
+  <a className="docs-api-card" href="/docs/modules/parquet/api-reference/parquet-source-loader">
+    <span className="docs-api-card__kind">Source</span>
+    <strong>ParquetSourceLoader</strong>
+    <span>Reuses cached schema and footer metadata for selective Arrow reads.</span>
+    <span className="docs-api-card__meta">Output: ArrowTableBatch</span>
+    <span className="docs-api-card__meta">APIs: createDataSource, getMetadata, getSchema, read</span>
   </a>
   <a className="docs-api-card" href="/docs/modules/parquet/api-reference/parquet-writer">
     <span className="docs-api-card__kind">Writer</span>

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -86,6 +86,7 @@ Release Date: 2026
 
 **@loaders.gl/parquet**
 
+- [`ParquetSourceLoader`](/docs/modules/parquet/api-reference/parquet-source-loader) NEW - reuses cached schema and footer metadata while streaming selected row groups and columns as Arrow batches with source-row provenance.
 - [`ParquetJSLoader`](/docs/modules/parquet/api-reference/parquet-js-loader) and [`ParquetJSWriter`](/docs/modules/parquet/api-reference/parquet-js-writer) NEW - add the experimental parquetjs plain-row and plain-table APIs.
 - `parquet.shape` on [`ParquetLoader`](/docs/modules/parquet/api-reference/parquet-loader) is now documented for selecting object-row or Arrow output from the canonical wasm-backed loader.
 

--- a/modules/core/src/iterators/make-iterator/make-stream-iterator.ts
+++ b/modules/core/src/iterators/make-iterator/make-stream-iterator.ts
@@ -43,30 +43,68 @@ async function* makeBrowserStreamIterator(
   const reader = stream.getReader();
 
   let nextBatchPromise: Promise<{done?: boolean; value?: Uint8Array}> | undefined;
+  let streamFinished = false;
+  let streamReadFailed = false;
+  let iteratorFailed = false;
 
   try {
     // eslint-disable-next-line no-constant-condition
     while (true) {
       const currentBatchPromise = nextBatchPromise || reader.read();
-      // Issue a read for an additional batch, while we await the next batch
-      // Idea is to make fetching happen in parallel with processing / parsing
-      if (options?._streamReadAhead) {
-        nextBatchPromise = reader.read();
-      }
+      nextBatchPromise = undefined;
       // Read from the stream
       // value is a Uint8Array
-      const {done, value} = await currentBatchPromise;
+      let batch;
+      try {
+        batch = await currentBatchPromise;
+      } catch (error) {
+        streamReadFailed = true;
+        throw error;
+      }
+      const {done, value} = batch;
       // Exit if we're done
       if (done) {
+        streamFinished = true;
         return;
+      }
+      // Issue a read for an additional batch while the current batch is processed
+      if (options?._streamReadAhead) {
+        nextBatchPromise = reader.read();
+        // Observe a prefetched rejection even if the consumer stops before requesting it
+        void nextBatchPromise.catch(() => {});
       }
       // Else yield the chunk
       yield toArrayBuffer(value);
     }
-  } catch (_error) {
-    // TODO - examples makes it look like this should always be called,
-    // but that generates exceptions so only call it if we do not reach the end
-    reader.releaseLock();
+  } catch (error) {
+    iteratorFailed = true;
+    throw error;
+  } finally {
+    let cleanupFailed = false;
+    let cleanupError: unknown;
+
+    if (!streamFinished && !streamReadFailed) {
+      try {
+        await reader.cancel();
+      } catch (error) {
+        cleanupFailed = true;
+        cleanupError = error;
+      }
+    }
+
+    try {
+      reader.releaseLock();
+    } catch (error) {
+      if (!cleanupFailed) {
+        cleanupFailed = true;
+        cleanupError = error;
+      }
+    }
+
+    // Preserve errors from iteration instead of replacing them with cleanup errors
+    if (!iteratorFailed && cleanupFailed) {
+      throw cleanupError;
+    }
   }
 }
 

--- a/modules/core/test/iterators/make-stream.spec.ts
+++ b/modules/core/test/iterators/make-stream.spec.ts
@@ -27,6 +27,61 @@ test('asyncIteratorToStream#makeIterator(iteratorToStream())', async () => {
   expect(chunks).toEqual(concatenatedData);
 });
 
+test('makeIterator#rethrows stream read errors and releases the lock', async () => {
+  const readError = new Error('Stream read failed');
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.error(readError);
+    }
+  });
+
+  let thrownError: unknown;
+  try {
+    for await (const _chunk of makeIterator(stream) as AsyncIterable<ArrayBuffer>) {
+      // The stream errors before yielding a chunk
+    }
+  } catch (error) {
+    thrownError = error;
+  }
+
+  expect(thrownError).toBe(readError);
+  expect(stream.locked).toBe(false);
+});
+
+test('makeIterator#cancels stream and releases the lock on early return', async () => {
+  let cancellationCount = 0;
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new Uint8Array([1]));
+    },
+    cancel() {
+      cancellationCount++;
+    }
+  });
+
+  for await (const _chunk of makeIterator(stream, {
+    _streamReadAhead: true
+  }) as AsyncIterable<ArrayBuffer>) {
+    break;
+  }
+
+  expect(cancellationCount).toBe(1);
+  expect(stream.locked).toBe(false);
+});
+
+test('makeIterator#releases stream lock after natural completion', async () => {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new Uint8Array([1]));
+      controller.close();
+    }
+  });
+
+  await concatenateArrayBuffersAsync(makeIterator(stream) as AsyncIterable<ArrayBuffer>);
+
+  expect(stream.locked).toBe(false);
+});
+
 test('asyncIteratorToStream#read stream using DOM/Node APIs', async () => {
   const data = [1, 2, 3].map(value => new Uint8Array([value]).buffer);
   const concatenatedData = concatenateArrayBuffers(...data);

--- a/modules/parquet/src/bundled.ts
+++ b/modules/parquet/src/bundled.ts
@@ -7,3 +7,14 @@ export type {GeoParquetLoaderOptions} from './geoparquet-loader';
 export {ParquetWASMLoaderWithParser as ParquetLoader} from './parquet-wasm-loader-with-parser';
 export {GeoParquetLoaderWithParser as GeoParquetLoader} from './geoparquet-loader-with-parser';
 export {ParquetLoaderWithParser as ParquetJSLoader} from './parquet-loader-with-parser';
+export {
+  ParquetSourceLoader,
+  ParquetSource,
+  type ParquetSourceLoaderOptions,
+  type ParquetSourceReadOptions,
+  type ParquetSourceMetadata,
+  type ParquetRowGroupMetadata,
+  type ParquetColumnChunkMetadata,
+  type ParquetBatchMetadata,
+  type ParquetSourceBatch
+} from './parquet-source-loader';

--- a/modules/parquet/src/index.ts
+++ b/modules/parquet/src/index.ts
@@ -11,6 +11,18 @@ export {ParquetLoader} from './parquet-loader';
 export {GeoParquetLoader} from './geoparquet-loader';
 export {ParquetJSLoader} from './parquet-js-loader';
 
+export {
+  ParquetSourceLoader,
+  ParquetSource,
+  type ParquetSourceLoaderOptions,
+  type ParquetSourceReadOptions,
+  type ParquetSourceMetadata,
+  type ParquetRowGroupMetadata,
+  type ParquetColumnChunkMetadata,
+  type ParquetBatchMetadata,
+  type ParquetSourceBatch
+} from './parquet-source-loader';
+
 export {ParquetWriter} from './parquet-writer';
 export type {ParquetJSWriterOptions} from './parquet-js-writer';
 export {ParquetJSWriter} from './parquet-js-writer';

--- a/modules/parquet/src/lib/utils/load-wasm.ts
+++ b/modules/parquet/src/lib/utils/load-wasm.ts
@@ -5,7 +5,7 @@
 import type * as ParquetWasm from 'parquet-wasm/esm/parquet_wasm.js';
 import {PARQUET_WASM_URL} from '../constants';
 
-let initializePromise: Promise<typeof ParquetWasm>;
+let initializePromise: Promise<typeof ParquetWasm> | undefined;
 
 export async function loadWasm(
   wasmUrl: ParquetWasm.InitInput | Promise<ParquetWasm.InitInput> = PARQUET_WASM_URL
@@ -14,7 +14,14 @@ export async function loadWasm(
     if (!wasmUrl) {
       throw new Error('ParquetLoader: No wasmUrl provided');
     }
-    initializePromise = loadAndInitializeWasm(wasmUrl);
+    const nextInitializePromise = loadAndInitializeWasm(wasmUrl);
+    const cachedInitializePromise = nextInitializePromise.catch(error => {
+      if (initializePromise === cachedInitializePromise) {
+        initializePromise = undefined;
+      }
+      throw error;
+    });
+    initializePromise = cachedInitializePromise;
   }
 
   return await initializePromise;

--- a/modules/parquet/src/lib/utils/make-stream-iterator.ts
+++ b/modules/parquet/src/lib/utils/make-stream-iterator.ts
@@ -43,32 +43,64 @@ async function* makeBrowserStreamIterator<T>(
   const reader = stream.getReader();
 
   let nextBatchPromise: Promise<{done?: boolean; value?: T}> | undefined;
+  let streamFinished = false;
+  let streamReadFailed = false;
+  let iteratorFailed = false;
 
   try {
     // eslint-disable-next-line no-constant-condition
     while (true) {
       const currentBatchPromise = nextBatchPromise || reader.read();
-      // Issue a read for an additional batch, while we await the next batch
-      // Idea is to make fetching happen in parallel with processing / parsing
-      if (options?._streamReadAhead) {
-        nextBatchPromise = reader.read();
-      }
+      nextBatchPromise = undefined;
       // Read from the stream
-      // value is a Uint8Array
-      const {done, value} = await currentBatchPromise;
+      let batch;
+      try {
+        batch = await currentBatchPromise;
+      } catch (error) {
+        streamReadFailed = true;
+        throw error;
+      }
+      const {done, value} = batch;
       // Exit if we're done
       if (done) {
+        streamFinished = true;
         return;
+      }
+      // Issue a read for an additional batch while the current batch is processed
+      if (options?._streamReadAhead) {
+        nextBatchPromise = reader.read();
+        // Observe a prefetched rejection even if the consumer stops before requesting it
+        void nextBatchPromise.catch(() => {});
       }
       // Else yield the chunk
       if (value) {
         yield value;
       }
     }
-  } catch (_error) {
-    // TODO - examples makes it look like this should always be called,
-    // but that generates exceptions so only call it if we do not reach the end
-    reader.releaseLock();
+  } catch (error) {
+    iteratorFailed = true;
+    throw error;
+  } finally {
+    let cleanupError: unknown;
+
+    if (!streamFinished && !streamReadFailed) {
+      try {
+        await reader.cancel();
+      } catch (error) {
+        cleanupError = error;
+      }
+    }
+
+    try {
+      reader.releaseLock();
+    } catch (error) {
+      cleanupError ||= error;
+    }
+
+    // Preserve iteration errors instead of replacing them with cleanup errors
+    if (!iteratorFailed && cleanupError) {
+      throw cleanupError;
+    }
   }
 }
 

--- a/modules/parquet/src/parquet-source-loader.ts
+++ b/modules/parquet/src/parquet-source-loader.ts
@@ -1,0 +1,477 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type * as parquetWasm from 'parquet-wasm/esm/parquet_wasm.js';
+import * as arrow from 'apache-arrow';
+
+import type {CoreAPI, DataSourceOptions, SourceLoader} from '@loaders.gl/loader-utils';
+import {DataSource} from '@loaders.gl/loader-utils';
+import type {ArrowTableBatch, Schema} from '@loaders.gl/schema';
+
+import {ParquetFormat} from './parquet-format';
+import {PARQUET_WASM_URL} from './lib/constants';
+import {normalizeArrowTableGeoMetadata} from './lib/geo/geospatial-metadata';
+import {loadWasm} from './lib/utils/load-wasm';
+import {makeStreamIterator} from './lib/utils/make-stream-iterator';
+
+// __VERSION__ is injected by babel-plugin-version-inline
+// @ts-ignore TS2304: Cannot find name '__VERSION__'.
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+
+/** Options applied to each read from a {@link ParquetSource}. */
+export type ParquetSourceReadOptions = {
+  /** Row-group indexes to read. Defaults to all row groups in file order. */
+  rowGroups?: readonly number[];
+  /** Column paths to project. Defaults to all columns. */
+  columns?: readonly string[];
+  /** Target number of rows in each returned Arrow batch. */
+  batchSize?: number;
+  /** Number of concurrent range requests used by parquet-wasm. */
+  concurrency?: number;
+};
+
+/** Options for creating a {@link ParquetSource}. */
+export type ParquetSourceLoaderOptions = DataSourceOptions & {
+  parquet?: ParquetSourceReadOptions & {
+    /** URL or module used to initialize parquet-wasm. */
+    wasmUrl?: parquetWasm.InitInput | Promise<parquetWasm.InitInput>;
+  };
+};
+
+/** Plain metadata for one Parquet column chunk. */
+export type ParquetColumnChunkMetadata = {
+  /** Nested column path. */
+  readonly path: readonly string[];
+  /** Optional external file containing the chunk. */
+  readonly filePath?: string;
+  /** Byte offset reported by the Parquet footer. */
+  readonly fileOffset: bigint;
+  /** Number of encoded values in the chunk. */
+  readonly valueCount: number;
+  /** Compression codec name. */
+  readonly compression: string;
+  /** Encodings used by the chunk. */
+  readonly encodings: readonly string[];
+  /** Compressed chunk size in bytes. */
+  readonly compressedSize: number;
+  /** Uncompressed chunk size in bytes. */
+  readonly uncompressedSize: number;
+};
+
+/** Plain metadata for one Parquet row group. */
+export type ParquetRowGroupMetadata = {
+  /** Zero-based row-group index. */
+  readonly index: number;
+  /** Absolute offset of the first row in the file. */
+  readonly rowOffset: number;
+  /** Number of rows in the row group. */
+  readonly rowCount: number;
+  /** Total compressed column size in bytes. */
+  readonly compressedSize: number;
+  /** Total uncompressed column size in bytes. */
+  readonly uncompressedSize: number;
+  /** Column chunks in this row group. */
+  readonly columns: readonly ParquetColumnChunkMetadata[];
+};
+
+/** Cached schema and footer metadata exposed by a {@link ParquetSource}. */
+export type ParquetSourceMetadata = {
+  /** Arrow-compatible loaders.gl schema. */
+  readonly schema: Schema;
+  /** Parquet format version stored in the footer. */
+  readonly version: number;
+  /** Total number of rows in the file. */
+  readonly rowCount: number;
+  /** Application string stored by the Parquet writer. */
+  readonly createdBy?: string;
+  /** File-level key/value metadata. */
+  readonly keyValueMetadata: Readonly<Record<string, string>>;
+  /** Row-group and column-chunk metadata. */
+  readonly rowGroups: readonly ParquetRowGroupMetadata[];
+};
+
+/** Provenance attached to every Arrow batch returned by {@link ParquetSource.read}. */
+export type ParquetBatchMetadata = {
+  /** Source URL, File name, or a stable Blob label. */
+  readonly sourceId: string;
+  /** Row group that produced this batch. */
+  readonly rowGroupIndex: number;
+  /** Absolute offset of the first batch row in the source file. */
+  readonly rowOffset: number;
+  /** Offset of the first batch row within its row group. */
+  readonly rowGroupRowOffset: number;
+};
+
+/** Arrow batch returned by {@link ParquetSource.read}. */
+export type ParquetSourceBatch = Omit<ArrowTableBatch<ParquetBatchMetadata>, 'metadata'> & {
+  /** Provenance for the source rows represented by this batch. */
+  readonly metadata: ParquetBatchMetadata;
+};
+
+/** Snapshotted options used internally for one read. */
+type ResolvedParquetSourceReadOptions = {
+  rowGroups?: number[];
+  columns?: string[];
+  batchSize?: number;
+  concurrency?: number;
+};
+
+type ParquetSourceState = {
+  parquetFile: parquetWasm.ParquetFile;
+  metadata: ParquetSourceMetadata;
+  schemaMetadata: Map<string, string>;
+};
+
+/** Source factory for reusable, selective access to Parquet files. */
+export const ParquetSourceLoader = {
+  ...ParquetFormat,
+  dataType: null as unknown as ParquetSource,
+  batchType: null as never,
+  name: 'ParquetSourceLoader',
+  id: 'parquet-source',
+  module: 'parquet',
+  version: VERSION,
+  type: 'parquet',
+  fromUrl: true,
+  fromBlob: true,
+
+  options: {
+    parquet: {
+      rowGroups: undefined,
+      columns: undefined,
+      batchSize: undefined,
+      concurrency: undefined,
+      wasmUrl: PARQUET_WASM_URL
+    }
+  },
+
+  defaultOptions: {
+    parquet: {
+      rowGroups: undefined!,
+      columns: undefined!,
+      batchSize: undefined!,
+      concurrency: undefined!,
+      wasmUrl: PARQUET_WASM_URL
+    }
+  },
+
+  testURL: (url: string): boolean => /\.parquet(?:$|[?#])/i.test(url),
+  createDataSource: (
+    data: string | Blob,
+    options: ParquetSourceLoaderOptions,
+    coreApi?: CoreAPI
+  ): ParquetSource => new ParquetSource(data, options, coreApi)
+} as const satisfies SourceLoader<ParquetSource>;
+
+/** Reusable Parquet file handle with cached footer/schema and selective Arrow reads. */
+export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoaderOptions> {
+  /** Shared lazy initialization for the source file and its copied metadata. */
+  private initializationPromise: Promise<ParquetSourceState> | null = null;
+  /** Opaque WASM input preserved outside recursive option merging. */
+  private readonly wasmUrl: parquetWasm.InitInput | Promise<parquetWasm.InitInput>;
+  /** Shared promise for idempotent asynchronous cleanup. */
+  private closePromise: Promise<void> | null = null;
+  /** Whether a caller currently owns the source's single read stream. */
+  private readActive = false;
+  /** Whether this source has stopped accepting new operations. */
+  private closed = false;
+  /** Whether the cached WASM file handle has been released. */
+  private freed = false;
+
+  /** Creates a lazy Parquet source without performing I/O. */
+  constructor(data: string | Blob, options: ParquetSourceLoaderOptions, coreApi?: CoreAPI) {
+    const wasmUrl = options.parquet?.wasmUrl;
+    super(data, options, ParquetSourceLoader.defaultOptions, coreApi);
+
+    // mergeOptions recursively treats opaque Promise, URL, module, and buffer inputs as option
+    // bags. Preserve the caller's wasm input by identity instead.
+    this.wasmUrl = wasmUrl ?? PARQUET_WASM_URL;
+    this.options.parquet.wasmUrl = this.wasmUrl;
+  }
+
+  /** Returns the cached Arrow-compatible schema. */
+  async getSchema(): Promise<Schema> {
+    const state = await this.getState();
+    return state.metadata.schema;
+  }
+
+  /** Returns cached plain file, row-group, and column-chunk metadata. */
+  async getMetadata(): Promise<ParquetSourceMetadata> {
+    const state = await this.getState();
+    return state.metadata;
+  }
+
+  /** Streams selected row groups and columns as Arrow batches with source-row provenance. */
+  async *read(options: ParquetSourceReadOptions = {}): AsyncIterable<ParquetSourceBatch> {
+    if (this.readActive) {
+      throw new Error('ParquetSource already has an active read');
+    }
+    this.readActive = true;
+
+    try {
+      const readOptions = this.getReadOptions(options);
+      const state = await this.getState();
+      const rowGroupIndexes = getRowGroupIndexes(readOptions.rowGroups, state.metadata.rowGroups);
+
+      for (const rowGroupIndex of rowGroupIndexes) {
+        const rowGroupMetadata = state.metadata.rowGroups[rowGroupIndex];
+        const stream = await state.parquetFile.stream({
+          rowGroups: [rowGroupIndex],
+          columns: readOptions.columns,
+          batchSize: readOptions.batchSize,
+          concurrency: readOptions.concurrency
+        });
+
+        let rowGroupRowOffset = 0;
+        for await (const wasmRecordBatch of makeStreamIterator<parquetWasm.RecordBatch>(stream)) {
+          const arrowTable = arrow.tableFromIPC(wasmRecordBatch.intoIPCStream());
+          const normalizedArrowTable = normalizeArrowTableGeoMetadata(
+            {shape: 'arrow-table', data: arrowTable},
+            state.schemaMetadata
+          );
+          const length = normalizedArrowTable.data.numRows;
+
+          yield {
+            batchType: 'data',
+            shape: 'arrow-table',
+            schema: normalizedArrowTable.schema,
+            data: normalizedArrowTable.data,
+            length,
+            metadata: {
+              sourceId: getSourceId(this.data, this.url),
+              rowGroupIndex,
+              rowOffset: rowGroupMetadata.rowOffset + rowGroupRowOffset,
+              rowGroupRowOffset
+            }
+          };
+
+          rowGroupRowOffset += length;
+        }
+      }
+    } finally {
+      this.readActive = false;
+    }
+  }
+
+  /** Releases the cached WASM file and prevents further operations. */
+  close(): Promise<void> {
+    if (this.closePromise) {
+      return this.closePromise;
+    }
+
+    if (this.readActive) {
+      return Promise.reject(
+        new Error('ParquetSource cannot close while a read is active; finish or cancel it first')
+      );
+    }
+    this.closed = true;
+    this.closePromise = this.releaseResources();
+    return this.closePromise;
+  }
+
+  /** Waits for initialization, if any, and releases the cached WASM file once. */
+  private async releaseResources(): Promise<void> {
+    if (this.freed) {
+      return;
+    }
+
+    const state = await this.initializationPromise?.catch(() => null);
+    state?.parquetFile.free();
+    this.freed = true;
+  }
+
+  /** Lazily opens the Parquet file and copies its schema/footer into JavaScript memory. */
+  private getState(): Promise<ParquetSourceState> {
+    if (this.closed) {
+      throw new Error('ParquetSource is closed');
+    }
+
+    if (!this.initializationPromise) {
+      const initializationPromise = this.initialize();
+      const cachedInitializationPromise = initializationPromise.catch(error => {
+        if (this.initializationPromise === cachedInitializationPromise) {
+          this.initializationPromise = null;
+        }
+        throw error;
+      });
+      this.initializationPromise = cachedInitializationPromise;
+    }
+
+    return this.initializationPromise;
+  }
+
+  /** Opens parquet-wasm and prepares plain metadata owned by this source. */
+  private async initialize(): Promise<ParquetSourceState> {
+    const wasm = await loadWasm(this.wasmUrl);
+    const parquetFile =
+      typeof this.data === 'string'
+        ? await wasm.ParquetFile.fromUrl(this.url)
+        : await wasm.ParquetFile.fromFile(this.data);
+
+    try {
+      const copiedMetadata = copyParquetMetadata(parquetFile, wasm);
+      const wasmSchema = parquetFile.schema();
+      const arrowSchemaTable = arrow.tableFromIPC(wasmSchema.intoIPCStream());
+      const normalizedArrowTable = normalizeArrowTableGeoMetadata(
+        {shape: 'arrow-table', data: arrowSchemaTable},
+        copiedMetadata.schemaMetadata
+      );
+
+      return {
+        parquetFile,
+        schemaMetadata: copiedMetadata.schemaMetadata,
+        metadata: Object.freeze({
+          ...copiedMetadata.metadata,
+          schema: normalizedArrowTable.schema
+        }) satisfies ParquetSourceMetadata
+      };
+    } catch (error) {
+      parquetFile.free();
+      throw error;
+    }
+  }
+
+  /** Merges source defaults with per-read options. */
+  private getReadOptions(options: ParquetSourceReadOptions): ResolvedParquetSourceReadOptions {
+    const rowGroups = options.rowGroups ?? this.options.parquet?.rowGroups;
+    const columns = options.columns ?? this.options.parquet?.columns;
+    return {
+      rowGroups: rowGroups && [...rowGroups],
+      columns: columns && [...columns],
+      batchSize: options.batchSize ?? this.options.parquet?.batchSize,
+      concurrency: options.concurrency ?? this.options.parquet?.concurrency
+    };
+  }
+}
+
+/** Copies footer wrappers into plain JavaScript values and releases their WASM handles. */
+function copyParquetMetadata(
+  parquetFile: parquetWasm.ParquetFile,
+  wasm: typeof parquetWasm
+): {
+  metadata: Omit<ParquetSourceMetadata, 'schema'>;
+  schemaMetadata: Map<string, string>;
+} {
+  const parquetMetadata = parquetFile.metadata();
+  try {
+    const fileMetadata = parquetMetadata.fileMetadata();
+    let version: number;
+    let rowCount: number;
+    let createdBy: string | undefined;
+    let schemaMetadata: Map<string, string>;
+    try {
+      version = fileMetadata.version();
+      rowCount = fileMetadata.numRows();
+      createdBy = fileMetadata.createdBy();
+      schemaMetadata = new Map(fileMetadata.keyValueMetadata() as Map<string, string>);
+    } finally {
+      fileMetadata.free();
+    }
+
+    const wasmRowGroups = parquetMetadata.rowGroups();
+    let rowOffset = 0;
+    let rowGroups: ParquetRowGroupMetadata[];
+    try {
+      rowGroups = wasmRowGroups.map((rowGroup, index) => {
+        const wasmColumns = rowGroup.columns();
+        let columns: ParquetColumnChunkMetadata[];
+        try {
+          columns = wasmColumns.map(column =>
+            Object.freeze({
+              path: Object.freeze(column.columnPath()),
+              filePath: column.filePath(),
+              fileOffset: column.fileOffset(),
+              valueCount: column.numValues(),
+              compression: getEnumName(wasm.Compression, column.compression()),
+              encodings: Object.freeze(
+                column.encodings().map(encoding => getEnumName(wasm.Encoding, encoding))
+              ),
+              compressedSize: column.compressedSize(),
+              uncompressedSize: column.uncompressedSize()
+            })
+          );
+        } finally {
+          freeWasmHandles(wasmColumns);
+        }
+
+        const rowCountForGroup = rowGroup.numRows();
+        const metadata: ParquetRowGroupMetadata = Object.freeze({
+          index,
+          rowOffset,
+          rowCount: rowCountForGroup,
+          compressedSize: rowGroup.compressedSize(),
+          uncompressedSize: rowGroup.totalByteSize(),
+          columns: Object.freeze(columns)
+        });
+        rowOffset += rowCountForGroup;
+        return metadata;
+      });
+    } finally {
+      freeWasmHandles(wasmRowGroups);
+    }
+
+    return {
+      schemaMetadata,
+      metadata: {
+        version,
+        rowCount,
+        createdBy,
+        keyValueMetadata: Object.freeze(Object.fromEntries(schemaMetadata)),
+        rowGroups: Object.freeze(rowGroups)
+      }
+    };
+  } finally {
+    parquetMetadata.free();
+  }
+}
+
+/** Releases every WASM metadata wrapper, including entries not visited after an accessor error. */
+function freeWasmHandles(handles: {free(): void}[]): void {
+  for (const handle of handles) {
+    handle.free();
+  }
+}
+
+/** Converts a numeric WASM enum value into a stable string. */
+function getEnumName(enumValues: object, value: unknown): string {
+  const enumName = (enumValues as Record<number, string>)[Number(value)];
+  return enumName || String(value);
+}
+
+/** Validates and resolves the row groups requested by one read. */
+function getRowGroupIndexes(
+  requestedRowGroups: readonly number[] | undefined,
+  rowGroups: readonly ParquetRowGroupMetadata[]
+): number[] {
+  const rowGroupIndexes =
+    requestedRowGroups !== undefined
+      ? [...requestedRowGroups]
+      : Array.from({length: rowGroups.length}, (_, index) => index);
+  const uniqueIndexes = new Set<number>();
+
+  for (const rowGroupIndex of rowGroupIndexes) {
+    if (
+      !Number.isInteger(rowGroupIndex) ||
+      rowGroupIndex < 0 ||
+      rowGroupIndex >= rowGroups.length
+    ) {
+      throw new Error(`ParquetSource row group index ${rowGroupIndex} is out of range`);
+    }
+    if (uniqueIndexes.has(rowGroupIndex)) {
+      throw new Error(`ParquetSource row group index ${rowGroupIndex} is duplicated`);
+    }
+    uniqueIndexes.add(rowGroupIndex);
+  }
+
+  return rowGroupIndexes;
+}
+
+/** Returns a stable identifier used in batch provenance. */
+function getSourceId(data: string | Blob, resolvedUrl: string): string {
+  if (typeof data === 'string') {
+    return resolvedUrl;
+  }
+  const namedBlob = data as Blob & {name?: string};
+  return namedBlob.name || 'blob';
+}

--- a/modules/parquet/src/unbundled.ts
+++ b/modules/parquet/src/unbundled.ts
@@ -7,3 +7,14 @@ export type {GeoParquetLoaderOptions} from './geoparquet-loader';
 export {ParquetLoader} from './parquet-loader';
 export {GeoParquetLoader} from './geoparquet-loader';
 export {ParquetJSLoader} from './parquet-js-loader';
+export {
+  ParquetSourceLoader,
+  ParquetSource,
+  type ParquetSourceLoaderOptions,
+  type ParquetSourceReadOptions,
+  type ParquetSourceMetadata,
+  type ParquetRowGroupMetadata,
+  type ParquetColumnChunkMetadata,
+  type ParquetBatchMetadata,
+  type ParquetSourceBatch
+} from './parquet-source-loader';

--- a/modules/parquet/test/index.ts
+++ b/modules/parquet/test/index.ts
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import './init';
+import './make-stream-iterator.spec';
 
 // parquetjs unit test suite
 import './parquetjs/codec-plain.spec';
@@ -18,6 +19,7 @@ import './parquetjs/reader.spec';
 // loader/writer
 import './parquet-arrow-loader.spec';
 import './parquet-arrow-writer.spec';
+import './parquet-source-loader.spec';
 
 import './parquet-loader.spec';
 import './geoparquet-loader.spec';

--- a/modules/parquet/test/make-stream-iterator.spec.ts
+++ b/modules/parquet/test/make-stream-iterator.spec.ts
@@ -1,0 +1,80 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'tape-promise/tape';
+import {isBrowser} from '@loaders.gl/loader-utils';
+import {makeStreamIterator} from '../src/lib/utils/make-stream-iterator';
+
+test('Parquet makeStreamIterator#rethrows read errors and releases the lock', async t => {
+  if (!isBrowser) {
+    t.comment('Browser-only stream lock behavior');
+    t.end();
+    return;
+  }
+
+  const readError = new Error('Stream read failed');
+  const stream = new ReadableStream<number>({
+    start(controller) {
+      controller.error(readError);
+    }
+  });
+
+  await t.rejects(collectValues(makeStreamIterator(stream)), readError, 'preserves the read error');
+  t.notOk(stream.locked, 'releases the reader lock');
+  t.end();
+});
+
+test('Parquet makeStreamIterator#cancels and unlocks on early return', async t => {
+  if (!isBrowser) {
+    t.comment('Browser-only stream lock behavior');
+    t.end();
+    return;
+  }
+
+  let cancellationCount = 0;
+  const stream = new ReadableStream<number>({
+    start(controller) {
+      controller.enqueue(1);
+    },
+    cancel() {
+      cancellationCount++;
+    }
+  });
+
+  for await (const value of makeStreamIterator(stream, {_streamReadAhead: true})) {
+    t.equal(value, 1, 'reads the first value');
+    break;
+  }
+
+  t.equal(cancellationCount, 1, 'cancels the unfinished stream');
+  t.notOk(stream.locked, 'releases the reader lock');
+  t.end();
+});
+
+test('Parquet makeStreamIterator#unlocks after natural completion', async t => {
+  if (!isBrowser) {
+    t.comment('Browser-only stream lock behavior');
+    t.end();
+    return;
+  }
+
+  const stream = new ReadableStream<number>({
+    start(controller) {
+      controller.enqueue(1);
+      controller.close();
+    }
+  });
+
+  t.deepEqual(await collectValues(makeStreamIterator(stream)), [1], 'reads every value');
+  t.notOk(stream.locked, 'releases the reader lock');
+  t.end();
+});
+
+async function collectValues<T>(values: AsyncIterable<T>): Promise<T[]> {
+  const collectedValues: T[] = [];
+  for await (const value of values) {
+    collectedValues.push(value);
+  }
+  return collectedValues;
+}

--- a/modules/parquet/test/parquet-arrow-writer.spec.ts
+++ b/modules/parquet/test/parquet-arrow-writer.spec.ts
@@ -19,6 +19,16 @@ test('ParquetWriter#writer objects', (t) => {
   t.end();
 });
 
+test('ParquetSource#public exports', (t) => {
+  t.ok(parquet.ParquetSourceLoader, 'root exports ParquetSourceLoader');
+  t.ok(parquet.ParquetSource, 'root exports ParquetSource');
+  t.ok(bundledParquet.ParquetSourceLoader, 'bundled entry point exports ParquetSourceLoader');
+  t.ok(bundledParquet.ParquetSource, 'bundled entry point exports ParquetSource');
+  t.ok(unbundledParquet.ParquetSourceLoader, 'unbundled entry point exports ParquetSourceLoader');
+  t.ok(unbundledParquet.ParquetSource, 'unbundled entry point exports ParquetSource');
+  t.end();
+});
+
 test('ParquetWriter#removed Arrow variant exports are absent', (t) => {
   t.notOk('ParquetArrowLoader' in parquet, 'root does not export ParquetArrowLoader');
   t.notOk('ParquetArrowWorkerLoader' in parquet, 'root does not export ParquetArrowWorkerLoader');

--- a/modules/parquet/test/parquet-source-loader.spec.ts
+++ b/modules/parquet/test/parquet-source-loader.spec.ts
@@ -1,0 +1,198 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'tape-promise/tape';
+import {fetchFile, load} from '@loaders.gl/core';
+import {
+  ParquetSource,
+  ParquetSourceLoader,
+  type ParquetSourceBatch
+} from '@loaders.gl/parquet';
+
+const FRUITS_URL = '@loaders.gl/parquet/test/data/fruits.parquet';
+
+test('ParquetSourceLoader#create reusable source with cached metadata', async t => {
+  const source = await createParquetSource();
+
+  t.ok(source instanceof ParquetSource, 'load returns a ParquetSource');
+
+  const metadata = await source.getMetadata();
+  const secondMetadata = await source.getMetadata();
+  const schema = await source.getSchema();
+
+  t.equal(secondMetadata, metadata, 'reuses the cached metadata object');
+  t.equal(schema, metadata.schema, 'reuses the cached schema object');
+  t.equal(metadata.rowCount, 40_000, 'reports total row count');
+  t.equal(metadata.rowGroups.length, 10, 'reports every row group');
+  t.equal(metadata.rowGroups[0].rowOffset, 0, 'first row group starts at row zero');
+  t.equal(metadata.rowGroups[1].rowOffset, 4_096, 'row offsets are cumulative');
+  t.equal(metadata.rowGroups[9].rowOffset, 36_864, 'last row-group offset is correct');
+  t.equal(metadata.rowGroups[9].rowCount, 3_136, 'last row-group size is correct');
+  t.ok(metadata.rowGroups[0].compressedSize > 0, 'reports compressed row-group size');
+  t.ok(metadata.rowGroups[0].uncompressedSize > 0, 'reports uncompressed row-group size');
+  t.ok(
+    metadata.rowGroups[0].columns.some(column => column.path.join('.') === 'name'),
+    'reports column paths'
+  );
+  t.ok(schema.fields.some(field => field.name === 'name'), 'returns the Arrow-compatible schema');
+
+  t.ok(Object.isFrozen(metadata), 'freezes the cached metadata object');
+  t.ok(Object.isFrozen(metadata.rowGroups), 'freezes the cached row-group list');
+  t.throws(
+    () => Array.prototype.reverse.call(metadata.rowGroups),
+    /read only|Cannot assign/i,
+    'prevents callers from reordering canonical row-group metadata'
+  );
+
+  await source.close();
+  await source.close();
+  await t.rejects(source.getMetadata(), /ParquetSource is closed/, 'operations fail after close');
+  t.end();
+});
+
+test('ParquetSource#preserves opaque WASM inputs by identity', async t => {
+  const wasmUrl = Promise.resolve(new URL('https://example.com/parquet_wasm_bg.wasm'));
+  const source = new ParquetSource(new Blob(), {parquet: {wasmUrl}});
+
+  t.equal(source.options.parquet.wasmUrl, wasmUrl, 'does not recursively merge the WASM input');
+
+  await source.close();
+  t.end();
+});
+
+test('ParquetSource#read selects row groups and columns with exact provenance', async t => {
+  const source = await createParquetSource();
+  const batches = await collectBatches(
+    source.read({
+      rowGroups: [1, 9],
+      columns: ['name', 'price'],
+      batchSize: 1_000,
+      concurrency: 1
+    })
+  );
+
+  t.equal(
+    batches.reduce((rowCount, batch) => rowCount + batch.length, 0),
+    7_232,
+    'returns only selected row groups'
+  );
+  t.deepEqual(
+    Array.from(new Set(batches.map(batch => batch.metadata.rowGroupIndex))),
+    [1, 9],
+    'preserves requested row-group order'
+  );
+
+  const firstBatchByRowGroup = new Map<number, ParquetSourceBatch>();
+  const nextOffsetByRowGroup = new Map<number, number>();
+  for (const batch of batches) {
+    const metadata = batch.metadata;
+    firstBatchByRowGroup.set(metadata.rowGroupIndex, firstBatchByRowGroup.get(metadata.rowGroupIndex) || batch);
+    t.equal(
+      metadata.rowGroupRowOffset,
+      nextOffsetByRowGroup.get(metadata.rowGroupIndex) || 0,
+      'row-group-relative offsets are contiguous'
+    );
+    t.equal(
+      metadata.rowOffset,
+      (metadata.rowGroupIndex === 1 ? 4_096 : 36_864) + metadata.rowGroupRowOffset,
+      'absolute source row offset is correct'
+    );
+    t.deepEqual(
+      batch.schema?.fields.map(field => field.name),
+      ['name', 'price'],
+      'projects only requested columns'
+    );
+    t.equal(batch.data.numRows, batch.length, 'Arrow table length matches batch length');
+    nextOffsetByRowGroup.set(metadata.rowGroupIndex, metadata.rowGroupRowOffset + batch.length);
+  }
+
+  t.equal(firstBatchByRowGroup.get(1)?.metadata.rowOffset, 4_096, 'group 1 provenance starts at 4,096');
+  t.equal(firstBatchByRowGroup.get(9)?.metadata.rowOffset, 36_864, 'group 9 provenance starts at 36,864');
+
+  await source.close();
+  t.end();
+});
+
+test('ParquetSource#read snapshots mutable selections before yielding', async t => {
+  const source = await createParquetSource();
+  const rowGroups = [0, 1];
+  const columns = ['name'];
+  const iterator = source.read({rowGroups, columns, batchSize: 5_000})[Symbol.asyncIterator]();
+  const batches: ParquetSourceBatch[] = [];
+
+  const firstResult = await iterator.next();
+  if (firstResult.value) {
+    batches.push(firstResult.value);
+  }
+  rowGroups[1] = 9;
+  columns[0] = 'price';
+
+  for (let result = await iterator.next(); !result.done; result = await iterator.next()) {
+    batches.push(result.value);
+  }
+
+  t.deepEqual(
+    batches.map(batch => batch.metadata.rowGroupIndex),
+    [0, 1],
+    'caller mutation does not change the selected row groups'
+  );
+  t.ok(
+    batches.every(batch => batch.schema?.fields[0]?.name === 'name'),
+    'caller mutation does not change the projected columns'
+  );
+
+  await source.close();
+  t.end();
+});
+
+test('ParquetSource#read validates row-group selections and supports early return', async t => {
+  const source = await createParquetSource();
+
+  t.deepEqual(await collectBatches(source.read({rowGroups: []})), [], 'empty selection yields no batches');
+  await t.rejects(
+    collectBatches(source.read({rowGroups: [10]})),
+    /row group index 10 is out of range/,
+    'rejects out-of-range row groups'
+  );
+  await t.rejects(
+    collectBatches(source.read({rowGroups: [1, 1]})),
+    /row group index 1 is duplicated/,
+    'rejects duplicate row groups'
+  );
+
+  const iterator = source.read({rowGroups: [0], batchSize: 100})[Symbol.asyncIterator]();
+  const firstResult = await iterator.next();
+  t.equal(firstResult.value?.metadata.rowOffset, 0, 'first early-return batch has provenance');
+  await t.rejects(
+    source.close(),
+    /cannot close while a read is active/,
+    'close rejects instead of deadlocking behind a paused read'
+  );
+  await t.rejects(
+    collectBatches(source.read({rowGroups: [1]})),
+    /already has an active read/,
+    'a second read rejects instead of queueing behind a paused read'
+  );
+  await iterator.return?.();
+
+  await source.close();
+  t.pass('source closes after an early iterator return');
+  t.end();
+});
+
+async function createParquetSource(): Promise<ParquetSource> {
+  const response = await fetchFile(FRUITS_URL);
+  const blob = await response.blob();
+  return await load(blob, ParquetSourceLoader);
+}
+
+async function collectBatches(
+  batches: AsyncIterable<ParquetSourceBatch>
+): Promise<ParquetSourceBatch[]> {
+  const collectedBatches: ParquetSourceBatch[] = [];
+  for await (const batch of batches) {
+    collectedBatches.push(batch);
+  }
+  return collectedBatches;
+}


### PR DESCRIPTION
## Goals

- Establish a reusable Parquet source foundation for large, selective datasets.
- Cache schema and footer metadata once, then read chosen row groups and columns as Arrow batches.
- Make streamed reads safe to stop early and give every batch exact source-row provenance.
- Partially addresses #3525.

## Changes

- Adds `ParquetSourceLoader` and `ParquetSource` for URL and Blob inputs.
- Adds lazy, cached schema/footer access through `getSchema()` and `getMetadata()`.
- Exposes immutable row-group and column-chunk metadata: row counts, row offsets, byte offsets, encodings, compression, and compressed/uncompressed sizes.
- Adds selective `read({rowGroups, columns, batchSize, concurrency})` with required row-group and source-row provenance on every Arrow batch.
- Snapshots read selections, rejects overlapping reads explicitly, and provides idempotent deterministic `close()`.
- Preserves opaque WASM inputs and makes failed WASM initialization retryable.
- Fixes browser stream iteration so read errors propagate, early return cancels, read-ahead rejection is observed, and reader locks are always released.
- Exports the source from root, bundled, and unbundled entry points and adds API docs/release notes.

## Why this foundation

The existing Parquet loader is optimized for one-shot loads. Interactive large-data applications need to inspect a footer once and issue repeated selective reads without reopening the file. The existing browser stream adapter also swallowed read failures and did not reliably cancel or unlock on early return, which made reusable source lifecycle management unsafe.

## Deliberately deferred

- Worker-backed decoding and transferable Arrow buffers.
- Custom range transport, `AbortSignal`, ETag/Last-Modified validation, and shared range scheduling.
- Download/request/network/decode telemetry.
- Min/max/null statistics, which parquet-wasm 0.7.1 does not expose.
- A bundler-resolved/self-hosted WASM default.
- Generic core routing through `ReadableFile`.

These remain follow-ups in #3525.

## Verification

- `env -u YARN_NO_PROXY yarn install --immutable`
- `env -u YARN_NO_PROXY yarn lint fix`
- `env -u YARN_NO_PROXY yarn build`
- `env -u YARN_NO_PROXY yarn test-node` — 1,719 passed, 81 skipped
- `env -u YARN_NO_PROXY yarn test-headless` — 1,722 passed, 60 skipped
- `cd website && env -u YARN_NO_PROXY yarn build`

The website build succeeds with the repository's existing Docusaurus/third-party bundling warnings.