### PR TITLE
feat(parquet): stream selective source batches

### DIFF
--- a/docs/modules/parquet/api-reference/parquet-source-loader.md
+++ b/docs/modules/parquet/api-reference/parquet-source-loader.md
@@ -6,9 +6,10 @@
   <img src="https://img.shields.io/badge/Status-Experimental-orange.svg?style=flat-square" alt="Status: Experimental" />
 </p>
 
-`ParquetSourceLoader` creates a reusable `ParquetSource` for selective access to a Parquet file.
-The source opens the file lazily, caches its schema and footer metadata, and can stream selected row
-groups and columns as Arrow batches without reopening the file for each read.
+`ParquetSourceLoader` creates a reusable `ParquetSource` for metadata, schema, and selective Arrow
+batch access without downloading an entire remote Parquet object. The source uses bounded HTTP byte
+ranges, decodes the footer once, and shares the resulting metadata and schema cache across calls and
+reads.
 
 ## Usage
 
@@ -16,22 +17,25 @@ groups and columns as Arrow batches without reopening the file for each read.
 import {load} from '@loaders.gl/core';
 import {ParquetSourceLoader} from '@loaders.gl/parquet';
 
+const abortController = new AbortController();
 const source = await load(
   'https://example.com/trips.parquet',
   ParquetSourceLoader,
-  {}
+  {parquet: {headers: {Authorization: 'Bearer token'}}}
 );
 
 try {
   const metadata = await source.getMetadata();
-  console.log(metadata.rowCount, metadata.rowGroups.length);
+  const schema = await source.getSchema();
 
   for await (const batch of source.read({
-    rowGroups: [2, 3],
-    columns: ['pickup_longitude', 'pickup_latitude'],
-    batchSize: 65_536
+    rowGroups: [4, 7, 8],
+    columns: ['x', 'y', 'source_id'],
+    batchSize: 524_288,
+    concurrency: 2,
+    signal: abortController.signal
   })) {
-    console.log(batch.data, batch.metadata);
+    console.log(schema, metadata.rowCount, batch.rowOffset, batch.data);
   }
 } finally {
   await source.close();
@@ -39,8 +43,8 @@ try {
 ```
 
 Both URL and `Blob` inputs are supported. The root loader is metadata-only; async `load()` imports its
-runtime implementation from the package's `parquet-source-loader` subpath. File access and WASM
-initialization begin when `getSchema()`, `getMetadata()`, or `read()` is first called.
+runtime implementation from the package's `parquet-source-loader` subpath. File access begins when
+`getSchema()`, `getMetadata()`, or `read()` is first called.
 
 Applications that need synchronous `createDataSource()` can import the runtime loader explicitly:
 
@@ -53,71 +57,79 @@ const source = createDataSource(url, [ParquetSourceLoader], {});
 
 ## API
 
-### `getSchema(): Promise<Schema>`
+### `getSchema(options?): Promise<Schema>`
 
 Returns the cached Arrow-compatible loaders.gl schema. Compatible GeoParquet metadata is normalized
 to GeoArrow field metadata in the same way as Arrow output from `ParquetLoader`.
 
-### `getMetadata(): Promise<ParquetSourceMetadata>`
+### `getMetadata(options?): Promise<ParquetSourceMetadata>`
 
-Returns cached, plain JavaScript metadata copied from the Parquet footer:
+Returns cached plain JavaScript metadata copied from the Parquet footer:
 
-- `schema`: Arrow-compatible loaders.gl schema.
-- `version`: Parquet format version.
-- `rowCount`: total file row count.
-- `createdBy`: optional writer identifier.
-- `keyValueMetadata`: file-level key/value metadata.
-- `rowGroups`: row count, absolute source-row offset, compressed and uncompressed size, and column
-  chunks for every row group.
+- file byte length, format version, writer, and row count;
+- key/value footer metadata;
+- row counts, absolute row offsets, and compressed/uncompressed byte lengths for each row group;
+- column path, compression, encodings, value count, physical range, byte lengths, and page offsets
+  for each column chunk; and
+- `ETag` or `Last-Modified` validators captured from remote objects.
 
-Each column chunk includes its nested `path`, optional `filePath`, `fileOffset`, value count,
-compression and encoding names, and compressed and uncompressed size. `fileOffset` is a `bigint`.
+Pass `{formatSpecificMetadata: true}` to include the decoded Parquet Thrift footer. Both metadata and
+schema objects are reused for the lifetime of the source.
 
-The returned schema and metadata objects are reused for the lifetime of the source.
+### `read(options?): AsyncIterable<ParquetSourceBatch>`
 
-### `read(options?: ParquetSourceReadOptions): AsyncIterable<ParquetSourceBatch>`
+Returns Arrow table batches. `rowGroups` controls which row groups are fetched and their output
+order. `columns` prevents unselected column chunks from being requested or decoded. Both selections
+are validated against the cached footer before row data is read.
 
-Streams Arrow batches for the selected row groups and columns. Omitting `rowGroups` reads every row
-group in file order. Explicit row-group indexes are read in the supplied order and must be unique and
-in range.
+Every batch includes provenance as top-level properties and in `batch.metadata`:
 
-Each batch includes provenance in `batch.metadata`:
-
-| Field | Description |
+| Property | Description |
 | --- | --- |
-| `sourceId` | Resolved URL, file name, or stable Blob label. |
-| `rowGroupIndex` | Zero-based source row-group index. |
-| `rowOffset` | Absolute offset of the first batch row in the source file. |
-| `rowGroupRowOffset` | Offset of the first batch row within its row group. |
+| `sourceId` / `source` | Source URL, file name, or stable Blob label. |
+| `sourceUrl` | Source URL when available. |
+| `rowGroupIndex` | Zero-based row-group index in the source file. |
+| `rowOffset` | Absolute source-row offset of the first batch row. |
+| `rowGroupRowOffset` | Offset of the first batch row within the row group. |
+| `rowCount` | Number of rows in the batch. |
+
+Rows are yielded in the requested row-group order even when `concurrency` allows multiple groups to
+decode at once. Ending iteration early, aborting `signal`, or calling `close()` cancels outstanding
+range requests. Network and decode errors are rethrown by the iterator.
 
 ### `close(): Promise<void>`
 
-Releases the cached WASM file handle and prevents additional operations. Calling `close()` more than
-once is safe. A source supports one active `read()` at a time; finish or cancel that iterator before
-starting another read or calling `close()`. Overlapping operations reject instead of waiting behind a
-paused consumer.
+Aborts active requests, closes the range-backed file, and permanently closes the source. Calling
+`close()` more than once is safe.
 
 ## Options
 
-Source defaults are configured under `parquet` when the source is created. `read()` accepts the first
-four options again and uses them to override the source defaults for that read.
+Source defaults are configured under `parquet`; `read()` options override those defaults for an
+individual read.
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| `parquet.rowGroups` | `number[]` | all row groups | Row-group indexes to read. |
-| `parquet.columns` | `string[]` | all columns | Column paths to project. |
-| `parquet.batchSize` | `number` | backend default | Target number of rows per Arrow batch. |
-| `parquet.concurrency` | `number` | backend default | Concurrent reads used by `parquet-wasm`. |
-| `parquet.wasmUrl` | `ParquetWasm.InitInput \| Promise<ParquetWasm.InitInput>` | external URL | Overrides the `parquet-wasm` binary location. |
+| `parquet.headers` | `HeadersInit` | `undefined` | Headers forwarded to all remote Parquet requests. |
+| `parquet.preserveBinary` | `boolean` | `false` | Preserves decoded binary values as byte arrays. |
+| `parquet.rowGroups` / `read.rowGroups` | `number[]` | all row groups | Row-group indexes to fetch, in output order. |
+| `parquet.columns` / `read.columns` | `string[]` | all columns | Top-level columns to fetch and decode. |
+| `parquet.batchSize` / `read.batchSize` | `number` | one row group | Maximum rows per emitted batch. |
+| `parquet.concurrency` / `read.concurrency` | `number` | `1` | Maximum row groups decoded concurrently. |
+| `read.signal` | `AbortSignal` | `undefined` | Cancels this read and its outstanding ranges. |
+| `rangeRequests.scheduler` | `RangeRequestScheduler` | per-source scheduler | Reuses a shared loaders.gl range scheduler. |
+| `rangeRequests.batchDelayMs` | `number` | `0` | Delay before coalescing queued ranges. |
+| `rangeRequests.maxGapBytes` | `number` | `0` | Maximum gap eligible for range coalescing. |
+| `rangeRequests.rangeExpansionBytes` | `number` | `0` | Maximum overfetch used to combine nearby ranges. |
+| `rangeRequests.maxMergedBytes` | `number` | scheduler default | Maximum size of one merged transport range. |
+| `rangeRequests.stats` | `Stats` | scheduler default | probe.gl range-request counters. |
+| `rangeRequests.onEvent` | `(event) => void` | `undefined` | Range scheduling diagnostic callback. |
 
 ## Current limitations
 
 - Decoding runs on the caller thread; worker-backed decoding and transferable Arrow buffers are not
   implemented yet.
-- URL and Blob access use the transport built into `parquet-wasm`. A custom fetch or range-request
-  transport, `AbortSignal`, and ETag/Last-Modified consistency checks are not exposed yet. Remote
-  reads depend on the server's CORS and byte-range behavior.
-- The default WASM binary is loaded from an external URL. Set `parquet.wasmUrl` to self-host the
-  binary; a bundler-resolved packaged default is not implemented yet.
-- Downloaded-byte, request-count, network-time, and decode-time telemetry are not reported yet.
+- The TypeScript decoder temporarily materializes object rows before creating Arrow batches. A
+  following tranche will decode directly into typed columns without changing the `read()` API.
+- Downloaded-byte, request-count, network-time, and decode-time telemetry are not yet attached to
+  batches.
 - Row-group and column-chunk sizes and offsets are available, but min/max/null statistics are not.

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -86,7 +86,7 @@ Release Date: 2026
 
 **@loaders.gl/parquet**
 
-- [`ParquetSourceLoader`](/docs/modules/parquet/api-reference/parquet-source-loader) NEW - reuses cached schema and footer metadata while streaming selected row groups and columns as Arrow batches with source-row provenance.
+- [`ParquetSourceLoader`](/docs/modules/parquet/api-reference/parquet-source-loader) NEW - adds reusable range-backed Parquet metadata and selective row-group/column reads as cancellable Arrow batches with source provenance and object-version validation. Its lightweight root export dynamically preloads the runtime implementation.
 - [`ParquetJSLoader`](/docs/modules/parquet/api-reference/parquet-js-loader) and [`ParquetJSWriter`](/docs/modules/parquet/api-reference/parquet-js-writer) NEW - add the experimental parquetjs plain-row and plain-table APIs.
 - `parquet.shape` on [`ParquetLoader`](/docs/modules/parquet/api-reference/parquet-loader) is now documented for selecting object-row or Arrow output from the canonical wasm-backed loader.
 

--- a/modules/loader-utils/src/lib/files/blob-file.ts
+++ b/modules/loader-utils/src/lib/files/blob-file.ts
@@ -30,10 +30,16 @@ export class BlobFile implements ReadableFile {
     };
   }
 
-  async read(start?: number | bigint, length?: number): Promise<ArrayBuffer> {
+  async read(start?: number | bigint, length?: number, signal?: AbortSignal): Promise<ArrayBuffer> {
+    if (signal?.aborted) {
+      throw new Error('Request aborted');
+    }
     const arrayBuffer = await this.handle
       .slice(Number(start), Number(start) + Number(length))
       .arrayBuffer();
+    if (signal?.aborted) {
+      throw new Error('Request aborted');
+    }
     return arrayBuffer;
   }
 }

--- a/modules/loader-utils/src/lib/files/file.ts
+++ b/modules/loader-utils/src/lib/files/file.ts
@@ -19,7 +19,7 @@ export interface ReadableFile {
   readonly url: string;
 
   /** Read data */
-  read(start?: number | bigint, length?: number): Promise<ArrayBuffer>;
+  read(start?: number | bigint, length?: number, signal?: AbortSignal): Promise<ArrayBuffer>;
   /** Read data */
   fetchRange?(offset: number | bigint, length: number, signal?: AbortSignal): Promise<Response>;
   /** Get information about file */

--- a/modules/parquet/package.json
+++ b/modules/parquet/package.json
@@ -74,6 +74,7 @@
     "@loaders.gl/gis": "5.0.0-alpha.1",
     "@loaders.gl/loader-utils": "5.0.0-alpha.1",
     "@loaders.gl/schema": "5.0.0-alpha.1",
+    "@loaders.gl/schema-utils": "5.0.0-alpha.1",
     "@loaders.gl/wkt": "5.0.0-alpha.1",
     "@probe.gl/log": "^4.1.1",
     "async-mutex": "^0.2.2",

--- a/modules/parquet/src/index.ts
+++ b/modules/parquet/src/index.ts
@@ -13,13 +13,19 @@ export {ParquetJSLoader} from './parquet-js-loader';
 
 export {ParquetSourceLoader} from './parquet-source-loader-types';
 export type {
-  ParquetSourceLoaderOptions,
-  ParquetSourceReadOptions,
-  ParquetSourceMetadata,
-  ParquetRowGroupMetadata,
-  ParquetColumnChunkMetadata,
+  ParquetBatch,
   ParquetBatchMetadata,
-  ParquetSourceBatch
+  ParquetBatchProvenance,
+  ParquetColumnChunkMetadata,
+  ParquetMetadataRequestOptions,
+  ParquetObjectVersion,
+  ParquetRangeRequestOptions,
+  ParquetReadOptions,
+  ParquetRowGroupMetadata,
+  ParquetSourceBatch,
+  ParquetSourceLoaderOptions,
+  ParquetSourceMetadata,
+  ParquetSourceReadOptions
 } from './parquet-source-types';
 
 export {ParquetWriter} from './parquet-writer';

--- a/modules/parquet/src/lib/sources/parquet-range-file.ts
+++ b/modules/parquet/src/lib/sources/parquet-range-file.ts
@@ -1,0 +1,299 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {ReadableFile, Stat} from '@loaders.gl/loader-utils';
+import {RangeRequestScheduler} from '@loaders.gl/loader-utils';
+
+import type {ParquetObjectVersion, ParquetRangeRequestOptions} from '../../parquet-source-types';
+
+type FetchLike = (url: string, options?: RequestInit) => Promise<Response>;
+
+type ParquetRangeFileOptions = {
+  fetch: FetchLike;
+  headers?: HeadersInit;
+  rangeRequests?: ParquetRangeRequestOptions;
+};
+
+type ContentRange = {
+  start: number;
+  end: number;
+  total: number;
+};
+
+/** Strict HTTP range-backed file with Parquet object-version validation. */
+export class ParquetRangeFile implements ReadableFile {
+  /** URL used as the file handle. */
+  readonly handle: string;
+  /** URL of the remote Parquet object. */
+  readonly url: string;
+
+  /** Fetch implementation inherited from source loader options. */
+  private readonly fetch: FetchLike;
+  /** Headers inherited from source loader options. */
+  private readonly headers?: HeadersInit;
+  /** Scheduler used to coalesce later row-group reads. */
+  private readonly scheduler: RangeRequestScheduler;
+  /** Aborts all active requests when the file is closed. */
+  private readonly closeController = new AbortController();
+  /** Exact ranges already loaded during initialization. */
+  private readonly cache = new Map<string, ArrayBuffer>();
+  /** Remote object byte length discovered from `Content-Range`. */
+  private fileByteLength = 0;
+  /** Object validators captured by the opening range request. */
+  private version: ParquetObjectVersion = {};
+  /** Whether `close()` has been called. */
+  private closed = false;
+
+  /** Creates an unopened remote Parquet file. Use `open()` before reading it. */
+  constructor(url: string, options: ParquetRangeFileOptions) {
+    this.handle = url;
+    this.url = url;
+    this.fetch = options.fetch;
+    this.headers = options.headers;
+    this.scheduler =
+      options.rangeRequests?.scheduler ||
+      new RangeRequestScheduler({
+        batchDelayMs: options.rangeRequests?.batchDelayMs ?? 0,
+        maxGapBytes: options.rangeRequests?.maxGapBytes,
+        rangeExpansionBytes: options.rangeRequests?.rangeExpansionBytes,
+        maxMergedBytes: options.rangeRequests?.maxMergedBytes,
+        stats: options.rangeRequests?.stats,
+        onEvent: options.rangeRequests?.onEvent
+      });
+  }
+
+  /** Total remote object byte length after `open()`. */
+  get size(): number {
+    return this.fileByteLength;
+  }
+
+  /** Total remote object byte length as a bigint after `open()`. */
+  get bigsize(): bigint {
+    return BigInt(this.fileByteLength);
+  }
+
+  /** Immutable copy of the HTTP validators captured when the object was opened. */
+  get objectVersion(): ParquetObjectVersion {
+    return {...this.version};
+  }
+
+  /** Opens the object with a four-byte range probe and caches the Parquet header. */
+  async open(signal?: AbortSignal): Promise<this> {
+    this.assertOpen();
+    const result = await this.fetchExactRange(0, 4, signal, false);
+    this.fileByteLength = result.contentRange.total;
+    this.version = getObjectVersion(result.response.headers);
+    this.cache.set(getRangeKey(0, 4), result.arrayBuffer);
+    return this;
+  }
+
+  /** Reads an exact byte range without downloading the complete object. */
+  async read(
+    start: number | bigint = 0,
+    length: number = this.size - Number(start),
+    signal?: AbortSignal
+  ): Promise<ArrayBuffer> {
+    this.assertOpen();
+    const offset = Number(start);
+    assertValidRange(offset, length, this.size);
+    if (length === 0) {
+      return new ArrayBuffer(0);
+    }
+
+    const cached = this.cache.get(getRangeKey(offset, length));
+    if (cached) {
+      return cached.slice(0);
+    }
+
+    const abortContext = createCombinedAbortSignal(signal, this.closeController.signal);
+    try {
+      return await this.scheduler.scheduleRequest({
+        sourceId: getVersionedSourceId(this.url, this.version),
+        offset,
+        length,
+        signal: abortContext.signal,
+        fetchRange: async (transportOffset, transportLength, transportSignal) => {
+          const result = await this.fetchExactRange(
+            transportOffset,
+            transportLength,
+            transportSignal,
+            true
+          );
+          return {
+            arrayBuffer: result.arrayBuffer,
+            status: result.response.status,
+            transportBytes: result.arrayBuffer.byteLength
+          };
+        }
+      });
+    } finally {
+      abortContext.dispose();
+    }
+  }
+
+  /** Returns file length information without another HTTP request. */
+  async stat(): Promise<Stat> {
+    this.assertOpen();
+    return {size: this.size, bigsize: this.bigsize, isDirectory: false};
+  }
+
+  /** Aborts active requests and prevents future reads. */
+  async close(): Promise<void> {
+    if (!this.closed) {
+      this.closed = true;
+      this.closeController.abort();
+      this.cache.clear();
+    }
+  }
+
+  /** Fetches and validates one exact HTTP byte range. */
+  private async fetchExactRange(
+    offset: number,
+    length: number,
+    signal: AbortSignal | undefined,
+    validateVersion: boolean
+  ): Promise<{response: Response; arrayBuffer: ArrayBuffer; contentRange: ContentRange}> {
+    const abortContext = createCombinedAbortSignal(signal, this.closeController.signal);
+    try {
+      const response = await this.fetch(this.url, {
+        headers: createRangeHeaders(this.headers, offset, length, validateVersion && this.version),
+        signal: abortContext.signal
+      });
+
+      if (response.status === 412) {
+        throw new Error('Parquet object changed while it was being read');
+      }
+      if (response.status !== 206) {
+        await response.body?.cancel().catch(() => {});
+        throw new Error(
+          `ParquetSource requires HTTP byte ranges (expected 206, received ${response.status})`
+        );
+      }
+
+      const contentRange = parseContentRange(response.headers.get('Content-Range'));
+      if (
+        contentRange.start !== offset ||
+        contentRange.end !== offset + length - 1 ||
+        (this.fileByteLength > 0 && contentRange.total !== this.fileByteLength)
+      ) {
+        await response.body?.cancel().catch(() => {});
+        throw new Error('Parquet range response does not match the requested object range');
+      }
+
+      if (validateVersion) {
+        assertObjectVersion(this.version, getObjectVersion(response.headers));
+      }
+
+      const arrayBuffer = await response.arrayBuffer();
+      if (arrayBuffer.byteLength !== length) {
+        throw new Error(
+          `Parquet range response returned ${arrayBuffer.byteLength} bytes; expected ${length}`
+        );
+      }
+      return {response, arrayBuffer, contentRange};
+    } finally {
+      abortContext.dispose();
+    }
+  }
+
+  /** Throws when the file has already been closed. */
+  private assertOpen(): void {
+    if (this.closed) {
+      throw new Error('Parquet source is closed');
+    }
+  }
+}
+
+/** Validates a requested range against the known object byte length. */
+function assertValidRange(offset: number, length: number, fileByteLength: number): void {
+  if (!Number.isSafeInteger(offset) || !Number.isSafeInteger(length) || offset < 0 || length < 0) {
+    throw new Error('Parquet byte range must use non-negative safe integers');
+  }
+  if (offset + length > fileByteLength) {
+    throw new Error('Parquet byte range exceeds the object length');
+  }
+}
+
+/** Creates request headers for one byte range and optional object precondition. */
+function createRangeHeaders(
+  defaultHeaders: HeadersInit | undefined,
+  offset: number,
+  length: number,
+  version: ParquetObjectVersion | false
+): Headers {
+  const headers = new Headers(defaultHeaders);
+  headers.set('Range', `bytes=${offset}-${offset + length - 1}`);
+  if (version && version.etag && !version.etag.startsWith('W/')) {
+    headers.set('If-Match', version.etag);
+  } else if (version && version.lastModified) {
+    headers.set('If-Unmodified-Since', version.lastModified);
+  }
+  return headers;
+}
+
+/** Parses a satisfied single-range `Content-Range` header. */
+function parseContentRange(value: string | null): ContentRange {
+  const match = value?.match(/^bytes (\d+)-(\d+)\/(\d+)$/);
+  if (!match) {
+    throw new Error(`Invalid Parquet Content-Range header: ${value}`);
+  }
+  return {start: Number(match[1]), end: Number(match[2]), total: Number(match[3])};
+}
+
+/** Reads supported object validators from response headers. */
+function getObjectVersion(headers: Headers): ParquetObjectVersion {
+  const etag = headers.get('ETag') || undefined;
+  const lastModified = headers.get('Last-Modified') || undefined;
+  return {etag, lastModified};
+}
+
+/** Rejects a response that identifies a different remote object version. */
+function assertObjectVersion(expected: ParquetObjectVersion, actual: ParquetObjectVersion): void {
+  if (expected.etag && actual.etag && expected.etag !== actual.etag) {
+    throw new Error('Parquet object ETag changed while it was being read');
+  }
+  if (
+    !expected.etag &&
+    expected.lastModified &&
+    actual.lastModified &&
+    expected.lastModified !== actual.lastModified
+  ) {
+    throw new Error('Parquet object Last-Modified changed while it was being read');
+  }
+}
+
+/** Creates a cache key for one exact range. */
+function getRangeKey(offset: number, length: number): string {
+  return `${offset}:${length}`;
+}
+
+/** Creates a scheduler identity that isolates object versions. */
+function getVersionedSourceId(url: string, version: ParquetObjectVersion): string {
+  return `${url}#${version.etag || version.lastModified || 'unversioned'}`;
+}
+
+/** Combines two abort signals and returns cleanup for installed listeners. */
+function createCombinedAbortSignal(
+  firstSignal?: AbortSignal,
+  secondSignal?: AbortSignal
+): {signal: AbortSignal; dispose: () => void} {
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+  const signals = [firstSignal, secondSignal].filter(Boolean) as AbortSignal[];
+  for (const signal of signals) {
+    if (signal.aborted) {
+      controller.abort();
+      break;
+    }
+    signal.addEventListener('abort', abort, {once: true});
+  }
+  return {
+    signal: controller.signal,
+    dispose: () => {
+      for (const signal of signals) {
+        signal.removeEventListener('abort', abort);
+      }
+    }
+  };
+}

--- a/modules/parquet/src/parquet-source-loader-types.ts
+++ b/modules/parquet/src/parquet-source-loader-types.ts
@@ -4,7 +4,6 @@
 
 import type {CoreAPI, SourceLoader} from '@loaders.gl/loader-utils';
 
-import {PARQUET_WASM_URL} from './lib/constants';
 import {ParquetFormat} from './parquet-format';
 import type {ParquetSource} from './parquet-source-loader';
 import type {ParquetSourceLoaderOptions} from './parquet-source-types';
@@ -42,7 +41,14 @@ export const ParquetSourceLoader = {
       columns: undefined,
       batchSize: undefined,
       concurrency: undefined,
-      wasmUrl: PARQUET_WASM_URL
+      headers: undefined,
+      preserveBinary: false,
+      wasmUrl: undefined
+    },
+    rangeRequests: {
+      batchDelayMs: 0,
+      maxGapBytes: 0,
+      rangeExpansionBytes: 0
     }
   },
   defaultOptions: {
@@ -51,7 +57,14 @@ export const ParquetSourceLoader = {
       columns: undefined!,
       batchSize: undefined!,
       concurrency: undefined!,
-      wasmUrl: PARQUET_WASM_URL
+      headers: undefined!,
+      preserveBinary: false,
+      wasmUrl: undefined!
+    },
+    rangeRequests: {
+      batchDelayMs: 0,
+      maxGapBytes: 0,
+      rangeExpansionBytes: 0
     }
   },
   testURL: (url: string): boolean => /\.parquet(?:$|[?#])/i.test(url),

--- a/modules/parquet/src/parquet-source-loader.ts
+++ b/modules/parquet/src/parquet-source-loader.ts
@@ -2,30 +2,40 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type * as parquetWasm from 'parquet-wasm/esm/parquet_wasm.js';
-import * as arrow from 'apache-arrow';
-
-import type {CoreAPI, SourceLoader} from '@loaders.gl/loader-utils';
-import {DataSource} from '@loaders.gl/loader-utils';
+import type {CoreAPI, ReadableFile, SourceLoader} from '@loaders.gl/loader-utils';
+import {BlobFile, DataSource} from '@loaders.gl/loader-utils';
 import type {Schema} from '@loaders.gl/schema';
+import {convertTable} from '@loaders.gl/schema-utils';
 
-import {PARQUET_WASM_URL} from './lib/constants';
-import {normalizeArrowTableGeoMetadata} from './lib/geo/geospatial-metadata';
-import {loadWasm} from './lib/utils/load-wasm';
-import {makeStreamIterator} from './lib/utils/make-stream-iterator';
+import {getSchemaFromParquetReader} from './lib/parsers/get-parquet-schema';
+import {ParquetRangeFile} from './lib/sources/parquet-range-file';
 import {ParquetSourceLoader as ParquetSourceLoaderMetadata} from './parquet-source-loader-types';
 import type {
+  ParquetBatch,
   ParquetColumnChunkMetadata,
+  ParquetMetadataRequestOptions,
+  ParquetObjectVersion,
   ParquetRowGroupMetadata,
   ParquetSourceBatch,
   ParquetSourceLoaderOptions,
   ParquetSourceMetadata,
   ParquetSourceReadOptions
 } from './parquet-source-types';
+import {preloadCompressions} from './parquetjs/compression';
+import {CompressionCodec, Encoding, type FileMetaData} from './parquetjs/parquet-thrift/index';
+import {ParquetReader} from './parquetjs/parser/parquet-reader';
+import type {ParquetRow} from './parquetjs/schema/declare';
+import type {ParquetSchema} from './parquetjs/schema/schema';
 
 export type {
+  ParquetBatch,
   ParquetBatchMetadata,
+  ParquetBatchProvenance,
   ParquetColumnChunkMetadata,
+  ParquetMetadataRequestOptions,
+  ParquetObjectVersion,
+  ParquetRangeRequestOptions,
+  ParquetReadOptions,
   ParquetRowGroupMetadata,
   ParquetSourceBatch,
   ParquetSourceLoaderOptions,
@@ -33,19 +43,41 @@ export type {
   ParquetSourceReadOptions
 } from './parquet-source-types';
 
-/** Snapshotted options used internally for one read. */
-type ResolvedParquetSourceReadOptions = {
-  rowGroups?: number[];
-  columns?: string[];
-  batchSize?: number;
-  concurrency?: number;
+type ParquetSourceInitialization = {
+  /** Random-access file shared by all reads. */
+  file: ReadableFile;
+  /** TypeScript Parquet reader with a cached footer. */
+  reader: ParquetReader;
+  /** loaders.gl logical schema. */
+  schema: Schema;
+  /** TypeScript Parquet decoder schema. */
+  parquetSchema: ParquetSchema;
+  /** Decoded Thrift footer. */
+  fileMetadata: FileMetaData;
+  /** Normalized public source metadata. */
+  metadata: ParquetSourceMetadata;
 };
 
-type ParquetSourceState = {
-  parquetFile: parquetWasm.ParquetFile;
-  metadata: ParquetSourceMetadata;
-  schemaMetadata: Map<string, string>;
+type ParquetRowGroupReadResult = {
+  /** Zero-based source row-group index. */
+  rowGroupIndex: number;
+  /** Materialized rows for the selected columns. */
+  rows: ParquetRow[];
 };
+
+type SettledParquetRowGroupRead =
+  | {
+      /** Successfully decoded row group. */
+      result: ParquetRowGroupReadResult;
+      /** No error occurred. */
+      error?: never;
+    }
+  | {
+      /** Row-group read failed. */
+      error: unknown;
+      /** No result was decoded. */
+      result?: never;
+    };
 
 const {
   preload: _preloadParquetSourceLoader,
@@ -53,7 +85,7 @@ const {
   ...ParquetSourceLoaderBase
 } = ParquetSourceLoaderMetadata;
 
-/** Runtime source factory for reusable, selective access to Parquet files. */
+/** Runtime source factory for reusable, range-backed Parquet access. */
 export const ParquetSourceLoaderWithParser = {
   ...ParquetSourceLoaderBase,
   createDataSource: (
@@ -66,314 +98,493 @@ export const ParquetSourceLoaderWithParser = {
 /** Runtime Parquet source loader exposed by the explicit package subpath. */
 export {ParquetSourceLoaderWithParser as ParquetSourceLoader};
 
-/** Reusable Parquet file handle with cached footer/schema and selective Arrow reads. */
+/** Reusable Parquet source that caches footer/schema state and selectively reads byte ranges. */
 export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoaderOptions> {
-  /** Shared lazy initialization for the source file and its copied metadata. */
-  private initializationPromise: Promise<ParquetSourceState> | null = null;
-  /** Opaque WASM input preserved outside recursive option merging. */
-  private readonly wasmUrl: parquetWasm.InitInput | Promise<parquetWasm.InitInput>;
-  /** Shared promise for idempotent asynchronous cleanup. */
-  private closePromise: Promise<void> | null = null;
-  /** Whether a caller currently owns the source's single read stream. */
-  private readActive = false;
-  /** Whether this source has stopped accepting new operations. */
+  /** Shared initialization for this source instance. */
+  private initializationPromise: Promise<ParquetSourceInitialization> | null = null;
+  /** File allocated during source initialization, including while it is opening. */
+  private readableFile: ReadableFile | null = null;
+  /** Whether this source has been permanently closed. */
   private closed = false;
-  /** Whether the cached WASM file handle has been released. */
-  private freed = false;
+  /** Compression module preload shared by all selective reads. */
+  private compressionPromise: Promise<void> | null = null;
+  /** Read abort controllers used to cancel active iterators when the source closes. */
+  private activeReadControllers = new Set<AbortController>();
 
-  /** Creates a lazy Parquet source without performing I/O. */
+  /** Creates a Parquet source backed by strict URL ranges or Blob slices. */
   constructor(data: string | Blob, options: ParquetSourceLoaderOptions, coreApi?: CoreAPI) {
     const wasmUrl = options.parquet?.wasmUrl;
     super(data, options, ParquetSourceLoaderWithParser.defaultOptions, coreApi);
-
-    // mergeOptions recursively treats opaque Promise, URL, module, and buffer inputs as option
-    // bags. Preserve the caller's wasm input by identity instead.
-    this.wasmUrl = wasmUrl ?? PARQUET_WASM_URL;
-    this.options.parquet.wasmUrl = this.wasmUrl;
-  }
-
-  /** Returns the cached Arrow-compatible schema. */
-  async getSchema(): Promise<Schema> {
-    const state = await this.getState();
-    return state.metadata.schema;
-  }
-
-  /** Returns cached plain file, row-group, and column-chunk metadata. */
-  async getMetadata(): Promise<ParquetSourceMetadata> {
-    const state = await this.getState();
-    return state.metadata;
-  }
-
-  /** Streams selected row groups and columns as Arrow batches with source-row provenance. */
-  async *read(options: ParquetSourceReadOptions = {}): AsyncIterable<ParquetSourceBatch> {
-    if (this.readActive) {
-      throw new Error('ParquetSource already has an active read');
+    if (wasmUrl !== undefined) {
+      this.options.parquet.wasmUrl = wasmUrl;
     }
-    this.readActive = true;
+  }
+
+  /** Returns the cached logical schema decoded from the Parquet footer. */
+  async getSchema(options: {signal?: AbortSignal} = {}): Promise<Schema> {
+    const initialization = await this.getInitialization(options.signal);
+    return initialization.schema;
+  }
+
+  /** Returns normalized dataset, row-group, and column-chunk metadata. */
+  async getMetadata(options: ParquetMetadataRequestOptions = {}): Promise<ParquetSourceMetadata> {
+    const initialization = await this.getInitialization(options.signal);
+    if (!options.formatSpecificMetadata) {
+      return initialization.metadata;
+    }
+    return {
+      ...initialization.metadata,
+      formatSpecificMetadata: initialization.fileMetadata
+    };
+  }
+
+  /** Selectively fetches row groups and columns as ordered Arrow batches with source provenance. */
+  async *read(options: ParquetSourceReadOptions = {}): AsyncIterable<ParquetSourceBatch> {
+    const readOptions = this.getReadOptions(options);
+    const readContext = createReadAbortContext(readOptions.signal);
+    const inFlightReads = new Set<Promise<SettledParquetRowGroupRead>>();
+    this.activeReadControllers.add(readContext.abortController);
 
     try {
-      const readOptions = this.getReadOptions(options);
-      const state = await this.getState();
-      const rowGroupIndexes = getRowGroupIndexes(readOptions.rowGroups, state.metadata.rowGroups);
+      const initialization = await this.getInitialization(readContext.abortController.signal);
+      await this.getCompressionInitialization();
+      throwIfAborted(readContext.abortController.signal);
 
-      for (const rowGroupIndex of rowGroupIndexes) {
-        const rowGroupMetadata = state.metadata.rowGroups[rowGroupIndex];
-        const stream = await state.parquetFile.stream({
-          rowGroups: [rowGroupIndex],
-          columns: readOptions.columns,
-          batchSize: readOptions.batchSize,
-          concurrency: readOptions.concurrency
-        });
+      const rowGroupIndices = normalizeRowGroupIndices(
+        readOptions.rowGroups,
+        initialization.fileMetadata.row_groups.length
+      );
+      const columns = normalizeColumns(readOptions.columns, initialization.schema);
+      const columnList = columns.map(column => [column]);
+      const batchSize = normalizeBatchSize(readOptions.batchSize);
+      const concurrency = normalizeConcurrency(readOptions.concurrency);
+      const projectedSchema = projectSchema(initialization.schema, columns);
+      const scheduledReads = new Map<number, Promise<SettledParquetRowGroupRead>>();
+      let nextPositionToSchedule = 0;
 
-        let rowGroupRowOffset = 0;
-        for await (const wasmRecordBatch of makeStreamIterator<parquetWasm.RecordBatch>(stream)) {
-          const arrowTable = arrow.tableFromIPC(wasmRecordBatch.intoIPCStream());
-          const normalizedArrowTable = normalizeArrowTableGeoMetadata(
-            {shape: 'arrow-table', data: arrowTable},
-            state.schemaMetadata
+      const scheduleReads = (): void => {
+        while (
+          nextPositionToSchedule < rowGroupIndices.length &&
+          scheduledReads.size < concurrency
+        ) {
+          const position = nextPositionToSchedule++;
+          const rowGroupIndex = rowGroupIndices[position];
+          const read: Promise<SettledParquetRowGroupRead> = this.readRowGroup(
+            initialization,
+            rowGroupIndex,
+            columnList,
+            readContext.abortController.signal
+          ).then(
+            result => ({result}) as SettledParquetRowGroupRead,
+            error => ({error}) as SettledParquetRowGroupRead
           );
-          const length = normalizedArrowTable.data.numRows;
+          scheduledReads.set(position, read);
+          inFlightReads.add(read);
+          void read.then(() => inFlightReads.delete(read));
+        }
+      };
 
-          yield {
-            batchType: 'data',
-            shape: 'arrow-table',
-            schema: normalizedArrowTable.schema,
-            data: normalizedArrowTable.data,
-            length,
-            metadata: {
-              sourceId: getSourceId(this.data, this.url),
-              rowGroupIndex,
-              rowOffset: rowGroupMetadata.rowOffset + rowGroupRowOffset,
-              rowGroupRowOffset
-            }
-          };
+      scheduleReads();
+      for (let position = 0; position < rowGroupIndices.length; position++) {
+        const settledRead = await scheduledReads.get(position)!;
+        scheduledReads.delete(position);
+        scheduleReads();
+        if ('error' in settledRead) {
+          throw settledRead.error;
+        }
 
-          rowGroupRowOffset += length;
+        const {rowGroupIndex, rows} = settledRead.result;
+        const outputBatchSize = batchSize || Math.max(rows.length, 1);
+        for (
+          let rowGroupRowOffset = 0;
+          rowGroupRowOffset < rows.length;
+          rowGroupRowOffset += outputBatchSize
+        ) {
+          throwIfAborted(readContext.abortController.signal);
+          const batchRows = rows.slice(rowGroupRowOffset, rowGroupRowOffset + outputBatchSize);
+          yield createParquetBatch(
+            initialization.metadata,
+            projectedSchema,
+            rowGroupIndex,
+            rowGroupRowOffset,
+            batchRows
+          );
         }
       }
     } finally {
-      this.readActive = false;
+      readContext.abortController.abort();
+      readContext.removeSignalListener();
+      this.activeReadControllers.delete(readContext.abortController);
+      await Promise.allSettled([...inFlightReads]);
     }
   }
 
-  /** Releases the cached WASM file and prevents further operations. */
-  close(): Promise<void> {
-    if (this.closePromise) {
-      return this.closePromise;
-    }
-
-    if (this.readActive) {
-      return Promise.reject(
-        new Error('ParquetSource cannot close while a read is active; finish or cancel it first')
-      );
-    }
-    this.closed = true;
-    this.closePromise = this.releaseResources();
-    return this.closePromise;
-  }
-
-  /** Waits for initialization, if any, and releases the cached WASM file once. */
-  private async releaseResources(): Promise<void> {
-    if (this.freed) {
+  /** Closes the underlying readable file and aborts active remote requests. */
+  async close(): Promise<void> {
+    if (this.closed) {
       return;
     }
-
-    const state = await this.initializationPromise?.catch(() => null);
-    state?.parquetFile.free();
-    this.freed = true;
+    this.closed = true;
+    for (const abortController of this.activeReadControllers) {
+      abortController.abort();
+    }
+    await this.readableFile?.close();
+    const initialization = await this.initializationPromise?.catch(() => null);
+    if (initialization?.file !== this.readableFile) {
+      await initialization?.file.close();
+    }
   }
 
-  /** Lazily opens the Parquet file and copies its schema/footer into JavaScript memory. */
-  private getState(): Promise<ParquetSourceState> {
+  /** Returns cached initialization, resetting the cache when initialization fails. */
+  private getInitialization(signal?: AbortSignal): Promise<ParquetSourceInitialization> {
     if (this.closed) {
-      throw new Error('ParquetSource is closed');
+      return Promise.reject(new Error('ParquetSource is closed'));
     }
-
     if (!this.initializationPromise) {
-      const initializationPromise = this.initialize();
-      const cachedInitializationPromise = initializationPromise.catch(error => {
-        if (this.initializationPromise === cachedInitializationPromise) {
-          this.initializationPromise = null;
-        }
+      this.initializationPromise = this.initialize(signal).catch(error => {
+        this.initializationPromise = null;
         throw error;
       });
-      this.initializationPromise = cachedInitializationPromise;
     }
-
     return this.initializationPromise;
   }
 
-  /** Opens parquet-wasm and prepares plain metadata owned by this source. */
-  private async initialize(): Promise<ParquetSourceState> {
-    const wasm = await loadWasm(this.wasmUrl);
-    const parquetFile =
-      typeof this.data === 'string'
-        ? await wasm.ParquetFile.fromUrl(this.url)
-        : await wasm.ParquetFile.fromFile(this.data);
-
-    try {
-      const copiedMetadata = copyParquetMetadata(parquetFile, wasm);
-      const wasmSchema = parquetFile.schema();
-      const arrowSchemaTable = arrow.tableFromIPC(wasmSchema.intoIPCStream());
-      const normalizedArrowTable = normalizeArrowTableGeoMetadata(
-        {shape: 'arrow-table', data: arrowSchemaTable},
-        copiedMetadata.schemaMetadata
-      );
-
-      return {
-        parquetFile,
-        schemaMetadata: copiedMetadata.schemaMetadata,
-        metadata: Object.freeze({
-          ...copiedMetadata.metadata,
-          schema: normalizedArrowTable.schema
-        }) satisfies ParquetSourceMetadata
-      };
-    } catch (error) {
-      parquetFile.free();
-      throw error;
+  /** Preloads TypeScript decoder compression modules once and permits retry after failure. */
+  private getCompressionInitialization(): Promise<void> {
+    if (!this.compressionPromise) {
+      this.compressionPromise = preloadCompressions()
+        .then(() => undefined)
+        .catch(error => {
+          this.compressionPromise = null;
+          throw error;
+        });
     }
+    return this.compressionPromise;
   }
 
-  /** Merges source defaults with per-read options. */
-  private getReadOptions(options: ParquetSourceReadOptions): ResolvedParquetSourceReadOptions {
+  /** Snapshots source defaults and per-read overrides before asynchronous iteration begins. */
+  private getReadOptions(options: ParquetSourceReadOptions): ParquetSourceReadOptions {
     const rowGroups = options.rowGroups ?? this.options.parquet?.rowGroups;
     const columns = options.columns ?? this.options.parquet?.columns;
     return {
       rowGroups: rowGroups && [...rowGroups],
       columns: columns && [...columns],
       batchSize: options.batchSize ?? this.options.parquet?.batchSize,
-      concurrency: options.concurrency ?? this.options.parquet?.concurrency
+      concurrency: options.concurrency ?? this.options.parquet?.concurrency,
+      signal: options.signal
     };
   }
-}
 
-/** Copies footer wrappers into plain JavaScript values and releases their WASM handles. */
-function copyParquetMetadata(
-  parquetFile: parquetWasm.ParquetFile,
-  wasm: typeof parquetWasm
-): {
-  metadata: Omit<ParquetSourceMetadata, 'schema'>;
-  schemaMetadata: Map<string, string>;
-} {
-  const parquetMetadata = parquetFile.metadata();
-  try {
-    const fileMetadata = parquetMetadata.fileMetadata();
-    let version: number;
-    let rowCount: number;
-    let createdBy: string | undefined;
-    let schemaMetadata: Map<string, string>;
+  /** Fetches and decodes one selected row group using the cached footer and schema. */
+  private async readRowGroup(
+    initialization: ParquetSourceInitialization,
+    rowGroupIndex: number,
+    columnList: string[][],
+    signal: AbortSignal
+  ): Promise<ParquetRowGroupReadResult> {
+    const rowGroup = initialization.fileMetadata.row_groups[rowGroupIndex];
+    const decodedRowGroup = await initialization.reader.readRowGroup(
+      initialization.parquetSchema,
+      rowGroup,
+      columnList,
+      signal
+    );
+    throwIfAborted(signal);
+    const rows = initialization.parquetSchema.materializeRows(decodedRowGroup);
+    return {rowGroupIndex, rows};
+  }
+
+  /** Opens the readable file and decodes its footer and schema once. */
+  private async initialize(signal?: AbortSignal): Promise<ParquetSourceInitialization> {
+    const file = await this.openFile(signal);
     try {
-      version = fileMetadata.version();
-      rowCount = fileMetadata.numRows();
-      createdBy = fileMetadata.createdBy();
-      schemaMetadata = new Map(fileMetadata.keyValueMetadata() as Map<string, string>);
-    } finally {
-      fileMetadata.free();
-    }
-
-    const wasmRowGroups = parquetMetadata.rowGroups();
-    let rowOffset = 0;
-    let rowGroups: ParquetRowGroupMetadata[];
-    try {
-      rowGroups = wasmRowGroups.map((rowGroup, index) => {
-        const wasmColumns = rowGroup.columns();
-        let columns: ParquetColumnChunkMetadata[];
-        try {
-          columns = wasmColumns.map(column =>
-            Object.freeze({
-              path: Object.freeze(column.columnPath()),
-              filePath: column.filePath(),
-              fileOffset: column.fileOffset(),
-              valueCount: column.numValues(),
-              compression: getEnumName(wasm.Compression, column.compression()),
-              encodings: Object.freeze(
-                column.encodings().map(encoding => getEnumName(wasm.Encoding, encoding))
-              ),
-              compressedSize: column.compressedSize(),
-              uncompressedSize: column.uncompressedSize()
-            })
-          );
-        } finally {
-          freeWasmHandles(wasmColumns);
-        }
-
-        const rowCountForGroup = rowGroup.numRows();
-        const metadata: ParquetRowGroupMetadata = Object.freeze({
-          index,
-          rowOffset,
-          rowCount: rowCountForGroup,
-          compressedSize: rowGroup.compressedSize(),
-          uncompressedSize: rowGroup.totalByteSize(),
-          columns: Object.freeze(columns)
-        });
-        rowOffset += rowCountForGroup;
-        return metadata;
+      const reader = new ParquetReader(file, {
+        preserveBinary: this.options.parquet?.preserveBinary,
+        signal
       });
-    } finally {
-      freeWasmHandles(wasmRowGroups);
+      const fileMetadata = await reader.getFileMetadata();
+      const parquetSchema = await reader.getSchema();
+      const schema = await getSchemaFromParquetReader(reader);
+      const metadata = createParquetSourceMetadata(
+        this.data,
+        this.url,
+        file,
+        fileMetadata,
+        schema,
+        file instanceof ParquetRangeFile ? file.objectVersion : undefined
+      );
+      reader.props.signal = undefined;
+      return {file, reader, schema, parquetSchema, fileMetadata, metadata};
+    } catch (error) {
+      await file.close();
+      throw error;
     }
+  }
 
-    return {
-      schemaMetadata,
-      metadata: {
-        version,
-        rowCount,
-        createdBy,
-        keyValueMetadata: Object.freeze(Object.fromEntries(schemaMetadata)),
-        rowGroups: Object.freeze(rowGroups)
-      }
-    };
-  } finally {
-    parquetMetadata.free();
+  /** Opens a Blob file or probes a remote object with one bounded range request. */
+  private async openFile(signal?: AbortSignal): Promise<ReadableFile> {
+    if (typeof this.data !== 'string') {
+      this.readableFile = new BlobFile(this.data);
+      return this.readableFile;
+    }
+    const file = new ParquetRangeFile(this.url, {
+      fetch: this.fetch,
+      headers: this.options.parquet?.headers,
+      rangeRequests: this.options.rangeRequests
+    });
+    this.readableFile = file;
+    return await file.open(signal);
   }
 }
 
-/** Releases every WASM metadata wrapper, including entries not visited after an accessor error. */
-function freeWasmHandles(handles: {free(): void}[]): void {
-  for (const handle of handles) {
-    handle.free();
-  }
+/** Normalizes a decoded Parquet footer into source metadata. */
+function createParquetSourceMetadata(
+  data: string | Blob,
+  url: string,
+  file: ReadableFile,
+  fileMetadata: FileMetaData,
+  schema: Schema,
+  objectVersion?: ParquetObjectVersion
+): ParquetSourceMetadata {
+  let rowOffset = 0;
+  const rowGroups = fileMetadata.row_groups.map((rowGroup, index) => {
+    const columns = rowGroup.columns
+      .filter(columnChunk => Boolean(columnChunk.meta_data))
+      .map(columnChunk => createColumnChunkMetadata(columnChunk));
+    const normalizedRowGroup = createRowGroupMetadata(
+      index,
+      rowOffset,
+      Number(rowGroup.num_rows),
+      Number(rowGroup.total_byte_size),
+      columns
+    );
+    rowOffset += normalizedRowGroup.rowCount;
+    return normalizedRowGroup;
+  });
+
+  return Object.freeze({
+    schema,
+    name: getSourceName(data, url),
+    url: url || undefined,
+    fileByteLength: file.size,
+    version: fileMetadata.version,
+    formatVersion: fileMetadata.version,
+    createdBy: fileMetadata.created_by,
+    rowCount: Number(fileMetadata.num_rows),
+    rowGroupCount: rowGroups.length,
+    keyValueMetadata: Object.freeze(getKeyValueMetadata(fileMetadata)),
+    rowGroups: Object.freeze(rowGroups),
+    objectVersion: hasObjectVersion(objectVersion) ? Object.freeze({...objectVersion}) : undefined
+  });
 }
 
-/** Converts a numeric WASM enum value into a stable string. */
-function getEnumName(enumValues: object, value: unknown): string {
-  const enumName = (enumValues as Record<number, string>)[Number(value)];
-  return enumName || String(value);
+/** Normalizes a decoded Parquet column chunk. */
+function createColumnChunkMetadata(
+  columnChunk: FileMetaData['row_groups'][number]['columns'][number]
+): ParquetColumnChunkMetadata {
+  const columnMetadata = columnChunk.meta_data!;
+  const dataPageOffset = Number(columnMetadata.data_page_offset);
+  const dictionaryPageOffset =
+    columnMetadata.dictionary_page_offset === undefined
+      ? undefined
+      : Number(columnMetadata.dictionary_page_offset);
+  const compressedByteLength = Number(columnMetadata.total_compressed_size);
+  const uncompressedByteLength = Number(columnMetadata.total_uncompressed_size);
+  return Object.freeze({
+    path: Object.freeze([...columnMetadata.path_in_schema]),
+    filePath: columnChunk.file_path || undefined,
+    compression: CompressionCodec[columnMetadata.codec] || String(columnMetadata.codec),
+    encodings: Object.freeze(
+      columnMetadata.encodings.map(encoding => Encoding[encoding] || String(encoding))
+    ),
+    valueCount: Number(columnMetadata.num_values),
+    fileOffset: Math.min(
+      dataPageOffset,
+      dictionaryPageOffset && dictionaryPageOffset > 0 ? dictionaryPageOffset : dataPageOffset
+    ),
+    compressedByteLength,
+    compressedSize: compressedByteLength,
+    uncompressedByteLength,
+    uncompressedSize: uncompressedByteLength,
+    dataPageOffset,
+    dictionaryPageOffset
+  });
 }
 
-/** Validates and resolves the row groups requested by one read. */
-function getRowGroupIndexes(
-  requestedRowGroups: readonly number[] | undefined,
-  rowGroups: readonly ParquetRowGroupMetadata[]
+/** Normalizes one decoded row group and derives its compressed byte length. */
+function createRowGroupMetadata(
+  index: number,
+  rowOffset: number,
+  rowCount: number,
+  uncompressedByteLength: number,
+  columns: ParquetColumnChunkMetadata[]
+): ParquetRowGroupMetadata {
+  const compressedByteLength = columns.reduce(
+    (sum, column) => sum + column.compressedByteLength,
+    0
+  );
+  return Object.freeze({
+    index,
+    rowOffset,
+    rowCount,
+    uncompressedByteLength,
+    uncompressedSize: uncompressedByteLength,
+    compressedByteLength,
+    compressedSize: compressedByteLength,
+    columns: Object.freeze(columns)
+  });
+}
+
+/** Converts decoded rows into one Arrow batch and attaches stable source provenance. */
+function createParquetBatch(
+  metadata: ParquetSourceMetadata,
+  schema: Schema,
+  rowGroupIndex: number,
+  rowGroupRowOffset: number,
+  rows: ParquetRow[]
+): ParquetBatch {
+  const arrowTable = convertTable({shape: 'object-row-table', schema, data: rows}, 'arrow-table');
+  const rowGroup = metadata.rowGroups[rowGroupIndex];
+  const sourceId = metadata.url || metadata.name;
+  const provenance = {
+    sourceId,
+    sourceUrl: metadata.url,
+    source: sourceId,
+    rowGroupIndex,
+    rowOffset: rowGroup.rowOffset + rowGroupRowOffset,
+    rowGroupRowOffset,
+    rowCount: rows.length
+  };
+  return {
+    batchType: 'data',
+    shape: 'arrow-table',
+    schemaType: 'explicit',
+    schema,
+    data: arrowTable.data,
+    length: rows.length,
+    metadata: provenance,
+    ...provenance
+  };
+}
+
+/** Validates and normalizes requested row-group indexes. */
+function normalizeRowGroupIndices(
+  rowGroups: readonly number[] | undefined,
+  rowGroupCount: number
 ): number[] {
-  const rowGroupIndexes =
-    requestedRowGroups !== undefined
-      ? [...requestedRowGroups]
-      : Array.from({length: rowGroups.length}, (_, index) => index);
-  const uniqueIndexes = new Set<number>();
-
-  for (const rowGroupIndex of rowGroupIndexes) {
-    if (
-      !Number.isInteger(rowGroupIndex) ||
-      rowGroupIndex < 0 ||
-      rowGroupIndex >= rowGroups.length
-    ) {
-      throw new Error(`ParquetSource row group index ${rowGroupIndex} is out of range`);
+  const rowGroupIndices = rowGroups || Array.from({length: rowGroupCount}, (_, index) => index);
+  const seenIndices = new Set<number>();
+  for (const rowGroupIndex of rowGroupIndices) {
+    if (!Number.isInteger(rowGroupIndex) || rowGroupIndex < 0 || rowGroupIndex >= rowGroupCount) {
+      throw new Error(`Invalid Parquet row-group index ${rowGroupIndex}`);
     }
-    if (uniqueIndexes.has(rowGroupIndex)) {
-      throw new Error(`ParquetSource row group index ${rowGroupIndex} is duplicated`);
+    if (seenIndices.has(rowGroupIndex)) {
+      throw new Error(`Duplicate Parquet row-group index ${rowGroupIndex}`);
     }
-    uniqueIndexes.add(rowGroupIndex);
+    seenIndices.add(rowGroupIndex);
   }
-
-  return rowGroupIndexes;
+  return [...rowGroupIndices];
 }
 
-/** Returns a stable identifier used in batch provenance. */
-function getSourceId(data: string | Blob, resolvedUrl: string): string {
-  if (typeof data === 'string') {
-    return resolvedUrl;
+/** Validates selected top-level columns against the source schema. */
+function normalizeColumns(columns: readonly string[] | undefined, schema: Schema): string[] {
+  if (!columns?.length) {
+    return [];
   }
-  const namedBlob = data as Blob & {name?: string};
-  return namedBlob.name || 'blob';
+  const availableColumns = new Set(schema.fields.map(field => field.name));
+  const normalizedColumns: string[] = [];
+  for (const column of columns) {
+    if (!availableColumns.has(column)) {
+      throw new Error(`Parquet column not found: ${column}`);
+    }
+    if (!normalizedColumns.includes(column)) {
+      normalizedColumns.push(column);
+    }
+  }
+  return normalizedColumns;
+}
+
+/** Returns a schema containing only explicitly selected top-level fields. */
+function projectSchema(schema: Schema, columns: string[]): Schema {
+  if (columns.length === 0) {
+    return schema;
+  }
+  const selectedColumns = new Set(columns);
+  return {...schema, fields: schema.fields.filter(field => selectedColumns.has(field.name))};
+}
+
+/** Validates an optional output batch size. */
+function normalizeBatchSize(batchSize?: number): number | undefined {
+  if (batchSize === undefined) {
+    return undefined;
+  }
+  if (!Number.isInteger(batchSize) || batchSize <= 0) {
+    throw new Error(`Invalid Parquet batch size ${batchSize}`);
+  }
+  return batchSize;
+}
+
+/** Validates the row-group decode concurrency limit. */
+function normalizeConcurrency(concurrency = 1): number {
+  if (!Number.isInteger(concurrency) || concurrency <= 0) {
+    throw new Error(`Invalid Parquet concurrency ${concurrency}`);
+  }
+  return concurrency;
+}
+
+/** Creates a read-scoped abort controller linked to the caller signal. */
+function createReadAbortContext(signal?: AbortSignal): {
+  /** Controller owned by the source read operation. */
+  abortController: AbortController;
+  /** Removes the caller-signal listener after the read settles. */
+  removeSignalListener: () => void;
+} {
+  const abortController = new AbortController();
+  const abortRead = (): void => abortController.abort();
+  if (signal?.aborted) {
+    abortRead();
+  } else {
+    signal?.addEventListener('abort', abortRead, {once: true});
+  }
+  return {
+    abortController,
+    removeSignalListener: () => signal?.removeEventListener('abort', abortRead)
+  };
+}
+
+/** Throws a cross-runtime AbortError when a signal has been aborted. */
+function throwIfAborted(signal: AbortSignal): void {
+  if (!signal.aborted) {
+    return;
+  }
+  const error = new Error('Parquet read aborted');
+  error.name = 'AbortError';
+  throw error;
+}
+
+/** Converts footer key/value pairs into an object. */
+function getKeyValueMetadata(fileMetadata: FileMetaData): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const entry of fileMetadata.key_value_metadata || []) {
+    if (entry.value !== undefined) {
+      result[entry.key] = entry.value;
+    }
+  }
+  return result;
+}
+
+/** Infers a stable display name from URL or File input. */
+function getSourceName(data: string | Blob, url: string): string {
+  const sourceName =
+    typeof data !== 'string' && 'name' in data && typeof data.name === 'string'
+      ? data.name
+      : typeof data === 'string'
+        ? url.split(/[?#]/)[0].split('/').pop() || 'parquet'
+        : 'parquet';
+  return sourceName.replace(/\.parquet$/i, '') || 'parquet';
+}
+
+/** Returns true when at least one HTTP object validator was captured. */
+function hasObjectVersion(version?: ParquetObjectVersion): version is ParquetObjectVersion {
+  return Boolean(version?.etag || version?.lastModified);
 }

--- a/modules/parquet/src/parquet-source-types.ts
+++ b/modules/parquet/src/parquet-source-types.ts
@@ -4,95 +4,168 @@
 
 import type * as parquetWasm from 'parquet-wasm/esm/parquet_wasm.js';
 
-import type {DataSourceOptions} from '@loaders.gl/loader-utils';
+import type {
+  DataSourceOptions,
+  RangeRequestScheduler,
+  RangeRequestSchedulerProps
+} from '@loaders.gl/loader-utils';
 import type {ArrowTableBatch, Schema} from '@loaders.gl/schema';
+import type {FileMetaData} from './parquetjs/parquet-thrift/index';
 
-/** Options applied to each read from a Parquet source. */
-export type ParquetSourceReadOptions = {
-  /** Row-group indexes to read. Defaults to all row groups in file order. */
-  rowGroups?: readonly number[];
-  /** Column paths to project. Defaults to all columns. */
-  columns?: readonly string[];
-  /** Target number of rows in each returned Arrow batch. */
-  batchSize?: number;
-  /** Number of concurrent range requests used by parquet-wasm. */
-  concurrency?: number;
+/** Version validators captured from an HTTP Parquet object. */
+export type ParquetObjectVersion = {
+  /** HTTP entity tag returned by the object store. */
+  etag?: string;
+  /** HTTP last-modified timestamp returned by the object store. */
+  lastModified?: string;
 };
 
-/** Options for creating a Parquet source. */
-export type ParquetSourceLoaderOptions = DataSourceOptions & {
-  parquet?: ParquetSourceReadOptions & {
-    /** URL or module used to initialize parquet-wasm. */
-    wasmUrl?: parquetWasm.InitInput | Promise<parquetWasm.InitInput>;
-  };
-};
-
-/** Plain metadata for one Parquet column chunk. */
+/** Normalized metadata for one Parquet column chunk. */
 export type ParquetColumnChunkMetadata = {
-  /** Nested column path. */
+  /** Nested column path in the Parquet schema. */
   readonly path: readonly string[];
   /** Optional external file containing the chunk. */
   readonly filePath?: string;
-  /** Byte offset reported by the Parquet footer. */
-  readonly fileOffset: bigint;
-  /** Number of encoded values in the chunk. */
-  readonly valueCount: number;
-  /** Compression codec name. */
+  /** Compression codec declared by the column chunk. */
   readonly compression: string;
-  /** Encodings used by the chunk. */
+  /** Encodings declared by the column chunk. */
   readonly encodings: readonly string[];
-  /** Compressed chunk size in bytes. */
+  /** Number of encoded values, including repeated values. */
+  readonly valueCount: number;
+  /** Absolute file offset of the beginning of the column chunk. */
+  readonly fileOffset: number;
+  /** Compressed byte length of the column chunk. */
+  readonly compressedByteLength: number;
+  /** Compatibility alias for `compressedByteLength`. */
   readonly compressedSize: number;
-  /** Uncompressed chunk size in bytes. */
+  /** Uncompressed byte length of the column chunk. */
+  readonly uncompressedByteLength: number;
+  /** Compatibility alias for `uncompressedByteLength`. */
   readonly uncompressedSize: number;
+  /** Absolute file offset of the first data page. */
+  readonly dataPageOffset: number;
+  /** Absolute file offset of the dictionary page, when present. */
+  readonly dictionaryPageOffset?: number;
 };
 
-/** Plain metadata for one Parquet row group. */
+/** Normalized metadata for one Parquet row group. */
 export type ParquetRowGroupMetadata = {
   /** Zero-based row-group index. */
   readonly index: number;
-  /** Absolute offset of the first row in the file. */
+  /** Absolute logical row offset of the row group in the source file. */
   readonly rowOffset: number;
-  /** Number of rows in the row group. */
+  /** Number of logical rows in the row group. */
   readonly rowCount: number;
-  /** Total compressed column size in bytes. */
-  readonly compressedSize: number;
-  /** Total uncompressed column size in bytes. */
+  /** Total uncompressed byte length declared by the row group. */
+  readonly uncompressedByteLength: number;
+  /** Compatibility alias for `uncompressedByteLength`. */
   readonly uncompressedSize: number;
-  /** Column chunks in this row group. */
+  /** Sum of compressed column-chunk byte lengths. */
+  readonly compressedByteLength: number;
+  /** Compatibility alias for `compressedByteLength`. */
+  readonly compressedSize: number;
+  /** Column chunks contained in the row group. */
   readonly columns: readonly ParquetColumnChunkMetadata[];
 };
 
-/** Cached schema and footer metadata exposed by a Parquet source. */
+/** Dataset-level metadata returned by `ParquetSource.getMetadata()`. */
 export type ParquetSourceMetadata = {
   /** Arrow-compatible loaders.gl schema. */
   readonly schema: Schema;
+  /** Display name inferred from the URL or File name. */
+  readonly name: string;
+  /** Resolved source URL for remote datasets. */
+  readonly url?: string;
+  /** Total Parquet object byte length. */
+  readonly fileByteLength: number;
   /** Parquet format version stored in the footer. */
   readonly version: number;
-  /** Total number of rows in the file. */
-  readonly rowCount: number;
-  /** Application string stored by the Parquet writer. */
+  /** Compatibility alias for `version`. */
+  readonly formatVersion: number;
+  /** Writer identifier stored in the footer. */
   readonly createdBy?: string;
-  /** File-level key/value metadata. */
+  /** Total logical row count. */
+  readonly rowCount: number;
+  /** Number of row groups. */
+  readonly rowGroupCount: number;
+  /** User key/value metadata stored in the footer. */
   readonly keyValueMetadata: Readonly<Record<string, string>>;
-  /** Row-group and column-chunk metadata. */
+  /** Normalized row-group and column-chunk metadata. */
   readonly rowGroups: readonly ParquetRowGroupMetadata[];
+  /** HTTP object validators captured when opening a remote source. */
+  readonly objectVersion?: ParquetObjectVersion;
+  /** Raw decoded Parquet footer, included only when requested. */
+  readonly formatSpecificMetadata?: FileMetaData;
 };
 
-/** Provenance attached to every Arrow batch returned by a Parquet source. */
-export type ParquetBatchMetadata = {
-  /** Source URL, File name, or a stable Blob label. */
+/** Options for one Parquet source metadata request. */
+export type ParquetMetadataRequestOptions = {
+  /** Include the decoded Parquet thrift footer in the returned metadata. */
+  formatSpecificMetadata?: boolean;
+  /** Abort source initialization and its range requests. */
+  signal?: AbortSignal;
+};
+
+/** Options for one selective `ParquetSource.read()` operation. */
+export type ParquetSourceReadOptions = {
+  /** Zero-based row-group indexes to decode, in output order. Defaults to all row groups. */
+  rowGroups?: readonly number[];
+  /** Top-level columns to fetch and decode. Defaults to all columns. */
+  columns?: readonly string[];
+  /** Maximum number of rows in each emitted Arrow batch. Defaults to one row group per batch. */
+  batchSize?: number;
+  /** Maximum number of row groups decoded concurrently. */
+  concurrency?: number;
+  /** Abort this read and all of its outstanding range requests. */
+  signal?: AbortSignal;
+};
+
+/** Compatibility alias for selective source read options. */
+export type ParquetReadOptions = ParquetSourceReadOptions;
+
+/** Stable source and row-position information attached to every Parquet batch. */
+export type ParquetBatchProvenance = {
+  /** Source URL, File name, or stable Blob label. */
   readonly sourceId: string;
-  /** Row group that produced this batch. */
+  /** Source URL when the source is remote. */
+  readonly sourceUrl?: string;
+  /** Compatibility alias for `sourceId`. */
+  readonly source: string;
+  /** Zero-based row-group index in the source file. */
   readonly rowGroupIndex: number;
-  /** Absolute offset of the first batch row in the source file. */
+  /** Absolute logical row offset of the first batch row in the source file. */
   readonly rowOffset: number;
-  /** Offset of the first batch row within its row group. */
+  /** Logical offset of the first batch row within its row group. */
   readonly rowGroupRowOffset: number;
+  /** Number of rows in the batch. */
+  readonly rowCount: number;
 };
 
-/** Arrow batch returned by a Parquet source. */
-export type ParquetSourceBatch = Omit<ArrowTableBatch<ParquetBatchMetadata>, 'metadata'> & {
-  /** Provenance for the source rows represented by this batch. */
-  readonly metadata: ParquetBatchMetadata;
+/** Compatibility alias for Parquet batch provenance. */
+export type ParquetBatchMetadata = ParquetBatchProvenance;
+
+/** Arrow batch returned by `ParquetSource.read()` with source provenance. */
+export type ParquetBatch = ArrowTableBatch<ParquetBatchProvenance> & ParquetBatchProvenance;
+
+/** Compatibility alias for Arrow batches returned by `ParquetSource.read()`. */
+export type ParquetSourceBatch = ParquetBatch;
+
+/** Range transport options for `ParquetSourceLoader`. */
+export type ParquetRangeRequestOptions = RangeRequestSchedulerProps & {
+  /** Reusable scheduler shared with other range-addressable sources. */
+  scheduler?: RangeRequestScheduler;
+};
+
+/** Options for constructing a `ParquetSource`. */
+export type ParquetSourceLoaderOptions = DataSourceOptions & {
+  parquet?: ParquetSourceReadOptions & {
+    /** HTTP headers forwarded to every remote Parquet request. */
+    headers?: HeadersInit;
+    /** Preserve binary values when the TypeScript decoder is used for later reads. */
+    preserveBinary?: boolean;
+    /** Retained for source API compatibility; the TypeScript backend does not initialize WASM. */
+    wasmUrl?: parquetWasm.InitInput | Promise<parquetWasm.InitInput>;
+  };
+  /** Byte-range scheduling and diagnostics configuration. */
+  rangeRequests?: ParquetRangeRequestOptions;
 };

--- a/modules/parquet/src/parquetjs/parser/parquet-reader.ts
+++ b/modules/parquet/src/parquetjs/parser/parquet-reader.ts
@@ -23,14 +23,22 @@ import {decodeFileMetadata, getThriftEnum, fieldIndexOf} from '../utils/read-uti
 import {decodeString, readUInt32LE, toUint8Array} from '../utils/binary-utils';
 
 export type ParquetReaderProps = {
+  /** Maximum dictionary-page read size. */
   defaultDictionarySize?: number;
+  /** Preserve BYTE_ARRAY values instead of decoding them as strings. */
   preserveBinary?: boolean;
+  /** Abort signal forwarded to every underlying random-access read. */
+  signal?: AbortSignal;
 };
 
 /** Properties for initializing a ParquetRowGroupReader */
 export type ParquetIterationProps = {
   /** Filter allowing some columns to be dropped */
   columnList?: string[] | string[][];
+  /** Zero-based row-group indexes to read, in output order. */
+  rowGroups?: number[];
+  /** Abort signal forwarded to row-group and column-chunk reads. */
+  signal?: AbortSignal;
 };
 
 /**
@@ -40,13 +48,14 @@ export type ParquetIterationProps = {
  * rows from a parquet file use the ParquetReader instead
  */
 export class ParquetReader {
-  static defaultProps: Required<ParquetReaderProps> = {
+  static defaultProps: Required<Omit<ParquetReaderProps, 'signal'>> & {signal?: AbortSignal} = {
     // max ArrayBuffer size in js is 2Gb
     defaultDictionarySize: 2147483648,
-    preserveBinary: false
+    preserveBinary: false,
+    signal: undefined
   };
 
-  props: Required<ParquetReaderProps>;
+  props: Required<Omit<ParquetReaderProps, 'signal'>> & {signal?: AbortSignal};
   file: ReadableFile;
   metadata: Promise<FileMetaData> | null = null;
 
@@ -85,28 +94,34 @@ export class ParquetReader {
     // Ensure strings are nested in arrays
     const columnList: string[][] = (props?.columnList || []).map(x => (Array.isArray(x) ? x : [x]));
 
-    const metadata = await this.getFileMetadata();
-    const schema = await this.getSchema();
+    const metadata = await this.getFileMetadata(props?.signal);
+    const schema = await this.getSchema(props?.signal);
 
     const rowGroupCount = metadata?.row_groups.length || 0;
+    const rowGroupIndices =
+      props?.rowGroups || Array.from({length: rowGroupCount}, (_, index) => index);
 
-    for (let rowGroupIndex = 0; rowGroupIndex < rowGroupCount; rowGroupIndex++) {
+    for (const rowGroupIndex of rowGroupIndices) {
+      if (!Number.isInteger(rowGroupIndex) || rowGroupIndex < 0 || rowGroupIndex >= rowGroupCount) {
+        throw new Error(`Invalid Parquet row-group index ${rowGroupIndex}`);
+      }
       const rowGroup = await this.readRowGroup(
         schema,
         metadata.row_groups[rowGroupIndex],
-        columnList
+        columnList,
+        props?.signal
       );
       yield rowGroup;
     }
   }
 
-  async getRowCount(): Promise<number> {
-    const metadata = await this.getFileMetadata();
+  async getRowCount(signal?: AbortSignal): Promise<number> {
+    const metadata = await this.getFileMetadata(signal);
     return Number(metadata.num_rows);
   }
 
-  async getSchema(): Promise<ParquetSchema> {
-    const metadata = await this.getFileMetadata();
+  async getSchema(signal?: AbortSignal): Promise<ParquetSchema> {
+    const metadata = await this.getFileMetadata(signal);
     const root = metadata.schema[0];
     const {schema: schemaDefinition} = decodeSchema(metadata.schema, 1, root.num_children!);
     const schema = new ParquetSchema(schemaDefinition);
@@ -126,10 +141,10 @@ export class ParquetReader {
     return md;
   }
 
-  async getFileMetadata(): Promise<FileMetaData> {
+  async getFileMetadata(signal?: AbortSignal): Promise<FileMetaData> {
     if (!this.metadata) {
-      await this.readHeader();
-      this.metadata = this.readFooter();
+      await this.readHeader(signal);
+      this.metadata = this.readFooter(signal);
     }
     return this.metadata;
   }
@@ -137,8 +152,8 @@ export class ParquetReader {
   // LOW LEVEL METHODS
 
   /** Metadata is stored in the footer */
-  async readHeader(): Promise<void> {
-    const arrayBuffer = await this.file.read(0, PARQUET_MAGIC.length);
+  async readHeader(signal?: AbortSignal): Promise<void> {
+    const arrayBuffer = await this.file.read(0, PARQUET_MAGIC.length, signal ?? this.props.signal);
     const magic = decodeString(toUint8Array(arrayBuffer));
     switch (magic) {
       case PARQUET_MAGIC:
@@ -151,9 +166,13 @@ export class ParquetReader {
   }
 
   /** Metadata is stored in the footer */
-  async readFooter(): Promise<FileMetaData> {
+  async readFooter(signal?: AbortSignal): Promise<FileMetaData> {
     const trailerLen = PARQUET_MAGIC.length + 4;
-    const arrayBuffer = await this.file.read(this.file.size - trailerLen, trailerLen);
+    const arrayBuffer = await this.file.read(
+      this.file.size - trailerLen,
+      trailerLen,
+      signal ?? this.props.signal
+    );
     const trailer = toUint8Array(arrayBuffer);
 
     const magic = decodeString(trailer, 4);
@@ -167,7 +186,11 @@ export class ParquetReader {
       throw new Error(`Invalid metadata size ${metadataOffset}`);
     }
 
-    const arrayBuffer2 = await this.file.read(metadataOffset, metadataSize);
+    const arrayBuffer2 = await this.file.read(
+      metadataOffset,
+      metadataSize,
+      signal ?? this.props.signal
+    );
     const metadataBuf = toUint8Array(arrayBuffer2);
     // let metadata = new parquet_thrift.FileMetaData();
     // parquet_util.decodeThrift(metadata, metadataBuf);
@@ -180,7 +203,8 @@ export class ParquetReader {
   async readRowGroup(
     schema: ParquetSchema,
     rowGroup: RowGroup,
-    columnList: string[][]
+    columnList: string[][],
+    signal?: AbortSignal
   ): Promise<ParquetRowGroup> {
     const buffer: ParquetRowGroup = {
       rowCount: Number(rowGroup.num_rows),
@@ -192,7 +216,7 @@ export class ParquetReader {
       if (columnList.length > 0 && fieldIndexOf(columnList, colKey!) < 0) {
         continue; // eslint-disable-line no-continue
       }
-      buffer.columnData[colKey!.join()] = await this.readColumnChunk(schema, colChunk);
+      buffer.columnData[colKey!.join()] = await this.readColumnChunk(schema, colChunk, signal);
     }
     return buffer;
   }
@@ -200,7 +224,11 @@ export class ParquetReader {
   /**
    * Each row group contains column chunks for all the columns.
    */
-  async readColumnChunk(schema: ParquetSchema, colChunk: ColumnChunk): Promise<ParquetColumnChunk> {
+  async readColumnChunk(
+    schema: ParquetSchema,
+    colChunk: ColumnChunk,
+    signal?: AbortSignal
+  ): Promise<ParquetColumnChunk> {
     if (colChunk.file_path !== undefined && colChunk.file_path !== null) {
       throw new Error('external references are not supported');
     }
@@ -218,13 +246,17 @@ export class ParquetReader {
     ) as any;
 
     const pagesOffset = Number(colChunk.meta_data?.data_page_offset!);
-    let pagesSize = Number(colChunk.meta_data?.total_compressed_size!);
+    const dictionaryPageOffset = colChunk.meta_data?.dictionary_page_offset;
+    const validDictionaryPageOffset =
+      dictionaryPageOffset !== undefined && Number(dictionaryPageOffset) > 0
+        ? Number(dictionaryPageOffset)
+        : undefined;
+    const chunkOffset = Math.min(pagesOffset, validDictionaryPageOffset ?? pagesOffset);
+    const chunkEnd = chunkOffset + Number(colChunk.meta_data?.total_compressed_size!);
+    let pagesSize = Math.max(0, chunkEnd - pagesOffset);
 
     if (!colChunk.file_path) {
-      pagesSize = Math.min(
-        this.file.size - pagesOffset,
-        Number(colChunk.meta_data?.total_compressed_size)
-      );
+      pagesSize = Math.min(this.file.size - pagesOffset, pagesSize);
     }
 
     const context: ParquetReaderContext = {
@@ -241,16 +273,18 @@ export class ParquetReader {
 
     let dictionary;
 
-    const dictionaryPageOffset = colChunk?.meta_data?.dictionary_page_offset;
-
-    if (dictionaryPageOffset) {
-      const dictionaryOffset = Number(dictionaryPageOffset);
+    if (validDictionaryPageOffset !== undefined) {
       // Getting dictionary from column chunk to iterate all over indexes to get dataPage values.
-      dictionary = await this.getDictionary(dictionaryOffset, context, pagesOffset);
+      dictionary = await this.getDictionary(
+        validDictionaryPageOffset,
+        context,
+        pagesOffset,
+        signal
+      );
     }
 
     dictionary = context.dictionary?.length ? context.dictionary : dictionary;
-    const arrayBuffer = await this.file.read(pagesOffset, pagesSize);
+    const arrayBuffer = await this.file.read(pagesOffset, pagesSize, signal ?? this.props.signal);
     const pagesBuf = toUint8Array(arrayBuffer);
     return await decodeDataPages(pagesBuf, {...context, dictionary});
   }
@@ -265,7 +299,8 @@ export class ParquetReader {
   async getDictionary(
     dictionaryPageOffset: number,
     context: ParquetReaderContext,
-    pagesOffset: number
+    pagesOffset: number,
+    signal?: AbortSignal
   ): Promise<any[]> {
     if (dictionaryPageOffset === 0) {
       // dictionarySize = Math.min(this.fileSize - pagesOffset, this.defaultDictionarySize);
@@ -279,10 +314,15 @@ export class ParquetReader {
     }
 
     const dictionarySize = Math.min(
+      Math.max(0, pagesOffset - dictionaryPageOffset),
       this.file.size - dictionaryPageOffset,
       this.props.defaultDictionarySize
     );
-    const arrayBuffer = await this.file.read(dictionaryPageOffset, dictionarySize);
+    const arrayBuffer = await this.file.read(
+      dictionaryPageOffset,
+      dictionarySize,
+      signal ?? this.props.signal
+    );
     const pagesBuf = toUint8Array(arrayBuffer);
 
     const cursor = {buffer: pagesBuf, offset: 0, size: pagesBuf.length};

--- a/modules/parquet/test/parquet-source-loader.spec.ts
+++ b/modules/parquet/test/parquet-source-loader.spec.ts
@@ -3,52 +3,91 @@
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';
-import {fetchFile, load} from '@loaders.gl/core';
-import {ParquetSourceLoader, type ParquetSourceBatch} from '@loaders.gl/parquet';
-import {ParquetSource} from '@loaders.gl/parquet/parquet-source-loader';
 
-const FRUITS_URL = '@loaders.gl/parquet/test/data/fruits.parquet';
+import {createDataSource, encode, fetchFile, load} from '@loaders.gl/core';
+import type {ObjectRowTable} from '@loaders.gl/schema';
+import {
+  type ParquetBatch,
+  ParquetJSWriter,
+  ParquetSourceLoader,
+  type ParquetSourceLoaderOptions,
+  type ParquetSourceMetadata
+} from '@loaders.gl/parquet';
+import {
+  ParquetSource,
+  ParquetSourceLoader as ParquetSourceLoaderWithParser
+} from '@loaders.gl/parquet/parquet-source-loader';
 
-test('ParquetSourceLoader#create reusable source with cached metadata', async t => {
-  const source = await createParquetSource();
+const FIXTURE_URL = '@loaders.gl/parquet/test/data/apache/good/alltypes_plain.parquet';
+const REMOTE_URL = 'https://example.com/data/alltypes_plain.parquet';
 
-  t.ok(source instanceof ParquetSource, 'load returns a ParquetSource');
+/** Lazily encoded three-row-group fixture shared by selective-read tests. */
+let selectiveFixturePromise: Promise<ArrayBuffer> | null = null;
 
+type RangeRequestRecord = {
+  /** Requested URL. */
+  url: string;
+  /** HTTP request headers. */
+  headers: Headers;
+  /** Inclusive first requested byte. */
+  start: number;
+  /** Inclusive last requested byte. */
+  end: number;
+};
+
+type RangeRequestInterceptor = (
+  /** Parsed request record. */
+  request: RangeRequestRecord,
+  /** Original fetch options, including the abort signal. */
+  requestOptions: RequestInit
+) => Promise<Response> | null;
+
+type RangeFetchOptions = {
+  /** ETag returned by each request, based on its zero-based request index. */
+  getEtag?: (requestIndex: number) => string;
+  /** Request log populated by the mock fetch implementation. */
+  requests?: RangeRequestRecord[];
+  /** Optional response override used by cancellation and error tests. */
+  intercept?: RangeRequestInterceptor;
+};
+
+test('ParquetSourceLoader#Blob metadata and schema are cached', async (t) => {
+  const fixture = await loadFixture();
+  const source = (await load(new Blob([fixture]), ParquetSourceLoader)) as ParquetSource;
+
+  t.ok(source instanceof ParquetSource, 'root metadata loader preloads the runtime source');
   const metadata = await source.getMetadata();
-  const secondMetadata = await source.getMetadata();
   const schema = await source.getSchema();
 
-  t.equal(secondMetadata, metadata, 'reuses the cached metadata object');
-  t.equal(schema, metadata.schema, 'reuses the cached schema object');
-  t.equal(metadata.rowCount, 40_000, 'reports total row count');
-  t.equal(metadata.rowGroups.length, 10, 'reports every row group');
-  t.equal(metadata.rowGroups[0].rowOffset, 0, 'first row group starts at row zero');
-  t.equal(metadata.rowGroups[1].rowOffset, 4_096, 'row offsets are cumulative');
-  t.equal(metadata.rowGroups[9].rowOffset, 36_864, 'last row-group offset is correct');
-  t.equal(metadata.rowGroups[9].rowCount, 3_136, 'last row-group size is correct');
-  t.ok(metadata.rowGroups[0].compressedSize > 0, 'reports compressed row-group size');
-  t.ok(metadata.rowGroups[0].uncompressedSize > 0, 'reports uncompressed row-group size');
-  t.ok(
-    metadata.rowGroups[0].columns.some(column => column.path.join('.') === 'name'),
-    'reports column paths'
+  t.ok(metadata.rowCount > 0, 'reports rows');
+  t.equal(metadata.rowGroupCount, metadata.rowGroups.length, 'reports row groups');
+  t.equal(metadata.fileByteLength, fixture.byteLength, 'reports file byte length');
+  t.equal(metadata.schema, schema, 'metadata retains the cached schema');
+  t.equal(metadata.version, metadata.formatVersion, 'retains the version compatibility alias');
+  t.ok(metadata.rowGroups[0].columns.length > 0, 'reports column chunks');
+  t.equal(metadata.rowGroups[0].rowOffset, 0, 'reports absolute row-group offsets');
+  t.equal(
+    metadata.rowGroups[0].compressedSize,
+    metadata.rowGroups[0].compressedByteLength,
+    'retains row-group size compatibility aliases'
   );
-  t.ok(schema.fields.some(field => field.name === 'name'), 'returns the Arrow-compatible schema');
-
+  t.ok(metadata.rowGroups[0].columns[0].fileOffset >= 4, 'reports column chunk offsets');
+  t.ok(schema.fields.length > 0, 'decodes logical schema');
+  t.equal(await source.getMetadata(), metadata, 'returns cached metadata object');
+  t.equal(await source.getSchema(), schema, 'returns cached schema object');
   t.ok(Object.isFrozen(metadata), 'freezes the cached metadata object');
   t.ok(Object.isFrozen(metadata.rowGroups), 'freezes the cached row-group list');
-  t.throws(
-    () => Array.prototype.reverse.call(metadata.rowGroups),
-    /read only|Cannot assign/i,
-    'prevents callers from reordering canonical row-group metadata'
-  );
+  t.ok(Object.isFrozen(metadata.rowGroups[0].columns), 'freezes cached column metadata');
 
+  const formatMetadata = await source.getMetadata({formatSpecificMetadata: true});
+  t.ok(formatMetadata.formatSpecificMetadata, 'optionally exposes decoded thrift footer');
   await source.close();
   await source.close();
   await t.rejects(source.getMetadata(), /ParquetSource is closed/, 'operations fail after close');
   t.end();
 });
 
-test('ParquetSource#preserves opaque WASM inputs by identity', async t => {
+test('ParquetSource#preserves opaque WASM inputs by identity', async (t) => {
   const wasmUrl = Promise.resolve(new URL('https://example.com/parquet_wasm_bg.wasm'));
   const source = new ParquetSource(new Blob(), {parquet: {wasmUrl}});
 
@@ -58,138 +97,377 @@ test('ParquetSource#preserves opaque WASM inputs by identity', async t => {
   t.end();
 });
 
-test('ParquetSource#read selects row groups and columns with exact provenance', async t => {
-  const source = await createParquetSource();
-  const batches = await collectBatches(
-    source.read({
-      rowGroups: [1, 9],
-      columns: ['name', 'price'],
-      batchSize: 1_000,
-      concurrency: 1
-    })
-  );
-
-  t.equal(
-    batches.reduce((rowCount, batch) => rowCount + batch.length, 0),
-    7_232,
-    'returns only selected row groups'
-  );
-  t.deepEqual(
-    Array.from(new Set(batches.map(batch => batch.metadata.rowGroupIndex))),
-    [1, 9],
-    'preserves requested row-group order'
-  );
-
-  const firstBatchByRowGroup = new Map<number, ParquetSourceBatch>();
-  const nextOffsetByRowGroup = new Map<number, number>();
-  for (const batch of batches) {
-    const metadata = batch.metadata;
-    firstBatchByRowGroup.set(metadata.rowGroupIndex, firstBatchByRowGroup.get(metadata.rowGroupIndex) || batch);
-    t.equal(
-      metadata.rowGroupRowOffset,
-      nextOffsetByRowGroup.get(metadata.rowGroupIndex) || 0,
-      'row-group-relative offsets are contiguous'
-    );
-    t.equal(
-      metadata.rowOffset,
-      (metadata.rowGroupIndex === 1 ? 4_096 : 36_864) + metadata.rowGroupRowOffset,
-      'absolute source row offset is correct'
-    );
-    t.deepEqual(
-      batch.schema?.fields.map(field => field.name),
-      ['name', 'price'],
-      'projects only requested columns'
-    );
-    t.equal(batch.data.numRows, batch.length, 'Arrow table length matches batch length');
-    nextOffsetByRowGroup.set(metadata.rowGroupIndex, metadata.rowGroupRowOffset + batch.length);
-  }
-
-  t.equal(firstBatchByRowGroup.get(1)?.metadata.rowOffset, 4_096, 'group 1 provenance starts at 4,096');
-  t.equal(firstBatchByRowGroup.get(9)?.metadata.rowOffset, 36_864, 'group 9 provenance starts at 36,864');
-
-  await source.close();
-  t.end();
-});
-
-test('ParquetSource#read snapshots mutable selections before yielding', async t => {
-  const source = await createParquetSource();
-  const rowGroups = [0, 1];
-  const columns = ['name'];
-  const iterator = source.read({rowGroups, columns, batchSize: 5_000})[Symbol.asyncIterator]();
-  const batches: ParquetSourceBatch[] = [];
-
-  const firstResult = await iterator.next();
-  if (firstResult.value) {
-    batches.push(firstResult.value);
-  }
-  rowGroups[1] = 9;
-  columns[0] = 'price';
-
-  for (let result = await iterator.next(); !result.done; result = await iterator.next()) {
-    batches.push(result.value);
-  }
+test('ParquetSource#read applies snapshotted source defaults', async (t) => {
+  const fixture = await createSelectiveFixture();
+  const rowGroups = [1];
+  const columns = ['x'];
+  const source = createRemoteSource(createRangeFetch(fixture), {
+    parquet: {rowGroups, columns, batchSize: 1, concurrency: 2}
+  });
+  const iterator = source.read()[Symbol.asyncIterator]();
+  const firstBatch = await iterator.next();
+  rowGroups[0] = 2;
+  columns[0] = 'y';
+  const remainingBatches = await collectParquetBatches({
+    [Symbol.asyncIterator]: () => iterator
+  });
+  const batches = firstBatch.value ? [firstBatch.value, ...remainingBatches] : remainingBatches;
 
   t.deepEqual(
-    batches.map(batch => batch.metadata.rowGroupIndex),
-    [0, 1],
-    'caller mutation does not change the selected row groups'
+    batches.map(batch => batch.rowGroupIndex),
+    [1, 1],
+    'uses the snapshotted default row-group selection'
   );
   t.ok(
-    batches.every(batch => batch.schema?.fields[0]?.name === 'name'),
-    'caller mutation does not change the projected columns'
+    batches.every(batch => batch.schema?.fields[0]?.name === 'x'),
+    'uses the snapshotted default column projection'
   );
-
   await source.close();
   t.end();
 });
 
-test('ParquetSource#read validates row-group selections and supports early return', async t => {
-  const source = await createParquetSource();
-
-  t.deepEqual(await collectBatches(source.read({rowGroups: []})), [], 'empty selection yields no batches');
-  await t.rejects(
-    collectBatches(source.read({rowGroups: [10]})),
-    /row group index 10 is out of range/,
-    'rejects out-of-range row groups'
-  );
-  await t.rejects(
-    collectBatches(source.read({rowGroups: [1, 1]})),
-    /row group index 1 is duplicated/,
-    'rejects duplicate row groups'
+test('ParquetSource#read selects row groups and columns with exact provenance', async (t) => {
+  const fixture = await createSelectiveFixture();
+  const requests: RangeRequestRecord[] = [];
+  const source = createRemoteSource(createRangeFetch(fixture, {requests}));
+  const metadata = await source.getMetadata();
+  const metadataRequestCount = requests.length;
+  const batches = await collectParquetBatches(
+    source.read({rowGroups: [1], columns: ['x', 'source_id'], batchSize: 1, concurrency: 2})
   );
 
-  const iterator = source.read({rowGroups: [0], batchSize: 100})[Symbol.asyncIterator]();
-  const firstResult = await iterator.next();
-  t.equal(firstResult.value?.metadata.rowOffset, 0, 'first early-return batch has provenance');
-  await t.rejects(
-    source.close(),
-    /cannot close while a read is active/,
-    'close rejects instead of deadlocking behind a paused read'
+  t.deepEqual(
+    metadata.rowGroups.map(rowGroup => rowGroup.rowOffset),
+    [0, 2, 4],
+    'metadata records cumulative source row offsets'
   );
-  await t.rejects(
-    collectBatches(source.read({rowGroups: [1]})),
-    /already has an active read/,
-    'a second read rejects instead of queueing behind a paused read'
+  t.equal(batches.length, 2, 'honors the requested batch size');
+  t.deepEqual(
+    batches.map(batch => batch.rowGroupIndex),
+    [1, 1],
+    'identifies the selected row group'
   );
+  t.deepEqual(
+    batches.map(batch => batch.rowOffset),
+    [2, 3],
+    'reports absolute source row offsets'
+  );
+  t.deepEqual(
+    batches.map(batch => batch.rowGroupRowOffset),
+    [0, 1],
+    'reports offsets within the row group'
+  );
+  t.ok(
+    batches.every(
+      batch =>
+        batch.source === REMOTE_URL &&
+        batch.sourceId === REMOTE_URL &&
+        batch.sourceUrl === REMOTE_URL
+    ),
+    'identifies the source through current and compatibility fields'
+  );
+  t.deepEqual(
+    batches.flatMap(batch => Array.from(batch.data.getChild('x')?.toArray() || [])),
+    [2, 3],
+    'returns only rows from the selected row group'
+  );
+  t.deepEqual(
+    batches[0].schema?.fields.map(field => field.name),
+    ['x', 'source_id'],
+    'projects the batch schema'
+  );
+  t.notOk(batches[0].data.getChild('ignored_payload'), 'does not materialize ignored columns');
+
+  const selectedRanges = getColumnRanges(metadata, 1, ['x', 'source_id']);
+  const dataRequests = requests.slice(metadataRequestCount);
+  t.ok(dataRequests.length > 0, 'fetches selected column chunks');
+  t.ok(
+    dataRequests.every(request =>
+      selectedRanges.some(range => request.start >= range.start && request.end <= range.end)
+    ),
+    'every post-metadata request stays inside a selected column chunk'
+  );
+  await source.close();
+  t.end();
+});
+
+test('ParquetSource#read cancels outstanding ranges when iteration ends early', async (t) => {
+  const fixture = await createSelectiveFixture();
+  let markBlockedRequestStarted: () => void = () => {};
+  const blockedRequestStarted = new Promise<void>(resolve => {
+    markBlockedRequestStarted = resolve;
+  });
+  let blockedRequestAborted = false;
+  let blockedRange: {start: number; end: number} | null = null;
+  const rangeFetch = createRangeFetch(fixture, {
+    intercept: (request, requestOptions) => {
+      if (!blockedRange || request.start < blockedRange.start || request.end > blockedRange.end) {
+        return null;
+      }
+      markBlockedRequestStarted();
+      return new Promise<Response>((_resolve, reject) => {
+        const rejectAborted = (): void => {
+          blockedRequestAborted = true;
+          reject(createAbortError());
+        };
+        if (requestOptions.signal?.aborted) {
+          rejectAborted();
+        } else {
+          requestOptions.signal?.addEventListener('abort', rejectAborted, {once: true});
+        }
+      });
+    }
+  });
+  const source = createRemoteSource(rangeFetch);
+  const metadata = await source.getMetadata();
+  [blockedRange] = getColumnRanges(metadata, 1, ['x']);
+
+  const iterator = source
+    .read({rowGroups: [0, 1], columns: ['x'], concurrency: 2})
+    [Symbol.asyncIterator]();
+  const firstBatch = await iterator.next();
+  await blockedRequestStarted;
+  t.equal(firstBatch.value?.rowGroupIndex, 0, 'emits the first row group in requested order');
   await iterator.return?.();
-
+  t.ok(blockedRequestAborted, 'aborts the concurrently requested next row group');
   await source.close();
-  t.pass('source closes after an early iterator return');
   t.end();
 });
 
-async function createParquetSource(): Promise<ParquetSource> {
-  const response = await fetchFile(FRUITS_URL);
-  const blob = await response.blob();
-  return await load(blob, ParquetSourceLoader);
+test('ParquetSource#read rethrows range errors and validates selections', async (t) => {
+  const fixture = await createSelectiveFixture();
+  let failedRange: {start: number; end: number} | null = null;
+  const source = createRemoteSource(
+    createRangeFetch(fixture, {
+      intercept: request => {
+        if (failedRange && request.start >= failedRange.start && request.end <= failedRange.end) {
+          return Promise.reject(new Error('selected range failed'));
+        }
+        return null;
+      }
+    })
+  );
+  const metadata = await source.getMetadata();
+  [failedRange] = getColumnRanges(metadata, 2, ['x']);
+
+  await t.rejects(
+    collectParquetBatches(source.read({rowGroups: [2], columns: ['x']})),
+    /selected range failed/,
+    'rethrows transport failures'
+  );
+  await t.rejects(
+    collectParquetBatches(source.read({rowGroups: [3]})),
+    /row-group index 3/,
+    'rejects an out-of-range row group'
+  );
+  await t.rejects(
+    collectParquetBatches(source.read({columns: ['missing']})),
+    /column not found: missing/,
+    'rejects an unknown column before row data is read'
+  );
+  await source.close();
+  t.end();
+});
+
+test('ParquetSourceLoader#URL uses bounded, versioned range requests', async (t) => {
+  const fixture = await loadFixture();
+  const requests: RangeRequestRecord[] = [];
+  const rangeFetch = createRangeFetch(fixture, {requests});
+  const source = createRemoteSource(rangeFetch, {
+    parquet: {headers: {Authorization: 'Bearer test'}}
+  });
+
+  const metadata = await source.getMetadata();
+  const requestCount = requests.length;
+  await source.getMetadata();
+  await source.getSchema();
+
+  t.equal(requests[0].headers.get('Range'), 'bytes=0-3', 'opens with four-byte probe');
+  t.equal(requests[0].headers.get('Authorization'), 'Bearer test', 'forwards source headers');
+  t.equal(requests[1].headers.get('If-Match'), '"fixture-v1"', 'pins later ranges');
+  t.equal(requests.length, requestCount, 'metadata and schema share one initialization');
+  t.equal(metadata.fileByteLength, fixture.byteLength, 'parses object length from Content-Range');
+  t.equal(metadata.objectVersion?.etag, '"fixture-v1"', 'exposes captured object version');
+  t.ok(
+    requests.every(request => request.headers.get('Range') !== `bytes=0-${fixture.byteLength - 1}`),
+    'does not request the complete object'
+  );
+  await source.close();
+  t.end();
+});
+
+test('ParquetSourceLoader#rejects object version changes', async (t) => {
+  const fixture = await loadFixture();
+  const rangeFetch = createRangeFetch(fixture, {
+    getEtag: requestIndex => (requestIndex === 0 ? '"fixture-v1"' : '"fixture-v2"')
+  });
+  const source = createRemoteSource(rangeFetch);
+
+  await t.rejects(source.getMetadata(), /ETag changed/, 'rejects mixed-version footer reads');
+  await source.close();
+  t.end();
+});
+
+test('ParquetSourceLoader#abort and close cancel initialization', async (t) => {
+  const callerAbortController = new AbortController();
+  const callerFetch = createPendingFetch();
+  const callerSource = createRemoteSource(callerFetch.fetch);
+  const callerRequest = callerSource.getMetadata({signal: callerAbortController.signal});
+  await callerFetch.started;
+  callerAbortController.abort();
+  await t.rejects(callerRequest, /abort/i, 'caller signal aborts the opening range');
+
+  const closeFetch = createPendingFetch();
+  const closeSource = createRemoteSource(closeFetch.fetch);
+  const closeRequest = closeSource.getMetadata();
+  await closeFetch.started;
+  await closeSource.close();
+  await t.rejects(closeRequest, /abort/i, 'closing the source aborts the opening range');
+  await t.rejects(closeSource.getMetadata(), /closed/i, 'closed sources cannot be reopened');
+  t.end();
+});
+
+/** Loads the shared Parquet fixture into memory for deterministic transport tests. */
+async function loadFixture(): Promise<ArrayBuffer> {
+  const response = await fetchFile(FIXTURE_URL);
+  return await response.arrayBuffer();
 }
 
-async function collectBatches(
-  batches: AsyncIterable<ParquetSourceBatch>
-): Promise<ParquetSourceBatch[]> {
-  const collectedBatches: ParquetSourceBatch[] = [];
+/** Encodes a deterministic three-row-group fixture with a deliberately large ignored column. */
+async function createSelectiveFixture(): Promise<ArrayBuffer> {
+  selectiveFixturePromise ||= encode(
+    {
+      shape: 'object-row-table',
+      schema: {
+        fields: [
+          {name: 'x', type: 'int32', nullable: false},
+          {name: 'y', type: 'int32', nullable: false},
+          {name: 'source_id', type: 'utf8', nullable: false},
+          {name: 'ignored_payload', type: 'utf8', nullable: false}
+        ],
+        metadata: {}
+      },
+      data: Array.from({length: 6}, (_, index) => ({
+        x: index,
+        y: 100 + index,
+        source_id: `source-${index}`,
+        ignored_payload: String(index).repeat(16_384)
+      }))
+    } satisfies ObjectRowTable,
+    ParquetJSWriter,
+    {parquet: {rowGroupSize: 2}}
+  );
+  return await selectiveFixturePromise;
+}
+
+/** Collects a selective source read for concise assertions. */
+async function collectParquetBatches(batches: AsyncIterable<ParquetBatch>): Promise<ParquetBatch[]> {
+  const result: ParquetBatch[] = [];
   for await (const batch of batches) {
-    collectedBatches.push(batch);
+    result.push(batch);
   }
-  return collectedBatches;
+  return result;
+}
+
+/** Returns the physical byte ranges occupied by selected row-group columns. */
+function getColumnRanges(
+  metadata: ParquetSourceMetadata,
+  rowGroupIndex: number,
+  columns: string[]
+): Array<{start: number; end: number}> {
+  return metadata.rowGroups[rowGroupIndex].columns
+    .filter(column => columns.includes(column.path[0]))
+    .map(column => ({
+      start: column.fileOffset,
+      end: column.fileOffset + column.compressedByteLength - 1
+    }));
+}
+
+/** Creates a Parquet source with a caller-supplied loaders.gl fetch implementation. */
+function createRemoteSource(
+  rangeFetch: (url: string, options?: RequestInit) => Promise<Response>,
+  options: ParquetSourceLoaderOptions = {}
+): ParquetSource {
+  return createDataSource(REMOTE_URL, [ParquetSourceLoaderWithParser], {
+    ...options,
+    core: {
+      ...options.core,
+      type: 'parquet',
+      loadOptions: {core: {fetch: rangeFetch}}
+    }
+  }) as ParquetSource;
+}
+
+/** Creates a deterministic HTTP byte-range fetch over an in-memory fixture. */
+function createRangeFetch(
+  fixture: ArrayBuffer,
+  options: RangeFetchOptions = {}
+): (url: string, requestOptions?: RequestInit) => Promise<Response> {
+  const requests = options.requests || [];
+  return async (url: string, requestOptions: RequestInit = {}): Promise<Response> => {
+    throwIfAborted(requestOptions.signal);
+    const headers = new Headers(requestOptions.headers);
+    const {start, end} = parseRangeHeader(headers.get('Range'));
+    const requestIndex = requests.length;
+    const request = {url, headers, start, end};
+    requests.push(request);
+    const interceptedResponse = options.intercept?.(request, requestOptions);
+    if (interceptedResponse) {
+      return await interceptedResponse;
+    }
+    const etag = options.getEtag?.(requestIndex) || '"fixture-v1"';
+    return new Response(fixture.slice(start, end + 1), {
+      status: 206,
+      headers: {
+        'Content-Range': `bytes ${start}-${end}/${fixture.byteLength}`,
+        ETag: etag
+      }
+    });
+  };
+}
+
+/** Creates a fetch that settles only when its request signal is aborted. */
+function createPendingFetch(): {
+  fetch: (url: string, options?: RequestInit) => Promise<Response>;
+  started: Promise<void>;
+} {
+  let markStarted: () => void = () => {};
+  const started = new Promise<void>(resolve => {
+    markStarted = resolve;
+  });
+  const fetch = async (_url: string, options: RequestInit = {}): Promise<Response> => {
+    markStarted();
+    return await new Promise<Response>((_resolve, reject) => {
+      const rejectAborted = () => reject(createAbortError());
+      if (options.signal?.aborted) {
+        rejectAborted();
+      } else {
+        options.signal?.addEventListener('abort', rejectAborted, {once: true});
+      }
+    });
+  };
+  return {fetch, started};
+}
+
+/** Parses the single-range request header produced by the source. */
+function parseRangeHeader(value: string | null): {start: number; end: number} {
+  const match = value?.match(/^bytes=(\d+)-(\d+)$/);
+  if (!match) {
+    throw new Error(`Unexpected Range header: ${value}`);
+  }
+  return {start: Number(match[1]), end: Number(match[2])};
+}
+
+/** Throws an AbortError when a mock request begins in an aborted state. */
+function throwIfAborted(signal?: AbortSignal | null): void {
+  if (signal?.aborted) {
+    throw createAbortError();
+  }
+}
+
+/** Creates a cross-runtime abort error. */
+function createAbortError(): Error {
+  const error = new Error('Request aborted');
+  error.name = 'AbortError';
+  return error;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5701,6 +5701,7 @@ __metadata:
     "@loaders.gl/gis": "npm:5.0.0-alpha.1"
     "@loaders.gl/loader-utils": "npm:5.0.0-alpha.1"
     "@loaders.gl/schema": "npm:5.0.0-alpha.1"
+    "@loaders.gl/schema-utils": "npm:5.0.0-alpha.1"
     "@loaders.gl/wkt": "npm:5.0.0-alpha.1"
     "@probe.gl/log": "npm:^4.1.1"
     "@types/node-int64": "npm:^0.4.29"


### PR DESCRIPTION
## Goals

- Add the selective, cancellable row-group read API proposed in #3525 on top of cached range-backed `ParquetSource`.
- Guarantee that unselected row groups and columns are not fetched.
- Return stable Arrow batches with exact source-row provenance while preserving requested row-group order.

## Changes

- Adds `ParquetSource.read()`, `ParquetReadOptions`, `ParquetBatch`, and provenance types.
- Selects and validates row groups and top-level columns against the cached footer/schema.
- Decodes row groups with bounded concurrency while emitting them in caller-requested order.
- Splits output by `batchSize` and attaches source, row-group, and absolute/relative row offsets.
- Cancels outstanding ranges on caller abort, early iterator return, or source close.
- Adds row-group offsets, physical column-chunk offsets, object-version validation, and strict range behavior.
- Snapshots source defaults before asynchronous iteration and preserves compatibility aliases.
- Keeps the package root metadata-only and exposes synchronous runtime access through `@loaders.gl/parquet/parquet-source-loader`.

## Validation

- `yarn lint fix`
- `yarn build`
- Focused source/compatibility/writer suites — 130 tests passed in Node and 130 in Chromium
- GitHub Actions — website, build/lint, Node 22/24/26, Chromium, and Coveralls passed

## Stack

- Base: `master` (source foundation #3530 is merged)
- This PR: selective row-group/column reads, provenance, and cancellation
- #3533: TypeScript decoder correctness
- #3535: pruning and telemetry
- #3538: worker delivery

Part of #3525.