### PR TITLE
feat(parquet): close TypeScript decoder gaps

### DIFF
--- a/docs/modules/parquet/README.md
+++ b/docs/modules/parquet/README.md
@@ -29,6 +29,7 @@ metadata before Parquet encoding.
 # Attribution
 
 - Based on a fork of https://github.com/ironSource/parquetjs and https://github.com/kbajalc/parquets under MIT license (Copyright (c) 2017 ironSource Ltd.).
+- Delta decoder improvements include adaptations from https://github.com/hyparam/hyparquet under the MIT license (Copyright (c) Hyperparam contributors).
 - Documentation was inspired by [parquet-go](https://github.com/xitongsys/parquet-go/blob/master/LICENSE) under Apache 2 license.
 
 # License

--- a/docs/modules/parquet/api-reference/parquet-source-loader.md
+++ b/docs/modules/parquet/api-reference/parquet-source-loader.md
@@ -97,6 +97,10 @@ Rows are yielded in the requested row-group order even when `concurrency` allows
 decode at once. Ending iteration early, aborting `signal`, or calling `close()` cancels outstanding
 range requests. Network and decode errors are rethrown by the iterator.
 
+The source materializes selected Parquet columns directly and converts those columns into typed
+Arrow batches. It does not construct an intermediate object for every row. Nested columns retain
+their composite values while primitive and logical columns flow through the columnar path.
+
 ### `close(): Promise<void>`
 
 Aborts active requests, closes the range-backed file, and permanently closes the source. Calling
@@ -110,7 +114,7 @@ individual read.
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
 | `parquet.headers` | `HeadersInit` | `undefined` | Headers forwarded to all remote Parquet requests. |
-| `parquet.preserveBinary` | `boolean` | `false` | Preserves decoded binary values as byte arrays. |
+| `parquet.preserveBinary` | `boolean` | `false` | Binary-value policy used by TypeScript-backed column reads. |
 | `parquet.rowGroups` / `read.rowGroups` | `number[]` | all row groups | Row-group indexes to fetch, in output order. |
 | `parquet.columns` / `read.columns` | `string[]` | all columns | Top-level columns to fetch and decode. |
 | `parquet.batchSize` / `read.batchSize` | `number` | one row group | Maximum rows per emitted batch. |
@@ -128,8 +132,6 @@ individual read.
 
 - Decoding runs on the caller thread; worker-backed decoding and transferable Arrow buffers are not
   implemented yet.
-- The TypeScript decoder temporarily materializes object rows before creating Arrow batches. A
-  following tranche will decode directly into typed columns without changing the `read()` API.
 - Downloaded-byte, request-count, network-time, and decode-time telemetry are not yet attached to
   batches.
 - Row-group and column-chunk sizes and offsets are available, but min/max/null statistics are not.

--- a/docs/modules/parquet/formats/parquet.md
+++ b/docs/modules/parquet/formats/parquet.md
@@ -36,7 +36,7 @@ A wide range of compression codecs are supported. Internal parquet compression f
 | `SNAPPY`       | ✅   | ✅    |                                                                         |
 | `BROTLI`       | ✅   | No    |                                                                         |
 | `LZO`          | ❌   | ❌    | There is currently no readily available browser-based LZO module for JS |
-| `LZ4`          | ✅   | ✅    |                                                                         |
+| `LZ4`          | ✅   | ✅    | Reads raw blocks, framed streams, and legacy Hadoop-framed Parquet data |
 | `LZ4_RAW`      | ✅   | ✅    |                                                                         |
 | `ZSTD`         | ✅   | ✅    |                                                                         |
 
@@ -51,9 +51,11 @@ The following Parquet encodings are supported:
 | `PLAIN`                   | ✅   | ✅    | All                                                                                                                                                                      |
 | `PLAIN_DICTIONARY`        | ✅   | ✅    | All                                                                                                                                                                      |
 | `RLE_DICTIONARY`          | ✅   | ❌    | All                                                                                                                                                                      |
-| `DELTA_BINARY_PACKED`     | ❌   | ❌    | `INT32`, `INT64`, `INT_8`, `INT_16`, `INT_32`, `INT_64`, `UINT_8`, `UINT_16`, `UINT_32`, `UINT_64`, `TIME_MILLIS`, `TIME_MICROS`, `TIMESTAMP_MILLIS`, `TIMESTAMP_MICROS` |
-| `DELTA_BYTE_ARRAY`        | ❌   | ❌    | `BYTE_ARRAY`, `UTF8`                                                                                                                                                     |
-| `DELTA_LENGTH_BYTE_ARRAY` | ❌   | ❌    | `BYTE_ARRAY`, `UTF8`                                                                                                                                                     |
+| `DELTA_BINARY_PACKED`     | ✅   | ❌    | `INT32`, `INT64`, `INT_8`, `INT_16`, `INT_32`, `INT_64`, `UINT_8`, `UINT_16`, `UINT_32`, `UINT_64`, `TIME_MILLIS`, `TIME_MICROS`, `TIMESTAMP_MILLIS`, `TIMESTAMP_MICROS` |
+| `DELTA_BYTE_ARRAY`        | ✅   | ❌    | `BYTE_ARRAY`, `UTF8`                                                                                                                                                     |
+| `DELTA_LENGTH_BYTE_ARRAY` | ✅   | ❌    | `BYTE_ARRAY`, `UTF8`                                                                                                                                                     |
+
+The TypeScript backend reads both Data Page V1 and Data Page V2. Delta encodings are decoder-only; the TypeScript writer continues to use its existing encodings.
 
 ## Repetition
 

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -87,6 +87,8 @@ Release Date: 2026
 **@loaders.gl/parquet**
 
 - [`ParquetSourceLoader`](/docs/modules/parquet/api-reference/parquet-source-loader) NEW - adds reusable range-backed Parquet metadata and selective row-group/column reads as cancellable Arrow batches with source provenance and object-version validation. Its lightweight root export dynamically preloads the runtime implementation.
+- `ParquetSourceLoader` now materializes selected columns directly into Arrow batches without an intermediate object-row table.
+- The Parquet TypeScript backend now reads Data Page V2, `DELTA_BINARY_PACKED`, `DELTA_LENGTH_BYTE_ARRAY`, `DELTA_BYTE_ARRAY`, and legacy Hadoop-framed LZ4 data.
 - [`ParquetJSLoader`](/docs/modules/parquet/api-reference/parquet-js-loader) and [`ParquetJSWriter`](/docs/modules/parquet/api-reference/parquet-js-writer) NEW - add the experimental parquetjs plain-row and plain-table APIs.
 - `parquet.shape` on [`ParquetLoader`](/docs/modules/parquet/api-reference/parquet-loader) is now documented for selecting object-row or Arrow output from the canonical wasm-backed loader.
 

--- a/modules/compression/src/lib/lz4-compression.ts
+++ b/modules/compression/src/lib/lz4-compression.ts
@@ -83,13 +83,57 @@ export class LZ4Compression extends Compression {
       }
 
       let uncompressed = new Uint8Array(maxSize);
+      const hadoopSize = this.decodeHadoopBlocks(inputArray, uncompressed);
+      if (hadoopSize !== null) {
+        return toArrayBuffer(uncompressed.slice(0, hadoopSize));
+      }
       const uncompressedSize = this.decodeBlock(inputArray, uncompressed);
+      if (uncompressedSize < 0 || uncompressedSize > maxSize) {
+        throw new Error(`Invalid LZ4 block at byte ${Math.abs(uncompressedSize)}`);
+      }
       uncompressed = uncompressed.slice(0, uncompressedSize);
 
       return toArrayBuffer(uncompressed);
     } catch (error) {
       throw this.improveError(error);
     }
+  }
+
+  /**
+   * Decodes the legacy Hadoop LZ4 block stream used by older Parquet writers.
+   * Returns null when the input is not a valid Hadoop-framed stream.
+   */
+  decodeHadoopBlocks(data: Uint8Array, output: Uint8Array): number | null {
+    let inputOffset = 0;
+    let outputOffset = 0;
+
+    while (inputOffset < data.length) {
+      if (data.length - inputOffset < 8) {
+        return null;
+      }
+      const uncompressedByteLength = readUInt32BE(data, inputOffset);
+      const compressedByteLength = readUInt32BE(data, inputOffset + 4);
+      inputOffset += 8;
+      if (
+        uncompressedByteLength === 0 ||
+        compressedByteLength === 0 ||
+        inputOffset + compressedByteLength > data.length ||
+        outputOffset + uncompressedByteLength > output.length
+      ) {
+        return null;
+      }
+
+      const compressedBlock = data.subarray(inputOffset, inputOffset + compressedByteLength);
+      const outputBlock = output.subarray(outputOffset, outputOffset + uncompressedByteLength);
+      const decodedByteLength = this.decodeBlock(compressedBlock, outputBlock);
+      if (decodedByteLength !== uncompressedByteLength) {
+        return null;
+      }
+      inputOffset += compressedByteLength;
+      outputOffset += uncompressedByteLength;
+    }
+
+    return outputOffset;
   }
 
   /**
@@ -178,4 +222,9 @@ export class LZ4Compression extends Compression {
     const magic = new Uint32Array(data.slice(0, 4));
     return magic[0] === LZ4_MAGIC_NUMBER;
   }
+}
+
+/** Reads one unsigned big-endian 32-bit Hadoop block length. */
+function readUInt32BE(data: Uint8Array, offset: number): number {
+  return new DataView(data.buffer, data.byteOffset, data.byteLength).getUint32(offset, false);
 }

--- a/modules/parquet/src/parquet-source-loader.ts
+++ b/modules/parquet/src/parquet-source-loader.ts
@@ -4,7 +4,7 @@
 
 import type {CoreAPI, ReadableFile, SourceLoader} from '@loaders.gl/loader-utils';
 import {BlobFile, DataSource} from '@loaders.gl/loader-utils';
-import type {Schema} from '@loaders.gl/schema';
+import type {ArrayType, Schema} from '@loaders.gl/schema';
 import {convertTable} from '@loaders.gl/schema-utils';
 
 import {getSchemaFromParquetReader} from './lib/parsers/get-parquet-schema';
@@ -24,7 +24,6 @@ import type {
 import {preloadCompressions} from './parquetjs/compression';
 import {CompressionCodec, Encoding, type FileMetaData} from './parquetjs/parquet-thrift/index';
 import {ParquetReader} from './parquetjs/parser/parquet-reader';
-import type {ParquetRow} from './parquetjs/schema/declare';
 import type {ParquetSchema} from './parquetjs/schema/schema';
 
 export type {
@@ -61,8 +60,10 @@ type ParquetSourceInitialization = {
 type ParquetRowGroupReadResult = {
   /** Zero-based source row-group index. */
   rowGroupIndex: number;
-  /** Materialized rows for the selected columns. */
-  rows: ParquetRow[];
+  /** Materialized columns for the selected fields. */
+  columns: Record<string, ArrayType>;
+  /** Number of logical rows in the decoded row group. */
+  rowCount: number;
 };
 
 type SettledParquetRowGroupRead =
@@ -193,21 +194,27 @@ export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoader
           throw settledRead.error;
         }
 
-        const {rowGroupIndex, rows} = settledRead.result;
-        const outputBatchSize = batchSize || Math.max(rows.length, 1);
+        const {rowGroupIndex, columns: decodedColumns, rowCount} = settledRead.result;
+        const outputBatchSize = batchSize || Math.max(rowCount, 1);
         for (
           let rowGroupRowOffset = 0;
-          rowGroupRowOffset < rows.length;
+          rowGroupRowOffset < rowCount;
           rowGroupRowOffset += outputBatchSize
         ) {
           throwIfAborted(readContext.abortController.signal);
-          const batchRows = rows.slice(rowGroupRowOffset, rowGroupRowOffset + outputBatchSize);
+          const batchRowCount = Math.min(outputBatchSize, rowCount - rowGroupRowOffset);
+          const columns = sliceColumns(
+            decodedColumns,
+            rowGroupRowOffset,
+            rowGroupRowOffset + batchRowCount
+          );
           yield createParquetBatch(
             initialization.metadata,
             projectedSchema,
             rowGroupIndex,
             rowGroupRowOffset,
-            batchRows
+            columns,
+            batchRowCount
           );
         }
       }
@@ -290,8 +297,8 @@ export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoader
       signal
     );
     throwIfAborted(signal);
-    const rows = initialization.parquetSchema.materializeRows(decodedRowGroup);
-    return {rowGroupIndex, rows};
+    const columns = initialization.parquetSchema.materializeColumns(decodedRowGroup);
+    return {rowGroupIndex, columns, rowCount: decodedRowGroup.rowCount};
   }
 
   /** Opens the readable file and decodes its footer and schema once. */
@@ -435,15 +442,16 @@ function createRowGroupMetadata(
   });
 }
 
-/** Converts decoded rows into one Arrow batch and attaches stable source provenance. */
+/** Converts decoded columns into one Arrow batch and attaches stable source provenance. */
 function createParquetBatch(
   metadata: ParquetSourceMetadata,
   schema: Schema,
   rowGroupIndex: number,
   rowGroupRowOffset: number,
-  rows: ParquetRow[]
+  columns: Record<string, ArrayType>,
+  rowCount: number
 ): ParquetBatch {
-  const arrowTable = convertTable({shape: 'object-row-table', schema, data: rows}, 'arrow-table');
+  const arrowTable = convertTable({shape: 'columnar-table', schema, data: columns}, 'arrow-table');
   const rowGroup = metadata.rowGroups[rowGroupIndex];
   const sourceId = metadata.url || metadata.name;
   const provenance = {
@@ -453,7 +461,7 @@ function createParquetBatch(
     rowGroupIndex,
     rowOffset: rowGroup.rowOffset + rowGroupRowOffset,
     rowGroupRowOffset,
-    rowCount: rows.length
+    rowCount
   };
   return {
     batchType: 'data',
@@ -461,10 +469,26 @@ function createParquetBatch(
     schemaType: 'explicit',
     schema,
     data: arrowTable.data,
-    length: rows.length,
+    length: rowCount,
     metadata: provenance,
     ...provenance
   };
+}
+
+/** Returns a row slice of every decoded column without constructing row objects. */
+function sliceColumns(
+  columns: Record<string, ArrayType>,
+  start: number,
+  end: number
+): Record<string, ArrayType> {
+  const slicedColumns: Record<string, ArrayType> = {};
+  for (const [name, column] of Object.entries(columns)) {
+    const slice = (column as ArrayType & {slice?: (start: number, end: number) => ArrayType}).slice;
+    slicedColumns[name] = slice
+      ? slice.call(column, start, end)
+      : Array.prototype.slice.call(column, start, end);
+  }
+  return slicedColumns;
 }
 
 /** Validates and normalizes requested row-group indexes. */

--- a/modules/parquet/src/parquetjs/LICENSE
+++ b/modules/parquet/src/parquetjs/LICENSE
@@ -18,3 +18,25 @@ PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIG
 HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+The delta decoder also includes adaptations from
+https://github.com/hyparam/hyparquet under the MIT license.
+
+Copyright (c) Hyperparam contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/modules/parquet/src/parquetjs/codecs/delta.ts
+++ b/modules/parquet/src/parquetjs/codecs/delta.ts
@@ -1,0 +1,211 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+// Portions adapted from hyparquet, Copyright (c) Hyperparam contributors
+
+import type {PrimitiveType} from '../schema/declare';
+import {copyUint8Array} from '../utils/binary-utils';
+import type {CursorBuffer, ParquetCodecOptions} from './declare';
+
+/** Delta encodings are currently decoder-only in loaders.gl. */
+export function encodeValues(
+  _type: PrimitiveType,
+  _values: unknown[],
+  _options: ParquetCodecOptions
+): Uint8Array {
+  throw new Error('Parquet delta encoding is not supported by the TypeScript writer');
+}
+
+/** Decodes one Parquet delta encoding based on its registered codec name. */
+export function decodeDeltaBinaryPackedValues(
+  type: PrimitiveType,
+  cursor: CursorBuffer,
+  count: number,
+  _options: ParquetCodecOptions
+): number[] {
+  if (type !== 'INT32' && type !== 'INT64') {
+    throw new Error(`DELTA_BINARY_PACKED does not support Parquet type ${type}`);
+  }
+  if (count === 0) {
+    return [];
+  }
+
+  const blockSize = readUnsignedVarIntNumber(cursor);
+  const miniBlockCount = readUnsignedVarIntNumber(cursor);
+  const totalValueCount = readUnsignedVarIntNumber(cursor);
+  if (blockSize <= 0 || miniBlockCount <= 0 || blockSize % miniBlockCount !== 0) {
+    throw new Error('Invalid DELTA_BINARY_PACKED block header');
+  }
+  if (totalValueCount < count) {
+    throw new Error(
+      `DELTA_BINARY_PACKED contains ${totalValueCount} values, expected at least ${count}`
+    );
+  }
+
+  const valuesPerMiniBlock = blockSize / miniBlockCount;
+  if (valuesPerMiniBlock % 8 !== 0) {
+    throw new Error('Invalid DELTA_BINARY_PACKED mini-block size');
+  }
+  let value = readZigZagVarInt(cursor);
+  const values: number[] = [convertDeltaInteger(type, value)];
+
+  while (values.length < count) {
+    const minimumDelta = readZigZagVarInt(cursor);
+    const bitWidths = readBitWidths(cursor, miniBlockCount);
+    for (const bitWidth of bitWidths) {
+      const packedOffset = cursor.offset;
+      const packedByteLength = Math.ceil((valuesPerMiniBlock * bitWidth) / 8);
+      assertReadable(cursor, packedByteLength);
+      const valueCount = Math.min(valuesPerMiniBlock, count - values.length);
+      for (let index = 0; index < valueCount; index++) {
+        const packedDelta = readPackedUnsignedInteger(
+          cursor.buffer,
+          packedOffset,
+          index * bitWidth,
+          bitWidth
+        );
+        value += minimumDelta + packedDelta;
+        values.push(convertDeltaInteger(type, value));
+      }
+      cursor.offset += packedByteLength;
+      if (values.length === count) {
+        break;
+      }
+    }
+  }
+
+  return values;
+}
+
+/** Converts one accumulated delta value with the physical integer type's wrapping semantics. */
+function convertDeltaInteger(type: PrimitiveType, value: bigint): number {
+  return Number(BigInt.asIntN(type === 'INT32' ? 32 : 64, value));
+}
+
+/** Decodes lengths with delta packing followed by contiguous byte-array payloads. */
+export function decodeDeltaLengthByteArrayValues(
+  type: PrimitiveType,
+  cursor: CursorBuffer,
+  count: number,
+  options: ParquetCodecOptions
+): Uint8Array[] {
+  assertByteArrayType(type, 'DELTA_LENGTH_BYTE_ARRAY');
+  const lengths = decodeDeltaBinaryPackedValues('INT32', cursor, count, options);
+  return lengths.map(length => readByteArray(cursor, length));
+}
+
+/** Decodes prefix lengths and delta-length suffixes into complete byte-array values. */
+export function decodeDeltaByteArrayValues(
+  type: PrimitiveType,
+  cursor: CursorBuffer,
+  count: number,
+  options: ParquetCodecOptions
+): Uint8Array[] {
+  assertByteArrayType(type, 'DELTA_BYTE_ARRAY');
+  const prefixLengths = decodeDeltaBinaryPackedValues('INT32', cursor, count, options);
+  const suffixes = decodeDeltaLengthByteArrayValues(type, cursor, count, options);
+  const values: Uint8Array[] = [];
+
+  for (let index = 0; index < count; index++) {
+    const previousValue = values[index - 1];
+    const prefixLength = prefixLengths[index];
+    const suffix = suffixes[index];
+    if (prefixLength < 0 || (prefixLength > 0 && prefixLength > (previousValue?.length || 0))) {
+      throw new Error(`Invalid DELTA_BYTE_ARRAY prefix length ${prefixLength}`);
+    }
+    if (prefixLength === 0) {
+      values.push(suffix);
+      continue;
+    }
+    const value = new Uint8Array(prefixLength + suffix.length);
+    value.set(previousValue.subarray(0, prefixLength));
+    value.set(suffix, prefixLength);
+    values.push(value);
+  }
+
+  return values;
+}
+
+/** Reads a sequence of one-byte mini-block bit widths. */
+function readBitWidths(cursor: CursorBuffer, count: number): number[] {
+  assertReadable(cursor, count);
+  const bitWidths = Array.from(cursor.buffer.subarray(cursor.offset, cursor.offset + count));
+  cursor.offset += count;
+  if (bitWidths.some(bitWidth => bitWidth > 64)) {
+    throw new Error('Invalid DELTA_BINARY_PACKED bit width');
+  }
+  return bitWidths;
+}
+
+/** Reads an unsigned little-endian bit-packed integer without changing the cursor. */
+function readPackedUnsignedInteger(
+  buffer: Uint8Array,
+  byteOffset: number,
+  bitOffset: number,
+  bitWidth: number
+): bigint {
+  let value = 0n;
+  for (let bitIndex = 0; bitIndex < bitWidth; bitIndex++) {
+    const sourceBit = bitOffset + bitIndex;
+    const byte = buffer[byteOffset + Math.floor(sourceBit / 8)];
+    if (byte & (1 << (sourceBit % 8))) {
+      value |= 1n << BigInt(bitIndex);
+    }
+  }
+  return value;
+}
+
+/** Reads an unsigned base-128 variable-length integer. */
+function readUnsignedVarInt(cursor: CursorBuffer): bigint {
+  let value = 0n;
+  for (let byteIndex = 0; byteIndex < 10; byteIndex++) {
+    assertReadable(cursor, 1);
+    const byte = cursor.buffer[cursor.offset++];
+    value |= BigInt(byte & 0x7f) << BigInt(byteIndex * 7);
+    if ((byte & 0x80) === 0) {
+      return value;
+    }
+  }
+  throw new Error('Invalid Parquet variable-length integer');
+}
+
+/** Reads an unsigned variable-length integer that must fit safely in a number. */
+function readUnsignedVarIntNumber(cursor: CursorBuffer): number {
+  const value = readUnsignedVarInt(cursor);
+  if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error('Parquet variable-length integer exceeds the safe integer range');
+  }
+  return Number(value);
+}
+
+/** Reads a zig-zag encoded signed variable-length integer. */
+function readZigZagVarInt(cursor: CursorBuffer): bigint {
+  const value = readUnsignedVarInt(cursor);
+  return (value >> 1n) ^ -(value & 1n);
+}
+
+/** Reads and copies one byte array of a validated length. */
+function readByteArray(cursor: CursorBuffer, length: number): Uint8Array {
+  if (!Number.isInteger(length) || length < 0) {
+    throw new Error(`Invalid delta byte-array length ${length}`);
+  }
+  assertReadable(cursor, length);
+  const value = copyUint8Array(cursor.buffer.subarray(cursor.offset, cursor.offset + length));
+  cursor.offset += length;
+  return value;
+}
+
+/** Restricts byte-array delta encodings to their Parquet physical types. */
+function assertByteArrayType(type: PrimitiveType, encoding: string): void {
+  if (type !== 'BYTE_ARRAY' && type !== 'FIXED_LEN_BYTE_ARRAY') {
+    throw new Error(`${encoding} does not support Parquet type ${type}`);
+  }
+}
+
+/** Ensures a codec read stays inside the current page buffer. */
+function assertReadable(cursor: CursorBuffer, byteLength: number): void {
+  const size = cursor.size ?? cursor.buffer.length;
+  if (byteLength < 0 || cursor.offset + byteLength > size) {
+    throw new Error('Unexpected end of Parquet delta-encoded data');
+  }
+}

--- a/modules/parquet/src/parquetjs/codecs/index.ts
+++ b/modules/parquet/src/parquetjs/codecs/index.ts
@@ -9,6 +9,7 @@ import type {ParquetCodecKit} from './declare';
 import * as PLAIN from './plain';
 import * as RLE from './rle';
 import * as DICTIONARY from './dictionary';
+import * as DELTA from './delta';
 
 export * from './declare';
 
@@ -32,5 +33,17 @@ export const PARQUET_CODECS: Record<ParquetCodec, ParquetCodecKit> = {
     // @ts-ignore
     encodeValues: DICTIONARY.encodeValues,
     decodeValues: DICTIONARY.decodeValues
+  },
+  DELTA_BINARY_PACKED: {
+    encodeValues: DELTA.encodeValues,
+    decodeValues: DELTA.decodeDeltaBinaryPackedValues
+  },
+  DELTA_LENGTH_BYTE_ARRAY: {
+    encodeValues: DELTA.encodeValues,
+    decodeValues: DELTA.decodeDeltaLengthByteArrayValues
+  },
+  DELTA_BYTE_ARRAY: {
+    encodeValues: DELTA.encodeValues,
+    decodeValues: DELTA.decodeDeltaByteArrayValues
   }
 };

--- a/modules/parquet/src/parquetjs/parser/decoders.ts
+++ b/modules/parquet/src/parquetjs/parser/decoders.ts
@@ -70,11 +70,14 @@ export async function decodeDataPages(
 
     const valueEncoding = getThriftEnum(
       Encoding,
-      page.pageHeader.data_page_header?.encoding!
+      page.pageHeader.data_page_header?.encoding ?? page.pageHeader.data_page_header_v2?.encoding!
     ) as ParquetCodec;
     // Pages might be in different encodings. We don't need to decode in case
     // of 'PLAIN' encoding because all values are already in place
-    if (dictionary.length && valueEncoding !== 'PLAIN') {
+    if (
+      dictionary.length &&
+      (valueEncoding === 'PLAIN_DICTIONARY' || valueEncoding === 'RLE_DICTIONARY')
+    ) {
       // eslint-disable-next-line no-loop-func
       page.values = page.values.map(value => dictionary[value]);
     }
@@ -304,7 +307,7 @@ async function decodeDataPage(
   const valueEncoding = getThriftEnum(Encoding, header.data_page_header?.encoding!) as ParquetCodec;
   const decodeOptions: ParquetCodecOptions = {
     typeLength: context.column.typeLength,
-    bitWidth: context.column.typeLength
+    bitWidth: getValueBitWidth(context, valueEncoding)
   };
 
   const values = decodeValues(
@@ -336,62 +339,95 @@ async function decodeDataPageV2(
   header: PageHeader,
   context: ParquetReaderContext
 ): Promise<ParquetPageData> {
+  const dataPageHeader = header.data_page_header_v2;
+  if (!dataPageHeader) {
+    throw new Error('Missing Parquet data page v2 header');
+  }
   const cursorEnd = cursor.offset + header.compressed_page_size;
-
-  const valueCount = header.data_page_header_v2?.num_values;
-  // @ts-ignore
-  const valueCountNonNull = valueCount - header.data_page_header_v2?.num_nulls;
-  const valueEncoding = getThriftEnum(
-    Encoding,
-    header.data_page_header_v2?.encoding!
-  ) as ParquetCodec;
+  const levelsOffset = cursor.offset;
+  const valueCount = dataPageHeader.num_values;
+  const valueCountNonNull = valueCount - dataPageHeader.num_nulls;
+  const valueEncoding = getThriftEnum(Encoding, dataPageHeader.encoding) as ParquetCodec;
+  if (
+    header.compressed_page_size < 0 ||
+    cursorEnd > (cursor.size ?? cursor.buffer.length) ||
+    valueCountNonNull < 0
+  ) {
+    throw new Error('Invalid Parquet data page v2 header');
+  }
 
   /* read repetition levels */
   // tslint:disable-next-line:prefer-array-literal
   let rLevels = new Array(valueCount);
   if (context.column.rLevelMax > 0) {
-    rLevels = decodeValues(PARQUET_RDLVL_TYPE, PARQUET_RDLVL_ENCODING, cursor, valueCount!, {
-      bitWidth: getBitWidth(context.column.rLevelMax),
-      disableEnvelope: true
-    });
+    const repetitionLevelCursor = createPageSliceCursor(
+      cursor,
+      levelsOffset,
+      dataPageHeader.repetition_levels_byte_length
+    );
+    rLevels = decodeValues(
+      PARQUET_RDLVL_TYPE,
+      PARQUET_RDLVL_ENCODING,
+      repetitionLevelCursor,
+      valueCount,
+      {
+        bitWidth: getBitWidth(context.column.rLevelMax),
+        disableEnvelope: true
+      }
+    );
   } else {
     rLevels.fill(0);
   }
+  const definitionLevelsOffset = levelsOffset + dataPageHeader.repetition_levels_byte_length;
 
   /* read definition levels */
   // tslint:disable-next-line:prefer-array-literal
   let dLevels = new Array(valueCount);
   if (context.column.dLevelMax > 0) {
-    dLevels = decodeValues(PARQUET_RDLVL_TYPE, PARQUET_RDLVL_ENCODING, cursor, valueCount!, {
-      bitWidth: getBitWidth(context.column.dLevelMax),
-      disableEnvelope: true
-    });
+    const definitionLevelCursor = createPageSliceCursor(
+      cursor,
+      definitionLevelsOffset,
+      dataPageHeader.definition_levels_byte_length
+    );
+    dLevels = decodeValues(
+      PARQUET_RDLVL_TYPE,
+      PARQUET_RDLVL_ENCODING,
+      definitionLevelCursor,
+      valueCount,
+      {
+        bitWidth: getBitWidth(context.column.dLevelMax),
+        disableEnvelope: true
+      }
+    );
   } else {
     dLevels.fill(0);
   }
 
   /* read values */
-  let valuesBufCursor = cursor;
-
-  if (header.data_page_header_v2?.is_compressed) {
-    const valuesBuf = await decompress(
-      context.compression,
-      cursor.buffer.slice(cursor.offset, cursorEnd),
-      header.uncompressed_page_size
-    );
-
-    valuesBufCursor = {
-      buffer: valuesBuf,
-      offset: 0,
-      size: valuesBuf.length
-    };
-
-    cursor.offset = cursorEnd;
+  const valuesOffset = definitionLevelsOffset + dataPageHeader.definition_levels_byte_length;
+  const valuesCompressedByteLength = cursorEnd - valuesOffset;
+  const valuesUncompressedByteLength =
+    header.uncompressed_page_size -
+    dataPageHeader.repetition_levels_byte_length -
+    dataPageHeader.definition_levels_byte_length;
+  if (valuesCompressedByteLength < 0 || valuesUncompressedByteLength < 0) {
+    throw new Error('Invalid Parquet data page v2 level lengths');
   }
+  let valuesBuffer = cursor.buffer.subarray(valuesOffset, cursorEnd);
+
+  if (dataPageHeader.is_compressed !== false && context.compression !== 'UNCOMPRESSED') {
+    valuesBuffer = await decompress(
+      context.compression,
+      valuesBuffer,
+      valuesUncompressedByteLength
+    );
+  }
+  const valuesBufCursor = {buffer: valuesBuffer, offset: 0, size: valuesBuffer.length};
+  cursor.offset = cursorEnd;
 
   const decodeOptions = {
     typeLength: context.column.typeLength,
-    bitWidth: context.column.typeLength
+    bitWidth: getValueBitWidth(context, valueEncoding)
   };
 
   const values = decodeValues(
@@ -406,9 +442,34 @@ async function decodeDataPageV2(
     dlevels: dLevels,
     rlevels: rLevels,
     values,
-    count: valueCount!,
+    count: valueCount,
     pageHeader: header
   };
+}
+
+/** Returns the physical value bit width required by encodings such as RLE BOOLEAN. */
+function getValueBitWidth(
+  context: ParquetReaderContext,
+  encoding: ParquetCodec
+): number | undefined {
+  if (encoding === 'RLE' && context.column.primitiveType === 'BOOLEAN') {
+    return 1;
+  }
+  return context.column.typeLength;
+}
+
+/** Creates a bounded cursor over one uncompressed data page v2 level section. */
+function createPageSliceCursor(
+  cursor: CursorBuffer,
+  offset: number,
+  byteLength: number
+): CursorBuffer {
+  const end = offset + byteLength;
+  if (byteLength < 0 || end > (cursor.size ?? cursor.buffer.length)) {
+    throw new Error('Invalid Parquet data page v2 level lengths');
+  }
+  const buffer = cursor.buffer.subarray(offset, end);
+  return {buffer, offset: 0, size: buffer.length};
 }
 
 /**

--- a/modules/parquet/src/parquetjs/schema/declare.ts
+++ b/modules/parquet/src/parquetjs/schema/declare.ts
@@ -7,7 +7,14 @@
 import Int64 from 'node-int64';
 import type {PageHeader} from '../parquet-thrift';
 
-export type ParquetCodec = 'PLAIN' | 'RLE' | 'PLAIN_DICTIONARY';
+export type ParquetCodec =
+  | 'PLAIN'
+  | 'RLE'
+  | 'PLAIN_DICTIONARY'
+  | 'RLE_DICTIONARY'
+  | 'DELTA_BINARY_PACKED'
+  | 'DELTA_LENGTH_BYTE_ARRAY'
+  | 'DELTA_BYTE_ARRAY';
 export type ParquetCompression =
   | 'UNCOMPRESSED'
   | 'GZIP'

--- a/modules/parquet/src/parquetjs/schema/schema.ts
+++ b/modules/parquet/src/parquetjs/schema/schema.ts
@@ -15,7 +15,8 @@ import {
   RepetitionType,
   SchemaDefinition
 } from './declare';
-import {materializeRows, shredBuffer, shredRecord} from './shred';
+import type {ArrayType} from '@loaders.gl/schema';
+import {materializeColumns, materializeRows, shredBuffer, shredRecord} from './shred';
 import {PARQUET_LOGICAL_TYPES} from './types';
 
 /**
@@ -80,6 +81,11 @@ export class ParquetSchema {
 
   materializeRows(rowGroup: ParquetRowGroup): ParquetRow[] {
     return materializeRows(this, rowGroup);
+  }
+
+  /** Materializes one decoded row group as top-level column arrays. */
+  materializeColumns(rowGroup: ParquetRowGroup): Record<string, ArrayType> {
+    return materializeColumns(this, rowGroup);
   }
 
   compress(type: ParquetCompression): this {

--- a/modules/parquet/src/parquetjs/schema/shred.ts
+++ b/modules/parquet/src/parquetjs/schema/shred.ts
@@ -300,23 +300,12 @@ function materializeColumnAsColumnarArray(
 
   const columnName = branch[0].name;
 
-  let column: ArrayType | undefined;
-  const {values} = columnData;
-  if (values.length === rowCount && branch[0].primitiveType) {
-    // if (branch[0].repetitionType === `REQUIRED`) {
-    //   switch (branch[0].primitiveType) {
-    //     case 'INT32': return values instanceof Int32Array ? values : new Int32Array(values);
-    //   }
-    // }
-    column = values;
-  }
-
-  if (column) {
-    columns[columnName] = column;
+  if (branch.length === 1 && field.repetitionType !== 'REPEATED') {
+    columns[columnName] = materializeFlatColumn(field, columnData, rowCount);
     return;
   }
 
-  column = new Array(rowCount);
+  const column: ArrayType = new Array(rowCount);
   for (let i = 0; i < rowCount; i++) {
     column[i] = {};
   }
@@ -396,4 +385,25 @@ function materializeColumnAsColumnarArray(
       column[i] = (column[i] as object)[columnName];
     }
   }
+}
+
+/** Materializes a required or optional top-level primitive column with logical type conversion. */
+function materializeFlatColumn(
+  field: ParquetField,
+  columnData: ParquetColumnChunk,
+  rowCount: number
+): ArrayType {
+  const column = new Array(rowCount).fill(null);
+  let valueIndex = 0;
+  for (let rowIndex = 0; rowIndex < Math.min(columnData.count, rowCount); rowIndex++) {
+    if (columnData.dlevels[rowIndex] === field.dLevelMax) {
+      column[rowIndex] = Types.fromPrimitive(
+        field.originalType || field.primitiveType!,
+        columnData.values[valueIndex],
+        field
+      );
+      valueIndex++;
+    }
+  }
+  return column;
 }

--- a/modules/parquet/test/data/files.ts
+++ b/modules/parquet/test/data/files.ts
@@ -95,7 +95,7 @@ export const PARQUET_FILES: ParquetTestFile[] = [
   {
     title: 'datapage_v2',
     path: 'good/datapage_v2.snappy.parquet',
-    supportedJs: false,
+    supportedJs: true,
     supportedWasm: true,
     supportedHyparquet: true
   },
@@ -123,7 +123,7 @@ export const PARQUET_FILES: ParquetTestFile[] = [
   {
     title: 'hadoop_lz4_compressed',
     path: 'good/hadoop_lz4_compressed.parquet',
-    supportedJs: false,
+    supportedJs: true,
     supportedWasm: true,
     supportedHyparquet: true
   },
@@ -229,28 +229,28 @@ export const PARQUET_FILES: ParquetTestFile[] = [
   {
     title: 'delta_binary_packed',
     path: 'good/delta_binary_packed.parquet',
-    supportedJs: false,
+    supportedJs: true,
     supportedWasm: true,
     supportedHyparquet: true
   },
   {
     title: 'delta_byte_array',
     path: 'good/delta_byte_array.parquet',
-    supportedJs: false,
+    supportedJs: true,
     supportedWasm: true,
     supportedHyparquet: true
   },
   {
     title: 'delta_encoding_optional_column',
     path: 'good/delta_encoding_optional_column.parquet',
-    supportedJs: false,
+    supportedJs: true,
     supportedWasm: true,
     supportedHyparquet: true
   },
   {
     title: 'delta_encoding_required_column',
     path: 'good/delta_encoding_required_column.parquet',
-    supportedJs: false,
+    supportedJs: true,
     supportedWasm: true,
     supportedHyparquet: true
   },

--- a/modules/parquet/test/index.ts
+++ b/modules/parquet/test/index.ts
@@ -8,6 +8,7 @@ import './make-stream-iterator.spec';
 // parquetjs unit test suite
 import './parquetjs/codec-plain.spec';
 import './parquetjs/codec-rle.spec';
+import './parquetjs/codec-delta.spec';
 import './parquetjs/schema.spec';
 import './parquetjs/shred.spec';
 import './parquetjs/thrift.spec';

--- a/modules/parquet/test/parquet-compatibility.spec.ts
+++ b/modules/parquet/test/parquet-compatibility.spec.ts
@@ -7,6 +7,7 @@ import type {Test} from 'tape';
 
 import {fetchFile, load} from '@loaders.gl/core';
 import {ParquetLoader} from '@loaders.gl/parquet';
+import type {ObjectRowTable} from '@loaders.gl/schema';
 import {parquetReadObjects} from 'hyparquet';
 import {compressors} from 'hyparquet-compressors';
 
@@ -17,9 +18,19 @@ const PARQUET_DIRECTORY = '@loaders.gl/parquet/test/data/apache';
 type CompatibilityResult = {
   supported: boolean;
   error?: string;
+  rows?: unknown[];
 };
 
 type LoadersGlBackend = 'typescript' | 'wasm';
+
+const TYPESCRIPT_DIFFERENTIAL_FIXTURES = new Set([
+  'datapage_v2',
+  'hadoop_lz4_compressed',
+  'delta_binary_packed',
+  'delta_byte_array',
+  'delta_encoding_optional_column',
+  'delta_encoding_required_column'
+]);
 
 for (const backend of ['typescript', 'wasm'] as const) {
   const supportProperty = backend === 'typescript' ? 'supportedJs' : 'supportedWasm';
@@ -47,6 +58,26 @@ for (const fixture of PARQUET_FILES) {
   });
 }
 
+for (const fixture of PARQUET_FILES.filter(({title}) => TYPESCRIPT_DIFFERENTIAL_FIXTURES.has(title))) {
+  test(`Parquet compatibility differential#typescript#${fixture.title}`, async (t) => {
+    const url = `${PARQUET_DIRECTORY}/${fixture.path}`;
+    const file = await readCompatibilityFixture(url);
+    const [loadersGlResult, hyparquetResult] = await Promise.all([
+      readWithLoadersGl(file, 'typescript'),
+      readWithHyparquet(file)
+    ]);
+
+    t.ok(loadersGlResult.supported, 'TypeScript backend reads the fixture');
+    t.ok(hyparquetResult.supported, 'hyparquet reads the fixture');
+    t.deepEqual(
+      normalizeRows(loadersGlResult.rows || []),
+      normalizeRows(hyparquetResult.rows || []),
+      'decoded rows match the reference implementation'
+    );
+    t.end();
+  });
+}
+
 /** Fetch and validate one fixture independently of the backend compatibility result. */
 async function readCompatibilityFixture(url: string): Promise<ArrayBuffer> {
   const response = await fetchFile(url);
@@ -62,11 +93,11 @@ async function readWithLoadersGl(
   backend: LoadersGlBackend
 ): Promise<CompatibilityResult> {
   try {
-    await load(file, ParquetLoader, {
+    const table = (await load(file, ParquetLoader, {
       core: {worker: false},
       parquet: {backend}
-    });
-    return {supported: true};
+    })) as ObjectRowTable;
+    return {supported: true, rows: table.data};
   } catch (error) {
     return {supported: false, error: getErrorMessage(error)};
   }
@@ -75,11 +106,56 @@ async function readWithLoadersGl(
 /** Read one compatibility fixture through the external hyparquet reference implementation. */
 async function readWithHyparquet(file: ArrayBuffer): Promise<CompatibilityResult> {
   try {
-    await parquetReadObjects({file, compressors});
-    return {supported: true};
+    const rows = await parquetReadObjects({file, compressors});
+    return {supported: true, rows};
   } catch (error) {
     return {supported: false, error: getErrorMessage(error)};
   }
+}
+
+/** Normalizes backend-specific scalar representations before differential comparison. */
+function normalizeRows(rows: unknown[]): unknown[] {
+  return rows.map(row => normalizeValue(row));
+}
+
+/** Normalizes bigint, binary, date, array, and object values recursively. */
+function normalizeValue(value: unknown): unknown {
+  if (typeof value === 'bigint') {
+    return Number(value);
+  }
+  if (typeof value === 'string') {
+    return Array.from(new TextEncoder().encode(value));
+  }
+  if (value instanceof Date) {
+    return value.valueOf();
+  }
+  if (ArrayBuffer.isView(value)) {
+    return Array.from(value as ArrayLike<number>);
+  }
+  if (Array.isArray(value)) {
+    return value.map(item => normalizeValue(item));
+  }
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value);
+    if (
+      entries.length === 1 &&
+      entries[0][0] === 'list' &&
+      Array.isArray(entries[0][1])
+    ) {
+      return entries[0][1].map(item => {
+        if (item && typeof item === 'object' && Object.keys(item).length === 1 && 'element' in item) {
+          return normalizeValue(item.element);
+        }
+        return normalizeValue(item);
+      });
+    }
+    return Object.fromEntries(
+      entries
+        .filter(([, item]) => item !== undefined && item !== null)
+        .map(([key, item]) => [key, normalizeValue(item)])
+    );
+  }
+  return value;
 }
 
 /** Assert one observed backend result against the executable matrix. */

--- a/modules/parquet/test/parquet-source-loader.spec.ts
+++ b/modules/parquet/test/parquet-source-loader.spec.ts
@@ -172,6 +172,11 @@ test('ParquetSource#read selects row groups and columns with exact provenance', 
     'returns only rows from the selected row group'
   );
   t.deepEqual(
+    batches.flatMap(batch => Array.from(batch.data.getChild('source_id')?.toArray() || [])),
+    ['source-2', 'source-3'],
+    'converts logical values directly from decoded columns'
+  );
+  t.deepEqual(
     batches[0].schema?.fields.map(field => field.name),
     ['x', 'source_id'],
     'projects the batch schema'

--- a/modules/parquet/test/parquet-typed-array.spec.ts
+++ b/modules/parquet/test/parquet-typed-array.spec.ts
@@ -12,7 +12,7 @@ import {decodeFileMetadata, decodePageHeader} from '../src/parquetjs/utils/read-
 import {ParquetReader} from '../src/parquetjs/parser/parquet-reader';
 import {ParquetEncoder} from '../src/parquetjs/encoder/parquet-encoder';
 import {ParquetSchema} from '../src/parquetjs/schema/schema';
-import {materializeRows} from '../src/parquetjs/schema/shred';
+import {materializeColumns, materializeRows} from '../src/parquetjs/schema/shred';
 import {concatUint8Arrays} from '../src/parquetjs/utils/binary-utils';
 
 const PARQUET_DIR = '@loaders.gl/parquet/test/data';
@@ -296,6 +296,34 @@ test('Parquet row materializer decodes dictionary-backed UTF8 bytes as strings',
   });
 
   t.equal(rows[0].name, 'hello', 'dictionary-selected UTF8 primitive materializes as string');
+  t.end();
+});
+
+test('Parquet column materializer converts logical values and preserves nulls', t => {
+  const schema = new ParquetSchema({
+    name: {
+      type: 'UTF8',
+      optional: true
+    }
+  });
+
+  const columns = materializeColumns(schema, {
+    rowCount: 3,
+    columnData: {
+      name: {
+        dlevels: [1, 0, 1],
+        rlevels: [0, 0, 0],
+        values: [
+          new Uint8Array([104, 101, 108, 108, 111]),
+          new Uint8Array([119, 111, 114, 108, 100])
+        ],
+        count: 3,
+        pageHeaders: []
+      }
+    }
+  });
+
+  t.deepEqual(columns.name, ['hello', null, 'world']);
   t.end();
 });
 

--- a/modules/parquet/test/parquetjs/codec-delta.spec.ts
+++ b/modules/parquet/test/parquetjs/codec-delta.spec.ts
@@ -1,0 +1,90 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'tape-promise/tape';
+import {PARQUET_CODECS} from '@loaders.gl/parquet/parquetjs/codecs';
+
+/** Creates an exact byte vector for concise codec fixtures. */
+function bytes(values: number[]): Uint8Array {
+  return new Uint8Array(values);
+}
+
+test('ParquetCodec::DELTA_BINARY_PACKED#decodes constant deltas', t => {
+  const cursor = {
+    buffer: bytes([0x80, 0x01, 0x04, 0x03, 0x02, 0x02, 0x00, 0x00, 0x00, 0x00]),
+    offset: 0
+  };
+
+  t.deepEqual(PARQUET_CODECS.DELTA_BINARY_PACKED.decodeValues('INT32', cursor, 3, {}), [
+    1, 2, 3
+  ]);
+  t.equal(cursor.offset, cursor.buffer.length, 'consumes the encoded block');
+  t.end();
+});
+
+test('ParquetCodec::DELTA_LENGTH_BYTE_ARRAY#decodes lengths and payloads', t => {
+  const cursor = {
+    buffer: bytes([
+      0x80,
+      0x01,
+      0x04,
+      0x02,
+      0x02,
+      0x02,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x61,
+      0x62,
+      0x63
+    ]),
+    offset: 0
+  };
+
+  const values = PARQUET_CODECS.DELTA_LENGTH_BYTE_ARRAY.decodeValues(
+    'BYTE_ARRAY',
+    cursor,
+    2,
+    {}
+  );
+  t.deepEqual(values.map(value => Array.from(value)), [[0x61], [0x62, 0x63]]);
+  t.equal(cursor.offset, cursor.buffer.length, 'consumes lengths and payloads');
+  t.end();
+});
+
+test('ParquetCodec::DELTA_BYTE_ARRAY#reconstructs shared prefixes', t => {
+  const prefixLengths = [
+    0x80, 0x01, 0x04, 0x02, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00
+  ];
+  const suffixLengths = [
+    0x80, 0x01, 0x04, 0x02, 0x06, 0x03, 0x00, 0x00, 0x00, 0x00
+  ];
+  const cursor = {
+    buffer: bytes([...prefixLengths, ...suffixLengths, 0x61, 0x62, 0x63, 0x64]),
+    offset: 0
+  };
+
+  const values = PARQUET_CODECS.DELTA_BYTE_ARRAY.decodeValues('BYTE_ARRAY', cursor, 2, {});
+  t.deepEqual(values.map(value => Array.from(value)), [
+    [0x61, 0x62, 0x63],
+    [0x61, 0x62, 0x64]
+  ]);
+  t.equal(cursor.offset, cursor.buffer.length, 'consumes prefixes, suffixes, and payloads');
+  t.end();
+});
+
+test('ParquetCodec::DELTA_BINARY_PACKED#rejects truncated data', t => {
+  t.throws(
+    () =>
+      PARQUET_CODECS.DELTA_BINARY_PACKED.decodeValues(
+        'INT32',
+        {buffer: bytes([0x80]), offset: 0},
+        1,
+        {}
+      ),
+    /Unexpected end/
+  );
+  t.end();
+});


### PR DESCRIPTION
## Goals

- Close the highest-value TypeScript Parquet decoder gaps identified by the executable hyparquet comparison.
- Keep selective `ParquetSource` output columnar through Arrow conversion.
- Turn newly supported Apache fixtures into cross-runtime compatibility guarantees.

## Changes

- Adds Data Page V2 and `DELTA_BINARY_PACKED`, `DELTA_LENGTH_BYTE_ARRAY`, and `DELTA_BYTE_ARRAY` decoding.
- Adds legacy Hadoop-framed LZ4 decompression while retaining framed and raw-block LZ4 support.
- Registers `RLE_DICTIONARY` and fixes RLE boolean plus INT32/INT64 delta semantics.
- Materializes selected source columns directly, including logical conversion and nullable flat columns.
- Promotes six Apache fixtures to supported and differentially checks decoded rows against hyparquet.
- Adds focused codec vectors, malformed-input coverage, source columnar assertions, documentation, and attribution.

## Validation

- `yarn lint fix`
- `yarn build`
- Focused decoder/source/compression suites — 145 tests passed in Node; 149 passed and 1 skipped in Chromium
- GitHub Actions — website, build/lint, Node 22/24/26, Chromium, and Coveralls passed

## Stack

- Base: `master` (source foundation #3530 and selective reads #3531 are merged)
- This PR: TypeScript decoder correctness and direct typed-column output
- #3535: pruning and telemetry
- #3538: worker delivery

Part of #3525.