### PR TITLE
feat(parquet): add statistics, pruning, and telemetry

### DIFF
--- a/docs/modules/parquet/api-reference/parquet-source-loader.md
+++ b/docs/modules/parquet/api-reference/parquet-source-loader.md
@@ -70,7 +70,9 @@ Returns cached plain JavaScript metadata copied from the Parquet footer:
 - key/value footer metadata;
 - row counts, absolute row offsets, and compressed/uncompressed byte lengths for each row group;
 - column path, compression, encodings, value count, physical range, byte lengths, and page offsets
-  for each column chunk; and
+  for each column chunk;
+- decoded minimum, maximum, null-count, and distinct-count statistics when supplied by the writer;
+  and
 - `ETag` or `Last-Modified` validators captured from remote objects.
 
 Pass `{formatSpecificMetadata: true}` to include the decoded Parquet Thrift footer. Both metadata and
@@ -101,6 +103,51 @@ The source materializes selected Parquet columns directly and converts those col
 Arrow batches. It does not construct an intermediate object for every row. Nested columns retain
 their composite values while primitive and logical columns flow through the columnar path.
 
+### Row-group pruning
+
+Use `rowGroupFilter` to remove candidate row groups using the normalized footer statistics before
+any selected column chunk is fetched. The filter runs after `rowGroups`, so explicit selection and
+statistics pruning can be combined.
+
+```typescript
+const batches = source.read({
+  columns: ['timestamp', 'value'],
+  rowGroupFilter: rowGroup => {
+    const timestamp = rowGroup.columns.find(column => column.path.join('.') === 'timestamp');
+    // Missing or malformed statistics are unknown: retain the row group.
+    if (timestamp?.statistics?.min === undefined || timestamp.statistics.max === undefined) {
+      return true;
+    }
+    return timestamp.statistics.max >= start && timestamp.statistics.min < end;
+  }
+});
+```
+
+Statistics are optional because Parquet writers are not required to emit them. A safe predicate
+retains a row group whenever the statistics required to prove exclusion are absent.
+
+## Telemetry
+
+`getTelemetry()` returns a cumulative snapshot for the source. `parquet.onTelemetry` additionally
+receives snapshots after range requests, cache hits, pruning, decoding, Arrow conversion, batches,
+cancellation, and failures. Exceptions thrown by the callback do not interrupt a read.
+
+```typescript
+const source = createDataSource(url, [ParquetSourceLoader], {
+  parquet: {
+    onTelemetry: event => console.log(event.type, event.telemetry)
+  }
+});
+
+await Array.fromAsync(source.read());
+console.log(source.getTelemetry());
+```
+
+The snapshot reports exact transport counts and bytes, range-cache hits, cumulative
+network/decode/Arrow durations, candidate/pruned/decoded row groups, emitted batches and rows,
+retries, cancellations, and failures. `retryCount` remains zero while the source uses its fail-fast
+range policy.
+
 ### `close(): Promise<void>`
 
 Aborts active requests, closes the range-backed file, and permanently closes the source. Calling
@@ -115,8 +162,10 @@ individual read.
 | --- | --- | --- | --- |
 | `parquet.headers` | `HeadersInit` | `undefined` | Headers forwarded to all remote Parquet requests. |
 | `parquet.preserveBinary` | `boolean` | `false` | Binary-value policy used by TypeScript-backed column reads. |
+| `parquet.onTelemetry` | `(event: ParquetTelemetryEvent) => void` | `undefined` | Receives cumulative transport, pruning, decode, and batch telemetry events. |
 | `parquet.rowGroups` / `read.rowGroups` | `number[]` | all row groups | Row-group indexes to fetch, in output order. |
 | `parquet.columns` / `read.columns` | `string[]` | all columns | Top-level columns to fetch and decode. |
+| `parquet.rowGroupFilter` / `read.rowGroupFilter` | `(rowGroup: ParquetRowGroupMetadata) => boolean` | keep all | Retains candidate row groups before their column chunks are fetched. |
 | `parquet.batchSize` / `read.batchSize` | `number` | one row group | Maximum rows per emitted batch. |
 | `parquet.concurrency` / `read.concurrency` | `number` | `1` | Maximum row groups decoded concurrently. |
 | `read.signal` | `AbortSignal` | `undefined` | Cancels this read and its outstanding ranges. |
@@ -132,6 +181,3 @@ individual read.
 
 - Decoding runs on the caller thread; worker-backed decoding and transferable Arrow buffers are not
   implemented yet.
-- Downloaded-byte, request-count, network-time, and decode-time telemetry are not yet attached to
-  batches.
-- Row-group and column-chunk sizes and offsets are available, but min/max/null statistics are not.

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -87,6 +87,7 @@ Release Date: 2026
 **@loaders.gl/parquet**
 
 - [`ParquetSourceLoader`](/docs/modules/parquet/api-reference/parquet-source-loader) NEW - adds reusable range-backed Parquet metadata and selective row-group/column reads as cancellable Arrow batches with source provenance and object-version validation. Its lightweight root export dynamically preloads the runtime implementation.
+- `ParquetSourceLoader` exposes normalized column-chunk statistics, predicate-based row-group pruning, and cumulative transport/decode/Arrow telemetry with exact request and byte counts.
 - `ParquetSourceLoader` now materializes selected columns directly into Arrow batches without an intermediate object-row table.
 - The Parquet TypeScript backend now reads Data Page V2, `DELTA_BINARY_PACKED`, `DELTA_LENGTH_BYTE_ARRAY`, `DELTA_BYTE_ARRAY`, and legacy Hadoop-framed LZ4 data.
 - [`ParquetJSLoader`](/docs/modules/parquet/api-reference/parquet-js-loader) and [`ParquetJSWriter`](/docs/modules/parquet/api-reference/parquet-js-writer) NEW - add the experimental parquetjs plain-row and plain-table APIs.

--- a/modules/parquet/src/index.ts
+++ b/modules/parquet/src/index.ts
@@ -17,6 +17,7 @@ export type {
   ParquetBatchMetadata,
   ParquetBatchProvenance,
   ParquetColumnChunkMetadata,
+  ParquetColumnChunkStatistics,
   ParquetMetadataRequestOptions,
   ParquetObjectVersion,
   ParquetRangeRequestOptions,
@@ -25,7 +26,9 @@ export type {
   ParquetSourceBatch,
   ParquetSourceLoaderOptions,
   ParquetSourceMetadata,
-  ParquetSourceReadOptions
+  ParquetSourceReadOptions,
+  ParquetTelemetry,
+  ParquetTelemetryEvent
 } from './parquet-source-types';
 
 export {ParquetWriter} from './parquet-writer';

--- a/modules/parquet/src/lib/sources/parquet-range-file.ts
+++ b/modules/parquet/src/lib/sources/parquet-range-file.ts
@@ -10,9 +10,35 @@ import type {ParquetObjectVersion, ParquetRangeRequestOptions} from '../../parqu
 type FetchLike = (url: string, options?: RequestInit) => Promise<Response>;
 
 type ParquetRangeFileOptions = {
+  /** Fetch implementation used for every HTTP range. */
   fetch: FetchLike;
+  /** Headers forwarded to every HTTP range. */
   headers?: HeadersInit;
+  /** Range coalescing and diagnostics configuration. */
   rangeRequests?: ParquetRangeRequestOptions;
+  /** Receives source-local transport telemetry deltas. */
+  onTelemetry?: (event: ParquetRangeTelemetryEvent) => void;
+};
+
+type ParquetRangeTelemetryEvent = {
+  /** Transport operation that produced this event. */
+  type: 'range-request' | 'cache-hit';
+  /** Number of transport requests contributed by this event. */
+  rangeRequestCount?: number;
+  /** Number of transport bytes requested by this event. */
+  requestedBytes?: number;
+  /** Number of response bytes downloaded by this event. */
+  downloadedBytes?: number;
+  /** Number of cache hits contributed by this event. */
+  cacheHits?: number;
+  /** Network duration contributed by this event. */
+  networkDurationMs?: number;
+  /** Number of failed requests contributed by this event. */
+  failedRangeRequestCount?: number;
+  /** Number of aborted requests contributed by this event. */
+  abortedRangeRequestCount?: number;
+  /** Error associated with a failed range request. */
+  error?: unknown;
 };
 
 type ContentRange = {
@@ -32,6 +58,8 @@ export class ParquetRangeFile implements ReadableFile {
   private readonly fetch: FetchLike;
   /** Headers inherited from source loader options. */
   private readonly headers?: HeadersInit;
+  /** Source telemetry callback invoked after transport and cache operations. */
+  private readonly onTelemetry?: (event: ParquetRangeTelemetryEvent) => void;
   /** Scheduler used to coalesce later row-group reads. */
   private readonly scheduler: RangeRequestScheduler;
   /** Aborts all active requests when the file is closed. */
@@ -51,6 +79,7 @@ export class ParquetRangeFile implements ReadableFile {
     this.url = url;
     this.fetch = options.fetch;
     this.headers = options.headers;
+    this.onTelemetry = options.onTelemetry;
     this.scheduler =
       options.rangeRequests?.scheduler ||
       new RangeRequestScheduler({
@@ -103,6 +132,7 @@ export class ParquetRangeFile implements ReadableFile {
 
     const cached = this.cache.get(getRangeKey(offset, length));
     if (cached) {
+      this.onTelemetry?.({type: 'cache-hit', cacheHits: 1});
       return cached.slice(0);
     }
 
@@ -155,6 +185,7 @@ export class ParquetRangeFile implements ReadableFile {
     validateVersion: boolean
   ): Promise<{response: Response; arrayBuffer: ArrayBuffer; contentRange: ContentRange}> {
     const abortContext = createCombinedAbortSignal(signal, this.closeController.signal);
+    const startTime = getCurrentTime();
     try {
       const response = await this.fetch(this.url, {
         headers: createRangeHeaders(this.headers, offset, length, validateVersion && this.version),
@@ -191,7 +222,26 @@ export class ParquetRangeFile implements ReadableFile {
           `Parquet range response returned ${arrayBuffer.byteLength} bytes; expected ${length}`
         );
       }
+      this.onTelemetry?.({
+        type: 'range-request',
+        rangeRequestCount: 1,
+        requestedBytes: length,
+        downloadedBytes: arrayBuffer.byteLength,
+        networkDurationMs: getCurrentTime() - startTime
+      });
       return {response, arrayBuffer, contentRange};
+    } catch (error) {
+      this.onTelemetry?.({
+        type: 'range-request',
+        rangeRequestCount: 1,
+        requestedBytes: length,
+        networkDurationMs: getCurrentTime() - startTime,
+        failedRangeRequestCount: 1,
+        abortedRangeRequestCount:
+          abortContext.signal.aborted || isAbortError(error) ? 1 : undefined,
+        error
+      });
+      throw error;
     } finally {
       abortContext.dispose();
     }
@@ -203,6 +253,16 @@ export class ParquetRangeFile implements ReadableFile {
       throw new Error('Parquet source is closed');
     }
   }
+}
+
+/** Returns a monotonic timestamp when available and falls back to wall-clock time. */
+function getCurrentTime(): number {
+  return globalThis.performance?.now() ?? Date.now();
+}
+
+/** Returns true for DOM and cross-runtime abort errors. */
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
 }
 
 /** Validates a requested range against the known object byte length. */

--- a/modules/parquet/src/parquet-source-loader-types.ts
+++ b/modules/parquet/src/parquet-source-loader-types.ts
@@ -41,8 +41,10 @@ export const ParquetSourceLoader = {
       columns: undefined,
       batchSize: undefined,
       concurrency: undefined,
+      rowGroupFilter: undefined,
       headers: undefined,
       preserveBinary: false,
+      onTelemetry: undefined,
       wasmUrl: undefined
     },
     rangeRequests: {
@@ -57,8 +59,10 @@ export const ParquetSourceLoader = {
       columns: undefined!,
       batchSize: undefined!,
       concurrency: undefined!,
+      rowGroupFilter: undefined!,
       headers: undefined!,
       preserveBinary: false,
+      onTelemetry: undefined!,
       wasmUrl: undefined!
     },
     rangeRequests: {

--- a/modules/parquet/src/parquet-source-loader.ts
+++ b/modules/parquet/src/parquet-source-loader.ts
@@ -13,24 +13,43 @@ import {ParquetSourceLoader as ParquetSourceLoaderMetadata} from './parquet-sour
 import type {
   ParquetBatch,
   ParquetColumnChunkMetadata,
+  ParquetColumnChunkStatistics,
   ParquetMetadataRequestOptions,
   ParquetObjectVersion,
   ParquetRowGroupMetadata,
   ParquetSourceBatch,
   ParquetSourceLoaderOptions,
   ParquetSourceMetadata,
-  ParquetSourceReadOptions
+  ParquetSourceReadOptions,
+  ParquetTelemetry,
+  ParquetTelemetryEvent
 } from './parquet-source-types';
 import {preloadCompressions} from './parquetjs/compression';
-import {CompressionCodec, Encoding, type FileMetaData} from './parquetjs/parquet-thrift/index';
+import {
+  CompressionCodec,
+  Encoding,
+  type FileMetaData,
+  type Statistics as ParquetThriftStatistics
+} from './parquetjs/parquet-thrift/index';
 import {ParquetReader} from './parquetjs/parser/parquet-reader';
+import type {ParquetField} from './parquetjs/schema/declare';
 import type {ParquetSchema} from './parquetjs/schema/schema';
+import * as Types from './parquetjs/schema/types';
+import {
+  copyUint8Array,
+  readDoubleLE,
+  readFloatLE,
+  readInt32LE,
+  readInt64LE,
+  toUint8Array
+} from './parquetjs/utils/binary-utils';
 
 export type {
   ParquetBatch,
   ParquetBatchMetadata,
   ParquetBatchProvenance,
   ParquetColumnChunkMetadata,
+  ParquetColumnChunkStatistics,
   ParquetMetadataRequestOptions,
   ParquetObjectVersion,
   ParquetRangeRequestOptions,
@@ -39,7 +58,9 @@ export type {
   ParquetSourceBatch,
   ParquetSourceLoaderOptions,
   ParquetSourceMetadata,
-  ParquetSourceReadOptions
+  ParquetSourceReadOptions,
+  ParquetTelemetry,
+  ParquetTelemetryEvent
 } from './parquet-source-types';
 
 type ParquetSourceInitialization = {
@@ -111,6 +132,8 @@ export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoader
   private compressionPromise: Promise<void> | null = null;
   /** Read abort controllers used to cancel active iterators when the source closes. */
   private activeReadControllers = new Set<AbortController>();
+  /** Cumulative source telemetry counters. */
+  private telemetry = createParquetTelemetry();
 
   /** Creates a Parquet source backed by strict URL ranges or Blob slices. */
   constructor(data: string | Blob, options: ParquetSourceLoaderOptions, coreApi?: CoreAPI) {
@@ -139,11 +162,18 @@ export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoader
     };
   }
 
+  /** Returns a copy of cumulative transport, decode, conversion, and pruning telemetry. */
+  getTelemetry(): ParquetTelemetry {
+    return {...this.telemetry};
+  }
+
   /** Selectively fetches row groups and columns as ordered Arrow batches with source provenance. */
   async *read(options: ParquetSourceReadOptions = {}): AsyncIterable<ParquetSourceBatch> {
     const readOptions = this.getReadOptions(options);
     const readContext = createReadAbortContext(readOptions.signal);
     const inFlightReads = new Set<Promise<SettledParquetRowGroupRead>>();
+    let completed = false;
+    let readError: unknown;
     this.activeReadControllers.add(readContext.abortController);
 
     try {
@@ -151,9 +181,22 @@ export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoader
       await this.getCompressionInitialization();
       throwIfAborted(readContext.abortController.signal);
 
-      const rowGroupIndices = normalizeRowGroupIndices(
+      const candidateRowGroupIndices = normalizeRowGroupIndices(
         readOptions.rowGroups,
         initialization.fileMetadata.row_groups.length
+      );
+      const rowGroupIndices = readOptions.rowGroupFilter
+        ? candidateRowGroupIndices.filter(rowGroupIndex =>
+            readOptions.rowGroupFilter!(initialization.metadata.rowGroups[rowGroupIndex])
+          )
+        : candidateRowGroupIndices;
+      this.recordTelemetry(
+        'row-group-prune',
+        {
+          rowGroupsRequested: candidateRowGroupIndices.length,
+          rowGroupsPruned: candidateRowGroupIndices.length - rowGroupIndices.length
+        },
+        {}
       );
       const columns = normalizeColumns(readOptions.columns, initialization.schema);
       const columnList = columns.map(column => [column]);
@@ -208,7 +251,8 @@ export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoader
             rowGroupRowOffset,
             rowGroupRowOffset + batchRowCount
           );
-          yield createParquetBatch(
+          const conversionStartTime = getCurrentTime();
+          const batch = createParquetBatch(
             initialization.metadata,
             projectedSchema,
             rowGroupIndex,
@@ -216,9 +260,33 @@ export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoader
             columns,
             batchRowCount
           );
+          const conversionDurationMs = getCurrentTime() - conversionStartTime;
+          this.recordTelemetry(
+            'arrow-conversion',
+            {arrowConversionDurationMs: conversionDurationMs},
+            {rowGroupIndex, durationMs: conversionDurationMs}
+          );
+          this.recordTelemetry(
+            'batch',
+            {batchesEmitted: 1, rowsEmitted: batchRowCount},
+            {rowGroupIndex, rowCount: batchRowCount}
+          );
+          yield batch;
         }
       }
+      completed = true;
+    } catch (error) {
+      readError = error;
+      if (readContext.abortController.signal.aborted) {
+        this.recordTelemetry('cancel', {cancellationCount: 1}, {error});
+      } else {
+        this.recordTelemetry('read-error', {failedReadCount: 1}, {error});
+      }
+      throw error;
     } finally {
+      if (!completed && readError === undefined) {
+        this.recordTelemetry('cancel', {cancellationCount: 1}, {});
+      }
       readContext.abortController.abort();
       readContext.removeSignalListener();
       this.activeReadControllers.delete(readContext.abortController);
@@ -276,6 +344,7 @@ export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoader
     return {
       rowGroups: rowGroups && [...rowGroups],
       columns: columns && [...columns],
+      rowGroupFilter: options.rowGroupFilter ?? this.options.parquet?.rowGroupFilter,
       batchSize: options.batchSize ?? this.options.parquet?.batchSize,
       concurrency: options.concurrency ?? this.options.parquet?.concurrency,
       signal: options.signal
@@ -289,6 +358,7 @@ export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoader
     columnList: string[][],
     signal: AbortSignal
   ): Promise<ParquetRowGroupReadResult> {
+    const decodeStartTime = getCurrentTime();
     const rowGroup = initialization.fileMetadata.row_groups[rowGroupIndex];
     const decodedRowGroup = await initialization.reader.readRowGroup(
       initialization.parquetSchema,
@@ -298,6 +368,12 @@ export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoader
     );
     throwIfAborted(signal);
     const columns = initialization.parquetSchema.materializeColumns(decodedRowGroup);
+    const decodeDurationMs = getCurrentTime() - decodeStartTime;
+    this.recordTelemetry(
+      'decode',
+      {decodeDurationMs, rowGroupsDecoded: 1},
+      {rowGroupIndex, durationMs: decodeDurationMs}
+    );
     return {rowGroupIndex, columns, rowCount: decodedRowGroup.rowCount};
   }
 
@@ -318,6 +394,7 @@ export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoader
         file,
         fileMetadata,
         schema,
+        parquetSchema,
         file instanceof ParquetRangeFile ? file.objectVersion : undefined
       );
       reader.props.signal = undefined;
@@ -337,10 +414,44 @@ export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoader
     const file = new ParquetRangeFile(this.url, {
       fetch: this.fetch,
       headers: this.options.parquet?.headers,
-      rangeRequests: this.options.rangeRequests
+      rangeRequests: this.options.rangeRequests,
+      onTelemetry: event =>
+        this.recordTelemetry(
+          event.type,
+          {
+            rangeRequestCount: event.rangeRequestCount,
+            requestedBytes: event.requestedBytes,
+            downloadedBytes: event.downloadedBytes,
+            cacheHits: event.cacheHits,
+            networkDurationMs: event.networkDurationMs,
+            failedRangeRequestCount: event.failedRangeRequestCount,
+            abortedRangeRequestCount: event.abortedRangeRequestCount
+          },
+          {durationMs: event.networkDurationMs, error: event.error}
+        )
     });
     this.readableFile = file;
     return await file.open(signal);
+  }
+
+  /** Applies telemetry deltas and emits a callback with the resulting cumulative snapshot. */
+  private recordTelemetry(
+    type: ParquetTelemetryEvent['type'],
+    delta: Partial<ParquetTelemetry>,
+    details: Omit<ParquetTelemetryEvent, 'type' | 'telemetry'>
+  ): void {
+    for (const [key, value] of Object.entries(delta) as Array<
+      [keyof ParquetTelemetry, number | undefined]
+    >) {
+      if (value !== undefined) {
+        this.telemetry[key] += value;
+      }
+    }
+    try {
+      this.options.parquet?.onTelemetry?.({type, telemetry: this.getTelemetry(), ...details});
+    } catch {
+      // Telemetry must never change source read behavior.
+    }
   }
 }
 
@@ -351,13 +462,14 @@ function createParquetSourceMetadata(
   file: ReadableFile,
   fileMetadata: FileMetaData,
   schema: Schema,
+  parquetSchema: ParquetSchema,
   objectVersion?: ParquetObjectVersion
 ): ParquetSourceMetadata {
   let rowOffset = 0;
   const rowGroups = fileMetadata.row_groups.map((rowGroup, index) => {
     const columns = rowGroup.columns
       .filter(columnChunk => Boolean(columnChunk.meta_data))
-      .map(columnChunk => createColumnChunkMetadata(columnChunk));
+      .map(columnChunk => createColumnChunkMetadata(columnChunk, parquetSchema));
     const normalizedRowGroup = createRowGroupMetadata(
       index,
       rowOffset,
@@ -387,7 +499,8 @@ function createParquetSourceMetadata(
 
 /** Normalizes a decoded Parquet column chunk. */
 function createColumnChunkMetadata(
-  columnChunk: FileMetaData['row_groups'][number]['columns'][number]
+  columnChunk: FileMetaData['row_groups'][number]['columns'][number],
+  parquetSchema: ParquetSchema
 ): ParquetColumnChunkMetadata {
   const columnMetadata = columnChunk.meta_data!;
   const dataPageOffset = Number(columnMetadata.data_page_offset);
@@ -395,6 +508,10 @@ function createColumnChunkMetadata(
     columnMetadata.dictionary_page_offset === undefined
       ? undefined
       : Number(columnMetadata.dictionary_page_offset);
+  const statistics = createColumnChunkStatistics(
+    columnMetadata.statistics,
+    parquetSchema.findField(columnMetadata.path_in_schema)
+  );
   const compressedByteLength = Number(columnMetadata.total_compressed_size);
   const uncompressedByteLength = Number(columnMetadata.total_uncompressed_size);
   return Object.freeze({
@@ -414,8 +531,75 @@ function createColumnChunkMetadata(
     uncompressedByteLength,
     uncompressedSize: uncompressedByteLength,
     dataPageOffset,
-    dictionaryPageOffset
+    dictionaryPageOffset,
+    statistics
   });
+}
+
+/** Decodes optional footer statistics into the column's logical value representation. */
+function createColumnChunkStatistics(
+  statistics: ParquetThriftStatistics | undefined,
+  field: ParquetField
+): ParquetColumnChunkStatistics | undefined {
+  if (!statistics) {
+    return undefined;
+  }
+  const minBytes = statistics.min_value ?? statistics.min;
+  const maxBytes = statistics.max_value ?? statistics.max;
+  const result: ParquetColumnChunkStatistics = {
+    nullCount: statistics.null_count === undefined ? undefined : Number(statistics.null_count),
+    distinctCount:
+      statistics.distinct_count === undefined ? undefined : Number(statistics.distinct_count)
+  };
+  if (minBytes) {
+    result.min = decodeStatisticsValueSafely(toUint8Array(minBytes), field);
+  }
+  if (maxBytes) {
+    result.max = decodeStatisticsValueSafely(toUint8Array(maxBytes), field);
+  }
+  if (
+    result.min === undefined &&
+    result.max === undefined &&
+    result.nullCount === undefined &&
+    result.distinctCount === undefined
+  ) {
+    return undefined;
+  }
+  return Object.freeze(result);
+}
+
+/** Decodes one footer statistic and returns undefined for malformed or unsupported values. */
+function decodeStatisticsValueSafely(bytes: Uint8Array, field: ParquetField): unknown {
+  try {
+    let primitiveValue: unknown;
+    switch (field.primitiveType) {
+      case 'BOOLEAN':
+        primitiveValue = Boolean(bytes[0]);
+        break;
+      case 'INT32':
+        primitiveValue = readInt32LE(bytes, 0);
+        break;
+      case 'INT64':
+        primitiveValue = readInt64LE(bytes, 0);
+        break;
+      case 'FLOAT':
+        primitiveValue = readFloatLE(bytes, 0);
+        break;
+      case 'DOUBLE':
+        primitiveValue = readDoubleLE(bytes, 0);
+        break;
+      case 'INT96':
+      case 'BYTE_ARRAY':
+      case 'FIXED_LEN_BYTE_ARRAY':
+        primitiveValue = copyUint8Array(bytes);
+        break;
+      default:
+        return undefined;
+    }
+    return Types.fromPrimitive(field.originalType || field.primitiveType, primitiveValue, field);
+  } catch {
+    return undefined;
+  }
 }
 
 /** Normalizes one decoded row group and derives its compressed byte length. */
@@ -554,6 +738,34 @@ function normalizeConcurrency(concurrency = 1): number {
     throw new Error(`Invalid Parquet concurrency ${concurrency}`);
   }
   return concurrency;
+}
+
+/** Creates a zero-filled telemetry snapshot for one Parquet source. */
+function createParquetTelemetry(): ParquetTelemetry {
+  return {
+    rangeRequestCount: 0,
+    requestedBytes: 0,
+    downloadedBytes: 0,
+    cacheHits: 0,
+    networkDurationMs: 0,
+    failedRangeRequestCount: 0,
+    abortedRangeRequestCount: 0,
+    retryCount: 0,
+    decodeDurationMs: 0,
+    arrowConversionDurationMs: 0,
+    rowGroupsRequested: 0,
+    rowGroupsPruned: 0,
+    rowGroupsDecoded: 0,
+    batchesEmitted: 0,
+    rowsEmitted: 0,
+    cancellationCount: 0,
+    failedReadCount: 0
+  };
+}
+
+/** Returns a monotonic timestamp when available and falls back to wall-clock time. */
+function getCurrentTime(): number {
+  return globalThis.performance?.now() ?? Date.now();
 }
 
 /** Creates a read-scoped abort controller linked to the caller signal. */

--- a/modules/parquet/src/parquet-source-types.ts
+++ b/modules/parquet/src/parquet-source-types.ts
@@ -20,6 +20,18 @@ export type ParquetObjectVersion = {
   lastModified?: string;
 };
 
+/** Footer statistics for one Parquet column chunk. */
+export type ParquetColumnChunkStatistics = {
+  /** Minimum value when the writer supplied valid statistics. */
+  min?: unknown;
+  /** Maximum value when the writer supplied valid statistics. */
+  max?: unknown;
+  /** Number of null values when reported by the writer. */
+  nullCount?: number;
+  /** Number of distinct values when reported by the writer. */
+  distinctCount?: number;
+};
+
 /** Normalized metadata for one Parquet column chunk. */
 export type ParquetColumnChunkMetadata = {
   /** Nested column path in the Parquet schema. */
@@ -46,6 +58,8 @@ export type ParquetColumnChunkMetadata = {
   readonly dataPageOffset: number;
   /** Absolute file offset of the dictionary page, when present. */
   readonly dictionaryPageOffset?: number;
+  /** Optional min/max and count statistics decoded from the footer. */
+  readonly statistics?: ParquetColumnChunkStatistics;
 };
 
 /** Normalized metadata for one Parquet row group. */
@@ -116,12 +130,76 @@ export type ParquetSourceReadOptions = {
   batchSize?: number;
   /** Maximum number of row groups decoded concurrently. */
   concurrency?: number;
+  /** Retains candidate row groups for which the predicate returns true. */
+  rowGroupFilter?: (rowGroup: ParquetRowGroupMetadata) => boolean;
   /** Abort this read and all of its outstanding range requests. */
   signal?: AbortSignal;
 };
 
 /** Compatibility alias for selective source read options. */
 export type ParquetReadOptions = ParquetSourceReadOptions;
+
+/** Cumulative transport, decode, conversion, and pruning counters for one source. */
+export type ParquetTelemetry = {
+  /** Number of HTTP byte-range requests sent by this source. */
+  rangeRequestCount: number;
+  /** Number of transport bytes requested from the remote object. */
+  requestedBytes: number;
+  /** Number of response bytes downloaded from the remote object. */
+  downloadedBytes: number;
+  /** Number of exact byte ranges served from the source cache. */
+  cacheHits: number;
+  /** Total time spent awaiting HTTP range requests. */
+  networkDurationMs: number;
+  /** Number of failed HTTP range requests. */
+  failedRangeRequestCount: number;
+  /** Number of aborted HTTP range requests. */
+  abortedRangeRequestCount: number;
+  /** Retry attempts made by this source. Currently zero because reads fail fast. */
+  retryCount: number;
+  /** Time spent fetching, decompressing, and decoding selected row groups. */
+  decodeDurationMs: number;
+  /** Time spent converting decoded columns into Arrow batches. */
+  arrowConversionDurationMs: number;
+  /** Candidate row groups considered by read operations. */
+  rowGroupsRequested: number;
+  /** Candidate row groups rejected by `rowGroupFilter`. */
+  rowGroupsPruned: number;
+  /** Row groups successfully decoded. */
+  rowGroupsDecoded: number;
+  /** Arrow batches emitted by read operations. */
+  batchesEmitted: number;
+  /** Rows emitted by read operations. */
+  rowsEmitted: number;
+  /** Read operations cancelled by signals, source close, or early iterator return. */
+  cancellationCount: number;
+  /** Read operations that failed for reasons other than cancellation. */
+  failedReadCount: number;
+};
+
+/** Event emitted after one Parquet source telemetry update. */
+export type ParquetTelemetryEvent = {
+  /** Operation that produced the telemetry update. */
+  type:
+    | 'range-request'
+    | 'cache-hit'
+    | 'row-group-prune'
+    | 'decode'
+    | 'arrow-conversion'
+    | 'batch'
+    | 'cancel'
+    | 'read-error';
+  /** Cumulative snapshot after applying this event. */
+  telemetry: ParquetTelemetry;
+  /** Row-group index associated with the event, when applicable. */
+  rowGroupIndex?: number;
+  /** Row count associated with a batch event. */
+  rowCount?: number;
+  /** Duration contributed by this event. */
+  durationMs?: number;
+  /** Error associated with a failed request or read. */
+  error?: unknown;
+};
 
 /** Stable source and row-position information attached to every Parquet batch. */
 export type ParquetBatchProvenance = {
@@ -163,6 +241,8 @@ export type ParquetSourceLoaderOptions = DataSourceOptions & {
     headers?: HeadersInit;
     /** Preserve binary values when the TypeScript decoder is used for later reads. */
     preserveBinary?: boolean;
+    /** Receives cumulative transport, pruning, decode, and batch telemetry events. */
+    onTelemetry?: (event: ParquetTelemetryEvent) => void;
     /** Retained for source API compatibility; the TypeScript backend does not initialize WASM. */
     wasmUrl?: parquetWasm.InitInput | Promise<parquetWasm.InitInput>;
   };

--- a/modules/parquet/test/parquet-source-loader.spec.ts
+++ b/modules/parquet/test/parquet-source-loader.spec.ts
@@ -11,7 +11,8 @@ import {
   ParquetJSWriter,
   ParquetSourceLoader,
   type ParquetSourceLoaderOptions,
-  type ParquetSourceMetadata
+  type ParquetSourceMetadata,
+  type ParquetTelemetryEvent
 } from '@loaders.gl/parquet';
 import {
   ParquetSource,
@@ -19,6 +20,8 @@ import {
 } from '@loaders.gl/parquet/parquet-source-loader';
 
 const FIXTURE_URL = '@loaders.gl/parquet/test/data/apache/good/alltypes_plain.parquet';
+const STATISTICS_FIXTURE_URL =
+  '@loaders.gl/parquet/test/data/apache/good/nullable.impala.parquet';
 const REMOTE_URL = 'https://example.com/data/alltypes_plain.parquet';
 
 /** Lazily encoded three-row-group fixture shared by selective-read tests. */
@@ -122,6 +125,27 @@ test('ParquetSource#read applies snapshotted source defaults', async (t) => {
     batches.every(batch => batch.schema?.fields[0]?.name === 'x'),
     'uses the snapshotted default column projection'
   );
+  await source.close();
+  t.end();
+});
+
+test('ParquetSourceLoader#decodes optional column-chunk statistics', async (t) => {
+  const fixture = await loadFixture(STATISTICS_FIXTURE_URL);
+  const source = createDataSource(new Blob([fixture]), [ParquetSourceLoaderWithParser], {
+    core: {type: 'parquet'}
+  }) as ParquetSource;
+  const metadata = await source.getMetadata();
+  const columns = metadata.rowGroups[0].columns;
+  const idStatistics = columns.find(column => column.path.join('.') === 'id')?.statistics;
+  const keyStatistics = columns.find(
+    column => column.path.join('.') === 'int_map.map.key'
+  )?.statistics;
+
+  t.equal(idStatistics?.min, 1, 'decodes physical INT64 minimum');
+  t.equal(idStatistics?.max, 7, 'decodes physical INT64 maximum');
+  t.equal(idStatistics?.nullCount, 0, 'retains an explicit zero null count');
+  t.equal(keyStatistics?.min, 'k1', 'converts a logical UTF8 minimum');
+  t.equal(keyStatistics?.max, 'k3', 'converts a logical UTF8 maximum');
   await source.close();
   t.end();
 });
@@ -235,6 +259,61 @@ test('ParquetSource#read cancels outstanding ranges when iteration ends early', 
   t.equal(firstBatch.value?.rowGroupIndex, 0, 'emits the first row group in requested order');
   await iterator.return?.();
   t.ok(blockedRequestAborted, 'aborts the concurrently requested next row group');
+  t.equal(source.getTelemetry().cancellationCount, 1, 'counts the cancelled read');
+  t.ok(source.getTelemetry().abortedRangeRequestCount >= 1, 'counts the aborted range');
+  await source.close();
+  t.end();
+});
+
+test('ParquetSource#prunes row groups and reports exact cumulative telemetry', async (t) => {
+  const fixture = await createSelectiveFixture();
+  const requests: RangeRequestRecord[] = [];
+  const events: ParquetTelemetryEvent[] = [];
+  const source = createRemoteSource(createRangeFetch(fixture, {requests}), {
+    parquet: {onTelemetry: event => events.push(event)}
+  });
+  const metadata = await source.getMetadata();
+  const metadataRequestCount = requests.length;
+  const batches = await collectParquetBatches(
+    source.read({
+      rowGroups: [0, 1, 2],
+      columns: ['x'],
+      rowGroupFilter: rowGroup => rowGroup.index !== 1
+    })
+  );
+  const telemetry = source.getTelemetry();
+  const downloadedBytes = requests.reduce(
+    (sum, request) => sum + request.end - request.start + 1,
+    0
+  );
+  const prunedRanges = getColumnRanges(metadata, 1, ['x']);
+  const dataRequests = requests.slice(metadataRequestCount);
+
+  t.deepEqual(
+    batches.flatMap(batch => Array.from(batch.data.getChild('x')?.toArray() || [])),
+    [0, 1, 4, 5],
+    'returns only rows from retained row groups'
+  );
+  t.ok(
+    dataRequests.every(request =>
+      prunedRanges.every(range => request.end < range.start || request.start > range.end)
+    ),
+    'does not fetch the pruned row group column'
+  );
+  t.equal(telemetry.rangeRequestCount, requests.length, 'counts every HTTP range');
+  t.equal(telemetry.requestedBytes, downloadedBytes, 'requested bytes match the server log');
+  t.equal(telemetry.downloadedBytes, downloadedBytes, 'downloaded bytes match the server log');
+  t.equal(telemetry.cacheHits, 1, 'counts the cached header read');
+  t.equal(telemetry.rowGroupsRequested, 3, 'counts candidate row groups');
+  t.equal(telemetry.rowGroupsPruned, 1, 'counts pruned row groups');
+  t.equal(telemetry.rowGroupsDecoded, 2, 'counts decoded row groups');
+  t.equal(telemetry.batchesEmitted, 2, 'counts emitted Arrow batches');
+  t.equal(telemetry.rowsEmitted, 4, 'counts emitted rows');
+  t.ok(telemetry.networkDurationMs >= 0, 'records network duration');
+  t.ok(telemetry.decodeDurationMs >= 0, 'records decode duration');
+  t.ok(telemetry.arrowConversionDurationMs >= 0, 'records Arrow conversion duration');
+  t.ok(events.some(event => event.type === 'row-group-prune'), 'emits a pruning event');
+  t.ok(events.some(event => event.type === 'batch'), 'emits batch events');
   await source.close();
   t.end();
 });
@@ -333,8 +412,8 @@ test('ParquetSourceLoader#abort and close cancel initialization', async (t) => {
 });
 
 /** Loads the shared Parquet fixture into memory for deterministic transport tests. */
-async function loadFixture(): Promise<ArrayBuffer> {
-  const response = await fetchFile(FIXTURE_URL);
+async function loadFixture(url = FIXTURE_URL): Promise<ArrayBuffer> {
+  const response = await fetchFile(url);
   return await response.arrayBuffer();
 }
 


### PR DESCRIPTION
## Goals

- Make Parquet footer statistics usable for selective remote reads.
- Prune row groups before issuing column-chunk range requests.
- Expose cumulative observability for transport, decoding, Arrow conversion, cancellation, and failures.

## Changes

- Normalizes optional min/max/null/distinct column-chunk statistics, including logical value conversion.
- Adds source and per-read `rowGroupFilter` defaults with safe pre-fetch pruning.
- Adds `ParquetSource.getTelemetry()` and `parquet.onTelemetry` event snapshots.
- Counts bytes, requests, cache hits, range failures/aborts, durations, row groups, batches, rows, cancellations, failures, and retries.
- Prevents telemetry callback exceptions from changing read behavior.
- Adds strict server tests proving pruned chunks are never fetched and transport counters match requests.
- Preserves the lightweight root/runtime-subpath split from the preceding tranches.

## Validation

- `yarn lint fix`
- `yarn build`
- Focused source/compatibility/writer suites — 138 tests passed in Node and Chromium
- GitHub Actions — website, build/lint, Node 22/24/26, Chromium, and Coveralls passed

## Stack

- Base: `master` (#3530, #3531, and #3533 are merged)
- This PR: statistics, pruning, and telemetry
- #3538: worker delivery

Part of #3525.