### PR TITLE
feat(parquet): add cancellable worker decode

### DIFF
--- a/docs/modules/parquet/api-reference/parquet-loader.md
+++ b/docs/modules/parquet/api-reference/parquet-loader.md
@@ -43,11 +43,23 @@ import {ParquetLoader} from '@loaders.gl/parquet';
 import {load} from '@loaders.gl/core';
 
 const arrowTable = await load(url, ParquetLoader, {
+  core: {
+    worker: true
+  },
   parquet: {
-    shape: 'arrow-table'
+    shape: 'arrow-table',
+    signal: abortController.signal
   }
 });
 ```
+
+## Worker execution
+
+The default wasm backend can decode on a worker when workers are enabled. The Parquet bytes are transferred into the worker, and Arrow output returns as a transferable Arrow IPC payload that is rehydrated into Apache Arrow class instances on the main thread. Aborting `parquet.signal` terminates the active worker rather than waiting for a non-cancellable WASM call to finish.
+
+The package publishes `parquet-worker.js` and `parquet_wasm_bg.wasm` beside its JavaScript output. The metadata loader resolves the worker with a module-relative `new URL(..., import.meta.url)`, while the worker resolves the WASM file beside itself. This lets compatible bundlers copy and fingerprint both assets without an implicit CDN request. Use `parquet.workerUrl` or `parquet.wasmUrl` when an application serves assets from a custom location.
+
+Set `core.worker: false` to decode on the calling thread. The TypeScript backend currently stays on the calling thread. Node worker threads remain opt-in through `core._nodeWorkers`.
 
 ## Shapes
 
@@ -147,7 +159,9 @@ Supports table category options such as `batchType` and `batchSize`.
 | `parquet.columns` | `string[]` | `undefined` | Restrict parsing to the listed columns. |
 | `parquet.rowGroups` | `number[]` | `undefined` | Restrict reading to the listed row groups for the wasm loader implementations. |
 | `parquet.concurrency` | `number` | `undefined` | Controls parallel reads for the wasm loader implementations. |
-| `parquet.wasmUrl` | `string` | bundled URL | Overrides the `parquet-wasm` binary URL for `ParquetLoader`. |
+| `parquet.signal` | `AbortSignal` | `undefined` | Cancels worker-backed parsing by terminating its active worker. |
+| `parquet.workerUrl` | `string` | package-local asset | Overrides the packaged worker URL. |
+| `parquet.wasmUrl` | `string` | package-local asset | Overrides the `parquet-wasm` binary URL for `ParquetLoader`. |
 
 ## Backend Selection
 

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -89,6 +89,7 @@ Release Date: 2026
 - [`ParquetSourceLoader`](/docs/modules/parquet/api-reference/parquet-source-loader) NEW - adds reusable range-backed Parquet metadata and selective row-group/column reads as cancellable Arrow batches with source provenance and object-version validation. Its lightweight root export dynamically preloads the runtime implementation.
 - `ParquetSourceLoader` exposes normalized column-chunk statistics, predicate-based row-group pruning, and cumulative transport/decode/Arrow telemetry with exact request and byte counts.
 - `ParquetSourceLoader` now materializes selected columns directly into Arrow batches without an intermediate object-row table.
+- The wasm-backed `ParquetLoader` can decode in a cancellable worker, transfers Arrow output through Arrow IPC, and resolves its packaged worker and WASM assets without an implicit CDN dependency.
 - The Parquet TypeScript backend now reads Data Page V2, `DELTA_BINARY_PACKED`, `DELTA_LENGTH_BYTE_ARRAY`, `DELTA_BYTE_ARRAY`, and legacy Hadoop-framed LZ4 data.
 - [`ParquetJSLoader`](/docs/modules/parquet/api-reference/parquet-js-loader) and [`ParquetJSWriter`](/docs/modules/parquet/api-reference/parquet-js-writer) NEW - add the experimental parquetjs plain-row and plain-table APIs.
 - `parquet.shape` on [`ParquetLoader`](/docs/modules/parquet/api-reference/parquet-loader) is now documented for selecting object-row or Arrow output from the canonical wasm-backed loader.

--- a/modules/loader-utils/src/lib/option-utils/merge-options.ts
+++ b/modules/loader-utils/src/lib/option-utils/merge-options.ts
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
+import {isPureObject} from '../javascript-utils/is-type';
+
 export type RequiredOptions<T> = Required<{[K in keyof T]: Required<T[K]>}>;
 
 export function getRequiredOptions<T>(options: T): RequiredOptions<T> {
@@ -33,7 +35,7 @@ function mergeOptionsRecursively(
 
   const options = {...baseOptions};
   for (const [key, newValue] of Object.entries(newOptions)) {
-    if (newValue && typeof newValue === 'object' && !Array.isArray(newValue)) {
+    if (isPureObject(newValue)) {
       options[key] = mergeOptionsRecursively(
         (options[key] as Record<string, unknown>) || {},
         newOptions[key] as Record<string, unknown>,

--- a/modules/loader-utils/src/lib/worker-loader-utils/parse-with-worker.ts
+++ b/modules/loader-utils/src/lib/worker-loader-utils/parse-with-worker.ts
@@ -35,6 +35,13 @@ export function canParseWithWorker(loader: Loader, options?: StrictLoaderOptions
     return false;
   }
 
+  if (
+    loader.id === 'parquet' &&
+    (options as {parquet?: {backend?: string}} | undefined)?.parquet?.backend === 'typescript'
+  ) {
+    return false;
+  }
+
   return Boolean(canProcessOnWorker(loader, workerOptions));
 }
 
@@ -49,10 +56,11 @@ export async function parseWithWorker(
   context?: LoaderContext,
   parseOnMainThread?: ParseOnMainThread
 ) {
+  const signal = getWorkerAbortSignal(options);
   const result = await processOnWorker(
     loader,
     data,
-    getWorkerOptions(options),
+    {...getWorkerOptions(options), signal},
     {
       process: async (input, processOptions, _workerContext, parseContext) => {
         if (!parseOnMainThread) {
@@ -74,6 +82,15 @@ export async function parseWithWorker(
   return isLoaderWithWorkerResultDeserializer(loader)
     ? loader.deserializeWorkerResult(result, options, context)
     : result;
+}
+
+/** Returns the loader-specific abort signal used to cancel a worker job. */
+function getWorkerAbortSignal(options?: StrictLoaderOptions): AbortSignal | undefined {
+  const parquetSignal = (options as {parquet?: {signal?: unknown}} | undefined)?.parquet?.signal;
+  if (typeof AbortSignal !== 'undefined' && parquetSignal instanceof AbortSignal) {
+    return parquetSignal;
+  }
+  return undefined;
 }
 
 /**

--- a/modules/parquet/package.json
+++ b/modules/parquet/package.json
@@ -43,6 +43,13 @@
       "types": "./dist/parquet-source-loader.d.ts",
       "import": "./dist/parquet-source-loader.js",
       "require": "./dist/parquet-source-loader.cjs"
+    },
+    "./parquet-worker.js": {
+      "import": "./dist/parquet-worker.js"
+    },
+    "./parquet-worker-node.cjs": {
+      "import": "./dist/parquet-worker-node.cjs",
+      "require": "./dist/parquet-worker-node.cjs"
     }
   },
   "sideEffects": false,
@@ -52,10 +59,12 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "yarn run copy-wasm",
+    "pre-build": "npm run copy-wasm && npm run build-worker && npm run build-worker-node",
     "build-bundle": "ocular-bundle ./bundle.ts --output=dist/dist.min.js",
     "build-bundle-dev": "ocular-bundle ./bundle.ts --env=dev --output=dist/dist.dev.js",
-    "copy-wasm": "cp ../../node_modules/parquet-wasm/esm/parquet_wasm_bg.wasm dist/parquet_wasm_bg.wasm"
+    "copy-wasm": "cp ../../node_modules/parquet-wasm/esm/parquet_wasm_bg.wasm dist/parquet_wasm_bg.wasm",
+    "build-worker": "esbuild src/workers/parquet-worker.ts --outfile=dist/parquet-worker.js --target=esnext --platform=browser --bundle --sourcemap --inject:src/polyfills/process.ts --banner:js=var\\ global=globalThis\\; --define:__VERSION__=\\\"$npm_package_version\\\"",
+    "build-worker-node": "esbuild src/workers/parquet-worker.ts --outfile=dist/parquet-worker-node.cjs --platform=node --target=node16 --bundle --sourcemap --tree-shaking=false --define:__VERSION__=\\\"$npm_package_version\\\""
   },
   "browser": {
     "child_process": false,

--- a/modules/parquet/src/lib/constants.ts
+++ b/modules/parquet/src/lib/constants.ts
@@ -6,8 +6,6 @@
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
 export const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
-export const PARQUET_WASM_URL = 'https://unpkg.com/parquet-wasm@0.7.1/esm/parquet_wasm_bg.wasm';
-
 /**
  * Parquet File Magic String
  */

--- a/modules/parquet/src/lib/encoders/encode-arrow-to-parquet.ts
+++ b/modules/parquet/src/lib/encoders/encode-arrow-to-parquet.ts
@@ -16,7 +16,7 @@ export async function encodeArrowToParquet(
   table: ArrowTable,
   options: ParquetWriterOptions
 ): Promise<ArrayBuffer> {
-  const wasmUrl = options.parquet?.wasmUrl!;
+  const wasmUrl = options.parquet?.wasmUrl;
   const wasm = await loadWasm(wasmUrl);
 
   // Serialize the table to the IPC format.

--- a/modules/parquet/src/lib/parquet-worker-transport.ts
+++ b/modules/parquet/src/lib/parquet-worker-transport.ts
@@ -1,0 +1,57 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {SerializedArrowTableIPC} from '@loaders.gl/arrow';
+import {deserializeArrowTableFromIPC, serializeArrowTableToIPC} from '@loaders.gl/arrow';
+import type {ArrowTable, ObjectRowTable} from '@loaders.gl/schema';
+
+type ParquetWorkerResult = ArrowTable | ObjectRowTable;
+
+type SerializedArrowTable = Omit<ArrowTable, 'data'> & {
+  /** Transferable Arrow IPC payload produced by the worker. */
+  data: SerializedArrowTableIPC;
+};
+
+/** Serializes a Parquet worker result so Arrow buffers are transferred without cloning. */
+export function serializeParquetWorkerResult(result: unknown): unknown {
+  if (!isArrowTable(result)) {
+    return result;
+  }
+  return {
+    ...result,
+    data: serializeArrowTableToIPC(result.data)
+  };
+}
+
+/** Rehydrates a transferred Parquet Arrow result into main-thread Arrow class instances. */
+export function deserializeParquetWorkerResult(result: unknown): ParquetWorkerResult {
+  if (isSerializedArrowTable(result)) {
+    return {...result, data: deserializeArrowTableFromIPC(result.data)};
+  }
+  return result as ParquetWorkerResult;
+}
+
+/** Returns true when a parser result wraps an Apache Arrow table. */
+function isArrowTable(value: unknown): value is ArrowTable {
+  const table = value as ArrowTable;
+  return Boolean(
+    table &&
+      typeof table === 'object' &&
+      table.shape === 'arrow-table' &&
+      table.data &&
+      'batches' in table.data
+  );
+}
+
+/** Returns true when a worker result contains the loaders.gl Arrow IPC transport format. */
+function isSerializedArrowTable(value: unknown): value is SerializedArrowTable {
+  const table = value as SerializedArrowTable;
+  return Boolean(
+    table &&
+      typeof table === 'object' &&
+      table.shape === 'arrow-table' &&
+      table.data &&
+      table.data.transport === 'arrow-ipc'
+  );
+}

--- a/modules/parquet/src/lib/parsers/convert-parquet-tables.ts
+++ b/modules/parquet/src/lib/parsers/convert-parquet-tables.ts
@@ -1,0 +1,39 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {convertArrowToTable} from '@loaders.gl/schema-utils';
+import type {
+  ArrowTable,
+  ArrowTableBatch,
+  ObjectRowTable,
+  ObjectRowTableBatch
+} from '@loaders.gl/schema';
+
+/**
+ * Converts an Arrow-backed table into object rows.
+ *
+ * @param arrowTable - Arrow table wrapper.
+ * @returns Object-row table.
+ */
+export function convertArrowTableToObjectRows(arrowTable: ArrowTable): ObjectRowTable {
+  return convertArrowToTable(arrowTable.data, 'object-row-table') as ObjectRowTable;
+}
+
+/**
+ * Converts an Arrow batch into object-row output.
+ *
+ * @param batch - Arrow table batch wrapper.
+ * @returns Object-row batch.
+ */
+export function convertArrowBatchToObjectRows(batch: ArrowTableBatch): ObjectRowTableBatch {
+  const objectRowTable = convertArrowToTable(batch.data, 'object-row-table') as ObjectRowTable;
+
+  return {
+    batchType: batch.batchType,
+    shape: objectRowTable.shape,
+    schema: objectRowTable.schema,
+    data: objectRowTable.data,
+    length: batch.length
+  };
+}

--- a/modules/parquet/src/lib/parsers/parse-parquet-tables.ts
+++ b/modules/parquet/src/lib/parsers/parse-parquet-tables.ts
@@ -3,7 +3,6 @@
 // Copyright (c) vis.gl contributors
 
 import type {ReadableFile} from '@loaders.gl/loader-utils';
-import {convertArrowToTable} from '@loaders.gl/schema-utils';
 import type {
   ArrowTable,
   ArrowTableBatch,
@@ -18,6 +17,15 @@ import {
   parseParquetFileToArrowWithJs,
   parseParquetFileToArrowInBatchesWithJs
 } from './parse-parquet-to-arrow-js';
+import {
+  convertArrowBatchToObjectRows,
+  convertArrowTableToObjectRows
+} from './convert-parquet-tables';
+
+export {
+  convertArrowBatchToObjectRows,
+  convertArrowTableToObjectRows
+} from './convert-parquet-tables';
 
 /**
  * Parses a parquet file into an Arrow-backed table.
@@ -106,32 +114,4 @@ function getParquetBackend(options: ParquetLoaderOptions): 'wasm' | 'typescript'
     return options.parquet.backend;
   }
   return options.parquet?.implementation === 'js' ? 'typescript' : 'wasm';
-}
-
-/**
- * Converts an Arrow-backed table into object rows.
- *
- * @param arrowTable - Arrow table wrapper.
- * @returns Object-row table.
- */
-export function convertArrowTableToObjectRows(arrowTable: ArrowTable): ObjectRowTable {
-  return convertArrowToTable(arrowTable.data, 'object-row-table') as ObjectRowTable;
-}
-
-/**
- * Converts an Arrow batch into object-row output.
- *
- * @param batch - Arrow table batch wrapper.
- * @returns Object-row batch.
- */
-export function convertArrowBatchToObjectRows(batch: ArrowTableBatch): ObjectRowTableBatch {
-  const objectRowTable = convertArrowToTable(batch.data, 'object-row-table') as ObjectRowTable;
-
-  return {
-    batchType: batch.batchType,
-    shape: objectRowTable.shape,
-    schema: objectRowTable.schema,
-    data: objectRowTable.data,
-    length: batch.length
-  };
 }

--- a/modules/parquet/src/lib/utils/load-wasm-node.ts
+++ b/modules/parquet/src/lib/utils/load-wasm-node.ts
@@ -1,0 +1,25 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** Loads the installed parquet-wasm binary in Node.js or defers to browser asset resolution. */
+export async function loadNodeWasmInput(): Promise<Uint8Array | undefined> {
+  if (!isNodeRuntime()) {
+    return undefined;
+  }
+  // Keep these specifiers dynamic so browser bundles do not include Node.js built-ins.
+  const nodeProtocol = 'node:';
+  const {readFile} = await import(/* @vite-ignore */ `${nodeProtocol}fs/promises`);
+  const {createRequire} = await import(/* @vite-ignore */ `${nodeProtocol}module`);
+  const {pathToFileURL} = await import(/* @vite-ignore */ `${nodeProtocol}url`);
+  const moduleUrl =
+    typeof __filename === 'string' ? pathToFileURL(__filename).toString() : import.meta.url;
+  const require = createRequire(moduleUrl);
+  const wasmPath = require.resolve('parquet-wasm/esm/parquet_wasm_bg.wasm');
+  return await readFile(wasmPath);
+}
+
+/** Returns true when Node.js built-ins are available in the current runtime. */
+function isNodeRuntime(): boolean {
+  return Boolean((globalThis as {process?: {versions?: {node?: string}}}).process?.versions?.node);
+}

--- a/modules/parquet/src/lib/utils/load-wasm.ts
+++ b/modules/parquet/src/lib/utils/load-wasm.ts
@@ -3,17 +3,14 @@
 // Copyright (c) vis.gl contributors
 
 import type * as ParquetWasm from 'parquet-wasm/esm/parquet_wasm.js';
-import {PARQUET_WASM_URL} from '../constants';
+import {loadNodeWasmInput} from './load-wasm-node';
 
 let initializePromise: Promise<typeof ParquetWasm> | undefined;
 
 export async function loadWasm(
-  wasmUrl: ParquetWasm.InitInput | Promise<ParquetWasm.InitInput> = PARQUET_WASM_URL
+  wasmUrl?: ParquetWasm.InitInput | Promise<ParquetWasm.InitInput>
 ): Promise<typeof ParquetWasm> {
   if (!initializePromise) {
-    if (!wasmUrl) {
-      throw new Error('ParquetLoader: No wasmUrl provided');
-    }
     const nextInitializePromise = loadAndInitializeWasm(wasmUrl);
     const cachedInitializePromise = nextInitializePromise.catch(error => {
       if (initializePromise === cachedInitializePromise) {
@@ -28,9 +25,21 @@ export async function loadWasm(
 }
 
 async function loadAndInitializeWasm(
-  wasmUrl: ParquetWasm.InitInput | Promise<ParquetWasm.InitInput>
+  wasmUrl?: ParquetWasm.InitInput | Promise<ParquetWasm.InitInput>
 ): Promise<typeof ParquetWasm> {
   const parquetWasm = await import('parquet-wasm/esm/parquet_wasm.js');
-  await parquetWasm.default({module_or_path: wasmUrl});
+  const moduleOrPath = wasmUrl ? await wasmUrl : await loadDefaultWasmInput();
+  if (moduleOrPath) {
+    await parquetWasm.default({module_or_path: moduleOrPath});
+  } else {
+    // parquet-wasm resolves its sibling asset with new URL(..., import.meta.url), which allows
+    // browser bundlers to copy and fingerprint the WASM file without a network CDN default.
+    await parquetWasm.default();
+  }
   return parquetWasm;
+}
+
+/** Loads a local Node asset or defers to parquet-wasm's browser import.meta resolver. */
+async function loadDefaultWasmInput(): Promise<Uint8Array | undefined> {
+  return await loadNodeWasmInput();
 }

--- a/modules/parquet/src/parquet-loader-base.ts
+++ b/modules/parquet/src/parquet-loader-base.ts
@@ -1,0 +1,34 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {
+  ArrowTable,
+  ArrowTableBatch,
+  ObjectRowTable,
+  ObjectRowTableBatch
+} from '@loaders.gl/schema';
+
+import {ParquetFormat} from './parquet-format';
+import {PARQUET_LOADER_DEFAULT_OPTIONS} from './parquet-loader-options';
+
+// __VERSION__ is injected by babel-plugin-version-inline
+// @ts-ignore TS2304: Cannot find name '__VERSION__'.
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+
+/** Shared Parquet loader metadata without parser preloading or worker delivery policy. */
+export const PARQUET_LOADER_BASE = {
+  ...ParquetFormat,
+
+  dataType: null as unknown as ObjectRowTable | ArrowTable,
+  batchType: null as unknown as ObjectRowTableBatch | ArrowTableBatch,
+
+  id: 'parquet',
+  module: 'parquet',
+  version: VERSION,
+  options: {
+    parquet: {
+      ...PARQUET_LOADER_DEFAULT_OPTIONS
+    }
+  }
+} as const;

--- a/modules/parquet/src/parquet-loader-options.ts
+++ b/modules/parquet/src/parquet-loader-options.ts
@@ -17,6 +17,11 @@ type ParquetCommonLoaderOptions = {
 type ParquetWasmLoaderOptions = ParquetCommonLoaderOptions & {
   rowGroups?: number[];
   concurrency?: number;
+  /** Cancels an active worker parse by terminating its worker. */
+  signal?: AbortSignal;
+  /** Overrides the packaged Parquet worker asset URL. */
+  workerUrl?: string;
+  /** Overrides the package-local parquet-wasm binary URL. */
   wasmUrl?: string;
 };
 

--- a/modules/parquet/src/parquet-loader-with-parser.ts
+++ b/modules/parquet/src/parquet-loader-with-parser.ts
@@ -18,10 +18,7 @@ import type {
   ParquetLoaderImplementationOptions,
   ParquetLoaderOptions
 } from './parquet-loader-options';
-import {ParquetLoader as ParquetLoaderMetadata} from './parquet-loader';
-
-const {preload: _ParquetLoaderPreload, ...ParquetLoaderMetadataWithoutPreload} =
-  ParquetLoaderMetadata;
+import {PARQUET_LOADER_BASE} from './parquet-loader-base';
 
 /** Default option bag for the experimental parquetjs plain-row loader. */
 const DEFAULT_PARQUET_JS_OPTIONS = {
@@ -32,7 +29,7 @@ const DEFAULT_PARQUET_JS_OPTIONS = {
 
 /** Parser-bearing TypeScript-only Parquet loader implementation. */
 export const ParquetLoaderWithParser = {
-  ...ParquetLoaderMetadataWithoutPreload,
+  ...PARQUET_LOADER_BASE,
   worker: false,
   parse(arrayBuffer: ArrayBuffer, options?: ParquetLoaderOptions) {
     return parseParquetFile(new BlobFile(arrayBuffer), getParquetOptions(options));

--- a/modules/parquet/src/parquet-loader-with-parser.ts
+++ b/modules/parquet/src/parquet-loader-with-parser.ts
@@ -33,6 +33,7 @@ const DEFAULT_PARQUET_JS_OPTIONS = {
 /** Parser-bearing TypeScript-only Parquet loader implementation. */
 export const ParquetLoaderWithParser = {
   ...ParquetLoaderMetadataWithoutPreload,
+  worker: false,
   parse(arrayBuffer: ArrayBuffer, options?: ParquetLoaderOptions) {
     return parseParquetFile(new BlobFile(arrayBuffer), getParquetOptions(options));
   },

--- a/modules/parquet/src/parquet-loader.ts
+++ b/modules/parquet/src/parquet-loader.ts
@@ -20,6 +20,21 @@ import {
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
 const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
+/** Module-relative worker asset for browser ESM and Node.js CommonJS distributions. */
+const PARQUET_WORKER_URL = import.meta.url
+  ? new URL(getParquetWorkerFile(), import.meta.url).toString()
+  : typeof __dirname === 'string'
+    ? `${__dirname}/parquet-worker-node.cjs`
+    : true;
+
+/** Selects the worker bundle for the current JavaScript runtime. */
+function getParquetWorkerFile(): string {
+  const isNode = Boolean(
+    (globalThis as {process?: {versions?: {node?: string}}}).process?.versions?.node
+  );
+  return isNode ? './parquet-worker-node.cjs' : './parquet-worker.js';
+}
+
 /** Options for the parquet loader */
 export type ParquetLoaderOptions = SharedParquetLoaderOptions;
 
@@ -55,7 +70,7 @@ export const ParquetLoader = {
   id: 'parquet',
   module: 'parquet',
   version: VERSION,
-  worker: false,
+  worker: PARQUET_WORKER_URL,
   options: {
     parquet: {
       ...PARQUET_LOADER_DEFAULT_OPTIONS

--- a/modules/parquet/src/parquet-loader.ts
+++ b/modules/parquet/src/parquet-loader.ts
@@ -10,30 +10,9 @@ import type {
   ArrowTableBatch
 } from '@loaders.gl/schema';
 
-import {ParquetFormat} from './parquet-format';
-import {
-  PARQUET_LOADER_DEFAULT_OPTIONS,
-  type ParquetLoaderOptions as SharedParquetLoaderOptions
-} from './parquet-loader-options';
-
-// __VERSION__ is injected by babel-plugin-version-inline
-// @ts-ignore TS2304: Cannot find name '__VERSION__'.
-const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
-
-/** Module-relative worker asset for browser ESM and Node.js CommonJS distributions. */
-const PARQUET_WORKER_URL = import.meta.url
-  ? new URL(getParquetWorkerFile(), import.meta.url).toString()
-  : typeof __dirname === 'string'
-    ? `${__dirname}/parquet-worker-node.cjs`
-    : true;
-
-/** Selects the worker bundle for the current JavaScript runtime. */
-function getParquetWorkerFile(): string {
-  const isNode = Boolean(
-    (globalThis as {process?: {versions?: {node?: string}}}).process?.versions?.node
-  );
-  return isNode ? './parquet-worker-node.cjs' : './parquet-worker.js';
-}
+import {PARQUET_LOADER_BASE} from './parquet-loader-base';
+import type {ParquetLoaderOptions as SharedParquetLoaderOptions} from './parquet-loader-options';
+import {PARQUET_WORKER_URL} from './parquet-worker-url';
 
 /** Options for the parquet loader */
 export type ParquetLoaderOptions = SharedParquetLoaderOptions;
@@ -62,20 +41,8 @@ async function preloadParquetLoader(_url: string, options?: LoaderOptions) {
 
 /** Metadata-only Parquet table loader supporting object-row and Arrow table output. */
 export const ParquetLoader = {
-  ...ParquetFormat,
-
-  dataType: null as unknown as ObjectRowTable | ArrowTable,
-  batchType: null as unknown as ObjectRowTableBatch | ArrowTableBatch,
-
-  id: 'parquet',
-  module: 'parquet',
-  version: VERSION,
+  ...PARQUET_LOADER_BASE,
   worker: PARQUET_WORKER_URL,
-  options: {
-    parquet: {
-      ...PARQUET_LOADER_DEFAULT_OPTIONS
-    }
-  },
   preload: preloadParquetLoader
 } as const satisfies Loader<
   ObjectRowTable | ArrowTable,

--- a/modules/parquet/src/parquet-wasm-loader-with-parser.ts
+++ b/modules/parquet/src/parquet-wasm-loader-with-parser.ts
@@ -22,6 +22,10 @@ import {
   parseParquetObjectRowTableInBatches
 } from './lib/parsers/parse-parquet-tables';
 import {normalizeParquetOptions} from './lib/utils/normalize-parquet-options';
+import {
+  deserializeParquetWorkerResult,
+  serializeParquetWorkerResult
+} from './lib/parquet-worker-transport';
 import {ParquetLoader as ParquetLoaderMetadata, type ParquetLoaderOptions} from './parquet-loader';
 
 const {preload: _ParquetLoaderPreload, ...ParquetLoaderMetadataWithoutPreload} =
@@ -50,7 +54,9 @@ export const ParquetWASMLoaderWithParser = {
   ) {
     const arrayBuffer = await concatenateArrayBuffersAsync(asyncIterator);
     yield* parseParquetTableInBatches(new BlobFile(arrayBuffer), options);
-  }
+  },
+  serializeWorkerResult: serializeParquetWorkerResult,
+  deserializeWorkerResult: deserializeParquetWorkerResult
 } as const satisfies LoaderWithParser<
   ObjectRowTable | ArrowTable,
   ObjectRowTableBatch | ArrowTableBatch,

--- a/modules/parquet/src/parquet-wasm-loader-with-parser.ts
+++ b/modules/parquet/src/parquet-wasm-loader-with-parser.ts
@@ -16,26 +16,28 @@ import {BlobFile} from '@loaders.gl/loader-utils';
 import type {ReadableFile} from '@loaders.gl/loader-utils';
 
 import {
-  parseParquetArrowTable,
-  parseParquetArrowTableInBatches,
-  parseParquetObjectRowTable,
-  parseParquetObjectRowTableInBatches
-} from './lib/parsers/parse-parquet-tables';
+  convertArrowBatchToObjectRows,
+  convertArrowTableToObjectRows
+} from './lib/parsers/convert-parquet-tables';
+import {
+  parseParquetFileToArrow,
+  parseParquetFileToArrowInBatches
+} from './lib/parsers/parse-parquet-to-arrow';
 import {normalizeParquetOptions} from './lib/utils/normalize-parquet-options';
 import {
   deserializeParquetWorkerResult,
   serializeParquetWorkerResult
 } from './lib/parquet-worker-transport';
-import {ParquetLoader as ParquetLoaderMetadata, type ParquetLoaderOptions} from './parquet-loader';
+import {PARQUET_LOADER_BASE} from './parquet-loader-base';
+import type {ParquetLoaderOptions} from './parquet-loader-options';
+import {PARQUET_WORKER_URL} from './parquet-worker-url';
 
-const {preload: _ParquetLoaderPreload, ...ParquetLoaderMetadataWithoutPreload} =
-  ParquetLoaderMetadata;
-
-export type {ParquetLoaderOptions} from './parquet-loader';
+export type {ParquetLoaderOptions} from './parquet-loader-options';
 
 /** WASM-backed Parquet table loader supporting object-row and Arrow table output. */
 export const ParquetWASMLoaderWithParser = {
-  ...ParquetLoaderMetadataWithoutPreload,
+  ...PARQUET_LOADER_BASE,
+  worker: PARQUET_WORKER_URL,
   parse(arrayBuffer: ArrayBuffer, options?: ParquetLoaderOptions) {
     return parseParquetTable(new BlobFile(arrayBuffer), options);
   },
@@ -76,10 +78,11 @@ async function parseParquetTable(
   const parquetOptions = getParquetOptions(options);
 
   if (parquetOptions.parquet?.shape === 'arrow-table') {
-    return await parseParquetArrowTable(file, parquetOptions);
+    return await parseParquetFileToArrow(file, parquetOptions.parquet);
   }
 
-  return await parseParquetObjectRowTable(file, parquetOptions);
+  const arrowTable = await parseParquetFileToArrow(file, parquetOptions.parquet);
+  return convertArrowTableToObjectRows(arrowTable);
 }
 
 /**
@@ -95,11 +98,13 @@ async function* parseParquetTableInBatches(
   const parquetOptions = getParquetOptions(options);
 
   if (parquetOptions.parquet?.shape === 'arrow-table') {
-    yield* parseParquetArrowTableInBatches(file, parquetOptions);
+    yield* parseParquetFileToArrowInBatches(file, parquetOptions.parquet);
     return;
   }
 
-  yield* parseParquetObjectRowTableInBatches(file, parquetOptions);
+  for await (const batch of parseParquetFileToArrowInBatches(file, parquetOptions.parquet)) {
+    yield convertArrowBatchToObjectRows(batch);
+  }
 }
 
 /**

--- a/modules/parquet/src/parquet-worker-url.ts
+++ b/modules/parquet/src/parquet-worker-url.ts
@@ -1,0 +1,18 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** Module-relative worker asset for browser ESM and Node.js CommonJS distributions. */
+export const PARQUET_WORKER_URL = import.meta.url
+  ? new URL(getParquetWorkerFile(), import.meta.url).toString()
+  : typeof __dirname === 'string'
+    ? `${__dirname}/parquet-worker-node.cjs`
+    : true;
+
+/** Selects the worker bundle for the current JavaScript runtime. */
+function getParquetWorkerFile(): string {
+  const isNode = Boolean(
+    (globalThis as {process?: {versions?: {node?: string}}}).process?.versions?.node
+  );
+  return isNode ? './parquet-worker-node.cjs' : './parquet-worker.js';
+}

--- a/modules/parquet/src/parquet-writer.ts
+++ b/modules/parquet/src/parquet-writer.ts
@@ -10,7 +10,7 @@ import {encodeArrowToParquet} from './lib/encoders/encode-arrow-to-parquet';
 import {ensureGeoParquetMetadataOnArrowTable} from './lib/geo/geospatial-metadata';
 import {normalizeParquetOptions} from './lib/utils/normalize-parquet-options';
 import {ParquetFormat} from './parquet-format';
-import {VERSION, PARQUET_WASM_URL} from './lib/constants';
+import {VERSION} from './lib/constants';
 
 /** Public options for the wasm-backed Parquet writer. */
 export type ParquetWriterOptions = WriterOptions & {
@@ -26,9 +26,7 @@ export const ParquetWriter = {
   module: 'parquet',
   version: VERSION,
   options: {
-    parquet: {
-      wasmUrl: PARQUET_WASM_URL
-    }
+    parquet: {}
   },
   encode(table: Table, options?: ParquetWriterOptions) {
     const arrowTable =

--- a/modules/parquet/src/polyfills/process.ts
+++ b/modules/parquet/src/polyfills/process.ts
@@ -1,0 +1,17 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** Minimal browser process shim required by transitive Parquet dependencies in a worker. */
+export const process = {
+  /** Empty environment exposed to dependencies that only probe for process.env. */
+  env: {} as Record<string, string | undefined>,
+  /** Empty version map exposed to dependencies that only probe for process.versions. */
+  versions: {} as Record<string, string | undefined>,
+  /** Browser workers do not have a process identifier. */
+  pid: 0,
+  /** Schedules a Node-style next-tick callback with its arguments. */
+  nextTick(callback: (...arguments_: unknown[]) => void, ...arguments_: unknown[]): void {
+    queueMicrotask(() => callback(...arguments_));
+  }
+};

--- a/modules/parquet/src/workers/parquet-worker-node.ts
+++ b/modules/parquet/src/workers/parquet-worker-node.ts
@@ -1,0 +1,5 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import './parquet-worker';

--- a/modules/parquet/src/workers/parquet-worker.ts
+++ b/modules/parquet/src/workers/parquet-worker.ts
@@ -1,0 +1,31 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {createLoaderWorker} from '@loaders.gl/loader-utils';
+import type {ParquetLoaderOptions} from '../parquet-loader-options';
+import {ParquetWASMLoaderWithParser} from '../parquet-wasm-loader-with-parser';
+
+/** Worker-local Parquet loader with a package-relative default WASM URL. */
+const ParquetWorkerLoader = {
+  ...ParquetWASMLoaderWithParser,
+  parse(arrayBuffer: ArrayBuffer, options?: ParquetLoaderOptions) {
+    return ParquetWASMLoaderWithParser.parse(arrayBuffer, addWorkerWasmUrl(options));
+  }
+};
+
+/** Adds the package-local WASM asset URL when the caller did not provide one. */
+function addWorkerWasmUrl(options?: ParquetLoaderOptions): ParquetLoaderOptions | undefined {
+  if (options?.parquet?.wasmUrl || typeof globalThis.location?.href !== 'string') {
+    return options;
+  }
+  return {
+    ...options,
+    parquet: {
+      ...options?.parquet,
+      wasmUrl: new URL('parquet_wasm_bg.wasm', globalThis.location.href).toString()
+    }
+  };
+}
+
+createLoaderWorker(ParquetWorkerLoader);

--- a/modules/parquet/test/parquet-arrow-loader.spec.ts
+++ b/modules/parquet/test/parquet-arrow-loader.spec.ts
@@ -5,7 +5,14 @@
 import test from 'tape-promise/tape';
 // import {validateLoader} from 'test/common/conformance';
 
-import {load, loadInBatches, encode, fetchFile, setLoaderOptions} from '@loaders.gl/core';
+import {
+  load,
+  loadInBatches,
+  encode,
+  fetchFile,
+  isBrowser,
+  setLoaderOptions
+} from '@loaders.gl/core';
 import type {ArrowTable, ObjectRowTable} from '@loaders.gl/schema';
 import {getGeometryColumnsFromSchema} from '@loaders.gl/geoarrow';
 import {getGeoMetadata, convertGeometryToWKB} from '@loaders.gl/gis';
@@ -29,6 +36,69 @@ test('ParquetLoader#loader objects', (t) => {
   // Not sure why validateLoader calls parse? Raises an error about "Invalid Parquet file"
   // validateLoader(t, ParquetLoader, 'ParquetLoader');
   // validateLoader(t, ParquetWorkerLoader, 'ParquetWorkerLoader');
+  t.end();
+});
+
+test('ParquetLoader#publishes a module-local worker asset', t => {
+  t.equal(typeof ParquetLoader.worker, 'string', 'declares a concrete packaged worker URL');
+  t.notOk(
+    String(ParquetLoader.worker).includes('unpkg.com'),
+    'does not use the implicit worker CDN fallback'
+  );
+  const workerFile = isBrowser ? '/parquet-worker.js' : '/parquet-worker-node.cjs';
+  t.ok(String(ParquetLoader.worker).endsWith(workerFile), 'targets the packaged runtime worker');
+  t.end();
+});
+
+test('ParquetLoader#worker keeps the browser responsive and rehydrates Arrow output', async t => {
+  if (!isBrowser) {
+    t.end();
+    return;
+  }
+
+  const response = await fetchFile(`${PARQUET_DIR}/geoparquet/example.parquet`);
+  const arrayBuffer = await response.arrayBuffer();
+  let mainThreadTicked = false;
+  const tablePromise = load(arrayBuffer, ParquetLoader, {
+    core: {worker: true, reuseWorkers: false},
+    parquet: {shape: 'arrow-table'}
+  }) as Promise<ArrowTable>;
+  await new Promise<void>(resolve =>
+    setTimeout(() => {
+      mainThreadTicked = true;
+      resolve();
+    }, 0)
+  );
+  const table = await tablePromise;
+
+  t.ok(mainThreadTicked, 'the main event loop advances while the worker decodes');
+  t.ok(table.data instanceof arrow.Table, 'rehydrates an Apache Arrow Table on the main thread');
+  t.equal(table.data.getChild('name')?.get(0), 'Fiji', 'rehydrated Arrow vectors retain methods');
+  t.end();
+});
+
+test('ParquetLoader#worker parse is cancellable', async t => {
+  if (!isBrowser) {
+    t.end();
+    return;
+  }
+
+  const response = await fetchFile(`${PARQUET_DIR}/geoparquet/example.parquet`);
+  const arrayBuffer = await response.arrayBuffer();
+  const abortController = new AbortController();
+  abortController.abort();
+  const tablePromise = load(arrayBuffer, ParquetLoader, {
+    core: {worker: true, reuseWorkers: true},
+    parquet: {shape: 'arrow-table', signal: abortController.signal}
+  });
+
+  let abortError: unknown;
+  try {
+    await tablePromise;
+  } catch (error) {
+    abortError = error;
+  }
+  t.equal((abortError as Error | undefined)?.name, 'AbortError', 'terminates the active worker parse');
   t.end();
 });
 

--- a/modules/worker-utils/src/lib/node/worker_threads-browser.ts
+++ b/modules/worker-utils/src/lib/node/worker_threads-browser.ts
@@ -8,6 +8,24 @@
  * The replacement is done in package.json browser field
  */
 export class NodeWorker {
+  /** Restores the native worker constructor when this browser shim is embedded in a Node bundle. */
+  constructor(...arguments_: unknown[]) {
+    const runtimeProcess = (
+      globalThis as {
+        process?: {
+          getBuiltinModule?: (specifier: string) => {
+            Worker?: new (...workerArguments: unknown[]) => NodeWorker;
+          };
+        };
+      }
+    ).process;
+    const WorkerConstructor = runtimeProcess?.getBuiltinModule?.('node:worker_threads').Worker;
+    if (WorkerConstructor) {
+      return new WorkerConstructor(...arguments_);
+    }
+  }
+
+  /** No-op browser fallback matching the native Worker API. */
   terminate() {}
 }
 

--- a/modules/worker-utils/src/lib/worker-api/get-worker-url.ts
+++ b/modules/worker-utils/src/lib/worker-api/get-worker-url.ts
@@ -36,6 +36,11 @@ export function getWorkerURL(worker: WorkerObject, options: WorkerOptions = {}):
 
   let url = workerOptions.workerUrl;
 
+  // A loader may publish a module-relative worker asset instead of relying on a CDN fallback.
+  if (!url && typeof worker.worker === 'string') {
+    url = worker.worker;
+  }
+
   // HACK: Allow for non-nested workerUrl for the CompressionWorker.
   // For the compression worker, workerOptions is currently not nested correctly. For most loaders,
   // you'd have options within an object, i.e. `{mvt: {coordinates: ...}}` but the CompressionWorker

--- a/modules/worker-utils/src/lib/worker-api/process-on-worker.ts
+++ b/modules/worker-utils/src/lib/worker-api/process-on-worker.ts
@@ -17,6 +17,9 @@ import {getTransferListForWriter} from '../worker-utils/get-transfer-list';
 
 /** Options for worker processing */
 export type ProcessOnWorkerOptions = WorkerOptions & {
+  /** Cancels the job by terminating its worker. */
+  signal?: AbortSignal;
+  /** Diagnostic name shown for the worker job. */
   jobName?: string;
   [key: string]: any;
 };
@@ -53,6 +56,7 @@ export async function processOnWorker(
   context: WorkerContext = {},
   jobContext: WorkerJobContext = {}
 ): Promise<any> {
+  throwIfAborted(options.signal);
   const name = getWorkerName(worker);
 
   const workerFarm = WorkerFarm.getWorkerFarm(options);
@@ -70,17 +74,40 @@ export async function processOnWorker(
     onMessage.bind(null, context)
   );
 
-  // Kick off the processing in the worker
-  const transferableOptions = getTransferListForWriter(options);
-  const transferableContext = getTransferListForWriter(jobContext);
-  job.postMessage('process', {
-    input: data,
-    options: transferableOptions,
-    context: transferableContext
-  });
+  const abortJob = (): void => job.abort();
+  options.signal?.addEventListener('abort', abortJob, {once: true});
+  if (options.signal?.aborted) {
+    abortJob();
+  }
 
-  const result = await job.result;
-  return result.result;
+  try {
+    // AbortSignal cannot be structured-cloned. It controls the job on this thread only.
+    const {signal: _signal, ...workerOptions} = options;
+    const transferableOptions = getTransferListForWriter(workerOptions);
+    const transferableContext = getTransferListForWriter(jobContext);
+    if (job.isRunning) {
+      job.postMessage('process', {
+        input: data,
+        options: transferableOptions,
+        context: transferableContext
+      });
+    }
+
+    const result = await job.result;
+    return result.result;
+  } finally {
+    options.signal?.removeEventListener('abort', abortJob);
+  }
+}
+
+/** Throws a cross-runtime abort error when a signal is already aborted. */
+function throwIfAborted(signal?: AbortSignal): void {
+  if (!signal?.aborted) {
+    return;
+  }
+  const error = new Error('Worker job was aborted');
+  error.name = 'AbortError';
+  throw error;
 }
 
 /**

--- a/modules/worker-utils/src/lib/worker-farm/worker-job.ts
+++ b/modules/worker-utils/src/lib/worker-farm/worker-job.ts
@@ -4,7 +4,6 @@
 
 import type {WorkerMessageType, WorkerMessagePayload} from '../../types';
 import WorkerThread from './worker-thread';
-import {assert} from '../env-utils/assert';
 
 /**
  * Represents one Job handled by a WorkerPool or WorkerFarm
@@ -44,7 +43,9 @@ export default class WorkerJob {
    * Call to resolve the `result` Promise with the supplied value
    */
   done(value: any): void {
-    assert(this.isRunning);
+    if (!this.isRunning) {
+      return;
+    }
     this.isRunning = false;
     this._resolve(value);
   }
@@ -53,8 +54,21 @@ export default class WorkerJob {
    * Call to reject the `result` Promise with the supplied error
    */
   error(error: Error): void {
-    assert(this.isRunning);
+    if (!this.isRunning) {
+      return;
+    }
     this.isRunning = false;
     this._reject(error);
+  }
+
+  /** Terminates the worker executing this job and rejects its result with an abort error. */
+  abort(): void {
+    if (!this.isRunning) {
+      return;
+    }
+    const error = new Error(`Worker job "${this.name}" was aborted`);
+    error.name = 'AbortError';
+    this.workerThread.destroy();
+    this.error(error);
   }
 }

--- a/modules/worker-utils/src/lib/worker-farm/worker-pool.ts
+++ b/modules/worker-utils/src/lib/worker-farm/worker-pool.ts
@@ -178,6 +178,8 @@ export default class WorkerPool {
    */
   returnWorkerToQueue(worker: WorkerThread) {
     const shouldDestroyWorker =
+      // Aborted jobs terminate their worker immediately.
+      worker.terminated ||
       // If the pool is destroyed, there is no reason to keep the worker around
       this.isDestroyed ||
       // If the app has disabled worker reuse, any completed workers should be destroyed
@@ -186,7 +188,9 @@ export default class WorkerPool {
       this.count > this._getMaxConcurrency();
 
     if (shouldDestroyWorker) {
-      worker.destroy();
+      if (!worker.terminated) {
+        worker.destroy();
+      }
       this.count--;
     } else {
       worker.unref();

--- a/modules/worker-utils/src/lib/worker-farm/worker-thread.ts
+++ b/modules/worker-utils/src/lib/worker-farm/worker-thread.ts
@@ -148,10 +148,11 @@ export default class WorkerThread {
       // Make sure relative URLs start with './'
       const absolute = this.url.includes(':/') || this.url.startsWith('/');
       const url = absolute ? this.url : `./${this.url}`;
+      const workerUrl = url.startsWith('file:') ? new URL(url) : url;
       const type = this.url.endsWith('.ts') || this.url.endsWith('.mjs') ? 'module' : 'commonjs';
       // console.log('Starting work from', url);
       // @ts-expect-error type is not known
-      worker = new NodeWorker(url, {eval: false, type});
+      worker = new NodeWorker(workerUrl, {eval: false, type});
     } else if (this.source) {
       worker = new NodeWorker(this.source, {eval: true});
     } else {

--- a/modules/worker-utils/test/lib/worker-api/process-on-worker.node.spec.ts
+++ b/modules/worker-utils/test/lib/worker-api/process-on-worker.node.spec.ts
@@ -47,6 +47,30 @@ parentPort.on('message', message => {
 });
 `;
 
+const AbortWorker = {
+  id: 'abort-test',
+  name: 'abort-test',
+  module: 'worker-utils',
+  version: 'latest',
+  worker: true,
+  options: {}
+};
+
+const abortWorkerSource = `
+const {parentPort} = require('worker_threads');
+
+parentPort.on('message', message => {
+  const {type, payload} = message;
+  if (type === 'process') {
+    setTimeout(() => parentPort.postMessage({
+      source: 'loaders.gl',
+      type: 'done',
+      payload: {result: payload.input}
+    }), payload.options.delay);
+  }
+});
+`;
+
 test('processOnWorker#jobContext', async t => {
   const result = await processOnWorker(
     TestWorker,
@@ -78,5 +102,31 @@ test('processOnWorker#jobContext', async t => {
     },
     'job context is transferred separately from options'
   );
+  t.end();
+});
+
+test('processOnWorker#AbortSignal terminates and replaces an active worker', async t => {
+  const abortController = new AbortController();
+  const abortedResult = processOnWorker(AbortWorker, 'aborted', {
+    worker: true,
+    source: abortWorkerSource,
+    delay: 1_000,
+    signal: abortController.signal
+  });
+  setTimeout(() => abortController.abort(), 10);
+
+  let abortError: unknown;
+  try {
+    await abortedResult;
+  } catch (error) {
+    abortError = error;
+  }
+  t.equal((abortError as Error | undefined)?.name, 'AbortError', 'rejects with an abort error');
+  const nextResult = await processOnWorker(AbortWorker, 'replacement', {
+    worker: true,
+    source: abortWorkerSource,
+    delay: 0
+  });
+  t.equal(nextResult, 'replacement', 'the pool starts a replacement worker after cancellation');
   t.end();
 });


### PR DESCRIPTION
## Goals

- Move the wasm-backed Parquet decode path off the main thread.
- Make worker-backed decoding cancellable and keep worker pools healthy after cancellation.
- Deliver worker and WASM assets from the package without an implicit CDN dependency.
- Keep the default WASM worker isolated from the TypeScript decoder and generic compression graph.

## Changes

- Publishes browser and Node Parquet worker assets and resolves package-local assets per runtime.
- Resolves the packaged `parquet-wasm` binary locally while preserving explicit `wasmUrl` overrides and retry-after-failure initialization.
- Transfers Arrow results as IPC bytes and rehydrates Apache Arrow instances on the caller thread.
- Adds `parquet.signal` cancellation that terminates active workers and replaces them in the pool.
- Preserves runtime objects such as `AbortSignal` during loader-option merging.
- Splits neutral metadata and Arrow-to-row conversion from backend dispatch so the WASM worker excludes BSON, hyparquet, the TypeScript decoder, and its compression dependencies.
- Produces a browser worker of 663,137 bytes raw / 105,719 bytes gzip.
- Adds browser responsiveness, rehydration, cancellation, packaged-asset, and pool-recovery coverage.

## Validation

- `yarn lint fix`
- `yarn build`
- Focused worker suites — 2 tests passed in Node and 23 in Chromium
- Bundle audit confirms no BSON, hyparquet, `ParquetSource`, or TypeScript parquetjs parser code in `parquet-worker.js`
- GitHub Actions — website, build/lint, Node 22/24/26, Chromium, and Coveralls passed

## Stack

- Base: `master` (#3530, #3531, #3533, and #3535 are merged)
- This PR: worker and package-asset delivery

Part of #3525.