### PR TITLE
fix(zip): guard zip64 extra-field parsing against malformed input

### DIFF
--- a/modules/zip/src/parse-zip/cd-file-header.ts
+++ b/modules/zip/src/parse-zip/cd-file-header.ts
@@ -57,6 +57,7 @@ const CD_EXTRA_FIELD_LENGTH_OFFSET = 30;
 const CD_START_DISK_OFFSET = 32;
 const CD_LOCAL_HEADER_OFFSET_OFFSET = 42;
 const CD_FILE_NAME_OFFSET = 46n;
+const ZIP64_EXTRA_FIELD_ID = 0x0001;
 
 export const signature: ZipSignature = new Uint8Array([0x50, 0x4b, 0x01, 0x02]);
 
@@ -144,14 +145,6 @@ export async function* makeZipCDHeaderIterator(
     );
   }
 }
-/**
- * returns the number written in the provided bytes
- * @param bytes two bytes containing the number
- * @returns the number written in the provided bytes
- */
-const getUint16 = (...bytes: [number, number]) => {
-  return bytes[0] + bytes[1] * 16;
-};
 
 /**
  * reads all nesessary data from zip64 record in the extra data
@@ -167,19 +160,27 @@ const findZip64DataInExtra = (zip64data: Zip64Data, extraField: DataView): Parti
   if (zip64dataList.length > 0) {
     // total length of data in zip64 notation in bytes
     const zip64chunkSize = zip64dataList.reduce((sum, curr) => sum + curr.length, 0);
-    // we're looking for the zip64 nontation header (0x0001)
-    // and a size field with a correct value next to it
-    const offsetInExtraData = new Uint8Array(extraField.buffer).findIndex(
-      (_val, i, arr) =>
-        getUint16(arr[i], arr[i + 1]) === 0x0001 &&
-        getUint16(arr[i + 2], arr[i + 3]) === zip64chunkSize
-    );
-    // then we read all the nesessary fields from the zip64 data
-    let bytesRead = 0;
-    for (const note of zip64dataList) {
-      const offset = bytesRead;
-      zip64DataRes[note.name] = extraField.getBigUint64(offsetInExtraData + 4 + offset, true);
-      bytesRead = offset + note.length;
+    let offset = 0;
+    while (offset + 4 <= extraField.byteLength) {
+      const headerId = extraField.getUint16(offset, true);
+      const dataSize = extraField.getUint16(offset + 2, true);
+      const payloadStart = offset + 4;
+      if (payloadStart + dataSize > extraField.byteLength) {
+        break;
+      }
+      if (headerId === ZIP64_EXTRA_FIELD_ID && dataSize === zip64chunkSize) {
+        let bytesRead = 0;
+        for (const note of zip64dataList) {
+          const fieldOffset = payloadStart + bytesRead;
+          if (fieldOffset + 8 > payloadStart + dataSize) {
+            break;
+          }
+          zip64DataRes[note.name] = extraField.getBigUint64(fieldOffset, true);
+          bytesRead += note.length;
+        }
+        break;
+      }
+      offset = payloadStart + dataSize;
     }
   }
 

--- a/modules/zip/test/zip-utils/cd-file-header.spec.ts
+++ b/modules/zip/test/zip-utils/cd-file-header.spec.ts
@@ -39,3 +39,82 @@ test('SLPKLoader#zip64 info generation', async t => {
   t.equal(header.byteLength, 20);
   t.end();
 });
+
+test('SLPKLoader#central directory file header parse with zip64 sentinel and empty extra field', async t => {
+  const header = generateCDHeader({crc32: 0, fileName: 'test.json', length: 0, offset: 0n});
+  const view = new DataView(header);
+  view.setUint32(20, 0xffffffff, true);
+  view.setUint32(24, 0xffffffff, true);
+  const cdFileHeader = await parseZipCDFileHeader(0n, new DataViewReadableFile(view));
+  t.equal(cdFileHeader?.fileName, 'test.json');
+  t.equal(cdFileHeader?.uncompressedSize, BigInt(0xffffffff));
+  t.equal(cdFileHeader?.compressedSize, BigInt(0xffffffff));
+  t.equal(cdFileHeader?.extraFieldLength, 0);
+  t.end();
+});
+
+test('SLPKLoader#central directory file header parse with truncated zip64 extra field', async t => {
+  const header = generateCDHeader({crc32: 0, fileName: 'test.json', length: 0, offset: 0n});
+  const view = new DataView(header);
+  view.setUint32(20, 0xffffffff, true);
+  view.setUint32(24, 0xffffffff, true);
+  view.setUint16(30, 8, true);
+  const extra = new Uint8Array([0x01, 0x00, 0x10, 0x00, 0, 0, 0, 0]);
+  const buffer = new Uint8Array(header.byteLength + extra.byteLength);
+  buffer.set(new Uint8Array(header), 0);
+  buffer.set(extra, header.byteLength);
+  const cdFileHeader = await parseZipCDFileHeader(
+    0n,
+    new DataViewReadableFile(new DataView(buffer.buffer))
+  );
+  t.equal(cdFileHeader?.uncompressedSize, BigInt(0xffffffff));
+  t.equal(cdFileHeader?.fileName, 'test.json');
+  t.equal(cdFileHeader?.extraFieldLength, 8);
+  t.end();
+});
+
+test('SLPKLoader#central directory file header parse with valid zip64 extra field', async t => {
+  const header = generateCDHeader({
+    crc32: 0,
+    fileName: 'test.json',
+    length: 0xffffffffff,
+    offset: 0n
+  });
+  const cdFileHeader = await parseZipCDFileHeader(
+    0n,
+    new DataViewReadableFile(new DataView(header))
+  );
+  t.equal(cdFileHeader?.uncompressedSize, BigInt(0xffffffffff));
+  t.equal(cdFileHeader?.compressedSize, BigInt(0xffffffffff));
+  t.equal(cdFileHeader?.extraFieldLength, 20);
+  t.equal(cdFileHeader?.localHeaderOffset, 0n);
+  t.end();
+});
+
+test('SLPKLoader#central directory file header parse with zip64 extra field after unrelated record', async t => {
+  const header = generateCDHeader({crc32: 0, fileName: 'test.json', length: 0, offset: 0n});
+  const view = new DataView(header);
+  view.setUint32(20, 0xffffffff, true);
+  view.setUint32(24, 0xffffffff, true);
+  view.setUint16(30, 28, true);
+  const extra = new DataView(new ArrayBuffer(28));
+  extra.setUint16(0, 0x9999, true);
+  extra.setUint16(2, 4, true);
+  extra.setUint16(4, 0x0001, true);
+  extra.setUint16(6, 16, true);
+  extra.setUint16(8, 0x0001, true);
+  extra.setUint16(10, 16, true);
+  extra.setBigUint64(12, BigInt(0x1122334455), true);
+  extra.setBigUint64(20, BigInt(0x66778899aa), true);
+  const buffer = new Uint8Array(header.byteLength + extra.byteLength);
+  buffer.set(new Uint8Array(header), 0);
+  buffer.set(new Uint8Array(extra.buffer), header.byteLength);
+  const cdFileHeader = await parseZipCDFileHeader(
+    0n,
+    new DataViewReadableFile(new DataView(buffer.buffer))
+  );
+  t.equal(cdFileHeader?.uncompressedSize, BigInt(0x1122334455));
+  t.equal(cdFileHeader?.compressedSize, BigInt(0x66778899aa));
+  t.equal(cdFileHeader?.extraFieldLength, 28);
+  t.end();
+});


### PR DESCRIPTION
## Problem

A single malformed or malicious ZIP makes the central-directory parser in `@loaders.gl/zip` throw an
uncaught `RangeError: Offset is outside the bounds of the DataView`. It surfaces on public entry
points that walk the central directory (`ZipFileSystem.readdir()` / `fetch()`,
`makeZipCDHeaderIterator()`, SLPK/i3s loading), so untrusted input can abort the caller.

## Root cause

`findZip64DataInExtra()` in `modules/zip/src/parse-zip/cd-file-header.ts` located the zip64 extra
record with a byte-wise scan and then read from the result without validating it:

```ts
const offsetInExtraData = new Uint8Array(extraField.buffer).findIndex(/* ... */);
for (const note of zip64dataList) {
  zip64DataRes[note.name] = extraField.getBigUint64(offsetInExtraData + 4 + offset, true);
}
```

When a CD size/offset field holds the zip64 sentinel `0xffffffff` but no matching zip64 record is
present, `findIndex()` returns `-1` and the code calls `getBigUint64(3, true)` — out of bounds for an
empty or short extra field, hence the `RangeError`. A truncated zip64 record hits the same path: the
record header matches, but the declared 16-byte payload is not there to read.

Two further defects came from the same scan:

- The local `getUint16(...bytes)` helper decoded little-endian as `bytes[0] + bytes[1] * 16` instead
  of `* 256`, so a `dataSize` field of `256` (`00 01`) compared equal to `16`.
- Scanning raw bytes cannot tell a record header from record contents, so `01 00` appearing inside a
  preceding extra record's payload was accepted as the zip64 header, and a short zip64 record could
  read into the bytes of the following record.

## Fix

`findZip64DataInExtra()` now walks the extra field as the spec describes it — a sequence of
`[headerId: uint16][dataSize: uint16][payload]` records:

- Record headers are only read while at least 4 bytes remain.
- A record whose declared payload runs past the end of the extra field ends the walk.
- The zip64 record is matched on `headerId === 0x0001 && dataSize === zip64chunkSize`, and each
  8-byte field read is bounds-checked against that record's payload end.
- If no matching record is found, the zip64 augmentation is skipped and the 32-bit CD values are
  returned unchanged — no exception.

The broken `getUint16` helper is removed; `DataView.getUint16(offset, true)` is used directly.

## Tests

`modules/zip/test/zip-utils/cd-file-header.spec.ts` gains four cases:

- zip64 sentinel with an empty extra field — parses without throwing, keeps the 32-bit values.
- zip64 sentinel with a truncated zip64 record (declares 16 payload bytes, provides 4) — same.
- valid zip64 record produced by this repo's own `createZip64Info()` — 64-bit sizes still decoded.
- valid zip64 record preceded by an unrelated record whose payload contains `01 00 10 00` — values
  come from the real record, not from the byte pattern inside the previous payload.

The first two cases throw `RangeError` on `master`; the last one silently decoded garbage there.

## Risk / compatibility

Behavior changes only for malformed input. Well-formed zip64 archives are parsed exactly as before —
the record they carry has `headerId 0x0001` and a `dataSize` equal to the number of sentinel fields
(8/16/24), which the new walk matches. The removed `* 16` decode agreed with a correct little-endian
decode for those sizes, so no valid archive relied on it.

## Verification needed

Dependency install and the test run could not be executed in the environment this patch was prepared
in, so the four new tests have been validated by byte-level tracing only. Please let CI run
`modules/zip` (`yarn test-node`) on this branch.
