### PR TITLE
fix(textures): remove deprecated texture-compressor dependency

### DIFF
--- a/docs/modules/textures/README.md
+++ b/docs/modules/textures/README.md
@@ -98,4 +98,4 @@ They return schema `Texture` objects rather than raw image trees.
 ## Attributions
 
 - The `CompressedTextureLoader` was forked from [PicoGL](https://github.com/tsherif/picogl.js/blob/master/examples/utils/utils.js), Copyright (c) 2017 Tarek Sherif, The MIT License (MIT)
-- The `CompressedTextureWriter` is a wrapper around @TimvanScherpenzeel's [`texture-compressor`](https://github.com/TimvanScherpenzeel/texture-compressor) utility (MIT licensed).
+- The `CompressedTextureWriter` is a wrapper around @TimvanScherpenzeel's [`texture-compressor`](https://github.com/TimvanScherpenzeel/texture-compressor) utility (MIT licensed). That utility is not a dependency of `@loaders.gl/textures`; applications that use the writer must install it separately.

--- a/docs/modules/textures/api-reference/compressed-texture-writer.md
+++ b/docs/modules/textures/api-reference/compressed-texture-writer.md
@@ -11,6 +11,16 @@ import {TexturesDocsTabs} from '@site/src/components/docs/textures-docs-tabs';
 
 > The experimental `CompressedTextureWriter` class can encode a binary encoded image into a compressed texture.
 
+:::caution
+This writer works by spawning the [`texture-compressor`](https://github.com/TimvanScherpenzeel/texture-compressor) command line utility via `npx`. That utility is **not** installed by `@loaders.gl/textures`. Applications that use this writer must install it themselves:
+
+```bash
+npm install --save-dev texture-compressor
+```
+
+The utility is invoked with `npx --no`, so it is never downloaded on demand. If it cannot be resolved locally, `encodeURLtoURL()` rejects.
+:::
+
 | Loader         | Characteristic                                         |
 | -------------- | ------------------------------------------------------ |
 | File Extension |                                                        |
@@ -46,4 +56,6 @@ TBA
 
 ## Remarks
 
+- Requires the `texture-compressor` CLI to be installed by the application, see the note above.
+- Output is currently hardcoded to the S3TC/DXT1 compression format, and the CLI only writes `.ktx` containers, so `outputUrl` must end in `.ktx` despite the writer being registered under the `dds` id.
 - For more information, see [`texture-compressor`](https://github.com/TimvanScherpenzeel/texture-compressor).

--- a/docs/modules/textures/formats/compressed-textures.md
+++ b/docs/modules/textures/formats/compressed-textures.md
@@ -170,7 +170,7 @@ At the time of writing, only S3 texture compression has been specified:
 
 Texture compression code is usually not readily available, particulary not in JavaScript. Compression is typically done by binary programs, e.g. [PVRTexTool](https://www.imaginationtech.com/developers/powervr-sdk-tools/pvrtextool/).
 
-The loaders.gl `CompressedTextureWriter` can compress textures (under Node.js only) by executing a binary with the appropriate command line, and then loading back the output.
+The loaders.gl `CompressedTextureWriter` can compress textures (under Node.js only) by executing a binary with the appropriate command line, and then loading back the output. The binary it invokes is not bundled with or installed by loaders.gl - see the [`CompressedTextureWriter`](/docs/modules/textures/api-reference/compressed-texture-writer) documentation for the prerequisites.
 
 ## IP and Patent Considerations
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -146,6 +146,11 @@ This unifies top-level loading behavior:
 - `SplatLayer`'s WebGPU path is experimental. It supports GPU projection, culling, binning, tile sorting, and oriented covariance rendering, but WebGPU picking is disabled in this initial implementation.
 - The CPU/WebGL fallback remains circular-billboard based. Applications that need the oriented Gaussian renderer should request `renderMode: 'gpu'` and handle the clear error raised when the current deck.gl device is not WebGPU.
 
+**@loaders.gl/textures**
+
+- `@loaders.gl/textures` no longer depends on the deprecated `texture-compressor` package, which pulled in vulnerable versions of `image-size`. The package was only ever used as a command line tool by the experimental `CompressedTextureWriter`, and was installed for every consumer whether or not that writer was used.
+- Applications that use `CompressedTextureWriter` must now install the CLI themselves, for example with `npm install --save-dev texture-compressor`. The CLI is invoked with `npx --no`, so it is never downloaded on demand; if it cannot be resolved locally, `encodeURLtoURL()` rejects. All other `@loaders.gl/textures` loaders and writers are unaffected.
+
 **@loaders.gl/tiles**
 
 - `Tileset3D` now requires a `Tile3DSource` and can no longer be instantiated with a JSON payload.

--- a/modules/textures/package.json
+++ b/modules/textures/package.json
@@ -88,8 +88,7 @@
     "@loaders.gl/schema": "5.0.0-alpha.1",
     "@loaders.gl/worker-utils": "5.0.0-alpha.1",
     "@math.gl/types": "^4.1.0",
-    "ktx-parse": "^0.7.0",
-    "texture-compressor": "^1.0.2"
+    "ktx-parse": "^0.7.0"
   },
   "peerDependencies": {
     "@loaders.gl/core": "~5.0.0-alpha.0"

--- a/modules/textures/src/lib/encoders/encode-texture.ts
+++ b/modules/textures/src/lib/encoders/encode-texture.ts
@@ -5,7 +5,19 @@
 import {ChildProcessProxy} from '@loaders.gl/worker-utils';
 import {CompressedTextureWriterOptions} from '../../compressed-texture-writer';
 
-/*
+/**
+ * Compresses an image file into an S3TC/DXT1 compressed texture file, under Node.js only.
+ *
+ * Note: despite the writer being named `CompressedTextureWriter` / "DDS Texture Container",
+ * the `texture-compressor` CLI only writes `.ktx` containers - the `outputUrl` must end
+ * in `.ktx` or the CLI rejects it.
+ *
+ * Note: This is an experimental encoder that shells out to the `texture-compressor` CLI.
+ * That CLI is *not* a dependency of `@loaders.gl/textures` - applications that use this
+ * writer must install it themselves (`npm install --save-dev texture-compressor`) or make
+ * it otherwise resolvable by `npx`. It is never downloaded on demand - if it cannot be
+ * resolved, this function rejects.
+ *
  * @see https://github.com/TimvanScherpenzeel/texture-compressor
  */
 export async function encodeImageURLToCompressedTextureURL(
@@ -15,7 +27,13 @@ export async function encodeImageURLToCompressedTextureURL(
 ): Promise<string> {
   // biome-ignore format: preserve intentional fixture layout
   const args = [
-    // Note: our actual executable is `npx`, so `texture-compressor` is an argument
+    // Note: our actual executable is `npx`, so `texture-compressor` is an argument.
+    // `--no` prevents npx from silently downloading the CLI at runtime: it must already
+    // be installed by the application.
+    '--no',
+    // `--` is required: without it npm parses the flags below as its own config
+    // instead of forwarding them to the CLI.
+    '--',
     'texture-compressor',
     '--type', 's3tc',
     '--compression', 'DXT1',

--- a/modules/textures/test/compressed-texture-writer.spec.ts
+++ b/modules/textures/test/compressed-texture-writer.spec.ts
@@ -14,17 +14,16 @@ test('CompressedTextureWriter#write-and-read-image', async t => {
     t.end();
     return;
   }
+  // The `texture-compressor` CLI is an optional, application-supplied prerequisite,
+  // so skip (rather than fail) when it is not installed in this environment.
+  let outputFilename: string | undefined;
   try {
-    const outputFilename = await encodeURLtoURL(
-      IMAGE_URL,
-      '/tmp/test.ktx',
-      CompressedTextureWriter,
-      {}
-    );
-    t.ok(outputFilename, 'a filename was returned');
-  } catch (_error) {
-    // @ts-ignore
-    // t.comment(error);
+    outputFilename = await encodeURLtoURL(IMAGE_URL, '/tmp/test.ktx', CompressedTextureWriter, {});
+  } catch (error) {
+    t.comment(`texture-compressor CLI not available, skipping: ${(error as Error).message}`);
+    t.end();
+    return;
   }
+  t.ok(outputFilename, 'a filename was returned');
   t.end();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5849,7 +5849,6 @@ __metadata:
     "@loaders.gl/worker-utils": "npm:5.0.0-alpha.1"
     "@math.gl/types": "npm:^4.1.0"
     ktx-parse: "npm:^0.7.0"
-    texture-compressor: "npm:^1.0.2"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
   languageName: unknown
@@ -13019,15 +13018,6 @@ __metadata:
   version: 2.0.1
   resolution: "argparse@npm:2.0.1"
   checksum: 10c0/c5640c2d89045371c7cedd6a70212a04e360fd34d6edeae32f6952c63949e3525ea77dbec0289d8213a99bbaeab5abfa860b5c12cf88a2e6cf8106e90dd27a7e
-  languageName: node
-  linkType: hard
-
-"argparse@npm:^1.0.10":
-  version: 1.0.10
-  resolution: "argparse@npm:1.0.10"
-  dependencies:
-    sprintf-js: "npm:~1.0.2"
-  checksum: 10c0/b2972c5c23c63df66bca144dbc65d180efa74f25f8fd9b7d9a0a6c88ae839db32df3d54770dcb6460cf840d232b60695d1a6b1053f599d84e73f7437087712de
   languageName: node
   linkType: hard
 
@@ -21100,15 +21090,6 @@ __metadata:
   version: 5.3.2
   resolution: "ignore@npm:5.3.2"
   checksum: 10c0/f9f652c957983634ded1e7f02da3b559a0d4cc210fca3792cb67f1b153623c9c42efdc1c4121af171e295444459fc4a9201101fb041b1104a3c000bccb188337
-  languageName: node
-  linkType: hard
-
-"image-size@npm:^0.7.4":
-  version: 0.7.5
-  resolution: "image-size@npm:0.7.5"
-  bin:
-    image-size: bin/image-size.js
-  checksum: 10c0/74e978c525e7d777df145bc66cfc4a4a7aa56de8e5daead3a69b0872082dbe385deb4a3b80799810df9e34b2031467412ae28810f2f65ec2e5fe08b895aa3491
   languageName: node
   linkType: hard
 
@@ -31292,13 +31273,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sprintf-js@npm:~1.0.2":
-  version: 1.0.3
-  resolution: "sprintf-js@npm:1.0.3"
-  checksum: 10c0/ecadcfe4c771890140da5023d43e190b7566d9cf8b2d238600f31bec0fc653f328da4450eb04bd59a431771a8e9cc0e118f0aa3974b683a4981b4e07abc2a5bb
-  languageName: node
-  linkType: hard
-
 "sql.js@npm:1.14.1":
   version: 1.14.1
   resolution: "sql.js@npm:1.14.1"
@@ -32178,18 +32152,6 @@ __metadata:
   version: 0.2.0
   resolution: "text-table@npm:0.2.0"
   checksum: 10c0/02805740c12851ea5982686810702e2f14369a5f4c5c40a836821e3eefc65ffeec3131ba324692a37608294b0fd8c1e55a2dd571ffed4909822787668ddbee5c
-  languageName: node
-  linkType: hard
-
-"texture-compressor@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "texture-compressor@npm:1.0.2"
-  dependencies:
-    argparse: "npm:^1.0.10"
-    image-size: "npm:^0.7.4"
-  bin:
-    texture-compressor: ./bin/texture-compressor.js
-  checksum: 10c0/ea0bce1cbda3a64f826867e97ee2a1f17a7219d21d97d7625a6370792afddc697e6832a9b3b39bf2eef0978af7bc0d1dcefaf7fd91d719213658b0a010a83c44
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`texture-compressor` was a runtime dependency of `@loaders.gl/textures`, so every consumer installed it along with its vulnerable `image-size` chain (GHSA-w3rx-r6r6-pgpr, GHSA-5p2g-fcmc-qvqq), whether or not they used `CompressedTextureWriter`.

The package was never imported. `encodeImageURLToCompressedTextureURL()` spawns it as a CLI through `npx`, so the dependency existed only to make it resolvable from the local `node_modules`. It is now an application-supplied prerequisite, which removes the vulnerable chain from every install.

## Why this approach

The issue offered two directions. This takes the second - making the tooling optional rather than swapping in a maintained encoder — because the writer looks legacy rather than actively supported:

- `encode()` throws `Not implemented`.
- All six declared writer options (`format`, `compression`, `quality`, `mipmap`, `flipY`, `toolFlags`) are inert. The CLI arguments are hardcoded to `s3tc`/`DXT1`/`normal`, and the options object is passed through as `spawn` options instead.
- The existing test wrapped its only assertion in an empty `catch`, so this path was never actually exercised in CI.

Replacing it with a maintained encoder would mean bundling proprietary binaries or writing a DXT encoder in JS, which seemed disproportionate for an experimental writer. Happy to go that way instead if you'd prefer.

## Changes

- Remove `texture-compressor` from `dependencies` and regenerate the lockfile, dropping `texture-compressor`, `image-size@0.7.5`, `argparse@1.0.10` and `sprintf-js@1.0.3`, and nothing else.
- Invoke the CLI as `npx --no -- texture-compressor ...`:
  - `--no` stops npx from **silently downloading** the deprecated package at runtime. Without it, removing the dependency just relocates the problem instead of fixing it.
  - `--` is required, because npm otherwise parses the CLI's flags as its own config (`npm warn Unknown cli config "--type"`) and the CLI receives no arguments at all.
- Skip the writer test explicitly when the CLI is absent, rather than swallowing every error and asserting nothing.
- Document the prerequisite in the writer reference, textures README, formats page, and the v5.0 upgrade guide.

## Verification

Installed the CLI into an isolated directory and drove the real `encodeURLtoURL()` → `CompressedTextureWriter` path end to end:

- Output is 76,920 bytes with valid KTX 1.1 magic (`ab 4b 54 58 20 31 31 bb`), matching a direct CLI invocation exactly.
- Byte-identical results on npm 10.9.9 and 11.13.0, covering both npm majors shipped with the supported Node engines.
- With the CLI absent, npx refuses rather than fetching: `npx canceled due to missing packages and no YES option`.
- `yarn install --immutable`, `yarn lint`, and the full Node test suite (404 files / 1931 tests) pass. The 3 failures in `modules/arrow/test/triangulate-on-worker.spec.ts` reproduce on unmodified `master` and are unrelated to this change.

## Notes for maintainers

Two pre-existing issues surfaced while verifying this. Both are left alone here, since fixing either would change published behavior beyond the scope of this fix:

1. The writer is registered as `id: 'dds'` / `name: 'DDS Texture Container'` / `extensions: ['dds']`, but `texture-compressor` rejects `.dds` outright (`.dds is not supported. The supported filetypes are: [.ktx]`) and only writes KTX containers. Documented rather than fixed.
2. `ChildProcessProxy.start()` resolves on a fixed 2s timer regardless of the child's exit code, so `encodeURLtoURL()` can return before the output file has been written.

One open question worth your call: `texture-compressor` could instead go in `devDependencies` of `modules/textures`. That would equally keep it out of consumer installs while letting CI actually exercise the writer, at the cost of leaving the repo's own audit noisy.

Fixes #3552