### PR TITLE
test(las): cover TypeScript LAZ in browsers

### DIFF
--- a/modules/las/test/typescript-laz.spec.ts
+++ b/modules/las/test/typescript-laz.spec.ts
@@ -1,0 +1,444 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {fetchFile} from '@loaders.gl/core';
+import {
+  createLAZChunkDecoderCursor,
+  decodeLAZChunk,
+  getLAZChunkByteLength
+} from '@loaders.gl/loader-utils';
+import type {LAZChunkMetadata, LAZPointDataTarget} from '@loaders.gl/loader-utils';
+import {convertTableToMesh} from '@loaders.gl/schema-utils';
+import {
+  decodeLAZFileInBatches,
+  parseLAS,
+  parseLASInBatches,
+  type LASArrowTable
+} from '../src/lib/typescript/parse-las';
+
+type LAZFixture = {
+  label: string;
+  pointDataRecordFormat: number;
+  pointDataRecordLength: number;
+  lasUrl: string;
+  lazUrl: string;
+  metadata?: Partial<LAZChunkMetadata>;
+};
+
+type CollectedAttributes = {
+  positions: number[];
+  intensities: number[];
+  classifications: number[];
+  colors: number[];
+};
+
+const POINT_COUNT = 1024;
+const CHUNK_POINT_COUNT = 256;
+const TEST_BATCH_SIZE = 127;
+const TEST_INPUT_CHUNK_SIZE = 257;
+
+const FIXTURES: LAZFixture[] = [
+  {
+    label: 'LAS 1.3 PDRF 4',
+    pointDataRecordFormat: 4,
+    pointDataRecordLength: 61,
+    lasUrl: '@loaders.gl/las/test/data/pdrf4-1.3.las',
+    lazUrl: '@loaders.gl/las/test/data/pdrf4-1.3.laz'
+  },
+  {
+    label: 'LAS 1.3 PDRF 5',
+    pointDataRecordFormat: 5,
+    pointDataRecordLength: 67,
+    lasUrl: '@loaders.gl/las/test/data/pdrf5-1.3.las',
+    lazUrl: '@loaders.gl/las/test/data/pdrf5-1.3.laz'
+  },
+  {
+    label: 'LAS 1.4 PDRF 6',
+    pointDataRecordFormat: 6,
+    pointDataRecordLength: 34,
+    lasUrl: '@loaders.gl/las/test/data/pdrf6-1.4.las',
+    lazUrl: '@loaders.gl/las/test/data/pdrf6-1.4.laz',
+    metadata: {point14ItemVersion: 3, byte14ItemVersion: 3}
+  },
+  {
+    label: 'LAS 1.4 PDRF 7 item version 4',
+    pointDataRecordFormat: 7,
+    pointDataRecordLength: 40,
+    lasUrl: '@loaders.gl/las/test/data/pdrf7-v4-1.4.las',
+    lazUrl: '@loaders.gl/las/test/data/pdrf7-v4-1.4.laz',
+    metadata: {point14ItemVersion: 4, rgb14ItemVersion: 4, byte14ItemVersion: 4}
+  },
+  {
+    label: 'LAS 1.4 PDRF 8',
+    pointDataRecordFormat: 8,
+    pointDataRecordLength: 42,
+    lasUrl: '@loaders.gl/las/test/data/pdrf8-1.4.las',
+    lazUrl: '@loaders.gl/las/test/data/pdrf8-1.4.laz',
+    metadata: {point14ItemVersion: 3, rgb14ItemVersion: 3, byte14ItemVersion: 3}
+  },
+  {
+    label: 'LAS 1.4 PDRF 9',
+    pointDataRecordFormat: 9,
+    pointDataRecordLength: 63,
+    lasUrl: '@loaders.gl/las/test/data/pdrf9-1.4.las',
+    lazUrl: '@loaders.gl/las/test/data/pdrf9-1.4.laz',
+    metadata: {point14ItemVersion: 3, wavePacketItemVersion: 3, byte14ItemVersion: 3}
+  },
+  {
+    label: 'LAS 1.4 PDRF 10',
+    pointDataRecordFormat: 10,
+    pointDataRecordLength: 71,
+    lasUrl: '@loaders.gl/las/test/data/pdrf10-1.4.las',
+    lazUrl: '@loaders.gl/las/test/data/pdrf10-1.4.laz',
+    metadata: {
+      point14ItemVersion: 3,
+      rgb14ItemVersion: 3,
+      wavePacketItemVersion: 3,
+      byte14ItemVersion: 3
+    }
+  }
+];
+
+test('TypeScript LAZ raw streaming preserves PDRF 4-10 records', async t => {
+  for (const fixture of FIXTURES) {
+    const [lasArrayBuffer, lazArrayBuffer] = await Promise.all([
+      loadArrayBuffer(fixture.lasUrl),
+      loadArrayBuffer(fixture.lazUrl)
+    ]);
+    const decodedBatches: Uint8Array[] = [];
+
+    for await (const batch of decodeLAZFileInBatches(
+      splitArrayBuffer(lazArrayBuffer, TEST_INPUT_CHUNK_SIZE),
+      {batchSize: TEST_BATCH_SIZE}
+    )) {
+      decodedBatches.push(new Uint8Array(batch.arrayBuffer));
+    }
+
+    const expected = getLASPointData(lasArrayBuffer, fixture.pointDataRecordLength);
+    t.deepEqual(
+      concatenateUint8Arrays(decodedBatches),
+      expected,
+      `${fixture.label} raw records match LAS`
+    );
+  }
+  t.end();
+}, 60000);
+
+test('TypeScript LAZ complete and split parsing preserve Arrow attributes', async t => {
+  for (const fixture of FIXTURES) {
+    const [lasArrayBuffer, lazArrayBuffer] = await Promise.all([
+      loadArrayBuffer(fixture.lasUrl),
+      loadArrayBuffer(fixture.lazUrl)
+    ]);
+    const expected = collectTableAttributes(parseLAS(lasArrayBuffer));
+    const complete = collectTableAttributes(parseLAS(lazArrayBuffer));
+    const streamed = await collectBatchAttributes(
+      parseLASInBatches(splitArrayBuffer(lazArrayBuffer, TEST_INPUT_CHUNK_SIZE), {
+        batchSize: TEST_BATCH_SIZE
+      })
+    );
+
+    t.deepEqual(complete, expected, `${fixture.label} complete parse matches LAS`);
+    t.deepEqual(streamed, expected, `${fixture.label} split parse matches LAS`);
+  }
+  t.end();
+}, 60000);
+
+test('TypeScript LAZ selective Point14 targets decode only requested layers', async t => {
+  const fixture = FIXTURES.find(({pointDataRecordFormat}) => pointDataRecordFormat === 7)!;
+  const lazArrayBuffer = await loadArrayBuffer(fixture.lazUrl);
+  const {compressed, metadata} = getFirstLAZChunk(lazArrayBuffer, fixture);
+  const rawPointData = decodeLAZChunk(compressed, metadata);
+  const expected = getExpectedPointData(rawPointData, metadata);
+
+  const targets: Array<{
+    label: string;
+    createTarget: () => LAZPointDataTarget;
+    validate: (target: LAZPointDataTarget) => void;
+  }> = [
+    {
+      label: 'positions only',
+      createTarget: () => createPointDataTarget(metadata.pointCount),
+      validate: target => t.deepEqual(target.positions, expected.positions, 'positions match')
+    },
+    {
+      label: 'intensity only',
+      createTarget: () => ({
+        ...createPointDataTarget(metadata.pointCount),
+        intensities: new Uint16Array(metadata.pointCount)
+      }),
+      validate: target => t.deepEqual(target.intensities, expected.intensities, 'intensity matches')
+    },
+    {
+      label: 'classification only',
+      createTarget: () => ({
+        ...createPointDataTarget(metadata.pointCount),
+        classifications: new Uint8Array(metadata.pointCount)
+      }),
+      validate: target =>
+        t.deepEqual(target.classifications, expected.classifications, 'classification matches')
+    },
+    {
+      label: 'RGB only',
+      createTarget: () => ({
+        ...createPointDataTarget(metadata.pointCount),
+        rawColors: new Uint16Array(metadata.pointCount * 3)
+      }),
+      validate: target => t.deepEqual(target.rawColors, expected.rawColors, 'RGB matches')
+    }
+  ];
+
+  for (const selection of targets) {
+    const target = selection.createTarget();
+    const cursor = createLAZChunkDecoderCursor(compressed, metadata);
+    t.equal(
+      cursor.decodeIntoPointData(target, metadata.pointCount),
+      metadata.pointCount,
+      `${selection.label} decodes every point`
+    );
+    selection.validate(target);
+  }
+
+  const lockedTarget = createPointDataTarget(metadata.pointCount);
+  const lockedCursor = createLAZChunkDecoderCursor(compressed, metadata);
+  lockedCursor.decodeIntoPointData(lockedTarget, 1);
+  t.throws(
+    () =>
+      lockedCursor.decodeIntoPointData(
+        {...lockedTarget, classifications: new Uint8Array(metadata.pointCount)},
+        1
+      ),
+    /Cannot change selected point-data fields/,
+    'selection cannot change after decoding begins'
+  );
+  t.end();
+}, 60000);
+
+test('TypeScript LAZ skips unrequested RGB and auxiliary PDRF 8-10 layers', async t => {
+  for (const fixture of FIXTURES.filter(({pointDataRecordFormat}) =>
+    [8, 9, 10].includes(pointDataRecordFormat)
+  )) {
+    const lazArrayBuffer = await loadArrayBuffer(fixture.lazUrl);
+    const {compressed, metadata} = getFirstLAZChunk(lazArrayBuffer, fixture);
+    const rawPointData = decodeLAZChunk(compressed, metadata);
+    const expected = getExpectedPointData(rawPointData, metadata);
+    const target = createPointDataTarget(metadata.pointCount);
+    const cursor = createLAZChunkDecoderCursor(compressed, metadata);
+
+    t.equal(
+      cursor.decodeIntoPointData(target, metadata.pointCount),
+      metadata.pointCount,
+      `${fixture.label} positions-only target decodes every point`
+    );
+    t.deepEqual(
+      target.positions,
+      expected.positions,
+      `${fixture.label} positions match raw records`
+    );
+  }
+  t.end();
+}, 60000);
+
+test('TypeScript LAZ validates VLR codecs and truncated input', async t => {
+  const fixture = FIXTURES.find(({pointDataRecordFormat}) => pointDataRecordFormat === 7)!;
+  const source = await loadArrayBuffer(fixture.lazUrl);
+  const vlrDataOffset = findLASZipVLRDataOffset(source);
+  const itemOffset = findLASZipItemOffset(source, 11);
+  const cases = [
+    {
+      label: 'arithmetic coder',
+      mutate: (dataView: DataView) => dataView.setUint16(vlrDataOffset + 2, 1, true),
+      error: /requires LASzip arithmetic coder 0; received 1/
+    },
+    {
+      label: 'item type',
+      mutate: (dataView: DataView) => dataView.setUint16(itemOffset, 12, true),
+      error: /type 12; expected 11/
+    },
+    {
+      label: 'item size',
+      mutate: (dataView: DataView) => dataView.setUint16(itemOffset + 2, 5, true),
+      error: /size 5; expected 6/
+    },
+    {
+      label: 'item version',
+      mutate: (dataView: DataView) => dataView.setUint16(itemOffset + 4, 5, true),
+      error: /unsupported LAS 1\.4 item type 11 version 5/
+    }
+  ];
+
+  for (const fixtureCase of cases) {
+    const corrupted = source.slice(0);
+    fixtureCase.mutate(new DataView(corrupted));
+    t.throws(() => parseLAS(corrupted), fixtureCase.error, `rejects invalid ${fixtureCase.label}`);
+  }
+
+  t.throws(
+    () => parseLAS(source.slice(0, source.byteLength - 32)),
+    /needs more|truncated|beyond input/i,
+    'rejects truncated compressed point data'
+  );
+  t.end();
+});
+
+/** Load one local LAS/LAZ fixture. */
+async function loadArrayBuffer(url: string): Promise<ArrayBuffer> {
+  return (await fetchFile(url)).arrayBuffer();
+}
+
+/** Return the complete point-record region from an uncompressed fixture. */
+function getLASPointData(arrayBuffer: ArrayBuffer, pointDataRecordLength: number): Uint8Array {
+  const pointDataOffset = new DataView(arrayBuffer).getUint32(96, true);
+  return new Uint8Array(arrayBuffer, pointDataOffset, POINT_COUNT * pointDataRecordLength);
+}
+
+/** Extract the first fixed-size compressed chunk and its codec metadata. */
+function getFirstLAZChunk(
+  arrayBuffer: ArrayBuffer,
+  fixture: LAZFixture
+): {compressed: Uint8Array; metadata: LAZChunkMetadata} {
+  const pointDataOffset = new DataView(arrayBuffer).getUint32(96, true);
+  const metadata: LAZChunkMetadata = {
+    pointCount: CHUNK_POINT_COUNT,
+    pointDataRecordFormat: fixture.pointDataRecordFormat,
+    pointDataRecordLength: fixture.pointDataRecordLength,
+    ...fixture.metadata
+  };
+  const remaining = new Uint8Array(arrayBuffer, pointDataOffset + 8);
+  const byteLength = getLAZChunkByteLength(remaining, metadata);
+  return {compressed: remaining.subarray(0, byteLength), metadata};
+}
+
+/** Allocate the always-required direct output columns. */
+function createPointDataTarget(pointCount: number): LAZPointDataTarget {
+  return {
+    positions: new Float64Array(pointCount * 3),
+    pointOffset: 0,
+    scale: [1, 1, 1],
+    offset: [0, 0, 0]
+  };
+}
+
+/** Extract direct-output oracle columns from complete raw PDRF 6-10 records. */
+function getExpectedPointData(
+  rawPointData: Uint8Array,
+  metadata: LAZChunkMetadata
+): {
+  positions: Float64Array;
+  intensities: Uint16Array;
+  classifications: Uint8Array;
+  rawColors: Uint16Array;
+} {
+  const dataView = new DataView(
+    rawPointData.buffer,
+    rawPointData.byteOffset,
+    rawPointData.byteLength
+  );
+  const positions = new Float64Array(metadata.pointCount * 3);
+  const intensities = new Uint16Array(metadata.pointCount);
+  const classifications = new Uint8Array(metadata.pointCount);
+  const rawColors = new Uint16Array(metadata.pointCount * 3);
+
+  for (let pointIndex = 0; pointIndex < metadata.pointCount; pointIndex++) {
+    const recordOffset = pointIndex * metadata.pointDataRecordLength;
+    const positionOffset = pointIndex * 3;
+    positions[positionOffset] = dataView.getInt32(recordOffset, true);
+    positions[positionOffset + 1] = dataView.getInt32(recordOffset + 4, true);
+    positions[positionOffset + 2] = dataView.getInt32(recordOffset + 8, true);
+    intensities[pointIndex] = dataView.getUint16(recordOffset + 12, true);
+    classifications[pointIndex] = dataView.getUint8(recordOffset + 16);
+    if ([7, 8, 10].includes(metadata.pointDataRecordFormat)) {
+      rawColors[positionOffset] = dataView.getUint16(recordOffset + 30, true);
+      rawColors[positionOffset + 1] = dataView.getUint16(recordOffset + 32, true);
+      rawColors[positionOffset + 2] = dataView.getUint16(recordOffset + 34, true);
+    }
+  }
+  return {positions, intensities, classifications, rawColors};
+}
+
+/** Collect represented attributes from one Arrow table. */
+function collectTableAttributes(table: LASArrowTable): CollectedAttributes {
+  const {attributes} = convertTableToMesh(table);
+  return {
+    positions: Array.from(attributes.POSITION.value),
+    intensities: Array.from(attributes.intensity.value),
+    classifications: Array.from(attributes.classification.value),
+    colors: Array.from(attributes.COLOR_0?.value || [])
+  };
+}
+
+/** Collect represented attributes from an Arrow table batch iterator. */
+async function collectBatchAttributes(
+  batches: AsyncIterable<LASArrowTable>
+): Promise<CollectedAttributes> {
+  const result: CollectedAttributes = {
+    positions: [],
+    intensities: [],
+    classifications: [],
+    colors: []
+  };
+  for await (const batch of batches) {
+    const attributes = collectTableAttributes(batch);
+    result.positions.push(...attributes.positions);
+    result.intensities.push(...attributes.intensities);
+    result.classifications.push(...attributes.classifications);
+    result.colors.push(...attributes.colors);
+  }
+  return result;
+}
+
+/** Yield independent copies at deterministic streaming boundaries. */
+async function* splitArrayBuffer(
+  arrayBuffer: ArrayBuffer,
+  chunkSize: number
+): AsyncIterable<ArrayBuffer> {
+  const bytes = new Uint8Array(arrayBuffer);
+  for (let byteOffset = 0; byteOffset < bytes.byteLength; byteOffset += chunkSize) {
+    yield bytes.slice(byteOffset, Math.min(byteOffset + chunkSize, bytes.byteLength)).buffer;
+  }
+}
+
+/** Concatenate raw output batches for byte-for-byte parity assertions. */
+function concatenateUint8Arrays(chunks: Uint8Array[]): Uint8Array {
+  const byteLength = chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0);
+  const result = new Uint8Array(byteLength);
+  let byteOffset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, byteOffset);
+    byteOffset += chunk.byteLength;
+  }
+  return result;
+}
+
+/** Find the LASzip VLR payload in a fixture. */
+function findLASZipVLRDataOffset(arrayBuffer: ArrayBuffer): number {
+  const dataView = new DataView(arrayBuffer);
+  let byteOffset = dataView.getUint16(94, true);
+  const variableLengthRecordCount = dataView.getUint32(100, true);
+  for (let recordIndex = 0; recordIndex < variableLengthRecordCount; recordIndex++) {
+    const recordId = dataView.getUint16(byteOffset + 18, true);
+    const recordLength = dataView.getUint16(byteOffset + 20, true);
+    const dataOffset = byteOffset + 54;
+    if (recordId === 22204) {
+      return dataOffset;
+    }
+    byteOffset = dataOffset + recordLength;
+  }
+  throw new Error('LASzip VLR not found');
+}
+
+/** Find one LASzip item descriptor in a fixture. */
+function findLASZipItemOffset(arrayBuffer: ArrayBuffer, targetItemType: number): number {
+  const dataView = new DataView(arrayBuffer);
+  const dataOffset = findLASZipVLRDataOffset(arrayBuffer);
+  const itemCount = dataView.getUint16(dataOffset + 32, true);
+  for (let itemIndex = 0; itemIndex < itemCount; itemIndex++) {
+    const itemOffset = dataOffset + 34 + itemIndex * 6;
+    if (dataView.getUint16(itemOffset, true) === targetItemType) {
+      return itemOffset;
+    }
+  }
+  throw new Error(`LASzip item type ${targetItemType} not found`);
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -55,7 +55,10 @@ const nodeExcludePatterns = [
   'modules/tiles/test/tileset/tileset-traverser.spec.ts'
 ];
 
-const browserExcludePatterns = ['modules/las/test/**'];
+const browserExcludePatterns = [
+  'modules/las/test/las-loader.spec.ts',
+  'modules/las/test/las-writer.spec.ts'
+];
 const sharedTestOptions = {
   passWithNoTests: true,
   setupFiles: ['./test/vitest-setup.ts'],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -55,10 +55,7 @@ const nodeExcludePatterns = [
   'modules/tiles/test/tileset/tileset-traverser.spec.ts'
 ];
 
-const browserExcludePatterns = [
-  'modules/las/test/las-loader.spec.ts',
-  'modules/las/test/las-writer.spec.ts'
-];
+const browserExcludePatterns = ['modules/las/test/!(typescript-laz).spec.ts'];
 const sharedTestOptions = {
   passWithNoTests: true,
   setupFiles: ['./test/vitest-setup.ts'],


### PR DESCRIPTION
## Goal

Increase meaningful browser coverage for the pure TypeScript LAZ parser and decoder so coverage reflects the browser-compatible implementation landed in the preceding LAZ hardening work.

## Changes

- Add a compact shared TypeScript LAZ suite that runs in both Node and Chromium.
- Cover byte-exact streaming decode for LAS 1.3/1.4 PDRF 4-10.
- Compare complete and split LAZ parsing against matching uncompressed LAS Arrow output.
- Exercise selective PDRF 7 columns, skipped PDRF 8-10 layers, field-selection locking, LASzip VLR validation, and truncated input.
- Narrow the browser exclusion from the entire LAS test directory to the two legacy monolithic LAS specs.

## Coverage

Focused Chromium coverage before -> after:

- `modules/las/src/lib/typescript/parse-las.ts`: `0/765` -> `548/765` lines
- `modules/loader-utils/src/lib/laz/laz-chunk-decoder.ts`: `619/1834` -> `1500/1834` lines

Focused Node coverage also improves:

- `parse-las.ts`: `617/765` -> `621/765` lines
- `laz-chunk-decoder.ts`: `1660/1834` -> `1669/1834` lines
- decoder branches: `621/775` -> `641/775`

## Validation

- `yarn lint fix`
- `yarn build`
- focused Node suite: 5 tests passed
- focused Chromium suite: 5 tests passed
- focused Node coverage: 81 passed, 1 skipped
- focused Chromium coverage: 16 passed
