### PR TITLE
fix(zip): support ZIP64 local size pairs and data descriptors

### DIFF
--- a/modules/zip/src/filesystems/zip-filesystem.ts
+++ b/modules/zip/src/filesystems/zip-filesystem.ts
@@ -124,7 +124,7 @@ export class ZipFileSystem implements FileSystem {
       const compressedFile = await readRange(
         this.file,
         localFileHeader.fileDataOffset,
-        localFileHeader.fileDataOffset + localFileHeader.compressedSize
+        localFileHeader.fileDataOffset + cdFileHeader.compressedSize
       );
 
       uncompressedFile = await compressionHandler(compressedFile);

--- a/modules/zip/src/parse-zip/local-file-header.ts
+++ b/modules/zip/src/parse-zip/local-file-header.ts
@@ -95,15 +95,17 @@ export const parseZipLocalFileHeader = async (
   const uncompressedSize = BigInt(mainHeader.getUint32(UNCOMPRESSED_SIZE_OFFSET, true));
 
   const expectedZip64Fields: Zip64ExtraFieldDescription<keyof Zip64LocalSizeData>[] = [];
-  if (uncompressedSize === ZIP64_UINT32_SENTINEL) {
-    expectedZip64Fields.push({name: 'uncompressedSize', byteLength: 8});
-  }
-  if (compressedSize === ZIP64_UINT32_SENTINEL) {
-    expectedZip64Fields.push({name: 'compressedSize', byteLength: 8});
+  if (uncompressedSize === ZIP64_UINT32_SENTINEL || compressedSize === ZIP64_UINT32_SENTINEL) {
+    // APPNOTE 4.5.3 requires both sizes in local ZIP64 extra data when either
+    // 32-bit size field contains the ZIP64 sentinel.
+    expectedZip64Fields.push(
+      {name: 'uncompressedSize', byteLength: 8},
+      {name: 'compressedSize', byteLength: 8}
+    );
   }
 
   const zip64Sizes = parseZip64ExtraField(extraDataBuffer, expectedZip64Fields);
-  if (zip64Sizes.compressedSize !== undefined) {
+  if (compressedSize === ZIP64_UINT32_SENTINEL && zip64Sizes.compressedSize !== undefined) {
     compressedSize = zip64Sizes.compressedSize;
   }
 

--- a/modules/zip/test/filesystems/zip-filesystem.spec.ts
+++ b/modules/zip/test/filesystems/zip-filesystem.spec.ts
@@ -77,6 +77,21 @@ test('zip#ZipFileSystem - fetch the file', async t => {
   t.end();
 });
 
+test('zip#ZipFileSystem - fetch uses central-directory sizes for data descriptors', async t => {
+  for (const includeSignature of [true, false]) {
+    const archive = createDataDescriptorArchive(includeSignature);
+    const fileSystem = new ZipFileSystem(archive);
+    const response = await fileSystem.fetch('test.txt');
+    t.equal(
+      await response.text(),
+      'data descriptor contents',
+      includeSignature ? 'reads signed descriptor archive' : 'reads unsigned descriptor archive'
+    );
+    await fileSystem.destroy();
+  }
+  t.end();
+});
+
 test('zip#ZipFileSystem - fetch should fail', async t => {
   const fileProvider = await getFileProvider(ZIP_FILE_PATH);
   const fileSystem = new ZipFileSystem(fileProvider);
@@ -169,4 +184,53 @@ function createMalformedZip64Archive(
   });
 
   return concatenateArrayBuffers(localHeader, centralDirectoryHeader, endOfCentralDirectory);
+}
+
+/**
+ * Creates an in-memory stored ZIP whose local header defers sizes to a data descriptor.
+ * @param includeSignature whether to include the optional data descriptor signature
+ * @returns ZIP archive bytes
+ */
+function createDataDescriptorArchive(includeSignature: boolean): ArrayBuffer {
+  const fileName = 'test.txt';
+  const contents = new TextEncoder().encode('data descriptor contents');
+  const localHeader = generateLocalHeader({crc32: 0, fileName, length: 0});
+  new DataView(localHeader).setUint16(6, 0x0008, true);
+
+  const descriptor = new DataView(new ArrayBuffer(includeSignature ? 16 : 12));
+  let descriptorOffset = 0;
+  if (includeSignature) {
+    descriptor.setUint32(descriptorOffset, 0x08074b50, true);
+    descriptorOffset += 4;
+  }
+  descriptor.setUint32(descriptorOffset, 0, true);
+  descriptor.setUint32(descriptorOffset + 4, contents.byteLength, true);
+  descriptor.setUint32(descriptorOffset + 8, contents.byteLength, true);
+
+  const centralDirectoryOffset = BigInt(
+    localHeader.byteLength + contents.byteLength + descriptor.byteLength
+  );
+  const centralDirectoryHeader = generateCDHeader({
+    crc32: 0,
+    fileName,
+    length: contents.byteLength,
+    offset: 0n
+  });
+  new DataView(centralDirectoryHeader).setUint16(8, 0x0008, true);
+  const endOfCentralDirectoryOffset =
+    centralDirectoryOffset + BigInt(centralDirectoryHeader.byteLength);
+  const endOfCentralDirectory = generateEoCD({
+    recordsNumber: 1,
+    cdSize: centralDirectoryHeader.byteLength,
+    cdOffset: centralDirectoryOffset,
+    eoCDStart: endOfCentralDirectoryOffset
+  });
+
+  return concatenateArrayBuffers(
+    localHeader,
+    contents.buffer,
+    descriptor.buffer,
+    centralDirectoryHeader,
+    endOfCentralDirectory
+  );
 }

--- a/modules/zip/test/zip-utils/local-file-header.spec.ts
+++ b/modules/zip/test/zip-utils/local-file-header.spec.ts
@@ -77,15 +77,16 @@ test('SLPKLoader#local file header parses valid zip64 sizes', async t => {
   t.end();
 });
 
-test('SLPKLoader#local file header parses only sentinel-backed zip64 fields', async t => {
+test('SLPKLoader#local file header requires the ZIP64 size pair', async t => {
   const compressedHeader = generateLocalHeader({crc32: 0, fileName: 'test.json', length: 0});
   const compressedHeaderView = new DataView(compressedHeader);
   compressedHeaderView.setUint32(18, 0xffffffff, true);
-  compressedHeaderView.setUint16(28, 12, true);
-  const compressedExtraField = new DataView(new ArrayBuffer(12));
+  compressedHeaderView.setUint16(28, 20, true);
+  const compressedExtraField = new DataView(new ArrayBuffer(20));
   compressedExtraField.setUint16(0, 0x0001, true);
-  compressedExtraField.setUint16(2, 8, true);
-  compressedExtraField.setBigUint64(4, 0x112233445566n, true);
+  compressedExtraField.setUint16(2, 16, true);
+  compressedExtraField.setBigUint64(4, 0x010203040506n, true);
+  compressedExtraField.setBigUint64(12, 0x112233445566n, true);
 
   const compressedFileHeader = await parseZipLocalFileHeader(
     0n,
@@ -98,11 +99,12 @@ test('SLPKLoader#local file header parses only sentinel-backed zip64 fields', as
   const uncompressedHeader = generateLocalHeader({crc32: 0, fileName: 'test.json', length: 0});
   const uncompressedHeaderView = new DataView(uncompressedHeader);
   uncompressedHeaderView.setUint32(22, 0xffffffff, true);
-  uncompressedHeaderView.setUint16(28, 12, true);
-  const uncompressedExtraField = new DataView(new ArrayBuffer(12));
+  uncompressedHeaderView.setUint16(28, 20, true);
+  const uncompressedExtraField = new DataView(new ArrayBuffer(20));
   uncompressedExtraField.setUint16(0, 0x0001, true);
-  uncompressedExtraField.setUint16(2, 8, true);
+  uncompressedExtraField.setUint16(2, 16, true);
   uncompressedExtraField.setBigUint64(4, 0x223344556677n, true);
+  uncompressedExtraField.setBigUint64(12, 0x334455667788n, true);
 
   const uncompressedFileHeader = await parseZipLocalFileHeader(
     0n,


### PR DESCRIPTION
## Goal

Make random-access ZIP reads interoperable with ZIP64 local headers and archives that defer sizes to data descriptors.

## Changes

- Parse the mandatory uncompressed/compressed ZIP64 size pair whenever either local 32-bit size is the ZIP64 sentinel.
- Keep legacy local compressed sizes authoritative when that field is not a sentinel.
- Read file payload ranges from central-directory sizes, which are authoritative when general-purpose bit 3 enables a data descriptor.
- Add shared Node/browser coverage for signed and unsigned data descriptors and both one-sentinel local ZIP64 layouts.

## Validation

- `yarn install`
- `yarn build`
- `yarn test-node`
- `yarn test-headless`
- `yarn lint fix`

Follow-up to #3545 and #3546.