### PR TITLE
refactor(parquet): make loader implementations explicit

### DIFF
--- a/docs/modules/parquet/api-reference/parquet-loader.md
+++ b/docs/modules/parquet/api-reference/parquet-loader.md
@@ -11,9 +11,10 @@ import BrowserOnly from '@docusaurus/BrowserOnly';
   <img src="https://img.shields.io/badge/Status-Experimental-orange.svg?style=flat-square" alt="Status: Experimental" />
 </p>
 
-Streaming loader for Apache Parquet encoded files. `ParquetLoader` returns plain JavaScript object rows by default and can return Arrow tables through `parquet.shape: 'arrow-table'`.
+Streaming loader for Apache Parquet encoded files. `ParquetLoader` is the primary wasm-backed loader;
+`ParquetJSLoader` is the experimental TypeScript loader variant. Both return object rows by default
+and support Arrow tables through `parquet.shape: 'arrow-table'`.
 
-`ParquetJSLoader` is the experimental TypeScript loader variant.
 <img src="https://img.shields.io/badge/From-v5.0-blue.svg?style=flat-square" alt="From-v5.0" />
 
 Please refer to the `parquet` format page for information on
@@ -31,7 +32,7 @@ const wasmRows = await load(url, ParquetLoader, {parquet: options});
 const typeScriptRows = await load(url, ParquetJSLoader, {parquet: options});
 ```
 
-Load a Parquet file as Arrow using the main loader.
+Load a Parquet file as Arrow using the primary loader.
 
 ```typescript
 import {ParquetLoader} from '@loaders.gl/parquet';
@@ -57,13 +58,15 @@ const arrowTable = await load(url, ParquetLoader, {
 | `object-row-table` | loaders.gl row table with objects                |
 | `arrow-table`      | loaders.gl `ArrowTable` wrapping an Arrow table  |
 
+## Streaming
+
 The ParquetLoader supports streaming parsing, in which case it will yield "batches" of rows.
 
 ```typescript
 import {ParquetLoader} from '@loaders.gl/parquet';
 import {loadInBatches} from '@loaders.gl/core';
 
-const batches = await loadInBatches('geo.parquet', ParquetLoader, {parquet: options}});
+const batches = await loadInBatches('geo.parquet', ParquetLoader, {parquet: options});
 
 for await (const batch of batches) {
   // batch.data will contain a number of rows
@@ -142,8 +145,7 @@ Supports table category options such as `batchType` and `batchSize`.
 
 | Option | Type | Default | Description |
 | ------ | ---- | ------- | ----------- |
-| `parquet.backend` | `'wasm' \| 'typescript'` | `'wasm'` | Selects the implementation used by `ParquetLoader`. |
-| `parquet.shape` | `'object-row-table' \| 'arrow-table'` | `'object-row-table'` | Selects the returned table shape for `ParquetLoader`. <img src="https://img.shields.io/badge/From-v5.0-blue.svg?style=flat-square" alt="From-v5.0" /> |
+| `parquet.shape` | `'object-row-table' \| 'arrow-table'` | `'object-row-table'` | Selects the returned table shape for `ParquetLoader` and `ParquetJSLoader`. <img src="https://img.shields.io/badge/From-v5.0-blue.svg?style=flat-square" alt="From-v5.0" /> |
 | `parquet.limit` | `number` | `undefined` | Maximum number of rows to return. |
 | `parquet.offset` | `number` | `0` | Number of rows to skip before returning data. |
 | `parquet.batchSize` | `number` | `undefined` | Target number of rows per batch when streaming. |
@@ -156,10 +158,13 @@ Supports table category options such as `batchType` and `batchSize`.
 
 ## Loader Variants
 
-- Use `ParquetLoader` for the default wasm-backed loader. It supports object-row and Arrow output.
+- Use `ParquetLoader` for the primary wasm-backed loader. It supports object-row and Arrow output
+  and can use the package's prebuilt worker.
 - Use `ParquetJSLoader` for the experimental TypeScript implementation. It supports object-row and
   Arrow output plus the common row options listed above, including `columns`, `limit`, `offset`,
   `batchSize`, and `preserveBinary`.
+
+The implementation is selected by the loader import. There is no runtime backend option.
 
 ```typescript
 import {load} from '@loaders.gl/core';
@@ -177,13 +182,13 @@ const table = await load(url, ParquetJSLoader, {
 For `shape: 'arrow-table'`, `ParquetJSLoader` converts its decoded rows to an Apache Arrow table and
 preserves compatible GeoParquet metadata on the Arrow schema.
 
-## Worker execution
+## Worker Execution
 
-The default wasm backend can decode on a worker when workers are enabled. The Parquet bytes are transferred into the worker, and Arrow output returns as a transferable Arrow IPC payload that is rehydrated into Apache Arrow class instances on the main thread. Aborting `parquet.signal` terminates the active worker rather than waiting for a non-cancellable WASM call to finish.
+The primary `ParquetLoader` can decode on a worker when workers are enabled. The Parquet bytes are transferred into the worker, and Arrow output returns as a transferable Arrow IPC payload that is rehydrated into Apache Arrow class instances on the main thread. Aborting `parquet.signal` terminates the active worker rather than waiting for a non-cancellable WASM call to finish.
 
 The package publishes `parquet-worker.js` and `parquet_wasm_bg.wasm` beside its JavaScript output. The metadata loader resolves the worker with a module-relative `new URL(..., import.meta.url)`, while the worker resolves the WASM file beside itself. This lets compatible bundlers copy and fingerprint both assets without an implicit CDN request. Use `parquet.workerUrl` or `parquet.wasmUrl` when an application serves assets from a custom location.
 
-Set `core.worker: false` to decode on the calling thread. The TypeScript backend currently stays on the calling thread. Node worker threads remain opt-in through `core._nodeWorkers`.
+Set `core.worker: false` to decode on the calling thread. `ParquetJSLoader` always parses on the calling thread and does not add another prebuilt worker to the package. Node worker threads for `ParquetLoader` remain opt-in through `core._nodeWorkers`.
 
 ## Live Benchmarks
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -127,6 +127,7 @@ This unifies top-level loading behavior:
 
 - `ParquetJSONLoader` and `ParquetJSONWriter` compatibility aliases have been removed. Use `ParquetLoader`, `ParquetWriter`, `ParquetJSLoader`, or `ParquetJSWriter` instead depending on the backend you want.
 - `ParquetLoader` and `ParquetWriter` remain the canonical wasm-backed APIs. The experimental parquetjs backend now lives behind the explicit `ParquetJSLoader` and `ParquetJSWriter` exports.
+- `parquet.backend` and the deprecated `parquet.implementation` options have been removed. Import `ParquetLoader` for WASM or `ParquetJSLoader` for the TypeScript parquetjs implementation.
 
 **@loaders.gl/images**
 

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -100,7 +100,8 @@ Release Date: 2026
 - `HttpFile` now supports pinned object identity, strict or best-effort validator consistency, cancellable exact range reads, shared scheduling, and immutable request/byte/time telemetry.
 - The Parquet TypeScript backend now reads Data Page V2, `DELTA_BINARY_PACKED`, `DELTA_LENGTH_BYTE_ARRAY`, `DELTA_BYTE_ARRAY`, and legacy Hadoop-framed LZ4 data.
 - [`ParquetJSLoader`](/docs/modules/parquet/api-reference/parquet-loader#loader-variants) and [`ParquetJSWriter`](/docs/modules/parquet/api-reference/parquet-writer#writer-variants) NEW - add the experimental parquetjs plain-row and plain-table APIs.
-- `parquet.shape` on [`ParquetLoader`](/docs/modules/parquet/api-reference/parquet-loader) is now documented for selecting object-row or Arrow output from the canonical wasm-backed loader.
+- Parquet parser selection now follows the imported loader: use the primary worker-capable `ParquetLoader` for WASM or the explicit main-thread `ParquetJSLoader` fallback for parquetjs. Runtime `parquet.backend` and `parquet.implementation` selectors have been removed.
+- `parquet.shape` on [`ParquetLoader`](/docs/modules/parquet/api-reference/parquet-loader) and `ParquetJSLoader` selects object-row or Arrow output.
 
 **@loaders.gl/geotiff**
 

--- a/examples/website/geospatial/app.tsx
+++ b/examples/website/geospatial/app.tsx
@@ -132,7 +132,6 @@ type AppState = {
   error?: string | null;
   loading?: boolean;
   loadDurationSeconds?: number | null;
-  displayedParquetImplementation?: 'wasm' | 'js' | null;
   loadedDataName: LoadedDataName;
   loadedGeometryType: LoadedGeometryType;
   // CURRENT VIEW POINT / CAMERA POSITION
@@ -143,9 +142,7 @@ type AppState = {
  * A Geospatial table map viewer
  */
 export default function App(props: AppProps = {}) {
-  const [parquetImplementation, setParquetImplementation] = useState<'wasm' | 'js'>('js');
   const [tableFormat, setTableFormat] = useState<TableFormat>('geoarrow');
-  const previousParquetImplementation = useRef(parquetImplementation);
   const previousTableFormat = useRef(tableFormat);
   const loadRequestIdRef = useRef(0);
   const availableExamples = useMemo(
@@ -161,7 +158,6 @@ export default function App(props: AppProps = {}) {
     error: null,
     loading: false,
     loadDurationSeconds: null,
-    displayedParquetImplementation: null,
     loadedDataName: 'geojson',
     loadedGeometryType: null
   });
@@ -185,37 +181,9 @@ export default function App(props: AppProps = {}) {
       initialCategoryName,
       initialExampleName,
       initialExample,
-      previousParquetImplementation.current,
       previousTableFormat.current
     );
   }, [availableExamples, props.format]);
-
-  useEffect(() => {
-    const implementationChanged = previousParquetImplementation.current !== parquetImplementation;
-    previousParquetImplementation.current = parquetImplementation;
-
-    if (
-      !implementationChanged ||
-      state.selectedCategoryName !== 'GeoParquet' ||
-      !state.selectedExample ||
-      !state.selectedExampleName
-    ) {
-      return;
-    }
-
-    void loadExample(
-      state.selectedCategoryName,
-      state.selectedExampleName,
-      state.selectedExample,
-      parquetImplementation,
-      tableFormat
-    );
-  }, [
-    parquetImplementation,
-    state.selectedCategoryName,
-    state.selectedExample,
-    state.selectedExampleName
-  ]);
 
   useEffect(() => {
     const formatChanged = previousTableFormat.current !== tableFormat;
@@ -229,11 +197,9 @@ export default function App(props: AppProps = {}) {
       state.selectedCategoryName,
       state.selectedExampleName,
       state.selectedExample,
-      parquetImplementation,
       tableFormat
     );
   }, [
-    parquetImplementation,
     state.selectedCategoryName,
     state.selectedExample,
     state.selectedExampleName,
@@ -271,7 +237,6 @@ export default function App(props: AppProps = {}) {
                   loadedDataName: state.loadedDataName,
                   loadedGeometryType: state.loadedGeometryType,
                   rowCount: state.table ? getTableLength(state.table) : null,
-                  parquetImplementation,
                   loadDurationSeconds: state.loadDurationSeconds,
                   loading: state.loading,
                   error: state.error,
@@ -284,13 +249,11 @@ export default function App(props: AppProps = {}) {
                         categoryName,
                         exampleName,
                         example,
-                        parquetImplementation,
                         tableFormat
                       );
                     }
                   },
-                  onTableFormatChange: setTableFormat,
-                  onParquetImplementationChange: setParquetImplementation
+                  onTableFormatChange: setTableFormat
                 })
             })
           }
@@ -299,7 +262,6 @@ export default function App(props: AppProps = {}) {
     ];
   }, [
     availableExamples,
-    parquetImplementation,
     props.hideChrome,
     state.error,
     state.loadedDataName,
@@ -333,11 +295,10 @@ export default function App(props: AppProps = {}) {
     categoryName: string,
     exampleName: string,
     example: Example,
-    implementation: 'wasm' | 'js',
     nextTableFormat: TableFormat
   ) {
     const url = example.data;
-    const loaderOptions = getLoaderOptions(example, implementation, nextTableFormat);
+    const loaderOptions = getLoaderOptions(example, nextTableFormat);
     const loaders = getLoaders(example, nextTableFormat);
     const requestId = ++loadRequestIdRef.current;
     const loadStartTime = performance.now();
@@ -372,7 +333,6 @@ export default function App(props: AppProps = {}) {
         error: null,
         loading: false,
         loadDurationSeconds,
-        displayedParquetImplementation: implementation,
         loadedDataName: loadedTableInfo.loadedDataName,
         loadedGeometryType: loadedTableInfo.loadedGeometryType
       }));
@@ -451,7 +411,6 @@ function getLoaders(example: Example, tableFormat: TableFormat) {
 
 function getLoaderOptions(
   example: Example,
-  implementation: 'wasm' | 'js',
   tableFormat: TableFormat
 ): LoaderOptions {
   const tableShape = tableFormat === 'geoarrow' ? 'arrow-table' : 'geojson-table';
@@ -461,8 +420,7 @@ function getLoaderOptions(
     ...LOADER_OPTIONS,
     parquet: {
       ...LOADER_OPTIONS.parquet,
-      shape: tableShape,
-      implementation
+      shape: tableShape
     },
     arrow: {
       ...LOADER_OPTIONS.arrow,
@@ -853,7 +811,6 @@ function renderGeospatialSidebar(
     loadedDataName: LoadedDataName;
     loadedGeometryType: LoadedGeometryType;
     rowCount: number | null;
-    parquetImplementation: 'wasm' | 'js';
     loadDurationSeconds?: number | null;
     loading: boolean;
     error?: string | null;
@@ -861,7 +818,6 @@ function renderGeospatialSidebar(
     viewState: Record<string, unknown>;
     onExampleChange: (selection: {categoryName: string; exampleName: string}) => void;
     onTableFormatChange: (tableFormat: TableFormat) => void;
-    onParquetImplementationChange: (implementation: 'wasm' | 'js') => void;
   }
 ): void {
   rootElement.replaceChildren();
@@ -884,12 +840,6 @@ function renderGeospatialSidebar(
       onTableFormatChange: options.onTableFormatChange
     })
   );
-
-  if (options.selectedCategoryName === 'GeoParquet') {
-    rootElement.appendChild(
-      createParquetSection(options.parquetImplementation, options.onParquetImplementationChange)
-    );
-  }
 
   rootElement.appendChild(
     createStatusSection({
@@ -1082,41 +1032,6 @@ function createArrowSeparator(): HTMLElement {
   separatorElement.style.color = '#64748b';
   separatorElement.style.fontSize = '13px';
   return separatorElement;
-}
-
-function createParquetSection(
-  parquetImplementation: 'wasm' | 'js',
-  onParquetImplementationChange: (implementation: 'wasm' | 'js') => void
-): HTMLElement {
-  const section = createSection();
-  section.appendChild(createLabel('GeoParquetLoader options', 'parquet-implementation'));
-
-  const selectElement = document.createElement('select');
-  selectElement.id = 'parquet-implementation';
-  selectElement.value = parquetImplementation;
-  selectElement.style.width = '100%';
-  selectElement.style.margin = '0 0 4px';
-  selectElement.style.padding = '8px';
-  selectElement.style.border = '1px solid rgba(148, 163, 184, 0.55)';
-  selectElement.style.borderRadius = '8px';
-  selectElement.style.background = 'var(--menu-background, #fff)';
-  selectElement.style.color = 'inherit';
-  selectElement.add(new Option('wasm', 'wasm'));
-  selectElement.add(new Option('js', 'js'));
-  selectElement.addEventListener('change', (event) => {
-    onParquetImplementationChange((event.target as HTMLSelectElement).value as 'wasm' | 'js');
-  });
-  section.appendChild(selectElement);
-
-  const hintElement = document.createElement('div');
-  hintElement.textContent =
-    'Switches GeoParquet loading between the Arrow-backed wasm path and the JS fallback.';
-  hintElement.style.color = '#555';
-  hintElement.style.fontSize = '12px';
-  hintElement.style.lineHeight = '1.4';
-  section.appendChild(hintElement);
-
-  return section;
 }
 
 function createErrorSection(message: string): HTMLElement {

--- a/modules/core/src/lib/api/load-loader.ts
+++ b/modules/core/src/lib/api/load-loader.ts
@@ -121,20 +121,9 @@ function getLoaderImplementationSpecifier(loader: Loader, options?: LoaderOption
 
 /** Gets the cache key for option-selected parser implementations. */
 function getLoaderImplementationCacheKey(loader: Loader, options?: LoaderOptions): string {
-  const loaderOptions = options?.[loader.id] as
-    | {backend?: unknown; implementation?: unknown}
-    | undefined;
+  const loaderOptions = options?.[loader.id] as {backend?: unknown} | undefined;
   const defaultLoaderOptions = loader.options?.[loader.id] as {backend?: unknown} | undefined;
-  return String(
-    loaderOptions?.backend ||
-      getDeprecatedImplementationBackend(loaderOptions?.implementation) ||
-      defaultLoaderOptions?.backend ||
-      ''
-  );
-}
-
-function getDeprecatedImplementationBackend(implementation: unknown): unknown {
-  return implementation === 'js' ? 'typescript' : implementation;
+  return String(loaderOptions?.backend || defaultLoaderOptions?.backend || '');
 }
 
 /** Imports a module and finds the parser-bearing loader implementation with the requested id. */

--- a/modules/loader-utils/src/lib/worker-loader-utils/parse-with-worker.ts
+++ b/modules/loader-utils/src/lib/worker-loader-utils/parse-with-worker.ts
@@ -35,13 +35,6 @@ export function canParseWithWorker(loader: Loader, options?: StrictLoaderOptions
     return false;
   }
 
-  if (
-    loader.id === 'parquet' &&
-    (options as {parquet?: {backend?: string}} | undefined)?.parquet?.backend === 'typescript'
-  ) {
-    return false;
-  }
-
   return Boolean(canProcessOnWorker(loader, workerOptions));
 }
 

--- a/modules/parquet/src/lib/parsers/parse-parquet-tables.ts
+++ b/modules/parquet/src/lib/parsers/parse-parquet-tables.ts
@@ -11,12 +11,7 @@ import type {
 } from '@loaders.gl/schema';
 
 import type {ParquetLoaderOptions} from '../../parquet-loader-options';
-import {parseParquetFile, parseParquetFileInBatches} from './parse-parquet-to-json';
 import {parseParquetFileToArrow, parseParquetFileToArrowInBatches} from './parse-parquet-to-arrow';
-import {
-  parseParquetFileToArrowWithJs,
-  parseParquetFileToArrowInBatchesWithJs
-} from './parse-parquet-to-arrow-js';
 import {
   convertArrowBatchToObjectRows,
   convertArrowTableToObjectRows
@@ -38,14 +33,7 @@ export function parseParquetArrowTable(
   file: ReadableFile,
   options: ParquetLoaderOptions
 ): Promise<ArrowTable> {
-  switch (getParquetBackend(options)) {
-    case 'typescript':
-      return parseParquetFileToArrowWithJs(file, options);
-
-    case 'wasm':
-    default:
-      return parseParquetFileToArrow(file, options.parquet);
-  }
+  return parseParquetFileToArrow(file, options.parquet);
 }
 
 /**
@@ -59,14 +47,7 @@ export function parseParquetArrowTableInBatches(
   file: ReadableFile,
   options: ParquetLoaderOptions
 ): AsyncIterable<ArrowTableBatch> {
-  switch (getParquetBackend(options)) {
-    case 'typescript':
-      return parseParquetFileToArrowInBatchesWithJs(file, options);
-
-    case 'wasm':
-    default:
-      return parseParquetFileToArrowInBatches(file, options.parquet);
-  }
+  return parseParquetFileToArrowInBatches(file, options.parquet);
 }
 
 /**
@@ -80,10 +61,6 @@ export async function parseParquetObjectRowTable(
   file: ReadableFile,
   options: ParquetLoaderOptions
 ): Promise<ObjectRowTable> {
-  if (getParquetBackend(options) === 'typescript') {
-    return await parseParquetFile(file, options);
-  }
-
   const arrowTable = await parseParquetArrowTable(file, options);
   return convertArrowTableToObjectRows(arrowTable);
 }
@@ -99,19 +76,7 @@ export async function* parseParquetObjectRowTableInBatches(
   file: ReadableFile,
   options: ParquetLoaderOptions
 ): AsyncIterable<ObjectRowTableBatch> {
-  if (getParquetBackend(options) === 'typescript') {
-    yield* parseParquetFileInBatches(file, options);
-    return;
-  }
-
   for await (const batch of parseParquetArrowTableInBatches(file, options)) {
     yield convertArrowBatchToObjectRows(batch);
   }
-}
-
-function getParquetBackend(options: ParquetLoaderOptions): 'wasm' | 'typescript' {
-  if (options.parquet?.backend) {
-    return options.parquet.backend;
-  }
-  return options.parquet?.implementation === 'js' ? 'typescript' : 'wasm';
 }

--- a/modules/parquet/src/lib/parsers/parse-parquet-to-arrow-js.ts
+++ b/modules/parquet/src/lib/parsers/parse-parquet-to-arrow-js.ts
@@ -6,7 +6,7 @@ import type {ReadableFile} from '@loaders.gl/loader-utils';
 import type {ArrowTable, ArrowTableBatch} from '@loaders.gl/schema';
 import {convertTable} from '@loaders.gl/schema-utils';
 
-import type {ParquetLoaderOptions} from '../../parquet-loader-options';
+import type {ParquetJSLoaderOptions} from '../../parquet-loader-options';
 import {normalizeArrowTableGeoMetadata} from '../geo/geospatial-metadata';
 import {parseParquetFile, parseParquetFileInBatches} from './parse-parquet-to-json';
 
@@ -18,7 +18,7 @@ import {parseParquetFile, parseParquetFileInBatches} from './parse-parquet-to-js
  */
 export async function parseParquetFileToArrowWithJs(
   file: ReadableFile,
-  options?: ParquetLoaderOptions
+  options?: ParquetJSLoaderOptions
 ): Promise<ArrowTable> {
   const objectRowTable = await parseParquetFile(file, options);
   return normalizeArrowTableGeoMetadata(convertTable(objectRowTable, 'arrow-table'));
@@ -32,7 +32,7 @@ export async function parseParquetFileToArrowWithJs(
  */
 export async function* parseParquetFileToArrowInBatchesWithJs(
   file: ReadableFile,
-  options?: ParquetLoaderOptions
+  options?: ParquetJSLoaderOptions
 ): AsyncIterable<ArrowTableBatch> {
   for await (const batch of parseParquetFileInBatches(file, options)) {
     const arrowTable = normalizeArrowTableGeoMetadata(convertTable(batch, 'arrow-table'));

--- a/modules/parquet/src/lib/parsers/parse-parquet-to-json.ts
+++ b/modules/parquet/src/lib/parsers/parse-parquet-to-json.ts
@@ -6,7 +6,7 @@ import {default as log} from '@probe.gl/log';
 import type {ReadableFile} from '@loaders.gl/loader-utils';
 import type {ObjectRowTable, ObjectRowTableBatch, Schema} from '@loaders.gl/schema';
 
-import type {ParquetLoaderOptions} from '../../parquet-loader-options';
+import type {ParquetJSLoaderOptions} from '../../parquet-loader-options';
 import type {ParquetRow} from '../../parquetjs/schema/declare';
 import {ParquetReader} from '../../parquetjs/parser/parquet-reader';
 import {getSchemaFromParquetReader} from './get-parquet-schema';
@@ -20,7 +20,7 @@ import {preloadCompressions} from '../../parquetjs/compression';
  */
 export async function parseParquetFile(
   file: ReadableFile,
-  options?: ParquetLoaderOptions
+  options?: ParquetJSLoaderOptions
 ): Promise<ObjectRowTable> {
   await preloadCompressions(options);
 
@@ -73,7 +73,7 @@ export async function parseParquetFile(
  */
 export async function* parseParquetFileInBatches(
   file: ReadableFile,
-  options?: ParquetLoaderOptions
+  options?: ParquetJSLoaderOptions
 ): AsyncIterable<ObjectRowTableBatch> {
   await preloadCompressions(options);
 
@@ -131,7 +131,7 @@ export async function* parseParquetFileInBatches(
 }
 
 function getParquetIterationProps(
-  options?: ParquetLoaderOptions
+  options?: ParquetJSLoaderOptions
 ): {columnList?: string[] | string[][]} | undefined {
   const columnList = options?.parquet?.columns;
   return columnList?.length ? {columnList} : undefined;

--- a/modules/parquet/src/parquet-js-loader.ts
+++ b/modules/parquet/src/parquet-js-loader.ts
@@ -19,7 +19,6 @@ const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
 /** Default option bag for the experimental parquetjs plain-row loader. */
 const DEFAULT_PARQUET_JS_OPTIONS = {
-  backend: 'typescript' as const,
   columns: undefined,
   preserveBinary: false,
   shape: 'object-row-table' as const

--- a/modules/parquet/src/parquet-loader-options.ts
+++ b/modules/parquet/src/parquet-loader-options.ts
@@ -25,21 +25,10 @@ type ParquetWasmLoaderOptions = ParquetCommonLoaderOptions & {
   wasmUrl?: string;
 };
 
-/** Internal superset of Parquet loader options that retains backend selection. */
-type ParquetInternalLoaderOptions = ParquetWasmLoaderOptions & {
-  shape?: 'object-row-table' | 'arrow-table';
-  backend?: 'wasm' | 'typescript';
-  /** @deprecated Use `backend` instead. */
-  implementation?: 'wasm' | 'js';
-};
-
 /** Public options for the wasm-backed `ParquetLoader` and `GeoParquetLoader`. */
 export type ParquetLoaderOptions = LoaderOptions & {
   parquet?: {
     shape?: 'object-row-table' | 'arrow-table';
-    backend?: 'wasm' | 'typescript';
-    /** @deprecated Use `backend` instead. */
-    implementation?: 'wasm' | 'js';
   } & {
     [Key in keyof ParquetWasmLoaderOptions]?: ParquetWasmLoaderOptions[Key];
   };
@@ -48,23 +37,14 @@ export type ParquetLoaderOptions = LoaderOptions & {
 /** Public options for the experimental parquetjs-backed `ParquetJSLoader`. */
 export type ParquetJSLoaderOptions = LoaderOptions & {
   parquet?: {
-    backend?: 'typescript';
     shape?: 'object-row-table' | 'arrow-table';
   } & {
     [Key in keyof ParquetCommonLoaderOptions]?: ParquetCommonLoaderOptions[Key];
   };
 };
 
-/** Internal options used by shared Parquet helpers that need backend selection. */
-export type ParquetLoaderImplementationOptions = LoaderOptions & {
-  parquet?: {
-    [Key in keyof ParquetInternalLoaderOptions]?: ParquetInternalLoaderOptions[Key];
-  };
-};
-
 /** Shared default option bag for the wasm-backed Parquet loaders. */
 export const PARQUET_LOADER_DEFAULT_OPTIONS = {
-  backend: 'wasm',
   columns: undefined,
   preserveBinary: false,
   shape: 'object-row-table'

--- a/modules/parquet/src/parquet-loader-with-parser.ts
+++ b/modules/parquet/src/parquet-loader-with-parser.ts
@@ -18,37 +18,36 @@ import {
   parseParquetFileToArrowWithJs
 } from './lib/parsers/parse-parquet-to-arrow-js';
 import {normalizeParquetOptions} from './lib/utils/normalize-parquet-options';
-import type {
-  ParquetLoaderImplementationOptions,
-  ParquetLoaderOptions
-} from './parquet-loader-options';
-import {PARQUET_LOADER_BASE} from './parquet-loader-base';
+import type {ParquetJSLoaderOptions} from './parquet-loader-options';
+import {ParquetJSLoader as ParquetJSLoaderMetadata} from './parquet-js-loader';
+
+const {preload: _ParquetJSLoaderPreload, ...ParquetJSLoaderMetadataWithoutPreload} =
+  ParquetJSLoaderMetadata;
 
 /** Default option bag for the experimental parquetjs plain-row loader. */
 const DEFAULT_PARQUET_JS_OPTIONS = {
-  backend: 'typescript' as const,
   columns: undefined,
   preserveBinary: false
 };
 
 /** Parser-bearing TypeScript-only Parquet loader implementation. */
 export const ParquetLoaderWithParser = {
-  ...PARQUET_LOADER_BASE,
+  ...ParquetJSLoaderMetadataWithoutPreload,
   worker: false,
-  parse(arrayBuffer: ArrayBuffer, options?: ParquetLoaderOptions) {
+  parse(arrayBuffer: ArrayBuffer, options?: ParquetJSLoaderOptions) {
     const parquetOptions = getParquetOptions(options);
     const file = new BlobFile(arrayBuffer);
     return parquetOptions.parquet?.shape === 'arrow-table'
       ? parseParquetFileToArrowWithJs(file, parquetOptions)
       : parseParquetFile(file, parquetOptions);
   },
-  parseFile(file: ReadableFile, options?: ParquetLoaderOptions) {
+  parseFile(file: ReadableFile, options?: ParquetJSLoaderOptions) {
     const parquetOptions = getParquetOptions(options);
     return parquetOptions.parquet?.shape === 'arrow-table'
       ? parseParquetFileToArrowWithJs(file, parquetOptions)
       : parseParquetFile(file, parquetOptions);
   },
-  parseFileInBatches(file: ReadableFile, options?: ParquetLoaderOptions) {
+  parseFileInBatches(file: ReadableFile, options?: ParquetJSLoaderOptions) {
     const parquetOptions = getParquetOptions(options);
     return parquetOptions.parquet?.shape === 'arrow-table'
       ? parseParquetFileToArrowInBatchesWithJs(file, parquetOptions)
@@ -58,7 +57,7 @@ export const ParquetLoaderWithParser = {
     asyncIterator:
       | AsyncIterable<ArrayBufferLike | ArrayBufferView>
       | Iterable<ArrayBufferLike | ArrayBufferView>,
-    options?: ParquetLoaderOptions,
+    options?: ParquetJSLoaderOptions,
     _context?: unknown
   ) {
     const arrayBuffer = await concatenateArrayBuffersAsync(asyncIterator);
@@ -73,7 +72,7 @@ export const ParquetLoaderWithParser = {
 } as const satisfies LoaderWithParser<
   ObjectRowTable | ArrowTable,
   ObjectRowTableBatch | ArrowTableBatch,
-  ParquetLoaderOptions
+  ParquetJSLoaderOptions
 >;
 
 /**
@@ -81,6 +80,6 @@ export const ParquetLoaderWithParser = {
  * @param options caller-supplied loader options
  * @returns normalized options with parquetjs defaults applied
  */
-function getParquetOptions(options?: ParquetLoaderOptions): ParquetLoaderImplementationOptions {
+function getParquetOptions(options?: ParquetJSLoaderOptions): ParquetJSLoaderOptions {
   return normalizeParquetOptions(options, DEFAULT_PARQUET_JS_OPTIONS);
 }

--- a/modules/parquet/src/parquet-loader.ts
+++ b/modules/parquet/src/parquet-loader.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {Loader, LoaderOptions} from '@loaders.gl/loader-utils';
+import type {Loader} from '@loaders.gl/loader-utils';
 import type {
   ObjectRowTable,
   ObjectRowTableBatch,
@@ -17,23 +17,10 @@ import {PARQUET_WORKER_URL} from './parquet-worker-url';
 /** Options for the parquet loader */
 export type ParquetLoaderOptions = SharedParquetLoaderOptions;
 
-/** Preloads the parser-bearing Parquet loader implementation selected by `parquet.backend`. */
-async function preloadParquetLoader(_url: string, options?: LoaderOptions) {
-  const parquetOptions = options as ParquetLoaderOptions | undefined;
-  switch (getParquetBackend(parquetOptions)) {
-    case 'wasm': {
-      const {ParquetWASMLoaderWithParser} = await import('./parquet-wasm-loader-with-parser');
-      return ParquetWASMLoaderWithParser;
-    }
-
-    case 'typescript': {
-      const {ParquetLoaderWithParser} = await import('./parquet-loader-with-parser');
-      return ParquetLoaderWithParser;
-    }
-
-    default:
-      throw new Error(`ParquetLoader: unsupported backend "${parquetOptions?.parquet?.backend}"`);
-  }
+/** Preloads the parser-bearing WASM Parquet loader implementation. */
+async function preloadParquetLoader() {
+  const {ParquetWASMLoaderWithParser} = await import('./parquet-wasm-loader-with-parser');
+  return ParquetWASMLoaderWithParser;
 }
 
 /** Metadata-only Parquet table loader supporting object-row and Arrow table output. */
@@ -46,13 +33,3 @@ export const ParquetLoader = {
   ObjectRowTableBatch | ArrowTableBatch,
   ParquetLoaderOptions
 >;
-
-function getParquetBackend(options?: ParquetLoaderOptions): 'wasm' | 'typescript' {
-  if (options?.parquet?.backend) {
-    return options.parquet.backend;
-  }
-  if (options?.parquet?.implementation === 'js') {
-    return 'typescript';
-  }
-  return ParquetLoader.options.parquet.backend;
-}

--- a/modules/parquet/src/parquet-wasm-loader-with-parser.ts
+++ b/modules/parquet/src/parquet-wasm-loader-with-parser.ts
@@ -113,14 +113,5 @@ async function* parseParquetTableInBatches(
  * @returns normalized loader options
  */
 export function getParquetOptions(options?: ParquetLoaderOptions): ParquetLoaderOptions {
-  return normalizeParquetOptions(
-    {
-      ...options,
-      parquet: {
-        ...(options?.parquet || {}),
-        backend: 'wasm'
-      }
-    },
-    ParquetWASMLoaderWithParser.options.parquet
-  );
+  return normalizeParquetOptions(options, ParquetWASMLoaderWithParser.options.parquet);
 }

--- a/modules/parquet/test/parquet-arrow-loader.spec.ts
+++ b/modules/parquet/test/parquet-arrow-loader.spec.ts
@@ -155,19 +155,14 @@ test('ParquetLoader#parse applies reader options without passing wasmUrl upstrea
   t.end();
 });
 
-test('ParquetLoader#arrow-table supports deprecated js implementation option', async (t) => {
+test('ParquetJSLoader#arrow-table preserves GeoParquet metadata', async (t) => {
   const url = `${PARQUET_DIR}/geoparquet/example.parquet`;
-  const table = (await load(
-    url,
-    ParquetLoader,
-    {
-      parquet: {
-        shape: 'arrow-table',
-        implementation: 'js',
-        limit: 3
-      }
-    } as any
-  )) as ArrowTable;
+  const table = (await load(url, ParquetJSLoader, {
+    parquet: {
+      shape: 'arrow-table',
+      limit: 3
+    }
+  })) as ArrowTable;
 
   t.equal(table.shape, 'arrow-table');
   t.equal(table.data.numRows, 3, 'TypeScript implementation converts selected rows to Arrow');
@@ -183,7 +178,6 @@ test('ParquetLoader#arrow-table supports deprecated js implementation option', a
   );
   t.end();
 });
-
 test('ParquetLoader#load supports arrow-table shape', async (t) => {
   const url = `${PARQUET_DIR}/geoparquet/example.parquet`;
   const wrapperTable = (await load(url, ParquetLoader, {
@@ -209,15 +203,14 @@ test('ParquetLoader#load supports arrow-table shape', async (t) => {
   t.end();
 });
 
-test('ParquetLoader#arrow-table loadInBatches supports TypeScript implementation', async (t) => {
+test('ParquetJSLoader#arrow-table supports loadInBatches', async (t) => {
   const url = `${PARQUET_DIR}/geoparquet/example.parquet`;
   const iterator = await loadInBatches(
     url,
-    ParquetLoader,
+    ParquetJSLoader,
     {
       parquet: {
         shape: 'arrow-table',
-        backend: 'typescript',
         limit: 5,
         batchSize: 2
       }
@@ -233,27 +226,12 @@ test('ParquetLoader#arrow-table loadInBatches supports TypeScript implementation
   t.equal(rowCount, 5, 'returns all requested rows');
   t.end();
 });
-
 test('ParquetWriter#Arrow table round trip', async (t) => {
   const table = createArrowTable();
 
   const parquetBuffer = await encode(table, ParquetWriter, {
     worker: false
   });
-  const newTable = (await load(parquetBuffer, ParquetLoader, {
-    core: {worker: false},
-    parquet: {shape: 'arrow-table'}
-  })) as ArrowTable;
-
-  t.deepEqual(table.data.schema, newTable.data.schema);
-  t.end();
-});
-
-test('ParquetWriter#ignores implementation option and stays on wasm', async (t) => {
-  const table = createArrowTable();
-  const parquetBuffer = await encode(table, ParquetWriter, {
-    parquet: {implementation: 'js'}
-  } as any);
   const newTable = (await load(parquetBuffer, ParquetLoader, {
     core: {worker: false},
     parquet: {shape: 'arrow-table'}
@@ -408,8 +386,7 @@ test('GeoParquetLoader#supports arrow-table shape', async (t) => {
   const url = `${PARQUET_DIR}/geoparquet/example.parquet`;
   const table = await load(url, GeoParquetLoader, {
     parquet: {
-      shape: 'arrow-table',
-      backend: 'wasm'
+      shape: 'arrow-table'
     }
   });
 

--- a/modules/parquet/test/parquet-compatibility.spec.ts
+++ b/modules/parquet/test/parquet-compatibility.spec.ts
@@ -6,7 +6,7 @@ import test from 'test/utils/vitest-tape';
 import type {Test} from 'test/utils/vitest-tape';
 
 import {fetchFile, load} from '@loaders.gl/core';
-import {ParquetLoader} from '@loaders.gl/parquet';
+import {ParquetJSLoader, ParquetLoader} from '@loaders.gl/parquet';
 import type {ObjectRowTable} from '@loaders.gl/schema';
 import {parquetReadObjects} from 'hyparquet';
 import {compressors} from 'hyparquet-compressors';
@@ -93,10 +93,8 @@ async function readWithLoadersGl(
   backend: LoadersGlBackend
 ): Promise<CompatibilityResult> {
   try {
-    const table = (await load(file, ParquetLoader, {
-      core: {worker: false},
-      parquet: {backend}
-    })) as ObjectRowTable;
+    const loader = backend === 'typescript' ? ParquetJSLoader : ParquetLoader;
+    const table = (await load(file, loader, {core: {worker: false}})) as ObjectRowTable;
     return {supported: true, rows: table.data};
   } catch (error) {
     return {supported: false, error: getErrorMessage(error)};

--- a/modules/parquet/test/parquet-loader.spec.ts
+++ b/modules/parquet/test/parquet-loader.spec.ts
@@ -49,28 +49,19 @@ test('ParquetJSLoader#loader objects', (t) => {
   t.end();
 });
 
-test('ParquetLoader#preload resolves backend parser implementations', async (t) => {
-  t.equal(await preload(ParquetLoader), ParquetWASMLoaderWithParser, 'default backend resolves wasm');
+test('Parquet loaders preload explicit parser implementations', async (t) => {
   t.equal(
-    await preload(ParquetLoader, {parquet: {backend: 'wasm'}}),
+    await preload(ParquetLoader),
     ParquetWASMLoaderWithParser,
-    'wasm backend resolves wasm parser'
+    'primary ParquetLoader resolves the WASM parser'
   );
   t.equal(
-    await preload(ParquetLoader, {parquet: {backend: 'typescript'}}),
+    await preload(ParquetJSLoader),
     ParquetLoaderWithParser,
-    'typescript backend resolves TypeScript parser'
+    'fallback ParquetJSLoader resolves the TypeScript parser'
   );
-  t.equal(
-    await preload(ParquetLoader, {parquet: {implementation: 'js'} as any}),
-    ParquetLoaderWithParser,
-    'deprecated js implementation resolves TypeScript parser'
-  );
-  t.equal(
-    await preload(ParquetLoader, {parquet: {backend: 'typescript', shape: 'arrow-table'}}),
-    ParquetLoaderWithParser,
-    'typescript backend resolves its parser for arrow-table shape'
-  );
+  t.equal(ParquetLoaderWithParser.id, ParquetJSLoader.id, 'fallback parser preserves loader id');
+  t.equal(ParquetJSLoader.worker, false, 'fallback parser stays on the main thread');
   t.end();
 });
 
@@ -360,15 +351,14 @@ test('ParquetJSLoader#load', async (t) => {
   t.end();
 });
 
-test('ParquetLoader#maps deprecated implementation option to backend', async (t) => {
+test('ParquetJSLoader#loads through the explicit TypeScript implementation', async (t) => {
   const url = '@loaders.gl/parquet/test/data/geoparquet/example.parquet';
-  const table = await load(url, ParquetLoader, {
+  const table = await load(url, ParquetJSLoader, {
     parquet: {
-      implementation: 'js',
       limit: 2
     },
     core: {worker: false}
-  } as any);
+  });
 
   t.equal(table.shape, 'object-row-table');
   if (table.shape === 'object-row-table') {

--- a/modules/parquet/test/parquet.bench.ts
+++ b/modules/parquet/test/parquet.bench.ts
@@ -67,7 +67,7 @@ export async function parquetBench(suite) {
     ]);
   const [typescriptLoader, wasmLoader] = await Promise.all([
     preload(ParquetJSLoader, {core: {worker: false}}),
-    preload(ParquetLoader, {core: {worker: false}, parquet: {backend: 'wasm'}})
+    preload(ParquetLoader, {core: {worker: false}})
   ]);
   const implementations = createParquetBenchmarkImplementations(typescriptLoader, wasmLoader);
   const scenarios: ParquetBenchmarkScenario[] = [
@@ -184,12 +184,12 @@ function createParquetBenchmarkImplementations(
     {
       id: 'typescript',
       name: 'loaders.gl TypeScript',
-      decode: scenario => decodeWithLoadersGl(scenario, typescriptLoader, 'typescript')
+      decode: scenario => decodeWithLoadersGl(scenario, typescriptLoader)
     },
     {
       id: 'wasm',
       name: 'loaders.gl parquet-wasm',
-      decode: scenario => decodeWithLoadersGl(scenario, wasmLoader, 'wasm')
+      decode: scenario => decodeWithLoadersGl(scenario, wasmLoader)
     },
     {
       id: 'hyparquet',
@@ -207,12 +207,11 @@ function createParquetBenchmarkImplementations(
 /** Decodes one scenario through a preloaded loaders.gl implementation. */
 async function decodeWithLoadersGl(
   scenario: ParquetBenchmarkScenario,
-  loader: LoaderWithParser,
-  backend: 'typescript' | 'wasm'
+  loader: LoaderWithParser
 ): Promise<number> {
   const table = (await parse(scenario.arrayBuffer, loader, {
     core: {worker: false},
-    parquet: {backend, columns: scenario.columns}
+    parquet: {columns: scenario.columns}
   })) as ObjectRowTable;
   return table.data.length;
 }

--- a/website/src/examples/parquet-benchmarks-app.tsx
+++ b/website/src/examples/parquet-benchmarks-app.tsx
@@ -5,18 +5,17 @@
 import React, {useEffect, useState} from 'react';
 
 import {Bench, type LogEntry} from '@probe.gl/bench';
-import {BenchResults} from '@probe.gl/react-bench';
 import type {ObjectRowTable} from '@loaders.gl/schema';
 
 type BenchmarkResultRow = {
-  /** Stable benchmark or group label. */
-  id: React.ReactNode;
-  /** Numeric throughput used by the result renderer. */
-  value?: number;
+  /** Human-readable fixture and feature label. */
+  scenario: string;
+  /** Human-readable loader variant label. */
+  implementation: string;
   /** Human-readable throughput. */
-  formattedValue?: string;
+  formattedValue: string;
   /** Human-readable measurement error. */
-  formattedError?: string;
+  formattedError: string;
 };
 
 type BenchmarkStatus = 'loading' | 'running' | 'complete' | 'failed';
@@ -156,8 +155,46 @@ export default function ParquetBenchmarksApp(): JSX.Element {
           </ul>
         </aside>
       ) : null}
-      <div className="benchmark-results">
-        <BenchResults log={rows} />
+      <div className="parquet-benchmark-results" aria-live="polite">
+        <table className="parquet-benchmark-table">
+          <thead>
+            <tr>
+              <th scope="col">Fixture</th>
+              <th scope="col">Loader Variant</th>
+              <th scope="col" className="parquet-benchmark-number">
+                Throughput
+              </th>
+              <th scope="col" className="parquet-benchmark-number">
+                Variation
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, rowIndex) => {
+              const startsScenario = rows[rowIndex - 1]?.scenario !== row.scenario;
+              const scenarioRowCount = rows.filter(
+                candidateRow => candidateRow.scenario === row.scenario
+              ).length;
+              return (
+                <tr key={`${row.scenario}-${row.implementation}`}>
+                  {startsScenario ? (
+                    <th scope="rowgroup" rowSpan={scenarioRowCount}>
+                      {row.scenario}
+                    </th>
+                  ) : null}
+                  <td>{row.implementation}</td>
+                  <td className="parquet-benchmark-number">
+                    <strong>{row.formattedValue}</strong> rows/s
+                  </td>
+                  <td className="parquet-benchmark-number">{row.formattedError}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+        {rows.length === 0 ? (
+          <p className="parquet-benchmark-empty">Results appear here as each case completes.</p>
+        ) : null}
       </div>
     </div>
   );
@@ -248,8 +285,7 @@ async function createParquetBenchmarkImplementations(): Promise<
         const table = (await loadersGlTypeScript.ParquetLoaderWithParser.parse(
           scenario.arrayBuffer,
           {
-            core: {worker: false},
-            parquet: {backend: 'typescript'}
+            core: {worker: false}
           }
         )) as ObjectRowTable;
         return table.data.length;
@@ -357,15 +393,16 @@ async function validateParquetBenchmarkScenario(
 /** Converts one probe.gl log entry into a result table row. */
 function createBenchmarkResultRow(entry: LogEntry): BenchmarkResultRow | null {
   switch (entry.type) {
-    case 'group':
-      return {id: entry.id};
-    case 'test':
+    case 'test': {
+      const separatorIndex = entry.id.lastIndexOf(' :: ');
       return {
-        id: entry.id.slice(entry.id.lastIndexOf(' :: ') + 4),
-        value: Number.parseFloat(entry.itersPerSecond),
+        scenario: separatorIndex >= 0 ? entry.id.slice(0, separatorIndex) : 'Parquet decode',
+        implementation:
+          separatorIndex >= 0 ? entry.id.slice(separatorIndex + 4) : entry.id,
         formattedValue: entry.itersPerSecond,
-        formattedError: `${(entry.error * 100).toFixed(2)}%`
+        formattedError: `±${(entry.error * 100).toFixed(2)}%`
       };
+    }
     case 'complete':
       return null;
     default:

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -564,6 +564,65 @@ body:has(.benchmark-page) footer.theme-layout-footer {
   z-index: 1;
 }
 
+.parquet-benchmark-results {
+  margin-bottom: 2rem;
+  overflow-x: auto;
+}
+
+.parquet-benchmark-table {
+  border: 1px solid var(--ifm-table-border-color);
+  border-collapse: separate;
+  border-radius: 8px;
+  border-spacing: 0;
+  margin: 0;
+  min-width: 620px;
+  overflow: hidden;
+  width: 100%;
+}
+
+.parquet-benchmark-table th,
+.parquet-benchmark-table td {
+  border: 0;
+  border-bottom: 1px solid var(--ifm-table-border-color);
+  padding: 0.7rem 0.8rem;
+  vertical-align: top;
+}
+
+.parquet-benchmark-table thead th {
+  background: var(--ifm-table-head-background);
+  color: var(--ifm-font-color-secondary);
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+  text-align: left;
+  text-transform: uppercase;
+}
+
+.parquet-benchmark-table tbody + tbody tr:first-child > * {
+  border-top: 1px solid var(--ifm-table-border-color);
+}
+
+.parquet-benchmark-table tbody tr:last-child > * {
+  border-bottom: 0;
+}
+
+.parquet-benchmark-table tbody th[scope='rowgroup'] {
+  background: var(--ifm-table-stripe-background);
+  font-weight: 600;
+  width: 34%;
+}
+
+.parquet-benchmark-table .parquet-benchmark-number {
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.parquet-benchmark-empty {
+  color: var(--ifm-font-color-secondary);
+  margin: 0;
+  padding: 1rem 0;
+}
+
 .badges {
   align-items: center;
   display: inline-flex;


### PR DESCRIPTION
## Goal

Make Parquet implementation selection explicit while preserving a common output contract. Runtime backend selectors made primary preload and worker paths aware of every fallback implementation, working against tree shaking and causing worker proliferation.

The intended model is one packaged worker for the primary implementation. Alternative loaders remain available through explicit imports and parse on the main thread unless an application supplies its own worker integration.

## Changes

- Make `ParquetLoader` always preload the primary `parquet-wasm` parser and retain its packaged worker.
- Keep `ParquetJSLoader` as an explicit TypeScript main-thread implementation with `worker: false`.
- Preserve `shape: 'arrow-table'` for the TypeScript loader, including full-table and batched conversion plus GeoParquet metadata.
- Remove `parquet.backend` and the deprecated `parquet.implementation` selector.
- Remove Parquet-specific selector handling from core loader caching and worker dispatch.
- Update tests, examples, release notes, upgrade guidance, and the consolidated Parquet loader documentation.
- Update live and Node benchmarks to compare explicit loader variants and maintained peer implementations.
- Replace the generic live benchmark result grid with a compact semantic table grouped by fixture, with throughput and variation columns.

## Validation

- `yarn install`
- `yarn lint fix`
- `yarn build`
- `yarn test-node`: 408 files passed, 3 skipped; 1955 tests passed, 81 skipped
- `npx vitest run --project headless modules/parquet/test/parquet-loader.spec.ts`: 23 passed
- `npx vitest run --project headless modules/parquet/test/parquet-arrow-loader.spec.ts -t ParquetJSLoader`: 3 passed, 19 skipped
- `yarn bench parquet`: completed all object-row and Arrow benchmark groups
- `cd website && yarn build`
- Browser verification: all nine live benchmark cases completed and rendered in the new table

The full `yarn test-headless` suite was also attempted. Its current repository-wide baseline has 29 failing files and 90 failing tests caused by prebuilt worker asset serving/module-format failures across compression, Draco, Excel, MVT, Parquet, PLY, terrain, textures, and ZIP browser imports. The focused Parquet headless coverage above passes.

## Stack

- Stacked on #3556 (`codex/parquet-source-worker`).