### PR TITLE
feat(gis): add GeoParquet and GeoArrow metadata schemas

### DIFF
--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -77,6 +77,11 @@ Release Date: 2026
 
 - The new lightweight `@loaders.gl/compression/native-decompression` entrypoint probes runtime support for gzip, deflate, raw deflate, Brotli, and future Zstandard decompression without importing codec fallbacks. Parquet and SPZ use it before lazily loading codec-backed implementations; until native Zstandard support becomes widely available, most runtimes still need `zstd-codec` for Zstandard-backed parsing.
 
+**@loaders.gl/gis**
+
+- Handwritten, documented GeoParquet and GeoArrow metadata types are exported from `@loaders.gl/gis`, while matching runtime validators are available from `@loaders.gl/gis/geospatial-metadata-zod-schema` without adding Zod to the lightweight root import.
+- Draft-07 `geoparquet.schema.json` and `geoarrow-metadata.schema.json` assets are published for validation and editor integrations.
+
 **@loaders.gl/deck-layers**
 
 - `SplatLayer` NEW - renders GraphDECO-style Gaussian splat Arrow tables from `PLYLoader` or `@loaders.gl/splats`.

--- a/modules/geoarrow/src/metadata/geoarrow-metadata.ts
+++ b/modules/geoarrow/src/metadata/geoarrow-metadata.ts
@@ -3,18 +3,10 @@
 // Copyright (c) vis.gl contributors
 
 import {Metadata, SchemaWithMetadata, getMetadataValue} from './metadata-utils';
+import type {GeoArrowEncoding, GeoArrowMetadata} from '@loaders.gl/gis';
+import {GeoArrowMetadataSchema} from '@loaders.gl/gis/geospatial-metadata-zod-schema';
 
-export type GeoArrowEncoding =
-  | 'geoarrow.geometry'
-  | 'geoarrow.geometrycollection'
-  | 'geoarrow.multipolygon'
-  | 'geoarrow.polygon'
-  | 'geoarrow.multilinestring'
-  | 'geoarrow.linestring'
-  | 'geoarrow.multipoint'
-  | 'geoarrow.point'
-  | 'geoarrow.wkb'
-  | 'geoarrow.wkt';
+export type {GeoArrowEncoding, GeoArrowMetadata} from '@loaders.gl/gis';
 
 /** Array containing all encodings */
 const GEOARROW_ENCODINGS = [
@@ -26,26 +18,13 @@ const GEOARROW_ENCODINGS = [
   'geoarrow.linestring',
   'geoarrow.multipoint',
   'geoarrow.point',
+  'geoarrow.box',
   'geoarrow.wkb',
   'geoarrow.wkt'
 ] as const satisfies GeoArrowEncoding[];
 
 const GEOARROW_ENCODING = 'ARROW:extension:name';
 const GEOARROW_METADATA = 'ARROW:extension:metadata';
-
-/**
- * Geospatial metadata for one column, extracted from Apache Arrow metadata
- * @see https://github.com/geoarrow/geoarrow/blob/main/extension-types.md
- */
-export type GeoArrowMetadata = {
-  /** Encoding of geometry in this column */
-  encoding?: GeoArrowEncoding;
-  /** CRS in [PROJJSON](https://proj.org/specifications/projjson.html). Omitted if producer has no information about CRS */
-  crs?: Record<string, unknown>;
-  /** Edges are either spherical or omitted */
-  edges?: 'spherical';
-  [key: string]: unknown;
-};
 
 /**
  * get geometry columns from arrow table
@@ -95,7 +74,7 @@ export function getGeometryMetadataForField(fieldMetadata: Metadata): GeoArrowMe
   const columnMetadata = getMetadataValue(fieldMetadata, GEOARROW_METADATA);
   if (columnMetadata) {
     try {
-      const parsedMetadata = JSON.parse(columnMetadata) as GeoArrowMetadata;
+      const parsedMetadata = GeoArrowMetadataSchema.parse(JSON.parse(columnMetadata));
       metadata = {
         ...(metadata || {}),
         ...parsedMetadata

--- a/modules/gis/package.json
+++ b/modules/gis/package.json
@@ -23,7 +23,14 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
-    }
+    },
+    "./geospatial-metadata-zod-schema": {
+      "types": "./dist/geospatial-metadata-zod-schema.d.ts",
+      "import": "./dist/geospatial-metadata-zod-schema.js",
+      "require": "./dist/geospatial-metadata-zod-schema.cjs"
+    },
+    "./geoparquet.schema.json": "./dist/geoparquet.schema.json",
+    "./geoarrow-metadata.schema.json": "./dist/geoarrow-metadata.schema.json"
   },
   "sideEffects": false,
   "files": [
@@ -31,6 +38,10 @@
     "dist",
     "README.md"
   ],
+  "scripts": {
+    "pre-build": "npm run generate-json-schema",
+    "generate-json-schema": "node ../../scripts/generate-json-schema.mjs --schema ./dist/geospatial-metadata-zod-schema.js --export GeoParquetMetadataSchema --output ./dist/geoparquet.schema.json --id https://unpkg.com/@loaders.gl/gis/geoparquet.schema.json --title 'loaders.gl GeoParquet metadata' && node ../../scripts/generate-json-schema.mjs --schema ./dist/geospatial-metadata-zod-schema.js --export GeoArrowMetadataSchema --output ./dist/geoarrow-metadata.schema.json --id https://unpkg.com/@loaders.gl/gis/geoarrow-metadata.schema.json --title 'loaders.gl GeoArrow field metadata'"
+  },
   "dependencies": {
     "@loaders.gl/loader-utils": "5.0.0-alpha.1",
     "@loaders.gl/schema": "5.0.0-alpha.1",
@@ -38,7 +49,8 @@
     "@mapbox/vector-tile": "^1.3.1",
     "@math.gl/polygon": "^4.1.0",
     "apache-arrow": ">= 17.0.0",
-    "pbf": "^3.2.1"
+    "pbf": "^3.2.1",
+    "zod": "^4.1.12"
   },
   "devDependencies": {
     "@math.gl/proj4": "^4.1.0"

--- a/modules/gis/src/geospatial-metadata-zod-schema.ts
+++ b/modules/gis/src/geospatial-metadata-zod-schema.ts
@@ -1,0 +1,101 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
+import {z} from 'zod';
+import type {
+  GeoArrowMetadata,
+  GeoColumnMetadata,
+  GeoMetadata,
+  GeoParquetGeometryType
+} from './lib/geoarrow/geoparquet-metadata';
+
+/** GeoParquet geometry type names, including optional Z dimensions. */
+export const GeoParquetGeometryTypeSchema = z.enum([
+  'Point',
+  'LineString',
+  'Polygon',
+  'MultiPoint',
+  'MultiLineString',
+  'MultiPolygon',
+  'GeometryCollection',
+  'Point Z',
+  'LineString Z',
+  'Polygon Z',
+  'MultiPoint Z',
+  'MultiLineString Z',
+  'MultiPolygon Z',
+  'GeometryCollection Z'
+]) satisfies z.ZodType<GeoParquetGeometryType>;
+
+const GeoParquetGeometryTypesSchema = z
+  .array(GeoParquetGeometryTypeSchema)
+  .refine(geometryTypes => new Set(geometryTypes).size === geometryTypes.length, {
+    message: 'GeoParquet geometry_types entries must be unique'
+  });
+
+/** Zod schema for metadata attached to one GeoParquet geometry column. */
+export const GeoParquetColumnMetadataSchema = z
+  .object({
+    encoding: z.enum([
+      'WKB',
+      'wkb',
+      'point',
+      'linestring',
+      'polygon',
+      'multipoint',
+      'multilinestring',
+      'multipolygon'
+    ]),
+    geometry_types: GeoParquetGeometryTypesSchema,
+    crs: z.union([z.record(z.string(), z.unknown()), z.null()]).optional(),
+    crs_type: z.enum(['projjson', 'wkt2:2019']).optional(),
+    orientation: z.literal('counterclockwise').optional(),
+    bbox: z
+      .union([
+        z.tuple([z.number(), z.number(), z.number(), z.number()]),
+        z.tuple([z.number(), z.number(), z.number(), z.number(), z.number(), z.number()])
+      ])
+      .optional(),
+    edges: z.enum(['planar', 'spherical']).optional(),
+    epoch: z.number().finite().optional()
+  })
+  .passthrough() satisfies z.ZodType<GeoColumnMetadata>;
+
+/** Zod schema for the GeoParquet metadata stored in a Parquet file's `geo` key. */
+export const GeoParquetMetadataSchema = z
+  .object({
+    version: z.string().min(1),
+    primary_column: z.string().min(1),
+    columns: z.record(z.string(), GeoParquetColumnMetadataSchema)
+  })
+  .passthrough()
+  .refine(metadata => Boolean(metadata.columns[metadata.primary_column]), {
+    message: 'GeoParquet primary_column must name an entry in columns',
+    path: ['primary_column']
+  }) satisfies z.ZodType<GeoMetadata>;
+
+/** Zod schema for metadata stored on one GeoArrow extension field. */
+export const GeoArrowMetadataSchema = z
+  .object({
+    encoding: z
+      .enum([
+        'geoarrow.geometry',
+        'geoarrow.geometrycollection',
+        'geoarrow.multipolygon',
+        'geoarrow.polygon',
+        'geoarrow.multilinestring',
+        'geoarrow.linestring',
+        'geoarrow.multipoint',
+        'geoarrow.point',
+        'geoarrow.box',
+        'geoarrow.wkb',
+        'geoarrow.wkt'
+      ])
+      .optional(),
+    crs: z.union([z.record(z.string(), z.unknown()), z.string()]).optional(),
+    crs_type: z.enum(['projjson', 'wkt2:2019', 'authority_code', 'srid']).optional(),
+    edges: z.enum(['spherical', 'vincenty', 'thomas', 'andoyer', 'karney']).optional(),
+    geometry_types: GeoParquetGeometryTypesSchema.optional()
+  })
+  .passthrough() satisfies z.ZodType<GeoArrowMetadata>;

--- a/modules/gis/src/index.ts
+++ b/modules/gis/src/index.ts
@@ -19,7 +19,11 @@ export {getMetadataValue, setMetadataValue} from './lib/geoarrow/metadata-utils'
 export type {
   GeoMetadata,
   GeoColumnMetadata,
-  GeoParquetGeometryType
+  GeoParquetGeometryType,
+  GeoArrowEncoding,
+  GeoArrowCRSType,
+  GeoArrowEdgeType,
+  GeoArrowMetadata
 } from './lib/geoarrow/geoparquet-metadata';
 export {
   getGeoMetadata,

--- a/modules/gis/src/lib/geoarrow/geoparquet-metadata.ts
+++ b/modules/gis/src/lib/geoarrow/geoparquet-metadata.ts
@@ -21,6 +21,7 @@ export type GeoMetadata = {
  */
 export type GeoColumnMetadata = {
   encoding:
+    | 'WKB'
     | 'wkb'
     | 'wkt'
     | 'point'
@@ -57,6 +58,41 @@ export type GeoParquetGeometryType =
   | 'MultiLineString Z'
   | 'MultiPolygon Z'
   | 'GeometryCollection Z';
+
+/** GeoArrow extension names used to describe geometry column encodings. */
+export type GeoArrowEncoding =
+  | 'geoarrow.geometry'
+  | 'geoarrow.geometrycollection'
+  | 'geoarrow.multipolygon'
+  | 'geoarrow.polygon'
+  | 'geoarrow.multilinestring'
+  | 'geoarrow.linestring'
+  | 'geoarrow.multipoint'
+  | 'geoarrow.point'
+  | 'geoarrow.box'
+  | 'geoarrow.wkb'
+  | 'geoarrow.wkt';
+
+/** CRS serialization identifiers defined by the GeoArrow extension metadata specification. */
+export type GeoArrowCRSType = 'projjson' | 'wkt2:2019' | 'authority_code' | 'srid';
+
+/** Non-planar edge interpretations supported by GeoArrow extension metadata. */
+export type GeoArrowEdgeType = 'spherical' | 'vincenty' | 'thomas' | 'andoyer' | 'karney';
+
+/** Geospatial metadata stored on one GeoArrow extension field. */
+export type GeoArrowMetadata = {
+  /** Geometry encoding declared by the Arrow extension name. */
+  encoding?: GeoArrowEncoding;
+  /** Coordinate reference system metadata as PROJJSON or a serialized string. */
+  crs?: Record<string, unknown> | string;
+  /** Serialization used when `crs` is represented as a string. */
+  crs_type?: GeoArrowCRSType;
+  /** Non-planar interpretation of edges between geometry vertices. */
+  edges?: GeoArrowEdgeType;
+  /** Geometry types represented by the field. */
+  geometry_types?: GeoParquetGeometryType[];
+  [key: string]: unknown;
+};
 
 /**
  * Reads GeoParquet metadata from a metadata container.

--- a/modules/gis/test/geoarrow/geospatial-metadata-zod-schema.spec.ts
+++ b/modules/gis/test/geoarrow/geospatial-metadata-zod-schema.spec.ts
@@ -1,0 +1,111 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
+import {
+  GeoArrowMetadataSchema,
+  GeoParquetMetadataSchema
+} from '@loaders.gl/gis/geospatial-metadata-zod-schema';
+import {describe, expect, it} from 'vitest';
+import {z} from 'zod';
+
+describe('geospatial metadata schemas', () => {
+  it('validates GeoParquet metadata and preserves extension properties', () => {
+    const metadata = GeoParquetMetadataSchema.parse({
+      version: '1.1.0',
+      primary_column: 'geometry',
+      columns: {
+        geometry: {
+          encoding: 'wkb',
+          geometry_types: ['Point', 'Point Z'],
+          bbox: [-180, -90, 180, 90],
+          covering: {bbox: {xmin: ['bbox', 0]}}
+        }
+      },
+      vendor: {dataset: 'places'}
+    });
+
+    expect(metadata.columns.geometry.covering).toBeDefined();
+    expect(metadata.vendor).toEqual({dataset: 'places'});
+
+    expect(
+      GeoParquetMetadataSchema.safeParse({
+        version: '1.1.0',
+        primary_column: 'geometry',
+        columns: {
+          geometry: {
+            encoding: 'WKB',
+            geometry_types: ['Point Z'],
+            crs: null,
+            crs_type: 'projjson',
+            orientation: 'counterclockwise',
+            bbox: [-180, -90, 0, 180, 90, 100],
+            edges: 'planar',
+            epoch: 2026.5
+          }
+        }
+      }).success
+    ).toBe(true);
+  });
+
+  it('rejects missing primary columns and malformed column metadata', () => {
+    expect(
+      GeoParquetMetadataSchema.safeParse({
+        version: '1.1.0',
+        primary_column: 'missing',
+        columns: {
+          geometry: {encoding: 'wkb', geometry_types: ['Point']}
+        }
+      }).success
+    ).toBe(false);
+    expect(
+      GeoParquetMetadataSchema.safeParse({
+        version: '1.1.0',
+        primary_column: 'geometry',
+        columns: {
+          geometry: {encoding: 'wkt', geometry_types: ['Point']}
+        }
+      }).success
+    ).toBe(false);
+    expect(
+      GeoParquetMetadataSchema.safeParse({
+        version: '1.1.0',
+        primary_column: 'geometry',
+        columns: {
+          geometry: {encoding: 'WKB', geometry_types: ['Point', 'Point']}
+        }
+      }).success
+    ).toBe(false);
+    expect(
+      GeoParquetMetadataSchema.safeParse({
+        version: '1.1.0',
+        primary_column: 'geometry',
+        columns: {
+          geometry: {encoding: 'invalid', geometry_types: ['Point']}
+        }
+      }).success
+    ).toBe(false);
+  });
+
+  it('validates GeoArrow field metadata', () => {
+    expect(
+      GeoArrowMetadataSchema.safeParse({
+        encoding: 'geoarrow.box',
+        crs: 'EPSG:4326',
+        crs_type: 'authority_code',
+        edges: 'karney'
+      }).success
+    ).toBe(true);
+    expect(GeoArrowMetadataSchema.safeParse({edges: 'planar'}).success).toBe(false);
+  });
+
+  it('exports both schemas as JSON Schema', () => {
+    const geoParquetJsonSchema = z.toJSONSchema(GeoParquetMetadataSchema, {target: 'draft-7'});
+    const geoArrowJsonSchema = z.toJSONSchema(GeoArrowMetadataSchema, {target: 'draft-7'});
+
+    expect(geoParquetJsonSchema.required).toEqual(
+      expect.arrayContaining(['version', 'primary_column', 'columns'])
+    );
+    expect(JSON.stringify(geoArrowJsonSchema)).toContain('geoarrow.wkb');
+  });
+});

--- a/modules/gis/test/index.ts
+++ b/modules/gis/test/index.ts
@@ -30,5 +30,6 @@ import './wkt-crs/parse-wkt-crs.spec';
 import './geoarrow/convert-geoarrow-to-binary-geometry.spec';
 import './geoarrow/convert-geoarrow-to-geojson.spec';
 import './geoarrow/wkb-geoarrow-utils.spec';
+import './geoarrow/geospatial-metadata-zod-schema.spec';
 
 import './table-converters/convert-geojson-to-arrow-table.spec';

--- a/modules/parquet/src/lib/geo/geospatial-metadata.ts
+++ b/modules/parquet/src/lib/geo/geospatial-metadata.ts
@@ -10,34 +10,21 @@ import {
   getMetadataValue,
   setGeoMetadata,
   setMetadataValue,
+  type GeoArrowEncoding,
+  type GeoArrowMetadata,
   type GeoColumnMetadata,
   type GeoMetadata,
   type GeoParquetGeometryType
 } from '@loaders.gl/gis';
+import {
+  GeoArrowMetadataSchema,
+  GeoParquetMetadataSchema
+} from '@loaders.gl/gis/geospatial-metadata-zod-schema';
 import {convertArrowToSchema} from '@loaders.gl/schema-utils';
 
 const GEOARROW_EXTENSION_NAME_KEY = 'ARROW:extension:name';
 const GEOARROW_EXTENSION_METADATA_KEY = 'ARROW:extension:metadata';
 const GEOPARQUET_VERSION = '1.1.0';
-
-type GeoArrowEncoding =
-  | 'geoarrow.geometry'
-  | 'geoarrow.geometrycollection'
-  | 'geoarrow.multipolygon'
-  | 'geoarrow.polygon'
-  | 'geoarrow.multilinestring'
-  | 'geoarrow.linestring'
-  | 'geoarrow.multipoint'
-  | 'geoarrow.point'
-  | 'geoarrow.wkb'
-  | 'geoarrow.wkt';
-
-type GeoArrowMetadata = {
-  encoding?: GeoArrowEncoding;
-  crs?: Record<string, unknown>;
-  edges?: 'spherical';
-  [key: string]: unknown;
-};
 
 const GEOARROW_ENCODINGS = [
   'geoarrow.geometry',
@@ -48,6 +35,7 @@ const GEOARROW_ENCODINGS = [
   'geoarrow.linestring',
   'geoarrow.multipoint',
   'geoarrow.point',
+  'geoarrow.box',
   'geoarrow.wkb',
   'geoarrow.wkt'
 ] as const satisfies GeoArrowEncoding[];
@@ -116,9 +104,10 @@ function getGeometryMetadataForField(
   const columnMetadata = getMetadataValue(fieldMetadata, GEOARROW_EXTENSION_METADATA_KEY);
   if (columnMetadata) {
     try {
+      const parsedMetadata = GeoArrowMetadataSchema.parse(JSON.parse(columnMetadata));
       metadata = {
         ...(metadata || {}),
-        ...(JSON.parse(columnMetadata) as GeoArrowMetadata)
+        ...parsedMetadata
       };
     } catch {
       return metadata;
@@ -354,51 +343,12 @@ function getGeoArrowMetadataFromGeoParquetField(
 }
 
 function isValidGeoParquetMetadata(geoMetadata: GeoMetadata | null): boolean {
-  if (!geoMetadata || typeof geoMetadata !== 'object') {
-    return false;
-  }
-
-  if (
-    typeof geoMetadata.version !== 'string' ||
-    typeof geoMetadata.primary_column !== 'string' ||
-    !geoMetadata.columns ||
-    typeof geoMetadata.columns !== 'object'
-  ) {
-    return false;
-  }
-
-  const primaryColumnMetadata = geoMetadata.columns[geoMetadata.primary_column];
-  if (!primaryColumnMetadata) {
-    return false;
-  }
-
-  return Object.values(geoMetadata.columns).every(isValidGeoParquetColumnMetadata);
+  return GeoParquetMetadataSchema.safeParse(geoMetadata).success;
 }
 
-function isValidGeoParquetColumnMetadata(columnMetadata: unknown): boolean {
-  if (!columnMetadata || typeof columnMetadata !== 'object') {
-    return false;
-  }
-
-  const {encoding, geometry_types} = columnMetadata as GeoColumnMetadata;
-  return (
-    typeof encoding === 'string' &&
-    Boolean(
-      GEOPARQUET_TO_GEOARROW_ENCODINGS[
-        encoding.toLowerCase() as keyof typeof GEOPARQUET_TO_GEOARROW_ENCODINGS
-      ]
-    ) &&
-    Array.isArray(geometry_types)
-  );
-}
-
-function synthesizeGeoParquetColumnMetadata(geometryMetadata: {
-  encoding?: GeoArrowEncoding;
-  crs?: Record<string, unknown>;
-  crs_type?: 'projjson' | 'wkt2:2019';
-  edges?: 'spherical';
-  geometry_types?: GeoParquetGeometryType[];
-}): GeoColumnMetadata | null {
+function synthesizeGeoParquetColumnMetadata(
+  geometryMetadata: GeoArrowMetadata
+): GeoColumnMetadata | null {
   const encoding = geometryMetadata.encoding
     ? GEOARROW_TO_GEOPARQUET_ENCODINGS[
         geometryMetadata.encoding as keyof typeof GEOARROW_TO_GEOPARQUET_ENCODINGS
@@ -418,10 +368,10 @@ function synthesizeGeoParquetColumnMetadata(geometryMetadata: {
     geometry_types: geometryTypes
   };
 
-  if (geometryMetadata.crs !== undefined) {
+  if (geometryMetadata.crs !== undefined && typeof geometryMetadata.crs !== 'string') {
     columnMetadata.crs = geometryMetadata.crs;
   }
-  if (geometryMetadata.crs_type !== undefined) {
+  if (geometryMetadata.crs_type === 'projjson' || geometryMetadata.crs_type === 'wkt2:2019') {
     columnMetadata.crs_type = geometryMetadata.crs_type;
   }
   if (geometryMetadata.edges === 'spherical') {

--- a/modules/parquet/test/geospatial-metadata.spec.ts
+++ b/modules/parquet/test/geospatial-metadata.spec.ts
@@ -1,0 +1,40 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
+import type {Schema} from '@loaders.gl/schema';
+import {describe, expect, it} from 'vitest';
+import {ensureGeoParquetMetadata} from '../src/lib/geo/geospatial-metadata';
+
+describe('geospatial metadata', () => {
+  it('validates GeoArrow extension metadata before synthesizing GeoParquet metadata', () => {
+    const schema: Schema = {
+      fields: [
+        {
+          name: 'geometry',
+          type: 'binary',
+          metadata: {
+            'ARROW:extension:name': 'geoarrow.wkb',
+            'ARROW:extension:metadata': JSON.stringify({
+              crs: {type: 'GeographicCRS'},
+              crs_type: 'projjson',
+              edges: 'spherical'
+            })
+          }
+        }
+      ],
+      metadata: {}
+    };
+
+    ensureGeoParquetMetadata(schema);
+
+    const metadata = JSON.parse(schema.metadata.geo);
+    expect(metadata.columns.geometry).toMatchObject({
+      encoding: 'wkb',
+      geometry_types: [],
+      crs: {type: 'GeographicCRS'},
+      crs_type: 'projjson',
+      edges: 'spherical'
+    });
+  });
+});

--- a/modules/parquet/test/index.ts
+++ b/modules/parquet/test/index.ts
@@ -25,5 +25,6 @@ import './parquet-source-capabilities.spec';
 
 import './parquet-loader.spec';
 import './geoparquet-loader.spec';
+import './geospatial-metadata.spec';
 import './parquet-typed-array.spec';
 import './parquet-compatibility.spec';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -163,6 +163,9 @@
       "@loaders.gl/gis": [
         "modules/gis/src"
       ],
+      "@loaders.gl/gis/*": [
+        "modules/gis/src/*"
+      ],
       "@loaders.gl/gis/test": [
         "modules/gis/test"
       ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5451,6 +5451,7 @@ __metadata:
     "@math.gl/proj4": "npm:^4.1.0"
     apache-arrow: "npm:>= 17.0.0"
     pbf: "npm:^3.2.1"
+    zod: "npm:^4.1.12"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
   languageName: unknown


### PR DESCRIPTION
## Goals

- Keep the documented handwritten GeoParquet and GeoArrow TypeScript types while adding runtime validation.
- Publish reusable Zod and draft-07 JSON Schemas without adding Zod to the lightweight `@loaders.gl/gis` root import.
- Validate geospatial metadata at the GeoArrow and Parquet integration boundaries.

## Changes

- Adds `geospatial-metadata-zod-schema.ts` with typed GeoParquet column/file and normalized GeoArrow metadata schemas.
- Exposes the runtime validators from `@loaders.gl/gis/geospatial-metadata-zod-schema`.
- Keeps and expands handwritten, TSDoc-documented metadata types on the `@loaders.gl/gis` root API; no public types use `z.infer`.
- Publishes `geoparquet.schema.json` and `geoarrow-metadata.schema.json`.
- Replaces Parquet's manual GeoParquet validator and unchecked GeoArrow metadata casts with the schemas.
- Adds shared schema and integration tests, including invalid primary columns, duplicate geometry types, CRS variants, and GeoArrow-to-GeoParquet synthesis.
- Documents the new public APIs and JSON Schema assets in the v5.0 release notes.

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn test-node-cover` — 409 files passed, 3 skipped; 1,956 tests passed, 81 skipped
- Focused final Node coverage — 3 files and 7 tests passed
- Focused final headless — 3 files and 7 tests passed
- New Zod schema module — 7/7 executable lines covered
- All newly added GeoArrow/GeoParquet validator integration lines covered
