### PR TITLE
Add Zod and JSON schemas for I3S metadata

### DIFF
--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -14,6 +14,7 @@ Release Date: 2026
 - **Raster sources** - New experimental `RasterSource` APIs add viewport-driven typed raster loading, with [`GeoTIFFSourceLoader`](/docs/modules/geotiff/api-reference/geotiff-source-loader), [`OMETiffSourceLoader`](/docs/modules/geotiff/api-reference/ometiff-source-loader), [`RasterSet`](/docs/modules/tiles/api-reference/raster-set), and new GeoTIFF / OME-TIFF website examples.
 - **Gaussian splats** - New `@loaders.gl/splats` loaders, Gaussian PLY Arrow table support, and WebGPU `SplatLayer` support add experimental rendering for 3D Gaussian splat scenes.
 - **OpenUSD scenes** - The new `@loaders.gl/scene` module provides an experimental [`USDLoader`](/docs/modules/scene/api-reference/usd-loader) for the [OpenUSD format](/docs/modules/scene/formats/usd), supporting ASCII USDA layers and uncompressed USDZ archives, including reference and variant composition.
+- **JSON format validation** - [Zod](https://zod.dev/) schemas add runtime validation while retaining handwritten TypeScript types, with exported JSON Schemas for `@loaders.gl/textures`, `@loaders.gl/potree`, `@loaders.gl/mvt`, `@loaders.gl/3d-tiles`, `@loaders.gl/gis`, `@loaders.gl/i3s`, and `@loaders.gl/splats`.
 
 **Features**
 
@@ -86,6 +87,10 @@ Release Date: 2026
 
 - Handwritten, documented GeoParquet and GeoArrow metadata types are exported from `@loaders.gl/gis`, while matching runtime validators are available from `@loaders.gl/gis/geospatial-metadata-zod-schema` without adding Zod to the lightweight root import.
 - Draft-07 `geoparquet.schema.json` and `geoarrow-metadata.schema.json` assets are published for validation and editor integrations.
+
+**@loaders.gl/i3s**
+
+- Handwritten I3S metadata types are paired with runtime scene-layer and node-page validators from `@loaders.gl/i3s/i3s-zod-schema`, plus published draft-07 JSON Schema assets.
 
 **@loaders.gl/deck-layers**
 

--- a/modules/i3s/package.json
+++ b/modules/i3s/package.json
@@ -27,6 +27,11 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
+    "./i3s-zod-schema": {
+      "types": "./dist/i3s-zod-schema.d.ts",
+      "import": "./dist/i3s-zod-schema.js",
+      "require": "./dist/i3s-zod-schema.cjs"
+    },
     "./bundled": {
       "types": "./dist/bundled.d.ts",
       "import": "./dist/bundled.js"
@@ -40,7 +45,9 @@
     },
     "./i3s-content-worker-node.js": {
       "import": "./dist/i3s-content-worker-node.js"
-    }
+    },
+    "./i3s-scene-layer.schema.json": "./dist/i3s-scene-layer.schema.json",
+    "./i3s-node-page.schema.json": "./dist/i3s-node-page.schema.json"
   },
   "sideEffects": false,
   "files": [
@@ -49,7 +56,8 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-bundle-dev && npm run build-worker && npm run build-worker-node",
+    "pre-build": "npm run generate-json-schema && npm run build-bundle && npm run build-bundle-dev && npm run build-worker && npm run build-worker-node",
+    "generate-json-schema": "node ../../scripts/generate-json-schema.mjs --schema ./dist/i3s-zod-schema.js --export I3SSceneLayerSchema --output ./dist/i3s-scene-layer.schema.json --id https://unpkg.com/@loaders.gl/i3s/i3s-scene-layer.schema.json --title 'loaders.gl I3S scene layer metadata' && node ../../scripts/generate-json-schema.mjs --schema ./dist/i3s-zod-schema.js --export I3SNodePageSchema --output ./dist/i3s-node-page.schema.json --id https://unpkg.com/@loaders.gl/i3s/i3s-node-page.schema.json --title 'loaders.gl I3S node page'",
     "build-bundle": "ocular-bundle ./bundle.ts --output=dist/dist.min.js",
     "build-bundle-dev": "ocular-bundle ./bundle.ts --env=dev --output=dist/dist.dev.js",
     "build-worker": "esbuild src/workers/i3s-content-worker.ts --outfile=dist/i3s-content-worker.js --target=esnext --bundle --define:__VERSION__=\\\"$npm_package_version\\\"",
@@ -68,7 +76,8 @@
     "@loaders.gl/zip": "5.0.0-alpha.1",
     "@math.gl/core": "^4.1.0",
     "@math.gl/culling": "^4.1.0",
-    "@math.gl/geospatial": "^4.1.0"
+    "@math.gl/geospatial": "^4.1.0",
+    "zod": "^4.1.12"
   },
   "peerDependencies": {
     "@loaders.gl/core": "~5.0.0-alpha.0"

--- a/modules/i3s/src/i3s-loader-with-parser.ts
+++ b/modules/i3s/src/i3s-loader-with-parser.ts
@@ -9,6 +9,7 @@ import {normalizeTileData, normalizeTilesetData} from './lib/parsers/parse-i3s';
 import {I3SParseOptions} from './types';
 import {getUrlWithoutParams} from './lib/utils/url-utils';
 import {I3SLoader as I3SLoaderMetadata} from './i3s-loader';
+import {I3SSceneLayerSchema} from './i3s-zod-schema';
 
 const {preload: _I3SLoaderPreload, ...I3SLoaderMetadataWithoutPreload} = I3SLoaderMetadata;
 
@@ -84,7 +85,8 @@ async function parseTileset(data, options: I3SLoaderOptions, context) {
     throw new Error('Point Cloud layers currently are not supported by I3SLoader');
   }
 
-  const tilesetPostprocessed = await normalizeTilesetData(tilesetJson, options, context);
+  const sceneLayer = I3SSceneLayerSchema.parse(tilesetJson);
+  const tilesetPostprocessed = await normalizeTilesetData(sceneLayer, options, context);
   return tilesetPostprocessed;
 }
 

--- a/modules/i3s/src/i3s-node-page-loader-with-parser.ts
+++ b/modules/i3s/src/i3s-node-page-loader-with-parser.ts
@@ -6,6 +6,7 @@ import type {LoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';
 import type {I3SLoaderOptions} from './i3s-loader';
 import type {NodePage} from './types';
 import {I3SNodePageLoader as I3SNodePageLoaderMetadata} from './i3s-node-page-loader';
+import {I3SNodePageSchema} from './i3s-zod-schema';
 
 const {preload: _I3SNodePageLoaderPreload, ...I3SNodePageLoaderMetadataWithoutPreload} =
   I3SNodePageLoaderMetadata;
@@ -24,5 +25,5 @@ async function parseNodePage(
   options?: LoaderOptions
 ): Promise<NodePage> {
   const text = typeof data === 'string' ? data : new TextDecoder().decode(data);
-  return JSON.parse(text) as NodePage;
+  return I3SNodePageSchema.parse(JSON.parse(text));
 }

--- a/modules/i3s/src/i3s-zod-schema.ts
+++ b/modules/i3s/src/i3s-zod-schema.ts
@@ -1,0 +1,112 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
+import {z} from 'zod';
+import type {
+  MeshGeometry,
+  MeshMaterial,
+  NodeInPage,
+  NodePage,
+  Obb,
+  SceneLayer3D,
+  SpatialReference
+} from './types';
+
+/** Zod schema for an I3S oriented bounding box. */
+export const I3SObbSchema = z
+  .object({
+    center: z.array(z.number().finite()).length(3),
+    halfSize: z.array(z.number().finite().nonnegative()).length(3),
+    quaternion: z.array(z.number().finite()).length(4)
+  })
+  .passthrough() satisfies z.ZodType<Obb>;
+
+/** Zod schema for an I3S mesh material reference in a node page. */
+export const I3SMeshMaterialSchema = z
+  .object({
+    definition: z.number().int().nonnegative(),
+    resource: z.number().int().nonnegative().optional(),
+    texelCountHint: z.number().nonnegative().optional()
+  })
+  .passthrough() satisfies z.ZodType<MeshMaterial>;
+
+/** Zod schema for an I3S mesh geometry reference in a node page. */
+export const I3SMeshGeometrySchema = z
+  .object({
+    definition: z.number().int().nonnegative(),
+    resource: z.number().int().nonnegative(),
+    vertexCount: z.number().int().nonnegative().optional(),
+    featureCount: z.number().int().nonnegative().optional()
+  })
+  .passthrough() satisfies z.ZodType<MeshGeometry>;
+
+/** Zod schema for one I3S node-page node. */
+export const I3SNodeInPageSchema = z
+  .object({
+    index: z.number().int().nonnegative(),
+    parentIndex: z.number().int().nonnegative().optional(),
+    lodThreshold: z.number().finite().nonnegative().optional(),
+    obb: I3SObbSchema,
+    children: z.array(z.number().int().nonnegative()).optional(),
+    mesh: z
+      .object({
+        material: I3SMeshMaterialSchema,
+        geometry: I3SMeshGeometrySchema,
+        attribute: z.object({resource: z.number().int().nonnegative()}).passthrough()
+      })
+      .passthrough()
+      .optional()
+  })
+  .passthrough() satisfies z.ZodType<NodeInPage>;
+
+/** Zod schema for an I3S node-page document. */
+export const I3SNodePageSchema = z
+  .object({nodes: z.array(I3SNodeInPageSchema)})
+  .passthrough() satisfies z.ZodType<NodePage>;
+
+/** Zod schema for the spatial-reference metadata used by an I3S scene layer. */
+export const I3SSpatialReferenceSchema = z
+  .object({
+    latestVcsWkid: z.number().int().optional(),
+    latestWkid: z.number().int().optional(),
+    vcsWkid: z.number().int().optional(),
+    wkid: z.number().int().optional(),
+    wkt: z.string().min(1).optional()
+  })
+  .passthrough()
+  .refine(
+    spatialReference => spatialReference.wkid !== undefined || Boolean(spatialReference.wkt),
+    {
+      message: 'I3S spatialReference must include wkid or wkt'
+    }
+  ) satisfies z.ZodType<SpatialReference>;
+
+/** Zod schema for raw I3S 3D Object and Integrated Mesh scene-layer metadata. */
+export const I3SSceneLayerSchema = z
+  .object({
+    id: z.number().int().nonnegative(),
+    href: z.string().optional(),
+    layerType: z.enum(['3DObject', 'IntegratedMesh']),
+    spatialReference: I3SSpatialReferenceSchema.optional(),
+    version: z.string().min(1),
+    name: z.string().optional(),
+    capabilities: z.array(z.string()),
+    disablePopup: z.boolean(),
+    store: z
+      .object({
+        profile: z.string().min(1),
+        version: z.union([z.number(), z.string().min(1)]),
+        defaultGeometrySchema: z.any()
+      })
+      .passthrough(),
+    nodePages: z
+      .object({
+        nodesPerPage: z.number().int().positive().max(4096),
+        rootIndex: z.number().int().nonnegative().optional(),
+        lodSelectionMetricType: z.literal('maxScreenThresholdSQ')
+      })
+      .passthrough()
+      .optional()
+  })
+  .passthrough() satisfies z.ZodType<SceneLayer3D>;

--- a/modules/i3s/src/index.ts
+++ b/modules/i3s/src/index.ts
@@ -19,6 +19,7 @@ export type {
   NodeReference,
   Resource,
   MaxScreenThresholdSQ,
+  NodePage,
   NodeInPage,
   SharedResources,
   Attribute,

--- a/modules/i3s/src/types.ts
+++ b/modules/i3s/src/types.ts
@@ -688,13 +688,13 @@ type FilterModeWireFrame = {
 /** Spec - https://github.com/Esri/i3s-spec/blob/master/docs/1.8/spatialReference.cmn.md */
 export type SpatialReference = {
   /** The current WKID value of the vertical coordinate system. */
-  latestVcsWkid: number;
-  /** dentifies the current WKID value associated with the same spatial reference. */
-  latestWkid: number;
+  latestVcsWkid?: number;
+  /** Identifies the current WKID value associated with the same spatial reference. */
+  latestWkid?: number;
   /** The WKID value of the vertical coordinate system. */
-  vcsWkid: number;
+  vcsWkid?: number;
   /** WKID, or Well-Known ID, of the CRS. Specify either WKID or WKT of the CRS. */
-  wkid: number;
+  wkid?: number;
   /** WKT, or Well-Known Text, of the CRS. Specify either WKT or WKID of the CRS but not both. */
   wkt?: string;
 };

--- a/modules/i3s/test/i3s-zod-schema.spec.ts
+++ b/modules/i3s/test/i3s-zod-schema.spec.ts
@@ -1,0 +1,104 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
+import {parse} from '@loaders.gl/core';
+import {I3SLoader, I3SNodePageLoader} from '@loaders.gl/i3s';
+import {I3SNodePageSchema, I3SSceneLayerSchema} from '@loaders.gl/i3s/i3s-zod-schema';
+import {describe, expect, it} from 'vitest';
+import {z} from 'zod';
+
+const obb = {
+  center: [8.67, 50.1, 189],
+  halfSize: [10, 20, 30],
+  quaternion: [0, 0, 0, 1]
+};
+
+describe('I3S metadata schemas', () => {
+  it('validates scene-layer metadata and preserves extensions', () => {
+    const sceneLayer = I3SSceneLayerSchema.parse({
+      id: 0,
+      layerType: '3DObject',
+      version: '1.8',
+      capabilities: ['View'],
+      disablePopup: false,
+      spatialReference: {wkid: 4326},
+      store: {
+        profile: 'meshpyramids',
+        version: '1.8',
+        defaultGeometrySchema: {},
+        vendorSetting: true
+      },
+      nodePages: {
+        nodesPerPage: 64,
+        lodSelectionMetricType: 'maxScreenThresholdSQ'
+      },
+      vendor: {dataset: 'buildings'}
+    });
+
+    expect(sceneLayer.vendor).toEqual({dataset: 'buildings'});
+    expect(sceneLayer.store.vendorSetting).toBe(true);
+  });
+
+  it('validates node pages and nested mesh references', () => {
+    const nodePage = I3SNodePageSchema.parse({
+      nodes: [
+        {
+          index: 0,
+          obb,
+          children: [],
+          mesh: {
+            material: {definition: 0, resource: 1},
+            geometry: {definition: 0, resource: 1, vertexCount: 12},
+            attribute: {definition: 0, resource: 1}
+          }
+        }
+      ],
+      pageIndex: 0
+    });
+
+    expect(nodePage.nodes[0].mesh?.geometry.vertexCount).toBe(12);
+    expect(nodePage.pageIndex).toBe(0);
+  });
+
+  it('rejects malformed metadata at loader boundaries', async () => {
+    await expect(parse('{"nodes":[{"index":0}]}', I3SNodePageLoader)).rejects.toThrow();
+    const invalidSceneLayer = new TextEncoder().encode('{"id":0,"layerType":"3DObject"}').buffer;
+    await expect(
+      parse(invalidSceneLayer, I3SLoader, {
+        i3s: {isTileset: true}
+      })
+    ).rejects.toThrow();
+  });
+
+  it('requires a WKID or WKT spatial reference', () => {
+    expect(() => I3SSceneLayerSchema.parse(createSceneLayer({spatialReference: {}}))).toThrow();
+  });
+
+  it('exports scene-layer and node-page JSON Schemas', () => {
+    const sceneLayerJsonSchema = z.toJSONSchema(I3SSceneLayerSchema, {target: 'draft-7'});
+    const nodePageJsonSchema = z.toJSONSchema(I3SNodePageSchema, {target: 'draft-7'});
+
+    expect(sceneLayerJsonSchema.required).toEqual(
+      expect.arrayContaining(['id', 'layerType', 'version', 'capabilities', 'store'])
+    );
+    expect(nodePageJsonSchema.required).toContain('nodes');
+  });
+});
+
+/** Creates minimal valid I3S scene-layer metadata with optional overrides. */
+function createSceneLayer(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 0,
+    layerType: '3DObject',
+    version: '1.8',
+    capabilities: ['View'],
+    disablePopup: false,
+    store: {
+      profile: 'meshpyramids',
+      version: '1.8',
+      defaultGeometrySchema: {}
+    },
+    ...overrides
+  };
+}

--- a/modules/i3s/test/index.ts
+++ b/modules/i3s/test/index.ts
@@ -6,6 +6,7 @@ import './i3s-loader.spec';
 import './parse-slpk.spec';
 import './parse-slpk-readable-file.spec';
 import './i3s-node-page-loader.spec';
+import './i3s-zod-schema.spec';
 import './i3s-attribute-loader.spec';
 // TODO v4.0 restore these tests
 // import './i3s-content-loader.spec';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5499,6 +5499,7 @@ __metadata:
     "@math.gl/core": "npm:^4.1.0"
     "@math.gl/culling": "npm:^4.1.0"
     "@math.gl/geospatial": "npm:^4.1.0"
+    zod: "npm:^4.1.12"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
   languageName: unknown


### PR DESCRIPTION
## Goals

- Add runtime validation for high-value I3S scene-layer and node-page metadata.
- Keep the existing handwritten TypeScript types and TSDoc as the authoritative public API.
- Publish reusable JSON Schemas without adding Zod to the package root import.
- Prevent the schema work from reducing Node or browser coverage.

## Changes

- Adds `@loaders.gl/i3s/i3s-zod-schema` with scene-layer, spatial-reference, node-page, mesh, and OBB schemas constrained with `satisfies z.ZodType<...>`.
- Validates scene-layer metadata and node-page documents at their loader boundaries.
- Publishes `i3s-scene-layer.schema.json` and `i3s-node-page.schema.json` as draft-07 package assets.
- Keeps the handwritten interfaces in `types.ts`, improves the spatial-reference contract, and exports `NodePage`.
- Adds schema, extension-preservation, invalid-input, loader-integration, and JSON Schema conversion tests.
- Adds a v5 Highlights entry for the Zod/JSON Schema rollout across the affected loaders.gl modules.

## Validation

- `yarn install`
- `yarn lint fix`
- `yarn build`
- `yarn test-node-cover`: 410 files passed, 1,962 tests passed, 100% line and branch coverage in `i3s-zod-schema.ts`
- `yarn test-headless`: 410 files passed, 1,924 tests passed
- Focused post-rebase Node tests: 2 files, 6 tests passed
