### PR TITLE
fix: address landed review feedback

### DIFF
--- a/docs/modules/3d-tiles/api-reference/tiles-3d-loader.md
+++ b/docs/modules/3d-tiles/api-reference/tiles-3d-loader.md
@@ -80,6 +80,22 @@ while (!tileset3d.isLoaded()) {
 }
 ```
 
+## Tileset Metadata Validation
+
+`Tiles3DLoader` validates raw tileset JSON before normalizing the header or loading tile content.
+Applications can use the same Zod schema directly:
+
+```typescript
+import {Tiles3DTilesetSchema} from '@loaders.gl/3d-tiles/tileset-zod-schema';
+
+const validatedTileset = Tiles3DTilesetSchema.parse(tilesetJson);
+```
+
+The equivalent generated JSON Schema is published as
+`@loaders.gl/3d-tiles/tileset.schema.json` for editors, build tools, and non-TypeScript validators.
+Both schemas enforce the same structural constraints, including that a tileset cannot define both
+`schema` and `schemaUri`.
+
 ## Options
 
 | Option               | Type             | Default | Description                                                                                                                                                           |

--- a/docs/modules/zip/formats/zip.md
+++ b/docs/modules/zip/formats/zip.md
@@ -4,6 +4,17 @@
 
 [ZIP Archive](<https://en.wikipedia.org/wiki/Zip_(file_format)>)
 
+## Supported local header layouts
+
+`ZipFileSystem.fetch()` supports entries whose local headers contain ordinary 32-bit sizes, ZIP64
+sizes, or zero sizes followed by a data descriptor. When general-purpose bit 3 indicates a data
+descriptor, the central-directory sizes are authoritative; both signed and unsigned descriptors are
+supported.
+
+ZIP64 local headers store the uncompressed and compressed sizes as a required pair in the ZIP64
+extended information record when either 32-bit local size is the ZIP64 sentinel. A non-sentinel
+compressed size remains authoritative for legacy layouts.
+
 ## ZIP64 validation
 
 The random-access ZIP header parsers validate required ZIP64 extended information records before

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -17,6 +17,10 @@ Release Date: 2026
 
 **Features**
 
+**@loaders.gl/3d-tiles**
+
+- [`Tiles3DLoader`](/docs/modules/3d-tiles/api-reference/tiles-3d-loader) validates tileset metadata at the loader boundary. The runtime `Tiles3DTilesetSchema` and generated `tileset.schema.json` are published for application and tooling use.
+
 **@loaders.gl/draco**
 
 - [`DracoWriter`](/docs/modules/draco/api-reference/draco-writer) now accepts plain `Mesh` data and Mesh Arrow tables in addition to existing Draco attribute-map input.

--- a/modules/3d-tiles/src/tileset-zod-schema.ts
+++ b/modules/3d-tiles/src/tileset-zod-schema.ts
@@ -101,13 +101,11 @@ export const Tiles3DTileSchema: z.ZodType<Tiles3DTileJSON> = z.lazy(() =>
     .passthrough()
 );
 
-/** Zod schema for raw 3D Tiles tileset JSON before loader normalization. */
-export const Tiles3DTilesetSchema = z
+/** Common fields in raw 3D Tiles tileset JSON before loader normalization. */
+const Tiles3DTilesetBaseSchema = z
   .object({
     asset: Tiles3DTilesetAssetSchema,
     properties: z.record(z.string(), TilesetPropertySchema).optional(),
-    schema: z.record(z.string(), z.unknown()).optional(),
-    schemaUri: z.string().optional(),
     statistics: z.unknown().optional(),
     groups: z.array(z.unknown()).optional(),
     metadata: z.unknown().optional(),
@@ -118,7 +116,32 @@ export const Tiles3DTilesetSchema = z
     extensions: z.record(z.string(), z.unknown()).optional(),
     extras: z.unknown().optional()
   })
-  .passthrough()
-  .refine(tileset => !(tileset.schema && tileset.schemaUri), {
-    message: 'Tileset cannot define both schema and schemaUri'
-  }) satisfies z.ZodType<Tiles3DTilesetJSON>;
+  .passthrough();
+
+/** Mutually exclusive inline, external, or absent metadata schema declarations. */
+const Tiles3DMetadataSchemaSource = z.union([
+  z
+    .object({
+      schema: z.record(z.string(), z.unknown()),
+      schemaUri: z.never().optional()
+    })
+    .passthrough(),
+  z
+    .object({
+      schema: z.never().optional(),
+      schemaUri: z.string()
+    })
+    .passthrough(),
+  z
+    .object({
+      schema: z.never().optional(),
+      schemaUri: z.never().optional()
+    })
+    .passthrough()
+]);
+
+/** Zod schema for raw 3D Tiles tileset JSON before loader normalization. */
+export const Tiles3DTilesetSchema = z.intersection(
+  Tiles3DTilesetBaseSchema,
+  Tiles3DMetadataSchemaSource
+) satisfies z.ZodType<Tiles3DTilesetJSON>;

--- a/modules/3d-tiles/test/tileset-zod-schema.spec.ts
+++ b/modules/3d-tiles/test/tileset-zod-schema.spec.ts
@@ -41,14 +41,21 @@ describe('Tiles3DTilesetSchema', () => {
   });
 
   it('rejects conflicting inline and external metadata schemas', () => {
+    const conflictingTileset = {
+      asset: {version: '1.1'},
+      schema: {},
+      schemaUri: 'metadata.schema.json',
+      geometricError: 1,
+      root: {boundingVolume: {sphere: [0, 0, 0, 1]}, geometricError: 0}
+    };
+
+    expect(Tiles3DTilesetSchema.safeParse(conflictingTileset).success).toBe(false);
+
+    const jsonSchema = z.toJSONSchema(Tiles3DTilesetSchema, {target: 'draft-7'});
+    const schemaFromJson = z.fromJSONSchema(jsonSchema);
     expect(
-      Tiles3DTilesetSchema.safeParse({
-        asset: {version: '1.1'},
-        schema: {},
-        schemaUri: 'metadata.schema.json',
-        geometricError: 1,
-        root: {boundingVolume: {sphere: [0, 0, 0, 1]}, geometricError: 0}
-      }).success
+      schemaFromJson.safeParse(conflictingTileset).success,
+      'generated JSON Schema rejects the same conflict'
     ).toBe(false);
   });
 
@@ -56,9 +63,8 @@ describe('Tiles3DTilesetSchema', () => {
     const jsonSchema = z.toJSONSchema(Tiles3DTilesetSchema, {target: 'draft-7'});
     const serializedJsonSchema = JSON.stringify(jsonSchema);
 
-    expect(jsonSchema.required).toEqual(
-      expect.arrayContaining(['asset', 'geometricError', 'root'])
-    );
     expect(serializedJsonSchema).toContain('boundingVolume');
+    expect(serializedJsonSchema).toContain('schemaUri');
+    expect(serializedJsonSchema).toContain('"not":{}');
   });
 });

--- a/modules/las/test/las-loader.spec.ts
+++ b/modules/las/test/las-loader.spec.ts
@@ -248,6 +248,35 @@ test('LAS loader variants parseInBatches', async t => {
   t.end();
 });
 
+test('LAS loader variants return Arrow tables', async t => {
+  const response = await fetchFile(LAS_EXTRABYTES_BINARY_URL);
+  const arrayBuffer = await response.arrayBuffer();
+
+  for (const {name, loader} of [
+    {name: 'laz-perf', loader: LAZPerfLoader},
+    {name: 'COPC', loader: LASCOPCLoader},
+    {name: 'laz-rs', loader: LAZRsLoader}
+  ]) {
+    const table = await parse(arrayBuffer.slice(0), loader, {
+      core: {worker: false},
+      las: {shape: 'arrow-table'}
+    });
+    t.equal(table.shape, 'arrow-table', `${name} variant returns an Arrow table`);
+    t.equal(table.data.numRows, LAS_EXTRABYTES_POINT_COUNT, `${name} variant returns every point`);
+  }
+
+  const syncTable = LAZPerfLoaderWithParser.parseSync(arrayBuffer, {
+    las: {shape: 'arrow-table'}
+  });
+  t.equal(syncTable.shape, 'arrow-table', 'laz-perf parseSync returns an Arrow table');
+  t.equal(
+    syncTable.data.numRows,
+    LAS_EXTRABYTES_POINT_COUNT,
+    'laz-perf parseSync returns every point'
+  );
+  t.end();
+});
+
 test('LASLoader#parse LAZ 1.2 PDRF 3 matches laz-rs variant', async t => {
   const expected = await parse(fetchFile(LAS_BINARY_URL), LAZRsLoader, {
     core: {worker: false}

--- a/modules/las/test/typescript-laz.spec.ts
+++ b/modules/las/test/typescript-laz.spec.ts
@@ -119,11 +119,13 @@ test('TypeScript LAZ raw streaming preserves PDRF 4-10 records', async t => {
     }
 
     const expected = getLASPointData(lasArrayBuffer, fixture.pointDataRecordLength);
-    t.deepEqual(
-      concatenateUint8Arrays(decodedBatches),
-      expected,
-      `${fixture.label} raw records match LAS`
+    const actual = concatenateUint8Arrays(decodedBatches);
+    t.equal(
+      actual.byteLength,
+      expected.byteLength,
+      `${fixture.label} raw record byte length matches LAS`
     );
+    t.deepEqual(actual, expected, `${fixture.label} raw records match LAS`);
   }
   t.end();
 }, 60000);
@@ -142,6 +144,18 @@ test('TypeScript LAZ complete and split parsing preserve Arrow attributes', asyn
       })
     );
 
+    for (const attributeName of Object.keys(expected) as Array<keyof CollectedAttributes>) {
+      t.equal(
+        complete[attributeName].length,
+        expected[attributeName].length,
+        `${fixture.label} complete ${attributeName} length matches LAS`
+      );
+      t.equal(
+        streamed[attributeName].length,
+        expected[attributeName].length,
+        `${fixture.label} split ${attributeName} length matches LAS`
+      );
+    }
     t.deepEqual(complete, expected, `${fixture.label} complete parse matches LAS`);
     t.deepEqual(streamed, expected, `${fixture.label} split parse matches LAS`);
   }


### PR DESCRIPTION
## Goals

- Close correctness and documentation follow-ups from recently merged LAS, ZIP, and 3D Tiles reviews.
- Restore coverage for the explicit LAS loader variants introduced by #3558.

## Changes

- Assert decoded raw-byte and Arrow attribute lengths before LAZ parity comparisons.
- Exercise laz-perf, COPC, and laz-rs variants with real LAZ Arrow output, including laz-perf sync parsing.
- Document supported ZIP local-header, ZIP64, and data-descriptor layouts.
- Represent the 3D Tiles `schema`/`schemaUri` exclusivity in generated JSON Schema and test runtime/generated validation.
- Document the public 3D Tiles schema exports and runtime validation workflow.

## Validation

- `yarn build`
- `yarn lint fix`
- 108 focused Node tests passed (1 skipped) across LAS, ZIP, and 3D Tiles.