### PR TITLE
Add Zod and JSON schemas for RAD metadata

### DIFF
--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -61,6 +61,7 @@ Release Date: 2026
 
 - [`SPLATLoader`](/docs/modules/splats/api-reference/splat-loader) NEW - loads raw `.splat` Gaussian splat files into Mesh Arrow tables.
 - [`KSPLATLoader`](/docs/modules/splats/api-reference/ksplat-loader) NEW - loads GaussianSplats3D `.ksplat` files into Mesh Arrow tables.
+- Handwritten RAD and RADC metadata types are paired with runtime validators from `@loaders.gl/splats/rad-zod-schema`, plus published draft-07 JSON Schema assets.
 
 **@loaders.gl/terrain**
 

--- a/modules/splats/package.json
+++ b/modules/splats/package.json
@@ -49,6 +49,11 @@
       "types": "./dist/rad-source-loader.d.ts",
       "import": "./dist/rad-source-loader.js"
     },
+    "./rad-zod-schema": {
+      "types": "./dist/rad-zod-schema.d.ts",
+      "import": "./dist/rad-zod-schema.js",
+      "require": "./dist/rad-zod-schema.cjs"
+    },
     "./unbundled": {
       "types": "./dist/unbundled.d.ts",
       "import": "./dist/unbundled.js"
@@ -56,7 +61,9 @@
     "./bundled": {
       "types": "./dist/bundled.d.ts",
       "import": "./dist/bundled.js"
-    }
+    },
+    "./rad-metadata.schema.json": "./dist/rad-metadata.schema.json",
+    "./radc-metadata.schema.json": "./dist/radc-metadata.schema.json"
   },
   "sideEffects": false,
   "files": [
@@ -65,7 +72,8 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run build-bundle && npm run build-bundle-dev",
+    "pre-build": "npm run generate-json-schema && npm run build-bundle && npm run build-bundle-dev",
+    "generate-json-schema": "node ../../scripts/generate-json-schema.mjs --schema ./dist/rad-zod-schema.js --export RADMetadataJSONSchema --output ./dist/rad-metadata.schema.json --id https://unpkg.com/@loaders.gl/splats/rad-metadata.schema.json --title 'loaders.gl Spark RAD metadata' && node ../../scripts/generate-json-schema.mjs --schema ./dist/rad-zod-schema.js --export RADChunkMetadataJSONSchema --output ./dist/radc-metadata.schema.json --id https://unpkg.com/@loaders.gl/splats/radc-metadata.schema.json --title 'loaders.gl Spark RADC chunk metadata'",
     "build-bundle": "ocular-bundle ./bundle.ts --output=dist/dist.min.js",
     "build-bundle-dev": "ocular-bundle ./bundle.ts --env=dev --output=dist/dist.dev.js"
   },
@@ -73,7 +81,8 @@
     "@loaders.gl/compression": "5.0.0-alpha.1",
     "@loaders.gl/loader-utils": "5.0.0-alpha.1",
     "@loaders.gl/schema": "5.0.0-alpha.1",
-    "apache-arrow": ">= 17.0.0"
+    "apache-arrow": ">= 17.0.0",
+    "zod": "^4.1.12"
   },
   "devDependencies": {
     "zstd-codec": "^0.1.0"

--- a/modules/splats/src/index.ts
+++ b/modules/splats/src/index.ts
@@ -5,12 +5,14 @@
 export type {GaussianSplats, SplatsLoaderOptions} from './types';
 export type {
   RADChunkMetadata,
+  RADChunkMetadataJSON,
   RADChunkProperty,
   RADChunkPropertyCompression,
   RADChunkPropertyEncoding,
   RADChunkPropertyName,
   RADChunkRange,
   RADMetadata,
+  RADMetadataJSON,
   RADSplatEncoding
 } from './lib/parse-rad';
 export {SPLATFormat, KSPLATFormat, SPZFormat, RADFormat} from './splats-format';

--- a/modules/splats/src/lib/parse-rad.ts
+++ b/modules/splats/src/lib/parse-rad.ts
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
+import {RADChunkMetadataJSONSchema, RADMetadataJSONSchema} from '../rad-zod-schema';
+
 const RAD_MAGIC = 0x30444152;
 const RAD_CHUNK_MAGIC = 0x43444152;
 const RAD_HEADER_BYTE_LENGTH = 8;
@@ -26,6 +28,8 @@ export type RADSplatEncoding = {
   sh3Max?: number;
   /** Whether opacity is encoded for LoD blending. */
   lodOpacity?: boolean;
+  /** Additional splat-encoding properties are preserved verbatim. */
+  [key: string]: unknown;
 };
 
 /** One RAD chunk location in the top-level RAD chunk table. */
@@ -40,14 +44,16 @@ export type RADChunkRange = {
   count?: number;
   /** Optional sidecar `.radc` filename relative to the RAD file URL. */
   filename?: string;
+  /** Additional chunk-range properties are preserved verbatim. */
+  [key: string]: unknown;
 };
 
-/** Parsed Spark RAD top-level metadata with loader-derived byte offsets. */
-export type RADMetadata = {
+/** Handwritten type for the JSON metadata stored in a Spark RAD header. */
+export type RADMetadataJSON = {
   /** RAD container version. Version 1 is currently supported. */
-  version: number;
+  version: 1;
   /** RAD payload type. Spark currently writes `gsplat`. */
-  type: string;
+  type: 'gsplat';
   /** Total splat count represented by the RAD source. */
   count: number;
   /** Maximum spherical harmonics degree present in the chunks. */
@@ -66,6 +72,12 @@ export type RADMetadata = {
   shCodeCount?: number;
   /** Optional RAD writer comment. */
   comment?: string;
+  /** Additional RAD metadata properties are preserved verbatim. */
+  [key: string]: unknown;
+};
+
+/** Parsed Spark RAD top-level metadata with loader-derived byte offsets. */
+export type RADMetadata = RADMetadataJSON & {
   /** Byte length of the JSON metadata block. */
   headerJsonByteLength: number;
   /** Byte offset where inline RAD chunks begin. */
@@ -124,12 +136,14 @@ export type RADChunkProperty = {
   min?: number;
   /** Optional decode maximum for quantized properties. */
   max?: number;
+  /** Additional chunk-property metadata is preserved verbatim. */
+  [key: string]: unknown;
 };
 
-/** Parsed Spark RADC chunk metadata with loader-derived byte offsets. */
-export type RADChunkMetadata = {
+/** Handwritten type for the JSON metadata stored in a Spark RADC chunk header. */
+export type RADChunkMetadataJSON = {
   /** RAD chunk version. Version 1 is currently supported. */
-  version: number;
+  version: 1;
   /** First global splat index represented by this chunk. */
   base: number;
   /** Number of splats represented by this chunk. */
@@ -144,6 +158,12 @@ export type RADChunkMetadata = {
   splatEncoding?: RADSplatEncoding;
   /** Property table for the chunk payload. */
   properties: RADChunkProperty[];
+  /** Additional RADC metadata properties are preserved verbatim. */
+  [key: string]: unknown;
+};
+
+/** Parsed Spark RADC chunk metadata with loader-derived byte offsets. */
+export type RADChunkMetadata = RADChunkMetadataJSON & {
   /** Byte length of the chunk JSON metadata block. */
   headerJsonByteLength: number;
   /** Byte offset where the chunk payload begins. */
@@ -191,9 +211,11 @@ export function tryParseRADHeader(data: ArrayBuffer | ArrayBufferView): RADMetad
     return null;
   }
 
-  const rawMetadata = parseJSONRecord(
-    bytes.subarray(RAD_HEADER_BYTE_LENGTH, headerJsonEnd),
-    'RADLoader: failed to parse RAD metadata JSON.'
+  const rawMetadata = RADMetadataJSONSchema.parse(
+    parseJSON(
+      bytes.subarray(RAD_HEADER_BYTE_LENGTH, headerJsonEnd),
+      'RADLoader: failed to parse RAD metadata JSON.'
+    )
   );
   return normalizeRADMetadata(rawMetadata, headerJsonByteLength);
 }
@@ -219,9 +241,11 @@ export function parseRADChunkHeader(data: ArrayBuffer | ArrayBufferView): RADChu
     throw new Error('RADLoader: RADC chunk must contain a complete metadata header.');
   }
 
-  const rawMetadata = parseJSONRecord(
-    bytes.subarray(RAD_HEADER_BYTE_LENGTH, headerJsonEnd),
-    'RADLoader: failed to parse RADC metadata JSON.'
+  const rawMetadata = RADChunkMetadataJSONSchema.parse(
+    parseJSON(
+      bytes.subarray(RAD_HEADER_BYTE_LENGTH, headerJsonEnd),
+      'RADLoader: failed to parse RADC metadata JSON.'
+    )
   );
   const payloadBytes = readSafeUint64(
     dataView,
@@ -242,186 +266,41 @@ export function roundUpToEight(byteLength: number): number {
 }
 
 function normalizeRADMetadata(
-  rawMetadata: Record<string, unknown>,
+  rawMetadata: RADMetadataJSON,
   headerJsonByteLength: number
 ): RADMetadata {
-  const version = requireSafeInteger(rawMetadata.version, 'RAD version');
-  if (version !== 1) {
-    throw new Error(`RADLoader: version ${version} is not supported.`);
-  }
-
-  const type = requireString(rawMetadata.type, 'RAD type');
-  if (type !== 'gsplat') {
-    throw new Error(`RADLoader: RAD type ${type} is not supported.`);
-  }
-
-  const chunks = requireArray(rawMetadata.chunks, 'RAD chunks').map((chunk, chunkIndex) =>
-    normalizeRADChunkRange(chunk, chunkIndex)
-  );
-  const metadata: RADMetadata = {
-    version,
-    type,
-    count: requireSafeInteger(rawMetadata.count, 'RAD count'),
-    maxSh: optionalSafeInteger(rawMetadata.maxSh, 'RAD maxSh'),
-    lodTree: optionalBoolean(rawMetadata.lodTree, 'RAD lodTree'),
-    chunkSize: optionalSafeInteger(rawMetadata.chunkSize, 'RAD chunkSize'),
-    allChunkBytes: optionalSafeInteger(rawMetadata.allChunkBytes, 'RAD allChunkBytes'),
-    chunks,
-    splatEncoding: optionalSplatEncoding(rawMetadata.splatEncoding, 'RAD splatEncoding'),
-    shCodeCount: optionalSafeInteger(rawMetadata.shCodeCount, 'RAD shCodeCount'),
-    comment: optionalString(rawMetadata.comment, 'RAD comment'),
+  return {
+    ...rawMetadata,
     headerJsonByteLength,
     chunksByteOffset: RAD_HEADER_BYTE_LENGTH + roundUpToEight(headerJsonByteLength)
-  };
-
-  return metadata;
-}
-
-function normalizeRADChunkRange(rawChunk: unknown, chunkIndex: number): RADChunkRange {
-  const chunk = requireRecord(rawChunk, `RAD chunk ${chunkIndex}`);
-  return {
-    offset: requireSafeInteger(chunk.offset, `RAD chunk ${chunkIndex} offset`),
-    bytes: requireSafeInteger(chunk.bytes, `RAD chunk ${chunkIndex} bytes`),
-    base: optionalSafeInteger(chunk.base, `RAD chunk ${chunkIndex} base`),
-    count: optionalSafeInteger(chunk.count, `RAD chunk ${chunkIndex} count`),
-    filename: optionalString(chunk.filename, `RAD chunk ${chunkIndex} filename`)
   };
 }
 
 function normalizeRADChunkMetadata(
-  rawMetadata: Record<string, unknown>,
+  rawMetadata: RADChunkMetadataJSON,
   headerJsonByteLength: number,
   payloadByteOffset: number,
   payloadBytes: number
 ): RADChunkMetadata {
-  const version = requireSafeInteger(rawMetadata.version, 'RADC version');
-  if (version !== 1) {
-    throw new Error(`RADLoader: RADC version ${version} is not supported.`);
-  }
-
-  const metadataPayloadBytes = requireSafeInteger(rawMetadata.payloadBytes, 'RADC payloadBytes');
-  if (metadataPayloadBytes !== payloadBytes) {
+  if (rawMetadata.payloadBytes !== payloadBytes) {
     throw new Error('RADLoader: RADC metadata payload byte length does not match binary header.');
   }
 
   return {
-    version,
-    base: requireSafeInteger(rawMetadata.base, 'RADC base'),
-    count: requireSafeInteger(rawMetadata.count, 'RADC count'),
+    ...rawMetadata,
     payloadBytes,
-    maxSh: optionalSafeInteger(rawMetadata.maxSh, 'RADC maxSh'),
-    lodTree: optionalBoolean(rawMetadata.lodTree, 'RADC lodTree'),
-    splatEncoding: optionalSplatEncoding(rawMetadata.splatEncoding, 'RADC splatEncoding'),
-    properties: requireArray(rawMetadata.properties, 'RADC properties').map((property, index) =>
-      normalizeRADChunkProperty(property, index)
-    ),
     headerJsonByteLength,
     payloadByteOffset,
     chunkByteLength: payloadByteOffset + payloadBytes
   };
 }
 
-function normalizeRADChunkProperty(rawProperty: unknown, propertyIndex: number): RADChunkProperty {
-  const property = requireRecord(rawProperty, `RADC property ${propertyIndex}`);
-  return {
-    offset: requireSafeInteger(property.offset, `RADC property ${propertyIndex} offset`),
-    bytes: requireSafeInteger(property.bytes, `RADC property ${propertyIndex} bytes`),
-    property: requireString(property.property, `RADC property ${propertyIndex} name`),
-    encoding: requireString(property.encoding, `RADC property ${propertyIndex} encoding`),
-    compression: optionalString(property.compression, `RADC property ${propertyIndex} compression`),
-    min: optionalFiniteNumber(property.min, `RADC property ${propertyIndex} min`),
-    max: optionalFiniteNumber(property.max, `RADC property ${propertyIndex} max`)
-  };
-}
-
-function optionalSplatEncoding(value: unknown, fieldName: string): RADSplatEncoding | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  const encoding = requireRecord(value, fieldName);
-  return {
-    rgbMin: optionalFiniteNumber(encoding.rgbMin, `${fieldName}.rgbMin`),
-    rgbMax: optionalFiniteNumber(encoding.rgbMax, `${fieldName}.rgbMax`),
-    lnScaleMin: optionalFiniteNumber(encoding.lnScaleMin, `${fieldName}.lnScaleMin`),
-    lnScaleMax: optionalFiniteNumber(encoding.lnScaleMax, `${fieldName}.lnScaleMax`),
-    sh1Max: optionalFiniteNumber(encoding.sh1Max, `${fieldName}.sh1Max`),
-    sh2Max: optionalFiniteNumber(encoding.sh2Max, `${fieldName}.sh2Max`),
-    sh3Max: optionalFiniteNumber(encoding.sh3Max, `${fieldName}.sh3Max`),
-    lodOpacity: optionalBoolean(encoding.lodOpacity, `${fieldName}.lodOpacity`)
-  };
-}
-
-function parseJSONRecord(bytes: Uint8Array, message: string): Record<string, unknown> {
+function parseJSON(bytes: Uint8Array, message: string): unknown {
   try {
-    return requireRecord(JSON.parse(TEXT_DECODER.decode(bytes)), message);
-  } catch (error) {
-    if (error instanceof Error && error.message.startsWith('RADLoader:')) {
-      throw error;
-    }
+    return JSON.parse(TEXT_DECODER.decode(bytes));
+  } catch {
     throw new Error(message);
   }
-}
-
-function requireRecord(value: unknown, fieldName: string): Record<string, unknown> {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    throw new Error(`RADLoader: ${fieldName} must be an object.`);
-  }
-  return value as Record<string, unknown>;
-}
-
-function requireArray(value: unknown, fieldName: string): unknown[] {
-  if (!Array.isArray(value)) {
-    throw new Error(`RADLoader: ${fieldName} must be an array.`);
-  }
-  return value;
-}
-
-function requireString(value: unknown, fieldName: string): string {
-  if (typeof value !== 'string') {
-    throw new Error(`RADLoader: ${fieldName} must be a string.`);
-  }
-  return value;
-}
-
-function optionalString(value: unknown, fieldName: string): string | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  return requireString(value, fieldName);
-}
-
-function optionalBoolean(value: unknown, fieldName: string): boolean | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  if (typeof value !== 'boolean') {
-    throw new Error(`RADLoader: ${fieldName} must be a boolean.`);
-  }
-  return value;
-}
-
-function requireSafeInteger(value: unknown, fieldName: string): number {
-  if (!Number.isSafeInteger(value) || Number(value) < 0) {
-    throw new Error(`RADLoader: ${fieldName} must be a non-negative safe integer.`);
-  }
-  return Number(value);
-}
-
-function optionalSafeInteger(value: unknown, fieldName: string): number | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  return requireSafeInteger(value, fieldName);
-}
-
-function optionalFiniteNumber(value: unknown, fieldName: string): number | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    throw new Error(`RADLoader: ${fieldName} must be a finite number.`);
-  }
-  return value;
 }
 
 function readSafeUint64(dataView: DataView, byteOffset: number, fieldName: string): number {

--- a/modules/splats/src/rad-zod-schema.ts
+++ b/modules/splats/src/rad-zod-schema.ts
@@ -1,0 +1,83 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {z} from 'zod';
+import type {
+  RADChunkMetadataJSON,
+  RADChunkProperty,
+  RADChunkRange,
+  RADMetadataJSON,
+  RADSplatEncoding
+} from './lib/parse-rad';
+
+const nonNegativeSafeIntegerSchema = z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER);
+
+/** Zod schema for Spark RAD splat quantization and shader decode ranges. */
+export const RADSplatEncodingSchema = z
+  .object({
+    rgbMin: z.number().finite().optional(),
+    rgbMax: z.number().finite().optional(),
+    lnScaleMin: z.number().finite().optional(),
+    lnScaleMax: z.number().finite().optional(),
+    sh1Max: z.number().finite().optional(),
+    sh2Max: z.number().finite().optional(),
+    sh3Max: z.number().finite().optional(),
+    lodOpacity: z.boolean().optional()
+  })
+  .passthrough() satisfies z.ZodType<RADSplatEncoding>;
+
+/** Zod schema for one chunk-table entry in top-level RAD metadata. */
+export const RADChunkRangeSchema = z
+  .object({
+    offset: nonNegativeSafeIntegerSchema,
+    bytes: nonNegativeSafeIntegerSchema,
+    base: nonNegativeSafeIntegerSchema.optional(),
+    count: nonNegativeSafeIntegerSchema.optional(),
+    filename: z.string().optional()
+  })
+  .passthrough() satisfies z.ZodType<RADChunkRange>;
+
+/** Zod schema for raw JSON metadata stored in a Spark RAD header. */
+export const RADMetadataJSONSchema = z
+  .object({
+    version: z.literal(1),
+    type: z.literal('gsplat'),
+    count: nonNegativeSafeIntegerSchema,
+    maxSh: nonNegativeSafeIntegerSchema.optional(),
+    lodTree: z.boolean().optional(),
+    chunkSize: nonNegativeSafeIntegerSchema.optional(),
+    allChunkBytes: nonNegativeSafeIntegerSchema.optional(),
+    chunks: z.array(RADChunkRangeSchema),
+    splatEncoding: RADSplatEncodingSchema.optional(),
+    shCodeCount: nonNegativeSafeIntegerSchema.optional(),
+    comment: z.string().optional()
+  })
+  .passthrough() satisfies z.ZodType<RADMetadataJSON>;
+
+/** Zod schema for one property-table entry in RADC metadata. */
+export const RADChunkPropertySchema = z
+  .object({
+    offset: nonNegativeSafeIntegerSchema,
+    bytes: nonNegativeSafeIntegerSchema,
+    property: z.string(),
+    encoding: z.string(),
+    compression: z.string().optional(),
+    min: z.number().finite().optional(),
+    max: z.number().finite().optional()
+  })
+  .passthrough() satisfies z.ZodType<RADChunkProperty>;
+
+/** Zod schema for raw JSON metadata stored in a Spark RADC chunk header. */
+export const RADChunkMetadataJSONSchema = z
+  .object({
+    version: z.literal(1),
+    base: nonNegativeSafeIntegerSchema,
+    count: nonNegativeSafeIntegerSchema,
+    payloadBytes: nonNegativeSafeIntegerSchema,
+    maxSh: nonNegativeSafeIntegerSchema.optional(),
+    lodTree: z.boolean().optional(),
+    splatEncoding: RADSplatEncodingSchema.optional(),
+    properties: z.array(RADChunkPropertySchema)
+  })
+  .passthrough() satisfies z.ZodType<RADChunkMetadataJSON>;

--- a/modules/splats/test/index.ts
+++ b/modules/splats/test/index.ts
@@ -6,3 +6,4 @@ import './splat-loader.spec';
 import './ksplat-loader.spec';
 import './spz-loader.spec';
 import './rad-source-loader.spec';
+import './rad-zod-schema.spec';

--- a/modules/splats/test/rad-zod-schema.spec.ts
+++ b/modules/splats/test/rad-zod-schema.spec.ts
@@ -2,10 +2,15 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {parseRADHeader} from '@loaders.gl/splats/rad-loader';
+import {
+  parseRADChunkHeader,
+  parseRADHeader,
+  tryParseRADHeader
+} from '@loaders.gl/splats/rad-loader';
 import {RADChunkMetadataJSONSchema, RADMetadataJSONSchema} from '@loaders.gl/splats/rad-zod-schema';
 import {describe, expect, it} from 'vitest';
 import {z} from 'zod';
+import {isRAD} from '../src/lib/parse-rad';
 
 describe('RAD metadata schemas', () => {
   it('validates RAD and RADC metadata while preserving extensions', () => {
@@ -49,6 +54,40 @@ describe('RAD metadata schemas', () => {
     ).toBe(false);
   });
 
+  it('recognizes RAD buffers and reports incomplete or malformed headers', () => {
+    const header = makeRADHeader({version: 1, type: 'gsplat', count: 0, chunks: []});
+
+    expect(isRAD(new Uint8Array(header))).toBe(true);
+    expect(isRAD(new Uint8Array(3))).toBe(false);
+    expect(tryParseRADHeader(header.slice(0, 7))).toBeNull();
+    expect(tryParseRADHeader(header.slice(0, 8))).toBeNull();
+    expect(() => parseRADHeader(header.slice(0, 7))).toThrow(/complete RAD metadata header/);
+    expect(() => tryParseRADHeader(new ArrayBuffer(8))).toThrow(/RAD0 magic header/);
+    expect(() => parseRADHeader(makeRADHeaderFromJSON('{'))).toThrow(
+      /failed to parse RAD metadata JSON/
+    );
+  });
+
+  it('validates the RADC binary envelope around schema-validated metadata', () => {
+    const metadata = {version: 1, base: 0, count: 0, payloadBytes: 0, properties: []};
+    const parsedMetadata = parseRADChunkHeader(makeRADCHeader(metadata));
+
+    expect(parsedMetadata.payloadBytes).toBe(0);
+    expect(parsedMetadata.chunkByteLength).toBe(parsedMetadata.payloadByteOffset);
+    expect(() => parseRADChunkHeader(new ArrayBuffer(7))).toThrow(/8-byte metadata header/);
+    expect(() => parseRADChunkHeader(makeIncompleteRADCHeader())).toThrow(
+      /complete metadata header/
+    );
+    expect(() =>
+      parseRADChunkHeader(makeRADCHeader({...metadata, payloadBytes: 1}, {binaryPayloadBytes: 0n}))
+    ).toThrow(/payload byte length does not match/);
+    expect(() =>
+      parseRADChunkHeader(
+        makeRADCHeader(metadata, {binaryPayloadBytes: BigInt(Number.MAX_SAFE_INTEGER) + 1n})
+      )
+    ).toThrow(/exceeds Number.MAX_SAFE_INTEGER/);
+  });
+
   it('exports RAD and RADC JSON Schemas', () => {
     const radJsonSchema = z.toJSONSchema(RADMetadataJSONSchema, {target: 'draft-7'});
     const radcJsonSchema = z.toJSONSchema(RADChunkMetadataJSONSchema, {target: 'draft-7'});
@@ -64,11 +103,52 @@ describe('RAD metadata schemas', () => {
 
 /** Builds a minimal binary RAD header around the supplied JSON metadata. */
 function makeRADHeader(metadata: unknown): ArrayBuffer {
-  const jsonBytes = new TextEncoder().encode(JSON.stringify(metadata));
+  return makeRADHeaderFromJSON(JSON.stringify(metadata));
+}
+
+/** Builds a minimal binary RAD header around the supplied raw JSON text. */
+function makeRADHeaderFromJSON(json: string): ArrayBuffer {
+  const jsonBytes = new TextEncoder().encode(json);
   const data = new ArrayBuffer(8 + jsonBytes.byteLength);
   const dataView = new DataView(data);
   dataView.setUint32(0, 0x30444152, true);
   dataView.setUint32(4, jsonBytes.byteLength, true);
   new Uint8Array(data, 8).set(jsonBytes);
+  return data;
+}
+
+/** Options for building a minimal binary RADC header. */
+type RADCHeaderOptions = {
+  /** Payload byte length stored in the binary envelope. */
+  binaryPayloadBytes?: bigint;
+};
+
+/** Builds a complete binary RADC header around the supplied JSON metadata. */
+function makeRADCHeader(
+  metadata: {payloadBytes: number},
+  options: RADCHeaderOptions = {}
+): ArrayBuffer {
+  const jsonBytes = new TextEncoder().encode(JSON.stringify(metadata));
+  const alignedJsonByteLength = (jsonBytes.byteLength + 7) & ~7;
+  const payloadByteLengthOffset = 8 + alignedJsonByteLength;
+  const data = new ArrayBuffer(payloadByteLengthOffset + 8);
+  const dataView = new DataView(data);
+  dataView.setUint32(0, 0x43444152, true);
+  dataView.setUint32(4, jsonBytes.byteLength, true);
+  new Uint8Array(data, 8).set(jsonBytes);
+  dataView.setBigUint64(
+    payloadByteLengthOffset,
+    options.binaryPayloadBytes ?? BigInt(metadata.payloadBytes),
+    true
+  );
+  return data;
+}
+
+/** Builds a RADC prefix whose declared metadata is not yet fully available. */
+function makeIncompleteRADCHeader(): ArrayBuffer {
+  const data = new ArrayBuffer(8);
+  const dataView = new DataView(data);
+  dataView.setUint32(0, 0x43444152, true);
+  dataView.setUint32(4, 1, true);
   return data;
 }

--- a/modules/splats/test/rad-zod-schema.spec.ts
+++ b/modules/splats/test/rad-zod-schema.spec.ts
@@ -1,0 +1,74 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {parseRADHeader} from '@loaders.gl/splats/rad-loader';
+import {RADChunkMetadataJSONSchema, RADMetadataJSONSchema} from '@loaders.gl/splats/rad-zod-schema';
+import {describe, expect, it} from 'vitest';
+import {z} from 'zod';
+
+describe('RAD metadata schemas', () => {
+  it('validates RAD and RADC metadata while preserving extensions', () => {
+    const metadata = RADMetadataJSONSchema.parse({
+      version: 1,
+      type: 'gsplat',
+      count: 2,
+      maxSh: 3,
+      chunks: [{offset: 0, bytes: 128, vendorChunk: true}],
+      splatEncoding: {rgbMin: 0, rgbMax: 1, lodOpacity: true},
+      vendor: {generator: 'Spark'}
+    });
+    const chunkMetadata = RADChunkMetadataJSONSchema.parse({
+      version: 1,
+      base: 0,
+      count: 2,
+      payloadBytes: 128,
+      properties: [
+        {offset: 0, bytes: 24, property: 'center', encoding: 'f32_lebytes', vendor: true}
+      ],
+      vendor: {chunk: 0}
+    });
+
+    expect(metadata.vendor).toEqual({generator: 'Spark'});
+    expect(metadata.chunks[0].vendorChunk).toBe(true);
+    expect(chunkMetadata.vendor).toEqual({chunk: 0});
+    expect(chunkMetadata.properties[0].vendor).toBe(true);
+  });
+
+  it('rejects unsupported and unsafe metadata at the parser boundary', () => {
+    expect(() =>
+      parseRADHeader(makeRADHeader({version: 2, type: 'gsplat', count: 0, chunks: []}))
+    ).toThrow();
+    expect(
+      RADMetadataJSONSchema.safeParse({
+        version: 1,
+        type: 'gsplat',
+        count: Number.MAX_SAFE_INTEGER + 1,
+        chunks: []
+      }).success
+    ).toBe(false);
+  });
+
+  it('exports RAD and RADC JSON Schemas', () => {
+    const radJsonSchema = z.toJSONSchema(RADMetadataJSONSchema, {target: 'draft-7'});
+    const radcJsonSchema = z.toJSONSchema(RADChunkMetadataJSONSchema, {target: 'draft-7'});
+
+    expect(radJsonSchema.required).toEqual(
+      expect.arrayContaining(['version', 'type', 'count', 'chunks'])
+    );
+    expect(radcJsonSchema.required).toEqual(
+      expect.arrayContaining(['version', 'base', 'count', 'payloadBytes', 'properties'])
+    );
+  });
+});
+
+/** Builds a minimal binary RAD header around the supplied JSON metadata. */
+function makeRADHeader(metadata: unknown): ArrayBuffer {
+  const jsonBytes = new TextEncoder().encode(JSON.stringify(metadata));
+  const data = new ArrayBuffer(8 + jsonBytes.byteLength);
+  const dataView = new DataView(data);
+  dataView.setUint32(0, 0x30444152, true);
+  dataView.setUint32(4, jsonBytes.byteLength, true);
+  new Uint8Array(data, 8).set(jsonBytes);
+  return data;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5808,6 +5808,7 @@ __metadata:
     "@loaders.gl/loader-utils": "npm:5.0.0-alpha.1"
     "@loaders.gl/schema": "npm:5.0.0-alpha.1"
     apache-arrow: "npm:>= 17.0.0"
+    zod: "npm:^4.1.12"
     zstd-codec: "npm:^0.1.0"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0


### PR DESCRIPTION
## Goals

- Add runtime validation for Spark RAD and RADC metadata at their parser boundaries.
- Keep the handwritten TypeScript types and TSDoc as the authoritative public API.
- Publish reusable draft-07 JSON Schemas from explicitly named Zod schema modules.
- Preserve forward-compatible extension properties without reducing test coverage.

## Changes

- Adds `@loaders.gl/splats/rad-zod-schema` with `RADMetadataJSONSchema`, `RADChunkMetadataJSONSchema`, and their nested schemas, all constrained against handwritten types with `satisfies z.ZodType<...>`.
- Keeps and expands the documented handwritten RAD/RADC metadata types; no public type is generated with `z.infer`.
- Validates top-level RAD and RADC chunk metadata before adding loader-derived byte offsets.
- Preserves unknown extension properties at the top level and in nested chunk, property, and encoding objects.
- Publishes `rad-metadata.schema.json` and `radc-metadata.schema.json` package assets.
- Adds the schema subpath and JSON Schema exports without exporting runtime schemas from the package root.
- Adds schema validation, extension preservation, unsafe-integer rejection, incremental-header, malformed-JSON, payload-envelope, and JSON Schema conversion tests.
- Updates the v5 splats release notes.

## Validation

- `yarn lint fix`
- `yarn build`
- Focused post-rebase Node coverage: 2 files / 13 tests passed; `rad-zod-schema.ts` is 6/6 lines and `parse-rad.ts` is 55/55 lines, 22/22 branches, and 10/10 functions
- Focused post-rebase headless coverage: 2 files / 13 tests passed with the same full RAD schema/parser coverage
- `yarn test-node` — 414 files passed, 1,982 tests passed before the final clean rebase
- `yarn test-headless` — 414 files passed, 1,943 tests passed before the final clean rebase
