### PR TITLE
feat(parquet): materialize TypeScript Arrow columns directly

### DIFF
--- a/docs/modules/parquet/api-reference/parquet-loader.md
+++ b/docs/modules/parquet/api-reference/parquet-loader.md
@@ -184,8 +184,9 @@ const table = await load(url, ParquetJSLoader, {
 });
 ```
 
-For `shape: 'arrow-table'`, `ParquetJSLoader` converts its decoded rows to an Apache Arrow table and
-preserves compatible GeoParquet metadata on the Arrow schema.
+For `shape: 'arrow-table'`, `ParquetJSLoader` materializes flat selected columns directly into Apache
+Arrow batches and preserves compatible GeoParquet metadata on the Arrow schema. Nested schemas use
+the object-row materializer as a compatibility fallback.
 
 ## Worker Execution
 
@@ -197,13 +198,14 @@ Set `core.worker: false` to decode on the calling thread. `ParquetJSLoader` alwa
 
 ## Live Benchmarks
 
-These benchmarks compare maintained JavaScript and WebAssembly object-row decode paths on common,
+These benchmarks compare maintained JavaScript and WebAssembly Arrow-table decode paths on common,
 checked-in fixtures. They are a reproducible baseline for finding optimization opportunities in the
 loaders.gl TypeScript backend, not a ranking of projects.
 
 The suite runs entirely in your browser. Fixture download and parser initialization happen before
-timing; each implementation is warmed up and must return the same row count. Results depend on the
-browser, hardware, thermal state, and whether this tab remains focused.
+timing; each implementation is warmed up and must return the same row count. The suite focuses on
+Arrow output and retains one object-row control to expose row-materialization cost. Results depend on
+the browser, hardware, thermal state, and whether this tab remains focused.
 
 The live suite includes both loaders.gl loader variants plus a browser-oriented peer reader.
 Dependency versions are pinned in the repository lockfile. The corresponding Node suite covers

--- a/modules/parquet/src/lib/parsers/parse-parquet-to-arrow-js.ts
+++ b/modules/parquet/src/lib/parsers/parse-parquet-to-arrow-js.ts
@@ -111,11 +111,11 @@ export async function* parseParquetFileToArrowInBatchesWithJs(
     for (let batchStart = selectionStart; batchStart < selectionEnd; batchStart += batchSize) {
       const batchEnd = Math.min(batchStart + batchSize, selectionEnd);
       const batchTable = sliceDecodedTable(decodedTable, batchStart, batchEnd);
+      const length = batchEnd - batchStart;
       const arrowTable = normalizeArrowTableGeoMetadata(
-        convertDecodedTableToArrow(batchTable),
+        convertDecodedTableToArrow(batchTable, length),
         schema.metadata
       );
-      const length = batchEnd - batchStart;
 
       yield {
         batchType: 'data',
@@ -134,7 +134,10 @@ export async function* parseParquetFileToArrowInBatchesWithJs(
 }
 
 /** Builds Arrow vectors directly from flat decoded columns and falls back for nested row tables. */
-function convertDecodedTableToArrow(table: ColumnarTable | ObjectRowTable): ArrowTable {
+function convertDecodedTableToArrow(
+  table: ColumnarTable | ObjectRowTable,
+  rowCount: number
+): ArrowTable {
   if (table.shape === 'object-row-table') {
     return convertTable(table, 'arrow-table');
   }
@@ -152,8 +155,28 @@ function convertDecodedTableToArrow(table: ColumnarTable | ObjectRowTable): Arro
   return {
     shape: 'arrow-table',
     schema: table.schema,
-    data: new arrow.Table(arrowSchema, vectors)
+    data: createArrowTable(arrowSchema, vectors, rowCount)
   };
+}
+
+/** Creates an Arrow table while retaining row counts for a schema with no projected fields. */
+function createArrowTable(
+  schema: arrow.Schema,
+  vectors: Record<string, arrow.Vector>,
+  rowCount: number
+): arrow.Table {
+  if (schema.fields.length || rowCount === 0) {
+    return new arrow.Table(schema, vectors);
+  }
+
+  const recordBatch = new arrow.RecordBatch(
+    schema,
+    arrow.makeData({type: new arrow.Struct([]), children: []})
+  );
+  // Apache Arrow JS derives RecordBatch length from its children and therefore resets an empty
+  // Struct to zero rows. Restore the explicit Parquet selection length after construction.
+  Object.defineProperty(recordBatch.data, 'length', {value: rowCount});
+  return new arrow.Table(schema, [recordBatch]);
 }
 
 /** Normalizes JavaScript values that Apache Arrow's 64-bit integer builders require as bigints. */

--- a/modules/parquet/src/lib/parsers/parse-parquet-to-arrow-js.ts
+++ b/modules/parquet/src/lib/parsers/parse-parquet-to-arrow-js.ts
@@ -4,15 +4,27 @@
 
 import * as arrow from 'apache-arrow';
 import type {ReadableFile} from '@loaders.gl/loader-utils';
-import type {ArrowTable, ArrowTableBatch} from '@loaders.gl/schema';
+import type {
+  ArrayType,
+  ArrowTable,
+  ArrowTableBatch,
+  ColumnarTable,
+  ObjectRowTable,
+  Schema
+} from '@loaders.gl/schema';
 import {convertSchemaToArrow, convertTable} from '@loaders.gl/schema-utils';
 
 import type {ParquetJSLoaderOptions} from '../../parquet-loader-options';
+import {preloadCompressions} from '../../parquetjs/compression';
+import {ParquetReader} from '../../parquetjs/parser/parquet-reader';
+import type {ParquetRowGroup} from '../../parquetjs/schema/declare';
+import type {ParquetSchema} from '../../parquetjs/schema/schema';
+import {materializeColumns, materializeRows} from '../../parquetjs/schema/shred';
 import {normalizeArrowTableGeoMetadata} from '../geo/geospatial-metadata';
-import {parseParquetFile, parseParquetFileInBatches} from './parse-parquet-to-json';
+import {getSchemaFromParquetReader} from './get-parquet-schema';
 
 /**
- * Parses a Parquet file with the TypeScript implementation and converts the decoded rows to Arrow.
+ * Parses a Parquet file with the TypeScript implementation directly into Arrow batches.
  * @param file readable Parquet file
  * @param options loader options applied before Arrow conversion
  * @returns Arrow table containing the decoded rows
@@ -21,20 +33,38 @@ export async function parseParquetFileToArrowWithJs(
   file: ReadableFile,
   options?: ParquetJSLoaderOptions
 ): Promise<ArrowTable> {
-  const objectRowTable = await parseParquetFile(file, options);
-  if (objectRowTable.data.length === 0 && objectRowTable.schema) {
-    const arrowSchema = convertSchemaToArrow(objectRowTable.schema);
-    return normalizeArrowTableGeoMetadata({
-      shape: 'arrow-table',
-      schema: objectRowTable.schema,
-      data: new arrow.Table(arrowSchema, [])
-    });
+  const recordBatches: arrow.RecordBatch[] = [];
+  let schema: Schema | undefined;
+
+  for await (const batch of parseParquetFileToArrowInBatchesWithJs(file, options)) {
+    schema ||= batch.schema;
+    recordBatches.push(...batch.data.batches);
   }
-  return normalizeArrowTableGeoMetadata(convertTable(objectRowTable, 'arrow-table'));
+
+  schema ||= await readProjectedSchema(file, options);
+  const table = recordBatches.length
+    ? new arrow.Table(recordBatches)
+    : new arrow.Table(convertSchemaToArrow(schema), []);
+  return normalizeArrowTableGeoMetadata(
+    {shape: 'arrow-table', data: table, schema},
+    schema.metadata
+  );
+}
+
+/** Reads the projected loaders.gl schema when row selection produces no Arrow record batches. */
+async function readProjectedSchema(
+  file: ReadableFile,
+  options?: ParquetJSLoaderOptions
+): Promise<Schema> {
+  const reader = new ParquetReader(file, {
+    preserveBinary: options?.parquet?.preserveBinary
+  });
+  return projectSchema(await getSchemaFromParquetReader(reader), options?.parquet?.columns);
 }
 
 /**
- * Parses a Parquet file in batches with the TypeScript implementation and converts each batch to Arrow.
+ * Parses a Parquet file in batches with the TypeScript implementation and materializes Arrow directly
+ * from decoded columns whenever the selected schema is flat.
  * @param file readable Parquet file
  * @param options loader options applied before Arrow conversion
  * @returns asynchronous Arrow table batches
@@ -43,15 +73,184 @@ export async function* parseParquetFileToArrowInBatchesWithJs(
   file: ReadableFile,
   options?: ParquetJSLoaderOptions
 ): AsyncIterable<ArrowTableBatch> {
-  for await (const batch of parseParquetFileInBatches(file, options)) {
-    const arrowTable = normalizeArrowTableGeoMetadata(convertTable(batch, 'arrow-table'));
+  await preloadCompressions(options);
 
-    yield {
-      batchType: batch.batchType,
-      shape: arrowTable.shape,
-      schema: arrowTable.schema,
-      data: arrowTable.data,
-      length: batch.length
+  const reader = new ParquetReader(file, {
+    preserveBinary: options?.parquet?.preserveBinary
+  });
+  const schema = projectSchema(await getSchemaFromParquetReader(reader), options?.parquet?.columns);
+  const parquetSchema = await reader.getSchema();
+  const rowGroups = reader.rowGroupIterator(getParquetIterationProps(options));
+  const rowOffset = Math.max(0, options?.parquet?.offset || 0);
+  const rowLimit = options?.parquet?.limit;
+  const requestedBatchSize = options?.parquet?.batchSize;
+  let rowsVisited = 0;
+  let rowsYielded = 0;
+
+  for await (const rowGroup of rowGroups) {
+    const selectionStart = Math.min(rowGroup.rowCount, Math.max(0, rowOffset - rowsVisited));
+    const availableRowCount = rowGroup.rowCount - selectionStart;
+    const remainingRowCount =
+      rowLimit === undefined
+        ? availableRowCount
+        : Math.max(0, Math.min(availableRowCount, rowLimit - rowsYielded));
+    const selectionEnd = selectionStart + remainingRowCount;
+    rowsVisited += rowGroup.rowCount;
+
+    if (selectionEnd <= selectionStart) {
+      if (rowLimit !== undefined && rowsYielded >= rowLimit) {
+        return;
+      }
+      continue;
+    }
+
+    const decodedTable = materializeRowGroup(schema, parquetSchema, rowGroup);
+    const batchSize =
+      requestedBatchSize && requestedBatchSize > 0 ? requestedBatchSize : remainingRowCount;
+
+    for (let batchStart = selectionStart; batchStart < selectionEnd; batchStart += batchSize) {
+      const batchEnd = Math.min(batchStart + batchSize, selectionEnd);
+      const batchTable = sliceDecodedTable(decodedTable, batchStart, batchEnd);
+      const arrowTable = normalizeArrowTableGeoMetadata(
+        convertDecodedTableToArrow(batchTable),
+        schema.metadata
+      );
+      const length = batchEnd - batchStart;
+
+      yield {
+        batchType: 'data',
+        shape: arrowTable.shape,
+        schema: arrowTable.schema,
+        data: arrowTable.data,
+        length
+      };
+      rowsYielded += length;
+    }
+
+    if (rowLimit !== undefined && rowsYielded >= rowLimit) {
+      return;
+    }
+  }
+}
+
+/** Builds Arrow vectors directly from flat decoded columns and falls back for nested row tables. */
+function convertDecodedTableToArrow(table: ColumnarTable | ObjectRowTable): ArrowTable {
+  if (table.shape === 'object-row-table') {
+    return convertTable(table, 'arrow-table');
+  }
+
+  const arrowSchema = convertSchemaToArrow(table.schema!);
+  const vectors: Record<string, arrow.Vector> = {};
+  for (const field of arrowSchema.fields) {
+    const column = table.data[field.name];
+    vectors[field.name] = arrow.vectorFromArray(
+      normalizeArrowColumn(column, field.type),
+      field.type
+    );
+  }
+
+  return {
+    shape: 'arrow-table',
+    schema: table.schema,
+    data: new arrow.Table(arrowSchema, vectors)
+  };
+}
+
+/** Normalizes JavaScript values that Apache Arrow's 64-bit integer builders require as bigints. */
+function normalizeArrowColumn(
+  column: ArrayLike<unknown>,
+  type: arrow.DataType
+): readonly unknown[] {
+  if (!(type instanceof arrow.Int) || type.bitWidth !== 64) {
+    return column as readonly unknown[];
+  }
+
+  return Array.from(column, value => {
+    if (value === null || value === undefined || typeof value === 'bigint') {
+      return value;
+    }
+    if (value instanceof Date) {
+      return BigInt(value.getTime());
+    }
+    return BigInt(value as number | string);
+  });
+}
+
+/** Materializes one decoded row group in the cheapest shape supported by its selected schema. */
+function materializeRowGroup(
+  schema: Schema,
+  parquetSchema: ParquetSchema,
+  rowGroup: ParquetRowGroup
+): ColumnarTable | ObjectRowTable {
+  if (Object.keys(rowGroup.columnData).every(columnKey => !columnKey.includes(','))) {
+    return {
+      shape: 'columnar-table',
+      schema,
+      data: materializeColumns(parquetSchema, rowGroup)
     };
   }
+
+  return {
+    shape: 'object-row-table',
+    schema,
+    data: materializeRows(parquetSchema, rowGroup)
+  };
+}
+
+/** Slices a decoded table without transposing its rows or columns. */
+function sliceDecodedTable(
+  table: ColumnarTable | ObjectRowTable,
+  start: number,
+  end: number
+): ColumnarTable | ObjectRowTable {
+  if (start === 0 && end === getDecodedTableLength(table)) {
+    return table;
+  }
+
+  if (table.shape === 'object-row-table') {
+    return {...table, data: table.data.slice(start, end)};
+  }
+
+  const data: Record<string, ArrayLike<unknown>> = {};
+  for (const [columnName, column] of Object.entries(table.data)) {
+    data[columnName] = sliceColumn(column, start, end);
+  }
+  return {...table, data};
+}
+
+/** Returns the row count of a decoded row or column table. */
+function getDecodedTableLength(table: ColumnarTable | ObjectRowTable): number {
+  if (table.shape === 'object-row-table') {
+    return table.data.length;
+  }
+  const firstColumn = Object.values(table.data)[0];
+  return firstColumn?.length || 0;
+}
+
+/** Slices an arbitrary column while preserving efficient native slice implementations. */
+function sliceColumn(column: ArrayLike<unknown>, start: number, end: number): ArrayLike<unknown> {
+  if ('slice' in column && typeof column.slice === 'function') {
+    return (column.slice as (start: number, end: number) => ArrayType)(start, end);
+  }
+  return Array.from(column).slice(start, end);
+}
+
+/** Creates row-group projection properties from public loader options. */
+function getParquetIterationProps(
+  options?: ParquetJSLoaderOptions
+): {columnList?: string[] | string[][]} | undefined {
+  const columnList = options?.parquet?.columns;
+  return columnList?.length ? {columnList} : undefined;
+}
+
+/** Restricts the loaders.gl schema to explicitly selected top-level columns. */
+function projectSchema(schema: Schema, columns?: string[]): Schema {
+  if (!columns?.length) {
+    return schema;
+  }
+
+  return {
+    ...schema,
+    fields: schema.fields.filter(field => columns.includes(field.name))
+  };
 }

--- a/modules/parquet/test/parquet-arrow-loader.spec.ts
+++ b/modules/parquet/test/parquet-arrow-loader.spec.ts
@@ -226,6 +226,28 @@ test('ParquetJSLoader#arrow-table supports loadInBatches', async (t) => {
   t.equal(rowCount, 5, 'returns all requested rows');
   t.end();
 });
+
+test('ParquetJSLoader#empty projection batches preserve their row counts', async (t) => {
+  const url = `${PARQUET_DIR}/apache/good/alltypes_plain.parquet`;
+  const iterator = await loadInBatches(url, ParquetJSLoader, {
+    parquet: {
+      shape: 'arrow-table',
+      columns: ['missing_column'],
+      offset: 2,
+      limit: 3,
+      batchSize: 2
+    }
+  });
+
+  const batchLengths: number[] = [];
+  for await (const batch of iterator) {
+    batchLengths.push(batch.length);
+    t.equal(batch.data.numRows, batch.length, 'Arrow rows match the advertised batch length');
+    t.equal(batch.data.numCols, 0, 'batch contains no projected columns');
+  }
+  t.deepEqual(batchLengths, [2, 1], 'preserves requested batching for empty projections');
+  t.end();
+});
 test('ParquetWriter#Arrow table round trip', async (t) => {
   const table = createArrowTable();
 

--- a/modules/parquet/test/parquet-loader.spec.ts
+++ b/modules/parquet/test/parquet-loader.spec.ts
@@ -146,6 +146,27 @@ test('ParquetJSLoader#arrow-table applies projection, offset, and limit', async 
   t.end();
 });
 
+test('ParquetJSLoader#arrow-table preserves rows for an empty projection', async (t) => {
+  const url = '@loaders.gl/parquet/test/data/apache/good/alltypes_plain.parquet';
+  const table = await load(url, ParquetJSLoader, {
+    core: {worker: false},
+    parquet: {
+      shape: 'arrow-table',
+      columns: ['missing_column'],
+      offset: 2,
+      limit: 3
+    }
+  });
+
+  t.equal(table.shape, 'arrow-table');
+  if (table.shape === 'arrow-table') {
+    t.equal(table.data.numRows, 3, 'preserves the selected row count');
+    t.equal(table.data.numCols, 0, 'returns no projected columns');
+    t.deepEqual(table.data.toArray(), [{}, {}, {}], 'retains empty records for selected rows');
+  }
+  t.end();
+});
+
 test('ParquetJSLoader#arrow-table materializes required INT64 logical values', async (t) => {
   const url = '@loaders.gl/parquet/test/data/fruits.parquet';
   const table = await load(url, ParquetJSLoader, {

--- a/modules/parquet/test/parquet-loader.spec.ts
+++ b/modules/parquet/test/parquet-loader.spec.ts
@@ -111,6 +111,60 @@ test('ParquetJSLoader#load arrow-table preserves schema for empty results', asyn
   t.end();
 });
 
+test('ParquetJSLoader#arrow-table applies projection, offset, and limit', async (t) => {
+  const url = '@loaders.gl/parquet/test/data/apache/good/alltypes_plain.parquet';
+  const options = {
+    core: {worker: false},
+    parquet: {
+      shape: 'arrow-table' as const,
+      columns: ['id', 'bool_col'],
+      offset: 2,
+      limit: 3
+    }
+  };
+  const arrowTable = await load(url, ParquetJSLoader, options);
+  const objectRowTable = await load(url, ParquetJSLoader, {
+    ...options,
+    parquet: {...options.parquet, shape: 'object-row-table'}
+  });
+
+  t.equal(arrowTable.shape, 'arrow-table');
+  t.equal(objectRowTable.shape, 'object-row-table');
+  if (arrowTable.shape === 'arrow-table' && objectRowTable.shape === 'object-row-table') {
+    t.equal(arrowTable.data.numRows, 3, 'returns the requested row range');
+    t.deepEqual(
+      arrowTable.schema?.fields.map(field => field.name),
+      ['id', 'bool_col'],
+      'returns only projected columns'
+    );
+    t.deepEqual(
+      arrowTable.data.getChild('id')?.toArray(),
+      new Int32Array(objectRowTable.data.map(row => row.id)),
+      'direct Arrow values match object-row decoding'
+    );
+  }
+  t.end();
+});
+
+test('ParquetJSLoader#arrow-table materializes required INT64 logical values', async (t) => {
+  const url = '@loaders.gl/parquet/test/data/fruits.parquet';
+  const table = await load(url, ParquetJSLoader, {
+    core: {worker: false},
+    parquet: {shape: 'arrow-table', columns: ['date'], limit: 1}
+  });
+
+  t.equal(table.shape, 'arrow-table');
+  if (table.shape === 'arrow-table') {
+    t.equal(table.data.numRows, 1);
+    t.equal(
+      table.data.getChild('date')?.get(0),
+      1625040045218n,
+      'converts the timestamp value for the Arrow Int64 vector'
+    );
+  }
+  t.end();
+});
+
 test('ParquetJSLoader#load alltypes_plain file', async (t) => {
   const url = '@loaders.gl/parquet/test/data/apache/good/alltypes_plain.parquet';
   const table = await load(url, ParquetJSLoader, getParquetLoaderOptions(url));

--- a/modules/parquet/test/parquet.bench.ts
+++ b/modules/parquet/test/parquet.bench.ts
@@ -5,11 +5,11 @@
 import {GeoParquetLoader, ParquetJSLoader, ParquetLoader} from '@loaders.gl/parquet';
 import {fetchFile, load, parse, preload} from '@loaders.gl/core';
 import type {LoaderWithParser} from '@loaders.gl/loader-utils';
-import type {ObjectRowTable} from '@loaders.gl/schema';
-import {parquetReadObjects} from 'hyparquet';
+import type {ArrowTable, ObjectRowTable} from '@loaders.gl/schema';
+import {convertTable, makeTableFromData} from '@loaders.gl/schema-utils';
+import {parquetRead, parquetReadObjects, type ColumnData} from 'hyparquet';
 import {compressors} from 'hyparquet-compressors';
 
-const PARQUET_URL = '@loaders.gl/parquet/test/data/fruits.parquet';
 const LZ4_PARQUET_URL =
   '@loaders.gl/parquet/test/data/apache/good/lz4_raw_compressed_larger.parquet';
 const HADOOP_LZ4_PARQUET_URL =
@@ -27,6 +27,8 @@ type ParquetBenchmarkScenario = {
   arrayBuffer: ArrayBuffer;
   /** Optional top-level Parquet columns decoded by every included implementation. */
   columns?: string[];
+  /** Table shape materialized by every included implementation. */
+  shape: 'arrow-table' | 'object-row-table';
   /** Implementations included when a backend cannot correctly execute the scenario. */
   implementationIds?: ParquetBenchmarkImplementationId[];
 };
@@ -43,22 +45,15 @@ type ParquetBenchmarkImplementation = {
 };
 
 export async function parquetBench(suite) {
-  const [
-    parquetResponse,
-    lz4ParquetResponse,
-    hadoopLz4ParquetResponse,
-    deltaByteArrayParquetResponse,
-    geoParquetResponse
-  ] = await Promise.all([
-    fetchFile(PARQUET_URL),
+  const [lz4ParquetResponse, hadoopLz4ParquetResponse, deltaByteArrayParquetResponse, geoParquetResponse] =
+    await Promise.all([
     fetchFile(LZ4_PARQUET_URL),
     fetchFile(HADOOP_LZ4_PARQUET_URL),
     fetchFile(DELTA_BYTE_ARRAY_PARQUET_URL),
     fetchFile(GEO_PARQUET_URL)
   ]);
-  const [arrayBuffer, lz4ArrayBuffer, hadoopLz4ArrayBuffer, deltaByteArrayBuffer, geoArrayBuffer] =
+  const [lz4ArrayBuffer, hadoopLz4ArrayBuffer, deltaByteArrayBuffer, geoArrayBuffer] =
     await Promise.all([
-      parquetResponse.arrayBuffer(),
       lz4ParquetResponse.arrayBuffer(),
       hadoopLz4ParquetResponse.arrayBuffer(),
       deltaByteArrayParquetResponse.arrayBuffer(),
@@ -70,28 +65,38 @@ export async function parquetBench(suite) {
   ]);
   const implementations = createParquetBenchmarkImplementations(typescriptLoader, wasmLoader);
   const scenarios: ParquetBenchmarkScenario[] = [
-    {name: 'GeoParquet object rows', arrayBuffer: geoArrayBuffer},
+    {name: 'GeoParquet → Arrow', arrayBuffer: geoArrayBuffer, shape: 'arrow-table'},
     {
-      name: 'LZ4_RAW full table',
+      name: 'LZ4_RAW full table → Arrow',
       arrayBuffer: lz4ArrayBuffer,
+      shape: 'arrow-table',
       implementationIds: ['typescript', 'wasm', 'hyparquet']
     },
     {
-      name: 'Hadoop LZ4 full table',
+      name: 'Hadoop LZ4 full table → Arrow',
       arrayBuffer: hadoopLz4ArrayBuffer,
+      shape: 'arrow-table',
       implementationIds: ['typescript', 'wasm', 'hyparquet']
     },
     {
-      name: 'DELTA_BYTE_ARRAY full table',
+      name: 'DELTA_BYTE_ARRAY full table → Arrow',
       arrayBuffer: deltaByteArrayBuffer,
+      shape: 'arrow-table',
       implementationIds: ['typescript', 'wasm', 'hyparquet']
     },
     {
-      name: 'DELTA_BYTE_ARRAY projected columns',
+      name: 'DELTA_BYTE_ARRAY projected columns → Arrow',
       arrayBuffer: deltaByteArrayBuffer,
       columns: ['c_customer_id', 'c_email_address'],
+      shape: 'arrow-table',
       // parquet-wasm 0.7.2 currently returns mismatched IPC schema/vector counts for this projection.
       implementationIds: ['typescript', 'hyparquet']
+    },
+    {
+      name: 'DELTA_BYTE_ARRAY full table → object rows',
+      arrayBuffer: deltaByteArrayBuffer,
+      shape: 'object-row-table',
+      implementationIds: ['typescript', 'wasm', 'hyparquet']
     }
   ];
 
@@ -102,7 +107,7 @@ export async function parquetBench(suite) {
         )
       : implementations;
     const rowCount = await validateParquetBenchmarkScenario(scenario, scenarioImplementations);
-    suite = suite.groupSorted(`Parquet object-row decode - ${scenario.name}`);
+    suite = suite.groupSorted(`Parquet decode - ${scenario.name}`);
 
     for (const implementation of scenarioImplementations) {
       suite.addAsync(
@@ -119,30 +124,6 @@ export async function parquetBench(suite) {
       );
     }
   }
-
-  suite = suite.group('ParquetLoader Arrow');
-
-  suite.addAsync(
-    "load(ParquetLoader, shape: 'arrow-table') - Parquet load",
-    {multiplier: 40000, unit: 'rows'},
-    async () => {
-      await load(arrayBuffer, ParquetLoader, {
-        core: {worker: false},
-        parquet: {shape: 'arrow-table'}
-      });
-    }
-  );
-
-  suite.addAsync(
-    "load(ParquetLoader, shape: 'arrow-table') - GeoParquet load",
-    {multiplier: 40000, unit: 'rows'},
-    async () => {
-      await load(geoArrayBuffer, ParquetLoader, {
-        core: {worker: false},
-        parquet: {shape: 'arrow-table'}
-      });
-    }
-  );
 
   suite = suite.group('GeoParquetLoader');
 
@@ -174,7 +155,7 @@ export async function parquetBench(suite) {
   // });
 }
 
-/** Creates equivalent object-row decode cases for the maintained Parquet implementations. */
+/** Creates equivalent Arrow-table decode cases for the maintained Parquet implementations. */
 function createParquetBenchmarkImplementations(
   typescriptLoader: LoaderWithParser,
   wasmLoader: LoaderWithParser
@@ -182,12 +163,12 @@ function createParquetBenchmarkImplementations(
   return [
     {
       id: 'typescript',
-      name: 'ParquetJSLoader (TypeScript)',
+      name: 'ParquetJSLoader',
       decode: scenario => decodeWithLoadersGl(scenario, typescriptLoader)
     },
     {
       id: 'wasm',
-      name: 'ParquetLoader (WASM)',
+      name: 'ParquetLoader',
       decode: scenario => decodeWithLoadersGl(scenario, wasmLoader)
     },
     {
@@ -205,19 +186,45 @@ async function decodeWithLoadersGl(
 ): Promise<number> {
   const table = (await parse(scenario.arrayBuffer, loader, {
     core: {worker: false},
-    parquet: {columns: scenario.columns}
-  })) as ObjectRowTable;
-  return table.data.length;
+    parquet: {columns: scenario.columns, shape: scenario.shape}
+  })) as ArrowTable | ObjectRowTable;
+  return table.shape === 'arrow-table' ? table.data.numRows : table.data.length;
 }
 
 /** Decodes one scenario through the latest pinned hyparquet implementation. */
 async function decodeWithHyparquet(scenario: ParquetBenchmarkScenario): Promise<number> {
-  const rows = await parquetReadObjects({
+  if (scenario.shape === 'object-row-table') {
+    const rows = await parquetReadObjects({
+      file: scenario.arrayBuffer,
+      columns: scenario.columns,
+      compressors
+    });
+    return rows.length;
+  }
+
+  const columns: Record<string, unknown[]> = {};
+  await parquetRead({
     file: scenario.arrayBuffer,
     columns: scenario.columns,
+    onChunk: chunk => appendHyparquetColumnChunk(columns, chunk),
     compressors
   });
-  return rows.length;
+  const columnarTable = makeTableFromData(columns);
+  const arrowTable = convertTable(columnarTable, 'arrow-table');
+  return arrowTable.data.numRows;
+}
+
+/** Copies one hyparquet output chunk into a contiguous top-level column. */
+function appendHyparquetColumnChunk(
+  columns: Record<string, unknown[]>,
+  chunk: ColumnData
+): void {
+  const column = columns[chunk.columnName] || [];
+  column.length = Math.max(column.length, chunk.rowEnd);
+  for (let valueIndex = 0; valueIndex < chunk.columnData.length; valueIndex++) {
+    column[chunk.rowStart + valueIndex] = chunk.columnData[valueIndex];
+  }
+  columns[chunk.columnName] = column;
 }
 
 /** Warms every implementation and verifies that benchmark throughput uses a common row count. */

--- a/website/src/examples/parquet-benchmarks-app.tsx
+++ b/website/src/examples/parquet-benchmarks-app.tsx
@@ -5,28 +5,31 @@
 import React, {useEffect, useState} from 'react';
 
 import {Bench, type LogEntry} from '@probe.gl/bench';
-import type {ObjectRowTable} from '@loaders.gl/schema';
+import type {ArrowTable, ObjectRowTable} from '@loaders.gl/schema';
 
 type BenchmarkResultRow = {
   /** Human-readable fixture and feature label. */
   scenario: string;
-  /** Human-readable loader variant label. */
-  implementation: string;
+  /** Loader variant that produced the result. */
+  implementationId: ParquetBenchmarkImplementationId;
   /** Human-readable throughput. */
   formattedValue: string;
-  /** Human-readable measurement error. */
-  formattedError: string;
 };
 
 type BenchmarkStatus = 'loading' | 'running' | 'complete' | 'failed';
 
 type ParquetBenchmarkImplementationId = 'typescript' | 'wasm' | 'hyparquet';
+type ParquetBenchmarkShape = 'arrow-table' | 'object-row-table';
 
 type ParquetBenchmarkScenario = {
   /** Human-readable fixture and feature label. */
   name: string;
   /** Complete fixture bytes held outside the timed callback. */
   arrayBuffer: ArrayBuffer;
+  /** Optional top-level columns decoded by every loader variant. */
+  columns?: string[];
+  /** Table shape materialized by every loader variant. */
+  shape: ParquetBenchmarkShape;
   /** Implementations that currently support the fixture features. */
   implementationIds: ParquetBenchmarkImplementationId[];
 };
@@ -36,7 +39,7 @@ type ParquetBenchmarkImplementation = {
   id: ParquetBenchmarkImplementationId;
   /** Human-readable implementation label. */
   name: string;
-  /** Hot object-row decode operation returning the output row count. */
+  /** Hot decode operation returning the output row count. */
   decode: (scenario: ParquetBenchmarkScenario) => Promise<number>;
 };
 
@@ -46,6 +49,32 @@ type ValidatedParquetBenchmarkImplementation = {
   /** Row count produced during warm-up. */
   rowCount: number;
 };
+
+type HyparquetColumnChunk = {
+  /** Top-level column name. */
+  columnName: string;
+  /** Values decoded for this chunk. */
+  columnData: ArrayLike<unknown>;
+  /** First row represented by the chunk. */
+  rowStart: number;
+  /** Exclusive last row represented by the chunk. */
+  rowEnd: number;
+};
+
+const PARQUET_BENCHMARK_IMPLEMENTATION_LABELS: Record<
+  ParquetBenchmarkImplementationId,
+  string
+> = {
+  typescript: 'ParquetJSLoader',
+  wasm: 'ParquetLoader',
+  hyparquet: 'hyparquet'
+};
+
+const PARQUET_BENCHMARK_IMPLEMENTATION_IDS: ParquetBenchmarkImplementationId[] = [
+  'typescript',
+  'wasm',
+  'hyparquet'
+];
 
 /** Renders live comparative Parquet decode benchmarks in the visitor's browser. */
 export default function ParquetBenchmarksApp(): JSX.Element {
@@ -131,10 +160,14 @@ export default function ParquetBenchmarksApp(): JSX.Element {
 
   const isRunning = status === 'loading' || status === 'running';
   const canRestart = status === 'complete' || status === 'failed';
+  const scenarioNames = Array.from(new Set(rows.map(row => row.scenario)));
 
   return (
     <div className="benchmark-page">
-      <p>Live Parquet object-row decode throughput. Keep this tab focused while it runs.</p>
+      <p>
+        Live Parquet decode throughput, primarily to Arrow with one object-row control. Keep this tab
+        focused while it runs.
+      </p>
       <div className="benchmark-status-row" aria-live="polite">
         {isRunning ? <span className="benchmark-spinner" aria-hidden="true" /> : null}
         <p className="benchmark-status">Status: {status}</p>
@@ -159,37 +192,44 @@ export default function ParquetBenchmarksApp(): JSX.Element {
         <table className="parquet-benchmark-table">
           <thead>
             <tr>
-              <th scope="col">Fixture</th>
-              <th scope="col">Loader Variant</th>
-              <th scope="col" className="parquet-benchmark-number">
-                Throughput
-              </th>
-              <th scope="col" className="parquet-benchmark-number">
-                Variation
-              </th>
+              <th scope="col">Test</th>
+              {PARQUET_BENCHMARK_IMPLEMENTATION_IDS.map(implementationId => (
+                <th
+                  key={implementationId}
+                  scope="col"
+                  className="parquet-benchmark-number"
+                >
+                  {PARQUET_BENCHMARK_IMPLEMENTATION_LABELS[implementationId]}
+                </th>
+              ))}
             </tr>
           </thead>
           <tbody>
-            {rows.map((row, rowIndex) => {
-              const startsScenario = rows[rowIndex - 1]?.scenario !== row.scenario;
-              const scenarioRowCount = rows.filter(
-                candidateRow => candidateRow.scenario === row.scenario
-              ).length;
-              return (
-                <tr key={`${row.scenario}-${row.implementation}`}>
-                  {startsScenario ? (
-                    <th scope="rowgroup" rowSpan={scenarioRowCount}>
-                      {row.scenario}
-                    </th>
-                  ) : null}
-                  <td>{row.implementation}</td>
-                  <td className="parquet-benchmark-number">
-                    <strong>{row.formattedValue}</strong> rows/s
-                  </td>
-                  <td className="parquet-benchmark-number">{row.formattedError}</td>
-                </tr>
-              );
-            })}
+            {scenarioNames.map(scenario => (
+              <tr key={scenario}>
+                <th scope="row">{scenario}</th>
+                {PARQUET_BENCHMARK_IMPLEMENTATION_IDS.map(implementationId => {
+                  const result = rows.find(
+                    row => row.scenario === scenario && row.implementationId === implementationId
+                  );
+                  return (
+                    <td
+                      key={implementationId}
+                      className="parquet-benchmark-number"
+                      aria-label={`${PARQUET_BENCHMARK_IMPLEMENTATION_LABELS[implementationId]} throughput`}
+                    >
+                      {result ? (
+                        <>
+                          <strong>{result.formattedValue}</strong> rows/s
+                        </>
+                      ) : (
+                        <span className="parquet-benchmark-pending">—</span>
+                      )}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
           </tbody>
         </table>
         {rows.length === 0 ? (
@@ -232,18 +272,35 @@ async function createParquetBenchmarkScenarios(): Promise<ParquetBenchmarkScenar
   const deltaByteArrayBuffer = await fetchParquetFixture(deltaByteArrayUrl);
   return [
     {
-      name: 'GeoParquet object rows',
+      name: 'GeoParquet → Arrow',
       arrayBuffer: geoParquetArrayBuffer,
+      shape: 'arrow-table',
       implementationIds: ['typescript', 'wasm', 'hyparquet']
     },
     {
-      name: 'LZ4_RAW object rows',
+      name: 'LZ4_RAW → Arrow',
       arrayBuffer: lz4ArrayBuffer,
+      shape: 'arrow-table',
       implementationIds: ['typescript', 'wasm', 'hyparquet']
     },
     {
-      name: 'DELTA_BYTE_ARRAY object rows',
+      name: 'DELTA_BYTE_ARRAY → Arrow',
       arrayBuffer: deltaByteArrayBuffer,
+      shape: 'arrow-table',
+      implementationIds: ['typescript', 'wasm', 'hyparquet']
+    },
+    {
+      name: 'DELTA_BYTE_ARRAY projection → Arrow',
+      arrayBuffer: deltaByteArrayBuffer,
+      columns: ['c_customer_id', 'c_email_address'],
+      shape: 'arrow-table',
+      // parquet-wasm 0.7.2 returns mismatched IPC schema/vector counts for this projection.
+      implementationIds: ['typescript', 'hyparquet']
+    },
+    {
+      name: 'DELTA_BYTE_ARRAY → object rows',
+      arrayBuffer: deltaByteArrayBuffer,
+      shape: 'object-row-table',
       implementationIds: ['typescript', 'wasm', 'hyparquet']
     }
   ];
@@ -258,7 +315,7 @@ async function fetchParquetFixture(url: string): Promise<ArrayBuffer> {
   return await response.arrayBuffer();
 }
 
-/** Loads browser implementations and creates equivalent object-row decode cases. */
+/** Loads browser implementations and creates equivalent Arrow-table decode cases. */
 async function createParquetBenchmarkImplementations(): Promise<
   ParquetBenchmarkImplementation[]
 > {
@@ -267,6 +324,7 @@ async function createParquetBenchmarkImplementations(): Promise<
     loadersGlTypeScript,
     loadersGlWasm,
     loadersGlTableConverters,
+    loadersGlSchemaUtils,
     hyparquet,
     hyparquetCompressors
   ] = await Promise.all([
@@ -274,46 +332,84 @@ async function createParquetBenchmarkImplementations(): Promise<
     import('../../../modules/parquet/src/parquet-js-loader'),
     import('../../../modules/parquet/src/lib/parsers/parse-parquet-to-arrow'),
     import('../../../modules/parquet/src/lib/parsers/convert-parquet-tables'),
+    import('@loaders.gl/schema-utils'),
     import('hyparquet'),
     import('hyparquet-compressors')
   ]);
   return [
     {
       id: 'typescript',
-      name: 'ParquetJSLoader (TypeScript)',
+      name: PARQUET_BENCHMARK_IMPLEMENTATION_LABELS.typescript,
       decode: async scenario => {
         const table = (await loadersGlTypeScript.ParquetJSLoaderWithParser.parse(
           scenario.arrayBuffer,
           {
-            core: {worker: false}
+            core: {worker: false},
+            parquet: {columns: scenario.columns, shape: scenario.shape}
           }
-        )) as ObjectRowTable;
-        return table.data.length;
+        )) as ArrowTable | ObjectRowTable;
+        return getBenchmarkTableRowCount(table);
       }
     },
     {
       id: 'wasm',
-      name: 'ParquetLoader (WASM)',
+      name: PARQUET_BENCHMARK_IMPLEMENTATION_LABELS.wasm,
       decode: async scenario => {
         const arrowTable = await loadersGlWasm.parseParquetFileToArrow(
-          new loadersGlLoaderUtils.BlobFile(scenario.arrayBuffer)
+          new loadersGlLoaderUtils.BlobFile(scenario.arrayBuffer),
+          {columns: scenario.columns}
         );
-        const table = loadersGlTableConverters.convertArrowTableToObjectRows(arrowTable);
-        return table.data.length;
+        if (scenario.shape === 'arrow-table') {
+          return arrowTable.data.numRows;
+        }
+        const objectRowTable = loadersGlTableConverters.convertArrowTableToObjectRows(arrowTable);
+        return objectRowTable.data.length;
       }
     },
     {
       id: 'hyparquet',
-      name: 'hyparquet',
+      name: PARQUET_BENCHMARK_IMPLEMENTATION_LABELS.hyparquet,
       decode: async scenario => {
-        const rows = await hyparquet.parquetReadObjects({
+        if (scenario.shape === 'object-row-table') {
+          const rows = await hyparquet.parquetReadObjects({
+            file: scenario.arrayBuffer,
+            columns: scenario.columns,
+            compressors: hyparquetCompressors.compressors
+          });
+          return rows.length;
+        }
+
+        const columns: Record<string, unknown[]> = {};
+        await hyparquet.parquetRead({
           file: scenario.arrayBuffer,
+          columns: scenario.columns,
+          onChunk: (chunk: HyparquetColumnChunk) => appendHyparquetColumnChunk(columns, chunk),
           compressors: hyparquetCompressors.compressors
         });
-        return rows.length;
+        const columnarTable = loadersGlSchemaUtils.makeTableFromData(columns);
+        const arrowTable = loadersGlSchemaUtils.convertTable(columnarTable, 'arrow-table');
+        return arrowTable.data.numRows;
       }
     }
   ];
+}
+
+/** Returns the materialized row count for either benchmark table shape. */
+function getBenchmarkTableRowCount(table: ArrowTable | ObjectRowTable): number {
+  return table.shape === 'arrow-table' ? table.data.numRows : table.data.length;
+}
+
+/** Copies one hyparquet output chunk into a contiguous top-level column. */
+function appendHyparquetColumnChunk(
+  columns: Record<string, unknown[]>,
+  chunk: HyparquetColumnChunk
+): void {
+  const column = columns[chunk.columnName] || [];
+  column.length = Math.max(column.length, chunk.rowEnd);
+  for (let valueIndex = 0; valueIndex < chunk.columnData.length; valueIndex++) {
+    column[chunk.rowStart + valueIndex] = chunk.columnData[valueIndex];
+  }
+  columns[chunk.columnName] = column;
 }
 
 /** Adds validated scenarios to the browser benchmark suite. */
@@ -341,7 +437,7 @@ async function addParquetBenchmarksToSuite(
       bench.group(`Parquet decode - ${scenario.name}`);
       for (const {implementation} of validatedImplementations) {
         bench.addAsync(
-          `${scenario.name} :: ${implementation.name}`,
+          `${scenario.name} :: ${implementation.id}`,
           {minIterations: 3, unit: 'rows', multiplier: rowCount},
           async () => {
             const decodedRowCount = await implementation.decode(scenario);
@@ -395,12 +491,19 @@ function createBenchmarkResultRow(entry: LogEntry): BenchmarkResultRow | null {
   switch (entry.type) {
     case 'test': {
       const separatorIndex = entry.id.lastIndexOf(' :: ');
+      const implementationId = entry.id.slice(
+        separatorIndex + 4
+      ) as ParquetBenchmarkImplementationId;
+      if (
+        separatorIndex < 0 ||
+        !PARQUET_BENCHMARK_IMPLEMENTATION_IDS.includes(implementationId)
+      ) {
+        return null;
+      }
       return {
-        scenario: separatorIndex >= 0 ? entry.id.slice(0, separatorIndex) : 'Parquet decode',
-        implementation:
-          separatorIndex >= 0 ? entry.id.slice(separatorIndex + 4) : entry.id,
-        formattedValue: entry.itersPerSecond,
-        formattedError: `±${(entry.error * 100).toFixed(2)}%`
+        scenario: entry.id.slice(0, separatorIndex),
+        implementationId,
+        formattedValue: entry.itersPerSecond
       };
     }
     case 'complete':

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -605,16 +605,20 @@ body:has(.benchmark-page) footer.theme-layout-footer {
   border-bottom: 0;
 }
 
-.parquet-benchmark-table tbody th[scope='rowgroup'] {
+.parquet-benchmark-table tbody th[scope='row'] {
   background: var(--ifm-table-stripe-background);
   font-weight: 600;
-  width: 34%;
+  width: 28%;
 }
 
 .parquet-benchmark-table .parquet-benchmark-number {
   font-variant-numeric: tabular-nums;
   text-align: right;
   white-space: nowrap;
+}
+
+.parquet-benchmark-pending {
+  color: var(--ifm-font-color-secondary);
 }
 
 .parquet-benchmark-empty {


### PR DESCRIPTION
## Goals

- Make `ParquetJSLoader` Arrow output genuinely columnar instead of routing flat schemas through object rows.
- Preserve projection, ranges, batching, nested-schema compatibility, GeoParquet metadata, and selected row counts for empty projections.
- Keep the live peer benchmark focused on equivalent Arrow results, with one object-row control.

## Changes

- Reads TypeScript row groups directly and materializes flat selected fields as columns before constructing Apache Arrow vectors.
- Retains object-row materialization as the compatibility fallback for nested/list/map schemas.
- Applies `columns`, `offset`, `limit`, and `batchSize` in the direct Arrow batch iterator.
- Preserves explicit row counts for empty-schema Arrow tables and batches, including unknown-column projections.
- Normalizes required 64-bit logical values for Apache Arrow bigint vectors.
- Adds Arrow/object parity coverage for projected row ranges, the `fruits.parquet` timestamp case, and empty-projection aggregation/batching.
- Transposes the live benchmark matrix so tests are rows and loader variants are columns, removes the variation column, labels output shapes explicitly, and keeps one object-row control.
- Updates the loader documentation to describe direct flat-column materialization and the nested fallback.

## Performance interpretation

This removes the row-shaped intermediate and its allocations, but the checked-in live fixtures remain dominated by Parquet decode. A fresh production-browser run remained within normal run-to-run range of the landed baseline; this PR intentionally does **not** claim the earlier large Node delta, which was a warm-up/order artifact. The direct columnar boundary is groundwork for the next decode/vector tranches.

## Stack status

- #3556, #3568, and the preceding performance tranche are landed.
- This PR is rebased directly on `master` and contains two focused commits touching seven files.

## Validation

- `yarn install`
- `yarn lint fix`
- `yarn build`
- `yarn exec vitest run modules/parquet/test/parquet-loader.spec.ts --project node` — 29/29 passed
- `yarn exec vitest run modules/parquet/test/parquet-loader.spec.ts --project headless -t "ParquetJSLoader#arrow-table"` — 2/2 passed
- New empty-projection batch regression passes in the headless project
- `cd website && yarn build`
- `yarn test-node` — Parquet tests pass; the repository run retains unrelated Arrow worker/network failures seen on the previous stack baseline
- `yarn test-headless` — 1,849 passed; 95 pre-existing worker-asset failures across many modules (`Unexpected token '<'` / classic-worker ESM loading)
