### PR TITLE
perf(parquet): accelerate RLE decoding

### DIFF
--- a/modules/parquet/src/parquetjs/codecs/rle.ts
+++ b/modules/parquet/src/parquetjs/codecs/rle.ts
@@ -79,85 +79,215 @@ export function decodeValues(
   type: PrimitiveType,
   cursor: CursorBuffer,
   count: number,
-  opts: ParquetCodecOptions
+  options: ParquetCodecOptions
 ): number[] {
-  if (!('bitWidth' in opts)) {
+  if (!('bitWidth' in options)) {
     throw new Error('bitWidth is required');
   }
+  const bitWidth = options.bitWidth!;
+  if (!Number.isInteger(bitWidth) || bitWidth < 0 || bitWidth > 64) {
+    throw new Error(`invalid bit width: ${bitWidth}`);
+  }
+  if (!Number.isInteger(count) || count < 0) {
+    throw new Error(`invalid value count: ${count}`);
+  }
 
-  if (!opts.disableEnvelope) {
+  if (!options.disableEnvelope) {
+    assertReadable(cursor, 4);
     cursor.offset += 4;
   }
 
-  let values: number[] = [];
-  while (values.length < count) {
-    const header = varint.decode(cursor.buffer as any, cursor.offset);
-    cursor.offset += varint.encodingLength(header);
-    let decodedValues: number[];
-    if (header & 1) {
-      const count = (header >> 1) * 8;
-      decodedValues = decodeRunBitpacked(cursor, count, opts);
+  const values = new Array<number>(count);
+  let outputOffset = 0;
+  while (outputOffset < count) {
+    const header = readUnsignedVarIntNumber(cursor);
+    if (header % 2 === 1) {
+      const runValueCount = ((header - 1) / 2) * 8;
+      if (runValueCount === 0) {
+        throw new Error('invalid RLE bit-packed run length');
+      }
+      const outputCount = Math.min(runValueCount, count - outputOffset);
+      decodeBitPackedRun(cursor, runValueCount, outputCount, bitWidth, values, outputOffset);
+      outputOffset += outputCount;
     } else {
-      const count = header >> 1;
-      decodedValues = decodeRunRepeated(cursor, count, opts);
+      const runValueCount = header / 2;
+      if (runValueCount === 0) {
+        throw new Error('invalid RLE repeated run length');
+      }
+      const outputCount = Math.min(runValueCount, count - outputOffset);
+      const value = decodeRepeatedRun(cursor, bitWidth);
+      values.fill(value, outputOffset, outputOffset + outputCount);
+      outputOffset += outputCount;
     }
-
-    // strange failure in docusaurus / webpack if we don't cast the type here
-    for (const value of decodedValues as any[]) {
-      values.push(value);
-    }
-  }
-  values = values.slice(0, count);
-
-  if (values.length !== count) {
-    throw new Error('invalid RLE encoding');
   }
 
   return values;
 }
 
-function decodeRunBitpacked(
+/** Decodes one complete bit-packed run directly into the caller's output array. */
+function decodeBitPackedRun(
   cursor: CursorBuffer,
-  count: number,
-  opts: ParquetCodecOptions
-): number[] {
-  // @ts-ignore
-  const bitWidth: number = opts.bitWidth;
-
-  if (count % 8 !== 0) {
+  runValueCount: number,
+  outputCount: number,
+  bitWidth: number,
+  output: number[],
+  outputOffset: number
+): void {
+  if (runValueCount % 8 !== 0) {
     throw new Error('must be a multiple of 8');
   }
+  const packedByteLength = bitWidth * (runValueCount / 8);
+  const packedOffset = cursor.offset;
+  const size = cursor.size ?? cursor.buffer.length;
+  // Preserve compatibility with files whose malformed final dictionary run omits encoded bytes.
+  cursor.offset = Math.min(cursor.offset + packedByteLength, size);
 
-  // tslint:disable-next-line:prefer-array-literal
-  const values = new Array(count).fill(0);
-  for (let b = 0; b < bitWidth * count; b++) {
-    if (cursor.buffer[cursor.offset + Math.floor(b / 8)] & (1 << (b % 8))) {
-      values[Math.floor(b / bitWidth)] |= 1 << (b % bitWidth);
-    }
+  if (bitWidth === 0) {
+    output.fill(0, outputOffset, outputOffset + outputCount);
+    return;
+  }
+  if (bitWidth <= 24) {
+    decodeUint32BitPackedRun(
+      cursor.buffer,
+      packedOffset,
+      outputCount,
+      bitWidth,
+      output,
+      outputOffset
+    );
+    return;
+  }
+  if (bitWidth <= 45) {
+    decodeNumberBitPackedRun(
+      cursor.buffer,
+      packedOffset,
+      outputCount,
+      bitWidth,
+      output,
+      outputOffset
+    );
+    return;
   }
 
-  cursor.offset += bitWidth * (count / 8);
-  return values;
+  const bitWidthBigInt = BigInt(bitWidth);
+  const mask = (1n << bitWidthBigInt) - 1n;
+  let packedBits = 0n;
+  let packedBitCount = 0;
+  let byteOffset = packedOffset;
+  for (let valueIndex = 0; valueIndex < outputCount; valueIndex++) {
+    while (packedBitCount < bitWidth) {
+      packedBits |= BigInt(cursor.buffer[byteOffset++] ?? 0) << BigInt(packedBitCount);
+      packedBitCount += 8;
+    }
+    output[outputOffset + valueIndex] = Number(packedBits & mask);
+    packedBits >>= bitWidthBigInt;
+    packedBitCount -= bitWidth;
+  }
 }
 
-function decodeRunRepeated(
-  cursor: CursorBuffer,
+/** Decodes common narrow bit widths with a fast 32-bit reservoir. */
+function decodeUint32BitPackedRun(
+  buffer: Uint8Array,
+  packedOffset: number,
   count: number,
-  opts: ParquetCodecOptions
-): number[] {
-  // @ts-ignore
-  const bitWidth: number = opts.bitWidth;
-
-  let value = 0;
-  for (let i = 0; i < Math.ceil(bitWidth / 8); i++) {
-    // eslint-disable-next-line
-    value << 8; //  TODO - this looks wrong
-    value += cursor.buffer[cursor.offset];
-    cursor.offset += 1;
+  bitWidth: number,
+  output: number[],
+  outputOffset: number
+): void {
+  if (bitWidth === 8) {
+    for (let valueIndex = 0; valueIndex < count; valueIndex++) {
+      output[outputOffset + valueIndex] = buffer[packedOffset + valueIndex] ?? 0;
+    }
+    return;
   }
 
-  // tslint:disable-next-line:prefer-array-literal
-  return new Array(count).fill(value);
+  const mask = 2 ** bitWidth - 1;
+  let packedBits = 0;
+  let packedBitCount = 0;
+  let byteOffset = packedOffset;
+  for (let valueIndex = 0; valueIndex < count; valueIndex++) {
+    while (packedBitCount < bitWidth) {
+      packedBits |= (buffer[byteOffset++] ?? 0) << packedBitCount;
+      packedBitCount += 8;
+    }
+    output[outputOffset + valueIndex] = packedBits & mask;
+    packedBits >>>= bitWidth;
+    packedBitCount -= bitWidth;
+  }
+}
+
+/** Decodes a bit-packed run with an exact number-based bit reservoir. */
+function decodeNumberBitPackedRun(
+  buffer: Uint8Array,
+  packedOffset: number,
+  count: number,
+  bitWidth: number,
+  output: number[],
+  outputOffset: number
+): void {
+  const divisor = 2 ** bitWidth;
+  let packedBits = 0;
+  let packedBitCount = 0;
+  let byteOffset = packedOffset;
+  for (let valueIndex = 0; valueIndex < count; valueIndex++) {
+    while (packedBitCount < bitWidth) {
+      packedBits += (buffer[byteOffset++] ?? 0) * 2 ** packedBitCount;
+      packedBitCount += 8;
+    }
+    output[outputOffset + valueIndex] = packedBits % divisor;
+    packedBits = Math.floor(packedBits / divisor);
+    packedBitCount -= bitWidth;
+  }
+}
+
+/** Decodes the single little-endian value stored by a repeated run. */
+function decodeRepeatedRun(cursor: CursorBuffer, bitWidth: number): number {
+  const byteWidth = Math.ceil(bitWidth / 8);
+  assertReadable(cursor, byteWidth);
+  if (byteWidth <= 6) {
+    let value = 0;
+    let multiplier = 1;
+    for (let byteIndex = 0; byteIndex < byteWidth; byteIndex++) {
+      value += cursor.buffer[cursor.offset++] * multiplier;
+      multiplier *= 256;
+    }
+    return value;
+  }
+
+  let value = 0n;
+  for (let byteIndex = 0; byteIndex < byteWidth; byteIndex++) {
+    value |= BigInt(cursor.buffer[cursor.offset++]) << BigInt(byteIndex * 8);
+  }
+  return Number(value);
+}
+
+/** Reads an unsigned base-128 run header without allocating an intermediate buffer. */
+function readUnsignedVarIntNumber(cursor: CursorBuffer): number {
+  let value = 0;
+  let multiplier = 1;
+  for (let byteIndex = 0; byteIndex < 10; byteIndex++) {
+    assertReadable(cursor, 1);
+    const byte = cursor.buffer[cursor.offset++];
+    value += (byte & 0x7f) * multiplier;
+    if ((byte & 0x80) === 0) {
+      if (!Number.isSafeInteger(value)) {
+        throw new Error('RLE run header exceeds the safe integer range');
+      }
+      return value;
+    }
+    multiplier *= 128;
+  }
+  throw new Error('invalid RLE run header');
+}
+
+/** Ensures an RLE read stays within the current cursor. */
+function assertReadable(cursor: CursorBuffer, byteLength: number): void {
+  const size = cursor.size ?? cursor.buffer.length;
+  if (byteLength < 0 || cursor.offset + byteLength > size) {
+    throw new Error(
+      `unexpected end of RLE data (offset=${cursor.offset}, requested=${byteLength}, size=${size})`
+    );
+  }
 }
 
 function encodeRunBitpacked(values: number[], opts: ParquetCodecOptions): Uint8Array {

--- a/modules/parquet/test/parquetjs/codec-rle.spec.ts
+++ b/modules/parquet/test/parquetjs/codec-rle.spec.ts
@@ -9,6 +9,23 @@ function bytes(values: number[]): Uint8Array {
   return new Uint8Array(values);
 }
 
+/** Encodes one eight-value bit-packed run for cross-width decoder tests. */
+function encodeBitPackedRun(values: number[], bitWidth: number): Uint8Array {
+  const encoded = [0x03];
+  let packedBits = 0n;
+  let packedBitCount = 0;
+  for (const value of values) {
+    packedBits |= BigInt(value) << BigInt(packedBitCount);
+    packedBitCount += bitWidth;
+    while (packedBitCount >= 8) {
+      encoded.push(Number(packedBits & 0xffn));
+      packedBits >>= 8n;
+      packedBitCount -= 8;
+    }
+  }
+  return bytes(encoded);
+}
+
 test('ParquetCodec::RLE#should encode bitpacked values', assert => {
   const buf = PARQUET_CODECS.RLE.encodeValues(
     'INT32',
@@ -55,12 +72,13 @@ test('ParquetCodec::RLE#should encode bitpacked values', assert => {
 });
 
 test('ParquetCodec::RLE#should decode bitpacked values', assert => {
+  const cursor = {
+    buffer: bytes([0x05, 0x88, 0xc6, 0xfa, 0x2e, 0x00, 0x00]),
+    offset: 0
+  };
   const vals = PARQUET_CODECS.RLE.decodeValues(
     'INT32',
-    {
-      buffer: bytes([0x05, 0x88, 0xc6, 0xfa, 0x2e, 0x00, 0x00]),
-      offset: 0,
-    },
+    cursor,
     10,
     {
       disableEnvelope: true,
@@ -68,6 +86,40 @@ test('ParquetCodec::RLE#should decode bitpacked values', assert => {
     });
 
   assert.deepEqual(vals, [0, 1, 2, 3, 4, 5, 6, 7, 6, 5]);
+  assert.equal(cursor.offset, cursor.buffer.length, 'consumes padding from the complete run');
+  assert.end();
+});
+
+test('ParquetCodec::RLE#decodes wide bitpacked values', assert => {
+  const vals = PARQUET_CODECS.RLE.decodeValues(
+    'INT32',
+    {
+      buffer: bytes([0x03, 0xbc, 0x3a, 0x12, 0xff, 0x0f, 0x00, 0x01, 0x20, 0x00, 0x03, 0x40, 0x00]),
+      offset: 0
+    },
+    8,
+    {
+      disableEnvelope: true,
+      bitWidth: 12
+    }
+  );
+
+  assert.deepEqual(vals, [0xabc, 0x123, 0xfff, 0, 1, 2, 3, 4]);
+  assert.end();
+});
+
+test('ParquetCodec::RLE#decodes every reservoir width', assert => {
+  for (const bitWidth of [0, 1, 7, 8, 9, 16, 24, 25, 32, 45, 46, 53, 64]) {
+    const divisor = bitWidth === 0 ? 1 : 2 ** Math.min(bitWidth, 52);
+    const values = [0, 1, 2, 3, 7, 15, 31, divisor - 1].map(value => value % divisor);
+    const decoded = PARQUET_CODECS.RLE.decodeValues(
+      'INT64',
+      {buffer: encodeBitPackedRun(values, bitWidth), offset: 0},
+      values.length,
+      {disableEnvelope: true, bitWidth}
+    );
+    assert.deepEqual(decoded, values, `decodes bit width ${bitWidth}`);
+  }
   assert.end();
 });
 
@@ -98,6 +150,38 @@ test('ParquetCodec::RLE#should decode repeated values', assert => {
     });
 
   assert.deepEqual(vals, [42, 42, 42, 42, 42, 42, 42, 42]);
+  assert.end();
+});
+
+test('ParquetCodec::RLE#decodes multi-byte repeated values as little endian', assert => {
+  const vals = PARQUET_CODECS.RLE.decodeValues(
+    'INT32',
+    {
+      buffer: bytes([0x10, 0xbc, 0x0a]),
+      offset: 0
+    },
+    8,
+    {
+      disableEnvelope: true,
+      bitWidth: 12
+    }
+  );
+
+  assert.deepEqual(vals, new Array(8).fill(0xabc));
+  assert.end();
+});
+
+test('ParquetCodec::RLE#zero-fills malformed dictionary runs', assert => {
+  assert.deepEqual(
+    PARQUET_CODECS.RLE.decodeValues(
+      'INT32',
+      {buffer: bytes([0x03, 0x88]), offset: 0},
+      8,
+      {disableEnvelope: true, bitWidth: 3}
+    ),
+    [0, 1, 2, 0, 0, 0, 0, 0],
+    'preserves compatibility with legacy files that omit trailing dictionary bytes'
+  );
   assert.end();
 });
 


### PR DESCRIPTION
## Goals

- Accelerate the TypeScript Parquet loader's RLE hybrid decoder, which is used for dictionary indices and definition/repetition levels.
- Remove per-bit and per-run allocation overhead while preserving decoding compatibility across supported bit widths.

## Changes

- Preallocate the final output and decode bit-packed and repeated runs directly into it.
- Replace allocation-heavy run-header decoding with an allocation-free unsigned varint reader.
- Add specialized reservoirs for common 32-bit widths, exact number-safe widths, and wide BigInt widths, including a byte-aligned fast path.
- Correct multi-byte repeated-run decoding to use Parquet's little-endian representation.
- Retain compatibility with legacy malformed final dictionary runs that omit trailing packed bytes.
- Add focused coverage for padding consumption, multi-byte repeated values, malformed trailing data, and widths from 0 through 64.

## Performance

On the same local build and fixture, the isolated RLE codec benchmark improved from approximately **35.5M** to **158.7M values/s** (about **4.46×**).

A representative end-to-end `RLE_DICTIONARY mixed table → Arrow` run improved from approximately **1.25M** to **2.06M rows/s**. End-to-end browser and machine results vary, so the isolated codec measurement is the most direct signal for this change.

## Validation

- `yarn build`
- `yarn test-node` — 417 files, 2,027 tests passed
- `yarn test-headless` — 417 files, 1,989 tests passed
- `cd website && yarn && yarn build`
- `yarn lint fix`
- Focused Parquet RLE, typed-array, compatibility, and loader tests

## Stack

This draft targets `codex/parquet-reader-fixed-cost` and depends on:

1. #3574
2. #3575
3. #3576

It should be rebased or retargeted as the parent PRs land.