### PR TITLE
perf(parquet): accelerate page assembly

### DIFF
--- a/modules/parquet/src/parquetjs/codecs/rle.ts
+++ b/modules/parquet/src/parquetjs/codecs/rle.ts
@@ -79,85 +79,215 @@ export function decodeValues(
   type: PrimitiveType,
   cursor: CursorBuffer,
   count: number,
-  opts: ParquetCodecOptions
+  options: ParquetCodecOptions
 ): number[] {
-  if (!('bitWidth' in opts)) {
+  if (!('bitWidth' in options)) {
     throw new Error('bitWidth is required');
   }
+  const bitWidth = options.bitWidth!;
+  if (!Number.isInteger(bitWidth) || bitWidth < 0 || bitWidth > 64) {
+    throw new Error(`invalid bit width: ${bitWidth}`);
+  }
+  if (!Number.isInteger(count) || count < 0) {
+    throw new Error(`invalid value count: ${count}`);
+  }
 
-  if (!opts.disableEnvelope) {
+  if (!options.disableEnvelope) {
+    assertReadable(cursor, 4);
     cursor.offset += 4;
   }
 
-  let values: number[] = [];
-  while (values.length < count) {
-    const header = varint.decode(cursor.buffer as any, cursor.offset);
-    cursor.offset += varint.encodingLength(header);
-    let decodedValues: number[];
-    if (header & 1) {
-      const count = (header >> 1) * 8;
-      decodedValues = decodeRunBitpacked(cursor, count, opts);
+  const values = new Array<number>(count);
+  let outputOffset = 0;
+  while (outputOffset < count) {
+    const header = readUnsignedVarIntNumber(cursor);
+    if (header % 2 === 1) {
+      const runValueCount = ((header - 1) / 2) * 8;
+      if (runValueCount === 0) {
+        throw new Error('invalid RLE bit-packed run length');
+      }
+      const outputCount = Math.min(runValueCount, count - outputOffset);
+      decodeBitPackedRun(cursor, runValueCount, outputCount, bitWidth, values, outputOffset);
+      outputOffset += outputCount;
     } else {
-      const count = header >> 1;
-      decodedValues = decodeRunRepeated(cursor, count, opts);
+      const runValueCount = header / 2;
+      if (runValueCount === 0) {
+        throw new Error('invalid RLE repeated run length');
+      }
+      const outputCount = Math.min(runValueCount, count - outputOffset);
+      const value = decodeRepeatedRun(cursor, bitWidth);
+      values.fill(value, outputOffset, outputOffset + outputCount);
+      outputOffset += outputCount;
     }
-
-    // strange failure in docusaurus / webpack if we don't cast the type here
-    for (const value of decodedValues as any[]) {
-      values.push(value);
-    }
-  }
-  values = values.slice(0, count);
-
-  if (values.length !== count) {
-    throw new Error('invalid RLE encoding');
   }
 
   return values;
 }
 
-function decodeRunBitpacked(
+/** Decodes one complete bit-packed run directly into the caller's output array. */
+function decodeBitPackedRun(
   cursor: CursorBuffer,
-  count: number,
-  opts: ParquetCodecOptions
-): number[] {
-  // @ts-ignore
-  const bitWidth: number = opts.bitWidth;
-
-  if (count % 8 !== 0) {
+  runValueCount: number,
+  outputCount: number,
+  bitWidth: number,
+  output: number[],
+  outputOffset: number
+): void {
+  if (runValueCount % 8 !== 0) {
     throw new Error('must be a multiple of 8');
   }
+  const packedByteLength = bitWidth * (runValueCount / 8);
+  const packedOffset = cursor.offset;
+  const size = cursor.size ?? cursor.buffer.length;
+  // Preserve compatibility with files whose malformed final dictionary run omits encoded bytes.
+  cursor.offset = Math.min(cursor.offset + packedByteLength, size);
 
-  // tslint:disable-next-line:prefer-array-literal
-  const values = new Array(count).fill(0);
-  for (let b = 0; b < bitWidth * count; b++) {
-    if (cursor.buffer[cursor.offset + Math.floor(b / 8)] & (1 << (b % 8))) {
-      values[Math.floor(b / bitWidth)] |= 1 << (b % bitWidth);
-    }
+  if (bitWidth === 0) {
+    output.fill(0, outputOffset, outputOffset + outputCount);
+    return;
+  }
+  if (bitWidth <= 24) {
+    decodeUint32BitPackedRun(
+      cursor.buffer,
+      packedOffset,
+      outputCount,
+      bitWidth,
+      output,
+      outputOffset
+    );
+    return;
+  }
+  if (bitWidth <= 45) {
+    decodeNumberBitPackedRun(
+      cursor.buffer,
+      packedOffset,
+      outputCount,
+      bitWidth,
+      output,
+      outputOffset
+    );
+    return;
   }
 
-  cursor.offset += bitWidth * (count / 8);
-  return values;
+  const bitWidthBigInt = BigInt(bitWidth);
+  const mask = (1n << bitWidthBigInt) - 1n;
+  let packedBits = 0n;
+  let packedBitCount = 0;
+  let byteOffset = packedOffset;
+  for (let valueIndex = 0; valueIndex < outputCount; valueIndex++) {
+    while (packedBitCount < bitWidth) {
+      packedBits |= BigInt(cursor.buffer[byteOffset++] ?? 0) << BigInt(packedBitCount);
+      packedBitCount += 8;
+    }
+    output[outputOffset + valueIndex] = Number(packedBits & mask);
+    packedBits >>= bitWidthBigInt;
+    packedBitCount -= bitWidth;
+  }
 }
 
-function decodeRunRepeated(
-  cursor: CursorBuffer,
+/** Decodes common narrow bit widths with a fast 32-bit reservoir. */
+function decodeUint32BitPackedRun(
+  buffer: Uint8Array,
+  packedOffset: number,
   count: number,
-  opts: ParquetCodecOptions
-): number[] {
-  // @ts-ignore
-  const bitWidth: number = opts.bitWidth;
-
-  let value = 0;
-  for (let i = 0; i < Math.ceil(bitWidth / 8); i++) {
-    // eslint-disable-next-line
-    value << 8; //  TODO - this looks wrong
-    value += cursor.buffer[cursor.offset];
-    cursor.offset += 1;
+  bitWidth: number,
+  output: number[],
+  outputOffset: number
+): void {
+  if (bitWidth === 8) {
+    for (let valueIndex = 0; valueIndex < count; valueIndex++) {
+      output[outputOffset + valueIndex] = buffer[packedOffset + valueIndex] ?? 0;
+    }
+    return;
   }
 
-  // tslint:disable-next-line:prefer-array-literal
-  return new Array(count).fill(value);
+  const mask = 2 ** bitWidth - 1;
+  let packedBits = 0;
+  let packedBitCount = 0;
+  let byteOffset = packedOffset;
+  for (let valueIndex = 0; valueIndex < count; valueIndex++) {
+    while (packedBitCount < bitWidth) {
+      packedBits |= (buffer[byteOffset++] ?? 0) << packedBitCount;
+      packedBitCount += 8;
+    }
+    output[outputOffset + valueIndex] = packedBits & mask;
+    packedBits >>>= bitWidth;
+    packedBitCount -= bitWidth;
+  }
+}
+
+/** Decodes a bit-packed run with an exact number-based bit reservoir. */
+function decodeNumberBitPackedRun(
+  buffer: Uint8Array,
+  packedOffset: number,
+  count: number,
+  bitWidth: number,
+  output: number[],
+  outputOffset: number
+): void {
+  const divisor = 2 ** bitWidth;
+  let packedBits = 0;
+  let packedBitCount = 0;
+  let byteOffset = packedOffset;
+  for (let valueIndex = 0; valueIndex < count; valueIndex++) {
+    while (packedBitCount < bitWidth) {
+      packedBits += (buffer[byteOffset++] ?? 0) * 2 ** packedBitCount;
+      packedBitCount += 8;
+    }
+    output[outputOffset + valueIndex] = packedBits % divisor;
+    packedBits = Math.floor(packedBits / divisor);
+    packedBitCount -= bitWidth;
+  }
+}
+
+/** Decodes the single little-endian value stored by a repeated run. */
+function decodeRepeatedRun(cursor: CursorBuffer, bitWidth: number): number {
+  const byteWidth = Math.ceil(bitWidth / 8);
+  assertReadable(cursor, byteWidth);
+  if (byteWidth <= 6) {
+    let value = 0;
+    let multiplier = 1;
+    for (let byteIndex = 0; byteIndex < byteWidth; byteIndex++) {
+      value += cursor.buffer[cursor.offset++] * multiplier;
+      multiplier *= 256;
+    }
+    return value;
+  }
+
+  let value = 0n;
+  for (let byteIndex = 0; byteIndex < byteWidth; byteIndex++) {
+    value |= BigInt(cursor.buffer[cursor.offset++]) << BigInt(byteIndex * 8);
+  }
+  return Number(value);
+}
+
+/** Reads an unsigned base-128 run header without allocating an intermediate buffer. */
+function readUnsignedVarIntNumber(cursor: CursorBuffer): number {
+  let value = 0;
+  let multiplier = 1;
+  for (let byteIndex = 0; byteIndex < 10; byteIndex++) {
+    assertReadable(cursor, 1);
+    const byte = cursor.buffer[cursor.offset++];
+    value += (byte & 0x7f) * multiplier;
+    if ((byte & 0x80) === 0) {
+      if (!Number.isSafeInteger(value)) {
+        throw new Error('RLE run header exceeds the safe integer range');
+      }
+      return value;
+    }
+    multiplier *= 128;
+  }
+  throw new Error('invalid RLE run header');
+}
+
+/** Ensures an RLE read stays within the current cursor. */
+function assertReadable(cursor: CursorBuffer, byteLength: number): void {
+  const size = cursor.size ?? cursor.buffer.length;
+  if (byteLength < 0 || cursor.offset + byteLength > size) {
+    throw new Error(
+      `unexpected end of RLE data (offset=${cursor.offset}, requested=${byteLength}, size=${size})`
+    );
+  }
 }
 
 function encodeRunBitpacked(values: number[], opts: ParquetCodecOptions): Uint8Array {

--- a/modules/parquet/src/parquetjs/parser/decoders.ts
+++ b/modules/parquet/src/parquetjs/parser/decoders.ts
@@ -44,20 +44,32 @@ export async function decodeDataPages(
     size: buffer.length
   };
 
+  const expectedLevelCount =
+    context.numValues === undefined ? undefined : Number(context.numValues);
+  if (
+    expectedLevelCount !== undefined &&
+    (!Number.isSafeInteger(expectedLevelCount) || expectedLevelCount < 0)
+  ) {
+    throw new Error(`Invalid Parquet column value count ${expectedLevelCount}`);
+  }
+
+  const outputCapacity = expectedLevelCount ?? 0;
   const data: ParquetColumnChunk = {
-    rlevels: [],
-    dlevels: [],
-    values: [],
+    rlevels: new Array<number>(outputCapacity),
+    dlevels: new Array<number>(outputCapacity),
+    values: new Array(outputCapacity),
     pageHeaders: [],
     count: 0
   };
 
   let dictionary = context.dictionary || [];
+  let levelOffset = 0;
+  let valueOffset = 0;
 
   while (
     // @ts-ignore size can be undefined
     cursor.offset < cursor.size &&
-    (!context.numValues || data.dlevels.length < Number(context.numValues))
+    (expectedLevelCount === undefined || levelOffset < expectedLevelCount)
   ) {
     // Looks like we have to decode these in sequence due to cursor updates?
     const page = await decodePage(cursor, context);
@@ -74,27 +86,30 @@ export async function decodeDataPages(
     ) as ParquetCodec;
     // Pages might be in different encodings. We don't need to decode in case
     // of 'PLAIN' encoding because all values are already in place
-    if (
+    const usesDictionary =
       dictionary.length &&
-      (valueEncoding === 'PLAIN_DICTIONARY' || valueEncoding === 'RLE_DICTIONARY')
-    ) {
-      // eslint-disable-next-line no-loop-func
-      page.values = page.values.map(value => dictionary[value]);
-    }
+      (valueEncoding === 'PLAIN_DICTIONARY' || valueEncoding === 'RLE_DICTIONARY');
 
     for (let index = 0; index < page.rlevels.length; index++) {
-      data.rlevels.push(page.rlevels[index]);
-      data.dlevels.push(page.dlevels[index]);
-      const value = page.values[index];
+      data.rlevels[levelOffset + index] = page.rlevels[index];
+      data.dlevels[levelOffset + index] = page.dlevels[index];
+    }
+    levelOffset += page.rlevels.length;
 
+    for (let index = 0; index < page.values.length; index++) {
+      const value = usesDictionary ? dictionary[page.values[index]] : page.values[index];
       if (value !== undefined) {
-        data.values.push(value);
+        data.values[valueOffset++] = value;
       }
     }
 
     data.count += page.count;
     data.pageHeaders.push(page.pageHeader);
   }
+
+  data.rlevels.length = levelOffset;
+  data.dlevels.length = levelOffset;
+  data.values.length = valueOffset;
 
   return data;
 }

--- a/modules/parquet/test/parquetjs/codec-rle.spec.ts
+++ b/modules/parquet/test/parquetjs/codec-rle.spec.ts
@@ -9,6 +9,23 @@ function bytes(values: number[]): Uint8Array {
   return new Uint8Array(values);
 }
 
+/** Encodes one eight-value bit-packed run for cross-width decoder tests. */
+function encodeBitPackedRun(values: number[], bitWidth: number): Uint8Array {
+  const encoded = [0x03];
+  let packedBits = 0n;
+  let packedBitCount = 0;
+  for (const value of values) {
+    packedBits |= BigInt(value) << BigInt(packedBitCount);
+    packedBitCount += bitWidth;
+    while (packedBitCount >= 8) {
+      encoded.push(Number(packedBits & 0xffn));
+      packedBits >>= 8n;
+      packedBitCount -= 8;
+    }
+  }
+  return bytes(encoded);
+}
+
 test('ParquetCodec::RLE#should encode bitpacked values', assert => {
   const buf = PARQUET_CODECS.RLE.encodeValues(
     'INT32',
@@ -55,12 +72,13 @@ test('ParquetCodec::RLE#should encode bitpacked values', assert => {
 });
 
 test('ParquetCodec::RLE#should decode bitpacked values', assert => {
+  const cursor = {
+    buffer: bytes([0x05, 0x88, 0xc6, 0xfa, 0x2e, 0x00, 0x00]),
+    offset: 0
+  };
   const vals = PARQUET_CODECS.RLE.decodeValues(
     'INT32',
-    {
-      buffer: bytes([0x05, 0x88, 0xc6, 0xfa, 0x2e, 0x00, 0x00]),
-      offset: 0,
-    },
+    cursor,
     10,
     {
       disableEnvelope: true,
@@ -68,6 +86,40 @@ test('ParquetCodec::RLE#should decode bitpacked values', assert => {
     });
 
   assert.deepEqual(vals, [0, 1, 2, 3, 4, 5, 6, 7, 6, 5]);
+  assert.equal(cursor.offset, cursor.buffer.length, 'consumes padding from the complete run');
+  assert.end();
+});
+
+test('ParquetCodec::RLE#decodes wide bitpacked values', assert => {
+  const vals = PARQUET_CODECS.RLE.decodeValues(
+    'INT32',
+    {
+      buffer: bytes([0x03, 0xbc, 0x3a, 0x12, 0xff, 0x0f, 0x00, 0x01, 0x20, 0x00, 0x03, 0x40, 0x00]),
+      offset: 0
+    },
+    8,
+    {
+      disableEnvelope: true,
+      bitWidth: 12
+    }
+  );
+
+  assert.deepEqual(vals, [0xabc, 0x123, 0xfff, 0, 1, 2, 3, 4]);
+  assert.end();
+});
+
+test('ParquetCodec::RLE#decodes every reservoir width', assert => {
+  for (const bitWidth of [0, 1, 7, 8, 9, 16, 24, 25, 32, 45, 46, 53, 64]) {
+    const divisor = bitWidth === 0 ? 1 : 2 ** Math.min(bitWidth, 52);
+    const values = [0, 1, 2, 3, 7, 15, 31, divisor - 1].map(value => value % divisor);
+    const decoded = PARQUET_CODECS.RLE.decodeValues(
+      'INT64',
+      {buffer: encodeBitPackedRun(values, bitWidth), offset: 0},
+      values.length,
+      {disableEnvelope: true, bitWidth}
+    );
+    assert.deepEqual(decoded, values, `decodes bit width ${bitWidth}`);
+  }
   assert.end();
 });
 
@@ -98,6 +150,38 @@ test('ParquetCodec::RLE#should decode repeated values', assert => {
     });
 
   assert.deepEqual(vals, [42, 42, 42, 42, 42, 42, 42, 42]);
+  assert.end();
+});
+
+test('ParquetCodec::RLE#decodes multi-byte repeated values as little endian', assert => {
+  const vals = PARQUET_CODECS.RLE.decodeValues(
+    'INT32',
+    {
+      buffer: bytes([0x10, 0xbc, 0x0a]),
+      offset: 0
+    },
+    8,
+    {
+      disableEnvelope: true,
+      bitWidth: 12
+    }
+  );
+
+  assert.deepEqual(vals, new Array(8).fill(0xabc));
+  assert.end();
+});
+
+test('ParquetCodec::RLE#zero-fills malformed dictionary runs', assert => {
+  assert.deepEqual(
+    PARQUET_CODECS.RLE.decodeValues(
+      'INT32',
+      {buffer: bytes([0x03, 0x88]), offset: 0},
+      8,
+      {disableEnvelope: true, bitWidth: 3}
+    ),
+    [0, 1, 2, 0, 0, 0, 0, 0],
+    'preserves compatibility with legacy files that omit trailing dictionary bytes'
+  );
   assert.end();
 });
 

--- a/modules/parquet/test/parquetjs/decoders.spec.ts
+++ b/modules/parquet/test/parquetjs/decoders.spec.ts
@@ -1,0 +1,52 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import type Int64 from 'node-int64';
+
+import {decodeDataPages} from '../../src/parquetjs/parser/decoders';
+import type {ParquetReaderContext} from '../../src/parquetjs/schema/declare';
+
+/** Minimal required-column context for page-assembly metadata tests. */
+const TEST_CONTEXT: ParquetReaderContext = {
+  type: 'INT32',
+  rLevelMax: 0,
+  dLevelMax: 0,
+  compression: 'UNCOMPRESSED',
+  column: {
+    name: 'value',
+    path: ['value'],
+    key: 'value',
+    primitiveType: 'INT32',
+    repetitionType: 'REQUIRED',
+    rLevelMax: 0,
+    dLevelMax: 0
+  }
+};
+
+test('decodeDataPages#returns preallocated empty column data', async t => {
+  const data = await decodeDataPages(new Uint8Array(), {
+    ...TEST_CONTEXT,
+    numValues: 0 as unknown as Int64
+  });
+
+  t.deepEqual(data.rlevels, [], 'returns no repetition levels');
+  t.deepEqual(data.dlevels, [], 'returns no definition levels');
+  t.deepEqual(data.values, [], 'returns no values');
+  t.deepEqual(data.pageHeaders, [], 'returns no page headers');
+  t.equal(data.count, 0, 'returns zero decoded values');
+  t.end();
+});
+
+test('decodeDataPages#rejects invalid metadata value counts', async t => {
+  await t.rejects(
+    decodeDataPages(new Uint8Array(), {
+      ...TEST_CONTEXT,
+      numValues: -1 as unknown as Int64
+    }),
+    /Invalid Parquet column value count -1/,
+    'rejects negative value counts before allocating page buffers'
+  );
+  t.end();
+});


### PR DESCRIPTION
## Goals

- Reduce the TypeScript Parquet loader's remaining per-row page-assembly overhead after decoding.
- Avoid redundant allocation and dictionary-mapping passes while preserving existing column-chunk output semantics.

## Changes

- Size repetition-level, definition-level, and value buffers from Parquet column metadata before decoding pages.
- Assemble page levels and values directly by index instead of repeatedly growing arrays with `push()`.
- Resolve dictionary indices while copying page values into the final column buffer, eliminating the intermediate `page.values.map(...)` allocation.
- Track decoded offsets independently so nullable columns retain compact non-null value arrays.
- Validate metadata value counts before allocating output buffers.
- Add shared Node/browser coverage for empty and invalid metadata counts.

## Performance

On the same local built stack and 20,000-row dictionary fixture, sustained Arrow decode improved from approximately **3.58M** to **4.13M rows/s** (about **15.4%**).

CPU profiles of the same workload also showed page-assembly samples falling by roughly half, moving the dominant remaining cost to Arrow byte-vector construction.

## Validation

- `yarn build`
- `yarn test-node` — 418 files, 2,029 tests passed
- `yarn test-headless` — 418 files, 1,991 tests passed
- `cd website && yarn && yarn build`
- `yarn lint fix`
- Focused loader, compatibility, typed-array, reader, and decoder tests — 168 tests passed
- Focused headless decoder test — 2 tests passed

## Stack

This draft targets `codex/parquet-rle-decode` and depends on:

1. #3574
2. #3575
3. #3576
4. #3577

It should be rebased or retargeted as the parent PRs land.