### PR TITLE
perf(parquet): accelerate Arrow byte assembly

### DIFF
--- a/modules/parquet/src/lib/parsers/parse-parquet-to-arrow-js.ts
+++ b/modules/parquet/src/lib/parsers/parse-parquet-to-arrow-js.ts
@@ -23,9 +23,11 @@ import type {
 } from '../../parquetjs/schema/declare';
 import type {ParquetSchema} from '../../parquetjs/schema/schema';
 import {materializeColumn, materializeRows} from '../../parquetjs/schema/shred';
-import {toUint8Array} from '../../parquetjs/utils/binary-utils';
 import {normalizeArrowTableGeoMetadata} from '../geo/geospatial-metadata';
 import {getSchemaFromParquetReader} from './get-parquet-schema';
+
+/** Largest byte value copied inline to avoid TypedArray#set call overhead. */
+const MAXIMUM_INLINE_BYTE_COPY_LENGTH = 7;
 
 /**
  * Parses a Parquet file with the TypeScript implementation directly into Arrow batches.
@@ -220,39 +222,57 @@ function createRawByteArrowVector(
 
   const rowCount = end - start;
   const valueOffsets = new Int32Array(rowCount + 1);
-  const nullBitmap = new Uint8Array(Math.ceil(rowCount / 8));
+  const byteValues = columnData.values as Uint8Array[];
+  const nullBitmap = parquetField.dLevelMax ? new Uint8Array(Math.ceil(rowCount / 8)) : undefined;
   let valueIndex = 0;
+  let firstValueIndex = 0;
   let dataByteLength = 0;
   let nullCount = 0;
 
-  for (let rowIndex = 0; rowIndex < start; rowIndex++) {
-    if (columnData.dlevels[rowIndex] === parquetField.dLevelMax) {
-      valueIndex++;
+  if (!nullBitmap) {
+    valueIndex = start;
+    firstValueIndex = valueIndex;
+    for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+      dataByteLength += byteValues[valueIndex++].byteLength;
+      if (dataByteLength > 0x7fffffff) {
+        throw new Error('Arrow Utf8/Binary column exceeds the 32-bit offset range');
+      }
+      valueOffsets[rowIndex + 1] = dataByteLength;
     }
-  }
-  const firstValueIndex = valueIndex;
-
-  for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
-    const sourceRowIndex = start + rowIndex;
-    if (columnData.dlevels[sourceRowIndex] === parquetField.dLevelMax) {
-      const bytes = toUint8Array(columnData.values[valueIndex++]);
-      dataByteLength += bytes.byteLength;
-      nullBitmap[rowIndex >> 3] |= 1 << (rowIndex & 7);
-    } else {
-      nullCount++;
+  } else {
+    for (let rowIndex = 0; rowIndex < start; rowIndex++) {
+      if (columnData.dlevels[rowIndex] === parquetField.dLevelMax) {
+        valueIndex++;
+      }
     }
-    if (dataByteLength > 0x7fffffff) {
-      throw new Error('Arrow Utf8/Binary column exceeds the 32-bit offset range');
+    firstValueIndex = valueIndex;
+    for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+      const sourceRowIndex = start + rowIndex;
+      if (columnData.dlevels[sourceRowIndex] === parquetField.dLevelMax) {
+        dataByteLength += byteValues[valueIndex++].byteLength;
+        nullBitmap[rowIndex >> 3] |= 1 << (rowIndex & 7);
+      } else {
+        nullCount++;
+      }
+      if (dataByteLength > 0x7fffffff) {
+        throw new Error('Arrow Utf8/Binary column exceeds the 32-bit offset range');
+      }
+      valueOffsets[rowIndex + 1] = dataByteLength;
     }
-    valueOffsets[rowIndex + 1] = dataByteLength;
   }
 
   const data = new Uint8Array(dataByteLength);
   let dataOffset = 0;
   for (let index = firstValueIndex; index < valueIndex; index++) {
-    const bytes = toUint8Array(columnData.values[index]);
-    data.set(bytes, dataOffset);
-    dataOffset += bytes.byteLength;
+    const bytes = byteValues[index];
+    if (bytes.byteLength <= MAXIMUM_INLINE_BYTE_COPY_LENGTH) {
+      for (let byteIndex = 0; byteIndex < bytes.byteLength; byteIndex++) {
+        data[dataOffset++] = bytes[byteIndex];
+      }
+    } else {
+      data.set(bytes, dataOffset);
+      dataOffset += bytes.byteLength;
+    }
   }
 
   const nulls = nullCount ? nullBitmap : undefined;

--- a/modules/parquet/src/parquetjs/codecs/rle.ts
+++ b/modules/parquet/src/parquetjs/codecs/rle.ts
@@ -79,85 +79,215 @@ export function decodeValues(
   type: PrimitiveType,
   cursor: CursorBuffer,
   count: number,
-  opts: ParquetCodecOptions
+  options: ParquetCodecOptions
 ): number[] {
-  if (!('bitWidth' in opts)) {
+  if (!('bitWidth' in options)) {
     throw new Error('bitWidth is required');
   }
+  const bitWidth = options.bitWidth!;
+  if (!Number.isInteger(bitWidth) || bitWidth < 0 || bitWidth > 64) {
+    throw new Error(`invalid bit width: ${bitWidth}`);
+  }
+  if (!Number.isInteger(count) || count < 0) {
+    throw new Error(`invalid value count: ${count}`);
+  }
 
-  if (!opts.disableEnvelope) {
+  if (!options.disableEnvelope) {
+    assertReadable(cursor, 4);
     cursor.offset += 4;
   }
 
-  let values: number[] = [];
-  while (values.length < count) {
-    const header = varint.decode(cursor.buffer as any, cursor.offset);
-    cursor.offset += varint.encodingLength(header);
-    let decodedValues: number[];
-    if (header & 1) {
-      const count = (header >> 1) * 8;
-      decodedValues = decodeRunBitpacked(cursor, count, opts);
+  const values = new Array<number>(count);
+  let outputOffset = 0;
+  while (outputOffset < count) {
+    const header = readUnsignedVarIntNumber(cursor);
+    if (header % 2 === 1) {
+      const runValueCount = ((header - 1) / 2) * 8;
+      if (runValueCount === 0) {
+        throw new Error('invalid RLE bit-packed run length');
+      }
+      const outputCount = Math.min(runValueCount, count - outputOffset);
+      decodeBitPackedRun(cursor, runValueCount, outputCount, bitWidth, values, outputOffset);
+      outputOffset += outputCount;
     } else {
-      const count = header >> 1;
-      decodedValues = decodeRunRepeated(cursor, count, opts);
+      const runValueCount = header / 2;
+      if (runValueCount === 0) {
+        throw new Error('invalid RLE repeated run length');
+      }
+      const outputCount = Math.min(runValueCount, count - outputOffset);
+      const value = decodeRepeatedRun(cursor, bitWidth);
+      values.fill(value, outputOffset, outputOffset + outputCount);
+      outputOffset += outputCount;
     }
-
-    // strange failure in docusaurus / webpack if we don't cast the type here
-    for (const value of decodedValues as any[]) {
-      values.push(value);
-    }
-  }
-  values = values.slice(0, count);
-
-  if (values.length !== count) {
-    throw new Error('invalid RLE encoding');
   }
 
   return values;
 }
 
-function decodeRunBitpacked(
+/** Decodes one complete bit-packed run directly into the caller's output array. */
+function decodeBitPackedRun(
   cursor: CursorBuffer,
-  count: number,
-  opts: ParquetCodecOptions
-): number[] {
-  // @ts-ignore
-  const bitWidth: number = opts.bitWidth;
-
-  if (count % 8 !== 0) {
+  runValueCount: number,
+  outputCount: number,
+  bitWidth: number,
+  output: number[],
+  outputOffset: number
+): void {
+  if (runValueCount % 8 !== 0) {
     throw new Error('must be a multiple of 8');
   }
+  const packedByteLength = bitWidth * (runValueCount / 8);
+  const packedOffset = cursor.offset;
+  const size = cursor.size ?? cursor.buffer.length;
+  // Preserve compatibility with files whose malformed final dictionary run omits encoded bytes.
+  cursor.offset = Math.min(cursor.offset + packedByteLength, size);
 
-  // tslint:disable-next-line:prefer-array-literal
-  const values = new Array(count).fill(0);
-  for (let b = 0; b < bitWidth * count; b++) {
-    if (cursor.buffer[cursor.offset + Math.floor(b / 8)] & (1 << (b % 8))) {
-      values[Math.floor(b / bitWidth)] |= 1 << (b % bitWidth);
-    }
+  if (bitWidth === 0) {
+    output.fill(0, outputOffset, outputOffset + outputCount);
+    return;
+  }
+  if (bitWidth <= 24) {
+    decodeUint32BitPackedRun(
+      cursor.buffer,
+      packedOffset,
+      outputCount,
+      bitWidth,
+      output,
+      outputOffset
+    );
+    return;
+  }
+  if (bitWidth <= 45) {
+    decodeNumberBitPackedRun(
+      cursor.buffer,
+      packedOffset,
+      outputCount,
+      bitWidth,
+      output,
+      outputOffset
+    );
+    return;
   }
 
-  cursor.offset += bitWidth * (count / 8);
-  return values;
+  const bitWidthBigInt = BigInt(bitWidth);
+  const mask = (1n << bitWidthBigInt) - 1n;
+  let packedBits = 0n;
+  let packedBitCount = 0;
+  let byteOffset = packedOffset;
+  for (let valueIndex = 0; valueIndex < outputCount; valueIndex++) {
+    while (packedBitCount < bitWidth) {
+      packedBits |= BigInt(cursor.buffer[byteOffset++] ?? 0) << BigInt(packedBitCount);
+      packedBitCount += 8;
+    }
+    output[outputOffset + valueIndex] = Number(packedBits & mask);
+    packedBits >>= bitWidthBigInt;
+    packedBitCount -= bitWidth;
+  }
 }
 
-function decodeRunRepeated(
-  cursor: CursorBuffer,
+/** Decodes common narrow bit widths with a fast 32-bit reservoir. */
+function decodeUint32BitPackedRun(
+  buffer: Uint8Array,
+  packedOffset: number,
   count: number,
-  opts: ParquetCodecOptions
-): number[] {
-  // @ts-ignore
-  const bitWidth: number = opts.bitWidth;
-
-  let value = 0;
-  for (let i = 0; i < Math.ceil(bitWidth / 8); i++) {
-    // eslint-disable-next-line
-    value << 8; //  TODO - this looks wrong
-    value += cursor.buffer[cursor.offset];
-    cursor.offset += 1;
+  bitWidth: number,
+  output: number[],
+  outputOffset: number
+): void {
+  if (bitWidth === 8) {
+    for (let valueIndex = 0; valueIndex < count; valueIndex++) {
+      output[outputOffset + valueIndex] = buffer[packedOffset + valueIndex] ?? 0;
+    }
+    return;
   }
 
-  // tslint:disable-next-line:prefer-array-literal
-  return new Array(count).fill(value);
+  const mask = 2 ** bitWidth - 1;
+  let packedBits = 0;
+  let packedBitCount = 0;
+  let byteOffset = packedOffset;
+  for (let valueIndex = 0; valueIndex < count; valueIndex++) {
+    while (packedBitCount < bitWidth) {
+      packedBits |= (buffer[byteOffset++] ?? 0) << packedBitCount;
+      packedBitCount += 8;
+    }
+    output[outputOffset + valueIndex] = packedBits & mask;
+    packedBits >>>= bitWidth;
+    packedBitCount -= bitWidth;
+  }
+}
+
+/** Decodes a bit-packed run with an exact number-based bit reservoir. */
+function decodeNumberBitPackedRun(
+  buffer: Uint8Array,
+  packedOffset: number,
+  count: number,
+  bitWidth: number,
+  output: number[],
+  outputOffset: number
+): void {
+  const divisor = 2 ** bitWidth;
+  let packedBits = 0;
+  let packedBitCount = 0;
+  let byteOffset = packedOffset;
+  for (let valueIndex = 0; valueIndex < count; valueIndex++) {
+    while (packedBitCount < bitWidth) {
+      packedBits += (buffer[byteOffset++] ?? 0) * 2 ** packedBitCount;
+      packedBitCount += 8;
+    }
+    output[outputOffset + valueIndex] = packedBits % divisor;
+    packedBits = Math.floor(packedBits / divisor);
+    packedBitCount -= bitWidth;
+  }
+}
+
+/** Decodes the single little-endian value stored by a repeated run. */
+function decodeRepeatedRun(cursor: CursorBuffer, bitWidth: number): number {
+  const byteWidth = Math.ceil(bitWidth / 8);
+  assertReadable(cursor, byteWidth);
+  if (byteWidth <= 6) {
+    let value = 0;
+    let multiplier = 1;
+    for (let byteIndex = 0; byteIndex < byteWidth; byteIndex++) {
+      value += cursor.buffer[cursor.offset++] * multiplier;
+      multiplier *= 256;
+    }
+    return value;
+  }
+
+  let value = 0n;
+  for (let byteIndex = 0; byteIndex < byteWidth; byteIndex++) {
+    value |= BigInt(cursor.buffer[cursor.offset++]) << BigInt(byteIndex * 8);
+  }
+  return Number(value);
+}
+
+/** Reads an unsigned base-128 run header without allocating an intermediate buffer. */
+function readUnsignedVarIntNumber(cursor: CursorBuffer): number {
+  let value = 0;
+  let multiplier = 1;
+  for (let byteIndex = 0; byteIndex < 10; byteIndex++) {
+    assertReadable(cursor, 1);
+    const byte = cursor.buffer[cursor.offset++];
+    value += (byte & 0x7f) * multiplier;
+    if ((byte & 0x80) === 0) {
+      if (!Number.isSafeInteger(value)) {
+        throw new Error('RLE run header exceeds the safe integer range');
+      }
+      return value;
+    }
+    multiplier *= 128;
+  }
+  throw new Error('invalid RLE run header');
+}
+
+/** Ensures an RLE read stays within the current cursor. */
+function assertReadable(cursor: CursorBuffer, byteLength: number): void {
+  const size = cursor.size ?? cursor.buffer.length;
+  if (byteLength < 0 || cursor.offset + byteLength > size) {
+    throw new Error(
+      `unexpected end of RLE data (offset=${cursor.offset}, requested=${byteLength}, size=${size})`
+    );
+  }
 }
 
 function encodeRunBitpacked(values: number[], opts: ParquetCodecOptions): Uint8Array {

--- a/modules/parquet/src/parquetjs/parser/decoders.ts
+++ b/modules/parquet/src/parquetjs/parser/decoders.ts
@@ -44,20 +44,32 @@ export async function decodeDataPages(
     size: buffer.length
   };
 
+  const expectedLevelCount =
+    context.numValues === undefined ? undefined : Number(context.numValues);
+  if (
+    expectedLevelCount !== undefined &&
+    (!Number.isSafeInteger(expectedLevelCount) || expectedLevelCount < 0)
+  ) {
+    throw new Error(`Invalid Parquet column value count ${expectedLevelCount}`);
+  }
+
+  const outputCapacity = expectedLevelCount ?? 0;
   const data: ParquetColumnChunk = {
-    rlevels: [],
-    dlevels: [],
-    values: [],
+    rlevels: new Array<number>(outputCapacity),
+    dlevels: new Array<number>(outputCapacity),
+    values: new Array(outputCapacity),
     pageHeaders: [],
     count: 0
   };
 
   let dictionary = context.dictionary || [];
+  let levelOffset = 0;
+  let valueOffset = 0;
 
   while (
     // @ts-ignore size can be undefined
     cursor.offset < cursor.size &&
-    (!context.numValues || data.dlevels.length < Number(context.numValues))
+    (expectedLevelCount === undefined || levelOffset < expectedLevelCount)
   ) {
     // Looks like we have to decode these in sequence due to cursor updates?
     const page = await decodePage(cursor, context);
@@ -74,27 +86,30 @@ export async function decodeDataPages(
     ) as ParquetCodec;
     // Pages might be in different encodings. We don't need to decode in case
     // of 'PLAIN' encoding because all values are already in place
-    if (
+    const usesDictionary =
       dictionary.length &&
-      (valueEncoding === 'PLAIN_DICTIONARY' || valueEncoding === 'RLE_DICTIONARY')
-    ) {
-      // eslint-disable-next-line no-loop-func
-      page.values = page.values.map(value => dictionary[value]);
-    }
+      (valueEncoding === 'PLAIN_DICTIONARY' || valueEncoding === 'RLE_DICTIONARY');
 
     for (let index = 0; index < page.rlevels.length; index++) {
-      data.rlevels.push(page.rlevels[index]);
-      data.dlevels.push(page.dlevels[index]);
-      const value = page.values[index];
+      data.rlevels[levelOffset + index] = page.rlevels[index];
+      data.dlevels[levelOffset + index] = page.dlevels[index];
+    }
+    levelOffset += page.rlevels.length;
 
+    for (let index = 0; index < page.values.length; index++) {
+      const value = usesDictionary ? dictionary[page.values[index]] : page.values[index];
       if (value !== undefined) {
-        data.values.push(value);
+        data.values[valueOffset++] = value;
       }
     }
 
     data.count += page.count;
     data.pageHeaders.push(page.pageHeader);
   }
+
+  data.rlevels.length = levelOffset;
+  data.dlevels.length = levelOffset;
+  data.values.length = valueOffset;
 
   return data;
 }

--- a/modules/parquet/test/parquet-loader.spec.ts
+++ b/modules/parquet/test/parquet-loader.spec.ts
@@ -113,6 +113,42 @@ test('ParquetJSLoader#loads the dictionary benchmark fixture', async (t) => {
   t.end();
 });
 
+test('ParquetJSLoader#arrow-table preserves ranged dictionary byte values', async (t) => {
+  const url = '@loaders.gl/parquet/test/data/benchmark-dictionary.parquet';
+  const parquetOptions = {
+    shape: 'arrow-table' as const,
+    columns: ['category', 'nullableLabel'],
+    offset: 4094,
+    limit: 5
+  };
+  const arrowTable = await load(url, ParquetJSLoader, {
+    core: {worker: false},
+    parquet: parquetOptions
+  });
+  const objectRowTable = await load(url, ParquetJSLoader, {
+    core: {worker: false},
+    parquet: {...parquetOptions, shape: 'object-row-table'}
+  });
+
+  t.equal(arrowTable.shape, 'arrow-table');
+  t.equal(objectRowTable.shape, 'object-row-table');
+  if (arrowTable.shape === 'arrow-table' && objectRowTable.shape === 'object-row-table') {
+    t.deepEqual(
+      arrowTable.data.batches.map(batch => batch.numRows),
+      [2, 3],
+      'retains row-group boundaries'
+    );
+    for (const columnName of parquetOptions.columns) {
+      t.deepEqual(
+        arrowTable.data.getChild(columnName)?.toArray(),
+        objectRowTable.data.map(row => row[columnName] ?? null),
+        `${columnName} values and nulls match object-row decoding`
+      );
+    }
+  }
+  t.end();
+});
+
 test('ParquetJSLoader#load arrow-table preserves schema for empty results', async (t) => {
   const url = '@loaders.gl/parquet/test/data/apache/good/alltypes_dictionary.parquet';
   const table = await load(url, ParquetJSLoader, {

--- a/modules/parquet/test/parquetjs/codec-rle.spec.ts
+++ b/modules/parquet/test/parquetjs/codec-rle.spec.ts
@@ -9,6 +9,23 @@ function bytes(values: number[]): Uint8Array {
   return new Uint8Array(values);
 }
 
+/** Encodes one eight-value bit-packed run for cross-width decoder tests. */
+function encodeBitPackedRun(values: number[], bitWidth: number): Uint8Array {
+  const encoded = [0x03];
+  let packedBits = 0n;
+  let packedBitCount = 0;
+  for (const value of values) {
+    packedBits |= BigInt(value) << BigInt(packedBitCount);
+    packedBitCount += bitWidth;
+    while (packedBitCount >= 8) {
+      encoded.push(Number(packedBits & 0xffn));
+      packedBits >>= 8n;
+      packedBitCount -= 8;
+    }
+  }
+  return bytes(encoded);
+}
+
 test('ParquetCodec::RLE#should encode bitpacked values', assert => {
   const buf = PARQUET_CODECS.RLE.encodeValues(
     'INT32',
@@ -55,12 +72,13 @@ test('ParquetCodec::RLE#should encode bitpacked values', assert => {
 });
 
 test('ParquetCodec::RLE#should decode bitpacked values', assert => {
+  const cursor = {
+    buffer: bytes([0x05, 0x88, 0xc6, 0xfa, 0x2e, 0x00, 0x00]),
+    offset: 0
+  };
   const vals = PARQUET_CODECS.RLE.decodeValues(
     'INT32',
-    {
-      buffer: bytes([0x05, 0x88, 0xc6, 0xfa, 0x2e, 0x00, 0x00]),
-      offset: 0,
-    },
+    cursor,
     10,
     {
       disableEnvelope: true,
@@ -68,6 +86,40 @@ test('ParquetCodec::RLE#should decode bitpacked values', assert => {
     });
 
   assert.deepEqual(vals, [0, 1, 2, 3, 4, 5, 6, 7, 6, 5]);
+  assert.equal(cursor.offset, cursor.buffer.length, 'consumes padding from the complete run');
+  assert.end();
+});
+
+test('ParquetCodec::RLE#decodes wide bitpacked values', assert => {
+  const vals = PARQUET_CODECS.RLE.decodeValues(
+    'INT32',
+    {
+      buffer: bytes([0x03, 0xbc, 0x3a, 0x12, 0xff, 0x0f, 0x00, 0x01, 0x20, 0x00, 0x03, 0x40, 0x00]),
+      offset: 0
+    },
+    8,
+    {
+      disableEnvelope: true,
+      bitWidth: 12
+    }
+  );
+
+  assert.deepEqual(vals, [0xabc, 0x123, 0xfff, 0, 1, 2, 3, 4]);
+  assert.end();
+});
+
+test('ParquetCodec::RLE#decodes every reservoir width', assert => {
+  for (const bitWidth of [0, 1, 7, 8, 9, 16, 24, 25, 32, 45, 46, 53, 64]) {
+    const divisor = bitWidth === 0 ? 1 : 2 ** Math.min(bitWidth, 52);
+    const values = [0, 1, 2, 3, 7, 15, 31, divisor - 1].map(value => value % divisor);
+    const decoded = PARQUET_CODECS.RLE.decodeValues(
+      'INT64',
+      {buffer: encodeBitPackedRun(values, bitWidth), offset: 0},
+      values.length,
+      {disableEnvelope: true, bitWidth}
+    );
+    assert.deepEqual(decoded, values, `decodes bit width ${bitWidth}`);
+  }
   assert.end();
 });
 
@@ -98,6 +150,38 @@ test('ParquetCodec::RLE#should decode repeated values', assert => {
     });
 
   assert.deepEqual(vals, [42, 42, 42, 42, 42, 42, 42, 42]);
+  assert.end();
+});
+
+test('ParquetCodec::RLE#decodes multi-byte repeated values as little endian', assert => {
+  const vals = PARQUET_CODECS.RLE.decodeValues(
+    'INT32',
+    {
+      buffer: bytes([0x10, 0xbc, 0x0a]),
+      offset: 0
+    },
+    8,
+    {
+      disableEnvelope: true,
+      bitWidth: 12
+    }
+  );
+
+  assert.deepEqual(vals, new Array(8).fill(0xabc));
+  assert.end();
+});
+
+test('ParquetCodec::RLE#zero-fills malformed dictionary runs', assert => {
+  assert.deepEqual(
+    PARQUET_CODECS.RLE.decodeValues(
+      'INT32',
+      {buffer: bytes([0x03, 0x88]), offset: 0},
+      8,
+      {disableEnvelope: true, bitWidth: 3}
+    ),
+    [0, 1, 2, 0, 0, 0, 0, 0],
+    'preserves compatibility with legacy files that omit trailing dictionary bytes'
+  );
   assert.end();
 });
 

--- a/modules/parquet/test/parquetjs/decoders.spec.ts
+++ b/modules/parquet/test/parquetjs/decoders.spec.ts
@@ -1,0 +1,52 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import type Int64 from 'node-int64';
+
+import {decodeDataPages} from '../../src/parquetjs/parser/decoders';
+import type {ParquetReaderContext} from '../../src/parquetjs/schema/declare';
+
+/** Minimal required-column context for page-assembly metadata tests. */
+const TEST_CONTEXT: ParquetReaderContext = {
+  type: 'INT32',
+  rLevelMax: 0,
+  dLevelMax: 0,
+  compression: 'UNCOMPRESSED',
+  column: {
+    name: 'value',
+    path: ['value'],
+    key: 'value',
+    primitiveType: 'INT32',
+    repetitionType: 'REQUIRED',
+    rLevelMax: 0,
+    dLevelMax: 0
+  }
+};
+
+test('decodeDataPages#returns preallocated empty column data', async t => {
+  const data = await decodeDataPages(new Uint8Array(), {
+    ...TEST_CONTEXT,
+    numValues: 0 as unknown as Int64
+  });
+
+  t.deepEqual(data.rlevels, [], 'returns no repetition levels');
+  t.deepEqual(data.dlevels, [], 'returns no definition levels');
+  t.deepEqual(data.values, [], 'returns no values');
+  t.deepEqual(data.pageHeaders, [], 'returns no page headers');
+  t.equal(data.count, 0, 'returns zero decoded values');
+  t.end();
+});
+
+test('decodeDataPages#rejects invalid metadata value counts', async t => {
+  await t.rejects(
+    decodeDataPages(new Uint8Array(), {
+      ...TEST_CONTEXT,
+      numValues: -1 as unknown as Int64
+    }),
+    /Invalid Parquet column value count -1/,
+    'rejects negative value counts before allocating page buffers'
+  );
+  t.end();
+});


### PR DESCRIPTION
## Goals

- Reduce Arrow Utf8/Binary materialization overhead in the TypeScript Parquet loader.
- Preserve required, nullable, ranged, and cross-row-group Arrow output semantics.

## Changes

- Reuse the retained decoded `Uint8Array` values directly instead of normalizing every value twice.
- Give required byte columns a dedicated offset path that avoids definition-level reads and null-bitmap allocation.
- Copy tiny dictionary byte values inline to avoid per-value `TypedArray#set` overhead while retaining bulk copies for larger values.
- Add a ranged dictionary regression test spanning two row groups and covering required and nullable Utf8 columns.

## Performance

Same-process Node 24 measurements against the parent tip after warm-up:

- 20K-row RLE_DICTIONARY Arrow table: 4.73 ms -> 4.33 ms per decode (~8.5%).
- LZ4_RAW Arrow table: 1.45 ms -> 1.35 ms per decode (~6.7%).
- DELTA_BYTE_ARRAY Arrow table: 1.95 ms -> 1.84 ms per decode (~5.9%).

The isolated byte-vector assembly kernel improves approximately 9-18%, depending on nullability.

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn test-node` (418 files, 2030 tests passed)
- `yarn test-headless` (418 files, 1992 tests passed)
- `cd website && yarn && yarn build`

## Stack

- Stacked on #3578.
- Relative to the base branch, this PR changes two files. Compared with `master`, it also contains the prerequisite Parquet performance stack #3574-#3578; review the tranche against `codex/parquet-page-assembly`.