### PR TITLE
perf(parquet): build primitive Arrow vectors directly

### DIFF
--- a/modules/parquet/src/lib/parsers/parse-parquet-to-arrow-js.ts
+++ b/modules/parquet/src/lib/parsers/parse-parquet-to-arrow-js.ts
@@ -165,6 +165,17 @@ function convertRowGroupSliceToArrow(
   for (const field of arrowSchema.fields) {
     const parquetField = parquetSchema.findField(field.name);
     const columnData = rowGroup.columnData[field.name];
+    const primitiveVector = createRawPrimitiveArrowVector(
+      field.type,
+      parquetField,
+      columnData,
+      start,
+      end
+    );
+    if (primitiveVector) {
+      vectors[field.name] = primitiveVector;
+      continue;
+    }
     const byteVector = createRawByteArrowVector(field.type, parquetField, columnData, start, end);
     if (byteVector) {
       vectors[field.name] = byteVector;
@@ -206,6 +217,79 @@ function createArrowTable(
   // Struct to zero rows. Restore the explicit Parquet selection length after construction.
   Object.defineProperty(recordBatch.data, 'length', {value: rowCount});
   return new arrow.Table(schema, [recordBatch]);
+}
+
+/** Typed arrays accepted by the direct primitive Arrow materialization path. */
+type RawPrimitiveArrowArray = Float32Array | Float64Array | Int32Array;
+
+/** Creates a fixed-width Arrow vector directly from decoded primitive Parquet values. */
+function createRawPrimitiveArrowVector(
+  arrowType: arrow.DataType,
+  parquetField: ParquetField,
+  columnData: ParquetColumnChunk | undefined,
+  start: number,
+  end: number
+): arrow.Vector | undefined {
+  if (!columnData) {
+    return undefined;
+  }
+  const rowCount = end - start;
+  const data = createRawPrimitiveArrowArray(arrowType, parquetField, rowCount);
+  if (!data) {
+    return undefined;
+  }
+
+  const nullBitmap = parquetField.dLevelMax ? new Uint8Array(Math.ceil(rowCount / 8)) : undefined;
+  let valueIndex = 0;
+  let nullCount = 0;
+
+  if (!nullBitmap) {
+    valueIndex = start;
+    for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+      data[rowIndex] = Number(columnData.values[valueIndex++]);
+    }
+  } else {
+    for (let rowIndex = 0; rowIndex < start; rowIndex++) {
+      if (columnData.dlevels[rowIndex] === parquetField.dLevelMax) {
+        valueIndex++;
+      }
+    }
+    for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+      const sourceRowIndex = start + rowIndex;
+      if (columnData.dlevels[sourceRowIndex] === parquetField.dLevelMax) {
+        data[rowIndex] = Number(columnData.values[valueIndex++]);
+        nullBitmap[rowIndex >> 3] |= 1 << (rowIndex & 7);
+      } else {
+        nullCount++;
+      }
+    }
+  }
+
+  const nulls = nullCount ? nullBitmap : undefined;
+  return new arrow.Vector([
+    arrow.makeData({type: arrowType, data, nullBitmap: nulls, nullCount} as any)
+  ]);
+}
+
+/** Allocates the Arrow typed array matching an unconverted physical Parquet primitive. */
+function createRawPrimitiveArrowArray(
+  arrowType: arrow.DataType,
+  parquetField: ParquetField,
+  rowCount: number
+): RawPrimitiveArrowArray | undefined {
+  if (parquetField.originalType) {
+    return undefined;
+  }
+  if (parquetField.primitiveType === 'FLOAT' && arrowType instanceof arrow.Float32) {
+    return new Float32Array(rowCount);
+  }
+  if (parquetField.primitiveType === 'DOUBLE' && arrowType instanceof arrow.Float64) {
+    return new Float64Array(rowCount);
+  }
+  if (parquetField.primitiveType === 'INT32' && arrowType instanceof arrow.Int32) {
+    return new Int32Array(rowCount);
+  }
+  return undefined;
 }
 
 /** Creates an Arrow Utf8 or Binary vector directly from decoded Parquet byte arrays. */

--- a/modules/parquet/test/parquet-loader.spec.ts
+++ b/modules/parquet/test/parquet-loader.spec.ts
@@ -113,11 +113,11 @@ test('ParquetJSLoader#loads the dictionary benchmark fixture', async (t) => {
   t.end();
 });
 
-test('ParquetJSLoader#arrow-table preserves ranged dictionary byte values', async (t) => {
+test('ParquetJSLoader#arrow-table preserves ranged dictionary values', async (t) => {
   const url = '@loaders.gl/parquet/test/data/benchmark-dictionary.parquet';
   const parquetOptions = {
     shape: 'arrow-table' as const,
-    columns: ['category', 'nullableLabel'],
+    columns: ['category', 'nullableLabel', 'quantity', 'price'],
     offset: 4094,
     limit: 5
   };
@@ -140,7 +140,41 @@ test('ParquetJSLoader#arrow-table preserves ranged dictionary byte values', asyn
     );
     for (const columnName of parquetOptions.columns) {
       t.deepEqual(
-        arrowTable.data.getChild(columnName)?.toArray(),
+        Array.from(arrowTable.data.getChild(columnName) || []),
+        objectRowTable.data.map(row => row[columnName] ?? null),
+        `${columnName} values and nulls match object-row decoding`
+      );
+    }
+  }
+  t.end();
+});
+
+test('ParquetJSLoader#arrow-table preserves ranged physical integer values', async (t) => {
+  const url = '@loaders.gl/parquet/test/data/apache/good/delta_binary_packed.parquet';
+  const columns = ['bitwidth0', 'bitwidth32', 'bitwidth64', 'int_value'];
+  const parquetOptions = {
+    shape: 'arrow-table' as const,
+    columns,
+    offset: 3,
+    limit: 5
+  };
+  const arrowTable = await load(url, ParquetJSLoader, {
+    core: {worker: false},
+    parquet: parquetOptions
+  });
+  const objectRowTable = await load(url, ParquetJSLoader, {
+    core: {worker: false},
+    parquet: {...parquetOptions, shape: 'object-row-table'}
+  });
+
+  t.equal(arrowTable.shape, 'arrow-table');
+  t.equal(objectRowTable.shape, 'object-row-table');
+  if (arrowTable.shape === 'arrow-table' && objectRowTable.shape === 'object-row-table') {
+    for (const columnName of columns) {
+      t.deepEqual(
+        Array.from(arrowTable.data.getChild(columnName) || [], value =>
+          typeof value === 'bigint' ? Number(value) : value
+        ),
         objectRowTable.data.map(row => row[columnName] ?? null),
         `${columnName} values and nulls match object-row decoding`
       );


### PR DESCRIPTION
## Goals

- Reduce ParquetJSLoader Arrow materialization overhead for common primitive columns.
- Preserve row-range selection, null handling, and Arrow type fidelity while bypassing generic Apache Arrow builders.

## Changes compared with master

- Builds unconverted physical FLOAT, DOUBLE, and INT32 columns directly into typed Arrow buffers.
- Creates Arrow validity bitmaps while copying selected optional values, avoiding intermediate JavaScript arrays and builder iteration.
- Keeps converted logical types and INT64 on the existing compatibility path.
- Extends ranged cross-row-group coverage to numeric dictionary columns and physical integer columns.
- This PR is stacked on #3579; the focused delta against its base is two files. The master comparison also contains prerequisite Parquet performance tranches #3574 through #3579.

## Performance

Same-process local medians against #3579:

- Dictionary numeric projection to Arrow: 2.44 ms to 1.34 ms per decode, about 45% faster.
- Full mixed dictionary table to Arrow: 4.49 ms to 3.51 ms per decode, about 22% faster.

## Validation

- yarn install
- yarn lint fix
- yarn build
- yarn test-node: 418 files, 2031 tests passed
- yarn test-headless: 418 files, 1993 tests passed
- website yarn install and yarn build