### PR TITLE
perf(parquet): reuse Arrow schemas across row groups

### DIFF
--- a/modules/parquet/src/lib/arrow/convert-schema-from-parquet.ts
+++ b/modules/parquet/src/lib/arrow/convert-schema-from-parquet.ts
@@ -96,16 +96,21 @@ function getField(name: string, field: FieldDefinition): Field {
   };
 }
 
+/** Returns defined physical field properties as Arrow-compatible string metadata. */
 function getFieldMetadata(field: FieldDefinition): Record<string, string> | undefined {
   let metadata: Record<string, string> | undefined;
 
   for (const key in field) {
-    if (key !== 'name') {
-      let value = field[key] || '';
-      value = typeof field[key] !== 'string' ? JSON.stringify(field[key]) : field[key];
-      metadata = metadata || {};
-      metadata[key] = value;
+    const fieldValue = field[key];
+    if (key === 'name' || fieldValue === undefined) {
+      continue;
     }
+    const metadataValue = typeof fieldValue === 'string' ? fieldValue : JSON.stringify(fieldValue);
+    if (metadataValue === undefined) {
+      continue;
+    }
+    metadata ||= {};
+    metadata[key] = metadataValue;
   }
 
   return metadata;

--- a/modules/parquet/src/lib/parsers/parse-parquet-to-arrow-js.ts
+++ b/modules/parquet/src/lib/parsers/parse-parquet-to-arrow-js.ts
@@ -23,7 +23,6 @@ import type {
 } from '../../parquetjs/schema/declare';
 import type {ParquetSchema} from '../../parquetjs/schema/schema';
 import {materializeColumn, materializeRows} from '../../parquetjs/schema/shred';
-import {normalizeArrowTableGeoMetadata} from '../geo/geospatial-metadata';
 import {getSchemaFromParquetReader} from './get-parquet-schema';
 
 /** Largest byte value copied inline to avoid TypedArray#set call overhead. */
@@ -51,10 +50,7 @@ export async function parseParquetFileToArrowWithJs(
   const table = recordBatches.length
     ? new arrow.Table(recordBatches)
     : new arrow.Table(convertSchemaToArrow(schema), []);
-  return normalizeArrowTableGeoMetadata(
-    {shape: 'arrow-table', data: table, schema},
-    schema.metadata
-  );
+  return {shape: 'arrow-table', data: table, schema};
 }
 
 /** Reads the projected loaders.gl schema when row selection produces no Arrow record batches. */
@@ -86,6 +82,7 @@ export async function* parseParquetFileToArrowInBatchesWithJs(
     retainByteArrayViews: true
   });
   const schema = projectSchema(await getSchemaFromParquetReader(reader), options?.parquet?.columns);
+  const arrowSchema = convertSchemaToArrow(schema);
   const parquetSchema = await reader.getSchema();
   const rowGroups = reader.rowGroupIterator(getParquetIterationProps(options));
   const rowOffset = Math.max(0, options?.parquet?.offset || 0);
@@ -111,9 +108,13 @@ export async function* parseParquetFileToArrowInBatchesWithJs(
       continue;
     }
 
-    const arrowTable = normalizeArrowTableGeoMetadata(
-      convertRowGroupSliceToArrow(schema, parquetSchema, rowGroup, selectionStart, selectionEnd),
-      schema.metadata
+    const arrowTable = convertRowGroupSliceToArrow(
+      schema,
+      arrowSchema,
+      parquetSchema,
+      rowGroup,
+      selectionStart,
+      selectionEnd
     );
     const batchSize =
       requestedBatchSize && requestedBatchSize > 0 ? requestedBatchSize : remainingRowCount;
@@ -146,6 +147,7 @@ export async function* parseParquetFileToArrowInBatchesWithJs(
 /** Builds Arrow from one selected row-group range and falls back for nested columns. */
 function convertRowGroupSliceToArrow(
   schema: Schema,
+  arrowSchema: arrow.Schema,
   parquetSchema: ParquetSchema,
   rowGroup: ParquetRowGroup,
   start: number,
@@ -160,7 +162,6 @@ function convertRowGroupSliceToArrow(
     return convertTable(table, 'arrow-table');
   }
 
-  const arrowSchema = convertSchemaToArrow(schema);
   const vectors: Record<string, arrow.Vector> = {};
   for (const field of arrowSchema.fields) {
     const parquetField = parquetSchema.findField(field.name);

--- a/modules/parquet/test/parquet-arrow-loader.spec.ts
+++ b/modules/parquet/test/parquet-arrow-loader.spec.ts
@@ -176,6 +176,18 @@ test('ParquetJSLoader#arrow-table preserves GeoParquet metadata', async (t) => {
     'wkb',
     'TypeScript implementation preserves GeoParquet schema metadata'
   );
+  t.equal(
+    table.data.schema.fields
+      .find(field => field.name === 'geometry')
+      ?.metadata.get('ARROW:extension:name'),
+    'geoarrow.wkb',
+    'TypeScript Arrow schema preserves GeoArrow field metadata'
+  );
+  t.ok(table.data.schema.metadata.get('geo'), 'TypeScript Arrow schema preserves GeoParquet metadata');
+  t.notOk(
+    table.data.schema.fields.find(field => field.name === 'pop_est')?.metadata.has('typeLength'),
+    'TypeScript Arrow schema omits absent physical metadata'
+  );
   t.end();
 });
 test('ParquetLoader#load supports arrow-table shape', async (t) => {
@@ -221,6 +233,19 @@ test('ParquetJSLoader#arrow-table supports loadInBatches', async (t) => {
   for await (const batch of iterator) {
     t.equal(batch.shape, 'arrow-table');
     t.ok(batch.data instanceof arrow.Table, 'returns Apache Arrow table batches');
+    t.equal(
+      getGeometryColumnsFromSchema(batch.schema).geometry?.encoding,
+      'geoarrow.wkb',
+      'batch loaders.gl schema includes GeoArrow field metadata'
+    );
+    t.equal(
+      batch.data.schema.fields
+        .find(field => field.name === 'geometry')
+        ?.metadata.get('ARROW:extension:name'),
+      'geoarrow.wkb',
+      'batch Arrow schema includes GeoArrow field metadata'
+    );
+    t.ok(batch.data.schema.metadata.get('geo'), 'batch Arrow schema preserves GeoParquet metadata');
     rowCount += batch.length;
   }
   t.equal(rowCount, 5, 'returns all requested rows');


### PR DESCRIPTION
## Goals

- Reduce fixed ParquetJSLoader Arrow setup costs for small files and row-group batches.
- Preserve loaders.gl, Arrow, GeoParquet, and GeoArrow metadata without repeated schema round-trips.

## Changes compared with master

- Converts the projected loaders.gl schema to Apache Arrow once per file and reuses it across flat row groups.
- Removes redundant per-row-group and final Arrow-to-loaders.gl-to-Arrow metadata normalization from the TypeScript parser.
- Omits absent physical Parquet properties instead of emitting undefined Arrow metadata values or literal undefined strings.
- Extends GeoParquet coverage for full-table and batched TypeScript output, including Arrow field and top-level metadata.
- This PR is stacked on #3580. The focused delta against its base is three files; the master comparison also contains prerequisite Parquet performance tranches #3574 through #3580.

## Performance

Same-process local medians against #3580:

- Two-row dictionary file to Arrow: 0.1786 ms to 0.1470 ms per decode, about 18% faster.
- GeoParquet airports file to Arrow: 0.5061 ms to 0.4636 ms per decode, about 8% faster.
- Full mixed dictionary table to Arrow: 3.3299 ms to 3.2681 ms per decode, about 2% faster.

## Validation

- yarn install
- yarn lint fix
- yarn build
- yarn test-node: 418 files, 2031 tests passed
- yarn test-headless: 418 files, 1993 tests passed
- website yarn install and yarn build