### PR TITLE
perf(parquet): hydrate Arrow schemas directly

### DIFF
--- a/modules/parquet/src/lib/arrow/convert-schema-from-parquet.ts
+++ b/modules/parquet/src/lib/arrow/convert-schema-from-parquet.ts
@@ -105,7 +105,14 @@ function getFieldMetadata(field: FieldDefinition): Record<string, string> | unde
     if (key === 'name' || fieldValue === undefined) {
       continue;
     }
-    const metadataValue = typeof fieldValue === 'string' ? fieldValue : JSON.stringify(fieldValue);
+    const metadataValue =
+      typeof fieldValue === 'string'
+        ? fieldValue
+        : typeof fieldValue === 'boolean'
+          ? fieldValue
+            ? 'true'
+            : 'false'
+          : JSON.stringify(fieldValue);
     if (metadataValue === undefined) {
       continue;
     }

--- a/modules/parquet/src/lib/parsers/parse-parquet-to-arrow-js.ts
+++ b/modules/parquet/src/lib/parsers/parse-parquet-to-arrow-js.ts
@@ -8,14 +8,13 @@ import type {
   ArrayType,
   ArrowTable,
   ArrowTableBatch,
+  DataType,
+  Field,
   ObjectRowTable,
-  Schema
+  Schema,
+  SchemaMetadata
 } from '@loaders.gl/schema';
-import {
-  convertTable,
-  deserializeArrowField,
-  deserializeArrowMetadata
-} from '@loaders.gl/schema-utils';
+import {convertTable, deserializeArrowType} from '@loaders.gl/schema-utils';
 
 import type {ParquetJSLoaderOptions} from '../../parquet-loader-options';
 import {preloadCompressions} from '../../parquetjs/compression';
@@ -31,6 +30,22 @@ import {getSchemaFromParquetReader} from './get-parquet-schema';
 
 /** Largest byte value copied inline to avoid TypedArray#set call overhead. */
 const MAXIMUM_INLINE_BYTE_COPY_LENGTH = 7;
+
+/** Primitive Arrow type instances used by serialized Parquet schemas. */
+const PARQUET_ARROW_PRIMITIVE_TYPES: Partial<Record<Extract<DataType, string>, arrow.DataType>> = {
+  binary: new arrow.Binary(),
+  bool: new arrow.Bool(),
+  float32: new arrow.Float32(),
+  float64: new arrow.Float64(),
+  int8: new arrow.Int8(),
+  int16: new arrow.Int16(),
+  int32: new arrow.Int32(),
+  int64: new arrow.Int64(),
+  uint16: new arrow.Uint16(),
+  uint32: new arrow.Uint32(),
+  uint64: new arrow.Uint64(),
+  utf8: new arrow.Utf8()
+};
 
 /** Inputs accepted by Apache Arrow's overloaded `Schema.assign` method. */
 type ArrowSchemaAssignment = arrow.Schema | arrow.Field | arrow.Field[];
@@ -198,9 +213,37 @@ export async function* parseParquetFileToArrowInBatchesWithJs(
 /** Converts a loaders.gl schema into the identity-aware Arrow schema used by Parquet batches. */
 function createParquetArrowSchema(schema: Schema): ParquetArrowSchema {
   return new ParquetArrowSchema(
-    schema.fields.map(field => deserializeArrowField(field)),
-    deserializeArrowMetadata(schema.metadata)
+    schema.fields.map(field => createParquetArrowField(field)),
+    createParquetArrowMetadata(schema.metadata)
   );
+}
+
+/** Hydrates one serialized Parquet field without generic Arrow conversion allocations. */
+function createParquetArrowField(field: Field): arrow.Field {
+  return new arrow.Field(
+    field.name,
+    createParquetArrowType(field.type),
+    field.nullable,
+    createParquetArrowMetadata(field.metadata)
+  );
+}
+
+/** Reuses immutable primitive Arrow types and falls back for composite serialized types. */
+function createParquetArrowType(dataType: DataType): arrow.DataType {
+  const primitiveType =
+    typeof dataType === 'string' ? PARQUET_ARROW_PRIMITIVE_TYPES[dataType] : undefined;
+  return primitiveType || deserializeArrowType(dataType);
+}
+
+/** Hydrates serialized Parquet metadata without an intermediate entries array. */
+function createParquetArrowMetadata(metadata?: SchemaMetadata): Map<string, string> {
+  const arrowMetadata = new Map<string, string>();
+  if (metadata) {
+    for (const key of Object.keys(metadata)) {
+      arrowMetadata.set(key, metadata[key]);
+    }
+  }
+  return arrowMetadata;
 }
 
 /** Builds Arrow from one selected row-group range and falls back for nested columns. */

--- a/modules/parquet/test/parquet-loader.spec.ts
+++ b/modules/parquet/test/parquet-loader.spec.ts
@@ -87,6 +87,18 @@ test('ParquetJSLoader#load supports arrow-table shape', async (t) => {
   t.equal(table.shape, 'arrow-table');
   if (table.shape === 'arrow-table') {
     t.equal(table.data.numRows, 2);
+    const identifierField = table.data.schema.fields.find(field => field.name === 'id');
+    t.deepEqual(
+      Object.fromEntries(identifierField?.metadata || []),
+      {
+        type: 'INT32',
+        optional: 'true',
+        repeated: 'false',
+        encoding: 'PLAIN',
+        compression: 'UNCOMPRESSED'
+      },
+      'preserves serialized Parquet field metadata in the Arrow schema'
+    );
   }
   t.end();
 });


### PR DESCRIPTION
## Goals

- Reduce fixed schema-hydration overhead in TypeScript Parquet to Arrow parsing.
- Preserve Arrow field metadata and composite-type correctness.
- Keep uncommon serialized Arrow types on the existing generic fallback path.

## Changes versus stacked parent #3585

- Hydrate Arrow fields directly instead of routing every field through generic schema-utils conversion.
- Reuse immutable Apache Arrow primitive type instances for Parquet primitive fields.
- Build schema and field metadata maps directly without intermediate entry arrays.
- Stringify Parquet boolean metadata directly instead of invoking JSON.stringify.
- Assert that Parquet field metadata survives direct hydration.

## Performance

Same-process medians against the exact #3585 parent:

| Scenario | Improvement |
| --- | ---: |
| 2-row dictionary | 6.2% |
| 20k-row mixed dictionary | 1.6% |
| LZ4_RAW | 2.0% |
| DELTA_BYTE_ARRAY | 2.3% |

GeoParquet and nested fixtures were neutral within run-to-run noise. Profiling reduced direct metadata-conversion samples from roughly 113 to 37.

## Validation

- `yarn install`
- `yarn lint fix`
- `yarn build`
- `yarn test-node`: 419 passed files, 2,033 passed tests, 81 skipped
- `yarn test-headless`: 419 passed files, 1,995 passed tests, 60 skipped
- Website install and build
- A/B Arrow schema and table signatures across tiny dictionary, mixed dictionary, GeoParquet, LZ4, DELTA_BYTE_ARRAY, and nested fixtures
- Fresh GitHub CI will validate the rebased stack