### PR TITLE
bench(parquet): expand browser performance matrix

### DIFF
--- a/docs/modules/parquet/api-reference/parquet-loader.md
+++ b/docs/modules/parquet/api-reference/parquet-loader.md
@@ -209,13 +209,22 @@ The suite runs entirely in your browser. Fixture download and parser initializat
 timing; each implementation is warmed up and must return the same row count. The matrix covers
 nullable primitives, nested and repeated data, dictionary and delta encodings, compression, and
 column projection. It focuses on Arrow output and retains one object-row control to expose
-row-materialization cost. Unsupported implementation/fixture combinations are skipped and shown as
-an em dash. Results depend on the browser, hardware, thermal state, and whether this tab remains
-focused.
+row-materialization cost. `N/A` means an implementation is intentionally excluded from a scenario;
+`Failed` means a selected implementation did not pass warm-up or correctness validation. A green
+marker identifies the fastest completed value in each row. Results depend on the browser, hardware,
+thermal state, and whether this tab remains focused.
 
-The live suite includes both loaders.gl loader variants plus a browser-oriented peer reader.
-Dependency versions are pinned in the repository lockfile. The corresponding Node suite covers
-additional codecs and projections with `yarn bench parquet`.
+The throughput cases emphasize sustained work rather than two-row initialization effects: the main
+fixtures span 1,000 to 40,000 rows, up to 66 columns, and multiple row groups. The compression matrix
+covers SNAPPY, GZIP, ZSTD, LZ4_RAW, and legacy LZ4 framing in addition to uncompressed data. Scenario
+labels show their row and top-level column counts so results from differently shaped files are not
+mistaken for equivalent workloads.
+
+The live suite includes `ParquetLoader` plus the browser-oriented `parquet-wasm` and `hyparquet`
+packages. External package versions are displayed in the table headers and pinned in the repository
+lockfile. The hyparquet compression cases use the separately pinned `hyparquet-compressors` 1.1.1
+package. The corresponding Node suite covers additional codecs and projections with
+`yarn bench parquet`.
 
 <BrowserOnly fallback={<p>Loading browser benchmarks...</p>}>
   {() => {

--- a/website/src/examples/parquet-benchmarks-app.tsx
+++ b/website/src/examples/parquet-benchmarks-app.tsx
@@ -14,6 +14,8 @@ type BenchmarkResultRow = {
   implementationId: ParquetBenchmarkImplementationId;
   /** Human-readable throughput. */
   formattedValue: string;
+  /** Numeric throughput reconstructed from the displayed SI value. */
+  throughput: number;
 };
 
 type BenchmarkStatus = 'loading' | 'running' | 'complete' | 'failed';
@@ -31,6 +33,13 @@ type ParquetBenchmarkScenario = {
   /** Table shape materialized by every loader variant. */
   shape: ParquetBenchmarkShape;
   /** Implementations that currently support the fixture features. */
+  implementationIds: ParquetBenchmarkImplementationId[];
+};
+
+type ParquetBenchmarkScenarioSummary = {
+  /** Human-readable fixture and feature label. */
+  name: string;
+  /** Implementations selected for this scenario. */
   implementationIds: ParquetBenchmarkImplementationId[];
 };
 
@@ -61,22 +70,35 @@ type HyparquetColumnChunk = {
   rowEnd: number;
 };
 
+type ParquetBenchmarkImplementationHeader = {
+  /** Package or loader name displayed in the benchmark table. */
+  name: string;
+  /** Exact external package version used by this benchmark. */
+  version?: string;
+};
+
+/** Exact parquet-wasm package version pinned by @loaders.gl/parquet. */
+const PARQUET_WASM_VERSION = '0.7.2';
+
+/** Exact hyparquet package version pinned by the website benchmark. */
+const HYPARQUET_VERSION = '1.28.2';
+
 const PARQUET_BENCHMARK_IMPLEMENTATION_LABELS: Record<
   ParquetBenchmarkImplementationId,
   string
 > = {
-  typescript: 'ParquetLoader (JS)',
-  wasm: 'ParquetLoader (WASM)',
-  hyparquet: 'hyparquet (JS)'
+  typescript: 'ParquetLoader',
+  wasm: `parquet-wasm v${PARQUET_WASM_VERSION}`,
+  hyparquet: `hyparquet v${HYPARQUET_VERSION}`
 };
 
 const PARQUET_BENCHMARK_IMPLEMENTATION_HEADERS: Record<
   ParquetBenchmarkImplementationId,
-  {name: string; runtime: string}
+  ParquetBenchmarkImplementationHeader
 > = {
-  typescript: {name: 'ParquetLoader', runtime: 'JS'},
-  wasm: {name: 'ParquetLoader', runtime: 'WASM'},
-  hyparquet: {name: 'hyparquet', runtime: 'JS'}
+  typescript: {name: 'ParquetLoader'},
+  wasm: {name: 'parquet-wasm', version: `v${PARQUET_WASM_VERSION}`},
+  hyparquet: {name: 'hyparquet', version: `v${HYPARQUET_VERSION}`}
 };
 
 const PARQUET_BENCHMARK_IMPLEMENTATION_IDS: ParquetBenchmarkImplementationId[] = [
@@ -88,6 +110,8 @@ const PARQUET_BENCHMARK_IMPLEMENTATION_IDS: ParquetBenchmarkImplementationId[] =
 /** Renders live comparative Parquet decode benchmarks in the visitor's browser. */
 export default function ParquetBenchmarksApp(): JSX.Element {
   const [rows, setRows] = useState<BenchmarkResultRow[]>([]);
+  const [scenarios, setScenarios] = useState<ParquetBenchmarkScenarioSummary[]>([]);
+  const [failedCellKeys, setFailedCellKeys] = useState<Set<string>>(new Set());
   const [warnings, setWarnings] = useState<string[]>([]);
   const [status, setStatus] = useState<BenchmarkStatus>('loading');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -96,6 +120,8 @@ export default function ParquetBenchmarksApp(): JSX.Element {
   useEffect(() => {
     let isMounted = true;
     setRows([]);
+    setScenarios([]);
+    setFailedCellKeys(new Set());
     setWarnings([]);
     setStatus('loading');
     setErrorMessage(null);
@@ -118,6 +144,20 @@ export default function ParquetBenchmarksApp(): JSX.Element {
       }
     };
 
+    /** Marks one selected implementation/scenario pair as a failed benchmark cell. */
+    const markCellFailed = (
+      scenario: string,
+      implementationId: ParquetBenchmarkImplementationId
+    ): void => {
+      if (isMounted) {
+        setFailedCellKeys(previousKeys => {
+          const nextKeys = new Set(previousKeys);
+          nextKeys.add(getBenchmarkCellKey(scenario, implementationId));
+          return nextKeys;
+        });
+      }
+    };
+
     /** Loads the fixtures, validates each scenario, and runs the browser suite. */
     const runBenchmarks = async (): Promise<void> => {
       try {
@@ -125,6 +165,11 @@ export default function ParquetBenchmarksApp(): JSX.Element {
           'Fixture setup failed',
           createParquetBenchmarkScenarios
         );
+        if (isMounted) {
+          setScenarios(
+            scenarios.map(({name, implementationIds}) => ({name, implementationIds}))
+          );
+        }
         const implementations = await runBenchmarkPhase(
           'Implementation setup failed',
           createParquetBenchmarkImplementations
@@ -138,7 +183,13 @@ export default function ParquetBenchmarksApp(): JSX.Element {
             })
         );
         await runBenchmarkPhase('Benchmark warm-up failed', async () => {
-          await addParquetBenchmarksToSuite(bench, scenarios, implementations, appendWarning);
+          await addParquetBenchmarksToSuite(
+            bench,
+            scenarios,
+            implementations,
+            appendWarning,
+            markCellFailed
+          );
         });
         if (isMounted) {
           setStatus('running');
@@ -169,7 +220,6 @@ export default function ParquetBenchmarksApp(): JSX.Element {
 
   const isRunning = status === 'loading' || status === 'running';
   const canRestart = status === 'complete' || status === 'failed';
-  const scenarioNames = Array.from(new Set(rows.map(row => row.scenario)));
 
   return (
     <div className="benchmark-page">
@@ -189,7 +239,7 @@ export default function ParquetBenchmarksApp(): JSX.Element {
       {errorMessage ? <pre className="benchmark-error">{errorMessage}</pre> : null}
       {warnings.length > 0 ? (
         <aside>
-          <strong>Skipped benchmark cases</strong>
+          <strong>Failed benchmark cases</strong>
           <ul>
             {warnings.map(warning => (
               <li key={warning}>{warning}</li>
@@ -211,38 +261,57 @@ export default function ParquetBenchmarksApp(): JSX.Element {
                     className="parquet-benchmark-number"
                   >
                     <span className="parquet-benchmark-loader-name">{header.name}</span>
-                    <span className="parquet-benchmark-loader-runtime">{header.runtime}</span>
+                    {header.version ? (
+                      <span className="parquet-benchmark-loader-version">{header.version}</span>
+                    ) : null}
                   </th>
                 );
               })}
             </tr>
           </thead>
           <tbody>
-            {scenarioNames.map(scenario => (
-              <tr key={scenario}>
-                <th scope="row">{scenario}</th>
-                {PARQUET_BENCHMARK_IMPLEMENTATION_IDS.map(implementationId => {
-                  const result = rows.find(
-                    row => row.scenario === scenario && row.implementationId === implementationId
-                  );
-                  return (
-                    <td
-                      key={implementationId}
-                      className="parquet-benchmark-number"
-                      aria-label={`${PARQUET_BENCHMARK_IMPLEMENTATION_LABELS[implementationId]} throughput`}
-                    >
-                      {result ? (
-                        <>
-                          <strong>{result.formattedValue}</strong> rows/s
-                        </>
-                      ) : (
-                        <span className="parquet-benchmark-pending">—</span>
-                      )}
-                    </td>
-                  );
-                })}
-              </tr>
-            ))}
+            {scenarios.map(scenario => {
+              const scenarioRows = rows.filter(row => row.scenario === scenario.name);
+              const bestThroughput = Math.max(
+                ...scenarioRows.map(row => row.throughput),
+                Number.NEGATIVE_INFINITY
+              );
+              return (
+                <tr key={scenario.name}>
+                  <th scope="row">{scenario.name}</th>
+                  {PARQUET_BENCHMARK_IMPLEMENTATION_IDS.map(implementationId => {
+                    const result = rows.find(
+                      row =>
+                        row.scenario === scenario.name && row.implementationId === implementationId
+                    );
+                    const cellKey = getBenchmarkCellKey(scenario.name, implementationId);
+                    const isApplicable = scenario.implementationIds.includes(implementationId);
+                    const isBestResult =
+                      status === 'complete' && result?.throughput === bestThroughput;
+                    return (
+                      <td
+                        key={implementationId}
+                        className="parquet-benchmark-number"
+                        aria-label={`${PARQUET_BENCHMARK_IMPLEMENTATION_LABELS[implementationId]} throughput`}
+                      >
+                        {result ? (
+                          <>
+                            {isBestResult ? <span aria-label="Best throughput">🟢 </span> : null}
+                            <strong>{result.formattedValue}</strong> rows/s
+                          </>
+                        ) : failedCellKeys.has(cellKey) ? (
+                          <span className="parquet-benchmark-failed">Failed</span>
+                        ) : !isApplicable ? (
+                          <span className="parquet-benchmark-not-applicable">N/A</span>
+                        ) : (
+                          <span className="parquet-benchmark-pending">—</span>
+                        )}
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            })}
           </tbody>
         </table>
         {rows.length === 0 ? (
@@ -276,6 +345,10 @@ async function createParquetBenchmarkScenarios(): Promise<ParquetBenchmarkScenar
     '../../../modules/parquet/test/data/apache/good/lz4_raw_compressed_larger.parquet',
     import.meta.url
   ).toString();
+  const legacyLz4Url = new URL(
+    '../../../modules/parquet/test/data/apache/good/hadoop_lz4_compressed_larger.parquet',
+    import.meta.url
+  ).toString();
   const deltaByteArrayUrl = new URL(
     '../../../modules/parquet/test/data/apache/good/delta_byte_array.parquet',
     import.meta.url
@@ -295,6 +368,7 @@ async function createParquetBenchmarkScenarios(): Promise<ParquetBenchmarkScenar
   const [
     geoParquetArrayBuffer,
     lz4ArrayBuffer,
+    legacyLz4ArrayBuffer,
     deltaByteArrayBuffer,
     deltaBinaryPackedArrayBuffer,
     dictionaryArrayBuffer,
@@ -302,20 +376,32 @@ async function createParquetBenchmarkScenarios(): Promise<ParquetBenchmarkScenar
   ] = await Promise.all([
     fetchParquetFixture(geoParquetUrl),
     fetchParquetFixture(lz4Url),
+    fetchParquetFixture(legacyLz4Url),
     fetchParquetFixture(deltaByteArrayUrl),
     fetchParquetFixture(deltaBinaryPackedUrl),
     fetchParquetFixture(dictionaryUrl),
     fetchParquetFixture(fruitsUrl)
   ]);
+  const compressedDictionaryFixtures = await createCompressedBenchmarkFixtures(
+    dictionaryArrayBuffer
+  );
   return [
     {
-      name: 'GeoParquet → Arrow',
+      name: 'GeoParquet SNAPPY · 1K rows × 4 cols → Arrow',
       arrayBuffer: geoParquetArrayBuffer,
       shape: 'arrow-table',
       implementationIds: ['typescript', 'wasm', 'hyparquet']
     },
     {
-      name: 'PLAIN nullable primitive projection → Arrow',
+      name: 'PLAIN mixed projection · 40K rows × 8 cols → Arrow',
+      arrayBuffer: fruitsArrayBuffer,
+      columns: ['name', 'quantity', 'price', 'date', 'day', 'finger', 'stock', 'colour'],
+      shape: 'arrow-table',
+      // parquet-wasm 0.7.2 retains the unprojected INTERVAL field in its IPC schema.
+      implementationIds: ['typescript', 'hyparquet']
+    },
+    {
+      name: 'PLAIN nullable primitives · 40K rows × 6 cols → Arrow',
       arrayBuffer: fruitsArrayBuffer,
       columns: ['name', 'quantity', 'price', 'date', 'day', 'finger'],
       shape: 'arrow-table',
@@ -323,7 +409,7 @@ async function createParquetBenchmarkScenarios(): Promise<ParquetBenchmarkScenar
       implementationIds: ['typescript', 'hyparquet']
     },
     {
-      name: 'PLAIN nested and repeated projection → Arrow',
+      name: 'PLAIN nested/repeated · 40K rows × 2 cols → Arrow',
       arrayBuffer: fruitsArrayBuffer,
       columns: ['stock', 'colour'],
       shape: 'arrow-table',
@@ -331,31 +417,49 @@ async function createParquetBenchmarkScenarios(): Promise<ParquetBenchmarkScenar
       implementationIds: ['typescript', 'hyparquet']
     },
     {
-      name: 'RLE_DICTIONARY mixed table → Arrow',
+      name: 'RLE_DICTIONARY mixed table · 20K rows × 5 cols → Arrow',
       arrayBuffer: dictionaryArrayBuffer,
       shape: 'arrow-table',
       implementationIds: ['typescript', 'wasm', 'hyparquet']
     },
     {
-      name: 'DELTA_BINARY_PACKED integer table → Arrow',
+      name: 'RLE_DICTIONARY + GZIP · 20K rows × 5 cols → Arrow',
+      arrayBuffer: compressedDictionaryFixtures.gzip,
+      shape: 'arrow-table',
+      implementationIds: ['typescript', 'wasm', 'hyparquet']
+    },
+    {
+      name: 'RLE_DICTIONARY + ZSTD · 20K rows × 5 cols → Arrow',
+      arrayBuffer: compressedDictionaryFixtures.zstd,
+      shape: 'arrow-table',
+      implementationIds: ['typescript', 'wasm', 'hyparquet']
+    },
+    {
+      name: 'DELTA_BINARY_PACKED wide integers · 200 rows × 66 cols → Arrow',
       arrayBuffer: deltaBinaryPackedArrayBuffer,
       shape: 'arrow-table',
       implementationIds: ['typescript', 'wasm', 'hyparquet']
     },
     {
-      name: 'LZ4_RAW → Arrow',
+      name: 'LZ4_RAW · 10K rows × 1 col → Arrow',
       arrayBuffer: lz4ArrayBuffer,
       shape: 'arrow-table',
       implementationIds: ['typescript', 'wasm', 'hyparquet']
     },
     {
-      name: 'DELTA_BYTE_ARRAY → Arrow',
+      name: 'LZ4 legacy framing · 10K rows × 1 col → Arrow',
+      arrayBuffer: legacyLz4ArrayBuffer,
+      shape: 'arrow-table',
+      implementationIds: ['typescript', 'wasm', 'hyparquet']
+    },
+    {
+      name: 'DELTA_BYTE_ARRAY strings · 1K rows × 9 cols → Arrow',
       arrayBuffer: deltaByteArrayBuffer,
       shape: 'arrow-table',
       implementationIds: ['typescript', 'wasm', 'hyparquet']
     },
     {
-      name: 'DELTA_BYTE_ARRAY projection → Arrow',
+      name: 'DELTA_BYTE_ARRAY projection · 1K rows × 2 cols → Arrow',
       arrayBuffer: deltaByteArrayBuffer,
       columns: ['c_customer_id', 'c_email_address'],
       shape: 'arrow-table',
@@ -363,12 +467,39 @@ async function createParquetBenchmarkScenarios(): Promise<ParquetBenchmarkScenar
       implementationIds: ['typescript', 'hyparquet']
     },
     {
-      name: 'DELTA_BYTE_ARRAY → object rows',
+      name: 'DELTA_BYTE_ARRAY control · 1K rows × 9 cols → object rows',
       arrayBuffer: deltaByteArrayBuffer,
       shape: 'object-row-table',
       implementationIds: ['typescript', 'wasm', 'hyparquet']
     }
   ];
+}
+
+/** Re-encodes the shared scale fixture with additional compression codecs before timing starts. */
+async function createCompressedBenchmarkFixtures(
+  arrayBuffer: ArrayBuffer
+): Promise<{gzip: ArrayBuffer; zstd: ArrayBuffer}> {
+  const {loadWasm} = await import('../../../modules/parquet/src/lib/utils/load-wasm');
+  const parquetWasm = await loadWasm();
+  const gzipTable = parquetWasm.readParquet(new Uint8Array(arrayBuffer));
+  const zstdTable = parquetWasm.readParquet(new Uint8Array(arrayBuffer));
+  const gzipProperties = new parquetWasm.WriterPropertiesBuilder()
+    .setCompression(parquetWasm.Compression.GZIP)
+    .setMaxRowGroupSize(4000)
+    .build();
+  const zstdProperties = new parquetWasm.WriterPropertiesBuilder()
+    .setCompression(parquetWasm.Compression.ZSTD)
+    .setMaxRowGroupSize(4000)
+    .build();
+  return {
+    gzip: copyUint8ArrayToArrayBuffer(parquetWasm.writeParquet(gzipTable, gzipProperties)),
+    zstd: copyUint8ArrayToArrayBuffer(parquetWasm.writeParquet(zstdTable, zstdProperties))
+  };
+}
+
+/** Copies a typed-array view into an exact standalone ArrayBuffer. */
+function copyUint8ArrayToArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.slice().buffer;
 }
 
 /** Fetches and validates one Parquet fixture response. */
@@ -391,7 +522,8 @@ async function createParquetBenchmarkImplementations(): Promise<
     loadersGlTableConverters,
     loadersGlSchemaUtils,
     hyparquet,
-    hyparquetCompressors
+    hyparquetCompressors,
+    zstdCodec
   ] = await Promise.all([
     import('@loaders.gl/loader-utils'),
     import('../../../modules/parquet/src/parquet-js-loader'),
@@ -399,7 +531,8 @@ async function createParquetBenchmarkImplementations(): Promise<
     import('../../../modules/parquet/src/lib/parsers/convert-parquet-tables'),
     import('@loaders.gl/schema-utils'),
     import('hyparquet'),
-    import('hyparquet-compressors')
+    import('hyparquet-compressors'),
+    import('zstd-codec')
   ]);
   return [
     {
@@ -410,7 +543,8 @@ async function createParquetBenchmarkImplementations(): Promise<
           scenario.arrayBuffer,
           {
             core: {worker: false},
-            parquet: {columns: scenario.columns, shape: scenario.shape}
+            parquet: {columns: scenario.columns, shape: scenario.shape},
+            modules: {'zstd-codec': zstdCodec.ZstdCodec}
           }
         )) as ArrowTable | ObjectRowTable;
         return getBenchmarkTableRowCount(table);
@@ -482,7 +616,11 @@ async function addParquetBenchmarksToSuite(
   bench: Bench,
   scenarios: ParquetBenchmarkScenario[],
   implementations: ParquetBenchmarkImplementation[],
-  onWarning: (warning: string) => void
+  onWarning: (warning: string) => void,
+  onCellFailed: (
+    scenario: string,
+    implementationId: ParquetBenchmarkImplementationId
+  ) => void
 ): Promise<void> {
   for (const scenario of scenarios) {
     try {
@@ -492,7 +630,8 @@ async function addParquetBenchmarksToSuite(
       const validatedImplementations = await validateParquetBenchmarkScenario(
         scenario,
         scenarioImplementations,
-        onWarning
+        onWarning,
+        onCellFailed
       );
       const rowCount = validatedImplementations[0]?.rowCount;
       if (rowCount === undefined) {
@@ -517,6 +656,9 @@ async function addParquetBenchmarksToSuite(
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       onWarning(`${scenario.name}: ${message}`);
+      for (const implementationId of scenario.implementationIds) {
+        onCellFailed(scenario.name, implementationId);
+      }
     }
   }
 }
@@ -525,7 +667,11 @@ async function addParquetBenchmarksToSuite(
 async function validateParquetBenchmarkScenario(
   scenario: ParquetBenchmarkScenario,
   implementations: ParquetBenchmarkImplementation[],
-  onWarning: (warning: string) => void
+  onWarning: (warning: string) => void,
+  onCellFailed: (
+    scenario: string,
+    implementationId: ParquetBenchmarkImplementationId
+  ) => void
 ): Promise<ValidatedParquetBenchmarkImplementation[]> {
   const validatedImplementations: ValidatedParquetBenchmarkImplementation[] = [];
   for (const implementation of implementations) {
@@ -537,6 +683,7 @@ async function validateParquetBenchmarkScenario(
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       onWarning(`${scenario.name} / ${implementation.name}: ${message}`);
+      onCellFailed(scenario.name, implementation.id);
     }
   }
   const expectedRowCount = validatedImplementations[0]?.rowCount;
@@ -545,6 +692,7 @@ async function validateParquetBenchmarkScenario(
       onWarning(
         `${scenario.name} / ${implementation.name}: decoded ${rowCount} rows; expected ${expectedRowCount}`
       );
+      onCellFailed(scenario.name, implementation.id);
       return false;
     }
     return true;
@@ -568,7 +716,8 @@ function createBenchmarkResultRow(entry: LogEntry): BenchmarkResultRow | null {
       return {
         scenario: entry.id.slice(0, separatorIndex),
         implementationId,
-        formattedValue: entry.itersPerSecond
+        formattedValue: entry.itersPerSecond,
+        throughput: parseFormattedThroughput(entry.itersPerSecond)
       };
     }
     case 'complete':
@@ -576,4 +725,35 @@ function createBenchmarkResultRow(entry: LogEntry): BenchmarkResultRow | null {
     default:
       return null;
   }
+}
+
+/** Creates a stable state key for one scenario/implementation table cell. */
+function getBenchmarkCellKey(
+  scenario: string,
+  implementationId: ParquetBenchmarkImplementationId
+): string {
+  return `${scenario}::${implementationId}`;
+}
+
+/** Converts probe.gl's formatted SI throughput back to a comparable numeric value. */
+function parseFormattedThroughput(formattedValue: string): number {
+  const match = /^([+-]?\d+(?:\.\d+)?)([KMGTPE]|m|µ|n|e[+-]?\d+)?$/.exec(formattedValue);
+  if (!match) {
+    return Number.NaN;
+  }
+  const suffixPowers: Record<string, number> = {
+    '': 0,
+    K: 3,
+    M: 6,
+    G: 9,
+    T: 12,
+    P: 15,
+    E: 18,
+    m: -3,
+    µ: -6,
+    n: -9
+  };
+  const suffix = match[2] || '';
+  const exponent = suffix.startsWith('e') ? Number(suffix.slice(1)) : suffixPowers[suffix];
+  return Number(match[1]) * 10 ** exponent;
 }

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -618,11 +618,11 @@ body:has(.benchmark-page) footer.theme-layout-footer {
 }
 
 .parquet-benchmark-loader-name,
-.parquet-benchmark-loader-runtime {
+.parquet-benchmark-loader-version {
   display: block;
 }
 
-.parquet-benchmark-loader-runtime {
+.parquet-benchmark-loader-version {
   font-size: 0.75rem;
   font-weight: 500;
 }


### PR DESCRIPTION
## Goals

- Replace small-file-focused signals with a demanding browser matrix for sustained Parquet throughput.
- Compare `ParquetLoader` fairly against browser-oriented alternatives with exact package versions visible.
- Make unsupported and failed cases explicit, and highlight the best completed result per scenario.

## Changes

- Expands the live matrix to fixtures spanning 1,000–40,000 rows, up to 66 columns, and multiple row groups.
- Covers nullable primitives, nested/repeated data, dictionary and delta encodings, projections, object-row control, and SNAPPY, GZIP, ZSTD, LZ4_RAW, legacy LZ4, and uncompressed inputs.
- Generates the GZIP and ZSTD multi-row-group fixtures before timing begins.
- Labels columns as `ParquetLoader`, `parquet-wasm v0.7.2`, and `hyparquet v1.28.2`; documents `hyparquet-compressors` 1.1.1.
- Shows `N/A` for deliberately unsupported combinations and `Failed` for warm-up or correctness failures.
- Adds a green marker to every best displayed throughput value in a completed row, including displayed ties.
- Documents the scale and interpretation of the live measurements on the Parquet loader page.

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn test-node` — 419 files passed, 2 skipped; 2,033 tests passed, 81 skipped
- `yarn test-headless` — 418 files and 1,994 tests passed; one unrelated `Tileset3D#one viewport traversal` test hit its existing 1-second timeout
- `cd website && yarn build`
- Live browser suite completed with all result states and winner markers rendered
