### PR TITLE
feat(loader-utils): encode LAZ point chunks

### DIFF
--- a/docs/modules/las/formats/las.md
+++ b/docs/modules/las/formats/las.md
@@ -64,7 +64,19 @@ LAS file versions and LASzip codec versions are independent. A claim such as "LA
 | Modern waveform PDRF 9-10 | Layered compressor 3, arithmetic coder 0, Point14/RGB14/RGBNIR14/Byte14 item versions 2-4, and WavePacket14 item version 3 or 4. |
 | Extra Bytes | Byte10 version 2 and Byte14 versions 2-4 are losslessly preserved in raw records. Extra Bytes VLR definitions are not exposed as typed columns. |
 | Chunk table | Version 0, fixed-size and variable-size chunks. Other chunk-table versions are rejected. |
-| Unsupported modes | Pointwise compressor 1, coders other than 0, legacy item version 1, and LAZ encoding. |
+| Unsupported modes | Pointwise compressor 1, coders other than 0, and legacy item version 1. |
+
+### TypeScript LAZ Encoder
+
+`encodeLAZChunk()` and `createLAZChunkEncoder()` encode raw LAS point records into one LASzip layered chunk. They do not write the surrounding LAS header, LASzip VLR, chunk table, or `.laz` file container.
+
+| LASzip feature | Supported TypeScript combinations |
+| --- | --- |
+| Modern PDRF 6-8 items | Layered compressor 3, arithmetic coder 0, and Point14/RGB14/RGBNIR14 item version 3. |
+| Extra Bytes | Byte14 item version 3 is losslessly encoded as independent layers. |
+| Input modes | Complete raw point buffers and feedable raw byte ranges. Feedable input is buffered until `close()` and `encode()` are called. |
+| Interoperability | PDRF 6-8 output is tested byte-for-byte through the TypeScript decoder and laz-perf. |
+| Unsupported modes | Legacy PDRF 0-5, waveform PDRF 9-10, item versions 2 and 4, and complete `.laz` file writing. |
 
 #### Point Record Formats
 
@@ -226,7 +238,7 @@ The TypeScript implementation should be completed in stages, with parity tests a
 | 3 | Complete raw LAS point readers and writers. | PDRF 0-10 fields round-trip where loaders.gl has an attribute representation, and unsupported fields are explicitly preserved or documented. |
 | 4 | Implement full LAZ file parsing. | LASzip VLRs, fixed and variable chunk tables, chunk sizes, and sequential point batches work without WASM. |
 | 5 | Expose waveform metadata and payload access. | PDRF 4/5/9/10 packet references become typed output metadata, and internal EVLR or external WDP sample payloads can be loaded on demand. Raw-record decompression is implemented. |
-| 6 | Implement LAZ encoding. | Raw point data compressed by the TypeScript encoder decodes byte-for-byte to the original records. |
+| 6 | Implement LAZ file writing. | `LASWriter` emits LASzip VLRs, layered chunks, and fixed-size chunk tables that established decoders can read. |
 | 7 | Complete stateful feedable LAZ streaming. | Replace bounded replay for legacy chunks with resumable arithmetic/item state, and stream layered chunks as soon as the field ranges needed for complete rows are available. |
 | 8 | Complete pure TypeScript COPC reading. | Header, COPC info VLR, hierarchy pages, range selection, and LAZ node decoding no longer depend on the existing COPC package internals. |
 | 9 | Implement COPC writing. | Writer emits valid COPC 1.0 with hierarchy pages, range-readable LAZ node chunks, and required VLRs. |

--- a/modules/las/test/las-loader.spec.ts
+++ b/modules/las/test/las-loader.spec.ts
@@ -39,7 +39,11 @@ import {
   encodeLAZChunk,
   NeedsMoreData
 } from '@loaders.gl/las';
-import {createLAZChunkDecoderCursor, decodeLAZChunkTable} from '@loaders.gl/loader-utils';
+import {
+  createLAZChunkDecoderCursor,
+  decodeLAZChunkTable,
+  getLAZChunkByteLength
+} from '@loaders.gl/loader-utils';
 import {LASCOPCLoaderWithParser} from '../src/las-copc-loader';
 import {LAZPerfLoaderWithParser} from '../src/lazperf-loader';
 import {LAZRsLoaderWithParser} from '../src/laz-rs-loader';
@@ -1511,16 +1515,68 @@ test('TypeScriptLAZ#rejects unsupported point format', t => {
   t.end();
 });
 
-test('TypeScriptLAZ#encoder API reports unimplemented LAZ encoding', t => {
-  const metadata = {
-    pointCount: 1,
-    pointDataRecordFormat: 0,
-    pointDataRecordLength: 20
-  };
+test('TypeScriptLAZ#encoder writes LASzip v3 PDRF 6-8 chunks', async t => {
+  for (const pointDataRecordFormat of [6, 7, 8]) {
+    const {rawPointData, metadata} = createLAZEncodingFixture(pointDataRecordFormat);
+    const compressed = encodeLAZChunk(rawPointData, metadata);
+    const decoded = decodeLAZChunk(compressed, metadata);
+    const lazPerfDecoded = await Las.PointData.decompressChunk(compressed, metadata);
+
+    t.deepEqual(decoded, rawPointData, `PDRF ${pointDataRecordFormat} TypeScript roundtrip`);
+    t.deepEqual(
+      lazPerfDecoded,
+      rawPointData,
+      `PDRF ${pointDataRecordFormat} laz-perf interoperability`
+    );
+    t.deepEqual(
+      encodeLAZChunk(rawPointData, metadata),
+      compressed,
+      `PDRF ${pointDataRecordFormat} output is deterministic`
+    );
+    t.equal(
+      getLAZChunkByteLength(compressed, metadata),
+      compressed.byteLength,
+      `PDRF ${pointDataRecordFormat} layered size headers are complete`
+    );
+  }
+
+  const {rawPointData, metadata} = createLAZEncodingFixture(8);
+  const padded = new Uint8Array(rawPointData.byteLength + 16);
+  padded.set(rawPointData, 8);
+  const encoder = createLAZChunkEncoder(metadata);
+  const splitOffset = Math.floor(rawPointData.byteLength / 2);
+  encoder.feed(padded.subarray(8, 8 + splitOffset));
+  encoder.feed(padded.subarray(8 + splitOffset, 8 + rawPointData.byteLength));
+  encoder.close();
+  t.deepEqual(
+    decodeLAZChunk(encoder.encode(), metadata),
+    rawPointData,
+    'feedable encoder preserves input view byte ranges'
+  );
+  t.end();
+});
+
+test('TypeScriptLAZ#encoder validates input and item versions', t => {
+  const {rawPointData, metadata} = createLAZEncodingFixture(6);
   t.throws(
-    () => encodeLAZChunk(new Uint8Array(20), metadata),
-    /not implemented yet/,
-    'complete-buffer encoder reports unimplemented LAZ encoding'
+    () =>
+      encodeLAZChunk(new Uint8Array(20), {
+        pointCount: 1,
+        pointDataRecordFormat: 0,
+        pointDataRecordLength: 20
+      }),
+    /does not support point format 0/,
+    'legacy point formats are rejected'
+  );
+  t.throws(
+    () => encodeLAZChunk(rawPointData.subarray(1), metadata),
+    /expected/,
+    'incomplete point data is rejected'
+  );
+  t.throws(
+    () => encodeLAZChunk(rawPointData, {...metadata, point14ItemVersion: 4}),
+    /only supports Point14 item version 3/,
+    'unsupported Point14 versions are rejected'
   );
 
   const encoder = createLAZChunkEncoder(metadata);
@@ -1535,11 +1591,6 @@ test('TypeScriptLAZ#encoder API reports unimplemented LAZ encoding', t => {
     () => encoder.feed(new Uint8Array(1)),
     /closed LAZ chunk encoder/,
     'closed feedable encoder rejects more input'
-  );
-  t.throws(
-    () => encoder.encode(),
-    /not implemented yet/,
-    'feedable encoder reports unimplemented LAZ encoding'
   );
   t.end();
 });
@@ -1633,6 +1684,67 @@ async function getCOPCRootChunk() {
       pointCount: node.pointCount,
       pointDataRecordFormat: copc.header.pointDataRecordFormat,
       pointDataRecordLength: copc.header.pointDataRecordLength
+    }
+  };
+}
+
+/** Create varied LAS 1.4 records for LAZ encoder interoperability tests. */
+function createLAZEncodingFixture(pointDataRecordFormat: number) {
+  const baseRecordLength = {6: 30, 7: 36, 8: 38}[pointDataRecordFormat];
+  if (!baseRecordLength) {
+    throw new Error(`Unsupported fixture point format ${pointDataRecordFormat}`);
+  }
+  const pointCount = 32;
+  const pointDataRecordLength = baseRecordLength + 2;
+  const rawPointData = new Uint8Array(pointCount * pointDataRecordLength);
+  let previousGpsTime = 1_000_000_000;
+
+  for (let pointIndex = 0; pointIndex < pointCount; pointIndex++) {
+    const recordOffset = pointIndex * pointDataRecordLength;
+    const view = new DataView(
+      rawPointData.buffer,
+      rawPointData.byteOffset + recordOffset,
+      pointDataRecordLength
+    );
+    const numberOfReturns = 1 + (pointIndex % 5);
+    const returnNumber = 1 + (pointIndex % numberOfReturns);
+    const scannerChannel = (pointIndex * 3 + 2) % 4;
+    const gpsTime = pointIndex % 7 === 0 ? previousGpsTime : 1_000_000_000 + pointIndex * 0.001;
+    previousGpsTime = gpsTime;
+
+    view.setInt32(0, 1000 + pointIndex * 13, true);
+    view.setInt32(4, -2000 + pointIndex * pointIndex, true);
+    view.setInt32(8, 50 - pointIndex * 3, true);
+    view.setUint16(12, 200 + pointIndex * 17, true);
+    view.setUint8(14, returnNumber | (numberOfReturns << 4));
+    view.setUint8(15, (pointIndex % 16) | (scannerChannel << 4) | ((pointIndex % 2) << 6));
+    view.setUint8(16, (pointIndex * 7) & 0xff);
+    view.setUint8(17, (pointIndex * 11) & 0xff);
+    view.setInt16(18, -100 + pointIndex * 9, true);
+    view.setUint16(20, 3 + (pointIndex >> 2), true);
+    view.setFloat64(22, gpsTime, true);
+
+    if (pointDataRecordFormat >= 7) {
+      view.setUint16(30, pointIndex * 1000, true);
+      view.setUint16(32, 65535 - pointIndex * 500, true);
+      view.setUint16(34, pointIndex * 257, true);
+    }
+    if (pointDataRecordFormat === 8) {
+      view.setUint16(36, pointIndex * 333, true);
+    }
+    view.setUint8(baseRecordLength, pointIndex);
+    view.setUint8(baseRecordLength + 1, 255 - pointIndex);
+  }
+
+  return {
+    rawPointData,
+    metadata: {
+      pointCount,
+      pointDataRecordFormat,
+      pointDataRecordLength,
+      point14ItemVersion: 3 as const,
+      rgb14ItemVersion: 3 as const,
+      byte14ItemVersion: 3 as const
     }
   };
 }

--- a/modules/loader-utils/src/lib/laz/laz-arithmetic-encoder.ts
+++ b/modules/loader-utils/src/lib/laz/laz-arithmetic-encoder.ts
@@ -1,0 +1,446 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+const AC_MIN_LENGTH = 0x01000000;
+const AC_MAX_LENGTH = 0xffffffff;
+const BM_LENGTH_SHIFT = 13;
+const BM_MAX_COUNT = 1 << BM_LENGTH_SHIFT;
+const BM_DISTRIBUTION_DIVISOR = 2 ** (31 - BM_LENGTH_SHIFT);
+const DM_LENGTH_SHIFT = 15;
+const DM_MAX_COUNT = 1 << DM_LENGTH_SHIFT;
+const DM_DISTRIBUTION_DIVISOR = 2 ** (31 - DM_LENGTH_SHIFT);
+
+/** Adaptive symbol model used by the LASzip arithmetic encoder. */
+export class ArithmeticModel {
+  /** Number of symbols represented by this model. */
+  readonly symbols: number;
+  /** Cumulative symbol distribution scaled to the arithmetic interval. */
+  readonly distribution: Uint32Array;
+  /** Adaptive occurrence count for each symbol. */
+  readonly symbolCount: Uint32Array;
+  /** Index of the final symbol, whose upper bound is the interval length. */
+  readonly lastSymbol: number;
+  /** Total observations represented by the current distribution. */
+  totalCount = 0;
+  /** Number of observations added at the next model update. */
+  updateCycle: number;
+  /** Symbols remaining before the next model update. */
+  symbolsUntilUpdate: number;
+
+  /** Create a uniformly initialized symbol model. */
+  constructor(symbols: number) {
+    if (symbols < 2 || symbols > 1 << 11) {
+      throw new Error(`Invalid arithmetic model symbol count ${symbols}`);
+    }
+    this.symbols = symbols;
+    this.lastSymbol = symbols - 1;
+    this.distribution = new Uint32Array(symbols);
+    this.symbolCount = new Uint32Array(symbols);
+    this.symbolCount.fill(1);
+    this.updateCycle = symbols;
+    this.symbolsUntilUpdate = symbols;
+    this.update();
+    this.symbolsUntilUpdate = this.updateCycle = (symbols + 6) >> 1;
+  }
+
+  /** Recompute the scaled cumulative distribution from adaptive counts. */
+  update(): void {
+    this.totalCount += this.updateCycle;
+    if (this.totalCount > DM_MAX_COUNT) {
+      this.totalCount = 0;
+      for (let symbol = 0; symbol < this.symbols; symbol++) {
+        this.symbolCount[symbol] = (this.symbolCount[symbol] + 1) >> 1;
+        this.totalCount += this.symbolCount[symbol];
+      }
+    }
+
+    let sum = 0;
+    const scale = (0x80000000 / this.totalCount) | 0;
+    for (let symbol = 0; symbol < this.symbols; symbol++) {
+      this.distribution[symbol] = ((scale * sum) / DM_DISTRIBUTION_DIVISOR) | 0;
+      sum += this.symbolCount[symbol];
+    }
+
+    this.updateCycle = (5 * this.updateCycle) >> 2;
+    const maxCycle = (this.symbols + 6) << 3;
+    if (this.updateCycle > maxCycle) {
+      this.updateCycle = maxCycle;
+    }
+    this.symbolsUntilUpdate = this.updateCycle;
+  }
+}
+
+/** Adaptive binary model used by the LASzip arithmetic encoder. */
+export class ArithmeticBitModel {
+  /** Number of observations added at the next model update. */
+  updateCycle = 4;
+  /** Bits remaining before the next model update. */
+  bitsUntilUpdate = 4;
+  /** Scaled probability of a zero bit. */
+  bit0Probability = 1 << (BM_LENGTH_SHIFT - 1);
+  /** Number of zero bits observed. */
+  bit0Count = 1;
+  /** Total number of bits observed. */
+  bitCount = 2;
+
+  /** Recompute the scaled zero-bit probability from adaptive counts. */
+  update(): void {
+    this.bitCount += this.updateCycle;
+    if (this.bitCount > BM_MAX_COUNT) {
+      this.bitCount = (this.bitCount + 1) >> 1;
+      this.bit0Count = (this.bit0Count + 1) >> 1;
+      if (this.bit0Count === this.bitCount) {
+        this.bitCount++;
+      }
+    }
+    const scale = (0x80000000 / this.bitCount) | 0;
+    this.bit0Probability = ((this.bit0Count * scale) / BM_DISTRIBUTION_DIVISOR) | 0;
+    this.updateCycle = (5 * this.updateCycle) >> 2;
+    if (this.updateCycle > 64) {
+      this.updateCycle = 64;
+    }
+    this.bitsUntilUpdate = this.updateCycle;
+  }
+}
+
+/** In-memory arithmetic encoder compatible with LASzip's FastAC streams. */
+export class ArithmeticEncoder {
+  /** Encoded output bytes. */
+  private readonly bytes: number[] = [];
+  /** Lower bound of the current arithmetic interval. */
+  private base = 0;
+  /** Length of the current arithmetic interval. */
+  private length = AC_MAX_LENGTH;
+  /** Whether the final synchronization bytes have been written. */
+  private finished = false;
+
+  /** Encode one bit using an adaptive binary model. */
+  encodeBit(model: ArithmeticBitModel, symbol: number): void {
+    const split = model.bit0Probability * (this.length >>> BM_LENGTH_SHIFT);
+    if (symbol === 0) {
+      this.length = split >>> 0;
+      model.bit0Count++;
+    } else if (symbol === 1) {
+      this.addToBase(split);
+      this.length = (this.length - split) >>> 0;
+    } else {
+      throw new Error(`Invalid arithmetic bit ${symbol}`);
+    }
+
+    this.renormalizeIfNeeded();
+    if (--model.bitsUntilUpdate === 0) {
+      model.update();
+    }
+  }
+
+  /** Encode one symbol using an adaptive symbol model. */
+  encodeSymbol(model: ArithmeticModel, symbol: number): void {
+    if (!Number.isInteger(symbol) || symbol < 0 || symbol > model.lastSymbol) {
+      throw new Error(`Invalid arithmetic symbol ${symbol}`);
+    }
+
+    let interval = this.length;
+    let lower: number;
+    if (symbol === model.lastSymbol) {
+      lower = model.distribution[symbol] * (interval >>> DM_LENGTH_SHIFT);
+      this.addToBase(lower);
+      this.length = (interval - lower) >>> 0;
+    } else {
+      interval >>>= DM_LENGTH_SHIFT;
+      lower = model.distribution[symbol] * interval;
+      this.addToBase(lower);
+      this.length = (model.distribution[symbol + 1] * interval - lower) >>> 0;
+    }
+
+    this.renormalizeIfNeeded();
+    model.symbolCount[symbol]++;
+    if (--model.symbolsUntilUpdate === 0) {
+      model.update();
+    }
+  }
+
+  /** Encode an unsigned value in a fixed number of arithmetic-coded bits. */
+  writeBits(bitCount: number, symbol: number): void {
+    if (!Number.isInteger(bitCount) || bitCount < 1 || bitCount > 32) {
+      throw new Error(`Invalid arithmetic bit count ${bitCount}`);
+    }
+    if (bitCount > 19) {
+      this.writeShort(symbol & 0xffff);
+      symbol >>>= 16;
+      bitCount -= 16;
+    }
+    const interval = this.length >>> bitCount;
+    this.addToBase(symbol * interval);
+    this.length = interval >>> 0;
+    this.renormalizeIfNeeded();
+  }
+
+  /** Encode a raw unsigned 16-bit integer. */
+  writeShort(symbol: number): void {
+    const interval = this.length >>> 16;
+    this.addToBase((symbol & 0xffff) * interval);
+    this.length = interval >>> 0;
+    this.renormalizeIfNeeded();
+  }
+
+  /** Encode a raw unsigned 32-bit integer in LASzip word order. */
+  writeInt(symbol: number): void {
+    this.writeShort(symbol & 0xffff);
+    this.writeShort(symbol >>> 16);
+  }
+
+  /** Finish the stream and return its synchronization-padded bytes. */
+  finish(): Uint8Array {
+    if (this.finished) {
+      return Uint8Array.from(this.bytes);
+    }
+    this.finished = true;
+
+    const initialBase = this.base;
+    let anotherByte = true;
+    if (this.length > 2 * AC_MIN_LENGTH) {
+      this.base = (this.base + AC_MIN_LENGTH) >>> 0;
+      this.length = AC_MIN_LENGTH >>> 1;
+    } else {
+      this.base = (this.base + (AC_MIN_LENGTH >>> 1)) >>> 0;
+      this.length = AC_MIN_LENGTH >>> 9;
+      anotherByte = false;
+    }
+    if (initialBase > this.base) {
+      this.propagateCarry();
+    }
+    this.renormalize();
+    this.bytes.push(0, 0);
+    if (anotherByte) {
+      this.bytes.push(0);
+    }
+    return Uint8Array.from(this.bytes);
+  }
+
+  /** Add to the interval base and propagate unsigned overflow. */
+  private addToBase(increment: number): void {
+    const initialBase = this.base;
+    this.base = (this.base + increment) >>> 0;
+    if (initialBase > this.base) {
+      this.propagateCarry();
+    }
+  }
+
+  /** Increment the last non-0xff output byte after interval overflow. */
+  private propagateCarry(): void {
+    let index = this.bytes.length - 1;
+    while (index >= 0 && this.bytes[index] === 0xff) {
+      this.bytes[index--] = 0;
+    }
+    if (index < 0) {
+      throw new Error('LASzip arithmetic carry precedes encoded output');
+    }
+    this.bytes[index]++;
+  }
+
+  /** Renormalize the arithmetic interval when it is too short. */
+  private renormalizeIfNeeded(): void {
+    if (this.length < AC_MIN_LENGTH) {
+      this.renormalize();
+    }
+  }
+
+  /** Emit leading interval bytes until the interval is large enough. */
+  private renormalize(): void {
+    do {
+      this.bytes.push(this.base >>> 24);
+      this.base = (this.base << 8) >>> 0;
+      this.length = (this.length << 8) >>> 0;
+    } while (this.length < AC_MIN_LENGTH);
+  }
+}
+
+/** LASzip modular integer predictor encoder. */
+export class IntegerCompressor {
+  /** Arithmetic stream that receives encoded corrections. */
+  private readonly encoder: ArithmeticEncoder;
+  /** Number of prediction contexts. */
+  private readonly contexts: number;
+  /** Number of high correction bits encoded as one symbol. */
+  private readonly bitsHigh: number;
+  /** Maximum correction bit width. */
+  private readonly correctionBits: number;
+  /** Modular integer range, or zero for signed 32-bit values. */
+  private readonly correctionRange: number;
+  /** Minimum signed correction represented by the modular range. */
+  private readonly correctionMinimum: number;
+  /** Models that encode correction bit widths. */
+  private readonly bitModels: ArithmeticModel[];
+  /** Binary model for zero-bit corrections. */
+  private readonly zeroBitCorrector = new ArithmeticBitModel();
+  /** Models that encode correction values. */
+  private readonly correctorModels: ArithmeticModel[];
+  /** Bit width used by the most recently encoded correction. */
+  k = 0;
+
+  /** Create an integer compressor for one arithmetic layer. */
+  constructor(encoder: ArithmeticEncoder, bits = 16, contexts = 1, bitsHigh = 8, range = 0) {
+    this.encoder = encoder;
+    this.contexts = contexts;
+    this.bitsHigh = bitsHigh;
+    if (range) {
+      let remainingRange = range;
+      let correctionBits = 0;
+      while (remainingRange) {
+        remainingRange >>= 1;
+        correctionBits++;
+      }
+      if (range === 2 ** (correctionBits - 1)) {
+        correctionBits--;
+      }
+      this.correctionBits = correctionBits;
+      this.correctionRange = range;
+      this.correctionMinimum = -(range / 2);
+    } else if (bits && bits < 32) {
+      this.correctionBits = bits;
+      this.correctionRange = 2 ** bits;
+      this.correctionMinimum = -(this.correctionRange / 2);
+    } else {
+      this.correctionBits = 32;
+      this.correctionRange = 0;
+      this.correctionMinimum = -2147483648;
+    }
+
+    this.bitModels = Array.from(
+      {length: this.contexts},
+      () => new ArithmeticModel(this.correctionBits + 1)
+    );
+    this.correctorModels = Array.from({length: this.correctionBits}, (_, index) => {
+      const bitCount = index + 1;
+      return new ArithmeticModel(2 ** Math.min(bitCount, this.bitsHigh));
+    });
+  }
+
+  /** Encode an integer relative to a predictor in the selected context. */
+  compress(prediction: number, value: number, context = 0): void {
+    if (!Number.isInteger(context) || context < 0 || context >= this.contexts) {
+      throw new Error(`Invalid integer compressor context ${context}`);
+    }
+    let correction = toInt32(value - prediction);
+    if (this.correctionRange) {
+      if (correction < this.correctionMinimum) {
+        correction += this.correctionRange;
+      } else if (correction > this.correctionMinimum + this.correctionRange - 1) {
+        correction -= this.correctionRange;
+      }
+    }
+    this.writeCorrector(correction, this.bitModels[context]);
+  }
+
+  /** Encode a folded signed correction and record its bit width. */
+  private writeCorrector(correction: number, bitModel: ArithmeticModel): void {
+    let folded = correction <= 0 ? -correction : correction - 1;
+    let bitCount = 0;
+    while (folded) {
+      folded >>>= 1;
+      bitCount++;
+    }
+    this.k = bitCount;
+    this.encoder.encodeSymbol(bitModel, bitCount);
+
+    if (bitCount === 0) {
+      this.encoder.encodeBit(this.zeroBitCorrector, correction);
+      return;
+    }
+    if (bitCount === 32) {
+      if (correction !== this.correctionMinimum) {
+        throw new Error(`Invalid ${bitCount}-bit integer correction ${correction}`);
+      }
+      return;
+    }
+
+    let symbol = correction < 0 ? correction + (2 ** bitCount - 1) : correction - 1;
+    const model = this.correctorModels[bitCount - 1];
+    if (bitCount <= this.bitsHigh) {
+      this.encoder.encodeSymbol(model, symbol);
+    } else {
+      const lowerBitCount = bitCount - this.bitsHigh;
+      const lowerMask = 2 ** lowerBitCount - 1;
+      const lower = symbol & lowerMask;
+      symbol >>>= lowerBitCount;
+      this.encoder.encodeSymbol(model, symbol);
+      this.encoder.writeBits(lowerBitCount, lower);
+    }
+  }
+}
+
+/** Five-value streaming median predictor used by LASzip coordinate coding. */
+export class StreamingMedian {
+  /** Smallest retained value. */
+  private value0 = 0;
+  /** Second-smallest retained value. */
+  private value1 = 0;
+  /** Current median. */
+  private value2 = 0;
+  /** Second-largest retained value. */
+  private value3 = 0;
+  /** Largest retained value. */
+  private value4 = 0;
+  /** Whether the next update shifts values toward the upper half. */
+  private high = true;
+
+  /** Add one value to the streaming median state. */
+  add(value: number): void {
+    if (this.high) {
+      if (value < this.value2) {
+        this.value4 = this.value3;
+        this.value3 = this.value2;
+        if (value < this.value0) {
+          this.value2 = this.value1;
+          this.value1 = this.value0;
+          this.value0 = value;
+        } else if (value < this.value1) {
+          this.value2 = this.value1;
+          this.value1 = value;
+        } else {
+          this.value2 = value;
+        }
+      } else {
+        if (value < this.value3) {
+          this.value4 = this.value3;
+          this.value3 = value;
+        } else {
+          this.value4 = value;
+        }
+        this.high = false;
+      }
+    } else if (this.value2 < value) {
+      this.value0 = this.value1;
+      this.value1 = this.value2;
+      if (this.value4 < value) {
+        this.value2 = this.value3;
+        this.value3 = this.value4;
+        this.value4 = value;
+      } else if (this.value3 < value) {
+        this.value2 = this.value3;
+        this.value3 = value;
+      } else {
+        this.value2 = value;
+      }
+    } else {
+      if (this.value1 < value) {
+        this.value0 = this.value1;
+        this.value1 = value;
+      } else {
+        this.value0 = value;
+      }
+      this.high = true;
+    }
+  }
+
+  /** Return the current median predictor. */
+  get(): number {
+    return this.value2;
+  }
+}
+
+/** Convert a number to signed 32-bit integer semantics. */
+export function toInt32(value: number): number {
+  return value | 0;
+}

--- a/modules/loader-utils/src/lib/laz/laz-chunk-encoder.ts
+++ b/modules/loader-utils/src/lib/laz/laz-chunk-encoder.ts
@@ -3,13 +3,67 @@
 // Copyright (c) vis.gl contributors
 
 import type {LAZChunkMetadata} from './laz-chunk-decoder';
+import {
+  ArithmeticEncoder,
+  ArithmeticModel,
+  IntegerCompressor,
+  StreamingMedian,
+  toInt32
+} from './laz-arithmetic-encoder';
+
+const POINT_FORMAT_BASE_LENGTHS: Record<number, number> = {6: 30, 7: 36, 8: 38};
+const GPS_TIME_MULTI = 500;
+const GPS_TIME_MULTI_MINUS = -10;
+const GPS_TIME_MULTI_CODE_FULL = 511;
+
+const NUMBER_RETURN_MAP_6_CONTEXT: number[][] = [
+  [0, 1, 2, 3, 4, 5, 3, 4, 4, 5, 5, 5, 5, 5, 5, 5],
+  [1, 0, 1, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3],
+  [2, 1, 2, 4, 4, 4, 4, 4, 4, 4, 4, 3, 3, 3, 3, 3],
+  [3, 3, 4, 5, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4],
+  [4, 3, 4, 4, 5, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4],
+  [5, 3, 4, 4, 4, 5, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4],
+  [3, 3, 4, 4, 4, 4, 5, 4, 4, 4, 4, 4, 4, 4, 4, 4],
+  [4, 3, 4, 4, 4, 4, 4, 5, 4, 4, 4, 4, 4, 4, 4, 4],
+  [4, 3, 4, 4, 4, 4, 4, 4, 5, 4, 4, 4, 4, 4, 4, 4],
+  [5, 3, 4, 4, 4, 4, 4, 4, 4, 5, 4, 4, 4, 4, 4, 4],
+  [5, 3, 4, 4, 4, 4, 4, 4, 4, 4, 5, 4, 4, 4, 4, 4],
+  [5, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 4, 4, 4],
+  [5, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 4, 4],
+  [5, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 4],
+  [5, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5],
+  [5, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5]
+];
+
+const NUMBER_RETURN_LEVEL_8_CONTEXT: number[][] = [
+  [0, 1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 7, 7, 7, 7],
+  [1, 0, 1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 7, 7, 7],
+  [2, 1, 0, 1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 7, 7],
+  [3, 2, 1, 0, 1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 7],
+  [4, 3, 2, 1, 0, 1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7],
+  [5, 4, 3, 2, 1, 0, 1, 2, 3, 4, 5, 6, 7, 7, 7, 7],
+  [6, 5, 4, 3, 2, 1, 0, 1, 2, 3, 4, 5, 6, 7, 7, 7],
+  [7, 6, 5, 4, 3, 2, 1, 0, 1, 2, 3, 4, 5, 6, 7, 7],
+  [7, 7, 6, 5, 4, 3, 2, 1, 0, 1, 2, 3, 4, 5, 6, 7],
+  [7, 7, 7, 6, 5, 4, 3, 2, 1, 0, 1, 2, 3, 4, 5, 6],
+  [7, 7, 7, 7, 6, 5, 4, 3, 2, 1, 0, 1, 2, 3, 4, 5],
+  [7, 7, 7, 7, 7, 6, 5, 4, 3, 2, 1, 0, 1, 2, 3, 4],
+  [7, 7, 7, 7, 7, 7, 6, 5, 4, 3, 2, 1, 0, 1, 2, 3],
+  [7, 7, 7, 7, 7, 7, 7, 6, 5, 4, 3, 2, 1, 0, 1, 2],
+  [7, 7, 7, 7, 7, 7, 7, 7, 6, 5, 4, 3, 2, 1, 0, 1],
+  [7, 7, 7, 7, 7, 7, 7, 7, 7, 6, 5, 4, 3, 2, 1, 0]
+];
 
 /** Feedable TypeScript LAZ chunk encoder. */
 export class FeedableLAZChunkEncoder {
-  private metadata: LAZChunkMetadata;
-  private chunks: Uint8Array[] = [];
+  /** Metadata describing the raw point records. */
+  private readonly metadata: LAZChunkMetadata;
+  /** Raw point byte ranges supplied by the caller. */
+  private readonly chunks: Uint8Array[] = [];
+  /** Whether the raw point input has been closed. */
   private closed = false;
 
+  /** Create a feedable encoder for one LAZ chunk. */
   constructor(metadata: LAZChunkMetadata) {
     this.metadata = metadata;
   }
@@ -41,20 +95,923 @@ export function createLAZChunkEncoder(metadata: LAZChunkMetadata): FeedableLAZCh
   return new FeedableLAZChunkEncoder(metadata);
 }
 
-/** Encode raw LAS point records into a compressed LAZ chunk. */
+/** Encode raw LAS 1.4 point records into one LASzip layered chunk. */
 export function encodeLAZChunk(
-  _rawPointData: ArrayBuffer | ArrayBufferView,
-  _metadata: LAZChunkMetadata
+  rawPointData: ArrayBuffer | ArrayBufferView,
+  metadata: LAZChunkMetadata
 ): Uint8Array {
-  throw new Error('TypeScript LAZ chunk encoding is not implemented yet');
+  const rawBytes = toUint8Array(rawPointData);
+  validateMetadata(rawBytes, metadata);
+  if (metadata.pointCount === 0) {
+    return new Uint8Array(0);
+  }
+
+  const pointRecordLength = metadata.pointDataRecordLength;
+  const pointFormat = metadata.pointDataRecordFormat;
+  const baseRecordLength = POINT_FORMAT_BASE_LENGTHS[pointFormat];
+  const extraByteCount = pointRecordLength - baseRecordLength;
+  const firstRecord = rawBytes.subarray(0, pointRecordLength);
+  const firstPoint = readPoint14(firstRecord, 0);
+  const pointEncoder = new Point14LayerEncoder(firstPoint);
+  const firstRgb = pointFormat >= 7 ? readRgb(firstRecord, 30) : null;
+  const rgbEncoder = firstRgb
+    ? new RGB14LayerEncoder(firstRgb, getScannerChannel(firstPoint))
+    : null;
+  const nirEncoder =
+    pointFormat === 8
+      ? new NIR14LayerEncoder(readUint16(firstRecord, 36), getScannerChannel(firstPoint))
+      : null;
+  const extraBytesEncoder = extraByteCount
+    ? new Byte14LayerEncoder(
+        firstRecord.subarray(baseRecordLength, pointRecordLength),
+        getScannerChannel(firstPoint)
+      )
+    : null;
+
+  for (let pointIndex = 1; pointIndex < metadata.pointCount; pointIndex++) {
+    const recordOffset = pointIndex * pointRecordLength;
+    const record = rawBytes.subarray(recordOffset, recordOffset + pointRecordLength);
+    const itemContext = pointEncoder.encode(readPoint14(record, 0));
+    rgbEncoder?.encode(readRgb(record, 30), itemContext);
+    nirEncoder?.encode(readUint16(record, 36), itemContext);
+    extraBytesEncoder?.encode(record.subarray(baseRecordLength, pointRecordLength), itemContext);
+  }
+
+  const pointLayers = pointEncoder.finish();
+  const rgbLayer = rgbEncoder?.finish();
+  const nirLayer = nirEncoder?.finish();
+  const extraByteLayers = extraBytesEncoder?.finish() || [];
+  const layers = [
+    ...pointLayers,
+    ...(rgbLayer ? [rgbLayer] : []),
+    ...(nirLayer ? [nirLayer] : []),
+    ...extraByteLayers
+  ];
+
+  const sizeHeader = new Uint8Array(4 + layers.length * 4);
+  const sizeView = new DataView(sizeHeader.buffer);
+  sizeView.setUint32(0, metadata.pointCount, true);
+  for (let index = 0; index < layers.length; index++) {
+    sizeView.setUint32(4 + index * 4, layers[index].byteLength, true);
+  }
+  return concatenateUint8Arrays([firstRecord, sizeHeader, ...layers]);
 }
 
+type Point14 = {
+  /** Quantized X coordinate. */
+  x: number;
+  /** Quantized Y coordinate. */
+  y: number;
+  /** Quantized Z coordinate. */
+  z: number;
+  /** Pulse return intensity. */
+  intensity: number;
+  /** Packed return number and number of returns. */
+  returns: number;
+  /** Packed classification, scanner-channel, and flight-line flags. */
+  flags: number;
+  /** Point classification. */
+  classification: number;
+  /** User-defined point data. */
+  userData: number;
+  /** Scan angle in LAS 1.4 units. */
+  scanAngle: number;
+  /** Point source identifier. */
+  pointSourceId: number;
+  /** Raw IEEE-754 GPS timestamp bits. */
+  gpsTimeBits: bigint;
+};
+
+type Rgb14 = {
+  /** Red channel. */
+  red: number;
+  /** Green channel. */
+  green: number;
+  /** Blue channel. */
+  blue: number;
+};
+
+/** Prediction state for one Point14 scanner channel. */
+class Point14Context {
+  /** Changed-value models selected by prior return and GPS state. */
+  readonly changedValuesModels = createModels(8, 128);
+  /** Scanner-channel delta model. */
+  readonly scannerChannelModel = new ArithmeticModel(3);
+  /** Return-number delta model used when GPS time is unchanged. */
+  readonly returnNumberGpsSameModel = new ArithmeticModel(13);
+  /** Lazily allocated number-of-returns models. */
+  readonly numberReturnsModels: Array<ArithmeticModel | null> = new Array(16).fill(null);
+  /** Lazily allocated return-number models. */
+  readonly returnNumberModels: Array<ArithmeticModel | null> = new Array(16).fill(null);
+  /** Lazily allocated classification models. */
+  readonly classificationModels: Array<ArithmeticModel | null> = new Array(64).fill(null);
+  /** Lazily allocated flag models. */
+  readonly flagModels: Array<ArithmeticModel | null> = new Array(64).fill(null);
+  /** Lazily allocated user-data models. */
+  readonly userDataModels: Array<ArithmeticModel | null> = new Array(64).fill(null);
+  /** GPS multiplier model. */
+  readonly gpsTimeMultiplierModel = new ArithmeticModel(515);
+  /** GPS zero-difference model. */
+  readonly gpsTimeZeroDifferenceModel = new ArithmeticModel(5);
+  /** X difference compressor. */
+  readonly xDifferenceCompressor: IntegerCompressor;
+  /** Y difference compressor. */
+  readonly yDifferenceCompressor: IntegerCompressor;
+  /** Z value compressor. */
+  readonly zCompressor: IntegerCompressor;
+  /** Intensity compressor. */
+  readonly intensityCompressor: IntegerCompressor;
+  /** Scan-angle compressor. */
+  readonly scanAngleCompressor: IntegerCompressor;
+  /** Point-source ID compressor. */
+  readonly pointSourceIdCompressor: IntegerCompressor;
+  /** GPS bit-difference compressor. */
+  readonly gpsTimeCompressor: IntegerCompressor;
+  /** Last X difference medians by return context. */
+  readonly lastXDifferenceMedian = Array.from({length: 12}, () => new StreamingMedian());
+  /** Last Y difference medians by return context. */
+  readonly lastYDifferenceMedian = Array.from({length: 12}, () => new StreamingMedian());
+  /** Last Z value by return level. */
+  readonly lastZ: number[];
+  /** Last intensity by first/last and GPS context. */
+  readonly lastIntensity: number[];
+  /** Last GPS time for each interleaved sequence. */
+  readonly lastGpsTimeBits: bigint[];
+  /** Last signed GPS bit difference for each sequence. */
+  readonly lastGpsTimeDifference = new Array<number>(4).fill(0);
+  /** Extreme GPS multiplier counters by sequence. */
+  readonly gpsTimeExtremeCounter = new Array<number>(4).fill(0);
+  /** Current GPS sequence. */
+  lastGpsSequence = 0;
+  /** Next GPS sequence replacement slot. */
+  nextGpsSequence = 0;
+  /** Whether the preceding point changed GPS time. */
+  gpsTimeChanged = false;
+  /** Last point encoded in this scanner channel. */
+  readonly last: Point14;
+
+  /** Create scanner-channel state initialized from a preceding point. */
+  constructor(point: Point14, layers: Point14ArithmeticLayers) {
+    this.last = {...point};
+    this.xDifferenceCompressor = new IntegerCompressor(layers.xy, 32, 2);
+    this.yDifferenceCompressor = new IntegerCompressor(layers.xy, 32, 22);
+    this.zCompressor = new IntegerCompressor(layers.z, 32, 20);
+    this.intensityCompressor = new IntegerCompressor(layers.intensity, 16, 4);
+    this.scanAngleCompressor = new IntegerCompressor(layers.scanAngle, 16, 2);
+    this.pointSourceIdCompressor = new IntegerCompressor(layers.pointSourceId, 16, 1);
+    this.gpsTimeCompressor = new IntegerCompressor(layers.gpsTime, 32, 9);
+    this.lastZ = new Array<number>(8).fill(point.z);
+    this.lastIntensity = new Array<number>(8).fill(point.intensity);
+    this.lastGpsTimeBits = [point.gpsTimeBits, 0n, 0n, 0n];
+  }
+}
+
+type Point14ArithmeticLayers = {
+  /** Scanner channel, return, X, and Y stream. */
+  xy: ArithmeticEncoder;
+  /** Z coordinate stream. */
+  z: ArithmeticEncoder;
+  /** Classification stream. */
+  classification: ArithmeticEncoder;
+  /** Classification and flight-line flags stream. */
+  flags: ArithmeticEncoder;
+  /** Intensity stream. */
+  intensity: ArithmeticEncoder;
+  /** Scan-angle stream. */
+  scanAngle: ArithmeticEncoder;
+  /** User-data stream. */
+  userData: ArithmeticEncoder;
+  /** Point-source identifier stream. */
+  pointSourceId: ArithmeticEncoder;
+  /** GPS timestamp stream. */
+  gpsTime: ArithmeticEncoder;
+};
+
+/** Encoder for the nine layered Point14 streams. */
+class Point14LayerEncoder {
+  /** Arithmetic encoder for each independent Point14 layer. */
+  private readonly layers: Point14ArithmeticLayers = {
+    xy: new ArithmeticEncoder(),
+    z: new ArithmeticEncoder(),
+    classification: new ArithmeticEncoder(),
+    flags: new ArithmeticEncoder(),
+    intensity: new ArithmeticEncoder(),
+    scanAngle: new ArithmeticEncoder(),
+    userData: new ArithmeticEncoder(),
+    pointSourceId: new ArithmeticEncoder(),
+    gpsTime: new ArithmeticEncoder()
+  };
+  /** Scanner-channel prediction contexts. */
+  private readonly contexts: Array<Point14Context | null> = new Array(4).fill(null);
+  /** Scanner channel used by the previous point. */
+  private currentScannerChannel: number;
+  /** Whether each optional Point14 layer changed in this chunk. */
+  private readonly changed = {
+    classification: false,
+    flags: false,
+    intensity: false,
+    scanAngle: false,
+    userData: false,
+    pointSourceId: false,
+    gpsTime: false
+  };
+
+  /** Initialize Point14 coding from the raw first point. */
+  constructor(firstPoint: Point14) {
+    this.currentScannerChannel = getScannerChannel(firstPoint);
+    this.contexts[this.currentScannerChannel] = new Point14Context(firstPoint, this.layers);
+  }
+
+  /** Encode one subsequent Point14 item and return the LASzip v3 item context. */
+  encode(point: Point14): number {
+    const previousContext = this.contexts[this.currentScannerChannel]!;
+    let lastPoint = previousContext.last;
+    const scannerChannel = getScannerChannel(point);
+    if (scannerChannel !== this.currentScannerChannel && this.contexts[scannerChannel]) {
+      lastPoint = this.contexts[scannerChannel]!.last;
+    }
+
+    const pointSourceChanged = point.pointSourceId !== lastPoint.pointSourceId;
+    const gpsTimeChanged = point.gpsTimeBits !== lastPoint.gpsTimeBits;
+    const scanAngleChanged = point.scanAngle !== lastPoint.scanAngle;
+    const lastNumberOfReturns = lastPoint.returns >> 4;
+    const lastReturnNumber = lastPoint.returns & 0x0f;
+    const numberOfReturns = point.returns >> 4;
+    const returnNumber = point.returns & 0x0f;
+    const previousReturnContext =
+      (lastReturnNumber === 1 ? 1 : 0) |
+      (lastReturnNumber >= lastNumberOfReturns ? 2 : 0) |
+      (previousContext.gpsTimeChanged ? 4 : 0);
+
+    let changedValues =
+      (scannerChannel !== this.currentScannerChannel ? 1 << 6 : 0) |
+      (pointSourceChanged ? 1 << 5 : 0) |
+      (gpsTimeChanged ? 1 << 4 : 0) |
+      (scanAngleChanged ? 1 << 3 : 0) |
+      (numberOfReturns !== lastNumberOfReturns ? 1 << 2 : 0);
+    if (returnNumber !== lastReturnNumber) {
+      if (returnNumber === (lastReturnNumber + 1) % 16) {
+        changedValues |= 1;
+      } else if (returnNumber === (lastReturnNumber + 15) % 16) {
+        changedValues |= 2;
+      } else {
+        changedValues |= 3;
+      }
+    }
+    this.layers.xy.encodeSymbol(
+      previousContext.changedValuesModels[previousReturnContext],
+      changedValues
+    );
+
+    let itemContext = 0;
+    if (scannerChannel !== this.currentScannerChannel) {
+      const scannerDifference = scannerChannel - this.currentScannerChannel;
+      this.layers.xy.encodeSymbol(previousContext.scannerChannelModel, (scannerDifference + 3) % 4);
+      this.contexts[scannerChannel] ||= new Point14Context(previousContext.last, this.layers);
+      this.currentScannerChannel = scannerChannel;
+      itemContext = scannerChannel;
+      lastPoint = this.contexts[scannerChannel]!.last;
+    }
+    const context = this.contexts[this.currentScannerChannel]!;
+
+    if (numberOfReturns !== lastNumberOfReturns) {
+      let model = context.numberReturnsModels[lastNumberOfReturns];
+      if (!model) {
+        model = new ArithmeticModel(16);
+        context.numberReturnsModels[lastNumberOfReturns] = model;
+      }
+      this.layers.xy.encodeSymbol(model, numberOfReturns);
+    }
+    if ((changedValues & 3) === 3) {
+      if (gpsTimeChanged) {
+        let model = context.returnNumberModels[lastReturnNumber];
+        if (!model) {
+          model = new ArithmeticModel(16);
+          context.returnNumberModels[lastReturnNumber] = model;
+        }
+        this.layers.xy.encodeSymbol(model, returnNumber);
+      } else {
+        const returnDifference = returnNumber - lastReturnNumber;
+        this.layers.xy.encodeSymbol(context.returnNumberGpsSameModel, (returnDifference + 14) % 16);
+      }
+    }
+
+    const returnMap = NUMBER_RETURN_MAP_6_CONTEXT[numberOfReturns][returnNumber];
+    const returnLevel = NUMBER_RETURN_LEVEL_8_CONTEXT[numberOfReturns][returnNumber];
+    const currentReturnContext =
+      (returnNumber === 1 ? 2 : 0) | (returnNumber >= numberOfReturns ? 1 : 0);
+    const xyContext = (returnMap << 1) | (gpsTimeChanged ? 1 : 0);
+    const xMedian = context.lastXDifferenceMedian[xyContext].get();
+    const xDifference = toInt32(point.x - lastPoint.x);
+    context.xDifferenceCompressor.compress(xMedian, xDifference, numberOfReturns === 1 ? 1 : 0);
+    context.lastXDifferenceMedian[xyContext].add(xDifference);
+
+    const yMedian = context.lastYDifferenceMedian[xyContext].get();
+    const yDifference = toInt32(point.y - lastPoint.y);
+    const yContext =
+      (numberOfReturns === 1 ? 1 : 0) | (Math.min(context.xDifferenceCompressor.k, 20) & ~1);
+    context.yDifferenceCompressor.compress(yMedian, yDifference, yContext);
+    context.lastYDifferenceMedian[xyContext].add(yDifference);
+
+    const zContext =
+      (numberOfReturns === 1 ? 1 : 0) |
+      (Math.min((context.xDifferenceCompressor.k + context.yDifferenceCompressor.k) >> 1, 18) & ~1);
+    context.zCompressor.compress(context.lastZ[returnLevel], point.z, zContext);
+    context.lastZ[returnLevel] = point.z;
+
+    if (point.classification !== lastPoint.classification) {
+      this.changed.classification = true;
+    }
+    const classificationContext =
+      ((lastPoint.classification & 0x1f) << 1) | (currentReturnContext === 3 ? 1 : 0);
+    let classificationModel = context.classificationModels[classificationContext];
+    if (!classificationModel) {
+      classificationModel = new ArithmeticModel(256);
+      context.classificationModels[classificationContext] = classificationModel;
+    }
+    this.layers.classification.encodeSymbol(classificationModel, point.classification);
+
+    const lastFlags = mergeFlags(lastPoint);
+    const flags = mergeFlags(point);
+    if (flags !== lastFlags) {
+      this.changed.flags = true;
+    }
+    let flagModel = context.flagModels[lastFlags];
+    if (!flagModel) {
+      flagModel = new ArithmeticModel(64);
+      context.flagModels[lastFlags] = flagModel;
+    }
+    this.layers.flags.encodeSymbol(flagModel, flags);
+
+    if (point.intensity !== lastPoint.intensity) {
+      this.changed.intensity = true;
+    }
+    const intensityIndex = (currentReturnContext << 1) | (gpsTimeChanged ? 1 : 0);
+    context.intensityCompressor.compress(
+      context.lastIntensity[intensityIndex],
+      point.intensity,
+      currentReturnContext
+    );
+    context.lastIntensity[intensityIndex] = point.intensity;
+
+    if (scanAngleChanged) {
+      this.changed.scanAngle = true;
+      context.scanAngleCompressor.compress(
+        lastPoint.scanAngle,
+        point.scanAngle,
+        gpsTimeChanged ? 1 : 0
+      );
+    }
+
+    if (point.userData !== lastPoint.userData) {
+      this.changed.userData = true;
+    }
+    const userDataContext = lastPoint.userData >> 2;
+    let userDataModel = context.userDataModels[userDataContext];
+    if (!userDataModel) {
+      userDataModel = new ArithmeticModel(256);
+      context.userDataModels[userDataContext] = userDataModel;
+    }
+    this.layers.userData.encodeSymbol(userDataModel, point.userData);
+
+    if (pointSourceChanged) {
+      this.changed.pointSourceId = true;
+      context.pointSourceIdCompressor.compress(lastPoint.pointSourceId, point.pointSourceId);
+    }
+    if (gpsTimeChanged) {
+      this.changed.gpsTime = true;
+      this.encodeGpsTime(context, point.gpsTimeBits);
+    }
+
+    copyPoint14(context.last, point);
+    context.gpsTimeChanged = gpsTimeChanged;
+    return itemContext;
+  }
+
+  /** Finish Point14 arithmetic streams in LASzip layer order. */
+  finish(): Uint8Array[] {
+    return [
+      this.layers.xy.finish(),
+      this.layers.z.finish(),
+      this.changed.classification ? this.layers.classification.finish() : new Uint8Array(0),
+      this.changed.flags ? this.layers.flags.finish() : new Uint8Array(0),
+      this.changed.intensity ? this.layers.intensity.finish() : new Uint8Array(0),
+      this.changed.scanAngle ? this.layers.scanAngle.finish() : new Uint8Array(0),
+      this.changed.userData ? this.layers.userData.finish() : new Uint8Array(0),
+      this.changed.pointSourceId ? this.layers.pointSourceId.finish() : new Uint8Array(0),
+      this.changed.gpsTime ? this.layers.gpsTime.finish() : new Uint8Array(0)
+    ];
+  }
+
+  /** Encode one changed GPS time into the active scanner-channel sequence state. */
+  private encodeGpsTime(context: Point14Context, gpsTimeBits: bigint): void {
+    const sequence = context.lastGpsSequence;
+    const difference64 = BigInt.asIntN(64, gpsTimeBits - context.lastGpsTimeBits[sequence]);
+    const difference = Number(BigInt.asIntN(32, difference64));
+    const differenceFits = difference64 === BigInt(difference);
+
+    if (context.lastGpsTimeDifference[sequence] === 0) {
+      if (differenceFits) {
+        this.layers.gpsTime.encodeSymbol(context.gpsTimeZeroDifferenceModel, 0);
+        context.gpsTimeCompressor.compress(0, difference, 0);
+        context.lastGpsTimeDifference[sequence] = difference;
+        context.gpsTimeExtremeCounter[sequence] = 0;
+      } else if (this.selectGpsTimeSequence(context, gpsTimeBits, false)) {
+        this.encodeGpsTime(context, gpsTimeBits);
+        return;
+      } else {
+        this.layers.gpsTime.encodeSymbol(context.gpsTimeZeroDifferenceModel, 1);
+        this.startGpsTimeSequence(context, gpsTimeBits);
+      }
+    } else if (differenceFits) {
+      const lastDifference = context.lastGpsTimeDifference[sequence];
+      const multiplier = quantizeFloat32(difference, lastDifference);
+      if (multiplier === 1) {
+        this.layers.gpsTime.encodeSymbol(context.gpsTimeMultiplierModel, 1);
+        context.gpsTimeCompressor.compress(lastDifference, difference, 1);
+        context.gpsTimeExtremeCounter[sequence] = 0;
+      } else if (multiplier > 0) {
+        if (multiplier < GPS_TIME_MULTI) {
+          this.layers.gpsTime.encodeSymbol(context.gpsTimeMultiplierModel, multiplier);
+          context.gpsTimeCompressor.compress(
+            toInt32(multiplier * lastDifference),
+            difference,
+            multiplier < 10 ? 2 : 3
+          );
+        } else {
+          this.layers.gpsTime.encodeSymbol(context.gpsTimeMultiplierModel, GPS_TIME_MULTI);
+          context.gpsTimeCompressor.compress(
+            toInt32(GPS_TIME_MULTI * lastDifference),
+            difference,
+            4
+          );
+          this.recordExtremeGpsDifference(context, sequence, difference);
+        }
+      } else if (multiplier < 0) {
+        if (multiplier > GPS_TIME_MULTI_MINUS) {
+          this.layers.gpsTime.encodeSymbol(
+            context.gpsTimeMultiplierModel,
+            GPS_TIME_MULTI - multiplier
+          );
+          context.gpsTimeCompressor.compress(toInt32(multiplier * lastDifference), difference, 5);
+        } else {
+          this.layers.gpsTime.encodeSymbol(
+            context.gpsTimeMultiplierModel,
+            GPS_TIME_MULTI - GPS_TIME_MULTI_MINUS
+          );
+          context.gpsTimeCompressor.compress(
+            toInt32(GPS_TIME_MULTI_MINUS * lastDifference),
+            difference,
+            6
+          );
+          this.recordExtremeGpsDifference(context, sequence, difference);
+        }
+      } else {
+        this.layers.gpsTime.encodeSymbol(context.gpsTimeMultiplierModel, 0);
+        context.gpsTimeCompressor.compress(0, difference, 7);
+        this.recordExtremeGpsDifference(context, sequence, difference);
+      }
+    } else if (this.selectGpsTimeSequence(context, gpsTimeBits, true)) {
+      this.encodeGpsTime(context, gpsTimeBits);
+      return;
+    } else {
+      this.layers.gpsTime.encodeSymbol(context.gpsTimeMultiplierModel, GPS_TIME_MULTI_CODE_FULL);
+      this.startGpsTimeSequence(context, gpsTimeBits);
+    }
+    context.lastGpsTimeBits[context.lastGpsSequence] = gpsTimeBits;
+  }
+
+  /** Select an existing GPS sequence whose bit difference fits in 32 bits. */
+  private selectGpsTimeSequence(
+    context: Point14Context,
+    gpsTimeBits: bigint,
+    hasLastDifference: boolean
+  ): boolean {
+    for (let index = 1; index < 4; index++) {
+      const sequence = (context.lastGpsSequence + index) & 3;
+      const difference64 = BigInt.asIntN(64, gpsTimeBits - context.lastGpsTimeBits[sequence]);
+      if (difference64 === BigInt.asIntN(32, difference64)) {
+        const symbol = hasLastDifference ? GPS_TIME_MULTI_CODE_FULL + index : index + 1;
+        const model = hasLastDifference
+          ? context.gpsTimeMultiplierModel
+          : context.gpsTimeZeroDifferenceModel;
+        this.layers.gpsTime.encodeSymbol(model, symbol);
+        context.lastGpsSequence = sequence;
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Start a new GPS sequence by writing upper and lower timestamp words. */
+  private startGpsTimeSequence(context: Point14Context, gpsTimeBits: bigint): void {
+    const previousBits = context.lastGpsTimeBits[context.lastGpsSequence];
+    context.gpsTimeCompressor.compress(
+      Number(BigInt.asIntN(32, previousBits >> 32n)),
+      Number(BigInt.asIntN(32, gpsTimeBits >> 32n)),
+      8
+    );
+    this.layers.gpsTime.writeInt(Number(gpsTimeBits & 0xffffffffn));
+    context.nextGpsSequence = (context.nextGpsSequence + 1) & 3;
+    context.lastGpsSequence = context.nextGpsSequence;
+    context.lastGpsTimeDifference[context.lastGpsSequence] = 0;
+    context.gpsTimeExtremeCounter[context.lastGpsSequence] = 0;
+  }
+
+  /** Update GPS difference prediction after four consecutive extreme multipliers. */
+  private recordExtremeGpsDifference(
+    context: Point14Context,
+    sequence: number,
+    difference: number
+  ): void {
+    context.gpsTimeExtremeCounter[sequence]++;
+    if (context.gpsTimeExtremeCounter[sequence] > 3) {
+      context.lastGpsTimeDifference[sequence] = difference;
+      context.gpsTimeExtremeCounter[sequence] = 0;
+    }
+  }
+}
+
+/** RGB prediction state for one LASzip v3 item context. */
+class RGB14Context {
+  /** Previous red channel. */
+  red: number;
+  /** Previous green channel. */
+  green: number;
+  /** Previous blue channel. */
+  blue: number;
+  /** Changed-byte mask model. */
+  readonly usedModel = new ArithmeticModel(128);
+  /** Byte correction models. */
+  readonly differenceModels = createModels(6, 256);
+
+  /** Initialize an RGB context from a previous color. */
+  constructor(color: Rgb14) {
+    this.red = color.red;
+    this.green = color.green;
+    this.blue = color.blue;
+  }
+}
+
+/** Encoder for the layered RGB14 stream. */
+class RGB14LayerEncoder {
+  /** RGB arithmetic stream. */
+  private readonly encoder = new ArithmeticEncoder();
+  /** LASzip v3 item contexts. */
+  private readonly contexts: Array<RGB14Context | null> = new Array(4).fill(null);
+  /** Item context used by the previous point. */
+  private currentContext: number;
+  /** Whether any RGB channel changed. */
+  private changed = false;
+
+  /** Initialize RGB coding from the first point. */
+  constructor(firstColor: Rgb14, firstContext: number) {
+    this.currentContext = firstContext;
+    this.contexts[firstContext] = new RGB14Context(firstColor);
+  }
+
+  /** Encode one RGB item in the Point14-provided item context. */
+  encode(color: Rgb14, itemContext: number): void {
+    let lastContext = this.contexts[this.currentContext]!;
+    if (itemContext !== this.currentContext) {
+      this.currentContext = itemContext;
+      if (!this.contexts[itemContext]) {
+        this.contexts[itemContext] = new RGB14Context({
+          red: lastContext.red,
+          green: lastContext.green,
+          blue: lastContext.blue
+        });
+        lastContext = this.contexts[itemContext]!;
+      }
+    }
+    const codingContext = this.contexts[this.currentContext]!;
+    let symbol =
+      ((color.red & 0xff) !== (lastContext.red & 0xff) ? 1 : 0) |
+      ((color.red & 0xff00) !== (lastContext.red & 0xff00) ? 2 : 0) |
+      ((color.green & 0xff) !== (lastContext.green & 0xff) ? 4 : 0) |
+      ((color.green & 0xff00) !== (lastContext.green & 0xff00) ? 8 : 0) |
+      ((color.blue & 0xff) !== (lastContext.blue & 0xff) ? 16 : 0) |
+      ((color.blue & 0xff00) !== (lastContext.blue & 0xff00) ? 32 : 0);
+    if (
+      (color.red & 0xff) !== (color.green & 0xff) ||
+      (color.red & 0xff) !== (color.blue & 0xff) ||
+      (color.red & 0xff00) !== (color.green & 0xff00) ||
+      (color.red & 0xff00) !== (color.blue & 0xff00)
+    ) {
+      symbol |= 64;
+    }
+    this.encoder.encodeSymbol(codingContext.usedModel, symbol);
+
+    let lowDifference = 0;
+    let highDifference = 0;
+    if (symbol & 1) {
+      lowDifference = (color.red & 0xff) - (lastContext.red & 0xff);
+      this.encoder.encodeSymbol(codingContext.differenceModels[0], foldUint8(lowDifference));
+    }
+    if (symbol & 2) {
+      highDifference = (color.red >> 8) - (lastContext.red >> 8);
+      this.encoder.encodeSymbol(codingContext.differenceModels[1], foldUint8(highDifference));
+    }
+    if (symbol & 64) {
+      if (symbol & 4) {
+        const correction =
+          (color.green & 0xff) - clampUint8(lowDifference + (lastContext.green & 0xff));
+        this.encoder.encodeSymbol(codingContext.differenceModels[2], foldUint8(correction));
+      }
+      if (symbol & 16) {
+        lowDifference = Math.trunc(
+          (lowDifference + (color.green & 0xff) - (lastContext.green & 0xff)) / 2
+        );
+        const correction =
+          (color.blue & 0xff) - clampUint8(lowDifference + (lastContext.blue & 0xff));
+        this.encoder.encodeSymbol(codingContext.differenceModels[4], foldUint8(correction));
+      }
+      if (symbol & 8) {
+        const correction =
+          (color.green >> 8) - clampUint8(highDifference + (lastContext.green >> 8));
+        this.encoder.encodeSymbol(codingContext.differenceModels[3], foldUint8(correction));
+      }
+      if (symbol & 32) {
+        highDifference = Math.trunc(
+          (highDifference + (color.green >> 8) - (lastContext.green >> 8)) / 2
+        );
+        const correction = (color.blue >> 8) - clampUint8(highDifference + (lastContext.blue >> 8));
+        this.encoder.encodeSymbol(codingContext.differenceModels[5], foldUint8(correction));
+      }
+    }
+    this.changed ||= symbol !== 0;
+    lastContext.red = color.red;
+    lastContext.green = color.green;
+    lastContext.blue = color.blue;
+  }
+
+  /** Finish the RGB stream, or return an omitted unchanged layer. */
+  finish(): Uint8Array {
+    return this.changed ? this.encoder.finish() : new Uint8Array(0);
+  }
+}
+
+/** NIR prediction state for one LASzip v3 item context. */
+class NIR14Context {
+  /** Previous NIR value. */
+  value: number;
+  /** Changed-byte mask model. */
+  readonly usedModel = new ArithmeticModel(4);
+  /** Byte correction models. */
+  readonly differenceModels = createModels(2, 256);
+
+  /** Initialize an NIR context from a previous value. */
+  constructor(value: number) {
+    this.value = value;
+  }
+}
+
+/** Encoder for the layered NIR14 stream. */
+class NIR14LayerEncoder {
+  /** NIR arithmetic stream. */
+  private readonly encoder = new ArithmeticEncoder();
+  /** LASzip v3 item contexts. */
+  private readonly contexts: Array<NIR14Context | null> = new Array(4).fill(null);
+  /** Item context used by the previous point. */
+  private currentContext: number;
+  /** Whether any NIR byte changed. */
+  private changed = false;
+
+  /** Initialize NIR coding from the first point. */
+  constructor(firstValue: number, firstContext: number) {
+    this.currentContext = firstContext;
+    this.contexts[firstContext] = new NIR14Context(firstValue);
+  }
+
+  /** Encode one NIR item in the Point14-provided item context. */
+  encode(value: number, itemContext: number): void {
+    let lastContext = this.contexts[this.currentContext]!;
+    if (itemContext !== this.currentContext) {
+      this.currentContext = itemContext;
+      if (!this.contexts[itemContext]) {
+        this.contexts[itemContext] = new NIR14Context(lastContext.value);
+        lastContext = this.contexts[itemContext]!;
+      }
+    }
+    const codingContext = this.contexts[this.currentContext]!;
+    const symbol =
+      ((value & 0xff) !== (lastContext.value & 0xff) ? 1 : 0) |
+      ((value & 0xff00) !== (lastContext.value & 0xff00) ? 2 : 0);
+    this.encoder.encodeSymbol(codingContext.usedModel, symbol);
+    if (symbol & 1) {
+      this.encoder.encodeSymbol(
+        codingContext.differenceModels[0],
+        foldUint8((value & 0xff) - (lastContext.value & 0xff))
+      );
+    }
+    if (symbol & 2) {
+      this.encoder.encodeSymbol(
+        codingContext.differenceModels[1],
+        foldUint8((value >> 8) - (lastContext.value >> 8))
+      );
+    }
+    this.changed ||= symbol !== 0;
+    lastContext.value = value;
+  }
+
+  /** Finish the NIR stream, or return an omitted unchanged layer. */
+  finish(): Uint8Array {
+    return this.changed ? this.encoder.finish() : new Uint8Array(0);
+  }
+}
+
+/** Extra-byte prediction state for one LASzip v3 item context. */
+class Byte14Context {
+  /** Previous value for each extra-byte layer. */
+  readonly values: Uint8Array;
+  /** Difference model for each extra-byte layer. */
+  readonly models: ArithmeticModel[];
+
+  /** Initialize an extra-byte context from preceding values. */
+  constructor(values: Uint8Array) {
+    this.values = values.slice();
+    this.models = createModels(values.byteLength, 256);
+  }
+}
+
+/** Encoder for independent Byte14 extra-byte streams. */
+class Byte14LayerEncoder {
+  /** Arithmetic stream for each extra-byte offset. */
+  private readonly encoders: ArithmeticEncoder[];
+  /** LASzip v3 item contexts. */
+  private readonly contexts: Array<Byte14Context | null> = new Array(4).fill(null);
+  /** Whether each extra-byte offset changed. */
+  private readonly changed: boolean[];
+  /** Item context used by the previous point. */
+  private currentContext: number;
+
+  /** Initialize extra-byte coding from the first point. */
+  constructor(firstValues: Uint8Array, firstContext: number) {
+    this.encoders = Array.from({length: firstValues.byteLength}, () => new ArithmeticEncoder());
+    this.changed = new Array<boolean>(firstValues.byteLength).fill(false);
+    this.currentContext = firstContext;
+    this.contexts[firstContext] = new Byte14Context(firstValues);
+  }
+
+  /** Encode extra bytes in the Point14-provided item context. */
+  encode(values: Uint8Array, itemContext: number): void {
+    let lastContext = this.contexts[this.currentContext]!;
+    if (itemContext !== this.currentContext) {
+      this.currentContext = itemContext;
+      if (!this.contexts[itemContext]) {
+        this.contexts[itemContext] = new Byte14Context(lastContext.values);
+        lastContext = this.contexts[itemContext]!;
+      }
+    }
+    const codingContext = this.contexts[this.currentContext]!;
+    for (let index = 0; index < values.byteLength; index++) {
+      const difference = values[index] - lastContext.values[index];
+      this.encoders[index].encodeSymbol(codingContext.models[index], foldUint8(difference));
+      if (difference) {
+        this.changed[index] = true;
+        lastContext.values[index] = values[index];
+      }
+    }
+  }
+
+  /** Finish changed extra-byte streams and omit unchanged offsets. */
+  finish(): Uint8Array[] {
+    return this.encoders.map((encoder, index) =>
+      this.changed[index] ? encoder.finish() : new Uint8Array(0)
+    );
+  }
+}
+
+/** Validate that raw records can be represented by the supported LASzip item set. */
+function validateMetadata(rawBytes: Uint8Array, metadata: LAZChunkMetadata): void {
+  if (!Number.isInteger(metadata.pointCount) || metadata.pointCount < 0) {
+    throw new Error(`Invalid LAZ chunk point count ${metadata.pointCount}`);
+  }
+  const baseLength = POINT_FORMAT_BASE_LENGTHS[metadata.pointDataRecordFormat];
+  if (!baseLength) {
+    throw new Error(
+      `TypeScript LAZ encoder does not support point format ${metadata.pointDataRecordFormat}`
+    );
+  }
+  if (
+    !Number.isInteger(metadata.pointDataRecordLength) ||
+    metadata.pointDataRecordLength < baseLength
+  ) {
+    throw new Error(
+      `Invalid point record length ${metadata.pointDataRecordLength} for point format ${metadata.pointDataRecordFormat}`
+    );
+  }
+  if (metadata.point14ItemVersion !== undefined && metadata.point14ItemVersion !== 3) {
+    throw new Error(`TypeScript LAZ encoder only supports Point14 item version 3`);
+  }
+  if (
+    metadata.pointDataRecordFormat >= 7 &&
+    metadata.rgb14ItemVersion !== undefined &&
+    metadata.rgb14ItemVersion !== 3
+  ) {
+    throw new Error(`TypeScript LAZ encoder only supports RGB14 item version 3`);
+  }
+  if (
+    metadata.pointDataRecordLength > baseLength &&
+    metadata.byte14ItemVersion !== undefined &&
+    metadata.byte14ItemVersion !== 3
+  ) {
+    throw new Error(`TypeScript LAZ encoder only supports Byte14 item version 3`);
+  }
+  const expectedByteLength = metadata.pointCount * metadata.pointDataRecordLength;
+  if (rawBytes.byteLength !== expectedByteLength) {
+    throw new Error(
+      `LAZ chunk input has ${rawBytes.byteLength} bytes; expected ${expectedByteLength}`
+    );
+  }
+}
+
+/** Parse a raw LAS 1.4 Point14 item. */
+function readPoint14(bytes: Uint8Array, offset: number): Point14 {
+  const view = new DataView(bytes.buffer, bytes.byteOffset + offset, 30);
+  return {
+    x: view.getInt32(0, true),
+    y: view.getInt32(4, true),
+    z: view.getInt32(8, true),
+    intensity: view.getUint16(12, true),
+    returns: view.getUint8(14),
+    flags: view.getUint8(15),
+    classification: view.getUint8(16),
+    userData: view.getUint8(17),
+    scanAngle: view.getInt16(18, true),
+    pointSourceId: view.getUint16(20, true),
+    gpsTimeBits: view.getBigUint64(22, true)
+  };
+}
+
+/** Parse one raw RGB14 item. */
+function readRgb(bytes: Uint8Array, offset: number): Rgb14 {
+  return {
+    red: readUint16(bytes, offset),
+    green: readUint16(bytes, offset + 2),
+    blue: readUint16(bytes, offset + 4)
+  };
+}
+
+/** Read one little-endian unsigned 16-bit integer. */
+function readUint16(bytes: Uint8Array, offset: number): number {
+  return bytes[offset] | (bytes[offset + 1] << 8);
+}
+
+/** Copy all Point14 fields without replacing context object identity. */
+function copyPoint14(target: Point14, source: Point14): void {
+  target.x = source.x;
+  target.y = source.y;
+  target.z = source.z;
+  target.intensity = source.intensity;
+  target.returns = source.returns;
+  target.flags = source.flags;
+  target.classification = source.classification;
+  target.userData = source.userData;
+  target.scanAngle = source.scanAngle;
+  target.pointSourceId = source.pointSourceId;
+  target.gpsTimeBits = source.gpsTimeBits;
+}
+
+/** Return the scanner-channel bits from a Point14 flags byte. */
+function getScannerChannel(point: Point14): number {
+  return (point.flags >> 4) & 3;
+}
+
+/** Merge Point14 classification and flight-line flags into the LASzip symbol. */
+function mergeFlags(point: Point14): number {
+  return ((point.flags >> 2) & 0x30) | (point.flags & 0x0f);
+}
+
+/** Create uniformly initialized arithmetic models. */
+function createModels(count: number, symbols: number): ArithmeticModel[] {
+  return Array.from({length: count}, () => new ArithmeticModel(symbols));
+}
+
+/** Fold an arbitrary signed byte difference into an unsigned byte. */
+function foldUint8(value: number): number {
+  return value & 0xff;
+}
+
+/** Clamp a predictor to the unsigned byte range. */
+function clampUint8(value: number): number {
+  return Math.min(255, Math.max(0, value));
+}
+
+/** Match LASzip's float32 multiplier calculation and nearest-integer quantization. */
+function quantizeFloat32(numerator: number, denominator: number): number {
+  const ratio = Math.fround(Math.fround(numerator) / Math.fround(denominator));
+  return ratio >= 0 ? Math.trunc(ratio + 0.5) : Math.trunc(ratio - 0.5);
+}
+
+/** Return a byte view that preserves an input view's byte range. */
 function toUint8Array(data: ArrayBuffer | ArrayBufferView): Uint8Array {
   return data instanceof ArrayBuffer
     ? new Uint8Array(data)
     : new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
 }
 
+/** Concatenate byte arrays without retaining caller-owned backing buffers. */
 function concatenateUint8Arrays(chunks: Uint8Array[]): Uint8Array {
   const totalLength = chunks.reduce((length, chunk) => length + chunk.byteLength, 0);
   const result = new Uint8Array(totalLength);

--- a/modules/loader-utils/test/lib/laz/laz-chunk-encoder.spec.ts
+++ b/modules/loader-utils/test/lib/laz/laz-chunk-encoder.spec.ts
@@ -1,0 +1,148 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {
+  createLAZChunkEncoder,
+  decodeLAZChunk,
+  encodeLAZChunk,
+  getLAZChunkByteLength
+} from '@loaders.gl/loader-utils';
+
+test('LAZChunkEncoder#encodes LASzip v3 PDRF 6-8 chunks', t => {
+  for (const pointDataRecordFormat of [6, 7, 8]) {
+    const {rawPointData, metadata} = createLAZEncodingFixture(pointDataRecordFormat);
+    const compressed = encodeLAZChunk(rawPointData, metadata);
+
+    t.deepEqual(
+      decodeLAZChunk(compressed, metadata),
+      rawPointData,
+      `PDRF ${pointDataRecordFormat} roundtrip`
+    );
+    t.deepEqual(
+      encodeLAZChunk(rawPointData, metadata),
+      compressed,
+      `PDRF ${pointDataRecordFormat} output is deterministic`
+    );
+    t.equal(
+      getLAZChunkByteLength(compressed, metadata),
+      compressed.byteLength,
+      `PDRF ${pointDataRecordFormat} layered size headers are complete`
+    );
+  }
+  t.end();
+});
+
+test('LAZChunkEncoder#feedable input preserves view ranges', t => {
+  const {rawPointData, metadata} = createLAZEncodingFixture(8);
+  const padded = new Uint8Array(rawPointData.byteLength + 16);
+  padded.set(rawPointData, 8);
+  const encoder = createLAZChunkEncoder(metadata);
+  const splitOffset = Math.floor(rawPointData.byteLength / 2);
+  encoder.feed(padded.subarray(8, 8 + splitOffset));
+  encoder.feed(padded.subarray(8 + splitOffset, 8 + rawPointData.byteLength));
+  t.throws(
+    () => encoder.encode(),
+    /input is not closed/,
+    'feedable encoder requires close before encode'
+  );
+  encoder.close();
+  t.throws(
+    () => encoder.feed(new Uint8Array(1)),
+    /closed LAZ chunk encoder/,
+    'closed feedable encoder rejects more input'
+  );
+  t.deepEqual(
+    decodeLAZChunk(encoder.encode(), metadata),
+    rawPointData,
+    'feedable encoder preserves input view byte ranges'
+  );
+  t.end();
+});
+
+test('LAZChunkEncoder#validates input and item versions', t => {
+  const {rawPointData, metadata} = createLAZEncodingFixture(6);
+  t.throws(
+    () =>
+      encodeLAZChunk(new Uint8Array(20), {
+        pointCount: 1,
+        pointDataRecordFormat: 0,
+        pointDataRecordLength: 20
+      }),
+    /does not support point format 0/,
+    'legacy point formats are rejected'
+  );
+  t.throws(
+    () => encodeLAZChunk(rawPointData.subarray(1), metadata),
+    /expected/,
+    'incomplete point data is rejected'
+  );
+  t.throws(
+    () => encodeLAZChunk(rawPointData, {...metadata, point14ItemVersion: 4}),
+    /only supports Point14 item version 3/,
+    'unsupported Point14 versions are rejected'
+  );
+  t.end();
+});
+
+/** Create varied LAS 1.4 records for shared LAZ encoder tests. */
+function createLAZEncodingFixture(pointDataRecordFormat: number) {
+  const baseRecordLength = {6: 30, 7: 36, 8: 38}[pointDataRecordFormat];
+  if (!baseRecordLength) {
+    throw new Error(`Unsupported fixture point format ${pointDataRecordFormat}`);
+  }
+  const pointCount = 32;
+  const pointDataRecordLength = baseRecordLength + 2;
+  const rawPointData = new Uint8Array(pointCount * pointDataRecordLength);
+  let previousGpsTime = 1_000_000_000;
+
+  for (let pointIndex = 0; pointIndex < pointCount; pointIndex++) {
+    const recordOffset = pointIndex * pointDataRecordLength;
+    const view = new DataView(
+      rawPointData.buffer,
+      rawPointData.byteOffset + recordOffset,
+      pointDataRecordLength
+    );
+    const numberOfReturns = 1 + (pointIndex % 5);
+    const returnNumber = 1 + (pointIndex % numberOfReturns);
+    const scannerChannel = (pointIndex * 3 + 2) % 4;
+    const gpsTime = pointIndex % 7 === 0 ? previousGpsTime : 1_000_000_000 + pointIndex * 0.001;
+    previousGpsTime = gpsTime;
+
+    view.setInt32(0, 1000 + pointIndex * 13, true);
+    view.setInt32(4, -2000 + pointIndex * pointIndex, true);
+    view.setInt32(8, 50 - pointIndex * 3, true);
+    view.setUint16(12, 200 + pointIndex * 17, true);
+    view.setUint8(14, returnNumber | (numberOfReturns << 4));
+    view.setUint8(15, (pointIndex % 16) | (scannerChannel << 4) | ((pointIndex % 2) << 6));
+    view.setUint8(16, (pointIndex * 7) & 0xff);
+    view.setUint8(17, (pointIndex * 11) & 0xff);
+    view.setInt16(18, -100 + pointIndex * 9, true);
+    view.setUint16(20, 3 + (pointIndex >> 2), true);
+    view.setFloat64(22, gpsTime, true);
+
+    if (pointDataRecordFormat >= 7) {
+      view.setUint16(30, pointIndex * 1000, true);
+      view.setUint16(32, 65535 - pointIndex * 500, true);
+      view.setUint16(34, pointIndex * 257, true);
+    }
+    if (pointDataRecordFormat === 8) {
+      view.setUint16(36, pointIndex * 333, true);
+    }
+    view.setUint8(baseRecordLength, pointIndex);
+    view.setUint8(baseRecordLength + 1, 255 - pointIndex);
+  }
+
+  return {
+    rawPointData,
+    metadata: {
+      pointCount,
+      pointDataRecordFormat,
+      pointDataRecordLength,
+      point14ItemVersion: 3 as const,
+      rgb14ItemVersion: 3 as const,
+      byte14ItemVersion: 3 as const
+    }
+  };
+}


### PR DESCRIPTION
## Goals

- Implement a pure TypeScript encoder for one LASzip layered point-data chunk.
- Establish interoperable LAZ output before adding complete LAS/LAZ and COPC container writers.
- Cover modern LAS 1.4 point formats without introducing a WASM encoding dependency.

## Changes

- Added arithmetic models, bit models, integer compression, and streaming-median prediction for LASzip-compatible output.
- Implemented layered compressor 3 / arithmetic coder 0 encoding for PDRF 6, 7, and 8 using Point14, RGB14, RGBNIR14, and Byte14 item version 3 streams.
- Completed the feedable chunk encoder API, including input lifecycle and byte-view handling.
- Added shared unit coverage for round trips, deterministic output, stream-size headers, validation, and feedable input.
- Added laz-perf interoperability coverage and updated the LAS format documentation to distinguish chunk encoding from complete `.laz` file writing.

## Validation

- `yarn lint fix`
- `yarn test-node`: 420 files passed, 2 skipped; 2037 tests passed, 81 skipped.
- Focused Node LAS suite: 67 passed, 1 skipped.
- Focused shared encoder suite in Node and headless: 3 passed in each runtime.
- Randomized interoperability probe: 100 PDRF 6-8 chunks decoded byte-for-byte through laz-perf.
- `yarn build` passed on the implemented encoder. A final worktree rerun compiled the changed packages, then stopped in the repository pre-build phase because the workspace alias resolved `@loaders.gl/core` to the main checkout's missing `modules/core/dist`.
- Full `yarn test-headless` remains red on current master: 30 worker-dependent test files fail because worker assets are served as HTML/classic-worker-incompatible modules. The focused encoder headless suite passes.

## Scope

This PR writes individual LAZ chunks only. It intentionally does not emit a LAS header, LASzip VLR, chunk table, or complete `.laz` file; that container work is the next stacked tranche.