### PR TITLE
feat(zarr): add deck.gl GeoZarr example

### DIFF
--- a/docs/modules/zarr/README.md
+++ b/docs/modules/zarr/README.md
@@ -47,6 +47,8 @@ root and selecting an image pyramid.
 For climate, weather, ocean, satellite, and other Earth-science stores, use
 `GeoZarrSourceLoader`. It recognizes the current GeoZarr `proj:` and `spatial:` conventions as
 well as the regular one-dimensional coordinate arrays commonly written by xarray/CF workflows.
+The [GeoZarr deck.gl example](/examples/geospatial/geo-zarr) reads a public NASA POWER climatology
+store directly from S3 and renders monthly solar irradiance on an interactive map.
 
 ## Attributions
 

--- a/docs/modules/zarr/api-reference/geo-zarr-source-loader.md
+++ b/docs/modules/zarr/api-reference/geo-zarr-source-loader.md
@@ -89,6 +89,10 @@ Reads the native-resolution array window intersecting `parameters.viewport`.
 The returned raster contains one typed-array band, exact source-coordinate bounds for the selected
 pixel window, and the normalized CRS.
 
+See the [GeoZarr deck.gl example](/examples/geospatial/geo-zarr) for a complete browser workflow
+that selects monthly NASA POWER climatology data, colorizes the returned typed raster, and displays
+it with deck.gl's `BitmapLayer`.
+
 ## Current scope
 
 This first version is intentionally limited to regular, axis-aligned 2D grids with optional named

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -152,6 +152,9 @@ Release Date: 2026
 - [`GeoZarrSourceLoader`](/docs/modules/zarr/api-reference/geo-zarr-source-loader) NEW - reads
   axis-aligned GeoZarr `proj:` / `spatial:` grids and regular CF/xarray coordinate arrays through
   viewport-clipped native Zarr windows with named time and vertical selections.
+- [GeoZarr with deck.gl](/examples/geospatial/geo-zarr) NEW - streams NASA POWER monthly solar
+  climatology from a public Zarr store, colorizes it in the browser, and displays it on an
+  interactive deck.gl map.
 - [`OMEZarrSourceLoader`](/docs/modules/zarr/api-reference/ome-zarr-source-loader) NEW - opens OME-Zarr v2 and v3 image pyramids, normalizes multiscale and channel metadata, and reads typed 2D planes with channel and level selection.
 - `loadZarrConsolidatedMetadata()` NEW - browses consolidated Zarr and SpatialData-style roots and distinguishes top-level groups from arrays.
 

--- a/examples/website/geozarr/README.md
+++ b/examples/website/geozarr/README.md
@@ -1,0 +1,11 @@
+# GeoZarr deck.gl Example
+
+Interactive `GeoZarrSourceLoader` demo that:
+
+- reads NASA POWER's public one-degree monthly climatology Zarr store directly from S3;
+- selects one month or the annual mean from the non-spatial `time` dimension;
+- colorizes the typed solar-irradiance raster in the browser; and
+- displays the result on a navigable deck.gl `BitmapLayer`.
+
+The remote store is CORS-enabled. Each time selection downloads one compressed global Zarr chunk
+of roughly 72 KB plus metadata and coordinate chunks.

--- a/examples/website/geozarr/app.tsx
+++ b/examples/website/geozarr/app.tsx
@@ -1,0 +1,552 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import React, {useEffect, useMemo, useState} from 'react';
+import {createRoot} from 'react-dom/client';
+
+import DeckGL from '@deck.gl/react';
+import {MapController} from '@deck.gl/core';
+import type {MapViewState} from '@deck.gl/core';
+import {BitmapLayer} from '@deck.gl/layers';
+
+import {createDataSource} from '@loaders.gl/core';
+import type {RasterBoundingBox, RasterData, RasterViewport} from '@loaders.gl/loader-utils';
+import {
+  GeoZarrSourceLoader,
+  type GeoZarrRasterSource,
+  type GeoZarrSourceMetadata
+} from '@loaders.gl/zarr';
+
+import {Map} from 'react-map-gl';
+import maplibregl from 'maplibre-gl';
+
+const DATA_URL =
+  'https://nasa-power.s3.us-west-2.amazonaws.com/syn1deg/spatial/power_syn1deg_climatology_spatial_utc.zarr';
+const DATA_ARRAY = 'ALLSKY_SFC_SW_DWN';
+const MAP_STYLE = 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json';
+const INITIAL_TIME_INDEX = 6;
+const INITIAL_OPACITY = 0.65;
+const COLOR_DOMAIN: [minimum: number, maximum: number] = [0, 350];
+const TIME_LABELS = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+  'Annual mean'
+];
+
+const COLOR_STOPS: Array<{position: number; color: [number, number, number]}> = [
+  {position: 0, color: [10, 24, 74]},
+  {position: 0.2, color: [52, 66, 145]},
+  {position: 0.4, color: [48, 129, 166]},
+  {position: 0.6, color: [85, 184, 125]},
+  {position: 0.8, color: [238, 196, 72]},
+  {position: 1, color: [246, 103, 48]}
+];
+
+const INITIAL_VIEW_STATE: MapViewState = {
+  longitude: 0,
+  latitude: 18,
+  zoom: 1.15,
+  minZoom: 0,
+  maxZoom: 7,
+  pitch: 0,
+  bearing: 0
+};
+
+type AppProps = {
+  /** Hides the example panel when embedded in another UI. */
+  hideChrome?: boolean;
+  /** Optional explanatory content rendered below the title. */
+  children?: React.ReactNode;
+};
+
+type RasterRenderState = {
+  /** Colorized raster pixels. */
+  canvas: HTMLCanvasElement;
+  /** Geographic bitmap bounds. */
+  bounds: [west: number, south: number, east: number, north: number];
+  /** Smallest finite source value. */
+  minimum: number;
+  /** Largest finite source value. */
+  maximum: number;
+};
+
+/**
+ * Deck.gl example that reads a public NASA POWER climatology variable directly from Zarr.
+ */
+export default function App(props: AppProps = {}) {
+  const source = useMemo(
+    () =>
+      createDataSource(DATA_URL, [GeoZarrSourceLoader], {
+        geozarr: {
+          array: DATA_ARRAY,
+          defaultSelection: {time: INITIAL_TIME_INDEX}
+        }
+      }) as GeoZarrRasterSource,
+    []
+  );
+  const [timeIndex, setTimeIndex] = useState(INITIAL_TIME_INDEX);
+  const [opacity, setOpacity] = useState(INITIAL_OPACITY);
+  const [playing, setPlaying] = useState(false);
+  const [metadata, setMetadata] = useState<GeoZarrSourceMetadata | null>(null);
+  const [rasterState, setRasterState] = useState<RasterRenderState | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const abortController = new AbortController();
+
+    void source
+      .getMetadata()
+      .then(nextMetadata => {
+        if (!cancelled) {
+          setMetadata(nextMetadata);
+          setError(null);
+        }
+      })
+      .catch(nextError => {
+        if (!cancelled && !abortController.signal.aborted) {
+          setError(getErrorMessage(nextError));
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+      abortController.abort();
+    };
+  }, [source]);
+
+  useEffect(() => {
+    if (!metadata) {
+      return;
+    }
+
+    let cancelled = false;
+    const abortController = new AbortController();
+
+    const loadRaster = async () => {
+      setLoading(true);
+      try {
+        const raster = await source.getRaster({
+          viewport: createGlobalRasterViewport(metadata),
+          selection: {time: timeIndex},
+          signal: abortController.signal
+        });
+        if (!cancelled) {
+          setRasterState(renderRaster(raster, metadata));
+          setError(null);
+        }
+      } catch (nextError) {
+        if (!cancelled && !abortController.signal.aborted) {
+          setError(getErrorMessage(nextError));
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void loadRaster();
+    return () => {
+      cancelled = true;
+      abortController.abort();
+    };
+  }, [metadata, source, timeIndex]);
+
+  useEffect(() => {
+    if (!playing) {
+      return;
+    }
+    const interval = globalThis.setInterval(
+      () => setTimeIndex(currentTimeIndex => (currentTimeIndex + 1) % TIME_LABELS.length),
+      1200
+    );
+    return () => globalThis.clearInterval(interval);
+  }, [playing]);
+
+  const layers = useMemo(
+    () =>
+      rasterState
+        ? [
+            new BitmapLayer({
+              id: `nasa-power-${timeIndex}`,
+              image: rasterState.canvas,
+              bounds: rasterState.bounds,
+              opacity
+            })
+          ]
+        : [],
+    [opacity, rasterState, timeIndex]
+  );
+
+  return (
+    <div style={{position: 'relative', height: '100%', background: '#07101f'}}>
+      <DeckGL
+        controller={{type: MapController}}
+        initialViewState={INITIAL_VIEW_STATE}
+        layers={layers}
+      >
+        <Map reuseMaps mapLib={maplibregl as never} mapStyle={MAP_STYLE} />
+      </DeckGL>
+      {loading && !rasterState ? <LoadingSpinner /> : null}
+      {!props.hideChrome ? (
+        <InfoPanel
+          error={error}
+          loading={loading}
+          metadata={metadata}
+          opacity={opacity}
+          playing={playing}
+          rasterState={rasterState}
+          timeIndex={timeIndex}
+          onPlayingChange={setPlaying}
+          onOpacityChange={setOpacity}
+          onTimeIndexChange={setTimeIndex}
+        >
+          {props.children}
+        </InfoPanel>
+      ) : null}
+    </div>
+  );
+}
+
+/** Mounts the example into a DOM container. */
+export function renderToDOM(container = document.body): void {
+  createRoot(container).render(<App />);
+}
+
+/** Creates a full-extent raster viewport in the source coordinate system. */
+function createGlobalRasterViewport(metadata: GeoZarrSourceMetadata): RasterViewport {
+  const boundingBox = metadata.boundingBox!;
+  return {
+    id: 'nasa-power-global-grid',
+    width: metadata.width,
+    height: metadata.height,
+    zoom: 0,
+    center: [0, 0],
+    crs: metadata.crs,
+    bounds: boundingBox,
+    project: coordinates => coordinates,
+    unprojectPosition: position => [position[0], position[1], position[2] || 0]
+  };
+}
+
+/** Colorizes one typed GeoZarr raster and flips south-to-north grids for bitmap display. */
+function renderRaster(
+  raster: RasterData,
+  metadata: GeoZarrSourceMetadata
+): RasterRenderState {
+  const canvas = document.createElement('canvas');
+  canvas.width = raster.width;
+  canvas.height = raster.height;
+  const context = canvas.getContext('2d');
+  if (!context) {
+    throw new Error('Canvas 2D rendering is unavailable.');
+  }
+
+  const imageData = context.createImageData(raster.width, raster.height);
+  const source = raster.data as ArrayLike<number>;
+  const flipVertically = metadata.transform[4] > 0;
+  let minimum = Number.POSITIVE_INFINITY;
+  let maximum = Number.NEGATIVE_INFINITY;
+
+  for (let row = 0; row < raster.height; row++) {
+    const targetRow = flipVertically ? raster.height - row - 1 : row;
+    for (let column = 0; column < raster.width; column++) {
+      const sourceIndex = row * raster.width + column;
+      const targetIndex = (targetRow * raster.width + column) * 4;
+      const value = source[sourceIndex];
+      if (!Number.isFinite(value)) {
+        imageData.data[targetIndex + 3] = 0;
+        continue;
+      }
+
+      minimum = Math.min(minimum, value);
+      maximum = Math.max(maximum, value);
+      const [red, green, blue] = getColor(value);
+      imageData.data[targetIndex] = red;
+      imageData.data[targetIndex + 1] = green;
+      imageData.data[targetIndex + 2] = blue;
+      imageData.data[targetIndex + 3] = 245;
+    }
+  }
+
+  context.putImageData(imageData, 0, 0);
+  return {
+    canvas,
+    bounds: flattenBoundingBox(raster.boundingBox || metadata.boundingBox!),
+    minimum,
+    maximum
+  };
+}
+
+/** Interpolates the example's perceptual solar-radiation color ramp. */
+function getColor(value: number): [number, number, number] {
+  const normalized = Math.max(
+    0,
+    Math.min(1, (value - COLOR_DOMAIN[0]) / (COLOR_DOMAIN[1] - COLOR_DOMAIN[0]))
+  );
+  const stopIndex = Math.min(
+    COLOR_STOPS.length - 2,
+    Math.floor(normalized * (COLOR_STOPS.length - 1))
+  );
+  const left = COLOR_STOPS[stopIndex];
+  const right = COLOR_STOPS[stopIndex + 1];
+  const progress = (normalized - left.position) / (right.position - left.position);
+  return left.color.map((channel, channelIndex) =>
+    Math.round(channel + (right.color[channelIndex] - channel) * progress)
+  ) as [number, number, number];
+}
+
+/** Flattens the common raster bounding-box representation for deck.gl. */
+function flattenBoundingBox(
+  boundingBox: RasterBoundingBox
+): [west: number, south: number, east: number, north: number] {
+  return [
+    boundingBox[0][0],
+    boundingBox[0][1],
+    boundingBox[1][0],
+    boundingBox[1][1]
+  ];
+}
+
+/** Displays dataset controls, metadata, and color-ramp context. */
+function InfoPanel(props: {
+  /** Child content supplied by the website page. */
+  children?: React.ReactNode;
+  /** Current loading error. */
+  error: string | null;
+  /** Whether a metadata or raster request is active. */
+  loading: boolean;
+  /** Normalized source metadata. */
+  metadata: GeoZarrSourceMetadata | null;
+  /** Raster layer opacity. */
+  opacity: number;
+  /** Whether month playback is active. */
+  playing: boolean;
+  /** Current colorized raster statistics. */
+  rasterState: RasterRenderState | null;
+  /** Selected climatology time index. */
+  timeIndex: number;
+  /** Updates playback state. */
+  onPlayingChange: (playing: boolean) => void;
+  /** Updates raster layer opacity. */
+  onOpacityChange: (opacity: number) => void;
+  /** Updates the climatology time index. */
+  onTimeIndexChange: (timeIndex: number) => void;
+}) {
+  const {
+    children,
+    error,
+    loading,
+    metadata,
+    opacity,
+    onOpacityChange,
+    onPlayingChange,
+    onTimeIndexChange,
+    playing,
+    rasterState,
+    timeIndex
+  } = props;
+
+  return (
+    <aside
+      style={{
+        position: 'absolute',
+        top: 20,
+        right: 20,
+        zIndex: 10,
+        width: 340,
+        maxWidth: 'calc(100% - 40px)',
+        padding: 18,
+        border: '1px solid rgba(151, 187, 255, 0.28)',
+        borderRadius: 14,
+        background: 'rgba(7, 16, 31, 0.9)',
+        boxShadow: '0 16px 50px rgba(0, 0, 0, 0.38)',
+        color: '#edf5ff',
+        fontFamily: 'system-ui, sans-serif',
+        fontSize: 13,
+        lineHeight: 1.45,
+        backdropFilter: 'blur(12px)'
+      }}
+    >
+      <div style={{color: '#8db9ff', fontSize: 11, fontWeight: 700, letterSpacing: 1.2}}>
+        NASA POWER · REMOTE ZARR
+      </div>
+      <h2 style={{fontSize: 20, lineHeight: 1.15, margin: '5px 0 8px'}}>
+        Global solar irradiance
+      </h2>
+      <div style={{marginBottom: 14, color: '#c9d9ee'}}>{children}</div>
+
+      <div style={{display: 'flex', alignItems: 'center', gap: 10, marginBottom: 8}}>
+        <button
+          type="button"
+          onClick={() => onPlayingChange(!playing)}
+          style={buttonStyle}
+        >
+          {playing ? 'Pause' : 'Play'}
+        </button>
+        <strong style={{fontSize: 15}}>{TIME_LABELS[timeIndex]}</strong>
+        {loading ? <span style={{marginLeft: 'auto', color: '#8db9ff'}}>Loading…</span> : null}
+      </div>
+      <input
+        aria-label="Climatology month"
+        type="range"
+        min={0}
+        max={TIME_LABELS.length - 1}
+        step={1}
+        value={timeIndex}
+        onChange={event => {
+          onPlayingChange(false);
+          onTimeIndexChange(Number(event.target.value));
+        }}
+        style={{width: '100%', accentColor: '#8db9ff'}}
+      />
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          margin: '1px 0 14px',
+          color: '#8ea1ba',
+          fontSize: 11
+        }}
+      >
+        <span>Jan</span>
+        <span>Jun</span>
+        <span>Dec</span>
+        <span>Annual</span>
+      </div>
+
+      <label
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'auto 1fr auto',
+          alignItems: 'center',
+          gap: 10,
+          marginBottom: 14,
+          color: '#c9d9ee'
+        }}
+      >
+        <span>Raster opacity</span>
+        <input
+          aria-label="Raster opacity"
+          type="range"
+          min={0.1}
+          max={1}
+          step={0.05}
+          value={opacity}
+          onInput={event => onOpacityChange(Number(event.currentTarget.value))}
+          style={{width: '100%', accentColor: '#8db9ff'}}
+        />
+        <span style={{minWidth: 34, textAlign: 'right', color: '#9fb1c8'}}>
+          {Math.round(opacity * 100)}%
+        </span>
+      </label>
+
+      <div
+        style={{
+          height: 12,
+          borderRadius: 6,
+          background:
+            'linear-gradient(90deg, rgb(10,24,74), rgb(52,66,145), rgb(48,129,166), rgb(85,184,125), rgb(238,196,72), rgb(246,103,48))'
+        }}
+      />
+      <div style={{display: 'flex', justifyContent: 'space-between', color: '#9fb1c8', fontSize: 11}}>
+        <span>0</span>
+        <span>175</span>
+        <span>350 W m⁻²</span>
+      </div>
+
+      {rasterState ? (
+        <div style={{marginTop: 12, color: '#c9d9ee'}}>
+          Current range: {rasterState.minimum.toFixed(1)}–{rasterState.maximum.toFixed(1)} W m⁻²
+        </div>
+      ) : null}
+      {metadata ? (
+        <div style={{display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 10}}>
+          <Badge>{metadata.width} × {metadata.height}</Badge>
+          <Badge>1° global grid</Badge>
+          <Badge>{metadata.crs}</Badge>
+          <Badge>CF/xarray</Badge>
+        </div>
+      ) : null}
+      {error ? (
+        <div style={{marginTop: 12, padding: 10, borderRadius: 8, background: '#481925', color: '#ffc7d1'}}>
+          {error}
+        </div>
+      ) : null}
+      <p style={{margin: '14px 0 0', color: '#8ea1ba', fontSize: 11}}>
+        Drag and zoom with deck.gl. Each selection fetches one compressed Zarr chunk directly from
+        the public NASA S3 bucket, then colorizes it in the browser.
+      </p>
+    </aside>
+  );
+}
+
+const buttonStyle: React.CSSProperties = {
+  appearance: 'none',
+  minWidth: 58,
+  padding: '6px 10px',
+  border: '1px solid rgba(151, 187, 255, 0.42)',
+  borderRadius: 7,
+  background: 'rgba(89, 138, 222, 0.22)',
+  color: '#edf5ff',
+  cursor: 'pointer',
+  font: 'inherit',
+  fontWeight: 650
+};
+
+/** Renders a compact metadata badge. */
+function Badge({children}: {children: React.ReactNode}) {
+  return (
+    <span
+      style={{
+        padding: '3px 7px',
+        borderRadius: 999,
+        background: 'rgba(141, 185, 255, 0.12)',
+        color: '#bcd4f6',
+        fontSize: 11
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+/** Displays a centered loading indicator before the first raster is available. */
+function LoadingSpinner() {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        inset: 0,
+        display: 'grid',
+        placeItems: 'center',
+        pointerEvents: 'none',
+        color: '#d9e8ff',
+        fontFamily: 'system-ui, sans-serif'
+      }}
+    >
+      <div style={{padding: '10px 14px', borderRadius: 9, background: 'rgba(7, 16, 31, 0.82)'}}>
+        Loading NASA POWER Zarr…
+      </div>
+    </div>
+  );
+}
+
+/** Converts an unknown thrown value into display text. */
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/examples/website/geozarr/index.html
+++ b/examples/website/geozarr/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>GeoZarr deck.gl Example</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      body {
+        margin: 0;
+        width: 100vw;
+        height: 100vh;
+        overflow: hidden;
+      }
+
+      #app {
+        height: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+  <script type="module">
+    import {renderToDOM} from './app.tsx';
+    renderToDOM(document.getElementById('app'));
+  </script>
+</html>

--- a/examples/website/geozarr/package.json
+++ b/examples/website/geozarr/package.json
@@ -1,0 +1,32 @@
+{
+  "private": true,
+  "name": "geozarr-deck-example",
+  "description": "GeoZarr raster source example rendered with deck.gl.",
+  "version": "0.0.0",
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "start": "vite",
+    "build": "tsc && vite build",
+    "serve": "vite preview"
+  },
+  "dependencies": {
+    "@deck.gl/core": "^9.3.0",
+    "@deck.gl/layers": "^9.3.0",
+    "@deck.gl/react": "^9.3.0",
+    "@loaders.gl/core": "workspace:*",
+    "@loaders.gl/zarr": "workspace:*",
+    "@luma.gl/core": "^9.3.2",
+    "@luma.gl/engine": "^9.3.2",
+    "@luma.gl/shadertools": "^9.3.2",
+    "mapbox-gl": "npm:maplibre-gl@^3.6.2",
+    "maplibre-gl": "^3.6.2",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
+    "react-map-gl": "^7.1.7"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "vite": "^7.2.7"
+  }
+}

--- a/examples/website/geozarr/react-dom-client.d.ts
+++ b/examples/website/geozarr/react-dom-client.d.ts
@@ -1,0 +1,6 @@
+declare module 'react-dom/client' {
+  export function createRoot(container: Element | DocumentFragment): {
+    render(children: unknown): void;
+    unmount(): void;
+  };
+}

--- a/examples/website/geozarr/tsconfig.json
+++ b/examples/website/geozarr/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "paths": {
+      "@loaders.gl/*": ["../../../modules/*/dist"]
+    },
+    "jsx": "react-jsx"
+  },
+  "include": ["./app.tsx", "./react-dom-client.d.ts"]
+}

--- a/examples/website/geozarr/vite.config.ts
+++ b/examples/website/geozarr/vite.config.ts
@@ -1,0 +1,20 @@
+import {defineConfig} from 'vite';
+import fs from 'fs';
+
+/** Resolves loaders.gl packages to local source while developing the example. */
+const getAliases = async (frameworkName, frameworkRootDirectory) => {
+  const modules = await fs.promises.readdir(`${frameworkRootDirectory}/modules`);
+  const aliases = {};
+  modules.forEach(module => {
+    aliases[`${frameworkName}/${module}`] = `${frameworkRootDirectory}/modules/${module}/src`;
+  });
+  return aliases;
+};
+
+export default defineConfig(async () => ({
+  resolve: {
+    extensions: ['.ts', '.tsx', '.mjs', '.js', '.jsx', '.json'],
+    alias: await getAliases('@loaders.gl', `${__dirname}/../../..`)
+  },
+  server: {open: true}
+}));

--- a/modules/zarr/README.md
+++ b/modules/zarr/README.md
@@ -42,6 +42,9 @@ const raster = await source.getRaster({
 The first version supports axis-aligned affine grids and native-resolution window reads. It does
 not reproject, resample, or handle curvilinear two-dimensional coordinate arrays.
 
+The [GeoZarr deck.gl example](https://loaders.gl/examples/geospatial/geo-zarr) reads NASA POWER
+climatology data directly from a public Zarr store and renders it on an interactive map.
+
 ## OME-Zarr SourceLoader
 
 `OMEZarrSourceLoader` is the first source-loader abstraction in this module. It is image-first:

--- a/modules/zarr/test/geo-zarr-source.browser.spec.ts
+++ b/modules/zarr/test/geo-zarr-source.browser.spec.ts
@@ -4,7 +4,12 @@
 
 import test from 'test/utils/vitest-tape';
 import {createDataSource} from '@loaders.gl/core';
-import {GeoZarrSourceLoader} from '@loaders.gl/zarr';
+import type {RasterBoundingBox, RasterViewport} from '@loaders.gl/loader-utils';
+import {
+  GeoZarrRasterSource,
+  GeoZarrSourceLoader,
+  type GeoZarrSourceLoaderOptions
+} from '@loaders.gl/zarr';
 
 const SPATIALDATA_V3_FIXTURE_URL = '/modules/zarr/test/data/spatialdata-v3.zarr';
 
@@ -23,3 +28,175 @@ test('GeoZarrSourceLoader supports browser-relative store metadata', async t => 
   ]);
   t.end();
 });
+
+test('GeoZarrRasterSource reads regular CF coordinates and raster windows in browsers', async t => {
+  const source = createInMemoryGeoZarrSource();
+  const metadata = await source.getMetadata();
+  const raster = await source.getRaster({
+    viewport: createViewport(
+      [
+        [100.5, 8.5],
+        [102.5, 10.5]
+      ],
+      'EPSG:4326'
+    )
+  });
+
+  t.equal(metadata.name, 'Air temperature');
+  t.equal(metadata.crs, 'EPSG:4326');
+  t.deepEqual(metadata.transform, [1, 0, 99.5, 0, -1, 10.5]);
+  t.deepEqual(metadata.boundingBox, [
+    [99.5, 8.5],
+    [102.5, 10.5]
+  ]);
+  t.deepEqual(metadata.selectionDimensions, [{name: 'time', size: 2, defaultIndex: 1}]);
+  t.equal(metadata.noData, 255);
+  t.equal(raster.width, 2);
+  t.equal(raster.height, 2);
+  t.equal(raster.dtype, 'uint8');
+  t.deepEqual(Array.from(raster.data as Uint8Array), [12, 13, 15, 16]);
+  t.end();
+});
+
+test('GeoZarrRasterSource validates browser viewport and dimension selections', async t => {
+  const source = createInMemoryGeoZarrSource();
+  const viewport = createViewport(
+    [
+      [100, 9],
+      [102, 10]
+    ],
+    'EPSG:3857'
+  );
+
+  await t.rejects(source.getRaster({viewport}), /does not support reprojection/);
+  viewport.crs = 'EPSG:4326';
+  await t.rejects(
+    source.getRaster({viewport, selection: {channel: 0}}),
+    /Unknown GeoZarr selection dimension channel/
+  );
+  await t.rejects(
+    source.getRaster({viewport, selection: {time: 2}}),
+    /time index 2 is out of bounds/
+  );
+  await t.rejects(
+    source.getRaster({viewport, resampleMethod: 'bilinear'}),
+    /native nearest-neighbor windows only/
+  );
+  t.end();
+});
+
+/** Creates a GeoZarr source backed by a small in-memory CF/xarray-style Zarr v3 store. */
+function createInMemoryGeoZarrSource(): GeoZarrRasterSource {
+  const baseUrl = 'https://example.com/browser-cf.zarr';
+  const options: GeoZarrSourceLoaderOptions = {
+    core: {loadOptions: {core: {fetch: createCFZarrFetcher(baseUrl)}}},
+    zarr: {requireConsolidatedMetadata: false},
+    geozarr: {array: 'temperature', defaultSelection: {time: 1}}
+  };
+  return new GeoZarrRasterSource(baseUrl, options);
+}
+
+/** Creates the minimal viewport shape accepted by raster sources. */
+function createViewport(
+  bounds: RasterBoundingBox,
+  coordinateReferenceSystem?: string
+): RasterViewport {
+  const [[minimumX, minimumY], [maximumX, maximumY]] = bounds;
+  return {
+    id: 'geo-zarr-browser-test',
+    width: 256,
+    height: 256,
+    zoom: 0,
+    center: [(minimumX + maximumX) / 2, (minimumY + maximumY) / 2],
+    crs: coordinateReferenceSystem,
+    bounds,
+    project: coordinates => coordinates,
+    unprojectPosition: position => [position[0], position[1], position[2] || 0]
+  };
+}
+
+/** Creates an in-memory HTTP view of a small xarray-style Zarr v3 climate store. */
+function createCFZarrFetcher(baseUrl: string): typeof fetch {
+  const responses = new Map<string, BodyInit>([
+    [`${baseUrl}/zarr.json`, encodeJson(createGroupMetadata())],
+    [
+      `${baseUrl}/temperature/zarr.json`,
+      encodeJson(
+        createArrayMetadata([2, 2, 3], [1, 2, 3], 'uint8', ['time', 'latitude', 'longitude'], {
+          long_name: 'Air temperature',
+          _FillValue: 255
+        })
+      )
+    ],
+    [`${baseUrl}/temperature/c/0/0/0`, new Uint8Array([1, 2, 3, 4, 5, 6])],
+    [`${baseUrl}/temperature/c/1/0/0`, new Uint8Array([11, 12, 13, 14, 15, 16])],
+    [
+      `${baseUrl}/latitude/zarr.json`,
+      encodeJson(
+        createArrayMetadata([2], [2], 'float64', ['latitude'], {
+          standard_name: 'latitude',
+          units: 'degrees_north'
+        })
+      )
+    ],
+    [`${baseUrl}/latitude/c/0`, encodeFloat64([10, 9])],
+    [
+      `${baseUrl}/longitude/zarr.json`,
+      encodeJson(
+        createArrayMetadata([3], [3], 'float64', ['longitude'], {
+          standard_name: 'longitude',
+          units: 'degrees_east'
+        })
+      )
+    ],
+    [`${baseUrl}/longitude/c/0`, encodeFloat64([100, 101, 102])]
+  ]);
+
+  return (async input => {
+    const url = input instanceof Request ? input.url : String(input);
+    const body = responses.get(url);
+    return body ? new Response(body) : new Response(null, {status: 404});
+  }) as typeof fetch;
+}
+
+/** Creates minimal Zarr v3 group metadata. */
+function createGroupMetadata(): Record<string, unknown> {
+  return {zarr_format: 3, node_type: 'group', attributes: {}};
+}
+
+/** Creates minimal uncompressed Zarr v3 array metadata. */
+function createArrayMetadata(
+  shape: number[],
+  chunks: number[],
+  dataType: 'uint8' | 'float64',
+  dimensionNames: string[],
+  attributes: Record<string, unknown>
+): Record<string, unknown> {
+  return {
+    zarr_format: 3,
+    node_type: 'array',
+    shape,
+    data_type: dataType,
+    chunk_grid: {name: 'regular', configuration: {chunk_shape: chunks}},
+    chunk_key_encoding: {name: 'default', configuration: {separator: '/'}},
+    codecs: [{name: 'bytes', configuration: {endian: 'little'}}],
+    fill_value: 0,
+    dimension_names: dimensionNames,
+    attributes
+  };
+}
+
+/** Encodes Zarr metadata as UTF-8 bytes. */
+function encodeJson(value: unknown): Uint8Array {
+  return new TextEncoder().encode(JSON.stringify(value));
+}
+
+/** Encodes float64 coordinate values using the explicit Zarr little-endian byte order. */
+function encodeFloat64(values: number[]): Uint8Array {
+  const buffer = new ArrayBuffer(values.length * Float64Array.BYTES_PER_ELEMENT);
+  const dataView = new DataView(buffer);
+  values.forEach((value, index) =>
+    dataView.setFloat64(index * Float64Array.BYTES_PER_ELEMENT, value, true)
+  );
+  return new Uint8Array(buffer);
+}

--- a/website/src/examples-sidebar.js
+++ b/website/src/examples-sidebar.js
@@ -83,7 +83,7 @@ const sidebars = {
     {
       type: 'category',
       label: 'Geospatial Raster Formats',
-      items: ['geospatial/geotiff']
+      items: ['geospatial/geotiff', 'geospatial/geo-zarr']
     },
     {
       type: 'category',

--- a/website/src/examples/geospatial/geo-zarr.mdx
+++ b/website/src/examples/geospatial/geo-zarr.mdx
@@ -1,0 +1,14 @@
+---
+title: "GeoZarr Raster Source"
+hide_title: true
+---
+
+import Demo from 'examples/website/geozarr/app';
+
+# GeoZarr with deck.gl
+
+<div style={{height: 'calc(100vh - var(--ifm-navbar-height))'}}>
+  <Demo>
+    [**`GeoZarrSourceLoader`**](/docs/modules/zarr/api-reference/geo-zarr-source-loader) reads NASA POWER's public monthly climatology directly from a remote Zarr store and renders it through a deck.gl `BitmapLayer`.
+  </Demo>
+</div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -19663,6 +19663,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"geozarr-deck-example@workspace:examples/website/geozarr":
+  version: 0.0.0-use.local
+  resolution: "geozarr-deck-example@workspace:examples/website/geozarr"
+  dependencies:
+    "@deck.gl/core": "npm:^9.3.0"
+    "@deck.gl/layers": "npm:^9.3.0"
+    "@deck.gl/react": "npm:^9.3.0"
+    "@loaders.gl/core": "workspace:*"
+    "@loaders.gl/zarr": "workspace:*"
+    "@luma.gl/core": "npm:^9.3.2"
+    "@luma.gl/engine": "npm:^9.3.2"
+    "@luma.gl/shadertools": "npm:^9.3.2"
+    mapbox-gl: "npm:maplibre-gl@^3.6.2"
+    maplibre-gl: "npm:^3.6.2"
+    react: "npm:^19.2.5"
+    react-dom: "npm:^19.2.5"
+    react-map-gl: "npm:^7.1.7"
+    typescript: "npm:^5.6.0"
+    vite: "npm:^7.2.7"
+  languageName: unknown
+  linkType: soft
+
 "get-caller-file@npm:2.0.5, get-caller-file@npm:^2.0.1, get-caller-file@npm:^2.0.5":
   version: 2.0.5
   resolution: "get-caller-file@npm:2.0.5"


### PR DESCRIPTION
## Goals

- Show a complete browser workflow for loading a real public Earth-science Zarr store and rendering it with deck.gl.
- Carry the GeoZarr browser coverage follow-up from #3587 into the next PR.

## Changes

- Add a standalone and website-embedded GeoZarr example backed by NASA POWER's public one-degree solar climatology store.
- Render monthly or annual irradiance as a colorized deck.gl `BitmapLayer` over a MapLibre basemap.
- Add month playback and selection plus a live raster-opacity control so the basemap remains visible.
- Document and link the example from the Zarr module pages, API reference, examples sidebar, and release notes.
- Expand browser coverage for CF/xarray coordinates, typed window reads, named selections, and unsupported viewport/resampling paths.
- Register the example workspace and update `yarn.lock`.

## Validation

- `yarn lint fix`
- `yarn workspace geozarr-deck-example exec tsc`
- `yarn workspace geozarr-deck-example build`
- `yarn workspace project-website build`
- `yarn vitest run --project node modules/zarr/test/geo-zarr-source.node.spec.ts` (5 passed)
- `yarn vitest run --project headless modules/zarr/test/geo-zarr-source.browser.spec.ts` (3 passed)
- `NX_DAEMON=false npx lerna run pre-build` (51 projects passed)
- Live browser verification against the remote NASA POWER store, including month playback and opacity changes