### PR TITLE
feat(parquet): show live benchmark progress

### DIFF
--- a/website/src/examples/parquet-benchmarks-app.tsx
+++ b/website/src/examples/parquet-benchmarks-app.tsx
@@ -276,6 +276,13 @@ export default function ParquetBenchmarksApp(): JSX.Element {
                 ...scenarioRows.map(row => row.throughput),
                 Number.NEGATIVE_INFINITY
               );
+              const isScenarioComplete = scenario.implementationIds.every(implementationId => {
+                const cellKey = getBenchmarkCellKey(scenario.name, implementationId);
+                return (
+                  scenarioRows.some(row => row.implementationId === implementationId) ||
+                  failedCellKeys.has(cellKey)
+                );
+              });
               return (
                 <tr key={scenario.name}>
                   <th scope="row">{scenario.name}</th>
@@ -287,7 +294,7 @@ export default function ParquetBenchmarksApp(): JSX.Element {
                     const cellKey = getBenchmarkCellKey(scenario.name, implementationId);
                     const isApplicable = scenario.implementationIds.includes(implementationId);
                     const isBestResult =
-                      status === 'complete' && result?.throughput === bestThroughput;
+                      isScenarioComplete && result?.throughput === bestThroughput;
                     return (
                       <td
                         key={implementationId}
@@ -304,7 +311,10 @@ export default function ParquetBenchmarksApp(): JSX.Element {
                         ) : !isApplicable ? (
                           <span className="parquet-benchmark-not-applicable">N/A</span>
                         ) : (
-                          <span className="parquet-benchmark-pending">—</span>
+                          <span
+                            className="parquet-benchmark-pending"
+                            aria-label="Benchmark pending"
+                          />
                         )}
                       </td>
                     );

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -628,7 +628,26 @@ body:has(.benchmark-page) footer.theme-layout-footer {
 }
 
 .parquet-benchmark-pending {
-  color: var(--ifm-font-color-secondary);
+  animation: parquet-benchmark-spin 0.8s linear infinite;
+  border: 2px solid var(--ifm-table-border-color);
+  border-radius: 50%;
+  border-top-color: var(--ifm-color-primary);
+  display: inline-block;
+  height: 0.9rem;
+  vertical-align: -0.1rem;
+  width: 0.9rem;
+}
+
+@keyframes parquet-benchmark-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .parquet-benchmark-pending {
+    animation: none;
+  }
 }
 
 .parquet-benchmark-empty {


### PR DESCRIPTION
## Goals

- Make unresolved Parquet benchmark cells visibly active while the suite is running.
- Reveal each row's winning result as soon as that row is resolved, without waiting for the full benchmark matrix.

## Changes

- Replace the pending-cell dash with an accessible CSS spinner.
- Respect `prefers-reduced-motion` by disabling spinner animation.
- Determine completion per scenario from successful and failed applicable implementations.
- Keep `N/A` and `Failed` states unchanged.

## Validation

- `yarn lint fix`
- `cd website && yarn build`
- Live browser verification: pending spinners remained visible while an already-complete row displayed its green winner marker.
