### PR TITLE
feat(las): write LASzip LAZ files

### DIFF
--- a/docs/modules/las/README.md
+++ b/docs/modules/las/README.md
@@ -15,7 +15,7 @@ npm install @loaders.gl/core @loaders.gl/las
 | Loader or Writer                                              | Description                                  |
 | ------------------------------------------------------------- | -------------------------------------------- |
 | [`LASLoader`](/docs/modules/las/api-reference/las-loader)      | Loads LAS/LAZ point clouds as Mesh objects or [Mesh Arrow tables](/docs/specifications/category-mesh#mesh-arrow-tables). |
-| [`LASWriter`](/docs/modules/las/api-reference/las-writer)      | Writes Mesh or Mesh Arrow table point clouds as uncompressed LAS data. |
+| [`LASWriter`](/docs/modules/las/api-reference/las-writer)      | Writes Mesh or Mesh Arrow table point clouds as LAS or LAZ data. |
 
 ## Attribution
 

--- a/docs/modules/las/api-reference/las-writer.md
+++ b/docs/modules/las/api-reference/las-writer.md
@@ -10,7 +10,7 @@ import {LasDocsTabs} from '@site/src/components/docs/las-docs-tabs';
   <img src="https://img.shields.io/badge/Status-Experimental-orange.svg?style=flat-square" alt="Status: Experimental" />
 </p>
 
-The `LASWriter` writes [Mesh](/docs/specifications/category-mesh) or [Mesh Arrow table](/docs/specifications/category-mesh#mesh-arrow-tables) point cloud data as uncompressed LAS binary data.
+The `LASWriter` writes [Mesh](/docs/specifications/category-mesh) or [Mesh Arrow table](/docs/specifications/category-mesh#mesh-arrow-tables) point cloud data as LAS or LAZ binary data.
 
 ## Usage
 
@@ -23,6 +23,7 @@ declare const pointCloud: Mesh | MeshArrowTable;
 
 const arrayBuffer = await encode(pointCloud, LASWriter, {
   las: {
+    format: 'laz',
     scale: [0.001, 0.001, 0.001]
   }
 });
@@ -32,15 +33,18 @@ const arrayBuffer = await encode(pointCloud, LASWriter, {
 
 `LASWriter` accepts Mesh Arrow tables and legacy Mesh objects. Arrow table input is normalized to the writer's Mesh representation before LAS binary data is encoded.
 
-The writer requires a `POSITION` attribute. It writes `COLOR_0`, `intensity`, and `classification` attributes when present. It can select LAS versions 1.0-1.4 and PDRF 0-8, but fields without a corresponding input attribute, including GPS time, waveform references, NIR, return flags, and scanner metadata, are zero-filled. Current round-trip coverage targets default LAS 1.2 and LAS 1.4/PDRF 7; full conformance for every selectable version/PDRF combination is not claimed. `LASWriter` does not write LAZ-compressed or COPC output.
+The writer requires a `POSITION` attribute. It writes `COLOR_0`, `intensity`, and `classification` attributes when present. It can select LAS versions 1.0-1.4 and PDRF 0-8 for uncompressed output, but fields without a corresponding input attribute, including GPS time, waveform references, NIR, return flags, and scanner metadata, are zero-filled. Current uncompressed round-trip coverage targets default LAS 1.2 and LAS 1.4/PDRF 7; full conformance for every selectable version/PDRF combination is not claimed.
+
+LAZ output uses LAS 1.4, PDRF 6-8, LASzip layered compressor 3, arithmetic coder 0, item version 3, and a fixed-size chunk table. The output is readable by the TypeScript loader and established WASM decoders. `LASWriter` does not yet write COPC output.
 
 ## Options
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| `las.format` | `'las' \| 'laz' \| 'copc'` | `'las'` | Output container. Only `'las'` is implemented; compressed formats throw. |
+| `las.format` | `'las' \| 'laz' \| 'copc'` | `'las'` | Output container. `'las'` and `'laz'` are implemented; `'copc'` throws. |
 | `las.version` | `'1.0'` through `'1.4'` | `'1.2'` or `'1.4'` | LAS header version. The default is 1.4 for modern PDRFs and 1.2 otherwise. |
 | `las.pointDataRecordFormat` | `0` through `8` | Derived | Point record layout. The default depends on version and whether `COLOR_0` is present. |
 | `las.scale` | `[number, number, number]` | `[0.001, 0.001, 0.001]` | Coordinate scale factors used to quantize positions into LAS integer coordinates. |
 | `las.offset` | `[number, number, number]` | Mesh minimum position | Coordinate offsets used to quantize positions into LAS integer coordinates. |
 | `las.colorDepth` | `number \| string` | - | Declares the source color component depth. |
+| `las.chunkSize` | `number` | `50000` | Number of points per fixed-size LAZ chunk. |

--- a/docs/modules/las/formats/las.md
+++ b/docs/modules/las/formats/las.md
@@ -70,13 +70,15 @@ LAS file versions and LASzip codec versions are independent. A claim such as "LA
 
 `encodeLAZChunk()` and `createLAZChunkEncoder()` encode raw LAS point records into one LASzip layered chunk. They do not write the surrounding LAS header, LASzip VLR, chunk table, or `.laz` file container.
 
+`LASWriter` uses the chunk encoder to write complete LAS 1.4 `.laz` files for PDRF 6-8, including the LASzip VLR, fixed-size chunks, chunk-table pointer, and version 0 chunk table.
+
 | LASzip feature | Supported TypeScript combinations |
 | --- | --- |
 | Modern PDRF 6-8 items | Layered compressor 3, arithmetic coder 0, and Point14/RGB14/RGBNIR14 item version 3. |
 | Extra Bytes | Byte14 item version 3 is losslessly encoded as independent layers. |
 | Input modes | Complete raw point buffers and feedable raw byte ranges. Feedable input is buffered until `close()` and `encode()` are called. |
 | Interoperability | PDRF 6-8 output is tested byte-for-byte through the TypeScript decoder and laz-perf. |
-| Unsupported modes | Legacy PDRF 0-5, waveform PDRF 9-10, item versions 2 and 4, and complete `.laz` file writing. |
+| Unsupported modes | Legacy PDRF 0-5, waveform PDRF 9-10, and item versions 2 and 4. |
 
 #### Point Record Formats
 

--- a/modules/las/src/las-writer.ts
+++ b/modules/las/src/las-writer.ts
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {WriterOptions, WriterWithEncoder} from '@loaders.gl/loader-utils';
+import {
+  encodeLAZChunk,
+  encodeLAZChunkTable,
+  type LAZChunkTableEntry,
+  type WriterOptions,
+  type WriterWithEncoder
+} from '@loaders.gl/loader-utils';
 import type {Mesh, MeshArrowTable, MeshAttribute} from '@loaders.gl/schema';
 import {convertMeshToTable, convertTableToMesh} from '@loaders.gl/schema-utils';
 import {LASFormat} from './las-format';
@@ -13,6 +19,9 @@ const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
 const LAS_HEADER_LENGTH = 227;
 const LAS_1_4_HEADER_LENGTH = 375;
+const LASZIP_VLR_HEADER_LENGTH = 54;
+const LASZIP_VLR_PAYLOAD_BASE_LENGTH = 34;
+const DEFAULT_LAZ_CHUNK_SIZE = 50_000;
 const POINT_RECORD_LENGTHS: Record<number, number> = {
   0: 20,
   1: 28,
@@ -29,7 +38,7 @@ const POINT_RECORD_LENGTHS: Record<number, number> = {
 export type LASWriterOptions = WriterOptions & {
   /** LAS-specific writer options. */
   las?: {
-    /** Output container format. Only uncompressed LAS is currently implemented. */
+    /** Output container format. COPC writing is not yet implemented. */
     format?: 'las' | 'laz' | 'copc';
     /** LAS file version to write. LAS 1.5 writing is intentionally not supported. */
     version?: '1.0' | '1.1' | '1.2' | '1.3' | '1.4';
@@ -41,18 +50,20 @@ export type LASWriterOptions = WriterOptions & {
     offset?: [number, number, number];
     /** Color component depth used by source color attributes. */
     colorDepth?: number | string;
+    /** Number of points per fixed-size LAZ chunk. */
+    chunkSize?: number;
   };
 };
 
 /**
- * Writer for uncompressed LAS point cloud data.
+ * Writer for LAS and LAZ point cloud data.
  */
 export const LASWriter = {
   ...LASFormat,
   dataType: null as unknown as Mesh | MeshArrowTable,
   batchType: null as never,
   version: VERSION,
-  extensions: ['las'],
+  extensions: ['las', 'laz'],
   options: {
     las: {}
   },
@@ -67,13 +78,11 @@ export const LASWriter = {
   }
 } as const satisfies WriterWithEncoder<Mesh | MeshArrowTable, never, LASWriterOptions>;
 
-/** Encode mesh category data as uncompressed LAS bytes. */
+/** Encode mesh category data as LAS or LAZ bytes. */
 function encodeLASSync(data: Mesh | MeshArrowTable, options: LASWriterOptions = {}): ArrayBuffer {
   const format = options.las?.format || 'las';
-  if (format !== 'las') {
-    throw new Error(
-      `LASWriter: TypeScript ${format.toUpperCase()} encoding is not implemented yet`
-    );
+  if (format === 'copc') {
+    throw new Error('LASWriter: TypeScript COPC encoding is not implemented yet');
   }
 
   const mesh = normalizeMesh(data);
@@ -93,10 +102,38 @@ function encodeLASSync(data: Mesh | MeshArrowTable, options: LASWriterOptions = 
   }
   const version = options.las?.version || (pointDataRecordFormat >= 6 ? '1.4' : '1.2');
   const headerLength = version === '1.4' ? LAS_1_4_HEADER_LENGTH : LAS_HEADER_LENGTH;
-  const arrayBuffer = new ArrayBuffer(headerLength + vertexCount * pointDataRecordLength);
-  const dataView = new DataView(arrayBuffer);
+  if (format === 'laz') {
+    validateLAZOptions(version, pointDataRecordFormat, options.las?.chunkSize);
+  }
 
-  writeHeader(dataView, {
+  const rawPointData = new Uint8Array(vertexCount * pointDataRecordLength);
+  const pointDataView = new DataView(rawPointData.buffer);
+
+  for (let vertexIndex = 0; vertexIndex < vertexCount; vertexIndex++) {
+    const pointOffset = vertexIndex * pointDataRecordLength;
+    pointDataView.setInt32(
+      pointOffset,
+      Math.round((getComponent(positionAttribute, vertexIndex, 0) - offset[0]) / scale[0]),
+      true
+    );
+    pointDataView.setInt32(
+      pointOffset + 4,
+      Math.round((getComponent(positionAttribute, vertexIndex, 1) - offset[1]) / scale[1]),
+      true
+    );
+    pointDataView.setInt32(
+      pointOffset + 8,
+      Math.round((getComponent(positionAttribute, vertexIndex, 2) - offset[2]) / scale[2]),
+      true
+    );
+    writePointRecord(pointDataView, pointOffset, vertexIndex, pointDataRecordFormat, {
+      intensityAttribute,
+      classificationAttribute,
+      colorAttribute
+    });
+  }
+
+  const writeParameters: LASWriteParameters = {
     vertexCount,
     boundingBox,
     scale,
@@ -105,33 +142,181 @@ function encodeLASSync(data: Mesh | MeshArrowTable, options: LASWriterOptions = 
     headerLength,
     pointDataRecordFormat,
     pointDataRecordLength
-  });
-
-  for (let vertexIndex = 0; vertexIndex < vertexCount; vertexIndex++) {
-    const pointOffset = headerLength + vertexIndex * pointDataRecordLength;
-    dataView.setInt32(
-      pointOffset,
-      Math.round((getComponent(positionAttribute, vertexIndex, 0) - offset[0]) / scale[0]),
-      true
-    );
-    dataView.setInt32(
-      pointOffset + 4,
-      Math.round((getComponent(positionAttribute, vertexIndex, 1) - offset[1]) / scale[1]),
-      true
-    );
-    dataView.setInt32(
-      pointOffset + 8,
-      Math.round((getComponent(positionAttribute, vertexIndex, 2) - offset[2]) / scale[2]),
-      true
-    );
-    writePointRecord(dataView, pointOffset, vertexIndex, pointDataRecordFormat, {
-      intensityAttribute,
-      classificationAttribute,
-      colorAttribute
-    });
+  };
+  if (format === 'laz') {
+    return encodeLAZFile(rawPointData, writeParameters, options.las?.chunkSize);
   }
 
+  const arrayBuffer = new ArrayBuffer(headerLength + rawPointData.byteLength);
+  writeHeader(new DataView(arrayBuffer), {...writeParameters, pointDataOffset: headerLength});
+  new Uint8Array(arrayBuffer, headerLength).set(rawPointData);
   return arrayBuffer;
+}
+
+/** Values shared by LAS header and point-data encoding. */
+type LASWriteParameters = {
+  /** Number of point records in the output. */
+  vertexCount: number;
+  /** World-coordinate bounds. */
+  boundingBox: [[number, number, number], [number, number, number]];
+  /** Coordinate quantization scales. */
+  scale: [number, number, number];
+  /** Coordinate quantization offsets. */
+  offset: [number, number, number];
+  /** LAS file version. */
+  version: '1.0' | '1.1' | '1.2' | '1.3' | '1.4';
+  /** Public header byte length. */
+  headerLength: number;
+  /** LAS point data record format. */
+  pointDataRecordFormat: number;
+  /** Byte length of each raw point record. */
+  pointDataRecordLength: number;
+};
+
+/** One LASzip item descriptor written into the codec VLR. */
+type LASzipItem = {
+  /** LASzip item type identifier. */
+  type: number;
+  /** Uncompressed item byte length. */
+  size: number;
+};
+
+/** Assemble raw LAS point records into a complete fixed-chunk LAZ file. */
+function encodeLAZFile(
+  rawPointData: Uint8Array,
+  parameters: LASWriteParameters,
+  requestedChunkSize?: number
+): ArrayBuffer {
+  const chunkSize = requestedChunkSize || DEFAULT_LAZ_CHUNK_SIZE;
+  const laszipVLR = createLASzipVLR(
+    parameters.pointDataRecordFormat,
+    parameters.pointDataRecordLength,
+    chunkSize
+  );
+  const pointDataOffset = parameters.headerLength + laszipVLR.byteLength;
+  const compressedChunks: Uint8Array[] = [];
+  const chunkTableEntries: LAZChunkTableEntry[] = [];
+
+  for (let pointOffset = 0; pointOffset < parameters.vertexCount; pointOffset += chunkSize) {
+    const pointCount = Math.min(chunkSize, parameters.vertexCount - pointOffset);
+    const byteOffset = pointOffset * parameters.pointDataRecordLength;
+    const compressed = encodeLAZChunk(
+      rawPointData.subarray(byteOffset, byteOffset + pointCount * parameters.pointDataRecordLength),
+      {
+        pointDataRecordFormat: parameters.pointDataRecordFormat,
+        pointDataRecordLength: parameters.pointDataRecordLength,
+        pointCount,
+        point14ItemVersion: 3,
+        rgb14ItemVersion: 3,
+        byte14ItemVersion: 3
+      }
+    );
+    compressedChunks.push(compressed);
+    chunkTableEntries.push({pointCount, byteLength: compressed.byteLength});
+  }
+
+  const compressedPointDataByteLength = compressedChunks.reduce(
+    (byteLength, chunk) => byteLength + chunk.byteLength,
+    0
+  );
+  const chunkTablePayload = encodeLAZChunkTable(chunkTableEntries);
+  const chunkTableOffset = pointDataOffset + 8 + compressedPointDataByteLength;
+  const arrayBuffer = new ArrayBuffer(chunkTableOffset + 8 + chunkTablePayload.byteLength);
+  const bytes = new Uint8Array(arrayBuffer);
+  const dataView = new DataView(arrayBuffer);
+
+  writeHeader(dataView, {
+    ...parameters,
+    pointDataOffset,
+    vlrCount: 1,
+    compressed: true
+  });
+  bytes.set(laszipVLR, parameters.headerLength);
+  writeUint64Fallback(dataView, pointDataOffset, chunkTableOffset);
+  let compressedOffset = pointDataOffset + 8;
+  for (const chunk of compressedChunks) {
+    bytes.set(chunk, compressedOffset);
+    compressedOffset += chunk.byteLength;
+  }
+  dataView.setUint32(chunkTableOffset, 0, true);
+  dataView.setUint32(chunkTableOffset + 4, chunkTableEntries.length, true);
+  bytes.set(chunkTablePayload, chunkTableOffset + 8);
+  return arrayBuffer;
+}
+
+/** Create the LASzip VLR for a layered LAS 1.4 point layout. */
+function createLASzipVLR(
+  pointDataRecordFormat: number,
+  pointDataRecordLength: number,
+  chunkSize: number
+): Uint8Array {
+  const items = getLASzipItems(pointDataRecordFormat, pointDataRecordLength);
+  const payloadLength = LASZIP_VLR_PAYLOAD_BASE_LENGTH + items.length * 6;
+  const bytes = new Uint8Array(LASZIP_VLR_HEADER_LENGTH + payloadLength);
+  const dataView = new DataView(bytes.buffer);
+  const payloadOffset = LASZIP_VLR_HEADER_LENGTH;
+
+  writeString(dataView, 2, 'laszip encoded', 16);
+  dataView.setUint16(18, 22204, true);
+  dataView.setUint16(20, payloadLength, true);
+  writeString(dataView, 22, 'loaders.gl LAZ writer', 32);
+  dataView.setUint16(payloadOffset, 3, true);
+  dataView.setUint16(payloadOffset + 2, 0, true);
+  dataView.setUint8(payloadOffset + 4, 3);
+  dataView.setUint8(payloadOffset + 5, 5);
+  dataView.setUint16(payloadOffset + 6, 1, true);
+  dataView.setUint32(payloadOffset + 8, 0, true);
+  dataView.setUint32(payloadOffset + 12, chunkSize, true);
+  bytes.fill(0xff, payloadOffset + 16, payloadOffset + 32);
+  dataView.setUint16(payloadOffset + 32, items.length, true);
+  for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
+    const itemOffset = payloadOffset + LASZIP_VLR_PAYLOAD_BASE_LENGTH + itemIndex * 6;
+    const item = items[itemIndex];
+    dataView.setUint16(itemOffset, item.type, true);
+    dataView.setUint16(itemOffset + 2, item.size, true);
+    dataView.setUint16(itemOffset + 4, 3, true);
+  }
+  return bytes;
+}
+
+/** Return LASzip item descriptors for one supported point format. */
+function getLASzipItems(
+  pointDataRecordFormat: number,
+  pointDataRecordLength: number
+): LASzipItem[] {
+  const items = [{type: 10, size: 30}];
+  if (pointDataRecordFormat === 7) {
+    items.push({type: 11, size: 6});
+  } else if (pointDataRecordFormat === 8) {
+    items.push({type: 12, size: 8});
+  }
+  const extraByteCount = pointDataRecordLength - POINT_RECORD_LENGTHS[pointDataRecordFormat];
+  if (extraByteCount > 0) {
+    items.push({type: 14, size: extraByteCount});
+  }
+  return items;
+}
+
+/** Validate the intentionally narrow LAZ container writer surface. */
+function validateLAZOptions(
+  version: string,
+  pointDataRecordFormat: number,
+  chunkSize?: number
+): void {
+  if (version !== '1.4') {
+    throw new Error(`LASWriter: LAZ output requires LAS 1.4; received ${version}`);
+  }
+  if (![6, 7, 8].includes(pointDataRecordFormat)) {
+    throw new Error(
+      `LASWriter: LAZ output only supports point data record formats 6-8; received ${pointDataRecordFormat}`
+    );
+  }
+  if (
+    chunkSize !== undefined &&
+    (!Number.isInteger(chunkSize) || chunkSize <= 0 || chunkSize > 0xffffffff)
+  ) {
+    throw new Error(`LASWriter: invalid LAZ chunk size ${chunkSize}`);
+  }
 }
 
 /** Return mesh data as a Mesh, converting MeshArrowTable input first. */
@@ -205,15 +390,13 @@ function getRequiredAttribute(mesh: Mesh, attributeName: string): MeshAttribute 
 /** Write the LAS 1.2 public header block. */
 function writeHeader(
   dataView: DataView,
-  parameters: {
-    vertexCount: number;
-    boundingBox: [[number, number, number], [number, number, number]];
-    scale: [number, number, number];
-    offset: [number, number, number];
-    version: '1.0' | '1.1' | '1.2' | '1.3' | '1.4';
-    headerLength: number;
-    pointDataRecordFormat: number;
-    pointDataRecordLength: number;
+  parameters: LASWriteParameters & {
+    /** Absolute point-data byte offset. */
+    pointDataOffset: number;
+    /** Number of VLR records before point data. */
+    vlrCount?: number;
+    /** Whether the point format byte carries the LASzip compression flag. */
+    compressed?: boolean;
   }
 ): void {
   const [versionMajor, versionMinor] = parameters.version.split('.').map(Number);
@@ -223,8 +406,9 @@ function writeHeader(
   writeString(dataView, 26, 'loaders.gl', 32);
   writeString(dataView, 58, 'loaders.gl', 32);
   dataView.setUint16(94, parameters.headerLength, true);
-  dataView.setUint32(96, parameters.headerLength, true);
-  dataView.setUint8(104, parameters.pointDataRecordFormat);
+  dataView.setUint32(96, parameters.pointDataOffset, true);
+  dataView.setUint32(100, parameters.vlrCount || 0, true);
+  dataView.setUint8(104, parameters.pointDataRecordFormat | (parameters.compressed ? 0x80 : 0));
   dataView.setUint16(105, parameters.pointDataRecordLength, true);
   dataView.setUint32(107, parameters.version === '1.4' ? 0 : parameters.vertexCount, true);
   dataView.setUint32(111, parameters.version === '1.4' ? 0 : parameters.vertexCount, true);
@@ -345,7 +529,7 @@ function getDefaultPointDataRecordFormat(
   options: LASWriterOptions,
   colorAttribute?: MeshAttribute
 ): number {
-  if (options.las?.version === '1.4') {
+  if (options.las?.format === 'laz' || options.las?.version === '1.4') {
     return colorAttribute ? 7 : 6;
   }
   return colorAttribute ? 2 : 0;

--- a/modules/las/test/las-writer.spec.ts
+++ b/modules/las/test/las-writer.spec.ts
@@ -7,6 +7,7 @@ import {validateWriter, validateMeshCategoryData} from 'test/common/conformance'
 
 import {LASCOPCLoader, LASLoader, LASWriter} from '@loaders.gl/las';
 import {encode, parse} from '@loaders.gl/core';
+import {decodeLAZChunkTable} from '@loaders.gl/loader-utils';
 import {convertMeshToTable, deduceMeshSchema} from '@loaders.gl/schema-utils';
 
 const attributes = {
@@ -77,11 +78,83 @@ test('LASWriter#encode LAS 1.4 point format 7', async t => {
   t.end();
 });
 
-test('LASWriter#rejects compressed formats until TypeScript encoder is complete', t => {
+test('LASWriter#encodes fixed-chunk LAZ point formats 6-8', async t => {
+  for (const pointDataRecordFormat of [6, 7, 8] as const) {
+    const arrayBuffer = await encode(mesh, LASWriter, {
+      las: {format: 'laz', pointDataRecordFormat, chunkSize: 2}
+    });
+    const dataView = new DataView(arrayBuffer);
+    const pointDataOffset = dataView.getUint32(96, true);
+    const chunkTableOffset = readUint64(dataView, pointDataOffset);
+    const chunkCount = dataView.getUint32(chunkTableOffset + 4, true);
+    const chunks = decodeLAZChunkTable(new Uint8Array(arrayBuffer, chunkTableOffset + 8), {
+      chunkCount,
+      pointCount: 3,
+      chunkSize: 2,
+      variable: false
+    });
+    const data = await parse(arrayBuffer, LASLoader, {core: {worker: false}});
+    const wasmData = await parse(arrayBuffer.slice(0), LASCOPCLoader, {
+      core: {worker: false}
+    });
+
+    t.equal(
+      dataView.getUint8(104),
+      0x80 | pointDataRecordFormat,
+      `PDRF ${pointDataRecordFormat} sets the compressed format flag`
+    );
+    t.equal(dataView.getUint32(100, true), 1, `PDRF ${pointDataRecordFormat} writes one VLR`);
+    t.equal(chunkCount, 2, `PDRF ${pointDataRecordFormat} writes two chunks`);
+    t.deepEqual(
+      chunks.map(chunk => chunk.pointCount),
+      [2, 1],
+      `PDRF ${pointDataRecordFormat} fixed chunk counts roundtrip`
+    );
+    t.equal(
+      chunks.reduce((byteLength, chunk) => byteLength + chunk.byteLength, 0),
+      chunkTableOffset - pointDataOffset - 8,
+      `PDRF ${pointDataRecordFormat} chunk sizes reach the table`
+    );
+    t.deepEqual(
+      Array.from(data.attributes.POSITION.value),
+      Array.from(wasmData.attributes.POSITION.value),
+      `PDRF ${pointDataRecordFormat} TypeScript positions match WASM`
+    );
+    t.deepEqual(
+      Array.from(data.attributes.intensity.value),
+      Array.from(wasmData.attributes.intensity.value),
+      `PDRF ${pointDataRecordFormat} TypeScript intensities match WASM`
+    );
+    t.deepEqual(
+      Array.from(data.attributes.classification.value),
+      Array.from(wasmData.attributes.classification.value),
+      `PDRF ${pointDataRecordFormat} TypeScript classifications match WASM`
+    );
+  }
+  t.end();
+});
+
+test('LASWriter#validates compressed output options', t => {
   t.throws(
-    () => LASWriter.encodeSync?.(mesh, {las: {format: 'laz'}}),
-    /LAZ encoding is not implemented/,
-    'LAZ writer fails clearly'
+    () =>
+      LASWriter.encodeSync?.(mesh, {
+        las: {format: 'laz', version: '1.2', pointDataRecordFormat: 6}
+      }),
+    /LAZ output requires LAS 1.4/,
+    'LAZ writer rejects legacy LAS versions'
+  );
+  t.throws(
+    () =>
+      LASWriter.encodeSync?.(mesh, {
+        las: {format: 'laz', version: '1.4', pointDataRecordFormat: 3}
+      }),
+    /only supports point data record formats 6-8/,
+    'LAZ writer rejects legacy point formats'
+  );
+  t.throws(
+    () => LASWriter.encodeSync?.(mesh, {las: {format: 'laz', chunkSize: 0}}),
+    /invalid LAZ chunk size/,
+    'LAZ writer rejects empty chunks'
   );
   t.throws(
     () => LASWriter.encodeSync?.(mesh, {las: {format: 'copc'}}),
@@ -111,3 +184,8 @@ test('LASWriter#preserves normalized byte colors', async t => {
   t.equal(dataView.getUint16(227 + 24, true), 0, 'blue channel preserves zero byte value');
   t.end();
 });
+
+/** Read a little-endian UInt64 that is known to fit in JavaScript's safe integer range. */
+function readUint64(dataView: DataView, byteOffset: number): number {
+  return dataView.getUint32(byteOffset, true) + dataView.getUint32(byteOffset + 4, true) * 2 ** 32;
+}

--- a/modules/loader-utils/src/index.ts
+++ b/modules/loader-utils/src/index.ts
@@ -179,7 +179,11 @@ export type {
   LAZChunkTableEntry,
   LAZPointDataTarget
 } from './lib/laz/laz-chunk-decoder';
-export {createLAZChunkEncoder, encodeLAZChunk} from './lib/laz/laz-chunk-encoder';
+export {
+  createLAZChunkEncoder,
+  encodeLAZChunk,
+  encodeLAZChunkTable
+} from './lib/laz/laz-chunk-encoder';
 export type {FeedableLAZChunkEncoder} from './lib/laz/laz-chunk-encoder';
 
 // PATH HELPERS

--- a/modules/loader-utils/src/lib/laz/laz-chunk-encoder.ts
+++ b/modules/loader-utils/src/lib/laz/laz-chunk-encoder.ts
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import type {LAZChunkMetadata} from './laz-chunk-decoder';
+import type {LAZChunkTableEntry} from './laz-chunk-decoder';
 import {
   ArithmeticEncoder,
   ArithmeticModel,
@@ -155,6 +156,36 @@ export function encodeLAZChunk(
     sizeView.setUint32(4 + index * 4, layers[index].byteLength, true);
   }
   return concatenateUint8Arrays([firstRecord, sizeHeader, ...layers]);
+}
+
+/** Encode LASzip chunk-table entries as one arithmetic-coded payload. */
+export function encodeLAZChunkTable(
+  chunks: readonly LAZChunkTableEntry[],
+  options: {
+    /** Whether to include the point count for each variable-size chunk. */
+    variable?: boolean;
+  } = {}
+): Uint8Array {
+  if (chunks.length === 0) {
+    return new Uint8Array(0);
+  }
+
+  const encoder = new ArithmeticEncoder();
+  const compressor = new IntegerCompressor(encoder, 32, 2);
+  let pointCountPredictor = 0;
+  let byteLengthPredictor = 0;
+
+  for (const chunk of chunks) {
+    validateChunkTableEntry(chunk);
+    if (options.variable) {
+      compressor.compress(pointCountPredictor, chunk.pointCount, 0);
+      pointCountPredictor = chunk.pointCount;
+    }
+    compressor.compress(byteLengthPredictor, chunk.byteLength, 1);
+    byteLengthPredictor = chunk.byteLength;
+  }
+
+  return encoder.finish();
 }
 
 type Point14 = {
@@ -923,6 +954,24 @@ function validateMetadata(rawBytes: Uint8Array, metadata: LAZChunkMetadata): voi
     throw new Error(
       `LAZ chunk input has ${rawBytes.byteLength} bytes; expected ${expectedByteLength}`
     );
+  }
+}
+
+/** Validate one chunk-table entry before integer compression. */
+function validateChunkTableEntry(chunk: LAZChunkTableEntry): void {
+  if (
+    !Number.isInteger(chunk.pointCount) ||
+    chunk.pointCount <= 0 ||
+    chunk.pointCount > 0xffffffff
+  ) {
+    throw new Error(`Invalid LAZ chunk point count ${chunk.pointCount}`);
+  }
+  if (
+    !Number.isInteger(chunk.byteLength) ||
+    chunk.byteLength <= 0 ||
+    chunk.byteLength > 0xffffffff
+  ) {
+    throw new Error(`Invalid LAZ chunk byte length ${chunk.byteLength}`);
   }
 }
 

--- a/modules/loader-utils/test/lib/laz/laz-chunk-encoder.spec.ts
+++ b/modules/loader-utils/test/lib/laz/laz-chunk-encoder.spec.ts
@@ -6,7 +6,9 @@ import test from 'test/utils/vitest-tape';
 import {
   createLAZChunkEncoder,
   decodeLAZChunk,
+  decodeLAZChunkTable,
   encodeLAZChunk,
+  encodeLAZChunkTable,
   getLAZChunkByteLength
 } from '@loaders.gl/loader-utils';
 
@@ -82,6 +84,43 @@ test('LAZChunkEncoder#validates input and item versions', t => {
     () => encodeLAZChunk(rawPointData, {...metadata, point14ItemVersion: 4}),
     /only supports Point14 item version 3/,
     'unsupported Point14 versions are rejected'
+  );
+  t.end();
+});
+
+test('LAZChunkEncoder#encodes fixed and variable chunk tables', t => {
+  const chunks = [
+    {pointCount: 50_000, byteLength: 100_000},
+    {pointCount: 50_000, byteLength: 90_000},
+    {pointCount: 23, byteLength: 800}
+  ];
+  const fixedTable = encodeLAZChunkTable(chunks);
+  t.deepEqual(
+    decodeLAZChunkTable(fixedTable, {
+      chunkCount: chunks.length,
+      pointCount: 100_023,
+      chunkSize: 50_000,
+      variable: false
+    }),
+    chunks,
+    'fixed-size chunk table roundtrips'
+  );
+
+  const variableTable = encodeLAZChunkTable(chunks, {variable: true});
+  t.deepEqual(
+    decodeLAZChunkTable(variableTable, {
+      chunkCount: chunks.length,
+      pointCount: 100_023,
+      chunkSize: 0xffffffff,
+      variable: true
+    }),
+    chunks,
+    'variable-size chunk table roundtrips'
+  );
+  t.throws(
+    () => encodeLAZChunkTable([{pointCount: 0, byteLength: 1}]),
+    /Invalid LAZ chunk point count/,
+    'empty chunks are rejected'
   );
   t.end();
 });


### PR DESCRIPTION
## Goals

- Extend `LASWriter` from raw LAS output to complete, interoperable LAZ files.
- Keep the first container-writing surface narrow and explicit: LAS 1.4, PDRF 6-8, fixed-size chunks.
- Reuse the TypeScript chunk encoder from #3589 and add the missing chunk-table encoder as a general low-level utility.

## Changes

- Added LASzip version 0 chunk-table encoding for fixed and variable chunk descriptions.
- Added `las.format: 'laz'` support to `LASWriter`, with a configurable `las.chunkSize` defaulting to 50,000 points.
- Emit the LAS 1.4 compressed point-format flag, LASzip VLR, chunk-table pointer, layered point chunks, and fixed-size chunk table.
- Support PDRF 6, 7, and 8 with Point14, RGB14/RGBNIR14, and item version 3.
- Preserve existing uncompressed LAS output and continue to reject COPC until the third tranche.
- Updated LAS writer and format documentation.

## Validation

- `yarn lint fix`
- `npx tsc --noEmit -p modules/loader-utils/tsconfig.json`
- `npx tsc --noEmit -p modules/las/tsconfig.json`
- Focused Node suites: 10 tests passed.
- `yarn test-node`: 420 files passed, 2 skipped; 2,039 tests passed, 81 skipped.
- Focused encoder/chunk-table headless suite: 4 tests passed.
- Generated PDRF 6-8 files decode through both `LASLoader` and the WASM-backed `LASCOPCLoader`; their chunk tables round-trip and terminate at the declared offset.
- Full `yarn test-headless` reproduces the current master worker-asset failures: 30 files / 92 tests fail on missing HTML-served workers or ESM workers loaded as classic scripts. The changed headless coverage passes.

## Scope

This is stacked on #3589. Review only the second commit for this tranche. COPC VLRs, variable node chunks, octree partitioning, and hierarchy pages are intentionally reserved for the next stacked PR.