### PR TITLE
docs(website): Lazy load website examples

### DIFF
--- a/docs/modules/i3s/recipes/attribute-driven-colorization.mdx
+++ b/docs/modules/i3s/recipes/attribute-driven-colorization.mdx
@@ -1,9 +1,9 @@
 # Attribute-driven colorization
 
-import Demo from 'examples/website/i3s-colorization-by-attributes/src/app';
+import {ClientExample} from '@site/src/components';
 
 <div style={{height: '50vh'}}>
-  <Demo />
+  <ClientExample kind="i3s-colorization-by-attributes" />
 </div>
 Please find source code of the example [here](https://github.com/visgl/loaders.gl/tree/master/examples/website/i3s-colorization-by-attributes)
 

--- a/docs/modules/i3s/recipes/building-scene-layer.mdx
+++ b/docs/modules/i3s/recipes/building-scene-layer.mdx
@@ -1,13 +1,13 @@
 # I3S Building Scene Layer (BSL)
 
-import Demo from 'examples/website/i3s-building-scene-layer/src/app';
+import {ClientExample} from '@site/src/components';
 
 <p class="badges">
   <img src="https://img.shields.io/badge/From-v3.2-blue.svg?style=flat-square" alt="From-v3.2" />
 </p>
 
 <div style={{height: '50vh'}}>
-  <Demo />
+  <ClientExample kind="i3s-building-scene-layer" />
 </div>
 Please find source code of the example [here](https://github.com/visgl/loaders.gl/tree/master/examples/website/i3s-building-scene-layer)
 

--- a/docs/modules/i3s/recipes/picking.mdx
+++ b/docs/modules/i3s/recipes/picking.mdx
@@ -1,9 +1,9 @@
 # I3S Picking
 
-import Demo from 'examples/website/i3s-picking/src/app';
+import {ClientExample} from '@site/src/components';
 
 <div style={{height: '50vh'}}>
-  <Demo />
+  <ClientExample kind="i3s-picking" />
 </div>
 
 <p></p>

--- a/website/src/components/example/client-example.tsx
+++ b/website/src/components/example/client-example.tsx
@@ -1,0 +1,78 @@
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import React, {
+  type ComponentType,
+  type LazyExoticComponent,
+  type ReactNode,
+  Suspense
+} from 'react';
+
+/** Website example applications that can be loaded on demand. */
+export type ClientExampleKind =
+  | '3d-tiles'
+  | 'benchmarks'
+  | 'geospatial'
+  | 'geotiff'
+  | 'gltf'
+  | 'home'
+  | 'i3s-building-scene-layer'
+  | 'i3s-colorization-by-attributes'
+  | 'i3s-picking'
+  | 'ometiff'
+  | 'textures'
+  | 'tiles'
+  | 'wms';
+
+/** Props for a lazily loaded client-only website example. */
+export type ClientExampleProps = {
+  /** Example application to load. */
+  kind: ClientExampleKind;
+  /** Content rendered while the browser downloads the example application. */
+  fallback?: ReactNode;
+  /** Content forwarded to the example application. */
+  children?: ReactNode;
+  /** Additional props forwarded to the example application. */
+  [propName: string]: unknown;
+};
+
+type ClientExampleComponent = LazyExoticComponent<ComponentType<any>>;
+
+const CLIENT_EXAMPLE_COMPONENTS: Record<ClientExampleKind, ClientExampleComponent> = {
+  '3d-tiles': React.lazy(() => import('examples/website/3d-tiles/app')),
+  benchmarks: React.lazy(() => import('../../examples/benchmarks-app')),
+  geospatial: React.lazy(() => import('examples/website/geospatial/app')),
+  geotiff: React.lazy(() => import('examples/website/geotiff/app')),
+  gltf: React.lazy(() => import('../../examples/gltf-demo-app')),
+  home: React.lazy(() => import('../../examples/home-demo')),
+  'i3s-building-scene-layer': React.lazy(
+    () => import('examples/website/i3s-building-scene-layer/src/app')
+  ),
+  'i3s-colorization-by-attributes': React.lazy(
+    () => import('examples/website/i3s-colorization-by-attributes/src/app')
+  ),
+  'i3s-picking': React.lazy(() => import('examples/website/i3s-picking/src/app')),
+  ometiff: React.lazy(() => import('examples/website/ometiff/app')),
+  textures: React.lazy(() => import('examples/website/textures/app')),
+  tiles: React.lazy(() => import('examples/website/tiles/app')),
+  wms: React.lazy(() => import('examples/website/wms/app'))
+};
+
+/**
+ * Loads only the active example application after the page mounts in the browser.
+ *
+ * Keeping example applications behind this boundary prevents Docusaurus route prefetching from
+ * downloading every example linked in a visible sidebar.
+ */
+export function ClientExample({kind, fallback, ...exampleProps}: ClientExampleProps): ReactNode {
+  const ExampleComponent = CLIENT_EXAMPLE_COMPONENTS[kind];
+  const loadingFallback = fallback ?? <div style={{height: '100%'}} />;
+
+  return (
+    <BrowserOnly fallback={loadingFallback}>
+      {() => (
+        <Suspense fallback={loadingFallback}>
+          <ExampleComponent {...exampleProps} />
+        </Suspense>
+      )}
+    </BrowserOnly>
+  );
+}

--- a/website/src/components/index.tsx
+++ b/website/src/components/index.tsx
@@ -1,5 +1,6 @@
 export {default as makeExample} from './example/make-example';
 export {default as ExamplesIndex} from './example/examples-index';
+export {ClientExample} from './example/client-example';
 
 export {default as Home} from './home';
 export {default as InfoPanel} from './info-panel';

--- a/website/src/examples/3d-tiles.mdx
+++ b/website/src/examples/3d-tiles.mdx
@@ -3,8 +3,8 @@ title: "3D Tiles"
 hide_title: true
 ---
 
-import Demo from 'examples/website/3d-tiles/app';
+import {ClientExample} from '../components';
 
 <div style={{height: '100vh'}}> 
-  <Demo />
+  <ClientExample kind="3d-tiles" />
 </div>

--- a/website/src/examples/benchmarks.mdx
+++ b/website/src/examples/benchmarks.mdx
@@ -3,11 +3,6 @@ title: "Benchmarks"
 hide_title: true
 ---
 
-import BrowserOnly from '@docusaurus/BrowserOnly';
+import {ClientExample} from '../components';
 
-<BrowserOnly fallback={<p>Loading browser benchmarks...</p>}>
-  {() => {
-    const BenchmarksApp = require('./benchmarks-app').default;
-    return <BenchmarksApp />;
-  }}
-</BrowserOnly>
+<ClientExample kind="benchmarks" fallback={<p>Loading browser benchmarks...</p>} />

--- a/website/src/examples/bioimaging/ome-tiff.mdx
+++ b/website/src/examples/bioimaging/ome-tiff.mdx
@@ -3,7 +3,7 @@ title: "OME-TIFF Source"
 hide_title: true
 ---
 
-import Demo from 'examples/website/ometiff/app';
+import {ClientExample} from '../../components';
 import {GeoTiffDocsTabs} from '@site/src/components/docs/geotiff-docs-tabs';
 
 # OME-TIFF
@@ -11,7 +11,7 @@ import {GeoTiffDocsTabs} from '@site/src/components/docs/geotiff-docs-tabs';
 <GeoTiffDocsTabs active="ometiff-example" />
 
 <div style={{height: 'calc(100vh - 76px)'}}>
-  <Demo>
+  <ClientExample kind="ometiff">
     [**`OMETiffSourceLoader`**](/docs/modules/geotiff/api-reference/ometiff-source-loader) loads non-geospatial OME-TIFF planes and returns typed raster data for channel-aware rendering.
-  </Demo>
+  </ClientExample>
 </div>

--- a/website/src/examples/geospatial/csv.mdx
+++ b/website/src/examples/geospatial/csv.mdx
@@ -3,13 +3,13 @@ title: "CSV"
 hide_title: true
 ---
 
-import Demo from 'examples/website/geospatial/app';
+import {ClientExample} from '../../components';
 import {CsvDocsTabs} from '@site/src/components/docs/csv-docs-tabs';
 
 <CsvDocsTabs active="try-it" />
 
 <div style={{height: 'calc(100vh - 76px)'}}>
-  <Demo format="CSV">
+  <ClientExample kind="geospatial" format="CSV">
     [**`CSVLoader`**](/docs/modules/csv/api-reference/csv-loader) loads CSV files with detected WKT and hex-encoded WKB geometry columns.
-  </Demo>
+  </ClientExample>
 </div>

--- a/website/src/examples/geospatial/flatgeobuf.mdx
+++ b/website/src/examples/geospatial/flatgeobuf.mdx
@@ -3,13 +3,13 @@ title: "FlatGeobuf"
 hide_title: true
 ---
 
-import Demo from 'examples/website/geospatial/app';
+import {ClientExample} from '../../components';
 import {FlatGeobufDocsTabs} from '@site/src/components/docs/flatgeobuf-docs-tabs';
 
 <FlatGeobufDocsTabs active="try-it" />
 
 <div style={{height: 'calc(100vh - 76px)'}}> 
-  <Demo format="FlatGeobuf" >
+  <ClientExample kind="geospatial" format="FlatGeobuf" >
     [**`FlatGeobufLoader`**](/docs/modules/flatgeobuf/api-reference/flatgeobuf-loader) loads FlatGeobuf files, optionally into GeoJSON.
-  </Demo>
+  </ClientExample>
 </div>

--- a/website/src/examples/geospatial/geoarrow.mdx
+++ b/website/src/examples/geospatial/geoarrow.mdx
@@ -3,10 +3,10 @@ title: "GeoArrow"
 hide_title: true
 ---
 
-import Demo from 'examples/website/geospatial/app';
+import {ClientExample} from '../../components';
 
 <div style={{height: '100vh'}}> 
-  <Demo format="GeoArrow" >
+  <ClientExample kind="geospatial" format="GeoArrow" >
     [**`GeoArrowLoader`**](/docs/modules/arrow/api-reference/geoarrow-loader) loads GeoArrow tables, optionally into GeoJSON.
-  </Demo>
+  </ClientExample>
 </div>

--- a/website/src/examples/geospatial/geojson.mdx
+++ b/website/src/examples/geospatial/geojson.mdx
@@ -3,13 +3,13 @@ title: "GeoJSON"
 hide_title: true
 ---
 
-import Demo from 'examples/website/geospatial/app';
+import {ClientExample} from '../../components';
 import {JsonDocsTabs} from '@site/src/components/docs/json-docs-tabs';
 
 <JsonDocsTabs active="try-it" tryItHref="/examples/geospatial/geojson" />
 
 <div style={{height: '100vh'}}> 
-  <Demo format="GeoJSON">
+  <ClientExample kind="geospatial" format="GeoJSON">
     [**`GeoJSONLoader`**](/docs/modules/json/api-reference/geojson-loader) loads GeoJSON files into tables.
-  </Demo>
+  </ClientExample>
 </div>

--- a/website/src/examples/geospatial/geopackage.mdx
+++ b/website/src/examples/geospatial/geopackage.mdx
@@ -3,13 +3,13 @@ title: "GeoPackage"
 hide_title: true
 ---
 
-import Demo from 'examples/website/geospatial/app';
+import {ClientExample} from '../../components';
 import {GeoPackageDocsTabs} from '@site/src/components/docs/geopackage-docs-tabs';
 
 <GeoPackageDocsTabs active="try-it" />
 
 <div style={{height: 'calc(100vh - 76px)'}}> 
-  <Demo format="GeoPackage" >
+  <ClientExample kind="geospatial" format="GeoPackage" >
       [**`GeoPackageLoader`**](/docs/modules/geopackage/api-reference/geopackage-loader) loads GeoPackage files, optionally into GeoJSON.
-  </Demo>
+  </ClientExample>
 </div>

--- a/website/src/examples/geospatial/geoparquet.mdx
+++ b/website/src/examples/geospatial/geoparquet.mdx
@@ -3,13 +3,13 @@ title: "GeoParquet"
 hide_title: true
 ---
 
-import Demo from 'examples/website/geospatial/app';
+import {ClientExample} from '../../components';
 import {ParquetDocsTabs} from '@site/src/components/docs/parquet-docs-tabs';
 
 <ParquetDocsTabs active="try-it" />
 
 <div style={{height: 'calc(100vh - 76px)'}}> 
-  <Demo format="GeoParquet" >
+  <ClientExample kind="geospatial" format="GeoParquet" >
       [**`GeoParquetLoader`**](/docs/modules/parquet/api-reference/geoparquet-loader) loads GeoParquet files, optionally into GeoJSON.
-  </Demo>
+  </ClientExample>
 </div>

--- a/website/src/examples/geospatial/geotiff.mdx
+++ b/website/src/examples/geospatial/geotiff.mdx
@@ -3,7 +3,7 @@ title: "GeoTIFF Raster Source"
 hide_title: true
 ---
 
-import Demo from 'examples/website/geotiff/app';
+import {ClientExample} from '../../components';
 import {GeoTiffDocsTabs} from '@site/src/components/docs/geotiff-docs-tabs';
 
 # GeoTIFF
@@ -11,7 +11,7 @@ import {GeoTiffDocsTabs} from '@site/src/components/docs/geotiff-docs-tabs';
 <GeoTiffDocsTabs active="geotiff-example" />
 
 <div style={{height: 'calc(100vh - 76px)'}}>
-  <Demo>
+  <ClientExample kind="geotiff">
     [**`GeoTIFFSourceLoader`**](/docs/modules/geotiff) loads typed raster data for the current viewport and renders it through a client-side color ramp.
-  </Demo>
+  </ClientExample>
 </div>

--- a/website/src/examples/geospatial/gpx.mdx
+++ b/website/src/examples/geospatial/gpx.mdx
@@ -3,13 +3,13 @@ title: "GPX"
 hide_title: true
 ---
 
-import Demo from 'examples/website/geospatial/app';
+import {ClientExample} from '../../components';
 import {KmlDocsTabs} from '@site/src/components/docs/kml-docs-tabs';
 
 <KmlDocsTabs active="try-it" tryItHref="/examples/geospatial/gpx" />
 
 <div style={{height: 'calc(100vh - 76px)'}}> 
-  <Demo format="GPX" >
+  <ClientExample kind="geospatial" format="GPX" >
       [**`GPXLoader`**](/docs/modules/kml/api-reference/gpx-loader) loads GPX files, optionally into GPX.
-  </Demo>
+  </ClientExample>
 </div>

--- a/website/src/examples/geospatial/kml.mdx
+++ b/website/src/examples/geospatial/kml.mdx
@@ -3,13 +3,13 @@ title: "KML"
 hide_title: true
 ---
 
-import Demo from 'examples/website/geospatial/app';
+import {ClientExample} from '../../components';
 import {KmlDocsTabs} from '@site/src/components/docs/kml-docs-tabs';
 
 <KmlDocsTabs active="try-it" />
 
 <div style={{height: 'calc(100vh - 76px)'}}> 
-  <Demo format="KML" >
+  <ClientExample kind="geospatial" format="KML" >
     [**`KMLLoader`**](/docs/modules/arrow/api-reference/kml-loader) loads KML files, optionally into GeoJSON.
-  </Demo>
+  </ClientExample>
 </div>

--- a/website/src/examples/geospatial/shapefile.mdx
+++ b/website/src/examples/geospatial/shapefile.mdx
@@ -3,13 +3,13 @@ title: "Shapefile"
 hide_title: true
 ---
 
-import Demo from 'examples/website/geospatial/app';
+import {ClientExample} from '../../components';
 import {ShapefileDocsTabs} from '@site/src/components/docs/shapefile-docs-tabs';
 
 <ShapefileDocsTabs active="try-it" />
 
 <div style={{height: 'calc(100vh - 76px)'}}> 
-  <Demo format="Shapefile" >
+  <ClientExample kind="geospatial" format="Shapefile" >
     [**`ShapefileLoader`**](/docs/modules/arrow/api-reference/geopackage-loader) loads Esri Shapefiles, optionally into GeoJSON.
-  </Demo>
+  </ClientExample>
 </div>

--- a/website/src/examples/geospatial/tcx.mdx
+++ b/website/src/examples/geospatial/tcx.mdx
@@ -3,13 +3,13 @@ title: "TCX"
 hide_title: true
 ---
 
-import Demo from 'examples/website/geospatial/app';
+import {ClientExample} from '../../components';
 import {KmlDocsTabs} from '@site/src/components/docs/kml-docs-tabs';
 
 <KmlDocsTabs active="try-it" tryItHref="/examples/geospatial/tcx" />
 
 <div style={{height: 'calc(100vh - 76px)'}}> 
-  <Demo format="TCX" >
+  <ClientExample kind="geospatial" format="TCX" >
     [**`RCXLoader`**](/docs/modules/kml/api-reference/tcx-loader) loads TCX files, optionally into GeoJSON.
-  </Demo>
+  </ClientExample>
 </div>

--- a/website/src/examples/gltf.mdx
+++ b/website/src/examples/gltf.mdx
@@ -5,8 +5,8 @@ hide_title: true
 
 
 
-import Demo from './gltf-demo-app';
+import {ClientExample} from '../components';
 
 <div style={{height: '100vh'}}> 
-  <Demo />
+  <ClientExample kind="gltf" />
 </div>

--- a/website/src/examples/i3s-building-scene-layer.mdx
+++ b/website/src/examples/i3s-building-scene-layer.mdx
@@ -3,8 +3,8 @@ title: "I3S Building Scene Layer"
 hide_title: true
 ---
 
-import Demo from 'examples/website/i3s-building-scene-layer/src/app';
+import {ClientExample} from '../components';
 
 <div style={{height: 'calc(100vh - var(--ifm-navbar-height))'}}>
-  <Demo />
+  <ClientExample kind="i3s-building-scene-layer" />
 </div>

--- a/website/src/examples/i3s-colorization-by-attributes.mdx
+++ b/website/src/examples/i3s-colorization-by-attributes.mdx
@@ -3,8 +3,8 @@ title: "I3S Colorization by Attributes"
 hide_title: true
 ---
 
-import Demo from 'examples/website/i3s-colorization-by-attributes/src/app';
+import {ClientExample} from '../components';
 
 <div style={{height: 'calc(100vh - var(--ifm-navbar-height))'}}>
-  <Demo />
+  <ClientExample kind="i3s-colorization-by-attributes" />
 </div>

--- a/website/src/examples/i3s-picking.mdx
+++ b/website/src/examples/i3s-picking.mdx
@@ -3,8 +3,8 @@ title: "I3S Picking"
 hide_title: true
 ---
 
-import Demo from 'examples/website/i3s-picking/src/app';
+import {ClientExample} from '../components';
 
 <div style={{height: 'calc(100vh - var(--ifm-navbar-height))'}}>
-  <Demo />
+  <ClientExample kind="i3s-picking" />
 </div>

--- a/website/src/examples/textures.mdx
+++ b/website/src/examples/textures.mdx
@@ -3,8 +3,8 @@ title: "Textures"
 hide_title: true
 ---
 
-import Demo from 'examples/website/textures/app';
+import {ClientExample} from '../components';
 
 <div style={{height: 'calc(100vh - var(--ifm-navbar-height))', overflowY: 'scroll'}}> 
-  <Demo />
+  <ClientExample kind="textures" />
 </div>

--- a/website/src/examples/tiles/arcgis-feature-server.mdx
+++ b/website/src/examples/tiles/arcgis-feature-server.mdx
@@ -3,11 +3,11 @@ title: "ArcGIS Feature Server"
 hide_title: true
 ---
 
-import Demo from 'examples/website/wms/app';
+import {ClientExample} from '../../components';
 import {WmsDocsTabs} from '@site/src/components/docs/wms-docs-tabs';
 
 <WmsDocsTabs active="arcgis-feature-server-example" />
 
 <div style={{height: 'calc(100vh - var(--ifm-navbar-height) - 4rem)'}}>
-  <Demo format="ArcGIS Feature Server" />
+  <ClientExample kind="wms" format="ArcGIS Feature Server" />
 </div>

--- a/website/src/examples/tiles/arcgis-image-server.mdx
+++ b/website/src/examples/tiles/arcgis-image-server.mdx
@@ -3,11 +3,11 @@ title: "ArcGIS Image Server"
 hide_title: true
 ---
 
-import Demo from 'examples/website/wms/app';
+import {ClientExample} from '../../components';
 import {WmsDocsTabs} from '@site/src/components/docs/wms-docs-tabs';
 
 <WmsDocsTabs active="arcgis-image-server-example" />
 
 <div style={{height: 'calc(100vh - var(--ifm-navbar-height) - 4rem)'}}>
-  <Demo format="ArcGIS Image Server" />
+  <ClientExample kind="wms" format="ArcGIS Image Server" />
 </div>

--- a/website/src/examples/tiles/mlt.mdx
+++ b/website/src/examples/tiles/mlt.mdx
@@ -3,13 +3,13 @@ title: "MapLibre Tile (MLT)"
 hide_title: true
 ---
 
-import Demo from 'examples/website/tiles/app';
+import {ClientExample} from '../../components';
 import {TileDocsTabs} from '@site/src/components/docs/tile-docs-tabs';
 
 <TileDocsTabs active="mlt-example" />
 
 <div style={{height: 'calc(100vh - var(--ifm-navbar-height) - 4rem)'}}> 
-  <Demo format="MLT">
+  <ClientExample kind="tiles" format="MLT">
     [**`MLTSourceLoader`**](/docs/modules/mlt/api-reference/mlt-source-loader) and [**`MLTLoader`**](/docs/modules/mlt/api-reference/mlt-loader) dynamically load [MapLibre tile](/docs/modules/mlt/formats/mlt) (`.mlt`) data.
-  </Demo>
+  </ClientExample>
 </div>

--- a/website/src/examples/tiles/mvt.mdx
+++ b/website/src/examples/tiles/mvt.mdx
@@ -3,18 +3,18 @@ title: "Mapbox Vector Tiles"
 hide_title: true
 ---
 
-import Demo from 'examples/website/tiles/app';
+import {ClientExample} from '../../components';
 import {TileDocsTabs} from '@site/src/components/docs/tile-docs-tabs';
 
 <TileDocsTabs active="mvt-example" />
 
 <div style={{height: 'calc(100vh - var(--ifm-navbar-height) - 4rem)'}}> 
-  <Demo format="MVT">
+  <ClientExample kind="tiles" format="MVT">
     [**`MVTSourceLoader`**](/docs/modules/mvt/api-reference/mvt-source-loader) dynamically loads tiles 
     from big pre-tiled hierarchies on cloud storage.
     <small>
       Uses [**`MVTLoader`**](/docs/modules/mvt/api-reference/mvt-loader) for Mapbox Vector Tiles files 
       and [**`ImageLoader`**](/docs/modules/images/api-reference/image-loader) for image tiles (JPEG, PNG etc).
     </small>
-  </Demo>
+  </ClientExample>
 </div>

--- a/website/src/examples/tiles/pmtiles.mdx
+++ b/website/src/examples/tiles/pmtiles.mdx
@@ -3,13 +3,13 @@ title: "PMTiles"
 hide_title: true
 ---
 
-import Demo from 'examples/website/tiles/app';
+import {ClientExample} from '../../components';
 import {TileDocsTabs} from '@site/src/components/docs/tile-docs-tabs';
 
 <TileDocsTabs active="pmtiles-example" />
 
 <div style={{height: 'calc(100vh - var(--ifm-navbar-height) - 4rem)'}}> 
-  <Demo format="PMTILES">
+  <ClientExample kind="tiles" format="PMTILES">
      [**`PMTilesSourceLoader`**](/docs/modules/pmtiles/api-reference/pmtiles-source-loader) **dynamically loads** tiles from a single gigantic PMTiles file on cloud storage using HTTP range requests. 
     <small>
       Uses [**`MVTLoader`**](/docs/modules/mvt/api-reference/mvt-loader) for Mapbox Vector Tiles files.
@@ -20,5 +20,5 @@ import {TileDocsTabs} from '@site/src/components/docs/tile-docs-tabs';
       `yarn serve-range --root ./modules/pmtiles/test/data/pmtiles-v3 --port 9000`, then choose
       the local range server entry.
     </small>
-  </Demo>
+  </ClientExample>
 </div>

--- a/website/src/examples/tiles/table-tiler.mdx
+++ b/website/src/examples/tiles/table-tiler.mdx
@@ -3,13 +3,13 @@ title: "TableTileSourceLoader"
 hide_title: true
 ---
 
-import Demo from 'examples/website/tiles/app';
+import {ClientExample} from '../../components';
 import {TileDocsTabs} from '@site/src/components/docs/tile-docs-tabs';
 
 <TileDocsTabs active="table-tiler-example" />
 
 <div style={{height: 'calc(100vh - var(--ifm-navbar-height) - 4rem)'}}> 
-  <Demo format="GeoJSON">
+  <ClientExample kind="tiles" format="GeoJSON">
     [**`TableTileSourceLoader`**](/docs/modules/mvt/api-reference/table-tile-source-loader) dynamically **generates** tiles from GeoJSON data loaded into the browser.
-  </Demo>
+  </ClientExample>
 </div>

--- a/website/src/examples/tiles/wfs.mdx
+++ b/website/src/examples/tiles/wfs.mdx
@@ -3,11 +3,11 @@ title: "WFS (OGC Web Feature Service)"
 hide_title: true
 ---
 
-import Demo from 'examples/website/wms/app';
+import {ClientExample} from '../../components';
 import {WmsDocsTabs} from '@site/src/components/docs/wms-docs-tabs';
 
 <WmsDocsTabs active="wfs-example" />
 
 <div style={{height: 'calc(100vh - var(--ifm-navbar-height) - 4rem)'}}>
-  <Demo format="WFS" />
+  <ClientExample kind="wms" format="WFS" />
 </div>

--- a/website/src/examples/tiles/wms.mdx
+++ b/website/src/examples/tiles/wms.mdx
@@ -3,13 +3,13 @@ title: "WMS (OGC Web Map Service)"
 hide_title: true
 ---
 
-import Demo from 'examples/website/wms/app';
+import {ClientExample} from '../../components';
 import {WmsDocsTabs} from '@site/src/components/docs/wms-docs-tabs';
 
 <WmsDocsTabs active="wms-example" />
 
 <div style={{height: 'calc(100vh - var(--ifm-navbar-height) - 4rem)'}}>
-  <Demo format="WMS">
+  <ClientExample kind="wms" format="WMS">
     [**`WMSSourceLoader`**](/docs/modules/wms/api-reference/wms-source-loader) loads imagery through `ImageSourceLayer`.
-  </Demo>
+  </ClientExample>
 </div>

--- a/website/src/pages/index.jsx
+++ b/website/src/pages/index.jsx
@@ -1,8 +1,12 @@
 import React from 'react';
-import {Home} from '../components';
+import {ClientExample, Home} from '../components';
 import Layout from '@theme/Layout';
-import HeroExample from '../examples/home-demo';
 import Concepts from '../components/home/concepts';
+
+/** Renders the homepage example behind the shared client-only loading boundary. */
+function HeroExample() {
+  return <ClientExample kind="home" />;
+}
 
 export default function IndexPage() {
   return (


### PR DESCRIPTION
## Goals

- Prevent pages with interactive examples from downloading every example application linked by a visible Docusaurus sidebar.
- Reduce the initial JavaScript payload while preserving the existing example experience.

## Changes

- Add a shared `ClientExample` boundary using `BrowserOnly`, `React.lazy`, and `Suspense`.
- Move example application imports behind dynamic imports so route prefetching only downloads lightweight page modules.
- Migrate the homepage, example pages, and embedded I3S recipes to the shared boundary.
- Preserve existing example props, children, and benchmark loading feedback.

## Root cause

Docusaurus prefetches visible sidebar routes. Those MDX routes statically imported their example applications, so prefetching neighboring pages also downloaded their full application dependency graphs.

## Impact

On the production CSV example page, the browser-loaded JavaScript decreased from 42 scripts / 6.30 MiB to 30 scripts / 1.63 MiB (about 74% fewer raw bytes). The active CSV map and controls still render normally.

## Validation

- `yarn lint fix`
- Repository pre-commit and pre-push lint hooks
- `cd website && yarn build`
- Browser verification of `/examples/geospatial/csv.html` against the production build