### PR TITLE
Fix MVT feature IDs and gzip completion

### DIFF
--- a/apps/tile-converter/src/lib/utils/compress-util.ts
+++ b/apps/tile-converter/src/lib/utils/compress-util.ts
@@ -1,5 +1,6 @@
 import {createGzip} from 'zlib';
 import {createReadStream, createWriteStream} from 'fs';
+import {pipeline} from 'stream';
 
 /**
  * Compress file to gzip file
@@ -14,15 +15,15 @@ export function compressFileWithGzip(pathFile: string): Promise<string> {
   const output = createWriteStream(compressedPathFile);
 
   return new Promise((resolve, reject) => {
-    input.on('end', () => {
+    pipeline(input, gzip, output, error => {
+      if (error) {
+        console.log(`${compressedPathFile}: compression error!`); // eslint-disable-line no-undef,no-console
+        reject(error);
+        return;
+      }
+
       console.log(`${compressedPathFile} compressed and saved.`); // eslint-disable-line no-undef,no-console
       resolve(compressedPathFile);
     });
-    input.on('error', error => {
-      console.log(`${compressedPathFile}: compression error!`); // eslint-disable-line no-undef,no-console
-      reject(error);
-    });
-    // @ts-ignore Seems typescript upgrade triggered this
-    input.pipe(gzip).pipe(output);
   });
 }

--- a/modules/mvt/src/lib/vector-tile/vector-tile-feature.ts
+++ b/modules/mvt/src/lib/vector-tile/vector-tile-feature.ts
@@ -382,8 +382,7 @@ function _toGeoJSONFeature(
   };
 
   if (vtFeature.id !== null) {
-    result.properties ||= {};
-    result.properties.id = vtFeature.id;
+    result.id = vtFeature.id;
   }
 
   return result;

--- a/modules/mvt/test/mvt-feature-id.spec.ts
+++ b/modules/mvt/test/mvt-feature-id.spec.ts
@@ -1,0 +1,32 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {beforeAll, expect, test} from 'vitest';
+import {fetchFile, parse} from '@loaders.gl/core';
+import {MVTLoader} from '@loaders.gl/mvt';
+import type {Feature} from '@loaders.gl/schema';
+
+const WITH_FEATURE_ID = '@loaders.gl/mvt/test/data/mvt/with_feature_id.mvt';
+
+let features: Feature[] = [];
+
+beforeAll(async () => {
+  const response = await fetchFile(WITH_FEATURE_ID);
+  const mvtArrayBuffer = await response.arrayBuffer();
+  const geojsonTable = await parse(mvtArrayBuffer, MVTLoader, {
+    worker: false,
+    mvt: {shape: 'geojson-table'}
+  });
+
+  features = geojsonTable.features;
+});
+
+test('MVTLoader preserves feature IDs as top-level GeoJSON members', () => {
+  expect(features.length).toBeGreaterThan(0);
+
+  for (const feature of features) {
+    expect(feature.id).toBeDefined();
+    expect(feature.properties ?? {}).not.toHaveProperty('id');
+  }
+});

--- a/test/tile-converter-compress.node.spec.ts
+++ b/test/tile-converter-compress.node.spec.ts
@@ -1,0 +1,79 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {afterEach, expect, test} from 'vitest';
+import {build} from 'esbuild';
+import {spawn} from 'node:child_process';
+import {mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join, resolve} from 'node:path';
+import {gunzipSync} from 'node:zlib';
+
+let temporaryDirectory: string | undefined;
+
+afterEach(async () => {
+  if (temporaryDirectory) {
+    await rm(temporaryDirectory, {recursive: true, force: true});
+    temporaryDirectory = undefined;
+  }
+});
+
+test('compressFileWithGzip resolves after writing a complete gzip file', async () => {
+  temporaryDirectory = await mkdtemp(join(tmpdir(), 'loaders-gl-gzip-'));
+  const inputPath = join(temporaryDirectory, 'input.bin');
+  const inputData = new Uint8Array(768 * 1024);
+  let randomState = 0x12345678;
+
+  for (let index = 0; index < inputData.length; index++) {
+    randomState ^= randomState << 13;
+    randomState ^= randomState >>> 17;
+    randomState ^= randomState << 5;
+    inputData[index] = randomState & 0xff;
+  }
+
+  await writeFile(inputPath, inputData);
+
+  const compressModulePath = resolve('apps/tile-converter/src/lib/utils/compress-util.ts');
+  const buildResult = await build({
+    bundle: true,
+    format: 'esm',
+    platform: 'node',
+    stdin: {
+      contents: `
+        import {compressFileWithGzip} from ${JSON.stringify(compressModulePath)};
+        await compressFileWithGzip(process.argv[1]);
+        process.exit(0);
+      `,
+      loader: 'ts',
+      resolveDir: process.cwd()
+    },
+    write: false
+  });
+  const childScript = buildResult.outputFiles[0].text;
+  const childProcess = spawn(
+    process.execPath,
+    ['--input-type=module', '--eval', childScript, inputPath],
+    {stdio: 'ignore'}
+  );
+
+  await new Promise<void>((resolveChildProcess, rejectChildProcess) => {
+    childProcess.on('error', rejectChildProcess);
+    childProcess.on('exit', (exitCode, signal) => {
+      if (exitCode === 0) {
+        resolveChildProcess();
+      } else {
+        rejectChildProcess(
+          new Error(`Compression child process exited with code ${exitCode} and signal ${signal}`)
+        );
+      }
+    });
+  });
+
+  const compressedPath = `${inputPath}.gz`;
+  const compressedData = await readFile(compressedPath);
+
+  expect(compressedPath).toBe(`${inputPath}.gz`);
+  expect([...compressedData.subarray(0, 2)]).toEqual([0x1f, 0x8b]);
+  expect(gunzipSync(compressedData).equals(inputData)).toBe(true);
+});


### PR DESCRIPTION
## Goals

- Preserve MVT feature IDs in the GeoJSON-standard top-level `Feature.id` field.
- Prevent tile-converter gzip promises from resolving before compressed output is complete.
- Fixes #3197.
- Fixes #3550.

## Changes

- Assign decoded vector-tile IDs to `feature.id` instead of `feature.properties.id`.
- Use Node's stream `pipeline()` so gzip completion waits for the output stream and propagates errors from every stage.
- Add a native Vitest regression for MVT feature ID placement.
- Add a Node-only regression that exits immediately after compression resolves and verifies the resulting gzip can be fully decompressed.

## Root causes

- The GeoJSON conversion path copied MVT IDs into the properties object rather than the standard top-level ID member.
- `compressFileWithGzip` resolved on the input stream's `end` event, which can occur before gzip finalization and output flushing.

## Validation

- `yarn install`
- `yarn lint fix`
- `yarn build`
- `yarn build-workers`
- `yarn test-node` — 426 files passed, 2,061 tests passed
- `yarn test-headless` — 424 files passed, 2,007 tests passed
- Post-rebase focused Node tests — 2 tests passed

`yarn test-audit` is not available as a script on the current `master` branch.