### PR TITLE
ci: publish master website to /next

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -3,6 +3,7 @@ name: website-deploy
 on:
   push:
     branches:
+      - master
       - 4.4-release
   workflow_dispatch:
 


### PR DESCRIPTION
## Goals

Publish the latest loaders.gl website from `master` at `/next/` automatically while keeping the release website at the root URL unchanged.

## Changes

- trigger the website deployment workflow on pushes to `master`
- reuse the existing branch-aware configuration that builds `master` with `DOCUSAURUS_BASE_URL=/next/`
- continue publishing `4.4-release` at the root and preserving the `next` deployment folder

## Root cause

The workflow already resolved `master` to the `next` target folder, but `master` was missing from the workflow's push branch filter. As a result, that deployment path could only be reached through a manual workflow dispatch.

## Validation

- `DOCUSAURUS_BASE_URL=/next/ yarn build`
- workflow YAML parse and trigger assertion
- `yarn lint fix`
- `git diff --check`
