### PR TITLE
fix(zarr): address GeoZarr example review feedback

### DIFF
--- a/examples/website/geozarr/app.tsx
+++ b/examples/website/geozarr/app.tsx
@@ -167,15 +167,15 @@ export default function App(props: AppProps = {}) {
   }, [metadata, source, timeIndex]);
 
   useEffect(() => {
-    if (!playing) {
+    if (!playing || loading) {
       return;
     }
-    const interval = globalThis.setInterval(
+    const timeout = globalThis.setTimeout(
       () => setTimeIndex(currentTimeIndex => (currentTimeIndex + 1) % TIME_LABELS.length),
       1200
     );
-    return () => globalThis.clearInterval(interval);
-  }, [playing]);
+    return () => globalThis.clearTimeout(timeout);
+  }, [loading, playing, timeIndex]);
 
   const layers = useMemo(
     () =>
@@ -268,7 +268,7 @@ function renderRaster(
       const sourceIndex = row * raster.width + column;
       const targetIndex = (targetRow * raster.width + column) * 4;
       const value = source[sourceIndex];
-      if (!Number.isFinite(value)) {
+      if (!Number.isFinite(value) || value === raster.noData) {
         imageData.data[targetIndex + 3] = 0;
         continue;
       }


### PR DESCRIPTION
## Goals

- Correct two edge cases identified during review of the GeoZarr deck.gl example.
- Keep slow-network playback reliable and prevent finite missing-value sentinels from affecting visualization statistics.

## Changes

- Treat `raster.noData` samples as transparent and exclude them from the displayed minimum and maximum.
- Replace fixed-interval playback with a one-shot timeout that advances only after the current raster load completes.
- Reset the playback delay after each accepted time selection.

## Root cause and impact

The original example only rejected non-finite samples, so finite `_FillValue` / `missing_value` sentinels could be rendered as valid data. Playback also advanced every 1.2 seconds regardless of request state, repeatedly aborting loads on slower connections. These fixes preserve accurate statistics and ensure each animation frame can finish loading.

## Validation

- `yarn install`
- `yarn lint fix`
- `yarn workspace geozarr-deck-example build`
- `yarn workspace project-website build`
- `yarn build`
- `yarn build-workers`
- `yarn test-node` — 189 passed, 6 skipped
- `yarn test-headless` — 1,877 passed, 50 skipped