### PR TITLE
fix(json): support WKT geometry columns

### DIFF
--- a/modules/json/src/lib/encoder-utils/encode-table-row.ts
+++ b/modules/json/src/lib/encoder-utils/encode-table-row.ts
@@ -3,9 +3,9 @@
 // Copyright (c) vis.gl contributors
 // Copyright 2022 Foursquare Labs, Inc.
 
-import type {Feature, Table} from '@loaders.gl/schema';
+import type {Feature, Geometry, Table} from '@loaders.gl/schema';
 import {getTableRowAsObject} from '@loaders.gl/schema-utils';
-import {getRowPropertyObject} from './encode-utils';
+import {getRowPropertyObject, parseGeometryString} from './encode-utils';
 import {Utf8ArrayBufferEncoder} from './utf8-encoder';
 
 type Row = {[key: string]: unknown};
@@ -38,7 +38,7 @@ function getFeatureFromRow(table: Table, row: Row, geometryColumnIndex: number):
   // Extract geometry feature
   const columnName = table.schema?.fields[geometryColumnIndex].name;
   let featureOrGeometry =
-    columnName && (row[columnName] as {[key: string]: unknown} | string | null | undefined);
+    columnName && (row[columnName] as Feature | Geometry | string | null | undefined);
 
   // GeoJSON support null geometries
   if (!featureOrGeometry) {
@@ -46,15 +46,12 @@ function getFeatureFromRow(table: Table, row: Row, geometryColumnIndex: number):
     return {type: 'Feature', geometry: null, properties};
   }
 
-  // Support string geometries?
-  // TODO: This assumes GeoJSON strings, which may not be the correct format
-  // (could be WKT, encoded WKB...)
   if (typeof featureOrGeometry === 'string') {
-    try {
-      featureOrGeometry = JSON.parse(featureOrGeometry);
-    } catch (_err) {
+    const parsedGeometry = parseGeometryString(featureOrGeometry);
+    if (!parsedGeometry) {
       throw new Error('Invalid string geometry');
     }
+    featureOrGeometry = parsedGeometry;
   }
 
   if (typeof featureOrGeometry !== 'object' || typeof featureOrGeometry?.type !== 'string') {

--- a/modules/json/src/lib/encoder-utils/encode-utils.ts
+++ b/modules/json/src/lib/encoder-utils/encode-utils.ts
@@ -3,8 +3,14 @@
 // Copyright (c) vis.gl contributors
 // Copyright 2022 Foursquare Labs, Inc.
 
-import type {Table} from '@loaders.gl/schema';
-import {getTableLength, getTableNumCols, getTableRowAsArray} from '@loaders.gl/schema-utils';
+import {GeometryConverter} from '@loaders.gl/gis';
+import type {Feature, Geometry, Table} from '@loaders.gl/schema';
+import {
+  convert,
+  getTableLength,
+  getTableNumCols,
+  getTableRowAsArray
+} from '@loaders.gl/schema-utils';
 
 type Row = {[key: string]: unknown};
 
@@ -29,13 +35,44 @@ export function detectGeometryColumnIndex(table: Table): number {
     const row = getTableRowAsArray(table, 0);
     for (let columnIndex = 0; columnIndex < getTableNumCols(table); columnIndex++) {
       const value = row?.[columnIndex];
-      if (value && typeof value === 'object') {
+      if (
+        value &&
+        (typeof value === 'object' ||
+          (typeof value === 'string' && parseGeometryString(value) !== null))
+      ) {
         return columnIndex;
       }
     }
   }
 
   throw new Error('Failed to detect geometry column');
+}
+
+/**
+ * Parses a GeoJSON- or WKT-encoded geometry string.
+ * @param value String containing a GeoJSON feature/geometry or WKT geometry.
+ * @returns The parsed feature or geometry, or `null` when the string is not a supported geometry.
+ */
+export function parseGeometryString(value: string): Feature | Geometry | null {
+  let parsedValue: unknown;
+  try {
+    parsedValue = JSON.parse(value);
+  } catch {
+    try {
+      parsedValue = convert(value, 'geojson-geometry', GeometryConverter);
+    } catch {
+      return null;
+    }
+  }
+
+  return isFeatureOrGeometry(parsedValue) ? parsedValue : null;
+}
+
+/** Returns whether a value looks like a GeoJSON feature or geometry. */
+function isFeatureOrGeometry(value: unknown): value is Feature | Geometry {
+  return (
+    typeof value === 'object' && value !== null && 'type' in value && typeof value.type === 'string'
+  );
 }
 
 /**

--- a/modules/json/test/geojson-writer-wkt.spec.ts
+++ b/modules/json/test/geojson-writer-wkt.spec.ts
@@ -1,0 +1,36 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+
+import {encodeTableAsText} from '@loaders.gl/core';
+import {GeoJSONWriter} from '@loaders.gl/json';
+import type {ObjectRowTable} from '@loaders.gl/schema';
+
+test('GeoJSONWriter auto-detects and converts a WKT geometry column', async () => {
+  const table: ObjectRowTable = {
+    shape: 'object-row-table',
+    schema: {
+      fields: [
+        {name: 'name', type: 'utf8'},
+        {name: 'location', type: 'utf8'}
+      ],
+      metadata: {}
+    },
+    data: [{name: 'origin', location: 'POINT (1 2)'}]
+  };
+
+  const encodedText = await encodeTableAsText(table, GeoJSONWriter);
+
+  expect(JSON.parse(encodedText)).toEqual({
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        geometry: {type: 'Point', coordinates: [1, 2]},
+        properties: {name: 'origin'}
+      }
+    ]
+  });
+});


### PR DESCRIPTION
## Goals

- Allow `GeoJSONWriter` to recognize WKT geometry columns without requiring `geojson.geometryColumn`.
- Preserve existing GeoJSON-string handling while converting WKT strings to GeoJSON geometry.
- Fixes #2487.

## Actual changes

- Parse string geometry cells as GeoJSON first, then fall back to the shared WKT geometry converter.
- Include supported geometry strings in geometry-column auto-detection.
- Add a native Vitest regression covering a nonstandard WKT column name after an ordinary string column.

## Validation

- `yarn install`
- `yarn lint fix`
- `yarn test-audit` — 462 files, 0 Tape, 0 violations
- `yarn build`
- `yarn build-workers`
- `yarn test-node` — 27 files passed; 189 tests passed, 6 skipped
- `yarn test-headless` — 357 files passed, 2 skipped; 1,878 tests passed, 50 skipped