### PR TITLE
perf(parquet): decode columns directly into Arrow buffers

### DIFF
--- a/docs/developer-guide/concepts/javascript-and-wasm-performance.md
+++ b/docs/developer-guide/concepts/javascript-and-wasm-performance.md
@@ -1,0 +1,79 @@
+# JavaScript and WebAssembly Performance
+
+WebAssembly (WASM) makes code written in languages such as Rust and C++ available in browsers. It
+can deliver excellent performance, particularly for dense computation with predictable memory
+access. It does not, however, make an entire data-loading pipeline faster by itself. JavaScript or
+TypeScript loaders can be faster and smaller when they perform less total work around the decode
+kernel.
+
+The useful comparison is therefore between complete loader pipelines, measured with representative
+data and output shapes, rather than between source languages.
+
+## Where WASM Excels
+
+WASM is often a strong choice when:
+
+- most elapsed time is spent in a compute-heavy inner loop
+- the algorithm maps cleanly to linear memory
+- input and output can remain in WASM memory for a substantial amount of work
+- a mature native implementation already provides broad format conformance
+- the module's download, compilation, and initialization costs are amortized over large inputs
+
+Compression, cryptography, numerical transforms, and complex entropy decoders often fit this
+profile.
+
+## Where JavaScript and TypeScript Can Win
+
+A JavaScript or TypeScript loader can outperform a WASM loader end to end when it combines several
+pipeline advantages:
+
+- **Selective I/O:** range requests, column projection, spatial selection, or field-layer selection
+  can avoid downloading and decoding irrelevant bytes.
+- **Direct output construction:** decoded values can be written directly into TypedArray, Arrow, or
+  GPU-ready buffers instead of being materialized as intermediate objects.
+- **Fewer memory copies:** WASM normally uses a separate linear memory. Moving data into that memory
+  and converting results back into JavaScript-owned structures can cost more than the decode kernel.
+- **Fewer boundary crossings:** repeated small calls between JavaScript and WASM are more expensive
+  than a small number of coarse calls.
+- **Browser-native facilities:** built-in streams and supported decompression formats can avoid
+  shipping another implementation and may use optimized platform code.
+- **Lazy code loading:** a focused TypeScript path and dynamically loaded codecs can have a smaller
+  startup and transfer cost than a general WASM binary containing every feature.
+- **Pipeline fusion:** parsing, validation, dictionary expansion, null handling, and final buffer
+  construction can share one pass over the data.
+
+These advantages do not imply that JavaScript has a faster instruction loop. They mean that loader
+architecture can eliminate enough I/O, allocation, copying, and conversion to outweigh a slower
+individual kernel.
+
+## Format Examples
+
+Parquet is naturally selective: its footer, row groups, column chunks, statistics, bloom filters,
+and page indexes can identify small byte ranges that satisfy a projection or filter. A loader that
+reads only those ranges and decodes directly into Arrow buffers may do substantially less work than
+a faster general-purpose decoder that materializes every selected value through intermediate
+representations.
+
+LAZ and COPC offer similar opportunities. A loader can request only relevant COPC nodes, decode only
+the LAZ field layers needed by the selected output schema, and write point attributes directly into
+their final typed columns. The arithmetic decoder is important, but it is only one stage of that
+pipeline.
+
+## How to Compare Implementations
+
+Measure the operation the application actually needs, including:
+
+- cold startup and warmed-up throughput
+- bytes fetched and decoded after projection or filtering
+- time to first useful batch and total elapsed time
+- peak and retained memory, including both JavaScript and WASM memory
+- final output construction and worker transfer costs
+- JavaScript, worker, codec, and WASM asset sizes
+- correctness across realistic encodings, compressions, schemas, null patterns, and input sizes
+
+Use multiple demanding cases. Tiny inputs expose startup costs; large and varied inputs expose
+sustained decode performance and memory behavior. A result for object rows does not predict the
+result for Arrow tables, and a full-file result does not predict a selective range scan.
+
+The practical rule is simple: choose implementations using reproducible end-to-end measurements.
+Treat language and runtime as design constraints, not performance conclusions.

--- a/docs/docs-sidebar.json
+++ b/docs/docs-sidebar.json
@@ -661,6 +661,7 @@
         "label": "Concepts",
         "items": [
           "developer-guide/concepts/javascript-apis",
+          "developer-guide/concepts/javascript-and-wasm-performance",
           "developer-guide/concepts/binary-data",
           "developer-guide/concepts/streaming",
           "developer-guide/concepts/async-iterators",

--- a/docs/modules/las/api-reference/las-loader.md
+++ b/docs/modules/las/api-reference/las-loader.md
@@ -43,6 +43,9 @@ const copcDecodedData = await load(url, LASCOPCLoader, options);
 | `LAZRsLoader` | Rust/WASM laz-rs | No | Compatibility and parity-testing variant. |
 
 Loader variants are selected by the loader import. There is no runtime backend option.
+See [JavaScript and WebAssembly performance](/docs/developer-guide/concepts/javascript-and-wasm-performance)
+for the pipeline effects that can let the TypeScript loader outperform a WASM variant, including
+selective field decoding, direct typed output, memory copies, and module startup.
 
 ## Options
 

--- a/docs/modules/parquet/api-reference/parquet-loader.md
+++ b/docs/modules/parquet/api-reference/parquet-loader.md
@@ -170,6 +170,9 @@ Supports table category options such as `batchType` and `batchSize`.
   `batchSize`, and `preserveBinary`.
 
 The implementation is selected by the loader import. There is no runtime backend option.
+The [JavaScript and WebAssembly performance](/docs/developer-guide/concepts/javascript-and-wasm-performance)
+concept guide explains why selective I/O, direct Arrow construction, memory copies, and startup cost
+can matter more than the language used for a decoder's inner loop.
 
 ```typescript
 import {load} from '@loaders.gl/core';
@@ -190,6 +193,10 @@ Arrow batches and preserves compatible GeoParquet metadata on the Arrow schema. 
 and value buffers without converting their bytes through JavaScript strings or copying every value
 into an intermediate buffer. Nested schemas use the object-row materializer as a compatibility
 fallback.
+
+Physical Parquet `INT64` columns map to Arrow `Int64`. Both Arrow and object-row output return exact
+JavaScript `bigint` values; callers that accept precision loss can convert them to `number`
+explicitly.
 
 ## Worker Execution
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -130,6 +130,7 @@ This unifies top-level loading behavior:
 - `ParquetJSONLoader` and `ParquetJSONWriter` compatibility aliases have been removed. Use `ParquetLoader`, `ParquetWriter`, `ParquetJSLoader`, or `ParquetJSWriter` instead depending on the backend you want.
 - `ParquetLoader` and `ParquetWriter` remain the canonical wasm-backed APIs. The experimental parquetjs backend now lives behind the explicit `ParquetJSLoader` and `ParquetJSWriter` exports.
 - `parquet.backend` and the deprecated `parquet.implementation` options have been removed. Import `ParquetLoader` for WASM or `ParquetJSLoader` for the TypeScript parquetjs implementation.
+- Unannotated Parquet `INT64` values now remain exact: Arrow output uses Arrow `Int64`, and object-row output uses JavaScript `bigint`. `ParquetJSWriter` accepts `bigint` and rejects unsafe `number` inputs for these fields rather than silently rounding them. Convert to `number` explicitly only when values are known to remain within JavaScript's safe integer range.
 
 **@loaders.gl/images**
 

--- a/modules/parquet/src/lib/arrow/convert-schema-from-parquet.ts
+++ b/modules/parquet/src/lib/arrow/convert-schema-from-parquet.ts
@@ -11,7 +11,7 @@ import {FileMetaData} from '../../parquetjs/parquet-thrift';
 export const PARQUET_TYPE_MAPPING: {[type in ParquetType]: DataType} = {
   BOOLEAN: 'bool',
   INT32: 'int32',
-  INT64: 'float64',
+  INT64: 'int64',
   INT96: 'float64',
   FLOAT: 'float32',
   DOUBLE: 'float64',

--- a/modules/parquet/src/lib/arrow/convert-schema-to-parquet.ts
+++ b/modules/parquet/src/lib/arrow/convert-schema-to-parquet.ts
@@ -18,7 +18,7 @@ import {
 export const PARQUET_TYPE_MAPPING: {[type in ParquetType]: DataType} = {
   BOOLEAN: 'bool',
   INT32: 'int32',
-  INT64: 'float64',
+  INT64: 'int64',
   INT96: 'float64',
   FLOAT: 'float32',
   DOUBLE: 'float64',

--- a/modules/parquet/src/lib/parsers/parse-parquet-to-arrow-js.ts
+++ b/modules/parquet/src/lib/parsers/parse-parquet-to-arrow-js.ts
@@ -145,7 +145,8 @@ export async function* parseParquetFileToArrowInBatchesWithJs(
 
   const reader = new ParquetReader(file, {
     preserveBinary: options?.parquet?.preserveBinary,
-    retainByteArrayViews: true
+    retainByteArrayViews: true,
+    useTypedValueBuffers: true
   });
   const schema = projectSchema(await getSchemaFromParquetReader(reader), options?.parquet?.columns);
   const arrowSchema = createParquetArrowSchema(schema);
@@ -353,7 +354,7 @@ function createParquetRecordBatch(
 }
 
 /** Typed arrays accepted by the direct primitive Arrow materialization path. */
-type RawPrimitiveArrowArray = Float32Array | Float64Array | Int32Array;
+type RawPrimitiveArrowArray = Float32Array | Float64Array | Int32Array | BigInt64Array;
 
 /** Creates a fixed-width Arrow vector directly from decoded primitive Parquet values. */
 function createRawPrimitiveArrowVector(
@@ -367,7 +368,14 @@ function createRawPrimitiveArrowVector(
     return undefined;
   }
   const rowCount = end - start;
-  const data = createRawPrimitiveArrowArray(arrowType, parquetField, rowCount);
+  const directData = createRawPrimitiveArrowArrayView(
+    arrowType,
+    parquetField,
+    columnData,
+    start,
+    end
+  );
+  const data = directData || createRawPrimitiveArrowArray(arrowType, parquetField, rowCount);
   if (!data) {
     return undefined;
   }
@@ -377,9 +385,11 @@ function createRawPrimitiveArrowVector(
   let nullCount = 0;
 
   if (!nullBitmap) {
-    valueIndex = start;
-    for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
-      data[rowIndex] = Number(columnData.values[valueIndex++]);
+    if (!directData) {
+      valueIndex = start;
+      for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+        setRawPrimitiveArrowValue(data, rowIndex, columnData.values[valueIndex++]);
+      }
     }
   } else {
     for (let rowIndex = 0; rowIndex < start; rowIndex++) {
@@ -390,7 +400,7 @@ function createRawPrimitiveArrowVector(
     for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
       const sourceRowIndex = start + rowIndex;
       if (columnData.dlevels[sourceRowIndex] === parquetField.dLevelMax) {
-        data[rowIndex] = Number(columnData.values[valueIndex++]);
+        setRawPrimitiveArrowValue(data, rowIndex, columnData.values[valueIndex++]);
         nullBitmap[rowIndex >> 3] |= 1 << (rowIndex & 7);
       } else {
         nullCount++;
@@ -404,13 +414,60 @@ function createRawPrimitiveArrowVector(
   ]);
 }
 
+/** Reuses a typed decoded column as the Arrow value buffer for required primitive fields. */
+function createRawPrimitiveArrowArrayView(
+  arrowType: arrow.DataType,
+  parquetField: ParquetField,
+  columnData: ParquetColumnChunk,
+  start: number,
+  end: number
+): RawPrimitiveArrowArray | undefined {
+  if (
+    parquetField.repetitionType !== 'REQUIRED' ||
+    (parquetField.originalType && parquetField.originalType !== 'INT_64')
+  ) {
+    return undefined;
+  }
+  const values = columnData.values;
+  if (
+    parquetField.primitiveType === 'FLOAT' &&
+    arrowType instanceof arrow.Float32 &&
+    values instanceof Float32Array
+  ) {
+    return values.subarray(start, end);
+  }
+  if (
+    parquetField.primitiveType === 'DOUBLE' &&
+    arrowType instanceof arrow.Float64 &&
+    values instanceof Float64Array
+  ) {
+    return values.subarray(start, end);
+  }
+  if (
+    parquetField.primitiveType === 'INT32' &&
+    arrowType instanceof arrow.Int32 &&
+    values instanceof Int32Array
+  ) {
+    return values.subarray(start, end);
+  }
+  if (
+    parquetField.primitiveType === 'INT64' &&
+    (!parquetField.originalType || parquetField.originalType === 'INT_64') &&
+    arrowType instanceof arrow.Int64 &&
+    values instanceof BigInt64Array
+  ) {
+    return values.subarray(start, end);
+  }
+  return undefined;
+}
+
 /** Allocates the Arrow typed array matching an unconverted physical Parquet primitive. */
 function createRawPrimitiveArrowArray(
   arrowType: arrow.DataType,
   parquetField: ParquetField,
   rowCount: number
 ): RawPrimitiveArrowArray | undefined {
-  if (parquetField.originalType) {
+  if (parquetField.originalType && parquetField.originalType !== 'INT_64') {
     return undefined;
   }
   if (parquetField.primitiveType === 'FLOAT' && arrowType instanceof arrow.Float32) {
@@ -422,7 +479,27 @@ function createRawPrimitiveArrowArray(
   if (parquetField.primitiveType === 'INT32' && arrowType instanceof arrow.Int32) {
     return new Int32Array(rowCount);
   }
+  if (
+    parquetField.primitiveType === 'INT64' &&
+    (!parquetField.originalType || parquetField.originalType === 'INT_64') &&
+    arrowType instanceof arrow.Int64
+  ) {
+    return new BigInt64Array(rowCount);
+  }
   return undefined;
+}
+
+/** Writes a decoded primitive into the exact TypedArray expected by Arrow. */
+function setRawPrimitiveArrowValue(
+  data: RawPrimitiveArrowArray,
+  index: number,
+  value: unknown
+): void {
+  if (data instanceof BigInt64Array) {
+    data[index] = typeof value === 'bigint' ? value : BigInt(value as number | string);
+  } else {
+    data[index] = Number(value);
+  }
 }
 
 /** Creates an Arrow Utf8 or Binary vector directly from decoded Parquet byte arrays. */

--- a/modules/parquet/src/parquetjs/codecs/declare.ts
+++ b/modules/parquet/src/parquetjs/codecs/declare.ts
@@ -6,6 +6,15 @@
 
 import {PrimitiveType} from '../schema/declare';
 
+/** Mutable destination accepted by Parquet value decoders. */
+export type ParquetValueBuffer =
+  | unknown[]
+  | Uint8Array
+  | Int32Array
+  | BigInt64Array
+  | Float32Array
+  | Float64Array;
+
 export interface CursorBuffer {
   buffer: Uint8Array;
   offset: number;
@@ -18,6 +27,14 @@ export interface ParquetCodecOptions {
   /** Retain byte arrays as views into the decoded page buffer. */
   retainByteArrayViews?: boolean;
   typeLength?: number;
+  /** Optional destination that lets a codec avoid allocating a page-local values array. */
+  output?: ParquetValueBuffer;
+  /** First element in `output` written by the codec. */
+  outputOffset?: number;
+  /** Optional dictionary resolved while decoding dictionary indices. */
+  dictionary?: readonly unknown[];
+  /** Preserve decoded INT64 values as bigint instead of converting them to number. */
+  int64AsBigInt?: boolean;
 }
 
 export interface ParquetCodecKit {
@@ -27,5 +44,16 @@ export interface ParquetCodecKit {
     cursor: CursorBuffer,
     count: number,
     opts: ParquetCodecOptions
-  ): any[];
+  ): ParquetValueBuffer;
+}
+
+/** Allocates a page-local output or returns the caller-provided column destination. */
+export function getParquetValueOutput(
+  options: ParquetCodecOptions,
+  count: number
+): {output: ParquetValueBuffer; outputOffset: number} {
+  return {
+    output: options.output || new Array<unknown>(count),
+    outputOffset: options.outputOffset || 0
+  };
 }

--- a/modules/parquet/src/parquetjs/codecs/delta.ts
+++ b/modules/parquet/src/parquetjs/codecs/delta.ts
@@ -5,7 +5,12 @@
 
 import type {PrimitiveType} from '../schema/declare';
 import {copyUint8Array} from '../utils/binary-utils';
-import type {CursorBuffer, ParquetCodecOptions} from './declare';
+import {
+  getParquetValueOutput,
+  type CursorBuffer,
+  type ParquetCodecOptions,
+  type ParquetValueBuffer
+} from './declare';
 
 /** Delta encodings are currently decoder-only in loaders.gl. */
 export function encodeValues(
@@ -21,13 +26,13 @@ export function decodeDeltaBinaryPackedValues(
   type: PrimitiveType,
   cursor: CursorBuffer,
   count: number,
-  _options: ParquetCodecOptions
-): number[] {
+  options: ParquetCodecOptions
+): ParquetValueBuffer {
   if (type !== 'INT32' && type !== 'INT64') {
     throw new Error(`DELTA_BINARY_PACKED does not support Parquet type ${type}`);
   }
   if (count === 0) {
-    return [];
+    return getParquetValueOutput(options, 0).output;
   }
 
   const blockSize = readUnsignedVarIntNumber(cursor);
@@ -48,8 +53,14 @@ export function decodeDeltaBinaryPackedValues(
   }
 
   return type === 'INT32'
-    ? decodeDeltaBinaryPackedInt32Values(cursor, count, miniBlockCount, valuesPerMiniBlock)
-    : decodeDeltaBinaryPackedInt64Values(cursor, count, miniBlockCount, valuesPerMiniBlock);
+    ? decodeDeltaBinaryPackedInt32Values(cursor, count, miniBlockCount, valuesPerMiniBlock, options)
+    : decodeDeltaBinaryPackedInt64Values(
+        cursor,
+        count,
+        miniBlockCount,
+        valuesPerMiniBlock,
+        options
+      );
 }
 
 /** Decodes DELTA_BINARY_PACKED INT32 values without entering the BigInt hot path. */
@@ -57,12 +68,13 @@ function decodeDeltaBinaryPackedInt32Values(
   cursor: CursorBuffer,
   count: number,
   miniBlockCount: number,
-  valuesPerMiniBlock: number
-): number[] {
-  const values = new Array<number>(count);
+  valuesPerMiniBlock: number,
+  options: ParquetCodecOptions
+): ParquetValueBuffer {
+  const {output, outputOffset} = getParquetValueOutput(options, count);
   let value = readZigZagVarInt32(cursor);
   let outputIndex = 0;
-  values[outputIndex++] = value;
+  output[outputOffset + outputIndex++] = value;
 
   while (outputIndex < count) {
     const minimumDelta = readZigZagVarInt32(cursor);
@@ -79,8 +91,8 @@ function decodeDeltaBinaryPackedInt32Values(
         valueCount,
         minimumDelta,
         value,
-        values,
-        outputIndex
+        output,
+        outputOffset + outputIndex
       );
       outputIndex += valueCount;
       cursor.offset += packedByteLength;
@@ -90,7 +102,7 @@ function decodeDeltaBinaryPackedInt32Values(
     }
   }
 
-  return values;
+  return output;
 }
 
 /** Decodes one INT32 mini-block with an exact number-based bit reservoir. */
@@ -101,7 +113,7 @@ function decodeInt32MiniBlock(
   count: number,
   minimumDelta: number,
   initialValue: number,
-  output: number[],
+  output: ParquetValueBuffer,
   outputOffset: number
 ): number {
   let value = initialValue;
@@ -136,12 +148,13 @@ function decodeDeltaBinaryPackedInt64Values(
   cursor: CursorBuffer,
   count: number,
   miniBlockCount: number,
-  valuesPerMiniBlock: number
-): number[] {
-  const values = new Array<number>(count);
+  valuesPerMiniBlock: number,
+  options: ParquetCodecOptions
+): ParquetValueBuffer {
+  const {output, outputOffset} = getParquetValueOutput(options, count);
   let value = readZigZagVarInt(cursor);
   let outputIndex = 0;
-  values[outputIndex++] = Number(BigInt.asIntN(64, value));
+  writeInt64Output(output, outputOffset + outputIndex++, value, options.int64AsBigInt);
 
   while (outputIndex < count) {
     const minimumDelta = readZigZagVarInt(cursor);
@@ -158,8 +171,9 @@ function decodeDeltaBinaryPackedInt64Values(
         valueCount,
         minimumDelta,
         value,
-        values,
-        outputIndex
+        output,
+        outputOffset + outputIndex,
+        options.int64AsBigInt
       );
       outputIndex += valueCount;
       cursor.offset += packedByteLength;
@@ -169,7 +183,7 @@ function decodeDeltaBinaryPackedInt64Values(
     }
   }
 
-  return values;
+  return output;
 }
 
 /** Decodes one INT64 mini-block, using numbers whenever the packed value remains exact. */
@@ -180,14 +194,15 @@ function decodeInt64MiniBlock(
   count: number,
   minimumDelta: bigint,
   initialValue: bigint,
-  output: number[],
-  outputOffset: number
+  output: ParquetValueBuffer,
+  outputOffset: number,
+  int64AsBigInt: boolean | undefined
 ): bigint {
   let value = initialValue;
   if (bitWidth === 0) {
     for (let index = 0; index < count; index++) {
       value += minimumDelta;
-      output[outputOffset + index] = Number(BigInt.asIntN(64, value));
+      writeInt64Output(output, outputOffset + index, value, int64AsBigInt);
     }
     return value;
   }
@@ -206,7 +221,7 @@ function decodeInt64MiniBlock(
       packedBits = Math.floor(packedBits / divisor);
       packedBitCount -= bitWidth;
       value += minimumDelta + BigInt(packedDelta);
-      output[outputOffset + index] = Number(BigInt.asIntN(64, value));
+      writeInt64Output(output, outputOffset + index, value, int64AsBigInt);
     }
     return value;
   }
@@ -232,9 +247,21 @@ function decodeInt64MiniBlock(
     packedBits >>= bitWidthBigInt;
     packedBitCount -= bitWidth;
     value += minimumDelta + packedDelta;
-    output[outputOffset + index] = Number(BigInt.asIntN(64, value));
+    writeInt64Output(output, outputOffset + index, value, int64AsBigInt);
   }
   return value;
+}
+
+/** Writes one signed INT64 without a bigint-to-number round trip for Arrow destinations. */
+function writeInt64Output(
+  output: ParquetValueBuffer,
+  outputIndex: number,
+  value: bigint,
+  int64AsBigInt: boolean | undefined
+): void {
+  (output as unknown[])[outputIndex] = int64AsBigInt
+    ? BigInt.asIntN(64, value)
+    : Number(BigInt.asIntN(64, value));
 }
 
 /** Decodes lengths with delta packing followed by contiguous byte-array payloads. */
@@ -243,10 +270,14 @@ export function decodeDeltaLengthByteArrayValues(
   cursor: CursorBuffer,
   count: number,
   options: ParquetCodecOptions
-): Uint8Array[] {
+): ParquetValueBuffer {
   assertByteArrayType(type, 'DELTA_LENGTH_BYTE_ARRAY');
-  const lengths = decodeDeltaBinaryPackedValues('INT32', cursor, count, options);
-  return lengths.map(length => readByteArray(cursor, length));
+  const lengths = decodeDeltaBinaryPackedValues('INT32', cursor, count, {});
+  const {output, outputOffset} = getParquetValueOutput(options, count);
+  for (let index = 0; index < count; index++) {
+    output[outputOffset + index] = readByteArray(cursor, Number(lengths[index]));
+  }
+  return output;
 }
 
 /** Decodes prefix lengths and delta-length suffixes into complete byte-array values. */
@@ -255,30 +286,32 @@ export function decodeDeltaByteArrayValues(
   cursor: CursorBuffer,
   count: number,
   options: ParquetCodecOptions
-): Uint8Array[] {
+): ParquetValueBuffer {
   assertByteArrayType(type, 'DELTA_BYTE_ARRAY');
-  const prefixLengths = decodeDeltaBinaryPackedValues('INT32', cursor, count, options);
-  const suffixes = decodeDeltaLengthByteArrayValues(type, cursor, count, options);
-  const values: Uint8Array[] = [];
+  const prefixLengths = decodeDeltaBinaryPackedValues('INT32', cursor, count, {});
+  const suffixes = decodeDeltaLengthByteArrayValues(type, cursor, count, {});
+  const {output, outputOffset} = getParquetValueOutput(options, count);
+  let previousValue: Uint8Array | undefined;
 
   for (let index = 0; index < count; index++) {
-    const previousValue = values[index - 1];
-    const prefixLength = prefixLengths[index];
-    const suffix = suffixes[index];
+    const prefixLength = Number(prefixLengths[index]);
+    const suffix = suffixes[index] as Uint8Array;
     if (prefixLength < 0 || (prefixLength > 0 && prefixLength > (previousValue?.length || 0))) {
       throw new Error(`Invalid DELTA_BYTE_ARRAY prefix length ${prefixLength}`);
     }
     if (prefixLength === 0) {
-      values.push(suffix);
+      output[outputOffset + index] = suffix;
+      previousValue = suffix;
       continue;
     }
     const value = new Uint8Array(prefixLength + suffix.length);
-    value.set(previousValue.subarray(0, prefixLength));
+    value.set(previousValue!.subarray(0, prefixLength));
     value.set(suffix, prefixLength);
-    values.push(value);
+    output[outputOffset + index] = value;
+    previousValue = value;
   }
 
-  return values;
+  return output;
 }
 
 /** Reads and validates a sequence of one-byte mini-block bit widths. */

--- a/modules/parquet/src/parquetjs/codecs/dictionary.ts
+++ b/modules/parquet/src/parquetjs/codecs/dictionary.ts
@@ -7,9 +7,9 @@
 import {decodeValues as decodeRleValues} from './rle';
 
 export function decodeValues(type, cursor, count, opts) {
-  opts.bitWidth = cursor.buffer[cursor.offset];
+  const bitWidth = cursor.buffer[cursor.offset];
   cursor.offset += 1;
-  return decodeRleValues(type, cursor, count, {...opts, disableEnvelope: true});
+  return decodeRleValues(type, cursor, count, {...opts, bitWidth, disableEnvelope: true});
 }
 
 export function encodeValues(type, cursor, count, opts) {

--- a/modules/parquet/src/parquetjs/codecs/plain.ts
+++ b/modules/parquet/src/parquetjs/codecs/plain.ts
@@ -6,7 +6,12 @@
 
 /* eslint-disable camelcase */
 import type {PrimitiveType} from '../schema/declare';
-import type {CursorBuffer, ParquetCodecOptions} from './declare';
+import {
+  getParquetValueOutput,
+  type CursorBuffer,
+  type ParquetCodecOptions,
+  type ParquetValueBuffer
+} from './declare';
 import {
   concatUint8Arrays,
   copyUint8Array,
@@ -51,20 +56,20 @@ export function decodeValues(
   cursor: CursorBuffer,
   count: number,
   opts: ParquetCodecOptions
-): any[] {
+): ParquetValueBuffer {
   switch (type) {
     case 'BOOLEAN':
-      return decodeValues_BOOLEAN(cursor, count);
+      return decodeValues_BOOLEAN(cursor, count, opts);
     case 'INT32':
-      return decodeValues_INT32(cursor, count);
+      return decodeValues_INT32(cursor, count, opts);
     case 'INT64':
-      return decodeValues_INT64(cursor, count);
+      return decodeValues_INT64(cursor, count, opts);
     case 'INT96':
-      return decodeValues_INT96(cursor, count);
+      return decodeValues_INT96(cursor, count, opts);
     case 'FLOAT':
-      return decodeValues_FLOAT(cursor, count);
+      return decodeValues_FLOAT(cursor, count, opts);
     case 'DOUBLE':
-      return decodeValues_DOUBLE(cursor, count);
+      return decodeValues_DOUBLE(cursor, count, opts);
     case 'BYTE_ARRAY':
       return decodeValues_BYTE_ARRAY(cursor, count, opts);
     case 'FIXED_LEN_BYTE_ARRAY':
@@ -84,14 +89,19 @@ function encodeValues_BOOLEAN(values: boolean[]): Uint8Array {
   return buf;
 }
 
-function decodeValues_BOOLEAN(cursor: CursorBuffer, count: number): boolean[] {
-  const values = new Array<boolean>(count);
+function decodeValues_BOOLEAN(
+  cursor: CursorBuffer,
+  count: number,
+  options: ParquetCodecOptions
+): ParquetValueBuffer {
+  const {output, outputOffset} = getParquetValueOutput(options, count);
   for (let i = 0; i < count; i++) {
     const b = cursor.buffer[cursor.offset + Math.floor(i / 8)];
-    values[i] = (b & (1 << (i % 8))) > 0;
+    const value = (b & (1 << (i % 8))) > 0;
+    output[outputOffset + i] = output instanceof Uint8Array ? Number(value) : value;
   }
   cursor.offset += Math.ceil(count / 8);
-  return values;
+  return output;
 }
 
 function encodeValues_INT32(values: number[]): Uint8Array {
@@ -102,17 +112,21 @@ function encodeValues_INT32(values: number[]): Uint8Array {
   return buf;
 }
 
-function decodeValues_INT32(cursor: CursorBuffer, count: number): number[] {
-  const values = new Array<number>(count);
+function decodeValues_INT32(
+  cursor: CursorBuffer,
+  count: number,
+  options: ParquetCodecOptions
+): ParquetValueBuffer {
+  const {output, outputOffset} = getParquetValueOutput(options, count);
   const dataView = getCursorDataView(cursor);
   for (let i = 0; i < count; i++) {
-    values[i] = dataView.getInt32(cursor.offset, true);
+    output[outputOffset + i] = dataView.getInt32(cursor.offset, true);
     cursor.offset += 4;
   }
-  return values;
+  return output;
 }
 
-function encodeValues_INT64(values: number[]): Uint8Array {
+function encodeValues_INT64(values: Array<number | bigint>): Uint8Array {
   const buf = new Uint8Array(8 * values.length);
   for (let i = 0; i < values.length; i++) {
     writeInt64LE(buf, values[i], i * 8);
@@ -120,14 +134,19 @@ function encodeValues_INT64(values: number[]): Uint8Array {
   return buf;
 }
 
-function decodeValues_INT64(cursor: CursorBuffer, count: number): number[] {
-  const values = new Array<number>(count);
+function decodeValues_INT64(
+  cursor: CursorBuffer,
+  count: number,
+  options: ParquetCodecOptions
+): ParquetValueBuffer {
+  const {output, outputOffset} = getParquetValueOutput(options, count);
   const dataView = getCursorDataView(cursor);
   for (let i = 0; i < count; i++) {
-    values[i] = Number(dataView.getBigInt64(cursor.offset, true));
+    const value = dataView.getBigInt64(cursor.offset, true);
+    output[outputOffset + i] = options.int64AsBigInt ? value : Number(value);
     cursor.offset += 8;
   }
-  return values;
+  return output;
 }
 
 function encodeValues_INT96(values: number[]): Uint8Array {
@@ -139,20 +158,24 @@ function encodeValues_INT96(values: number[]): Uint8Array {
   return buf;
 }
 
-function decodeValues_INT96(cursor: CursorBuffer, count: number): number[] {
-  const values = new Array<number>(count);
+function decodeValues_INT96(
+  cursor: CursorBuffer,
+  count: number,
+  options: ParquetCodecOptions
+): ParquetValueBuffer {
+  const {output, outputOffset} = getParquetValueOutput(options, count);
   const dataView = getCursorDataView(cursor);
   for (let i = 0; i < count; i++) {
     const low = Number(dataView.getBigInt64(cursor.offset, true));
     const high = dataView.getUint32(cursor.offset + 8, true);
     if (high === 0xffffffff) {
-      values[i] = ~-low + 1; // truncate to 64 actual precision
+      output[outputOffset + i] = ~-low + 1; // truncate to 64 actual precision
     } else {
-      values[i] = low; // truncate to 64 actual precision
+      output[outputOffset + i] = low; // truncate to 64 actual precision
     }
     cursor.offset += 12;
   }
-  return values;
+  return output;
 }
 
 function encodeValues_FLOAT(values: number[]): Uint8Array {
@@ -163,14 +186,18 @@ function encodeValues_FLOAT(values: number[]): Uint8Array {
   return buf;
 }
 
-function decodeValues_FLOAT(cursor: CursorBuffer, count: number): number[] {
-  const values = new Array<number>(count);
+function decodeValues_FLOAT(
+  cursor: CursorBuffer,
+  count: number,
+  options: ParquetCodecOptions
+): ParquetValueBuffer {
+  const {output, outputOffset} = getParquetValueOutput(options, count);
   const dataView = getCursorDataView(cursor);
   for (let i = 0; i < count; i++) {
-    values[i] = dataView.getFloat32(cursor.offset, true);
+    output[outputOffset + i] = dataView.getFloat32(cursor.offset, true);
     cursor.offset += 4;
   }
-  return values;
+  return output;
 }
 
 function encodeValues_DOUBLE(values: number[]): Uint8Array {
@@ -181,14 +208,18 @@ function encodeValues_DOUBLE(values: number[]): Uint8Array {
   return buf;
 }
 
-function decodeValues_DOUBLE(cursor: CursorBuffer, count: number): number[] {
-  const values = new Array<number>(count);
+function decodeValues_DOUBLE(
+  cursor: CursorBuffer,
+  count: number,
+  options: ParquetCodecOptions
+): ParquetValueBuffer {
+  const {output, outputOffset} = getParquetValueOutput(options, count);
   const dataView = getCursorDataView(cursor);
   for (let i = 0; i < count; i++) {
-    values[i] = dataView.getFloat64(cursor.offset, true);
+    output[outputOffset + i] = dataView.getFloat64(cursor.offset, true);
     cursor.offset += 8;
   }
-  return values;
+  return output;
 }
 
 function encodeValues_BYTE_ARRAY(values: any[]): Uint8Array {
@@ -213,15 +244,15 @@ function decodeValues_BYTE_ARRAY(
   cursor: CursorBuffer,
   count: number,
   options: ParquetCodecOptions
-): Uint8Array[] {
-  const values = new Array<Uint8Array>(count);
+): ParquetValueBuffer {
+  const {output, outputOffset} = getParquetValueOutput(options, count);
   const dataView = getCursorDataView(cursor);
   for (let i = 0; i < count; i++) {
     const len = dataView.getUint32(cursor.offset, true);
     cursor.offset += 4;
-    values[i] = readByteArray(cursor, len, options.retainByteArrayViews);
+    output[outputOffset + i] = readByteArray(cursor, len, options.retainByteArrayViews);
   }
-  return values;
+  return output;
 }
 
 function encodeValues_FIXED_LEN_BYTE_ARRAY(values: any[], opts: ParquetCodecOptions): Uint8Array {
@@ -241,15 +272,15 @@ function decodeValues_FIXED_LEN_BYTE_ARRAY(
   cursor: CursorBuffer,
   count: number,
   opts: ParquetCodecOptions
-): Uint8Array[] {
-  const values = new Array<Uint8Array>(count);
+): ParquetValueBuffer {
+  const {output, outputOffset} = getParquetValueOutput(opts, count);
   if (!opts.typeLength) {
     throw new Error('missing option: typeLength (required for FIXED_LEN_BYTE_ARRAY)');
   }
   for (let i = 0; i < count; i++) {
-    values[i] = readByteArray(cursor, opts.typeLength, opts.retainByteArrayViews);
+    output[outputOffset + i] = readByteArray(cursor, opts.typeLength, opts.retainByteArrayViews);
   }
-  return values;
+  return output;
 }
 
 /** Reads one byte-array value, optionally retaining a view into the decoded page buffer. */

--- a/modules/parquet/src/parquetjs/codecs/rle.ts
+++ b/modules/parquet/src/parquetjs/codecs/rle.ts
@@ -5,7 +5,12 @@
 // Forked from https://github.com/kbajalc/parquets under MIT license
 
 import type {PrimitiveType} from '../schema/declare';
-import type {CursorBuffer, ParquetCodecOptions} from './declare';
+import {
+  getParquetValueOutput,
+  type CursorBuffer,
+  type ParquetCodecOptions,
+  type ParquetValueBuffer
+} from './declare';
 import {concatUint8Arrays, writeUInt32LE} from '../utils/binary-utils';
 import varint from 'varint';
 
@@ -80,7 +85,7 @@ export function decodeValues(
   cursor: CursorBuffer,
   count: number,
   options: ParquetCodecOptions
-): number[] {
+): ParquetValueBuffer {
   if (!('bitWidth' in options)) {
     throw new Error('bitWidth is required');
   }
@@ -97,7 +102,7 @@ export function decodeValues(
     cursor.offset += 4;
   }
 
-  const values = new Array<number>(count);
+  const {output, outputOffset: initialOutputOffset} = getParquetValueOutput(options, count);
   let outputOffset = 0;
   while (outputOffset < count) {
     const header = readUnsignedVarIntNumber(cursor);
@@ -107,7 +112,15 @@ export function decodeValues(
         throw new Error('invalid RLE bit-packed run length');
       }
       const outputCount = Math.min(runValueCount, count - outputOffset);
-      decodeBitPackedRun(cursor, runValueCount, outputCount, bitWidth, values, outputOffset);
+      decodeBitPackedRun(
+        cursor,
+        runValueCount,
+        outputCount,
+        bitWidth,
+        output,
+        initialOutputOffset + outputOffset,
+        options.dictionary
+      );
       outputOffset += outputCount;
     } else {
       const runValueCount = header / 2;
@@ -116,12 +129,15 @@ export function decodeValues(
       }
       const outputCount = Math.min(runValueCount, count - outputOffset);
       const value = decodeRepeatedRun(cursor, bitWidth);
-      values.fill(value, outputOffset, outputOffset + outputCount);
+      const resolvedValue = resolveDictionaryValue(value, options.dictionary);
+      for (let index = 0; index < outputCount; index++) {
+        output[initialOutputOffset + outputOffset + index] = resolvedValue;
+      }
       outputOffset += outputCount;
     }
   }
 
-  return values;
+  return output;
 }
 
 /** Decodes one complete bit-packed run directly into the caller's output array. */
@@ -130,8 +146,9 @@ function decodeBitPackedRun(
   runValueCount: number,
   outputCount: number,
   bitWidth: number,
-  output: number[],
-  outputOffset: number
+  output: ParquetValueBuffer,
+  outputOffset: number,
+  dictionary?: readonly unknown[]
 ): void {
   if (runValueCount % 8 !== 0) {
     throw new Error('must be a multiple of 8');
@@ -143,7 +160,10 @@ function decodeBitPackedRun(
   cursor.offset = Math.min(cursor.offset + packedByteLength, size);
 
   if (bitWidth === 0) {
-    output.fill(0, outputOffset, outputOffset + outputCount);
+    const resolvedValue = resolveDictionaryValue(0, dictionary);
+    for (let index = 0; index < outputCount; index++) {
+      output[outputOffset + index] = resolvedValue;
+    }
     return;
   }
   if (bitWidth <= 24) {
@@ -153,7 +173,8 @@ function decodeBitPackedRun(
       outputCount,
       bitWidth,
       output,
-      outputOffset
+      outputOffset,
+      dictionary
     );
     return;
   }
@@ -164,7 +185,8 @@ function decodeBitPackedRun(
       outputCount,
       bitWidth,
       output,
-      outputOffset
+      outputOffset,
+      dictionary
     );
     return;
   }
@@ -179,7 +201,8 @@ function decodeBitPackedRun(
       packedBits |= BigInt(cursor.buffer[byteOffset++] ?? 0) << BigInt(packedBitCount);
       packedBitCount += 8;
     }
-    output[outputOffset + valueIndex] = Number(packedBits & mask);
+    const value = Number(packedBits & mask);
+    output[outputOffset + valueIndex] = resolveDictionaryValue(value, dictionary);
     packedBits >>= bitWidthBigInt;
     packedBitCount -= bitWidth;
   }
@@ -191,12 +214,14 @@ function decodeUint32BitPackedRun(
   packedOffset: number,
   count: number,
   bitWidth: number,
-  output: number[],
-  outputOffset: number
+  output: ParquetValueBuffer,
+  outputOffset: number,
+  dictionary?: readonly unknown[]
 ): void {
   if (bitWidth === 8) {
     for (let valueIndex = 0; valueIndex < count; valueIndex++) {
-      output[outputOffset + valueIndex] = buffer[packedOffset + valueIndex] ?? 0;
+      const value = buffer[packedOffset + valueIndex] ?? 0;
+      output[outputOffset + valueIndex] = resolveDictionaryValue(value, dictionary);
     }
     return;
   }
@@ -210,7 +235,8 @@ function decodeUint32BitPackedRun(
       packedBits |= (buffer[byteOffset++] ?? 0) << packedBitCount;
       packedBitCount += 8;
     }
-    output[outputOffset + valueIndex] = packedBits & mask;
+    const value = packedBits & mask;
+    output[outputOffset + valueIndex] = resolveDictionaryValue(value, dictionary);
     packedBits >>>= bitWidth;
     packedBitCount -= bitWidth;
   }
@@ -222,8 +248,9 @@ function decodeNumberBitPackedRun(
   packedOffset: number,
   count: number,
   bitWidth: number,
-  output: number[],
-  outputOffset: number
+  output: ParquetValueBuffer,
+  outputOffset: number,
+  dictionary?: readonly unknown[]
 ): void {
   const divisor = 2 ** bitWidth;
   let packedBits = 0;
@@ -234,10 +261,22 @@ function decodeNumberBitPackedRun(
       packedBits += (buffer[byteOffset++] ?? 0) * 2 ** packedBitCount;
       packedBitCount += 8;
     }
-    output[outputOffset + valueIndex] = packedBits % divisor;
+    const value = packedBits % divisor;
+    output[outputOffset + valueIndex] = resolveDictionaryValue(value, dictionary);
     packedBits = Math.floor(packedBits / divisor);
     packedBitCount -= bitWidth;
   }
+}
+
+/** Resolves one dictionary index and rejects corrupt out-of-range references. */
+function resolveDictionaryValue(value: number, dictionary?: readonly unknown[]): unknown {
+  if (!dictionary) {
+    return value;
+  }
+  if (value < 0 || value >= dictionary.length) {
+    throw new Error(`Invalid Parquet dictionary index ${value}`);
+  }
+  return dictionary[value];
 }
 
 /** Decodes the single little-endian value stored by a repeated run. */

--- a/modules/parquet/src/parquetjs/encoder/parquet-encoder.ts
+++ b/modules/parquet/src/parquetjs/encoder/parquet-encoder.ts
@@ -394,7 +394,7 @@ async function encodeDataPage(
   }
 
   /* encode values */
-  const valuesBuf = encodeValues(column.primitiveType!, column.encoding!, data.values, {
+  const valuesBuf = encodeValues(column.primitiveType!, column.encoding!, data.values as any[], {
     typeLength: column.typeLength,
     bitWidth: column.typeLength
   });
@@ -437,7 +437,7 @@ async function encodeDataPageV2(
   page: Uint8Array;
 }> {
   /* encode values */
-  const valuesBuf = encodeValues(column.primitiveType!, column.encoding!, data.values, {
+  const valuesBuf = encodeValues(column.primitiveType!, column.encoding!, data.values as any[], {
     typeLength: column.typeLength,
     bitWidth: column.typeLength
   });

--- a/modules/parquet/src/parquetjs/parser/decoders.ts
+++ b/modules/parquet/src/parquetjs/parser/decoders.ts
@@ -14,6 +14,7 @@ import {
   SchemaDefinition
 } from '../schema/declare';
 import {CursorBuffer, ParquetCodecOptions, PARQUET_CODECS} from '../codecs/index';
+import type {ParquetValueBuffer} from '../codecs/declare';
 import {
   ConvertedType,
   Encoding,
@@ -26,6 +27,13 @@ import {
 import {decompress} from '../compression';
 import {PARQUET_RDLVL_TYPE, PARQUET_RDLVL_ENCODING} from '../../lib/constants';
 import {decodePageHeader, getThriftEnum, getBitWidth} from '../utils/read-utils';
+
+/** Preallocated column destination used to bypass page-local value arrays. */
+type ParquetPageDecodeTarget = {
+  values: ParquetValueBuffer;
+  valueOffset: number;
+  dictionary: readonly unknown[];
+};
 
 /**
  * Decode data pages
@@ -57,7 +65,7 @@ export async function decodeDataPages(
   const data: ParquetColumnChunk = {
     rlevels: new Array<number>(outputCapacity),
     dlevels: new Array<number>(outputCapacity),
-    values: new Array(outputCapacity),
+    values: createParquetColumnValueBuffer(context, outputCapacity),
     pageHeaders: [],
     count: 0
   };
@@ -72,7 +80,11 @@ export async function decodeDataPages(
     (expectedLevelCount === undefined || levelOffset < expectedLevelCount)
   ) {
     // Looks like we have to decode these in sequence due to cursor updates?
-    const page = await decodePage(cursor, context);
+    const page = await decodePage(cursor, context, {
+      values: data.values,
+      valueOffset,
+      dictionary
+    });
 
     if (page.dictionary) {
       dictionary = page.dictionary;
@@ -80,26 +92,27 @@ export async function decodeDataPages(
       continue;
     }
 
-    const valueEncoding = getThriftEnum(
-      Encoding,
-      page.pageHeader.data_page_header?.encoding ?? page.pageHeader.data_page_header_v2?.encoding!
-    ) as ParquetCodec;
-    // Pages might be in different encodings. We don't need to decode in case
-    // of 'PLAIN' encoding because all values are already in place
-    const usesDictionary =
-      dictionary.length &&
-      (valueEncoding === 'PLAIN_DICTIONARY' || valueEncoding === 'RLE_DICTIONARY');
-
     for (let index = 0; index < page.rlevels.length; index++) {
       data.rlevels[levelOffset + index] = page.rlevels[index];
       data.dlevels[levelOffset + index] = page.dlevels[index];
     }
     levelOffset += page.rlevels.length;
 
-    for (let index = 0; index < page.values.length; index++) {
-      const value = usesDictionary ? dictionary[page.values[index]] : page.values[index];
-      if (value !== undefined) {
-        data.values[valueOffset++] = value;
+    if (page.directValuesWritten !== undefined) {
+      valueOffset += page.directValuesWritten;
+    } else {
+      const valueEncoding = getThriftEnum(
+        Encoding,
+        page.pageHeader.data_page_header?.encoding ?? page.pageHeader.data_page_header_v2?.encoding!
+      ) as ParquetCodec;
+      const usesDictionary =
+        dictionary.length &&
+        (valueEncoding === 'PLAIN_DICTIONARY' || valueEncoding === 'RLE_DICTIONARY');
+      for (let index = 0; index < page.values.length; index++) {
+        const value = usesDictionary ? dictionary[Number(page.values[index])] : page.values[index];
+        if (value !== undefined) {
+          data.values[valueOffset++] = value;
+        }
       }
     }
 
@@ -109,7 +122,7 @@ export async function decodeDataPages(
 
   data.rlevels.length = levelOffset;
   data.dlevels.length = levelOffset;
-  data.values.length = valueOffset;
+  data.values = trimParquetValueBuffer(data.values, valueOffset);
 
   return data;
 }
@@ -121,7 +134,8 @@ export async function decodeDataPages(
  */
 export async function decodePage(
   cursor: CursorBuffer,
-  context: ParquetReaderContext
+  context: ParquetReaderContext,
+  target?: ParquetPageDecodeTarget
 ): Promise<ParquetPageData> {
   let page;
 
@@ -132,10 +146,10 @@ export async function decodePage(
 
   switch (pageType) {
     case 'DATA_PAGE':
-      page = await decodeDataPage(cursor, pageHeader, context);
+      page = await decodeDataPage(cursor, pageHeader, context, target);
       break;
     case 'DATA_PAGE_V2':
-      page = await decodeDataPageV2(cursor, pageHeader, context);
+      page = await decodeDataPageV2(cursor, pageHeader, context, target);
       break;
     case 'DICTIONARY_PAGE':
       page = {
@@ -239,7 +253,7 @@ function decodeValues(
   cursor: CursorBuffer,
   count: number,
   opts: ParquetCodecOptions
-): any[] {
+): ParquetValueBuffer {
   if (!(encoding in PARQUET_CODECS)) {
     throw new Error(`invalid encoding: ${encoding}`);
   }
@@ -255,7 +269,8 @@ function decodeValues(
 async function decodeDataPage(
   cursor: CursorBuffer,
   header: PageHeader,
-  context: ParquetReaderContext
+  context: ParquetReaderContext,
+  target?: ParquetPageDecodeTarget
 ): Promise<ParquetPageData> {
   const cursorEnd = cursor.offset + header.compressed_page_size;
   const valueCount = header.data_page_header?.num_values;
@@ -290,7 +305,7 @@ async function decodeDataPage(
       bitWidth: getBitWidth(context.column.rLevelMax),
       disableEnvelope: false
       // column: opts.column
-    });
+    }) as number[];
   } else {
     rLevels.fill(0);
   }
@@ -307,7 +322,7 @@ async function decodeDataPage(
       bitWidth: getBitWidth(context.column.dLevelMax),
       disableEnvelope: false
       // column: opts.column
-    });
+    }) as number[];
   } else {
     dLevels.fill(0);
   }
@@ -323,7 +338,11 @@ async function decodeDataPage(
   const decodeOptions: ParquetCodecOptions = {
     typeLength: context.column.typeLength,
     bitWidth: getValueBitWidth(context, valueEncoding),
-    retainByteArrayViews: context.retainByteArrayViews
+    retainByteArrayViews: context.retainByteArrayViews,
+    output: target?.values,
+    outputOffset: target?.valueOffset,
+    dictionary: isDictionaryEncoding(valueEncoding) ? target?.dictionary : undefined,
+    int64AsBigInt: shouldDecodeInt64AsBigInt(context)
   };
 
   const values = decodeValues(
@@ -338,6 +357,7 @@ async function decodeDataPage(
     dlevels: dLevels,
     rlevels: rLevels,
     values,
+    directValuesWritten: target ? valueCountNonNull : undefined,
     count: valueCount!,
     pageHeader: header
   };
@@ -353,7 +373,8 @@ async function decodeDataPage(
 async function decodeDataPageV2(
   cursor: CursorBuffer,
   header: PageHeader,
-  context: ParquetReaderContext
+  context: ParquetReaderContext,
+  target?: ParquetPageDecodeTarget
 ): Promise<ParquetPageData> {
   const dataPageHeader = header.data_page_header_v2;
   if (!dataPageHeader) {
@@ -390,7 +411,7 @@ async function decodeDataPageV2(
         bitWidth: getBitWidth(context.column.rLevelMax),
         disableEnvelope: true
       }
-    );
+    ) as number[];
   } else {
     rLevels.fill(0);
   }
@@ -414,7 +435,7 @@ async function decodeDataPageV2(
         bitWidth: getBitWidth(context.column.dLevelMax),
         disableEnvelope: true
       }
-    );
+    ) as number[];
   } else {
     dLevels.fill(0);
   }
@@ -444,7 +465,11 @@ async function decodeDataPageV2(
   const decodeOptions = {
     typeLength: context.column.typeLength,
     bitWidth: getValueBitWidth(context, valueEncoding),
-    retainByteArrayViews: context.retainByteArrayViews
+    retainByteArrayViews: context.retainByteArrayViews,
+    output: target?.values,
+    outputOffset: target?.valueOffset,
+    dictionary: isDictionaryEncoding(valueEncoding) ? target?.dictionary : undefined,
+    int64AsBigInt: shouldDecodeInt64AsBigInt(context)
   };
 
   const values = decodeValues(
@@ -459,9 +484,59 @@ async function decodeDataPageV2(
     dlevels: dLevels,
     rlevels: rLevels,
     values,
+    directValuesWritten: target ? valueCountNonNull : undefined,
     count: valueCount,
     pageHeader: header
   };
+}
+
+/** Returns whether an encoding stores RLE dictionary indices instead of physical values. */
+function isDictionaryEncoding(encoding: ParquetCodec): boolean {
+  return encoding === 'PLAIN_DICTIONARY' || encoding === 'RLE_DICTIONARY';
+}
+
+/** Preserves exact physical signed INT64 values in every output shape. */
+function shouldDecodeInt64AsBigInt(context: ParquetReaderContext): boolean {
+  return Boolean(
+    context.column.primitiveType === 'INT64' &&
+      (!context.column.originalType || context.column.originalType === 'INT_64')
+  );
+}
+
+/** Allocates the narrowest lossless column buffer supported by the current JavaScript decoder. */
+function createParquetColumnValueBuffer(
+  context: ParquetReaderContext,
+  capacity: number
+): ParquetValueBuffer {
+  if (!context.useTypedValueBuffers || capacity === 0) {
+    return new Array<unknown>(capacity);
+  }
+  switch (context.column.primitiveType) {
+    case 'BOOLEAN':
+      return new Uint8Array(capacity);
+    case 'INT32':
+      return new Int32Array(capacity);
+    case 'INT64':
+      return !context.column.originalType || context.column.originalType === 'INT_64'
+        ? new BigInt64Array(capacity)
+        : new Float64Array(capacity);
+    case 'INT96':
+    case 'DOUBLE':
+      return new Float64Array(capacity);
+    case 'FLOAT':
+      return new Float32Array(capacity);
+    default:
+      return new Array<unknown>(capacity);
+  }
+}
+
+/** Restricts an overallocated typed column buffer to its decoded non-null values. */
+function trimParquetValueBuffer(values: ParquetValueBuffer, length: number): ParquetValueBuffer {
+  if (Array.isArray(values)) {
+    values.length = length;
+    return values;
+  }
+  return values.subarray(0, length) as ParquetValueBuffer;
 }
 
 /** Returns the physical value bit width required by encodings such as RLE BOOLEAN. */
@@ -534,8 +609,8 @@ async function decodeDictionaryPage(
     dictCursor,
     numValues,
     // TODO - this looks wrong?
-    context as ParquetCodecOptions
+    {...context, int64AsBigInt: shouldDecodeInt64AsBigInt(context)} as ParquetCodecOptions
   );
 
-  return decodedDictionaryValues;
+  return decodedDictionaryValues as (string | ArrayBuffer)[];
 }

--- a/modules/parquet/src/parquetjs/parser/parquet-reader.ts
+++ b/modules/parquet/src/parquetjs/parser/parquet-reader.ts
@@ -32,6 +32,8 @@ export type ParquetReaderProps = {
   preserveBinary?: boolean;
   /** Retain byte arrays as views into decoded page buffers for direct materialization. */
   retainByteArrayViews?: boolean;
+  /** Decode supported primitive columns into typed buffers instead of boxed JavaScript arrays. */
+  useTypedValueBuffers?: boolean;
   /** Abort signal forwarded to every underlying random-access read. */
   signal?: AbortSignal;
 };
@@ -58,6 +60,7 @@ export class ParquetReader {
     defaultDictionarySize: 2147483648,
     preserveBinary: false,
     retainByteArrayViews: false,
+    useTypedValueBuffers: false,
     signal: undefined
   };
 
@@ -296,7 +299,8 @@ export class ParquetReader {
       dictionary: [],
       // Options - TBD is this the right place for these?
       preserveBinary: this.props.preserveBinary,
-      retainByteArrayViews: this.props.retainByteArrayViews
+      retainByteArrayViews: this.props.retainByteArrayViews,
+      useTypedValueBuffers: this.props.useTypedValueBuffers
     };
 
     let dictionary: any[] | undefined;

--- a/modules/parquet/src/parquetjs/schema/declare.ts
+++ b/modules/parquet/src/parquetjs/schema/declare.ts
@@ -6,6 +6,7 @@
 
 import Int64 from 'node-int64';
 import type {PageHeader} from '../parquet-thrift';
+import type {ParquetValueBuffer} from '../codecs/declare';
 
 export type ParquetCodec =
   | 'PLAIN'
@@ -123,13 +124,17 @@ export interface ParquetReaderContext {
   preserveBinary?: boolean;
   /** Retain byte arrays as views into decoded page buffers for direct materialization. */
   retainByteArrayViews?: boolean;
+  /** Decode primitive values into typed column buffers when their physical type permits it. */
+  useTypedValueBuffers?: boolean;
 }
 
 export interface ParquetPageData {
   dlevels: number[];
   rlevels: number[];
   /** Actual column chunks */
-  values: any[]; // ArrayLike<any>;
+  values: ParquetValueBuffer;
+  /** Number of values written directly into the column destination, if one was supplied. */
+  directValuesWritten?: number;
   count: number;
   dictionary?: ParquetDictionary;
   /** The "raw" page header from the file */
@@ -158,7 +163,7 @@ export class ParquetRowGroup {
 export interface ParquetColumnChunk {
   dlevels: number[];
   rlevels: number[];
-  values: any[];
+  values: ParquetValueBuffer;
   count: number;
   pageHeaders: PageHeader[];
 }

--- a/modules/parquet/src/parquetjs/schema/shred.ts
+++ b/modules/parquet/src/parquetjs/schema/shred.ts
@@ -67,7 +67,10 @@ export function shredRecord(
   for (const field of schema.fieldList) {
     Array.prototype.push.apply(rowGroup.columnData[field.key].rlevels, data[field.key].rlevels);
     Array.prototype.push.apply(rowGroup.columnData[field.key].dlevels, data[field.key].dlevels);
-    Array.prototype.push.apply(rowGroup.columnData[field.key].values, data[field.key].values);
+    Array.prototype.push.apply(
+      rowGroup.columnData[field.key].values as unknown[],
+      data[field.key].values as unknown as unknown[]
+    );
     rowGroup.columnData[field.key].count += data[field.key].count;
   }
 }
@@ -126,7 +129,7 @@ function shredRecordFields(
         data[field.key].count += 1;
         data[field.key].rlevels.push(rlvl);
         data[field.key].dlevels.push(field.dLevelMax);
-        data[field.key].values.push(
+        (data[field.key].values as unknown[]).push(
           Types.toPrimitive((field.originalType || field.primitiveType)!, values[i])
         );
       }

--- a/modules/parquet/src/parquetjs/schema/types.ts
+++ b/modules/parquet/src/parquetjs/schema/types.ts
@@ -291,12 +291,24 @@ function toPrimitive_UINT32(value: any): number {
   return v;
 }
 
-function toPrimitive_INT64(value: any): number {
-  const v = parseInt(value, 10);
-  if (Number.isNaN(v)) {
+function toPrimitive_INT64(value: unknown): number | bigint {
+  if (typeof value === 'number') {
+    if (!Number.isSafeInteger(value)) {
+      throw new Error(`invalid value for INT64: ${value}`);
+    }
+    return value;
+  }
+
+  let primitiveValue: bigint;
+  try {
+    primitiveValue = BigInt(value as bigint | boolean | string);
+  } catch {
     throw new Error(`invalid value for INT64: ${value}`);
   }
-  return v;
+  if (primitiveValue < -(2n ** 63n) || primitiveValue > 2n ** 63n - 1n) {
+    throw new Error(`invalid value for INT64: ${value}`);
+  }
+  return primitiveValue;
 }
 
 function decimalToPrimitive_INT64(value: number, field: ParquetField) {

--- a/modules/parquet/test/expected.ts
+++ b/modules/parquet/test/expected.ts
@@ -7,6 +7,7 @@
 const TEXT_ENCODER = new TextEncoder();
 
 const RAW_TEXT_FIELDS = new Set(['c1', 'date_string_col', 'string_col']);
+const BIGINT_FIELDS = new Set(['bigint_col', 'c0', 'item', 'number']);
 
 function bytes(values: number[]): Uint8Array {
   return new Uint8Array(values);
@@ -25,7 +26,10 @@ function toTypedParquetFixture(value: unknown, key?: string): unknown {
     if (RAW_TEXT_FIELDS.has(key || '')) {
       return utf8Bytes(value);
     }
-    return isNumericString(value) ? Number(value) : value;
+    if (!isNumericString(value)) {
+      return value;
+    }
+    return BIGINT_FIELDS.has(key || '') && /^-?\d+$/.test(value) ? BigInt(value) : Number(value);
   }
 
   if (Array.isArray(value)) {
@@ -413,7 +417,7 @@ export const NESTED_MAPS_EXPECTED = typedParquetRows([
 
 export const NO_NULLABLE_EXPECTED = typedParquetRows([
   {
-    ID: 8,
+    ID: 8n,
     Int_Array: { list: [{ element: -1 }] },
     int_array_array: { list: [{ element: { list: [{ element: -1 }, { element: -2 }] } }, { element: {} }] },
     Int_Map: {map: [{key: 'k1', value: -1}]},
@@ -448,7 +452,7 @@ export const NO_NULLABLE_EXPECTED = typedParquetRows([
 
 export const NULLABLE_EXPECTED = typedParquetRows([
   {
-    id: 1,
+    id: 1n,
     int_array: {
       list: [
         { element: '1' },
@@ -492,7 +496,7 @@ export const NULLABLE_EXPECTED = typedParquetRows([
     }
   },
   {
-    id: 2,
+    id: 2n,
     int_array: {
       list: [
         {},
@@ -553,7 +557,7 @@ export const NULLABLE_EXPECTED = typedParquetRows([
     }
   },
   {
-    id: 3,
+    id: 3n,
     int_array: {},
     int_array_Array: { list: [{}] },
     int_map: {},
@@ -561,14 +565,14 @@ export const NULLABLE_EXPECTED = typedParquetRows([
     nested_struct: { C: { d: {} }, g: {} }
   },
   {
-    id: 4,
+    id: 4n,
     int_array_Array: {},
     int_map: {},
     int_Map_Array: {},
     nested_struct: { C: {} }
   },
   {
-    id: 5,
+    id: 5n,
     int_map: {},
     nested_struct: {
       g: {
@@ -579,10 +583,10 @@ export const NULLABLE_EXPECTED = typedParquetRows([
     }
   },
   {
-    id: 6
+    id: 6n
   },
   {
-    id: 7,
+    id: 7n,
     int_array_Array: { list: [{}, { element: { list: [{ element: '5' }, { element: '6' }] } }] },
     int_map: { map: [{ key: 'k1' }, { key: 'k3' }] },
     nested_struct: {
@@ -652,22 +656,22 @@ export const LZ4_RAW_COMPRESSED_LARGER_LAST_EXPECTED = {
 
 export const LZ4_RAW_COMPRESSED_EXPECTED = [
   {
-    c0: 1593604800,
+    c0: 1593604800n,
     c1: utf8Bytes('abc'),
     v11: 42
   },
   {
-    c0: 1593604800,
+    c0: 1593604800n,
     c1: utf8Bytes('def'),
     v11: 7.7
   },
   {
-    c0: 1593604801,
+    c0: 1593604801n,
     c1: utf8Bytes('abc'),
     v11: 42.125
   },
   {
-    c0: 1593604801,
+    c0: 1593604801n,
     c1: utf8Bytes('def'),
     v11: 7.7
   }

--- a/modules/parquet/test/parquet-int64.spec.ts
+++ b/modules/parquet/test/parquet-int64.spec.ts
@@ -1,0 +1,68 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import * as arrow from 'apache-arrow';
+import {encode, load} from '@loaders.gl/core';
+import {ParquetJSLoader, ParquetJSWriter} from '@loaders.gl/parquet';
+import type {ObjectRowTable} from '@loaders.gl/schema';
+import {expect, test} from 'vitest';
+
+const EXACT_INT64_VALUES = [9007199254740993n, -9007199254740993n, 9223372036854775807n];
+
+/** Creates a physical INT64 Parquet fixture containing values that cannot be represented as numbers. */
+async function createExactInt64Fixture(): Promise<ArrayBuffer> {
+  const table: ObjectRowTable = {
+    shape: 'object-row-table',
+    schema: {
+      fields: [{name: 'value', type: 'int64', nullable: false}],
+      metadata: {}
+    },
+    data: EXACT_INT64_VALUES.map(value => ({value}))
+  };
+
+  return await encode(table, ParquetJSWriter, {worker: false});
+}
+
+test('ParquetJSLoader preserves physical INT64 values as exact bigint object rows', async () => {
+  const parquetBuffer = await createExactInt64Fixture();
+  const table = await load(parquetBuffer, ParquetJSLoader, {
+    core: {worker: false},
+    parquet: {shape: 'object-row-table'}
+  });
+
+  expect(table.shape).toBe('object-row-table');
+  if (table.shape === 'object-row-table') {
+    expect(table.schema?.fields[0].type).toBe('int64');
+    expect(table.data.map(row => row.value)).toEqual(EXACT_INT64_VALUES);
+  }
+});
+
+test('ParquetJSLoader preserves physical INT64 values in Arrow Int64 vectors', async () => {
+  const parquetBuffer = await createExactInt64Fixture();
+  const table = await load(parquetBuffer, ParquetJSLoader, {
+    core: {worker: false},
+    parquet: {shape: 'arrow-table'}
+  });
+
+  expect(table.shape).toBe('arrow-table');
+  if (table.shape === 'arrow-table') {
+    expect(table.data.schema.fields[0].type).toBeInstanceOf(arrow.Int64);
+    expect(Array.from(table.data.getChildAt(0) || [])).toEqual(EXACT_INT64_VALUES);
+  }
+});
+
+test('ParquetJSWriter rejects unsafe number inputs instead of silently corrupting INT64 values', async () => {
+  const table: ObjectRowTable = {
+    shape: 'object-row-table',
+    schema: {
+      fields: [{name: 'value', type: 'int64', nullable: false}],
+      metadata: {}
+    },
+    data: [{value: Number.MAX_SAFE_INTEGER + 1}]
+  };
+
+  await expect(encode(table, ParquetJSWriter, {worker: false})).rejects.toThrow(
+    'invalid value for INT64'
+  );
+});

--- a/modules/parquet/test/parquet-loader.spec.ts
+++ b/modules/parquet/test/parquet-loader.spec.ts
@@ -184,9 +184,7 @@ test('ParquetJSLoader#arrow-table preserves ranged physical integer values', asy
   if (arrowTable.shape === 'arrow-table' && objectRowTable.shape === 'object-row-table') {
     for (const columnName of columns) {
       t.deepEqual(
-        Array.from(arrowTable.data.getChild(columnName) || [], value =>
-          typeof value === 'bigint' ? Number(value) : value
-        ),
+        Array.from(arrowTable.data.getChild(columnName) || []),
         objectRowTable.data.map(row => row[columnName] ?? null),
         `${columnName} values and nulls match object-row decoding`
       );
@@ -542,9 +540,11 @@ test('ParquetJSLoader#load repeated_no_annotation file as an Arrow table', async
 
   t.equal(table.shape, 'arrow-table');
   if (table.shape === 'arrow-table') {
-    const lastRow = JSON.parse(JSON.stringify(table.data.get(5)?.toJSON())) as {
-      phoneNumbers: {phone: Array<{number: number; kind: string | null}>};
-    };
+    const lastRow = JSON.parse(
+      JSON.stringify(table.data.get(5)?.toJSON(), (_key, value) =>
+        typeof value === 'bigint' ? value.toString() : value
+      )
+    ) as {phoneNumbers: {phone: Array<{number: string; kind: string | null}>}};
     t.equal(table.data.numRows, 6);
     t.ok(JSON.stringify(table.schema).includes('"type":"list"'), 'schema contains Arrow lists');
     t.equal(lastRow.phoneNumbers.phone.length, 3, 'all repeated structs are retained');

--- a/modules/parquet/test/parquetjs/codec-output-buffer.spec.ts
+++ b/modules/parquet/test/parquetjs/codec-output-buffer.spec.ts
@@ -1,0 +1,109 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import {PARQUET_CODECS} from '@loaders.gl/parquet/parquetjs/codecs';
+
+/** Creates an exact byte vector for concise codec fixtures. */
+function bytes(values: number[]): Uint8Array {
+  return new Uint8Array(values);
+}
+
+test('PLAIN writes values into a caller-provided typed buffer', () => {
+  const output = new Int32Array(5).fill(-1);
+  const decoded = PARQUET_CODECS.PLAIN.decodeValues(
+    'INT32',
+    {buffer: bytes([1, 0, 0, 0, 254, 255, 255, 255, 3, 0, 0, 0]), offset: 0},
+    3,
+    {output, outputOffset: 1}
+  );
+
+  expect(decoded).toBe(output);
+  expect(output).toEqual(new Int32Array([-1, 1, -2, 3, -1]));
+});
+
+test('RLE resolves bit-packed dictionary indices into the destination', () => {
+  const output = new Float64Array(10).fill(-1);
+  const dictionary = [11, 13, 17, 19, 23, 29, 31, 37];
+  const decoded = PARQUET_CODECS.RLE.decodeValues(
+    'INT32',
+    {buffer: bytes([0x03, 0x88, 0xc6, 0xfa]), offset: 0},
+    8,
+    {disableEnvelope: true, bitWidth: 3, dictionary, output, outputOffset: 1}
+  );
+
+  expect(decoded).toBe(output);
+  expect(Array.from(output)).toEqual([-1, ...dictionary, -1]);
+});
+
+test('RLE resolves repeated dictionary indices into the destination', () => {
+  const output = new Int32Array(8);
+  PARQUET_CODECS.RLE.decodeValues(
+    'INT32',
+    {buffer: bytes([0x10, 0x02]), offset: 0},
+    8,
+    {disableEnvelope: true, bitWidth: 3, dictionary: [10, 20, 30], output}
+  );
+
+  expect(output).toEqual(new Int32Array(8).fill(30));
+});
+
+test('RLE rejects corrupt dictionary indices instead of writing coerced zeroes', () => {
+  expect(() =>
+    PARQUET_CODECS.RLE.decodeValues(
+      'INT32',
+      {buffer: bytes([0x10, 0x03]), offset: 0},
+      8,
+      {disableEnvelope: true, bitWidth: 3, dictionary: [10, 20, 30], output: new Int32Array(8)}
+    )
+  ).toThrow('Invalid Parquet dictionary index 3');
+});
+
+test('DELTA_BINARY_PACKED writes values at a destination offset', () => {
+  const output = new Int32Array(6).fill(-1);
+  const decoded = PARQUET_CODECS.DELTA_BINARY_PACKED.decodeValues(
+    'INT32',
+    {
+      buffer: bytes([0x80, 0x01, 0x04, 0x03, 0x02, 0x02, 0x00, 0x00, 0x00, 0x00]),
+      offset: 0
+    },
+    3,
+    {output, outputOffset: 2}
+  );
+
+  expect(decoded).toBe(output);
+  expect(output).toEqual(new Int32Array([-1, -1, 1, 2, 3, -1]));
+});
+
+test('PLAIN keeps boolean arrays compatible and supports compact typed destinations', () => {
+  const arrayValues = PARQUET_CODECS.PLAIN.decodeValues(
+    'BOOLEAN',
+    {buffer: bytes([0x05]), offset: 0},
+    3,
+    {}
+  );
+  const typedValues = new Uint8Array(3);
+  PARQUET_CODECS.PLAIN.decodeValues(
+    'BOOLEAN',
+    {buffer: bytes([0x05]), offset: 0},
+    3,
+    {output: typedValues}
+  );
+
+  expect(arrayValues).toEqual([true, false, true]);
+  expect(typedValues).toEqual(new Uint8Array([1, 0, 1]));
+});
+
+test('PLAIN preserves exact INT64 values in BigInt destinations', () => {
+  const encoded = new Uint8Array(8);
+  new DataView(encoded.buffer).setBigInt64(0, 9007199254740993n, true);
+  const output = new BigInt64Array(1);
+
+  PARQUET_CODECS.PLAIN.decodeValues('INT64', {buffer: encoded, offset: 0}, 1, {
+    int64AsBigInt: true,
+    output
+  });
+
+  expect(output[0]).toBe(9007199254740993n);
+});


### PR DESCRIPTION
## Goals

- Make the TypeScript Parquet path construct Arrow output with fewer allocations, copies, and intermediate arrays.
- Preserve Parquet physical `INT64` values exactly instead of maintaining an undocumented lossy mapping.
- Explain when end-to-end TypeScript loaders can outperform or outsize-equivalent WASM pipelines.

## Changes

- Adds caller-provided codec destinations and preallocated column buffers.
- Writes PLAIN, RLE/dictionary, and DELTA decoded values directly into final column storage.
- Fuses dictionary lookup into RLE decoding and rejects corrupt out-of-range dictionary indices.
- Reuses required primitive TypedArray slices as Arrow value buffers.
- Maps unannotated physical `INT64` to Arrow `Int64` and JavaScript `bigint` for both Arrow and object-row output.
- Preserves exact `bigint` values through `ParquetJSWriter`; unsafe `number` inputs are rejected rather than rounded.
- Adds focused codec, exactness, and public round-trip tests above `Number.MAX_SAFE_INTEGER`.
- Adds a general JavaScript-versus-WebAssembly performance concept page and links it from Parquet and LAS loader docs.

## Benchmark signal

A local run of the existing live suite measured the TypeScript loader at 1.39M rows/s for projected nullable PLAIN data, 4.51M rows/s for the mixed RLE_DICTIONARY table, and 89.8K rows/s for DELTA_BINARY_PACKED integers. An adjacent baseline run was materially slower on those paths, but host variance is high, so these numbers are directional rather than a proposed CI threshold. Nested/repeated schemas and several full-table cases remain roadmap targets.

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn build-workers`
- `yarn test-node` — 189 passed, 6 skipped
- `yarn test-headless` — 1,887 passed, 50 skipped
- `yarn test-audit` — 0 violations
- `website/yarn build`
- `yarn bench parquet`