### PR TITLE
feat(raster): preserve source-specific request types

### DIFF
--- a/docs/developer-guide/using-sources.mdx
+++ b/docs/developer-guide/using-sources.mdx
@@ -65,10 +65,16 @@ Use it when a source needs to:
 
 - accept a viewport request instead of a tile index
 - return typed raster values rather than browser image objects
+- select named non-spatial dimensions such as time or vertical level
 - preserve band count, dtype, bounds, and CRS metadata for styling or texture upload
 
-`GeoTIFFSourceLoader` is the first built-in `RasterSource`. It accepts a `RasterViewport`, returns
-`RasterData`, and preserves native CRS metadata instead of reprojecting in v1.
+`GeoTIFFSourceLoader` and `GeoZarrSourceLoader` are built-in `RasterSource` implementations. Both
+accept a `RasterViewport` and return `RasterData`. GeoTIFF requests can select numeric bands, while
+GeoZarr requests can use the common `selection` map for named dimensions declared by the source.
+
+`RasterSource` is generic over its raster data, request parameters, and metadata. Higher-level
+managers such as `RasterSet` preserve those source-specific types while retaining defaults for
+applications that only need the common raster contract.
 
 ## Options
 

--- a/docs/modules/tiles/api-reference/raster-set.md
+++ b/docs/modules/tiles/api-reference/raster-set.md
@@ -63,13 +63,21 @@ Supported options include:
 
 Convenience factory for wrapping a loaders.gl `RasterSource`.
 
-### `loadMetadata(): Promise<RasterSourceMetadata>`
+The returned `RasterSet` infers the source's raster data, request, and metadata types. This lets a
+GeoZarr source preserve named selections such as `selection: {time: 6}` through request callbacks,
+refetch policies, and the accepted `currentRequest`, while GeoTIFF callers continue to use the
+common `bands` and `interleaved` parameters.
+
+### `loadMetadata(): Promise<MetadataT>`
 
 Loads and caches source metadata.
 
-### `requestRaster(parameters: GetRasterParameters, debounceTime?): number`
+### `requestRaster(parameters: ParametersT, debounceTime?): number`
 
 Schedules a viewport-driven raster request and returns the assigned request id.
+
+`GetRasterParameters.selection` optionally maps non-spatial dimension names to integer indices.
+Individual sources define the supported names and may expose a narrower request type.
 
 ### `subscribe(listener): () => void`
 
@@ -87,8 +95,8 @@ Available callbacks include:
 
 ### Properties
 
-- `metadata: RasterSourceMetadata | null`
-- `raster: RasterData | null`
-- `currentRequest: RasterSetRequest | null`
-- `rasterSource: RasterSource | null`
+- `metadata: MetadataT | null`
+- `raster: DataT | null`
+- `currentRequest: RasterSetRequest<DataT, ParametersT> | null`
+- `rasterSource: RasterSource<DataT, ParametersT, MetadataT> | null`
 - `isLoaded: boolean`

--- a/docs/modules/zarr/api-reference/geo-zarr-source-loader.md
+++ b/docs/modules/zarr/api-reference/geo-zarr-source-loader.md
@@ -81,7 +81,8 @@ Returns normalized raster metadata plus:
 
 Reads the native-resolution array window intersecting `parameters.viewport`.
 
-- `selection?: Record<string, number>` selects named non-spatial indices.
+- `selection?: RasterSelection` selects named non-spatial indices through the common
+  `GetRasterParameters` contract.
 - `signal?: AbortSignal` cancels metadata and chunk requests.
 - `resampleMethod?: 'nearest'` is accepted for API compatibility. Bilinear resampling is not yet
   implemented.

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -146,6 +146,9 @@ Release Date: 2026
 **@loaders.gl/tiles**
 
 - `RasterSet` NEW - loading manager for `RasterSource` implementations with metadata caching, debounced viewport requests, and loading lifecycle callbacks.
+- `RasterSet` now preserves source-specific request and metadata types, including named
+  `GetRasterParameters.selection` indices for time, vertical level, and other non-spatial raster
+  dimensions.
 
 **@loaders.gl/zarr**
 

--- a/modules/loader-utils/src/index.ts
+++ b/modules/loader-utils/src/index.ts
@@ -278,6 +278,7 @@ export type {
   RasterBoundingBox,
   RasterViewport,
   RasterData,
+  RasterSelection,
   GetRasterParameters,
   RasterOverview,
   RasterSourceMetadata

--- a/modules/loader-utils/src/lib/sources/raster-source.ts
+++ b/modules/loader-utils/src/lib/sources/raster-source.ts
@@ -78,11 +78,20 @@ export type RasterData = {
 };
 
 /**
+ * Named indices selected from non-spatial raster dimensions.
+ *
+ * Sources define the supported dimension names in their source-specific metadata.
+ */
+export type RasterSelection = Readonly<Record<string, number>>;
+
+/**
  * Parameters for {@link RasterSource.getRaster}.
  */
 export type GetRasterParameters = {
   /** Requested output viewport. */
   viewport: RasterViewport;
+  /** Optional named indices for non-spatial dimensions such as time or vertical level. */
+  selection?: RasterSelection;
   /** Optional sample indices to request. */
   bands?: number[];
   /** Whether to interleave multi-band output. Defaults to `false`. */
@@ -145,17 +154,25 @@ export type RasterSourceMetadata = {
 
 /**
  * RasterSource - data sources that allow typed raster data to be queried by viewport.
+ *
+ * @typeParam DataT Raster payload returned by the source.
+ * @typeParam ParametersT Request parameters accepted by the source.
+ * @typeParam MetadataT Metadata returned by the source.
  */
-export abstract class RasterSource {
+export abstract class RasterSource<
+  DataT extends RasterData = RasterData,
+  ParametersT extends GetRasterParameters = GetRasterParameters,
+  MetadataT extends RasterSourceMetadata = RasterSourceMetadata
+> {
   /** Canonical source type identifier used during source selection. */
   static type: string = 'template';
   /** URL matcher used during automatic source selection. */
   static testURL = (url: string): boolean => false;
 
   /** Returns normalized dataset metadata without loading raster samples. */
-  abstract getMetadata(): Promise<RasterSourceMetadata>;
+  abstract getMetadata(): Promise<MetadataT>;
   /** Loads raster samples for the supplied viewport request. */
-  abstract getRaster(parameters: GetRasterParameters): Promise<RasterData>;
+  abstract getRaster(parameters: ParametersT): Promise<DataT>;
 }
 
 /**

--- a/modules/tiles/src/raster-set.ts
+++ b/modules/tiles/src/raster-set.ts
@@ -10,57 +10,76 @@ import type {
 } from '@loaders.gl/loader-utils';
 
 /** Accepted raster request currently retained by {@link RasterSet}. */
-export type RasterSetRequest<DataT = RasterData> = {
+export type RasterSetRequest<
+  DataT extends RasterData = RasterData,
+  ParametersT extends GetRasterParameters = GetRasterParameters
+> = {
   /** Unique request id assigned by the manager. */
   requestId: number;
   /** Raster request parameters that produced the accepted raster payload. */
-  parameters: GetRasterParameters;
+  parameters: ParametersT;
   /** Raster retained as the current output. */
   raster: DataT;
 };
 
 /** Arguments supplied to {@link RasterSetBaseProps.shouldRefetch}. */
-export type RasterSetShouldRefetchArgs<DataT = RasterData> = {
+export type RasterSetShouldRefetchArgs<
+  DataT extends RasterData = RasterData,
+  ParametersT extends GetRasterParameters = GetRasterParameters,
+  MetadataT extends RasterSourceMetadata = RasterSourceMetadata
+> = {
   /** Current accepted request retained by the raster manager, if any. */
-  currentRequest: RasterSetRequest<DataT> | null;
+  currentRequest: RasterSetRequest<DataT, ParametersT> | null;
   /** Source metadata resolved by {@link RasterSet.loadMetadata}, if available. */
-  metadata: RasterSourceMetadata | null;
+  metadata: MetadataT | null;
   /** Candidate raster request parameters under evaluation. */
-  nextParameters: GetRasterParameters;
+  nextParameters: ParametersT;
 };
 
 /** Configuration shared by all {@link RasterSet} instances. */
-export type RasterSetBaseProps<DataT = RasterData> = {
+export type RasterSetBaseProps<
+  DataT extends RasterData = RasterData,
+  ParametersT extends GetRasterParameters = GetRasterParameters,
+  MetadataT extends RasterSourceMetadata = RasterSourceMetadata
+> = {
   /** Callback used to load source metadata. */
-  getMetadata: () => Promise<RasterSourceMetadata>;
+  getMetadata: () => Promise<MetadataT>;
   /** Callback used to load raster data for a viewport-derived request. */
-  getRaster: (parameters: GetRasterParameters) => Promise<DataT>;
+  getRaster: (parameters: ParametersT) => Promise<DataT>;
   /** Debounce interval applied before issuing raster requests. */
   debounceTime?: number;
   /** Optional policy callback that can skip redundant raster requests. */
-  shouldRefetch?: (args: RasterSetShouldRefetchArgs<DataT>) => boolean;
+  shouldRefetch?: (args: RasterSetShouldRefetchArgs<DataT, ParametersT, MetadataT>) => boolean;
 };
 
 /** Options for creating a {@link RasterSet}. */
-export type RasterSetProps<DataT = RasterData> = Partial<RasterSetBaseProps<DataT>> & {
+export type RasterSetProps<
+  DataT extends RasterData = RasterData,
+  ParametersT extends GetRasterParameters = GetRasterParameters,
+  MetadataT extends RasterSourceMetadata = RasterSourceMetadata
+> = Partial<RasterSetBaseProps<DataT, ParametersT, MetadataT>> & {
   /** Optional loaders.gl raster source backing this manager. */
-  rasterSource?: RasterSource | null;
+  rasterSource?: RasterSource<DataT, ParametersT, MetadataT> | null;
 };
 
 /** Subscription callbacks emitted by {@link RasterSet}. */
-export type RasterSetListener<DataT = RasterData> = {
+export type RasterSetListener<
+  DataT extends RasterData = RasterData,
+  ParametersT extends GetRasterParameters = GetRasterParameters,
+  MetadataT extends RasterSourceMetadata = RasterSourceMetadata
+> = {
   /** Fired when metadata/raster loading starts or stops. */
   onLoadingStateChange?: (isLoading: boolean) => void;
   /** Fired when source metadata resolves successfully. */
-  onMetadataLoad?: (metadata: RasterSourceMetadata) => void;
+  onMetadataLoad?: (metadata: MetadataT) => void;
   /** Fired when metadata loading fails. */
   onMetadataLoadError?: (error: Error) => void;
   /** Fired when a new raster request is issued. */
-  onRasterLoadStart?: (requestId: number, parameters: GetRasterParameters) => void;
+  onRasterLoadStart?: (requestId: number, parameters: ParametersT) => void;
   /** Fired when a raster request resolves and becomes current. */
-  onRasterLoad?: (request: RasterSetRequest<DataT>) => void;
+  onRasterLoad?: (request: RasterSetRequest<DataT, ParametersT>) => void;
   /** Fired when a raster request fails. */
-  onRasterLoadError?: (requestId: number, error: Error, parameters: GetRasterParameters) => void;
+  onRasterLoadError?: (requestId: number, error: Error, parameters: ParametersT) => void;
   /** Fired when metadata or the current raster changes. */
   onUpdate?: () => void;
 };
@@ -84,14 +103,24 @@ const DEFAULT_RASTERSET_PROPS: Required<Omit<RasterSetProps, 'rasterSource'>> = 
   shouldRefetch: () => true
 };
 
-/** Shared raster request manager used by viewport-driven raster examples and layers. */
-export class RasterSet<DataT = RasterData> {
+/**
+ * Shared raster request manager used by viewport-driven raster examples and layers.
+ *
+ * @typeParam DataT Raster payload retained by the manager.
+ * @typeParam ParametersT Request parameters accepted by the source.
+ * @typeParam MetadataT Metadata returned by the source.
+ */
+export class RasterSet<
+  DataT extends RasterData = RasterData,
+  ParametersT extends GetRasterParameters = GetRasterParameters,
+  MetadataT extends RasterSourceMetadata = RasterSourceMetadata
+> {
   /** Cached metadata returned by the backing source, if any. */
-  metadata: RasterSourceMetadata | null = null;
+  metadata: MetadataT | null = null;
 
-  private _opts: Required<RasterSetProps<DataT>>;
-  private _listeners = new Set<RasterSetListener<DataT>>();
-  private _currentRequest: RasterSetRequest<DataT> | null = null;
+  private _opts: Required<RasterSetProps<DataT, ParametersT, MetadataT>>;
+  private _listeners = new Set<RasterSetListener<DataT, ParametersT, MetadataT>>();
+  private _currentRequest: RasterSetRequest<DataT, ParametersT> | null = null;
   private _lastAcceptedRequestId = -1;
   private _nextRequestId = 0;
   private _loadCounter = 0;
@@ -100,7 +129,7 @@ export class RasterSet<DataT = RasterData> {
   private _finalized = false;
 
   /** Creates a raster manager from a source or direct callbacks. */
-  constructor(opts: RasterSetProps<DataT>) {
+  constructor(opts: RasterSetProps<DataT, ParametersT, MetadataT>) {
     this._opts = this._normalizeOptions(opts);
     if (!this._opts.rasterSource && (!opts.getRaster || !opts.getMetadata)) {
       throw new Error(
@@ -110,11 +139,18 @@ export class RasterSet<DataT = RasterData> {
   }
 
   /** Convenience factory for wrapping a loaders.gl {@link RasterSource}. */
-  static fromRasterSource<DataT = RasterData>(
-    rasterSource: RasterSource,
-    opts: Omit<RasterSetProps<DataT>, 'rasterSource' | 'getRaster' | 'getMetadata'> = {}
-  ): RasterSet<DataT> {
-    return new RasterSet<DataT>({...opts, rasterSource});
+  static fromRasterSource<
+    DataT extends RasterData = RasterData,
+    ParametersT extends GetRasterParameters = GetRasterParameters,
+    MetadataT extends RasterSourceMetadata = RasterSourceMetadata
+  >(
+    rasterSource: RasterSource<DataT, ParametersT, MetadataT>,
+    opts: Omit<
+      RasterSetProps<DataT, ParametersT, MetadataT>,
+      'rasterSource' | 'getRaster' | 'getMetadata'
+    > = {}
+  ): RasterSet<DataT, ParametersT, MetadataT> {
+    return new RasterSet<DataT, ParametersT, MetadataT>({...opts, rasterSource});
   }
 
   /** Whether the manager has no requests in flight and a current raster. */
@@ -128,23 +164,23 @@ export class RasterSet<DataT = RasterData> {
   }
 
   /** Current accepted request and raster payload, if any. */
-  get currentRequest(): RasterSetRequest<DataT> | null {
+  get currentRequest(): RasterSetRequest<DataT, ParametersT> | null {
     return this._currentRequest;
   }
 
   /** Backing raster source when constructed from one. */
-  get rasterSource(): RasterSource | null {
+  get rasterSource(): RasterSource<DataT, ParametersT, MetadataT> | null {
     return this._opts.rasterSource;
   }
 
   /** Subscribes to metadata and raster lifecycle events. */
-  subscribe(listener: RasterSetListener<DataT>): () => void {
+  subscribe(listener: RasterSetListener<DataT, ParametersT, MetadataT>): () => void {
     this._listeners.add(listener);
     return () => this._listeners.delete(listener);
   }
 
   /** Updates source callbacks or debounce settings, resetting state when the source changes. */
-  setOptions(opts: RasterSetProps<DataT>): void {
+  setOptions(opts: RasterSetProps<DataT, ParametersT, MetadataT>): void {
     const previousRasterSource = this._opts.rasterSource;
     const nextOptions = this._normalizeOptions({...this._opts, ...opts});
     const sourceChanged =
@@ -165,7 +201,7 @@ export class RasterSet<DataT = RasterData> {
   }
 
   /** Loads metadata from the current raster source or callbacks. */
-  async loadMetadata(): Promise<RasterSourceMetadata> {
+  async loadMetadata(): Promise<MetadataT> {
     this._startLoading();
     try {
       const metadata = await this._opts.getMetadata();
@@ -192,7 +228,7 @@ export class RasterSet<DataT = RasterData> {
   }
 
   /** Debounces and issues a new raster request for the supplied parameters. */
-  requestRaster(parameters: GetRasterParameters, debounceTime = this._opts.debounceTime): number {
+  requestRaster(parameters: ParametersT, debounceTime = this._opts.debounceTime): number {
     if (!this.shouldRefetchRaster(parameters)) {
       return this._currentRequest?.requestId ?? -1;
     }
@@ -213,7 +249,7 @@ export class RasterSet<DataT = RasterData> {
   }
 
   /** Returns `true` when the supplied parameters warrant a new raster fetch. */
-  shouldRefetchRaster(parameters: GetRasterParameters): boolean {
+  shouldRefetchRaster(parameters: ParametersT): boolean {
     return this._opts.shouldRefetch({
       currentRequest: this._currentRequest,
       metadata: this.metadata,
@@ -230,7 +266,7 @@ export class RasterSet<DataT = RasterData> {
   }
 
   /** Loads a raster immediately and accepts it only if it is the newest completed request. */
-  private async _loadRaster(requestId: number, parameters: GetRasterParameters): Promise<void> {
+  private async _loadRaster(requestId: number, parameters: ParametersT): Promise<void> {
     if (this._finalized) {
       return;
     }
@@ -276,7 +312,9 @@ export class RasterSet<DataT = RasterData> {
   }
 
   /** Resolves current options from either a source or direct callbacks. */
-  private _normalizeOptions(opts: RasterSetProps<DataT>): Required<RasterSetProps<DataT>> {
+  private _normalizeOptions(
+    opts: RasterSetProps<DataT, ParametersT, MetadataT>
+  ): Required<RasterSetProps<DataT, ParametersT, MetadataT>> {
     const rasterSource = opts.rasterSource || null;
     return {
       ...DEFAULT_RASTERSET_PROPS,
@@ -288,22 +326,22 @@ export class RasterSet<DataT = RasterData> {
           if (rasterSource) {
             return rasterSource.getMetadata();
           }
-          return DEFAULT_RASTERSET_PROPS.getMetadata();
+          return DEFAULT_RASTERSET_PROPS.getMetadata() as Promise<MetadataT>;
         }),
       getRaster:
         opts.getRaster ||
-        ((parameters: GetRasterParameters) => {
+        ((parameters: ParametersT) => {
           if (rasterSource) {
-            return rasterSource.getRaster(parameters) as Promise<DataT>;
+            return rasterSource.getRaster(parameters);
           }
           return DEFAULT_RASTERSET_PROPS.getRaster(parameters) as Promise<DataT>;
         }),
       debounceTime: opts.debounceTime ?? DEFAULT_RASTERSET_PROPS.debounceTime,
       shouldRefetch:
         (opts.shouldRefetch as
-          | ((args: RasterSetShouldRefetchArgs<DataT>) => boolean)
+          | ((args: RasterSetShouldRefetchArgs<DataT, ParametersT, MetadataT>) => boolean)
           | undefined) ||
-        ((args: RasterSetShouldRefetchArgs<DataT>) =>
+        ((args: RasterSetShouldRefetchArgs<DataT, ParametersT, MetadataT>) =>
           DEFAULT_RASTERSET_PROPS.shouldRefetch(args as RasterSetShouldRefetchArgs))
     };
   }

--- a/modules/tiles/test/raster-set-dimensions.spec.ts
+++ b/modules/tiles/test/raster-set-dimensions.spec.ts
@@ -1,0 +1,95 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, expectTypeOf, test} from 'vitest';
+import type {
+  GetRasterParameters,
+  RasterData,
+  RasterSource,
+  RasterSourceMetadata,
+  RasterViewport
+} from '@loaders.gl/loader-utils';
+import {RasterSet} from '@loaders.gl/tiles';
+
+type TemporalRasterParameters = GetRasterParameters & {
+  selection: {time: number};
+};
+
+type TemporalRasterMetadata = RasterSourceMetadata & {
+  selectionDimensions: Array<{name: string; size: number; defaultIndex: number}>;
+};
+
+test('RasterSet preserves source-specific request and metadata types', async () => {
+  const viewport: RasterViewport = {
+    id: 'temporal-raster',
+    width: 2,
+    height: 1,
+    zoom: 0,
+    center: [0, 0],
+    bounds: [
+      [0, 0],
+      [2, 1]
+    ],
+    project: coordinates => coordinates,
+    unprojectPosition: position => [position[0], position[1], position[2] || 0]
+  };
+  const metadata: TemporalRasterMetadata = {
+    width: 2,
+    height: 1,
+    bandCount: 1,
+    dtype: 'float32',
+    selectionDimensions: [{name: 'time', size: 12, defaultIndex: 0}]
+  };
+  const raster: RasterData = {
+    data: new Float32Array([1, 2]),
+    width: 2,
+    height: 1,
+    bandCount: 1,
+    dtype: 'float32'
+  };
+  let receivedParameters: TemporalRasterParameters | null = null;
+  let startedTimeIndex: number | null = null;
+  const source: RasterSource<RasterData, TemporalRasterParameters, TemporalRasterMetadata> = {
+    getMetadata: async () => metadata,
+    getRaster: async parameters => {
+      receivedParameters = parameters;
+      return raster;
+    }
+  };
+  const rasterSet = RasterSet.fromRasterSource(source, {
+    shouldRefetch: ({currentRequest, nextParameters, metadata: currentMetadata}) =>
+      !currentRequest ||
+      currentRequest.parameters.selection.time !== nextParameters.selection.time ||
+      currentMetadata?.selectionDimensions[0].name !== 'time'
+  });
+
+  expectTypeOf(rasterSet.metadata).toEqualTypeOf<TemporalRasterMetadata | null>();
+  expectTypeOf(rasterSet.currentRequest?.parameters).toEqualTypeOf<
+    TemporalRasterParameters | undefined
+  >();
+
+  const loadedMetadata = await rasterSet.loadMetadata();
+  const loadedRequest = new Promise<TemporalRasterParameters>(resolve => {
+    rasterSet.subscribe({
+      onRasterLoadStart: (_requestId, parameters) => {
+        startedTimeIndex = parameters.selection.time;
+      },
+      onRasterLoad: request => resolve(request.parameters)
+    });
+  });
+
+  rasterSet.requestRaster({viewport, selection: {time: 4}});
+  const acceptedParameters = await loadedRequest;
+
+  expect(loadedMetadata.selectionDimensions).toEqual([{name: 'time', size: 12, defaultIndex: 0}]);
+  expect(startedTimeIndex).toBe(4);
+  expect(acceptedParameters.selection.time).toBe(4);
+  expect(receivedParameters).not.toBeNull();
+  expect(receivedParameters!.selection.time).toBe(4);
+  expect(receivedParameters!.signal).toBeInstanceOf(AbortSignal);
+  expect(rasterSet.shouldRefetchRaster({viewport, selection: {time: 4}})).toBe(false);
+  expect(rasterSet.shouldRefetchRaster({viewport, selection: {time: 5}})).toBe(true);
+
+  rasterSet.finalize();
+});

--- a/modules/zarr/src/geo-zarr-source-loader.ts
+++ b/modules/zarr/src/geo-zarr-source-loader.ts
@@ -80,10 +80,7 @@ export type GeoZarrSourceLoaderOptions = ZarrSourceLoaderOptions & {
 };
 
 /** Parameters used to request a native-resolution spatial window from a GeoZarr array. */
-export type GetGeoZarrParameters = Omit<GetRasterParameters, 'bands' | 'interleaved'> & {
-  /** Named indices for non-spatial dimensions such as time, vertical level, or band. */
-  selection?: Record<string, number>;
-};
+export type GetGeoZarrParameters = Omit<GetRasterParameters, 'bands' | 'interleaved'>;
 
 type GeoZarrAttributes = Record<string, unknown>;
 
@@ -166,7 +163,10 @@ export const GeoZarrSourceLoader = {
 } as const satisfies SourceLoader<GeoZarrRasterSource>;
 
 /** Viewport-driven raster source for GeoZarr and regular CF/xarray Zarr data variables. */
-export class GeoZarrRasterSource extends ZarrSource implements RasterSource {
+export class GeoZarrRasterSource
+  extends ZarrSource
+  implements RasterSource<RasterData, GetGeoZarrParameters, GeoZarrSourceMetadata>
+{
   /** Shared source initialization request. */
   private initializationPromise: Promise<GeoZarrInit> | null = null;
 


### PR DESCRIPTION
## Goals

- Let viewport-driven raster sources expose named non-spatial selections such as time and vertical level through the common raster request contract.
- Preserve source-specific raster data, request, and metadata types through `RasterSet` so GeoZarr can use the same loading manager pattern as GeoTIFF without losing type information.
- Establish the API foundation for a follow-up GeoZarr example migration to `RasterSet`.

## Changes

- Add and export `RasterSelection`, and expose `selection` on `GetRasterParameters`.
- Make `RasterSource` generic over its raster payload, request parameters, and metadata while preserving the existing defaults.
- Propagate those types through `RasterSet`, its request records, listeners, refetch policy, callbacks, and `fromRasterSource()` inference.
- Type `GeoZarrRasterSource` with its specific request and metadata contracts and remove its duplicate selection declaration.
- Add a focused Vitest case covering dimension selection, type inference, metadata, callbacks, abort-signal forwarding, and refetch behavior.
- Update RasterSource, RasterSet, GeoZarr, and release documentation.

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn build-workers`
- `yarn test-node` — 189 passed, 6 skipped
- `yarn test-headless` — 1,878 passed, 50 skipped
- `yarn test-audit` — 0 violations
- `yarn workspace project-website build`
