### PR TITLE
perf(parquet): build nested Arrow vectors directly

### DIFF
--- a/modules/parquet/src/lib/arrow/create-nested-arrow-vector.ts
+++ b/modules/parquet/src/lib/arrow/create-nested-arrow-vector.ts
@@ -1,0 +1,544 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import * as arrow from 'apache-arrow';
+
+import type {
+  ParquetColumnChunk,
+  ParquetField,
+  ParquetRowGroup
+} from '../../parquetjs/schema/declare';
+
+/** Largest byte value copied inline to avoid TypedArray#set call overhead. */
+const MAXIMUM_INLINE_BYTE_COPY_LENGTH = 7;
+
+/** Primitive Arrow arrays emitted directly from decoded physical Parquet values. */
+type NestedPrimitiveArrowArray = Float32Array | Float64Array | Int32Array | BigInt64Array;
+
+/** Selected decoded values and their Arrow validity information. */
+type SelectedLeafValues = {
+  length: number;
+  firstValueIndex: number;
+  valueCount: number;
+  nullBitmap?: Uint8Array;
+  nullCount: number;
+};
+
+/** Repeated-list offsets plus the selected primitive values contained by the lists. */
+type SelectedRepeatedValues = SelectedLeafValues & {
+  valueOffsets: Int32Array;
+};
+
+/**
+ * Creates an Arrow List vector directly from a repeated Parquet primitive or repeated struct.
+ * Returns undefined for shapes whose repetition tree is not supported by the direct path.
+ */
+export function createNestedArrowVector(
+  arrowType: arrow.DataType,
+  parquetField: ParquetField,
+  rowGroup: ParquetRowGroup,
+  start: number,
+  end: number
+): arrow.Vector | undefined {
+  if (!(arrowType instanceof arrow.List) || parquetField.repetitionType !== 'REPEATED') {
+    return undefined;
+  }
+
+  const data = parquetField.fields
+    ? createRepeatedStructData(arrowType, parquetField, rowGroup, start, end)
+    : createRepeatedPrimitiveData(arrowType, parquetField, rowGroup, start, end);
+  return data ? new arrow.Vector([data]) : undefined;
+}
+
+/** Creates a top-level repeated primitive as Arrow List data. */
+function createRepeatedPrimitiveData(
+  listType: arrow.List,
+  parquetField: ParquetField,
+  rowGroup: ParquetRowGroup,
+  start: number,
+  end: number
+): arrow.Data | undefined {
+  const columnData = rowGroup.columnData[parquetField.key];
+  if (!columnData) {
+    return undefined;
+  }
+
+  const selected = selectRootRepeatedValues(columnData, parquetField, start, end);
+  const childData = createSelectedLeafData(
+    listType.children[0].type,
+    parquetField,
+    columnData,
+    selected
+  );
+  if (!childData) {
+    return undefined;
+  }
+
+  return arrow.makeData({
+    type: listType,
+    valueOffsets: selected.valueOffsets,
+    child: childData
+  } as any);
+}
+
+/** Creates a top-level repeated group as Arrow List<Struct> data. */
+function createRepeatedStructData(
+  listType: arrow.List,
+  parquetField: ParquetField,
+  rowGroup: ParquetRowGroup,
+  start: number,
+  end: number
+): arrow.Data | undefined {
+  const structType = listType.children[0].type;
+  if (!(structType instanceof arrow.Struct)) {
+    return undefined;
+  }
+
+  const primitiveLeaves = listPrimitiveLeaves(parquetField);
+  const driverField = primitiveLeaves.reduce<ParquetField | undefined>(
+    (driver, leaf) => (!driver || leaf.rLevelMax < driver.rLevelMax ? leaf : driver),
+    undefined
+  );
+  const driverColumn = driverField && rowGroup.columnData[driverField.key];
+  if (!driverField || !driverColumn) {
+    return undefined;
+  }
+
+  const rootLayout = selectRepeatedStructLayout(driverColumn, parquetField, start, end);
+  const children: arrow.Data[] = [];
+  for (const arrowChild of structType.children) {
+    const parquetChild = parquetField.fields?.[arrowChild.name];
+    if (!parquetChild || parquetChild.fields) {
+      return undefined;
+    }
+    const columnData = rowGroup.columnData[parquetChild.key];
+    if (!columnData) {
+      return undefined;
+    }
+
+    let childData: arrow.Data | undefined;
+    if (parquetChild.repetitionType === 'REPEATED' && arrowChild.type instanceof arrow.List) {
+      childData = createRepeatedStructChildData(
+        arrowChild.type,
+        parquetField,
+        parquetChild,
+        columnData,
+        start,
+        end,
+        rootLayout.elementCount
+      );
+    } else {
+      const selected = selectStructScalarValues(
+        columnData,
+        parquetField,
+        parquetChild,
+        start,
+        end,
+        rootLayout.elementCount
+      );
+      childData = createSelectedLeafData(arrowChild.type, parquetChild, columnData, selected);
+    }
+    if (!childData) {
+      return undefined;
+    }
+    children.push(childData);
+  }
+
+  const structData = arrow.makeData({
+    type: structType,
+    length: rootLayout.elementCount,
+    nullCount: 0,
+    children
+  });
+  return arrow.makeData({
+    type: listType,
+    valueOffsets: rootLayout.valueOffsets,
+    child: structData
+  } as any);
+}
+
+/** Creates one repeated primitive child within a repeated struct. */
+function createRepeatedStructChildData(
+  listType: arrow.List,
+  parentField: ParquetField,
+  parquetField: ParquetField,
+  columnData: ParquetColumnChunk,
+  start: number,
+  end: number,
+  parentCount: number
+): arrow.Data | undefined {
+  const selected = selectStructRepeatedValues(
+    columnData,
+    parentField,
+    parquetField,
+    start,
+    end,
+    parentCount
+  );
+  const childData = createSelectedLeafData(
+    listType.children[0].type,
+    parquetField,
+    columnData,
+    selected
+  );
+  if (!childData) {
+    return undefined;
+  }
+  return arrow.makeData({
+    type: listType,
+    valueOffsets: selected.valueOffsets,
+    child: childData
+  } as any);
+}
+
+/** Selects primitive values and row offsets for a top-level repeated leaf. */
+function selectRootRepeatedValues(
+  columnData: ParquetColumnChunk,
+  parquetField: ParquetField,
+  start: number,
+  end: number
+): SelectedRepeatedValues {
+  const rowCount = end - start;
+  const valueCounts = new Int32Array(rowCount);
+  let rowIndex = -1;
+  let sourceValueIndex = 0;
+  let firstValueIndex = -1;
+  let valueCount = 0;
+
+  for (let levelIndex = 0; levelIndex < columnData.dlevels.length; levelIndex++) {
+    if (columnData.rlevels[levelIndex] === 0) {
+      rowIndex++;
+    }
+    const hasValue = columnData.dlevels[levelIndex] === parquetField.dLevelMax;
+    if (rowIndex >= start && rowIndex < end && hasValue) {
+      firstValueIndex = firstValueIndex < 0 ? sourceValueIndex : firstValueIndex;
+      valueCounts[rowIndex - start]++;
+      valueCount++;
+    }
+    if (hasValue) {
+      sourceValueIndex++;
+    }
+    if (rowIndex >= end) {
+      break;
+    }
+  }
+
+  return {
+    length: valueCount,
+    firstValueIndex: Math.max(0, firstValueIndex),
+    valueCount,
+    nullCount: 0,
+    valueOffsets: accumulateOffsets(valueCounts)
+  };
+}
+
+/** Selects row offsets and element count for a top-level repeated group. */
+function selectRepeatedStructLayout(
+  columnData: ParquetColumnChunk,
+  parentField: ParquetField,
+  start: number,
+  end: number
+): {valueOffsets: Int32Array; elementCount: number} {
+  const valueCounts = new Int32Array(end - start);
+  let rowIndex = -1;
+  let elementCount = 0;
+
+  for (let levelIndex = 0; levelIndex < columnData.dlevels.length; levelIndex++) {
+    const repetitionLevel = columnData.rlevels[levelIndex];
+    if (repetitionLevel === 0) {
+      rowIndex++;
+    }
+    if (
+      rowIndex >= start &&
+      rowIndex < end &&
+      repetitionLevel <= parentField.rLevelMax &&
+      columnData.dlevels[levelIndex] >= parentField.dLevelMax
+    ) {
+      valueCounts[rowIndex - start]++;
+      elementCount++;
+    }
+    if (rowIndex >= end) {
+      break;
+    }
+  }
+
+  return {valueOffsets: accumulateOffsets(valueCounts), elementCount};
+}
+
+/** Selects scalar child values aligned to the repeated parent struct elements. */
+function selectStructScalarValues(
+  columnData: ParquetColumnChunk,
+  parentField: ParquetField,
+  parquetField: ParquetField,
+  start: number,
+  end: number,
+  parentCount: number
+): SelectedLeafValues {
+  const nullBitmap = new Uint8Array(Math.ceil(parentCount / 8));
+  let rowIndex = -1;
+  let sourceValueIndex = 0;
+  let firstValueIndex = -1;
+  let outputIndex = 0;
+  let valueCount = 0;
+
+  for (let levelIndex = 0; levelIndex < columnData.dlevels.length; levelIndex++) {
+    const repetitionLevel = columnData.rlevels[levelIndex];
+    if (repetitionLevel === 0) {
+      rowIndex++;
+    }
+    const definitionLevel = columnData.dlevels[levelIndex];
+    const hasValue = definitionLevel === parquetField.dLevelMax;
+    if (
+      rowIndex >= start &&
+      rowIndex < end &&
+      repetitionLevel <= parentField.rLevelMax &&
+      definitionLevel >= parentField.dLevelMax
+    ) {
+      if (hasValue) {
+        firstValueIndex = firstValueIndex < 0 ? sourceValueIndex : firstValueIndex;
+        nullBitmap[outputIndex >> 3] |= 1 << (outputIndex & 7);
+        valueCount++;
+      }
+      outputIndex++;
+    }
+    if (hasValue) {
+      sourceValueIndex++;
+    }
+    if (rowIndex >= end) {
+      break;
+    }
+  }
+
+  if (outputIndex !== parentCount) {
+    throw new Error(
+      `Parquet nested column ${parquetField.key} has ${outputIndex} parent values; expected ${parentCount}`
+    );
+  }
+  const nullCount = parentCount - valueCount;
+  return {
+    length: parentCount,
+    firstValueIndex: Math.max(0, firstValueIndex),
+    valueCount,
+    nullBitmap: nullCount ? nullBitmap : undefined,
+    nullCount
+  };
+}
+
+/** Selects repeated child values and list offsets aligned to repeated parent struct elements. */
+function selectStructRepeatedValues(
+  columnData: ParquetColumnChunk,
+  parentField: ParquetField,
+  parquetField: ParquetField,
+  start: number,
+  end: number,
+  parentCount: number
+): SelectedRepeatedValues {
+  const valueCounts = new Int32Array(parentCount);
+  let rowIndex = -1;
+  let parentIndex = -1;
+  let sourceValueIndex = 0;
+  let firstValueIndex = -1;
+  let valueCount = 0;
+
+  for (let levelIndex = 0; levelIndex < columnData.dlevels.length; levelIndex++) {
+    const repetitionLevel = columnData.rlevels[levelIndex];
+    if (repetitionLevel === 0) {
+      rowIndex++;
+    }
+    const definitionLevel = columnData.dlevels[levelIndex];
+    const hasValue = definitionLevel === parquetField.dLevelMax;
+    if (rowIndex >= start && rowIndex < end) {
+      if (repetitionLevel <= parentField.rLevelMax && definitionLevel >= parentField.dLevelMax) {
+        parentIndex++;
+      }
+      if (hasValue) {
+        if (parentIndex < 0 || parentIndex >= parentCount) {
+          throw new Error(
+            `Parquet nested column ${parquetField.key} has invalid repetition levels`
+          );
+        }
+        firstValueIndex = firstValueIndex < 0 ? sourceValueIndex : firstValueIndex;
+        valueCounts[parentIndex]++;
+        valueCount++;
+      }
+    }
+    if (hasValue) {
+      sourceValueIndex++;
+    }
+    if (rowIndex >= end) {
+      break;
+    }
+  }
+
+  if (parentIndex + 1 !== parentCount) {
+    throw new Error(
+      `Parquet nested column ${parquetField.key} has ${parentIndex + 1} parent values; expected ${parentCount}`
+    );
+  }
+  return {
+    length: valueCount,
+    firstValueIndex: Math.max(0, firstValueIndex),
+    valueCount,
+    nullCount: 0,
+    valueOffsets: accumulateOffsets(valueCounts)
+  };
+}
+
+/** Creates Arrow primitive or byte data for selected decoded leaf values. */
+function createSelectedLeafData(
+  arrowType: arrow.DataType,
+  parquetField: ParquetField,
+  columnData: ParquetColumnChunk,
+  selected: SelectedLeafValues
+): arrow.Data | undefined {
+  const primitiveData = createSelectedPrimitiveData(arrowType, parquetField, columnData, selected);
+  if (primitiveData) {
+    return primitiveData;
+  }
+  return createSelectedByteData(arrowType, parquetField, columnData, selected);
+}
+
+/** Creates fixed-width Arrow data for selected physical primitive values. */
+function createSelectedPrimitiveData(
+  arrowType: arrow.DataType,
+  parquetField: ParquetField,
+  columnData: ParquetColumnChunk,
+  selected: SelectedLeafValues
+): arrow.Data | undefined {
+  const data = createNestedPrimitiveArray(arrowType, parquetField, selected.length);
+  if (!data) {
+    return undefined;
+  }
+
+  const sourceValues = columnData.values;
+  let sourceValueIndex = selected.firstValueIndex;
+  for (let outputIndex = 0; outputIndex < selected.length; outputIndex++) {
+    if (!selected.nullBitmap || selected.nullBitmap[outputIndex >> 3] & (1 << (outputIndex & 7))) {
+      setNestedPrimitiveValue(data, outputIndex, sourceValues[sourceValueIndex++]);
+    }
+  }
+
+  return arrow.makeData({
+    type: arrowType,
+    data,
+    nullBitmap: selected.nullBitmap,
+    nullCount: selected.nullCount
+  } as any);
+}
+
+/** Allocates the Arrow array matching an unconverted physical Parquet primitive. */
+function createNestedPrimitiveArray(
+  arrowType: arrow.DataType,
+  parquetField: ParquetField,
+  length: number
+): NestedPrimitiveArrowArray | undefined {
+  if (parquetField.originalType && parquetField.originalType !== 'INT_64') {
+    return undefined;
+  }
+  if (parquetField.primitiveType === 'FLOAT' && arrowType instanceof arrow.Float32) {
+    return new Float32Array(length);
+  }
+  if (parquetField.primitiveType === 'DOUBLE' && arrowType instanceof arrow.Float64) {
+    return new Float64Array(length);
+  }
+  if (parquetField.primitiveType === 'INT32' && arrowType instanceof arrow.Int32) {
+    return new Int32Array(length);
+  }
+  if (parquetField.primitiveType === 'INT64' && arrowType instanceof arrow.Int64) {
+    return new BigInt64Array(length);
+  }
+  return undefined;
+}
+
+/** Writes one decoded primitive into the exact array expected by Arrow. */
+function setNestedPrimitiveValue(
+  data: NestedPrimitiveArrowArray,
+  index: number,
+  value: unknown
+): void {
+  if (data instanceof BigInt64Array) {
+    data[index] = typeof value === 'bigint' ? value : BigInt(value as number | string);
+  } else {
+    data[index] = Number(value);
+  }
+}
+
+/** Creates Arrow Utf8 or Binary data for selected decoded byte values. */
+function createSelectedByteData(
+  arrowType: arrow.DataType,
+  parquetField: ParquetField,
+  columnData: ParquetColumnChunk,
+  selected: SelectedLeafValues
+): arrow.Data | undefined {
+  if (!supportsNestedByteData(arrowType, parquetField)) {
+    return undefined;
+  }
+
+  const byteValues = columnData.values as Uint8Array[];
+  const valueOffsets = new Int32Array(selected.length + 1);
+  let sourceValueIndex = selected.firstValueIndex;
+  let dataByteLength = 0;
+  for (let outputIndex = 0; outputIndex < selected.length; outputIndex++) {
+    if (!selected.nullBitmap || selected.nullBitmap[outputIndex >> 3] & (1 << (outputIndex & 7))) {
+      dataByteLength += byteValues[sourceValueIndex++].byteLength;
+      if (dataByteLength > 0x7fffffff) {
+        throw new Error('Arrow Utf8/Binary column exceeds the 32-bit offset range');
+      }
+    }
+    valueOffsets[outputIndex + 1] = dataByteLength;
+  }
+
+  const data = new Uint8Array(dataByteLength);
+  let dataOffset = 0;
+  const valueEnd = selected.firstValueIndex + selected.valueCount;
+  for (let valueIndex = selected.firstValueIndex; valueIndex < valueEnd; valueIndex++) {
+    const bytes = byteValues[valueIndex];
+    if (bytes.byteLength <= MAXIMUM_INLINE_BYTE_COPY_LENGTH) {
+      for (let byteIndex = 0; byteIndex < bytes.byteLength; byteIndex++) {
+        data[dataOffset++] = bytes[byteIndex];
+      }
+    } else {
+      data.set(bytes, dataOffset);
+      dataOffset += bytes.byteLength;
+    }
+  }
+
+  return arrow.makeData({
+    type: arrowType,
+    valueOffsets,
+    data,
+    nullBitmap: selected.nullBitmap,
+    nullCount: selected.nullCount
+  } as any);
+}
+
+/** Returns whether one Parquet byte leaf maps directly to Arrow Utf8 or Binary. */
+function supportsNestedByteData(arrowType: arrow.DataType, parquetField: ParquetField): boolean {
+  if (arrowType instanceof arrow.Utf8) {
+    return parquetField.originalType === 'UTF8';
+  }
+  return (
+    arrowType instanceof arrow.Binary &&
+    !parquetField.originalType &&
+    (parquetField.primitiveType === 'BYTE_ARRAY' ||
+      parquetField.primitiveType === 'FIXED_LEN_BYTE_ARRAY')
+  );
+}
+
+/** Lists all primitive descendant fields in schema order. */
+function listPrimitiveLeaves(parquetField: ParquetField): ParquetField[] {
+  if (!parquetField.fields) {
+    return [parquetField];
+  }
+  return Object.values(parquetField.fields).flatMap(listPrimitiveLeaves);
+}
+
+/** Converts per-parent value counts into Arrow list offsets. */
+function accumulateOffsets(valueCounts: Int32Array): Int32Array {
+  const valueOffsets = new Int32Array(valueCounts.length + 1);
+  for (let index = 0; index < valueCounts.length; index++) {
+    valueOffsets[index + 1] = valueOffsets[index] + valueCounts[index];
+  }
+  return valueOffsets;
+}

--- a/modules/parquet/src/lib/parsers/parse-parquet-to-arrow-js.ts
+++ b/modules/parquet/src/lib/parsers/parse-parquet-to-arrow-js.ts
@@ -26,6 +26,7 @@ import type {
 } from '../../parquetjs/schema/declare';
 import type {ParquetSchema} from '../../parquetjs/schema/schema';
 import {materializeColumn, materializeRows} from '../../parquetjs/schema/shred';
+import {createNestedArrowVector} from '../arrow/create-nested-arrow-vector';
 import {getSchemaFromParquetReader} from './get-parquet-schema';
 
 /** Largest byte value copied inline to avoid TypedArray#set call overhead. */
@@ -247,7 +248,7 @@ function createParquetArrowMetadata(metadata?: SchemaMetadata): Map<string, stri
   return arrowMetadata;
 }
 
-/** Builds Arrow from one selected row-group range and falls back for nested columns. */
+/** Builds Arrow from one selected row-group range with per-column fallbacks. */
 function convertRowGroupSliceToArrow(
   schema: Schema,
   arrowSchema: arrow.Schema,
@@ -256,19 +257,16 @@ function convertRowGroupSliceToArrow(
   start: number,
   end: number
 ): ArrowTable {
-  if (Object.keys(rowGroup.columnData).some(columnKey => columnKey.includes(','))) {
-    const table: ObjectRowTable = {
-      shape: 'object-row-table',
-      schema,
-      data: materializeRows(parquetSchema, rowGroup).slice(start, end)
-    };
-    return convertTable(table, 'arrow-table');
-  }
-
   const vectors: Record<string, arrow.Vector> = {};
+  let materializedRows: Record<string, unknown>[] | undefined;
   for (const field of arrowSchema.fields) {
     const parquetField = parquetSchema.findField(field.name);
     const columnData = rowGroup.columnData[field.name];
+    const nestedVector = createNestedArrowVector(field.type, parquetField, rowGroup, start, end);
+    if (nestedVector) {
+      vectors[field.name] = nestedVector;
+      continue;
+    }
     const primitiveVector = createRawPrimitiveArrowVector(
       field.type,
       parquetField,
@@ -286,9 +284,26 @@ function convertRowGroupSliceToArrow(
       continue;
     }
 
-    const fullColumn =
-      materializeColumn(parquetSchema, rowGroup, field.name) ||
-      new Array(rowGroup.rowCount).fill(null);
+    let fullColumn = materializeColumn(parquetSchema, rowGroup, field.name);
+    if (!fullColumn && parquetField.fields) {
+      materializedRows ||= materializeRows(parquetSchema, rowGroup);
+      const fallbackTable: ObjectRowTable = {
+        shape: 'object-row-table',
+        schema: {
+          ...schema,
+          fields: schema.fields.filter(schemaField => schemaField.name === field.name)
+        },
+        data: materializedRows.slice(start, end)
+      };
+      const fallbackArrowTable = convertTable(fallbackTable, 'arrow-table');
+      const fallbackVector = fallbackArrowTable.data.getChild(field.name);
+      if (!fallbackVector) {
+        throw new Error(`Failed to materialize nested Parquet column ${field.name}`);
+      }
+      vectors[field.name] = fallbackVector;
+      continue;
+    }
+    fullColumn ||= new Array(rowGroup.rowCount).fill(null);
     const column = sliceColumn(fullColumn, start, end);
     vectors[field.name] = arrow.vectorFromArray(
       normalizeArrowColumn(column, field.type),

--- a/modules/parquet/src/parquetjs/utils/read-utils.ts
+++ b/modules/parquet/src/parquetjs/utils/read-utils.ts
@@ -91,26 +91,31 @@ export function getBitWidth(val: number): number {
   return Math.ceil(Math.log2(val + 1));
 }
 
-// Supports MQTT path wildcards
-// + all immediate children
-// # all descendents
+/**
+ * Finds the selected field path that contains a Parquet leaf path.
+ * A selected parent includes all descendant leaves. MQTT-style `+` and `#` path wildcards are
+ * retained for internal callers (`+` matches one segment and `#` matches all remaining segments).
+ */
 export function fieldIndexOf(arr: string[][], elem: string[]): number {
-  for (let j = 0; j < arr.length; j++) {
-    if (arr[j].length > elem.length) {
-      continue; // eslint-disable-line no-continue
-    }
-    let m = true;
-    for (let i = 0; i < elem.length; i++) {
-      if (arr[j][i] === elem[i] || arr[j][i] === '+' || arr[j][i] === '#') {
-        continue; // eslint-disable-line no-continue
+  for (let fieldIndex = 0; fieldIndex < arr.length; fieldIndex++) {
+    const selectedPath = arr[fieldIndex];
+    let matches = true;
+    for (let pathIndex = 0; pathIndex < selectedPath.length; pathIndex++) {
+      const selectedSegment = selectedPath[pathIndex];
+      if (selectedSegment === '#') {
+        return fieldIndex;
       }
-      if (i >= arr[j].length && arr[j][arr[j].length - 1] === '#') {
-        continue; // eslint-disable-line no-continue
+      if (
+        pathIndex >= elem.length ||
+        (selectedSegment !== '+' && selectedSegment !== elem[pathIndex])
+      ) {
+        matches = false;
+        break;
       }
-      m = false;
-      break;
     }
-    if (m) return j;
+    if (matches) {
+      return fieldIndex;
+    }
   }
   return -1;
 }

--- a/modules/parquet/test/parquet-nested-arrow.spec.ts
+++ b/modules/parquet/test/parquet-nested-arrow.spec.ts
@@ -1,0 +1,47 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+
+import {load} from '@loaders.gl/core';
+import {ParquetJSLoader} from '@loaders.gl/parquet';
+
+test('ParquetJSLoader projects nested and repeated columns directly to Arrow', async () => {
+  const table = await load(
+    '@loaders.gl/parquet/test/data/fruits.parquet',
+    ParquetJSLoader,
+    {
+      core: {worker: false},
+      parquet: {
+        shape: 'arrow-table',
+        columns: ['stock', 'colour'],
+        offset: 1,
+        limit: 3,
+        batchSize: 2
+      }
+    }
+  );
+
+  expect(table.shape).toBe('arrow-table');
+  if (table.shape !== 'arrow-table') {
+    return;
+  }
+
+  expect(table.data.schema.fields.map(field => field.name)).toEqual(['stock', 'colour']);
+  expect(table.data.batches.map(batch => batch.numRows)).toEqual([2, 1]);
+  expect(table.data.getChild('colour')?.get(0)?.toArray()).toEqual(['orange']);
+  const stock = JSON.parse(
+    JSON.stringify(table.data.getChild('stock')?.toArray(), (_key, value) =>
+      typeof value === 'bigint' ? value.toString() : value
+    )
+  );
+  expect(stock).toEqual([
+    [{quantity: ['50', '33'], warehouse: 'X'}],
+    [
+      {quantity: ['42'], warehouse: 'f'},
+      {quantity: ['20'], warehouse: 'x'}
+    ],
+    []
+  ]);
+});

--- a/modules/parquet/test/parquetjs/read-utils.spec.ts
+++ b/modules/parquet/test/parquetjs/read-utils.spec.ts
@@ -1,0 +1,23 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+
+import {fieldIndexOf} from '../../src/parquetjs/utils/read-utils';
+
+describe('fieldIndexOf', () => {
+  test('matches selected parents and exact leaf paths', () => {
+    expect(fieldIndexOf([['stock']], ['stock', 'quantity'])).toBe(0);
+    expect(fieldIndexOf([['colour']], ['stock', 'quantity'])).toBe(-1);
+    expect(fieldIndexOf([['stock', 'quantity']], ['stock', 'quantity'])).toBe(0);
+    expect(fieldIndexOf([['stock', 'quantity']], ['stock'])).toBe(-1);
+  });
+
+  test('matches MQTT-style path wildcards', () => {
+    expect(fieldIndexOf([['stock', '+']], ['stock', 'quantity'])).toBe(0);
+    expect(fieldIndexOf([['stock', '+']], ['stock', 'quantity', 'unit'])).toBe(0);
+    expect(fieldIndexOf([['stock', '#']], ['stock', 'quantity', 'unit'])).toBe(0);
+    expect(fieldIndexOf([['+', 'quantity']], ['stock', 'quantity'])).toBe(0);
+  });
+});

--- a/test/large-fixture-allowlist.txt
+++ b/test/large-fixture-allowlist.txt
@@ -9,6 +9,7 @@ modules/gltf/test/glb-loader.spec.ts::modules/gltf/test/data/gltf-2.0/2CylinderE
 modules/gltf/test/gltf-loader.spec.ts::modules/gltf/test/data/gltf-2.0/2CylinderEngine.glb # Canonical multi-mesh glTF preserves realistic scene and resource integration coverage.
 modules/loader-utils/test/lib/iterators/make-iterator.spec.ts::modules/draco/test/data/raw-attribute-buffers/lidar-positions.bin # Iterator chunk-boundary coverage needs a buffer large enough to span many chunks.
 modules/parquet/test/parquet-loader.spec.ts::modules/parquet/test/data/fruits.parquet # Canonical Parquet interoperability fixture covers encoded pages and schema metadata.
+modules/parquet/test/parquet-nested-arrow.spec.ts::modules/parquet/test/data/fruits.parquet # Canonical nested/repeated fixture validates projected Arrow offsets, struct children, and row slicing.
 modules/parquet/test/parquetjs/integration.spec.ts::modules/parquet/test/data/fruits.parquet # JavaScript backend parity is checked against the canonical encoded-page fixture.
 modules/parquet/test/parquetjs/reader.spec.ts::modules/parquet/test/data/fruits.parquet # Reader integration retains realistic row-group and metadata behavior.
 modules/ply/test/ply-loader.spec.js::modules/ply/test/data/bun_zipper.ply # Canonical Stanford bunny fixture covers a realistic mesh header and vertex corpus.


### PR DESCRIPTION
## Goals

- Correct top-level projection of nested Parquet fields by selecting all descendant leaf chunks.
- Remove object-row materialization from the common repeated primitive and repeated struct Arrow paths.
- Preserve correctness for deeper unsupported nesting with a per-column fallback instead of forcing the entire table through object rows.

## Changes

- Fixes Parquet field-path matching so selecting `stock` includes `stock.quantity` and `stock.warehouse`.
- Builds Arrow list offsets directly from Parquet repetition levels.
- Builds repeated struct children, nested repeated child offsets, validity bitmaps, and primitive/UTF-8 buffers directly from decoded definition/repetition levels.
- Keeps ranged and batched parsing columnar, including empty repeated groups.
- Adds native Vitest coverage for nested projection, non-zero offsets, batching, empty lists, exact nested `INT64` values, and path wildcard/prefix behavior.
- Retains the established one-column object fallback for deeper nesting that is not yet handled by the direct builder.

## Performance

On the live benchmark fixture (`PLAIN nested and repeated projection → Arrow`, 40K rows), one local run measured:

- `ParquetJSLoader`: 871K rows/s
- pinned `hyparquet`: 138K rows/s

That is about 6.3× in this run, with high host variance. The previous loaders.gl result is not a valid baseline because the projection bug returned null for the nested `stock` column.

## Validation

- `yarn build`
- `yarn build-workers`
- `yarn test-node` — 189 passed
- `yarn test-headless` — 1,890 passed
- `yarn test-audit` — 0 violations
- `yarn lint fix`
