### PR TITLE
chore: add SPDX headers to bson, copc, and geopackage

### DIFF
--- a/modules/bson/test/bson-loader.bench.js
+++ b/modules/bson/test/bson-loader.bench.js
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {BSONLoader} from '@loaders.gl/bson';
 import {load} from '@loaders.gl/core';
 

--- a/modules/bson/test/index.ts
+++ b/modules/bson/test/index.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // JSON Parsers
 import './bson-loader.spec';
 // import './json-writer.spec';

--- a/modules/copc/test/copc-source.spec.ts
+++ b/modules/copc/test/copc-source.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import test from 'test/utils/vitest-tape';
 import {createDataSource, encodeSync, fetchFile, isBrowser} from '@loaders.gl/core';
 import {COPCSourceLoader, COPCTileSource, COPCWriter} from '@loaders.gl/copc';

--- a/modules/geopackage/src/lib/parse-geopackage.ts
+++ b/modules/geopackage/src/lib/parse-geopackage.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 /* eslint-disable camelcase */
 import {isBrowser} from '@loaders.gl/loader-utils';
 import type {

--- a/modules/geopackage/src/lib/types.ts
+++ b/modules/geopackage/src/lib/types.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 /* eslint-disable camelcase */
 export interface GeometryBitFlags {
   littleEndian: boolean;

--- a/modules/geopackage/test/geopackage-arrow-loader.spec.ts
+++ b/modules/geopackage/test/geopackage-arrow-loader.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import test from 'test/utils/vitest-tape';
 import {validateLoader} from 'test/common/conformance';
 import {setLoaderOptions, fetchFile, load} from '@loaders.gl/core';

--- a/modules/geopackage/test/geopackage-loader.spec.ts
+++ b/modules/geopackage/test/geopackage-loader.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import test from 'test/utils/vitest-tape';
 import {load, fetchFile} from '@loaders.gl/core';
 import {GeoPackageLoader} from '@loaders.gl/geopackage';

--- a/modules/geopackage/test/geopackage-source.spec.ts
+++ b/modules/geopackage/test/geopackage-source.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import test from 'test/utils/vitest-tape';
 import {createDataSource, fetchFile, load, setLoaderOptions} from '@loaders.gl/core';
 import {getTableRowAsObject} from '@loaders.gl/schema-utils';


### PR DESCRIPTION
## Goal

Continue #2830 by completing the SPDX license-header pass for the BSON, COPC, and GeoPackage modules.

## Changes

- Add the standard loaders.gl MIT SPDX header to all previously uncovered JavaScript and TypeScript source/test files in `modules/bson`, `modules/copc`, and `modules/geopackage`.
- Keep the batch limited to clearly project-authored files; no vendored sources or generated bundle artifacts are changed.

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn build-workers`
- `yarn test-node` — 27 files passed; 189 tests passed, 6 skipped
- `yarn test-headless` — 356 files passed, 2 skipped; 1,877 tests passed, 50 skipped
- SPDX audit across the three modules' JavaScript and TypeScript source/test files