### PR TITLE
perf(parquet): decode levels into column buffers

### DIFF
--- a/modules/parquet/src/parquetjs/parser/decoders.ts
+++ b/modules/parquet/src/parquetjs/parser/decoders.ts
@@ -28,11 +28,14 @@ import {decompress} from '../compression';
 import {PARQUET_RDLVL_TYPE, PARQUET_RDLVL_ENCODING} from '../../lib/constants';
 import {decodePageHeader, getThriftEnum, getBitWidth} from '../utils/read-utils';
 
-/** Preallocated column destination used to bypass page-local value arrays. */
+/** Preallocated column destination used to bypass page-local value and level arrays. */
 type ParquetPageDecodeTarget = {
   values: ParquetValueBuffer;
   valueOffset: number;
   dictionary: readonly unknown[];
+  rlevels: number[];
+  dlevels: number[];
+  levelOffset: number;
 };
 
 /**
@@ -63,8 +66,14 @@ export async function decodeDataPages(
 
   const outputCapacity = expectedLevelCount ?? 0;
   const data: ParquetColumnChunk = {
-    rlevels: new Array<number>(outputCapacity),
-    dlevels: new Array<number>(outputCapacity),
+    rlevels:
+      context.rLevelMax > 0
+        ? new Array<number>(outputCapacity)
+        : new Array<number>(outputCapacity).fill(0),
+    dlevels:
+      context.dLevelMax > 0
+        ? new Array<number>(outputCapacity)
+        : new Array<number>(outputCapacity).fill(0),
     values: createParquetColumnValueBuffer(context, outputCapacity),
     pageHeaders: [],
     count: 0
@@ -83,7 +92,10 @@ export async function decodeDataPages(
     const page = await decodePage(cursor, context, {
       values: data.values,
       valueOffset,
-      dictionary
+      dictionary,
+      rlevels: data.rlevels,
+      dlevels: data.dlevels,
+      levelOffset
     });
 
     if (page.dictionary) {
@@ -92,11 +104,7 @@ export async function decodeDataPages(
       continue;
     }
 
-    for (let index = 0; index < page.rlevels.length; index++) {
-      data.rlevels[levelOffset + index] = page.rlevels[index];
-      data.dlevels[levelOffset + index] = page.dlevels[index];
-    }
-    levelOffset += page.rlevels.length;
+    levelOffset += page.count;
 
     if (page.directValuesWritten !== undefined) {
       valueOffset += page.directValuesWritten;
@@ -297,39 +305,39 @@ async function decodeDataPage(
     Encoding,
     header.data_page_header?.repetition_level_encoding!
   ) as ParquetCodec;
-  // tslint:disable-next-line:prefer-array-literal
-  let rLevels = new Array(valueCount);
-
-  if (context.column.rLevelMax > 0) {
-    rLevels = decodeValues(PARQUET_RDLVL_TYPE, rLevelEncoding, dataCursor, valueCount!, {
-      bitWidth: getBitWidth(context.column.rLevelMax),
-      disableEnvelope: false
-      // column: opts.column
-    }) as number[];
-  } else {
-    rLevels.fill(0);
-  }
+  const rLevels = decodeLevels(
+    dataCursor,
+    valueCount!,
+    context.column.rLevelMax,
+    rLevelEncoding,
+    false,
+    target?.rlevels,
+    target?.levelOffset
+  );
 
   /* read definition levels */
   const dLevelEncoding = getThriftEnum(
     Encoding,
     header.data_page_header?.definition_level_encoding!
   ) as ParquetCodec;
-  // tslint:disable-next-line:prefer-array-literal
-  let dLevels = new Array(valueCount);
+  const dLevels = decodeLevels(
+    dataCursor,
+    valueCount!,
+    context.column.dLevelMax,
+    dLevelEncoding,
+    false,
+    target?.dlevels,
+    target?.levelOffset
+  );
+  let valueCountNonNull = valueCount!;
   if (context.column.dLevelMax > 0) {
-    dLevels = decodeValues(PARQUET_RDLVL_TYPE, dLevelEncoding, dataCursor, valueCount!, {
-      bitWidth: getBitWidth(context.column.dLevelMax),
-      disableEnvelope: false
-      // column: opts.column
-    }) as number[];
-  } else {
-    dLevels.fill(0);
-  }
-  let valueCountNonNull = 0;
-  for (const dlvl of dLevels) {
-    if (dlvl === context.column.dLevelMax) {
-      valueCountNonNull++;
+    valueCountNonNull = 0;
+    const decodedDefinitionLevels = target?.dlevels || dLevels;
+    const definitionLevelOffset = target?.levelOffset || 0;
+    for (let index = 0; index < valueCount!; index++) {
+      if (decodedDefinitionLevels[definitionLevelOffset + index] === context.column.dLevelMax) {
+        valueCountNonNull++;
+      }
     }
   }
 
@@ -394,49 +402,47 @@ async function decodeDataPageV2(
   }
 
   /* read repetition levels */
-  // tslint:disable-next-line:prefer-array-literal
-  let rLevels = new Array(valueCount);
+  let rLevels: number[] = [];
   if (context.column.rLevelMax > 0) {
     const repetitionLevelCursor = createPageSliceCursor(
       cursor,
       levelsOffset,
       dataPageHeader.repetition_levels_byte_length
     );
-    rLevels = decodeValues(
-      PARQUET_RDLVL_TYPE,
-      PARQUET_RDLVL_ENCODING,
+    rLevels = decodeLevels(
       repetitionLevelCursor,
       valueCount,
-      {
-        bitWidth: getBitWidth(context.column.rLevelMax),
-        disableEnvelope: true
-      }
-    ) as number[];
-  } else {
+      context.column.rLevelMax,
+      PARQUET_RDLVL_ENCODING,
+      true,
+      target?.rlevels,
+      target?.levelOffset
+    );
+  } else if (!target) {
+    rLevels = new Array(valueCount);
     rLevels.fill(0);
   }
   const definitionLevelsOffset = levelsOffset + dataPageHeader.repetition_levels_byte_length;
 
   /* read definition levels */
-  // tslint:disable-next-line:prefer-array-literal
-  let dLevels = new Array(valueCount);
+  let dLevels: number[] = [];
   if (context.column.dLevelMax > 0) {
     const definitionLevelCursor = createPageSliceCursor(
       cursor,
       definitionLevelsOffset,
       dataPageHeader.definition_levels_byte_length
     );
-    dLevels = decodeValues(
-      PARQUET_RDLVL_TYPE,
-      PARQUET_RDLVL_ENCODING,
+    dLevels = decodeLevels(
       definitionLevelCursor,
       valueCount,
-      {
-        bitWidth: getBitWidth(context.column.dLevelMax),
-        disableEnvelope: true
-      }
-    ) as number[];
-  } else {
+      context.column.dLevelMax,
+      PARQUET_RDLVL_ENCODING,
+      true,
+      target?.dlevels,
+      target?.levelOffset
+    );
+  } else if (!target) {
+    dLevels = new Array(valueCount);
     dLevels.fill(0);
   }
 
@@ -488,6 +494,28 @@ async function decodeDataPageV2(
     count: valueCount,
     pageHeader: header
   };
+}
+
+/** Decodes repetition or definition levels into an optional column-level destination. */
+function decodeLevels(
+  cursor: CursorBuffer,
+  count: number,
+  levelMax: number,
+  encoding: ParquetCodec,
+  disableEnvelope: boolean,
+  output?: number[],
+  outputOffset = 0
+): number[] {
+  if (levelMax === 0) {
+    return output ? [] : new Array<number>(count).fill(0);
+  }
+  const levels = decodeValues(PARQUET_RDLVL_TYPE, encoding, cursor, count, {
+    bitWidth: getBitWidth(levelMax),
+    disableEnvelope,
+    output,
+    outputOffset
+  }) as number[];
+  return output ? [] : levels;
 }
 
 /** Returns whether an encoding stores RLE dictionary indices instead of physical values. */

--- a/modules/parquet/test/parquet-direct-level-decode.spec.ts
+++ b/modules/parquet/test/parquet-direct-level-decode.spec.ts
@@ -1,0 +1,48 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+
+import {fetchFile} from '@loaders.gl/core';
+import {ArrayBufferFile} from '@loaders.gl/loader-utils';
+
+import {ParquetReader} from '../src/parquetjs/parser/parquet-reader';
+
+const TEST_CASES = [
+  {
+    name: 'data page v1',
+    url: '@loaders.gl/parquet/test/data/apache/good/alltypes_plain.parquet',
+    columnKey: 'string_col',
+    rlevels: [0, 0, 0, 0, 0, 0, 0, 0],
+    dlevels: [1, 1, 1, 1, 1, 1, 1, 1]
+  },
+  {
+    name: 'data page v2',
+    url: '@loaders.gl/parquet/test/data/apache/good/datapage_v2.snappy.parquet',
+    columnKey: 'e,list,element',
+    rlevels: [0, 1, 1, 0, 0, 0, 1, 1, 0, 1],
+    dlevels: [2, 2, 2, 0, 0, 2, 2, 2, 2, 2]
+  }
+] as const;
+
+describe('Parquet direct level decoding', () => {
+  test.each(TEST_CASES)(
+    'decodes $name levels into column buffers',
+    async ({url, columnKey, rlevels, dlevels}) => {
+      const response = await fetchFile(url);
+      const arrayBuffer = await response.arrayBuffer();
+      const reader = new ParquetReader(new ArrayBufferFile(arrayBuffer));
+      const rowGroup = (await reader.rowGroupIterator().next()).value;
+
+      expect(rowGroup).toBeDefined();
+      if (!rowGroup) {
+        throw new Error('Expected one Parquet row group');
+      }
+      expect(rowGroup.columnData[columnKey].rlevels).toEqual(rlevels);
+      expect(rowGroup.columnData[columnKey].dlevels).toEqual(dlevels);
+
+      reader.close();
+    }
+  );
+});


### PR DESCRIPTION
Goals

- Remove page-local repetition/definition-level allocation and copy passes from the TypeScript Parquet decoder.
- Improve sustained Arrow decode throughput for nullable, nested, and repeated columns without changing decoded results.

Changes

- Preallocate final column-level buffers from column metadata.
- Decode Data Page V1 and V2 RLE levels directly into those buffers at the correct page offset.
- Initialize constant zero levels once per column instead of once per page plus a copy.
- Preserve standalone decodePage behavior when no destination is supplied.
- Add exact V1 and nested/repeated V2 level regression coverage.

Local adjacent benchmark vs master

- PLAIN nullable primitive projection → Arrow: 1.83M to 2.02M rows/s (+10%).
- PLAIN nested/repeated projection → Arrow: 3.33M to 3.59M rows/s (+8%).
- DELTA_BINARY_PACKED integer table → Arrow: 115K to 122K rows/s (+6%).
- Hadoop LZ4 full table → Arrow: 6.10M to 6.43M rows/s (+5%).

These are directional single-machine Chromium measurements; noisy cases are intentionally omitted.

Validation

- yarn build
- yarn build-workers
- yarn test-node: 27 files, 189 passed
- yarn test-headless: 361 files, 1,892 passed
- yarn test-audit: 0 violations
- yarn lint fix
- website yarn build