### PR TITLE
chore: add SPDX headers to Arrow and mesh modules

### DIFF
--- a/modules/arrow/src/arrow-writer.ts
+++ b/modules/arrow/src/arrow-writer.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // import type {} from '@loaders.gl/loader-utils';
 
 import type {WriterWithEncoder, WriterOptions} from '@loaders.gl/loader-utils';

--- a/modules/arrow/src/geoarrow-writer.ts
+++ b/modules/arrow/src/geoarrow-writer.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // import type {} from '@loaders.gl/loader-utils';
 
 import type {WriterWithEncoder, WriterOptions} from '@loaders.gl/loader-utils';

--- a/modules/obj/src/lib/obj-types.ts
+++ b/modules/obj/src/lib/obj-types.ts
@@ -1,0 +1,3 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors

--- a/modules/obj/src/lib/parse-obj-meshes.ts
+++ b/modules/obj/src/lib/parse-obj-meshes.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // OBJ Loader, adapted from THREE.js (MIT license)
 //
 // Attributions per original THREE.js source file:

--- a/modules/obj/src/lib/parse-obj.ts
+++ b/modules/obj/src/lib/parse-obj.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import type {Mesh, MeshAttributes} from '@loaders.gl/schema';
 import {getMeshBoundingBox} from '@loaders.gl/schema-utils';
 import {parseOBJMeshes} from './parse-obj-meshes';

--- a/modules/obj/src/workers/obj-worker.ts
+++ b/modules/obj/src/workers/obj-worker.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {createLoaderWorker} from '@loaders.gl/loader-utils';
 import {OBJLoaderWithParser} from '../obj-loader-with-parser';
 

--- a/modules/obj/test/index.js
+++ b/modules/obj/test/index.js
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import './obj-loader.spec';
 import './obj-writer.spec';
 import './mtl-loader.spec';

--- a/modules/obj/test/mtl-loader.spec.js
+++ b/modules/obj/test/mtl-loader.spec.js
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 /* eslint-disable max-len */
 import test from 'test/utils/vitest-tape';
 import {validateLoader} from 'test/common/conformance';

--- a/modules/obj/test/obj-loader.spec.js
+++ b/modules/obj/test/obj-loader.spec.js
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 /* eslint-disable max-len */
 import test from 'test/utils/vitest-tape';
 import {validateLoader, validateMeshCategoryData} from 'test/common/conformance';

--- a/modules/ply/src/workers/ply-worker.ts
+++ b/modules/ply/src/workers/ply-worker.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {createLoaderWorker} from '@loaders.gl/loader-utils';
 import {PLYLoaderWithParser} from '../ply-loader-with-parser';
 

--- a/modules/ply/test/index.js
+++ b/modules/ply/test/index.js
@@ -1,2 +1,6 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import './ply-loader.spec';
 import './ply-writer.spec';

--- a/modules/ply/test/ply-loader.bench.js
+++ b/modules/ply/test/ply-loader.bench.js
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {fetchFile, load, parse} from '@loaders.gl/core';
 import {PLYLoader, PLYWorkerLoader} from '@loaders.gl/ply';
 

--- a/modules/ply/test/ply-loader.spec.js
+++ b/modules/ply/test/ply-loader.spec.js
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 /* eslint-disable max-len */
 import test from 'test/utils/vitest-tape';
 import * as arrow from 'apache-arrow';

--- a/modules/schema/src/deprecated/mesh-utils.ts
+++ b/modules/schema/src/deprecated/mesh-utils.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // Mesh category utilities
 // TODO - move to mesh category module, or to math.gl/geometry module
 import {MeshAttributes} from '../categories/category-mesh';

--- a/modules/worker-utils/test/lib/library-utils/fixture/module.js
+++ b/modules/worker-utils/test/lib/library-utils/fixture/module.js
@@ -1,1 +1,5 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 module.exports = require('./submodule');

--- a/modules/worker-utils/test/lib/library-utils/fixture/submodule.js
+++ b/modules/worker-utils/test/lib/library-utils/fixture/submodule.js
@@ -1,1 +1,5 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 module.exports = module;


### PR DESCRIPTION
## Goal

Continue #2830 with a reviewable SPDX tranche covering Arrow, OBJ, PLY, Schema, and Worker Utils, while auditing adjacent PCD files and keeping modules that need deeper vendored-license review out of scope.

## Changes

- add the standard loaders.gl MIT SPDX header to 16 previously uncovered JavaScript and TypeScript source/test files
- retain the existing THREE.js MIT attribution in the adapted OBJ parser
- confirm that all audited PCD JavaScript/TypeScript source and test files already have SPDX headers
- make no runtime or test-behavior changes

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn build-workers`
- `yarn test-node` — 27 files passed; 189 tests passed, 6 skipped
- `yarn test-headless` — 363 files passed, 2 skipped; 1,894 tests passed, 50 skipped
- SPDX audit across Arrow, OBJ, PLY, Schema, Worker Utils, and PCD