### PR TITLE
chore: add SPDX headers to small utility modules

### DIFF
--- a/modules/3d-tiles/src/lib/utils/version.ts
+++ b/modules/3d-tiles/src/lib/utils/version.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // Version constant cannot be imported, it needs to correspond to the build version of **this** module.
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.

--- a/modules/3d-tiles/test/lib/parsers/helpers/parse-3d-tile-subtree.spec.ts
+++ b/modules/3d-tiles/test/lib/parsers/helpers/parse-3d-tile-subtree.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import test from 'test/utils/vitest-tape';
 import {coreApi} from '@loaders.gl/core';
 

--- a/modules/3d-tiles/test/tiles-3d-archive-readable-file.spec.ts
+++ b/modules/3d-tiles/test/tiles-3d-archive-readable-file.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import test from 'test/utils/vitest-tape';
 import {parse3DTilesArchive} from '../src/3d-tiles-archive/3d-tiles-archive-parser';
 import {createReadableFileFromBuffer, loadArrayBufferFromFile} from 'test/utils/readable-files';

--- a/modules/crypto/src/lib/crypto-hash.ts
+++ b/modules/crypto/src/lib/crypto-hash.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {getJSModule, registerJSModules} from '@loaders.gl/loader-utils';
 import {Hash} from './hash';
 

--- a/modules/crypto/src/workers/crypto-worker-node.ts
+++ b/modules/crypto/src/workers/crypto-worker-node.ts
@@ -1,1 +1,5 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import './crypto-worker';

--- a/modules/csv/test/csv.bench.ts
+++ b/modules/csv/test/csv.bench.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {encodeTableAsText, fetchFile, parse, preload} from '@loaders.gl/core';
 import {CSVLoader, CSVWriter} from '@loaders.gl/csv';
 import type {Loader} from '@loaders.gl/loader-utils';

--- a/modules/csv/test/index.ts
+++ b/modules/csv/test/index.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // Uncomment to test papaparse
 import './papaparse/papaparse.spec';
 // import './csv-writer-papaparse.spec';

--- a/modules/excel/src/lib/encode-excel.ts
+++ b/modules/excel/src/lib/encode-excel.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // import * as xlsx from 'xlsx';
 
 /**

--- a/modules/excel/src/workers/excel-worker.ts
+++ b/modules/excel/src/workers/excel-worker.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {createLoaderWorker} from '@loaders.gl/loader-utils';
 import {ExcelLoaderWithParser} from '../excel-loader-with-parser';
 

--- a/modules/excel/test/excel.bench.ts
+++ b/modules/excel/test/excel.bench.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {ExcelLoader} from '@loaders.gl/excel';
 import {load} from '@loaders.gl/core';
 

--- a/modules/excel/test/index.ts
+++ b/modules/excel/test/index.ts
@@ -1,1 +1,5 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import './excel-loader.spec';

--- a/modules/graphs/src/index.ts
+++ b/modules/graphs/src/index.ts
@@ -1,0 +1,3 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors

--- a/modules/graphs/test/index.ts
+++ b/modules/graphs/test/index.ts
@@ -1,0 +1,3 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors

--- a/modules/lerc/test/index.ts
+++ b/modules/lerc/test/index.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // LERC - Limited Error Raster Compression
 
 import './lerc/lerc-sanity.spec';

--- a/modules/parquet/src/lib/arrow/convert-columns-to-row-group.ts
+++ b/modules/parquet/src/lib/arrow/convert-columns-to-row-group.ts
@@ -1,0 +1,3 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors

--- a/modules/sql/test/duckdb-sql-source.node.spec.ts
+++ b/modules/sql/test/duckdb-sql-source.node.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import test from 'test/utils/vitest-tape';
 import {createDataSource} from '@loaders.gl/core';
 import {DuckDBSQLDataSource, DuckDBSQLSource} from '@loaders.gl/sql';

--- a/modules/sql/test/snowflake-sql-source.spec.ts
+++ b/modules/sql/test/snowflake-sql-source.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import test from 'test/utils/vitest-tape';
 import {createDataSource} from '@loaders.gl/core';
 import {SnowflakeSQLDataSource, SnowflakeSQLSource} from '@loaders.gl/sql';

--- a/modules/sql/test/sql-source.spec.ts
+++ b/modules/sql/test/sql-source.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import test from 'test/utils/vitest-tape';
 import type {Schema} from '@loaders.gl/schema';
 

--- a/modules/sql/test/sql-utils.spec.ts
+++ b/modules/sql/test/sql-utils.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import test from 'test/utils/vitest-tape';
 
 import {

--- a/modules/video/test/gif-builder.spec.js
+++ b/modules/video/test/gif-builder.spec.js
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import test from 'test/utils/vitest-tape';
 
 import {load, isBrowser} from '@loaders.gl/core';

--- a/modules/video/test/index.js
+++ b/modules/video/test/index.js
@@ -1,2 +1,6 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import './video-loader.spec';
 import './gif-builder.spec';

--- a/modules/video/test/video-loader.spec.js
+++ b/modules/video/test/video-loader.spec.js
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import test from 'test/utils/vitest-tape';
 
 import {VideoLoader} from '@loaders.gl/video';

--- a/modules/zarr/test/utils.spec.js
+++ b/modules/zarr/test/utils.spec.js
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import test from 'test/utils/vitest-tape';
 
 // @ts-ignore


### PR DESCRIPTION
## Goal

Continue #2830 with a reviewable SPDX tranche that completes the remaining JavaScript and TypeScript header gaps in ten small, license-safe modules.

## Changes

- add the standard loaders.gl MIT SPDX header to 23 source and test files
- complete the audited `src`/`test` coverage for 3D Tiles, Crypto, CSV, Excel, Graphs, LERC, Parquet, SQL, Video, and Zarr
- limit the batch to project-authored files and empty package placeholders
- keep MVT, compression, schema-utils, ZIP, and larger vendored-source modules for separate provenance review
- make no runtime or test-behavior changes

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn build-workers`
- `yarn test-node` — 27 files passed; 189 tests passed, 6 skipped
- `yarn test-headless` — 369 files passed, 2 skipped; 1,925 tests passed, 50 skipped
- SPDX audit across all JavaScript and TypeScript files under the ten modules' `src` and `test` directories