### PR TITLE
feat(parquet): add adaptive dictionary and delta writing

### DIFF
--- a/docs/modules/parquet/api-reference/parquet-writer.md
+++ b/docs/modules/parquet/api-reference/parquet-writer.md
@@ -66,22 +66,44 @@ const parquetBuffer = await encode(arrowTable, ParquetWriter, {
 
 ### TypeScript writer options
 
-`ParquetJSWriter` accepts `parquet.columnEncodings`, keyed by top-level column name. Use
-`BYTE_STREAM_SPLIT` for fixed-width numeric or binary columns when the following page compression can
-benefit from grouping corresponding bytes. Unsupported physical types are rejected instead of
-silently falling back to `PLAIN`.
+`ParquetJSWriter` accepts `parquet.columnEncodings`, keyed by top-level column name. It also supports
+adaptive or forced chunk dictionaries independently of the primary encoding. Unsupported
+encoding/type combinations and unknown column names are rejected instead of silently falling back.
 
 ```typescript
 const parquet = await encode(table, ParquetJSWriter, {
   parquet: {
     useDataPageV2: true,
+    pageSize: 8192,
+    dictionary: 'auto',
+    columnDictionaries: {
+      identifier: false
+    },
     columnEncodings: {
       temperature: 'BYTE_STREAM_SPLIT',
-      timestamp: 'BYTE_STREAM_SPLIT'
+      timestamp: 'DELTA_BINARY_PACKED',
+      identifier: 'DELTA_BYTE_ARRAY'
     }
   }
 });
 ```
+
+The selectable primary encodings are:
+
+| Encoding | Physical types | Typical data |
+| -------- | -------------- | ------------ |
+| `PLAIN` | All | Baseline or already-compressed values |
+| `BYTE_STREAM_SPLIT` | `INT32`, `INT64`, `FLOAT`, `DOUBLE`, `FIXED_LEN_BYTE_ARRAY` | Fixed-width numeric values followed by compression |
+| `DELTA_BINARY_PACKED` | `INT32`, `INT64` | Ordered counters, timestamps, and low-delta integers |
+| `DELTA_LENGTH_BYTE_ARRAY` | `BYTE_ARRAY` | Variable-width values with compressible lengths |
+| `DELTA_BYTE_ARRAY` | `BYTE_ARRAY`, `FIXED_LEN_BYTE_ARRAY` | Sorted or shared-prefix strings and binary values |
+
+Dictionary encoding is configured separately because it emits a PLAIN dictionary page followed by
+`RLE_DICTIONARY` data pages. `dictionary: 'auto'` uses a dictionary only when its uncompressed value
+payload plus index stream are smaller than the selected primary encoding. `dictionary: true` forces
+one when it fits the size limit, and `false` disables it. If a forced dictionary exceeds
+`dictionaryPageSizeLimit`, the complete column chunk uses its primary encoding instead of mixing
+incompatible dictionary domains.
 
 See the [Parquet format page](/docs/modules/parquet/formats/parquet#value-encodings) for the complete
 read/write encoding matrix.
@@ -89,9 +111,12 @@ read/write encoding matrix.
 | Option | Type | Default | Description |
 | ------ | ---- | ------- | ----------- |
 | `parquet.wasmUrl` | `string` | bundled URL | Overrides the `parquet-wasm` binary URL for `ParquetWriter`. |
-| `parquet.columnEncodings` | `Record<string, 'PLAIN' \| 'BYTE_STREAM_SPLIT'>` | `{}` | Selects value encodings by top-level column name for `ParquetJSWriter`. |
+| `parquet.columnEncodings` | `Record<string, ParquetJSWriterEncoding>` | `{}` | Selects the primary value encoding by top-level column name for `ParquetJSWriter`. |
+| `parquet.dictionary` | `boolean \| 'auto'` | `'auto'` | Enables, disables, or adaptively selects a chunk-wide dictionary. |
+| `parquet.columnDictionaries` | `Record<string, boolean \| 'auto'>` | `{}` | Overrides the dictionary policy by top-level column name. |
+| `parquet.dictionaryPageSizeLimit` | `number` | `1048576` | Maximum uncompressed PLAIN dictionary payload in bytes; oversized dictionaries fall back for the complete chunk. |
 | `parquet.rowGroupSize` | `number` | implementation default | Sets the target row count per row group for `ParquetJSWriter`. |
-| `parquet.pageSize` | `number` | implementation default | Sets the target value count per page for `ParquetJSWriter`. |
+| `parquet.pageSize` | `number` | `8192` | Sets the target shredded level-entry count per page. Boundaries remain aligned to top-level rows. |
 | `parquet.useDataPageV2` | `boolean` | `false` | Emits Data Page V2 from `ParquetJSWriter`. |
 
 ## Writer Variants
@@ -112,8 +137,10 @@ const parquetBuffer = await encode(table, ParquetJSWriter, {
 });
 ```
 
-`ParquetJSWriter` supports `parquet.rowGroupSize`, `parquet.pageSize`, and
-`parquet.useDataPageV2`; their defaults are selected by the implementation.
+`ParquetJSWriter` emits multiple pages when a column chunk exceeds `parquet.pageSize`. A repeated row
+larger than the target stays intact in one page. Dictionary pages are shared by all data pages in a
+column chunk, and footer offsets plus encoding statistics identify the dictionary and data-page
+regions for other readers.
 
 The TypeScript writer emits Parquet 2.13 `LogicalType` metadata for Arrow-compatible integer,
 date/time/timestamp, decimal, FLOAT16, and string fields. Nanosecond and unsigned 64-bit values are

--- a/docs/modules/parquet/formats/parquet.md
+++ b/docs/modules/parquet/formats/parquet.md
@@ -149,12 +149,14 @@ need to inflate an entire column chunk at once.
 | ------------ | ------- | -------- | ----- |
 | Data Page V1 | ✅ | ✅ | Levels and values share one compressed payload |
 | Data Page V2 | ✅ | ✅ | Levels remain uncompressed; value compression is independently declared |
-| Dictionary page | ✅ | ❌ | New dictionaries are not yet emitted by the TypeScript writer |
+| Dictionary page | ✅ | ✅ | One chunk-wide dictionary may be shared by multiple data pages |
 | Optional page CRC | ⚠️ | ❌ | CRC metadata is decoded but payload verification is not yet enforced |
 | Legacy `INDEX_PAGE` | ❌ | ❌ | Deprecated and distinct from the modern page-index structures |
 
 `ParquetJSWriter` selects Data Page V2 with `parquet.useDataPageV2`. The reader accepts both versions
-within the same file.
+within the same file. `parquet.pageSize` is a target number of shredded level entries per page. Page
+boundaries are aligned to top-level rows, so a repeated row is never split between pages; a single
+row larger than the target remains one page.
 
 ## Value Encodings
 
@@ -167,25 +169,39 @@ uses, while each page identifies its actual value encoding.
 | `PLAIN_DICTIONARY` | All physical types | ✅ | ❌ | Deprecated dictionary identifier |
 | `RLE` | Boolean, levels, dictionary indexes | ✅ | ✅ | Writer uses it for definition/repetition levels |
 | `BIT_PACKED` | Legacy levels | ❌ | ❌ | Deprecated and superseded by the RLE/bit-packing hybrid |
-| `DELTA_BINARY_PACKED` | `INT32`, `INT64` | ✅ | ❌ | Effective for ordered integer sequences |
-| `DELTA_LENGTH_BYTE_ARRAY` | `BYTE_ARRAY` | ✅ | ❌ | Delta-encodes lengths followed by concatenated bytes |
-| `DELTA_BYTE_ARRAY` | `BYTE_ARRAY`, `FIXED_LEN_BYTE_ARRAY` | ✅ | ❌ | Prefix/suffix encoding for related byte strings |
-| `RLE_DICTIONARY` | All physical types | ✅ | ❌ | Modern dictionary index encoding |
+| `DELTA_BINARY_PACKED` | `INT32`, `INT64` | ✅ | ✅ | Effective for ordered integer sequences |
+| `DELTA_LENGTH_BYTE_ARRAY` | `BYTE_ARRAY` | ✅ | ✅ | Delta-encodes lengths followed by concatenated bytes |
+| `DELTA_BYTE_ARRAY` | `BYTE_ARRAY`, `FIXED_LEN_BYTE_ARRAY` | ✅ | ✅ | Prefix/suffix encoding for related byte strings |
+| `RLE_DICTIONARY` | All physical types | ✅ | ✅ | Modern dictionary index encoding |
 | `BYTE_STREAM_SPLIT` | `INT32`, `INT64`, `FLOAT`, `DOUBLE`, `FIXED_LEN_BYTE_ARRAY` | ✅ | ✅ | Transposes fixed-width bytes to improve later compression |
 | `ALP` | `FLOAT`, `DOUBLE` | ❌ | ❌ | Preview encoding in the current Apache specification |
 
-The TypeScript writer can opt individual top-level columns into byte-stream split:
+The TypeScript writer can select stable non-dictionary encodings by top-level column name:
 
 ```typescript
 const parquet = await encode(table, ParquetJSWriter, {
   parquet: {
     columnEncodings: {
       temperature: 'BYTE_STREAM_SPLIT',
-      timestamp: 'BYTE_STREAM_SPLIT'
-    }
+      timestamp: 'DELTA_BINARY_PACKED',
+      identifier: 'DELTA_BYTE_ARRAY'
+    },
+    dictionary: 'auto'
   }
 });
 ```
+
+Dictionary encoding is a column-chunk policy rather than a primary `columnEncodings` value because
+one chunk can start with a PLAIN dictionary page and then use `RLE_DICTIONARY` data pages. With
+`dictionary: 'auto'`, the writer builds a candidate dictionary and uses it only when the dictionary
+payload plus indexes are smaller than the selected primary encoding. `dictionary: true` forces the
+dictionary when it fits `dictionaryPageSizeLimit`; an oversized dictionary falls back for the
+complete chunk. `columnDictionaries` can override the policy for individual columns.
+
+The dictionary is planned across the complete column chunk and shared by every data page. This
+avoids page-to-page dictionary churn and lets the writer make one stable size decision before
+emitting bytes. High-cardinality data therefore stays on its selected PLAIN, delta, or
+byte-stream-split encoding instead of paying dictionary overhead.
 
 ## Compression
 
@@ -259,10 +275,10 @@ The TypeScript implementation is aiming for complete stable-format read support.
 gaps are currently:
 
 1. page-index and Bloom-filter reads for page-level pruning;
-2. dictionary and delta encoding in the writer;
-3. complete high-level nested-schema writing;
-4. Variant value decoding and shredding;
-5. page CRC verification and emission; and
+2. complete high-level nested-schema writing;
+3. Variant value decoding and shredding;
+4. page CRC verification and emission;
+5. statistics and page-index writing; and
 6. Parquet modular encryption.
 
 Preview features such as ALP are tracked separately from stable-format completeness.

--- a/modules/parquet/src/lib/encoders/encode-table-to-parquet-js.ts
+++ b/modules/parquet/src/lib/encoders/encode-table-to-parquet-js.ts
@@ -61,10 +61,16 @@ function convertSchemaToParquetSchema(
 ): SchemaDefinition {
   const parquetFields: SchemaDefinition = {};
   const columnEncodings = options.parquet?.columnEncodings || {};
+  const columnDictionaries = options.parquet?.columnDictionaries || {};
   const fieldNames = new Set(schema.fields.map(field => field.name));
   for (const columnName of Object.keys(columnEncodings)) {
     if (!fieldNames.has(columnName)) {
       throw new Error(`ParquetJSWriter: Unknown column encoding override "${columnName}"`);
+    }
+  }
+  for (const columnName of Object.keys(columnDictionaries)) {
+    if (!fieldNames.has(columnName)) {
+      throw new Error(`ParquetJSWriter: Unknown column dictionary override "${columnName}"`);
     }
   }
 

--- a/modules/parquet/src/parquet-js-writer.ts
+++ b/modules/parquet/src/parquet-js-writer.ts
@@ -15,12 +15,23 @@ import {ParquetFormat} from './parquet-format';
 const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
 /** Stable value encodings selectable by the TypeScript Parquet writer. */
-export type ParquetJSWriterEncoding = 'PLAIN' | 'BYTE_STREAM_SPLIT';
+export type ParquetJSWriterEncoding =
+  | 'PLAIN'
+  | 'BYTE_STREAM_SPLIT'
+  | 'DELTA_BINARY_PACKED'
+  | 'DELTA_LENGTH_BYTE_ARRAY'
+  | 'DELTA_BYTE_ARRAY';
 
 /** Encoder-specific options for the experimental parquetjs writer. */
 type ParquetJSWriterEncoderOptions = {
   /** Value encoding overrides keyed by top-level column name. */
   columnEncodings?: Record<string, ParquetJSWriterEncoding>;
+  /** Enables dictionary pages globally when forced or size-beneficial. */
+  dictionary?: boolean | 'auto';
+  /** Dictionary policy overrides keyed by top-level column name. */
+  columnDictionaries?: Record<string, boolean | 'auto'>;
+  /** Maximum uncompressed PLAIN dictionary payload per column chunk. */
+  dictionaryPageSizeLimit?: number;
   rowGroupSize?: number;
   pageSize?: number;
   useDataPageV2?: boolean;

--- a/modules/parquet/src/parquetjs/codecs/delta.ts
+++ b/modules/parquet/src/parquetjs/codecs/delta.ts
@@ -4,7 +4,7 @@
 // Portions adapted from hyparquet, Copyright (c) Hyperparam contributors
 
 import type {PrimitiveType} from '../schema/declare';
-import {copyUint8Array} from '../utils/binary-utils';
+import {concatUint8Arrays, copyUint8Array, toUint8Array} from '../utils/binary-utils';
 import {
   getParquetValueOutput,
   type CursorBuffer,
@@ -12,13 +12,198 @@ import {
   type ParquetValueBuffer
 } from './declare';
 
-/** Delta encodings are currently decoder-only in loaders.gl. */
-export function encodeValues(
-  _type: PrimitiveType,
-  _values: unknown[],
+const DELTA_BLOCK_SIZE = 128;
+const DELTA_MINI_BLOCK_COUNT = 4;
+const DELTA_VALUES_PER_MINI_BLOCK = DELTA_BLOCK_SIZE / DELTA_MINI_BLOCK_COUNT;
+
+/** Encodes INT32 or INT64 values using Parquet DELTA_BINARY_PACKED. */
+export function encodeDeltaBinaryPackedValues(
+  type: PrimitiveType,
+  values: unknown[],
   _options: ParquetCodecOptions
 ): Uint8Array {
-  throw new Error('Parquet delta encoding is not supported by the TypeScript writer');
+  if (type !== 'INT32' && type !== 'INT64') {
+    throw new Error(`DELTA_BINARY_PACKED does not support Parquet type ${type}`);
+  }
+  if (values.length === 0) {
+    return new Uint8Array(0);
+  }
+
+  const integerValues = values.map(value => getSignedInteger(type, value));
+  const output: Uint8Array[] = [
+    encodeUnsignedVarInt(BigInt(DELTA_BLOCK_SIZE)),
+    encodeUnsignedVarInt(BigInt(DELTA_MINI_BLOCK_COUNT)),
+    encodeUnsignedVarInt(BigInt(integerValues.length)),
+    encodeZigZagVarInt(integerValues[0])
+  ];
+
+  const deltas: bigint[] = [];
+  for (let valueIndex = 1; valueIndex < integerValues.length; valueIndex++) {
+    const delta = integerValues[valueIndex] - integerValues[valueIndex - 1];
+    deltas.push(type === 'INT32' ? BigInt.asIntN(32, delta) : BigInt.asIntN(64, delta));
+  }
+
+  for (let blockOffset = 0; blockOffset < deltas.length; blockOffset += DELTA_BLOCK_SIZE) {
+    const block = deltas.slice(blockOffset, blockOffset + DELTA_BLOCK_SIZE);
+    const minimumDelta = block.reduce(
+      (minimum, delta) => (delta < minimum ? delta : minimum),
+      block[0]
+    );
+    output.push(encodeZigZagVarInt(minimumDelta));
+
+    const miniBlocks: bigint[][] = [];
+    const bitWidths = new Uint8Array(DELTA_MINI_BLOCK_COUNT);
+    for (let miniBlockIndex = 0; miniBlockIndex < DELTA_MINI_BLOCK_COUNT; miniBlockIndex++) {
+      const miniBlockOffset = miniBlockIndex * DELTA_VALUES_PER_MINI_BLOCK;
+      const adjustedDeltas = block
+        .slice(miniBlockOffset, miniBlockOffset + DELTA_VALUES_PER_MINI_BLOCK)
+        .map(delta => delta - minimumDelta);
+      while (adjustedDeltas.length < DELTA_VALUES_PER_MINI_BLOCK) {
+        adjustedDeltas.push(0n);
+      }
+      miniBlocks.push(adjustedDeltas);
+      bitWidths[miniBlockIndex] = adjustedDeltas.reduce(
+        (bitWidth, delta) => Math.max(bitWidth, getUnsignedBitWidth(delta)),
+        0
+      );
+    }
+    output.push(bitWidths);
+    for (let miniBlockIndex = 0; miniBlockIndex < DELTA_MINI_BLOCK_COUNT; miniBlockIndex++) {
+      output.push(packUnsignedValues(miniBlocks[miniBlockIndex], bitWidths[miniBlockIndex]));
+    }
+  }
+  return concatUint8Arrays(output);
+}
+
+/** Encodes BYTE_ARRAY values as delta-packed lengths followed by their contiguous payloads. */
+export function encodeDeltaLengthByteArrayValues(
+  type: PrimitiveType,
+  values: unknown[],
+  _options: ParquetCodecOptions
+): Uint8Array {
+  if (type !== 'BYTE_ARRAY') {
+    throw new Error(`DELTA_LENGTH_BYTE_ARRAY does not support Parquet type ${type}`);
+  }
+  const byteArrays = values.map(value => toUint8Array(value as ArrayBuffer | ArrayBufferView));
+  const encodedLengths = encodeDeltaBinaryPackedValues(
+    'INT32',
+    byteArrays.map(value => value.byteLength),
+    {}
+  );
+  return concatUint8Arrays([encodedLengths, ...byteArrays]);
+}
+
+/** Encodes byte arrays as delta-packed prefix lengths and delta-length suffixes. */
+export function encodeDeltaByteArrayValues(
+  type: PrimitiveType,
+  values: unknown[],
+  _options: ParquetCodecOptions
+): Uint8Array {
+  assertByteArrayType(type, 'DELTA_BYTE_ARRAY');
+  const byteArrays = values.map(value => toUint8Array(value as ArrayBuffer | ArrayBufferView));
+  const prefixLengths: number[] = [];
+  const suffixes: Uint8Array[] = [];
+  let previousValue: Uint8Array = new Uint8Array(0);
+  for (const value of byteArrays) {
+    const prefixLength = getCommonPrefixLength(previousValue, value);
+    prefixLengths.push(prefixLength);
+    suffixes.push(value.subarray(prefixLength));
+    previousValue = value;
+  }
+  return concatUint8Arrays([
+    encodeDeltaBinaryPackedValues('INT32', prefixLengths, {}),
+    encodeDeltaLengthByteArrayValues('BYTE_ARRAY', suffixes, {})
+  ]);
+}
+
+/** Returns whether an encoding is valid for a physical Parquet type. */
+export function isDeltaEncodingType(encoding: string, type: PrimitiveType): boolean {
+  switch (encoding) {
+    case 'DELTA_BINARY_PACKED':
+      return type === 'INT32' || type === 'INT64';
+    case 'DELTA_LENGTH_BYTE_ARRAY':
+      return type === 'BYTE_ARRAY';
+    case 'DELTA_BYTE_ARRAY':
+      return type === 'BYTE_ARRAY' || type === 'FIXED_LEN_BYTE_ARRAY';
+    default:
+      return false;
+  }
+}
+
+/** Converts one writer value to its exact signed physical integer. */
+function getSignedInteger(type: 'INT32' | 'INT64', value: unknown): bigint {
+  let integerValue: bigint;
+  try {
+    integerValue = BigInt(value as bigint | boolean | number | string);
+  } catch {
+    throw new Error(`Invalid ${type} value ${value}`);
+  }
+  const bitWidth = type === 'INT32' ? 32 : 64;
+  if (integerValue !== BigInt.asIntN(bitWidth, integerValue)) {
+    throw new Error(`${type} value ${value} is out of range`);
+  }
+  return integerValue;
+}
+
+/** Encodes a non-negative integer as an unsigned base-128 variable integer. */
+function encodeUnsignedVarInt(value: bigint): Uint8Array {
+  if (value < 0n) {
+    throw new Error(`Cannot encode negative unsigned variable integer ${value}`);
+  }
+  const bytes: number[] = [];
+  let remainingValue = value;
+  do {
+    const byte = Number(remainingValue & 0x7fn);
+    remainingValue >>= 7n;
+    bytes.push(remainingValue === 0n ? byte : byte | 0x80);
+  } while (remainingValue !== 0n);
+  return Uint8Array.from(bytes);
+}
+
+/** Encodes a signed integer using zig-zag base-128 variable integer representation. */
+function encodeZigZagVarInt(value: bigint): Uint8Array {
+  const zigZagValue = value >= 0n ? value * 2n : -value * 2n - 1n;
+  return encodeUnsignedVarInt(zigZagValue);
+}
+
+/** Returns the minimum unsigned bit width needed for a non-negative integer. */
+function getUnsignedBitWidth(value: bigint): number {
+  if (value < 0n) {
+    throw new Error(`Cannot bit-pack negative value ${value}`);
+  }
+  return value === 0n ? 0 : value.toString(2).length;
+}
+
+/** Bit-packs unsigned values least-significant bit first as required by Parquet. */
+function packUnsignedValues(values: bigint[], bitWidth: number): Uint8Array {
+  if (bitWidth === 0) {
+    return new Uint8Array(0);
+  }
+  const output = new Uint8Array((values.length * bitWidth) / 8);
+  const mask = (1n << BigInt(bitWidth)) - 1n;
+  let packedBits = 0n;
+  let packedBitCount = 0;
+  let outputOffset = 0;
+  for (const value of values) {
+    packedBits |= (value & mask) << BigInt(packedBitCount);
+    packedBitCount += bitWidth;
+    while (packedBitCount >= 8) {
+      output[outputOffset++] = Number(packedBits & 0xffn);
+      packedBits >>= 8n;
+      packedBitCount -= 8;
+    }
+  }
+  return output;
+}
+
+/** Returns the common leading byte count of two byte arrays. */
+function getCommonPrefixLength(left: Uint8Array, right: Uint8Array): number {
+  const maximumLength = Math.min(left.length, right.length);
+  let prefixLength = 0;
+  while (prefixLength < maximumLength && left[prefixLength] === right[prefixLength]) {
+    prefixLength++;
+  }
+  return prefixLength;
 }
 
 /** Decodes one Parquet delta encoding based on its registered codec name. */

--- a/modules/parquet/src/parquetjs/codecs/dictionary.ts
+++ b/modules/parquet/src/parquetjs/codecs/dictionary.ts
@@ -5,6 +5,9 @@
 // Forked from https://github.com/kbajalc/parquets under MIT license
 
 import {decodeValues as decodeRleValues} from './rle';
+import {encodeValues as encodeRleValues} from './rle';
+import type {PrimitiveType} from '../schema/declare';
+import type {ParquetCodecOptions} from './declare';
 
 export function decodeValues(type, cursor, count, opts) {
   const bitWidth = cursor.buffer[cursor.offset];
@@ -12,6 +15,21 @@ export function decodeValues(type, cursor, count, opts) {
   return decodeRleValues(type, cursor, count, {...opts, bitWidth, disableEnvelope: true});
 }
 
-export function encodeValues(type, cursor, count, opts) {
-  throw new Error('Encode dictionary functionality is not supported');
+/** Encodes dictionary indexes as a bit width followed by the RLE/bit-packed hybrid stream. */
+export function encodeValues(
+  _type: PrimitiveType,
+  values: number[],
+  options: ParquetCodecOptions
+): Uint8Array {
+  if (options.bitWidth === undefined) {
+    throw new Error('bitWidth is required for dictionary encoding');
+  }
+  const encodedIndices = encodeRleValues('INT32', values, {
+    bitWidth: options.bitWidth,
+    disableEnvelope: true
+  });
+  const output = new Uint8Array(encodedIndices.length + 1);
+  output[0] = options.bitWidth;
+  output.set(encodedIndices, 1);
+  return output;
 }

--- a/modules/parquet/src/parquetjs/codecs/index.ts
+++ b/modules/parquet/src/parquetjs/codecs/index.ts
@@ -36,15 +36,15 @@ export const PARQUET_CODECS: Record<ParquetCodec, ParquetCodecKit> = {
     decodeValues: DICTIONARY.decodeValues
   },
   DELTA_BINARY_PACKED: {
-    encodeValues: DELTA.encodeValues,
+    encodeValues: DELTA.encodeDeltaBinaryPackedValues,
     decodeValues: DELTA.decodeDeltaBinaryPackedValues
   },
   DELTA_LENGTH_BYTE_ARRAY: {
-    encodeValues: DELTA.encodeValues,
+    encodeValues: DELTA.encodeDeltaLengthByteArrayValues,
     decodeValues: DELTA.decodeDeltaLengthByteArrayValues
   },
   DELTA_BYTE_ARRAY: {
-    encodeValues: DELTA.encodeValues,
+    encodeValues: DELTA.encodeDeltaByteArrayValues,
     decodeValues: DELTA.decodeDeltaByteArrayValues
   },
   BYTE_STREAM_SPLIT: {

--- a/modules/parquet/src/parquetjs/codecs/rle.ts
+++ b/modules/parquet/src/parquetjs/codecs/rle.ts
@@ -333,18 +333,23 @@ function encodeRunBitpacked(values: number[], opts: ParquetCodecOptions): Uint8A
   // @ts-ignore
   const bitWidth: number = opts.bitWidth;
 
-  for (let i = 0; i < values.length % 8; i++) {
-    values.push(0);
+  const paddedValues = values.slice();
+  const padding = (8 - (paddedValues.length % 8)) % 8;
+  for (let index = 0; index < padding; index++) {
+    paddedValues.push(0);
   }
 
-  const buf = new Uint8Array(Math.ceil(bitWidth * (values.length / 8)));
-  for (let b = 0; b < bitWidth * values.length; b++) {
-    if ((values[Math.floor(b / bitWidth)] & (1 << (b % bitWidth))) > 0) {
+  const buf = new Uint8Array(Math.ceil(bitWidth * (paddedValues.length / 8)));
+  for (let b = 0; b < bitWidth * paddedValues.length; b++) {
+    if ((paddedValues[Math.floor(b / bitWidth)] & (1 << (b % bitWidth))) > 0) {
       buf[Math.floor(b / 8)] |= 1 << (b % 8);
     }
   }
 
-  return concatUint8Arrays([Uint8Array.from(varint.encode(((values.length / 8) << 1) | 1)), buf]);
+  return concatUint8Arrays([
+    Uint8Array.from(varint.encode(((paddedValues.length / 8) << 1) | 1)),
+    buf
+  ]);
 }
 
 function encodeRunRepeated(value: number, count: number, opts: ParquetCodecOptions): Uint8Array {
@@ -355,8 +360,7 @@ function encodeRunRepeated(value: number, count: number, opts: ParquetCodecOptio
 
   for (let i = 0; i < buf.length; i++) {
     buf[i] = value & 0xff;
-    // eslint-disable-next-line
-    value >> 8; //  TODO - this looks wrong
+    value = Math.floor(value / 256);
   }
 
   return concatUint8Arrays([Uint8Array.from(varint.encode(count << 1)), buf]);

--- a/modules/parquet/src/parquetjs/encoder/dictionary-planner.ts
+++ b/modules/parquet/src/parquetjs/encoder/dictionary-planner.ts
@@ -1,0 +1,99 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {PARQUET_CODECS} from '../codecs/index';
+import type {ParquetField} from '../schema/declare';
+
+/** Dictionary selection policy for one Parquet column chunk. */
+export type ParquetDictionaryPolicy = boolean | 'auto';
+
+/** A chunk-wide dictionary and the index stream replacing its non-null values. */
+export interface ParquetDictionaryPlan {
+  /** Unique physical values written to the dictionary page. */
+  readonly values: unknown[];
+  /** Dictionary index corresponding to every non-null column value. */
+  readonly indices: number[];
+  /** PLAIN-encoded dictionary page payload. */
+  readonly encodedValues: Uint8Array;
+  /** Bit width used by RLE_DICTIONARY index pages. */
+  readonly bitWidth: number;
+}
+
+/** Builds a forced or size-beneficial dictionary plan for a complete column chunk. */
+export function planDictionary(
+  column: ParquetField,
+  values: readonly unknown[],
+  policy: ParquetDictionaryPolicy,
+  dictionaryPageSizeLimit: number
+): ParquetDictionaryPlan | undefined {
+  if (!Number.isInteger(dictionaryPageSizeLimit) || dictionaryPageSizeLimit <= 0) {
+    throw new Error(
+      `Parquet dictionary page size limit must be a positive integer, received ${dictionaryPageSizeLimit}`
+    );
+  }
+  if (policy === false || values.length === 0 || isDictionaryEncoding(column.encoding!)) {
+    return undefined;
+  }
+
+  const dictionaryValues: unknown[] = [];
+  const dictionaryIndices = new Map<string, number>();
+  const indices = new Array<number>(values.length);
+  for (let valueIndex = 0; valueIndex < values.length; valueIndex++) {
+    const value = values[valueIndex];
+    const key = getDictionaryKey(value);
+    let dictionaryIndex = dictionaryIndices.get(key);
+    if (dictionaryIndex === undefined) {
+      dictionaryIndex = dictionaryValues.length;
+      dictionaryIndices.set(key, dictionaryIndex);
+      dictionaryValues.push(value);
+    }
+    indices[valueIndex] = dictionaryIndex;
+  }
+
+  const encodedValues = PARQUET_CODECS.PLAIN.encodeValues(column.primitiveType!, dictionaryValues, {
+    typeLength: column.typeLength
+  });
+  if (encodedValues.length > dictionaryPageSizeLimit) {
+    return undefined;
+  }
+  const bitWidth = dictionaryValues.length <= 1 ? 0 : Math.ceil(Math.log2(dictionaryValues.length));
+  if (policy === 'auto') {
+    const encodedIndices = PARQUET_CODECS.RLE_DICTIONARY.encodeValues(
+      column.primitiveType!,
+      indices,
+      {bitWidth}
+    );
+    const encodedPrimaryValues = PARQUET_CODECS[column.encoding!].encodeValues(
+      column.primitiveType!,
+      values as unknown[],
+      {typeLength: column.typeLength, bitWidth: column.typeLength}
+    );
+    if (encodedValues.length + encodedIndices.length >= encodedPrimaryValues.length) {
+      return undefined;
+    }
+  }
+
+  return {values: dictionaryValues, indices, encodedValues, bitWidth};
+}
+
+/** Returns a stable content key for one physical Parquet value. */
+function getDictionaryKey(value: unknown): string {
+  if (value instanceof Uint8Array) {
+    let key = `bytes:${value.length}:`;
+    for (const byte of value) {
+      key += String.fromCharCode(byte);
+    }
+    return key;
+  }
+  if (typeof value === 'number') {
+    if (Number.isNaN(value)) return 'number:NaN';
+    if (Object.is(value, -0)) return 'number:-0';
+  }
+  return `${typeof value}:${String(value)}`;
+}
+
+/** Returns whether the selected primary encoding already requires a dictionary page. */
+function isDictionaryEncoding(encoding: string): boolean {
+  return encoding === 'PLAIN_DICTIONARY' || encoding === 'RLE_DICTIONARY';
+}

--- a/modules/parquet/src/parquetjs/encoder/page-planner.ts
+++ b/modules/parquet/src/parquetjs/encoder/page-planner.ts
@@ -1,0 +1,83 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {ParquetColumnChunk, ParquetField} from '../schema/declare';
+
+/** One row-aligned slice of a shredded column prepared for page encoding. */
+export interface PlannedParquetPage {
+  /** Shredded levels and non-null values contained in this page. */
+  readonly data: ParquetColumnChunk;
+  /** Number of top-level rows represented by the page. */
+  readonly rowCount: number;
+}
+
+/** Splits a shredded column into target-sized pages without splitting a top-level row. */
+export function planColumnPages(
+  column: ParquetField,
+  data: ParquetColumnChunk,
+  rowCount: number,
+  pageSize: number
+): PlannedParquetPage[] {
+  if (!Number.isInteger(pageSize) || pageSize <= 0) {
+    throw new Error(`Parquet page size must be a positive integer, received ${pageSize}`);
+  }
+  if (data.rlevels.length < data.count || data.dlevels.length < data.count) {
+    throw new Error(`Invalid shredded column ${column.key}: level buffers are shorter than count`);
+  }
+  if (rowCount === 0) {
+    return [];
+  }
+
+  const rowStarts = [0];
+  for (let levelIndex = 1; levelIndex < data.count; levelIndex++) {
+    if (data.rlevels[levelIndex] === 0) {
+      rowStarts.push(levelIndex);
+    }
+  }
+  rowStarts.push(data.count);
+  if (rowStarts.length !== rowCount + 1) {
+    throw new Error(
+      `Invalid shredded column ${column.key}: found ${rowStarts.length - 1} rows, expected ${rowCount}`
+    );
+  }
+
+  const pages: PlannedParquetPage[] = [];
+  let pageStartRow = 0;
+  let valueStart = 0;
+  while (pageStartRow < rowCount) {
+    const levelStart = rowStarts[pageStartRow];
+    let pageEndRow = pageStartRow + 1;
+    while (pageEndRow < rowCount && rowStarts[pageEndRow + 1] - levelStart <= pageSize) {
+      pageEndRow++;
+    }
+
+    const levelEnd = rowStarts[pageEndRow];
+    let valueCount = 0;
+    for (let levelIndex = levelStart; levelIndex < levelEnd; levelIndex++) {
+      if (data.dlevels[levelIndex] === column.dLevelMax) {
+        valueCount++;
+      }
+    }
+    const valueEnd = valueStart + valueCount;
+    pages.push({
+      rowCount: pageEndRow - pageStartRow,
+      data: {
+        rlevels: data.rlevels.slice(levelStart, levelEnd),
+        dlevels: data.dlevels.slice(levelStart, levelEnd),
+        values: data.values.slice(valueStart, valueEnd),
+        count: levelEnd - levelStart,
+        pageHeaders: []
+      }
+    });
+    pageStartRow = pageEndRow;
+    valueStart = valueEnd;
+  }
+
+  if (valueStart !== data.values.length) {
+    throw new Error(
+      `Invalid shredded column ${column.key}: consumed ${valueStart} values, expected ${data.values.length}`
+    );
+  }
+  return pages;
+}

--- a/modules/parquet/src/parquetjs/encoder/parquet-encoder.ts
+++ b/modules/parquet/src/parquetjs/encoder/parquet-encoder.ts
@@ -29,6 +29,7 @@ import {
   DataPageHeaderV2,
   DateType,
   DecimalType,
+  DictionaryPageHeader,
   EdgeInterpolationAlgorithm,
   Encoding,
   EnumType,
@@ -48,6 +49,7 @@ import {
   NanoSeconds,
   NullType,
   PageHeader,
+  PageEncodingStats,
   PageType,
   RowGroup,
   SchemaElement,
@@ -63,6 +65,8 @@ import {osopen, oswrite, osclose} from '../utils/file-utils';
 import {getBitWidth, serializeThrift} from '../utils/read-utils';
 import {concatUint8Arrays, encodeUtf8, writeUInt32LE} from '../utils/binary-utils';
 import {CompactInt64} from '../utils/uint8-array-compact-protocol';
+import {planColumnPages} from './page-planner';
+import {planDictionary, type ParquetDictionaryPolicy} from './dictionary-planner';
 
 /**
  * Parquet File Magic String
@@ -92,6 +96,9 @@ export interface ParquetEncoderOptions {
   rowGroupSize?: number;
   pageSize?: number;
   useDataPageV2?: boolean;
+  dictionary?: ParquetDictionaryPolicy;
+  columnDictionaries?: Record<string, ParquetDictionaryPolicy>;
+  dictionaryPageSizeLimit?: number;
 
   // Write Stream Options
   flags?: string;
@@ -268,6 +275,9 @@ export class ParquetEnvelopeWriter {
   public rowGroups: RowGroup[];
   public pageSize: number;
   public useDataPageV2: boolean;
+  public dictionary: ParquetDictionaryPolicy;
+  public columnDictionaries: Record<string, ParquetDictionaryPolicy>;
+  public dictionaryPageSizeLimit: number;
 
   constructor(
     schema: ParquetSchema,
@@ -284,6 +294,9 @@ export class ParquetEnvelopeWriter {
     this.rowGroups = [];
     this.pageSize = opts.pageSize || PARQUET_DEFAULT_PAGE_SIZE;
     this.useDataPageV2 = 'useDataPageV2' in opts ? Boolean(opts.useDataPageV2) : false;
+    this.dictionary = opts.dictionary ?? 'auto';
+    this.columnDictionaries = opts.columnDictionaries || {};
+    this.dictionaryPageSizeLimit = opts.dictionaryPageSizeLimit ?? 1024 * 1024;
   }
 
   writeSection(buf: Uint8Array): Promise<void> {
@@ -306,7 +319,10 @@ export class ParquetEnvelopeWriter {
     const rgroup = await encodeRowGroup(this.schema, records, {
       baseOffset: this.offset,
       pageSize: this.pageSize,
-      useDataPageV2: this.useDataPageV2
+      useDataPageV2: this.useDataPageV2,
+      dictionary: this.dictionary,
+      columnDictionaries: this.columnDictionaries,
+      dictionaryPageSizeLimit: this.dictionaryPageSizeLimit
     });
 
     this.rowCount += records.rowCount;
@@ -394,7 +410,9 @@ function encodeValues(
  */
 async function encodeDataPage(
   column: ParquetField,
-  data: ParquetColumnChunk
+  data: ParquetColumnChunk,
+  valueEncoding: ParquetCodec = column.encoding!,
+  valueBitWidth?: number
 ): Promise<{
   header: PageHeader;
   headerSize: number;
@@ -418,9 +436,9 @@ async function encodeDataPage(
   }
 
   /* encode values */
-  const valuesBuf = encodeValues(column.primitiveType!, column.encoding!, data.values as any[], {
+  const valuesBuf = encodeValues(column.primitiveType!, valueEncoding, data.values as any[], {
     typeLength: column.typeLength,
-    bitWidth: column.typeLength
+    bitWidth: valueBitWidth ?? column.typeLength
   });
 
   const dataBuf = concatUint8Arrays([rLevelsBuf, dLevelsBuf, valuesBuf]);
@@ -433,7 +451,7 @@ async function encodeDataPage(
     type: PageType.DATA_PAGE,
     data_page_header: new DataPageHeader({
       num_values: data.count,
-      encoding: Encoding[column.encoding!] as any,
+      encoding: Encoding[valueEncoding] as any,
       definition_level_encoding: Encoding[PARQUET_RDLVL_ENCODING], // [PARQUET_RDLVL_ENCODING],
       repetition_level_encoding: Encoding[PARQUET_RDLVL_ENCODING] // [PARQUET_RDLVL_ENCODING]
     }),
@@ -454,16 +472,18 @@ async function encodeDataPage(
 async function encodeDataPageV2(
   column: ParquetField,
   data: ParquetColumnChunk,
-  rowCount: number
+  rowCount: number,
+  valueEncoding: ParquetCodec = column.encoding!,
+  valueBitWidth?: number
 ): Promise<{
   header: PageHeader;
   headerSize: number;
   page: Uint8Array;
 }> {
   /* encode values */
-  const valuesBuf = encodeValues(column.primitiveType!, column.encoding!, data.values as any[], {
+  const valuesBuf = encodeValues(column.primitiveType!, valueEncoding, data.values as any[], {
     typeLength: column.typeLength,
-    bitWidth: column.typeLength
+    bitWidth: valueBitWidth ?? column.typeLength
   });
 
   // compression = column.compression === 'UNCOMPRESSED' ? (compression || 'UNCOMPRESSED') : column.compression;
@@ -493,7 +513,7 @@ async function encodeDataPageV2(
       num_values: data.count,
       num_nulls: data.count - data.values.length,
       num_rows: rowCount,
-      encoding: Encoding[column.encoding!] as any,
+      encoding: Encoding[valueEncoding] as any,
       definition_levels_byte_length: dLevelsBuf.length,
       repetition_levels_byte_length: rLevelsBuf.length,
       is_compressed: column.compression !== 'UNCOMPRESSED'
@@ -506,6 +526,32 @@ async function encodeDataPageV2(
   const headerBuf = serializeThrift(header);
   const page = concatUint8Arrays([headerBuf, rLevelsBuf, dLevelsBuf, compressedBuf]);
   return {header, headerSize: headerBuf.length, page};
+}
+
+/** Encodes one chunk-wide PLAIN dictionary page. */
+async function encodeDictionaryPage(
+  column: ParquetField,
+  dictionaryValues: unknown[]
+): Promise<{header: PageHeader; headerSize: number; page: Uint8Array}> {
+  const valuesBuffer = encodeValues(column.primitiveType!, 'PLAIN', dictionaryValues as any[], {
+    typeLength: column.typeLength
+  });
+  const compressedBuffer = await Compression.deflate(column.compression!, valuesBuffer);
+  const header = new PageHeader({
+    type: PageType.DICTIONARY_PAGE,
+    dictionary_page_header: new DictionaryPageHeader({
+      num_values: dictionaryValues.length,
+      encoding: Encoding.PLAIN
+    }),
+    uncompressed_page_size: valuesBuffer.length,
+    compressed_page_size: compressedBuffer.length
+  });
+  const headerBuffer = serializeThrift(header);
+  return {
+    header,
+    headerSize: headerBuffer.length,
+    page: concatUint8Arrays([headerBuffer, compressedBuffer])
+  };
 }
 
 /**
@@ -524,31 +570,85 @@ async function encodeColumnChunk(
   const data = buffer.columnData[column.path.join()];
   const baseOffset = (opts.baseOffset || 0) + offset;
   /* encode data page(s) */
-  // const pages: Uint8Array[] = [];
-  let pageBuf: Uint8Array;
+  const pages: Uint8Array[] = [];
   // tslint:disable-next-line:variable-name
   let total_uncompressed_size = 0;
   // tslint:disable-next-line:variable-name
   let total_compressed_size = 0;
-  {
-    const result = opts.useDataPageV2
-      ? await encodeDataPageV2(column, data, buffer.rowCount)
-      : await encodeDataPage(column, data);
-    // pages.push(result.page);
-    pageBuf = result.page;
+  const plannedPages = planColumnPages(
+    column,
+    data,
+    buffer.rowCount,
+    opts.pageSize || PARQUET_DEFAULT_PAGE_SIZE
+  );
+  const dictionaryPolicy =
+    opts.columnDictionaries?.[column.path[0]] ?? opts.dictionary ?? ('auto' as const);
+  const dictionaryPlan = planDictionary(
+    column,
+    Array.from(data.values),
+    dictionaryPolicy,
+    opts.dictionaryPageSizeLimit ?? 1024 * 1024
+  );
+  if (dictionaryPlan) {
+    const result = await encodeDictionaryPage(column, dictionaryPlan.values);
+    pages.push(result.page);
     total_uncompressed_size += result.header.uncompressed_page_size + result.headerSize;
     total_compressed_size += result.header.compressed_page_size + result.headerSize;
   }
 
-  // const pagesBuf = concatUint8Arrays(pages);
+  const valueEncoding: ParquetCodec = dictionaryPlan ? 'RLE_DICTIONARY' : column.encoding!;
+  let dictionaryIndexOffset = 0;
+  for (const plannedPage of plannedPages) {
+    const pageData = dictionaryPlan
+      ? {
+          ...plannedPage.data,
+          values: dictionaryPlan.indices.slice(
+            dictionaryIndexOffset,
+            dictionaryIndexOffset + plannedPage.data.values.length
+          )
+        }
+      : plannedPage.data;
+    dictionaryIndexOffset += plannedPage.data.values.length;
+    const result = opts.useDataPageV2
+      ? await encodeDataPageV2(
+          column,
+          pageData,
+          plannedPage.rowCount,
+          valueEncoding,
+          dictionaryPlan?.bitWidth
+        )
+      : await encodeDataPage(column, pageData, valueEncoding, dictionaryPlan?.bitWidth);
+    pages.push(result.page);
+    total_uncompressed_size += result.header.uncompressed_page_size + result.headerSize;
+    total_compressed_size += result.header.compressed_page_size + result.headerSize;
+  }
+
+  const pagesBuf = concatUint8Arrays(pages);
   // const compression = column.compression === 'UNCOMPRESSED' ? (opts.compression || 'UNCOMPRESSED') : column.compression;
 
   /* prepare metadata header */
   const metadata = new ColumnMetaData({
     path_in_schema: column.path,
     num_values: int64(data.count),
-    data_page_offset: int64(baseOffset),
+    data_page_offset: int64(baseOffset + (dictionaryPlan ? pages[0].length : 0)),
+    dictionary_page_offset: dictionaryPlan ? int64(baseOffset) : undefined,
     encodings: [],
+    encoding_stats: [
+      ...(dictionaryPlan
+        ? [
+            new PageEncodingStats({
+              page_type: PageType.DICTIONARY_PAGE,
+              encoding: Encoding.PLAIN,
+              count: 1
+            })
+          ]
+        : []),
+      new PageEncodingStats({
+        page_type: opts.useDataPageV2 ? PageType.DATA_PAGE_V2 : PageType.DATA_PAGE,
+        encoding: Encoding[valueEncoding],
+        count: plannedPages.length
+      })
+    ],
     total_uncompressed_size: int64(total_uncompressed_size), //  : pagesBuf.length,
     total_compressed_size: int64(total_compressed_size),
     type: Type[column.primitiveType!],
@@ -557,11 +657,12 @@ async function encodeColumnChunk(
 
   /* list encodings */
   metadata.encodings.push(Encoding[PARQUET_RDLVL_ENCODING]);
-  metadata.encodings.push(Encoding[column.encoding!]);
+  if (dictionaryPlan) metadata.encodings.push(Encoding.PLAIN);
+  metadata.encodings.push(Encoding[valueEncoding]);
 
   /* concat metadata header and data pages */
-  const metadataOffset = baseOffset + pageBuf.length;
-  const body = concatUint8Arrays([pageBuf, serializeThrift(metadata)]);
+  const metadataOffset = baseOffset + pagesBuf.length;
+  const body = concatUint8Arrays([pagesBuf, serializeThrift(metadata)]);
   return {body, metadata, metadataOffset};
 }
 

--- a/modules/parquet/src/parquetjs/parser/decoders.ts
+++ b/modules/parquet/src/parquetjs/parser/decoders.ts
@@ -786,14 +786,27 @@ async function decodeDictionaryPage(
   }
 
   const numValues = pageHeader?.dictionary_page_header?.num_values || 0;
+  const declaredEncoding = getThriftEnum(
+    Encoding,
+    pageHeader.dictionary_page_header?.encoding!
+  ) as ParquetCodec;
+  // Some established writers put the data-page dictionary encoding in this field even though
+  // dictionary values themselves use PLAIN. Preserve compatibility with those files.
+  const dictionaryValueEncoding =
+    declaredEncoding === 'PLAIN_DICTIONARY' || declaredEncoding === 'RLE_DICTIONARY'
+      ? 'PLAIN'
+      : declaredEncoding;
 
   const decodedDictionaryValues = decodeValues(
     context.column.primitiveType!,
-    context.column.encoding!,
+    dictionaryValueEncoding,
     dictCursor,
     numValues,
-    // TODO - this looks wrong?
-    {...context, int64AsBigInt: shouldDecodeInt64AsBigInt(context)} as ParquetCodecOptions
+    {
+      ...context,
+      typeLength: context.column.typeLength,
+      int64AsBigInt: shouldDecodeInt64AsBigInt(context)
+    } as ParquetCodecOptions
   );
 
   return decodedDictionaryValues as (string | ArrayBuffer)[];

--- a/modules/parquet/src/parquetjs/schema/schema.ts
+++ b/modules/parquet/src/parquetjs/schema/schema.ts
@@ -6,6 +6,7 @@
 
 import {PARQUET_CODECS} from '../codecs/index';
 import {isByteStreamSplitType} from '../codecs/byte-stream-split';
+import {isDeltaEncodingType} from '../codecs/delta';
 import {PARQUET_COMPRESSION_METHODS} from '../compression';
 import {
   FieldDefinition,
@@ -171,6 +172,9 @@ function buildFields(
     const primitiveType = opts.physicalType || typeDef.primitiveType;
     if (opts.encoding === 'BYTE_STREAM_SPLIT' && !isByteStreamSplitType(primitiveType)) {
       throw new Error(`BYTE_STREAM_SPLIT does not support ${primitiveType}`);
+    }
+    if (opts.encoding.startsWith('DELTA_') && !isDeltaEncodingType(opts.encoding, primitiveType)) {
+      throw new Error(`${opts.encoding} does not support ${primitiveType}`);
     }
 
     opts.compression = opts.compression || 'UNCOMPRESSED';

--- a/modules/parquet/test/parquet-writer-delta-encodings.spec.ts
+++ b/modules/parquet/test/parquet-writer-delta-encodings.spec.ts
@@ -1,0 +1,71 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {encode, load} from '@loaders.gl/core';
+import {BlobFile} from '@loaders.gl/loader-utils';
+import {ParquetJSLoader, ParquetJSWriter, ParquetReader} from '@loaders.gl/parquet';
+import type {ObjectRowTable} from '@loaders.gl/schema';
+import {expect, test} from 'vitest';
+
+const INPUT: ObjectRowTable = {
+  shape: 'object-row-table',
+  schema: {
+    fields: [
+      {name: 'sequence', type: 'int32', nullable: false},
+      {name: 'counter', type: 'int64', nullable: false},
+      {name: 'label', type: 'utf8', nullable: false},
+      {name: 'payload', type: 'binary', nullable: false},
+      {name: 'token', type: {type: 'fixed-size-binary', byteWidth: 3}, nullable: false}
+    ],
+    metadata: {}
+  },
+  data: Array.from({length: 9}, (_, index) => ({
+    sequence: index * 10,
+    counter: 9_007_199_254_740_993n + BigInt(index * 2),
+    label: `shared-prefix-${index}`,
+    payload: new Uint8Array(index + 1).fill(index),
+    token: new Uint8Array([1, 2, index])
+  }))
+};
+
+test.each([false, true])(
+  'ParquetJSWriter emits stable delta encodings with Data Page V2=%s',
+  async useDataPageV2 => {
+    const parquetBuffer = await encode(INPUT, ParquetJSWriter, {
+      worker: false,
+      parquet: {
+        pageSize: 4,
+        useDataPageV2,
+        dictionary: false,
+        columnEncodings: {
+          sequence: 'DELTA_BINARY_PACKED',
+          counter: 'DELTA_BINARY_PACKED',
+          label: 'DELTA_BYTE_ARRAY',
+          payload: 'DELTA_LENGTH_BYTE_ARRAY',
+          token: 'DELTA_BYTE_ARRAY'
+        }
+      }
+    });
+    const output = await load(parquetBuffer, ParquetJSLoader, {core: {worker: false}});
+    expect(output).toMatchObject({shape: 'object-row-table', data: INPUT.data});
+
+    const metadata = await new ParquetReader(new BlobFile(parquetBuffer)).getFileMetadata();
+    expect(metadata.row_groups[0].columns.map(column => column.meta_data?.encodings)).toEqual([
+      expect.arrayContaining([5]),
+      expect.arrayContaining([5]),
+      expect.arrayContaining([7]),
+      expect.arrayContaining([6]),
+      expect.arrayContaining([7])
+    ]);
+  }
+);
+
+test('ParquetJSWriter rejects delta encodings on unsupported columns', async () => {
+  await expect(
+    encode(INPUT, ParquetJSWriter, {
+      worker: false,
+      parquet: {columnEncodings: {label: 'DELTA_BINARY_PACKED'}}
+    })
+  ).rejects.toThrow('DELTA_BINARY_PACKED does not support BYTE_ARRAY');
+});

--- a/modules/parquet/test/parquet-writer-dictionary.spec.ts
+++ b/modules/parquet/test/parquet-writer-dictionary.spec.ts
@@ -1,0 +1,110 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {encode, load} from '@loaders.gl/core';
+import {BlobFile} from '@loaders.gl/loader-utils';
+import {ParquetJSLoader, ParquetJSWriter, ParquetLoader, ParquetReader} from '@loaders.gl/parquet';
+import type {ObjectRowTable} from '@loaders.gl/schema';
+import {parquetReadObjects} from 'hyparquet';
+import {compressors} from 'hyparquet-compressors';
+import {expect, test} from 'vitest';
+
+const INPUT: ObjectRowTable = {
+  shape: 'object-row-table',
+  schema: {
+    fields: [
+      {name: 'sequence', type: 'int32', nullable: false},
+      {name: 'label', type: 'utf8', nullable: false},
+      {name: 'token', type: {type: 'fixed-size-binary', byteWidth: 3}, nullable: false}
+    ],
+    metadata: {}
+  },
+  data: Array.from({length: 10}, (_, index) => ({
+    sequence: index,
+    label: index % 2 ? 'alpha' : 'beta',
+    token: new Uint8Array(index % 2 ? [1, 2, 3] : [4, 5, 6])
+  }))
+};
+
+test.each([false, true])(
+  'ParquetJSWriter emits chunk dictionaries and multiple Data Page V2=%s pages',
+  async useDataPageV2 => {
+    const parquetBuffer = await encode(INPUT, ParquetJSWriter, {
+      worker: false,
+      parquet: {
+        pageSize: 3,
+        useDataPageV2,
+        dictionary: 'auto',
+        columnDictionaries: {sequence: false, token: true}
+      }
+    });
+    const output = await load(parquetBuffer, ParquetJSLoader, {core: {worker: false}});
+    expect(output).toMatchObject({shape: 'object-row-table', data: INPUT.data});
+
+    const metadata = await new ParquetReader(new BlobFile(parquetBuffer)).getFileMetadata();
+    const [sequence, label, token] = metadata.row_groups[0].columns.map(column => column.meta_data!);
+    expect(sequence.encodings).not.toContain(8);
+    for (const column of [label, token]) {
+      expect(column.encodings).toEqual(expect.arrayContaining([0, 8]));
+      expect(Number(column.dictionary_page_offset)).toBeLessThan(Number(column.data_page_offset));
+      expect(column.encoding_stats).toEqual([
+        expect.objectContaining({page_type: 2, encoding: 0, count: 1}),
+        expect.objectContaining({
+          page_type: useDataPageV2 ? 3 : 0,
+          encoding: 8,
+          count: 4
+        })
+      ]);
+    }
+  }
+);
+
+test('ParquetJSWriter falls back when a forced dictionary exceeds its size limit', async () => {
+  const parquetBuffer = await encode(INPUT, ParquetJSWriter, {
+    worker: false,
+    parquet: {dictionary: true, dictionaryPageSizeLimit: 1}
+  });
+  const metadata = await new ParquetReader(new BlobFile(parquetBuffer)).getFileMetadata();
+  expect(metadata.row_groups[0].columns.every(column => !column.meta_data?.encodings.includes(8))).toBe(
+    true
+  );
+});
+
+test('ParquetJSWriter rejects unknown dictionary column overrides', async () => {
+  await expect(
+    encode(INPUT, ParquetJSWriter, {
+      worker: false,
+      parquet: {columnDictionaries: {typo: true}}
+    })
+  ).rejects.toThrow('Unknown column dictionary override "typo"');
+});
+
+test('ParquetJSWriter multi-page dictionaries interoperate with maintained browser readers', async () => {
+  const parquetBuffer = await encode(INPUT, ParquetJSWriter, {
+    worker: false,
+    parquet: {
+      pageSize: 3,
+      useDataPageV2: true,
+      dictionary: true,
+      columnDictionaries: {sequence: false}
+    }
+  });
+  const [typescriptTable, wasmTable, hyparquetRows] = await Promise.all([
+    load(parquetBuffer, ParquetJSLoader, {core: {worker: false}}),
+    load(parquetBuffer, ParquetLoader, {core: {worker: false}}),
+    parquetReadObjects({file: parquetBuffer, compressors})
+  ]);
+  const expectedRows = INPUT.data.map(({sequence, label}) => ({sequence, label}));
+  expect(selectScalarColumns(typescriptTable.data)).toEqual(expectedRows);
+  expect(selectScalarColumns(wasmTable.data)).toEqual(expectedRows);
+  expect(selectScalarColumns(hyparquetRows)).toEqual(expectedRows);
+});
+
+/** Selects scalar columns whose representation is identical across maintained readers. */
+function selectScalarColumns(rows: unknown[]): Array<{sequence: number; label: string}> {
+  return rows.map(row => {
+    const objectRow = row as {sequence: number; label: string};
+    return {sequence: objectRow.sequence, label: objectRow.label};
+  });
+}

--- a/modules/parquet/test/parquet-writer-pages.spec.ts
+++ b/modules/parquet/test/parquet-writer-pages.spec.ts
@@ -1,0 +1,43 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {encode, load} from '@loaders.gl/core';
+import {BlobFile} from '@loaders.gl/loader-utils';
+import {ParquetJSLoader, ParquetJSWriter, ParquetReader} from '@loaders.gl/parquet';
+import type {ObjectRowTable} from '@loaders.gl/schema';
+import {expect, test} from 'vitest';
+
+const INPUT: ObjectRowTable = {
+  shape: 'object-row-table',
+  schema: {
+    fields: [{name: 'value', type: 'int32', nullable: false}],
+    metadata: {}
+  },
+  data: [{value: 10}, {value: 20}, {value: 30}, {value: 40}, {value: 50}]
+};
+
+test.each([false, true])(
+  'ParquetJSWriter emits multiple row-aligned pages with Data Page V2=%s',
+  async useDataPageV2 => {
+    const parquetBuffer = await encode(INPUT, ParquetJSWriter, {
+      worker: false,
+      parquet: {pageSize: 2, useDataPageV2}
+    });
+    const output = await load(parquetBuffer, ParquetJSLoader, {core: {worker: false}});
+    expect(output).toMatchObject({shape: 'object-row-table', data: INPUT.data});
+
+    const reader = new ParquetReader(new BlobFile(parquetBuffer));
+    const metadata = await reader.getFileMetadata();
+    const rowGroup = await reader.readRowGroup(
+      await reader.getSchema(),
+      metadata.row_groups[0],
+      []
+    );
+    const pageHeaders = rowGroup.columnData.value.pageHeaders;
+    expect(pageHeaders).toHaveLength(3);
+    if (useDataPageV2) {
+      expect(pageHeaders.map(page => page.data_page_header_v2?.num_rows)).toEqual([2, 2, 1]);
+    }
+  }
+);

--- a/modules/parquet/test/parquet.bench.ts
+++ b/modules/parquet/test/parquet.bench.ts
@@ -2,8 +2,14 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {GeoParquetLoader, ParquetJSLoader, ParquetLoader} from '@loaders.gl/parquet';
-import {fetchFile, load, parse, preload} from '@loaders.gl/core';
+import {
+  GeoParquetLoader,
+  ParquetJSLoader,
+  ParquetJSWriter,
+  ParquetLoader,
+  type ParquetJSWriterOptions
+} from '@loaders.gl/parquet';
+import {encode, fetchFile, load, parse, preload} from '@loaders.gl/core';
 import type {LoaderWithParser} from '@loaders.gl/loader-utils';
 import type {ArrowTable, ObjectRowTable} from '@loaders.gl/schema';
 import {convertTable, makeTableFromData} from '@loaders.gl/schema-utils';
@@ -46,6 +52,15 @@ type ParquetBenchmarkImplementation = {
   name: string;
   /** Hot decode operation returning the validated output row count. */
   decode: (scenario: ParquetBenchmarkScenario) => Promise<number>;
+};
+
+type ParquetWriterBenchmarkScenario = {
+  /** Human-readable data distribution and encoding label. */
+  name: string;
+  /** Scale-oriented input table prepared outside the timed callback. */
+  table: ObjectRowTable;
+  /** TypeScript writer options used by the timed callback. */
+  options: ParquetJSWriterOptions;
 };
 
 export async function parquetBench(suite) {
@@ -175,6 +190,8 @@ export async function parquetBench(suite) {
     }
   }
 
+  suite = await addParquetWriterBenchmarks(suite);
+
   suite = suite.group('GeoParquetLoader');
 
   suite.addAsync(
@@ -203,6 +220,98 @@ export async function parquetBench(suite) {
   //     core: {worker: false}
   //   });
   // });
+}
+
+/** Adds scale-oriented writer throughput cases and records the resulting bytes per row. */
+async function addParquetWriterBenchmarks(suite) {
+  const rowCount = 100_000;
+  const monotonicIntegerTable = makeObjectRowTable(
+    'sequence',
+    'int32',
+    Array.from({length: rowCount}, (_, index) => index * 10)
+  );
+  const lowCardinalityStringTable = makeObjectRowTable(
+    'label',
+    'utf8',
+    Array.from({length: rowCount}, (_, index) => `category-${index % 16}`)
+  );
+  const sharedPrefixStringTable = makeObjectRowTable(
+    'identifier',
+    'utf8',
+    Array.from({length: rowCount}, (_, index) => `customer/account/2026/08/${index}`)
+  );
+  const writerScenarios: ParquetWriterBenchmarkScenario[] = [
+    {
+      name: 'PLAIN monotonic INT32',
+      table: monotonicIntegerTable,
+      options: {parquet: {dictionary: false, columnEncodings: {sequence: 'PLAIN'}}}
+    },
+    {
+      name: 'DELTA_BINARY_PACKED monotonic INT32',
+      table: monotonicIntegerTable,
+      options: {
+        parquet: {dictionary: false, columnEncodings: {sequence: 'DELTA_BINARY_PACKED'}}
+      }
+    },
+    {
+      name: 'PLAIN low-cardinality STRING',
+      table: lowCardinalityStringTable,
+      options: {parquet: {dictionary: false, columnEncodings: {label: 'PLAIN'}}}
+    },
+    {
+      name: 'AUTO DICTIONARY low-cardinality STRING',
+      table: lowCardinalityStringTable,
+      options: {parquet: {dictionary: 'auto'}}
+    },
+    {
+      name: 'PLAIN shared-prefix STRING',
+      table: sharedPrefixStringTable,
+      options: {parquet: {dictionary: false, columnEncodings: {identifier: 'PLAIN'}}}
+    },
+    {
+      name: 'DELTA_BYTE_ARRAY shared-prefix STRING',
+      table: sharedPrefixStringTable,
+      options: {
+        parquet: {dictionary: false, columnEncodings: {identifier: 'DELTA_BYTE_ARRAY'}}
+      }
+    }
+  ];
+
+  suite = suite.groupSorted('ParquetJSWriter scale');
+  for (const scenario of writerScenarios) {
+    const sample = await encode(scenario.table, ParquetJSWriter, {
+      ...scenario.options,
+      worker: false
+    });
+    const bytesPerRow = sample.byteLength / rowCount;
+    suite.addAsync(
+      `ParquetJSWriter - ${scenario.name} (${bytesPerRow.toFixed(2)} B/row)`,
+      {...BENCHMARK_OPTIONS, multiplier: rowCount},
+      async () => {
+        const parquet = await encode(scenario.table, ParquetJSWriter, {
+          ...scenario.options,
+          worker: false
+        });
+        if (parquet.byteLength === 0) {
+          throw new Error(`${scenario.name} produced an empty Parquet file`);
+        }
+      }
+    );
+  }
+  return suite;
+}
+
+/** Creates a single-column object-row table for a deterministic writer benchmark. */
+function makeObjectRowTable(
+  name: string,
+  type: 'int32' | 'utf8',
+  values: Array<number | string>
+): ObjectRowTable {
+  return {
+    shape: 'object-row-table',
+    schema: {fields: [{name, type, nullable: false}], metadata: {}},
+    data: values.map(value => ({[name]: value}))
+  };
 }
 
 /** Creates equivalent Arrow-table decode cases for the maintained Parquet implementations. */

--- a/modules/parquet/test/parquetjs/codec-delta-encode.spec.ts
+++ b/modules/parquet/test/parquetjs/codec-delta-encode.spec.ts
@@ -1,0 +1,71 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import {PARQUET_CODECS} from '../../src/parquetjs/codecs';
+
+test('DELTA_BINARY_PACKED encoder matches the canonical constant-delta layout', () => {
+  expect(Array.from(PARQUET_CODECS.DELTA_BINARY_PACKED.encodeValues('INT32', [1, 2, 3], {}))).toEqual(
+    [0x80, 0x01, 0x04, 0x03, 0x02, 0x02, 0x00, 0x00, 0x00, 0x00]
+  );
+});
+
+test('DELTA_BINARY_PACKED encoder round-trips multiple INT32 blocks', () => {
+  const values = Array.from({length: 300}, (_, index) =>
+    index % 17 === 0 ? -2_147_483_648 + index : (index * index - 5000) | 0
+  );
+  const encoded = PARQUET_CODECS.DELTA_BINARY_PACKED.encodeValues('INT32', values, {});
+  const decoded = PARQUET_CODECS.DELTA_BINARY_PACKED.decodeValues(
+    'INT32',
+    {buffer: encoded, offset: 0, size: encoded.length},
+    values.length,
+    {}
+  );
+  expect(Array.from(decoded)).toEqual(values);
+});
+
+test('DELTA_BINARY_PACKED encoder preserves exact wide INT64 values', () => {
+  const values = [-(2n ** 63n), 2n ** 63n - 1n, -1n, 0n, 9_007_199_254_740_993n];
+  const encoded = PARQUET_CODECS.DELTA_BINARY_PACKED.encodeValues('INT64', values, {});
+  const decoded = PARQUET_CODECS.DELTA_BINARY_PACKED.decodeValues(
+    'INT64',
+    {buffer: encoded, offset: 0, size: encoded.length},
+    values.length,
+    {int64AsBigInt: true}
+  );
+  expect(Array.from(decoded)).toEqual(values);
+});
+
+test.each(['DELTA_LENGTH_BYTE_ARRAY', 'DELTA_BYTE_ARRAY'] as const)(
+  '%s encoder round-trips byte arrays',
+  encoding => {
+    const values = [
+      new Uint8Array([97, 98, 99]),
+      new Uint8Array([97, 98, 100]),
+      new Uint8Array([97, 98, 100, 101]),
+      new Uint8Array(0)
+    ];
+    const encoded = PARQUET_CODECS[encoding].encodeValues('BYTE_ARRAY', values, {});
+    const decoded = PARQUET_CODECS[encoding].decodeValues(
+      'BYTE_ARRAY',
+      {buffer: encoded, offset: 0, size: encoded.length},
+      values.length,
+      {}
+    );
+    expect(Array.from(decoded)).toEqual(values);
+  }
+);
+
+test('delta encoders reject unsupported physical types', () => {
+  expect(() => PARQUET_CODECS.DELTA_BINARY_PACKED.encodeValues('FLOAT', [1], {})).toThrow(
+    'does not support Parquet type FLOAT'
+  );
+  expect(() =>
+    PARQUET_CODECS.DELTA_LENGTH_BYTE_ARRAY.encodeValues(
+      'FIXED_LEN_BYTE_ARRAY',
+      [new Uint8Array(2)],
+      {}
+    )
+  ).toThrow('does not support Parquet type FIXED_LEN_BYTE_ARRAY');
+});

--- a/modules/parquet/test/parquetjs/codec-dictionary-encode.spec.ts
+++ b/modules/parquet/test/parquetjs/codec-dictionary-encode.spec.ts
@@ -1,0 +1,38 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import {PARQUET_CODECS} from '../../src/parquetjs/codecs';
+import {planDictionary} from '../../src/parquetjs/encoder/dictionary-planner';
+import {ParquetSchema} from '../../src/parquetjs/schema/schema';
+
+test.each([
+  {indices: [1, 2, 3], bitWidth: 2},
+  {indices: [300, 300, 300, 300], bitWidth: 9}
+])('dictionary index encoder round-trips $indices at bit width $bitWidth', ({indices, bitWidth}) => {
+  const encoded = PARQUET_CODECS.RLE_DICTIONARY.encodeValues('INT32', indices, {bitWidth});
+  const decoded = PARQUET_CODECS.RLE_DICTIONARY.decodeValues(
+    'INT32',
+    {buffer: encoded, offset: 0, size: encoded.length},
+    indices.length,
+    {}
+  );
+  expect(Array.from(decoded)).toEqual(indices);
+});
+
+test('dictionary planner selects low-cardinality values and rejects larger output', () => {
+  const column = new ParquetSchema({value: {type: 'UTF8'}}).fields.value;
+  const repeatedValues = Array.from({length: 100}, (_, index) =>
+    new TextEncoder().encode(index % 2 ? 'alpha' : 'beta')
+  );
+  const uniqueValues = Array.from({length: 20}, (_, index) =>
+    new TextEncoder().encode(`unique-${index}`)
+  );
+
+  const plan = planDictionary(column, repeatedValues, 'auto', 1024);
+  expect(plan?.values).toHaveLength(2);
+  expect(plan?.indices).toHaveLength(100);
+  expect(planDictionary(column, uniqueValues, 'auto', 1024)).toBeUndefined();
+  expect(planDictionary(column, repeatedValues, true, 1)).toBeUndefined();
+});

--- a/modules/parquet/test/parquetjs/page-planner.spec.ts
+++ b/modules/parquet/test/parquetjs/page-planner.spec.ts
@@ -1,0 +1,60 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import {planColumnPages} from '../../src/parquetjs/encoder/page-planner';
+import {ParquetSchema} from '../../src/parquetjs/schema/schema';
+
+test('page planner splits flat columns at the configured value count', () => {
+  const column = new ParquetSchema({value: {type: 'INT32'}}).fields.value;
+  const pages = planColumnPages(
+    column,
+    {
+      rlevels: [0, 0, 0, 0, 0],
+      dlevels: [0, 0, 0, 0, 0],
+      values: [10, 20, 30, 40, 50],
+      count: 5,
+      pageHeaders: []
+    },
+    5,
+    2
+  );
+
+  expect(pages.map(page => page.rowCount)).toEqual([2, 2, 1]);
+  expect(pages.map(page => page.data.values)).toEqual([[10, 20], [30, 40], [50]]);
+});
+
+test('page planner preserves repeated rows and their value alignment', () => {
+  const column = new ParquetSchema({value: {type: 'INT32', repeated: true}}).fields.value;
+  const pages = planColumnPages(
+    column,
+    {
+      rlevels: [0, 1, 1, 0, 0, 1],
+      dlevels: [1, 1, 1, 0, 1, 1],
+      values: [10, 11, 12, 30, 31],
+      count: 6,
+      pageHeaders: []
+    },
+    3,
+    2
+  );
+
+  expect(pages.map(page => page.rowCount)).toEqual([1, 1, 1]);
+  expect(pages.map(page => page.data.count)).toEqual([3, 1, 2]);
+  expect(pages.map(page => page.data.values)).toEqual([[10, 11, 12], [], [30, 31]]);
+});
+
+test('page planner rejects invalid sizes and inconsistent shredded rows', () => {
+  const column = new ParquetSchema({value: {type: 'INT32'}}).fields.value;
+  const data = {
+    rlevels: [0],
+    dlevels: [0],
+    values: [1],
+    count: 1,
+    pageHeaders: []
+  };
+
+  expect(() => planColumnPages(column, data, 1, 0)).toThrow('positive integer');
+  expect(() => planColumnPages(column, data, 2, 1)).toThrow('found 1 rows, expected 2');
+});


### PR DESCRIPTION
## Goals

- Make `pageSize` produce real row-aligned Parquet data pages.
- Complete stable dictionary and delta writer encodings for efficient output at scale.
- Select compact representations adaptively without penalizing high-cardinality columns.

## Changes

- Adds row-boundary-aware page planning and emits multiple Data Page V1 or V2 pages per column chunk.
- Adds exact `DELTA_BINARY_PACKED`, `DELTA_LENGTH_BYTE_ARRAY`, and `DELTA_BYTE_ARRAY` writers with physical-type validation.
- Adds chunk-wide dictionary planning with auto, forced, disabled, per-column, and size-limit policies.
- Emits dictionary pages, correct page offsets, encoding lists, and page encoding statistics.
- Fixes RLE repeated-value and bit-packed padding edge cases used by dictionary indices.
- Preserves compatibility with existing files whose dictionary page header declares a dictionary data encoding.
- Adds focused codec and planner tests, multi-page V1/V2 round trips, and interoperability coverage with the TypeScript loader, parquet-wasm, and hyparquet.
- Adds 100k-row writer benchmarks for monotonic integers, low-cardinality strings, and shared-prefix strings, reporting throughput and bytes per row.
- Documents the new writer options, encoding matrix, adaptive behavior, and multi-page output.

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn build-workers`
- `yarn test-node`
- `yarn test-headless`
- `yarn test-audit`
- `cd website && yarn && yarn build`

The live browser benchmark command currently stops in the existing benchmark harness with `ReferenceError: require is not defined` before reaching the Parquet cases. That harness issue and the partial slow-lane Coveralls baseline issue are intentionally left for separate follow-up PRs.