### PR TITLE
fix(gltf): support per-texture UV transforms

### DIFF
--- a/modules/gltf/src/lib/extensions/KHR_texture_transform.ts
+++ b/modules/gltf/src/lib/extensions/KHR_texture_transform.ts
@@ -44,9 +44,9 @@ type CompoundGLTFTextureInfo = GLTFTextureInfo &
   GLTFMaterialOcclusionTextureInfo;
 /** Parameters for TEXCOORD transformation */
 type TransformParameters = {
-  /** Original texCoord value https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#_textureinfo_texcoord */
-  originalTexCoord: number;
-  /** New texCoord value from extension https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_texture_transform#gltf-schema-updates */
+  /** Source texCoord selected by the texture info or extension. */
+  sourceTexCoord: number;
+  /** Generated texCoord containing the transformed values. */
   texCoord: number;
   /** Transformation matrix */
   matrix: Matrix3;
@@ -65,52 +65,105 @@ export async function decode(gltfData: GLTFWithBuffers, options: GLTFLoaderOptio
   }
   const materials = gltfData.json.materials || [];
   for (let i = 0; i < materials.length; i++) {
-    transformTexCoords(i, gltfData);
+    transformTexCoords(i, gltfData, gltfScenegraph);
   }
+  gltfScenegraph.removeExtension(KHR_TEXTURE_TRANSFORM);
 }
 
 /**
  * Transform TEXCOORD by material
  * @param materialIndex processing material index
  * @param gltfData gltf buffers and json
+ * @param gltfScenegraph glTF scenegraph used to remove decoded extensions
  */
-function transformTexCoords(materialIndex: number, gltfData: GLTFWithBuffers): void {
+function transformTexCoords(
+  materialIndex: number,
+  gltfData: GLTFWithBuffers,
+  gltfScenegraph: GLTFScenegraph
+): void {
   const material = gltfData.json.materials?.[materialIndex];
-  const materialTextures = [
-    material?.pbrMetallicRoughness?.baseColorTexture,
-    material?.emissiveTexture,
-    material?.normalTexture,
-    material?.occlusionTexture,
-    material?.pbrMetallicRoughness?.metallicRoughnessTexture
-  ];
-
-  // Save processed texCoords in order no to process the same twice
-  const processedTexCoords: [number, number][] = [];
+  const materialTextures = findTextureInfos(material);
+  const processedTransforms = new Map<string, TransformParameters>();
+  let nextTexCoord = getNextTexCoord(gltfData);
 
   for (const textureInfo of materialTextures) {
-    if (textureInfo && textureInfo?.extensions?.[KHR_TEXTURE_TRANSFORM]) {
-      transformPrimitives(gltfData, materialIndex, textureInfo, processedTexCoords);
+    const extension = textureInfo.extensions?.[KHR_TEXTURE_TRANSFORM] as TextureInfo | undefined;
+    if (extension) {
+      const sourceTexCoord = extension.texCoord ?? textureInfo.texCoord ?? 0;
+      const transformKey = getTransformKey(sourceTexCoord, extension);
+      let transformParameters = processedTransforms.get(transformKey);
+      if (!transformParameters) {
+        transformParameters = {
+          sourceTexCoord,
+          texCoord: nextTexCoord++,
+          matrix: makeTransformationMatrix(extension)
+        };
+        transformPrimitives(gltfData, materialIndex, transformParameters);
+        processedTransforms.set(transformKey, transformParameters);
+      }
+      textureInfo.texCoord = transformParameters.texCoord;
+      gltfScenegraph.removeObjectExtension(textureInfo, KHR_TEXTURE_TRANSFORM);
+      if (textureInfo.extensions && Object.keys(textureInfo.extensions).length === 0) {
+        delete textureInfo.extensions;
+      }
     }
   }
 }
 
 /**
- * Transform primitives of the particular material
+ * Finds texture infos at any nesting level of a material, including KHR_materials_* extensions.
+ * @param value material value to inspect
+ * @returns texture infos using KHR_texture_transform
+ */
+function findTextureInfos(value: unknown): CompoundGLTFTextureInfo[] {
+  if (!value || typeof value !== 'object') {
+    return [];
+  }
+  const object = value as Record<string, unknown>;
+  const textureInfos: CompoundGLTFTextureInfo[] = [];
+  const extensions = object.extensions as Record<string, unknown> | undefined;
+  if (Number.isFinite(object.index) && extensions?.[KHR_TEXTURE_TRANSFORM]) {
+    textureInfos.push(object as CompoundGLTFTextureInfo);
+  }
+  for (const nestedValue of Object.values(object)) {
+    textureInfos.push(...findTextureInfos(nestedValue));
+  }
+  return textureInfos;
+}
+
+/** Returns the first TEXCOORD set index unused by every primitive. */
+function getNextTexCoord(gltfData: GLTFWithBuffers): number {
+  let maximumTexCoord = -1;
+  for (const mesh of gltfData.json.meshes || []) {
+    for (const primitive of mesh.primitives) {
+      for (const attributeName of Object.keys(primitive.attributes)) {
+        const match = /^TEXCOORD_(\d+)$/.exec(attributeName);
+        if (match) {
+          maximumTexCoord = Math.max(maximumTexCoord, Number(match[1]));
+        }
+      }
+    }
+  }
+  return maximumTexCoord + 1;
+}
+
+/** Returns a stable key for transformations that can share generated attributes. */
+function getTransformKey(sourceTexCoord: number, extension: TextureInfo): string {
+  const {offset = [0, 0], rotation = 0, scale = [1, 1]} = extension;
+  return JSON.stringify([sourceTexCoord, offset, rotation, scale]);
+}
+
+/**
+ * Transform primitives of the particular material.
  * @param gltfData gltf data
  * @param materialIndex primitives with this material will be transformed
- * @param texture texture object
- * @param processedTexCoords storage to save already processed texCoords
+ * @param transformParameters source and generated texture coordinate sets
  */
 function transformPrimitives(
   gltfData: GLTFWithBuffers,
   materialIndex: number,
-  texture: CompoundGLTFTextureInfo,
-  processedTexCoords: [number, number][]
-) {
-  const transformParameters = getTransformParameters(texture, processedTexCoords);
-  if (!transformParameters) {
-    return;
-  }
+  transformParameters: TransformParameters
+): void {
   const meshes = gltfData.json.meshes || [];
   for (const mesh of meshes) {
     for (const primitive of mesh.primitives) {
@@ -120,36 +173,6 @@ function transformPrimitives(
       }
     }
   }
-}
-
-/**
- * Get parameters for TEXCOORD transformation
- * @param texture texture object
- * @param processedTexCoords storage to save already processed texCoords
- * @returns texCoord couple and transformation matrix
- */
-function getTransformParameters(
-  texture: CompoundGLTFTextureInfo,
-  processedTexCoords: [number, number][]
-): TransformParameters | null {
-  const textureInfo = texture.extensions?.[KHR_TEXTURE_TRANSFORM];
-  const {texCoord: originalTexCoord = 0} = texture;
-  // If texCoord is not set in the extension, original attribute data will be replaced
-  const {texCoord = originalTexCoord} = textureInfo;
-  // Make sure that couple [originalTexCoord, extensionTexCoord] is not processed twice
-  const isProcessed =
-    processedTexCoords.findIndex(
-      ([original, newTexCoord]) => original === originalTexCoord && newTexCoord === texCoord
-    ) !== -1;
-  if (!isProcessed) {
-    const matrix = makeTransformationMatrix(textureInfo);
-    if (originalTexCoord !== texCoord) {
-      texture.texCoord = texCoord;
-    }
-    processedTexCoords.push([originalTexCoord, texCoord]);
-    return {originalTexCoord, texCoord, matrix};
-  }
-  return null;
 }
 
 /**
@@ -163,8 +186,8 @@ function transformPrimitive(
   primitive: GLTFMeshPrimitive,
   transformParameters: TransformParameters
 ) {
-  const {originalTexCoord, texCoord, matrix} = transformParameters;
-  const texCoordAccessor = primitive.attributes[`TEXCOORD_${originalTexCoord}`];
+  const {sourceTexCoord, texCoord, matrix} = transformParameters;
+  const texCoordAccessor = primitive.attributes[`TEXCOORD_${sourceTexCoord}`];
   if (Number.isFinite(texCoordAccessor)) {
     // Get accessor of the `TEXCOORD_0` attribute
     const accessor = gltfData.json.accessors?.[texCoordAccessor];
@@ -196,66 +219,9 @@ function transformPrimitive(
           // Save result in Float32Array
           result.set([scratchVector[0], scratchVector[1]], i * components);
         }
-        // If texCoord the same, replace gltf structural data
-        if (originalTexCoord === texCoord) {
-          updateGltf(accessor, gltfData, result, accessor.bufferView);
-        } else {
-          // If texCoord change, create new attribute
-          createAttribute(texCoord, accessor, primitive, gltfData, result);
-        }
+        createAttribute(texCoord, accessor, primitive, gltfData, result);
       }
     }
-  }
-}
-
-/**
- * Update GLTF structural objects with new data as we create new `Float32Array` for `TEXCOORD_0`.
- * @param accessor accessor to change
- * @param gltfData gltf json and buffers
- * @param newTexcoordArray typed array with data after transformation
- */
-function updateGltf(
-  accessor: GLTFAccessor,
-  gltfData: GLTFWithBuffers,
-  newTexCoordArray: Float32Array,
-  originalBufferViewIndex: number
-): void {
-  accessor.componentType = 5126;
-  accessor.byteOffset = 0;
-
-  const accessors = gltfData.json.accessors || [];
-  const bufferViewReferenceCount = accessors.reduce((count, currentAccessor) => {
-    return currentAccessor.bufferView === originalBufferViewIndex ? count + 1 : count;
-  }, 0);
-  const shouldCreateNewBufferView = bufferViewReferenceCount > 1;
-
-  gltfData.buffers.push({
-    arrayBuffer: ensureArrayBuffer(newTexCoordArray.buffer),
-    byteOffset: 0,
-    byteLength: newTexCoordArray.buffer.byteLength
-  });
-  const newBufferIndex = gltfData.buffers.length - 1;
-
-  gltfData.json.bufferViews = gltfData.json.bufferViews || [];
-  if (shouldCreateNewBufferView) {
-    gltfData.json.bufferViews.push({
-      buffer: newBufferIndex,
-      byteLength: newTexCoordArray.buffer.byteLength,
-      byteOffset: 0
-    });
-    accessor.bufferView = gltfData.json.bufferViews.length - 1;
-    return;
-  }
-
-  const bufferView = gltfData.json.bufferViews[originalBufferViewIndex];
-  if (!bufferView) {
-    return;
-  }
-  bufferView.buffer = newBufferIndex;
-  bufferView.byteOffset = 0;
-  bufferView.byteLength = newTexCoordArray.buffer.byteLength;
-  if (bufferView.byteStride !== undefined) {
-    delete (bufferView as {byteStride?: number}).byteStride;
   }
 }
 

--- a/modules/gltf/src/lib/extensions/KHR_texture_transform.ts
+++ b/modules/gltf/src/lib/extensions/KHR_texture_transform.ts
@@ -67,7 +67,9 @@ export async function decode(gltfData: GLTFWithBuffers, options: GLTFLoaderOptio
   for (let i = 0; i < materials.length; i++) {
     transformTexCoords(i, gltfData, gltfScenegraph);
   }
-  gltfScenegraph.removeExtension(KHR_TEXTURE_TRANSFORM);
+  if (!materials.some(material => findTextureInfos(material).length > 0)) {
+    gltfScenegraph.removeExtension(KHR_TEXTURE_TRANSFORM);
+  }
 }
 
 /**
@@ -95,10 +97,13 @@ function transformTexCoords(
       if (!transformParameters) {
         transformParameters = {
           sourceTexCoord,
-          texCoord: nextTexCoord++,
+          texCoord: nextTexCoord,
           matrix: makeTransformationMatrix(extension)
         };
-        transformPrimitives(gltfData, materialIndex, transformParameters);
+        if (!transformPrimitives(gltfData, materialIndex, transformParameters)) {
+          continue;
+        }
+        nextTexCoord++;
         processedTransforms.set(transformKey, transformParameters);
       }
       textureInfo.texCoord = transformParameters.texCoord;
@@ -125,8 +130,10 @@ function findTextureInfos(value: unknown): CompoundGLTFTextureInfo[] {
   if (Number.isFinite(object.index) && extensions?.[KHR_TEXTURE_TRANSFORM]) {
     textureInfos.push(object as CompoundGLTFTextureInfo);
   }
-  for (const nestedValue of Object.values(object)) {
-    textureInfos.push(...findTextureInfos(nestedValue));
+  for (const [key, nestedValue] of Object.entries(object)) {
+    if (key !== 'extras') {
+      textureInfos.push(...findTextureInfos(nestedValue));
+    }
   }
   return textureInfos;
 }
@@ -158,21 +165,53 @@ function getTransformKey(sourceTexCoord: number, extension: TextureInfo): string
  * @param gltfData gltf data
  * @param materialIndex primitives with this material will be transformed
  * @param transformParameters source and generated texture coordinate sets
+ * @returns true when every relevant primitive received the generated attribute
  */
 function transformPrimitives(
   gltfData: GLTFWithBuffers,
   materialIndex: number,
   transformParameters: TransformParameters
-): void {
+): boolean {
+  const primitives: GLTFMeshPrimitive[] = [];
   const meshes = gltfData.json.meshes || [];
   for (const mesh of meshes) {
     for (const primitive of mesh.primitives) {
       const material = primitive.material;
       if (Number.isFinite(material) && materialIndex === material) {
-        transformPrimitive(gltfData, primitive, transformParameters);
+        primitives.push(primitive);
       }
     }
   }
+  if (
+    primitives.length === 0 ||
+    primitives.some(
+      primitive => !canTransformPrimitive(gltfData, primitive, transformParameters.sourceTexCoord)
+    )
+  ) {
+    return false;
+  }
+  for (const primitive of primitives) {
+    transformPrimitive(gltfData, primitive, transformParameters);
+  }
+  return true;
+}
+
+/** Returns whether a primitive's source texture coordinates can be transformed without data loss. */
+function canTransformPrimitive(
+  gltfData: GLTFWithBuffers,
+  primitive: GLTFMeshPrimitive,
+  sourceTexCoord: number
+): boolean {
+  const texCoordAccessor = primitive.attributes[`TEXCOORD_${sourceTexCoord}`];
+  if (!Number.isFinite(texCoordAccessor)) {
+    return false;
+  }
+  const accessor = gltfData.json.accessors?.[texCoordAccessor];
+  if (!accessor || accessor.bufferView === undefined || accessor.sparse) {
+    return false;
+  }
+  const bufferView = gltfData.json.bufferViews?.[accessor.bufferView];
+  return Boolean(bufferView && gltfData.buffers[bufferView.buffer]);
 }
 
 /**

--- a/modules/gltf/test/lib/extensions/KHR_texture_transform.spec.ts
+++ b/modules/gltf/test/lib/extensions/KHR_texture_transform.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-len, camelcase */
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 
 import {parse, fetchFile} from '@loaders.gl/core';
 import {GLTFLoader, postProcessGLTF} from '@loaders.gl/gltf';
@@ -9,27 +9,22 @@ import {decode as decodeTextureTransform} from '../../../src/lib/extensions/KHR_
 
 const GLTF_BINARY_URL = '@loaders.gl/gltf/test/data/meshopt/BoxTextured_meshopt.glb';
 
-test('GLTFLoader#KHR_texture_transform', async t => {
+test('GLTFLoader#KHR_texture_transform', async () => {
   const response = await fetchFile(GLTF_BINARY_URL);
   const data = await response.arrayBuffer();
   const gltfWithBuffers = await parse(data, GLTFLoader);
   const gltf = postProcessGLTF(gltfWithBuffers);
 
-  t.equals(gltf.bufferViews[3].byteLength, 192, 'Has correct bufferView byte length');
-  t.equals(
-    gltf.accessors[2].componentType,
-    5126,
-    'UV0 component type has been changed from 5123 (int16) to 5126 (float)'
-  );
-  t.equals(
-    gltf.accessors[2].value.constructor,
-    Float32Array,
-    'UV0 data has been transformed from Uint16Array to Float32Array'
-  );
-  t.end();
+  const primitive = gltf.meshes[0].primitives[0];
+  const transformedTexCoord = primitive.material?.pbrMetallicRoughness?.baseColorTexture?.texCoord;
+  expect(transformedTexCoord).toBe(1);
+  expect(gltf.accessors[2].componentType).toBe(5123);
+  expect(primitive.attributes.TEXCOORD_0).toBe(gltf.accessors[2]);
+  expect(primitive.attributes.TEXCOORD_1.componentType).toBe(5126);
+  expect(primitive.attributes.TEXCOORD_1.value).toBeInstanceOf(Float32Array);
 });
 
-test('GLTFLoader#KHR_texture_transform preserves shared bufferView data', async t => {
+test('GLTFLoader#KHR_texture_transform preserves shared bufferView data', async () => {
   const interleavedVertexData = new Float32Array([
     // Vertex 0
     0, 0, 0, 0, 0, 1, 0, 0,
@@ -89,21 +84,15 @@ test('GLTFLoader#KHR_texture_transform preserves shared bufferView data', async 
   await decodeTextureTransform(gltfWithBuffers, {gltf: {loadBuffers: true}} as GLTFLoaderOptions);
 
   const bufferViews = gltfWithBuffers.json.bufferViews || [];
-  t.equals(bufferViews.length, 2, 'Creates a new bufferView for transformed texcoords');
-  t.equals(
-    bufferViews[0]?.byteStride,
-    32,
-    'Retains original interleaved bufferView byteStride for other attributes'
-  );
-  t.equals(
-    bufferViews[0]?.byteLength,
-    interleavedVertexData.byteLength,
-    'Retains original interleaved bufferView byteLength for other attributes'
-  );
+  expect(bufferViews).toHaveLength(2);
+  expect(bufferViews[0]?.byteStride).toBe(32);
+  expect(bufferViews[0]?.byteLength).toBe(interleavedVertexData.byteLength);
 
   const texCoordAccessor = gltfWithBuffers.json.accessors?.[2];
-  t.equals(texCoordAccessor?.bufferView, 1, 'Moves texcoord accessor to new bufferView');
-  t.equals(texCoordAccessor?.byteOffset || 0, 0, 'Resets texcoord accessor byte offset');
+  expect(texCoordAccessor?.bufferView).toBe(0);
+  expect(texCoordAccessor?.byteOffset).toBe(24);
+  expect(gltfWithBuffers.json.meshes?.[0].primitives[0].attributes.TEXCOORD_0).toBe(2);
+  expect(gltfWithBuffers.json.meshes?.[0].primitives[0].attributes.TEXCOORD_1).toBe(3);
 
   const newTexCoordValues = Array.from(new Float32Array(gltfWithBuffers.buffers[1].arrayBuffer));
   const expectedTexCoordValues = [0.1, 0.2, 2.1, 0.2];
@@ -111,19 +100,72 @@ test('GLTFLoader#KHR_texture_transform preserves shared bufferView data', async 
     const actualValue = newTexCoordValues[index];
     return Number.isFinite(actualValue) && Math.abs(actualValue - expectedValue) < 1e-6;
   });
-  t.ok(
-    areTexCoordValuesWithinTolerance,
-    'Applies texture transform to texcoords in isolated buffer'
-  );
+  expect(areTexCoordValuesWithinTolerance).toBe(true);
 
   const interleavedValuesAfterTransform = Array.from(
     new Float32Array(gltfWithBuffers.buffers[0].arrayBuffer)
   );
-  t.deepEquals(
-    interleavedValuesAfterTransform,
-    originalInterleavedCopy,
-    'Leaves shared interleaved buffer data unchanged'
-  );
+  expect(interleavedValuesAfterTransform).toEqual(originalInterleavedCopy);
+});
 
-  t.end();
+test('GLTFLoader#KHR_texture_transform supports distinct transforms per texture', async () => {
+  const texCoords = new Float32Array([0, 0, 1, 1]);
+  const gltfWithBuffers: GLTFWithBuffers = {
+    json: {
+      asset: {version: '2.0'},
+      extensionsUsed: ['KHR_texture_transform', 'KHR_materials_clearcoat'],
+      buffers: [{byteLength: texCoords.byteLength}],
+      bufferViews: [{buffer: 0, byteLength: texCoords.byteLength}],
+      accessors: [{bufferView: 0, componentType: 5126, count: 2, type: 'VEC2'}],
+      materials: [
+        {
+          pbrMetallicRoughness: {
+            baseColorTexture: {
+              index: 0,
+              extensions: {KHR_texture_transform: {offset: [0.25, 0.5]}}
+            },
+            metallicRoughnessTexture: {
+              index: 1,
+              extensions: {KHR_texture_transform: {scale: [2, 3]}}
+            }
+          },
+          extensions: {
+            KHR_materials_clearcoat: {
+              clearcoatTexture: {
+                index: 2,
+                extensions: {KHR_texture_transform: {offset: [0.25, 0.5]}}
+              }
+            }
+          }
+        }
+      ],
+      meshes: [{primitives: [{attributes: {TEXCOORD_0: 0}, material: 0}]}]
+    },
+    buffers: [
+      {
+        arrayBuffer: texCoords.buffer,
+        byteOffset: 0,
+        byteLength: texCoords.byteLength
+      }
+    ]
+  };
+
+  await decodeTextureTransform(gltfWithBuffers, {gltf: {loadBuffers: true}} as GLTFLoaderOptions);
+
+  const material = gltfWithBuffers.json.materials?.[0];
+  const primitive = gltfWithBuffers.json.meshes?.[0].primitives[0];
+  const clearcoatTexture = material?.extensions?.KHR_materials_clearcoat.clearcoatTexture;
+  expect(material?.pbrMetallicRoughness?.baseColorTexture?.texCoord).toBe(1);
+  expect(material?.pbrMetallicRoughness?.metallicRoughnessTexture?.texCoord).toBe(2);
+  expect(clearcoatTexture.texCoord).toBe(1);
+  expect(primitive?.attributes).toEqual({TEXCOORD_0: 0, TEXCOORD_1: 1, TEXCOORD_2: 2});
+  expect(Array.from(new Float32Array(gltfWithBuffers.buffers[1].arrayBuffer))).toEqual([
+    0.25, 0.5, 1.25, 1.5
+  ]);
+  expect(Array.from(new Float32Array(gltfWithBuffers.buffers[2].arrayBuffer))).toEqual([
+    0, 0, 2, 3
+  ]);
+  expect(material?.pbrMetallicRoughness?.baseColorTexture?.extensions).toBeUndefined();
+  expect(gltfWithBuffers.json.extensionsUsed).toEqual(['KHR_materials_clearcoat']);
+  expect(gltfWithBuffers.json.extensionsRemoved).toEqual(['KHR_texture_transform']);
 });

--- a/modules/gltf/test/lib/extensions/KHR_texture_transform.spec.ts
+++ b/modules/gltf/test/lib/extensions/KHR_texture_transform.spec.ts
@@ -169,3 +169,115 @@ test('GLTFLoader#KHR_texture_transform supports distinct transforms per texture'
   expect(gltfWithBuffers.json.extensionsUsed).toEqual(['KHR_materials_clearcoat']);
   expect(gltfWithBuffers.json.extensionsRemoved).toEqual(['KHR_texture_transform']);
 });
+
+test('GLTFLoader#KHR_texture_transform preserves transforms that cannot be baked atomically', async () => {
+  const baseTexCoords = new Float32Array([0, 0]);
+  const sparseIndices = new Uint8Array([0]);
+  const sparseValues = new Float32Array([1, 1]);
+  const transform = {offset: [0.25, 0.5]};
+  const gltfWithBuffers: GLTFWithBuffers = {
+    json: {
+      asset: {version: '2.0'},
+      extensionsUsed: ['KHR_texture_transform'],
+      buffers: [
+        {byteLength: baseTexCoords.byteLength},
+        {byteLength: sparseIndices.byteLength},
+        {byteLength: sparseValues.byteLength}
+      ],
+      bufferViews: [
+        {buffer: 0, byteLength: baseTexCoords.byteLength},
+        {buffer: 1, byteLength: sparseIndices.byteLength},
+        {buffer: 2, byteLength: sparseValues.byteLength}
+      ],
+      accessors: [
+        {bufferView: 0, componentType: 5126, count: 1, type: 'VEC2'},
+        {
+          componentType: 5126,
+          count: 1,
+          type: 'VEC2',
+          sparse: {
+            count: 1,
+            indices: {bufferView: 1, componentType: 5121},
+            values: {bufferView: 2}
+          }
+        }
+      ],
+      materials: [
+        {
+          pbrMetallicRoughness: {
+            baseColorTexture: {
+              index: 0,
+              extensions: {KHR_texture_transform: transform}
+            }
+          }
+        }
+      ],
+      meshes: [
+        {
+          primitives: [
+            {attributes: {TEXCOORD_0: 0}, material: 0},
+            {attributes: {TEXCOORD_0: 1}, material: 0}
+          ]
+        }
+      ]
+    },
+    buffers: [
+      {arrayBuffer: baseTexCoords.buffer, byteOffset: 0, byteLength: baseTexCoords.byteLength},
+      {arrayBuffer: sparseIndices.buffer, byteOffset: 0, byteLength: sparseIndices.byteLength},
+      {arrayBuffer: sparseValues.buffer, byteOffset: 0, byteLength: sparseValues.byteLength}
+    ]
+  };
+
+  await decodeTextureTransform(gltfWithBuffers, {gltf: {loadBuffers: true}} as GLTFLoaderOptions);
+
+  const texture = gltfWithBuffers.json.materials?.[0].pbrMetallicRoughness?.baseColorTexture;
+  expect(texture?.texCoord).toBeUndefined();
+  expect(texture?.extensions?.KHR_texture_transform).toEqual(transform);
+  expect(gltfWithBuffers.json.meshes?.[0].primitives[0].attributes).toEqual({TEXCOORD_0: 0});
+  expect(gltfWithBuffers.json.meshes?.[0].primitives[1].attributes).toEqual({TEXCOORD_0: 1});
+  expect(gltfWithBuffers.json.accessors).toHaveLength(2);
+  expect(gltfWithBuffers.buffers).toHaveLength(3);
+  expect(gltfWithBuffers.json.extensionsUsed).toEqual(['KHR_texture_transform']);
+});
+
+test('GLTFLoader#KHR_texture_transform ignores texture-shaped application extras', async () => {
+  const texCoords = new Float32Array([0, 0]);
+  const customTextureInfo = {
+    index: 7,
+    extensions: {KHR_texture_transform: {scale: [9, 9]}}
+  };
+  const gltfWithBuffers: GLTFWithBuffers = {
+    json: {
+      asset: {version: '2.0'},
+      extensionsUsed: ['KHR_texture_transform'],
+      buffers: [{byteLength: texCoords.byteLength}],
+      bufferViews: [{buffer: 0, byteLength: texCoords.byteLength}],
+      accessors: [{bufferView: 0, componentType: 5126, count: 1, type: 'VEC2'}],
+      materials: [
+        {
+          extras: {customTextureInfo},
+          pbrMetallicRoughness: {
+            baseColorTexture: {
+              index: 0,
+              extensions: {KHR_texture_transform: {offset: [0.25, 0.5]}}
+            }
+          }
+        }
+      ],
+      meshes: [{primitives: [{attributes: {TEXCOORD_0: 0}, material: 0}]}]
+    },
+    buffers: [{arrayBuffer: texCoords.buffer, byteOffset: 0, byteLength: texCoords.byteLength}]
+  };
+
+  await decodeTextureTransform(gltfWithBuffers, {gltf: {loadBuffers: true}} as GLTFLoaderOptions);
+
+  const material = gltfWithBuffers.json.materials?.[0];
+  expect(material?.extras?.customTextureInfo).toEqual(customTextureInfo);
+  expect(material?.pbrMetallicRoughness?.baseColorTexture?.texCoord).toBe(1);
+  expect(gltfWithBuffers.json.meshes?.[0].primitives[0].attributes).toEqual({
+    TEXCOORD_0: 0,
+    TEXCOORD_1: 1
+  });
+  expect(gltfWithBuffers.json.accessors).toHaveLength(2);
+  expect(gltfWithBuffers.buffers).toHaveLength(2);
+});


### PR DESCRIPTION
## Goals

Support per-texture KHR_texture_transform transforms without overwriting shared UV attributes.

Fixes #2929.

## Changes

- Preserve original texture-coordinate accessors.
- Generate a separate UV attribute for each distinct texture transform.
- Point each texture info at its generated texture-coordinate set.
- Discover transformed textures inside core materials and KHR_materials_* extensions.
- Reuse generated attributes for identical transforms.
- Remove decoded KHR_texture_transform metadata.
- Add Vitest coverage for distinct and shared transforms.

## Verification

- yarn build
- yarn test-node
- yarn test-headless
- yarn test-audit
- yarn lint fix