### PR TITLE
chore: add SPDX headers to math module

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -24,8 +24,8 @@ THE SOFTWARE.
 
 Copyright (c) 2015 Uber Technologies, Inc.
 
-loaders.gl includes certain files from Cesium (https://github.com/AnalyticalGraphicsInc/cesium) 
-under the  Apache 2 License (found in the submodule: modules/3d-tiles):)
+loaders.gl includes certain files from Cesium (https://github.com/CesiumGS/cesium)
+under the Apache 2.0 License, including files in modules/3d-tiles and modules/math.
 
 Copyright 2011-2018 CesiumJS Contributors
 
@@ -38,4 +38,3 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and limitations under the License.
-

--- a/modules/math/src/geometry/attributes/compute-bounding-box.ts
+++ b/modules/math/src/geometry/attributes/compute-bounding-box.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {makeAttributeIterator} from '../iterators/attribute-iterator';
 import {assert} from '../utils/assert';
 

--- a/modules/math/src/geometry/attributes/compute-bounding-sphere.ts
+++ b/modules/math/src/geometry/attributes/compute-bounding-sphere.ts
@@ -1,3 +1,10 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+//
+// Portions adapted from THREE.js (MIT)
+// Copyright (c) 2010-2026 three.js authors
+
 /* eslint-disable */
 /**
 import {getPositions} from './get-attribute-from-geometry';

--- a/modules/math/src/geometry/attributes/compute-tangents.ts
+++ b/modules/math/src/geometry/attributes/compute-tangents.ts
@@ -1,3 +1,10 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+//
+// Portions adapted from THREE.js (MIT)
+// Copyright (c) 2010-2026 three.js authors
+
 /*
 export function computeTangents({indices, positions, normals, uvs}) {
   var index = geometry.index;

--- a/modules/math/src/geometry/attributes/compute-vertex-normals.ts
+++ b/modules/math/src/geometry/attributes/compute-vertex-normals.ts
@@ -1,3 +1,10 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+//
+// Portions adapted from THREE.js (MIT)
+// Copyright (c) 2010-2026 three.js authors
+
 import type {TypedArray} from '@math.gl/core';
 import {Vector3} from '@math.gl/core';
 import {GL} from '../constants';

--- a/modules/math/src/geometry/attributes/convert-to-non-indexed.ts
+++ b/modules/math/src/geometry/attributes/convert-to-non-indexed.ts
@@ -1,3 +1,10 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+//
+// Portions adapted from THREE.js (MIT)
+// Copyright (c) 2010-2026 three.js authors
+
 /* eslint-disable */
 // @ts-nocheck
 /**

--- a/modules/math/src/geometry/attributes/get-attribute-from-geometry.ts
+++ b/modules/math/src/geometry/attributes/get-attribute-from-geometry.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import isGeometry from '../is-geometry';
 import {assert} from '../utils/assert';
 

--- a/modules/math/src/geometry/attributes/normalize.ts
+++ b/modules/math/src/geometry/attributes/normalize.ts
@@ -1,3 +1,10 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+//
+// Portions adapted from THREE.js (MIT)
+// Copyright (c) 2010-2026 three.js authors
+
 /* eslint-disable */
 import {Vector3} from '@math.gl/core';
 

--- a/modules/math/src/geometry/colors/rgb565.ts
+++ b/modules/math/src/geometry/colors/rgb565.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 /**
  * Decode color values
  * @param rgb565

--- a/modules/math/src/geometry/compression/attribute-compression.ts
+++ b/modules/math/src/geometry/compression/attribute-compression.ts
@@ -1,5 +1,9 @@
-// This file is derived from the Cesium code base under Apache 2 license
-// See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
+// loaders.gl
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2011-2018 CesiumJS Contributors
+//
+// This file is derived from the Cesium code base under the Apache 2.0 License.
+// See LICENSE and https://github.com/CesiumGS/cesium/blob/main/LICENSE.md
 
 // Attribute compression and decompression functions.
 

--- a/modules/math/src/geometry/constants.ts
+++ b/modules/math/src/geometry/constants.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // Subset of WebGL constants
 
 export const GL_PRIMITIVE = {

--- a/modules/math/src/geometry/gl/gl-type.ts
+++ b/modules/math/src/geometry/gl/gl-type.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import type {TypedArray} from '@math.gl/core';
 import {GL_TYPE as GL} from '../constants';
 

--- a/modules/math/src/geometry/is-geometry.ts
+++ b/modules/math/src/geometry/is-geometry.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 /**
  * Checking if it is geometry
  * @param geometry

--- a/modules/math/src/geometry/iterators/attribute-iterator.ts
+++ b/modules/math/src/geometry/iterators/attribute-iterator.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 /**
  * Iterates over a single attribute
  * NOTE: For performance, re-yields the same modified element

--- a/modules/math/src/geometry/iterators/primitive-iterator.ts
+++ b/modules/math/src/geometry/iterators/primitive-iterator.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {GL} from '../constants';
 import {getPrimitiveModeType} from '../primitives/modes';
 

--- a/modules/math/src/geometry/primitives/modes.ts
+++ b/modules/math/src/geometry/primitives/modes.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {GL} from '../constants';
 
 /**

--- a/modules/math/src/geometry/typed-arrays/typed-array-utils.ts
+++ b/modules/math/src/geometry/typed-arrays/typed-array-utils.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 /**
  * Concats typed arrays
  * @param arrays

--- a/modules/math/src/geometry/utils/assert.ts
+++ b/modules/math/src/geometry/utils/assert.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 /**
  * Throws error message
  * @param condition checks if an attribute equal to condition

--- a/modules/math/src/geometry/utils/coordinates.ts
+++ b/modules/math/src/geometry/utils/coordinates.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 /**
  * Handle UVs if they are out of range [0,1].
  * @param n

--- a/modules/math/src/index.ts
+++ b/modules/math/src/index.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 export type TypedArrayConstructor =
   | Int8ArrayConstructor
   | Uint8ArrayConstructor

--- a/modules/math/src/utils/assert.ts
+++ b/modules/math/src/utils/assert.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // Replacement for the external assert method to reduce bundle size
 // Note: We don't use the second "message" argument in calling code,
 // so no need to support it here

--- a/modules/math/test/geometry/attributes/compute-vertex-normals.spec.js
+++ b/modules/math/test/geometry/attributes/compute-vertex-normals.spec.js
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import test from 'test/utils/vitest-tape';
 import {Vector3} from '@math.gl/core';
 import {GL, computeVertexNormals} from '@loaders.gl/math';

--- a/modules/math/test/geometry/colors/rgb565.spec.js
+++ b/modules/math/test/geometry/colors/rgb565.spec.js
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import test from 'test/utils/vitest-tape';
 // import {encodeRGB565, decodeRGB565} from '@loaders.gl/math';
 

--- a/modules/math/test/geometry/compression/attribute-compression.spec.js
+++ b/modules/math/test/geometry/compression/attribute-compression.spec.js
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 /* eslint-disable max-statements */
 import {it, expect} from 'test/utils/expect-assertions';
 import {Vector2, Vector3, Vector4, _MathUtils} from '@math.gl/core';

--- a/modules/math/test/index.js
+++ b/modules/math/test/index.js
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // import './geometry/attributes/compute-vertex-normals.spec';
 import './geometry/compression/attribute-compression.spec';
 import './geometry/colors/rgb565.spec';


### PR DESCRIPTION
## Goal

Continue #2830 by completing the SPDX license audit for the Math module, including its third-party-derived geometry code.

## Changes

- add SPDX headers to all 24 previously uncovered JavaScript and TypeScript files under `modules/math/src` and `modules/math/test`
- mark 23 loaders.gl/THREE.js-compatible files as MIT
- retain explicit THREE.js MIT attribution on five adapted geometry files
- mark Cesium-derived `attribute-compression.ts` as Apache-2.0 and retain its CesiumJS copyright notice
- update the root Cesium notice to use the current repository URL and identify `modules/math`
- make no runtime or test-behavior changes

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn build-workers`
- `yarn test-node` — 27 files passed; 189 tests passed, 6 skipped
- `yarn test-headless` — 375 files passed, 2 skipped; 1,947 tests passed, 50 skipped
- SPDX audit across Math JavaScript and TypeScript source/test files