### PR TITLE
feat(sql): add portable predicate parser

### DIFF
--- a/modules/sql/README.md
+++ b/modules/sql/README.md
@@ -1,6 +1,8 @@
 # @loaders.gl/sql
 
 This module contains SQL-oriented `DataSource` implementations for external and embedded databases.
+It also provides a dependency-free parser for turning a small SQL `WHERE` expression into a
+portable predicate AST.
 
 ## Included sources
 
@@ -8,6 +10,17 @@ This module contains SQL-oriented `DataSource` implementations for external and 
 - `SnowflakeSQLSource` for remote Snowflake SQL API access
 
 ## Usage
+
+Install the DuckDB runtime needed by your application in addition to `@loaders.gl/sql`:
+
+```bash
+yarn add @duckdb/node-api
+# or, for browsers
+yarn add @duckdb/duckdb-wasm
+```
+
+Both DuckDB packages are optional peers and are dynamically imported only when a DuckDB source
+connects. Importing the SQL predicate parser does not load or install either runtime.
 
 ```ts
 import {createDataSource} from '@loaders.gl/core';
@@ -25,3 +38,38 @@ const rows = await dataSource.queryRows('SELECT * FROM numbers');
 
 Use `queryArrow()` when the backing adapter supports Arrow-native results, or when you want
 loaders.gl to convert row results into an Arrow table.
+
+## SQL predicate expressions
+
+`parseSQLPredicate()` accepts the expression after `WHERE`, not a complete `SELECT` statement. It
+supports comparisons, `IN`, `IS [NOT] NULL`, `AND`, `OR`, `NOT`, parentheses, scalar literals, and
+named parameters.
+
+```ts
+import {parseSQLPredicate} from '@loaders.gl/sql';
+
+const predicate = parseSQLPredicate(
+  "timestamp >= :start AND status IN ('valid', 'estimated')",
+  {parameters: {start: new Date('2026-01-01T00:00:00Z')}}
+);
+
+for await (const batch of parquetSource.read({
+  columns: ['timestamp', 'value'],
+  predicate
+})) {
+  // SQLPredicate is structurally compatible with the experimental Parquet predicate subset.
+}
+```
+
+The resulting `op`/`args` representation is directionally aligned with CQL2 JSON but does not
+claim CQL2 conformance. `SQL_PREDICATE_JSON_SCHEMA`, `validateSQLPredicate()`, and
+`isSQLPredicate()` support dependency-free payload validation.
+
+Applications already using Zod can opt into the separate subpath without adding Zod to the root
+bundle:
+
+```ts
+import {SQLPredicateSchema} from '@loaders.gl/sql/sql-predicate-zod';
+
+const predicate = SQLPredicateSchema.parse(untrustedPayload);
+```

--- a/modules/sql/package.json
+++ b/modules/sql/package.json
@@ -25,6 +25,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./sql-predicate-zod": {
+      "types": "./dist/sql-predicate-zod.d.ts",
+      "import": "./dist/sql-predicate-zod.js",
+      "require": "./dist/sql-predicate-zod.cjs"
     }
   },
   "sideEffects": false,
@@ -43,14 +48,31 @@
     "build-bundle": "# ocular-bundle ./bundle.ts --external:{util,fs,path}"
   },
   "dependencies": {
-    "@duckdb/duckdb-wasm": "^1.33.1-dev45.0",
-    "@duckdb/node-api": "^1.5.2-r.1",
     "@loaders.gl/loader-utils": "5.0.0-alpha.1",
     "@loaders.gl/schema": "5.0.0-alpha.1",
     "@loaders.gl/schema-utils": "5.0.0-alpha.1",
     "apache-arrow": ">= 17.0.0"
   },
   "peerDependencies": {
-    "@loaders.gl/core": "~5.0.0-alpha.0"
+    "@duckdb/duckdb-wasm": "^1.33.1-dev45.0",
+    "@duckdb/node-api": "^1.5.2-r.1",
+    "@loaders.gl/core": "~5.0.0-alpha.0",
+    "zod": "^4.1.12"
+  },
+  "peerDependenciesMeta": {
+    "@duckdb/duckdb-wasm": {
+      "optional": true
+    },
+    "@duckdb/node-api": {
+      "optional": true
+    },
+    "zod": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@duckdb/duckdb-wasm": "^1.33.1-dev45.0",
+    "@duckdb/node-api": "^1.5.2-r.1",
+    "zod": "^4.1.12"
   }
 }

--- a/modules/sql/src/index.ts
+++ b/modules/sql/src/index.ts
@@ -5,6 +5,24 @@
 export {SQLDataSource, registerSQLAdapter, getSQLAdapterFactory} from './sql-source';
 export {DuckDBSQLSource, DuckDBSQLDataSource} from './duckdb-sql-source';
 export {SnowflakeSQLSource, SnowflakeSQLDataSource} from './snowflake-sql-source';
+export {parseSQLPredicate} from './parse-sql-predicate';
+export {
+  isSQLPredicate,
+  SQL_PREDICATE_JSON_SCHEMA,
+  validateSQLPredicate
+} from './sql-predicate-schema';
+
+export type {
+  SQLComparisonPredicate,
+  SQLInPredicate,
+  SQLLogicalPredicate,
+  SQLNotPredicate,
+  SQLNullPredicate,
+  SQLPredicate,
+  SQLPredicateParserOptions,
+  SQLPredicateProperty,
+  SQLPredicateValue
+} from './sql-predicate-types';
 
 export type {
   SQLAdapter,

--- a/modules/sql/src/parse-sql-predicate.ts
+++ b/modules/sql/src/parse-sql-predicate.ts
@@ -1,0 +1,362 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {
+  SQLLogicalPredicate,
+  SQLPredicate,
+  SQLPredicateParserOptions,
+  SQLPredicateProperty,
+  SQLPredicateValue
+} from './sql-predicate-types';
+import {validateSQLPredicate} from './sql-predicate-schema';
+
+const MAXIMUM_SQL_LENGTH = 65_536;
+const MAXIMUM_SQL_TOKENS = 4096;
+const MAXIMUM_EXPRESSION_DEPTH = 64;
+
+type SQLPredicateToken = Readonly<{
+  kind: 'identifier' | 'number' | 'parameter' | 'string' | 'symbol';
+  value: string;
+}>;
+
+/**
+ * Parses a small SQL `WHERE` expression into a portable CQL2-shaped predicate AST.
+ *
+ * Supported syntax is limited to comparisons, `IN`, `IS [NOT] NULL`, `AND`, `OR`, `NOT`, named
+ * parameters, scalar literals, and parentheses. The input is the expression after `WHERE`, not a
+ * complete `SELECT` statement.
+ */
+export function parseSQLPredicate(
+  source: string,
+  options: SQLPredicateParserOptions = {}
+): SQLPredicate {
+  const parser = new SQLPredicateParser(source, options.parameters ?? {});
+  const predicate = parser.parse();
+  validateSQLPredicate(predicate);
+  return predicate;
+}
+
+/** Dependency-free recursive-descent parser for one SQL predicate expression. */
+class SQLPredicateParser {
+  private readonly tokens: readonly SQLPredicateToken[];
+  private readonly parameters: Readonly<Record<string, SQLPredicateValue>>;
+  private position = 0;
+
+  constructor(source: string, parameters: Readonly<Record<string, SQLPredicateValue>>) {
+    this.tokens = tokenizeSQLPredicate(source);
+    this.parameters = parameters;
+  }
+
+  /** Parses the complete token stream. */
+  parse(): SQLPredicate {
+    const predicate = this.parseOr(0);
+    this.takeSymbol(';');
+    const token = this.peek();
+    if (token) {
+      throw new Error(`SQL predicate contains unexpected token ${JSON.stringify(token.value)}`);
+    }
+    return predicate;
+  }
+
+  /** Parses left-associative disjunction. */
+  private parseOr(depth: number): SQLPredicate {
+    let predicate = this.parseAnd(depth + 1);
+    while (this.takeKeyword('OR')) {
+      predicate = combineLogicalPredicate('or', predicate, this.parseAnd(depth + 1));
+    }
+    return predicate;
+  }
+
+  /** Parses left-associative conjunction. */
+  private parseAnd(depth: number): SQLPredicate {
+    let predicate = this.parseNot(depth + 1);
+    while (this.takeKeyword('AND')) {
+      predicate = combineLogicalPredicate('and', predicate, this.parseNot(depth + 1));
+    }
+    return predicate;
+  }
+
+  /** Parses boolean negation and parenthesized predicates. */
+  private parseNot(depth: number): SQLPredicate {
+    this.assertDepth(depth);
+    if (this.takeKeyword('NOT')) {
+      return {op: 'not', args: [this.parseNot(depth + 1)]};
+    }
+    if (this.takeSymbol('(')) {
+      const predicate = this.parseOr(depth + 1);
+      this.expectSymbol(')');
+      return predicate;
+    }
+    return this.parseLeaf();
+  }
+
+  /** Parses one comparison, membership, or null predicate. */
+  private parseLeaf(): SQLPredicate {
+    const property = this.parseProperty();
+    if (this.takeKeyword('IS')) {
+      const negated = this.takeKeyword('NOT');
+      this.expectKeyword('NULL');
+      const predicate: SQLPredicate = {op: 'isNull', args: [property]};
+      return negated ? {op: 'not', args: [predicate]} : predicate;
+    }
+
+    const negatedMembership = this.takeKeyword('NOT');
+    if (negatedMembership || this.peekKeyword('IN')) {
+      this.expectKeyword('IN');
+      this.expectSymbol('(');
+      if (this.peek()?.kind === 'symbol' && this.peek()?.value === ')') {
+        throw new Error('SQL predicate IN requires at least one scalar value');
+      }
+      const values: SQLPredicateValue[] = [this.parseValue()];
+      while (this.takeSymbol(',')) {
+        values.push(this.parseValue());
+      }
+      this.expectSymbol(')');
+      const predicate: SQLPredicate = {op: 'in', args: [property, values]};
+      return negatedMembership ? {op: 'not', args: [predicate]} : predicate;
+    }
+
+    const token = this.take();
+    if (
+      token?.kind !== 'symbol' ||
+      !['=', '!=', '<>', '<', '<=', '>', '>='].includes(token.value)
+    ) {
+      throw new Error('SQL predicate expected a comparison, IN, or IS NULL operator');
+    }
+    const operator = token.value === '!=' ? '<>' : token.value;
+    return {
+      op: operator as '=' | '<>' | '<' | '<=' | '>' | '>=',
+      args: [property, this.parseValue()]
+    };
+  }
+
+  /** Parses an identifier into a property reference. */
+  private parseProperty(): SQLPredicateProperty {
+    const token = this.take();
+    if (token?.kind !== 'identifier') {
+      throw new Error('SQL predicate expected a column identifier');
+    }
+    return {property: token.value};
+  }
+
+  /** Parses one scalar literal or named parameter. */
+  private parseValue(): SQLPredicateValue {
+    const negative = this.takeSymbol('-');
+    const token = this.take();
+    if (!token) {
+      throw new Error('SQL predicate expected a scalar value');
+    }
+    if (negative && token.kind !== 'number') {
+      throw new Error('SQL predicate only permits unary minus on numeric literals');
+    }
+    if (token.kind === 'number') {
+      return parseNumericLiteral(negative ? `-${token.value}` : token.value);
+    }
+    if (negative) {
+      throw new Error('SQL predicate expected a numeric literal after unary minus');
+    }
+    if (token.kind === 'string') {
+      return token.value;
+    }
+    if (token.kind === 'parameter') {
+      if (!Object.hasOwn(this.parameters, token.value)) {
+        throw new Error(`SQL predicate parameter ":${token.value}" requires a value`);
+      }
+      const value = this.parameters[token.value];
+      validateParameterValue(value, token.value);
+      return value;
+    }
+    if (token.kind === 'identifier' && /^(TRUE|FALSE)$/i.test(token.value)) {
+      return /^TRUE$/i.test(token.value);
+    }
+    if (token.kind === 'identifier' && /^NULL$/i.test(token.value)) {
+      throw new Error('SQL predicate comparisons with NULL must use IS NULL or IS NOT NULL');
+    }
+    throw new Error(`SQL predicate does not support scalar token ${JSON.stringify(token.value)}`);
+  }
+
+  /** Rejects excessively nested inputs before recursion can exhaust the stack. */
+  private assertDepth(depth: number): void {
+    if (depth > MAXIMUM_EXPRESSION_DEPTH) {
+      throw new Error('SQL predicate nesting exceeds its safe limit');
+    }
+  }
+
+  /** Consumes one required keyword. */
+  private expectKeyword(keyword: string): void {
+    if (!this.takeKeyword(keyword)) {
+      throw new Error(`SQL predicate expected ${keyword}`);
+    }
+  }
+
+  /** Returns whether the next token is a keyword without consuming it. */
+  private peekKeyword(keyword: string): boolean {
+    const token = this.peek();
+    return token?.kind === 'identifier' && token.value.toUpperCase() === keyword;
+  }
+
+  /** Consumes one optional keyword. */
+  private takeKeyword(keyword: string): boolean {
+    if (!this.peekKeyword(keyword)) {
+      return false;
+    }
+    this.position++;
+    return true;
+  }
+
+  /** Consumes one required symbol. */
+  private expectSymbol(symbol: string): void {
+    if (!this.takeSymbol(symbol)) {
+      throw new Error(`SQL predicate expected ${JSON.stringify(symbol)}`);
+    }
+  }
+
+  /** Consumes one optional symbol. */
+  private takeSymbol(symbol: string): boolean {
+    const token = this.peek();
+    if (token?.kind !== 'symbol' || token.value !== symbol) {
+      return false;
+    }
+    this.position++;
+    return true;
+  }
+
+  /** Consumes and returns the next token. */
+  private take(): SQLPredicateToken | undefined {
+    const token = this.tokens[this.position];
+    if (token) {
+      this.position++;
+    }
+    return token;
+  }
+
+  /** Returns the next token without consuming it. */
+  private peek(): SQLPredicateToken | undefined {
+    return this.tokens[this.position];
+  }
+}
+
+/** Flattens adjacent equal logical operators into one CQL2-shaped node. */
+function combineLogicalPredicate(
+  operator: 'and' | 'or',
+  left: SQLPredicate,
+  right: SQLPredicate
+): SQLLogicalPredicate {
+  return left.op === operator
+    ? {op: operator, args: [...(left as SQLLogicalPredicate).args, right]}
+    : {op: operator, args: [left, right]};
+}
+
+/** Converts a bounded SQL numeric token to a number or exact bigint. */
+function parseNumericLiteral(source: string): number | bigint {
+  if (/^-?\d+$/.test(source)) {
+    const bigint = BigInt(source);
+    if (bigint > BigInt(Number.MAX_SAFE_INTEGER) || bigint < BigInt(Number.MIN_SAFE_INTEGER)) {
+      return bigint;
+    }
+  }
+  const number = Number(source);
+  if (!Number.isFinite(number)) {
+    throw new Error('SQL predicate numeric literals must be finite');
+  }
+  return number;
+}
+
+/** Validates one named parameter at its parser boundary. */
+function validateParameterValue(value: unknown, name: string): asserts value is SQLPredicateValue {
+  const probe = {op: '=', args: [{property: '_'}, value]} as unknown;
+  try {
+    validateSQLPredicate(probe);
+  } catch {
+    throw new Error(`SQL predicate parameter ":${name}" has an unsupported value`);
+  }
+}
+
+/** Tokenizes a safely bounded SQL predicate expression. */
+function tokenizeSQLPredicate(source: string): SQLPredicateToken[] {
+  if (
+    typeof source !== 'string' ||
+    source.trim().length === 0 ||
+    source.length > MAXIMUM_SQL_LENGTH
+  ) {
+    throw new Error('SQL predicate requires a non-empty, safely bounded expression');
+  }
+
+  const tokens: SQLPredicateToken[] = [];
+  let position = 0;
+  while (position < source.length) {
+    const character = source[position];
+    if (/\s/.test(character)) {
+      position++;
+      continue;
+    }
+    if (character === "'") {
+      const result = readQuotedToken(source, position, "'", "'");
+      tokens.push({kind: 'string', value: result.value});
+      position = result.position;
+    } else if (character === '"') {
+      const result = readQuotedToken(source, position, '"', '"');
+      tokens.push({kind: 'identifier', value: result.value});
+      position = result.position;
+    } else if (character === ':') {
+      const match = /^[A-Za-z_][A-Za-z0-9_]*/.exec(source.slice(position + 1));
+      if (!match) {
+        throw new Error(`SQL predicate contains an invalid parameter at character ${position}`);
+      }
+      tokens.push({kind: 'parameter', value: match[0]});
+      position += match[0].length + 1;
+    } else {
+      const numberMatch = /^(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?/.exec(source.slice(position));
+      const identifierMatch = /^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*/.exec(
+        source.slice(position)
+      );
+      if (numberMatch) {
+        tokens.push({kind: 'number', value: numberMatch[0]});
+        position += numberMatch[0].length;
+      } else if (identifierMatch) {
+        tokens.push({kind: 'identifier', value: identifierMatch[0]});
+        position += identifierMatch[0].length;
+      } else {
+        const twoCharacters = source.slice(position, position + 2);
+        if (['<=', '>=', '<>', '!='].includes(twoCharacters)) {
+          tokens.push({kind: 'symbol', value: twoCharacters});
+          position += 2;
+        } else if ('(),;-=<>'.includes(character)) {
+          tokens.push({kind: 'symbol', value: character});
+          position++;
+        } else {
+          throw new Error(`SQL predicate contains an unsupported token at character ${position}`);
+        }
+      }
+    }
+    if (tokens.length > MAXIMUM_SQL_TOKENS) {
+      throw new Error('SQL predicate exceeds its safe token limit');
+    }
+  }
+  return tokens;
+}
+
+/** Reads one SQL string or quoted identifier with doubled-quote escaping. */
+function readQuotedToken(
+  source: string,
+  start: number,
+  quote: string,
+  escapedQuote: string
+): {value: string; position: number} {
+  let value = '';
+  let position = start + 1;
+  while (position < source.length) {
+    if (source[position] !== quote) {
+      value += source[position++];
+      continue;
+    }
+    if (source[position + 1] === escapedQuote) {
+      value += quote;
+      position += 2;
+      continue;
+    }
+    return {value, position: position + 1};
+  }
+  throw new Error(`SQL predicate contains an unterminated quoted value at character ${start}`);
+}

--- a/modules/sql/src/sql-predicate-schema.ts
+++ b/modules/sql/src/sql-predicate-schema.ts
@@ -1,0 +1,226 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {SQLPredicate, SQLPredicateValue} from './sql-predicate-types';
+
+const MAXIMUM_PREDICATE_DEPTH = 64;
+const MAXIMUM_PREDICATE_NODES = 4096;
+
+/**
+ * JSON Schema for the JSON-serializable portion of the loaders.gl SQL predicate AST.
+ *
+ * In-process predicates additionally accept `bigint`, `Date`, and `Uint8Array` values, which JSON
+ * Schema cannot represent directly.
+ */
+export const SQL_PREDICATE_JSON_SCHEMA = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  $id: 'https://loaders.gl/schemas/sql-predicate.schema.json',
+  title: 'loaders.gl SQL predicate',
+  oneOf: [
+    {$ref: '#/$defs/comparison'},
+    {$ref: '#/$defs/in'},
+    {$ref: '#/$defs/isNull'},
+    {$ref: '#/$defs/logical'},
+    {$ref: '#/$defs/not'}
+  ],
+  $defs: {
+    property: {
+      type: 'object',
+      required: ['property'],
+      properties: {property: {type: 'string', minLength: 1}},
+      additionalProperties: false
+    },
+    value: {type: ['boolean', 'number', 'string']},
+    comparison: {
+      type: 'object',
+      required: ['op', 'args'],
+      properties: {
+        op: {enum: ['=', '<>', '<', '<=', '>', '>=']},
+        args: {
+          type: 'array',
+          prefixItems: [{$ref: '#/$defs/property'}, {$ref: '#/$defs/value'}],
+          minItems: 2,
+          maxItems: 2
+        }
+      },
+      additionalProperties: false
+    },
+    in: {
+      type: 'object',
+      required: ['op', 'args'],
+      properties: {
+        op: {const: 'in'},
+        args: {
+          type: 'array',
+          prefixItems: [
+            {$ref: '#/$defs/property'},
+            {type: 'array', items: {$ref: '#/$defs/value'}, minItems: 1}
+          ],
+          minItems: 2,
+          maxItems: 2
+        }
+      },
+      additionalProperties: false
+    },
+    isNull: {
+      type: 'object',
+      required: ['op', 'args'],
+      properties: {
+        op: {const: 'isNull'},
+        args: {
+          type: 'array',
+          prefixItems: [{$ref: '#/$defs/property'}],
+          minItems: 1,
+          maxItems: 1
+        }
+      },
+      additionalProperties: false
+    },
+    logical: {
+      type: 'object',
+      required: ['op', 'args'],
+      properties: {
+        op: {enum: ['and', 'or']},
+        args: {type: 'array', items: {$ref: '#'}, minItems: 2}
+      },
+      additionalProperties: false
+    },
+    not: {
+      type: 'object',
+      required: ['op', 'args'],
+      properties: {
+        op: {const: 'not'},
+        args: {type: 'array', prefixItems: [{$ref: '#'}], minItems: 1, maxItems: 1}
+      },
+      additionalProperties: false
+    }
+  }
+} as const;
+
+/** Returns whether an unknown value is a valid portable SQL predicate. */
+export function isSQLPredicate(value: unknown): value is SQLPredicate {
+  try {
+    validateSQLPredicate(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Validates an unknown portable SQL predicate or throws a path-specific error. */
+export function validateSQLPredicate(value: unknown): asserts value is SQLPredicate {
+  const state = {nodes: 0};
+  validatePredicateNode(value, '$', 0, state);
+}
+
+/** Validates one recursive predicate node. */
+function validatePredicateNode(
+  value: unknown,
+  path: string,
+  depth: number,
+  state: {nodes: number}
+): asserts value is SQLPredicate {
+  if (depth > MAXIMUM_PREDICATE_DEPTH) {
+    throw new Error(`SQL predicate ${path} exceeds the maximum nesting depth`);
+  }
+  state.nodes++;
+  if (state.nodes > MAXIMUM_PREDICATE_NODES) {
+    throw new Error('SQL predicate exceeds the maximum node count');
+  }
+  if (!isRecord(value) || !hasExactKeys(value, ['op', 'args'])) {
+    throw new Error(`SQL predicate ${path} must contain only op and args`);
+  }
+  if (typeof value.op !== 'string' || !Array.isArray(value.args)) {
+    throw new Error(`SQL predicate ${path} requires string op and array args`);
+  }
+
+  switch (value.op) {
+    case 'and':
+    case 'or':
+      if (value.args.length < 2) {
+        throw new Error(`SQL predicate ${path}.${value.op} requires at least two arguments`);
+      }
+      for (let index = 0; index < value.args.length; index++) {
+        validatePredicateNode(value.args[index], `${path}.args[${index}]`, depth + 1, state);
+      }
+      return;
+    case 'not':
+      if (value.args.length !== 1) {
+        throw new Error(`SQL predicate ${path}.not requires exactly one argument`);
+      }
+      validatePredicateNode(value.args[0], `${path}.args[0]`, depth + 1, state);
+      return;
+    case 'isNull':
+      if (value.args.length !== 1) {
+        throw new Error(`SQL predicate ${path}.isNull requires exactly one argument`);
+      }
+      validatePredicateProperty(value.args[0], `${path}.args[0]`);
+      return;
+    case 'in':
+      if (value.args.length !== 2 || !Array.isArray(value.args[1]) || value.args[1].length === 0) {
+        throw new Error(`SQL predicate ${path}.in requires a property and non-empty value list`);
+      }
+      validatePredicateProperty(value.args[0], `${path}.args[0]`);
+      value.args[1].forEach((item, index) =>
+        validatePredicateValue(item, `${path}.args[1][${index}]`)
+      );
+      return;
+    case '=':
+    case '<>':
+    case '<':
+    case '<=':
+    case '>':
+    case '>=':
+      if (value.args.length !== 2) {
+        throw new Error(`SQL predicate ${path}.${value.op} requires exactly two arguments`);
+      }
+      validatePredicateProperty(value.args[0], `${path}.args[0]`);
+      validatePredicateValue(value.args[1], `${path}.args[1]`);
+      return;
+    default:
+      throw new Error(`SQL predicate ${path} has unsupported operator ${JSON.stringify(value.op)}`);
+  }
+}
+
+/** Validates one property reference. */
+function validatePredicateProperty(value: unknown, path: string): void {
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, ['property']) ||
+    typeof value.property !== 'string' ||
+    value.property.length === 0
+  ) {
+    throw new Error(`SQL predicate ${path} requires a non-empty property reference`);
+  }
+}
+
+/** Validates one structured-cloneable predicate scalar. */
+function validatePredicateValue(value: unknown, path: string): asserts value is SQLPredicateValue {
+  if (
+    typeof value === 'boolean' ||
+    typeof value === 'bigint' ||
+    typeof value === 'string' ||
+    value instanceof Uint8Array
+  ) {
+    return;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return;
+  }
+  if (value instanceof Date && Number.isFinite(value.getTime())) {
+    return;
+  }
+  throw new Error(`SQL predicate ${path} contains an unsupported scalar value`);
+}
+
+/** Returns whether an unknown value is a non-null object. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Returns whether an object contains exactly the expected enumerable keys. */
+function hasExactKeys(value: Record<string, unknown>, expectedKeys: readonly string[]): boolean {
+  const keys = Object.keys(value);
+  return keys.length === expectedKeys.length && expectedKeys.every(key => keys.includes(key));
+}

--- a/modules/sql/src/sql-predicate-types.ts
+++ b/modules/sql/src/sql-predicate-types.ts
@@ -1,0 +1,71 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** Scalar values supported by portable SQL predicate expressions. */
+export type SQLPredicateValue = boolean | number | bigint | string | Date | Uint8Array;
+
+/** Reference to one column in a portable SQL predicate expression. */
+export type SQLPredicateProperty = Readonly<{
+  /** Column or qualified column name. */
+  property: string;
+}>;
+
+/** Binary comparison between a column and a scalar value. */
+export type SQLComparisonPredicate = Readonly<{
+  /** CQL2-shaped comparison operator. */
+  op: '=' | '<>' | '<' | '<=' | '>' | '>=';
+  /** Column reference followed by the scalar value to compare. */
+  args: readonly [SQLPredicateProperty, SQLPredicateValue];
+}>;
+
+/** Membership test between a column and scalar values. */
+export type SQLInPredicate = Readonly<{
+  /** CQL2-shaped membership operator. */
+  op: 'in';
+  /** Column reference followed by a non-empty list of candidate values. */
+  args: readonly [SQLPredicateProperty, readonly SQLPredicateValue[]];
+}>;
+
+/** Null test for one column. */
+export type SQLNullPredicate = Readonly<{
+  /** CQL2-shaped null-test operator. */
+  op: 'isNull';
+  /** Column reference to test. */
+  args: readonly [SQLPredicateProperty];
+}>;
+
+/** Conjunction or disjunction of two or more predicates. */
+export type SQLLogicalPredicate = Readonly<{
+  /** CQL2-shaped logical operator. */
+  op: 'and' | 'or';
+  /** Two or more child predicates. */
+  args: readonly SQLPredicate[];
+}>;
+
+/** Negation of one predicate. */
+export type SQLNotPredicate = Readonly<{
+  /** CQL2-shaped negation operator. */
+  op: 'not';
+  /** Single child predicate. */
+  args: readonly [SQLPredicate];
+}>;
+
+/**
+ * Portable predicate AST emitted by the loaders.gl SQL expression parser.
+ *
+ * The expression shape is directionally aligned with CQL2 JSON, but this deliberately small
+ * subset does not claim CQL2 conformance.
+ */
+export type SQLPredicate =
+  | SQLComparisonPredicate
+  | SQLInPredicate
+  | SQLNullPredicate
+  | SQLLogicalPredicate
+  | SQLNotPredicate;
+
+/** Options for parsing one SQL predicate expression. */
+export type SQLPredicateParserOptions = Readonly<{
+  /** Named values referenced using SQL parameters such as `:minimumFare`. */
+  parameters?: Readonly<Record<string, SQLPredicateValue>>;
+}>;

--- a/modules/sql/src/sql-predicate-zod.ts
+++ b/modules/sql/src/sql-predicate-zod.ts
@@ -1,0 +1,49 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {z} from 'zod';
+
+import type {SQLPredicate, SQLPredicateValue} from './sql-predicate-types';
+
+/** Zod schema for scalar values accepted by in-process SQL predicates. */
+export const SQLPredicateValueSchema: z.ZodType<SQLPredicateValue> = z.union([
+  z.boolean(),
+  z.number().finite(),
+  z.bigint(),
+  z.string(),
+  z.date(),
+  z.instanceof(Uint8Array)
+]);
+
+const SQLPredicatePropertySchema = z.object({property: z.string().min(1)}).strict();
+
+/**
+ * Optional Zod schema for validating the portable loaders.gl SQL predicate AST.
+ *
+ * Import from `@loaders.gl/sql/sql-predicate-zod`; the package root does not load Zod.
+ */
+export const SQLPredicateSchema: z.ZodType<SQLPredicate> = z.lazy(() =>
+  z.union([
+    z
+      .object({
+        op: z.enum(['=', '<>', '<', '<=', '>', '>=']),
+        args: z.tuple([SQLPredicatePropertySchema, SQLPredicateValueSchema])
+      })
+      .strict(),
+    z
+      .object({
+        op: z.literal('in'),
+        args: z.tuple([SQLPredicatePropertySchema, z.array(SQLPredicateValueSchema).min(1)])
+      })
+      .strict(),
+    z.object({op: z.literal('isNull'), args: z.tuple([SQLPredicatePropertySchema])}).strict(),
+    z
+      .object({
+        op: z.enum(['and', 'or']),
+        args: z.array(SQLPredicateSchema).min(2)
+      })
+      .strict(),
+    z.object({op: z.literal('not'), args: z.tuple([SQLPredicateSchema])}).strict()
+  ])
+);

--- a/modules/sql/test/sql-predicate.spec.ts
+++ b/modules/sql/test/sql-predicate.spec.ts
@@ -1,0 +1,107 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+
+import {
+  isSQLPredicate,
+  parseSQLPredicate,
+  SQL_PREDICATE_JSON_SCHEMA,
+  validateSQLPredicate
+} from '@loaders.gl/sql';
+import {SQLPredicateSchema} from '@loaders.gl/sql/sql-predicate-zod';
+
+test('parseSQLPredicate emits a CQL2-shaped AST with SQL precedence', () => {
+  expect(
+    parseSQLPredicate("status = 'valid' OR category IN ('a', 'b') AND value >= :minimum", {
+      parameters: {minimum: 10}
+    })
+  ).toEqual({
+    op: 'or',
+    args: [
+      {op: '=', args: [{property: 'status'}, 'valid']},
+      {
+        op: 'and',
+        args: [
+          {op: 'in', args: [{property: 'category'}, ['a', 'b']]},
+          {op: '>=', args: [{property: 'value'}, 10]}
+        ]
+      }
+    ]
+  });
+});
+
+test('parseSQLPredicate normalizes null, inequality, negation, identifiers, and exact integers', () => {
+  expect(
+    parseSQLPredicate(
+      '"source id" IS NOT NULL AND NOT (count != -9223372036854775808 OR active = FALSE)'
+    )
+  ).toEqual({
+    op: 'and',
+    args: [
+      {op: 'not', args: [{op: 'isNull', args: [{property: 'source id'}]}]},
+      {
+        op: 'not',
+        args: [
+          {
+            op: 'or',
+            args: [
+              {op: '<>', args: [{property: 'count'}, -9223372036854775808n]},
+              {op: '=', args: [{property: 'active'}, false]}
+            ]
+          }
+        ]
+      }
+    ]
+  });
+});
+
+test('parseSQLPredicate preserves escaped strings and structured-cloneable parameters', () => {
+  const timestamp = new Date('2026-08-20T00:00:00Z');
+  const binary = new Uint8Array([1, 2, 3]);
+  expect(
+    parseSQLPredicate("name = 'O''Brien' AND timestamp >= :timestamp AND payload = :binary;", {
+      parameters: {timestamp, binary}
+    })
+  ).toEqual({
+    op: 'and',
+    args: [
+      {op: '=', args: [{property: 'name'}, "O'Brien"]},
+      {op: '>=', args: [{property: 'timestamp'}, timestamp]},
+      {op: '=', args: [{property: 'payload'}, binary]}
+    ]
+  });
+});
+
+test('SQL predicate validators accept supported ASTs and reject malformed payloads', () => {
+  const predicate = {op: '=', args: [{property: 'value'}, 4]} as const;
+  expect(isSQLPredicate(predicate)).toBe(true);
+  expect(() => validateSQLPredicate(predicate)).not.toThrow();
+  expect(SQLPredicateSchema.parse(predicate)).toEqual(predicate);
+
+  expect(isSQLPredicate({op: 'and', args: [predicate]})).toBe(false);
+  expect(isSQLPredicate({op: 'in', args: [{property: 'value'}, []]})).toBe(false);
+  expect(isSQLPredicate({op: '=', args: [{property: 'value'}, Number.NaN]})).toBe(false);
+  expect(isSQLPredicate({op: '=', args: [{property: 'value'}, 1], extra: true})).toBe(false);
+  expect(() => SQLPredicateSchema.parse({op: 'not', args: []})).toThrow();
+});
+
+test('SQL predicate JSON Schema describes the dependency-free JSON payload subset', () => {
+  expect(SQL_PREDICATE_JSON_SCHEMA.$schema).toBe('https://json-schema.org/draft/2020-12/schema');
+  expect(SQL_PREDICATE_JSON_SCHEMA.$defs.logical.properties.args.minItems).toBe(2);
+  expect(SQL_PREDICATE_JSON_SCHEMA.$defs.value.type).toEqual(['boolean', 'number', 'string']);
+});
+
+test.each([
+  ['', /non-empty/],
+  ['WHERE value = 1', /expected a comparison/],
+  ['value = NULL', /must use IS NULL/],
+  ['value IN ()', /requires at least one scalar value/],
+  ['value = :missing', /requires a value/],
+  ["value = 'unterminated", /unterminated/],
+  ['value LIKE 1', /expected a comparison/],
+  ['value = 1 trailing', /unexpected token/]
+])('parseSQLPredicate rejects unsupported input %o', (source, expectedError) => {
+  expect(() => parseSQLPredicate(source)).toThrow(expectedError);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5825,8 +5825,19 @@ __metadata:
     "@loaders.gl/schema": "npm:5.0.0-alpha.1"
     "@loaders.gl/schema-utils": "npm:5.0.0-alpha.1"
     apache-arrow: "npm:>= 17.0.0"
+    zod: "npm:^4.1.12"
   peerDependencies:
+    "@duckdb/duckdb-wasm": ^1.33.1-dev45.0
+    "@duckdb/node-api": ^1.5.2-r.1
     "@loaders.gl/core": ~5.0.0-alpha.0
+    zod: ^4.1.12
+  peerDependenciesMeta:
+    "@duckdb/duckdb-wasm":
+      optional: true
+    "@duckdb/node-api":
+      optional: true
+    zod:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Goals

- Give loaders.gl a small, reusable SQL `WHERE` expression parser for data-source predicates.
- Keep the predicate representation directionally aligned with CQL2 JSON without claiming conformance.
- Keep parser-only `@loaders.gl/sql` usage independent of DuckDB and Zod runtime costs.

## Changes

- Adds `parseSQLPredicate()` for comparisons, `IN`, `IS [NOT] NULL`, `AND`, `OR`, `NOT`, parentheses, scalar literals, quoted identifiers, and named parameters.
- Adds public predicate AST types with exact `bigint`, `Date`, and `Uint8Array` values for in-process use.
- Adds a dependency-free runtime validator and a Draft 2020-12 JSON Schema for JSON payloads.
- Adds an optional `@loaders.gl/sql/sql-predicate-zod` subpath.
- Moves DuckDB runtimes from mandatory dependencies to optional peers; the existing sources continue to load them through dynamic imports.
- Documents the parser and its intended structural handoff to data sources such as `ParquetSource`.

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn build-workers`
- `yarn test-node` — 189 passed, 6 skipped on the final master rebase
- `yarn test-headless` — 1,975 passed, 50 skipped before the clean master rebase
- `yarn test-headless modules/sql/test/sql-predicate.spec.ts` — 13 passed after the final master rebase
- `yarn test-audit` — 0 violations
