### PR TITLE
chore: add SPDX headers to images module

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -24,6 +24,12 @@ THE SOFTWARE.
 
 Copyright (c) 2015 Uber Technologies, Inc.
 
+Portions of modules/images/src/lib/category-api/binary-image-api.ts are based on
+binary-gltf-utils (https://github.com/Qantas94Heavy/binary-gltf-utils) under the
+MIT License reproduced above.
+
+Copyright (c) 2016-17 Karl Cheng
+
 loaders.gl includes certain files from Cesium (https://github.com/CesiumGS/cesium)
 under the Apache 2.0 License, including files in modules/3d-tiles and modules/math.
 

--- a/modules/images/bundle.ts
+++ b/modules/images/bundle.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // Re-export core API so they don't get overwritten
 export * from '@loaders.gl/core';
 export * from '@loaders.gl/images';

--- a/modules/images/src/image-bitmap-loader-with-parser.ts
+++ b/modules/images/src/image-bitmap-loader-with-parser.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import type {LoaderWithParser} from '@loaders.gl/loader-utils';
 import {parseImageBitmap, parseImageBitmapBlob} from './lib/parsers/parse-image-bitmap';
 import {

--- a/modules/images/src/image-bitmap-loader.ts
+++ b/modules/images/src/image-bitmap-loader.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import type {Loader, StrictLoaderOptions} from '@loaders.gl/loader-utils';
 import {VERSION} from './lib/utils/version';
 import {ImageBitmapFormat} from './image-format';

--- a/modules/images/src/image-loader-with-parser.ts
+++ b/modules/images/src/image-loader-with-parser.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import type {LoaderWithParser} from '@loaders.gl/loader-utils';
 import type {ImageType} from './types';
 import {parseImage} from './lib/parsers/parse-image';

--- a/modules/images/src/image-loader.ts
+++ b/modules/images/src/image-loader.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import type {Loader, StrictLoaderOptions} from '@loaders.gl/loader-utils';
 import type {ImageType} from './types';
 import {VERSION} from './lib/utils/version';

--- a/modules/images/src/index.ts
+++ b/modules/images/src/index.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // TYPES
 export type {ImageDataType, ImageType, ImageTypeEnum} from './types';
 export type {ImageLoaderOptions} from './image-loader';

--- a/modules/images/src/lib/category-api/binary-image-api.ts
+++ b/modules/images/src/lib/category-api/binary-image-api.ts
@@ -1,5 +1,9 @@
-// Attributions
-// * Based on binary-gltf-utils under MIT license: Copyright (c) 2016-17 Karl Cheng
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+//
+// Based on binary-gltf-utils under the MIT License
+// Copyright (c) 2016-17 Karl Cheng
 
 import {getISOBMFFMediaType} from './parse-isobmff-binary';
 

--- a/modules/images/src/lib/category-api/image-type.ts
+++ b/modules/images/src/lib/category-api/image-type.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {isBrowser} from '@loaders.gl/loader-utils';
 import type {ImageTypeEnum} from '../../types';
 

--- a/modules/images/src/lib/category-api/parsed-image-api.ts
+++ b/modules/images/src/lib/category-api/parsed-image-api.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import type {ImageType, ImageTypeEnum, ImageDataType} from '../../types';
 
 type GetImageBitmapDataNode = (image: unknown) => ImageDataType | ImageData;

--- a/modules/images/src/lib/encoders/encode-image.ts
+++ b/modules/images/src/lib/encoders/encode-image.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // Image loading/saving for browser and Node.js
 import {ImageDataType} from '../../types';
 import {getImageSize} from '../category-api/parsed-image-api';

--- a/modules/images/src/lib/parsers/parse-image-bitmap.ts
+++ b/modules/images/src/lib/parsers/parse-image-bitmap.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import type {LoaderContext} from '@loaders.gl/loader-utils';
 import {isBrowser} from '@loaders.gl/loader-utils';
 import type {ImageBitmapLoaderOptions} from '../../image-bitmap-loader';

--- a/modules/images/src/lib/parsers/parse-image.ts
+++ b/modules/images/src/lib/parsers/parse-image.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import type {LoaderContext} from '@loaders.gl/loader-utils';
 import {assert, isBrowser} from '@loaders.gl/loader-utils';
 import type {ImageType} from '../../types';

--- a/modules/images/src/lib/parsers/parse-to-image-bitmap.ts
+++ b/modules/images/src/lib/parsers/parse-to-image-bitmap.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {isSVG, getBlob} from './svg-utils';
 import {parseToImage} from './parse-to-image';
 

--- a/modules/images/src/lib/parsers/parse-to-image.ts
+++ b/modules/images/src/lib/parsers/parse-to-image.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 type HTMLImageLoadOptions = {
   image?: {
     decode?: boolean;

--- a/modules/images/src/lib/parsers/parse-to-node-image.ts
+++ b/modules/images/src/lib/parsers/parse-to-node-image.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import type {ImageDataType} from '../../types';
 import {assert} from '@loaders.gl/loader-utils';
 import {getBinaryImageMetadata} from '../category-api/binary-image-api';

--- a/modules/images/src/lib/parsers/svg-utils.ts
+++ b/modules/images/src/lib/parsers/svg-utils.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // SVG parsing has limitations, e.g:
 // https://bugs.chromium.org/p/chromium/issues/detail?id=606319
 

--- a/modules/images/src/lib/utils/version.ts
+++ b/modules/images/src/lib/utils/version.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // Version constant cannot be imported, it needs to correspond to the build version of **this** module.
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.

--- a/modules/images/src/types.ts
+++ b/modules/images/src/types.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 /**
  * data images
  */

--- a/modules/images/test/image-loader.spec.ts
+++ b/modules/images/test/image-loader.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {expect, test} from 'vitest';
 
 import {ImageLoader, ImageBitmapLoader, getImageType, getImageData} from '@loaders.gl/images';

--- a/modules/images/test/image-writer.spec.ts
+++ b/modules/images/test/image-writer.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {expect, test} from 'vitest';
 import {encode, parse} from '@loaders.gl/core';
 import {

--- a/modules/images/test/images.bench.ts
+++ b/modules/images/test/images.bench.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {ImageBitmapLoader, isImageTypeSupported} from '@loaders.gl/images';
 import {fetchFile, parse} from '@loaders.gl/core';
 

--- a/modules/images/test/index.ts
+++ b/modules/images/test/index.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import './lib/category-api/image-format.spec';
 import './lib/category-api/binary-image-api.spec';
 import './lib/category-api/parsed-image-api.spec';

--- a/modules/images/test/lib/category-api/binary-image-api.spec.ts
+++ b/modules/images/test/lib/category-api/binary-image-api.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {expect, test} from 'vitest';
 import {fetchFile} from '@loaders.gl/core';
 import {getBinaryImageMetadata} from '@loaders.gl/images';

--- a/modules/images/test/lib/category-api/image-format.spec.ts
+++ b/modules/images/test/lib/category-api/image-format.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {expect, test} from 'vitest';
 import {isBrowser} from '@loaders.gl/loader-utils';
 import {isImageFormatSupported, getSupportedImageFormats} from '@loaders.gl/images';

--- a/modules/images/test/lib/category-api/parsed-image-api.spec.ts
+++ b/modules/images/test/lib/category-api/parsed-image-api.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {expect, test} from 'vitest';
 import {load} from '@loaders.gl/core';
 import {

--- a/modules/images/test/lib/test-cases.ts
+++ b/modules/images/test/lib/test-cases.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {isBrowser} from '@loaders.gl/core';
 
 const CONTENT_BASE = '@loaders.gl/images/test/data';


### PR DESCRIPTION
## Goal

Continue #2830 by completing the SPDX license audit for the Images module, including its third-party-derived image metadata code.

## Changes

- add MIT SPDX headers to all 26 previously uncovered tracked TypeScript files in `modules/images`, including the bundle entry, source, tests, and benchmarks
- retain the `binary-gltf-utils` MIT attribution and Karl Cheng copyright notice in `binary-image-api.ts`
- add the corresponding `binary-gltf-utils` notice to the root `LICENSE`
- make no runtime or test-behavior changes

## Validation

- `yarn install`
- `yarn lint fix`
- `yarn build`
- `yarn build-workers`
- `yarn test-node` — 27 files passed; 189 tests passed, 6 skipped
- `yarn test-headless` — 375 files passed, 2 skipped; 1,950 tests passed, 50 skipped
- tracked-file SPDX audit across the complete Images module