### PR TITLE
chore: add SPDX headers to GIS, Schema Utils, and Video

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -30,6 +30,12 @@ MIT License reproduced above.
 
 Copyright (c) 2016-17 Karl Cheng
 
+Portions of modules/schema-utils/src/lib/utils/async-queue.ts are adapted from
+async-iter-demo (https://github.com/rauschma/async-iter-demo) under the MIT
+License reproduced above.
+
+Copyright (c) 2016 Axel Rauschmayer
+
 loaders.gl includes certain files from Cesium (https://github.com/CesiumGS/cesium)
 under the Apache 2.0 License, including files in modules/3d-tiles and modules/math.
 

--- a/modules/gis/src/index.ts
+++ b/modules/gis/src/index.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // Types from `@loaders.gl/schema`
 export type {Geometry as GeoJSONGeometry} from '@loaders.gl/schema';
 export {GIS_CONVERTERS} from './converters';

--- a/modules/gis/src/lib/binary-geometry-api/transform-coordinates.ts
+++ b/modules/gis/src/lib/binary-geometry-api/transform-coordinates.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import type {BinaryFeatureCollection, BinaryGeometry, Feature} from '@loaders.gl/schema';
 
 type TransformCoordinate = (coord: number[]) => number[];

--- a/modules/gis/test/binary-features/binary-to-geojson.spec.ts
+++ b/modules/gis/test/binary-features/binary-to-geojson.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 /* eslint-disable max-depth */
 import test from 'test/utils/vitest-tape';
 import type {BinaryFeatureCollection, FeatureCollection} from '@loaders.gl/schema';

--- a/modules/gis/test/binary-features/geojson-to-binary.spec.ts
+++ b/modules/gis/test/binary-features/geojson-to-binary.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 /* eslint-disable max-statements */
 // @ts-nocheck
 import test from 'test/utils/vitest-tape';

--- a/modules/gis/test/binary-features/geojson-to-flat-geojson.spec.ts
+++ b/modules/gis/test/binary-features/geojson-to-flat-geojson.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // @ts-nocheck
 import test from 'test/utils/vitest-tape';
 import {fetchFile} from '@loaders.gl/core';

--- a/modules/gis/test/binary-features/gis.bench.ts
+++ b/modules/gis/test/binary-features/gis.bench.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {JSONLoader} from '@loaders.gl/json';
 import {load} from '@loaders.gl/core';
 import {earcut} from '@math.gl/polygon';

--- a/modules/gis/test/binary-features/transform.spec.ts
+++ b/modules/gis/test/binary-features/transform.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import test from 'test/utils/vitest-tape';
 import {BinaryFeatureCollection, Feature} from '@loaders.gl/schema';
 import {transformBinaryCoords, transformGeoJsonCoords} from '@loaders.gl/gis';

--- a/modules/gis/test/data/binary-features/empty_binary.ts
+++ b/modules/gis/test/data/binary-features/empty_binary.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {BinaryFeatureCollection} from '@loaders.gl/schema';
 
 export const EMPTY_BINARY_DATA: BinaryFeatureCollection = {

--- a/modules/schema-utils/bundle.ts
+++ b/modules/schema-utils/bundle.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // Re-export core API so they don't get overwritten
 export * from '@loaders.gl/core';
 export * from '@loaders.gl/schema-utils';

--- a/modules/schema-utils/src/lib/mesh/mesh-utils.ts
+++ b/modules/schema-utils/src/lib/mesh/mesh-utils.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // Mesh category utilities
 // TODO - move to mesh category module, or to math.gl/geometry module
 import {MeshAttributes} from '@loaders.gl/schema';

--- a/modules/schema-utils/src/lib/utils/assert.ts
+++ b/modules/schema-utils/src/lib/utils/assert.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // Replacement for the external assert method to reduce bundle size
 // Note: We don't use the second "message" argument in calling code,
 // so no need to support it here

--- a/modules/schema-utils/src/lib/utils/async-queue.ts
+++ b/modules/schema-utils/src/lib/utils/async-queue.ts
@@ -1,5 +1,10 @@
-// From https://github.com/rauschma/async-iter-demo/tree/master/src under MIT license
-// http://2ality.com/2016/10/asynchronous-iteration.html
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+//
+// Adapted from async-iter-demo under the MIT License
+// Copyright (c) 2016 Axel Rauschmayer
+// https://github.com/rauschma/async-iter-demo
 
 class ArrayQueue<T> extends Array<T> {
   enqueue(value: T) {

--- a/modules/video/bundle.ts
+++ b/modules/video/bundle.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // Re-export core API so they don't get overwritten
 export * from '@loaders.gl/core';
 export * from '@loaders.gl/video';

--- a/modules/video/test-included/parse-video.spec.js
+++ b/modules/video/test-included/parse-video.spec.js
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import test, {testIfBrowser} from 'test/utils/vitest-tape';
 
 import parseVideo, {parseVideoBlob} from '../src/lib/parsers/parse-video';


### PR DESCRIPTION
## Goal

Continue #2830 by completing the SPDX license audit for the remaining uncovered files in the GIS, Schema Utils, and Video modules, while verifying that reused code is permissively licensed.

## Changes

- add MIT SPDX headers to all 14 previously uncovered tracked JavaScript and TypeScript files across `modules/gis`, `modules/schema-utils`, and `modules/video`
- verify that `async-queue.ts` is adapted from [async-iter-demo](https://github.com/rauschma/async-iter-demo/blob/master/LICENSE), which uses the permissive, [OSI-approved MIT License](https://opensource.org/license/mit)
- retain Axel Rauschmayer's copyright beside the adapted implementation
- add the corresponding `async-iter-demo` notice to the root `LICENSE`
- make no runtime or test-behavior changes

## Validation

- `yarn install`
- `yarn lint fix`
- `yarn build`
- `yarn build-workers`
- `yarn test-node` — 28 files passed; 190 tests passed, 6 skipped
- `yarn test-headless` — 376 files passed, 2 skipped; 1,965 tests passed, 50 skipped
- tracked-file SPDX audits across GIS, Schema Utils, and Video