### PR TITLE
feat(gltf): backport portable primitive topologies to 4.4

### DIFF
--- a/docs/modules/gltf/api-reference/post-process-gltf.md
+++ b/docs/modules/gltf/api-reference/post-process-gltf.md
@@ -45,6 +45,8 @@ The GLTF post processor copies objects in the input gltf json field as necessary
 - The `GLTFPostprocessed` type has less optional fields. Many optional `GLTF` fields will be required and populated with empty arrays etc as appropriate.
 - "Resolves" references to GLTF objects. glTF objects reference other object with integer indexes. Such indexes will be replaced with object references, simplifying iteration over the scenegraph.
 - Generates required `id` fields for all objects.
+- Expands `LINE_LOOP` and `TRIANGLE_FAN` primitives into portable indexed `LINES` and `TRIANGLES`
+  without changing the loaded source JSON or buffers.
 
 ## Post Processing of glTF Extensions
 
@@ -76,6 +78,15 @@ Background: The GLTF file format describes a tree structure, however it links no
 ### Adds `id` to every node
 
 The postprocessor makes sure each node and an `id` value, unless already present.
+
+### Normalizes WebGL-only primitive topologies
+
+WebGPU does not support the glTF `LINE_LOOP` and `TRIANGLE_FAN` primitive modes.
+`postProcessGLTF` expands those modes into indexed `LINES` and `TRIANGLES`, respectively. Indexed
+and non-indexed source primitives are both supported, winding is preserved, and generated indices
+use `Uint16Array` or `Uint32Array` according to the largest referenced vertex. The original glTF
+primitive, accessor, and buffer data remain unchanged. Bufferless index accessors are materialized
+from their implicit-zero base and optional sparse substitutions before topology expansion.
 
 ## Node Specific Post Processing
 

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -131,6 +131,7 @@ A minor release that includes:
 **@loaders.gl/gltf**
 
 - `GLTFLoader`: Support models with more complex use of `KHR_texture_transform` extension.
+- [`postProcessGLTF()`](/docs/modules/gltf/api-reference/post-process-gltf) expands WebGL-only `LINE_LOOP` and `TRIANGLE_FAN` primitives into portable indexed `LINES` and `TRIANGLES` without mutating the loaded source data.
 
 **@loaders.gl/las**
 

--- a/modules/gltf/src/index.ts
+++ b/modules/gltf/src/index.ts
@@ -21,6 +21,7 @@ export type {
   GLTF_KHR_binary_glTF,
   GLTF_KHR_draco_mesh_compression,
   GLTF_KHR_texture_basisu,
+  GLTF_KHR_meshopt_compression,
   GLTF_EXT_meshopt_compression,
   GLTF_EXT_texture_webp
 } from './lib/types/gltf-json-schema';

--- a/modules/gltf/src/lib/api/post-process-gltf.ts
+++ b/modules/gltf/src/lib/api/post-process-gltf.ts
@@ -40,6 +40,7 @@ import type {
 import {assert} from '../utils/assert';
 import {getAccessorArrayTypeAndLength} from '../gltf-utils/gltf-utils';
 import {copyToArrayBuffer} from '@loaders.gl/loader-utils';
+import type {BigTypedArray, BigTypedArrayConstructor} from '@loaders.gl/loader-utils';
 
 // This is a post processor for loaded glTF files
 // The goal is to make the loaded data easier to use in WebGL applications
@@ -323,7 +324,7 @@ class GLTFPostProcessor {
       primitives: []
     };
     if (gltfMesh.primitives) {
-      mesh.primitives = gltfMesh.primitives.map((gltfPrimitive) => {
+      mesh.primitives = gltfMesh.primitives.map((gltfPrimitive, primitiveIndex) => {
         const primitive: GLTFMeshPrimitivePostprocessed = {
           ...gltfPrimitive,
           attributes: {},
@@ -340,7 +341,7 @@ class GLTFPostProcessor {
         if (gltfPrimitive.material !== undefined) {
           primitive.material = this.getMaterial(gltfPrimitive.material);
         }
-        return primitive;
+        return normalizePrimitiveTopology(primitive, mesh.id, primitiveIndex);
       });
     }
     return mesh;
@@ -425,9 +426,70 @@ class GLTFPostProcessor {
         );
       }
       accessor.value = new ArrayType(cutBuffer);
+    } else {
+      const {ArrayType} = getAccessorArrayTypeAndLength(accessor, {
+        byteLength: accessor.count * accessor.bytesPerElement
+      });
+      accessor.value = new ArrayType(accessor.count * accessor.components);
+    }
+
+    if (gltfAccessor.sparse) {
+      this._applySparseAccessor(accessor, gltfAccessor.sparse);
     }
 
     return accessor;
+  }
+
+  /** Applies sparse accessor replacements to an accessor's materialized values. */
+  _applySparseAccessor(
+    accessor: GLTFAccessorPostprocessed,
+    sparse: NonNullable<GLTFAccessor['sparse']>
+  ): void {
+    const SparseIndexArray = getSparseIndexArrayType(sparse.indices.componentType);
+    const sparseIndices = this._getTypedArrayFromBufferView(
+      SparseIndexArray,
+      this.getBufferView(sparse.indices.bufferView),
+      sparse.indices.byteOffset || 0,
+      sparse.count
+    );
+    const SparseValueArray = accessor.value.constructor as BigTypedArrayConstructor;
+    const sparseValues = this._getTypedArrayFromBufferView(
+      SparseValueArray,
+      this.getBufferView(sparse.values.bufferView),
+      sparse.values.byteOffset || 0,
+      sparse.count * accessor.components
+    );
+
+    for (let sparseValueIndex = 0; sparseValueIndex < sparse.count; sparseValueIndex++) {
+      const accessorIndex = Number(sparseIndices[sparseValueIndex]);
+      assert(
+        Number.isInteger(accessorIndex) && accessorIndex >= 0 && accessorIndex < accessor.count,
+        'glTF sparse accessor index is out of bounds'
+      );
+      for (let componentIndex = 0; componentIndex < accessor.components; componentIndex++) {
+        const targetIndex = accessorIndex * accessor.components + componentIndex;
+        const sourceIndex = sparseValueIndex * accessor.components + componentIndex;
+        Reflect.set(accessor.value, targetIndex, sparseValues[sourceIndex]);
+      }
+    }
+  }
+
+  /** Creates a typed array from a byte range within a resolved buffer view. */
+  _getTypedArrayFromBufferView(
+    ArrayType: BigTypedArrayConstructor,
+    bufferView: GLTFBufferViewPostprocessed,
+    byteOffset: number,
+    length: number
+  ): BigTypedArray {
+    const byteLength = length * ArrayType.BYTES_PER_ELEMENT;
+    assert(
+      byteOffset + byteLength <= bufferView.byteLength,
+      'glTF sparse accessor data exceeds its buffer view'
+    );
+    const buffer = bufferView.buffer;
+    const absoluteByteOffset = buffer.byteOffset + (bufferView.byteOffset || 0) + byteOffset;
+    const arrayBuffer = copyToArrayBuffer(buffer.arrayBuffer, absoluteByteOffset, byteLength);
+    return new ArrayType(arrayBuffer);
   }
 
   /**
@@ -549,6 +611,144 @@ class GLTFPostProcessor {
     }
     return camera;
   }
+}
+
+/**
+ * Expands WebGL-only primitive topologies into portable indexed topologies.
+ *
+ * WebGPU does not support `LINE_LOOP` or `TRIANGLE_FAN`. The returned primitive uses a generated
+ * index accessor and leaves the source glTF primitive, accessor, and buffer data unchanged.
+ *
+ * @param primitive Resolved glTF primitive.
+ * @param meshId Identifier of the primitive's containing mesh.
+ * @param primitiveIndex Position of the primitive in its containing mesh.
+ * @returns The resolved primitive, normalized when it uses a WebGL-only topology.
+ * @throws If an indexed primitive is postprocessed without its index buffer data.
+ */
+function normalizePrimitiveTopology(
+  primitive: GLTFMeshPrimitivePostprocessed,
+  meshId: string,
+  primitiveIndex: number
+): GLTFMeshPrimitivePostprocessed {
+  if (primitive.mode !== 2 && primitive.mode !== 6) {
+    return primitive;
+  }
+
+  const sourceIndices = primitive.indices?.value;
+  const sourceIndexCount = primitive.indices?.count ?? getPrimitiveVertexCount(primitive);
+  const maximumIndex = getMaximumIndex(sourceIndices, sourceIndexCount);
+  const IndexArray = maximumIndex <= 65535 ? Uint16Array : Uint32Array;
+  const generatedIndices =
+    primitive.mode === 2
+      ? createLineLoopIndices(sourceIndices, sourceIndexCount, IndexArray)
+      : createTriangleFanIndices(sourceIndices, sourceIndexCount, IndexArray);
+
+  primitive.mode = primitive.mode === 2 ? 1 : 4;
+  primitive.indices = {
+    id: `${meshId}-primitive-${primitiveIndex}-portable-indices`,
+    components: 1,
+    bytesPerComponent: IndexArray.BYTES_PER_ELEMENT,
+    bytesPerElement: IndexArray.BYTES_PER_ELEMENT,
+    componentType: IndexArray === Uint16Array ? 5123 : 5125,
+    normalized: false,
+    count: generatedIndices.length,
+    type: 'SCALAR',
+    min: generatedIndices.length ? [getMinimumIndex(generatedIndices)] : undefined,
+    max: generatedIndices.length ? [maximumIndex] : undefined,
+    value: generatedIndices
+  };
+
+  return primitive;
+}
+
+/** Returns the typed-array constructor for valid sparse accessor index component types. */
+function getSparseIndexArrayType(
+  componentType: number
+): Uint8ArrayConstructor | Uint16ArrayConstructor | Uint32ArrayConstructor {
+  switch (componentType) {
+    case 5121:
+      return Uint8Array;
+    case 5123:
+      return Uint16Array;
+    case 5125:
+      return Uint32Array;
+    default:
+      throw new Error(`Invalid glTF sparse index component type ${componentType}`);
+  }
+}
+
+/** Returns the vertex count shared by a non-indexed primitive's attributes. */
+function getPrimitiveVertexCount(primitive: GLTFMeshPrimitivePostprocessed): number {
+  const attribute = Object.values(primitive.attributes)[0];
+  assert(attribute, 'glTF primitive must define at least one attribute');
+  return attribute.count;
+}
+
+/** Returns the largest referenced vertex index. */
+function getMaximumIndex(
+  indices: ArrayLike<number | bigint> | undefined,
+  indexCount: number
+): number {
+  if (!indices) {
+    return Math.max(0, indexCount - 1);
+  }
+
+  let maximumIndex = 0;
+  for (let index = 0; index < indexCount; index++) {
+    maximumIndex = Math.max(maximumIndex, Number(indices[index]));
+  }
+  return maximumIndex;
+}
+
+/** Returns the smallest generated vertex index. */
+function getMinimumIndex(indices: Uint16Array | Uint32Array): number {
+  let minimumIndex = Infinity;
+  for (const index of indices) {
+    minimumIndex = Math.min(minimumIndex, index);
+  }
+  return minimumIndex;
+}
+
+/** Reads an authored index or generates the equivalent sequential index. */
+function getSourceIndex(indices: ArrayLike<number | bigint> | undefined, index: number): number {
+  return indices ? Number(indices[index]) : index;
+}
+
+/** Expands a line loop into a portable line list. */
+function createLineLoopIndices(
+  sourceIndices: ArrayLike<number | bigint> | undefined,
+  sourceIndexCount: number,
+  IndexArray: Uint16ArrayConstructor | Uint32ArrayConstructor
+): Uint16Array | Uint32Array {
+  if (sourceIndexCount < 2) {
+    return new IndexArray(0);
+  }
+
+  const generatedIndices = new IndexArray(sourceIndexCount * 2);
+  for (let sourceIndex = 0; sourceIndex < sourceIndexCount; sourceIndex++) {
+    generatedIndices[sourceIndex * 2] = getSourceIndex(sourceIndices, sourceIndex);
+    generatedIndices[sourceIndex * 2 + 1] = getSourceIndex(
+      sourceIndices,
+      (sourceIndex + 1) % sourceIndexCount
+    );
+  }
+  return generatedIndices;
+}
+
+/** Expands a triangle fan into a portable triangle list while preserving winding. */
+function createTriangleFanIndices(
+  sourceIndices: ArrayLike<number | bigint> | undefined,
+  sourceIndexCount: number,
+  IndexArray: Uint16ArrayConstructor | Uint32ArrayConstructor
+): Uint16Array | Uint32Array {
+  const triangleCount = Math.max(0, sourceIndexCount - 2);
+  const generatedIndices = new IndexArray(triangleCount * 3);
+  for (let triangleIndex = 0; triangleIndex < triangleCount; triangleIndex++) {
+    generatedIndices[triangleIndex * 3] = getSourceIndex(sourceIndices, 0);
+    generatedIndices[triangleIndex * 3 + 1] = getSourceIndex(sourceIndices, triangleIndex + 1);
+    generatedIndices[triangleIndex * 3 + 2] = getSourceIndex(sourceIndices, triangleIndex + 2);
+  }
+  return generatedIndices;
 }
 
 export function postProcessGLTF(

--- a/modules/gltf/test/lib/api/post-process-gltf.spec.ts
+++ b/modules/gltf/test/lib/api/post-process-gltf.spec.ts
@@ -52,3 +52,123 @@ test('gltf#postProcessGLTF', (t) => {
   }
   t.end();
 });
+test('gltf#postProcessGLTF normalizes indexed LINE_LOOP topology without mutating source data', (t) => {
+  const sourceIndices = new Uint16Array([3, 1, 4, 2]);
+  const source = {
+    json: {
+      asset: {version: '2.0'},
+      buffers: [{byteLength: sourceIndices.byteLength}],
+      bufferViews: [{buffer: 0, byteLength: sourceIndices.byteLength}],
+      accessors: [
+        {bufferView: 0, componentType: 5123, count: sourceIndices.length, type: 'SCALAR'},
+        {componentType: 5126, count: 5, type: 'VEC3'}
+      ],
+      meshes: [{primitives: [{attributes: {POSITION: 1}, indices: 0, mode: 2}]}]
+    },
+    buffers: [
+      {
+        arrayBuffer: sourceIndices.buffer,
+        byteOffset: 0,
+        byteLength: sourceIndices.byteLength
+      }
+    ]
+  } as GLTFWithBuffers;
+
+  const json = postProcessGLTF(source);
+  const primitive = json.meshes[0].primitives[0];
+
+  t.equal(primitive.mode, 1, 'converts LINE_LOOP to LINES');
+  t.deepEqual(
+    Array.from(primitive.indices?.value || []),
+    [3, 1, 1, 4, 4, 2, 2, 3],
+    'expands the loop into line-list indices'
+  );
+  t.equal(primitive.indices?.componentType, 5123, 'uses portable unsigned-short indices');
+  t.equal(source.json.meshes?.[0].primitives[0].mode, 2, 'preserves the source primitive mode');
+  t.equal(source.json.accessors?.[0].count, 4, 'preserves the source index accessor');
+  t.deepEqual(Array.from(sourceIndices), [3, 1, 4, 2], 'preserves the source index buffer');
+  t.end();
+});
+
+test('gltf#postProcessGLTF normalizes non-indexed TRIANGLE_FAN topology', (t) => {
+  const json = postProcessGLTF({
+    json: {
+      asset: {version: '2.0'},
+      accessors: [{componentType: 5126, count: 4, type: 'VEC3'}],
+      meshes: [{primitives: [{attributes: {POSITION: 0}, mode: 6}]}]
+    },
+    buffers: []
+  } as GLTFWithBuffers);
+  const primitive = json.meshes[0].primitives[0];
+
+  t.equal(primitive.mode, 4, 'converts TRIANGLE_FAN to TRIANGLES');
+  t.deepEqual(
+    Array.from(primitive.indices?.value || []),
+    [0, 1, 2, 0, 2, 3],
+    'expands the fan into triangle-list indices'
+  );
+  t.equal(primitive.indices?.count, 6, 'updates the generated index count');
+  t.equal(primitive.indices?.max?.[0], 3, 'records the generated maximum index');
+  t.end();
+});
+
+test('gltf#postProcessGLTF materializes an implicit-zero index accessor', (t) => {
+  const json = postProcessGLTF({
+    json: {
+      asset: {version: '2.0'},
+      accessors: [
+        {componentType: 5123, count: 3, type: 'SCALAR'},
+        {componentType: 5126, count: 1, type: 'VEC3'}
+      ],
+      meshes: [{primitives: [{attributes: {POSITION: 1}, indices: 0, mode: 2}]}]
+    },
+    buffers: []
+  } as GLTFWithBuffers);
+
+  const primitive = json.meshes[0].primitives[0];
+  t.equal(primitive.mode, 1, 'converts LINE_LOOP to LINES');
+  t.deepEqual(
+    Array.from(primitive.indices?.value || []),
+    [0, 0, 0, 0, 0, 0],
+    'uses the accessor implicit-zero values'
+  );
+  t.end();
+});
+
+test('gltf#postProcessGLTF applies sparse-only index accessor substitutions', (t) => {
+  const sparseData = new Uint8Array([1, 3, 5, 0, 2, 0]);
+  const json = postProcessGLTF({
+    json: {
+      asset: {version: '2.0'},
+      buffers: [{byteLength: sparseData.byteLength}],
+      bufferViews: [
+        {buffer: 0, byteOffset: 0, byteLength: 2},
+        {buffer: 0, byteOffset: 2, byteLength: 4}
+      ],
+      accessors: [
+        {
+          componentType: 5123,
+          count: 4,
+          type: 'SCALAR',
+          sparse: {
+            count: 2,
+            indices: {bufferView: 0, componentType: 5121},
+            values: {bufferView: 1}
+          }
+        },
+        {componentType: 5126, count: 6, type: 'VEC3'}
+      ],
+      meshes: [{primitives: [{attributes: {POSITION: 1}, indices: 0, mode: 2}]}]
+    },
+    buffers: [{arrayBuffer: sparseData.buffer, byteOffset: 0, byteLength: sparseData.byteLength}]
+  } as GLTFWithBuffers);
+
+  const primitive = json.meshes[0].primitives[0];
+  t.equal(primitive.mode, 1, 'converts LINE_LOOP to LINES');
+  t.deepEqual(
+    Array.from(primitive.indices?.value || []),
+    [0, 5, 5, 0, 0, 2, 2, 0],
+    'applies sparse substitutions to the implicit-zero base'
+  );
+  t.end();
+});


### PR DESCRIPTION
## Goals

- Backport the merged portable primitive normalization from #3571 to the loaders.gl 4.4 release line used by luma.gl.
- Keep WebGL-only glTF primitive modes out of renderer-specific code.
- Complete the public KHR_meshopt_compression type export identified after #3617 merged.

## Changes

- Expand indexed and non-indexed LINE_LOOP primitives into indexed LINES.
- Expand indexed and non-indexed TRIANGLE_FAN primitives into indexed TRIANGLES while preserving winding.
- Select Uint16Array or Uint32Array from the largest referenced vertex.
- Materialize implicit-zero and sparse-only accessors before topology expansion.
- Preserve source JSON, accessors, and buffers and document the postprocessing behavior.
- Re-export GLTF_KHR_meshopt_compression from the @loaders.gl/gltf package entry point.
- Exclude unrelated v5-only glTF 2.1 context from the original merge.

## Verification

- corepack yarn install
- corepack yarn lint fix — passes with existing warnings and no errors
- corepack yarn build — passes after refreshing the post-#3617 dependency tree
- corepack yarn test-node — 6578/6578 passing for the topology backport
- corepack yarn test browser-headless — 325/325 passing for the topology backport
- corepack yarn test-website — production website generated successfully
- The 4.4 branch does not expose test-headless or test-audit scripts; the equivalent browser-headless mode was run directly.

## Risks and follow-up

- Sparse accessor materialization is shared postprocessing behavior and is covered by the full Node and browser suites.
- This PR is rebased onto the merged KHR_meshopt_compression backport #3617 and completes its missing public type export.
- After this lands, luma.gl can consume both loaders.gl Tranche 2 backports and update its reference ledger and capability registry.