### PR TITLE
perf(parquet): compact Arrow decode levels at scale

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -235,11 +235,12 @@ jobs:
       - name: Build workers
         run: yarn run build-workers
 
-      - name: Run affected or full slow suite
+      - name: Run full slow suite for comparable coverage
         env:
           VITEST_MAX_WORKERS: 1
         run: >-
           yarn test-slow-affected-cover
+          --all
           --reporter=default
           --reporter=blob
           --outputFile.blob=.vitest-reports/blob-slow.json

--- a/docs/modules/parquet/api-reference/parquet-loader.md
+++ b/docs/modules/parquet/api-reference/parquet-loader.md
@@ -224,7 +224,8 @@ timing; each implementation is warmed up and must return the same row count. The
 nullable primitives, nested and repeated data, dictionary and delta encodings, compression, and
 column projection. It focuses on Arrow output and retains one object-row control to expose
 row-materialization cost. `N/A` means an implementation is intentionally excluded from a scenario;
-`Failed` means a selected implementation did not pass warm-up or correctness validation. A green
+`Failed` means a selected implementation threw or could not complete; and `Incorrect` means it
+completed but returned a different row count from the validated result. A green
 marker identifies the fastest completed value in each row. Results depend on the browser, hardware,
 thermal state, and whether this tab remains focused.
 

--- a/modules/parquet/src/lib/parquet-predicate.ts
+++ b/modules/parquet/src/lib/parquet-predicate.ts
@@ -11,6 +11,7 @@ import type {
   ParquetPredicateValue,
   ParquetRowGroupMetadata
 } from '../parquet-source-types';
+import {encodeUtf8} from '../parquetjs/utils/binary-utils';
 
 /** Returns the unique top-level columns referenced by a predicate. */
 export function getParquetPredicateColumns(predicate: ParquetPredicate): string[] {
@@ -216,48 +217,75 @@ function canComparisonMatch(
     switch (operator) {
       case '=':
         return !(
-          (minimum !== undefined && comparePredicateValues(value, minimum) < 0) ||
-          (maximum !== undefined && comparePredicateValues(value, maximum) > 0)
+          (minimum !== undefined && compareStatisticsValues(value, minimum) < 0) ||
+          (maximum !== undefined && compareStatisticsValues(value, maximum) > 0)
         );
       case '<>':
         return !(
           minimum !== undefined &&
           maximum !== undefined &&
-          comparePredicateValues(value, minimum) === 0 &&
-          comparePredicateValues(value, maximum) === 0
+          compareStatisticsValues(value, minimum) === 0 &&
+          compareStatisticsValues(value, maximum) === 0
         );
       case '<':
-        return minimum === undefined || comparePredicateValues(minimum, value) < 0;
+        return minimum === undefined || compareStatisticsValues(minimum, value) < 0;
       case '<=':
-        return minimum === undefined || comparePredicateValues(minimum, value) <= 0;
+        return minimum === undefined || compareStatisticsValues(minimum, value) <= 0;
       case '>':
-        return maximum === undefined || comparePredicateValues(maximum, value) > 0;
+        return maximum === undefined || compareStatisticsValues(maximum, value) > 0;
       case '>=':
-        return maximum === undefined || comparePredicateValues(maximum, value) >= 0;
+        return maximum === undefined || compareStatisticsValues(maximum, value) >= 0;
     }
   } catch {
     return true;
   }
 }
 
-/** Compares predicate-compatible scalar values, including binary values lexicographically. */
+/** Compares statistics using Parquet's unsigned UTF-8 byte ordering for strings. */
+function compareStatisticsValues(left: unknown, right: unknown): number {
+  if (typeof left === 'string' && typeof right === 'string') {
+    return compareUint8Arrays(encodeUtf8(left), encodeUtf8(right));
+  }
+  return comparePredicateValues(left, right);
+}
+
+/** Compares predicate-compatible scalar values and rejects incomparable types. */
 function comparePredicateValues(left: unknown, right: unknown): number {
   if (left instanceof Uint8Array && right instanceof Uint8Array) {
-    const length = Math.min(left.length, right.length);
-    for (let index = 0; index < length; index++) {
-      if (left[index] !== right[index]) {
-        return left[index] < right[index] ? -1 : 1;
-      }
-    }
-    return Math.sign(left.length - right.length);
+    return compareUint8Arrays(left, right);
   }
-  const comparableLeft = left instanceof Date ? left.getTime() : left;
-  const comparableRight = right instanceof Date ? right.getTime() : right;
+  if (left instanceof Uint8Array || right instanceof Uint8Array) {
+    throw new Error('Parquet binary predicates require binary values on both sides');
+  }
+  if (left instanceof Date || right instanceof Date) {
+    if (!(left instanceof Date) || !(right instanceof Date)) {
+      throw new Error('Parquet date predicates require date values on both sides');
+    }
+    const leftTime = left.getTime();
+    const rightTime = right.getTime();
+    if (!Number.isFinite(leftTime) || !Number.isFinite(rightTime)) {
+      throw new Error('Invalid dates cannot be ordered by a Parquet predicate');
+    }
+    return leftTime < rightTime ? -1 : leftTime > rightTime ? 1 : 0;
+  }
+  const leftType = typeof left;
+  const rightType = typeof right;
+  const bothNumeric =
+    (leftType === 'number' || leftType === 'bigint') &&
+    (rightType === 'number' || rightType === 'bigint');
+  if (!bothNumeric && leftType !== rightType) {
+    throw new Error(`Parquet predicate cannot compare ${leftType} with ${rightType}`);
+  }
+  if (!bothNumeric && leftType !== 'string' && leftType !== 'boolean') {
+    throw new Error(`Parquet predicate does not support ${leftType} values`);
+  }
+  const comparableLeft = left as string | boolean | number | bigint;
+  const comparableRight = right as string | boolean | number | bigint;
   if (
-    (typeof comparableLeft === 'number' && Number.isNaN(comparableLeft)) ||
-    (typeof comparableRight === 'number' && Number.isNaN(comparableRight))
+    (typeof comparableLeft === 'number' && !Number.isFinite(comparableLeft)) ||
+    (typeof comparableRight === 'number' && !Number.isFinite(comparableRight))
   ) {
-    throw new Error('NaN cannot be ordered by a Parquet predicate');
+    throw new Error('Non-finite numbers cannot be ordered by a Parquet predicate');
   }
   if ((comparableLeft as never) < (comparableRight as never)) {
     return -1;
@@ -266,6 +294,17 @@ function comparePredicateValues(left: unknown, right: unknown): number {
     return 1;
   }
   return 0;
+}
+
+/** Compares two byte sequences using unsigned lexicographic ordering. */
+function compareUint8Arrays(left: Uint8Array, right: Uint8Array): number {
+  const length = Math.min(left.length, right.length);
+  for (let index = 0; index < length; index++) {
+    if (left[index] !== right[index]) {
+      return left[index] < right[index] ? -1 : 1;
+    }
+  }
+  return Math.sign(left.length - right.length);
 }
 
 /** Reads one value from an array-like materialized Parquet column. */

--- a/modules/parquet/src/lib/parsers/parse-parquet-to-arrow-js.ts
+++ b/modules/parquet/src/lib/parsers/parse-parquet-to-arrow-js.ts
@@ -148,7 +148,8 @@ export async function* parseParquetFileToArrowInBatchesWithJs(
   const reader = new ParquetReader(file, {
     preserveBinary: options?.parquet?.preserveBinary,
     retainByteArrayViews: true,
-    useTypedValueBuffers: true
+    useTypedValueBuffers: true,
+    useTypedLevelBuffers: true
   });
   const schema = projectSchema(await getSchemaFromParquetReader(reader), options?.parquet?.columns);
   const arrowSchema = createParquetArrowSchema(schema);

--- a/modules/parquet/src/parquet-source-loader.ts
+++ b/modules/parquet/src/parquet-source-loader.ts
@@ -69,6 +69,7 @@ import {
   readFloatLE,
   readInt32LE,
   readInt64LE,
+  readUInt64LE,
   toUint8Array
 } from './parquetjs/utils/binary-utils';
 import {fieldIndexOf} from './parquetjs/utils/read-utils';
@@ -570,7 +571,7 @@ export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoader
           columnChunks: selectedColumnChunks.map(createParquetSourceWorkerColumnChunk),
           ranges,
           batchSize: batchSize || Math.max(Number(rowGroup.num_rows), 1),
-          predicate,
+          predicate: predicate ? copyParquetPredicate(predicate) : undefined,
           preserveBinary: Boolean(this.options.parquet?.preserveBinary)
         },
         workerOptions
@@ -810,7 +811,8 @@ function decodeStatisticsValueSafely(bytes: Uint8Array, field: ParquetField): un
         primitiveValue = readInt32LE(bytes, 0);
         break;
       case 'INT64':
-        primitiveValue = readInt64LE(bytes, 0);
+        primitiveValue =
+          field.originalType === 'UINT_64' ? readUInt64LE(bytes, 0) : readInt64LE(bytes, 0);
         break;
       case 'FLOAT':
         primitiveValue = readFloatLE(bytes, 0);

--- a/modules/parquet/src/parquetjs/codecs/declare.ts
+++ b/modules/parquet/src/parquetjs/codecs/declare.ts
@@ -10,6 +10,8 @@ import {PrimitiveType} from '../schema/declare';
 export type ParquetValueBuffer =
   | unknown[]
   | Uint8Array
+  | Uint16Array
+  | Uint32Array
   | Int32Array
   | BigInt64Array
   | Float32Array

--- a/modules/parquet/src/parquetjs/codecs/rle.ts
+++ b/modules/parquet/src/parquetjs/codecs/rle.ts
@@ -130,9 +130,12 @@ export function decodeValues(
       const outputCount = Math.min(runValueCount, count - outputOffset);
       const value = decodeRepeatedRun(cursor, bitWidth);
       const resolvedValue = resolveDictionaryValue(value, options.dictionary);
-      for (let index = 0; index < outputCount; index++) {
-        output[initialOutputOffset + outputOffset + index] = resolvedValue;
-      }
+      fillParquetValueBuffer(
+        output,
+        resolvedValue,
+        initialOutputOffset + outputOffset,
+        initialOutputOffset + outputOffset + outputCount
+      );
       outputOffset += outputCount;
     }
   }
@@ -161,9 +164,7 @@ function decodeBitPackedRun(
 
   if (bitWidth === 0) {
     const resolvedValue = resolveDictionaryValue(0, dictionary);
-    for (let index = 0; index < outputCount; index++) {
-      output[outputOffset + index] = resolvedValue;
-    }
+    fillParquetValueBuffer(output, resolvedValue, outputOffset, outputOffset + outputCount);
     return;
   }
   if (bitWidth <= 24) {
@@ -206,6 +207,24 @@ function decodeBitPackedRun(
     packedBits >>= bitWidthBigInt;
     packedBitCount -= bitWidth;
   }
+}
+
+/** Fills a decoder destination while preserving bigint typed-array semantics. */
+function fillParquetValueBuffer(
+  output: ParquetValueBuffer,
+  value: unknown,
+  start: number,
+  end: number
+): void {
+  if (output instanceof BigInt64Array) {
+    output.fill(typeof value === 'bigint' ? value : BigInt(value as number), start, end);
+    return;
+  }
+  if (Array.isArray(output)) {
+    output.fill(value, start, end);
+    return;
+  }
+  output.fill(Number(value), start, end);
 }
 
 /** Decodes common narrow bit widths with a fast 32-bit reservoir. */

--- a/modules/parquet/src/parquetjs/encoder/parquet-encoder.ts
+++ b/modules/parquet/src/parquetjs/encoder/parquet-encoder.ts
@@ -421,18 +421,28 @@ async function encodeDataPage(
   /* encode repetition and definition levels */
   let rLevelsBuf: Uint8Array = new Uint8Array(0);
   if (column.rLevelMax > 0) {
-    rLevelsBuf = encodeValues(PARQUET_RDLVL_TYPE, PARQUET_RDLVL_ENCODING, data.rlevels, {
-      bitWidth: getBitWidth(column.rLevelMax)
-      // disableEnvelope: false
-    });
+    rLevelsBuf = encodeValues(
+      PARQUET_RDLVL_TYPE,
+      PARQUET_RDLVL_ENCODING,
+      data.rlevels as number[],
+      {
+        bitWidth: getBitWidth(column.rLevelMax)
+        // disableEnvelope: false
+      }
+    );
   }
 
   let dLevelsBuf: Uint8Array = new Uint8Array(0);
   if (column.dLevelMax > 0) {
-    dLevelsBuf = encodeValues(PARQUET_RDLVL_TYPE, PARQUET_RDLVL_ENCODING, data.dlevels, {
-      bitWidth: getBitWidth(column.dLevelMax)
-      // disableEnvelope: false
-    });
+    dLevelsBuf = encodeValues(
+      PARQUET_RDLVL_TYPE,
+      PARQUET_RDLVL_ENCODING,
+      data.dlevels as number[],
+      {
+        bitWidth: getBitWidth(column.dLevelMax)
+        // disableEnvelope: false
+      }
+    );
   }
 
   /* encode values */
@@ -492,18 +502,28 @@ async function encodeDataPageV2(
   /* encode repetition and definition levels */
   let rLevelsBuf: Uint8Array = new Uint8Array(0);
   if (column.rLevelMax > 0) {
-    rLevelsBuf = encodeValues(PARQUET_RDLVL_TYPE, PARQUET_RDLVL_ENCODING, data.rlevels, {
-      bitWidth: getBitWidth(column.rLevelMax),
-      disableEnvelope: true
-    });
+    rLevelsBuf = encodeValues(
+      PARQUET_RDLVL_TYPE,
+      PARQUET_RDLVL_ENCODING,
+      data.rlevels as number[],
+      {
+        bitWidth: getBitWidth(column.rLevelMax),
+        disableEnvelope: true
+      }
+    );
   }
 
   let dLevelsBuf: Uint8Array = new Uint8Array(0);
   if (column.dLevelMax > 0) {
-    dLevelsBuf = encodeValues(PARQUET_RDLVL_TYPE, PARQUET_RDLVL_ENCODING, data.dlevels, {
-      bitWidth: getBitWidth(column.dLevelMax),
-      disableEnvelope: true
-    });
+    dLevelsBuf = encodeValues(
+      PARQUET_RDLVL_TYPE,
+      PARQUET_RDLVL_ENCODING,
+      data.dlevels as number[],
+      {
+        bitWidth: getBitWidth(column.dLevelMax),
+        disableEnvelope: true
+      }
+    );
   }
 
   /* build page header */

--- a/modules/parquet/src/parquetjs/parser/decoders.ts
+++ b/modules/parquet/src/parquetjs/parser/decoders.ts
@@ -10,6 +10,7 @@ import {
   ParquetReaderContext,
   ParquetPageData,
   ParquetLogicalType,
+  ParquetLevelBuffer,
   ParquetTimeUnit,
   ParquetType,
   PrimitiveType,
@@ -37,8 +38,8 @@ type ParquetPageDecodeTarget = {
   values: ParquetValueBuffer;
   valueOffset: number;
   dictionary: readonly unknown[];
-  rlevels: number[];
-  dlevels: number[];
+  rlevels: ParquetLevelBuffer;
+  dlevels: ParquetLevelBuffer;
   levelOffset: number;
 };
 
@@ -70,14 +71,8 @@ export async function decodeDataPages(
 
   const outputCapacity = expectedLevelCount ?? 0;
   const data: ParquetColumnChunk = {
-    rlevels:
-      context.rLevelMax > 0
-        ? new Array<number>(outputCapacity)
-        : new Array<number>(outputCapacity).fill(0),
-    dlevels:
-      context.dLevelMax > 0
-        ? new Array<number>(outputCapacity)
-        : new Array<number>(outputCapacity).fill(0),
+    rlevels: createParquetLevelBuffer(context, outputCapacity, context.rLevelMax),
+    dlevels: createParquetLevelBuffer(context, outputCapacity, context.dLevelMax),
     values: createParquetColumnValueBuffer(context, outputCapacity),
     pageHeaders: [],
     count: 0
@@ -132,8 +127,8 @@ export async function decodeDataPages(
     data.pageHeaders.push(page.pageHeader);
   }
 
-  data.rlevels.length = levelOffset;
-  data.dlevels.length = levelOffset;
+  data.rlevels = trimParquetLevelBuffer(data.rlevels, levelOffset);
+  data.dlevels = trimParquetLevelBuffer(data.dlevels, levelOffset);
   data.values = trimParquetValueBuffer(data.values, valueOffset);
 
   return data;
@@ -664,7 +659,7 @@ function decodeLevels(
   levelMax: number,
   encoding: ParquetCodec,
   disableEnvelope: boolean,
-  output?: number[],
+  output?: ParquetLevelBuffer,
   outputOffset = 0
 ): number[] {
   if (levelMax === 0) {
@@ -677,6 +672,33 @@ function decodeLevels(
     outputOffset
   }) as number[];
   return output ? [] : levels;
+}
+
+/** Allocates compact unsigned storage for repetition and definition levels. */
+function createParquetLevelBuffer(
+  context: ParquetReaderContext,
+  capacity: number,
+  levelMax: number
+): ParquetLevelBuffer {
+  if (!context.useTypedLevelBuffers || capacity === 0) {
+    return levelMax > 0 ? new Array<number>(capacity) : new Array<number>(capacity).fill(0);
+  }
+  if (levelMax <= 0xff) {
+    return new Uint8Array(capacity);
+  }
+  if (levelMax <= 0xffff) {
+    return new Uint16Array(capacity);
+  }
+  return new Uint32Array(capacity);
+}
+
+/** Restricts an overallocated level buffer to the number of decoded levels. */
+function trimParquetLevelBuffer(levels: ParquetLevelBuffer, length: number): ParquetLevelBuffer {
+  if (Array.isArray(levels)) {
+    levels.length = length;
+    return levels;
+  }
+  return levels.subarray(0, length) as ParquetLevelBuffer;
 }
 
 /** Returns whether an encoding stores RLE dictionary indices instead of physical values. */

--- a/modules/parquet/src/parquetjs/parser/parquet-reader.ts
+++ b/modules/parquet/src/parquetjs/parser/parquet-reader.ts
@@ -34,6 +34,8 @@ export type ParquetReaderProps = {
   retainByteArrayViews?: boolean;
   /** Decode supported primitive columns into typed buffers instead of boxed JavaScript arrays. */
   useTypedValueBuffers?: boolean;
+  /** Decode repetition and definition levels into compact unsigned typed arrays. */
+  useTypedLevelBuffers?: boolean;
   /** Abort signal forwarded to every underlying random-access read. */
   signal?: AbortSignal;
 };
@@ -61,6 +63,7 @@ export class ParquetReader {
     preserveBinary: false,
     retainByteArrayViews: false,
     useTypedValueBuffers: false,
+    useTypedLevelBuffers: false,
     signal: undefined
   };
 
@@ -300,7 +303,8 @@ export class ParquetReader {
       // Options - TBD is this the right place for these?
       preserveBinary: this.props.preserveBinary,
       retainByteArrayViews: this.props.retainByteArrayViews,
-      useTypedValueBuffers: this.props.useTypedValueBuffers
+      useTypedValueBuffers: this.props.useTypedValueBuffers,
+      useTypedLevelBuffers: this.props.useTypedLevelBuffers
     };
 
     let dictionary: any[] | undefined;

--- a/modules/parquet/src/parquetjs/schema/declare.ts
+++ b/modules/parquet/src/parquetjs/schema/declare.ts
@@ -199,7 +199,12 @@ export interface ParquetReaderContext {
   retainByteArrayViews?: boolean;
   /** Decode primitive values into typed column buffers when their physical type permits it. */
   useTypedValueBuffers?: boolean;
+  /** Decode repetition and definition levels into compact unsigned typed arrays. */
+  useTypedLevelBuffers?: boolean;
 }
+
+/** Mutable storage for decoded Parquet repetition and definition levels. */
+export type ParquetLevelBuffer = number[] | Uint8Array | Uint16Array | Uint32Array;
 
 export interface ParquetPageData {
   dlevels: number[];
@@ -234,8 +239,8 @@ export class ParquetRowGroup {
 
 /** Holds the data for one column chunk */
 export interface ParquetColumnChunk {
-  dlevels: number[];
-  rlevels: number[];
+  dlevels: ParquetLevelBuffer;
+  rlevels: ParquetLevelBuffer;
   values: ParquetValueBuffer;
   count: number;
   pageHeaders: PageHeader[];

--- a/modules/parquet/src/parquetjs/schema/shred.ts
+++ b/modules/parquet/src/parquetjs/schema/shred.ts
@@ -65,8 +65,14 @@ export function shredRecord(
   }
   rowGroup.rowCount += 1;
   for (const field of schema.fieldList) {
-    Array.prototype.push.apply(rowGroup.columnData[field.key].rlevels, data[field.key].rlevels);
-    Array.prototype.push.apply(rowGroup.columnData[field.key].dlevels, data[field.key].dlevels);
+    Array.prototype.push.apply(
+      rowGroup.columnData[field.key].rlevels as number[],
+      data[field.key].rlevels as number[]
+    );
+    Array.prototype.push.apply(
+      rowGroup.columnData[field.key].dlevels as number[],
+      data[field.key].dlevels as number[]
+    );
     Array.prototype.push.apply(
       rowGroup.columnData[field.key].values as unknown[],
       data[field.key].values as unknown as unknown[]
@@ -114,8 +120,8 @@ function shredRecordFields(
         shredRecordFields(field.fields!, null!, data, rLevel, dLevel);
       } else {
         data[field.key].count += 1;
-        data[field.key].rlevels.push(rLevel);
-        data[field.key].dlevels.push(dLevel);
+        (data[field.key].rlevels as number[]).push(rLevel);
+        (data[field.key].dlevels as number[]).push(dLevel);
       }
       continue; // eslint-disable-line no-continue
     }
@@ -127,8 +133,8 @@ function shredRecordFields(
         shredRecordFields(field.fields!, values[i], data, rlvl, field.dLevelMax);
       } else {
         data[field.key].count += 1;
-        data[field.key].rlevels.push(rlvl);
-        data[field.key].dlevels.push(field.dLevelMax);
+        (data[field.key].rlevels as number[]).push(rlvl);
+        (data[field.key].dlevels as number[]).push(field.dLevelMax);
         (data[field.key].values as unknown[]).push(
           Types.toPrimitive((field.originalType || field.primitiveType)!, values[i], field)
         );

--- a/modules/parquet/src/parquetjs/utils/binary-utils.ts
+++ b/modules/parquet/src/parquetjs/utils/binary-utils.ts
@@ -60,9 +60,14 @@ export function readUInt32LE(binary: Uint8Array, offset: number): number {
   return getDataView(binary).getUint32(offset, true);
 }
 
-/** Read signed little-endian 64-bit integer as number. */
-export function readInt64LE(binary: Uint8Array, offset: number): number {
-  return Number(getDataView(binary).getBigInt64(offset, true));
+/** Read signed little-endian 64-bit integer without losing precision. */
+export function readInt64LE(binary: Uint8Array, offset: number): bigint {
+  return getDataView(binary).getBigInt64(offset, true);
+}
+
+/** Read unsigned little-endian 64-bit integer without losing precision. */
+export function readUInt64LE(binary: Uint8Array, offset: number): bigint {
+  return getDataView(binary).getBigUint64(offset, true);
 }
 
 /** Read little-endian 32-bit float. */

--- a/modules/parquet/test/parquet-int64.spec.ts
+++ b/modules/parquet/test/parquet-int64.spec.ts
@@ -8,6 +8,8 @@ import {ParquetJSLoader, ParquetJSWriter} from '@loaders.gl/parquet';
 import type {ObjectRowTable} from '@loaders.gl/schema';
 import {expect, test} from 'vitest';
 
+import {readInt64LE, readUInt64LE} from '../src/parquetjs/utils/binary-utils';
+
 const EXACT_INT64_VALUES = [9007199254740993n, -9007199254740993n, 9223372036854775807n];
 
 /** Creates a physical INT64 Parquet fixture containing values that cannot be represented as numbers. */
@@ -50,6 +52,16 @@ test('ParquetJSLoader preserves physical INT64 values in Arrow Int64 vectors', a
     expect(table.data.schema.fields[0].type).toBeInstanceOf(arrow.Int64);
     expect(Array.from(table.data.getChildAt(0) || [])).toEqual(EXACT_INT64_VALUES);
   }
+});
+
+test('Parquet INT64 statistics retain values beyond safe integers', () => {
+  const signedBytes = new Uint8Array(8);
+  const unsignedBytes = new Uint8Array(8);
+  new DataView(signedBytes.buffer).setBigInt64(0, -9007199254740993n, true);
+  new DataView(unsignedBytes.buffer).setBigUint64(0, 18446744073709551615n, true);
+
+  expect(readInt64LE(signedBytes, 0)).toBe(-9007199254740993n);
+  expect(readUInt64LE(unsignedBytes, 0)).toBe(18446744073709551615n);
 });
 
 test('ParquetJSWriter rejects unsafe number inputs instead of silently corrupting INT64 values', async () => {

--- a/modules/parquet/test/parquet-predicate.spec.ts
+++ b/modules/parquet/test/parquet-predicate.spec.ts
@@ -113,6 +113,23 @@ test('Parquet predicates compare binary values and snapshot mutable values', () 
   expect(gatherParquetColumns({binary: [binaryValue]}, [0])).toEqual({binary: [binaryValue]});
 });
 
+test('Parquet predicates reject incomparable scalar types during exact filtering', () => {
+  expect(() =>
+    filterParquetRowIndices(
+      {op: '=', args: [{property: 'value'}, 1]},
+      {value: ['1']},
+      1
+    )
+  ).toThrow(/cannot compare string with number/);
+  expect(() =>
+    filterParquetRowIndices(
+      {op: '=', args: [{property: 'value'}, new Uint8Array([1])]},
+      {value: ['\u0001']},
+      1
+    )
+  ).toThrow(/binary predicates require binary values/);
+});
+
 test('Parquet footer statistics only prune predicates proven impossible', () => {
   const rowGroup = createRowGroupMetadata({minimum: 10, maximum: 19, nullCount: 0});
 
@@ -162,6 +179,25 @@ test('Parquet footer statistics only prune predicates proven impossible', () => 
   expect(canParquetRowGroupMatch({op: '>', args: [{property: 'id'}, 19]}, inexactRowGroup)).toBe(
     true
   );
+});
+
+test('Parquet footer statistics use UTF-8 byte ordering and retain incomparable groups', () => {
+  const unicodeRowGroup = createRowGroupMetadata({
+    minimum: '\uE000',
+    maximum: '\u{10000}',
+    nullCount: 0
+  });
+  expect(
+    canParquetRowGroupMatch(
+      {op: '>=', args: [{property: 'id'}, '\u{10000}']},
+      unicodeRowGroup
+    )
+  ).toBe(true);
+
+  const numericRowGroup = createRowGroupMetadata({minimum: 10, maximum: 19, nullCount: 0});
+  expect(
+    canParquetRowGroupMatch({op: '=', args: [{property: 'id'}, '15']}, numericRowGroup)
+  ).toBe(true);
 });
 
 test('Parquet predicate negation preserves CQL2 null semantics', () => {
@@ -233,16 +269,16 @@ test('ParquetSource transfers serializable predicates through worker decoding', 
     source.read({
       columns: ['payload'],
       batchSize: 2,
-      predicate: {op: 'in', args: [{property: 'id'}, [1, 5, 10]]}
+      predicate: {op: '=', args: [{property: 'binary'}, new Uint8Array([1])]}
     })
   );
 
   expect(batches.flatMap(batch => Array.from(batch.data.getChild('payload')?.toArray() || []))).toEqual([
     'row-1',
     'row-5',
-    'row-10'
+    'row-9'
   ]);
-  expect(batches.map(batch => batch.rowIndices)).toEqual([[1], [5], [10]]);
+  expect(batches.map(batch => batch.rowIndices)).toEqual([[1], [5], [9]]);
   expect(source.getTelemetry()).toMatchObject({
     predicateRowsTested: 12,
     predicateRowsMatched: 3,
@@ -253,8 +289,8 @@ test('ParquetSource transfers serializable predicates through worker decoding', 
 
 /** Creates normalized row-group metadata for conservative statistics tests. */
 function createRowGroupMetadata(statistics: {
-  minimum: number;
-  maximum: number;
+  minimum: unknown;
+  maximum: unknown;
   nullCount: number;
 }): ParquetRowGroupMetadata {
   return {
@@ -296,14 +332,16 @@ async function createPredicateFixture(): Promise<ArrayBuffer> {
         fields: [
           {name: 'id', type: 'int32', nullable: false},
           {name: 'category', type: 'utf8', nullable: false},
-          {name: 'payload', type: 'utf8', nullable: false}
+          {name: 'payload', type: 'utf8', nullable: false},
+          {name: 'binary', type: 'binary', nullable: false}
         ],
         metadata: {}
       },
       data: Array.from({length: 12}, (_, index) => ({
         id: index,
         category: index % 2 === 0 ? 'even' : 'odd',
-        payload: `row-${index}`
+        payload: `row-${index}`,
+        binary: new Uint8Array([index % 4])
       }))
     } satisfies ObjectRowTable,
     ParquetJSWriter,

--- a/modules/parquet/test/parquet-source-loader.spec.ts
+++ b/modules/parquet/test/parquet-source-loader.spec.ts
@@ -178,8 +178,8 @@ test('ParquetSourceLoader#decodes optional column-chunk statistics', async (t) =
     column => column.path.join('.') === 'int_map.map.key'
   )?.statistics;
 
-  t.equal(idStatistics?.min, 1, 'decodes physical INT64 minimum');
-  t.equal(idStatistics?.max, 7, 'decodes physical INT64 maximum');
+  t.equal(idStatistics?.min, 1n, 'decodes physical INT64 minimum exactly');
+  t.equal(idStatistics?.max, 7n, 'decodes physical INT64 maximum exactly');
   t.equal(idStatistics?.nullCount, 0, 'retains an explicit zero null count');
   t.equal(keyStatistics?.min, 'k1', 'converts a logical UTF8 minimum');
   t.equal(keyStatistics?.max, 'k3', 'converts a logical UTF8 maximum');

--- a/modules/parquet/test/parquet.bench.ts
+++ b/modules/parquet/test/parquet.bench.ts
@@ -105,7 +105,21 @@ export async function parquetBench(suite) {
     preload(ParquetLoader, {core: {worker: false}})
   ]);
   const implementations = createParquetBenchmarkImplementations(typescriptLoader, wasmLoader);
+  const wideScaleArrayBuffer = await createWideScaleParquetFixture();
   const scenarios: ParquetBenchmarkScenario[] = [
+    {
+      name: 'Wide nullable mixed 100K × 20 → Arrow',
+      arrayBuffer: wideScaleArrayBuffer,
+      shape: 'arrow-table'
+    },
+    {
+      name: 'Wide nullable mixed projection 100K × 5 → Arrow',
+      arrayBuffer: wideScaleArrayBuffer,
+      columns: ['id', 'count_0', 'metric_0', 'category_0', 'label_0'],
+      shape: 'arrow-table',
+      // parquet-wasm 0.7.2 fails to materialize this projected mixed schema.
+      implementationIds: ['typescript', 'hyparquet']
+    },
     {name: 'GeoParquet → Arrow', arrayBuffer: geoArrayBuffer, shape: 'arrow-table'},
     {
       name: 'PLAIN nullable primitive projection → Arrow',
@@ -223,6 +237,69 @@ export async function parquetBench(suite) {
   //     core: {worker: false}
   //   });
   // });
+}
+
+/** Encodes a wide mixed-type fixture that exposes decode allocation and scaling costs. */
+async function createWideScaleParquetFixture(): Promise<ArrayBuffer> {
+  const rowCount = 100_000;
+  const table: ObjectRowTable = {
+    shape: 'object-row-table',
+    schema: {
+      fields: [
+        {name: 'id', type: 'int32', nullable: false},
+        ...Array.from({length: 6}, (_, index) => ({
+          name: `count_${index}`,
+          type: 'int32' as const,
+          nullable: true
+        })),
+        ...Array.from({length: 6}, (_, index) => ({
+          name: `metric_${index}`,
+          type: 'float64' as const,
+          nullable: true
+        })),
+        ...Array.from({length: 4}, (_, index) => ({
+          name: `category_${index}`,
+          type: 'utf8' as const,
+          nullable: true
+        })),
+        ...Array.from({length: 3}, (_, index) => ({
+          name: `label_${index}`,
+          type: 'utf8' as const,
+          nullable: true
+        }))
+      ],
+      metadata: {}
+    },
+    data: Array.from({length: rowCount}, (_, rowIndex) => {
+      const row: Record<string, unknown> = {id: rowIndex};
+      for (let columnIndex = 0; columnIndex < 6; columnIndex++) {
+        row[`count_${columnIndex}`] =
+          (rowIndex + columnIndex) % 17 === 0 ? null : rowIndex * (columnIndex + 1);
+        row[`metric_${columnIndex}`] =
+          (rowIndex + columnIndex) % 23 === 0
+            ? null
+            : rowIndex * 0.125 + columnIndex / 10;
+      }
+      for (let columnIndex = 0; columnIndex < 4; columnIndex++) {
+        row[`category_${columnIndex}`] =
+          (rowIndex + columnIndex) % 29 === 0
+            ? null
+            : `category-${columnIndex}-${rowIndex % 32}`;
+      }
+      for (let columnIndex = 0; columnIndex < 3; columnIndex++) {
+        row[`label_${columnIndex}`] =
+          (rowIndex + columnIndex) % 31 === 0
+            ? null
+            : `tenant/${columnIndex}/record/${rowIndex}`;
+      }
+      return row;
+    })
+  };
+
+  return await encode(table, ParquetJSWriter, {
+    worker: false,
+    parquet: {dictionary: 'auto', pageSize: 64 * 1024, rowGroupSize: 25_000}
+  });
 }
 
 /** Adds an exact predicate and hidden-filter-column throughput case at meaningful scale. */

--- a/modules/parquet/test/parquetjs/decoders.spec.ts
+++ b/modules/parquet/test/parquetjs/decoders.spec.ts
@@ -39,6 +39,27 @@ test('decodeDataPages#returns preallocated empty column data', async t => {
   t.end();
 });
 
+test('decodeDataPages#uses compact typed level buffers when requested', async t => {
+  const [data, wideData, veryWideData] = await Promise.all(
+    [1, 256, 65_536].map(dLevelMax =>
+      decodeDataPages(new Uint8Array(), {
+        ...TEST_CONTEXT,
+        dLevelMax,
+        numValues: 4 as unknown as Int64,
+        useTypedLevelBuffers: true
+      })
+    )
+  );
+
+  t.ok(data.rlevels instanceof Uint8Array, 'uses a typed repetition-level buffer');
+  t.ok(data.dlevels instanceof Uint8Array, 'uses a typed definition-level buffer');
+  t.ok(wideData.dlevels instanceof Uint16Array, 'widens definition levels when required');
+  t.ok(veryWideData.dlevels instanceof Uint32Array, 'supports deeply nested definition levels');
+  t.equal(data.rlevels.length, 0, 'trims repetition levels to the decoded length');
+  t.equal(data.dlevels.length, 0, 'trims definition levels to the decoded length');
+  t.end();
+});
+
 test('decodeDataPages#rejects invalid metadata value counts', async t => {
   await t.rejects(
     decodeDataPages(new Uint8Array(), {

--- a/modules/polyfills/test/filesystems/node-file.node.spec.ts
+++ b/modules/polyfills/test/filesystems/node-file.node.spec.ts
@@ -1,3 +1,6 @@
+import {copyFile, mkdtemp, rm} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
 import {expect, test} from 'vitest';
 import '@loaders.gl/polyfills';
 import {NodeFile} from '@loaders.gl/loader-utils';
@@ -14,11 +17,20 @@ test('NodeFile#open and read', async () => {
   expect(reference.compare(Buffer.from(arrayBuffer))).toBe(0);
 });
 test('NodeFile#truncate and append', async () => {
-  const provider = new NodeFile(SLPK_URL, 'a+');
-  const initialSize = await getSize(provider);
-  const ending = await provider.read(TEST_OFFSET, Number(initialSize - TEST_OFFSET));
-  await provider.truncate(Number(TEST_OFFSET));
-  expect(await getSize(provider)).toBe(TEST_OFFSET);
-  await provider.append(new Uint8Array(ending));
-  expect(await getSize(provider)).toBe(initialSize);
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), 'loaders-gl-node-file-'));
+  const temporaryFile = join(temporaryDirectory, 'test.slpk');
+  await copyFile(SLPK_URL, temporaryFile);
+
+  const provider = new NodeFile(temporaryFile, 'a+');
+  try {
+    const initialSize = await getSize(provider);
+    const ending = await provider.read(TEST_OFFSET, Number(initialSize - TEST_OFFSET));
+    await provider.truncate(Number(TEST_OFFSET));
+    expect(await getSize(provider)).toBe(TEST_OFFSET);
+    await provider.append(new Uint8Array(ending));
+    expect(await getSize(provider)).toBe(initialSize);
+  } finally {
+    await provider.close();
+    await rm(temporaryDirectory, {recursive: true, force: true});
+  }
 });

--- a/modules/sql/README.md
+++ b/modules/sql/README.md
@@ -46,7 +46,7 @@ supports comparisons, `IN`, `IS [NOT] NULL`, `AND`, `OR`, `NOT`, parentheses, sc
 named parameters.
 
 ```ts
-import {parseSQLPredicate} from '@loaders.gl/sql';
+import {parseSQLPredicate} from '@loaders.gl/sql/sql-predicate';
 
 const predicate = parseSQLPredicate(
   "timestamp >= :start AND status IN ('valid', 'estimated')",
@@ -61,7 +61,8 @@ for await (const batch of parquetSource.read({
 }
 ```
 
-The resulting `op`/`args` representation is directionally aligned with CQL2 JSON but does not
+The dependency-free `sql-predicate` subpath does not load or traverse the optional database
+adapters. The resulting `op`/`args` representation is directionally aligned with CQL2 JSON but does not
 claim CQL2 conformance. `SQL_PREDICATE_JSON_SCHEMA`, `validateSQLPredicate()`, and
 `isSQLPredicate()` support dependency-free payload validation.
 

--- a/modules/sql/package.json
+++ b/modules/sql/package.json
@@ -26,6 +26,11 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
+    "./sql-predicate": {
+      "types": "./dist/sql-predicate.d.ts",
+      "import": "./dist/sql-predicate.js",
+      "require": "./dist/sql-predicate.cjs"
+    },
     "./sql-predicate-zod": {
       "types": "./dist/sql-predicate-zod.d.ts",
       "import": "./dist/sql-predicate-zod.js",

--- a/modules/sql/src/parse-sql-predicate.ts
+++ b/modules/sql/src/parse-sql-predicate.ts
@@ -39,8 +39,11 @@ export function parseSQLPredicate(
 
 /** Dependency-free recursive-descent parser for one SQL predicate expression. */
 class SQLPredicateParser {
+  /** Token stream parsed by this parser instance. */
   private readonly tokens: readonly SQLPredicateToken[];
+  /** Named scalar parameters available to the expression. */
   private readonly parameters: Readonly<Record<string, SQLPredicateValue>>;
+  /** Current index in the token stream. */
   private position = 0;
 
   constructor(source: string, parameters: Readonly<Record<string, SQLPredicateValue>>) {

--- a/modules/sql/src/sql-predicate.ts
+++ b/modules/sql/src/sql-predicate.ts
@@ -1,0 +1,22 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export {parseSQLPredicate} from './parse-sql-predicate';
+export {
+  isSQLPredicate,
+  SQL_PREDICATE_JSON_SCHEMA,
+  validateSQLPredicate
+} from './sql-predicate-schema';
+
+export type {
+  SQLComparisonPredicate,
+  SQLInPredicate,
+  SQLLogicalPredicate,
+  SQLNotPredicate,
+  SQLNullPredicate,
+  SQLPredicate,
+  SQLPredicateParserOptions,
+  SQLPredicateProperty,
+  SQLPredicateValue
+} from './sql-predicate-types';

--- a/modules/sql/test/sql-predicate.spec.ts
+++ b/modules/sql/test/sql-predicate.spec.ts
@@ -9,7 +9,7 @@ import {
   parseSQLPredicate,
   SQL_PREDICATE_JSON_SCHEMA,
   validateSQLPredicate
-} from '@loaders.gl/sql';
+} from '@loaders.gl/sql/sql-predicate';
 import {SQLPredicateSchema} from '@loaders.gl/sql/sql-predicate-zod';
 
 test('parseSQLPredicate emits a CQL2-shaped AST with SQL precedence', () => {

--- a/website/src/examples/parquet-benchmarks-app.tsx
+++ b/website/src/examples/parquet-benchmarks-app.tsx
@@ -19,6 +19,7 @@ type BenchmarkResultRow = {
 };
 
 type BenchmarkStatus = 'loading' | 'running' | 'complete' | 'failed';
+type BenchmarkCellOutcome = 'failed' | 'incorrect';
 
 type ParquetBenchmarkImplementationId = 'typescript' | 'wasm' | 'hyparquet';
 type ParquetBenchmarkShape = 'arrow-table' | 'object-row-table';
@@ -111,7 +112,7 @@ const PARQUET_BENCHMARK_IMPLEMENTATION_IDS: ParquetBenchmarkImplementationId[] =
 export default function ParquetBenchmarksApp(): JSX.Element {
   const [rows, setRows] = useState<BenchmarkResultRow[]>([]);
   const [scenarios, setScenarios] = useState<ParquetBenchmarkScenarioSummary[]>([]);
-  const [failedCellKeys, setFailedCellKeys] = useState<Set<string>>(new Set());
+  const [cellOutcomes, setCellOutcomes] = useState<Map<string, BenchmarkCellOutcome>>(new Map());
   const [warnings, setWarnings] = useState<string[]>([]);
   const [status, setStatus] = useState<BenchmarkStatus>('loading');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -121,7 +122,7 @@ export default function ParquetBenchmarksApp(): JSX.Element {
     let isMounted = true;
     setRows([]);
     setScenarios([]);
-    setFailedCellKeys(new Set());
+    setCellOutcomes(new Map());
     setWarnings([]);
     setStatus('loading');
     setErrorMessage(null);
@@ -144,16 +145,17 @@ export default function ParquetBenchmarksApp(): JSX.Element {
       }
     };
 
-    /** Marks one selected implementation/scenario pair as a failed benchmark cell. */
-    const markCellFailed = (
+    /** Records why one selected implementation/scenario pair has no benchmark result. */
+    const markCellOutcome = (
       scenario: string,
-      implementationId: ParquetBenchmarkImplementationId
+      implementationId: ParquetBenchmarkImplementationId,
+      outcome: BenchmarkCellOutcome
     ): void => {
       if (isMounted) {
-        setFailedCellKeys(previousKeys => {
-          const nextKeys = new Set(previousKeys);
-          nextKeys.add(getBenchmarkCellKey(scenario, implementationId));
-          return nextKeys;
+        setCellOutcomes(previousOutcomes => {
+          const nextOutcomes = new Map(previousOutcomes);
+          nextOutcomes.set(getBenchmarkCellKey(scenario, implementationId), outcome);
+          return nextOutcomes;
         });
       }
     };
@@ -188,7 +190,7 @@ export default function ParquetBenchmarksApp(): JSX.Element {
             scenarios,
             implementations,
             appendWarning,
-            markCellFailed
+            markCellOutcome
           );
         });
         if (isMounted) {
@@ -239,7 +241,7 @@ export default function ParquetBenchmarksApp(): JSX.Element {
       {errorMessage ? <pre className="benchmark-error">{errorMessage}</pre> : null}
       {warnings.length > 0 ? (
         <aside>
-          <strong>Failed benchmark cases</strong>
+          <strong>Benchmark diagnostics</strong>
           <ul>
             {warnings.map(warning => (
               <li key={warning}>{warning}</li>
@@ -280,7 +282,7 @@ export default function ParquetBenchmarksApp(): JSX.Element {
                 const cellKey = getBenchmarkCellKey(scenario.name, implementationId);
                 return (
                   scenarioRows.some(row => row.implementationId === implementationId) ||
-                  failedCellKeys.has(cellKey)
+                  cellOutcomes.has(cellKey)
                 );
               });
               return (
@@ -292,6 +294,7 @@ export default function ParquetBenchmarksApp(): JSX.Element {
                         row.scenario === scenario.name && row.implementationId === implementationId
                     );
                     const cellKey = getBenchmarkCellKey(scenario.name, implementationId);
+                    const cellOutcome = cellOutcomes.get(cellKey);
                     const isApplicable = scenario.implementationIds.includes(implementationId);
                     const isBestResult =
                       isScenarioComplete && result?.throughput === bestThroughput;
@@ -306,8 +309,10 @@ export default function ParquetBenchmarksApp(): JSX.Element {
                             {isBestResult ? <span aria-label="Best throughput">🟢 </span> : null}
                             <strong>{result.formattedValue}</strong> rows/s
                           </>
-                        ) : failedCellKeys.has(cellKey) ? (
+                        ) : cellOutcome === 'failed' ? (
                           <span className="parquet-benchmark-failed">Failed</span>
+                        ) : cellOutcome === 'incorrect' ? (
+                          <span className="parquet-benchmark-incorrect">Incorrect</span>
                         ) : !isApplicable ? (
                           <span className="parquet-benchmark-not-applicable">N/A</span>
                         ) : (
@@ -627,9 +632,10 @@ async function addParquetBenchmarksToSuite(
   scenarios: ParquetBenchmarkScenario[],
   implementations: ParquetBenchmarkImplementation[],
   onWarning: (warning: string) => void,
-  onCellFailed: (
+  onCellOutcome: (
     scenario: string,
-    implementationId: ParquetBenchmarkImplementationId
+    implementationId: ParquetBenchmarkImplementationId,
+    outcome: BenchmarkCellOutcome
   ) => void
 ): Promise<void> {
   for (const scenario of scenarios) {
@@ -641,7 +647,7 @@ async function addParquetBenchmarksToSuite(
         scenario,
         scenarioImplementations,
         onWarning,
-        onCellFailed
+        onCellOutcome
       );
       const rowCount = validatedImplementations[0]?.rowCount;
       if (rowCount === undefined) {
@@ -667,7 +673,7 @@ async function addParquetBenchmarksToSuite(
       const message = error instanceof Error ? error.message : String(error);
       onWarning(`${scenario.name}: ${message}`);
       for (const implementationId of scenario.implementationIds) {
-        onCellFailed(scenario.name, implementationId);
+        onCellOutcome(scenario.name, implementationId, 'failed');
       }
     }
   }
@@ -678,9 +684,10 @@ async function validateParquetBenchmarkScenario(
   scenario: ParquetBenchmarkScenario,
   implementations: ParquetBenchmarkImplementation[],
   onWarning: (warning: string) => void,
-  onCellFailed: (
+  onCellOutcome: (
     scenario: string,
-    implementationId: ParquetBenchmarkImplementationId
+    implementationId: ParquetBenchmarkImplementationId,
+    outcome: BenchmarkCellOutcome
   ) => void
 ): Promise<ValidatedParquetBenchmarkImplementation[]> {
   const validatedImplementations: ValidatedParquetBenchmarkImplementation[] = [];
@@ -693,7 +700,7 @@ async function validateParquetBenchmarkScenario(
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       onWarning(`${scenario.name} / ${implementation.name}: ${message}`);
-      onCellFailed(scenario.name, implementation.id);
+      onCellOutcome(scenario.name, implementation.id, 'failed');
     }
   }
   const expectedRowCount = validatedImplementations[0]?.rowCount;
@@ -702,7 +709,7 @@ async function validateParquetBenchmarkScenario(
       onWarning(
         `${scenario.name} / ${implementation.name}: decoded ${rowCount} rows; expected ${expectedRowCount}`
       );
-      onCellFailed(scenario.name, implementation.id);
+      onCellOutcome(scenario.name, implementation.id, 'incorrect');
       return false;
     }
     return true;


### PR DESCRIPTION
## Goals

- Improve sustained TypeScript Parquet-to-Arrow decode throughput and memory behavior on wide, nullable data.
- Preserve exact and conservative predicate behavior before the selective-read and GeoParquet pruning tranches.
- Keep comparative benchmarks demanding, reproducible, and explicit about unsupported, failed, and incorrect results.
- Incorporate the outstanding review findings from #3612, #3614, and #3615.

## Changes

- Decode repetition and definition levels directly into compact Uint8Array, Uint16Array, or Uint32Array storage on the Arrow path while preserving ordinary arrays for object-row compatibility.
- Fill repeated RLE runs in bulk instead of assigning each level individually.
- Add generated 100K-row by 20-column mixed nullable full-table and projection benchmarks.
- Distinguish live benchmark outcomes as N/A, Failed, and Incorrect.
- Compare UTF-8 footer statistics using unsigned UTF-8 byte order and reject incomparable exact predicate values.
- Preserve signed and unsigned INT64 statistics as bigint without safe-integer rounding.
- Clone binary predicates per worker job so transferable buffers cannot detach predicates reused by later row groups.
- Add a dependency-free @loaders.gl/sql/sql-predicate export that does not traverse optional DuckDB adapters, plus the requested parser field TSDoc.

## Representative browser benchmark snapshot

Same local Chromium environment as the pre-change master baseline:

| Scenario | master | this PR | change |
| --- | ---: | ---: | ---: |
| GeoParquet to Arrow | 789K rows/s | 2.06M rows/s | 2.61x |
| PLAIN nullable projection to Arrow | 2.48M | 5.55M | 2.24x |
| RLE_DICTIONARY to Arrow | 2.74M | 4.42M | 1.61x |
| LZ4_RAW to Arrow | 3.57M | 6.72M | 1.88x |
| DELTA_BYTE_ARRAY projection to Arrow | 889K | 1.60M | 1.80x |

New wide case: ParquetJSLoader reaches 1.26M rows/s on 100K rows by 20 mixed nullable columns, versus parquet-wasm at 2.28M and hyparquet at 117K. Its five-column projection reaches 4.77M rows/s versus hyparquet at 1.43M. parquet-wasm 0.7.2 cannot materialize that projected mixed schema and is recorded as N/A rather than silently compared.

These measurements identify direction and bottlenecks; they are not a hardware-independent performance guarantee.

## Validation

- yarn lint fix
- yarn build
- yarn build-workers
- yarn test-audit
- yarn test-node: 190 passed, 6 skipped
- yarn test-headless: 1,982 passed, 50 skipped
- yarn test-headless-cover: 1,982 passed, 50 skipped
- Parquet browser benchmark completed all applicable cases
- website yarn build

Browser coverage for @loaders.gl/parquet remains above its committed ratchets: statements 75.10% / 66%, lines 75.01% / 65%, functions 81.53% / 74%, branches 68.10% / 60%.