### PR TITLE
chore: add SPDX headers to core module

### DIFF
--- a/modules/core/bundle.ts
+++ b/modules/core/bundle.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 // Import from package name instead of relative path
 // This will be resolved to src or dist by esbuild depending on bundle settings
 // dist has TS transformers applied

--- a/modules/core/test/iterators/make-stream.spec.ts
+++ b/modules/core/test/iterators/make-stream.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {expect, test} from 'vitest';
 import {isBrowser, makeStream, makeIterator} from '@loaders.gl/core';
 import {concatenateArrayBuffers, concatenateArrayBuffersAsync} from '@loaders.gl/loader-utils';

--- a/modules/core/test/javascript-utils/text-encoder.spec.ts
+++ b/modules/core/test/javascript-utils/text-encoder.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {expect, test} from 'vitest';
 test('TextEncoder', () => {
   expect(

--- a/modules/core/test/lib/api/create-raster-source.spec.ts
+++ b/modules/core/test/lib/api/create-raster-source.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {expect, test} from 'vitest';
 import {createDataSource} from '@loaders.gl/core';
 import {fetchFile, resolvePath} from '@loaders.gl/core';

--- a/modules/core/test/lib/api/load-in-batches.spec.ts
+++ b/modules/core/test/lib/api/load-in-batches.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {expect, test} from 'vitest';
 import {loadInBatches, fetchFile, isBrowser} from '@loaders.gl/core';
 import {CSVLoader} from '@loaders.gl/csv';

--- a/modules/core/test/lib/api/load.node.spec.ts
+++ b/modules/core/test/lib/api/load.node.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {expect, test} from 'vitest';
 import {load, resolvePath} from '@loaders.gl/core';
 import {JSONLoader} from '@loaders.gl/json';

--- a/modules/core/test/lib/api/load.spec.ts
+++ b/modules/core/test/lib/api/load.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {expect, test} from 'vitest';
 import {parseFromContext} from '@loaders.gl/loader-utils';
 import {

--- a/modules/core/test/lib/api/parse-in-batches.spec.ts
+++ b/modules/core/test/lib/api/parse-in-batches.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {expect, test} from 'vitest';
 import {parseInBatches} from '@loaders.gl/core';
 const NoOpLoader = {

--- a/modules/core/test/lib/api/parse.spec.ts
+++ b/modules/core/test/lib/api/parse.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {test} from 'vitest';
 import {isBrowser, parse} from '@loaders.gl/core';
 import type {LoaderWithParser} from '@loaders.gl/loader-utils';

--- a/modules/core/test/lib/api/preload.spec.ts
+++ b/modules/core/test/lib/api/preload.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {describe, expect, test} from 'vitest';
 import {parse, parseInBatches, parseSync, preload, preloadSync} from '@loaders.gl/core';
 import {CSVLoader as UnbundledCSVLoader} from '@loaders.gl/csv/unbundled';

--- a/modules/core/test/lib/api/register-loaders.spec.ts
+++ b/modules/core/test/lib/api/register-loaders.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {expect, test} from 'vitest';
 import {registerLoaders} from '@loaders.gl/core';
 import {getRegisteredLoaders} from '@loaders.gl/core/lib/api/register-loaders';

--- a/modules/core/test/lib/api/select-loader.spec.ts
+++ b/modules/core/test/lib/api/select-loader.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {expect, test} from 'vitest';
 import {fetchFile, selectLoader, selectLoaderSync, isBrowser} from '@loaders.gl/core';
 import {ImageLoader} from '@loaders.gl/images';

--- a/modules/core/test/lib/api/set-loader-options.spec.ts
+++ b/modules/core/test/lib/api/set-loader-options.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {expect, test} from 'vitest';
 import {setLoaderOptions, getLoaderOptions} from '@loaders.gl/core';
 test('setLoaderOptions', () => {

--- a/modules/core/test/lib/api/source-loader.spec.ts
+++ b/modules/core/test/lib/api/source-loader.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {expect, test} from 'vitest';
 import {createDataSource, fetchFile, load, parse, resolvePath} from '@loaders.gl/core';
 import {

--- a/modules/core/test/lib/fetch/fetch-error-message.spec.ts
+++ b/modules/core/test/lib/fetch/fetch-error-message.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {expect, test} from 'vitest';
 import {
   getErrorMessageFromResponseSync,

--- a/modules/core/test/lib/fetch/fetch-file.browser.spec.ts
+++ b/modules/core/test/lib/fetch/fetch-file.browser.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {expect, test} from 'vitest';
 import {fetchFile} from '@loaders.gl/core';
 

--- a/modules/core/test/lib/fetch/fetch-file.node.external.spec.ts
+++ b/modules/core/test/lib/fetch/fetch-file.node.external.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {expect, test} from 'vitest';
 import {fetchFile} from '@loaders.gl/core';
 

--- a/modules/core/test/lib/fetch/fetch-file.spec.ts
+++ b/modules/core/test/lib/fetch/fetch-file.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {expect, test} from 'vitest';
 import {isBrowser, fetchFile} from '@loaders.gl/core';
 

--- a/modules/core/test/lib/filesystems/browser-filesystem.browser.spec.ts
+++ b/modules/core/test/lib/filesystems/browser-filesystem.browser.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {expect, test} from 'vitest';
 import {fetchFile, _BrowserFileSystem as BrowserFileSystem} from '@loaders.gl/core';
 

--- a/modules/core/test/lib/init.spec.ts
+++ b/modules/core/test/lib/init.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {test} from 'vitest';
 // import {isBrowser} from '@loaders.gl/core';
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.

--- a/modules/core/test/lib/loader-utils/auto-parse.spec.ts
+++ b/modules/core/test/lib/loader-utils/auto-parse.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {expect, test} from 'vitest';
 import {load} from '@loaders.gl/core';
 import {OBJLoader} from '@loaders.gl/obj';

--- a/modules/core/test/lib/loader-utils/core-loader-options.spec.ts
+++ b/modules/core/test/lib/loader-utils/core-loader-options.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {expect, test} from 'vitest';
 import {
   getGlobalLoaderOptions,

--- a/modules/core/test/lib/loader-utils/format-exports.node.spec.ts
+++ b/modules/core/test/lib/loader-utils/format-exports.node.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {describe, expect, test} from 'vitest';
 import {readFileSync} from 'node:fs';
 import {join} from 'node:path';

--- a/modules/core/test/lib/loader-utils/format-metadata.spec.ts
+++ b/modules/core/test/lib/loader-utils/format-metadata.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {expect, test} from 'vitest';
 
 import {Tiles3DFormat, Tile3DSubtreeFormat, ThreeTZFormat} from '@loaders.gl/3d-tiles';

--- a/modules/core/test/lib/loader-utils/get-data.spec.ts
+++ b/modules/core/test/lib/loader-utils/get-data.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {expect, test} from 'vitest';
 import {
   getArrayBufferOrStringFromDataSync,

--- a/modules/core/test/lib/loader-utils/loggers.spec.ts
+++ b/modules/core/test/lib/loader-utils/loggers.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {expect, test} from 'vitest';
 import {NullLog, ConsoleLog} from '@loaders.gl/core/lib/loader-utils/loggers';
 

--- a/modules/core/test/lib/loader-utils/normalize-loader.spec.ts
+++ b/modules/core/test/lib/loader-utils/normalize-loader.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {expect, test} from 'vitest';
 import {isLoaderObject, normalizeLoader} from '@loaders.gl/core/lib/loader-utils/normalize-loader';
 import * as threeDTiles from '@loaders.gl/3d-tiles';

--- a/modules/core/test/lib/loader-utils/option-utils.spec.ts
+++ b/modules/core/test/lib/loader-utils/option-utils.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {expect, test} from 'vitest';
 import {
   getGlobalLoaderOptions,

--- a/modules/core/test/lib/progress/fetch-progress.spec.ts
+++ b/modules/core/test/lib/progress/fetch-progress.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {expect, test} from 'vitest';
 import {fetchFile, _fetchProgress} from '@loaders.gl/core';
 const PROGRESS_IMAGE_URL = '@loaders.gl/images/test/data/img1-preview.jpeg';

--- a/modules/core/test/lib/utils/mime-type-utils.spec.ts
+++ b/modules/core/test/lib/utils/mime-type-utils.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {expect, test} from 'vitest';
 import {
   parseMIMEType,

--- a/modules/core/test/lib/utils/resource-utils.spec.ts
+++ b/modules/core/test/lib/utils/resource-utils.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {expect, test} from 'vitest';
 import {isBrowser} from '@loaders.gl/core';
 import {

--- a/modules/core/test/lib/utils/response-utils.spec.ts
+++ b/modules/core/test/lib/utils/response-utils.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {expect, test} from 'vitest';
 import {isBrowser} from '@loaders.gl/core';
 import {

--- a/modules/core/test/lib/utils/url-utils.spec.ts
+++ b/modules/core/test/lib/utils/url-utils.spec.ts
@@ -1,3 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
 import {expect, test} from 'vitest';
 import {shortenUrlForDisplay} from '@loaders.gl/core/lib/utils/url-utils';
 test('shortenUrlForDisplay', async () => {


### PR DESCRIPTION
## Goal

Continue #2830 by completing the SPDX license audit for the Core module.

## Changes

- add MIT SPDX headers to all 33 previously uncovered tracked TypeScript files in `modules/core`
- cover the bundle entry and 32 Core test files
- preserve the existing file contents and behavior; this is a header-only change
- confirm the affected files contain no third-party attribution or non-MIT licensing markers

## Validation

- `yarn install`
- `yarn lint fix`
- `yarn build`
- `yarn build-workers`
- `yarn test-node` — 28 files passed; 190 tests passed, 6 skipped
- `yarn test-headless` — 377 files passed, 2 skipped; 1,978 tests passed, 50 skipped