### PR TITLE
feat(parquet): prune selective reads with page indexes

### DIFF
--- a/docs/modules/parquet/api-reference/parquet-source-loader.md
+++ b/docs/modules/parquet/api-reference/parquet-source-loader.md
@@ -76,8 +76,8 @@ Returns cached plain JavaScript metadata copied from the Parquet footer:
 - file byte length, format version, writer, and row count;
 - key/value footer metadata;
 - row counts, absolute row offsets, and compressed/uncompressed byte lengths for each row group;
-- column path, compression, encodings, value count, physical range, byte lengths, and page offsets
-  for each column chunk;
+- column path, compression, encodings, value count, physical range, byte lengths, data/dictionary
+  page offsets, and optional column/offset index ranges for each column chunk;
 - decoded minimum, maximum, null-count, distinct-count, and bound-exactness statistics when
   supplied by the writer;
   and
@@ -121,7 +121,7 @@ version validation.
 Rows fall back to caller-thread decoding when workers are disabled or unavailable. Nested columns
 retain their composite values while primitive and logical columns flow through the columnar path.
 
-### Predicate filtering and row-group pruning
+### Predicate filtering and page pruning
 
 Use the serializable `predicate` option for exact row filtering. Its experimental `op`/`args`
 expression shape is directionally aligned with
@@ -133,8 +133,14 @@ but they are omitted from Arrow output unless they also appear in `columns`.
 
 Before fetching column chunks, the source conservatively applies the predicate to footer min, max,
 and null-count statistics. A row group is pruned only when those statistics prove that it cannot
-contain a match. Missing, malformed, or insufficient statistics retain the row group. Every row in
-the surviving groups is then evaluated exactly on the caller thread or worker, so statistics can
+contain a match.
+
+For flat primitive columns, the source then reads available Parquet column indexes and offset
+indexes. Per-page min/max/null statistics produce candidate row ranges, and page locations turn
+those ranges into actual byte reads for projected and hidden filter columns. Candidate ranges are
+expanded when columns have different page boundaries, preventing duplicate or misaligned rows.
+Missing, malformed, nested, or insufficient indexes fall back to complete selected column chunks.
+Every candidate row is still evaluated exactly on the caller thread or worker, so page pruning can
 only improve I/O and cannot change query results.
 
 ```typescript
@@ -189,7 +195,8 @@ console.log(source.getTelemetry());
 ```
 
 The frozen snapshot reports exact transport counts and bytes, range-cache hits, cumulative
-network/decode/Arrow durations, candidate/pruned/decoded row groups, statistics-pruned groups,
+network/decode/Arrow durations, candidate/pruned/decoded row groups, statistics- and page-index-
+pruned groups, index blobs read, data pages read/pruned, rows eliminated before page reads,
 predicate rows tested/matched, emitted batches and rows, retries, cancellations, and failures.
 `retryCount` remains zero while the source uses its fail-fast range policy.
 
@@ -198,8 +205,8 @@ predicate rows tested/matched, emitted batches and rows, retries, cancellations,
 The source exposes the frozen `PARQUET_SOURCE_CAPABILITIES` descriptor synchronously, before any
 network or decoding work starts. It reports support for cached immutable metadata, row-group and
 column selection, provenance, cancellation, custom range transport, object-version validation,
-statistics-driven predicate pushdown, exact predicate filtering, transport/decode telemetry,
-package-local assets, and worker-backed selective decoding.
+statistics-driven row-group and page-index predicate pushdown, exact predicate filtering,
+transport/decode telemetry, package-local assets, and worker-backed selective decoding.
 
 ### `close(): Promise<void>`
 
@@ -247,5 +254,6 @@ serve the package's WASM loader and writer paths.
 - Range fetching remains on the caller thread so custom fetch implementations and authenticated,
   version-pinned requests do not cross the worker boundary.
 - Node.js decodes on the caller thread; the package only prebuilds the browser source worker.
-- Predicate pushdown currently uses row-group footer statistics. Page-index and Bloom-filter range
-  planning remain future work.
+- Page-index range planning currently requires independently materializable flat primitive columns;
+  nested or repeated selections conservatively use complete selected column chunks.
+- Bloom-filter range planning remains future work.

--- a/docs/modules/parquet/formats/parquet.md
+++ b/docs/modules/parquet/formats/parquet.md
@@ -234,17 +234,17 @@ can make selective reads much cheaper.
 | Row-group and column-chunk offsets | ✅ | ✅ | Drive byte-range projection and row-group selection |
 | Column-chunk min/max/null/distinct statistics | ✅ | ❌ | Drive conservative `ParquetSource` predicate pushdown and remain exposed in metadata |
 | Page statistics in page headers | ⚠️ | ❌ | Thrift fields are decoded but not exposed as a pruning API |
-| Column index | ❌ | ❌ | Page-level min/max/null pruning is a roadmap item |
-| Offset index | ❌ | ❌ | Page locations and first-row indexes are not yet used for range planning |
+| Column index | ✅ | ❌ | Flat-column predicates use page min/max/null statistics to derive candidate row ranges |
+| Offset index | ✅ | ❌ | Flat selected columns use page locations and first-row indexes for selective byte reads |
 | Bloom filters | ❌ | ❌ | Split-block Bloom filter lookup and writing are roadmap items |
 | Size statistics | ❌ | ❌ | Histogram metadata from newer format versions is not yet exposed |
 | Column order and sorting columns | ⚠️ | ❌ | Raw footer metadata is retained; semantic pruning is not yet applied |
 
 `ParquetSourceLoader` accepts serializable logical predicates, prunes impossible row groups using
-footer statistics, and exactly filters surviving rows on the caller thread or worker. Filter-only
-columns are not returned in the projected Arrow schema. Pruning currently stops at row-group
-granularity; page indexes and Bloom filters are the main remaining steps toward more precise range
-reads.
+footer statistics, and uses column/offset indexes to avoid irrelevant data pages for flat primitive
+columns. Filter-only columns are not returned in the projected Arrow schema. Candidate rows are
+still filtered exactly on the caller thread or worker. Nested/repeated page planning and Bloom
+filters remain the main steps toward broader page-level pruning.
 
 ## Integrity and Encryption
 
@@ -277,7 +277,7 @@ corpora run in the slow lane.
 The TypeScript implementation is aiming for complete stable-format read support. The largest known
 gaps are currently:
 
-1. page-index and Bloom-filter reads for page-level predicate pruning;
+1. split-block Bloom-filter reads and nested/repeated page-index planning;
 2. complete high-level nested-schema writing;
 3. Variant value decoding and shredding;
 4. page CRC verification and emission;

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -116,6 +116,7 @@ Release Date: 2026
 
 - [`ParquetSourceLoader`](/docs/modules/parquet/api-reference/parquet-source-loader) NEW - adds reusable range-backed Parquet metadata and selective row-group/column reads as cancellable Arrow batches with source provenance and object-version validation. Its lightweight root export dynamically preloads the runtime implementation.
 - `ParquetSourceLoader` exposes normalized column-chunk statistics, predicate-based row-group pruning, and cumulative transport/decode/Arrow telemetry with exact request and byte counts.
+- `ParquetSourceLoader` reads column and offset indexes for flat primitive selections, converts page statistics into candidate row ranges, and fetches only the required data-page ranges before exact filtering on the caller thread or worker.
 - `ParquetSourceLoader` now publishes an immutable capability descriptor, deep-freezes cached schema metadata and batch provenance, and preserves caller abort reasons.
 - `ParquetSourceLoader` now materializes selected columns directly into Arrow batches without an intermediate object-row table.
 - `ParquetJSLoader` now constructs flat Arrow Utf8 and Binary vectors directly from decoded Parquet byte arrays, avoiding decode-to-string, re-encode, and intermediate per-value copies.

--- a/modules/parquet/src/lib/parquet-page-index.ts
+++ b/modules/parquet/src/lib/parquet-page-index.ts
@@ -1,0 +1,571 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {ReadableFile} from '@loaders.gl/loader-utils';
+
+import type {
+  ParquetComparisonPredicate,
+  ParquetInPredicate,
+  ParquetNullPredicate,
+  ParquetPredicate
+} from '../parquet-source-types';
+import {
+  ColumnIndex,
+  Encoding,
+  OffsetIndex,
+  type ColumnChunk,
+  type RowGroup
+} from '../parquetjs/parquet-thrift/index';
+import type {ParquetField} from '../parquetjs/schema/declare';
+import type {ParquetSchema} from '../parquetjs/schema/schema';
+import * as Types from '../parquetjs/schema/types';
+import {
+  copyUint8Array,
+  readDoubleLE,
+  readFloatLE,
+  readInt32LE,
+  readInt64LE,
+  toUint8Array
+} from '../parquetjs/utils/binary-utils';
+import {Uint8ArrayCompactProtocol} from '../parquetjs/utils/uint8-array-compact-protocol';
+import {Uint8ArrayTransport} from '../parquetjs/utils/uint8-array-transport';
+import {canParquetStatisticsMatch, getParquetPredicateColumns} from './parquet-predicate';
+
+/** Half-open logical row range relative to one Parquet row group. */
+export type ParquetRowRange = {
+  /** First included row. */
+  start: number;
+  /** First excluded row. */
+  end: number;
+};
+
+/** One data-page location decoded from a Parquet offset index. */
+export type ParquetDataPageLocation = {
+  /** Absolute page-header offset in the source object. */
+  offset: number;
+  /** Page header plus compressed body byte length. */
+  compressedByteLength: number;
+  /** First logical row represented by the page. */
+  firstRowIndex: number;
+  /** First logical row represented by the next page. */
+  endRowIndex: number;
+};
+
+/** Page locations keyed by the physical Parquet column path. */
+export type ParquetPageLocations = Record<string, ParquetDataPageLocation[]>;
+
+/** Selective page plan for one row group. */
+export type ParquetPagePruningPlan = {
+  /** Candidate row ranges after conservative page-statistics pruning. */
+  rowRanges: ParquetRowRange[];
+  /** Offset-index page locations for every decoded column. */
+  pageLocations: ParquetPageLocations;
+  /** Number of column and offset index blobs decoded. */
+  indexCount: number;
+  /** Data pages in all decoded column chunks. */
+  totalPageCount: number;
+  /** Data pages required by the candidate ranges. */
+  selectedPageCount: number;
+  /** Logical rows eliminated before data-page reads. */
+  prunedRowCount: number;
+};
+
+type ParquetPageStatistics = {
+  min?: unknown;
+  max?: unknown;
+  nullCount?: number;
+  minIsExact?: boolean;
+  maxIsExact?: boolean;
+};
+
+type ParquetColumnPageStatistics = {
+  pages: ParquetDataPageLocation[];
+  statistics: ParquetPageStatistics[];
+};
+
+/**
+ * Builds a conservative selective-page plan from Parquet column and offset indexes.
+ *
+ * Returns `undefined` when indexes or the current flat-column decoder cannot safely avoid full
+ * column-chunk reads. An empty `rowRanges` array means the indexes prove the predicate cannot match.
+ */
+export async function createParquetPagePruningPlan(
+  file: ReadableFile,
+  rowGroup: RowGroup,
+  schema: ParquetSchema,
+  selectedColumnPaths: readonly string[][],
+  predicate: ParquetPredicate,
+  signal?: AbortSignal
+): Promise<ParquetPagePruningPlan | undefined> {
+  const rowCount = Number(rowGroup.num_rows);
+  const selectedColumnChunks = getSelectedColumnChunks(rowGroup, selectedColumnPaths);
+  if (!isSafeFlatPageSelection(schema, selectedColumnChunks) || rowCount <= 0) {
+    return undefined;
+  }
+
+  const pageLocations: ParquetPageLocations = {};
+  const pageStatistics: Record<string, ParquetColumnPageStatistics> = {};
+  const predicateColumns = new Set(getParquetPredicateColumns(predicate));
+  let indexCount = 0;
+
+  await Promise.all(
+    selectedColumnChunks.map(async columnChunk => {
+      const path = columnChunk.meta_data!.path_in_schema;
+      const pathKey = path.join('.');
+      const offsetIndexRange = getIndexRange(
+        columnChunk.offset_index_offset,
+        columnChunk.offset_index_length
+      );
+      if (!offsetIndexRange) {
+        return;
+      }
+      const offsetIndexBytes = await file.read(
+        offsetIndexRange.offset,
+        offsetIndexRange.length,
+        signal
+      );
+      let pages: ParquetDataPageLocation[];
+      try {
+        pages = decodeOffsetIndex(toUint8Array(offsetIndexBytes), rowCount);
+      } catch {
+        return;
+      }
+      pageLocations[pathKey] = pages;
+      indexCount++;
+
+      if (path.length !== 1 || !predicateColumns.has(path[0])) {
+        return;
+      }
+      const columnIndexRange = getIndexRange(
+        columnChunk.column_index_offset,
+        columnChunk.column_index_length
+      );
+      if (!columnIndexRange) {
+        return;
+      }
+      const columnIndexBytes = await file.read(
+        columnIndexRange.offset,
+        columnIndexRange.length,
+        signal
+      );
+      const field = schema.findField(path);
+      try {
+        pageStatistics[path[0]] = {
+          pages,
+          statistics: decodeColumnIndex(toUint8Array(columnIndexBytes), pages, field)
+        };
+      } catch {
+        return;
+      }
+      indexCount++;
+    })
+  );
+
+  if (
+    selectedColumnChunks.some(
+      columnChunk => !pageLocations[columnChunk.meta_data!.path_in_schema.join('.')]
+    )
+  ) {
+    return undefined;
+  }
+
+  const candidateRanges = getPredicateRowRanges(predicate, pageStatistics, rowCount);
+  if (candidateRanges === undefined) {
+    return undefined;
+  }
+  const rowRanges = expandAndMergeRowRanges(candidateRanges, pageLocations, rowCount);
+  const prunedRowCount = rowCount - getRowRangeCount(rowRanges);
+  if (prunedRowCount <= 0) {
+    return undefined;
+  }
+
+  const totalPageCount = Object.values(pageLocations).reduce(
+    (count, pages) => count + pages.length,
+    0
+  );
+  const selectedPageCount = Object.values(pageLocations).reduce(
+    (count, pages) => count + countSelectedPages(pages, rowRanges),
+    0
+  );
+  return {
+    rowRanges,
+    pageLocations,
+    indexCount,
+    totalPageCount,
+    selectedPageCount,
+    prunedRowCount
+  };
+}
+
+/** Returns data-page byte ranges needed to decode a selective row-group plan. */
+export function getParquetPageReadRanges(
+  rowGroup: RowGroup,
+  selectedColumnPaths: readonly string[][],
+  plan: ParquetPagePruningPlan
+): Array<{offset: number; length: number}> {
+  const ranges: Array<{offset: number; length: number}> = [];
+  for (const columnChunk of getSelectedColumnChunks(rowGroup, selectedColumnPaths)) {
+    const columnMetadata = columnChunk.meta_data!;
+    const pages = plan.pageLocations[columnMetadata.path_in_schema.join('.')];
+    const selectedPages = pages.filter(page =>
+      plan.rowRanges.some(range => page.endRowIndex > range.start && page.firstRowIndex < range.end)
+    );
+    if (!selectedPages.length) {
+      continue;
+    }
+    const dictionaryPageOffset = Number(columnMetadata.dictionary_page_offset);
+    if (Number.isSafeInteger(dictionaryPageOffset) && dictionaryPageOffset > 0) {
+      ranges.push({
+        offset: dictionaryPageOffset,
+        length: Math.max(0, pages[0].offset - dictionaryPageOffset)
+      });
+    }
+    for (const rowRange of plan.rowRanges) {
+      const overlappingPages = pages.filter(
+        page => page.endRowIndex > rowRange.start && page.firstRowIndex < rowRange.end
+      );
+      if (!overlappingPages.length) {
+        continue;
+      }
+      const firstPage = overlappingPages[0];
+      const lastPage = overlappingPages[overlappingPages.length - 1];
+      ranges.push({
+        offset: firstPage.offset,
+        length: lastPage.offset + lastPage.compressedByteLength - firstPage.offset
+      });
+    }
+  }
+  return mergeByteRanges(ranges.filter(range => range.length > 0));
+}
+
+/** Decodes one compact-protocol Parquet offset index. */
+export function decodeOffsetIndex(bytes: Uint8Array, rowCount: number): ParquetDataPageLocation[] {
+  const protocol = new Uint8ArrayCompactProtocol(new Uint8ArrayTransport(bytes));
+  const offsetIndex = OffsetIndex.read(protocol as any);
+  if (
+    offsetIndex.page_locations.length === 0 ||
+    Number(offsetIndex.page_locations[0].first_row_index) !== 0
+  ) {
+    throw new Error('Invalid Parquet offset index page locations');
+  }
+  return offsetIndex.page_locations.map((location, index, locations) => {
+    const firstRowIndex = Number(location.first_row_index);
+    const endRowIndex =
+      index + 1 < locations.length ? Number(locations[index + 1].first_row_index) : rowCount;
+    const offset = Number(location.offset);
+    const compressedByteLength = location.compressed_page_size;
+    if (
+      !Number.isSafeInteger(offset) ||
+      !Number.isSafeInteger(compressedByteLength) ||
+      !Number.isSafeInteger(firstRowIndex) ||
+      !Number.isSafeInteger(endRowIndex) ||
+      offset < 0 ||
+      compressedByteLength <= 0 ||
+      firstRowIndex < 0 ||
+      endRowIndex <= firstRowIndex ||
+      endRowIndex > rowCount
+    ) {
+      throw new Error('Invalid Parquet offset index page location');
+    }
+    return {offset, compressedByteLength, firstRowIndex, endRowIndex};
+  });
+}
+
+/** Returns whether one predicate leaf can match supplied page statistics. */
+function getPredicateRowRanges(
+  predicate: ParquetPredicate,
+  columns: Record<string, ParquetColumnPageStatistics>,
+  rowCount: number
+): ParquetRowRange[] | undefined {
+  if (predicate.op === 'and' || predicate.op === 'or') {
+    if (predicate.op === 'and') {
+      let ranges: ParquetRowRange[] | undefined;
+      for (const child of predicate.args) {
+        ranges = intersectRowRanges(ranges, getPredicateRowRanges(child, columns, rowCount));
+      }
+      return ranges;
+    }
+    let ranges: ParquetRowRange[] = [];
+    for (const child of predicate.args) {
+      const childRanges = getPredicateRowRanges(child, columns, rowCount);
+      if (childRanges === undefined) {
+        return undefined;
+      }
+      ranges = unionRowRanges(ranges, childRanges);
+    }
+    return ranges;
+  }
+  if (predicate.op === 'not') {
+    return undefined;
+  }
+
+  const leafPredicate = predicate as
+    | ParquetComparisonPredicate
+    | ParquetInPredicate
+    | ParquetNullPredicate;
+  const column = columns[leafPredicate.args[0].property];
+  if (!column) {
+    return undefined;
+  }
+  const ranges: ParquetRowRange[] = [];
+  for (let pageIndex = 0; pageIndex < column.pages.length; pageIndex++) {
+    const page = column.pages[pageIndex];
+    if (
+      canParquetStatisticsMatch(
+        leafPredicate,
+        column.statistics[pageIndex],
+        page.endRowIndex - page.firstRowIndex
+      )
+    ) {
+      ranges.push({start: page.firstRowIndex, end: page.endRowIndex});
+    }
+  }
+  return mergeRowRanges(ranges);
+}
+
+/** Decodes column-index values into the logical representation used by exact predicates. */
+function decodeColumnIndex(
+  bytes: Uint8Array,
+  pages: readonly ParquetDataPageLocation[],
+  field: ParquetField
+): ParquetPageStatistics[] {
+  const protocol = new Uint8ArrayCompactProtocol(new Uint8ArrayTransport(bytes));
+  const columnIndex = ColumnIndex.read(protocol as any);
+  if (
+    columnIndex.null_pages.length !== pages.length ||
+    columnIndex.min_values.length !== pages.length ||
+    columnIndex.max_values.length !== pages.length ||
+    (columnIndex.null_counts !== undefined && columnIndex.null_counts.length !== pages.length)
+  ) {
+    throw new Error('Parquet column and offset indexes contain different page counts');
+  }
+  return pages.map((_page, pageIndex) => ({
+    min: columnIndex.null_pages[pageIndex]
+      ? undefined
+      : decodeStatisticsValue(columnIndex.min_values[pageIndex], field),
+    max: columnIndex.null_pages[pageIndex]
+      ? undefined
+      : decodeStatisticsValue(columnIndex.max_values[pageIndex], field),
+    nullCount:
+      columnIndex.null_counts?.[pageIndex] !== undefined
+        ? Number(columnIndex.null_counts[pageIndex])
+        : columnIndex.null_pages[pageIndex]
+          ? pages[pageIndex].endRowIndex - pages[pageIndex].firstRowIndex
+          : undefined,
+    minIsExact: true,
+    maxIsExact: true
+  }));
+}
+
+/** Decodes one physical statistics value and applies its Parquet logical annotation. */
+function decodeStatisticsValue(bytes: Uint8Array, field: ParquetField): unknown {
+  let primitiveValue: unknown;
+  switch (field.primitiveType) {
+    case 'BOOLEAN':
+      primitiveValue = Boolean(bytes[0]);
+      break;
+    case 'INT32':
+      primitiveValue = readInt32LE(bytes, 0);
+      break;
+    case 'INT64':
+      primitiveValue = readInt64LE(bytes, 0);
+      break;
+    case 'FLOAT':
+      primitiveValue = readFloatLE(bytes, 0);
+      break;
+    case 'DOUBLE':
+      primitiveValue = readDoubleLE(bytes, 0);
+      break;
+    case 'INT96':
+    case 'BYTE_ARRAY':
+    case 'FIXED_LEN_BYTE_ARRAY':
+      primitiveValue = copyUint8Array(bytes);
+      break;
+    default:
+      return undefined;
+  }
+  return Types.fromPrimitive(field.originalType || field.primitiveType, primitiveValue, field);
+}
+
+/** Returns selected physical chunks, using an empty path list as the all-column sentinel. */
+function getSelectedColumnChunks(
+  rowGroup: RowGroup,
+  selectedColumnPaths: readonly string[][]
+): ColumnChunk[] {
+  return rowGroup.columns.filter(columnChunk => {
+    const path = columnChunk.meta_data?.path_in_schema;
+    return Boolean(
+      path &&
+        (selectedColumnPaths.length === 0 ||
+          selectedColumnPaths.some(selectedPath => selectedPath[0] === path[0]))
+    );
+  });
+}
+
+/** Restricts selective page reads to independently materializable flat primitive columns. */
+function isSafeFlatPageSelection(
+  schema: ParquetSchema,
+  columnChunks: readonly ColumnChunk[]
+): boolean {
+  return (
+    columnChunks.length > 0 &&
+    columnChunks.every(columnChunk => {
+      const path = columnChunk.meta_data?.path_in_schema;
+      if (!path || path.length !== 1) {
+        return false;
+      }
+      const field = schema.findField(path);
+      const dictionaryEncoded = columnChunk.meta_data!.encodings.some(
+        encoding => encoding === Encoding.PLAIN_DICTIONARY || encoding === Encoding.RLE_DICTIONARY
+      );
+      const dictionaryPageOffset = Number(columnChunk.meta_data!.dictionary_page_offset);
+      return (
+        field.path.length === 1 &&
+        field.repetitionType !== 'REPEATED' &&
+        field.rLevelMax === 0 &&
+        (!dictionaryEncoded ||
+          (Number.isSafeInteger(dictionaryPageOffset) && dictionaryPageOffset > 0))
+      );
+    })
+  );
+}
+
+/** Validates one optional footer index byte range. */
+function getIndexRange(
+  offsetValue: ColumnChunk['offset_index_offset'],
+  lengthValue: number | undefined
+): {offset: number; length: number} | undefined {
+  if (offsetValue === undefined || lengthValue === undefined) {
+    return undefined;
+  }
+  const offset = Number(offsetValue);
+  if (
+    !Number.isSafeInteger(offset) ||
+    !Number.isSafeInteger(lengthValue) ||
+    offset < 0 ||
+    lengthValue <= 0
+  ) {
+    return undefined;
+  }
+  return {offset, length: lengthValue};
+}
+
+/** Expands ranges to selected-column page boundaries until all columns agree, then merges them. */
+function expandAndMergeRowRanges(
+  ranges: readonly ParquetRowRange[],
+  pageLocations: ParquetPageLocations,
+  rowCount: number
+): ParquetRowRange[] {
+  const pagesByColumn = Object.values(pageLocations);
+  const expanded = ranges.map(range => {
+    let current = {...range};
+    let changed = true;
+    while (changed) {
+      changed = false;
+      for (const pages of pagesByColumn) {
+        const overlapping = pages.filter(
+          page => page.endRowIndex > current.start && page.firstRowIndex < current.end
+        );
+        if (!overlapping.length) {
+          continue;
+        }
+        const start = Math.min(current.start, overlapping[0].firstRowIndex);
+        const end = Math.max(current.end, overlapping[overlapping.length - 1].endRowIndex);
+        if (start !== current.start || end !== current.end) {
+          current = {start, end};
+          changed = true;
+        }
+      }
+    }
+    return {start: Math.max(0, current.start), end: Math.min(rowCount, current.end)};
+  });
+  return mergeRowRanges(expanded);
+}
+
+/** Intersects sorted row ranges; `undefined` represents every row. */
+function intersectRowRanges(
+  left: ParquetRowRange[] | undefined,
+  right: ParquetRowRange[] | undefined
+): ParquetRowRange[] | undefined {
+  if (left === undefined) {
+    return right;
+  }
+  if (right === undefined) {
+    return left;
+  }
+  const ranges: ParquetRowRange[] = [];
+  let leftIndex = 0;
+  let rightIndex = 0;
+  while (leftIndex < left.length && rightIndex < right.length) {
+    const start = Math.max(left[leftIndex].start, right[rightIndex].start);
+    const end = Math.min(left[leftIndex].end, right[rightIndex].end);
+    if (start < end) {
+      ranges.push({start, end});
+    }
+    if (left[leftIndex].end < right[rightIndex].end) {
+      leftIndex++;
+    } else {
+      rightIndex++;
+    }
+  }
+  return ranges;
+}
+
+/** Unions two sorted row-range sets. */
+function unionRowRanges(
+  left: readonly ParquetRowRange[],
+  right: readonly ParquetRowRange[]
+): ParquetRowRange[] {
+  return mergeRowRanges([...left, ...right]);
+}
+
+/** Sorts and merges overlapping or touching logical row ranges. */
+function mergeRowRanges(ranges: readonly ParquetRowRange[]): ParquetRowRange[] {
+  const sorted = [...ranges].sort(
+    (left, right) => left.start - right.start || left.end - right.end
+  );
+  const merged: ParquetRowRange[] = [];
+  for (const range of sorted) {
+    const previous = merged[merged.length - 1];
+    if (previous && range.start <= previous.end) {
+      previous.end = Math.max(previous.end, range.end);
+    } else {
+      merged.push({...range});
+    }
+  }
+  return merged;
+}
+
+/** Counts logical rows represented by disjoint ranges. */
+function getRowRangeCount(ranges: readonly ParquetRowRange[]): number {
+  return ranges.reduce((count, range) => count + range.end - range.start, 0);
+}
+
+/** Counts unique pages overlapping at least one selected row range. */
+function countSelectedPages(
+  pages: readonly ParquetDataPageLocation[],
+  ranges: readonly ParquetRowRange[]
+): number {
+  return pages.filter(page =>
+    ranges.some(range => page.endRowIndex > range.start && page.firstRowIndex < range.end)
+  ).length;
+}
+
+/** Sorts and merges overlapping or touching byte ranges without overfetch gaps. */
+function mergeByteRanges(
+  ranges: readonly {offset: number; length: number}[]
+): Array<{offset: number; length: number}> {
+  const sorted = [...ranges].sort((left, right) => left.offset - right.offset);
+  const merged: Array<{offset: number; length: number}> = [];
+  for (const range of sorted) {
+    const previous = merged[merged.length - 1];
+    const end = range.offset + range.length;
+    if (previous && range.offset <= previous.offset + previous.length) {
+      previous.length = Math.max(previous.offset + previous.length, end) - previous.offset;
+    } else {
+      merged.push({...range});
+    }
+  }
+  return merged;
+}

--- a/modules/parquet/src/lib/parquet-predicate.ts
+++ b/modules/parquet/src/lib/parquet-predicate.ts
@@ -5,8 +5,12 @@
 import type {ArrayType} from '@loaders.gl/schema';
 
 import type {
+  ParquetColumnChunkStatistics,
+  ParquetComparisonPredicate,
+  ParquetInPredicate,
   ParquetLogicalPredicate,
   ParquetNotPredicate,
+  ParquetNullPredicate,
   ParquetPredicate,
   ParquetPredicateValue,
   ParquetRowGroupMetadata
@@ -104,28 +108,27 @@ export function canParquetRowGroupMatch(
   if (!statistics) {
     return true;
   }
-  if (statistics.nullCount === rowGroup.rowCount) {
+  return canParquetStatisticsMatch(predicate, statistics, rowGroup.rowCount);
+}
+
+/** Conservatively determines whether one predicate leaf can match supplied statistics. */
+export function canParquetStatisticsMatch(
+  predicate: ParquetComparisonPredicate | ParquetInPredicate | ParquetNullPredicate,
+  statistics: ParquetColumnChunkStatistics,
+  rowCount: number
+): boolean {
+  if (statistics.nullCount === rowCount) {
     return predicate.op === 'isNull';
   }
   if (predicate.op === 'isNull') {
     return statistics.nullCount !== 0;
   }
+  const minimum = statistics.minIsExact === false ? undefined : statistics.min;
+  const maximum = statistics.maxIsExact === false ? undefined : statistics.max;
   if (predicate.op === 'in') {
-    return predicate.args[1].some(value =>
-      canComparisonMatch(
-        '=',
-        value,
-        statistics.minIsExact === false ? undefined : statistics.min,
-        statistics.maxIsExact === false ? undefined : statistics.max
-      )
-    );
+    return predicate.args[1].some(value => canComparisonMatch('=', value, minimum, maximum));
   }
-  return canComparisonMatch(
-    predicate.op,
-    predicate.args[1],
-    statistics.minIsExact === false ? undefined : statistics.min,
-    statistics.maxIsExact === false ? undefined : statistics.max
-  );
+  return canComparisonMatch(predicate.op, predicate.args[1], minimum, maximum);
 }
 
 /** Returns exact source row indexes matching a predicate. */

--- a/modules/parquet/src/lib/parquet-source-worker-decoder.ts
+++ b/modules/parquet/src/lib/parquet-source-worker-decoder.ts
@@ -29,17 +29,32 @@ export async function decodeParquetSourceWorkerInput(
   const rowGroup = createWorkerRowGroup(input);
 
   const decodeStartTime = getCurrentTime();
-  const decodedRowGroup = await reader.readRowGroup(schema, rowGroup, []);
-  const columns = schema.materializeColumns(decodedRowGroup);
-  const rowIndices = input.predicate
-    ? filterParquetRowIndices(input.predicate, columns, input.rowCount)
+  const decodedRowGroups = input.pagePlan
+    ? await Promise.all(
+        input.pagePlan.rowRanges.map(rowRange =>
+          reader.readRowGroupRange(schema, rowGroup, [], rowRange, input.pagePlan!.pageLocations)
+        )
+      )
+    : [await reader.readRowGroup(schema, rowGroup, [])];
+  const columns = concatenateMaterializedColumns(
+    decodedRowGroups.map(decodedRowGroup => schema.materializeColumns(decodedRowGroup))
+  );
+  const sourceRowIndices = input.pagePlan
+    ? input.pagePlan.rowRanges.flatMap(rowRange =>
+        Array.from({length: rowRange.end - rowRange.start}, (_, index) => rowRange.start + index)
+      )
     : undefined;
+  const sourceRowCount = sourceRowIndices?.length ?? input.rowCount;
+  const localRowIndices = input.predicate
+    ? filterParquetRowIndices(input.predicate, columns, sourceRowCount)
+    : undefined;
+  const rowIndices = localRowIndices?.map(rowIndex => sourceRowIndices?.[rowIndex] ?? rowIndex);
   const decodeDurationMs = getCurrentTime() - decodeStartTime;
 
   const conversionStartTime = getCurrentTime();
   const batches: ParquetSourceWorkerBatch[] = [];
   const outputColumns = new Set(input.projectedSchema.fields.map(field => field.name));
-  const outputRowCount = rowIndices?.length ?? input.rowCount;
+  const outputRowCount = rowIndices?.length ?? sourceRowCount;
   for (
     let outputRowOffset = 0;
     outputRowOffset < outputRowCount;
@@ -47,9 +62,13 @@ export async function decodeParquetSourceWorkerInput(
   ) {
     const rowCount = Math.min(input.batchSize, outputRowCount - outputRowOffset);
     const batchRowIndices = rowIndices?.slice(outputRowOffset, outputRowOffset + rowCount);
+    const batchLocalRowIndices = localRowIndices?.slice(
+      outputRowOffset,
+      outputRowOffset + rowCount
+    );
     const rowGroupRowOffset = batchRowIndices?.[0] ?? outputRowOffset;
-    const batchColumns = batchRowIndices
-      ? gatherParquetColumns(columns, batchRowIndices, outputColumns)
+    const batchColumns = batchLocalRowIndices
+      ? gatherParquetColumns(columns, batchLocalRowIndices, outputColumns)
       : sliceColumns(columns, outputRowOffset, outputRowOffset + rowCount);
     const arrowTable = convertTable(
       {
@@ -68,12 +87,29 @@ export async function decodeParquetSourceWorkerInput(
   }
   const arrowConversionDurationMs = getCurrentTime() - conversionStartTime;
   return {
-    sourceRowCount: input.rowCount,
+    sourceRowCount,
     rowCount: outputRowCount,
     batches,
     decodeDurationMs,
     arrowConversionDurationMs
   };
+}
+
+/** Concatenates materialized page-range fragments without constructing row objects. */
+function concatenateMaterializedColumns(
+  fragments: readonly Record<string, ArrayType>[]
+): Record<string, ArrayType> {
+  const columns: Record<string, unknown[]> = {};
+  for (const fragment of fragments) {
+    for (const [name, values] of Object.entries(fragment)) {
+      columns[name] ||= [];
+      const destination = columns[name];
+      for (let index = 0; index < values.length; index++) {
+        destination.push(values[index]);
+      }
+    }
+  }
+  return columns as Record<string, ArrayType>;
 }
 
 /** Returns a contiguous row slice of every decoded column without constructing row objects. */

--- a/modules/parquet/src/lib/parquet-source-worker-types.ts
+++ b/modules/parquet/src/lib/parquet-source-worker-types.ts
@@ -7,6 +7,7 @@ import type {StrictLoaderOptions} from '@loaders.gl/loader-utils';
 import type {Schema} from '@loaders.gl/schema';
 
 import type {ParquetPredicate} from '../parquet-source-types';
+import type {ParquetPagePruningPlan} from './parquet-page-index';
 import type {SchemaDefinition} from '../parquetjs/schema/declare';
 
 /** One transferable range containing a selected Parquet column chunk. */
@@ -59,6 +60,8 @@ export type ParquetSourceWorkerInput = {
   batchSize: number;
   /** Serializable exact predicate evaluated after decoding. */
   predicate?: ParquetPredicate;
+  /** Selective data-page plan prepared from column and offset indexes on the caller thread. */
+  pagePlan?: ParquetPagePruningPlan;
   /** Whether BYTE_ARRAY values stay binary during logical conversion. */
   preserveBinary: boolean;
 };

--- a/modules/parquet/src/parquet-source-capabilities.ts
+++ b/modules/parquet/src/parquet-source-capabilities.ts
@@ -20,6 +20,8 @@ export type ParquetSourceCapabilities = Readonly<{
   supportsColumnStatistics: boolean;
   /** Serializable predicates can prune impossible row groups using column statistics. */
   supportsPredicatePushdown: boolean;
+  /** Column and offset indexes can avoid irrelevant data-page range reads for flat columns. */
+  supportsPageIndexPruning: boolean;
   /** Surviving decoded rows are filtered exactly on the caller thread or worker. */
   supportsExactPredicateFiltering: boolean;
   /** Callers can supply the random-access transport used by the source. */
@@ -44,6 +46,7 @@ export const PARQUET_SOURCE_CAPABILITIES: ParquetSourceCapabilities = Object.fre
   supportsLocalWasmAsset: true,
   supportsColumnStatistics: true,
   supportsPredicatePushdown: true,
+  supportsPageIndexPruning: true,
   supportsExactPredicateFiltering: true,
   supportsCustomRangeTransport: true,
   supportsObjectVersionValidation: true,

--- a/modules/parquet/src/parquet-source-loader.ts
+++ b/modules/parquet/src/parquet-source-loader.ts
@@ -18,6 +18,11 @@ import {
   validateParquetPredicate
 } from './lib/parquet-predicate';
 import {
+  createParquetPagePruningPlan,
+  getParquetPageReadRanges,
+  type ParquetPagePruningPlan
+} from './lib/parquet-page-index';
+import {
   canDecodeParquetSourceOnWorker,
   decodeParquetSourceRowGroupOnWorker
 } from './lib/parquet-source-worker-client';
@@ -119,7 +124,7 @@ type ParquetSourceInitialization = {
 type ParquetRowGroupReadResult = {
   /** Zero-based source row-group index. */
   rowGroupIndex: number;
-  /** Number of logical rows in the decoded row group. */
+  /** Number of logical rows retained for output. */
   rowCount: number;
   /** Exact source row indexes retained by the predicate. */
   rowIndices?: number[];
@@ -283,6 +288,7 @@ export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoader
             projectedSchema,
             batchSize,
             predicate,
+            projectedColumnNames,
             decodeOnWorker ? workerOptions : undefined,
             readContext.abortController.signal
           ).then(
@@ -341,7 +347,7 @@ export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoader
           continue;
         }
 
-        const outputRowCount = predicate ? rowIndices!.length : rowCount;
+        const outputRowCount = rowCount;
         const outputBatchSize = batchSize || Math.max(outputRowCount, 1);
         for (
           let outputRowOffset = 0;
@@ -350,13 +356,15 @@ export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoader
         ) {
           throwIfAborted(readContext.abortController.signal);
           const batchRowCount = Math.min(outputBatchSize, outputRowCount - outputRowOffset);
-          const batchRowIndices = predicate
+          const batchRowIndices = rowIndices
             ? rowIndices!.slice(outputRowOffset, outputRowOffset + batchRowCount)
             : undefined;
           const rowGroupRowOffset = batchRowIndices?.[0] ?? outputRowOffset;
-          const batchColumns = batchRowIndices
-            ? gatherParquetColumns(materializedColumns!, batchRowIndices, projectedColumnNames)
-            : sliceColumns(materializedColumns!, outputRowOffset, outputRowOffset + batchRowCount);
+          const batchColumns = sliceColumns(
+            materializedColumns!,
+            outputRowOffset,
+            outputRowOffset + batchRowCount
+          );
           const conversionStartTime = getCurrentTime();
           const batch = createParquetBatch(
             initialization.metadata,
@@ -487,9 +495,28 @@ export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoader
     projectedSchema: Schema,
     batchSize: number | undefined,
     predicate: ParquetPredicate | undefined,
+    projectedColumnNames: ReadonlySet<string> | undefined,
     workerOptions: ParquetSourceWorkerOptions | undefined,
     signal: AbortSignal
   ): Promise<ParquetRowGroupReadResult> {
+    const rowGroup = initialization.fileMetadata.row_groups[rowGroupIndex];
+    const pagePlan = predicate
+      ? await createParquetPagePruningPlan(
+          initialization.file,
+          rowGroup,
+          initialization.parquetSchema,
+          columnList,
+          predicate,
+          signal
+        )
+      : undefined;
+    if (pagePlan) {
+      this.recordPagePruningTelemetry(rowGroupIndex, pagePlan);
+      if (pagePlan.rowRanges.length === 0) {
+        return {rowGroupIndex, columns: {}, rowCount: 0, rowIndices: []};
+      }
+    }
+
     if (workerOptions) {
       return await this.readRowGroupOnWorker(
         initialization,
@@ -498,24 +525,53 @@ export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoader
         projectedSchema,
         batchSize,
         predicate,
+        pagePlan,
         workerOptions,
         signal
       );
     }
 
     const decodeStartTime = getCurrentTime();
-    const rowGroup = initialization.fileMetadata.row_groups[rowGroupIndex];
-    const decodedRowGroup = await initialization.reader.readRowGroup(
-      initialization.parquetSchema,
-      rowGroup,
-      columnList,
-      signal
-    );
+    const decodedRowGroups = pagePlan
+      ? await Promise.all(
+          pagePlan.rowRanges.map(rowRange =>
+            initialization.reader.readRowGroupRange(
+              initialization.parquetSchema,
+              rowGroup,
+              columnList,
+              rowRange,
+              pagePlan.pageLocations,
+              signal
+            )
+          )
+        )
+      : [
+          await initialization.reader.readRowGroup(
+            initialization.parquetSchema,
+            rowGroup,
+            columnList,
+            signal
+          )
+        ];
     throwIfAborted(signal);
-    const columns = initialization.parquetSchema.materializeColumns(decodedRowGroup);
-    const rowIndices = predicate
-      ? filterParquetRowIndices(predicate, columns, decodedRowGroup.rowCount)
+    const columns = concatenateMaterializedColumns(
+      decodedRowGroups.map(decodedRowGroup =>
+        initialization.parquetSchema.materializeColumns(decodedRowGroup)
+      )
+    );
+    const sourceRowIndices = pagePlan
+      ? pagePlan.rowRanges.flatMap(rowRange =>
+          Array.from({length: rowRange.end - rowRange.start}, (_, index) => rowRange.start + index)
+        )
       : undefined;
+    const localRowCount = sourceRowIndices?.length ?? Number(rowGroup.num_rows);
+    const localRowIndices = predicate
+      ? filterParquetRowIndices(predicate, columns, localRowCount)
+      : undefined;
+    const rowIndices = localRowIndices?.map(rowIndex => sourceRowIndices?.[rowIndex] ?? rowIndex);
+    const outputColumns = localRowIndices
+      ? gatherParquetColumns(columns, localRowIndices, projectedColumnNames)
+      : columns;
     const decodeDurationMs = getCurrentTime() - decodeStartTime;
     this.recordTelemetry(
       'decode',
@@ -526,13 +582,18 @@ export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoader
       this.recordTelemetry(
         'predicate-filter',
         {
-          predicateRowsTested: decodedRowGroup.rowCount,
+          predicateRowsTested: localRowCount,
           predicateRowsMatched: rowIndices!.length
         },
         {rowGroupIndex, rowCount: rowIndices!.length}
       );
     }
-    return {rowGroupIndex, columns, rowCount: decodedRowGroup.rowCount, rowIndices};
+    return {
+      rowGroupIndex,
+      columns: outputColumns,
+      rowCount: rowIndices?.length ?? localRowCount,
+      rowIndices
+    };
   }
 
   /** Fetches selected chunks and transfers their decompression and Arrow conversion to a worker. */
@@ -543,6 +604,7 @@ export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoader
     projectedSchema: Schema,
     batchSize: number | undefined,
     predicate: ParquetPredicate | undefined,
+    pagePlan: ParquetPagePruningPlan | undefined,
     workerOptions: ParquetSourceWorkerOptions,
     signal: AbortSignal
   ): Promise<ParquetRowGroupReadResult> {
@@ -551,9 +613,11 @@ export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoader
       const path = columnChunk.meta_data?.path_in_schema;
       return Boolean(path && (columnList.length === 0 || fieldIndexOf(columnList, path) >= 0));
     });
+    const rangeDescriptors = pagePlan
+      ? getParquetPageReadRanges(rowGroup, columnList, pagePlan)
+      : selectedColumnChunks.map(getColumnChunkRange);
     const ranges = await Promise.all(
-      selectedColumnChunks.map(async columnChunk => {
-        const {offset, length} = getColumnChunkRange(columnChunk);
+      rangeDescriptors.map(async ({offset, length}) => {
         return {offset, data: await initialization.file.read(offset, length, signal)};
       })
     );
@@ -572,6 +636,7 @@ export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoader
           ranges,
           batchSize: batchSize || Math.max(Number(rowGroup.num_rows), 1),
           predicate: predicate ? copyParquetPredicate(predicate) : undefined,
+          pagePlan,
           preserveBinary: Boolean(this.options.parquet?.preserveBinary)
         },
         workerOptions
@@ -602,6 +667,22 @@ export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoader
       );
     }
     return {rowGroupIndex, rowCount: workerResult.rowCount, workerResult};
+  }
+
+  /** Records the rows and pages avoided by one conservative page-index plan. */
+  private recordPagePruningTelemetry(rowGroupIndex: number, plan: ParquetPagePruningPlan): void {
+    this.recordTelemetry(
+      'page-index-prune',
+      {
+        pageIndexesRead: plan.indexCount,
+        pagesRead: plan.selectedPageCount,
+        pagesPruned: plan.totalPageCount - plan.selectedPageCount,
+        rowsPrunedByPageIndex: plan.prunedRowCount,
+        rowGroupsPrunedByPageIndex: plan.rowRanges.length === 0 ? 1 : 0,
+        rowGroupsPruned: plan.rowRanges.length === 0 ? 1 : 0
+      },
+      {rowGroupIndex, rowCount: plan.prunedRowCount}
+    );
   }
 
   /** Opens the readable file and decodes its footer and schema once. */
@@ -759,6 +840,16 @@ function createColumnChunkMetadata(
     uncompressedSize: uncompressedByteLength,
     dataPageOffset,
     dictionaryPageOffset,
+    columnIndexOffset:
+      columnChunk.column_index_offset === undefined
+        ? undefined
+        : Number(columnChunk.column_index_offset),
+    columnIndexByteLength: columnChunk.column_index_length,
+    offsetIndexOffset:
+      columnChunk.offset_index_offset === undefined
+        ? undefined
+        : Number(columnChunk.offset_index_offset),
+    offsetIndexByteLength: columnChunk.offset_index_length,
     statistics
   });
 }
@@ -982,6 +1073,23 @@ function sliceColumns(
   return slicedColumns;
 }
 
+/** Concatenates materialized page-range fragments without constructing row objects. */
+function concatenateMaterializedColumns(
+  fragments: readonly Record<string, ArrayType>[]
+): Record<string, ArrayType> {
+  const columns: Record<string, unknown[]> = {};
+  for (const fragment of fragments) {
+    for (const [name, values] of Object.entries(fragment)) {
+      columns[name] ||= [];
+      const destination = columns[name];
+      for (let index = 0; index < values.length; index++) {
+        destination.push(values[index]);
+      }
+    }
+  }
+  return columns as Record<string, ArrayType>;
+}
+
 /** Validates and normalizes requested row-group indexes. */
 function normalizeRowGroupIndices(
   rowGroups: readonly number[] | undefined,
@@ -1063,6 +1171,11 @@ function createParquetTelemetry(): ParquetTelemetry {
     rowGroupsRequested: 0,
     rowGroupsPruned: 0,
     rowGroupsPrunedByStatistics: 0,
+    rowGroupsPrunedByPageIndex: 0,
+    pageIndexesRead: 0,
+    pagesRead: 0,
+    pagesPruned: 0,
+    rowsPrunedByPageIndex: 0,
     rowGroupsDecoded: 0,
     batchesEmitted: 0,
     rowsEmitted: 0,

--- a/modules/parquet/src/parquet-source-types.ts
+++ b/modules/parquet/src/parquet-source-types.ts
@@ -63,6 +63,14 @@ export type ParquetColumnChunkMetadata = {
   readonly dataPageOffset: number;
   /** Absolute file offset of the dictionary page, when present. */
   readonly dictionaryPageOffset?: number;
+  /** Absolute file offset of the optional per-page column statistics index. */
+  readonly columnIndexOffset?: number;
+  /** Serialized byte length of the optional per-page column statistics index. */
+  readonly columnIndexByteLength?: number;
+  /** Absolute file offset of the optional data-page location index. */
+  readonly offsetIndexOffset?: number;
+  /** Serialized byte length of the optional data-page location index. */
+  readonly offsetIndexByteLength?: number;
   /** Optional min/max and count statistics decoded from the footer. */
   readonly statistics?: ParquetColumnChunkStatistics;
 };
@@ -236,6 +244,16 @@ export type ParquetTelemetry = {
   rowGroupsPruned: number;
   /** Candidate row groups proven impossible using footer statistics. */
   rowGroupsPrunedByStatistics: number;
+  /** Row groups proven impossible using page-level column indexes. */
+  rowGroupsPrunedByPageIndex: number;
+  /** Column-index and offset-index blobs decoded for selective reads. */
+  pageIndexesRead: number;
+  /** Data pages fetched for page-index-planned reads. */
+  pagesRead: number;
+  /** Data pages avoided by page-index-planned reads. */
+  pagesPruned: number;
+  /** Candidate rows eliminated before data-page reads. */
+  rowsPrunedByPageIndex: number;
   /** Row groups successfully decoded. */
   rowGroupsDecoded: number;
   /** Arrow batches emitted by read operations. */
@@ -259,6 +277,7 @@ export type ParquetTelemetryEvent = {
     | 'range-request'
     | 'cache-hit'
     | 'row-group-prune'
+    | 'page-index-prune'
     | 'predicate-filter'
     | 'decode'
     | 'arrow-conversion'

--- a/modules/parquet/src/parquetjs/parser/parquet-reader.ts
+++ b/modules/parquet/src/parquetjs/parser/parquet-reader.ts
@@ -17,10 +17,17 @@ import {
   ParquetCompression,
   ParquetColumnChunk,
   PrimitiveType,
-  ParquetReaderContext
+  ParquetReaderContext,
+  type ParquetLevelBuffer
 } from '../schema/declare';
 import {decodeFileMetadata, getThriftEnum, fieldIndexOf} from '../utils/read-utils';
 import {decodeString, readUInt32LE, toUint8Array} from '../utils/binary-utils';
+import {CompactInt64} from '../utils/uint8-array-compact-protocol';
+import type {
+  ParquetDataPageLocation,
+  ParquetPageLocations,
+  ParquetRowRange
+} from '../../lib/parquet-page-index';
 
 /** Bounds concurrent range requests when a row group contains unusually many selected columns. */
 const MAXIMUM_CONCURRENT_COLUMN_READS = 16;
@@ -251,6 +258,42 @@ export class ParquetReader {
     };
   }
 
+  /** Reads independently materializable flat columns for one logical row range using page indexes. */
+  async readRowGroupRange(
+    schema: ParquetSchema,
+    rowGroup: RowGroup,
+    columnList: string[][],
+    rowRange: ParquetRowRange,
+    pageLocations: ParquetPageLocations,
+    signal?: AbortSignal
+  ): Promise<ParquetRowGroup> {
+    const selectedColumnChunks = rowGroup.columns.filter(columnChunk => {
+      const columnKey = columnChunk.meta_data?.path_in_schema;
+      return columnList.length === 0 || fieldIndexOf(columnList, columnKey!) >= 0;
+    });
+    const columnEntries = await Promise.all(
+      selectedColumnChunks.map(async columnChunk => {
+        const columnKey = columnChunk.meta_data!.path_in_schema.join();
+        const pages = pageLocations[columnChunk.meta_data!.path_in_schema.join('.')];
+        if (!pages) {
+          throw new Error(`Parquet offset index missing for ${columnKey}`);
+        }
+        const columnData = await this.readColumnChunkRange(
+          schema,
+          columnChunk,
+          rowRange,
+          pages,
+          signal
+        );
+        return [columnKey, columnData] as const;
+      })
+    );
+    return {
+      rowCount: rowRange.end - rowRange.start,
+      columnData: Object.fromEntries(columnEntries)
+    };
+  }
+
   /**
    * Each row group contains column chunks for all the columns.
    */
@@ -328,6 +371,71 @@ export class ParquetReader {
     return await decodeDataPages(pagesBuf, {...context, dictionary});
   }
 
+  /** Reads and decodes only the contiguous data pages overlapping one flat-column row range. */
+  async readColumnChunkRange(
+    schema: ParquetSchema,
+    columnChunk: ColumnChunk,
+    rowRange: ParquetRowRange,
+    pages: readonly ParquetDataPageLocation[],
+    signal?: AbortSignal
+  ): Promise<ParquetColumnChunk> {
+    if (columnChunk.file_path !== undefined && columnChunk.file_path !== null) {
+      throw new Error('external references are not supported');
+    }
+    const columnMetadata = columnChunk.meta_data!;
+    const field = schema.findField(columnMetadata.path_in_schema);
+    if (field.path.length !== 1 || field.repetitionType === 'REPEATED' || field.rLevelMax !== 0) {
+      throw new Error('Selective Parquet page reads currently require flat primitive columns');
+    }
+    const type: PrimitiveType = getThriftEnum(Type, columnMetadata.type) as any;
+    if (type !== field.primitiveType) {
+      throw new Error(`chunk type not matching schema: ${type}`);
+    }
+    const compression: ParquetCompression = getThriftEnum(
+      CompressionCodec,
+      columnMetadata.codec
+    ) as any;
+    const overlappingPages = pages.filter(
+      page => page.endRowIndex > rowRange.start && page.firstRowIndex < rowRange.end
+    );
+    if (!overlappingPages.length) {
+      throw new Error('Parquet page plan does not overlap the requested row range');
+    }
+    const firstPage = overlappingPages[0];
+    const lastPage = overlappingPages[overlappingPages.length - 1];
+    const context: ParquetReaderContext = {
+      type,
+      rLevelMax: field.rLevelMax,
+      dLevelMax: field.dLevelMax,
+      compression,
+      column: field,
+      numValues: new CompactInt64(lastPage.endRowIndex - firstPage.firstRowIndex),
+      dictionary: [],
+      preserveBinary: this.props.preserveBinary,
+      retainByteArrayViews: this.props.retainByteArrayViews,
+      useTypedValueBuffers: this.props.useTypedValueBuffers
+    };
+
+    let dictionary: any[] | undefined;
+    const dictionaryPageOffset = Number(columnMetadata.dictionary_page_offset);
+    if (Number.isSafeInteger(dictionaryPageOffset) && dictionaryPageOffset > 0) {
+      const dictionaryLength = Math.max(0, pages[0].offset - dictionaryPageOffset);
+      const dictionaryBuffer = toUint8Array(
+        await this.file.read(dictionaryPageOffset, dictionaryLength, signal ?? this.props.signal)
+      );
+      dictionary = await decodeDictionaryBuffer(dictionaryBuffer, context);
+    }
+
+    const dataLength = lastPage.offset + lastPage.compressedByteLength - firstPage.offset;
+    const dataBuffer = toUint8Array(
+      await this.file.read(firstPage.offset, dataLength, signal ?? this.props.signal)
+    );
+    const decoded = await decodeDataPages(dataBuffer, {...context, dictionary});
+    const relativeStart = rowRange.start - firstPage.firstRowIndex;
+    const relativeEnd = relativeStart + rowRange.end - rowRange.start;
+    return sliceFlatColumnChunk(decoded, field.dLevelMax, relativeStart, relativeEnd);
+  }
+
   /**
    * Getting dictionary for allows to flatten values by indices.
    * @param dictionaryPageOffset
@@ -375,4 +483,39 @@ async function decodeDictionaryBuffer(
   const cursor = {buffer: dictionaryBuffer, offset: 0, size: dictionaryBuffer.length};
   const decodedPage = await decodePage(cursor, context);
   return decodedPage.dictionary!;
+}
+
+/** Slices one decoded flat column chunk while preserving optional-value alignment. */
+function sliceFlatColumnChunk(
+  columnChunk: ParquetColumnChunk,
+  definitionLevelMaximum: number,
+  start: number,
+  end: number
+): ParquetColumnChunk {
+  const valueStart = countDefinedValues(columnChunk.dlevels, definitionLevelMaximum, 0, start);
+  const valueEnd =
+    valueStart + countDefinedValues(columnChunk.dlevels, definitionLevelMaximum, start, end);
+  return {
+    rlevels: columnChunk.rlevels.slice(start, end),
+    dlevels: columnChunk.dlevels.slice(start, end),
+    values: columnChunk.values.slice(valueStart, valueEnd) as typeof columnChunk.values,
+    count: end - start,
+    pageHeaders: columnChunk.pageHeaders
+  };
+}
+
+/** Counts defined primitive values represented by one flat level interval. */
+function countDefinedValues(
+  definitionLevels: ParquetLevelBuffer,
+  definitionLevelMaximum: number,
+  start: number,
+  end: number
+): number {
+  let count = 0;
+  for (let index = start; index < Math.min(end, definitionLevels.length); index++) {
+    if (definitionLevels[index] === definitionLevelMaximum) {
+      count++;
+    }
+  }
+  return count;
 }

--- a/modules/parquet/test/parquet-page-index.spec.ts
+++ b/modules/parquet/test/parquet-page-index.spec.ts
@@ -1,0 +1,249 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {beforeAll, describe, expect, test} from 'vitest';
+
+import {createDataSource, isBrowser} from '@loaders.gl/core';
+import type {ParquetBatch, ParquetSourceMetadata} from '@loaders.gl/parquet';
+import type {ParquetSourceLoaderOptions} from '@loaders.gl/parquet';
+import {
+  ParquetSource,
+  ParquetSourceLoader
+} from '@loaders.gl/parquet/parquet-source-loader';
+import * as arrow from 'apache-arrow';
+
+import {loadWasm} from '../src/lib/utils/load-wasm';
+
+const ROW_COUNT = 8192;
+const SELECTED_ROW_START = 7000;
+const SELECTED_ROW_END = 7010;
+const REMOTE_URL = 'https://example.com/page-index.parquet';
+
+let pageIndexFixture: ArrayBuffer;
+
+beforeAll(async () => {
+  pageIndexFixture = await createPageIndexFixture();
+});
+
+describe('Parquet page-index pruning', () => {
+  test('reads only candidate pages and preserves exact predicate results', async () => {
+    const source = createRemoteSource(pageIndexFixture, {core: {worker: false}});
+    const metadata = await source.getMetadata();
+    const metadataTelemetry = source.getTelemetry();
+    const batches = await collectBatches(
+      source.read({
+        columns: ['id', 'category', 'payload'],
+        predicate: {
+          op: 'and',
+          args: [
+            {op: '>=', args: [{property: 'id'}, SELECTED_ROW_START]},
+            {op: '<', args: [{property: 'id'}, SELECTED_ROW_END]}
+          ]
+        }
+      })
+    );
+
+    expect(getColumnMetadata(metadata, 'id')).toMatchObject({
+      columnIndexByteLength: expect.any(Number),
+      offsetIndexByteLength: expect.any(Number)
+    });
+    expect(getBatchValues(batches, 'id')).toEqual(
+      Array.from(
+        {length: SELECTED_ROW_END - SELECTED_ROW_START},
+        (_, index) => SELECTED_ROW_START + index
+      )
+    );
+    expect(getBatchValues(batches, 'payload')).toEqual(
+      Array.from(
+        {length: SELECTED_ROW_END - SELECTED_ROW_START},
+        (_, index) => `payload-${SELECTED_ROW_START + index}-${'-'.repeat(20)}`
+      )
+    );
+    expect(getBatchValues(batches, 'category')).toEqual(
+      Array.from({length: SELECTED_ROW_END - SELECTED_ROW_START}, () => 'group-6')
+    );
+    expect(batches[0].rowGroupRowIndices).toEqual(
+      Array.from(
+        {length: SELECTED_ROW_END - SELECTED_ROW_START},
+        (_, index) => SELECTED_ROW_START + index
+      )
+    );
+
+    const telemetry = source.getTelemetry();
+    const selectedColumnBytes = ['id', 'category', 'payload'].reduce(
+      (sum, column) => sum + getColumnMetadata(metadata, column).compressedByteLength,
+      0
+    );
+    expect(telemetry.pageIndexesRead).toBeGreaterThanOrEqual(3);
+    expect(telemetry.pagesPruned).toBeGreaterThan(0);
+    expect(telemetry.rowsPrunedByPageIndex).toBeGreaterThan(0);
+    expect(telemetry.predicateRowsTested).toBeLessThan(ROW_COUNT);
+    expect(telemetry.requestedBytes - metadataTelemetry.requestedBytes).toBeLessThan(
+      selectedColumnBytes / 2
+    );
+    await source.close();
+  });
+
+  test('merges discontiguous candidate pages without duplicating source rows', async () => {
+    const source = createRemoteSource(pageIndexFixture, {core: {worker: false}});
+    const batches = await collectBatches(
+      source.read({
+        columns: ['id'],
+        predicate: {
+          op: 'or',
+          args: [
+            {op: '<', args: [{property: 'id'}, 10]},
+            {op: '>=', args: [{property: 'id'}, ROW_COUNT - 12]}
+          ]
+        }
+      })
+    );
+
+    const expected = [
+      ...Array.from({length: 10}, (_, index) => index),
+      ...Array.from({length: 12}, (_, index) => ROW_COUNT - 12 + index)
+    ];
+    expect(getBatchValues(batches, 'id')).toEqual(expected);
+    expect(batches.flatMap(batch => batch.rowGroupRowIndices || [])).toEqual(expected);
+    expect(source.getTelemetry().predicateRowsTested).toBeLessThan(ROW_COUNT / 2);
+    await source.close();
+  });
+
+  test('avoids data-page reads when page-range intersections are empty', async () => {
+    const source = createRemoteSource(pageIndexFixture, {core: {worker: false}});
+    await source.getMetadata();
+    const metadataTelemetry = source.getTelemetry();
+    const batches = await collectBatches(
+      source.read({
+        columns: ['payload'],
+        predicate: {
+          op: 'and',
+          args: [
+            {op: '<', args: [{property: 'id'}, 100]},
+            {op: '>', args: [{property: 'id'}, ROW_COUNT - 100]}
+          ]
+        }
+      })
+    );
+
+    expect(batches).toEqual([]);
+    expect(source.getTelemetry()).toMatchObject({
+      rowGroupsPrunedByPageIndex: 1,
+      rowGroupsDecoded: 0,
+      predicateRowsTested: 0
+    });
+    expect(source.getTelemetry().requestedBytes - metadataTelemetry.requestedBytes).toBeLessThan(
+      4096
+    );
+    await source.close();
+  });
+
+  test('transfers selective page ranges through worker decoding', async () => {
+    if (!isBrowser) {
+      return;
+    }
+    const source = createRemoteSource(pageIndexFixture, {
+      core: {worker: true, reuseWorkers: false, _workerType: 'test'}
+    });
+    const batches = await collectBatches(
+      source.read({
+        columns: ['payload'],
+        predicate: {
+          op: 'and',
+          args: [
+            {op: '>=', args: [{property: 'id'}, SELECTED_ROW_START]},
+            {op: '<', args: [{property: 'id'}, SELECTED_ROW_END]}
+          ]
+        }
+      })
+    );
+
+    expect(getBatchValues(batches, 'payload')).toHaveLength(
+      SELECTED_ROW_END - SELECTED_ROW_START
+    );
+    expect(source.getTelemetry()).toMatchObject({
+      rowsPrunedByPageIndex: expect.any(Number),
+      predicateRowsMatched: SELECTED_ROW_END - SELECTED_ROW_START
+    });
+    expect(source.getTelemetry().rowsPrunedByPageIndex).toBeGreaterThan(0);
+    await source.close();
+  });
+});
+
+/** Creates a multi-page fixture whose page and chunk statistics are written by parquet-rs. */
+async function createPageIndexFixture(): Promise<ArrayBuffer> {
+  const wasm = await loadWasm();
+  const table = arrow.tableFromArrays({
+    id: Int32Array.from({length: ROW_COUNT}, (_, index) => index),
+    category: Array.from({length: ROW_COUNT}, (_, index) => `group-${Math.floor(index / 1024)}`),
+    payload: Array.from(
+      {length: ROW_COUNT},
+      (_, index) => `payload-${index}-${'-'.repeat(20)}`
+    )
+  });
+  const wasmTable = wasm.Table.fromIPCStream(arrow.tableToIPC(table));
+  const writerProperties = new wasm.WriterPropertiesBuilder()
+    .setStatisticsEnabled(wasm.EnabledStatistics.Page)
+    .setDataPageSizeLimit(1024)
+    .setDictionaryEnabled(false)
+    .setColumnDictionaryEnabled('category', true)
+    .build();
+  const bytes = wasm.writeParquet(wasmTable, writerProperties);
+  return bytes.slice().buffer;
+}
+
+/** Creates a strict in-memory HTTP range source for the generated fixture. */
+function createRemoteSource(
+  fixture: ArrayBuffer,
+  options: ParquetSourceLoaderOptions
+): ParquetSource {
+  const rangeFetch = async (_url: string, requestOptions: RequestInit = {}): Promise<Response> => {
+    const range = new Headers(requestOptions.headers).get('Range');
+    const match = range?.match(/^bytes=(\d+)-(\d+)$/);
+    if (!match) {
+      throw new Error(`Unexpected Range header: ${range}`);
+    }
+    const start = Number(match[1]);
+    const end = Number(match[2]);
+    return new Response(fixture.slice(start, end + 1), {
+      status: 206,
+      headers: {
+        'Content-Range': `bytes ${start}-${end}/${fixture.byteLength}`,
+        ETag: '"page-index-fixture"'
+      }
+    });
+  };
+  return createDataSource(REMOTE_URL, [ParquetSourceLoader], {
+    ...options,
+    core: {
+      ...options.core,
+      type: 'parquet',
+      _workerType: options.core?._workerType ?? 'test',
+      loadOptions: {core: {fetch: rangeFetch}}
+    }
+  }) as ParquetSource;
+}
+
+/** Returns normalized metadata for one top-level fixture column. */
+function getColumnMetadata(metadata: ParquetSourceMetadata, column: string) {
+  const columnMetadata = metadata.rowGroups[0].columns.find(candidate => candidate.path[0] === column);
+  if (!columnMetadata) {
+    throw new Error(`Missing fixture column ${column}`);
+  }
+  return columnMetadata;
+}
+
+/** Collects an Arrow batch stream for focused assertions. */
+async function collectBatches(batches: AsyncIterable<ParquetBatch>): Promise<ParquetBatch[]> {
+  const result: ParquetBatch[] = [];
+  for await (const batch of batches) {
+    result.push(batch);
+  }
+  return result;
+}
+
+/** Materializes one Arrow column across all emitted batches. */
+function getBatchValues(batches: readonly ParquetBatch[], column: string): unknown[] {
+  return batches.flatMap(batch => Array.from(batch.data.getChild(column)?.toArray() || []));
+}

--- a/modules/parquet/test/parquet-source-capabilities.spec.ts
+++ b/modules/parquet/test/parquet-source-capabilities.spec.ts
@@ -19,6 +19,7 @@ test('ParquetSourceCapabilities#advertises implemented and deferred features', t
     supportsLocalWasmAsset: true,
     supportsColumnStatistics: true,
     supportsPredicatePushdown: true,
+    supportsPageIndexPruning: true,
     supportsExactPredicateFiltering: true,
     supportsCustomRangeTransport: true,
     supportsObjectVersionValidation: true,


### PR DESCRIPTION
## Goals

- Make selective `ParquetSource` queries reduce actual remote I/O below the row-group level.
- Use standard Parquet column and offset indexes conservatively, without changing exact predicate results.
- Preserve the scale-oriented Arrow and typed-level optimizations landed in #3620 on both main-thread and worker paths.

## Changes

- Decode Parquet `ColumnIndex` and `OffsetIndex` metadata for selected flat primitive columns.
- Build conservative candidate row ranges from page min/max/null statistics, including safe `AND`/`OR` composition and fallback for unsupported predicates.
- Expand candidate ranges across differing selected-column page boundaries so projected columns remain aligned.
- Fetch only the selected data pages and required dictionary pages through `ReadableFile` byte ranges.
- Decode discontiguous page ranges on the main thread or transfer the same selective ranges to `ParquetSource` workers.
- Preserve exact filtering and original row-group provenance after page pruning.
- Expose page-index offsets and lengths in normalized metadata, plus page/read/pruning capabilities and telemetry.
- Fall back to full column-chunk reads for nested/repeated columns, missing or malformed indexes, and unsafe dictionary metadata.
- Document the behavior, telemetry, current limitations, and Parquet format support.

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn build-workers`
- `yarn test-audit`
- `yarn test-node` — 190 passed
- `yarn test-headless` — 1,986 passed
- `yarn test-headless-cover modules/parquet/test` — 259 passed
- `cd website && yarn && yarn build`

Focused page-index tests cover main-thread and worker decoding, dictionary-backed projection, discontiguous ranges, empty intersections, exact row provenance, telemetry, and transport byte reduction. The new planner reports 84.7% statement, 100% function, and 76.8% branch coverage in the Parquet coverage run.
