### PR TITLE
feat(stac): add lightweight catalog source

### DIFF
--- a/docs/docs-sidebar.json
+++ b/docs/docs-sidebar.json
@@ -53,6 +53,7 @@
       "modules/pmtiles/formats/pmtiles",
       "modules/textures/formats/pvr",
       "modules/shapefile/formats/shapefile",
+      "modules/stac/formats/stac",
       "modules/kml/formats/tcx",
       "modules/mvt/formats/tilejson",
       "modules/scene/formats/usd",
@@ -202,6 +203,7 @@
           "modules/pmtiles/api-reference/pmtiles-source-loader",
           "modules/potree/api-reference/potree-source-loader",
           "modules/tiles/api-reference/raster-set",
+          "modules/stac/api-reference/stac-source-loader",
           "modules/tiles/api-reference/tiles-3d-source",
           "modules/tiles/api-reference/tileset-3d-source",
           "modules/mvt/api-reference/mvt-source-loader",
@@ -509,6 +511,13 @@
           "modules/shapefile/README",
           "modules/shapefile/api-reference/shp-loader",
           "modules/shapefile/api-reference/dbf-loader"
+        ]
+      },
+      {
+        "type": "category",
+        "label": "@loaders.gl/stac",
+        "items": [
+          "modules/stac/README"
         ]
       },
       {

--- a/docs/modules/stac/README.md
+++ b/docs/modules/stac/README.md
@@ -1,0 +1,55 @@
+# @loaders.gl/stac
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v5.0-blue.svg?style=flat-square" alt="From-v5.0" />
+  &nbsp;
+  <img src="https://img.shields.io/badge/Status-Experimental-orange.svg?style=flat-square" alt="Status: Experimental" />
+</p>
+
+The `@loaders.gl/stac` module discovers datasets and assets described by the
+[SpatioTemporal Asset Catalog specification](https://stacspec.org/). It supports both linked static
+catalogs and server-side STAC API Item Search without imposing a rendering framework or a database
+dependency.
+
+## Installation
+
+```bash
+npm install @loaders.gl/core @loaders.gl/stac
+```
+
+## Usage
+
+```ts
+import {load} from '@loaders.gl/core';
+import {STACSourceLoader} from '@loaders.gl/stac';
+
+const source = await load('https://example.com/catalog.json', STACSourceLoader);
+const {mode, root} = await source.getMetadata();
+
+if (mode === 'api') {
+  for await (const item of source.search({
+    collections: ['buildings'],
+    bbox: [-71.1, 42.3, -71.0, 42.4]
+  })) {
+    console.log(source.getAssets(item, {roles: ['data']}));
+  }
+} else {
+  // Static catalogs are only crawled when the application explicitly opts in.
+  for await (const item of source.traverse({maxDepth: 4, maxRequests: 100})) {
+    console.log(item.id);
+  }
+}
+```
+
+See [`STACSourceLoader`](/docs/modules/stac/api-reference/stac-source-loader) for the source API and
+[STAC format notes](/docs/modules/stac/formats/stac) for protocol behavior.
+
+## Browser access
+
+Catalog discovery does not guarantee that an asset can be read by a browser. A browser-native
+remote Parquet query requires the asset host to allow cross-origin requests, accept byte ranges,
+and expose headers such as `Content-Range` and `Content-Length`.
+
+The source preserves all provider assets so the application can select an appropriate mirror.
+Probe the selected URL with a small range request and handle a rejected fetch separately from a
+server that returns the whole object instead of `206 Partial Content`.

--- a/docs/modules/stac/api-reference/stac-source-loader.md
+++ b/docs/modules/stac/api-reference/stac-source-loader.md
@@ -1,0 +1,80 @@
+# STACSourceLoader
+
+The `STACSourceLoader` creates a lightweight source for static STAC catalogs and STAC APIs.
+
+```ts
+import {load} from '@loaders.gl/core';
+import {STACSourceLoader} from '@loaders.gl/stac';
+
+const source = await load('https://example.com/stac', STACSourceLoader);
+```
+
+For synchronous `createDataSource()`, import the runtime-bearing subpath:
+
+```ts
+import {createDataSource} from '@loaders.gl/core';
+import {STACSourceLoader} from '@loaders.gl/stac/stac-source';
+
+const source = createDataSource('https://example.com/stac', STACSourceLoader);
+```
+
+## Methods
+
+### `getMetadata(options?)`
+
+Returns the root Catalog or Collection, declared conformance classes, and the detected mode:
+
+- `api` when the root exposes Item Search or API conformance declarations.
+- `static` for a linked catalog of JSON documents.
+
+The root document is fetched once and cached.
+
+### `getCollections(options?)`
+
+Returns Collections. For a STAC API it follows the Collections endpoint and `next` links. For a
+static catalog it follows only `child` links and never downloads Items.
+
+Options are `signal`, `maxDepth`, and `maxRequests`.
+
+### `search(query?)`
+
+Runs server-side STAC API Item Search and follows `next` links. Both GET and POST pagination links
+are supported, including the STAC `body` and `merge` fields.
+
+Supported core query properties are:
+
+- `ids`
+- `collections`
+- `bbox`
+- `datetime`
+- `limit`
+- `signal`
+
+`search()` throws for a static catalog. This prevents a seemingly small query from silently
+crawling a very large linked catalog.
+
+### `traverse(options?)`
+
+Explicitly traverses `child` and `item` links in a static catalog. URLs are cycle-protected and
+bounded by `maxDepth` and `maxRequests`. The core `ids`, `collections`, `bbox`, and `datetime`
+constraints are evaluated locally before Items are yielded.
+
+### `getAssets(item, selection?)`
+
+Returns assets with URLs resolved against the Item document. Assets can be selected by `roles` and
+exact `mediaTypes`.
+
+## Options
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `stac.maxDepth` | `number` | `32` | Default maximum static child-catalog depth. |
+| `stac.maxRequests` | `number` | `1000` | Default maximum documents fetched by one static traversal. |
+
+## Capabilities
+
+`STACSource.capabilities` implements the protocol-neutral `CatalogSource` capability contract from
+`@loaders.gl/loader-utils`. STAC-specific methods remain available directly on `STACSource`.
+
+The initial implementation does not advertise text search or CQL2. Those extensions can be added
+without changing the shared catalog contract.

--- a/docs/modules/stac/formats/stac.md
+++ b/docs/modules/stac/formats/stac.md
@@ -1,0 +1,49 @@
+# STAC
+
+The [SpatioTemporal Asset Catalog](https://stacspec.org/) specification describes geospatial assets
+using JSON and GeoJSON documents connected by typed links. STAC metadata points to data; it does
+not prescribe how a GeoTIFF, GeoParquet file, Zarr store, PMTiles archive, or other asset is decoded.
+
+## Core objects
+
+- A **Catalog** organizes child Catalogs and Collections.
+- A **Collection** describes a related set of Items and their spatial and temporal extent.
+- An **Item** is a GeoJSON Feature whose `assets` map identifies downloadable or streamable data.
+- A **STAC API** adds HTTP discovery, Collections, Item Search, pagination, and optional extensions
+  such as CQL2.
+
+STAC extension fields are preserved by `@loaders.gl/stac` rather than discarded.
+
+## Static catalogs and APIs
+
+Static STAC and STAC API expose similar documents but have materially different query costs. A
+STAC API evaluates search constraints on the server. A static catalog requires the client to follow
+links and inspect Item metadata.
+
+`STACSource.search()` therefore only invokes a discovered STAC API search relation.
+`STACSource.traverse()` is the explicit, bounded operation for static catalogs.
+
+## Composing catalogs and format sources
+
+Catalog discovery and asset decoding are intentionally separate:
+
+1. Open a catalog with `STACSourceLoader`.
+2. Select an Item and a suitable data asset.
+3. Open that asset with a format source such as `ParquetSourceLoader`, `GeoTIFFSourceLoader`, or
+   `PMTilesSourceLoader`.
+
+This keeps the STAC module small and lets each format source retain its own range planning,
+predicate pushdown, worker, and caching behavior.
+
+## CORS and random access
+
+A public object URL is not necessarily browser-readable. Browser-native random access requires:
+
+- a successful cross-origin `GET` or `HEAD` request;
+- support for a single byte range with a `206 Partial Content` response;
+- readable `Content-Range`, `Content-Length`, and preferably `ETag` or version headers.
+
+When a STAC Item offers multiple mirrors, test the chosen asset host rather than assuming every
+provider has the same CORS policy. In browser JavaScript, a CORS rejection is intentionally
+indistinguishable from some network failures, so applications should present it as an inaccessible
+asset and offer another mirror when available.

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -1,5 +1,8 @@
 # What's New
 
+- A new experimental `@loaders.gl/stac` module discovers static STAC catalogs and paginated STAC
+  APIs through a lightweight `STACSource`, with a shared catalog interface also implemented by CSW.
+
 ## v5.0 (In Development)
 
 Release Date: 2026

--- a/modules/loader-utils/src/index.ts
+++ b/modules/loader-utils/src/index.ts
@@ -249,6 +249,8 @@ export type {
 } from './lib/sources/data-source-manager';
 export {DataSourceManager} from './lib/sources/data-source-manager';
 
+export type {CatalogSource, CatalogSourceCapabilities} from './lib/sources/catalog-source';
+
 export {ImageSource} from './lib/sources/image-source';
 export type {ImageType} from './lib/sources/utils/image-type';
 export type {ImageSourceMetadata} from './lib/sources/image-source';

--- a/modules/loader-utils/src/lib/sources/catalog-source.ts
+++ b/modules/loader-utils/src/lib/sources/catalog-source.ts
@@ -1,0 +1,42 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** Common feature declarations for discoverable resource catalogs. */
+export type CatalogSourceCapabilities = Readonly<{
+  /** Catalog records can be queried. */
+  search: boolean;
+  /** Search results can be consumed across multiple result pages. */
+  pagination: boolean;
+  /** The catalog exposes parent/child traversal. */
+  hierarchy: boolean;
+  /** Search accepts a spatial constraint. */
+  spatialFilter: boolean;
+  /** Search accepts a temporal constraint. */
+  temporalFilter: boolean;
+  /** Search accepts a free-text constraint. */
+  textFilter: boolean;
+  /** Search accepts a CQL2 filter. */
+  cql2Filter: boolean;
+  /** The catalog exposes named collections. */
+  collections: boolean;
+  /** Records can describe downloadable or streamable assets. */
+  assets: boolean;
+}>;
+
+/**
+ * Minimal shared interface for catalog protocols such as STAC and OGC CSW.
+ *
+ * Protocol-specific sources retain their richer methods and record models. This interface only
+ * standardizes capability discovery, catalog metadata, and asynchronous record search.
+ */
+export interface CatalogSource<RecordT, QueryT = undefined, MetadataT = unknown> {
+  /** Features implemented by this catalog source. */
+  readonly capabilities: CatalogSourceCapabilities;
+
+  /** Returns protocol-specific catalog metadata. */
+  getMetadata(): Promise<MetadataT>;
+
+  /** Searches catalog records, following protocol pagination when supported. */
+  search(query?: QueryT): AsyncIterable<RecordT>;
+}

--- a/modules/parquet/src/lib/parquet-page-index.ts
+++ b/modules/parquet/src/lib/parquet-page-index.ts
@@ -26,6 +26,8 @@ import {
   readFloatLE,
   readInt32LE,
   readInt64LE,
+  readUInt32LE,
+  readUInt64LE,
   toUint8Array
 } from '../parquetjs/utils/binary-utils';
 import {Uint8ArrayCompactProtocol} from '../parquetjs/utils/uint8-array-compact-protocol';
@@ -113,9 +115,10 @@ export async function createParquetPagePruningPlan(
     selectedColumnChunks.map(async columnChunk => {
       const path = columnChunk.meta_data!.path_in_schema;
       const pathKey = path.join('.');
-      const offsetIndexRange = getIndexRange(
+      const offsetIndexRange = getParquetIndexRange(
         columnChunk.offset_index_offset,
-        columnChunk.offset_index_length
+        columnChunk.offset_index_length,
+        file.size
       );
       if (!offsetIndexRange) {
         return;
@@ -137,9 +140,10 @@ export async function createParquetPagePruningPlan(
       if (path.length !== 1 || !predicateColumns.has(path[0])) {
         return;
       }
-      const columnIndexRange = getIndexRange(
+      const columnIndexRange = getParquetIndexRange(
         columnChunk.column_index_offset,
-        columnChunk.column_index_length
+        columnChunk.column_index_length,
+        file.size
       );
       if (!columnIndexRange) {
         return;
@@ -343,10 +347,10 @@ function decodeColumnIndex(
   return pages.map((_page, pageIndex) => ({
     min: columnIndex.null_pages[pageIndex]
       ? undefined
-      : decodeStatisticsValue(columnIndex.min_values[pageIndex], field),
+      : decodeParquetPageStatisticsValue(columnIndex.min_values[pageIndex], field),
     max: columnIndex.null_pages[pageIndex]
       ? undefined
-      : decodeStatisticsValue(columnIndex.max_values[pageIndex], field),
+      : decodeParquetPageStatisticsValue(columnIndex.max_values[pageIndex], field),
     nullCount:
       columnIndex.null_counts?.[pageIndex] !== undefined
         ? Number(columnIndex.null_counts[pageIndex])
@@ -358,18 +362,20 @@ function decodeColumnIndex(
   }));
 }
 
-/** Decodes one physical statistics value and applies its Parquet logical annotation. */
-function decodeStatisticsValue(bytes: Uint8Array, field: ParquetField): unknown {
+/** Decodes one physical page-index statistic and applies its Parquet logical annotation. */
+export function decodeParquetPageStatisticsValue(bytes: Uint8Array, field: ParquetField): unknown {
   let primitiveValue: unknown;
   switch (field.primitiveType) {
     case 'BOOLEAN':
       primitiveValue = Boolean(bytes[0]);
       break;
     case 'INT32':
-      primitiveValue = readInt32LE(bytes, 0);
+      primitiveValue =
+        field.originalType === 'UINT_32' ? readUInt32LE(bytes, 0) : readInt32LE(bytes, 0);
       break;
     case 'INT64':
-      primitiveValue = readInt64LE(bytes, 0);
+      primitiveValue =
+        field.originalType === 'UINT_64' ? readUInt64LE(bytes, 0) : readInt64LE(bytes, 0);
       break;
     case 'FLOAT':
       primitiveValue = readFloatLE(bytes, 0);
@@ -431,10 +437,11 @@ function isSafeFlatPageSelection(
   );
 }
 
-/** Validates one optional footer index byte range. */
-function getIndexRange(
+/** Validates one optional footer index byte range against the containing file. */
+export function getParquetIndexRange(
   offsetValue: ColumnChunk['offset_index_offset'],
-  lengthValue: number | undefined
+  lengthValue: number | undefined,
+  fileSize: number
 ): {offset: number; length: number} | undefined {
   if (offsetValue === undefined || lengthValue === undefined) {
     return undefined;
@@ -443,8 +450,11 @@ function getIndexRange(
   if (
     !Number.isSafeInteger(offset) ||
     !Number.isSafeInteger(lengthValue) ||
+    !Number.isSafeInteger(fileSize) ||
     offset < 0 ||
-    lengthValue <= 0
+    lengthValue <= 0 ||
+    fileSize < 0 ||
+    offset > fileSize - lengthValue
   ) {
     return undefined;
   }

--- a/modules/parquet/src/parquet-source-loader.ts
+++ b/modules/parquet/src/parquet-source-loader.ts
@@ -74,6 +74,7 @@ import {
   readFloatLE,
   readInt32LE,
   readInt64LE,
+  readUInt32LE,
   readUInt64LE,
   toUint8Array
 } from './parquetjs/utils/binary-utils';
@@ -899,7 +900,8 @@ function decodeStatisticsValueSafely(bytes: Uint8Array, field: ParquetField): un
         primitiveValue = Boolean(bytes[0]);
         break;
       case 'INT32':
-        primitiveValue = readInt32LE(bytes, 0);
+        primitiveValue =
+          field.originalType === 'UINT_32' ? readUInt32LE(bytes, 0) : readInt32LE(bytes, 0);
         break;
       case 'INT64':
         primitiveValue =

--- a/modules/parquet/test/parquet-page-index.spec.ts
+++ b/modules/parquet/test/parquet-page-index.spec.ts
@@ -13,7 +13,12 @@ import {
 } from '@loaders.gl/parquet/parquet-source-loader';
 import * as arrow from 'apache-arrow';
 
+import {
+  decodeParquetPageStatisticsValue,
+  getParquetIndexRange
+} from '../src/lib/parquet-page-index';
 import {loadWasm} from '../src/lib/utils/load-wasm';
+import type {ParquetField} from '../src/parquetjs/schema/declare';
 
 const ROW_COUNT = 8192;
 const SELECTED_ROW_START = 7000;
@@ -27,6 +32,34 @@ beforeAll(async () => {
 });
 
 describe('Parquet page-index pruning', () => {
+  test('decodes unsigned page-index statistics without sign extension', () => {
+    const uint32Bytes = new Uint8Array(4);
+    new DataView(uint32Bytes.buffer).setUint32(0, 0xffffffff, true);
+    const uint64Bytes = new Uint8Array(8);
+    new DataView(uint64Bytes.buffer).setBigUint64(0, 0xffffffffffffffffn, true);
+
+    expect(
+      decodeParquetPageStatisticsValue(
+        uint32Bytes,
+        {primitiveType: 'INT32', originalType: 'UINT_32'} as ParquetField
+      )
+    ).toBe(0xffffffff);
+    expect(
+      decodeParquetPageStatisticsValue(
+        uint64Bytes,
+        {primitiveType: 'INT64', originalType: 'UINT_64'} as ParquetField
+      )
+    ).toBe(0xffffffffffffffffn);
+  });
+
+  test('rejects optional index ranges outside the containing file', () => {
+    expect(getParquetIndexRange(80n, 20, 100)).toEqual({offset: 80, length: 20});
+    expect(getParquetIndexRange(80n, 21, 100)).toBeUndefined();
+    expect(getParquetIndexRange(101n, 1, 100)).toBeUndefined();
+    expect(getParquetIndexRange(-1n, 1, 100)).toBeUndefined();
+    expect(getParquetIndexRange(0n, 0, 100)).toBeUndefined();
+  });
+
   test('reads only candidate pages and preserves exact predicate results', async () => {
     const source = createRemoteSource(pageIndexFixture, {core: {worker: false}});
     const metadata = await source.getMetadata();

--- a/modules/stac/README.md
+++ b/modules/stac/README.md
@@ -1,0 +1,5 @@
+# @loaders.gl/stac
+
+Framework-independent discovery and traversal for static STAC catalogs and STAC APIs.
+
+See the [loaders.gl documentation](https://loaders.gl/docs/modules/stac).

--- a/modules/stac/package.json
+++ b/modules/stac/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@loaders.gl/stac",
+  "version": "5.0.0-alpha.1",
+  "description": "Framework-independent source for SpatioTemporal Asset Catalogs",
+  "license": "MIT",
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/visgl/loaders.gl"
+  },
+  "keywords": [
+    "STAC",
+    "SpatioTemporal Asset Catalog",
+    "catalog",
+    "geospatial",
+    "cloud native"
+  ],
+  "types": "dist/index.d.ts",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./stac-source": {
+      "types": "./dist/stac-source.d.ts",
+      "import": "./dist/stac-source.js",
+      "require": "./dist/stac-source.cjs"
+    }
+  },
+  "sideEffects": false,
+  "files": [
+    "src",
+    "dist",
+    "README.md"
+  ],
+  "dependencies": {
+    "@loaders.gl/loader-utils": "5.0.0-alpha.1"
+  },
+  "peerDependencies": {
+    "@loaders.gl/core": "~5.0.0-alpha.0"
+  }
+}

--- a/modules/stac/src/index.ts
+++ b/modules/stac/src/index.ts
@@ -1,0 +1,25 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export {STACSourceLoader} from './stac-source-loader-types';
+export type {STACSourceLoaderOptions} from './stac-source-loader-types';
+export type {
+  STACAsset,
+  STACAssetSelection,
+  STACBoundingBox,
+  STACCatalog,
+  STACCollection,
+  STACCollections,
+  STACExtent,
+  STACGeometry,
+  STACItem,
+  STACItemCollection,
+  STACLink,
+  STACMode,
+  STACObject,
+  STACResolvedAsset,
+  STACSearchQuery,
+  STACSourceMetadata,
+  STACTraversalOptions
+} from './stac-types';

--- a/modules/stac/src/stac-source-loader-types.ts
+++ b/modules/stac/src/stac-source-loader-types.ts
@@ -1,0 +1,65 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {CoreAPI, DataSourceOptions, SourceLoader} from '@loaders.gl/loader-utils';
+import type {STACSource} from './stac-source';
+
+// __VERSION__ is injected by babel-plugin-version-inline
+// @ts-ignore TS2304: Cannot find name '__VERSION__'.
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+
+/** Options for static STAC traversal and STAC API discovery. */
+export type STACSourceLoaderOptions = DataSourceOptions & {
+  stac?: {
+    /** Maximum child depth used by `traverse()` when not overridden per call. */
+    maxDepth?: number;
+    /** Maximum documents fetched by `traverse()` when not overridden per call. */
+    maxRequests?: number;
+  };
+};
+
+/** Loads the runtime STAC source implementation from its explicit package subpath. */
+async function preloadSTACSourceLoader(): Promise<SourceLoader<STACSource>> {
+  const {STACSourceLoaderWithParser} = await import('@loaders.gl/stac/stac-source');
+  return STACSourceLoaderWithParser;
+}
+
+/** Lightweight metadata for static STAC catalogs and STAC API roots. */
+export const STACSourceLoader = {
+  dataType: null as unknown as STACSource,
+  batchType: null as never,
+  name: 'STACSourceLoader',
+  id: 'stac-source',
+  module: 'stac',
+  version: VERSION,
+  extensions: ['json'],
+  mimeTypes: ['application/json', 'application/geo+json'],
+  type: 'stac',
+  fromUrl: true,
+  fromBlob: false,
+  options: {
+    stac: {
+      maxDepth: 32,
+      maxRequests: 1000
+    }
+  },
+  defaultOptions: {
+    stac: {
+      maxDepth: 32,
+      maxRequests: 1000
+    }
+  },
+  testURL: (url: string): boolean =>
+    /(?:^|[/_.-])stac(?:[/_.?#-]|$)|\/(?:catalog|collection)\.json(?:$|[?#])/i.test(url),
+  preload: preloadSTACSourceLoader,
+  createDataSource(
+    _data: string | Blob,
+    _options: STACSourceLoaderOptions,
+    _coreApi?: CoreAPI
+  ): STACSource {
+    throw new Error(
+      'STACSourceLoader requires async load() or an explicit @loaders.gl/stac/stac-source import'
+    );
+  }
+} as const satisfies SourceLoader<STACSource>;

--- a/modules/stac/src/stac-source.ts
+++ b/modules/stac/src/stac-source.ts
@@ -102,8 +102,9 @@ export class STACSource
 
   /** Returns the cached root Catalog or Collection. */
   async getRoot(options: {signal?: AbortSignal} = {}): Promise<STACCatalog | STACCollection> {
+    throwIfAborted(options.signal);
     if (!this.rootPromise) {
-      const rootPromise = this.fetchObject(this.url, options.signal).then(object => {
+      const rootPromise = this.fetchObject(this.url).then(object => {
         if (!isCatalog(object) && !isCollection(object)) {
           throw new Error(`STAC root must be a Catalog or Collection: ${this.url}`);
         }
@@ -116,7 +117,7 @@ export class STACSource
         }
       });
     }
-    return await this.rootPromise;
+    return await waitForPromiseWithSignal(this.rootPromise, options.signal);
   }
 
   /** Returns root metadata and whether a STAC API search relation was discovered. */
@@ -343,6 +344,11 @@ export class STACSource
     assertResponse(response, url);
     const object = validateObject(await response.json(), url);
     this.attachDocumentUrl(object, url);
+    if (isItemCollection(object)) {
+      for (const item of object.features) {
+        this.attachDocumentUrl(item, url);
+      }
+    }
     return object;
   }
 
@@ -452,6 +458,22 @@ function throwIfAborted(signal?: AbortSignal): void {
   if (signal?.aborted) {
     throw signal.reason || new DOMException('The operation was aborted', 'AbortError');
   }
+}
+
+/** Waits for shared work while applying cancellation only to the current caller. */
+function waitForPromiseWithSignal<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) {
+    return promise;
+  }
+  throwIfAborted(signal);
+  return new Promise<T>((resolve, reject) => {
+    const handleAbort = (): void =>
+      reject(signal.reason || new DOMException('The operation was aborted', 'AbortError'));
+    signal.addEventListener('abort', handleAbort, {once: true});
+    void promise
+      .then(resolve, reject)
+      .finally(() => signal.removeEventListener('abort', handleAbort));
+  });
 }
 
 /** Validates a core STAC document while preserving extension fields. */

--- a/modules/stac/src/stac-source.ts
+++ b/modules/stac/src/stac-source.ts
@@ -1,0 +1,613 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {
+  CatalogSource,
+  CatalogSourceCapabilities,
+  CoreAPI,
+  SourceLoader
+} from '@loaders.gl/loader-utils';
+import {DataSource} from '@loaders.gl/loader-utils';
+
+import {STACSourceLoader as STACSourceLoaderMetadata} from './stac-source-loader-types';
+import type {STACSourceLoaderOptions} from './stac-source-loader-types';
+import type {
+  STACAssetSelection,
+  STACBoundingBox,
+  STACCatalog,
+  STACCollection,
+  STACCollections,
+  STACItem,
+  STACItemCollection,
+  STACLink,
+  STACObject,
+  STACResolvedAsset,
+  STACSearchQuery,
+  STACSourceMetadata,
+  STACTraversalOptions
+} from './stac-types';
+
+const DEFAULT_MAX_DEPTH = 32;
+const DEFAULT_MAX_REQUESTS = 1000;
+
+const {
+  preload: _preloadSTACSourceLoader,
+  createDataSource: _createMetadataDataSource,
+  ...STACSourceLoaderBase
+} = STACSourceLoaderMetadata;
+
+/** Runtime source factory for static STAC catalogs and STAC APIs. */
+export const STACSourceLoaderWithParser = {
+  ...STACSourceLoaderBase,
+  createDataSource(
+    data: string | Blob,
+    options: STACSourceLoaderOptions,
+    coreApi?: CoreAPI
+  ): STACSource {
+    if (typeof data !== 'string') {
+      throw new Error('STACSource requires a catalog URL');
+    }
+    return new STACSource(data, options, coreApi);
+  }
+} as const satisfies SourceLoader<STACSource>;
+
+/** Runtime STAC source loader exposed by the explicit package subpath. */
+export {STACSourceLoaderWithParser as STACSourceLoader};
+
+type STACRequest = {
+  url: string;
+  method: 'GET' | 'POST';
+  headers?: Record<string, string>;
+  body?: Record<string, unknown>;
+};
+
+type STACTraversalEntry = {
+  url: string;
+  depth: number;
+};
+
+/**
+ * Lightweight source for static STAC catalogs and STAC API Item Search.
+ *
+ * Static catalogs are only crawled through the explicit `traverse()` method. `search()` is reserved
+ * for server-side STAC API Item Search, preventing an accidental crawl of a planet-scale catalog.
+ */
+export class STACSource
+  extends DataSource<string, STACSourceLoaderOptions>
+  implements CatalogSource<STACItem, STACSearchQuery, STACSourceMetadata>
+{
+  /** Features exposed through the protocol-neutral catalog interface. */
+  readonly capabilities: CatalogSourceCapabilities = Object.freeze({
+    search: true,
+    pagination: true,
+    hierarchy: true,
+    spatialFilter: true,
+    temporalFilter: true,
+    textFilter: false,
+    cql2Filter: false,
+    collections: true,
+    assets: true
+  });
+
+  /** Cached root initialization shared by metadata and query methods. */
+  private rootPromise: Promise<STACCatalog | STACCollection> | null = null;
+  /** Source document URL retained for resolving relative links and assets. */
+  private readonly documentUrls = new WeakMap<object, string>();
+
+  /** Creates a source for a static STAC root or STAC API landing page. */
+  constructor(url: string, options: STACSourceLoaderOptions, coreApi?: CoreAPI) {
+    super(url, options, STACSourceLoaderWithParser.defaultOptions, coreApi);
+  }
+
+  /** Returns the cached root Catalog or Collection. */
+  async getRoot(options: {signal?: AbortSignal} = {}): Promise<STACCatalog | STACCollection> {
+    if (!this.rootPromise) {
+      const rootPromise = this.fetchObject(this.url, options.signal).then(object => {
+        if (!isCatalog(object) && !isCollection(object)) {
+          throw new Error(`STAC root must be a Catalog or Collection: ${this.url}`);
+        }
+        return object;
+      });
+      this.rootPromise = rootPromise;
+      void rootPromise.catch(() => {
+        if (this.rootPromise === rootPromise) {
+          this.rootPromise = null;
+        }
+      });
+    }
+    return await this.rootPromise;
+  }
+
+  /** Returns root metadata and whether a STAC API search relation was discovered. */
+  async getMetadata(options: {signal?: AbortSignal} = {}): Promise<STACSourceMetadata> {
+    const root = await this.getRoot(options);
+    const conformsTo = Array.isArray(root.conformsTo) ? root.conformsTo : [];
+    return {
+      root,
+      mode: findLink(root.links, 'search') || conformsTo.length > 0 ? 'api' : 'static',
+      conformsTo
+    };
+  }
+
+  /**
+   * Lists collections from an API Collections endpoint or a static catalog hierarchy.
+   * Static traversal follows `child` links but never fetches Item links.
+   */
+  async getCollections(
+    options: {signal?: AbortSignal; maxDepth?: number; maxRequests?: number} = {}
+  ): Promise<STACCollection[]> {
+    const metadata = await this.getMetadata({signal: options.signal});
+    if (metadata.mode === 'api') {
+      return await this.getAPICollections(metadata.root, options.signal);
+    }
+    return await this.getStaticCollections(metadata.root, options);
+  }
+
+  /**
+   * Searches a STAC API and follows `next` links until all result pages are consumed.
+   * Throws for static catalogs; use `traverse()` to opt into client-side crawling.
+   */
+  async *search(query: STACSearchQuery = {}): AsyncIterable<STACItem> {
+    const root = await this.getRoot({signal: query.signal});
+    const searchLink = findLink(root.links, 'search');
+    if (!searchLink) {
+      throw new Error('This is a static STAC catalog; use STACSource.traverse() explicitly');
+    }
+
+    let request: STACRequest | null = createSearchRequest(
+      searchLink,
+      this.getDocumentUrl(root),
+      query
+    );
+    const visitedRequests = new Set<string>();
+    while (request) {
+      throwIfAborted(query.signal);
+      const requestKey = getRequestKey(request);
+      if (visitedRequests.has(requestKey)) {
+        throw new Error(`STAC pagination cycle detected at ${request.url}`);
+      }
+      visitedRequests.add(requestKey);
+
+      const page = await this.fetchItemCollection(request, query.signal);
+      for (const item of page.features) {
+        yield item;
+      }
+      const nextLink = findLink(page.links, 'next');
+      request = nextLink ? createNextRequest(nextLink, this.getDocumentUrl(page), request) : null;
+    }
+  }
+
+  /**
+   * Explicitly traverses a static STAC link graph with cycle, depth, and request limits.
+   * Optional standard Item Search constraints are evaluated locally.
+   */
+  async *traverse(options: STACTraversalOptions = {}): AsyncIterable<STACItem> {
+    const root = await this.getRoot({signal: options.signal});
+    const maxDepth = options.maxDepth ?? this.options.stac?.maxDepth ?? DEFAULT_MAX_DEPTH;
+    const maxRequests =
+      options.maxRequests ?? this.options.stac?.maxRequests ?? DEFAULT_MAX_REQUESTS;
+    validateTraversalLimit('maxDepth', maxDepth);
+    validateTraversalLimit('maxRequests', maxRequests);
+
+    const rootUrl = this.getDocumentUrl(root);
+    const queue: STACTraversalEntry[] = [{url: rootUrl, depth: 0}];
+    const visitedUrls = new Set<string>();
+    let requestCount = 0;
+
+    while (queue.length > 0) {
+      throwIfAborted(options.signal);
+      const entry = queue.shift()!;
+      if (visitedUrls.has(entry.url)) {
+        continue;
+      }
+      if (requestCount >= maxRequests) {
+        throw new Error(`STAC traversal exceeded maxRequests (${maxRequests})`);
+      }
+      visitedUrls.add(entry.url);
+      requestCount++;
+
+      const object =
+        entry.url === rootUrl ? root : await this.fetchObject(entry.url, options.signal);
+      if (isItem(object)) {
+        if (matchesItem(object, options)) {
+          yield object;
+        }
+        continue;
+      }
+      if (isItemCollection(object)) {
+        for (const item of object.features) {
+          if (matchesItem(item, options)) {
+            yield item;
+          }
+        }
+      }
+
+      for (const link of object.links) {
+        if (link.rel !== 'child' && link.rel !== 'item') {
+          continue;
+        }
+        const depth = link.rel === 'child' ? entry.depth + 1 : entry.depth;
+        if (depth <= maxDepth) {
+          queue.push({url: resolveUrl(link.href, this.getDocumentUrl(object)), depth});
+        }
+      }
+    }
+  }
+
+  /** Returns matching Item assets with document-relative URLs resolved to absolute URLs. */
+  getAssets(item: STACItem, selection: STACAssetSelection = {}): STACResolvedAsset[] {
+    const baseUrl = this.documentUrls.get(item) || this.url;
+    const requiredRoles = new Set(selection.roles || []);
+    const requiredMediaTypes = new Set(selection.mediaTypes || []);
+
+    return Object.entries(item.assets)
+      .filter(([, asset]) => {
+        const matchesRole =
+          requiredRoles.size === 0 || asset.roles?.some(role => requiredRoles.has(role));
+        const matchesMediaType =
+          requiredMediaTypes.size === 0 ||
+          Boolean(asset.type && requiredMediaTypes.has(asset.type));
+        return matchesRole && matchesMediaType;
+      })
+      .map(([key, asset]) => ({...asset, key, href: resolveUrl(asset.href, baseUrl)}));
+  }
+
+  /** Fetches every page from a STAC API Collections relation. */
+  private async getAPICollections(
+    root: STACCatalog | STACCollection,
+    signal?: AbortSignal
+  ): Promise<STACCollection[]> {
+    const collectionsLink = findLink(root.links, 'data') || findLink(root.links, 'collections');
+    if (!collectionsLink) {
+      return isCollection(root) ? [root] : [];
+    }
+
+    const collections: STACCollection[] = [];
+    const visitedUrls = new Set<string>();
+    let url: string | null = resolveUrl(collectionsLink.href, this.getDocumentUrl(root));
+    while (url) {
+      throwIfAborted(signal);
+      if (visitedUrls.has(url)) {
+        throw new Error(`STAC Collections pagination cycle detected at ${url}`);
+      }
+      visitedUrls.add(url);
+      const response = await this.fetch(url, {signal});
+      assertResponse(response, url);
+      const page = validateCollections(await response.json(), url);
+      this.attachDocumentUrl(page, url);
+      for (const collection of page.collections) {
+        this.attachDocumentUrl(collection, url);
+      }
+      collections.push(...page.collections);
+      const nextLink = findLink(page.links, 'next');
+      url = nextLink ? resolveUrl(nextLink.href, url) : null;
+    }
+    return collections;
+  }
+
+  /** Traverses only static `child` links to collect Collection documents. */
+  private async getStaticCollections(
+    root: STACCatalog | STACCollection,
+    options: {signal?: AbortSignal; maxDepth?: number; maxRequests?: number}
+  ): Promise<STACCollection[]> {
+    const maxDepth = options.maxDepth ?? this.options.stac?.maxDepth ?? DEFAULT_MAX_DEPTH;
+    const maxRequests =
+      options.maxRequests ?? this.options.stac?.maxRequests ?? DEFAULT_MAX_REQUESTS;
+    validateTraversalLimit('maxDepth', maxDepth);
+    validateTraversalLimit('maxRequests', maxRequests);
+
+    const rootUrl = this.getDocumentUrl(root);
+    const queue: STACTraversalEntry[] = [{url: rootUrl, depth: 0}];
+    const visitedUrls = new Set<string>();
+    const collections: STACCollection[] = [];
+    let requestCount = 0;
+    while (queue.length > 0) {
+      throwIfAborted(options.signal);
+      const entry = queue.shift()!;
+      if (visitedUrls.has(entry.url)) {
+        continue;
+      }
+      if (requestCount >= maxRequests) {
+        throw new Error(`STAC collection traversal exceeded maxRequests (${maxRequests})`);
+      }
+      visitedUrls.add(entry.url);
+      requestCount++;
+
+      const object =
+        entry.url === rootUrl ? root : await this.fetchObject(entry.url, options.signal);
+      if (isCollection(object)) {
+        collections.push(object);
+      }
+      if (!isCatalog(object) && !isCollection(object)) {
+        continue;
+      }
+      if (entry.depth < maxDepth) {
+        for (const link of object.links) {
+          if (link.rel === 'child') {
+            queue.push({
+              url: resolveUrl(link.href, this.getDocumentUrl(object)),
+              depth: entry.depth + 1
+            });
+          }
+        }
+      }
+    }
+    return collections;
+  }
+
+  /** Fetches and validates one core STAC document. */
+  private async fetchObject(url: string, signal?: AbortSignal): Promise<STACObject> {
+    throwIfAborted(signal);
+    const response = await this.fetch(url, {signal});
+    assertResponse(response, url);
+    const object = validateObject(await response.json(), url);
+    this.attachDocumentUrl(object, url);
+    return object;
+  }
+
+  /** Executes one STAC API Item Search page request. */
+  private async fetchItemCollection(
+    request: STACRequest,
+    signal?: AbortSignal
+  ): Promise<STACItemCollection> {
+    const headers = new Headers(request.headers);
+    let url = request.url;
+    let body: string | undefined;
+    if (request.method === 'POST') {
+      headers.set('content-type', 'application/json');
+      body = JSON.stringify(request.body || {});
+    } else if (request.body && Object.keys(request.body).length > 0) {
+      url = appendQuery(url, request.body);
+    }
+    const response = await this.fetch(url, {method: request.method, headers, body, signal});
+    assertResponse(response, url);
+    const page = validateItemCollection(await response.json(), url);
+    this.attachDocumentUrl(page, url);
+    for (const item of page.features) {
+      this.attachDocumentUrl(item, url);
+    }
+    return page;
+  }
+
+  /** Associates an object and its nested links with the fetched document URL. */
+  private attachDocumentUrl(object: STACObject | STACCollections, url: string): void {
+    this.documentUrls.set(object, url);
+  }
+
+  /** Returns the URL from which a STAC object was fetched. */
+  private getDocumentUrl(object: object): string {
+    return this.documentUrls.get(object) || this.url;
+  }
+}
+
+/** Creates the first API Item Search request. */
+function createSearchRequest(link: STACLink, baseUrl: string, query: STACSearchQuery): STACRequest {
+  const {signal: _signal, ...body} = query;
+  return {
+    url: resolveUrl(link.href, baseUrl),
+    method: link.method || 'POST',
+    headers: link.headers,
+    body
+  };
+}
+
+/** Creates a pagination request according to the STAC API next-link fields. */
+function createNextRequest(
+  link: STACLink,
+  baseUrl: string,
+  previousRequest: STACRequest
+): STACRequest {
+  const linkBody = link.body || {};
+  return {
+    url: resolveUrl(link.href, baseUrl),
+    method: link.method || previousRequest.method,
+    headers: {...previousRequest.headers, ...link.headers},
+    body: link.merge ? {...previousRequest.body, ...linkBody} : link.body
+  };
+}
+
+/** Creates a stable pagination-cycle key for GET and POST requests. */
+function getRequestKey(request: STACRequest): string {
+  return `${request.method} ${request.url} ${JSON.stringify(request.body || {})}`;
+}
+
+/** Adds flat STAC Item Search parameters to a GET URL. */
+function appendQuery(url: string, body: Record<string, unknown>): string {
+  const parsedUrl = new URL(url);
+  for (const [key, value] of Object.entries(body)) {
+    if (value !== undefined) {
+      parsedUrl.searchParams.set(key, Array.isArray(value) ? value.join(',') : String(value));
+    }
+  }
+  return parsedUrl.href;
+}
+
+/** Resolves a possibly relative STAC link or asset URL. */
+function resolveUrl(url: string, baseUrl: string): string {
+  return new URL(url, baseUrl).href;
+}
+
+/** Returns the first link with a requested relation. */
+function findLink(links: STACLink[], relation: string): STACLink | undefined {
+  return links.find(link => link.rel === relation);
+}
+
+/** Throws a useful HTTP failure for a STAC request. */
+function assertResponse(response: Response, url: string): void {
+  if (!response.ok) {
+    throw new Error(`STAC request failed (${response.status} ${response.statusText}): ${url}`);
+  }
+}
+
+/** Validates traversal limits shared by static traversal operations. */
+function validateTraversalLimit(name: string, value: number): void {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new Error(`STAC ${name} must be a positive integer`);
+  }
+}
+
+/** Throws an abort reason before starting additional catalog work. */
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw signal.reason || new DOMException('The operation was aborted', 'AbortError');
+  }
+}
+
+/** Validates a core STAC document while preserving extension fields. */
+function validateObject(value: unknown, url: string): STACObject {
+  if (!isRecord(value)) {
+    throw new Error(`Invalid STAC JSON document: ${url}`);
+  }
+  if (value.type === 'Catalog' || value.type === 'Collection') {
+    if (typeof value.id !== 'string' || !Array.isArray(value.links)) {
+      throw new Error(`Invalid STAC Catalog or Collection: ${url}`);
+    }
+    return value as STACCatalog | STACCollection;
+  }
+  if (value.type === 'Feature') {
+    if (typeof value.id !== 'string' || !isRecord(value.assets) || !Array.isArray(value.links)) {
+      throw new Error(`Invalid STAC Item: ${url}`);
+    }
+    return value as STACItem;
+  }
+  if (value.type === 'FeatureCollection') {
+    return validateItemCollection(value, url);
+  }
+  throw new Error(`Unsupported STAC object type at ${url}`);
+}
+
+/** Validates an Item Collection response. */
+function validateItemCollection(value: unknown, url: string): STACItemCollection {
+  if (
+    !isRecord(value) ||
+    value.type !== 'FeatureCollection' ||
+    !Array.isArray(value.features) ||
+    !Array.isArray(value.links)
+  ) {
+    throw new Error(`Invalid STAC ItemCollection: ${url}`);
+  }
+  for (const item of value.features) {
+    if (!isItem(item)) {
+      throw new Error(`Invalid STAC Item in ItemCollection: ${url}`);
+    }
+  }
+  return value as STACItemCollection;
+}
+
+/** Validates a Collections response. */
+function validateCollections(value: unknown, url: string): STACCollections {
+  if (!isRecord(value) || !Array.isArray(value.collections) || !Array.isArray(value.links)) {
+    throw new Error(`Invalid STAC Collections response: ${url}`);
+  }
+  if (!value.collections.every(isCollection)) {
+    throw new Error(`Invalid Collection in STAC Collections response: ${url}`);
+  }
+  return value as STACCollections;
+}
+
+/** Whether a value is a STAC Catalog. */
+function isCatalog(value: unknown): value is STACCatalog {
+  return isRecord(value) && value.type === 'Catalog' && Array.isArray(value.links);
+}
+
+/** Whether a value is a STAC Collection. */
+function isCollection(value: unknown): value is STACCollection {
+  return isRecord(value) && value.type === 'Collection' && Array.isArray(value.links);
+}
+
+/** Whether a value is a STAC Item. */
+function isItem(value: unknown): value is STACItem {
+  return (
+    isRecord(value) &&
+    value.type === 'Feature' &&
+    typeof value.id === 'string' &&
+    isRecord(value.assets) &&
+    Array.isArray(value.links)
+  );
+}
+
+/** Whether a value is a STAC Item Collection. */
+function isItemCollection(value: unknown): value is STACItemCollection {
+  return (
+    isRecord(value) &&
+    value.type === 'FeatureCollection' &&
+    Array.isArray(value.features) &&
+    Array.isArray(value.links)
+  );
+}
+
+/** Whether an unknown JSON value is an object. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+/** Applies the locally supported subset of STAC Item Search parameters. */
+function matchesItem(item: STACItem, query: STACSearchQuery): boolean {
+  if (query.ids && !query.ids.includes(item.id)) {
+    return false;
+  }
+  if (query.collections && (!item.collection || !query.collections.includes(item.collection))) {
+    return false;
+  }
+  if (query.bbox && item.bbox && !intersectsBoundingBox(query.bbox, item.bbox)) {
+    return false;
+  }
+  return !query.datetime || intersectsDatetime(query.datetime, item);
+}
+
+/** Tests two two-dimensional projections of STAC bounding boxes for overlap. */
+function intersectsBoundingBox(left: STACBoundingBox, right: STACBoundingBox): boolean {
+  const leftMaximumX = left.length === 6 ? left[3] : left[2];
+  const leftMaximumY = left.length === 6 ? left[4] : left[3];
+  const rightMaximumX = right.length === 6 ? right[3] : right[2];
+  const rightMaximumY = right.length === 6 ? right[4] : right[3];
+  return !(
+    leftMaximumX < right[0] ||
+    rightMaximumX < left[0] ||
+    leftMaximumY < right[1] ||
+    rightMaximumY < left[1]
+  );
+}
+
+/** Tests a STAC datetime instant or interval against an Item temporal extent. */
+function intersectsDatetime(datetime: string, item: STACItem): boolean {
+  const queryInterval = parseDatetimeInterval(datetime, true);
+  const itemDatetime = item.properties.datetime;
+  const itemInterval =
+    typeof itemDatetime === 'string'
+      ? parseDatetimeInterval(itemDatetime, false)
+      : parseItemDatetimeInterval(item);
+  if (!itemInterval) {
+    return true;
+  }
+  return queryInterval[0] <= itemInterval[1] && itemInterval[0] <= queryInterval[1];
+}
+
+/** Parses a search datetime, optionally throwing for invalid caller input. */
+function parseDatetimeInterval(
+  datetime: string,
+  throwOnInvalid: boolean
+): readonly [number, number] {
+  const parts = datetime.split('/');
+  const start = parts[0] === '..' ? Number.NEGATIVE_INFINITY : Date.parse(parts[0]);
+  const endPart = parts.length > 1 ? parts[1] : parts[0];
+  const end = endPart === '..' ? Number.POSITIVE_INFINITY : Date.parse(endPart);
+  if (parts.length > 2 || Number.isNaN(start) || Number.isNaN(end) || start > end) {
+    if (throwOnInvalid) {
+      throw new Error(`Invalid STAC datetime: ${datetime}`);
+    }
+    return [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY];
+  }
+  return [start, end];
+}
+
+/** Reads an Item start/end datetime interval when no exact datetime is present. */
+function parseItemDatetimeInterval(item: STACItem): readonly [number, number] | null {
+  const start = item.properties.start_datetime;
+  const end = item.properties.end_datetime;
+  if (!start || !end) {
+    return null;
+  }
+  return parseDatetimeInterval(`${start}/${end}`, false);
+}

--- a/modules/stac/src/stac-types.ts
+++ b/modules/stac/src/stac-types.ts
@@ -1,0 +1,230 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** A four- or six-dimensional STAC bounding box. */
+export type STACBoundingBox =
+  | readonly [number, number, number, number]
+  | readonly [number, number, number, number, number, number];
+
+/** Hypermedia link shared by STAC catalogs, collections, items, and API responses. */
+export type STACLink = {
+  /** Link relation such as `self`, `child`, `item`, `next`, or `search`. */
+  rel: string;
+  /** Absolute or document-relative target URL. */
+  href: string;
+  /** Optional media type of the target. */
+  type?: string;
+  /** Human-readable link title. */
+  title?: string;
+  /** HTTP method declared by STAC API pagination links. */
+  method?: 'GET' | 'POST';
+  /** Optional request headers declared by a STAC API link. */
+  headers?: Record<string, string>;
+  /** Optional request body declared by a STAC API link. */
+  body?: Record<string, unknown>;
+  /** Whether a pagination body is merged with the previous request body. */
+  merge?: boolean;
+  /** STAC extension fields. */
+  [key: string]: unknown;
+};
+
+/** Downloadable or streamable resource described by one STAC Item. */
+export type STACAsset = {
+  /** Absolute or document-relative asset URL. */
+  href: string;
+  /** Human-readable asset title. */
+  title?: string;
+  /** Human-readable asset description. */
+  description?: string;
+  /** Asset media type. */
+  type?: string;
+  /** Semantic roles such as `data`, `thumbnail`, or `metadata`. */
+  roles?: string[];
+  /** STAC extension fields. */
+  [key: string]: unknown;
+};
+
+/** Root object for a static STAC Catalog or STAC API. */
+export type STACCatalog = {
+  /** STAC object discriminator. */
+  type: 'Catalog';
+  /** STAC specification version implemented by this object. */
+  stac_version: string;
+  /** STAC extension schema URLs. */
+  stac_extensions?: string[];
+  /** Catalog identifier. */
+  id: string;
+  /** Human-readable title. */
+  title?: string;
+  /** Human-readable description. */
+  description: string;
+  /** Hypermedia links. */
+  links: STACLink[];
+  /** STAC API conformance declaration URLs. */
+  conformsTo?: string[];
+  /** STAC extension fields. */
+  [key: string]: unknown;
+};
+
+/** Spatial and temporal extent of a STAC Collection. */
+export type STACExtent = {
+  /** Collection spatial extents. */
+  spatial: {bbox: STACBoundingBox[]};
+  /** Collection temporal intervals. */
+  temporal: {interval: Array<readonly [string | null, string | null]>};
+};
+
+/** STAC Collection describing a related set of Items. */
+export type STACCollection = {
+  /** STAC object discriminator. */
+  type: 'Collection';
+  /** STAC specification version implemented by this object. */
+  stac_version: string;
+  /** STAC extension schema URLs. */
+  stac_extensions?: string[];
+  /** Collection identifier. */
+  id: string;
+  /** Human-readable title. */
+  title?: string;
+  /** Human-readable description. */
+  description: string;
+  /** Hypermedia links. */
+  links: STACLink[];
+  /** STAC API conformance declaration URLs. */
+  conformsTo?: string[];
+  /** SPDX identifier or `proprietary`/`various`. */
+  license: string;
+  /** Collection spatial and temporal extent. */
+  extent: STACExtent;
+  /** Collection-level assets. */
+  assets?: Record<string, STACAsset>;
+  /** Summary values for Item properties. */
+  summaries?: Record<string, unknown>;
+  /** STAC extension fields. */
+  [key: string]: unknown;
+};
+
+/** GeoJSON geometry carried by a STAC Item. */
+export type STACGeometry = {
+  /** GeoJSON geometry type. */
+  type: string;
+  /** GeoJSON coordinates. */
+  coordinates?: unknown;
+  /** Child geometries for a GeometryCollection. */
+  geometries?: STACGeometry[];
+  /** GeoJSON extension fields. */
+  [key: string]: unknown;
+};
+
+/** One spatiotemporal record and its assets. */
+export type STACItem = {
+  /** GeoJSON feature discriminator. */
+  type: 'Feature';
+  /** STAC specification version implemented by this object. */
+  stac_version: string;
+  /** STAC extension schema URLs. */
+  stac_extensions?: string[];
+  /** Item identifier. */
+  id: string;
+  /** Item geometry, or `null` when unavailable. */
+  geometry: STACGeometry | null;
+  /** Item bounding box. */
+  bbox?: STACBoundingBox;
+  /** Item properties, including `datetime` or start/end datetimes. */
+  properties: Record<string, unknown> & {
+    datetime?: string | null;
+    start_datetime?: string;
+    end_datetime?: string;
+  };
+  /** Collection identifier. */
+  collection?: string;
+  /** Hypermedia links. */
+  links: STACLink[];
+  /** Assets keyed by application-defined names. */
+  assets: Record<string, STACAsset>;
+  /** STAC extension fields. */
+  [key: string]: unknown;
+};
+
+/** Paginated STAC API search response. */
+export type STACItemCollection = {
+  /** GeoJSON collection discriminator. */
+  type: 'FeatureCollection';
+  /** Items in this result page. */
+  features: STACItem[];
+  /** Pagination and related links. */
+  links: STACLink[];
+  /** Total matching Items when reported by the API. */
+  numberMatched?: number;
+  /** Items returned in this response when reported by the API. */
+  numberReturned?: number;
+  /** STAC extension fields. */
+  [key: string]: unknown;
+};
+
+/** Response returned by a STAC API Collections endpoint. */
+export type STACCollections = {
+  /** Collections in this result page. */
+  collections: STACCollection[];
+  /** Pagination and related links. */
+  links: STACLink[];
+  /** STAC extension fields. */
+  [key: string]: unknown;
+};
+
+/** Any core STAC document understood by `STACSource`. */
+export type STACObject = STACCatalog | STACCollection | STACItem | STACItemCollection;
+
+/** Protocol mode discovered from the root STAC document. */
+export type STACMode = 'static' | 'api';
+
+/** Metadata returned by `STACSource.getMetadata()`. */
+export type STACSourceMetadata = {
+  /** Root Catalog or Collection. */
+  root: STACCatalog | STACCollection;
+  /** Whether this source exposes a STAC API search endpoint. */
+  mode: STACMode;
+  /** Declared API conformance classes. */
+  conformsTo: readonly string[];
+};
+
+/** Standard STAC API Item Search parameters supported without extensions. */
+export type STACSearchQuery = {
+  /** Item identifiers to match. */
+  ids?: readonly string[];
+  /** Collection identifiers to match. */
+  collections?: readonly string[];
+  /** Spatial intersection bounding box. */
+  bbox?: STACBoundingBox;
+  /** RFC 3339 datetime or closed/open interval. */
+  datetime?: string;
+  /** Maximum Items requested per API response. */
+  limit?: number;
+  /** Abort this search and its pagination requests. */
+  signal?: AbortSignal;
+};
+
+/** Explicit traversal limits for linked static STAC catalogs. */
+export type STACTraversalOptions = STACSearchQuery & {
+  /** Maximum child-catalog depth below the root. */
+  maxDepth?: number;
+  /** Maximum number of STAC documents fetched. */
+  maxRequests?: number;
+};
+
+/** Selects assets from one STAC Item. */
+export type STACAssetSelection = {
+  /** Require at least one matching asset role. */
+  roles?: readonly string[];
+  /** Require an exact media type. */
+  mediaTypes?: readonly string[];
+};
+
+/** Asset with its Item key and an absolute URL. */
+export type STACResolvedAsset = STACAsset & {
+  /** Key of the asset in the Item. */
+  key: string;
+  /** Absolute asset URL resolved against its containing STAC document. */
+  href: string;
+};

--- a/modules/stac/test/index.ts
+++ b/modules/stac/test/index.ts
@@ -1,0 +1,5 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import './stac-source.spec';

--- a/modules/stac/test/stac-source.spec.ts
+++ b/modules/stac/test/stac-source.spec.ts
@@ -1,0 +1,425 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test, vi} from 'vitest';
+
+import {STACSource, STACSourceLoaderWithParser} from '../src/stac-source';
+import {STACSourceLoader} from '../src/stac-source-loader-types';
+import type {STACItem} from '../src/stac-types';
+
+const ROOT_URL = 'https://example.test/catalog.json';
+
+describe('STACSource metadata loader', () => {
+  test('exposes lightweight metadata and preloads the runtime source', async () => {
+    expect(STACSourceLoader.fromUrl).toBe(true);
+    expect(STACSourceLoader.fromBlob).toBe(false);
+    expect(STACSourceLoader.testURL(ROOT_URL)).toBe(true);
+    expect(STACSourceLoaderWithParser.createDataSource).toBeTypeOf('function');
+    expect(STACSourceLoaderWithParser.createDataSource(ROOT_URL, {})).toBeInstanceOf(STACSource);
+    await expect(STACSourceLoader.preload()).resolves.toBe(STACSourceLoaderWithParser);
+    expect(() => STACSourceLoader.createDataSource(ROOT_URL, {})).toThrow(/async load/);
+    expect(() => STACSourceLoaderWithParser.createDataSource(new Blob(), {})).toThrow(
+      /catalog URL/
+    );
+  });
+});
+
+describe('STACSource static catalogs', () => {
+  test('traverses relative links, avoids cycles, filters Items, and resolves assets', async () => {
+    const documents: Record<string, unknown> = {
+      [ROOT_URL]: createCatalog('root', [
+        {rel: 'child', href: 'collections/places.json'},
+        {rel: 'child', href: 'collections/places.json'}
+      ]),
+      'https://example.test/collections/places.json': createCollection('places', [
+        {rel: 'root', href: '../catalog.json'},
+        {rel: 'item', href: '../items/boston.json'},
+        {rel: 'item', href: '../items/london.json'}
+      ]),
+      'https://example.test/items/boston.json': createItem(
+        'boston',
+        'places',
+        [-71.2, 42.2, -70.9, 42.5],
+        '2026-08-20T12:00:00Z',
+        {
+          data: {
+            href: '../data/boston.parquet',
+            type: 'application/vnd.apache.parquet',
+            roles: ['data']
+          }
+        }
+      ),
+      'https://example.test/items/london.json': createItem(
+        'london',
+        'places',
+        [-0.3, 51.3, 0.1, 51.7],
+        '2020-01-01T00:00:00Z'
+      )
+    };
+    const fetch = createFetch(documents);
+    const source = createSource(ROOT_URL, fetch);
+
+    await expect(source.getMetadata()).resolves.toMatchObject({mode: 'static'});
+    const collections = await source.getCollections();
+    expect(collections.map(collection => collection.id)).toEqual(['places']);
+
+    const items = await collect(
+      source.traverse({
+        bbox: [-72, 41, -70, 43],
+        datetime: '2025-01-01T00:00:00Z/..',
+        collections: ['places']
+      })
+    );
+    expect(items.map(item => item.id)).toEqual(['boston']);
+    expect(source.getAssets(items[0], {roles: ['data']})).toEqual([
+      expect.objectContaining({
+        key: 'data',
+        href: 'https://example.test/data/boston.parquet'
+      })
+    ]);
+    expect(source.getAssets(items[0], {mediaTypes: ['image/png']})).toEqual([]);
+    expect(fetch).toHaveBeenCalledTimes(5);
+  });
+
+  test('requires explicit traversal and enforces traversal limits', async () => {
+    const documents: Record<string, unknown> = {
+      [ROOT_URL]: createCatalog('root', [{rel: 'child', href: 'child.json'}]),
+      'https://example.test/child.json': createCatalog('child', [
+        {rel: 'child', href: 'grandchild.json'}
+      ]),
+      'https://example.test/grandchild.json': createCollection('collection', [])
+    };
+    const source = createSource(ROOT_URL, createFetch(documents));
+
+    await expect(collect(source.search())).rejects.toThrow(/use STACSource\.traverse/);
+    await expect(collect(source.traverse({maxRequests: 1}))).rejects.toThrow(/maxRequests/);
+    await expect(source.getCollections({maxDepth: 0})).rejects.toThrow(/maxDepth/);
+    await expect(source.getCollections({maxDepth: 1})).resolves.toEqual([]);
+  });
+
+  test('supports temporal intervals and conservative filtering of missing extents', async () => {
+    const intervalItem = createItem('interval', 'events', [0, 0, 1, 1], null);
+    intervalItem.properties.start_datetime = '2020-01-01T00:00:00Z';
+    intervalItem.properties.end_datetime = '2020-12-31T23:59:59Z';
+    const unknownItem = createItem('unknown', 'events', [0, 0, 1, 1], null);
+    const documents: Record<string, unknown> = {
+      [ROOT_URL]: createCollection('events', [
+        {rel: 'item', href: 'interval.json'},
+        {rel: 'item', href: 'unknown.json'}
+      ]),
+      'https://example.test/interval.json': intervalItem,
+      'https://example.test/unknown.json': unknownItem
+    };
+    const source = createSource(ROOT_URL, createFetch(documents));
+
+    expect(
+      (await collect(source.traverse({datetime: '2020-06-01T00:00:00Z'}))).map(item => item.id)
+    ).toEqual(['interval', 'unknown']);
+    expect(
+      (await collect(source.traverse({datetime: '2022-01-01T00:00:00Z'}))).map(item => item.id)
+    ).toEqual(['unknown']);
+    await expect(collect(source.traverse({datetime: 'not-a-date'}))).rejects.toThrow(
+      /Invalid STAC datetime/
+    );
+  });
+
+  test('reads linked ItemCollections and exercises all local Item constraints', async () => {
+    const included = createItem('included', 'places', [0, 0, 0, 1, 1, 1]);
+    const wrongId = createItem('wrong-id', 'places', [0, 0, 1, 1]);
+    const noCollection = createItem('included', '', [0, 0, 1, 1]);
+    delete noCollection.collection;
+    const documents: Record<string, unknown> = {
+      [ROOT_URL]: createCatalog('root', [{rel: 'item', href: 'items.json'}]),
+      'https://example.test/items.json': createItemCollection([included, wrongId, noCollection], [])
+    };
+    const source = createSource(ROOT_URL, createFetch(documents));
+
+    const items = await collect(
+      source.traverse({
+        ids: ['included'],
+        collections: ['places'],
+        bbox: [0, 0, 0, 1, 1, 1]
+      })
+    );
+    expect(items).toEqual([included]);
+
+    const detachedItem = createItem('detached', 'places', [0, 0, 1, 1], null, {
+      data: {href: 'data.parquet', type: 'application/vnd.apache.parquet'},
+      preview: {href: 'preview.png', type: 'image/png', roles: ['thumbnail']}
+    });
+    expect(source.getAssets(detachedItem, {roles: ['data']})).toEqual([]);
+    expect(source.getAssets(detachedItem, {mediaTypes: ['image/png']})).toEqual([
+      expect.objectContaining({key: 'preview', href: 'https://example.test/preview.png'})
+    ]);
+  });
+
+  test('propagates aborts, HTTP failures, and invalid documents', async () => {
+    const abortController = new AbortController();
+    abortController.abort(new Error('stop'));
+    const abortedSource = createSource(ROOT_URL, createFetch({}));
+    await expect(abortedSource.getRoot({signal: abortController.signal})).rejects.toThrow('stop');
+
+    const failedSource = createSource(
+      ROOT_URL,
+      vi.fn(async () => new Response('', {status: 503, statusText: 'Unavailable'}))
+    );
+    await expect(failedSource.getRoot()).rejects.toThrow(/503 Unavailable/);
+
+    const invalidSource = createSource(ROOT_URL, createFetch({[ROOT_URL]: {hello: 'world'}}));
+    await expect(invalidSource.getRoot()).rejects.toThrow(/Unsupported STAC object type/);
+
+    const itemRoot = createSource(
+      ROOT_URL,
+      createFetch({[ROOT_URL]: createItem('item-root', 'collection', [0, 0, 1, 1])})
+    );
+    await expect(itemRoot.getRoot()).rejects.toThrow(/root must be a Catalog or Collection/);
+
+    const primitiveRoot = createSource(ROOT_URL, createFetch({[ROOT_URL]: null}));
+    await expect(primitiveRoot.getRoot()).rejects.toThrow(/Invalid STAC JSON document/);
+
+    const invalidCatalog = createSource(
+      ROOT_URL,
+      createFetch({[ROOT_URL]: {type: 'Catalog', id: 7, links: []}})
+    );
+    await expect(invalidCatalog.getRoot()).rejects.toThrow(/Invalid STAC Catalog/);
+  });
+
+  test('bounds Collection traversal independently from Item traversal', async () => {
+    const documents: Record<string, unknown> = {
+      [ROOT_URL]: createCatalog('root', [
+        {rel: 'child', href: 'item.json'},
+        {rel: 'child', href: 'collection.json'}
+      ]),
+      'https://example.test/item.json': createItem('item', 'collection', [0, 0, 1, 1]),
+      'https://example.test/collection.json': createCollection('collection', [])
+    };
+    const source = createSource(ROOT_URL, createFetch(documents));
+    await expect(source.getCollections({maxRequests: 2})).rejects.toThrow(/maxRequests/);
+  });
+});
+
+describe('STACSource API', () => {
+  test('posts Item Search parameters and follows merged POST pagination', async () => {
+    const root = createCatalog('api', [
+      {rel: 'search', href: '/search', method: 'POST'},
+      {rel: 'data', href: '/collections'}
+    ]);
+    root.conformsTo = ['https://api.stacspec.org/v1.0.0/item-search'];
+    const boston = createItem('boston', 'places', [-71.2, 42.2, -70.9, 42.5]);
+    const cambridge = createItem('cambridge', 'places', [-71.2, 42.3, -71, 42.5]);
+    const fetch = vi.fn(async (url: string, options?: RequestInit) => {
+      if (url === ROOT_URL) {
+        return jsonResponse(root);
+      }
+      if (url === 'https://example.test/search') {
+        const body = JSON.parse(String(options?.body || '{}'));
+        if (body.token === 'next-page') {
+          return jsonResponse(createItemCollection([cambridge], []));
+        }
+        expect(options?.method).toBe('POST');
+        expect(body).toEqual({collections: ['places'], bbox: [-72, 41, -70, 43], limit: 1});
+        return jsonResponse(
+          createItemCollection(
+            [boston],
+            [
+              {
+                rel: 'next',
+                href: '/search',
+                method: 'POST',
+                body: {token: 'next-page'},
+                merge: true
+              }
+            ]
+          )
+        );
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+    const source = createSource(ROOT_URL, fetch);
+
+    await expect(source.getMetadata()).resolves.toMatchObject({mode: 'api'});
+    const items = await collect(
+      source.search({collections: ['places'], bbox: [-72, 41, -70, 43], limit: 1})
+    );
+    expect(items.map(item => item.id)).toEqual(['boston', 'cambridge']);
+    expect(fetch).toHaveBeenCalledTimes(3);
+  });
+
+  test('supports GET search and detects pagination cycles', async () => {
+    const root = createCatalog('api', [{rel: 'search', href: '/search', method: 'GET'}]);
+    const fetch = vi.fn(async (url: string) => {
+      if (url === ROOT_URL) {
+        return jsonResponse(root);
+      }
+      expect(url).toContain('ids=one%2Ctwo');
+      return jsonResponse(createItemCollection([], [{rel: 'next', href: url, method: 'GET'}]));
+    });
+    const source = createSource(ROOT_URL, fetch);
+    await expect(collect(source.search({ids: ['one', 'two']}))).rejects.toThrow(/cycle/);
+  });
+
+  test('follows Collections pagination', async () => {
+    const root = createCatalog('api', [{rel: 'data', href: '/collections'}]);
+    root.conformsTo = ['https://api.stacspec.org/v1.0.0/core'];
+    const first = createCollection('first', []);
+    const second = createCollection('second', []);
+    const fetch = createFetch({
+      [ROOT_URL]: root,
+      'https://example.test/collections': {
+        collections: [first],
+        links: [{rel: 'next', href: '?page=2'}]
+      },
+      'https://example.test/collections?page=2': {collections: [second], links: []}
+    });
+    const source = createSource(ROOT_URL, fetch);
+    const collections = await source.getCollections();
+    expect(collections.map(collection => collection.id)).toEqual(['first', 'second']);
+  });
+
+  test('handles APIs without a Collections relation and rejects pagination cycles', async () => {
+    const collectionRoot = createCollection('root-collection', []);
+    collectionRoot.conformsTo = ['https://api.stacspec.org/v1.0.0/core'];
+    const collectionSource = createSource(ROOT_URL, createFetch({[ROOT_URL]: collectionRoot}));
+    await expect(collectionSource.getCollections()).resolves.toEqual([collectionRoot]);
+
+    const catalogRoot = createCatalog('root-catalog', []);
+    catalogRoot.conformsTo = ['https://api.stacspec.org/v1.0.0/core'];
+    const catalogSource = createSource(ROOT_URL, createFetch({[ROOT_URL]: catalogRoot}));
+    await expect(catalogSource.getCollections()).resolves.toEqual([]);
+
+    const cyclingRoot = createCatalog('api', [{rel: 'data', href: '/collections'}]);
+    cyclingRoot.conformsTo = ['https://api.stacspec.org/v1.0.0/core'];
+    const cyclingSource = createSource(
+      ROOT_URL,
+      createFetch({
+        [ROOT_URL]: cyclingRoot,
+        'https://example.test/collections': {
+          collections: [],
+          links: [{rel: 'next', href: '/collections'}]
+        }
+      })
+    );
+    await expect(cyclingSource.getCollections()).rejects.toThrow(/cycle/);
+  });
+
+  test('rejects malformed Item Search and Collections responses', async () => {
+    const searchRoot = createCatalog('api', [{rel: 'search', href: '/search'}]);
+    const invalidItemCollection = createSource(
+      ROOT_URL,
+      createFetch({
+        [ROOT_URL]: searchRoot,
+        'https://example.test/search': {type: 'FeatureCollection', features: [], links: 'bad'}
+      })
+    );
+    await expect(collect(invalidItemCollection.search())).rejects.toThrow(
+      /Invalid STAC ItemCollection/
+    );
+
+    const invalidItem = createSource(
+      ROOT_URL,
+      createFetch({
+        [ROOT_URL]: searchRoot,
+        'https://example.test/search': createItemCollection(
+          [{type: 'Feature', id: 'broken'} as unknown as STACItem],
+          []
+        )
+      })
+    );
+    await expect(collect(invalidItem.search())).rejects.toThrow(/Invalid STAC Item/);
+
+    const collectionsRoot = createCatalog('api', [{rel: 'data', href: '/collections'}]);
+    collectionsRoot.conformsTo = ['https://api.stacspec.org/v1.0.0/core'];
+    const invalidCollections = createSource(
+      ROOT_URL,
+      createFetch({[ROOT_URL]: collectionsRoot, 'https://example.test/collections': {links: []}})
+    );
+    await expect(invalidCollections.getCollections()).rejects.toThrow(
+      /Invalid STAC Collections response/
+    );
+
+    const invalidCollection = createSource(
+      ROOT_URL,
+      createFetch({
+        [ROOT_URL]: collectionsRoot,
+        'https://example.test/collections': {collections: [{type: 'Catalog'}], links: []}
+      })
+    );
+    await expect(invalidCollection.getCollections()).rejects.toThrow(/Invalid Collection/);
+  });
+});
+
+function createSource(url: string, fetch: typeof globalThis.fetch): STACSource {
+  return new STACSource(url, {core: {loadOptions: {core: {fetch}}}});
+}
+
+function createFetch(documents: Record<string, unknown>): typeof globalThis.fetch {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (!(url in documents)) {
+      return new Response('', {status: 404, statusText: 'Not Found'});
+    }
+    return jsonResponse(documents[url]);
+  });
+}
+
+function jsonResponse(value: unknown): Response {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: {'content-type': 'application/json'}
+  });
+}
+
+function createCatalog(id: string, links: Array<Record<string, unknown>>) {
+  return {
+    type: 'Catalog' as const,
+    stac_version: '1.1.0',
+    id,
+    description: id,
+    links
+  };
+}
+
+function createCollection(id: string, links: Array<Record<string, unknown>>) {
+  return {
+    ...createCatalog(id, links),
+    type: 'Collection' as const,
+    license: 'MIT',
+    extent: {
+      spatial: {bbox: [[-180, -90, 180, 90]]},
+      temporal: {interval: [[null, null]]}
+    }
+  };
+}
+
+function createItem(
+  id: string,
+  collection: string,
+  bbox: NonNullable<STACItem['bbox']>,
+  datetime: string | null = '2026-01-01T00:00:00Z',
+  assets: STACItem['assets'] = {}
+): STACItem {
+  return {
+    type: 'Feature',
+    stac_version: '1.1.0',
+    id,
+    collection,
+    bbox,
+    geometry: null,
+    properties: {datetime},
+    links: [],
+    assets
+  };
+}
+
+function createItemCollection(items: STACItem[], links: Array<Record<string, unknown>>) {
+  return {type: 'FeatureCollection' as const, features: items, links};
+}
+
+async function collect<T>(values: AsyncIterable<T>): Promise<T[]> {
+  const result: T[] = [];
+  for await (const value of values) {
+    result.push(value);
+  }
+  return result;
+}

--- a/modules/stac/test/stac-source.spec.ts
+++ b/modules/stac/test/stac-source.spec.ts
@@ -125,13 +125,18 @@ describe('STACSource static catalogs', () => {
   });
 
   test('reads linked ItemCollections and exercises all local Item constraints', async () => {
-    const included = createItem('included', 'places', [0, 0, 0, 1, 1, 1]);
+    const included = createItem('included', 'places', [0, 0, 0, 1, 1, 1], '2026-01-01T00:00:00Z', {
+      data: {href: 'data.parquet', roles: ['data']}
+    });
     const wrongId = createItem('wrong-id', 'places', [0, 0, 1, 1]);
     const noCollection = createItem('included', '', [0, 0, 1, 1]);
     delete noCollection.collection;
     const documents: Record<string, unknown> = {
-      [ROOT_URL]: createCatalog('root', [{rel: 'item', href: 'items.json'}]),
-      'https://example.test/items.json': createItemCollection([included, wrongId, noCollection], [])
+      [ROOT_URL]: createCatalog('root', [{rel: 'item', href: 'pages/items.json'}]),
+      'https://example.test/pages/items.json': createItemCollection(
+        [included, wrongId, noCollection],
+        []
+      )
     };
     const source = createSource(ROOT_URL, createFetch(documents));
 
@@ -143,6 +148,9 @@ describe('STACSource static catalogs', () => {
       })
     );
     expect(items).toEqual([included]);
+    expect(source.getAssets(items[0], {roles: ['data']})).toEqual([
+      expect.objectContaining({href: 'https://example.test/pages/data.parquet'})
+    ]);
 
     const detachedItem = createItem('detached', 'places', [0, 0, 1, 1], null, {
       data: {href: 'data.parquet', type: 'application/vnd.apache.parquet'},
@@ -183,6 +191,34 @@ describe('STACSource static catalogs', () => {
       createFetch({[ROOT_URL]: {type: 'Catalog', id: 7, links: []}})
     );
     await expect(invalidCatalog.getRoot()).rejects.toThrow(/Invalid STAC Catalog/);
+  });
+
+  test('isolates concurrent caller aborts from the cached root fetch', async () => {
+    const firstRequest = createDeferredResponse();
+    const firstFetch = vi.fn(async () => await firstRequest.promise);
+    const firstSource = createSource(ROOT_URL, firstFetch);
+    const firstAbortController = new AbortController();
+    const cancelledFirstCaller = firstSource.getRoot({signal: firstAbortController.signal});
+    const activeSecondCaller = firstSource.getRoot();
+    firstAbortController.abort(new Error('cancel first caller'));
+    firstRequest.resolve(jsonResponse(createCatalog('first-root', [])));
+
+    await expect(cancelledFirstCaller).rejects.toThrow('cancel first caller');
+    await expect(activeSecondCaller).resolves.toMatchObject({id: 'first-root'});
+    expect(firstFetch).toHaveBeenCalledOnce();
+
+    const secondRequest = createDeferredResponse();
+    const secondFetch = vi.fn(async () => await secondRequest.promise);
+    const secondSource = createSource(ROOT_URL, secondFetch);
+    const activeFirstCaller = secondSource.getRoot();
+    const secondAbortController = new AbortController();
+    const cancelledSecondCaller = secondSource.getRoot({signal: secondAbortController.signal});
+    secondAbortController.abort(new Error('cancel second caller'));
+    secondRequest.resolve(jsonResponse(createCatalog('second-root', [])));
+
+    await expect(cancelledSecondCaller).rejects.toThrow('cancel second caller');
+    await expect(activeFirstCaller).resolves.toMatchObject({id: 'second-root'});
+    expect(secondFetch).toHaveBeenCalledOnce();
   });
 
   test('bounds Collection traversal independently from Item traversal', async () => {
@@ -422,4 +458,16 @@ async function collect<T>(values: AsyncIterable<T>): Promise<T[]> {
     result.push(value);
   }
   return result;
+}
+
+/** Creates a manually resolved response promise for concurrent cancellation tests. */
+function createDeferredResponse(): {
+  promise: Promise<Response>;
+  resolve: (response: Response) => void;
+} {
+  let resolve!: (response: Response) => void;
+  const promise = new Promise<Response>(resolvePromise => {
+    resolve = resolvePromise;
+  });
+  return {promise, resolve};
 }

--- a/modules/stac/tsconfig.json
+++ b/modules/stac/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "references": [{"path": "../loader-utils"}]
+}

--- a/modules/wms/src/csw-source-loader.ts
+++ b/modules/wms/src/csw-source-loader.ts
@@ -4,7 +4,13 @@
 
 /* eslint-disable camelcase */
 
-import type {CoreAPI, SourceLoader, DataSourceOptions} from '@loaders.gl/loader-utils';
+import type {
+  CatalogSource,
+  CatalogSourceCapabilities,
+  CoreAPI,
+  SourceLoader,
+  DataSourceOptions
+} from '@loaders.gl/loader-utils';
 import {DataSource} from '@loaders.gl/loader-utils';
 
 import type {CSWCapabilities} from './csw-capabilities-loader';
@@ -17,6 +23,10 @@ import type {CSWDomain} from './csw-domain-loader';
 import {CSWDomainLoaderWithParser} from './csw-domain-loader-with-parser';
 
 import {WMSErrorLoaderWithParser} from './wms-error-loader-with-parser';
+
+// __VERSION__ is injected by babel-plugin-version-inline
+// @ts-ignore TS2304: Cannot find name '__VERSION__'.
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
 /** Describes a service or resource exposed by the catalog */
 export type Service = {
@@ -47,7 +57,7 @@ export type CSWGetRecordsParameters = CSWCommonParameters & {
   /** Request type */
   request?: 'GetRecords';
   /** type of records */
-  typenames: 'csw:Record';
+  typenames?: 'csw:Record';
 };
 
 export type CSWGetDomainParameters = CSWCommonParameters & {
@@ -57,7 +67,18 @@ export type CSWGetDomainParameters = CSWCommonParameters & {
 };
 
 export type CSWSourceLoaderOptions = DataSourceOptions & {
-  csw?: {};
+  csw?: Record<string, never>;
+};
+
+/** One catalog record returned by a CSW `GetRecords` response. */
+export type CSWRecord = CSWRecords['records'][number];
+
+/** Query accepted by the shared catalog search interface. */
+export type CSWCatalogQuery = {
+  /** Standard CSW `GetRecords` parameters. */
+  parameters?: CSWGetRecordsParameters;
+  /** Vendor-specific query parameters appended to the request. */
+  vendorParameters?: Record<string, unknown>;
 };
 
 export const CSWSourceLoader = {
@@ -66,22 +87,18 @@ export const CSWSourceLoader = {
   name: 'CSW',
   id: 'csw',
   module: 'wms',
-  version: '0.0.0',
+  version: VERSION,
   extensions: [],
   mimeTypes: [],
   type: 'csw',
   fromUrl: true,
   fromBlob: false,
 
-  options: {
-    wfs: {}
-  },
+  options: {csw: {}},
 
-  defaultOptions: {
-    wfs: {}
-  },
+  defaultOptions: {csw: {}},
 
-  testURL: (url: string): boolean => url.toLowerCase().includes('wfs'),
+  testURL: (url: string): boolean => CSWCatalogSource.testURL(url),
   createDataSource: (
     url: string,
     options: CSWSourceLoaderOptions,
@@ -95,11 +112,26 @@ export const CSWSourceLoader = {
  * - provides type safe methods to query and parse results (and errors) from a CSW service
  * @note Only the URL parameter conversion is supported. XML posts are not supported.
  */
-export class CSWCatalogSource extends DataSource<string, CSWSourceLoaderOptions> {
+export class CSWCatalogSource
+  extends DataSource<string, CSWSourceLoaderOptions>
+  implements CatalogSource<CSWRecord, CSWCatalogQuery, CSWCapabilities>
+{
   static readonly type = 'csw';
   static testURL = (url: string): boolean => url.toLowerCase().includes('csw');
 
-  capabilities: CSWCapabilities | null = null;
+  /** Features exposed through the protocol-neutral catalog interface. */
+  readonly capabilities: CatalogSourceCapabilities = Object.freeze({
+    search: true,
+    pagination: false,
+    hierarchy: false,
+    spatialFilter: false,
+    temporalFilter: false,
+    textFilter: false,
+    cql2Filter: false,
+    collections: false,
+    assets: false
+  });
+
   /** A list of loaders used by the CSWCatalogSource methods */
   readonly loaders = [WMSErrorLoaderWithParser, CSWCapabilitiesLoaderWithParser];
 
@@ -115,6 +147,12 @@ export class CSWCatalogSource extends DataSource<string, CSWSourceLoaderOptions>
 
   normalizeMetadata(capabilities: CSWCapabilities): CSWCapabilities {
     return capabilities;
+  }
+
+  /** Searches one page of CSW records through the shared catalog interface. */
+  async *search(query: CSWCatalogQuery = {}): AsyncIterable<CSWRecord> {
+    const records = await this.getRecords(query.parameters, query.vendorParameters);
+    yield* records.records;
   }
 
   async getServiceDirectory(options?: {includeUnknown?: boolean}): Promise<Service[]> {
@@ -277,8 +315,8 @@ export class CSWCatalogSource extends DataSource<string, CSWSourceLoaderOptions>
 
   /** Checks for and parses a CSW XML formatted ServiceError and throws an exception */
   protected _checkResponse(response: Response, arrayBuffer: ArrayBuffer): void {
-    const contentType = response.headers['content-type'];
-    if (!response.ok || WMSErrorLoaderWithParser.mimeTypes.includes(contentType)) {
+    const contentType = response.headers.get('content-type') || '';
+    if (!response.ok || WMSErrorLoaderWithParser.mimeTypes.some(type => type === contentType)) {
       const error = WMSErrorLoaderWithParser.parseSync?.(
         arrayBuffer,
         this.options.core.loadOptions

--- a/modules/wms/src/index.ts
+++ b/modules/wms/src/index.ts
@@ -69,7 +69,12 @@ export {GMLLoader as _GMLLoader} from './gml-loader';
 
 // OGC Services
 
-// export {CSWSourceLoader} from './csw-source-loader';
+export type {
+  CSWCatalogQuery,
+  CSWRecord,
+  CSWSourceLoaderOptions
+} from './csw-source-loader';
+export {CSWCatalogSource, CSWSourceLoader} from './csw-source-loader';
 export {WMSSourceLoader, WMSImageSource} from './wms-source-loader';
 export {WFSSourceLoader, WFSVectorSource} from './wfs-source-loader';
 

--- a/modules/wms/test/csw/csw-source.spec.ts
+++ b/modules/wms/test/csw/csw-source.spec.ts
@@ -1,0 +1,34 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test, vi} from 'vitest';
+
+import type {CSWCapabilities, CSWRecords} from '@loaders.gl/wms';
+import {CSWCatalogSource, CSWSourceLoader} from '@loaders.gl/wms';
+
+describe('CSWCatalogSource', () => {
+  test('implements the shared catalog contract', async () => {
+    const source = new CSWCatalogSource('https://example.test/csw', {});
+    const capabilities = {version: '3.0.0'} as unknown as CSWCapabilities;
+    const records = {
+      records: [{title: 'A'}, {title: 'B'}]
+    } as unknown as CSWRecords;
+    vi.spyOn(source, 'getCapabilities').mockResolvedValue(capabilities);
+    vi.spyOn(source, 'getRecords').mockResolvedValue(records);
+
+    expect(source.capabilities).toMatchObject({search: true, pagination: false});
+    await expect(source.getMetadata()).resolves.toBe(capabilities);
+    expect(await collect(source.search())).toEqual(records.records);
+    expect(CSWSourceLoader.testURL('https://example.test/csw')).toBe(true);
+    expect(CSWSourceLoader.testURL('https://example.test/wfs')).toBe(false);
+  });
+});
+
+async function collect<T>(values: AsyncIterable<T>): Promise<T[]> {
+  const result: T[] = [];
+  for await (const value of values) {
+    result.push(value);
+  }
+  return result;
+}

--- a/modules/wms/test/csw/csw-source.spec.ts
+++ b/modules/wms/test/csw/csw-source.spec.ts
@@ -23,7 +23,22 @@ describe('CSWCatalogSource', () => {
     expect(CSWSourceLoader.testURL('https://example.test/csw')).toBe(true);
     expect(CSWSourceLoader.testURL('https://example.test/wfs')).toBe(false);
   });
+
+  test('accepts successful responses without an error content type', () => {
+    const source = new TestCSWCatalogSource('https://example.test/csw', {});
+    const response = new Response(null, {status: 200});
+
+    expect(() => source.checkResponse(response, new ArrayBuffer(0))).not.toThrow();
+  });
 });
+
+/** Test facade exposing the protected response validator. */
+class TestCSWCatalogSource extends CSWCatalogSource {
+  /** Invokes the protected response validator for focused behavior coverage. */
+  checkResponse(response: Response, arrayBuffer: ArrayBuffer): void {
+    this._checkResponse(response, arrayBuffer);
+  }
+}
 
 async function collect<T>(values: AsyncIterable<T>): Promise<T[]> {
   const result: T[] = [];

--- a/modules/wms/test/index.ts
+++ b/modules/wms/test/index.ts
@@ -7,6 +7,7 @@
 import './csw/csw-capabilities-loader.spec';
 import './csw/csw-domain-loader.spec';
 import './csw/csw-records-loader.spec';
+import './csw/csw-source.spec';
 
 // WMS - Web Map Service
 

--- a/test/aliases.ts
+++ b/test/aliases.ts
@@ -48,6 +48,7 @@ function makeAliases() {
     '@loaders.gl/pcd/test': resolveTestPath('./modules/pcd/test'),
     '@loaders.gl/ply/test': resolveTestPath('./modules/ply/test'),
     '@loaders.gl/splats/test': resolveTestPath('./modules/splats/test'),
+    '@loaders.gl/stac/test': resolveTestPath('./modules/stac/test'),
     '@loaders.gl/pmtiles/test': resolveTestPath('./modules/pmtiles/test'),
     '@loaders.gl/polyfills/test': resolveTestPath('./modules/polyfills/test'),
     '@loaders.gl/potree/test': resolveTestPath('./modules/potree/test'),

--- a/test/coverage-thresholds.json
+++ b/test/coverage-thresholds.json
@@ -587,6 +587,21 @@
         "branches": 49
       }
     },
+    "@loaders.gl/stac": {
+      "path": "modules/stac",
+      "browser": {
+        "statements": 90,
+        "lines": 90,
+        "functions": 90,
+        "branches": 90
+      },
+      "merged": {
+        "statements": 90,
+        "lines": 90,
+        "functions": 90,
+        "branches": 90
+      }
+    },
     "@loaders.gl/terrain": {
       "path": "modules/terrain",
       "browser": {

--- a/test/modules.ts
+++ b/test/modules.ts
@@ -52,6 +52,7 @@ import '@loaders.gl/kml/test';
 import '@loaders.gl/shapefile/test';
 import '@loaders.gl/wkt/test';
 import '@loaders.gl/wms/test';
+import '@loaders.gl/stac/test';
 
 import '@loaders.gl/mlt/test';
 import '@loaders.gl/mvt/test';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -280,6 +280,15 @@
       "@loaders.gl/splats/test": [
         "modules/splats/test"
       ],
+      "@loaders.gl/stac": [
+        "modules/stac/src"
+      ],
+      "@loaders.gl/stac/*": [
+        "modules/stac/src/*"
+      ],
+      "@loaders.gl/stac/test": [
+        "modules/stac/test"
+      ],
       "@loaders.gl/scene": [
         "modules/scene/src"
       ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5836,6 +5836,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@loaders.gl/stac@workspace:modules/stac":
+  version: 0.0.0-use.local
+  resolution: "@loaders.gl/stac@workspace:modules/stac"
+  dependencies:
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.1"
+  peerDependencies:
+    "@loaders.gl/core": ~5.0.0-alpha.0
+  languageName: unknown
+  linkType: soft
+
 "@loaders.gl/terrain@npm:^5.0.0-alpha.0, @loaders.gl/terrain@workspace:modules/terrain":
   version: 0.0.0-use.local
   resolution: "@loaders.gl/terrain@workspace:modules/terrain"


### PR DESCRIPTION
## Goals

- Add a small, browser-first STAC source that discovers cloud-native assets without bringing a database or rendering dependency into loaders.gl.
- Define a narrow catalog contract shared by STAC and CSW while retaining protocol-specific APIs.
- Preserve correctness and graceful fallback in the newly landed Parquet page-index pruning.

## Changes

- Adds the experimental `@loaders.gl/stac` package with a lightweight root loader and explicit runtime subpath.
- Supports static Catalog/Collection traversal with cycle, depth, request, spatial, temporal, collection, and ID controls.
- Supports STAC API Item Search and Collections pagination, including GET/POST next-link bodies and merge semantics.
- Resolves relative Item asset URLs and filters assets by role or media type.
- Adds `CatalogSource` and capability types to `@loaders.gl/loader-utils`; adapts and republishes `CSWCatalogSource` through the same contract.
- Documents static versus API behavior, format-source composition, and the separate CORS plus byte-range requirements for browser-native asset queries.
- Fixes follow-up findings from #3623: unsigned `UINT_32`/`UINT_64` page bounds and optional index ranges outside the source file.
- Adds focused browser tests and a 90% initial coverage ratchet for the new STAC package.

## Validation

- `yarn lint fix`
- TypeScript project builds for loader-utils, Parquet, WMS, and STAC
- STAC source browser tests: 12 passed
- CSW catalog-contract browser test: passed
- Parquet page-index follow-up browser tests: passed

Full repository CI is running on the pushed branch.
