### PR TITLE
fix(parquet): stream during dataset discovery

### DIFF
--- a/docs/modules/parquet/api-reference/parquet-source-loader.md
+++ b/docs/modules/parquet/api-reference/parquet-source-loader.md
@@ -65,7 +65,7 @@ const source = createDataSource(url, [ParquetSourceLoader], {});
 ## Multi-file datasets
 
 `ParquetDatasetSource` composes a lazy file provider with one selective `ParquetSource` per selected
-file. The provider may be backed by STAC, a database, an application manifest, or a static list;
+file. The provider may be backed by STAC, a database, an application manifest, or a static array;
 the Parquet module does not depend on any catalog protocol.
 
 ```ts
@@ -121,6 +121,10 @@ later files in memory. Each batch adds `datasetFileIndex`, `datasetFileId`, `dat
 `datasetFileMetadata` without copying its Arrow buffers. Predicates, projection, batching, range
 requests, worker decoding, cancellation, and exact row provenance remain the responsibility of each
 child `ParquetSource`.
+
+Static descriptors must be supplied as a reusable array. Streaming or one-shot iterables belong
+inside a provider function so every `getSchema()` or `read()` operation receives a fresh collection.
+Catalog discovery for later files overlaps decoding and consumption of the first selected file.
 
 Files must expose the same field schema by default. Set `parquetDataset.validateSchema` to `false`
 only when the caller intentionally handles heterogeneous Arrow batches. `getTelemetry()` reports

--- a/modules/parquet/src/parquet-dataset-source.ts
+++ b/modules/parquet/src/parquet-dataset-source.ts
@@ -82,6 +82,11 @@ export class ParquetDatasetSource {
     options: ParquetDatasetSourceOptions = {},
     coreApi?: CoreAPI
   ) {
+    if (!Array.isArray(files) && typeof files !== 'function') {
+      throw new Error(
+        'ParquetDatasetSource files must be a reusable descriptor array or a provider function'
+      );
+    }
     this.files = files;
     this.options = options;
     this.coreApi = coreApi;
@@ -136,6 +141,7 @@ export class ParquetDatasetSource {
     let nextSchedulePosition = 0;
     let nextYieldPosition = 0;
     let providerComplete = false;
+    let discoveryError: unknown;
     const fileConcurrency = normalizeFileConcurrency(
       options.fileConcurrency ?? this.options.parquetDataset?.fileConcurrency
     );
@@ -155,10 +161,20 @@ export class ParquetDatasetSource {
       scheduledReads.set(position, {queue, task});
     };
 
-    try {
-      while (scheduledReads.size < fileConcurrency && !providerComplete) {
-        await scheduleNext();
+    const fillAvailableSlots = async (): Promise<void> => {
+      try {
+        while (scheduledReads.size < fileConcurrency && !providerComplete) {
+          await scheduleNext();
+        }
+      } catch (error) {
+        discoveryError = error;
+        providerComplete = true;
       }
+    };
+
+    try {
+      await scheduleNext();
+      let discoveryPromise = fillAvailableSlots();
 
       while (scheduledReads.size > 0) {
         const scheduledRead = scheduledReads.get(nextYieldPosition);
@@ -173,7 +189,15 @@ export class ParquetDatasetSource {
         }
         await scheduledRead.task;
         scheduledReads.delete(nextYieldPosition++);
-        await scheduleNext();
+        await discoveryPromise;
+        if (discoveryError !== undefined) {
+          throw discoveryError;
+        }
+        discoveryPromise = fillAvailableSlots();
+      }
+      await discoveryPromise;
+      if (discoveryError !== undefined) {
+        throw discoveryError;
       }
     } finally {
       readContext.abortController.abort();
@@ -301,7 +325,7 @@ async function getFileCollection(
   files: ParquetDatasetFiles,
   query: ParquetDatasetFileQuery
 ): Promise<ParquetDatasetFileCollection> {
-  return typeof files === 'function' ? await (files as ParquetDatasetFileProvider)(query) : files;
+  return typeof files === 'function' ? await files(query) : files;
 }
 
 /** Attaches dataset-level descriptor provenance without copying Arrow buffers. */

--- a/modules/parquet/src/parquet-dataset-source.ts
+++ b/modules/parquet/src/parquet-dataset-source.ts
@@ -13,7 +13,6 @@ import type {
   ParquetDatasetBoundingBox,
   ParquetDatasetFile,
   ParquetDatasetFileCollection,
-  ParquetDatasetFileProvider,
   ParquetDatasetFileQuery,
   ParquetDatasetFiles,
   ParquetDatasetPartitionValue,

--- a/modules/parquet/src/parquet-source-types.ts
+++ b/modules/parquet/src/parquet-source-types.ts
@@ -401,8 +401,8 @@ export type ParquetDatasetFileProvider = (
   query: ParquetDatasetFileQuery
 ) => ParquetDatasetFileCollection | Promise<ParquetDatasetFileCollection>;
 
-/** Static descriptors or a lazy catalog-backed provider accepted by `ParquetDatasetSource`. */
-export type ParquetDatasetFiles = ParquetDatasetFileCollection | ParquetDatasetFileProvider;
+/** Reusable static descriptors or a lazy catalog-backed provider accepted by the dataset source. */
+export type ParquetDatasetFiles = readonly ParquetDatasetFile[] | ParquetDatasetFileProvider;
 
 /** Options for constructing a multi-file `ParquetDatasetSource`. */
 export type ParquetDatasetSourceOptions = ParquetSourceLoaderOptions & {

--- a/modules/parquet/test/parquet-dataset-source.spec.ts
+++ b/modules/parquet/test/parquet-dataset-source.spec.ts
@@ -66,6 +66,35 @@ describe('ParquetDatasetSource', () => {
     await source.close();
   });
 
+  test('emits the first file while lazy discovery of later files is blocked', async () => {
+    let releaseDiscovery: (() => void) | undefined;
+    const discoveryBlocked = new Promise<void>(resolve => {
+      releaseDiscovery = resolve;
+    });
+    const source = new ParquetDatasetSource(
+      async function* () {
+        yield {data: westernFile, id: 'first'};
+        await discoveryBlocked;
+        yield {data: easternFile, id: 'second'};
+      },
+      {core: {worker: false}, parquetDataset: {fileConcurrency: 2}}
+    );
+    const iterator = source.read()[Symbol.asyncIterator]();
+
+    const first = await Promise.race([
+      iterator.next(),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('first batch waited for later discovery')), 1000)
+      )
+    ]);
+    expect(first.value?.datasetFileId).toBe('first');
+
+    releaseDiscovery?.();
+    const remaining = await collectBatches({[Symbol.asyncIterator]: () => iterator});
+    expect(remaining.map(batch => batch.datasetFileId)).toEqual(['second']);
+    await source.close();
+  });
+
   test('passes discovery constraints to providers and conservatively prunes descriptors', async () => {
     let providerQuery: ParquetDatasetFileQuery | undefined;
     const source = new ParquetDatasetSource(
@@ -182,6 +211,16 @@ describe('ParquetDatasetSource', () => {
     await expect(collectBatches(invalidConcurrencySource.read())).rejects.toThrow(
       'fileConcurrency must be a positive integer'
     );
+
+    const oneShotFiles = (function* () {
+      yield {data: westernFile};
+    })();
+    expect(
+      () =>
+        new ParquetDatasetSource(
+          oneShotFiles as unknown as ConstructorParameters<typeof ParquetDatasetSource>[0]
+        )
+    ).toThrow('reusable descriptor array or a provider function');
   });
 
   test('aborts active reads when closed and rejects later operations', async () => {


### PR DESCRIPTION
## Goals

- Address the two post-merge review findings from #3626.
- Preserve prompt first-file results during slow catalog discovery.
- Prevent schema inspection from consuming one-shot dataset inputs.

## Changes

- Consume the first file queue while later provider discovery fills concurrency slots in parallel.
- Restrict reusable static inputs to descriptor arrays; streaming iterables must be returned by a provider factory.
- Document the lifecycle contract.
- Add regressions for blocked later discovery and rejected one-shot top-level iterables.

## Validation

- `yarn lint fix`
- focused Chromium tests — 8 passed
- `yarn test-node` — 191 passed
