### PR TITLE
chore: normalize SPDX license expressions

### DIFF
--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile-gltf.ts
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile-gltf.ts
@@ -1,5 +1,5 @@
 // loaders.gl
-// SPDX-License-Identifier: MIT license
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
 import {parseFromContext, LoaderContext} from '@loaders.gl/loader-utils';

--- a/modules/3d-tiles/test/tile-3d-subtree-loader.spec.ts
+++ b/modules/3d-tiles/test/tile-3d-subtree-loader.spec.ts
@@ -1,5 +1,5 @@
 // loaders.gl
-// SPDX-License-Identifier: MIT and Apache-2.0
+// SPDX-License-Identifier: MIT AND Apache-2.0
 // Copyright vis.gl contributors
 
 // This file is derived from the Cesium code base under Apache 2 license

--- a/modules/gis/src/lib/geometry-converters/wkb/triangulate-wkb.ts
+++ b/modules/gis/src/lib/geometry-converters/wkb/triangulate-wkb.ts
@@ -1,5 +1,5 @@
 // loaders.gl
-// SPDX-License-Identifier: MIT and ISC
+// SPDX-License-Identifier: MIT AND ISC
 // Copyright (c) vis.gl contributors
 
 /*

--- a/modules/json/src/lib/clarinet/clarinet.ts
+++ b/modules/json/src/lib/clarinet/clarinet.ts
@@ -1,5 +1,5 @@
 // loaders.gl
-// SPDX-License-Identifier: MIT AND BSD
+// SPDX-License-Identifier: MIT AND BSD-2-Clause
 // Copyright (c) vis.gl contributors
 // This is a fork of the clarinet library, originally BSD license (see LICENSE file)
 // loaders.gl changes:


### PR DESCRIPTION
Goals of this PR

Normalize existing SPDX license expressions whose provenance already establishes whether MIT applies.

Actual changes

- Correct the MIT-only expression in the 3D Tiles glTF parser.
- Use SPDX `AND` syntax for the Cesium-derived 3D Tiles test and the Earcut-derived WKB triangulator.
- Specify the checked-in Clarinet BSD two-clause license as `BSD-2-Clause` alongside loaders.gl MIT changes.

Validation

- `yarn lint fix`
- `git diff --check`