### PR TITLE
feat(gltf): select supported AVIF texture sources

### DIFF
--- a/docs/modules/gltf/formats/gltf.md
+++ b/docs/modules/gltf/formats/gltf.md
@@ -94,6 +94,10 @@ loaders.gl aims to provide support for glTF extensions that can be handled compl
 
 Note that many glTF extensions affect aspects that are firmly outside of the scope of loaders.gl (e.g. rendering), and no attempt is made to process those extensions in loaders.gl.
 
+For optional WebP or AVIF extensions, `GLTFLoader` retains the ordinary texture source when the
+active runtime cannot decode the extension image. A required extension fails before image loading
+when its image MIME type is unsupported.
+
 | Extension                                                 | Preprocessed | Description                                                                                 |
 | --------------------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------- |
 | [KHR_draco_mesh_compression](#khr_draco_mesh_compression) | Y            | Decompresses draco-compressed geometries                                                    |
@@ -101,7 +105,8 @@ Note that many glTF extensions affect aspects that are firmly outside of the sco
 | [EXT_meshopt_compression](#ext_meshopt_compression)       | Y            | Decompresses existing version 0 meshopt streams                                             |
 | [KHR_texture_basisu](#khr_texture_basisu)                 | Y            | Adds the ability to specify textures using KTX v2                                           |
 | [KHR_texture_transform](#khr_texture_transform)           | Y            | Adds transformation properties (translation, rotation, scale) for TEXCOORD\_ mesh attribute |
-| KHR_texture_webp                                          | Y            |
+| [EXT_texture_webp](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Vendor/EXT_texture_webp) | Y | Selects the WebP source when the active decoder supports it |
+| [EXT_texture_avif](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Vendor/EXT_texture_avif) | Y | Selects the AVIF source when the active decoder supports it |
 | [EXT_mesh_features](#ext_mesh_features)                   | Y            | 3D tiles extension                                                                          |
 | [EXT_structural_metadata](#ext_structural_metadata)       | Y            | 3D tiles extension                                                                          |
 | [KHR_lights_punctual](#khr_lights_punctual)               | Y\*          | Deprecated                                                                                  |

--- a/modules/gltf/src/lib/api/gltf-extensions.ts
+++ b/modules/gltf/src/lib/api/gltf-extensions.ts
@@ -18,6 +18,7 @@ import * as EXT_structural_metadata from '../extensions/EXT_structural_metadata'
 import * as EXT_meshopt_compression from '../extensions/EXT_meshopt_compression';
 import * as KHR_meshopt_compression from '../extensions/KHR_meshopt_compression';
 import * as EXT_texture_webp from '../extensions/EXT_texture_webp';
+import * as EXT_texture_avif from '../extensions/EXT_texture_avif';
 import * as KHR_texture_basisu from '../extensions/KHR_texture_basisu';
 import * as KHR_draco_mesh_compression from '../extensions/KHR_draco_mesh_compression';
 import * as KHR_texture_transform from '../extensions/KHR_texture_transform';
@@ -57,6 +58,7 @@ export const EXTENSIONS: GLTFExtensionPlugin[] = [
   EXT_mesh_features,
   KHR_meshopt_compression,
   EXT_meshopt_compression,
+  EXT_texture_avif,
   EXT_texture_webp,
   // Basisu should come after webp, we want basisu to be preferred if both are provided
   KHR_texture_basisu,

--- a/modules/gltf/src/lib/api/gltf-extensions.ts
+++ b/modules/gltf/src/lib/api/gltf-extensions.ts
@@ -31,7 +31,11 @@ import * as EXT_feature_metadata from '../extensions/deprecated/EXT_feature_meta
 
 type GLTFExtensionPlugin = {
   name: string;
-  preprocess?: (gltfData: {json: GLTF}, options: GLTFLoaderOptions, context) => void;
+  preprocess?: (
+    gltfData: {json: GLTF},
+    options: GLTFLoaderOptions,
+    context
+  ) => void | Promise<void>;
   decode?: (
     gltfData: {
       json: GLTF;
@@ -76,10 +80,10 @@ export const EXTENSIONS: GLTFExtensionPlugin[] = [
 const EXTENSIONS_ENCODING: GLTFExtensionPlugin[] = [EXT_structural_metadata, EXT_mesh_features];
 
 /** Call before any resource loading starts */
-export function preprocessExtensions(gltf, options: GLTFLoaderOptions = {}, context?) {
+export async function preprocessExtensions(gltf, options: GLTFLoaderOptions = {}, context?) {
   const extensions = EXTENSIONS.filter(extension => useExtension(extension.name, options));
   for (const extension of extensions) {
-    extension.preprocess?.(gltf, options, context);
+    await extension.preprocess?.(gltf, options, context);
   }
 }
 

--- a/modules/gltf/src/lib/extensions/EXT_texture_avif.ts
+++ b/modules/gltf/src/lib/extensions/EXT_texture_avif.ts
@@ -1,0 +1,53 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+// GLTF EXTENSION: EXT_TEXTURE_AVIF
+// https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Vendor/EXT_texture_avif
+/* eslint-disable camelcase */
+
+import type {GLTF, GLTF_EXT_texture_avif} from '../types/gltf-json-schema';
+import type {GLTFLoaderOptions} from '../../gltf-loader';
+
+import {isImageFormatSupported} from '@loaders.gl/images';
+import {GLTFScenegraph} from '../api/gltf-scenegraph';
+
+const EXT_TEXTURE_AVIF = 'EXT_texture_avif';
+
+/** Extension name. */
+export const name = EXT_TEXTURE_AVIF;
+
+/**
+ * Selects AVIF image sources when the active image decoder supports AVIF.
+ *
+ * Optional AVIF sources retain their ordinary texture source when unsupported. Required AVIF
+ * sources fail before image loading so callers never receive a texture with an invalid source.
+ *
+ * @param gltfData Parsed glTF JSON whose texture sources may be updated in place.
+ * @param options glTF loader options. The extension currently has no custom options.
+ */
+export function preprocess(gltfData: {json: GLTF}, options: GLTFLoaderOptions): void {
+  void options;
+  const scenegraph = new GLTFScenegraph(gltfData);
+
+  if (!isImageFormatSupported('image/avif')) {
+    if (scenegraph.getRequiredExtensions().includes(EXT_TEXTURE_AVIF)) {
+      throw new Error(`gltf: Required extension ${EXT_TEXTURE_AVIF} not supported by browser`);
+    }
+    return;
+  }
+
+  const {json} = scenegraph;
+  for (const texture of json.textures || []) {
+    const extension = scenegraph.getObjectExtension<GLTF_EXT_texture_avif>(
+      texture,
+      EXT_TEXTURE_AVIF
+    );
+    if (extension) {
+      texture.source = extension.source;
+    }
+    scenegraph.removeObjectExtension(texture, EXT_TEXTURE_AVIF);
+  }
+
+  scenegraph.removeExtension(EXT_TEXTURE_AVIF);
+}

--- a/modules/gltf/src/lib/extensions/EXT_texture_avif.ts
+++ b/modules/gltf/src/lib/extensions/EXT_texture_avif.ts
@@ -9,7 +9,7 @@
 import type {GLTF, GLTF_EXT_texture_avif} from '../types/gltf-json-schema';
 import type {GLTFLoaderOptions} from '../../gltf-loader';
 
-import {isImageFormatSupported} from '@loaders.gl/images';
+import {getSupportedImageFormats} from '@loaders.gl/images';
 import {GLTFScenegraph} from '../api/gltf-scenegraph';
 
 const EXT_TEXTURE_AVIF = 'EXT_texture_avif';
@@ -26,11 +26,15 @@ export const name = EXT_TEXTURE_AVIF;
  * @param gltfData Parsed glTF JSON whose texture sources may be updated in place.
  * @param options glTF loader options. The extension currently has no custom options.
  */
-export function preprocess(gltfData: {json: GLTF}, options: GLTFLoaderOptions): void {
+export async function preprocess(
+  gltfData: {json: GLTF},
+  options: GLTFLoaderOptions
+): Promise<void> {
   void options;
   const scenegraph = new GLTFScenegraph(gltfData);
 
-  if (!isImageFormatSupported('image/avif')) {
+  const supportedImageFormats = await getSupportedImageFormats();
+  if (!supportedImageFormats.has('image/avif')) {
     if (scenegraph.getRequiredExtensions().includes(EXT_TEXTURE_AVIF)) {
       throw new Error(`gltf: Required extension ${EXT_TEXTURE_AVIF} not supported by browser`);
     }

--- a/modules/gltf/src/lib/parsers/parse-gltf.ts
+++ b/modules/gltf/src/lib/parsers/parse-gltf.ts
@@ -95,7 +95,7 @@ async function parseGLTFWithExternalAssets(
 
   normalizeGLTFV1(gltf, {normalize: options?.gltf?.normalize});
 
-  preprocessExtensions(gltf, options, context);
+  await preprocessExtensions(gltf, options, context);
 
   // Load linked buffers asynchronously and decodes base64 buffers in parallel
   if (options?.gltf?.loadBuffers && gltf.json.buffers) {

--- a/modules/gltf/src/lib/types/gltf-json-schema.ts
+++ b/modules/gltf/src/lib/types/gltf-json-schema.ts
@@ -904,7 +904,9 @@ export type GLTF_EXT_texture_webp = {
  * @see https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Vendor/EXT_texture_avif
  */
 export type GLTF_EXT_texture_avif = {
+  /** Index of the AVIF image used in place of the ordinary texture source. */
   source: GLTFId;
+  /** Application-specific extension data. */
   extras?: any;
 };
 

--- a/modules/gltf/src/lib/types/gltf-json-schema.ts
+++ b/modules/gltf/src/lib/types/gltf-json-schema.ts
@@ -901,6 +901,14 @@ export type GLTF_EXT_texture_webp = {
 };
 
 /**
+ * @see https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Vendor/EXT_texture_avif
+ */
+export type GLTF_EXT_texture_avif = {
+  source: GLTFId;
+  extras?: any;
+};
+
+/**
  * @see https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Vendor/MSFT_texture_dds
  */
 export type GLTF_MSFT_texture_dds = {

--- a/modules/gltf/test/lib/extensions/EXT_texture_avif.cross.spec.ts
+++ b/modules/gltf/test/lib/extensions/EXT_texture_avif.cross.spec.ts
@@ -5,24 +5,27 @@
 /* eslint-disable camelcase */
 import {afterEach, describe, expect, test, vi} from 'vitest';
 
-vi.mock('@loaders.gl/images', () => ({isImageFormatSupported: vi.fn()}));
+vi.mock('@loaders.gl/images', async importOriginal => ({
+  ...(await importOriginal()),
+  getSupportedImageFormats: vi.fn()
+}));
 
-import {isImageFormatSupported} from '@loaders.gl/images';
+import {getSupportedImageFormats} from '@loaders.gl/images';
 import {preprocessExtensions} from '../../../src/lib/api/gltf-extensions';
 import {preprocess} from '../../../src/lib/extensions/EXT_texture_avif';
 
-const isImageFormatSupportedMock = vi.mocked(isImageFormatSupported);
+const getSupportedImageFormatsMock = vi.mocked(getSupportedImageFormats);
 
 afterEach(() => {
-  isImageFormatSupportedMock.mockReset();
+  getSupportedImageFormatsMock.mockReset();
 });
 
 describe('EXT_texture_avif', () => {
-  test('selects the AVIF source through the loader registry and removes the processed extension', () => {
-    isImageFormatSupportedMock.mockReturnValue(true);
+  test('selects the AVIF source through the loader registry and removes the processed extension', async () => {
+    getSupportedImageFormatsMock.mockResolvedValue(new Set(['image/avif']));
     const gltfData = makeGLTFData({required: true});
 
-    preprocessExtensions(gltfData, {});
+    await preprocessExtensions(gltfData, {});
 
     expect(gltfData.json.textures?.[0]?.source).toBe(1);
     expect(gltfData.json.textures?.[0]?.extensions).toEqual({});
@@ -30,21 +33,21 @@ describe('EXT_texture_avif', () => {
     expect(gltfData.json.extensionsRequired).toEqual([]);
   });
 
-  test('keeps an optional AVIF extension and fallback source when AVIF is unsupported', () => {
-    isImageFormatSupportedMock.mockReturnValue(false);
+  test('keeps an optional AVIF extension and fallback source when AVIF is unsupported', async () => {
+    getSupportedImageFormatsMock.mockResolvedValue(new Set());
     const gltfData = makeGLTFData({required: false});
 
-    preprocess(gltfData, {});
+    await preprocess(gltfData, {});
 
     expect(gltfData.json.textures?.[0]?.source).toBe(0);
     expect(gltfData.json.textures?.[0]?.extensions?.EXT_texture_avif).toEqual({source: 1});
     expect(gltfData.json.extensionsUsed).toEqual(['EXT_texture_avif']);
   });
 
-  test('rejects a required AVIF extension when AVIF is unsupported', () => {
-    isImageFormatSupportedMock.mockReturnValue(false);
+  test('rejects a required AVIF extension when AVIF is unsupported', async () => {
+    getSupportedImageFormatsMock.mockResolvedValue(new Set());
 
-    expect(() => preprocess(makeGLTFData({required: true}), {})).toThrow(
+    await expect(preprocess(makeGLTFData({required: true}), {})).rejects.toThrow(
       'Required extension EXT_texture_avif not supported by browser'
     );
   });

--- a/modules/gltf/test/lib/extensions/EXT_texture_avif.node.spec.ts
+++ b/modules/gltf/test/lib/extensions/EXT_texture_avif.node.spec.ts
@@ -1,0 +1,67 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/* eslint-disable camelcase */
+import {afterEach, describe, expect, test, vi} from 'vitest';
+
+vi.mock('@loaders.gl/images', () => ({isImageFormatSupported: vi.fn()}));
+
+import {isImageFormatSupported} from '@loaders.gl/images';
+import {preprocessExtensions} from '../../../src/lib/api/gltf-extensions';
+import {preprocess} from '../../../src/lib/extensions/EXT_texture_avif';
+
+const isImageFormatSupportedMock = vi.mocked(isImageFormatSupported);
+
+afterEach(() => {
+  isImageFormatSupportedMock.mockReset();
+});
+
+describe('EXT_texture_avif', () => {
+  test('selects the AVIF source through the loader registry and removes the processed extension', () => {
+    isImageFormatSupportedMock.mockReturnValue(true);
+    const gltfData = makeGLTFData({required: true});
+
+    preprocessExtensions(gltfData, {});
+
+    expect(gltfData.json.textures?.[0]?.source).toBe(1);
+    expect(gltfData.json.textures?.[0]?.extensions).toEqual({});
+    expect(gltfData.json.extensionsUsed).toEqual([]);
+    expect(gltfData.json.extensionsRequired).toEqual([]);
+  });
+
+  test('keeps an optional AVIF extension and fallback source when AVIF is unsupported', () => {
+    isImageFormatSupportedMock.mockReturnValue(false);
+    const gltfData = makeGLTFData({required: false});
+
+    preprocess(gltfData, {});
+
+    expect(gltfData.json.textures?.[0]?.source).toBe(0);
+    expect(gltfData.json.textures?.[0]?.extensions?.EXT_texture_avif).toEqual({source: 1});
+    expect(gltfData.json.extensionsUsed).toEqual(['EXT_texture_avif']);
+  });
+
+  test('rejects a required AVIF extension when AVIF is unsupported', () => {
+    isImageFormatSupportedMock.mockReturnValue(false);
+
+    expect(() => preprocess(makeGLTFData({required: true}), {})).toThrow(
+      'Required extension EXT_texture_avif not supported by browser'
+    );
+  });
+});
+
+function makeGLTFData({required}: {required: boolean}) {
+  return {
+    json: {
+      asset: {version: '2.0'},
+      extensionsUsed: ['EXT_texture_avif'],
+      extensionsRequired: required ? ['EXT_texture_avif'] : [],
+      textures: [
+        {
+          source: 0,
+          extensions: {EXT_texture_avif: {source: 1}}
+        }
+      ]
+    }
+  };
+}

--- a/modules/gltf/test/lib/extensions/EXT_texture_avif.spec.ts
+++ b/modules/gltf/test/lib/extensions/EXT_texture_avif.spec.ts
@@ -1,0 +1,13 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+
+import {getSupportedImageFormats} from '@loaders.gl/images';
+
+test('EXT_texture_avif detects Chromium AVIF decode support asynchronously', async () => {
+  const supportedImageFormats = await getSupportedImageFormats();
+
+  expect(supportedImageFormats).toContain('image/avif');
+});

--- a/modules/images/src/lib/category-api/image-format.ts
+++ b/modules/images/src/lib/category-api/image-format.ts
@@ -19,7 +19,7 @@ const MIME_TYPES = [
 ];
 
 /** Only one round of tests is performed */
-const mimeTypeSupportedPromise: Promise<Set<string>> | null = null;
+let mimeTypeSupportedPromise: Promise<Set<string>> | null = null;
 
 /** Run-time browser detection of file formats requires async tests for most precise results */
 export async function getSupportedImageFormats(): Promise<Set<string>> {
@@ -27,6 +27,12 @@ export async function getSupportedImageFormats(): Promise<Set<string>> {
     return await mimeTypeSupportedPromise;
   }
 
+  mimeTypeSupportedPromise = getSupportedImageFormatsAsync();
+  return await mimeTypeSupportedPromise;
+}
+
+/** Detects the image MIME types that the active runtime can decode. */
+async function getSupportedImageFormatsAsync(): Promise<Set<string>> {
   const supportedMimeTypes = new Set<string>();
   for (const mimeType of MIME_TYPES) {
     const supported = isBrowser
@@ -36,7 +42,6 @@ export async function getSupportedImageFormats(): Promise<Set<string>> {
       supportedMimeTypes.add(mimeType);
     }
   }
-
   return supportedMimeTypes;
 }
 


### PR DESCRIPTION
## Goals

Complete the loaders.gl ownership boundary for `EXT_texture_avif` so glTF assets select AVIF only when the active decoder supports it.

## Changes

- Register `EXT_texture_avif` in the GLTFLoader extension pipeline.
- Select the extension source on supported decoders.
- Preserve an optional extension's ordinary fallback source when AVIF is unavailable, and reject unsupported required AVIF before image loading.
- Add the public schema type and focused registry coverage.

## Verification

- `yarn install`
- `yarn lint fix`
- `yarn build`
- `yarn test-node` — 194 passed, 6 skipped
- `yarn test-headless` — 2,021 passed, 50 skipped

## Follow-up

A loaders.gl v5 alpha publication is required before luma.gl can consume this support and mark Tranche 2 complete on master.