### PR TITLE
feat(sql): add lightweight Arrow query PoC

### DIFF
--- a/modules/sql/README.md
+++ b/modules/sql/README.md
@@ -39,6 +39,28 @@ const rows = await dataSource.queryRows('SELECT * FROM numbers');
 Use `queryArrow()` when the backing adapter supports Arrow-native results, or when you want
 loaders.gl to convert row results into an Arrow table.
 
+## Lightweight Arrow queries
+
+`@loaders.gl/sql/arrow-query` provides an experimental in-memory query path for Arrow tables. It
+supports the portable predicate AST, projection, and limits. This is useful for lightweight local
+filtering; it is not a replacement for DuckDB and does not yet implement SQL `SELECT` parsing,
+aggregation, or joins.
+
+```ts
+import {parseSQLPredicate} from '@loaders.gl/sql/sql-predicate';
+import {queryArrowTable} from '@loaders.gl/sql/arrow-query';
+
+const flights = queryArrowTable(arrowTable, {
+  predicate: parseSQLPredicate('year >= 2024 AND cancelled = FALSE'),
+  columns: ['carrier', 'fare'],
+  limit: 100
+});
+```
+
+Projection and limit-only queries preserve Arrow's zero-copy table views. Predicate queries
+currently materialize matching rows while keeping predicate columns out of the result unless
+selected explicitly.
+
 ## SQL predicate expressions
 
 `parseSQLPredicate()` accepts the expression after `WHERE`, not a complete `SELECT` statement. It

--- a/modules/sql/README.md
+++ b/modules/sql/README.md
@@ -42,9 +42,14 @@ loaders.gl to convert row results into an Arrow table.
 ## Lightweight Arrow queries
 
 `@loaders.gl/sql/arrow-query` provides an experimental in-memory query path for Arrow tables. It
-supports the portable predicate AST, projection, and limits. This is useful for lightweight local
-filtering; it is not a replacement for DuckDB and does not yet implement SQL `SELECT` parsing,
-aggregation, or joins.
+uses the shared `TableQueryOptions` planner, which always orders operations as scan, filter,
+project, then limit. The same immutable plan can be lowered by GPU dataframe implementations
+without adopting Arrow's materialization strategy. This is useful for lightweight local filtering;
+it is not a replacement for DuckDB and does not yet implement SQL `SELECT` parsing, aggregation,
+or joins.
+
+Backends that only need the portable query contract can import `TableQueryOptions` and
+`planTableQuery()` from `@loaders.gl/sql/table-query` without importing the Arrow executor.
 
 ```ts
 import {parseSQLPredicate} from '@loaders.gl/sql/sql-predicate';
@@ -60,6 +65,16 @@ const flights = queryArrowTable(arrowTable, {
 Projection and limit-only queries preserve Arrow's zero-copy table views. Predicate queries
 currently materialize matching rows while keeping predicate columns out of the result unless
 selected explicitly.
+
+Named SQL parameters can remain unresolved while a caller builds or compiles a query. Bind them
+immediately before an Arrow backend executes the predicate:
+
+```ts
+import {bindSQLPredicate, parseSQLPredicate} from '@loaders.gl/sql/sql-predicate';
+
+const predicate = parseSQLPredicate('fare >= :minimumFare', {preserveParameters: true});
+const boundPredicate = bindSQLPredicate(predicate, {minimumFare: 250});
+```
 
 ## SQL predicate expressions
 

--- a/modules/sql/package.json
+++ b/modules/sql/package.json
@@ -36,6 +36,11 @@
       "import": "./dist/arrow-query.js",
       "require": "./dist/arrow-query.cjs"
     },
+    "./table-query": {
+      "types": "./dist/table-query.d.ts",
+      "import": "./dist/table-query.js",
+      "require": "./dist/table-query.cjs"
+    },
     "./sql-predicate-zod": {
       "types": "./dist/sql-predicate-zod.d.ts",
       "import": "./dist/sql-predicate-zod.js",

--- a/modules/sql/package.json
+++ b/modules/sql/package.json
@@ -31,6 +31,11 @@
       "import": "./dist/sql-predicate.js",
       "require": "./dist/sql-predicate.cjs"
     },
+    "./arrow-query": {
+      "types": "./dist/arrow-query.d.ts",
+      "import": "./dist/arrow-query.js",
+      "require": "./dist/arrow-query.cjs"
+    },
     "./sql-predicate-zod": {
       "types": "./dist/sql-predicate-zod.d.ts",
       "import": "./dist/sql-predicate-zod.js",

--- a/modules/sql/src/arrow-query.ts
+++ b/modules/sql/src/arrow-query.ts
@@ -1,0 +1,7 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export {queryArrowTable} from './query-arrow-table';
+
+export type {ArrowQueryOptions} from './query-arrow-table';

--- a/modules/sql/src/arrow-query.ts
+++ b/modules/sql/src/arrow-query.ts
@@ -3,5 +3,15 @@
 // Copyright (c) vis.gl contributors
 
 export {queryArrowTable} from './query-arrow-table';
+export {getSQLPredicateColumnNames, planTableQuery} from './table-query';
 
+export type {
+  TableQueryFilterStep,
+  TableQueryLimitStep,
+  TableQueryOptions,
+  TableQueryPlan,
+  TableQueryPlanStep,
+  TableQueryProjectStep,
+  TableQueryScanStep
+} from './table-query';
 export type {ArrowQueryOptions} from './query-arrow-table';

--- a/modules/sql/src/bind-sql-predicate.ts
+++ b/modules/sql/src/bind-sql-predicate.ts
@@ -1,0 +1,89 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {validateSQLPredicate} from './sql-predicate-schema';
+import {
+  isSQLPredicateParameter,
+  type SQLPredicate,
+  type SQLPredicateParameterValues,
+  type SQLPredicateScalar,
+  type SQLPredicateValue
+} from './sql-predicate-types';
+
+/** Binds named parameter references in a portable SQL predicate without mutating the input AST. */
+export function bindSQLPredicate(
+  predicate: SQLPredicate,
+  parameters: SQLPredicateParameterValues
+): SQLPredicate {
+  validateSQLPredicate(predicate);
+  return bindPredicate(predicate, parameters);
+}
+
+/** Returns a predicate copy with every parameter reference replaced by its caller-supplied scalar. */
+function bindPredicate(
+  predicate: SQLPredicate,
+  parameters: SQLPredicateParameterValues
+): SQLPredicate {
+  switch (predicate.op) {
+    case 'and':
+    case 'or':
+      return {
+        op: predicate.op,
+        args: predicate.args.map(child => bindPredicate(child, parameters))
+      };
+    case 'not':
+      return {op: 'not', args: [bindPredicate(predicate.args[0], parameters)]};
+    case 'isNull':
+      return {op: 'isNull', args: [{property: predicate.args[0].property}]};
+    case 'in':
+      return {
+        op: 'in',
+        args: [
+          {property: predicate.args[0].property},
+          predicate.args[1].map(value => bindPredicateValue(value, parameters))
+        ]
+      };
+    default:
+      return {
+        op: predicate.op,
+        args: [
+          {property: predicate.args[0].property},
+          bindPredicateValue(predicate.args[1], parameters)
+        ]
+      };
+  }
+}
+
+/** Resolves one scalar or named parameter reference into a concrete SQL predicate scalar. */
+function bindPredicateValue(
+  value: SQLPredicateValue,
+  parameters: SQLPredicateParameterValues
+): SQLPredicateScalar {
+  if (!isSQLPredicateParameter(value)) {
+    return value;
+  }
+  if (!Object.hasOwn(parameters, value.parameter)) {
+    throw new Error(`SQL predicate parameter ":${value.parameter}" requires a value`);
+  }
+  const parameterValue = parameters[value.parameter];
+  validatePredicateParameterValue(parameterValue, value.parameter);
+  return parameterValue;
+}
+
+/** Validates a caller-supplied parameter as a concrete predicate scalar. */
+function validatePredicateParameterValue(
+  value: unknown,
+  parameterName: string
+): asserts value is SQLPredicateScalar {
+  if (isSQLPredicateParameter(value)) {
+    throw new Error(
+      `SQL predicate parameter ":${parameterName}" cannot reference another parameter`
+    );
+  }
+  try {
+    validateSQLPredicate({op: '=', args: [{property: '_'}, value]});
+  } catch {
+    throw new Error(`SQL predicate parameter ":${parameterName}" has an unsupported value`);
+  }
+}

--- a/modules/sql/src/index.ts
+++ b/modules/sql/src/index.ts
@@ -7,6 +7,9 @@ export {DuckDBSQLSource, DuckDBSQLDataSource} from './duckdb-sql-source';
 export {SnowflakeSQLSource, SnowflakeSQLDataSource} from './snowflake-sql-source';
 export {queryArrowTable} from './query-arrow-table';
 export {parseSQLPredicate} from './parse-sql-predicate';
+export {bindSQLPredicate} from './bind-sql-predicate';
+export {getSQLPredicateColumnNames, planTableQuery} from './table-query';
+export {isSQLPredicateParameter} from './sql-predicate-types';
 export {
   isSQLPredicate,
   SQL_PREDICATE_JSON_SCHEMA,
@@ -20,8 +23,11 @@ export type {
   SQLNotPredicate,
   SQLNullPredicate,
   SQLPredicate,
+  SQLPredicateParameter,
+  SQLPredicateParameterValues,
   SQLPredicateParserOptions,
   SQLPredicateProperty,
+  SQLPredicateScalar,
   SQLPredicateValue
 } from './sql-predicate-types';
 
@@ -41,3 +47,12 @@ export type {
 } from './sql-types';
 
 export type {ArrowQueryOptions} from './query-arrow-table';
+export type {
+  TableQueryFilterStep,
+  TableQueryLimitStep,
+  TableQueryOptions,
+  TableQueryPlan,
+  TableQueryPlanStep,
+  TableQueryProjectStep,
+  TableQueryScanStep
+} from './table-query';

--- a/modules/sql/src/index.ts
+++ b/modules/sql/src/index.ts
@@ -5,6 +5,7 @@
 export {SQLDataSource, registerSQLAdapter, getSQLAdapterFactory} from './sql-source';
 export {DuckDBSQLSource, DuckDBSQLDataSource} from './duckdb-sql-source';
 export {SnowflakeSQLSource, SnowflakeSQLDataSource} from './snowflake-sql-source';
+export {queryArrowTable} from './query-arrow-table';
 export {parseSQLPredicate} from './parse-sql-predicate';
 export {
   isSQLPredicate,
@@ -38,3 +39,5 @@ export type {
   SQLSourceOptions,
   SQLTableInfo
 } from './sql-types';
+
+export type {ArrowQueryOptions} from './query-arrow-table';

--- a/modules/sql/src/parse-sql-predicate.ts
+++ b/modules/sql/src/parse-sql-predicate.ts
@@ -5,6 +5,7 @@
 import type {
   SQLLogicalPredicate,
   SQLPredicate,
+  SQLPredicateParameterValues,
   SQLPredicateParserOptions,
   SQLPredicateProperty,
   SQLPredicateValue
@@ -31,7 +32,11 @@ export function parseSQLPredicate(
   source: string,
   options: SQLPredicateParserOptions = {}
 ): SQLPredicate {
-  const parser = new SQLPredicateParser(source, options.parameters ?? {});
+  const parser = new SQLPredicateParser(
+    source,
+    options.parameters ?? {},
+    options.preserveParameters === true
+  );
   const predicate = parser.parse();
   validateSQLPredicate(predicate);
   return predicate;
@@ -42,13 +47,20 @@ class SQLPredicateParser {
   /** Token stream parsed by this parser instance. */
   private readonly tokens: readonly SQLPredicateToken[];
   /** Named scalar parameters available to the expression. */
-  private readonly parameters: Readonly<Record<string, SQLPredicateValue>>;
+  private readonly parameters: SQLPredicateParameterValues;
+  /** Whether named parameters remain references in the parsed AST. */
+  private readonly preserveParameters: boolean;
   /** Current index in the token stream. */
   private position = 0;
 
-  constructor(source: string, parameters: Readonly<Record<string, SQLPredicateValue>>) {
+  constructor(
+    source: string,
+    parameters: SQLPredicateParameterValues,
+    preserveParameters: boolean
+  ) {
     this.tokens = tokenizeSQLPredicate(source);
     this.parameters = parameters;
+    this.preserveParameters = preserveParameters;
   }
 
   /** Parses the complete token stream. */
@@ -163,6 +175,9 @@ class SQLPredicateParser {
       return token.value;
     }
     if (token.kind === 'parameter') {
+      if (this.preserveParameters) {
+        return {parameter: token.value};
+      }
       if (!Object.hasOwn(this.parameters, token.value)) {
         throw new Error(`SQL predicate parameter ":${token.value}" requires a value`);
       }

--- a/modules/sql/src/query-arrow-table.ts
+++ b/modules/sql/src/query-arrow-table.ts
@@ -1,0 +1,348 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import * as arrow from 'apache-arrow';
+import type {ArrowTable} from '@loaders.gl/schema';
+import {convertArrowToSchema} from '@loaders.gl/schema-utils';
+
+import type {
+  SQLComparisonPredicate,
+  SQLInPredicate,
+  SQLLogicalPredicate,
+  SQLNotPredicate,
+  SQLNullPredicate,
+  SQLPredicate,
+  SQLPredicateValue
+} from './sql-predicate-types';
+
+/** Options for the lightweight in-memory Arrow query executor. */
+export type ArrowQueryOptions = Readonly<{
+  /** Filters source rows using the portable SQL predicate representation. */
+  predicate?: SQLPredicate;
+  /** Selects output columns in the supplied order. Defaults to all source columns. */
+  columns?: readonly string[];
+  /** Restricts the result to the first matching rows. */
+  limit?: number;
+  /** Cancels the query before or during predicate evaluation. */
+  signal?: AbortSignal;
+}>;
+
+type SQLTruthValue = boolean | null;
+
+/**
+ * Executes a small, Arrow-native query over one in-memory table.
+ *
+ * The proof of concept supports portable predicates, column projection, and limits. Projection
+ * and limits without a predicate preserve Arrow's zero-copy views. Predicate evaluation is
+ * currently row-oriented and materializes the matching result rows; later physical operators can
+ * replace this implementation with vectorized selection handling without changing this API.
+ */
+export function queryArrowTable(
+  sourceTable: ArrowTable,
+  options: ArrowQueryOptions = {}
+): ArrowTable {
+  validateArrowQueryOptions(options);
+  throwIfAborted(options.signal);
+
+  const sourceData = sourceTable.data;
+  const columnNames = getOutputColumnNames(sourceData, options.columns);
+  const predicateColumnNames = options.predicate ? getPredicateColumnNames(options.predicate) : [];
+  validateColumnNames(sourceData, columnNames);
+  validateColumnNames(sourceData, predicateColumnNames);
+
+  const projectedData = sourceData.select(columnNames);
+  const limit = options.limit ?? Number.POSITIVE_INFINITY;
+  if (!options.predicate) {
+    return wrapArrowTable(projectedData.slice(0, limit));
+  }
+
+  const predicateColumns = getPredicateColumns(sourceData, predicateColumnNames);
+  const matchingRowIndices: number[] = [];
+  for (let rowIndex = 0; rowIndex < sourceData.numRows && matchingRowIndices.length < limit; rowIndex++) {
+    throwIfAborted(options.signal);
+    if (evaluatePredicate(options.predicate, predicateColumns, rowIndex) === true) {
+      matchingRowIndices.push(rowIndex);
+    }
+  }
+
+  if (matchingRowIndices.length === 0) {
+    return wrapArrowTable(projectedData.slice(0, 0));
+  }
+
+  const outputColumns: Record<string, arrow.Vector> = {};
+  for (const field of projectedData.schema.fields) {
+    const sourceColumn = projectedData.getChild(field.name);
+    if (!sourceColumn) {
+      throw new Error(`Arrow query could not read column "${field.name}".`);
+    }
+    const values = matchingRowIndices.map(rowIndex => sourceColumn.get(rowIndex));
+    outputColumns[field.name] = arrow.vectorFromArray(values, sourceColumn.type);
+  }
+  return wrapArrowTable(new arrow.Table(projectedData.schema, outputColumns));
+}
+
+/** Returns requested output columns, defaulting to all source columns. */
+function getOutputColumnNames(
+  sourceTable: arrow.Table,
+  requestedColumnNames: readonly string[] | undefined
+): string[] {
+  if (requestedColumnNames === undefined) {
+    return sourceTable.schema.fields.map(field => field.name);
+  }
+  return [...requestedColumnNames];
+}
+
+/** Validates public query options before any table processing begins. */
+function validateArrowQueryOptions(options: ArrowQueryOptions): void {
+  if (
+    options.limit !== undefined &&
+    (!Number.isSafeInteger(options.limit) || options.limit < 0)
+  ) {
+    throw new Error('Arrow query limit must be a non-negative safe integer.');
+  }
+}
+
+/** Validates that every selected or predicate-referenced column exists exactly once. */
+function validateColumnNames(sourceTable: arrow.Table, columnNames: readonly string[]): void {
+  const availableColumnNames = new Set(sourceTable.schema.fields.map(field => field.name));
+  const seenColumnNames = new Set<string>();
+  for (const columnName of columnNames) {
+    if (!availableColumnNames.has(columnName)) {
+      throw new Error(`Arrow query column not found: ${columnName}`);
+    }
+    if (seenColumnNames.has(columnName)) {
+      throw new Error(`Arrow query column was selected more than once: ${columnName}`);
+    }
+    seenColumnNames.add(columnName);
+  }
+}
+
+/** Creates a predicate-column lookup so values are not resolved for every source row. */
+function getPredicateColumns(
+  sourceTable: arrow.Table,
+  columnNames: readonly string[]
+): Readonly<Record<string, arrow.Vector>> {
+  const columns: Record<string, arrow.Vector> = {};
+  for (const columnName of columnNames) {
+    const column = sourceTable.getChild(columnName);
+    if (!column) {
+      throw new Error(`Arrow query column not found: ${columnName}`);
+    }
+    columns[columnName] = column;
+  }
+  return columns;
+}
+
+/** Collects each column property referenced by a portable predicate exactly once. */
+function getPredicateColumnNames(predicate: SQLPredicate): string[] {
+  const columnNames = new Set<string>();
+  visitPredicate(predicate, currentPredicate => {
+    if (isLogicalPredicate(currentPredicate) || isNotPredicate(currentPredicate)) {
+      return;
+    }
+    columnNames.add(currentPredicate.args[0].property);
+  });
+  return [...columnNames];
+}
+
+/** Evaluates a predicate against one Arrow table row using SQL three-valued Boolean logic. */
+function evaluatePredicate(
+  predicate: SQLPredicate,
+  columns: Readonly<Record<string, arrow.Vector>>,
+  rowIndex: number
+): SQLTruthValue {
+  if (isLogicalPredicate(predicate)) {
+    const values = predicate.args.map(child => evaluatePredicate(child, columns, rowIndex));
+    return predicate.op === 'and' ? evaluateAnd(values) : evaluateOr(values);
+  }
+  if (isNotPredicate(predicate)) {
+    const value = evaluatePredicate(predicate.args[0], columns, rowIndex);
+    return value === null ? null : !value;
+  }
+
+  const value = getColumnValue(columns, predicate.args[0].property, rowIndex);
+  if (isNullPredicate(predicate)) {
+    return value === null;
+  }
+  if (isInPredicate(predicate)) {
+    return evaluateIn(value, predicate.args[1]);
+  }
+  return evaluateComparison(value, predicate);
+}
+
+/** Returns the value of one predicate column or raises an internal invariant error. */
+function getColumnValue(
+  columns: Readonly<Record<string, arrow.Vector>>,
+  columnName: string,
+  rowIndex: number
+): unknown {
+  const column = columns[columnName];
+  if (!column) {
+    throw new Error(`Arrow query could not read predicate column "${columnName}".`);
+  }
+  return column.get(rowIndex);
+}
+
+/** Evaluates SQL AND with null propagation. */
+function evaluateAnd(values: readonly SQLTruthValue[]): SQLTruthValue {
+  if (values.includes(false)) {
+    return false;
+  }
+  return values.includes(null) ? null : true;
+}
+
+/** Evaluates SQL OR with null propagation. */
+function evaluateOr(values: readonly SQLTruthValue[]): SQLTruthValue {
+  if (values.includes(true)) {
+    return true;
+  }
+  return values.includes(null) ? null : false;
+}
+
+/** Evaluates a membership expression with SQL null propagation. */
+function evaluateIn(value: unknown, candidates: readonly SQLPredicateValue[]): SQLTruthValue {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  for (const candidate of candidates) {
+    if (compareValues(value, candidate) === 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Evaluates a binary SQL comparison with SQL null propagation. */
+function evaluateComparison(
+  value: unknown,
+  predicate: SQLComparisonPredicate
+): SQLTruthValue {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const comparison = compareValues(value, predicate.args[1]);
+  switch (predicate.op) {
+    case '=':
+      return comparison === 0;
+    case '<>':
+      return comparison !== 0;
+    case '<':
+      return comparison < 0;
+    case '<=':
+      return comparison <= 0;
+    case '>':
+      return comparison > 0;
+    case '>=':
+      return comparison >= 0;
+  }
+}
+
+/** Compares supported predicate values and rejects comparisons without an unambiguous ordering. */
+function compareValues(left: unknown, right: SQLPredicateValue): number {
+  if (left instanceof Date && right instanceof Date) {
+    return compareNumbers(left.getTime(), right.getTime());
+  }
+  if (left instanceof Uint8Array && right instanceof Uint8Array) {
+    return compareBinary(left, right);
+  }
+  if (typeof left === 'bigint' && typeof right === 'bigint') {
+    return left === right ? 0 : left < right ? -1 : 1;
+  }
+  if (typeof left === 'bigint' && typeof right === 'number' && Number.isSafeInteger(right)) {
+    return compareValues(left, BigInt(right));
+  }
+  if (typeof left === 'number' && typeof right === 'bigint' && Number.isSafeInteger(left)) {
+    return compareValues(BigInt(left), right);
+  }
+  if (typeof left === 'number' && typeof right === 'number') {
+    return compareNumbers(left, right);
+  }
+  if (typeof left === 'string' && typeof right === 'string') {
+    return left === right ? 0 : left < right ? -1 : 1;
+  }
+  if (typeof left === 'boolean' && typeof right === 'boolean') {
+    return Number(left) - Number(right);
+  }
+  throw new Error(
+    `Arrow query cannot compare ${getValueType(left)} with ${getValueType(right)} values.`
+  );
+}
+
+/** Compares two finite number values. */
+function compareNumbers(left: number, right: number): number {
+  if (!Number.isFinite(left) || !Number.isFinite(right)) {
+    throw new Error('Arrow query cannot compare non-finite numbers.');
+  }
+  return left === right ? 0 : left < right ? -1 : 1;
+}
+
+/** Compares binary values lexicographically. */
+function compareBinary(left: Uint8Array, right: Uint8Array): number {
+  const commonLength = Math.min(left.length, right.length);
+  for (let index = 0; index < commonLength; index++) {
+    if (left[index] !== right[index]) {
+      return left[index] < right[index] ? -1 : 1;
+    }
+  }
+  return left.length === right.length ? 0 : left.length < right.length ? -1 : 1;
+}
+
+/** Returns a human-readable type name for predicate diagnostics. */
+function getValueType(value: unknown): string {
+  if (value instanceof Date) {
+    return 'Date';
+  }
+  if (value instanceof Uint8Array) {
+    return 'Uint8Array';
+  }
+  return typeof value;
+}
+
+/** Recursively visits the predicate tree depth-first. */
+function visitPredicate(predicate: SQLPredicate, visit: (predicate: SQLPredicate) => void): void {
+  visit(predicate);
+  if (isLogicalPredicate(predicate) || isNotPredicate(predicate)) {
+    for (const child of predicate.args) {
+      visitPredicate(child, visit);
+    }
+  }
+}
+
+/** Returns whether the predicate combines two or more child predicates. */
+function isLogicalPredicate(predicate: SQLPredicate): predicate is SQLLogicalPredicate {
+  return predicate.op === 'and' || predicate.op === 'or';
+}
+
+/** Returns whether the predicate negates one child predicate. */
+function isNotPredicate(predicate: SQLPredicate): predicate is SQLNotPredicate {
+  return predicate.op === 'not';
+}
+
+/** Returns whether the predicate tests a column for null values. */
+function isNullPredicate(predicate: SQLPredicate): predicate is SQLNullPredicate {
+  return predicate.op === 'isNull';
+}
+
+/** Returns whether the predicate tests a column against several values. */
+function isInPredicate(predicate: SQLPredicate): predicate is SQLInPredicate {
+  return predicate.op === 'in';
+}
+
+/** Throws a standard cancellation error if a caller has aborted the query. */
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    const error = new Error('Arrow query was aborted.');
+    error.name = 'AbortError';
+    throw error;
+  }
+}
+
+/** Wraps an Arrow table with the loaders.gl Arrow-table shape and converted schema. */
+function wrapArrowTable(data: arrow.Table): ArrowTable {
+  return {
+    shape: 'arrow-table',
+    schema: convertArrowToSchema(data.schema),
+    data
+  };
+}

--- a/modules/sql/src/query-arrow-table.ts
+++ b/modules/sql/src/query-arrow-table.ts
@@ -6,27 +6,33 @@ import * as arrow from 'apache-arrow';
 import type {ArrowTable} from '@loaders.gl/schema';
 import {convertArrowToSchema} from '@loaders.gl/schema-utils';
 
-import type {
-  SQLComparisonPredicate,
-  SQLInPredicate,
-  SQLLogicalPredicate,
-  SQLNotPredicate,
-  SQLNullPredicate,
-  SQLPredicate,
-  SQLPredicateValue
+import {
+  isSQLPredicateParameter,
+  type SQLComparisonPredicate,
+  type SQLInPredicate,
+  type SQLLogicalPredicate,
+  type SQLNotPredicate,
+  type SQLNullPredicate,
+  type SQLPredicate,
+  type SQLPredicateValue
 } from './sql-predicate-types';
+import {
+  getSQLPredicateColumnNames,
+  planTableQuery,
+  type TableQueryFilterStep,
+  type TableQueryLimitStep,
+  type TableQueryOptions,
+  type TableQueryPlanStep,
+  type TableQueryProjectStep,
+  type TableQueryScanStep
+} from './table-query';
 
 /** Options for the lightweight in-memory Arrow query executor. */
-export type ArrowQueryOptions = Readonly<{
-  /** Filters source rows using the portable SQL predicate representation. */
-  predicate?: SQLPredicate;
-  /** Selects output columns in the supplied order. Defaults to all source columns. */
-  columns?: readonly string[];
-  /** Restricts the result to the first matching rows. */
-  limit?: number;
-  /** Cancels the query before or during predicate evaluation. */
-  signal?: AbortSignal;
-}>;
+export type ArrowQueryOptions = TableQueryOptions &
+  Readonly<{
+    /** Cancels the query before or during predicate evaluation. */
+    signal?: AbortSignal;
+  }>;
 
 type SQLTruthValue = boolean | null;
 
@@ -42,26 +48,30 @@ export function queryArrowTable(
   sourceTable: ArrowTable,
   options: ArrowQueryOptions = {}
 ): ArrowTable {
-  validateArrowQueryOptions(options);
   throwIfAborted(options.signal);
 
   const sourceData = sourceTable.data;
-  const columnNames = getOutputColumnNames(sourceData, options.columns);
-  const predicateColumnNames = options.predicate ? getPredicateColumnNames(options.predicate) : [];
-  validateColumnNames(sourceData, columnNames);
-  validateColumnNames(sourceData, predicateColumnNames);
-
-  const projectedData = sourceData.select(columnNames);
-  const limit = options.limit ?? Number.POSITIVE_INFINITY;
-  if (!options.predicate) {
+  const plan = planTableQuery(
+    sourceData.schema.fields.map(field => field.name),
+    options
+  );
+  const scannedData = sourceData.select([...getScanStep(plan).columns]);
+  const projectedData = scannedData.select([...getProjectStep(plan).columns]);
+  const predicate = getFilterStep(plan)?.predicate;
+  const limit = getLimitStep(plan)?.limit ?? Number.POSITIVE_INFINITY;
+  if (!predicate) {
     return wrapArrowTable(projectedData.slice(0, limit));
   }
 
-  const predicateColumns = getPredicateColumns(sourceData, predicateColumnNames);
+  const predicateColumns = getPredicateColumns(scannedData, getSQLPredicateColumnNames(predicate));
   const matchingRowIndices: number[] = [];
-  for (let rowIndex = 0; rowIndex < sourceData.numRows && matchingRowIndices.length < limit; rowIndex++) {
+  for (
+    let rowIndex = 0;
+    rowIndex < scannedData.numRows && matchingRowIndices.length < limit;
+    rowIndex++
+  ) {
     throwIfAborted(options.signal);
-    if (evaluatePredicate(options.predicate, predicateColumns, rowIndex) === true) {
+    if (evaluatePredicate(predicate, predicateColumns, rowIndex) === true) {
       matchingRowIndices.push(rowIndex);
     }
   }
@@ -82,42 +92,6 @@ export function queryArrowTable(
   return wrapArrowTable(new arrow.Table(projectedData.schema, outputColumns));
 }
 
-/** Returns requested output columns, defaulting to all source columns. */
-function getOutputColumnNames(
-  sourceTable: arrow.Table,
-  requestedColumnNames: readonly string[] | undefined
-): string[] {
-  if (requestedColumnNames === undefined) {
-    return sourceTable.schema.fields.map(field => field.name);
-  }
-  return [...requestedColumnNames];
-}
-
-/** Validates public query options before any table processing begins. */
-function validateArrowQueryOptions(options: ArrowQueryOptions): void {
-  if (
-    options.limit !== undefined &&
-    (!Number.isSafeInteger(options.limit) || options.limit < 0)
-  ) {
-    throw new Error('Arrow query limit must be a non-negative safe integer.');
-  }
-}
-
-/** Validates that every selected or predicate-referenced column exists exactly once. */
-function validateColumnNames(sourceTable: arrow.Table, columnNames: readonly string[]): void {
-  const availableColumnNames = new Set(sourceTable.schema.fields.map(field => field.name));
-  const seenColumnNames = new Set<string>();
-  for (const columnName of columnNames) {
-    if (!availableColumnNames.has(columnName)) {
-      throw new Error(`Arrow query column not found: ${columnName}`);
-    }
-    if (seenColumnNames.has(columnName)) {
-      throw new Error(`Arrow query column was selected more than once: ${columnName}`);
-    }
-    seenColumnNames.add(columnName);
-  }
-}
-
 /** Creates a predicate-column lookup so values are not resolved for every source row. */
 function getPredicateColumns(
   sourceTable: arrow.Table,
@@ -132,18 +106,6 @@ function getPredicateColumns(
     columns[columnName] = column;
   }
   return columns;
-}
-
-/** Collects each column property referenced by a portable predicate exactly once. */
-function getPredicateColumnNames(predicate: SQLPredicate): string[] {
-  const columnNames = new Set<string>();
-  visitPredicate(predicate, currentPredicate => {
-    if (isLogicalPredicate(currentPredicate) || isNotPredicate(currentPredicate)) {
-      return;
-    }
-    columnNames.add(currentPredicate.args[0].property);
-  });
-  return [...columnNames];
 }
 
 /** Evaluates a predicate against one Arrow table row using SQL three-valued Boolean logic. */
@@ -214,10 +176,7 @@ function evaluateIn(value: unknown, candidates: readonly SQLPredicateValue[]): S
 }
 
 /** Evaluates a binary SQL comparison with SQL null propagation. */
-function evaluateComparison(
-  value: unknown,
-  predicate: SQLComparisonPredicate
-): SQLTruthValue {
+function evaluateComparison(value: unknown, predicate: SQLComparisonPredicate): SQLTruthValue {
   if (value === null || value === undefined) {
     return null;
   }
@@ -240,6 +199,11 @@ function evaluateComparison(
 
 /** Compares supported predicate values and rejects comparisons without an unambiguous ordering. */
 function compareValues(left: unknown, right: SQLPredicateValue): number {
+  if (isSQLPredicateParameter(right)) {
+    throw new Error(
+      `Arrow query parameter ":${right.parameter}" must be bound before query execution.`
+    );
+  }
   if (left instanceof Date && right instanceof Date) {
     return compareNumbers(left.getTime(), right.getTime());
   }
@@ -299,16 +263,6 @@ function getValueType(value: unknown): string {
   return typeof value;
 }
 
-/** Recursively visits the predicate tree depth-first. */
-function visitPredicate(predicate: SQLPredicate, visit: (predicate: SQLPredicate) => void): void {
-  visit(predicate);
-  if (isLogicalPredicate(predicate) || isNotPredicate(predicate)) {
-    for (const child of predicate.args) {
-      visitPredicate(child, visit);
-    }
-  }
-}
-
 /** Returns whether the predicate combines two or more child predicates. */
 function isLogicalPredicate(predicate: SQLPredicate): predicate is SQLLogicalPredicate {
   return predicate.op === 'and' || predicate.op === 'or';
@@ -327,6 +281,36 @@ function isNullPredicate(predicate: SQLPredicate): predicate is SQLNullPredicate
 /** Returns whether the predicate tests a column against several values. */
 function isInPredicate(predicate: SQLPredicate): predicate is SQLInPredicate {
   return predicate.op === 'in';
+}
+
+/** Returns the mandatory source scan from a normalized table-query plan. */
+function getScanStep(plan: readonly TableQueryPlanStep[]): TableQueryScanStep {
+  const step = plan.find((candidate): candidate is TableQueryScanStep => candidate.kind === 'scan');
+  if (!step) {
+    throw new Error('Arrow query plan is missing a scan step.');
+  }
+  return step;
+}
+
+/** Returns the optional predicate filter from a normalized table-query plan. */
+function getFilterStep(plan: readonly TableQueryPlanStep[]): TableQueryFilterStep | undefined {
+  return plan.find((candidate): candidate is TableQueryFilterStep => candidate.kind === 'filter');
+}
+
+/** Returns the mandatory output projection from a normalized table-query plan. */
+function getProjectStep(plan: readonly TableQueryPlanStep[]): TableQueryProjectStep {
+  const step = plan.find(
+    (candidate): candidate is TableQueryProjectStep => candidate.kind === 'project'
+  );
+  if (!step) {
+    throw new Error('Arrow query plan is missing a project step.');
+  }
+  return step;
+}
+
+/** Returns the optional result limit from a normalized table-query plan. */
+function getLimitStep(plan: readonly TableQueryPlanStep[]): TableQueryLimitStep | undefined {
+  return plan.find((candidate): candidate is TableQueryLimitStep => candidate.kind === 'limit');
 }
 
 /** Throws a standard cancellation error if a caller has aborted the query. */

--- a/modules/sql/src/sql-predicate-schema.ts
+++ b/modules/sql/src/sql-predicate-schema.ts
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {SQLPredicate, SQLPredicateValue} from './sql-predicate-types';
+import {
+  isSQLPredicateParameter,
+  type SQLPredicate,
+  type SQLPredicateValue
+} from './sql-predicate-types';
 
 const MAXIMUM_PREDICATE_DEPTH = 64;
 const MAXIMUM_PREDICATE_NODES = 4096;
@@ -31,7 +35,17 @@ export const SQL_PREDICATE_JSON_SCHEMA = {
       properties: {property: {type: 'string', minLength: 1}},
       additionalProperties: false
     },
-    value: {type: ['boolean', 'number', 'string']},
+    value: {
+      oneOf: [
+        {type: ['boolean', 'number', 'string']},
+        {
+          type: 'object',
+          required: ['parameter'],
+          properties: {parameter: {type: 'string', minLength: 1}},
+          additionalProperties: false
+        }
+      ]
+    },
     comparison: {
       type: 'object',
       required: ['op', 'args'],
@@ -197,6 +211,9 @@ function validatePredicateProperty(value: unknown, path: string): void {
 
 /** Validates one structured-cloneable predicate scalar. */
 function validatePredicateValue(value: unknown, path: string): asserts value is SQLPredicateValue {
+  if (isSQLPredicateParameter(value)) {
+    return;
+  }
   if (
     typeof value === 'boolean' ||
     typeof value === 'bigint' ||

--- a/modules/sql/src/sql-predicate-types.ts
+++ b/modules/sql/src/sql-predicate-types.ts
@@ -3,7 +3,19 @@
 // Copyright (c) vis.gl contributors
 
 /** Scalar values supported by portable SQL predicate expressions. */
-export type SQLPredicateValue = boolean | number | bigint | string | Date | Uint8Array;
+export type SQLPredicateScalar = boolean | number | bigint | string | Date | Uint8Array;
+
+/** Named parameter reference retained in a portable SQL predicate until execution time. */
+export type SQLPredicateParameter = Readonly<{
+  /** Parameter name without the leading SQL colon. */
+  parameter: string;
+}>;
+
+/** Scalar value or unresolved named parameter accepted by a portable predicate expression. */
+export type SQLPredicateValue = SQLPredicateScalar | SQLPredicateParameter;
+
+/** Runtime values used to bind named predicate parameters before a backend executes them. */
+export type SQLPredicateParameterValues = Readonly<Record<string, SQLPredicateScalar>>;
 
 /** Reference to one column in a portable SQL predicate expression. */
 export type SQLPredicateProperty = Readonly<{
@@ -67,5 +79,21 @@ export type SQLPredicate =
 /** Options for parsing one SQL predicate expression. */
 export type SQLPredicateParserOptions = Readonly<{
   /** Named values referenced using SQL parameters such as `:minimumFare`. */
-  parameters?: Readonly<Record<string, SQLPredicateValue>>;
+  parameters?: SQLPredicateParameterValues;
+  /** Retains named references in the emitted AST instead of resolving them while parsing. */
+  preserveParameters?: boolean;
 }>;
+
+/** Returns whether a value is a named parameter reference. */
+export function isSQLPredicateParameter(value: unknown): value is SQLPredicateParameter {
+  const parameterValue = value as {parameter?: unknown};
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.keys(value).length === 1 &&
+    Object.hasOwn(value, 'parameter') &&
+    typeof parameterValue.parameter === 'string' &&
+    parameterValue.parameter.length > 0
+  );
+}

--- a/modules/sql/src/sql-predicate-zod.ts
+++ b/modules/sql/src/sql-predicate-zod.ts
@@ -13,7 +13,8 @@ export const SQLPredicateValueSchema: z.ZodType<SQLPredicateValue> = z.union([
   z.bigint(),
   z.string(),
   z.date(),
-  z.instanceof(Uint8Array)
+  z.instanceof(Uint8Array),
+  z.object({parameter: z.string().min(1)}).strict()
 ]);
 
 const SQLPredicatePropertySchema = z.object({property: z.string().min(1)}).strict();

--- a/modules/sql/src/sql-predicate.ts
+++ b/modules/sql/src/sql-predicate.ts
@@ -8,6 +8,8 @@ export {
   SQL_PREDICATE_JSON_SCHEMA,
   validateSQLPredicate
 } from './sql-predicate-schema';
+export {bindSQLPredicate} from './bind-sql-predicate';
+export {isSQLPredicateParameter} from './sql-predicate-types';
 
 export type {
   SQLComparisonPredicate,
@@ -16,7 +18,10 @@ export type {
   SQLNotPredicate,
   SQLNullPredicate,
   SQLPredicate,
+  SQLPredicateParameter,
+  SQLPredicateParameterValues,
   SQLPredicateParserOptions,
   SQLPredicateProperty,
+  SQLPredicateScalar,
   SQLPredicateValue
 } from './sql-predicate-types';

--- a/modules/sql/src/table-query.ts
+++ b/modules/sql/src/table-query.ts
@@ -1,0 +1,150 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {validateSQLPredicate} from './sql-predicate-schema';
+import type {SQLPredicate} from './sql-predicate-types';
+
+/** Immutable, backend-neutral request for a table query. */
+export type TableQueryOptions = Readonly<{
+  /** Portable SQL predicate applied before projection. */
+  predicate?: SQLPredicate;
+  /** Output columns in caller-specified order. Defaults to every source column. */
+  columns?: readonly string[];
+  /** Maximum number of rows retained after filtering and projection. */
+  limit?: number;
+}>;
+
+/** Reads the minimum source columns required by the remaining table-query plan. */
+export type TableQueryScanStep = Readonly<{
+  /** Plan discriminator. */
+  kind: 'scan';
+  /** Source columns required for filtering and output. */
+  columns: readonly string[];
+}>;
+
+/** Applies a portable SQL predicate while all predicate columns remain available. */
+export type TableQueryFilterStep = Readonly<{
+  /** Plan discriminator. */
+  kind: 'filter';
+  /** Predicate evaluated using SQL three-valued Boolean semantics. */
+  predicate: SQLPredicate;
+}>;
+
+/** Narrows the result to requested output columns. */
+export type TableQueryProjectStep = Readonly<{
+  /** Plan discriminator. */
+  kind: 'project';
+  /** Output columns in caller-specified order. */
+  columns: readonly string[];
+}>;
+
+/** Retains the first rows in source order after filtering and projection. */
+export type TableQueryLimitStep = Readonly<{
+  /** Plan discriminator. */
+  kind: 'limit';
+  /** Maximum number of retained rows. */
+  limit: number;
+}>;
+
+/** One immutable operation in a normalized table-query plan. */
+export type TableQueryPlanStep =
+  | TableQueryScanStep
+  | TableQueryFilterStep
+  | TableQueryProjectStep
+  | TableQueryLimitStep;
+
+/** Immutable logical query plan shared by Arrow and GPU dataframe backends. */
+export type TableQueryPlan = readonly TableQueryPlanStep[];
+
+/**
+ * Produces the canonical scan, filter, project, and limit sequence for a table query.
+ *
+ * Predicate columns are retained by the scan even if callers omit them from the output projection.
+ * This makes SQL `WHERE` semantics independent of a backend's internal API call order.
+ */
+export function planTableQuery(
+  sourceColumnNames: readonly string[],
+  options: TableQueryOptions = {}
+): TableQueryPlan {
+  validateTableQueryOptions(sourceColumnNames, options);
+
+  const outputColumnNames = options.columns ? [...options.columns] : [...sourceColumnNames];
+  const predicateColumnNames = options.predicate
+    ? getSQLPredicateColumnNames(options.predicate)
+    : [];
+  const requiredColumnNames = new Set([...outputColumnNames, ...predicateColumnNames]);
+  const scanColumnNames = sourceColumnNames.filter(columnName =>
+    requiredColumnNames.has(columnName)
+  );
+  const steps: TableQueryPlanStep[] = [
+    Object.freeze({kind: 'scan' as const, columns: Object.freeze(scanColumnNames)})
+  ];
+
+  if (options.predicate) {
+    steps.push(Object.freeze({kind: 'filter' as const, predicate: options.predicate}));
+  }
+  steps.push(Object.freeze({kind: 'project' as const, columns: Object.freeze(outputColumnNames)}));
+  if (options.limit !== undefined) {
+    steps.push(Object.freeze({kind: 'limit' as const, limit: options.limit}));
+  }
+  return Object.freeze(steps);
+}
+
+/** Returns every source column referenced by one portable predicate, in first-use order. */
+export function getSQLPredicateColumnNames(predicate: SQLPredicate): string[] {
+  const columnNames = new Set<string>();
+  visitSQLPredicate(predicate, currentPredicate => {
+    if (
+      currentPredicate.op !== 'and' &&
+      currentPredicate.op !== 'or' &&
+      currentPredicate.op !== 'not'
+    ) {
+      columnNames.add((currentPredicate.args[0] as {property: string}).property);
+    }
+  });
+  return [...columnNames];
+}
+
+/** Validates a table-query request against a source schema before a backend receives it. */
+function validateTableQueryOptions(
+  sourceColumnNames: readonly string[],
+  options: TableQueryOptions
+): void {
+  const availableColumnNames = new Set(sourceColumnNames);
+  const outputColumnNames = options.columns ?? sourceColumnNames;
+  const seenColumnNames = new Set<string>();
+  for (const columnName of outputColumnNames) {
+    if (!availableColumnNames.has(columnName)) {
+      throw new Error(`Table query column not found: ${columnName}`);
+    }
+    if (seenColumnNames.has(columnName)) {
+      throw new Error(`Table query column was selected more than once: ${columnName}`);
+    }
+    seenColumnNames.add(columnName);
+  }
+  if (options.limit !== undefined && (!Number.isSafeInteger(options.limit) || options.limit < 0)) {
+    throw new Error('Table query limit must be a non-negative safe integer.');
+  }
+  if (options.predicate) {
+    validateSQLPredicate(options.predicate);
+    for (const columnName of getSQLPredicateColumnNames(options.predicate)) {
+      if (!availableColumnNames.has(columnName)) {
+        throw new Error(`Table query predicate column not found: ${columnName}`);
+      }
+    }
+  }
+}
+
+/** Recursively visits every predicate node in depth-first order. */
+function visitSQLPredicate(
+  predicate: SQLPredicate,
+  visit: (predicate: SQLPredicate) => void
+): void {
+  visit(predicate);
+  if (predicate.op === 'and' || predicate.op === 'or' || predicate.op === 'not') {
+    for (const child of predicate.args) {
+      visitSQLPredicate(child, visit);
+    }
+  }
+}

--- a/modules/sql/test/arrow-query.spec.ts
+++ b/modules/sql/test/arrow-query.spec.ts
@@ -7,7 +7,12 @@ import {expect, test} from 'vitest';
 import type {ArrowTable} from '@loaders.gl/schema';
 import {convertArrowToSchema} from '@loaders.gl/schema-utils';
 
-import {parseSQLPredicate, queryArrowTable} from '@loaders.gl/sql';
+import {
+  bindSQLPredicate,
+  parseSQLPredicate,
+  planTableQuery,
+  queryArrowTable
+} from '@loaders.gl/sql';
 
 test('queryArrowTable filters, projects, and limits Arrow data', () => {
   const table = makeArrowTable({
@@ -50,6 +55,33 @@ test('queryArrowTable permits a projected column to also appear in the predicate
   });
 
   expect(toRows(result)).toEqual([{status: 'valid'}, {status: 'valid'}]);
+});
+
+test('planTableQuery retains predicate columns before projecting the requested output', () => {
+  const predicate = parseSQLPredicate('year >= 2024 AND cancelled = FALSE');
+
+  expect(
+    planTableQuery(['year', 'cancelled', 'carrier', 'fare'], {
+      predicate,
+      columns: ['carrier', 'fare'],
+      limit: 20
+    })
+  ).toEqual([
+    {kind: 'scan', columns: ['year', 'cancelled', 'carrier', 'fare']},
+    {kind: 'filter', predicate},
+    {kind: 'project', columns: ['carrier', 'fare']},
+    {kind: 'limit', limit: 20}
+  ]);
+});
+
+test('queryArrowTable requires named parameters to be bound immediately before execution', () => {
+  const predicate = parseSQLPredicate('value >= :minimum', {preserveParameters: true});
+  const table = makeArrowTable({value: [1, 2, 3]});
+
+  expect(() => queryArrowTable(table, {predicate})).toThrow(/must be bound/);
+  expect(
+    toRows(queryArrowTable(table, {predicate: bindSQLPredicate(predicate, {minimum: 2})}))
+  ).toEqual([{value: 2}, {value: 3}]);
 });
 
 test('queryArrowTable retains zero-copy Arrow views for projection and limit without filtering', () => {

--- a/modules/sql/test/arrow-query.spec.ts
+++ b/modules/sql/test/arrow-query.spec.ts
@@ -1,0 +1,93 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import * as arrow from 'apache-arrow';
+import {expect, test} from 'vitest';
+import type {ArrowTable} from '@loaders.gl/schema';
+import {convertArrowToSchema} from '@loaders.gl/schema-utils';
+
+import {parseSQLPredicate, queryArrowTable} from '@loaders.gl/sql';
+
+test('queryArrowTable filters, projects, and limits Arrow data', () => {
+  const table = makeArrowTable({
+    year: [2023, 2024, 2025, 2026],
+    cancelled: [false, true, false, false],
+    carrier: ['AA', 'BB', 'CC', 'DD'],
+    fare: [120, 240, 180, 320]
+  });
+
+  const result = queryArrowTable(table, {
+    predicate: parseSQLPredicate('year >= 2024 AND cancelled = FALSE'),
+    columns: ['carrier', 'fare'],
+    limit: 1
+  });
+
+  expect(result.data.schema.fields.map(field => field.name)).toEqual(['carrier', 'fare']);
+  expect(toRows(result)).toEqual([{carrier: 'CC', fare: 180}]);
+});
+
+test('queryArrowTable applies SQL null semantics and keeps predicate columns internal', () => {
+  const table = makeArrowTable({
+    status: ['valid', null, 'invalid', 'valid'],
+    payload: [1, 2, 3, 4]
+  });
+
+  const result = queryArrowTable(table, {
+    predicate: parseSQLPredicate("NOT (status = 'invalid')"),
+    columns: ['payload']
+  });
+
+  expect(toRows(result)).toEqual([{payload: 1}, {payload: 4}]);
+});
+
+test('queryArrowTable permits a projected column to also appear in the predicate', () => {
+  const table = makeArrowTable({status: ['valid', 'invalid', 'valid']});
+
+  const result = queryArrowTable(table, {
+    predicate: parseSQLPredicate("status = 'valid'"),
+    columns: ['status']
+  });
+
+  expect(toRows(result)).toEqual([{status: 'valid'}, {status: 'valid'}]);
+});
+
+test('queryArrowTable retains zero-copy Arrow views for projection and limit without filtering', () => {
+  const table = makeArrowTable({first: [1, 2, 3], second: ['a', 'b', 'c']});
+
+  const result = queryArrowTable(table, {columns: ['second'], limit: 2});
+
+  expect(result.data.numRows).toBe(2);
+  expect(result.data.schema.fields.map(field => field.name)).toEqual(['second']);
+  expect(toRows(result)).toEqual([{second: 'a'}, {second: 'b'}]);
+});
+
+test.each([
+  [{columns: ['missing']}, /column not found/],
+  [{columns: ['value', 'value']}, /more than once/],
+  [{limit: -1}, /non-negative/],
+  [{limit: 1.5}, /safe integer/]
+])('queryArrowTable rejects invalid query options %o', (options, expectedError) => {
+  const table = makeArrowTable({value: [1, 2, 3]});
+  expect(() => queryArrowTable(table, options)).toThrow(expectedError);
+});
+
+test('queryArrowTable reports cancellation before scanning', () => {
+  const controller = new AbortController();
+  controller.abort();
+
+  expect(() => queryArrowTable(makeArrowTable({value: [1]}), {signal: controller.signal})).toThrow(
+    /aborted/
+  );
+});
+
+/** Wraps simple test columns in the loaders.gl Arrow table shape. */
+function makeArrowTable(columns: Record<string, readonly unknown[]>): ArrowTable {
+  const data = arrow.tableFromArrays(columns);
+  return {shape: 'arrow-table', schema: convertArrowToSchema(data.schema), data};
+}
+
+/** Converts Arrow rows to plain objects for readable assertions. */
+function toRows(table: ArrowTable): Record<string, unknown>[] {
+  return table.data.toArray().map(row => row?.toJSON() ?? {});
+}

--- a/modules/sql/test/sql-predicate.spec.ts
+++ b/modules/sql/test/sql-predicate.spec.ts
@@ -5,6 +5,7 @@
 import {expect, test} from 'vitest';
 
 import {
+  bindSQLPredicate,
   isSQLPredicate,
   parseSQLPredicate,
   SQL_PREDICATE_JSON_SCHEMA,
@@ -74,6 +75,28 @@ test('parseSQLPredicate preserves escaped strings and structured-cloneable param
   });
 });
 
+test('parseSQLPredicate can preserve named parameters for late binding', () => {
+  const predicate = parseSQLPredicate('value >= :minimum AND active = :active', {
+    preserveParameters: true
+  });
+
+  expect(predicate).toEqual({
+    op: 'and',
+    args: [
+      {op: '>=', args: [{property: 'value'}, {parameter: 'minimum'}]},
+      {op: '=', args: [{property: 'active'}, {parameter: 'active'}]}
+    ]
+  });
+  expect(bindSQLPredicate(predicate, {minimum: 10, active: true})).toEqual({
+    op: 'and',
+    args: [
+      {op: '>=', args: [{property: 'value'}, 10]},
+      {op: '=', args: [{property: 'active'}, true]}
+    ]
+  });
+  expect(() => bindSQLPredicate(predicate, {minimum: 10})).toThrow(/:active/);
+});
+
 test('SQL predicate validators accept supported ASTs and reject malformed payloads', () => {
   const predicate = {op: '=', args: [{property: 'value'}, 4]} as const;
   expect(isSQLPredicate(predicate)).toBe(true);
@@ -90,7 +113,7 @@ test('SQL predicate validators accept supported ASTs and reject malformed payloa
 test('SQL predicate JSON Schema describes the dependency-free JSON payload subset', () => {
   expect(SQL_PREDICATE_JSON_SCHEMA.$schema).toBe('https://json-schema.org/draft/2020-12/schema');
   expect(SQL_PREDICATE_JSON_SCHEMA.$defs.logical.properties.args.minItems).toBe(2);
-  expect(SQL_PREDICATE_JSON_SCHEMA.$defs.value.type).toEqual(['boolean', 'number', 'string']);
+  expect(SQL_PREDICATE_JSON_SCHEMA.$defs.value.oneOf).toHaveLength(2);
 });
 
 test.each([


### PR DESCRIPTION
## Goals

- Establish a small Arrow-native local query path for loaders.gl without introducing a full SQL engine.
- Define one portable query-plan contract that Arrow and GPU dataframe executors can share.
- Preserve named predicate parameters until the backend is ready to bind them.

## Changes

- Add immutable `TableQueryOptions` and a normalized `scan → filter → project → limit` planner, published at `@loaders.gl/sql/table-query`.
- Refactor `queryArrowTable()` to execute that plan while retaining predicate-only columns internally and Arrow's zero-copy projection/limit path.
- Extend the portable SQL predicate AST with named parameter references, parser preservation, and an immutable `bindSQLPredicate()` step before execution.
- Update JSON/Zod validation, public exports, documentation, and focused tests for planning, deferred parameters, and Arrow execution.

## Validation

- `yarn lint fix` passed.
- `yarn build` passed.
- `yarn test-node` passed: 29 files, 194 tests passed (6 skipped).
- Focused `yarn test-headless modules/sql/test/arrow-query.spec.ts modules/sql/test/sql-predicate.spec.ts` passed: 25 tests.
- The full headless suite ran 2,032 tests successfully but had 15 unrelated Parquet failures because this isolated worktree shares `node_modules` via symlink and Vite blocks the Parquet WASM path outside its allowed roots.
