### PR TITLE
docs: improve loader tables on format pages

### DIFF
--- a/docs/modules/arrow/README.md
+++ b/docs/modules/arrow/README.md
@@ -16,15 +16,12 @@ See [Using with Apache Arrow](/docs/developer-guide/apache-arrow) for practical 
 
 ## Loaders and Writers
 
-| Loader                                                                |
-| --------------------------------------------------------------------- |
-| [`ArrowLoader`](/docs/modules/arrow/api-reference/arrow-loader)       |
-| [`ArrowWorkerLoader`](/docs/modules/arrow/api-reference/arrow-loader) |
-| [`GeoArrowLoader`](/docs/modules/arrow/api-reference/geoarrow-loader) |
-
-| Writer                                                          |
-| --------------------------------------------------------------- |
-| [`ArrowWriter`](/docs/modules/arrow/api-reference/arrow-writer) |
+| Loader / Writer | Description |
+| --------------- | ----------- |
+| [`ArrowLoader`](/docs/modules/arrow/api-reference/arrow-loader) | Loads Apache Arrow IPC files and streams as loaders.gl tables. |
+| [`ArrowWorkerLoader`](/docs/modules/arrow/api-reference/arrow-loader) | Deprecated alias for `ArrowLoader`. |
+| [`GeoArrowLoader`](/docs/modules/arrow/api-reference/geoarrow-loader) | Loads Arrow data and interprets GeoArrow geometry columns. |
+| [`ArrowWriter`](/docs/modules/arrow/api-reference/arrow-writer) | Writes arrays as Apache Arrow IPC data. |
 
 ## Additional APIs
 

--- a/docs/modules/bson/README.md
+++ b/docs/modules/bson/README.md
@@ -17,10 +17,10 @@ npm install @loaders.gl/core @loaders.gl/bson
 
 ## Loaders and Writers
 
-| Loader                                                       |
-| ------------------------------------------------------------ |
-| [`BSONLoader`](/docs/modules/bson/api-reference/bson-loader) |
-| [`BSONWriter`](/docs/modules/bson/api-reference/bson-writer) |
+| Loader / Writer | Description |
+| --------------- | ----------- |
+| [`BSONLoader`](/docs/modules/bson/api-reference/bson-loader) | Loads BSON binary documents into JSON-like JavaScript objects. |
+| [`BSONWriter`](/docs/modules/bson/api-reference/bson-writer) | Writes JSON-like JavaScript objects as BSON binary documents. |
 
 ## Attribution
 

--- a/docs/modules/copc/README.md
+++ b/docs/modules/copc/README.md
@@ -22,9 +22,9 @@ npm install @loaders.gl/core @loaders.gl/copc
 
 ## APIs
 
-| Loader                                                       |
-| ------------------------------------------------------------ |
-| [`COPCSourceLoader`](/docs/modules/copc/api-reference/copc-source-loader) <img src="https://img.shields.io/badge/From-v5.0-blue.svg?style=flat-square" alt="From-v5.0" /> |
+| Source | Description |
+| ------ | ----------- |
+| [`COPCSourceLoader`](/docs/modules/copc/api-reference/copc-source-loader) <img src="https://img.shields.io/badge/From-v5.0-blue.svg?style=flat-square" alt="From-v5.0" /> | Loads viewport-selected point data from COPC files. |
 
 ## Attribution
 

--- a/docs/modules/excel/README.md
+++ b/docs/modules/excel/README.md
@@ -10,9 +10,9 @@ npm install @loaders.gl/core @loaders.gl/excel
 
 ## Loaders and Writers
 
-| Loader                                                                        |
-| ----------------------------------------------------------------------------- |
-| [`ExcelLoader`](/docs/modules/excel/api-reference/excel-loader#excelloader)   |
+| Loader | Description |
+| ------ | ----------- |
+| [`ExcelLoader`](/docs/modules/excel/api-reference/excel-loader#excelloader) | Loads Excel workbooks as loaders.gl tables. |
 
 ## Additional APIs
 

--- a/docs/modules/flatgeobuf/README.md
+++ b/docs/modules/flatgeobuf/README.md
@@ -19,10 +19,10 @@ npm install @loaders.gl/core
 
 ## Loaders and Writers
 
-| Loader                                                                         |
-| ------------------------------------------------------------------------------ |
-| [`FlatGeobufLoader`](/docs/modules/flatgeobuf/api-reference/flatgeobuf-loader) |
-| [`FlatGeobufSourceLoader`](/docs/modules/flatgeobuf/api-reference/flatgeobuf-source-loader) <img src="https://img.shields.io/badge/From-v5.0-blue.svg?style=flat-square" alt="From-v5.0" /> |
+| Loader / Source | Description |
+| --------------- | ----------- |
+| [`FlatGeobufLoader`](/docs/modules/flatgeobuf/api-reference/flatgeobuf-loader) | Loads FlatGeobuf files as geospatial tables. |
+| [`FlatGeobufSourceLoader`](/docs/modules/flatgeobuf/api-reference/flatgeobuf-source-loader) <img src="https://img.shields.io/badge/From-v5.0-blue.svg?style=flat-square" alt="From-v5.0" /> | Streams features and spatially filtered data from FlatGeobuf sources. |
 
 ## Attribution
 

--- a/docs/modules/geopackage/README.md
+++ b/docs/modules/geopackage/README.md
@@ -12,10 +12,10 @@ npm install @loaders.gl/geopackage
 
 ## Loaders and Writers
 
-| Export                                                                                     |
-| ------------------------------------------------------------------------------------------ |
-| [`GeoPackageLoader`](/docs/modules/geopackage/api-reference/geopackage-loader)             |
-| [`GeoPackageSource`](/docs/modules/geopackage/api-reference/geopackage-source)            |
+| Loader / Source | Description |
+| --------------- | ----------- |
+| [`GeoPackageLoader`](/docs/modules/geopackage/api-reference/geopackage-loader) | Loads GeoPackage files and exposes their tables and layers. |
+| [`GeoPackageSource`](/docs/modules/geopackage/api-reference/geopackage-source) | Provides access to GeoPackage tables as a data source. |
 
 ## Attribution
 

--- a/docs/modules/geotiff/README.md
+++ b/docs/modules/geotiff/README.md
@@ -23,11 +23,11 @@ npm install @loaders.gl/core @loaders.gl/geotiff
 
 ## Loaders and Sources
 
-| Loader                                                                |
-| --------------------------------------------------------------------- |
-| [`GeoTIFFLoader`](/docs/modules/geotiff/api-reference/geotiff-loader) |
-| [`GeoTIFFSourceLoader`](/docs/modules/geotiff/api-reference/geotiff-source-loader) |
-| [`OMETiffSourceLoader`](/docs/modules/geotiff/api-reference/ometiff-source-loader) |
+| Loader / Source | Description |
+| ---------------- | ----------- |
+| [`GeoTIFFLoader`](/docs/modules/geotiff/api-reference/geotiff-loader) | Loads GeoTIFF and OME-TIFF images. |
+| [`GeoTIFFSourceLoader`](/docs/modules/geotiff/api-reference/geotiff-source-loader) | Provides viewport-driven access to geospatial raster data. |
+| [`OMETiffSourceLoader`](/docs/modules/geotiff/api-reference/ometiff-source-loader) | Provides typed OME-TIFF planes for viewport requests. |
 
 ## Additional APIs
 

--- a/docs/modules/geotiff/README.md
+++ b/docs/modules/geotiff/README.md
@@ -25,9 +25,9 @@ npm install @loaders.gl/core @loaders.gl/geotiff
 
 | Loader / Source | Description |
 | ---------------- | ----------- |
-| [`GeoTIFFLoader`](/docs/modules/geotiff/api-reference/geotiff-loader) | Loads GeoTIFF and OME-TIFF images. |
+| [`GeoTIFFLoader`](/docs/modules/geotiff/api-reference/geotiff-loader) | Loads georeferenced GeoTIFF images. |
 | [`GeoTIFFSourceLoader`](/docs/modules/geotiff/api-reference/geotiff-source-loader) | Provides viewport-driven access to geospatial raster data. |
-| [`OMETiffSourceLoader`](/docs/modules/geotiff/api-reference/ometiff-source-loader) | Provides typed OME-TIFF planes for viewport requests. |
+| [`OMETiffSourceLoader`](/docs/modules/geotiff/api-reference/ometiff-source-loader) | Provides typed non-geospatial OME-TIFF planes selected by level, time, z, and channel. |
 
 ## Additional APIs
 

--- a/docs/modules/json/README.md
+++ b/docs/modules/json/README.md
@@ -20,15 +20,15 @@ npm install @loaders.gl/core @loaders.gl/json
 
 ## Loaders and Writers
 
-| Exports                                                                     |
-| --------------------------------------------------------------------------- |
-| [`JSONLoader`](/docs/modules/json/api-reference/json-loader)                |
-| [`JSONTableLoader`](/docs/modules/json/api-reference/json-table-loader)     |
-| [`NDJSONLoader`](/docs/modules/json/api-reference/ndjson-loader) |
-| [`GeoJSONLoader`](/docs/modules/json/api-reference/geojson-loader)          |
-| [`NDGeoJSONLoader`](/docs/modules/json/api-reference/ndgeojson-loader)      |
-| [`JSONWriter`](/docs/modules/json/api-reference/json-writer)                |
-| [`GeoJSONWriter`](/docs/modules/json/api-reference/geojson-writer)          |
+| Loader / Writer | Description |
+| --------------- | ----------- |
+| [`JSONLoader`](/docs/modules/json/api-reference/json-loader) | Loads arbitrary JSON documents and can extract arrays as loaders.gl row tables. |
+| [`JSONTableLoader`](/docs/modules/json/api-reference/json-table-loader) | Loads JSON row arrays as loaders.gl row tables or Apache Arrow tables. |
+| [`NDJSONLoader`](/docs/modules/json/api-reference/ndjson-loader) | Loads newline-delimited JSON records. |
+| [`GeoJSONLoader`](/docs/modules/json/api-reference/geojson-loader) | Loads GeoJSON features and feature collections. |
+| [`NDGeoJSONLoader`](/docs/modules/json/api-reference/ndgeojson-loader) | Loads newline-delimited GeoJSON records. |
+| [`JSONWriter`](/docs/modules/json/api-reference/json-writer) | Writes loaders.gl tables as JSON arrays or custom wrapped JSON values. |
+| [`GeoJSONWriter`](/docs/modules/json/api-reference/geojson-writer) | Writes geospatial tables as GeoJSON. |
 
 ## Additional APIs
 

--- a/docs/modules/mlt/README.md
+++ b/docs/modules/mlt/README.md
@@ -13,17 +13,12 @@ npm install @loaders.gl/mlt
 npm install @loaders.gl/core
 ```
 
-## Loaders
+## Loaders and Sources
 
-| Loader                                                    |
-| --------------------------------------------------------- |
-| [`MLTLoader`](/docs/modules/mlt/api-reference/mlt-loader) |
-
-## Sources
-
-| Source                                                    |
-| --------------------------------------------------------- |
-| [`MLTSourceLoader`](/docs/modules/mlt/api-reference/mlt-source-loader) |
+| Loader / Source | Description |
+| --------------- | ----------- |
+| [`MLTLoader`](/docs/modules/mlt/api-reference/mlt-loader) | Loads MapLibre Tile vector tiles. |
+| [`MLTSourceLoader`](/docs/modules/mlt/api-reference/mlt-source-loader) | Loads MapLibre Tile data as a tile source. |
 
 ## Examples
 

--- a/docs/modules/mvt/README.md
+++ b/docs/modules/mvt/README.md
@@ -13,27 +13,22 @@ npm install @loaders.gl/core
 
 ## Loaders and Writers
 
-| Loader / Writer                                           |
-| --------------------------------------------------------- |
-| [`MapStyleLoader`](/docs/modules/mvt/api-reference/map-style-loader) |
-| [`MVTLoader`](/docs/modules/mvt/api-reference/mvt-loader) |
-| [`TileJSONLoader`](/docs/modules/mvt/api-reference/tilejson-loader) |
-| [`MVTWriter`](/docs/modules/mvt/api-reference/mvt-writer) |
+| Loader / Writer / Source | Description |
+| ----------------------- | ----------- |
+| [`MapStyleLoader`](/docs/modules/mvt/api-reference/map-style-loader) | Parses MapLibre and Mapbox style JSON. |
+| [`MVTLoader`](/docs/modules/mvt/api-reference/mvt-loader) | Parses Mapbox Vector Tiles. |
+| [`TileJSONLoader`](/docs/modules/mvt/api-reference/tilejson-loader) | Parses TileJSON metadata and tilestats. |
+| [`MVTWriter`](/docs/modules/mvt/api-reference/mvt-writer) | Writes Mapbox Vector Tile data. |
+| [`MVTSourceLoader`](/docs/modules/mvt/api-reference/mvt-source-loader) | Dynamically loads tiles from pre-tiled MVT hierarchies. |
+| [`TableTileSourceLoader`](/docs/modules/mvt/api-reference/table-tile-source-loader) | Generates vector tiles from geospatial tables on the fly. |
 
 ## Formats
 
-| Format |
-| ------ |
-| [`Map Styles`](/docs/modules/mvt/formats/map-style) |
-| [`MVT`](/docs/modules/mvt/formats/mvt) |
-| [`TileJSON`](/docs/modules/mvt/formats/tilejson) |
-
-## Sources
-
-| Component                                                              |
-| ---------------------------------------------------------------------- |
-| [`MVTSourceLoader`](/docs/modules/mvt/api-reference/mvt-source-loader)              |
-| [`TableTileSourceLoader`](/docs/modules/mvt/api-reference/table-tile-source-loader) |
+| Format | Description |
+| ------ | ----------- |
+| [`Map Styles`](/docs/modules/mvt/formats/map-style) | MapLibre and Mapbox style JSON documents. |
+| [`MVT`](/docs/modules/mvt/formats/mvt) | Binary vector tiles containing geospatial geometry. |
+| [`TileJSON`](/docs/modules/mvt/formats/tilejson) | JSON metadata describing tiled map resources. |
 
 ## Attribution
 

--- a/docs/modules/pmtiles/README.md
+++ b/docs/modules/pmtiles/README.md
@@ -4,9 +4,9 @@ Support for loading tiled data from [PMTiles](/docs/modules/pmtiles/formats/pmti
 
 ## Loaders and Writers
 
-| Loader                                                                |
-| --------------------------------------------------------------------- |
-| [`PMTilesSourceLoader`](/docs/modules/pmtiles/api-reference/pmtiles-source-loader) |
+| Source | Description |
+| ------ | ----------- |
+| [`PMTilesSourceLoader`](/docs/modules/pmtiles/api-reference/pmtiles-source-loader) | Loads tiled data from PMTiles archives. |
 
 ## Attribution
 

--- a/docs/modules/shapefile/README.md
+++ b/docs/modules/shapefile/README.md
@@ -10,10 +10,10 @@ npm install @loaders.gl/shapefile
 
 ## Loaders and Writers
 
-| Loader                                                          |
-| --------------------------------------------------------------- |
-| [`ShapefileLoader`](/docs/modules/shapefile/api-reference/shapefile-loader) |
-| [`SHPLoader`](/docs/modules/shapefile/api-reference/shp-loader) |
+| Loader | Description |
+| ------ | ----------- |
+| [`ShapefileLoader`](/docs/modules/shapefile/api-reference/shapefile-loader) | Loads Shapefile archives as geospatial tables. |
+| [`SHPLoader`](/docs/modules/shapefile/api-reference/shp-loader) | Loads individual Shapefile `.shp` geometry files. |
 
 ## Attribution
 

--- a/docs/modules/wkt/README.md
+++ b/docs/modules/wkt/README.md
@@ -14,14 +14,14 @@ The `@loaders.gl/wkt` module handles the following formats:
 
 ## Loaders and Writers
 
-| Loader                                                           |
-| ---------------------------------------------------------------- |
-| [`WKBLoader`](/docs/modules/wkt/api-reference/wkb-loader)        |
-| [`WKBWriter`](/docs/modules/wkt/api-reference/wkb-writer)        |
-| [`WKTLoader`](/docs/modules/wkt/api-reference/wkt-loader)        |
-| [`WKTWriter`](/docs/modules/wkt/api-reference/wkt-writer)        |
-| [`WKTCRSLoader`](/docs/modules/wkt/api-reference/wkt-crs-loader) |
-| [`WKTCRSWriter`](/docs/modules/wkt/api-reference/wkt-crs-writer) |
+| Loader / Writer | Description |
+| --------------- | ----------- |
+| [`WKBLoader`](/docs/modules/wkt/api-reference/wkb-loader) | Parses Well-Known Binary geometry. |
+| [`WKBWriter`](/docs/modules/wkt/api-reference/wkb-writer) | Writes geometry as Well-Known Binary. |
+| [`WKTLoader`](/docs/modules/wkt/api-reference/wkt-loader) | Parses Well-Known Text geometry. |
+| [`WKTWriter`](/docs/modules/wkt/api-reference/wkt-writer) | Writes geometry as Well-Known Text. |
+| [`WKTCRSLoader`](/docs/modules/wkt/api-reference/wkt-crs-loader) | Parses Well-Known Text coordinate reference systems. |
+| [`WKTCRSWriter`](/docs/modules/wkt/api-reference/wkt-crs-writer) | Writes coordinate reference systems as WKT-CRS. |
 
 ## Attribution
 


### PR DESCRIPTION
## Goals

Improve format-page loader tables so source loaders are listed alongside related loaders and writers, with concise descriptions that make the tables easier to scan.

## Changes

- Added concise descriptions to loader, writer, and source entries across 13 module overview pages.
- Folded source-loader entries into the main table where applicable.
- Removed the redundant MVT Sources table.
- Added descriptions to the MVT Formats table.

## Validation

- `git diff --check`
- `yarn lint`
