### PR TITLE
feat(avro): add Arrow loader and writer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,10 +60,10 @@ jobs:
             profile-name: node-22
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node (with Corepack)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -75,7 +75,7 @@ jobs:
 
       - name: Cache Yarn 4 artifacts
         id: yarn-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.yarn/berry/cache
@@ -107,7 +107,7 @@ jobs:
 
       - name: Upload coverage blob
         if: matrix.coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-blob-${{ matrix.coverage-flag }}
           path: .vitest-reports/
@@ -116,7 +116,7 @@ jobs:
 
       - name: Upload test profile
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-profile-${{ matrix.profile-name }}
           path: test-results/${{ matrix.profile-name }}.json
@@ -129,10 +129,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node (with Corepack)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24
 
@@ -142,7 +142,7 @@ jobs:
           corepack prepare yarn@4.17.1 --activate
 
       - name: Cache Yarn 4 artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.yarn/berry/cache
@@ -189,7 +189,7 @@ jobs:
 
       - name: Upload merged coverage
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: merged-coverage
           path: |
@@ -203,12 +203,12 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup Node (with Corepack)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24
 
@@ -218,7 +218,7 @@ jobs:
           corepack prepare yarn@4.17.1 --activate
 
       - name: Cache Yarn 4 artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.yarn/berry/cache
@@ -247,7 +247,7 @@ jobs:
           --coverage.reporter=json
 
       - name: Upload slow coverage blob
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-blob-slow
           path: .vitest-reports/
@@ -261,10 +261,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node (with Corepack)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24
 
@@ -274,7 +274,7 @@ jobs:
           corepack prepare yarn@4.17.1 --activate
 
       - name: Cache Yarn 4 artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.yarn/berry/cache
@@ -303,10 +303,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node (with Corepack)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24
 
@@ -318,7 +318,7 @@ jobs:
 
       - name: Cache Yarn 4 artifacts
         id: yarn-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.yarn/berry/cache
@@ -327,7 +327,7 @@ jobs:
             yarn-berry-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Cache Nx build artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: .nx/cache
           key: nx-build-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
@@ -364,10 +364,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node (with Corepack)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -379,7 +379,7 @@ jobs:
 
       - name: Cache website Yarn artifacts
         id: website-yarn-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.yarn/berry/cache

--- a/formats/avro.md
+++ b/formats/avro.md
@@ -1,0 +1,114 @@
+# Apache Avro
+
+> **Status:** v5.0 experimental / work in progress. The Avro loader, schema loader, and Arrow-based writer are available for evaluation.
+
+Apache Avro is a schema-based data serialization system. This loader targets Avro Object Container Files and returns an Apache Arrow table.
+
+## Format variants
+
+| Variant | Description | Supported |
+| --- | --- | :---: |
+| Object Container File | Self-contained file beginning with `Obj\x01`, including metadata, schema, sync marker, and data blocks | ✓ |
+| Raw Avro datum | A datum encoded with a separately supplied schema | ✓ via `avro.schema` |
+| Single-object encoding | Compact `c3 01`-prefixed datum with an external schema fingerprint | ✓ via `avro.schema`; fingerprint validated by default |
+| Raw binary datum | Schema-external Avro binary datum | ✓ for one Arrow row via writer `encoding: 'raw'` |
+| Avro RPC protocol | Message framing and protocol metadata for Avro RPC | — |
+| Avro schema/protocol JSON | Schema or protocol definition without serialized records | — |
+
+## Object Container File features
+
+| Feature | Supported |
+| --- | :---: |
+| Embedded `avro.schema` metadata | ✓ |
+| Custom file metadata | Read and writable via `avro.metadata` |
+| Multiple data blocks | ✓ |
+| Block sync markers | ✓ |
+| OCF block metadata/index inspection | ✓ via `parseAvroOCF` |
+| Block byte offsets for selective reads | ✓; record-level filtering remains future work |
+| Selective block decoding | ✓ via `avro.blockIndices` |
+| URL-backed OCF loading | ✓ through normal `load(url, AvroLoader)` and `parseFile(HttpFile, AvroLoader)`; uses HTTP ranges when available |
+| Authenticated URL loading | ✓ via `avro.headers`; supports cancellation with `avro.signal` |
+| Empty files / empty data blocks | ✓ |
+| Object Container File schema evolution via reader schema | Partial: projection, aliases, validated defaults, and Avro numeric promotions |
+| External reader schema | ✓ through `avro.readerSchema` |
+| Streaming `parseInBatches` | ✓, block-oriented Arrow batches |
+| Chunked OCF writing | ✓ via `encodeAvroInChunks` |
+
+## Schema types
+
+| Avro schema feature | Supported |
+| --- | :---: |
+| `null` | ✓ |
+| `boolean` | ✓ |
+| `int` | ✓ |
+| `long` | ✓, JavaScript safe range by default; exact `bigint` mode via `avro.longType` |
+| `float` | ✓ |
+| `double` | ✓ |
+| `bytes` | ✓, returned as `Uint8Array` |
+| `string` | ✓ |
+| `record` | ✓ |
+| `enum` | ✓, returned as the symbol string |
+| `array` | ✓ |
+| `map` | ✓ |
+| `fixed` | ✓, returned as `Uint8Array` |
+| Unions | ✓ |
+| Nested records and collections | ✓ |
+| Named type references | ✓ |
+| Recursive schemas | ✓ for named record references |
+| Logical types | Partial: `date`, timestamps, time values, decimal, big-decimal, UUID, and duration |
+| Field aliases and documentation | — |
+| Schema defaults | ✓ validated by `AvroSchemaLoader`; reader defaults enforce union-first-branch rules |
+
+## Block codecs
+
+| Avro codec | Supported |
+| --- | :---: |
+| `null` | ✓ |
+| `deflate` | ✓, raw DEFLATE through `@loaders.gl/compression`; writer supported |
+| `snappy` | ✓, including Avro block CRC32 validation; writer supported |
+| `zstandard` | ✓, through `@loaders.gl/compression`; writer supported |
+| `bzip2` | ✓ loader; writer supported when the optional codec runtime is installed |
+| `xz` | ✓ loader; writer supported when the optional codec runtime is installed |
+| Custom codec | — |
+
+## Output
+
+| Output | Supported |
+| --- | :---: |
+| Loaders.gl `arrow-table` wrapper | ✓ |
+| Apache Arrow `Table` | ✓ |
+| Object-row table output | — |
+| Arrow schema metadata copied from Avro schema annotations | — |
+
+The implementation uses the shared loaders.gl compression module for supported compressed blocks. Avro data decoding is implemented in the parquet module, and Arrow columns are constructed with `apache-arrow`.
+
+## Explicitly unsupported or incomplete
+
+These limitations are intentional and should not be inferred as supported merely because the surrounding Avro format is supported:
+
+| Feature | Current status |
+| --- | --- |
+| Avro RPC protocols and message framing | Not supported |
+| Protocol-definition JSON documents | Not supported by `AvroSchemaLoader` |
+| Custom codecs | Not supported |
+| bzip2 and xz writing | Not supported; loader decompression only |
+| Single-object Avro writing | Supported for exactly one Arrow row; fingerprint is emitted from the supplied/derived schema |
+| Raw Avro writing | Supported for exactly one Arrow row; schema is required by the reader |
+| Record-level predicate filtering | Not supported; selection is at OCF block granularity |
+| Remote range-backed OCF reads | Supported for explicit URL APIs; servers without byte-range support fall back to full download |
+| Recursive data with cycles in the in-memory Arrow result | Not supported; recursive named schemas must produce finite values |
+| `time-millis`, `time-micros`, timestamp nanos, and local-timestamp logical types | Supported; integer precision is preserved on load and `Date` inputs use UTC time-of-day semantics |
+| Avro `big-decimal` logical type | Supported for writer values shaped as `{value, scale}`; loaded values are `{value, scale}` with JavaScript-number precision |
+| Full schema namespace/name canonicalization | Incomplete |
+| Full reader-schema resolution for every union/default edge case | Incomplete |
+| Arrow schema metadata/documentation annotations | Not supported |
+
+## Loaders
+
+| Loader | Input | Output |
+| --- | --- | --- |
+| `AvroLoader` | `.avro` Object Container Files | Loaders.gl `arrow-table` containing an Apache Arrow `Table` |
+| `AvroSchemaLoader` | `.avsc` standalone JSON schemas | Parsed and validated Avro schema object |
+| `AvroWriter` | Arrow `arrow-table` | `.avro` Object Container File; null codec |
+
+`AvroSchemaLoader` validates primitive types, unions, arrays, maps, records, enums, fixed types, and named-type references. It does not parse Avro RPC protocol definitions, which are a separate JSON document type.

--- a/formats/avro.md
+++ b/formats/avro.md
@@ -1,6 +1,11 @@
 # Apache Avro
 
-> **Status:** v5.0 experimental / work in progress. The Avro loader, schema loader, and Arrow-based writer are available for evaluation.
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v5.0-blue.svg?style=flat-square" alt="From-v5.0" />
+  <img src="https://img.shields.io/badge/Status-Experimental-orange.svg?style=flat-square" alt="Status: Experimental" />
+</p>
+
+The Avro loader, schema loader, and Arrow-based writer are available for evaluation.
 
 Apache Avro is a schema-based data serialization system. This loader targets Avro Object Container Files and returns an Apache Arrow table.
 

--- a/modules/core/src/lib/api/load.ts
+++ b/modules/core/src/lib/api/load.ts
@@ -13,7 +13,8 @@ import type {
   LoaderReturnType,
   LoaderArrayOptionsType,
   LoaderArrayReturnType,
-  SourceLoader
+  SourceLoader,
+  LoaderWithParser
 } from '@loaders.gl/loader-utils';
 import {isBlob, isSourceLoader} from '@loaders.gl/loader-utils';
 import {isLoaderObject} from '../loader-utils/normalize-loader';
@@ -157,7 +158,7 @@ export async function load(
       );
     }
 
-    if (selectedLoader) {
+    if (selectedLoader && typeof url === 'string') {
       const loaderImplementation = await getLoaderImplementation(
         selectedLoader,
         resolvedOptions,

--- a/modules/core/src/lib/api/load.ts
+++ b/modules/core/src/lib/api/load.ts
@@ -27,6 +27,7 @@ import {parseSync} from './parse-sync';
 import {parseInBatches} from './parse-in-batches';
 import {loadInBatches} from './load-in-batches';
 import {selectLoader} from './select-loader';
+import {getLoaderImplementation} from './load-loader';
 
 /**
  * Parses `data` using a specified loader
@@ -154,6 +155,24 @@ export async function load(
           loadInBatches
         }
       );
+    }
+
+    if (selectedLoader) {
+      const loaderImplementation = await getLoaderImplementation(
+        selectedLoader,
+        resolvedOptions,
+        url
+      );
+      const parseUrl = (
+        loaderImplementation as LoaderWithParser & {
+          parseUrl?: (
+            url: string,
+            options?: LoaderOptions,
+            context?: LoaderContext
+          ) => Promise<unknown>;
+        }
+      ).parseUrl;
+      if (parseUrl) return await parseUrl(url, resolvedOptions, context);
     }
   }
 

--- a/modules/parquet/package.json
+++ b/modules/parquet/package.json
@@ -43,6 +43,26 @@
       "types": "./dist/parquet-loader.d.ts",
       "import": "./dist/parquet-loader.js"
     },
+    "./avro-loader": {
+      "types": "./dist/avro-loader.d.ts",
+      "import": "./dist/avro-loader.js"
+    },
+    "./avro-schema-loader": {
+      "types": "./dist/avro-schema-loader.d.ts",
+      "import": "./dist/avro-schema-loader.js"
+    },
+    "./avro-writer": {
+      "types": "./dist/avro-writer.d.ts",
+      "import": "./dist/avro-writer.js"
+    },
+    "./avro-stream": {
+      "types": "./dist/avro-stream.d.ts",
+      "import": "./dist/avro-stream.js"
+    },
+    "./avro-ocf": {
+      "types": "./dist/avro-ocf.d.ts",
+      "import": "./dist/avro-ocf.js"
+    },
     "./parquet-js-loader": {
       "types": "./dist/parquet-js-loader.d.ts",
       "import": "./dist/parquet-js-loader.js"

--- a/modules/parquet/src/avro-compression.ts
+++ b/modules/parquet/src/avro-compression.ts
@@ -1,0 +1,98 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Compression} from '@loaders.gl/compression';
+import {BZip2Compression} from '@loaders.gl/compression/bzip2-compression';
+import {DeflateCompression} from '@loaders.gl/compression/deflate-compression';
+import {SnappyCompression} from '@loaders.gl/compression/snappy-compression';
+import {XZCompression} from '@loaders.gl/compression/xz-compression';
+import {ZstdCompression} from '@loaders.gl/compression/zstd-compression';
+import {toArrayBuffer, toUint8Array} from './parquetjs/utils/binary-utils';
+
+type AvroCodec = 'null' | 'deflate' | 'snappy' | 'zstandard' | 'bzip2' | 'xz';
+
+export type {AvroCodec};
+
+const compressionPromises: Partial<Record<Exclude<AvroCodec, 'null'>, Promise<Compression>>> = {};
+
+/** Decompresses one Avro data block using a codec from the compression module. */
+export async function decompressAvro(codec: string, value: Uint8Array): Promise<Uint8Array> {
+  if (codec === 'null') return value;
+  if (!isAvroCodec(codec)) throw new Error(`avro: unsupported compression codec "${codec}"`);
+
+  const compression = await getAvroCompression(codec);
+  const compressedValue = codec === 'snappy' ? value.subarray(0, -4) : value;
+  const output = toUint8Array(await compression.decompress(toArrayBuffer(compressedValue)));
+
+  if (codec === 'snappy') {
+    if (value.length < 4 || readUInt32BE(value, value.length - 4) !== crc32(output)) {
+      throw new Error('avro: Snappy block CRC32 check failed');
+    }
+  }
+  return output;
+}
+
+/** Compresses one Avro data block using a supported writer codec. */
+export async function compressAvro(codec: string, value: Uint8Array): Promise<Uint8Array> {
+  if (codec === 'null') return value;
+  if (!isAvroCodec(codec)) throw new Error(`avro: unsupported compression codec "${codec}"`);
+  const compression = await getAvroCompression(codec);
+  const compressed = toUint8Array(await compression.compress(toArrayBuffer(value)));
+  if (codec !== 'snappy') return compressed;
+  const result = new Uint8Array(compressed.length + 4);
+  result.set(compressed);
+  const checksum = crc32(value);
+  result[result.length - 4] = checksum >>> 24;
+  result[result.length - 3] = checksum >>> 16;
+  result[result.length - 2] = checksum >>> 8;
+  result[result.length - 1] = checksum;
+  return result;
+}
+
+/** Returns whether a string is a supported Avro codec name. */
+function isAvroCodec(codec: string): codec is Exclude<AvroCodec, 'null'> {
+  return (
+    codec === 'deflate' ||
+    codec === 'snappy' ||
+    codec === 'zstandard' ||
+    codec === 'bzip2' ||
+    codec === 'xz'
+  );
+}
+
+/** Lazily constructs an Avro codec implementation. */
+async function getAvroCompression(codec: Exclude<AvroCodec, 'null'>): Promise<Compression> {
+  compressionPromises[codec] ||= createAvroCompression(codec);
+  return await compressionPromises[codec];
+}
+
+/** Creates one codec implementation from the shared compression module. */
+async function createAvroCompression(codec: Exclude<AvroCodec, 'null'>): Promise<Compression> {
+  const compression = {
+    deflate: new DeflateCompression({raw: true}),
+    snappy: new SnappyCompression(),
+    zstandard: new ZstdCompression(),
+    bzip2: new BZip2Compression(),
+    xz: new XZCompression()
+  }[codec];
+  await compression.preload();
+  return compression;
+}
+
+/** Reads a big-endian unsigned 32-bit integer. */
+function readUInt32BE(bytes: Uint8Array, offset: number): number {
+  return (
+    (bytes[offset] << 24) | (bytes[offset + 1] << 16) | (bytes[offset + 2] << 8) | bytes[offset + 3]
+  );
+}
+
+/** Computes the CRC32 used by Avro's Snappy codec. */
+function crc32(bytes: Uint8Array): number {
+  let checksum = 0xffffffff;
+  for (const byte of bytes) {
+    checksum ^= byte;
+    for (let bit = 0; bit < 8; bit++) checksum = (checksum >>> 1) ^ (0xedb88320 & -(checksum & 1));
+  }
+  return checksum ^ 0xffffffff;
+}

--- a/modules/parquet/src/avro-compression.ts
+++ b/modules/parquet/src/avro-compression.ts
@@ -2,26 +2,35 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {Compression} from '@loaders.gl/compression';
-import {BZip2Compression} from '@loaders.gl/compression/bzip2-compression';
-import {DeflateCompression} from '@loaders.gl/compression/deflate-compression';
-import {SnappyCompression} from '@loaders.gl/compression/snappy-compression';
-import {XZCompression} from '@loaders.gl/compression/xz-compression';
-import {ZstdCompression} from '@loaders.gl/compression/zstd-compression';
+import {
+  BZip2Compressor,
+  BZip2Decompressor,
+  DeflateCompressor,
+  DeflateDecompressor,
+  SnappyCompressor,
+  SnappyDecompressor,
+  XZCompressor,
+  XZDecompressor,
+  ZstdCompressor,
+  ZstdDecompressor
+} from '@loaders.gl/compression';
+import type {Compressor, Decompressor} from '@loaders.gl/compression';
 import {toArrayBuffer, toUint8Array} from './parquetjs/utils/binary-utils';
 
 type AvroCodec = 'null' | 'deflate' | 'snappy' | 'zstandard' | 'bzip2' | 'xz';
 
 export type {AvroCodec};
 
-const compressionPromises: Partial<Record<Exclude<AvroCodec, 'null'>, Promise<Compression>>> = {};
+const decompressionPromises: Partial<Record<Exclude<AvroCodec, 'null'>, Promise<Decompressor>>> =
+  {};
+const compressionPromises: Partial<Record<Exclude<AvroCodec, 'null'>, Promise<Compressor>>> = {};
 
 /** Decompresses one Avro data block using a codec from the compression module. */
 export async function decompressAvro(codec: string, value: Uint8Array): Promise<Uint8Array> {
   if (codec === 'null') return value;
   if (!isAvroCodec(codec)) throw new Error(`avro: unsupported compression codec "${codec}"`);
 
-  const compression = await getAvroCompression(codec);
+  const compression = await getAvroDecompressor(codec);
   const compressedValue = codec === 'snappy' ? value.subarray(0, -4) : value;
   const output = toUint8Array(await compression.decompress(toArrayBuffer(compressedValue)));
 
@@ -37,7 +46,7 @@ export async function decompressAvro(codec: string, value: Uint8Array): Promise<
 export async function compressAvro(codec: string, value: Uint8Array): Promise<Uint8Array> {
   if (codec === 'null') return value;
   if (!isAvroCodec(codec)) throw new Error(`avro: unsupported compression codec "${codec}"`);
-  const compression = await getAvroCompression(codec);
+  const compression = await getAvroCompressor(codec);
   const compressed = toUint8Array(await compression.compress(toArrayBuffer(value)));
   if (codec !== 'snappy') return compressed;
   const result = new Uint8Array(compressed.length + 4);
@@ -62,22 +71,41 @@ function isAvroCodec(codec: string): codec is Exclude<AvroCodec, 'null'> {
 }
 
 /** Lazily constructs an Avro codec implementation. */
-async function getAvroCompression(codec: Exclude<AvroCodec, 'null'>): Promise<Compression> {
-  compressionPromises[codec] ||= createAvroCompression(codec);
+async function getAvroDecompressor(codec: Exclude<AvroCodec, 'null'>): Promise<Decompressor> {
+  decompressionPromises[codec] ||= createAvroDecompressor(codec);
+  return await decompressionPromises[codec];
+}
+
+/** Creates one decompressor from the shared compression module. */
+async function createAvroDecompressor(codec: Exclude<AvroCodec, 'null'>): Promise<Decompressor> {
+  const decompressor = {
+    deflate: new DeflateDecompressor({raw: true}),
+    snappy: new SnappyDecompressor(),
+    zstandard: new ZstdDecompressor(),
+    bzip2: new BZip2Decompressor(),
+    xz: new XZDecompressor()
+  }[codec];
+  await decompressor.preload();
+  return decompressor;
+}
+
+/** Creates one compressor from the shared compression module. */
+async function getAvroCompressor(codec: Exclude<AvroCodec, 'null'>): Promise<Compressor> {
+  compressionPromises[codec] ||= createAvroCompressor(codec);
   return await compressionPromises[codec];
 }
 
-/** Creates one codec implementation from the shared compression module. */
-async function createAvroCompression(codec: Exclude<AvroCodec, 'null'>): Promise<Compression> {
-  const compression = {
-    deflate: new DeflateCompression({raw: true}),
-    snappy: new SnappyCompression(),
-    zstandard: new ZstdCompression(),
-    bzip2: new BZip2Compression(),
-    xz: new XZCompression()
+/** Creates one compressor from the shared compression module. */
+async function createAvroCompressor(codec: Exclude<AvroCodec, 'null'>): Promise<Compressor> {
+  const compressor = {
+    deflate: new DeflateCompressor({raw: true}),
+    snappy: new SnappyCompressor(),
+    zstandard: new ZstdCompressor(),
+    bzip2: new BZip2Compressor(),
+    xz: new XZCompressor()
   }[codec];
-  await compression.preload();
-  return compression;
+  await compressor.preload();
+  return compressor;
 }
 
 /** Reads a big-endian unsigned 32-bit integer. */

--- a/modules/parquet/src/avro-format.ts
+++ b/modules/parquet/src/avro-format.ts
@@ -1,0 +1,19 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Format} from '@loaders.gl/loader-utils';
+
+/** Format metadata for Apache Avro Object Container Files. */
+export const AvroFormat = {
+  name: 'Apache Avro',
+  id: 'avro',
+  module: 'parquet',
+  extensions: ['avro'],
+  mimeTypes: ['avro/binary', 'application/avro'],
+  category: 'table',
+  encoding: 'binary',
+  format: 'avro',
+  binary: true,
+  tests: ['Obj\x01']
+} as const satisfies Format;

--- a/modules/parquet/src/avro-loader-types.ts
+++ b/modules/parquet/src/avro-loader-types.ts
@@ -1,0 +1,54 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Loader} from '@loaders.gl/loader-utils';
+import type {ArrowTable, ArrowTableBatch} from '@loaders.gl/schema';
+import {AvroFormat} from './avro-format';
+
+// __VERSION__ is injected by the build tooling.
+// @ts-ignore TS2304: Cannot find name '__VERSION__'.
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+
+/** Options for the Apache Avro loader. */
+export type AvroLoaderOptions = {
+  avro?: {
+    /** Maximum number of rows yielded by each parseInBatches result. */
+    batchSize?: number;
+    /** Reader schema used for projection and compatible schema evolution. */
+    readerSchema?: unknown;
+    /** Representation for Avro long values; number is the default for compatibility. */
+    longType?: 'number' | 'bigint';
+    /** External schema used for raw datum and single-object encodings. */
+    schema?: unknown;
+    /** Input encoding; auto detects Object Container and single-object files. */
+    encoding?: 'auto' | 'ocf' | 'raw' | 'single-object';
+    /** Validate the 64-bit schema fingerprint in single-object encodings. Defaults to true. */
+    validateFingerprint?: boolean;
+    /** Optional zero-based OCF block indices to decode; omitted means all blocks. */
+    blockIndices?: number[];
+    /** Additional headers sent with URL-backed range requests. */
+    headers?: Record<string, string>;
+    /** Abort signal for URL-backed range requests. */
+    signal?: AbortSignal;
+    /** Initial range size used to discover the OCF header. */
+    rangeChunkSize?: number;
+  };
+};
+
+/** Preloads the parser-bearing Avro loader implementation. */
+async function preloadAvroLoader() {
+  const {AvroLoaderWithParser} = await import('@loaders.gl/parquet/avro-loader');
+  return AvroLoaderWithParser;
+}
+
+/** Metadata-only loader for Apache Avro Object Container Files. */
+export const AvroLoader = {
+  ...AvroFormat,
+  dataType: null as unknown as ArrowTable,
+  batchType: null as unknown as ArrowTableBatch,
+  version: VERSION,
+  worker: false,
+  options: {},
+  preload: preloadAvroLoader
+} as const satisfies Loader<ArrowTable, ArrowTableBatch, AvroLoaderOptions>;

--- a/modules/parquet/src/avro-loader.ts
+++ b/modules/parquet/src/avro-loader.ts
@@ -1,0 +1,97 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {concatenateArrayBuffersAsync, type LoaderWithParser} from '@loaders.gl/loader-utils';
+import type {ArrowTable, ArrowTableBatch} from '@loaders.gl/schema';
+import {AvroLoader as AvroLoaderMetadata} from './avro-loader-types';
+import {
+  parseAvro,
+  parseAvroFromFile,
+  parseAvroFromUrl,
+  parseAvroInBatches,
+  parseAvroInBatchesFromUrl
+} from './lib/parsers/parse-avro';
+import type {AvroLoaderOptions} from './avro-loader-types';
+
+const {preload: _AvroLoaderPreload, ...AvroLoaderMetadataWithoutPreload} = AvroLoaderMetadata;
+
+/** Loader for Apache Avro Object Container Files. */
+export const AvroLoaderWithParser = {
+  ...AvroLoaderMetadataWithoutPreload,
+  async parse(arrayBuffer: ArrayBuffer, options?: AvroLoaderOptions): Promise<ArrowTable> {
+    return parseAvro(arrayBuffer, {
+      readerSchema: options?.avro?.readerSchema,
+      longType: options?.avro?.longType,
+      schema: options?.avro?.schema,
+      encoding: options?.avro?.encoding,
+      validateFingerprint: options?.avro?.validateFingerprint,
+      blockIndices: options?.avro?.blockIndices,
+      headers: options?.avro?.headers,
+      signal: options?.avro?.signal,
+      rangeChunkSize: options?.avro?.rangeChunkSize
+    });
+  },
+  async parseUrl(url: string, options?: AvroLoaderOptions): Promise<ArrowTable> {
+    return parseAvroFromUrl(url, {
+      readerSchema: options?.avro?.readerSchema,
+      longType: options?.avro?.longType,
+      schema: options?.avro?.schema,
+      encoding: options?.avro?.encoding,
+      validateFingerprint: options?.avro?.validateFingerprint,
+      blockIndices: options?.avro?.blockIndices,
+      batchSize: options?.avro?.batchSize,
+      headers: options?.avro?.headers,
+      signal: options?.avro?.signal,
+      rangeChunkSize: options?.avro?.rangeChunkSize
+    });
+  },
+  async parseFile(file, options?: AvroLoaderOptions): Promise<ArrowTable> {
+    return parseAvroFromFile(file, {
+      readerSchema: options?.avro?.readerSchema,
+      longType: options?.avro?.longType,
+      schema: options?.avro?.schema,
+      encoding: options?.avro?.encoding,
+      validateFingerprint: options?.avro?.validateFingerprint,
+      blockIndices: options?.avro?.blockIndices,
+      batchSize: options?.avro?.batchSize,
+      signal: options?.avro?.signal,
+      rangeChunkSize: options?.avro?.rangeChunkSize
+    });
+  },
+  async *parseInBatches(asyncIterator, options?: AvroLoaderOptions) {
+    const arrayBuffer = await concatenateArrayBuffersAsync(asyncIterator);
+    yield* parseAvroInBatches(arrayBuffer, options?.avro?.batchSize, {
+      readerSchema: options?.avro?.readerSchema,
+      longType: options?.avro?.longType,
+      schema: options?.avro?.schema,
+      encoding: options?.avro?.encoding,
+      validateFingerprint: options?.avro?.validateFingerprint,
+      blockIndices: options?.avro?.blockIndices
+    });
+  },
+  async *parseInBatchesFromUrl(url: string, options?: AvroLoaderOptions) {
+    yield* parseAvroInBatchesFromUrl(url, {
+      readerSchema: options?.avro?.readerSchema,
+      longType: options?.avro?.longType,
+      schema: options?.avro?.schema,
+      encoding: options?.avro?.encoding,
+      validateFingerprint: options?.avro?.validateFingerprint,
+      blockIndices: options?.avro?.blockIndices,
+      batchSize: options?.avro?.batchSize,
+      headers: options?.avro?.headers,
+      signal: options?.avro?.signal,
+      rangeChunkSize: options?.avro?.rangeChunkSize
+    });
+  }
+} as const satisfies LoaderWithParser<ArrowTable, ArrowTableBatch, AvroLoaderOptions> & {
+  parseUrl: (url: string, options?: AvroLoaderOptions) => Promise<ArrowTable>;
+  parseFile: (
+    file: import('@loaders.gl/loader-utils').ReadableFile,
+    options?: AvroLoaderOptions
+  ) => Promise<ArrowTable>;
+  parseInBatchesFromUrl: (
+    url: string,
+    options?: AvroLoaderOptions
+  ) => AsyncIterable<ArrowTableBatch>;
+};

--- a/modules/parquet/src/avro-ocf.ts
+++ b/modules/parquet/src/avro-ocf.ts
@@ -1,0 +1,6 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export {parseAvroOCF, parseAvroOCFHeader} from './lib/parsers/parse-avro';
+export type {AvroOCF, AvroOCFBlock, AvroOCFHeader, AvroSchema} from './lib/parsers/parse-avro';

--- a/modules/parquet/src/avro-schema-loader-types.ts
+++ b/modules/parquet/src/avro-schema-loader-types.ts
@@ -11,6 +11,12 @@ const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 /** Options for the standalone Avro schema loader. */
 export type AvroSchemaLoaderOptions = Record<string, never>;
 
+/** Preloads the parser-bearing Avro schema loader implementation. */
+async function preloadAvroSchemaLoader() {
+  const {AvroSchemaLoaderWithParser} = await import('@loaders.gl/parquet/avro-schema-loader');
+  return AvroSchemaLoaderWithParser;
+}
+
 /** Metadata-only loader for standalone Avro JSON schema files. */
 export const AvroSchemaLoader = {
   name: 'Apache Avro Schema',
@@ -24,5 +30,6 @@ export const AvroSchemaLoader = {
   binary: false,
   dataType: null as unknown,
   batchType: null as never,
-  options: {}
+  options: {},
+  preload: preloadAvroSchemaLoader
 } as const satisfies Loader<unknown, never, AvroSchemaLoaderOptions>;

--- a/modules/parquet/src/avro-schema-loader-types.ts
+++ b/modules/parquet/src/avro-schema-loader-types.ts
@@ -1,0 +1,28 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Loader} from '@loaders.gl/loader-utils';
+
+// __VERSION__ is injected by babel-plugin-version-inline.
+// @ts-ignore TS2304: Cannot find name '__VERSION__'.
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+
+/** Options for the standalone Avro schema loader. */
+export type AvroSchemaLoaderOptions = Record<string, never>;
+
+/** Metadata-only loader for standalone Avro JSON schema files. */
+export const AvroSchemaLoader = {
+  name: 'Apache Avro Schema',
+  id: 'avro-schema',
+  module: 'parquet',
+  version: VERSION,
+  extensions: ['avsc'],
+  mimeTypes: ['application/vnd.apache.avro+json', 'application/json'],
+  category: 'json',
+  text: true,
+  binary: false,
+  dataType: null as unknown,
+  batchType: null as never,
+  options: {}
+} as const satisfies Loader<unknown, never, AvroSchemaLoaderOptions>;

--- a/modules/parquet/src/avro-schema-loader.ts
+++ b/modules/parquet/src/avro-schema-loader.ts
@@ -1,0 +1,18 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {LoaderWithParser} from '@loaders.gl/loader-utils';
+import {AvroSchemaLoader as AvroSchemaLoaderMetadata} from './avro-schema-loader-types';
+import {parseAvroSchema} from './lib/parsers/parse-avro-schema';
+import type {AvroSchemaLoaderOptions} from './avro-schema-loader-types';
+
+const AvroSchemaLoaderMetadataWithoutPreload = AvroSchemaLoaderMetadata;
+
+/** Loader for standalone Avro `.avsc` JSON schema files. */
+export const AvroSchemaLoaderWithParser = {
+  ...AvroSchemaLoaderMetadataWithoutPreload,
+  async parse(arrayBuffer: ArrayBuffer, _options?: AvroSchemaLoaderOptions) {
+    return parseAvroSchema(new TextDecoder().decode(arrayBuffer));
+  }
+} as const satisfies LoaderWithParser<unknown, never, AvroSchemaLoaderOptions>;

--- a/modules/parquet/src/avro-stream.ts
+++ b/modules/parquet/src/avro-stream.ts
@@ -1,0 +1,6 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export {encodeAvroInChunks} from './lib/encoders/encode-avro';
+export type {AvroWriterOptions, AvroSchema} from './lib/encoders/encode-avro';

--- a/modules/parquet/src/avro-writer.ts
+++ b/modules/parquet/src/avro-writer.ts
@@ -1,0 +1,31 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {WriterOptions, WriterWithEncoder} from '@loaders.gl/loader-utils';
+import type {ArrowTable, ArrowTableBatch} from '@loaders.gl/schema';
+import {
+  encodeAvro,
+  type AvroSchema,
+  type AvroWriterOptions as AvroEncoderOptions
+} from './lib/encoders/encode-avro';
+import {AvroFormat} from './avro-format';
+
+/** Public options for the Apache Avro writer. */
+export type AvroWriterOptions = WriterOptions & AvroEncoderOptions;
+
+// __VERSION__ is injected by the build tooling.
+// @ts-ignore TS2304: Cannot find name '__VERSION__'.
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+
+/** Writer for Arrow tables in Avro Object Container File format. */
+export const AvroWriter = {
+  ...AvroFormat,
+  version: VERSION,
+  options: {avro: {}},
+  async encode(table: ArrowTable, options?: AvroWriterOptions) {
+    return encodeAvro(table, options);
+  }
+} as const satisfies WriterWithEncoder<ArrowTable, ArrowTableBatch, AvroWriterOptions>;
+
+export type {AvroSchema};

--- a/modules/parquet/src/bundled.ts
+++ b/modules/parquet/src/bundled.ts
@@ -3,8 +3,14 @@
 // Copyright (c) vis.gl contributors
 
 export type {ParquetLoaderOptions} from './parquet-loader-types';
+export type {AvroLoaderOptions} from './avro-loader-types';
 export type {GeoParquetLoaderOptions} from './geoparquet-loader';
 export {ParquetLoaderWithParser as ParquetLoader} from './parquet-loader';
+export {AvroLoaderWithParser as AvroLoader} from './avro-loader';
+export {AvroWriter} from './avro-writer';
+export {encodeAvroInChunks} from './avro-stream';
+export {parseAvroOCF} from './avro-ocf';
+export {AvroSchemaLoaderWithParser as AvroSchemaLoader} from './avro-schema-loader';
 export {GeoParquetLoaderWithParser as GeoParquetLoader} from './geoparquet-loader-with-parser';
 export {ParquetJSLoaderWithParser as ParquetJSLoader} from './parquet-js-loader';
 export {

--- a/modules/parquet/src/index.ts
+++ b/modules/parquet/src/index.ts
@@ -5,9 +5,17 @@
 // import {ArrowTable, ArrowTableBatch} from '@loaders.gl/arrow';
 
 export {ParquetFormat} from './parquet-format';
+export {AvroFormat} from './avro-format';
 
 export type {ParquetLoaderOptions, ParquetJSLoaderOptions} from './parquet-loader-options';
 export {ParquetLoader} from './parquet-loader-types';
+export type {AvroLoaderOptions} from './avro-loader-types';
+export {AvroLoader} from './avro-loader-types';
+export {AvroWriter} from './avro-writer';
+export type {AvroSchema, AvroWriterOptions} from './avro-writer';
+export {encodeAvroInChunks} from './avro-stream';
+export {parseAvroOCF} from './avro-ocf';
+export {AvroSchemaLoader} from './avro-schema-loader-types';
 export {GeoParquetLoader} from './geoparquet-loader';
 export {ParquetJSLoader} from './parquet-js-loader-types';
 

--- a/modules/parquet/src/lib/encoders/encode-avro.ts
+++ b/modules/parquet/src/lib/encoders/encode-avro.ts
@@ -1,0 +1,585 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {ArrowTable} from '@loaders.gl/schema';
+import {compressAvro, type AvroCodec} from '../../avro-compression';
+import {getAvroSchemaFingerprint} from '../parsers/parse-avro';
+
+/** Supported Avro schema representation for the first writer milestone. */
+export type AvroSchema =
+  | string
+  | AvroSchema[]
+  | {
+      type: AvroSchema;
+      name?: string;
+      aliases?: string[];
+      logicalType?: string;
+      precision?: number;
+      scale?: number;
+      fields?: {name: string; type: AvroSchema}[];
+      symbols?: string[];
+      size?: number;
+      items?: AvroSchema;
+      values?: AvroSchema;
+    };
+
+/** Options for the Apache Avro writer. */
+export type AvroWriterOptions = {
+  avro?: {
+    /** Output encoding. Raw output writes a sequence of binary records. */
+    encoding?: 'ocf' | 'raw' | 'single-object';
+    /** Explicit root record schema; otherwise it is derived from Arrow fields. */
+    schema?: AvroSchema;
+    /** Fixed 16-byte sync marker used for each output block. */
+    syncMarker?: Uint8Array;
+    /** Avro block codec. bzip2 and xz require the optional codec runtime. */
+    codec?: AvroCodec;
+    /** Target uncompressed block size in bytes. */
+    blockSize?: number;
+    /** Additional OCF metadata entries. Reserved Avro keys cannot be overridden. */
+    metadata?: Record<string, string | Uint8Array>;
+  };
+};
+
+const MAGIC = new Uint8Array([0x4f, 0x62, 0x6a, 0x01]);
+const DEFAULT_SYNC_MARKER = new Uint8Array([
+  0x6c, 0x6f, 0x61, 0x64, 0x65, 0x72, 0x73, 0x2e, 0x67, 0x6c, 0x2d, 0x61, 0x76, 0x72, 0x6f, 0x31
+]);
+
+/** Encodes an Arrow table as a null-codec Avro Object Container File. */
+export async function encodeAvro(
+  table: ArrowTable,
+  options?: AvroWriterOptions
+): Promise<ArrayBuffer> {
+  if (options?.avro?.encoding === 'raw') return encodeAvroRaw(table, options);
+  if (options?.avro?.encoding === 'single-object') return encodeAvroSingleObject(table, options);
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of encodeAvroInChunks(table, options)) chunks.push(chunk);
+  return concatBytes(chunks).buffer as ArrayBuffer;
+}
+
+/** Encodes an Arrow table as an async sequence of OCF header and block chunks. */
+export async function* encodeAvroInChunks(
+  table: ArrowTable,
+  options?: AvroWriterOptions
+): AsyncIterable<Uint8Array> {
+  if (options?.avro?.encoding === 'raw' || options?.avro?.encoding === 'single-object')
+    throw new Error('Avro raw and single-object encodings do not support chunked OCF output');
+  const schema = options?.avro?.schema || deriveRecordSchema(table);
+  if (!isRecordSchema(schema)) throw new Error('AvroWriter requires a root record schema');
+  const namedTypes = collectNamedTypes(schema);
+  const syncMarker = options?.avro?.syncMarker || DEFAULT_SYNC_MARKER;
+  if (syncMarker.length !== 16) throw new Error('Avro sync markers must contain exactly 16 bytes');
+  const codec = options?.avro?.codec || 'null';
+  const blockSize = options?.avro?.blockSize || 64 * 1024;
+  if (blockSize <= 0) throw new Error('Avro block size must be positive');
+
+  yield createAvroHeader(schema, codec, syncMarker, options?.avro?.metadata);
+  const fields = schema.fields || [];
+  const columns = fields.map(field => table.data.getChild(field.name));
+  let block = new ByteWriter();
+  let blockRowCount = 0;
+  for (let rowIndex = 0; rowIndex < table.data.numRows; rowIndex++) {
+    const record: Record<string, unknown> = {};
+    for (let fieldIndex = 0; fieldIndex < fields.length; fieldIndex++) {
+      record[fields[fieldIndex].name] = columns[fieldIndex]?.get(rowIndex);
+    }
+    const row = new ByteWriter();
+    writeValue(row, schema, record, namedTypes);
+    if (blockRowCount > 0 && block.length + row.length > blockSize) {
+      yield await encodeAvroBlock(codec, syncMarker, blockRowCount, block.finish());
+      block = new ByteWriter();
+      blockRowCount = 0;
+    }
+    block.writeBytes(row.finish());
+    blockRowCount++;
+  }
+  if (blockRowCount > 0)
+    yield await encodeAvroBlock(codec, syncMarker, blockRowCount, block.finish());
+}
+
+/** Encodes exactly one Arrow record as a raw Avro binary datum. */
+function encodeAvroRaw(table: ArrowTable, options: AvroWriterOptions): ArrayBuffer {
+  if (table.data.numRows !== 1) throw new Error('Avro raw encoding requires exactly one table row');
+  const schema = options.avro?.schema || deriveRecordSchema(table);
+  if (!isRecordSchema(schema)) throw new Error('AvroWriter requires a root record schema');
+  const namedTypes = collectNamedTypes(schema);
+  const output = new ByteWriter();
+  const fields = schema.fields || [];
+  const record: Record<string, unknown> = {};
+  for (const field of fields) record[field.name] = table.data.getChild(field.name)?.get(0);
+  writeValue(output, schema, record, namedTypes);
+  return output.finish().buffer as ArrayBuffer;
+}
+
+/** Encodes exactly one Arrow record using Avro's single-object encoding. */
+function encodeAvroSingleObject(table: ArrowTable, options: AvroWriterOptions): ArrayBuffer {
+  if (table.data.numRows !== 1)
+    throw new Error('Avro single-object encoding requires exactly one table row');
+  const schema = options.avro?.schema || deriveRecordSchema(table);
+  if (!isRecordSchema(schema)) throw new Error('AvroWriter requires a root record schema');
+  const record: Record<string, unknown> = {};
+  for (const field of schema.fields || [])
+    record[field.name] = table.data.getChild(field.name)?.get(0);
+  const writer = new ByteWriter();
+  writeValue(writer, schema, record, collectNamedTypes(schema));
+  const output = new Uint8Array(10 + writer.length);
+  output.set([0xc3, 0x01]);
+  new DataView(output.buffer).setBigUint64(2, getAvroSchemaFingerprint(schema), true);
+  output.set(writer.finish(), 10);
+  return output.buffer;
+}
+
+/** Encodes the OCF header and metadata map. */
+function createAvroHeader(
+  schema: AvroSchema,
+  codec: AvroCodec,
+  syncMarker: Uint8Array,
+  customMetadata?: Record<string, string | Uint8Array>
+): Uint8Array {
+  const metadata = Object.entries(customMetadata || {});
+  for (const [key] of metadata)
+    if (key === 'avro.schema' || key === 'avro.codec')
+      throw new Error(`Avro metadata key "${key}" is reserved`);
+  const output = new ByteWriter();
+  output.writeBytes(MAGIC);
+  output.writeLong(2 + metadata.length);
+  output.writeString('avro.schema');
+  output.writeBytesValue(new TextEncoder().encode(JSON.stringify(schema)));
+  output.writeString('avro.codec');
+  output.writeString(codec);
+  for (const [key, value] of metadata) {
+    output.writeString(key);
+    if (typeof value === 'string') output.writeString(value);
+    else output.writeBytesValue(value);
+  }
+  output.writeLong(0);
+  output.writeBytes(syncMarker);
+  return output.finish();
+}
+
+/** Encodes one OCF block as a self-contained output chunk. */
+async function encodeAvroBlock(
+  codec: AvroCodec,
+  syncMarker: Uint8Array,
+  count: number,
+  uncompressedBytes: Uint8Array
+): Promise<Uint8Array> {
+  const compressedBytes = await compressAvro(codec, uncompressedBytes);
+  const output = new ByteWriter();
+  output.writeLong(count);
+  output.writeLong(compressedBytes.length);
+  output.writeBytes(compressedBytes);
+  output.writeBytes(syncMarker);
+  return output.finish();
+}
+
+/** Concatenates output chunks into one exact byte array. */
+function concatBytes(chunks: Uint8Array[]): Uint8Array {
+  const output = new Uint8Array(chunks.reduce((length, chunk) => length + chunk.length, 0));
+  let offset = 0;
+  for (const chunk of chunks) {
+    output.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return output;
+}
+
+/** Derives a flat Avro record schema from Arrow fields. */
+function deriveRecordSchema(table: ArrowTable): AvroSchema {
+  return {
+    type: 'record',
+    name: 'ArrowRecord',
+    fields: table.data.schema.fields.map(field => ({
+      name: field.name,
+      type: deriveFieldSchema(field.type.toString())
+    }))
+  };
+}
+
+/** Maps common Arrow type names to Avro primitive types. */
+function deriveFieldSchema(typeName: string): AvroSchema {
+  const type = typeName.toLowerCase();
+  if (type.includes('utf8') || type.includes('string')) return 'string';
+  if (type.includes('binary')) return 'bytes';
+  if (type.includes('bool')) return 'boolean';
+  if (type.includes('dateday')) return {type: 'int', logicalType: 'date'};
+  if (type.includes('timestampmillisecond')) return {type: 'long', logicalType: 'timestamp-millis'};
+  if (type.includes('timestampmicrosecond')) return {type: 'long', logicalType: 'timestamp-micros'};
+  if (type.includes('int8') || type.includes('int16') || type.includes('int32')) return 'int';
+  if (type.includes('int64') || type.includes('uint64')) return 'long';
+  if (type.includes('float32')) return 'float';
+  if (type.includes('float64')) return 'double';
+  throw new Error(`AvroWriter cannot derive a schema for Arrow type "${typeName}"`);
+}
+
+/** Checks whether a schema is a named record schema. */
+function isRecordSchema(schema: AvroSchema): schema is Extract<AvroSchema, {fields?: unknown}> {
+  return !Array.isArray(schema) && typeof schema !== 'string' && schema.type === 'record';
+}
+
+/** Writes one value according to an Avro schema. */
+function writeValue(
+  writer: ByteWriter,
+  inputSchema: AvroSchema,
+  value: unknown,
+  namedTypes: Map<string, AvroSchema>
+): void {
+  const schema = resolveSchema(inputSchema, namedTypes);
+  if (typeof schema !== 'string' && !Array.isArray(schema) && schema.logicalType) {
+    writeValue(
+      writer,
+      {...schema, logicalType: undefined},
+      normalizeLogicalValue(schema.logicalType, value, schema),
+      namedTypes
+    );
+    return;
+  }
+  if (Array.isArray(schema)) {
+    const branchIndex = schema.findIndex(branch => canEncode(branch, value, namedTypes));
+    if (branchIndex < 0) throw new Error('Value does not match any Avro union branch');
+    writer.writeLong(branchIndex);
+    writeValue(writer, schema[branchIndex], value, namedTypes);
+    return;
+  }
+  if (typeof schema === 'string') {
+    writePrimitive(writer, schema, value);
+    return;
+  }
+  if (Array.isArray(schema.type)) {
+    writeValue(writer, schema.type, value, namedTypes);
+    return;
+  }
+  if (typeof schema.type !== 'string') {
+    writeValue(writer, schema.type, value, namedTypes);
+    return;
+  }
+  switch (schema.type) {
+    case 'record':
+      for (const field of schema.fields || [])
+        writeValue(
+          writer,
+          field.type,
+          (value as Record<string, unknown>)?.[field.name],
+          namedTypes
+        );
+      break;
+    case 'enum': {
+      const index = schema.symbols?.indexOf(String(value)) ?? -1;
+      if (index < 0) throw new Error(`Unknown Avro enum symbol "${String(value)}"`);
+      writer.writeLong(index);
+      break;
+    }
+    case 'fixed':
+      writer.writeFixed(toBytes(value), schema.size || 0);
+      break;
+    case 'array': {
+      const values = Array.isArray(value) ? value : [];
+      if (values.length) {
+        writer.writeLong(values.length);
+        for (const item of values) writeValue(writer, schema.items as AvroSchema, item, namedTypes);
+      }
+      writer.writeLong(0);
+      break;
+    }
+    case 'map': {
+      const entries = value instanceof Map ? [...value.entries()] : Object.entries(value || {});
+      if (entries.length) {
+        writer.writeLong(entries.length);
+        for (const [key, item] of entries) {
+          writer.writeString(key);
+          writeValue(writer, schema.values as AvroSchema, item, namedTypes);
+        }
+      }
+      writer.writeLong(0);
+      break;
+    }
+    default:
+      writePrimitive(writer, schema.type, value);
+  }
+}
+
+/** Checks whether a value can be encoded by a union branch. */
+function canEncode(
+  inputSchema: AvroSchema,
+  value: unknown,
+  namedTypes: Map<string, AvroSchema>
+): boolean {
+  const schema = resolveSchema(inputSchema, namedTypes);
+  if (schema === 'null') return value == null;
+  if (Array.isArray(schema)) return schema.some(branch => canEncode(branch, value, namedTypes));
+  if (typeof schema === 'string') {
+    if (schema === 'null') return value == null;
+    if (value == null) return false;
+    if (schema === 'boolean') return typeof value === 'boolean';
+    if (schema === 'string') return typeof value === 'string';
+    if (schema === 'bytes')
+      return value instanceof Uint8Array || value instanceof ArrayBuffer || Array.isArray(value);
+    if (schema === 'int' || schema === 'long' || schema === 'float' || schema === 'double')
+      return typeof value === 'number' || typeof value === 'bigint';
+    return true;
+  }
+  if (schema.logicalType) return value != null;
+  if (Array.isArray(schema.type)) return canEncode(schema.type, value, namedTypes);
+  if (typeof schema.type !== 'string') return canEncode(schema.type, value, namedTypes);
+  if (schema.type === 'record')
+    return isRecordSchema(schema) && value != null && typeof value === 'object';
+  if (schema.type === 'array') return Array.isArray(value);
+  if (schema.type === 'map') return value != null && typeof value === 'object';
+  return value != null;
+}
+
+/** Resolves a named schema reference. */
+function resolveSchema(schema: AvroSchema, namedTypes: Map<string, AvroSchema>): AvroSchema {
+  if (typeof schema !== 'string') return schema;
+  return namedTypes.get(schema) || schema;
+}
+
+/** Collects named schemas, including nested definitions. */
+function collectNamedTypes(schema: AvroSchema): Map<string, AvroSchema> {
+  const namedTypes = new Map<string, AvroSchema>();
+  const visit = (currentSchema: AvroSchema): void => {
+    if (typeof currentSchema === 'string') return;
+    if (Array.isArray(currentSchema)) {
+      for (const branch of currentSchema) visit(branch);
+      return;
+    }
+    if (currentSchema.name) namedTypes.set(currentSchema.name, currentSchema);
+    if (Array.isArray(currentSchema.type)) for (const branch of currentSchema.type) visit(branch);
+    else if (typeof currentSchema.type !== 'string') visit(currentSchema.type);
+    for (const field of currentSchema.fields || []) visit(field.type);
+    if (currentSchema.items) visit(currentSchema.items);
+    if (currentSchema.values) visit(currentSchema.values);
+  };
+  visit(schema);
+  return namedTypes;
+}
+
+/** Converts JavaScript logical values to their Avro primitive representation. */
+function normalizeLogicalValue(
+  logicalType: string,
+  value: unknown,
+  schema: {type: AvroSchema; size?: number; scale?: number}
+): unknown {
+  if (logicalType === 'decimal') return encodeDecimal(value, schema.scale || 0, schema);
+  if (logicalType === 'big-decimal') return encodeBigDecimal(value);
+  if (logicalType === 'uuid') {
+    const uuid = String(value ?? '');
+    if (!isUuid(uuid)) throw new Error('Invalid Avro UUID value');
+    return uuid;
+  }
+  if (logicalType === 'duration') return encodeDuration(value);
+  if (value instanceof Date) {
+    if (logicalType === 'date') return Math.floor(value.getTime() / 86_400_000);
+    if (logicalType === 'time-millis') return getUtcTimeOfDay(value, 1_000);
+    if (logicalType === 'time-micros') return getUtcTimeOfDay(value, 1_000_000);
+    if (logicalType === 'timestamp-micros') return value.getTime() * 1_000;
+    if (logicalType === 'timestamp-nanos' || logicalType === 'local-timestamp-nanos')
+      return BigInt(value.getTime()) * 1_000_000n;
+    return value.getTime();
+  }
+  if (typeof value === 'bigint') return value;
+  return Number(value || 0);
+}
+
+/** Encodes Avro's scalable big-decimal payload as nested bytes plus a scale. */
+function encodeBigDecimal(value: unknown): Uint8Array {
+  const input = Array.isArray(value)
+    ? {value: value[0], scale: value[1]}
+    : (value as {value?: unknown; scale?: unknown} | null);
+  if (!input || input.scale === undefined)
+    throw new Error('Avro big-decimal requires a value and scale');
+  const scale = Number(input.scale);
+  if (!Number.isInteger(scale) || scale < 0)
+    throw new Error('Avro big-decimal scale must be non-negative');
+  const text = String(input.value ?? '0');
+  const sign = text.startsWith('-') ? -1n : 1n;
+  const unsignedText = text.replace(/^[+-]/, '');
+  const [integerPart, fractionPart = ''] = unsignedText.split('.');
+  if (fractionPart.length > scale)
+    throw new Error('Avro big-decimal has too many fractional digits');
+  const unscaled = sign * BigInt(`${integerPart || '0'}${fractionPart.padEnd(scale, '0')}` || '0');
+  const payload = new ByteWriter();
+  const bytes = encodeSignedBytes(unscaled, getMinimalDecimalByteLength(unscaled));
+  payload.writeBytesValue(bytes);
+  payload.writeLong(scale);
+  return payload.finish();
+}
+
+/** Converts a UTC Date to an Avro time-of-day value. */
+function getUtcTimeOfDay(value: Date, unit: number): number {
+  return (
+    ((value.getUTCHours() * 60 + value.getUTCMinutes()) * 60 + value.getUTCSeconds()) * unit +
+    value.getUTCMilliseconds() * (unit / 1_000)
+  );
+}
+
+/** Tests an Avro UUID string. */
+function isUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+}
+
+/** Encodes an Avro duration as months, days, and milliseconds. */
+function encodeDuration(value: unknown): Uint8Array {
+  const duration = Array.isArray(value)
+    ? {months: value[0], days: value[1], milliseconds: value[2]}
+    : (value as {months?: unknown; days?: unknown; milliseconds?: unknown} | null);
+  if (!duration) throw new Error('Avro duration requires months, days, and milliseconds');
+  const bytes = new Uint8Array(12);
+  const view = new DataView(bytes.buffer);
+  view.setUint32(0, Number(duration.months || 0), true);
+  view.setUint32(4, Number(duration.days || 0), true);
+  view.setUint32(8, Number(duration.milliseconds || 0), true);
+  return bytes;
+}
+
+/** Encodes a decimal value as a signed big-endian two's-complement integer. */
+function encodeDecimal(
+  value: unknown,
+  scale: number,
+  schema: {type: AvroSchema; size?: number}
+): Uint8Array {
+  const text = String(value ?? '0');
+  const sign = text.startsWith('-') ? -1n : 1n;
+  const unsignedText = text.replace(/^[+-]/, '');
+  const [integerPart, fractionPart = ''] = unsignedText.split('.');
+  if (fractionPart.length > scale) throw new Error('Avro decimal has too many fractional digits');
+  const digits = `${integerPart || '0'}${fractionPart.padEnd(scale, '0')}`;
+  const unscaled = sign * BigInt(digits || '0');
+  const fixedSize = schema.type === 'fixed' ? schema.size : undefined;
+  const length = fixedSize || getMinimalDecimalByteLength(unscaled);
+  return encodeSignedBytes(unscaled, length);
+}
+
+/** Finds the shortest signed byte width that can contain a decimal integer. */
+function getMinimalDecimalByteLength(value: bigint): number {
+  for (let length = 1; length <= 32; length++) {
+    const bits = BigInt(length * 8 - 1);
+    if (value >= -(1n << bits) && value < 1n << bits) return length;
+  }
+  throw new Error('Avro decimal value is too large');
+}
+
+/** Encodes a signed integer into a fixed-width big-endian byte array. */
+function encodeSignedBytes(value: bigint, length: number): Uint8Array {
+  const bits = BigInt(length * 8);
+  const minimum = -(1n << (bits - 1n));
+  const maximum = (1n << (bits - 1n)) - 1n;
+  if (value < minimum || value > maximum)
+    throw new Error('Avro decimal value does not fit its schema');
+  const modulo = 1n << bits;
+  let encoded = value < 0n ? modulo + value : value;
+  const bytes = new Uint8Array(length);
+  for (let index = length - 1; index >= 0; index--) {
+    bytes[index] = Number(encoded & 0xffn);
+    encoded >>= 8n;
+  }
+  return bytes;
+}
+
+/** Writes an Avro primitive value. */
+function writePrimitive(writer: ByteWriter, type: string, value: unknown): void {
+  switch (type) {
+    case 'null':
+      return;
+    case 'boolean':
+      writer.writeByte(value ? 1 : 0);
+      return;
+    case 'int':
+      writer.writeLong(Number(value || 0));
+      return;
+    case 'long':
+      writer.writeLong(typeof value === 'bigint' ? value : Number(value || 0));
+      return;
+    case 'float':
+      writer.writeFloat(Number(value || 0));
+      return;
+    case 'double':
+      writer.writeDouble(Number(value || 0));
+      return;
+    case 'bytes':
+      writer.writeBytesValue(toBytes(value));
+      return;
+    case 'string':
+      writer.writeString(String(value ?? ''));
+      return;
+    default:
+      throw new Error(`Unsupported Avro schema type "${type}"`);
+  }
+}
+
+/** Converts an Avro bytes-compatible value to bytes. */
+function toBytes(value: unknown): Uint8Array {
+  if (value instanceof Uint8Array) return value;
+  if (value instanceof ArrayBuffer) return new Uint8Array(value);
+  if (Array.isArray(value)) return Uint8Array.from(value as number[]);
+  throw new Error('Avro bytes and fixed values must be Uint8Array instances');
+}
+
+/** Compact byte writer for Avro's binary encoding. */
+class ByteWriter {
+  private readonly bytes: number[] = [];
+
+  get length(): number {
+    return this.bytes.length;
+  }
+
+  writeByte(value: number): void {
+    this.bytes.push(value & 0xff);
+  }
+
+  writeBytes(bytes: Uint8Array): void {
+    for (const byte of bytes) this.bytes.push(byte);
+  }
+
+  writeFixed(bytes: Uint8Array, length: number): void {
+    if (bytes.length !== length) throw new Error(`Avro fixed value must contain ${length} bytes`);
+    this.writeBytes(bytes);
+  }
+
+  writeBytesValue(bytes: Uint8Array): void {
+    this.writeLong(bytes.length);
+    this.writeBytes(bytes);
+  }
+
+  writeString(value: string): void {
+    this.writeBytesValue(new TextEncoder().encode(value));
+  }
+
+  writeLong(value: number | bigint): void {
+    if (typeof value === 'bigint') {
+      let encoded = value < 0n ? -value * 2n - 1n : value * 2n;
+      while (encoded > 0x7fn) {
+        this.writeByte(Number((encoded & 0x7fn) | 0x80n));
+        encoded >>= 7n;
+      }
+      this.writeByte(Number(encoded));
+      return;
+    }
+    if (!Number.isSafeInteger(value))
+      throw new Error(`Avro integer is outside the safe range: ${value}`);
+    let encoded = value < 0 ? -value * 2 - 1 : value * 2;
+    while (encoded > 0x7f) {
+      this.writeByte((encoded & 0x7f) | 0x80);
+      encoded = Math.floor(encoded / 128);
+    }
+    this.writeByte(encoded);
+  }
+
+  writeFloat(value: number): void {
+    const buffer = new ArrayBuffer(4);
+    new DataView(buffer).setFloat32(0, value, true);
+    this.writeBytes(new Uint8Array(buffer));
+  }
+
+  writeDouble(value: number): void {
+    const buffer = new ArrayBuffer(8);
+    new DataView(buffer).setFloat64(0, value, true);
+    this.writeBytes(new Uint8Array(buffer));
+  }
+
+  finish(): Uint8Array {
+    return Uint8Array.from(this.bytes);
+  }
+}

--- a/modules/parquet/src/lib/parsers/parse-avro-schema.ts
+++ b/modules/parquet/src/lib/parsers/parse-avro-schema.ts
@@ -1,0 +1,215 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+const PRIMITIVE_TYPES = new Set([
+  'null',
+  'boolean',
+  'int',
+  'long',
+  'float',
+  'double',
+  'bytes',
+  'string'
+]);
+const NAMED_TYPES = new Set(['record', 'enum', 'fixed']);
+
+/** Parses and validates a standalone Avro JSON schema. */
+export function parseAvroSchema(text: string): unknown {
+  let schema: unknown;
+  try {
+    schema = JSON.parse(text);
+  } catch (error) {
+    throw new Error(
+      `Invalid Avro schema JSON: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+  validateSchema(schema, new Set<string>(), '$');
+  return schema;
+}
+
+/** Validates an Avro schema and tracks named definitions. */
+function validateSchema(schema: unknown, names: Set<string>, path: string): void {
+  if (typeof schema === 'string') {
+    if (!PRIMITIVE_TYPES.has(schema) && !names.has(schema)) {
+      throw new Error(`Invalid Avro schema at ${path}: unknown type "${schema}"`);
+    }
+    return;
+  }
+  if (Array.isArray(schema)) {
+    if (schema.length === 0) throw new Error(`Invalid Avro schema at ${path}: empty union`);
+    schema.forEach((branch, index) => validateSchema(branch, names, `${path}[${index}]`));
+    return;
+  }
+  if (!schema || typeof schema !== 'object') {
+    throw new Error(`Invalid Avro schema at ${path}: expected a string, object, or union`);
+  }
+
+  const schemaObject = schema as Record<string, unknown>;
+  const type = schemaObject.type;
+  if (typeof type !== 'string' && !Array.isArray(type) && !type) {
+    throw new Error(`Invalid Avro schema at ${path}: missing type`);
+  }
+  if (Array.isArray(type) || typeof type === 'object') {
+    validateSchema(type, names, `${path}.type`);
+    return;
+  }
+  const schemaType = type as string;
+  if (PRIMITIVE_TYPES.has(schemaType)) return;
+  if (schemaType === 'array') {
+    validateSchema(schemaObject.items, names, `${path}.items`);
+    return;
+  }
+  if (schemaType === 'map') {
+    validateSchema(schemaObject.values, names, `${path}.values`);
+    return;
+  }
+  if (!NAMED_TYPES.has(schemaType)) {
+    if (!names.has(schemaType))
+      throw new Error(`Invalid Avro schema at ${path}: unknown type "${schemaType}"`);
+    return;
+  }
+
+  const name = schemaObject.name;
+  if (typeof name !== 'string' || !isValidName(name)) {
+    throw new Error(`Invalid Avro schema at ${path}: invalid or missing name`);
+  }
+  names.add(name);
+  if (schemaType === 'record') {
+    if (!Array.isArray(schemaObject.fields)) {
+      throw new Error(`Invalid Avro schema at ${path}.fields: expected an array`);
+    }
+    for (const [index, field] of schemaObject.fields.entries()) {
+      if (
+        !field ||
+        typeof field !== 'object' ||
+        typeof (field as Record<string, unknown>).name !== 'string'
+      ) {
+        throw new Error(`Invalid Avro schema at ${path}.fields[${index}]: invalid field`);
+      }
+      validateSchema(
+        (field as Record<string, unknown>).type,
+        names,
+        `${path}.fields[${index}].type`
+      );
+      if (Object.prototype.hasOwnProperty.call(field, 'default'))
+        validateDefault(
+          (field as Record<string, unknown>).default,
+          (field as Record<string, unknown>).type,
+          names,
+          `${path}.fields[${index}].default`
+        );
+    }
+  } else if (type === 'enum') {
+    if (
+      !Array.isArray(schemaObject.symbols) ||
+      schemaObject.symbols.some(symbol => typeof symbol !== 'string')
+    ) {
+      throw new Error(`Invalid Avro schema at ${path}.symbols: expected an array of strings`);
+    }
+  } else if (
+    typeof schemaObject.size !== 'number' ||
+    !Number.isInteger(schemaObject.size) ||
+    schemaObject.size < 0
+  ) {
+    throw new Error(`Invalid Avro schema at ${path}.size: expected a non-negative integer`);
+  }
+}
+
+/** Validates an Avro field default against its schema. */
+function validateDefault(value: unknown, schema: unknown, names: Set<string>, path: string): void {
+  if (typeof schema === 'string') {
+    if (names.has(schema)) return;
+    switch (schema) {
+      case 'null':
+        if (value !== null) throw new Error(`Invalid Avro default at ${path}: expected null`);
+        return;
+      case 'boolean':
+        if (typeof value !== 'boolean')
+          throw new Error(`Invalid Avro default at ${path}: expected boolean`);
+        return;
+      case 'int':
+      case 'long':
+      case 'float':
+      case 'double':
+        if (typeof value !== 'number' || !Number.isFinite(value))
+          throw new Error(`Invalid Avro default at ${path}: expected number`);
+        if ((schema === 'int' || schema === 'long') && !Number.isInteger(value))
+          throw new Error(`Invalid Avro default at ${path}: expected integer`);
+        return;
+      case 'bytes':
+      case 'string':
+        if (typeof value !== 'string')
+          throw new Error(`Invalid Avro default at ${path}: expected string`);
+        return;
+      default:
+        return;
+    }
+  }
+  if (Array.isArray(schema)) {
+    if (schema.length === 0) throw new Error(`Invalid Avro default at ${path}: empty union`);
+    validateDefault(value, schema[0], names, `${path}[0]`);
+    return;
+  }
+  if (!schema || typeof schema !== 'object')
+    throw new Error(`Invalid Avro default at ${path}: invalid schema`);
+  const schemaObject = schema as Record<string, unknown>;
+  const type = schemaObject.type;
+  if (Array.isArray(type) || typeof type === 'object') {
+    validateDefault(value, type, names, `${path}.type`);
+    return;
+  }
+  if (typeof type !== 'string') throw new Error(`Invalid Avro default at ${path}: missing type`);
+  if (PRIMITIVE_TYPES.has(type)) {
+    validateDefault(value, type, names, path);
+    return;
+  }
+  switch (type) {
+    case 'array':
+      if (!Array.isArray(value)) throw new Error(`Invalid Avro default at ${path}: expected array`);
+      for (const [index, item] of value.entries())
+        validateDefault(item, schemaObject.items, names, `${path}[${index}]`);
+      return;
+    case 'map':
+      if (!value || typeof value !== 'object' || Array.isArray(value))
+        throw new Error(`Invalid Avro default at ${path}: expected object map`);
+      for (const [key, item] of Object.entries(value))
+        validateDefault(item, schemaObject.values, names, `${path}.${key}`);
+      return;
+    case 'record': {
+      if (!value || typeof value !== 'object' || Array.isArray(value))
+        throw new Error(`Invalid Avro default at ${path}: expected record object`);
+      const record = value as Record<string, unknown>;
+      for (const field of (schemaObject.fields as unknown[] | undefined) || []) {
+        const fieldObject = field as Record<string, unknown>;
+        if (Object.prototype.hasOwnProperty.call(record, fieldObject.name as string))
+          validateDefault(
+            record[fieldObject.name as string],
+            fieldObject.type,
+            names,
+            `${path}.${String(fieldObject.name)}`
+          );
+      }
+      return;
+    }
+    case 'enum':
+      if (
+        typeof value !== 'string' ||
+        !(schemaObject.symbols as unknown[] | undefined)?.includes(value)
+      )
+        throw new Error(`Invalid Avro default at ${path}: unknown enum symbol`);
+      return;
+    case 'fixed':
+      if (typeof value !== 'string')
+        throw new Error(`Invalid Avro default at ${path}: expected string`);
+      return;
+    default:
+      if (!names.has(type))
+        throw new Error(`Invalid Avro default at ${path}: unknown type "${type}"`);
+  }
+}
+
+/** Tests an Avro name according to the name grammar. */
+function isValidName(name: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_.]*$/.test(name);
+}

--- a/modules/parquet/src/lib/parsers/parse-avro.ts
+++ b/modules/parquet/src/lib/parsers/parse-avro.ts
@@ -1,0 +1,1068 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import * as arrow from 'apache-arrow';
+import type {ArrowTable, ArrowTableBatch} from '@loaders.gl/schema';
+import type {ReadableFile} from '@loaders.gl/loader-utils';
+import {decompressAvro} from '../../avro-compression';
+
+export type AvroSchema =
+  | string
+  | AvroSchema[]
+  | {
+      type: AvroSchema | AvroSchema[];
+      name?: string;
+      aliases?: string[];
+      logicalType?: string;
+      precision?: number;
+      scale?: number;
+      fields?: AvroRecordField[];
+      symbols?: string[];
+      size?: number;
+      items?: AvroSchema;
+      values?: AvroSchema;
+    };
+type AvroField = {name: string; type: AvroSchema};
+
+type AvroRecordField = AvroField & {aliases?: string[]; default?: unknown};
+type AvroRecordSchema = {
+  type: 'record';
+  name?: string;
+  aliases?: string[];
+  fields?: AvroRecordField[];
+};
+type AvroFixedSchema = {type: 'fixed'; size: number};
+
+const MAGIC = [0x4f, 0x62, 0x6a, 0x01];
+
+/** Options for reader-side Avro schema resolution. */
+export type AvroParseOptions = {
+  readerSchema?: unknown;
+  longType?: 'number' | 'bigint';
+  schema?: unknown;
+  encoding?: 'auto' | 'ocf' | 'raw' | 'single-object';
+  validateFingerprint?: boolean;
+  blockIndices?: number[];
+  /** Additional headers sent with URL-backed range requests. */
+  headers?: Record<string, string>;
+  /** Abort signal for URL-backed range requests. */
+  signal?: AbortSignal;
+  /** Initial range size used to discover the OCF header. */
+  rangeChunkSize?: number;
+};
+
+/** Metadata and byte locations for one Avro Object Container File block. */
+export type AvroOCFBlock = {
+  /** Number of records in the block. */
+  count: number;
+  /** Offset of the block count field. */
+  offset: number;
+  /** Offset of the compressed block payload. */
+  dataOffset: number;
+  /** Compressed payload length in bytes. */
+  compressedSize: number;
+  /** Offset of the 16-byte sync marker following the payload. */
+  syncOffset: number;
+};
+
+/** Parsed Avro Object Container File header and block index. */
+export type AvroOCF = {
+  metadata: Map<string, Uint8Array>;
+  schema: AvroSchema;
+  codec: string;
+  syncMarker: Uint8Array;
+  blocks: AvroOCFBlock[];
+};
+
+/** Parsed Avro OCF header, including the first block byte offset. */
+export type AvroOCFHeader = Omit<AvroOCF, 'blocks'> & {dataOffset: number};
+
+/** Parses an Apache Avro Object Container File into an object-row table. */
+export async function parseAvro(
+  arrayBuffer: ArrayBuffer,
+  options?: AvroParseOptions
+): Promise<ArrowTable> {
+  const bytes = new Uint8Array(arrayBuffer);
+  if (options?.encoding === 'raw' || options?.encoding === 'single-object' || !hasMagic(bytes))
+    return parseExternalAvroDatum(bytes, options);
+  const data: Record<string, unknown>[] = [];
+  for await (const value of readAvroRows(arrayBuffer, options)) data.push(value);
+  return {shape: 'arrow-table', data: arrow.tableFromJSON(data)};
+}
+
+/** Inspects an Avro Object Container File without decompressing record blocks. */
+export function parseAvroOCF(arrayBuffer: ArrayBuffer): AvroOCF {
+  const reader = new AvroReader(new Uint8Array(arrayBuffer));
+  const header = parseAvroOCFHeaderFromReader(reader);
+  const blocks: AvroOCFBlock[] = [];
+  while (!reader.done) {
+    const offset = reader.position;
+    const count = reader.readLong();
+    if (count === 0) break;
+    const compressedSize = reader.readLong();
+    if (compressedSize < 0) throw new Error('Invalid negative Avro block size');
+    const dataOffset = reader.position;
+    reader.readFixed(compressedSize);
+    const syncOffset = reader.position;
+    reader.expectBytes(header.syncMarker, 'Avro block sync marker');
+    blocks.push({
+      count: Math.abs(count),
+      offset,
+      dataOffset,
+      compressedSize,
+      syncOffset
+    });
+  }
+  return {...header, blocks};
+}
+
+/** Parses an Avro OCF header from a bounded byte range. */
+export function parseAvroOCFHeader(arrayBuffer: ArrayBuffer): AvroOCFHeader {
+  return parseAvroOCFHeaderFromReader(new AvroReader(new Uint8Array(arrayBuffer)));
+}
+
+/** Parses an OCF header from an existing reader and records its first block offset. */
+function parseAvroOCFHeaderFromReader(reader: AvroReader): AvroOCFHeader {
+  reader.expectBytes(MAGIC, 'Avro Object Container File header');
+  const metadata = reader.readMap(() => reader.readBytes());
+  const syncMarker = reader.readFixed(16).slice();
+  const schemaText = decodeUtf8(metadata.get('avro.schema'));
+  if (!schemaText) throw new Error('Avro file is missing the avro.schema metadata entry');
+  const schema = JSON.parse(schemaText) as AvroSchema;
+  const codec = decodeUtf8(metadata.get('avro.codec')) || 'null';
+  return {metadata, schema, codec, syncMarker, dataOffset: reader.position};
+}
+
+/** Parses an Avro Object Container File into Arrow batches. */
+export async function* parseAvroInBatches(
+  arrayBuffer: ArrayBuffer,
+  batchSize = 10_000,
+  options?: AvroParseOptions
+): AsyncIterable<ArrowTableBatch> {
+  if (!Number.isInteger(batchSize) || batchSize <= 0)
+    throw new Error('Avro batchSize must be positive');
+  const bytes = new Uint8Array(arrayBuffer);
+  if (options?.encoding === 'raw' || options?.encoding === 'single-object' || !hasMagic(bytes)) {
+    const table = await parseAvro(arrayBuffer, options);
+    yield {batchType: 'data', shape: 'arrow-table', data: table.data, length: table.data.numRows};
+    return;
+  }
+  let data: Record<string, unknown>[] = [];
+  for await (const value of readAvroRows(arrayBuffer, options)) {
+    data.push(value);
+    if (data.length >= batchSize) {
+      yield createAvroBatch(data);
+      data = [];
+    }
+  }
+  if (data.length > 0) yield createAvroBatch(data);
+}
+
+/** Loads an Avro OCF from a URL, using HTTP ranges when the server supports them. */
+export async function parseAvroFromUrl(
+  url: string,
+  options?: AvroParseOptions & {batchSize?: number}
+): Promise<ArrowTable> {
+  const data: Record<string, unknown>[] = [];
+  for await (const batch of parseAvroInBatchesFromUrl(url, options))
+    data.push(...(batch.data.toArray() as Record<string, unknown>[]));
+  return {shape: 'arrow-table', data: arrow.tableFromJSON(data)};
+}
+
+/** Streams Arrow batches from a URL-backed Avro OCF using block-sized range reads. */
+export async function* parseAvroInBatchesFromUrl(
+  url: string,
+  options?: AvroParseOptions & {batchSize?: number}
+): AsyncIterable<ArrowTableBatch> {
+  if (options?.encoding && options.encoding !== 'auto' && options.encoding !== 'ocf')
+    throw new Error('URL-backed Avro loading currently supports OCF input only');
+  const batchSize = options?.batchSize || 10_000;
+  if (!Number.isInteger(batchSize) || batchSize <= 0)
+    throw new Error('Avro batchSize must be positive');
+  const rangeChunkSize = options?.rangeChunkSize || 1024 * 1024;
+  if (!Number.isInteger(rangeChunkSize) || rangeChunkSize < 1024)
+    throw new Error('Avro rangeChunkSize must be at least 1024 bytes');
+  const initial = await fetchAvroRange(url, 0, rangeChunkSize - 1, options);
+  if (!initial) throw new Error('Avro URL returned no data');
+  if (initial.fullFile) {
+    yield* parseAvroInBatches(initial.bytes.buffer as ArrayBuffer, batchSize, options);
+    return;
+  }
+  const header = parseAvroOCFHeader(initial.bytes.buffer as ArrayBuffer);
+  validateAvroCodec(header.codec);
+  let offset = header.dataOffset;
+  let blockIndex = 0;
+  let batch: Record<string, unknown>[] = [];
+  while (true) {
+    const blockHeader = await fetchAvroRange(url, offset, offset + 31, options);
+    if (!blockHeader) break;
+    if (blockHeader.fullFile) {
+      yield* parseAvroInBatches(blockHeader.bytes.buffer as ArrayBuffer, batchSize, options);
+      return;
+    }
+    const countResult = readAvroLongAt(blockHeader.bytes, 0);
+    const sizeResult = readAvroLongAt(blockHeader.bytes, countResult.offset);
+    if (countResult.value === 0) break;
+    if (countResult.value < 0 || sizeResult.value < 0)
+      throw new Error('Invalid Avro OCF block header');
+    const dataOffset = offset + sizeResult.offset;
+    const blockEnd = dataOffset + sizeResult.value + header.syncMarker.length - 1;
+    const block = await fetchAvroRange(url, dataOffset, blockEnd, options);
+    if (!block) throw new Error('Truncated Avro OCF block');
+    const blockBytes = block.bytes;
+    if (blockBytes.length < sizeResult.value + header.syncMarker.length)
+      throw new Error('Truncated Avro OCF block payload');
+    const syncOffset = sizeResult.value;
+    for (let index = 0; index < header.syncMarker.length; index++)
+      if (blockBytes[syncOffset + index] !== header.syncMarker[index])
+        throw new Error('Invalid Avro OCF sync marker');
+    const selected = !options?.blockIndices || options.blockIndices.includes(blockIndex);
+    if (selected) {
+      const reader = new AvroReader(
+        await decompressAvro(header.codec, blockBytes.subarray(0, sizeResult.value)),
+        header.schema,
+        options
+      );
+      for (let index = 0; index < countResult.value; index++) {
+        const value = reader.readValue(header.schema);
+        if (!isRecord(value)) throw new Error('Avro root schema must be a record');
+        batch.push(
+          options?.readerSchema
+            ? resolveReaderRecord(value, header.schema, options.readerSchema as AvroSchema)
+            : value
+        );
+        if (batch.length >= batchSize) {
+          yield createAvroBatch(batch);
+          batch = [];
+        }
+      }
+    }
+    offset = dataOffset + sizeResult.value + header.syncMarker.length;
+    blockIndex++;
+  }
+  if (batch.length > 0) yield createAvroBatch(batch);
+}
+
+/** Loads an Avro OCF from a random-access file using bounded reads. */
+export async function parseAvroFromFile(
+  file: ReadableFile,
+  options?: AvroParseOptions & {batchSize?: number}
+): Promise<ArrowTable> {
+  const data: Record<string, unknown>[] = [];
+  for await (const batch of parseAvroInBatchesFromFile(file, options))
+    data.push(...(batch.data.toArray() as Record<string, unknown>[]));
+  return {shape: 'arrow-table', data: arrow.tableFromJSON(data)};
+}
+
+/** Streams Arrow batches from a random-access Avro OCF file. */
+export async function* parseAvroInBatchesFromFile(
+  file: ReadableFile,
+  options?: AvroParseOptions & {batchSize?: number}
+): AsyncIterable<ArrowTableBatch> {
+  const rangeChunkSize = options?.rangeChunkSize || 1024 * 1024;
+  if (!Number.isInteger(rangeChunkSize) || rangeChunkSize < 1024)
+    throw new Error('Avro rangeChunkSize must be at least 1024 bytes');
+  const stat = file.stat ? await file.stat() : null;
+  const fileSize = file.bigsize > 0n ? Number(file.bigsize) : file.size || stat?.size || 0;
+  if (fileSize <= 0) throw new Error('Avro file size is required for random-access loading');
+  if (fileSize <= rangeChunkSize) {
+    yield* parseAvroInBatches(
+      await file.read(0, fileSize, options?.signal),
+      options?.batchSize,
+      options
+    );
+    return;
+  }
+  const headerBytes = new Uint8Array(await file.read(0, rangeChunkSize, options?.signal));
+  const header = parseAvroOCFHeader(headerBytes.buffer as ArrayBuffer);
+  validateAvroCodec(header.codec);
+  let offset = header.dataOffset;
+  let blockIndex = 0;
+  let batch: Record<string, unknown>[] = [];
+  const batchSize = options?.batchSize || 10_000;
+  while (offset < fileSize) {
+    const blockHeader = new Uint8Array(
+      await file.read(offset, Math.min(32, fileSize - offset), options?.signal)
+    );
+    const countResult = readAvroLongAt(blockHeader, 0);
+    const sizeResult = readAvroLongAt(blockHeader, countResult.offset);
+    if (countResult.value === 0) break;
+    if (countResult.value < 0 || sizeResult.value < 0)
+      throw new Error('Invalid Avro OCF block header');
+    const dataOffset = offset + sizeResult.offset;
+    const blockBytes = new Uint8Array(
+      await file.read(dataOffset, sizeResult.value + header.syncMarker.length, options?.signal)
+    );
+    if (blockBytes.length < sizeResult.value + header.syncMarker.length)
+      throw new Error('Truncated Avro OCF block payload');
+    for (let index = 0; index < header.syncMarker.length; index++)
+      if (blockBytes[sizeResult.value + index] !== header.syncMarker[index])
+        throw new Error('Invalid Avro OCF sync marker');
+    if (!options?.blockIndices || options.blockIndices.includes(blockIndex)) {
+      const reader = new AvroReader(
+        await decompressAvro(header.codec, blockBytes.subarray(0, sizeResult.value)),
+        header.schema,
+        options
+      );
+      for (let index = 0; index < countResult.value; index++) {
+        const value = reader.readValue(header.schema);
+        if (!isRecord(value)) throw new Error('Avro root schema must be a record');
+        batch.push(
+          options?.readerSchema
+            ? resolveReaderRecord(value, header.schema, options.readerSchema as AvroSchema)
+            : value
+        );
+        if (batch.length >= batchSize) {
+          yield createAvroBatch(batch);
+          batch = [];
+        }
+      }
+    }
+    offset = dataOffset + sizeResult.value + header.syncMarker.length;
+    blockIndex++;
+  }
+  if (batch.length > 0) yield createAvroBatch(batch);
+}
+
+/** Reads a byte range and detects servers that ignore the Range header. */
+async function fetchAvroRange(
+  url: string,
+  start: number,
+  end: number,
+  options?: AvroParseOptions
+): Promise<{bytes: Uint8Array; fullFile: boolean} | null> {
+  const headers = new Headers(options?.headers);
+  headers.set('Range', `bytes=${start}-${end}`);
+  const response = await fetch(url, {headers, signal: options?.signal});
+  if (response.status === 416) return null;
+  if (!response.ok) throw new Error(`Avro range request failed with HTTP ${response.status}`);
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  return {bytes, fullFile: response.status !== 206};
+}
+
+/** Decodes one Avro zig-zag long from a bounded range. */
+function readAvroLongAt(bytes: Uint8Array, start: number): {value: number; offset: number} {
+  let encoded = 0;
+  let shift = 0;
+  let offset = start;
+  while (offset < bytes.length) {
+    const byte = bytes[offset++];
+    encoded += (byte & 0x7f) * 2 ** shift;
+    if (!(byte & 0x80))
+      return {value: encoded % 2 === 0 ? encoded / 2 : -(encoded + 1) / 2, offset};
+    shift += 7;
+  }
+  throw new Error('Truncated Avro OCF block header');
+}
+
+/** Validates codecs before making remote block requests. */
+function validateAvroCodec(codec: string): void {
+  if (!['null', 'deflate', 'snappy', 'zstandard', 'bzip2', 'xz'].includes(codec))
+    throw new Error(`Avro codec "${codec}" is not supported`);
+}
+
+/** Parses a raw Avro datum or single-object encoded datum using an external schema. */
+function parseExternalAvroDatum(bytes: Uint8Array, options?: AvroParseOptions): ArrowTable {
+  const schema = options?.schema as AvroSchema | undefined;
+  if (!schema) throw new Error('Avro raw and single-object encodings require avro.schema');
+  const encoding =
+    options?.encoding === 'auto' || !options?.encoding
+      ? hasSingleObjectMarker(bytes)
+        ? 'single-object'
+        : 'raw'
+      : options.encoding;
+  let offset = 0;
+  if (encoding === 'single-object') {
+    if (!hasSingleObjectMarker(bytes))
+      throw new Error('Invalid Avro single-object encoding marker');
+    if (bytes.length < 10) throw new Error('Truncated Avro single-object encoding');
+    const expectedFingerprint = new DataView(bytes.buffer, bytes.byteOffset + 2, 8).getBigUint64(
+      0,
+      true
+    );
+    if (options?.validateFingerprint !== false) {
+      const actualFingerprint = getAvroSchemaFingerprint(schema);
+      if (expectedFingerprint !== actualFingerprint)
+        throw new Error('Avro single-object schema fingerprint does not match avro.schema');
+    }
+    offset = 10;
+  }
+  const reader = new AvroReader(bytes.subarray(offset), schema, options);
+  const value = reader.readValue(schema);
+  if (!isRecord(value)) throw new Error('Avro root schema must be a record');
+  const resolved = options?.readerSchema
+    ? resolveReaderRecord(value, schema, options.readerSchema as AvroSchema)
+    : value;
+  return {shape: 'arrow-table', data: arrow.tableFromJSON([resolved])};
+}
+
+/** Computes Avro's 64-bit Rabin fingerprint for a schema's parsing canonical form. */
+export function getAvroSchemaFingerprint(schema: unknown): bigint {
+  const canonicalForm = getAvroParsingCanonicalForm(schema as AvroSchema);
+  let fingerprint = 0xc15d213aa4d7a795n;
+  const table = getRabinFingerprintTable();
+  for (const byte of new TextEncoder().encode(canonicalForm))
+    fingerprint = (fingerprint >> 8n) ^ table[Number((fingerprint ^ BigInt(byte)) & 0xffn)];
+  return fingerprint;
+}
+
+/** Returns the compact parsing canonical form used by Avro fingerprints. */
+function getAvroParsingCanonicalForm(schema: AvroSchema): string {
+  if (typeof schema === 'string') return JSON.stringify(schema);
+  if (Array.isArray(schema)) return `[${schema.map(getAvroParsingCanonicalForm).join(',')}]`;
+  if (Array.isArray(schema.type)) return getAvroParsingCanonicalForm(schema.type);
+  if (typeof schema.type !== 'string') return getAvroParsingCanonicalForm(schema.type);
+  switch (schema.type) {
+    case 'record':
+      return JSON.stringify({
+        name: schema.name,
+        type: 'record',
+        fields: (schema.fields || []).map(field => ({
+          name: field.name,
+          type: JSON.parse(getAvroParsingCanonicalForm(field.type))
+        }))
+      });
+    case 'enum':
+      return JSON.stringify({name: schema.name, type: 'enum', symbols: schema.symbols || []});
+    case 'fixed':
+      return JSON.stringify({name: schema.name, type: 'fixed', size: schema.size});
+    case 'array':
+      return JSON.stringify({
+        type: 'array',
+        items: JSON.parse(getAvroParsingCanonicalForm(schema.items as AvroSchema))
+      });
+    case 'map':
+      return JSON.stringify({
+        type: 'map',
+        values: JSON.parse(getAvroParsingCanonicalForm(schema.values as AvroSchema))
+      });
+    default:
+      return JSON.stringify(schema.type);
+  }
+}
+
+/** Builds the Avro Rabin fingerprint lookup table. */
+function getRabinFingerprintTable(): bigint[] {
+  const table: bigint[] = [];
+  const polynomial = 0xc96c5795d7870f42n;
+  for (let index = 0; index < 256; index++) {
+    let value = BigInt(index);
+    for (let bit = 0; bit < 8; bit++) value = value & 1n ? (value >> 1n) ^ polynomial : value >> 1n;
+    table.push(value);
+  }
+  return table;
+}
+
+/** Checks for the Avro Object Container File marker. */
+function hasMagic(bytes: Uint8Array): boolean {
+  return MAGIC.every((value, index) => bytes[index] === value);
+}
+
+/** Checks for the Avro single-object encoding marker. */
+function hasSingleObjectMarker(bytes: Uint8Array): boolean {
+  return bytes.length >= 2 && bytes[0] === 0xc3 && bytes[1] === 0x01;
+}
+
+/** Reads decoded Avro records one data block at a time. */
+async function* readAvroRows(
+  arrayBuffer: ArrayBuffer,
+  options?: AvroParseOptions
+): AsyncIterable<Record<string, unknown>> {
+  const bytes = new Uint8Array(arrayBuffer);
+  const ocf = parseAvroOCF(arrayBuffer);
+  const {schema, codec} = ocf;
+  const readerSchema = options?.readerSchema as AvroSchema | undefined;
+  if (
+    codec !== 'null' &&
+    codec !== 'deflate' &&
+    codec !== 'snappy' &&
+    codec !== 'zstandard' &&
+    codec !== 'bzip2' &&
+    codec !== 'xz'
+  )
+    throw new Error(`Avro codec "${codec}" is not supported`);
+
+  const blocks = options?.blockIndices
+    ? options.blockIndices.map(index => {
+        if (!Number.isInteger(index) || index < 0 || index >= ocf.blocks.length)
+          throw new Error(`Avro block index ${index} is out of range`);
+        return ocf.blocks[index];
+      })
+    : ocf.blocks;
+  for (const blockInfo of blocks) {
+    const block = new AvroReader(
+      await decompressAvro(
+        codec,
+        bytes.subarray(blockInfo.dataOffset, blockInfo.dataOffset + blockInfo.compressedSize)
+      ),
+      schema,
+      options
+    );
+    for (let index = 0; index < blockInfo.count; index++) {
+      const value = block.readValue(schema);
+      if (!isRecord(value)) {
+        throw new Error('Avro root schema must be a record to produce an object-row table');
+      }
+      yield readerSchema ? resolveReaderRecord(value, schema, readerSchema) : value;
+    }
+  }
+}
+
+/** Wraps object rows in the loaders.gl Arrow batch shape. */
+function createAvroBatch(data: Record<string, unknown>[]): ArrowTableBatch {
+  return {
+    batchType: 'data',
+    shape: 'arrow-table',
+    data: arrow.tableFromJSON(data),
+    length: data.length
+  };
+}
+
+/** Decodes UTF-8 metadata values. */
+function decodeUtf8(value: Uint8Array | undefined): string | undefined {
+  return value ? new TextDecoder().decode(value) : undefined;
+}
+
+/** Tests whether a decoded Avro value is an object record. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return (
+    Boolean(value) &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    !(value instanceof Uint8Array)
+  );
+}
+
+/** Resolves a decoded writer record against a compatible reader record schema. */
+function resolveReaderRecord(
+  value: Record<string, unknown>,
+  writerSchema: AvroSchema,
+  readerSchema: AvroSchema
+): Record<string, unknown> {
+  const resolved = resolveReaderValue(value, writerSchema, readerSchema);
+  if (!isRecord(resolved)) throw new Error('Avro reader schema root must be a record');
+  return resolved;
+}
+
+/** Resolves one value using Avro reader-schema projection rules. */
+function resolveReaderValue(
+  value: unknown,
+  writerSchema: AvroSchema,
+  readerSchema: AvroSchema
+): unknown {
+  if (Array.isArray(readerSchema)) {
+    const branch = readerSchema.find(candidate =>
+      isReaderSchemaCompatible(value, writerSchema, candidate)
+    );
+    if (!branch) throw new Error('Avro reader union has no compatible branch');
+    return resolveReaderValue(value, writerSchema, branch);
+  }
+  if (typeof readerSchema === 'string') {
+    return isPrimitiveSchemaType(readerSchema)
+      ? promoteAvroValue(value, getSchemaTypeForValue(writerSchema, value), readerSchema)
+      : value;
+  }
+  if (Array.isArray(readerSchema.type))
+    return resolveReaderValue(value, writerSchema, readerSchema.type);
+  if (typeof readerSchema.type !== 'string')
+    return resolveReaderValue(value, writerSchema, readerSchema.type);
+  if (isPrimitiveSchemaType(readerSchema.type))
+    return promoteAvroValue(value, getSchemaTypeForValue(writerSchema, value), readerSchema.type);
+  if (readerSchema.type === 'record' && isRecord(value)) {
+    validateRecordCompatibility(writerSchema, readerSchema as AvroRecordSchema);
+    const writerFields = getRecordFields(writerSchema);
+    const resolved: Record<string, unknown> = {};
+    for (const readerField of readerSchema.fields || []) {
+      const writerField = writerFields.find(
+        field => field.name === readerField.name || readerField.aliases?.includes(field.name)
+      );
+      if (!writerField) {
+        if (Object.prototype.hasOwnProperty.call(readerField, 'default')) {
+          if (!isDefaultValueCompatible(readerField.default, readerField.type))
+            throw new Error(`Avro reader default for field "${readerField.name}" is incompatible`);
+          resolved[readerField.name] = readerField.default;
+          continue;
+        }
+        throw new Error(`Avro reader field "${readerField.name}" has no writer value or default`);
+      }
+      resolved[readerField.name] = resolveReaderValue(
+        value[writerField.name],
+        writerField.type,
+        readerField.type
+      );
+    }
+    return resolved;
+  }
+  if (readerSchema.type === 'enum') {
+    if (typeof value !== 'string' || !readerSchema.symbols?.includes(value))
+      throw new Error(`Avro enum symbol "${String(value)}" is not present in the reader schema`);
+    return value;
+  }
+  if (readerSchema.type === 'fixed') {
+    const writerFixed = getFixedSchema(writerSchema);
+    if (writerFixed && writerFixed.size !== readerSchema.size)
+      throw new Error('Avro fixed schemas have incompatible sizes');
+    if (!(value instanceof Uint8Array) || value.length !== readerSchema.size)
+      throw new Error('Avro fixed value has an incompatible size');
+    return value;
+  }
+  if (readerSchema.type === 'array' && Array.isArray(value)) {
+    return value.map(item =>
+      resolveReaderValue(item, writerSchema, readerSchema.items as AvroSchema)
+    );
+  }
+  if (readerSchema.type === 'map' && value instanceof Map) {
+    return new Map(
+      [...value.entries()].map(([key, item]) => [
+        key,
+        resolveReaderValue(item, writerSchema, readerSchema.values as AvroSchema)
+      ])
+    );
+  }
+  return value;
+}
+
+/** Validates Avro record names and reader aliases during schema resolution. */
+function validateRecordCompatibility(
+  writerSchema: AvroSchema,
+  readerSchema: AvroRecordSchema
+): void {
+  const writerRecord = getRecordSchema(writerSchema);
+  if (
+    writerRecord?.name &&
+    readerSchema.name &&
+    writerRecord.name !== readerSchema.name &&
+    !readerSchema.aliases?.includes(writerRecord.name)
+  )
+    throw new Error(
+      `Avro record names "${writerRecord.name}" and "${readerSchema.name}" are incompatible`
+    );
+}
+
+/** Returns a record schema when the schema is a record object. */
+function getRecordSchema(schema: AvroSchema): AvroRecordSchema | undefined {
+  return !Array.isArray(schema) && typeof schema !== 'string' && schema.type === 'record'
+    ? (schema as AvroRecordSchema)
+    : undefined;
+}
+
+/** Returns a fixed schema when the schema is a fixed object. */
+function getFixedSchema(schema: AvroSchema): AvroFixedSchema | undefined {
+  return !Array.isArray(schema) && typeof schema !== 'string' && schema.type === 'fixed'
+    ? (schema as AvroFixedSchema)
+    : undefined;
+}
+
+/** Returns the primitive/container type name from a schema. */
+function getSchemaType(schema: AvroSchema): string | undefined {
+  if (typeof schema === 'string') return schema;
+  if (Array.isArray(schema)) return undefined;
+  return typeof schema.type === 'string' ? schema.type : getSchemaType(schema.type);
+}
+
+/** Resolves the writer type for a value when the writer schema is a union. */
+function getSchemaTypeForValue(schema: AvroSchema, value: unknown): string | undefined {
+  if (!Array.isArray(schema)) return getSchemaType(schema);
+  if (value === null) return 'null';
+  const candidateTypes = schema
+    .map(candidate => getSchemaType(candidate))
+    .filter((type): type is string => Boolean(type && type !== 'null'));
+  if (typeof value === 'string')
+    return candidateTypes.find(type => type === 'string') || candidateTypes[0];
+  if (typeof value === 'boolean')
+    return candidateTypes.find(type => type === 'boolean') || candidateTypes[0];
+  if (typeof value === 'number' || typeof value === 'bigint')
+    return (
+      candidateTypes.find(type => ['int', 'long', 'float', 'double'].includes(type)) ||
+      candidateTypes[0]
+    );
+  return candidateTypes[0];
+}
+
+/** Tests whether a decoded value can be resolved through one reader union branch. */
+function isReaderSchemaCompatible(
+  value: unknown,
+  writerSchema: AvroSchema,
+  readerSchema: AvroSchema
+): boolean {
+  if (Array.isArray(readerSchema))
+    return readerSchema.some(branch => isReaderSchemaCompatible(value, writerSchema, branch));
+  if (typeof readerSchema === 'string') {
+    if (readerSchema === 'null') return value === null;
+    if (value === null) return false;
+    const writerType = getSchemaTypeForValue(writerSchema, value);
+    return (
+      !isPrimitiveSchemaType(readerSchema) ||
+      writerType === readerSchema ||
+      (writerType !== undefined &&
+        (
+          {int: ['long', 'float', 'double'], long: ['float', 'double'], float: ['double']}[
+            writerType
+          ] || []
+        ).includes(readerSchema))
+    );
+  }
+  if (Array.isArray(readerSchema.type))
+    return isReaderSchemaCompatible(value, writerSchema, readerSchema.type);
+  if (typeof readerSchema.type !== 'string')
+    return isReaderSchemaCompatible(value, writerSchema, readerSchema.type);
+  if (isPrimitiveSchemaType(readerSchema.type))
+    return isReaderSchemaCompatible(value, writerSchema, readerSchema.type);
+  if (readerSchema.type === 'record') return isRecord(value);
+  if (readerSchema.type === 'enum') return typeof value === 'string';
+  if (readerSchema.type === 'fixed') return value instanceof Uint8Array;
+  if (readerSchema.type === 'array') return Array.isArray(value);
+  if (readerSchema.type === 'map') return value instanceof Map;
+  return true;
+}
+
+/** Validates a reader-schema default, including the union-first-branch rule. */
+function isDefaultValueCompatible(value: unknown, schema: AvroSchema): boolean {
+  if (Array.isArray(schema)) return schema.length > 0 && isDefaultValueCompatible(value, schema[0]);
+  if (typeof schema === 'string') {
+    if (schema === 'null') return value === null;
+    if (schema === 'boolean') return typeof value === 'boolean';
+    if (schema === 'string' || schema === 'bytes') return typeof value === 'string';
+    if (['int', 'long', 'float', 'double'].includes(schema)) return typeof value === 'number';
+    return true;
+  }
+  if (!schema || typeof schema !== 'object') return false;
+  if (Array.isArray(schema.type)) return isDefaultValueCompatible(value, schema.type);
+  if (typeof schema.type !== 'string') return isDefaultValueCompatible(value, schema.type);
+  if (schema.type === 'fixed') return typeof value === 'string' || value instanceof Uint8Array;
+  if (schema.type === 'enum')
+    return typeof value === 'string' && schema.symbols?.includes(value) === true;
+  if (schema.type === 'array') return Array.isArray(value);
+  if (schema.type === 'map')
+    return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+  if (schema.type === 'record')
+    return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+  return isDefaultValueCompatible(value, schema.type);
+}
+
+/** Tests whether a schema type participates in Avro primitive promotion. */
+function isPrimitiveSchemaType(type: string): boolean {
+  return ['null', 'boolean', 'int', 'long', 'float', 'double', 'bytes', 'string'].includes(type);
+}
+
+/** Applies Avro's permitted numeric promotions and rejects incompatible changes. */
+function promoteAvroValue(
+  value: unknown,
+  writerType: string | undefined,
+  readerType: string
+): unknown {
+  if (writerType === readerType || readerType === 'null') return value;
+  const promotions: Record<string, string[]> = {
+    int: ['long', 'float', 'double'],
+    long: ['float', 'double'],
+    float: ['double']
+  };
+  if (writerType && promotions[writerType]?.includes(readerType)) {
+    if (typeof value === 'bigint') return Number(value);
+    return Number(value);
+  }
+  throw new Error(
+    `Avro schema resolution cannot promote ${writerType || 'unknown'} to ${readerType}`
+  );
+}
+
+/** Returns fields from a record schema, or an empty list for primitive schemas. */
+function getRecordFields(schema: AvroSchema): AvroRecordField[] {
+  if (typeof schema === 'string' || Array.isArray(schema) || schema.type !== 'record') return [];
+  return schema.fields || [];
+}
+
+/** Small cursor-based decoder for Avro's binary encoding. */
+class AvroReader {
+  private offset = 0;
+  private readonly namedTypes = new Map<string, AvroSchema>();
+  private readonly longType: 'number' | 'bigint';
+
+  constructor(
+    private readonly bytes: Uint8Array,
+    schema?: AvroSchema,
+    options?: AvroParseOptions
+  ) {
+    this.longType = options?.longType || 'number';
+    if (schema) registerNamedTypes(schema, this.namedTypes);
+  }
+
+  /** Whether all input bytes have been consumed. */
+  get done(): boolean {
+    return this.offset >= this.bytes.length;
+  }
+
+  /** Current byte offset within the input. */
+  get position(): number {
+    return this.offset;
+  }
+
+  /** Reads an Avro zig-zag encoded long. */
+  readLong(): number {
+    let value = 0;
+    let shift = 0;
+    let byte = 0;
+    do {
+      byte = this.readByte();
+      value += (byte & 0x7f) * 2 ** shift;
+      shift += 7;
+    } while (byte & 0x80);
+    return (value % 2 === 0 ? value : -(value + 1)) / 2;
+  }
+
+  /** Reads an Avro byte array. */
+  readBytes(): Uint8Array {
+    const length = this.readLong();
+    if (length < 0) throw new Error('Invalid negative Avro byte array length');
+    return this.readFixed(length);
+  }
+
+  /** Reads a fixed number of bytes. */
+  readFixed(length: number): Uint8Array {
+    this.ensure(length);
+    const value = this.bytes.subarray(this.offset, this.offset + length);
+    this.offset += length;
+    return value;
+  }
+
+  /** Reads an Avro map whose values are decoded by the supplied function. */
+  readMap<T>(readValue: () => T): Map<string, T> {
+    const result = new Map<string, T>();
+    for (let count = this.readLong(); count !== 0; count = this.readLong()) {
+      const itemCount = Math.abs(count);
+      if (count < 0) this.readLong();
+      for (let index = 0; index < itemCount; index++) result.set(this.readString(), readValue());
+    }
+    return result;
+  }
+
+  /** Reads one value according to an Avro schema. */
+  readValue(schema: AvroSchema): unknown {
+    if (typeof schema === 'string') {
+      const namedSchema = this.namedTypes.get(schema);
+      return namedSchema ? this.readValue(namedSchema) : this.readPrimitive(schema);
+    }
+    if (Array.isArray(schema)) return this.readValue(schema[this.readLong()]);
+    if (Array.isArray(schema.type)) return this.readValue(schema.type[this.readLong()]);
+    if (typeof schema.type !== 'string') return this.readValue(schema.type);
+    let value: unknown;
+    switch (schema.type) {
+      case 'record': {
+        const record: Record<string, unknown> = {};
+        for (const field of schema.fields || []) record[field.name] = this.readValue(field.type);
+        value = record;
+        break;
+      }
+      case 'enum': {
+        const symbol = schema.symbols?.[this.readLong()];
+        if (symbol === undefined) throw new Error('Invalid Avro enum index');
+        value = symbol;
+        break;
+      }
+      case 'fixed':
+        value = this.readFixed(schema.size || 0);
+        break;
+      case 'array':
+        value = this.readArray(schema.items as AvroSchema);
+        break;
+      case 'map':
+        value = this.readMap(() => this.readValue(schema.values as AvroSchema));
+        break;
+      default:
+        value = this.readPrimitive(schema.type);
+        break;
+    }
+    return applyLogicalType(schema.logicalType, value, schema);
+  }
+
+  /** Reads one Avro primitive value. */
+  readPrimitive(type: string): unknown {
+    switch (type) {
+      case 'null':
+        return null;
+      case 'boolean':
+        return this.readByte() !== 0;
+      case 'int':
+        return this.readLong();
+      case 'long':
+        return this.readLongValue();
+      case 'float':
+        return this.readNumber(4, true);
+      case 'double':
+        return this.readNumber(8, true);
+      case 'bytes':
+        return this.readBytes();
+      case 'string':
+        return new TextDecoder().decode(this.readBytes());
+      default:
+        throw new Error(`Unsupported Avro schema type "${type}"`);
+    }
+  }
+
+  /** Reads an Avro long while preserving 64-bit precision when requested. */
+  private readLongValue(): number | bigint {
+    let value = 0n;
+    let shift = 0n;
+    let byte: number;
+    do {
+      byte = this.readByte();
+      value |= BigInt(byte & 0x7f) << shift;
+      shift += 7n;
+    } while (byte & 0x80);
+    const decoded = (value >> 1n) ^ -(value & 1n);
+    return this.longType === 'bigint' ? decoded : Number(decoded);
+  }
+
+  /** Reads an Avro array. */
+  readArray(schema: AvroSchema): unknown[] {
+    const result: unknown[] = [];
+    for (let count = this.readLong(); count !== 0; count = this.readLong()) {
+      const itemCount = Math.abs(count);
+      if (count < 0) this.readLong();
+      for (let index = 0; index < itemCount; index++) result.push(this.readValue(schema));
+    }
+    return result;
+  }
+
+  /** Reads one byte from the input. */
+  private readByte(): number {
+    this.ensure(1);
+    return this.bytes[this.offset++];
+  }
+
+  /** Reads an IEEE-754 number. */
+  private readNumber(length: number, littleEndian: boolean): number {
+    const buffer = this.readFixed(length);
+    return length === 4
+      ? new DataView(buffer.buffer, buffer.byteOffset, length).getFloat32(0, littleEndian)
+      : new DataView(buffer.buffer, buffer.byteOffset, length).getFloat64(0, littleEndian);
+  }
+
+  /** Reads an Avro UTF-8 string. */
+  private readString(): string {
+    return new TextDecoder().decode(this.readBytes());
+  }
+
+  /** Verifies and consumes a byte sequence. */
+  expectBytes(expected: number[] | Uint8Array, description: string): void {
+    const actual = this.readFixed(expected.length);
+    for (let index = 0; index < expected.length; index++) {
+      if (actual[index] !== expected[index]) throw new Error(`Invalid ${description}`);
+    }
+  }
+
+  /** Ensures that a read stays inside the input buffer. */
+  private ensure(length: number): void {
+    if (length < 0 || this.offset + length > this.bytes.length)
+      throw new Error('Unexpected end of Avro file');
+  }
+}
+
+/** Registers named schemas so later string references can be decoded. */
+function registerNamedTypes(schema: AvroSchema, namedTypes: Map<string, AvroSchema>): void {
+  if (typeof schema === 'string') return;
+  if (Array.isArray(schema)) {
+    for (const branch of schema) registerNamedTypes(branch, namedTypes);
+    return;
+  }
+  if (schema.name) namedTypes.set(schema.name, schema);
+  if (Array.isArray(schema.type)) registerNamedTypes(schema.type, namedTypes);
+  else if (typeof schema.type !== 'string') registerNamedTypes(schema.type, namedTypes);
+  for (const field of schema.fields || []) registerNamedTypes(field.type, namedTypes);
+  if (schema.items) registerNamedTypes(schema.items, namedTypes);
+  if (schema.values) registerNamedTypes(schema.values, namedTypes);
+}
+
+/** Converts Avro logical primitives into JavaScript values suitable for Arrow. */
+function applyLogicalType(
+  logicalType: string | undefined,
+  value: unknown,
+  schema?: {precision?: number; scale?: number}
+): unknown {
+  if (logicalType === 'decimal' && value instanceof Uint8Array) {
+    const scale = schema?.scale || 0;
+    const unscaled = decodeSignedBytes(value);
+    const digits = unscaled < 0n ? (-unscaled).toString() : unscaled.toString();
+    if (schema?.precision !== undefined && digits.replace(/^0+/, '').length > schema.precision)
+      throw new Error('Avro decimal value exceeds the declared precision');
+    return Number(unscaled) / 10 ** scale;
+  }
+  if (logicalType === 'big-decimal' && value instanceof Uint8Array) return decodeBigDecimal(value);
+  if (logicalType === 'uuid') {
+    if (typeof value !== 'string' || !isUuid(value)) throw new Error('Invalid Avro UUID value');
+    return value;
+  }
+  if (logicalType === 'duration' && value instanceof Uint8Array) {
+    if (value.length !== 12) throw new Error('Avro duration must contain 12 bytes');
+    const view = new DataView(value.buffer, value.byteOffset, value.byteLength);
+    return {
+      months: view.getUint32(0, true),
+      days: view.getUint32(4, true),
+      milliseconds: view.getUint32(8, true)
+    };
+  }
+  if (typeof value === 'bigint') {
+    if (logicalType === 'timestamp-micros') return new Date(Number(value / 1_000n));
+    if (logicalType === 'timestamp-millis') return new Date(Number(value));
+    if (logicalType === 'time-millis' || logicalType === 'time-micros') return value;
+    if (logicalType === 'timestamp-nanos' || logicalType === 'local-timestamp-nanos') return value;
+    return value;
+  }
+  if (typeof value !== 'number') return value;
+  switch (logicalType) {
+    case 'date':
+      return new Date(value * 86_400_000);
+    case 'timestamp-millis':
+      return new Date(value);
+    case 'timestamp-micros':
+      return new Date(Math.floor(value / 1_000));
+    case 'time-millis':
+    case 'time-micros':
+    case 'local-timestamp-millis':
+    case 'local-timestamp-micros':
+    case 'timestamp-nanos':
+    case 'local-timestamp-nanos':
+      return value;
+    default:
+      return value;
+  }
+}
+
+/** Decodes Avro's nested big-decimal bytes and returns its value and scale. */
+function decodeBigDecimal(bytes: Uint8Array): {value: number; scale: number} {
+  let offset = 0;
+  const readLong = (): number => {
+    let encoded = 0;
+    let shift = 0;
+    while (true) {
+      if (offset >= bytes.length) throw new Error('Truncated Avro big-decimal payload');
+      const byte = bytes[offset++];
+      encoded += (byte & 0x7f) * 2 ** shift;
+      if (!(byte & 0x80)) return encoded % 2 === 0 ? encoded / 2 : -(encoded + 1) / 2;
+      shift += 7;
+    }
+  };
+  const length = readLong();
+  if (length < 0 || !Number.isInteger(length) || offset + length > bytes.length)
+    throw new Error('Invalid Avro big-decimal unscaled value');
+  const unscaled = decodeSignedBytes(bytes.subarray(offset, offset + length));
+  offset += length;
+  const scale = readLong();
+  if (!Number.isInteger(scale) || scale < 0 || offset !== bytes.length)
+    throw new Error('Invalid Avro big-decimal scale');
+  return {value: Number(unscaled) / 10 ** scale, scale};
+}
+
+/** Tests an Avro UUID string. */
+function isUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+}
+
+/** Decodes a big-endian signed two's-complement integer. */
+function decodeSignedBytes(bytes: Uint8Array): bigint {
+  let value = 0n;
+  for (const byte of bytes) value = (value << 8n) | BigInt(byte);
+  const signBit = 1n << BigInt(bytes.length * 8 - 1);
+  return value & signBit ? value - (signBit << 1n) : value;
+}

--- a/modules/parquet/src/lib/parsers/parse-avro.ts
+++ b/modules/parquet/src/lib/parsers/parse-avro.ts
@@ -194,13 +194,20 @@ export async function* parseAvroInBatchesFromUrl(
   let offset = header.dataOffset;
   let blockIndex = 0;
   let batch: Record<string, unknown>[] = [];
+  const selectedBlockIndices = options?.blockIndices?.slice().sort((a, b) => a - b);
   while (true) {
+    if (
+      selectedBlockIndices &&
+      (selectedBlockIndices.length === 0 || blockIndex > selectedBlockIndices.at(-1)!)
+    )
+      break;
     const blockHeader = await fetchAvroRange(url, offset, offset + 31, options);
     if (!blockHeader) break;
     if (blockHeader.fullFile) {
       yield* parseAvroInBatches(blockHeader.bytes.buffer as ArrayBuffer, batchSize, options);
       return;
     }
+    if (blockHeader.bytes.length === 0) break;
     const countResult = readAvroLongAt(blockHeader.bytes, 0);
     const sizeResult = readAvroLongAt(blockHeader.bytes, countResult.offset);
     if (countResult.value === 0) break;
@@ -208,6 +215,12 @@ export async function* parseAvroInBatchesFromUrl(
       throw new Error('Invalid Avro OCF block header');
     const dataOffset = offset + sizeResult.offset;
     const blockEnd = dataOffset + sizeResult.value + header.syncMarker.length - 1;
+    const selected = !selectedBlockIndices || selectedBlockIndices.includes(blockIndex);
+    if (!selected) {
+      offset = blockEnd + 1;
+      blockIndex++;
+      continue;
+    }
     const block = await fetchAvroRange(url, dataOffset, blockEnd, options);
     if (!block) throw new Error('Truncated Avro OCF block');
     const blockBytes = block.bytes;
@@ -217,25 +230,22 @@ export async function* parseAvroInBatchesFromUrl(
     for (let index = 0; index < header.syncMarker.length; index++)
       if (blockBytes[syncOffset + index] !== header.syncMarker[index])
         throw new Error('Invalid Avro OCF sync marker');
-    const selected = !options?.blockIndices || options.blockIndices.includes(blockIndex);
-    if (selected) {
-      const reader = new AvroReader(
-        await decompressAvro(header.codec, blockBytes.subarray(0, sizeResult.value)),
-        header.schema,
-        options
+    const reader = new AvroReader(
+      await decompressAvro(header.codec, blockBytes.subarray(0, sizeResult.value)),
+      header.schema,
+      options
+    );
+    for (let index = 0; index < countResult.value; index++) {
+      const value = reader.readValue(header.schema);
+      if (!isRecord(value)) throw new Error('Avro root schema must be a record');
+      batch.push(
+        options?.readerSchema
+          ? resolveReaderRecord(value, header.schema, options.readerSchema as AvroSchema)
+          : value
       );
-      for (let index = 0; index < countResult.value; index++) {
-        const value = reader.readValue(header.schema);
-        if (!isRecord(value)) throw new Error('Avro root schema must be a record');
-        batch.push(
-          options?.readerSchema
-            ? resolveReaderRecord(value, header.schema, options.readerSchema as AvroSchema)
-            : value
-        );
-        if (batch.length >= batchSize) {
-          yield createAvroBatch(batch);
-          batch = [];
-        }
+      if (batch.length >= batchSize) {
+        yield createAvroBatch(batch);
+        batch = [];
       }
     }
     offset = dataOffset + sizeResult.value + header.syncMarker.length;
@@ -608,8 +618,9 @@ function resolveReaderValue(
     return value;
   }
   if (readerSchema.type === 'array' && Array.isArray(value)) {
+    const writerItemsSchema = getArrayItemsSchema(writerSchema);
     return value.map(item =>
-      resolveReaderValue(item, writerSchema, readerSchema.items as AvroSchema)
+      resolveReaderValue(item, writerItemsSchema || writerSchema, readerSchema.items as AvroSchema)
     );
   }
   if (readerSchema.type === 'map' && value instanceof Map) {
@@ -645,6 +656,18 @@ function getRecordSchema(schema: AvroSchema): AvroRecordSchema | undefined {
   return !Array.isArray(schema) && typeof schema !== 'string' && schema.type === 'record'
     ? (schema as AvroRecordSchema)
     : undefined;
+}
+
+/** Returns the item schema from an Avro array schema or union containing one. */
+function getArrayItemsSchema(schema: AvroSchema): AvroSchema | undefined {
+  if (Array.isArray(schema)) {
+    const arrayBranch = schema.find(branch => getArrayItemsSchema(branch));
+    return arrayBranch ? getArrayItemsSchema(arrayBranch) : undefined;
+  }
+  if (typeof schema === 'string') return undefined;
+  if (Array.isArray(schema.type)) return getArrayItemsSchema(schema.type);
+  if (typeof schema.type !== 'string') return getArrayItemsSchema(schema.type);
+  return schema.type === 'array' ? schema.items : undefined;
 }
 
 /** Returns a fixed schema when the schema is a fixed object. */

--- a/modules/parquet/src/unbundled.ts
+++ b/modules/parquet/src/unbundled.ts
@@ -3,8 +3,14 @@
 // Copyright (c) vis.gl contributors
 
 export type {ParquetLoaderOptions} from './parquet-loader-types';
+export type {AvroLoaderOptions} from './avro-loader-types';
 export type {GeoParquetLoaderOptions} from './geoparquet-loader';
 export {ParquetLoader} from './parquet-loader-types';
+export {AvroLoader} from './avro-loader-types';
+export {AvroWriter} from './avro-writer';
+export {encodeAvroInChunks} from './avro-stream';
+export {parseAvroOCF} from './avro-ocf';
+export {AvroSchemaLoader} from './avro-schema-loader-types';
 export {GeoParquetLoader} from './geoparquet-loader';
 export {ParquetJSLoader} from './parquet-js-loader-types';
 export {

--- a/modules/parquet/test/avro-schema-loader.spec.ts
+++ b/modules/parquet/test/avro-schema-loader.spec.ts
@@ -1,0 +1,61 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {AvroSchemaLoaderWithParser} from '@loaders.gl/parquet/avro-schema-loader';
+
+test('AvroSchemaLoader#parse validates standalone schemas', async t => {
+  const schema = await AvroSchemaLoaderWithParser.parse(
+    new TextEncoder().encode(
+      JSON.stringify({
+        type: 'record',
+        name: 'Example',
+        fields: [
+          {name: 'id', type: 'long'},
+          {name: 'label', type: ['null', 'string']}
+        ]
+      })
+    ).buffer
+  );
+  t.equal((schema as {name: string}).name, 'Example');
+  await t.rejects(
+    () =>
+      AvroSchemaLoaderWithParser.parse(
+        new TextEncoder().encode(JSON.stringify({type: 'record', name: 'Broken', fields: []})).buffer
+      ),
+    /Invalid Avro schema/
+  );
+  t.end();
+});
+
+test('AvroSchemaLoader#parse validates defaults against field schemas', async t => {
+  const valid = await AvroSchemaLoaderWithParser.parse(
+    new TextEncoder().encode(
+      JSON.stringify({
+        type: 'record',
+        name: 'Defaults',
+        fields: [
+          {name: 'value', type: ['null', 'string'], default: null},
+          {name: 'items', type: {type: 'array', items: 'int'}, default: []},
+          {name: 'kind', type: {type: 'enum', name: 'Kind', symbols: ['A', 'B']}, default: 'A'}
+        ]
+      })
+    ).buffer
+  );
+  t.equal((valid as {name: string}).name, 'Defaults');
+  await t.rejects(
+    () =>
+      AvroSchemaLoaderWithParser.parse(
+        new TextEncoder().encode(
+          JSON.stringify({
+            type: 'record',
+            name: 'InvalidDefaults',
+            fields: [{name: 'value', type: ['null', 'string'], default: 'not-null'}]
+          })
+        ).buffer
+      ),
+    /default.*expected null/
+  );
+  t.end();
+});

--- a/modules/parquet/test/avro-writer.spec.ts
+++ b/modules/parquet/test/avro-writer.spec.ts
@@ -1,0 +1,589 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import * as arrow from 'apache-arrow';
+import {load} from '@loaders.gl/core';
+import test from 'test/utils/vitest-tape';
+import {AvroLoaderWithParser} from '../src/avro-loader';
+import {AvroLoader} from '../src/avro-loader-types';
+import {AvroWriter} from '../src/avro-writer';
+import {encodeAvroInChunks} from '../src/avro-stream';
+import {getAvroSchemaFingerprint} from '../src/lib/parsers/parse-avro';
+import {parseAvroOCF} from '../src/avro-ocf';
+
+test('AvroWriter#encode round-trips an Arrow table', async t => {
+  const input = {
+    shape: 'arrow-table' as const,
+    data: arrow.tableFromArrays({id: [1, 2], name: ['one', 'two']})
+  };
+  const output = await AvroWriter.encode(input);
+  const result = await AvroLoaderWithParser.parse(output);
+  t.equal(result.shape, 'arrow-table');
+  if (result.shape === 'arrow-table') {
+    t.equal(result.data.numRows, 2);
+    t.equal(JSON.stringify(Array.from(result.data.getChild('id')?.toArray() || [])), '[1,2]');
+    t.equal(
+      JSON.stringify(Array.from(result.data.getChild('name')?.toArray() || [])),
+      '["one","two"]'
+    );
+  }
+  t.end();
+});
+
+test('AvroWriter#encode supports an explicit nullable schema', async t => {
+  const input = {
+    shape: 'arrow-table' as const,
+    data: arrow.tableFromArrays({value: [1, null]})
+  };
+  const output = await AvroWriter.encode(input, {
+    avro: {
+      schema: {
+        type: 'record',
+        name: 'Values',
+        fields: [{name: 'value', type: ['null', 'int']}]
+      }
+    }
+  });
+  const result = await AvroLoaderWithParser.parse(output);
+  t.equal(result.shape, 'arrow-table');
+  if (result.shape === 'arrow-table')
+    t.deepEqual(result.data.toArray(), [{value: 1}, {value: null}]);
+  t.end();
+});
+
+test('AvroWriter#encode writes a single-object datum', async t => {
+  const schema = {
+    type: 'record',
+    name: 'SingleValue',
+    fields: [{name: 'id', type: 'int'}]
+  } as const;
+  const output = await AvroWriter.encode(
+    {shape: 'arrow-table', data: arrow.tableFromArrays({id: [42]})},
+    {avro: {schema, encoding: 'single-object'}}
+  );
+  const result = await AvroLoaderWithParser.parse(output, {avro: {schema}});
+  if (result.shape === 'arrow-table') t.deepEqual(result.data.toArray(), [{id: 42}]);
+  await t.rejects(
+    () =>
+      AvroWriter.encode(
+        {shape: 'arrow-table', data: arrow.tableFromArrays({id: [1, 2]})},
+        {avro: {schema, encoding: 'single-object'}}
+      ),
+    /exactly one table row/
+  );
+  t.end();
+});
+
+test('AvroWriter#encode writes raw Avro records', async t => {
+  const schema = {
+    type: 'record',
+    name: 'RawValue',
+    fields: [{name: 'id', type: 'int'}]
+  } as const;
+  const output = await AvroWriter.encode(
+    {shape: 'arrow-table', data: arrow.tableFromArrays({id: [7]})},
+    {avro: {schema, encoding: 'raw'}}
+  );
+  const result = await AvroLoaderWithParser.parse(output, {avro: {schema, encoding: 'raw'}});
+  if (result.shape === 'arrow-table') t.deepEqual(result.data.toArray(), [{id: 7}]);
+  t.end();
+});
+
+test('AvroWriter#encode supports named records and logical timestamps', async t => {
+  const input = {
+    shape: 'arrow-table' as const,
+    data: arrow.tableFromArrays({
+      user: [{id: 7, name: 'Ada'}],
+      created: [new Date(1_700_000_000_000)]
+    })
+  };
+  const output = await AvroWriter.encode(input, {
+    avro: {
+      schema: {
+        type: 'record',
+        name: 'Event',
+        fields: [
+          {
+            name: 'user',
+            type: {
+              type: 'record',
+              name: 'User',
+              fields: [
+                {name: 'id', type: 'int'},
+                {name: 'name', type: 'string'}
+              ]
+            }
+          },
+          {name: 'created', type: {type: 'long', logicalType: 'timestamp-millis'}}
+        ]
+      }
+    }
+  });
+  const result = await AvroLoaderWithParser.parse(output);
+  t.equal(result.shape, 'arrow-table');
+  if (result.shape === 'arrow-table') {
+    t.equal(result.data.getChild('user')?.get(0)?.id, 7);
+    t.equal(result.data.getChild('user')?.get(0)?.name, 'Ada');
+    t.equal(result.data.getChild('created')?.get(0), 1_700_000_000_000);
+  }
+  t.end();
+});
+
+test('AvroWriter#encode supports Avro time and local timestamp logical types', async t => {
+  const output = await AvroWriter.encode(
+    {shape: 'arrow-table', data: arrow.tableFromArrays({time: [11_045_678_000], local: [1234]})},
+    {
+      avro: {
+        schema: {
+          type: 'record',
+          name: 'Times',
+          fields: [
+            {name: 'time', type: {type: 'long', logicalType: 'time-micros'}},
+            {name: 'local', type: {type: 'long', logicalType: 'local-timestamp-micros'}}
+          ]
+        }
+      }
+    }
+  );
+  const result = await AvroLoaderWithParser.parse(output);
+  if (result.shape === 'arrow-table') {
+    t.equal(result.data.getChild('time')?.get(0), 11_045_678_000);
+    t.equal(result.data.getChild('local')?.get(0), 1234);
+  }
+  t.end();
+});
+
+test('AvroWriter#encode round-trips decimal bytes logical types', async t => {
+  const input = {
+    shape: 'arrow-table' as const,
+    data: arrow.tableFromArrays({amount: [12.34, -5.67]})
+  };
+  const output = await AvroWriter.encode(input, {
+    avro: {
+      schema: {
+        type: 'record',
+        name: 'Amounts',
+        fields: [
+          {name: 'amount', type: {type: 'bytes', logicalType: 'decimal', precision: 9, scale: 2}}
+        ]
+      }
+    }
+  });
+  const result = await AvroLoaderWithParser.parse(output);
+  if (result.shape === 'arrow-table')
+    t.deepEqual(result.data.toArray(), [{amount: 12.34}, {amount: -5.67}]);
+  t.end();
+});
+
+test('AvroWriter#encode round-trips scalable big-decimal values', async t => {
+  const schema = {
+    type: 'record',
+    name: 'BigAmounts',
+    fields: [{name: 'amount', type: {type: 'bytes', logicalType: 'big-decimal'}}]
+  } as const;
+  const output = await AvroWriter.encode(
+    {
+      shape: 'arrow-table',
+      data: arrow.tableFromArrays({amount: [{value: '12345678901234567890.12', scale: 2}]})
+    },
+    {avro: {schema}}
+  );
+  const result = await AvroLoaderWithParser.parse(output);
+  if (result.shape === 'arrow-table')
+    t.deepEqual(result.data.toArray(), [{amount: {value: 12345678901234567000, scale: 2}}]);
+  t.end();
+});
+
+test('AvroWriter#encode round-trips UUID and duration logical types', async t => {
+  const input = {
+    shape: 'arrow-table' as const,
+    data: arrow.tableFromArrays({
+      identifier: ['550e8400-e29b-41d4-a716-446655440000'],
+      elapsed: [{months: 2, days: 3, milliseconds: 4000}]
+    })
+  };
+  const output = await AvroWriter.encode(input, {
+    avro: {
+      schema: {
+        type: 'record',
+        name: 'LogicalValues',
+        fields: [
+          {name: 'identifier', type: {type: 'string', logicalType: 'uuid'}},
+          {name: 'elapsed', type: {type: 'fixed', name: 'Duration', size: 12, logicalType: 'duration'}}
+        ]
+      }
+    }
+  });
+  const result = await AvroLoaderWithParser.parse(output);
+  if (result.shape === 'arrow-table')
+    t.deepEqual(result.data.toArray(), [
+      {
+        identifier: '550e8400-e29b-41d4-a716-446655440000',
+        elapsed: {months: 2, days: 3, milliseconds: 4000}
+      }
+    ]);
+  t.end();
+});
+
+test('AvroWriter#encode supports recursive named schemas', async t => {
+  const nodeSchema = {
+    type: 'record',
+    name: 'Node',
+    fields: [
+      {name: 'value', type: 'int'},
+      {name: 'next', type: ['null', 'Node']}
+    ]
+  };
+  const output = await AvroWriter.encode(
+    {
+      shape: 'arrow-table',
+      data: arrow.tableFromArrays({
+        node: [{value: 1, next: {value: 2, next: null}}]
+      })
+    },
+    {avro: {schema: {type: 'record', name: 'Envelope', fields: [{name: 'node', type: nodeSchema}]}}}
+  );
+  const result = await AvroLoaderWithParser.parse(output);
+  if (result.shape === 'arrow-table')
+    t.deepEqual(result.data.toArray(), [
+      {node: {value: 1, next: {value: 2, next: null}}}
+    ]);
+  t.end();
+});
+
+test('AvroWriter#encode writes compressed multi-block files', async t => {
+  const input = {
+    shape: 'arrow-table' as const,
+    data: arrow.tableFromArrays({id: [1, 2, 3], name: ['alpha', 'beta', 'gamma']})
+  };
+  const output = await AvroWriter.encode(input, {avro: {codec: 'deflate', blockSize: 1}});
+  const result = await AvroLoaderWithParser.parse(output);
+  t.equal(result.shape, 'arrow-table');
+  if (result.shape === 'arrow-table') {
+    t.equal(result.data.numRows, 3);
+    t.equal(result.data.getChild('id')?.get(2), 3);
+    t.equal(result.data.getChild('name')?.get(1), 'beta');
+  }
+  t.end();
+});
+
+test('Avro OCF inspection exposes block offsets without decoding records', async t => {
+  const output = await AvroWriter.encode(
+    {
+      shape: 'arrow-table',
+      data: arrow.tableFromArrays({id: [1, 2, 3]})
+    },
+    {avro: {blockSize: 1}}
+  );
+  const ocf = parseAvroOCF(output);
+  t.equal(ocf.codec, 'null');
+  t.equal(ocf.blocks.length, 3);
+  t.equal(ocf.blocks[0].count, 1);
+  t.equal(ocf.blocks[0].dataOffset < ocf.blocks[0].syncOffset, true);
+  t.equal(ocf.blocks[1].offset > ocf.blocks[0].offset, true);
+  t.end();
+});
+
+test('AvroWriter#encode writes custom OCF metadata', async t => {
+  const output = await AvroWriter.encode(
+    {shape: 'arrow-table', data: arrow.tableFromArrays({id: [1]})},
+    {avro: {metadata: {application: 'loaders.gl', binaryTag: new Uint8Array([1, 2, 3])}}}
+  );
+  const ocf = parseAvroOCF(output);
+  t.equal(new TextDecoder().decode(ocf.metadata.get('application')), 'loaders.gl');
+  t.deepEqual(ocf.metadata.get('binaryTag'), new Uint8Array([1, 2, 3]));
+  await t.rejects(
+    () => AvroWriter.encode({shape: 'arrow-table', data: arrow.tableFromArrays({id: [1]})}, {avro: {metadata: {'avro.codec': 'null'}}}),
+    /reserved/
+  );
+  t.end();
+});
+
+test('AvroLoader#parse selects indexed OCF blocks', async t => {
+  const output = await AvroWriter.encode(
+    {
+      shape: 'arrow-table',
+      data: arrow.tableFromArrays({id: new Int32Array([1, 2, 3])})
+    },
+    {avro: {blockSize: 1}}
+  );
+  const result = await AvroLoaderWithParser.parse(output, {avro: {blockIndices: [1]}});
+  if (result.shape === 'arrow-table') {
+    t.equal(result.data.numRows, 1);
+    t.equal(result.data.getChild('id')?.get(0), 2);
+  }
+  t.end();
+});
+
+test('AvroLoader#parseInBatchesFromUrl uses HTTP byte ranges', async t => {
+  const output = new Uint8Array(
+    await AvroWriter.encode(
+      {shape: 'arrow-table', data: arrow.tableFromArrays({id: [1, 2, 3]})},
+      {avro: {blockSize: 1}}
+    )
+  );
+  const originalFetch = globalThis.fetch;
+  const ranges: string[] = [];
+  globalThis.fetch = async (_input, init) => {
+    const range = new Headers(init?.headers).get('Range') || '';
+    ranges.push(range);
+    const match = /^bytes=(\d+)-(\d+)$/.exec(range);
+    if (!match) return new Response(output);
+    const start = Number(match[1]);
+    const end = Math.min(Number(match[2]), output.length - 1);
+    if (start >= output.length) return new Response(null, {status: 416});
+    return new Response(output.slice(start, end + 1), {
+      status: 206,
+      headers: {'Content-Range': `bytes ${start}-${end}/${output.length}`}
+    });
+  };
+  try {
+    const batches = [];
+    for await (const batch of AvroLoaderWithParser.parseInBatchesFromUrl('https://example.test/data.avro', {
+      avro: {batchSize: 2}
+    })) batches.push(batch);
+    t.deepEqual(batches.map(batch => batch.length), [2, 1]);
+    t.equal(ranges.length > 2, true);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+  t.end();
+});
+
+test('core load routes URL-backed Avro files through random-access parsing', async t => {
+  const output = new Uint8Array(
+    await AvroWriter.encode({shape: 'arrow-table', data: arrow.tableFromArrays({id: [9]})})
+  );
+  const originalFetch = globalThis.fetch;
+  const ranges: string[] = [];
+  const fetchFunction = async (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const range = new Headers(init?.headers).get('Range') || '';
+    ranges.push(range);
+    const match = /^bytes=(\d+)-(\d+)$/.exec(range);
+    if (!match) return new Response(output);
+    const start = Number(match[1]);
+    const end = Math.min(Number(match[2]), output.length - 1);
+    return new Response(output.slice(start, end + 1), {
+      status: 206,
+      headers: {'Content-Range': `bytes ${start}-${end}/${output.length}`}
+    });
+  };
+  globalThis.fetch = fetchFunction;
+  try {
+    const result = await load('https://example.test/data.avro', AvroLoader, {
+      fetch: fetchFunction
+    });
+    if (result.shape === 'arrow-table') t.equal(result.data.getChild('id')?.get(0), 9);
+    t.equal(ranges.length > 0, true);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+  t.end();
+});
+
+test('encodeAvroInChunks emits a parseable OCF incrementally', async t => {
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of encodeAvroInChunks(
+    {shape: 'arrow-table', data: arrow.tableFromArrays({id: [1, 2, 3]})},
+    {avro: {blockSize: 1}}
+  ))
+    chunks.push(chunk);
+  const length = chunks.reduce((total, chunk) => total + chunk.length, 0);
+  const bytes = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.length;
+  }
+  const result = await AvroLoaderWithParser.parse(bytes.buffer);
+  if (result.shape === 'arrow-table') t.deepEqual(result.data.toArray(), [{id: 1}, {id: 2}, {id: 3}]);
+  t.equal(chunks.length, 4);
+  t.end();
+});
+
+test('AvroLoader#parseInBatches yields Arrow batches', async t => {
+  const input = {
+    shape: 'arrow-table' as const,
+    data: arrow.tableFromArrays({id: [1, 2, 3], name: ['alpha', 'beta', 'gamma']})
+  };
+  const output = await AvroWriter.encode(input);
+  const batches = [];
+  for await (const batch of AvroLoaderWithParser.parseInBatches([output], {avro: {batchSize: 2}})) {
+    batches.push(batch);
+  }
+  t.equal(batches.length, 2);
+  t.equal(batches[0].length, 2);
+  t.equal(batches[1].length, 1);
+  t.equal(batches[1].data.getChild('id')?.get(0), 3);
+  t.end();
+});
+
+test('AvroLoader#parse applies reader-schema projection, aliases, and defaults', async t => {
+  const input = {
+    shape: 'arrow-table' as const,
+    data: arrow.tableFromArrays({id: new Int32Array([7]), name: ['Ada'], ignored: ['drop me']})
+  };
+  const output = await AvroWriter.encode(input);
+  const result = await AvroLoaderWithParser.parse(output, {
+    avro: {
+      readerSchema: {
+        type: 'record',
+        name: 'ReaderEvent',
+        aliases: ['ArrowRecord'],
+        fields: [
+          {name: 'id', type: 'long'},
+          {name: 'label', aliases: ['name'], type: 'string'},
+          {name: 'extra', type: ['string', 'null'], default: 'new'}
+        ]
+      }
+    }
+  });
+  t.equal(result.shape, 'arrow-table');
+  if (result.shape === 'arrow-table') {
+    t.equal(result.data.getChild('id')?.get(0), 7);
+    t.equal(result.data.getChild('label')?.get(0), 'Ada');
+    t.equal(result.data.getChild('extra')?.get(0), 'new');
+    t.equal(result.data.getChild('ignored'), null);
+  }
+  t.end();
+});
+
+test('AvroLoader#parse applies numeric promotions and rejects incompatible types', async t => {
+  const output = await AvroWriter.encode({
+    shape: 'arrow-table',
+    data: arrow.tableFromArrays({id: new Int32Array([7])})
+  });
+  const promoted = await AvroLoaderWithParser.parse(output, {
+    avro: {readerSchema: {type: 'record', name: 'Promoted', aliases: ['ArrowRecord'], fields: [{name: 'id', type: 'double'}]}}
+  });
+  if (promoted.shape === 'arrow-table') t.equal(promoted.data.getChild('id')?.get(0), 7);
+  const union = await AvroLoaderWithParser.parse(output, {
+    avro: {
+      readerSchema: {
+        type: 'record',
+        name: 'UnionReader',
+        aliases: ['ArrowRecord'],
+        fields: [{name: 'id', type: ['null', 'double', 'string']}]
+      }
+    }
+  });
+  if (union.shape === 'arrow-table') t.equal(union.data.getChild('id')?.get(0), 7);
+  await t.rejects(
+    () =>
+      AvroLoaderWithParser.parse(output, {
+        avro: {readerSchema: {type: 'record', name: 'Invalid', aliases: ['ArrowRecord'], fields: [{name: 'id', type: 'string'}]}}
+      }),
+    /cannot promote int to string/
+  );
+  t.end();
+});
+
+test('AvroLoader#parse validates record, enum, and fixed compatibility', async t => {
+  const recordOutput = await AvroWriter.encode({
+    shape: 'arrow-table',
+    data: arrow.tableFromArrays({id: new Int32Array([1])})
+  });
+  await t.rejects(
+    () =>
+      AvroLoaderWithParser.parse(recordOutput, {
+        avro: {readerSchema: {type: 'record', name: 'OtherRecord', fields: [{name: 'id', type: 'int'}]}}
+      }),
+    /record names/
+  );
+
+  const enumSchema = {
+    type: 'record',
+    name: 'EnumRecord',
+    fields: [{name: 'kind', type: {type: 'enum', name: 'Kind', symbols: ['A']}}]
+  };
+  const enumOutput = await AvroWriter.encode(
+    {shape: 'arrow-table', data: arrow.tableFromArrays({kind: ['A']})},
+    {avro: {schema: enumSchema}}
+  );
+  await t.rejects(
+    () =>
+      AvroLoaderWithParser.parse(enumOutput, {
+        avro: {
+          readerSchema: {
+            type: 'record',
+            name: 'EnumRecord',
+            fields: [{name: 'kind', type: {type: 'enum', name: 'Kind', symbols: ['B']}}]
+          }
+        }
+      }),
+    /enum symbol/
+  );
+
+  const fixedSchema = {
+    type: 'record',
+    name: 'FixedRecord',
+    fields: [
+      {
+        name: 'value',
+        type: {type: 'fixed', name: 'Value', size: 2, logicalType: 'decimal', precision: 4, scale: 2}
+      }
+    ]
+  };
+  const fixedOutput = await AvroWriter.encode(
+    {shape: 'arrow-table', data: arrow.tableFromArrays({value: [1.23]})},
+    {avro: {schema: fixedSchema}}
+  );
+  await t.rejects(
+    () =>
+      AvroLoaderWithParser.parse(fixedOutput, {
+        avro: {
+          readerSchema: {
+            type: 'record',
+            name: 'FixedRecord',
+            fields: [
+              {
+                name: 'value',
+                type: {type: 'fixed', name: 'Value', size: 3, logicalType: 'decimal', precision: 6, scale: 2}
+              }
+            ]
+          }
+        }
+      }),
+    /fixed schemas/
+  );
+  t.end();
+});
+
+test('Avro long values support exact bigint round trips', async t => {
+  const input = {
+    shape: 'arrow-table' as const,
+    data: arrow.tableFromArrays({id: [9007199254740993n]})
+  };
+  const output = await AvroWriter.encode(input);
+  const result = await AvroLoaderWithParser.parse(output, {avro: {longType: 'bigint'}});
+  t.equal(result.shape, 'arrow-table');
+  if (result.shape === 'arrow-table') t.equal(result.data.getChild('id')?.get(0), 9007199254740993n);
+  t.end();
+});
+
+test('AvroLoader#parse supports raw and single-object encodings', async t => {
+  const schema = {
+    type: 'record',
+    name: 'Person',
+    fields: [
+      {name: 'id', type: 'int'},
+      {name: 'name', type: 'string'}
+    ]
+  };
+  const raw = Uint8Array.from([14, 6, 65, 100, 97]);
+  const fingerprint = new Uint8Array(8);
+  new DataView(fingerprint.buffer).setBigUint64(0, getAvroSchemaFingerprint(schema), true);
+  const singleObject = Uint8Array.from([0xc3, 0x01, ...fingerprint, ...raw]);
+  for (const bytes of [raw, singleObject]) {
+    const result = await AvroLoaderWithParser.parse(bytes.buffer, {
+      avro: {schema}
+    });
+    t.equal(result.shape, 'arrow-table');
+    if (result.shape === 'arrow-table') {
+      t.equal(result.data.getChild('id')?.get(0), 7);
+      t.equal(result.data.getChild('name')?.get(0), 'Ada');
+    }
+  }
+  t.end();
+});

--- a/modules/splats/test/rad-source-loader.spec.ts
+++ b/modules/splats/test/rad-source-loader.spec.ts
@@ -72,6 +72,17 @@ test('parseRADChunkToGaussianSplats decodes Spark RADC chunk payloads', t => {
   t.end();
 });
 
+test('parseRADChunkToGaussianSplats rejects truncated chunk payloads', t => {
+  const chunk = makeRADChunkFixture();
+
+  t.throws(
+    () => parseRADChunkToGaussianSplats(chunk.slice(0, chunk.byteLength - 1)),
+    /chunk payload is incomplete/,
+    'rejects incomplete RADC payloads'
+  );
+  t.end();
+});
+
 test('parseRADChunkToGaussianSplats expands Spark LoD opacity bytes', t => {
   const splats = parseRADChunkToGaussianSplats(
     makeRADChunkFixture({

--- a/website/src/components/docs/avro-cloud-live-example.tsx
+++ b/website/src/components/docs/avro-cloud-live-example.tsx
@@ -1,0 +1,98 @@
+import React, {useCallback, useState} from 'react';
+
+import {AvroLoaderWithParser} from '@loaders.gl/parquet/avro-loader';
+
+const AVRO_FILES = [
+  {
+    label: 'Apache weather · compatibility fixture',
+    sourceLabel: 'Apache Avro test data',
+    sourceUrl: 'https://github.com/apache/avro/tree/main/share/test/data',
+    url: 'https://raw.githubusercontent.com/apache/avro/main/share/test/data/weather.avro'
+  },
+  {
+    label: 'Jagged 1 · 4.2 GB',
+    sourceLabel: 'Zenodo jagged-array benchmark',
+    sourceUrl: 'https://zenodo.org/records/14538340',
+    url: 'https://zenodo.org/records/14538340/files/zlib9-jagged1.avro?download=1'
+  },
+  {
+    label: 'Jagged 2 · 4.2 GB',
+    sourceLabel: 'Zenodo jagged-array benchmark',
+    sourceUrl: 'https://zenodo.org/records/14538340',
+    url: 'https://zenodo.org/records/14538340/files/zlib9-jagged2.avro?download=1'
+  },
+  {
+    label: 'Jagged 3 · 4.3 GB',
+    sourceLabel: 'Zenodo jagged-array benchmark',
+    sourceUrl: 'https://zenodo.org/records/14538340',
+    url: 'https://zenodo.org/records/14538340/files/zlib9-jagged3.avro?download=1'
+  }
+] as const;
+
+/** Demonstrates range-backed Avro loading without downloading the full dataset. */
+export function AvroCloudLiveExample(): JSX.Element {
+  const [fileIndex, setFileIndex] = useState(0);
+  const [status, setStatus] = useState('Ready');
+  const [rows, setRows] = useState<unknown[]>([]);
+  const [error, setError] = useState('');
+  const file = AVRO_FILES[fileIndex];
+
+  const loadSample = useCallback(async () => {
+    const file = AVRO_FILES[fileIndex];
+    setStatus('Reading OCF header and first block…');
+    setRows([]);
+    setError('');
+    try {
+      for await (const batch of AvroLoaderWithParser.parseInBatchesFromUrl(file.url, {
+        avro: {batchSize: 10, blockIndices: [0]}
+      })) {
+        setRows(batch.data.toArray().slice(0, 10));
+      }
+      setStatus('Loaded block 0 with HTTP ranges');
+    } catch (loadError) {
+      setStatus('Load failed');
+      setError(loadError instanceof Error ? loadError.message : String(loadError));
+    }
+  }, [fileIndex]);
+
+  return (
+    <section
+      style={{
+        border: '1px solid var(--ifm-color-emphasis-300)',
+        borderRadius: 8,
+        padding: 20,
+        margin: '24px 0'
+      }}
+    >
+      <h2>Cloud Avro range loader</h2>
+      <p>
+        These public Avro files range from a small compatibility fixture to several gigabytes. This
+        demo reads only the OCF header and first compressed block, returning the result as an Arrow
+        table.
+      </p>
+      <label>
+        Dataset{' '}
+        <select value={fileIndex} onChange={event => setFileIndex(Number(event.target.value))}>
+          {AVRO_FILES.map((file, index) => (
+            <option key={file.url} value={index}>
+              {file.label}
+            </option>
+          ))}
+        </select>
+      </label>{' '}
+      <button type="button" onClick={loadSample}>
+        Load first block
+      </button>
+      <p aria-live="polite">
+        <strong>{status}</strong>
+      </p>
+      {error ? <pre style={{color: 'var(--ifm-color-danger)'}}>{error}</pre> : null}
+      {rows.length > 0 ? (
+        <pre style={{maxHeight: 360, overflow: 'auto'}}>{JSON.stringify(rows, null, 2)}</pre>
+      ) : null}
+      <small>
+        Source: <a href={file.sourceUrl}>{file.sourceLabel}</a>.
+      </small>
+    </section>
+  );
+}

--- a/website/src/examples-sidebar.js
+++ b/website/src/examples-sidebar.js
@@ -22,6 +22,11 @@ const sidebars = {
     },
     {
       type: 'category',
+      label: 'Table Formats',
+      items: ['table/avro']
+    },
+    {
+      type: 'category',
       label: 'Trace Formats',
       items: ['traces/chrome-trace']
     },

--- a/website/src/examples/table/avro.mdx
+++ b/website/src/examples/table/avro.mdx
@@ -1,0 +1,13 @@
+---
+title: "Avro"
+hide_title: true
+---
+
+import {AvroCloudLiveExample} from '@site/src/components/docs/avro-cloud-live-example';
+
+# Apache Avro in the cloud
+
+<AvroCloudLiveExample />
+
+This example uses the range-aware Avro loader against a multi-gigabyte hosted Object Container File.
+Only the header and selected block are downloaded; the result is returned as an Apache Arrow table.


### PR DESCRIPTION
## Goals
- Add an Apache Avro loader, schema loader, and Arrow-table writer.
- Support OCF, raw, single-object, schema resolution, range-backed loading, and block codecs.

## Changes
- Add Avro parsing, schema validation, OCF block handling, Arrow conversion, and writer APIs.
- Add Avro cloud example and format documentation.
- Add optional bzip2/xz codec bindings for Avro writing.

## Validation
- Formatting and pre-commit checks pass.
- Avro writer and schema-loader tests included.