### PR TITLE
feat(las): recover LAZ and add COPC writers

### DIFF
--- a/docs/modules/copc/README.md
+++ b/docs/modules/copc/README.md
@@ -12,7 +12,7 @@ import {CopcDocsTabs} from '@site/src/components/docs/copc-docs-tabs';
 
 <CopcDocsTabs active="overview" />
 
-The `@loaders.gl/copc` module provides support for the [COPC](/docs/modules/copc/formats/copc) format.
+The `@loaders.gl/copc` module loads and writes the [COPC](/docs/modules/copc/formats/copc) format.
 
 ## Installation
 
@@ -22,9 +22,10 @@ npm install @loaders.gl/core @loaders.gl/copc
 
 ## APIs
 
-| Source | Description |
-| ------ | ----------- |
-| [`COPCSourceLoader`](/docs/modules/copc/api-reference/copc-source-loader) <img src="https://img.shields.io/badge/From-v5.0-blue.svg?style=flat-square" alt="From-v5.0" /> | Loads viewport-selected point data from COPC files. |
+| API | Description |
+| --- | --- |
+| [`COPCSourceLoader`](/docs/modules/copc/api-reference/copc-source-loader) <img src="https://img.shields.io/badge/From-v5.0-blue.svg?style=flat-square" alt="From-v5.0" /> | Loads viewport-selected point data from COPC files through byte ranges. |
+| [`COPCWriter`](/docs/modules/copc/api-reference/copc-writer) | Writes Mesh or Mesh Arrow table point clouds as COPC 1.0 data. |
 
 ## Attribution
 

--- a/docs/modules/copc/api-reference/copc-writer.md
+++ b/docs/modules/copc/api-reference/copc-writer.md
@@ -1,0 +1,46 @@
+import {CopcDocsTabs} from '@site/src/components/docs/copc-docs-tabs';
+
+# COPCWriter
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v5.0-blue.svg?style=flat-square" alt="From-v5.0" />
+  <img src="https://img.shields.io/badge/Status-Experimental-orange.svg?style=flat-square" alt="Status: Experimental" />
+</p>
+
+<CopcDocsTabs active="writer" />
+
+`COPCWriter` writes [Mesh](/docs/specifications/category-mesh) or [Mesh Arrow table](/docs/specifications/category-mesh#mesh-arrow-tables) point clouds as COPC 1.0-compatible LAZ data.
+
+## Usage
+
+```typescript
+import {encode} from '@loaders.gl/core';
+import {COPCWriter} from '@loaders.gl/copc';
+
+const arrayBuffer = await encode(pointCloud, COPCWriter, {
+  copc: {
+    nodePointLimit: 50000,
+    pointDataRecordFormat: 7,
+    scale: [0.001, 0.001, 0.001]
+  }
+});
+```
+
+## Data Organization
+
+The writer first converts supported mesh attributes to LAS 1.4 point records, then assigns every point to exactly one octree level. Parent nodes retain a deterministic level-of-detail sample and remaining points are partitioned into child octants. Each point-bearing node is encoded as an independent LAZ chunk and listed in a single hierarchy EVLR.
+
+The writer emits PDRF 6, 7, or 8 with LASzip layered compressor 3, arithmetic coder 0, and item version 3. `POSITION` is required. `COLOR_0`, `intensity`, and `classification` are written when present; other LAS fields are zero-filled. A coordinate reference system is emitted only when `copc.wkt` is supplied.
+
+## Options
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `copc.nodePointLimit` | `number` | `50000` | Target maximum number of points retained at each octree node. A node at `maximumDepth` may exceed the target. |
+| `copc.maximumDepth` | `number` | `16` | Maximum octree depth, from 0 through 30. |
+| `copc.pointDataRecordFormat` | `6 \| 7 \| 8` | Derived | LAS 1.4 point layout. The default is 7 when `COLOR_0` is present and 6 otherwise. |
+| `copc.scale` | `[number, number, number]` | `[0.001, 0.001, 0.001]` | Coordinate quantization scale factors. |
+| `copc.offset` | `[number, number, number]` | Data minimum | Coordinate quantization offsets. |
+| `copc.spacing` | `number` | Cube width divided by 128 | Root point spacing stored in the COPC info VLR. |
+| `copc.wkt` | `string` | - | Optional OGC WKT coordinate reference system. |
+| `copc.colorDepth` | `number \| string` | - | Declares the source color component depth. |

--- a/docs/modules/copc/formats/copc.md
+++ b/docs/modules/copc/formats/copc.md
@@ -17,4 +17,6 @@ Key aspects distinguish an organized COPC LAZ file from an LAZ 1.4 that is unorg
 
 - It MUST contain ONLY LAS PDRFs 6, 7, or 8 formatted data
 - It MUST contain a COPC info VLR
-- It MUST contain a COPC hierarchy VLR
+- It MUST contain a COPC hierarchy VLR or EVLR
+
+`COPCWriter` emits LAS 1.4 PDRF 6-8 data with the COPC info VLR, variable-size LASzip chunks, a version 0 variable chunk table, and a single hierarchy EVLR. Points are sampled deterministically into parent levels and remaining points are partitioned spatially into child octants.

--- a/docs/modules/las/README.md
+++ b/docs/modules/las/README.md
@@ -15,7 +15,7 @@ npm install @loaders.gl/core @loaders.gl/las
 | Loader or Writer                                              | Description                                  |
 | ------------------------------------------------------------- | -------------------------------------------- |
 | [`LASLoader`](/docs/modules/las/api-reference/las-loader)      | Loads LAS/LAZ point clouds as Mesh objects or [Mesh Arrow tables](/docs/specifications/category-mesh#mesh-arrow-tables). |
-| [`LASWriter`](/docs/modules/las/api-reference/las-writer)      | Writes Mesh or Mesh Arrow table point clouds as uncompressed LAS data. |
+| [`LASWriter`](/docs/modules/las/api-reference/las-writer)      | Writes Mesh or Mesh Arrow table point clouds as LAS or LAZ data. |
 
 ## Attribution
 

--- a/docs/modules/las/api-reference/las-writer.md
+++ b/docs/modules/las/api-reference/las-writer.md
@@ -10,7 +10,7 @@ import {LasDocsTabs} from '@site/src/components/docs/las-docs-tabs';
   <img src="https://img.shields.io/badge/Status-Experimental-orange.svg?style=flat-square" alt="Status: Experimental" />
 </p>
 
-The `LASWriter` writes [Mesh](/docs/specifications/category-mesh) or [Mesh Arrow table](/docs/specifications/category-mesh#mesh-arrow-tables) point cloud data as uncompressed LAS binary data.
+The `LASWriter` writes [Mesh](/docs/specifications/category-mesh) or [Mesh Arrow table](/docs/specifications/category-mesh#mesh-arrow-tables) point cloud data as LAS or LAZ binary data.
 
 ## Usage
 
@@ -23,6 +23,7 @@ declare const pointCloud: Mesh | MeshArrowTable;
 
 const arrayBuffer = await encode(pointCloud, LASWriter, {
   las: {
+    format: 'laz',
     scale: [0.001, 0.001, 0.001]
   }
 });
@@ -32,15 +33,18 @@ const arrayBuffer = await encode(pointCloud, LASWriter, {
 
 `LASWriter` accepts Mesh Arrow tables and legacy Mesh objects. Arrow table input is normalized to the writer's Mesh representation before LAS binary data is encoded.
 
-The writer requires a `POSITION` attribute. It writes `COLOR_0`, `intensity`, and `classification` attributes when present. It can select LAS versions 1.0-1.4 and PDRF 0-8, but fields without a corresponding input attribute, including GPS time, waveform references, NIR, return flags, and scanner metadata, are zero-filled. Current round-trip coverage targets default LAS 1.2 and LAS 1.4/PDRF 7; full conformance for every selectable version/PDRF combination is not claimed. `LASWriter` does not write LAZ-compressed or COPC output.
+The writer requires a `POSITION` attribute. It writes `COLOR_0`, `intensity`, and `classification` attributes when present. It can select LAS versions 1.0-1.4 and PDRF 0-8 for uncompressed output, but fields without a corresponding input attribute, including GPS time, waveform references, NIR, return flags, and scanner metadata, are zero-filled. Current uncompressed round-trip coverage targets default LAS 1.2 and LAS 1.4/PDRF 7; full conformance for every selectable version/PDRF combination is not claimed.
+
+LAZ output uses LAS 1.4, PDRF 6-8, LASzip layered compressor 3, arithmetic coder 0, item version 3, and a fixed-size chunk table. The output is readable by the TypeScript loader and established WASM decoders. `LASWriter` does not yet write COPC output.
 
 ## Options
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| `las.format` | `'las' \| 'laz' \| 'copc'` | `'las'` | Output container. Only `'las'` is implemented; compressed formats throw. |
+| `las.format` | `'las' \| 'laz' \| 'copc'` | `'las'` | Output container. `'las'` and `'laz'` are implemented; `'copc'` throws. |
 | `las.version` | `'1.0'` through `'1.4'` | `'1.2'` or `'1.4'` | LAS header version. The default is 1.4 for modern PDRFs and 1.2 otherwise. |
 | `las.pointDataRecordFormat` | `0` through `8` | Derived | Point record layout. The default depends on version and whether `COLOR_0` is present. |
 | `las.scale` | `[number, number, number]` | `[0.001, 0.001, 0.001]` | Coordinate scale factors used to quantize positions into LAS integer coordinates. |
 | `las.offset` | `[number, number, number]` | Mesh minimum position | Coordinate offsets used to quantize positions into LAS integer coordinates. |
 | `las.colorDepth` | `number \| string` | - | Declares the source color component depth. |
+| `las.chunkSize` | `number` | `50000` | Number of points per fixed-size LAZ chunk. |

--- a/docs/modules/las/api-reference/las-writer.md
+++ b/docs/modules/las/api-reference/las-writer.md
@@ -35,13 +35,13 @@ const arrayBuffer = await encode(pointCloud, LASWriter, {
 
 The writer requires a `POSITION` attribute. It writes `COLOR_0`, `intensity`, and `classification` attributes when present. It can select LAS versions 1.0-1.4 and PDRF 0-8 for uncompressed output, but fields without a corresponding input attribute, including GPS time, waveform references, NIR, return flags, and scanner metadata, are zero-filled. Current uncompressed round-trip coverage targets default LAS 1.2 and LAS 1.4/PDRF 7; full conformance for every selectable version/PDRF combination is not claimed.
 
-LAZ output uses LAS 1.4, PDRF 6-8, LASzip layered compressor 3, arithmetic coder 0, item version 3, and a fixed-size chunk table. The output is readable by the TypeScript loader and established WASM decoders. `LASWriter` does not yet write COPC output.
+LAZ output uses LAS 1.4, PDRF 6-8, LASzip layered compressor 3, arithmetic coder 0, item version 3, and a fixed-size chunk table. The output is readable by the TypeScript loader and established WASM decoders. COPC output is provided separately by [`COPCWriter`](/docs/modules/copc/api-reference/copc-writer) to keep the LAS and COPC packages acyclic.
 
 ## Options
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| `las.format` | `'las' \| 'laz' \| 'copc'` | `'las'` | Output container. `'las'` and `'laz'` are implemented; `'copc'` throws. |
+| `las.format` | LAS or LAZ | `'las'` | Output container. Both LAS and LAZ are implemented. Use `COPCWriter` for COPC output. |
 | `las.version` | `'1.0'` through `'1.4'` | `'1.2'` or `'1.4'` | LAS header version. The default is 1.4 for modern PDRFs and 1.2 otherwise. |
 | `las.pointDataRecordFormat` | `0` through `8` | Derived | Point record layout. The default depends on version and whether `COLOR_0` is present. |
 | `las.scale` | `[number, number, number]` | `[0.001, 0.001, 0.001]` | Coordinate scale factors used to quantize positions into LAS integer coordinates. |

--- a/docs/modules/las/formats/las.md
+++ b/docs/modules/las/formats/las.md
@@ -47,8 +47,8 @@ LAS file versions and LASzip codec versions are independent. A claim such as "LA
 | Uncompressed LAS writing | Partial. Supports LAS output for represented mesh/table fields. |
 | LAS versions | Versions 1.0-1.4 are selectable and LAS 1.5 is rejected. Round-trip coverage currently targets default LAS 1.2 and LAS 1.4/PDRF 7; full version conformance is not claimed. |
 | Point data record formats | PDRF 0-8 are selectable. Only position, intensity, classification, and RGB input attributes are represented; other fields are zero-filled. |
-| LAZ writing | Not implemented. |
-| COPC writing | Not implemented. |
+| LAZ writing | Supported for LAS 1.4 PDRF 6-8 with fixed-size LASzip chunk tables. |
+| COPC writing | Supported by `@loaders.gl/copc` through its separate `COPCWriter` entry point. |
 | VLRs, EVLRs, CRS, Extra Bytes VLRs | Not complete. |
 | Streaming writing | `encodeInBatches` may buffer input so final counts, bounds, offsets, and headers can be written correctly. |
 
@@ -129,7 +129,7 @@ Dedicated PDRF 4-10 fixtures compare every raw decoded byte and every represente
 | Point decoding | Supported for COPC nodes using LAZ 1.4 PDRF 6, 7, or 8. |
 | Render attribute output | The TypeScript path decodes positions and RGB directly into typed Arrow attributes, skipping intensity/classification layers and avoiding their arrays, an intermediate raw-record buffer, and a second point traversal. |
 | Progressive point output while range data arrives | Not implemented. |
-| COPC writer | Not implemented. |
+| COPC writer | Implemented in `@loaders.gl/copc` as `COPCWriter`; it emits range-readable COPC 1.0-compatible output. |
 
 ## Version History
 
@@ -243,4 +243,4 @@ The TypeScript implementation should be completed in stages, with parity tests a
 | 6 | Implement LAZ file writing. | `LASWriter` emits LASzip VLRs, layered chunks, and fixed-size chunk tables that established decoders can read. |
 | 7 | Complete stateful feedable LAZ streaming. | Replace bounded replay for legacy chunks with resumable arithmetic/item state, and stream layered chunks as soon as the field ranges needed for complete rows are available. |
 | 8 | Complete pure TypeScript COPC reading. | Header, COPC info VLR, hierarchy pages, range selection, and LAZ node decoding no longer depend on the existing COPC package internals. |
-| 9 | Implement COPC writing. | Writer emits valid COPC 1.0 with hierarchy pages, range-readable LAZ node chunks, and required VLRs. |
+| 9 | Implement COPC writing. | `COPCWriter` emits valid COPC 1.0 with hierarchy pages, range-readable LAZ node chunks, and required VLRs. |

--- a/docs/modules/las/formats/las.md
+++ b/docs/modules/las/formats/las.md
@@ -70,13 +70,15 @@ LAS file versions and LASzip codec versions are independent. A claim such as "LA
 
 `encodeLAZChunk()` and `createLAZChunkEncoder()` encode raw LAS point records into one LASzip layered chunk. They do not write the surrounding LAS header, LASzip VLR, chunk table, or `.laz` file container.
 
+`LASWriter` uses the chunk encoder to write complete LAS 1.4 `.laz` files for PDRF 6-8, including the LASzip VLR, fixed-size chunks, chunk-table pointer, and version 0 chunk table.
+
 | LASzip feature | Supported TypeScript combinations |
 | --- | --- |
 | Modern PDRF 6-8 items | Layered compressor 3, arithmetic coder 0, and Point14/RGB14/RGBNIR14 item version 3. |
 | Extra Bytes | Byte14 item version 3 is losslessly encoded as independent layers. |
 | Input modes | Complete raw point buffers and feedable raw byte ranges. Feedable input is buffered until `close()` and `encode()` are called. |
 | Interoperability | PDRF 6-8 output is tested byte-for-byte through the TypeScript decoder and laz-perf. |
-| Unsupported modes | Legacy PDRF 0-5, waveform PDRF 9-10, item versions 2 and 4, and complete `.laz` file writing. |
+| Unsupported modes | Legacy PDRF 0-5, waveform PDRF 9-10, and item versions 2 and 4. |
 
 #### Point Record Formats
 

--- a/modules/copc/README.md
+++ b/modules/copc/README.md
@@ -2,6 +2,6 @@
 
 [loaders.gl](https://loaders.gl/docs) is a collection of framework-independent 3D and geospatial parsers and encoders.
 
-This module contains loaders for the COPC format.
+This module contains range-based loaders and a writer for the COPC format.
 
 For documentation please visit the [website](https://loaders.gl).

--- a/modules/copc/package.json
+++ b/modules/copc/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@loaders.gl/images": "5.0.0-alpha.2",
+    "@loaders.gl/las": "5.0.0-alpha.2",
     "@loaders.gl/loader-utils": "5.0.0-alpha.2",
     "@loaders.gl/mvt": "5.0.0-alpha.2",
     "@loaders.gl/schema": "5.0.0-alpha.2",

--- a/modules/copc/src/copc-writer.ts
+++ b/modules/copc/src/copc-writer.ts
@@ -2,19 +2,49 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {WriterOptions, WriterWithEncoder} from '@loaders.gl/loader-utils';
+import {
+  encodeLASzipVLR,
+  encodeLAZChunk,
+  encodeLAZChunkTable,
+  type LAZChunkTableEntry,
+  type WriterOptions,
+  type WriterWithEncoder
+} from '@loaders.gl/loader-utils';
+import {LASWriter} from '@loaders.gl/las';
 import type {Mesh, MeshArrowTable} from '@loaders.gl/schema';
 import {COPCFormat} from './copc-format';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
 const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+const LAS_1_4_HEADER_LENGTH = 375;
+const COPC_INFO_PAYLOAD_LENGTH = 160;
+const VLR_HEADER_LENGTH = 54;
+const EVLR_HEADER_LENGTH = 60;
+const HIERARCHY_ENTRY_LENGTH = 32;
+const VARIABLE_LAZ_CHUNK_SIZE = 0xffffffff;
+const DEFAULT_NODE_POINT_LIMIT = 50_000;
+const DEFAULT_MAXIMUM_DEPTH = 16;
 
 /** Options for `COPCWriter`. */
 export type COPCWriterOptions = WriterOptions & {
   copc?: {
     /** Target maximum number of points per COPC node. */
     nodePointLimit?: number;
+    /** Maximum octree depth used when points remain spatially coincident. */
+    maximumDepth?: number;
+    /** LAS point data record format. */
+    pointDataRecordFormat?: 6 | 7 | 8;
+    /** Coordinate scale factors used to quantize positions. */
+    scale?: [number, number, number];
+    /** Coordinate offsets used to quantize positions. */
+    offset?: [number, number, number];
+    /** Color component depth used by source color attributes. */
+    colorDepth?: number | string;
+    /** Root-node point spacing stored in the COPC info VLR. */
+    spacing?: number;
+    /** Optional coordinate reference system encoded as an OGC WKT VLR. */
+    wkt?: string;
   };
 };
 
@@ -28,11 +58,508 @@ export const COPCWriter = {
   options: {
     copc: {}
   },
-  encode: async () => encodeCOPCSync(),
+  encode: async (data, options) => encodeCOPCSync(data, options),
   encodeSync: encodeCOPCSync
 } as const satisfies WriterWithEncoder<Mesh | MeshArrowTable, never, COPCWriterOptions>;
 
 /** Encode a mesh or Arrow table as COPC. */
-function encodeCOPCSync(): ArrayBuffer {
-  throw new Error('COPCWriter: TypeScript COPC encoding is not implemented yet');
+function encodeCOPCSync(data: Mesh | MeshArrowTable, options: COPCWriterOptions = {}): ArrayBuffer {
+  const nodePointLimit = options.copc?.nodePointLimit ?? DEFAULT_NODE_POINT_LIMIT;
+  const maximumDepth = options.copc?.maximumDepth ?? DEFAULT_MAXIMUM_DEPTH;
+  validateOptions(nodePointLimit, maximumDepth, options.copc?.spacing);
+
+  const rawLAS = encodeRawLAS(data, options);
+  if (rawLAS.pointCount === 0) {
+    throw new Error('COPCWriter: at least one point is required');
+  }
+  const cube = createCube(rawLAS.bounds, Math.max(...rawLAS.scale));
+  const nodes = createOctreeNodes(rawLAS, cube, nodePointLimit, maximumDepth);
+  compressNodes(nodes, rawLAS);
+
+  const laszipVLR = encodeLASzipVLR({
+    pointDataRecordFormat: rawLAS.pointDataRecordFormat,
+    pointDataRecordLength: rawLAS.pointDataRecordLength,
+    chunkSize: VARIABLE_LAZ_CHUNK_SIZE
+  });
+  const wktVLR = options.copc?.wkt
+    ? encodeVLR(
+        'LASF_Projection',
+        2112,
+        'OGC WKT coordinate system',
+        encodeNullTerminatedString(options.copc.wkt)
+      )
+    : null;
+  const pointDataOffset =
+    LAS_1_4_HEADER_LENGTH +
+    VLR_HEADER_LENGTH +
+    COPC_INFO_PAYLOAD_LENGTH +
+    laszipVLR.byteLength +
+    (wktVLR?.byteLength || 0);
+
+  let pointDataByteOffset = pointDataOffset + 8;
+  const chunkTableEntries: LAZChunkTableEntry[] = [];
+  for (const node of nodes) {
+    node.pointDataOffset = pointDataByteOffset;
+    pointDataByteOffset += node.compressed.byteLength;
+    chunkTableEntries.push({
+      pointCount: node.pointIndices.length,
+      byteLength: node.compressed.byteLength
+    });
+  }
+
+  const chunkTablePayload = encodeLAZChunkTable(chunkTableEntries, {variable: true});
+  const chunkTableOffset = pointDataByteOffset;
+  const evlrOffset = chunkTableOffset + 8 + chunkTablePayload.byteLength;
+  const hierarchyOffset = evlrOffset + EVLR_HEADER_LENGTH;
+  const hierarchyPayload = encodeHierarchy(nodes);
+  const hierarchyEVLR = encodeEVLR('copc', 1000, 'COPC hierarchy', hierarchyPayload);
+  const spacing =
+    options.copc?.spacing ||
+    Math.max((cube[3] - cube[0]) / 128, rawLAS.scale[0], rawLAS.scale[1], rawLAS.scale[2]);
+  const infoVLR = encodeVLR(
+    'copc',
+    1,
+    'COPC info VLR',
+    encodeCOPCInfo(cube, spacing, hierarchyOffset, hierarchyPayload.byteLength)
+  );
+  const vlrs = [infoVLR, laszipVLR, ...(wktVLR ? [wktVLR] : [])];
+  const arrayBuffer = new ArrayBuffer(evlrOffset + hierarchyEVLR.byteLength);
+  const bytes = new Uint8Array(arrayBuffer);
+  const dataView = new DataView(arrayBuffer);
+
+  bytes.set(rawLAS.header, 0);
+  dataView.setUint16(6, dataView.getUint16(6, true) | 16, true);
+  dataView.setUint32(96, pointDataOffset, true);
+  dataView.setUint32(100, vlrs.length, true);
+  dataView.setUint8(104, rawLAS.pointDataRecordFormat | 0x80);
+  writeUint64(dataView, 235, evlrOffset);
+  dataView.setUint32(243, 1, true);
+
+  let outputOffset = LAS_1_4_HEADER_LENGTH;
+  for (const vlr of vlrs) {
+    bytes.set(vlr, outputOffset);
+    outputOffset += vlr.byteLength;
+  }
+  writeUint64(dataView, pointDataOffset, chunkTableOffset);
+  outputOffset = pointDataOffset + 8;
+  for (const node of nodes) {
+    bytes.set(node.compressed, outputOffset);
+    outputOffset += node.compressed.byteLength;
+  }
+  dataView.setUint32(chunkTableOffset, 0, true);
+  dataView.setUint32(chunkTableOffset + 4, nodes.length, true);
+  bytes.set(chunkTablePayload, chunkTableOffset + 8);
+  bytes.set(hierarchyEVLR, evlrOffset);
+  return arrayBuffer;
+}
+
+/** Raw LAS point records and metadata used by the COPC organizer. */
+type RawLASData = {
+  /** LAS 1.4 public header. */
+  header: Uint8Array;
+  /** Contiguous uncompressed point records. */
+  pointData: Uint8Array;
+  /** Number of point records. */
+  pointCount: number;
+  /** LAS point data record format. */
+  pointDataRecordFormat: number;
+  /** Byte length of one point record. */
+  pointDataRecordLength: number;
+  /** Coordinate scale factors. */
+  scale: [number, number, number];
+  /** Coordinate offsets. */
+  offset: [number, number, number];
+  /** Data bounds as minimum and maximum coordinates. */
+  bounds: Bounds3D;
+};
+
+/** Six-value axis-aligned 3D bounds. */
+type Bounds3D = [number, number, number, number, number, number];
+
+/** Four-value COPC octree key. */
+type COPCKey = [number, number, number, number];
+
+/** One point-bearing COPC octree node. */
+type COPCNode = {
+  /** Octree key as depth, X, Y, and Z. */
+  key: COPCKey;
+  /** Spatial cube represented by the key. */
+  bounds: Bounds3D;
+  /** Source point indices assigned to this level of detail. */
+  pointIndices: number[];
+  /** Compressed LAZ chunk. */
+  compressed: Uint8Array;
+  /** Absolute file offset of the compressed chunk. */
+  pointDataOffset: number;
+};
+
+/** State shared while recursively partitioning point indices. */
+type OctreeContext = {
+  /** Raw LAS records and coordinate metadata. */
+  rawLAS: RawLASData;
+  /** Target maximum points retained at each node. */
+  nodePointLimit: number;
+  /** Maximum permitted node depth. */
+  maximumDepth: number;
+  /** Nodes in deterministic pre-order. */
+  nodes: COPCNode[];
+  /** View used to read quantized point positions. */
+  pointDataView: DataView;
+};
+
+/** Encode input data once as uncompressed LAS 1.4 point records. */
+function encodeRawLAS(data: Mesh | MeshArrowTable, options: COPCWriterOptions): RawLASData {
+  const arrayBuffer = LASWriter.encodeSync(data, {
+    las: {
+      version: '1.4',
+      pointDataRecordFormat: options.copc?.pointDataRecordFormat,
+      scale: options.copc?.scale,
+      offset: options.copc?.offset,
+      colorDepth: options.copc?.colorDepth
+    }
+  });
+  const dataView = new DataView(arrayBuffer);
+  const pointDataOffset = dataView.getUint32(96, true);
+  const pointCount = readUint64(dataView, 247);
+  const pointDataRecordFormat = dataView.getUint8(104) & 0x3f;
+  const pointDataRecordLength = dataView.getUint16(105, true);
+  return {
+    header: new Uint8Array(arrayBuffer, 0, LAS_1_4_HEADER_LENGTH).slice(),
+    pointData: new Uint8Array(
+      arrayBuffer,
+      pointDataOffset,
+      pointCount * pointDataRecordLength
+    ).slice(),
+    pointCount,
+    pointDataRecordFormat,
+    pointDataRecordLength,
+    scale: [
+      dataView.getFloat64(131, true),
+      dataView.getFloat64(139, true),
+      dataView.getFloat64(147, true)
+    ],
+    offset: [
+      dataView.getFloat64(155, true),
+      dataView.getFloat64(163, true),
+      dataView.getFloat64(171, true)
+    ],
+    bounds: [
+      dataView.getFloat64(187, true),
+      dataView.getFloat64(203, true),
+      dataView.getFloat64(219, true),
+      dataView.getFloat64(179, true),
+      dataView.getFloat64(195, true),
+      dataView.getFloat64(211, true)
+    ]
+  };
+}
+
+/** Create a deterministic point-bearing COPC octree. */
+function createOctreeNodes(
+  rawLAS: RawLASData,
+  cube: Bounds3D,
+  nodePointLimit: number,
+  maximumDepth: number
+): COPCNode[] {
+  const context: OctreeContext = {
+    rawLAS,
+    nodePointLimit,
+    maximumDepth,
+    nodes: [],
+    pointDataView: new DataView(
+      rawLAS.pointData.buffer,
+      rawLAS.pointData.byteOffset,
+      rawLAS.pointData.byteLength
+    )
+  };
+  appendOctreeNode(
+    context,
+    [0, 0, 0, 0],
+    cube,
+    Array.from({length: rawLAS.pointCount}, (_, pointIndex) => pointIndex)
+  );
+  return context.nodes;
+}
+
+/** Retain a level-of-detail sample and recursively partition remaining points. */
+function appendOctreeNode(
+  context: OctreeContext,
+  key: COPCKey,
+  bounds: Bounds3D,
+  pointIndices: number[]
+): void {
+  const canSplit = pointIndices.length > context.nodePointLimit && key[0] < context.maximumDepth;
+  const {sample, remaining} = canSplit
+    ? samplePointIndices(pointIndices, context.nodePointLimit)
+    : {sample: pointIndices, remaining: []};
+  context.nodes.push({
+    key,
+    bounds,
+    pointIndices: sample,
+    compressed: new Uint8Array(0),
+    pointDataOffset: 0
+  });
+  if (remaining.length === 0) {
+    return;
+  }
+
+  const middle: [number, number, number] = [
+    (bounds[0] + bounds[3]) / 2,
+    (bounds[1] + bounds[4]) / 2,
+    (bounds[2] + bounds[5]) / 2
+  ];
+  const buckets = Array.from({length: 8}, () => [] as number[]);
+  for (const pointIndex of remaining) {
+    const position = readPointPosition(context, pointIndex);
+    const childX = position[0] >= middle[0] ? 1 : 0;
+    const childY = position[1] >= middle[1] ? 1 : 0;
+    const childZ = position[2] >= middle[2] ? 1 : 0;
+    buckets[childX * 4 + childY * 2 + childZ].push(pointIndex);
+  }
+
+  for (let childX = 0; childX < 2; childX++) {
+    for (let childY = 0; childY < 2; childY++) {
+      for (let childZ = 0; childZ < 2; childZ++) {
+        const childIndices = buckets[childX * 4 + childY * 2 + childZ];
+        if (childIndices.length === 0) {
+          continue;
+        }
+        appendOctreeNode(
+          context,
+          [key[0] + 1, key[1] * 2 + childX, key[2] * 2 + childY, key[3] * 2 + childZ],
+          createChildBounds(bounds, childX, childY, childZ),
+          childIndices
+        );
+      }
+    }
+  }
+}
+
+/** Select evenly spaced source-order samples for one octree level. */
+function samplePointIndices(
+  pointIndices: number[],
+  sampleCount: number
+): {sample: number[]; remaining: number[]} {
+  const sample: number[] = [];
+  const remaining: number[] = [];
+  let sampleIndex = 0;
+  let nextSamplePosition = Math.floor(((sampleIndex + 0.5) * pointIndices.length) / sampleCount);
+  for (let position = 0; position < pointIndices.length; position++) {
+    if (sampleIndex < sampleCount && position === nextSamplePosition) {
+      sample.push(pointIndices[position]);
+      sampleIndex++;
+      nextSamplePosition = Math.floor(((sampleIndex + 0.5) * pointIndices.length) / sampleCount);
+    } else {
+      remaining.push(pointIndices[position]);
+    }
+  }
+  return {sample, remaining};
+}
+
+/** Read one point's dequantized XYZ position. */
+function readPointPosition(context: OctreeContext, pointIndex: number): [number, number, number] {
+  const byteOffset = pointIndex * context.rawLAS.pointDataRecordLength;
+  return [
+    context.pointDataView.getInt32(byteOffset, true) * context.rawLAS.scale[0] +
+      context.rawLAS.offset[0],
+    context.pointDataView.getInt32(byteOffset + 4, true) * context.rawLAS.scale[1] +
+      context.rawLAS.offset[1],
+    context.pointDataView.getInt32(byteOffset + 8, true) * context.rawLAS.scale[2] +
+      context.rawLAS.offset[2]
+  ];
+}
+
+/** Return the child cube selected by three octant bits. */
+function createChildBounds(
+  bounds: Bounds3D,
+  childX: number,
+  childY: number,
+  childZ: number
+): Bounds3D {
+  const middleX = (bounds[0] + bounds[3]) / 2;
+  const middleY = (bounds[1] + bounds[4]) / 2;
+  const middleZ = (bounds[2] + bounds[5]) / 2;
+  return [
+    childX ? middleX : bounds[0],
+    childY ? middleY : bounds[1],
+    childZ ? middleZ : bounds[2],
+    childX ? bounds[3] : middleX,
+    childY ? bounds[4] : middleY,
+    childZ ? bounds[5] : middleZ
+  ];
+}
+
+/** Compress each node as one independent LAZ chunk. */
+function compressNodes(nodes: COPCNode[], rawLAS: RawLASData): void {
+  for (const node of nodes) {
+    const pointData = new Uint8Array(node.pointIndices.length * rawLAS.pointDataRecordLength);
+    for (let index = 0; index < node.pointIndices.length; index++) {
+      const sourceOffset = node.pointIndices[index] * rawLAS.pointDataRecordLength;
+      pointData.set(
+        rawLAS.pointData.subarray(sourceOffset, sourceOffset + rawLAS.pointDataRecordLength),
+        index * rawLAS.pointDataRecordLength
+      );
+    }
+    node.compressed = encodeLAZChunk(pointData, {
+      pointDataRecordFormat: rawLAS.pointDataRecordFormat,
+      pointDataRecordLength: rawLAS.pointDataRecordLength,
+      pointCount: node.pointIndices.length,
+      point14ItemVersion: 3,
+      rgb14ItemVersion: 3,
+      byte14ItemVersion: 3
+    });
+  }
+}
+
+/** Encode a single-page COPC hierarchy. */
+function encodeHierarchy(nodes: COPCNode[]): Uint8Array {
+  const sortedNodes = [...nodes].sort((left, right) => compareKeys(left.key, right.key));
+  const bytes = new Uint8Array(sortedNodes.length * HIERARCHY_ENTRY_LENGTH);
+  const dataView = new DataView(bytes.buffer);
+  for (let nodeIndex = 0; nodeIndex < sortedNodes.length; nodeIndex++) {
+    const node = sortedNodes[nodeIndex];
+    const byteOffset = nodeIndex * HIERARCHY_ENTRY_LENGTH;
+    dataView.setInt32(byteOffset, node.key[0], true);
+    dataView.setInt32(byteOffset + 4, node.key[1], true);
+    dataView.setInt32(byteOffset + 8, node.key[2], true);
+    dataView.setInt32(byteOffset + 12, node.key[3], true);
+    writeUint64(dataView, byteOffset + 16, node.pointDataOffset);
+    dataView.setInt32(byteOffset + 24, node.compressed.byteLength, true);
+    dataView.setInt32(byteOffset + 28, node.pointIndices.length, true);
+  }
+  return bytes;
+}
+
+/** Compare COPC keys lexicographically. */
+function compareKeys(left: COPCKey, right: COPCKey): number {
+  for (let index = 0; index < left.length; index++) {
+    if (left[index] !== right[index]) {
+      return left[index] - right[index];
+    }
+  }
+  return 0;
+}
+
+/** Encode the fixed-length COPC info payload. */
+function encodeCOPCInfo(
+  cube: Bounds3D,
+  spacing: number,
+  hierarchyOffset: number,
+  hierarchyByteLength: number
+): Uint8Array {
+  const bytes = new Uint8Array(COPC_INFO_PAYLOAD_LENGTH);
+  const dataView = new DataView(bytes.buffer);
+  dataView.setFloat64(0, (cube[0] + cube[3]) / 2, true);
+  dataView.setFloat64(8, (cube[1] + cube[4]) / 2, true);
+  dataView.setFloat64(16, (cube[2] + cube[5]) / 2, true);
+  dataView.setFloat64(24, (cube[3] - cube[0]) / 2, true);
+  dataView.setFloat64(32, spacing, true);
+  writeUint64(dataView, 40, hierarchyOffset);
+  writeUint64(dataView, 48, hierarchyByteLength);
+  dataView.setFloat64(56, 0, true);
+  dataView.setFloat64(64, 0, true);
+  return bytes;
+}
+
+/** Encode a standard LAS variable-length record. */
+function encodeVLR(
+  userId: string,
+  recordId: number,
+  description: string,
+  payload: Uint8Array
+): Uint8Array {
+  if (payload.byteLength > 0xffff) {
+    throw new Error(`COPCWriter: VLR payload exceeds 65535 bytes (${payload.byteLength})`);
+  }
+  const bytes = new Uint8Array(VLR_HEADER_LENGTH + payload.byteLength);
+  const dataView = new DataView(bytes.buffer);
+  writeString(dataView, 2, userId, 16);
+  dataView.setUint16(18, recordId, true);
+  dataView.setUint16(20, payload.byteLength, true);
+  writeString(dataView, 22, description, 32);
+  bytes.set(payload, VLR_HEADER_LENGTH);
+  return bytes;
+}
+
+/** Encode a LAS extended variable-length record. */
+function encodeEVLR(
+  userId: string,
+  recordId: number,
+  description: string,
+  payload: Uint8Array
+): Uint8Array {
+  const bytes = new Uint8Array(EVLR_HEADER_LENGTH + payload.byteLength);
+  const dataView = new DataView(bytes.buffer);
+  writeString(dataView, 2, userId, 16);
+  dataView.setUint16(18, recordId, true);
+  writeUint64(dataView, 20, payload.byteLength);
+  writeString(dataView, 28, description, 32);
+  bytes.set(payload, EVLR_HEADER_LENGTH);
+  return bytes;
+}
+
+/** Return the smallest non-degenerate cube centered on the data bounds. */
+function createCube(bounds: Bounds3D, minimumWidth: number): Bounds3D {
+  const center: [number, number, number] = [
+    (bounds[0] + bounds[3]) / 2,
+    (bounds[1] + bounds[4]) / 2,
+    (bounds[2] + bounds[5]) / 2
+  ];
+  const radius =
+    Math.max(bounds[3] - bounds[0], bounds[4] - bounds[1], bounds[5] - bounds[2], minimumWidth) / 2;
+  return [
+    center[0] - radius,
+    center[1] - radius,
+    center[2] - radius,
+    center[0] + radius,
+    center[1] + radius,
+    center[2] + radius
+  ];
+}
+
+/** Validate COPC organization options. */
+function validateOptions(nodePointLimit: number, maximumDepth: number, spacing?: number): void {
+  if (!Number.isInteger(nodePointLimit) || nodePointLimit <= 0 || nodePointLimit > 0x7fffffff) {
+    throw new Error(`COPCWriter: invalid node point limit ${nodePointLimit}`);
+  }
+  if (!Number.isInteger(maximumDepth) || maximumDepth < 0 || maximumDepth > 30) {
+    throw new Error(`COPCWriter: invalid maximum depth ${maximumDepth}`);
+  }
+  if (spacing !== undefined && (!Number.isFinite(spacing) || spacing <= 0)) {
+    throw new Error(`COPCWriter: invalid spacing ${spacing}`);
+  }
+}
+
+/** Encode a string with LAS-required null termination. */
+function encodeNullTerminatedString(value: string): Uint8Array {
+  const encoded = new TextEncoder().encode(value);
+  const bytes = new Uint8Array(encoded.byteLength + 1);
+  bytes.set(encoded);
+  return bytes;
+}
+
+/** Write a fixed-length ASCII string into a DataView. */
+function writeString(
+  dataView: DataView,
+  byteOffset: number,
+  value: string,
+  byteLength: number
+): void {
+  for (let characterIndex = 0; characterIndex < byteLength; characterIndex++) {
+    dataView.setUint8(byteOffset + characterIndex, value.charCodeAt(characterIndex) || 0);
+  }
+}
+
+/** Write a safe JavaScript integer as a little-endian UInt64. */
+function writeUint64(dataView: DataView, byteOffset: number, value: number): void {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`COPCWriter: UInt64 value is outside the safe integer range (${value})`);
+  }
+  dataView.setUint32(byteOffset, value >>> 0, true);
+  dataView.setUint32(byteOffset + 4, Math.floor(value / 2 ** 32), true);
+}
+
+/** Read a little-endian UInt64 known to fit in JavaScript's safe integer range. */
+function readUint64(dataView: DataView, byteOffset: number): number {
+  return dataView.getUint32(byteOffset, true) + dataView.getUint32(byteOffset + 4, true) * 2 ** 32;
 }

--- a/modules/copc/test/copc-source.spec.ts
+++ b/modules/copc/test/copc-source.spec.ts
@@ -3,11 +3,21 @@
 // Copyright (c) vis.gl contributors
 
 import test from 'test/utils/vitest-tape';
-import {createDataSource, encodeSync, fetchFile, isBrowser} from '@loaders.gl/core';
+import {validateWriter} from 'test/common/conformance';
+import {createDataSource, encodeSync, fetchFile, isBrowser, parse} from '@loaders.gl/core';
 import {COPCSourceLoader, COPCTileSource, COPCWriter} from '@loaders.gl/copc';
+import {LASLoader} from '@loaders.gl/las';
+import {decodeLAZChunk, decodeLAZChunkTable} from '@loaders.gl/loader-utils';
+import {deduceMeshSchema} from '@loaders.gl/schema-utils';
+import {Copc} from 'copc';
 
 const ELLIPSOID_FILE_PATH = 'modules/copc/test/data/ellipsoid.copc.laz';
 const ELLIPSOID_BROWSER_URL = new URL('./data/ellipsoid.copc.laz', import.meta.url).href;
+
+test('COPCWriter#writer conformance', t => {
+  validateWriter(t, COPCWriter, 'COPCWriter');
+  t.end();
+});
 
 test('COPCSourceLoader#creates a source through createDataSource', async t => {
   const dataSource = createDataSource(await createEllipsoidSourceData(), [COPCSourceLoader], {
@@ -171,12 +181,132 @@ test('COPCSourceLoader#derives cartographic view metadata from the dataset', asy
   t.end();
 });
 
-test('COPCWriter#reports unimplemented TypeScript COPC encoding', t => {
-  t.throws(
-    () => encodeSync({} as any, COPCWriter),
-    /not implemented yet/,
-    'COPCWriter encodeSync reports unimplemented encoding'
+test('COPCWriter#encodes range-readable octree nodes', async t => {
+  const mesh = createCOPCWriterMesh();
+  const arrayBuffer = encodeSync(mesh, COPCWriter, {
+    copc: {nodePointLimit: 4, maximumDepth: 4, pointDataRecordFormat: 7, scale: [0.01, 0.01, 0.01]}
+  });
+  const blob = new Blob([arrayBuffer]);
+  const ranges: Array<[number, number]> = [];
+  const getter = async (begin: number, end: number): Promise<Uint8Array> => {
+    ranges.push([begin, end]);
+    return new Uint8Array(await blob.slice(begin, end).arrayBuffer());
+  };
+  const copc = await Copc.create(getter);
+  const hierarchy = await Copc.loadHierarchyPage(getter, copc.info.rootHierarchyPage);
+  const nodes = Object.values(hierarchy.nodes);
+  const rootNode = hierarchy.nodes['0-0-0-0'];
+
+  t.equal(copc.header.pointDataRecordFormat, 7, 'writes PDRF 7');
+  t.equal(copc.header.pointCount, mesh.attributes.POSITION.value.length / 3, 'writes point count');
+  t.equal(copc.header.globalEncoding & 16, 16, 'sets the WKT global encoding bit');
+  t.ok(rootNode, 'writes a root hierarchy node');
+  t.equal(rootNode.pointCount, 4, 'root node respects the point target');
+  t.ok(nodes.length > 1, 'partitions points into child nodes');
+  t.equal(
+    nodes.reduce((pointCount, node) => pointCount + node.pointCount, 0),
+    copc.header.pointCount,
+    'hierarchy assigns every point exactly once'
   );
+  t.ok(
+    ranges.some(
+      ([begin, end]) =>
+        begin === copc.info.rootHierarchyPage.pageOffset &&
+        end - begin === copc.info.rootHierarchyPage.pageLength
+    ),
+    'hierarchy is loaded through its declared byte range'
+  );
+
+  const pointDataPositions: string[] = [];
+  for (const node of nodes) {
+    const compressed = await Copc.loadCompressedPointDataBuffer(getter, node);
+    const rawPointData = decodeLAZChunk(compressed, {
+      pointCount: node.pointCount,
+      pointDataRecordFormat: copc.header.pointDataRecordFormat,
+      pointDataRecordLength: copc.header.pointDataRecordLength
+    });
+    pointDataPositions.push(...readPointPositions(rawPointData, copc.header));
+  }
+  t.deepEqual(
+    pointDataPositions.sort(),
+    readMeshPositions(mesh).sort(),
+    'independent node chunks preserve every source position'
+  );
+  const lasData = await parse(arrayBuffer.slice(0), LASLoader, {core: {worker: false}});
+  t.deepEqual(
+    readFlatPositions(lasData.attributes.POSITION.value).sort(),
+    readMeshPositions(mesh).sort(),
+    'ordinary variable-chunk LAZ parsing preserves every source position'
+  );
+
+  const dataView = new DataView(arrayBuffer);
+  const chunkTableOffset = readUint64(dataView, copc.header.pointDataOffset);
+  const chunkCount = dataView.getUint32(chunkTableOffset + 4, true);
+  const chunkTable = decodeLAZChunkTable(
+    new Uint8Array(
+      arrayBuffer,
+      chunkTableOffset + 8,
+      copc.header.evlrOffset - chunkTableOffset - 8
+    ),
+    {
+      chunkCount,
+      pointCount: copc.header.pointCount,
+      chunkSize: 0xffffffff,
+      variable: true
+    }
+  );
+  t.equal(chunkCount, nodes.length, 'variable chunk table covers every hierarchy node');
+  t.equal(
+    chunkTable.reduce((pointCount, chunk) => pointCount + chunk.pointCount, 0),
+    copc.header.pointCount,
+    'variable chunk table preserves node point counts'
+  );
+
+  const source = COPCSourceLoader.createDataSource(blob, {copc: {decoder: 'typescript-laz'}});
+  await source.initialize();
+  const rootTile = await source.getRootTile();
+  const childTiles = await source.getChildren(rootTile);
+  const content = await source.loadTileContent(childTiles[0] || rootTile);
+  t.ok(childTiles.length > 0, 'range source exposes generated child tiles');
+  t.ok(content?.pointCount, 'range source decodes generated tile content');
+  t.end();
+});
+
+test('COPCWriter#validates organization options', t => {
+  const mesh = createCOPCWriterMesh();
+  t.throws(
+    () => encodeSync(mesh, COPCWriter, {copc: {nodePointLimit: 0}}),
+    /invalid node point limit/,
+    'rejects an empty node target'
+  );
+  t.throws(
+    () => encodeSync(mesh, COPCWriter, {copc: {maximumDepth: 31}}),
+    /invalid maximum depth/,
+    'rejects octree depths outside Int32 key coordinates'
+  );
+  t.end();
+});
+
+test('COPCWriter#defaults to PDRF 6 without colors', async t => {
+  const coloredMesh = createCOPCWriterMesh();
+  const attributes = {POSITION: coloredMesh.attributes.POSITION};
+  const mesh = {
+    ...coloredMesh,
+    attributes,
+    schema: deduceMeshSchema(attributes, {topology: 'point-list', mode: '0'})
+  };
+  const arrayBuffer = encodeSync(mesh, COPCWriter, {
+    copc: {nodePointLimit: 8, wkt: 'LOCAL_CS["loaders.gl test"]'}
+  });
+  const blob = new Blob([arrayBuffer]);
+  const getter = async (begin: number, end: number): Promise<Uint8Array> =>
+    new Uint8Array(await blob.slice(begin, end).arrayBuffer());
+  const copc = await Copc.create(getter);
+  const hierarchy = await Copc.loadHierarchyPage(getter, copc.info.rootHierarchyPage);
+
+  t.equal(copc.header.pointDataRecordFormat, 6, 'selects PDRF 6');
+  t.equal(copc.wkt, 'LOCAL_CS["loaders.gl test"]', 'writes an optional WKT VLR');
+  t.ok(hierarchy.nodes['0-0-0-0'], 'PDRF 6 hierarchy is readable');
   t.end();
 });
 
@@ -189,4 +319,72 @@ async function createEllipsoidSourceData(): Promise<string | Blob> {
 async function createEllipsoidBlob(): Promise<Blob> {
   const url = isBrowser ? ELLIPSOID_BROWSER_URL : ELLIPSOID_FILE_PATH;
   return new Blob([await (await fetchFile(url)).arrayBuffer()]);
+}
+
+/** Create a colored point cloud spanning all root octants. */
+function createCOPCWriterMesh() {
+  const positions: number[] = [];
+  const colors: number[] = [];
+  for (let z = 0; z < 2; z++) {
+    for (let y = 0; y < 4; y++) {
+      for (let x = 0; x < 5; x++) {
+        positions.push(x * 10 - 20, y * 8 - 12, z * 30 - 15);
+        colors.push(x * 10, y * 20, z * 100);
+      }
+    }
+  }
+  const attributes = {
+    POSITION: {value: new Float64Array(positions), size: 3},
+    COLOR_0: {value: new Uint16Array(colors), size: 3}
+  };
+  return {
+    attributes,
+    topology: 'point-list' as const,
+    mode: 0,
+    schema: deduceMeshSchema(attributes, {topology: 'point-list', mode: '0'})
+  };
+}
+
+/** Read dequantized positions from raw LAS records. */
+function readPointPositions(rawPointData: Uint8Array, header: any): string[] {
+  const dataView = new DataView(
+    rawPointData.buffer,
+    rawPointData.byteOffset,
+    rawPointData.byteLength
+  );
+  const positions: string[] = [];
+  for (
+    let pointIndex = 0;
+    pointIndex < rawPointData.byteLength / header.pointDataRecordLength;
+    pointIndex++
+  ) {
+    const byteOffset = pointIndex * header.pointDataRecordLength;
+    positions.push(
+      [
+        dataView.getInt32(byteOffset, true) * header.scale[0] + header.offset[0],
+        dataView.getInt32(byteOffset + 4, true) * header.scale[1] + header.offset[1],
+        dataView.getInt32(byteOffset + 8, true) * header.scale[2] + header.offset[2]
+      ].join(',')
+    );
+  }
+  return positions;
+}
+
+/** Return source mesh positions as stable string keys. */
+function readMeshPositions(mesh: ReturnType<typeof createCOPCWriterMesh>): string[] {
+  return readFlatPositions(mesh.attributes.POSITION.value);
+}
+
+/** Return flat XYZ values as stable string keys. */
+function readFlatPositions(positions: ArrayLike<number>): string[] {
+  const result: string[] = [];
+  for (let index = 0; index < positions.length; index += 3) {
+    result.push([positions[index], positions[index + 1], positions[index + 2]].join(','));
+  }
+  return result;
+}
+
+/** Read a little-endian UInt64 that fits in JavaScript's safe integer range. */
+function readUint64(dataView: DataView, byteOffset: number): number {
+  return dataView.getUint32(byteOffset, true) + dataView.getUint32(byteOffset + 4, true) * 2 ** 32;
 }

--- a/modules/copc/tsconfig.json
+++ b/modules/copc/tsconfig.json
@@ -9,6 +9,7 @@
   },
   "references": [
     {"path": "../loader-utils"},
+    {"path": "../las"},
     {"path": "../schema"},
     {"path": "../schema-utils"},
     {"path": "../images"}

--- a/modules/las/src/las-writer.ts
+++ b/modules/las/src/las-writer.ts
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {WriterOptions, WriterWithEncoder} from '@loaders.gl/loader-utils';
+import {
+  encodeLAZChunk,
+  encodeLAZChunkTable,
+  type LAZChunkTableEntry,
+  type WriterOptions,
+  type WriterWithEncoder
+} from '@loaders.gl/loader-utils';
 import type {Mesh, MeshArrowTable, MeshAttribute} from '@loaders.gl/schema';
 import {convertMeshToTable, convertTableToMesh} from '@loaders.gl/schema-utils';
 import {LASFormat} from './las-format';
@@ -13,6 +19,9 @@ const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
 const LAS_HEADER_LENGTH = 227;
 const LAS_1_4_HEADER_LENGTH = 375;
+const LASZIP_VLR_HEADER_LENGTH = 54;
+const LASZIP_VLR_PAYLOAD_BASE_LENGTH = 34;
+const DEFAULT_LAZ_CHUNK_SIZE = 50_000;
 const POINT_RECORD_LENGTHS: Record<number, number> = {
   0: 20,
   1: 28,
@@ -29,7 +38,7 @@ const POINT_RECORD_LENGTHS: Record<number, number> = {
 export type LASWriterOptions = WriterOptions & {
   /** LAS-specific writer options. */
   las?: {
-    /** Output container format. Only uncompressed LAS is currently implemented. */
+    /** Output container format. COPC writing is not yet implemented. */
     format?: 'las' | 'laz' | 'copc';
     /** LAS file version to write. LAS 1.5 writing is intentionally not supported. */
     version?: '1.0' | '1.1' | '1.2' | '1.3' | '1.4';
@@ -41,18 +50,20 @@ export type LASWriterOptions = WriterOptions & {
     offset?: [number, number, number];
     /** Color component depth used by source color attributes. */
     colorDepth?: number | string;
+    /** Number of points per fixed-size LAZ chunk. */
+    chunkSize?: number;
   };
 };
 
 /**
- * Writer for uncompressed LAS point cloud data.
+ * Writer for LAS and LAZ point cloud data.
  */
 export const LASWriter = {
   ...LASFormat,
   dataType: null as unknown as Mesh | MeshArrowTable,
   batchType: null as never,
   version: VERSION,
-  extensions: ['las'],
+  extensions: ['las', 'laz'],
   options: {
     las: {}
   },
@@ -67,13 +78,11 @@ export const LASWriter = {
   }
 } as const satisfies WriterWithEncoder<Mesh | MeshArrowTable, never, LASWriterOptions>;
 
-/** Encode mesh category data as uncompressed LAS bytes. */
+/** Encode mesh category data as LAS or LAZ bytes. */
 function encodeLASSync(data: Mesh | MeshArrowTable, options: LASWriterOptions = {}): ArrayBuffer {
   const format = options.las?.format || 'las';
-  if (format !== 'las') {
-    throw new Error(
-      `LASWriter: TypeScript ${format.toUpperCase()} encoding is not implemented yet`
-    );
+  if (format === 'copc') {
+    throw new Error('LASWriter: TypeScript COPC encoding is not implemented yet');
   }
 
   const mesh = normalizeMesh(data);
@@ -93,10 +102,38 @@ function encodeLASSync(data: Mesh | MeshArrowTable, options: LASWriterOptions = 
   }
   const version = options.las?.version || (pointDataRecordFormat >= 6 ? '1.4' : '1.2');
   const headerLength = version === '1.4' ? LAS_1_4_HEADER_LENGTH : LAS_HEADER_LENGTH;
-  const arrayBuffer = new ArrayBuffer(headerLength + vertexCount * pointDataRecordLength);
-  const dataView = new DataView(arrayBuffer);
+  if (format === 'laz') {
+    validateLAZOptions(version, pointDataRecordFormat, options.las?.chunkSize);
+  }
 
-  writeHeader(dataView, {
+  const rawPointData = new Uint8Array(vertexCount * pointDataRecordLength);
+  const pointDataView = new DataView(rawPointData.buffer);
+
+  for (let vertexIndex = 0; vertexIndex < vertexCount; vertexIndex++) {
+    const pointOffset = vertexIndex * pointDataRecordLength;
+    pointDataView.setInt32(
+      pointOffset,
+      Math.round((getComponent(positionAttribute, vertexIndex, 0) - offset[0]) / scale[0]),
+      true
+    );
+    pointDataView.setInt32(
+      pointOffset + 4,
+      Math.round((getComponent(positionAttribute, vertexIndex, 1) - offset[1]) / scale[1]),
+      true
+    );
+    pointDataView.setInt32(
+      pointOffset + 8,
+      Math.round((getComponent(positionAttribute, vertexIndex, 2) - offset[2]) / scale[2]),
+      true
+    );
+    writePointRecord(pointDataView, pointOffset, vertexIndex, pointDataRecordFormat, {
+      intensityAttribute,
+      classificationAttribute,
+      colorAttribute
+    });
+  }
+
+  const writeParameters: LASWriteParameters = {
     vertexCount,
     boundingBox,
     scale,
@@ -105,33 +142,181 @@ function encodeLASSync(data: Mesh | MeshArrowTable, options: LASWriterOptions = 
     headerLength,
     pointDataRecordFormat,
     pointDataRecordLength
-  });
-
-  for (let vertexIndex = 0; vertexIndex < vertexCount; vertexIndex++) {
-    const pointOffset = headerLength + vertexIndex * pointDataRecordLength;
-    dataView.setInt32(
-      pointOffset,
-      Math.round((getComponent(positionAttribute, vertexIndex, 0) - offset[0]) / scale[0]),
-      true
-    );
-    dataView.setInt32(
-      pointOffset + 4,
-      Math.round((getComponent(positionAttribute, vertexIndex, 1) - offset[1]) / scale[1]),
-      true
-    );
-    dataView.setInt32(
-      pointOffset + 8,
-      Math.round((getComponent(positionAttribute, vertexIndex, 2) - offset[2]) / scale[2]),
-      true
-    );
-    writePointRecord(dataView, pointOffset, vertexIndex, pointDataRecordFormat, {
-      intensityAttribute,
-      classificationAttribute,
-      colorAttribute
-    });
+  };
+  if (format === 'laz') {
+    return encodeLAZFile(rawPointData, writeParameters, options.las?.chunkSize);
   }
 
+  const arrayBuffer = new ArrayBuffer(headerLength + rawPointData.byteLength);
+  writeHeader(new DataView(arrayBuffer), {...writeParameters, pointDataOffset: headerLength});
+  new Uint8Array(arrayBuffer, headerLength).set(rawPointData);
   return arrayBuffer;
+}
+
+/** Values shared by LAS header and point-data encoding. */
+type LASWriteParameters = {
+  /** Number of point records in the output. */
+  vertexCount: number;
+  /** World-coordinate bounds. */
+  boundingBox: [[number, number, number], [number, number, number]];
+  /** Coordinate quantization scales. */
+  scale: [number, number, number];
+  /** Coordinate quantization offsets. */
+  offset: [number, number, number];
+  /** LAS file version. */
+  version: '1.0' | '1.1' | '1.2' | '1.3' | '1.4';
+  /** Public header byte length. */
+  headerLength: number;
+  /** LAS point data record format. */
+  pointDataRecordFormat: number;
+  /** Byte length of each raw point record. */
+  pointDataRecordLength: number;
+};
+
+/** One LASzip item descriptor written into the codec VLR. */
+type LASzipItem = {
+  /** LASzip item type identifier. */
+  type: number;
+  /** Uncompressed item byte length. */
+  size: number;
+};
+
+/** Assemble raw LAS point records into a complete fixed-chunk LAZ file. */
+function encodeLAZFile(
+  rawPointData: Uint8Array,
+  parameters: LASWriteParameters,
+  requestedChunkSize?: number
+): ArrayBuffer {
+  const chunkSize = requestedChunkSize || DEFAULT_LAZ_CHUNK_SIZE;
+  const laszipVLR = createLASzipVLR(
+    parameters.pointDataRecordFormat,
+    parameters.pointDataRecordLength,
+    chunkSize
+  );
+  const pointDataOffset = parameters.headerLength + laszipVLR.byteLength;
+  const compressedChunks: Uint8Array[] = [];
+  const chunkTableEntries: LAZChunkTableEntry[] = [];
+
+  for (let pointOffset = 0; pointOffset < parameters.vertexCount; pointOffset += chunkSize) {
+    const pointCount = Math.min(chunkSize, parameters.vertexCount - pointOffset);
+    const byteOffset = pointOffset * parameters.pointDataRecordLength;
+    const compressed = encodeLAZChunk(
+      rawPointData.subarray(byteOffset, byteOffset + pointCount * parameters.pointDataRecordLength),
+      {
+        pointDataRecordFormat: parameters.pointDataRecordFormat,
+        pointDataRecordLength: parameters.pointDataRecordLength,
+        pointCount,
+        point14ItemVersion: 3,
+        rgb14ItemVersion: 3,
+        byte14ItemVersion: 3
+      }
+    );
+    compressedChunks.push(compressed);
+    chunkTableEntries.push({pointCount, byteLength: compressed.byteLength});
+  }
+
+  const compressedPointDataByteLength = compressedChunks.reduce(
+    (byteLength, chunk) => byteLength + chunk.byteLength,
+    0
+  );
+  const chunkTablePayload = encodeLAZChunkTable(chunkTableEntries);
+  const chunkTableOffset = pointDataOffset + 8 + compressedPointDataByteLength;
+  const arrayBuffer = new ArrayBuffer(chunkTableOffset + 8 + chunkTablePayload.byteLength);
+  const bytes = new Uint8Array(arrayBuffer);
+  const dataView = new DataView(arrayBuffer);
+
+  writeHeader(dataView, {
+    ...parameters,
+    pointDataOffset,
+    vlrCount: 1,
+    compressed: true
+  });
+  bytes.set(laszipVLR, parameters.headerLength);
+  writeUint64Fallback(dataView, pointDataOffset, chunkTableOffset);
+  let compressedOffset = pointDataOffset + 8;
+  for (const chunk of compressedChunks) {
+    bytes.set(chunk, compressedOffset);
+    compressedOffset += chunk.byteLength;
+  }
+  dataView.setUint32(chunkTableOffset, 0, true);
+  dataView.setUint32(chunkTableOffset + 4, chunkTableEntries.length, true);
+  bytes.set(chunkTablePayload, chunkTableOffset + 8);
+  return arrayBuffer;
+}
+
+/** Create the LASzip VLR for a layered LAS 1.4 point layout. */
+function createLASzipVLR(
+  pointDataRecordFormat: number,
+  pointDataRecordLength: number,
+  chunkSize: number
+): Uint8Array {
+  const items = getLASzipItems(pointDataRecordFormat, pointDataRecordLength);
+  const payloadLength = LASZIP_VLR_PAYLOAD_BASE_LENGTH + items.length * 6;
+  const bytes = new Uint8Array(LASZIP_VLR_HEADER_LENGTH + payloadLength);
+  const dataView = new DataView(bytes.buffer);
+  const payloadOffset = LASZIP_VLR_HEADER_LENGTH;
+
+  writeString(dataView, 2, 'laszip encoded', 16);
+  dataView.setUint16(18, 22204, true);
+  dataView.setUint16(20, payloadLength, true);
+  writeString(dataView, 22, 'loaders.gl LAZ writer', 32);
+  dataView.setUint16(payloadOffset, 3, true);
+  dataView.setUint16(payloadOffset + 2, 0, true);
+  dataView.setUint8(payloadOffset + 4, 3);
+  dataView.setUint8(payloadOffset + 5, 5);
+  dataView.setUint16(payloadOffset + 6, 1, true);
+  dataView.setUint32(payloadOffset + 8, 0, true);
+  dataView.setUint32(payloadOffset + 12, chunkSize, true);
+  bytes.fill(0xff, payloadOffset + 16, payloadOffset + 32);
+  dataView.setUint16(payloadOffset + 32, items.length, true);
+  for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
+    const itemOffset = payloadOffset + LASZIP_VLR_PAYLOAD_BASE_LENGTH + itemIndex * 6;
+    const item = items[itemIndex];
+    dataView.setUint16(itemOffset, item.type, true);
+    dataView.setUint16(itemOffset + 2, item.size, true);
+    dataView.setUint16(itemOffset + 4, 3, true);
+  }
+  return bytes;
+}
+
+/** Return LASzip item descriptors for one supported point format. */
+function getLASzipItems(
+  pointDataRecordFormat: number,
+  pointDataRecordLength: number
+): LASzipItem[] {
+  const items = [{type: 10, size: 30}];
+  if (pointDataRecordFormat === 7) {
+    items.push({type: 11, size: 6});
+  } else if (pointDataRecordFormat === 8) {
+    items.push({type: 12, size: 8});
+  }
+  const extraByteCount = pointDataRecordLength - POINT_RECORD_LENGTHS[pointDataRecordFormat];
+  if (extraByteCount > 0) {
+    items.push({type: 14, size: extraByteCount});
+  }
+  return items;
+}
+
+/** Validate the intentionally narrow LAZ container writer surface. */
+function validateLAZOptions(
+  version: string,
+  pointDataRecordFormat: number,
+  chunkSize?: number
+): void {
+  if (version !== '1.4') {
+    throw new Error(`LASWriter: LAZ output requires LAS 1.4; received ${version}`);
+  }
+  if (![6, 7, 8].includes(pointDataRecordFormat)) {
+    throw new Error(
+      `LASWriter: LAZ output only supports point data record formats 6-8; received ${pointDataRecordFormat}`
+    );
+  }
+  if (
+    chunkSize !== undefined &&
+    (!Number.isInteger(chunkSize) || chunkSize <= 0 || chunkSize > 0xffffffff)
+  ) {
+    throw new Error(`LASWriter: invalid LAZ chunk size ${chunkSize}`);
+  }
 }
 
 /** Return mesh data as a Mesh, converting MeshArrowTable input first. */
@@ -205,15 +390,13 @@ function getRequiredAttribute(mesh: Mesh, attributeName: string): MeshAttribute 
 /** Write the LAS 1.2 public header block. */
 function writeHeader(
   dataView: DataView,
-  parameters: {
-    vertexCount: number;
-    boundingBox: [[number, number, number], [number, number, number]];
-    scale: [number, number, number];
-    offset: [number, number, number];
-    version: '1.0' | '1.1' | '1.2' | '1.3' | '1.4';
-    headerLength: number;
-    pointDataRecordFormat: number;
-    pointDataRecordLength: number;
+  parameters: LASWriteParameters & {
+    /** Absolute point-data byte offset. */
+    pointDataOffset: number;
+    /** Number of VLR records before point data. */
+    vlrCount?: number;
+    /** Whether the point format byte carries the LASzip compression flag. */
+    compressed?: boolean;
   }
 ): void {
   const [versionMajor, versionMinor] = parameters.version.split('.').map(Number);
@@ -223,8 +406,9 @@ function writeHeader(
   writeString(dataView, 26, 'loaders.gl', 32);
   writeString(dataView, 58, 'loaders.gl', 32);
   dataView.setUint16(94, parameters.headerLength, true);
-  dataView.setUint32(96, parameters.headerLength, true);
-  dataView.setUint8(104, parameters.pointDataRecordFormat);
+  dataView.setUint32(96, parameters.pointDataOffset, true);
+  dataView.setUint32(100, parameters.vlrCount || 0, true);
+  dataView.setUint8(104, parameters.pointDataRecordFormat | (parameters.compressed ? 0x80 : 0));
   dataView.setUint16(105, parameters.pointDataRecordLength, true);
   dataView.setUint32(107, parameters.version === '1.4' ? 0 : parameters.vertexCount, true);
   dataView.setUint32(111, parameters.version === '1.4' ? 0 : parameters.vertexCount, true);
@@ -345,7 +529,7 @@ function getDefaultPointDataRecordFormat(
   options: LASWriterOptions,
   colorAttribute?: MeshAttribute
 ): number {
-  if (options.las?.version === '1.4') {
+  if (options.las?.format === 'laz' || options.las?.version === '1.4') {
     return colorAttribute ? 7 : 6;
   }
   return colorAttribute ? 2 : 0;

--- a/modules/las/src/las-writer.ts
+++ b/modules/las/src/las-writer.ts
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {
+  encodeLASzipVLR,
   encodeLAZChunk,
   encodeLAZChunkTable,
   type LAZChunkTableEntry,
@@ -19,8 +20,6 @@ const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
 const LAS_HEADER_LENGTH = 227;
 const LAS_1_4_HEADER_LENGTH = 375;
-const LASZIP_VLR_HEADER_LENGTH = 54;
-const LASZIP_VLR_PAYLOAD_BASE_LENGTH = 34;
 const DEFAULT_LAZ_CHUNK_SIZE = 50_000;
 const POINT_RECORD_LENGTHS: Record<number, number> = {
   0: 20,
@@ -173,14 +172,6 @@ type LASWriteParameters = {
   pointDataRecordLength: number;
 };
 
-/** One LASzip item descriptor written into the codec VLR. */
-type LASzipItem = {
-  /** LASzip item type identifier. */
-  type: number;
-  /** Uncompressed item byte length. */
-  size: number;
-};
-
 /** Assemble raw LAS point records into a complete fixed-chunk LAZ file. */
 function encodeLAZFile(
   rawPointData: Uint8Array,
@@ -188,11 +179,11 @@ function encodeLAZFile(
   requestedChunkSize?: number
 ): ArrayBuffer {
   const chunkSize = requestedChunkSize || DEFAULT_LAZ_CHUNK_SIZE;
-  const laszipVLR = createLASzipVLR(
-    parameters.pointDataRecordFormat,
-    parameters.pointDataRecordLength,
+  const laszipVLR = encodeLASzipVLR({
+    pointDataRecordFormat: parameters.pointDataRecordFormat,
+    pointDataRecordLength: parameters.pointDataRecordLength,
     chunkSize
-  );
+  });
   const pointDataOffset = parameters.headerLength + laszipVLR.byteLength;
   const compressedChunks: Uint8Array[] = [];
   const chunkTableEntries: LAZChunkTableEntry[] = [];
@@ -242,59 +233,6 @@ function encodeLAZFile(
   dataView.setUint32(chunkTableOffset + 4, chunkTableEntries.length, true);
   bytes.set(chunkTablePayload, chunkTableOffset + 8);
   return arrayBuffer;
-}
-
-/** Create the LASzip VLR for a layered LAS 1.4 point layout. */
-function createLASzipVLR(
-  pointDataRecordFormat: number,
-  pointDataRecordLength: number,
-  chunkSize: number
-): Uint8Array {
-  const items = getLASzipItems(pointDataRecordFormat, pointDataRecordLength);
-  const payloadLength = LASZIP_VLR_PAYLOAD_BASE_LENGTH + items.length * 6;
-  const bytes = new Uint8Array(LASZIP_VLR_HEADER_LENGTH + payloadLength);
-  const dataView = new DataView(bytes.buffer);
-  const payloadOffset = LASZIP_VLR_HEADER_LENGTH;
-
-  writeString(dataView, 2, 'laszip encoded', 16);
-  dataView.setUint16(18, 22204, true);
-  dataView.setUint16(20, payloadLength, true);
-  writeString(dataView, 22, 'loaders.gl LAZ writer', 32);
-  dataView.setUint16(payloadOffset, 3, true);
-  dataView.setUint16(payloadOffset + 2, 0, true);
-  dataView.setUint8(payloadOffset + 4, 3);
-  dataView.setUint8(payloadOffset + 5, 5);
-  dataView.setUint16(payloadOffset + 6, 1, true);
-  dataView.setUint32(payloadOffset + 8, 0, true);
-  dataView.setUint32(payloadOffset + 12, chunkSize, true);
-  bytes.fill(0xff, payloadOffset + 16, payloadOffset + 32);
-  dataView.setUint16(payloadOffset + 32, items.length, true);
-  for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
-    const itemOffset = payloadOffset + LASZIP_VLR_PAYLOAD_BASE_LENGTH + itemIndex * 6;
-    const item = items[itemIndex];
-    dataView.setUint16(itemOffset, item.type, true);
-    dataView.setUint16(itemOffset + 2, item.size, true);
-    dataView.setUint16(itemOffset + 4, 3, true);
-  }
-  return bytes;
-}
-
-/** Return LASzip item descriptors for one supported point format. */
-function getLASzipItems(
-  pointDataRecordFormat: number,
-  pointDataRecordLength: number
-): LASzipItem[] {
-  const items = [{type: 10, size: 30}];
-  if (pointDataRecordFormat === 7) {
-    items.push({type: 11, size: 6});
-  } else if (pointDataRecordFormat === 8) {
-    items.push({type: 12, size: 8});
-  }
-  const extraByteCount = pointDataRecordLength - POINT_RECORD_LENGTHS[pointDataRecordFormat];
-  if (extraByteCount > 0) {
-    items.push({type: 14, size: extraByteCount});
-  }
-  return items;
 }
 
 /** Validate the intentionally narrow LAZ container writer surface. */

--- a/modules/las/src/las-writer.ts
+++ b/modules/las/src/las-writer.ts
@@ -37,8 +37,8 @@ const POINT_RECORD_LENGTHS: Record<number, number> = {
 export type LASWriterOptions = WriterOptions & {
   /** LAS-specific writer options. */
   las?: {
-    /** Output container format. COPC writing is not yet implemented. */
-    format?: 'las' | 'laz' | 'copc';
+    /** Output container format. COPC has its own writer in @loaders.gl/copc. */
+    format?: 'las' | 'laz';
     /** LAS file version to write. LAS 1.5 writing is intentionally not supported. */
     version?: '1.0' | '1.1' | '1.2' | '1.3' | '1.4';
     /** LAS point data record format to write. */
@@ -80,10 +80,6 @@ export const LASWriter = {
 /** Encode mesh category data as LAS or LAZ bytes. */
 function encodeLASSync(data: Mesh | MeshArrowTable, options: LASWriterOptions = {}): ArrayBuffer {
   const format = options.las?.format || 'las';
-  if (format === 'copc') {
-    throw new Error('LASWriter: TypeScript COPC encoding is not implemented yet');
-  }
-
   const mesh = normalizeMesh(data);
   const positionAttribute = getRequiredAttribute(mesh, 'POSITION');
   const colorAttribute = mesh.attributes.COLOR_0;

--- a/modules/las/test/las-writer.spec.ts
+++ b/modules/las/test/las-writer.spec.ts
@@ -7,6 +7,7 @@ import {validateWriter, validateMeshCategoryData} from 'test/common/conformance'
 
 import {LASCOPCLoader, LASLoader, LASWriter} from '@loaders.gl/las';
 import {encode, parse} from '@loaders.gl/core';
+import {decodeLAZChunkTable} from '@loaders.gl/loader-utils';
 import {convertMeshToTable, deduceMeshSchema} from '@loaders.gl/schema-utils';
 
 const attributes = {
@@ -77,11 +78,83 @@ test('LASWriter#encode LAS 1.4 point format 7', async t => {
   t.end();
 });
 
-test('LASWriter#rejects compressed formats until TypeScript encoder is complete', t => {
+test('LASWriter#encodes fixed-chunk LAZ point formats 6-8', async t => {
+  for (const pointDataRecordFormat of [6, 7, 8] as const) {
+    const arrayBuffer = await encode(mesh, LASWriter, {
+      las: {format: 'laz', pointDataRecordFormat, chunkSize: 2}
+    });
+    const dataView = new DataView(arrayBuffer);
+    const pointDataOffset = dataView.getUint32(96, true);
+    const chunkTableOffset = readUint64(dataView, pointDataOffset);
+    const chunkCount = dataView.getUint32(chunkTableOffset + 4, true);
+    const chunks = decodeLAZChunkTable(new Uint8Array(arrayBuffer, chunkTableOffset + 8), {
+      chunkCount,
+      pointCount: 3,
+      chunkSize: 2,
+      variable: false
+    });
+    const data = await parse(arrayBuffer, LASLoader, {core: {worker: false}});
+    const wasmData = await parse(arrayBuffer.slice(0), LASCOPCLoader, {
+      core: {worker: false}
+    });
+
+    t.equal(
+      dataView.getUint8(104),
+      0x80 | pointDataRecordFormat,
+      `PDRF ${pointDataRecordFormat} sets the compressed format flag`
+    );
+    t.equal(dataView.getUint32(100, true), 1, `PDRF ${pointDataRecordFormat} writes one VLR`);
+    t.equal(chunkCount, 2, `PDRF ${pointDataRecordFormat} writes two chunks`);
+    t.deepEqual(
+      chunks.map(chunk => chunk.pointCount),
+      [2, 1],
+      `PDRF ${pointDataRecordFormat} fixed chunk counts roundtrip`
+    );
+    t.equal(
+      chunks.reduce((byteLength, chunk) => byteLength + chunk.byteLength, 0),
+      chunkTableOffset - pointDataOffset - 8,
+      `PDRF ${pointDataRecordFormat} chunk sizes reach the table`
+    );
+    t.deepEqual(
+      Array.from(data.attributes.POSITION.value),
+      Array.from(wasmData.attributes.POSITION.value),
+      `PDRF ${pointDataRecordFormat} TypeScript positions match WASM`
+    );
+    t.deepEqual(
+      Array.from(data.attributes.intensity.value),
+      Array.from(wasmData.attributes.intensity.value),
+      `PDRF ${pointDataRecordFormat} TypeScript intensities match WASM`
+    );
+    t.deepEqual(
+      Array.from(data.attributes.classification.value),
+      Array.from(wasmData.attributes.classification.value),
+      `PDRF ${pointDataRecordFormat} TypeScript classifications match WASM`
+    );
+  }
+  t.end();
+});
+
+test('LASWriter#validates compressed output options', t => {
   t.throws(
-    () => LASWriter.encodeSync?.(mesh, {las: {format: 'laz'}}),
-    /LAZ encoding is not implemented/,
-    'LAZ writer fails clearly'
+    () =>
+      LASWriter.encodeSync?.(mesh, {
+        las: {format: 'laz', version: '1.2', pointDataRecordFormat: 6}
+      }),
+    /LAZ output requires LAS 1.4/,
+    'LAZ writer rejects legacy LAS versions'
+  );
+  t.throws(
+    () =>
+      LASWriter.encodeSync?.(mesh, {
+        las: {format: 'laz', version: '1.4', pointDataRecordFormat: 3}
+      }),
+    /only supports point data record formats 6-8/,
+    'LAZ writer rejects legacy point formats'
+  );
+  t.throws(
+    () => LASWriter.encodeSync?.(mesh, {las: {format: 'laz', chunkSize: 0}}),
+    /invalid LAZ chunk size/,
+    'LAZ writer rejects empty chunks'
   );
   t.throws(
     () => LASWriter.encodeSync?.(mesh, {las: {format: 'copc'}}),
@@ -111,3 +184,8 @@ test('LASWriter#preserves normalized byte colors', async t => {
   t.equal(dataView.getUint16(227 + 24, true), 0, 'blue channel preserves zero byte value');
   t.end();
 });
+
+/** Read a little-endian UInt64 that is known to fit in JavaScript's safe integer range. */
+function readUint64(dataView: DataView, byteOffset: number): number {
+  return dataView.getUint32(byteOffset, true) + dataView.getUint32(byteOffset + 4, true) * 2 ** 32;
+}

--- a/modules/las/test/las-writer.spec.ts
+++ b/modules/las/test/las-writer.spec.ts
@@ -156,11 +156,6 @@ test('LASWriter#validates compressed output options', t => {
     /invalid LAZ chunk size/,
     'LAZ writer rejects empty chunks'
   );
-  t.throws(
-    () => LASWriter.encodeSync?.(mesh, {las: {format: 'copc'}}),
-    /COPC encoding is not implemented/,
-    'COPC writer fails clearly'
-  );
   t.end();
 });
 

--- a/modules/loader-utils/src/index.ts
+++ b/modules/loader-utils/src/index.ts
@@ -181,6 +181,7 @@ export type {
 } from './lib/laz/laz-chunk-decoder';
 export {
   createLAZChunkEncoder,
+  encodeLASzipVLR,
   encodeLAZChunk,
   encodeLAZChunkTable
 } from './lib/laz/laz-chunk-encoder';

--- a/modules/loader-utils/src/index.ts
+++ b/modules/loader-utils/src/index.ts
@@ -179,7 +179,11 @@ export type {
   LAZChunkTableEntry,
   LAZPointDataTarget
 } from './lib/laz/laz-chunk-decoder';
-export {createLAZChunkEncoder, encodeLAZChunk} from './lib/laz/laz-chunk-encoder';
+export {
+  createLAZChunkEncoder,
+  encodeLAZChunk,
+  encodeLAZChunkTable
+} from './lib/laz/laz-chunk-encoder';
 export type {FeedableLAZChunkEncoder} from './lib/laz/laz-chunk-encoder';
 
 // PATH HELPERS

--- a/modules/loader-utils/src/lib/laz/laz-chunk-encoder.ts
+++ b/modules/loader-utils/src/lib/laz/laz-chunk-encoder.ts
@@ -13,6 +13,8 @@ import {
 } from './laz-arithmetic-encoder';
 
 const POINT_FORMAT_BASE_LENGTHS: Record<number, number> = {6: 30, 7: 36, 8: 38};
+const LASZIP_VLR_HEADER_LENGTH = 54;
+const LASZIP_VLR_PAYLOAD_BASE_LENGTH = 34;
 const GPS_TIME_MULTI = 500;
 const GPS_TIME_MULTI_MINUS = -10;
 const GPS_TIME_MULTI_CODE_FULL = 511;
@@ -188,6 +190,47 @@ export function encodeLAZChunkTable(
   return encoder.finish();
 }
 
+/** Encode a complete LASzip VLR for a supported layered point layout. */
+export function encodeLASzipVLR(options: {
+  /** LAS point data record format. */
+  pointDataRecordFormat: number;
+  /** Uncompressed byte length of each point record. */
+  pointDataRecordLength: number;
+  /** Fixed chunk size or `0xffffffff` for variable chunks. */
+  chunkSize: number;
+  /** LASzip item codec version. */
+  itemVersion?: 3;
+}): Uint8Array {
+  const itemVersion = options.itemVersion || 3;
+  const items = getLASzipItems(options.pointDataRecordFormat, options.pointDataRecordLength);
+  const payloadLength = LASZIP_VLR_PAYLOAD_BASE_LENGTH + items.length * 6;
+  const bytes = new Uint8Array(LASZIP_VLR_HEADER_LENGTH + payloadLength);
+  const dataView = new DataView(bytes.buffer);
+  const payloadOffset = LASZIP_VLR_HEADER_LENGTH;
+
+  writeString(dataView, 2, 'laszip encoded', 16);
+  dataView.setUint16(18, 22204, true);
+  dataView.setUint16(20, payloadLength, true);
+  writeString(dataView, 22, 'loaders.gl LAZ writer', 32);
+  dataView.setUint16(payloadOffset, 3, true);
+  dataView.setUint16(payloadOffset + 2, 0, true);
+  dataView.setUint8(payloadOffset + 4, 3);
+  dataView.setUint8(payloadOffset + 5, 5);
+  dataView.setUint16(payloadOffset + 6, 1, true);
+  dataView.setUint32(payloadOffset + 8, 0, true);
+  dataView.setUint32(payloadOffset + 12, options.chunkSize, true);
+  bytes.fill(0xff, payloadOffset + 16, payloadOffset + 32);
+  dataView.setUint16(payloadOffset + 32, items.length, true);
+  for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
+    const itemOffset = payloadOffset + LASZIP_VLR_PAYLOAD_BASE_LENGTH + itemIndex * 6;
+    const item = items[itemIndex];
+    dataView.setUint16(itemOffset, item.type, true);
+    dataView.setUint16(itemOffset + 2, item.size, true);
+    dataView.setUint16(itemOffset + 4, itemVersion, true);
+  }
+  return bytes;
+}
+
 type Point14 = {
   /** Quantized X coordinate. */
   x: number;
@@ -220,6 +263,14 @@ type Rgb14 = {
   green: number;
   /** Blue channel. */
   blue: number;
+};
+
+/** One LASzip item descriptor written into the codec VLR. */
+type LASzipItem = {
+  /** LASzip item type identifier. */
+  type: number;
+  /** Uncompressed item byte length. */
+  size: number;
 };
 
 /** Prediction state for one Point14 scanner channel. */
@@ -975,6 +1026,30 @@ function validateChunkTableEntry(chunk: LAZChunkTableEntry): void {
   }
 }
 
+/** Return LASzip item descriptors for one supported point format. */
+function getLASzipItems(
+  pointDataRecordFormat: number,
+  pointDataRecordLength: number
+): LASzipItem[] {
+  const baseLength = POINT_FORMAT_BASE_LENGTHS[pointDataRecordFormat];
+  if (!baseLength || pointDataRecordLength < baseLength) {
+    throw new Error(
+      `Invalid point record length ${pointDataRecordLength} for point format ${pointDataRecordFormat}`
+    );
+  }
+  const items: LASzipItem[] = [{type: 10, size: 30}];
+  if (pointDataRecordFormat === 7) {
+    items.push({type: 11, size: 6});
+  } else if (pointDataRecordFormat === 8) {
+    items.push({type: 12, size: 8});
+  }
+  const extraByteCount = pointDataRecordLength - baseLength;
+  if (extraByteCount > 0) {
+    items.push({type: 14, size: extraByteCount});
+  }
+  return items;
+}
+
 /** Parse a raw LAS 1.4 Point14 item. */
 function readPoint14(bytes: Uint8Array, offset: number): Point14 {
   const view = new DataView(bytes.buffer, bytes.byteOffset + offset, 30);
@@ -1070,4 +1145,16 @@ function concatenateUint8Arrays(chunks: Uint8Array[]): Uint8Array {
     offset += chunk.byteLength;
   }
   return result;
+}
+
+/** Write a fixed-length ASCII string into a DataView. */
+function writeString(
+  dataView: DataView,
+  byteOffset: number,
+  value: string,
+  byteLength: number
+): void {
+  for (let characterIndex = 0; characterIndex < byteLength; characterIndex++) {
+    dataView.setUint8(byteOffset + characterIndex, value.charCodeAt(characterIndex) || 0);
+  }
 }

--- a/modules/loader-utils/src/lib/laz/laz-chunk-encoder.ts
+++ b/modules/loader-utils/src/lib/laz/laz-chunk-encoder.ts
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import type {LAZChunkMetadata} from './laz-chunk-decoder';
+import type {LAZChunkTableEntry} from './laz-chunk-decoder';
 import {
   ArithmeticEncoder,
   ArithmeticModel,
@@ -155,6 +156,36 @@ export function encodeLAZChunk(
     sizeView.setUint32(4 + index * 4, layers[index].byteLength, true);
   }
   return concatenateUint8Arrays([firstRecord, sizeHeader, ...layers]);
+}
+
+/** Encode LASzip chunk-table entries as one arithmetic-coded payload. */
+export function encodeLAZChunkTable(
+  chunks: readonly LAZChunkTableEntry[],
+  options: {
+    /** Whether to include the point count for each variable-size chunk. */
+    variable?: boolean;
+  } = {}
+): Uint8Array {
+  if (chunks.length === 0) {
+    return new Uint8Array(0);
+  }
+
+  const encoder = new ArithmeticEncoder();
+  const compressor = new IntegerCompressor(encoder, 32, 2);
+  let pointCountPredictor = 0;
+  let byteLengthPredictor = 0;
+
+  for (const chunk of chunks) {
+    validateChunkTableEntry(chunk);
+    if (options.variable) {
+      compressor.compress(pointCountPredictor, chunk.pointCount, 0);
+      pointCountPredictor = chunk.pointCount;
+    }
+    compressor.compress(byteLengthPredictor, chunk.byteLength, 1);
+    byteLengthPredictor = chunk.byteLength;
+  }
+
+  return encoder.finish();
 }
 
 type Point14 = {
@@ -923,6 +954,24 @@ function validateMetadata(rawBytes: Uint8Array, metadata: LAZChunkMetadata): voi
     throw new Error(
       `LAZ chunk input has ${rawBytes.byteLength} bytes; expected ${expectedByteLength}`
     );
+  }
+}
+
+/** Validate one chunk-table entry before integer compression. */
+function validateChunkTableEntry(chunk: LAZChunkTableEntry): void {
+  if (
+    !Number.isInteger(chunk.pointCount) ||
+    chunk.pointCount <= 0 ||
+    chunk.pointCount > 0xffffffff
+  ) {
+    throw new Error(`Invalid LAZ chunk point count ${chunk.pointCount}`);
+  }
+  if (
+    !Number.isInteger(chunk.byteLength) ||
+    chunk.byteLength <= 0 ||
+    chunk.byteLength > 0xffffffff
+  ) {
+    throw new Error(`Invalid LAZ chunk byte length ${chunk.byteLength}`);
   }
 }
 

--- a/modules/loader-utils/test/lib/laz/laz-chunk-encoder.spec.ts
+++ b/modules/loader-utils/test/lib/laz/laz-chunk-encoder.spec.ts
@@ -6,7 +6,9 @@ import test from 'test/utils/vitest-tape';
 import {
   createLAZChunkEncoder,
   decodeLAZChunk,
+  decodeLAZChunkTable,
   encodeLAZChunk,
+  encodeLAZChunkTable,
   getLAZChunkByteLength
 } from '@loaders.gl/loader-utils';
 
@@ -82,6 +84,43 @@ test('LAZChunkEncoder#validates input and item versions', t => {
     () => encodeLAZChunk(rawPointData, {...metadata, point14ItemVersion: 4}),
     /only supports Point14 item version 3/,
     'unsupported Point14 versions are rejected'
+  );
+  t.end();
+});
+
+test('LAZChunkEncoder#encodes fixed and variable chunk tables', t => {
+  const chunks = [
+    {pointCount: 50_000, byteLength: 100_000},
+    {pointCount: 50_000, byteLength: 90_000},
+    {pointCount: 23, byteLength: 800}
+  ];
+  const fixedTable = encodeLAZChunkTable(chunks);
+  t.deepEqual(
+    decodeLAZChunkTable(fixedTable, {
+      chunkCount: chunks.length,
+      pointCount: 100_023,
+      chunkSize: 50_000,
+      variable: false
+    }),
+    chunks,
+    'fixed-size chunk table roundtrips'
+  );
+
+  const variableTable = encodeLAZChunkTable(chunks, {variable: true});
+  t.deepEqual(
+    decodeLAZChunkTable(variableTable, {
+      chunkCount: chunks.length,
+      pointCount: 100_023,
+      chunkSize: 0xffffffff,
+      variable: true
+    }),
+    chunks,
+    'variable-size chunk table roundtrips'
+  );
+  t.throws(
+    () => encodeLAZChunkTable([{pointCount: 0, byteLength: 1}]),
+    /Invalid LAZ chunk point count/,
+    'empty chunks are rejected'
   );
   t.end();
 });

--- a/website/src/components/docs/copc-docs-tabs.tsx
+++ b/website/src/components/docs/copc-docs-tabs.tsx
@@ -11,13 +11,14 @@ type CopcDocsTab = {
 };
 
 /** COPC documentation tab identifiers. */
-export type CopcDocsTabId = 'overview' | 'format' | 'source' | 'example';
+export type CopcDocsTabId = 'overview' | 'format' | 'source' | 'writer' | 'example';
 
 const COPC_DOCS_TABS: CopcDocsTab[] = [
   {id: 'example', label: 'Try It', href: '/examples/pointclouds/copc-source'},
   {id: 'overview', label: 'Overview', href: '/docs/modules/copc'},
   {id: 'format', label: 'Format', href: '/docs/modules/copc/formats/copc'},
-  {id: 'source', label: 'COPCSourceLoader', href: '/docs/modules/copc/api-reference/copc-source-loader'}
+  {id: 'source', label: 'COPCSourceLoader', href: '/docs/modules/copc/api-reference/copc-source-loader'},
+  {id: 'writer', label: 'COPCWriter', href: '/docs/modules/copc/api-reference/copc-writer'}
 ];
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -5270,6 +5270,7 @@ __metadata:
   resolution: "@loaders.gl/copc@workspace:modules/copc"
   dependencies:
     "@loaders.gl/images": "npm:5.0.0-alpha.2"
+    "@loaders.gl/las": "npm:5.0.0-alpha.2"
     "@loaders.gl/loader-utils": "npm:5.0.0-alpha.2"
     "@loaders.gl/mvt": "npm:5.0.0-alpha.2"
     "@loaders.gl/schema": "npm:5.0.0-alpha.2"


### PR DESCRIPTION
## Goals

- Recover .laz file writing on top of current master.
- Add a range-readable COPCWriter.
- Keep the LAS and COPC public APIs acyclic and explicit.

## Changes

- Restore LASWriter LAZ output for LAS 1.4 PDRF 6-8.
- Emit LASzip VLR metadata, fixed-size or variable-size chunks, and chunk tables.
- Add optional WKT VLR metadata for LAS and LAZ output.
- Add LAZ writer round-trip tests against TypeScript and WASM decoders.
- Implement COPCWriter with independent LAZ node chunks, COPC info VLR, hierarchy EVLR, variable chunk tables, WKT support, and deterministic octree organization.
- Add exact range-request and Blob-backed COPC coverage.
- Make LASWriter own LAS/LAZ output; use COPCWriter for COPC output.
- Update LAS and COPC documentation and package dependencies.

## Validation

- yarn build passed.
- yarn test-node passed: 194 passed, 6 skipped.
- Focused Chromium writer suites passed: 11 LAZ/WKT tests, plus 21 combined writer tests before this tranche.
- yarn lint fix passed.
- Full Chromium suite has unrelated worker-bundle failures: 94 failed, 1,969 passed.

This is the single consolidated branch for the LAZ recovery, additional LAZ table/WKT support, and the COPC writer work.