### PR TITLE
feat(las): expose GPS time and NIR Arrow columns

### DIFF
--- a/docs/modules/las/README.md
+++ b/docs/modules/las/README.md
@@ -2,7 +2,7 @@
 
 The `@loaders.gl/las` module supports the [LASER file format](/docs/modules/las/formats/las) (LAS) and its compressed version (LAZ).
 
-`LASLoader` supports LAZ point formats 0-10 for documented LASzip codec combinations. Arrow output exposes positions, intensity, classification, and RGB, while the raw APIs preserve complete supported point records. See the [LAS/LAZ implementation limits](/docs/modules/las/formats/las#current-implementation-limits) for exact codec, point-format, fixture, and streaming details.
+`LASLoader` supports LAZ point formats 0-10 for documented LASzip codec combinations. Arrow output exposes positions, intensity, classification, RGB, GPS time, and NIR where present, while the raw APIs preserve complete supported point records. See the [LAS/LAZ implementation limits](/docs/modules/las/formats/las#current-implementation-limits) for exact codec, point-format, fixture, and streaming details.
 
 ## Installation
 

--- a/docs/modules/las/api-reference/las-loader.md
+++ b/docs/modules/las/api-reference/las-loader.md
@@ -20,7 +20,8 @@ const data = await load(url, LASLoader, options);
 const table = await load(url, LASLoader, {
   las: {
     ...options?.las,
-    shape: 'arrow-table'
+    shape: 'arrow-table',
+    columns: ['POSITION', 'COLOR_0']
   }
 });
 ```
@@ -54,6 +55,7 @@ selective field decoding, direct typed output, memory copies, and module startup
 | `options.las.shape`      | `string`             | `mesh`     | Format of parsed data, e.g: `'mesh'`, `'columnar-table'`, `'arrow-table'`.                                                                                       |
 | `options.las.fp64`       | `number`             | `false`    | If `true`, positions are stored in 64-bit floats instead of 32-bit.                                                                                              |
 | `options.las.colorDepth` | `number` or `string` | `8`        | Whether colors encoded using 8 or 16 bits? Can be set to `'auto'`. Note: LAS specification recommends 16 bits.                                                   |
+| `options.las.columns`    | `string[]`           | all        | Arrow columns to decode: `POSITION`, `intensity`, `classification`, `COLOR_0`, `GPS_TIME`, and `NIR`. `POSITION` is always returned; an empty array requests positions only. |
 | `options.las.workerUrl`  | `string`             | -          | Overrides the packaged `LASLoader` worker. Supplying a URL for another LAS loader opts that loader into an application-built worker.                            |
 | `options.onProgress`     | `function`           | -          | Callback when a new chunk of data is read. Only works on the main thread.                                                                                        |
 
@@ -67,6 +69,8 @@ Applications that need a compatibility loader in a worker can build one and prov
 
 ## TypeScript LAZ Streaming
 
-`LASLoader.parseInBatches` consumes compressed LAZ input incrementally. Legacy interleaved PDRF 0-5 chunks can emit complete Arrow batches before the current compressed chunk or file has finished arriving. PDRF 6-10 table parsing emits after complete layered LAZ chunks are available and selectively decodes only the field layers represented by the returned Arrow schema. Complete-buffer `parse` uses the same direct-column path instead of allocating and reparsing complete raw records. Legacy Point10/GPS/RGB/Byte item version 2, WavePacket13 item version 1, and modern item versions 2-4 are supported. Legacy LASzip item version 1 uses a different codec and is rejected. NIR, PDRF 4/5/9/10 waveform packet references, and Extra Bytes remain available only through raw-record decoding because they are not yet represented in the returned Arrow schema. Waveform sample payloads referenced by those records are not loaded. The raw chunk decoder remains available when complete LAS point records, including currently unexposed fields, are required.
+`LASLoader.parseInBatches` consumes compressed LAZ input incrementally. Legacy interleaved PDRF 0-5 chunks can emit complete Arrow batches before the current compressed chunk or file has finished arriving. PDRF 6-10 table parsing emits after complete layered LAZ chunks are available and selectively decodes only the field layers requested by `las.columns`. Complete-buffer `parse` uses the same direct-column path instead of allocating and reparsing complete raw records. Legacy Point10/GPS/RGB/Byte item version 2, WavePacket13 item version 1, and modern item versions 2-4 are supported. Legacy LASzip item version 1 uses a different codec and is rejected. `GPS_TIME` and `NIR` are available as typed Arrow columns for records that contain them. PDRF 4/5/9/10 waveform packet references and Extra Bytes remain available only through raw-record decoding because they are not yet represented in the returned Arrow schema. Waveform sample payloads referenced by those records are not loaded. The raw chunk decoder remains available when complete LAS point records, including currently unexposed fields, are required.
+
+For layered PDRF 6-10 chunks, omitted intensity, classification, RGB, GPS time, and NIR columns do not allocate output arrays or construct arithmetic decoders for those independent layers. Legacy PDRF 0-5 fields share an interleaved entropy stream, so column selection avoids output allocation and extraction but cannot skip the corresponding entropy decoding.
 
 Legacy point-level progress uses bounded geometric replay: when more compressed bytes arrive, the decoder replays previously emitted points through a record-sized scratch buffer and writes only new points into reusable output batches. This avoids committing partially mutated arithmetic state and bounds retry work to a linear factor of the compressed chunk size, but it retains the compressed chunk until completion. Layered PDRF 6-10 remains chunk-streaming because its independent field ranges must be available before complete rows can be assembled. Variable-size chunk point counts are stored in the LASzip chunk table at EOF, so a forward-only variable-chunk input is buffered until the table is available. See the [LAS/LAZ format implementation limits](/docs/modules/las/formats/las#current-implementation-limits) for supported point formats and remaining limitations.

--- a/docs/modules/las/formats/las.md
+++ b/docs/modules/las/formats/las.md
@@ -31,9 +31,9 @@ LAS file versions and LASzip codec versions are independent. A claim such as "LA
 | --- | --- |
 | Uncompressed LAS 1.0-1.4 | Partial. Reads common public-header fields and PDRF 0-10 record layouts. Dedicated conformance fixtures do not yet cover every header version/PDRF combination. |
 | LAS 1.5 | Partial. Extended point counts and PDRF 9/10 files are fixture-tested; LAS 1.5 metadata and conformance rules are not complete. |
-| Arrow columns | `POSITION`, `intensity`, `classification`, and `COLOR_0` for RGB formats. |
-| GPS time | Parsed only indirectly by format layout today; not exposed as a first-class attribute by the TypeScript path. |
-| NIR | Not exposed as a first-class attribute. |
+| Arrow columns | `POSITION`, `intensity`, `classification`, `COLOR_0`, `GPS_TIME`, and `NIR` where present. `las.columns` selects optional output columns; `POSITION` is always returned. |
+| GPS time | Exposed as `GPS_TIME` for PDRF 1, 3-5, and 6-10. |
+| NIR | Exposed as `NIR` for PDRF 8 and 10. |
 | Return flags, scanner channel, scan angle, point source ID, user data | Incomplete. |
 | Waveform packet fields | PDRF 4/5/9/10 packet references are preserved by the raw TypeScript LAZ APIs but are not exposed as Arrow columns. Waveform payload handling is not implemented. |
 | Extra bytes | Raw record length is respected, but Extra Bytes VLR metadata is not mapped to output attributes. |
@@ -87,16 +87,16 @@ LAS file versions and LASzip codec versions are independent. A claim such as "LA
 | PDRF | Valid LAS versions | Raw LAZ decode | Arrow output | Dedicated fixture coverage |
 | --- | --- | --- | --- | --- |
 | 0 | 1.0-1.4 | Supported for the legacy codec combination above. | XYZ, intensity, classification. | Synthetic chunk unit test. |
-| 1 | 1.1-1.4 | Supported for the legacy codec combination above. | XYZ, intensity, classification; GPS time omitted. | Synthetic chunk unit test. |
+| 1 | 1.1-1.4 | Supported for the legacy codec combination above. | XYZ, intensity, classification, `GPS_TIME`. | Synthetic chunk unit test. |
 | 2 | 1.2-1.4 | Supported for the legacy codec combination above. | XYZ, intensity, classification, RGB. | Synthetic chunk unit test. |
-| 3 | 1.2-1.4 | Supported for the legacy codec combination above. | XYZ, intensity, classification, RGB; GPS time omitted. | Full-file parity with laz-rs on two LAS 1.2 files. |
-| 4 | 1.3-1.4 | Supported, including WavePacket13 and Extra Bytes. | XYZ, intensity, classification; GPS time and waveform reference omitted. | Byte-for-byte paired LAS/LAZ fixture. |
-| 5 | 1.3-1.4 | Supported, including RGB, WavePacket13, and Extra Bytes. | XYZ, intensity, classification, RGB; GPS time and waveform reference omitted. | Byte-for-byte paired LAS/LAZ fixture. |
-| 6 | 1.4-1.5 | Supported for Point14 item versions 2-4. | XYZ, intensity, classification. | LAS 1.4 byte parity plus COPC decoder parity. |
-| 7 | 1.4-1.5 | Supported for Point14/RGB14 item versions 2-4. | XYZ, intensity, classification, RGB. | LAS 1.4 v3 decoder parity and v4 byte parity across all scanner channels. |
-| 8 | 1.4-1.5 | Supported for Point14/RGBNIR14 item versions 2-4. | XYZ, intensity, classification, RGB; NIR omitted. | LAS 1.4 byte parity including NIR and Extra Bytes. |
-| 9 | 1.4-1.5 | Supported, including WavePacket14 versions 3-4 and exact 64-bit offsets. | XYZ, intensity, classification; waveform reference omitted. | LAS 1.4/v3 and LAS 1.5/v4 byte parity. |
-| 10 | 1.4-1.5 | Supported, including RGB, NIR, WavePacket14 versions 3-4, and exact 64-bit offsets. | XYZ, intensity, classification, RGB; NIR and waveform reference omitted. | LAS 1.4/v3 and LAS 1.5/v4 byte parity. |
+| 3 | 1.2-1.4 | Supported for the legacy codec combination above. | XYZ, intensity, classification, RGB, `GPS_TIME`. | Full-file parity with laz-rs on two LAS 1.2 files. |
+| 4 | 1.3-1.4 | Supported, including WavePacket13 and Extra Bytes. | XYZ, intensity, classification, `GPS_TIME`; waveform reference omitted. | Byte-for-byte paired LAS/LAZ fixture. |
+| 5 | 1.3-1.4 | Supported, including RGB, WavePacket13, and Extra Bytes. | XYZ, intensity, classification, RGB, `GPS_TIME`; waveform reference omitted. | Byte-for-byte paired LAS/LAZ fixture. |
+| 6 | 1.4-1.5 | Supported for Point14 item versions 2-4. | XYZ, intensity, classification, `GPS_TIME`. | LAS 1.4 byte parity plus COPC decoder parity. |
+| 7 | 1.4-1.5 | Supported for Point14/RGB14 item versions 2-4. | XYZ, intensity, classification, RGB, `GPS_TIME`. | LAS 1.4 v3 decoder parity and v4 byte parity across all scanner channels. |
+| 8 | 1.4-1.5 | Supported for Point14/RGBNIR14 item versions 2-4. | XYZ, intensity, classification, RGB, `GPS_TIME`, `NIR`. | LAS 1.4 byte parity including NIR and Extra Bytes. |
+| 9 | 1.4-1.5 | Supported, including WavePacket14 versions 3-4 and exact 64-bit offsets. | XYZ, intensity, classification, `GPS_TIME`; waveform reference omitted. | LAS 1.4/v3 and LAS 1.5/v4 byte parity. |
+| 10 | 1.4-1.5 | Supported, including RGB, NIR, WavePacket14 versions 3-4, and exact 64-bit offsets. | XYZ, intensity, classification, RGB, `GPS_TIME`, `NIR`; waveform reference omitted. | LAS 1.4/v3 and LAS 1.5/v4 byte parity. |
 
 #### Streaming Granularity
 
@@ -110,15 +110,17 @@ LAS file versions and LASzip codec versions are independent. A claim such as "LA
 
 #### Selective LAZ 1.4 Decoding
 
-For complete-buffer `parse` and streaming `parseInBatches`, the TypeScript parser writes positions, intensity, classification, and RGB values directly into Arrow column buffers. PDRF 6-10 store groups of fields in independent compressed layers. The parser therefore avoids arithmetic decoding for scan flags, scan angle, user data, point source ID, GPS time, NIR, waveform packet references, and Extra Bytes layers that are not represented in the returned table.
+For complete-buffer `parse` and streaming `parseInBatches`, the TypeScript parser writes requested positions, intensity, classification, RGB, GPS time, and NIR values directly into Arrow column buffers. `las.columns` accepts `POSITION`, `intensity`, `classification`, `COLOR_0`, `GPS_TIME`, and `NIR`; positions remain mandatory for point-cloud output. Omitting the option returns all represented fields, while an empty array returns positions only.
 
-The direct chunk target is more selective: intensity, classification, and RGB arrays are optional, and omitted layers are skipped without constructing their arithmetic decoders or models. The COPC rendering path uses this to request positions and RGB only, avoiding unused intensity and classification allocations and decompression.
+PDRF 6-10 store groups of fields in independent compressed layers. Omitted intensity, classification, RGB, GPS time, and NIR layers are skipped without allocating their output arrays or constructing their arithmetic decoders and models. The parser also avoids arithmetic decoding for scan flags, scan angle, user data, point source ID, waveform packet references, and Extra Bytes layers that are not represented in the returned table. The COPC rendering path uses the same direct target to request positions and RGB only.
+
+Legacy PDRF 0-5 fields share an interleaved entropy stream. Column selection still avoids output arrays, color-depth detection, and field extraction for omitted columns, but it cannot skip the corresponding entropy decoding.
 
 Compressed field layers are decoded as bounded ranges of the original chunk instead of copied into per-layer readers. LASzip v3's historical item-context channel behavior is preserved separately from each point's actual scanner channel, while LASzip v4 uses the corrected context-switch behavior declared by each item in the LASzip VLR. These details reduce temporary allocation and property lookup overhead without changing the complete-record APIs.
 
 `decodeLAZChunk()` and the raw cursor API continue to decode every field and return complete LAS point records byte-for-byte. A cursor cannot switch between raw and selective output, or change its selected fields, after decoding starts because skipped arithmetic streams cannot be resumed at the corresponding point.
 
-Dedicated PDRF 4-10 fixtures compare every raw decoded byte and every represented Arrow attribute against matching uncompressed LAS records. LASzip-generated PDRF 4/5 fixtures validate legacy WavePacket13 and PDRF 5 field ordering. A current-LASzip PDRF 7 fixture verifies Point14, RGB14, and Byte14 item version 4 across all four scanner-channel contexts while retaining a LAS 1.4 header. The bundled COPC decoder misdecodes that fixture's RGB values after scanner-channel changes, and bundled laz-rs rejects item version 4, so current LASzip plus uncompressed LAS provide its correctness oracle. PDRF 8 coverage includes NIR, Extra Bytes, and scanner-channel transitions. PDRF 9/10 coverage exercises all waveform-offset predictor modes, exact 64-bit offsets above `Number.MAX_SAFE_INTEGER`, packet sizes, float vector fields, and Extra Bytes. LASzip-generated LAS 1.5 PDRF 9/10 fixtures additionally verify item version 4 across all four scanner-channel contexts. NIR, waveform references, and Extra Bytes are preserved by raw decoding but are not yet exposed as Arrow columns.
+Dedicated PDRF 4-10 fixtures compare every raw decoded byte and every represented Arrow attribute against matching uncompressed LAS records. LASzip-generated PDRF 4/5 fixtures validate legacy WavePacket13 and PDRF 5 field ordering. A current-LASzip PDRF 7 fixture verifies Point14, RGB14, and Byte14 item version 4 across all four scanner-channel contexts while retaining a LAS 1.4 header. The bundled COPC decoder misdecodes that fixture's RGB values after scanner-channel changes, and bundled laz-rs rejects item version 4, so current LASzip plus uncompressed LAS provide its correctness oracle. PDRF 8 coverage includes NIR, GPS time, Extra Bytes, and scanner-channel transitions. PDRF 9/10 coverage exercises all waveform-offset predictor modes, exact 64-bit offsets above `Number.MAX_SAFE_INTEGER`, packet sizes, float vector fields, GPS time, NIR, and Extra Bytes. LASzip-generated LAS 1.5 PDRF 9/10 fixtures additionally verify item version 4 across all four scanner-channel contexts. Waveform references and Extra Bytes are preserved by raw decoding but are not yet exposed as Arrow columns.
 
 ### TypeScript COPC Path
 

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -51,6 +51,7 @@ Release Date: 2026
 
 - [`LASWriter`](/docs/modules/las/api-reference/las-writer) NEW -writes uncompressed LAS point cloud data.
 - [`LASLoader`](/docs/modules/las/api-reference/las-loader) now uses the pure TypeScript implementation and ships the only prebuilt LAS worker. Compatibility loaders are available through explicit imports and can use an application-provided `las.workerUrl`.
+- `LASLoader` adds `las.columns` projection for Arrow point attributes. Layered PDRF 6-10 LAZ input skips omitted intensity, classification, RGB, GPS time, and NIR decoder layers and output allocations.
 
 **@loaders.gl/obj**
 

--- a/modules/las/src/index.ts
+++ b/modules/las/src/index.ts
@@ -6,7 +6,7 @@
 
 export {LASFormat} from './las-format';
 
-export type {LASLoaderOptions} from './las-loader-types';
+export type {LASColumnName, LASLoaderOptions} from './las-loader-types';
 
 export type {LASWriterOptions} from './las-writer';
 export {LASWriter} from './las-writer';

--- a/modules/las/src/las-loader-shared.ts
+++ b/modules/las/src/las-loader-shared.ts
@@ -11,6 +11,15 @@ import type {LASMesh} from './lib/las-types';
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
 const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
+/** Arrow column names that can be selected from LAS point records. */
+export type LASColumnName =
+  | 'POSITION'
+  | 'intensity'
+  | 'classification'
+  | 'COLOR_0'
+  | 'GPS_TIME'
+  | 'NIR';
+
 /** Options accepted by LAS loader implementations. */
 export type LASLoaderOptions = LoaderOptions & {
   las?: {
@@ -20,6 +29,8 @@ export type LASLoaderOptions = LoaderOptions & {
     fp64?: boolean;
     /** Output color depth or automatic source-depth detection. */
     colorDepth?: number | string;
+    /** Arrow columns to decode. POSITION is always included. */
+    columns?: readonly LASColumnName[];
     /** Override the URL to the worker bundle. */
     workerUrl?: string;
   };
@@ -40,7 +51,8 @@ export const LAS_LOADER_METADATA = {
     las: {
       shape: 'mesh',
       fp64: false,
-      colorDepth: 8
+      colorDepth: 8,
+      columns: undefined
     }
   }
 } as const satisfies Loader<LASMesh | MeshArrowTable, LASMesh | MeshArrowTable, LASLoaderOptions>;

--- a/modules/las/src/las-loader-types.ts
+++ b/modules/las/src/las-loader-types.ts
@@ -7,7 +7,7 @@ import type {MeshArrowTable} from '@loaders.gl/schema';
 import type {LASMesh} from './lib/las-types';
 import {LAS_LOADER_METADATA, type LASLoaderOptions} from './las-loader-shared';
 
-export type {LASLoaderOptions} from './las-loader-shared';
+export type {LASColumnName, LASLoaderOptions} from './las-loader-shared';
 
 /** Preloads the parser-bearing primary TypeScript LAS loader implementation. */
 async function preload() {

--- a/modules/las/src/lib/typescript/parse-las.ts
+++ b/modules/las/src/lib/typescript/parse-las.ts
@@ -94,11 +94,14 @@ type RawPointBatchState = {
 };
 
 type PointDataBatchState = {
+  batchCapacity: number;
   positions: Float32Array | Float64Array;
   colors: Uint8Array | null;
   rawColors: Uint16Array | null;
-  intensities: Uint16Array;
-  classifications: Uint8Array;
+  intensities: Uint16Array | null;
+  classifications: Uint8Array | null;
+  gpsTimes: Float64Array | null;
+  nir: Uint16Array | null;
   target: LAZPointDataTarget;
   batchPointCount: number;
   totalRead: number;
@@ -218,7 +221,9 @@ function parseCompleteLAZFileToArrowTable(
     state.positions,
     colors,
     state.intensities,
-    state.classifications
+    state.classifications,
+    state.gpsTimes,
+    state.nir
   );
 }
 
@@ -814,15 +819,26 @@ function parseLASArrowTableBatch(
   const batchSize = lasHeader.pointsCount;
   const PositionsType = options.las?.fp64 ? Float64Array : Float32Array;
   const positions = new PositionsType(batchSize * 3);
-  const colors = lasHeader.hasColor ? new Uint8Array(batchSize * 4) : null;
-  const intensities = new Uint16Array(batchSize);
-  const classifications = new Uint8Array(batchSize);
+  const selection = getLASColumnSelection(options);
+  const colors = lasHeader.hasColor && selection.color ? new Uint8Array(batchSize * 4) : null;
+  const intensities = selection.intensity ? new Uint16Array(batchSize) : null;
+  const classifications = selection.classification ? new Uint8Array(batchSize) : null;
+  const gpsTimes =
+    selection.gpsTime && getGpsTimeOffset(lasHeader.pointsFormatId) >= 0
+      ? new Float64Array(batchSize)
+      : null;
+  const nir =
+    selection.nir && getNirOffset(lasHeader.pointsFormatId) >= 0
+      ? new Uint16Array(batchSize)
+      : null;
 
   populateLASAttributesFromDataView(makeDataView(arrayBuffer), lasHeader, options, {
     positions,
     colors,
     intensities,
     classifications,
+    gpsTimes,
+    nir,
     pointOffset: 0,
     sourcePointIndex: 0,
     pointCount: batchSize
@@ -833,7 +849,9 @@ function parseLASArrowTableBatch(
     positions,
     colors,
     intensities,
-    classifications
+    classifications,
+    gpsTimes,
+    nir
   );
 }
 
@@ -841,16 +859,28 @@ function makeLASArrowTableFromAttributes(
   lasHeader: LASHeader,
   positions: Float32Array | Float64Array,
   colors: Uint8Array | null,
-  intensities: Uint16Array,
-  classifications: Uint8Array
+  intensities: Uint16Array | null,
+  classifications: Uint8Array | null,
+  gpsTimes: Float64Array | null,
+  nir: Uint16Array | null
 ): LASArrowTable {
   const attributes: MeshAttributes = {
-    POSITION: {value: positions, size: 3},
-    intensity: {value: intensities, size: 1},
-    classification: {value: classifications, size: 1}
+    POSITION: {value: positions, size: 3}
   };
+  if (intensities) {
+    attributes.intensity = {value: intensities, size: 1};
+  }
+  if (classifications) {
+    attributes.classification = {value: classifications, size: 1};
+  }
   if (colors) {
     attributes.COLOR_0 = {value: colors, size: 4};
+  }
+  if (gpsTimes) {
+    attributes.GPS_TIME = {value: gpsTimes, size: 1};
+  }
+  if (nir) {
+    attributes.NIR = {value: nir, size: 1};
   }
 
   const schema = getLASSchema(lasHeader, attributes);
@@ -882,8 +912,10 @@ function populateLASAttributesFromDataView(
   target: {
     positions: Float32Array | Float64Array;
     colors: Uint8Array | null;
-    intensities: Uint16Array;
-    classifications: Uint8Array;
+    intensities: Uint16Array | null;
+    classifications: Uint8Array | null;
+    gpsTimes: Float64Array | null;
+    nir: Uint16Array | null;
     pointOffset: number;
     sourcePointIndex: number;
     pointCount: number;
@@ -895,14 +927,23 @@ function populateLASAttributesFromDataView(
   } = lasHeader;
   const pointsFormatId = lasHeader.pointsFormatId;
   const pointRecordLength = lasHeader.pointsStructSize;
-  const colorOffset = getColorOffset(pointsFormatId);
-  const twoByteColor = detectTwoByteColors(
-    dataView,
-    lasHeader,
-    target.sourcePointIndex,
-    target.pointCount,
-    options.las?.colorDepth
-  );
+  const colorOffset = target.colors ? getColorOffset(pointsFormatId) : -1;
+  const twoByteColor =
+    colorOffset >= 0
+      ? detectTwoByteColors(
+          dataView,
+          lasHeader,
+          target.sourcePointIndex,
+          target.pointCount,
+          options.las?.colorDepth
+        )
+      : false;
+  const intensities = target.intensities;
+  const classifications = target.classifications;
+  const gpsTimes = target.gpsTimes;
+  const nir = target.nir;
+  const gpsTimeOffset = gpsTimes ? getGpsTimeOffset(pointsFormatId) : -1;
+  const nirOffset = nir ? getNirOffset(pointsFormatId) : -1;
 
   for (let pointIndex = 0; pointIndex < target.pointCount; pointIndex++) {
     const sourcePointIndex = target.sourcePointIndex + pointIndex;
@@ -914,12 +955,18 @@ function populateLASAttributesFromDataView(
       dataView.getInt32(pointOffset + 4, true) * scaleY + offsetY;
     target.positions[targetPointIndex * 3 + 2] =
       dataView.getInt32(pointOffset + 8, true) * scaleZ + offsetZ;
-    target.intensities[targetPointIndex] = dataView.getUint16(pointOffset + 12, true);
-    target.classifications[targetPointIndex] = readClassification(
-      dataView,
-      pointOffset,
-      pointsFormatId
-    );
+    if (intensities) {
+      intensities[targetPointIndex] = dataView.getUint16(pointOffset + 12, true);
+    }
+    if (classifications) {
+      classifications[targetPointIndex] = readClassification(dataView, pointOffset, pointsFormatId);
+    }
+    if (gpsTimes && gpsTimeOffset >= 0) {
+      gpsTimes[targetPointIndex] = dataView.getFloat64(pointOffset + gpsTimeOffset, true);
+    }
+    if (nir && nirOffset >= 0) {
+      nir[targetPointIndex] = dataView.getUint16(pointOffset + nirOffset, true);
+    }
 
     if (colorOffset >= 0 && target.colors) {
       const red = dataView.getUint16(pointOffset + colorOffset, true);
@@ -962,6 +1009,21 @@ function getColorOffset(pointsFormatId: number): number {
     default:
       return -1;
   }
+}
+
+function getGpsTimeOffset(pointsFormatId: number): number {
+  return pointsFormatId === 1 ||
+    pointsFormatId === 3 ||
+    pointsFormatId === 4 ||
+    pointsFormatId === 5
+    ? 20
+    : pointsFormatId >= 6 && pointsFormatId <= 10
+      ? 22
+      : -1;
+}
+
+function getNirOffset(pointsFormatId: number): number {
+  return pointsFormatId === 8 || pointsFormatId === 10 ? 36 : -1;
 }
 
 function detectTwoByteColors(
@@ -1486,22 +1548,37 @@ function createPointDataBatchState(
 ): PointDataBatchState {
   const PositionsType = options.las?.fp64 ? Float64Array : Float32Array;
   const positions = new PositionsType(batchSize * 3);
+  const selection = getLASColumnSelection(options);
   const useRawColors =
-    header.hasColor && (options.las?.colorDepth === 16 || options.las?.colorDepth === 'auto');
-  const colors = header.hasColor && !useRawColors ? new Uint8Array(batchSize * 4) : null;
+    header.hasColor &&
+    selection.color &&
+    (options.las?.colorDepth === 16 || options.las?.colorDepth === 'auto');
+  const colors =
+    header.hasColor && selection.color && !useRawColors ? new Uint8Array(batchSize * 4) : null;
   const rawColors = useRawColors ? new Uint16Array(batchSize * 3) : null;
-  const intensities = new Uint16Array(batchSize);
-  const classifications = new Uint8Array(batchSize);
+  const intensities = selection.intensity ? new Uint16Array(batchSize) : null;
+  const classifications = selection.classification ? new Uint8Array(batchSize) : null;
+  const gpsTimes =
+    selection.gpsTime && getGpsTimeOffset(header.pointsFormatId) >= 0
+      ? new Float64Array(batchSize)
+      : null;
+  const nir =
+    selection.nir && getNirOffset(header.pointsFormatId) >= 0 ? new Uint16Array(batchSize) : null;
   return {
+    batchCapacity: batchSize,
     positions,
     colors,
     rawColors,
     intensities,
     classifications,
+    gpsTimes,
+    nir,
     target: {
       positions,
       intensities,
       classifications,
+      gpsTimes,
+      nir,
       colors,
       rawColors,
       pointOffset: 0,
@@ -1580,7 +1657,7 @@ function* appendDecodedLAZChunkToPointDataBatches(
   const decoder = createLAZChunkDecoderCursor(compressedChunk, metadata);
 
   while (decoder.remainingPointCount > 0) {
-    const batchCapacity = state.intensities.length;
+    const batchCapacity = state.batchCapacity;
     const batchRemainingPointCount = batchCapacity - state.batchPointCount;
     state.target.pointOffset = state.batchPointCount;
     const pointsDecoded = decoder.decodeIntoPointData(state.target, batchRemainingPointCount);
@@ -1666,14 +1743,18 @@ function flushPointDataBatch(
     totalRead: state.totalRead
   };
   const batchPointCount = state.batchPointCount;
-  const fullBatch = batchPointCount === state.intensities.length;
+  const fullBatch = batchPointCount === state.batchCapacity;
   const positions = fullBatch ? state.positions : state.positions.subarray(0, batchPointCount * 3);
-  const intensities = fullBatch
-    ? state.intensities
-    : state.intensities.subarray(0, batchPointCount);
-  const classifications = fullBatch
-    ? state.classifications
-    : state.classifications.subarray(0, batchPointCount);
+  const intensities = state.intensities
+    ? fullBatch
+      ? state.intensities
+      : state.intensities.subarray(0, batchPointCount)
+    : null;
+  const classifications = state.classifications
+    ? fullBatch
+      ? state.classifications
+      : state.classifications.subarray(0, batchPointCount)
+    : null;
   const colors = state.colors
     ? fullBatch
       ? state.colors
@@ -1681,12 +1762,20 @@ function flushPointDataBatch(
     : state.rawColors
       ? convertRawColorsToUint8(state.rawColors, batchPointCount, options)
       : null;
+  const gpsTimes = state.gpsTimes
+    ? fullBatch
+      ? state.gpsTimes
+      : state.gpsTimes.subarray(0, batchPointCount)
+    : null;
+  const nir = state.nir ? (fullBatch ? state.nir : state.nir.subarray(0, batchPointCount)) : null;
   const table = makeLASArrowTableFromAttributes(
     batchHeader,
     positions,
     colors,
     intensities,
-    classifications
+    classifications,
+    gpsTimes,
+    nir
   );
 
   state.batchPointCount = 0;
@@ -1695,15 +1784,65 @@ function flushPointDataBatch(
     state.positions = new PositionsType(state.positions.length);
     state.colors = state.colors ? new Uint8Array(state.colors.length) : null;
     state.rawColors = state.rawColors ? new Uint16Array(state.rawColors.length) : null;
-    state.intensities = new Uint16Array(state.intensities.length);
-    state.classifications = new Uint8Array(state.classifications.length);
+    state.intensities = state.intensities ? new Uint16Array(state.intensities.length) : null;
+    state.classifications = state.classifications
+      ? new Uint8Array(state.classifications.length)
+      : null;
+    state.gpsTimes = state.gpsTimes ? new Float64Array(state.gpsTimes.length) : null;
+    state.nir = state.nir ? new Uint16Array(state.nir.length) : null;
     state.target.positions = state.positions;
     state.target.colors = state.colors;
     state.target.rawColors = state.rawColors;
     state.target.intensities = state.intensities;
     state.target.classifications = state.classifications;
+    state.target.gpsTimes = state.gpsTimes;
+    state.target.nir = state.nir;
   }
   return table;
+}
+
+/** Resolve optional Arrow columns once before allocating or decoding a point batch. */
+function getLASColumnSelection(options: LASLoaderOptions): {
+  intensity: boolean;
+  classification: boolean;
+  color: boolean;
+  gpsTime: boolean;
+  nir: boolean;
+} {
+  const columns = options.las?.columns;
+  if (!columns) {
+    return {intensity: true, classification: true, color: true, gpsTime: true, nir: true};
+  }
+
+  let intensity = false;
+  let classification = false;
+  let color = false;
+  let gpsTime = false;
+  let nir = false;
+  for (const column of columns as readonly string[]) {
+    switch (column) {
+      case 'POSITION':
+        break;
+      case 'intensity':
+        intensity = true;
+        break;
+      case 'classification':
+        classification = true;
+        break;
+      case 'COLOR_0':
+        color = true;
+        break;
+      case 'GPS_TIME':
+        gpsTime = true;
+        break;
+      case 'NIR':
+        nir = true;
+        break;
+      default:
+        throw new Error(`LASLoader: unsupported column ${column}`);
+    }
+  }
+  return {intensity, classification, color, gpsTime, nir};
 }
 
 function convertRawColorsToUint8(

--- a/modules/las/test/las-loader.bench.ts
+++ b/modules/las/test/las-loader.bench.ts
@@ -20,6 +20,7 @@ const LAZ_1_2_PDRF_3 = 3;
 const LAZ_1_4_PDRF_7 = 7;
 const BATCH_SIZE = 25_000;
 const STREAMING_LAZ_CHUNK_SIZE = 64 * 1024;
+const RENDER_COLUMNS = ['POSITION', 'COLOR_0'] as const;
 const LAZ_1_2_LOADER_VARIANTS = [
   {name: 'typescript', loader: LASLoader},
   {name: 'laz-perf', loader: LAZPerfLoader},
@@ -109,6 +110,36 @@ export default async function lasLoaderBench(bench) {
         batchSize: BATCH_SIZE,
         core: {worker: false},
         las: {shape: 'arrow-table'}
+      });
+      for await (const _batch of batches) {
+        _batch;
+      }
+    }
+  );
+
+  bench.groupSorted('LASLoader selective parse LAZ 1.4 PDRF 7');
+
+  bench.addAsync(
+    'parse LAZ 1.4 PDRF 7 columns=POSITION,COLOR_0 variant=typescript',
+    laz14BenchmarkOptions,
+    async () => {
+      await parse(laz14ArrayBuffer, LASLoader, {
+        core: {worker: false},
+        las: {shape: 'arrow-table', columns: RENDER_COLUMNS}
+      });
+    }
+  );
+
+  bench.groupSorted('LASLoader selective parseInBatches streaming LAZ 1.4 PDRF 7');
+
+  bench.addAsync(
+    'parseInBatches streaming LAZ 1.4 PDRF 7 columns=POSITION,COLOR_0 variant=typescript',
+    laz14BenchmarkOptions,
+    async () => {
+      const batches = await parseInBatches(laz14Chunks, LASLoader, {
+        batchSize: BATCH_SIZE,
+        core: {worker: false},
+        las: {shape: 'arrow-table', columns: RENDER_COLUMNS}
       });
       for await (const _batch of batches) {
         _batch;

--- a/modules/las/test/las-loader.spec.ts
+++ b/modules/las/test/las-loader.spec.ts
@@ -5,10 +5,15 @@
 import {expect, test} from 'vitest';
 import {fetchFile, parse, parseInBatches} from '@loaders.gl/core';
 import {LASLoader, LASWorkerLoader} from '@loaders.gl/las';
+import type {MeshArrowTable} from '@loaders.gl/schema';
 import {validateLoader} from 'test/common/conformance';
 
 const PDRF_4_LAS_URL = '@loaders.gl/las/test/data/pdrf4-1.3.las';
 const PDRF_4_LAZ_URL = '@loaders.gl/las/test/data/pdrf4-1.3.laz';
+const PDRF_7_LAS_URL = '@loaders.gl/las/test/data/pdrf7-v4-1.4.las';
+const PDRF_7_LAZ_URL = '@loaders.gl/las/test/data/pdrf7-v4-1.4.laz';
+const PDRF_8_LAS_URL = '@loaders.gl/las/test/data/pdrf8-1.4.las';
+const PDRF_8_LAZ_URL = '@loaders.gl/las/test/data/pdrf8-1.4.laz';
 const POINT_COUNT = 1024;
 
 test('LASLoader#loader conformance', () => {
@@ -19,7 +24,7 @@ test('LASLoader#loader conformance', () => {
 test('LASLoader#small uncompressed and compressed fixtures agree', async () => {
   const lasArrayBuffer = await (await fetchFile(PDRF_4_LAS_URL)).arrayBuffer();
   const lazArrayBuffer = await (await fetchFile(PDRF_4_LAZ_URL)).arrayBuffer();
-  const loaderOptions = {las: {backend: 'typescript' as const}, core: {worker: false}};
+  const loaderOptions = {core: {worker: false}};
   const uncompressed = await parse(lasArrayBuffer, LASLoader, loaderOptions);
   const compressed = await parse(lazArrayBuffer, LASLoader, loaderOptions);
 
@@ -37,7 +42,6 @@ test('LASLoader#small fixture streams requested mesh batches', async () => {
   const lazArrayBuffer = await (await fetchFile(PDRF_4_LAZ_URL)).arrayBuffer();
   const batches = await parseInBatches(lazArrayBuffer, LASLoader, {
     batchSize: 127,
-    las: {backend: 'typescript'},
     core: {worker: false}
   });
   const batchVertexCounts: number[] = [];
@@ -53,7 +57,7 @@ test('LASLoader#small fixture streams requested mesh batches', async () => {
 test('LASLoader#small fixture emits an Arrow table', async () => {
   const lazArrayBuffer = await (await fetchFile(PDRF_4_LAZ_URL)).arrayBuffer();
   const table = await parse(lazArrayBuffer, LASLoader, {
-    las: {backend: 'typescript', shape: 'arrow-table'},
+    las: {shape: 'arrow-table'},
     core: {worker: false}
   });
 
@@ -62,3 +66,141 @@ test('LASLoader#small fixture emits an Arrow table', async () => {
   expect(table.data.getChild('POSITION')).toBeTruthy();
   expect(table.data.getChild('intensity')).toBeTruthy();
 });
+
+test('LASLoader#columns decodes only requested PDRF 7 Arrow columns', async () => {
+  const [lasArrayBuffer, lazArrayBuffer] = await Promise.all([
+    fetchFile(PDRF_7_LAS_URL).then(response => response.arrayBuffer()),
+    fetchFile(PDRF_7_LAZ_URL).then(response => response.arrayBuffer())
+  ]);
+  const options = {
+    las: {shape: 'arrow-table' as const, columns: ['POSITION', 'COLOR_0'] as const},
+    core: {worker: false}
+  };
+  const uncompressed = (await parse(lasArrayBuffer, LASLoader, options)) as MeshArrowTable;
+  const compressed = (await parse(lazArrayBuffer, LASLoader, options)) as MeshArrowTable;
+
+  expect(getArrowColumnNames(compressed)).toEqual(['POSITION', 'COLOR_0']);
+  expect(getArrowColumnValues(compressed, 'POSITION')).toEqual(
+    getArrowColumnValues(uncompressed, 'POSITION')
+  );
+  expect(getArrowColumnValues(compressed, 'COLOR_0')).toEqual(
+    getArrowColumnValues(uncompressed, 'COLOR_0')
+  );
+
+  const positionsOnlyMesh = await parse(lasArrayBuffer, LASLoader, {
+    las: {columns: []},
+    core: {worker: false}
+  });
+  expect(Object.keys(positionsOnlyMesh.attributes)).toEqual(['POSITION']);
+});
+
+test('LASLoader#parseInBatches preserves selected columns across chunked PDRF 7 input', async () => {
+  const lazArrayBuffer = await fetchFile(PDRF_7_LAZ_URL).then(response => response.arrayBuffer());
+  const expected = (await parse(lazArrayBuffer, LASLoader, {
+    las: {shape: 'arrow-table', columns: ['intensity', 'classification']},
+    core: {worker: false}
+  })) as MeshArrowTable;
+  const batches = await parseInBatches(splitArrayBuffer(lazArrayBuffer, 257), LASLoader, {
+    batchSize: 127,
+    las: {shape: 'arrow-table', columns: ['intensity', 'classification']},
+    core: {worker: false}
+  });
+  const streamedColumns = {
+    POSITION: [] as unknown[],
+    intensity: [] as unknown[],
+    classification: [] as unknown[]
+  };
+
+  for await (const batch of batches as AsyncIterable<MeshArrowTable>) {
+    expect(getArrowColumnNames(batch)).toEqual(['POSITION', 'intensity', 'classification']);
+    streamedColumns.POSITION.push(...getArrowColumnValues(batch, 'POSITION'));
+    streamedColumns.intensity.push(...getArrowColumnValues(batch, 'intensity'));
+    streamedColumns.classification.push(...getArrowColumnValues(batch, 'classification'));
+  }
+
+  expect(streamedColumns.POSITION).toEqual(getArrowColumnValues(expected, 'POSITION'));
+  expect(streamedColumns.intensity).toEqual(getArrowColumnValues(expected, 'intensity'));
+  expect(streamedColumns.classification).toEqual(getArrowColumnValues(expected, 'classification'));
+});
+
+test('LASLoader#columns decodes GPS time and NIR for PDRF 8', async () => {
+  const [lasArrayBuffer, lazArrayBuffer] = await Promise.all([
+    fetchFile(PDRF_8_LAS_URL).then(response => response.arrayBuffer()),
+    fetchFile(PDRF_8_LAZ_URL).then(response => response.arrayBuffer())
+  ]);
+  const options = {
+    las: {shape: 'arrow-table' as const, columns: ['POSITION', 'GPS_TIME', 'NIR'] as const},
+    core: {worker: false}
+  };
+  const uncompressed = (await parse(lasArrayBuffer, LASLoader, options)) as MeshArrowTable;
+  const compressed = (await parse(lazArrayBuffer, LASLoader, options)) as MeshArrowTable;
+
+  expect(getArrowColumnNames(compressed)).toEqual(['POSITION', 'GPS_TIME', 'NIR']);
+  expect(getArrowColumnValues(compressed, 'POSITION')).toEqual(
+    getArrowColumnValues(uncompressed, 'POSITION')
+  );
+  expect(getArrowColumnValues(compressed, 'GPS_TIME')).toEqual(
+    getArrowColumnValues(uncompressed, 'GPS_TIME')
+  );
+  expect(getArrowColumnValues(compressed, 'NIR')).toEqual(
+    getArrowColumnValues(uncompressed, 'NIR')
+  );
+
+  const batches = await parseInBatches(splitArrayBuffer(lazArrayBuffer, 257), LASLoader, {
+    batchSize: 127,
+    las: {shape: 'arrow-table', columns: ['POSITION', 'GPS_TIME', 'NIR']},
+    core: {worker: false}
+  });
+  const streamedValues = {
+    POSITION: [] as unknown[],
+    GPS_TIME: [] as unknown[],
+    NIR: [] as unknown[]
+  };
+  for await (const batch of batches as AsyncIterable<MeshArrowTable>) {
+    expect(getArrowColumnNames(batch)).toEqual(['POSITION', 'GPS_TIME', 'NIR']);
+    streamedValues.POSITION.push(...getArrowColumnValues(batch, 'POSITION'));
+    streamedValues.GPS_TIME.push(...getArrowColumnValues(batch, 'GPS_TIME'));
+    streamedValues.NIR.push(...getArrowColumnValues(batch, 'NIR'));
+  }
+  expect(streamedValues.POSITION).toEqual(getArrowColumnValues(uncompressed, 'POSITION'));
+  expect(streamedValues.GPS_TIME).toEqual(getArrowColumnValues(uncompressed, 'GPS_TIME'));
+  expect(streamedValues.NIR).toEqual(getArrowColumnValues(uncompressed, 'NIR'));
+});
+
+test('LASLoader#columns validates unsupported names', async () => {
+  const lasArrayBuffer = await fetchFile(PDRF_4_LAS_URL).then(response => response.arrayBuffer());
+
+  await expect(
+    parse(lasArrayBuffer, LASLoader, {
+      las: {shape: 'arrow-table', columns: ['unsupported' as never]},
+      core: {worker: false}
+    })
+  ).rejects.toThrow('LASLoader: unsupported column unsupported');
+});
+
+/** Return Arrow field names in schema order. */
+function getArrowColumnNames(table: MeshArrowTable): string[] {
+  return table.data.schema.fields.map(field => field.name);
+}
+
+/** Materialize one Arrow column for parity assertions. */
+function getArrowColumnValues(table: MeshArrowTable, columnName: string): unknown[] {
+  const column = table.data.getChild(columnName);
+  if (!column) {
+    throw new Error(`Missing Arrow column ${columnName}`);
+  }
+  return Array.from(column, value =>
+    value && typeof value === 'object' && Symbol.iterator in value
+      ? Array.from(value as Iterable<unknown>)
+      : value
+  );
+}
+
+/** Split fixture bytes at deterministic non-record-aligned boundaries. */
+function splitArrayBuffer(arrayBuffer: ArrayBuffer, chunkByteLength: number): ArrayBuffer[] {
+  const chunks: ArrayBuffer[] = [];
+  for (let byteOffset = 0; byteOffset < arrayBuffer.byteLength; byteOffset += chunkByteLength) {
+    chunks.push(arrayBuffer.slice(byteOffset, byteOffset + chunkByteLength));
+  }
+  return chunks;
+}

--- a/modules/las/test/las-loader.spec.ts
+++ b/modules/las/test/las-loader.spec.ts
@@ -73,18 +73,24 @@ test('LASLoader#columns decodes only requested PDRF 7 Arrow columns', async () =
     fetchFile(PDRF_7_LAZ_URL).then(response => response.arrayBuffer())
   ]);
   const options = {
-    las: {shape: 'arrow-table' as const, columns: ['POSITION', 'COLOR_0'] as const},
+    las: {
+      shape: 'arrow-table' as const,
+      columns: ['POSITION', 'COLOR_0', 'GPS_TIME'] as const
+    },
     core: {worker: false}
   };
   const uncompressed = (await parse(lasArrayBuffer, LASLoader, options)) as MeshArrowTable;
   const compressed = (await parse(lazArrayBuffer, LASLoader, options)) as MeshArrowTable;
 
-  expect(getArrowColumnNames(compressed)).toEqual(['POSITION', 'COLOR_0']);
+  expect(getArrowColumnNames(compressed)).toEqual(['POSITION', 'COLOR_0', 'GPS_TIME']);
   expect(getArrowColumnValues(compressed, 'POSITION')).toEqual(
     getArrowColumnValues(uncompressed, 'POSITION')
   );
   expect(getArrowColumnValues(compressed, 'COLOR_0')).toEqual(
     getArrowColumnValues(uncompressed, 'COLOR_0')
+  );
+  expect(getArrowColumnValues(compressed, 'GPS_TIME')).toEqual(
+    getArrowColumnValues(uncompressed, 'GPS_TIME')
   );
 
   const positionsOnlyMesh = await parse(lasArrayBuffer, LASLoader, {

--- a/modules/loader-utils/src/lib/laz/laz-chunk-decoder.ts
+++ b/modules/loader-utils/src/lib/laz/laz-chunk-decoder.ts
@@ -31,6 +31,10 @@ export type LAZPointDataTarget = {
   intensities?: Uint16Array | null;
   /** Optional point classification values. Omit to skip the independent Point14 class layer. */
   classifications?: Uint8Array | null;
+  /** Optional GPS time values from the Point14 layer. */
+  gpsTimes?: Float64Array | null;
+  /** Optional near-infrared channel values from RGBNIR14. */
+  nir?: Uint16Array | null;
   /** Optional final RGBA colors as 8-bit channel values. */
   colors?: Uint8Array | null;
   /** Optional raw RGB colors as 16-bit LAS channel values. */
@@ -62,6 +66,10 @@ type LAZPointDataSelection = {
   classification: boolean;
   /** Decode RGB values when the point format has an RGB item. */
   color: boolean;
+  /** Decode GPS time values. */
+  gpsTime: boolean;
+  /** Decode NIR values when the point format has an RGBNIR item. */
+  nir: boolean;
 };
 
 /** Error raised when a feedable decoder needs more compressed bytes. */
@@ -271,14 +279,20 @@ function getLAZPointDataSelection(target: LAZPointDataTarget): LAZPointDataSelec
   return {
     intensity: Boolean(target.intensities),
     classification: Boolean(target.classifications),
-    color: Boolean(target.colors || target.rawColors)
+    color: Boolean(target.colors || target.rawColors),
+    gpsTime: Boolean(target.gpsTimes),
+    nir: Boolean(target.nir)
   };
 }
 
 /** Encode a direct-output field selection as a compact cursor compatibility key. */
 function getLAZPointDataSelectionKey(selection: LAZPointDataSelection): number {
   return (
-    (selection.intensity ? 1 : 0) | (selection.classification ? 2 : 0) | (selection.color ? 4 : 0)
+    (selection.intensity ? 1 : 0) |
+    (selection.classification ? 2 : 0) |
+    (selection.color ? 4 : 0) |
+    (selection.gpsTime ? 8 : 0) |
+    (selection.nir ? 16 : 0)
   );
 }
 
@@ -1336,14 +1350,16 @@ class Point14Context {
     if (mode === Point14DecompressionMode.Full) {
       this.flagModel = createModels(64, 64);
       this.userDataModel = createModels(64, 256);
-      this.gpsTimeMultiModel = new ArithmeticModel(515);
-      this.gpsTime0DiffModel = new ArithmeticModel(5);
       this.scanAngle = createIntegerDecompressor(16, 2);
       this.pointSourceId = createIntegerDecompressor(16, 1);
+      this.multiExtremeCounter = new Array<number>(4).fill(0);
+    }
+    if (mode === Point14DecompressionMode.Full || selection?.gpsTime) {
+      this.gpsTimeMultiModel = new ArithmeticModel(515);
+      this.gpsTime0DiffModel = new ArithmeticModel(5);
       this.gpsTime = createIntegerDecompressor(32, 9);
       this.lastGpsTime = new Array<number>(4).fill(0);
       this.lastGpsTimeDiff = new Array<number>(4).fill(0);
-      this.multiExtremeCounter = new Array<number>(4).fill(0);
     }
   }
 }
@@ -1390,7 +1406,8 @@ class Point14Decompressor {
     this.scanAngle = this.decompressOptionalFields ? new ArithmeticDecoder() : null;
     this.userData = this.decompressOptionalFields ? new ArithmeticDecoder() : null;
     this.pointSourceId = this.decompressOptionalFields ? new ArithmeticDecoder() : null;
-    this.gpsTime = this.decompressOptionalFields ? new ArithmeticDecoder() : null;
+    this.gpsTime =
+      this.decompressOptionalFields || selection?.gpsTime ? new ArithmeticDecoder() : null;
   }
 
   readSizes(): void {
@@ -1429,7 +1446,7 @@ class Point14Decompressor {
   }
 
   decompressPoint(output?: Uint8Array, outputOffset: number = 0): Point14 {
-    const decompressOptionalFields = this.decompressOptionalFields;
+    const decompressGpsTime = this.gpsTime !== null;
     if (!this.activeContext) {
       const point = this.contexts[0].last;
       if (output) {
@@ -1445,7 +1462,7 @@ class Point14Decompressor {
         copyPoint14(context.last, point);
       }
       context.haveLast = true;
-      if (decompressOptionalFields) {
+      if (decompressGpsTime) {
         context.lastGpsTime[0] = context.last.gpsTime;
       }
       this.activeContext = context;
@@ -1497,7 +1514,7 @@ class Point14Decompressor {
       if (context.lastIntensity.length) {
         context.lastIntensity.fill(previous.last.intensity);
       }
-      if (decompressOptionalFields) {
+      if (decompressGpsTime) {
         context.lastGpsTime[0] = previous.last.gpsTime;
       }
     }
@@ -1870,6 +1887,9 @@ class NIR14Decompressor {
   private lastChannel = -1;
   private nirCount = 0;
   private nir = new ArithmeticDecoder();
+  private scratch = new Uint8Array(2);
+  /** Most recently decoded NIR value for direct point-data output. */
+  decodedNir = 0;
   /** RGBNIR item version controlling scanner-channel predictor selection. */
   private itemVersion: 2 | 3 | 4;
 
@@ -1893,10 +1913,12 @@ class NIR14Decompressor {
       context.lastValue = readUint16(output, outputOffset);
       context.haveLast = true;
       this.lastChannel = scannerChannel;
+      this.decodedNir = context.lastValue;
       return outputOffset + 2;
     }
     if (this.nirCount === 0) {
       writeUint16(this.contexts[this.lastChannel].lastValue, output, outputOffset);
+      this.decodedNir = this.contexts[this.lastChannel].lastValue;
       return outputOffset + 2;
     }
     const context = this.contexts[scannerChannel];
@@ -1922,8 +1944,15 @@ class NIR14Decompressor {
         ? ((this.nir.decodeSymbol(context.diffModel[1]) + (lastContext.lastValue >> 8)) & 0xff) << 8
         : lastContext.lastValue & 0xff00;
     lastContext.lastValue = value;
+    this.decodedNir = value;
     writeUint16(value, output, outputOffset);
     return outputOffset + 2;
+  }
+
+  /** Decode one NIR value without allocating a temporary point record. */
+  decompressNir(scannerChannel: number): number {
+    this.decompress(this.scratch, 0, scannerChannel);
+    return this.decodedNir;
   }
 }
 
@@ -2762,6 +2791,7 @@ class PointFormat6Decompressor implements PointDecompressor {
         offset,
         targetPointIndex++
       );
+      writeGpsTimeToPointDataTarget(point, target, targetPointIndex - 1);
     }
   }
 
@@ -2888,6 +2918,7 @@ class PointFormat7Decompressor implements PointDecompressor {
         offset,
         targetPointIndex
       );
+      writeGpsTimeToPointDataTarget(point, target, targetPointIndex);
       if (colors && this.rgb) {
         const colorOffset = targetPointIndex * 4;
         colors[colorOffset] = this.rgb.decodedRed & 0xff;
@@ -2964,7 +2995,9 @@ class PointFormat8Decompressor implements PointDecompressor {
         ? new RGB14Decompressor(stream, metadata.rgb14ItemVersion ?? 3)
         : null;
     this.nir =
-      outputMode === 'raw' ? new NIR14Decompressor(stream, metadata.rgb14ItemVersion ?? 3) : null;
+      outputMode === 'raw' || selection?.nir
+        ? new NIR14Decompressor(stream, metadata.rgb14ItemVersion ?? 3)
+        : null;
     this.bytes =
       outputMode === 'raw' && extraByteCount
         ? new Byte14Decompressor(stream, extraByteCount, metadata.byte14ItemVersion ?? 3)
@@ -2989,11 +3022,13 @@ class PointFormat8Decompressor implements PointDecompressor {
     } else if (this.first) {
       this.stream.consume(6);
     }
+    const nir = this.nir ? this.nir.decompressNir(this.point.itemContextChannel) : 0;
     if (this.first) {
-      this.stream.consume(2 + this.extraByteCount);
+      this.stream.consume((this.nir ? 0 : 2) + this.extraByteCount);
     }
     this.readFirstMetadata();
     writePoint14ToPointDataTarget(point, target, targetPointIndex);
+    writeNirToPointDataTarget(nir, target, targetPointIndex);
     if (this.rgb) {
       writeRgbToPointDataTarget(
         this.rgb.decodedRed,
@@ -3022,8 +3057,9 @@ class PointFormat8Decompressor implements PointDecompressor {
       } else if (this.first) {
         this.stream.consume(6);
       }
+      const nir = this.nir ? this.nir.decompressNir(this.point.itemContextChannel) : 0;
       if (this.first) {
-        this.stream.consume(2 + this.extraByteCount);
+        this.stream.consume((this.nir ? 0 : 2) + this.extraByteCount);
       }
       this.readFirstMetadata();
       writePoint14ToPointDataArrays(
@@ -3035,6 +3071,7 @@ class PointFormat8Decompressor implements PointDecompressor {
         offset,
         targetPointIndex
       );
+      writeGpsTimeToPointDataTarget(point, target, targetPointIndex);
       if (colors && this.rgb) {
         const colorOffset = targetPointIndex * 4;
         colors[colorOffset] = this.rgb.decodedRed & 0xff;
@@ -3047,6 +3084,7 @@ class PointFormat8Decompressor implements PointDecompressor {
         rawColors[colorOffset + 1] = this.rgb.decodedGreen;
         rawColors[colorOffset + 2] = this.rgb.decodedBlue;
       }
+      writeNirToPointDataTarget(nir, target, targetPointIndex);
       targetPointIndex++;
     }
   }
@@ -3173,6 +3211,7 @@ class PointFormat9Decompressor implements PointDecompressor {
         offset,
         targetPointIndex++
       );
+      writeGpsTimeToPointDataTarget(point, target, targetPointIndex - 1);
     }
   }
 
@@ -3246,7 +3285,9 @@ class PointFormat10Decompressor implements PointDecompressor {
         ? new RGB14Decompressor(stream, metadata.rgb14ItemVersion ?? 3)
         : null;
     this.nir =
-      outputMode === 'raw' ? new NIR14Decompressor(stream, metadata.rgb14ItemVersion ?? 3) : null;
+      outputMode === 'raw' || selection?.nir
+        ? new NIR14Decompressor(stream, metadata.rgb14ItemVersion ?? 3)
+        : null;
     this.wavePacket =
       outputMode === 'raw'
         ? new WavePacket14Decompressor(stream, metadata.wavePacketItemVersion ?? 3)
@@ -3278,11 +3319,13 @@ class PointFormat10Decompressor implements PointDecompressor {
     } else if (this.first) {
       this.stream.consume(6);
     }
+    const nir = this.nir ? this.nir.decompressNir(this.point.itemContextChannel) : 0;
     if (this.first) {
-      this.stream.consume(2 + 29 + this.extraByteCount);
+      this.stream.consume((this.nir ? 0 : 2) + 29 + this.extraByteCount);
     }
     this.readFirstMetadata();
     writePoint14ToPointDataTarget(point, target, targetPointIndex);
+    writeNirToPointDataTarget(nir, target, targetPointIndex);
     if (this.rgb) {
       writeRgbToPointDataTarget(
         this.rgb.decodedRed,
@@ -3312,8 +3355,9 @@ class PointFormat10Decompressor implements PointDecompressor {
       } else if (this.first) {
         this.stream.consume(6);
       }
+      const nir = this.nir ? this.nir.decompressNir(this.point.itemContextChannel) : 0;
       if (this.first) {
-        this.stream.consume(2 + 29 + this.extraByteCount);
+        this.stream.consume((this.nir ? 0 : 2) + 29 + this.extraByteCount);
       }
       this.readFirstMetadata();
       writePoint14ToPointDataArrays(
@@ -3325,6 +3369,7 @@ class PointFormat10Decompressor implements PointDecompressor {
         offset,
         targetPointIndex
       );
+      writeGpsTimeToPointDataTarget(point, target, targetPointIndex);
       if (colors && this.rgb) {
         const colorOffset = targetPointIndex * 4;
         colors[colorOffset] = this.rgb.decodedRed & 0xff;
@@ -3337,6 +3382,7 @@ class PointFormat10Decompressor implements PointDecompressor {
         rawColors[colorOffset + 1] = this.rgb.decodedGreen;
         rawColors[colorOffset + 2] = this.rgb.decodedBlue;
       }
+      writeNirToPointDataTarget(nir, target, targetPointIndex);
       targetPointIndex++;
     }
   }
@@ -3597,6 +3643,9 @@ function writePoint14ToPointDataTarget(
     target.offset,
     targetPointIndex
   );
+  if (target.gpsTimes) {
+    target.gpsTimes[targetPointIndex] = point.gpsTime;
+  }
 }
 
 function writePoint14ToPointDataArrays(
@@ -3617,6 +3666,26 @@ function writePoint14ToPointDataArrays(
   }
   if (classifications) {
     classifications[targetPointIndex] = point.classification;
+  }
+}
+
+function writeGpsTimeToPointDataTarget(
+  point: Point14,
+  target: LAZPointDataTarget,
+  targetPointIndex: number
+): void {
+  if (target.gpsTimes) {
+    target.gpsTimes[targetPointIndex] = point.gpsTime;
+  }
+}
+
+function writeNirToPointDataTarget(
+  value: number,
+  target: LAZPointDataTarget,
+  targetPointIndex: number
+): void {
+  if (target.nir) {
+    target.nir[targetPointIndex] = value;
   }
 }
 

--- a/modules/loader-utils/src/lib/laz/laz-chunk-decoder.ts
+++ b/modules/loader-utils/src/lib/laz/laz-chunk-decoder.ts
@@ -1352,7 +1352,6 @@ class Point14Context {
       this.userDataModel = createModels(64, 256);
       this.scanAngle = createIntegerDecompressor(16, 2);
       this.pointSourceId = createIntegerDecompressor(16, 1);
-      this.multiExtremeCounter = new Array<number>(4).fill(0);
     }
     if (mode === Point14DecompressionMode.Full || selection?.gpsTime) {
       this.gpsTimeMultiModel = new ArithmeticModel(515);
@@ -1360,6 +1359,7 @@ class Point14Context {
       this.gpsTime = createIntegerDecompressor(32, 9);
       this.lastGpsTime = new Array<number>(4).fill(0);
       this.lastGpsTimeDiff = new Array<number>(4).fill(0);
+      this.multiExtremeCounter = new Array<number>(4).fill(0);
     }
   }
 }


### PR DESCRIPTION
## Goals

Expose GPS time and NIR as selectable Arrow columns in the pure TypeScript LAS/LAZ loader while preserving direct typed-array decoding and streaming batches.

## Changes

- Add `GPS_TIME` and `NIR` to `las.columns`.
- Decode GPS time from legacy LAS records and Point14.
- Decode NIR from RGBNIR14 for PDRF 8 and 10.
- Preserve selective independent-layer skipping for modern LAZ.
- Add PDRF 8 atomic and split-input `parseInBatches` parity coverage.
- Update LAS format tables, API docs, README, and release notes.

## Validation

- `yarn build`
- `yarn lint fix`
- `yarn test-audit`
- `yarn test-headless modules/las/test/las-loader.spec.ts`
- `yarn test-headless modules/las/test/typescript-laz.spec.ts