### PR TITLE
feat(las): support variable LAZ chunk tables

### DIFF
--- a/docs/modules/las/api-reference/las-writer.md
+++ b/docs/modules/las/api-reference/las-writer.md
@@ -35,7 +35,7 @@ const arrayBuffer = await encode(pointCloud, LASWriter, {
 
 The writer requires a `POSITION` attribute. It writes `COLOR_0`, `intensity`, and `classification` attributes when present. It can select LAS versions 1.0-1.4 and PDRF 0-8 for uncompressed output, but fields without a corresponding input attribute, including GPS time, waveform references, NIR, return flags, and scanner metadata, are zero-filled. Current uncompressed round-trip coverage targets default LAS 1.2 and LAS 1.4/PDRF 7; full conformance for every selectable version/PDRF combination is not claimed.
 
-LAZ output uses LAS 1.4, PDRF 6-8, LASzip layered compressor 3, arithmetic coder 0, item version 3, and a fixed-size chunk table. The output is readable by the TypeScript loader and established WASM decoders. COPC output is provided separately by [`COPCWriter`](/docs/modules/copc/api-reference/copc-writer) to keep the LAS and COPC packages acyclic.
+LAZ output uses LAS 1.4, PDRF 6-8, LASzip layered compressor 3, arithmetic coder 0, and item version 3. Fixed-size chunk tables are the default; variable-size tables can be enabled when needed. The output is readable by the TypeScript loader and established WASM decoders. COPC output is provided separately by [`COPCWriter`](/docs/modules/copc/api-reference/copc-writer) to keep the LAS and COPC packages acyclic.
 
 ## Options
 
@@ -47,4 +47,5 @@ LAZ output uses LAS 1.4, PDRF 6-8, LASzip layered compressor 3, arithmetic coder
 | `las.scale` | `[number, number, number]` | `[0.001, 0.001, 0.001]` | Coordinate scale factors used to quantize positions into LAS integer coordinates. |
 | `las.offset` | `[number, number, number]` | Mesh minimum position | Coordinate offsets used to quantize positions into LAS integer coordinates. |
 | `las.colorDepth` | `number \| string` | - | Declares the source color component depth. |
-| `las.chunkSize` | `number` | `50000` | Number of points per fixed-size LAZ chunk. |
+| `las.chunkSize` | `number` | `50000` | Number of points per LAZ chunk. |
+| `las.variableChunkTable` | `boolean` | `false` | Use a variable-size LAZ chunk table and store each chunk's point count. |

--- a/docs/modules/las/formats/las.md
+++ b/docs/modules/las/formats/las.md
@@ -47,9 +47,9 @@ LAS file versions and LASzip codec versions are independent. A claim such as "LA
 | Uncompressed LAS writing | Partial. Supports LAS output for represented mesh/table fields. |
 | LAS versions | Versions 1.0-1.4 are selectable and LAS 1.5 is rejected. Round-trip coverage currently targets default LAS 1.2 and LAS 1.4/PDRF 7; full version conformance is not claimed. |
 | Point data record formats | PDRF 0-8 are selectable. Only position, intensity, classification, and RGB input attributes are represented; other fields are zero-filled. |
-| LAZ writing | Supported for LAS 1.4 PDRF 6-8 with fixed-size LASzip chunk tables. |
+| LAZ writing | Supported for LAS 1.4 PDRF 6-8 with fixed-size or variable-size LASzip chunk tables. |
 | COPC writing | Supported by `@loaders.gl/copc` through its separate `COPCWriter` entry point. |
-| VLRs, EVLRs, CRS, Extra Bytes VLRs | Not complete. |
+| VLRs, EVLRs, CRS, Extra Bytes VLRs | The LASzip VLR is written for LAZ; broader metadata records remain incomplete. |
 | Streaming writing | `encodeInBatches` may buffer input so final counts, bounds, offsets, and headers can be written correctly. |
 
 ### TypeScript LAZ Decoder

--- a/modules/las/src/las-writer.ts
+++ b/modules/las/src/las-writer.ts
@@ -21,6 +21,7 @@ const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 const LAS_HEADER_LENGTH = 227;
 const LAS_1_4_HEADER_LENGTH = 375;
 const DEFAULT_LAZ_CHUNK_SIZE = 50_000;
+const VARIABLE_LAZ_CHUNK_SIZE = 0xffffffff;
 const POINT_RECORD_LENGTHS: Record<number, number> = {
   0: 20,
   1: 28,
@@ -51,6 +52,8 @@ export type LASWriterOptions = WriterOptions & {
     colorDepth?: number | string;
     /** Number of points per fixed-size LAZ chunk. */
     chunkSize?: number;
+    /** Write a variable-size LAZ chunk table instead of a fixed-size table. */
+    variableChunkTable?: boolean;
   };
 };
 
@@ -139,7 +142,12 @@ function encodeLASSync(data: Mesh | MeshArrowTable, options: LASWriterOptions = 
     pointDataRecordLength
   };
   if (format === 'laz') {
-    return encodeLAZFile(rawPointData, writeParameters, options.las?.chunkSize);
+    return encodeLAZFile(
+      rawPointData,
+      writeParameters,
+      options.las?.chunkSize,
+      options.las?.variableChunkTable
+    );
   }
 
   const arrayBuffer = new ArrayBuffer(headerLength + rawPointData.byteLength);
@@ -172,13 +180,14 @@ type LASWriteParameters = {
 function encodeLAZFile(
   rawPointData: Uint8Array,
   parameters: LASWriteParameters,
-  requestedChunkSize?: number
+  requestedChunkSize?: number,
+  variableChunkTable = false
 ): ArrayBuffer {
   const chunkSize = requestedChunkSize || DEFAULT_LAZ_CHUNK_SIZE;
   const laszipVLR = encodeLASzipVLR({
     pointDataRecordFormat: parameters.pointDataRecordFormat,
     pointDataRecordLength: parameters.pointDataRecordLength,
-    chunkSize
+    chunkSize: variableChunkTable ? VARIABLE_LAZ_CHUNK_SIZE : chunkSize
   });
   const pointDataOffset = parameters.headerLength + laszipVLR.byteLength;
   const compressedChunks: Uint8Array[] = [];
@@ -206,7 +215,9 @@ function encodeLAZFile(
     (byteLength, chunk) => byteLength + chunk.byteLength,
     0
   );
-  const chunkTablePayload = encodeLAZChunkTable(chunkTableEntries);
+  const chunkTablePayload = encodeLAZChunkTable(chunkTableEntries, {
+    variable: variableChunkTable
+  });
   const chunkTableOffset = pointDataOffset + 8 + compressedPointDataByteLength;
   const arrayBuffer = new ArrayBuffer(chunkTableOffset + 8 + chunkTablePayload.byteLength);
   const bytes = new Uint8Array(arrayBuffer);

--- a/modules/las/test/las-writer.spec.ts
+++ b/modules/las/test/las-writer.spec.ts
@@ -159,6 +159,37 @@ test('LASWriter#validates compressed output options', t => {
   t.end();
 });
 
+test('LASWriter#encodes variable LAZ chunks', async t => {
+  const arrayBuffer = await encode(mesh, LASWriter, {
+    las: {
+      format: 'laz',
+      pointDataRecordFormat: 7,
+      chunkSize: 2,
+      variableChunkTable: true
+    }
+  });
+  const dataView = new DataView(arrayBuffer);
+  const pointDataOffset = dataView.getUint32(96, true);
+  const chunkTableOffset = readUint64(dataView, pointDataOffset);
+  const chunkCount = dataView.getUint32(chunkTableOffset + 4, true);
+  const chunks = decodeLAZChunkTable(new Uint8Array(arrayBuffer, chunkTableOffset + 8), {
+    chunkCount,
+    pointCount: 3,
+    chunkSize: 0xffffffff,
+    variable: true
+  });
+  const data = await parse(arrayBuffer, LASLoader, {core: {worker: false}});
+
+  t.equal(dataView.getUint32(100, true), 1, 'writes one LASzip VLR');
+  t.deepEqual(
+    chunks.map(chunk => chunk.pointCount),
+    [2, 1],
+    'variable chunk table preserves point counts'
+  );
+  t.equal(data.attributes.POSITION.value.length, 9, 'variable LAZ parses through LASLoader');
+  t.end();
+});
+
 test('LASWriter#preserves normalized byte colors', async t => {
   const colorAttributes = {
     POSITION: attributes.POSITION,


### PR DESCRIPTION
## Goals

Add variable-size LASzip chunk table support to the recovered LASWriter LAZ path.

## Changes

- Add `las.variableChunkTable` to opt into variable-size LAZ chunk tables.
- Emit the LASzip variable chunk-size marker and per-chunk point counts.
- Preserve fixed-size chunk tables as the default.
- Add focused writer/loader coverage and update LAS documentation.

LAZ recovery and the COPC writer are already merged into `master`; this PR is limited to the variable LAZ table follow-up.

## Validation

- Focused Chromium tests: 11 passed.
- Node tests: 194 passed, 6 skipped.