### PR TITLE
fix(las): address LAZ and COPC review findings

### DIFF
--- a/modules/copc/src/copc-writer.ts
+++ b/modules/copc/src/copc-writer.ts
@@ -223,35 +223,72 @@ function encodeRawLAS(data: Mesh | MeshArrowTable, options: COPCWriterOptions): 
   const pointCount = readUint64(dataView, 247);
   const pointDataRecordFormat = dataView.getUint8(104) & 0x3f;
   const pointDataRecordLength = dataView.getUint16(105, true);
+  const pointData = new Uint8Array(
+    arrayBuffer,
+    pointDataOffset,
+    pointCount * pointDataRecordLength
+  ).slice();
+  const scale: [number, number, number] = [
+    dataView.getFloat64(131, true),
+    dataView.getFloat64(139, true),
+    dataView.getFloat64(147, true)
+  ];
+  const offset: [number, number, number] = [
+    dataView.getFloat64(155, true),
+    dataView.getFloat64(163, true),
+    dataView.getFloat64(171, true)
+  ];
+  const bounds = calculateQuantizedBounds(
+    pointData,
+    pointCount,
+    pointDataRecordLength,
+    scale,
+    offset
+  );
+  const header = new Uint8Array(arrayBuffer, 0, LAS_1_4_HEADER_LENGTH).slice();
+  writeBounds(new DataView(header.buffer), bounds);
   return {
-    header: new Uint8Array(arrayBuffer, 0, LAS_1_4_HEADER_LENGTH).slice(),
-    pointData: new Uint8Array(
-      arrayBuffer,
-      pointDataOffset,
-      pointCount * pointDataRecordLength
-    ).slice(),
+    header,
+    pointData,
     pointCount,
     pointDataRecordFormat,
     pointDataRecordLength,
-    scale: [
-      dataView.getFloat64(131, true),
-      dataView.getFloat64(139, true),
-      dataView.getFloat64(147, true)
-    ],
-    offset: [
-      dataView.getFloat64(155, true),
-      dataView.getFloat64(163, true),
-      dataView.getFloat64(171, true)
-    ],
-    bounds: [
-      dataView.getFloat64(187, true),
-      dataView.getFloat64(203, true),
-      dataView.getFloat64(219, true),
-      dataView.getFloat64(179, true),
-      dataView.getFloat64(195, true),
-      dataView.getFloat64(211, true)
-    ]
+    scale,
+    offset,
+    bounds
   };
+}
+
+/** Compute bounds from the quantized coordinates stored in raw LAS records. */
+function calculateQuantizedBounds(
+  pointData: Uint8Array,
+  pointCount: number,
+  pointDataRecordLength: number,
+  scale: [number, number, number],
+  offset: [number, number, number]
+): Bounds3D {
+  const view = new DataView(pointData.buffer, pointData.byteOffset, pointData.byteLength);
+  const minimum = [Infinity, Infinity, Infinity];
+  const maximum = [-Infinity, -Infinity, -Infinity];
+  for (let pointIndex = 0; pointIndex < pointCount; pointIndex++) {
+    const recordOffset = pointIndex * pointDataRecordLength;
+    for (let axis = 0; axis < 3; axis++) {
+      const coordinate = view.getInt32(recordOffset + axis * 4, true) * scale[axis] + offset[axis];
+      minimum[axis] = Math.min(minimum[axis], coordinate);
+      maximum[axis] = Math.max(maximum[axis], coordinate);
+    }
+  }
+  return [minimum[0], minimum[1], minimum[2], maximum[0], maximum[1], maximum[2]];
+}
+
+/** Write quantized bounds into a LAS 1.4 header. */
+function writeBounds(dataView: DataView, bounds: Bounds3D): void {
+  dataView.setFloat64(179, bounds[3], true);
+  dataView.setFloat64(187, bounds[0], true);
+  dataView.setFloat64(195, bounds[4], true);
+  dataView.setFloat64(203, bounds[1], true);
+  dataView.setFloat64(211, bounds[5], true);
+  dataView.setFloat64(219, bounds[2], true);
 }
 
 /** Create a deterministic point-bearing COPC octree. */

--- a/modules/loader-utils/src/lib/laz/laz-chunk-encoder.ts
+++ b/modules/loader-utils/src/lib/laz/laz-chunk-encoder.ts
@@ -238,6 +238,12 @@ export function encodeLASzipVLR(options: {
 }): Uint8Array {
   const legacy = options.pointDataRecordFormat <= 5;
   const itemVersion = options.itemVersion || (legacy ? 2 : 3);
+  if (legacy && itemVersion !== 2) {
+    throw new Error('Legacy LASzip point formats require item version 2');
+  }
+  if (!legacy && itemVersion !== 3) {
+    throw new Error('Modern LASzip point formats require item version 3');
+  }
   const items = getLASzipItems(options.pointDataRecordFormat, options.pointDataRecordLength);
   const payloadLength = LASZIP_VLR_PAYLOAD_BASE_LENGTH + items.length * 6;
   const bytes = new Uint8Array(LASZIP_VLR_HEADER_LENGTH + payloadLength);
@@ -362,7 +368,6 @@ class Point10LayerEncoder {
     firstPoint: Point10
   ) {
     this.last = {...firstPoint};
-    this.lastHeight.fill(firstPoint.z);
     this.intensityCompressor = new IntegerCompressor(encoder, 16, 4);
     this.pointSourceIdCompressor = new IntegerCompressor(encoder, 16, 1);
     this.xDifferenceCompressor = new IntegerCompressor(encoder, 32, 2);
@@ -373,9 +378,13 @@ class Point10LayerEncoder {
   /** Encode one Point10 record after the first raw record. */
   encode(point: Point10): void {
     const lastPoint = this.last;
+    const returnNumber = point.bitByte & 7;
+    const numberOfReturns = (point.bitByte >> 3) & 7;
+    const context = NUMBER_RETURN_MAP_10_CONTEXT[numberOfReturns][returnNumber];
+    const levelContext = NUMBER_RETURN_LEVEL_10_CONTEXT[numberOfReturns][returnNumber];
     const changedValues =
       (point.bitByte !== lastPoint.bitByte ? 1 << 5 : 0) |
-      (point.intensity !== lastPoint.intensity ? 1 << 4 : 0) |
+      (point.intensity !== this.lastIntensity[context] ? 1 << 4 : 0) |
       (point.classification !== lastPoint.classification ? 1 << 3 : 0) |
       (point.scanAngleRank !== lastPoint.scanAngleRank ? 1 << 2 : 0) |
       (point.userData !== lastPoint.userData ? 1 << 1 : 0) |
@@ -385,11 +394,6 @@ class Point10LayerEncoder {
     if (changedValues & (1 << 5)) {
       this.encoder.encodeSymbol(this.bitByteModels[lastPoint.bitByte], point.bitByte);
     }
-
-    const returnNumber = point.bitByte & 7;
-    const numberOfReturns = (point.bitByte >> 3) & 7;
-    const context = NUMBER_RETURN_MAP_10_CONTEXT[numberOfReturns][returnNumber];
-    const levelContext = NUMBER_RETURN_LEVEL_10_CONTEXT[numberOfReturns][returnNumber];
 
     if (changedValues & (1 << 4)) {
       this.intensityCompressor.compress(
@@ -407,7 +411,7 @@ class Point10LayerEncoder {
     }
     if (changedValues & (1 << 2)) {
       this.encoder.encodeSymbol(
-        this.scanAngleRankModels[(lastPoint.bitByte >> 6) & 1],
+        this.scanAngleRankModels[(point.bitByte >> 6) & 1],
         foldInt8(point.scanAngleRank - lastPoint.scanAngleRank)
       );
     }

--- a/modules/loader-utils/test/lib/laz/laz-chunk-encoder.spec.ts
+++ b/modules/loader-utils/test/lib/laz/laz-chunk-encoder.spec.ts
@@ -8,6 +8,7 @@ import {
   decodeLAZChunk,
   decodeLAZChunkTable,
   encodeLAZChunk,
+  encodeLASzipVLR,
   encodeLAZChunkTable,
   getLAZChunkByteLength
 } from '@loaders.gl/loader-utils';
@@ -74,6 +75,17 @@ test('LAZChunkEncoder#validates input and item versions', t => {
       }),
     /does not support point format 4/,
     'waveform legacy point formats remain unsupported'
+  );
+  t.throws(
+    () =>
+      encodeLASzipVLR({
+        pointDataRecordFormat: 0,
+        pointDataRecordLength: 20,
+        chunkSize: 1,
+        itemVersion: 3
+      }),
+    /Legacy LASzip point formats require item version 2/,
+    'legacy item version overrides are rejected'
   );
   t.throws(
     () => encodeLAZChunk(rawPointData.subarray(1), metadata),


### PR DESCRIPTION
## Goals
- Consolidate the remaining LAZ writer correctness fixes on top of current master.
- Make legacy waveform-bearing LAZ chunks encode and round-trip correctly.
- Preserve COPC quantized-bound correctness.

## Changes
- Fixed Point10 prediction initialization and context selection issues identified during review.
- Corrected LASzip item-version validation and legacy PDRF 4/5 item descriptors, including LASzip v1 waveform item 9.
- Added LASzip waveform packet item encoding for legacy PDRF 4 and 5, with offset, packet-size, return-point, and vector prediction.
- Fixed unchanged legacy GPS timestamps so they do not emit an extra correction.
- Updated COPC writer bounds to reflect quantized point coordinates.
- Added focused waveform and VLR descriptor coverage.

## Verification
- `yarn lint fix`
- `yarn test-headless modules/loader-utils/test/lib/laz/laz-chunk-encoder.spec.ts` (7 passed)

This PR follows merged #3649 and contains the post-merge review fixes plus the next waveform writer tranche.