### PR TITLE
feat(laz): encode legacy waveform items

### DIFF
--- a/modules/copc/src/copc-writer.ts
+++ b/modules/copc/src/copc-writer.ts
@@ -223,35 +223,72 @@ function encodeRawLAS(data: Mesh | MeshArrowTable, options: COPCWriterOptions): 
   const pointCount = readUint64(dataView, 247);
   const pointDataRecordFormat = dataView.getUint8(104) & 0x3f;
   const pointDataRecordLength = dataView.getUint16(105, true);
+  const pointData = new Uint8Array(
+    arrayBuffer,
+    pointDataOffset,
+    pointCount * pointDataRecordLength
+  ).slice();
+  const scale: [number, number, number] = [
+    dataView.getFloat64(131, true),
+    dataView.getFloat64(139, true),
+    dataView.getFloat64(147, true)
+  ];
+  const offset: [number, number, number] = [
+    dataView.getFloat64(155, true),
+    dataView.getFloat64(163, true),
+    dataView.getFloat64(171, true)
+  ];
+  const bounds = calculateQuantizedBounds(
+    pointData,
+    pointCount,
+    pointDataRecordLength,
+    scale,
+    offset
+  );
+  const header = new Uint8Array(arrayBuffer, 0, LAS_1_4_HEADER_LENGTH).slice();
+  writeBounds(new DataView(header.buffer), bounds);
   return {
-    header: new Uint8Array(arrayBuffer, 0, LAS_1_4_HEADER_LENGTH).slice(),
-    pointData: new Uint8Array(
-      arrayBuffer,
-      pointDataOffset,
-      pointCount * pointDataRecordLength
-    ).slice(),
+    header,
+    pointData,
     pointCount,
     pointDataRecordFormat,
     pointDataRecordLength,
-    scale: [
-      dataView.getFloat64(131, true),
-      dataView.getFloat64(139, true),
-      dataView.getFloat64(147, true)
-    ],
-    offset: [
-      dataView.getFloat64(155, true),
-      dataView.getFloat64(163, true),
-      dataView.getFloat64(171, true)
-    ],
-    bounds: [
-      dataView.getFloat64(187, true),
-      dataView.getFloat64(203, true),
-      dataView.getFloat64(219, true),
-      dataView.getFloat64(179, true),
-      dataView.getFloat64(195, true),
-      dataView.getFloat64(211, true)
-    ]
+    scale,
+    offset,
+    bounds
   };
+}
+
+/** Compute bounds from the quantized coordinates stored in raw LAS records. */
+function calculateQuantizedBounds(
+  pointData: Uint8Array,
+  pointCount: number,
+  pointDataRecordLength: number,
+  scale: [number, number, number],
+  offset: [number, number, number]
+): Bounds3D {
+  const view = new DataView(pointData.buffer, pointData.byteOffset, pointData.byteLength);
+  const minimum = [Infinity, Infinity, Infinity];
+  const maximum = [-Infinity, -Infinity, -Infinity];
+  for (let pointIndex = 0; pointIndex < pointCount; pointIndex++) {
+    const recordOffset = pointIndex * pointDataRecordLength;
+    for (let axis = 0; axis < 3; axis++) {
+      const coordinate = view.getInt32(recordOffset + axis * 4, true) * scale[axis] + offset[axis];
+      minimum[axis] = Math.min(minimum[axis], coordinate);
+      maximum[axis] = Math.max(maximum[axis], coordinate);
+    }
+  }
+  return [minimum[0], minimum[1], minimum[2], maximum[0], maximum[1], maximum[2]];
+}
+
+/** Write quantized bounds into a LAS 1.4 header. */
+function writeBounds(dataView: DataView, bounds: Bounds3D): void {
+  dataView.setFloat64(179, bounds[3], true);
+  dataView.setFloat64(187, bounds[0], true);
+  dataView.setFloat64(195, bounds[4], true);
+  dataView.setFloat64(203, bounds[1], true);
+  dataView.setFloat64(211, bounds[5], true);
+  dataView.setFloat64(219, bounds[2], true);
 }
 
 /** Create a deterministic point-bearing COPC octree. */

--- a/modules/las/src/las-writer.ts
+++ b/modules/las/src/las-writer.ts
@@ -235,6 +235,15 @@ function encodeLASSync(data: Mesh | MeshArrowTable, options: LASWriterOptions = 
 
 /** Validate that the selected LAS header can represent the point record format. */
 function validatePointDataRecordVersion(version: string, pointDataRecordFormat: number): void {
+  if (
+    pointDataRecordFormat >= 4 &&
+    pointDataRecordFormat <= 5 &&
+    !['1.3', '1.4'].includes(version)
+  ) {
+    throw new Error(
+      `LASWriter: point data record format ${pointDataRecordFormat} requires LAS 1.3; received ${version}`
+    );
+  }
   if (pointDataRecordFormat >= 6 && version !== '1.4') {
     throw new Error(
       `LASWriter: point data record format ${pointDataRecordFormat} requires LAS 1.4; received ${version}`
@@ -458,12 +467,21 @@ function validateLAZOptions(
       `LASWriter: LAZ PDRF ${pointDataRecordFormat} output requires LAS 1.2 or newer; received ${version}`
     );
   }
+  if (
+    pointDataRecordFormat >= 4 &&
+    pointDataRecordFormat <= 5 &&
+    !['1.3', '1.4'].includes(version)
+  ) {
+    throw new Error(
+      `LASWriter: LAZ PDRF ${pointDataRecordFormat} requires LAS 1.3 or newer; received ${version}`
+    );
+  }
   if (pointDataRecordFormat >= 6 && version !== '1.4') {
     throw new Error(`LASWriter: LAZ output requires LAS 1.4; received ${version}`);
   }
-  if (![0, 1, 2, 3, 6, 7, 8].includes(pointDataRecordFormat)) {
+  if (![0, 1, 2, 3, 4, 5, 6, 7, 8].includes(pointDataRecordFormat)) {
     throw new Error(
-      `LASWriter: LAZ output currently supports point data record formats 0-3 and 6-8; received ${pointDataRecordFormat}`
+      `LASWriter: LAZ output currently supports point data record formats 0-8; received ${pointDataRecordFormat}`
     );
   }
   if (
@@ -794,14 +812,25 @@ function writePointRecord(
       pointOffset + 15,
       getUInt8Attribute(attributes.classificationAttribute, vertexIndex) & 0x1f
     );
-    dataView.setInt8(pointOffset + 16, 0);
+    dataView.setInt8(
+      pointOffset + 16,
+      getInt16Attribute(attributes.scanAngleAttribute, vertexIndex)
+    );
     dataView.setUint8(
       pointOffset + 17,
       getUInt8Attribute(attributes.userDataAttribute, vertexIndex)
     );
-    dataView.setUint16(pointOffset + 18, 0, true);
+    dataView.setUint16(
+      pointOffset + 18,
+      getUInt16Attribute(attributes.pointSourceIdAttribute, vertexIndex),
+      true
+    );
     if (pointDataRecordFormat === 1 || pointDataRecordFormat === 3 || pointDataRecordFormat >= 4) {
-      dataView.setFloat64(pointOffset + 20, 0, true);
+      dataView.setFloat64(
+        pointOffset + 20,
+        getAttributeValue(attributes.gpsTimeAttribute, vertexIndex),
+        true
+      );
     }
   } else {
     const returnNumber = getUInt8Attribute(attributes.returnNumberAttribute, vertexIndex, 1) & 0x0f;

--- a/modules/las/src/las-writer.ts
+++ b/modules/las/src/las-writer.ts
@@ -121,6 +121,11 @@ function encodeLASSync(data: Mesh | MeshArrowTable, options: LASWriterOptions = 
   const keyPointAttribute = mesh.attributes.keyPoint;
   const withheldAttribute = mesh.attributes.withheld;
   const overlapAttribute = mesh.attributes.overlap;
+  const waveformDescriptorAttribute = mesh.attributes.wavePacketDescriptorIndex;
+  const waveformOffsetAttribute = mesh.attributes.wavePacketOffset;
+  const waveformSizeAttribute = mesh.attributes.wavePacketSize;
+  const waveformReturnPointAttribute = mesh.attributes.wavePacketReturnPoint;
+  const waveformVectorAttribute = mesh.attributes.wavePacketVector;
   const boundingBox = getBoundingBox(positionAttribute, vertexCount);
   const returnCounts = getReturnCounts(returnNumberAttribute, vertexCount);
   const scale = getScale(mesh, options);
@@ -193,6 +198,11 @@ function encodeLASSync(data: Mesh | MeshArrowTable, options: LASWriterOptions = 
         keyPointAttribute,
         withheldAttribute,
         overlapAttribute,
+        waveformDescriptorAttribute,
+        waveformOffsetAttribute,
+        waveformSizeAttribute,
+        waveformReturnPointAttribute,
+        waveformVectorAttribute,
         extraByteFields
       }
     );
@@ -645,7 +655,12 @@ function validateOptionalPointAttributes(mesh: Mesh, vertexCount: number): void 
     'keyPoint',
     'withheld',
     'overlap',
-    'nir'
+    'nir',
+    'wavePacketDescriptorIndex',
+    'wavePacketOffset',
+    'wavePacketSize',
+    'wavePacketReturnPoint',
+    'wavePacketVector'
   ];
   for (const attributeName of scalarAttributeNames) {
     const attribute = mesh.attributes[attributeName];
@@ -656,6 +671,10 @@ function validateOptionalPointAttributes(mesh: Mesh, vertexCount: number): void 
   const colorAttribute = mesh.attributes.COLOR_0;
   if (colorAttribute) {
     validateOptionalAttribute('COLOR_0', colorAttribute, vertexCount, 3, false);
+  }
+  const waveformVectorAttribute = mesh.attributes.wavePacketVector;
+  if (waveformVectorAttribute) {
+    validateOptionalAttribute('wavePacketVector', waveformVectorAttribute, vertexCount, 3);
   }
 }
 
@@ -794,6 +813,11 @@ function writePointRecord(
     keyPointAttribute?: MeshAttribute;
     withheldAttribute?: MeshAttribute;
     overlapAttribute?: MeshAttribute;
+    waveformDescriptorAttribute?: MeshAttribute;
+    waveformOffsetAttribute?: MeshAttribute;
+    waveformSizeAttribute?: MeshAttribute;
+    waveformReturnPointAttribute?: MeshAttribute;
+    waveformVectorAttribute?: MeshAttribute;
     extraByteFields: readonly LASExtraByteField[];
   }
 ): void {
@@ -831,6 +855,35 @@ function writePointRecord(
         getAttributeValue(attributes.gpsTimeAttribute, vertexIndex),
         true
       );
+    }
+    if (pointDataRecordFormat === 4 || pointDataRecordFormat === 5) {
+      const waveformOffset = pointDataRecordFormat === 4 ? 28 : 34;
+      dataView.setUint8(
+        pointOffset + waveformOffset,
+        getUInt8Attribute(attributes.waveformDescriptorAttribute, vertexIndex)
+      );
+      dataView.setBigUint64(
+        pointOffset + waveformOffset + 1,
+        getBigUint64Attribute(attributes.waveformOffsetAttribute, vertexIndex),
+        true
+      );
+      dataView.setUint32(
+        pointOffset + waveformOffset + 9,
+        getUInt32Attribute(attributes.waveformSizeAttribute, vertexIndex),
+        true
+      );
+      dataView.setFloat32(
+        pointOffset + waveformOffset + 13,
+        getAttributeValue(attributes.waveformReturnPointAttribute, vertexIndex),
+        true
+      );
+      for (let componentIndex = 0; componentIndex < 3; componentIndex++) {
+        dataView.setFloat32(
+          pointOffset + waveformOffset + 17 + componentIndex * 4,
+          getComponent(attributes.waveformVectorAttribute, vertexIndex, componentIndex),
+          true
+        );
+      }
     }
   } else {
     const returnNumber = getUInt8Attribute(attributes.returnNumberAttribute, vertexIndex, 1) & 0x0f;
@@ -1034,11 +1087,11 @@ function writeString(
 
 /** Return a single attribute component with 0 as the missing component fallback. */
 function getComponent(
-  attribute: MeshAttribute,
+  attribute: MeshAttribute | undefined,
   vertexIndex: number,
   componentIndex: number
 ): number {
-  return attribute.value[vertexIndex * attribute.size + componentIndex] || 0;
+  return attribute ? attribute.value[vertexIndex * attribute.size + componentIndex] || 0 : 0;
 }
 
 /** Return a LAS UInt16 attribute value. */
@@ -1046,6 +1099,22 @@ function getUInt16Attribute(attribute: MeshAttribute | undefined, vertexIndex: n
   return attribute
     ? Math.max(0, Math.min(65535, Math.round(getComponent(attribute, vertexIndex, 0))))
     : 0;
+}
+
+/** Return a LAS unsigned 32-bit attribute value. */
+function getUInt32Attribute(attribute: MeshAttribute | undefined, vertexIndex: number): number {
+  return attribute
+    ? Math.max(0, Math.min(0xffffffff, Math.round(getComponent(attribute, vertexIndex, 0))))
+    : 0;
+}
+
+/** Return a lossless unsigned 64-bit waveform offset attribute value. */
+function getBigUint64Attribute(attribute: MeshAttribute | undefined, vertexIndex: number): bigint {
+  if (!attribute) {
+    return 0n;
+  }
+  const value = attribute.value[vertexIndex * attribute.size];
+  return typeof value === 'bigint' ? value : BigInt(Math.max(0, Math.round(Number(value))));
 }
 
 /** Return a LAS UInt8 attribute value. */

--- a/modules/las/test/las-loader.node.slow.spec.ts
+++ b/modules/las/test/las-loader.node.slow.spec.ts
@@ -1564,11 +1564,11 @@ test('TypeScriptLAZ#encoder validates input and item versions', t => {
     () =>
       encodeLAZChunk(new Uint8Array(20), {
         pointCount: 1,
-        pointDataRecordFormat: 4,
-        pointDataRecordLength: 57
+        pointDataRecordFormat: 11,
+        pointDataRecordLength: 20
       }),
-    /does not support point format 4/,
-    'waveform legacy point formats remain unsupported'
+    /does not support point format 11/,
+    'unsupported point formats fail clearly'
   );
   t.throws(
     () => encodeLAZChunk(rawPointData.subarray(1), metadata),

--- a/modules/las/test/las-writer.spec.ts
+++ b/modules/las/test/las-writer.spec.ts
@@ -220,13 +220,13 @@ test('LASWriter#validates compressed output options', t => {
     /LAZ output requires LAS 1.4/,
     'LAZ writer rejects legacy LAS versions'
   );
-  t.throws(
-    () =>
-      LASWriter.encodeSync?.(mesh, {
-        las: {format: 'laz', version: '1.4', pointDataRecordFormat: 5}
-      }),
-    /currently supports point data record formats 0-3 and 6-8/,
-    'LAZ writer rejects unsupported waveform point formats'
+  const waveform = LASWriter.encodeSync?.(mesh, {
+    las: {format: 'laz', version: '1.4', pointDataRecordFormat: 5}
+  });
+  t.equal(
+    new DataView(waveform!).getUint8(104) & 0x7f,
+    5,
+    'LAZ writer supports legacy waveform point formats'
   );
   t.throws(
     () => LASWriter.encodeSync?.(mesh, {las: {format: 'laz', chunkSize: 0}}),

--- a/modules/las/test/las-writer.spec.ts
+++ b/modules/las/test/las-writer.spec.ts
@@ -203,7 +203,7 @@ test('LASWriter#encodes legacy GPS and RGB LAZ point formats', async t => {
     if (pointDataRecordFormat === 3) {
       t.deepEqual(
         Array.from(data.attributes.COLOR_0?.value || []),
-        [10, 20, 30, 255, 246, 246, 246, 255, 70, 80, 90, 255],
+        [10, 20, 30, 255, 40, 50, 60, 255, 70, 80, 90, 255],
         'PDRF 3 RGB roundtrips through TypeScript decoder'
       );
     }

--- a/modules/loader-utils/src/lib/laz/laz-chunk-encoder.ts
+++ b/modules/loader-utils/src/lib/laz/laz-chunk-encoder.ts
@@ -17,6 +17,8 @@ const POINT_FORMAT_BASE_LENGTHS: Record<number, number> = {
   1: 28,
   2: 26,
   3: 34,
+  4: 57,
+  5: 63,
   6: 30,
   7: 36,
   8: 38
@@ -140,7 +142,7 @@ export function encodeLAZChunk(
     return new Uint8Array(0);
   }
 
-  if (metadata.pointDataRecordFormat <= 3) {
+  if (metadata.pointDataRecordFormat <= 5) {
     return encodeLegacyPointFormatChunk(rawBytes, metadata);
   }
 
@@ -268,7 +270,7 @@ export function encodeLASzipVLR(options: {
     const item = items[itemIndex];
     dataView.setUint16(itemOffset, item.type, true);
     dataView.setUint16(itemOffset + 2, item.size, true);
-    dataView.setUint16(itemOffset + 4, itemVersion, true);
+    dataView.setUint16(itemOffset + 4, item.version ?? itemVersion, true);
   }
   return bytes;
 }
@@ -323,12 +325,17 @@ function encodeLegacyPointFormatChunk(
   const encoder = new ArithmeticEncoder();
   const pointEncoder = new Point10LayerEncoder(encoder, readPoint10(firstRecord, 0));
   const gpsTimeEncoder =
-    pointFormat === 1 || pointFormat === 3
+    pointFormat === 1 || pointFormat === 3 || pointFormat === 4 || pointFormat === 5
       ? new GpsTime10LayerEncoder(encoder, readFloat64(firstRecord, 20))
       : null;
-  const rgbOffset = pointFormat === 2 ? 20 : pointFormat === 3 ? 28 : -1;
+  const rgbOffset = pointFormat === 2 ? 20 : pointFormat === 3 || pointFormat === 5 ? 28 : -1;
   const rgbEncoder =
     rgbOffset >= 0 ? new RGB10LayerEncoder(encoder, readRgb(firstRecord, rgbOffset)) : null;
+  const wavePacketOffset = pointFormat === 4 ? 28 : pointFormat === 5 ? 34 : -1;
+  const wavePacketEncoder =
+    wavePacketOffset >= 0
+      ? new WavePacket13LayerEncoder(encoder, readWavePacket(firstRecord, wavePacketOffset))
+      : null;
   const extraBytesEncoder = extraByteCount
     ? new Byte10LayerEncoder(encoder, firstRecord.subarray(baseRecordLength, pointRecordLength))
     : null;
@@ -339,6 +346,7 @@ function encodeLegacyPointFormatChunk(
     pointEncoder.encode(readPoint10(record, 0));
     gpsTimeEncoder?.encode(readFloat64(record, 20));
     rgbEncoder?.encode(readRgb(record, rgbOffset));
+    wavePacketEncoder?.encode(readWavePacket(record, wavePacketOffset));
     extraBytesEncoder?.encode(record.subarray(baseRecordLength, pointRecordLength));
   }
 
@@ -480,10 +488,14 @@ class GpsTime10LayerEncoder {
 
     if (this.lastGpsTimeDifference[sequence] === 0) {
       if (differenceFits) {
-        this.encoder.encodeSymbol(this.gpsTime0DiffModel, 0);
-        this.gpsTime.compress(0, difference, 0);
-        this.lastGpsTimeDifference[sequence] = difference;
-        this.multiExtremeCounter[sequence] = 0;
+        if (difference === 0) {
+          this.encoder.encodeSymbol(this.gpsTime0DiffModel, 0);
+        } else {
+          this.encoder.encodeSymbol(this.gpsTime0DiffModel, 1);
+          this.gpsTime.compress(0, difference, 0);
+          this.lastGpsTimeDifference[sequence] = difference;
+          this.multiExtremeCounter[sequence] = 0;
+        }
       } else if (this.selectSequence(gpsTime, false)) {
         this.encode(gpsTime);
         return;
@@ -655,6 +667,89 @@ class RGB10LayerEncoder {
   }
 }
 
+type WavePacket13 = {
+  /** Waveform descriptor table index. */
+  descriptorIndex: number;
+  /** Byte offset of the waveform packet in the external waveform data. */
+  offset: bigint;
+  /** Waveform packet byte length. */
+  packetSize: number;
+  /** Raw IEEE-754 bits for the return-point location. */
+  returnPointBits: number;
+  /** Raw IEEE-754 bits for the waveform X vector component. */
+  xBits: number;
+  /** Raw IEEE-754 bits for the waveform Y vector component. */
+  yBits: number;
+  /** Raw IEEE-754 bits for the waveform Z vector component. */
+  zBits: number;
+};
+
+/** Encode the legacy LASzip waveform packet reference item. */
+class WavePacket13LayerEncoder {
+  private readonly descriptorModel: ArithmeticModel;
+  private readonly offsetDifferenceModels: ArithmeticModel[];
+  private readonly offsetDifferenceCompressor: IntegerCompressor;
+  private readonly packetSizeCompressor: IntegerCompressor;
+  private readonly returnPointCompressor: IntegerCompressor;
+  private readonly vectorCompressor: IntegerCompressor;
+  private last: WavePacket13;
+  private lastOffsetDifference = 0;
+  private lastOffsetDifferenceSymbol = 0;
+
+  /** Initialize waveform prediction state from the first raw packet reference. */
+  constructor(
+    private readonly encoder: ArithmeticEncoder,
+    firstPacket: WavePacket13
+  ) {
+    this.descriptorModel = new ArithmeticModel(256);
+    this.offsetDifferenceModels = createModels(4, 4);
+    this.offsetDifferenceCompressor = new IntegerCompressor(encoder, 32, 1);
+    this.packetSizeCompressor = new IntegerCompressor(encoder, 32, 1);
+    this.returnPointCompressor = new IntegerCompressor(encoder, 32, 1);
+    this.vectorCompressor = new IntegerCompressor(encoder, 32, 3);
+    this.last = {...firstPacket};
+  }
+
+  /** Encode one waveform packet reference after the first raw item. */
+  encode(packet: WavePacket13): void {
+    const last = this.last;
+    this.encoder.encodeSymbol(this.descriptorModel, packet.descriptorIndex);
+    let offsetDifferenceSymbol = 0;
+    if (packet.offset === last.offset) {
+      offsetDifferenceSymbol = 0;
+    } else if (packet.offset === last.offset + BigInt(last.packetSize)) {
+      offsetDifferenceSymbol = 1;
+    } else {
+      const difference = BigInt.asIntN(64, packet.offset - last.offset);
+      if (difference === BigInt.asIntN(32, difference)) {
+        offsetDifferenceSymbol = 2;
+      } else {
+        offsetDifferenceSymbol = 3;
+      }
+    }
+    this.encoder.encodeSymbol(
+      this.offsetDifferenceModels[this.lastOffsetDifferenceSymbol],
+      offsetDifferenceSymbol
+    );
+    this.lastOffsetDifferenceSymbol = offsetDifferenceSymbol;
+    if (offsetDifferenceSymbol === 2) {
+      const difference = Number(BigInt.asIntN(32, packet.offset - last.offset));
+      this.offsetDifferenceCompressor.compress(this.lastOffsetDifference, difference, 0);
+      this.lastOffsetDifference = difference;
+    }
+    if (offsetDifferenceSymbol === 3) {
+      this.encoder.writeInt(Number(packet.offset & 0xffffffffn));
+      this.encoder.writeInt(Number(packet.offset >> 32n));
+    }
+    this.packetSizeCompressor.compress(last.packetSize, packet.packetSize, 0);
+    this.returnPointCompressor.compress(last.returnPointBits, packet.returnPointBits, 0);
+    this.vectorCompressor.compress(last.xBits, packet.xBits, 0);
+    this.vectorCompressor.compress(last.yBits, packet.yBits, 1);
+    this.vectorCompressor.compress(last.zBits, packet.zBits, 2);
+    this.last = {...packet};
+  }
+}
+
 /** Encode the legacy Byte item that carries Extra Bytes values. */
 class Byte10LayerEncoder {
   private readonly models: ArithmeticModel[];
@@ -693,6 +788,8 @@ type LASzipItem = {
   type: number;
   /** Uncompressed item byte length. */
   size: number;
+  /** LASzip item codec version, when it differs from the point-family version. */
+  version?: 1 | 2 | 3;
 };
 
 /** Prediction state for one Point14 scanner channel. */
@@ -1459,13 +1556,21 @@ function getLASzipItems(
       `Invalid point record length ${pointDataRecordLength} for point format ${pointDataRecordFormat}`
     );
   }
-  if (pointDataRecordFormat <= 3) {
+  if (pointDataRecordFormat <= 5) {
     const legacyItems: LASzipItem[] = [{type: 6, size: 20}];
-    if (pointDataRecordFormat === 1 || pointDataRecordFormat === 3) {
+    if (
+      pointDataRecordFormat === 1 ||
+      pointDataRecordFormat === 3 ||
+      pointDataRecordFormat === 4 ||
+      pointDataRecordFormat === 5
+    ) {
       legacyItems.push({type: 7, size: 8});
     }
-    if (pointDataRecordFormat === 2 || pointDataRecordFormat === 3) {
+    if (pointDataRecordFormat === 2 || pointDataRecordFormat === 3 || pointDataRecordFormat === 5) {
       legacyItems.push({type: 8, size: 6});
+    }
+    if (pointDataRecordFormat === 4 || pointDataRecordFormat === 5) {
+      legacyItems.push({type: 9, size: 29, version: 1});
     }
     const legacyExtraByteCount = pointDataRecordLength - baseLength;
     if (legacyExtraByteCount > 0) {
@@ -1526,6 +1631,20 @@ function readRgb(bytes: Uint8Array, offset: number): Rgb14 {
     red: readUint16(bytes, offset),
     green: readUint16(bytes, offset + 2),
     blue: readUint16(bytes, offset + 4)
+  };
+}
+
+/** Parse one raw legacy waveform packet reference. */
+function readWavePacket(bytes: Uint8Array, offset: number): WavePacket13 {
+  const view = new DataView(bytes.buffer, bytes.byteOffset + offset, 29);
+  return {
+    descriptorIndex: view.getUint8(0),
+    offset: view.getBigUint64(1, true),
+    packetSize: view.getUint32(9, true),
+    returnPointBits: view.getInt32(13, true),
+    xBits: view.getInt32(17, true),
+    yBits: view.getInt32(21, true),
+    zBits: view.getInt32(25, true)
   };
 }
 

--- a/modules/loader-utils/src/lib/laz/laz-chunk-encoder.ts
+++ b/modules/loader-utils/src/lib/laz/laz-chunk-encoder.ts
@@ -238,6 +238,12 @@ export function encodeLASzipVLR(options: {
 }): Uint8Array {
   const legacy = options.pointDataRecordFormat <= 5;
   const itemVersion = options.itemVersion || (legacy ? 2 : 3);
+  if (legacy && itemVersion !== 2) {
+    throw new Error('Legacy LASzip point formats require item version 2');
+  }
+  if (!legacy && itemVersion !== 3) {
+    throw new Error('Modern LASzip point formats require item version 3');
+  }
   const items = getLASzipItems(options.pointDataRecordFormat, options.pointDataRecordLength);
   const payloadLength = LASZIP_VLR_PAYLOAD_BASE_LENGTH + items.length * 6;
   const bytes = new Uint8Array(LASZIP_VLR_HEADER_LENGTH + payloadLength);
@@ -362,7 +368,6 @@ class Point10LayerEncoder {
     firstPoint: Point10
   ) {
     this.last = {...firstPoint};
-    this.lastHeight.fill(firstPoint.z);
     this.intensityCompressor = new IntegerCompressor(encoder, 16, 4);
     this.pointSourceIdCompressor = new IntegerCompressor(encoder, 16, 1);
     this.xDifferenceCompressor = new IntegerCompressor(encoder, 32, 2);
@@ -373,9 +378,13 @@ class Point10LayerEncoder {
   /** Encode one Point10 record after the first raw record. */
   encode(point: Point10): void {
     const lastPoint = this.last;
+    const returnNumber = point.bitByte & 7;
+    const numberOfReturns = (point.bitByte >> 3) & 7;
+    const context = NUMBER_RETURN_MAP_10_CONTEXT[numberOfReturns][returnNumber];
+    const levelContext = NUMBER_RETURN_LEVEL_10_CONTEXT[numberOfReturns][returnNumber];
     const changedValues =
       (point.bitByte !== lastPoint.bitByte ? 1 << 5 : 0) |
-      (point.intensity !== lastPoint.intensity ? 1 << 4 : 0) |
+      (point.intensity !== this.lastIntensity[context] ? 1 << 4 : 0) |
       (point.classification !== lastPoint.classification ? 1 << 3 : 0) |
       (point.scanAngleRank !== lastPoint.scanAngleRank ? 1 << 2 : 0) |
       (point.userData !== lastPoint.userData ? 1 << 1 : 0) |
@@ -385,11 +394,6 @@ class Point10LayerEncoder {
     if (changedValues & (1 << 5)) {
       this.encoder.encodeSymbol(this.bitByteModels[lastPoint.bitByte], point.bitByte);
     }
-
-    const returnNumber = point.bitByte & 7;
-    const numberOfReturns = (point.bitByte >> 3) & 7;
-    const context = NUMBER_RETURN_MAP_10_CONTEXT[numberOfReturns][returnNumber];
-    const levelContext = NUMBER_RETURN_LEVEL_10_CONTEXT[numberOfReturns][returnNumber];
 
     if (changedValues & (1 << 4)) {
       this.intensityCompressor.compress(
@@ -407,7 +411,7 @@ class Point10LayerEncoder {
     }
     if (changedValues & (1 << 2)) {
       this.encoder.encodeSymbol(
-        this.scanAngleRankModels[(lastPoint.bitByte >> 6) & 1],
+        this.scanAngleRankModels[(point.bitByte >> 6) & 1],
         foldInt8(point.scanAngleRank - lastPoint.scanAngleRank)
       );
     }

--- a/modules/loader-utils/src/lib/laz/laz-chunk-encoder.ts
+++ b/modules/loader-utils/src/lib/laz/laz-chunk-encoder.ts
@@ -21,7 +21,9 @@ const POINT_FORMAT_BASE_LENGTHS: Record<number, number> = {
   5: 63,
   6: 30,
   7: 36,
-  8: 38
+  8: 38,
+  9: 59,
+  10: 67
 };
 const LASZIP_VLR_HEADER_LENGTH = 54;
 const LASZIP_VLR_PAYLOAD_BASE_LENGTH = 34;
@@ -153,13 +155,23 @@ export function encodeLAZChunk(
   const firstRecord = rawBytes.subarray(0, pointRecordLength);
   const firstPoint = readPoint14(firstRecord, 0);
   const pointEncoder = new Point14LayerEncoder(firstPoint);
-  const firstRgb = pointFormat >= 7 ? readRgb(firstRecord, 30) : null;
+  const firstRgb =
+    pointFormat === 7 || pointFormat === 8 || pointFormat === 10 ? readRgb(firstRecord, 30) : null;
   const rgbEncoder = firstRgb
     ? new RGB14LayerEncoder(firstRgb, getScannerChannel(firstPoint))
     : null;
   const nirEncoder =
-    pointFormat === 8
+    pointFormat === 8 || pointFormat === 10
       ? new NIR14LayerEncoder(readUint16(firstRecord, 36), getScannerChannel(firstPoint))
+      : null;
+  const wavePacketOffset = pointFormat === 9 ? 30 : pointFormat === 10 ? 38 : -1;
+  const wavePacketEncoder =
+    wavePacketOffset >= 0
+      ? new WavePacket14LayerEncoder(
+          readWavePacket(firstRecord, wavePacketOffset),
+          getScannerChannel(firstPoint),
+          metadata.wavePacketItemVersion ?? 3
+        )
       : null;
   const extraBytesEncoder = extraByteCount
     ? new Byte14LayerEncoder(
@@ -173,18 +185,21 @@ export function encodeLAZChunk(
     const record = rawBytes.subarray(recordOffset, recordOffset + pointRecordLength);
     const itemContext = pointEncoder.encode(readPoint14(record, 0));
     rgbEncoder?.encode(readRgb(record, 30), itemContext);
-    nirEncoder?.encode(readUint16(record, 36), itemContext);
+    nirEncoder?.encode(readUint16(record, pointFormat === 10 ? 36 : 36), itemContext);
+    wavePacketEncoder?.encode(readWavePacket(record, wavePacketOffset), itemContext);
     extraBytesEncoder?.encode(record.subarray(baseRecordLength, pointRecordLength), itemContext);
   }
 
   const pointLayers = pointEncoder.finish();
   const rgbLayer = rgbEncoder?.finish();
   const nirLayer = nirEncoder?.finish();
+  const wavePacketLayer = wavePacketEncoder?.finish();
   const extraByteLayers = extraBytesEncoder?.finish() || [];
   const layers = [
     ...pointLayers,
     ...(rgbLayer ? [rgbLayer] : []),
     ...(nirLayer ? [nirLayer] : []),
+    ...(wavePacketLayer ? [wavePacketLayer] : []),
     ...extraByteLayers
   ];
 
@@ -747,6 +762,126 @@ class WavePacket13LayerEncoder {
     this.vectorCompressor.compress(last.yBits, packet.yBits, 1);
     this.vectorCompressor.compress(last.zBits, packet.zBits, 2);
     this.last = {...packet};
+  }
+}
+
+/** Prediction state for one modern waveform scanner-channel context. */
+class WavePacket14Context {
+  /** Last packet reference. */
+  packet: WavePacket13;
+  /** Descriptor arithmetic model. */
+  readonly descriptorModel = new ArithmeticModel(256);
+  /** Offset selector models. */
+  readonly offsetDifferenceModels = createModels(4, 4);
+  /** Offset difference compressor. */
+  readonly offsetDifferenceCompressor: IntegerCompressor;
+  /** Packet-size compressor. */
+  readonly packetSizeCompressor: IntegerCompressor;
+  /** Return-point compressor. */
+  readonly returnPointCompressor: IntegerCompressor;
+  /** Vector compressor. */
+  readonly vectorCompressor: IntegerCompressor;
+  /** Last signed offset difference. */
+  lastOffsetDifference = 0;
+  /** Last offset selector. */
+  lastOffsetDifferenceSymbol = 0;
+  /** Whether this context has a packet reference. */
+  haveLast = false;
+
+  /** Initialize one modern waveform prediction context. */
+  constructor(encoder: ArithmeticEncoder, packet: WavePacket13) {
+    this.packet = {...packet};
+    this.offsetDifferenceCompressor = new IntegerCompressor(encoder, 32, 1);
+    this.packetSizeCompressor = new IntegerCompressor(encoder, 32, 1);
+    this.returnPointCompressor = new IntegerCompressor(encoder, 32, 1);
+    this.vectorCompressor = new IntegerCompressor(encoder, 32, 3);
+    this.haveLast = true;
+  }
+}
+
+/** Encode the LASzip v3/v4 modern waveform packet reference layer. */
+class WavePacket14LayerEncoder {
+  private readonly encoder = new ArithmeticEncoder();
+  private readonly contexts: Array<WavePacket14Context | null> = new Array(4).fill(null);
+  private readonly itemVersion: 3 | 4;
+  private lastChannel: number;
+
+  /** Initialize modern waveform coding from the first packet reference. */
+  constructor(firstPacket: WavePacket13, firstChannel: number, itemVersion: 3 | 4) {
+    this.itemVersion = itemVersion;
+    this.lastChannel = firstChannel;
+    this.contexts[firstChannel] = new WavePacket14Context(this.encoder, firstPacket);
+  }
+
+  /** Encode one waveform reference using the Point14 scanner-channel context. */
+  encode(packet: WavePacket13, scannerChannel: number): void {
+    const previousContext = this.contexts[this.lastChannel]!;
+    let targetContext = this.contexts[scannerChannel];
+    let codingContext = targetContext;
+    if (scannerChannel !== this.lastChannel) {
+      if (!targetContext) {
+        targetContext = new WavePacket14Context(this.encoder, previousContext.packet);
+        targetContext.lastOffsetDifference = previousContext.lastOffsetDifference;
+        targetContext.lastOffsetDifferenceSymbol = previousContext.lastOffsetDifferenceSymbol;
+        this.contexts[scannerChannel] = targetContext;
+        codingContext = targetContext;
+      } else if (this.itemVersion < 4) {
+        codingContext = targetContext;
+        targetContext = previousContext;
+      }
+      this.lastChannel = scannerChannel;
+    }
+    this.encodePacket(codingContext!, targetContext!, packet);
+  }
+
+  /** Finish the independent waveform arithmetic stream. */
+  finish(): Uint8Array {
+    return this.encoder.finish();
+  }
+
+  private encodePacket(
+    codingContext: WavePacket14Context,
+    targetContext: WavePacket14Context,
+    packet: WavePacket13
+  ): void {
+    const last = targetContext.packet;
+    this.encoder.encodeSymbol(codingContext.descriptorModel, packet.descriptorIndex);
+    let offsetDifferenceSymbol = 0;
+    if (packet.offset === last.offset) {
+      offsetDifferenceSymbol = 0;
+    } else if (packet.offset === last.offset + BigInt(last.packetSize)) {
+      offsetDifferenceSymbol = 1;
+    } else if (
+      BigInt.asIntN(64, packet.offset - last.offset) ===
+      BigInt.asIntN(32, packet.offset - last.offset)
+    ) {
+      offsetDifferenceSymbol = 2;
+    } else {
+      offsetDifferenceSymbol = 3;
+    }
+    this.encoder.encodeSymbol(
+      codingContext.offsetDifferenceModels[codingContext.lastOffsetDifferenceSymbol],
+      offsetDifferenceSymbol
+    );
+    codingContext.lastOffsetDifferenceSymbol = offsetDifferenceSymbol;
+    if (offsetDifferenceSymbol === 2) {
+      const difference = Number(BigInt.asIntN(32, packet.offset - last.offset));
+      codingContext.offsetDifferenceCompressor.compress(
+        codingContext.lastOffsetDifference,
+        difference,
+        0
+      );
+      codingContext.lastOffsetDifference = difference;
+    } else if (offsetDifferenceSymbol === 3) {
+      this.encoder.writeInt(Number(packet.offset & 0xffffffffn));
+      this.encoder.writeInt(Number(packet.offset >> 32n));
+    }
+    codingContext.packetSizeCompressor.compress(last.packetSize, packet.packetSize, 0);
+    codingContext.returnPointCompressor.compress(last.returnPointBits, packet.returnPointBits, 0);
+    codingContext.vectorCompressor.compress(last.xBits, packet.xBits, 0);
+    codingContext.vectorCompressor.compress(last.yBits, packet.yBits, 1);
+    codingContext.vectorCompressor.compress(last.zBits, packet.zBits, 2);
+    targetContext.packet = {...packet};
   }
 }
 
@@ -1513,6 +1648,13 @@ function validateMetadata(rawBytes: Uint8Array, metadata: LAZChunkMetadata): voi
     throw new Error(`TypeScript LAZ encoder only supports RGB14 item version 3`);
   }
   if (
+    (metadata.pointDataRecordFormat === 9 || metadata.pointDataRecordFormat === 10) &&
+    metadata.wavePacketItemVersion !== undefined &&
+    metadata.wavePacketItemVersion !== 3
+  ) {
+    throw new Error(`TypeScript LAZ encoder only supports WavePacket14 item version 3`);
+  }
+  if (
     metadata.pointDataRecordLength > baseLength &&
     metadata.byte14ItemVersion !== undefined &&
     metadata.byte14ItemVersion !== 3
@@ -1583,6 +1725,11 @@ function getLASzipItems(
     items.push({type: 11, size: 6});
   } else if (pointDataRecordFormat === 8) {
     items.push({type: 12, size: 8});
+  } else if (pointDataRecordFormat === 10) {
+    items.push({type: 12, size: 8});
+  }
+  if (pointDataRecordFormat === 9 || pointDataRecordFormat === 10) {
+    items.push({type: 13, size: 29});
   }
   const extraByteCount = pointDataRecordLength - baseLength;
   if (extraByteCount > 0) {

--- a/modules/loader-utils/test/lib/laz/laz-chunk-encoder.spec.ts
+++ b/modules/loader-utils/test/lib/laz/laz-chunk-encoder.spec.ts
@@ -8,6 +8,7 @@ import {
   decodeLAZChunk,
   decodeLAZChunkTable,
   encodeLAZChunk,
+  encodeLASzipVLR,
   encodeLAZChunkTable,
   getLAZChunkByteLength
 } from '@loaders.gl/loader-utils';
@@ -74,6 +75,17 @@ test('LAZChunkEncoder#validates input and item versions', t => {
       }),
     /does not support point format 4/,
     'waveform legacy point formats remain unsupported'
+  );
+  t.throws(
+    () =>
+      encodeLASzipVLR({
+        pointDataRecordFormat: 0,
+        pointDataRecordLength: 20,
+        chunkSize: 1,
+        itemVersion: 3
+      }),
+    /Legacy LASzip point formats require item version 2/,
+    'legacy item version overrides are rejected'
   );
   t.throws(
     () => encodeLAZChunk(rawPointData.subarray(1), metadata),

--- a/modules/loader-utils/test/lib/laz/laz-chunk-encoder.spec.ts
+++ b/modules/loader-utils/test/lib/laz/laz-chunk-encoder.spec.ts
@@ -180,6 +180,62 @@ test('LAZChunkEncoder#writes legacy waveform LASzip item descriptors', t => {
   t.end();
 });
 
+test('LAZChunkEncoder#roundtrips modern waveform items', t => {
+  for (const pointDataRecordFormat of [9, 10] as const) {
+    const pointDataRecordLength = pointDataRecordFormat === 9 ? 59 : 67;
+    const rawPointData = new Uint8Array(pointDataRecordLength * 2);
+    const dataView = new DataView(rawPointData.buffer);
+    for (let pointIndex = 0; pointIndex < 2; pointIndex++) {
+      const recordOffset = pointIndex * pointDataRecordLength;
+      dataView.setInt32(recordOffset, 100 + pointIndex, true);
+      dataView.setInt32(recordOffset + 4, 200 + pointIndex, true);
+      dataView.setInt32(recordOffset + 8, 300 + pointIndex, true);
+      dataView.setUint16(recordOffset + 12, 10 + pointIndex, true);
+      dataView.setUint8(recordOffset + 14, 0x11);
+      dataView.setUint8(recordOffset + 15, 0);
+      dataView.setUint8(recordOffset + 16, 2);
+      dataView.setUint8(recordOffset + 17, 3);
+      dataView.setInt16(recordOffset + 18, -4 + pointIndex, true);
+      dataView.setUint16(recordOffset + 20, 7, true);
+      dataView.setFloat64(recordOffset + 22, 123.5 + pointIndex * 0.001, true);
+      if (pointDataRecordFormat === 10) {
+        dataView.setUint16(recordOffset + 30, 1000 + pointIndex, true);
+        dataView.setUint16(recordOffset + 32, 2000 + pointIndex, true);
+        dataView.setUint16(recordOffset + 34, 3000 + pointIndex, true);
+        dataView.setUint16(recordOffset + 36, 4000 + pointIndex, true);
+      }
+      const waveformOffset = pointDataRecordFormat === 9 ? 30 : 38;
+      dataView.setUint8(recordOffset + waveformOffset, 1);
+      dataView.setBigUint64(
+        recordOffset + waveformOffset + 1,
+        BigInt(5000 + pointIndex * 20),
+        true
+      );
+      dataView.setUint32(recordOffset + waveformOffset + 9, 16 + pointIndex, true);
+      dataView.setInt32(recordOffset + waveformOffset + 13, 0x3f000000 + pointIndex, true);
+      dataView.setInt32(recordOffset + waveformOffset + 17, 0x3f800000 + pointIndex, true);
+      dataView.setInt32(recordOffset + waveformOffset + 21, 0x40000000 + pointIndex, true);
+      dataView.setInt32(recordOffset + waveformOffset + 25, 0x40400000 + pointIndex, true);
+    }
+    const metadata = {
+      pointCount: 2,
+      pointDataRecordFormat,
+      pointDataRecordLength,
+      point14ItemVersion: 3 as const,
+      wavePacketItemVersion: 3 as const,
+      rgb14ItemVersion: 3 as const,
+      byte14ItemVersion: 3 as const
+    };
+    const compressed = encodeLAZChunk(rawPointData, metadata);
+    t.deepEqual(
+      decodeLAZChunk(compressed, metadata),
+      rawPointData,
+      `PDRF ${pointDataRecordFormat} waveform item roundtrips`
+    );
+  }
+  t.end();
+});
+
 test('LAZChunkEncoder#encodes LASzip v2 PDRF 0 chunks', t => {
   const pointCount = 32;
   const pointDataRecordLength = 22;

--- a/modules/loader-utils/test/lib/laz/laz-chunk-encoder.spec.ts
+++ b/modules/loader-utils/test/lib/laz/laz-chunk-encoder.spec.ts
@@ -68,13 +68,14 @@ test('LAZChunkEncoder#validates input and item versions', t => {
   const {rawPointData, metadata} = createLAZEncodingFixture(6);
   t.throws(
     () =>
-      encodeLAZChunk(new Uint8Array(20), {
-        pointCount: 1,
-        pointDataRecordFormat: 4,
-        pointDataRecordLength: 57
+      encodeLASzipVLR({
+        pointDataRecordFormat: 6,
+        pointDataRecordLength: 30,
+        chunkSize: 1,
+        itemVersion: 2
       }),
-    /does not support point format 4/,
-    'waveform legacy point formats remain unsupported'
+    /Modern LASzip point formats require item version 3/,
+    'modern item version overrides are rejected'
   );
   t.throws(
     () =>
@@ -96,6 +97,85 @@ test('LAZChunkEncoder#validates input and item versions', t => {
     () => encodeLAZChunk(rawPointData, {...metadata, point14ItemVersion: 4}),
     /only supports Point14 item version 3/,
     'unsupported Point14 versions are rejected'
+  );
+  t.end();
+});
+
+test('LAZChunkEncoder#roundtrips legacy waveform items', t => {
+  for (const pointDataRecordFormat of [4, 5] as const) {
+    const pointDataRecordLength = pointDataRecordFormat === 4 ? 57 : 63;
+    const rawPointData = new Uint8Array(pointDataRecordLength * 2);
+    const dataView = new DataView(rawPointData.buffer);
+    for (let pointIndex = 0; pointIndex < 2; pointIndex++) {
+      const recordOffset = pointIndex * pointDataRecordLength;
+      dataView.setInt32(recordOffset, 100, true);
+      dataView.setInt32(recordOffset + 4, 200, true);
+      dataView.setInt32(recordOffset + 8, 300, true);
+      dataView.setUint16(recordOffset + 12, 10, true);
+      dataView.setUint8(recordOffset + 14, 9);
+      dataView.setUint8(recordOffset + 15, 2);
+      dataView.setInt8(recordOffset + 16, -3);
+      dataView.setUint16(recordOffset + 18, 7, true);
+      dataView.setFloat64(recordOffset + 20, 123.5, true);
+      const waveformOffset = pointDataRecordFormat === 4 ? 28 : 34;
+      if (pointDataRecordFormat === 5) {
+        dataView.setUint16(recordOffset + 28, 1000, true);
+        dataView.setUint16(recordOffset + 30, 2000, true);
+        dataView.setUint16(recordOffset + 32, 3000, true);
+      }
+      dataView.setUint8(recordOffset + waveformOffset, 1);
+      dataView.setBigUint64(
+        recordOffset + waveformOffset + 1,
+        BigInt(5000 + pointIndex * 20),
+        true
+      );
+      dataView.setUint32(recordOffset + waveformOffset + 9, 16, true);
+      dataView.setInt32(recordOffset + waveformOffset + 13, 0x3f000000 + pointIndex, true);
+      dataView.setInt32(recordOffset + waveformOffset + 17, 0x3f800000 + pointIndex, true);
+      dataView.setInt32(recordOffset + waveformOffset + 21, 0x40000000 + pointIndex, true);
+      dataView.setInt32(recordOffset + waveformOffset + 25, 0x40400000 + pointIndex, true);
+    }
+    const encoded = encodeLAZChunk(rawPointData, {
+      pointCount: 2,
+      pointDataRecordFormat,
+      pointDataRecordLength
+    });
+    const decoded = decodeLAZChunk(encoded, {
+      pointCount: 2,
+      pointDataRecordFormat,
+      pointDataRecordLength
+    });
+    const mismatchIndex = decoded.findIndex((value, index) => value !== rawPointData[index]);
+    t.equal(
+      mismatchIndex,
+      -1,
+      `PDRF ${pointDataRecordFormat} waveform item roundtrips (first mismatch ${mismatchIndex})`
+    );
+  }
+  t.end();
+});
+
+test('LAZChunkEncoder#writes legacy waveform LASzip item descriptors', t => {
+  const vlr = encodeLASzipVLR({
+    pointDataRecordFormat: 5,
+    pointDataRecordLength: 63,
+    chunkSize: 50_000
+  });
+  const dataView = new DataView(vlr.buffer, vlr.byteOffset, vlr.byteLength);
+  const itemOffset = 54 + 34;
+  t.deepEqual(
+    [0, 1, 2, 3].map(index => [
+      dataView.getUint16(itemOffset + index * 6, true),
+      dataView.getUint16(itemOffset + index * 6 + 2, true),
+      dataView.getUint16(itemOffset + index * 6 + 4, true)
+    ]),
+    [
+      [6, 20, 2],
+      [7, 8, 2],
+      [8, 6, 2],
+      [9, 29, 1]
+    ],
+    'PDRF 5 items use the LASzip v1 waveform descriptor'
   );
   t.end();
 });


### PR DESCRIPTION
## Goals
- Add interoperable TypeScript LAZ chunk encoding for waveform-bearing LAS point formats.
- Preserve complete raw point records across legacy and modern waveform layouts.
- Keep the public LASWriter and low-level codec claims precise.

## Changes
- Encode LASzip waveform item 9 for legacy PDRF 4 and 5.
- Encode LASzip WavePacket14 item 13 for modern PDRF 9 and 10.
- Add waveform descriptor, 64-bit offset, packet-size, return-point, and vector prediction.
- Support scanner-channel context behavior for modern waveform coding.
- Add PDRF 4/5 legacy item descriptors and modern PDRF 9/10 item descriptors.
- Fix unchanged legacy GPS timestamps so they do not emit a correction the decoder does not consume.
- Enable public LASWriter LAZ output for PDRF 4/5 on LAS 1.3/1.4.
- Preserve legacy GPS time, scan angle, point source ID, and waveform reference fields.
- Add explicit mesh attribute mapping for waveform references.
- Add round-trip coverage for legacy and modern waveform records, item versions, VLR descriptors, and public writer output.
- Update the LAS documentation capability atlas and implementation boundaries.

## Verification
- yarn lint fix
- Focused LAZ encoder suite: 8 passed.
- CI rerun queued for the full build, node, browser, slow, and website matrix.

The public writer still does not assemble complete .laz or COPC containers; this PR strengthens the codec and legacy writer path.