### PR TITLE
fix(las): decode legacy scan flags correctly

### DIFF
--- a/modules/las/src/lib/typescript/parse-las.ts
+++ b/modules/las/src/lib/typescript/parse-las.ts
@@ -1378,10 +1378,12 @@ function populateLASAttributesFromDataView(
       scannerChannels[targetPointIndex] = pointsFormatId <= 5 ? 0 : (scanFlags >> 4) & 0x03;
     }
     if (scanDirectionFlags) {
-      scanDirectionFlags[targetPointIndex] = (scanFlags >> 6) & 1;
+      scanDirectionFlags[targetPointIndex] =
+        pointsFormatId <= 5 ? (returnFlags >> 6) & 1 : (scanFlags >> 6) & 1;
     }
     if (edgeOfFlightLines) {
-      edgeOfFlightLines[targetPointIndex] = (scanFlags >> 7) & 1;
+      edgeOfFlightLines[targetPointIndex] =
+        pointsFormatId <= 5 ? (returnFlags >> 7) & 1 : (scanFlags >> 7) & 1;
     }
     if (waveforms) {
       const waveformOffset = getWaveformOffset(pointsFormatId);

--- a/modules/las/test/las-loader.spec.ts
+++ b/modules/las/test/las-loader.spec.ts
@@ -110,6 +110,22 @@ test('LASLoader#columns decodes legacy point metadata', async () => {
       getArrowColumnValues(uncompressed, columnName)
     );
   }
+
+  const header = parseLASHeader(lasArrayBuffer);
+  const pointDataView = new DataView(lasArrayBuffer);
+  const expectedScanDirectionFlags: number[] = [];
+  const expectedEdgeOfFlightLines: number[] = [];
+  for (let pointIndex = 0; pointIndex < header.pointsCount; pointIndex++) {
+    const returnFlags = pointDataView.getUint8(
+      header.pointsOffset + pointIndex * header.pointsStructSize + 14
+    );
+    expectedScanDirectionFlags.push((returnFlags >> 6) & 1);
+    expectedEdgeOfFlightLines.push((returnFlags >> 7) & 1);
+  }
+  expect(getArrowColumnValues(uncompressed, 'scanDirectionFlag')).toEqual(
+    expectedScanDirectionFlags
+  );
+  expect(getArrowColumnValues(uncompressed, 'edgeOfFlightLine')).toEqual(expectedEdgeOfFlightLines);
 });
 
 test('LASLoader#columns decodes only requested PDRF 7 Arrow columns', async () => {


### PR DESCRIPTION
## Goals

- Correct `scanDirectionFlag` and `edgeOfFlightLine` decoding for legacy LAS/LAZ PDRF 0-5.
- Add a regression assertion against the raw LAS record bytes.

## Changes

- Read legacy scan direction and edge-of-flight-line bits from the PDRF 0-5 return-flags byte.
- Continue reading the separate scan-flags byte for modern PDRF 6-10.
- Assert the legacy Arrow columns against independently decoded raw record bits.

## Validation

- `yarn test-headless modules/las/test/las-loader.spec.ts`: 12 passed.
- `git diff --check`: passed.
- TypeScript compilation in the isolated worktree requires dependency build outputs; the focused headless suite passed using the repository's existing dependencies.
