### PR TITLE
fix(las): make LAS 1.4 Rust loader safe

### DIFF
--- a/modules/las/src/laz-rs-loader.ts
+++ b/modules/las/src/laz-rs-loader.ts
@@ -15,6 +15,9 @@ import initLazRsWasm from './libs/laz-rs-wasm/laz_rs_wasm';
  */
 export const LAZRsLoader = {
   ...LASWorkerLoader,
+  // The bundled LAS worker imports the laz-perf implementation. Keep the
+  // laz-rs variant on the main thread until it has a dedicated worker bundle.
+  worker: false,
   parse: async (arrayBuffer: ArrayBuffer, options?: LASLoaderOptions) => {
     await initLazRsWasm();
     return parseLAS(arrayBuffer, {...options});

--- a/modules/las/src/lib/laz-perf/parse-las.ts
+++ b/modules/las/src/lib/laz-perf/parse-las.ts
@@ -63,75 +63,79 @@ function parseLASMesh(arrayBuffer: ArrayBuffer, options: LASLoaderOptions = {}):
 
   /* eslint-disable max-statements */
   // @ts-ignore Possibly undefined
-  parseLASChunked(arrayBuffer, options.las?.skip, (decoder: any = {}, lasHeader: LASHeader) => {
-    if (!originalHeader) {
-      originalHeader = lasHeader;
-      const total = lasHeader.totalToRead;
+  parseLASChunked(
+    arrayBuffer,
+    options.las?.skip ?? 1,
+    (decoder: any = {}, lasHeader: LASHeader) => {
+      if (!originalHeader) {
+        originalHeader = lasHeader;
+        const total = lasHeader.totalToRead;
 
-      const PositionsType = options.las?.fp64 ? Float64Array : Float32Array;
-      positions = new PositionsType(total * 3);
-      // laslaz-decoder.js `pointFormatReaders`
-      colors = lasHeader.hasColor ? new Uint8Array(total * 4) : null;
-      intensities = new Uint16Array(total);
-      classifications = new Uint8Array(total);
+        const PositionsType = options.las?.fp64 ? Float64Array : Float32Array;
+        positions = new PositionsType(total * 3);
+        // laslaz-decoder.js `pointFormatReaders`
+        colors = lasHeader.hasColor ? new Uint8Array(total * 4) : null;
+        intensities = new Uint16Array(total);
+        classifications = new Uint8Array(total);
 
-      lasMesh.loaderData = lasHeader;
-      lasMesh.attributes = {
-        POSITION: {value: positions, size: 3},
-        // non-gltf attributes, use non-capitalized names for now
-        intensity: {value: intensities, size: 1},
-        classification: {value: classifications, size: 1}
+        lasMesh.loaderData = lasHeader;
+        lasMesh.attributes = {
+          POSITION: {value: positions, size: 3},
+          // non-gltf attributes, use non-capitalized names for now
+          intensity: {value: intensities, size: 1},
+          classification: {value: classifications, size: 1}
+        };
+
+        if (colors) {
+          lasMesh.attributes.COLOR_0 = {value: colors, size: 4};
+        }
+      }
+
+      const batchSize = decoder.pointsCount;
+      const {
+        scale: [scaleX, scaleY, scaleZ],
+        offset: [offsetX, offsetY, offsetZ]
+      } = lasHeader;
+
+      const twoByteColor = detectTwoByteColors(decoder, batchSize, options.las?.colorDepth);
+
+      for (let i = 0; i < batchSize; i++) {
+        const {position, color, intensity, classification} = decoder.getPoint(i);
+
+        positions[pointIndex * 3] = position[0] * scaleX + offsetX;
+        positions[pointIndex * 3 + 1] = position[1] * scaleY + offsetY;
+        positions[pointIndex * 3 + 2] = position[2] * scaleZ + offsetZ;
+
+        if (color && colors) {
+          if (twoByteColor) {
+            colors[pointIndex * 4] = color[0] / 256;
+            colors[pointIndex * 4 + 1] = color[1] / 256;
+            colors[pointIndex * 4 + 2] = color[2] / 256;
+          } else {
+            colors[pointIndex * 4] = color[0];
+            colors[pointIndex * 4 + 1] = color[1];
+            colors[pointIndex * 4 + 2] = color[2];
+          }
+          colors[pointIndex * 4 + 3] = 255;
+        }
+
+        intensities[pointIndex] = intensity;
+        classifications[pointIndex] = classification;
+
+        pointIndex++;
+      }
+
+      const meshBatch = {
+        ...lasMesh,
+        header: {
+          vertexCount: lasHeader.totalRead
+        },
+        progress: lasHeader.totalRead / lasHeader.totalToRead
       };
 
-      if (colors) {
-        lasMesh.attributes.COLOR_0 = {value: colors, size: 4};
-      }
+      options?.onProgress?.(meshBatch);
     }
-
-    const batchSize = decoder.pointsCount;
-    const {
-      scale: [scaleX, scaleY, scaleZ],
-      offset: [offsetX, offsetY, offsetZ]
-    } = lasHeader;
-
-    const twoByteColor = detectTwoByteColors(decoder, batchSize, options.las?.colorDepth);
-
-    for (let i = 0; i < batchSize; i++) {
-      const {position, color, intensity, classification} = decoder.getPoint(i);
-
-      positions[pointIndex * 3] = position[0] * scaleX + offsetX;
-      positions[pointIndex * 3 + 1] = position[1] * scaleY + offsetY;
-      positions[pointIndex * 3 + 2] = position[2] * scaleZ + offsetZ;
-
-      if (color && colors) {
-        if (twoByteColor) {
-          colors[pointIndex * 4] = color[0] / 256;
-          colors[pointIndex * 4 + 1] = color[1] / 256;
-          colors[pointIndex * 4 + 2] = color[2] / 256;
-        } else {
-          colors[pointIndex * 4] = color[0];
-          colors[pointIndex * 4 + 1] = color[1];
-          colors[pointIndex * 4 + 2] = color[2];
-        }
-        colors[pointIndex * 4 + 3] = 255;
-      }
-
-      intensities[pointIndex] = intensity;
-      classifications[pointIndex] = classification;
-
-      pointIndex++;
-    }
-
-    const meshBatch = {
-      ...lasMesh,
-      header: {
-        vertexCount: lasHeader.totalRead
-      },
-      progress: lasHeader.totalRead / lasHeader.totalToRead
-    };
-
-    options?.onProgress?.(meshBatch);
-  });
+  );
   /* eslint-enable max-statements */
 
   lasMesh.header = {
@@ -153,7 +157,11 @@ function parseLASMesh(arrayBuffer: ArrayBuffer, options: LASLoaderOptions = {}):
  * @return parsed point cloud
  */
 /* eslint-enable max-statements */
-export function parseLASChunked(rawData: ArrayBuffer, skip: number, onParseData: any = {}): void {
+export function parseLASChunked(
+  rawData: ArrayBuffer,
+  skip: number = 1,
+  onParseData: any = {}
+): void {
   const dataHandler = new LASFile(rawData);
 
   try {

--- a/modules/las/src/lib/laz-rs-wasm/parse-las.ts
+++ b/modules/las/src/lib/laz-rs-wasm/parse-las.ts
@@ -63,75 +63,79 @@ function parseLASMesh(arrayBuffer: ArrayBuffer, options: LASLoaderOptions = {}):
 
   /* eslint-disable max-statements */
   // @ts-ignore Possibly undefined
-  parseLASChunked(arrayBuffer, options.las?.skip, (decoder: any = {}, lasHeader: LASHeader) => {
-    if (!originalHeader) {
-      originalHeader = lasHeader;
-      const total = lasHeader.totalToRead;
+  parseLASChunked(
+    arrayBuffer,
+    options.las?.skip ?? 1,
+    (decoder: any = {}, lasHeader: LASHeader) => {
+      if (!originalHeader) {
+        originalHeader = lasHeader;
+        const total = lasHeader.totalToRead;
 
-      const PositionsType = options.las?.fp64 ? Float64Array : Float32Array;
-      positions = new PositionsType(total * 3);
-      // laslaz-decoder.js `pointFormatReaders`
-      colors = lasHeader.hasColor ? new Uint8Array(total * 4) : null;
-      intensities = new Uint16Array(total);
-      classifications = new Uint8Array(total);
+        const PositionsType = options.las?.fp64 ? Float64Array : Float32Array;
+        positions = new PositionsType(total * 3);
+        // laslaz-decoder.js `pointFormatReaders`
+        colors = lasHeader.hasColor ? new Uint8Array(total * 4) : null;
+        intensities = new Uint16Array(total);
+        classifications = new Uint8Array(total);
 
-      lasMesh.loaderData = lasHeader;
-      lasMesh.attributes = {
-        POSITION: {value: positions, size: 3},
-        // non-gltf attributes, use non-capitalized names for now
-        intensity: {value: intensities, size: 1},
-        classification: {value: classifications, size: 1}
+        lasMesh.loaderData = lasHeader;
+        lasMesh.attributes = {
+          POSITION: {value: positions, size: 3},
+          // non-gltf attributes, use non-capitalized names for now
+          intensity: {value: intensities, size: 1},
+          classification: {value: classifications, size: 1}
+        };
+
+        if (colors) {
+          lasMesh.attributes.COLOR_0 = {value: colors, size: 4};
+        }
+      }
+
+      const batchSize = decoder.pointsCount;
+      const {
+        scale: [scaleX, scaleY, scaleZ],
+        offset: [offsetX, offsetY, offsetZ]
+      } = lasHeader;
+
+      const twoByteColor = detectTwoByteColors(decoder, batchSize, options.las?.colorDepth);
+
+      for (let i = 0; i < batchSize; i++) {
+        const {position, color, intensity, classification} = decoder.getPoint(i);
+
+        positions[pointIndex * 3] = position[0] * scaleX + offsetX;
+        positions[pointIndex * 3 + 1] = position[1] * scaleY + offsetY;
+        positions[pointIndex * 3 + 2] = position[2] * scaleZ + offsetZ;
+
+        if (color && colors) {
+          if (twoByteColor) {
+            colors[pointIndex * 4] = color[0] / 256;
+            colors[pointIndex * 4 + 1] = color[1] / 256;
+            colors[pointIndex * 4 + 2] = color[2] / 256;
+          } else {
+            colors[pointIndex * 4] = color[0];
+            colors[pointIndex * 4 + 1] = color[1];
+            colors[pointIndex * 4 + 2] = color[2];
+          }
+          colors[pointIndex * 4 + 3] = 255;
+        }
+
+        intensities[pointIndex] = intensity;
+        classifications[pointIndex] = classification;
+
+        pointIndex++;
+      }
+
+      const meshBatch = {
+        ...lasMesh,
+        header: {
+          vertexCount: lasHeader.totalRead
+        },
+        progress: lasHeader.totalRead / lasHeader.totalToRead
       };
 
-      if (colors) {
-        lasMesh.attributes.COLOR_0 = {value: colors, size: 4};
-      }
+      options?.onProgress?.(meshBatch);
     }
-
-    const batchSize = decoder.pointsCount;
-    const {
-      scale: [scaleX, scaleY, scaleZ],
-      offset: [offsetX, offsetY, offsetZ]
-    } = lasHeader;
-
-    const twoByteColor = detectTwoByteColors(decoder, batchSize, options.las?.colorDepth);
-
-    for (let i = 0; i < batchSize; i++) {
-      const {position, color, intensity, classification} = decoder.getPoint(i);
-
-      positions[pointIndex * 3] = position[0] * scaleX + offsetX;
-      positions[pointIndex * 3 + 1] = position[1] * scaleY + offsetY;
-      positions[pointIndex * 3 + 2] = position[2] * scaleZ + offsetZ;
-
-      if (color && colors) {
-        if (twoByteColor) {
-          colors[pointIndex * 4] = color[0] / 256;
-          colors[pointIndex * 4 + 1] = color[1] / 256;
-          colors[pointIndex * 4 + 2] = color[2] / 256;
-        } else {
-          colors[pointIndex * 4] = color[0];
-          colors[pointIndex * 4 + 1] = color[1];
-          colors[pointIndex * 4 + 2] = color[2];
-        }
-        colors[pointIndex * 4 + 3] = 255;
-      }
-
-      intensities[pointIndex] = intensity;
-      classifications[pointIndex] = classification;
-
-      pointIndex++;
-    }
-
-    const meshBatch = {
-      ...lasMesh,
-      header: {
-        vertexCount: lasHeader.totalRead
-      },
-      progress: lasHeader.totalRead / lasHeader.totalToRead
-    };
-
-    options?.onProgress?.(meshBatch);
-  });
+  );
   /* eslint-enable max-statements */
 
   lasMesh.header = {
@@ -153,7 +157,11 @@ function parseLASMesh(arrayBuffer: ArrayBuffer, options: LASLoaderOptions = {}):
  * @return parsed point cloud
  */
 /* eslint-enable max-statements */
-export function parseLASChunked(rawData: ArrayBuffer, skip: number, onParseData: any = {}): void {
+export function parseLASChunked(
+  rawData: ArrayBuffer,
+  skip: number = 1,
+  onParseData: any = {}
+): void {
   const dataHandler = new LASFile(rawData);
 
   try {

--- a/modules/las/test/las-loader.spec.ts
+++ b/modules/las/test/las-loader.spec.ts
@@ -10,7 +10,7 @@ import {
   validateTableCategoryData
 } from 'test/common/conformance';
 
-import {LASLoader, LASWorkerLoader} from '@loaders.gl/las';
+import {LASLoader, LASWorkerLoader, LAZRsLoader} from '@loaders.gl/las';
 import {setLoaderOptions, fetchFile, parse, load} from '@loaders.gl/core';
 // import {ArrowLoader} from '@loaders.gl/arrow';
 
@@ -62,6 +62,17 @@ test('LASLoader#options', async (t) => {
     'POSITION attribute is Float64Array'
   );
 
+  t.end();
+});
+
+test('LAZRsLoader#defaults skip and stays on the main thread', async (t) => {
+  t.notOk(LAZRsLoader.worker, 'laz-rs does not use the laz-perf worker bundle');
+
+  const data = await parse(fetchFile(LAS_BINARY_URL), LAZRsLoader, {
+    core: {worker: false}
+  });
+  validateMeshCategoryData(t, data);
+  t.equal(data.attributes.POSITION.value.length, 808042 * 3, 'all points are decoded by default');
   t.end();
 });
 


### PR DESCRIPTION
## Goals
- Fix LAS 1.4 parsing through LAZRsLoader on the 4.5 release line.
- Prevent the Rust LAS backend from selecting the incompatible laz-perf worker.

## Changes
- Default missing LAS skip values to 1 in both LAS parser implementations.
- Mark LAZRsLoader as main-thread-only until a dedicated Rust backend worker exists.
- Add regression coverage using the indoor LAZ fixture.

## Validation
- yarn lint fix
- yarn build
- yarn test-node
- yarn build-workers
- yarn test-headless (disabled in this environment)