### PR TITLE
[codex] Use RasterSet across Zarr examples

### DIFF
--- a/examples/website/geozarr/app.tsx
+++ b/examples/website/geozarr/app.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import React, {useEffect, useMemo, useState} from 'react';
+import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {createRoot} from 'react-dom/client';
 
 import DeckGL from '@deck.gl/react';
@@ -14,9 +14,12 @@ import {createDataSource} from '@loaders.gl/core';
 import type {RasterBoundingBox, RasterData, RasterViewport} from '@loaders.gl/loader-utils';
 import {
   GeoZarrSourceLoader,
+  type GetGeoZarrParameters,
   type GeoZarrRasterSource,
   type GeoZarrSourceMetadata
 } from '@loaders.gl/zarr';
+import type {RasterSetRequest} from '@loaders.gl/tiles';
+import {RasterSet} from '@loaders.gl/tiles';
 
 import {Map} from 'react-map-gl';
 import maplibregl from 'maplibre-gl';
@@ -95,6 +98,12 @@ export default function App(props: AppProps = {}) {
       }) as GeoZarrRasterSource,
     []
   );
+  const rasterSetRef = useRef<
+    RasterSet<RasterData, GetGeoZarrParameters, GeoZarrSourceMetadata> | null
+  >(null);
+  if (!rasterSetRef.current) {
+    rasterSetRef.current = RasterSet.fromRasterSource(source);
+  }
   const [timeIndex, setTimeIndex] = useState(INITIAL_TIME_INDEX);
   const [opacity, setOpacity] = useState(INITIAL_OPACITY);
   const [playing, setPlaying] = useState(false);
@@ -104,67 +113,37 @@ export default function App(props: AppProps = {}) {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    let cancelled = false;
-    const abortController = new AbortController();
+    const rasterSet = rasterSetRef.current!;
+    const unsubscribe = rasterSet.subscribe({
+      onLoadingStateChange: isLoading => setLoading(isLoading),
+      onMetadataLoad: nextMetadata => {
+        setMetadata(nextMetadata);
+        setError(null);
+      },
+      onMetadataLoadError: nextError => setError(getErrorMessage(nextError)),
+      onRasterLoad: ({raster}: RasterSetRequest<RasterData, GetGeoZarrParameters>) => {
+        setRasterState(renderRaster(raster, rasterSet.metadata!));
+        setError(null);
+      },
+      onRasterLoadError: (_requestId, nextError) => setError(getErrorMessage(nextError))
+    });
 
-    void source
-      .getMetadata()
-      .then(nextMetadata => {
-        if (!cancelled) {
-          setMetadata(nextMetadata);
-          setError(null);
-        }
-      })
-      .catch(nextError => {
-        if (!cancelled && !abortController.signal.aborted) {
-          setError(getErrorMessage(nextError));
-          setLoading(false);
-        }
-      });
+    void rasterSet.loadMetadata().catch(() => {});
 
     return () => {
-      cancelled = true;
-      abortController.abort();
+      unsubscribe();
+      rasterSet.finalize();
     };
-  }, [source]);
+  }, []);
 
   useEffect(() => {
     if (!metadata) {
       return;
     }
 
-    let cancelled = false;
-    const abortController = new AbortController();
-
-    const loadRaster = async () => {
-      setLoading(true);
-      try {
-        const raster = await source.getRaster({
-          viewport: createGlobalRasterViewport(metadata),
-          selection: {time: timeIndex},
-          signal: abortController.signal
-        });
-        if (!cancelled) {
-          setRasterState(renderRaster(raster, metadata));
-          setError(null);
-        }
-      } catch (nextError) {
-        if (!cancelled && !abortController.signal.aborted) {
-          setError(getErrorMessage(nextError));
-        }
-      } finally {
-        if (!cancelled) {
-          setLoading(false);
-        }
-      }
-    };
-
-    void loadRaster();
-    return () => {
-      cancelled = true;
-      abortController.abort();
-    };
-  }, [metadata, source, timeIndex]);
+    const viewport = createGlobalRasterViewport(metadata);
+    rasterSetRef.current?.requestRaster({viewport, selection: {time: timeIndex}});
+  }, [metadata, timeIndex]);
 
   useEffect(() => {
     if (!playing || loading) {

--- a/examples/website/omezarr/app.tsx
+++ b/examples/website/omezarr/app.tsx
@@ -6,8 +6,14 @@ import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {createRoot} from 'react-dom/client';
 
 import {createDataSource} from '@loaders.gl/core';
-import type {RasterData} from '@loaders.gl/loader-utils';
-import type {OMEZarrSourceLoaderMetadata, ZarrConsolidatedMetadata} from '@loaders.gl/zarr';
+import type {RasterData, RasterViewport} from '@loaders.gl/loader-utils';
+import {RasterSet} from '@loaders.gl/tiles';
+import type {
+  GetOMEZarrParameters,
+  OMEZarrImageSource,
+  OMEZarrSourceLoaderMetadata,
+  ZarrConsolidatedMetadata
+} from '@loaders.gl/zarr';
 import {OMEZarrSourceLoader, loadZarrConsolidatedMetadata} from '@loaders.gl/zarr';
 
 type AppProps = {
@@ -17,6 +23,8 @@ type AppProps = {
 };
 
 type DisplayMode = 'composite' | `channel-${number}`;
+
+type OMEZarrRasterRequest = GetOMEZarrParameters & {viewport: RasterViewport};
 
 type DatasetPreset = {
   /** Stable identifier used by the preset selector. */
@@ -85,6 +93,50 @@ export default function App(props: AppProps = {}) {
         : null,
     [requireConsolidatedMetadata, rootUrl, selectedPath]
   );
+  const rasterSetRef = useRef<RasterSet<RasterData, OMEZarrRasterRequest> | null>(null);
+
+  useEffect(() => {
+    if (!source) {
+      rasterSetRef.current?.finalize();
+      rasterSetRef.current = null;
+      return;
+    }
+
+    const imageSource = source as OMEZarrImageSource;
+    const rasterSet = new RasterSet<RasterData, OMEZarrRasterRequest>({
+      getMetadata: () => imageSource.getMetadata(),
+      getRaster: ({viewport: _viewport, ...parameters}) => imageSource.getRaster(parameters)
+    });
+    rasterSetRef.current = rasterSet;
+    const unsubscribe = rasterSet.subscribe({
+      onLoadingStateChange: isLoading => setLoading(isLoading),
+      onMetadataLoad: nextMetadata => {
+        setMetadata(nextMetadata);
+        setDisplayMode(nextMetadata.bandCount >= 2 ? 'composite' : 'channel-0');
+        setSelectedLevel(getInitialDisplayLevel(nextMetadata));
+        setError(null);
+      },
+      onMetadataLoadError: nextError => setError(getErrorMessage(nextError)),
+      onRasterLoad: ({raster, parameters}) => {
+        const requestedChannels = parameters.channels || [0];
+        const channelColors = requestedChannels.map(
+          (channel, index) => rasterSet.metadata!.channels[channel]?.color || COMPOSITE_COLORS[index]
+        );
+        setRasterCanvas(renderRasterToCanvas(raster, channelColors));
+        setError(null);
+      },
+      onRasterLoadError: (_requestId, nextError) => setError(getErrorMessage(nextError))
+    });
+    void rasterSet.loadMetadata().catch(() => {});
+
+    return () => {
+      unsubscribe();
+      rasterSet.finalize();
+      if (rasterSetRef.current === rasterSet) {
+        rasterSetRef.current = null;
+      }
+    };
+  }, [source]);
 
   useEffect(() => {
     let cancelled = false;
@@ -134,85 +186,17 @@ export default function App(props: AppProps = {}) {
   }, [rootUrl]);
 
   useEffect(() => {
-    if (!source) {
+    if (!metadata || !rasterSetRef.current) {
       return;
     }
 
-    let cancelled = false;
-
-    const loadImage = async () => {
-      setLoading(true);
-      try {
-        const nextMetadata = await source.getMetadata();
-        if (cancelled) {
-          return;
-        }
-
-        setMetadata(nextMetadata);
-        setDisplayMode(nextMetadata.bandCount >= 2 ? 'composite' : 'channel-0');
-        setSelectedLevel(getInitialDisplayLevel(nextMetadata));
-        setError(null);
-      } catch (nextError) {
-        if (!cancelled) {
-          setError(getErrorMessage(nextError));
-        }
-      } finally {
-        if (!cancelled) {
-          setLoading(false);
-        }
-      }
-    };
-
-    void loadImage();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [source]);
-
-  useEffect(() => {
-    if (!metadata || !source) {
-      return;
-    }
-
-    let cancelled = false;
-    const abortController = new AbortController();
-
-    const loadRaster = async () => {
-      setLoading(true);
-      try {
-        const requestedChannels = getRequestedChannels(metadata, displayMode);
-        const raster = await source.getRaster({
-          level: selectedLevel,
-          channels: requestedChannels,
-          signal: abortController.signal
-        });
-        if (cancelled) {
-          return;
-        }
-        const channelColors = requestedChannels.map(
-          (channel, index) => metadata.channels[channel]?.color || COMPOSITE_COLORS[index]
-        );
-        setRasterCanvas(renderRasterToCanvas(raster, channelColors));
-        setError(null);
-      } catch (nextError) {
-        if (!cancelled) {
-          setError(getErrorMessage(nextError));
-        }
-      } finally {
-        if (!cancelled) {
-          setLoading(false);
-        }
-      }
-    };
-
-    void loadRaster();
-
-    return () => {
-      cancelled = true;
-      abortController.abort();
-    };
-  }, [displayMode, metadata, selectedLevel, source]);
+    const requestedChannels = getRequestedChannels(metadata, displayMode);
+    rasterSetRef.current.requestRaster({
+      viewport: createOMEZarrViewport(metadata),
+      level: selectedLevel,
+      channels: requestedChannels
+    });
+  }, [displayMode, metadata, selectedLevel]);
 
   const imagePaths = useMemo(() => {
     if (consolidated) {
@@ -753,6 +737,19 @@ function scaleToByte(value: number, minimum: number, maximum: number): number {
 /** Converts an unknown thrown value into display text. */
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+/** Supplies the request-manager viewport required by the shared RasterSet API. */
+function createOMEZarrViewport(metadata: OMEZarrSourceLoaderMetadata): RasterViewport {
+  return {
+    id: 'omezarr-image-plane',
+    width: metadata.width,
+    height: metadata.height,
+    zoom: 0,
+    center: [0, 0],
+    project: coordinates => coordinates,
+    unprojectPosition: position => [position[0], position[1], position[2] || 0]
+  };
 }
 
 /** Mounts the standalone example into a DOM container. */


### PR DESCRIPTION
## Goals

Make the shared RasterSet lifecycle the common request-management path for loaders.gl Zarr examples.

## Changes

- migrate the GeoZarr NASA POWER example from bespoke metadata/raster effects to RasterSet
- migrate the OME-Zarr example to RasterSet with an adapter for pyramid/channel requests
- retain existing dataset selection, playback, opacity, compositing, and remote URL behavior
- finalize managers on source changes and route loading/errors through subscriptions

## Validation

- yarn lint fix
- yarn build
- yarn build-workers
- yarn test-node
- yarn test-headless
- yarn --cwd website build

This is the next incremental Zarr tranche; generic NDArray/Zarr array APIs and v2/v3 conformance coverage remain follow-up work.