### PR TITLE
fix(mvt): preserve feature IDs in GeoJSON output on 4.5

### DIFF
--- a/modules/mvt/src/lib/vector-tile/vector-tile-feature.ts
+++ b/modules/mvt/src/lib/vector-tile/vector-tile-feature.ts
@@ -382,8 +382,7 @@ function _toGeoJSONFeature(
   };
 
   if (vtFeature.id !== null) {
-    result.properties ||= {};
-    result.properties.id = vtFeature.id;
+    result.id = vtFeature.id;
   }
 
   return result;

--- a/modules/mvt/test/mvt-loader.spec.ts
+++ b/modules/mvt/test/mvt-loader.spec.ts
@@ -298,7 +298,15 @@ test('Features with top-level id', async (t) => {
   const response = await fetchFile(WITH_FEATURE_ID);
   const mvtArrayBuffer = await response.arrayBuffer();
 
-  const binary = await parse(mvtArrayBuffer, MVTLoader, {mvt: {shape: 'binary'}});
+  const geojsonFeatures = await parse(mvtArrayBuffer, MVTLoader);
+  for (const feature of geojsonFeatures) {
+    t.ok(feature.id, 'feature.id is preserved');
+    t.notOk(feature.properties.id, 'feature.id is not copied to properties');
+  }
+
+  const binaryResponse = await fetchFile(WITH_FEATURE_ID);
+  const binaryArrayBuffer = await binaryResponse.arrayBuffer();
+  const binary = await parse(binaryArrayBuffer, MVTLoader, {mvt: {shape: 'binary'}});
   t.ok(binary.points.fields.length, 'feature.id fields are preserved');
   t.ok(binary.lines.fields.length, 'feature.id fields are preserved');
   t.ok(binary.polygons.fields.length, 'feature.id fields are preserved');


### PR DESCRIPTION
## Goals

Backport the MVT GeoJSON feature-ID correction from `master` to the 4.5 release line.

## Changes

- Emit vector-tile feature IDs as the standard GeoJSON top-level `Feature.id` member.
- Stop duplicating those IDs into `Feature.properties.id`.
- Extend the existing 4.5 feature-ID fixture coverage to assert GeoJSON behavior.

## Testing

- `modules/mvt/test/mvt-loader.spec.ts` (1,391 passing assertions)
- `yarn lint fix`