### PR TITLE
feat(3d-tiles): support multiple tile contents

### DIFF
--- a/docs/docs-sidebar.json
+++ b/docs/docs-sidebar.json
@@ -20,6 +20,7 @@
       "modules/traces/formats/chrome-trace",
       "modules/textures/formats/compressed-textures",
       "modules/copc/formats/copc",
+      "modules/3d-tiles/formats/3d-tiles",
       "modules/textures/formats/crunch",
       "modules/csv/formats/csv",
       "modules/wms/formats/csw",

--- a/docs/modules/3d-tiles/README.md
+++ b/docs/modules/3d-tiles/README.md
@@ -10,6 +10,9 @@ import {Tiles3DDocsTabs} from '@site/src/components/docs/tiles-3d-docs-tabs';
 
 The `@loaders.gl/3d-tiles` module supports loading and traversing 3D Tiles.
 
+See the [3D Tiles format compatibility matrix](./formats/3d-tiles) for a capability-by-capability
+summary of parser, traversal, extension, and renderer-facing support.
+
 References
 
 - [3D Tiles Specification](https://github.com/AnalyticalGraphicsInc/3d-tiles) - The living specification.

--- a/docs/modules/3d-tiles/formats/3d-tiles.md
+++ b/docs/modules/3d-tiles/formats/3d-tiles.md
@@ -1,0 +1,85 @@
+import {Tiles3DDocsTabs} from '@site/src/components/docs/tiles-3d-docs-tabs';
+
+# 3D Tiles
+
+<Tiles3DDocsTabs active="module" />
+
+3D Tiles is a hierarchical, streamable format for rendering large geospatial datasets. A tileset
+describes a tree of bounding volumes, geometric-error values, refinement rules, and references to
+renderable tile payloads. The runtime selects the smallest useful set of payloads for the current
+viewport instead of downloading the complete dataset.
+
+## Compatibility at a glance
+
+The checkboxes below describe loaders.gl behavior in the current 5.0 development line. A checked
+item means the loader parses and exposes the capability; it does not imply that every renderer
+provides a visual implementation for that feature.
+
+### Tileset and traversal
+
+| Capability | Status | Notes |
+| --- | :---: | --- |
+| 3D Tiles 1.0 tileset JSON | [x] | Parsed and normalized by [`Tiles3DLoader`](../api-reference/tiles-3d-loader). |
+| 3D Tiles 1.1 tileset JSON | [x] | Includes implicit-tiling and metadata declarations. |
+| Explicit child hierarchies | [x] | Traversed by [`Tileset3D`](../../tiles/api-reference/tileset-3d). |
+| Lazy implicit subtrees | [x] | Availability resources are requested after visibility and LOD checks. |
+| `REPLACE` refinement | [x] | Ancestors are replaced as children become renderable. |
+| `ADD` refinement | [x] | Ancestors and descendants may render together. |
+| Geometric-error transform scaling | [x] | Uses the conservative maximum scale component. |
+| Perspective and orthographic SSE | [x] | Uses logical/CSS viewport pixels. |
+| Progressive and foveated request priority | [x] | Changes request order, not the final SSE target. |
+| Skip-level-of-detail traversal | [ ] | Planned Cesium-parity tranche. |
+
+### Tile payloads
+
+| Payload | Status | Notes |
+| --- | :---: | --- |
+| `b3dm` batched 3D model | [x] | Batch tables and glTF payloads are exposed. |
+| `i3dm` instanced 3D model | [x] | Instancing metadata is parsed. |
+| `pnts` point cloud | [x] | Draco-compressed point attributes are supported. |
+| `cmpt` composite | [x] | Child payloads are parsed through the composite loader. |
+| `glb` / glTF tile content | [x] | Structure-first content detection supports extensionless resources. |
+| External tileset content | [x] | Nested tilesets are installed below the owning tile. |
+| Multiple contents per tile | [ ] | Metadata arrays are accepted and preserved; independent runtime loading/rendering is the next tranche. |
+| `3tz` archive resources | [x] | Archive-backed sources use the same URL/content pipeline. |
+
+### Extensions and metadata
+
+| Capability | Status | Notes |
+| --- | :---: | --- |
+| Required-extension validation | [x] | Unsupported required names fail before normalization or network requests. |
+| `3DTILES_implicit_tiling` | [x] | QUADTREE and OCTREE availability are supported. |
+| `3DTILES_bounding_volume_S2` | [x] | S2 volumes are converted to traversal-ready oriented boxes. |
+| `3DTILES_content_gltf` | [x] | glTF tile content is recognized. |
+| `3DTILES_draco_point_compression` | [x] | Point-cloud Draco metadata is exposed to the decoder. |
+| `3DTILES_batch_table_hierarchy` | [ ] | Parser scaffolding exists; complete hierarchy semantics remain planned. |
+| `EXT_mesh_features` | [x] | Feature identifiers are preserved for supported glTF payloads. |
+| `EXT_structural_metadata` | [x] | Schema and property-table metadata are exposed where present. |
+| Subtree metadata materialization | [ ] | Availability is implemented; metadata inheritance is planned. |
+| Styling expressions | [ ] | Rendering-side style evaluation is not provided by this module. |
+
+## How to read the matrix
+
+The loader and runtime have separate responsibilities. `Tiles3DLoader` parses tileset and tile
+payloads, while `Tileset3D` performs view-dependent traversal, request scheduling, caching, and
+LOD selection. A checked parser capability may therefore still require application or renderer
+work before it affects pixels.
+
+For the selection algorithm, see [screen-space error and LOD](../concepts/screen-space-error-and-lod).
+For hierarchy metadata and lazy requests, see [implicit tiling and subtrees](../concepts/implicit-tiling-and-subtrees).
+For cache and request behavior, see [caching and memory](../concepts/caching-and-memory) and
+[request scheduling and priorities](../concepts/request-scheduling-and-priorities).
+
+## Supported coordinate and volume forms
+
+The runtime accepts oriented boxes, spheres, and geographic regions. S2 extension volumes are
+normalized to oriented boxes while retaining their source token and height range for implicit
+subdivision. Tile transforms are composed with ancestor and tileset transforms before culling and
+geometric-error scaling.
+
+## Related specifications
+
+- [OGC 3D Tiles Standard](https://www.ogc.org/standard/3dtiles/)
+- [3D Tiles specification](https://github.com/CesiumGS/3d-tiles)
+- [3DTILES_implicit_tiling](https://github.com/CesiumGS/3d-tiles/tree/main/extensions/3DTILES_implicit_tiling)
+- [3DTILES_multiple_contents](https://github.com/CesiumGS/3d-tiles/tree/main/extensions/3DTILES_multiple_contents)

--- a/docs/modules/3d-tiles/formats/3d-tiles.md
+++ b/docs/modules/3d-tiles/formats/3d-tiles.md
@@ -40,7 +40,7 @@ provides a visual implementation for that feature.
 | `cmpt` composite | [x] | Child payloads are parsed through the composite loader. |
 | `glb` / glTF tile content | [x] | Structure-first content detection supports extensionless resources. |
 | External tileset content | [x] | Nested tilesets are installed below the owning tile. |
-| Multiple contents per tile | [ ] | Metadata arrays are accepted and preserved; independent runtime loading/rendering is the next tranche. |
+| Multiple contents per tile | [x] | Explicit content arrays are normalized and loaded in source order; `Tile3D.content` remains the primary payload and `Tile3D.contents` exposes all payloads. |
 | `3tz` archive resources | [x] | Archive-backed sources use the same URL/content pipeline. |
 
 ### Extensions and metadata

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -277,7 +277,7 @@ A minor release that includes:
 
 - **3D Tiles 1.1 Writing** [`Tile3DWriter`](/docs/modules/3d-tiles/api-reference/tile-3d-writer) now supports writing 3DTiles 1.1
 - **3D Tiles 1.1 Extensions** `EXT_mesh_features` and `EXT_structural_metadata` are now supported.
-- **3D Tiles format compatibility** - Added a checked compatibility matrix covering tileset traversal, tile payloads, extensions, metadata, and known renderer limitations. Multiple-content metadata arrays are now accepted and preserved for the next independent-content loading tranche.
+- **3D Tiles format compatibility** - Added a checked compatibility matrix covering tileset traversal, tile payloads, extensions, metadata, and known renderer limitations. Multiple explicit contents are normalized, loaded in source order, and exposed through `Tile3D.contents` while preserving the legacy primary `Tile3D.content` field.
 - **Transform-correct LOD** Geometric error is scaled conservatively by composed tile and tileset transforms without compounding after runtime updates.
 - **Projection-correct SSE** Orthographic viewports use `metersPerPixel`, while perspective and orthographic traversal consistently use logical pixels without a second device-pixel-ratio correction.
 - **Dynamic SSE** Perspective traversal can reduce distant, horizon-facing refinement with view-dependent density and height falloff while leaving orthographic and I3S LOD behavior unchanged.

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -277,6 +277,7 @@ A minor release that includes:
 
 - **3D Tiles 1.1 Writing** [`Tile3DWriter`](/docs/modules/3d-tiles/api-reference/tile-3d-writer) now supports writing 3DTiles 1.1
 - **3D Tiles 1.1 Extensions** `EXT_mesh_features` and `EXT_structural_metadata` are now supported.
+- **3D Tiles format compatibility** - Added a checked compatibility matrix covering tileset traversal, tile payloads, extensions, metadata, and known renderer limitations. Multiple-content metadata arrays are now accepted and preserved for the next independent-content loading tranche.
 - **Transform-correct LOD** Geometric error is scaled conservatively by composed tile and tileset transforms without compounding after runtime updates.
 - **Projection-correct SSE** Orthographic viewports use `metersPerPixel`, while perspective and orthographic traversal consistently use logical pixels without a second device-pixel-ratio correction.
 - **Dynamic SSE** Perspective traversal can reduce distant, horizon-facing refinement with view-dependent density and height falloff while leaving orthographic and I3S LOD behavior unchanged.

--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile-header.ts
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile-header.ts
@@ -68,7 +68,6 @@ function normalizeTileContents(
 
   const contentEntries = Array.isArray(content) ? content : [content];
   const normalizedContents = contentEntries.map(contentEntry => {
-    const contentUri = contentEntry.uri || contentEntry.url;
     return {
       ...contentEntry,
       boundingVolume: normalizeS2BoundingVolume(contentEntry.boundingVolume),

--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile-header.ts
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile-header.ts
@@ -51,6 +51,40 @@ function getTileType(tile: Tiles3DTileJSON, tileContentUrl: string = ''): TILE_T
   }
 }
 
+/**
+ * Resolves one or more tile content references using the parse-scoped URI cache.
+ *
+ * @param content - Raw content metadata from the tile.
+ * @param resourceResolver - Resolver shared by the complete tileset parse.
+ * @returns Resolved content metadata and URLs in source order.
+ */
+function normalizeTileContents(
+  content: Tiles3DTileJSON['content'],
+  resourceResolver: CachedUriResolver
+): {content?: Tiles3DTileJSONPostprocessed['content']; contentUrls: string[]} {
+  if (!content) {
+    return {content: undefined, contentUrls: []};
+  }
+
+  const contentEntries = Array.isArray(content) ? content : [content];
+  const normalizedContents = contentEntries.map(contentEntry => {
+    const contentUri = contentEntry.uri || contentEntry.url;
+    return {
+      ...contentEntry,
+      boundingVolume: normalizeS2BoundingVolume(contentEntry.boundingVolume),
+      uri: contentUri ? resourceResolver.resolve(contentUri) : contentEntry.uri,
+      url: undefined
+    };
+  });
+
+  return {
+    content: Array.isArray(content) ? normalizedContents : normalizedContents[0],
+    contentUrls: normalizedContents
+      .map(contentEntry => contentEntry.uri)
+      .filter((contentUrl): contentUrl is string => Boolean(contentUrl))
+  };
+}
+
 function getRefine(refine?: string): TILE_REFINEMENT | string | undefined {
   switch (refine) {
     case 'REPLACE':
@@ -80,26 +114,15 @@ export function normalizeTileData(
   if (!tile) {
     return null;
   }
-  let tileContentUrl: string | undefined;
-  if (tile.content) {
-    const contentUri = tile.content.uri || tile.content?.url;
-    if (typeof contentUri !== 'undefined') {
-      // sparse implicit tilesets may not define content for all nodes
-      tileContentUrl = resourceResolver.resolve(contentUri);
-    }
-  }
+  const normalizedContents = normalizeTileContents(tile.content, resourceResolver);
+  const tileContentUrl = normalizedContents.contentUrls[0];
   const boundingVolume = normalizeS2BoundingVolume(tile.boundingVolume) as Tile3DBoundingVolume;
-  const content = tile.content
-    ? {
-        ...tile.content,
-        boundingVolume: normalizeS2BoundingVolume(tile.content.boundingVolume)
-      }
-    : undefined;
   const viewerRequestVolume = normalizeS2BoundingVolume(tile.viewerRequestVolume);
   const tilePostprocessed: Tiles3DTileJSONPostprocessed = {
     ...tile,
     boundingVolume,
-    content,
+    content: normalizedContents.content,
+    contentUrls: normalizedContents.contentUrls,
     viewerRequestVolume,
     id: tileContentUrl,
     contentUrl: tileContentUrl,
@@ -241,14 +264,10 @@ export async function normalizeImplicitTileHeaders(
   const normalizedTile: Tiles3DTileJSON = {
     ...tile,
     boundingVolume: normalizeS2BoundingVolume(tile.boundingVolume) as Tile3DBoundingVolume,
-    content: tile.content
-      ? {
-          ...tile.content,
-          boundingVolume: normalizeS2BoundingVolume(tile.content.boundingVolume)
-        }
-      : undefined,
+    content: tile.content,
     viewerRequestVolume: normalizeS2BoundingVolume(tile.viewerRequestVolume)
   };
+  const normalizedContents = normalizeTileContents(normalizedTile.content, resourceResolver);
   const maximumLevel = Number.isFinite(implicitTilingExtension.availableLevels)
     ? implicitTilingExtension.availableLevels - 1
     : implicitTilingExtension.maximumLevel;
@@ -264,11 +283,16 @@ export async function normalizeImplicitTileHeaders(
     );
   }
 
-  const contentUriTemplate = normalizedTile.content?.uri || normalizedTile.content?.url || '';
+  const contentEntries = Array.isArray(normalizedContents.content)
+    ? normalizedContents.content
+    : normalizedContents.content
+      ? [normalizedContents.content]
+      : [];
+  const contentUriTemplate = contentEntries[0]?.uri || contentEntries[0]?.url || '';
   const descriptor: ImplicitTilingDescriptor = {
     contentUrlTemplate: contentUriTemplate ? resourceResolver.resolve(contentUriTemplate) : '',
-    contentHeader: normalizedTile.content
-      ? {...normalizedTile.content, uri: undefined, url: undefined}
+    contentHeader: contentEntries[0]
+      ? {...contentEntries[0], uri: undefined, url: undefined}
       : undefined,
     subtreesUrlTemplate: resourceResolver.resolve(implicitTilingExtension.subtrees.uri),
     subdivisionScheme: implicitTilingExtension.subdivisionScheme,
@@ -296,7 +320,9 @@ export async function normalizeImplicitTileHeaders(
     type: TILE_TYPE.EMPTY,
     refine: descriptor.refine,
     children: [],
-    implicitSubtree
+    implicitSubtree,
+    content: normalizedContents.content,
+    contentUrls: normalizedContents.contentUrls
   } as Tiles3DTileJSONPostprocessed;
 }
 

--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile-header.ts
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile-header.ts
@@ -72,15 +72,18 @@ function normalizeTileContents(
     return {
       ...contentEntry,
       boundingVolume: normalizeS2BoundingVolume(contentEntry.boundingVolume),
-      uri: contentUri ? resourceResolver.resolve(contentUri) : contentEntry.uri,
-      url: undefined
+      uri: contentEntry.uri,
+      url: contentEntry.url
     };
   });
 
   return {
     content: Array.isArray(content) ? normalizedContents : normalizedContents[0],
     contentUrls: normalizedContents
-      .map(contentEntry => contentEntry.uri)
+      .map(contentEntry => {
+        const contentUri = contentEntry.uri || contentEntry.url;
+        return contentUri ? resourceResolver.resolve(contentUri) : undefined;
+      })
       .filter((contentUrl): contentUrl is string => Boolean(contentUrl))
   };
 }

--- a/modules/3d-tiles/src/tileset-zod-schema.ts
+++ b/modules/3d-tiles/src/tileset-zod-schema.ts
@@ -92,7 +92,8 @@ export const Tiles3DTileSchema: z.ZodType<Tiles3DTileJSON> = z.lazy(() =>
       geometricError: z.number().nonnegative(),
       refine: z.string().optional(),
       transform: z.array(z.number()).length(16).optional(),
-      content: Tiles3DTileContentSchema.optional(),
+      // 3D Tiles 1.1 allows a tile to reference one or more independent contents.
+      content: z.union([Tiles3DTileContentSchema, z.array(Tiles3DTileContentSchema)]).optional(),
       children: z.array(Tiles3DTileSchema).default([]),
       extensions: z.record(z.string(), z.unknown()).optional(),
       extras: z.unknown().optional(),

--- a/modules/3d-tiles/src/types.ts
+++ b/modules/3d-tiles/src/types.ts
@@ -128,7 +128,11 @@ export type Tiles3DTileJSON = {
   /** A floating-point 4x4 affine transformation matrix, stored in column-major order, that transforms the tile's content */
   transform?: number[];
   /** Metadata about the tile's content and a link to the content. */
-  content?: Tiles3DTileContentJSON;
+  /**
+   * Tile content metadata. 3D Tiles 1.1 permits either one content object or an array of
+   * independent content objects; loaders.gl preserves the source shape during parsing.
+   */
+  content?: Tiles3DTileContentJSON | Tiles3DTileContentJSON[];
   /** An array of objects that define child tiles. */
   children: Tiles3DTileJSON[];
   /** Dictionary object with extension-specific objects. */
@@ -148,6 +152,8 @@ export type Tiles3DTileJSONPostprocessed = Omit<Tiles3DTileJSON, 'refine' | 'chi
   id?: string;
   /** Content full URL */
   contentUrl?: string;
+  /** Resolved URLs for every content object when the source uses multiple contents. */
+  contentUrls?: string[];
   /** LOD metric type */
   lodMetricType?: LOD_METRIC_TYPE.GEOMETRIC_ERROR;
   /** LOD metric value */

--- a/modules/3d-tiles/test/multiple-contents.browser.spec.ts
+++ b/modules/3d-tiles/test/multiple-contents.browser.spec.ts
@@ -1,0 +1,45 @@
+import {describe, expect, test} from 'vitest';
+import {Tiles3DTilesetSchema} from '../src/tileset-zod-schema';
+import {normalizeTileData} from '../src/lib/parsers/parse-3d-tile-header';
+
+describe('3D Tiles multiple contents', () => {
+  test('accepts and preserves an array of content references', () => {
+    const tileset = Tiles3DTilesetSchema.parse({
+      asset: {version: '1.1'},
+      geometricError: 10,
+      root: {
+        boundingVolume: {sphere: [0, 0, 0, 1]},
+        geometricError: 1,
+        content: [{uri: 'geometry.b3dm'}, {uri: 'attributes.json', extras: {kind: 'metadata'}}],
+        children: []
+      }
+    });
+
+    const normalizedTile = normalizeTileData(tileset.root, 'https://example.com/');
+
+    expect(Array.isArray(normalizedTile?.content)).toBe(true);
+    expect(normalizedTile?.contentUrls).toEqual([
+      'https://example.com/geometry.b3dm',
+      'https://example.com/attributes.json'
+    ]);
+    expect((normalizedTile?.content as Array<{extras?: {kind?: string}}>)[1].extras?.kind).toBe(
+      'metadata'
+    );
+  });
+
+  test('keeps single-content callers on the existing object shape', () => {
+    const normalizedTile = normalizeTileData(
+      {
+        boundingVolume: {sphere: [0, 0, 0, 1]},
+        geometricError: 1,
+        content: {uri: 'tile.b3dm'},
+        children: []
+      },
+      'https://example.com/'
+    );
+
+    expect(Array.isArray(normalizedTile?.content)).toBe(false);
+    expect(normalizedTile?.contentUrl).toBe('https://example.com/tile.b3dm');
+    expect(normalizedTile?.contentUrls).toEqual(['https://example.com/tile.b3dm']);
+  });
+});

--- a/modules/3d-tiles/test/multiple-contents.browser.spec.ts
+++ b/modules/3d-tiles/test/multiple-contents.browser.spec.ts
@@ -1,6 +1,8 @@
 import {describe, expect, test} from 'vitest';
 import {Tiles3DTilesetSchema} from '../src/tileset-zod-schema';
 import {normalizeTileData} from '../src/lib/parsers/parse-3d-tile-header';
+import {Tiles3DLoader} from '../src/tiles-3d-loader';
+import {Tiles3DSource} from '@loaders.gl/tiles';
 
 describe('3D Tiles multiple contents', () => {
   test('accepts and preserves an array of content references', () => {
@@ -41,5 +43,33 @@ describe('3D Tiles multiple contents', () => {
     expect(Array.isArray(normalizedTile?.content)).toBe(false);
     expect(normalizedTile?.contentUrl).toBe('https://example.com/tile.b3dm');
     expect(normalizedTile?.contentUrls).toEqual(['https://example.com/tile.b3dm']);
+  });
+
+  test('loads multiple explicit contents in source order', async () => {
+    const requestedUrls: string[] = [];
+    const source = new Tiles3DSource({
+      url: 'https://example.com/tileset.json',
+      loader: Tiles3DLoader,
+      resolver: {
+        loadRoot: async () => ({}) as never,
+        loadResource: async url => {
+          requestedUrls.push(url);
+          return {shape: url.endsWith('.json') ? 'tileset3d' : 'tile3d', url};
+        }
+      }
+    });
+    const tile = {
+      contentUrl: 'https://example.com/geometry.b3dm',
+      contentUrls: ['https://example.com/geometry.b3dm', 'https://example.com/metadata.json'],
+      content: null,
+      contents: []
+    } as never;
+
+    const result = await source.loadTileContent(tile);
+
+    expect(requestedUrls).toEqual(tile.contentUrls);
+    expect(result.contents).toHaveLength(2);
+    expect(result.nestedTilesets).toHaveLength(1);
+    expect(tile.content).toEqual(result.contents?.[0]);
   });
 });

--- a/modules/tiles/src/tileset-3d/common/tile-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tile-3d.ts
@@ -69,6 +69,8 @@ export class Tile3D {
   refine: TILE_REFINEMENT;
   type: string;
   contentUrl: string;
+  /** Resolved render-content URLs in source order; empty for contentless tiles. */
+  contentUrls: string[] = [];
   /** Different refinement algorithms used by I3S and 3D tiles */
   lodMetricType = 'geometricError';
   /**
@@ -91,6 +93,8 @@ export class Tile3D {
    * not the content's metadata in the tileset JSON file.
    */
   content: any = null;
+  /** Loaded payloads in the same order as {@link contentUrls}; `content` remains the primary payload. */
+  contents: any[] = [];
   contentState: number = TILE_CONTENT_STATE.UNLOADED;
   gpuMemoryUsageInBytes: number = 0;
 
@@ -199,6 +203,7 @@ export class Tile3D {
     this.refine = this._getRefine(header.refine);
     this.type = header.type;
     this.contentUrl = header.contentUrl;
+    this.contentUrls = header.contentUrls || (header.contentUrl ? [header.contentUrl] : []);
     this.childrenState = header.implicitSubtree ? 'unloaded' : 'ready';
 
     this._initializeLodMetric(header);
@@ -368,7 +373,11 @@ export class Tile3D {
    * Memory usage of tile on GPU
    */
   _getGpuMemoryUsageInBytes(): number {
-    return this.content.gpuMemoryUsageInBytes || this.content.byteLength || 0;
+    const contents = this.contents.length ? this.contents : [this.content];
+    return contents.reduce(
+      (total, content) => total + (content?.gpuMemoryUsageInBytes || content?.byteLength || 0),
+      0
+    );
   }
 
   /**
@@ -487,6 +496,11 @@ export class Tile3D {
     try {
       const loadResult = await this.tileset.source.loadTileContent(this);
 
+      if (loadResult.contents) {
+        this.contents = loadResult.contents;
+        this.content = this.contents[0] || null;
+      }
+
       if (this.tileset.options.contentLoader) {
         await this.tileset.options.contentLoader(this);
       }
@@ -585,6 +599,9 @@ export class Tile3D {
     this.refine = this._getRefine(materializedHeader.refine);
     this.type = materializedHeader.type;
     this.contentUrl = materializedHeader.contentUrl;
+    this.contentUrls =
+      materializedHeader.contentUrls ||
+      (materializedHeader.contentUrl ? [materializedHeader.contentUrl] : []);
     this._initializeLodMetric(materializedHeader);
     this._updateLodMetricScale();
     this._initializeBoundingVolumes(this.header);
@@ -595,9 +612,12 @@ export class Tile3D {
 
   // Unloads the tile's content.
   unloadContent() {
-    if (this.content && this.content.destroy) {
-      this.content.destroy();
+    for (const content of this.contents.length ? this.contents : [this.content]) {
+      if (content && content.destroy) {
+        content.destroy();
+      }
     }
+    this.contents = [];
     this.content = null;
     if (this.header.content && this.header.content.destroy) {
       this.header.content.destroy();
@@ -906,6 +926,7 @@ export class Tile3D {
   _initializeContent(tileHeader) {
     // Empty tile by default
     this.content = {_tileset: this.tileset, _tile: this};
+    this.contents = [];
     this.hasEmptyContent = true;
     this.contentState = TILE_CONTENT_STATE.UNLOADED;
 
@@ -913,7 +934,7 @@ export class Tile3D {
     // This is `false` until the tile's content is loaded.
     this.hasTilesetContent = false;
 
-    if (tileHeader.contentUrl) {
+    if (tileHeader.contentUrl || tileHeader.contentUrls?.length) {
       this.content = null;
       this.hasEmptyContent = false;
     }
@@ -961,18 +982,23 @@ export class Tile3D {
    * `content`.
    */
   _isTileset(): boolean {
-    return this.content?.shape === 'tileset3d';
+    return (this.contents.length ? this.contents : [this.content]).some(
+      content => content?.shape === 'tileset3d'
+    );
   }
 
   _onContentLoaded() {
     // Vector and Geometry tile rendering do not support the skip LOD optimization.
-    switch (this.content && this.content.type) {
-      case 'vctr':
-      case 'geom':
-        // @ts-ignore
-        this.tileset._traverser.disableSkipLevelOfDetail = true;
-        break;
-      default:
+    const contents = this.contents.length ? this.contents : [this.content];
+    for (const content of contents) {
+      switch (content && content.type) {
+        case 'vctr':
+        case 'geom':
+          // @ts-ignore
+          this.tileset._traverser.disableSkipLevelOfDetail = true;
+          break;
+        default:
+      }
     }
 
     // The content may be tileset json

--- a/modules/tiles/src/tileset-3d/common/tileset-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tileset-3d.ts
@@ -812,10 +812,13 @@ export class Tileset3D {
     for (const tile of this.selectedTiles) {
       if (tile.contentAvailable && tile.content) {
         tilesRenderable++;
-        if (tile.content.pointCount) {
-          pointsRenderable += tile.content.pointCount;
-        } else {
-          pointsRenderable += tile.content.vertexCount;
+        const contents = tile.contents.length ? tile.contents : [tile.content];
+        for (const content of contents) {
+          if (content.pointCount) {
+            pointsRenderable += content.pointCount;
+          } else {
+            pointsRenderable += content.vertexCount || 0;
+          }
         }
       }
     }

--- a/modules/tiles/src/tileset-3d/common/tileset-source.ts
+++ b/modules/tiles/src/tileset-3d/common/tileset-source.ts
@@ -69,8 +69,12 @@ export type TilesetSourceInput = TilesetJSON | TilesetSourceRequest;
 export type TileContentLoadResult = {
   /** Whether the tile content request produced usable content. */
   loaded: boolean;
+  /** All payloads loaded for a tile, in source order. */
+  contents?: any[];
   /** Nested tileset metadata to install below the loaded tile, if any. */
   nestedTileset?: TilesetJSON;
+  /** Nested tilesets found among multiple content payloads. */
+  nestedTilesets?: TilesetJSON[];
 };
 
 /** Result of a source-managed lazy child-header request. */

--- a/modules/tiles/src/tileset-3d/format-3d-tiles/tiles-3d-source.ts
+++ b/modules/tiles/src/tileset-3d/format-3d-tiles/tiles-3d-source.ts
@@ -275,7 +275,9 @@ export class Tiles3DSource implements Tileset3DSource {
    * Loads binary content or nested tileset JSON for a runtime tile.
    */
   async loadTileContent(tile: Tile3D): Promise<TileContentLoadResult> {
-    const contentUrl = this.getTileUrl(tile.contentUrl);
+    const contentUrls = (tile.contentUrls.length ? tile.contentUrls : [tile.contentUrl]).filter(
+      Boolean
+    );
     const tilesetLoaderOptions =
       (this.loadOptions[this.loader.id] as Record<string, unknown>) || {};
     const options = {
@@ -289,12 +291,18 @@ export class Tiles3DSource implements Tileset3DSource {
       }
     };
 
-    const content = await this.loadResourceData(contentUrl, options);
-    tile.content = content;
+    const contents = await Promise.all(
+      contentUrls.map(contentUrl => this.loadResourceData(this.getTileUrl(contentUrl), options))
+    );
+    tile.contents = contents;
+    tile.content = contents[0] || null;
+    const nestedTilesets = contents.filter(content => content?.shape === 'tileset3d');
 
     return {
       loaded: true,
-      nestedTileset: content?.shape === 'tileset3d' ? content : undefined
+      contents,
+      nestedTileset: nestedTilesets[0],
+      nestedTilesets
     };
   }
 
@@ -458,7 +466,8 @@ export class Tiles3DSource implements Tileset3DSource {
    * Updates content-format flags and installs nested tileset subtrees.
    */
   onTileLoaded(tileset: Tileset3D, tile: Tile3D, loadResult: TileContentLoadResult): void {
-    const {extensionsRemoved = []} = tile.content?.gltf || {};
+    const contents = tile.contents.length ? tile.contents : [tile.content];
+    const extensionsRemoved = contents.flatMap(content => content?.gltf?.extensionsRemoved || []);
     if (extensionsRemoved.includes('KHR_draco_mesh_compression')) {
       this.contentFormats.draco = true;
     }
@@ -469,8 +478,10 @@ export class Tiles3DSource implements Tileset3DSource {
       this.contentFormats.ktx2 = true;
     }
 
-    if (loadResult.nestedTileset) {
-      tileset._initializeTileHeaders(loadResult.nestedTileset, tile);
+    const nestedTilesets =
+      loadResult.nestedTilesets || (loadResult.nestedTileset ? [loadResult.nestedTileset] : []);
+    for (const nestedTileset of nestedTilesets) {
+      tileset._initializeTileHeaders(nestedTileset, tile);
     }
   }
 

--- a/modules/tiles/src/tileset-3d/format-3d-tiles/tiles-3d-source.ts
+++ b/modules/tiles/src/tileset-3d/format-3d-tiles/tiles-3d-source.ts
@@ -275,9 +275,7 @@ export class Tiles3DSource implements Tileset3DSource {
    * Loads binary content or nested tileset JSON for a runtime tile.
    */
   async loadTileContent(tile: Tile3D): Promise<TileContentLoadResult> {
-    const contentUrls = (tile.contentUrls.length ? tile.contentUrls : [tile.contentUrl]).filter(
-      Boolean
-    );
+    const contentUrls = (tile.contentUrls || [tile.contentUrl]).filter(Boolean);
     const tilesetLoaderOptions =
       (this.loadOptions[this.loader.id] as Record<string, unknown>) || {};
     const options = {


### PR DESCRIPTION
## Goals

- Extend loaders.gl 3D Tiles compatibility to tiles that declare multiple content payloads.
- Publish a clear format compatibility matrix for parser, traversal, extension, metadata, and renderer-facing support.

## Changes

- Accept and validate 3D Tiles 1.1 content arrays.
- Preserve content metadata and resolved URLs in source order.
- Load multiple explicit content payloads together and expose them through `Tile3D.contents`.
- Preserve the legacy primary `Tile3D.content` field for existing consumers.
- Account for all loaded payloads in memory usage, nested-tileset installation, compression flags, and point statistics.
- Add focused Chromium tests for normalization and runtime loading.
- Add the 3D Tiles format compatibility page, sidebar entry, and `whats-new` entry.

## Validation

- `yarn lint fix`
- Focused Chromium test: `modules/3d-tiles/test/multiple-contents.browser.spec.ts`

The full repository build is currently blocked by pre-existing missing `@bufbuild/protobuf` dependencies in `modules/traces`.

Related tracker: #1245
