### PR TITLE
[codex] Generalize RasterSet for Zarr request types

### DIFF
--- a/examples/website/omezarr/app.tsx
+++ b/examples/website/omezarr/app.tsx
@@ -103,7 +103,7 @@ export default function App(props: AppProps = {}) {
     }
 
     const imageSource = source as OMEZarrImageSource;
-    const rasterSet = new RasterSet<RasterData, OMEZarrRasterRequest>({
+    const rasterSet = RasterSet.fromCallbacks<RasterData, OMEZarrRasterRequest>({
       getMetadata: () => imageSource.getMetadata(),
       getRaster: ({viewport: _viewport, ...parameters}) => imageSource.getRaster(parameters)
     });

--- a/modules/tiles/src/raster-set.ts
+++ b/modules/tiles/src/raster-set.ts
@@ -12,7 +12,7 @@ import type {
 /** Accepted raster request currently retained by {@link RasterSet}. */
 export type RasterSetRequest<
   DataT extends RasterData = RasterData,
-  ParametersT extends GetRasterParameters = GetRasterParameters
+  ParametersT extends object = GetRasterParameters
 > = {
   /** Unique request id assigned by the manager. */
   requestId: number;
@@ -25,7 +25,7 @@ export type RasterSetRequest<
 /** Arguments supplied to {@link RasterSetBaseProps.shouldRefetch}. */
 export type RasterSetShouldRefetchArgs<
   DataT extends RasterData = RasterData,
-  ParametersT extends GetRasterParameters = GetRasterParameters,
+  ParametersT extends object = GetRasterParameters,
   MetadataT extends RasterSourceMetadata = RasterSourceMetadata
 > = {
   /** Current accepted request retained by the raster manager, if any. */
@@ -39,7 +39,7 @@ export type RasterSetShouldRefetchArgs<
 /** Configuration shared by all {@link RasterSet} instances. */
 export type RasterSetBaseProps<
   DataT extends RasterData = RasterData,
-  ParametersT extends GetRasterParameters = GetRasterParameters,
+  ParametersT extends object = GetRasterParameters,
   MetadataT extends RasterSourceMetadata = RasterSourceMetadata
 > = {
   /** Callback used to load source metadata. */
@@ -55,17 +55,17 @@ export type RasterSetBaseProps<
 /** Options for creating a {@link RasterSet}. */
 export type RasterSetProps<
   DataT extends RasterData = RasterData,
-  ParametersT extends GetRasterParameters = GetRasterParameters,
+  ParametersT extends object = GetRasterParameters,
   MetadataT extends RasterSourceMetadata = RasterSourceMetadata
 > = Partial<RasterSetBaseProps<DataT, ParametersT, MetadataT>> & {
   /** Optional loaders.gl raster source backing this manager. */
-  rasterSource?: RasterSource<DataT, ParametersT, MetadataT> | null;
+  rasterSource?: RasterSource<DataT, GetRasterParameters, MetadataT> | null;
 };
 
 /** Subscription callbacks emitted by {@link RasterSet}. */
 export type RasterSetListener<
   DataT extends RasterData = RasterData,
-  ParametersT extends GetRasterParameters = GetRasterParameters,
+  ParametersT extends object = GetRasterParameters,
   MetadataT extends RasterSourceMetadata = RasterSourceMetadata
 > = {
   /** Fired when metadata/raster loading starts or stops. */
@@ -112,7 +112,7 @@ const DEFAULT_RASTERSET_PROPS: Required<Omit<RasterSetProps, 'rasterSource'>> = 
  */
 export class RasterSet<
   DataT extends RasterData = RasterData,
-  ParametersT extends GetRasterParameters = GetRasterParameters,
+  ParametersT extends object = GetRasterParameters,
   MetadataT extends RasterSourceMetadata = RasterSourceMetadata
 > {
   /** Cached metadata returned by the backing source, if any. */
@@ -169,7 +169,7 @@ export class RasterSet<
   }
 
   /** Backing raster source when constructed from one. */
-  get rasterSource(): RasterSource<DataT, ParametersT, MetadataT> | null {
+  get rasterSource(): RasterSource<DataT, GetRasterParameters, MetadataT> | null {
     return this._opts.rasterSource;
   }
 
@@ -279,7 +279,9 @@ export class RasterSet<
     try {
       const abortController = new AbortController();
       this._abortController = abortController;
-      const raster = await this._opts.getRaster({...parameters, signal: abortController.signal});
+      const raster = await this._opts.getRaster(
+        Object.assign({}, parameters, {signal: abortController.signal}) as ParametersT
+      );
       if (
         this._finalized ||
         abortController.signal.aborted ||
@@ -332,9 +334,11 @@ export class RasterSet<
         opts.getRaster ||
         ((parameters: ParametersT) => {
           if (rasterSource) {
-            return rasterSource.getRaster(parameters);
+            return rasterSource.getRaster(parameters as GetRasterParameters);
           }
-          return DEFAULT_RASTERSET_PROPS.getRaster(parameters) as Promise<DataT>;
+          return DEFAULT_RASTERSET_PROPS.getRaster(
+            parameters as GetRasterParameters
+          ) as Promise<DataT>;
         }),
       debounceTime: opts.debounceTime ?? DEFAULT_RASTERSET_PROPS.debounceTime,
       shouldRefetch:

--- a/modules/tiles/src/raster-set.ts
+++ b/modules/tiles/src/raster-set.ts
@@ -153,6 +153,17 @@ export class RasterSet<
     return new RasterSet<DataT, ParametersT, MetadataT>({...opts, rasterSource});
   }
 
+  /** Convenience factory for sources whose requests are not viewport-shaped. */
+  static fromCallbacks<
+    DataT extends RasterData = RasterData,
+    ParametersT extends object = GetRasterParameters,
+    MetadataT extends RasterSourceMetadata = RasterSourceMetadata
+  >(
+    opts: RasterSetBaseProps<DataT, ParametersT, MetadataT>
+  ): RasterSet<DataT, ParametersT, MetadataT> {
+    return new RasterSet<DataT, ParametersT, MetadataT>(opts);
+  }
+
   /** Whether the manager has no requests in flight and a current raster. */
   get isLoaded(): boolean {
     return this._loadCounter === 0 && Boolean(this._currentRequest);

--- a/modules/tiles/test/raster-set-dimensions.spec.ts
+++ b/modules/tiles/test/raster-set-dimensions.spec.ts
@@ -93,3 +93,44 @@ test('RasterSet preserves source-specific request and metadata types', async () 
 
   rasterSet.finalize();
 });
+
+test('RasterSet accepts non-viewport array requests', async () => {
+  type ArrayRequest = {level: number; channels: number[]};
+  type ArrayMetadata = RasterSourceMetadata & {levels: number};
+
+  const metadata: ArrayMetadata = {
+    width: 4,
+    height: 2,
+    bandCount: 3,
+    dtype: 'uint8',
+    levels: 3
+  };
+  const raster: RasterData = {
+    data: new Uint8Array([1]),
+    width: 1,
+    height: 1,
+    bandCount: 1,
+    dtype: 'uint8'
+  };
+  const rasterSet = new RasterSet<RasterData, ArrayRequest, ArrayMetadata>({
+    getMetadata: async () => metadata,
+    getRaster: async parameters => {
+      expect(parameters.level).toBe(2);
+      expect(parameters.channels).toEqual([1, 2]);
+      expect((parameters as ArrayRequest & {signal?: AbortSignal}).signal).toBeInstanceOf(
+        AbortSignal
+      );
+      return raster;
+    }
+  });
+
+  expectTypeOf(rasterSet.currentRequest?.parameters).toEqualTypeOf<ArrayRequest | undefined>();
+  await rasterSet.loadMetadata();
+  const loadedRequest = new Promise<ArrayRequest>(resolve =>
+    rasterSet.subscribe({onRasterLoad: request => resolve(request.parameters)})
+  );
+  rasterSet.requestRaster({level: 2, channels: [1, 2]});
+
+  await expect(loadedRequest).resolves.toEqual({level: 2, channels: [1, 2]});
+  rasterSet.finalize();
+});

--- a/modules/tiles/test/raster-set-dimensions.spec.ts
+++ b/modules/tiles/test/raster-set-dimensions.spec.ts
@@ -112,7 +112,7 @@ test('RasterSet accepts non-viewport array requests', async () => {
     bandCount: 1,
     dtype: 'uint8'
   };
-  const rasterSet = new RasterSet<RasterData, ArrayRequest, ArrayMetadata>({
+  const rasterSet = RasterSet.fromCallbacks<RasterData, ArrayRequest, ArrayMetadata>({
     getMetadata: async () => metadata,
     getRaster: async parameters => {
       expect(parameters.level).toBe(2);

--- a/modules/zarr/src/index.ts
+++ b/modules/zarr/src/index.ts
@@ -14,6 +14,8 @@ export {ZarrArraySourceLoader, ZarrArraySource} from './zarr-array-source';
 export type {
   GetZarrArrayParameters,
   ZarrArrayData,
+  ZarrArraySelection,
+  ZarrArraySlice,
   ZarrArraySourceLoaderOptions,
   ZarrArraySourceMetadata
 } from './zarr-array-source';

--- a/modules/zarr/src/index.ts
+++ b/modules/zarr/src/index.ts
@@ -10,6 +10,13 @@ export {
   loadZarrConsolidatedMetadata
 } from './ome-zarr-source-loader';
 export {GeoZarrSourceLoader, GeoZarrRasterSource} from './geo-zarr-source-loader';
+export {ZarrArraySourceLoader, ZarrArraySource} from './zarr-array-source';
+export type {
+  GetZarrArrayParameters,
+  ZarrArrayData,
+  ZarrArraySourceLoaderOptions,
+  ZarrArraySourceMetadata
+} from './zarr-array-source';
 export type {
   GetOMEZarrParameters,
   LoadConsolidatedMetadataOptions,

--- a/modules/zarr/src/zarr-array-source.ts
+++ b/modules/zarr/src/zarr-array-source.ts
@@ -25,6 +25,8 @@ export type ZarrArraySourceMetadata = {
 export type GetZarrArrayParameters = {
   /** Integer or slice selector for each dimension; null retains that dimension. */
   selection?: ZarrArraySelection;
+  /** Named selectors resolved against the metadata dimension labels. */
+  selectionByDimension?: Readonly<Record<string, number | null | ZarrArraySlice>>;
   /** Abort signal forwarded to metadata and chunk requests. */
   signal?: AbortSignal;
 };
@@ -122,7 +124,7 @@ export class ZarrArraySource extends ZarrSource {
   /** Reads the selected array values. */
   async getArray(parameters: GetZarrArrayParameters = {}): Promise<ZarrArrayData> {
     const {array, metadata} = await this.getInitializationPromise(parameters.signal);
-    const selection = parameters.selection || metadata.shape.map(() => null);
+    const selection = parameters.selection || createNamedSelection(parameters.selectionByDimension, metadata);
     if (selection.length !== metadata.shape.length) {
       throw new Error(`Zarr array selection must have ${metadata.shape.length} dimensions.`);
     }
@@ -169,6 +171,22 @@ export class ZarrArraySource extends ZarrSource {
       }
     };
   }
+}
+
+/** Converts named dimension selectors into the positional form accepted by Zarrita. */
+function createNamedSelection(
+  selectionByDimension: GetZarrArrayParameters['selectionByDimension'],
+  metadata: ZarrArraySourceMetadata
+): ZarrArraySelection {
+  const selection = metadata.shape.map(() => null) as ZarrArraySelection;
+  for (const [dimension, selector] of Object.entries(selectionByDimension || {})) {
+    const dimensionIndex = metadata.dimensions.indexOf(dimension);
+    if (dimensionIndex < 0) {
+      throw new Error(`Unknown Zarr array dimension ${dimension}.`);
+    }
+    selection[dimensionIndex] = selector;
+  }
+  return selection;
 }
 
 /** Tests whether a selector is a slice descriptor rather than an index. */

--- a/modules/zarr/src/zarr-array-source.ts
+++ b/modules/zarr/src/zarr-array-source.ts
@@ -23,11 +23,24 @@ export type ZarrArraySourceMetadata = {
 
 /** Parameters for reading a Zarr array selection. */
 export type GetZarrArrayParameters = {
-  /** Integer index for each selected dimension; null retains that dimension. */
-  selection?: Array<number | null>;
+  /** Integer or slice selector for each dimension; null retains that dimension. */
+  selection?: ZarrArraySelection;
   /** Abort signal forwarded to metadata and chunk requests. */
   signal?: AbortSignal;
 };
+
+/** Slice selector accepted by {@link ZarrArraySource#getArray}. */
+export type ZarrArraySlice = {
+  /** Inclusive starting index, defaulting to the dimension boundary. */
+  start?: number;
+  /** Exclusive stopping index, defaulting to the dimension boundary. */
+  stop?: number;
+  /** Stride between selected indices, defaulting to one. */
+  step?: number;
+};
+
+/** Positional selectors for a Zarr array read. */
+export type ZarrArraySelection = Array<number | null | ZarrArraySlice>;
 
 /** Result of a Zarr array read. */
 export type ZarrArrayData = {
@@ -113,7 +126,12 @@ export class ZarrArraySource extends ZarrSource {
     if (selection.length !== metadata.shape.length) {
       throw new Error(`Zarr array selection must have ${metadata.shape.length} dimensions.`);
     }
-    const chunk = await zarrita.get(array, selection, {signal: parameters.signal});
+    const zarritaSelection = selection.map(selector =>
+      isZarrArraySlice(selector)
+        ? zarrita.slice(selector.start ?? null, selector.stop ?? null, selector.step ?? null)
+        : selector
+    );
+    const chunk = await zarrita.get(array, zarritaSelection, {signal: parameters.signal});
     if (!chunk || typeof chunk !== 'object' || !('data' in chunk) || !('shape' in chunk)) {
       throw new Error('Failed to read Zarr array selection.');
     }
@@ -151,4 +169,9 @@ export class ZarrArraySource extends ZarrSource {
       }
     };
   }
+}
+
+/** Tests whether a selector is a slice descriptor rather than an index. */
+function isZarrArraySlice(selector: number | null | ZarrArraySlice): selector is ZarrArraySlice {
+  return typeof selector === 'object' && selector !== null;
 }

--- a/modules/zarr/src/zarr-array-source.ts
+++ b/modules/zarr/src/zarr-array-source.ts
@@ -1,0 +1,154 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import * as zarrita from 'zarrita';
+import type {Readable} from 'zarrita';
+import type {CoreAPI, SourceLoader, TypedArray} from '@loaders.gl/loader-utils';
+import {ZarrSource, type ZarrSourceLoaderOptions} from './ome-zarr-source-loader';
+
+/** Metadata describing one directly addressable Zarr array. */
+export type ZarrArraySourceMetadata = {
+  /** Array path relative to the selected Zarr group. */
+  path: string;
+  /** Dimension lengths in storage order. */
+  shape: number[];
+  /** Native chunk lengths in storage order. */
+  chunks: number[];
+  /** Zarrita dtype identifier. */
+  dtype: string;
+  /** Stable dimension names, supplied by the caller or generated from rank. */
+  dimensions: string[];
+};
+
+/** Parameters for reading a Zarr array selection. */
+export type GetZarrArrayParameters = {
+  /** Integer index for each selected dimension; null retains that dimension. */
+  selection?: Array<number | null>;
+  /** Abort signal forwarded to metadata and chunk requests. */
+  signal?: AbortSignal;
+};
+
+/** Result of a Zarr array read. */
+export type ZarrArrayData = {
+  /** Decoded array values in row-major selection order. */
+  data: TypedArray;
+  /** Resulting shape after applying integer selections. */
+  shape: number[];
+};
+
+/** Options for {@link ZarrArraySourceLoader}. */
+export type ZarrArraySourceLoaderOptions = ZarrSourceLoaderOptions & {
+  /** Array path and optional dimension labels. */
+  zarrArray?: {
+    /** Array path relative to `zarr.path`, defaulting to the selected root array. */
+    path?: string;
+    /** Dimension labels in storage order. */
+    dimensions?: string[];
+  };
+};
+
+/** Source loader for direct, non-geospatial Zarr array access. */
+export const ZarrArraySourceLoader = {
+  dataType: null as unknown as ZarrArraySource,
+  dataSource: null as unknown as ZarrArraySource,
+  batchType: null as never,
+  name: 'ZarrArraySourceLoader',
+  id: 'zarr-array',
+  module: 'zarr',
+  version: 'latest',
+  extensions: ['zarr'],
+  mimeTypes: [],
+  type: 'zarr-array',
+  fromUrl: true,
+  fromBlob: false,
+  options: {
+    zarr: {
+      metadataPath: 'auto',
+      path: null,
+      labels: undefined!,
+      requireConsolidatedMetadata: true
+    },
+    zarrArray: {path: undefined!, dimensions: undefined!}
+  } as ZarrArraySourceLoaderOptions,
+  defaultOptions: {
+    zarr: {
+      metadataPath: 'auto',
+      path: null,
+      labels: undefined!,
+      requireConsolidatedMetadata: true
+    },
+    zarrArray: {path: undefined!, dimensions: undefined!}
+  },
+  testURL: (url: string): boolean => /\.zarr(?:$|[/?#])/i.test(url),
+  createDataSource: (
+    data: string,
+    options: ZarrArraySourceLoaderOptions,
+    coreApi?: CoreAPI
+  ): ZarrArraySource => new ZarrArraySource(data, options, coreApi)
+} as const satisfies SourceLoader<ZarrArraySource>;
+
+/** Runtime source for direct access to a single Zarr array. */
+export class ZarrArraySource extends ZarrSource {
+  /** Cached array initialization. */
+  private initializationPromise: Promise<{
+    array: zarrita.Array<zarrita.DataType, Readable>;
+    metadata: ZarrArraySourceMetadata;
+  }> | null = null;
+
+  /** Opens a Zarr array source. */
+  constructor(data: string, options: ZarrArraySourceLoaderOptions, coreApi?: CoreAPI) {
+    super(data, options, coreApi);
+  }
+
+  /** Returns array shape, chunks, dtype, and dimension labels. */
+  async getMetadata(signal?: AbortSignal): Promise<ZarrArraySourceMetadata> {
+    return (await this.getInitializationPromise(signal)).metadata;
+  }
+
+  /** Reads the selected array values. */
+  async getArray(parameters: GetZarrArrayParameters = {}): Promise<ZarrArrayData> {
+    const {array, metadata} = await this.getInitializationPromise(parameters.signal);
+    const selection = parameters.selection || metadata.shape.map(() => null);
+    if (selection.length !== metadata.shape.length) {
+      throw new Error(`Zarr array selection must have ${metadata.shape.length} dimensions.`);
+    }
+    const chunk = await zarrita.get(array, selection, {signal: parameters.signal});
+    if (!chunk || typeof chunk !== 'object' || !('data' in chunk) || !('shape' in chunk)) {
+      throw new Error('Failed to read Zarr array selection.');
+    }
+    return {data: chunk.data as TypedArray, shape: [...chunk.shape]};
+  }
+
+  /** Opens the configured array and resolves its normalized metadata. */
+  private async getInitializationPromise(signal?: AbortSignal) {
+    if (!this.initializationPromise) {
+      this.initializationPromise = this.initialize(signal);
+    }
+    return await this.initializationPromise;
+  }
+
+  /** Opens the array selected by the source options. */
+  private async initialize(signal?: AbortSignal) {
+    const group = await this.openGroup(signal);
+    const options = (this.options as ZarrArraySourceLoaderOptions).zarrArray;
+    const path = options?.path || '';
+    const location = path ? group.resolve(path) : group;
+    const array = await zarrita.open(location, {kind: 'array', signal});
+    const dimensions = options?.dimensions || this.options.zarr?.labels ||
+      array.shape.map((_size, index) => `dim_${index}`);
+    if (dimensions.length !== array.shape.length) {
+      throw new Error(`Zarr array dimensions must have length ${array.shape.length}.`);
+    }
+    return {
+      array,
+      metadata: {
+        path,
+        shape: [...array.shape],
+        chunks: [...array.chunks],
+        dtype: String(array.dtype),
+        dimensions: [...dimensions]
+      }
+    };
+  }
+}

--- a/modules/zarr/test/zarr-array-source.node.spec.ts
+++ b/modules/zarr/test/zarr-array-source.node.spec.ts
@@ -31,6 +31,12 @@ test('ZarrArraySource reads array metadata and integer selections', async t => {
   const selected = await source.getArray({selection: [0, 1, 0, null, null]});
   t.deepEqual(selected.shape, [167, 439]);
   t.equal(selected.data.length, 167 * 439);
+
+  const window = await source.getArray({
+    selection: [0, 1, 0, {start: 2, stop: 5}, {start: 4, stop: 9, step: 2}]
+  });
+  t.deepEqual(window.shape, [3, 3]);
+  t.equal(window.data.length, 9);
   t.end();
 });
 

--- a/modules/zarr/test/zarr-array-source.node.spec.ts
+++ b/modules/zarr/test/zarr-array-source.node.spec.ts
@@ -1,0 +1,45 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {pathToFileURL} from 'node:url';
+import '@loaders.gl/polyfills';
+import test from 'test/utils/vitest-tape';
+import {createDataSource, resolvePath} from '@loaders.gl/core';
+import {
+  ZarrArraySource,
+  ZarrArraySourceLoader,
+  type ZarrArraySourceLoaderOptions
+} from '@loaders.gl/zarr';
+
+const FIXTURE_PATH = resolvePath('@loaders.gl/zarr/test/data/spatialdata-v3.zarr');
+const FIXTURE_URL = pathToFileURL(FIXTURE_PATH).href;
+
+test('ZarrArraySource reads array metadata and integer selections', async t => {
+  const options: ZarrArraySourceLoaderOptions = {
+    zarr: {path: 'images/example-image'},
+    zarrArray: {path: '0', dimensions: ['t', 'c', 'z', 'y', 'x']}
+  };
+  const source = createDataSource(FIXTURE_URL, [ZarrArraySourceLoader], options);
+
+  t.ok(source instanceof ZarrArraySource);
+  const metadata = await source.getMetadata();
+  t.deepEqual(metadata.shape, [1, 3, 1, 167, 439]);
+  t.deepEqual(metadata.chunks, [1, 1, 1, 167, 439]);
+  t.deepEqual(metadata.dimensions, ['t', 'c', 'z', 'y', 'x']);
+
+  const selected = await source.getArray({selection: [0, 1, 0, null, null]});
+  t.deepEqual(selected.shape, [167, 439]);
+  t.equal(selected.data.length, 167 * 439);
+  t.end();
+});
+
+test('ZarrArraySource validates selection rank and dimension labels', async t => {
+  const source = createDataSource(FIXTURE_URL, [ZarrArraySourceLoader], {
+    zarr: {path: 'images/example-image'},
+    zarrArray: {path: '0', dimensions: ['t']}
+  });
+
+  await t.rejects(source.getMetadata(), /dimensions must have length 5/);
+  t.end();
+});

--- a/modules/zarr/test/zarr-array-source.node.spec.ts
+++ b/modules/zarr/test/zarr-array-source.node.spec.ts
@@ -37,6 +37,11 @@ test('ZarrArraySource reads array metadata and integer selections', async t => {
   });
   t.deepEqual(window.shape, [3, 3]);
   t.equal(window.data.length, 9);
+
+  const namedWindow = await source.getArray({
+    selectionByDimension: {t: 0, c: 1, z: 0, y: {start: 2, stop: 5}, x: {start: 4, stop: 9, step: 2}}
+  });
+  t.deepEqual(namedWindow.shape, [3, 3]);
   t.end();
 });
 
@@ -47,5 +52,15 @@ test('ZarrArraySource validates selection rank and dimension labels', async t =>
   });
 
   await t.rejects(source.getMetadata(), /dimensions must have length 5/);
+  t.end();
+});
+
+test('ZarrArraySource rejects unknown named dimensions', async t => {
+  const source = createDataSource(FIXTURE_URL, [ZarrArraySourceLoader], {
+    zarr: {path: 'images/example-image'},
+    zarrArray: {path: '0'}
+  });
+
+  await t.rejects(source.getArray({selectionByDimension: {unknown: 0}}), /Unknown Zarr array dimension/);
   t.end();
 });


### PR DESCRIPTION
## Goals

Make the shared RasterSet and Zarr runtime reusable for OME-Zarr, NDArray, and other non-viewport data sources.

## Changes

- allow RasterSet request types to be any object-shaped parameter type
- add `RasterSet.fromCallbacks` for non-viewport sources
- update the OME-Zarr example to use the public callback factory for level/channel requests
- add `ZarrArraySource` for direct array metadata and integer dimension selections
- add positional and named slice selections with optional start, stop, and step
- expose array shape, chunks, dtype, and dimension labels
- preserve the existing RasterSource convenience factory for viewport raster sources
- add hermetic fixture coverage for v3 array metadata, integer selections, slices, and named dimensions

## Validation

- yarn lint fix
- yarn build
- focused Zarr test: yarn test-node modules/zarr/test/zarr-array-source.node.spec.ts (3/3)
- focused RasterSet browser test: yarn test-headless modules/tiles/test/raster-set-dimensions.spec.ts (2/2)
- yarn --cwd website build

This is the next incremental Zarr tranche; richer codecs, caching, and virtual-Zarr references remain follow-up work.