### PR TITLE
docs(scan): expand format capability roadmap

### DIFF
--- a/docs/developer-guide/common-scan-architecture.md
+++ b/docs/developer-guide/common-scan-architecture.md
@@ -481,25 +481,64 @@ semantics?
 
 ## Roadmap
 
-The implementation evolves in reviewable tranches. The foundation now provides the first four
-items; the later work can land independently without changing portable query semantics:
+The implementation evolves in reviewable tranches. The first five are now landed; the remaining
+work is deliberately ordered by how much useful physical pruning each format can provide:
 
-1. **Foundation:** shared generic predicate, late binding, `TableQueryOptions`, canonical planning,
-   capability descriptors, and common ordered scan-task execution.
-2. **SQL adapters:** parameterized DuckDB and Snowflake compilation while retaining raw SQL for the
-   full language.
-3. **Reference executors:** switchable Arrow and lazy DuckDB execution over the same browser data,
-   without ingesting the Arrow result into DuckDB.
-4. **Physical scans:** common projection, predicate, and global-limit semantics across Parquet and
-   Iceberg, including hidden predicate/delete columns and aligned provenance.
-5. **Explain:** serializable physical plans, pushed-versus-residual diagnostics, and telemetry
-   annotations.
-6. **More table formats:** Delta transaction logs and deletion vectors, then Lance fragments and
-   indices, reusing Parquet or format-native physical tasks as appropriate.
-7. **GPU execution:** lower the shared predicate to luma.gl/WGSL masks or indices and add a
-   GPU-specific limit/selection stage.
-8. **Relational growth:** add ordering, expressions, aggregates, or joins only where at least two
-   materially different backends need the same portable meaning.
+1. **Foundation — landed:** shared generic predicate, late binding, `TableQueryOptions`, canonical
+   planning, capability descriptors, and common ordered scan-task execution.
+2. **SQL adapters — landed:** parameterized DuckDB and Snowflake compilation while retaining raw SQL
+   for the full language.
+3. **Reference executors — landed:** switchable Arrow and lazy DuckDB execution over the same
+   browser data, without ingesting the Arrow result into DuckDB.
+4. **Columnar physical scans — landed:** common projection, predicate, global-limit semantics,
+   hidden predicate/delete columns, and aligned provenance across Parquet and Iceberg.
+5. **Explain and diagnostics — landed:** serializable logical/physical plans, pushed-versus-residual
+   annotations, footer-only Parquet row-group explanations, and telemetry alignment.
+6. **FlatGeobuf spatial scan:** add a `FlatGeobufSource` scan adapter over the existing packed R-tree
+   and feature header. Spatial bounding boxes should prune feature ranges before decoding; scalar
+   attributes can initially be residual Arrow filtering. Preserve the existing vector-source API and
+   expose Arrow batches through the scan path rather than forcing GeoJSON materialization.
+7. **GeoArrow and Arrow IPC:** make GeoArrow/Arrow batches first-class scan inputs and outputs.
+   Projection and residual predicates are cheap in-memory operations; geometry columns, extension
+   metadata, and zero-copy slicing must survive the plan. This becomes the conformance reference for
+   vector formats that do not yet have physical indexes.
+8. **Stripe and block formats:** add ORC stripe/row-index planning, then CSV/JSONL chunk scans with
+   conservative byte-range tasking. ORC can advertise statistics pushdown; CSV/JSONL should advertise
+   residual filtering and projection pushdown only when the parser can avoid decoding unused fields.
+9. **Transactional and fragment formats:** Delta Lake logs/deletion vectors, Lance fragments and
+   indices, and future Iceberg table features. Reuse the snapshot, delete, provenance, and explain
+   contracts; each format should contribute a native file/fragment planner rather than another
+   query AST.
+10. **GPU execution:** lower the shared predicate to luma.gl/WGSL masks or indices and add a
+    GPU-specific limit/selection stage. GPU plans should report whether compaction is deferred or
+    materialized, so CPU and GPU diagnostics remain comparable.
+11. **Raster and multidimensional scans:** standardize the sibling `RasterQuery`/`ScanTask` shape for
+    GeoTIFF/COG, Zarr/GeoZarr, OME-Zarr, and NetCDF. Share scheduling, cancellation, range caching,
+    explain, telemetry, and spatial-envelope pruning with table scans while keeping pixel windows,
+    levels, chunks, and resampling out of `TableQuery`.
+12. **Relational growth:** add ordering, scalar expressions, aggregates, unions, or joins only when
+    at least two materially different backends can implement the same portable meaning. Spatial
+    predicates and nearest-neighbor search should remain extensions until indexed CPU, GPU, and
+    remote-source strategies converge.
+
+### Format capability matrix
+
+The roadmap is capability-driven rather than format-driven. A new adapter can land incrementally by
+advertising the strongest correct level for each operator:
+
+| Format/source | Natural physical unit | Projection | Predicate | Limit | First useful tranche |
+| --- | --- | --- | --- | --- | --- |
+| Arrow / GeoArrow | record batch | residual/zero-copy | residual | residual | 7 |
+| Parquet / Iceberg | row group, page, file | pushdown | statistics + residual | global/pushdown | 4 |
+| FlatGeobuf | R-tree feature range | residual | bbox pushdown, scalar residual | residual | 6 |
+| ORC | stripe, row index | pushdown | statistics + residual | global/pushdown | 8 |
+| CSV / JSONL | byte-range chunk | parser-dependent | residual | global | 8 |
+| Delta / Lance | file, fragment, delete vector | format-native | format-native + residual | global | 9 |
+| GeoTIFF / Zarr | tile, chunk, overview | band/variable pushdown | spatial/window pushdown | task-local | 11 |
+
+“Pushdown” in this table is a promise about avoiding physical work, not merely accepting the
+operator. An adapter must report `residual` when it must decode rows or features before evaluating
+the predicate, and conformance tests must verify that hidden filter columns never leak into output.
 
 The desired end state is not one monolithic engine. It is a family of specialized planners and
 executors that agree on what a query means.

--- a/docs/developer-guide/common-scan-architecture.md
+++ b/docs/developer-guide/common-scan-architecture.md
@@ -375,6 +375,70 @@ Capabilities answer two different questions:
 The planner may reject a query only for a correctness gap. An optimization gap should produce a
 residual operator or a diagnostic.
 
+## Query discovery and reusable controls
+
+A reusable query editor needs more than an execution function. It needs to discover columns,
+types, semantic roles, source bounds, and physical capabilities before it can construct a valid
+query. Sources expose that information through `getQueryMetadata()` without materializing result
+rows:
+
+```ts
+type ScanQueryMetadata = Readonly<{
+  sourceType: string;
+  queryType: 'table' | 'point-cloud' | 'raster';
+  name?: string;
+  description?: string;
+  schema: Schema;
+  columns: readonly ScanColumnMetadata[];
+  capabilities: ScanQueryCapabilities;
+  spatial?: ScanSpatialMetadata;
+  statistics?: {rowCount?: number | bigint; byteLength?: number | bigint};
+}>;
+```
+
+`schema` is the authoritative execution schema. `columns` is a panel-ready view of those fields
+that adds semantic roles such as `identifier`, `geometry`, `x`, `y`, `z`, `time`, `intensity`, or
+`classification`. The common `createScanQueryMetadata()` helper derives names, types, nullability,
+titles, and descriptions from a loaders.gl schema; adapters only annotate roles that cannot be
+inferred from physical Arrow types.
+
+The discovery call is intentionally separate from `getMetadata()` and `getSchema()`:
+
+- `getMetadata()` describes the dataset in its native domain, for example vector layers or an
+  Iceberg snapshot.
+- `getSchema()` returns the source's conventional schema, which may omit synthetic query columns
+  such as GeoArrow geometry.
+- `getQueryMetadata()` returns exactly the columns and controls visible to the portable query.
+- `explain()` accepts a proposed query and reports its logical and physical plan without reading
+  result rows.
+
+This distinction lets a FlatGeobuf vector source preserve its established property-only
+`getSchema()` contract while exposing the generated `geometry` column to a query panel. Parquet can
+obtain the same shape from its footer, Iceberg from table and manifest metadata, Arrow directly
+from its schema, and a SQL source from catalog schema discovery.
+
+A framework-specific panel can remain outside the scan core. Its data flow is small and reusable:
+
+```text
+source.getQueryMetadata()
+    -> column projection picker
+    -> typed predicate builder
+    -> named parameter inputs
+    -> optional bounds / level-of-detail controls
+    -> capability badges
+    -> source.explain(query)
+    -> source.read(query) or source.query(query)
+```
+
+Named values are discovered from the AST with `getColumnarPredicateParameterNames()`. The panel
+does not need to parse SQL text, and parameter values remain separate from the immutable predicate.
+This is important for prepared SQL, GPU uniforms, saved queries, and URL state.
+
+Discovery should normally require only headers, footers, manifests, catalog calls, or already
+available in-memory schemas. It must accept cancellation and must not silently begin a full data
+scan. Column statistics and enumerated value hints can be added later, but should identify whether
+they are exact or sampled before a panel uses them to constrain input.
+
 ## Explainability and telemetry
 
 Remote scans are often optimized more by avoiding bytes than by decoding them faster. Planning and
@@ -494,7 +558,7 @@ work is deliberately ordered by how much useful physical pruning each format can
    hidden predicate/delete columns, and aligned provenance across Parquet and Iceberg.
 5. **Explain and diagnostics — landed:** serializable logical/physical plans, pushed-versus-residual
    annotations, footer-only Parquet row-group explanations, and telemetry alignment.
-6. **FlatGeobuf spatial scan:** add a `FlatGeobufSource` scan adapter over the existing packed R-tree
+6. **FlatGeobuf spatial scan — landed:** add a `FlatGeobufSource` scan adapter over the existing packed R-tree
    and feature header. Spatial bounding boxes should prune feature ranges before decoding; scalar
    attributes can initially be residual Arrow filtering. Preserve the existing vector-source API and
    expose Arrow batches through the scan path rather than forcing GeoJSON materialization.
@@ -512,11 +576,15 @@ work is deliberately ordered by how much useful physical pruning each format can
 10. **GPU execution:** lower the shared predicate to luma.gl/WGSL masks or indices and add a
     GPU-specific limit/selection stage. GPU plans should report whether compaction is deferred or
     materialized, so CPU and GPU diagnostics remain comparable.
-11. **Raster and multidimensional scans:** standardize the sibling `RasterQuery`/`ScanTask` shape for
+11. **Point-cloud scans:** standardize the sibling `PointCloudQueryOptions` contract, implement COPC
+    hierarchy and bounds planning first, then reuse its planner and Arrow batch conventions for
+    Potree. Preserve point budgets, hierarchy levels, target spacing, coordinate roles, and node
+    provenance instead of forcing them into scalar table predicates.
+12. **Raster and multidimensional scans:** standardize the sibling `RasterQuery`/`ScanTask` shape for
     GeoTIFF/COG, Zarr/GeoZarr, OME-Zarr, and NetCDF. Share scheduling, cancellation, range caching,
     explain, telemetry, and spatial-envelope pruning with table scans while keeping pixel windows,
     levels, chunks, and resampling out of `TableQuery`.
-12. **Relational growth:** add ordering, scalar expressions, aggregates, unions, or joins only when
+13. **Relational growth:** add ordering, scalar expressions, aggregates, unions, or joins only when
     at least two materially different backends can implement the same portable meaning. Spatial
     predicates and nearest-neighbor search should remain extensions until indexed CPU, GPU, and
     remote-source strategies converge.
@@ -534,7 +602,8 @@ advertising the strongest correct level for each operator:
 | ORC | stripe, row index | pushdown | statistics + residual | global/pushdown | 8 |
 | CSV / JSONL | byte-range chunk | parser-dependent | residual | global | 8 |
 | Delta / Lance | file, fragment, delete vector | format-native | format-native + residual | global | 9 |
-| GeoTIFF / Zarr | tile, chunk, overview | band/variable pushdown | spatial/window pushdown | task-local | 11 |
+| COPC / Potree | hierarchy node | attribute decode | bounds + attribute residual | global | 11 |
+| GeoTIFF / Zarr | tile, chunk, overview | band/variable pushdown | spatial/window pushdown | task-local | 12 |
 
 “Pushdown” in this table is a promise about avoiding physical work, not merely accepting the
 operator. An adapter must report `residual` when it must decode rows or features before evaluating
@@ -542,6 +611,60 @@ the predicate, and conformance tests must verify that hidden filter columns neve
 
 The desired end state is not one monolithic engine. It is a family of specialized planners and
 executors that agree on what a query means.
+
+## Point-cloud participation
+
+COPC and Potree participate through a sibling point-cloud query. They share relational attribute
+semantics while retaining hierarchy and resolution controls that do not belong in `TableQuery`:
+
+```ts
+type PointCloudQueryOptions<PredicateT extends ColumnarPredicate = ColumnarPredicate> =
+  TableQueryOptions<PredicateT> &
+    Readonly<{
+      bounds?: {
+        minimum: readonly [number, number, number];
+        maximum: readonly [number, number, number];
+      };
+      minimumLevel?: number;
+      maximumLevel?: number;
+      targetSpacing?: number;
+    }>;
+```
+
+Projection chooses decoded point attributes. The predicate filters attributes with the same null
+and comparison semantics as a table scan. Bounds select points in the source coordinate system,
+and hierarchy levels or target spacing determine which physical nodes may contribute. The global
+`limit` still counts points that survive bounds and predicates; it is not a license for each node
+to emit its own limit.
+
+`validatePointCloudQueryOptions()` applies ordinary table-query validation and additionally rejects
+non-finite or inverted bounds, invalid hierarchy levels, and non-positive spacing. A point-cloud
+adapter advertises table capabilities plus `bounds`, `levelOfDetail`, and `spacing` support.
+
+COPC is the first physical target because its hierarchy pages, node bounds, point counts, and LAZ
+chunks create a clean pruning ladder:
+
+```text
+PointCloudQueryOptions
+    -> COPC header and schema discovery
+    -> hierarchy page traversal
+    -> bounds / level / spacing node selection
+    -> ordered node ScanTasks
+    -> requested-attribute LAZ decoding
+    -> exact residual bounds and attribute filtering
+    -> global limit
+    -> Arrow or GeoArrow point batches
+```
+
+Potree can reuse the logical query, metadata roles, hierarchy selection interface, scan executor,
+and result batches. Its physical adapter remains separate because Potree versions differ in
+metadata, hierarchy storage, point encoding, and URL layout. Initial Potree support can conservatively
+advertise bounds and level selection as pushdown while keeping scalar attribute predicates residual.
+
+Both adapters should expose `x`, `y`, and `z` roles even when their native attribute names use LAS
+conventions such as `X`, `Y`, and `Z`. Intensity, classification, color, GPS time, and point-source
+identifier roles allow the same query panel to render useful typed controls without embedding COPC
+or Potree naming rules in UI code.
 
 ## Raster participation
 

--- a/docs/developer-guide/common-scan-architecture.md
+++ b/docs/developer-guide/common-scan-architecture.md
@@ -346,26 +346,28 @@ correctness using the shared contract:
 
 ```ts
 type TableQueryCapabilities = Readonly<{
-  projection: 'unsupported' | 'residual' | 'pushdown';
-  predicate: 'unsupported' | 'residual' | 'pushdown';
-  limit: 'unsupported' | 'residual' | 'pushdown';
+  projection: 'unsupported' | 'residual' | 'pushdown' | 'pushdown+residual';
+  predicate: 'unsupported' | 'residual' | 'pushdown' | 'pushdown+residual';
+  limit: 'unsupported' | 'residual' | 'pushdown' | 'pushdown+residual';
   streaming: boolean;
   cancellation: boolean;
 }>;
 
 const PARQUET_TABLE_QUERY_CAPABILITIES = {
   projection: 'pushdown',
-  predicate: 'pushdown',
+  predicate: 'pushdown+residual',
   limit: 'pushdown',
   streaming: true,
   cancellation: true
 };
 ```
 
-`pushdown` means the backend has a physical opportunity to avoid work; it does not promise that
-every expression can be proven from metadata. Parquet still evaluates a residual predicate exactly
-after conservative statistics and page pruning. `residual` means correct local execution without a
-storage-level optimization. `unsupported` is a correctness gap that must be rejected or delegated.
+`pushdown` means the backend has a physical opportunity to avoid work and can execute the requested
+operator as part of physical planning. `pushdown+residual` means it can prune physical work before
+decoding and still must evaluate the surviving rows exactly. Parquet uses this level for statistics
+and page pruning followed by exact predicate evaluation. `residual` means correct local execution
+without a storage-level optimization. `unsupported` is a correctness gap that must be rejected or
+delegated.
 
 Capabilities answer two different questions:
 
@@ -482,7 +484,7 @@ const explanation = await parquetSource.explain({
   limit: 100
 });
 
-explanation.operators.predicate.support; // 'pushdown' | 'residual' | 'unsupported'
+explanation.operators.predicate.support; // 'pushdown' | 'pushdown+residual' | 'residual' | 'unsupported'
 explanation.rowGroups?.prunedByStatistics;
 ```
 
@@ -597,9 +599,9 @@ advertising the strongest correct level for each operator:
 | Format/source | Natural physical unit | Projection | Predicate | Limit | First useful tranche |
 | --- | --- | --- | --- | --- | --- |
 | Arrow / GeoArrow | record batch | residual/zero-copy | residual | residual | 7 |
-| Parquet / Iceberg | row group, page, file | pushdown | statistics + residual | global/pushdown | 4 |
+| Parquet / Iceberg | row group, page, file | pushdown | pushdown + residual | global/pushdown | 4 |
 | FlatGeobuf | R-tree feature range | residual | bbox pushdown, scalar residual | residual | 6 |
-| ORC | stripe, row index | pushdown | statistics + residual | global/pushdown | 8 |
+| ORC | stripe, row index | pushdown | pushdown + residual | global/pushdown | 8 |
 | CSV / JSONL | byte-range chunk | parser-dependent | residual | global | 8 |
 | Delta / Lance | file, fragment, delete vector | format-native | format-native + residual | global | 9 |
 | COPC / Potree | hierarchy node | attribute decode | bounds + attribute residual | global | 11 |

--- a/modules/flatgeobuf/src/flatgeobuf-source-loader.ts
+++ b/modules/flatgeobuf/src/flatgeobuf-source-loader.ts
@@ -3,8 +3,21 @@
 // Copyright (c) vis.gl contributors
 
 import type {ArrowTable, ArrowTableBatch, Schema} from '@loaders.gl/schema';
-import type {CoreAPI, DataSourceOptions, GetFeaturesParameters, SourceLoader, VectorSource, VectorSourceData, VectorSourceLayer, VectorSourceMetadata} from '@loaders.gl/loader-utils';
-import {DataSource} from '@loaders.gl/loader-utils';
+import type {
+  CoreAPI,
+  DataSourceOptions,
+  GetFeaturesParameters,
+  ScanColumnRole,
+  ScanQueryMetadata,
+  ScanQueryMetadataOptions,
+  SourceLoader,
+  TableQueryExplain,
+  VectorSource,
+  VectorSourceData,
+  VectorSourceLayer,
+  VectorSourceMetadata
+} from '@loaders.gl/loader-utils';
+import {createScanQueryMetadata, DataSource, explainTableQuery} from '@loaders.gl/loader-utils';
 import {FlatGeobufFormat} from './flatgeobuf-format';
 import {
   makeArrowSchema,
@@ -27,7 +40,33 @@ export type FlatGeobufSourceLoaderOptions = DataSourceOptions & {flatgeobuf?: {f
 /** Portable query options accepted by `FlatGeobufVectorSource.query()`. */
 export type FlatGeobufReadOptions = FlatGeobufQueryOptions;
 
-type HeaderInfo = {arrayBuffer: ArrayBuffer; header: FlatGeobufHeader; schema: Schema; metadata: VectorSourceMetadata; layerName: string};
+/** Footer-free explanation of a FlatGeobuf portable query. */
+export type FlatGeobufSourceExplain = TableQueryExplain &
+  Readonly<{
+    /** Source discriminator for format-specific explain consumers. */
+    source: 'flatgeobuf';
+    /** Packed R-tree bounds planning performed before feature decoding. */
+    spatial: Readonly<{
+      /** Whether the query requests a bounding box. */
+      enabled: boolean;
+      /** FlatGeobuf packed R-tree support for bounding boxes. */
+      support: 'pushdown';
+      /** Requested bounds in the source coordinate reference system. */
+      bounds?: Readonly<{
+        minimum: readonly [number, number];
+        maximum: readonly [number, number];
+      }>;
+    }>;
+  }>;
+
+type HeaderInfo = {
+  arrayBuffer: ArrayBuffer;
+  header: FlatGeobufHeader;
+  schema: Schema;
+  querySchema: Schema;
+  metadata: VectorSourceMetadata;
+  layerName: string;
+};
 type FetchLike = (url: string, options?: RequestInit) => Promise<Response>;
 
 /** Incrementally loads indexed FlatGeobuf data sources. */
@@ -62,6 +101,55 @@ export class FlatGeobufVectorSource extends DataSource<string, FlatGeobufSourceL
   async getMetadata(options: {formatSpecificMetadata?: boolean} = {}): Promise<VectorSourceMetadata> {
     const info = await this.getHeaderInfo();
     return options.formatSpecificMetadata ? {...info.metadata, formatSpecificMetadata: serializeHeader(info.header)} : info.metadata;
+  }
+
+  /** Discovers query-visible columns, spatial bounds, and capabilities without decoding features. */
+  async getQueryMetadata(options: ScanQueryMetadataOptions = {}): Promise<ScanQueryMetadata> {
+    assertNotAborted(options.signal);
+    const info = await this.getHeaderInfo();
+    assertNotAborted(options.signal);
+    return createScanQueryMetadata({
+      sourceType: 'flatgeobuf',
+      queryType: 'table',
+      name: info.layerName,
+      description: info.header.description,
+      schema: info.querySchema,
+      columnRoles: getColumnRoles(info.header),
+      capabilities: {table: this.tableQueryCapabilities, bounds: 'pushdown'},
+      spatial: {
+        bounds: getScanBoundsFromHeader(info.header),
+        coordinateReferenceSystems: getLayerCrs(info.header)
+      },
+      statistics: {rowCount: info.header.featuresCount}
+    });
+  }
+
+  /** Explains relational and packed R-tree work without decoding feature rows. */
+  async explain(options: FlatGeobufReadOptions = {}): Promise<FlatGeobufSourceExplain> {
+    assertNotAborted(options.signal);
+    const info = await this.getHeaderInfo();
+    assertNotAborted(options.signal);
+    const sourceColumnNames = info.querySchema.fields.map(field => field.name);
+    const explanation = explainTableQuery(
+      sourceColumnNames,
+      {columns: options.columns, predicate: options.predicate, limit: options.limit},
+      this.tableQueryCapabilities
+    );
+    const bounds = options.boundingBox
+      ? Object.freeze({
+          minimum: Object.freeze([...options.boundingBox[0]]) as readonly [number, number],
+          maximum: Object.freeze([...options.boundingBox[1]]) as readonly [number, number]
+        })
+      : undefined;
+    return Object.freeze({
+      ...explanation,
+      source: 'flatgeobuf' as const,
+      spatial: Object.freeze({
+        enabled: Boolean(bounds),
+        support: 'pushdown' as const,
+        bounds
+      })
+    });
   }
 
   /** Returns features in the requested format for one bounding box. */
@@ -102,8 +190,8 @@ async function loadHeaderInfo(url: string, fetch: FetchLike): Promise<HeaderInfo
   const arrayBuffer = await response.arrayBuffer();
   const header = readFlatGeobufHeader(arrayBuffer);
   const layerName = inferLayerName(url, header);
-  const arrowSchema = makeArrowSchema(header);
-  return {arrayBuffer, header, schema: {...arrowSchema, fields: arrowSchema.fields.slice(0, -1)}, layerName, metadata: buildMetadata(layerName, header)};
+  const querySchema = makeArrowSchema(header);
+  return {arrayBuffer, header, schema: {...querySchema, fields: querySchema.fields.slice(0, -1)}, querySchema, layerName, metadata: buildMetadata(layerName, header)};
 }
 
 function buildMetadata(layerName: string, header: FlatGeobufHeader): VectorSourceMetadata {
@@ -114,5 +202,7 @@ function buildMetadata(layerName: string, header: FlatGeobufHeader): VectorSourc
 function inferLayerName(url: string, header: FlatGeobufHeader): string { if (header.title) return header.title; const fileName = url.split(/[?#]/)[0].split('/').pop() || 'flatgeobuf'; return fileName.replace(/\.fgb$/i, '') || 'flatgeobuf'; }
 function getLayerCrs(header: FlatGeobufHeader): string[] | undefined { const values = [header.crs?.codeString, header.crs?.wkt, Number.isFinite(header.crs?.code) ? `EPSG:${header.crs?.code}` : undefined].filter(Boolean).map(String); return values.length ? values : undefined; }
 function getBoundingBoxFromHeader(header: FlatGeobufHeader): [[number, number], [number, number]] | undefined { const envelope = header.envelope; return envelope && envelope.length >= 4 ? [[envelope[0], envelope[1]], [envelope[2], envelope[3]]] : undefined; }
+function getScanBoundsFromHeader(header: FlatGeobufHeader): {minimum: [number, number]; maximum: [number, number]} | undefined { const boundingBox = getBoundingBoxFromHeader(header); return boundingBox ? {minimum: boundingBox[0], maximum: boundingBox[1]} : undefined; }
+function getColumnRoles(header: FlatGeobufHeader): Record<string, ScanColumnRole> { const roles: Record<string, ScanColumnRole> = {geometry: 'geometry'}; for (const column of header.columns) if (column.primaryKey) roles[column.name] = 'identifier'; return roles; }
 function serializeHeader(header: FlatGeobufHeader): Record<string, unknown> { return {...header, envelope: header.envelope ? Array.from(header.envelope) : undefined}; }
 function assertNotAborted(signal?: AbortSignal): void { if (signal?.aborted) { const error = new Error('Aborted'); error.name = 'AbortError'; throw error; } }

--- a/modules/flatgeobuf/src/flatgeobuf-source-loader.ts
+++ b/modules/flatgeobuf/src/flatgeobuf-source-loader.ts
@@ -2,12 +2,18 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {Schema} from '@loaders.gl/schema';
+import type {ArrowTable, ArrowTableBatch, Schema} from '@loaders.gl/schema';
 import type {CoreAPI, DataSourceOptions, GetFeaturesParameters, SourceLoader, VectorSource, VectorSourceData, VectorSourceLayer, VectorSourceMetadata} from '@loaders.gl/loader-utils';
 import {DataSource} from '@loaders.gl/loader-utils';
 import {FlatGeobufFormat} from './flatgeobuf-format';
-import {makeArrowSchema, parseFlatGeobuf} from './lib/parse-flatgeobuf';
+import {
+  makeArrowSchema,
+  parseFlatGeobuf,
+  queryFlatGeobufArrowTable,
+  type FlatGeobufQueryOptions
+} from './lib/parse-flatgeobuf';
 import {readFlatGeobufHeader, type FlatGeobufHeader} from './lib/flatgeobuf-reader';
+import {FLATGEOBUF_TABLE_QUERY_CAPABILITIES} from './flatgeobuf-table-query-capabilities';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
@@ -17,6 +23,9 @@ type FlatGeobufResponseFormat = 'geojson' | 'binary' | 'arrow';
 
 /** Options for `FlatGeobufSourceLoader`. */
 export type FlatGeobufSourceLoaderOptions = DataSourceOptions & {flatgeobuf?: {format?: FlatGeobufResponseFormat}};
+
+/** Portable query options accepted by `FlatGeobufVectorSource.query()`. */
+export type FlatGeobufReadOptions = FlatGeobufQueryOptions;
 
 type HeaderInfo = {arrayBuffer: ArrayBuffer; header: FlatGeobufHeader; schema: Schema; metadata: VectorSourceMetadata; layerName: string};
 type FetchLike = (url: string, options?: RequestInit) => Promise<Response>;
@@ -38,6 +47,8 @@ export const FlatGeobufSourceLoader = {
 
 /** Runtime vector source backed by FlatGeobuf HTTP data. */
 export class FlatGeobufVectorSource extends DataSource<string, FlatGeobufSourceLoaderOptions> implements VectorSource {
+  /** Conservative table-query capabilities; bounding-box pruning is format-specific. */
+  readonly tableQueryCapabilities = FLATGEOBUF_TABLE_QUERY_CAPABILITIES;
   /** Shared header and dataset promise for this URL. */
   protected headerInfoPromise: Promise<HeaderInfo> | null = null;
 
@@ -60,6 +71,26 @@ export class FlatGeobufVectorSource extends DataSource<string, FlatGeobufSourceL
     assertNotAborted(parameters.signal);
     const format = parameters.format || this.options.flatgeobuf?.format || 'arrow';
     return parseFlatGeobuf(info.arrayBuffer, {shape: format === 'arrow' ? 'arrow-table' : format === 'binary' ? 'binary-geometry' : 'geojson-table', boundingBox: parameters.boundingBox, crs: parameters.crs || 'WGS84', reproject: Boolean(parameters.crs && parameters.crs !== info.header.crs?.wkt)}) as VectorSourceData;
+  }
+
+  /** Executes a spatially pruned FlatGeobuf query and returns an Arrow table. */
+  async query(options: FlatGeobufReadOptions = {}): Promise<ArrowTable> {
+    assertNotAborted(options.signal);
+    const info = await this.getHeaderInfo();
+    assertNotAborted(options.signal);
+    return queryFlatGeobufArrowTable(info.arrayBuffer, options);
+  }
+
+  /** Streams one stable-schema Arrow batch for a portable FlatGeobuf query. */
+  async *read(options: FlatGeobufReadOptions = {}): AsyncIterable<ArrowTableBatch> {
+    const table = await this.query(options);
+    yield {
+      shape: 'arrow-table',
+      batchType: 'data',
+      length: table.data.numRows,
+      schema: table.schema,
+      data: table.data
+    };
   }
 
   protected getHeaderInfo(): Promise<HeaderInfo> { this.headerInfoPromise ||= loadHeaderInfo(this.url, this.fetch); return this.headerInfoPromise; }

--- a/modules/flatgeobuf/src/flatgeobuf-table-query-capabilities.ts
+++ b/modules/flatgeobuf/src/flatgeobuf-table-query-capabilities.ts
@@ -1,0 +1,14 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {TableQueryCapabilities} from '@loaders.gl/loader-utils';
+
+/** Conservative capabilities of the current FlatGeobuf table-query adapter. */
+export const FLATGEOBUF_TABLE_QUERY_CAPABILITIES: TableQueryCapabilities = Object.freeze({
+  projection: 'residual',
+  predicate: 'residual',
+  limit: 'residual',
+  streaming: true,
+  cancellation: true
+});

--- a/modules/flatgeobuf/src/index.ts
+++ b/modules/flatgeobuf/src/index.ts
@@ -10,6 +10,7 @@ export {FlatGeobufLoader} from './flatgeobuf-loader';
 
 export type {
   FlatGeobufReadOptions,
+  FlatGeobufSourceExplain,
   FlatGeobufSourceLoaderOptions
 } from './flatgeobuf-source-loader';
 export {

--- a/modules/flatgeobuf/src/index.ts
+++ b/modules/flatgeobuf/src/index.ts
@@ -3,11 +3,15 @@
 // Copyright (c) vis.gl contributors
 
 export {FlatGeobufFormat} from './flatgeobuf-format';
+export {FLATGEOBUF_TABLE_QUERY_CAPABILITIES} from './flatgeobuf-table-query-capabilities';
 
 export type {FlatGeobufLoaderOptions} from './flatgeobuf-loader';
 export {FlatGeobufLoader} from './flatgeobuf-loader';
 
-export type {FlatGeobufSourceLoaderOptions} from './flatgeobuf-source-loader';
+export type {
+  FlatGeobufReadOptions,
+  FlatGeobufSourceLoaderOptions
+} from './flatgeobuf-source-loader';
 export {
   FlatGeobufSourceLoader,
   FlatGeobufSourceLoader as _FlatGeobufSourceLoader,

--- a/modules/flatgeobuf/src/lib/parse-flatgeobuf.ts
+++ b/modules/flatgeobuf/src/lib/parse-flatgeobuf.ts
@@ -6,6 +6,12 @@ import * as arrow from 'apache-arrow';
 import {Proj4Projection} from '@math.gl/proj4';
 import type {ArrowTable, ArrowTableBatch, Feature, Field, Schema, Table} from '@loaders.gl/schema';
 import {
+  filterColumnarRowIndices,
+  planTableQuery,
+  type ColumnarPredicate,
+  type TableQueryOptions
+} from '@loaders.gl/loader-utils';
+import {
   convertGeojsonToBinaryFeatureCollection,
   encodeWKBGeometryValue,
   GeoArrowBuilder,
@@ -34,6 +40,16 @@ export type ParseFlatGeobufOptions = {
   crs?: string;
   reproject?: boolean;
 };
+
+/** Portable FlatGeobuf query options, with an indexed spatial envelope. */
+export type FlatGeobufQueryOptions<PredicateT extends ColumnarPredicate = ColumnarPredicate> =
+  TableQueryOptions<PredicateT> &
+    Readonly<{
+      /** Bounding box used to prune features before property decoding. */
+      boundingBox?: [[number, number], [number, number]];
+      /** Cancels parsing before or during feature materialization. */
+      signal?: AbortSignal;
+    }>;
 
 /** Parses a FlatGeobuf buffer through the Arrow-native decode pipeline. */
 export function parseFlatGeobuf(
@@ -114,6 +130,60 @@ export function parseFlatGeobufToArrowTable(
     shape: 'arrow-table',
     schema,
     data: new arrow.Table(arrowSchema, [new arrow.RecordBatch(arrowSchema, structData)])
+  };
+}
+
+/** Executes a portable projection, residual predicate, and limit over FlatGeobuf features. */
+export function queryFlatGeobufArrowTable(
+  arrayBuffer: ArrayBuffer,
+  options: FlatGeobufQueryOptions = {}
+): ArrowTable {
+  throwIfAborted(options.signal);
+  const sourceTable = parseFlatGeobufToArrowTable(arrayBuffer, {
+    boundingBox: options.boundingBox
+  });
+  const sourceColumnNames = sourceTable.data.schema.fields.map(field => field.name);
+  const plan = planTableQuery(sourceColumnNames, options);
+  const scanStep = plan.find(step => step.kind === 'scan');
+  const projectStep = plan.find(step => step.kind === 'project');
+  if (!scanStep || scanStep.kind !== 'scan' || !projectStep || projectStep.kind !== 'project') {
+    throw new Error('FlatGeobuf query planner produced an invalid plan.');
+  }
+  const scannedColumns: Record<string, any[]> = {};
+  for (const columnName of scanStep.columns) {
+    const column = sourceTable.data.getChild(columnName);
+    if (!column) throw new Error(`FlatGeobuf query could not read column "${columnName}".`);
+    scannedColumns[columnName] = column.toArray();
+  }
+  const predicateStep = plan.find(step => step.kind === 'filter');
+  const limitStep = plan.find(step => step.kind === 'limit');
+  const matchingRowIndices =
+    predicateStep?.kind === 'filter'
+      ? filterColumnarRowIndices(predicateStep.predicate, scannedColumns, sourceTable.data.numRows)
+      : Array.from({length: sourceTable.data.numRows}, (_, index) => index);
+  const limit = limitStep?.kind === 'limit' ? limitStep.limit : matchingRowIndices.length;
+  const rowIndices = matchingRowIndices.slice(0, limit);
+  const projectedSchema = sourceTable.data.select([...projectStep.columns]).schema;
+  const sourceSchema = sourceTable.schema;
+  if (!sourceSchema) throw new Error('FlatGeobuf query source is missing a schema.');
+  const outputColumns: Record<string, arrow.Vector> = {};
+  for (const field of projectedSchema.fields) {
+    const column = sourceTable.data.getChild(field.name);
+    if (!column) throw new Error(`FlatGeobuf query could not project column "${field.name}".`);
+    outputColumns[field.name] = arrow.vectorFromArray(
+      rowIndices.map(rowIndex => column.get(rowIndex)),
+      column.type
+    );
+  }
+  return {
+    shape: 'arrow-table',
+    schema: {
+      ...sourceSchema,
+      fields: projectStep.columns
+        .map(columnName => sourceSchema.fields.find(field => field.name === columnName))
+        .filter((field): field is Field => Boolean(field))
+    },
+    data: new arrow.Table(projectedSchema, outputColumns)
   };
 }
 
@@ -217,6 +287,14 @@ function writeGeometry(
   header: FlatGeobufHeader
 ): void {
   writeFlatGeobufGeometry(builder, arrayBuffer, geometryOffset, header);
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    const error = new Error('Aborted');
+    error.name = 'AbortError';
+    throw error;
+  }
 }
 
 function getGeometryEncoding(type: FlatGeobufGeometryType): GeoArrowBuilderEncoding {

--- a/modules/flatgeobuf/test/flatgeobuf-source-loader.spec.ts
+++ b/modules/flatgeobuf/test/flatgeobuf-source-loader.spec.ts
@@ -160,6 +160,25 @@ test('FlatGeobufSourceLoader#getFeatures returns empty valid tables for no-match
   t.end();
 });
 
+test('FlatGeobufVectorSource#query combines bbox pruning with portable projection and limit', async t => {
+  const source = await createSource();
+  const table = await source.query({
+    boundingBox: NARROW_BOUNDING_BOX,
+    columns: ['name'],
+    predicate: {op: '<>', args: [{property: 'id'}, '']},
+    limit: 2
+  });
+
+  t.deepEqual(
+    table.schema.fields.map(field => field.name),
+    ['name'],
+    'projects requested fields'
+  );
+  t.equal(table.data.numRows, 2, 'applies a global limit after the residual predicate');
+  t.equal(source.tableQueryCapabilities.predicate, 'residual', 'reports conservative capability');
+  t.end();
+});
+
 test('FlatGeobufSourceLoader#getFeatures respects abort signals', async t => {
   const abortController = new AbortController();
   const delayedSource = createDataSource(REMOTE_FGB_URL, [FlatGeobufSourceLoader], {

--- a/modules/flatgeobuf/test/flatgeobuf-source-loader.spec.ts
+++ b/modules/flatgeobuf/test/flatgeobuf-source-loader.spec.ts
@@ -56,6 +56,23 @@ test('FlatGeobufSourceLoader#getSchema and getMetadata expose header metadata', 
   t.end();
 });
 
+test('FlatGeobufVectorSource#getQueryMetadata discovers panel controls from the header', async t => {
+  const source = await createSource();
+  const queryMetadata = await source.getQueryMetadata();
+
+  t.equal(queryMetadata.sourceType, 'flatgeobuf', 'identifies the source adapter');
+  t.deepEqual(
+    queryMetadata.columns.map(column => column.name),
+    ['id', 'name', 'geometry'],
+    'includes every query-visible column'
+  );
+  t.equal(queryMetadata.columns[2]?.role, 'geometry', 'identifies the geometry control');
+  t.equal(queryMetadata.capabilities.bounds, 'pushdown', 'advertises packed R-tree pruning');
+  t.ok(queryMetadata.spatial?.bounds, 'discovers dataset bounds');
+  t.equal(queryMetadata.statistics?.rowCount, 179, 'discovers feature count');
+  t.end();
+});
+
 test('FlatGeobufSourceLoader#getFeatures returns matching feature sets across formats', async t => {
   const source = await createSource();
   const defaultTable = await source.getFeatures({
@@ -176,6 +193,22 @@ test('FlatGeobufVectorSource#query combines bbox pruning with portable projectio
   );
   t.equal(table.data.numRows, 2, 'applies a global limit after the residual predicate');
   t.equal(source.tableQueryCapabilities.predicate, 'residual', 'reports conservative capability');
+  t.end();
+});
+
+test('FlatGeobufVectorSource#explain reports relational and spatial planning', async t => {
+  const source = await createSource();
+  const explanation = await source.explain({
+    boundingBox: NARROW_BOUNDING_BOX,
+    columns: ['name'],
+    predicate: {op: '<>', args: [{property: 'id'}, '']},
+    limit: 2
+  });
+
+  t.deepEqual(explanation.outputColumns, ['name'], 'reports visible output columns');
+  t.deepEqual(explanation.requiredColumns, ['id', 'name'], 'retains hidden predicate columns');
+  t.equal(explanation.spatial.enabled, true, 'reports requested bounds');
+  t.equal(explanation.spatial.support, 'pushdown', 'reports packed R-tree pushdown');
   t.end();
 });
 

--- a/modules/loader-utils/src/index.ts
+++ b/modules/loader-utils/src/index.ts
@@ -260,6 +260,7 @@ export {
   filterColumnarRowIndices,
   gatherColumnarColumns,
   getColumnarPredicateColumns,
+  getColumnarPredicateParameterNames,
   getColumnarPredicatePath,
   getColumnarPredicatePaths,
   isColumnarPredicateParameter,
@@ -267,6 +268,8 @@ export {
   validateColumnarPredicate
 } from './lib/scan-utils/columnar-predicate';
 export {executeScanTasks} from './lib/scan-utils/scan-executor';
+export {createScanQueryMetadata} from './lib/scan-utils/scan-query-metadata';
+export {validatePointCloudQueryOptions} from './lib/scan-utils/point-cloud-query';
 export {
   planTableQuery,
   validateTableQueryLimit,
@@ -274,6 +277,23 @@ export {
 } from './lib/scan-utils/table-query';
 export {explainTableQuery} from './lib/scan-utils/table-query-explain';
 export type {ScanExecutorOptions, ScanTask} from './lib/scan-utils/scan-executor';
+export type {
+  CreateScanQueryMetadataOptions,
+  ScanBounds,
+  ScanColumnMetadata,
+  ScanColumnRole,
+  ScanQueryCapabilities,
+  ScanQueryMetadata,
+  ScanQueryMetadataOptions,
+  ScanQueryMetadataProvider,
+  ScanSourceStatistics,
+  ScanSpatialMetadata
+} from './lib/scan-utils/scan-query-metadata';
+export type {
+  PointCloudQueryBounds,
+  PointCloudQueryCapabilities,
+  PointCloudQueryOptions
+} from './lib/scan-utils/point-cloud-query';
 export type {
   ColumnarComparisonPredicate,
   ColumnarInPredicate,

--- a/modules/loader-utils/src/lib/scan-utils/columnar-predicate.ts
+++ b/modules/loader-utils/src/lib/scan-utils/columnar-predicate.ts
@@ -102,6 +102,25 @@ export function getColumnarPredicatePaths<ValueT, PropertyT extends ColumnarPred
   return [...paths.values()];
 }
 
+/** Returns unresolved named parameter names in their first-occurrence order. */
+export function getColumnarPredicateParameterNames<PropertyT extends ColumnarPredicateProperty>(
+  predicate: ParameterizedColumnarPredicate<PropertyT>
+): string[] {
+  const parameterNames = new Set<string>();
+  visitColumnarPredicate(predicate, child => {
+    if (child.op === 'and' || child.op === 'or' || child.op === 'not' || child.op === 'isNull') {
+      return;
+    }
+    const values = child.op === 'in' ? child.args[1] : [child.args[1]];
+    for (const value of values) {
+      if (isColumnarPredicateParameter(value)) {
+        parameterNames.add(value.parameter);
+      }
+    }
+  });
+  return [...parameterNames];
+}
+
 export function copyColumnarPredicate(predicate: ColumnarPredicate): ColumnarPredicate {
   if (predicate.op === 'and' || predicate.op === 'or') {
     return {op: predicate.op, args: predicate.args.map(copyColumnarPredicate)};

--- a/modules/loader-utils/src/lib/scan-utils/point-cloud-query.ts
+++ b/modules/loader-utils/src/lib/scan-utils/point-cloud-query.ts
@@ -1,0 +1,92 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {ColumnarPredicate, ColumnarPredicateProperty} from './columnar-predicate';
+import type {
+  TableQueryCapabilities,
+  TableQueryOperatorSupport,
+  TableQueryOptions
+} from './table-query';
+import {validateTableQueryOptions} from './table-query';
+
+/** Three-dimensional axis-aligned bounds in the point cloud's source coordinate system. */
+export type PointCloudQueryBounds = Readonly<{
+  /** Inclusive minimum X, Y, and Z coordinates. */
+  minimum: readonly [x: number, y: number, z: number];
+  /** Inclusive maximum X, Y, and Z coordinates. */
+  maximum: readonly [x: number, y: number, z: number];
+}>;
+
+/** Portable attribute, bounds, and hierarchy request for a point-cloud scan. */
+export type PointCloudQueryOptions<
+  PredicateT extends ColumnarPredicate<unknown, ColumnarPredicateProperty> = ColumnarPredicate
+> = TableQueryOptions<PredicateT> &
+  Readonly<{
+    /** Optional three-dimensional source-coordinate bounds. */
+    bounds?: PointCloudQueryBounds;
+    /** Shallowest hierarchy level that may contribute points. */
+    minimumLevel?: number;
+    /** Deepest hierarchy level that may contribute points. */
+    maximumLevel?: number;
+    /** Desired maximum point spacing in source coordinate units. */
+    targetSpacing?: number;
+  }>;
+
+/** Capabilities advertised by a point-cloud query adapter. */
+export type PointCloudQueryCapabilities = TableQueryCapabilities &
+  Readonly<{
+    /** Whether spatial bounds prune hierarchy nodes or are evaluated residually. */
+    bounds: TableQueryOperatorSupport;
+    /** Whether hierarchy level constraints avoid physical node reads. */
+    levelOfDetail: TableQueryOperatorSupport;
+    /** Whether target spacing participates in physical node selection. */
+    spacing: TableQueryOperatorSupport;
+  }>;
+
+/** Validates a point-cloud query against the attributes exposed by one source. */
+export function validatePointCloudQueryOptions<
+  ValueT,
+  PropertyT extends ColumnarPredicateProperty,
+  PredicateT extends ColumnarPredicate<ValueT, PropertyT>
+>(sourceColumnNames: readonly string[], options: PointCloudQueryOptions<PredicateT>): void {
+  validateTableQueryOptions(sourceColumnNames, options);
+  validatePointCloudBounds(options.bounds);
+  validateHierarchyLevel(options.minimumLevel, 'minimumLevel');
+  validateHierarchyLevel(options.maximumLevel, 'maximumLevel');
+  if (
+    options.minimumLevel !== undefined &&
+    options.maximumLevel !== undefined &&
+    options.minimumLevel > options.maximumLevel
+  ) {
+    throw new Error('Point cloud query minimumLevel cannot exceed maximumLevel.');
+  }
+  if (
+    options.targetSpacing !== undefined &&
+    (!Number.isFinite(options.targetSpacing) || options.targetSpacing <= 0)
+  ) {
+    throw new Error('Point cloud query targetSpacing must be a positive finite number.');
+  }
+}
+
+function validatePointCloudBounds(bounds: PointCloudQueryBounds | undefined): void {
+  if (!bounds) {
+    return;
+  }
+  for (let dimension = 0; dimension < 3; dimension++) {
+    const minimum = bounds.minimum[dimension];
+    const maximum = bounds.maximum[dimension];
+    if (!Number.isFinite(minimum) || !Number.isFinite(maximum)) {
+      throw new Error('Point cloud query bounds must contain finite coordinates.');
+    }
+    if (minimum > maximum) {
+      throw new Error('Point cloud query bounds minimum cannot exceed maximum.');
+    }
+  }
+}
+
+function validateHierarchyLevel(level: number | undefined, name: string): void {
+  if (level !== undefined && (!Number.isSafeInteger(level) || level < 0)) {
+    throw new Error(`Point cloud query ${name} must be a non-negative safe integer.`);
+  }
+}

--- a/modules/loader-utils/src/lib/scan-utils/scan-query-metadata.ts
+++ b/modules/loader-utils/src/lib/scan-utils/scan-query-metadata.ts
@@ -1,0 +1,191 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {DataType, FieldMetadata, Schema} from '@loaders.gl/schema';
+import type {TableQueryCapabilities, TableQueryOperatorSupport} from './table-query';
+
+/** Semantic role used by query editors to choose appropriate controls for a column. */
+export type ScanColumnRole =
+  | 'attribute'
+  | 'identifier'
+  | 'geometry'
+  | 'longitude'
+  | 'latitude'
+  | 'x'
+  | 'y'
+  | 'z'
+  | 'time'
+  | 'intensity'
+  | 'classification'
+  | 'color';
+
+/** Schema information for one selectable or filterable scan column. */
+export type ScanColumnMetadata = Readonly<{
+  /** Stable source column name used by projections and predicates. */
+  name: string;
+  /** Portable loaders.gl data type. */
+  type: DataType;
+  /** Whether the source may produce null values for the column. */
+  nullable: boolean;
+  /** Semantic role used to select specialized query controls. */
+  role: ScanColumnRole;
+  /** Optional display title obtained from source field metadata. */
+  title?: string;
+  /** Optional human-readable description obtained from source field metadata. */
+  description?: string;
+  /** Original field metadata for source-specific UI extensions. */
+  metadata: Readonly<FieldMetadata>;
+}>;
+
+/** Axis-aligned source bounds expressed in the source coordinate reference system. */
+export type ScanBounds = Readonly<{
+  /** Inclusive minimum coordinate for each available dimension. */
+  minimum: readonly number[];
+  /** Inclusive maximum coordinate for each available dimension. */
+  maximum: readonly number[];
+}>;
+
+/** Spatial discovery information shared by vector, point-cloud, and raster query editors. */
+export type ScanSpatialMetadata = Readonly<{
+  /** Source bounds, when declared by format metadata. */
+  bounds?: ScanBounds;
+  /** Coordinate reference system identifiers or definitions advertised by the source. */
+  coordinateReferenceSystems?: readonly string[];
+}>;
+
+/** Capabilities that a common scan-query panel can expose across source families. */
+export type ScanQueryCapabilities = Readonly<{
+  /** Relational projection, predicate, limit, streaming, and cancellation support. */
+  table?: TableQueryCapabilities;
+  /** Spatial bounds support when it is not already represented by a scalar predicate. */
+  bounds?: TableQueryOperatorSupport;
+  /** Hierarchy or resolution selection support for point clouds and multiscale rasters. */
+  levelOfDetail?: TableQueryOperatorSupport;
+}>;
+
+/** Lightweight source statistics obtained without materializing result rows. */
+export type ScanSourceStatistics = Readonly<{
+  /** Exact or estimated source row/feature/point count. */
+  rowCount?: number | bigint;
+  /** Physical byte length when it is available from source metadata. */
+  byteLength?: number | bigint;
+}>;
+
+/** Metadata used to populate a source-neutral query editor before executing a scan. */
+export type ScanQueryMetadata = Readonly<{
+  /** Stable adapter or format identifier. */
+  sourceType: string;
+  /** Query family used to enable table, point-cloud, or raster controls. */
+  queryType: 'table' | 'point-cloud' | 'raster';
+  /** Optional source display name. */
+  name?: string;
+  /** Optional source description. */
+  description?: string;
+  /** Complete query-visible schema, including geometry or coordinate columns. */
+  schema: Schema;
+  /** Query-visible columns in source order. */
+  columns: readonly ScanColumnMetadata[];
+  /** Portable and source-family-specific execution capabilities. */
+  capabilities: ScanQueryCapabilities;
+  /** Optional spatial metadata used to populate bounds controls. */
+  spatial?: ScanSpatialMetadata;
+  /** Optional statistics obtained from source metadata. */
+  statistics?: ScanSourceStatistics;
+}>;
+
+/** Options accepted by query metadata discovery methods. */
+export type ScanQueryMetadataOptions = Readonly<{
+  /** Cancels metadata discovery without starting a data scan. */
+  signal?: AbortSignal;
+}>;
+
+/** Structural interface implemented by sources that support query-panel discovery. */
+export type ScanQueryMetadataProvider = {
+  /** Discovers query-visible columns and capabilities without materializing result rows. */
+  getQueryMetadata(options?: ScanQueryMetadataOptions): Promise<ScanQueryMetadata>;
+};
+
+/** Inputs used to derive normalized query metadata from a loaders.gl schema. */
+export type CreateScanQueryMetadataOptions = Readonly<{
+  /** Stable adapter or format identifier. */
+  sourceType: string;
+  /** Query family used to enable specialized controls. */
+  queryType: ScanQueryMetadata['queryType'];
+  /** Complete query-visible schema. */
+  schema: Schema;
+  /** Portable and source-family-specific execution capabilities. */
+  capabilities: ScanQueryCapabilities;
+  /** Optional source display name. */
+  name?: string;
+  /** Optional source description. */
+  description?: string;
+  /** Optional semantic roles keyed by source column name. */
+  columnRoles?: Readonly<Record<string, ScanColumnRole>>;
+  /** Optional spatial metadata. */
+  spatial?: ScanSpatialMetadata;
+  /** Optional source statistics. */
+  statistics?: ScanSourceStatistics;
+}>;
+
+/**
+ * Creates immutable query metadata and derives panel-ready columns from a loaders.gl schema.
+ *
+ * Source adapters only need to supply semantic roles that cannot be inferred from Arrow types.
+ */
+export function createScanQueryMetadata(
+  options: CreateScanQueryMetadataOptions
+): ScanQueryMetadata {
+  const schema: Schema = Object.freeze({
+    fields: Object.freeze(
+      options.schema.fields.map(field =>
+        Object.freeze({...field, metadata: Object.freeze({...field.metadata})})
+      )
+    ) as unknown as Schema['fields'],
+    metadata: Object.freeze({...options.schema.metadata})
+  });
+  const columns = schema.fields.map(field =>
+    Object.freeze({
+      name: field.name,
+      type: field.type,
+      nullable: field.nullable !== false,
+      role: options.columnRoles?.[field.name] || 'attribute',
+      title: getNonEmptyMetadataValue(field.metadata, 'title'),
+      description: getNonEmptyMetadataValue(field.metadata, 'description'),
+      metadata: field.metadata || Object.freeze({})
+    })
+  );
+
+  return Object.freeze({
+    sourceType: options.sourceType,
+    queryType: options.queryType,
+    name: options.name,
+    description: options.description,
+    schema,
+    columns: Object.freeze(columns),
+    capabilities: Object.freeze({...options.capabilities}),
+    spatial: options.spatial
+      ? Object.freeze({
+          ...options.spatial,
+          bounds: options.spatial.bounds
+            ? Object.freeze({
+                minimum: Object.freeze([...options.spatial.bounds.minimum]),
+                maximum: Object.freeze([...options.spatial.bounds.maximum])
+              })
+            : undefined,
+          coordinateReferenceSystems: options.spatial.coordinateReferenceSystems
+            ? Object.freeze([...options.spatial.coordinateReferenceSystems])
+            : undefined
+        })
+      : undefined,
+    statistics: options.statistics ? Object.freeze({...options.statistics}) : undefined
+  });
+}
+
+function getNonEmptyMetadataValue(
+  metadata: FieldMetadata | undefined,
+  key: string
+): string | undefined {
+  const value = metadata?.[key];
+  return value || undefined;
+}

--- a/modules/loader-utils/src/lib/scan-utils/table-query.ts
+++ b/modules/loader-utils/src/lib/scan-utils/table-query.ts
@@ -65,13 +65,17 @@ export type TableQueryPlan<PredicateT = ColumnarPredicate> =
   readonly TableQueryPlanStep<PredicateT>[];
 
 /** Capability levels for an individual portable table-query operator. */
-export type TableQueryOperatorSupport = 'unsupported' | 'residual' | 'pushdown';
+export type TableQueryOperatorSupport =
+  | 'unsupported'
+  | 'residual'
+  | 'pushdown'
+  | 'pushdown+residual';
 
 /** Optimization and correctness capabilities advertised by a table-query backend. */
 export type TableQueryCapabilities = Readonly<{
   /** Whether output projection can avoid reading unrequested columns. */
   projection: TableQueryOperatorSupport;
-  /** Whether predicates are unsupported, evaluated residually, or pushed into physical planning. */
+  /** Whether predicates are unsupported, residual, pushed down, or both pushed and residual. */
   predicate: TableQueryOperatorSupport;
   /** Whether limits are unsupported, applied after execution, or stop physical work early. */
   limit: TableQueryOperatorSupport;

--- a/modules/loader-utils/test/lib/scan-utils/point-cloud-query.spec.ts
+++ b/modules/loader-utils/test/lib/scan-utils/point-cloud-query.spec.ts
@@ -1,0 +1,31 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+import {validatePointCloudQueryOptions} from '../../../src';
+
+describe('validatePointCloudQueryOptions', () => {
+  test('accepts table semantics with spatial and hierarchy constraints', () => {
+    expect(() =>
+      validatePointCloudQueryOptions(['X', 'Y', 'Z', 'Intensity'], {
+        columns: ['X', 'Y', 'Z'],
+        predicate: {op: '>=', args: [{property: 'Intensity'}, 10]},
+        limit: 1000,
+        bounds: {minimum: [0, 1, 2], maximum: [3, 4, 5]},
+        minimumLevel: 2,
+        maximumLevel: 8,
+        targetSpacing: 0.5
+      })
+    ).not.toThrow();
+  });
+
+  test.each([
+    [{bounds: {minimum: [2, 0, 0], maximum: [1, 1, 1]}}, /minimum cannot exceed/],
+    [{minimumLevel: -1}, /minimumLevel/],
+    [{minimumLevel: 3, maximumLevel: 2}, /cannot exceed/],
+    [{targetSpacing: 0}, /positive finite/]
+  ] as const)('rejects invalid point-cloud options', (options, expectedMessage) => {
+    expect(() => validatePointCloudQueryOptions(['X'], options)).toThrow(expectedMessage);
+  });
+});

--- a/modules/loader-utils/test/lib/scan-utils/scan-query-metadata.spec.ts
+++ b/modules/loader-utils/test/lib/scan-utils/scan-query-metadata.spec.ts
@@ -1,0 +1,71 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+import {createScanQueryMetadata} from '../../../src';
+
+describe('createScanQueryMetadata', () => {
+  test('derives immutable panel columns from a schema', () => {
+    const metadata = createScanQueryMetadata({
+      sourceType: 'example',
+      queryType: 'table',
+      schema: {
+        fields: [
+          {
+            name: 'id',
+            type: 'int64',
+            nullable: false,
+            metadata: {title: 'Feature ID', description: 'Stable identifier'}
+          },
+          {name: 'geometry', type: 'binary', nullable: true}
+        ],
+        metadata: {format: 'example'}
+      },
+      columnRoles: {id: 'identifier', geometry: 'geometry'},
+      capabilities: {
+        table: {
+          projection: 'pushdown',
+          predicate: 'residual',
+          limit: 'residual',
+          streaming: true,
+          cancellation: true
+        },
+        bounds: 'pushdown'
+      },
+      spatial: {
+        bounds: {minimum: [-180, -90], maximum: [180, 90]},
+        coordinateReferenceSystems: ['EPSG:4326']
+      },
+      statistics: {rowCount: 12n}
+    });
+
+    expect(metadata.columns).toEqual([
+      {
+        name: 'id',
+        type: 'int64',
+        nullable: false,
+        role: 'identifier',
+        title: 'Feature ID',
+        description: 'Stable identifier',
+        metadata: {title: 'Feature ID', description: 'Stable identifier'}
+      },
+      {
+        name: 'geometry',
+        type: 'binary',
+        nullable: true,
+        role: 'geometry',
+        title: undefined,
+        description: undefined,
+        metadata: {}
+      }
+    ]);
+    expect(metadata.spatial?.bounds).toEqual({
+      minimum: [-180, -90],
+      maximum: [180, 90]
+    });
+    expect(Object.isFrozen(metadata)).toBe(true);
+    expect(Object.isFrozen(metadata.columns)).toBe(true);
+    expect(Object.isFrozen(metadata.schema.fields)).toBe(true);
+  });
+});

--- a/modules/loader-utils/test/lib/scan-utils/table-query.spec.ts
+++ b/modules/loader-utils/test/lib/scan-utils/table-query.spec.ts
@@ -7,6 +7,7 @@ import {describe, expect, test} from 'vitest';
 import {
   bindColumnarPredicateParameters,
   explainTableQuery,
+  getColumnarPredicateParameterNames,
   planTableQuery,
   validateTableQueryLimit,
   type ParameterizedColumnarPredicate
@@ -64,6 +65,30 @@ describe('portable table queries', () => {
         status: 'active'
       })
     ).toThrow(/unsupported value/);
+  });
+
+  test('discovers unique named parameters in AST order', () => {
+    const predicate: ParameterizedColumnarPredicate = {
+      op: 'and',
+      args: [
+        {op: '>=', args: [{property: 'fare'}, {parameter: 'minimum'}]},
+        {
+          op: 'in',
+          args: [
+            {property: 'carrier'},
+            [{parameter: 'carrier'}, {parameter: 'backupCarrier'}, {parameter: 'carrier'}]
+          ]
+        },
+        {op: '<=', args: [{property: 'fare'}, {parameter: 'maximum'}]}
+      ]
+    };
+
+    expect(getColumnarPredicateParameterNames(predicate)).toEqual([
+      'minimum',
+      'carrier',
+      'backupCarrier',
+      'maximum'
+    ]);
   });
 
   test('explains pushed and residual operators without reading rows', () => {

--- a/modules/parquet/src/parquet-source-capabilities.ts
+++ b/modules/parquet/src/parquet-source-capabilities.ts
@@ -7,7 +7,7 @@ import type {TableQueryCapabilities} from '@loaders.gl/loader-utils';
 /** Portable table-query capabilities of Parquet-backed scans. */
 export const PARQUET_TABLE_QUERY_CAPABILITIES: TableQueryCapabilities = Object.freeze({
   projection: 'pushdown',
-  predicate: 'pushdown',
+  predicate: 'pushdown+residual',
   limit: 'pushdown',
   streaming: true,
   cancellation: true

--- a/modules/parquet/test/parquet-source-capabilities.spec.ts
+++ b/modules/parquet/test/parquet-source-capabilities.spec.ts
@@ -13,7 +13,7 @@ test('ParquetSourceCapabilities#advertises implemented and deferred features', t
   const expectedCapabilities: ParquetSourceCapabilities = {
     tableQuery: {
       projection: 'pushdown',
-      predicate: 'pushdown',
+      predicate: 'pushdown+residual',
       limit: 'pushdown',
       streaming: true,
       cancellation: true


### PR DESCRIPTION
## Goals

Expand the common scan roadmap beyond Parquet and Iceberg to cover spatial, vector, transactional, streaming, and raster-adjacent formats.

## Changes

- Add explicit tranches for FlatGeobuf, GeoArrow/Arrow IPC, ORC, CSV/JSONL, Delta, Lance, GPU, and raster scans.
- Add a capability matrix distinguishing physical units and pushdown strength.
- Clarify that adapters report residual filtering when decoding is required.
- Keep TableQuery narrow and define the sibling RasterQuery direction.

This is documentation-only.