### PR TITLE
feat(3d-tiles): preserve implicit subtree metadata

### DIFF
--- a/docs/modules/3d-tiles/concepts/implicit-tiling-and-subtrees.md
+++ b/docs/modules/3d-tiles/concepts/implicit-tiling-and-subtrees.md
@@ -160,7 +160,9 @@ The underscored SSE field is diagnostic rather than stable API. Use these values
 ## Current Limitations
 
 - Only the first `contentAvailability` stream is used; `3DTILES_multiple_contents` is not implemented.
-- Subtree and tile metadata semantics beyond availability are not materialized yet.
+- Subtree metadata references (`propertyTables`, `tileMetadata`, `contentMetadata`, and
+  `subtreeMetadata`) are preserved on generated headers as `implicitMetadata`. The runtime does not
+  yet decode property-table classes, enums, or values.
 - S2-derived implicit descendants use a conservative root oriented box rather than recomputing a tight S2 box in the `@loaders.gl/tiles` runtime.
 - Lazy hierarchy metadata is source-managed; custom source implementations must provide `loadTileChildren` to use the same traversal hook.
 

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -278,6 +278,7 @@ A minor release that includes:
 - **3D Tiles 1.1 Writing** [`Tile3DWriter`](/docs/modules/3d-tiles/api-reference/tile-3d-writer) now supports writing 3DTiles 1.1
 - **3D Tiles 1.1 Extensions** `EXT_mesh_features` and `EXT_structural_metadata` are now supported.
 - **3D Tiles format compatibility** - Added a checked compatibility matrix covering tileset traversal, tile payloads, extensions, metadata, and known renderer limitations. Multiple explicit contents are normalized, loaded in source order, and exposed through `Tile3D.contents` while preserving the legacy primary `Tile3D.content` field.
+- **Implicit subtree metadata** - Generated implicit-tile headers now preserve subtree property-table and tile/content/subtree metadata references through `implicitMetadata`, without pretending to decode metadata values before structural metadata support is complete.
 - **Transform-correct LOD** Geometric error is scaled conservatively by composed tile and tileset transforms without compounding after runtime updates.
 - **Projection-correct SSE** Orthographic viewports use `metersPerPixel`, while perspective and orthographic traversal consistently use logical pixels without a second device-pixel-ratio correction.
 - **Dynamic SSE** Perspective traversal can reduce distant, horizon-facing refinement with view-dependent density and height falloff while leaving orthographic and I3S LOD behavior unchanged.

--- a/modules/tiles/src/tileset-3d/format-3d-tiles/implicit-tiling.ts
+++ b/modules/tiles/src/tileset-3d/format-3d-tiles/implicit-tiling.ts
@@ -73,11 +73,11 @@ export type ParsedImplicitSubtree = {
   /** Availability of subtree roots immediately below this subtree. */
   childSubtreeAvailability: ImplicitAvailability;
   /** Property-table payloads referenced by subtree metadata declarations. */
-  propertyTables?: unknown[];
-  /** Property-table index for metadata attached to each available tile. */
-  tileMetadata?: number;
-  /** Property-table indexes for metadata attached to each content stream. */
-  contentMetadata?: number[];
+  propertyTables?: unknown;
+  /** Property-table reference for metadata attached to each available tile. */
+  tileMetadata?: unknown;
+  /** Property-table references for metadata attached to each content stream. */
+  contentMetadata?: unknown;
   /** Metadata entity attached to the subtree itself. */
   subtreeMetadata?: unknown;
 };
@@ -97,11 +97,11 @@ export type ImplicitTileHeader = Record<string, any> & {
 /** Metadata references inherited by generated implicit tile headers. */
 export type ImplicitSubtreeMetadata = {
   /** Property tables declared by the subtree. */
-  propertyTables?: unknown[];
-  /** Tile-level metadata property-table index. */
-  tileMetadata?: number;
-  /** Content-level metadata property-table indexes in content order. */
-  contentMetadata?: number[];
+  propertyTables?: unknown;
+  /** Tile-level metadata property-table reference. */
+  tileMetadata?: unknown;
+  /** Content-level metadata property-table references in content order. */
+  contentMetadata?: unknown;
   /** Subtree-level metadata entity. */
   subtreeMetadata?: unknown;
 };

--- a/modules/tiles/src/tileset-3d/format-3d-tiles/implicit-tiling.ts
+++ b/modules/tiles/src/tileset-3d/format-3d-tiles/implicit-tiling.ts
@@ -72,6 +72,14 @@ export type ParsedImplicitSubtree = {
   contentAvailability?: ImplicitAvailability | ImplicitAvailability[];
   /** Availability of subtree roots immediately below this subtree. */
   childSubtreeAvailability: ImplicitAvailability;
+  /** Property-table payloads referenced by subtree metadata declarations. */
+  propertyTables?: unknown[];
+  /** Property-table index for metadata attached to each available tile. */
+  tileMetadata?: number;
+  /** Property-table indexes for metadata attached to each content stream. */
+  contentMetadata?: number[];
+  /** Metadata entity attached to the subtree itself. */
+  subtreeMetadata?: unknown;
 };
 
 /** Runtime header produced for an available implicit tile. */
@@ -82,6 +90,20 @@ export type ImplicitTileHeader = Record<string, any> & {
   children: ImplicitTileHeader[];
   /** Optional lazy reference when this tile begins a child subtree. */
   implicitSubtree?: ImplicitSubtreeReference;
+  /** Raw subtree metadata references preserved for application-level interpretation. */
+  implicitMetadata?: ImplicitSubtreeMetadata;
+};
+
+/** Metadata references inherited by generated implicit tile headers. */
+export type ImplicitSubtreeMetadata = {
+  /** Property tables declared by the subtree. */
+  propertyTables?: unknown[];
+  /** Tile-level metadata property-table index. */
+  tileMetadata?: number;
+  /** Content-level metadata property-table indexes in content order. */
+  contentMetadata?: number[];
+  /** Subtree-level metadata entity. */
+  subtreeMetadata?: unknown;
 };
 
 /** Result of materializing exactly one subtree resource. */
@@ -235,7 +257,7 @@ function materializeAvailableTile(
             childIndex,
             descriptor.subdivisionScheme
           );
-          children.push(createLazyImplicitTileHeader(descriptor, childCoordinates));
+          children.push(createLazyImplicitTileHeader(subtree, descriptor, childCoordinates));
           counters.childSubtreeCount++;
         }
       }
@@ -243,6 +265,7 @@ function materializeAvailableTile(
   }
 
   return formatImplicitTileHeader(
+    subtree,
     descriptor,
     reference,
     globalCoordinates,
@@ -259,6 +282,7 @@ function materializeAvailableTile(
  * @returns Header that participates in culling and SSE before its subtree is requested.
  */
 function createLazyImplicitTileHeader(
+  subtree: ParsedImplicitSubtree,
   descriptor: ImplicitTilingDescriptor,
   coordinates: ImplicitTileCoordinates
 ): ImplicitTileHeader {
@@ -276,7 +300,8 @@ function createLazyImplicitTileHeader(
     lodMetricType: descriptor.lodMetricType,
     lodMetricValue: descriptor.rootLodMetricValue / 2 ** coordinates.level,
     refine: descriptor.refine,
-    type: TILE_TYPE.EMPTY
+    type: TILE_TYPE.EMPTY,
+    implicitMetadata: getImplicitSubtreeMetadata(subtree)
   };
 }
 
@@ -291,6 +316,7 @@ function createLazyImplicitTileHeader(
  * @returns Runtime tile header.
  */
 function formatImplicitTileHeader(
+  subtree: ParsedImplicitSubtree,
   descriptor: ImplicitTilingDescriptor,
   reference: ImplicitSubtreeReference,
   coordinates: ImplicitTileCoordinates,
@@ -317,7 +343,36 @@ function formatImplicitTileHeader(
       descriptor.rootBoundingVolume,
       coordinates,
       descriptor.subdivisionScheme
-    )
+    ),
+    implicitMetadata: getImplicitSubtreeMetadata(subtree)
+  };
+}
+
+/**
+ * Copies subtree metadata references without interpreting property-table schemas.
+ *
+ * Keeping the references on generated headers makes metadata available to applications while
+ * avoiding a false promise that the runtime has already decoded classes, enums, or values.
+ *
+ * @param subtree - Parsed subtree containing optional metadata declarations.
+ * @returns Metadata references, or `undefined` when the subtree declares none.
+ */
+function getImplicitSubtreeMetadata(
+  subtree: ParsedImplicitSubtree
+): ImplicitSubtreeMetadata | undefined {
+  if (
+    !subtree.propertyTables &&
+    subtree.tileMetadata === undefined &&
+    !subtree.contentMetadata &&
+    subtree.subtreeMetadata === undefined
+  ) {
+    return undefined;
+  }
+  return {
+    propertyTables: subtree.propertyTables,
+    tileMetadata: subtree.tileMetadata,
+    contentMetadata: subtree.contentMetadata,
+    subtreeMetadata: subtree.subtreeMetadata
   };
 }
 

--- a/modules/tiles/test/tileset/implicit-subtree-metadata.browser.spec.ts
+++ b/modules/tiles/test/tileset/implicit-subtree-metadata.browser.spec.ts
@@ -1,0 +1,47 @@
+import {describe, expect, test} from 'vitest';
+import {
+  createImplicitSubtreeReference,
+  LOD_METRIC_TYPE,
+  materializeImplicitSubtree,
+  TILE_REFINEMENT,
+  type ImplicitTilingDescriptor,
+  type ParsedImplicitSubtree
+} from '@loaders.gl/tiles';
+
+const descriptor: ImplicitTilingDescriptor = {
+  contentUrlTemplate: 'https://example.com/content/{level}/{x}/{y}.b3dm',
+  subtreesUrlTemplate: 'https://example.com/subtrees/{level}/{x}/{y}.subtree',
+  subdivisionScheme: 'QUADTREE',
+  subtreeLevels: 1,
+  maximumLevel: 1,
+  refine: TILE_REFINEMENT.REPLACE,
+  lodMetricType: LOD_METRIC_TYPE.GEOMETRIC_ERROR,
+  rootLodMetricValue: 8,
+  rootBoundingVolume: {region: [0, 0, 1, 1, 0, 10]}
+};
+
+describe('implicit subtree metadata', () => {
+  test('preserves metadata references on generated headers', () => {
+    const subtree: ParsedImplicitSubtree = {
+      tileAvailability: {constant: 1},
+      contentAvailability: {constant: 1},
+      childSubtreeAvailability: {constant: 0},
+      propertyTables: [{name: 'buildings'}],
+      tileMetadata: 0,
+      contentMetadata: [0],
+      subtreeMetadata: {source: 'fixture'}
+    };
+
+    const result = materializeImplicitSubtree(
+      subtree,
+      createImplicitSubtreeReference(descriptor, {level: 0, x: 0, y: 0, z: 0})
+    );
+
+    expect(result.root.implicitMetadata).toEqual({
+      propertyTables: [{name: 'buildings'}],
+      tileMetadata: 0,
+      contentMetadata: [0],
+      subtreeMetadata: {source: 'fixture'}
+    });
+  });
+});


### PR DESCRIPTION
## Goals

- Preserve implicit-subtree metadata references during lazy materialization.
- Make the current metadata capability explicit without claiming value decoding that is not implemented.

## Changes

- Carry subtree property tables, tile metadata, content metadata, and subtree metadata through the parsed implicit-subtree model.
- Attach immutable-by-convention metadata references to generated implicit tile headers as `implicitMetadata`.
- Preserve metadata on both materialized tiles and lazy subtree-boundary placeholders.
- Add focused Chromium coverage and document the runtime limitation: metadata values and classes are not decoded yet.
- Update the implicit-tiling guide and `whats-new`.

## Validation

- `yarn lint fix`
- Focused Chromium tests: implicit metadata plus existing implicit traversal tests (8/8)

Related tracker: #1245
