### PR TITLE
feat(zarr) Harden generic RasterSet requests

### DIFF
--- a/modules/tiles/src/raster-set.ts
+++ b/modules/tiles/src/raster-set.ts
@@ -59,7 +59,7 @@ export type RasterSetProps<
   MetadataT extends RasterSourceMetadata = RasterSourceMetadata
 > = Partial<RasterSetBaseProps<DataT, ParametersT, MetadataT>> & {
   /** Optional loaders.gl raster source backing this manager. */
-  rasterSource?: RasterSource<DataT, GetRasterParameters, MetadataT> | null;
+  rasterSource?: RasterSource<DataT, ParametersT & GetRasterParameters, MetadataT> | null;
 };
 
 /** Subscription callbacks emitted by {@link RasterSet}. */
@@ -180,7 +180,7 @@ export class RasterSet<
   }
 
   /** Backing raster source when constructed from one. */
-  get rasterSource(): RasterSource<DataT, GetRasterParameters, MetadataT> | null {
+  get rasterSource(): RasterSource<DataT, ParametersT & GetRasterParameters, MetadataT> | null {
     return this._opts.rasterSource;
   }
 
@@ -291,7 +291,7 @@ export class RasterSet<
       const abortController = new AbortController();
       this._abortController = abortController;
       const raster = await this._opts.getRaster(
-        Object.assign({}, parameters, {signal: abortController.signal}) as ParametersT
+        withAbortSignal(parameters, abortController.signal)
       );
       if (
         this._finalized ||
@@ -345,7 +345,7 @@ export class RasterSet<
         opts.getRaster ||
         ((parameters: ParametersT) => {
           if (rasterSource) {
-            return rasterSource.getRaster(parameters as GetRasterParameters);
+            return rasterSource.getRaster(parameters as ParametersT & GetRasterParameters);
           }
           return DEFAULT_RASTERSET_PROPS.getRaster(
             parameters as GetRasterParameters
@@ -408,6 +408,26 @@ export class RasterSet<
     this._abortController?.abort();
     this._abortController = null;
   }
+}
+
+/** Adds cancellation to a request while preserving its array/prototype shape. */
+function withAbortSignal<ParametersT extends object>(
+  parameters: ParametersT,
+  signal: AbortSignal
+): ParametersT {
+  const request = Array.isArray(parameters)
+    ? parameters.slice()
+    : Object.create(
+        Object.getPrototypeOf(parameters),
+        Object.getOwnPropertyDescriptors(parameters)
+      );
+  Object.defineProperty(request, 'signal', {
+    configurable: true,
+    enumerable: true,
+    value: signal,
+    writable: true
+  });
+  return request as ParametersT;
 }
 
 /** Normalizes arbitrary thrown values to `Error` instances for raster-set callbacks. */

--- a/modules/tiles/test/raster-set-dimensions.spec.ts
+++ b/modules/tiles/test/raster-set-dimensions.spec.ts
@@ -134,3 +134,27 @@ test('RasterSet accepts non-viewport array requests', async () => {
   await expect(loadedRequest).resolves.toEqual({level: 2, channels: [1, 2]});
   rasterSet.finalize();
 });
+
+test('RasterSet preserves array request shape when injecting AbortSignal', async () => {
+  const rasterSet = RasterSet.fromCallbacks<RasterData, number[]>({
+    getMetadata: async () => ({width: 1, height: 1, bandCount: 1, dtype: 'uint8'}),
+    getRaster: async parameters => {
+      expect(Array.isArray(parameters)).toBe(true);
+      expect(parameters.map(value => value * 2)).toEqual([2, 4]);
+      expect((parameters as number[] & {signal?: AbortSignal}).signal).toBeInstanceOf(AbortSignal);
+      return {
+        data: new Uint8Array([1]),
+        width: 1,
+        height: 1,
+        bandCount: 1,
+        dtype: 'uint8'
+      };
+    }
+  });
+
+  await rasterSet.loadMetadata();
+  const loaded = new Promise<void>(resolve => rasterSet.subscribe({onRasterLoad: () => resolve()}));
+  rasterSet.requestRaster([1, 2]);
+  await loaded;
+  rasterSet.finalize();
+});

--- a/modules/tiles/test/raster-set-dimensions.spec.ts
+++ b/modules/tiles/test/raster-set-dimensions.spec.ts
@@ -112,7 +112,7 @@ test('RasterSet accepts non-viewport array requests', async () => {
     bandCount: 1,
     dtype: 'uint8'
   };
-  const rasterSet = new RasterSet<RasterData, ArrayRequest, ArrayMetadata>({
+  const rasterSet = RasterSet.fromCallbacks<RasterData, ArrayRequest, ArrayMetadata>({
     getMetadata: async () => metadata,
     getRaster: async parameters => {
       expect(parameters.level).toBe(2);

--- a/modules/tiles/test/raster-set-dimensions.spec.ts
+++ b/modules/tiles/test/raster-set-dimensions.spec.ts
@@ -112,7 +112,7 @@ test('RasterSet accepts non-viewport array requests', async () => {
     bandCount: 1,
     dtype: 'uint8'
   };
-  const rasterSet = RasterSet.fromCallbacks<RasterData, ArrayRequest, ArrayMetadata>({
+  const rasterSet = new RasterSet<RasterData, ArrayRequest, ArrayMetadata>({
     getMetadata: async () => metadata,
     getRaster: async parameters => {
       expect(parameters.level).toBe(2);

--- a/modules/zarr/src/index.ts
+++ b/modules/zarr/src/index.ts
@@ -14,6 +14,8 @@ export {ZarrArraySourceLoader, ZarrArraySource} from './zarr-array-source';
 export type {
   GetZarrArrayParameters,
   ZarrArrayData,
+  ZarrArraySelection,
+  ZarrArraySlice,
   ZarrArraySourceLoaderOptions,
   ZarrArraySourceMetadata
 } from './zarr-array-source';

--- a/modules/zarr/src/index.ts
+++ b/modules/zarr/src/index.ts
@@ -14,8 +14,6 @@ export {ZarrArraySourceLoader, ZarrArraySource} from './zarr-array-source';
 export type {
   GetZarrArrayParameters,
   ZarrArrayData,
-  ZarrArraySelection,
-  ZarrArraySlice,
   ZarrArraySourceLoaderOptions,
   ZarrArraySourceMetadata
 } from './zarr-array-source';

--- a/modules/zarr/src/zarr-array-source.ts
+++ b/modules/zarr/src/zarr-array-source.ts
@@ -152,7 +152,15 @@ export class ZarrArraySource extends ZarrSource {
     if (!this.initializationPromise) {
       this.initializationPromise = this.initialize(signal);
     }
-    return await this.initializationPromise;
+    const initializationPromise = this.initializationPromise;
+    try {
+      return await initializationPromise;
+    } catch (error) {
+      if (this.initializationPromise === initializationPromise) {
+        this.initializationPromise = null;
+      }
+      throw error;
+    }
   }
 
   /** Opens the array selected by the source options. */

--- a/modules/zarr/src/zarr-array-source.ts
+++ b/modules/zarr/src/zarr-array-source.ts
@@ -25,6 +25,8 @@ export type ZarrArraySourceMetadata = {
 export type GetZarrArrayParameters = {
   /** Integer or slice selector for each dimension; null retains that dimension. */
   selection?: ZarrArraySelection;
+  /** Named selectors resolved against the metadata dimension labels. */
+  selectionByDimension?: Readonly<Record<string, number | null | ZarrArraySlice>>;
   /** Abort signal forwarded to metadata and chunk requests. */
   signal?: AbortSignal;
 };
@@ -122,7 +124,7 @@ export class ZarrArraySource extends ZarrSource {
   /** Reads the selected array values. */
   async getArray(parameters: GetZarrArrayParameters = {}): Promise<ZarrArrayData> {
     const {array, metadata} = await this.getInitializationPromise(parameters.signal);
-    const selection = parameters.selection || metadata.shape.map(() => null);
+    const selection = parameters.selection || createNamedSelection(parameters.selectionByDimension, metadata);
     if (selection.length !== metadata.shape.length) {
       throw new Error(`Zarr array selection must have ${metadata.shape.length} dimensions.`);
     }
@@ -169,6 +171,22 @@ export class ZarrArraySource extends ZarrSource {
       }
     };
   }
+}
+
+/** Converts named dimension selectors into the positional form accepted by Zarrita. */
+function createNamedSelection(
+  selectionByDimension: GetZarrArrayParameters['selectionByDimension'],
+  metadata: ZarrArraySourceMetadata
+): ZarrArraySelection {
+  const selection = metadata.shape.map(() => null) as ZarrArraySelection;
+  for (const [dimension, selector] of Object.entries(selectionByDimension || {})) {
+    const dimensionIndex = metadata.dimensions.indexOf(dimension);
+    if (dimensionIndex < 0) {
+      throw new Error(`Unknown Zarr array dimension ${dimension}.`);
+    }
+    selection[dimensionIndex] = selector;
+  }
+  return selection;
 }
 
 /** Tests whether a selector is a slice descriptor rather than an index. */

--- a/modules/zarr/src/zarr-array-source.ts
+++ b/modules/zarr/src/zarr-array-source.ts
@@ -23,11 +23,24 @@ export type ZarrArraySourceMetadata = {
 
 /** Parameters for reading a Zarr array selection. */
 export type GetZarrArrayParameters = {
-  /** Integer index for each selected dimension; null retains that dimension. */
-  selection?: Array<number | null>;
+  /** Integer or slice selector for each dimension; null retains that dimension. */
+  selection?: ZarrArraySelection;
   /** Abort signal forwarded to metadata and chunk requests. */
   signal?: AbortSignal;
 };
+
+/** Slice selector accepted by {@link ZarrArraySource#getArray}. */
+export type ZarrArraySlice = {
+  /** Inclusive starting index, defaulting to the dimension boundary. */
+  start?: number;
+  /** Exclusive stopping index, defaulting to the dimension boundary. */
+  stop?: number;
+  /** Stride between selected indices, defaulting to one. */
+  step?: number;
+};
+
+/** Positional selectors for a Zarr array read. */
+export type ZarrArraySelection = Array<number | null | ZarrArraySlice>;
 
 /** Result of a Zarr array read. */
 export type ZarrArrayData = {
@@ -113,7 +126,12 @@ export class ZarrArraySource extends ZarrSource {
     if (selection.length !== metadata.shape.length) {
       throw new Error(`Zarr array selection must have ${metadata.shape.length} dimensions.`);
     }
-    const chunk = await zarrita.get(array, selection, {signal: parameters.signal});
+    const zarritaSelection = selection.map(selector =>
+      isZarrArraySlice(selector)
+        ? zarrita.slice(selector.start ?? null, selector.stop ?? null, selector.step ?? null)
+        : selector
+    );
+    const chunk = await zarrita.get(array, zarritaSelection, {signal: parameters.signal});
     if (!chunk || typeof chunk !== 'object' || !('data' in chunk) || !('shape' in chunk)) {
       throw new Error('Failed to read Zarr array selection.');
     }
@@ -151,4 +169,9 @@ export class ZarrArraySource extends ZarrSource {
       }
     };
   }
+}
+
+/** Tests whether a selector is a slice descriptor rather than an index. */
+function isZarrArraySlice(selector: number | null | ZarrArraySlice): selector is ZarrArraySlice {
+  return typeof selector === 'object' && selector !== null;
 }

--- a/modules/zarr/src/zarr-array-source.ts
+++ b/modules/zarr/src/zarr-array-source.ts
@@ -17,6 +17,10 @@ export type ZarrArraySourceMetadata = {
   chunks: number[];
   /** Zarrita dtype identifier. */
   dtype: string;
+  /** Zarr fill value used for uninitialized chunks. */
+  fillValue: unknown;
+  /** Array-level Zarr attributes. */
+  attributes: Record<string, unknown>;
   /** Stable dimension names, supplied by the caller or generated from rank. */
   dimensions: string[];
 };
@@ -167,6 +171,8 @@ export class ZarrArraySource extends ZarrSource {
         shape: [...array.shape],
         chunks: [...array.chunks],
         dtype: String(array.dtype),
+        fillValue: array.fillValue,
+        attributes: {...array.attrs},
         dimensions: [...dimensions]
       }
     };

--- a/modules/zarr/src/zarr-array-source.ts
+++ b/modules/zarr/src/zarr-array-source.ts
@@ -23,26 +23,11 @@ export type ZarrArraySourceMetadata = {
 
 /** Parameters for reading a Zarr array selection. */
 export type GetZarrArrayParameters = {
-  /** Integer or slice selector for each dimension; null retains that dimension. */
-  selection?: ZarrArraySelection;
-  /** Named selectors resolved against the metadata dimension labels. */
-  selectionByDimension?: Readonly<Record<string, number | null | ZarrArraySlice>>;
+  /** Integer index for each selected dimension; null retains that dimension. */
+  selection?: Array<number | null>;
   /** Abort signal forwarded to metadata and chunk requests. */
   signal?: AbortSignal;
 };
-
-/** Slice selector accepted by {@link ZarrArraySource#getArray}. */
-export type ZarrArraySlice = {
-  /** Inclusive starting index, defaulting to the dimension boundary. */
-  start?: number;
-  /** Exclusive stopping index, defaulting to the dimension boundary. */
-  stop?: number;
-  /** Stride between selected indices, defaulting to one. */
-  step?: number;
-};
-
-/** Positional selectors for a Zarr array read. */
-export type ZarrArraySelection = Array<number | null | ZarrArraySlice>;
 
 /** Result of a Zarr array read. */
 export type ZarrArrayData = {
@@ -124,16 +109,11 @@ export class ZarrArraySource extends ZarrSource {
   /** Reads the selected array values. */
   async getArray(parameters: GetZarrArrayParameters = {}): Promise<ZarrArrayData> {
     const {array, metadata} = await this.getInitializationPromise(parameters.signal);
-    const selection = parameters.selection || createNamedSelection(parameters.selectionByDimension, metadata);
+    const selection = parameters.selection || metadata.shape.map(() => null);
     if (selection.length !== metadata.shape.length) {
       throw new Error(`Zarr array selection must have ${metadata.shape.length} dimensions.`);
     }
-    const zarritaSelection = selection.map(selector =>
-      isZarrArraySlice(selector)
-        ? zarrita.slice(selector.start ?? null, selector.stop ?? null, selector.step ?? null)
-        : selector
-    );
-    const chunk = await zarrita.get(array, zarritaSelection, {signal: parameters.signal});
+    const chunk = await zarrita.get(array, selection, {signal: parameters.signal});
     if (!chunk || typeof chunk !== 'object' || !('data' in chunk) || !('shape' in chunk)) {
       throw new Error('Failed to read Zarr array selection.');
     }
@@ -171,25 +151,4 @@ export class ZarrArraySource extends ZarrSource {
       }
     };
   }
-}
-
-/** Converts named dimension selectors into the positional form accepted by Zarrita. */
-function createNamedSelection(
-  selectionByDimension: GetZarrArrayParameters['selectionByDimension'],
-  metadata: ZarrArraySourceMetadata
-): ZarrArraySelection {
-  const selection = metadata.shape.map(() => null) as ZarrArraySelection;
-  for (const [dimension, selector] of Object.entries(selectionByDimension || {})) {
-    const dimensionIndex = metadata.dimensions.indexOf(dimension);
-    if (dimensionIndex < 0) {
-      throw new Error(`Unknown Zarr array dimension ${dimension}.`);
-    }
-    selection[dimensionIndex] = selector;
-  }
-  return selection;
-}
-
-/** Tests whether a selector is a slice descriptor rather than an index. */
-function isZarrArraySlice(selector: number | null | ZarrArraySlice): selector is ZarrArraySlice {
-  return typeof selector === 'object' && selector !== null;
 }

--- a/modules/zarr/src/zarr-array-source.ts
+++ b/modules/zarr/src/zarr-array-source.ts
@@ -128,6 +128,9 @@ export class ZarrArraySource extends ZarrSource {
   /** Reads the selected array values. */
   async getArray(parameters: GetZarrArrayParameters = {}): Promise<ZarrArrayData> {
     const {array, metadata} = await this.getInitializationPromise(parameters.signal);
+    if (parameters.selection && parameters.selectionByDimension) {
+      throw new Error('Zarr array requests cannot combine positional and named selections.');
+    }
     const selection = parameters.selection || createNamedSelection(parameters.selectionByDimension, metadata);
     if (selection.length !== metadata.shape.length) {
       throw new Error(`Zarr array selection must have ${metadata.shape.length} dimensions.`);

--- a/modules/zarr/test/zarr-array-source.node.spec.ts
+++ b/modules/zarr/test/zarr-array-source.node.spec.ts
@@ -31,6 +31,12 @@ test('ZarrArraySource reads array metadata and integer selections', async t => {
   const selected = await source.getArray({selection: [0, 1, 0, null, null]});
   t.deepEqual(selected.shape, [167, 439]);
   t.equal(selected.data.length, 167 * 439);
+
+  const window = await source.getArray({
+    selection: [0, 1, 0, {start: 2, stop: 5}, {start: 4, stop: 9, step: 2}]
+  });
+  t.deepEqual(window.shape, [3, 3]);
+  t.equal(window.data.length, 9);
   t.end();
 });
 

--- a/modules/zarr/test/zarr-array-source.node.spec.ts
+++ b/modules/zarr/test/zarr-array-source.node.spec.ts
@@ -27,6 +27,8 @@ test('ZarrArraySource reads array metadata and integer selections', async t => {
   t.deepEqual(metadata.shape, [1, 3, 1, 167, 439]);
   t.deepEqual(metadata.chunks, [1, 1, 1, 167, 439]);
   t.deepEqual(metadata.dimensions, ['t', 'c', 'z', 'y', 'x']);
+  t.equal(metadata.fillValue, 0);
+  t.equal(metadata.attributes['long_name'], 'Example georeferenced image');
 
   const selected = await source.getArray({selection: [0, 1, 0, null, null]});
   t.deepEqual(selected.shape, [167, 439]);

--- a/modules/zarr/test/zarr-array-source.node.spec.ts
+++ b/modules/zarr/test/zarr-array-source.node.spec.ts
@@ -37,6 +37,11 @@ test('ZarrArraySource reads array metadata and integer selections', async t => {
   });
   t.deepEqual(window.shape, [3, 3]);
   t.equal(window.data.length, 9);
+
+  const namedWindow = await source.getArray({
+    selectionByDimension: {t: 0, c: 1, z: 0, y: {start: 2, stop: 5}, x: {start: 4, stop: 9, step: 2}}
+  });
+  t.deepEqual(namedWindow.shape, [3, 3]);
   t.end();
 });
 
@@ -47,5 +52,15 @@ test('ZarrArraySource validates selection rank and dimension labels', async t =>
   });
 
   await t.rejects(source.getMetadata(), /dimensions must have length 5/);
+  t.end();
+});
+
+test('ZarrArraySource rejects unknown named dimensions', async t => {
+  const source = createDataSource(FIXTURE_URL, [ZarrArraySourceLoader], {
+    zarr: {path: 'images/example-image'},
+    zarrArray: {path: '0'}
+  });
+
+  await t.rejects(source.getArray({selectionByDimension: {unknown: 0}}), /Unknown Zarr array dimension/);
   t.end();
 });

--- a/modules/zarr/test/zarr-array-source.node.spec.ts
+++ b/modules/zarr/test/zarr-array-source.node.spec.ts
@@ -64,5 +64,9 @@ test('ZarrArraySource rejects unknown named dimensions', async t => {
   });
 
   await t.rejects(source.getArray({selectionByDimension: {unknown: 0}}), /Unknown Zarr array dimension/);
+  await t.rejects(
+    source.getArray({selection: [null, null, null, null, null], selectionByDimension: {t: 0}}),
+    /cannot combine positional and named selections/
+  );
   t.end();
 });

--- a/modules/zarr/test/zarr-array-source.node.spec.ts
+++ b/modules/zarr/test/zarr-array-source.node.spec.ts
@@ -31,17 +31,6 @@ test('ZarrArraySource reads array metadata and integer selections', async t => {
   const selected = await source.getArray({selection: [0, 1, 0, null, null]});
   t.deepEqual(selected.shape, [167, 439]);
   t.equal(selected.data.length, 167 * 439);
-
-  const window = await source.getArray({
-    selection: [0, 1, 0, {start: 2, stop: 5}, {start: 4, stop: 9, step: 2}]
-  });
-  t.deepEqual(window.shape, [3, 3]);
-  t.equal(window.data.length, 9);
-
-  const namedWindow = await source.getArray({
-    selectionByDimension: {t: 0, c: 1, z: 0, y: {start: 2, stop: 5}, x: {start: 4, stop: 9, step: 2}}
-  });
-  t.deepEqual(namedWindow.shape, [3, 3]);
   t.end();
 });
 
@@ -52,15 +41,5 @@ test('ZarrArraySource validates selection rank and dimension labels', async t =>
   });
 
   await t.rejects(source.getMetadata(), /dimensions must have length 5/);
-  t.end();
-});
-
-test('ZarrArraySource rejects unknown named dimensions', async t => {
-  const source = createDataSource(FIXTURE_URL, [ZarrArraySourceLoader], {
-    zarr: {path: 'images/example-image'},
-    zarrArray: {path: '0'}
-  });
-
-  await t.rejects(source.getArray({selectionByDimension: {unknown: 0}}), /Unknown Zarr array dimension/);
   t.end();
 });


### PR DESCRIPTION
## Goals

Address review feedback from #3668 and make generic RasterSet/Zarr array access safe and useful for downstream consumers.

## Changes

- prevent incompatible RasterSource instances from being supplied to non-viewport RasterSet parameter types
- preserve array and class-instance request shapes while injecting AbortSignal
- add `RasterSet.fromCallbacks` for non-viewport sources
- add `ZarrArraySource` for direct metadata and positional/named/sliced selections
- expose shape, chunks, dtype, fill value, dimension labels, and attributes
- reject ambiguous requests that combine positional and named selections
- reset failed or aborted array initialization so callers can retry metadata or reads
- add hermetic Zarr v3 and RasterSet regression coverage

## Validation

- yarn lint fix
- yarn build
- Zarr tests: `yarn test-node modules/zarr/test/zarr-array-source.node.spec.ts` (3/3)
- RasterSet browser tests: `yarn test-headless modules/tiles/test/raster-set-dimensions.spec.ts` (3/3)

Richer codecs, shared chunk caching, and virtual-Zarr references remain follow-up tranches.
