### PR TITLE
feat(copc): expose progressive TypeScript tile batches

### DIFF
--- a/docs/modules/copc/api-reference/copc-source-loader.md
+++ b/docs/modules/copc/api-reference/copc-source-loader.md
@@ -34,7 +34,7 @@ The created data source exposes the point-cloud tile methods used by `PointCloud
 - `getRootTile()` returns the root octree tile header.
 - `getChildren(tile)` returns available child tile headers.
 - `loadTileContent(tile)` returns normalized point positions, optional colors, point count, and cartographic origin.
-- `loadTileContentInBatches(tile, options)` yields normalized Arrow point tables progressively after the selected node range has been fetched. The TypeScript LAZ variant is required and `options.batchSize` controls the maximum points per table.
+- `loadTileContentInBatches(tile, options)` yields normalized Arrow point tables progressively after the selected node range has been fetched. The TypeScript LAZ variant is required. `options.batchSize` controls the maximum points per table, `options.columns` can request positions only, and `options.signal` cancels the request/decode.
 
 `loadTileContentInBatches` does not yet split the HTTP range request itself. COPC node data is fetched as one complete compressed range because layered LAZ fields need the chunk size metadata and compressed field ranges before decoding can begin. The method avoids building one full decoded Arrow table and is the API boundary for future progressive range delivery.
 

--- a/docs/modules/copc/api-reference/copc-source-loader.md
+++ b/docs/modules/copc/api-reference/copc-source-loader.md
@@ -34,6 +34,9 @@ The created data source exposes the point-cloud tile methods used by `PointCloud
 - `getRootTile()` returns the root octree tile header.
 - `getChildren(tile)` returns available child tile headers.
 - `loadTileContent(tile)` returns normalized point positions, optional colors, point count, and cartographic origin.
+- `loadTileContentInBatches(tile, options)` yields normalized Arrow point tables progressively after the selected node range has been fetched. The TypeScript LAZ variant is required and `options.batchSize` controls the maximum points per table.
+
+`loadTileContentInBatches` does not yet split the HTTP range request itself. COPC node data is fetched as one complete compressed range because layered LAZ fields need the chunk size metadata and compressed field ranges before decoding can begin. The method avoids building one full decoded Arrow table and is the API boundary for future progressive range delivery.
 
 ## Options
 

--- a/modules/copc/src/copc-source-loader.ts
+++ b/modules/copc/src/copc-source-loader.ts
@@ -61,6 +61,20 @@ export type COPCSourceLoaderOptions = DataSourceOptions & {
   };
 };
 
+/** Options for progressive COPC point batches. */
+export type COPCTileContentBatchOptions = {
+  /** Maximum number of points in each yielded Arrow table. */
+  batchSize?: number;
+};
+
+/** Arrow table content returned for one COPC tile batch. */
+export type COPCTileContent = {
+  data: MeshArrowTable;
+  pointCount: number;
+  cartographicOrigin: number[];
+  coordinateSystem: (typeof COORDINATE_SYSTEM)[keyof typeof COORDINATE_SYSTEM];
+};
+
 /**
  * Creates point cloud tile source for COPC urls or blobs
  */
@@ -291,6 +305,67 @@ export class COPCTileSource
     return this.createTileContentResult(pointCount, positions, colors, cartographicOrigin);
   }
 
+  /**
+   * Yield TypeScript-decoded COPC tile content as Arrow batches.
+   *
+   * The compressed node range is currently fetched as one range request. Once
+   * it is available, point batches are decoded and yielded without building a
+   * full decoded node table first. The existing `loadTileContent` method
+   * remains the compatibility API for callers that need one table.
+   */
+  async *loadTileContentInBatches(
+    tile: {id: string},
+    options: COPCTileContentBatchOptions = {}
+  ): AsyncIterable<COPCTileContent> {
+    const {copc} = await this._initPromise;
+    const node = await this.getNodeById(tile.id);
+    if (!node) {
+      return;
+    }
+    if (
+      this.options.copc?.decoder !== 'typescript-laz' ||
+      !supportsDirectCOPCPointDataOutput(copc.header.pointDataRecordFormat)
+    ) {
+      throw new Error('COPC progressive batches require the TypeScript LAZ decoder for PDRF 6-8');
+    }
+
+    const nativeOrigin = this.getNativeTileCenter(tile.id);
+    const cartographicOrigin = this.projectPoint(nativeOrigin);
+    const compressed = await Copc.loadCompressedPointDataBuffer(this._urlOrGetter, node);
+    const batchSize = Math.max(1, Math.floor(options.batchSize || 65536));
+    const colors = pointFormatHasColor(copc.header.pointDataRecordFormat);
+    const cursor = createLAZChunkDecoderCursor(compressed, {
+      pointCount: node.pointCount,
+      pointDataRecordFormat: copc.header.pointDataRecordFormat,
+      pointDataRecordLength: copc.header.pointDataRecordLength
+    });
+
+    while (cursor.remainingPointCount > 0) {
+      const pointCount = Math.min(batchSize, cursor.remainingPointCount);
+      const nativePositions = new Float64Array(pointCount * 3);
+      const positions = new Float32Array(pointCount * 3);
+      const batchColors = colors ? new Uint16Array(pointCount * 3) : null;
+      const decodedPointCount = cursor.decodeIntoPointData(
+        {
+          positions: nativePositions,
+          rawColors: batchColors,
+          pointOffset: 0,
+          scale: copc.header.scale,
+          offset: copc.header.offset
+        },
+        pointCount
+      );
+      if (decodedPointCount !== pointCount) {
+        throw new Error(
+          `COPC TypeScript LAZ decoder produced ${decodedPointCount} points; expected ${pointCount}`
+        );
+      }
+
+      this.transformTilePositions(nativePositions, positions, nativeOrigin, cartographicOrigin);
+      yield this.createTileContentResult(pointCount, positions, batchColors, cartographicOrigin);
+    }
+  }
+
   /** Decode a COPC node directly into the typed attributes used for rendering. */
   protected async loadTypeScriptTileContent(
     copc: Copc,
@@ -495,7 +570,7 @@ export class COPCTileSource
     positions: Float32Array,
     colors: Uint16Array | null,
     origin: number[]
-  ) {
+  ): COPCTileContent {
     const positionsAttribute = {value: positions, size: 3};
     const colorsAttribute = colors ? {value: colors, size: 3, normalized: true} : undefined;
     const data = this.createTileContentTable(pointCount, positionsAttribute, colorsAttribute);

--- a/modules/copc/src/copc-source-loader.ts
+++ b/modules/copc/src/copc-source-loader.ts
@@ -65,6 +65,10 @@ export type COPCSourceLoaderOptions = DataSourceOptions & {
 export type COPCTileContentBatchOptions = {
   /** Maximum number of points in each yielded Arrow table. */
   batchSize?: number;
+  /** Optional cancellation signal for the range request and decode loop. */
+  signal?: AbortSignal;
+  /** Arrow attributes to populate. POSITION is always included. */
+  columns?: readonly ('POSITION' | 'COLOR_0')[];
 };
 
 /** Arrow table content returned for one COPC tile batch. */
@@ -329,11 +333,19 @@ export class COPCTileSource
       throw new Error('COPC progressive batches require the TypeScript LAZ decoder for PDRF 6-8');
     }
 
+    if (options.signal?.aborted) {
+      throw new Error('COPC progressive tile decode was aborted');
+    }
+    const batchSize = options.batchSize ?? 65536;
+    if (!Number.isSafeInteger(batchSize) || batchSize < 1) {
+      throw new Error('COPC progressive tile batchSize must be a positive integer');
+    }
     const nativeOrigin = this.getNativeTileCenter(tile.id);
     const cartographicOrigin = this.projectPoint(nativeOrigin);
     const compressed = await Copc.loadCompressedPointDataBuffer(this._urlOrGetter, node);
-    const batchSize = Math.max(1, Math.floor(options.batchSize || 65536));
-    const colors = pointFormatHasColor(copc.header.pointDataRecordFormat);
+    const colors =
+      pointFormatHasColor(copc.header.pointDataRecordFormat) &&
+      (options.columns ? options.columns.includes('COLOR_0') : true);
     const cursor = createLAZChunkDecoderCursor(compressed, {
       pointCount: node.pointCount,
       pointDataRecordFormat: copc.header.pointDataRecordFormat,
@@ -341,6 +353,9 @@ export class COPCTileSource
     });
 
     while (cursor.remainingPointCount > 0) {
+      if (options.signal?.aborted) {
+        throw new Error('COPC progressive tile decode was aborted');
+      }
       const pointCount = Math.min(batchSize, cursor.remainingPointCount);
       const nativePositions = new Float64Array(pointCount * 3);
       const positions = new Float32Array(pointCount * 3);

--- a/modules/copc/src/index.ts
+++ b/modules/copc/src/index.ts
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-export type {COPCSourceLoaderOptions} from './copc-source-loader';
+export type {
+  COPCSourceLoaderOptions,
+  COPCTileContent,
+  COPCTileContentBatchOptions
+} from './copc-source-loader';
 export type {COPCWriterOptions} from './copc-writer';
 export {COPCFormat} from './copc-format';
 export {COPCSourceLoader} from './copc-source-loader';

--- a/modules/copc/test/copc-source.spec.ts
+++ b/modules/copc/test/copc-source.spec.ts
@@ -133,6 +133,35 @@ test('COPCSourceLoader#streams TypeScript tile content as Arrow batches', async 
   t.end();
 });
 
+test('COPCSourceLoader#streams position-only TypeScript tile batches', async t => {
+  const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {
+    copc: {decoder: 'typescript-laz'}
+  });
+  await source.initialize();
+
+  const rootTile = await source.getRootTile();
+  const atomicContent = await source.loadTileContent(rootTile);
+  const atomicPositions = atomicContent?.data.data.getChild('POSITION');
+  const streamedPositions: number[] = [];
+  for await (const batch of source.loadTileContentInBatches(rootTile, {
+    batchSize: 127,
+    columns: ['POSITION']
+  })) {
+    t.notOk(batch.data.data.getChild('COLOR_0'), 'color output is omitted');
+    const positions = batch.data.data.getChild('POSITION');
+    for (let index = 0; index < batch.pointCount; index++) {
+      streamedPositions.push(...(positions?.get(index)?.toArray() || []));
+    }
+  }
+
+  const expectedPositions: number[] = [];
+  for (let index = 0; index < rootTile.pointCount; index++) {
+    expectedPositions.push(...(atomicPositions?.get(index)?.toArray() || []));
+  }
+  t.deepEqual(streamedPositions, expectedPositions, 'position-only batches match atomic output');
+  t.end();
+});
+
 test('COPCSourceLoader#TypeScript tile attributes match laz-perf', async t => {
   if (isBrowser) {
     t.comment('Skipping browser parity until laz-perf wasm is served as an asset');

--- a/modules/copc/test/copc-source.spec.ts
+++ b/modules/copc/test/copc-source.spec.ts
@@ -96,6 +96,43 @@ test('COPCSourceLoader#loads tile content with TypeScript LAZ decoder', async t 
   t.end();
 });
 
+test('COPCSourceLoader#streams TypeScript tile content as Arrow batches', async t => {
+  const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {
+    copc: {decoder: 'typescript-laz'}
+  });
+  await source.initialize();
+
+  const rootTile = await source.getRootTile();
+  const atomicContent = await source.loadTileContent(rootTile);
+  const streamedPositions: number[] = [];
+  const streamedColors: number[] = [];
+  let streamedPointCount = 0;
+
+  for await (const batch of source.loadTileContentInBatches(rootTile, {batchSize: 127})) {
+    const positions = batch.data.data.getChild('POSITION');
+    const colors = batch.data.data.getChild('COLOR_0');
+    streamedPointCount += batch.pointCount;
+    for (let index = 0; index < batch.pointCount; index++) {
+      streamedPositions.push(...(positions?.get(index)?.toArray() || []));
+      streamedColors.push(...(colors?.get(index)?.toArray() || []));
+    }
+  }
+
+  const atomicPositions = atomicContent?.data.data.getChild('POSITION');
+  const atomicColors = atomicContent?.data.data.getChild('COLOR_0');
+  const expectedPositions: number[] = [];
+  const expectedColors: number[] = [];
+  for (let index = 0; index < rootTile.pointCount; index++) {
+    expectedPositions.push(...(atomicPositions?.get(index)?.toArray() || []));
+    expectedColors.push(...(atomicColors?.get(index)?.toArray() || []));
+  }
+
+  t.equal(streamedPointCount, rootTile.pointCount, 'all points are yielded');
+  t.deepEqual(streamedPositions, expectedPositions, 'batched positions match atomic output');
+  t.deepEqual(streamedColors, expectedColors, 'batched colors match atomic output');
+  t.end();
+});
+
 test('COPCSourceLoader#TypeScript tile attributes match laz-perf', async t => {
   if (isBrowser) {
     t.comment('Skipping browser parity until laz-perf wasm is served as an asset');

--- a/modules/las/test/las-loader.node.slow.spec.ts
+++ b/modules/las/test/las-loader.node.slow.spec.ts
@@ -1127,6 +1127,64 @@ test('TypeScriptLAZ#feedable decoder accepts split chunks', async t => {
   t.end();
 });
 
+test('TypeScriptLAZ#position batches start before later layers arrive', async t => {
+  const {compressed, metadata} = await getCOPCRootChunk();
+  const expectedPositions = new Float64Array(metadata.pointCount * 3);
+  const expectedCursor = createLAZChunkDecoderCursor(compressed, metadata);
+  expectedCursor.decodeIntoPointData(
+    {
+      positions: expectedPositions,
+      pointOffset: 0,
+      scale: [1, 1, 1],
+      offset: [0, 0, 0]
+    },
+    metadata.pointCount
+  );
+
+  const decoder = createLAZChunkDecoder(metadata);
+  const positions = new Float64Array(metadata.pointCount * 3);
+  let decodedPointCount = 0;
+  let firstDecodedByteLength = -1;
+  for (let offset = 0; offset < compressed.byteLength; offset += 257) {
+    decoder.feed(compressed.subarray(offset, Math.min(offset + 257, compressed.byteLength)));
+    let batchPointCount = decoder.readPositionDataBatch(
+      {
+        positions,
+        pointOffset: decodedPointCount,
+        scale: [1, 1, 1],
+        offset: [0, 0, 0]
+      },
+      metadata.pointCount - decodedPointCount
+    );
+    while (batchPointCount && batchPointCount > 0) {
+      if (firstDecodedByteLength < 0) {
+        firstDecodedByteLength = Math.min(offset + 257, compressed.byteLength);
+      }
+      decodedPointCount += batchPointCount;
+      batchPointCount = decoder.readPositionDataBatch(
+        {
+          positions,
+          pointOffset: decodedPointCount,
+          scale: [1, 1, 1],
+          offset: [0, 0, 0]
+        },
+        metadata.pointCount - decodedPointCount
+      );
+    }
+    if (decodedPointCount === metadata.pointCount) {
+      break;
+    }
+  }
+
+  t.equal(decodedPointCount, metadata.pointCount, 'all positions decode from the first layer');
+  t.ok(
+    firstDecodedByteLength > 0 && firstDecodedByteLength < compressed.byteLength,
+    'positions decode before the complete compressed chunk arrives'
+  );
+  t.deepEqual(positions, expectedPositions, 'progressive positions match complete decoding');
+  t.end();
+});
+
 test('TypeScriptLAZ#decodeLAZChunkInBatches accepts split chunks', async t => {
   const {compressed, metadata} = await getCOPCRootChunk();
   const expected = decodeLAZChunk(compressed, metadata);

--- a/modules/loader-utils/src/lib/laz/laz-chunk-decoder.ts
+++ b/modules/loader-utils/src/lib/laz/laz-chunk-decoder.ts
@@ -163,6 +163,34 @@ export class FeedableLAZChunkDecoder {
     return batch;
   }
 
+  /**
+   * Decode the next position-only point-data batch as soon as Point14 bytes arrive.
+   *
+   * This is limited to layered PDRF 6-8 chunks and targets without RGB fields.
+   * Later independent layers are represented by a zero-filled skipped tail; no
+   * values from those layers are read by the position-only decoder.
+   */
+  readPositionDataBatch(target: LAZPointDataTarget, pointCount: number): number | null {
+    if (target.colors || target.rawColors) {
+      throw new Error('Position-only LAZ batches cannot request color output');
+    }
+    if (this.metadata.pointDataRecordFormat < 6 || this.metadata.pointDataRecordFormat > 8) {
+      throw new Error('Position-only LAZ batches require point formats 6-8');
+    }
+    if (!this.cursor) {
+      const compressed = this.getProgressivePositionData();
+      if (!compressed) {
+        return null;
+      }
+      this.cursor = createLAZChunkDecoderCursor(compressed, this.metadata);
+    }
+    if (this.cursor.remainingPointCount <= 0) {
+      return 0;
+    }
+    const batchPointCount = Math.min(pointCount, this.cursor.remainingPointCount);
+    return this.cursor.decodeIntoPointData(target, batchPointCount);
+  }
+
   private hasCompleteChunk(): boolean {
     if (!hasLayeredChunkSizeHeaders(this.metadata.pointDataRecordFormat)) {
       return this.closed;
@@ -195,6 +223,18 @@ export class FeedableLAZChunkDecoder {
   private getCompressedAvailable(): Uint8Array {
     this.compressed ||= concatenateUint8Arrays(this.chunks);
     return this.compressed;
+  }
+
+  private getProgressivePositionData(): Uint8Array | null {
+    const available = this.getCompressedAvailable();
+    const layout = getLayeredChunkLayout(available, this.metadata);
+    if (!layout || available.byteLength < layout.pointDataByteLength) {
+      return null;
+    }
+
+    const compressed = new Uint8Array(layout.byteLength);
+    compressed.set(available.subarray(0, Math.min(available.byteLength, layout.byteLength)));
+    return compressed;
   }
 }
 
@@ -458,6 +498,36 @@ function getLAZChunkMinimumByteLength(metadata: LAZChunkMetadata): number {
     4 +
     getChunkSizeHeaderCount(metadata.pointDataRecordFormat, extraByteCount) * 4
   );
+}
+
+type LAZLayeredChunkLayout = {
+  byteLength: number;
+  pointDataByteLength: number;
+};
+
+function getLayeredChunkLayout(
+  bytes: Uint8Array,
+  metadata: LAZChunkMetadata
+): LAZLayeredChunkLayout | null {
+  const extraByteCount = getExtraByteCount(metadata);
+  const sizeHeaderOffset = metadata.pointDataRecordLength + 4;
+  const sizeHeaderCount = getChunkSizeHeaderCount(metadata.pointDataRecordFormat, extraByteCount);
+  const sizeHeaderByteLength = sizeHeaderCount * 4;
+  if (bytes.byteLength < sizeHeaderOffset + sizeHeaderByteLength) {
+    return null;
+  }
+
+  const dataView = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let byteLength = sizeHeaderOffset + sizeHeaderByteLength;
+  let pointDataByteLength = byteLength;
+  for (let index = 0; index < sizeHeaderCount; index++) {
+    const layerByteLength = dataView.getUint32(sizeHeaderOffset + index * 4, true);
+    byteLength += layerByteLength;
+    if (index < 9) {
+      pointDataByteLength += layerByteLength;
+    }
+  }
+  return {byteLength, pointDataByteLength};
 }
 
 const AC_MIN_LENGTH = 0x01000000;


### PR DESCRIPTION
## Goals

- Expose progressive Arrow output for TypeScript-decoded COPC nodes.
- Avoid building one full decoded Arrow table before the caller can consume points.
- Preserve the existing atomic `loadTileContent` API and COPC hierarchy/range behavior.

## Changes

- Add `COPCTileSource.loadTileContentInBatches(tile, options)`.
- Decode PDRF 6-8 node chunks directly into bounded typed Arrow batch buffers.
- Support position-only batches to skip RGB arithmetic decoding and allocation when color is not requested.
- Add feedable position-layer decoding for PDRF 6-8: positions can be emitted once the Point14 layer arrives, before RGB/NIR/Extra Bytes tail data.
- Support cancellation through `options.signal` and validate positive integer batch sizes.
- Preserve tile-relative positions, optional RGB attributes, coordinate system, origin, and point counts for every batch.
- Export `COPCTileContent` and `COPCTileContentBatchOptions` types.
- Add atomic-versus-batched, position-only, and partial-layer parity coverage.
- Document that the current COPC range request still fetches each compressed node as one request; range splitting and progressive network delivery remain follow-up work.

## Validation

- `yarn test-headless modules/copc/test/copc-source.spec.ts`: 13 passed.
- Focused progressive test: 1 passed.
- `tspc -b modules/loader-utils/tsconfig.json modules/las/tsconfig.json modules/copc/tsconfig.json`: passed.
- `yarn lint fix` passed.
- `git diff --check` passed.
- The full LAS slow file reached 65 passed and 1 skipped, but three pre-existing large-fixture tests exceeded the file’s 5-second per-test timeout.
