### PR TITLE
fix(parquet): align scan plans with execution

### DIFF
--- a/docs/modules/parquet/api-reference/parquet-source-loader.md
+++ b/docs/modules/parquet/api-reference/parquet-source-loader.md
@@ -211,7 +211,10 @@ Parquet row-group plan. The physical section reports retained row-group indexes 
 for callback, spatial-statistics, column-statistics, and Bloom-filter pruning. It also reports the
 number and byte size of Bloom-filter payloads inspected while planning. For indexed files it also
 reports candidate row ranges, selected versus total pages, pruned rows, and the absolute data-page
-ranges required by each retained row group. Planning may therefore read footer, Bloom-filter,
+ranges required by each retained row group. A plan includes `predicate` and `projection` phases
+when hidden filter columns require late materialization; the predicate phase contains page-index
+ranges for filter columns and the projection phase contains the complete projected column-chunk
+ranges actually fetched after matches are known. Planning may therefore read footer, Bloom-filter,
 column-index, and offset-index ranges, but it does not decode data pages.
 
 `explain(options)` is an alias for `getScanPlan(options)`. `scan(options)` is an alias for

--- a/docs/modules/parquet/api-reference/parquet-writer.md
+++ b/docs/modules/parquet/api-reference/parquet-writer.md
@@ -100,7 +100,8 @@ const parquet = await encode(table, ParquetJSWriter, {
       timestamp: 'DELTA_BINARY_PACKED',
       identifier: 'DELTA_BYTE_ARRAY'
     },
-    bloomFilter: {identifier: true}
+    bloomFilter: {identifier: true},
+    pageIndex: {timestamp: true}
   }
 });
 ```
@@ -133,6 +134,7 @@ read/write encoding matrix.
 | `parquet.columnDictionaries` | `Record<string, boolean \| 'auto'>` | `{}` | Overrides the dictionary policy by top-level column name. |
 | `parquet.dictionaryPageSizeLimit` | `number` | `1048576` | Maximum uncompressed PLAIN dictionary payload in bytes; oversized dictionaries fall back for the complete chunk. |
 | `parquet.bloomFilter` | `boolean \| Record<string, boolean>` | `false` | Emits uncompressed split-block Bloom filters for supported scalar columns, globally or by top-level column name. |
+| `parquet.pageIndex` | `boolean \| Record<string, boolean>` | `false` | Emits column and offset indexes for supported non-repeated scalar columns, globally or by top-level column name. |
 | `parquet.rowGroupSize` | `number` | implementation default | Sets the target row count per row group for `ParquetJSWriter`. |
 | `parquet.pageSize` | `number` | `8192` | Sets the target shredded level-entry count per page. Boundaries remain aligned to top-level rows. |
 | `parquet.useDataPageV2` | `boolean` | `false` | Emits Data Page V2 from `ParquetJSWriter`. |

--- a/docs/modules/parquet/formats/parquet.md
+++ b/docs/modules/parquet/formats/parquet.md
@@ -237,8 +237,8 @@ can make selective reads much cheaper.
 | Row-group and column-chunk offsets | ✅ | ✅ | Drive byte-range projection and row-group selection |
 | Column-chunk min/max/null/distinct statistics | ✅ | ❌ | Drive conservative `ParquetSource` predicate pushdown and remain exposed in metadata |
 | Page statistics in page headers | ⚠️ | ❌ | Thrift fields are decoded but not exposed as a pruning API |
-| [Column index](https://github.com/apache/parquet-format/blob/master/PageIndex.md) | ✅ | ❌ | Flat-column predicates use page min/max/null statistics to derive candidate row ranges |
-| [Offset index](https://github.com/apache/parquet-format/blob/master/PageIndex.md) | ✅ | ❌ | Flat selected columns use page locations and first-row indexes for selective byte reads |
+| [Column index](https://github.com/apache/parquet-format/blob/master/PageIndex.md) | ✅ | ✅ (opt-in) | Flat-column predicates use page min/max/null statistics to derive candidate row ranges; `ParquetJSWriter` emits indexes for supported non-repeated scalar columns |
+| [Offset index](https://github.com/apache/parquet-format/blob/master/PageIndex.md) | ✅ | ✅ (opt-in) | Flat selected columns use page locations and first-row indexes for selective byte reads; `ParquetJSWriter` emits indexes alongside column indexes |
 | [Bloom filters](https://github.com/apache/parquet-format/blob/master/BloomFilter.md) | ✅ | ✅ | TypeScript reads split-block Bloom filters for safe equality/`IN` row-group pruning; `ParquetJSWriter` can emit them opt-in |
 | Size statistics | ❌ | ❌ | Histogram metadata from newer format work is not yet exposed; see the upstream [`ColumnMetaData`](https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift) definition |
 | Column order and sorting columns | ⚠️ | ❌ | Raw footer metadata is retained; semantic pruning is not yet applied |

--- a/modules/parquet/src/lib/encoders/encode-table-to-parquet-js.ts
+++ b/modules/parquet/src/lib/encoders/encode-table-to-parquet-js.ts
@@ -72,6 +72,10 @@ function convertSchemaToParquetSchema(
     options.parquet?.bloomFilter && typeof options.parquet.bloomFilter === 'object'
       ? options.parquet.bloomFilter
       : {};
+  const pageIndexColumns =
+    options.parquet?.pageIndex && typeof options.parquet.pageIndex === 'object'
+      ? options.parquet.pageIndex
+      : {};
   const fieldNames = new Set(schema.fields.map(field => field.name));
   const geoMetadata = getGeoMetadata(schema.metadata);
   for (const columnName of Object.keys(columnEncodings)) {
@@ -87,6 +91,11 @@ function convertSchemaToParquetSchema(
   for (const columnName of Object.keys(bloomFilterColumns)) {
     if (!fieldNames.has(columnName)) {
       throw new Error(`ParquetJSWriter: Unknown Bloom-filter column "${columnName}"`);
+    }
+  }
+  for (const columnName of Object.keys(pageIndexColumns)) {
+    if (!fieldNames.has(columnName)) {
+      throw new Error(`ParquetJSWriter: Unknown page-index column "${columnName}"`);
     }
   }
 

--- a/modules/parquet/src/parquet-dataset-source.ts
+++ b/modules/parquet/src/parquet-dataset-source.ts
@@ -162,9 +162,16 @@ export class ParquetDatasetSource {
       if (!firstFilePlan) {
         throw new Error('ParquetDatasetSource query selected no files');
       }
+      const effectivePredicate = firstFilePlan.parquet.plan.find(step => step.kind === 'filter');
+      const effectiveLimit = options.limit ?? this.options.parquet?.limit;
       const explanation = explainTableQuery(
         firstFilePlan.parquet.sourceColumns,
-        {columns: options.columns, predicate: options.predicate, limit: options.limit},
+        {
+          columns: firstFilePlan.parquet.outputColumns,
+          predicate:
+            effectivePredicate?.kind === 'filter' ? effectivePredicate.predicate : undefined,
+          limit: effectiveLimit
+        },
         PARQUET_TABLE_QUERY_CAPABILITIES
       );
       return Object.freeze({

--- a/modules/parquet/src/parquet-dataset-source.ts
+++ b/modules/parquet/src/parquet-dataset-source.ts
@@ -29,6 +29,7 @@ import type {
   ParquetDatasetSourceOptions,
   ParquetDatasetTelemetry,
   ParquetSourceBatch,
+  ParquetPredicate,
   ParquetSourceExplain,
   ParquetTelemetry
 } from './parquet-source-types';
@@ -201,16 +202,13 @@ export class ParquetDatasetSource {
       throw new Error('ParquetDatasetSource can only execute dataset scan plans');
     }
     validateTableQueryLimit(options.limit);
-    let remainingRows = options.limit ?? Number.POSITIVE_INFINITY;
+    let remainingRows = options.limit ?? this.options.parquet?.limit ?? Number.POSITIVE_INFINITY;
     if (remainingRows === 0) return;
-    const predicateStep = plan.plan.find(step => step.kind === 'filter');
     const limitStep = plan.plan.find(step => step.kind === 'limit');
     const readOptions: ParquetDatasetReadOptions = {
       ...options,
       columns: options.columns ?? plan.outputColumns,
-      predicate:
-        options.predicate ??
-        (predicateStep?.kind === 'filter' ? predicateStep.predicate : undefined),
+      predicate: options.predicate,
       limit: options.limit ?? (limitStep?.kind === 'limit' ? limitStep.limit : undefined)
     };
     remainingRows = readOptions.limit ?? Number.POSITIVE_INFINITY;
@@ -256,7 +254,7 @@ export class ParquetDatasetSource {
   async *read(options: ParquetDatasetReadOptions = {}): AsyncIterable<ParquetDatasetBatch> {
     this.assertOpen();
     validateTableQueryLimit(options.limit);
-    let remainingRows = options.limit ?? Number.POSITIVE_INFINITY;
+    let remainingRows = options.limit ?? this.options.parquet?.limit ?? Number.POSITIVE_INFINITY;
     if (remainingRows === 0) return;
     const readContext = createDatasetAbortContext(options.signal);
     this.activeReadControllers.add(readContext.abortController);
@@ -303,6 +301,9 @@ export class ParquetDatasetSource {
   ): AsyncIterable<ScanTask<ParquetDatasetBatch>> {
     const selectedFiles = this.getSelectedFiles({...options, signal});
     for await (const indexedFile of selectedFiles) {
+      if (filePlans && !filePlans.has(indexedFile.index)) {
+        continue;
+      }
       yield {
         run: taskSignal =>
           this.readFile(indexedFile, options, taskSignal, filePlans?.get(indexedFile.index))
@@ -374,7 +375,7 @@ export class ParquetDatasetSource {
         concurrency: options.concurrency,
         rowGroups: scanPlan?.rowGroups.indices,
         rowGroupFilter: options.rowGroupFilter,
-        predicate: options.predicate,
+        predicate: options.predicate ?? (!options.bbox ? getPlanPredicate(scanPlan) : undefined),
         bbox: options.bbox,
         geometryColumn: options.geometryColumn,
         limit: undefined,
@@ -415,7 +416,10 @@ export class ParquetDatasetSource {
 
   /** Creates a child source while preserving caller fetch, worker, range, and decode options. */
   private createSource(file: ParquetDatasetFile): ParquetSource {
-    return new ParquetSource(file.data, this.options, this.coreApi);
+    const parquetOptions = this.options.parquet
+      ? {...this.options.parquet, limit: undefined}
+      : undefined;
+    return new ParquetSource(file.data, {...this.options, parquet: parquetOptions}, this.coreApi);
   }
 
   /** Lazily discovers descriptors and applies conservative local pruning. */
@@ -501,6 +505,12 @@ function createDatasetBatch(
     ...datasetProvenance
   });
   return {...batch, metadata: provenance, ...datasetProvenance};
+}
+
+/** Returns the filter predicate recorded in one child source plan. */
+function getPlanPredicate(plan: ParquetSourceExplain | undefined): ParquetPredicate | undefined {
+  const filter = plan?.plan.find(step => step.kind === 'filter');
+  return filter?.kind === 'filter' ? filter.predicate : undefined;
 }
 
 /** Returns a stable descriptor identity for batch provenance and diagnostics. */

--- a/modules/parquet/src/parquet-js-writer.ts
+++ b/modules/parquet/src/parquet-js-writer.ts
@@ -34,6 +34,8 @@ type ParquetJSWriterEncoderOptions = {
   dictionaryPageSizeLimit?: number;
   /** Emits Parquet split-block Bloom filters for selected columns. */
   bloomFilter?: boolean | Record<string, boolean>;
+  /** Emits Parquet column and offset indexes for selected non-repeated columns. */
+  pageIndex?: boolean | Record<string, boolean>;
   rowGroupSize?: number;
   pageSize?: number;
   useDataPageV2?: boolean;

--- a/modules/parquet/src/parquet-source-loader.ts
+++ b/modules/parquet/src/parquet-source-loader.ts
@@ -656,8 +656,12 @@ export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoader
     const plans: ParquetPageScanPlan[] = [];
     for (const rowGroupIndex of rowGroupPlan.rowGroupIndices) {
       const rowGroup = initialization.fileMetadata.row_groups[rowGroupIndex];
+      let predicateProvedEmpty = false;
       for (const phase of phases) {
         throwIfAborted(signal);
+        if (phase.phase === 'projection' && predicateProvedEmpty) {
+          continue;
+        }
         const pagePlan = phase.predicate
           ? await createParquetPagePruningPlan(
               initialization.file,
@@ -689,6 +693,9 @@ export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoader
               })
             : createFullColumnScanPlan(rowGroup, rowGroupIndex, phase.phase, phase.columns)
         );
+        if (phase.phase === 'predicate' && pagePlan?.rowRanges.length === 0) {
+          predicateProvedEmpty = true;
+        }
       }
     }
     return plans;

--- a/modules/parquet/src/parquet-source-loader.ts
+++ b/modules/parquet/src/parquet-source-loader.ts
@@ -89,6 +89,7 @@ import {
   type ColumnChunk,
   type FileMetaData,
   type GeospatialStatistics as ParquetThriftGeospatialStatistics,
+  type RowGroup,
   type Statistics as ParquetThriftStatistics
 } from './parquetjs/parquet-thrift/index';
 import {ParquetReader} from './parquetjs/parser/parquet-reader';
@@ -301,7 +302,7 @@ export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoader
         bytesRead: physicalPlan.bloomFilterBytesRead
       }),
       pages: Object.freeze({
-        rowGroupsPlanned: pagePlans.length,
+        rowGroupsPlanned: new Set(pagePlans.map(plan => plan.rowGroupIndex)).size,
         indexesRead: pagePlans.reduce((sum, plan) => sum + plan.indexesRead, 0),
         total: pagePlans.reduce((sum, plan) => sum + plan.totalPages, 0),
         selected: pagePlans.reduce((sum, plan) => sum + plan.selectedPages, 0),
@@ -630,37 +631,65 @@ export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoader
     const predicateColumns = getParquetPredicateColumns(rowGroupPlan.predicate);
     const decodedColumns =
       columns.length === 0 ? [] : [...new Set([...columns, ...predicateColumns])];
-    const columnList = decodedColumns.map(column => [column]);
+    const hasHiddenPredicateColumns =
+      columns.length > 0 && predicateColumns.some(column => !columns.includes(column));
+    const phases = hasHiddenPredicateColumns
+      ? [
+          {
+            phase: 'predicate' as const,
+            columns: predicateColumns.map(column => [column]),
+            predicate: rowGroupPlan.predicate
+          },
+          {
+            phase: 'projection' as const,
+            columns: columns.map(column => [column]),
+            predicate: undefined
+          }
+        ]
+      : [
+          {
+            phase: 'combined' as const,
+            columns: decodedColumns.map(column => [column]),
+            predicate: rowGroupPlan.predicate
+          }
+        ];
     const plans: ParquetPageScanPlan[] = [];
     for (const rowGroupIndex of rowGroupPlan.rowGroupIndices) {
-      throwIfAborted(signal);
       const rowGroup = initialization.fileMetadata.row_groups[rowGroupIndex];
-      const pagePlan = await createParquetPagePruningPlan(
-        initialization.file,
-        rowGroup,
-        initialization.parquetSchema,
-        columnList,
-        rowGroupPlan.predicate,
-        signal
-      );
-      if (!pagePlan) continue;
-      plans.push(
-        Object.freeze({
-          rowGroupIndex,
-          rowRanges: Object.freeze(
-            pagePlan.rowRanges.map(rowRange => Object.freeze({...rowRange}))
-          ),
-          indexesRead: pagePlan.indexCount,
-          totalPages: pagePlan.totalPageCount,
-          selectedPages: pagePlan.selectedPageCount,
-          rowsPruned: pagePlan.prunedRowCount,
-          ranges: Object.freeze(
-            getParquetPageReadRanges(rowGroup, columnList, pagePlan).map(range =>
-              Object.freeze({...range})
+      for (const phase of phases) {
+        throwIfAborted(signal);
+        const pagePlan = phase.predicate
+          ? await createParquetPagePruningPlan(
+              initialization.file,
+              rowGroup,
+              initialization.parquetSchema,
+              phase.columns,
+              phase.predicate,
+              signal
             )
-          )
-        })
-      );
+          : undefined;
+        plans.push(
+          pagePlan
+            ? Object.freeze({
+                rowGroupIndex,
+                phase: phase.phase,
+                columns: Object.freeze(phase.columns.map(column => Object.freeze([...column]))),
+                rowRanges: Object.freeze(
+                  pagePlan.rowRanges.map(rowRange => Object.freeze({...rowRange}))
+                ),
+                indexesRead: pagePlan.indexCount,
+                totalPages: pagePlan.totalPageCount,
+                selectedPages: pagePlan.selectedPageCount,
+                rowsPruned: pagePlan.prunedRowCount,
+                ranges: Object.freeze(
+                  getParquetPageReadRanges(rowGroup, phase.columns, pagePlan).map(range =>
+                    Object.freeze({...range})
+                  )
+                )
+              })
+            : createFullColumnScanPlan(rowGroup, rowGroupIndex, phase.phase, phase.columns)
+        );
+      }
     }
     return plans;
   }
@@ -1325,6 +1354,40 @@ function createRowGroupMetadata(
     compressedSize: compressedByteLength,
     columns: Object.freeze(columns)
   });
+}
+
+/** Describes a phase that reads complete column chunks because no page index is available. */
+function createFullColumnScanPlan(
+  rowGroup: RowGroup,
+  rowGroupIndex: number,
+  phase: ParquetPageScanPlan['phase'],
+  columns: readonly string[][]
+): ParquetPageScanPlan {
+  const selectedColumnChunks = rowGroup.columns.filter(columnChunk => {
+    const path = columnChunk.meta_data?.path_in_schema;
+    return Boolean(
+      path && (columns.length === 0 || columns.some(column => pathMatchesSelection(column, path)))
+    );
+  });
+  const rowCount = Number(rowGroup.num_rows);
+  return Object.freeze({
+    rowGroupIndex,
+    phase,
+    columns: Object.freeze(columns.map(column => Object.freeze([...column]))),
+    rowRanges: Object.freeze([Object.freeze({start: 0, end: rowCount})]),
+    indexesRead: 0,
+    totalPages: 0,
+    selectedPages: 0,
+    rowsPruned: 0,
+    ranges: Object.freeze(
+      selectedColumnChunks.map(columnChunk => Object.freeze(getColumnChunkRange(columnChunk)))
+    )
+  });
+}
+
+/** Returns whether a requested path selects a footer leaf or one of its nested children. */
+function pathMatchesSelection(selection: readonly string[], path: readonly string[]): boolean {
+  return selection.length <= path.length && selection.every((part, index) => part === path[index]);
 }
 
 /** Returns the complete contiguous byte range occupied by one Parquet column chunk. */

--- a/modules/parquet/src/parquet-source-types.ts
+++ b/modules/parquet/src/parquet-source-types.ts
@@ -290,6 +290,10 @@ export type ParquetSourceExplain = TableQueryExplain<ParquetPredicate> &
 export type ParquetPageScanPlan = Readonly<{
   /** Zero-based row-group index. */
   rowGroupIndex: number;
+  /** Physical phase represented by this plan. */
+  phase: 'combined' | 'predicate' | 'projection';
+  /** Nested column paths fetched during this physical phase. */
+  columns: readonly (readonly string[])[];
   /** Candidate half-open row ranges retained by page statistics. */
   rowRanges: readonly Readonly<{start: number; end: number}>[];
   /** Column-index and offset-index payloads decoded. */

--- a/modules/parquet/src/parquetjs/encoder/parquet-encoder.ts
+++ b/modules/parquet/src/parquetjs/encoder/parquet-encoder.ts
@@ -24,6 +24,7 @@ import {
   BsonType,
   BoundingBox,
   ColumnChunk,
+  ColumnIndex,
   ColumnMetaData,
   CompressionCodec,
   ConvertedType,
@@ -54,6 +55,7 @@ import {
   PageHeader,
   PageEncodingStats,
   PageType,
+  PageLocation,
   RowGroup,
   SchemaElement,
   StringType,
@@ -62,7 +64,8 @@ import {
   TimestampType,
   Type,
   UUIDType,
-  VariantType
+  VariantType,
+  OffsetIndex
 } from '../parquet-thrift/index';
 import {osopen, oswrite, osclose} from '../utils/file-utils';
 import {getBitWidth, serializeThrift} from '../utils/read-utils';
@@ -70,7 +73,11 @@ import {concatUint8Arrays, encodeUtf8, writeUInt32LE} from '../utils/binary-util
 import {CompactInt64} from '../utils/uint8-array-compact-protocol';
 import {planColumnPages} from './page-planner';
 import {planDictionary, type ParquetDictionaryPolicy} from './dictionary-planner';
-import {encodeParquetSplitBlockBloomFilter} from '../../lib/parquet-bloom-filter';
+import {
+  encodeParquetBloomFilterValue,
+  encodeParquetSplitBlockBloomFilter
+} from '../../lib/parquet-bloom-filter';
+import {BoundaryOrder} from '../parquet-thrift/BoundaryOrder';
 
 /**
  * Parquet File Magic String
@@ -104,6 +111,7 @@ export interface ParquetEncoderOptions {
   columnDictionaries?: Record<string, ParquetDictionaryPolicy>;
   dictionaryPageSizeLimit?: number;
   bloomFilter?: boolean | Record<string, boolean>;
+  pageIndex?: boolean | Record<string, boolean>;
 
   // Write Stream Options
   flags?: string;
@@ -284,6 +292,7 @@ export class ParquetEnvelopeWriter {
   public columnDictionaries: Record<string, ParquetDictionaryPolicy>;
   public dictionaryPageSizeLimit: number;
   public bloomFilter?: boolean | Record<string, boolean>;
+  public pageIndex?: boolean | Record<string, boolean>;
 
   constructor(
     schema: ParquetSchema,
@@ -304,6 +313,7 @@ export class ParquetEnvelopeWriter {
     this.columnDictionaries = opts.columnDictionaries || {};
     this.dictionaryPageSizeLimit = opts.dictionaryPageSizeLimit ?? 1024 * 1024;
     this.bloomFilter = opts.bloomFilter;
+    this.pageIndex = opts.pageIndex;
   }
 
   writeSection(buf: Uint8Array): Promise<void> {
@@ -330,7 +340,8 @@ export class ParquetEnvelopeWriter {
       dictionary: this.dictionary,
       columnDictionaries: this.columnDictionaries,
       dictionaryPageSizeLimit: this.dictionaryPageSizeLimit,
-      bloomFilter: this.bloomFilter
+      bloomFilter: this.bloomFilter,
+      pageIndex: this.pageIndex
     });
 
     this.rowCount += records.rowCount;
@@ -653,11 +664,18 @@ async function encodeColumnChunk(
   body: Uint8Array;
   metadata: ColumnMetaData;
   metadataOffset: number;
+  offsetIndexOffset?: number;
+  offsetIndexLength?: number;
+  columnIndexOffset?: number;
+  columnIndexLength?: number;
 }> {
   const data = buffer.columnData[column.path.join()];
   const baseOffset = (opts.baseOffset || 0) + offset;
   /* encode data page(s) */
   const pages: Uint8Array[] = [];
+  const pageLocations: PageLocation[] = [];
+  let pageOffset = 0;
+  let firstRowIndex = 0;
   // tslint:disable-next-line:variable-name
   let total_uncompressed_size = 0;
   // tslint:disable-next-line:variable-name
@@ -679,6 +697,7 @@ async function encodeColumnChunk(
   if (dictionaryPlan) {
     const result = await encodeDictionaryPage(column, dictionaryPlan.values);
     pages.push(result.page);
+    pageOffset += result.page.length;
     total_uncompressed_size += result.header.uncompressed_page_size + result.headerSize;
     total_compressed_size += result.header.compressed_page_size + result.headerSize;
   }
@@ -705,7 +724,16 @@ async function encodeColumnChunk(
           dictionaryPlan?.bitWidth
         )
       : await encodeDataPage(column, pageData, valueEncoding, dictionaryPlan?.bitWidth);
+    pageLocations.push(
+      new PageLocation({
+        offset: baseOffset + pageOffset,
+        compressed_page_size: result.page.length,
+        first_row_index: firstRowIndex
+      })
+    );
+    firstRowIndex += plannedPage.rowCount;
     pages.push(result.page);
+    pageOffset += result.page.length;
     total_uncompressed_size += result.header.uncompressed_page_size + result.headerSize;
     total_compressed_size += result.header.compressed_page_size + result.headerSize;
   }
@@ -715,6 +743,10 @@ async function encodeColumnChunk(
   const bloomFilterEnabled =
     opts.bloomFilter === true || opts.bloomFilter?.[column.path[0]] === true;
   const bloomFilter = bloomFilterEnabled ? createColumnBloomFilter(column, data.values) : undefined;
+  const pageIndexEnabled = opts.pageIndex === true || opts.pageIndex?.[column.path[0]] === true;
+  const pageIndexes = pageIndexEnabled
+    ? createColumnPageIndexes(column, plannedPages, pageLocations)
+    : undefined;
 
   /* prepare metadata header */
   const metadata = new ColumnMetaData({
@@ -755,12 +787,185 @@ async function encodeColumnChunk(
 
   /* concat metadata header and data pages */
   const metadataOffset = baseOffset + pagesBuf.length + (bloomFilter?.length || 0);
+  const metadataEncoded = serializeThrift(metadata);
+  const offsetIndexOffset = pageIndexes ? metadataOffset + metadataEncoded.length : undefined;
+  const columnIndexOffset = pageIndexes
+    ? metadataOffset + metadataEncoded.length + pageIndexes.offsetIndex.length
+    : undefined;
   const body = concatUint8Arrays([
     pagesBuf,
     ...(bloomFilter ? [bloomFilter] : []),
-    serializeThrift(metadata)
+    metadataEncoded,
+    ...(pageIndexes ? [pageIndexes.offsetIndex, pageIndexes.columnIndex] : [])
   ]);
-  return {body, metadata, metadataOffset};
+  return {
+    body,
+    metadata,
+    metadataOffset,
+    offsetIndexOffset,
+    offsetIndexLength: pageIndexes?.offsetIndex.length,
+    columnIndexOffset,
+    columnIndexLength: pageIndexes?.columnIndex.length
+  };
+}
+
+/** Builds page indexes for simple non-repeated scalar columns. */
+function createColumnPageIndexes(
+  column: ParquetField,
+  plannedPages: ReturnType<typeof planColumnPages>,
+  pageLocations: PageLocation[]
+): {offsetIndex: Uint8Array; columnIndex: Uint8Array} | undefined {
+  if (
+    column.rLevelMax > 0 ||
+    column.repetitionType === 'REPEATED' ||
+    !isPageIndexPhysicalType(column.primitiveType) ||
+    plannedPages.length !== pageLocations.length ||
+    plannedPages.length === 0
+  ) {
+    return undefined;
+  }
+
+  const nullPages: boolean[] = [];
+  const minValues: Uint8Array[] = [];
+  const maxValues: Uint8Array[] = [];
+  const nullCounts: number[] = [];
+  for (const plannedPage of plannedPages) {
+    const values = plannedPage.data.values;
+    const nullCount = plannedPage.data.count - values.length;
+    nullCounts.push(nullCount);
+    if (values.length === 0) {
+      nullPages.push(true);
+      minValues.push(new Uint8Array(0));
+      maxValues.push(new Uint8Array(0));
+      continue;
+    }
+    const bounds = getPageBounds(values, column.primitiveType!, column.typeLength);
+    if (!bounds) return undefined;
+    nullPages.push(false);
+    minValues.push(bounds.min);
+    maxValues.push(bounds.max);
+  }
+
+  return {
+    offsetIndex: serializeThrift(new OffsetIndex({page_locations: pageLocations})),
+    columnIndex: serializeThrift(
+      new ColumnIndex({
+        null_pages: nullPages,
+        min_values: minValues,
+        max_values: maxValues,
+        boundary_order: BoundaryOrder.UNORDERED,
+        null_counts: nullCounts
+      })
+    )
+  };
+}
+
+function isPageIndexPhysicalType(
+  physicalType: ParquetField['primitiveType']
+): physicalType is PageIndexPhysicalType {
+  return (
+    physicalType === 'BOOLEAN' ||
+    physicalType === 'INT32' ||
+    physicalType === 'INT64' ||
+    physicalType === 'FLOAT' ||
+    physicalType === 'DOUBLE' ||
+    physicalType === 'BYTE_ARRAY' ||
+    physicalType === 'FIXED_LEN_BYTE_ARRAY'
+  );
+}
+
+type PageIndexPhysicalType =
+  | 'BOOLEAN'
+  | 'INT32'
+  | 'INT64'
+  | 'FLOAT'
+  | 'DOUBLE'
+  | 'BYTE_ARRAY'
+  | 'FIXED_LEN_BYTE_ARRAY';
+
+function getPageBounds(
+  values: ParquetColumnChunk['values'],
+  physicalType: PageIndexPhysicalType,
+  typeLength?: number
+): {min: Uint8Array; max: Uint8Array} | undefined {
+  const normalizedValues = Array.from(values as Iterable<unknown>, value =>
+    normalizePageIndexValue(value, physicalType)
+  );
+  if (normalizedValues.some(value => value === undefined)) return undefined;
+  const comparableValues = normalizedValues as Array<
+    boolean | number | bigint | string | Uint8Array
+  >;
+  let min = comparableValues[0];
+  let max = comparableValues[0];
+  for (const value of comparableValues.slice(1)) {
+    if (comparePageIndexValues(value, min, physicalType) < 0) min = value;
+    if (comparePageIndexValues(value, max, physicalType) > 0) max = value;
+  }
+  try {
+    return {
+      min: encodeParquetBloomFilterValue(min, physicalType, typeLength),
+      max: encodeParquetBloomFilterValue(max, physicalType, typeLength)
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizePageIndexValue(
+  value: unknown,
+  physicalType: PageIndexPhysicalType
+): boolean | number | bigint | string | Uint8Array | undefined {
+  if (physicalType === 'BYTE_ARRAY' || physicalType === 'FIXED_LEN_BYTE_ARRAY') {
+    if (typeof value === 'string') return new TextEncoder().encode(value);
+    if (value instanceof ArrayBuffer) return new Uint8Array(value);
+    if (ArrayBuffer.isView(value)) {
+      return new Uint8Array(value.buffer, value.byteOffset, value.byteLength).slice();
+    }
+    return undefined;
+  }
+  if (
+    typeof value === 'boolean' ||
+    typeof value === 'number' ||
+    typeof value === 'bigint' ||
+    typeof value === 'string'
+  ) {
+    return value;
+  }
+  return undefined;
+}
+
+function comparePageIndexValues(
+  left: boolean | number | bigint | string | Uint8Array,
+  right: boolean | number | bigint | string | Uint8Array,
+  physicalType: PageIndexPhysicalType
+): number {
+  if (physicalType === 'BYTE_ARRAY' || physicalType === 'FIXED_LEN_BYTE_ARRAY') {
+    const leftBytes = typeof left === 'string' ? new TextEncoder().encode(left) : left;
+    const rightBytes = typeof right === 'string' ? new TextEncoder().encode(right) : right;
+    if (!(leftBytes instanceof Uint8Array) || !(rightBytes instanceof Uint8Array)) return 0;
+    const length = Math.min(leftBytes.length, rightBytes.length);
+    for (let index = 0; index < length; index++) {
+      if (leftBytes[index] !== rightBytes[index]) {
+        return leftBytes[index] < rightBytes[index] ? -1 : 1;
+      }
+    }
+    return leftBytes.length - rightBytes.length;
+  }
+  if (typeof left === 'boolean' && typeof right === 'boolean') return Number(left) - Number(right);
+  if (physicalType !== 'INT64') {
+    const leftNumber = Number(left);
+    const rightNumber = Number(right);
+    return leftNumber < rightNumber ? -1 : leftNumber > rightNumber ? 1 : 0;
+  }
+  try {
+    const leftNumber = BigInt(left as number | bigint | string);
+    const rightNumber = BigInt(right as number | bigint | string);
+    return leftNumber < rightNumber ? -1 : leftNumber > rightNumber ? 1 : 0;
+  } catch {
+    const leftNumber = Number(left);
+    const rightNumber = Number(right);
+    return leftNumber < rightNumber ? -1 : leftNumber > rightNumber ? 1 : 0;
+  }
 }
 
 /** Builds a Bloom filter for writer-supported physical scalar columns. */
@@ -821,7 +1026,17 @@ async function encodeRowGroup(
 
     const cchunk = new ColumnChunk({
       file_offset: int64(cchunkData.metadataOffset),
-      meta_data: cchunkData.metadata
+      meta_data: cchunkData.metadata,
+      offset_index_offset:
+        cchunkData.offsetIndexOffset === undefined
+          ? undefined
+          : int64(cchunkData.offsetIndexOffset),
+      offset_index_length: cchunkData.offsetIndexLength,
+      column_index_offset:
+        cchunkData.columnIndexOffset === undefined
+          ? undefined
+          : int64(cchunkData.columnIndexOffset),
+      column_index_length: cchunkData.columnIndexLength
     });
 
     metadata.columns.push(cchunk);

--- a/modules/parquet/test/parquet-dataset-source.spec.ts
+++ b/modules/parquet/test/parquet-dataset-source.spec.ts
@@ -125,6 +125,26 @@ describe('ParquetDatasetSource', () => {
     await source.close();
   });
 
+  test('builds logical explanation from effective child defaults', async () => {
+    const source = new ParquetDatasetSource([{data: westernFile}], {
+      core: {worker: false},
+      parquet: {
+        columns: ['value'],
+        predicate: {op: '=', args: [{property: 'id'}, 1]},
+        limit: 1
+      }
+    });
+    const plan = await source.getScanPlan();
+    expect(plan.outputColumns).toEqual(['value']);
+    expect(plan.requiredColumns).toEqual(['id', 'value']);
+    expect(plan.plan).toContainEqual({
+      kind: 'filter',
+      predicate: {op: '=', args: [{property: 'id'}, 1]}
+    });
+    expect(plan.plan).toContainEqual({kind: 'limit', limit: 1});
+    await source.close();
+  });
+
   test('emits the first file while lazy discovery of later files is blocked', async () => {
     let releaseDiscovery: (() => void) | undefined;
     const discoveryBlocked = new Promise<void>(resolve => {

--- a/modules/parquet/test/parquet-dataset-source.spec.ts
+++ b/modules/parquet/test/parquet-dataset-source.spec.ts
@@ -145,6 +145,25 @@ describe('ParquetDatasetSource', () => {
     await source.close();
   });
 
+  test('applies a constructor Parquet limit once across the dataset', async () => {
+    const source = new ParquetDatasetSource(
+      [{data: westernFile}, {data: easternFile}],
+      {core: {worker: false}, parquet: {limit: 1}}
+    );
+
+    const plan = await source.getScanPlan({columns: ['value']});
+    expect(plan.plan).toContainEqual({kind: 'limit', limit: 1});
+    const batches = await collectBatches(source.read({columns: ['value']}));
+    expect(batches.flatMap(batch => [...batch.data.getChild('value')!.toArray()])).toEqual([
+      'west-one'
+    ]);
+    const plannedBatches = await collectBatches(source.executeScanPlan(plan));
+    expect(plannedBatches.flatMap(batch => [...batch.data.getChild('value')!.toArray()])).toEqual([
+      'west-one'
+    ]);
+    await source.close();
+  });
+
   test('emits the first file while lazy discovery of later files is blocked', async () => {
     let releaseDiscovery: (() => void) | undefined;
     const discoveryBlocked = new Promise<void>(resolve => {

--- a/modules/parquet/test/parquet-source-loader.spec.ts
+++ b/modules/parquet/test/parquet-source-loader.spec.ts
@@ -250,6 +250,53 @@ test('ParquetJSWriter emits opt-in Bloom filters consumed by source planning', a
   t.end();
 });
 
+test('ParquetJSWriter emits page indexes consumed by selective page planning', async t => {
+  const parquetBuffer = await encode(
+    {
+      shape: 'object-row-table',
+      schema: {
+        fields: [
+          {name: 'x', type: 'int32', nullable: false},
+          {name: 'payload', type: 'utf8', nullable: false}
+        ],
+        metadata: {}
+      },
+      data: [
+        {x: 0, payload: 'zero'},
+        {x: 1, payload: 'one'},
+        {x: 100, payload: 'hundred'},
+        {x: 101, payload: 'hundred-one'}
+      ]
+    } satisfies ObjectRowTable,
+    ParquetJSWriter,
+    {worker: false, parquet: {pageSize: 2, pageIndex: {x: true}}}
+  );
+  const source = createDataSource(new Blob([parquetBuffer]), [ParquetSourceLoaderWithParser], {
+    core: {type: 'parquet'}
+  }) as ParquetSource;
+  const metadata = await source.getMetadata();
+  const xColumn = metadata.rowGroups[0].columns.find(column => column.path.join('.') === 'x');
+  t.ok(xColumn?.columnIndexOffset !== undefined, 'writes column-index offset');
+  t.ok(xColumn?.offsetIndexOffset !== undefined, 'writes offset-index offset');
+  const plan = await source.getScanPlan({
+    columns: ['payload'],
+    predicate: {op: '>=', args: [{property: 'x'}, 100]}
+  });
+  t.equal(plan.pages.indexesRead, 2, 'reads both page indexes for the predicate column');
+  t.equal(plan.pages.plans[0]?.selectedPages, 1, 'selects only the matching predicate page');
+  t.equal(plan.pages.plans[0]?.totalPages, 2, 'reports all predicate pages');
+  const batches = await collectParquetBatches(
+    source.read({columns: ['payload'], predicate: {op: '>=', args: [{property: 'x'}, 100]}})
+  );
+  t.deepEqual(
+    batches.flatMap(batch => Array.from(batch.data.getChild('payload')?.toArray() || [])),
+    ['hundred', 'hundred-one'],
+    'decodes rows selected by the page index'
+  );
+  await source.close();
+  t.end();
+});
+
 test('ParquetSource#read selects row groups and columns with exact provenance', async (t) => {
   const fixture = await createSelectiveFixture();
   const requests: RangeRequestRecord[] = [];

--- a/modules/parquet/test/parquet-source-loader.spec.ts
+++ b/modules/parquet/test/parquet-source-loader.spec.ts
@@ -207,6 +207,14 @@ test('ParquetSource#getScanPlan shares logical and physical pruning decisions', 
   t.equal(plan.rowGroups.prunedByBloomFilter, 0, 'does not invent Bloom-filter pruning');
   t.equal(plan.plan.at(-1)?.kind, 'limit', 'retains the common logical limit');
   t.ok(Object.isFrozen(plan.rowGroups.indices), 'freezes physical plan selections');
+  t.deepEqual(
+    plan.pages.plans.map(pagePlan => ({phase: pagePlan.phase, columns: pagePlan.columns})),
+    [
+      {phase: 'predicate', columns: [['x']]},
+      {phase: 'projection', columns: [['source_id']]}
+    ],
+    'describes caller-thread late-materialization phases'
+  );
 
   await source.close();
   t.end();

--- a/modules/parquet/test/parquet-source-loader.spec.ts
+++ b/modules/parquet/test/parquet-source-loader.spec.ts
@@ -285,6 +285,15 @@ test('ParquetJSWriter emits page indexes consumed by selective page planning', a
   t.equal(plan.pages.indexesRead, 2, 'reads both page indexes for the predicate column');
   t.equal(plan.pages.plans[0]?.selectedPages, 1, 'selects only the matching predicate page');
   t.equal(plan.pages.plans[0]?.totalPages, 2, 'reports all predicate pages');
+  const emptyPlan = await source.getScanPlan({
+    columns: ['payload'],
+    predicate: {op: '>=', args: [{property: 'x'}, 1000]}
+  });
+  t.deepEqual(
+    emptyPlan.pages.plans.map(pagePlan => pagePlan.phase),
+    ['predicate'],
+    'does not advertise a projection phase after page indexes prove no rows match'
+  );
   const batches = await collectParquetBatches(
     source.read({columns: ['payload'], predicate: {op: '>=', args: [{property: 'x'}, 100]}})
   );


### PR DESCRIPTION
## Goals

- Make Parquet physical scan plans describe the ranges the executor actually fetches.
- Keep dataset-level logical explanations aligned with effective child-source options.
- Continue the scan-planning tranche with explicit late-materialization phases.
- Let the TypeScript writer produce interoperable page indexes for exercising selective scans.

## Changes

- Add `phase` and `columns` to page scan plans.
- Report separate `predicate` and `projection` phases when hidden filter columns trigger late materialization.
- Report complete projected column-chunk ranges for the projection phase instead of advertising ranges that execution does not use.
- Suppress projection ranges when page indexes prove a predicate row group is empty.
- Preserve one row-group count in aggregate page-plan summaries when a row group has multiple phases.
- Build `ParquetDatasetSource` explanations from effective child plans, including constructor defaults and derived GeoParquet covering predicates.
- Apply dataset constructor limits globally and preserve per-file derived predicates when executing cached plans.
- Add opt-in `ParquetJSWriter` page-index output for supported non-repeated scalar columns, including ColumnIndex and OffsetIndex footer references.
- Add writer/source coverage proving generated page indexes prune pages and preserve exact results.
- Document page-index writer support and update the Parquet feature matrix.
- Rebased onto current `master` and addressed all three review conversations.

## Validation

- `yarn lint fix`
- Focused Parquet Chromium tests: 36 passed
- Full Parquet Chromium suite previously: 338 passed, 5 skipped

## Stack

- Base: `master`
