### PR TITLE
feat(examples): reuse metadata-driven scan query panel

### DIFF
--- a/docs/developer-guide/common-scan-architecture.md
+++ b/docs/developer-guide/common-scan-architecture.md
@@ -531,6 +531,34 @@ Every executor of the portable query should share behavioral tests for:
 Format-owning modules should add exhaustive pruning and correctness tests. Wrapper modules should
 retain only focused public-entrypoint conformance tests.
 
+## Reusing the scan query panel
+
+Examples and applications should let the source describe its controls instead of maintaining a
+format-specific list of column names. A compatible source exposes `getQueryMetadata()` before the
+first data request:
+
+```ts
+const metadata = await source.getQueryMetadata();
+```
+
+The returned schema and capability descriptors drive the shared `ScanQueryPanel` used by the
+documentation examples. The panel currently exposes three source-neutral controls:
+
+- output-column projection, populated from `metadata.columns`;
+- a global row limit, enabled only when the source advertises limit support;
+- a source-coordinate bounding box when `metadata.spatial` and bounds pushdown are available.
+
+The panel emits the same immutable query shape consumed by a source's `query()` or `scan()` method.
+This keeps Iceberg, FlatGeobuf, Arrow, and future COPC/Potree or raster examples visually
+consistent while preserving their physical executors. A source may add a format-specific editor
+alongside the panel—for example, the Iceberg example retains its SQL/predicate editor—without
+duplicating schema discovery or projection/limit controls.
+
+When adding an example, load metadata first, render a loading state, and keep metadata failures
+separate from scan failures. The preview should show bounded Arrow output and explain which work was
+performed (for example, FlatGeobuf packed-R-tree pruning or Iceberg manifest planning), rather than
+silently converting the result to an unrelated object format.
+
 ## Evolution rules
 
 New logical operators should be added only when there is a real execution strategy and a clear

--- a/modules/parquet/src/iceberg-table-source.ts
+++ b/modules/parquet/src/iceberg-table-source.ts
@@ -3,7 +3,15 @@
 // Copyright (c) vis.gl contributors
 
 import type {CoreAPI} from '@loaders.gl/loader-utils';
-import {DataSource as BaseDataSource, validateTableQueryLimit} from '@loaders.gl/loader-utils';
+import {
+  createScanQueryMetadata,
+  DataSource as BaseDataSource,
+  validateTableQueryLimit,
+  type ScanColumnRole,
+  type ScanQueryMetadata,
+  type ScanQueryMetadataOptions
+} from '@loaders.gl/loader-utils';
+import type {Schema} from '@loaders.gl/schema';
 import * as arrow from 'apache-arrow';
 
 import type {
@@ -89,6 +97,38 @@ export class IcebergTableSource extends BaseDataSource<string, IcebergSourceOpti
       this.metadataPromise = this.loadMetadata(signal);
     }
     return this.metadataPromise;
+  }
+
+  /** Discovers the current snapshot schema and scan capabilities without decoding table rows. */
+  async getQueryMetadata(options: ScanQueryMetadataOptions = {}): Promise<ScanQueryMetadata> {
+    this.assertOpen();
+    await this.getMetadata(options.signal);
+    const plan = await this.getScanPlan(options.signal);
+    let schema: Schema;
+    if (plan.dataFiles.length > 0) {
+      const parquetSource = new ParquetDatasetSource(
+        [{data: plan.dataFiles[0].data, id: plan.dataFiles[0].data}],
+        this.options,
+        this.coreApi
+      );
+      try {
+        schema = await parquetSource.getSchema({signal: options.signal});
+      } finally {
+        await parquetSource.close();
+      }
+    } else {
+      schema = {fields: [], metadata: {}};
+    }
+    const rowCount = plan.dataFiles.reduce((total, file) => total + (file.recordCount || 0), 0);
+    return createScanQueryMetadata({
+      sourceType: 'iceberg',
+      queryType: 'table',
+      name: this.data,
+      schema,
+      capabilities: {table: this.tableQueryCapabilities},
+      columnRoles: getIcebergColumnRoles(schema),
+      statistics: {rowCount}
+    });
   }
 
   /** Returns the snapshot selected by the table metadata, if one exists. */
@@ -966,4 +1006,27 @@ function combineAbortSignals(
     signal: controller.signal,
     dispose: () => signals.forEach(candidate => candidate.removeEventListener('abort', abort))
   };
+}
+
+function getIcebergColumnRoles(schema: Schema): Record<string, ScanColumnRole> {
+  const roles: Record<string, ScanColumnRole> = {};
+  for (const field of schema.fields) {
+    const normalizedName = field.name.toLowerCase();
+    if (normalizedName === 'geometry' || normalizedName === 'geom' || normalizedName === 'shape') {
+      roles[field.name] = 'geometry';
+    } else if (
+      normalizedName === 'longitude' ||
+      normalizedName === 'lon' ||
+      normalizedName === 'x'
+    ) {
+      roles[field.name] = 'longitude';
+    } else if (
+      normalizedName === 'latitude' ||
+      normalizedName === 'lat' ||
+      normalizedName === 'y'
+    ) {
+      roles[field.name] = 'latitude';
+    }
+  }
+  return roles;
 }

--- a/modules/parquet/src/iceberg-table-source.ts
+++ b/modules/parquet/src/iceberg-table-source.ts
@@ -11,7 +11,7 @@ import {
   type ScanQueryMetadata,
   type ScanQueryMetadataOptions
 } from '@loaders.gl/loader-utils';
-import type {Schema} from '@loaders.gl/schema';
+import type {DataType, Schema} from '@loaders.gl/schema';
 import * as arrow from 'apache-arrow';
 
 import type {
@@ -102,7 +102,7 @@ export class IcebergTableSource extends BaseDataSource<string, IcebergSourceOpti
   /** Discovers the current snapshot schema and scan capabilities without decoding table rows. */
   async getQueryMetadata(options: ScanQueryMetadataOptions = {}): Promise<ScanQueryMetadata> {
     this.assertOpen();
-    await this.getMetadata(options.signal);
+    const tableMetadata = await this.getMetadata(options.signal);
     const plan = await this.getScanPlan(options.signal);
     let schema: Schema;
     if (plan.dataFiles.length > 0) {
@@ -117,7 +117,12 @@ export class IcebergTableSource extends BaseDataSource<string, IcebergSourceOpti
         await parquetSource.close();
       }
     } else {
-      schema = {fields: [], metadata: {}};
+      const snapshot = await this.getCurrentSnapshot(options.signal);
+      const schemaId = snapshot?.['schema-id'] ?? tableMetadata['current-schema-id'];
+      const icebergSchema = tableMetadata.schemas?.find(
+        candidate => candidate['schema-id'] === schemaId
+      );
+      schema = createSchemaFromIcebergMetadata(icebergSchema);
     }
     const rowCount = plan.dataFiles.reduce((total, file) => total + (file.recordCount || 0), 0);
     return createScanQueryMetadata({
@@ -1029,4 +1034,52 @@ function getIcebergColumnRoles(schema: Schema): Record<string, ScanColumnRole> {
     }
   }
   return roles;
+}
+
+function createSchemaFromIcebergMetadata(
+  icebergSchema: NonNullable<IcebergTableMetadata['schemas']>[number] | undefined
+): Schema {
+  return {
+    fields: (icebergSchema?.fields || []).flatMap(field => {
+      const name = typeof field.name === 'string' ? field.name : undefined;
+      if (!name) return [];
+      return [
+        {
+          name,
+          type: getIcebergDataType(field.type),
+          nullable: field.required !== true,
+          metadata: {}
+        }
+      ];
+    }),
+    metadata: {}
+  };
+}
+
+function getIcebergDataType(type: unknown): DataType {
+  switch (typeof type === 'string' ? type.toLowerCase() : '') {
+    case 'boolean':
+      return 'bool';
+    case 'int':
+      return 'int32';
+    case 'long':
+      return 'int64';
+    case 'float':
+      return 'float32';
+    case 'double':
+      return 'float64';
+    case 'date':
+      return 'date-day';
+    case 'time':
+      return 'time-microsecond';
+    case 'timestamp':
+    case 'timestamptz':
+      return 'timestamp-microsecond';
+    case 'binary':
+    case 'fixed':
+      return 'binary';
+    case 'string':
+    default:
+      return 'utf8';
+  }
 }

--- a/modules/parquet/src/parquet-source-loader.ts
+++ b/modules/parquet/src/parquet-source-loader.ts
@@ -7,9 +7,15 @@ import type {CoreAPI, ReadableFile, SourceLoader} from '@loaders.gl/loader-utils
 import {
   BlobFile,
   DataSource,
+  createScanQueryMetadata,
   explainTableQuery,
   isBrowser,
   validateTableQueryLimit
+} from '@loaders.gl/loader-utils';
+import type {
+  ScanColumnRole,
+  ScanQueryMetadata,
+  ScanQueryMetadataOptions
 } from '@loaders.gl/loader-utils';
 import type {ArrayType, ArrowTable, Schema} from '@loaders.gl/schema';
 import {convertTable} from '@loaders.gl/schema-utils';
@@ -265,6 +271,23 @@ export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoader
       ...initialization.metadata,
       formatSpecificMetadata: initialization.fileMetadata
     };
+  }
+
+  /** Discovers schema, capabilities, and footer statistics without decoding Parquet data pages. */
+  async getQueryMetadata(options: ScanQueryMetadataOptions = {}): Promise<ScanQueryMetadata> {
+    const [schema, metadata] = await Promise.all([
+      this.getSchema({signal: options.signal}),
+      this.getMetadata({signal: options.signal})
+    ]);
+    return createScanQueryMetadata({
+      sourceType: 'parquet',
+      queryType: 'table',
+      name: metadata.name,
+      schema,
+      capabilities: {table: this.tableQueryCapabilities},
+      columnRoles: getParquetColumnRoles(schema.fields.map(field => field.name)),
+      statistics: {rowCount: metadata.rowCount, byteLength: metadata.fileByteLength}
+    });
   }
 
   /** Plans a portable query using Parquet metadata without decoding data pages. */
@@ -1106,6 +1129,29 @@ export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoader
       // Telemetry must never change source read behavior.
     }
   }
+}
+
+function getParquetColumnRoles(columnNames: readonly string[]): Record<string, ScanColumnRole> {
+  const roles: Record<string, ScanColumnRole> = {};
+  for (const columnName of columnNames) {
+    const normalizedName = columnName.toLowerCase();
+    if (normalizedName === 'geometry' || normalizedName === 'geom' || normalizedName === 'shape') {
+      roles[columnName] = 'geometry';
+    } else if (
+      normalizedName === 'longitude' ||
+      normalizedName === 'lon' ||
+      normalizedName === 'x'
+    ) {
+      roles[columnName] = 'longitude';
+    } else if (
+      normalizedName === 'latitude' ||
+      normalizedName === 'lat' ||
+      normalizedName === 'y'
+    ) {
+      roles[columnName] = 'latitude';
+    }
+  }
+  return roles;
 }
 
 /** Normalizes a decoded Parquet footer into source metadata. */

--- a/modules/parquet/test/iceberg-table-source.cross.spec.ts
+++ b/modules/parquet/test/iceberg-table-source.cross.spec.ts
@@ -61,19 +61,58 @@ test('IcebergTableSource exposes the declared schema for an empty snapshot', asy
       'format-version': 2,
       location: 'table',
       'current-snapshot-id': -1,
-      'current-schema-id': 7,
-      schemas: [{
-        'schema-id': 7,
-        fields: [
+        'current-schema-id': 7,
+        schemas: [{
+          'schema-id': 7,
+          fields: [
+          {name: 'flag', type: 'boolean', required: true},
+          {name: 'count', type: 'int', required: true},
           {name: 'id', type: 'long', required: true},
-          {name: 'label', type: 'string', required: false}
+          {name: 'ratio', type: 'float', required: false},
+          {name: 'score', type: 'double', required: false},
+          {name: 'day', type: 'date', required: false},
+          {name: 'clock', type: 'time', required: false},
+          {name: 'created', type: 'timestamp', required: false},
+          {name: 'updated', type: 'timestamptz', required: false},
+          {name: 'payload', type: 'binary', required: false},
+          {name: 'fixed', type: 'fixed', required: false},
+          {name: 'label', type: 'string', required: false},
+          {name: 'other', type: {type: 'list'}, required: false}
         ]
       }]
     })
   );
   const metadata = await source.getQueryMetadata();
-  expect(metadata.columns.map(column => column.name)).toEqual(['id', 'label']);
-  expect(metadata.columns[0].type).toBe('int64');
+  expect(metadata.columns.map(column => column.name)).toEqual([
+    'flag',
+    'count',
+    'id',
+    'ratio',
+    'score',
+    'day',
+    'clock',
+    'created',
+    'updated',
+    'payload',
+    'fixed',
+    'label',
+    'other'
+  ]);
+  expect(metadata.columns.map(column => column.type)).toEqual([
+    'bool',
+    'int32',
+    'int64',
+    'float32',
+    'float64',
+    'date-day',
+    'time-microsecond',
+    'timestamp-microsecond',
+    'timestamp-microsecond',
+    'binary',
+    'binary',
+    'utf8',
+    'utf8'
+  ]);
   await source.close();
 });
 

--- a/modules/parquet/test/iceberg-table-source.cross.spec.ts
+++ b/modules/parquet/test/iceberg-table-source.cross.spec.ts
@@ -55,6 +55,28 @@ test('IcebergTableSource supports tables without a current snapshot', async () =
   await expect(source.getCurrentSnapshot()).resolves.toBeUndefined();
 });
 
+test('IcebergTableSource exposes the declared schema for an empty snapshot', async () => {
+  const source = new IcebergTableSource(
+    createMetadataUrl({
+      'format-version': 2,
+      location: 'table',
+      'current-snapshot-id': -1,
+      'current-schema-id': 7,
+      schemas: [{
+        'schema-id': 7,
+        fields: [
+          {name: 'id', type: 'long', required: true},
+          {name: 'label', type: 'string', required: false}
+        ]
+      }]
+    })
+  );
+  const metadata = await source.getQueryMetadata();
+  expect(metadata.columns.map(column => column.name)).toEqual(['id', 'label']);
+  expect(metadata.columns[0].type).toBe('int64');
+  await source.close();
+});
+
 test('IcebergTableSource scans an empty current snapshot through the dataset source', async () => {
   const source = new IcebergTableSource(
     createMetadataUrl({

--- a/modules/parquet/test/parquet-source-loader.spec.ts
+++ b/modules/parquet/test/parquet-source-loader.spec.ts
@@ -103,6 +103,19 @@ test('ParquetSourceLoader#Blob metadata and schema are cached', async (t) => {
   t.end();
 });
 
+test('ParquetSource#getQueryMetadata exposes panel-ready schema and statistics', async t => {
+  const fixture = await loadFixture();
+  const source = (await load(new Blob([fixture]), ParquetSourceLoader)) as ParquetSource;
+  const metadata = await source.getQueryMetadata();
+
+  t.equal(metadata.sourceType, 'parquet', 'identifies the source adapter');
+  t.equal(metadata.queryType, 'table', 'identifies the query family');
+  t.ok(metadata.columns.length > 0, 'discovers selectable columns');
+  t.equal(metadata.capabilities.table?.projection, 'pushdown', 'reports projection pushdown');
+  t.ok(Number(metadata.statistics?.rowCount) > 0, 'reports footer row count');
+  await source.close();
+});
+
 test('ParquetSource#preserves opaque WASM inputs by identity', async (t) => {
   const wasmUrl = Promise.resolve(new URL('https://example.com/parquet_wasm_bg.wasm'));
   const source = new ParquetSource(new Blob(), {parquet: {wasmUrl}});

--- a/website/package.json
+++ b/website/package.json
@@ -40,6 +40,7 @@
     "@loaders.gl/csv": "workspace:*",
     "@loaders.gl/deck-layers": "workspace:*",
     "@loaders.gl/excel": "workspace:*",
+    "@loaders.gl/flatgeobuf": "workspace:*",
     "@loaders.gl/geopackage": "workspace:*",
     "@loaders.gl/i3s": "workspace:*",
     "@loaders.gl/json": "workspace:*",

--- a/website/src/components/docs/flatgeobuf-scan-live-example.tsx
+++ b/website/src/components/docs/flatgeobuf-scan-live-example.tsx
@@ -1,0 +1,99 @@
+import React, {useEffect, useState} from 'react';
+import type {FlatGeobufReadOptions} from '@loaders.gl/flatgeobuf';
+import type {ArrowTable} from '@loaders.gl/schema';
+import {FlatGeobufVectorSource} from '@loaders.gl/flatgeobuf';
+import type {ScanQueryMetadata} from '@loaders.gl/loader-utils';
+import {ScanQueryPanel, type ScanQueryPanelState} from './scan-query-panel';
+
+type FlatGeobufDemoState = Readonly<{
+  metadata?: ScanQueryMetadata;
+  table?: ArrowTable;
+  error?: string;
+  loading: boolean;
+}>;
+
+const DEFAULT_FLATGEOBUF_URL =
+  'https://raw.githubusercontent.com/visgl/loaders.gl/master/modules/flatgeobuf/test/data/countries.fgb';
+
+/** Demonstrates metadata-driven projection, limit, and bbox controls over FlatGeobuf. */
+export function FlatGeobufScanLiveExample(): JSX.Element {
+  const [url, setUrl] = useState(DEFAULT_FLATGEOBUF_URL);
+  const [query, setQuery] = useState<ScanQueryPanelState>({});
+  const [submittedQuery, setSubmittedQuery] = useState<ScanQueryPanelState>({});
+  const [state, setState] = useState<FlatGeobufDemoState>({loading: true});
+
+  useEffect(() => {
+    let mounted = true;
+    const source = new FlatGeobufVectorSource(url, {flatgeobuf: {format: 'arrow'}});
+    setState({loading: true});
+    void (async () => {
+      try {
+        const metadata = await source.getQueryMetadata();
+        const options: FlatGeobufReadOptions = {
+          columns: submittedQuery.columns,
+          limit: submittedQuery.limit,
+          boundingBox: submittedQuery.boundingBox
+        };
+        const table = await source.query(options);
+        if (mounted) setState({metadata, table, loading: false});
+      } catch (error) {
+        if (mounted) setState({loading: false, error: error instanceof Error ? error.message : String(error)});
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [url, submittedQuery]);
+
+  return (
+    <div>
+      <label htmlFor="flatgeobuf-scan-url">FlatGeobuf URL</label>
+      <input
+        id="flatgeobuf-scan-url"
+        style={{display: 'block', width: '100%', margin: '6px 0', padding: 7}}
+        value={url}
+        onChange={event => setUrl(event.target.value)}
+      />
+      <ScanQueryPanel
+        metadata={state.metadata}
+        loading={state.loading}
+        value={query}
+        onApply={nextQuery => {
+          setQuery(nextQuery);
+          setSubmittedQuery(nextQuery);
+        }}
+        title="FlatGeobuf scan parameters"
+      />
+      {state.error ? <p role="alert">{state.error}</p> : null}
+      {state.table ? <FlatGeobufPreview table={state.table} /> : null}
+    </div>
+  );
+}
+
+function FlatGeobufPreview({table}: {table: ArrowTable}): JSX.Element {
+  const columns = table.schema.fields.map(field => field.name);
+  const rowCount = Math.min(table.data.numRows, 5);
+  return (
+    <div style={{overflowX: 'auto'}}>
+      <p>
+        <strong>Arrow result:</strong> {table.data.numRows} rows · {columns.length} columns
+      </p>
+      <table>
+        <thead><tr>{columns.map(column => <th key={column}>{column}</th>)}</tr></thead>
+        <tbody>
+          {Array.from({length: rowCount}, (_, rowIndex) => (
+            <tr key={rowIndex}>
+              {columns.map(column => <td key={column}>{formatCell(table.data.getChild(column)?.get(rowIndex))}</td>)}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function formatCell(value: unknown): string {
+  if (value === null || value === undefined) return '—';
+  if (typeof value === 'object') return '[value]';
+  return String(value);
+}

--- a/website/src/components/docs/flatgeobuf-scan-live-example.tsx
+++ b/website/src/components/docs/flatgeobuf-scan-live-example.tsx
@@ -33,6 +33,11 @@ export function FlatGeobufScanLiveExample(): JSX.Element {
           columns: submittedQuery.columns,
           limit: submittedQuery.limit,
           boundingBox: submittedQuery.boundingBox
+            ? [
+                [submittedQuery.boundingBox[0], submittedQuery.boundingBox[1]],
+                [submittedQuery.boundingBox[2], submittedQuery.boundingBox[3]]
+              ]
+            : undefined
         };
         const table = await source.query(options);
         if (mounted) setState({metadata, table, loading: false});

--- a/website/src/components/docs/iceberg-scan-live-example.tsx
+++ b/website/src/components/docs/iceberg-scan-live-example.tsx
@@ -2,7 +2,9 @@ import React, {useEffect, useState} from 'react';
 import styled from 'styled-components';
 import type {Table as ArrowTable} from 'apache-arrow';
 import type {ParquetPredicate} from '@loaders.gl/parquet';
+import type {ScanQueryMetadata} from '@loaders.gl/loader-utils';
 import {ExampleUrlInputCard, type UrlOption} from 'examples/website/shared/url-input-card';
+import {ScanQueryPanel, type ScanQueryPanelState} from './scan-query-panel';
 
 type IcebergDemoState = {
   /** Current stage reached by the browser demo. */
@@ -70,6 +72,9 @@ export function IcebergScanLiveExample(): JSX.Element {
   const [astText, setAstText] = useState(DEFAULT_PREDICATE_AST);
   const [sqlText, setSqlText] = useState(DEFAULT_SQL);
   const [submittedAst, setSubmittedAst] = useState(DEFAULT_PREDICATE_AST);
+  const [queryMetadata, setQueryMetadata] = useState<ScanQueryMetadata>();
+  const [queryState, setQueryState] = useState<ScanQueryPanelState>({});
+  const [submittedQueryState, setSubmittedQueryState] = useState<ScanQueryPanelState>({});
   const [state, setState] = useState<IcebergDemoState>({
     stage: 'loading',
     filesSelected: 0,
@@ -86,6 +91,8 @@ export function IcebergScanLiveExample(): JSX.Element {
         const source = new IcebergTableSource(metadataUrl, {
           core: {loadOptions: {core: {fetch: fetchWithExposedContentRange}}, worker: false}
         });
+        const metadata = await source.getQueryMetadata();
+        if (isMounted) setQueryMetadata(metadata);
         const predicate = parsePredicateAst(submittedAst);
         const plan = await source.getScanPlan();
         if (isMounted) {
@@ -95,7 +102,9 @@ export function IcebergScanLiveExample(): JSX.Element {
         let preview: IcebergTablePreview | undefined;
         for await (const batch of source.scan({
           core: {worker: false},
-          predicate
+          predicate,
+          columns: submittedQueryState.columns,
+          limit: submittedQueryState.limit
         })) {
           preview ||= createIcebergTablePreview(batch.data);
           rowsScanned += batch.length;
@@ -126,7 +135,7 @@ export function IcebergScanLiveExample(): JSX.Element {
     return () => {
       isMounted = false;
     };
-  }, [selectedTableUrl, submittedAst]);
+  }, [selectedTableUrl, submittedAst, submittedQueryState]);
 
   return (
     <ExampleFrame aria-label="Live Iceberg scan example">
@@ -216,6 +225,16 @@ export function IcebergScanLiveExample(): JSX.Element {
           WHERE column operator value; Run applies the predicate to Iceberg and Parquet.
         </QueryHint>
       </QueryForm>
+      <ScanQueryPanel
+        metadata={queryMetadata}
+        loading={state.stage === 'loading' && !queryMetadata}
+        value={queryState}
+        onApply={nextQuery => {
+          setQueryState(nextQuery);
+          setSubmittedQueryState(nextQuery);
+        }}
+        title="Iceberg scan parameters"
+      />
       {state.stage === 'failed' ? (
         <ErrorMessage>{state.error}</ErrorMessage>
       ) : (

--- a/website/src/components/docs/parquet-scan-live-example.tsx
+++ b/website/src/components/docs/parquet-scan-live-example.tsx
@@ -1,0 +1,79 @@
+import React, {useEffect, useState} from 'react';
+import type {ParquetSource} from '@loaders.gl/parquet';
+import type {ArrowTable} from '@loaders.gl/schema';
+import type {ScanQueryMetadata} from '@loaders.gl/loader-utils';
+import {ScanQueryPanel, type ScanQueryPanelState} from './scan-query-panel';
+
+type ParquetDemoState = Readonly<{
+  metadata?: ScanQueryMetadata;
+  table?: ArrowTable;
+  loading: boolean;
+  error?: string;
+}>;
+
+const DEFAULT_PARQUET_URL =
+  'https://raw.githubusercontent.com/visgl/loaders.gl/master/modules/parquet/test/data/geoparquet/airports.parquet';
+
+/** Demonstrates the shared scan panel on a standalone range-readable Parquet file. */
+export function ParquetScanLiveExample(): JSX.Element {
+  const [url, setUrl] = useState(DEFAULT_PARQUET_URL);
+  const [query, setQuery] = useState<ScanQueryPanelState>({});
+  const [submittedQuery, setSubmittedQuery] = useState<ScanQueryPanelState>({});
+  const [state, setState] = useState<ParquetDemoState>({loading: true});
+
+  useEffect(() => {
+    let mounted = true;
+    void (async () => {
+      try {
+        const {ParquetSource} = await import('@loaders.gl/parquet');
+        const source = new ParquetSource(url, {parquet: {worker: false}}) as ParquetSource;
+        const metadata = await source.getQueryMetadata();
+        let table: ArrowTable | undefined;
+        for await (const batch of source.read({
+          columns: submittedQuery.columns,
+          limit: submittedQuery.limit,
+          signal: undefined
+        })) {
+          table = batch.data;
+          break;
+        }
+        await source.close();
+        if (mounted) setState({metadata, table, loading: false});
+      } catch (error) {
+        if (mounted) setState({loading: false, error: error instanceof Error ? error.message : String(error)});
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [url, submittedQuery]);
+
+  return (
+    <div>
+      <label htmlFor="parquet-scan-url">Parquet URL</label>
+      <input
+        id="parquet-scan-url"
+        style={{display: 'block', width: '100%', margin: '6px 0', padding: 7}}
+        value={url}
+        onChange={event => setUrl(event.target.value)}
+      />
+      <ScanQueryPanel
+        metadata={state.metadata}
+        loading={state.loading}
+        value={query}
+        onApply={nextQuery => {
+          setQuery(nextQuery);
+          setSubmittedQuery(nextQuery);
+        }}
+        title="Parquet scan parameters"
+      />
+      {state.error ? <p role="alert">{state.error}</p> : null}
+      {state.table ? <ParquetPreview table={state.table} /> : null}
+    </div>
+  );
+}
+
+function ParquetPreview({table}: {table: ArrowTable}): JSX.Element {
+  const columns = table.schema.fields.map(field => field.name);
+  return <p><strong>Arrow result:</strong> {table.data.numRows} rows · {columns.length} columns ({columns.join(', ')})</p>;
+}

--- a/website/src/components/docs/scan-query-panel.tsx
+++ b/website/src/components/docs/scan-query-panel.tsx
@@ -49,7 +49,11 @@ export function ScanQueryPanel({
   const sourceBounds = metadata?.spatial?.bounds;
   const toggleColumn = (name: string): void => {
     setSelectedColumns(current =>
-      current.includes(name) ? current.filter(column => column !== name) : [...current, name]
+      current.length === 0
+        ? columns.map(column => column.name).filter(column => column !== name)
+        : current.includes(name)
+          ? current.filter(column => column !== name)
+          : [...current, name]
     );
   };
 

--- a/website/src/components/docs/scan-query-panel.tsx
+++ b/website/src/components/docs/scan-query-panel.tsx
@@ -1,0 +1,229 @@
+import React, {useEffect, useState} from 'react';
+import styled from 'styled-components';
+import type {ScanQueryMetadata} from '@loaders.gl/loader-utils';
+
+/** State emitted by the reusable scan-query controls. */
+export type ScanQueryPanelState = Readonly<{
+  /** Output columns; an empty selection means all columns. */
+  columns?: readonly string[];
+  /** Maximum number of rows to return. */
+  limit?: number;
+  /** Optional source-coordinate bounding box in minX, minY, maxX, maxY order. */
+  boundingBox?: readonly [number, number, number, number];
+}>;
+
+/** Props for a source-neutral query-parameter panel. */
+export type ScanQueryPanelProps = Readonly<{
+  /** Metadata discovered from the active source. */
+  metadata?: ScanQueryMetadata;
+  /** Whether metadata discovery is still in progress. */
+  loading?: boolean;
+  /** Current query values to show in the controls. */
+  value?: ScanQueryPanelState;
+  /** Called when the user submits the panel. */
+  onApply: (value: ScanQueryPanelState) => void;
+  /** Optional label shown above the controls. */
+  title?: string;
+}>;
+
+/** Renders schema-driven projection, limit, and spatial controls for compatible scan sources. */
+export function ScanQueryPanel({
+  metadata,
+  loading = false,
+  value,
+  onApply,
+  title = 'Scan query'
+}: ScanQueryPanelProps): JSX.Element {
+  const [selectedColumns, setSelectedColumns] = useState<string[]>(value?.columns ? [...value.columns] : []);
+  const [limitText, setLimitText] = useState(value?.limit === undefined ? '' : String(value.limit));
+  const [boundingBoxText, setBoundingBoxText] = useState('');
+
+  useEffect(() => {
+    setSelectedColumns(value?.columns ? [...value.columns] : []);
+    setLimitText(value?.limit === undefined ? '' : String(value.limit));
+  }, [value]);
+
+  const columns = metadata?.columns || [];
+  const hasLimit = metadata?.capabilities.table?.limit && metadata.capabilities.table.limit !== 'unsupported';
+  const hasBounds = metadata?.capabilities.bounds && metadata.capabilities.bounds !== 'unsupported';
+  const sourceBounds = metadata?.spatial?.bounds;
+  const toggleColumn = (name: string): void => {
+    setSelectedColumns(current =>
+      current.includes(name) ? current.filter(column => column !== name) : [...current, name]
+    );
+  };
+
+  return (
+    <Panel aria-label={`${title} controls`}>
+      <PanelHeader>
+        <strong>{title}</strong>
+        <PanelHint>
+          {loading ? 'Discovering schema…' : metadata ? `${metadata.sourceType} · ${metadata.queryType}` : 'Select a source'}
+        </PanelHint>
+      </PanelHeader>
+      {metadata ? (
+        <>
+          <MetadataSummary>
+            <span>{columns.length} columns</span>
+            {metadata.statistics?.rowCount !== undefined ? <span>{String(metadata.statistics.rowCount)} rows</span> : null}
+            {metadata.spatial?.coordinateReferenceSystems?.[0] ? (
+              <span>{metadata.spatial.coordinateReferenceSystems[0]}</span>
+            ) : null}
+          </MetadataSummary>
+          <FieldGroup>
+            <FieldLabel>Output columns</FieldLabel>
+            <ColumnGrid>
+              {columns.map(column => (
+                <ColumnOption key={column.name}>
+                  <input
+                    type="checkbox"
+                    checked={selectedColumns.length === 0 || selectedColumns.includes(column.name)}
+                    onChange={() => toggleColumn(column.name)}
+                  />
+                  <span>{column.title || column.name}</span>
+                  <ColumnType>{column.role}</ColumnType>
+                </ColumnOption>
+              ))}
+            </ColumnGrid>
+            <FieldHint>Leave every column selected to preserve the source projection.</FieldHint>
+          </FieldGroup>
+          <InlineFields>
+            {hasLimit ? (
+              <FieldGroup>
+                <FieldLabel htmlFor="scan-query-limit">Row limit</FieldLabel>
+                <TextInput
+                  id="scan-query-limit"
+                  inputMode="numeric"
+                  min="0"
+                  placeholder="All rows"
+                  value={limitText}
+                  onChange={event => setLimitText(event.target.value)}
+                />
+              </FieldGroup>
+            ) : null}
+            {hasBounds ? (
+              <FieldGroup>
+                <FieldLabel htmlFor="scan-query-bounds">Bounding box</FieldLabel>
+                <TextInput
+                  id="scan-query-bounds"
+                  placeholder={sourceBounds ? formatBounds(sourceBounds) : 'minX,minY,maxX,maxY'}
+                  value={boundingBoxText}
+                  onChange={event => setBoundingBoxText(event.target.value)}
+                />
+              </FieldGroup>
+            ) : null}
+          </InlineFields>
+          <ApplyButton
+            type="button"
+            onClick={() => {
+              const limit = limitText.trim() ? Number(limitText) : undefined;
+              const boundingBox = parseBounds(boundingBoxText);
+              onApply({
+                columns: selectedColumns.length && selectedColumns.length < columns.length ? selectedColumns : undefined,
+                limit: Number.isSafeInteger(limit) && (limit as number) >= 0 ? limit : undefined,
+                boundingBox
+              });
+            }}
+          >
+            Apply scan parameters
+          </ApplyButton>
+        </>
+      ) : (
+        <EmptyState>{loading ? 'Reading source metadata before opening the data…' : 'Metadata will appear here when a source is selected.'}</EmptyState>
+      )}
+    </Panel>
+  );
+}
+
+function parseBounds(value: string): readonly [number, number, number, number] | undefined {
+  const numbers = value.split(',').map(part => Number(part.trim()));
+  return numbers.length === 4 && numbers.every(Number.isFinite) ? [numbers[0], numbers[1], numbers[2], numbers[3]] : undefined;
+}
+
+function formatBounds(bounds: {minimum: readonly number[]; maximum: readonly number[]}): string {
+  return [...bounds.minimum.slice(0, 2), ...bounds.maximum.slice(0, 2)].join(',');
+}
+
+const Panel = styled.section`
+  border: 1px solid #d8dee9;
+  border-radius: 8px;
+  padding: 14px;
+  margin: 14px 0;
+  background: #fbfcfe;
+`;
+const PanelHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+`;
+const PanelHint = styled.span`
+  color: #667085;
+  font-size: 0.82rem;
+`;
+const MetadataSummary = styled.div`
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  color: #475467;
+  font-size: 0.82rem;
+  margin-bottom: 10px;
+`;
+const FieldGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  flex: 1;
+`;
+const FieldLabel = styled.label`
+  font-weight: 600;
+  font-size: 0.82rem;
+`;
+const FieldHint = styled.div`
+  color: #667085;
+  font-size: 0.76rem;
+`;
+const ColumnGrid = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+`;
+const ColumnOption = styled.label`
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border: 1px solid #d0d5dd;
+  border-radius: 5px;
+  padding: 5px 7px;
+  background: white;
+  font-size: 0.82rem;
+`;
+const ColumnType = styled.span`
+  color: #667085;
+  font-size: 0.7rem;
+`;
+const InlineFields = styled.div`
+  display: flex;
+  gap: 12px;
+  margin-top: 12px;
+  flex-wrap: wrap;
+`;
+const TextInput = styled.input`
+  min-width: 180px;
+  border: 1px solid #d0d5dd;
+  border-radius: 5px;
+  padding: 7px;
+`;
+const ApplyButton = styled.button`
+  margin-top: 12px;
+  border: 0;
+  border-radius: 5px;
+  padding: 8px 12px;
+  color: white;
+  background: #475467;
+  cursor: pointer;
+`;
+const EmptyState = styled.div`
+  color: #667085;
+  font-size: 0.84rem;
+`;

--- a/website/src/examples/geospatial/flatgeobuf.mdx
+++ b/website/src/examples/geospatial/flatgeobuf.mdx
@@ -5,11 +5,20 @@ hide_title: true
 
 import {ClientExample} from '../../components';
 import {FlatGeobufDocsTabs} from '@site/src/components/docs/flatgeobuf-docs-tabs';
+import {FlatGeobufScanLiveExample} from '@site/src/components/docs/flatgeobuf-scan-live-example';
 
 <FlatGeobufDocsTabs active="try-it" />
 
 <div style={{height: 'calc(100vh - 76px)'}}> 
-  <ClientExample kind="geospatial" format="FlatGeobuf" >
+<ClientExample kind="geospatial" format="FlatGeobuf" >
     [**`FlatGeobufLoader`**](/docs/modules/flatgeobuf/api-reference/flatgeobuf-loader) loads FlatGeobuf files, optionally into GeoJSON.
-  </ClientExample>
+</ClientExample>
+
+## Query the source
+
+The source adapter can discover its Arrow schema and packed R-tree capabilities before decoding
+features. The shared scan panel uses that metadata to populate projection and spatial controls,
+then returns a bounded Arrow result without materializing GeoJSON.
+
+<FlatGeobufScanLiveExample />
 </div>

--- a/website/src/examples/geospatial/overture-parquet.mdx
+++ b/website/src/examples/geospatial/overture-parquet.mdx
@@ -4,6 +4,7 @@ hide_title: true
 ---
 
 import {ClientExample} from '../../components';
+import {ParquetScanLiveExample} from '@site/src/components/docs/parquet-scan-live-example';
 
 # Overture GeoParquet query in the browser
 
@@ -14,3 +15,11 @@ import {ClientExample} from '../../components';
     Overture's ZSTD pages decode in the Parquet source worker using native `DecompressionStream` support when available and a lightweight JavaScript fallback otherwise.
   </ClientExample>
 </div>
+
+## Query a standalone Parquet file
+
+The same metadata-driven panel also works for a plain range-readable Parquet object. It discovers
+the footer schema and statistics first, then applies projection and limits before Arrow batches are
+returned.
+
+<ParquetScanLiveExample />

--- a/yarn.lock
+++ b/yarn.lock
@@ -28580,6 +28580,7 @@ __metadata:
     "@loaders.gl/csv": "workspace:*"
     "@loaders.gl/deck-layers": "workspace:*"
     "@loaders.gl/excel": "workspace:*"
+    "@loaders.gl/flatgeobuf": "workspace:*"
     "@loaders.gl/geopackage": "workspace:*"
     "@loaders.gl/i3s": "workspace:*"
     "@loaders.gl/json": "workspace:*"


### PR DESCRIPTION
## Goals

- Make the common scan architecture visible and reusable in compatible documentation examples.
- Populate query controls from source-discovered metadata instead of hard-coded columns.
- Continue the roadmap after the merged common-scan PR without replaying stale history.

## Changes

- Add a reusable `ScanQueryPanel` for schema-driven projection, limits, and spatial bounds.
- Add `IcebergTableSource.getQueryMetadata()` using the current snapshot and first Parquet schema.
- Wire the panel into the Iceberg live scan example while retaining its SQL/predicate editor.
- Add a FlatGeobuf live query example showing metadata discovery, packed-R-tree bounds, and Arrow previews.
- Document the panel contract and guidance for future COPC, Potree, raster, and Arrow examples.
- Address the follow-up documentation intent from `codex/common-scan-architecture`; its earlier review fix is already present on master.

## Verification

- `yarn lint fix`
- `yarn build`
- `yarn test-node`
- `cd website && yarn build`
