### PR TITLE
feat(3d-tiles): decode i3dm oct-encoded orientation

### DIFF
--- a/docs/modules/3d-tiles/concepts/implicit-tiling-and-subtrees.md
+++ b/docs/modules/3d-tiles/concepts/implicit-tiling-and-subtrees.md
@@ -107,6 +107,9 @@ The lazy subtree root remains the traversal boundary until its availability requ
 
 Subtree completion does not masquerade as tile-content completion or enter the GPU cache. It updates hierarchy metadata, then the next traversal selects and requests render content normally.
 
+For payload-level compatibility, the [3D Tiles format matrix](../formats/3d-tiles#tile-payloads)
+records i3dm orientation support, including octahedrally encoded instance directions.
+
 ## URLs, Authentication, and Archives
 
 Content and subtree templates are resolved against the tileset base URI during normalization. At request time the source applies the same inherited root, session, and tileset-version query parameters used for tile content; parameters already present on the subtree URI win.

--- a/docs/modules/3d-tiles/formats/3d-tiles.md
+++ b/docs/modules/3d-tiles/formats/3d-tiles.md
@@ -36,6 +36,7 @@ provides a visual implementation for that feature.
 | --- | :---: | --- |
 | `b3dm` batched 3D model | [x] | Batch tables and glTF payloads are exposed. |
 | `i3dm` instanced 3D model | [x] | Instancing metadata is parsed. |
+| i3dm oct-encoded orientation | [x] | `NORMAL_UP_OCT32P` and `NORMAL_RIGHT_OCT32P` are decoded into instance transforms. |
 | `pnts` point cloud | [x] | Draco-compressed point attributes are supported. |
 | `cmpt` composite | [x] | Child payloads are parsed through the composite loader. |
 | `glb` / glTF tile content | [x] | Structure-first content detection supports extensionless resources. |

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -279,6 +279,7 @@ A minor release that includes:
 - **3D Tiles 1.1 Extensions** `EXT_mesh_features` and `EXT_structural_metadata` are now supported.
 - **3D Tiles format compatibility** - Added a checked compatibility matrix covering tileset traversal, tile payloads, extensions, metadata, and known renderer limitations. Multiple explicit contents are normalized, loaded in source order, and exposed through `Tile3D.contents` while preserving the legacy primary `Tile3D.content` field.
 - **Implicit subtree metadata** - Generated implicit-tile headers now preserve subtree property-table and tile/content/subtree metadata references through `implicitMetadata`, without pretending to decode metadata values before structural metadata support is complete.
+- **i3dm orientation** - Instanced 3D Model tiles now decode `NORMAL_UP_OCT32P` and `NORMAL_RIGHT_OCT32P`, including quantized-position fixtures, and use the decoded basis for per-instance transforms.
 - **Transform-correct LOD** Geometric error is scaled conservatively by composed tile and tileset transforms without compounding after runtime updates.
 - **Projection-correct SSE** Orthographic viewports use `metersPerPixel`, while perspective and orthographic traversal consistently use logical pixels without a second device-pixel-ratio correction.
 - **Dynamic SSE** Perspective traversal can reduce distant, horizon-facing refinement with view-dependent density and height falloff while leaving orthographic and I3S LOD behavior unchanged.

--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile-instanced-model.ts
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile-instanced-model.ts
@@ -7,7 +7,7 @@
 
 import {Vector3, Matrix3, Matrix4, Quaternion} from '@math.gl/core';
 import {Ellipsoid} from '@math.gl/geospatial';
-import {GL} from '@loaders.gl/math'; // 'math.gl/geometry';
+import {GL, octDecodeInRange} from '@loaders.gl/math'; // 'math.gl/geometry';
 import Tile3DFeatureTable from '../classes/tile-3d-feature-table';
 import Tile3DBatchTable from '../classes/tile-3d-batch-table';
 
@@ -157,32 +157,37 @@ function extractInstancedAttributes(
     instanceTranslationRotationScale.translation = instancePosition;
 
     // Get the instance rotation
-    tile.normalUp = featureTable.getProperty('NORMAL_UP', GL.FLOAT, 3, i, scratch1);
-    tile.normalRight = featureTable.getProperty('NORMAL_RIGHT', GL.FLOAT, 3, i, scratch2);
+    const normalUp = featureTable.getProperty('NORMAL_UP', GL.FLOAT, 3, i, scratch1);
+    const normalRight = featureTable.getProperty('NORMAL_RIGHT', GL.FLOAT, 3, i, scratch2);
+    tile.normalUp = normalUp;
+    tile.normalRight = normalRight;
 
-    const hasCustomOrientation = false;
-    if (tile.normalUp) {
-      if (!tile.normalRight) {
+    let hasCustomOrientation = false;
+    if (normalUp) {
+      if (!normalRight) {
         throw new Error('i3dm: Custom orientation requires both NORMAL_UP and NORMAL_RIGHT.');
       }
-      // Vector3.unpack(normalUp, 0, instanceNormalUp);
-      // Vector3.unpack(normalRight, 0, instanceNormalRight);
+      instanceNormalUp.copy(normalUp);
+      instanceNormalRight.copy(normalRight);
       tile.hasCustomOrientation = true;
+      hasCustomOrientation = true;
     } else {
-      tile.octNormalUp = featureTable.getProperty(
+      const octNormalUp = featureTable.getProperty(
         'NORMAL_UP_OCT32P',
         GL.UNSIGNED_SHORT,
         2,
         i,
         scratch1
       );
-      tile.octNormalRight = featureTable.getProperty(
+      const octNormalRight = featureTable.getProperty(
         'NORMAL_RIGHT_OCT32P',
         GL.UNSIGNED_SHORT,
         2,
         i,
         scratch2
       );
+      tile.octNormalUp = octNormalUp;
+      tile.octNormalRight = octNormalRight;
 
       if (tile.octNormalUp) {
         if (!tile.octNormalRight) {
@@ -191,12 +196,9 @@ function extractInstancedAttributes(
           );
         }
 
-        throw new Error('i3dm: oct-encoded orientation not implemented');
-        /*
-        AttributeCompression.octDecodeInRange(octNormalUp[0], octNormalUp[1], 65535, instanceNormalUp);
-        AttributeCompression.octDecodeInRange(octNormalRight[0], octNormalRight[1], 65535, instanceNormalRight);
+        decodeOct32POrientation(octNormalUp, octNormalRight, instanceNormalUp, instanceNormalRight);
+        tile.hasCustomOrientation = true;
         hasCustomOrientation = true;
-        */
       } else if (tile.eastNorthUp) {
         Ellipsoid.WGS84.eastNorthUpToFixedFrame(instancePosition, instanceTransform);
         instanceTransform.getRotationMatrix3(instanceRotation);
@@ -256,4 +258,26 @@ function extractInstancedAttributes(
   }
 
   tile.instances = instances;
+}
+
+/**
+ * Decodes the two 16-bit octahedral direction vectors used by the i3dm orientation semantics.
+ *
+ * The feature-table values are unsigned normalized coordinates in the inclusive `[0, 65535]`
+ * range. Both directions are decoded before constructing the orthonormal basis, preserving the
+ * same right/up/forward convention as the uncompressed `NORMAL_UP` and `NORMAL_RIGHT` fields.
+ *
+ * @param encodedUp - Two-component oct-encoded up direction.
+ * @param encodedRight - Two-component oct-encoded right direction.
+ * @param normalUp - Destination up vector.
+ * @param normalRight - Destination right vector.
+ */
+function decodeOct32POrientation(
+  encodedUp: number[],
+  encodedRight: number[],
+  normalUp: Vector3,
+  normalRight: Vector3
+): void {
+  octDecodeInRange(encodedUp[0], encodedUp[1], 65535, normalUp);
+  octDecodeInRange(encodedRight[0], encodedRight[1], 65535, normalRight);
 }

--- a/modules/3d-tiles/test/lib/parsers/instanced-model-3d-tile.spec.ts
+++ b/modules/3d-tiles/test/lib/parsers/instanced-model-3d-tile.spec.ts
@@ -163,7 +163,7 @@ test('instanced model tile#renders with feature defined orientation', async t =>
 });
 
 // TODO - this should be a render test
-test.skip('instanced model tile#renders with feature defined Oct32P encoded orientation', async t => {
+test('instanced model tile#renders with feature defined Oct32P encoded orientation', async t => {
   const tileData = await loadRootTileFromTileset(t, OCT16P_ORIENTATION_URL);
   const tile = await parse(tileData, Tiles3DLoader);
   t.ok(tile, 'loaded tile with feature defined Oct32P encoded orientation');
@@ -203,7 +203,7 @@ test('instanced model tile#renders with feature defined quantized position', asy
 });
 
 // TODO - this should be a render test
-test.skip('instanced model tile#renders with feature defined quantized position and Oct32P encoded orientation', async t => {
+test('instanced model tile#renders with feature defined quantized position and Oct32P encoded orientation', async t => {
   const tileData = await loadRootTileFromTileset(t, QUANTIZED_OCT32_PORIENTATION_URL);
   const tile = await parse(tileData, Tiles3DLoader);
   t.ok(tile, 'loaded tile with feature defined quantized position and Oct32P encoded orientation');


### PR DESCRIPTION
## Goals

- Complete the remaining i3dm orientation semantics for 3D Tiles 1.0/1.1 content.
- Decode octahedrally encoded instance directions into the same transform basis used by uncompressed orientations.

## Changes

- Decode `NORMAL_UP_OCT32P` and `NORMAL_RIGHT_OCT32P` with the shared 16-bit octahedral decoder.
- Correctly mark custom orientation and build per-instance right/up/forward rotation bases.
- Preserve decoded orientation fields on the parsed tile result.
- Re-enable the standard and quantized-position Cesium i3dm orientation fixtures.
- Update the 3D Tiles compatibility matrix, runtime guide, and What’s New.

Related: #1245 (partial progress; keep open)

## Validation

- `yarn lint fix`
- `yarn test-headless modules/3d-tiles/test/lib/parsers/instanced-model-3d-tile.spec.ts`
- 20/20 tests passed

The repository-wide suite still reports the pre-existing missing `@bufbuild/protobuf` dependency in `modules/traces`.
