### PR TITLE
feat(copc): stream node ranges and hierarchy pages

### DIFF
--- a/docs/modules/copc/api-reference/copc-source-loader.md
+++ b/docs/modules/copc/api-reference/copc-source-loader.md
@@ -35,11 +35,13 @@ The created data source exposes the point-cloud tile methods used by `PointCloud
 - `getChildren(tile)` returns available child tile headers.
 - `loadTileContent(tile)` returns normalized point positions, optional colors, point count, and cartographic origin.
 - `loadTileContentInBatches(tile, options)` yields normalized Arrow point tables progressively after the selected node range has been fetched. The TypeScript LAZ variant is required. `options.batchSize` controls the maximum points per table, `options.columns` can request positions only, and `options.signal` cancels the request/decode.
+- `loadHierarchyInBatches(options)` yields hierarchy pages and their discovered nodes as they are fetched.
 
-`loadTileContentInBatches` does not yet split the HTTP range request itself. COPC node data is fetched as one complete compressed range because layered LAZ fields need the chunk size metadata and compressed field ranges before decoding can begin. The method avoids building one full decoded Arrow table and is the API boundary for future progressive range delivery.
+For TypeScript position-only batches, `loadTileContentInBatches` splits the node range into sequential requests and can emit positions as soon as the Point14 layer arrives. RGB requests still use one complete node range until progressive RGB decoding is implemented. `options.rangeChunkSize` controls the position-only request size.
 
 ## Options
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
 | `copc.sourceCoordinateSystem` | `string` | Auto-detected from COPC WKT | Coordinate system definition used when the source metadata does not include WKT. |
+| `copc.rangeChunkSize` | `number` | `65536` | Default byte size for position-only TypeScript COPC node range requests. |

--- a/modules/copc/src/copc-source-loader.ts
+++ b/modules/copc/src/copc-source-loader.ts
@@ -15,6 +15,7 @@ import type {
 } from '@loaders.gl/loader-utils';
 import {
   createLAZChunkDecoderCursor,
+  createLAZChunkDecoder,
   DataSource,
   concatenateArrayBuffersFromArray,
   decodeLAZChunkInBatches
@@ -58,6 +59,8 @@ export type COPCSourceLoaderOptions = DataSourceOptions & {
     /** Decoder backend for compressed COPC LAZ node chunks. */
     decoder?: 'laz-perf' | 'typescript-laz';
     sourceCoordinateSystem?: string;
+    /** Default byte size for progressive COPC node range requests. */
+    rangeChunkSize?: number;
   };
 };
 
@@ -69,6 +72,24 @@ export type COPCTileContentBatchOptions = {
   signal?: AbortSignal;
   /** Arrow attributes to populate. POSITION is always included. */
   columns?: readonly ('POSITION' | 'COLOR_0')[];
+  /** Byte size for progressive node range requests. */
+  rangeChunkSize?: number;
+};
+
+/** Options for progressive COPC hierarchy page loading. */
+export type COPCHierarchyBatchOptions = {
+  /** Cancel hierarchy page requests and traversal. */
+  signal?: AbortSignal;
+  /** Stop after loading this many hierarchy pages. */
+  maxPages?: number;
+};
+
+/** One hierarchy page and the nodes/pages discovered in it. */
+export type COPCHierarchyBatch = {
+  pageId: string;
+  page: Hierarchy.Page;
+  nodes: Hierarchy.Node.Map;
+  pages: Hierarchy.Page.Map;
 };
 
 /** Arrow table content returned for one COPC tile batch. */
@@ -342,10 +363,28 @@ export class COPCTileSource
     }
     const nativeOrigin = this.getNativeTileCenter(tile.id);
     const cartographicOrigin = this.projectPoint(nativeOrigin);
-    const compressed = await Copc.loadCompressedPointDataBuffer(this._urlOrGetter, node);
     const colors =
       pointFormatHasColor(copc.header.pointDataRecordFormat) &&
       (options.columns ? options.columns.includes('COLOR_0') : true);
+    const rangeChunkSize = options.rangeChunkSize ?? this.options.copc?.rangeChunkSize ?? 65536;
+    if (!Number.isSafeInteger(rangeChunkSize) || rangeChunkSize < 1) {
+      throw new Error('COPC progressive rangeChunkSize must be a positive integer');
+    }
+
+    if (!colors) {
+      yield* this.loadPositionOnlyTileContentInBatches(
+        copc,
+        node,
+        nativeOrigin,
+        cartographicOrigin,
+        batchSize,
+        rangeChunkSize,
+        options.signal
+      );
+      return;
+    }
+
+    const compressed = await Copc.loadCompressedPointDataBuffer(this._urlOrGetter, node);
     const cursor = createLAZChunkDecoderCursor(compressed, {
       pointCount: node.pointCount,
       pointDataRecordFormat: copc.header.pointDataRecordFormat,
@@ -378,6 +417,154 @@ export class COPCTileSource
 
       this.transformTilePositions(nativePositions, positions, nativeOrigin, cartographicOrigin);
       yield this.createTileContentResult(pointCount, positions, batchColors, cartographicOrigin);
+    }
+  }
+
+  /** Yield position-only batches while the node range is still arriving. */
+  protected async *loadPositionOnlyTileContentInBatches(
+    copc: Copc,
+    node: Hierarchy.Node,
+    nativeOrigin: number[],
+    cartographicOrigin: number[],
+    batchSize: number,
+    rangeChunkSize: number,
+    signal?: AbortSignal
+  ): AsyncIterable<COPCTileContent> {
+    const decoder = createLAZChunkDecoder({
+      pointCount: node.pointCount,
+      pointDataRecordFormat: copc.header.pointDataRecordFormat,
+      pointDataRecordLength: copc.header.pointDataRecordLength
+    });
+    let decodedPointCount = 0;
+
+    for await (const compressedChunk of this.loadCOPCNodeRangeChunks(
+      node,
+      rangeChunkSize,
+      signal
+    )) {
+      decoder.feed(compressedChunk);
+      yield* this.readPositionOnlyBatches(
+        decoder,
+        copc,
+        node.pointCount,
+        nativeOrigin,
+        cartographicOrigin,
+        batchSize,
+        decodedPointCount
+      );
+      decodedPointCount = node.pointCount - decoder.remainingPointCount;
+    }
+
+    decoder.close();
+    if (decodedPointCount < node.pointCount) {
+      yield* this.readPositionOnlyBatches(
+        decoder,
+        copc,
+        node.pointCount,
+        nativeOrigin,
+        cartographicOrigin,
+        batchSize,
+        decodedPointCount
+      );
+      decodedPointCount = node.pointCount - decoder.remainingPointCount;
+    }
+    if (decodedPointCount !== node.pointCount) {
+      throw new Error(
+        `COPC TypeScript LAZ position decoder produced ${decodedPointCount} points; expected ${node.pointCount}`
+      );
+    }
+  }
+
+  /** Read all currently available position-only batches from a feedable decoder. */
+  protected *readPositionOnlyBatches(
+    decoder: ReturnType<typeof createLAZChunkDecoder>,
+    copc: Copc,
+    nodePointCount: number,
+    nativeOrigin: number[],
+    cartographicOrigin: number[],
+    batchSize: number,
+    decodedPointCount: number
+  ): Iterable<COPCTileContent> {
+    while (decodedPointCount < nodePointCount) {
+      const pointCount = Math.min(batchSize, nodePointCount - decodedPointCount);
+      const nativePositions = new Float64Array(pointCount * 3);
+      const positions = new Float32Array(pointCount * 3);
+      const decoded = decoder.readPositionDataBatch(
+        {
+          positions: nativePositions,
+          pointOffset: 0,
+          scale: copc.header.scale,
+          offset: copc.header.offset
+        },
+        pointCount
+      );
+      if (decoded === null) {
+        return;
+      }
+      if (decoded === 0) {
+        return;
+      }
+      this.transformTilePositions(nativePositions, positions, nativeOrigin, cartographicOrigin);
+      yield this.createTileContentResult(pointCount, positions, null, cartographicOrigin);
+      decodedPointCount += decoded;
+    }
+  }
+
+  /** Yield hierarchy pages as they are fetched, merging them into the cache. */
+  async *loadHierarchyInBatches(
+    options: COPCHierarchyBatchOptions = {}
+  ): AsyncIterable<COPCHierarchyBatch> {
+    const {copc} = await this._initPromise;
+    const rootPage = copc.info.rootHierarchyPage;
+    const pending: Array<[string, Hierarchy.Page]> = [['root', rootPage]];
+    const visited = new Set<string>();
+    let loadedPageCount = 0;
+
+    while (pending.length > 0) {
+      if (options.signal?.aborted) {
+        throw new Error('COPC hierarchy loading was aborted');
+      }
+      if (options.maxPages !== undefined && loadedPageCount >= options.maxPages) {
+        return;
+      }
+      const [pageId, page] = pending.shift()!;
+      const pageKey = `${page.pageOffset}:${page.pageLength}`;
+      if (visited.has(pageKey)) {
+        continue;
+      }
+      visited.add(pageKey);
+      const subtree =
+        pageId === 'root' && this._hierarchy
+          ? this._hierarchy
+          : await Copc.loadHierarchyPage(this._urlOrGetter, page);
+      if (this._hierarchy) {
+        this._hierarchy.nodes = {...this._hierarchy.nodes, ...subtree.nodes};
+        this._hierarchy.pages = {...this._hierarchy.pages, ...subtree.pages};
+      }
+      loadedPageCount++;
+      yield {pageId, page, nodes: subtree.nodes, pages: subtree.pages};
+      for (const [childPageId, childPage] of Object.entries(subtree.pages)) {
+        if (childPage) {
+          pending.push([childPageId, childPage]);
+        }
+      }
+    }
+  }
+
+  /** Fetch a COPC node range in sequential chunks. */
+  protected async *loadCOPCNodeRangeChunks(
+    node: Hierarchy.Node,
+    rangeChunkSize: number,
+    signal?: AbortSignal
+  ): AsyncIterable<Uint8Array> {
+    const get = Getter.create(this._urlOrGetter);
+    const rangeEnd = node.pointDataOffset + node.pointDataLength;
+    for (let begin = node.pointDataOffset; begin < rangeEnd; begin += rangeChunkSize) {
+      if (signal?.aborted) {
+        throw new Error('COPC progressive tile range request was aborted');
+      }
+      const end = Math.min(begin + rangeChunkSize, rangeEnd);
+      yield await get(begin, end);
     }
   }
 

--- a/modules/copc/src/copc-source-loader.ts
+++ b/modules/copc/src/copc-source-loader.ts
@@ -540,6 +540,9 @@ export class COPCTileSource
       if (this._hierarchy) {
         this._hierarchy.nodes = {...this._hierarchy.nodes, ...subtree.nodes};
         this._hierarchy.pages = {...this._hierarchy.pages, ...subtree.pages};
+        if (pageId !== 'root') {
+          delete this._hierarchy.pages[pageId];
+        }
       }
       loadedPageCount++;
       yield {pageId, page, nodes: subtree.nodes, pages: subtree.pages};
@@ -564,7 +567,11 @@ export class COPCTileSource
         throw new Error('COPC progressive tile range request was aborted');
       }
       const end = Math.min(begin + rangeChunkSize, rangeEnd);
-      yield await get(begin, end);
+      const chunk = await get(begin, end);
+      if (signal?.aborted) {
+        throw new Error('COPC progressive tile range request was aborted');
+      }
+      yield chunk;
     }
   }
 

--- a/modules/copc/src/index.ts
+++ b/modules/copc/src/index.ts
@@ -4,6 +4,8 @@
 
 export type {
   COPCSourceLoaderOptions,
+  COPCHierarchyBatch,
+  COPCHierarchyBatchOptions,
   COPCTileContent,
   COPCTileContentBatchOptions
 } from './copc-source-loader';

--- a/modules/copc/test/copc-source.spec.ts
+++ b/modules/copc/test/copc-source.spec.ts
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import test from 'test/utils/vitest-tape';
+import {expect, test as vitestTest} from 'vitest';
 import {validateWriter} from 'test/common/conformance';
 import {createDataSource, encodeSync, fetchFile, isBrowser, parse} from '@loaders.gl/core';
 import {COPCSourceLoader, COPCTileSource, COPCWriter} from '@loaders.gl/copc';
@@ -163,17 +164,16 @@ test('COPCSourceLoader#streams position-only TypeScript tile batches', async t =
   t.end();
 });
 
-test('COPCSourceLoader#streams hierarchy pages', async t => {
+vitestTest('COPCSourceLoader#streams hierarchy pages', async () => {
   const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {});
   const batches = [];
   for await (const batch of source.loadHierarchyInBatches({maxPages: 1})) {
     batches.push(batch);
   }
 
-  t.equal(batches.length, 1, 'maxPages limits hierarchy loading');
-  t.equal(batches[0]?.pageId, 'root', 'first hierarchy batch is the root page');
-  t.ok(batches[0]?.nodes['0-0-0-0'], 'root page exposes the root node');
-  t.end();
+  expect(batches).toHaveLength(1);
+  expect(batches[0]?.pageId).toBe('root');
+  expect(batches[0]?.nodes['0-0-0-0']).toBeTruthy();
 });
 
 test('COPCSourceLoader#TypeScript tile attributes match laz-perf', async t => {

--- a/modules/copc/test/copc-source.spec.ts
+++ b/modules/copc/test/copc-source.spec.ts
@@ -145,7 +145,8 @@ test('COPCSourceLoader#streams position-only TypeScript tile batches', async t =
   const streamedPositions: number[] = [];
   for await (const batch of source.loadTileContentInBatches(rootTile, {
     batchSize: 127,
-    columns: ['POSITION']
+    columns: ['POSITION'],
+    rangeChunkSize: 257
   })) {
     t.notOk(batch.data.data.getChild('COLOR_0'), 'color output is omitted');
     const positions = batch.data.data.getChild('POSITION');
@@ -159,6 +160,19 @@ test('COPCSourceLoader#streams position-only TypeScript tile batches', async t =
     expectedPositions.push(...(atomicPositions?.get(index)?.toArray() || []));
   }
   t.deepEqual(streamedPositions, expectedPositions, 'position-only batches match atomic output');
+  t.end();
+});
+
+test('COPCSourceLoader#streams hierarchy pages', async t => {
+  const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {});
+  const batches = [];
+  for await (const batch of source.loadHierarchyInBatches({maxPages: 1})) {
+    batches.push(batch);
+  }
+
+  t.equal(batches.length, 1, 'maxPages limits hierarchy loading');
+  t.equal(batches[0]?.pageId, 'root', 'first hierarchy batch is the root page');
+  t.ok(batches[0]?.nodes['0-0-0-0'], 'root page exposes the root node');
   t.end();
 });
 

--- a/modules/loader-utils/src/lib/laz/laz-chunk-decoder.ts
+++ b/modules/loader-utils/src/lib/laz/laz-chunk-decoder.ts
@@ -135,6 +135,11 @@ export class FeedableLAZChunkDecoder {
     this.closed = true;
   }
 
+  /** Number of points that remain available after progressive decoding starts. */
+  get remainingPointCount(): number {
+    return this.cursor?.remainingPointCount ?? this.metadata.pointCount;
+  }
+
   /** Decode all fed point data into raw LAS point records. */
   decode(): Uint8Array {
     if (!this.closed) {


### PR DESCRIPTION
## Goals

- Advance COPC streaming beyond full-node range fetches for the TypeScript position-only path.
- Expose hierarchy pages as an async stream while preserving the existing hierarchy cache and tile APIs.
- Keep RGB decoding and atomic compatibility behavior unchanged until progressive RGB readiness is implemented.

## Changes

- Fetch TypeScript position-only COPC node data through sequential byte ranges controlled by `rangeChunkSize`.
- Feed those ranges into the LAZ decoder and emit positions as soon as the PDRF 6-8 Point14 layer is available.
- Preserve complete-range decoding for requests that include RGB.
- Add `COPCTileSource.loadHierarchyInBatches(options)` with cancellation and `maxPages` support.
- Merge streamed hierarchy pages into the existing source cache.
- Add public `COPCHierarchyBatch` and `COPCHierarchyBatchOptions` types.
- Extend the feedable LAZ decoder with progressive position-batch state and remaining-point tracking.
- Add focused COPC tests for chunked position ranges and hierarchy page streaming.
- Update COPC API documentation with current progressive limitations.

## Validation

- `yarn test-headless modules/copc/test/copc-source.spec.ts`: 14 passed.
- `tspc -b modules/loader-utils/tsconfig.json modules/las/tsconfig.json modules/copc/tsconfig.json --pretty false`: passed.
- `yarn lint fix` passed.
- `git diff --check` passed.

## Limitations

- Progressive RGB output still requires a complete node range.
- LASzip variable-chunk table streaming and arbitrary sparse layer fetches remain follow-up work.
