### PR TITLE
test(3d-tiles): cover geographic region bounds

### DIFF
--- a/docs/modules/3d-tiles/formats/3d-tiles.md
+++ b/docs/modules/3d-tiles/formats/3d-tiles.md
@@ -75,7 +75,8 @@ For cache and request behavior, see [caching and memory](../concepts/caching-and
 
 ## Supported coordinate and volume forms
 
-The runtime accepts oriented boxes, spheres, and geographic regions. S2 extension volumes are
+The runtime accepts oriented boxes, spheres, and geographic regions, including regions that cross
+the antimeridian and degenerate-height regions. S2 extension volumes are
 normalized to oriented boxes while retaining their source token and height range for implicit
 subdivision. Tile transforms are composed with ancestor and tileset transforms before culling and
 geometric-error scaling.

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -295,6 +295,7 @@ A minor release that includes:
 - **Implicit multiple contents** - Implicit subtrees now preserve every content-availability stream and materialize available content URLs in source order, while retaining the legacy single-content shape when only one stream is available.
 - **i3dm orientation** - Instanced 3D Model tiles now decode `NORMAL_UP_OCT32P` and `NORMAL_RIGHT_OCT32P`, including quantized-position fixtures, and use the decoded basis for per-instance transforms.
 - **3D Tiles metadata topology** - Tileset schemas, groups, tileset/tile/content metadata entities, and content group references are now typed and preserved through normalization; binary property-table decoding and metadata-derived bounds remain follow-up work.
+- **Region bounding volumes** - Geographic regions that cross the antimeridian now produce tight traversal OBBs instead of spanning the long way around the globe; polar and zero-height regions remain finite.
 - **Transform-correct LOD** Geometric error is scaled conservatively by composed tile and tileset transforms without compounding after runtime updates.
 - **Projection-correct SSE** Orthographic viewports use `metersPerPixel`, while perspective and orthographic traversal consistently use logical pixels without a second device-pixel-ratio correction.
 - **Dynamic SSE** Perspective traversal can reduce distant, horizon-facing refinement with view-dependent density and height falloff while leaving orthographic and I3S LOD behavior unchanged.

--- a/modules/tiles/test/tileset/helpers/bounding-volume.browser.spec.ts
+++ b/modules/tiles/test/tileset/helpers/bounding-volume.browser.spec.ts
@@ -1,0 +1,32 @@
+import {describe, expect, test} from 'vitest';
+import {Matrix4} from '@math.gl/core';
+import {createBoundingVolume} from '../../../src/tileset-3d/helpers/bounding-volume';
+
+describe('3D Tiles region bounding volumes', () => {
+  test('unwraps regions that cross the antimeridian', () => {
+    const boundingVolume = createBoundingVolume(
+      {region: [Math.PI * (170 / 180), -0.1, -Math.PI * (170 / 180), 0.1, 0, 10]},
+      new Matrix4()
+    );
+
+    expect(Math.abs(boundingVolume.center[0])).toBeGreaterThan(6_000_000);
+    expect(Math.abs(boundingVolume.center[1])).toBeLessThan(100_000);
+  });
+
+  test('keeps polar regions finite', () => {
+    const boundingVolume = createBoundingVolume(
+      {region: [-Math.PI, Math.PI * (89 / 180), Math.PI, Math.PI * (89.9 / 180), -100, 100]},
+      new Matrix4()
+    );
+
+    expect(boundingVolume.center.every(Number.isFinite)).toBe(true);
+    expect(boundingVolume.halfAxes.every(Number.isFinite)).toBe(true);
+  });
+
+  test('supports regions with zero thickness', () => {
+    const boundingVolume = createBoundingVolume({region: [0, 0, 0.1, 0.1, 10, 10]}, new Matrix4());
+
+    expect(boundingVolume.center.every(Number.isFinite)).toBe(true);
+    expect(boundingVolume.halfAxes.every(Number.isFinite)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Goals

- Lock in geographic region bounding-volume behavior supplied by math.gl.
- Cover antimeridian-crossing, polar, and zero-height regions in loaders.gl traversal.

## Changes

- Add Chromium regression coverage for antimeridian, polar, and zero-height regions.
- Document the supported geographic-region behavior in the 3D Tiles format page and What's New.
- Remove the previous loaders.gl-local OBB algorithm; region construction now uses `makeOBBFromRegion` from `@math.gl/geospatial@4.2.0-alpha.5`, landed through #3731 and visgl/math.gl#111.

Related: #1245 (partial progress; keep open)

## Validation

- `yarn lint fix`
- `yarn test-audit` — 550 files, 0 violations
- Focused Chromium tests — 1 file, 3 tests passed
