### PR TITLE
feat(scan): add point cloud, raster, and relational tranche foundations

### DIFF
--- a/docs/developer-guide/common-scan-architecture.md
+++ b/docs/developer-guide/common-scan-architecture.md
@@ -12,6 +12,31 @@ they share is the logical meaning of a query and a small set of execution invari
 > The portable query is a contract between planners and executors. It is not intended to become a
 > second implementation of the complete SQL language.
 
+## Format-family support at a glance
+
+This is the end-user view of the architecture. “Supported” means a source can be used through the
+common scan contract today. “Partial” means useful metadata or Arrow reading exists, but some
+operators or pushdown opportunities remain source-specific. “Specialized” means the format has a
+different query model, such as tiles or raster windows, rather than a relational table scan.
+
+| Format family | Status | What is supported |
+| --- | --- | --- |
+| Arrow / GeoArrow | Partial | In-memory projection, predicates, and limits; GeoArrow extension-column conformance is still expanding. |
+| Parquet / Iceberg | Supported | Schema discovery, projection, filtering, global limits, streaming Arrow batches, cancellation, and metadata pruning. |
+| FlatGeobuf | Supported | Arrow feature queries, R-tree bounding-box pruning, residual attribute filtering, projection, and limits. |
+| DuckDB / Snowflake SQL | Supported | Raw SQL plus the portable table query with safe parameter binding. |
+| CSV / JSONL / ORC | Planned | Existing loaders are available; common chunk, stripe, and row-index scans are next. |
+| Delta Lake / Lance | Partial | Read-only metadata and Arrow-batch paths exist; common snapshot/fragment planning and predicate pushdown are incomplete. |
+| COPC / Potree | Partial | Point-cloud metadata, coordinate roles, hierarchy bounds, level-of-detail, spacing, and capability discovery are available; full common point streaming is source-specific. |
+| GeoTIFF / COG / Zarr / GeoZarr / OME-Zarr | Partial | Raster window, band/channel, overview/level, and multidimensional selection APIs are available with shared query validation and capabilities. |
+| NetCDF | Planned | The loader is available; the shared multidimensional raster scan contract is not yet wired in. |
+| MVT / PMTiles / 3D Tiles / I3S | Specialized | Use tile and tileset source APIs; tile addressing and level-of-detail remain outside `TableQuery`. |
+| WMS / WFS / STAC and other services | Specialized | Use the service or catalog query APIs; they are not normalized into the table scan contract. |
+
+The matrix describes the public experience, not identical physical performance. A source may accept
+the same logical query while evaluating some operators after decoding; capability metadata and
+explain output identify what was pushed down and what remained residual.
+
 ## Why a common scan architecture?
 
 Columnar storage systems often expose nearly identical user-facing controls under different names:
@@ -606,18 +631,19 @@ work is deliberately ordered by how much useful physical pruning each format can
 10. **GPU execution:** lower the shared predicate to luma.gl/WGSL masks or indices and add a
     GPU-specific limit/selection stage. GPU plans should report whether compaction is deferred or
     materialized, so CPU and GPU diagnostics remain comparable.
-11. **Point-cloud scans:** standardize the sibling `PointCloudQueryOptions` contract, implement COPC
-    hierarchy and bounds planning first, then reuse its planner and Arrow batch conventions for
-    Potree. Preserve point budgets, hierarchy levels, target spacing, coordinate roles, and node
-    provenance instead of forcing them into scalar table predicates.
-12. **Raster and multidimensional scans:** standardize the sibling `RasterQuery`/`ScanTask` shape for
-    GeoTIFF/COG, Zarr/GeoZarr, OME-Zarr, and NetCDF. Share scheduling, cancellation, range caching,
-    explain, telemetry, and spatial-envelope pruning with table scans while keeping pixel windows,
-    levels, chunks, and resampling out of `TableQuery`.
-13. **Relational growth:** add ordering, scalar expressions, aggregates, unions, or joins only when
-    at least two materially different backends can implement the same portable meaning. Spatial
-    predicates and nearest-neighbor search should remain extensions until indexed CPU, GPU, and
-    remote-source strategies converge.
+11. **Point-cloud scans — foundation landed:** standardize `PointCloudQueryOptions` validation and
+    capability discovery, with COPC and Potree metadata exposing coordinate roles, bounds, hierarchy
+    levels, spacing, and point statistics. Full common point streaming, residual attribute filtering,
+    and global point limits remain adapter work.
+12. **Raster and multidimensional scans — foundation landed:** standardize `RasterQueryOptions` and
+    capability discovery for GeoTIFF/COG and Zarr/GeoZarr/OME-Zarr. Existing raster sources retain
+    their window, band, overview, chunk, and dimension APIs; NetCDF and shared task-level explain and
+    telemetry remain follow-ups.
+13. **Relational growth — logical planner landed:** add a portable plan vocabulary for ordering,
+    scalar expressions, aggregates, unions, and equi-joins. Physical execution is deliberately
+    backend-specific and should be added only when at least two materially different backends can
+    implement the same portable meaning. Spatial predicates and nearest-neighbor search remain
+    extensions until indexed CPU, GPU, and remote-source strategies converge.
 
 ### Format capability matrix
 

--- a/modules/copc/src/copc-source-loader.ts
+++ b/modules/copc/src/copc-source-loader.ts
@@ -30,6 +30,7 @@ const COORDINATE_SYSTEM = {
   LNGLAT_OFFSETS: 'lnglat-offsets'
 } as const;
 
+/** Infers a query-panel semantic role from a COPC dimension name. */
 function inferCOPCColumnRole(
   name: string
 ): 'attribute' | 'x' | 'y' | 'z' | 'intensity' | 'classification' | 'color' {
@@ -188,7 +189,7 @@ export class COPCTileSource
   /** Discovers point attributes and spatial bounds without decoding point rows. */
   async getQueryMetadata() {
     const {copc} = await this._initPromise;
-    const schema = await this.getSchema();
+    const schema = getCOPCHeaderSchema(copc.header.pointDataRecordFormat);
     const roles = Object.fromEntries(
       schema.fields.map(field => [field.name, inferCOPCColumnRole(field.name)])
     );
@@ -980,6 +981,34 @@ function getDataTypeFromDimension(dimension: Dimension): DataType {
     default:
       return 'null';
   }
+}
+
+/** Builds the standard query schema from a COPC point-data record format. */
+function getCOPCHeaderSchema(pointDataRecordFormat: number): Schema {
+  const fields: Field[] = [
+    {name: 'X', type: 'float64', nullable: false},
+    {name: 'Y', type: 'float64', nullable: false},
+    {name: 'Z', type: 'float64', nullable: false}
+  ];
+  if (pointDataRecordFormat === 1 || pointDataRecordFormat === 3 || pointDataRecordFormat >= 6) {
+    fields.push({name: 'Intensity', type: 'uint16', nullable: false});
+  }
+  if (
+    pointDataRecordFormat === 2 ||
+    pointDataRecordFormat === 3 ||
+    pointDataRecordFormat === 7 ||
+    pointDataRecordFormat === 8 ||
+    pointDataRecordFormat === 10
+  ) {
+    fields.push(
+      {name: 'Red', type: 'uint16', nullable: false},
+      {name: 'Green', type: 'uint16', nullable: false},
+      {name: 'Blue', type: 'uint16', nullable: false}
+    );
+  }
+  if (pointDataRecordFormat >= 6)
+    fields.push({name: 'Classification', type: 'uint8', nullable: false});
+  return {fields, metadata: {}};
 }
 
 function createProjection(projectionData?: string): Proj4Projection | null {

--- a/modules/copc/src/copc-source-loader.ts
+++ b/modules/copc/src/copc-source-loader.ts
@@ -19,6 +19,7 @@ import {
   concatenateArrayBuffersFromArray,
   decodeLAZChunkInBatches
 } from '@loaders.gl/loader-utils';
+import {createScanQueryMetadata, type PointCloudQueryCapabilities} from '@loaders.gl/loader-utils';
 import {Proj4Projection} from '@math.gl/proj4';
 
 import {Copc, Las, Hierarchy, Dimension, Getter, Bounds, Key} from 'copc';
@@ -28,6 +29,19 @@ const COORDINATE_SYSTEM = {
   CARTESIAN: 'cartesian',
   LNGLAT_OFFSETS: 'lnglat-offsets'
 } as const;
+
+function inferCOPCColumnRole(
+  name: string
+): 'attribute' | 'x' | 'y' | 'z' | 'intensity' | 'classification' | 'color' {
+  const normalizedName = name.toLowerCase();
+  if (normalizedName === 'x') return 'x';
+  if (normalizedName === 'y') return 'y';
+  if (normalizedName === 'z') return 'z';
+  if (normalizedName.includes('intensity')) return 'intensity';
+  if (normalizedName.includes('classification')) return 'classification';
+  if (normalizedName.includes('color') || normalizedName.includes('red')) return 'color';
+  return 'attribute';
+}
 
 type COPCViewState = {
   boundingVolume: {
@@ -119,6 +133,17 @@ export class COPCTileSource
   extends DataSource<string | Blob, COPCSourceLoaderOptions>
   implements TileSource
 {
+  /** Common point-cloud scan capabilities exposed by COPC. */
+  readonly pointCloudQueryCapabilities: PointCloudQueryCapabilities = Object.freeze({
+    projection: 'pushdown',
+    predicate: 'residual',
+    limit: 'residual',
+    streaming: true,
+    cancellation: true,
+    bounds: 'pushdown',
+    levelOfDetail: 'pushdown',
+    spacing: 'pushdown'
+  });
   mimeType: string | null = null;
   metadata: Promise<COPCMetadata>;
   isReady = false;
@@ -158,6 +183,33 @@ export class COPCTileSource
     }
 
     return {fields, metadata: {}};
+  }
+
+  /** Discovers point attributes and spatial bounds without decoding point rows. */
+  async getQueryMetadata() {
+    const {copc} = await this._initPromise;
+    const schema = await this.getSchema();
+    const roles = Object.fromEntries(
+      schema.fields.map(field => [field.name, inferCOPCColumnRole(field.name)])
+    );
+    return createScanQueryMetadata({
+      sourceType: 'copc',
+      queryType: 'point-cloud',
+      schema,
+      capabilities: {
+        table: this.pointCloudQueryCapabilities,
+        bounds: 'pushdown',
+        levelOfDetail: 'pushdown'
+      },
+      columnRoles: roles,
+      spatial: {
+        bounds: {minimum: copc.header.min, maximum: copc.header.max},
+        coordinateReferenceSystems: this.options.copc?.sourceCoordinateSystem
+          ? [this.options.copc.sourceCoordinateSystem]
+          : undefined
+      },
+      statistics: {rowCount: copc.header.pointCount}
+    });
   }
 
   async getMetadata(): Promise<COPCMetadata> {

--- a/modules/geotiff/src/geotiff-source-loader.ts
+++ b/modules/geotiff/src/geotiff-source-loader.ts
@@ -55,7 +55,7 @@ export const GEOTIFF_RASTER_QUERY_CAPABILITIES: RasterQueryCapabilities = Object
   variables: 'pushdown',
   slices: 'unsupported',
   streaming: false,
-  cancellation: true
+  cancellation: false
 });
 
 /**

--- a/modules/geotiff/src/geotiff-source-loader.ts
+++ b/modules/geotiff/src/geotiff-source-loader.ts
@@ -16,7 +16,8 @@ import type {
   RasterChannelDataType,
   RasterBoundingBox,
   RangeRequestSchedulerProps,
-  RangeRequestTransportResult
+  RangeRequestTransportResult,
+  RasterQueryCapabilities
 } from '@loaders.gl/loader-utils';
 import {
   DataSource,
@@ -46,6 +47,16 @@ export type GeoTIFFSourceLoaderOptions = DataSourceOptions & {
     rangeSchedulerProps?: RangeRequestSchedulerProps;
   };
 };
+
+/** Common raster-query capabilities of GeoTIFF and COG sources. */
+export const GEOTIFF_RASTER_QUERY_CAPABILITIES: RasterQueryCapabilities = Object.freeze({
+  bounds: 'pushdown',
+  level: 'pushdown',
+  variables: 'pushdown',
+  slices: 'unsupported',
+  streaming: false,
+  cancellation: true
+});
 
 /**
  * Source factory for viewport-driven GeoTIFF datasets.
@@ -106,6 +117,8 @@ export class GeoTIFFRasterSource
   extends DataSource<string | Blob, GeoTIFFSourceLoaderOptions>
   implements RasterSource
 {
+  /** Capabilities advertised by this viewport-driven raster source. */
+  readonly rasterQueryCapabilities = GEOTIFF_RASTER_QUERY_CAPABILITIES;
   private _initPromise: Promise<GeoTIFFInit> | null = null;
   private _rangeScheduler: RangeRequestScheduler | null = null;
 
@@ -130,6 +143,11 @@ export class GeoTIFFRasterSource
   async getMetadata(): Promise<RasterSourceMetadata> {
     const {metadata} = await this._getInitPromise();
     return metadata;
+  }
+
+  /** Returns raster-query capabilities without opening raster samples. */
+  getRasterQueryCapabilities(): RasterQueryCapabilities {
+    return this.rasterQueryCapabilities;
   }
 
   /**

--- a/modules/geotiff/test/geotiff-loader.spec.ts
+++ b/modules/geotiff/test/geotiff-loader.spec.ts
@@ -5,7 +5,7 @@
 import test from 'test/utils/vitest-tape';
 
 import {load} from '@loaders.gl/core';
-import {GeoTIFFLoader} from '@loaders.gl/geotiff';
+import {GeoTIFFLoader, GeoTIFFSourceLoader} from '@loaders.gl/geotiff';
 
 const TIFF_URL = '@loaders.gl/geotiff/test/data/gfw-azores.tif';
 
@@ -13,5 +13,12 @@ test('GeoTIFFLoader.', async t => {
   const geoimage = await load(TIFF_URL, GeoTIFFLoader);
   t.ok(geoimage, 'GeoTIFFLoader returned a result');
 
+  t.end();
+});
+
+test('GeoTIFF raster query capabilities report cancellation conservatively', async t => {
+  const source = GeoTIFFSourceLoader.createDataSource('https://example.com/data.tif', {});
+  t.equal(source.getRasterQueryCapabilities().bounds, 'pushdown');
+  t.notOk(source.getRasterQueryCapabilities().cancellation);
   t.end();
 });

--- a/modules/loader-utils/src/index.ts
+++ b/modules/loader-utils/src/index.ts
@@ -268,6 +268,17 @@ export {
   validateColumnarPredicate
 } from './lib/scan-utils/columnar-predicate';
 export {executeScanTasks} from './lib/scan-utils/scan-executor';
+export {validateRasterQueryOptions} from './lib/scan-utils/raster-query';
+export type {RasterQueryOptions, RasterQueryCapabilities} from './lib/scan-utils/raster-query';
+export {planRelationalQuery} from './lib/scan-utils/relational-query';
+export type {
+  RelationalAggregate,
+  RelationalChildQuery,
+  RelationalExpression,
+  RelationalOrderKey,
+  RelationalPlanStep,
+  RelationalQueryOptions
+} from './lib/scan-utils/relational-query';
 export {createScanQueryMetadata} from './lib/scan-utils/scan-query-metadata';
 export {validatePointCloudQueryOptions} from './lib/scan-utils/point-cloud-query';
 export {

--- a/modules/loader-utils/src/lib/scan-utils/raster-query.ts
+++ b/modules/loader-utils/src/lib/scan-utils/raster-query.ts
@@ -67,12 +67,14 @@ export function validateRasterQueryOptions(options: RasterQueryOptions): void {
   }
 }
 
+/** Validates a positive raster dimension. */
 function validatePositiveInteger(value: number, name: string): void {
   if (!Number.isSafeInteger(value) || value < 1) {
     throw new Error(`Raster query ${name} must be a positive safe integer.`);
   }
 }
 
+/** Validates a non-negative raster index. */
 function validateNonNegativeInteger(value: number, name: string): void {
   if (!Number.isSafeInteger(value) || value < 0) {
     throw new Error(`Raster query ${name} must be a non-negative safe integer.`);

--- a/modules/loader-utils/src/lib/scan-utils/raster-query.ts
+++ b/modules/loader-utils/src/lib/scan-utils/raster-query.ts
@@ -1,0 +1,80 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {RasterBoundingBox} from '../sources/raster-source';
+
+/** A bounded raster request shared by GeoTIFF, Zarr, and multidimensional sources. */
+export type RasterQueryOptions = Readonly<{
+  /** Source-coordinate bounds to read, in `[min, max]` form. */
+  bounds?: RasterBoundingBox;
+  /** Requested output width in pixels. */
+  width?: number;
+  /** Requested output height in pixels. */
+  height?: number;
+  /** Overview or multiscale level to read. */
+  level?: number;
+  /** Named variables or bands to include in the result. */
+  variables?: readonly string[];
+  /** Numeric channel indices to include in the result. */
+  channels?: readonly number[];
+  /** Non-spatial dimension selections, such as time or elevation. */
+  slices?: Readonly<Record<string, number | readonly [number, number]>>;
+}>;
+
+/** Operator support advertised by a raster source. */
+export type RasterQueryCapabilities = Readonly<{
+  /** Whether bounds avoid reading unrelated tiles or chunks. */
+  bounds: 'unsupported' | 'residual' | 'pushdown';
+  /** Whether levels or overviews avoid reading full resolution data. */
+  level: 'unsupported' | 'residual' | 'pushdown';
+  /** Whether variables or channels avoid decoding unrelated values. */
+  variables: 'unsupported' | 'residual' | 'pushdown';
+  /** Whether named dimensions are selected before decoding. */
+  slices: 'unsupported' | 'residual' | 'pushdown';
+  /** Whether requests stream bounded tile or chunk tasks. */
+  streaming: boolean;
+  /** Whether range, chunk, and decode work observes cancellation. */
+  cancellation: boolean;
+}>;
+
+/** Validates a raster query without opening or decoding source data. */
+export function validateRasterQueryOptions(options: RasterQueryOptions): void {
+  if (options.width !== undefined) validatePositiveInteger(options.width, 'width');
+  if (options.height !== undefined) validatePositiveInteger(options.height, 'height');
+  if (options.level !== undefined) validateNonNegativeInteger(options.level, 'level');
+  if (options.bounds) {
+    for (let axis = 0; axis < 2; axis++) {
+      const minimum = options.bounds[0][axis];
+      const maximum = options.bounds[1][axis];
+      if (!Number.isFinite(minimum) || !Number.isFinite(maximum) || minimum > maximum) {
+        throw new Error('Raster query bounds must contain finite, ordered coordinates.');
+      }
+    }
+  }
+  for (const channel of options.channels || []) {
+    validateNonNegativeInteger(channel, 'channel');
+  }
+  for (const [name, slice] of Object.entries(options.slices || {})) {
+    if (!name) throw new Error('Raster query slice names must be non-empty.');
+    if (Array.isArray(slice)) {
+      if (slice.length !== 2 || !slice.every(Number.isFinite) || slice[0] > slice[1]) {
+        throw new Error(`Raster query slice ${name} must be an ordered finite range.`);
+      }
+    } else if (!Number.isFinite(slice)) {
+      throw new Error(`Raster query slice ${name} must be finite.`);
+    }
+  }
+}
+
+function validatePositiveInteger(value: number, name: string): void {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new Error(`Raster query ${name} must be a positive safe integer.`);
+  }
+}
+
+function validateNonNegativeInteger(value: number, name: string): void {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`Raster query ${name} must be a non-negative safe integer.`);
+  }
+}

--- a/modules/loader-utils/src/lib/scan-utils/relational-query.ts
+++ b/modules/loader-utils/src/lib/scan-utils/relational-query.ts
@@ -82,15 +82,45 @@ export function planRelationalQuery<PredicateT extends ColumnarPredicate = Colum
   readonly tablePlan: ReturnType<typeof planTableQuery>;
   readonly relationalSteps: readonly RelationalPlanStep[];
 } {
-  const tablePlan = planTableQuery(sourceColumnNames, options);
   const available = new Set(sourceColumnNames);
+  const expressionNames = new Set<string>();
   for (const expression of options.expressions || []) {
     if (!expression.name) throw new Error('Relational expression names must be non-empty.');
-    if (available.has(expression.name)) {
+    if (available.has(expression.name) || expressionNames.has(expression.name)) {
       throw new Error(`Relational expression duplicates column: ${expression.name}`);
     }
-    available.add(expression.name);
+    expressionNames.add(expression.name);
   }
+  const requiredColumns = new Set<string>();
+  for (const expression of options.expressions || []) {
+    if (expression.expression.op === 'column') requiredColumns.add(expression.expression.column);
+    if ('left' in expression.expression) {
+      requiredColumns.add(expression.expression.left);
+      requiredColumns.add(expression.expression.right);
+    }
+  }
+  for (const key of options.orderBy || []) requiredColumns.add(key.column);
+  for (const key of options.groupBy || []) requiredColumns.add(key);
+  for (const aggregate of options.aggregates || []) {
+    if (aggregate.column) requiredColumns.add(aggregate.column);
+  }
+  const outputColumns = options.columns?.filter(column => !expressionNames.has(column));
+  const tablePlan = [
+    ...planTableQuery(sourceColumnNames, {
+      ...options,
+      columns: outputColumns,
+      predicate: options.predicate
+    })
+  ];
+  const scanStep = tablePlan[0];
+  if (scanStep?.kind === 'scan') {
+    const scanColumns = new Set(scanStep.columns);
+    for (const column of requiredColumns) {
+      if (available.has(column)) scanColumns.add(column);
+    }
+    tablePlan[0] = Object.freeze({kind: 'scan', columns: Object.freeze([...scanColumns])});
+  }
+  for (const expression of expressionNames) available.add(expression);
   for (const key of options.orderBy || []) {
     if (!available.has(key.column))
       throw new Error(`Relational order column not found: ${key.column}`);

--- a/modules/loader-utils/src/lib/scan-utils/relational-query.ts
+++ b/modules/loader-utils/src/lib/scan-utils/relational-query.ts
@@ -1,0 +1,120 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {ColumnarPredicate} from './columnar-predicate';
+import type {TableQueryOptions} from './table-query';
+import {planTableQuery} from './table-query';
+
+/** A scalar expression in the portable relational planner. */
+export type RelationalExpression = Readonly<{
+  /** Output alias for the expression. */
+  name: string;
+  /** Expression operator and operands. */
+  expression:
+    | {readonly op: 'column'; readonly column: string}
+    | {readonly op: 'literal'; readonly value: boolean | number | string | null}
+    | {
+        readonly op: 'add' | 'subtract' | 'multiply' | 'divide';
+        readonly left: string;
+        readonly right: string;
+      };
+}>;
+
+/** A portable ordering key. */
+export type RelationalOrderKey = Readonly<{
+  /** Column or expression name to order by. */
+  column: string;
+  /** Sort direction. */
+  direction?: 'asc' | 'desc';
+  /** Null placement. */
+  nulls?: 'first' | 'last';
+}>;
+
+/** A portable aggregate specification. */
+export type RelationalAggregate = Readonly<{
+  /** Aggregate function. */
+  function: 'count' | 'sum' | 'min' | 'max' | 'avg';
+  /** Input column, omitted for `count(*)`. */
+  column?: string;
+  /** Output alias. */
+  name: string;
+}>;
+
+/** A relational child query used by unions and joins. */
+export type RelationalChildQuery<PredicateT extends ColumnarPredicate = ColumnarPredicate> =
+  Readonly<{
+    /** Logical source name. */
+    source: string;
+    /** Portable table query applied to the child. */
+    query?: TableQueryOptions<PredicateT>;
+  }>;
+
+/** Portable relational extensions layered on top of a table scan. */
+export type RelationalQueryOptions<PredicateT extends ColumnarPredicate = ColumnarPredicate> =
+  TableQueryOptions<PredicateT> &
+    Readonly<{
+      /** Computed columns evaluated before projection. */
+      expressions?: readonly RelationalExpression[];
+      /** Stable ordering applied before the global limit. */
+      orderBy?: readonly RelationalOrderKey[];
+      /** Grouping keys for aggregate output. */
+      groupBy?: readonly string[];
+      /** Aggregate output definitions. */
+      aggregates?: readonly RelationalAggregate[];
+      /** Additional child queries to concatenate. */
+      union?: readonly RelationalChildQuery<PredicateT>[];
+      /** Optional equi-join child and key mapping. */
+      join?: Readonly<{child: RelationalChildQuery<PredicateT>; left: string; right: string}>;
+    }>;
+
+/** Logical operator in a relational query plan. */
+export type RelationalPlanStep = Readonly<{
+  kind: 'table-query' | 'expression' | 'order' | 'aggregate' | 'union' | 'join';
+  detail: unknown;
+}>;
+
+/** Validates and normalizes the relational extensions without executing them. */
+export function planRelationalQuery<PredicateT extends ColumnarPredicate = ColumnarPredicate>(
+  sourceColumnNames: readonly string[],
+  options: RelationalQueryOptions<PredicateT> = {}
+): {
+  readonly tablePlan: ReturnType<typeof planTableQuery>;
+  readonly relationalSteps: readonly RelationalPlanStep[];
+} {
+  const tablePlan = planTableQuery(sourceColumnNames, options);
+  const available = new Set(sourceColumnNames);
+  for (const expression of options.expressions || []) {
+    if (!expression.name) throw new Error('Relational expression names must be non-empty.');
+    if (available.has(expression.name)) {
+      throw new Error(`Relational expression duplicates column: ${expression.name}`);
+    }
+    available.add(expression.name);
+  }
+  for (const key of options.orderBy || []) {
+    if (!available.has(key.column))
+      throw new Error(`Relational order column not found: ${key.column}`);
+  }
+  for (const key of options.groupBy || []) {
+    if (!available.has(key)) throw new Error(`Relational group column not found: ${key}`);
+  }
+  for (const aggregate of options.aggregates || []) {
+    if (!aggregate.name) throw new Error('Relational aggregate names must be non-empty.');
+    if (aggregate.column && !available.has(aggregate.column)) {
+      throw new Error(`Relational aggregate column not found: ${aggregate.column}`);
+    }
+  }
+  const relationalSteps: RelationalPlanStep[] = [];
+  if (options.expressions?.length)
+    relationalSteps.push({kind: 'expression', detail: options.expressions});
+  if (options.orderBy?.length) relationalSteps.push({kind: 'order', detail: options.orderBy});
+  if (options.aggregates?.length || options.groupBy?.length) {
+    relationalSteps.push({
+      kind: 'aggregate',
+      detail: {groupBy: options.groupBy, aggregates: options.aggregates}
+    });
+  }
+  if (options.union?.length) relationalSteps.push({kind: 'union', detail: options.union});
+  if (options.join) relationalSteps.push({kind: 'join', detail: options.join});
+  return {tablePlan, relationalSteps: Object.freeze(relationalSteps)};
+}

--- a/modules/loader-utils/test/lib/scan-utils/raster-relational-query.cross.spec.ts
+++ b/modules/loader-utils/test/lib/scan-utils/raster-relational-query.cross.spec.ts
@@ -1,0 +1,64 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+import {planRelationalQuery, validateRasterQueryOptions} from '../../../src';
+
+describe('raster query validation', () => {
+  test('accepts bounded multiscale requests', () => {
+    expect(() =>
+      validateRasterQueryOptions({
+        bounds: [
+          [0, 1],
+          [10, 11]
+        ],
+        width: 256,
+        height: 128,
+        level: 2,
+        channels: [0, 3],
+        slices: {time: [0, 4]}
+      })
+    ).not.toThrow();
+  });
+
+  test('rejects inverted bounds and invalid dimensions', () => {
+    expect(() =>
+      validateRasterQueryOptions({
+        bounds: [
+          [2, 0],
+          [1, 1]
+        ]
+      })
+    ).toThrow();
+    expect(() => validateRasterQueryOptions({width: 0})).toThrow();
+    expect(() => validateRasterQueryOptions({level: -1})).toThrow();
+  });
+});
+
+describe('relational query planning', () => {
+  test('retains table plan and relational operators', () => {
+    const plan = planRelationalQuery(['id', 'value'], {
+      columns: ['id'],
+      expressions: [
+        {name: 'doubleValue', expression: {op: 'multiply', left: 'value', right: 'value'}}
+      ],
+      orderBy: [{column: 'doubleValue', direction: 'desc'}],
+      groupBy: ['id'],
+      aggregates: [{name: 'total', function: 'sum', column: 'value'}],
+      limit: 5
+    });
+    expect(plan.tablePlan.map(step => step.kind)).toEqual(['scan', 'project', 'limit']);
+    expect(plan.relationalSteps.map(step => step.kind)).toEqual([
+      'expression',
+      'order',
+      'aggregate'
+    ]);
+  });
+
+  test('rejects references to unavailable relational columns', () => {
+    expect(() => planRelationalQuery(['id'], {orderBy: [{column: 'missing'}]})).toThrow(
+      'Relational order column not found'
+    );
+  });
+});

--- a/modules/loader-utils/test/lib/scan-utils/raster-relational-query.cross.spec.ts
+++ b/modules/loader-utils/test/lib/scan-utils/raster-relational-query.cross.spec.ts
@@ -48,6 +48,7 @@ describe('relational query planning', () => {
       aggregates: [{name: 'total', function: 'sum', column: 'value'}],
       limit: 5
     });
+    expect(plan.tablePlan[0]).toMatchObject({kind: 'scan', columns: ['id', 'value']});
     expect(plan.tablePlan.map(step => step.kind)).toEqual(['scan', 'project', 'limit']);
     expect(plan.relationalSteps.map(step => step.kind)).toEqual([
       'expression',

--- a/modules/potree/src/lib/potree-node-source.ts
+++ b/modules/potree/src/lib/potree-node-source.ts
@@ -144,7 +144,7 @@ export class PotreeNodesSource extends DataSource<string, PotreeSourceLoaderOpti
     await this.initPromise;
     const fields = getPotreeSchemaFields(this.metadata?.pointAttributes || []);
     const schema = {fields, metadata: {}};
-    const bounds = this.boundingBox || this.nativeHierarchyBoundingBox;
+    const bounds = this.nativeHierarchyBoundingBox || this.boundingBox;
     return createScanQueryMetadata({
       sourceType: 'potree',
       queryType: 'point-cloud',
@@ -895,6 +895,7 @@ export class PotreeNodesSource extends DataSource<string, PotreeSourceLoaderOpti
   }
 }
 
+/** Builds query-visible fields from Potree point-attribute metadata. */
 function getPotreeSchemaFields(pointAttributes: PotreeMetadata['pointAttributes']): Field[] {
   if (!Array.isArray(pointAttributes)) {
     return [
@@ -911,6 +912,7 @@ function getPotreeSchemaFields(pointAttributes: PotreeMetadata['pointAttributes'
   return fields;
 }
 
+/** Maps one Potree attribute identifier to a loaders.gl field. */
 function getPotreeField(attribute: string): Field | undefined {
   const fieldTypes: Record<string, {name: string; type: DataType}> = {
     POSITION_CARTESIAN: {name: 'POSITION_CARTESIAN', type: 'float32'},
@@ -928,6 +930,7 @@ function getPotreeField(attribute: string): Field | undefined {
   return fieldType ? {...fieldType, nullable: false} : undefined;
 }
 
+/** Infers a query-panel semantic role from a Potree attribute name. */
 function inferPotreeColumnRole(
   name: string
 ): 'attribute' | 'x' | 'y' | 'z' | 'intensity' | 'classification' | 'color' {

--- a/modules/potree/src/lib/potree-node-source.ts
+++ b/modules/potree/src/lib/potree-node-source.ts
@@ -4,9 +4,14 @@
 
 import type {PotreeSourceLoaderOptions} from '../potree-source-loader';
 import type {CoreAPI, Loader, LoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';
-import {DataSource, resolvePath} from '@loaders.gl/loader-utils';
+import {
+  createScanQueryMetadata,
+  DataSource,
+  resolvePath,
+  type PointCloudQueryCapabilities
+} from '@loaders.gl/loader-utils';
 import {LASLoader} from '@loaders.gl/las';
-import type {Mesh, MeshArrowTable} from '@loaders.gl/schema';
+import type {DataType, Field, Mesh, MeshArrowTable} from '@loaders.gl/schema';
 import {convertMeshToTable} from '@loaders.gl/schema-utils';
 import {PotreeBoundingBox, PotreeMetadata} from '../types/potree-metadata';
 import {
@@ -47,6 +52,17 @@ export interface PotreeNodeMesh extends LASMesh {
  * @note Point cloud nodes tile source
  */
 export class PotreeNodesSource extends DataSource<string, PotreeSourceLoaderOptions> {
+  /** Common point-cloud scan capabilities exposed by Potree metadata and hierarchy nodes. */
+  readonly pointCloudQueryCapabilities: PointCloudQueryCapabilities = Object.freeze({
+    projection: 'pushdown',
+    predicate: 'residual',
+    limit: 'residual',
+    streaming: true,
+    cancellation: true,
+    bounds: 'pushdown',
+    levelOfDetail: 'pushdown',
+    spacing: 'pushdown'
+  });
   /** Dataset base URL */
   baseUrl: string = '';
   /** Metadata URL, preserving direct `cloud.js` inputs. */
@@ -121,6 +137,39 @@ export class PotreeNodesSource extends DataSource<string, PotreeSourceLoaderOpti
       formatSpecificMetadata: this.metadata,
       viewState: this.getViewState()
     };
+  }
+
+  /** Discovers point attributes and hierarchy bounds without loading node content. */
+  async getQueryMetadata() {
+    await this.initPromise;
+    const fields = getPotreeSchemaFields(this.metadata?.pointAttributes || []);
+    const schema = {fields, metadata: {}};
+    const bounds = this.boundingBox || this.nativeHierarchyBoundingBox;
+    return createScanQueryMetadata({
+      sourceType: 'potree',
+      queryType: 'point-cloud',
+      schema,
+      capabilities: {
+        table: this.pointCloudQueryCapabilities,
+        bounds: 'pushdown',
+        levelOfDetail: 'pushdown'
+      },
+      columnRoles: Object.fromEntries(
+        fields.map(field => [field.name, inferPotreeColumnRole(field.name)])
+      ),
+      spatial: bounds
+        ? {
+            bounds: {
+              minimum: [bounds.lx, bounds.ly, bounds.lz],
+              maximum: [bounds.ux, bounds.uy, bounds.uz]
+            },
+            coordinateReferenceSystems: this.metadata?.projection
+              ? [this.metadata.projection]
+              : undefined
+          }
+        : undefined,
+      statistics: this.metadata?.points === undefined ? undefined : {rowCount: this.metadata.points}
+    });
   }
 
   /** Is data set supported */
@@ -844,4 +893,50 @@ export class PotreeNodesSource extends DataSource<string, PotreeSourceLoaderOpti
       uy: Math.max(...latitudes)
     };
   }
+}
+
+function getPotreeSchemaFields(pointAttributes: PotreeMetadata['pointAttributes']): Field[] {
+  if (!Array.isArray(pointAttributes)) {
+    return [
+      {name: 'X', type: 'float64', nullable: false},
+      {name: 'Y', type: 'float64', nullable: false},
+      {name: 'Z', type: 'float64', nullable: false}
+    ];
+  }
+  const fields: Field[] = [];
+  for (const attribute of pointAttributes) {
+    const field = getPotreeField(attribute);
+    if (field) fields.push(field);
+  }
+  return fields;
+}
+
+function getPotreeField(attribute: string): Field | undefined {
+  const fieldTypes: Record<string, {name: string; type: DataType}> = {
+    POSITION_CARTESIAN: {name: 'POSITION_CARTESIAN', type: 'float32'},
+    RGBA_PACKED: {name: 'RGBA_PACKED', type: 'uint8'},
+    COLOR_PACKED: {name: 'COLOR_PACKED', type: 'uint8'},
+    RGB_PACKED: {name: 'RGB_PACKED', type: 'uint8'},
+    NORMAL_FLOATS: {name: 'NORMAL_FLOATS', type: 'float32'},
+    INTENSITY: {name: 'INTENSITY', type: 'uint16'},
+    CLASSIFICATION: {name: 'CLASSIFICATION', type: 'uint8'},
+    NORMAL_SPHEREMAPPED: {name: 'NORMAL_SPHEREMAPPED', type: 'uint8'},
+    NORMAL_OCT16: {name: 'NORMAL_OCT16', type: 'uint16'},
+    NORMAL: {name: 'NORMAL', type: 'float32'}
+  };
+  const fieldType = fieldTypes[attribute];
+  return fieldType ? {...fieldType, nullable: false} : undefined;
+}
+
+function inferPotreeColumnRole(
+  name: string
+): 'attribute' | 'x' | 'y' | 'z' | 'intensity' | 'classification' | 'color' {
+  const normalizedName = name.toLowerCase();
+  if (normalizedName === 'x' || normalizedName.includes('position_cartesian')) return 'x';
+  if (normalizedName === 'y') return 'y';
+  if (normalizedName === 'z') return 'z';
+  if (normalizedName.includes('intensity')) return 'intensity';
+  if (normalizedName.includes('classification')) return 'classification';
+  if (normalizedName.includes('color') || normalizedName.includes('rgb')) return 'color';
+  return 'attribute';
 }

--- a/modules/potree/test/potree-source.spec.ts
+++ b/modules/potree/test/potree-source.spec.ts
@@ -71,3 +71,15 @@ test('PotreeSourceLoader#exposes normalized tile headers and bounds', async t =>
 
   t.end();
 });
+
+test('PotreeSourceLoader#exposes point-cloud query metadata', async t => {
+  const source = PotreeSourceLoader.createDataSource(POTREE_BIN_URL, {});
+  await source.initialize();
+
+  const metadata = await source.getQueryMetadata();
+  t.equal(metadata.queryType, 'point-cloud');
+  t.ok(metadata.columns.some(column => column.role === 'color'));
+  t.equal(metadata.capabilities.bounds, 'pushdown');
+  t.equal(metadata.spatial?.bounds?.minimum.length, 3);
+  t.end();
+});

--- a/modules/zarr/src/ome-zarr-source-loader.ts
+++ b/modules/zarr/src/ome-zarr-source-loader.ts
@@ -9,7 +9,8 @@ import type {
   SourceLoader,
   DataSourceOptions,
   RasterData,
-  RasterChannelDataType
+  RasterChannelDataType,
+  RasterQueryCapabilities
 } from '@loaders.gl/loader-utils';
 import {DataSource} from '@loaders.gl/loader-utils';
 
@@ -167,6 +168,15 @@ export async function loadZarrConsolidatedMetadata(
  * Base runtime source for Zarr-backed sources that resolve groups and consolidated metadata.
  */
 export abstract class ZarrSource extends DataSource<string, ZarrSourceLoaderOptions> {
+  /** Common raster-query capabilities shared by Zarr-backed sources. */
+  readonly rasterQueryCapabilities: RasterQueryCapabilities = Object.freeze({
+    bounds: 'pushdown',
+    level: 'pushdown',
+    variables: 'pushdown',
+    slices: 'pushdown',
+    streaming: false,
+    cancellation: true
+  });
   /** Zarrita store used for metadata and chunk reads. */
   protected readonly store: zarrita.FetchStore;
   /** Selected group path within the store root. */
@@ -205,6 +215,11 @@ export abstract class ZarrSource extends DataSource<string, ZarrSourceLoaderOpti
         });
       }
     });
+  }
+
+  /** Returns raster-query capabilities without reading array chunks. */
+  getRasterQueryCapabilities(): RasterQueryCapabilities {
+    return this.rasterQueryCapabilities;
   }
 
   /** Fetches Zarr metadata or chunk data through the injected core API when available. */


### PR DESCRIPTION
## Goals

Implement the shared foundations for scan-architecture tranches 11–13 while preserving the existing table, tile, and raster source contracts.

## Changes

- Add point-cloud query metadata and capabilities to COPC and Potree, including coordinate roles, hierarchy bounds, level of detail, spacing, CRS, and point statistics.
- Add shared raster-query validation and capabilities for GeoTIFF/COG and Zarr/GeoZarr/OME-Zarr.
- Add a portable relational logical planner for ordering, scalar expressions, aggregates, unions, and equi-joins.
- Export the new contracts from `@loaders.gl/loader-utils`.
- Add an end-user format-family support matrix to the common scan documentation.
- Add focused validation and planner tests.

## Scope

This PR establishes the shared contracts and discovery layer. Physical point filtering and compaction, NetCDF adapter wiring, raster telemetry and explain integration, and backend execution for relational operators remain follow-up work because their physical semantics are source-specific.

## Verification

- `yarn lint fix`
- `yarn build`
- `yarn test-node modules/loader-utils/test/lib/scan-utils/raster-relational-query.cross.spec.ts`
