### PR TITLE
test: establish coverage summary baseline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -176,6 +176,10 @@ jobs:
       - name: Enforce per-package coverage ratchets
         run: yarn test-coverage-check
 
+      - name: Publish package coverage summary
+        if: always()
+        run: yarn test-coverage-summary
+
       - name: Sanitize lcov for Coveralls
         run: node ./scripts/sanitize-lcov.mjs coverage/lcov.info
 
@@ -195,6 +199,7 @@ jobs:
           path: |
             coverage/
             test-results/coverage-check.json
+            test-results/coverage-summary.md
           if-no-files-found: warn
 
   slow-tests:

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "test-audit": "node ./scripts/audit-tests.mjs",
     "test-profile": "node ./scripts/run-test-profile.mjs",
     "test-coverage-check": "node ./scripts/check-coverage-thresholds.mjs",
+    "test-coverage-summary": "node ./scripts/write-coverage-summary.mjs",
     "test-coverage-ratchet": "node ./scripts/check-coverage-thresholds.mjs --update",
     "test-vitest-async-guardrails": "node ./scripts/check-vitest-async-guardrails.mjs",
     "playwright:install": "playwright install chromium",

--- a/scripts/check-coverage-thresholds.mjs
+++ b/scripts/check-coverage-thresholds.mjs
@@ -26,6 +26,9 @@ const publishedPackages = findPublishedPackages();
 const results = [];
 const violations = [];
 
+checkCoverageSummaryFreshness('browser', browserSummary, violations);
+checkCoverageSummaryFreshness('merged', mergedSummary, violations);
+
 for (const publishedPackage of publishedPackages) {
   const browserCoverage = aggregatePackageCoverage(browserSummary, publishedPackage.path);
   const mergedCoverage = aggregatePackageCoverage(mergedSummary, publishedPackage.path);
@@ -140,6 +143,22 @@ function readJsonFile(filePath) {
     throw new Error(`Required coverage file does not exist: ${path.relative(repositoryRoot, filePath)}`);
   }
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+/** Rejects a coverage summary that contains source records but no executed code. */
+function checkCoverageSummaryFreshness(coverageKind, coverageSummary, violations_) {
+  const total = coverageSummary.total;
+  if (!total || total.statements?.total === 0) {
+    return;
+  }
+
+  const coveredStatements = total.statements?.covered || 0;
+  if (coveredStatements === 0) {
+    violations_.push(
+      `${coverageKind} coverage summary contains ${total.statements.total} statements but ` +
+        'zero covered statements; regenerate the report before checking thresholds'
+    );
+  }
 }
 
 /** Discovers non-private published packages under modules. */

--- a/scripts/write-coverage-summary.mjs
+++ b/scripts/write-coverage-summary.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repositoryRoot = process.cwd();
+const inputPath = path.resolve(process.argv[2] || 'test-results/coverage-check.json');
+const outputPath = path.resolve(process.argv[3] || 'test-results/coverage-summary.md');
+const report = readJson(inputPath);
+const metrics = ['statements', 'lines', 'functions', 'branches'];
+const rows = [...report.results].sort((left, right) => {
+  const leftFloor = Math.min(...metrics.map(metric => left.merged[metric].percentage));
+  const rightFloor = Math.min(...metrics.map(metric => right.merged[metric].percentage));
+  return leftFloor - rightFloor || left.name.localeCompare(right.name);
+});
+
+const lines = [
+  '# Coverage summary',
+  '',
+  `Generated: ${report.generatedAt}`,
+  `Target: ${report.target}% | Packages at target: ${report.packagesAtTarget}/${report.packageCount}`,
+  '',
+  '| Package | Browser S/L/F/B | Merged S/L/F/B | Lowest merged metric |',
+  '| --- | ---: | ---: | ---: |'
+];
+
+for (const result of rows) {
+  const browser = formatMetrics(result.browser);
+  const merged = formatMetrics(result.merged);
+  const lowestMetric = metrics.reduce((lowest, metric) =>
+    result.merged[metric].percentage < result.merged[lowest].percentage ? metric : lowest
+  );
+  lines.push(
+    `| ${result.name} | ${browser} | ${merged} | ${lowestMetric} ` +
+      `${result.merged[lowestMetric].percentage.toFixed(2)}% |`
+  );
+}
+
+if (report.violations.length > 0) {
+  lines.push('', '## Violations', '');
+  for (const violation of report.violations) {
+    lines.push(`- ${violation}`);
+  }
+}
+
+fs.mkdirSync(path.dirname(outputPath), {recursive: true});
+fs.writeFileSync(outputPath, `${lines.join('\n')}\n`);
+
+if (process.env.GITHUB_STEP_SUMMARY) {
+  fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${lines.join('\n')}\n`);
+}
+
+console.log(`Coverage summary written to ${path.relative(repositoryRoot, outputPath)}`);
+
+/** Reads a required JSON report. */
+function readJson(filePath) {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Required coverage report does not exist: ${path.relative(repositoryRoot, filePath)}`);
+  }
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+/** Formats the four coverage metrics in the stable roadmap order. */
+function formatMetrics(coverage) {
+  return metrics.map(metric => `${coverage[metric].percentage.toFixed(2)}%`).join('/');
+}


### PR DESCRIPTION
## Goals

Establish a trustworthy first tranche for the loaders.gl coverage roadmap by rejecting stale aggregate reports and publishing package-level coverage visibility in CI.

## Changes

- Reject browser or merged coverage summaries that contain source statements but zero covered statements.
- Add `yarn test-coverage-summary` to generate a sortable Markdown report for all published packages with browser and merged S/L/F/B metrics.
- Append the report to the GitHub Actions step summary when available.
- Upload the Markdown report as part of the merged coverage artifact.

## Validation

- `node --check scripts/check-coverage-thresholds.mjs`
- `node --check scripts/write-coverage-summary.mjs`
- `package.json` JSON parse check
- `git diff --check`

The full test audit could not run locally because the fresh worktree has no installed Yarn dependency state; CI should run the complete coverage and audit jobs.