### PR TITLE
feat(3d-tiles): support implicit multiple contents

### DIFF
--- a/docs/modules/3d-tiles/concepts/implicit-tiling-and-subtrees.md
+++ b/docs/modules/3d-tiles/concepts/implicit-tiling-and-subtrees.md
@@ -6,6 +6,15 @@ import {Tiles3DDocsTabs} from '@site/src/components/docs/tiles-3d-docs-tabs';
 
 Implicit tiling describes a regular quadtree or octree with coordinate templates instead of listing every tile header in the root tileset JSON. Availability files called **subtrees** say which tiles, content resources, and deeper subtrees exist. loaders.gl loads these availability files lazily so a large implicit tileset can become traversable without downloading its complete hierarchy.
 
+### Multiple content streams
+
+An implicit tile may declare several content templates. The subtree's `contentAvailability` array is
+aligned with those templates in source order: each available stream is expanded independently and
+emitted in the tile header's `content` array and `contentUrls` list. A tile with one available
+stream keeps the legacy single-object `content` shape, and a tile with no available streams remains
+a contentless connector. Content headers stay associated with their stream, even when an earlier
+stream is unavailable.
+
 ## Explicit and Implicit Hierarchies
 
 An explicit tile stores its child headers directly in `children`. An implicit root stores:
@@ -162,7 +171,8 @@ The underscored SSE field is diagnostic rather than stable API. Use these values
 
 ## Current Limitations
 
-- Only the first `contentAvailability` stream is used; `3DTILES_multiple_contents` is not implemented.
+- Implicit multiple-content availability is materialized in source order. Applications still decide
+  how to compose or render heterogeneous content types returned by the streams.
 - Subtree metadata references (`propertyTables`, `tileMetadata`, `contentMetadata`, and
   `subtreeMetadata`) are preserved on generated headers as `implicitMetadata`. The runtime does not
   yet decode property-table classes, enums, or values.

--- a/docs/modules/3d-tiles/formats/3d-tiles.md
+++ b/docs/modules/3d-tiles/formats/3d-tiles.md
@@ -23,6 +23,7 @@ provides a visual implementation for that feature.
 | 3D Tiles 1.1 tileset JSON | [x] | Includes implicit-tiling and metadata declarations. |
 | Explicit child hierarchies | [x] | Traversed by [`Tileset3D`](../../tiles/api-reference/tileset-3d). |
 | Lazy implicit subtrees | [x] | Availability resources are requested after visibility and LOD checks. |
+| Implicit multiple contents | [x] | All declared content-availability streams produce ordered `content` and `contentUrls` entries. |
 | `REPLACE` refinement | [x] | Ancestors are replaced as children become renderable. |
 | `ADD` refinement | [x] | Ancestors and descendants may render together. |
 | Geometric-error transform scaling | [x] | Uses the conservative maximum scale component. |

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -279,6 +279,7 @@ A minor release that includes:
 - **3D Tiles 1.1 Extensions** `EXT_mesh_features` and `EXT_structural_metadata` are now supported.
 - **3D Tiles format compatibility** - Added a checked compatibility matrix covering tileset traversal, tile payloads, extensions, metadata, and known renderer limitations. Multiple explicit contents are normalized, loaded in source order, and exposed through `Tile3D.contents` while preserving the legacy primary `Tile3D.content` field.
 - **Implicit subtree metadata** - Generated implicit-tile headers now preserve subtree property-table and tile/content/subtree metadata references through `implicitMetadata`, without pretending to decode metadata values before structural metadata support is complete.
+- **Implicit multiple contents** - Implicit subtrees now preserve every content-availability stream and materialize available content URLs in source order, while retaining the legacy single-content shape when only one stream is available.
 - **i3dm orientation** - Instanced 3D Model tiles now decode `NORMAL_UP_OCT32P` and `NORMAL_RIGHT_OCT32P`, including quantized-position fixtures, and use the decoded basis for per-instance transforms.
 - **Transform-correct LOD** Geometric error is scaled conservatively by composed tile and tileset transforms without compounding after runtime updates.
 - **Projection-correct SSE** Orthographic viewports use `metersPerPixel`, while perspective and orthographic traversal consistently use logical pixels without a second device-pixel-ratio correction.

--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile-header.ts
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile-header.ts
@@ -293,9 +293,18 @@ export async function normalizeImplicitTileHeaders(
   const contentUriTemplate = contentEntries[0]?.uri || contentEntries[0]?.url || '';
   const descriptor: ImplicitTilingDescriptor = {
     contentUrlTemplate: contentUriTemplate ? resourceResolver.resolve(contentUriTemplate) : '',
+    contentUrlTemplates: contentEntries.map(contentEntry => {
+      const contentUri = contentEntry?.uri || contentEntry?.url || '';
+      return contentUri ? resourceResolver.resolve(contentUri) : '';
+    }),
     contentHeader: contentEntries[0]
       ? {...contentEntries[0], uri: undefined, url: undefined}
       : undefined,
+    contentHeaders: contentEntries.map(contentEntry => ({
+      ...contentEntry,
+      uri: undefined,
+      url: undefined
+    })),
     subtreesUrlTemplate: resourceResolver.resolve(implicitTilingExtension.subtrees.uri),
     subdivisionScheme: implicitTilingExtension.subdivisionScheme,
     subtreeLevels: implicitTilingExtension.subtreeLevels,

--- a/modules/tiles/src/tileset-3d/format-3d-tiles/implicit-tiling.ts
+++ b/modules/tiles/src/tileset-3d/format-3d-tiles/implicit-tiling.ts
@@ -23,8 +23,12 @@ export type ImplicitTileCoordinates = {
 export type ImplicitTilingDescriptor = {
   /** Absolute template URL for render content, or an empty string for a contentless hierarchy. */
   contentUrlTemplate: string;
+  /** Absolute templates for every implicit content stream, in source order. */
+  contentUrlTemplates?: string[];
   /** Non-URI content metadata inherited by each available implicit content resource. */
   contentHeader?: Record<string, any>;
+  /** Metadata inherited by every implicit content stream, in source order. */
+  contentHeaders?: Array<Record<string, any>>;
   /** Absolute template URL for subtree availability files. */
   subtreesUrlTemplate: string;
   /** Spatial subdivision used by the hierarchy. */
@@ -66,7 +70,7 @@ export type ParsedImplicitSubtree = {
   /** Availability of tiles inside this subtree. */
   tileAvailability: ImplicitAvailability;
   /**
-   * Availability of tile content; only the first multiple-content stream is currently used.
+   * Availability of tile content. Array entries correspond to content templates in source order.
    * Omitted availability denotes a metadata-only subtree with no render content.
    */
   contentAvailability?: ImplicitAvailability | ImplicitAvailability[];
@@ -220,8 +224,8 @@ function materializeAvailableTile(
   }
 
   counters.tileCount++;
-  const contentAvailable = getAvailabilityValue(
-    getPrimaryContentAvailability(subtree.contentAvailability),
+  const contentAvailability = getContentAvailability(
+    subtree.contentAvailability,
     availabilityIndex
   );
   const children: ImplicitTileHeader[] = [];
@@ -269,7 +273,7 @@ function materializeAvailableTile(
     descriptor,
     reference,
     globalCoordinates,
-    contentAvailable,
+    contentAvailability,
     children
   );
 }
@@ -311,7 +315,7 @@ function createLazyImplicitTileHeader(
  * @param descriptor - Shared implicit hierarchy description.
  * @param reference - Current subtree reference used to build stable IDs.
  * @param coordinates - Global tile coordinates.
- * @param contentAvailable - Whether the subtree declares render content for this tile.
+ * @param contentAvailability - Availability for each content stream in source order.
  * @param children - Materialized or lazy child headers.
  * @returns Runtime tile header.
  */
@@ -320,20 +324,39 @@ function formatImplicitTileHeader(
   descriptor: ImplicitTilingDescriptor,
   reference: ImplicitSubtreeReference,
   coordinates: ImplicitTileCoordinates,
-  contentAvailable: boolean,
+  contentAvailability: boolean[],
   children: ImplicitTileHeader[]
 ): ImplicitTileHeader {
-  const contentUrl =
-    contentAvailable && descriptor.contentUrlTemplate
-      ? replaceImplicitUrlTemplate(descriptor.contentUrlTemplate, coordinates)
-      : undefined;
+  const contentUrlTemplates = descriptor.contentUrlTemplates?.length
+    ? descriptor.contentUrlTemplates
+    : [descriptor.contentUrlTemplate];
+  const contentEntries = contentUrlTemplates
+    .map((templateUrl, contentIndex) => {
+      if (!contentAvailability[contentIndex] || !templateUrl) {
+        return null;
+      }
+      return {
+        contentIndex,
+        contentUrl: replaceImplicitUrlTemplate(templateUrl, coordinates)
+      };
+    })
+    .filter((entry): entry is {contentIndex: number; contentUrl: string} => Boolean(entry));
+  const availableContentUrls = contentEntries.map(entry => entry.contentUrl);
+  const content = contentEntries.map(({contentIndex, contentUrl}) => ({
+    ...(descriptor.contentHeaders?.[contentIndex] ||
+      (contentIndex === 0 ? descriptor.contentHeader : {}) ||
+      {}),
+    uri: contentUrl
+  }));
+  const contentUrl = availableContentUrls[0];
   const lodMetricValue = descriptor.rootLodMetricValue / 2 ** coordinates.level;
 
   return {
     id: getImplicitTileId(reference, coordinates),
     children,
     contentUrl,
-    content: contentUrl ? {...descriptor.contentHeader, uri: contentUrl} : undefined,
+    content: content.length > 1 ? content : content[0],
+    contentUrls: availableContentUrls,
     refine: descriptor.refine,
     type: getImplicitTileType(contentUrl),
     lodMetricType: descriptor.lodMetricType,
@@ -411,17 +434,17 @@ function getAvailabilityValue(availability: ImplicitAvailability, index: number)
 }
 
 /**
- * Selects the first content availability stream until multiple contents are supported.
+ * Reads every content availability stream for one tile in descriptor/source order.
  *
  * @param availability - Single or multiple-content availability declaration.
- * @returns Primary content availability declaration.
+ * @returns Availability flags aligned with the content URL templates.
  */
-function getPrimaryContentAvailability(
-  availability: ImplicitAvailability | ImplicitAvailability[] | undefined
-): ImplicitAvailability {
-  return Array.isArray(availability)
-    ? availability[0] || {constant: 0}
-    : availability || {constant: 0};
+function getContentAvailability(
+  availability: ImplicitAvailability | ImplicitAvailability[] | undefined,
+  index: number
+): boolean[] {
+  const streams = Array.isArray(availability) ? availability : [availability];
+  return streams.map(stream => getAvailabilityValue(stream || {constant: 0}, index));
 }
 
 /**

--- a/modules/tiles/test/tileset/implicit-tiling.spec.ts
+++ b/modules/tiles/test/tileset/implicit-tiling.spec.ts
@@ -59,6 +59,57 @@ test('implicit tiling materializes one sparse subtree and leaves lazy boundaries
   t.end();
 });
 
+test('implicit tiling materializes multiple content streams in source order', t => {
+  const descriptor = createDescriptor({
+    contentUrlTemplates: [
+      'https://example.com/geometry/{level}/{x}/{y}/{z}.b3dm',
+      'https://example.com/metadata/{level}/{x}/{y}/{z}.json'
+    ],
+    contentHeaders: [{group: 'geometry'}, {group: 'metadata'}]
+  });
+  const result = materializeImplicitSubtree(
+    {
+      tileAvailability: {constant: 1},
+      contentAvailability: [{constant: 1}, {constant: 1}],
+      childSubtreeAvailability: {constant: 0}
+    },
+    createImplicitSubtreeReference(descriptor, {level: 0, x: 0, y: 0, z: 0})
+  );
+
+  t.equal(result.root.contentUrl, 'https://example.com/geometry/0/0/0/0.b3dm');
+  t.deepEqual(result.root.contentUrls, [
+    'https://example.com/geometry/0/0/0/0.b3dm',
+    'https://example.com/metadata/0/0/0/0.json'
+  ]);
+  t.deepEqual(result.root.content, [
+    {group: 'geometry', uri: 'https://example.com/geometry/0/0/0/0.b3dm'},
+    {group: 'metadata', uri: 'https://example.com/metadata/0/0/0/0.json'}
+  ]);
+  t.end();
+});
+
+test('implicit tiling preserves content-header indexes for sparse streams', t => {
+  const descriptor = createDescriptor({
+    contentUrlTemplates: [
+      'https://example.com/a/{level}.b3dm',
+      'https://example.com/b/{level}.json'
+    ],
+    contentHeaders: [{group: 'a'}, {group: 'b'}]
+  });
+  const result = materializeImplicitSubtree(
+    {
+      tileAvailability: {constant: 1},
+      contentAvailability: [{constant: 0}, {constant: 1}],
+      childSubtreeAvailability: {constant: 0}
+    },
+    createImplicitSubtreeReference(descriptor, {level: 0, x: 0, y: 0, z: 0})
+  );
+
+  t.equal(result.root.contentUrl, 'https://example.com/b/0.json');
+  t.deepEqual(result.root.content, {group: 'b', uri: 'https://example.com/b/0.json'});
+  t.end();
+});
+
 test('implicit tiling treats maximumLevel as the last zero-based available level', t => {
   const descriptor = createDescriptor({maximumLevel: 1});
   const subtree: ParsedImplicitSubtree = {


### PR DESCRIPTION
## Goals

Complete the next 3D Tiles parity tranche by supporting multiple content-availability streams in implicit subtrees while preserving existing single-content behavior.

## Changes

- Preserve every implicit content URL template and per-stream content header during tileset normalization.
- Materialize all available content streams in source order from subtree availability arrays.
- Keep legacy `content` object and `contentUrl` fields for one available stream, and expose ordered `content` arrays/`contentUrls` for multiple streams.
- Preserve correct header-to-stream association when earlier streams are unavailable.
- Add focused implicit-tiling tests and update the 3D Tiles compatibility matrix, implicit-tiling guide, and What's New.

## Scope

This addresses the implicit multiple-content follow-up tracked in #1245. Heterogeneous content composition remains the application's responsibility.

## Validation

- `yarn lint fix`
- Focused Chromium suite: `yarn test-headless modules/tiles/test/tileset/implicit-tiling.spec.ts` (9 passed)
- `yarn build` reached the affected tiles build; the repository build is currently blocked by pre-existing missing `@bufbuild/protobuf` dependencies in `modules/traces`.
