### PR TITLE
docs(zarr): better attributions / Zarrita usage etc

### DIFF
--- a/docs/modules/zarr/README.md
+++ b/docs/modules/zarr/README.md
@@ -52,5 +52,8 @@ store directly from S3 and renders monthly solar irradiance on an interactive ma
 
 ## Attributions
 
-The OME-Zarr source uses [zarrita.js](https://zarrita.dev/) under the MIT license. The legacy Zarr
-v2 API wraps [zarr.js](https://github.com/gzuidhof/zarr.js/) under the MIT license.
+The OME-Zarr and GeoZarr source loaders use the independent
+[zarrita.js project](https://github.com/manzt/zarrita.js), documented at
+[zarrita.dev](https://zarrita.dev/), under the MIT license. It is the Zarr engine used by these
+loaders, not a loaders.gl development fork or seed project. The legacy Zarr v2 API wraps
+[zarr.js](https://github.com/gzuidhof/zarr.js/) under the MIT license.

--- a/docs/modules/zarr/README.md
+++ b/docs/modules/zarr/README.md
@@ -50,7 +50,7 @@ well as the regular one-dimensional coordinate arrays commonly written by xarray
 The [GeoZarr deck.gl example](/examples/geospatial/geo-zarr) reads a public NASA POWER climatology
 store directly from S3 and renders monthly solar irradiance on an interactive map.
 
-## Attributions
+# Attributions
 
 The OME-Zarr and GeoZarr source loaders use the independent
 [zarrita.js project](https://github.com/manzt/zarrita.js), documented at

--- a/docs/modules/zarr/api-reference/geo-zarr-source-loader.md
+++ b/docs/modules/zarr/api-reference/geo-zarr-source-loader.md
@@ -8,6 +8,8 @@
 
 `GeoZarrSourceLoader` opens a numeric Zarr data variable as a viewport-driven geospatial raster
 source. It supports Zarr v2 and v3 stores through Zarrita.
+Zarrita provides the store access and array chunk decoding, while loaders.gl supplies the
+viewport-driven `RasterSource` API and normalized GeoZarr metadata.
 
 The source recognizes two interoperable metadata patterns:
 

--- a/docs/modules/zarr/api-reference/geo-zarr-source-loader.md
+++ b/docs/modules/zarr/api-reference/geo-zarr-source-loader.md
@@ -8,7 +8,8 @@
 
 `GeoZarrSourceLoader` opens a numeric Zarr data variable as a viewport-driven geospatial raster
 source. It supports Zarr v2 and v3 stores through Zarrita.
-Zarrita provides the store access and array chunk decoding, while loaders.gl supplies the
+The independent [zarrita.js project](https://github.com/manzt/zarrita.js) provides store access
+and array chunk decoding, while loaders.gl supplies the
 viewport-driven `RasterSource` API and normalized GeoZarr metadata.
 
 The source recognizes two interoperable metadata patterns:

--- a/docs/modules/zarr/api-reference/geo-zarr-source-loader.md
+++ b/docs/modules/zarr/api-reference/geo-zarr-source-loader.md
@@ -8,8 +8,7 @@
 
 `GeoZarrSourceLoader` opens a numeric Zarr data variable as a viewport-driven geospatial raster
 source. It supports Zarr v2 and v3 stores through Zarrita.
-The independent [zarrita.js project](https://github.com/manzt/zarrita.js) provides store access
-and array chunk decoding, while loaders.gl supplies the
+The source uses Zarrita for store access and array chunk decoding, while loaders.gl supplies the
 viewport-driven `RasterSource` API and normalized GeoZarr metadata.
 
 The source recognizes two interoperable metadata patterns:
@@ -106,3 +105,9 @@ GeoZarr layouts.
 
 The GeoZarr conventions are still pre-stable. The source therefore retains original group and array
 attributes in `metadata` and treats unknown optional fields as ignorable.
+
+# Attributions
+
+This source uses the independent [zarrita.js project](https://github.com/manzt/zarrita.js),
+documented at [zarrita.dev](https://zarrita.dev/), for Zarr store access and chunk decoding.
+loaders.gl supplies the viewport-driven raster API and normalized GeoZarr metadata.

--- a/docs/modules/zarr/api-reference/ome-zarr-source-loader.md
+++ b/docs/modules/zarr/api-reference/ome-zarr-source-loader.md
@@ -7,7 +7,8 @@
 </p>
 
 `OMEZarrSourceLoader` creates a non-geospatial source for OME-Zarr v2 and v3 image pyramids.
-It uses [zarrita.js](https://zarrita.dev/) for Zarr store access and chunk decoding; loaders.gl
+It uses the independent [zarrita.js project](https://github.com/manzt/zarrita.js), documented at
+[zarrita.dev](https://zarrita.dev/), for Zarr store access and chunk decoding; loaders.gl
 adds the source lifecycle, metadata normalization, cancellation, and raster result contract.
 
 ## Usage

--- a/docs/modules/zarr/api-reference/ome-zarr-source-loader.md
+++ b/docs/modules/zarr/api-reference/ome-zarr-source-loader.md
@@ -7,6 +7,8 @@
 </p>
 
 `OMEZarrSourceLoader` creates a non-geospatial source for OME-Zarr v2 and v3 image pyramids.
+It uses [zarrita.js](https://zarrita.dev/) for Zarr store access and chunk decoding; loaders.gl
+adds the source lifecycle, metadata normalization, cancellation, and raster result contract.
 
 ## Usage
 

--- a/docs/modules/zarr/api-reference/ome-zarr-source-loader.md
+++ b/docs/modules/zarr/api-reference/ome-zarr-source-loader.md
@@ -7,9 +7,6 @@
 </p>
 
 `OMEZarrSourceLoader` creates a non-geospatial source for OME-Zarr v2 and v3 image pyramids.
-It uses the independent [zarrita.js project](https://github.com/manzt/zarrita.js), documented at
-[zarrita.dev](https://zarrita.dev/), for Zarr store access and chunk decoding; loaders.gl
-adds the source lifecycle, metadata normalization, cancellation, and raster result contract.
 
 ## Usage
 
@@ -82,3 +79,10 @@ can use to browse SpatialData-style roots before opening a specific image group.
 
 The source reads numeric OME-Zarr image planes and pyramids. It does not yet normalize SpatialData
 tables, points, shapes, or coordinate systems into loaders.gl data sources.
+
+# Attributions
+
+This source uses the independent [zarrita.js project](https://github.com/manzt/zarrita.js),
+documented at [zarrita.dev](https://zarrita.dev/), for Zarr store access and chunk decoding.
+loaders.gl adds the source lifecycle, metadata normalization, cancellation, and raster result
+contract.

--- a/modules/zarr/README.md
+++ b/modules/zarr/README.md
@@ -10,8 +10,10 @@ This module contains loaders for the Zarr format.
 
 ## Implementation
 
-The source-loader APIs in this module use [zarrita.js](https://zarrita.dev/) to open Zarr v2 and
-v3 stores, discover metadata, and decode array chunks. loaders.gl provides the `DataSource`,
+The source-loader APIs in this module use the independent
+[zarrita.js project](https://github.com/manzt/zarrita.js) (see its
+[documentation](https://zarrita.dev/)) to open Zarr v2 and v3 stores, discover metadata, and
+decode array chunks. loaders.gl provides the `DataSource`,
 `RasterSource`, selection, cancellation, and metadata contracts around Zarrita. The legacy
 `loadZarr()` pixel-pyramid API continues to use its existing `zarr.js` implementation.
 

--- a/modules/zarr/README.md
+++ b/modules/zarr/README.md
@@ -8,15 +8,6 @@
 
 This module contains loaders for the Zarr format.
 
-## Implementation
-
-The source-loader APIs in this module use the independent
-[zarrita.js project](https://github.com/manzt/zarrita.js) (see its
-[documentation](https://zarrita.dev/)) to open Zarr v2 and v3 stores, discover metadata, and
-decode array chunks. loaders.gl provides the `DataSource`,
-`RasterSource`, selection, cancellation, and metadata contracts around Zarrita. The legacy
-`loadZarr()` pixel-pyramid API continues to use its existing `zarr.js` implementation.
-
 ## Exports
 
 - `loadZarr()` and `ZarrPixelSource` for the existing pixel-pyramid API
@@ -103,3 +94,11 @@ const imageMetadata = await imageSource.getMetadata();
 
 See the [`OMEZarrSourceLoader` API reference](https://loaders.gl/docs/modules/zarr/api-reference/ome-zarr-source-loader)
 for source options, raster output layout, and current scope.
+
+# Attributions
+
+The source-loader APIs use the independent [zarrita.js project](https://github.com/manzt/zarrita.js),
+with [documentation at zarrita.dev](https://zarrita.dev/), to open Zarr v2 and v3 stores, discover
+metadata, and decode array chunks. loaders.gl provides the `DataSource`, `RasterSource`, selection,
+cancellation, and metadata contracts around Zarrita. The legacy `loadZarr()` pixel-pyramid API
+continues to use its existing [zarr.js implementation](https://github.com/gzuidhof/zarr.js/).

--- a/modules/zarr/README.md
+++ b/modules/zarr/README.md
@@ -8,6 +8,13 @@
 
 This module contains loaders for the Zarr format.
 
+## Implementation
+
+The source-loader APIs in this module use [zarrita.js](https://zarrita.dev/) to open Zarr v2 and
+v3 stores, discover metadata, and decode array chunks. loaders.gl provides the `DataSource`,
+`RasterSource`, selection, cancellation, and metadata contracts around Zarrita. The legacy
+`loadZarr()` pixel-pyramid API continues to use its existing `zarr.js` implementation.
+
 ## Exports
 
 - `loadZarr()` and `ZarrPixelSource` for the existing pixel-pyramid API


### PR DESCRIPTION
## Goals

Document the Zarrita dependency behind the loaders.gl Zarr source APIs.

## Changes

- identify Zarrita as the Zarr v2/v3 store and chunk-decoding engine
- clarify the loaders.gl source, raster, selection, cancellation, and metadata responsibilities
- distinguish the legacy `loadZarr()`/`zarr.js` implementation

## Validation

- yarn lint fix
