### PR TITLE
feat(copc): progressively decode RGB and NIR layers

### DIFF
--- a/docs/modules/copc/api-reference/copc-source-loader.md
+++ b/docs/modules/copc/api-reference/copc-source-loader.md
@@ -34,14 +34,14 @@ The created data source exposes the point-cloud tile methods used by `PointCloud
 - `getRootTile()` returns the root octree tile header.
 - `getChildren(tile)` returns available child tile headers.
 - `loadTileContent(tile)` returns normalized point positions, optional colors, point count, and cartographic origin.
-- `loadTileContentInBatches(tile, options)` yields normalized Arrow point tables progressively after the selected node range has been fetched. The TypeScript LAZ variant is required. `options.batchSize` controls the maximum points per table, `options.columns` can request positions only, and `options.signal` cancels the request/decode.
+- `loadTileContentInBatches(tile, options)` yields normalized Arrow point tables progressively as the selected node range is fetched. The TypeScript LAZ variant is required. `options.batchSize` controls the maximum points per table, `options.columns` can request `POSITION`, `COLOR_0`, and `NIR`, and `options.signal` cancels the request/decode.
 - `loadHierarchyInBatches(options)` yields hierarchy pages and their discovered nodes as they are fetched.
 
-For TypeScript position-only batches, `loadTileContentInBatches` splits the node range into sequential requests and can emit positions as soon as the Point14 layer arrives. RGB requests still use one complete node range until progressive RGB decoding is implemented. `options.rangeChunkSize` controls the position-only request size.
+For TypeScript PDRF 6-8 batches, `loadTileContentInBatches` splits the node range into sequential requests and emits rows as soon as the requested independent layers arrive. PDRF 7 RGB waits for Point14 and RGB; PDRF 8 RGB/NIR waits for the layers requested through `options.columns`. `options.rangeChunkSize` controls the request size.
 
 ## Options
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
 | `copc.sourceCoordinateSystem` | `string` | Auto-detected from COPC WKT | Coordinate system definition used when the source metadata does not include WKT. |
-| `copc.rangeChunkSize` | `number` | `65536` | Default byte size for position-only TypeScript COPC node range requests. |
+| `copc.rangeChunkSize` | `number` | `65536` | Default byte size for TypeScript COPC node range requests. |

--- a/modules/copc/src/copc-source-loader.ts
+++ b/modules/copc/src/copc-source-loader.ts
@@ -71,7 +71,7 @@ export type COPCTileContentBatchOptions = {
   /** Optional cancellation signal for the range request and decode loop. */
   signal?: AbortSignal;
   /** Arrow attributes to populate. POSITION is always included. */
-  columns?: readonly ('POSITION' | 'COLOR_0')[];
+  columns?: readonly ('POSITION' | 'COLOR_0' | 'NIR')[];
   /** Byte size for progressive node range requests. */
   rangeChunkSize?: number;
 };
@@ -366,69 +366,41 @@ export class COPCTileSource
     const colors =
       pointFormatHasColor(copc.header.pointDataRecordFormat) &&
       (options.columns ? options.columns.includes('COLOR_0') : true);
+    const nir =
+      copc.header.pointDataRecordFormat === 8 && Boolean(options.columns?.includes('NIR'));
     const rangeChunkSize = options.rangeChunkSize ?? this.options.copc?.rangeChunkSize ?? 65536;
     if (!Number.isSafeInteger(rangeChunkSize) || rangeChunkSize < 1) {
       throw new Error('COPC progressive rangeChunkSize must be a positive integer');
     }
 
-    if (!colors) {
-      yield* this.loadPositionOnlyTileContentInBatches(
-        copc,
-        node,
-        nativeOrigin,
-        cartographicOrigin,
-        batchSize,
-        rangeChunkSize,
-        options.signal
-      );
-      return;
+    if (options.columns?.includes('NIR') && copc.header.pointDataRecordFormat !== 8) {
+      throw new Error('COPC NIR output requires PDRF 8');
     }
 
-    const compressed = await Copc.loadCompressedPointDataBuffer(this._urlOrGetter, node);
-    const cursor = createLAZChunkDecoderCursor(compressed, {
-      pointCount: node.pointCount,
-      pointDataRecordFormat: copc.header.pointDataRecordFormat,
-      pointDataRecordLength: copc.header.pointDataRecordLength
-    });
-
-    while (cursor.remainingPointCount > 0) {
-      if (options.signal?.aborted) {
-        throw new Error('COPC progressive tile decode was aborted');
-      }
-      const pointCount = Math.min(batchSize, cursor.remainingPointCount);
-      const nativePositions = new Float64Array(pointCount * 3);
-      const positions = new Float32Array(pointCount * 3);
-      const batchColors = colors ? new Uint16Array(pointCount * 3) : null;
-      const decodedPointCount = cursor.decodeIntoPointData(
-        {
-          positions: nativePositions,
-          rawColors: batchColors,
-          pointOffset: 0,
-          scale: copc.header.scale,
-          offset: copc.header.offset
-        },
-        pointCount
-      );
-      if (decodedPointCount !== pointCount) {
-        throw new Error(
-          `COPC TypeScript LAZ decoder produced ${decodedPointCount} points; expected ${pointCount}`
-        );
-      }
-
-      this.transformTilePositions(nativePositions, positions, nativeOrigin, cartographicOrigin);
-      yield this.createTileContentResult(pointCount, positions, batchColors, cartographicOrigin);
-    }
+    yield* this.loadProgressiveTileContentInBatches(
+      copc,
+      node,
+      nativeOrigin,
+      cartographicOrigin,
+      batchSize,
+      rangeChunkSize,
+      options.signal,
+      colors,
+      nir
+    );
   }
 
-  /** Yield position-only batches while the node range is still arriving. */
-  protected async *loadPositionOnlyTileContentInBatches(
+  /** Yield selectively requested batches while the node range is still arriving. */
+  protected async *loadProgressiveTileContentInBatches(
     copc: Copc,
     node: Hierarchy.Node,
     nativeOrigin: number[],
     cartographicOrigin: number[],
     batchSize: number,
     rangeChunkSize: number,
-    signal?: AbortSignal
+    signal: AbortSignal | undefined,
+    colors: boolean,
+    nir: boolean
   ): AsyncIterable<COPCTileContent> {
     const decoder = createLAZChunkDecoder({
       pointCount: node.pointCount,
@@ -443,55 +415,65 @@ export class COPCTileSource
       signal
     )) {
       decoder.feed(compressedChunk);
-      yield* this.readPositionOnlyBatches(
+      yield* this.readProgressiveBatches(
         decoder,
         copc,
         node.pointCount,
         nativeOrigin,
         cartographicOrigin,
         batchSize,
-        decodedPointCount
+        decodedPointCount,
+        colors,
+        nir
       );
       decodedPointCount = node.pointCount - decoder.remainingPointCount;
     }
 
     decoder.close();
     if (decodedPointCount < node.pointCount) {
-      yield* this.readPositionOnlyBatches(
+      yield* this.readProgressiveBatches(
         decoder,
         copc,
         node.pointCount,
         nativeOrigin,
         cartographicOrigin,
         batchSize,
-        decodedPointCount
+        decodedPointCount,
+        colors,
+        nir
       );
       decodedPointCount = node.pointCount - decoder.remainingPointCount;
     }
     if (decodedPointCount !== node.pointCount) {
       throw new Error(
-        `COPC TypeScript LAZ position decoder produced ${decodedPointCount} points; expected ${node.pointCount}`
+        `COPC TypeScript LAZ point-data decoder produced ${decodedPointCount} points; expected ${node.pointCount}`
       );
     }
   }
 
-  /** Read all currently available position-only batches from a feedable decoder. */
-  protected *readPositionOnlyBatches(
+  /** Read all currently available selectively requested batches from a feedable decoder. */
+  protected *readProgressiveBatches(
     decoder: ReturnType<typeof createLAZChunkDecoder>,
     copc: Copc,
     nodePointCount: number,
     nativeOrigin: number[],
     cartographicOrigin: number[],
     batchSize: number,
-    decodedPointCount: number
+    decodedPointCount: number,
+    includeColors: boolean,
+    includeNir: boolean
   ): Iterable<COPCTileContent> {
     while (decodedPointCount < nodePointCount) {
       const pointCount = Math.min(batchSize, nodePointCount - decodedPointCount);
       const nativePositions = new Float64Array(pointCount * 3);
       const positions = new Float32Array(pointCount * 3);
-      const decoded = decoder.readPositionDataBatch(
+      const batchColors = includeColors ? new Uint16Array(pointCount * 3) : null;
+      const batchNir = includeNir ? new Uint16Array(pointCount) : null;
+      const decoded = decoder.readPointDataBatch(
         {
           positions: nativePositions,
+          rawColors: batchColors,
+          nir: batchNir,
           pointOffset: 0,
           scale: copc.header.scale,
           offset: copc.header.offset
@@ -505,7 +487,13 @@ export class COPCTileSource
         return;
       }
       this.transformTilePositions(nativePositions, positions, nativeOrigin, cartographicOrigin);
-      yield this.createTileContentResult(pointCount, positions, null, cartographicOrigin);
+      yield this.createTileContentResult(
+        pointCount,
+        positions,
+        batchColors,
+        cartographicOrigin,
+        batchNir
+      );
       decodedPointCount += decoded;
     }
   }
@@ -778,11 +766,17 @@ export class COPCTileSource
     pointCount: number,
     positions: Float32Array,
     colors: Uint16Array | null,
-    origin: number[]
+    origin: number[],
+    nir: Uint16Array | null = null
   ): COPCTileContent {
     const positionsAttribute = {value: positions, size: 3};
     const colorsAttribute = colors ? {value: colors, size: 3, normalized: true} : undefined;
-    const data = this.createTileContentTable(pointCount, positionsAttribute, colorsAttribute);
+    const data = this.createTileContentTable(
+      pointCount,
+      positionsAttribute,
+      colorsAttribute,
+      nir ? {value: nir, size: 1} : undefined
+    );
 
     return {
       data,
@@ -797,13 +791,17 @@ export class COPCTileSource
   protected createTileContentTable(
     pointCount: number,
     positions: {value: Float32Array; size: number},
-    colors?: {value: Uint16Array; size: number; normalized: boolean}
+    colors?: {value: Uint16Array; size: number; normalized: boolean},
+    nir?: {value: Uint16Array; size: number}
   ): MeshArrowTable {
     const attributes: Mesh['attributes'] = {
       POSITION: positions
     };
     if (colors) {
       attributes.COLOR_0 = colors;
+    }
+    if (nir) {
+      attributes.NIR = nir;
     }
 
     return convertMeshToTable(

--- a/modules/copc/test/copc-source.spec.ts
+++ b/modules/copc/test/copc-source.spec.ts
@@ -109,7 +109,10 @@ test('COPCSourceLoader#streams TypeScript tile content as Arrow batches', async 
   const streamedColors: number[] = [];
   let streamedPointCount = 0;
 
-  for await (const batch of source.loadTileContentInBatches(rootTile, {batchSize: 127})) {
+  for await (const batch of source.loadTileContentInBatches(rootTile, {
+    batchSize: 127,
+    rangeChunkSize: 257
+  })) {
     const positions = batch.data.data.getChild('POSITION');
     const colors = batch.data.data.getChild('COLOR_0');
     streamedPointCount += batch.pointCount;

--- a/modules/las/test/typescript-laz.spec.ts
+++ b/modules/las/test/typescript-laz.spec.ts
@@ -6,6 +6,7 @@ import test from 'test/utils/vitest-tape';
 import {fetchFile, isBrowser, parse} from '@loaders.gl/core';
 import {LASLoader} from '@loaders.gl/las';
 import {
+  createLAZChunkDecoder,
   createLAZChunkDecoderCursor,
   decodeLAZChunk,
   getLAZChunkByteLength
@@ -256,6 +257,76 @@ test('TypeScript LAZ skips unrequested RGB and auxiliary PDRF 8-10 layers', asyn
   }
   t.end();
 }, 60000);
+
+test('TypeScript LAZ progressively delivers PDRF 8 RGB and NIR', async t => {
+  const fixture = FIXTURES.find(({pointDataRecordFormat}) => pointDataRecordFormat === 8)!;
+  const lazArrayBuffer = await loadArrayBuffer(fixture.lazUrl);
+  const {compressed, metadata} = getFirstLAZChunk(lazArrayBuffer, fixture);
+  const expectedPositions = new Float64Array(metadata.pointCount * 3);
+  const expectedColors = new Uint16Array(metadata.pointCount * 3);
+  const expectedNir = new Uint16Array(metadata.pointCount);
+  const expectedCursor = createLAZChunkDecoderCursor(compressed, metadata);
+
+  expectedCursor.decodeIntoPointData(
+    {
+      positions: expectedPositions,
+      rawColors: expectedColors,
+      nir: expectedNir,
+      pointOffset: 0,
+      scale: [1, 1, 1],
+      offset: [0, 0, 0]
+    },
+    metadata.pointCount
+  );
+
+  const decoder = createLAZChunkDecoder(metadata);
+  const positions = new Float64Array(metadata.pointCount * 3);
+  const colors = new Uint16Array(metadata.pointCount * 3);
+  const nir = new Uint16Array(metadata.pointCount);
+  let decodedPointCount = 0;
+  let firstDecodedByteLength = -1;
+
+  for (let offset = 0; offset < compressed.byteLength; offset += TEST_INPUT_CHUNK_SIZE) {
+    const end = Math.min(offset + TEST_INPUT_CHUNK_SIZE, compressed.byteLength);
+    decoder.feed(compressed.subarray(offset, end));
+    let batchPointCount = decoder.readPointDataBatch(
+      {
+        positions,
+        rawColors: colors,
+        nir,
+        pointOffset: decodedPointCount,
+        scale: [1, 1, 1],
+        offset: [0, 0, 0]
+      },
+      metadata.pointCount - decodedPointCount
+    );
+    while (batchPointCount && batchPointCount > 0) {
+      firstDecodedByteLength = firstDecodedByteLength < 0 ? end : firstDecodedByteLength;
+      decodedPointCount += batchPointCount;
+      batchPointCount = decoder.readPointDataBatch(
+        {
+          positions,
+          rawColors: colors,
+          nir,
+          pointOffset: decodedPointCount,
+          scale: [1, 1, 1],
+          offset: [0, 0, 0]
+        },
+        metadata.pointCount - decodedPointCount
+      );
+    }
+  }
+
+  t.equal(decodedPointCount, metadata.pointCount, 'all PDRF 8 points decode');
+  t.ok(
+    firstDecodedByteLength > 0 && firstDecodedByteLength < compressed.byteLength,
+    'RGB and NIR decode before the complete compressed chunk arrives'
+  );
+  t.deepEqual(positions, expectedPositions, 'progressive PDRF 8 positions match');
+  t.deepEqual(colors, expectedColors, 'progressive PDRF 8 RGB matches');
+  t.deepEqual(nir, expectedNir, 'progressive PDRF 8 NIR matches');
+  t.end();
+});
 
 test('TypeScript LAZ validates VLR codecs and truncated input', async t => {
   const fixture = FIXTURES.find(({pointDataRecordFormat}) => pointDataRecordFormat === 7)!;

--- a/modules/loader-utils/src/lib/laz/laz-chunk-decoder.ts
+++ b/modules/loader-utils/src/lib/laz/laz-chunk-decoder.ts
@@ -176,14 +176,25 @@ export class FeedableLAZChunkDecoder {
    * values from those layers are read by the position-only decoder.
    */
   readPositionDataBatch(target: LAZPointDataTarget, pointCount: number): number | null {
-    if (target.colors || target.rawColors) {
-      throw new Error('Position-only LAZ batches cannot request color output');
+    if (target.colors || target.rawColors || target.nir) {
+      throw new Error('Position-only LAZ batches cannot request color or NIR output');
     }
+    return this.readPointDataBatch(target, pointCount);
+  }
+
+  /** Decode the next selectively requested PDRF 6-8 point-data batch. */
+  readPointDataBatch(target: LAZPointDataTarget, pointCount: number): number | null {
     if (this.metadata.pointDataRecordFormat < 6 || this.metadata.pointDataRecordFormat > 8) {
-      throw new Error('Position-only LAZ batches require point formats 6-8');
+      throw new Error('Progressive LAZ point-data batches require point formats 6-8');
+    }
+    if ((target.colors || target.rawColors) && this.metadata.pointDataRecordFormat === 6) {
+      throw new Error('Point format 6 does not contain RGB data');
+    }
+    if (target.nir && this.metadata.pointDataRecordFormat !== 8) {
+      throw new Error('NIR output requires point format 8');
     }
     if (!this.cursor) {
-      const compressed = this.getProgressivePositionData();
+      const compressed = this.getProgressivePointData(target);
       if (!compressed) {
         return null;
       }
@@ -230,10 +241,15 @@ export class FeedableLAZChunkDecoder {
     return this.compressed;
   }
 
-  private getProgressivePositionData(): Uint8Array | null {
+  private getProgressivePointData(target: LAZPointDataTarget): Uint8Array | null {
     const available = this.getCompressedAvailable();
     const layout = getLayeredChunkLayout(available, this.metadata);
-    if (!layout || available.byteLength < layout.pointDataByteLength) {
+    if (!layout) {
+      return null;
+    }
+    const requiredLayerCount = getProgressiveLayerCount(this.metadata, target);
+    const requiredByteLength = layout.getByteLength(requiredLayerCount);
+    if (available.byteLength < requiredByteLength) {
       return null;
     }
 
@@ -507,7 +523,8 @@ function getLAZChunkMinimumByteLength(metadata: LAZChunkMetadata): number {
 
 type LAZLayeredChunkLayout = {
   byteLength: number;
-  pointDataByteLength: number;
+  layerByteLengths: number[];
+  getByteLength: (layerCount: number) => number;
 };
 
 function getLayeredChunkLayout(
@@ -524,15 +541,33 @@ function getLayeredChunkLayout(
 
   const dataView = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
   let byteLength = sizeHeaderOffset + sizeHeaderByteLength;
-  let pointDataByteLength = byteLength;
+  const layerByteLengths: number[] = [];
   for (let index = 0; index < sizeHeaderCount; index++) {
     const layerByteLength = dataView.getUint32(sizeHeaderOffset + index * 4, true);
     byteLength += layerByteLength;
-    if (index < 9) {
-      pointDataByteLength += layerByteLength;
-    }
+    layerByteLengths.push(layerByteLength);
   }
-  return {byteLength, pointDataByteLength};
+  const dataOffset = sizeHeaderOffset + sizeHeaderByteLength;
+  return {
+    byteLength,
+    layerByteLengths,
+    getByteLength: layerCount =>
+      dataOffset + layerByteLengths.slice(0, layerCount).reduce((sum, value) => sum + value, 0)
+  };
+}
+
+function getProgressiveLayerCount(metadata: LAZChunkMetadata, target: LAZPointDataTarget): number {
+  let layerCount = 9;
+  if (target.colors || target.rawColors) {
+    layerCount = 10;
+  }
+  if (target.nir) {
+    layerCount = 11;
+  }
+  return Math.min(
+    layerCount,
+    getChunkSizeHeaderCount(metadata.pointDataRecordFormat, getExtraByteCount(metadata))
+  );
 }
 
 const AC_MIN_LENGTH = 0x01000000;


### PR DESCRIPTION
## Goals

- Extend progressive COPC delivery from position-only to PDRF 7 RGB.
- Add selective progressive RGB/NIR delivery for PDRF 8.
- Keep Arrow batch output and existing atomic decoder compatibility.

## Changes

- Generalize the feedable TypeScript LAZ decoder to wait for the requested independent layer prefix.
- Use progressive range fetching for all TypeScript COPC PDRF 6-8 batches.
- Emit COLOR_0 for PDRF 7 and optional NIR for PDRF 8 when requested.
- Add byte-for-byte PDRF 8 RGB/NIR progressive parity coverage.
- Exercise PDRF 7 RGB through small COPC range chunks and update API documentation.

## Validation

- Usage Error: Couldn't find the node_modules state file - running an install might help (findPackageLocation)

$ yarn run [--inspect] [--inspect-brk] [-T,--top-level] [-B,--binaries-only] [--require #0] <scriptName> ...
- TypeScript build for loader-utils, las, and copc
- COPC focused browser suite: 14 passed
- Isolated progressive PDRF 8 test: passed

The existing LAS worker test requires prebuilt worker bundles and was not run successfully in this worktree.