### PR TITLE
feat(copc): add progressive point field selection

### DIFF
--- a/docs/modules/copc/api-reference/copc-source-loader.md
+++ b/docs/modules/copc/api-reference/copc-source-loader.md
@@ -34,7 +34,7 @@ The created data source exposes the point-cloud tile methods used by `PointCloud
 - `getRootTile()` returns the root octree tile header.
 - `getChildren(tile)` returns available child tile headers.
 - `loadTileContent(tile)` returns normalized point positions, optional colors, point count, and cartographic origin.
-- `loadTileContentInBatches(tile, options)` yields normalized Arrow point tables progressively as the selected node range is fetched. The TypeScript LAZ variant is required. `options.batchSize` controls the maximum points per table, `options.columns` can request `POSITION`, `COLOR_0`, and `NIR`, and `options.signal` cancels the request/decode.
+- `loadTileContentInBatches(tile, options)` yields normalized Arrow point tables progressively as the selected node range is fetched. The TypeScript LAZ variant is required. `options.batchSize` controls the maximum points per table, `options.columns` can request `POSITION`, `COLOR_0`, `NIR`, `intensity`, `classification`, `GPS_TIME`, `scanAngle`, and `pointSourceId`, and `options.signal` cancels the request/decode.
 - `loadHierarchyInBatches(options)` yields hierarchy pages and their discovered nodes as they are fetched.
 
 For TypeScript PDRF 6-8 batches, `loadTileContentInBatches` splits the node range into sequential requests and emits rows as soon as the requested independent layers arrive. PDRF 7 RGB waits for Point14 and RGB; PDRF 8 RGB/NIR waits for the layers requested through `options.columns`. `options.rangeChunkSize` controls the request size.

--- a/modules/copc/src/copc-source-loader.ts
+++ b/modules/copc/src/copc-source-loader.ts
@@ -71,7 +71,16 @@ export type COPCTileContentBatchOptions = {
   /** Optional cancellation signal for the range request and decode loop. */
   signal?: AbortSignal;
   /** Arrow attributes to populate. POSITION is always included. */
-  columns?: readonly ('POSITION' | 'COLOR_0' | 'NIR')[];
+  columns?: readonly (
+    | 'POSITION'
+    | 'COLOR_0'
+    | 'NIR'
+    | 'intensity'
+    | 'classification'
+    | 'GPS_TIME'
+    | 'scanAngle'
+    | 'pointSourceId'
+  )[];
   /** Byte size for progressive node range requests. */
   rangeChunkSize?: number;
 };
@@ -368,6 +377,11 @@ export class COPCTileSource
       (options.columns ? options.columns.includes('COLOR_0') : true);
     const nir =
       copc.header.pointDataRecordFormat === 8 && Boolean(options.columns?.includes('NIR'));
+    const intensity = Boolean(options.columns?.includes('intensity'));
+    const classification = Boolean(options.columns?.includes('classification'));
+    const gpsTime = Boolean(options.columns?.includes('GPS_TIME'));
+    const scanAngle = Boolean(options.columns?.includes('scanAngle'));
+    const pointSourceId = Boolean(options.columns?.includes('pointSourceId'));
     const rangeChunkSize = options.rangeChunkSize ?? this.options.copc?.rangeChunkSize ?? 65536;
     if (!Number.isSafeInteger(rangeChunkSize) || rangeChunkSize < 1) {
       throw new Error('COPC progressive rangeChunkSize must be a positive integer');
@@ -386,7 +400,12 @@ export class COPCTileSource
       rangeChunkSize,
       options.signal,
       colors,
-      nir
+      nir,
+      intensity,
+      classification,
+      gpsTime,
+      scanAngle,
+      pointSourceId
     );
   }
 
@@ -400,7 +419,12 @@ export class COPCTileSource
     rangeChunkSize: number,
     signal: AbortSignal | undefined,
     colors: boolean,
-    nir: boolean
+    nir: boolean,
+    intensity: boolean,
+    classification: boolean,
+    gpsTime: boolean,
+    scanAngle: boolean,
+    pointSourceId: boolean
   ): AsyncIterable<COPCTileContent> {
     const decoder = createLAZChunkDecoder({
       pointCount: node.pointCount,
@@ -424,7 +448,12 @@ export class COPCTileSource
         batchSize,
         decodedPointCount,
         colors,
-        nir
+        nir,
+        intensity,
+        classification,
+        gpsTime,
+        scanAngle,
+        pointSourceId
       );
       decodedPointCount = node.pointCount - decoder.remainingPointCount;
     }
@@ -440,7 +469,12 @@ export class COPCTileSource
         batchSize,
         decodedPointCount,
         colors,
-        nir
+        nir,
+        intensity,
+        classification,
+        gpsTime,
+        scanAngle,
+        pointSourceId
       );
       decodedPointCount = node.pointCount - decoder.remainingPointCount;
     }
@@ -461,7 +495,12 @@ export class COPCTileSource
     batchSize: number,
     decodedPointCount: number,
     includeColors: boolean,
-    includeNir: boolean
+    includeNir: boolean,
+    includeIntensity: boolean,
+    includeClassification: boolean,
+    includeGpsTime: boolean,
+    includeScanAngle: boolean,
+    includePointSourceId: boolean
   ): Iterable<COPCTileContent> {
     while (decodedPointCount < nodePointCount) {
       const pointCount = Math.min(batchSize, nodePointCount - decodedPointCount);
@@ -469,11 +508,21 @@ export class COPCTileSource
       const positions = new Float32Array(pointCount * 3);
       const batchColors = includeColors ? new Uint16Array(pointCount * 3) : null;
       const batchNir = includeNir ? new Uint16Array(pointCount) : null;
+      const batchIntensities = includeIntensity ? new Uint16Array(pointCount) : null;
+      const batchClassifications = includeClassification ? new Uint8Array(pointCount) : null;
+      const batchGpsTimes = includeGpsTime ? new Float64Array(pointCount) : null;
+      const batchScanAngles = includeScanAngle ? new Int16Array(pointCount) : null;
+      const batchPointSourceIds = includePointSourceId ? new Uint16Array(pointCount) : null;
       const decoded = decoder.readPointDataBatch(
         {
           positions: nativePositions,
           rawColors: batchColors,
           nir: batchNir,
+          intensities: batchIntensities,
+          classifications: batchClassifications,
+          gpsTimes: batchGpsTimes,
+          scanAngles: batchScanAngles,
+          pointSourceIds: batchPointSourceIds,
           pointOffset: 0,
           scale: copc.header.scale,
           offset: copc.header.offset
@@ -492,7 +541,14 @@ export class COPCTileSource
         positions,
         batchColors,
         cartographicOrigin,
-        batchNir
+        batchNir,
+        {
+          batchIntensities,
+          batchClassifications,
+          batchGpsTimes,
+          batchScanAngles,
+          batchPointSourceIds
+        }
       );
       decodedPointCount += decoded;
     }
@@ -528,9 +584,7 @@ export class COPCTileSource
       if (this._hierarchy) {
         this._hierarchy.nodes = {...this._hierarchy.nodes, ...subtree.nodes};
         this._hierarchy.pages = {...this._hierarchy.pages, ...subtree.pages};
-        if (pageId !== 'root') {
-          delete this._hierarchy.pages[pageId];
-        }
+        delete this._hierarchy.pages[pageId];
       }
       loadedPageCount++;
       yield {pageId, page, nodes: subtree.nodes, pages: subtree.pages};
@@ -767,7 +821,14 @@ export class COPCTileSource
     positions: Float32Array,
     colors: Uint16Array | null,
     origin: number[],
-    nir: Uint16Array | null = null
+    nir: Uint16Array | null = null,
+    pointData: {
+      batchIntensities: Uint16Array | null;
+      batchClassifications: Uint8Array | null;
+      batchGpsTimes: Float64Array | null;
+      batchScanAngles: Int16Array | null;
+      batchPointSourceIds: Uint16Array | null;
+    } | null = null
   ): COPCTileContent {
     const positionsAttribute = {value: positions, size: 3};
     const colorsAttribute = colors ? {value: colors, size: 3, normalized: true} : undefined;
@@ -775,7 +836,8 @@ export class COPCTileSource
       pointCount,
       positionsAttribute,
       colorsAttribute,
-      nir ? {value: nir, size: 1} : undefined
+      nir ? {value: nir, size: 1} : undefined,
+      pointData
     );
 
     return {
@@ -792,7 +854,14 @@ export class COPCTileSource
     pointCount: number,
     positions: {value: Float32Array; size: number},
     colors?: {value: Uint16Array; size: number; normalized: boolean},
-    nir?: {value: Uint16Array; size: number}
+    nir?: {value: Uint16Array; size: number},
+    pointData?: {
+      batchIntensities: Uint16Array | null;
+      batchClassifications: Uint8Array | null;
+      batchGpsTimes: Float64Array | null;
+      batchScanAngles: Int16Array | null;
+      batchPointSourceIds: Uint16Array | null;
+    } | null
   ): MeshArrowTable {
     const attributes: Mesh['attributes'] = {
       POSITION: positions
@@ -802,6 +871,21 @@ export class COPCTileSource
     }
     if (nir) {
       attributes.NIR = nir;
+    }
+    if (pointData?.batchIntensities) {
+      attributes.intensity = {value: pointData.batchIntensities, size: 1};
+    }
+    if (pointData?.batchClassifications) {
+      attributes.classification = {value: pointData.batchClassifications, size: 1};
+    }
+    if (pointData?.batchGpsTimes) {
+      attributes.GPS_TIME = {value: pointData.batchGpsTimes, size: 1};
+    }
+    if (pointData?.batchScanAngles) {
+      attributes.scanAngle = {value: pointData.batchScanAngles, size: 1};
+    }
+    if (pointData?.batchPointSourceIds) {
+      attributes.pointSourceId = {value: pointData.batchPointSourceIds, size: 1};
     }
 
     return convertMeshToTable(

--- a/modules/copc/test/copc-source.spec.ts
+++ b/modules/copc/test/copc-source.spec.ts
@@ -97,7 +97,7 @@ test('COPCSourceLoader#loads tile content with TypeScript LAZ decoder', async t 
   t.end();
 });
 
-test('COPCSourceLoader#streams TypeScript tile content as Arrow batches', async t => {
+vitestTest('COPCSourceLoader#streams TypeScript tile content as Arrow batches', async () => {
   const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {
     copc: {decoder: 'typescript-laz'}
   });
@@ -131,10 +131,46 @@ test('COPCSourceLoader#streams TypeScript tile content as Arrow batches', async 
     expectedColors.push(...(atomicColors?.get(index)?.toArray() || []));
   }
 
-  t.equal(streamedPointCount, rootTile.pointCount, 'all points are yielded');
-  t.deepEqual(streamedPositions, expectedPositions, 'batched positions match atomic output');
-  t.deepEqual(streamedColors, expectedColors, 'batched colors match atomic output');
-  t.end();
+  expect(streamedPointCount).toBe(rootTile.pointCount);
+  expect(streamedPositions).toEqual(expectedPositions);
+  expect(streamedColors).toEqual(expectedColors);
+});
+
+vitestTest('COPCSourceLoader#selects progressive point-data columns', async () => {
+  const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {
+    copc: {decoder: 'typescript-laz'}
+  });
+  await source.initialize();
+
+  const rootTile = await source.getRootTile();
+  const columns = [
+    'POSITION',
+    'COLOR_0',
+    'intensity',
+    'classification',
+    'GPS_TIME',
+    'scanAngle',
+    'pointSourceId'
+  ] as const;
+  const batches = source.loadTileContentInBatches(rootTile, {
+    batchSize: 127,
+    columns,
+    rangeChunkSize: 257
+  });
+  let firstBatch;
+  for await (const batch of batches) {
+    firstBatch = batch;
+    break;
+  }
+
+  expect(firstBatch).toBeTruthy();
+  expect(firstBatch?.data.data.getChild('POSITION')).toBeTruthy();
+  expect(firstBatch?.data.data.getChild('COLOR_0')).toBeTruthy();
+  expect(firstBatch?.data.data.getChild('intensity')).toBeTruthy();
+  expect(firstBatch?.data.data.getChild('classification')).toBeTruthy();
+  expect(firstBatch?.data.data.getChild('GPS_TIME')).toBeTruthy();
+  expect(firstBatch?.data.data.getChild('scanAngle')).toBeTruthy();
+  expect(firstBatch?.data.data.getChild('pointSourceId')).toBeTruthy();
 });
 
 test('COPCSourceLoader#streams position-only TypeScript tile batches', async t => {

--- a/modules/las/test/typescript-laz.spec.ts
+++ b/modules/las/test/typescript-laz.spec.ts
@@ -325,6 +325,55 @@ vitestTest('TypeScript LAZ progressively delivers PDRF 8 RGB and NIR', async () 
   expect(nir).toEqual(expectedNir);
 });
 
+vitestTest('TypeScript LAZ does not wait for unrequested Point14 layers', async () => {
+  const fixture = FIXTURES.find(({pointDataRecordFormat}) => pointDataRecordFormat === 7)!;
+  const lazArrayBuffer = await loadArrayBuffer(fixture.lazUrl);
+  const {compressed, metadata} = getFirstLAZChunk(lazArrayBuffer, fixture);
+  const expectedPositions = new Float64Array(metadata.pointCount * 3);
+  const expectedClassifications = new Uint8Array(metadata.pointCount);
+  const expectedCursor = createLAZChunkDecoderCursor(compressed, metadata);
+  expectedCursor.decodeIntoPointData(
+    {
+      positions: expectedPositions,
+      classifications: expectedClassifications,
+      pointOffset: 0,
+      scale: [1, 1, 1],
+      offset: [0, 0, 0]
+    },
+    metadata.pointCount
+  );
+
+  const decoder = createLAZChunkDecoder(metadata);
+  const positions = new Float64Array(metadata.pointCount * 3);
+  const classifications = new Uint8Array(metadata.pointCount);
+  let decodedPointCount = 0;
+  let firstDecodedByteLength = -1;
+  for (let offset = 0; offset < compressed.byteLength; offset += TEST_INPUT_CHUNK_SIZE) {
+    const end = Math.min(offset + TEST_INPUT_CHUNK_SIZE, compressed.byteLength);
+    decoder.feed(compressed.subarray(offset, end));
+    const decoded = decoder.readPointDataBatch(
+      {
+        positions,
+        classifications,
+        pointOffset: decodedPointCount,
+        scale: [1, 1, 1],
+        offset: [0, 0, 0]
+      },
+      metadata.pointCount - decodedPointCount
+    );
+    if (decoded) {
+      firstDecodedByteLength = end;
+      decodedPointCount += decoded;
+      break;
+    }
+  }
+
+  expect(decodedPointCount).toBe(metadata.pointCount);
+  expect(firstDecodedByteLength > 0 && firstDecodedByteLength < compressed.byteLength).toBe(true);
+  expect(positions).toEqual(expectedPositions);
+  expect(classifications).toEqual(expectedClassifications);
+});
+
 test('TypeScript LAZ validates VLR codecs and truncated input', async t => {
   const fixture = FIXTURES.find(({pointDataRecordFormat}) => pointDataRecordFormat === 7)!;
   const source = await loadArrayBuffer(fixture.lazUrl);

--- a/modules/las/test/typescript-laz.spec.ts
+++ b/modules/las/test/typescript-laz.spec.ts
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import test from 'test/utils/vitest-tape';
+import {expect, test as vitestTest} from 'vitest';
 import {fetchFile, isBrowser, parse} from '@loaders.gl/core';
 import {LASLoader} from '@loaders.gl/las';
 import {
@@ -258,7 +259,7 @@ test('TypeScript LAZ skips unrequested RGB and auxiliary PDRF 8-10 layers', asyn
   t.end();
 }, 60000);
 
-test('TypeScript LAZ progressively delivers PDRF 8 RGB and NIR', async t => {
+vitestTest('TypeScript LAZ progressively delivers PDRF 8 RGB and NIR', async () => {
   const fixture = FIXTURES.find(({pointDataRecordFormat}) => pointDataRecordFormat === 8)!;
   const lazArrayBuffer = await loadArrayBuffer(fixture.lazUrl);
   const {compressed, metadata} = getFirstLAZChunk(lazArrayBuffer, fixture);
@@ -317,15 +318,11 @@ test('TypeScript LAZ progressively delivers PDRF 8 RGB and NIR', async t => {
     }
   }
 
-  t.equal(decodedPointCount, metadata.pointCount, 'all PDRF 8 points decode');
-  t.ok(
-    firstDecodedByteLength > 0 && firstDecodedByteLength < compressed.byteLength,
-    'RGB and NIR decode before the complete compressed chunk arrives'
-  );
-  t.deepEqual(positions, expectedPositions, 'progressive PDRF 8 positions match');
-  t.deepEqual(colors, expectedColors, 'progressive PDRF 8 RGB matches');
-  t.deepEqual(nir, expectedNir, 'progressive PDRF 8 NIR matches');
-  t.end();
+  expect(decodedPointCount).toBe(metadata.pointCount);
+  expect(firstDecodedByteLength > 0 && firstDecodedByteLength < compressed.byteLength).toBe(true);
+  expect(positions).toEqual(expectedPositions);
+  expect(colors).toEqual(expectedColors);
+  expect(nir).toEqual(expectedNir);
 });
 
 test('TypeScript LAZ validates VLR codecs and truncated input', async t => {

--- a/modules/loader-utils/src/lib/laz/laz-chunk-decoder.ts
+++ b/modules/loader-utils/src/lib/laz/laz-chunk-decoder.ts
@@ -556,6 +556,7 @@ function getLayeredChunkLayout(
   };
 }
 
+/** Return the layered-stream prefix needed to satisfy a direct-output selection. */
 function getProgressiveLayerCount(metadata: LAZChunkMetadata, target: LAZPointDataTarget): number {
   let layerCount = 9;
   if (target.colors || target.rawColors) {

--- a/modules/loader-utils/src/lib/laz/laz-chunk-decoder.ts
+++ b/modules/loader-utils/src/lib/laz/laz-chunk-decoder.ts
@@ -558,7 +558,31 @@ function getLayeredChunkLayout(
 
 /** Return the layered-stream prefix needed to satisfy a direct-output selection. */
 function getProgressiveLayerCount(metadata: LAZChunkMetadata, target: LAZPointDataTarget): number {
-  let layerCount = 9;
+  // The first two streams contain XY and Z. Optional Point14 streams follow
+  // in codec order: classification, flags, intensity, scan angle, user data,
+  // point source ID, and GPS time.
+  let layerCount = 2;
+  if (target.classifications) {
+    layerCount = 3;
+  }
+  if (target.scannerChannels || target.scanDirectionFlags || target.edgeOfFlightLines) {
+    layerCount = 4;
+  }
+  if (target.intensities) {
+    layerCount = 5;
+  }
+  if (target.scanAngles) {
+    layerCount = 6;
+  }
+  if (target.userData) {
+    layerCount = 7;
+  }
+  if (target.pointSourceIds) {
+    layerCount = 8;
+  }
+  if (target.gpsTimes) {
+    layerCount = 9;
+  }
   if (target.colors || target.rawColors) {
     layerCount = 10;
   }


### PR DESCRIPTION
## Goals

- Complete the progressive COPC hardening follow-up from #3686 and #3678.
- Extend progressive TypeScript LAZ delivery beyond positions and RGB/NIR to common point attributes.

## Changes

- Add selective COPC Arrow columns for `intensity`, `classification`, `GPS_TIME`, `scanAngle`, and `pointSourceId`.
- Populate only requested typed arrays while preserving the existing default POSITION/COLOR_0 behavior.
- Remove consumed hierarchy page placeholders from the shared cache.
- Convert the newly added progressive tests to native Vitest APIs.
- Add TSDoc for progressive layer selection and update COPC API documentation.
- Preserve cancellation checks around each range request result.

## Validation

- `yarn lint fix`
- TypeScript build for loader-utils, las, and copc
- COPC focused browser tests: 15 passed
- Progressive PDRF 8 RGB/NIR test: passed

This PR addresses the actionable review feedback from the landed progressive COPC PRs.
