### PR TITLE
test(math): improve utility coverage

### DIFF
--- a/modules/math/src/geometry/colors/rgb565.ts
+++ b/modules/math/src/geometry/colors/rgb565.ts
@@ -26,8 +26,8 @@ export function decodeRGB565(rgb565: number, target: number[] = [0, 0, 0]): numb
  * @returns color
  */
 export function encodeRGB565(rgb: number[]): number {
-  const r5 = Math.floor(rgb[0] / 8) + 4;
-  const g6 = Math.floor(rgb[1] / 4) + 2;
-  const b5 = Math.floor(rgb[2] / 8) + 4;
-  return r5 + (g6 << 5) + (b5 << 11);
+  const r5 = Math.round((rgb[0] / 255) * 31);
+  const g6 = Math.round((rgb[1] / 255) * 63);
+  const b5 = Math.round((rgb[2] / 255) * 31);
+  return (r5 << 11) + (g6 << 5) + b5;
 }

--- a/modules/math/src/geometry/iterators/attribute-iterator.ts
+++ b/modules/math/src/geometry/iterators/attribute-iterator.ts
@@ -12,7 +12,7 @@ export function* makeAttributeIterator(values: any, size: number): Iterable<any>
   const element = new ArrayType(size);
   for (let i = 0; i < values.length; i += size) {
     for (let j = 0; j < size; j++) {
-      element[j] = element[i + j];
+      element[j] = values[i + j];
     }
     yield element;
   }

--- a/modules/math/test/geometry/colors/rgb565.spec.js
+++ b/modules/math/test/geometry/colors/rgb565.spec.js
@@ -2,13 +2,20 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
-// import {encodeRGB565, decodeRGB565} from '@loaders.gl/math';
+import {expect, test} from 'vitest';
+import {decodeRGB565, encodeRGB565} from '@loaders.gl/math';
 
-test('encodeRGB565/decodeRGB565', t => {
-  // const color = [255, 128, 30];
-  // const rgb565 = encodeRGB565(color);
-  // const decodedColor = decodeRGB565(rgb565);
-  // t.deepEqual(decodedColor, [255, 128, 30]);
-  t.end();
+test('encodeRGB565/decodeRGB565', () => {
+  const color = [255, 128, 24];
+  const rgb565 = encodeRGB565(color);
+
+  expect(rgb565).toBe(0xfc03);
+  expect(decodeRGB565(rgb565)).toEqual([248, 128, 24]);
+});
+
+test('decodeRGB565 writes into the provided target', () => {
+  const target = [0, 0, 0];
+
+  expect(decodeRGB565(0x07e0, target)).toBe(target);
+  expect(target).toEqual([0, 252, 0]);
 });

--- a/modules/math/test/geometry/math-utils.spec.ts
+++ b/modules/math/test/geometry/math-utils.spec.ts
@@ -1,0 +1,95 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+import {
+  GL,
+  GLType,
+  concatTypedArrays,
+  emod,
+  isGeometry,
+  makeAttributeIterator,
+  makePrimitiveIterator
+} from '@loaders.gl/math';
+
+describe('geometry utility functions', () => {
+  test('iterates typed-array attributes in fixed-size groups', () => {
+    const values = new Float32Array([1, 2, 3, 4, 5, 6]);
+
+    const attributes = [];
+    for (const value of makeAttributeIterator(values, 3)) {
+      attributes.push([...value]);
+    }
+
+    expect(attributes).toEqual([
+      [1, 2, 3],
+      [4, 5, 6]
+    ]);
+  });
+
+  test('iterates indexed triangle primitives', () => {
+    const primitives = [
+      ...makePrimitiveIterator({values: new Uint16Array([2, 0, 1])}, {}, GL.TRIANGLES)
+    ];
+
+    expect(primitives).toHaveLength(1);
+    expect(primitives[0]).toMatchObject({i1: 2, i2: 0, i3: 1, type: GL.TRIANGLES});
+  });
+
+  test('iterates non-indexed points and lines', () => {
+    const points = [];
+    for (const primitive of makePrimitiveIterator(undefined, {}, GL.POINTS, 2, 4)) {
+      points.push(primitive.i1);
+    }
+    expect(points).toEqual([2, 3]);
+
+    const lines = [];
+    for (const primitive of makePrimitiveIterator(undefined, {}, GL.LINES, 1, 5)) {
+      lines.push([primitive.i1, primitive.i2]);
+    }
+    expect(lines).toEqual([
+      [1, 2],
+      [3, 4]
+    ]);
+  });
+
+  test('recognizes geometry objects', () => {
+    expect(isGeometry({mode: GL.TRIANGLES, attributes: {positions: {}}})).toBeTruthy();
+    expect(isGeometry({mode: GL.TRIANGLES})).toBeFalsy();
+    expect(isGeometry(null)).toBeFalsy();
+  });
+
+  test('concatenates typed arrays and computes modular coordinates', () => {
+    expect(concatTypedArrays([new Uint8Array([1, 2]), new Uint8Array([3])])).toEqual(
+      new Uint8Array([1, 2, 3])
+    );
+    expect(emod(1.25)).toBeCloseTo(0.25);
+    expect(emod(-0.25)).toBeCloseTo(0.75);
+  });
+});
+
+describe('GLType', () => {
+  test('maps typed arrays and names to GL types', () => {
+    expect(GLType.fromTypedArray(new Uint8Array())).toBe(String(GL.UNSIGNED_BYTE));
+    expect(GLType.fromTypedArray(Float32Array)).toBe(String(GL.FLOAT));
+    expect(GLType.fromName('UNSIGNED_SHORT')).toBe(GL.UNSIGNED_SHORT);
+  });
+
+  test('creates typed views and reports byte sizes', () => {
+    const buffer = new ArrayBuffer(8);
+    const view = GLType.createTypedArray(GL.UNSIGNED_SHORT, buffer);
+
+    expect(view).toBeInstanceOf(Uint16Array);
+    expect(view.length).toBe(4);
+    expect(GLType.getByteSize(GL.FLOAT)).toBe(4);
+    expect(GLType.getArrayType(GL.UNSIGNED_SHORT)).toBe(Uint16Array);
+    expect(GLType.validate(GL.FLOAT)).toBe(true);
+  });
+
+  test('rejects unknown GL types', () => {
+    expect(() => GLType.fromName('UNKNOWN')).toThrow('Failed to convert GL type');
+    expect(() => GLType.fromTypedArray(Array)).toThrow('Failed to convert GL type');
+    expect(() => GLType.getArrayType(0)).toThrow('Failed to convert GL type');
+  });
+});


### PR DESCRIPTION
## Goals

Start the next coverage tranche by improving coverage and native Vitest adoption in the small, pure `@loaders.gl/math` package.

## Changes

- Add native Vitest coverage for attribute/primitive iterators, geometry detection, typed-array concatenation, modular coordinates, and GL type conversions.
- Replace the empty RGB565 adapter test with native Vitest assertions, including caller-provided target behavior.
- Fix `makeAttributeIterator` to read source values instead of the output buffer.
- Correct RGB565 bit packing and standard 5/6-bit color quantization.

## Validation

- `yarn test-headless --run modules/math/test` — 3 files, 58 tests passed.
- `yarn test-audit` — 526 files, 0 Tape imports, 0 violations.
- `yarn lint fix` — clean.
- `git diff --check` — clean.

The full repository coverage merge remains covered by CI; focused local coverage instrumentation was blocked by unrelated optional dependency resolution in the shared checkout.