### PR TITLE
feat(scan): start panel and Arrow coverage tranches

### DIFF
--- a/docs/developer-guide/common-scan-architecture.md
+++ b/docs/developer-guide/common-scan-architecture.md
@@ -657,13 +657,14 @@ exposed yet. A residual predicate is still correct; it simply cannot avoid decod
 
 | Family and representative sources | Status | Discovery | Projection / selection | Filter / spatial controls | Limit / stream | Priority |
 | --- | --- | --- | --- | --- | --- | --- |
-| Arrow / GeoArrow | Ready | schema | zero-copy/residual | residual, null-safe | yes / batches | conformance reference |
+| Arrow / GeoArrow | Foundation | schema for Arrow tables | zero-copy/residual | residual, null-safe | yes / batches | P1: add common source and panel adapter |
 | Parquet / Iceberg | Ready | footer/catalog | pushdown | statistics + residual | global / batches | maintain and extend |
 | FlatGeobuf | Ready | header/index | Arrow properties | bbox pushdown, scalar residual | bounded / batches | maintain and panel |
-| ORC | Foundation | stripe schema | planned stripe projection | planned row-index/statistics | planned | P2 |
+| ORC | Planned | loader metadata only | planned | planned row-index/statistics | planned | P2 |
 | CSV / JSONL | Planned | header/sample | parser-dependent | residual | planned chunks | P2 |
 | GeoPackage / Shapefile / MLT | Planned | container/header | planned | planned spatial or residual | planned | P2 |
-| Delta Lake / Lance | Foundation | log/manifest | format-native | fragments + residual | global / batches | P1 |
+| Delta Lake | Planned | loader not yet present | planned | planned log/deletion-vector pruning | planned | P1 |
+| Lance | Foundation | manifest/fragments | format-native | fragments + residual | global / batches | P1 |
 | COPC / Potree | Foundation | header/hierarchy | point attributes | bounds pushdown, attribute residual | planned global / batches | P1 |
 | LAS / LAZ / PLY / PCD / splats | Planned | header | sequential attribute decode | residual unless indexed | planned | P2 |
 | GeoTIFF / COG | Foundation | TIFF/overview metadata | bands/windows | window pushdown | tile-local / typed arrays | P1 |

--- a/modules/sql/src/arrow-table-source.ts
+++ b/modules/sql/src/arrow-table-source.ts
@@ -1,0 +1,111 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {
+  DataSourceOptions,
+  ScanQueryMetadata,
+  ScanQueryMetadataOptions
+} from '@loaders.gl/loader-utils';
+import {createScanQueryMetadata, DataSource, type ScanColumnRole} from '@loaders.gl/loader-utils';
+import {convertArrowToSchema} from '@loaders.gl/schema-utils';
+import type {ArrowTable, ArrowTableBatch} from '@loaders.gl/schema';
+import {
+  ARROW_TABLE_QUERY_CAPABILITIES,
+  explainArrowTableQuery,
+  queryArrowTable
+} from './query-arrow-table';
+import type {ArrowQueryOptions} from './query-arrow-table';
+import type {TableQueryExplain, TableQueryOptions} from './table-query';
+
+/** In-memory source options; the source owns the supplied Arrow table. */
+export type ArrowTableSourceOptions = DataSourceOptions;
+
+/**
+ * Query source for an in-memory Arrow or GeoArrow table.
+ *
+ * This is the reference source for the shared scan panel: metadata discovery is synchronous in
+ * practice, and query execution delegates to the existing Arrow executor without ingesting data
+ * into DuckDB or another intermediate representation.
+ */
+export class ArrowTableSource extends DataSource<ArrowTable, ArrowTableSourceOptions> {
+  /** Creates a source over an existing Arrow table without copying its vectors. */
+  constructor(data: ArrowTable, options: ArrowTableSourceOptions = {}) {
+    super(data, options);
+  }
+
+  /** Discovers query-visible fields and capabilities without evaluating any rows. */
+  async getQueryMetadata(options: ScanQueryMetadataOptions = {}): Promise<ScanQueryMetadata> {
+    throwIfAborted(options.signal);
+    const schema = convertArrowToSchema(this.data.data.schema);
+    return createScanQueryMetadata({
+      sourceType: 'arrow-table',
+      queryType: 'table',
+      schema,
+      capabilities: {table: ARROW_TABLE_QUERY_CAPABILITIES},
+      columnRoles: getArrowColumnRoles(schema.fields.map(field => field.name)),
+      statistics: {rowCount: this.data.data.numRows}
+    });
+  }
+
+  /** Executes a portable query and returns an Arrow table result. */
+  query(options: ArrowQueryOptions = {}): ArrowTable {
+    return queryArrowTable(this.data, options);
+  }
+
+  /** Explains a portable query without evaluating table rows. */
+  explain(options: TableQueryOptions = {}): TableQueryExplain {
+    return explainArrowTableQuery(this.data, options);
+  }
+
+  /** Executes a query as one bounded Arrow batch. */
+  async *read(options: ArrowQueryOptions = {}): AsyncIterableIterator<ArrowTableBatch> {
+    const result = this.query(options);
+    yield {
+      batchType: 'data',
+      shape: 'arrow-table',
+      schema: result.schema,
+      data: result.data,
+      length: result.data.numRows
+    };
+  }
+}
+
+/** Returns conventional semantic roles for common Arrow coordinate and time names. */
+function getArrowColumnRoles(
+  columnNames: readonly string[]
+): Readonly<Record<string, ScanColumnRole>> {
+  const roles: Record<string, ScanColumnRole> = {};
+  for (const columnName of columnNames) {
+    const normalizedName = columnName.toLowerCase();
+    if (normalizedName === 'x' || normalizedName === 'longitude' || normalizedName === 'lon') {
+      roles[columnName] = normalizedName === 'x' ? 'x' : 'longitude';
+    } else if (
+      normalizedName === 'y' ||
+      normalizedName === 'latitude' ||
+      normalizedName === 'lat'
+    ) {
+      roles[columnName] = normalizedName === 'y' ? 'y' : 'latitude';
+    } else if (
+      normalizedName === 'z' ||
+      normalizedName === 'elevation' ||
+      normalizedName === 'altitude'
+    ) {
+      roles[columnName] = normalizedName === 'z' ? 'z' : 'attribute';
+    } else if (
+      normalizedName === 'time' ||
+      normalizedName.endsWith('_time') ||
+      normalizedName.endsWith('timestamp')
+    ) {
+      roles[columnName] = 'time';
+    }
+  }
+  return roles;
+}
+
+/** Throws the common source cancellation error before metadata or execution work begins. */
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    throw new Error('Request aborted');
+  }
+}

--- a/modules/sql/src/index.ts
+++ b/modules/sql/src/index.ts
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 export {SQLDataSource, registerSQLAdapter, getSQLAdapterFactory} from './sql-source';
+export {ArrowTableSource} from './arrow-table-source';
 export {DuckDBSQLSource, DuckDBSQLDataSource} from './duckdb-sql-source';
 export {SnowflakeSQLSource, SnowflakeSQLDataSource} from './snowflake-sql-source';
 export {
@@ -55,6 +56,7 @@ export type {
 } from './sql-types';
 
 export type {ArrowQueryOptions} from './query-arrow-table';
+export type {ArrowTableSourceOptions} from './arrow-table-source';
 export type {
   CompiledSQLTableQuery,
   SQLTableQuery,

--- a/modules/sql/test/arrow-query.spec.ts
+++ b/modules/sql/test/arrow-query.spec.ts
@@ -9,6 +9,7 @@ import {convertArrowToSchema} from '@loaders.gl/schema-utils';
 
 import {
   ARROW_TABLE_QUERY_CAPABILITIES,
+  ArrowTableSource,
   bindSQLPredicate,
   parseSQLPredicate,
   planTableQuery,
@@ -24,6 +25,26 @@ test('Arrow executor advertises portable query capabilities', () => {
     cancellation: true
   });
   expect(Object.isFrozen(ARROW_TABLE_QUERY_CAPABILITIES)).toBe(true);
+});
+
+test('ArrowTableSource exposes shared metadata and bounded scan batches', async () => {
+  const source = new ArrowTableSource(makeArrowTable({x: [1, 2], value: [10, 20]}));
+
+  const metadata = await source.getQueryMetadata();
+  expect(metadata.queryType).toBe('table');
+  expect(metadata.columns.map(column => [column.name, column.role])).toEqual([
+    ['x', 'x'],
+    ['value', 'attribute']
+  ]);
+  expect(metadata.statistics?.rowCount).toBe(2);
+
+  const batches = [];
+  for await (const batch of source.read({columns: ['value'], limit: 1})) {
+    batches.push(batch);
+  }
+  expect(batches).toHaveLength(1);
+  expect(batches[0].length).toBe(1);
+  expect(batches[0].data.schema.fields.map(field => field.name)).toEqual(['value']);
 });
 
 test('queryArrowTable filters, projects, and limits Arrow data', () => {

--- a/website/src/components/docs/scan-query-panel.tsx
+++ b/website/src/components/docs/scan-query-panel.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useId, useState} from 'react';
 import styled from 'styled-components';
 import type {ScanQueryMetadata} from '@loaders.gl/loader-utils';
 
@@ -10,6 +10,12 @@ export type ScanQueryPanelState = Readonly<{
   limit?: number;
   /** Optional source-coordinate bounding box in minX, minY, maxX, maxY order. */
   boundingBox?: readonly [number, number, number, number];
+  /** Optional raster overview or point-cloud minimum hierarchy level. */
+  level?: number;
+  /** Optional point-cloud maximum hierarchy level. */
+  maximumLevel?: number;
+  /** Optional point-cloud target spacing. */
+  targetSpacing?: number;
 }>;
 
 /** Props for a source-neutral query-parameter panel. */
@@ -34,18 +40,34 @@ export function ScanQueryPanel({
   onApply,
   title = 'Scan query'
 }: ScanQueryPanelProps): JSX.Element {
+  const panelId = useId().replace(/:/g, '');
   const [selectedColumns, setSelectedColumns] = useState<string[]>(value?.columns ? [...value.columns] : []);
   const [limitText, setLimitText] = useState(value?.limit === undefined ? '' : String(value.limit));
-  const [boundingBoxText, setBoundingBoxText] = useState('');
+  const [boundingBoxText, setBoundingBoxText] = useState(
+    value?.boundingBox ? value.boundingBox.join(',') : ''
+  );
+  const [levelText, setLevelText] = useState(value?.level === undefined ? '' : String(value.level));
+  const [maximumLevelText, setMaximumLevelText] = useState(
+    value?.maximumLevel === undefined ? '' : String(value.maximumLevel)
+  );
+  const [targetSpacingText, setTargetSpacingText] = useState(
+    value?.targetSpacing === undefined ? '' : String(value.targetSpacing)
+  );
 
   useEffect(() => {
     setSelectedColumns(value?.columns ? [...value.columns] : []);
     setLimitText(value?.limit === undefined ? '' : String(value.limit));
+    setBoundingBoxText(value?.boundingBox ? value.boundingBox.join(',') : '');
+    setLevelText(value?.level === undefined ? '' : String(value.level));
+    setMaximumLevelText(value?.maximumLevel === undefined ? '' : String(value.maximumLevel));
+    setTargetSpacingText(value?.targetSpacing === undefined ? '' : String(value.targetSpacing));
   }, [value]);
 
   const columns = metadata?.columns || [];
   const hasLimit = metadata?.capabilities.table?.limit && metadata.capabilities.table.limit !== 'unsupported';
   const hasBounds = metadata?.capabilities.bounds && metadata.capabilities.bounds !== 'unsupported';
+  const hasLevel = metadata?.capabilities.levelOfDetail && metadata.capabilities.levelOfDetail !== 'unsupported';
+  const isPointCloud = metadata?.queryType === 'point-cloud';
   const sourceBounds = metadata?.spatial?.bounds;
   const toggleColumn = (name: string): void => {
     setSelectedColumns(current =>
@@ -94,9 +116,9 @@ export function ScanQueryPanel({
           <InlineFields>
             {hasLimit ? (
               <FieldGroup>
-                <FieldLabel htmlFor="scan-query-limit">Row limit</FieldLabel>
+                <FieldLabel htmlFor={`${panelId}-limit`}>Row limit</FieldLabel>
                 <TextInput
-                  id="scan-query-limit"
+                  id={`${panelId}-limit`}
                   inputMode="numeric"
                   min="0"
                   placeholder="All rows"
@@ -107,14 +129,53 @@ export function ScanQueryPanel({
             ) : null}
             {hasBounds ? (
               <FieldGroup>
-                <FieldLabel htmlFor="scan-query-bounds">Bounding box</FieldLabel>
+                <FieldLabel htmlFor={`${panelId}-bounds`}>Bounding box</FieldLabel>
                 <TextInput
-                  id="scan-query-bounds"
+                  id={`${panelId}-bounds`}
                   placeholder={sourceBounds ? formatBounds(sourceBounds) : 'minX,minY,maxX,maxY'}
                   value={boundingBoxText}
                   onChange={event => setBoundingBoxText(event.target.value)}
                 />
               </FieldGroup>
+            ) : null}
+            {hasLevel ? (
+              <FieldGroup>
+                <FieldLabel htmlFor={`${panelId}-level`}>{isPointCloud ? 'Minimum level' : 'Overview level'}</FieldLabel>
+                <TextInput
+                  id={`${panelId}-level`}
+                  inputMode="numeric"
+                  min="0"
+                  placeholder="Native/default"
+                  value={levelText}
+                  onChange={event => setLevelText(event.target.value)}
+                />
+              </FieldGroup>
+            ) : null}
+            {isPointCloud && hasLevel ? (
+              <>
+                <FieldGroup>
+                  <FieldLabel htmlFor={`${panelId}-maximum-level`}>Maximum level</FieldLabel>
+                  <TextInput
+                    id={`${panelId}-maximum-level`}
+                    inputMode="numeric"
+                    min="0"
+                    placeholder="Any"
+                    value={maximumLevelText}
+                    onChange={event => setMaximumLevelText(event.target.value)}
+                  />
+                </FieldGroup>
+                <FieldGroup>
+                  <FieldLabel htmlFor={`${panelId}-spacing`}>Target spacing</FieldLabel>
+                  <TextInput
+                    id={`${panelId}-spacing`}
+                    inputMode="decimal"
+                    min="0"
+                    placeholder="Native/default"
+                    value={targetSpacingText}
+                    onChange={event => setTargetSpacingText(event.target.value)}
+                  />
+                </FieldGroup>
+              </>
             ) : null}
           </InlineFields>
           <ApplyButton
@@ -122,10 +183,16 @@ export function ScanQueryPanel({
             onClick={() => {
               const limit = limitText.trim() ? Number(limitText) : undefined;
               const boundingBox = parseBounds(boundingBoxText);
+              const level = parseNonNegativeInteger(levelText);
+              const maximumLevel = parseNonNegativeInteger(maximumLevelText);
+              const targetSpacing = parsePositiveNumber(targetSpacingText);
               onApply({
                 columns: selectedColumns.length && selectedColumns.length < columns.length ? selectedColumns : undefined,
                 limit: Number.isSafeInteger(limit) && (limit as number) >= 0 ? limit : undefined,
-                boundingBox
+                boundingBox,
+                level,
+                maximumLevel,
+                targetSpacing
               });
             }}
           >
@@ -139,13 +206,29 @@ export function ScanQueryPanel({
   );
 }
 
+/** Parses a four-coordinate source bounding box from panel text. */
 function parseBounds(value: string): readonly [number, number, number, number] | undefined {
   const numbers = value.split(',').map(part => Number(part.trim()));
   return numbers.length === 4 && numbers.every(Number.isFinite) ? [numbers[0], numbers[1], numbers[2], numbers[3]] : undefined;
 }
 
+/** Formats the two-dimensional portion of discovered source bounds. */
 function formatBounds(bounds: {minimum: readonly number[]; maximum: readonly number[]}): string {
   return [...bounds.minimum.slice(0, 2), ...bounds.maximum.slice(0, 2)].join(',');
+}
+
+/** Parses an optional non-negative hierarchy or overview level. */
+function parseNonNegativeInteger(value: string): number | undefined {
+  if (!value.trim()) return undefined;
+  const number = Number(value);
+  return Number.isSafeInteger(number) && number >= 0 ? number : undefined;
+}
+
+/** Parses an optional positive point-cloud spacing. */
+function parsePositiveNumber(value: string): number | undefined {
+  if (!value.trim()) return undefined;
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? number : undefined;
 }
 
 const Panel = styled.section`

--- a/website/src/components/docs/scan-query-panel.tsx
+++ b/website/src/components/docs/scan-query-panel.tsx
@@ -12,6 +12,8 @@ export type ScanQueryPanelState = Readonly<{
   boundingBox?: readonly [number, number, number, number];
   /** Optional raster overview or point-cloud minimum hierarchy level. */
   level?: number;
+  /** Optional point-cloud minimum hierarchy level. */
+  minimumLevel?: number;
   /** Optional point-cloud maximum hierarchy level. */
   maximumLevel?: number;
   /** Optional point-cloud target spacing. */
@@ -47,6 +49,9 @@ export function ScanQueryPanel({
     value?.boundingBox ? value.boundingBox.join(',') : ''
   );
   const [levelText, setLevelText] = useState(value?.level === undefined ? '' : String(value.level));
+  const [minimumLevelText, setMinimumLevelText] = useState(
+    value?.minimumLevel === undefined ? '' : String(value.minimumLevel)
+  );
   const [maximumLevelText, setMaximumLevelText] = useState(
     value?.maximumLevel === undefined ? '' : String(value.maximumLevel)
   );
@@ -59,6 +64,7 @@ export function ScanQueryPanel({
     setLimitText(value?.limit === undefined ? '' : String(value.limit));
     setBoundingBoxText(value?.boundingBox ? value.boundingBox.join(',') : '');
     setLevelText(value?.level === undefined ? '' : String(value.level));
+    setMinimumLevelText(value?.minimumLevel === undefined ? '' : String(value.minimumLevel));
     setMaximumLevelText(value?.maximumLevel === undefined ? '' : String(value.maximumLevel));
     setTargetSpacingText(value?.targetSpacing === undefined ? '' : String(value.targetSpacing));
   }, [value]);
@@ -146,8 +152,10 @@ export function ScanQueryPanel({
                   inputMode="numeric"
                   min="0"
                   placeholder="Native/default"
-                  value={levelText}
-                  onChange={event => setLevelText(event.target.value)}
+                  value={isPointCloud ? minimumLevelText : levelText}
+                  onChange={event =>
+                    isPointCloud ? setMinimumLevelText(event.target.value) : setLevelText(event.target.value)
+                  }
                 />
               </FieldGroup>
             ) : null}
@@ -184,13 +192,15 @@ export function ScanQueryPanel({
               const limit = limitText.trim() ? Number(limitText) : undefined;
               const boundingBox = parseBounds(boundingBoxText);
               const level = parseNonNegativeInteger(levelText);
+              const minimumLevel = parseNonNegativeInteger(minimumLevelText);
               const maximumLevel = parseNonNegativeInteger(maximumLevelText);
               const targetSpacing = parsePositiveNumber(targetSpacingText);
               onApply({
                 columns: selectedColumns.length && selectedColumns.length < columns.length ? selectedColumns : undefined,
                 limit: Number.isSafeInteger(limit) && (limit as number) >= 0 ? limit : undefined,
                 boundingBox,
-                level,
+                level: isPointCloud ? undefined : level,
+                minimumLevel: isPointCloud ? minimumLevel : undefined,
                 maximumLevel,
                 targetSpacing
               });


### PR DESCRIPTION
## Goals

Start the format-support-first scan roadmap by making the shared panel usable for point-cloud and raster controls and promoting Arrow/GeoArrow to a real common scan source.

## Changes

- Add reusable hierarchy/overview level, point-cloud minimum/maximum levels, and target-spacing controls to ScanQueryPanel.
- Emit minimumLevel for COPC/Potree queries while retaining level for raster overview queries.
- Preserve and synchronize bounds and panel state across metadata refreshes, with instance-scoped control IDs.
- Add ArrowTableSource with metadata-only discovery, semantic coordinate/time roles, explain, query, and bounded batch reads.
- Correct Arrow/GeoArrow, ORC, Delta Lake, and Lance support statuses in the scan scorecard.

## Verification

- yarn lint fix
- yarn build
- yarn test-headless modules/sql/test/arrow-query.spec.ts
- git diff --check

The website build completed with existing Docusaurus broken-link and HTML-minifier warnings.