### PR TITLE
feat(gltf): prototype Mesh Arrow scene conversion

### DIFF
--- a/docs/arrowjs/arrow-sidebar.json
+++ b/docs/arrowjs/arrow-sidebar.json
@@ -22,6 +22,11 @@
     },
     {
       "type": "category",
+      "label": "Usage Guide",
+      "items": ["arrowjs/usage-guide/mesharrow"]
+    },
+    {
+      "type": "category",
       "label": "Developer Guide",
       "items": [
         "arrowjs/developer-guide/introduction",

--- a/docs/arrowjs/usage-guide/mesharrow.md
+++ b/docs/arrowjs/usage-guide/mesharrow.md
@@ -79,24 +79,29 @@ Use `convertMeshToTable(mesh, 'arrow-table')` when starting from a legacy loader
 
 ### Project a glTF scene
 
-`@loaders.gl/gltf/mesh-arrow` projects an already loaded glTF scene into one Mesh Arrow table per primitive. It preserves each primitive's source-compatible attributes and returns scene placement separately, rather than baking transforms into vertex data.
+`@loaders.gl/gltf/mesh-arrow` converts an already loaded glTF scene into reusable Mesh Arrow geometries and separate scene placements. Each source primitive is converted once even when its mesh is referenced by multiple nodes.
 
 ```ts
 import {load} from '@loaders.gl/core';
 import {GLTFLoader} from '@loaders.gl/gltf';
-import {extractGLTFMeshArrowPrimitives} from '@loaders.gl/gltf/mesh-arrow';
+import {convertGLTFToMeshArrow} from '@loaders.gl/gltf/mesh-arrow';
 
 const gltf = await load('scene.glb', GLTFLoader);
-const primitives = extractGLTFMeshArrowPrimitives(gltf);
+const meshArrow = convertGLTFToMeshArrow(gltf);
 
-for (const primitive of primitives) {
-  primitive.table; // MeshArrowTable
-  primitive.worldMatrix; // placement in the glTF scene
-  primitive.materialIndex; // optional source material reference
+for (const geometry of meshArrow.geometries) {
+  geometry.table; // MeshArrowTable, including optional row-0 indices
+  geometry.materialIndex; // optional source material reference
+  geometry.materialized; // true if packed storage had to be allocated
+}
+
+for (const placement of meshArrow.placements) {
+  meshArrow.geometries[placement.geometryIndex];
+  placement.worldMatrix;
 }
 ```
 
-The projection preserves dense, non-interleaved vertex buffer views. Sparse and interleaved accessors are rejected explicitly. It does not bake node transforms, evaluate skinning or morph targets, resolve GPU instancing, or decide how to batch draws.
+Dense, packed accessors retain views of their source buffers. Interleaved, sparse, and implicit-zero accessors are materialized into packed arrays containing the same component values. Use `{accessorLayout: 'zero-copy-only'}` to reject accessors that require allocation. Conversion does not modify the source glTF, bake node transforms, evaluate skinning or morph targets, resolve GPU instancing, or decide how to batch draws.
 
 ## Rendering with luma.gl
 

--- a/docs/arrowjs/usage-guide/mesharrow.md
+++ b/docs/arrowjs/usage-guide/mesharrow.md
@@ -1,0 +1,150 @@
+# Mesh Arrow Tables
+
+Mesh Arrow is the loaders.gl convention for representing one renderable mesh or point-cloud primitive as an Apache Arrow table. It is a vis.gl interoperability contract, not an Apache Arrow, GeoArrow, or glTF standard.
+
+The contract deliberately covers geometry attributes, primitive topology, indices, and a small amount of metadata. Scene graphs, materials, textures, instances, and draw scheduling remain separate concerns.
+
+## Data model
+
+A `MeshArrowTable` wraps an `arrow.Table`:
+
+```ts
+import type {MeshArrowTable} from '@loaders.gl/schema';
+
+declare const mesh: MeshArrowTable;
+
+mesh.shape; // 'arrow-table'
+mesh.topology; // 'point-list' | 'triangle-list' | 'triangle-strip'
+mesh.data; // Apache Arrow Table
+```
+
+The raw Arrow table has **one vertex per row**. Each vertex attribute is a scalar numeric column or a numeric `FixedSizeList` column. This is directly compatible with GPU vertex and instance buffers.
+
+| Column | Arrow type | Requirement | Meaning |
+| --- | --- | --- | --- |
+| `POSITION` | `FixedSizeList<Float32, 3>` | Required | One XYZ position per row |
+| `NORMAL` | Numeric `FixedSizeList<3>` | Optional | One normal per row |
+| `COLOR_0` | Numeric `FixedSizeList<3 or 4>` | Optional | First vertex color |
+| `TEXCOORD_0`, `TEXCOORD_1` | Numeric `FixedSizeList<2>` | Optional | Texture coordinates |
+| `indices` | `List<Int32>` | Indexed meshes only | Complete primitive index list at row `0`; remaining rows are null |
+| Custom | Numeric scalar or `FixedSizeList<1-4>` | Optional | Loader- or application-specific vertex attribute |
+
+`POSITION`, `NORMAL`, `COLOR_0`, and `TEXCOORD_n` use glTF attribute semantic names. The lowercase `indices` name follows the glTF primitive property; it is not a vertex attribute.
+
+`@loaders.gl/schema` exports `MeshArrowTable`, `MeshArrowColumns`, `MeshArrowTableData`, `IndexedMeshArrowColumns`, `IndexedMeshArrowTableData`, `meshArrowSchema`, and `indexedMeshArrowSchema` for this contract.
+
+### Metadata and record batches
+
+Schema metadata retains `topology`, numeric primitive `mode`, and optionally `boundingBox`. Field metadata can retain the source `normalized`, `byteOffset`, and `byteStride` values. Metadata values are strings; structured values are JSON-encoded.
+
+The `MeshArrowTable.topology` property is authoritative. Schema metadata lets the same information survive when a raw Arrow table is passed without the loaders.gl wrapper.
+
+Record batches are chunks of one logical vertex table, not separate meshes. An indexed table has one primitive-level index list. Keep primitives with different materials or pipelines in separate Mesh Arrow tables, or place them in an explicit scene/primitive layer above the tables.
+
+## Producing tables
+
+Mesh-category loaders expose Arrow output through a loader-specific `shape: 'arrow-table'` option:
+
+```ts
+import {load} from '@loaders.gl/core';
+import {LASLoader} from '@loaders.gl/las';
+import type {MeshArrowTable} from '@loaders.gl/schema';
+
+const pointCloud = (await load('point-cloud.laz', LASLoader, {
+  las: {shape: 'arrow-table'}
+})) as MeshArrowTable;
+```
+
+`@loaders.gl/schema-utils` can build a table from typed attributes:
+
+```ts
+import {makeMeshArrowTable} from '@loaders.gl/schema-utils';
+
+const triangle = makeMeshArrowTable(
+  {
+    POSITION: {
+      value: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+      size: 3
+    }
+  },
+  {
+    topology: 'triangle-list',
+    mode: 4,
+    indices: {value: new Uint32Array([0, 1, 2]), size: 1}
+  }
+);
+```
+
+Use `convertMeshToTable(mesh, 'arrow-table')` when starting from a legacy loaders.gl `Mesh`. See the [Mesh and PointCloud category](/docs/specifications/category-mesh) for the loader and writer matrix.
+
+### Project a glTF scene
+
+`@loaders.gl/gltf/mesh-arrow` projects an already loaded glTF scene into one Mesh Arrow table per primitive. It preserves each primitive's source-compatible attributes and returns scene placement separately, rather than baking transforms into vertex data.
+
+```ts
+import {load} from '@loaders.gl/core';
+import {GLTFLoader} from '@loaders.gl/gltf';
+import {extractGLTFMeshArrowPrimitives} from '@loaders.gl/gltf/mesh-arrow';
+
+const gltf = await load('scene.glb', GLTFLoader);
+const primitives = extractGLTFMeshArrowPrimitives(gltf);
+
+for (const primitive of primitives) {
+  primitive.table; // MeshArrowTable
+  primitive.worldMatrix; // placement in the glTF scene
+  primitive.materialIndex; // optional source material reference
+}
+```
+
+The projection preserves dense, non-interleaved vertex buffer views. Sparse and interleaved accessors are rejected explicitly. It does not bake node transforms, evaluate skinning or morph targets, resolve GPU instancing, or decide how to batch draws.
+
+## Rendering with luma.gl
+
+`@luma.gl/arrow` accepts the loaders.gl wrapper structurally, without introducing a loaders.gl dependency. `makeGPUGeometryFromArrow()` can create static GPU geometry from a Mesh Arrow table:
+
+```ts
+import {makeGPUGeometryFromArrow} from '@luma.gl/arrow';
+
+const geometry = makeGPUGeometryFromArrow(device, {
+  arrowMesh: triangle,
+  interleaved: true
+});
+```
+
+The adapter maps common Mesh Arrow columns to luma.gl geometry attributes, can pack attributes into an interleaved vertex buffer, and uploads the row-0 `indices` list as a separate index buffer. Its direct geometry path is for numeric scalar and fixed-size-list attributes with portable GPU vertex formats; applications should convert unsupported nullable, variable-length, 64-bit integer, or Float64 attributes before upload.
+
+## Meshes, instances, and draws
+
+Keep these responsibilities separate:
+
+| Concern | Recommended representation |
+| --- | --- |
+| Vertex and index data for one renderable primitive | `MeshArrowTable`, then luma.gl Arrow geometry |
+| Per-object transforms, colors, feature ids, or visibility | A separate row-oriented Arrow table |
+| Draw counts, offsets, materials, pipelines, and resource groups | Renderer-owned draw metadata and render APIs |
+
+This supports two common batching strategies:
+
+- **Instancing:** retain one Mesh Arrow geometry and keep one transform and property set per row of a separate instance table.
+- **Packed primitives:** pack compatible vertex/index ranges into shared GPU buffers and retain a renderer draw record per primitive or material group.
+
+Indirect draw commands complement Mesh Arrow but are not part of its schema. A renderer still owns pipeline, material, texture, bind-group, and geometry compatibility.
+
+## Relationship to GeoArrow and storage
+
+GeoArrow represents geospatial feature semantics such as points, lines, polygons, coordinate reference systems, and geometry metadata. Mesh Arrow represents already renderable vertex attributes and topology. A GeoArrow feature table may need tessellation or expansion before it becomes a Mesh Arrow table. Keep source feature tables and derived render meshes separate, joining them with an explicit row index or feature id when needed.
+
+The raw Arrow table can be serialized with Arrow IPC and maps naturally to Parquet's fixed-width columns. That does not make Mesh Arrow a file-format standard: readers still need to agree on the vis.gl column and metadata conventions, and a collection of primitives needs a dataset-level organization.
+
+## Current non-goals
+
+Mesh Arrow does not standardize scene hierarchy, materials, textures, samplers, shader selection, compression or quantization transforms, morph targets, skinning, animation, feature metadata, picking ids, or indirect-draw/resource-group records.
+
+Use glTF for portable scene and material interchange. Use Mesh Arrow when the useful boundary is a typed, columnar, render-oriented primitive that can flow between loaders.gl, Arrow tooling, and luma.gl.
+
+## Related documentation
+
+- [Mesh and PointCloud category](/docs/specifications/category-mesh)
+- [Apache Arrow support in loaders.gl](/docs/developer-guide/apache-arrow)
+- [GeoArrow format](/docs/modules/arrow/formats/geoarrow)
+- [luma.gl Arrow overview](https://luma.gl/docs/api-reference/arrow)

--- a/docs/modules/gltf/api-reference/gltf-loader.md
+++ b/docs/modules/gltf/api-reference/gltf-loader.md
@@ -50,6 +50,17 @@ The loader also supports draft glTF 2.1 [thumbnails](/docs/modules/gltf/formats/
 
 The GLTF Loader returns an object with a `json` field containing the glTF Scenegraph. In its basic mode, the `GLTFLoader` does not modify the loaded JSON in any way. Instead, the results of additional processing are placed in parallel top-level fields such as `buffers` and `images`. This ensures that applications that want to work with the standard glTF data structure can do so.
 
+For applications that need static geometry in the Mesh Arrow layout, use `extractGLTFMeshArrowPrimitives()` after loading. It returns one table per primitive with its node path, world transform, material index, and source indices. Dense, non-interleaved vertex accessors retain views of their source typed arrays. The projection does not bake node transforms, skinning, morph targets, or GPU instancing; those remain scene-level concerns.
+
+```ts
+import {load} from '@loaders.gl/core';
+import {GLTFLoader} from '@loaders.gl/gltf';
+import {extractGLTFMeshArrowPrimitives} from '@loaders.gl/gltf/mesh-arrow';
+
+const gltf = await load(url, GLTFLoader);
+const primitives = extractGLTFMeshArrowPrimitives(gltf);
+```
+
 Optionally, the loaded gltf can be "post processed", which lightly annotates and transforms the loaded JSON structure to make it easier to use. Refer to [postProcessGLTF](post-process-gltf) for details.
 
 In addition, certain glTF extensions, including Draco and [meshopt compression](/docs/modules/gltf/formats/gltf#meshopt-compression), can be fully or partially processed during loading. When possible (and extension processing is enabled), such extensions will be resolved/decompressed and replaced with standards conformant representations.

--- a/docs/modules/gltf/api-reference/gltf-loader.md
+++ b/docs/modules/gltf/api-reference/gltf-loader.md
@@ -50,15 +50,15 @@ The loader also supports draft glTF 2.1 [thumbnails](/docs/modules/gltf/formats/
 
 The GLTF Loader returns an object with a `json` field containing the glTF Scenegraph. In its basic mode, the `GLTFLoader` does not modify the loaded JSON in any way. Instead, the results of additional processing are placed in parallel top-level fields such as `buffers` and `images`. This ensures that applications that want to work with the standard glTF data structure can do so.
 
-For applications that need static geometry in the Mesh Arrow layout, use `extractGLTFMeshArrowPrimitives()` after loading. It returns one table per primitive with its node path, world transform, material index, and source indices. Dense, non-interleaved vertex accessors retain views of their source typed arrays. The projection does not bake node transforms, skinning, morph targets, or GPU instancing; those remain scene-level concerns.
+For applications that need static geometry in the Mesh Arrow layout, use `convertGLTFToMeshArrow()` after loading. It converts each source primitive once and returns node placements separately, preserving mesh reuse. Dense, packed accessors retain views of source buffers; interleaved, sparse, and implicit-zero accessors are materialized without changing their logical component values. Conversion does not modify the glTF or bake node transforms, skinning, morph targets, or GPU instancing.
 
 ```ts
 import {load} from '@loaders.gl/core';
 import {GLTFLoader} from '@loaders.gl/gltf';
-import {extractGLTFMeshArrowPrimitives} from '@loaders.gl/gltf/mesh-arrow';
+import {convertGLTFToMeshArrow} from '@loaders.gl/gltf/mesh-arrow';
 
 const gltf = await load(url, GLTFLoader);
-const primitives = extractGLTFMeshArrowPrimitives(gltf);
+const meshArrow = convertGLTFToMeshArrow(gltf);
 ```
 
 Optionally, the loaded gltf can be "post processed", which lightly annotates and transforms the loaded JSON structure to make it easier to use. Refer to [postProcessGLTF](post-process-gltf) for details.

--- a/docs/specifications/category-mesh.md
+++ b/docs/specifications/category-mesh.md
@@ -58,6 +58,8 @@ Legacy Mesh loader variants return a JavaScript object shape that is optimized f
 
 ## Mesh Arrow Tables
 
+See the [Mesh Arrow usage guide](/docs/arrowjs/usage-guide/mesharrow) for the complete column and metadata conventions, construction examples, and luma.gl rendering guidance.
+
 `@loaders.gl/schema` exports predefined schema contracts for common mesh columns:
 
 | Export                       | Description                                                                                 |

--- a/modules/gltf/package.json
+++ b/modules/gltf/package.json
@@ -41,6 +41,10 @@
       "types": "./dist/bundled.d.ts",
       "import": "./dist/bundled.js"
     },
+    "./mesh-arrow": {
+      "types": "./dist/mesh-arrow.d.ts",
+      "import": "./dist/mesh-arrow.js"
+    },
     "./gltf.schema.json": "./dist/gltf.schema.json",
     "./gltf-1.schema.json": "./dist/gltf-1.schema.json",
     "./gltf-2.schema.json": "./dist/gltf-2.schema.json",
@@ -67,6 +71,7 @@
     "@loaders.gl/images": "5.0.0-alpha.2",
     "@loaders.gl/loader-utils": "5.0.0-alpha.2",
     "@loaders.gl/schema": "5.0.0-alpha.2",
+    "@loaders.gl/schema-utils": "5.0.0-alpha.2",
     "@loaders.gl/textures": "5.0.0-alpha.2",
     "@math.gl/core": "^4.1.0",
     "meshoptimizer": "^1.2.0",

--- a/modules/gltf/src/lib/api/gltf-mesh-arrow.ts
+++ b/modules/gltf/src/lib/api/gltf-mesh-arrow.ts
@@ -10,59 +10,108 @@ import type {GLTFWithBuffers} from '../types/gltf-types';
 import {getTypedArrayForAccessor} from '../gltf-utils/get-typed-array';
 import {getSizeFromAccessorType} from '../gltf-utils/gltf-constants';
 
-/** A mesh primitive projected from a glTF scene into a Mesh Arrow table. */
-export type GLTFMeshArrowPrimitive = {
-  /** Arrow table containing the primitive's vertex attributes and optional indices. */
+/** Controls whether accessors requiring packed storage may be materialized. */
+export type GLTFMeshArrowOptions = {
+  /** Accessor layout policy. Defaults to materializing exact logical values when necessary. */
+  accessorLayout?: 'materialize' | 'zero-copy-only';
+};
+
+/** A glTF scene projected into reusable Mesh Arrow geometry and separate scene placements. */
+export type GLTFMeshArrow = {
+  /** Unique source mesh primitives, each represented by one Mesh Arrow table. */
+  geometries: GLTFMeshArrowGeometry[];
+  /** Scene occurrences that place reusable geometries at glTF nodes. */
+  placements: GLTFMeshArrowPlacement[];
+};
+
+/** One unique source glTF mesh primitive represented as Mesh Arrow geometry. */
+export type GLTFMeshArrowGeometry = {
+  /** Arrow table containing vertex attributes and the optional row-0 index list. */
   table: MeshArrowTable;
-  /** Source-compatible attribute descriptors, including normalized and stride metadata. */
+  /** Source-compatible attribute descriptors, including normalization metadata. */
   attributes: MeshAttributes;
-  /** World transform of the node that instantiates the primitive. */
-  worldMatrix: Matrix4;
-  /** Index of the source node. */
-  nodeIndex: number;
-  /** Node indices from the selected scene root through the source node. */
-  nodePath: number[];
   /** Index of the source mesh. */
   meshIndex: number;
   /** Index of the primitive within the source mesh. */
   primitiveIndex: number;
   /** Index of the primitive material, when specified. */
   materialIndex?: number;
+  /** Whether any accessor required packed allocation rather than borrowing source storage. */
+  materialized: boolean;
+};
+
+/** Placement of one reusable Mesh Arrow geometry in the selected glTF scene. */
+export type GLTFMeshArrowPlacement = {
+  /** Index into the result's geometries array. */
+  geometryIndex: number;
+  /** World transform of the node instantiating the geometry. */
+  worldMatrix: Matrix4;
+  /** Index of the source node. */
+  nodeIndex: number;
+  /** Node indices from the selected scene root through the source node. */
+  nodePath: number[];
+};
+
+type ConversionState = {
+  gltf: GLTFWithBuffers;
+  options: Required<GLTFMeshArrowOptions>;
+  geometries: GLTFMeshArrowGeometry[];
+  placements: GLTFMeshArrowPlacement[];
+  geometryIndices: Map<string, number>;
+};
+
+type MeshAttributeResult = {
+  attribute: MeshAttribute;
+  materialized: boolean;
+};
+
+type MeshTypedArrayConstructor = {
+  readonly BYTES_PER_ELEMENT: number;
+  new (length: number): MeshAttribute['value'];
+  new (buffer: ArrayBuffer, byteOffset: number, length: number): MeshAttribute['value'];
 };
 
 /**
- * Project the default glTF scene into one Mesh Arrow table per mesh primitive.
+ * Convert the selected glTF scene to reusable Mesh Arrow geometries and placements.
  *
- * This projection preserves source vertex attribute views for dense, non-interleaved accessors.
- * It does not bake node transforms, apply skinning or morph targets, or flatten GPU instancing.
- * Those scene-level concerns remain represented by the returned primitive metadata and source glTF.
+ * Dense packed accessors borrow their original storage. Interleaved, sparse, and implicit-zero
+ * accessors are materialized without changing component types, normalization, indexing, node
+ * transforms, or primitive reuse. The input glTF and its buffers are never modified.
  * @param gltf Parsed glTF data with resolved binary buffers.
- * @returns Mesh Arrow primitives in default-scene traversal order.
+ * @param options Accessor materialization policy.
+ * @returns Reusable geometries and their scene placements.
  */
-export function extractGLTFMeshArrowPrimitives(gltf: GLTFWithBuffers): GLTFMeshArrowPrimitive[] {
-  const rootNodeIndices = getRootNodeIndices(gltf);
-  const primitives: GLTFMeshArrowPrimitive[] = [];
+export function convertGLTFToMeshArrow(
+  gltf: GLTFWithBuffers,
+  options: GLTFMeshArrowOptions = {}
+): GLTFMeshArrow {
+  const state: ConversionState = {
+    gltf,
+    options: {accessorLayout: options.accessorLayout || 'materialize'},
+    geometries: [],
+    placements: [],
+    geometryIndices: new Map()
+  };
 
-  for (const rootNodeIndex of rootNodeIndices) {
-    visitNode(gltf, rootNodeIndex, new Matrix4(), [], primitives);
+  for (const rootNodeIndex of getRootNodeIndices(gltf)) {
+    visitNode(state, rootNodeIndex, new Matrix4(), []);
   }
 
-  return primitives;
+  return {geometries: state.geometries, placements: state.placements};
 }
 
-/** Visit a node and append each of its mesh primitives to the projection result. */
+/** Visit a node and append placements for each of its mesh primitives. */
 function visitNode(
-  gltf: GLTFWithBuffers,
+  state: ConversionState,
   nodeIndex: number,
   parentWorldMatrix: Matrix4,
-  parentNodePath: number[],
-  primitives: GLTFMeshArrowPrimitive[]
+  parentNodePath: number[]
 ): void {
   if (parentNodePath.includes(nodeIndex)) {
     throw new Error(`glTF node hierarchy contains a cycle at node ${nodeIndex}`);
   }
 
-  const node = gltf.json.nodes?.[nodeIndex];
+  const node = state.gltf.json.nodes?.[nodeIndex];
   if (!node) {
     throw new Error(`glTF scene references missing node ${nodeIndex}`);
   }
@@ -71,34 +120,51 @@ function visitNode(
   const worldMatrix = new Matrix4(parentWorldMatrix).multiplyRight(getNodeMatrix(node));
 
   if (node.mesh !== undefined) {
-    const mesh = gltf.json.meshes?.[node.mesh];
+    const mesh = state.gltf.json.meshes?.[node.mesh];
     if (!mesh) {
       throw new Error(`glTF node ${nodeIndex} references missing mesh ${node.mesh}`);
     }
 
     for (const [primitiveIndex, primitive] of mesh.primitives.entries()) {
-      const {table, attributes} = convertGLTFPrimitiveToMeshArrowTable(gltf, primitive);
-      primitives.push({
-        table,
-        attributes,
-        worldMatrix,
-        nodeIndex,
-        nodePath,
-        meshIndex: node.mesh,
-        primitiveIndex,
-        materialIndex: primitive.material
-      });
+      const geometryIndex = getOrCreateGeometry(state, node.mesh, primitiveIndex, primitive);
+      state.placements.push({geometryIndex, worldMatrix, nodeIndex, nodePath});
     }
   }
 
   for (const childNodeIndex of node.children || []) {
-    visitNode(gltf, childNodeIndex, worldMatrix, nodePath, primitives);
+    visitNode(state, childNodeIndex, worldMatrix, nodePath);
   }
+}
+
+/** Get or create the unique geometry for one source mesh primitive. */
+function getOrCreateGeometry(
+  state: ConversionState,
+  meshIndex: number,
+  primitiveIndex: number,
+  primitive: GLTFMeshPrimitive
+): number {
+  const key = `${meshIndex}:${primitiveIndex}`;
+  const existingIndex = state.geometryIndices.get(key);
+  if (existingIndex !== undefined) {
+    return existingIndex;
+  }
+
+  const geometry = convertGLTFPrimitiveToMeshArrowGeometry(
+    state.gltf,
+    meshIndex,
+    primitiveIndex,
+    primitive,
+    state.options
+  );
+  const geometryIndex = state.geometries.length;
+  state.geometries.push(geometry);
+  state.geometryIndices.set(key, geometryIndex);
+  return geometryIndex;
 }
 
 /** Get the selected scene roots, or infer roots when a glTF asset does not define scenes. */
 function getRootNodeIndices(gltf: GLTFWithBuffers): number[] {
-  const selectedScene = gltf.json.scenes?.[gltf.json.scene || 0];
+  const selectedScene = gltf.json.scenes?.[gltf.json.scene ?? 0];
   if (selectedScene) {
     return selectedScene.nodes || [];
   }
@@ -122,87 +188,188 @@ function getNodeMatrix(node: GLTFNode): Matrix4 {
     .scale(node.scale || [1, 1, 1]);
 }
 
-/** Convert one glTF mesh primitive to its Mesh Arrow representation. */
-function convertGLTFPrimitiveToMeshArrowTable(
+/** Convert one glTF mesh primitive to reusable Mesh Arrow geometry. */
+function convertGLTFPrimitiveToMeshArrowGeometry(
   gltf: GLTFWithBuffers,
-  primitive: GLTFMeshPrimitive
-): {table: MeshArrowTable; attributes: MeshAttributes} {
+  meshIndex: number,
+  primitiveIndex: number,
+  primitive: GLTFMeshPrimitive,
+  options: Required<GLTFMeshArrowOptions>
+): GLTFMeshArrowGeometry {
   const attributes: MeshAttributes = {};
+  let materialized = false;
 
   for (const [attributeName, accessorIndex] of Object.entries(primitive.attributes)) {
-    attributes[attributeName] = getMeshAttribute(gltf, accessorIndex);
+    const result = getMeshAttribute(gltf, accessorIndex, options);
+    attributes[attributeName] = result.attribute;
+    materialized ||= result.materialized;
   }
 
-  const indices =
-    primitive.indices === undefined ? undefined : getMeshAttribute(gltf, primitive.indices);
-  const mode = primitive.mode || 4;
+  const indexResult =
+    primitive.indices === undefined
+      ? undefined
+      : getMeshAttribute(gltf, primitive.indices, options);
+  materialized ||= indexResult?.materialized || false;
+  const mode = primitive.mode ?? 4;
 
   return {
-    table: makeMeshArrowTable(attributes, {topology: getMeshTopology(mode), mode, indices}),
-    attributes
+    table: makeMeshArrowTable(attributes, {
+      topology: getMeshTopology(mode),
+      mode,
+      indices: indexResult?.attribute
+    }),
+    attributes,
+    meshIndex,
+    primitiveIndex,
+    materialIndex: primitive.material,
+    materialized
   };
 }
 
-/** Get a zero-copy Mesh attribute from a dense glTF accessor. */
-function getMeshAttribute(gltf: GLTFWithBuffers, accessorIndex: number): MeshAttribute {
+/** Get an exact-value Mesh attribute, borrowing packed storage where possible. */
+function getMeshAttribute(
+  gltf: GLTFWithBuffers,
+  accessorIndex: number,
+  options: Required<GLTFMeshArrowOptions>
+): MeshAttributeResult {
   const accessor = gltf.json.accessors?.[accessorIndex];
   if (!accessor) {
     throw new Error(`glTF primitive references missing accessor ${accessorIndex}`);
   }
-  if (accessor.sparse) {
-    throw new Error(
-      `glTF accessor ${accessorIndex} is sparse and cannot be projected without materializing it`
-    );
-  }
-  if (accessor.bufferView === undefined) {
-    throw new Error(`glTF accessor ${accessorIndex} has no buffer view and cannot be projected`);
-  }
 
-  const bufferView = gltf.json.bufferViews?.[accessor.bufferView];
-  if (!bufferView) {
+  const size = getSizeFromAccessorType(accessor.type);
+  const ArrayType = getMeshTypedArrayConstructor(accessor.componentType);
+  const elementByteLength = size * ArrayType.BYTES_PER_ELEMENT;
+  const bufferView =
+    accessor.bufferView === undefined ? undefined : gltf.json.bufferViews?.[accessor.bufferView];
+  if (accessor.bufferView !== undefined && !bufferView) {
     throw new Error(
       `glTF accessor ${accessorIndex} references missing buffer view ${accessor.bufferView}`
     );
   }
 
-  const size = getSizeFromAccessorType(accessor.type);
-  const elementByteLength = size * getAccessorComponentByteLength(accessor);
-  if (bufferView.byteStride && bufferView.byteStride !== elementByteLength) {
+  const isInterleaved = Boolean(
+    bufferView?.byteStride && bufferView.byteStride !== elementByteLength
+  );
+  const requiresMaterialization = !bufferView || isInterleaved || Boolean(accessor.sparse);
+  if (requiresMaterialization && options.accessorLayout === 'zero-copy-only') {
+    const reason = accessor.sparse ? 'sparse' : isInterleaved ? 'interleaved' : 'implicit-zero';
     throw new Error(
-      `glTF accessor ${accessorIndex} is interleaved and cannot be projected without materializing it`
+      `glTF accessor ${accessorIndex} is ${reason} and cannot be projected without materializing it`
     );
   }
 
-  // Component byte-length validation above rejects the bigint component types that MeshAttribute excludes.
-  const value = getTypedArrayForAccessor(
-    gltf.json,
-    gltf.buffers,
-    accessor
-  ) as MeshAttribute['value'];
+  let value = bufferView
+    ? (getTypedArrayForAccessor(gltf.json, gltf.buffers, accessor) as MeshAttribute['value'])
+    : new ArrayType(accessor.count * size);
+
+  if (accessor.sparse) {
+    const materializedValue = new ArrayType(value.length);
+    materializedValue.set(value);
+    applySparseAccessor(gltf, accessorIndex, accessor, materializedValue, size);
+    value = materializedValue;
+  }
+
   return {
-    value,
-    size,
-    byteOffset: accessor.byteOffset,
-    byteStride: bufferView.byteStride,
-    normalized: accessor.normalized
+    attribute: {
+      value,
+      size,
+      byteOffset: requiresMaterialization ? 0 : accessor.byteOffset,
+      byteStride: requiresMaterialization ? undefined : bufferView?.byteStride,
+      normalized: accessor.normalized
+    },
+    materialized: requiresMaterialization
   };
 }
 
-/** Return the component byte length for a glTF accessor. */
-function getAccessorComponentByteLength(accessor: GLTFAccessor): number {
-  switch (accessor.componentType) {
+/** Apply sparse substitutions to an independently allocated accessor value. */
+function applySparseAccessor(
+  gltf: GLTFWithBuffers,
+  accessorIndex: number,
+  accessor: GLTFAccessor,
+  value: MeshAttribute['value'],
+  size: number
+): void {
+  const sparse = accessor.sparse!;
+  const sparseIndices = getBufferViewValues(
+    gltf,
+    sparse.indices.bufferView,
+    sparse.indices.byteOffset || 0,
+    sparse.indices.componentType,
+    sparse.count,
+    `glTF accessor ${accessorIndex} sparse indices`
+  );
+  const sparseValues = getBufferViewValues(
+    gltf,
+    sparse.values.bufferView,
+    sparse.values.byteOffset || 0,
+    accessor.componentType,
+    sparse.count * size,
+    `glTF accessor ${accessorIndex} sparse values`
+  );
+
+  for (let sparseIndex = 0; sparseIndex < sparse.count; sparseIndex++) {
+    const accessorElementIndex = Number(sparseIndices[sparseIndex]);
+    if (
+      !Number.isInteger(accessorElementIndex) ||
+      accessorElementIndex < 0 ||
+      accessorElementIndex >= accessor.count
+    ) {
+      throw new Error(`glTF accessor ${accessorIndex} sparse index is out of bounds`);
+    }
+    for (let componentIndex = 0; componentIndex < size; componentIndex++) {
+      value[accessorElementIndex * size + componentIndex] =
+        sparseValues[sparseIndex * size + componentIndex];
+    }
+  }
+}
+
+/** Get tightly packed typed values from a glTF buffer view. */
+function getBufferViewValues(
+  gltf: GLTFWithBuffers,
+  bufferViewIndex: number,
+  localByteOffset: number,
+  componentType: number,
+  count: number,
+  path: string
+): MeshAttribute['value'] {
+  const bufferView = gltf.json.bufferViews?.[bufferViewIndex];
+  if (!bufferView) {
+    throw new Error(`${path} reference missing buffer view ${bufferViewIndex}`);
+  }
+  const buffer = gltf.buffers[bufferView.buffer];
+  if (!buffer) {
+    throw new Error(`${path} reference missing buffer ${bufferView.buffer}`);
+  }
+  const ArrayType = getMeshTypedArrayConstructor(componentType);
+  const byteLength = count * ArrayType.BYTES_PER_ELEMENT;
+  if (localByteOffset + byteLength > bufferView.byteLength) {
+    throw new Error(`${path} exceed buffer view ${bufferViewIndex}`);
+  }
+  const byteOffset = buffer.byteOffset + (bufferView.byteOffset || 0) + localByteOffset;
+  return new ArrayType(buffer.arrayBuffer, byteOffset, count);
+}
+
+/** Return the numeric typed-array constructor for a Mesh Arrow accessor component type. */
+function getMeshTypedArrayConstructor(componentType: number): MeshTypedArrayConstructor {
+  switch (componentType) {
     case 5120:
+      return Int8Array;
     case 5121:
-      return 1;
+      return Uint8Array;
     case 5122:
+      return Int16Array;
     case 5123:
-      return 2;
+      return Uint16Array;
+    case 5124:
+      return Int32Array;
     case 5125:
+      return Uint32Array;
     case 5126:
-      return 4;
+      return Float32Array;
     default:
       throw new Error(
-        `glTF accessor component type ${accessor.componentType} is not supported by Mesh Arrow`
+        `glTF accessor component type ${componentType} is not supported by Mesh Arrow`
       );
   }
 }

--- a/modules/gltf/src/lib/api/gltf-mesh-arrow.ts
+++ b/modules/gltf/src/lib/api/gltf-mesh-arrow.ts
@@ -1,0 +1,222 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Matrix4} from '@math.gl/core';
+import type {MeshAttribute, MeshAttributes, MeshArrowTable} from '@loaders.gl/schema';
+import {makeMeshArrowTable} from '@loaders.gl/schema-utils';
+import type {GLTFAccessor, GLTFMeshPrimitive, GLTFNode} from '../types/gltf-json-schema';
+import type {GLTFWithBuffers} from '../types/gltf-types';
+import {getTypedArrayForAccessor} from '../gltf-utils/get-typed-array';
+import {getSizeFromAccessorType} from '../gltf-utils/gltf-constants';
+
+/** A mesh primitive projected from a glTF scene into a Mesh Arrow table. */
+export type GLTFMeshArrowPrimitive = {
+  /** Arrow table containing the primitive's vertex attributes and optional indices. */
+  table: MeshArrowTable;
+  /** Source-compatible attribute descriptors, including normalized and stride metadata. */
+  attributes: MeshAttributes;
+  /** World transform of the node that instantiates the primitive. */
+  worldMatrix: Matrix4;
+  /** Index of the source node. */
+  nodeIndex: number;
+  /** Node indices from the selected scene root through the source node. */
+  nodePath: number[];
+  /** Index of the source mesh. */
+  meshIndex: number;
+  /** Index of the primitive within the source mesh. */
+  primitiveIndex: number;
+  /** Index of the primitive material, when specified. */
+  materialIndex?: number;
+};
+
+/**
+ * Project the default glTF scene into one Mesh Arrow table per mesh primitive.
+ *
+ * This projection preserves source vertex attribute views for dense, non-interleaved accessors.
+ * It does not bake node transforms, apply skinning or morph targets, or flatten GPU instancing.
+ * Those scene-level concerns remain represented by the returned primitive metadata and source glTF.
+ * @param gltf Parsed glTF data with resolved binary buffers.
+ * @returns Mesh Arrow primitives in default-scene traversal order.
+ */
+export function extractGLTFMeshArrowPrimitives(gltf: GLTFWithBuffers): GLTFMeshArrowPrimitive[] {
+  const rootNodeIndices = getRootNodeIndices(gltf);
+  const primitives: GLTFMeshArrowPrimitive[] = [];
+
+  for (const rootNodeIndex of rootNodeIndices) {
+    visitNode(gltf, rootNodeIndex, new Matrix4(), [], primitives);
+  }
+
+  return primitives;
+}
+
+/** Visit a node and append each of its mesh primitives to the projection result. */
+function visitNode(
+  gltf: GLTFWithBuffers,
+  nodeIndex: number,
+  parentWorldMatrix: Matrix4,
+  parentNodePath: number[],
+  primitives: GLTFMeshArrowPrimitive[]
+): void {
+  if (parentNodePath.includes(nodeIndex)) {
+    throw new Error(`glTF node hierarchy contains a cycle at node ${nodeIndex}`);
+  }
+
+  const node = gltf.json.nodes?.[nodeIndex];
+  if (!node) {
+    throw new Error(`glTF scene references missing node ${nodeIndex}`);
+  }
+
+  const nodePath = [...parentNodePath, nodeIndex];
+  const worldMatrix = new Matrix4(parentWorldMatrix).multiplyRight(getNodeMatrix(node));
+
+  if (node.mesh !== undefined) {
+    const mesh = gltf.json.meshes?.[node.mesh];
+    if (!mesh) {
+      throw new Error(`glTF node ${nodeIndex} references missing mesh ${node.mesh}`);
+    }
+
+    for (const [primitiveIndex, primitive] of mesh.primitives.entries()) {
+      const {table, attributes} = convertGLTFPrimitiveToMeshArrowTable(gltf, primitive);
+      primitives.push({
+        table,
+        attributes,
+        worldMatrix,
+        nodeIndex,
+        nodePath,
+        meshIndex: node.mesh,
+        primitiveIndex,
+        materialIndex: primitive.material
+      });
+    }
+  }
+
+  for (const childNodeIndex of node.children || []) {
+    visitNode(gltf, childNodeIndex, worldMatrix, nodePath, primitives);
+  }
+}
+
+/** Get the selected scene roots, or infer roots when a glTF asset does not define scenes. */
+function getRootNodeIndices(gltf: GLTFWithBuffers): number[] {
+  const selectedScene = gltf.json.scenes?.[gltf.json.scene || 0];
+  if (selectedScene) {
+    return selectedScene.nodes || [];
+  }
+
+  const childNodeIndices = new Set(gltf.json.nodes?.flatMap(node => node.children || []));
+  return (gltf.json.nodes || [])
+    .map((_, nodeIndex) => nodeIndex)
+    .filter(nodeIndex => !childNodeIndices.has(nodeIndex));
+}
+
+/** Get the local transform encoded by a glTF node. */
+function getNodeMatrix(node: GLTFNode): Matrix4 {
+  if (node.matrix) {
+    return new Matrix4(node.matrix);
+  }
+
+  const rotationMatrix = new Matrix4().fromQuaternion(node.rotation || [0, 0, 0, 1]);
+  return new Matrix4()
+    .translate(node.translation || [0, 0, 0])
+    .multiplyRight(rotationMatrix)
+    .scale(node.scale || [1, 1, 1]);
+}
+
+/** Convert one glTF mesh primitive to its Mesh Arrow representation. */
+function convertGLTFPrimitiveToMeshArrowTable(
+  gltf: GLTFWithBuffers,
+  primitive: GLTFMeshPrimitive
+): {table: MeshArrowTable; attributes: MeshAttributes} {
+  const attributes: MeshAttributes = {};
+
+  for (const [attributeName, accessorIndex] of Object.entries(primitive.attributes)) {
+    attributes[attributeName] = getMeshAttribute(gltf, accessorIndex);
+  }
+
+  const indices =
+    primitive.indices === undefined ? undefined : getMeshAttribute(gltf, primitive.indices);
+  const mode = primitive.mode || 4;
+
+  return {
+    table: makeMeshArrowTable(attributes, {topology: getMeshTopology(mode), mode, indices}),
+    attributes
+  };
+}
+
+/** Get a zero-copy Mesh attribute from a dense glTF accessor. */
+function getMeshAttribute(gltf: GLTFWithBuffers, accessorIndex: number): MeshAttribute {
+  const accessor = gltf.json.accessors?.[accessorIndex];
+  if (!accessor) {
+    throw new Error(`glTF primitive references missing accessor ${accessorIndex}`);
+  }
+  if (accessor.sparse) {
+    throw new Error(
+      `glTF accessor ${accessorIndex} is sparse and cannot be projected without materializing it`
+    );
+  }
+  if (accessor.bufferView === undefined) {
+    throw new Error(`glTF accessor ${accessorIndex} has no buffer view and cannot be projected`);
+  }
+
+  const bufferView = gltf.json.bufferViews?.[accessor.bufferView];
+  if (!bufferView) {
+    throw new Error(
+      `glTF accessor ${accessorIndex} references missing buffer view ${accessor.bufferView}`
+    );
+  }
+
+  const size = getSizeFromAccessorType(accessor.type);
+  const elementByteLength = size * getAccessorComponentByteLength(accessor);
+  if (bufferView.byteStride && bufferView.byteStride !== elementByteLength) {
+    throw new Error(
+      `glTF accessor ${accessorIndex} is interleaved and cannot be projected without materializing it`
+    );
+  }
+
+  // Component byte-length validation above rejects the bigint component types that MeshAttribute excludes.
+  const value = getTypedArrayForAccessor(
+    gltf.json,
+    gltf.buffers,
+    accessor
+  ) as MeshAttribute['value'];
+  return {
+    value,
+    size,
+    byteOffset: accessor.byteOffset,
+    byteStride: bufferView.byteStride,
+    normalized: accessor.normalized
+  };
+}
+
+/** Return the component byte length for a glTF accessor. */
+function getAccessorComponentByteLength(accessor: GLTFAccessor): number {
+  switch (accessor.componentType) {
+    case 5120:
+    case 5121:
+      return 1;
+    case 5122:
+    case 5123:
+      return 2;
+    case 5125:
+    case 5126:
+      return 4;
+    default:
+      throw new Error(
+        `glTF accessor component type ${accessor.componentType} is not supported by Mesh Arrow`
+      );
+  }
+}
+
+/** Map the supported glTF primitive modes to Mesh Arrow topology names. */
+function getMeshTopology(mode: number): MeshArrowTable['topology'] {
+  switch (mode) {
+    case 0:
+      return 'point-list';
+    case 4:
+      return 'triangle-list';
+    case 5:
+      return 'triangle-strip';
+    default:
+      throw new Error(`glTF primitive mode ${mode} is not supported by Mesh Arrow`);
+  }
+}

--- a/modules/gltf/src/mesh-arrow.ts
+++ b/modules/gltf/src/mesh-arrow.ts
@@ -1,0 +1,8 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export {
+  extractGLTFMeshArrowPrimitives,
+  type GLTFMeshArrowPrimitive
+} from './lib/api/gltf-mesh-arrow';

--- a/modules/gltf/src/mesh-arrow.ts
+++ b/modules/gltf/src/mesh-arrow.ts
@@ -3,6 +3,9 @@
 // Copyright (c) vis.gl contributors
 
 export {
-  extractGLTFMeshArrowPrimitives,
-  type GLTFMeshArrowPrimitive
+  convertGLTFToMeshArrow,
+  type GLTFMeshArrow,
+  type GLTFMeshArrowGeometry,
+  type GLTFMeshArrowOptions,
+  type GLTFMeshArrowPlacement
 } from './lib/api/gltf-mesh-arrow';

--- a/modules/gltf/test/lib/api/gltf-mesh-arrow.cross.spec.ts
+++ b/modules/gltf/test/lib/api/gltf-mesh-arrow.cross.spec.ts
@@ -3,44 +3,107 @@
 // Copyright (c) vis.gl contributors
 
 import {describe, expect, test} from 'vitest';
-import {extractGLTFMeshArrowPrimitives} from '@loaders.gl/gltf/mesh-arrow';
+import {convertGLTFToMeshArrow} from '@loaders.gl/gltf/mesh-arrow';
 import type {GLTFWithBuffers} from '../../../src/lib/types/gltf-types';
 
-describe('extractGLTFMeshArrowPrimitives', () => {
-  test('projects indexed geometry without copying dense vertex attributes', () => {
+describe('convertGLTFToMeshArrow', () => {
+  test('returns reusable indexed geometry and a separate scene placement', () => {
     const {gltf, positions} = makeGLTF();
 
-    const [primitive] = extractGLTFMeshArrowPrimitives(gltf);
-    const positionVector = primitive.table.data.getChild('POSITION')!;
+    const result = convertGLTFToMeshArrow(gltf);
+    const [geometry] = result.geometries;
+    const [placement] = result.placements;
+    const positionVector = geometry.table.data.getChild('POSITION')!;
     const positionValues = positionVector.data[0].children[0].values;
 
     expect(positionValues.buffer).toBe(positions.buffer);
-    expect(primitive.table.indices?.value).toEqual(new Uint16Array([0, 1]));
-    expect(primitive.table.schema.metadata).toMatchObject({topology: 'triangle-list', mode: '4'});
-    expect(primitive.attributes.POSITION.normalized).toBe(true);
-    expect(primitive.nodePath).toEqual([0, 1]);
-    expect(primitive.materialIndex).toBe(2);
-    expect(Array.from(primitive.worldMatrix)).toEqual([
+    expect(geometry.table.indices?.value).toEqual(new Uint16Array([0, 1]));
+    expect(geometry.table.data.getChild('indices')?.get(0)?.toArray()).toEqual(
+      new Int32Array([0, 1])
+    );
+    expect(geometry.table.schema.metadata).toMatchObject({topology: 'triangle-list', mode: '4'});
+    expect(geometry.attributes.POSITION.normalized).toBeUndefined();
+    expect(geometry).toMatchObject({meshIndex: 0, primitiveIndex: 0, materialIndex: 2});
+    expect(geometry.materialized).toBe(false);
+    expect(placement).toMatchObject({geometryIndex: 0, nodeIndex: 1, nodePath: [0, 1]});
+    expect(Array.from(placement.worldMatrix)).toEqual([
       2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2, 0, 1, 2, 3, 1
     ]);
   });
 
-  test('rejects interleaved accessors instead of silently materializing them', () => {
+  test('stores reused geometry once and emits each placement', () => {
     const {gltf} = makeGLTF();
-    gltf.json.bufferViews![0].byteStride = 16;
+    gltf.json.scenes![0].nodes!.push(2);
+    gltf.json.nodes!.push({mesh: 0, translation: [10, 0, 0]});
 
-    expect(() => extractGLTFMeshArrowPrimitives(gltf)).toThrow(/interleaved/);
+    const result = convertGLTFToMeshArrow(gltf);
+
+    expect(result.geometries).toHaveLength(1);
+    expect(result.placements).toHaveLength(2);
+    expect(result.placements.map(placement => placement.geometryIndex)).toEqual([0, 0]);
+    expect(result.placements.map(placement => placement.nodeIndex)).toEqual([1, 2]);
   });
 
-  test('rejects sparse accessors instead of silently ignoring replacements', () => {
-    const {gltf} = makeGLTF();
-    gltf.json.accessors![0].sparse = {
-      count: 1,
-      indices: {bufferView: 1, componentType: 5121},
-      values: {bufferView: 1}
-    };
+  test('materializes interleaved accessors without changing logical values', () => {
+    const gltf = makeInterleavedGLTF();
+    const sourceBytes = new Uint8Array(gltf.buffers[0].arrayBuffer).slice();
 
-    expect(() => extractGLTFMeshArrowPrimitives(gltf)).toThrow(/sparse/);
+    const result = convertGLTFToMeshArrow(gltf);
+    const [geometry] = result.geometries;
+
+    expect(geometry.materialized).toBe(true);
+    expect(geometry.attributes.POSITION.value).toEqual(new Float32Array([0, 0, 0, 1, 2, 3]));
+    expect(geometry.attributes.POSITION.value.buffer).not.toBe(gltf.buffers[0].arrayBuffer);
+    expect(new Uint8Array(gltf.buffers[0].arrayBuffer)).toEqual(sourceBytes);
+  });
+
+  test('preserves quantized component storage and normalization', () => {
+    const source = new Uint16Array([0, 32767, 65535, 65535, 32767, 0]);
+    const gltf = makeSinglePrimitiveGLTF(source.buffer, {
+      accessors: [{bufferView: 0, componentType: 5123, count: 2, type: 'VEC3', normalized: true}],
+      bufferViews: [{buffer: 0, byteLength: source.byteLength}]
+    });
+
+    const {geometries} = convertGLTFToMeshArrow(gltf);
+    const positionValues =
+      geometries[0].table.data.getChild('POSITION')!.data[0].children[0].values;
+
+    expect(positionValues).toBeInstanceOf(Uint16Array);
+    expect(positionValues.buffer).toBe(source.buffer);
+    expect(geometries[0].attributes.POSITION.normalized).toBe(true);
+    expect(geometries[0].materialized).toBe(false);
+  });
+
+  test('supports an explicit zero-copy-only policy', () => {
+    const gltf = makeInterleavedGLTF();
+
+    expect(() => convertGLTFToMeshArrow(gltf, {accessorLayout: 'zero-copy-only'})).toThrow(
+      /accessor 0 is interleaved/
+    );
+  });
+
+  test('materializes sparse substitutions without mutating glTF JSON or buffers', () => {
+    const gltf = makeSparseGLTF();
+    const sourceJson = JSON.stringify(gltf.json);
+    const sourceBytes = new Uint8Array(gltf.buffers[0].arrayBuffer).slice();
+
+    const result = convertGLTFToMeshArrow(gltf);
+    const [geometry] = result.geometries;
+
+    expect(geometry.materialized).toBe(true);
+    expect(geometry.attributes.POSITION.value).toEqual(new Float32Array([0, 0, 0, 9, 8, 7]));
+    expect(JSON.stringify(gltf.json)).toBe(sourceJson);
+    expect(new Uint8Array(gltf.buffers[0].arrayBuffer)).toEqual(sourceBytes);
+  });
+
+  test('preserves point-list mode zero', () => {
+    const {gltf} = makeGLTF();
+    gltf.json.meshes![0].primitives[0].mode = 0;
+
+    const {geometries} = convertGLTFToMeshArrow(gltf);
+
+    expect(geometries[0].table.topology).toBe('point-list');
+    expect(geometries[0].table.schema.metadata.mode).toBe('0');
   });
 });
 
@@ -65,18 +128,11 @@ function makeGLTF(): {gltf: GLTFWithBuffers; positions: Float32Array} {
         ],
         meshes: [
           {
-            primitives: [
-              {
-                attributes: {POSITION: 0},
-                indices: 1,
-                material: 2,
-                mode: 4
-              }
-            ]
+            primitives: [{attributes: {POSITION: 0}, indices: 1, material: 2, mode: 4}]
           }
         ],
         accessors: [
-          {bufferView: 0, componentType: 5126, count: 2, type: 'VEC3', normalized: true},
+          {bufferView: 0, componentType: 5126, count: 2, type: 'VEC3'},
           {bufferView: 1, componentType: 5123, count: 2, type: 'SCALAR'}
         ],
         bufferViews: [
@@ -87,5 +143,65 @@ function makeGLTF(): {gltf: GLTFWithBuffers; positions: Float32Array} {
       },
       buffers: [{arrayBuffer: source, byteOffset: 0, byteLength: source.byteLength}]
     }
+  };
+}
+
+/** Create glTF geometry with two VEC3 positions embedded in 16-byte vertex records. */
+function makeInterleavedGLTF(): GLTFWithBuffers {
+  const source = new Float32Array([0, 0, 0, 99, 1, 2, 3, 88]);
+  return makeSinglePrimitiveGLTF(source.buffer, {
+    accessors: [{bufferView: 0, componentType: 5126, count: 2, type: 'VEC3'}],
+    bufferViews: [{buffer: 0, byteLength: source.byteLength, byteStride: 16}]
+  });
+}
+
+/** Create glTF geometry with one sparse replacement over packed base positions. */
+function makeSparseGLTF(): GLTFWithBuffers {
+  const source = new ArrayBuffer(40);
+  new Float32Array(source, 0, 6).set([0, 0, 0, 1, 1, 1]);
+  new Uint8Array(source, 24, 1)[0] = 1;
+  new Float32Array(source, 28, 3).set([9, 8, 7]);
+
+  return makeSinglePrimitiveGLTF(source, {
+    accessors: [
+      {
+        bufferView: 0,
+        componentType: 5126,
+        count: 2,
+        type: 'VEC3',
+        sparse: {
+          count: 1,
+          indices: {bufferView: 1, componentType: 5121},
+          values: {bufferView: 2}
+        }
+      }
+    ],
+    bufferViews: [
+      {buffer: 0, byteOffset: 0, byteLength: 24},
+      {buffer: 0, byteOffset: 24, byteLength: 1},
+      {buffer: 0, byteOffset: 28, byteLength: 12}
+    ]
+  });
+}
+
+/** Create a minimal one-node, one-primitive glTF around supplied accessor storage. */
+function makeSinglePrimitiveGLTF(
+  source: ArrayBuffer,
+  binary: {
+    accessors: NonNullable<GLTFWithBuffers['json']['accessors']>;
+    bufferViews: NonNullable<GLTFWithBuffers['json']['bufferViews']>;
+  }
+): GLTFWithBuffers {
+  return {
+    json: {
+      asset: {version: '2.0'},
+      scenes: [{nodes: [0]}],
+      nodes: [{mesh: 0}],
+      meshes: [{primitives: [{attributes: {POSITION: 0}, mode: 4}]}],
+      accessors: binary.accessors,
+      bufferViews: binary.bufferViews,
+      buffers: [{byteLength: source.byteLength}]
+    },
+    buffers: [{arrayBuffer: source, byteOffset: 0, byteLength: source.byteLength}]
   };
 }

--- a/modules/gltf/test/lib/api/gltf-mesh-arrow.cross.spec.ts
+++ b/modules/gltf/test/lib/api/gltf-mesh-arrow.cross.spec.ts
@@ -1,0 +1,91 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+import {extractGLTFMeshArrowPrimitives} from '@loaders.gl/gltf/mesh-arrow';
+import type {GLTFWithBuffers} from '../../../src/lib/types/gltf-types';
+
+describe('extractGLTFMeshArrowPrimitives', () => {
+  test('projects indexed geometry without copying dense vertex attributes', () => {
+    const {gltf, positions} = makeGLTF();
+
+    const [primitive] = extractGLTFMeshArrowPrimitives(gltf);
+    const positionVector = primitive.table.data.getChild('POSITION')!;
+    const positionValues = positionVector.data[0].children[0].values;
+
+    expect(positionValues.buffer).toBe(positions.buffer);
+    expect(primitive.table.indices?.value).toEqual(new Uint16Array([0, 1]));
+    expect(primitive.table.schema.metadata).toMatchObject({topology: 'triangle-list', mode: '4'});
+    expect(primitive.attributes.POSITION.normalized).toBe(true);
+    expect(primitive.nodePath).toEqual([0, 1]);
+    expect(primitive.materialIndex).toBe(2);
+    expect(Array.from(primitive.worldMatrix)).toEqual([
+      2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2, 0, 1, 2, 3, 1
+    ]);
+  });
+
+  test('rejects interleaved accessors instead of silently materializing them', () => {
+    const {gltf} = makeGLTF();
+    gltf.json.bufferViews![0].byteStride = 16;
+
+    expect(() => extractGLTFMeshArrowPrimitives(gltf)).toThrow(/interleaved/);
+  });
+
+  test('rejects sparse accessors instead of silently ignoring replacements', () => {
+    const {gltf} = makeGLTF();
+    gltf.json.accessors![0].sparse = {
+      count: 1,
+      indices: {bufferView: 1, componentType: 5121},
+      values: {bufferView: 1}
+    };
+
+    expect(() => extractGLTFMeshArrowPrimitives(gltf)).toThrow(/sparse/);
+  });
+});
+
+/** Create a small indexed glTF scene with a translated root and scaled mesh node. */
+function makeGLTF(): {gltf: GLTFWithBuffers; positions: Float32Array} {
+  const positions = new Float32Array([0, 0, 0, 1, 0, 0]);
+  const indices = new Uint16Array([0, 1]);
+  const source = new ArrayBuffer(positions.byteLength + indices.byteLength);
+  new Float32Array(source, 0, positions.length).set(positions);
+  new Uint16Array(source, positions.byteLength, indices.length).set(indices);
+
+  return {
+    positions: new Float32Array(source, 0, positions.length),
+    gltf: {
+      json: {
+        asset: {version: '2.0'},
+        scenes: [{nodes: [0]}],
+        scene: 0,
+        nodes: [
+          {translation: [1, 2, 3], children: [1]},
+          {scale: [2, 2, 2], mesh: 0}
+        ],
+        meshes: [
+          {
+            primitives: [
+              {
+                attributes: {POSITION: 0},
+                indices: 1,
+                material: 2,
+                mode: 4
+              }
+            ]
+          }
+        ],
+        accessors: [
+          {bufferView: 0, componentType: 5126, count: 2, type: 'VEC3', normalized: true},
+          {bufferView: 1, componentType: 5123, count: 2, type: 'SCALAR'}
+        ],
+        bufferViews: [
+          {buffer: 0, byteOffset: 0, byteLength: positions.byteLength},
+          {buffer: 0, byteOffset: positions.byteLength, byteLength: indices.byteLength}
+        ],
+        buffers: [{byteLength: source.byteLength}]
+      },
+      buffers: [{arrayBuffer: source, byteOffset: 0, byteLength: source.byteLength}]
+    }
+  };
+}

--- a/modules/gltf/tsconfig.json
+++ b/modules/gltf/tsconfig.json
@@ -11,6 +11,7 @@
     {"path": "../draco"},
     {"path": "../images"},
     {"path": "../loader-utils"},
+    {"path": "../schema-utils"},
     {"path": "../textures"},
     {"path": "../math"}
   ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -5486,6 +5486,7 @@ __metadata:
     "@loaders.gl/images": "npm:5.0.0-alpha.2"
     "@loaders.gl/loader-utils": "npm:5.0.0-alpha.2"
     "@loaders.gl/schema": "npm:5.0.0-alpha.2"
+    "@loaders.gl/schema-utils": "npm:5.0.0-alpha.2"
     "@loaders.gl/textures": "npm:5.0.0-alpha.2"
     "@math.gl/core": "npm:^4.1.0"
     meshoptimizer: "npm:^1.2.0"


### PR DESCRIPTION
## Goals

- Prototype an opt-in `convertGLTFToMeshArrow()` API over already loaded `GLTFWithBuffers` data.
- Represent each source glTF primitive once while keeping scene placement separate.
- Preserve glTF component types, normalization, indexing, transforms, and mesh reuse without introducing a second glTF parser or object model.
- Keep the current Mesh Arrow row-0 index-column convention while the broader schema remains experimental.

## Changes

- Add `convertGLTFToMeshArrow()` under `@loaders.gl/gltf/mesh-arrow`.
- Return unique `geometries` plus separate node `placements` containing geometry references, node paths, and world transforms.
- Continue returning one `MeshArrowTable` per geometry, including the existing row-0 `indices` list.
- Borrow dense packed accessor storage without copying.
- Materialize interleaved, sparse, and implicit-zero accessors into packed arrays containing the same logical component values.
- Add `accessorLayout: 'zero-copy-only'` for callers that want materialization to fail explicitly.
- Preserve quantized component storage and `normalized` metadata rather than dequantizing.
- Add cross-runtime coverage for indexed geometry, reused meshes, world transforms, zero-copy storage, interleaving, sparse accessors, quantization, source immutability, and point topology.
- Update the glTF and Mesh Arrow documentation for the prototype API and its boundaries.

## Relationship to earlier proposals

- Retains the useful primitive-plus-placement boundary explored in #3160 without adopting glTF Transform as a runtime dependency or implicitly unwelding, de-instancing, or dequantizing assets.
- Retains the single-table Mesh Arrow convention documented in #3161, including the row-0 index list.
- Supersedes the flattened primitive-occurrence API currently proposed in #3637 by storing reusable geometry once and representing node occurrences separately.

## Current non-goals

- Baking node transforms into vertex attributes.
- Evaluating skinning, morph targets, animation, or GPU instancing.
- Packing multiple primitives into shared draw buffers.
- Changing the current Mesh Arrow index-column convention.

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn build-workers`
- `yarn test-node` — 315 passed, 6 skipped
- `yarn test-headless` — 2,383 passed, 48 skipped
- `yarn test-audit` — 0 violations
