### PR TITLE
test(schema-utils): expand native Vitest coverage

### DIFF
--- a/modules/schema-utils/test/lib/table/table-accessors.spec.ts
+++ b/modules/schema-utils/test/lib/table/table-accessors.spec.ts
@@ -8,9 +8,21 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import type {Table} from '@loaders.gl/schema';
-import {getTableLength, getTableNumCols, isTable} from '@loaders.gl/schema-utils';
+import {
+  getTableCell,
+  getTableCellAt,
+  getTableColumnIndex,
+  getTableColumnName,
+  getTableLength,
+  getTableNumCols,
+  getTableRowAsArray,
+  getTableRowAsObject,
+  getTableRowShape,
+  isTable,
+  makeRowIterator
+} from '@loaders.gl/schema-utils';
 
 type TestCase = {
   name: string;
@@ -57,13 +69,56 @@ const TEST_CASES: TestCase[] = [
   }
 ];
 
-test('table accessors', async t => {
+test('table accessors', () => {
   for (const tc of TEST_CASES) {
-    t.equal(isTable(tc.table), tc.isTable, `isTable() correct: ${tc.name}`);
+    expect(isTable(tc.table), `isTable() correct: ${tc.name}`).toBe(tc.isTable);
     if (isTable(tc.table)) {
-      t.equal(getTableLength(tc.table), tc.numRows, `getTableLength() correct: ${tc.name}`);
-      t.equal(getTableNumCols(tc.table), tc.numCols, `isTable() correct: ${tc.name}`);
+      expect(getTableLength(tc.table), `getTableLength() correct: ${tc.name}`).toBe(tc.numRows);
+      expect(getTableNumCols(tc.table), `getTableNumCols() correct: ${tc.name}`).toBe(tc.numCols);
     }
   }
-  t.end();
+});
+
+test('accesses and converts rows across table shapes', () => {
+  const schema = {fields: [{name: 'a'}, {name: 'b'}]};
+  const arrayTable = {
+    shape: 'array-row-table',
+    schema,
+    data: [
+      [1, 2],
+      [3, 4]
+    ]
+  } as Table;
+  const objectTable = {shape: 'object-row-table', schema, data: [{a: 1, b: 2}]} as Table;
+  const columnarTable = {shape: 'columnar-table', data: {a: [1], b: [2]}} as Table;
+  const geojsonTable = {
+    shape: 'geojson-table',
+    schema,
+    features: [{a: 1, b: 2}]
+  } as Table;
+
+  expect(getTableCell(arrayTable, 1, 'b')).toBe(4);
+  expect(getTableCellAt(objectTable, 0, 1)).toBe(2);
+  expect(getTableRowAsObject(arrayTable, 0)).toEqual({a: 1, b: 2});
+  expect(getTableRowAsArray(objectTable, 0)).toEqual([1, 2]);
+  expect(getTableRowAsObject(columnarTable, 0)).toEqual({a: 1, b: 2});
+  expect(getTableRowAsArray(geojsonTable, 0)).toEqual([1, 2]);
+  expect(getTableRowShape(arrayTable)).toBe('array-row-table');
+  expect(getTableColumnIndex(arrayTable, 'b')).toBe(1);
+  expect(getTableColumnName(arrayTable, 0)).toBe('a');
+  expect([...makeRowIterator(arrayTable, 'array-row-table')]).toEqual([
+    [1, 2],
+    [3, 4]
+  ]);
+});
+
+test('reports invalid table shapes and missing columns', () => {
+  const emptyTable = {shape: 'array-row-table', data: []} as Table;
+
+  expect(() => getTableNumCols(emptyTable)).toThrow('empty table');
+  expect(() => getTableColumnIndex(emptyTable, 'missing')).toThrow('missing');
+  expect(() => getTableColumnName(emptyTable, 0)).toThrow('0');
+  expect(() => getTableRowShape({shape: 'columnar-table', data: {}} as Table)).toThrow(
+    'Not a row table'
+  );
 });

--- a/modules/schema-utils/test/lib/utils/async-queue.spec.ts
+++ b/modules/schema-utils/test/lib/utils/async-queue.spec.ts
@@ -2,19 +2,18 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {AsyncQueue} from '@loaders.gl/schema-utils';
 
-test('Enqueue before dequeue', async t => {
+test('Enqueue before dequeue', async () => {
   const queue = new AsyncQueue();
   queue.enqueue('a');
   queue.enqueue('b');
   queue.close();
-  t.deepEqual(await takeAsync(queue), ['a', 'b']);
-  t.end();
+  expect(await takeAsync(queue)).toEqual(['a', 'b']);
 });
 
-test('Dequeue before enqueue', async t => {
+test('Dequeue before enqueue', async () => {
   const queue = new AsyncQueue();
   const promise = Promise.all([queue.next(), queue.next()]);
 
@@ -24,15 +23,35 @@ test('Dequeue before enqueue', async t => {
 
   const array = await promise;
   const values = array.map(x => x.value);
-  t.deepEqual(values, ['a', 'b']);
-  t.end();
+  expect(values).toEqual(['a', 'b']);
+});
+
+test('rejects values after close and resolves pending reads', async () => {
+  const queue = new AsyncQueue<string>();
+  const pendingRead = queue.next();
+
+  queue.close();
+
+  expect(await pendingRead).toEqual({done: true});
+  expect(() => queue.enqueue('after close')).toThrow('Closed');
+  expect(await queue.next()).toEqual({done: true});
+});
+
+test('propagates errors to a pending read', async () => {
+  const queue = new AsyncQueue<string>();
+  const pendingRead = queue.next();
+  const error = new Error('bad value');
+
+  queue.enqueue(error);
+
+  await expect(pendingRead).rejects.toThrow('bad value');
 });
 
 /**
  * @returns a Promise for an Array with the elements
  * in `asyncIterable`
  */
-async function takeAsync(asyncIterable, count = Infinity) {
+async function takeAsync(asyncIterable: AsyncIterable<unknown>, count = Infinity) {
   const result: unknown[] = [];
   const iterator = asyncIterable[Symbol.asyncIterator]();
   while (result.length < count) {


### PR DESCRIPTION
## Goals

Continue the coverage roadmap’s first low-coverage tranche with focused coverage and native Vitest migration in `@loaders.gl/schema-utils`.

## Changes

- Convert the async queue tests from the tape-shaped adapter to native Vitest.
- Add coverage for pending reads, close behavior, post-close enqueue errors, and error propagation.
- Convert table accessor tests to native Vitest.
- Add coverage across array-row, object-row, columnar, and GeoJSON table shapes, row/cell accessors, column lookup, row iterators, and invalid empty-table cases.

## Validation

- `yarn test-headless --run modules/schema-utils/test/lib/utils/async-queue.spec.ts modules/schema-utils/test/lib/table/table-accessors.spec.ts` — 2 files, 7 tests passed.
- `yarn test-audit` — 529 files, 0 Tape imports, 0 violations.
- `yarn lint fix` — clean.
- `git diff --check` — clean.