### PR TITLE
feat(zarr): integrate multiscale levels with scan metadata

### DIFF
--- a/docs/modules/zarr/README.md
+++ b/docs/modules/zarr/README.md
@@ -50,6 +50,28 @@ well as the regular one-dimensional coordinate arrays commonly written by xarray
 The [GeoZarr deck.gl example](/examples/geospatial/geo-zarr) reads a public NASA POWER climatology
 store directly from S3 and renders monthly solar irradiance on an interactive map.
 
+## Feature matrix
+
+| Capability | Zarr v2 | Zarr v3 | OME-Zarr | GeoZarr / CF | Status |
+| --- | --- | --- | --- | --- | --- |
+| Browser and Node.js reads | Yes | Yes | Yes | Yes | Available |
+| HTTP range/chunked access | Yes | Yes | Yes | Yes | Available |
+| Consolidated metadata discovery | `.zmetadata`, `zmetadata` | `zarr.json` | Yes | Yes | Available |
+| Multidimensional arrays and named dimensions | Yes | Yes | Yes | Yes | Available |
+| Chunk-aware raster reads | Yes | Yes | Yes | Yes | Available |
+| OME image channels, time, and z planes | — | — | Yes | — | Available |
+| OME multiscale pyramids | — | — | Yes | — | Available |
+| Automatic display-level selection | — | — | Yes | — | Available |
+| Scan metadata and level-of-detail discovery | — | — | Yes | Planned for GeoZarr | Available for OME-Zarr |
+| GeoZarr `proj:` and `spatial:` metadata | — | — | — | Yes | Available |
+| CF/xarray coordinates, time, vertical, and band selection | — | — | — | Yes | Available |
+| Viewport-driven geospatial windows | — | — | — | Yes | Available |
+| Typed planar or interleaved channel output | Yes | Yes | Yes | Yes | Available |
+| Zarrita-backed v2/v3 implementation | Yes | Yes | Yes | Yes | Available |
+| SpatialData tables, points, and shapes | — | — | Planned | — | Planned |
+| Codec expansion and broader multiscale layouts | Partial | Partial | Planned | Planned | Planned |
+| Scan pushdown for richer raster predicates | — | — | Planned | Planned | Planned |
+
 ## Attributions
 
 The OME-Zarr source uses [zarrita.js](https://zarrita.dev/) under the MIT license. The legacy Zarr

--- a/docs/modules/zarr/api-reference/ome-zarr-source-loader.md
+++ b/docs/modules/zarr/api-reference/ome-zarr-source-loader.md
@@ -26,7 +26,7 @@ const source = createDataSource('https://example.com/spatialdata.zarr', [OMEZarr
 });
 
 const metadata = await source.getMetadata();
-const raster = await source.getRaster({level: 0, t: 0, z: 0});
+const raster = await source.getRaster({level: 'auto', width: 1024, height: 768, t: 0, z: 0});
 ```
 
 ## Source options
@@ -57,9 +57,13 @@ coordinate transformations when present.
 
 ### `getRaster(parameters?: GetOMEZarrParameters): Promise<RasterData>`
 
-Loads one complete 2D plane from a pyramid level.
+Loads one complete 2D plane from a pyramid level. OME-Zarr multiscale metadata is also exposed
+through the common `ScanQueryMetadataProvider` interface (`source.getQueryMetadata()`), allowing
+source-neutral scan UIs to discover the available levels without reading pixel chunks.
 
-- `level?: number` selects the zero-based pyramid level.
+- `level?: number | 'auto'` selects a level explicitly, or chooses the smallest level that still
+  covers the requested `width` and `height`.
+- `width?: number` and `height?: number` provide target display dimensions for `level: 'auto'`.
 - `t?: number` selects the time index.
 - `z?: number` selects the z index.
 - `channels?: number[]` selects one or more channel indices.
@@ -68,6 +72,10 @@ Loads one complete 2D plane from a pyramid level.
 
 Planar multi-channel results contain one typed array per channel. Interleaved results contain one
 typed array with `bandCount` samples per pixel.
+
+When `level` is omitted, level `0` is used for backwards compatibility. `getMetadata().levels`
+contains each level's pixel dimensions, dataset path, coordinate transformations, and scale
+relative to the full-resolution level.
 
 ## Consolidated root discovery
 

--- a/modules/loader-utils/src/index.ts
+++ b/modules/loader-utils/src/index.ts
@@ -297,6 +297,7 @@ export type {
   ScanQueryMetadata,
   ScanQueryMetadataOptions,
   ScanQueryMetadataProvider,
+  ScanRasterLevel,
   ScanSourceStatistics,
   ScanSpatialMetadata
 } from './lib/scan-utils/scan-query-metadata';

--- a/modules/loader-utils/src/lib/scan-utils/scan-query-metadata.ts
+++ b/modules/loader-utils/src/lib/scan-utils/scan-query-metadata.ts
@@ -54,6 +54,18 @@ export type ScanSpatialMetadata = Readonly<{
   coordinateReferenceSystems?: readonly string[];
 }>;
 
+/** One raster resolution level exposed to a scan query editor. */
+export type ScanRasterLevel = Readonly<{
+  /** Zero-based level index in the source pyramid. */
+  index: number;
+  /** Pixel width at this level. */
+  width: number;
+  /** Pixel height at this level. */
+  height: number;
+  /** Optional scale relative to the full-resolution level. */
+  scale?: readonly [number, number];
+}>;
+
 /** Capabilities that a common scan-query panel can expose across source families. */
 export type ScanQueryCapabilities = Readonly<{
   /** Relational projection, predicate, limit, streaming, and cancellation support. */
@@ -92,6 +104,8 @@ export type ScanQueryMetadata = Readonly<{
   spatial?: ScanSpatialMetadata;
   /** Optional statistics obtained from source metadata. */
   statistics?: ScanSourceStatistics;
+  /** Optional multiscale raster levels. */
+  levels?: readonly ScanRasterLevel[];
 }>;
 
 /** Options accepted by query metadata discovery methods. */
@@ -126,6 +140,8 @@ export type CreateScanQueryMetadataOptions = Readonly<{
   spatial?: ScanSpatialMetadata;
   /** Optional source statistics. */
   statistics?: ScanSourceStatistics;
+  /** Optional multiscale raster levels. */
+  levels?: readonly ScanRasterLevel[];
 }>;
 
 /**
@@ -178,7 +194,19 @@ export function createScanQueryMetadata(
             : undefined
         })
       : undefined,
-    statistics: options.statistics ? Object.freeze({...options.statistics}) : undefined
+    statistics: options.statistics ? Object.freeze({...options.statistics}) : undefined,
+    levels: options.levels
+      ? Object.freeze(
+          options.levels.map(level =>
+            Object.freeze({
+              ...level,
+              scale: level.scale
+                ? (Object.freeze([...level.scale]) as readonly [number, number])
+                : undefined
+            })
+          )
+        )
+      : undefined
   });
 }
 

--- a/modules/loader-utils/test/lib/scan-utils/scan-query-metadata.spec.ts
+++ b/modules/loader-utils/test/lib/scan-utils/scan-query-metadata.spec.ts
@@ -68,4 +68,18 @@ describe('createScanQueryMetadata', () => {
     expect(Object.isFrozen(metadata.columns)).toBe(true);
     expect(Object.isFrozen(metadata.schema.fields)).toBe(true);
   });
+
+  test('normalizes multiscale raster levels', () => {
+    const metadata = createScanQueryMetadata({
+      sourceType: 'omezarr',
+      queryType: 'raster',
+      schema: {fields: [], metadata: {}},
+      capabilities: {levelOfDetail: 'pushdown'},
+      levels: [{index: 0, width: 1024, height: 512, scale: [1, 1]}]
+    });
+
+    expect(metadata.levels).toEqual([{index: 0, width: 1024, height: 512, scale: [1, 1]}]);
+    expect(Object.isFrozen(metadata.levels)).toBe(true);
+    expect(Object.isFrozen(metadata.levels?.[0])).toBe(true);
+  });
 });

--- a/modules/zarr/src/ome-zarr-source-loader.ts
+++ b/modules/zarr/src/ome-zarr-source-loader.ts
@@ -12,7 +12,13 @@ import type {
   RasterChannelDataType,
   RasterQueryCapabilities
 } from '@loaders.gl/loader-utils';
-import {DataSource} from '@loaders.gl/loader-utils';
+import {
+  createScanQueryMetadata,
+  DataSource,
+  type ScanQueryMetadata,
+  type ScanQueryMetadataOptions,
+  type ScanQueryMetadataProvider
+} from '@loaders.gl/loader-utils';
 
 import type {Labels, Channel, Multiscale, RootAttrs, SupportedTypedArray} from './types';
 import {guessLabels, guessTileSize, validLabels} from './lib/utils';
@@ -64,8 +70,12 @@ export type ZarrSourceLoader<SourceT extends ZarrSource = ZarrSource> = SourceLo
 
 /** Parameters used to request a 2D OME-Zarr plane. */
 export type GetOMEZarrParameters = {
-  /** Zero-based pyramid level. Defaults to `0`. */
-  level?: number;
+  /** Zero-based pyramid level, or `auto` to select from the requested dimensions. */
+  level?: number | 'auto';
+  /** Target display width used by automatic level selection. */
+  width?: number;
+  /** Target display height used by automatic level selection. */
+  height?: number;
   /** Zero-based time index. Defaults to the OME display setting or `0`. */
   t?: number;
   /** Zero-based z index. Defaults to the OME display setting or `0`. */
@@ -102,6 +112,8 @@ export type OMEZarrLevelMetadata = {
   height: number;
   /** OME coordinate transformations declared for this level. */
   coordinateTransformations?: unknown[];
+  /** Scale relative to the full-resolution level. */
+  scale?: [number, number];
 };
 
 /** Normalized metadata exposed by {@link OMEZarrImageSource}. */
@@ -327,7 +339,7 @@ export const OMEZarrSourceLoader = {
 /**
  * Source that loads 2D planes from an OME-Zarr pyramid.
  */
-export class OMEZarrImageSource extends ZarrSource {
+export class OMEZarrImageSource extends ZarrSource implements ScanQueryMetadataProvider {
   /** Shared source initialization request. */
   private initPromise: Promise<OMEZarrInit> | null = null;
 
@@ -337,10 +349,31 @@ export class OMEZarrImageSource extends ZarrSource {
     return metadata;
   }
 
+  /** Discovers the raster pyramid through the common scan metadata contract. */
+  async getQueryMetadata(options: ScanQueryMetadataOptions = {}): Promise<ScanQueryMetadata> {
+    const metadata = await this.getMetadata(options.signal);
+    return createScanQueryMetadata({
+      sourceType: 'omezarr',
+      queryType: 'raster',
+      name: metadata.name,
+      description: 'OME-Zarr multiscale image',
+      schema: {fields: [], metadata: {}},
+      capabilities: {
+        levelOfDetail: metadata.levels.length > 1 ? 'pushdown' : 'unsupported'
+      },
+      levels: metadata.levels.map(level => ({
+        index: level.level,
+        width: level.width,
+        height: level.height,
+        scale: level.scale
+      }))
+    });
+  }
+
   /** Loads one 2D OME-Zarr plane or channel composite. */
   async getRaster(parameters: GetOMEZarrParameters = {}): Promise<RasterData> {
     const {data, metadata} = await this.getInitPromise(parameters.signal);
-    const level = parameters.level ?? 0;
+    const level = selectOMEZarrLevel(metadata.levels, parameters);
     const pixelSource = data[level];
 
     if (!pixelSource) {
@@ -544,7 +577,8 @@ function normalizeOMEZarrMetadata(
       path: dataset?.path || String(level),
       width: levelWidth,
       height: levelHeight,
-      coordinateTransformations: dataset?.coordinateTransformations
+      coordinateTransformations: dataset?.coordinateTransformations,
+      scale: [width / levelWidth, height / levelHeight] as [number, number]
     };
   });
 
@@ -570,6 +604,23 @@ function normalizeOMEZarrMetadata(
     metadata: attrs as unknown as Record<string, unknown>,
     coordinateTransformations: attrs.coordinateTransformations
   };
+}
+
+/** Selects an explicit level or the closest pyramid level for a target viewport. */
+function selectOMEZarrLevel(
+  levels: OMEZarrLevelMetadata[],
+  parameters: GetOMEZarrParameters
+): number {
+  if (typeof parameters.level === 'number') {
+    return parameters.level;
+  }
+  if (parameters.level !== 'auto' || !parameters.width || !parameters.height) {
+    return 0;
+  }
+  const suitable = levels
+    .filter(level => level.width >= parameters.width! && level.height >= parameters.height!)
+    .sort((first, second) => first.width * first.height - second.width * second.height);
+  return (suitable[0] || levels[0]).level;
 }
 
 /** Converts OME display settings for one channel into public metadata. */


### PR DESCRIPTION
## Goals

- Integrate OME-Zarr multiscale imagery with the emerging scan metadata architecture.
- Make pyramid resolution selection practical for display clients while preserving explicit level selection.

## Changes

- Add normalized raster level metadata to the shared scan-query contract.
- Make `OMEZarrImageSource` implement `ScanQueryMetadataProvider` for raster discovery.
- Add automatic OME-Zarr level selection using target display dimensions via `level: 'auto'`.
- Expose per-level scale metadata and retain explicit-level backwards compatibility.
- Document the scan metadata integration and multiscale request options.
- Add focused metadata, selection, and source tests.

## Validation

- `yarn build`
- `yarn lint fix`
- `yarn test-node modules/zarr/test/ome-zarr-source.node.spec.ts`
- `yarn test modules/loader-utils/test/lib/scan-utils/scan-query-metadata.spec.ts`
