### PR TITLE
test: expand WKT and MLT coverage

### DIFF
--- a/modules/mlt/test/mlt-loader.spec.ts
+++ b/modules/mlt/test/mlt-loader.spec.ts
@@ -2,36 +2,32 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import type {MLTLoaderOptions} from '@loaders.gl/mlt';
 import {MLTLoader} from '@loaders.gl/mlt/bundled';
 
-test('MLTLoader#metadata', t => {
-  t.ok(MLTLoader, 'MLTLoader defined');
-  t.equal(MLTLoader.name, 'MapLibre Tile', 'name is correct');
-  t.equal(MLTLoader.id, 'mlt', 'id is correct');
-  t.deepEqual(MLTLoader.extensions, ['mlt'], 'extensions are correct');
-  t.end();
+test('MLTLoader#metadata', () => {
+  expect(MLTLoader).toBeTruthy();
+  expect(MLTLoader.name).toBe('MapLibre Tile');
+  expect(MLTLoader.id).toBe('mlt');
+  expect(MLTLoader.extensions).toEqual(['mlt']);
 });
 
-test('MLTLoader#options defaults', t => {
-  t.equal(MLTLoader.options.mlt.shape, 'geojson-table', 'default shape is geojson-table');
-  t.equal(MLTLoader.options.mlt.coordinates, 'local', 'default coordinates are local');
-  t.equal(MLTLoader.options.mlt.layerProperty, 'layerName', 'default layerProperty is layerName');
-  t.end();
+test('MLTLoader#options defaults', () => {
+  expect(MLTLoader.options.mlt.shape).toBe('geojson-table');
+  expect(MLTLoader.options.mlt.coordinates).toBe('local');
+  expect(MLTLoader.options.mlt.layerProperty).toBe('layerName');
 });
 
-test('MLTLoader#parse empty tile', async t => {
+test('MLTLoader#parse empty tile', async () => {
   const emptyBuffer = new ArrayBuffer(0);
   const result = await MLTLoader.parse(emptyBuffer, {mlt: {shape: 'geojson-table'}});
-  t.equal(result.shape, 'geojson-table', 'empty tile returns a GeoJSON table');
-  t.equal(result.features.length, 0, 'empty tile returns empty features');
-  t.end();
+  expect(result.shape).toBe('geojson-table');
+  expect(result.features).toHaveLength(0);
 });
 
-test('MLTLoader#throws on wgs84 without tileIndex', async t => {
+test('MLTLoader#throws on wgs84 without tileIndex', async () => {
   const emptyBuffer = new ArrayBuffer(0);
   const options: MLTLoaderOptions = {mlt: {coordinates: 'wgs84'}};
-  t.throws(() => MLTLoader.parseSync(emptyBuffer, options), 'throws without tileIndex');
-  t.end();
+  expect(() => MLTLoader.parseSync(emptyBuffer, options)).toThrow();
 });

--- a/modules/wkt/test/wkt-writer.spec.ts
+++ b/modules/wkt/test/wkt-writer.spec.ts
@@ -2,16 +2,13 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 
 import {encodeTextSync} from '@loaders.gl/core';
 import {WKTWriter} from '@loaders.gl/wkt';
 
-test('WKTWriter', t => {
-  t.throws(
-    () => encodeTextSync({type: 'FeatureCollection'}, WKTWriter),
-    'does not accept featurecollections'
-  );
+test('WKTWriter', () => {
+  expect(() => encodeTextSync({type: 'FeatureCollection'}, WKTWriter)).toThrow();
 
   // const fixtures = [
   //   'LINESTRING (30 10, 10 30, 40 40)',
@@ -37,8 +34,36 @@ test('WKTWriter', t => {
     }
   };
 
-  const wkt = encodeTextSync(geojsonFeature.geometry, WKTWriter);
-  t.equal(wkt, 'POINT (42 20)', 'point equal');
-
-  t.end();
+  expect(encodeTextSync(geojsonFeature.geometry, WKTWriter)).toBe('POINT (42 20)');
+  expect(
+    encodeTextSync(
+      {
+        type: 'LineString',
+        coordinates: [
+          [0, 1],
+          [2, 3]
+        ]
+      },
+      WKTWriter
+    )
+  ).toBe('LINESTRING (0 1, 2 3)');
+  expect(
+    encodeTextSync(
+      {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [0, 0],
+            [1, 0],
+            [0, 1],
+            [0, 0]
+          ]
+        ]
+      },
+      WKTWriter
+    )
+  ).toBe('POLYGON ((0 0, 1 0, 0 1, 0 0))');
+  expect(
+    encodeTextSync({type: 'GeometryCollection', geometries: [geojsonFeature.geometry]}, WKTWriter)
+  ).toBe('GEOMETRYCOLLECTION (POINT (42 20))');
 });


### PR DESCRIPTION
## Goals

Batch the next coverage tranche across two low-coverage modules while continuing the migration from the tape-shaped adapter to native Vitest.

## Changes

- Convert MLT loader metadata, defaults, empty parsing, and error tests to native Vitest.
- Convert WKT writer tests to native Vitest.
- Expand WKT writer coverage for Point, LineString, Polygon, and GeometryCollection outputs.

## Validation

- `yarn test-headless --run modules/wkt/test/wkt-writer.spec.ts modules/mlt/test/mlt-loader.spec.ts` — 2 files, 5 tests passed.
- `yarn test-audit` — 529 files, 0 Tape imports, 0 violations.
- `yarn lint fix` — clean.
- `git diff --check` — clean.