### PR TITLE
feat(copc): prefetch progressive node ranges

### DIFF
--- a/docs/modules/copc/api-reference/copc-source-loader.md
+++ b/docs/modules/copc/api-reference/copc-source-loader.md
@@ -37,7 +37,7 @@ The created data source exposes the point-cloud tile methods used by `PointCloud
 - `loadTileContentInBatches(tile, options)` yields normalized Arrow point tables progressively as the selected node range is fetched. The TypeScript LAZ variant is required. `options.batchSize` controls the maximum points per table, `options.columns` can request `POSITION`, `COLOR_0`, `NIR`, `intensity`, `classification`, `GPS_TIME`, `scanAngle`, and `pointSourceId`, and `options.signal` cancels the request/decode.
 - `loadHierarchyInBatches(options)` yields hierarchy pages and their discovered nodes as they are fetched.
 
-For TypeScript PDRF 6-8 batches, `loadTileContentInBatches` splits the node range into sequential requests and emits rows as soon as the requested independent layers arrive. PDRF 7 RGB waits for Point14 and RGB; PDRF 8 RGB/NIR waits for the layers requested through `options.columns`. `options.rangeChunkSize` controls the request size.
+For TypeScript PDRF 6-8 batches, `loadTileContentInBatches` splits the node range into requests and emits rows as soon as the requested independent layers arrive. PDRF 7 RGB waits for Point14 and RGB; PDRF 8 RGB/NIR waits for the layers requested through `options.columns`. `options.rangeChunkSize` controls request size, while `options.rangeConcurrency` can fetch later ranges ahead of in-order decoding.
 
 ## Options
 
@@ -45,3 +45,4 @@ For TypeScript PDRF 6-8 batches, `loadTileContentInBatches` splits the node rang
 | --- | --- | --- | --- |
 | `copc.sourceCoordinateSystem` | `string` | Auto-detected from COPC WKT | Coordinate system definition used when the source metadata does not include WKT. |
 | `copc.rangeChunkSize` | `number` | `65536` | Default byte size for TypeScript COPC node range requests. |
+| `copc.rangeConcurrency` | `number` | `1` | Maximum number of node ranges fetched ahead of decoding. Results are still decoded and yielded in range order. |

--- a/modules/copc/src/copc-source-loader.ts
+++ b/modules/copc/src/copc-source-loader.ts
@@ -670,28 +670,40 @@ export class COPCTileSource
   ): AsyncIterable<Uint8Array> {
     const get = Getter.create(this._urlOrGetter);
     const rangeEnd = node.pointDataOffset + node.pointDataLength;
-    const ranges: Array<[number, number]> = [];
-    for (let begin = node.pointDataOffset; begin < rangeEnd; begin += rangeChunkSize) {
-      ranges.push([begin, Math.min(begin + rangeChunkSize, rangeEnd)]);
-    }
-
-    const pending = new Map<number, Promise<Uint8Array>>();
+    const rangeCount = Math.ceil(node.pointDataLength / rangeChunkSize);
+    type RangeResult = {chunk: Uint8Array; error?: never} | {chunk?: never; error: unknown};
+    const pending = new Map<number, Promise<RangeResult>>();
     let nextToSchedule = 0;
-    for (let nextToYield = 0; nextToYield < ranges.length; nextToYield++) {
-      if (signal?.aborted) {
-        throw new Error('COPC progressive tile range request was aborted');
+    try {
+      for (let nextToYield = 0; nextToYield < rangeCount; nextToYield++) {
+        if (signal?.aborted) {
+          throw new Error('COPC progressive tile range request was aborted');
+        }
+        while (nextToSchedule < rangeCount && pending.size < rangeConcurrency) {
+          const begin = node.pointDataOffset + nextToSchedule * rangeChunkSize;
+          const end = Math.min(begin + rangeChunkSize, rangeEnd);
+          pending.set(
+            nextToSchedule,
+            get(begin, end).then(
+              chunk => ({chunk}),
+              error => ({error})
+            )
+          );
+          nextToSchedule++;
+        }
+        const result = await pending.get(nextToYield)!;
+        pending.delete(nextToYield);
+        if ('error' in result) {
+          throw result.error;
+        }
+        if (signal?.aborted) {
+          throw new Error('COPC progressive tile range request was aborted');
+        }
+        yield result.chunk;
       }
-      while (nextToSchedule < ranges.length && pending.size < rangeConcurrency) {
-        const [begin, end] = ranges[nextToSchedule];
-        pending.set(nextToSchedule, get(begin, end));
-        nextToSchedule++;
-      }
-      const chunk = await pending.get(nextToYield)!;
-      pending.delete(nextToYield);
-      if (signal?.aborted) {
-        throw new Error('COPC progressive tile range request was aborted');
-      }
-      yield chunk;
+    } finally {
+      // Promises are handled at creation, so abandoned prefetches cannot reject globally.
+      pending.clear();
     }
   }
 

--- a/modules/copc/src/copc-source-loader.ts
+++ b/modules/copc/src/copc-source-loader.ts
@@ -76,6 +76,8 @@ export type COPCSourceLoaderOptions = DataSourceOptions & {
     sourceCoordinateSystem?: string;
     /** Default byte size for progressive COPC node range requests. */
     rangeChunkSize?: number;
+    /** Maximum number of COPC node ranges fetched ahead of decode. */
+    rangeConcurrency?: number;
   };
 };
 
@@ -98,6 +100,8 @@ export type COPCTileContentBatchOptions = {
   )[];
   /** Byte size for progressive node range requests. */
   rangeChunkSize?: number;
+  /** Maximum number of node ranges fetched ahead of decode. Defaults to 1. */
+  rangeConcurrency?: number;
 };
 
 /** Options for progressive COPC hierarchy page loading. */
@@ -395,10 +399,11 @@ export class COPCTileSource
   /**
    * Yield TypeScript-decoded COPC tile content as Arrow batches.
    *
-   * The compressed node range is currently fetched as one range request. Once
-   * it is available, point batches are decoded and yielded without building a
-   * full decoded node table first. The existing `loadTileContent` method
-   * remains the compatibility API for callers that need one table.
+   * The compressed node range is fetched in bounded chunks. Chunks may be
+   * prefetched, but point batches are decoded and yielded in range order
+   * without building a full decoded node table first. The existing
+   * `loadTileContent` method remains the compatibility API for callers that
+   * need one table.
    */
   async *loadTileContentInBatches(
     tile: {id: string},
@@ -439,6 +444,10 @@ export class COPCTileSource
     if (!Number.isSafeInteger(rangeChunkSize) || rangeChunkSize < 1) {
       throw new Error('COPC progressive rangeChunkSize must be a positive integer');
     }
+    const rangeConcurrency = options.rangeConcurrency ?? this.options.copc?.rangeConcurrency ?? 1;
+    if (!Number.isSafeInteger(rangeConcurrency) || rangeConcurrency < 1) {
+      throw new Error('COPC progressive rangeConcurrency must be a positive integer');
+    }
 
     if (options.columns?.includes('NIR') && copc.header.pointDataRecordFormat !== 8) {
       throw new Error('COPC NIR output requires PDRF 8');
@@ -451,6 +460,7 @@ export class COPCTileSource
       cartographicOrigin,
       batchSize,
       rangeChunkSize,
+      rangeConcurrency,
       options.signal,
       colors,
       nir,
@@ -470,6 +480,7 @@ export class COPCTileSource
     cartographicOrigin: number[],
     batchSize: number,
     rangeChunkSize: number,
+    rangeConcurrency: number,
     signal: AbortSignal | undefined,
     colors: boolean,
     nir: boolean,
@@ -489,6 +500,7 @@ export class COPCTileSource
     for await (const compressedChunk of this.loadCOPCNodeRangeChunks(
       node,
       rangeChunkSize,
+      rangeConcurrency,
       signal
     )) {
       decoder.feed(compressedChunk);
@@ -649,20 +661,33 @@ export class COPCTileSource
     }
   }
 
-  /** Fetch a COPC node range in sequential chunks. */
+  /** Fetch a COPC node range in bounded parallel chunks while preserving order. */
   protected async *loadCOPCNodeRangeChunks(
     node: Hierarchy.Node,
     rangeChunkSize: number,
+    rangeConcurrency: number,
     signal?: AbortSignal
   ): AsyncIterable<Uint8Array> {
     const get = Getter.create(this._urlOrGetter);
     const rangeEnd = node.pointDataOffset + node.pointDataLength;
+    const ranges: Array<[number, number]> = [];
     for (let begin = node.pointDataOffset; begin < rangeEnd; begin += rangeChunkSize) {
+      ranges.push([begin, Math.min(begin + rangeChunkSize, rangeEnd)]);
+    }
+
+    const pending = new Map<number, Promise<Uint8Array>>();
+    let nextToSchedule = 0;
+    for (let nextToYield = 0; nextToYield < ranges.length; nextToYield++) {
       if (signal?.aborted) {
         throw new Error('COPC progressive tile range request was aborted');
       }
-      const end = Math.min(begin + rangeChunkSize, rangeEnd);
-      const chunk = await get(begin, end);
+      while (nextToSchedule < ranges.length && pending.size < rangeConcurrency) {
+        const [begin, end] = ranges[nextToSchedule];
+        pending.set(nextToSchedule, get(begin, end));
+        nextToSchedule++;
+      }
+      const chunk = await pending.get(nextToYield)!;
+      pending.delete(nextToYield);
       if (signal?.aborted) {
         throw new Error('COPC progressive tile range request was aborted');
       }

--- a/modules/copc/test/copc-source.spec.ts
+++ b/modules/copc/test/copc-source.spec.ts
@@ -111,7 +111,8 @@ vitestTest('COPCSourceLoader#streams TypeScript tile content as Arrow batches', 
 
   for await (const batch of source.loadTileContentInBatches(rootTile, {
     batchSize: 127,
-    rangeChunkSize: 257
+    rangeChunkSize: 257,
+    rangeConcurrency: 3
   })) {
     const positions = batch.data.data.getChild('POSITION');
     const colors = batch.data.data.getChild('COLOR_0');
@@ -155,7 +156,8 @@ vitestTest('COPCSourceLoader#selects progressive point-data columns', async () =
   const batches = source.loadTileContentInBatches(rootTile, {
     batchSize: 127,
     columns,
-    rangeChunkSize: 257
+    rangeChunkSize: 257,
+    rangeConcurrency: 2
   });
   let firstBatch;
   for await (const batch of batches) {

--- a/modules/copc/test/copc-source.spec.ts
+++ b/modules/copc/test/copc-source.spec.ts
@@ -15,6 +15,23 @@ import {Copc} from 'copc';
 const ELLIPSOID_FILE_PATH = 'modules/copc/test/data/ellipsoid.copc.laz';
 const ELLIPSOID_BROWSER_URL = new URL('./data/ellipsoid.copc.laz', import.meta.url).href;
 
+/** Test surface for the protected progressive range iterator. */
+class TestCOPCTileSource extends COPCTileSource {
+  /** Replace the byte-range getter after normal source initialization. */
+  setRangeGetter(getter: (begin: number, end: number) => Promise<Uint8Array>): void {
+    this._urlOrGetter = getter;
+  }
+
+  /** Expose ordered range prefetching for focused scheduling tests. */
+  readNodeRanges(
+    node: {pointCount: number; pointDataOffset: number; pointDataLength: number},
+    rangeChunkSize: number,
+    rangeConcurrency: number
+  ): AsyncIterable<Uint8Array> {
+    return this.loadCOPCNodeRangeChunks(node, rangeChunkSize, rangeConcurrency);
+  }
+}
+
 test('COPCWriter#writer conformance', t => {
   validateWriter(t, COPCWriter, 'COPCWriter');
   t.end();
@@ -215,6 +232,38 @@ vitestTest('COPCSourceLoader#streams hierarchy pages', async () => {
   expect(batches).toHaveLength(1);
   expect(batches[0]?.pageId).toBe('root');
   expect(batches[0]?.nodes['0-0-0-0']).toBeTruthy();
+});
+
+vitestTest('COPCSourceLoader#handles abandoned prefetched range failures', async () => {
+  const source = new TestCOPCTileSource(await createEllipsoidSourceData(), {});
+  await source.initialize();
+  let requestCount = 0;
+  const unhandledRejections: unknown[] = [];
+  const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
+    event.preventDefault();
+    unhandledRejections.push(event.reason);
+  };
+  globalThis.addEventListener('unhandledrejection', handleUnhandledRejection);
+  source.setRangeGetter(async () => {
+    const requestIndex = requestCount++;
+    if (requestIndex === 1) {
+      throw new Error('prefetched range failed');
+    }
+    return new Uint8Array([requestIndex]);
+  });
+
+  try {
+    const iterator = source
+      .readNodeRanges({pointCount: 1, pointDataOffset: 0, pointDataLength: 1_000_000_000}, 1, 3)
+      [Symbol.asyncIterator]();
+    expect(await iterator.next()).toEqual({done: false, value: new Uint8Array([0])});
+    expect(requestCount).toBe(3);
+    await iterator.return?.();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(unhandledRejections).toEqual([]);
+  } finally {
+    globalThis.removeEventListener('unhandledrejection', handleUnhandledRejection);
+  }
 });
 
 test('COPCSourceLoader#TypeScript tile attributes match laz-perf', async t => {


### PR DESCRIPTION
## Goals

- Reduce remote COPC node loading latency for progressive TypeScript LAZ decoding.
- Preserve ordered, incremental Arrow output and the existing sequential default.

## Changes

- Add `rangeConcurrency` to COPC source and progressive tile batch options.
- Prefetch a bounded number of node ranges ahead of decoding.
- Preserve compressed byte order and yield order regardless of request completion order.
- Recheck cancellation before scheduling, after each request, and before yielding.
- Exercise concurrent range loading in the COPC progressive RGB and selective-column tests.
- Document the new option and its ordering guarantee.

## Validation

- `yarn lint fix`
- TypeScript build for loader-utils, las, and copc
- COPC focused browser tests: 15 passed

The default remains `rangeConcurrency: 1`; callers opt into parallel range prefetch explicitly.
