### PR TITLE
fix(gltf): preserve Mesh Arrow accessor metadata

### DIFF
--- a/modules/gltf/src/lib/api/gltf-mesh-arrow.ts
+++ b/modules/gltf/src/lib/api/gltf-mesh-arrow.ts
@@ -375,6 +375,8 @@ function getMeshTypedArrayConstructor(componentType: number): MeshTypedArrayCons
       return Uint32Array;
     case 5126:
       return Float32Array;
+    case 5130:
+      return Float64Array;
     default:
       throw new Error(
         `glTF accessor component type ${componentType} is not supported by Mesh Arrow`

--- a/modules/gltf/src/lib/api/gltf-mesh-arrow.ts
+++ b/modules/gltf/src/lib/api/gltf-mesh-arrow.ts
@@ -4,7 +4,7 @@
 
 import {Matrix4} from '@math.gl/core';
 import type {MeshAttribute, MeshAttributes, MeshArrowTable} from '@loaders.gl/schema';
-import {makeMeshArrowTable} from '@loaders.gl/schema-utils';
+import {deduceMeshSchema, makeMeshArrowTable} from '@loaders.gl/schema-utils';
 import type {GLTFAccessor, GLTFMeshPrimitive, GLTFNode} from '../types/gltf-json-schema';
 import type {GLTFWithBuffers} from '../types/gltf-types';
 import {getTypedArrayForAccessor} from '../gltf-utils/get-typed-array';
@@ -214,6 +214,7 @@ function convertGLTFPrimitiveToMeshArrowGeometry(
 
   return {
     table: makeMeshArrowTable(attributes, {
+      schema: deduceMeshSchema(attributes),
       topology: getMeshTopology(mode),
       mode,
       indices: indexResult?.attribute
@@ -270,14 +271,21 @@ function getMeshAttribute(
     value = materializedValue;
   }
 
+  const attribute: MeshAttribute = {value, size};
+  if (!requiresMaterialization) {
+    if (accessor.byteOffset !== undefined) {
+      attribute.byteOffset = accessor.byteOffset;
+    }
+    if (bufferView?.byteStride !== undefined) {
+      attribute.byteStride = bufferView.byteStride;
+    }
+  }
+  if (accessor.normalized !== undefined) {
+    attribute.normalized = accessor.normalized;
+  }
+
   return {
-    attribute: {
-      value,
-      size,
-      byteOffset: requiresMaterialization ? 0 : accessor.byteOffset,
-      byteStride: requiresMaterialization ? undefined : bufferView?.byteStride,
-      normalized: accessor.normalized
-    },
+    attribute,
     materialized: requiresMaterialization
   };
 }

--- a/modules/gltf/test/lib/api/gltf-mesh-arrow.cross.spec.ts
+++ b/modules/gltf/test/lib/api/gltf-mesh-arrow.cross.spec.ts
@@ -77,6 +77,31 @@ describe('convertGLTFToMeshArrow', () => {
     expect(geometries[0].materialized).toBe(false);
   });
 
+  test('preserves metadata on canonical Float32 POSITION fields', () => {
+    const {gltf} = makeGLTF();
+    gltf.json.accessors![0].byteOffset = 0;
+    gltf.json.bufferViews![0].byteStride = 12;
+
+    const {geometries} = convertGLTFToMeshArrow(gltf);
+
+    expect(
+      geometries[0].table.schema.fields.find(field => field.name === 'POSITION')?.metadata
+    ).toEqual({byteOffset: '0', byteStride: '12'});
+  });
+
+  test('accepts supported Float64 accessors', () => {
+    const source = new Float64Array([0, 0, 0, 1, 2, 3]);
+    const gltf = makeSinglePrimitiveGLTF(source.buffer, {
+      accessors: [{bufferView: 0, componentType: 5130, count: 2, type: 'VEC3'}],
+      bufferViews: [{buffer: 0, byteLength: source.byteLength}]
+    });
+
+    const {geometries} = convertGLTFToMeshArrow(gltf);
+
+    expect(geometries[0].attributes.POSITION.value).toBeInstanceOf(Float64Array);
+    expect(geometries[0].attributes.POSITION.value.buffer).toBe(source.buffer);
+  });
+
   test('supports an explicit zero-copy-only policy', () => {
     const gltf = makeInterleavedGLTF();
 

--- a/modules/gltf/test/lib/api/gltf-mesh-arrow.cross.spec.ts
+++ b/modules/gltf/test/lib/api/gltf-mesh-arrow.cross.spec.ts
@@ -71,6 +71,9 @@ describe('convertGLTFToMeshArrow', () => {
     expect(positionValues).toBeInstanceOf(Uint16Array);
     expect(positionValues.buffer).toBe(source.buffer);
     expect(geometries[0].attributes.POSITION.normalized).toBe(true);
+    expect(
+      geometries[0].table.schema.fields.find(field => field.name === 'POSITION')?.metadata
+    ).toEqual({normalized: 'true'});
     expect(geometries[0].materialized).toBe(false);
   });
 

--- a/modules/schema-utils/src/lib/mesh/convert-mesh-to-table.ts
+++ b/modules/schema-utils/src/lib/mesh/convert-mesh-to-table.ts
@@ -172,7 +172,21 @@ function getAttributeArrowField(
   column: arrow.Vector
 ): arrow.Field {
   if (attributeName === 'POSITION' && isMeshPositionColumn(column)) {
-    return meshArrowSchema.fields[0];
+    const canonicalField = meshArrowSchema.fields[0];
+    const suppliedField = schema?.fields.find(schemaField => schemaField.name === attributeName);
+    if (!suppliedField?.metadata) {
+      return canonicalField;
+    }
+    const metadata = new Map(canonicalField.metadata);
+    for (const [key, value] of Object.entries(suppliedField.metadata)) {
+      metadata.set(key, value);
+    }
+    return new arrow.Field(
+      canonicalField.name,
+      canonicalField.type,
+      canonicalField.nullable,
+      metadata
+    );
   }
 
   const field = schema?.fields.find(schemaField => schemaField.name === attributeName);


### PR DESCRIPTION
## Goals

- Preserve glTF accessor metadata in the serialized Mesh Arrow schema.

## Changes

- Pass `deduceMeshSchema(attributes)` to `makeMeshArrowTable()` in the glTF Mesh Arrow converter.
- Retain `normalized`, `byteOffset`, and `byteStride` field metadata for table-only consumers.
- Add a regression assertion for normalized `Uint16` POSITION storage.
- Avoid emitting undefined accessor metadata for materialized attributes.

## Context

Follow-up to the review of #3695, which merged before this review fix could be attached. The original inline review is addressed in the reply on #3695.

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn test-node modules/gltf/test/lib/api/gltf-mesh-arrow.cross.spec.ts`
- `yarn test-headless modules/gltf/test/lib/api/gltf-mesh-arrow.cross.spec.ts`
