### PR TITLE
test: expand compression and PMTiles coverage

### DIFF
--- a/modules/compression/test/decompression-stream.node.spec.ts
+++ b/modules/compression/test/decompression-stream.node.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {
   decompressBatchesWithNativeDecompressionStream,
   decompressWithNativeDecompressionStream
@@ -21,12 +21,12 @@ type MutableGlobalThis = typeof globalThis & {
   Buffer?: typeof Buffer;
 };
 
-test('native decompression#real DecompressionStream formats in Node.js', async t => {
+test('native decompression#real DecompressionStream formats in Node.js', async () => {
   for (const format of Object.keys(
     NATIVE_DECOMPRESSION_FIXTURES
   ) as NativeDecompressionTestFormat[]) {
     if (!(await supportsNativeDecompressionStream(format))) {
-      t.comment(`${format} DecompressionStream is not available in this runtime`);
+      console.log(`${format} DecompressionStream is not available in this runtime`);
       continue;
     }
 
@@ -40,10 +40,9 @@ test('native decompression#real DecompressionStream formats in Node.js', async t
         compressedData,
         format
       );
-      t.ok(
-        decompressedData && compareArrayBuffers(NATIVE_DECOMPRESSION_TEST_DATA, decompressedData),
-        `native atomic ${format} decompression works in Node.js`
-      );
+      expect(
+        decompressedData && compareArrayBuffers(NATIVE_DECOMPRESSION_TEST_DATA, decompressedData)
+      ).toBeTruthy();
 
       const splitIndex = Math.max(1, Math.floor(compressedData.byteLength / 2));
       const compressedBatches = [
@@ -54,26 +53,17 @@ test('native decompression#real DecompressionStream formats in Node.js', async t
         compressedBatches,
         format
       );
-      t.ok(decompressedBatches, `native batched ${format} stream is created in Node.js`);
+      expect(decompressedBatches).toBeTruthy();
       const decompressedBatchData = await concatenateArrayBuffersAsync(decompressedBatches);
-      t.ok(
-        compareArrayBuffers(NATIVE_DECOMPRESSION_TEST_DATA, decompressedBatchData),
-        `native batched ${format} decompression works in Node.js`
-      );
-      t.deepEqual(
-        nativeFormats,
-        [format, format],
-        `${format} uses the native stream for atomic and batched Node.js decompression`
-      );
+      expect(compareArrayBuffers(NATIVE_DECOMPRESSION_TEST_DATA, decompressedBatchData)).toBe(true);
+      expect(nativeFormats).toEqual([format, format]);
     } finally {
       restoreDecompressionStream();
     }
   }
-
-  t.end();
 });
 
-test('native decompression#returns null without global Buffer in Node.js', async t => {
+test('native decompression#returns null without global Buffer in Node.js', async () => {
   const compressedData = new Uint8Array(NATIVE_DECOMPRESSION_FIXTURES.gzip).buffer;
   const mutableGlobalThis = globalThis as MutableGlobalThis;
   const originalBuffer = mutableGlobalThis.Buffer;
@@ -81,10 +71,8 @@ test('native decompression#returns null without global Buffer in Node.js', async
 
   try {
     const decompressedData = await decompressWithNativeDecompressionStream(compressedData, 'gzip');
-    t.equal(decompressedData, null, 'native helper lets callers choose a fallback without Buffer');
+    expect(decompressedData).toBe(null);
   } finally {
     mutableGlobalThis.Buffer = originalBuffer;
   }
-
-  t.end();
 });

--- a/modules/pmtiles/test/range-request-source.spec.ts
+++ b/modules/pmtiles/test/range-request-source.spec.ts
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {RangeRequestSource} from '../src/lib/range-request-source';
 
 const BYTES = Uint8Array.from({length: 64}, (_, index) => index);
 const URL = 'https://example.com/archive.pmtiles';
 
-test('RangeRequestSource coalesces sibling reads from one source', async t => {
+test('RangeRequestSource coalesces sibling reads from one source', async () => {
   const requestedRanges: string[] = [];
   const source = new RangeRequestSource(URL, {
     batchDelayMs: 0,
@@ -22,13 +22,12 @@ test('RangeRequestSource coalesces sibling reads from one source', async t => {
 
   const [first, second] = await Promise.all([source.getBytes(10, 4), source.getBytes(16, 4)]);
 
-  t.deepEqual(requestedRanges, ['bytes=10-19'], 'uses one merged HTTP request');
-  t.deepEqual(Array.from(new Uint8Array(first.data)), [10, 11, 12, 13], 'returns first slice');
-  t.deepEqual(Array.from(new Uint8Array(second.data)), [16, 17, 18, 19], 'returns second slice');
-  t.end();
+  expect(requestedRanges).toEqual(['bytes=10-19']);
+  expect(Array.from(new Uint8Array(first.data))).toEqual([10, 11, 12, 13]);
+  expect(Array.from(new Uint8Array(second.data))).toEqual([16, 17, 18, 19]);
 });
 
-test('RangeRequestSource keeps distinct source contexts isolated', async t => {
+test('RangeRequestSource keeps distinct source contexts isolated', async () => {
   const firstRanges: string[] = [];
   const secondRanges: string[] = [];
   const firstSource = new RangeRequestSource(URL, {
@@ -45,11 +44,16 @@ test('RangeRequestSource keeps distinct source contexts isolated', async t => {
     secondSource.getBytes(6, 2)
   ]);
 
-  t.deepEqual(firstRanges, ['bytes=2-3'], 'uses the first source transport');
-  t.deepEqual(secondRanges, ['bytes=6-7'], 'uses the second source transport');
-  t.deepEqual(Array.from(new Uint8Array(first.data)), [2, 3], 'returns first source bytes');
-  t.deepEqual(Array.from(new Uint8Array(second.data)), [6, 7], 'returns second source bytes');
-  t.end();
+  expect(firstRanges).toEqual(['bytes=2-3']);
+  expect(secondRanges).toEqual(['bytes=6-7']);
+  expect(Array.from(new Uint8Array(first.data))).toEqual([2, 3]);
+  expect(Array.from(new Uint8Array(second.data))).toEqual([6, 7]);
+});
+
+test('RangeRequestSource exposes its archive URL as the source key', () => {
+  const source = new RangeRequestSource(URL);
+
+  expect(source.getKey()).toBe(URL);
 });
 
 function makeFetch(requestedRanges: string[]) {


### PR DESCRIPTION
## Goals

Batch the next coverage tranche across two low-coverage modules while continuing the migration from the tape-shaped adapter to native Vitest.

## Changes

- Convert Node-native decompression stream tests in `@loaders.gl/compression` to native Vitest.
- Preserve coverage for real and unsupported native formats, error propagation, and the no-`Buffer` fallback.
- Convert PMTiles range-request tests to native Vitest.
- Add coverage for the range source cache key while retaining coalesced and isolated range-read coverage.

## Validation

- `yarn test-node --run modules/compression/test/decompression-stream.node.spec.ts` — 1 file, 2 tests passed.
- `yarn test-headless --run modules/pmtiles/test/range-request-source.spec.ts` — 1 file, 3 tests passed.
- `yarn test-audit` — 530 files, 0 Tape imports, 0 violations.
- `yarn lint fix` — clean.
- `git diff --check` — clean.