### PR TITLE
feat(parquet): decode unshredded Variant values

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@
 - Prefer high-signal behavior and boundary coverage over test count. Test an implementation exhaustively in its owning module, then keep only focused public-entrypoint or integration conformance in wrapper modules; do not duplicate the same fixture, call, and assertions across packages.
 - Use the smallest deterministic fixture that exercises the behavior. Fixtures over 1 MiB require an audited exception in the fast suite. Keep one representative large end-to-end parse in the slow lane when scale itself is meaningful.
 - Parse immutable fixture data once with `beforeAll` when multiple assertions inspect the same result. Tests that mutate a result must clone it or parse independently so state cannot leak between cases.
-- Write new and substantially revised tests with native Vitest `test`, `describe`, `test.each`, lifecycle hooks, mocks, and `expect`. Do not add Tape imports; the Tape allowlist may only shrink.
+- Write every new test case, and every substantially revised test, with native Vitest syntax (`test`, `describe`, `test.each`, lifecycle hooks, mocks, and `expect`). Do not use Tape for new coverage or add Tape imports; the Tape allowlist may only shrink.
 - Coverage is enforced per non-private published `modules/*` package across statements, lines, functions, and branches. Never lower a committed threshold or add an exclusion merely to make coverage pass; generated, vendored, declaration, or unreachable platform-specific exclusions require an adjacent reason.
 - Run `yarn test-audit` after changing test structure or fixtures. Use `yarn test-profile <mode>` when adding costly coverage, and move any fast test file that remains above the documented performance budget into smaller fast cases plus an explicit slow case.
 

--- a/docs/modules/parquet/api-reference/parquet-loader.md
+++ b/docs/modules/parquet/api-reference/parquet-loader.md
@@ -145,10 +145,11 @@ for example `UTF8` values are returned as JavaScript strings and `JSON` values a
 returned as parsed JavaScript values.
 
 Unshredded Parquet `VARIANT` groups are decoded into JavaScript primitives, arrays, and
-objects for object-row results. Arrow results retain the canonical `metadata` and `value`
-binary child fields so applications can choose when to decode or project them. Shredded
-Variant values are currently exposed as their typed child columns and are not yet
-reconstructed into one JavaScript value.
+objects for object-row results from the TypeScript `ParquetJSLoader` variant. Arrow results
+and the default WASM `ParquetLoader` retain the canonical `metadata` and `value` binary child
+fields so applications can choose when to decode or project them. Shredded Variant values
+are currently exposed as their typed child columns and are not yet reconstructed into one
+JavaScript value.
 
 `ParquetJSLoader` reads the Parquet 2.13 `LogicalType` annotation before using the legacy
 `ConvertedType` fallback. Arrow output preserves exact signed and unsigned integer widths,

--- a/docs/modules/parquet/api-reference/parquet-loader.md
+++ b/docs/modules/parquet/api-reference/parquet-loader.md
@@ -144,6 +144,12 @@ Unannotated Parquet `BYTE_ARRAY` and `FIXED_LEN_BYTE_ARRAY` columns are returned
 for example `UTF8` values are returned as JavaScript strings and `JSON` values are
 returned as parsed JavaScript values.
 
+Unshredded Parquet `VARIANT` groups are decoded into JavaScript primitives, arrays, and
+objects for object-row results. Arrow results retain the canonical `metadata` and `value`
+binary child fields so applications can choose when to decode or project them. Shredded
+Variant values are currently exposed as their typed child columns and are not yet
+reconstructed into one JavaScript value.
+
 `ParquetJSLoader` reads the Parquet 2.13 `LogicalType` annotation before using the legacy
 `ConvertedType` fallback. Arrow output preserves exact signed and unsigned integer widths,
 date/time/timestamp units through nanoseconds, Decimal128/256 precision and scale, UUID fixed-size

--- a/docs/modules/parquet/formats/parquet.md
+++ b/docs/modules/parquet/formats/parquet.md
@@ -115,7 +115,7 @@ The exact physical constraints and sort orders are defined by Apache's
 | `UNKNOWN` | Any physical type | Null | ✅ | ⚠️ | Values must be treated as null; writing is low-level only |
 | `LIST` | Three-level nested structure | List | ✅ | ✅ | High-level writer emits the standard `list`/`element` layout, including nested element types |
 | `MAP` | Repeated key/value structure | Map | ✅ | ✅ | High-level writer accepts `Map`, entry arrays, and plain objects; keys must be non-nullable |
-| [`VARIANT`](https://github.com/apache/parquet-format/blob/master/VariantEncoding.md) | Variant metadata/value byte columns | Struct of binary metadata/value fields | ⚠️ | ❌ | Unshredded values are decoded for object-row reads; Arrow retains the canonical binary fields and shredded-value reconstruction remains a roadmap item |
+| [`VARIANT`](https://github.com/apache/parquet-format/blob/master/VariantEncoding.md) | Variant metadata/value byte columns | Struct of binary metadata/value fields | ⚠️ | ❌ | Unshredded values are decoded for TypeScript object-row reads; Arrow and WASM retain the canonical binary fields, and shredded-value reconstruction remains a roadmap item |
 | [`VECTOR`](https://github.com/apache/parquet-format/pull/592) | Vector logical type (proposed) | Not yet mapped | ❌ | ❌ | Active upstream proposal; intentionally not advertised as supported |
 | `GEOMETRY` | `BYTE_ARRAY` | GeoArrow WKB binary | ✅ | ✅ | CRS plus native bbox/type statistics; TypeScript writer |
 | `GEOGRAPHY` | `BYTE_ARRAY` | GeoArrow WKB binary | ✅ | ✅ | CRS, all five edge algorithms, antimeridian-aware reads, and native statistics |

--- a/docs/modules/parquet/formats/parquet.md
+++ b/docs/modules/parquet/formats/parquet.md
@@ -115,7 +115,7 @@ The exact physical constraints and sort orders are defined by Apache's
 | `UNKNOWN` | Any physical type | Null | ✅ | ⚠️ | Values must be treated as null; writing is low-level only |
 | `LIST` | Three-level nested structure | List | ✅ | ✅ | High-level writer emits the standard `list`/`element` layout, including nested element types |
 | `MAP` | Repeated key/value structure | Map | ✅ | ✅ | High-level writer accepts `Map`, entry arrays, and plain objects; keys must be non-nullable |
-| [`VARIANT`](https://github.com/apache/parquet-format/blob/master/VariantEncoding.md) | Variant metadata/value byte columns | Binary plus metadata | ⚠️ | ❌ | Metadata is retained; Variant payload decoding and shredding remain roadmap items |
+| [`VARIANT`](https://github.com/apache/parquet-format/blob/master/VariantEncoding.md) | Variant metadata/value byte columns | Struct of binary metadata/value fields | ⚠️ | ❌ | Unshredded values are decoded for object-row reads; Arrow retains the canonical binary fields and shredded-value reconstruction remains a roadmap item |
 | [`VECTOR`](https://github.com/apache/parquet-format/pull/592) | Vector logical type (proposed) | Not yet mapped | ❌ | ❌ | Active upstream proposal; intentionally not advertised as supported |
 | `GEOMETRY` | `BYTE_ARRAY` | GeoArrow WKB binary | ✅ | ✅ | CRS plus native bbox/type statistics; TypeScript writer |
 | `GEOGRAPHY` | `BYTE_ARRAY` | GeoArrow WKB binary | ✅ | ✅ | CRS, all five edge algorithms, antimeridian-aware reads, and native statistics |
@@ -285,7 +285,7 @@ The TypeScript implementation is aiming for complete stable-format read support.
 gaps are currently:
 
 1. repeated-leaf page-index continuation and pruning;
-2. Variant value decoding and shredding;
+2. Variant shredding and Arrow-native Variant extension output (unshredded object-row decoding is supported);
 3. page CRC verification and emission;
 4. size statistics and semantic sorting metadata; and
 5. Parquet modular encryption.

--- a/modules/parquet/src/parquetjs/schema/shred.ts
+++ b/modules/parquet/src/parquetjs/schema/shred.ts
@@ -8,6 +8,7 @@ import {ArrayType} from '@loaders.gl/schema';
 import {ParquetRowGroup, ParquetColumnChunk, ParquetField, ParquetRow} from './declare';
 import {ParquetSchema} from './schema';
 import * as Types from './types';
+import {decodeVariant} from './variant';
 
 export {ParquetRowGroup};
 
@@ -218,7 +219,56 @@ export function materializeRows(schema: ParquetSchema, rowGroup: ParquetRowGroup
       materializeColumnAsRows(schema, columnData, key, rows);
     }
   }
+  decodeVariantFields(schema.fields, rows);
   return rows;
+}
+
+/** Decodes complete unshredded VARIANT groups after their binary child columns are materialized. */
+function decodeVariantFields(fields: Record<string, ParquetField>, records: unknown[]): void {
+  for (const field of Object.values(fields)) {
+    if (field.logicalType?.type === 'VARIANT') {
+      for (const record of records) {
+        if (record && typeof record === 'object') {
+          const row = record as Record<string, unknown>;
+          row[field.name] = decodeVariantRecord(row[field.name]);
+        }
+      }
+    } else if (field.fields) {
+      for (const record of records) {
+        if (record && typeof record === 'object') {
+          decodeVariantFields(field.fields, getNestedRecords(record, field.name));
+        }
+      }
+    }
+  }
+}
+
+/** Recursively decodes one materialized Variant group, preserving shredded values as records. */
+function decodeVariantRecord(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(decodeVariantRecord);
+  }
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+  const record = value as Record<string, unknown>;
+  const metadata = record.metadata;
+  const variantValue = record.value;
+  if (isByteArray(metadata) && isByteArray(variantValue)) {
+    return decodeVariant(metadata, variantValue);
+  }
+  return value;
+}
+
+/** Finds nested records while preserving repeated group values. */
+function getNestedRecords(record: object, fieldName: string): unknown[] {
+  const value = Reflect.get(record, fieldName);
+  return Array.isArray(value) ? value : value && typeof value === 'object' ? [value] : [];
+}
+
+/** Identifies binary values emitted by Parquet primitive materialization. */
+function isByteArray(value: unknown): value is ArrayBuffer | ArrayBufferView {
+  return value instanceof ArrayBuffer || ArrayBuffer.isView(value);
 }
 
 /** Populate record fields for one column */

--- a/modules/parquet/src/parquetjs/schema/shred.ts
+++ b/modules/parquet/src/parquetjs/schema/shred.ts
@@ -230,7 +230,9 @@ function decodeVariantFields(fields: Record<string, ParquetField>, records: unkn
       for (const record of records) {
         if (record && typeof record === 'object') {
           const row = record as Record<string, unknown>;
-          row[field.name] = decodeVariantRecord(row[field.name]);
+          if (Object.prototype.hasOwnProperty.call(row, field.name)) {
+            row[field.name] = decodeVariantRecord(row[field.name]);
+          }
         }
       }
     } else if (field.fields) {

--- a/modules/parquet/src/parquetjs/schema/variant.ts
+++ b/modules/parquet/src/parquetjs/schema/variant.ts
@@ -1,0 +1,310 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {decodeUtf8, toUint8Array} from '../utils/binary-utils';
+
+const MAXIMUM_VARIANT_NESTING = 1024;
+
+/** Decodes the binary metadata/value pair used by the Parquet VARIANT type. */
+export function decodeVariant(
+  metadataInput: ArrayBuffer | ArrayBufferView,
+  valueInput: ArrayBuffer | ArrayBufferView
+): unknown {
+  const metadata = toUint8Array(metadataInput);
+  const value = toUint8Array(valueInput);
+  const dictionary = decodeVariantMetadata(metadata);
+  const decoded = decodeVariantValue(value, 0, value.length, dictionary, 0);
+  if (decoded.nextOffset !== value.length) {
+    throw new Error(
+      `parquet: trailing bytes in VARIANT value (${value.length - decoded.nextOffset})`
+    );
+  }
+  return decoded.value;
+}
+
+interface VariantMetadata {
+  /** Dictionary strings used by object field IDs. */
+  dictionary: string[];
+}
+
+interface DecodedVariantValue {
+  /** Decoded JavaScript value. */
+  value: unknown;
+  /** Offset immediately following the encoded value. */
+  nextOffset: number;
+}
+
+/** Parses the versioned dictionary at the start of every Variant value. */
+function decodeVariantMetadata(bytes: Uint8Array): VariantMetadata {
+  if (bytes.length < 2) {
+    throw new Error('parquet: VARIANT metadata is truncated');
+  }
+  const header = bytes[0];
+  const version = header & 0xf;
+  if (version !== 1) {
+    throw new Error(`parquet: unsupported VARIANT metadata version ${version}`);
+  }
+  const offsetSize = ((header >> 6) & 0x3) + 1;
+  const dictionarySize = readUnsigned(bytes, 1, offsetSize);
+  const offsetsStart = 1 + offsetSize;
+  const offsetsEnd = offsetsStart + (dictionarySize + 1) * offsetSize;
+  if (offsetsEnd > bytes.length) {
+    throw new Error('parquet: VARIANT metadata offsets are truncated');
+  }
+  const dictionaryBytes = bytes.subarray(offsetsEnd);
+  const dictionary: string[] = [];
+  let previousOffset = 0;
+  for (let index = 0; index < dictionarySize + 1; index++) {
+    const offset = readUnsigned(bytes, offsetsStart + index * offsetSize, offsetSize);
+    if (offset < previousOffset || offset > dictionaryBytes.length) {
+      throw new Error('parquet: invalid VARIANT metadata dictionary offset');
+    }
+    if (index < dictionarySize) {
+      dictionary.push(
+        decodeUtf8(
+          dictionaryBytes.subarray(
+            offset,
+            readUnsigned(bytes, offsetsStart + (index + 1) * offsetSize, offsetSize)
+          )
+        )
+      );
+    }
+    previousOffset = offset;
+  }
+  if (previousOffset !== dictionaryBytes.length) {
+    throw new Error('parquet: VARIANT metadata does not consume its dictionary bytes');
+  }
+  return {dictionary};
+}
+
+/** Decodes one self-contained Variant value within the enclosing byte range. */
+function decodeVariantValue(
+  bytes: Uint8Array,
+  offset: number,
+  endOffset: number,
+  metadata: VariantMetadata,
+  depth: number
+): DecodedVariantValue {
+  if (depth > MAXIMUM_VARIANT_NESTING || offset >= endOffset) {
+    throw new Error('parquet: invalid or excessively nested VARIANT value');
+  }
+  const valueMetadata = bytes[offset++];
+  const basicType = valueMetadata & 0x3;
+  const valueHeader = valueMetadata >> 2;
+  switch (basicType) {
+    case 0:
+      return decodePrimitiveValue(bytes, offset, endOffset, valueHeader);
+    case 1: {
+      const stringEnd = checkedEnd(offset + valueHeader, endOffset);
+      return {value: decodeUtf8(bytes.subarray(offset, stringEnd)), nextOffset: stringEnd};
+    }
+    case 2:
+      return decodeObjectValue(bytes, offset, endOffset, valueHeader, metadata, depth + 1);
+    case 3:
+      return decodeArrayValue(bytes, offset, endOffset, valueHeader, metadata, depth + 1);
+    default:
+      throw new Error(`parquet: invalid VARIANT basic type ${basicType}`);
+  }
+}
+
+/** Decodes a Variant primitive identified by its six-bit primitive header. */
+function decodePrimitiveValue(
+  bytes: Uint8Array,
+  offset: number,
+  endOffset: number,
+  primitiveType: number
+): DecodedVariantValue {
+  switch (primitiveType) {
+    case 0:
+      return {value: null, nextOffset: offset};
+    case 1:
+      return {value: true, nextOffset: offset};
+    case 2:
+      return {value: false, nextOffset: offset};
+    case 3:
+      return {value: readSigned(bytes, offset, 1), nextOffset: checkedEnd(offset + 1, endOffset)};
+    case 4:
+      return {value: readSigned(bytes, offset, 2), nextOffset: checkedEnd(offset + 2, endOffset)};
+    case 5:
+      return {value: readSigned(bytes, offset, 4), nextOffset: checkedEnd(offset + 4, endOffset)};
+    case 6:
+      return {value: readBigInt(bytes, offset, 8), nextOffset: checkedEnd(offset + 8, endOffset)};
+    case 7:
+      return {value: readFloat64(bytes, offset), nextOffset: checkedEnd(offset + 8, endOffset)};
+    case 8:
+    case 9:
+    case 10: {
+      const scale = readSigned(bytes, offset, 1);
+      const width = primitiveType === 8 ? 4 : primitiveType === 9 ? 8 : 16;
+      const unscaled = readBigInt(bytes, offset + 1, width);
+      return {
+        value: formatVariantDecimal(unscaled, scale),
+        nextOffset: checkedEnd(offset + 1 + width, endOffset)
+      };
+    }
+    case 11:
+      return {value: readSigned(bytes, offset, 4), nextOffset: checkedEnd(offset + 4, endOffset)};
+    case 12:
+    case 13:
+    case 17:
+    case 18:
+    case 19:
+      return {value: readBigInt(bytes, offset, 8), nextOffset: checkedEnd(offset + 8, endOffset)};
+    case 14:
+      return {value: readFloat32(bytes, offset), nextOffset: checkedEnd(offset + 4, endOffset)};
+    case 15: {
+      const length = readUnsigned(bytes, offset, 4);
+      const start = checkedEnd(offset + 4, endOffset);
+      const binaryEnd = checkedEnd(start + length, endOffset);
+      return {value: bytes.slice(start, binaryEnd), nextOffset: binaryEnd};
+    }
+    case 16: {
+      const length = readUnsigned(bytes, offset, 4);
+      const start = checkedEnd(offset + 4, endOffset);
+      const stringEnd = checkedEnd(start + length, endOffset);
+      return {value: decodeUtf8(bytes.subarray(start, stringEnd)), nextOffset: stringEnd};
+    }
+    case 20: {
+      const uuidEnd = checkedEnd(offset + 16, endOffset);
+      return {value: bytes.slice(offset, uuidEnd), nextOffset: uuidEnd};
+    }
+    default:
+      throw new Error(`parquet: unsupported VARIANT primitive type ${primitiveType}`);
+  }
+}
+
+/** Decodes an object using metadata dictionary field IDs and relative value offsets. */
+function decodeObjectValue(
+  bytes: Uint8Array,
+  offset: number,
+  endOffset: number,
+  valueHeader: number,
+  metadata: VariantMetadata,
+  depth: number
+): DecodedVariantValue {
+  const isLarge = (valueHeader & 0x10) !== 0;
+  const fieldIdSize = ((valueHeader >> 2) & 0x3) + 1;
+  const fieldOffsetSize = (valueHeader & 0x3) + 1;
+  const countSize = isLarge ? 4 : 1;
+  const count = readUnsigned(bytes, offset, countSize);
+  offset = checkedEnd(offset + countSize, endOffset);
+  const fieldIds: number[] = [];
+  for (let index = 0; index < count; index++) {
+    fieldIds.push(readUnsigned(bytes, offset, fieldIdSize));
+    offset = checkedEnd(offset + fieldIdSize, endOffset);
+  }
+  const offsets: number[] = [];
+  for (let index = 0; index <= count; index++) {
+    offsets.push(readUnsigned(bytes, offset, fieldOffsetSize));
+    offset = checkedEnd(offset + fieldOffsetSize, endOffset);
+  }
+  const valuesStart = offset;
+  const valuesEnd = checkedEnd(valuesStart + offsets[offsets.length - 1], endOffset);
+  const object: Record<string, unknown> = {};
+  for (let index = 0; index < count; index++) {
+    const fieldId = fieldIds[index];
+    const fieldName = metadata.dictionary[fieldId];
+    if (fieldName === undefined) {
+      throw new Error(`parquet: invalid VARIANT object field id ${fieldId}`);
+    }
+    if (fieldName in object) {
+      throw new Error(`parquet: duplicate VARIANT object field ${fieldName}`);
+    }
+    const valueOffset = checkedEnd(valuesStart + offsets[index], valuesEnd);
+    const decoded = decodeVariantValue(bytes, valueOffset, valuesEnd, metadata, depth);
+    object[fieldName] = decoded.value;
+  }
+  return {value: object, nextOffset: valuesEnd};
+}
+
+/** Decodes an array using relative offsets into its contiguous value region. */
+function decodeArrayValue(
+  bytes: Uint8Array,
+  offset: number,
+  endOffset: number,
+  valueHeader: number,
+  metadata: VariantMetadata,
+  depth: number
+): DecodedVariantValue {
+  const isLarge = (valueHeader & 0x4) !== 0;
+  const fieldOffsetSize = (valueHeader & 0x3) + 1;
+  const countSize = isLarge ? 4 : 1;
+  const count = readUnsigned(bytes, offset, countSize);
+  offset = checkedEnd(offset + countSize, endOffset);
+  const offsets: number[] = [];
+  for (let index = 0; index <= count; index++) {
+    offsets.push(readUnsigned(bytes, offset, fieldOffsetSize));
+    offset = checkedEnd(offset + fieldOffsetSize, endOffset);
+  }
+  const valuesStart = offset;
+  const valuesEnd = checkedEnd(valuesStart + offsets[offsets.length - 1], endOffset);
+  const array = new Array<unknown>(count);
+  for (let index = 0; index < count; index++) {
+    const valueOffset = checkedEnd(valuesStart + offsets[index], valuesEnd);
+    array[index] = decodeVariantValue(bytes, valueOffset, valuesEnd, metadata, depth).value;
+  }
+  return {value: array, nextOffset: valuesEnd};
+}
+
+/** Reads an unsigned little-endian integer of up to four bytes. */
+function readUnsigned(bytes: Uint8Array, offset: number, byteLength: number): number {
+  let value = 0;
+  for (let index = 0; index < byteLength; index++) {
+    value += bytes[offset + index] * 2 ** (index * 8);
+  }
+  if (!Number.isSafeInteger(value)) {
+    throw new Error('parquet: VARIANT integer exceeds JavaScript safe range');
+  }
+  return value;
+}
+
+/** Reads a signed little-endian integer of up to four bytes. */
+function readSigned(bytes: Uint8Array, offset: number, byteLength: number): number {
+  const unsigned = readUnsigned(bytes, offset, byteLength);
+  const signBit = 2 ** (byteLength * 8 - 1);
+  return unsigned >= signBit ? unsigned - 2 ** (byteLength * 8) : unsigned;
+}
+
+/** Reads a signed little-endian integer while preserving 64- and 128-bit precision. */
+function readBigInt(bytes: Uint8Array, offset: number, byteLength: number): bigint {
+  let value = 0n;
+  for (let index = 0; index < byteLength; index++) {
+    value |= BigInt(bytes[offset + index]) << BigInt(index * 8);
+  }
+  const signBit = 1n << BigInt(byteLength * 8 - 1);
+  return value >= signBit ? value - (1n << BigInt(byteLength * 8)) : value;
+}
+
+/** Reads a little-endian IEEE-754 single-precision value. */
+function readFloat32(bytes: Uint8Array, offset: number): number {
+  return new DataView(bytes.buffer, bytes.byteOffset + offset, 4).getFloat32(0, true);
+}
+
+/** Reads a little-endian IEEE-754 double-precision value. */
+function readFloat64(bytes: Uint8Array, offset: number): number {
+  return new DataView(bytes.buffer, bytes.byteOffset + offset, 8).getFloat64(0, true);
+}
+
+/** Formats a Variant decimal without losing precision when JavaScript numbers are unsafe. */
+function formatVariantDecimal(unscaled: bigint, scale: number): number | string {
+  if (
+    scale === 0 &&
+    unscaled >= BigInt(Number.MIN_SAFE_INTEGER) &&
+    unscaled <= BigInt(Number.MAX_SAFE_INTEGER)
+  ) {
+    return Number(unscaled);
+  }
+  const sign = unscaled < 0n ? '-' : '';
+  const digits = (unscaled < 0n ? -unscaled : unscaled).toString().padStart(scale + 1, '0');
+  const split = digits.length - scale;
+  return `${sign}${digits.slice(0, split)}.${digits.slice(split)}`;
+}
+
+/** Validates an offset against the enclosing value boundary. */
+function checkedEnd(offset: number, endOffset: number): number {
+  if (!Number.isSafeInteger(offset) || offset < 0 || offset > endOffset) {
+    throw new Error('parquet: truncated VARIANT value');
+  }
+  return offset;
+}

--- a/modules/parquet/src/parquetjs/schema/variant.ts
+++ b/modules/parquet/src/parquetjs/schema/variant.ts
@@ -201,14 +201,14 @@ function decodeObjectValue(
   }
   const valuesStart = offset;
   const valuesEnd = checkedEnd(valuesStart + offsets[offsets.length - 1], endOffset);
-  const object: Record<string, unknown> = {};
+  const object: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
   for (let index = 0; index < count; index++) {
     const fieldId = fieldIds[index];
     const fieldName = metadata.dictionary[fieldId];
     if (fieldName === undefined) {
       throw new Error(`parquet: invalid VARIANT object field id ${fieldId}`);
     }
-    if (fieldName in object) {
+    if (Object.prototype.hasOwnProperty.call(object, fieldName)) {
       throw new Error(`parquet: duplicate VARIANT object field ${fieldName}`);
     }
     const valueOffset = checkedEnd(valuesStart + offsets[index], valuesEnd);
@@ -288,6 +288,9 @@ function readFloat64(bytes: Uint8Array, offset: number): number {
 
 /** Formats a Variant decimal without losing precision when JavaScript numbers are unsafe. */
 function formatVariantDecimal(unscaled: bigint, scale: number): number | string {
+  if (scale < 0) {
+    return `${unscaled.toString()}${'0'.repeat(-scale)}`;
+  }
   if (
     scale === 0 &&
     unscaled >= BigInt(Number.MIN_SAFE_INTEGER) &&

--- a/modules/parquet/test/index.ts
+++ b/modules/parquet/test/index.ts
@@ -13,6 +13,7 @@ import './parquetjs/schema.spec';
 import './parquetjs/shred.spec';
 import './parquetjs/thrift.spec';
 import './parquetjs/reader.spec';
+import './parquetjs/variant.spec';
 
 // The integration spec runs tens of thousands of detailed tests. Too slow for CI, uncomment to run.
 // import './parquetjs/integration.spec';

--- a/modules/parquet/test/parquetjs/variant.spec.ts
+++ b/modules/parquet/test/parquetjs/variant.spec.ts
@@ -1,0 +1,98 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+
+import {decodeVariant} from '../../src/parquetjs/schema/variant';
+import {ParquetSchema} from '../../src/parquetjs/schema/schema';
+import {materializeRows} from '../../src/parquetjs/schema/shred';
+
+function createMetadata(dictionary: string[]): Uint8Array {
+  const dictionaryBytes = new TextEncoder().encode(dictionary.join(''));
+  const offsets = [0];
+  for (const value of dictionary) {
+    offsets.push(offsets[offsets.length - 1] + new TextEncoder().encode(value).length);
+  }
+  return new Uint8Array([
+    0x01,
+    dictionary.length,
+    ...offsets,
+    ...dictionaryBytes
+  ]);
+}
+
+describe('Parquet VARIANT binary encoding', () => {
+  test('decodes primitive and short-string values', () => {
+    const metadata = createMetadata([]);
+    expect(decodeVariant(metadata, new Uint8Array([0]))).toBeNull();
+    expect(decodeVariant(metadata, new Uint8Array([4]))).toBe(true);
+    expect(decodeVariant(metadata, new Uint8Array([8]))).toBe(false);
+    expect(decodeVariant(metadata, new Uint8Array([20, 42, 0, 0, 0]))).toBe(42);
+    expect(decodeVariant(metadata, new Uint8Array([1 | (5 << 2), 104, 101, 108, 108, 111]))).toBe(
+      'hello'
+    );
+  });
+
+  test('decodes arrays and objects whose value offsets are not monotonic', () => {
+    const metadata = createMetadata(['a', 'b']);
+    // Object header: basic type 2, one-byte field ids and offsets.
+    // The values are stored as "b", then "a", while the sorted field ids are a, b.
+    const value = new Uint8Array([
+      2,
+      2,
+      0,
+      1,
+      2,
+      0,
+      4,
+      5,
+      98,
+      5,
+      97
+    ]);
+    expect(decodeVariant(metadata, value)).toEqual({a: 'a', b: 'b'});
+
+    // Array header: basic type 3 and one-byte offsets, containing true and null.
+    expect(decodeVariant(metadata, new Uint8Array([3, 2, 0, 1, 2, 4, 0]))).toEqual([true, null]);
+  });
+
+  test('preserves exact int64 values and binary values', () => {
+    const metadata = createMetadata([]);
+    expect(decodeVariant(metadata, new Uint8Array([24, 0, 0, 0, 0, 0, 0, 0, 128]))).toBe(
+      -9223372036854775808n
+    );
+    expect(decodeVariant(metadata, new Uint8Array([60, 2, 0, 0, 0, 1, 2]))).toEqual(
+      new Uint8Array([1, 2])
+    );
+  });
+
+  test('rejects unsupported metadata versions', () => {
+    expect(() => decodeVariant(new Uint8Array([2, 0, 0]), new Uint8Array([0]))).toThrow(
+      'unsupported VARIANT metadata version'
+    );
+  });
+
+  test('decodes an unshredded Variant while materializing object rows', () => {
+    const schema = new ParquetSchema({
+      event: {
+        optional: true,
+        logicalType: {type: 'VARIANT', specificationVersion: 1},
+        fields: {
+          metadata: {type: 'BYTE_ARRAY'},
+          value: {type: 'BYTE_ARRAY'}
+        }
+      }
+    });
+    const metadata = createMetadata(['message']);
+    const value = new Uint8Array([1 | (2 << 2), 104, 105]);
+    const rows = materializeRows(schema, {
+      rowCount: 1,
+      columnData: {
+        'event,metadata': {count: 1, dlevels: [1], rlevels: [0], values: [metadata], pageHeaders: []},
+        'event,value': {count: 1, dlevels: [1], rlevels: [0], values: [value], pageHeaders: []}
+      }
+    });
+    expect(rows).toEqual([{event: 'hi'}]);
+  });
+});

--- a/modules/parquet/test/parquetjs/variant.spec.ts
+++ b/modules/parquet/test/parquetjs/variant.spec.ts
@@ -67,6 +67,23 @@ describe('Parquet VARIANT binary encoding', () => {
     );
   });
 
+  test('handles negative decimal scales and prototype-shaped field names', () => {
+    const metadata = createMetadata(['__proto__']);
+    // decimal4: primitive type 8, scale -2, unscaled value 123.
+    expect(
+      decodeVariant(metadata, new Uint8Array([8 << 2, 0xfe, 123, 0, 0, 0]))
+    ).toBe('12300');
+
+    // Object header with one-byte field IDs and offsets; the key is __proto__.
+    const decoded = decodeVariant(
+      metadata,
+      new Uint8Array([2, 1, 0, 0, 2, 5, 120])
+    ) as Record<string, unknown>;
+    expect(Object.getPrototypeOf(decoded)).toBeNull();
+    expect(Object.prototype.hasOwnProperty.call(decoded, '__proto__')).toBe(true);
+    expect(decoded['__proto__']).toBe('x');
+  });
+
   test('rejects unsupported metadata versions', () => {
     expect(() => decodeVariant(new Uint8Array([2, 0, 0]), new Uint8Array([0]))).toThrow(
       'unsupported VARIANT metadata version'
@@ -94,5 +111,21 @@ describe('Parquet VARIANT binary encoding', () => {
       }
     });
     expect(rows).toEqual([{event: 'hi'}]);
+  });
+
+  test('does not add absent optional Variant fields to object rows', () => {
+    const schema = new ParquetSchema({
+      event: {
+        optional: true,
+        logicalType: {type: 'VARIANT', specificationVersion: 1},
+        fields: {
+          metadata: {type: 'BYTE_ARRAY'},
+          value: {type: 'BYTE_ARRAY'}
+        }
+      }
+    });
+    const rows = materializeRows(schema, {rowCount: 1, columnData: {}});
+    expect(rows).toEqual([{}]);
+    expect(Object.prototype.hasOwnProperty.call(rows[0], 'event')).toBe(false);
   });
 });


### PR DESCRIPTION
## Goals

Advance Parquet Variant support with standards-based decoding for complete unshredded values while keeping Arrow storage lossless and documenting the remaining shredded-value boundary.

## Changes

- Add a browser-safe Parquet Variant binary decoder for metadata dictionaries, primitive values, strings, arrays, objects, binary, decimal, timestamp, and UUID encodings.
- Decode complete unshredded VARIANT groups during TypeScript object-row materialization, including nested groups and repeated values.
- Preserve canonical metadata/value binary child fields for Arrow results and leave shredded groups available for the next tranche.
- Add focused conformance tests for primitives, exact integers, arrays, non-monotonic object offsets, binary values, malformed versions, negative decimal scales, prototype-shaped field names, and row materialization.
- Update the Parquet feature matrix, loader documentation, and AGENTS.md to require native Vitest syntax for all new tests.

## Validation

- yarn lint fix
- yarn build
- yarn test-node
- yarn test-headless (424 files, 2,387 tests passed; 2 files and 47 tests skipped)
- Focused Variant Chromium suite: 7 tests passed

## Follow-up boundary

This PR intentionally does not reconstruct shredded typed_value columns or introduce an Arrow-native Variant extension type; those remain the next Variant tranche.