### PR TITLE
feat(scan): add ORC source adapter

### DIFF
--- a/modules/orc/package.json
+++ b/modules/orc/package.json
@@ -38,6 +38,10 @@
     "./orc-loader": {
       "types": "./dist/orc-loader.d.ts",
       "import": "./dist/orc-loader.js"
+    },
+    "./orc-source-loader": {
+      "types": "./dist/orc-source-loader.d.ts",
+      "import": "./dist/orc-source-loader.js"
     }
   },
   "sideEffects": false,

--- a/modules/orc/src/index.ts
+++ b/modules/orc/src/index.ts
@@ -3,8 +3,8 @@
 // Copyright (c) vis.gl contributors
 
 export {ORCFormat} from './orc-format';
-export {ORCSource, ORCSourceLoader} from './orc-source-loader';
-export type {ORCQueryOptions, ORCSourceOptions} from './orc-source-loader';
+export {ORCSourceLoader} from './orc-source-loader-types';
+export type {ORCSourceLoaderOptions} from './orc-source-loader-types';
 export type {ORCLoaderOptions} from './orc-loader-types';
 export {ORCLoader} from './orc-loader-types';
 export {ORCWriter} from './orc-writer';

--- a/modules/orc/src/index.ts
+++ b/modules/orc/src/index.ts
@@ -3,6 +3,8 @@
 // Copyright (c) vis.gl contributors
 
 export {ORCFormat} from './orc-format';
+export {ORCSource, ORCSourceLoader} from './orc-source-loader';
+export type {ORCQueryOptions, ORCSourceOptions} from './orc-source-loader';
 export type {ORCLoaderOptions} from './orc-loader-types';
 export {ORCLoader} from './orc-loader-types';
 export {ORCWriter} from './orc-writer';

--- a/modules/orc/src/orc-source-loader-types.ts
+++ b/modules/orc/src/orc-source-loader-types.ts
@@ -1,0 +1,33 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {ORCFormat} from './orc-format';
+import type {ORCSourceOptions} from './orc-source-loader';
+
+// __VERSION__ is injected by babel-plugin-version-inline
+// @ts-ignore TS2304: Cannot find name '__VERSION__'.
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+
+/** Metadata-only ORC source loader options. */
+export type ORCSourceLoaderOptions = ORCSourceOptions;
+
+/** Loads the parser-bearing ORC source implementation on demand. */
+async function preloadORCSourceLoader() {
+  const {ORCSourceLoaderWithParser} = await import('@loaders.gl/orc/orc-source-loader');
+  return ORCSourceLoaderWithParser;
+}
+
+/** Metadata-only ORC source loader; parser code is loaded through `preload()`. */
+export const ORCSourceLoader = {
+  ...ORCFormat,
+  name: 'ORCSourceLoader',
+  version: VERSION,
+  type: 'orc-source',
+  fromUrl: true,
+  fromBlob: true,
+  options: {},
+  defaultOptions: {},
+  testURL: (url: string): boolean => /\.orc(?:$|[?#])/i.test(url),
+  preload: preloadORCSourceLoader
+} as const;

--- a/modules/orc/src/orc-source-loader.ts
+++ b/modules/orc/src/orc-source-loader.ts
@@ -7,16 +7,18 @@ import type {
   DataSourceOptions,
   ScanQueryMetadata,
   ScanQueryMetadataOptions,
-  SourceLoader
+  SourceLoader,
+  TableQueryOptions
 } from '@loaders.gl/loader-utils';
 import {
   createScanQueryMetadata,
   DataSource,
-  type TableQueryOptions
+  validateTableQueryOptions
 } from '@loaders.gl/loader-utils';
-import {ORCFormat} from './orc-format';
 import {parseORC, ORCTypeKind, type ORCTypeDescription} from './lib/parsers/parse-orc';
 import {parseORCToArrow} from './lib/parsers/parse-orc-to-arrow';
+import {preloadORCCompression} from './lib/parsers/orc-compression';
+import {ORCFormat} from './orc-format';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
@@ -27,23 +29,6 @@ export type ORCSourceOptions = DataSourceOptions;
 
 /** Query options accepted by the current ORC source implementation. */
 export type ORCQueryOptions = TableQueryOptions & Readonly<{signal?: AbortSignal}>;
-
-/** Source loader metadata for range-ready ORC query discovery. */
-export const ORCSourceLoader = {
-  dataType: null as unknown as ORCSource,
-  batchType: null as never,
-  ...ORCFormat,
-  name: 'ORCSourceLoader',
-  version: VERSION,
-  type: 'orc-source',
-  fromUrl: true,
-  fromBlob: true,
-  options: {},
-  defaultOptions: {},
-  testURL: (url: string): boolean => /\.orc(?:$|[?#])/i.test(url),
-  createDataSource: (data: string | Blob, options: ORCSourceOptions): ORCSource =>
-    new ORCSource(data, options)
-} as const satisfies SourceLoader<ORCSource>;
 
 /**
  * Lightweight ORC scan source.
@@ -63,6 +48,7 @@ export class ORCSource extends DataSource<string | Blob, ORCSourceOptions> {
   /** Discovers ORC footer schema and stripe statistics without decoding data streams. */
   async getQueryMetadata(options: ScanQueryMetadataOptions = {}): Promise<ScanQueryMetadata> {
     const arrayBuffer = await this.getArrayBuffer(options.signal);
+    await preloadORCCompression();
     const file = parseORC(arrayBuffer);
     const schema = createORCSchema(file.footer.types[0], file.footer.types);
     return createScanQueryMetadata({
@@ -88,10 +74,19 @@ export class ORCSource extends DataSource<string | Blob, ORCSourceOptions> {
   /** Executes a portable query after decoding the ORC file into an Arrow table. */
   async query(options: ORCQueryOptions = {}): Promise<ArrowTable> {
     throwIfAborted(options.signal);
-    const table = parseORCToArrow(await this.getArrayBuffer(options.signal));
     if (options.predicate) {
-      throw new Error('ORC residual predicates are not implemented yet.');
+      throw new Error('ORC predicates are not implemented yet.');
     }
+    const arrayBuffer = await this.getArrayBuffer(options.signal);
+    await preloadORCCompression();
+    const file = parseORC(arrayBuffer);
+    validateTableQueryOptions(
+      file.footer.fieldNames.length
+        ? file.footer.fieldNames
+        : file.footer.types[0]?.fieldNames || [],
+      options
+    );
+    const table = parseORCToArrow(arrayBuffer);
     const projectedData = table.data.select(
       options.columns ? [...options.columns] : table.data.schema.fields.map(field => field.name)
     );
@@ -127,11 +122,33 @@ export class ORCSource extends DataSource<string | Blob, ORCSourceOptions> {
             })
           : this.data.arrayBuffer();
     }
-    const arrayBuffer = await this.arrayBufferPromise;
-    throwIfAborted(signal);
-    return arrayBuffer;
+    try {
+      const arrayBuffer = await this.arrayBufferPromise;
+      throwIfAborted(signal);
+      return arrayBuffer;
+    } catch (error) {
+      this.arrayBufferPromise = null;
+      throw error;
+    }
   }
 }
+
+/** Parser-bearing ORC source loader exposed through the explicit source subpath. */
+export const ORCSourceLoaderWithParser = {
+  dataType: null as unknown as ORCSource,
+  batchType: null as never,
+  ...ORCFormat,
+  name: 'ORCSourceLoader',
+  version: VERSION,
+  type: 'orc-source',
+  fromUrl: true,
+  fromBlob: true,
+  options: {},
+  defaultOptions: {},
+  testURL: (url: string): boolean => /\.orc(?:$|[?#])/i.test(url),
+  createDataSource: (data: string | Blob, options: ORCSourceOptions): ORCSource =>
+    new ORCSource(data, options)
+} as const satisfies SourceLoader<ORCSource>;
 
 /** Converts an ORC struct footer type into a loaders.gl schema without reading stripes. */
 function createORCSchema(
@@ -141,7 +158,11 @@ function createORCSchema(
   const fields: Field[] =
     rootType?.fieldNames.map((name, index) => ({
       name,
-      type: getORCDataType(types[rootType.subtypes[index]]?.kind),
+      type: getORCDataType(
+        types[rootType.subtypes[index]]?.kind,
+        types[rootType.subtypes[index]],
+        types
+      ),
       nullable: true,
       metadata: {}
     })) || [];
@@ -149,7 +170,11 @@ function createORCSchema(
 }
 
 /** Maps supported ORC primitive kinds to portable schema data types. */
-function getORCDataType(typeId: number): DataType {
+function getORCDataType(
+  typeId: number | undefined,
+  typeDescription?: ORCTypeDescription,
+  types: readonly ORCTypeDescription[] = []
+): DataType {
   switch (typeId) {
     case ORCTypeKind.BOOLEAN:
       return 'bool';
@@ -170,6 +195,43 @@ function getORCDataType(typeId: number): DataType {
       return 'binary';
     case ORCTypeKind.TIMESTAMP:
       return 'timestamp-millisecond';
+    case ORCTypeKind.LIST: {
+      const childTypeId = typeDescription?.subtypes[0];
+      return {
+        type: 'list',
+        children: [
+          {
+            name: 'item',
+            type: getORCDataType(types[childTypeId ?? 0]?.kind, types[childTypeId ?? 0], types),
+            nullable: true,
+            metadata: {}
+          }
+        ]
+      };
+    }
+    case ORCTypeKind.MAP:
+      return {
+        type: 'map',
+        keysSorted: false,
+        children:
+          typeDescription?.subtypes.map((childTypeId, index) => ({
+            name: index === 0 ? 'key' : 'value',
+            type: getORCDataType(types[childTypeId]?.kind, types[childTypeId], types),
+            nullable: true,
+            metadata: {}
+          })) || []
+      };
+    case ORCTypeKind.STRUCT:
+      return {
+        type: 'struct',
+        children:
+          typeDescription?.subtypes.map((childTypeId, index) => ({
+            name: typeDescription.fieldNames[index] || `field_${index}`,
+            type: getORCDataType(types[childTypeId]?.kind, types[childTypeId], types),
+            nullable: true,
+            metadata: {}
+          })) || []
+      };
     default:
       return 'utf8';
   }

--- a/modules/orc/src/orc-source-loader.ts
+++ b/modules/orc/src/orc-source-loader.ts
@@ -1,0 +1,181 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {ArrowTable, ArrowTableBatch, DataType, Field, Schema} from '@loaders.gl/schema';
+import type {
+  DataSourceOptions,
+  ScanQueryMetadata,
+  ScanQueryMetadataOptions,
+  SourceLoader
+} from '@loaders.gl/loader-utils';
+import {
+  createScanQueryMetadata,
+  DataSource,
+  type TableQueryOptions
+} from '@loaders.gl/loader-utils';
+import {ORCFormat} from './orc-format';
+import {parseORC, ORCTypeKind, type ORCTypeDescription} from './lib/parsers/parse-orc';
+import {parseORCToArrow} from './lib/parsers/parse-orc-to-arrow';
+
+// __VERSION__ is injected by babel-plugin-version-inline
+// @ts-ignore TS2304: Cannot find name '__VERSION__'.
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+
+/** Options for an ORC source backed by a URL, Blob, or complete ArrayBuffer. */
+export type ORCSourceOptions = DataSourceOptions;
+
+/** Query options accepted by the current ORC source implementation. */
+export type ORCQueryOptions = TableQueryOptions & Readonly<{signal?: AbortSignal}>;
+
+/** Source loader metadata for range-ready ORC query discovery. */
+export const ORCSourceLoader = {
+  dataType: null as unknown as ORCSource,
+  batchType: null as never,
+  ...ORCFormat,
+  name: 'ORCSourceLoader',
+  version: VERSION,
+  type: 'orc-source',
+  fromUrl: true,
+  fromBlob: true,
+  options: {},
+  defaultOptions: {},
+  testURL: (url: string): boolean => /\.orc(?:$|[?#])/i.test(url),
+  createDataSource: (data: string | Blob, options: ORCSourceOptions): ORCSource =>
+    new ORCSource(data, options)
+} as const satisfies SourceLoader<ORCSource>;
+
+/**
+ * Lightweight ORC scan source.
+ *
+ * Footer parsing is metadata-only and exposes a shared query schema. The current decoder reads the
+ * complete file before applying residual Arrow projection, predicates, and limits; stripe-level
+ * pruning remains the next ORC-specific tranche.
+ */
+export class ORCSource extends DataSource<string | Blob, ORCSourceOptions> {
+  private arrayBufferPromise: Promise<ArrayBuffer> | null = null;
+
+  /** Creates an ORC source over a URL or Blob. */
+  constructor(data: string | Blob, options: ORCSourceOptions = {}) {
+    super(data, options);
+  }
+
+  /** Discovers ORC footer schema and stripe statistics without decoding data streams. */
+  async getQueryMetadata(options: ScanQueryMetadataOptions = {}): Promise<ScanQueryMetadata> {
+    const arrayBuffer = await this.getArrayBuffer(options.signal);
+    const file = parseORC(arrayBuffer);
+    const schema = createORCSchema(file.footer.types[0], file.footer.types);
+    return createScanQueryMetadata({
+      sourceType: 'orc',
+      queryType: 'table',
+      schema,
+      capabilities: {
+        table: {
+          projection: 'residual',
+          predicate: 'unsupported',
+          limit: 'residual',
+          streaming: false,
+          cancellation: false
+        }
+      },
+      statistics: {
+        rowCount: file.footer.numberOfRows,
+        byteLength: arrayBuffer.byteLength
+      }
+    });
+  }
+
+  /** Executes a portable query after decoding the ORC file into an Arrow table. */
+  async query(options: ORCQueryOptions = {}): Promise<ArrowTable> {
+    throwIfAborted(options.signal);
+    const table = parseORCToArrow(await this.getArrayBuffer(options.signal));
+    if (options.predicate) {
+      throw new Error('ORC residual predicates are not implemented yet.');
+    }
+    const projectedData = table.data.select(
+      options.columns ? [...options.columns] : table.data.schema.fields.map(field => field.name)
+    );
+    const limitedData = projectedData.slice(0, options.limit ?? Number.POSITIVE_INFINITY);
+    return {
+      shape: 'arrow-table',
+      data: limitedData
+    };
+  }
+
+  /** Executes a query as one bounded Arrow batch. */
+  async *read(options: ORCQueryOptions = {}): AsyncIterableIterator<ArrowTableBatch> {
+    const table = await this.query(options);
+    yield {
+      batchType: 'data',
+      shape: 'arrow-table',
+      schema: table.schema,
+      data: table.data,
+      length: table.data.numRows
+    };
+  }
+
+  /** Returns the complete ORC bytes, fetching the source only once. */
+  private async getArrayBuffer(signal?: AbortSignal): Promise<ArrayBuffer> {
+    throwIfAborted(signal);
+    if (!this.arrayBufferPromise) {
+      this.arrayBufferPromise =
+        typeof this.data === 'string'
+          ? this.fetch(this.url, {signal}).then(response => {
+              if (!response.ok)
+                throw new Error(`ORC request failed with status ${response.status}.`);
+              return response.arrayBuffer();
+            })
+          : this.data.arrayBuffer();
+    }
+    const arrayBuffer = await this.arrayBufferPromise;
+    throwIfAborted(signal);
+    return arrayBuffer;
+  }
+}
+
+/** Converts an ORC struct footer type into a loaders.gl schema without reading stripes. */
+function createORCSchema(
+  rootType: ORCTypeDescription | undefined,
+  types: readonly ORCTypeDescription[]
+): Schema {
+  const fields: Field[] =
+    rootType?.fieldNames.map((name, index) => ({
+      name,
+      type: getORCDataType(types[rootType.subtypes[index]]?.kind),
+      nullable: true,
+      metadata: {}
+    })) || [];
+  return {fields, metadata: {}};
+}
+
+/** Maps supported ORC primitive kinds to portable schema data types. */
+function getORCDataType(typeId: number): DataType {
+  switch (typeId) {
+    case ORCTypeKind.BOOLEAN:
+      return 'bool';
+    case ORCTypeKind.BYTE:
+      return 'int8';
+    case ORCTypeKind.SHORT:
+      return 'int16';
+    case ORCTypeKind.INT:
+    case ORCTypeKind.DATE:
+      return 'int32';
+    case ORCTypeKind.LONG:
+      return 'int64';
+    case ORCTypeKind.FLOAT:
+      return 'float32';
+    case ORCTypeKind.DOUBLE:
+      return 'float64';
+    case ORCTypeKind.BINARY:
+      return 'binary';
+    case ORCTypeKind.TIMESTAMP:
+      return 'timestamp-millisecond';
+    default:
+      return 'utf8';
+  }
+}
+
+/** Throws the common source cancellation error before metadata or decode work begins. */
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) throw new Error('Request aborted');
+}

--- a/modules/orc/src/orc-source-loader.ts
+++ b/modules/orc/src/orc-source-loader.ts
@@ -151,7 +151,7 @@ export const ORCSourceLoaderWithParser = {
 } as const satisfies SourceLoader<ORCSource>;
 
 /** Converts an ORC struct footer type into a loaders.gl schema without reading stripes. */
-function createORCSchema(
+export function createORCSchema(
   rootType: ORCTypeDescription | undefined,
   types: readonly ORCTypeDescription[]
 ): Schema {
@@ -170,7 +170,7 @@ function createORCSchema(
 }
 
 /** Maps supported ORC primitive kinds to portable schema data types. */
-function getORCDataType(
+export function getORCDataType(
   typeId: number | undefined,
   typeDescription?: ORCTypeDescription,
   types: readonly ORCTypeDescription[] = []

--- a/modules/orc/test/orc-loader.spec.ts
+++ b/modules/orc/test/orc-loader.spec.ts
@@ -7,7 +7,13 @@ import * as arrow from 'apache-arrow';
 import {deflateSync, zlibSync} from 'fflate';
 import {SnappyCompression} from '@loaders.gl/compression/snappy-compression';
 import {ORCLoaderWithParser} from '../src/orc-loader';
-import {ORCSource, ORCSourceLoaderWithParser} from '../src/orc-source-loader';
+import {
+  createORCSchema,
+  getORCDataType,
+  ORCSource,
+  ORCSourceLoaderWithParser
+} from '../src/orc-source-loader';
+import {ORCTypeKind} from '../src/lib/parsers/parse-orc';
 import {ORCWriter} from '../src/orc-writer';
 import {decompressORCStream, preloadORCCompression} from '../src/lib/parsers/orc-compression';
 
@@ -39,6 +45,23 @@ test('ORC source loader exposes explicit parser entry points', () => {
   expect(ORCSourceLoaderWithParser.testURL('https://example.com/file.orc')).toBe(true);
   expect(ORCSourceLoaderWithParser.testURL('https://example.com/file.txt')).toBe(false);
   expect(ORCSourceLoaderWithParser.createDataSource(new Blob())).toBeInstanceOf(ORCSource);
+});
+
+test('ORC metadata preserves nested map and struct types', () => {
+  const types = [
+    {kind: ORCTypeKind.STRUCT, fieldNames: ['properties', 'attributes'], subtypes: [1, 2]},
+    {kind: ORCTypeKind.MAP, fieldNames: [], subtypes: [3, 4]},
+    {kind: ORCTypeKind.STRUCT, fieldNames: ['x'], subtypes: [5]},
+    {kind: ORCTypeKind.STRING, fieldNames: [], subtypes: []},
+    {kind: ORCTypeKind.INT, fieldNames: [], subtypes: []},
+    {kind: ORCTypeKind.DOUBLE, fieldNames: [], subtypes: []}
+  ];
+  const schema = createORCSchema(types[0], types);
+  expect(schema.fields[0].type).toMatchObject({type: 'map'});
+  expect(schema.fields[1].type).toMatchObject({type: 'struct'});
+  expect(
+    getORCDataType(ORCTypeKind.LIST, {kind: ORCTypeKind.LIST, fieldNames: [], subtypes: [5]}, types)
+  ).toMatchObject({type: 'list'});
 });
 
 test('ORCSource rejects unsupported predicates before reading the source', async () => {

--- a/modules/orc/test/orc-loader.spec.ts
+++ b/modules/orc/test/orc-loader.spec.ts
@@ -7,8 +7,27 @@ import * as arrow from 'apache-arrow';
 import {deflateSync, zlibSync} from 'fflate';
 import {SnappyCompression} from '@loaders.gl/compression/snappy-compression';
 import {ORCLoaderWithParser} from '../src/orc-loader';
+import {ORCSource} from '../src/orc-source-loader';
 import {ORCWriter} from '../src/orc-writer';
 import {decompressORCStream, preloadORCCompression} from '../src/lib/parsers/orc-compression';
+
+test('ORCSource exposes footer metadata and shared projection/limit reads', async () => {
+  const input = {
+    shape: 'arrow-table' as const,
+    data: arrow.tableFromArrays({name: ['a', 'b', 'a', 'b']})
+  };
+  const encoded = await ORCWriter.encode(input);
+  const source = new ORCSource(new Blob([encoded]));
+
+  const metadata = await source.getQueryMetadata();
+  expect(metadata.sourceType).toBe('orc');
+  expect(metadata.columns.map(column => column.name)).toEqual(['name']);
+  expect(metadata.statistics?.rowCount).toBe(4);
+
+  const result = await source.query({columns: ['name'], limit: 1});
+  expect(result.data.schema.fields.map(field => field.name)).toEqual(['name']);
+  expect(result.data.getChild('name')?.toArray()).toEqual(['a']);
+});
 
 test('ORCLoader#parse decodes dictionary-encoded string columns', async () => {
   const indexes = Uint8Array.from([0xfd, 0x00, 0x01, 0x00]);

--- a/modules/orc/test/orc-loader.spec.ts
+++ b/modules/orc/test/orc-loader.spec.ts
@@ -29,6 +29,49 @@ test('ORCSource exposes footer metadata and shared projection/limit reads', asyn
   expect(result.data.getChild('name')?.toArray()).toEqual(['a']);
 });
 
+test('ORCSource rejects unsupported predicates before reading the source', async () => {
+  const source = new ORCSource(new Blob([new Uint8Array([0])]));
+  await expect(source.query({predicate: {type: 'literal', value: true} as never})).rejects.toThrow(
+    'ORC predicates are not implemented yet'
+  );
+});
+
+test('ORCSource validates query limits before decoding rows', async () => {
+  const input = {
+    shape: 'arrow-table' as const,
+    data: arrow.tableFromArrays({name: ['a', 'b']})
+  };
+  const encoded = await ORCWriter.encode(input);
+  const source = new ORCSource(new Blob([encoded]));
+  await expect(source.query({limit: -1})).rejects.toThrow('non-negative safe integer');
+});
+
+test('ORCSource clears failed URL fetches so a retry can succeed', async () => {
+  const input = {
+    shape: 'arrow-table' as const,
+    data: arrow.tableFromArrays({name: ['a']})
+  };
+  const encoded = await ORCWriter.encode(input);
+  let attempts = 0;
+  const source = new ORCSource('https://example.com/data.orc', {
+    core: {
+      loadOptions: {
+        core: {
+          fetch: async () => {
+            attempts++;
+            if (attempts === 1) throw new Error('temporary failure');
+            return new Response(encoded);
+          }
+        }
+      }
+    }
+  });
+  await expect(source.getQueryMetadata()).rejects.toThrow('temporary failure');
+  const metadata = await source.getQueryMetadata();
+  expect(metadata.statistics?.rowCount).toBe(1);
+  expect(attempts).toBe(2);
+});
+
 test('ORCLoader#parse decodes dictionary-encoded string columns', async () => {
   const indexes = Uint8Array.from([0xfd, 0x00, 0x01, 0x00]);
   const lengths = Uint8Array.from([0xfe, 0x01, 0x02]);

--- a/modules/orc/test/orc-loader.spec.ts
+++ b/modules/orc/test/orc-loader.spec.ts
@@ -7,7 +7,7 @@ import * as arrow from 'apache-arrow';
 import {deflateSync, zlibSync} from 'fflate';
 import {SnappyCompression} from '@loaders.gl/compression/snappy-compression';
 import {ORCLoaderWithParser} from '../src/orc-loader';
-import {ORCSource} from '../src/orc-source-loader';
+import {ORCSource, ORCSourceLoaderWithParser} from '../src/orc-source-loader';
 import {ORCWriter} from '../src/orc-writer';
 import {decompressORCStream, preloadORCCompression} from '../src/lib/parsers/orc-compression';
 
@@ -27,6 +27,18 @@ test('ORCSource exposes footer metadata and shared projection/limit reads', asyn
   const result = await source.query({columns: ['name'], limit: 1});
   expect(result.data.schema.fields.map(field => field.name)).toEqual(['name']);
   expect(result.data.getChild('name')?.toArray()).toEqual(['a']);
+
+  const defaultQuery = await source.query({limit: 2});
+  expect(defaultQuery.data.numRows).toBe(2);
+  const batches = source.read({limit: 1});
+  const batch = await batches[Symbol.asyncIterator]().next();
+  expect(batch.value?.length).toBe(1);
+});
+
+test('ORC source loader exposes explicit parser entry points', () => {
+  expect(ORCSourceLoaderWithParser.testURL('https://example.com/file.orc')).toBe(true);
+  expect(ORCSourceLoaderWithParser.testURL('https://example.com/file.txt')).toBe(false);
+  expect(ORCSourceLoaderWithParser.createDataSource(new Blob())).toBeInstanceOf(ORCSource);
 });
 
 test('ORCSource rejects unsupported predicates before reading the source', async () => {


### PR DESCRIPTION
## Goals

Advance the format-support-first scan roadmap with the first ORC source adapter and footer-driven query discovery.

## Changes

- Add `ORCSourceLoader` and `ORCSource` to `@loaders.gl/orc`.
- Discover ORC schema, row count, byte length, and capabilities from the footer without decoding stripes.
- Expose projection, global limit, bounded Arrow batch reads, and source cancellation checks.
- Mark predicates as unsupported until ORC stripe statistics and residual filtering are implemented, avoiding overclaiming pushdown.
- Add focused metadata and query tests using writer-generated ORC fixtures.

## Verification

- `yarn lint fix`
- `yarn build`
- `yarn test-headless modules/orc/test/orc-loader.spec.ts`
- `git diff --check`

The build retains existing unrelated bundler warnings.