### PR TITLE
feat(gltf): broaden Mesh Arrow primitive coverage

### DIFF
--- a/docs/modules/gltf/api-reference/gltf-loader.md
+++ b/docs/modules/gltf/api-reference/gltf-loader.md
@@ -61,6 +61,13 @@ const gltf = await load(url, GLTFLoader);
 const meshArrow = convertGLTFToMeshArrow(gltf);
 ```
 
+The result separates reusable source geometries from scene placements. Each geometry contains one
+Arrow table per mesh primitive plus the original attribute component types and normalization
+metadata; each placement identifies the source node and its world transform. All glTF primitive
+attributes are projected as columns, including normals, tangents, texture coordinates, colors,
+joints, and weights. Standard glTF point, line, and triangle modes are represented by the table's
+`topology` metadata. The converter does not modify the input JSON or buffers.
+
 Optionally, the loaded gltf can be "post processed", which lightly annotates and transforms the loaded JSON structure to make it easier to use. Refer to [postProcessGLTF](post-process-gltf) for details.
 
 In addition, certain glTF extensions, including Draco and [meshopt compression](/docs/modules/gltf/formats/gltf#meshopt-compression), can be fully or partially processed during loading. When possible (and extension processing is enabled), such extensions will be resolved/decompressed and replaced with standards conformant representations.

--- a/modules/gltf/src/lib/api/gltf-mesh-arrow.ts
+++ b/modules/gltf/src/lib/api/gltf-mesh-arrow.ts
@@ -389,10 +389,18 @@ function getMeshTopology(mode: number): MeshArrowTable['topology'] {
   switch (mode) {
     case 0:
       return 'point-list';
+    case 1:
+      return 'line-list';
+    case 3:
+      return 'line-strip';
+    case 2:
+      return 'line-loop';
     case 4:
       return 'triangle-list';
     case 5:
       return 'triangle-strip';
+    case 6:
+      return 'triangle-fan';
     default:
       throw new Error(`glTF primitive mode ${mode} is not supported by Mesh Arrow`);
   }

--- a/modules/gltf/test/lib/api/gltf-mesh-arrow.cross.spec.ts
+++ b/modules/gltf/test/lib/api/gltf-mesh-arrow.cross.spec.ts
@@ -133,6 +133,33 @@ describe('convertGLTFToMeshArrow', () => {
     expect(geometries[0].table.topology).toBe('point-list');
     expect(geometries[0].table.schema.metadata.mode).toBe('0');
   });
+
+  test.each([
+    [1, 'line-list'],
+    [2, 'line-loop'],
+    [3, 'line-strip'],
+    [4, 'triangle-list'],
+    [5, 'triangle-strip'],
+    [6, 'triangle-fan']
+  ] as const)('maps glTF primitive mode %s to %s', (mode, topology) => {
+    const {gltf} = makeGLTF();
+    gltf.json.meshes![0].primitives[0].mode = mode;
+
+    const {geometries} = convertGLTFToMeshArrow(gltf);
+
+    expect(geometries[0].table.topology).toBe(topology);
+  });
+
+  test('projects non-position vertex attributes into Arrow columns', () => {
+    const {gltf} = makeGLTF();
+    gltf.json.meshes![0].primitives[0].attributes.NORMAL = 2;
+    gltf.json.accessors!.push({bufferView: 0, componentType: 5126, count: 2, type: 'VEC3'});
+
+    const {geometries} = convertGLTFToMeshArrow(gltf);
+
+    expect(geometries[0].attributes.NORMAL.size).toBe(3);
+    expect(geometries[0].table.data.getChild('NORMAL')).toBeDefined();
+  });
 });
 
 /** Create a small indexed glTF scene with a translated root and scaled mesh node. */

--- a/modules/schema-utils/src/lib/mesh/convert-mesh-to-table.ts
+++ b/modules/schema-utils/src/lib/mesh/convert-mesh-to-table.ts
@@ -28,7 +28,14 @@ export type MeshArrowTableOptions = {
   /** Schema describing the mesh attributes and metadata. */
   schema?: Schema;
   /** Mesh primitive topology represented by the table rows. */
-  topology?: 'point-list' | 'triangle-list' | 'triangle-strip';
+  topology?:
+    | 'point-list'
+    | 'line-list'
+    | 'line-loop'
+    | 'line-strip'
+    | 'triangle-list'
+    | 'triangle-strip'
+    | 'triangle-fan';
   /** Numeric draw mode associated with the mesh topology. */
   mode?: number;
   /** Optional mesh bounding box metadata. */

--- a/modules/schema/src/categories/category-mesh.ts
+++ b/modules/schema/src/categories/category-mesh.ts
@@ -10,7 +10,7 @@ import * as arrow from 'apache-arrow';
 /** Mesh as columnar table */
 export interface MeshTable extends ColumnarTable {
   // shape: 'mesh-table';
-  topology: 'point-list' | 'triangle-list' | 'triangle-strip';
+  topology: MeshTopology;
   indices?: MeshAttribute;
 }
 
@@ -18,7 +18,7 @@ export interface MeshTable extends ColumnarTable {
 export interface MeshArrowTable extends ArrowTable {
   // shape: 'mesh-arrow-table';
   /** Mesh topology represented by the Arrow table rows and indices. */
-  topology: 'point-list' | 'triangle-list' | 'triangle-strip';
+  topology: MeshTopology;
   /** Optional top-level primitive indices accessor for indexed meshes. */
   indices?: MeshAttribute;
   /** Raw Apache Arrow table data for Mesh or IndexedMesh columns. */
@@ -32,6 +32,16 @@ export type MeshArrowColumns = {
   /** Loader-specific vertex attribute columns appended after predefined fields. */
   [attributeName: string]: arrow.DataType;
 };
+
+/** Primitive topology names shared by columnar and Arrow mesh representations. */
+export type MeshTopology =
+  | 'point-list'
+  | 'line-list'
+  | 'line-loop'
+  | 'line-strip'
+  | 'triangle-list'
+  | 'triangle-strip'
+  | 'triangle-fan';
 
 /** Apache Arrow columns for an indexed mesh vertex table. */
 export type IndexedMeshArrowColumns = MeshArrowColumns & {
@@ -68,7 +78,7 @@ export const indexedMeshArrowSchema = new arrow.Schema<IndexedMeshArrowColumns>(
 export type MeshGeometry = {
   attributes: {[attributeName: string]: MeshAttribute};
   indices?: MeshAttribute;
-  topology: 'point-list' | 'triangle-list' | 'triangle-strip';
+  topology: MeshTopology;
   mode: number;
 };
 

--- a/modules/schema/src/index.ts
+++ b/modules/schema/src/index.ts
@@ -49,7 +49,8 @@ export type {
   Mesh,
   MeshGeometry,
   MeshAttribute,
-  MeshAttributes
+  MeshAttributes,
+  MeshTopology
 } from './categories/category-mesh';
 export {meshArrowSchema, indexedMeshArrowSchema} from './categories/category-mesh';
 


### PR DESCRIPTION
## Goals
- Stabilize the Mesh Arrow converter contract for downstream consumers.
- Cover the complete standard glTF primitive-mode set and common vertex attributes.

## Changes
- Add documented geometry/placement and attribute-column contract to the glTF loader docs.
- Extend Mesh topology types with line list/loop/strip and triangle fan.
- Map all standard glTF primitive modes in `convertGLTFToMeshArrow()`.
- Add coverage for non-POSITION attributes and every primitive mode.

## Validation
- `yarn lint fix`
- focused `yarn test-node modules/gltf/test/lib/api/gltf-mesh-arrow.cross.spec.ts` (16 tests)
- `yarn build`