### PR TITLE
feat(website): improve examples data exploration

### DIFF
--- a/docs/modules/json/api-reference/ndgeojson-loader.md
+++ b/docs/modules/json/api-reference/ndgeojson-loader.md
@@ -17,12 +17,11 @@ Streaming loader for NDJSON encoded files and related formats (LDJSON and JSONL)
 | File Extension | `.ndgeojson`, `.geojsonl`, `.ldgeojson`                                            |
 | Media Type     | `application/geo+x-ndjson`, `application/geo+x-ldjson`, `application/geo+json-seq` |
 | File Type      | Text                                                                               |
-| File Format    | [NDJSON][format_ndjson], [LDJSON][format_], [][format_]                            |
+| File Format    | [NDJSON][format_ndjson], [LDJSON][format_ldjson], [JSON Text Sequences][format_geojsonseq] |
 | Data Format    | [Classic Table](/docs/specifications/category-table)                               |
 | Supported APIs | `load`, `parse`, `parseSync`, `parseInBatches`                                     |
 
 [format_geojsonl]: https://www.placemark.io/documentation/geojsonl
-
-[format_geojsonseq]:
-[format_ldjson]: http://ndjson.org/
-[format_jsonjson]: http://ndjson.org/
+[format_ndjson]: http://ndjson.org/
+[format_ldjson]: http://jsonlines.org/
+[format_geojsonseq]: https://datatracker.ietf.org/doc/html/rfc7464

--- a/examples/website/geospatial/app.tsx
+++ b/examples/website/geospatial/app.tsx
@@ -14,6 +14,8 @@ import {GeoJsonLayer} from '@deck.gl/layers';
 import {ColumnPanel, CustomPanel, SidebarWidget} from '@deck.gl-community/widgets';
 import {GeoArrowLayer} from '@loaders.gl/deck-layers';
 import {createDeckFullscreenWidget, createDeckStatsWidget} from '../shared/create-deck-stats-widget';
+import {createExampleSourcePanel, type ExampleSource} from '../shared/example-source-picker';
+import {getExampleDevicePixelRatio, getExampleRowLimit} from '../shared/example-performance';
 
 // import {FileUploader} from './components/file-uploader';
 
@@ -49,7 +51,7 @@ export const INITIAL_MAP_STYLE =
 const LOADER_OPTIONS = {
   core: {
     worker: false,
-    limit: 1800000
+    limit: getExampleRowLimit()
   },
   modules: {
     'zstd-codec': ZstdCodec
@@ -223,6 +225,14 @@ export default function App(props: AppProps = {}) {
           id: 'geospatial-example-panel',
           title: getLoaderDisplayName(state.selectedCategoryName, tableFormat),
           panels: {
+            source: createExampleSourcePanel({
+              surface: 'geospatial',
+              selectedLabel: getExampleSourceName(state.selectedExample, state.selectedExampleName),
+              selectedUrl: typeof state.selectedExample?.data === 'string' ? state.selectedExample.data : undefined,
+              onSourceChange: (source) => {
+                void loadExampleSource(source);
+              }
+            }),
             controls: new CustomPanel({
               id: 'geospatial-example-controls',
               title: '',
@@ -280,6 +290,7 @@ export default function App(props: AppProps = {}) {
   return (
     <div style={{position: 'relative', height: '100%'}}>
       <DeckGL
+        useDevicePixels={getExampleDevicePixelRatio()}
         layers={renderLayer(state)}
         viewState={state.viewState}
         onViewStateChange={({viewState}) => setState((state) => ({...state, viewState}))}
@@ -352,6 +363,27 @@ export default function App(props: AppProps = {}) {
         loadDurationSeconds: null
       }));
     }
+  }
+
+  async function loadExampleSource(source: ExampleSource): Promise<void> {
+    const formatToCategory: Record<string, string> = {
+      CSV: 'CSV',
+      GeoArrow: 'GeoArrow',
+      GeoJSON: 'GeoJSON',
+      GeoPackage: 'GeoPackage',
+      GeoParquet: 'GeoParquet',
+      FlatGeobuf: 'FlatGeobuf',
+      KML: 'KML',
+      GPX: 'GPX',
+      TCX: 'TCX',
+      Auto: 'GeoJSON'
+    };
+    const categoryName = formatToCategory[source.format] || 'GeoJSON';
+    const example: Example = {
+      format: source.format.toLowerCase() as Example['format'],
+      data: source.value
+    };
+    await loadExample(categoryName, source.label, example, tableFormat);
   }
 }
 
@@ -1097,6 +1129,10 @@ function getExampleSourceName(
   const sourceUrl = selectedExample?.data;
   if (!sourceUrl) {
     return selectedExampleName || 'dataset';
+  }
+
+  if (typeof File !== 'undefined' && sourceUrl instanceof File) {
+    return sourceUrl.name;
   }
 
   if (sourceUrl.startsWith('data:')) {

--- a/examples/website/geospatial/app.tsx
+++ b/examples/website/geospatial/app.tsx
@@ -14,7 +14,11 @@ import {GeoJsonLayer} from '@deck.gl/layers';
 import {ColumnPanel, CustomPanel, SidebarWidget} from '@deck.gl-community/widgets';
 import {GeoArrowLayer} from '@loaders.gl/deck-layers';
 import {createDeckFullscreenWidget, createDeckStatsWidget} from '../shared/create-deck-stats-widget';
-import {createExampleSourcePanel, type ExampleSource} from '../shared/example-source-picker';
+import {
+  createExampleSourcePanel,
+  getExampleSourceFromUrl,
+  type ExampleSource
+} from '../shared/example-source-picker';
 import {getExampleDevicePixelRatio, getExampleRowLimit} from '../shared/example-performance';
 
 // import {FileUploader} from './components/file-uploader';
@@ -167,6 +171,12 @@ export default function App(props: AppProps = {}) {
   });
 
   useEffect(() => {
+    const shareableSource = getExampleSourceFromUrl('geospatial');
+    if (shareableSource) {
+      void loadExampleSource(shareableSource);
+      return;
+    }
+
     const initialCategoryName = props.format || INITIAL_LOADER_NAME;
     const initialExamples = availableExamples[initialCategoryName];
     if (!initialExamples) {
@@ -385,6 +395,7 @@ export default function App(props: AppProps = {}) {
       KML: 'KML',
       GPX: 'GPX',
       TCX: 'TCX',
+      Shapefile: 'Shapefile',
       Auto: 'GeoJSON'
     };
     const categoryName = formatToCategory[source.format] || 'GeoJSON';

--- a/examples/website/geospatial/app.tsx
+++ b/examples/website/geospatial/app.tsx
@@ -31,7 +31,7 @@ import {
   type GeoArrowEncoding,
   type GeoArrowMetadata
 } from '@loaders.gl/geoarrow';
-import {GeoParquetLoader, preloadCompressions} from '@loaders.gl/parquet';
+import {GeoParquetLoader, ParquetLoader, preloadCompressions} from '@loaders.gl/parquet';
 import {FlatGeobufLoader} from '@loaders.gl/flatgeobuf';
 import {GeoPackageLoader} from '@loaders.gl/geopackage';
 import {ShapefileLoader} from '@loaders.gl/shapefile';
@@ -91,6 +91,7 @@ const LOADER_OPTIONS = {
 } as const;
 
 type TableFormat = 'geojson' | 'geoarrow';
+type ParquetLoaderName = 'parquet' | 'geoparquet';
 type LoadedDataName = 'geojson' | 'geoarrow';
 type LoadedGeometryType = GeoArrowEncoding | string | null;
 
@@ -145,6 +146,7 @@ type AppState = {
  */
 export default function App(props: AppProps = {}) {
   const [tableFormat, setTableFormat] = useState<TableFormat>('geoarrow');
+  const [parquetLoaderName, setParquetLoaderName] = useState<ParquetLoaderName>('parquet');
   const previousTableFormat = useRef(tableFormat);
   const loadRequestIdRef = useRef(0);
   const availableExamples = useMemo(
@@ -183,9 +185,10 @@ export default function App(props: AppProps = {}) {
       initialCategoryName,
       initialExampleName,
       initialExample,
-      previousTableFormat.current
+      previousTableFormat.current,
+      parquetLoaderName
     );
-  }, [availableExamples, props.format]);
+  }, [availableExamples, parquetLoaderName, props.format]);
 
   useEffect(() => {
     const formatChanged = previousTableFormat.current !== tableFormat;
@@ -205,7 +208,8 @@ export default function App(props: AppProps = {}) {
     state.selectedCategoryName,
     state.selectedExample,
     state.selectedExampleName,
-    tableFormat
+    tableFormat,
+    parquetLoaderName
   ]);
 
   const widgets = useMemo(() => {
@@ -223,7 +227,7 @@ export default function App(props: AppProps = {}) {
         widthPx: 420,
         panel: new ColumnPanel({
           id: 'geospatial-example-panel',
-          title: getLoaderDisplayName(state.selectedCategoryName, tableFormat),
+            title: getLoaderDisplayName(state.selectedCategoryName, tableFormat, parquetLoaderName),
           panels: {
             source: createExampleSourcePanel({
               surface: 'geospatial',
@@ -242,13 +246,14 @@ export default function App(props: AppProps = {}) {
                   selectedCategoryName: state.selectedCategoryName,
                   selectedExampleName: state.selectedExampleName,
                   tableFormat,
+                  parquetLoaderName,
                   activeLayerName: getActiveLayerName(state.table),
                   sourceName: getExampleSourceName(state.selectedExample, state.selectedExampleName),
                   loadedDataName: state.loadedDataName,
                   loadedGeometryType: state.loadedGeometryType,
-                  rowCount: state.table ? getTableLength(state.table) : null,
+                  rowCount: getTableRowCount(state.table),
                   loadDurationSeconds: state.loadDurationSeconds,
-                  loading: state.loading,
+                  loading: Boolean(state.loading),
                   error: state.error,
                   schema: state.table?.schema ? JSON.stringify(state.table.schema, null, 2) : null,
                   viewState: state.viewState,
@@ -259,11 +264,13 @@ export default function App(props: AppProps = {}) {
                         categoryName,
                         exampleName,
                         example,
-                        tableFormat
+                        tableFormat,
+                        parquetLoaderName
                       );
                     }
                   },
-                  onTableFormatChange: setTableFormat
+                  onTableFormatChange: setTableFormat,
+                  onParquetLoaderChange: setParquetLoaderName
                 })
             })
           }
@@ -284,7 +291,8 @@ export default function App(props: AppProps = {}) {
     state.table?.shape,
     state.table?.schema,
     state.viewState,
-    tableFormat
+    tableFormat,
+    parquetLoaderName
   ]);
 
   return (
@@ -306,11 +314,12 @@ export default function App(props: AppProps = {}) {
     categoryName: string,
     exampleName: string,
     example: Example,
-    nextTableFormat: TableFormat
+    nextTableFormat: TableFormat,
+    nextParquetLoaderName: ParquetLoaderName
   ) {
     const url = example.data;
     const loaderOptions = getLoaderOptions(example, nextTableFormat);
-    const loaders = getLoaders(example, nextTableFormat);
+    const loaders = getLoaders(example, nextTableFormat, nextParquetLoaderName);
     const requestId = ++loadRequestIdRef.current;
     const loadStartTime = performance.now();
 
@@ -383,11 +392,15 @@ export default function App(props: AppProps = {}) {
       format: source.format.toLowerCase() as Example['format'],
       data: source.value
     };
-    await loadExample(categoryName, source.label, example, tableFormat);
+    await loadExample(categoryName, source.label, example, tableFormat, parquetLoaderName);
   }
 }
 
-function getLoaders(example: Example, tableFormat: TableFormat) {
+function getLoaders(
+  example: Example,
+  tableFormat: TableFormat,
+  parquetLoaderName: ParquetLoaderName
+) {
   if (tableFormat === 'geojson') {
     switch (example.format) {
       case 'geopackage':
@@ -407,7 +420,7 @@ function getLoaders(example: Example, tableFormat: TableFormat) {
       case 'flatgeobuf':
         return [FlatGeobufLoader];
       case 'geoparquet':
-        return [GeoParquetLoader];
+        return [parquetLoaderName === 'parquet' ? ParquetLoader : GeoParquetLoader];
       case 'geoarrow':
         return [GeoArrowLoader];
       default:
@@ -433,7 +446,7 @@ function getLoaders(example: Example, tableFormat: TableFormat) {
     case 'flatgeobuf':
       return [FlatGeobufLoader];
     case 'geoparquet':
-      return [GeoParquetLoader];
+      return [parquetLoaderName === 'parquet' ? ParquetLoader : GeoParquetLoader];
     case 'geoarrow':
       return [GeoArrowLoader];
     default:
@@ -523,13 +536,14 @@ function convertWKBArrowTableToGeoJSON(table: Table): Table {
 
 function getLoaderDisplayName(
   selectedCategoryName?: string | null,
-  tableFormat: TableFormat = 'geojson'
+  tableFormat: TableFormat = 'geojson',
+  parquetLoaderName: ParquetLoaderName = 'parquet'
 ): string {
   switch (selectedCategoryName) {
     case 'GeoArrow':
       return 'GeoArrowLoader';
     case 'GeoParquet':
-      return 'GeoParquetLoader';
+      return parquetLoaderName === 'parquet' ? 'ParquetLoader' : 'GeoParquetLoader';
     case 'GeoJSON':
       return 'GeoJSONLoader';
     case 'CSV':
@@ -831,6 +845,17 @@ function getExamplesForFormat(
   return {...examples};
 }
 
+function getTableRowCount(table: Table | null): number | null {
+  if (!table) {
+    return null;
+  }
+  try {
+    return getTableLength(table);
+  } catch {
+    return null;
+  }
+}
+
 function renderGeospatialSidebar(
   rootElement: HTMLElement,
   options: {
@@ -838,6 +863,7 @@ function renderGeospatialSidebar(
     selectedCategoryName?: string | null;
     selectedExampleName?: string | null;
     tableFormat: TableFormat;
+    parquetLoaderName: ParquetLoaderName;
     activeLayerName: string;
     sourceName: string;
     loadedDataName: LoadedDataName;
@@ -850,6 +876,7 @@ function renderGeospatialSidebar(
     viewState: Record<string, unknown>;
     onExampleChange: (selection: {categoryName: string; exampleName: string}) => void;
     onTableFormatChange: (tableFormat: TableFormat) => void;
+    onParquetLoaderChange: (loaderName: ParquetLoaderName) => void;
   }
 ): void {
   rootElement.replaceChildren();
@@ -868,8 +895,10 @@ function renderGeospatialSidebar(
       selectedCategoryName: options.selectedCategoryName,
       selectedExampleName: options.selectedExampleName,
       tableFormat: options.tableFormat,
+      parquetLoaderName: options.parquetLoaderName,
       onExampleChange: options.onExampleChange,
-      onTableFormatChange: options.onTableFormatChange
+      onTableFormatChange: options.onTableFormatChange,
+      onParquetLoaderChange: options.onParquetLoaderChange
     })
   );
 
@@ -908,8 +937,10 @@ function createSelectSection(options: {
   selectedCategoryName?: string | null;
   selectedExampleName?: string | null;
   tableFormat: TableFormat;
+  parquetLoaderName: ParquetLoaderName;
   onExampleChange: (selection: {categoryName: string; exampleName: string}) => void;
   onTableFormatChange: (tableFormat: TableFormat) => void;
+  onParquetLoaderChange: (loaderName: ParquetLoaderName) => void;
 }): HTMLElement {
   const section = createSection();
   section.appendChild(createLabel('Dataset'));
@@ -972,6 +1003,35 @@ function createSelectSection(options: {
 
   formatSelectElement.value = options.tableFormat;
   section.appendChild(formatSelectElement);
+
+  if (options.selectedCategoryName === 'GeoParquet') {
+    const loaderDetailsElement = document.createElement('details');
+    const loaderSummaryElement = document.createElement('summary');
+    loaderSummaryElement.textContent = 'Loader options';
+    loaderSummaryElement.style.cursor = 'pointer';
+    loaderSummaryElement.style.fontSize = '11px';
+    loaderDetailsElement.appendChild(loaderSummaryElement);
+    const loaderSelectElement = document.createElement('select');
+    loaderSelectElement.style.width = '100%';
+    loaderSelectElement.style.marginTop = '6px';
+    loaderSelectElement.style.padding = '4px 6px';
+    loaderSelectElement.style.fontSize = '11px';
+    loaderSelectElement.addEventListener('change', event => {
+      options.onParquetLoaderChange((event.target as HTMLSelectElement).value as ParquetLoaderName);
+    });
+    for (const [value, label] of [
+      ['parquet', 'ParquetLoader (TypeScript)'],
+      ['geoparquet', 'GeoParquetLoader']
+    ] as const) {
+      const optionElement = document.createElement('option');
+      optionElement.value = value;
+      optionElement.textContent = label;
+      loaderSelectElement.appendChild(optionElement);
+    }
+    loaderSelectElement.value = options.parquetLoaderName;
+    loaderDetailsElement.appendChild(loaderSelectElement);
+    section.appendChild(loaderDetailsElement);
+  }
   return section;
 }
 
@@ -1133,6 +1193,10 @@ function getExampleSourceName(
 
   if (typeof File !== 'undefined' && sourceUrl instanceof File) {
     return sourceUrl.name;
+  }
+
+  if (typeof sourceUrl !== 'string') {
+    return selectedExampleName || 'dataset';
   }
 
   if (sourceUrl.startsWith('data:')) {

--- a/examples/website/geospatial/examples.ts
+++ b/examples/website/geospatial/examples.ts
@@ -26,10 +26,8 @@ export type Example = {
   }) => null | {title: string; properties: Record<string, unknown>};
 };
 
-export const INITIAL_LOADER_NAME = 'GeoParquet';
-export const INITIAL_EXAMPLE_NAME = 'Airports';
-// export const INITIAL_LOADER_NAME = 'GeoJSON';
-// export const INITIAL_EXAMPLE_NAME = 'Vancouver';
+export const INITIAL_LOADER_NAME = 'GeoJSON';
+export const INITIAL_EXAMPLE_NAME = 'Countries';
 
 export const LOADERS_URL = 'https://raw.githubusercontent.com/visgl/loaders.gl/master';
 const DECKGL_DATA_URL = 'https://raw.githubusercontent.com/visgl/deck.gl-data/master';
@@ -233,7 +231,7 @@ export const EXAMPLES: Record<string, Record<string, Example>> = {
     },
     Countries: {
       format: 'geojson',
-      data: `${LOADERS_URL}/modules/geojson/test/data/countries.json`,
+      data: 'https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_50m_admin_0_scale_rank.geojson',
       viewState: {longitude: -4.65, latitude: -29.76, zoom: 1.76}
     }
   },

--- a/examples/website/geospatial/examples.ts
+++ b/examples/website/geospatial/examples.ts
@@ -122,7 +122,7 @@ export const EXAMPLES: Record<string, Record<string, Example>> = {
   GeoParquet: {
     Airports: {
       format: 'geoparquet',
-      data: `${LOADERS_URL}/modules/parquet/test/data/geoparquet/airports.parquet`,
+      data: 'https://github.com/visgl/loaders.gl/raw/refs/heads/master/modules/parquet/test/data/geoparquet/airports.parquet',
       viewState: {longitude: -4.65, latitude: -29.76, zoom: 1.76}
     },
     'Countries (zstd)': {

--- a/examples/website/geospatial/examples.ts
+++ b/examples/website/geospatial/examples.ts
@@ -14,7 +14,7 @@ export type Example = {
     | 'tcx'
     | 'gpx'
     | 'csv';
-  data: string;
+  data: string | File;
   attributions?: string[];
   viewState?: Record<string, unknown>;
   tileSize?: number[];

--- a/examples/website/pointcloud/app.tsx
+++ b/examples/website/pointcloud/app.tsx
@@ -30,6 +30,8 @@ import {PLYLoader} from '@loaders.gl/ply';
 import type {Example} from './examples';
 import {EXAMPLES} from './examples';
 import {createDeckFullscreenWidget, createDeckStatsWidget} from '../shared/create-deck-stats-widget';
+import {createExampleSourcePanel, type ExampleSource} from '../shared/example-source-picker';
+import {getExampleDevicePixelRatio} from '../shared/example-performance';
 import '@deck.gl/widgets/stylesheet.css';
 
 const POINT_CLOUD_LOADERS = [DracoLoader, LASLoader, PLYLoader, PCDLoader, OBJLoader] as const;
@@ -160,6 +162,16 @@ export default function App(props: AppProps = {}) {
           id: 'pointcloud-example-panel',
           title: '',
           panels: {
+            source: createExampleSourcePanel({
+              surface: 'pointcloud',
+              selectedLabel: state.selectedExampleName || undefined,
+              selectedUrl: typeof getSelectedUrl(availableExamples, state.selectedCategoryName, state.selectedExampleName) === 'string'
+                ? getSelectedUrl(availableExamples, state.selectedCategoryName, state.selectedExampleName) as string
+                : undefined,
+              onSourceChange: (source) => {
+                void loadExampleSource(source);
+              }
+            }),
             controls: new CustomPanel({
               id: 'pointcloud-example-controls',
               title: '',
@@ -221,6 +233,7 @@ export default function App(props: AppProps = {}) {
   return (
     <div style={{position: 'relative', height: '100%'}}>
       <DeckGL
+        useDevicePixels={getExampleDevicePixelRatio()}
         key={state.controllerMode}
         layers={layers}
         views={getViewForControllerMode(state.controllerMode)}
@@ -255,6 +268,24 @@ export default function App(props: AppProps = {}) {
             } as OrbitViewState)
           : currentState.viewState
     }));
+  }
+
+  async function loadExampleSource(source: ExampleSource): Promise<void> {
+    const formatToType: Record<string, Example['type']> = {
+      PLY: 'ply',
+      LAS: 'las',
+      LAZ: 'las',
+      Draco: 'draco',
+      PCD: 'pcd',
+      OBJ: 'obj',
+      Auto: 'ply'
+    };
+    const type = formatToType[source.format] || 'ply';
+    await onExampleChange({
+      categoryName: source.format,
+      exampleName: source.label,
+      example: {type, url: source.value}
+    });
   }
 
   async function onExampleChange({
@@ -884,7 +915,8 @@ function getSelectedUrl(
   if (!selectedCategoryName || !selectedExampleName) {
     return '';
   }
-  return examples[selectedCategoryName]?.[selectedExampleName]?.url || '';
+  const selectedUrl = examples[selectedCategoryName]?.[selectedExampleName]?.url;
+  return typeof selectedUrl === 'string' ? selectedUrl : '';
 }
 
 function getFileNameFromUrl(url: string): string {

--- a/examples/website/pointcloud/app.tsx
+++ b/examples/website/pointcloud/app.tsx
@@ -30,7 +30,11 @@ import {PLYLoader} from '@loaders.gl/ply';
 import type {Example} from './examples';
 import {EXAMPLES} from './examples';
 import {createDeckFullscreenWidget, createDeckStatsWidget} from '../shared/create-deck-stats-widget';
-import {createExampleSourcePanel, type ExampleSource} from '../shared/example-source-picker';
+import {
+  createExampleSourcePanel,
+  getExampleSourceFromUrl,
+  type ExampleSource
+} from '../shared/example-source-picker';
 import {getExampleDevicePixelRatio} from '../shared/example-performance';
 import '@deck.gl/widgets/stylesheet.css';
 
@@ -109,6 +113,12 @@ export default function App(props: AppProps = {}) {
   const loadRequestId = useRef(0);
 
   useEffect(() => {
+    const shareableSource = getExampleSourceFromUrl('pointcloud');
+    if (shareableSource) {
+      void loadExampleSource(shareableSource);
+      return;
+    }
+
     if (props.example) {
       void onExampleChange({
         categoryName: props.categoryName || props.format || 'URL',

--- a/examples/website/pointcloud/examples.ts
+++ b/examples/website/pointcloud/examples.ts
@@ -4,7 +4,7 @@
 
 export type Example = {
   type: 'las' | 'draco' | 'pcd' | 'ply' | 'obj';
-  url: string;
+  url: string | File;
   urls?: string[];
   pointCount?: number;
   initialExample?: boolean;

--- a/examples/website/shared/example-catalog.ts
+++ b/examples/website/shared/example-catalog.ts
@@ -42,7 +42,7 @@ export const CURATED_EXAMPLES: readonly CuratedExample[] = [
     id: 'geoparquet-airports',
     label: 'Airports in GeoParquet',
     format: 'GeoParquet',
-    url: 'https://raw.githubusercontent.com/visgl/loaders.gl/master/modules/parquet/test/data/geoparquet/airports.parquet',
+    url: 'https://github.com/visgl/loaders.gl/raw/refs/heads/master/modules/parquet/test/data/geoparquet/airports.parquet',
     surface: 'geospatial',
     description: 'A columnar point dataset that demonstrates GeoParquet.',
     mobileSafe: true
@@ -86,4 +86,3 @@ export function getCuratedExamples(surface: ExampleSurface): CuratedExample[] {
 export function getCuratedExample(id: string | null): CuratedExample | null {
   return CURATED_EXAMPLES.find(example => example.id === id) || null;
 }
-

--- a/examples/website/shared/example-catalog.ts
+++ b/examples/website/shared/example-catalog.ts
@@ -25,6 +25,8 @@ export type CuratedExample = {
   sizeBytes?: number;
   /** Whether this dataset is suitable for constrained mobile devices. */
   mobileSafe?: boolean;
+  /** Preview image path relative to the website static directory. */
+  thumbnail: string;
 };
 
 /** Small, reliable datasets selected for the public examples site. */
@@ -36,6 +38,7 @@ export const CURATED_EXAMPLES: readonly CuratedExample[] = [
     url: 'https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_50m_admin_0_scale_rank.geojson',
     surface: 'geospatial',
     description: 'A compact world map with country boundaries.',
+    thumbnail: 'images/examples/geospatial/geojson.jpg',
     mobileSafe: true
   },
   {
@@ -45,6 +48,7 @@ export const CURATED_EXAMPLES: readonly CuratedExample[] = [
     url: 'https://github.com/visgl/loaders.gl/raw/refs/heads/master/modules/parquet/test/data/geoparquet/airports.parquet',
     surface: 'geospatial',
     description: 'A columnar point dataset that demonstrates GeoParquet.',
+    thumbnail: 'images/examples/geospatial/geoparquet.jpg',
     mobileSafe: true
   },
   {
@@ -54,6 +58,7 @@ export const CURATED_EXAMPLES: readonly CuratedExample[] = [
     url: 'https://r2-public.protomaps.com/protomaps-sample-datasets/nz-buildings-v3.pmtiles',
     surface: 'tiles',
     description: 'A cloud-hosted vector tile archive loaded with range requests.',
+    thumbnail: 'images/examples/tiles/pmtiles.jpg',
     attribution: '© Land Information New Zealand',
     mobileSafe: true
   },
@@ -64,6 +69,7 @@ export const CURATED_EXAMPLES: readonly CuratedExample[] = [
     url: 'https://raw.githubusercontent.com/visgl/loaders.gl/master/modules/ply/test/data/bunny.ply',
     surface: 'pointcloud',
     description: 'A small point cloud for a fast first render.',
+    thumbnail: 'images/examples/pointclouds/ply.jpg',
     mobileSafe: true
   },
   {
@@ -73,6 +79,7 @@ export const CURATED_EXAMPLES: readonly CuratedExample[] = [
     url: 'https://raw.githubusercontent.com/visgl/deck.gl-data/master/examples/point-cloud-ply/lucy100k.ply',
     surface: 'pointcloud',
     description: 'A richer point cloud for desktop-capable devices.',
+    thumbnail: 'images/examples/pointclouds/ply.jpg',
     mobileSafe: false
   }
 ];

--- a/examples/website/shared/example-catalog.ts
+++ b/examples/website/shared/example-catalog.ts
@@ -1,0 +1,89 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** Rendering surface used by a curated example dataset. */
+export type ExampleSurface = 'geospatial' | 'tiles' | 'pointcloud';
+
+/** A curated dataset shown by the shared example source picker. */
+export type CuratedExample = {
+  /** Stable identifier used in shareable URLs. */
+  id: string;
+  /** Human-readable dataset name. */
+  label: string;
+  /** Dataset format understood by the selected example surface. */
+  format: string;
+  /** Source URL. */
+  url: string;
+  /** Surface on which the dataset can be rendered. */
+  surface: ExampleSurface;
+  /** Short description shown in the picker. */
+  description: string;
+  /** Optional attribution text. */
+  attribution?: string;
+  /** Approximate source size in bytes when known. */
+  sizeBytes?: number;
+  /** Whether this dataset is suitable for constrained mobile devices. */
+  mobileSafe?: boolean;
+};
+
+/** Small, reliable datasets selected for the public examples site. */
+export const CURATED_EXAMPLES: readonly CuratedExample[] = [
+  {
+    id: 'geojson-countries',
+    label: 'Natural Earth countries',
+    format: 'GeoJSON',
+    url: 'https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_50m_admin_0_scale_rank.geojson',
+    surface: 'geospatial',
+    description: 'A compact world map with country boundaries.',
+    mobileSafe: true
+  },
+  {
+    id: 'geoparquet-airports',
+    label: 'Airports in GeoParquet',
+    format: 'GeoParquet',
+    url: 'https://raw.githubusercontent.com/visgl/loaders.gl/master/modules/parquet/test/data/geoparquet/airports.parquet',
+    surface: 'geospatial',
+    description: 'A columnar point dataset that demonstrates GeoParquet.',
+    mobileSafe: true
+  },
+  {
+    id: 'pmtiles-new-zealand-buildings',
+    label: 'New Zealand buildings',
+    format: 'PMTiles',
+    url: 'https://r2-public.protomaps.com/protomaps-sample-datasets/nz-buildings-v3.pmtiles',
+    surface: 'tiles',
+    description: 'A cloud-hosted vector tile archive loaded with range requests.',
+    attribution: '© Land Information New Zealand',
+    mobileSafe: true
+  },
+  {
+    id: 'pointcloud-bunny',
+    label: 'Stanford bunny',
+    format: 'PLY',
+    url: 'https://raw.githubusercontent.com/visgl/loaders.gl/master/modules/ply/test/data/bunny.ply',
+    surface: 'pointcloud',
+    description: 'A small point cloud for a fast first render.',
+    mobileSafe: true
+  },
+  {
+    id: 'pointcloud-lucy',
+    label: 'Lucy 100K',
+    format: 'PLY',
+    url: 'https://raw.githubusercontent.com/visgl/deck.gl-data/master/examples/point-cloud-ply/lucy100k.ply',
+    surface: 'pointcloud',
+    description: 'A richer point cloud for desktop-capable devices.',
+    mobileSafe: false
+  }
+];
+
+/** Returns curated datasets for one rendering surface. */
+export function getCuratedExamples(surface: ExampleSurface): CuratedExample[] {
+  return CURATED_EXAMPLES.filter(example => example.surface === surface);
+}
+
+/** Finds a curated dataset by its shareable identifier. */
+export function getCuratedExample(id: string | null): CuratedExample | null {
+  return CURATED_EXAMPLES.find(example => example.id === id) || null;
+}
+

--- a/examples/website/shared/example-performance.ts
+++ b/examples/website/shared/example-performance.ts
@@ -1,0 +1,20 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** Returns a conservative deck.gl device-pixel setting for the current device. */
+export function getExampleDevicePixelRatio(): number {
+  if (typeof window === 'undefined') {
+    return 1;
+  }
+
+  const isConstrainedDevice = window.matchMedia('(max-width: 700px)').matches ||
+    /iPad|iPhone|iPod/.test(window.navigator.userAgent);
+  return isConstrainedDevice ? 1 : Math.min(window.devicePixelRatio || 1, 2);
+}
+
+/** Returns the maximum number of decoded geospatial rows for the current device. */
+export function getExampleRowLimit(): number {
+  return getExampleDevicePixelRatio() === 1 ? 500_000 : 1_800_000;
+}
+

--- a/examples/website/shared/example-source-picker.tsx
+++ b/examples/website/shared/example-source-picker.tsx
@@ -1,0 +1,172 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {createRoot, type Root} from 'react-dom/client';
+import {CustomPanel} from '@deck.gl-community/widgets';
+import {getCuratedExamples, type CuratedExample, type ExampleSurface} from './example-catalog';
+
+/** A source selected by the shared example picker. */
+export type ExampleSource = {
+  /** URL or local file to load. */
+  value: string | File;
+  /** User-facing source label. */
+  label: string;
+  /** Inferred or explicitly selected format. */
+  format: string;
+  /** Curated dataset identifier when applicable. */
+  curatedId?: string;
+};
+
+/** Props for the shared example source picker. */
+export type ExampleSourcePickerProps = {
+  /** Rendering surface that limits curated choices and inference. */
+  surface: ExampleSurface;
+  /** Current source label shown in the control. */
+  selectedLabel?: string;
+  /** Current source URL when the source is remote. */
+  selectedUrl?: string;
+  /** Called when the user chooses a source. */
+  onSourceChange: (source: ExampleSource) => void;
+};
+
+/** Creates a panel-system panel containing the shared source picker. */
+export function createExampleSourcePanel(
+  props: ExampleSourcePickerProps
+): CustomPanel {
+  let root: Root | null = null;
+  return new CustomPanel({
+    id: `example-source-${props.surface}`,
+    title: 'Choose data',
+    keepMounted: false,
+    onRenderHTML: rootElement => {
+      root = createRoot(rootElement);
+      root.render(<ExampleSourcePicker {...props} />);
+      return () => {
+        root?.unmount();
+        root = null;
+      };
+    }
+  });
+}
+
+function ExampleSourcePicker({surface, selectedLabel, selectedUrl, onSourceChange}: ExampleSourcePickerProps) {
+  const curatedExamples = getCuratedExamples(surface);
+  const handleFile = (file: File | undefined) => {
+    if (!file) {
+      return;
+    }
+    const source = {
+      value: file,
+      label: file.name,
+      format: inferFormat(file.name)
+    };
+    onSourceChange(source);
+  };
+
+  return (
+    <div
+      onDragOver={event => event.preventDefault()}
+      onDrop={event => {
+        event.preventDefault();
+        handleFile(event.dataTransfer.files[0]);
+      }}
+      style={styles.container}
+    >
+      <label style={styles.label}>
+        Curated dataset
+        <select
+          value=""
+          onChange={event => {
+            const curatedExample = curatedExamples.find(example => example.id === event.target.value);
+            if (curatedExample) {
+              const source = toSource(curatedExample);
+              updateShareableSourceState(source);
+              onSourceChange(source);
+            }
+          }}
+          style={styles.control}
+        >
+          <option value="">{selectedLabel || 'Select a dataset'}</option>
+          {curatedExamples.map(example => (
+            <option key={example.id} value={example.id}>
+              {example.label}{example.mobileSafe ? ' · mobile' : ''}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label style={styles.label}>
+        URL
+        <input
+          type="url"
+          defaultValue={selectedUrl || ''}
+          placeholder="https://…"
+          style={styles.control}
+          onKeyDown={event => {
+            if (event.key === 'Enter') {
+              const url = event.currentTarget.value.trim();
+              if (url) {
+                const source = {value: url, label: getFileName(url), format: inferFormat(url)};
+                updateShareableSourceState(source);
+                onSourceChange(source);
+              }
+            }
+          }}
+        />
+      </label>
+      <label style={styles.dropZone}>
+        <span>Drop a file here or choose one</span>
+        <input type="file" onChange={event => handleFile(event.target.files?.[0])} style={styles.fileInput} />
+      </label>
+      <small style={styles.hint}>Format: URL extension is used when available; the renderer may apply a format override.</small>
+    </div>
+  );
+}
+
+function toSource(example: CuratedExample): ExampleSource {
+  return {value: example.url, label: example.label, format: example.format, curatedId: example.id};
+}
+
+function inferFormat(value: string): string {
+  const pathname = value.split('?')[0].toLowerCase();
+  if (pathname.endsWith('.pmtiles')) return 'PMTiles';
+  if (pathname.endsWith('.parquet')) return 'GeoParquet';
+  if (pathname.endsWith('.ply')) return 'PLY';
+  if (pathname.endsWith('.las') || pathname.endsWith('.laz')) return 'LAS';
+  if (pathname.endsWith('.geojson') || pathname.endsWith('.json')) return 'GeoJSON';
+  if (pathname.endsWith('.csv')) return 'CSV';
+  return 'Auto';
+}
+
+function getFileName(url: string): string {
+  try {
+    const pathname = new URL(url).pathname;
+    return pathname.slice(pathname.lastIndexOf('/') + 1) || 'Custom URL';
+  } catch {
+    return 'Custom URL';
+  }
+}
+
+function updateShareableSourceState(source: ExampleSource): void {
+  if (typeof window === 'undefined' || typeof source.value !== 'string') {
+    return;
+  }
+  const url = new URL(window.location.href);
+  url.searchParams.set('source', source.value);
+  url.searchParams.set('format', source.format);
+  if (source.curatedId) {
+    url.searchParams.set('dataset', source.curatedId);
+  } else {
+    url.searchParams.delete('dataset');
+  }
+  window.history.replaceState({}, '', url);
+}
+
+const styles = {
+  container: {display: 'grid', gap: 10, padding: '4px 0'},
+  label: {display: 'grid', gap: 4, fontSize: 12},
+  control: {boxSizing: 'border-box' as const, width: '100%', minHeight: 38, padding: '8px 10px', border: '1px solid rgba(148, 163, 184, 0.55)', borderRadius: 8, font: 'inherit'},
+  dropZone: {display: 'grid', gap: 6, placeItems: 'center', padding: 14, border: '1px dashed rgba(59, 130, 246, 0.65)', borderRadius: 8, background: 'rgba(239, 246, 255, 0.7)', textAlign: 'center' as const, fontSize: 12},
+  fileInput: {maxWidth: '100%', fontSize: 12},
+  hint: {color: '#64748b', lineHeight: 1.4}
+};

--- a/examples/website/shared/example-source-picker.tsx
+++ b/examples/website/shared/example-source-picker.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {createRoot, type Root} from 'react-dom/client';
 import {CustomPanel} from '@deck.gl-community/widgets';
 import {getCuratedExamples, type CuratedExample, type ExampleSurface} from './example-catalog';
 
@@ -34,25 +33,35 @@ export type ExampleSourcePickerProps = {
 export function createExampleSourcePanel(
   props: ExampleSourcePickerProps
 ): CustomPanel {
-  let root: Root | null = null;
   return new CustomPanel({
     id: `example-source-${props.surface}`,
     title: 'Choose data',
     keepMounted: false,
     onRenderHTML: rootElement => {
-      root = createRoot(rootElement);
-      root.render(<ExampleSourcePicker {...props} />);
-      return () => {
-        root?.unmount();
-        root = null;
-      };
+      renderExampleSourcePicker(rootElement, props);
     }
   });
 }
 
-function ExampleSourcePicker({surface, selectedLabel, selectedUrl, onSourceChange}: ExampleSourcePickerProps) {
+function renderExampleSourcePicker(rootElement: HTMLElement, props: ExampleSourcePickerProps): void {
+  const {surface, selectedLabel, selectedUrl, onSourceChange} = props;
   const curatedExamples = getCuratedExamples(surface);
-  const handleFile = (file: File | undefined) => {
+  rootElement.replaceChildren();
+  rootElement.style.fontSize = '11px';
+  const detailsElement = document.createElement('details');
+  const summaryElement = document.createElement('summary');
+  summaryElement.textContent = 'Source options';
+  summaryElement.style.cursor = 'pointer';
+  summaryElement.style.fontWeight = '600';
+  detailsElement.appendChild(summaryElement);
+  const contentElement = document.createElement('div');
+  contentElement.style.display = 'grid';
+  contentElement.style.gap = '6px';
+  contentElement.style.padding = '6px 0 0';
+  detailsElement.appendChild(contentElement);
+  rootElement.appendChild(detailsElement);
+
+  const handleFile = (file: File | undefined): void => {
     if (!file) {
       return;
     }
@@ -64,63 +73,76 @@ function ExampleSourcePicker({surface, selectedLabel, selectedUrl, onSourceChang
     onSourceChange(source);
   };
 
-  return (
-    <div
-      onDragOver={event => event.preventDefault()}
-      onDrop={event => {
-        event.preventDefault();
-        handleFile(event.dataTransfer.files[0]);
-      }}
-      style={styles.container}
-    >
-      <label style={styles.label}>
-        Curated dataset
-        <select
-          value=""
-          onChange={event => {
-            const curatedExample = curatedExamples.find(example => example.id === event.target.value);
-            if (curatedExample) {
-              const source = toSource(curatedExample);
-              updateShareableSourceState(source);
-              onSourceChange(source);
-            }
-          }}
-          style={styles.control}
-        >
-          <option value="">{selectedLabel || 'Select a dataset'}</option>
-          {curatedExamples.map(example => (
-            <option key={example.id} value={example.id}>
-              {example.label}{example.mobileSafe ? ' · mobile' : ''}
-            </option>
-          ))}
-        </select>
-      </label>
-      <label style={styles.label}>
-        URL
-        <input
-          type="url"
-          defaultValue={selectedUrl || ''}
-          placeholder="https://…"
-          style={styles.control}
-          onKeyDown={event => {
-            if (event.key === 'Enter') {
-              const url = event.currentTarget.value.trim();
-              if (url) {
-                const source = {value: url, label: getFileName(url), format: inferFormat(url)};
-                updateShareableSourceState(source);
-                onSourceChange(source);
-              }
-            }
-          }}
-        />
-      </label>
-      <label style={styles.dropZone}>
-        <span>Drop a file here or choose one</span>
-        <input type="file" onChange={event => handleFile(event.target.files?.[0])} style={styles.fileInput} />
-      </label>
-      <small style={styles.hint}>Format: URL extension is used when available; the renderer may apply a format override.</small>
-    </div>
-  );
+  const curatedLabel = document.createElement('label');
+  applyStyles(curatedLabel, styles.label);
+  curatedLabel.append('Curated dataset');
+  const curatedSelect = document.createElement('select');
+  curatedSelect.setAttribute('aria-label', 'Curated dataset');
+  applyStyles(curatedSelect, styles.control);
+  const currentOption = document.createElement('option');
+  currentOption.textContent = selectedLabel || 'Select a dataset';
+  curatedSelect.appendChild(currentOption);
+  for (const example of curatedExamples) {
+    const option = document.createElement('option');
+    option.value = example.id;
+    option.textContent = `${example.label}${example.mobileSafe ? ' · mobile' : ''}`;
+    curatedSelect.appendChild(option);
+  }
+  curatedSelect.addEventListener('change', () => {
+    const curatedExample = curatedExamples.find(example => example.id === curatedSelect.value);
+    if (curatedExample) {
+      const source = toSource(curatedExample);
+      updateShareableSourceState(source);
+      onSourceChange(source);
+    }
+  });
+  curatedLabel.appendChild(curatedSelect);
+  contentElement.appendChild(curatedLabel);
+
+  const urlLabel = document.createElement('label');
+  applyStyles(urlLabel, styles.label);
+  urlLabel.append('URL');
+  const urlInput = document.createElement('input');
+  urlInput.type = 'url';
+  urlInput.value = selectedUrl || '';
+  urlInput.placeholder = 'https://…';
+  urlInput.setAttribute('aria-label', 'URL');
+  applyStyles(urlInput, styles.control);
+  urlInput.addEventListener('keydown', event => {
+    if (event.key === 'Enter' && urlInput.value.trim()) {
+      const url = urlInput.value.trim();
+      const source = {value: url, label: getFileName(url), format: inferFormat(url)};
+      updateShareableSourceState(source);
+      onSourceChange(source);
+    }
+  });
+  urlLabel.appendChild(urlInput);
+  contentElement.appendChild(urlLabel);
+
+  const dropZone = document.createElement('label');
+  applyStyles(dropZone, styles.dropZone);
+  dropZone.append('Drop a file here or choose one');
+  const fileInput = document.createElement('input');
+  fileInput.type = 'file';
+  fileInput.setAttribute('aria-label', 'Choose a file');
+  applyStyles(fileInput, styles.fileInput);
+  fileInput.addEventListener('change', () => handleFile(fileInput.files?.[0]));
+  dropZone.appendChild(fileInput);
+  dropZone.addEventListener('dragover', event => event.preventDefault());
+  dropZone.addEventListener('drop', event => {
+    event.preventDefault();
+    handleFile(event.dataTransfer?.files[0]);
+  });
+  contentElement.appendChild(dropZone);
+
+  const hint = document.createElement('small');
+  hint.textContent = 'Format: URL extension is used when available; the renderer may apply a format override.';
+  applyStyles(hint, styles.hint);
+  contentElement.appendChild(hint);
+}
+
+function applyStyles(element: HTMLElement, style: Record<string, string>): void {
+  Object.assign(element.style, style);
 }
 
 function toSource(example: CuratedExample): ExampleSource {
@@ -162,11 +184,10 @@ function updateShareableSourceState(source: ExampleSource): void {
   window.history.replaceState({}, '', url);
 }
 
-const styles = {
-  container: {display: 'grid', gap: 10, padding: '4px 0'},
-  label: {display: 'grid', gap: 4, fontSize: 12},
-  control: {boxSizing: 'border-box' as const, width: '100%', minHeight: 38, padding: '8px 10px', border: '1px solid rgba(148, 163, 184, 0.55)', borderRadius: 8, font: 'inherit'},
-  dropZone: {display: 'grid', gap: 6, placeItems: 'center', padding: 14, border: '1px dashed rgba(59, 130, 246, 0.65)', borderRadius: 8, background: 'rgba(239, 246, 255, 0.7)', textAlign: 'center' as const, fontSize: 12},
-  fileInput: {maxWidth: '100%', fontSize: 12},
+const styles: Record<string, Record<string, string>> = {
+  label: {display: 'grid', gap: '3px', fontSize: '11px'},
+  control: {boxSizing: 'border-box', width: '100%', minHeight: '30px', padding: '4px 6px', border: '1px solid rgba(148, 163, 184, 0.55)', borderRadius: '6px', font: 'inherit'},
+  dropZone: {display: 'grid', gap: '4px', placeItems: 'center', padding: '8px', border: '1px dashed rgba(59, 130, 246, 0.65)', borderRadius: '6px', background: 'rgba(239, 246, 255, 0.7)', textAlign: 'center', fontSize: '11px'},
+  fileInput: {maxWidth: '100%', fontSize: '11px'},
   hint: {color: '#64748b', lineHeight: 1.4}
 };

--- a/examples/website/shared/example-source-picker.tsx
+++ b/examples/website/shared/example-source-picker.tsx
@@ -3,7 +3,12 @@
 // Copyright (c) vis.gl contributors
 
 import {CustomPanel} from '@deck.gl-community/widgets';
-import {getCuratedExamples, type CuratedExample, type ExampleSurface} from './example-catalog';
+import {
+  getCuratedExample,
+  getCuratedExamples,
+  type CuratedExample,
+  type ExampleSurface
+} from './example-catalog';
 
 /** A source selected by the shared example picker. */
 export type ExampleSource = {
@@ -28,6 +33,29 @@ export type ExampleSourcePickerProps = {
   /** Called when the user chooses a source. */
   onSourceChange: (source: ExampleSource) => void;
 };
+
+/** Reads a remote source previously written to the current page URL. */
+export function getExampleSourceFromUrl(surface: ExampleSurface): ExampleSource | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const url = new URL(window.location.href);
+  const sourceUrl = url.searchParams.get('source');
+  const curatedExample = getCuratedExample(url.searchParams.get('dataset'));
+  if (curatedExample && curatedExample.surface === surface) {
+    return toSource(curatedExample);
+  }
+  if (!sourceUrl) {
+    return null;
+  }
+
+  return {
+    value: sourceUrl,
+    label: getFileName(sourceUrl),
+    format: url.searchParams.get('format') || inferFormat(sourceUrl)
+  };
+}
 
 /** Creates a panel-system panel containing the shared source picker. */
 export function createExampleSourcePanel(
@@ -157,6 +185,12 @@ function inferFormat(value: string): string {
   if (pathname.endsWith('.las') || pathname.endsWith('.laz')) return 'LAS';
   if (pathname.endsWith('.geojson') || pathname.endsWith('.json')) return 'GeoJSON';
   if (pathname.endsWith('.csv')) return 'CSV';
+  if (pathname.endsWith('.gpkg')) return 'GeoPackage';
+  if (pathname.endsWith('.fgb')) return 'FlatGeobuf';
+  if (pathname.endsWith('.shp')) return 'Shapefile';
+  if (pathname.endsWith('.kml')) return 'KML';
+  if (pathname.endsWith('.gpx')) return 'GPX';
+  if (pathname.endsWith('.tcx')) return 'TCX';
   return 'Auto';
 }
 

--- a/examples/website/tiles/app.tsx
+++ b/examples/website/tiles/app.tsx
@@ -23,7 +23,11 @@ import {MapView} from '@deck.gl/core';
 import {ColumnPanel, CustomPanel, SidebarWidget} from '@deck.gl-community/widgets';
 import {Tile2DSourceLayer} from '@loaders.gl/deck-layers';
 import {createDeckFullscreenWidget, createDeckStatsWidget} from '../shared/create-deck-stats-widget';
-import {createExampleSourcePanel, type ExampleSource} from '../shared/example-source-picker';
+import {
+  createExampleSourcePanel,
+  getExampleSourceFromUrl,
+  type ExampleSource
+} from '../shared/example-source-picker';
 import {getExampleDevicePixelRatio} from '../shared/example-performance';
 
 import {Map} from 'react-map-gl';
@@ -80,6 +84,12 @@ export default function App(props: AppProps = {}) {
   });
 
   useEffect(() => {
+    const shareableSource = getExampleSourceFromUrl('tiles');
+    if (shareableSource) {
+      void loadExampleSource(shareableSource);
+      return;
+    }
+
     const initialCategoryName = props.format || INITIAL_CATEGORY_NAME;
     const initialExamples = availableExamples[initialCategoryName];
     if (!initialExamples) {

--- a/examples/website/tiles/app.tsx
+++ b/examples/website/tiles/app.tsx
@@ -23,6 +23,8 @@ import {MapView} from '@deck.gl/core';
 import {ColumnPanel, CustomPanel, SidebarWidget} from '@deck.gl-community/widgets';
 import {Tile2DSourceLayer} from '@loaders.gl/deck-layers';
 import {createDeckFullscreenWidget, createDeckStatsWidget} from '../shared/create-deck-stats-widget';
+import {createExampleSourcePanel, type ExampleSource} from '../shared/example-source-picker';
+import {getExampleDevicePixelRatio} from '../shared/example-performance';
 
 import {Map} from 'react-map-gl';
 import maplibregl from 'maplibre-gl';
@@ -160,6 +162,14 @@ export default function App(props: AppProps = {}) {
           id: 'tiles-example-panel',
           title: '',
           panels: {
+            source: createExampleSourcePanel({
+              surface: 'tiles',
+              selectedLabel: state.selectedExampleName || undefined,
+              selectedUrl: typeof currentExample?.data === 'string' ? currentExample.data : undefined,
+              onSourceChange: (source) => {
+                void loadExampleSource(source);
+              }
+            }),
             controls: new CustomPanel({
               id: 'tiles-example-controls',
               title: '',
@@ -201,6 +211,7 @@ export default function App(props: AppProps = {}) {
   return (
     <div style={{position: 'relative', height: '100%'}}>
       <DeckGL
+        useDevicePixels={getExampleDevicePixelRatio()}
         layers={[tileLayer]}
         views={new MapView({repeat: true})}
         viewState={state.viewState as any}
@@ -299,6 +310,19 @@ export default function App(props: AppProps = {}) {
     ) {
       setRangeStats(getRangeStats(rangeStatsObjectRef.current));
     }
+  }
+
+  async function loadExampleSource(source: ExampleSource): Promise<void> {
+    const sourceType = source.format.toLowerCase() === 'pmtiles' ? 'pmtiles' : 'table';
+    const example: Example = {
+      sourceType,
+      data: source.value
+    };
+    await onExampleChange({
+      categoryName: source.format,
+      exampleName: source.label,
+      example
+    });
   }
 }
 

--- a/examples/website/tiles/examples.ts
+++ b/examples/website/tiles/examples.ts
@@ -4,7 +4,7 @@
 
 export type Example = {
   sourceType: 'mvt' | 'pmtiles' | 'table' | 'mlt';
-  data: string;
+  data: string | File;
   attributions?: string[];
   viewState?: Record<string, unknown>;
   tileSize?: number[];

--- a/modules/compression/src/index.ts
+++ b/modules/compression/src/index.ts
@@ -7,6 +7,11 @@ export type {CompressionMetadata} from './compression-types';
 
 export {Compression, Compressor, Decompressor} from './lib/compression';
 
+// Deprecated compatibility exports retained for archive and ZIP consumers.
+export {DeflateCompression} from './lib/deflate-compression';
+export {GZipCompression} from './lib/gzip-compression';
+export {NoCompression} from './lib/no-compression';
+
 export {
   NoCompressor,
   NoDecompressor,

--- a/modules/orc/src/orc-loader-types.ts
+++ b/modules/orc/src/orc-loader-types.ts
@@ -18,7 +18,7 @@ export type ORCLoaderOptions = {
 
 /** Preloads the parser-bearing ORC loader implementation. */
 async function preloadORCLoader() {
-  const {ORCLoaderWithParser} = await import('@loaders.gl/orc/orc-loader');
+  const {ORCLoaderWithParser} = await import('./orc-loader');
   return ORCLoaderWithParser;
 }
 

--- a/modules/parquet/src/parquet-loader-types.ts
+++ b/modules/parquet/src/parquet-loader-types.ts
@@ -12,6 +12,7 @@ import type {
 
 import {PARQUET_LOADER_BASE} from './parquet-loader-base';
 import type {ParquetLoaderOptions as SharedParquetLoaderOptions} from './parquet-loader-options';
+import {PARQUET_WORKER_URL} from './parquet-worker-url';
 
 /** Options for the Parquet loader. */
 export type ParquetLoaderOptions = SharedParquetLoaderOptions;
@@ -25,6 +26,7 @@ async function preloadParquetLoader() {
 /** Metadata-only Parquet table loader supporting object-row and Arrow table output. */
 export const ParquetLoader = {
   ...PARQUET_LOADER_BASE,
+  worker: PARQUET_WORKER_URL,
   preload: preloadParquetLoader
 } as const satisfies Loader<
   ObjectRowTable | ArrowTable,

--- a/modules/parquet/src/parquet-loader-types.ts
+++ b/modules/parquet/src/parquet-loader-types.ts
@@ -12,7 +12,6 @@ import type {
 
 import {PARQUET_LOADER_BASE} from './parquet-loader-base';
 import type {ParquetLoaderOptions as SharedParquetLoaderOptions} from './parquet-loader-options';
-import {PARQUET_WORKER_URL} from './parquet-worker-url';
 
 /** Options for the Parquet loader. */
 export type ParquetLoaderOptions = SharedParquetLoaderOptions;
@@ -26,7 +25,6 @@ async function preloadParquetLoader() {
 /** Metadata-only Parquet table loader supporting object-row and Arrow table output. */
 export const ParquetLoader = {
   ...PARQUET_LOADER_BASE,
-  worker: PARQUET_WORKER_URL,
   preload: preloadParquetLoader
 } as const satisfies Loader<
   ObjectRowTable | ArrowTable,

--- a/modules/parquet/src/parquet-worker-url.ts
+++ b/modules/parquet/src/parquet-worker-url.ts
@@ -4,10 +4,15 @@
 
 /** Module-relative worker asset for browser ESM and Node.js CommonJS distributions. */
 export const PARQUET_WORKER_URL = import.meta.url
-  ? new URL(getParquetWorkerFile(), import.meta.url).toString()
+  ? getParquetWorkerUrl(import.meta.url)
   : typeof __dirname === 'string'
     ? `${__dirname}/parquet-worker-node.cjs`
     : true;
+
+/** Builds a package-relative worker URL without making the development bundler resolve the asset. */
+function getParquetWorkerUrl(moduleUrl: string): string {
+  return `${moduleUrl.slice(0, moduleUrl.lastIndexOf('/') + 1)}${getParquetWorkerFile()}`;
+}
 
 /** Selects the worker bundle for the current JavaScript runtime. */
 function getParquetWorkerFile(): string {

--- a/website/package.json
+++ b/website/package.json
@@ -6,7 +6,7 @@
   "packageManager": "yarn@4.17.1",
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "docusaurus start",
+    "start": "./scripts/start.sh",
     "build": "./scripts/build.sh prod",
     "build-staging": "./scripts/build.sh staging",
     "swizzle": "docusaurus swizzle",

--- a/website/scripts/start.sh
+++ b/website/scripts/start.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+# The integrated examples import this worker by module-relative URL. Build it
+# before starting Docusaurus so a fresh checkout does not crash at compile time.
+(cd ../modules/parquet && ../../node_modules/.bin/esbuild src/workers/parquet-source-worker.ts \
+  --outfile=dist/parquet-source-worker.js \
+  --target=esnext --platform=browser --bundle --sourcemap \
+  --inject:src/polyfills/process.ts --banner:js='var global=globalThis;' \
+  --define:__VERSION__=\"$npm_package_version\")
+
+exec docusaurus start "$@"

--- a/website/src/components/example/examples-index.tsx
+++ b/website/src/components/example/examples-index.tsx
@@ -63,7 +63,7 @@ export default function ExamplesIndex({
 }) {
   const mainSidebar = useDocsSidebar();
   const sidebarItems = mainSidebar?.items?.[0]?.items || mainSidebar?.items || [];
-  const featuredImageUrl = useBaseUrl('/images/maps.jpg');
+  const featuredImageRoot = useBaseUrl('/');
 
   return (
     <MainExamples>
@@ -71,7 +71,7 @@ export default function ExamplesIndex({
       <ExamplesGroup>
         {CURATED_EXAMPLES.map(example => (
           <ExampleCard key={example.id} href={getExampleHref(example.surface, example.format)}>
-            <img width="100%" src={featuredImageUrl} alt="" />
+            <img width="100%" src={`${featuredImageRoot}${example.thumbnail}`} alt={example.label} />
             <ExampleTitle>
               <span>{example.label}</span>
               <small>{example.description}</small>

--- a/website/src/components/example/examples-index.tsx
+++ b/website/src/components/example/examples-index.tsx
@@ -11,6 +11,7 @@ import {
   ExampleLogo,
   ExampleTitle
 } from './styled';
+import {CURATED_EXAMPLES} from '../../../../examples/website/shared/example-catalog';
 
 const DEFAULT_EXAMPLE_THUMBNAIL = '/images/maps.jpg';
 
@@ -62,9 +63,22 @@ export default function ExamplesIndex({
 }) {
   const mainSidebar = useDocsSidebar();
   const sidebarItems = mainSidebar?.items?.[0]?.items || mainSidebar?.items || [];
+  const featuredImageUrl = useBaseUrl('/images/maps.jpg');
 
   return (
     <MainExamples>
+      <ExampleHeader>Featured datasets</ExampleHeader>
+      <ExamplesGroup>
+        {CURATED_EXAMPLES.map(example => (
+          <ExampleCard key={example.id} href={getExampleHref(example.surface, example.format)}>
+            <img width="100%" src={featuredImageUrl} alt="" />
+            <ExampleTitle>
+              <span>{example.label}</span>
+              <small>{example.description}</small>
+            </ExampleTitle>
+          </ExampleCard>
+        ))}
+      </ExamplesGroup>
       {sidebarItems.map(item => {
         if (item.type === 'category' && item.items && item.label) {
           return renderCategory(item, getThumbnail, getLogo, defaultThumbnail);
@@ -73,4 +87,14 @@ export default function ExamplesIndex({
       })}
     </MainExamples>
   );
+}
+
+function getExampleHref(surface: string, format: string): string {
+  if (surface === 'tiles') {
+    return format.toLowerCase() === 'pmtiles' ? '/examples/tiles/pmtiles' : '/examples/tiles/mvt';
+  }
+  if (surface === 'pointcloud') {
+    return `/examples/pointclouds/${format.toLowerCase()}`;
+  }
+  return `/examples/geospatial/${format.toLowerCase()}`;
 }

--- a/website/src/theme/DocItem/Content/index.tsx
+++ b/website/src/theme/DocItem/Content/index.tsx
@@ -50,13 +50,15 @@ function insertLoaderLiveExample(children: ReactNode, syntheticTitle: string | n
 
   for (const node of nodes) {
     if (!exampleInserted) {
-      if (!sawRenderedTitle && isHeadingNode(node, 'h1')) {
+      if (!sawRenderedTitle) {
         beforeExample.push(node)
-        sawRenderedTitle = true
+        if (isHeadingNode(node, 'h1')) {
+          sawRenderedTitle = true
+        }
         continue
       }
 
-      if (isBadgeParagraph(node) || isImageParagraph(node)) {
+      if (isBadgeParagraph(node) || isImageParagraph(node) || isDocsPageTabs(node)) {
         beforeExample.push(node)
         continue
       }
@@ -80,6 +82,13 @@ function insertLoaderLiveExample(children: ReactNode, syntheticTitle: string | n
 
 function isHeadingNode(node: ReactNode, tagName: string): boolean {
   return React.isValidElement(node) && node.type === tagName
+}
+
+function isDocsPageTabs(node: ReactNode): boolean {
+  if (!React.isValidElement(node) || typeof node.type !== 'function') {
+    return false
+  }
+  return node.type.name === 'JsonDocsTabs'
 }
 
 function isParagraphNode(node: ReactNode): boolean {


### PR DESCRIPTION
## Goals

Make loaders.gl examples more compelling and usable on mobile, especially iOS, with curated datasets, common source-selection controls, and safer memory defaults.

## Changes

- Added a curated dataset catalog for geospatial, tiled, and point-cloud examples, with relevant preview images on the examples index.
- Added shared panel-based source controls for curated datasets, arbitrary URLs, local files, and drag-and-drop input.
- Added format inference and shareable URL state for remote sources.
- Integrated the source picker into geospatial, tile, and point-cloud examples.
- Added conservative mobile device-pixel and decoded-row budgets.
- Made the TypeScript `ParquetLoader` selectable and the default loader for GeoParquet examples.
- Made the website startup script build the Parquet source worker automatically.
- Fixed eager Parquet worker resolution that could crash non-Parquet pages.
- Fixed live-example placement so documentation navigation and titles appear before embedded examples.
- Fixed malformed NDGeoJSON format references.

## Validation

- `yarn lint fix` passes with no fixes applied; the repository still reports pre-existing generated JavaScript lint diagnostics outside this change.
- The full Docusaurus development site starts at `http://127.0.0.1:3000/` after automatically building `parquet-source-worker.js`.
- Manually verified the geospatial example source picker and Parquet loader selector in Chromium.
- Full repository TypeScript validation remains affected by pre-existing workspace configuration and declaration errors.

## Follow-up

- Validate the examples on physical iOS Safari and tune individual datasets based on device telemetry.
