### PR TITLE
feat(copc): complete native TypeScript reader

### DIFF
--- a/docs/modules/copc/README.md
+++ b/docs/modules/copc/README.md
@@ -12,7 +12,7 @@ import {CopcDocsTabs} from '@site/src/components/docs/copc-docs-tabs';
 
 <CopcDocsTabs active="overview" />
 
-The `@loaders.gl/copc` module loads and writes the [COPC](/docs/modules/copc/formats/copc) format.
+The `@loaders.gl/copc` module loads and writes the [COPC](/docs/modules/copc/formats/copc) format. Its primary reader is TypeScript-only and performs native COPC hierarchy, byte-range, and LAZ point decoding.
 
 ## Installation
 
@@ -29,4 +29,4 @@ npm install @loaders.gl/core @loaders.gl/copc
 
 ## Attribution
 
-This module is a fork of Connor Manning's awesome [copc.js](https://github.com/connormanning/copc.js/) module, under MIT license.
+The original module was based on Connor Manning's [copc.js](https://github.com/connormanning/copc.js/) project under the MIT license. The current primary reader is a first-party TypeScript implementation with no `copc` runtime dependency.

--- a/docs/modules/copc/api-reference/copc-source-loader.md
+++ b/docs/modules/copc/api-reference/copc-source-loader.md
@@ -34,10 +34,10 @@ The created data source exposes the point-cloud tile methods used by `PointCloud
 - `getRootTile()` returns the root octree tile header.
 - `getChildren(tile)` returns available child tile headers.
 - `loadTileContent(tile)` returns normalized point positions, optional colors, point count, and cartographic origin.
-- `loadTileContentInBatches(tile, options)` yields normalized Arrow point tables progressively as the selected node range is fetched. The TypeScript LAZ variant is required. `options.batchSize` controls the maximum points per table, `options.columns` can request `POSITION`, `COLOR_0`, `NIR`, `intensity`, `classification`, `GPS_TIME`, `scanAngle`, and `pointSourceId`, and `options.signal` cancels the request/decode.
+- `loadTileContentInBatches(tile, options)` yields normalized Arrow point tables progressively as the selected node range is fetched. `options.batchSize` controls the maximum points per table, `options.columns` selects the attributes listed below, and `options.signal` cancels the request/decode.
 - `loadHierarchyInBatches(options)` yields hierarchy pages and their discovered nodes as they are fetched.
 
-For TypeScript PDRF 6-8 batches, `loadTileContentInBatches` splits the node range into requests and emits rows as soon as the requested independent layers arrive. PDRF 7 RGB waits for Point14 and RGB; PDRF 8 RGB/NIR waits for the layers requested through `options.columns`. `options.rangeChunkSize` controls request size, while `options.rangeConcurrency` can fetch later ranges ahead of in-order decoding.
+The source uses the native TypeScript COPC and LAZ readers for PDRF 6-8. `loadTileContentInBatches` splits the node range into requests and emits rows as soon as the requested independent layers arrive. PDRF 7 RGB waits for Point14 and RGB; PDRF 8 RGB/NIR waits for the layers requested through `options.columns`. `options.rangeChunkSize` controls request size, while `options.rangeConcurrency` can fetch later ranges ahead of in-order decoding.
 
 ## Options
 
@@ -46,3 +46,30 @@ For TypeScript PDRF 6-8 batches, `loadTileContentInBatches` splits the node rang
 | `copc.sourceCoordinateSystem` | `string` | Auto-detected from COPC WKT | Coordinate system definition used when the source metadata does not include WKT. |
 | `copc.rangeChunkSize` | `number` | `65536` | Default byte size for TypeScript COPC node range requests. |
 | `copc.rangeConcurrency` | `number` | `1` | Maximum number of node ranges fetched ahead of decoding. Results are still decoded and yielded in range order. |
+
+### Progressive Columns
+
+`POSITION` is always present. PDRF 7/8 color remains enabled by default; all other attributes are opt-in through `options.columns`.
+
+| Column request | Arrow output |
+| --- | --- |
+| `COLOR_0`, `NIR` | 16-bit RGB and PDRF 8 near-infrared channels. |
+| `intensity`, `classification`, `GPS_TIME`, `scanAngle`, `userData`, `pointSourceId` | Standard LAS 1.4 scalar fields. |
+| `returnNumber`, `numberOfReturns`, `scannerChannel` | Pulse-return and scanner metadata. |
+| `scanDirectionFlag`, `edgeOfFlightLine` | Flight-line flags as 0/1 byte columns. |
+| `EXTRA_BYTES` | One named typed `EXTRA_BYTES_*` Arrow attribute per VLR descriptor, including vector size and scale/offset transforms. |
+
+## Low-Level Range APIs
+
+The package exports the native parsing primitives used by `COPCSourceLoader`:
+
+| API | Description |
+| --- | --- |
+| `openCOPC(readRange)` | Reads and validates the LAS 1.4 header, VLR/EVLR descriptors, COPC info VLR, WKT, and Extra Bytes metadata. |
+| `loadCOPCHierarchyPage(readRange, page)` | Fetches and parses one hierarchy page. |
+| `loadCOPCNodeData(readRange, node)` | Fetches one exact compressed node range. |
+| `parseCOPCHeader(bytes)` | Parses and validates a 375-byte COPC LAS header. |
+| `parseCOPCInfo(bytes)` | Parses a 160-byte COPC info payload. |
+| `parseCOPCHierarchy(bytes)` | Parses native 32-byte hierarchy entries. |
+
+`readRange(begin, end, signal)` returns exactly the requested half-open range as a `Uint8Array`. Offsets and lengths must remain within JavaScript's safe integer range.

--- a/docs/modules/copc/formats/copc.md
+++ b/docs/modules/copc/formats/copc.md
@@ -7,9 +7,76 @@ import {CopcDocsTabs} from '@site/src/components/docs/copc-docs-tabs';
 - _[Specification at COPC.io](https://copc.io/)_
 - _[Video Overview](https://www.youtube.com/watch?v=rWkKKZYN86A)_
 
-COPC, short for Cloud-Optimized Point Cloud, is a LAZ 1.4 file that stores point data organized in a clustered octree. It contains a VLR (LAS Variable Length Record) that describe the octree organization of data that are stored in LAZ 1.4 chunks.
+COPC, short for Cloud Optimized Point Cloud, is a range-readable LAZ 1.4 file whose point data is organized as a clustered octree. A COPC reader can select spatial nodes and fetch only their compressed byte ranges instead of downloading the complete point cloud.
 
-Data organization of COPC is modeled after the [EPT data format](https://entwine.io/en/latest/entwine-point-tile.html), but COPC clusters the storage of the octree as variably-chunked LAZ data in a single file. This allows the data to be consumed sequentially by any reader than can handle variably-chunked LAZ 1.4 (LASzip, for example), or as a spatial subset for readers that interpret the COPC hierarchy.
+Data organization is modeled after the [EPT data format](https://entwine.io/en/latest/entwine-point-tile.html), but COPC stores the octree as variably chunked LAZ data in one file. The same file can therefore be consumed sequentially by a variable-chunk LAZ reader or spatially by a COPC hierarchy reader.
+
+## Feature Matrix
+
+The primary `@loaders.gl/copc` implementation is TypeScript-only. It does not require the `copc` package, laz-perf, Rust, or WebAssembly at runtime.
+
+| Capability | Status | Current behavior |
+| --- | :---: | --- |
+| LAS 1.4 public header | **Full** | Validates the LAS signature, version, compressed PDRF, point counts, record length, scales, offsets, bounds, and VLR/EVLR offsets. |
+| COPC info VLR | **Full** | Parses the root cube, spacing, hierarchy range, and GPS time range. The info record must be the first VLR. |
+| VLR and EVLR discovery | **Full** | Walks record headers through exact range reads and retains user ID, record ID, description, payload offset, and payload length. |
+| Coordinate reference system | **Full** | Reads OGC WKT from VLR or EVLR record 2112 and projects tile bounds and positions when the WKT is supported by proj4. A caller-supplied CRS can be used as a fallback. |
+| Extra Bytes metadata | **Full** | Parses 192-byte descriptors and retains the raw VLR payload. Scalar and 2/3-component values, signedness, floating-point types, and descriptor scale/offset are preserved. |
+| Root and child hierarchy pages | **Full** | Parses native 32-byte hierarchy entries, follows page references lazily, caches loaded pages, and validates offsets, lengths, and point counts. |
+| Spatial node selection | **Full** | Resolves `depth-x-y-z` keys, computes octree bounds, exposes children, and fetches only selected node byte ranges. |
+| Node range input | **Full** | Supports HTTP range-readable URLs, browser `Blob` objects, and local files in Node.js with `@loaders.gl/polyfills`. Short or invalid ranges fail deterministically. |
+| PDRF 6 | **Full** | TypeScript Point14 decoding with positions and selectively requested scalar fields. |
+| PDRF 7 | **Full** | PDRF 6 plus progressive RGB decoding. |
+| PDRF 8 | **Full** | PDRF 7 plus progressive NIR decoding. |
+| LAZ codec | **Full for COPC** | Layered LASzip compressor 3, arithmetic coder 0, Point14/RGB14/RGBNIR14/Byte14 item versions 2-4. |
+| Arrow table output | **Full** | Atomic and batched APIs return Arrow tables directly without an intermediate object-per-point representation. |
+| Selective field decoding | **Full** | Unrequested LAZ field layers are skipped, avoiding arithmetic decoder state, output arrays, and point traversal for those fields. |
+| Progressive node decoding | **Full at layer boundaries** | Node byte ranges are fed incrementally. Rows are emitted when all compressed layers required by the requested columns are available. |
+| Cancellation | **Full** | Abort signals are checked during hierarchy traversal, range loading, and progressive point decoding. |
+| COPC writing | **Experimental** | Writes LAS 1.4 PDRF 6-8, variable LAZ chunks, a version 0 chunk table, COPC info VLR, and hierarchy EVLR. |
+| Waveform PDRF 9/10 | **Not part of COPC 1.0** | COPC 1.0 permits only PDRF 6, 7, and 8. |
+
+### Arrow Columns
+
+`POSITION` is always decoded. Other columns are opt-in for progressive batches except that RGB is included by default when the point format contains color.
+
+| Arrow column | PDRF 6 | PDRF 7 | PDRF 8 | Source fields |
+| --- | :---: | :---: | :---: | --- |
+| `POSITION` | Yes | Yes | Yes | Scaled and offset X, Y, Z, transformed to tile-relative coordinates. |
+| `COLOR_0` | - | Yes | Yes | 16-bit red, green, and blue. |
+| `NIR` | - | - | Yes | 16-bit near-infrared channel. |
+| `intensity` | Yes | Yes | Yes | 16-bit pulse intensity. |
+| `classification` | Yes | Yes | Yes | LAS 1.4 classification code. |
+| `GPS_TIME` | Yes | Yes | Yes | 64-bit GPS time. |
+| `scanAngle` | Yes | Yes | Yes | LAS 1.4 signed scan angle. |
+| `pointSourceId` | Yes | Yes | Yes | 16-bit point source identifier. |
+| `userData` | Yes | Yes | Yes | 8-bit user data value. |
+| `returnNumber` | Yes | Yes | Yes | Return ordinal for the emitted pulse. |
+| `numberOfReturns` | Yes | Yes | Yes | Total returns for the emitted pulse. |
+| `scannerChannel` | Yes | Yes | Yes | LAS 1.4 scanner channel. |
+| `scanDirectionFlag` | Yes | Yes | Yes | Scan direction bit. |
+| `edgeOfFlightLine` | Yes | Yes | Yes | End-of-flight-line bit. |
+| `EXTRA_BYTES_*` | Yes | Yes | Yes | Named typed attributes from the Extra Bytes descriptor VLR, requested with `EXTRA_BYTES`. |
+
+Classification flags (`synthetic`, `keyPoint`, `withheld`, and `overlap`) remain available through the low-level point schema but are not yet separate progressive Arrow attributes.
+
+### Streaming Boundaries
+
+COPC is naturally range-streamable at hierarchy-page and node boundaries. The source first reads the LAS header and VLR headers, fetches the COPC info payload, and then fetches only the hierarchy pages and point nodes selected by traversal.
+
+Within a node, layered LAZ stores fields in independent compressed ranges. Position-only rows can be emitted once the Point14 layers arrive. PDRF 7 color rows wait for both Point14 and RGB layers, while PDRF 8 NIR rows additionally wait for RGB/NIR. The complete file and unrelated nodes are never required, but an individual requested row cannot be emitted before all layers selected for that row are available.
+
+## Range Layout
+
+| File region | How the reader uses it |
+| --- | --- |
+| LAS 1.4 public header | Locates VLRs, point data, EVLRs, record format, scales, offsets, and dataset bounds. |
+| COPC info VLR | Locates the root hierarchy page and defines the root octree cube and spacing. |
+| Hierarchy page | Maps octree keys either to compressed node ranges or to additional hierarchy pages. |
+| Point-data range | Contains one independently decodable LAZ chunk for a point-bearing node. |
+| Hierarchy EVLRs | May hold root or child hierarchy pages outside the regular VLR area. |
+
+Each point-bearing hierarchy entry contains `pointDataOffset`, `pointDataLength`, and `pointCount`. `COPCSourceLoader` requests the half-open range `pointDataOffset..pointDataOffset + pointDataLength` and passes the arriving bytes to the TypeScript LAZ decoder.
 
 ## Implementation
 

--- a/docs/modules/las/formats/las.md
+++ b/docs/modules/las/formats/las.md
@@ -126,12 +126,13 @@ Dedicated PDRF 4-10 fixtures compare every raw decoded byte and every represente
 
 | Capability | TypeScript status |
 | --- | --- |
-| COPC hierarchy and range selection | Uses the existing COPC path; not a standalone TypeScript COPC parser yet. |
-| Node range fetching | Supported. Each selected node's compressed byte range is fetched as a complete chunk. |
+| COPC header and metadata | Native TypeScript parsing for the LAS 1.4 header, VLR/EVLR descriptors, COPC info, WKT, and raw Extra Bytes metadata. |
+| COPC hierarchy and range selection | Native TypeScript hierarchy-page parsing, lazy child-page traversal, octree bounds, and node range selection. |
+| Node range fetching | Selected node ranges are fetched incrementally without downloading unrelated nodes or the complete file. |
 | Point decoding | Supported for COPC nodes using LAZ 1.4 PDRF 6, 7, or 8. |
-| Render attribute output | The TypeScript path decodes positions and RGB directly into typed Arrow attributes, skipping intensity/classification layers and avoiding their arrays, an intermediate raw-record buffer, and a second point traversal. |
-| Progressive point output while range data arrives | Not implemented. |
-| COPC writer | Implemented in `@loaders.gl/copc` as `COPCWriter`; it emits range-readable COPC 1.0-compatible output. |
+| Render attribute output | Positions, RGB, NIR, intensity, classification, GPS time, scan angle, and point source ID decode directly into Arrow buffers. Unrequested layers are skipped. |
+| Progressive point output while range data arrives | Implemented at layered LAZ readiness boundaries. Position-only rows can arrive before RGB and NIR layers. |
+| COPC writer | Experimental `COPCWriter` output includes range-readable LAZ node chunks, a variable chunk table, COPC info, and a hierarchy EVLR. |
 
 ## Version History
 
@@ -250,5 +251,3 @@ The TypeScript implementation should be completed in stages, with parity tests a
 | 5 | Expose waveform payload access and typed Extra Bytes. | `WAVEFORM` packet-reference rows and raw `EXTRA_BYTES` payloads are typed Arrow output; internal EVLR or external WDP sample payloads and descriptor-level Extra Bytes conversion remain follow-up work. |
 | 6 | Implement LAZ file writing. | `LASWriter` emits LASzip VLRs, layered chunks, and fixed-size chunk tables that established decoders can read. |
 | 7 | Complete stateful feedable LAZ streaming. | Replace bounded replay for legacy chunks with resumable arithmetic/item state, and stream layered chunks as soon as the field ranges needed for complete rows are available. |
-| 8 | Complete pure TypeScript COPC reading. | Header, COPC info VLR, hierarchy pages, range selection, and LAZ node decoding no longer depend on the existing COPC package internals. |
-| 9 | Implement COPC writing. | `COPCWriter` emits valid COPC 1.0 with hierarchy pages, range-readable LAZ node chunks, and required VLRs. |

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -137,6 +137,8 @@ const parquetBuffer = await encode(parquetArrowTable, ParquetWriter);
 
 `LASLoader` no longer supports `options.las.backend`. It now uses the pure TypeScript implementation. Import `LAZPerfLoader`, `LASCOPCLoader`, or `LAZRsLoader` explicitly when a compatibility loader is required.
 
+`COPCSourceLoader` no longer supports `options.copc.decoder`. COPC headers, hierarchy pages, node ranges, and PDRF 6-8 LAZ chunks are now read by the native TypeScript implementation.
+
 ### SourceLoader migration examples
 
 Before, in 4.4:

--- a/modules/copc/package.json
+++ b/modules/copc/package.json
@@ -47,8 +47,7 @@
     "@loaders.gl/mvt": "5.0.0-alpha.2",
     "@loaders.gl/schema": "5.0.0-alpha.2",
     "@loaders.gl/schema-utils": "5.0.0-alpha.2",
-    "@math.gl/proj4": "^4.1.0",
-    "copc": "0.0.8"
+    "@math.gl/proj4": "^4.1.0"
   },
   "gitHead": "c95a4ff72512668a93d9041ce8636bac09333fd5"
 }

--- a/modules/copc/src/README.md
+++ b/modules/copc/src/README.md
@@ -1,20 +1,13 @@
-# copc.js fork notes
+# COPC implementation notes
 
-copc.js was forked after some consideration:
+The primary COPC reader is implemented in this module and has no runtime dependency on `copc.js`. It provides:
 
-- Split out LAZ functionality (use `@loaders.gl/las` module).
-- Adapt to loaders.gl dynamic source system (replace `Getter`).
-- Avoid bundling issues (e.g. dynamic import of fs) as loaders.gl already handles these.
-- Modernize / simplify code (see below)
+- Native LAS 1.4, VLR/EVLR, COPC info, and hierarchy parsing.
+- Browser, HTTP, Blob, and Node random-access reads through loaders.gl file abstractions.
+- TypeScript LAZ decoding directly into Arrow attributes.
+- Selective and progressive PDRF 6-8 field delivery.
 
-If some of the loaders.gl changes could be upstreamed we might consider unforking.
-
-## Code "simplifications"
-
-- Remove dated typescript constructs (e.g. ES2015 module syntax is preferred over namespaces)
-- Multiple exports of same name (Hierarchy etc)
-- Avoid importing Node.js dependencies
-- Consolidate large number of small source code files.
+The original module and test fixtures were based on Connor Manning's `copc.js` project. The attribution and license are retained below.
 
 ## Original License
 

--- a/modules/copc/src/copc-source-loader.ts
+++ b/modules/copc/src/copc-source-loader.ts
@@ -252,6 +252,7 @@ export class COPCTileSource
   protected _projection: Proj4Projection | null = null;
   protected _hierarchy: COPCHierarchy | null = null;
   protected _pageLoadPromises: Map<string, Promise<void>> = new Map();
+  protected _closePromise: Promise<void> | null = null;
 
   constructor(data: string | Blob, options: COPCSourceLoaderOptions, coreApi?: CoreAPI) {
     super(data, options, COPCSourceLoader.defaultOptions, coreApi);
@@ -265,15 +266,21 @@ export class COPCTileSource
     await this._initPromise;
   }
 
+  /** Release the underlying random-access file handle. */
+  close(): Promise<void> {
+    this._closePromise ||= this._readableFile.close();
+    return this._closePromise;
+  }
+
   async getSchema(): Promise<Schema> {
     const {copc} = await this._initPromise;
-    return getCOPCHeaderSchema(copc.header.pointDataRecordFormat);
+    return getCOPCHeaderSchema(copc);
   }
 
   /** Discovers point attributes and spatial bounds without decoding point rows. */
   async getQueryMetadata() {
     const {copc} = await this._initPromise;
-    const schema = getCOPCHeaderSchema(copc.header.pointDataRecordFormat);
+    const schema = getCOPCHeaderSchema(copc);
     const roles = Object.fromEntries(
       schema.fields.map(field => [field.name, inferCOPCColumnRole(field.name)])
     );
@@ -399,11 +406,10 @@ export class COPCTileSource
     }
     const compressed = await loadCOPCNodeData(this._readRange, node);
     const pointData = new Uint8Array(copc.header.pointDataRecordLength);
-    const cursor = createLAZChunkDecoderCursor(compressed, {
-      pointCount: node.pointCount,
-      pointDataRecordFormat: copc.header.pointDataRecordFormat,
-      pointDataRecordLength: copc.header.pointDataRecordLength
-    });
+    const cursor = createLAZChunkDecoderCursor(
+      compressed,
+      getCOPCLAZChunkMetadata(copc, node.pointCount)
+    );
     cursor.decodeInto(pointData, 0, 1);
     return readCOPCPointValues(pointData, copc.header);
   }
@@ -511,11 +517,7 @@ export class COPCTileSource
     signal: AbortSignal | undefined,
     selection: COPCPointSelection
   ): AsyncIterable<COPCTileContent> {
-    const decoder = createLAZChunkDecoder({
-      pointCount: node.pointCount,
-      pointDataRecordFormat: copc.header.pointDataRecordFormat,
-      pointDataRecordLength: copc.header.pointDataRecordLength
-    });
+    const decoder = createLAZChunkDecoder(getCOPCLAZChunkMetadata(copc, node.pointCount));
     let decodedPointCount = 0;
 
     for await (const compressedChunk of this.loadCOPCNodeRangeChunks(
@@ -755,11 +757,10 @@ export class COPCTileSource
     const colors = pointFormatHasColor(copc.header.pointDataRecordFormat)
       ? new Uint16Array(pointCount * 3)
       : null;
-    const cursor = createLAZChunkDecoderCursor(compressed, {
-      pointCount,
-      pointDataRecordFormat: copc.header.pointDataRecordFormat,
-      pointDataRecordLength: copc.header.pointDataRecordLength
-    });
+    const cursor = createLAZChunkDecoderCursor(
+      compressed,
+      getCOPCLAZChunkMetadata(copc, pointCount)
+    );
 
     const decodedPointCount = cursor.decodeIntoPointData(
       {
@@ -1152,6 +1153,9 @@ export class COPCTileSource
 
   protected getChildKeys(tileId: string): string[] {
     const key = parseCOPCKey(tileId);
+    if (key[0] === 31) {
+      return [];
+    }
     const result: string[] = [];
 
     for (let childX = 0; childX < 2; childX++) {
@@ -1180,9 +1184,9 @@ export class COPCTileSource
       result.push(
         formatCOPCKey([
           depth,
-          key[1] >> (key[0] - depth),
-          key[2] >> (key[0] - depth),
-          key[3] >> (key[0] - depth)
+          Math.floor(key[1] / 2 ** (key[0] - depth)),
+          Math.floor(key[2] / 2 ** (key[0] - depth)),
+          Math.floor(key[3] / 2 ** (key[0] - depth))
         ])
       );
     }
@@ -1232,8 +1236,9 @@ export class COPCTileSource
   */
 }
 
-/** Builds the standard query schema from a COPC point-data record format. */
-function getCOPCHeaderSchema(pointDataRecordFormat: number): Schema {
+/** Builds the query schema from COPC point-data and Extra Bytes metadata. */
+function getCOPCHeaderSchema(copc: COPCFile): Schema {
+  const pointDataRecordFormat = copc.header.pointDataRecordFormat;
   const fields: Field[] = [
     {name: 'X', type: 'float64', nullable: false},
     {name: 'Y', type: 'float64', nullable: false},
@@ -1264,7 +1269,54 @@ function getCOPCHeaderSchema(pointDataRecordFormat: number): Schema {
   if (pointDataRecordFormat === 8) {
     fields.push({name: 'Infrared', type: 'uint16', nullable: false});
   }
+  const extraByteCount = getCOPCExtraByteCount(copc.header);
+  if (extraByteCount > 0 && copc.extraBytesDescriptors.length > 0) {
+    const attributes = createLASTypedExtraBytesAttributes(
+      0,
+      copc.extraBytesDescriptors,
+      extraByteCount
+    );
+    for (const attribute of attributes) {
+      const scalarType = getTypedArraySchemaType(attribute.value);
+      fields.push({
+        name: attribute.name,
+        type:
+          attribute.size === 1
+            ? scalarType
+            : {
+                type: 'fixed-size-list',
+                listSize: attribute.size,
+                children: [{name: 'value', type: scalarType}]
+              },
+        nullable: false
+      });
+    }
+  }
   return {fields, metadata: {}};
+}
+
+/** Map a typed Extra Bytes array to its serializable Arrow scalar type. */
+function getTypedArraySchemaType(value: LASTypedExtraBytesAttribute['value']): Field['type'] {
+  if (value instanceof Uint8Array) return 'uint8';
+  if (value instanceof Int8Array) return 'int8';
+  if (value instanceof Uint16Array) return 'uint16';
+  if (value instanceof Int16Array) return 'int16';
+  if (value instanceof Uint32Array) return 'uint32';
+  if (value instanceof Int32Array) return 'int32';
+  if (value instanceof Float32Array) return 'float32';
+  return 'float64';
+}
+
+/** Build decoder metadata from the validated COPC LASzip VLR. */
+function getCOPCLAZChunkMetadata(copc: COPCFile, pointCount: number) {
+  return {
+    pointCount,
+    pointDataRecordFormat: copc.header.pointDataRecordFormat,
+    pointDataRecordLength: copc.header.pointDataRecordLength,
+    point14ItemVersion: copc.laz.point14ItemVersion,
+    rgb14ItemVersion: copc.laz.rgb14ItemVersion,
+    byte14ItemVersion: copc.laz.byte14ItemVersion
+  };
 }
 
 function createProjection(projectionData?: string): Proj4Projection | null {

--- a/modules/copc/src/copc-source-loader.ts
+++ b/modules/copc/src/copc-source-loader.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {Schema, Field, DataType, Mesh, MeshArrowTable} from '@loaders.gl/schema';
+import type {Schema, Field, Mesh, MeshArrowTable} from '@loaders.gl/schema';
 import {convertMeshToTable} from '@loaders.gl/schema-utils';
 import type {
   CoreAPI,
@@ -16,16 +16,23 @@ import type {
 import {
   createLAZChunkDecoderCursor,
   createLAZChunkDecoder,
+  BlobFile,
   DataSource,
-  concatenateArrayBuffersFromArray,
-  decodeLAZChunkInBatches
+  HttpFile,
+  isBrowser,
+  NodeFile,
+  type ReadableFile
 } from '@loaders.gl/loader-utils';
 import {createScanQueryMetadata, type PointCloudQueryCapabilities} from '@loaders.gl/loader-utils';
 import {Proj4Projection} from '@math.gl/proj4';
-
-import {Copc, Las, Hierarchy, Dimension, Getter, Bounds, Key} from 'copc';
+import {
+  createLASTypedExtraBytesAttributes,
+  populateLASTypedExtraBytes,
+  type LASTypedExtraBytesAttribute
+} from '@loaders.gl/las';
 
 const VERSION = '1.0.0';
+const COPC_PREFIX_CACHE_LENGTH = 65536;
 const COORDINATE_SYSTEM = {
   CARTESIAN: 'cartesian',
   LNGLAT_OFFSETS: 'lnglat-offsets'
@@ -56,7 +63,7 @@ type COPCViewState = {
 };
 
 type COPCMetadata = TileSourceMetadata & {
-  formatSpecificMetadata: Copc;
+  formatSpecificMetadata: COPCFile;
   viewState: COPCViewState;
 };
 
@@ -67,12 +74,56 @@ type GetNodeParameters = {
   limit?: number;
 };
 
+type COPCPointSelection = {
+  colors: boolean;
+  nir: boolean;
+  intensity: boolean;
+  classification: boolean;
+  gpsTime: boolean;
+  scanAngle: boolean;
+  userData: boolean;
+  pointSourceId: boolean;
+  returnNumber: boolean;
+  numberOfReturns: boolean;
+  scannerChannel: boolean;
+  scanDirectionFlag: boolean;
+  edgeOfFlightLine: boolean;
+  extraBytes: boolean;
+};
+
+type COPCPointDataArrays = {
+  batchIntensities: Uint16Array | null;
+  batchClassifications: Uint8Array | null;
+  batchGpsTimes: Float64Array | null;
+  batchScanAngles: Int16Array | null;
+  batchUserData: Uint8Array | null;
+  batchPointSourceIds: Uint16Array | null;
+  batchReturnNumbers: Uint8Array | null;
+  batchNumberOfReturns: Uint8Array | null;
+  batchScannerChannels: Uint8Array | null;
+  batchScanDirectionFlags: Uint8Array | null;
+  batchEdgeOfFlightLines: Uint8Array | null;
+  typedExtraBytes: LASTypedExtraBytesAttribute[];
+};
+
 import {COPCFormat} from './copc-format';
+import {
+  formatCOPCKey,
+  getCOPCKeyBounds,
+  loadCOPCHierarchyPage,
+  loadCOPCNodeData,
+  openCOPC,
+  parseCOPCKey,
+  type COPCFile,
+  type COPCHeader,
+  type COPCHierarchy,
+  type COPCHierarchyNode,
+  type COPCHierarchyPage,
+  type COPCRangeReader
+} from './lib/copc-reader';
 
 export type COPCSourceLoaderOptions = DataSourceOptions & {
   copc?: {
-    /** Decoder backend for compressed COPC LAZ node chunks. */
-    decoder?: 'laz-perf' | 'typescript-laz';
     sourceCoordinateSystem?: string;
     /** Default byte size for progressive COPC node range requests. */
     rangeChunkSize?: number;
@@ -96,7 +147,14 @@ export type COPCTileContentBatchOptions = {
     | 'classification'
     | 'GPS_TIME'
     | 'scanAngle'
+    | 'userData'
     | 'pointSourceId'
+    | 'returnNumber'
+    | 'numberOfReturns'
+    | 'scannerChannel'
+    | 'scanDirectionFlag'
+    | 'edgeOfFlightLine'
+    | 'EXTRA_BYTES'
   )[];
   /** Byte size for progressive node range requests. */
   rangeChunkSize?: number;
@@ -115,9 +173,9 @@ export type COPCHierarchyBatchOptions = {
 /** One hierarchy page and the nodes/pages discovered in it. */
 export type COPCHierarchyBatch = {
   pageId: string;
-  page: Hierarchy.Page;
-  nodes: Hierarchy.Node.Map;
-  pages: Hierarchy.Page.Map;
+  page: COPCHierarchyPage;
+  nodes: COPCHierarchy['nodes'];
+  pages: COPCHierarchy['pages'];
 };
 
 /** Arrow table content returned for one COPC tile batch. */
@@ -184,19 +242,21 @@ export class COPCTileSource
   isReady = false;
 
   protected _initPromise: Promise<{
-    copc: Copc;
-    hierarchy: Hierarchy.Subtree;
-    rootNode: Hierarchy.Node;
+    copc: COPCFile;
+    hierarchy: COPCHierarchy;
+    rootNode: COPCHierarchyNode;
   }>;
-  protected _urlOrGetter: string | Getter;
-  protected _copc: Copc | null = null;
+  protected _readableFile: ReadableFile;
+  protected _readRange: COPCRangeReader;
+  protected _copc: COPCFile | null = null;
   protected _projection: Proj4Projection | null = null;
-  protected _hierarchy: Hierarchy.Subtree | null = null;
+  protected _hierarchy: COPCHierarchy | null = null;
   protected _pageLoadPromises: Map<string, Promise<void>> = new Map();
 
   constructor(data: string | Blob, options: COPCSourceLoaderOptions, coreApi?: CoreAPI) {
     super(data, options, COPCSourceLoader.defaultOptions, coreApi);
-    this._urlOrGetter = createCOPCGetter(data, this.url);
+    this._readableFile = createCOPCReadableFile(data, this.url, this.fetch);
+    this._readRange = createCachedCOPCRangeReader(this._readableFile);
     this._initPromise = this._initCopc(this.url || 'Blob');
     this.metadata = this.getMetadata();
   }
@@ -206,18 +266,8 @@ export class COPCTileSource
   }
 
   async getSchema(): Promise<Schema> {
-    const {copc, rootNode} = await this._initPromise;
-    const view = await this.loadPointDataView(copc, rootNode);
-
-    const fields: Field[] = [];
-    for (const [name, dimension] of Object.entries(view.dimensions)) {
-      if (dimension) {
-        const type = getDataTypeFromDimension(dimension);
-        fields.push({name, type, nullable: false});
-      }
-    }
-
-    return {fields, metadata: {}};
+    const {copc} = await this._initPromise;
+    return getCOPCHeaderSchema(copc.header.pointDataRecordFormat);
   }
 
   /** Discovers point attributes and spatial bounds without decoding point rows. */
@@ -239,9 +289,11 @@ export class COPCTileSource
       columnRoles: roles,
       spatial: {
         bounds: {minimum: copc.header.min, maximum: copc.header.max},
-        coordinateReferenceSystems: this.options.copc?.sourceCoordinateSystem
-          ? [this.options.copc.sourceCoordinateSystem]
-          : undefined
+        coordinateReferenceSystems: copc.wkt
+          ? [copc.wkt]
+          : this.options.copc?.sourceCoordinateSystem
+            ? [this.options.copc.sourceCoordinateSystem]
+            : undefined
       },
       statistics: {rowCount: copc.header.pointCount}
     });
@@ -342,31 +394,22 @@ export class COPCTileSource
   async getPoints(parameters: GetNodeParameters) {
     const {copc} = await this._initPromise;
     const node = await this.getNode(parameters);
-    const view = node && (await this.loadPointDataView(copc, node));
-    if (!view) {
+    if (!node || node.pointCount === 0) {
       return null;
     }
-
-    // console.log('Dimensions:', view.dimensions);
-
-    const schema = await this.getSchema();
-    const columnNames = schema.fields.map(field => field.name);
-    const columnGetters = columnNames.map(name => view.getter(name));
-
-    // const offset = parameters.offset || 0;
-    // const limit = Math.min(parameters.limit ?? view.pointCount, view.pointCount - offset);
-    // const ArrayType = getArrayTypeFromDataType(limit);
-
-    function getXyzi(index: number): number[] {
-      return columnGetters.map(get => get(index));
-    }
-    const point = getXyzi(0);
-    // console.log('Point:', point);
-    return point;
+    const compressed = await loadCOPCNodeData(this._readRange, node);
+    const pointData = new Uint8Array(copc.header.pointDataRecordLength);
+    const cursor = createLAZChunkDecoderCursor(compressed, {
+      pointCount: node.pointCount,
+      pointDataRecordFormat: copc.header.pointDataRecordFormat,
+      pointDataRecordLength: copc.header.pointDataRecordLength
+    });
+    cursor.decodeInto(pointData, 0, 1);
+    return readCOPCPointValues(pointData, copc.header);
   }
 
-  async getNode(parameters: GetNodeParameters): Promise<Hierarchy.Node | undefined> {
-    return await this.getNodeById(Key.toString(parameters.nodeIndex));
+  async getNode(parameters: GetNodeParameters): Promise<COPCHierarchyNode | undefined> {
+    return await this.getNodeById(formatCOPCKey(parameters.nodeIndex));
   }
 
   async loadTileContent(tile: {id: string}) {
@@ -379,21 +422,7 @@ export class COPCTileSource
     const nativeOrigin = this.getNativeTileCenter(tile.id);
     const cartographicOrigin = this.projectPoint(nativeOrigin);
 
-    if (
-      this.options.copc?.decoder === 'typescript-laz' &&
-      supportsDirectCOPCPointDataOutput(copc.header.pointDataRecordFormat)
-    ) {
-      return await this.loadTypeScriptTileContent(copc, node, nativeOrigin, cartographicOrigin);
-    }
-
-    const view = await this.loadPointDataView(copc, node);
-    const pointCount = view.pointCount;
-    const positions = new Float32Array(pointCount * 3);
-    const colors = this.createColorArray(view, pointCount);
-
-    this.populateTileAttributes(view, positions, colors, nativeOrigin, cartographicOrigin);
-
-    return this.createTileContentResult(pointCount, positions, colors, cartographicOrigin);
+    return await this.loadTypeScriptTileContent(copc, node, nativeOrigin, cartographicOrigin);
   }
 
   /**
@@ -414,13 +443,6 @@ export class COPCTileSource
     if (!node) {
       return;
     }
-    if (
-      this.options.copc?.decoder !== 'typescript-laz' ||
-      !supportsDirectCOPCPointDataOutput(copc.header.pointDataRecordFormat)
-    ) {
-      throw new Error('COPC progressive batches require the TypeScript LAZ decoder for PDRF 6-8');
-    }
-
     if (options.signal?.aborted) {
       throw new Error('COPC progressive tile decode was aborted');
     }
@@ -430,16 +452,24 @@ export class COPCTileSource
     }
     const nativeOrigin = this.getNativeTileCenter(tile.id);
     const cartographicOrigin = this.projectPoint(nativeOrigin);
-    const colors =
-      pointFormatHasColor(copc.header.pointDataRecordFormat) &&
-      (options.columns ? options.columns.includes('COLOR_0') : true);
-    const nir =
-      copc.header.pointDataRecordFormat === 8 && Boolean(options.columns?.includes('NIR'));
-    const intensity = Boolean(options.columns?.includes('intensity'));
-    const classification = Boolean(options.columns?.includes('classification'));
-    const gpsTime = Boolean(options.columns?.includes('GPS_TIME'));
-    const scanAngle = Boolean(options.columns?.includes('scanAngle'));
-    const pointSourceId = Boolean(options.columns?.includes('pointSourceId'));
+    const selection: COPCPointSelection = {
+      colors:
+        pointFormatHasColor(copc.header.pointDataRecordFormat) &&
+        (options.columns ? options.columns.includes('COLOR_0') : true),
+      nir: copc.header.pointDataRecordFormat === 8 && Boolean(options.columns?.includes('NIR')),
+      intensity: Boolean(options.columns?.includes('intensity')),
+      classification: Boolean(options.columns?.includes('classification')),
+      gpsTime: Boolean(options.columns?.includes('GPS_TIME')),
+      scanAngle: Boolean(options.columns?.includes('scanAngle')),
+      userData: Boolean(options.columns?.includes('userData')),
+      pointSourceId: Boolean(options.columns?.includes('pointSourceId')),
+      returnNumber: Boolean(options.columns?.includes('returnNumber')),
+      numberOfReturns: Boolean(options.columns?.includes('numberOfReturns')),
+      scannerChannel: Boolean(options.columns?.includes('scannerChannel')),
+      scanDirectionFlag: Boolean(options.columns?.includes('scanDirectionFlag')),
+      edgeOfFlightLine: Boolean(options.columns?.includes('edgeOfFlightLine')),
+      extraBytes: Boolean(options.columns?.includes('EXTRA_BYTES'))
+    };
     const rangeChunkSize = options.rangeChunkSize ?? this.options.copc?.rangeChunkSize ?? 65536;
     if (!Number.isSafeInteger(rangeChunkSize) || rangeChunkSize < 1) {
       throw new Error('COPC progressive rangeChunkSize must be a positive integer');
@@ -452,6 +482,9 @@ export class COPCTileSource
     if (options.columns?.includes('NIR') && copc.header.pointDataRecordFormat !== 8) {
       throw new Error('COPC NIR output requires PDRF 8');
     }
+    if (selection.extraBytes && !copc.extraBytes) {
+      throw new Error('COPC typed Extra Bytes output requires an Extra Bytes VLR');
+    }
 
     yield* this.loadProgressiveTileContentInBatches(
       copc,
@@ -462,33 +495,21 @@ export class COPCTileSource
       rangeChunkSize,
       rangeConcurrency,
       options.signal,
-      colors,
-      nir,
-      intensity,
-      classification,
-      gpsTime,
-      scanAngle,
-      pointSourceId
+      selection
     );
   }
 
   /** Yield selectively requested batches while the node range is still arriving. */
   protected async *loadProgressiveTileContentInBatches(
-    copc: Copc,
-    node: Hierarchy.Node,
+    copc: COPCFile,
+    node: COPCHierarchyNode,
     nativeOrigin: number[],
     cartographicOrigin: number[],
     batchSize: number,
     rangeChunkSize: number,
     rangeConcurrency: number,
     signal: AbortSignal | undefined,
-    colors: boolean,
-    nir: boolean,
-    intensity: boolean,
-    classification: boolean,
-    gpsTime: boolean,
-    scanAngle: boolean,
-    pointSourceId: boolean
+    selection: COPCPointSelection
   ): AsyncIterable<COPCTileContent> {
     const decoder = createLAZChunkDecoder({
       pointCount: node.pointCount,
@@ -512,13 +533,7 @@ export class COPCTileSource
         cartographicOrigin,
         batchSize,
         decodedPointCount,
-        colors,
-        nir,
-        intensity,
-        classification,
-        gpsTime,
-        scanAngle,
-        pointSourceId
+        selection
       );
       decodedPointCount = node.pointCount - decoder.remainingPointCount;
     }
@@ -533,13 +548,7 @@ export class COPCTileSource
         cartographicOrigin,
         batchSize,
         decodedPointCount,
-        colors,
-        nir,
-        intensity,
-        classification,
-        gpsTime,
-        scanAngle,
-        pointSourceId
+        selection
       );
       decodedPointCount = node.pointCount - decoder.remainingPointCount;
     }
@@ -553,31 +562,37 @@ export class COPCTileSource
   /** Read all currently available selectively requested batches from a feedable decoder. */
   protected *readProgressiveBatches(
     decoder: ReturnType<typeof createLAZChunkDecoder>,
-    copc: Copc,
+    copc: COPCFile,
     nodePointCount: number,
     nativeOrigin: number[],
     cartographicOrigin: number[],
     batchSize: number,
     decodedPointCount: number,
-    includeColors: boolean,
-    includeNir: boolean,
-    includeIntensity: boolean,
-    includeClassification: boolean,
-    includeGpsTime: boolean,
-    includeScanAngle: boolean,
-    includePointSourceId: boolean
+    selection: COPCPointSelection
   ): Iterable<COPCTileContent> {
     while (decodedPointCount < nodePointCount) {
       const pointCount = Math.min(batchSize, nodePointCount - decodedPointCount);
       const nativePositions = new Float64Array(pointCount * 3);
       const positions = new Float32Array(pointCount * 3);
-      const batchColors = includeColors ? new Uint16Array(pointCount * 3) : null;
-      const batchNir = includeNir ? new Uint16Array(pointCount) : null;
-      const batchIntensities = includeIntensity ? new Uint16Array(pointCount) : null;
-      const batchClassifications = includeClassification ? new Uint8Array(pointCount) : null;
-      const batchGpsTimes = includeGpsTime ? new Float64Array(pointCount) : null;
-      const batchScanAngles = includeScanAngle ? new Int16Array(pointCount) : null;
-      const batchPointSourceIds = includePointSourceId ? new Uint16Array(pointCount) : null;
+      const batchColors = selection.colors ? new Uint16Array(pointCount * 3) : null;
+      const batchNir = selection.nir ? new Uint16Array(pointCount) : null;
+      const batchIntensities = selection.intensity ? new Uint16Array(pointCount) : null;
+      const batchClassifications = selection.classification ? new Uint8Array(pointCount) : null;
+      const batchGpsTimes = selection.gpsTime ? new Float64Array(pointCount) : null;
+      const batchScanAngles = selection.scanAngle ? new Int16Array(pointCount) : null;
+      const batchUserData = selection.userData ? new Uint8Array(pointCount) : null;
+      const batchPointSourceIds = selection.pointSourceId ? new Uint16Array(pointCount) : null;
+      const batchReturnNumbers = selection.returnNumber ? new Uint8Array(pointCount) : null;
+      const batchNumberOfReturns = selection.numberOfReturns ? new Uint8Array(pointCount) : null;
+      const batchScannerChannels = selection.scannerChannel ? new Uint8Array(pointCount) : null;
+      const batchScanDirectionFlags = selection.scanDirectionFlag
+        ? new Uint8Array(pointCount)
+        : null;
+      const batchEdgeOfFlightLines = selection.edgeOfFlightLine ? new Uint8Array(pointCount) : null;
+      const extraByteCount = getCOPCExtraByteCount(copc.header);
+      const batchExtraBytes = selection.extraBytes
+        ? new Uint8Array(pointCount * extraByteCount)
+        : null;
       const decoded = decoder.readPointDataBatch(
         {
           positions: nativePositions,
@@ -587,7 +602,14 @@ export class COPCTileSource
           classifications: batchClassifications,
           gpsTimes: batchGpsTimes,
           scanAngles: batchScanAngles,
+          userData: batchUserData,
           pointSourceIds: batchPointSourceIds,
+          returnNumbers: batchReturnNumbers,
+          numberOfReturns: batchNumberOfReturns,
+          scannerChannels: batchScannerChannels,
+          scanDirectionFlags: batchScanDirectionFlags,
+          edgeOfFlightLines: batchEdgeOfFlightLines,
+          extraBytes: batchExtraBytes,
           pointOffset: 0,
           scale: copc.header.scale,
           offset: copc.header.offset
@@ -599,6 +621,12 @@ export class COPCTileSource
       }
       if (decoded === 0) {
         return;
+      }
+      const typedExtraBytes = batchExtraBytes
+        ? createLASTypedExtraBytesAttributes(pointCount, copc.extraBytesDescriptors, extraByteCount)
+        : [];
+      if (batchExtraBytes) {
+        populateLASTypedExtraBytes(batchExtraBytes, pointCount, extraByteCount, typedExtraBytes);
       }
       this.transformTilePositions(nativePositions, positions, nativeOrigin, cartographicOrigin);
       yield this.createTileContentResult(
@@ -612,7 +640,14 @@ export class COPCTileSource
           batchClassifications,
           batchGpsTimes,
           batchScanAngles,
-          batchPointSourceIds
+          batchUserData,
+          batchPointSourceIds,
+          batchReturnNumbers,
+          batchNumberOfReturns,
+          batchScannerChannels,
+          batchScanDirectionFlags,
+          batchEdgeOfFlightLines,
+          typedExtraBytes
         }
       );
       decodedPointCount += decoded;
@@ -625,7 +660,7 @@ export class COPCTileSource
   ): AsyncIterable<COPCHierarchyBatch> {
     const {copc} = await this._initPromise;
     const rootPage = copc.info.rootHierarchyPage;
-    const pending: Array<[string, Hierarchy.Page]> = [['root', rootPage]];
+    const pending: Array<[string, COPCHierarchyPage]> = [['root', rootPage]];
     const visited = new Set<string>();
     let loadedPageCount = 0;
 
@@ -645,7 +680,7 @@ export class COPCTileSource
       const subtree =
         pageId === 'root' && this._hierarchy
           ? this._hierarchy
-          : await Copc.loadHierarchyPage(this._urlOrGetter, page);
+          : await loadCOPCHierarchyPage(this._readRange, page, options.signal);
       if (this._hierarchy) {
         this._hierarchy.nodes = {...this._hierarchy.nodes, ...subtree.nodes};
         this._hierarchy.pages = {...this._hierarchy.pages, ...subtree.pages};
@@ -663,12 +698,11 @@ export class COPCTileSource
 
   /** Fetch a COPC node range in bounded parallel chunks while preserving order. */
   protected async *loadCOPCNodeRangeChunks(
-    node: Hierarchy.Node,
+    node: COPCHierarchyNode,
     rangeChunkSize: number,
     rangeConcurrency: number,
     signal?: AbortSignal
   ): AsyncIterable<Uint8Array> {
-    const get = Getter.create(this._urlOrGetter);
     const rangeEnd = node.pointDataOffset + node.pointDataLength;
     const rangeCount = Math.ceil(node.pointDataLength / rangeChunkSize);
     type RangeResult = {chunk: Uint8Array; error?: never} | {chunk?: never; error: unknown};
@@ -684,7 +718,7 @@ export class COPCTileSource
           const end = Math.min(begin + rangeChunkSize, rangeEnd);
           pending.set(
             nextToSchedule,
-            get(begin, end).then(
+            this._readRange(begin, end, signal).then(
               chunk => ({chunk}),
               error => ({error})
             )
@@ -709,13 +743,13 @@ export class COPCTileSource
 
   /** Decode a COPC node directly into the typed attributes used for rendering. */
   protected async loadTypeScriptTileContent(
-    copc: Copc,
-    node: Hierarchy.Node,
+    copc: COPCFile,
+    node: COPCHierarchyNode,
     nativeOrigin: number[],
     cartographicOrigin: number[]
   ) {
     const pointCount = node.pointCount;
-    const compressed = await Copc.loadCompressedPointDataBuffer(this._urlOrGetter, node);
+    const compressed = await loadCOPCNodeData(this._readRange, node);
     const nativePositions = new Float64Array(pointCount * 3);
     const positions = new Float32Array(pointCount * 3);
     const colors = pointFormatHasColor(copc.header.pointDataRecordFormat)
@@ -778,8 +812,8 @@ export class COPCTileSource
   }
 
   async _initCopc(url: string) {
-    const copc = await Copc.create(this._urlOrGetter);
-    const hierarchy = await Copc.loadHierarchyPage(this._urlOrGetter, copc.info.rootHierarchyPage);
+    const copc = await openCOPC(this._readRange);
+    const hierarchy = await loadCOPCHierarchyPage(this._readRange, copc.info.rootHierarchyPage);
     const {['0-0-0-0']: rootNode} = hierarchy.nodes;
     if (!rootNode) {
       throw new Error(`Failed to load COPC hierarchy root node ${url}`);
@@ -791,28 +825,7 @@ export class COPCTileSource
     return {copc, hierarchy, rootNode};
   }
 
-  protected async loadPointDataView(copc: Copc, node: Hierarchy.Node) {
-    if (this.options.copc?.decoder !== 'typescript-laz') {
-      return await Copc.loadPointDataView(this._urlOrGetter, copc, node);
-    }
-
-    const compressed = await Copc.loadCompressedPointDataBuffer(this._urlOrGetter, node);
-    const metadata = {
-      pointCount: node.pointCount,
-      pointDataRecordFormat: copc.header.pointDataRecordFormat,
-      pointDataRecordLength: copc.header.pointDataRecordLength
-    };
-    const batches: Uint8Array[] = [];
-    for await (const batch of decodeLAZChunkInBatches([compressed], metadata, {
-      batchSize: node.pointCount
-    })) {
-      batches.push(batch);
-    }
-    const pointData = new Uint8Array(concatenateArrayBuffersFromArray(batches));
-    return Las.View.create(pointData, copc.header, copc.eb);
-  }
-
-  protected async getNodeById(tileId: string): Promise<Hierarchy.Node | undefined> {
+  protected async getNodeById(tileId: string): Promise<COPCHierarchyNode | undefined> {
     await this.initialize();
 
     if (!this._hierarchy) {
@@ -834,91 +847,13 @@ export class COPCTileSource
     return this._hierarchy.nodes[tileId];
   }
 
-  protected createColorArray(
-    view: Awaited<ReturnType<typeof Copc.loadPointDataView>>,
-    pointCount: number
-  ) {
-    const hasColors =
-      Boolean(view.dimensions.Red) &&
-      Boolean(view.dimensions.Green) &&
-      Boolean(view.dimensions.Blue);
-    return hasColors ? new Uint16Array(pointCount * 3) : null;
-  }
-
-  protected populateTileAttributes(
-    view: Awaited<ReturnType<typeof Copc.loadPointDataView>>,
-    positions: Float32Array,
-    colors: Uint16Array | null,
-    nativeOrigin: number[],
-    cartographicOrigin: number[]
-  ): void {
-    const getX = view.getter('X');
-    const getY = view.getter('Y');
-    const getZ = view.getter('Z');
-    const getRed = colors ? view.getter('Red') : null;
-    const getGreen = colors ? view.getter('Green') : null;
-    const getBlue = colors ? view.getter('Blue') : null;
-
-    for (let index = 0; index < view.pointCount; index++) {
-      const targetIndex = index * 3;
-      this.writePositionValues(
-        positions,
-        targetIndex,
-        [getX(index), getY(index), getZ(index)],
-        nativeOrigin,
-        cartographicOrigin
-      );
-      if (colors && getRed && getGreen && getBlue) {
-        this.writeColorValues(colors, targetIndex, getRed(index), getGreen(index), getBlue(index));
-      }
-    }
-  }
-
-  protected writePositionValues(
-    positions: Float32Array,
-    targetIndex: number,
-    nativePosition: [number, number, number],
-    nativeOrigin: number[],
-    cartographicOrigin: number[]
-  ): void {
-    if (this._projection) {
-      const cartographicPosition = this.projectPoint(nativePosition);
-      positions[targetIndex] = cartographicPosition[0] - cartographicOrigin[0];
-      positions[targetIndex + 1] = cartographicPosition[1] - cartographicOrigin[1];
-      positions[targetIndex + 2] = nativePosition[2] - nativeOrigin[2];
-      return;
-    }
-
-    positions[targetIndex] = nativePosition[0] - nativeOrigin[0];
-    positions[targetIndex + 1] = nativePosition[1] - nativeOrigin[1];
-    positions[targetIndex + 2] = nativePosition[2] - nativeOrigin[2];
-  }
-
-  protected writeColorValues(
-    colors: Uint16Array,
-    targetIndex: number,
-    red: number,
-    green: number,
-    blue: number
-  ): void {
-    colors[targetIndex] = red;
-    colors[targetIndex + 1] = green;
-    colors[targetIndex + 2] = blue;
-  }
-
   protected createTileContentResult(
     pointCount: number,
     positions: Float32Array,
     colors: Uint16Array | null,
     origin: number[],
     nir: Uint16Array | null = null,
-    pointData: {
-      batchIntensities: Uint16Array | null;
-      batchClassifications: Uint8Array | null;
-      batchGpsTimes: Float64Array | null;
-      batchScanAngles: Int16Array | null;
-      batchPointSourceIds: Uint16Array | null;
-    } | null = null
+    pointData: COPCPointDataArrays | null = null
   ): COPCTileContent {
     const positionsAttribute = {value: positions, size: 3};
     const colorsAttribute = colors ? {value: colors, size: 3, normalized: true} : undefined;
@@ -945,13 +880,7 @@ export class COPCTileSource
     positions: {value: Float32Array; size: number},
     colors?: {value: Uint16Array; size: number; normalized: boolean},
     nir?: {value: Uint16Array; size: number},
-    pointData?: {
-      batchIntensities: Uint16Array | null;
-      batchClassifications: Uint8Array | null;
-      batchGpsTimes: Float64Array | null;
-      batchScanAngles: Int16Array | null;
-      batchPointSourceIds: Uint16Array | null;
-    } | null
+    pointData?: COPCPointDataArrays | null
   ): MeshArrowTable {
     const attributes: Mesh['attributes'] = {
       POSITION: positions
@@ -974,8 +903,29 @@ export class COPCTileSource
     if (pointData?.batchScanAngles) {
       attributes.scanAngle = {value: pointData.batchScanAngles, size: 1};
     }
+    if (pointData?.batchUserData) {
+      attributes.userData = {value: pointData.batchUserData, size: 1};
+    }
     if (pointData?.batchPointSourceIds) {
       attributes.pointSourceId = {value: pointData.batchPointSourceIds, size: 1};
+    }
+    if (pointData?.batchReturnNumbers) {
+      attributes.returnNumber = {value: pointData.batchReturnNumbers, size: 1};
+    }
+    if (pointData?.batchNumberOfReturns) {
+      attributes.numberOfReturns = {value: pointData.batchNumberOfReturns, size: 1};
+    }
+    if (pointData?.batchScannerChannels) {
+      attributes.scannerChannel = {value: pointData.batchScannerChannels, size: 1};
+    }
+    if (pointData?.batchScanDirectionFlags) {
+      attributes.scanDirectionFlag = {value: pointData.batchScanDirectionFlags, size: 1};
+    }
+    if (pointData?.batchEdgeOfFlightLines) {
+      attributes.edgeOfFlightLine = {value: pointData.batchEdgeOfFlightLines, size: 1};
+    }
+    for (const attribute of pointData?.typedExtraBytes || []) {
+      attributes[attribute.name] = {value: attribute.value, size: attribute.size};
     }
 
     return convertMeshToTable(
@@ -1013,12 +963,12 @@ export class COPCTileSource
     await this._pageLoadPromises.get(tileId);
   }
 
-  protected async loadHierarchyPage(tileId: string, page: Hierarchy.Page): Promise<void> {
+  protected async loadHierarchyPage(tileId: string, page: COPCHierarchyPage): Promise<void> {
     if (!this._hierarchy) {
       return;
     }
 
-    const subtree = await Copc.loadHierarchyPage(this._urlOrGetter, page);
+    const subtree = await loadCOPCHierarchyPage(this._readRange, page);
     this._hierarchy.nodes = {
       ...this._hierarchy.nodes,
       ...subtree.nodes
@@ -1032,7 +982,7 @@ export class COPCTileSource
 
   protected getTileHeader(
     tileId: string,
-    node: Hierarchy.Node
+    node: COPCHierarchyNode
   ): {
     id: string;
     level: number;
@@ -1044,7 +994,7 @@ export class COPCTileSource
       radius: number;
     };
   } {
-    const [depth] = Key.parse(tileId);
+    const [depth] = parseCOPCKey(tileId);
     return {
       id: tileId,
       level: depth,
@@ -1182,7 +1132,7 @@ export class COPCTileSource
 
   protected getNativeTileBounds(tileId: string): [number[], number[]] {
     const {copc} = this.unwrapState();
-    const nativeBounds = Bounds.stepTo(copc.info.cube, Key.parse(tileId));
+    const nativeBounds = getCOPCKeyBounds(copc.info.cube, parseCOPCKey(tileId));
     const dataMin = copc.header.min;
     const dataMax = copc.header.max;
 
@@ -1201,14 +1151,14 @@ export class COPCTileSource
   }
 
   protected getChildKeys(tileId: string): string[] {
-    const key = Key.parse(tileId);
+    const key = parseCOPCKey(tileId);
     const result: string[] = [];
 
     for (let childX = 0; childX < 2; childX++) {
       for (let childY = 0; childY < 2; childY++) {
         for (let childZ = 0; childZ < 2; childZ++) {
           result.push(
-            Key.toString([
+            formatCOPCKey([
               key[0] + 1,
               key[1] * 2 + childX,
               key[2] * 2 + childY,
@@ -1223,12 +1173,12 @@ export class COPCTileSource
   }
 
   protected getAncestorKeys(tileId: string): string[] {
-    const key = Key.parse(tileId);
+    const key = parseCOPCKey(tileId);
     const result: string[] = [];
 
     for (let depth = key[0] - 1; depth >= 0; depth--) {
       result.push(
-        Key.toString([
+        formatCOPCKey([
           depth,
           key[1] >> (key[0] - depth),
           key[2] >> (key[0] - depth),
@@ -1241,8 +1191,8 @@ export class COPCTileSource
   }
 
   protected unwrapState(): {
-    copc: Copc;
-    hierarchy: Hierarchy.Subtree;
+    copc: COPCFile;
+    hierarchy: COPCHierarchy;
   } {
     if (!this._copc || !this._hierarchy) {
       throw new Error('COPC source is not initialized');
@@ -1282,45 +1232,38 @@ export class COPCTileSource
   */
 }
 
-function getDataTypeFromDimension(dimension: Dimension): DataType {
-  const {type, size} = dimension;
-  switch (type) {
-    case 'unsigned':
-      return size === 1 ? 'uint8' : size === 2 ? 'uint16' : size === 4 ? 'uint32' : 'uint64';
-    case 'signed':
-      return size === 1 ? 'int8' : size === 2 ? 'int16' : size === 4 ? 'int32' : 'int64';
-    case 'float':
-      return size === 4 ? 'float32' : 'float64';
-    default:
-      return 'null';
-  }
-}
-
 /** Builds the standard query schema from a COPC point-data record format. */
 function getCOPCHeaderSchema(pointDataRecordFormat: number): Schema {
   const fields: Field[] = [
     {name: 'X', type: 'float64', nullable: false},
     {name: 'Y', type: 'float64', nullable: false},
-    {name: 'Z', type: 'float64', nullable: false}
+    {name: 'Z', type: 'float64', nullable: false},
+    {name: 'Intensity', type: 'uint16', nullable: false},
+    {name: 'ReturnNumber', type: 'uint8', nullable: false},
+    {name: 'NumberOfReturns', type: 'uint8', nullable: false},
+    {name: 'ScanDirectionFlag', type: 'bool', nullable: false},
+    {name: 'EdgeOfFlightLine', type: 'bool', nullable: false},
+    {name: 'Classification', type: 'uint8', nullable: false},
+    {name: 'Synthetic', type: 'bool', nullable: false},
+    {name: 'KeyPoint', type: 'bool', nullable: false},
+    {name: 'Withheld', type: 'bool', nullable: false},
+    {name: 'Overlap', type: 'bool', nullable: false},
+    {name: 'ScannerChannel', type: 'uint8', nullable: false},
+    {name: 'ScanAngle', type: 'float32', nullable: false},
+    {name: 'UserData', type: 'uint8', nullable: false},
+    {name: 'PointSourceId', type: 'uint16', nullable: false},
+    {name: 'GpsTime', type: 'float64', nullable: false}
   ];
-  if (pointDataRecordFormat === 1 || pointDataRecordFormat === 3 || pointDataRecordFormat >= 6) {
-    fields.push({name: 'Intensity', type: 'uint16', nullable: false});
-  }
-  if (
-    pointDataRecordFormat === 2 ||
-    pointDataRecordFormat === 3 ||
-    pointDataRecordFormat === 7 ||
-    pointDataRecordFormat === 8 ||
-    pointDataRecordFormat === 10
-  ) {
+  if (pointDataRecordFormat === 7 || pointDataRecordFormat === 8) {
     fields.push(
       {name: 'Red', type: 'uint16', nullable: false},
       {name: 'Green', type: 'uint16', nullable: false},
       {name: 'Blue', type: 'uint16', nullable: false}
     );
   }
-  if (pointDataRecordFormat >= 6)
-    fields.push({name: 'Classification', type: 'uint8', nullable: false});
+  if (pointDataRecordFormat === 8) {
+    fields.push({name: 'Infrared', type: 'uint16', nullable: false});
+  }
   return {fields, metadata: {}};
 }
 
@@ -1347,28 +1290,88 @@ function normalizeProjectionDefinition(projectionData: string): string {
   return horizontalWktMatch?.[1] || projectionData;
 }
 
-/** Return whether a valid COPC point format supports direct typed point-data output. */
-function supportsDirectCOPCPointDataOutput(pointDataRecordFormat: number): boolean {
-  return pointDataRecordFormat >= 6 && pointDataRecordFormat <= 8;
-}
-
 /** Return whether a LAS point format contains RGB channels. */
 function pointFormatHasColor(pointDataRecordFormat: number): boolean {
   return pointDataRecordFormat === 7 || pointDataRecordFormat === 8;
 }
 
-/** Create the COPC package byte-range getter for URL/path and Blob inputs. */
-function createCOPCGetter(data: string | Blob, url: string): string | Getter {
-  if (typeof data === 'string') {
-    return url;
+/** Return the packed Extra Bytes width in a COPC point record. */
+function getCOPCExtraByteCount(header: COPCHeader): number {
+  const baseRecordLength =
+    header.pointDataRecordFormat === 6 ? 30 : header.pointDataRecordFormat === 7 ? 36 : 38;
+  return header.pointDataRecordLength - baseRecordLength;
+}
+
+/** Read one modern LAS point in the same field order returned by `getSchema()`. */
+function readCOPCPointValues(pointData: Uint8Array, header: COPCHeader): number[] {
+  const dataView = new DataView(pointData.buffer, pointData.byteOffset, pointData.byteLength);
+  const returnFlags = dataView.getUint8(14);
+  const scanFlags = dataView.getUint8(15);
+  const values = [
+    dataView.getInt32(0, true) * header.scale[0] + header.offset[0],
+    dataView.getInt32(4, true) * header.scale[1] + header.offset[1],
+    dataView.getInt32(8, true) * header.scale[2] + header.offset[2],
+    dataView.getUint16(12, true),
+    returnFlags & 0x0f,
+    returnFlags >> 4,
+    (scanFlags >> 6) & 1,
+    (scanFlags >> 7) & 1,
+    dataView.getUint8(16),
+    scanFlags & 1,
+    (scanFlags >> 1) & 1,
+    (scanFlags >> 2) & 1,
+    (scanFlags >> 3) & 1,
+    (scanFlags >> 4) & 3,
+    dataView.getInt16(18, true) * 0.006,
+    dataView.getUint8(17),
+    dataView.getUint16(20, true),
+    dataView.getFloat64(22, true)
+  ];
+  if (header.pointDataRecordFormat >= 7) {
+    values.push(
+      dataView.getUint16(30, true),
+      dataView.getUint16(32, true),
+      dataView.getUint16(34, true)
+    );
   }
+  if (header.pointDataRecordFormat === 8) {
+    values.push(dataView.getUint16(36, true));
+  }
+  return values;
+}
 
-  return async (begin: number, end: number): Promise<Uint8Array> => {
-    if (begin < 0 || end < 0 || begin > end) {
-      throw new Error('Invalid range');
+/** Create a cross-platform random-access file for URL, path, and Blob inputs. */
+function createCOPCReadableFile(
+  data: string | Blob,
+  url: string,
+  fetchFunction: (url: string, options?: RequestInit) => Promise<Response>
+): ReadableFile {
+  if (typeof data !== 'string') {
+    return new BlobFile(data);
+  }
+  if (isBrowser || /^https?:\/\//i.test(url)) {
+    return new HttpFile(url, {fetch: fetchFunction});
+  }
+  return new NodeFile(url, 'r');
+}
+
+/** Cache the metadata prefix while retaining exact reads for hierarchy and node ranges. */
+function createCachedCOPCRangeReader(readableFile: ReadableFile): COPCRangeReader {
+  const prefixPromise = Promise.resolve(readableFile.stat?.()).then(async stat => {
+    const prefixLength = Math.min(stat?.size || COPC_PREFIX_CACHE_LENGTH, COPC_PREFIX_CACHE_LENGTH);
+    return new Uint8Array(await readableFile.read(0, prefixLength));
+  });
+  return async (begin, end, signal) => {
+    if (signal?.aborted) {
+      throw new Error('COPC range request was aborted');
     }
-
-    const arrayBuffer = await data.slice(begin, end).arrayBuffer();
-    return new Uint8Array(arrayBuffer);
+    const prefix = await prefixPromise;
+    if (signal?.aborted) {
+      throw new Error('COPC range request was aborted');
+    }
+    if (begin >= 0 && end <= prefix.byteLength) {
+      return prefix.subarray(begin, end);
+    }
+    return new Uint8Array(await readableFile.read(begin, end - begin, signal));
   };
 }

--- a/modules/copc/src/index.ts
+++ b/modules/copc/src/index.ts
@@ -11,6 +11,27 @@ export type {
 } from './copc-source-loader';
 export type {COPCWriterOptions} from './copc-writer';
 export {COPCFormat} from './copc-format';
+export {
+  formatCOPCKey,
+  getCOPCKeyBounds,
+  loadCOPCHierarchyPage,
+  loadCOPCNodeData,
+  openCOPC,
+  parseCOPCHeader,
+  parseCOPCHierarchy,
+  parseCOPCInfo,
+  parseCOPCKey
+} from './lib/copc-reader';
+export type {
+  COPCFile,
+  COPCHeader,
+  COPCHierarchy,
+  COPCHierarchyNode,
+  COPCHierarchyPage,
+  COPCInfo,
+  COPCRangeReader,
+  COPCVariableLengthRecord
+} from './lib/copc-reader';
 export {COPCSourceLoader} from './copc-source-loader';
 export {COPCTileSource} from './copc-source-loader';
 export {COPCWriter} from './copc-writer';

--- a/modules/copc/src/index.ts
+++ b/modules/copc/src/index.ts
@@ -17,6 +17,7 @@ export {
   loadCOPCHierarchyPage,
   loadCOPCNodeData,
   openCOPC,
+  parseCOPCLAZMetadata,
   parseCOPCHeader,
   parseCOPCHierarchy,
   parseCOPCInfo,
@@ -29,6 +30,7 @@ export type {
   COPCHierarchyNode,
   COPCHierarchyPage,
   COPCInfo,
+  COPCLAZMetadata,
   COPCRangeReader,
   COPCVariableLengthRecord
 } from './lib/copc-reader';

--- a/modules/copc/src/lib/copc-reader.ts
+++ b/modules/copc/src/lib/copc-reader.ts
@@ -1,0 +1,553 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {parseLASExtraBytes, type LASExtraBytesDescriptor} from '@loaders.gl/las';
+
+/** Function that reads an exact half-open byte range from a COPC file. */
+export type COPCRangeReader = (
+  begin: number,
+  end: number,
+  signal?: AbortSignal
+) => Promise<Uint8Array>;
+
+/** LAS 1.4 public header fields required by a COPC reader. */
+export type COPCHeader = {
+  /** LAS file signature. */
+  fileSignature: 'LASF';
+  /** LAS global encoding bit field. */
+  globalEncoding: number;
+  /** LAS major version. */
+  majorVersion: 1;
+  /** LAS minor version. */
+  minorVersion: 4;
+  /** Public header byte length. */
+  headerLength: number;
+  /** Byte offset of point data. */
+  pointDataOffset: number;
+  /** Number of regular VLRs. */
+  vlrCount: number;
+  /** Uncompressed point data record format. */
+  pointDataRecordFormat: 6 | 7 | 8;
+  /** Byte length of one uncompressed point record. */
+  pointDataRecordLength: number;
+  /** Extended LAS 1.4 point count. */
+  pointCount: number;
+  /** Coordinate scale factors. */
+  scale: [number, number, number];
+  /** Coordinate offsets. */
+  offset: [number, number, number];
+  /** Dataset minimum coordinates. */
+  min: [number, number, number];
+  /** Dataset maximum coordinates. */
+  max: [number, number, number];
+  /** Byte offset of internally stored waveform data. */
+  waveformDataOffset: number;
+  /** Byte offset of the first EVLR. */
+  evlrOffset: number;
+  /** Number of EVLRs. */
+  evlrCount: number;
+};
+
+/** One LAS VLR or EVLR descriptor. */
+export type COPCVariableLengthRecord = {
+  /** VLR user identifier. */
+  userId: string;
+  /** VLR record identifier. */
+  recordId: number;
+  /** Absolute byte offset of the record payload. */
+  contentOffset: number;
+  /** Byte length of the record payload. */
+  contentLength: number;
+  /** Human-readable record description. */
+  description: string;
+  /** Whether this record uses the LAS EVLR header. */
+  isExtended: boolean;
+};
+
+/** Byte range containing a COPC hierarchy page. */
+export type COPCHierarchyPage = {
+  /** Absolute file byte offset. */
+  pageOffset: number;
+  /** Page byte length. */
+  pageLength: number;
+};
+
+/** Byte range and point count for one COPC octree node. */
+export type COPCHierarchyNode = {
+  /** Number of points in this node. */
+  pointCount: number;
+  /** Absolute offset of the compressed LAZ node chunk. */
+  pointDataOffset: number;
+  /** Compressed LAZ node chunk byte length. */
+  pointDataLength: number;
+};
+
+/** Parsed hierarchy entries from one or more COPC hierarchy pages. */
+export type COPCHierarchy = {
+  /** Point-bearing nodes keyed by `depth-x-y-z`. */
+  nodes: Record<string, COPCHierarchyNode | undefined>;
+  /** Child hierarchy pages keyed by `depth-x-y-z`. */
+  pages: Record<string, COPCHierarchyPage | undefined>;
+};
+
+/** Parsed COPC info VLR. */
+export type COPCInfo = {
+  /** Root octree cube as minimum XYZ followed by maximum XYZ. */
+  cube: [number, number, number, number, number, number];
+  /** Root point spacing. */
+  spacing: number;
+  /** Root hierarchy page byte range. */
+  rootHierarchyPage: COPCHierarchyPage;
+  /** Minimum and maximum GPS time. */
+  gpsTimeRange: [number, number];
+};
+
+/** Native metadata required to read a COPC file. */
+export type COPCFile = {
+  /** LAS 1.4 public header. */
+  header: COPCHeader;
+  /** Regular VLR and EVLR descriptors. */
+  vlrs: COPCVariableLengthRecord[];
+  /** COPC info VLR. */
+  info: COPCInfo;
+  /** OGC WKT coordinate reference system, when present. */
+  wkt?: string;
+  /** Raw Extra Bytes VLR payload, when present. */
+  extraBytes?: Uint8Array;
+  /** Parsed Extra Bytes descriptors, when present. */
+  extraBytesDescriptors: LASExtraBytesDescriptor[];
+};
+
+const LAS_1_4_HEADER_LENGTH = 375;
+const VLR_HEADER_LENGTH = 54;
+const EVLR_HEADER_LENGTH = 60;
+const COPC_INFO_LENGTH = 160;
+const HIERARCHY_ENTRY_LENGTH = 32;
+const COPC_INFO_USER_ID = 'copc';
+const COPC_INFO_RECORD_ID = 1;
+const WKT_USER_ID = 'LASF_Projection';
+const WKT_RECORD_ID = 2112;
+const EXTRA_BYTES_USER_ID = 'LASF_Spec';
+const EXTRA_BYTES_RECORD_ID = 4;
+
+/** Open and validate a COPC 1.0 file using only exact byte-range reads. */
+export async function openCOPC(
+  readRange: COPCRangeReader,
+  signal?: AbortSignal
+): Promise<COPCFile> {
+  const header = parseCOPCHeader(await readExactRange(readRange, 0, LAS_1_4_HEADER_LENGTH, signal));
+  const regularVlrs = await readVariableLengthRecords(
+    readRange,
+    header.headerLength,
+    header.vlrCount,
+    false,
+    header.pointDataOffset,
+    signal
+  );
+  const extendedVlrs = header.evlrCount
+    ? await readVariableLengthRecords(
+        readRange,
+        header.evlrOffset,
+        header.evlrCount,
+        true,
+        Number.MAX_SAFE_INTEGER,
+        signal
+      )
+    : [];
+  const vlrs = [...regularVlrs, ...extendedVlrs];
+  const infoRecord = findRecord(regularVlrs, COPC_INFO_USER_ID, COPC_INFO_RECORD_ID);
+  if (!infoRecord) {
+    throw new Error('COPC info VLR is required');
+  }
+  if (regularVlrs[0] !== infoRecord) {
+    throw new Error('COPC info VLR must be the first VLR');
+  }
+  const info = parseCOPCInfo(await readRecordPayload(readRange, infoRecord, signal));
+  const wktRecord = findRecord(vlrs, WKT_USER_ID, WKT_RECORD_ID);
+  const wkt = wktRecord?.contentLength
+    ? decodeCString(await readRecordPayload(readRange, wktRecord, signal)) || undefined
+    : undefined;
+  const extraBytesRecord = findRecord(vlrs, EXTRA_BYTES_USER_ID, EXTRA_BYTES_RECORD_ID);
+  const extraBytes = extraBytesRecord
+    ? await readRecordPayload(readRange, extraBytesRecord, signal)
+    : undefined;
+
+  return {
+    header,
+    vlrs,
+    info,
+    wkt,
+    extraBytes,
+    extraBytesDescriptors: extraBytes ? parseLASExtraBytes(extraBytes) : []
+  };
+}
+
+/** Parse and validate the LAS 1.4 public header required by COPC 1.0. */
+export function parseCOPCHeader(bytes: Uint8Array): COPCHeader {
+  if (bytes.byteLength < LAS_1_4_HEADER_LENGTH) {
+    throw new Error(`COPC header requires ${LAS_1_4_HEADER_LENGTH} bytes`);
+  }
+  const dataView = createDataView(bytes);
+  if (decodeCString(bytes.subarray(0, 4)) !== 'LASF') {
+    throw new Error('Invalid COPC LAS file signature');
+  }
+  const majorVersion = dataView.getUint8(24);
+  const minorVersion = dataView.getUint8(25);
+  if (majorVersion !== 1 || minorVersion !== 4) {
+    throw new Error(`COPC requires LAS 1.4; received LAS ${majorVersion}.${minorVersion}`);
+  }
+  const headerLength = dataView.getUint16(94, true);
+  if (headerLength < LAS_1_4_HEADER_LENGTH) {
+    throw new Error(`Invalid COPC LAS header length ${headerLength}`);
+  }
+  const encodedPointFormat = dataView.getUint8(104);
+  const pointDataRecordFormat = encodedPointFormat & 0x3f;
+  if ((encodedPointFormat & 0x80) === 0) {
+    throw new Error('COPC point data must use LAZ compression');
+  }
+  if (pointDataRecordFormat < 6 || pointDataRecordFormat > 8) {
+    throw new Error(`COPC requires PDRF 6, 7, or 8; received ${pointDataRecordFormat}`);
+  }
+  const pointDataOffset = dataView.getUint32(96, true);
+  if (pointDataOffset < headerLength) {
+    throw new Error('COPC point data offset precedes the VLR area');
+  }
+  const globalEncoding = dataView.getUint16(6, true);
+  if ((globalEncoding & 0x10) === 0) {
+    throw new Error('COPC requires the LAS 1.4 WKT global encoding bit');
+  }
+  const pointDataRecordLength = dataView.getUint16(105, true);
+  const minimumRecordLengths = [0, 0, 0, 0, 0, 0, 30, 36, 38];
+  if (pointDataRecordLength < minimumRecordLengths[pointDataRecordFormat]) {
+    throw new Error(
+      `COPC PDRF ${pointDataRecordFormat} requires at least ${minimumRecordLengths[pointDataRecordFormat]} bytes per point`
+    );
+  }
+
+  return {
+    fileSignature: 'LASF',
+    globalEncoding,
+    majorVersion: 1,
+    minorVersion: 4,
+    headerLength,
+    pointDataOffset,
+    vlrCount: dataView.getUint32(100, true),
+    pointDataRecordFormat: pointDataRecordFormat as 6 | 7 | 8,
+    pointDataRecordLength,
+    pointCount: readSafeUint64(dataView, 247, 'point count'),
+    scale: readPoint(dataView, 131),
+    offset: readPoint(dataView, 155),
+    min: [
+      dataView.getFloat64(187, true),
+      dataView.getFloat64(203, true),
+      dataView.getFloat64(219, true)
+    ],
+    max: [
+      dataView.getFloat64(179, true),
+      dataView.getFloat64(195, true),
+      dataView.getFloat64(211, true)
+    ],
+    waveformDataOffset: readSafeUint64(dataView, 227, 'waveform data offset'),
+    evlrOffset: readSafeUint64(dataView, 235, 'EVLR offset'),
+    evlrCount: dataView.getUint32(243, true)
+  };
+}
+
+/** Parse the 160-byte COPC info VLR payload. */
+export function parseCOPCInfo(bytes: Uint8Array): COPCInfo {
+  if (bytes.byteLength !== COPC_INFO_LENGTH) {
+    throw new Error(`COPC info VLR must contain ${COPC_INFO_LENGTH} bytes`);
+  }
+  const dataView = createDataView(bytes);
+  const center: [number, number, number] = [
+    dataView.getFloat64(0, true),
+    dataView.getFloat64(8, true),
+    dataView.getFloat64(16, true)
+  ];
+  const radius = dataView.getFloat64(24, true);
+  const spacing = dataView.getFloat64(32, true);
+  if (!center.every(Number.isFinite) || !Number.isFinite(radius) || radius <= 0) {
+    throw new Error('COPC info VLR contains an invalid root cube');
+  }
+  if (!Number.isFinite(spacing) || spacing <= 0) {
+    throw new Error('COPC info VLR contains invalid point spacing');
+  }
+  const rootHierarchyPage = {
+    pageOffset: readSafeUint64(dataView, 40, 'root hierarchy offset'),
+    pageLength: readSafeUint64(dataView, 48, 'root hierarchy length')
+  };
+  validatePage(rootHierarchyPage, 'root hierarchy');
+  for (let byteOffset = 72; byteOffset < bytes.byteLength; byteOffset++) {
+    if (bytes[byteOffset] !== 0) {
+      throw new Error('COPC info VLR reserved bytes must be zero');
+    }
+  }
+  return {
+    cube: [
+      center[0] - radius,
+      center[1] - radius,
+      center[2] - radius,
+      center[0] + radius,
+      center[1] + radius,
+      center[2] + radius
+    ],
+    spacing,
+    rootHierarchyPage,
+    gpsTimeRange: [dataView.getFloat64(56, true), dataView.getFloat64(64, true)]
+  };
+}
+
+/** Parse one COPC hierarchy page. */
+export function parseCOPCHierarchy(bytes: Uint8Array): COPCHierarchy {
+  if (bytes.byteLength === 0 || bytes.byteLength % HIERARCHY_ENTRY_LENGTH !== 0) {
+    throw new Error(`Invalid COPC hierarchy page length ${bytes.byteLength}`);
+  }
+  const dataView = createDataView(bytes);
+  const nodes: COPCHierarchy['nodes'] = {};
+  const pages: COPCHierarchy['pages'] = {};
+  for (let byteOffset = 0; byteOffset < bytes.byteLength; byteOffset += HIERARCHY_ENTRY_LENGTH) {
+    const key = formatCOPCKey([
+      dataView.getInt32(byteOffset, true),
+      dataView.getInt32(byteOffset + 4, true),
+      dataView.getInt32(byteOffset + 8, true),
+      dataView.getInt32(byteOffset + 12, true)
+    ]);
+    const offset = readSafeUint64(dataView, byteOffset + 16, `hierarchy offset for ${key}`);
+    const length = dataView.getInt32(byteOffset + 24, true);
+    const pointCount = dataView.getInt32(byteOffset + 28, true);
+    if (length < 0 || pointCount < -1) {
+      throw new Error(`Invalid COPC hierarchy entry ${key}`);
+    }
+    if (nodes[key] || pages[key]) {
+      throw new Error(`Duplicate COPC hierarchy entry ${key}`);
+    }
+    if (pointCount === -1) {
+      const page = {pageOffset: offset, pageLength: length};
+      validatePage(page, `hierarchy page ${key}`);
+      pages[key] = page;
+    } else {
+      if (pointCount > 0 && length === 0) {
+        throw new Error(`COPC node ${key} has points but no compressed data`);
+      }
+      nodes[key] = {pointCount, pointDataOffset: offset, pointDataLength: length};
+    }
+  }
+  return {nodes, pages};
+}
+
+/** Fetch and parse one hierarchy page. */
+export async function loadCOPCHierarchyPage(
+  readRange: COPCRangeReader,
+  page: COPCHierarchyPage,
+  signal?: AbortSignal
+): Promise<COPCHierarchy> {
+  validatePage(page, 'hierarchy');
+  return parseCOPCHierarchy(
+    await readExactRange(readRange, page.pageOffset, page.pageOffset + page.pageLength, signal)
+  );
+}
+
+/** Fetch one complete compressed COPC node chunk. */
+export async function loadCOPCNodeData(
+  readRange: COPCRangeReader,
+  node: COPCHierarchyNode,
+  signal?: AbortSignal
+): Promise<Uint8Array> {
+  if (node.pointDataOffset < 0 || node.pointDataLength < 0) {
+    throw new Error('Invalid COPC node byte range');
+  }
+  return await readExactRange(
+    readRange,
+    node.pointDataOffset,
+    node.pointDataOffset + node.pointDataLength,
+    signal
+  );
+}
+
+/** Format a COPC octree key as `depth-x-y-z`. */
+export function formatCOPCKey(key: readonly number[]): string {
+  if (!isValidCOPCKey(key)) {
+    throw new Error(`Invalid COPC key ${key.join('-')}`);
+  }
+  return key.join('-');
+}
+
+/** Parse a `depth-x-y-z` COPC octree key. */
+export function parseCOPCKey(key: string): [number, number, number, number] {
+  const values = key.split('-').map(value => Number(value));
+  if (!isValidCOPCKey(values)) {
+    throw new Error(`Invalid COPC key ${key}`);
+  }
+  return values as [number, number, number, number];
+}
+
+/** Compute the octree bounds represented by a COPC key. */
+export function getCOPCKeyBounds(
+  cube: readonly number[],
+  key: readonly [number, number, number, number]
+): [number, number, number, number, number, number] {
+  let bounds = [...cube] as [number, number, number, number, number, number];
+  for (let bit = key[0] - 1; bit >= 0; bit--) {
+    const middleX = (bounds[0] + bounds[3]) / 2;
+    const middleY = (bounds[1] + bounds[4]) / 2;
+    const middleZ = (bounds[2] + bounds[5]) / 2;
+    const childX = (key[1] >> bit) & 1;
+    const childY = (key[2] >> bit) & 1;
+    const childZ = (key[3] >> bit) & 1;
+    bounds = [
+      childX ? middleX : bounds[0],
+      childY ? middleY : bounds[1],
+      childZ ? middleZ : bounds[2],
+      childX ? bounds[3] : middleX,
+      childY ? bounds[4] : middleY,
+      childZ ? bounds[5] : middleZ
+    ];
+  }
+  return bounds;
+}
+
+/** Read one VLR payload by descriptor. */
+async function readRecordPayload(
+  readRange: COPCRangeReader,
+  record: COPCVariableLengthRecord,
+  signal?: AbortSignal
+): Promise<Uint8Array> {
+  return await readExactRange(
+    readRange,
+    record.contentOffset,
+    record.contentOffset + record.contentLength,
+    signal
+  );
+}
+
+/** Walk regular VLR or EVLR headers without reading unrelated payload bytes. */
+async function readVariableLengthRecords(
+  readRange: COPCRangeReader,
+  startOffset: number,
+  count: number,
+  isExtended: boolean,
+  maximumEndOffset: number,
+  signal?: AbortSignal
+): Promise<COPCVariableLengthRecord[]> {
+  if (!Number.isSafeInteger(startOffset) || startOffset < 0) {
+    throw new Error('Invalid LAS variable length record offset');
+  }
+  const headerLength = isExtended ? EVLR_HEADER_LENGTH : VLR_HEADER_LENGTH;
+  const records: COPCVariableLengthRecord[] = [];
+  let byteOffset = startOffset;
+  for (let recordIndex = 0; recordIndex < count; recordIndex++) {
+    if (byteOffset + headerLength > maximumEndOffset) {
+      throw new Error('LAS VLR header overlaps point data');
+    }
+    const bytes = await readExactRange(readRange, byteOffset, byteOffset + headerLength, signal);
+    const dataView = createDataView(bytes);
+    const contentLength = isExtended
+      ? readSafeUint64(dataView, 20, 'EVLR content length')
+      : dataView.getUint16(20, true);
+    const contentOffset = byteOffset + headerLength;
+    const contentEnd = contentOffset + contentLength;
+    if (!Number.isSafeInteger(contentEnd) || contentEnd > maximumEndOffset) {
+      throw new Error('LAS variable length record exceeds its containing section');
+    }
+    records.push({
+      userId: decodeCString(bytes.subarray(2, 18)),
+      recordId: dataView.getUint16(18, true),
+      contentOffset,
+      contentLength,
+      description: decodeCString(bytes.subarray(isExtended ? 28 : 22, headerLength)),
+      isExtended
+    });
+    byteOffset = contentEnd;
+  }
+  return records;
+}
+
+/** Find one VLR by its user and record identifiers. */
+function findRecord(
+  records: readonly COPCVariableLengthRecord[],
+  userId: string,
+  recordId: number
+): COPCVariableLengthRecord | undefined {
+  return records.find(record => record.userId === userId && record.recordId === recordId);
+}
+
+/** Read a byte range and verify that the source returned exactly that range. */
+async function readExactRange(
+  readRange: COPCRangeReader,
+  begin: number,
+  end: number,
+  signal?: AbortSignal
+): Promise<Uint8Array> {
+  if (!Number.isSafeInteger(begin) || !Number.isSafeInteger(end) || begin < 0 || end < begin) {
+    throw new Error(`Invalid COPC byte range ${begin}-${end}`);
+  }
+  if (signal?.aborted) {
+    throw new Error('COPC range request was aborted');
+  }
+  const bytes = await readRange(begin, end, signal);
+  if (signal?.aborted) {
+    throw new Error('COPC range request was aborted');
+  }
+  if (bytes.byteLength !== end - begin) {
+    throw new Error(
+      `COPC range source returned ${bytes.byteLength} bytes; expected ${end - begin}`
+    );
+  }
+  return bytes;
+}
+
+/** Validate one non-empty hierarchy page range. */
+function validatePage(page: COPCHierarchyPage, label: string): void {
+  if (
+    !Number.isSafeInteger(page.pageOffset) ||
+    !Number.isSafeInteger(page.pageLength) ||
+    page.pageOffset < 0 ||
+    page.pageLength <= 0 ||
+    page.pageLength % HIERARCHY_ENTRY_LENGTH !== 0
+  ) {
+    throw new Error(`Invalid COPC ${label} byte range`);
+  }
+}
+
+/** Read a three-component little-endian float64 point. */
+function readPoint(dataView: DataView, byteOffset: number): [number, number, number] {
+  return [
+    dataView.getFloat64(byteOffset, true),
+    dataView.getFloat64(byteOffset + 8, true),
+    dataView.getFloat64(byteOffset + 16, true)
+  ];
+}
+
+/** Read a uint64 that can be represented exactly by JavaScript. */
+function readSafeUint64(dataView: DataView, byteOffset: number, label: string): number {
+  const value = dataView.getBigUint64(byteOffset, true);
+  if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error(`COPC ${label} exceeds JavaScript's safe integer range`);
+  }
+  return Number(value);
+}
+
+/** Decode a fixed-width null-terminated ASCII/UTF-8 string. */
+function decodeCString(bytes: Uint8Array): string {
+  const zeroOffset = bytes.indexOf(0);
+  return new TextDecoder().decode(zeroOffset < 0 ? bytes : bytes.subarray(0, zeroOffset));
+}
+
+/** Create an alignment-safe DataView over the exact input view. */
+function createDataView(bytes: Uint8Array): DataView {
+  return new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+}
+
+/** Return whether values form a representable COPC octree key. */
+function isValidCOPCKey(key: readonly number[]): boolean {
+  if (
+    key.length !== 4 ||
+    key.some(value => !Number.isSafeInteger(value) || value < 0) ||
+    key[0] > 30
+  ) {
+    return false;
+  }
+  const coordinateLimit = 2 ** key[0];
+  return key[1] < coordinateLimit && key[2] < coordinateLimit && key[3] < coordinateLimit;
+}

--- a/modules/copc/src/lib/copc-reader.ts
+++ b/modules/copc/src/lib/copc-reader.ts
@@ -103,6 +103,22 @@ export type COPCInfo = {
   gpsTimeRange: [number, number];
 };
 
+/** LASzip codec metadata required to decode COPC node chunks. */
+export type COPCLAZMetadata = {
+  /** LASzip compressor identifier. COPC uses layered compressor 3. */
+  compressor: number;
+  /** LASzip entropy coder identifier. The TypeScript decoder supports arithmetic coder 0. */
+  coder: number;
+  /** Declared LASzip chunk size. COPC normally uses variable-size chunks. */
+  chunkSize: number;
+  /** Point14 item version. */
+  point14ItemVersion: 2 | 3 | 4;
+  /** RGB14 or RGBNIR14 item version, when present. */
+  rgb14ItemVersion?: 2 | 3 | 4;
+  /** Byte14 item version, when Extra Bytes are present. */
+  byte14ItemVersion?: 2 | 3 | 4;
+};
+
 /** Native metadata required to read a COPC file. */
 export type COPCFile = {
   /** LAS 1.4 public header. */
@@ -111,6 +127,8 @@ export type COPCFile = {
   vlrs: COPCVariableLengthRecord[];
   /** COPC info VLR. */
   info: COPCInfo;
+  /** Parsed and validated LASzip codec metadata. */
+  laz: COPCLAZMetadata;
   /** OGC WKT coordinate reference system, when present. */
   wkt?: string;
   /** Raw Extra Bytes VLR payload, when present. */
@@ -130,6 +148,8 @@ const WKT_USER_ID = 'LASF_Projection';
 const WKT_RECORD_ID = 2112;
 const EXTRA_BYTES_USER_ID = 'LASF_Spec';
 const EXTRA_BYTES_RECORD_ID = 4;
+const LASZIP_USER_ID = 'laszip encoded';
+const LASZIP_RECORD_ID = 22204;
 
 /** Open and validate a COPC 1.0 file using only exact byte-range reads. */
 export async function openCOPC(
@@ -164,6 +184,14 @@ export async function openCOPC(
     throw new Error('COPC info VLR must be the first VLR');
   }
   const info = parseCOPCInfo(await readRecordPayload(readRange, infoRecord, signal));
+  const laszipRecord = findRecord(regularVlrs, LASZIP_USER_ID, LASZIP_RECORD_ID);
+  if (!laszipRecord) {
+    throw new Error('COPC LASzip VLR is required');
+  }
+  const laz = parseCOPCLAZMetadata(
+    await readRecordPayload(readRange, laszipRecord, signal),
+    header
+  );
   const wktRecord = findRecord(vlrs, WKT_USER_ID, WKT_RECORD_ID);
   const wkt = wktRecord?.contentLength
     ? decodeCString(await readRecordPayload(readRange, wktRecord, signal)) || undefined
@@ -177,9 +205,81 @@ export async function openCOPC(
     header,
     vlrs,
     info,
+    laz,
     wkt,
     extraBytes,
     extraBytesDescriptors: extraBytes ? parseLASExtraBytes(extraBytes) : []
+  };
+}
+
+/** Parse and validate the LASzip item table used by COPC node chunks. */
+export function parseCOPCLAZMetadata(bytes: Uint8Array, header: COPCHeader): COPCLAZMetadata {
+  if (bytes.byteLength < 34) {
+    throw new Error('Malformed COPC LASzip VLR');
+  }
+  const dataView = createDataView(bytes);
+  const compressor = dataView.getUint16(0, true);
+  const coder = dataView.getUint16(2, true);
+  if (compressor !== 3) {
+    throw new Error(`COPC requires LASzip layered compressor 3; received ${compressor}`);
+  }
+  if (coder !== 0) {
+    throw new Error(
+      `COPC TypeScript decoding requires LASzip arithmetic coder 0; received ${coder}`
+    );
+  }
+
+  const extraByteCount =
+    header.pointDataRecordLength - [0, 0, 0, 0, 0, 0, 30, 36, 38][header.pointDataRecordFormat];
+  const expectedItems: Array<{type: number; size: number}> = [{type: 10, size: 30}];
+  if (header.pointDataRecordFormat === 7) {
+    expectedItems.push({type: 11, size: 6});
+  } else if (header.pointDataRecordFormat === 8) {
+    expectedItems.push({type: 12, size: 8});
+  }
+  if (extraByteCount > 0) {
+    expectedItems.push({type: 14, size: extraByteCount});
+  }
+
+  const itemCount = dataView.getUint16(32, true);
+  if (bytes.byteLength < 34 + itemCount * 6) {
+    throw new Error('Malformed COPC LASzip VLR item table');
+  }
+  if (itemCount !== expectedItems.length) {
+    throw new Error(
+      `COPC PDRF ${header.pointDataRecordFormat} has ${itemCount} LASzip items; expected ${expectedItems.length}`
+    );
+  }
+
+  let point14ItemVersion: 2 | 3 | 4 | undefined;
+  let rgb14ItemVersion: 2 | 3 | 4 | undefined;
+  let byte14ItemVersion: 2 | 3 | 4 | undefined;
+  for (let itemIndex = 0; itemIndex < expectedItems.length; itemIndex++) {
+    const itemOffset = 34 + itemIndex * 6;
+    const itemType = dataView.getUint16(itemOffset, true);
+    const itemSize = dataView.getUint16(itemOffset + 2, true);
+    const itemVersion = dataView.getUint16(itemOffset + 4, true);
+    const expectedItem = expectedItems[itemIndex];
+    if (itemType !== expectedItem.type || itemSize !== expectedItem.size) {
+      throw new Error(
+        `COPC LASzip item ${itemIndex} is type ${itemType}, size ${itemSize}; expected type ${expectedItem.type}, size ${expectedItem.size}`
+      );
+    }
+    if (itemVersion !== 2 && itemVersion !== 3 && itemVersion !== 4) {
+      throw new Error(`Unsupported COPC LASzip item type ${itemType} version ${itemVersion}`);
+    }
+    if (itemType === 10) point14ItemVersion = itemVersion;
+    else if (itemType === 11 || itemType === 12) rgb14ItemVersion = itemVersion;
+    else if (itemType === 14) byte14ItemVersion = itemVersion;
+  }
+
+  return {
+    compressor,
+    coder,
+    chunkSize: dataView.getUint32(12, true),
+    point14ItemVersion: point14ItemVersion!,
+    rgb14ItemVersion,
+    byte14ItemVersion
   };
 }
 
@@ -544,7 +644,7 @@ function isValidCOPCKey(key: readonly number[]): boolean {
   if (
     key.length !== 4 ||
     key.some(value => !Number.isSafeInteger(value) || value < 0) ||
-    key[0] > 30
+    key[0] > 31
   ) {
     return false;
   }

--- a/modules/copc/test/copc-source.node.spec.ts
+++ b/modules/copc/test/copc-source.node.spec.ts
@@ -4,7 +4,7 @@
 
 import '@loaders.gl/polyfills';
 import {COPCSourceLoader} from '@loaders.gl/copc';
-import {expect, test} from 'vitest';
+import {expect, test, vi} from 'vitest';
 
 const COPC_FILE_PATH = 'modules/copc/test/data/ellipsoid.copc.laz';
 
@@ -18,4 +18,16 @@ test('COPCSourceLoader reads local files through the native range reader', async
   expect(rootTile.pointCount).toBeGreaterThan(0);
   expect(content?.pointCount).toBe(rootTile.pointCount);
   expect(content?.data.data.getChild('POSITION')?.length).toBe(rootTile.pointCount);
+});
+
+test('COPCSourceLoader closes its local file handle exactly once', async () => {
+  const source = COPCSourceLoader.createDataSource(COPC_FILE_PATH, {});
+  await source.initialize();
+  const readableFile = source['_readableFile'];
+  const close = vi.spyOn(readableFile, 'close');
+
+  await source.close();
+  await source.close();
+
+  expect(close).toHaveBeenCalledOnce();
 });

--- a/modules/copc/test/copc-source.node.spec.ts
+++ b/modules/copc/test/copc-source.node.spec.ts
@@ -1,0 +1,21 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import '@loaders.gl/polyfills';
+import {COPCSourceLoader} from '@loaders.gl/copc';
+import {expect, test} from 'vitest';
+
+const COPC_FILE_PATH = 'modules/copc/test/data/ellipsoid.copc.laz';
+
+test('COPCSourceLoader reads local files through the native range reader', async () => {
+  const source = COPCSourceLoader.createDataSource(COPC_FILE_PATH, {});
+  await source.initialize();
+
+  const rootTile = await source.getRootTile();
+  const content = await source.loadTileContent(rootTile);
+
+  expect(rootTile.pointCount).toBeGreaterThan(0);
+  expect(content?.pointCount).toBe(rootTile.pointCount);
+  expect(content?.data.data.getChild('POSITION')?.length).toBe(rootTile.pointCount);
+});

--- a/modules/copc/test/copc-source.spec.ts
+++ b/modules/copc/test/copc-source.spec.ts
@@ -36,6 +36,11 @@ class TestCOPCTileSource extends COPCTileSource {
   ): AsyncIterable<Uint8Array> {
     return this.loadCOPCNodeRangeChunks(node, rangeChunkSize, rangeConcurrency);
   }
+
+  /** Expose child-key generation for maximum-depth coverage. */
+  readChildKeys(tileId: string): string[] {
+    return this.getChildKeys(tileId);
+  }
 }
 
 test('COPCWriter#writer conformance', t => {
@@ -268,6 +273,39 @@ vitestTest('COPCSourceLoader#handles abandoned prefetched range failures', async
   } finally {
     globalThis.removeEventListener('unhandledrejection', handleUnhandledRejection);
   }
+});
+
+vitestTest('COPCSourceLoader#does not create children beyond depth 31', async () => {
+  const source = new TestCOPCTileSource(await createEllipsoidSourceData(), {});
+  await source.initialize();
+  expect(source.readChildKeys('31-2147483647-2147483647-2147483647')).toEqual([]);
+});
+
+vitestTest('COPCSourceLoader#includes typed Extra Bytes dimensions in its schema', async () => {
+  const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {});
+  const metadata = await source.getMetadata();
+  const copc = metadata.formatSpecificMetadata;
+  copc.header.pointDataRecordLength += 1;
+  copc.extraBytesDescriptors = [
+    {
+      dataType: 1,
+      options: 0,
+      name: 'quality',
+      description: '',
+      scale: 0,
+      offset: 0,
+      scales: [0, 0, 0],
+      offsets: [0, 0, 0],
+      data: new Uint8Array(192)
+    }
+  ];
+
+  const schema = await source.getSchema();
+  expect(schema.fields).toContainEqual({
+    name: 'EXTRA_BYTES_quality',
+    type: 'uint8',
+    nullable: false
+  });
 });
 test('COPCSourceLoader#loads tile content from a Blob', async t => {
   const blob = await createEllipsoidBlob();

--- a/modules/copc/test/copc-source.spec.ts
+++ b/modules/copc/test/copc-source.spec.ts
@@ -6,11 +6,17 @@ import test from 'test/utils/vitest-tape';
 import {expect, test as vitestTest} from 'vitest';
 import {validateWriter} from 'test/common/conformance';
 import {createDataSource, encodeSync, fetchFile, isBrowser, parse} from '@loaders.gl/core';
-import {COPCSourceLoader, COPCTileSource, COPCWriter} from '@loaders.gl/copc';
+import {
+  COPCSourceLoader,
+  COPCTileSource,
+  COPCWriter,
+  loadCOPCHierarchyPage,
+  loadCOPCNodeData,
+  openCOPC
+} from '@loaders.gl/copc';
 import {LASLoader} from '@loaders.gl/las';
 import {decodeLAZChunk, decodeLAZChunkTable} from '@loaders.gl/loader-utils';
 import {deduceMeshSchema} from '@loaders.gl/schema-utils';
-import {Copc} from 'copc';
 
 const ELLIPSOID_FILE_PATH = 'modules/copc/test/data/ellipsoid.copc.laz';
 const ELLIPSOID_BROWSER_URL = new URL('./data/ellipsoid.copc.laz', import.meta.url).href;
@@ -19,7 +25,7 @@ const ELLIPSOID_BROWSER_URL = new URL('./data/ellipsoid.copc.laz', import.meta.u
 class TestCOPCTileSource extends COPCTileSource {
   /** Replace the byte-range getter after normal source initialization. */
   setRangeGetter(getter: (begin: number, end: number) => Promise<Uint8Array>): void {
-    this._urlOrGetter = getter;
+    this._readRange = getter;
   }
 
   /** Expose ordered range prefetching for focused scheduling tests. */
@@ -71,13 +77,7 @@ test('COPCSourceLoader#loads normalized root and child tiles', async t => {
 });
 
 test('COPCSourceLoader#loads full point content for a tile', async t => {
-  if (isBrowser) {
-    t.comment('Skipping browser content decode until laz-perf wasm is served as an asset');
-    t.end();
-    return;
-  }
-
-  const source = COPCSourceLoader.createDataSource(ELLIPSOID_FILE_PATH, {});
+  const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {});
   await source.initialize();
 
   const rootTile = await source.getRootTile();
@@ -97,9 +97,7 @@ test('COPCSourceLoader#loads full point content for a tile', async t => {
 });
 
 test('COPCSourceLoader#loads tile content with TypeScript LAZ decoder', async t => {
-  const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {
-    copc: {decoder: 'typescript-laz'}
-  });
+  const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {});
   await source.initialize();
 
   const rootTile = await source.getRootTile();
@@ -115,9 +113,7 @@ test('COPCSourceLoader#loads tile content with TypeScript LAZ decoder', async t 
 });
 
 vitestTest('COPCSourceLoader#streams TypeScript tile content as Arrow batches', async () => {
-  const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {
-    copc: {decoder: 'typescript-laz'}
-  });
+  const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {});
   await source.initialize();
 
   const rootTile = await source.getRootTile();
@@ -155,9 +151,7 @@ vitestTest('COPCSourceLoader#streams TypeScript tile content as Arrow batches', 
 });
 
 vitestTest('COPCSourceLoader#selects progressive point-data columns', async () => {
-  const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {
-    copc: {decoder: 'typescript-laz'}
-  });
+  const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {});
   await source.initialize();
 
   const rootTile = await source.getRootTile();
@@ -168,7 +162,13 @@ vitestTest('COPCSourceLoader#selects progressive point-data columns', async () =
     'classification',
     'GPS_TIME',
     'scanAngle',
-    'pointSourceId'
+    'userData',
+    'pointSourceId',
+    'returnNumber',
+    'numberOfReturns',
+    'scannerChannel',
+    'scanDirectionFlag',
+    'edgeOfFlightLine'
   ] as const;
   const batches = source.loadTileContentInBatches(rootTile, {
     batchSize: 127,
@@ -189,13 +189,17 @@ vitestTest('COPCSourceLoader#selects progressive point-data columns', async () =
   expect(firstBatch?.data.data.getChild('classification')).toBeTruthy();
   expect(firstBatch?.data.data.getChild('GPS_TIME')).toBeTruthy();
   expect(firstBatch?.data.data.getChild('scanAngle')).toBeTruthy();
+  expect(firstBatch?.data.data.getChild('userData')).toBeTruthy();
   expect(firstBatch?.data.data.getChild('pointSourceId')).toBeTruthy();
+  expect(firstBatch?.data.data.getChild('returnNumber')).toBeTruthy();
+  expect(firstBatch?.data.data.getChild('numberOfReturns')).toBeTruthy();
+  expect(firstBatch?.data.data.getChild('scannerChannel')).toBeTruthy();
+  expect(firstBatch?.data.data.getChild('scanDirectionFlag')).toBeTruthy();
+  expect(firstBatch?.data.data.getChild('edgeOfFlightLine')).toBeTruthy();
 });
 
 test('COPCSourceLoader#streams position-only TypeScript tile batches', async t => {
-  const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {
-    copc: {decoder: 'typescript-laz'}
-  });
+  const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {});
   await source.initialize();
 
   const rootTile = await source.getRootTile();
@@ -265,57 +269,7 @@ vitestTest('COPCSourceLoader#handles abandoned prefetched range failures', async
     globalThis.removeEventListener('unhandledrejection', handleUnhandledRejection);
   }
 });
-
-test('COPCSourceLoader#TypeScript tile attributes match laz-perf', async t => {
-  if (isBrowser) {
-    t.comment('Skipping browser parity until laz-perf wasm is served as an asset');
-    t.end();
-    return;
-  }
-
-  const lazPerfSource = COPCSourceLoader.createDataSource(ELLIPSOID_FILE_PATH, {});
-  const typescriptSource = COPCSourceLoader.createDataSource(ELLIPSOID_FILE_PATH, {
-    copc: {decoder: 'typescript-laz'}
-  });
-  await Promise.all([lazPerfSource.initialize(), typescriptSource.initialize()]);
-
-  const rootTile = await typescriptSource.getRootTile();
-  const [lazPerfContent, typescriptContent] = await Promise.all([
-    lazPerfSource.loadTileContent(rootTile),
-    typescriptSource.loadTileContent(rootTile)
-  ]);
-  const lazPerfPositions = lazPerfContent?.data.data.getChild('POSITION');
-  const typescriptPositions = typescriptContent?.data.data.getChild('POSITION');
-  const lazPerfColors = lazPerfContent?.data.data.getChild('COLOR_0');
-  const typescriptColors = typescriptContent?.data.data.getChild('COLOR_0');
-
-  t.equal(typescriptContent?.pointCount, lazPerfContent?.pointCount, 'point counts match');
-  t.deepEqual(
-    Array.from({length: rootTile.pointCount}, (_, index) =>
-      typescriptPositions?.get(index)?.toArray()
-    ),
-    Array.from({length: rootTile.pointCount}, (_, index) =>
-      lazPerfPositions?.get(index)?.toArray()
-    ),
-    'tile-relative positions match laz-perf'
-  );
-  t.deepEqual(
-    Array.from({length: rootTile.pointCount}, (_, index) =>
-      typescriptColors?.get(index)?.toArray()
-    ),
-    Array.from({length: rootTile.pointCount}, (_, index) => lazPerfColors?.get(index)?.toArray()),
-    'raw colors match laz-perf'
-  );
-  t.end();
-});
-
 test('COPCSourceLoader#loads tile content from a Blob', async t => {
-  if (isBrowser) {
-    t.comment('Skipping browser content decode until laz-perf wasm is served as an asset');
-    t.end();
-    return;
-  }
-
   const blob = await createEllipsoidBlob();
   const source = COPCSourceLoader.createDataSource(blob, {});
   await source.initialize();
@@ -336,6 +290,8 @@ test('COPCSourceLoader#derives cartographic view metadata from the dataset', asy
   const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {});
 
   const metadata = await source.getMetadata();
+  const schema = await source.getSchema();
+  const firstPoint = await source.getPoints({nodeIndex: [0, 0, 0, 0]});
   const viewState = source.getViewState();
 
   t.ok(
@@ -348,6 +304,16 @@ test('COPCSourceLoader#derives cartographic view metadata from the dataset', asy
     viewState.cartographicCenter,
     'metadata view state matches the source view state'
   );
+  t.equal(
+    metadata.formatSpecificMetadata.header.pointDataRecordFormat,
+    7,
+    'native metadata exposes the COPC point format'
+  );
+  t.ok(
+    schema.fields.some(field => field.name === 'ScannerChannel'),
+    'native schema exposes modern LAS fields without decoding the root node'
+  );
+  t.equal(firstPoint?.length, schema.fields.length, 'native point values match the source schema');
   t.end();
 });
 
@@ -362,8 +328,8 @@ test('COPCWriter#encodes range-readable octree nodes', async t => {
     ranges.push([begin, end]);
     return new Uint8Array(await blob.slice(begin, end).arrayBuffer());
   };
-  const copc = await Copc.create(getter);
-  const hierarchy = await Copc.loadHierarchyPage(getter, copc.info.rootHierarchyPage);
+  const copc = await openCOPC(getter);
+  const hierarchy = await loadCOPCHierarchyPage(getter, copc.info.rootHierarchyPage);
   const nodes = Object.values(hierarchy.nodes);
   const rootNode = hierarchy.nodes['0-0-0-0'];
 
@@ -389,7 +355,7 @@ test('COPCWriter#encodes range-readable octree nodes', async t => {
 
   const pointDataPositions: string[] = [];
   for (const node of nodes) {
-    const compressed = await Copc.loadCompressedPointDataBuffer(getter, node);
+    const compressed = await loadCOPCNodeData(getter, node);
     const rawPointData = decodeLAZChunk(compressed, {
       pointCount: node.pointCount,
       pointDataRecordFormat: copc.header.pointDataRecordFormat,
@@ -432,7 +398,7 @@ test('COPCWriter#encodes range-readable octree nodes', async t => {
     'variable chunk table preserves node point counts'
   );
 
-  const source = COPCSourceLoader.createDataSource(blob, {copc: {decoder: 'typescript-laz'}});
+  const source = COPCSourceLoader.createDataSource(blob, {});
   await source.initialize();
   const rootTile = await source.getRootTile();
   const childTiles = await source.getChildren(rootTile);
@@ -471,8 +437,8 @@ test('COPCWriter#defaults to PDRF 6 without colors', async t => {
   const blob = new Blob([arrayBuffer]);
   const getter = async (begin: number, end: number): Promise<Uint8Array> =>
     new Uint8Array(await blob.slice(begin, end).arrayBuffer());
-  const copc = await Copc.create(getter);
-  const hierarchy = await Copc.loadHierarchyPage(getter, copc.info.rootHierarchyPage);
+  const copc = await openCOPC(getter);
+  const hierarchy = await loadCOPCHierarchyPage(getter, copc.info.rootHierarchyPage);
 
   t.equal(copc.header.pointDataRecordFormat, 6, 'selects PDRF 6');
   t.equal(copc.wkt, 'LOCAL_CS["loaders.gl test"]', 'writes an optional WKT VLR');

--- a/modules/copc/test/lib/copc-reader.spec.ts
+++ b/modules/copc/test/lib/copc-reader.spec.ts
@@ -7,8 +7,10 @@ import {
   loadCOPCHierarchyPage,
   loadCOPCNodeData,
   openCOPC,
+  parseCOPCLAZMetadata,
   parseCOPCHeader,
-  parseCOPCHierarchy
+  parseCOPCHierarchy,
+  parseCOPCKey
 } from '@loaders.gl/copc';
 import {describe, expect, test} from 'vitest';
 
@@ -33,6 +35,7 @@ describe('native COPC reader', () => {
     expect(copc.header.pointDataRecordFormat).toBe(7);
     expect(copc.header.pointCount).toBeGreaterThan(0);
     expect(copc.info.spacing).toBeGreaterThan(0);
+    expect(copc.laz).toMatchObject({compressor: 3, coder: 0, point14ItemVersion: 3});
     expect(rootNode).toBeTruthy();
     expect(requestedRanges.every(([begin, end]) => end - begin < fileBytes.byteLength)).toBe(true);
 
@@ -78,5 +81,47 @@ describe('native COPC reader', () => {
     dataView.setInt32(28, 1, true);
     expect(() => parseCOPCHierarchy(hierarchy)).toThrow(/points but no compressed data/);
     expect(() => parseCOPCHierarchy(new Uint8Array(64))).toThrow(/Duplicate/);
+  });
+
+  test('parses LASzip item versions and rejects unsupported codec metadata', async () => {
+    const fileBytes = new Uint8Array(await (await fetchFile(COPC_URL)).arrayBuffer());
+    const readRange = async (begin: number, end: number): Promise<Uint8Array> =>
+      fileBytes.slice(begin, end);
+    const copc = await openCOPC(readRange);
+    const laszipRecord = copc.vlrs.find(record => record.recordId === 22204);
+    expect(laszipRecord).toBeTruthy();
+    const payload = fileBytes.slice(
+      laszipRecord!.contentOffset,
+      laszipRecord!.contentOffset + laszipRecord!.contentLength
+    );
+
+    const versionFour = payload.slice();
+    const versionFourView = new DataView(versionFour.buffer);
+    versionFourView.setUint16(38, 4, true);
+    versionFourView.setUint16(44, 4, true);
+    expect(parseCOPCLAZMetadata(versionFour, copc.header)).toMatchObject({
+      point14ItemVersion: 4,
+      rgb14ItemVersion: 4
+    });
+
+    const unsupportedVersion = payload.slice();
+    new DataView(unsupportedVersion.buffer).setUint16(38, 5, true);
+    expect(() => parseCOPCLAZMetadata(unsupportedVersion, copc.header)).toThrow(
+      /unsupported COPC LASzip item/i
+    );
+  });
+
+  test('accepts the maximum representable COPC key depth', () => {
+    const hierarchy = new Uint8Array(32);
+    const dataView = new DataView(hierarchy.buffer);
+    dataView.setInt32(0, 31, true);
+    dataView.setInt32(4, 0x7fffffff, true);
+    dataView.setInt32(8, 0x7fffffff, true);
+    dataView.setInt32(12, 0x7fffffff, true);
+
+    expect(parseCOPCHierarchy(hierarchy).nodes['31-2147483647-2147483647-2147483647']).toBeTruthy();
+    expect(parseCOPCKey('31-2147483647-2147483647-2147483647')).toEqual([
+      31, 0x7fffffff, 0x7fffffff, 0x7fffffff
+    ]);
   });
 });

--- a/modules/copc/test/lib/copc-reader.spec.ts
+++ b/modules/copc/test/lib/copc-reader.spec.ts
@@ -1,0 +1,82 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {fetchFile} from '@loaders.gl/core';
+import {
+  loadCOPCHierarchyPage,
+  loadCOPCNodeData,
+  openCOPC,
+  parseCOPCHeader,
+  parseCOPCHierarchy
+} from '@loaders.gl/copc';
+import {describe, expect, test} from 'vitest';
+
+const COPC_URL = new URL('../data/ellipsoid.copc.laz', import.meta.url).href;
+
+describe('native COPC reader', () => {
+  test('opens metadata, hierarchy, and node ranges without reading the whole file', async () => {
+    const arrayBuffer = await (await fetchFile(COPC_URL)).arrayBuffer();
+    const fileBytes = new Uint8Array(arrayBuffer);
+    const requestedRanges: Array<[number, number]> = [];
+    const readRange = async (begin: number, end: number): Promise<Uint8Array> => {
+      requestedRanges.push([begin, end]);
+      return fileBytes.slice(begin, end);
+    };
+
+    const copc = await openCOPC(readRange);
+    const hierarchy = await loadCOPCHierarchyPage(readRange, copc.info.rootHierarchyPage);
+    const rootNode = hierarchy.nodes['0-0-0-0'];
+
+    expect(copc.header.majorVersion).toBe(1);
+    expect(copc.header.minorVersion).toBe(4);
+    expect(copc.header.pointDataRecordFormat).toBe(7);
+    expect(copc.header.pointCount).toBeGreaterThan(0);
+    expect(copc.info.spacing).toBeGreaterThan(0);
+    expect(rootNode).toBeTruthy();
+    expect(requestedRanges.every(([begin, end]) => end - begin < fileBytes.byteLength)).toBe(true);
+
+    const compressed = await loadCOPCNodeData(readRange, rootNode!);
+    expect(compressed.byteLength).toBe(rootNode?.pointDataLength);
+    expect(requestedRanges.at(-1)).toEqual([
+      rootNode?.pointDataOffset,
+      rootNode!.pointDataOffset + rootNode!.pointDataLength
+    ]);
+  });
+
+  test('preserves nonzero ArrayBufferView offsets while parsing the header', async () => {
+    const source = new Uint8Array(await (await fetchFile(COPC_URL)).arrayBuffer(), 0, 375);
+    const padded = new Uint8Array(source.byteLength + 11);
+    padded.set(source, 7);
+
+    const header = parseCOPCHeader(padded.subarray(7, 7 + source.byteLength));
+    expect(header.pointDataRecordFormat).toBe(7);
+    expect(header.scale.every(Number.isFinite)).toBe(true);
+  });
+
+  test('rejects invalid COPC headers and hierarchy entries', async () => {
+    const validHeader = new Uint8Array(
+      await (await fetchFile(COPC_URL)).arrayBuffer(),
+      0,
+      375
+    ).slice();
+    const invalidSignature = validHeader.slice();
+    invalidSignature[0] = 0;
+    expect(() => parseCOPCHeader(invalidSignature)).toThrow(/signature/);
+    const missingWktFlag = validHeader.slice();
+    const headerView = new DataView(
+      missingWktFlag.buffer,
+      missingWktFlag.byteOffset,
+      missingWktFlag.byteLength
+    );
+    headerView.setUint16(6, headerView.getUint16(6, true) & ~0x10, true);
+    expect(() => parseCOPCHeader(missingWktFlag)).toThrow(/WKT global encoding bit/);
+    expect(() => parseCOPCHierarchy(new Uint8Array(31))).toThrow(/page length/);
+
+    const hierarchy = new Uint8Array(32);
+    const dataView = new DataView(hierarchy.buffer);
+    dataView.setInt32(28, 1, true);
+    expect(() => parseCOPCHierarchy(hierarchy)).toThrow(/points but no compressed data/);
+    expect(() => parseCOPCHierarchy(new Uint8Array(64))).toThrow(/Duplicate/);
+  });
+});

--- a/modules/las/src/index.ts
+++ b/modules/las/src/index.ts
@@ -18,6 +18,16 @@ export type {
   LASVariableLengthRecord,
   LASWaveformPacketDescriptor
 } from './lib/las-types';
+export {
+  createLASTypedExtraBytesAttributes,
+  createLASTypedExtraBytesValue,
+  parseLASExtraBytes,
+  populateLASTypedExtraBytes
+} from './lib/las-extra-bytes';
+export type {
+  LASTypedExtraBytesAttribute,
+  LASTypedExtraBytesValue
+} from './lib/las-extra-bytes';
 
 export {LASLoader} from './las-loader-types';
 export {LASCOPCLoader} from './las-copc-loader-types';

--- a/modules/las/src/lib/las-extra-bytes.ts
+++ b/modules/las/src/lib/las-extra-bytes.ts
@@ -1,0 +1,242 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {LASExtraBytesDescriptor} from './las-types';
+
+/** Typed-array values supported for LAS Extra Bytes Arrow attributes. */
+export type LASTypedExtraBytesValue =
+  | Uint8Array
+  | Int8Array
+  | Uint16Array
+  | Int16Array
+  | Uint32Array
+  | Int32Array
+  | Float32Array
+  | Float64Array;
+
+/** Prepared typed LAS Extra Bytes attribute and its source-record layout. */
+export type LASTypedExtraBytesAttribute = {
+  /** Stable Arrow attribute name. */
+  name: string;
+  /** Typed output values. */
+  value: LASTypedExtraBytesValue;
+  /** Number of components per point. */
+  size: number;
+  /** LAS scalar data type code. */
+  scalarDataType: number;
+  /** Byte offset within the packed Extra Bytes record. */
+  byteOffset: number;
+  /** Total source byte length per point. */
+  byteLength: number;
+  /** Per-component scales. */
+  scales: number[];
+  /** Per-component offsets. */
+  offsets: number[];
+  /** Whether transformed integer values require Float64 output. */
+  outputFloat64: boolean;
+};
+
+/** Parse the 192-byte descriptors in an LAS Extra Bytes VLR payload. */
+export function parseLASExtraBytes(data: Uint8Array): LASExtraBytesDescriptor[] {
+  if (data.byteLength % 192 !== 0) {
+    throw new Error(`LAS Extra Bytes VLR length ${data.byteLength} is not a multiple of 192`);
+  }
+  const descriptors: LASExtraBytesDescriptor[] = [];
+  const dataView = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  for (let descriptorOffset = 0; descriptorOffset < data.byteLength; descriptorOffset += 192) {
+    const scales: [number, number, number] = [
+      dataView.getFloat64(descriptorOffset + 112, true),
+      dataView.getFloat64(descriptorOffset + 120, true),
+      dataView.getFloat64(descriptorOffset + 128, true)
+    ];
+    const offsets: [number, number, number] = [
+      dataView.getFloat64(descriptorOffset + 136, true),
+      dataView.getFloat64(descriptorOffset + 144, true),
+      dataView.getFloat64(descriptorOffset + 152, true)
+    ];
+    descriptors.push({
+      dataType: data[descriptorOffset + 2],
+      options: data[descriptorOffset + 3],
+      name: readLASString(data, descriptorOffset + 4, 32),
+      description: readLASString(data, descriptorOffset + 160, 32),
+      scale: scales[0],
+      offset: offsets[0],
+      scales,
+      offsets,
+      data: data.slice(descriptorOffset, descriptorOffset + 192)
+    });
+  }
+  return descriptors;
+}
+
+/** Allocate typed Arrow attributes described by an LAS Extra Bytes VLR. */
+export function createLASTypedExtraBytesAttributes(
+  pointCount: number,
+  descriptors: readonly LASExtraBytesDescriptor[],
+  extraByteCount: number
+): LASTypedExtraBytesAttribute[] {
+  let byteOffset = 0;
+  const usedNames = new Set<string>();
+  const attributes: LASTypedExtraBytesAttribute[] = [];
+  for (let descriptorIndex = 0; descriptorIndex < descriptors.length; descriptorIndex++) {
+    const descriptor = descriptors[descriptorIndex];
+    const scalarDataType = getExtraBytesScalarDataType(descriptor.dataType);
+    const size = getExtraBytesComponentCount(descriptor.dataType);
+    const scalarByteLength = getExtraBytesScalarByteLength(scalarDataType);
+    const byteLength = scalarByteLength * size;
+    if (descriptor.dataType < 1 || descriptor.dataType > 30 || !byteLength) {
+      throw new Error(`Unsupported typed LAS Extra Bytes data type ${descriptor.dataType}`);
+    }
+    if (scalarDataType === 7 || scalarDataType === 8) {
+      throw new Error(
+        `Typed LAS Extra Bytes data type ${descriptor.dataType} requires BigInt output`
+      );
+    }
+    let name = `EXTRA_BYTES_${sanitizeExtraBytesName(descriptor.name)}`;
+    if (name === 'EXTRA_BYTES_') {
+      name = `EXTRA_BYTES_${descriptorIndex}`;
+    }
+    const baseName = name;
+    let suffix = 1;
+    while (usedNames.has(name)) {
+      name = `${baseName}_${suffix++}`;
+    }
+    usedNames.add(name);
+    const outputFloat64 = Boolean(descriptor.options & 0x18) && scalarDataType !== 10;
+    attributes.push({
+      name,
+      value: createLASTypedExtraBytesValue(scalarDataType, pointCount * size, outputFloat64),
+      size,
+      scalarDataType,
+      byteOffset,
+      byteLength,
+      outputFloat64,
+      scales:
+        descriptor.options & 0x08 ? descriptor.scales.slice(0, size) : new Array(size).fill(1),
+      offsets:
+        descriptor.options & 0x10 ? descriptor.offsets.slice(0, size) : new Array(size).fill(0)
+    });
+    byteOffset += byteLength;
+  }
+  if (byteOffset !== extraByteCount) {
+    throw new Error(
+      `LAS Extra Bytes descriptors use ${byteOffset} bytes; point records provide ${extraByteCount}`
+    );
+  }
+  return attributes;
+}
+
+/** Populate typed attributes from packed Extra Bytes records. */
+export function populateLASTypedExtraBytes(
+  rawExtraBytes: Uint8Array,
+  pointCount: number,
+  extraByteCount: number,
+  attributes: readonly LASTypedExtraBytesAttribute[]
+): void {
+  if (rawExtraBytes.byteLength < pointCount * extraByteCount) {
+    throw new Error('Packed LAS Extra Bytes data is truncated');
+  }
+  const dataView = new DataView(
+    rawExtraBytes.buffer,
+    rawExtraBytes.byteOffset,
+    rawExtraBytes.byteLength
+  );
+  for (let pointIndex = 0; pointIndex < pointCount; pointIndex++) {
+    const recordOffset = pointIndex * extraByteCount;
+    for (const attribute of attributes) {
+      const targetOffset = pointIndex * attribute.size;
+      const sourceOffset = recordOffset + attribute.byteOffset;
+      const scalarByteLength = getExtraBytesScalarByteLength(attribute.scalarDataType);
+      for (let componentIndex = 0; componentIndex < attribute.size; componentIndex++) {
+        attribute.value[targetOffset + componentIndex] =
+          readExtraBytesValue(
+            dataView,
+            sourceOffset + componentIndex * scalarByteLength,
+            attribute.scalarDataType
+          ) *
+            attribute.scales[componentIndex] +
+          attribute.offsets[componentIndex];
+      }
+    }
+  }
+}
+
+function readLASString(bytes: Uint8Array, offset: number, length: number): string {
+  return new TextDecoder()
+    .decode(bytes.subarray(offset, offset + length))
+    .replace(/\0+$/, '')
+    .trim();
+}
+
+function sanitizeExtraBytesName(name: string): string {
+  return name.trim().replace(/[^A-Za-z0-9_]+/g, '_');
+}
+
+function getExtraBytesScalarDataType(dataType: number): number {
+  return dataType > 20 ? dataType - 20 : dataType > 10 ? dataType - 10 : dataType;
+}
+
+function getExtraBytesComponentCount(dataType: number): number {
+  return dataType > 20 ? 3 : dataType > 10 ? 2 : 1;
+}
+
+function getExtraBytesScalarByteLength(dataType: number): number {
+  if (dataType <= 2) return 1;
+  if (dataType <= 4) return 2;
+  if (dataType <= 6 || dataType === 9) return 4;
+  if (dataType === 7 || dataType === 8 || dataType === 10) return 8;
+  return 0;
+}
+
+function readExtraBytesValue(dataView: DataView, offset: number, scalarDataType: number): number {
+  switch (scalarDataType) {
+    case 1:
+      return dataView.getUint8(offset);
+    case 2:
+      return dataView.getInt8(offset);
+    case 3:
+      return dataView.getUint16(offset, true);
+    case 4:
+      return dataView.getInt16(offset, true);
+    case 5:
+      return dataView.getUint32(offset, true);
+    case 6:
+      return dataView.getInt32(offset, true);
+    case 9:
+      return dataView.getFloat32(offset, true);
+    case 10:
+      return dataView.getFloat64(offset, true);
+    default:
+      throw new Error(`Unsupported typed LAS Extra Bytes scalar data type ${scalarDataType}`);
+  }
+}
+
+/** Allocate the typed-array representation for one LAS Extra Bytes scalar type. */
+export function createLASTypedExtraBytesValue(
+  scalarDataType: number,
+  length: number,
+  outputFloat64: boolean
+): LASTypedExtraBytesValue {
+  if (outputFloat64 && scalarDataType !== 10) return new Float64Array(length);
+  switch (scalarDataType) {
+    case 1:
+      return new Uint8Array(length);
+    case 2:
+      return new Int8Array(length);
+    case 3:
+      return new Uint16Array(length);
+    case 4:
+      return new Int16Array(length);
+    case 5:
+      return new Uint32Array(length);
+    case 6:
+      return new Int32Array(length);
+    case 9:
+      return new Float32Array(length);
+    case 10:
+      return new Float64Array(length);
+    default:
+      throw new Error(`Unsupported typed LAS Extra Bytes scalar data type ${scalarDataType}`);
+  }
+}

--- a/modules/las/src/lib/typescript/parse-las.ts
+++ b/modules/las/src/lib/typescript/parse-las.ts
@@ -15,9 +15,14 @@ import {
 import type {LAZChunkMetadata, LAZPointDataTarget} from '@loaders.gl/loader-utils';
 import type {LASLoaderOptions} from '../../las-loader-types';
 import {getLASSchema} from '../get-las-schema';
+import {
+  createLASTypedExtraBytesAttributes,
+  createLASTypedExtraBytesValue,
+  parseLASExtraBytes,
+  type LASTypedExtraBytesAttribute
+} from '../las-extra-bytes';
 import type {
   LASExtendedVariableLengthRecord,
-  LASExtraBytesDescriptor,
   LASHeader,
   LASMetadata,
   LASVariableLengthRecord,
@@ -119,34 +124,11 @@ type PointDataBatchState = {
   edgeOfFlightLines: Uint8Array | null;
   waveforms: Uint8Array | null;
   extraBytes: Uint8Array | null;
-  typedExtraBytes: TypedExtraBytesAttribute[] | null;
+  typedExtraBytes: LASTypedExtraBytesAttribute[] | null;
   target: LAZPointDataTarget;
   batchPointCount: number;
   totalRead: number;
 };
-
-type TypedExtraBytesAttribute = {
-  name: string;
-  value: TypedExtraBytesValue;
-  size: number;
-  scalarDataType: number;
-  byteOffset: number;
-  byteLength: number;
-  scales: number[];
-  offsets: number[];
-  /** Whether transformed integer values require a floating-point output buffer. */
-  outputFloat64: boolean;
-};
-
-type TypedExtraBytesValue =
-  | Uint8Array
-  | Int8Array
-  | Uint16Array
-  | Int16Array
-  | Uint32Array
-  | Int32Array
-  | Float32Array
-  | Float64Array;
 
 type LAZStreamingDecodeStats = {
   copiedBytes: number;
@@ -1040,35 +1022,6 @@ function parseTypedLASMetadataRecord(
   }
 }
 
-function parseLASExtraBytes(data: Uint8Array): LASExtraBytesDescriptor[] {
-  const descriptors: LASExtraBytesDescriptor[] = [];
-  const dataView = new DataView(data.buffer, data.byteOffset, data.byteLength);
-  for (let offset = 0; offset + 192 <= data.byteLength; offset += 192) {
-    const scales: [number, number, number] = [
-      dataView.getFloat64(offset + 112, true),
-      dataView.getFloat64(offset + 120, true),
-      dataView.getFloat64(offset + 128, true)
-    ];
-    const offsets: [number, number, number] = [
-      dataView.getFloat64(offset + 136, true),
-      dataView.getFloat64(offset + 144, true),
-      dataView.getFloat64(offset + 152, true)
-    ];
-    descriptors.push({
-      dataType: data[offset + 2],
-      options: data[offset + 3],
-      name: readLASString(data, offset + 4, 32),
-      description: readLASString(data, offset + 160, 32),
-      scale: scales[0],
-      offset: offsets[0],
-      scales,
-      offsets,
-      data: data.slice(offset, offset + 192)
-    });
-  }
-  return descriptors;
-}
-
 function parseLASWaveformDescriptor(
   recordId: number,
   data: Uint8Array
@@ -1255,7 +1208,7 @@ function makeLASArrowTableFromAttributes(
   edgeOfFlightLines: Uint8Array | null,
   waveforms: Uint8Array | null,
   extraBytes: Uint8Array | null,
-  typedExtraBytes: TypedExtraBytesAttribute[] | null
+  typedExtraBytes: LASTypedExtraBytesAttribute[] | null
 ): LASArrowTable {
   const attributes: MeshAttributes = {
     POSITION: {value: positions, size: 3}
@@ -1357,7 +1310,7 @@ function populateLASAttributesFromDataView(
     edgeOfFlightLines: Uint8Array | null;
     waveforms: Uint8Array | null;
     extraBytes: Uint8Array | null;
-    typedExtraBytes: TypedExtraBytesAttribute[] | null;
+    typedExtraBytes: LASTypedExtraBytesAttribute[] | null;
     pointOffset: number;
     sourcePointIndex: number;
     pointCount: number;
@@ -2178,77 +2131,14 @@ function createPointDataBatchState(
 function createTypedExtraBytesAttributes(
   batchSize: number,
   header: LASHeader
-): TypedExtraBytesAttribute[] {
-  const descriptors = header.metadata?.extraBytes || [];
-  let byteOffset = 0;
-  const usedNames = new Set<string>();
-  const attributes: TypedExtraBytesAttribute[] = [];
-  for (let descriptorIndex = 0; descriptorIndex < descriptors.length; descriptorIndex++) {
-    const descriptor = descriptors[descriptorIndex];
-    const scalarDataType = getExtraBytesScalarDataType(descriptor.dataType);
-    const size = getExtraBytesComponentCount(descriptor.dataType);
-    const scalarByteLength = getExtraBytesScalarByteLength(scalarDataType);
-    const byteLength = scalarByteLength * size;
-    if (descriptor.dataType < 1 || descriptor.dataType > 30 || !byteLength) {
-      throw new Error(`LASLoader: unsupported typed Extra Bytes data type ${descriptor.dataType}`);
-    }
-    if (scalarDataType === 7 || scalarDataType === 8) {
-      throw new Error(
-        `LASLoader: typed Extra Bytes data type ${descriptor.dataType} requires BigInt output; use extraBytes: 'raw'`
-      );
-    }
-    let name = `EXTRA_BYTES_${sanitizeExtraBytesName(descriptor.name)}`;
-    if (name === 'EXTRA_BYTES_') {
-      name = `EXTRA_BYTES_${descriptorIndex}`;
-    }
-    const baseName = name;
-    let suffix = 1;
-    while (usedNames.has(name)) {
-      name = `${baseName}_${suffix++}`;
-    }
-    usedNames.add(name);
-    attributes.push({
-      name,
-      value: createExtraBytesTypedArray(
-        scalarDataType,
-        batchSize * size,
-        Boolean(descriptor.options & 0x18) && scalarDataType !== 10
-      ),
-      size,
-      scalarDataType,
-      byteOffset,
-      byteLength,
-      outputFloat64: Boolean(descriptor.options & 0x18) && scalarDataType !== 10,
-      scales:
-        descriptor.options & 0x08 ? descriptor.scales.slice(0, size) : new Array(size).fill(1),
-      offsets:
-        descriptor.options & 0x10 ? descriptor.offsets.slice(0, size) : new Array(size).fill(0)
-    });
-    byteOffset += byteLength;
-  }
-  const expectedByteLength =
+): LASTypedExtraBytesAttribute[] {
+  const extraByteCount =
     header.pointsStructSize - getLAZPointDataRecordBaseLength(header.pointsFormatId);
-  if (byteOffset !== expectedByteLength) {
-    throw new Error(
-      `LASLoader: Extra Bytes descriptors use ${byteOffset} bytes; point records provide ${expectedByteLength}`
-    );
-  }
-  return attributes;
-}
-
-/** Convert a descriptor name into a stable Arrow attribute-name component. */
-function sanitizeExtraBytesName(name: string): string {
-  return name.trim().replace(/[^A-Za-z0-9_]+/g, '_');
-}
-
-/** Resolve the scalar type code for a descriptor, including legacy vector codes. */
-function getExtraBytesScalarDataType(dataType: number): number {
-  return dataType > 20 ? dataType - 20 : dataType > 10 ? dataType - 10 : dataType;
-}
-
-/** Return the number of scalar components represented by an Extra Bytes type. */
-function getExtraBytesComponentCount(dataType: number): number {
-  return dataType > 20 ? 3 : dataType > 10 ? 2 : 1;
+  return createLASTypedExtraBytesAttributes(
+    batchSize,
+    header.metadata?.extraBytes || [],
+    extraByteCount
+  );
 }
 
 /** Return the byte width of one scalar Extra Bytes value. */
@@ -2260,46 +2150,13 @@ function getExtraBytesScalarByteLength(dataType: number): number {
   return 0;
 }
 
-/** Allocate the typed array corresponding to a supported LAS scalar type. */
-function createExtraBytesTypedArray(
-  scalarDataType: number,
-  length: number,
-  outputFloat64 = false
-): TypedExtraBytesValue {
-  if (outputFloat64 && scalarDataType !== 10) {
-    return new Float64Array(length);
-  }
-  switch (scalarDataType) {
-    case 1:
-      return new Uint8Array(length);
-    case 2:
-      return new Int8Array(length);
-    case 3:
-      return new Uint16Array(length);
-    case 4:
-      return new Int16Array(length);
-    case 5:
-      return new Uint32Array(length);
-    case 6:
-      return new Int32Array(length);
-    case 9:
-      return new Float32Array(length);
-    case 10:
-      return new Float64Array(length);
-    default:
-      throw new Error(
-        `LASLoader: unsupported typed Extra Bytes scalar data type ${scalarDataType}`
-      );
-  }
-}
-
 /** Decode typed Extra Bytes directly from uncompressed LAS point records. */
 function populateTypedExtraBytesFromDataView(
   dataView: DataView,
   pointOffset: number,
   pointDataRecordFormat: number,
   targetPointIndex: number,
-  attributes: TypedExtraBytesAttribute[]
+  attributes: LASTypedExtraBytesAttribute[]
 ): void {
   const extraByteBaseOffset = pointOffset + getLAZPointDataRecordBaseLength(pointDataRecordFormat);
   for (const attribute of attributes) {
@@ -2326,7 +2183,7 @@ function populateTypedExtraBytesFromRaw(
   sourcePointOffset: number,
   targetPointOffset: number,
   pointCount: number,
-  attributes: TypedExtraBytesAttribute[]
+  attributes: LASTypedExtraBytesAttribute[]
 ): void {
   const dataView = new DataView(
     rawPointData.buffer,
@@ -2721,7 +2578,7 @@ function flushPointDataBatch(
     state.typedExtraBytes = state.typedExtraBytes
       ? state.typedExtraBytes.map(attribute => ({
           ...attribute,
-          value: createExtraBytesTypedArray(
+          value: createLASTypedExtraBytesValue(
             attribute.scalarDataType,
             attribute.value.length,
             attribute.outputFloat64

--- a/modules/las/test/las-extra-bytes.spec.ts
+++ b/modules/las/test/las-extra-bytes.spec.ts
@@ -1,0 +1,51 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+import {
+  createLASTypedExtraBytesAttributes,
+  parseLASExtraBytes,
+  populateLASTypedExtraBytes
+} from '@loaders.gl/las';
+
+describe('LAS Extra Bytes utilities', () => {
+  test('parses offset views and decodes scaled vector attributes', () => {
+    const storage = new Uint8Array(197);
+    const payload = storage.subarray(5);
+    const descriptorView = new DataView(payload.buffer, payload.byteOffset, payload.byteLength);
+    payload[2] = 23;
+    payload[3] = 0x18;
+    new TextEncoder().encodeInto('surface normal', payload.subarray(4, 36));
+    descriptorView.setFloat64(112, 2, true);
+    descriptorView.setFloat64(120, 3, true);
+    descriptorView.setFloat64(128, 4, true);
+    descriptorView.setFloat64(136, 10, true);
+    descriptorView.setFloat64(144, 20, true);
+    descriptorView.setFloat64(152, 30, true);
+
+    const descriptors = parseLASExtraBytes(payload);
+    const attributes = createLASTypedExtraBytesAttributes(2, descriptors, 6);
+    const rawValues = new Uint8Array(12);
+    const rawView = new DataView(rawValues.buffer);
+    [1, 2, 3, 4, 5, 6].forEach((value, index) => rawView.setUint16(index * 2, value, true));
+    populateLASTypedExtraBytes(rawValues, 2, 6, attributes);
+
+    expect(descriptors[0]?.name).toBe('surface normal');
+    expect(attributes[0]?.name).toBe('EXTRA_BYTES_surface_normal');
+    expect(attributes[0]?.size).toBe(3);
+    expect(attributes[0]?.value).toBeInstanceOf(Float64Array);
+    expect(Array.from(attributes[0]?.value || [])).toEqual([12, 26, 42, 18, 35, 54]);
+  });
+
+  test('rejects truncated descriptors and packed point data', () => {
+    expect(() => parseLASExtraBytes(new Uint8Array(191))).toThrow(/multiple of 192/);
+
+    const descriptor = new Uint8Array(192);
+    descriptor[2] = 1;
+    const attributes = createLASTypedExtraBytesAttributes(2, parseLASExtraBytes(descriptor), 1);
+    expect(() => populateLASTypedExtraBytes(new Uint8Array(1), 2, 1, attributes)).toThrow(
+      /truncated/
+    );
+  });
+});

--- a/modules/loader-utils/src/lib/laz/laz-chunk-decoder.ts
+++ b/modules/loader-utils/src/lib/laz/laz-chunk-decoder.ts
@@ -95,6 +95,7 @@ type LAZPointDataSelection = {
   pointSourceId: boolean;
   flags: boolean;
   waveform: boolean;
+  extraBytes: boolean;
 };
 
 /** Error raised when a feedable decoder needs more compressed bytes. */
@@ -372,7 +373,8 @@ function getLAZPointDataSelection(target: LAZPointDataTarget): LAZPointDataSelec
     userData: Boolean(target.userData),
     pointSourceId: Boolean(target.pointSourceIds),
     flags: Boolean(target.scannerChannels || target.scanDirectionFlags || target.edgeOfFlightLines),
-    waveform: Boolean(target.waveforms)
+    waveform: Boolean(target.waveforms),
+    extraBytes: Boolean(target.extraBytes)
   };
 }
 
@@ -388,7 +390,8 @@ function getLAZPointDataSelectionKey(selection: LAZPointDataSelection): number {
     (selection.userData ? 64 : 0) |
     (selection.pointSourceId ? 128 : 0) |
     (selection.flags ? 256 : 0) |
-    (selection.waveform ? 512 : 0)
+    (selection.waveform ? 512 : 0) |
+    (selection.extraBytes ? 1024 : 0)
   );
 }
 
@@ -558,6 +561,9 @@ function getLayeredChunkLayout(
 
 /** Return the layered-stream prefix needed to satisfy a direct-output selection. */
 function getProgressiveLayerCount(metadata: LAZChunkMetadata, target: LAZPointDataTarget): number {
+  if (target.extraBytes) {
+    return getChunkSizeHeaderCount(metadata.pointDataRecordFormat, getExtraByteCount(metadata));
+  }
   // The first two streams contain XY and Z. Optional Point14 streams follow
   // in codec order: classification, flags, intensity, scan angle, user data,
   // point source ID, and GPS time.
@@ -2934,7 +2940,7 @@ class PointFormat6Decompressor implements PointDecompressor {
       selection
     );
     this.bytes =
-      outputMode === 'raw' && extraByteCount
+      (outputMode === 'raw' || selection?.extraBytes) && extraByteCount
         ? new Byte14Decompressor(stream, extraByteCount, metadata.byte14ItemVersion ?? 3)
         : null;
   }
@@ -2950,7 +2956,13 @@ class PointFormat6Decompressor implements PointDecompressor {
 
   decompressPointData(target: LAZPointDataTarget, targetPointIndex: number): void {
     const point = this.point.decompressPoint();
-    if (this.first && this.extraByteCount) {
+    if (this.bytes && target.extraBytes) {
+      this.bytes.decompress(
+        target.extraBytes,
+        targetPointIndex * this.extraByteCount,
+        this.point.itemContextChannel
+      );
+    } else if (this.first && this.extraByteCount) {
       this.stream.consume(this.extraByteCount);
     }
     this.readFirstMetadata();
@@ -2967,7 +2979,13 @@ class PointFormat6Decompressor implements PointDecompressor {
 
     for (let pointIndex = 0; pointIndex < pointCount; pointIndex++) {
       const point = this.point.decompressPoint();
-      if (this.first && this.extraByteCount) {
+      if (this.bytes && target.extraBytes) {
+        this.bytes.decompress(
+          target.extraBytes,
+          targetPointIndex * this.extraByteCount,
+          this.point.itemContextChannel
+        );
+      } else if (this.first && this.extraByteCount) {
         this.stream.consume(this.extraByteCount);
       }
       this.readFirstMetadata();
@@ -3038,7 +3056,7 @@ class PointFormat7Decompressor implements PointDecompressor {
         ? new RGB14Decompressor(stream, metadata.rgb14ItemVersion ?? 3)
         : null;
     this.bytes =
-      outputMode === 'raw' && extraByteCount
+      (outputMode === 'raw' || selection?.extraBytes) && extraByteCount
         ? new Byte14Decompressor(stream, extraByteCount, metadata.byte14ItemVersion ?? 3)
         : null;
   }
@@ -3061,7 +3079,13 @@ class PointFormat7Decompressor implements PointDecompressor {
       this.stream.consume(6);
     }
     // The first point stores extra bytes before the layered stream metadata.
-    if (this.first && this.extraByteCount) {
+    if (this.bytes && target.extraBytes) {
+      this.bytes.decompress(
+        target.extraBytes,
+        targetPointIndex * this.extraByteCount,
+        this.point.itemContextChannel
+      );
+    } else if (this.first && this.extraByteCount) {
       this.stream.consume(this.extraByteCount);
     }
     this.readFirstMetadata();
@@ -3095,7 +3119,13 @@ class PointFormat7Decompressor implements PointDecompressor {
       } else if (this.first) {
         this.stream.consume(6);
       }
-      if (this.first && this.extraByteCount) {
+      if (this.bytes && target.extraBytes) {
+        this.bytes.decompress(
+          target.extraBytes,
+          targetPointIndex * this.extraByteCount,
+          this.point.itemContextChannel
+        );
+      } else if (this.first && this.extraByteCount) {
         this.stream.consume(this.extraByteCount);
       }
       this.readFirstMetadata();
@@ -3190,7 +3220,7 @@ class PointFormat8Decompressor implements PointDecompressor {
         ? new NIR14Decompressor(stream, metadata.rgb14ItemVersion ?? 3)
         : null;
     this.bytes =
-      outputMode === 'raw' && extraByteCount
+      (outputMode === 'raw' || selection?.extraBytes) && extraByteCount
         ? new Byte14Decompressor(stream, extraByteCount, metadata.byte14ItemVersion ?? 3)
         : null;
   }
@@ -3213,9 +3243,19 @@ class PointFormat8Decompressor implements PointDecompressor {
     } else if (this.first) {
       this.stream.consume(6);
     }
+    if (!this.nir && this.first) {
+      this.stream.consume(2);
+    }
     const nir = this.nir ? this.nir.decompressNir(this.point.itemContextChannel) : 0;
+    if (this.bytes && target.extraBytes) {
+      this.bytes.decompress(
+        target.extraBytes,
+        targetPointIndex * this.extraByteCount,
+        this.point.itemContextChannel
+      );
+    }
     if (this.first) {
-      this.stream.consume((this.nir ? 0 : 2) + this.extraByteCount);
+      this.stream.consume(this.bytes ? 0 : this.extraByteCount);
     }
     this.readFirstMetadata();
     writePoint14ToPointDataTarget(point, target, targetPointIndex);
@@ -3248,9 +3288,19 @@ class PointFormat8Decompressor implements PointDecompressor {
       } else if (this.first) {
         this.stream.consume(6);
       }
+      if (!this.nir && this.first) {
+        this.stream.consume(2);
+      }
       const nir = this.nir ? this.nir.decompressNir(this.point.itemContextChannel) : 0;
+      if (this.bytes && target.extraBytes) {
+        this.bytes.decompress(
+          target.extraBytes,
+          targetPointIndex * this.extraByteCount,
+          this.point.itemContextChannel
+        );
+      }
       if (this.first) {
-        this.stream.consume((this.nir ? 0 : 2) + this.extraByteCount);
+        this.stream.consume(this.bytes ? 0 : this.extraByteCount);
       }
       this.readFirstMetadata();
       writePoint14ToPointDataArrays(

--- a/modules/loader-utils/test/lib/laz/laz-chunk-encoder.spec.ts
+++ b/modules/loader-utils/test/lib/laz/laz-chunk-encoder.spec.ts
@@ -5,6 +5,7 @@
 import test from 'test/utils/vitest-tape';
 import {
   createLAZChunkEncoder,
+  createLAZChunkDecoderCursor,
   decodeLAZChunk,
   decodeLAZChunkTable,
   encodeLAZChunk,
@@ -32,6 +33,43 @@ test('LAZChunkEncoder#encodes LASzip v3 PDRF 6-8 chunks', t => {
       getLAZChunkByteLength(compressed, metadata),
       compressed.byteLength,
       `PDRF ${pointDataRecordFormat} layered size headers are complete`
+    );
+  }
+  t.end();
+});
+
+test('LAZChunkDecoder#decodes modern Extra Bytes directly into point-data targets', t => {
+  for (const pointDataRecordFormat of [6, 7, 8]) {
+    const {rawPointData, metadata} = createLAZEncodingFixture(pointDataRecordFormat);
+    const compressed = encodeLAZChunk(rawPointData, metadata);
+    const extraBytes = new Uint8Array(metadata.pointCount * 2);
+    const positions = new Float64Array(metadata.pointCount * 3);
+    const cursor = createLAZChunkDecoderCursor(compressed, metadata);
+
+    cursor.decodeIntoPointData(
+      {
+        positions,
+        extraBytes,
+        pointOffset: 0,
+        scale: [1, 1, 1],
+        offset: [0, 0, 0]
+      },
+      metadata.pointCount
+    );
+
+    const expectedExtraBytes = new Uint8Array(metadata.pointCount * 2);
+    for (let pointIndex = 0; pointIndex < metadata.pointCount; pointIndex++) {
+      const sourceOffset =
+        pointIndex * metadata.pointDataRecordLength + metadata.pointDataRecordLength - 2;
+      expectedExtraBytes.set(rawPointData.subarray(sourceOffset, sourceOffset + 2), pointIndex * 2);
+    }
+    const mismatchIndex = extraBytes.findIndex(
+      (value, index) => value !== expectedExtraBytes[index]
+    );
+    t.equal(
+      mismatchIndex,
+      -1,
+      `PDRF ${pointDataRecordFormat} Extra Bytes (first mismatch ${mismatchIndex}: ${extraBytes[mismatchIndex]} vs ${expectedExtraBytes[mismatchIndex]})`
     );
   }
   t.end();

--- a/yarn.lock
+++ b/yarn.lock
@@ -5296,7 +5296,6 @@ __metadata:
     "@loaders.gl/schema": "npm:5.0.0-alpha.2"
     "@loaders.gl/schema-utils": "npm:5.0.0-alpha.2"
     "@math.gl/proj4": "npm:^4.1.0"
-    copc: "npm:0.0.8"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Goals

- Complete the first-party TypeScript COPC reader and remove the runtime `copc` package dependency.
- Finish the next two reader tranches: common LAS 1.4 point metadata and typed Extra Bytes Arrow output.
- Make the COPC format page the canonical, evidence-based capability matrix.

## Changes

- Add native COPC header, VLR/EVLR, info VLR, hierarchy-page, octree-key, bounds, and exact node-range parsing.
- Support HTTP URLs, browser Blobs, and local Node files through one exact range-reader interface.
- Route atomic and progressive PDRF 6-8 node decoding exclusively through the TypeScript LAZ implementation.
- Preserve bounded concurrent range prefetching, in-order delivery, cancellation, and handled abandoned-request failures.
- Remove `copc.decoder` and the `copc` package dependency; document the migration.
- Expose return number/count, scanner channel, scan direction, edge-of-flight-line, and user-data Arrow columns.
- Extract shared alignment-safe LAS Extra Bytes utilities and emit named typed scalar/vector Arrow attributes with descriptor scale and offset transforms.
- Export low-level native COPC range APIs and parsed metadata types.
- Add a comprehensive COPC capability matrix, Arrow-column table, streaming boundaries, and range-layout documentation.
- Add browser and Node coverage for native opening, hierarchy/node ranges, malformed input, offset views, standard fields, and typed Extra Bytes.

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn build-workers`
- `yarn test-node` (44 files, 318 passed)
- `yarn test-headless` (428 files, 2,417 passed)
- `yarn test-audit` (0 violations)
- `website/yarn build`
