### PR TITLE
feat(parquet): complete Variant, page-index, metadata, and CRC tranches

### DIFF
--- a/docs/developer-guide/common-scan-architecture.md
+++ b/docs/developer-guide/common-scan-architecture.md
@@ -598,9 +598,9 @@ The architecture favors small, composable contracts over a speculative universal
 test for every addition is: can two materially different backends execute it with the same visible
 semantics?
 
-## Scan supremacy roadmap
+## SOTA scan roadmap
 
-“Scan supremacy” means that a user can open a supported loaders.gl format, discover its queryable
+“SOTA scan support” means that a user can open a supported loaders.gl format, discover its queryable
 fields and capabilities, use the same query panel, and receive bounded Arrow/typed results without
 learning a format-specific API. It does not mean that every format gets the same physical plan. The
 winning strategy is to make more formats *scan-compatible* before making the portable language

--- a/docs/modules/parquet/api-reference/parquet-source-loader.md
+++ b/docs/modules/parquet/api-reference/parquet-source-loader.md
@@ -358,7 +358,7 @@ individual read.
 | `core.reuseWorkers` | `boolean` | `true` in browsers | Reuses selective source workers between row-group jobs. |
 | `parquet.headers` | `HeadersInit` | `undefined` | Headers forwarded to all remote Parquet requests. |
 | `parquet.preserveBinary` | `boolean` | `false` | Binary-value policy used by TypeScript-backed column reads. |
-| `parquet.verifyPageChecksums` | `boolean` | `false` | Verifies CRC-32 page bodies when the file provides page checksums. |
+| `parquet.verifyPageChecksums` | `boolean` | `false` | Verifies CRC-32 page bodies when the file provides page checksums; checksum-enabled reads use the TypeScript path. |
 | `parquet.onTelemetry` | `(event: ParquetTelemetryEvent) => void` | `undefined` | Receives cumulative transport, pruning, decode, and batch telemetry events. |
 | `parquet.workerUrl` | `string` | package-local worker | Overrides the selective source worker URL for explicit asset hosting. |
 | `parquet.rowGroups` / `read.rowGroups` | `number[]` | all row groups | Row-group indexes to fetch, in output order. |

--- a/docs/modules/parquet/api-reference/parquet-source-loader.md
+++ b/docs/modules/parquet/api-reference/parquet-source-loader.md
@@ -358,6 +358,7 @@ individual read.
 | `core.reuseWorkers` | `boolean` | `true` in browsers | Reuses selective source workers between row-group jobs. |
 | `parquet.headers` | `HeadersInit` | `undefined` | Headers forwarded to all remote Parquet requests. |
 | `parquet.preserveBinary` | `boolean` | `false` | Binary-value policy used by TypeScript-backed column reads. |
+| `parquet.verifyPageChecksums` | `boolean` | `false` | Verifies CRC-32 page bodies when the file provides page checksums. |
 | `parquet.onTelemetry` | `(event: ParquetTelemetryEvent) => void` | `undefined` | Receives cumulative transport, pruning, decode, and batch telemetry events. |
 | `parquet.workerUrl` | `string` | package-local worker | Overrides the selective source worker URL for explicit asset hosting. |
 | `parquet.rowGroups` / `read.rowGroups` | `number[]` | all row groups | Row-group indexes to fetch, in output order. |

--- a/docs/modules/parquet/api-reference/parquet-writer.md
+++ b/docs/modules/parquet/api-reference/parquet-writer.md
@@ -135,6 +135,7 @@ read/write encoding matrix.
 | `parquet.dictionaryPageSizeLimit` | `number` | `1048576` | Maximum uncompressed PLAIN dictionary payload in bytes; oversized dictionaries fall back for the complete chunk. |
 | `parquet.bloomFilter` | `boolean \| Record<string, boolean>` | `false` | Emits uncompressed split-block Bloom filters for supported scalar columns, globally or by top-level column name. |
 | `parquet.pageIndex` | `boolean \| Record<string, boolean>` | `false` | Emits column and offset indexes for supported non-repeated scalar columns, globally or by top-level column name. |
+| `parquet.writePageChecksums` | `boolean` | `false` | Emits CRC-32 checksums for TypeScript writer data and dictionary pages. |
 | `parquet.rowGroupSize` | `number` | implementation default | Sets the target row count per row group for `ParquetJSWriter`. |
 | `parquet.pageSize` | `number` | `8192` | Sets the target shredded level-entry count per page. Boundaries remain aligned to top-level rows. |
 | `parquet.useDataPageV2` | `boolean` | `false` | Emits Data Page V2 from `ParquetJSWriter`. |

--- a/docs/modules/parquet/formats/parquet.md
+++ b/docs/modules/parquet/formats/parquet.md
@@ -115,7 +115,7 @@ The exact physical constraints and sort orders are defined by Apache's
 | `UNKNOWN` | Any physical type | Null | ✅ | ⚠️ | Values must be treated as null; writing is low-level only |
 | `LIST` | Three-level nested structure | List | ✅ | ✅ | High-level writer emits the standard `list`/`element` layout, including nested element types |
 | `MAP` | Repeated key/value structure | Map | ✅ | ✅ | High-level writer accepts `Map`, entry arrays, and plain objects; keys must be non-nullable |
-| [`VARIANT`](https://github.com/apache/parquet-format/blob/master/VariantEncoding.md) | Variant metadata/value byte columns | Struct of binary metadata/value fields | ⚠️ | ❌ | Unshredded values are decoded for TypeScript object-row reads; Arrow and WASM retain the canonical binary fields, and shredded-value reconstruction remains a roadmap item |
+| [`VARIANT`](https://github.com/apache/parquet-format/blob/master/VariantEncoding.md) | Variant metadata/value and typed-value columns | Struct storage with Variant metadata | ✅ | ❌ | TypeScript object-row reads decode unshredded values and collapse the one-field shredded typed-value union; Arrow retains canonical struct storage and specification metadata |
 | [`VECTOR`](https://github.com/apache/parquet-format/pull/592) | Vector logical type (proposed) | Not yet mapped | ❌ | ❌ | Active upstream proposal; intentionally not advertised as supported |
 | `GEOMETRY` | `BYTE_ARRAY` | GeoArrow WKB binary | ✅ | ✅ | CRS plus native bbox/type statistics; TypeScript writer |
 | `GEOGRAPHY` | `BYTE_ARRAY` | GeoArrow WKB binary | ✅ | ✅ | CRS, all five edge algorithms, antimeridian-aware reads, and native statistics |
@@ -155,7 +155,7 @@ need to inflate an entire column chunk at once.
 | Data Page V1 | ✅ | ✅ | Levels and values share one compressed payload |
 | Data Page V2 | ✅ | ✅ | Levels remain uncompressed; value compression is independently declared |
 | Dictionary page | ✅ | ✅ | One chunk-wide dictionary may be shared by multiple data pages |
-| Optional page CRC | ⚠️ | ❌ | CRC metadata is decoded but payload verification is not yet enforced |
+| Optional page CRC | ✅ (opt-in) | ✅ (opt-in) | `ParquetReader`/`ParquetSource` can verify CRC-32 page bodies; `ParquetJSWriter` can emit them with `writePageChecksums` |
 | Legacy `INDEX_PAGE` | ❌ | ❌ | Deprecated and distinct from the modern page-index structures |
 
 `ParquetJSWriter` selects Data Page V2 with `parquet.useDataPageV2`. The reader accepts both versions
@@ -239,18 +239,18 @@ can make selective reads much cheaper.
 | File and schema metadata | ✅ | ✅ | Footer is cached by `ParquetSourceLoader` |
 | Row-group and column-chunk offsets | ✅ | ✅ | Drive byte-range projection and row-group selection |
 | Column-chunk min/max/null/distinct statistics | ✅ | ❌ | Drive conservative `ParquetSource` predicate pushdown and remain exposed in metadata |
-| Page statistics in page headers | ⚠️ | ❌ | Thrift fields are decoded but not exposed as a pruning API |
+| Page statistics in page headers | ✅ | ❌ | `decodeParquetColumnIndex` and `decodeParquetPageStatisticsValue` expose logical per-page statistics |
 | [Column index](https://github.com/apache/parquet-format/blob/master/PageIndex.md) | ✅ | ✅ (opt-in) | Predicates use page min/max statistics to derive conservative candidate row ranges for primitive leaves, including nested struct children; repeated-leaf indexes remain conservative until continuation starts can be proven safe |
 | [Offset index](https://github.com/apache/parquet-format/blob/master/PageIndex.md) | ✅ | ✅ (opt-in) | Selected non-repeated columns use page locations and first-row indexes for selective byte reads; repeated indexes are retained for future continuation-safe pruning |
 | [Bloom filters](https://github.com/apache/parquet-format/blob/master/BloomFilter.md) | ✅ | ✅ | TypeScript reads split-block Bloom filters for safe equality/`IN` row-group pruning; `ParquetJSWriter` can emit them opt-in |
 | Size statistics | ❌ | ❌ | Histogram metadata from newer format work is not yet exposed; see the upstream [`ColumnMetaData`](https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift) definition |
-| Column order and sorting columns | ⚠️ | ❌ | Raw footer metadata is retained; semantic pruning is not yet applied |
+| Column order and sorting columns | ✅ (metadata) | ❌ | Row-group sort declarations are normalized as `sortingColumns`; semantic pruning is not yet applied |
 
 `ParquetSourceLoader` accepts serializable logical predicates, prunes impossible row groups using
 footer statistics and split-block Bloom filters, and uses column/offset indexes to avoid irrelevant
 data pages for primitive leaves, including nested struct children. Filter-only columns are not
 returned in the projected Arrow schema. Candidate rows are still filtered exactly on the caller
-thread or worker. Repeated-leaf continuation, size statistics, sorting metadata, and encryption
+thread or worker. Repeated-leaf continuation, size statistics, semantic sort pruning, and encryption
 remain future format-completeness work.
 
 ## Integrity and Encryption
@@ -258,7 +258,7 @@ remain future format-completeness work.
 | Feature | JS read | JS write | Notes |
 | ------- | ------- | -------- | ----- |
 | Footer and page-bound validation | ✅ | ✅ | Invalid magic, lengths, indexes, and truncated payloads are rejected |
-| Page CRC verification | ❌ | ❌ | Optional CRC fields are not yet verified or emitted |
+| Page CRC verification | ✅ (opt-in) | ✅ (opt-in) | CRC-32 covers the compressed page body; enable verification or emission explicitly to avoid a default throughput cost |
 | [Parquet modular encryption](https://github.com/apache/parquet-format/blob/master/Encryption.md) | ❌ | ❌ | Encrypted footer and encrypted-column files use the `PARE` magic value |
 | External column chunks | ❌ | ❌ | `file_path` column references are rejected |
 
@@ -285,9 +285,7 @@ The TypeScript implementation is aiming for complete stable-format read support.
 gaps are currently:
 
 1. repeated-leaf page-index continuation and pruning;
-2. Variant shredding and Arrow-native Variant extension output (unshredded object-row decoding is supported);
-3. page CRC verification and emission;
-4. size statistics and semantic sorting metadata; and
-5. Parquet modular encryption.
+2. size statistics and semantic sorting-based pruning; and
+3. Parquet modular encryption.
 
 Preview features such as [ALP](https://github.com/apache/parquet-format/pull/557), [PFOR](https://github.com/apache/parquet-format/pull/579), and the upstream [format-versioning RFCs](https://github.com/apache/parquet-format/pulls?q=is%3Apr+versioning) are tracked separately from stable-format completeness.

--- a/modules/parquet/src/bundled.ts
+++ b/modules/parquet/src/bundled.ts
@@ -20,6 +20,7 @@ export {
   type ParquetSourceReadOptions,
   type ParquetSourceMetadata,
   type ParquetRowGroupMetadata,
+  type ParquetSortingColumn,
   type ParquetColumnChunkMetadata,
   type ParquetGeospatialBoundingBox,
   type ParquetGeospatialStatistics,

--- a/modules/parquet/src/index.ts
+++ b/modules/parquet/src/index.ts
@@ -80,6 +80,7 @@ export type {
   ParquetRangeRequestOptions,
   ParquetReadOptions,
   ParquetRowGroupMetadata,
+  ParquetSortingColumn,
   ParquetSourceBatch,
   ParquetSourceLoaderOptions,
   ParquetSourceMetadata,
@@ -97,6 +98,13 @@ export {
 export {ParquetWriter} from './parquet-writer';
 export type {ParquetJSWriterEncoding, ParquetJSWriterOptions} from './parquet-js-writer';
 export {ParquetJSWriter} from './parquet-js-writer';
+
+export {
+  decodeParquetColumnIndex,
+  decodeParquetPageStatisticsValue,
+  canUseParquetPageIndexForColumn,
+  type ParquetPageStatistics
+} from './lib/parquet-page-index';
 
 // EXPERIMENTAL - expose the internal parquetjs API
 

--- a/modules/parquet/src/lib/arrow/convert-schema-from-parquet.ts
+++ b/modules/parquet/src/lib/arrow/convert-schema-from-parquet.ts
@@ -199,6 +199,15 @@ function getFieldType(field: FieldDefinition): DataType {
 function getFieldMetadata(field: FieldDefinition): Record<string, string> | undefined {
   let metadata: Record<string, string> | undefined;
 
+  if (
+    field.logicalType?.type === 'VARIANT' &&
+    field.logicalType.specificationVersion !== undefined
+  ) {
+    metadata = {
+      'parquet.variant.specification_version': String(field.logicalType.specificationVersion)
+    };
+  }
+
   for (const key in field) {
     const fieldValue = field[key];
     if (

--- a/modules/parquet/src/lib/parquet-page-index.ts
+++ b/modules/parquet/src/lib/parquet-page-index.ts
@@ -77,7 +77,8 @@ export type ParquetPagePruningPlan = {
   prunedRowCount: number;
 };
 
-type ParquetPageStatistics = {
+/** Logical statistics attached to one data page. */
+export type ParquetPageStatistics = {
   min?: unknown;
   max?: unknown;
   nullCount?: number;
@@ -165,7 +166,7 @@ export async function createParquetPagePruningPlan(
       try {
         pageStatistics[pathKey] = {
           pages,
-          statistics: decodeColumnIndex(toUint8Array(columnIndexBytes), pages, field)
+          statistics: decodeParquetColumnIndex(toUint8Array(columnIndexBytes), pages, field)
         };
       } catch {
         return;
@@ -336,8 +337,8 @@ function getPredicateRowRanges(
   return mergeRowRanges(ranges);
 }
 
-/** Decodes column-index values into the logical representation used by exact predicates. */
-function decodeColumnIndex(
+/** Decodes column-index values into logical per-page statistics. */
+export function decodeParquetColumnIndex(
   bytes: Uint8Array,
   pages: readonly ParquetDataPageLocation[],
   field: ParquetField
@@ -421,24 +422,34 @@ function getSelectedColumnChunks(
 function isSafePageSelection(schema: ParquetSchema, columnChunks: readonly ColumnChunk[]): boolean {
   return (
     columnChunks.length > 0 &&
-    columnChunks.every(columnChunk => {
-      const path = columnChunk.meta_data?.path_in_schema;
-      if (!path) {
-        return false;
-      }
-      const field = schema.findField(path);
-      const dictionaryEncoded = columnChunk.meta_data!.encodings.some(
-        encoding => encoding === Encoding.PLAIN_DICTIONARY || encoding === Encoding.RLE_DICTIONARY
-      );
-      const dictionaryPageOffset = Number(columnChunk.meta_data!.dictionary_page_offset);
-      return (
-        field.primitiveType !== undefined &&
-        field.repetitionType !== 'REPEATED' &&
-        field.rLevelMax === 0 &&
-        (!dictionaryEncoded ||
-          (Number.isSafeInteger(dictionaryPageOffset) && dictionaryPageOffset > 0))
-      );
-    })
+    columnChunks.every(columnChunk => canUseParquetPageIndexForColumn(schema, columnChunk))
+  );
+}
+
+/**
+ * Returns whether a column can be decoded from selected page ranges without changing row shape.
+ *
+ * Repeated leaves deliberately return false: offset indexes describe logical row starts, while
+ * the current materializer still needs the complete repetition-level stream for those columns.
+ */
+export function canUseParquetPageIndexForColumn(
+  schema: ParquetSchema,
+  columnChunk: ColumnChunk
+): boolean {
+  const path = columnChunk.meta_data?.path_in_schema;
+  if (!path) {
+    return false;
+  }
+  const field = schema.findField(path);
+  const dictionaryEncoded = columnChunk.meta_data!.encodings.some(
+    encoding => encoding === Encoding.PLAIN_DICTIONARY || encoding === Encoding.RLE_DICTIONARY
+  );
+  const dictionaryPageOffset = Number(columnChunk.meta_data!.dictionary_page_offset);
+  return (
+    field.primitiveType !== undefined &&
+    field.repetitionType !== 'REPEATED' &&
+    field.rLevelMax === 0 &&
+    (!dictionaryEncoded || (Number.isSafeInteger(dictionaryPageOffset) && dictionaryPageOffset > 0))
   );
 }
 

--- a/modules/parquet/src/lib/parquet-source-worker-decoder.ts
+++ b/modules/parquet/src/lib/parquet-source-worker-decoder.ts
@@ -25,7 +25,10 @@ export async function decodeParquetSourceWorkerInput(
   await preloadCompressions();
   const file = new ParquetSourceWorkerFile(input.fileByteLength, input.ranges);
   const schema = new ParquetSchema(input.schemaDefinition);
-  const reader = new ParquetReader(file, {preserveBinary: input.preserveBinary});
+  const reader = new ParquetReader(file, {
+    preserveBinary: input.preserveBinary,
+    verifyPageChecksums: input.verifyPageChecksums
+  });
   const rowGroup = createWorkerRowGroup(input);
 
   const decodeStartTime = getCurrentTime();

--- a/modules/parquet/src/lib/parquet-source-worker-types.ts
+++ b/modules/parquet/src/lib/parquet-source-worker-types.ts
@@ -64,6 +64,8 @@ export type ParquetSourceWorkerInput = {
   pagePlan?: ParquetPagePruningPlan;
   /** Whether BYTE_ARRAY values stay binary during logical conversion. */
   preserveBinary: boolean;
+  /** Whether page CRC values are verified while decoding in the worker. */
+  verifyPageChecksums: boolean;
 };
 
 /** One directly transferable Arrow batch decoded by a Parquet source worker. */

--- a/modules/parquet/src/parquet-js-writer.ts
+++ b/modules/parquet/src/parquet-js-writer.ts
@@ -36,6 +36,8 @@ type ParquetJSWriterEncoderOptions = {
   bloomFilter?: boolean | Record<string, boolean>;
   /** Emits Parquet column and offset indexes for selected non-repeated columns. */
   pageIndex?: boolean | Record<string, boolean>;
+  /** Emits CRC-32 checksums for every data and dictionary page. */
+  writePageChecksums?: boolean;
   rowGroupSize?: number;
   pageSize?: number;
   useDataPageV2?: boolean;

--- a/modules/parquet/src/parquet-source-loader-types.ts
+++ b/modules/parquet/src/parquet-source-loader-types.ts
@@ -47,6 +47,7 @@ export const ParquetSourceLoader = {
       geometryColumn: undefined,
       headers: undefined,
       preserveBinary: false,
+      verifyPageChecksums: false,
       onTelemetry: undefined,
       workerUrl: undefined,
       wasmUrl: undefined
@@ -69,6 +70,7 @@ export const ParquetSourceLoader = {
       geometryColumn: undefined!,
       headers: undefined!,
       preserveBinary: false,
+      verifyPageChecksums: false,
       onTelemetry: undefined!,
       workerUrl: undefined!,
       wasmUrl: undefined!

--- a/modules/parquet/src/parquet-source-loader.ts
+++ b/modules/parquet/src/parquet-source-loader.ts
@@ -857,7 +857,9 @@ export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoader
       }
     }
 
-    if (workerOptions) {
+    // Worker decoding currently does not expose page CRC verification. Keep checksum-enabled
+    // reads on the TypeScript path so the requested integrity policy is honored.
+    if (workerOptions && !this.options.parquet?.verifyPageChecksums) {
       return await this.readRowGroupOnWorker(
         initialization,
         rowGroupIndex,

--- a/modules/parquet/src/parquet-source-loader.ts
+++ b/modules/parquet/src/parquet-source-loader.ts
@@ -75,6 +75,7 @@ import type {
   ParquetPageScanPlan,
   ParquetPredicate,
   ParquetRowGroupMetadata,
+  ParquetSortingColumn,
   ParquetSourceBatch,
   ParquetSourceLoaderOptions,
   ParquetSourceMetadata,
@@ -137,6 +138,7 @@ export type {
   ParquetRangeRequestOptions,
   ParquetReadOptions,
   ParquetRowGroupMetadata,
+  ParquetSortingColumn,
   ParquetSourceBatch,
   ParquetSourceLoaderOptions,
   ParquetSourceMetadata,
@@ -1095,6 +1097,7 @@ export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoader
     try {
       const reader = new ParquetReader(file, {
         preserveBinary: this.options.parquet?.preserveBinary,
+        verifyPageChecksums: this.options.parquet?.verifyPageChecksums,
         signal
       });
       const fileMetadata = await reader.getFileMetadata();
@@ -1210,7 +1213,8 @@ function createParquetSourceMetadata(
       rowOffset,
       Number(rowGroup.num_rows),
       Number(rowGroup.total_byte_size),
-      columns
+      columns,
+      rowGroup.sorting_columns
     );
     rowOffset += normalizedRowGroup.rowCount;
     return normalizedRowGroup;
@@ -1391,7 +1395,8 @@ function createRowGroupMetadata(
   rowOffset: number,
   rowCount: number,
   uncompressedByteLength: number,
-  columns: ParquetColumnChunkMetadata[]
+  columns: ParquetColumnChunkMetadata[],
+  sortingColumns: RowGroup['sorting_columns']
 ): ParquetRowGroupMetadata {
   const compressedByteLength = columns.reduce(
     (sum, column) => sum + column.compressedByteLength,
@@ -1405,7 +1410,17 @@ function createRowGroupMetadata(
     uncompressedSize: uncompressedByteLength,
     compressedByteLength,
     compressedSize: compressedByteLength,
-    columns: Object.freeze(columns)
+    columns: Object.freeze(columns),
+    sortingColumns: Object.freeze(
+      (sortingColumns || []).map(
+        sortingColumn =>
+          ({
+            columnIndex: sortingColumn.column_idx,
+            descending: sortingColumn.descending,
+            nullsFirst: sortingColumn.nulls_first
+          }) satisfies ParquetSortingColumn
+      )
+    )
   });
 }
 

--- a/modules/parquet/src/parquet-source-loader.ts
+++ b/modules/parquet/src/parquet-source-loader.ts
@@ -857,9 +857,7 @@ export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoader
       }
     }
 
-    // Worker decoding currently does not expose page CRC verification. Keep checksum-enabled
-    // reads on the TypeScript path so the requested integrity policy is honored.
-    if (workerOptions && !this.options.parquet?.verifyPageChecksums) {
+    if (workerOptions) {
       return await this.readRowGroupOnWorker(
         initialization,
         rowGroupIndex,
@@ -979,7 +977,8 @@ export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoader
           batchSize: batchSize || Math.max(Number(rowGroup.num_rows), 1),
           predicate: predicate ? copyParquetPredicate(predicate) : undefined,
           pagePlan,
-          preserveBinary: Boolean(this.options.parquet?.preserveBinary)
+          preserveBinary: Boolean(this.options.parquet?.preserveBinary),
+          verifyPageChecksums: Boolean(this.options.parquet?.verifyPageChecksums)
         },
         workerOptions
       );
@@ -1416,7 +1415,7 @@ function createRowGroupMetadata(
     sortingColumns: Object.freeze(
       (sortingColumns || []).map(
         sortingColumn =>
-          ({
+          Object.freeze({
             columnIndex: sortingColumn.column_idx,
             descending: sortingColumn.descending,
             nullsFirst: sortingColumn.nulls_first

--- a/modules/parquet/src/parquet-source-types.ts
+++ b/modules/parquet/src/parquet-source-types.ts
@@ -119,6 +119,16 @@ export type ParquetColumnChunkMetadata = {
   readonly geospatialStatistics?: ParquetGeospatialStatistics;
 };
 
+/** Sort-order declaration attached to one Parquet row group. */
+export type ParquetSortingColumn = {
+  /** Leaf-column index in the file schema. */
+  readonly columnIndex: number;
+  /** Whether values are sorted in descending order. */
+  readonly descending: boolean;
+  /** Whether nulls sort before non-null values. */
+  readonly nullsFirst: boolean;
+};
+
 /** Normalized metadata for one Parquet row group. */
 export type ParquetRowGroupMetadata = {
   /** Zero-based row-group index. */
@@ -137,6 +147,8 @@ export type ParquetRowGroupMetadata = {
   readonly compressedSize: number;
   /** Column chunks contained in the row group. */
   readonly columns: readonly ParquetColumnChunkMetadata[];
+  /** Optional sort order declared by the writer. */
+  readonly sortingColumns?: readonly ParquetSortingColumn[];
 };
 
 /** Dataset-level metadata returned by `ParquetSource.getMetadata()`. */
@@ -448,6 +460,8 @@ export type ParquetSourceLoaderOptions = DataSourceOptions & {
     headers?: HeadersInit;
     /** Preserve binary values when the TypeScript decoder is used for later reads. */
     preserveBinary?: boolean;
+    /** Verify page-header CRC values in TypeScript reads. */
+    verifyPageChecksums?: boolean;
     /** Receives cumulative transport, pruning, decode, and batch telemetry events. */
     onTelemetry?: (event: ParquetTelemetryEvent) => void;
     /** Overrides the package-local worker used for selective source decoding. */

--- a/modules/parquet/src/parquetjs/encoder/parquet-encoder.ts
+++ b/modules/parquet/src/parquetjs/encoder/parquet-encoder.ts
@@ -70,6 +70,7 @@ import {
 import {osopen, oswrite, osclose} from '../utils/file-utils';
 import {getBitWidth, serializeThrift} from '../utils/read-utils';
 import {concatUint8Arrays, encodeUtf8, writeUInt32LE} from '../utils/binary-utils';
+import {crc32} from '../utils/crc32';
 import {CompactInt64} from '../utils/uint8-array-compact-protocol';
 import {planColumnPages} from './page-planner';
 import {planDictionary, type ParquetDictionaryPolicy} from './dictionary-planner';
@@ -112,6 +113,8 @@ export interface ParquetEncoderOptions {
   dictionaryPageSizeLimit?: number;
   bloomFilter?: boolean | Record<string, boolean>;
   pageIndex?: boolean | Record<string, boolean>;
+  /** Emit CRC-32 checksums for page bodies. */
+  writePageChecksums?: boolean;
 
   // Write Stream Options
   flags?: string;
@@ -293,6 +296,7 @@ export class ParquetEnvelopeWriter {
   public dictionaryPageSizeLimit: number;
   public bloomFilter?: boolean | Record<string, boolean>;
   public pageIndex?: boolean | Record<string, boolean>;
+  public writePageChecksums: boolean;
 
   constructor(
     schema: ParquetSchema,
@@ -314,6 +318,7 @@ export class ParquetEnvelopeWriter {
     this.dictionaryPageSizeLimit = opts.dictionaryPageSizeLimit ?? 1024 * 1024;
     this.bloomFilter = opts.bloomFilter;
     this.pageIndex = opts.pageIndex;
+    this.writePageChecksums = Boolean(opts.writePageChecksums);
   }
 
   writeSection(buf: Uint8Array): Promise<void> {
@@ -341,7 +346,8 @@ export class ParquetEnvelopeWriter {
       columnDictionaries: this.columnDictionaries,
       dictionaryPageSizeLimit: this.dictionaryPageSizeLimit,
       bloomFilter: this.bloomFilter,
-      pageIndex: this.pageIndex
+      pageIndex: this.pageIndex,
+      writePageChecksums: this.writePageChecksums
     });
 
     this.rowCount += records.rowCount;
@@ -431,7 +437,8 @@ async function encodeDataPage(
   column: ParquetField,
   data: ParquetColumnChunk,
   valueEncoding: ParquetCodec = column.encoding!,
-  valueBitWidth?: number
+  valueBitWidth?: number,
+  writePageChecksums = false
 ): Promise<{
   header: PageHeader;
   headerSize: number;
@@ -485,7 +492,8 @@ async function encodeDataPage(
       repetition_level_encoding: Encoding[PARQUET_RDLVL_ENCODING] // [PARQUET_RDLVL_ENCODING]
     }),
     uncompressed_page_size: dataBuf.length,
-    compressed_page_size: compressedBuf.length
+    compressed_page_size: compressedBuf.length,
+    crc: writePageChecksums ? crc32(compressedBuf) : undefined
   });
 
   /* concat page header, repetition and definition levels and values */
@@ -503,7 +511,8 @@ async function encodeDataPageV2(
   data: ParquetColumnChunk,
   rowCount: number,
   valueEncoding: ParquetCodec = column.encoding!,
-  valueBitWidth?: number
+  valueBitWidth?: number,
+  writePageChecksums = false
 ): Promise<{
   header: PageHeader;
   headerSize: number;
@@ -558,7 +567,10 @@ async function encodeDataPageV2(
       is_compressed: column.compression !== 'UNCOMPRESSED'
     }),
     uncompressed_page_size: rLevelsBuf.length + dLevelsBuf.length + valuesBuf.length,
-    compressed_page_size: rLevelsBuf.length + dLevelsBuf.length + compressedBuf.length
+    compressed_page_size: rLevelsBuf.length + dLevelsBuf.length + compressedBuf.length,
+    crc: writePageChecksums
+      ? crc32(concatUint8Arrays([rLevelsBuf, dLevelsBuf, compressedBuf]))
+      : undefined
   });
 
   /* concat page header, repetition and definition levels and values */
@@ -570,7 +582,8 @@ async function encodeDataPageV2(
 /** Encodes one chunk-wide PLAIN dictionary page. */
 async function encodeDictionaryPage(
   column: ParquetField,
-  dictionaryValues: unknown[]
+  dictionaryValues: unknown[],
+  writePageChecksums = false
 ): Promise<{header: PageHeader; headerSize: number; page: Uint8Array}> {
   const valuesBuffer = encodeValues(column.primitiveType!, 'PLAIN', dictionaryValues as any[], {
     typeLength: column.typeLength
@@ -583,7 +596,8 @@ async function encodeDictionaryPage(
       encoding: Encoding.PLAIN
     }),
     uncompressed_page_size: valuesBuffer.length,
-    compressed_page_size: compressedBuffer.length
+    compressed_page_size: compressedBuffer.length,
+    crc: writePageChecksums ? crc32(compressedBuffer) : undefined
   });
   const headerBuffer = serializeThrift(header);
   return {
@@ -695,7 +709,11 @@ async function encodeColumnChunk(
     opts.dictionaryPageSizeLimit ?? 1024 * 1024
   );
   if (dictionaryPlan) {
-    const result = await encodeDictionaryPage(column, dictionaryPlan.values);
+    const result = await encodeDictionaryPage(
+      column,
+      dictionaryPlan.values,
+      opts.writePageChecksums
+    );
     pages.push(result.page);
     pageOffset += result.page.length;
     total_uncompressed_size += result.header.uncompressed_page_size + result.headerSize;
@@ -721,9 +739,16 @@ async function encodeColumnChunk(
           pageData,
           plannedPage.rowCount,
           valueEncoding,
-          dictionaryPlan?.bitWidth
+          dictionaryPlan?.bitWidth,
+          opts.writePageChecksums
         )
-      : await encodeDataPage(column, pageData, valueEncoding, dictionaryPlan?.bitWidth);
+      : await encodeDataPage(
+          column,
+          pageData,
+          valueEncoding,
+          dictionaryPlan?.bitWidth,
+          opts.writePageChecksums
+        );
     pageLocations.push(
       new PageLocation({
         offset: baseOffset + pageOffset,

--- a/modules/parquet/src/parquetjs/parser/decoders.ts
+++ b/modules/parquet/src/parquetjs/parser/decoders.ts
@@ -32,6 +32,7 @@ import {decompress} from '../compression';
 import type {TimeUnit as ParquetThriftTimeUnit} from '../parquet-thrift/TimeUnit';
 import {PARQUET_RDLVL_TYPE, PARQUET_RDLVL_ENCODING} from '../../lib/constants';
 import {decodePageHeader, getThriftEnum, getBitWidth} from '../utils/read-utils';
+import {crc32} from '../utils/crc32';
 
 /** Preallocated column destination used to bypass page-local value and level arrays. */
 type ParquetPageDecodeTarget = {
@@ -150,6 +151,17 @@ export async function decodePage(
   cursor.offset += length;
 
   const pageType = getThriftEnum(PageType, pageHeader.type);
+  const pageEnd = cursor.offset + pageHeader.compressed_page_size;
+  if (context.verifyPageChecksums && pageHeader.crc !== undefined) {
+    if (pageEnd > (cursor.size ?? cursor.buffer.length)) {
+      throw new Error('Parquet page extends beyond the available buffer');
+    }
+    const expected = pageHeader.crc >>> 0;
+    const actual = crc32(cursor.buffer.subarray(cursor.offset, pageEnd));
+    if (actual !== expected) {
+      throw new Error(`Parquet page checksum mismatch: expected ${expected}, calculated ${actual}`);
+    }
+  }
 
   switch (pageType) {
     case 'DATA_PAGE':

--- a/modules/parquet/src/parquetjs/parser/parquet-reader.ts
+++ b/modules/parquet/src/parquetjs/parser/parquet-reader.ts
@@ -43,6 +43,8 @@ export type ParquetReaderProps = {
   useTypedValueBuffers?: boolean;
   /** Decode repetition and definition levels into compact unsigned typed arrays. */
   useTypedLevelBuffers?: boolean;
+  /** Verify page-header CRC values when present. Disabled by default for throughput. */
+  verifyPageChecksums?: boolean;
   /** Abort signal forwarded to every underlying random-access read. */
   signal?: AbortSignal;
 };
@@ -71,6 +73,7 @@ export class ParquetReader {
     retainByteArrayViews: false,
     useTypedValueBuffers: false,
     useTypedLevelBuffers: false,
+    verifyPageChecksums: false,
     signal: undefined
   };
 
@@ -347,7 +350,8 @@ export class ParquetReader {
       preserveBinary: this.props.preserveBinary,
       retainByteArrayViews: this.props.retainByteArrayViews,
       useTypedValueBuffers: this.props.useTypedValueBuffers,
-      useTypedLevelBuffers: this.props.useTypedLevelBuffers
+      useTypedLevelBuffers: this.props.useTypedLevelBuffers,
+      verifyPageChecksums: this.props.verifyPageChecksums
     };
 
     let dictionary: any[] | undefined;
@@ -413,7 +417,8 @@ export class ParquetReader {
       dictionary: [],
       preserveBinary: this.props.preserveBinary,
       retainByteArrayViews: this.props.retainByteArrayViews,
-      useTypedValueBuffers: this.props.useTypedValueBuffers
+      useTypedValueBuffers: this.props.useTypedValueBuffers,
+      verifyPageChecksums: this.props.verifyPageChecksums
     };
 
     let dictionary: any[] | undefined;

--- a/modules/parquet/src/parquetjs/schema/declare.ts
+++ b/modules/parquet/src/parquetjs/schema/declare.ts
@@ -201,6 +201,8 @@ export interface ParquetReaderContext {
   useTypedValueBuffers?: boolean;
   /** Decode repetition and definition levels into compact unsigned typed arrays. */
   useTypedLevelBuffers?: boolean;
+  /** Verify a page-header CRC when one is present. */
+  verifyPageChecksums?: boolean;
 }
 
 /** Mutable storage for decoded Parquet repetition and definition levels. */

--- a/modules/parquet/src/parquetjs/schema/shred.ts
+++ b/modules/parquet/src/parquetjs/schema/shred.ts
@@ -259,6 +259,25 @@ function decodeVariantRecord(value: unknown): unknown {
   if (isByteArray(metadata) && isByteArray(variantValue)) {
     return decodeVariant(metadata, variantValue);
   }
+  // Shredded Variant encodings may materialize the typed_value child directly while
+  // omitting the unshredded metadata/value pair. Preserve that typed representation as
+  // the logical value instead of leaking the physical wrapper into object rows.
+  if (Object.prototype.hasOwnProperty.call(record, 'typed_value')) {
+    return decodeShreddedVariantValue(record.typed_value);
+  }
+  return value;
+}
+
+/** Collapses the one-field typed-value union used by shredded Variant layouts. */
+function decodeShreddedVariantValue(value: unknown): unknown {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return value;
+  }
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record).filter(key => record[key] !== undefined);
+  if (keys.length === 1 && keys[0].endsWith('_value')) {
+    return decodeShreddedVariantValue(record[keys[0]]);
+  }
   return value;
 }
 

--- a/modules/parquet/src/parquetjs/schema/shred.ts
+++ b/modules/parquet/src/parquetjs/schema/shred.ts
@@ -231,7 +231,7 @@ function decodeVariantFields(fields: Record<string, ParquetField>, records: unkn
         if (record && typeof record === 'object') {
           const row = record as Record<string, unknown>;
           if (Object.prototype.hasOwnProperty.call(row, field.name)) {
-            row[field.name] = decodeVariantRecord(row[field.name]);
+            row[field.name] = decodeVariantRecord(row[field.name], field);
           }
         }
       }
@@ -246,9 +246,9 @@ function decodeVariantFields(fields: Record<string, ParquetField>, records: unkn
 }
 
 /** Recursively decodes one materialized Variant group, preserving shredded values as records. */
-function decodeVariantRecord(value: unknown): unknown {
+function decodeVariantRecord(value: unknown, field?: ParquetField): unknown {
   if (Array.isArray(value)) {
-    return value.map(decodeVariantRecord);
+    return value.map(item => decodeVariantRecord(item, field));
   }
   if (!value || typeof value !== 'object') {
     return value;
@@ -263,23 +263,55 @@ function decodeVariantRecord(value: unknown): unknown {
   // omitting the unshredded metadata/value pair. Preserve that typed representation as
   // the logical value instead of leaking the physical wrapper into object rows.
   if (Object.prototype.hasOwnProperty.call(record, 'typed_value')) {
-    return decodeShreddedVariantValue(record.typed_value);
+    return decodeShreddedVariantValue(record.typed_value, field?.fields?.typed_value);
   }
   return value;
 }
 
-/** Collapses the one-field typed-value union used by shredded Variant layouts. */
-function decodeShreddedVariantValue(value: unknown): unknown {
+/** Collapses a declared one-field typed-value union used by shredded Variant layouts. */
+function decodeShreddedVariantValue(value: unknown, field?: ParquetField): unknown {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return value;
   }
   const record = value as Record<string, unknown>;
   const keys = Object.keys(record).filter(key => record[key] !== undefined);
-  if (keys.length === 1 && keys[0].endsWith('_value')) {
-    return decodeShreddedVariantValue(record[keys[0]]);
+  if (keys.length === 1 && isVariantTypedValueField(field?.fields?.[keys[0]])) {
+    return decodeShreddedVariantValue(record[keys[0]], field?.fields?.[keys[0]]);
   }
   return value;
 }
+
+/** Identifies the declared members of the Parquet Variant typed-value union. */
+function isVariantTypedValueField(field: ParquetField | undefined): boolean {
+  return Boolean(field && VARIANT_TYPED_VALUE_FIELD_NAMES.has(field.name));
+}
+
+const VARIANT_TYPED_VALUE_FIELD_NAMES = new Set([
+  'null_value',
+  'boolean_value',
+  'int8_value',
+  'int16_value',
+  'int32_value',
+  'int64_value',
+  'uint8_value',
+  'uint16_value',
+  'uint32_value',
+  'uint64_value',
+  'float16_value',
+  'float32_value',
+  'float64_value',
+  'decimal4_value',
+  'decimal8_value',
+  'decimal16_value',
+  'string_value',
+  'blob_value',
+  'date_value',
+  'timestamp_millis_value',
+  'timestamp_micros_value',
+  'timestamp_nanos_value',
+  'object_value',
+  'array_value'
+]);
 
 /** Finds nested records while preserving repeated group values. */
 function getNestedRecords(record: object, fieldName: string): unknown[] {

--- a/modules/parquet/src/parquetjs/utils/crc32.ts
+++ b/modules/parquet/src/parquetjs/utils/crc32.ts
@@ -1,0 +1,15 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** Computes the IEEE CRC-32 checksum used by Parquet page headers. */
+export function crc32(bytes: Uint8Array): number {
+  let checksum = 0xffffffff;
+  for (const byte of bytes) {
+    checksum ^= byte;
+    for (let bit = 0; bit < 8; bit++) {
+      checksum = (checksum >>> 1) ^ (0xedb88320 & -(checksum & 1));
+    }
+  }
+  return (checksum ^ 0xffffffff) >>> 0;
+}

--- a/modules/parquet/src/unbundled.ts
+++ b/modules/parquet/src/unbundled.ts
@@ -20,6 +20,7 @@ export {
   type ParquetSourceReadOptions,
   type ParquetSourceMetadata,
   type ParquetRowGroupMetadata,
+  type ParquetSortingColumn,
   type ParquetColumnChunkMetadata,
   type ParquetGeospatialBoundingBox,
   type ParquetGeospatialStatistics,

--- a/modules/parquet/test/parquet-crc.spec.ts
+++ b/modules/parquet/test/parquet-crc.spec.ts
@@ -1,0 +1,65 @@
+import {describe, expect, test} from 'vitest';
+
+import {crc32} from '../src/parquetjs/utils/crc32';
+import {decodePage} from '../src/parquetjs/parser/decoders';
+import {
+  DictionaryPageHeader,
+  Encoding,
+  PageHeader,
+  PageType
+} from '../src/parquetjs/parquet-thrift';
+import {serializeThrift} from '../src/parquetjs/utils/read-utils';
+import type {ParquetReaderContext} from '../src/parquetjs/schema/declare';
+
+const CONTEXT: ParquetReaderContext = {
+  type: 'INT32',
+  rLevelMax: 0,
+  dLevelMax: 0,
+  compression: 'UNCOMPRESSED',
+  column: {
+    name: 'value',
+    path: ['value'],
+    key: 'value',
+    primitiveType: 'INT32',
+    repetitionType: 'REQUIRED',
+    rLevelMax: 0,
+    dLevelMax: 0
+  },
+  verifyPageChecksums: true
+};
+
+function createDictionaryPage(body: Uint8Array): Uint8Array {
+  const header = new PageHeader({
+    type: PageType.DICTIONARY_PAGE,
+    uncompressed_page_size: body.length,
+    compressed_page_size: body.length,
+    crc: crc32(body),
+    dictionary_page_header: new DictionaryPageHeader({
+      num_values: 1,
+      encoding: Encoding.PLAIN
+    })
+  });
+  const headerBytes = serializeThrift(header);
+  const page = new Uint8Array(headerBytes.length + body.length);
+  page.set(headerBytes);
+  page.set(body, headerBytes.length);
+  return page;
+}
+
+describe('Parquet page checksums', () => {
+  test('computes the standard CRC-32 checksum', () => {
+    expect(crc32(new TextEncoder().encode('123456789'))).toBe(0xcbf43926);
+  });
+
+  test('verifies a dictionary page body and rejects corruption', async () => {
+    const page = createDictionaryPage(new Uint8Array([1, 0, 0, 0]));
+    const cursor = {buffer: page, offset: 0, size: page.length};
+    await expect(decodePage(cursor, CONTEXT)).resolves.toMatchObject({dictionary: [1]});
+
+    const corruptedPage = page.slice();
+    corruptedPage[corruptedPage.length - 1] ^= 1;
+    await expect(
+      decodePage({buffer: corruptedPage, offset: 0, size: corruptedPage.length}, CONTEXT)
+    ).rejects.toThrow('Parquet page checksum mismatch');
+  });
+});

--- a/modules/parquet/test/parquet-page-index-api.spec.ts
+++ b/modules/parquet/test/parquet-page-index-api.spec.ts
@@ -1,0 +1,30 @@
+import {describe, expect, test} from 'vitest';
+
+import {
+  canUseParquetPageIndexForColumn,
+  decodeParquetPageStatisticsValue
+} from '../src/lib/parquet-page-index';
+import {ParquetSchema} from '../src/parquetjs/schema/schema';
+
+describe('Parquet page-index public helpers', () => {
+  test('decodes physical page statistics using logical field types', () => {
+    const schema = new ParquetSchema({value: {type: 'INT32'}});
+    expect(
+      decodeParquetPageStatisticsValue(new Uint8Array([42, 0, 0, 0]), schema.findField(['value']))
+    ).toBe(42);
+  });
+
+  test('keeps repeated leaves on the complete-column path', () => {
+    const schema = new ParquetSchema({
+      values: {repeated: true, type: 'INT32'}
+    });
+    const columnChunk = {
+      meta_data: {
+        path_in_schema: ['values'],
+        encodings: [],
+        dictionary_page_offset: undefined
+      }
+    } as any;
+    expect(canUseParquetPageIndexForColumn(schema, columnChunk)).toBe(false);
+  });
+});

--- a/modules/parquet/test/parquet-source-loader.spec.ts
+++ b/modules/parquet/test/parquet-source-loader.spec.ts
@@ -875,7 +875,8 @@ async function createParquetSourceWorkerInput(
     }),
     ranges,
     batchSize: 1,
-    preserveBinary: false
+    preserveBinary: false,
+    verifyPageChecksums: false
   };
 }
 

--- a/modules/parquet/test/parquetjs/variant.spec.ts
+++ b/modules/parquet/test/parquetjs/variant.spec.ts
@@ -155,6 +155,31 @@ describe('Parquet VARIANT binary encoding', () => {
     expect(rows).toEqual([{event: 'typed result'}]);
   });
 
+  test('preserves object-shaped typed_value fields ending in _value', () => {
+    const schema = new ParquetSchema({
+      event: {
+        optional: true,
+        logicalType: {type: 'VARIANT', specificationVersion: 1},
+        fields: {
+          typed_value: {fields: {price_value: {type: 'INT32'}}}
+        }
+      }
+    });
+    const rows = materializeRows(schema, {
+      rowCount: 1,
+      columnData: {
+        'event,typed_value,price_value': {
+          count: 1,
+          dlevels: [1],
+          rlevels: [0],
+          values: [10],
+          pageHeaders: []
+        }
+      }
+    });
+    expect(rows).toEqual([{event: {price_value: 10}}]);
+  });
+
   test('marks Arrow Variant storage with its Parquet specification version', () => {
     const schema = new ParquetSchema({
       event: {

--- a/modules/parquet/test/parquetjs/variant.spec.ts
+++ b/modules/parquet/test/parquetjs/variant.spec.ts
@@ -7,6 +7,7 @@ import {describe, expect, test} from 'vitest';
 import {decodeVariant} from '../../src/parquetjs/schema/variant';
 import {ParquetSchema} from '../../src/parquetjs/schema/schema';
 import {materializeRows} from '../../src/parquetjs/schema/shred';
+import {convertParquetSchema} from '../../src/lib/arrow/convert-schema-from-parquet';
 
 function createMetadata(dictionary: string[]): Uint8Array {
   const dictionaryBytes = new TextEncoder().encode(dictionary.join(''));
@@ -127,5 +128,44 @@ describe('Parquet VARIANT binary encoding', () => {
     const rows = materializeRows(schema, {rowCount: 1, columnData: {}});
     expect(rows).toEqual([{}]);
     expect(Object.prototype.hasOwnProperty.call(rows[0], 'event')).toBe(false);
+  });
+
+  test('materializes a shredded typed_value Variant child', () => {
+    const schema = new ParquetSchema({
+      event: {
+        optional: true,
+        logicalType: {type: 'VARIANT', specificationVersion: 1},
+        fields: {
+          typed_value: {fields: {string_value: {type: 'UTF8'}}}
+        }
+      }
+    });
+    const rows = materializeRows(schema, {
+      rowCount: 1,
+      columnData: {
+        'event,typed_value,string_value': {
+          count: 1,
+          dlevels: [1],
+          rlevels: [0],
+          values: [new TextEncoder().encode('typed result')],
+          pageHeaders: []
+        }
+      }
+    });
+    expect(rows).toEqual([{event: 'typed result'}]);
+  });
+
+  test('marks Arrow Variant storage with its Parquet specification version', () => {
+    const schema = new ParquetSchema({
+      event: {
+        logicalType: {type: 'VARIANT', specificationVersion: 1},
+        fields: {typed_value: {type: 'UTF8'}}
+      }
+    });
+    const arrowSchema = convertParquetSchema(schema, null);
+    expect(arrowSchema.fields[0]).toMatchObject({
+      type: {type: 'struct'},
+      metadata: {'parquet.variant.specification_version': '1'}
+    });
   });
 });


### PR DESCRIPTION
## Goals

Extend the TypeScript Parquet implementation toward complete stable-format coverage while preserving conservative scan behavior and keeping each tranche independently reviewable.

## Implementation

1. **Variant values**

   - Reconstruct the one-field shredded `typed_value` union for TypeScript object-row results.
   - Retain the Variant specification version in Arrow-compatible schema metadata.

2. **Page-index safety**

   - Expose logical page-index statistics decoding.
   - Expose an explicit repeated-leaf safety predicate; repeated leaves remain on the complete-column path until repetition-level continuation can be proven safe.

3. **Statistics and ordering metadata**

   - Normalize row-group sorting-column declarations in `ParquetSource` metadata.
   - Update the Parquet feature matrix to distinguish supported metadata from semantic pruning.

4. **Page integrity**

   - Add opt-in CRC-32 page-body verification to `ParquetReader` and `ParquetSource`.
   - Add matching opt-in CRC-32 emission to `ParquetJSWriter`.

## Documentation

- Document checksum options and the updated Variant, page-index, sorting metadata, and integrity support.
- Use neutral SOTA/support language throughout internal documentation.

## Validation

- `yarn build` ✅
- `yarn lint fix` ✅
- `yarn test-audit` ✅ (0 violations)
- `yarn test-node` ✅ (315 passed, 6 skipped)
- Focused headless Parquet and new tests ✅ (46 passed)
- Full headless suite: 2 legacy `ParquetJSLoader` fixture failures in `parquet-loader.spec.ts`; 2,414 passed, 47 skipped.

The branch is based on current `master`.