### PR TITLE
feat(scan): formalize shared table source contract

### DIFF
--- a/docs/developer-guide/common-scan-architecture.md
+++ b/docs/developer-guide/common-scan-architecture.md
@@ -146,7 +146,7 @@ combines metadata discovery with an ordered batch reader:
 ```ts
 type TableScanSource<BatchT, PredicateT extends ColumnarPredicate = ColumnarPredicate> =
   ScanQueryMetadataProvider & {
-    read(options?: TableQueryOptions<PredicateT>): AsyncIterable<BatchT>;
+    read(options?: TableQueryOptions<PredicateT> & {signal?: AbortSignal}): AsyncIterable<BatchT>;
   };
 ```
 

--- a/docs/developer-guide/common-scan-architecture.md
+++ b/docs/developer-guide/common-scan-architecture.md
@@ -138,6 +138,24 @@ ranges; DuckDB may compile the whole sequence to one prepared statement; Arrow m
 steps over vectors; luma.gl may lower filter to WGSL and retain indices. Operator fusion is welcome
 as long as the visible result is equivalent.
 
+### The source contract
+
+Format adapters that participate in the table scan architecture implement `TableScanSource`. It
+combines metadata discovery with an ordered batch reader:
+
+```ts
+type TableScanSource<BatchT, PredicateT extends ColumnarPredicate = ColumnarPredicate> =
+  ScanQueryMetadataProvider & {
+    read(options?: TableQueryOptions<PredicateT>): AsyncIterable<BatchT>;
+  };
+```
+
+`getQueryMetadata()` is intentionally cheap and drives the query panel. `read()` is the execution
+boundary: it may prune manifests, row groups, pages, or ranges, but it must preserve the logical
+plan's projection, three-valued predicate semantics, source ordering, and global limit. Parquet is
+the reference implementation: its `ParquetSource` exposes the shared capabilities and explainable
+logical plan while adding row-group, page-index, Bloom-filter, range, and worker details.
+
 ### Package ownership
 
 | Layer | Owning package | Responsibility |

--- a/modules/loader-utils/src/index.ts
+++ b/modules/loader-utils/src/index.ts
@@ -297,6 +297,7 @@ export type {
   ScanQueryMetadata,
   ScanQueryMetadataOptions,
   ScanQueryMetadataProvider,
+  TableScanReadOptions,
   TableScanSource,
   ScanRasterLevel,
   ScanSourceStatistics,

--- a/modules/loader-utils/src/index.ts
+++ b/modules/loader-utils/src/index.ts
@@ -297,6 +297,7 @@ export type {
   ScanQueryMetadata,
   ScanQueryMetadataOptions,
   ScanQueryMetadataProvider,
+  TableScanSource,
   ScanRasterLevel,
   ScanSourceStatistics,
   ScanSpatialMetadata

--- a/modules/loader-utils/src/lib/scan-utils/scan-query-metadata.ts
+++ b/modules/loader-utils/src/lib/scan-utils/scan-query-metadata.ts
@@ -3,7 +3,12 @@
 // Copyright (c) vis.gl contributors
 
 import type {DataType, FieldMetadata, Schema} from '@loaders.gl/schema';
-import type {TableQueryCapabilities, TableQueryOperatorSupport} from './table-query';
+import type {ColumnarPredicate} from './columnar-predicate';
+import type {
+  TableQueryCapabilities,
+  TableQueryOperatorSupport,
+  TableQueryOptions
+} from './table-query';
 
 /** Semantic role used by query editors to choose appropriate controls for a column. */
 export type ScanColumnRole =
@@ -118,6 +123,21 @@ export type ScanQueryMetadataOptions = Readonly<{
 export type ScanQueryMetadataProvider = {
   /** Discovers query-visible columns and capabilities without materializing result rows. */
   getQueryMetadata(options?: ScanQueryMetadataOptions): Promise<ScanQueryMetadata>;
+};
+
+/**
+ * Shared table-scan contract implemented by format-specific executors.
+ *
+ * The metadata method powers source-neutral query controls, while `read()` consumes the same
+ * immutable table-query options and emits ordered batches. Format adapters may extend the options
+ * and batch metadata with source-specific planning details.
+ */
+export type TableScanSource<
+  BatchT = unknown,
+  PredicateT extends ColumnarPredicate = ColumnarPredicate
+> = ScanQueryMetadataProvider & {
+  /** Reads the query result as ordered batches without changing the logical query semantics. */
+  read(options?: TableQueryOptions<PredicateT>): AsyncIterable<BatchT>;
 };
 
 /** Inputs used to derive normalized query metadata from a loaders.gl schema. */

--- a/modules/loader-utils/src/lib/scan-utils/scan-query-metadata.ts
+++ b/modules/loader-utils/src/lib/scan-utils/scan-query-metadata.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import type {DataType, FieldMetadata, Schema} from '@loaders.gl/schema';
-import type {ColumnarPredicate} from './columnar-predicate';
+import type {ColumnarPredicate, ColumnarPredicateProperty} from './columnar-predicate';
 import type {
   TableQueryCapabilities,
   TableQueryOperatorSupport,
@@ -125,6 +125,14 @@ export type ScanQueryMetadataProvider = {
   getQueryMetadata(options?: ScanQueryMetadataOptions): Promise<ScanQueryMetadata>;
 };
 
+/** Query options supplied to a table-scan executor, including cooperative cancellation. */
+export type TableScanReadOptions<
+  PredicateT extends ColumnarPredicate<unknown, ColumnarPredicateProperty> = ColumnarPredicate<
+    unknown,
+    ColumnarPredicateProperty
+  >
+> = TableQueryOptions<PredicateT> & Readonly<{signal?: AbortSignal}>;
+
 /**
  * Shared table-scan contract implemented by format-specific executors.
  *
@@ -134,10 +142,13 @@ export type ScanQueryMetadataProvider = {
  */
 export type TableScanSource<
   BatchT = unknown,
-  PredicateT extends ColumnarPredicate = ColumnarPredicate
+  PredicateT extends ColumnarPredicate<unknown, ColumnarPredicateProperty> = ColumnarPredicate<
+    unknown,
+    ColumnarPredicateProperty
+  >
 > = ScanQueryMetadataProvider & {
   /** Reads the query result as ordered batches without changing the logical query semantics. */
-  read(options?: TableQueryOptions<PredicateT>): AsyncIterable<BatchT>;
+  read(options?: TableScanReadOptions<PredicateT>): AsyncIterable<BatchT>;
 };
 
 /** Inputs used to derive normalized query metadata from a loaders.gl schema. */

--- a/modules/parquet/src/parquet-source-loader.ts
+++ b/modules/parquet/src/parquet-source-loader.ts
@@ -15,7 +15,8 @@ import {
 import type {
   ScanColumnRole,
   ScanQueryMetadata,
-  ScanQueryMetadataOptions
+  ScanQueryMetadataOptions,
+  TableScanSource
 } from '@loaders.gl/loader-utils';
 import type {ArrayType, ArrowTable, Schema} from '@loaders.gl/schema';
 import {convertTable} from '@loaders.gl/schema-utils';
@@ -229,7 +230,10 @@ export const ParquetSourceLoaderWithParser = {
 export {ParquetSourceLoaderWithParser as ParquetSourceLoader};
 
 /** Reusable Parquet source that caches footer/schema state and selectively reads byte ranges. */
-export class ParquetSource extends DataSource<string | Blob, ParquetSourceLoaderOptions> {
+export class ParquetSource
+  extends DataSource<string | Blob, ParquetSourceLoaderOptions>
+  implements TableScanSource<ParquetSourceBatch, ParquetPredicate>
+{
   /** Common projection, predicate, limit, streaming, and cancellation capabilities. */
   readonly tableQueryCapabilities = PARQUET_TABLE_QUERY_CAPABILITIES;
   /** Immutable feature support for the current range-backed source implementation. */


### PR DESCRIPTION
## Goals

Formalize the common table-scan source contract and make the Parquet executor the reference implementation for it.

## Changes

- Add `TableScanSource` to `@loaders.gl/loader-utils`.
- Define the contract as metadata discovery plus ordered `read(TableQueryOptions)` batches.
- Make `ParquetSource` implement the shared contract with its existing row-group/page/range executor.
- Document the contract, invariants, capability metadata, and Parquet reference path in the common scan architecture guide.

## Validation

- `yarn lint fix`
- `yarn build`

Browser tests could not be run in the restricted environment because Vitest could not bind its local browser server port.
