### PR TITLE
test: deepen LAS and FlatGeobuf coverage

### DIFF
--- a/modules/flatgeobuf/test/reader-coverage.spec.ts
+++ b/modules/flatgeobuf/test/reader-coverage.spec.ts
@@ -1,0 +1,98 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+
+import {FlatGeobufColumnType, FlatGeobufGeometryType} from '../src/lib/flatgeobuf-reader';
+import {getProjection, makeArrowSchema} from '../src/lib/parse-flatgeobuf';
+
+const COLUMN_TYPES = [
+  ['byte', FlatGeobufColumnType.Byte, 'int8'],
+  ['ubyte', FlatGeobufColumnType.UByte, 'uint8'],
+  ['bool', FlatGeobufColumnType.Bool, 'bool'],
+  ['short', FlatGeobufColumnType.Short, 'int16'],
+  ['ushort', FlatGeobufColumnType.UShort, 'uint16'],
+  ['int', FlatGeobufColumnType.Int, 'int32'],
+  ['uint', FlatGeobufColumnType.UInt, 'uint32'],
+  ['long', FlatGeobufColumnType.Long, 'int64'],
+  ['ulong', FlatGeobufColumnType.ULong, 'uint64'],
+  ['float', FlatGeobufColumnType.Float, 'float32'],
+  ['double', FlatGeobufColumnType.Double, 'float64'],
+  ['string', FlatGeobufColumnType.String, 'utf8'],
+  ['json', FlatGeobufColumnType.Json, 'utf8'],
+  ['datetime', FlatGeobufColumnType.DateTime, 'date-millisecond'],
+  ['binary', FlatGeobufColumnType.Binary, 'binary']
+] as const;
+
+describe('FlatGeobuf reader metadata branches', () => {
+  test.each(COLUMN_TYPES)('maps %s column type to Arrow', (_name, type, expectedType) => {
+    const schema = makeArrowSchema({
+      columns: [
+        {
+          name: 'value',
+          type,
+          width: -1,
+          precision: -1,
+          scale: -1,
+          nullable: true,
+          unique: false,
+          primaryKey: false
+        }
+      ],
+      geometryType: FlatGeobufGeometryType.Point,
+      hasZ: false,
+      indexNodeSize: 16,
+      featuresCount: 0
+    });
+
+    expect(schema.fields[0].type).toBe(expectedType);
+  });
+
+  test('uses null for unknown column types and preserves Z metadata', () => {
+    const schema = makeArrowSchema({
+      columns: [
+        {
+          name: 'unknown',
+          type: 99,
+          width: 10,
+          precision: 2,
+          scale: 1,
+          nullable: false,
+          unique: true,
+          primaryKey: true
+        }
+      ],
+      geometryType: FlatGeobufGeometryType.LineString,
+      hasZ: true,
+      indexNodeSize: 4,
+      featuresCount: 12,
+      envelope: new Float64Array([1, 2, 3, 4]),
+      title: 'title',
+      description: 'description',
+      metadata: 'metadata'
+    });
+
+    expect(schema.fields[0].type).toBe('null');
+    expect(schema.fields[0].metadata).toMatchObject({
+      width: '10',
+      precision: '2',
+      scale: '1',
+      unique: 'true',
+      primary_key: 'true'
+    });
+    expect(schema.metadata).toMatchObject({
+      title: 'title',
+      description: 'description',
+      featureCount: '12',
+      bounds: '1,2,3,4'
+    });
+    expect(schema.fields[1].metadata?.['ARROW:extension:name']).toBe('geoarrow.linestring');
+  });
+
+  test('returns no projection unless requested and handles invalid CRS definitions', () => {
+    expect(getProjection({}, false)).toBeUndefined();
+    expect(getProjection({crs: {}}, true)).toBeUndefined();
+    expect(getProjection({crs: {wkt: 'not a CRS'}}, true)).toBeUndefined();
+  });
+});

--- a/modules/las/test/get-las-schema.spec.ts
+++ b/modules/las/test/get-las-schema.spec.ts
@@ -1,0 +1,63 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+
+import {getLASSchema, makeMetadataFromLasHeader} from '../src/lib/get-las-schema';
+
+const LAS_HEADER = {
+  pointsOffset: 227,
+  pointsFormatId: 3,
+  pointsStructSize: 34,
+  pointsCount: 2,
+  scale: [0.01, 0.01, 0.01],
+  offset: [100, 200, 300],
+  totalToRead: 2,
+  totalRead: 2,
+  maxs: [10, 20, 30],
+  mins: [1, 2, 3],
+  versionAsString: '1.2',
+  isCompressed: false
+} as any;
+
+test('makeMetadataFromLasHeader includes optional LAS metadata', () => {
+  const metadata = makeMetadataFromLasHeader(LAS_HEADER);
+
+  expect(metadata).toMatchObject({
+    las_pointsOffset: '227',
+    las_pointsFormatId: '3',
+    las_pointsStructSize: '34',
+    las_pointsCount: '2',
+    las_scale: '[0.01,0.01,0.01]',
+    las_offset: '[100,200,300]',
+    las_maxs: '[10,20,30]',
+    las_mins: '[1,2,3]',
+    las_totalToRead: '2',
+    las_versionAsString: '1.2',
+    las_isCompressed: 'false'
+  });
+});
+
+test('makeMetadataFromLasHeader omits absent optional values', () => {
+  const metadata = makeMetadataFromLasHeader({
+    ...LAS_HEADER,
+    maxs: undefined,
+    mins: undefined,
+    versionAsString: undefined,
+    isCompressed: undefined
+  });
+
+  expect(metadata.las_maxs).toBeUndefined();
+  expect(metadata.las_mins).toBeUndefined();
+  expect(metadata.las_versionAsString).toBeUndefined();
+  expect(metadata.las_isCompressed).toBeUndefined();
+});
+
+test('getLASSchema carries LAS metadata into the mesh schema', () => {
+  const attributes = {POSITION: {value: new Float32Array([0, 1, 2]), size: 3}};
+  const schema = getLASSchema(LAS_HEADER, attributes);
+
+  expect(schema.metadata?.las_pointsCount).toBe('2');
+  expect(schema.fields[0].name).toBe('POSITION');
+});


### PR DESCRIPTION
Goals of this PR:
- Move coverage materially in the low-coverage LAS and FlatGeobuf modules.
- Exercise reusable binary/schema branches with compact deterministic tests.

Changes:
- Add FlatGeobuf metadata coverage for every column-to-Arrow type mapping, unknown-type fallback, geometry Z metadata, schema metadata, and CRS projection fallbacks.
- Add LAS schema metadata coverage for all optional header fields, omission behavior, and propagation into the generated schema.
- Keep the tranche focused on branch-heavy reusable helpers without adding large fixtures or network dependencies.

Validation:
- Focused Chromium suites: 2 files, 20 tests passed.
- `yarn test-audit`: 540 files, 0 Tape, 0 violations.
- `yarn lint fix` and `git diff --check` clean.

Note: this fresh worktree does not have the repository's hook dependencies, so the commit used `--no-verify`; validation was run directly in the worktree.