### PR TITLE
feat(scan): add catalog fragment discovery

### DIFF
--- a/docs/developer-guide/common-scan-architecture.md
+++ b/docs/developer-guide/common-scan-architecture.md
@@ -85,6 +85,29 @@ The logical query does not prescribe whether a backend materializes rows, return
 retains selection indices. It prescribes which rows and columns are visible to the caller and in
 which source order they are selected.
 
+### Catalog fragments
+
+Catalog-backed sources may additionally implement `ScanFragmentProvider`. Its
+`getScanFragments()` method returns immutable, format-neutral descriptors after cheap catalog
+pruning and before opening Parquet pages:
+
+```ts
+type ScanFragment = {
+  id: string;
+  uri?: string;
+  partitionValues?: Record<string, unknown>;
+  byteLength?: number | bigint;
+  rowCount?: number | bigint;
+  metadata?: Record<string, unknown>;
+};
+```
+
+`ParquetDatasetSource` exposes descriptor-selected files through this contract. `IcebergTableSource`
+uses the same shape for snapshot-selected data files and preserves snapshot, manifest, partition,
+schema, and column-bound metadata. The fragment layer is deliberately separate from Parquet row
+groups: catalog planning chooses files, while the Parquet executor continues to choose row groups,
+pages, and byte ranges.
+
 ## The portable logical query
 
 The foundational types live in `@loaders.gl/loader-utils`, below every storage, SQL, and Arrow

--- a/modules/loader-utils/src/index.ts
+++ b/modules/loader-utils/src/index.ts
@@ -288,6 +288,7 @@ export {
 } from './lib/scan-utils/table-query';
 export {explainTableQuery} from './lib/scan-utils/table-query-explain';
 export type {ScanExecutorOptions, ScanTask} from './lib/scan-utils/scan-executor';
+export type {ScanFragment, ScanFragmentProvider} from './lib/scan-utils/scan-fragments';
 export type {
   CreateScanQueryMetadataOptions,
   ScanBounds,

--- a/modules/loader-utils/src/lib/scan-utils/scan-fragments.ts
+++ b/modules/loader-utils/src/lib/scan-utils/scan-fragments.ts
@@ -1,0 +1,33 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {TableScanReadOptions} from './scan-query-metadata';
+import type {ColumnarPredicate, ColumnarPredicateProperty} from './columnar-predicate';
+
+/** A catalog-independent fragment selected before format-specific decoding. */
+export type ScanFragment = Readonly<{
+  /** Stable identifier for the fragment or data file. */
+  id: string;
+  /** URI or opaque source handle used by the physical executor. */
+  uri?: string;
+  /** Partition values available for early query pruning. */
+  partitionValues?: Readonly<Record<string, unknown>>;
+  /** Approximate physical size, when supplied by the catalog. */
+  byteLength?: number | bigint;
+  /** Approximate row count, when supplied by the catalog. */
+  rowCount?: number | bigint;
+  /** Format- or catalog-specific metadata retained for explain/provenance output. */
+  metadata?: Readonly<Record<string, unknown>>;
+}>;
+
+/** Provider contract for catalog or manifest layers that select physical scan fragments. */
+export type ScanFragmentProvider<
+  PredicateT extends ColumnarPredicate<unknown, ColumnarPredicateProperty> = ColumnarPredicate<
+    unknown,
+    ColumnarPredicateProperty
+  >
+> = {
+  /** Discovers fragments without opening their data pages. */
+  getScanFragments(options?: TableScanReadOptions<PredicateT>): Promise<readonly ScanFragment[]>;
+};

--- a/modules/parquet/src/iceberg-table-source.ts
+++ b/modules/parquet/src/iceberg-table-source.ts
@@ -246,25 +246,36 @@ export class IcebergTableSource
   /** Discovers snapshot-selected data files as catalog-independent scan fragments. */
   async getScanFragments(options: IcebergScanOptions = {}): Promise<readonly ScanFragment[]> {
     this.assertOpen();
+    const metadata = await this.getMetadata(options.signal);
     const plan = await this.getScanPlan(options.signal, options.snapshotId, options.snapshotRef);
     return Object.freeze(
-      plan.dataFiles.map(file =>
-        Object.freeze({
-          id: file.data,
-          uri: file.data,
-          partitionValues: file.partition,
-          byteLength: file.fileSize,
-          rowCount: file.recordCount,
-          metadata: {
-            snapshotId: file.snapshotId,
-            manifestPath: file.manifestPath,
-            partitionSpecId: file.partitionSpecId,
-            schemaId: file.schemaId,
-            lowerBounds: file.lowerBounds,
-            upperBounds: file.upperBounds
-          }
-        })
-      )
+      plan.dataFiles
+        .filter(
+          file =>
+            canMatchIcebergPredicate(file, options.predicate, metadata) &&
+            canMatchIcebergSpatialFilter(file, options.spatialFilter, metadata) &&
+            matchesIcebergPartitions(
+              getIcebergPartitions(file.partition, file.partitionSpecId, file.schemaId, metadata),
+              options.partitions
+            )
+        )
+        .map(file =>
+          Object.freeze({
+            id: file.data,
+            uri: file.data,
+            partitionValues: file.partition,
+            byteLength: file.fileSize,
+            rowCount: file.recordCount,
+            metadata: {
+              snapshotId: file.snapshotId,
+              manifestPath: file.manifestPath,
+              partitionSpecId: file.partitionSpecId,
+              schemaId: file.schemaId,
+              lowerBounds: file.lowerBounds,
+              upperBounds: file.upperBounds
+            }
+          })
+        )
     );
   }
 
@@ -815,6 +826,21 @@ function getIcebergPartitions(
     if (value !== undefined) result[schemaField.name] = value;
   }
   return result;
+}
+
+/** Applies dataset-style exact partition constraints to an Iceberg partition map. */
+function matchesIcebergPartitions(
+  partitions: Readonly<Record<string, ParquetDatasetPartitionValue>> | undefined,
+  query: IcebergScanOptions['partitions']
+): boolean {
+  if (!query) return true;
+  for (const [key, requested] of Object.entries(query)) {
+    const actual = partitions?.[key];
+    if (actual === undefined) continue;
+    const accepted = Array.isArray(requested) ? requested : [requested];
+    if (!accepted.includes(actual)) return false;
+  }
+  return true;
 }
 
 /** Normalizes Avro map values, which may decode as JavaScript Maps or plain objects. */

--- a/modules/parquet/src/iceberg-table-source.ts
+++ b/modules/parquet/src/iceberg-table-source.ts
@@ -8,6 +8,8 @@ import {
   DataSource as BaseDataSource,
   validateTableQueryLimit,
   type ScanColumnRole,
+  type ScanFragment,
+  type ScanFragmentProvider,
   type ScanQueryMetadata,
   type ScanQueryMetadataOptions
 } from '@loaders.gl/loader-utils';
@@ -79,7 +81,10 @@ export type IcebergScanOptions = ParquetDatasetReadOptions & {
  * The source owns Iceberg metadata and manifest discovery, then delegates selected data files to
  * `ParquetDatasetSource` for projection, filtering, range access, workers, and Arrow materialization.
  */
-export class IcebergTableSource extends BaseDataSource<string, IcebergSourceOptions> {
+export class IcebergTableSource
+  extends BaseDataSource<string, IcebergSourceOptions>
+  implements ScanFragmentProvider<ParquetPredicate>
+{
   /** Common query capabilities after Iceberg snapshot and delete processing. */
   readonly tableQueryCapabilities = PARQUET_TABLE_QUERY_CAPABILITIES;
   private metadataPromise: Promise<IcebergTableMetadata> | null = null;
@@ -236,6 +241,31 @@ export class IcebergTableSource extends BaseDataSource<string, IcebergSourceOpti
     snapshotRef?: string
   ): Promise<readonly IcebergDeleteFile[]> {
     return (await this.getScanPlan(signal, snapshotId, snapshotRef)).deleteFiles;
+  }
+
+  /** Discovers snapshot-selected data files as catalog-independent scan fragments. */
+  async getScanFragments(options: IcebergScanOptions = {}): Promise<readonly ScanFragment[]> {
+    this.assertOpen();
+    const plan = await this.getScanPlan(options.signal, options.snapshotId, options.snapshotRef);
+    return Object.freeze(
+      plan.dataFiles.map(file =>
+        Object.freeze({
+          id: file.data,
+          uri: file.data,
+          partitionValues: file.partition,
+          byteLength: file.fileSize,
+          rowCount: file.recordCount,
+          metadata: {
+            snapshotId: file.snapshotId,
+            manifestPath: file.manifestPath,
+            partitionSpecId: file.partitionSpecId,
+            schemaId: file.schemaId,
+            lowerBounds: file.lowerBounds,
+            upperBounds: file.upperBounds
+          }
+        })
+      )
+    );
   }
 
   /** Reads the current snapshot as Arrow batches through the existing Parquet dataset source. */

--- a/modules/parquet/src/parquet-dataset-source.ts
+++ b/modules/parquet/src/parquet-dataset-source.ts
@@ -151,6 +151,11 @@ export class ParquetDatasetSource implements ScanFragmentProvider<ParquetPredica
     const selectedFiles = this.getSelectedFiles(options);
     for await (const indexedFile of selectedFiles) {
       const file = indexedFile.file;
+      if (typeof file.data !== 'string' && !file.id) {
+        throw new Error(
+          'Parquet dataset Blob fragments require an explicit stable id for fragment discovery'
+        );
+      }
       fragments.push(
         Object.freeze({
           id: getDatasetFileId(file, indexedFile.index),

--- a/modules/parquet/src/parquet-dataset-source.ts
+++ b/modules/parquet/src/parquet-dataset-source.ts
@@ -7,6 +7,8 @@ import {
   explainTableQuery,
   validateTableQueryLimit,
   type CoreAPI,
+  type ScanFragment,
+  type ScanFragmentProvider,
   type ScanTask
 } from '@loaders.gl/loader-utils';
 import type {Schema} from '@loaders.gl/schema';
@@ -77,7 +79,7 @@ type ParquetDatasetDiscoverySummary = {
  * The source accepts static descriptors or a lazy provider, allowing STAC and other catalogs to be
  * injected without coupling `@loaders.gl/parquet` to a catalog protocol.
  */
-export class ParquetDatasetSource {
+export class ParquetDatasetSource implements ScanFragmentProvider<ParquetPredicate> {
   /** Common projection, predicate, limit, streaming, and cancellation capabilities. */
   readonly tableQueryCapabilities = PARQUET_TABLE_QUERY_CAPABILITIES;
   /** Static descriptors or lazy catalog-backed file provider. */
@@ -138,6 +140,27 @@ export class ParquetDatasetSource {
       ...this.telemetry,
       parquet: Object.freeze({...this.telemetry.parquet})
     });
+  }
+
+  /** Discovers catalog-independent fragments after applying descriptor-level pruning. */
+  async getScanFragments(
+    options: ParquetDatasetReadOptions = {}
+  ): Promise<readonly ScanFragment[]> {
+    this.assertOpen();
+    const fragments: ScanFragment[] = [];
+    const selectedFiles = this.getSelectedFiles(options);
+    for await (const indexedFile of selectedFiles) {
+      const file = indexedFile.file;
+      fragments.push(
+        Object.freeze({
+          id: getDatasetFileId(file, indexedFile.index),
+          uri: typeof file.data === 'string' ? file.data : undefined,
+          partitionValues: file.partitions,
+          metadata: file.metadata
+        })
+      );
+    }
+    return Object.freeze(fragments);
   }
 
   /** Plans descriptor discovery and every retained file's Parquet physical scan. */

--- a/modules/parquet/test/parquet-dataset-source.spec.ts
+++ b/modules/parquet/test/parquet-dataset-source.spec.ts
@@ -404,6 +404,16 @@ describe('ParquetDatasetSource', () => {
     await source.close();
     await expect(source.getSchema()).rejects.toThrow('ParquetDatasetSource is closed');
   });
+
+  test('requires stable IDs when discovering Blob-backed fragments', async () => {
+    const source = new ParquetDatasetSource([{data: westernFile}]);
+    await expect(source.getScanFragments()).rejects.toThrow('explicit stable id');
+
+    const identifiedSource = new ParquetDatasetSource([{data: westernFile, id: 'western'}]);
+    await expect(identifiedSource.getScanFragments()).resolves.toMatchObject([
+      {id: 'western'}
+    ]);
+  });
 });
 
 /** Encodes a small deterministic Parquet file for multi-file source tests. */

--- a/website/src/components/home/concepts.jsx
+++ b/website/src/components/home/concepts.jsx
@@ -780,6 +780,7 @@ export default function Concepts() {
           <GuideLink to="/docs/developer-guide/using-loaders">Using loaders</GuideLink>
           <GuideLink to="/docs/developer-guide/using-writers">Using writers</GuideLink>
           <GuideLink to="/docs/developer-guide/using-sources">Using sources</GuideLink>
+          <GuideLink to="/docs/developer-guide/common-scan-architecture">Using scans</GuideLink>
           <GuideLink to="/docs/developer-guide/composite-loaders">Composite loaders</GuideLink>
         </LinkBar>
 


### PR DESCRIPTION
## Goals

Add the catalog-aware fragment layer for the common scan architecture and expose the scan experience in the documentation navigation.

## Changes

- Add `ScanFragment` and `ScanFragmentProvider` to `@loaders.gl/loader-utils`.
- Let `ParquetDatasetSource` expose descriptor-pruned Parquet files as immutable scan fragments.
- Let `IcebergTableSource` expose snapshot-selected data files with snapshot, manifest, partition, schema, bounds, size, and row-count metadata.
- Keep catalog fragment selection separate from Parquet row-group/page/range execution.
- Document the fragment contract and add a “Using scans” tab to the homepage concept navigation.

## Validation

- `yarn lint fix`
- `yarn build` (started successfully; final output was unavailable in the restricted runner)
