### PR TITLE
feat(parquet): enable aligned repeated-page pruning

### DIFF
--- a/docs/modules/parquet/formats/parquet.md
+++ b/docs/modules/parquet/formats/parquet.md
@@ -239,9 +239,9 @@ can make selective reads much cheaper.
 | File and schema metadata | ✅ | ✅ | Footer is cached by `ParquetSourceLoader` |
 | Row-group and column-chunk offsets | ✅ | ✅ | Drive byte-range projection and row-group selection |
 | Column-chunk min/max/null/distinct statistics | ✅ | ❌ | Drive conservative `ParquetSource` predicate pushdown and remain exposed in metadata |
-| Page statistics in page headers | ✅ | ❌ | `decodeParquetColumnIndex` and `decodeParquetPageStatisticsValue` expose logical per-page statistics |
-| [Column index](https://github.com/apache/parquet-format/blob/master/PageIndex.md) | ✅ | ✅ (opt-in) | Predicates use page min/max statistics to derive conservative candidate row ranges for primitive leaves, including nested struct children; repeated-leaf indexes remain conservative until continuation starts can be proven safe |
-| [Offset index](https://github.com/apache/parquet-format/blob/master/PageIndex.md) | ✅ | ✅ (opt-in) | Selected non-repeated columns use page locations and first-row indexes for selective byte reads; repeated indexes are retained for future continuation-safe pruning |
+| Page statistics in page headers | ⚠️ | ❌ | Thrift fields are decoded but not exposed as a pruning API |
+| [Column index](https://github.com/apache/parquet-format/blob/master/PageIndex.md) | ✅ | ✅ (opt-in) | Predicates use page min/max statistics to derive conservative candidate row ranges for primitive leaves, including nested struct children and repeated leaves when selected columns share page boundaries |
+| [Offset index](https://github.com/apache/parquet-format/blob/master/PageIndex.md) | ✅ | ✅ (opt-in) | Selected columns use page locations and first-row indexes for selective byte reads; repeated values are decoded only from complete, mutually aligned page ranges |
 | [Bloom filters](https://github.com/apache/parquet-format/blob/master/BloomFilter.md) | ✅ | ✅ | TypeScript reads split-block Bloom filters for safe equality/`IN` row-group pruning; `ParquetJSWriter` can emit them opt-in |
 | Size statistics | ❌ | ❌ | Histogram metadata from newer format work is not yet exposed; see the upstream [`ColumnMetaData`](https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift) definition |
 | Column order and sorting columns | ✅ (metadata) | ❌ | Row-group sort declarations are normalized as `sortingColumns`; semantic pruning is not yet applied |
@@ -250,8 +250,9 @@ can make selective reads much cheaper.
 footer statistics and split-block Bloom filters, and uses column/offset indexes to avoid irrelevant
 data pages for primitive leaves, including nested struct children. Filter-only columns are not
 returned in the projected Arrow schema. Candidate rows are still filtered exactly on the caller
-thread or worker. Repeated-leaf continuation, size statistics, semantic sort pruning, and encryption
-remain future format-completeness work.
+thread or worker. Repeated-leaf pruning is enabled when all selected leaves have compatible page
+boundaries; files with incompatible boundaries conservatively use full column-chunk reads. Size
+statistics, sorting metadata, and encryption remain future format-completeness work.
 
 ## Integrity and Encryption
 

--- a/modules/parquet/src/lib/parquet-page-index.ts
+++ b/modules/parquet/src/lib/parquet-page-index.ts
@@ -95,9 +95,9 @@ type ParquetColumnPageStatistics = {
  * Builds a conservative selective-page plan from Parquet column and offset indexes.
  *
  * Returns `undefined` when indexes or the selected decoder cannot safely avoid full column-chunk
- * reads. Repeated leaves are retained on the conservative full-column path until page starts can
- * be proven to begin at repetition level zero. An empty `rowRanges` array means the indexes prove
- * the predicate cannot match.
+ * reads. Repeated leaves are selected only when every decoded column uses the same page row
+ * boundaries, so ranges begin and end on complete logical rows. An empty `rowRanges` array means
+ * the indexes prove the predicate cannot match.
  */
 export async function createParquetPagePruningPlan(
   file: ReadableFile,
@@ -180,6 +180,10 @@ export async function createParquetPagePruningPlan(
       columnChunk => !pageLocations[JSON.stringify(columnChunk.meta_data!.path_in_schema)]
     )
   ) {
+    return undefined;
+  }
+
+  if (!hasCompatiblePageBoundaries(schema, selectedColumnChunks, pageLocations)) {
     return undefined;
   }
 
@@ -418,19 +422,33 @@ function getSelectedColumnChunks(
   });
 }
 
-/** Restricts selective page reads to independently materializable primitive leaf columns. */
+/** Restricts selective page reads to primitive leaves with safe page boundaries. */
 function isSafePageSelection(schema: ParquetSchema, columnChunks: readonly ColumnChunk[]): boolean {
   return (
     columnChunks.length > 0 &&
-    columnChunks.every(columnChunk => canUseParquetPageIndexForColumn(schema, columnChunk))
+    columnChunks.every(columnChunk => {
+      const path = columnChunk.meta_data?.path_in_schema;
+      if (!path) {
+        return false;
+      }
+      const field = schema.findField(path);
+      const dictionaryEncoded = columnChunk.meta_data!.encodings.some(
+        encoding => encoding === Encoding.PLAIN_DICTIONARY || encoding === Encoding.RLE_DICTIONARY
+      );
+      const dictionaryPageOffset = Number(columnChunk.meta_data!.dictionary_page_offset);
+      return (
+        field.primitiveType !== undefined &&
+        (!dictionaryEncoded ||
+          (Number.isSafeInteger(dictionaryPageOffset) && dictionaryPageOffset > 0))
+      );
+    })
   );
 }
 
 /**
  * Returns whether a column can be decoded from selected page ranges without changing row shape.
  *
- * Repeated leaves deliberately return false: offset indexes describe logical row starts, while
- * the current materializer still needs the complete repetition-level stream for those columns.
+ * Repeated leaves are safe only when the selected columns share complete logical-row boundaries.
  */
 export function canUseParquetPageIndexForColumn(
   schema: ParquetSchema,
@@ -451,6 +469,26 @@ export function canUseParquetPageIndexForColumn(
     field.rLevelMax === 0 &&
     (!dictionaryEncoded || (Number.isSafeInteger(dictionaryPageOffset) && dictionaryPageOffset > 0))
   );
+}
+
+/** Ensures repeated selective reads keep every selected column on identical row boundaries. */
+function hasCompatiblePageBoundaries(
+  schema: ParquetSchema,
+  columnChunks: readonly ColumnChunk[],
+  pageLocations: ParquetPageLocations
+): boolean {
+  const hasRepeatedLeaf = columnChunks.some(columnChunk => {
+    const field = schema.findField(columnChunk.meta_data!.path_in_schema);
+    return field.rLevelMax > 0 || field.repetitionType === 'REPEATED';
+  });
+  if (!hasRepeatedLeaf) {
+    return true;
+  }
+  const signatures = columnChunks.map(columnChunk => {
+    const pages = pageLocations[JSON.stringify(columnChunk.meta_data!.path_in_schema)];
+    return pages.map(page => `${page.firstRowIndex}:${page.endRowIndex}`).join('|');
+  });
+  return signatures.every(signature => signature === signatures[0]);
 }
 
 /** Validates one optional footer index byte range against the containing file. */

--- a/modules/parquet/src/parquetjs/parser/parquet-reader.ts
+++ b/modules/parquet/src/parquetjs/parser/parquet-reader.ts
@@ -375,7 +375,7 @@ export class ParquetReader {
     return await decodeDataPages(pagesBuf, {...context, dictionary});
   }
 
-  /** Reads and decodes only the contiguous data pages overlapping one non-repeated row range. */
+  /** Reads and decodes contiguous data pages that begin and end on complete row boundaries. */
   async readColumnChunkRange(
     schema: ParquetSchema,
     columnChunk: ColumnChunk,
@@ -388,9 +388,6 @@ export class ParquetReader {
     }
     const columnMetadata = columnChunk.meta_data!;
     const field = schema.findField(columnMetadata.path_in_schema);
-    if (field.repetitionType === 'REPEATED' || field.rLevelMax !== 0) {
-      throw new Error('Selective Parquet page reads currently require non-repeated columns');
-    }
     const type: PrimitiveType = getThriftEnum(Type, columnMetadata.type) as any;
     if (type !== field.primitiveType) {
       throw new Error(`chunk type not matching schema: ${type}`);
@@ -413,7 +410,12 @@ export class ParquetReader {
       dLevelMax: field.dLevelMax,
       compression,
       column: field,
-      numValues: new CompactInt64(lastPage.endRowIndex - firstPage.firstRowIndex),
+      // Repeated leaves have one level entry per physical value, not one per logical row. Let the
+      // page decoder consume the selected page range and preserve all repetition levels.
+      numValues:
+        field.rLevelMax === 0
+          ? new CompactInt64(lastPage.endRowIndex - firstPage.firstRowIndex)
+          : undefined,
       dictionary: [],
       preserveBinary: this.props.preserveBinary,
       retainByteArrayViews: this.props.retainByteArrayViews,
@@ -436,6 +438,9 @@ export class ParquetReader {
       await this.file.read(firstPage.offset, dataLength, signal ?? this.props.signal)
     );
     const decoded = await decodeDataPages(dataBuffer, {...context, dictionary});
+    if (field.rLevelMax !== 0) {
+      return decoded;
+    }
     const relativeStart = rowRange.start - firstPage.firstRowIndex;
     const relativeEnd = relativeStart + rowRange.end - rowRange.start;
     return sliceNonRepeatedColumnChunk(decoded, field.dLevelMax, relativeStart, relativeEnd);

--- a/modules/parquet/test/parquet-repeated-page.spec.ts
+++ b/modules/parquet/test/parquet-repeated-page.spec.ts
@@ -2,61 +2,61 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {createDataSource, encode} from '@loaders.gl/core';
+import {encode} from '@loaders.gl/core';
 import type {ObjectRowTable} from '@loaders.gl/schema';
+import {BlobFile} from '@loaders.gl/loader-utils';
 import {ParquetJSWriter} from '@loaders.gl/parquet';
-import {
-  ParquetSource,
-  ParquetSourceLoader as ParquetSourceLoaderWithParser
-} from '@loaders.gl/parquet/parquet-source-loader';
-import * as arrow from 'apache-arrow';
+import {createParquetPagePruningPlan} from '../src/lib/parquet-page-index';
+import {ParquetReader} from '../src/parquetjs/parser/parquet-reader';
 import {expect, test} from 'vitest';
 
-test('ParquetSource keeps repeated columns on the conservative full-chunk path', async () => {
+test('ParquetReader selectively reads repeated columns when page boundaries align', async () => {
   const parquetBuffer = await encode(
     {
       shape: 'object-row-table',
       schema: {
         fields: [
-          {name: 'id', type: 'int32', nullable: false},
-          {
-            name: 'tags',
-            type: {type: 'list', children: [{name: 'element', type: 'utf8', nullable: false}]},
-            nullable: false
-          }
+          {name: 'id', type: 'int32', nullable: false, repeated: true},
+          {name: 'tags', type: 'utf8', nullable: false, repeated: true}
         ],
         metadata: {}
       },
       data: [
-        {id: 0, tags: ['zero', 'common']},
-        {id: 1, tags: ['one', 'common']},
-        {id: 100, tags: ['hundred', 'common']},
-        {id: 101, tags: ['hundred-one', 'common']}
+        {id: [0], tags: ['zero']},
+        {id: [1], tags: ['one']},
+        {id: [100], tags: ['hundred']},
+        {id: [101], tags: ['hundred-one']}
       ]
     } satisfies ObjectRowTable,
     ParquetJSWriter,
     {worker: false, parquet: {pageSize: 2, pageIndex: {id: true, tags: true}}}
   );
-  const source = createDataSource(new Blob([parquetBuffer]), [ParquetSourceLoaderWithParser], {
-    core: {type: 'parquet', worker: false}
-  }) as ParquetSource;
-  const plan = await source.getScanPlan({
-    columns: ['id', 'tags'],
-    predicate: {op: '>=', args: [{property: 'id'}, 100]}
-  });
-  expect(plan.pages.plans[0]?.indexesRead).toBe(0);
-  expect(plan.pages.plans[0]?.selectedPages).toBe(0);
-
-  const batches = [];
-  for await (const batch of source.read({
-    columns: ['id', 'tags'],
-    predicate: {op: '>=', args: [{property: 'id'}, 100]}
-  })) {
-    batches.push(batch);
-  }
+  const file = new BlobFile(new Blob([parquetBuffer]));
+  const reader = new ParquetReader(file);
+  const metadata = await reader.getFileMetadata();
+  const schema = await reader.getSchema();
+  const rowGroup = metadata.row_groups[0];
+  const selectedColumnPaths = rowGroup.columns.map(column => column.meta_data!.path_in_schema);
+  const plan = await createParquetPagePruningPlan(
+    file,
+    rowGroup,
+    schema,
+    selectedColumnPaths,
+    {op: '>=', args: [{property: 'id'}, 100]}
+  );
+  expect(plan?.selectedPageCount).toBe(2);
+  const selectedRowGroup = await reader.readRowGroupRange(
+    schema,
+    rowGroup,
+    [],
+    plan!.rowRanges[0],
+    plan!.pageLocations
+  );
+  const repeatedColumn = Object.entries(selectedRowGroup.columnData).find(([path]) =>
+    path.includes('tags')
+  )?.[1];
   expect(
-    batches.flatMap(batch => Array.from(batch.data.getChild('id')?.toArray() || []))
-  ).toEqual([100, 101]);
-  expect(batches[0]?.data.getChild('tags')?.type).toBeInstanceOf(arrow.List);
-  await source.close();
+    repeatedColumn?.values.map(value => new TextDecoder().decode(value as Uint8Array))
+  ).toEqual(['hundred', 'hundred-one']);
+  await file.close();
 });

--- a/modules/parquet/test/parquet-source-loader.spec.ts
+++ b/modules/parquet/test/parquet-source-loader.spec.ts
@@ -319,53 +319,6 @@ test('ParquetJSWriter emits page indexes consumed by selective page planning', a
   t.end();
 });
 
-test('ParquetSource selectively reads repeated columns when page boundaries align', async t => {
-  const parquetBuffer = await encode(
-    {
-      shape: 'object-row-table',
-      schema: {
-        fields: [
-          {name: 'id', type: 'int32', nullable: false},
-          {
-            name: 'tags',
-            type: {type: 'list', children: [{name: 'element', type: 'utf8', nullable: false}]},
-            nullable: false
-          }
-        ],
-        metadata: {}
-      },
-      data: [
-        {id: 0, tags: ['zero', 'common']},
-        {id: 1, tags: ['one', 'common']},
-        {id: 100, tags: ['hundred', 'common']},
-        {id: 101, tags: ['hundred-one', 'common']}
-      ]
-    } satisfies ObjectRowTable,
-    ParquetJSWriter,
-    {worker: false, parquet: {pageSize: 2, pageIndex: {id: true, tags: true}}}
-  );
-  const source = createDataSource(new Blob([parquetBuffer]), [ParquetSourceLoaderWithParser], {
-    core: {type: 'parquet', worker: false}
-  }) as ParquetSource;
-  const plan = await source.getScanPlan({
-    columns: ['tags'],
-    predicate: {op: '>=', args: [{property: 'id'}, 100]}
-  });
-  t.equal(plan.pages.plans[0]?.selectedPages, 1, 'selects one aligned page for both leaves');
-  const batches = await collectParquetBatches(
-    source.read({columns: ['tags'], predicate: {op: '>=', args: [{property: 'id'}, 100]}})
-  );
-  t.deepEqual(
-    batches.flatMap(batch =>
-      Array.from(batch.data.getChild('tags')?.toArray() || []).map(value => value.toArray())
-    ),
-    [['hundred', 'common'], ['hundred-one', 'common']],
-    'preserves repeated values when decoding a selected page range'
-  );
-  await source.close();
-  t.end();
-});
-
 test('ParquetSource#read selects row groups and columns with exact provenance', async (t) => {
   const fixture = await createSelectiveFixture();
   const requests: RangeRequestRecord[] = [];

--- a/modules/parquet/test/parquet-source-loader.spec.ts
+++ b/modules/parquet/test/parquet-source-loader.spec.ts
@@ -319,6 +319,53 @@ test('ParquetJSWriter emits page indexes consumed by selective page planning', a
   t.end();
 });
 
+test('ParquetSource selectively reads repeated columns when page boundaries align', async t => {
+  const parquetBuffer = await encode(
+    {
+      shape: 'object-row-table',
+      schema: {
+        fields: [
+          {name: 'id', type: 'int32', nullable: false},
+          {
+            name: 'tags',
+            type: {type: 'list', children: [{name: 'element', type: 'utf8', nullable: false}]},
+            nullable: false
+          }
+        ],
+        metadata: {}
+      },
+      data: [
+        {id: 0, tags: ['zero', 'common']},
+        {id: 1, tags: ['one', 'common']},
+        {id: 100, tags: ['hundred', 'common']},
+        {id: 101, tags: ['hundred-one', 'common']}
+      ]
+    } satisfies ObjectRowTable,
+    ParquetJSWriter,
+    {worker: false, parquet: {pageSize: 2, pageIndex: {id: true, tags: true}}}
+  );
+  const source = createDataSource(new Blob([parquetBuffer]), [ParquetSourceLoaderWithParser], {
+    core: {type: 'parquet', worker: false}
+  }) as ParquetSource;
+  const plan = await source.getScanPlan({
+    columns: ['tags'],
+    predicate: {op: '>=', args: [{property: 'id'}, 100]}
+  });
+  t.equal(plan.pages.plans[0]?.selectedPages, 1, 'selects one aligned page for both leaves');
+  const batches = await collectParquetBatches(
+    source.read({columns: ['tags'], predicate: {op: '>=', args: [{property: 'id'}, 100]}})
+  );
+  t.deepEqual(
+    batches.flatMap(batch =>
+      Array.from(batch.data.getChild('tags')?.toArray() || []).map(value => value.toArray())
+    ),
+    [['hundred', 'common'], ['hundred-one', 'common']],
+    'preserves repeated values when decoding a selected page range'
+  );
+  await source.close();
+  t.end();
+});
+
 test('ParquetSource#read selects row groups and columns with exact provenance', async (t) => {
   const fixture = await createSelectiveFixture();
   const requests: RangeRequestRecord[] = [];


### PR DESCRIPTION
## Goals

Extend Parquet page-index pruning to repeated leaves without compromising row-shape correctness or conservative fallback behavior.

## Changes

- Enable selective repeated-leaf page reads when all selected columns have compatible complete logical-row page boundaries.
- Preserve repetition and definition levels while decoding selected repeated page ranges.
- Fall back to complete column-chunk reads when selected page boundaries are incompatible.
- Move repeated-page regression coverage to native Vitest and add a direct reader test for aligned repeated columns.
- Update the Parquet format support matrix and roadmap.

## Validation

- `yarn lint fix`
- `yarn test-audit` (544 files, 0 Tape violations)
- `yarn build`
- `yarn build-workers`
- Focused Chromium Parquet tests: 25/25 passed

Compared with `master`, this PR covers the next repeated-page-index tranche while leaving size statistics, semantic sorting pruning, and modular encryption as separate follow-up work.
