### PR TITLE
feat(las): complete streaming, waveform writer, and CRS tranches

### DIFF
--- a/docs/modules/las/api-reference/las-writer.md
+++ b/docs/modules/las/api-reference/las-writer.md
@@ -33,9 +33,9 @@ const arrayBuffer = await encode(pointCloud, LASWriter, {
 
 `LASWriter` accepts Mesh Arrow tables and legacy Mesh objects. Arrow table input is normalized to the writer's Mesh representation before LAS binary data is encoded.
 
-The writer requires a `POSITION` attribute. It writes `COLOR_0`, `intensity`, and `classification` attributes when present. It can select LAS versions 1.0-1.4 and PDRF 0-8 for uncompressed output, but fields without a corresponding input attribute, including GPS time, waveform references, NIR, return flags, and scanner metadata, are zero-filled. Current uncompressed round-trip coverage targets default LAS 1.2 and LAS 1.4/PDRF 7; full conformance for every selectable version/PDRF combination is not claimed.
+The writer requires a `POSITION` attribute. It can select LAS versions 1.0-1.4 and PDRF 0-10. Represented input attributes include color, intensity, classification, GPS time, NIR, return and scanner metadata, waveform packet references, and configured Extra Bytes. Fields without a corresponding input attribute are zero-filled.
 
-LAZ output uses LAS 1.4, PDRF 6-8, LASzip layered compressor 3, arithmetic coder 0, and item version 3. Fixed-size chunk tables are the default; variable-size tables can be enabled when needed. The output is readable by the TypeScript loader and established WASM decoders. COPC output is provided separately by [`COPCWriter`](/docs/modules/copc/api-reference/copc-writer) to keep the LAS and COPC packages acyclic.
+LAZ output supports PDRF 0-10. Legacy formats use LASzip compressor 2 and item version 2; modern formats use layered compressor 3 and item version 3. PDRF 4/5 and 9/10 preserve waveform packet references; waveform sample payload storage remains outside the writer. Fixed-size chunk tables are the default, and variable-size tables can be enabled when needed. The output is readable by the TypeScript loader. Interoperability is covered by independent LASzip fixtures and by bundled WASM comparisons for the item sets those variants support. COPC output is provided separately by [`COPCWriter`](/docs/modules/copc/api-reference/copc-writer) to keep the LAS and COPC packages acyclic.
 
 ## Options
 
@@ -43,7 +43,7 @@ LAZ output uses LAS 1.4, PDRF 6-8, LASzip layered compressor 3, arithmetic coder
 | --- | --- | --- | --- |
 | `las.format` | LAS or LAZ | `'las'` | Output container. Both LAS and LAZ are implemented. Use `COPCWriter` for COPC output. |
 | `las.version` | `'1.0'` through `'1.4'` | `'1.2'` or `'1.4'` | LAS header version. The default is 1.4 for modern PDRFs and 1.2 otherwise. |
-| `las.pointDataRecordFormat` | `0` through `8` | Derived | Point record layout. The default depends on version and whether `COLOR_0` is present. |
+| `las.pointDataRecordFormat` | `0` through `10` | Derived | Point record layout. The default depends on version and whether `COLOR_0` is present. |
 | `las.scale` | `[number, number, number]` | `[0.001, 0.001, 0.001]` | Coordinate scale factors used to quantize positions into LAS integer coordinates. |
 | `las.offset` | `[number, number, number]` | Mesh minimum position | Coordinate offsets used to quantize positions into LAS integer coordinates. |
 | `las.colorDepth` | `number \| string` | - | Declares the source color component depth. |
@@ -52,4 +52,6 @@ LAZ output uses LAS 1.4, PDRF 6-8, LASzip layered compressor 3, arithmetic coder
 
 Use `las.extraBytes` to append one- or three-component typed mesh attributes to each point record and emit an Extra Bytes VLR. Each entry accepts an `attribute` name and optional `name` and `description`; the writer infers the LAS data type from the typed array and attribute size. LAS Extra Bytes has no four-component data type, so four-component attributes are rejected.
 
-For modern PDRFs, the writer also maps optional point attributes named `gpsTime`, `scanAngle`, `userData`, `pointSourceId`, `returnNumber`, `numberOfReturns`, `scannerChannel`, `scanDirectionFlag`, `edgeOfFlightLine`, `synthetic`, `keyPoint`, `withheld`, and `overlap`. For PDRF 8, the optional `nir` attribute is written as a 16-bit near-infrared channel. Missing fields are zero-filled.
+For modern PDRFs, the writer also maps optional point attributes named `gpsTime`, `scanAngle`, `userData`, `pointSourceId`, `returnNumber`, `numberOfReturns`, `scannerChannel`, `scanDirectionFlag`, `edgeOfFlightLine`, `synthetic`, `keyPoint`, `withheld`, and `overlap`. For PDRF 8 and 10, the optional `nir` attribute is written as a 16-bit near-infrared channel. Missing fields are zero-filled.
+
+Waveform PDRFs 4, 5, 9, and 10 map `wavePacketDescriptorIndex`, `wavePacketOffset`, `wavePacketSize`, `wavePacketReturnPoint`, and the three-component `wavePacketVector` attribute into each point's 29-byte packet reference. PDRF 10 also maps `COLOR_0` and `nir`.

--- a/docs/modules/las/formats/las.md
+++ b/docs/modules/las/formats/las.md
@@ -37,8 +37,8 @@ LAS file versions and LASzip codec versions are independent. A claim such as "LA
 | Return flags and scanner channel | Exposed as typed Arrow columns for supported point formats. |
 | Waveform packet fields | PDRF 4/5/9/10 packet references are exposed as the optional fixed-width `WAVEFORM` Arrow column. Waveform sample payload handling is not implemented. |
 | Extra bytes | Extra Bytes VLR descriptors are exposed as typed metadata; the raw per-point payload is available through `EXTRA_BYTES`, or descriptor-defined numeric attributes through `las.extraBytes: 'typed'`. Scalar data types 1-6 and 9-10 plus deprecated 2-component and 3-component vector codes based on those scalar types are supported with per-component descriptor scale/offset. 64-bit integer types 7-8 and vector codes based on them remain raw-only. Raw Extra Bytes are opt-in when `las.columns` is omitted; list `EXTRA_BYTES` explicitly. Typed Extra Bytes are included by default when `las.extraBytes: 'typed'` and `las.columns` is omitted. |
-| VLRs, EVLRs, CRS, WKT, GeoTIFF records | VLRs and complete EVLRs are preserved in metadata. WKT CRS records (coordinate-system and math-transform), GeoTIFF CRS payloads, Extra Bytes, waveform descriptors, and LASzip records are recognized. Full CRS reprojection is outside the loader. |
-| `parseInBatches` | Incremental for uncompressed LAS and fixed-size LAZ chunks. Legacy LAZ can emit complete rows with bounded replay; layered PDRF 6-10 emits after each complete compressed chunk. |
+| VLRs, EVLRs, CRS, WKT, GeoTIFF records | VLRs and complete EVLRs are preserved in metadata. WKT CRS records (coordinate-system and math-transform), GeoTIFF CRS payloads and resolved GeoKey entries, Extra Bytes, waveform descriptors, and LASzip records are recognized. Full CRS reprojection is outside the loader. |
+| `parseInBatches` | Incremental for uncompressed LAS and fixed-size LAZ chunks. Legacy LAZ can emit complete rows with bounded replay; layered PDRF 6-8 can emit selected Arrow rows once their required layers arrive. PDRF 9-10 and typed Extra Bytes currently retain complete-chunk delivery. |
 
 ### TypeScript LAS Writer
 
@@ -46,8 +46,8 @@ LAS file versions and LASzip codec versions are independent. A claim such as "LA
 | --- | --- |
 | Uncompressed LAS writing | Partial. Supports LAS output for represented mesh/table fields. |
 | LAS versions | Versions 1.0-1.4 are selectable and LAS 1.5 is rejected. Round-trip coverage currently targets default LAS 1.2 and LAS 1.4/PDRF 7; full version conformance is not claimed. |
-| Point data record formats | PDRF 0-8 are selectable. Only position, intensity, classification, and RGB input attributes are represented; other fields are zero-filled. |
-| LAZ writing | Supported for LAS 1.4 PDRF 6-8 with fixed-size or variable-size LASzip chunk tables. |
+| Point data record formats | PDRF 0-10 are selectable. Position, intensity, classification, RGB, NIR, GPS time, return/scan fields, waveform packet references, and configured Extra Bytes are mapped from input attributes. Missing fields are zero-filled. |
+| LAZ writing | Supported for PDRF 0-10 with fixed-size or variable-size LASzip chunk tables. Legacy PDRFs use LASzip compressor 2/item version 2; modern PDRFs use layered compressor 3/item version 3. |
 | COPC writing | Supported by `@loaders.gl/copc` through its separate `COPCWriter` entry point. |
 | VLRs, EVLRs, CRS, Extra Bytes VLRs | LASzip and configured Extra Bytes VLRs are written; broader metadata records remain incomplete. |
 | Streaming writing | `encodeInBatches` may buffer input so final counts, bounds, offsets, and headers can be written correctly. |
@@ -62,7 +62,7 @@ LAS file versions and LASzip codec versions are independent. A claim such as "LA
 | Legacy waveform PDRF 4-5 | Compressor 2, arithmetic coder 0, Point10/GPS/RGB/Byte item version 2, and WavePacket13 item version 1. |
 | Modern PDRF 6-8 items | Layered compressor 3, arithmetic coder 0, and Point14/RGB14/RGBNIR14/Byte14 item versions 2, 3, or 4. |
 | Modern waveform PDRF 9-10 | Layered compressor 3, arithmetic coder 0, Point14/RGB14/RGBNIR14/Byte14 item versions 2-4, and WavePacket14 item version 3 or 4. |
-| Extra Bytes | Byte10 version 2 and Byte14 versions 2-4 are losslessly preserved in raw records. Extra Bytes VLR definitions are not exposed as typed columns. |
+| Extra Bytes | Byte10 version 2 and Byte14 versions 2-4 are losslessly preserved in raw records. Extra Bytes VLR definitions can be exposed as typed scalar or vector Arrow columns for supported numeric types. |
 | Chunk table | Version 0, fixed-size and variable-size chunks. Other chunk-table versions are rejected. |
 | Unsupported modes | Pointwise compressor 1, coders other than 0, and legacy item version 1. |
 
@@ -70,15 +70,16 @@ LAS file versions and LASzip codec versions are independent. A claim such as "LA
 
 `encodeLAZChunk()` and `createLAZChunkEncoder()` encode raw LAS point records into one LASzip layered chunk. They do not write the surrounding LAS header, LASzip VLR, chunk table, or `.laz` file container.
 
-`LASWriter` uses the chunk encoder to write complete LAS 1.4 `.laz` files for PDRF 6-8, including the LASzip VLR, fixed-size or variable-size chunks, chunk-table pointer, and version 0 chunk table.
+`LASWriter` uses the chunk encoder to write complete `.laz` files for PDRF 0-10, including the LASzip VLR, fixed-size or variable-size chunks, chunk-table pointer, and version 0 chunk table.
 
 | LASzip feature | Supported TypeScript combinations |
 | --- | --- |
-| Modern PDRF 6-8 items | Layered compressor 3, arithmetic coder 0, and Point14/RGB14/RGBNIR14 item version 3. |
+| Legacy PDRF 0-5 items | Compressor 2, arithmetic coder 0, and Point10/GPS/RGB/Byte item version 2, with WavePacket13 item version 1 for PDRF 4-5. |
+| Modern PDRF 6-10 items | Layered compressor 3, arithmetic coder 0, and Point14/RGB14/RGBNIR14/Byte14 item version 3, with WavePacket14 item version 3 for PDRF 9-10. |
 | Extra Bytes | Byte14 item version 3 is losslessly encoded as independent layers. |
 | Input modes | Complete raw point buffers and feedable raw byte ranges. Feedable input is buffered until `close()` and `encode()` are called. |
-| Interoperability | PDRF 6-8 output is tested byte-for-byte through the TypeScript decoder and laz-perf. |
-| Unsupported modes | Legacy PDRF 0-5, waveform PDRF 9-10, and item versions 2 and 4. |
+| Interoperability | PDRF 0-10 output is decoded through the TypeScript implementation. Independent LASzip fixtures cover legacy, modern, and waveform item sets; bundled WASM comparisons cover the item sets those variants support. |
+| Unsupported modes | Pointwise compressor 1, coders other than 0, and alternate emitted item versions. |
 
 #### Point Record Formats
 
@@ -104,9 +105,10 @@ LAS file versions and LASzip codec versions are independent. A claim such as "LA
 | --- | --- | --- |
 | Uncompressed LAS | After the header and enough complete point records arrive. | Only incomplete framing and the current output batch are retained. |
 | Fixed-chunk legacy LAZ PDRF 0-5 | Before the current compressed chunk is complete, after enough bytes decode complete rows. | Uses bounded geometric replay and retains the current compressed chunk. |
-| Fixed-chunk layered LAZ PDRF 6-10 | After one complete compressed LAZ chunk arrives. | Independent field ranges are located by per-chunk size metadata; the whole file is not required. |
+| Fixed-chunk layered LAZ PDRF 6-8 | After all compressed layers required by the requested Arrow columns arrive. | Unrequested trailing layers do not delay the first batch. Typed Extra Bytes still use complete-chunk projection. |
+| Fixed-chunk layered LAZ PDRF 9-10 | After one complete compressed LAZ chunk arrives. | Waveform packet projection still uses the complete raw record chunk. |
 | Variable-chunk LAZ | After the EOF chunk table is available. | A forward-only source is buffered because per-chunk point counts are stored at EOF. |
-| COPC node | After the selected node byte range has been fetched. | Current COPC integration fetches and decodes one complete node chunk; it does not emit partial node rows. |
+| COPC node | After the compressed layers required by the selected columns arrive. | Node ranges are fetched in bounded ordered requests; unrequested trailing layers do not delay the first PDRF 6-8 batch. |
 
 #### Selective LAZ 1.4 Decoding
 
@@ -167,7 +169,7 @@ LAS 1.4 can still carry legacy point formats 0 through 5 for compatibility. For 
 
 ## Geospatial Reference Systems
 
-The TypeScript parser preserves the LAS geospatial reference system metadata without changing coordinates. For WKT CRS VLRs, `loaderData.metadata.wkt` contains the OGC Coordinate System WKT (record ID 2112) and `loaderData.metadata.wktMathTransform` contains the OGC Math Transform WKT (record ID 2111). For legacy GeoTIFF CRS VLRs, `loaderData.metadata.geotiff` contains the raw GeoKey directory, double parameters, and ASCII parameters from record IDs 34735, 34736, and 34737.
+The TypeScript parser preserves the LAS geospatial reference system metadata without changing coordinates. For WKT CRS VLRs, `loaderData.metadata.wkt` contains the OGC Coordinate System WKT (record ID 2112) and `loaderData.metadata.wktMathTransform` contains the OGC Math Transform WKT (record ID 2111). For legacy GeoTIFF CRS VLRs, `loaderData.metadata.geotiff` contains the raw GeoKey directory, double parameters, and ASCII parameters from record IDs 34735, 34736, and 34737. `geotiff.keyDirectory.entries` also resolves inline values and references into the double and ASCII parameter records while retaining each key's original tag location, count, and offset.
 
 This is metadata support, not a reprojection engine: `POSITION` values remain in the LAS file's declared coordinate reference system, with the LAS header scale and offset applied. Applications that need a different CRS should interpret the WKT or GeoTIFF metadata with a CRS library and perform reprojection explicitly. Raw VLR and EVLR records remain available for vendor-specific CRS extensions.
 

--- a/modules/las/src/index.ts
+++ b/modules/las/src/index.ts
@@ -13,6 +13,8 @@ export {LASWriter} from './las-writer';
 export type {
   LASExtendedVariableLengthRecord,
   LASExtraBytesDescriptor,
+  LASGeoTIFFKey,
+  LASGeoTIFFKeyDirectory,
   LASHeader,
   LASMetadata,
   LASVariableLengthRecord,

--- a/modules/las/src/las-writer.ts
+++ b/modules/las/src/las-writer.ts
@@ -34,7 +34,9 @@ const POINT_RECORD_LENGTHS: Record<number, number> = {
   5: 63,
   6: 30,
   7: 36,
-  8: 38
+  8: 38,
+  9: 59,
+  10: 67
 };
 
 /** Description of a typed mesh attribute stored in LAS Extra Bytes. */
@@ -56,7 +58,7 @@ export type LASWriterOptions = WriterOptions & {
     /** LAS file version to write. LAS 1.5 writing is intentionally not supported. */
     version?: '1.0' | '1.1' | '1.2' | '1.3' | '1.4';
     /** LAS point data record format to write. */
-    pointDataRecordFormat?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+    pointDataRecordFormat?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
     /** Coordinate scale factors used to quantize positions into LAS integer coordinates. */
     scale?: [number, number, number];
     /** Coordinate offsets used to quantize positions into LAS integer coordinates. */
@@ -489,9 +491,9 @@ function validateLAZOptions(
   if (pointDataRecordFormat >= 6 && version !== '1.4') {
     throw new Error(`LASWriter: LAZ output requires LAS 1.4; received ${version}`);
   }
-  if (![0, 1, 2, 3, 4, 5, 6, 7, 8].includes(pointDataRecordFormat)) {
+  if (![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10].includes(pointDataRecordFormat)) {
     throw new Error(
-      `LASWriter: LAZ output currently supports point data record formats 0-8; received ${pointDataRecordFormat}`
+      `LASWriter: LAZ output currently supports point data record formats 0-10; received ${pointDataRecordFormat}`
     );
   }
   if (
@@ -659,8 +661,7 @@ function validateOptionalPointAttributes(mesh: Mesh, vertexCount: number): void 
     'wavePacketDescriptorIndex',
     'wavePacketOffset',
     'wavePacketSize',
-    'wavePacketReturnPoint',
-    'wavePacketVector'
+    'wavePacketReturnPoint'
   ];
   for (const attributeName of scalarAttributeNames) {
     const attribute = mesh.attributes[attributeName];
@@ -858,32 +859,7 @@ function writePointRecord(
     }
     if (pointDataRecordFormat === 4 || pointDataRecordFormat === 5) {
       const waveformOffset = pointDataRecordFormat === 4 ? 28 : 34;
-      dataView.setUint8(
-        pointOffset + waveformOffset,
-        getUInt8Attribute(attributes.waveformDescriptorAttribute, vertexIndex)
-      );
-      dataView.setBigUint64(
-        pointOffset + waveformOffset + 1,
-        getBigUint64Attribute(attributes.waveformOffsetAttribute, vertexIndex),
-        true
-      );
-      dataView.setUint32(
-        pointOffset + waveformOffset + 9,
-        getUInt32Attribute(attributes.waveformSizeAttribute, vertexIndex),
-        true
-      );
-      dataView.setFloat32(
-        pointOffset + waveformOffset + 13,
-        getAttributeValue(attributes.waveformReturnPointAttribute, vertexIndex),
-        true
-      );
-      for (let componentIndex = 0; componentIndex < 3; componentIndex++) {
-        dataView.setFloat32(
-          pointOffset + waveformOffset + 17 + componentIndex * 4,
-          getComponent(attributes.waveformVectorAttribute, vertexIndex, componentIndex),
-          true
-        );
-      }
+      writeWaveformPacket(dataView, pointOffset + waveformOffset, vertexIndex, attributes);
     }
   } else {
     const returnNumber = getUInt8Attribute(attributes.returnNumberAttribute, vertexIndex, 1) & 0x0f;
@@ -924,6 +900,10 @@ function writePointRecord(
       getAttributeValue(attributes.gpsTimeAttribute, vertexIndex),
       true
     );
+    if (pointDataRecordFormat === 9 || pointDataRecordFormat === 10) {
+      const waveformOffset = pointDataRecordFormat === 9 ? 30 : 38;
+      writeWaveformPacket(dataView, pointOffset + waveformOffset, vertexIndex, attributes);
+    }
   }
 
   writePointColor(
@@ -933,7 +913,7 @@ function writePointRecord(
     pointDataRecordFormat,
     attributes.colorAttribute
   );
-  if (pointDataRecordFormat === 8) {
+  if (pointDataRecordFormat === 8 || pointDataRecordFormat === 10) {
     dataView.setUint16(
       pointOffset + 36,
       getUInt16Attribute(attributes.nirAttribute, vertexIndex),
@@ -947,6 +927,47 @@ function writePointRecord(
     basePointDataRecordLength,
     attributes.extraByteFields
   );
+}
+
+/** Write one 29-byte LAS waveform packet reference. */
+function writeWaveformPacket(
+  dataView: DataView,
+  byteOffset: number,
+  vertexIndex: number,
+  attributes: {
+    waveformDescriptorAttribute?: MeshAttribute;
+    waveformOffsetAttribute?: MeshAttribute;
+    waveformSizeAttribute?: MeshAttribute;
+    waveformReturnPointAttribute?: MeshAttribute;
+    waveformVectorAttribute?: MeshAttribute;
+  }
+): void {
+  dataView.setUint8(
+    byteOffset,
+    getUInt8Attribute(attributes.waveformDescriptorAttribute, vertexIndex)
+  );
+  dataView.setBigUint64(
+    byteOffset + 1,
+    getBigUint64Attribute(attributes.waveformOffsetAttribute, vertexIndex),
+    true
+  );
+  dataView.setUint32(
+    byteOffset + 9,
+    getUInt32Attribute(attributes.waveformSizeAttribute, vertexIndex),
+    true
+  );
+  dataView.setFloat32(
+    byteOffset + 13,
+    getAttributeValue(attributes.waveformReturnPointAttribute, vertexIndex),
+    true
+  );
+  for (let componentIndex = 0; componentIndex < 3; componentIndex++) {
+    dataView.setFloat32(
+      byteOffset + 17 + componentIndex * 4,
+      getComponent(attributes.waveformVectorAttribute, vertexIndex, componentIndex),
+      true
+    );
+  }
 }
 
 /** Write configured Extra Bytes values into one raw LAS point record. */
@@ -1052,6 +1073,7 @@ function getColorOffset(pointDataRecordFormat: number): number {
       return 57;
     case 7:
     case 8:
+    case 10:
       return 30;
     default:
       return -1;

--- a/modules/las/src/lib/las-types.ts
+++ b/modules/las/src/lib/las-types.ts
@@ -80,6 +80,32 @@ export type LASWaveformPacketDescriptor = {
   digitizerOffset: number;
 };
 
+/** One resolved GeoTIFF GeoKey directory entry from LAS CRS metadata. */
+export type LASGeoTIFFKey = {
+  /** GeoTIFF key identifier. */
+  keyId: number;
+  /** TIFF tag containing the value, or zero when the value is inline. */
+  tiffTagLocation: number;
+  /** Number of values referenced by this key. */
+  count: number;
+  /** Inline value or offset into the referenced GeoTIFF parameter tag. */
+  valueOffset: number;
+  /** Resolved scalar, numeric array, or ASCII value when its source tag is available. */
+  value?: number | number[] | string;
+};
+
+/** Parsed GeoTIFF GeoKey directory header and entries. */
+export type LASGeoTIFFKeyDirectory = {
+  /** GeoKey directory format version. */
+  version: number;
+  /** GeoKey revision. */
+  keyRevision: number;
+  /** GeoKey minor revision. */
+  minorRevision: number;
+  /** Resolved GeoKey entries. */
+  entries: LASGeoTIFFKey[];
+};
+
 /** Typed metadata parsed from a LAS file. */
 export type LASMetadata = {
   /** File source id from the public header. */
@@ -128,6 +154,8 @@ export type LASMetadata = {
     doubles?: Float64Array;
     /** GeoAsciiParamsTag payload. */
     ascii?: string;
+    /** Parsed and resolved GeoKey directory entries. */
+    keyDirectory?: LASGeoTIFFKeyDirectory;
   };
   /** Extra Bytes descriptors parsed from the Extra Bytes VLR. */
   extraBytes: LASExtraBytesDescriptor[];

--- a/modules/las/src/lib/typescript/parse-las.ts
+++ b/modules/las/src/lib/typescript/parse-las.ts
@@ -6,10 +6,13 @@ import type {MeshArrowTable, MeshAttributes} from '@loaders.gl/schema';
 import {makeMeshArrowTable} from '@loaders.gl/schema-utils';
 import {
   BinaryChunkReader,
+  createLAZChunkDecoder,
   createLAZChunkDecoderCursor,
   decodeLAZChunk,
   decodeLAZChunkTable,
   getLAZChunkByteLength,
+  getLAZChunkDeclaredByteLength,
+  getLAZChunkHeaderByteLength,
   NeedsMoreData
 } from '@loaders.gl/loader-utils';
 import type {LAZChunkMetadata, LAZPointDataTarget} from '@loaders.gl/loader-utils';
@@ -23,6 +26,7 @@ import {
 } from '../las-extra-bytes';
 import type {
   LASExtendedVariableLengthRecord,
+  LASGeoTIFFKey,
   LASHeader,
   LASMetadata,
   LASVariableLengthRecord,
@@ -701,17 +705,35 @@ async function* parsePendingLAZFileInArrowBatches(
   while (sourcePointIndex < header.pointsCount) {
     const chunkPointCount = Math.min(laszip.chunkSize, header.pointsCount - sourcePointIndex);
     const metadata = createLAZChunkMetadata(header, laszip, chunkPointCount);
-    const chunkByteLength = await readLAZChunkByteLengthFromReader(reader, inputIterator, metadata);
-    const compressedChunk = reader.readBytes(chunkByteLength);
+    const supportsProgressivePointData =
+      header.pointsFormatId >= 6 &&
+      header.pointsFormatId <= 8 &&
+      !state.waveforms &&
+      !state.typedExtraBytes;
 
-    for (const batch of appendDecodedLAZChunkToPointDataBatches(
-      compressedChunk,
-      metadata,
-      outputHeader,
-      state,
-      options
-    )) {
-      yield batch;
+    if (supportsProgressivePointData) {
+      yield* appendProgressiveLAZChunkToPointDataBatches(
+        reader,
+        inputIterator,
+        metadata,
+        outputHeader,
+        state,
+        options
+      );
+    } else {
+      const chunkByteLength = await readLAZChunkByteLengthFromReader(
+        reader,
+        inputIterator,
+        metadata
+      );
+      const compressedChunk = reader.readBytes(chunkByteLength);
+      yield* appendDecodedLAZChunkToPointDataBatches(
+        compressedChunk,
+        metadata,
+        outputHeader,
+        state,
+        options
+      );
     }
 
     sourcePointIndex += chunkPointCount;
@@ -720,6 +742,75 @@ async function* parsePendingLAZFileInArrowBatches(
   const finalBatch = flushPointDataBatch(outputHeader, state, options);
   if (finalBatch) {
     yield finalBatch;
+  }
+}
+
+/** Feed one layered LAZ chunk and yield requested Arrow rows before its trailing layers arrive. */
+async function* appendProgressiveLAZChunkToPointDataBatches(
+  reader: BinaryChunkReader,
+  inputIterator: AsyncIterator<ArrayBufferLike | ArrayBufferView>,
+  metadata: LAZChunkMetadata,
+  header: LASHeader,
+  state: PointDataBatchState,
+  options: LASLoaderOptions
+): AsyncIterable<LASArrowTable> {
+  const headerByteLength = getLAZChunkHeaderByteLength(metadata);
+  await readUntilAvailable(
+    reader,
+    inputIterator,
+    headerByteLength,
+    'LASLoader: incomplete layered LAZ chunk header'
+  );
+  const compressedHeader = reader.readBytes(headerByteLength);
+  const chunkByteLength = getLAZChunkDeclaredByteLength(compressedHeader, metadata);
+  const decoder = createLAZChunkDecoder(metadata);
+  decoder.feed(compressedHeader);
+  let fedByteLength = headerByteLength;
+
+  while (fedByteLength < chunkByteLength) {
+    yield* readAvailableLAZPointDataBatches(decoder, header, state, options);
+    if (reader.getAvailableByteLength() === 0) {
+      const next = await inputIterator.next();
+      if (next.done) {
+        throw new NeedsMoreData('LASLoader: incomplete layered LAZ chunk payload');
+      }
+      reader.write(next.value);
+    }
+    const byteLength = Math.min(reader.getAvailableByteLength(), chunkByteLength - fedByteLength);
+    decoder.feed(reader.readBytes(byteLength));
+    fedByteLength += byteLength;
+  }
+
+  decoder.close();
+  yield* readAvailableLAZPointDataBatches(decoder, header, state, options);
+  if (decoder.remainingPointCount !== 0) {
+    throw new NeedsMoreData(
+      `LASLoader: layered LAZ chunk produced ${metadata.pointCount - decoder.remainingPointCount} of ${metadata.pointCount} points`
+    );
+  }
+}
+
+/** Drain all currently decodable rows from one feedable layered LAZ chunk. */
+function* readAvailableLAZPointDataBatches(
+  decoder: ReturnType<typeof createLAZChunkDecoder>,
+  header: LASHeader,
+  state: PointDataBatchState,
+  options: LASLoaderOptions
+): Iterable<LASArrowTable> {
+  while (decoder.remainingPointCount > 0) {
+    const batchRemainingPointCount = state.batchCapacity - state.batchPointCount;
+    state.target.pointOffset = state.batchPointCount;
+    const pointsDecoded = decoder.readPointDataBatch(state.target, batchRemainingPointCount);
+    if (!pointsDecoded) {
+      return;
+    }
+    state.batchPointCount += pointsDecoded;
+    if (state.batchPointCount === state.batchCapacity) {
+      const batch = flushPointDataBatch(header, state, options);
+      if (batch) {
+        yield batch;
+      }
+    }
   }
 }
 
@@ -930,6 +1021,7 @@ function parseLASMetadata(arrayBuffer: ArrayBufferLike, header: LASHeader): LASM
   )) {
     parseTypedLASMetadataRecord(record, metadata);
   }
+  resolveLASGeoTIFFKeyDirectory(metadata);
   return metadata;
 }
 
@@ -1020,6 +1112,69 @@ function parseTypedLASMetadataRecord(
   } else if (record.userId === 'LASF_Projection' && record.recordId === 34737) {
     metadata.geotiff = {...metadata.geotiff, ascii: decodeLASString(data)};
   }
+}
+
+/** Resolve GeoKey directory entries against their companion LAS GeoTIFF records. */
+function resolveLASGeoTIFFKeyDirectory(metadata: LASMetadata): void {
+  const geotiff = metadata.geotiff;
+  const keys = geotiff?.keys;
+  if (!geotiff || !keys || keys.length < 4) {
+    return;
+  }
+  const declaredEntryCount = keys[3];
+  if (keys.length < 4 + declaredEntryCount * 4) {
+    return;
+  }
+  const entries: LASGeoTIFFKey[] = [];
+  for (let entryIndex = 0; entryIndex < declaredEntryCount; entryIndex++) {
+    const entryOffset = 4 + entryIndex * 4;
+    const entry: LASGeoTIFFKey = {
+      keyId: keys[entryOffset],
+      tiffTagLocation: keys[entryOffset + 1],
+      count: keys[entryOffset + 2],
+      valueOffset: keys[entryOffset + 3]
+    };
+    entry.value = resolveLASGeoTIFFKeyValue(entry, geotiff);
+    if (entry.value === undefined) {
+      delete entry.value;
+    }
+    entries.push(entry);
+  }
+  geotiff.keyDirectory = {
+    version: keys[0],
+    keyRevision: keys[1],
+    minorRevision: keys[2],
+    entries
+  };
+}
+
+/** Resolve one GeoKey value from its TIFF-tag location. */
+function resolveLASGeoTIFFKeyValue(
+  entry: LASGeoTIFFKey,
+  geotiff: NonNullable<LASMetadata['geotiff']>
+): number | number[] | string | undefined {
+  if (entry.tiffTagLocation === 0) {
+    return entry.valueOffset;
+  }
+  if (entry.tiffTagLocation === 34735 && geotiff.keys) {
+    const values = geotiff.keys.slice(entry.valueOffset, entry.valueOffset + entry.count);
+    return values.length === entry.count ? Array.from(values) : undefined;
+  }
+  if (entry.tiffTagLocation === 34736 && geotiff.doubles) {
+    const values = geotiff.doubles.slice(entry.valueOffset, entry.valueOffset + entry.count);
+    if (values.length !== entry.count) {
+      return undefined;
+    }
+    return entry.count === 1 ? values[0] : Array.from(values);
+  }
+  if (entry.tiffTagLocation === 34737 && geotiff.ascii !== undefined) {
+    const end = entry.valueOffset + entry.count;
+    if (end > geotiff.ascii.length) {
+      return undefined;
+    }
+    return geotiff.ascii.slice(entry.valueOffset, end).replace(/\|$/, '');
+  }
+  return undefined;
 }
 
 function parseLASWaveformDescriptor(

--- a/modules/las/test/las-loader.spec.ts
+++ b/modules/las/test/las-loader.spec.ts
@@ -228,6 +228,31 @@ test('LASLoader#parseInBatches preserves selected columns across chunked PDRF 7 
   expect(streamedColumns.classification).toEqual(getArrowColumnValues(expected, 'classification'));
 });
 
+test('LASLoader#parseInBatches yields PDRF 7 rows before the compressed chunk tail arrives', async () => {
+  const lazArrayBuffer = await fetchFile(PDRF_7_LAZ_URL).then(response => response.arrayBuffer());
+  const chunks = splitArrayBuffer(lazArrayBuffer, 257);
+  let consumedChunkCount = 0;
+  async function* trackConsumedChunks(): AsyncIterable<ArrayBuffer> {
+    for (const chunk of chunks) {
+      consumedChunkCount++;
+      yield chunk;
+    }
+  }
+
+  const batches = await parseInBatches(trackConsumedChunks(), LASLoader, {
+    batchSize: 127,
+    las: {shape: 'arrow-table', columns: ['POSITION', 'classification']},
+    core: {worker: false}
+  });
+  const iterator = (batches as AsyncIterable<MeshArrowTable>)[Symbol.asyncIterator]();
+  const firstBatch = await iterator.next();
+
+  expect(firstBatch.done).toBe(false);
+  expect(firstBatch.value?.data.numRows).toBe(127);
+  expect(consumedChunkCount).toBeLessThan(chunks.length);
+  await iterator.return?.();
+});
+
 test('LASLoader#columns decodes GPS time and NIR for PDRF 8', async () => {
   const [lasArrayBuffer, lazArrayBuffer] = await Promise.all([
     fetchFile(PDRF_8_LAS_URL).then(response => response.arrayBuffer()),
@@ -608,9 +633,13 @@ test('LASLoader#columns enables typed Extra Bytes when columns are omitted', asy
 test('LASLoader#metadata parses LAS 1.4 CRS and waveform records', () => {
   const wktMathTransform = new TextEncoder().encode('PARAM_MT["transform"]');
   const wktCoordinateSystem = new TextEncoder().encode('GEOGCS["coordinate-system"]');
-  const geoKeyDirectory = new Uint8Array(8);
-  new DataView(geoKeyDirectory.buffer).setUint16(0, 1, true);
-  new DataView(geoKeyDirectory.buffer).setUint16(2, 1, true);
+  const geoKeyDirectory = new Uint8Array(32);
+  const geoKeyView = new DataView(geoKeyDirectory.buffer);
+  for (const [index, value] of [
+    1, 1, 0, 3, 1024, 0, 1, 1, 2057, 34736, 1, 0, 1026, 34737, 7, 0
+  ].entries()) {
+    geoKeyView.setUint16(index * 2, value, true);
+  }
   const geoDoubleParameters = new ArrayBuffer(8);
   new DataView(geoDoubleParameters).setFloat64(0, 4326, true);
   const geoAsciiParameters = new TextEncoder().encode('WGS 84|');
@@ -656,9 +685,21 @@ test('LASLoader#metadata parses LAS 1.4 CRS and waveform records', () => {
   expect(metadata.projectId).toBe('12345678-1234-5678-9abcdef012345678');
   expect(metadata.wkt).toBe('GEOGCS["coordinate-system"]');
   expect(metadata.wktMathTransform).toBe('PARAM_MT["transform"]');
-  expect(metadata.geotiff?.keys).toEqual(new Uint16Array([1, 1, 0, 0]));
+  expect(metadata.geotiff?.keys).toEqual(
+    new Uint16Array([1, 1, 0, 3, 1024, 0, 1, 1, 2057, 34736, 1, 0, 1026, 34737, 7, 0])
+  );
   expect(metadata.geotiff?.doubles).toEqual(new Float64Array([4326]));
   expect(metadata.geotiff?.ascii).toBe('WGS 84|');
+  expect(metadata.geotiff?.keyDirectory).toEqual({
+    version: 1,
+    keyRevision: 1,
+    minorRevision: 0,
+    entries: [
+      {keyId: 1024, tiffTagLocation: 0, count: 1, valueOffset: 1, value: 1},
+      {keyId: 2057, tiffTagLocation: 34736, count: 1, valueOffset: 0, value: 4326},
+      {keyId: 1026, tiffTagLocation: 34737, count: 7, valueOffset: 0, value: 'WGS 84'}
+    ]
+  });
   expect(metadata.waveformPacketDescriptors[0]).toMatchObject({
     bitsPerSample: 16,
     numberOfSamples: 128,

--- a/modules/las/test/las-writer.spec.ts
+++ b/modules/las/test/las-writer.spec.ts
@@ -445,6 +445,90 @@ test('LASWriter#preserves NIR in PDRF 8 LAZ', t => {
   t.end();
 });
 
+test('LASWriter#encodes waveform PDRF 9 and 10 LAZ containers', async t => {
+  const waveformAttributes = {
+    POSITION: {value: new Float64Array([1, 2, 3]), size: 3},
+    COLOR_0: {value: new Uint8Array([10, 20, 30]), size: 3},
+    nir: {value: new Uint16Array([1234]), size: 1},
+    wavePacketDescriptorIndex: {value: new Uint8Array([7]), size: 1},
+    wavePacketOffset: {value: new Float64Array([123456]), size: 1},
+    wavePacketSize: {value: new Uint32Array([4096]), size: 1},
+    wavePacketReturnPoint: {value: new Float32Array([0.25]), size: 1},
+    wavePacketVector: {value: new Float32Array([1.5, -2.5, 3.5]), size: 3}
+  };
+  const waveformMesh = {
+    attributes: waveformAttributes,
+    topology: 'point-list' as const,
+    mode: 0,
+    schema: deduceMeshSchema(waveformAttributes, {topology: 'point-list', mode: '0'})
+  };
+
+  for (const pointDataRecordFormat of [9, 10] as const) {
+    const arrayBuffer = await encode(waveformMesh, LASWriter, {
+      las: {format: 'laz', pointDataRecordFormat, chunkSize: 1}
+    });
+    const dataView = new DataView(arrayBuffer);
+    const pointDataOffset = dataView.getUint32(96, true);
+    const chunkTableOffset = readUint64(dataView, pointDataOffset);
+    const pointDataRecordLength = pointDataRecordFormat === 9 ? 59 : 67;
+    const decoded = decodeLAZChunk(arrayBuffer.slice(pointDataOffset + 8, chunkTableOffset), {
+      pointDataRecordFormat,
+      pointDataRecordLength,
+      pointCount: 1,
+      point14ItemVersion: 3,
+      rgb14ItemVersion: 3,
+      wavePacketItemVersion: 3,
+      byte14ItemVersion: 3
+    });
+    const decodedView = new DataView(decoded.buffer, decoded.byteOffset, decoded.byteLength);
+    const waveformOffset = pointDataRecordFormat === 9 ? 30 : 38;
+    const uncompressed = await encode(waveformMesh, LASWriter, {
+      las: {format: 'las', pointDataRecordFormat}
+    });
+    const uncompressedDataView = new DataView(uncompressed);
+    const uncompressedPointOffset = uncompressedDataView.getUint32(96, true);
+
+    t.equal(
+      dataView.getUint8(104),
+      0x80 | pointDataRecordFormat,
+      `writes PDRF ${pointDataRecordFormat}`
+    );
+    t.equal(
+      dataView.getUint16(105, true),
+      pointDataRecordLength,
+      'writes the waveform record length'
+    );
+    t.equal(decodedView.getUint8(waveformOffset), 7, 'preserves the waveform descriptor index');
+    t.equal(
+      decodedView.getBigUint64(waveformOffset + 1, true),
+      123456n,
+      'preserves the waveform offset'
+    );
+    t.equal(decodedView.getUint32(waveformOffset + 9, true), 4096, 'preserves the waveform size');
+    t.equal(
+      decodedView.getFloat32(waveformOffset + 13, true),
+      0.25,
+      'preserves the return location'
+    );
+    t.deepEqual(
+      [0, 1, 2].map(componentIndex =>
+        decodedView.getFloat32(waveformOffset + 17 + componentIndex * 4, true)
+      ),
+      [1.5, -2.5, 3.5],
+      'preserves the waveform vector'
+    );
+    t.deepEqual(
+      decoded,
+      new Uint8Array(uncompressed, uncompressedPointOffset, pointDataRecordLength),
+      `PDRF ${pointDataRecordFormat} compressed point bytes match uncompressed LAS`
+    );
+    if (pointDataRecordFormat === 10) {
+      t.equal(decodedView.getUint16(36, true), 1234, 'PDRF 10 preserves NIR');
+    }
+  }
+  t.end();
+});
+
 test('LASWriter#writes Extra Bytes in LAS and LAZ', t => {
   const extraAttributes = {
     POSITION: {value: new Float64Array([1, 2, 3]), size: 3},

--- a/modules/loader-utils/src/index.ts
+++ b/modules/loader-utils/src/index.ts
@@ -169,7 +169,9 @@ export {
   decodeLAZChunkTable,
   decodeLAZChunk,
   decodeLAZChunkInBatches,
-  getLAZChunkByteLength
+  getLAZChunkByteLength,
+  getLAZChunkDeclaredByteLength,
+  getLAZChunkHeaderByteLength
 } from './lib/laz/laz-chunk-decoder';
 export type {
   FeedableLAZChunkDecoder,

--- a/modules/loader-utils/src/lib/laz/laz-chunk-decoder.ts
+++ b/modules/loader-utils/src/lib/laz/laz-chunk-decoder.ts
@@ -115,6 +115,8 @@ export class FeedableLAZChunkDecoder {
   private cursor: LAZChunkDecoderCursor | null = null;
   private fedByteLength = 0;
   private requiredByteLength: number | null = null;
+  private progressiveRequiredByteLength: number | null = null;
+  private progressiveSelectionKey: number | null = null;
 
   constructor(metadata: LAZChunkMetadata) {
     this.metadata = metadata;
@@ -215,7 +217,7 @@ export class FeedableLAZChunkDecoder {
     if (this.requiredByteLength !== null) {
       return this.fedByteLength >= this.requiredByteLength;
     }
-    if (this.fedByteLength < getLAZChunkMinimumByteLength(this.metadata)) {
+    if (this.fedByteLength < getLAZChunkHeaderByteLength(this.metadata)) {
       return false;
     }
 
@@ -243,17 +245,27 @@ export class FeedableLAZChunkDecoder {
   }
 
   private getProgressivePointData(target: LAZPointDataTarget): Uint8Array | null {
-    const available = this.getCompressedAvailable();
-    const layout = getLayeredChunkLayout(available, this.metadata);
-    if (!layout) {
-      return null;
+    const selectionKey = getLAZPointDataSelectionKey(getLAZPointDataSelection(target));
+    if (this.progressiveSelectionKey !== selectionKey) {
+      this.progressiveRequiredByteLength = null;
+      this.progressiveSelectionKey = selectionKey;
     }
-    const requiredLayerCount = getProgressiveLayerCount(this.metadata, target);
-    const requiredByteLength = layout.getByteLength(requiredLayerCount);
-    if (available.byteLength < requiredByteLength) {
+
+    if (this.progressiveRequiredByteLength === null) {
+      const availableHeader = this.getCompressedAvailable();
+      const headerLayout = getLayeredChunkLayout(availableHeader, this.metadata);
+      if (!headerLayout) {
+        return null;
+      }
+      const requiredLayerCount = getProgressiveLayerCount(this.metadata, target);
+      this.progressiveRequiredByteLength = headerLayout.getByteLength(requiredLayerCount);
+    }
+    if (this.fedByteLength < this.progressiveRequiredByteLength) {
       return null;
     }
 
+    const available = this.getCompressedAvailable();
+    const layout = getLayeredChunkLayout(available, this.metadata)!;
     const compressed = new Uint8Array(layout.byteLength);
     compressed.set(available.subarray(0, Math.min(available.byteLength, layout.byteLength)));
     return compressed;
@@ -512,7 +524,8 @@ export function decodeLAZChunkTable(
   return chunks;
 }
 
-function getLAZChunkMinimumByteLength(metadata: LAZChunkMetadata): number {
+/** Return the bytes needed to read one layered LAZ chunk's size headers. */
+export function getLAZChunkHeaderByteLength(metadata: LAZChunkMetadata): number {
   if (!hasLayeredChunkSizeHeaders(metadata.pointDataRecordFormat)) {
     return metadata.pointDataRecordLength + 4;
   }
@@ -522,6 +535,26 @@ function getLAZChunkMinimumByteLength(metadata: LAZChunkMetadata): number {
     4 +
     getChunkSizeHeaderCount(metadata.pointDataRecordFormat, extraByteCount) * 4
   );
+}
+
+/**
+ * Return the compressed byte length declared by a layered LAZ chunk header.
+ *
+ * Unlike {@link getLAZChunkByteLength}, this function does not require the
+ * compressed layer payloads to have arrived.
+ */
+export function getLAZChunkDeclaredByteLength(
+  compressedHeader: ArrayBuffer | ArrayBufferView,
+  metadata: LAZChunkMetadata
+): number {
+  if (!hasLayeredChunkSizeHeaders(metadata.pointDataRecordFormat)) {
+    throw new NeedsMoreData('Legacy LAZ chunk byte length is not self-describing');
+  }
+  const layout = getLayeredChunkLayout(toUint8Array(compressedHeader), metadata);
+  if (!layout) {
+    throw new NeedsMoreData('LAZ chunk decoder needs the complete layered size header');
+  }
+  return layout.byteLength;
 }
 
 type LAZLayeredChunkLayout = {

--- a/modules/loader-utils/test/lib/laz/laz-chunk-decoder.spec.ts
+++ b/modules/loader-utils/test/lib/laz/laz-chunk-decoder.spec.ts
@@ -3,7 +3,13 @@
 // Copyright (c) vis.gl contributors
 
 import {expect, test} from 'vitest';
-import {decodeLAZChunkTable, NeedsMoreData} from '@loaders.gl/loader-utils';
+import {
+  decodeLAZChunkTable,
+  encodeLAZChunk,
+  getLAZChunkDeclaredByteLength,
+  getLAZChunkHeaderByteLength,
+  NeedsMoreData
+} from '@loaders.gl/loader-utils';
 
 const FIXED_CHUNK_TABLE = new Uint8Array([107, 237, 189, 84, 131, 215, 0, 0, 0]);
 const VARIABLE_CHUNK_TABLE = new Uint8Array([
@@ -56,4 +62,40 @@ test('decodeLAZChunkTable rejects truncated arithmetic input', () => {
       variable: true
     })
   ).toThrowError(NeedsMoreData);
+});
+
+test('layered LAZ chunk framing is available before layer payloads', () => {
+  const metadata = {
+    pointDataRecordFormat: 7,
+    pointDataRecordLength: 36,
+    pointCount: 2,
+    point14ItemVersion: 3 as const,
+    rgb14ItemVersion: 3 as const,
+    byte14ItemVersion: 3 as const
+  };
+  const rawPointData = new Uint8Array(metadata.pointDataRecordLength * metadata.pointCount);
+  const dataView = new DataView(rawPointData.buffer);
+  for (let pointIndex = 0; pointIndex < metadata.pointCount; pointIndex++) {
+    const pointOffset = pointIndex * metadata.pointDataRecordLength;
+    dataView.setInt32(pointOffset, pointIndex, true);
+    dataView.setInt32(pointOffset + 4, pointIndex * 2, true);
+    dataView.setInt32(pointOffset + 8, pointIndex * 3, true);
+    dataView.setUint8(pointOffset + 14, 0x11);
+    dataView.setFloat64(pointOffset + 22, pointIndex, true);
+  }
+  const compressed = encodeLAZChunk(rawPointData, metadata);
+  const headerByteLength = getLAZChunkHeaderByteLength(metadata);
+  const padded = new Uint8Array(headerByteLength + 8);
+  padded.set(compressed.subarray(0, headerByteLength), 4);
+
+  expect(getLAZChunkDeclaredByteLength(padded.subarray(4, 4 + headerByteLength), metadata)).toBe(
+    compressed.byteLength
+  );
+  expect(() => getLAZChunkDeclaredByteLength(compressed.subarray(0, 8), metadata)).toThrowError(
+    NeedsMoreData
+  );
+  expect(getLAZChunkHeaderByteLength({...metadata, pointDataRecordFormat: 3})).toBe(40);
+  expect(() =>
+    getLAZChunkDeclaredByteLength(compressed, {...metadata, pointDataRecordFormat: 3})
+  ).toThrowError(/Legacy LAZ chunk byte length is not self-describing/);
 });


### PR DESCRIPTION
## Goals

- Complete the progressive layered LAZ, full LAZ container writer, and typed CRS metadata roadmap tranches.
- Preserve TypeScript decoder performance, Arrow-first output, and complete-buffer API compatibility.

## Changes

- Stream fixed-chunk PDRF 6-8 Arrow batches once the requested LAZ layers arrive, without waiting for trailing unrequested layers.
- Add LAZ chunk framing helpers and cache progressive layer-prefix sizing to avoid repeated input concatenation.
- Extend `LASWriter` LAZ output through PDRF 9 and 10, including lossless WavePacket14 references, RGB/NIR layout, and fixed or variable chunk tables.
- Resolve GeoTIFF key-directory entries into typed inline, double, and ASCII values while preserving their raw VLR payloads.
- Add ownership, progressive-delivery, waveform writer, raw-record parity, and CRS metadata tests.
- Update LAS format and writer documentation with precise streaming, waveform payload, writer, CRS, and interoperability limits.

## Validation

- `yarn build`
- `yarn build-workers`
- `yarn test-node` (44 files, 326 passed, 6 skipped)
- `yarn test-headless` (438 files passed, 2 skipped; 2514 tests passed, 47 skipped)
- Focused LAS and LAZ tests (4 files, 55 passed)
- `yarn test-audit` (544 files, 0 violations)
- `yarn lint fix`
- `website/yarn build`
- `yarn bench las`: TypeScript PDRF 7 streaming 1.38M points/s; selective position/color streaming 2.33M points/s; parser-level copy/allocation counters remain zero
