### PR TITLE
feat(parquet): support repeated page continuations

### DIFF
--- a/docs/modules/parquet/formats/parquet.md
+++ b/docs/modules/parquet/formats/parquet.md
@@ -241,7 +241,7 @@ can make selective reads much cheaper.
 | Column-chunk min/max/null/distinct statistics | ✅ | ❌ | Drive conservative `ParquetSource` predicate pushdown and remain exposed in metadata |
 | Page statistics in page headers | ⚠️ | ❌ | Thrift fields are decoded but not exposed as a pruning API |
 | [Column index](https://github.com/apache/parquet-format/blob/master/PageIndex.md) | ✅ | ✅ (opt-in) | Predicates use page min/max statistics to derive conservative candidate row ranges for primitive leaves, including nested struct children and repeated leaves when selected columns share page boundaries |
-| [Offset index](https://github.com/apache/parquet-format/blob/master/PageIndex.md) | ✅ | ✅ (opt-in) | Selected columns use page locations and first-row indexes for selective byte reads; repeated values are decoded only from complete, mutually aligned page ranges |
+| [Offset index](https://github.com/apache/parquet-format/blob/master/PageIndex.md) | ✅ | ✅ (opt-in) | Selected columns use page locations and first-row indexes for selective byte reads; repeated values and continuation pages are decoded only from complete, mutually aligned row ranges |
 | [Bloom filters](https://github.com/apache/parquet-format/blob/master/BloomFilter.md) | ✅ | ✅ | TypeScript reads split-block Bloom filters for safe equality/`IN` row-group pruning; `ParquetJSWriter` can emit them opt-in |
 | Size statistics | ❌ | ❌ | Histogram metadata from newer format work is not yet exposed; see the upstream [`ColumnMetaData`](https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift) definition |
 | Column order and sorting columns | ✅ (metadata) | ❌ | Row-group sort declarations are normalized as `sortingColumns`; semantic pruning is not yet applied |
@@ -250,9 +250,9 @@ can make selective reads much cheaper.
 footer statistics and split-block Bloom filters, and uses column/offset indexes to avoid irrelevant
 data pages for primitive leaves, including nested struct children. Filter-only columns are not
 returned in the projected Arrow schema. Candidate rows are still filtered exactly on the caller
-thread or worker. Repeated-leaf pruning is enabled when all selected leaves have compatible page
-boundaries; files with incompatible boundaries conservatively use full column-chunk reads. Size
-statistics, sorting metadata, and encryption remain future format-completeness work.
+thread or worker. Repeated-leaf pruning is enabled when all selected leaves have compatible page boundaries,
+including pages that continue one logical row; files with incompatible boundaries conservatively use full
+column-chunk reads. Size statistics, sorting metadata, and encryption remain future format-completeness work.
 
 ## Integrity and Encryption
 
@@ -285,8 +285,7 @@ corpora run in the slow lane.
 The TypeScript implementation is aiming for complete stable-format read support. The largest known
 gaps are currently:
 
-1. repeated-leaf page-index continuation and pruning;
-2. size statistics and semantic sorting-based pruning; and
-3. Parquet modular encryption.
+1. size statistics and semantic sorting-based pruning; and
+2. Parquet modular encryption.
 
 Preview features such as [ALP](https://github.com/apache/parquet-format/pull/557), [PFOR](https://github.com/apache/parquet-format/pull/579), and the upstream [format-versioning RFCs](https://github.com/apache/parquet-format/pulls?q=is%3Apr+versioning) are tracked separately from stable-format completeness.

--- a/modules/parquet/src/lib/parquet-page-index.ts
+++ b/modules/parquet/src/lib/parquet-page-index.ts
@@ -266,10 +266,27 @@ export function decodeOffsetIndex(bytes: Uint8Array, rowCount: number): ParquetD
   ) {
     throw new Error('Invalid Parquet offset index page locations');
   }
+  let previousFirstRowIndex = -1;
+  for (const location of offsetIndex.page_locations) {
+    const firstRowIndex = Number(location.first_row_index);
+    if (!Number.isSafeInteger(firstRowIndex) || firstRowIndex < previousFirstRowIndex) {
+      throw new Error('Invalid Parquet offset index page locations');
+    }
+    previousFirstRowIndex = firstRowIndex;
+  }
   return offsetIndex.page_locations.map((location, index, locations) => {
     const firstRowIndex = Number(location.first_row_index);
-    const endRowIndex =
-      index + 1 < locations.length ? Number(locations[index + 1].first_row_index) : rowCount;
+    // A repeated row may continue on one or more pages. In that case the offset index
+    // legitimately repeats first_row_index. Extend each continuation page to the next
+    // strictly larger row start so selecting the row includes the complete continuation.
+    let endRowIndex = rowCount;
+    for (let nextIndex = index + 1; nextIndex < locations.length; nextIndex++) {
+      const nextFirstRowIndex = Number(locations[nextIndex].first_row_index);
+      if (nextFirstRowIndex > firstRowIndex) {
+        endRowIndex = nextFirstRowIndex;
+        break;
+      }
+    }
     const offset = Number(location.offset);
     const compressedByteLength = location.compressed_page_size;
     if (

--- a/modules/parquet/test/parquet-page-index-api.spec.ts
+++ b/modules/parquet/test/parquet-page-index-api.spec.ts
@@ -2,9 +2,12 @@ import {describe, expect, test} from 'vitest';
 
 import {
   canUseParquetPageIndexForColumn,
+  decodeOffsetIndex,
   decodeParquetPageStatisticsValue
 } from '../src/lib/parquet-page-index';
 import {ParquetSchema} from '../src/parquetjs/schema/schema';
+import {OffsetIndex, PageLocation} from '../src/parquetjs/parquet-thrift';
+import {serializeThrift} from '../src/parquetjs/utils/read-utils';
 
 describe('Parquet page-index public helpers', () => {
   test('decodes physical page statistics using logical field types', () => {
@@ -26,5 +29,24 @@ describe('Parquet page-index public helpers', () => {
       }
     } as any;
     expect(canUseParquetPageIndexForColumn(schema, columnChunk)).toBe(false);
+  });
+
+  test('extends repeated offset-index continuation pages to the next row', () => {
+    const bytes = serializeThrift(
+      new OffsetIndex({
+        page_locations: [
+          new PageLocation({offset: 10, compressed_page_size: 5, first_row_index: 0}),
+          new PageLocation({offset: 20, compressed_page_size: 5, first_row_index: 1}),
+          new PageLocation({offset: 30, compressed_page_size: 5, first_row_index: 1}),
+          new PageLocation({offset: 40, compressed_page_size: 5, first_row_index: 3})
+        ]
+      })
+    );
+    expect(decodeOffsetIndex(bytes, 4).map(page => [page.firstRowIndex, page.endRowIndex])).toEqual([
+      [0, 1],
+      [1, 3],
+      [1, 3],
+      [3, 4]
+    ]);
   });
 });


### PR DESCRIPTION
## Goals

Support valid Parquet offset indexes when a repeated logical row continues across multiple data pages, while preserving conservative page pruning and exact row reconstruction.

## Changes

- Accept non-decreasing `first_row_index` values in offset indexes.
- Extend continuation pages to the next strictly larger logical row start so all pages for a repeated row are selected together.
- Reject malformed decreasing row starts.
- Add native Vitest coverage for continuation-page normalization.
- Update the Parquet support matrix and roadmap.

## Validation

- `yarn lint fix`
- `yarn test-audit` (544 files, 0 Tape violations)
- Focused Chromium Parquet tests: 4/4 passed

This follow-up is based on current `master` after #3720 and completes the repeated-page continuation portion of the page-index tranche. Size statistics, semantic sorting pruning, and modular encryption remain separate format-completeness work.
