### PR TITLE
feat(scan): add Delta snapshot source

### DIFF
--- a/modules/parquet/package.json
+++ b/modules/parquet/package.json
@@ -71,6 +71,10 @@
       "types": "./dist/iceberg-rest-catalog.d.ts",
       "import": "./dist/iceberg-rest-catalog.js"
     },
+    "./delta-source": {
+      "types": "./dist/delta-source.d.ts",
+      "import": "./dist/delta-source.js"
+    },
     "./parquet-js-loader": {
       "types": "./dist/parquet-js-loader.d.ts",
       "import": "./dist/parquet-js-loader.js"

--- a/modules/parquet/src/delta-format.ts
+++ b/modules/parquet/src/delta-format.ts
@@ -1,0 +1,12 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** Metadata describing the Delta Lake transaction-log format. */
+export const DeltaFormat = {
+  name: 'Delta Lake',
+  id: 'delta',
+  module: 'parquet',
+  extensions: ['json', 'checkpoint.parquet'],
+  mimeTypes: ['application/json']
+};

--- a/modules/parquet/src/delta-source-loader-types.ts
+++ b/modules/parquet/src/delta-source-loader-types.ts
@@ -1,0 +1,40 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {SourceLoader} from '@loaders.gl/loader-utils';
+import {DeltaFormat} from './delta-format';
+import type {DeltaSourceOptions} from './delta-types';
+import type {DeltaTableSource} from './delta-source';
+
+// __VERSION__ is injected by babel-plugin-version-inline
+// @ts-ignore TS2304: Cannot find name '__VERSION__'.
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+
+/** Metadata-only Delta source loader options. */
+export type DeltaSourceLoaderOptions = DeltaSourceOptions;
+
+/** Loads the parser-bearing Delta source implementation on demand. */
+async function preloadDeltaSourceLoader(): Promise<SourceLoader<DeltaTableSource>> {
+  const {DeltaSourceLoaderWithParser} = await import('@loaders.gl/parquet/delta-source');
+  return DeltaSourceLoaderWithParser;
+}
+
+/** Metadata-only Delta source loader; runtime code is available through `preload()`. */
+export const DeltaSourceLoader = {
+  ...DeltaFormat,
+  dataType: null as unknown as DeltaTableSource,
+  batchType: null as never,
+  name: 'DeltaSourceLoader',
+  version: VERSION,
+  type: 'delta',
+  fromUrl: true,
+  fromBlob: true,
+  options: {},
+  defaultOptions: {},
+  testURL: (url: string): boolean =>
+    /\/_delta_log\/(?:\d{20}\.json|_last_checkpoint)(?:$|[?#])/i.test(url),
+  preload: preloadDeltaSourceLoader
+} as const satisfies Omit<SourceLoader<DeltaTableSource>, 'createDataSource'> & {
+  preload: () => Promise<SourceLoader<DeltaTableSource>>;
+};

--- a/modules/parquet/src/delta-source.ts
+++ b/modules/parquet/src/delta-source.ts
@@ -31,7 +31,7 @@ const DeltaFormat = {
   version: VERSION,
   extensions: ['json', 'checkpoint.parquet'],
   mimeTypes: ['application/json']
-} as const;
+};
 
 /** Lightweight Delta Lake snapshot source backed by a newline-delimited commit log. */
 export class DeltaTableSource

--- a/modules/parquet/src/delta-source.ts
+++ b/modules/parquet/src/delta-source.ts
@@ -19,19 +19,11 @@ import type {
   ParquetDatasetExplain,
   ParquetPredicate
 } from './parquet-source-types';
+import {DeltaFormat} from './delta-format';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
 const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
-
-const DeltaFormat = {
-  name: 'Delta Lake',
-  id: 'delta',
-  module: 'parquet',
-  version: VERSION,
-  extensions: ['json', 'checkpoint.parquet'],
-  mimeTypes: ['application/json']
-};
 
 /** Lightweight Delta Lake snapshot source backed by a newline-delimited commit log. */
 export class DeltaTableSource
@@ -58,6 +50,7 @@ export class DeltaTableSource
           uri: this.resolveDataFile(file.path),
           partitionValues: file.partitionValues,
           byteLength: file.size,
+          rowCount: getDeltaRecordCount(file.stats),
           metadata: {stats: file.stats}
         })
       )
@@ -155,13 +148,16 @@ export class DeltaTableSource
 
   private resolveDataFile(path: string): string {
     if (this.options.delta?.baseUrl) return new URL(path, this.options.delta.baseUrl).toString();
-    if (typeof this.data === 'string') return new URL(path, this.data).toString();
+    if (typeof this.data === 'string') {
+      const tableRoot = this.data.replace(/\/_delta_log\/[^/]*$/i, '/');
+      return new URL(path, tableRoot).toString();
+    }
     return path;
   }
 }
 
-/** Metadata loader for a Delta commit-log-backed table source. */
-export const DeltaSourceLoader = {
+/** Parser-bearing Delta source loader exposed through the explicit source subpath. */
+export const DeltaSourceLoaderWithParser = {
   ...DeltaFormat,
   dataType: null as unknown as DeltaTableSource,
   batchType: null as never,
@@ -172,10 +168,31 @@ export const DeltaSourceLoader = {
   fromBlob: true,
   options: {},
   defaultOptions: {},
-  testURL: (url: string): boolean => /(?:_delta_log|\.jsonl?)(?:$|[?#])/i.test(url),
+  testURL: (url: string): boolean =>
+    /\/_delta_log\/(?:\d{20}\.json|_last_checkpoint)(?:$|[?#])/i.test(url),
   createDataSource: (data: string | Blob, options: DeltaSourceOptions = {}): DeltaTableSource =>
     new DeltaTableSource(data, options)
 } as const satisfies SourceLoader<DeltaTableSource>;
+
+/** Extracts Delta's optional `numRecords` statistic from an add action. */
+function getDeltaRecordCount(
+  stats: string | Readonly<Record<string, unknown>> | undefined
+): number | undefined {
+  const parsed = typeof stats === 'string' ? parseDeltaStats(stats) : stats;
+  const value = parsed?.numRecords;
+  return typeof value === 'number' && Number.isSafeInteger(value) ? value : undefined;
+}
+
+function parseDeltaStats(stats: string): Readonly<Record<string, unknown>> | undefined {
+  try {
+    const value: unknown = JSON.parse(stats);
+    return value && typeof value === 'object'
+      ? (value as Readonly<Record<string, unknown>>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 function selectActiveDeltaFiles(
   actions: readonly DeltaAction[]

--- a/modules/parquet/src/delta-source.ts
+++ b/modules/parquet/src/delta-source.ts
@@ -1,0 +1,189 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {
+  ScanFragment,
+  ScanFragmentProvider,
+  ScanQueryMetadata,
+  ScanQueryMetadataOptions,
+  TableScanSource,
+  SourceLoader
+} from '@loaders.gl/loader-utils';
+import {createScanQueryMetadata, DataSource} from '@loaders.gl/loader-utils';
+import {ParquetDatasetSource} from './parquet-dataset-source';
+import {PARQUET_TABLE_QUERY_CAPABILITIES} from './parquet-source-capabilities';
+import type {DeltaAction, DeltaScanOptions, DeltaSourceOptions} from './delta-types';
+import type {
+  ParquetDatasetBatch,
+  ParquetDatasetExplain,
+  ParquetPredicate
+} from './parquet-source-types';
+
+// __VERSION__ is injected by babel-plugin-version-inline
+// @ts-ignore TS2304: Cannot find name '__VERSION__'.
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+
+const DeltaFormat = {
+  name: 'Delta Lake',
+  id: 'delta',
+  module: 'parquet',
+  version: VERSION,
+  extensions: ['json', 'checkpoint.parquet'],
+  mimeTypes: ['application/json']
+} as const;
+
+/** Lightweight Delta Lake snapshot source backed by a newline-delimited commit log. */
+export class DeltaTableSource
+  extends DataSource<string | Blob, DeltaSourceOptions>
+  implements
+    TableScanSource<ParquetDatasetBatch, ParquetPredicate>,
+    ScanFragmentProvider<ParquetPredicate>
+{
+  private actionsPromise: Promise<readonly DeltaAction[]> | null = null;
+
+  /** Creates a source from a Delta commit JSON URL or Blob. */
+  constructor(data: string | Blob, options: DeltaSourceOptions = {}) {
+    super(data, options);
+  }
+
+  /** Discovers the active Parquet files represented by the commit log. */
+  async getScanFragments(options: DeltaScanOptions = {}): Promise<readonly ScanFragment[]> {
+    const actions = await this.getActions(options.signal);
+    const activeFiles = selectActiveDeltaFiles(actions);
+    return Object.freeze(
+      activeFiles.map(file =>
+        Object.freeze({
+          id: file.path,
+          uri: this.resolveDataFile(file.path),
+          partitionValues: file.partitionValues,
+          byteLength: file.size,
+          metadata: {stats: file.stats}
+        })
+      )
+    );
+  }
+
+  /** Discovers schema and snapshot statistics without decoding all rows. */
+  async getQueryMetadata(options: ScanQueryMetadataOptions = {}): Promise<ScanQueryMetadata> {
+    const fragments = await this.getScanFragments(options);
+    if (!fragments.length) {
+      throw new Error('Delta snapshot contains no active Parquet files');
+    }
+    const dataset = this.createDataset(fragments);
+    const schema = await dataset.getSchema({signal: options.signal});
+    return createScanQueryMetadata({
+      sourceType: 'delta',
+      queryType: 'table',
+      name: this.data instanceof Blob ? undefined : this.data,
+      schema,
+      capabilities: {table: PARQUET_TABLE_QUERY_CAPABILITIES},
+      statistics: {
+        rowCount: fragments.reduce((total, fragment) => total + Number(fragment.rowCount || 0), 0),
+        byteLength: fragments.reduce(
+          (total, fragment) => total + Number(fragment.byteLength || 0),
+          0
+        )
+      }
+    });
+  }
+
+  /** Explains the Delta snapshot and delegated Parquet physical plans. */
+  async getScanPlan(options: DeltaScanOptions = {}): Promise<ParquetDatasetExplain> {
+    return this.createDataset(await this.getScanFragments(options)).getScanPlan(options);
+  }
+
+  /** Reads the active snapshot through the shared Parquet dataset executor. */
+  read(options: DeltaScanOptions = {}): AsyncIterable<ParquetDatasetBatch> {
+    return this.createDatasetFromOptions(options).read(options);
+  }
+
+  /** Alias for `read()` used by scan-aware consumers. */
+  scan(options: DeltaScanOptions = {}): AsyncIterable<ParquetDatasetBatch> {
+    return this.read(options);
+  }
+
+  private async getActions(signal?: AbortSignal): Promise<readonly DeltaAction[]> {
+    if (!this.actionsPromise) {
+      this.actionsPromise = (async () => {
+        const text =
+          typeof this.data === 'string'
+            ? await this.readResponse(await this.fetch(this.url, {signal}))
+            : await this.data.text();
+        return Object.freeze(
+          text
+            .split(/\r?\n/)
+            .filter(Boolean)
+            .map(line => JSON.parse(line) as DeltaAction)
+        );
+      })();
+    }
+    return this.actionsPromise;
+  }
+
+  private async readResponse(response: Response): Promise<string> {
+    if (!response.ok)
+      throw new Error(`Delta commit log request failed with status ${response.status}`);
+    return response.text();
+  }
+
+  private createDataset(fragments: readonly ScanFragment[]): ParquetDatasetSource {
+    return new ParquetDatasetSource(
+      fragments.map(fragment => ({
+        data: fragment.uri!,
+        id: fragment.id,
+        partitions: fragment.partitionValues as never,
+        metadata: fragment.metadata
+      })),
+      this.options
+    );
+  }
+
+  private createDatasetFromOptions(options: DeltaScanOptions): ParquetDatasetSource {
+    return new ParquetDatasetSource(
+      () =>
+        this.getScanFragments(options).then(fragments =>
+          fragments.map(fragment => ({
+            data: fragment.uri!,
+            id: fragment.id,
+            partitions: fragment.partitionValues as never
+          }))
+        ),
+      this.options
+    );
+  }
+
+  private resolveDataFile(path: string): string {
+    if (this.options.delta?.baseUrl) return new URL(path, this.options.delta.baseUrl).toString();
+    if (typeof this.data === 'string') return new URL(path, this.data).toString();
+    return path;
+  }
+}
+
+/** Metadata loader for a Delta commit-log-backed table source. */
+export const DeltaSourceLoader = {
+  ...DeltaFormat,
+  dataType: null as unknown as DeltaTableSource,
+  batchType: null as never,
+  name: 'DeltaSourceLoader',
+  version: VERSION,
+  type: 'delta',
+  fromUrl: true,
+  fromBlob: true,
+  options: {},
+  defaultOptions: {},
+  testURL: (url: string): boolean => /(?:_delta_log|\.jsonl?)(?:$|[?#])/i.test(url),
+  createDataSource: (data: string | Blob, options: DeltaSourceOptions = {}): DeltaTableSource =>
+    new DeltaTableSource(data, options)
+} as const satisfies SourceLoader<DeltaTableSource>;
+
+function selectActiveDeltaFiles(
+  actions: readonly DeltaAction[]
+): Array<NonNullable<DeltaAction['add']>> {
+  const files = new Map<string, NonNullable<DeltaAction['add']>>();
+  for (const action of actions) {
+    if (action.add) files.set(action.add.path, action.add);
+    if (action.remove) files.delete(action.remove.path);
+  }
+  return [...files.values()];
+}

--- a/modules/parquet/src/delta-types.ts
+++ b/modules/parquet/src/delta-types.ts
@@ -1,0 +1,24 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {ParquetDatasetSourceOptions, ParquetDatasetReadOptions} from './parquet-source-types';
+
+/** One Delta Lake transaction action from a commit log or checkpoint projection. */
+export type DeltaAction = Readonly<{
+  add?: Readonly<{
+    path: string;
+    size?: number;
+    partitionValues?: Readonly<Record<string, string | null>>;
+    stats?: string | Readonly<Record<string, unknown>>;
+  }>;
+  remove?: Readonly<{path: string}>;
+}>;
+
+/** Options for reading one Delta commit log as a snapshot. */
+export type DeltaSourceOptions = ParquetDatasetSourceOptions & {
+  delta?: {version?: number; baseUrl?: string};
+};
+
+/** Query options accepted by a Delta snapshot scan. */
+export type DeltaScanOptions = ParquetDatasetReadOptions & {version?: number};

--- a/modules/parquet/src/index.ts
+++ b/modules/parquet/src/index.ts
@@ -33,7 +33,8 @@ export type {
 } from './iceberg-types';
 export {IcebergTableSource} from './iceberg-table-source';
 export type {IcebergScanOptions, IcebergSourceOptions} from './iceberg-table-source';
-export {DeltaSourceLoader, DeltaTableSource} from './delta-source';
+export {DeltaSourceLoader} from './delta-source-loader-types';
+export type {DeltaSourceLoaderOptions} from './delta-source-loader-types';
 export type {DeltaAction, DeltaScanOptions, DeltaSourceOptions} from './delta-types';
 export {IcebergRestCatalog} from './iceberg-rest-catalog';
 export type {

--- a/modules/parquet/src/index.ts
+++ b/modules/parquet/src/index.ts
@@ -33,6 +33,8 @@ export type {
 } from './iceberg-types';
 export {IcebergTableSource} from './iceberg-table-source';
 export type {IcebergScanOptions, IcebergSourceOptions} from './iceberg-table-source';
+export {DeltaSourceLoader, DeltaTableSource} from './delta-source';
+export type {DeltaAction, DeltaScanOptions, DeltaSourceOptions} from './delta-types';
 export {IcebergRestCatalog} from './iceberg-rest-catalog';
 export type {
   IcebergRestCatalogOptions,

--- a/modules/parquet/test/delta-source.spec.ts
+++ b/modules/parquet/test/delta-source.spec.ts
@@ -7,7 +7,7 @@ import {DeltaSourceLoader, DeltaTableSource} from '../src/delta-source';
 
 test('DeltaTableSource selects active files from commit actions', async () => {
   const log = [
-    JSON.stringify({add: {path: 'part-0.parquet', size: 120, partitionValues: {year: '2024'}}}),
+    JSON.stringify({add: {path: 'part-0.parquet', size: 120, partitionValues: {year: '2024'}, stats: JSON.stringify({numRecords: 3})}}),
     JSON.stringify({add: {path: 'part-1.parquet', size: 80}}),
     JSON.stringify({remove: {path: 'part-0.parquet'}})
   ].join('\n');
@@ -17,6 +17,25 @@ test('DeltaTableSource selects active files from commit actions', async () => {
   ]);
 });
 
+test('DeltaTableSource resolves commit URLs relative to the table root', async () => {
+  const log = JSON.stringify({add: {path: 'part-0.parquet', size: 12, stats: {numRecords: 4}}});
+  const source = new DeltaTableSource('https://example.com/table/_delta_log/00000000000000000001.json', {
+    core: {loadOptions: {core: {fetch: async () => new Response(log)}}}
+  });
+  await expect(source.getScanFragments()).resolves.toEqual([
+    expect.objectContaining({
+      uri: 'https://example.com/table/part-0.parquet',
+      rowCount: 4,
+      byteLength: 12
+    })
+  ]);
+});
+
 test('DeltaSourceLoader identifies commit-log URLs', () => {
-  expect(DeltaSourceLoader.testURL('https://example.com/table/_delta_log/000.json')).toBe(true);
+  expect(
+    DeltaSourceLoader.testURL(
+      'https://example.com/table/_delta_log/00000000000000000001.json'
+    )
+  ).toBe(true);
+  expect(DeltaSourceLoader.testURL('https://example.com/data.json')).toBe(false);
 });

--- a/modules/parquet/test/delta-source.spec.ts
+++ b/modules/parquet/test/delta-source.spec.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {expect, test} from 'vitest';
-import {DeltaSourceLoader, DeltaTableSource} from '../src/delta-source';
+import {DeltaSourceLoaderWithParser, DeltaTableSource} from '../src/delta-source';
 
 test('DeltaTableSource selects active files from commit actions', async () => {
   const log = [
@@ -33,9 +33,9 @@ test('DeltaTableSource resolves commit URLs relative to the table root', async (
 
 test('DeltaSourceLoader identifies commit-log URLs', () => {
   expect(
-    DeltaSourceLoader.testURL(
+    DeltaSourceLoaderWithParser.testURL(
       'https://example.com/table/_delta_log/00000000000000000001.json'
     )
   ).toBe(true);
-  expect(DeltaSourceLoader.testURL('https://example.com/data.json')).toBe(false);
+  expect(DeltaSourceLoaderWithParser.testURL('https://example.com/data.json')).toBe(false);
 });

--- a/modules/parquet/test/delta-source.spec.ts
+++ b/modules/parquet/test/delta-source.spec.ts
@@ -1,0 +1,22 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import {DeltaSourceLoader, DeltaTableSource} from '../src/delta-source';
+
+test('DeltaTableSource selects active files from commit actions', async () => {
+  const log = [
+    JSON.stringify({add: {path: 'part-0.parquet', size: 120, partitionValues: {year: '2024'}}}),
+    JSON.stringify({add: {path: 'part-1.parquet', size: 80}}),
+    JSON.stringify({remove: {path: 'part-0.parquet'}})
+  ].join('\n');
+  const source = new DeltaTableSource(new Blob([log]), {delta: {baseUrl: 'https://example.com/table/'}});
+  await expect(source.getScanFragments()).resolves.toEqual([
+    expect.objectContaining({id: 'part-1.parquet', uri: 'https://example.com/table/part-1.parquet'})
+  ]);
+});
+
+test('DeltaSourceLoader identifies commit-log URLs', () => {
+  expect(DeltaSourceLoader.testURL('https://example.com/table/_delta_log/000.json')).toBe(true);
+});


### PR DESCRIPTION
## Goals

Add the next catalog-aware scan tranche for Delta Lake, reusing the common fragment contract and Parquet dataset executor.

## Changes

- Add `DeltaTableSource` for newline-delimited Delta commit logs.
- Track active `add` files and apply `remove` actions.
- Expose `getScanFragments()`, `getQueryMetadata()`, `getScanPlan()`, `read()`, and `scan()`.
- Delegate physical reads to `ParquetDatasetSource`.
- Add `DeltaSourceLoader` metadata and public Delta types.
- Add focused active-file and loader detection tests.

This is intentionally a lightweight first tranche; checkpoint parsing, full log version discovery, and deletion-vector application remain follow-up work.

## Validation

- `yarn lint fix`
- `yarn build` (type issue found and fixed in follow-up commit)
