### PR TITLE
feat(copc): production-harden writer hierarchy

### DIFF
--- a/docs/modules/copc/api-reference/copc-writer.md
+++ b/docs/modules/copc/api-reference/copc-writer.md
@@ -4,7 +4,6 @@ import {CopcDocsTabs} from '@site/src/components/docs/copc-docs-tabs';
 
 <p class="badges">
   <img src="https://img.shields.io/badge/From-v5.0-blue.svg?style=flat-square" alt="From-v5.0" />
-  <img src="https://img.shields.io/badge/Status-Experimental-orange.svg?style=flat-square" alt="Status: Experimental" />
 </p>
 
 <CopcDocsTabs active="writer" />
@@ -28,9 +27,11 @@ const arrayBuffer = await encode(pointCloud, COPCWriter, {
 
 ## Data Organization
 
-The writer first converts supported mesh attributes to LAS 1.4 point records, then assigns every point to exactly one octree level. Parent nodes retain a deterministic level-of-detail sample and remaining points are partitioned into child octants. Each point-bearing node is encoded as an independent LAZ chunk and listed in a single hierarchy EVLR.
+The writer first converts supported mesh attributes to LAS 1.4 point records, then assigns every point to exactly one octree level. Parent nodes retain a deterministic level-of-detail sample and remaining points are partitioned into child octants. Each point-bearing node is encoded as an independent LAZ chunk. The hierarchy EVLR is divided into range-readable pages, with absolute child-page references from each parent page.
 
-The writer emits PDRF 6, 7, or 8 with LASzip layered compressor 3, arithmetic coder 0, and item version 3. `POSITION` is required. `COLOR_0`, `intensity`, and `classification` are written when present; other LAS fields are zero-filled. A coordinate reference system is emitted only when `copc.wkt` is supplied.
+The writer emits PDRF 6, 7, or 8 with LASzip layered compressor 3, arithmetic coder 0, and item version 3. `POSITION` is required. Represented LAS attributes such as RGB, NIR, GPS time, intensity, classification, return fields, scanner metadata, and classification flags are written when present; missing fields are zero-filled. A coordinate reference system is emitted only when `copc.wkt` is supplied.
+
+Generated files are exercised through both the native TypeScript reader and the independent `copc` implementation. PDRF 6, 7, and 8 node chunks are covered, including NIR, GPS bounds, deep sparse octrees, and recursively range-loaded hierarchy pages.
 
 ## Options
 
@@ -38,9 +39,12 @@ The writer emits PDRF 6, 7, or 8 with LASzip layered compressor 3, arithmetic co
 | --- | --- | --- | --- |
 | `copc.nodePointLimit` | `number` | `50000` | Target maximum number of points retained at each octree node. A node at `maximumDepth` may exceed the target. |
 | `copc.maximumDepth` | `number` | `16` | Maximum octree depth, from 0 through 30. |
+| `copc.hierarchyPageDepth` | `number` | `3` | Number of octree levels represented in each hierarchy page. Smaller values produce more, smaller range requests. |
 | `copc.pointDataRecordFormat` | `6 \| 7 \| 8` | Derived | LAS 1.4 point layout. The default is 7 when `COLOR_0` is present and 6 otherwise. |
 | `copc.scale` | `[number, number, number]` | `[0.001, 0.001, 0.001]` | Coordinate quantization scale factors. |
 | `copc.offset` | `[number, number, number]` | Data minimum | Coordinate quantization offsets. |
 | `copc.spacing` | `number` | Cube width divided by 128 | Root point spacing stored in the COPC info VLR. |
 | `copc.wkt` | `string` | - | Optional OGC WKT coordinate reference system. |
 | `copc.colorDepth` | `number \| string` | - | Declares the source color component depth. |
+
+The COPC info VLR records the finite minimum and maximum GPS times written to the point records. Inputs without finite GPS times use `[0, 0]`.

--- a/docs/modules/copc/formats/copc.md
+++ b/docs/modules/copc/formats/copc.md
@@ -33,7 +33,7 @@ The primary `@loaders.gl/copc` implementation is TypeScript-only. It does not re
 | Selective field decoding | **Full** | Unrequested LAZ field layers are skipped, avoiding arithmetic decoder state, output arrays, and point traversal for those fields. |
 | Progressive node decoding | **Full at layer boundaries** | Node byte ranges are fed incrementally. Rows are emitted when all compressed layers required by the requested columns are available. |
 | Cancellation | **Full** | Abort signals are checked during hierarchy traversal, range loading, and progressive point decoding. |
-| COPC writing | **Experimental** | Writes LAS 1.4 PDRF 6-8, variable LAZ chunks, a version 0 chunk table, COPC info VLR, and hierarchy EVLR. |
+| COPC writing | **Full for represented attributes** | Writes LAS 1.4 PDRF 6-8, variable LAZ chunks, a version 0 chunk table, COPC info VLR, and a range-pageable hierarchy EVLR. |
 | Waveform PDRF 9/10 | **Not part of COPC 1.0** | COPC 1.0 permits only PDRF 6, 7, and 8. |
 
 ### Arrow Columns
@@ -86,4 +86,4 @@ Key aspects distinguish an organized COPC LAZ file from an LAZ 1.4 that is unorg
 - It MUST contain a COPC info VLR
 - It MUST contain a COPC hierarchy VLR or EVLR
 
-`COPCWriter` emits LAS 1.4 PDRF 6-8 data with the COPC info VLR, variable-size LASzip chunks, a version 0 variable chunk table, and a single hierarchy EVLR. Points are sampled deterministically into parent levels and remaining points are partitioned spatially into child octants.
+`COPCWriter` emits LAS 1.4 PDRF 6-8 data with the COPC info VLR, variable-size LASzip chunks, a version 0 variable chunk table, and a hierarchy EVLR split into independently range-readable pages. Points are sampled deterministically into parent levels and remaining points are partitioned spatially into child octants. The info VLR publishes only the root page range; entries with a point count of `-1` reference descendant page ranges.

--- a/docs/modules/las/formats/las.md
+++ b/docs/modules/las/formats/las.md
@@ -134,7 +134,7 @@ Dedicated PDRF 4-10 fixtures compare every raw decoded byte and every represente
 | Point decoding | Supported for COPC nodes using LAZ 1.4 PDRF 6, 7, or 8. |
 | Render attribute output | Positions, RGB, NIR, intensity, classification, GPS time, scan angle, and point source ID decode directly into Arrow buffers. Unrequested layers are skipped. |
 | Progressive point output while range data arrives | Implemented at layered LAZ readiness boundaries. Position-only rows can arrive before RGB and NIR layers. |
-| COPC writer | Experimental `COPCWriter` output includes range-readable LAZ node chunks, a variable chunk table, COPC info, and a hierarchy EVLR. |
+| COPC writer | `COPCWriter` output includes range-readable LAZ node chunks, a variable chunk table, COPC info, and a paged hierarchy EVLR. |
 
 ## Version History
 

--- a/modules/copc/package.json
+++ b/modules/copc/package.json
@@ -49,5 +49,8 @@
     "@loaders.gl/schema-utils": "5.0.0-alpha.2",
     "@math.gl/proj4": "^4.1.0"
   },
+  "devDependencies": {
+    "copc": "0.0.8"
+  },
   "gitHead": "c95a4ff72512668a93d9041ce8636bac09333fd5"
 }

--- a/modules/copc/src/copc-source-loader.ts
+++ b/modules/copc/src/copc-source-loader.ts
@@ -837,9 +837,9 @@ export class COPCTileSource
       return this._hierarchy.nodes[tileId];
     }
 
-    const parentKeys = this.getAncestorKeys(tileId);
-    for (const parentKey of parentKeys) {
-      await this.ensureHierarchyLoaded(parentKey);
+    const hierarchyKeys = [...this.getAncestorKeys(tileId).reverse(), tileId];
+    for (const hierarchyKey of hierarchyKeys) {
+      await this.ensureHierarchyLoaded(hierarchyKey);
       if (this._hierarchy.nodes[tileId]) {
         return this._hierarchy.nodes[tileId];
       }

--- a/modules/copc/src/copc-writer.ts
+++ b/modules/copc/src/copc-writer.ts
@@ -25,6 +25,7 @@ const HIERARCHY_ENTRY_LENGTH = 32;
 const VARIABLE_LAZ_CHUNK_SIZE = 0xffffffff;
 const DEFAULT_NODE_POINT_LIMIT = 50_000;
 const DEFAULT_MAXIMUM_DEPTH = 16;
+const DEFAULT_HIERARCHY_PAGE_DEPTH = 3;
 
 /** Options for `COPCWriter`. */
 export type COPCWriterOptions = WriterOptions & {
@@ -33,6 +34,8 @@ export type COPCWriterOptions = WriterOptions & {
     nodePointLimit?: number;
     /** Maximum octree depth used when points remain spatially coincident. */
     maximumDepth?: number;
+    /** Number of octree levels represented by each hierarchy page. */
+    hierarchyPageDepth?: number;
     /** LAS point data record format. */
     pointDataRecordFormat?: 6 | 7 | 8;
     /** Coordinate scale factors used to quantize positions. */
@@ -66,7 +69,8 @@ export const COPCWriter = {
 function encodeCOPCSync(data: Mesh | MeshArrowTable, options: COPCWriterOptions = {}): ArrayBuffer {
   const nodePointLimit = options.copc?.nodePointLimit ?? DEFAULT_NODE_POINT_LIMIT;
   const maximumDepth = options.copc?.maximumDepth ?? DEFAULT_MAXIMUM_DEPTH;
-  validateOptions(nodePointLimit, maximumDepth, options.copc?.spacing);
+  const hierarchyPageDepth = options.copc?.hierarchyPageDepth ?? DEFAULT_HIERARCHY_PAGE_DEPTH;
+  validateOptions(nodePointLimit, maximumDepth, hierarchyPageDepth, options.copc?.spacing);
 
   const rawLAS = encodeRawLAS(data, options);
   if (rawLAS.pointCount === 0) {
@@ -111,8 +115,8 @@ function encodeCOPCSync(data: Mesh | MeshArrowTable, options: COPCWriterOptions 
   const chunkTableOffset = pointDataByteOffset;
   const evlrOffset = chunkTableOffset + 8 + chunkTablePayload.byteLength;
   const hierarchyOffset = evlrOffset + EVLR_HEADER_LENGTH;
-  const hierarchyPayload = encodeHierarchy(nodes);
-  const hierarchyEVLR = encodeEVLR('copc', 1000, 'COPC hierarchy', hierarchyPayload);
+  const hierarchy = encodeHierarchyPages(nodes, hierarchyOffset, hierarchyPageDepth);
+  const hierarchyEVLR = encodeEVLR('copc', 1000, 'COPC hierarchy', hierarchy.payload);
   const spacing =
     options.copc?.spacing ||
     Math.max((cube[3] - cube[0]) / 128, rawLAS.scale[0], rawLAS.scale[1], rawLAS.scale[2]);
@@ -120,7 +124,13 @@ function encodeCOPCSync(data: Mesh | MeshArrowTable, options: COPCWriterOptions 
     'copc',
     1,
     'COPC info VLR',
-    encodeCOPCInfo(cube, spacing, hierarchyOffset, hierarchyPayload.byteLength)
+    encodeCOPCInfo(
+      cube,
+      spacing,
+      hierarchyOffset,
+      hierarchy.rootPageByteLength,
+      rawLAS.gpsTimeRange
+    )
   );
   const vlrs = [infoVLR, laszipVLR, ...(wktVLR ? [wktVLR] : [])];
   const arrayBuffer = new ArrayBuffer(evlrOffset + hierarchyEVLR.byteLength);
@@ -171,6 +181,8 @@ type RawLASData = {
   offset: [number, number, number];
   /** Data bounds as minimum and maximum coordinates. */
   bounds: Bounds3D;
+  /** Minimum and maximum GPS time stored in the point records. */
+  gpsTimeRange: [number, number];
 };
 
 /** Six-value axis-aligned 3D bounds. */
@@ -191,6 +203,20 @@ type COPCNode = {
   compressed: Uint8Array;
   /** Absolute file offset of the compressed chunk. */
   pointDataOffset: number;
+};
+
+/** One independently range-readable COPC hierarchy page. */
+type COPCHierarchyOutputPage = {
+  /** Key of the page's root node. */
+  key: COPCKey;
+  /** Point nodes encoded directly in this page. */
+  nodes: COPCNode[];
+  /** Descendant pages referenced by this page. */
+  children: COPCHierarchyOutputPage[];
+  /** Absolute file byte offset assigned during layout. */
+  byteOffset: number;
+  /** Encoded page byte length. */
+  byteLength: number;
 };
 
 /** State shared while recursively partitioning point indices. */
@@ -247,6 +273,7 @@ function encodeRawLAS(data: Mesh | MeshArrowTable, options: COPCWriterOptions): 
   );
   const header = new Uint8Array(arrayBuffer, 0, LAS_1_4_HEADER_LENGTH).slice();
   writeBounds(new DataView(header.buffer), bounds);
+  const gpsTimeRange = calculateGpsTimeRange(pointData, pointCount, pointDataRecordLength);
   return {
     header,
     pointData,
@@ -255,8 +282,28 @@ function encodeRawLAS(data: Mesh | MeshArrowTable, options: COPCWriterOptions): 
     pointDataRecordLength,
     scale,
     offset,
-    bounds
+    bounds,
+    gpsTimeRange
   };
+}
+
+/** Calculate the finite GPS time range stored by modern LAS point records. */
+function calculateGpsTimeRange(
+  pointData: Uint8Array,
+  pointCount: number,
+  pointDataRecordLength: number
+): [number, number] {
+  const dataView = new DataView(pointData.buffer, pointData.byteOffset, pointData.byteLength);
+  let minimum = Infinity;
+  let maximum = -Infinity;
+  for (let pointIndex = 0; pointIndex < pointCount; pointIndex++) {
+    const gpsTime = dataView.getFloat64(pointIndex * pointDataRecordLength + 22, true);
+    if (Number.isFinite(gpsTime)) {
+      minimum = Math.min(minimum, gpsTime);
+      maximum = Math.max(maximum, gpsTime);
+    }
+  }
+  return minimum === Infinity ? [0, 0] : [minimum, maximum];
 }
 
 /** Compute bounds from the quantized coordinates stored in raw LAS records. */
@@ -448,21 +495,120 @@ function compressNodes(nodes: COPCNode[], rawLAS: RawLASData): void {
   }
 }
 
-/** Encode a single-page COPC hierarchy. */
-function encodeHierarchy(nodes: COPCNode[]): Uint8Array {
-  const sortedNodes = [...nodes].sort((left, right) => compareKeys(left.key, right.key));
-  const bytes = new Uint8Array(sortedNodes.length * HIERARCHY_ENTRY_LENGTH);
+/** Encode a hierarchy as a tree of independently range-readable pages. */
+function encodeHierarchyPages(
+  nodes: COPCNode[],
+  hierarchyOffset: number,
+  hierarchyPageDepth: number
+): {payload: Uint8Array; rootPageByteLength: number} {
+  const rootPage = createHierarchyPage(nodes, 0, hierarchyPageDepth);
+  const pages: COPCHierarchyOutputPage[] = [];
+  appendHierarchyPages(rootPage, pages);
+
+  let byteOffset = hierarchyOffset;
+  for (const page of pages) {
+    page.byteOffset = byteOffset;
+    page.byteLength = (page.nodes.length + page.children.length) * HIERARCHY_ENTRY_LENGTH;
+    byteOffset += page.byteLength;
+  }
+
+  const payload = new Uint8Array(byteOffset - hierarchyOffset);
+  for (const page of pages) {
+    payload.set(encodeHierarchyPage(page), page.byteOffset - hierarchyOffset);
+  }
+  return {payload, rootPageByteLength: rootPage.byteLength};
+}
+
+/** Partition one hierarchy subtree into a page and descendant pages. */
+function createHierarchyPage(
+  nodes: COPCNode[],
+  rootDepth: number,
+  hierarchyPageDepth: number
+): COPCHierarchyOutputPage {
+  const boundaryDepth = rootDepth + hierarchyPageDepth;
+  const pageNodes: COPCNode[] = [];
+  const childNodeGroups = new Map<string, {key: COPCKey; nodes: COPCNode[]}>();
+
+  for (const node of nodes) {
+    if (node.key[0] < boundaryDepth) {
+      pageNodes.push(node);
+      continue;
+    }
+    const childPageKey = getAncestorKey(node.key, boundaryDepth);
+    const childPageId = childPageKey.join('-');
+    let group = childNodeGroups.get(childPageId);
+    if (!group) {
+      group = {key: childPageKey, nodes: []};
+      childNodeGroups.set(childPageId, group);
+    }
+    group.nodes.push(node);
+  }
+
+  const childGroups = [...childNodeGroups.values()].sort((left, right) =>
+    compareKeys(left.key, right.key)
+  );
+  return {
+    key: getAncestorKey(nodes[0].key, rootDepth),
+    nodes: pageNodes.sort((left, right) => compareKeys(left.key, right.key)),
+    children: childGroups.map(group =>
+      createHierarchyPage(group.nodes, boundaryDepth, hierarchyPageDepth)
+    ),
+    byteOffset: 0,
+    byteLength: 0
+  };
+}
+
+/** Return the ancestor of an octree key at the requested depth. */
+function getAncestorKey(key: COPCKey, depth: number): COPCKey {
+  const shift = key[0] - depth;
+  const divisor = 2 ** shift;
+  return [
+    depth,
+    Math.floor(key[1] / divisor),
+    Math.floor(key[2] / divisor),
+    Math.floor(key[3] / divisor)
+  ];
+}
+
+/** Flatten hierarchy pages in deterministic root-first order. */
+function appendHierarchyPages(
+  page: COPCHierarchyOutputPage,
+  pages: COPCHierarchyOutputPage[]
+): void {
+  pages.push(page);
+  for (const child of page.children) {
+    appendHierarchyPages(child, pages);
+  }
+}
+
+/** Encode one hierarchy page, including references to descendant pages. */
+function encodeHierarchyPage(page: COPCHierarchyOutputPage): Uint8Array {
+  const entries: Array<
+    | {key: COPCKey; node: COPCNode; child?: never}
+    | {key: COPCKey; node?: never; child: COPCHierarchyOutputPage}
+  > = [
+    ...page.nodes.map(node => ({key: node.key, node})),
+    ...page.children.map(child => ({key: child.key, child}))
+  ];
+  entries.sort((left, right) => compareKeys(left.key, right.key));
+  const bytes = new Uint8Array(entries.length * HIERARCHY_ENTRY_LENGTH);
   const dataView = new DataView(bytes.buffer);
-  for (let nodeIndex = 0; nodeIndex < sortedNodes.length; nodeIndex++) {
-    const node = sortedNodes[nodeIndex];
-    const byteOffset = nodeIndex * HIERARCHY_ENTRY_LENGTH;
-    dataView.setInt32(byteOffset, node.key[0], true);
-    dataView.setInt32(byteOffset + 4, node.key[1], true);
-    dataView.setInt32(byteOffset + 8, node.key[2], true);
-    dataView.setInt32(byteOffset + 12, node.key[3], true);
-    writeUint64(dataView, byteOffset + 16, node.pointDataOffset);
-    dataView.setInt32(byteOffset + 24, node.compressed.byteLength, true);
-    dataView.setInt32(byteOffset + 28, node.pointIndices.length, true);
+  for (let entryIndex = 0; entryIndex < entries.length; entryIndex++) {
+    const entry = entries[entryIndex];
+    const byteOffset = entryIndex * HIERARCHY_ENTRY_LENGTH;
+    dataView.setInt32(byteOffset, entry.key[0], true);
+    dataView.setInt32(byteOffset + 4, entry.key[1], true);
+    dataView.setInt32(byteOffset + 8, entry.key[2], true);
+    dataView.setInt32(byteOffset + 12, entry.key[3], true);
+    if (entry.node) {
+      writeUint64(dataView, byteOffset + 16, entry.node.pointDataOffset);
+      dataView.setInt32(byteOffset + 24, entry.node.compressed.byteLength, true);
+      dataView.setInt32(byteOffset + 28, entry.node.pointIndices.length, true);
+    } else {
+      writeUint64(dataView, byteOffset + 16, entry.child.byteOffset);
+      dataView.setInt32(byteOffset + 24, entry.child.byteLength, true);
+      dataView.setInt32(byteOffset + 28, -1, true);
+    }
   }
   return bytes;
 }
@@ -482,7 +628,8 @@ function encodeCOPCInfo(
   cube: Bounds3D,
   spacing: number,
   hierarchyOffset: number,
-  hierarchyByteLength: number
+  hierarchyByteLength: number,
+  gpsTimeRange: [number, number]
 ): Uint8Array {
   const bytes = new Uint8Array(COPC_INFO_PAYLOAD_LENGTH);
   const dataView = new DataView(bytes.buffer);
@@ -493,8 +640,8 @@ function encodeCOPCInfo(
   dataView.setFloat64(32, spacing, true);
   writeUint64(dataView, 40, hierarchyOffset);
   writeUint64(dataView, 48, hierarchyByteLength);
-  dataView.setFloat64(56, 0, true);
-  dataView.setFloat64(64, 0, true);
+  dataView.setFloat64(56, gpsTimeRange[0], true);
+  dataView.setFloat64(64, gpsTimeRange[1], true);
   return bytes;
 }
 
@@ -555,12 +702,20 @@ function createCube(bounds: Bounds3D, minimumWidth: number): Bounds3D {
 }
 
 /** Validate COPC organization options. */
-function validateOptions(nodePointLimit: number, maximumDepth: number, spacing?: number): void {
+function validateOptions(
+  nodePointLimit: number,
+  maximumDepth: number,
+  hierarchyPageDepth: number,
+  spacing?: number
+): void {
   if (!Number.isInteger(nodePointLimit) || nodePointLimit <= 0 || nodePointLimit > 0x7fffffff) {
     throw new Error(`COPCWriter: invalid node point limit ${nodePointLimit}`);
   }
   if (!Number.isInteger(maximumDepth) || maximumDepth < 0 || maximumDepth > 30) {
     throw new Error(`COPCWriter: invalid maximum depth ${maximumDepth}`);
+  }
+  if (!Number.isInteger(hierarchyPageDepth) || hierarchyPageDepth < 1 || hierarchyPageDepth > 30) {
+    throw new Error(`COPCWriter: invalid hierarchy page depth ${hierarchyPageDepth}`);
   }
   if (spacing !== undefined && (!Number.isFinite(spacing) || spacing <= 0)) {
     throw new Error(`COPCWriter: invalid spacing ${spacing}`);

--- a/modules/copc/test/copc-source.spec.ts
+++ b/modules/copc/test/copc-source.spec.ts
@@ -464,6 +464,7 @@ vitestTest('COPCWriter writes range-readable hierarchy pages and GPS bounds', as
     return new Uint8Array(await blob.slice(begin, end).arrayBuffer());
   };
   const copc = await openCOPC(getter);
+  const rootHierarchy = await loadCOPCHierarchyPage(getter, copc.info.rootHierarchyPage);
   const hierarchy = await loadCompleteHierarchy(getter, copc.info.rootHierarchyPage);
 
   expect(hierarchy.pageCount).toBeGreaterThan(1);
@@ -476,6 +477,19 @@ vitestTest('COPCWriter writes range-readable hierarchy pages and GPS bounds', as
     copc.info.rootHierarchyPage.pageOffset,
     copc.info.rootHierarchyPage.pageOffset + copc.info.rootHierarchyPage.pageLength
   ]);
+
+  const boundarySource = COPCSourceLoader.createDataSource(blob, {});
+  await boundarySource.initialize();
+  const boundaryPageKey = Object.keys(rootHierarchy.pages)[0];
+  expect(boundaryPageKey).toBeTruthy();
+  const boundaryNodeIndex = boundaryPageKey.split('-').map(Number) as [
+    number,
+    number,
+    number,
+    number
+  ];
+  const boundaryNode = await boundarySource.getNode({nodeIndex: boundaryNodeIndex});
+  expect(boundaryNode?.pointCount).toBeGreaterThan(0);
 
   const source = COPCSourceLoader.createDataSource(blob, {});
   await source.initialize();

--- a/modules/copc/test/copc-source.spec.ts
+++ b/modules/copc/test/copc-source.spec.ts
@@ -446,6 +446,46 @@ test('COPCWriter#encodes range-readable octree nodes', async t => {
   t.end();
 });
 
+vitestTest('COPCWriter writes range-readable hierarchy pages and GPS bounds', async () => {
+  const mesh = createCOPCWriterMesh();
+  const arrayBuffer = encodeSync(mesh, COPCWriter, {
+    copc: {
+      nodePointLimit: 2,
+      maximumDepth: 6,
+      hierarchyPageDepth: 1,
+      pointDataRecordFormat: 7,
+      scale: [0.01, 0.01, 0.01]
+    }
+  });
+  const blob = new Blob([arrayBuffer]);
+  const ranges: Array<[number, number]> = [];
+  const getter = async (begin: number, end: number): Promise<Uint8Array> => {
+    ranges.push([begin, end]);
+    return new Uint8Array(await blob.slice(begin, end).arrayBuffer());
+  };
+  const copc = await openCOPC(getter);
+  const hierarchy = await loadCompleteHierarchy(getter, copc.info.rootHierarchyPage);
+
+  expect(hierarchy.pageCount).toBeGreaterThan(1);
+  expect(Object.keys(hierarchy.nodes).length).toBeGreaterThan(1);
+  expect(Object.values(hierarchy.nodes).reduce((sum, node) => sum + node.pointCount, 0)).toBe(
+    mesh.attributes.POSITION.value.length / 3
+  );
+  expect(copc.info.gpsTimeRange).toEqual([1_000, 1_039]);
+  expect(ranges).toContainEqual([
+    copc.info.rootHierarchyPage.pageOffset,
+    copc.info.rootHierarchyPage.pageOffset + copc.info.rootHierarchyPage.pageLength
+  ]);
+
+  const source = COPCSourceLoader.createDataSource(blob, {});
+  await source.initialize();
+  const pages = [];
+  for await (const page of source.loadHierarchyInBatches()) {
+    pages.push(page);
+  }
+  expect(pages).toHaveLength(hierarchy.pageCount);
+});
+
 test('COPCWriter#validates organization options', t => {
   const mesh = createCOPCWriterMesh();
   t.throws(
@@ -457,6 +497,11 @@ test('COPCWriter#validates organization options', t => {
     () => encodeSync(mesh, COPCWriter, {copc: {maximumDepth: 31}}),
     /invalid maximum depth/,
     'rejects octree depths outside Int32 key coordinates'
+  );
+  t.throws(
+    () => encodeSync(mesh, COPCWriter, {copc: {hierarchyPageDepth: 0}}),
+    /invalid hierarchy page depth/,
+    'rejects empty hierarchy pages'
   );
   t.end();
 });
@@ -484,6 +529,51 @@ test('COPCWriter#defaults to PDRF 6 without colors', async t => {
   t.end();
 });
 
+vitestTest('COPCWriter preserves PDRF 8 NIR values across paged nodes', async () => {
+  const baseMesh = createCOPCWriterMesh();
+  const pointCount = baseMesh.attributes.POSITION.value.length / 3;
+  const nir = Uint16Array.from({length: pointCount}, (_, index) => index * 101);
+  const attributes = {...baseMesh.attributes, nir: {value: nir, size: 1}};
+  const mesh = {
+    ...baseMesh,
+    attributes,
+    schema: deduceMeshSchema(attributes, {topology: 'point-list', mode: '0'})
+  };
+  const arrayBuffer = encodeSync(mesh, COPCWriter, {
+    copc: {
+      nodePointLimit: 2,
+      hierarchyPageDepth: 1,
+      pointDataRecordFormat: 8,
+      scale: [0.01, 0.01, 0.01]
+    }
+  });
+  const getter = async (begin: number, end: number): Promise<Uint8Array> =>
+    new Uint8Array(arrayBuffer.slice(begin, end));
+  const copc = await openCOPC(getter);
+  const hierarchy = await loadCompleteHierarchy(getter, copc.info.rootHierarchyPage);
+  const decodedNir: number[] = [];
+
+  for (const node of Object.values(hierarchy.nodes)) {
+    const compressed = await loadCOPCNodeData(getter, node);
+    const pointData = decodeLAZChunk(compressed, {
+      pointCount: node.pointCount,
+      pointDataRecordFormat: 8,
+      pointDataRecordLength: copc.header.pointDataRecordLength
+    });
+    const dataView = new DataView(pointData.buffer, pointData.byteOffset, pointData.byteLength);
+    for (let pointIndex = 0; pointIndex < node.pointCount; pointIndex++) {
+      decodedNir.push(
+        dataView.getUint16(pointIndex * copc.header.pointDataRecordLength + 36, true)
+      );
+    }
+  }
+
+  expect(copc.header.pointDataRecordFormat).toBe(8);
+  expect(decodedNir.sort((left, right) => left - right)).toEqual(
+    Array.from(nir).sort((left, right) => left - right)
+  );
+});
+
 /** Returns the COPC fixture input for the active test runner. */
 async function createEllipsoidSourceData(): Promise<string | Blob> {
   return isBrowser ? await createEllipsoidBlob() : ELLIPSOID_FILE_PATH;
@@ -499,17 +589,20 @@ async function createEllipsoidBlob(): Promise<Blob> {
 function createCOPCWriterMesh() {
   const positions: number[] = [];
   const colors: number[] = [];
+  const gpsTimes: number[] = [];
   for (let z = 0; z < 2; z++) {
     for (let y = 0; y < 4; y++) {
       for (let x = 0; x < 5; x++) {
         positions.push(x * 10 - 20, y * 8 - 12, z * 30 - 15);
         colors.push(x * 10, y * 20, z * 100);
+        gpsTimes.push(1_000 + gpsTimes.length);
       }
     }
   }
   const attributes = {
     POSITION: {value: new Float64Array(positions), size: 3},
-    COLOR_0: {value: new Uint16Array(colors), size: 3}
+    COLOR_0: {value: new Uint16Array(colors), size: 3},
+    gpsTime: {value: new Float64Array(gpsTimes), size: 1}
   };
   return {
     attributes,
@@ -517,6 +610,30 @@ function createCOPCWriterMesh() {
     mode: 0,
     schema: deduceMeshSchema(attributes, {topology: 'point-list', mode: '0'})
   };
+}
+
+/** Recursively load every hierarchy page through its declared byte range. */
+async function loadCompleteHierarchy(
+  getter: (begin: number, end: number) => Promise<Uint8Array>,
+  rootPage: {pageOffset: number; pageLength: number}
+): Promise<{
+  nodes: Record<string, {pointCount: number; pointDataOffset: number; pointDataLength: number}>;
+  pageCount: number;
+}> {
+  const nodes: Record<
+    string,
+    {pointCount: number; pointDataOffset: number; pointDataLength: number}
+  > = {};
+  const pending = [rootPage];
+  let pageCount = 0;
+  while (pending.length > 0) {
+    const page = pending.shift()!;
+    const hierarchy = await loadCOPCHierarchyPage(getter, page);
+    Object.assign(nodes, hierarchy.nodes);
+    pending.push(...Object.values(hierarchy.pages));
+    pageCount++;
+  }
+  return {nodes, pageCount};
 }
 
 /** Read dequantized positions from raw LAS records. */

--- a/modules/copc/test/copc-writer.node.slow.spec.ts
+++ b/modules/copc/test/copc-writer.node.slow.spec.ts
@@ -1,0 +1,76 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {encodeSync} from '@loaders.gl/core';
+import {COPCWriter} from '@loaders.gl/copc';
+import {deduceMeshSchema} from '@loaders.gl/schema-utils';
+import {Copc} from 'copc';
+import {expect, test} from 'vitest';
+
+test('COPCWriter output is readable by the independent copc implementation', async () => {
+  const mesh = createConformanceMesh();
+  const arrayBuffer = encodeSync(mesh, COPCWriter, {
+    copc: {
+      nodePointLimit: 2,
+      maximumDepth: 8,
+      hierarchyPageDepth: 1,
+      pointDataRecordFormat: 7,
+      scale: [0.01, 0.01, 0.01],
+      wkt: 'LOCAL_CS["loaders.gl COPCWriter conformance"]'
+    }
+  });
+  const getBytes = async (begin: number, end: number): Promise<Uint8Array> =>
+    new Uint8Array(arrayBuffer.slice(begin, end));
+  const copc = await Copc.create(getBytes);
+  const pendingPages = [copc.info.rootHierarchyPage];
+  const nodes = [];
+  let pageCount = 0;
+
+  while (pendingPages.length > 0) {
+    const page = pendingPages.shift()!;
+    const hierarchy = await Copc.loadHierarchyPage(getBytes, page);
+    nodes.push(...Object.values(hierarchy.nodes));
+    for (const childPage of Object.values(hierarchy.pages)) {
+      if (childPage) {
+        pendingPages.push(childPage);
+      }
+    }
+    pageCount++;
+  }
+
+  expect(copc.header.pointDataRecordFormat).toBe(7);
+  expect(copc.header.pointCount).toBe(mesh.attributes.POSITION.value.length / 3);
+  expect(copc.wkt).toBe('LOCAL_CS["loaders.gl COPCWriter conformance"]');
+  expect(pageCount).toBeGreaterThan(1);
+  expect(nodes.reduce((sum, node) => sum + node.pointCount, 0)).toBe(copc.header.pointCount);
+  const compressedRoot = await Copc.loadCompressedPointDataBuffer(getBytes, nodes[0]);
+  expect(compressedRoot.byteLength).toBe(nodes[0].pointDataLength);
+});
+
+/** Create a deterministic point cloud with a deep, sparse octree. */
+function createConformanceMesh() {
+  const positions: number[] = [];
+  const colors: number[] = [];
+  const gpsTimes: number[] = [];
+  for (let pointIndex = 0; pointIndex < 64; pointIndex++) {
+    const reversedBits = Number.parseInt(
+      pointIndex.toString(2).padStart(6, '0').split('').reverse().join(''),
+      2
+    );
+    positions.push(pointIndex * 2, reversedBits * 3, (pointIndex % 7) * 11);
+    colors.push(pointIndex, 255 - pointIndex, pointIndex * 3);
+    gpsTimes.push(20_000 + pointIndex / 4);
+  }
+  const attributes = {
+    POSITION: {value: new Float64Array(positions), size: 3},
+    COLOR_0: {value: new Uint16Array(colors), size: 3},
+    gpsTime: {value: new Float64Array(gpsTimes), size: 1}
+  };
+  return {
+    attributes,
+    topology: 'point-list' as const,
+    mode: 0,
+    schema: deduceMeshSchema(attributes, {topology: 'point-list', mode: '0'})
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5212,6 +5212,7 @@ __metadata:
     "@loaders.gl/schema": "npm:5.0.0-alpha.2"
     "@loaders.gl/schema-utils": "npm:5.0.0-alpha.2"
     "@math.gl/proj4": "npm:^4.1.0"
+    copc: "npm:0.0.8"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Goals

- Complete the highest-priority remaining LAS/COPC roadmap tranche by making `COPCWriter` production-ready for its documented PDRF 6-8 input surface.
- Keep generated files sequentially LAZ-readable and independently range-readable as COPC 1.0.

## Changes

- Partition deep octrees into deterministic hierarchy page trees instead of one monolithic hierarchy page.
- Emit absolute child-page ranges with `pointCount: -1` and publish only the root page range in the COPC info VLR.
- Add `copc.hierarchyPageDepth` to control the number of octree levels represented per page; the default of 3 bounds a full page to 585 entries.
- Derive COPC GPS-time bounds from finite encoded point values instead of always writing `[0, 0]`.
- Add recursive range-loading coverage for deep and sparse hierarchy pages.
- Add explicit PDRF 8/NIR node round-trip coverage, complementing existing PDRF 6 and 7 tests.
- Add a hermetic slow conformance test using the independent `copc` implementation.
- Remove the experimental documentation label and document paging, GPS bounds, represented attributes, and conformance coverage.

## Validation

- `yarn build`
- `yarn build-workers`
- `yarn test-node` (44 files, 326 passed, 6 skipped)
- `yarn test-headless` (438 files passed, 2 skipped; 2517 tests passed, 47 skipped)
- `yarn test-slow modules/copc/test/copc-writer.node.slow.spec.ts`
- `yarn test-profile slow modules/copc/test/copc-writer.node.slow.spec.ts` (18 ms test time)
- `yarn test-audit` (545 files, 0 violations)
- `yarn lint fix`
- `website/yarn build`
- Focused `copc-writer.ts` coverage: 97.8% lines, 89.9% branches, 97.1% functions
