### PR TITLE
fix(parquet): preserve repeated page row starts

### DIFF
--- a/modules/parquet/src/lib/parquet-page-index.ts
+++ b/modules/parquet/src/lib/parquet-page-index.ts
@@ -219,7 +219,8 @@ export async function createParquetPagePruningPlan(
 export function getParquetPageReadRanges(
   rowGroup: RowGroup,
   selectedColumnPaths: readonly string[][],
-  plan: ParquetPagePruningPlan
+  plan: ParquetPagePruningPlan,
+  schema: ParquetSchema
 ): Array<{offset: number; length: number}> {
   const ranges: Array<{offset: number; length: number}> = [];
   for (const columnChunk of getSelectedColumnChunks(rowGroup, selectedColumnPaths)) {
@@ -231,6 +232,8 @@ export function getParquetPageReadRanges(
     if (!selectedPages.length) {
       continue;
     }
+    const field = schema.findField(columnMetadata.path_in_schema);
+    const repeated = field.rLevelMax > 0 || field.repetitionType === 'REPEATED';
     const dictionaryPageOffset = Number(columnMetadata.dictionary_page_offset);
     if (Number.isSafeInteger(dictionaryPageOffset) && dictionaryPageOffset > 0) {
       ranges.push({
@@ -245,7 +248,9 @@ export function getParquetPageReadRanges(
       if (!overlappingPages.length) {
         continue;
       }
-      const firstPage = overlappingPages[0];
+      // A repeated page may begin with a continuation level. Transfer the complete prefix so
+      // worker-backed readers can probe predecessor pages before decoding the selected range.
+      const firstPage = repeated ? pages[0] : overlappingPages[0];
       const lastPage = overlappingPages[overlappingPages.length - 1];
       ranges.push({
         offset: firstPage.offset,

--- a/modules/parquet/src/parquet-source-loader.ts
+++ b/modules/parquet/src/parquet-source-loader.ts
@@ -715,9 +715,12 @@ export class ParquetSource
                 selectedPages: pagePlan.selectedPageCount,
                 rowsPruned: pagePlan.prunedRowCount,
                 ranges: Object.freeze(
-                  getParquetPageReadRanges(rowGroup, phase.columns, pagePlan).map(range =>
-                    Object.freeze({...range})
-                  )
+                  getParquetPageReadRanges(
+                    rowGroup,
+                    phase.columns,
+                    pagePlan,
+                    initialization.parquetSchema
+                  ).map(range => Object.freeze({...range}))
                 )
               })
             : createFullColumnScanPlan(rowGroup, rowGroupIndex, phase.phase, phase.columns)
@@ -958,7 +961,7 @@ export class ParquetSource
       return Boolean(path && (columnList.length === 0 || fieldIndexOf(columnList, path) >= 0));
     });
     const rangeDescriptors = pagePlan
-      ? getParquetPageReadRanges(rowGroup, columnList, pagePlan)
+      ? getParquetPageReadRanges(rowGroup, columnList, pagePlan, initialization.parquetSchema)
       : selectedColumnChunks.map(getColumnChunkRange);
     const ranges = await Promise.all(
       rangeDescriptors.map(async ({offset, length}) => {

--- a/modules/parquet/src/parquetjs/parser/parquet-reader.ts
+++ b/modules/parquet/src/parquetjs/parser/parquet-reader.ts
@@ -434,20 +434,29 @@ export class ParquetReader {
       dictionary = await decodeDictionaryBuffer(dictionaryBuffer, context);
     }
 
-    let decoded: ParquetColumnChunk;
-    while (true) {
-      const dataLength = lastPage.offset + lastPage.compressedByteLength - firstPage.offset;
-      const dataBuffer = toUint8Array(
-        await this.file.read(firstPage.offset, dataLength, signal ?? this.props.signal)
-      );
-      decoded = await decodeDataPages(dataBuffer, {...context, dictionary});
-      if (field.rLevelMax === 0 || decoded.rlevels[0] === 0 || firstPageIndex === 0) {
-        break;
+    if (field.rLevelMax !== 0) {
+      // Probe predecessor pages independently, then decode the final range once. This avoids
+      // quadratic re-decoding when a large repeated row spans many pages.
+      while (firstPageIndex > 0) {
+        const probeBuffer = toUint8Array(
+          await this.file.read(
+            firstPage.offset,
+            firstPage.compressedByteLength,
+            signal ?? this.props.signal
+          )
+        );
+        const probe = await decodeDataPages(probeBuffer, {...context, dictionary});
+        if (probe.rlevels[0] === 0) {
+          break;
+        }
+        firstPage = pages[--firstPageIndex];
       }
-      // An offset-index page can begin with continuation levels for a row that started on the
-      // preceding page. Include earlier pages until the selected byte range starts at a row.
-      firstPage = pages[--firstPageIndex];
     }
+    const dataLength = lastPage.offset + lastPage.compressedByteLength - firstPage.offset;
+    const dataBuffer = toUint8Array(
+      await this.file.read(firstPage.offset, dataLength, signal ?? this.props.signal)
+    );
+    const decoded = await decodeDataPages(dataBuffer, {...context, dictionary});
     if (field.rLevelMax !== 0) {
       const rowStart = rowRange.start - firstPage.firstRowIndex;
       return sliceRepeatedColumnChunk(

--- a/modules/parquet/src/parquetjs/parser/parquet-reader.ts
+++ b/modules/parquet/src/parquetjs/parser/parquet-reader.ts
@@ -402,8 +402,9 @@ export class ParquetReader {
     if (!overlappingPages.length) {
       throw new Error('Parquet page plan does not overlap the requested row range');
     }
-    const firstPage = overlappingPages[0];
+    let firstPageIndex = pages.indexOf(overlappingPages[0]);
     const lastPage = overlappingPages[overlappingPages.length - 1];
+    let firstPage = pages[firstPageIndex];
     const context: ParquetReaderContext = {
       type,
       rLevelMax: field.rLevelMax,
@@ -433,13 +434,28 @@ export class ParquetReader {
       dictionary = await decodeDictionaryBuffer(dictionaryBuffer, context);
     }
 
-    const dataLength = lastPage.offset + lastPage.compressedByteLength - firstPage.offset;
-    const dataBuffer = toUint8Array(
-      await this.file.read(firstPage.offset, dataLength, signal ?? this.props.signal)
-    );
-    const decoded = await decodeDataPages(dataBuffer, {...context, dictionary});
+    let decoded: ParquetColumnChunk;
+    while (true) {
+      const dataLength = lastPage.offset + lastPage.compressedByteLength - firstPage.offset;
+      const dataBuffer = toUint8Array(
+        await this.file.read(firstPage.offset, dataLength, signal ?? this.props.signal)
+      );
+      decoded = await decodeDataPages(dataBuffer, {...context, dictionary});
+      if (field.rLevelMax === 0 || decoded.rlevels[0] === 0 || firstPageIndex === 0) {
+        break;
+      }
+      // An offset-index page can begin with continuation levels for a row that started on the
+      // preceding page. Include earlier pages until the selected byte range starts at a row.
+      firstPage = pages[--firstPageIndex];
+    }
     if (field.rLevelMax !== 0) {
-      return decoded;
+      const rowStart = rowRange.start - firstPage.firstRowIndex;
+      return sliceRepeatedColumnChunk(
+        decoded,
+        Math.max(0, rowStart),
+        rowRange.end - rowRange.start,
+        field.dLevelMax
+      );
     }
     const relativeStart = rowRange.start - firstPage.firstRowIndex;
     const relativeEnd = relativeStart + rowRange.end - rowRange.start;
@@ -510,6 +526,38 @@ function sliceNonRepeatedColumnChunk(
     dlevels: columnChunk.dlevels.slice(start, end),
     values: columnChunk.values.slice(valueStart, valueEnd) as typeof columnChunk.values,
     count: end - start,
+    pageHeaders: columnChunk.pageHeaders
+  };
+}
+
+/** Slices a repeated column by logical rows while preserving its level/value alignment. */
+function sliceRepeatedColumnChunk(
+  columnChunk: ParquetColumnChunk,
+  rowStart: number,
+  rowCount: number,
+  definitionLevelMaximum: number
+): ParquetColumnChunk {
+  const rowStarts: number[] = [];
+  for (let levelIndex = 0; levelIndex < columnChunk.rlevels.length; levelIndex++) {
+    if (columnChunk.rlevels[levelIndex] === 0) {
+      rowStarts.push(levelIndex);
+    }
+  }
+  const levelStart = rowStarts[rowStart];
+  const endRow = rowStart + rowCount;
+  const levelEnd = rowStarts[endRow] ?? columnChunk.rlevels.length;
+  if (levelStart === undefined || endRow > rowStarts.length || levelEnd < levelStart) {
+    throw new Error('Parquet repeated page range does not contain the requested rows');
+  }
+  const valueStart = countDefinedValues(columnChunk.dlevels, definitionLevelMaximum, 0, levelStart);
+  const valueEnd =
+    valueStart +
+    countDefinedValues(columnChunk.dlevels, definitionLevelMaximum, levelStart, levelEnd);
+  return {
+    rlevels: columnChunk.rlevels.slice(levelStart, levelEnd),
+    dlevels: columnChunk.dlevels.slice(levelStart, levelEnd),
+    values: columnChunk.values.slice(valueStart, valueEnd) as typeof columnChunk.values,
+    count: levelEnd - levelStart,
     pageHeaders: columnChunk.pageHeaders
   };
 }


### PR DESCRIPTION
## Goals

Preserve complete logical rows when selective reads encounter repeated Parquet pages that begin with continuation repetition levels.

## Changes

- Extend repeated page reads backward until decoding starts at a complete logical-row boundary.
- Trim the decoded repeated levels and values to the requested row range without losing value alignment.
- Validate that the requested logical rows are fully present in the selected pages.
- Add the review follow-up for PR #3724; its inline thread has been answered and resolved.

## Validation

- `yarn lint fix`
- `yarn test-audit` (544 files, 0 Tape violations)
- Focused Chromium Parquet tests: 4/4 passed

This follow-up is based on current `master`, after the repeated-page index tranche landed in #3724.
