### PR TITLE
test: expand video and polyfills coverage

### DIFF
--- a/modules/polyfills/test/polyfills-core.node.spec.ts
+++ b/modules/polyfills/test/polyfills-core.node.spec.ts
@@ -1,0 +1,114 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Readable} from 'node:stream';
+import {expect, test} from 'vitest';
+
+import {atob, btoa} from '../src/buffer/btoa.node';
+import {decodeDataUri} from '../src/fetch/decode-data-uri';
+import {Headers} from '../src/fetch/headers-polyfill';
+import {Response} from '../src/fetch/response-polyfill';
+import {BlobPolyfill} from '../src/file/blob';
+import {FilePolyfill} from '../src/file/file';
+import {FileReaderPolyfill} from '../src/file/file-reader';
+import {concatenateArrayBuffers, concatenateReadStream} from '../src/filesystems/stream-utils.node';
+import {makeNodeStream} from '../src/streams/make-node-stream';
+import {assert} from '../src/utils/assert';
+
+test('HeadersPolyfill normalizes and iterates header values', () => {
+  const headers = new Headers([
+    ['Accept', 'application/json'],
+    ['Accept', 'text/plain']
+  ]);
+  headers.set('X-Test', 42);
+  expect(headers.get('accept')).toBe('application/json, text/plain');
+  expect(headers.get('X-TEST')).toBe('42');
+  expect([...headers]).toEqual([
+    ['accept', 'application/json, text/plain'],
+    ['x-test', '42']
+  ]);
+  headers.delete('x-test');
+  expect(headers.has('X-Test')).toBe(false);
+  expect(() => headers.set('', 'invalid')).toThrow(TypeError);
+});
+
+test('decodeDataUri handles encoded and base64 data', () => {
+  expect(new TextDecoder().decode(decodeDataUri('data:text/plain,hello%20world').arrayBuffer)).toBe(
+    'hello world'
+  );
+  expect(decodeDataUri('data:;charset=utf-8,hello').mimeType).toBe('text/plain;charset=utf-8');
+  expect(
+    new TextDecoder().decode(decodeDataUri('data:text/plain;base64,aGVsbG8=').arrayBuffer)
+  ).toBe('hello');
+});
+
+test('ResponsePolyfill reads strings, JSON, streams, and compressed bodies', async () => {
+  const response = new Response('{"answer":42}', {url: 'memory:'});
+  expect(response.ok).toBe(true);
+  expect(await response.json()).toEqual({answer: 42});
+  expect(await new Response('hello', {url: 'memory:'}).text()).toBe('hello');
+
+  const streamResponse = new Response(Readable.from([Buffer.from('streamed')]), {url: 'memory:'});
+  expect(new TextDecoder().decode(await streamResponse.arrayBuffer())).toBe('streamed');
+  expect(await new Response(new Uint8Array([1, 2]), {url: 'memory:'}).blob()).toBeInstanceOf(Blob);
+});
+
+test('BlobPolyfill handles parts, slices, streams, and File metadata', async () => {
+  const blob = new BlobPolyfill(['hello', new Uint8Array([32, 119, 111, 114, 108, 100])], {
+    type: 'TEXT/PLAIN'
+  });
+  expect(blob.size).toBe(11);
+  expect(blob.type).toBe('text/plain');
+  expect(await blob.text()).toBe('hello world');
+  expect(await blob.slice(-5).text()).toBe('world');
+  const streamedBytes: number[] = [];
+  for await (const chunk of blob.stream()) {
+    streamedBytes.push(...chunk);
+  }
+  expect(new Uint8Array(streamedBytes)).toEqual(new Uint8Array(await blob.arrayBuffer()));
+
+  const file = new FilePolyfill(['data'], 'folder/name.txt', {lastModified: 123});
+  expect(file.name).toBe('folder:name.txt');
+  expect(file.lastModified).toBe(123);
+  expect(file[Symbol.toStringTag]).toBe('File');
+});
+
+test('FileReaderPolyfill reports text, bytes, and data URLs', async () => {
+  const blob = new BlobPolyfill(['hello']);
+  const reader = new FileReaderPolyfill();
+  const results: unknown[] = [];
+  reader.onload = event => results.push(event.target.result);
+  await reader.readAsText(blob);
+  await reader.readAsArrayBuffer(blob);
+  await reader.readAsDataURL(blob);
+  expect(results[0]).toBe('hello');
+  expect(new TextDecoder().decode(results[1] as ArrayBuffer)).toBe('hello');
+  expect(results[2]).toMatch(/^data:\/\/;base64,/);
+  await expect(reader.readAsBinaryString(blob)).rejects.toThrow('Not implemented');
+});
+
+test('stream and binary helpers preserve data and errors', async () => {
+  expect(atob('hello')).toBe('aGVsbG8=');
+  expect(btoa('aGVsbG8=')).toBe('hello');
+  expect(
+    new Uint8Array(concatenateArrayBuffers([new Uint8Array([1]), new ArrayBuffer(2)])).length
+  ).toBe(3);
+
+  const stream = makeNodeStream(
+    (async function* () {
+      yield new Uint8Array([1, 2]);
+      yield new Uint8Array([3]);
+    })()
+  );
+  expect([
+    ...(await new Promise<Buffer[]>((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      stream.on('data', chunk => chunks.push(chunk));
+      stream.on('end', () => resolve(chunks));
+      stream.on('error', reject);
+    }))
+  ]).toHaveLength(2);
+
+  expect(() => assert(false, 'bad')).toThrow('@loaders.gl/polyfills assertion bad');
+});

--- a/modules/video/test/gif-builder.spec.js
+++ b/modules/video/test/gif-builder.spec.js
@@ -2,57 +2,56 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {afterEach, expect, test, vi} from 'vitest';
 
-import {load, isBrowser} from '@loaders.gl/core';
-import {ImageBitmapLoader} from '@loaders.gl/images';
-import {GIFBuilder} from '@loaders.gl/video';
+import GIFBuilder from '../src/gif-builder';
 
-const IMAGE_URLS = [
-  'http://i.imgur.com/2OO33vX.jpg',
-  'http://i.imgur.com/qOwVaSN.png',
-  'http://i.imgur.com/Vo5mFZJ.gif'
-];
-
-test('GIFBuilder#imports', t => {
-  t.ok(GIFBuilder, 'GIFBuilder defined');
-  t.end();
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
-test('GIFBuilder#load(URL)', async t => {
-  if (!isBrowser) {
-    t.end();
-    return;
-  }
+test('GIFBuilder exposes metadata and accepts image files', async () => {
+  expect(GIFBuilder.properties).toMatchObject({id: 'gif', extensions: ['gif']});
+  const gifBuilder = new GIFBuilder({source: 'images', width: 400, height: 300});
+  const createGIF = vi
+    .spyOn(gifBuilder.gifshot, 'createGIF')
+    .mockImplementation((options, callback) => {
+      expect(options).toMatchObject({images: ['first-image'], gifWidth: 400, gifHeight: 300});
+      callback({error: false, image: 'data:image/gif;base64,AAAA'});
+    });
 
-  const gifBuilder = new GIFBuilder({source: 'images', width: 400, height: 400});
-
-  for (const image of IMAGE_URLS) {
-    await gifBuilder.add(image);
-  }
-
-  const gifDataUrl = await gifBuilder.build();
-  t.ok(gifDataUrl.startsWith('data:image/gif;'), 'build() returns GIF image encoded as data URL');
-
-  t.end();
+  await gifBuilder.add('first-image');
+  await expect(gifBuilder.build()).resolves.toBe('data:image/gif;base64,AAAA');
+  expect(createGIF).toHaveBeenCalledTimes(1);
 });
 
-test('GIFBuilder#load(Image)', async t => {
-  if (!isBrowser) {
-    t.end();
-    return;
-  }
+test('GIFBuilder supports video and webcam sources', async () => {
+  const videoBuilder = new GIFBuilder({source: 'video', width: 10, height: 20});
+  vi.spyOn(videoBuilder.gifshot, 'createGIF').mockImplementation((options, callback) => {
+    expect(options).toMatchObject({video: ['video-file'], gifWidth: 10, gifHeight: 20});
+    callback({error: false, image: 'video-gif'});
+  });
+  await videoBuilder.add('video-file');
+  await expect(videoBuilder.build()).resolves.toBe('video-gif');
 
-  const IMAGES = await Promise.all(IMAGE_URLS.map(url => load(url, ImageBitmapLoader)));
+  const webcamBuilder = new GIFBuilder({source: 'webcam'});
+  vi.spyOn(webcamBuilder.gifshot, 'createGIF').mockImplementation((_options, callback) => {
+    callback({error: false, image: 'webcam-gif'});
+  });
+  await expect(webcamBuilder.build()).resolves.toBe('webcam-gif');
+});
 
-  const gifBuilder = new GIFBuilder({source: 'images', width: 400, height: 400});
+test('GIFBuilder rejects invalid sources, files, and gifshot errors', async () => {
+  const invalidBuilder = new GIFBuilder({source: 'invalid'});
+  await expect(invalidBuilder.build()).rejects.toThrow('GIFBuilder: invalid source');
 
-  for (const image of IMAGES) {
-    await gifBuilder.add(image);
-  }
+  const webcamBuilder = new GIFBuilder({source: 'webcam'});
+  await webcamBuilder.add('unexpected-file');
+  await expect(webcamBuilder.build()).rejects.toThrow();
 
-  const gifDataUrl = await gifBuilder.build();
-  t.ok(gifDataUrl.startsWith('data:image/gif;'), 'build() returns GIF image encoded as data URL');
-
-  t.end();
+  const errorBuilder = new GIFBuilder({source: 'images'});
+  vi.spyOn(errorBuilder.gifshot, 'createGIF').mockImplementation((_options, callback) => {
+    callback({error: true, errorMsg: 'gifshot failed'});
+  });
+  await expect(errorBuilder.build()).rejects.toBe('gifshot failed');
 });

--- a/modules/video/test/video-loader.spec.js
+++ b/modules/video/test/video-loader.spec.js
@@ -2,21 +2,37 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test, vi} from 'vitest';
 
-import {VideoLoader} from '@loaders.gl/video';
-import {isBrowser} from '@loaders.gl/core';
+import {VideoFormat} from '../src/video-format';
+import {VideoLoader} from '../src/video-loader';
+import {VideoLoaderWithParser} from '../src/video-loader-with-parser';
 
-test('video loaders#imports', t => {
-  t.ok(VideoLoader, 'ImageLoader defined');
-  t.end();
+test('video loader exposes stable metadata', () => {
+  expect(VideoLoader).toMatchObject({
+    id: 'video',
+    name: 'Video',
+    extensions: ['mp4'],
+    mimeTypes: ['video/mp4'],
+    binary: true
+  });
+  expect(VideoLoader).not.toHaveProperty('parse');
+  expect(VideoFormat).toEqual(expect.objectContaining({id: 'video', format: 'video'}));
 });
 
-test('VideoLoader#load(URL)', async t => {
-  if (!isBrowser) {
-    t.end();
-    return;
-  }
+test('video loader preloads its parser-bearing implementation', async () => {
+  const parserLoader = await VideoLoader.preload();
+  expect(parserLoader).toBe(VideoLoaderWithParser);
+  expect(parserLoader.parse).toBeTypeOf('function');
+  expect(parserLoader.parseBlob).toBeTypeOf('function');
+});
 
-  t.end();
+test('video parser creates a video element from binary data', async () => {
+  const video = {src: ''};
+  vi.spyOn(document, 'createElement').mockReturnValue(video);
+  vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:video-fixture');
+
+  const parsedVideo = await VideoLoaderWithParser.parse(new ArrayBuffer(0));
+  expect(parsedVideo).toBe(video);
+  expect(parsedVideo.src).toBe('blob:video-fixture');
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,7 +22,6 @@ const excludePatterns = [
   'modules/mvt/test/table-tile-source-loader-full.spec.ts',
   'modules/mvt/test/table-tile-source-loader-multi-world.spec.ts',
   'modules/polyfills/test/load-library/require-utils.spec.ts',
-  'modules/video/test/**',
   'modules/xml/test/sax-ts/testcases/issue-30.spec.ts',
   'modules/xml/test/sax-ts/testcases/**/*.spec.ts',
   'test/browser.ts',


### PR DESCRIPTION
## Goals
- Raise coverage for the previously uncovered `video` and `polyfills` packages.
- Remove the remaining tape adapter usage from the video tests.

## Changes
- Enable `modules/video/test/**` in Vitest discovery.
- Replace remote GIF/image tests with deterministic Vitest tests covering image, video, webcam, invalid-source, and gifshot-error paths.
- Cover video loader metadata, lazy parser loading, and binary-to-video parsing.
- Add direct Node tests for polyfill headers, data URIs, responses, blobs, files, file readers, streams, and binary helpers.

## Validation
- `yarn lint fix`
- `yarn test-audit` (547 files, 0 Tape, 0 violations)
- `yarn test-vitest-async-guardrails`
- Focused Node tests: 6 passed
- Focused headless video tests: 6 passed
- `yarn build`
- `git diff --check`

Coverage thresholds are unchanged; CI will calculate the merged browser/Node package deltas.