### PR TITLE
feat(wms): add ArcGIS dynamic tile sources

### DIFF
--- a/docs/modules/wms/services/arcgis-image-server.md
+++ b/docs/modules/wms/services/arcgis-image-server.md
@@ -10,7 +10,8 @@ ArcGIS Image Server endpoints expose raster imagery and image services through t
 
 loaders.gl provides `_ArcGISImageServerSourceLoader` as an experimental image source loader for
 ArcGIS `ImageServer` endpoints. It can load service metadata and request exported images for a
-viewport.
+viewport. `ArcGISImageTileSourceLoader` provides a deck.gl-compatible tile source backed by the
+`/exportImage` endpoint.
 
 ## Usage
 
@@ -34,9 +35,27 @@ const image = await source.getImage({
 });
 ```
 
+For deck.gl tile rendering, use `ArcGISImageTileSourceLoader`. It requests one `/exportImage`
+image per tile and supports ImageServer rendering parameters.
+
+```ts
+import {ArcGISImageTileSourceLoader} from '@loaders.gl/wms';
+
+const tileSource = createDataSource(url, [ArcGISImageTileSourceLoader], {
+  type: 'arcgis-image-server-tiles',
+  'arcgis-image-server-tiles': {
+    tileSize: 512,
+    parameters: {format: 'png32', transparent: true}
+  }
+});
+
+tileSource.updateParameters({renderingRule: JSON.stringify({rasterFunction: 'Hillshade'})});
+```
+
 ## Example
 
 - [ArcGIS Image Server example](/examples/tiles/arcgis-image-server)
+- [ArcGIS ImageServer tiles example](/examples/tiles/arcgis-image-server-tiles)
 
 ## References
 

--- a/docs/modules/wms/services/arcgis-map-server.md
+++ b/docs/modules/wms/services/arcgis-map-server.md
@@ -6,8 +6,9 @@ import {ClientExample} from '@site/src/components';
 <WmsDocsTabs active="arcgis-map-server" />
 
 ArcGIS MapServer services can expose cached map tiles through the REST `/tile/{z}/{y}/{x}`
-endpoint. loaders.gl provides an image `TileSource` for these services and reads the service's
-metadata document to expose zoom levels, extent, spatial reference, and attribution.
+endpoint or render dynamic tiles through `/export`. loaders.gl provides an image `TileSource` that
+selects cached tiles automatically when `tileInfo` is advertised and can render dynamic services
+with runtime parameters.
 
 ## Usage
 
@@ -24,6 +25,26 @@ const source = createDataSource(
 const metadata = await source.getMetadata();
 const image = await source.getTile({x: 2, y: 1, z: 2});
 ```
+
+For dynamic services, select export mode and configure the request parameters. A pool of service
+URLs can be supplied for simple request distribution.
+
+```ts
+const source = createDataSource(url, [ArcGISMapTileSourceLoader], {
+  type: 'arcgis-map-server',
+  'arcgis-map-server': {
+    mode: 'dynamic',
+    tileSize: 512,
+    urls: ['https://tiles-a.example.com/MapServer', 'https://tiles-b.example.com/MapServer'],
+    exportParameters: {layers: 'show:0', format: 'jpgpng'}
+  }
+});
+
+source.updateParameters({time: '2024-01-01'});
+```
+
+ArcGIS ImageServer export tiles are available through `ArcGISImageTileSourceLoader`, which uses
+the corresponding `/exportImage` endpoint and supports the same tile-source integration.
 
 ## Live example
 

--- a/examples/website/wms/app.tsx
+++ b/examples/website/wms/app.tsx
@@ -13,6 +13,7 @@ import {createDataSource} from '@loaders.gl/core';
 import {
   _ArcGISFeatureServerSourceLoader,
   _ArcGISImageServerSourceLoader,
+  ArcGISImageTileSourceLoader,
   ArcGISMapTileSourceLoader,
   WFSSourceLoader,
   WMSSourceLoader,
@@ -58,6 +59,7 @@ type AppProps = {
 const SOURCE_FACTORIES = [
   WMSSourceLoader,
   _ArcGISImageServerSourceLoader,
+  ArcGISImageTileSourceLoader,
   _ArcGISFeatureServerSourceLoader,
   WFSSourceLoader,
   WMTSSourceLoader,
@@ -196,7 +198,11 @@ export default function App(props: AppProps = {}) {
       return null;
     }
 
-    if (example.type === 'wmts' || example.type === 'arcgis-map-server') {
+    if (
+      example.type === 'wmts' ||
+      example.type === 'arcgis-map-server' ||
+      example.type === 'arcgis-image-server-tiles'
+    ) {
       return [
         new TileSourceLayer({
           id: `${example.type}-${example.url}`,

--- a/examples/website/wms/examples.ts
+++ b/examples/website/wms/examples.ts
@@ -105,6 +105,14 @@ export const EXAMPLES: Record<string, Record<string, Example>> = {
       }
     },
   },
+  'ArcGIS ImageServer tiles': {
+    'NLCD Land Cover tile exports': {
+      type: 'arcgis-image-server-tiles',
+      url: 'https://sampleserver6.arcgisonline.com/arcgis/rest/services/NLCDLandCover2001/ImageServer',
+      description: 'ArcGIS ImageServer exportImage requests rendered as deck.gl tiles.',
+      viewState: {longitude: -96, latitude: 38.5, zoom: 4}
+    }
+  },
   'ArcGIS MapServer': {
     'World Imagery cached tiles': {
       type: 'arcgis-map-server',

--- a/modules/wms/src/arcgis/arcgis-image-tile-source-loader.ts
+++ b/modules/wms/src/arcgis/arcgis-image-tile-source-loader.ts
@@ -35,7 +35,11 @@ export class ArcGISImageTileSource
   /** MIME type rendered by the generic deck.gl tile adapter. */
   readonly mimeType = 'image/png';
 
+  /** Cached ImageServer metadata. */
   private _metadata: any | null = null;
+  /** In-flight metadata request shared by concurrent callers. */
+  private _metadataPromise: Promise<any> | null = null;
+  /** Parameters applied to subsequent export requests. */
   private _runtimeParameters: Record<string, string | number | boolean> = {};
 
   /** Creates an ArcGIS ImageServer tile source. */
@@ -46,10 +50,7 @@ export class ArcGISImageTileSource
 
   /** Returns normalized ImageServer metadata. */
   async getMetadata(): Promise<TileSourceMetadata> {
-    if (!this._metadata) {
-      this._metadata = await this._loadMetadata();
-    }
-    const metadata = this._metadata;
+    const metadata = await this._getMetadata();
     const extent = metadata.fullExtent || metadata.extent;
     const spatialReference = metadata.spatialReference || extent?.spatialReference;
     return {
@@ -120,6 +121,7 @@ export class ArcGISImageTileSource
     return url.toString();
   }
 
+  /** Fetches the ImageServer metadata document. */
   private async _loadMetadata(): Promise<any> {
     const url = new URL(this.url);
     url.searchParams.set('f', 'pjson');
@@ -130,6 +132,22 @@ export class ArcGISImageTileSource
     return response.json();
   }
 
+  /** Returns cached metadata and shares a single request among concurrent callers. */
+  private async _getMetadata(): Promise<any> {
+    if (this._metadata) return this._metadata;
+    if (!this._metadataPromise) {
+      this._metadataPromise = this._loadMetadata();
+    }
+    try {
+      const metadata = await this._metadataPromise;
+      this._metadata = metadata;
+      return metadata;
+    } finally {
+      this._metadataPromise = null;
+    }
+  }
+
+  /** Selects a service endpoint for a tile using a stable URL-pool mapping. */
   private getServiceURL(parameters: GetTileParameters): string {
     const urls = this.options['arcgis-image-server-tiles']?.urls;
     return urls?.length ? urls[(parameters.x + parameters.y) % urls.length] : this.url;
@@ -159,6 +177,7 @@ export const ArcGISImageTileSourceLoader = {
   ) => new ArcGISImageTileSource(url, options, coreApi)
 } as const satisfies SourceLoader<ArcGISImageTileSource>;
 
+/** Calculates the Web Mercator extent represented by an XYZ tile. */
 function getWebMercatorTileBounds(parameters: GetTileParameters): [number, number, number, number] {
   const worldSize = 20037508.342789244;
   const tileCount = 2 ** parameters.z;

--- a/modules/wms/src/arcgis/arcgis-image-tile-source-loader.ts
+++ b/modules/wms/src/arcgis/arcgis-image-tile-source-loader.ts
@@ -1,0 +1,171 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {ImageType} from '@loaders.gl/images';
+import {ImageLoader} from '@loaders.gl/images';
+import type {
+  CoreAPI,
+  DataSourceOptions,
+  GetTileDataParameters,
+  GetTileParameters,
+  SourceLoader,
+  TileSource,
+  TileSourceMetadata
+} from '@loaders.gl/loader-utils';
+import {DataSource} from '@loaders.gl/loader-utils';
+
+/** Options for the ArcGIS ImageServer tile source. */
+export type ArcGISImageTileSourceLoaderOptions = DataSourceOptions & {
+  'arcgis-image-server-tiles'?: {
+    /** Tile size used for exportImage requests. */
+    tileSize?: number;
+    /** Optional service URL pool for simple request distribution. */
+    urls?: string[];
+    /** Additional exportImage parameters. */
+    parameters?: Record<string, string | number | boolean>;
+  };
+};
+
+/** A tile source that renders ArcGIS ImageServer exports as deck.gl tiles. */
+export class ArcGISImageTileSource
+  extends DataSource<string, ArcGISImageTileSourceLoaderOptions>
+  implements TileSource
+{
+  /** MIME type rendered by the generic deck.gl tile adapter. */
+  readonly mimeType = 'image/png';
+
+  private _metadata: any | null = null;
+  private _runtimeParameters: Record<string, string | number | boolean> = {};
+
+  /** Creates an ArcGIS ImageServer tile source. */
+  constructor(url: string, options: ArcGISImageTileSourceLoaderOptions = {}, coreApi?: CoreAPI) {
+    super(url.replace(/\/$/, ''), options, ArcGISImageTileSourceLoader.defaultOptions, coreApi);
+    this.getTileData = this.getTileData.bind(this);
+  }
+
+  /** Returns normalized ImageServer metadata. */
+  async getMetadata(): Promise<TileSourceMetadata> {
+    if (!this._metadata) {
+      this._metadata = await this._loadMetadata();
+    }
+    const metadata = this._metadata;
+    const extent = metadata.fullExtent || metadata.extent;
+    const spatialReference = metadata.spatialReference || extent?.spatialReference;
+    return {
+      name: metadata.name || metadata.serviceDescription || '',
+      title: metadata.name || metadata.serviceDescription || '',
+      abstract: metadata.description || metadata.serviceDescription || '',
+      attributions: metadata.copyrightText ? [metadata.copyrightText] : undefined,
+      boundingBox: extent
+        ? [
+            [extent.xmin, extent.ymin],
+            [extent.xmax, extent.ymax]
+          ]
+        : undefined,
+      layer: {
+        name: metadata.name || '',
+        srs: spatialReference?.wkid ? [`EPSG:${spatialReference.wkid}`] : [],
+        layers: []
+      }
+    };
+  }
+
+  /** Fetches one ImageServer export tile. */
+  async getTile(parameters: GetTileParameters, signal?: AbortSignal): Promise<ImageType | null> {
+    const response = await this.fetch(this.getTileURL(parameters), signal ? {signal} : undefined);
+    if (!response.ok) {
+      throw new Error(
+        `ArcGIS ImageServer tile request failed: ${response.status} ${response.statusText}`
+      );
+    }
+    return (await this.coreApi.parse(
+      await response.arrayBuffer(),
+      ImageLoader,
+      this.loadOptions
+    )) as ImageType;
+  }
+
+  /** Fetches a tile using the deck.gl-compatible request shape. */
+  async getTileData(parameters: GetTileDataParameters): Promise<ImageType | null> {
+    return this.getTile(parameters.index, parameters.signal);
+  }
+
+  /** Updates parameters applied to subsequent ImageServer export requests. */
+  updateParameters(parameters: Record<string, string | number | boolean>): void {
+    this._runtimeParameters = {...this._runtimeParameters, ...parameters};
+  }
+
+  /** Builds an ImageServer exportImage URL for one web-mercator tile. */
+  getTileURL(parameters: GetTileParameters, tileSize?: number): string {
+    const options = this.options['arcgis-image-server-tiles'] || {};
+    const resolvedTileSize = tileSize || options.tileSize || 256;
+    const [west, south, east, north] = getWebMercatorTileBounds(parameters);
+    const url = new URL(this.getServiceURL(parameters));
+    url.pathname = `${url.pathname.replace(/\/$/, '')}/exportImage`;
+    const requestParameters = {
+      f: 'image',
+      bbox: `${west},${south},${east},${north}`,
+      bboxSR: 3857,
+      imageSR: 3857,
+      size: `${resolvedTileSize},${resolvedTileSize}`,
+      format: 'png32',
+      transparent: true,
+      ...options.parameters,
+      ...this._runtimeParameters
+    };
+    for (const [key, value] of Object.entries(requestParameters)) {
+      url.searchParams.set(key, String(value));
+    }
+    return url.toString();
+  }
+
+  private async _loadMetadata(): Promise<any> {
+    const url = new URL(this.url);
+    url.searchParams.set('f', 'pjson');
+    const response = await this.fetch(url.toString());
+    if (!response.ok) {
+      throw new Error(`ArcGIS ImageServer metadata request failed: ${response.status}`);
+    }
+    return response.json();
+  }
+
+  private getServiceURL(parameters: GetTileParameters): string {
+    const urls = this.options['arcgis-image-server-tiles']?.urls;
+    return urls?.length ? urls[(parameters.x + parameters.y) % urls.length] : this.url;
+  }
+}
+
+/** Source loader for ArcGIS ImageServer export tiles. */
+export const ArcGISImageTileSourceLoader = {
+  dataType: null as unknown as ArcGISImageTileSource,
+  batchType: null as never,
+  name: 'ArcGIS ImageServer tiles',
+  id: 'arcgis-image-server-tiles',
+  module: 'wms',
+  version: '0.0.0',
+  extensions: [],
+  mimeTypes: [],
+  type: 'arcgis-image-server-tiles',
+  fromUrl: true,
+  fromBlob: false,
+  options: {'arcgis-image-server-tiles': {}},
+  defaultOptions: {'arcgis-image-server-tiles': {}},
+  testURL: (url: string): boolean => /imageserver/i.test(url),
+  createDataSource: (
+    url: string,
+    options: ArcGISImageTileSourceLoaderOptions = {},
+    coreApi?: CoreAPI
+  ) => new ArcGISImageTileSource(url, options, coreApi)
+} as const satisfies SourceLoader<ArcGISImageTileSource>;
+
+function getWebMercatorTileBounds(parameters: GetTileParameters): [number, number, number, number] {
+  const worldSize = 20037508.342789244;
+  const tileCount = 2 ** parameters.z;
+  const tileSize = (worldSize * 2) / tileCount;
+  const west = -worldSize + parameters.x * tileSize;
+  const east = west + tileSize;
+  const north = worldSize - parameters.y * tileSize;
+  const south = north - tileSize;
+  return [west, south, east, north];
+}

--- a/modules/wms/src/arcgis/arcgis-map-tile-source-loader.ts
+++ b/modules/wms/src/arcgis/arcgis-map-tile-source-loader.ts
@@ -49,6 +49,7 @@ export type ArcGISMapServerMetadata = {
     cols?: number;
     format?: string;
     spatialReference?: unknown;
+    origin?: {x: number; y: number};
   };
 };
 
@@ -63,7 +64,11 @@ export class ArcGISMapTileSource
   /** MIME type rendered by the generic deck.gl tile adapter. */
   readonly mimeType = 'image/png';
 
-  private _metadata: any | null = null;
+  /** Cached service metadata. */
+  private _metadata: ArcGISMapServerMetadata | null = null;
+  /** In-flight metadata request shared by concurrent callers. */
+  private _metadataPromise: Promise<ArcGISMapServerMetadata> | null = null;
+  /** Parameters applied to subsequent dynamic exports. */
   private _runtimeParameters: ArcGISMapTileParameters = {};
 
   /** Creates an ArcGIS MapServer tile source. */
@@ -74,17 +79,17 @@ export class ArcGISMapTileSource
 
   /** Loads and normalizes ArcGIS service metadata. */
   async getMetadata(): Promise<TileSourceMetadata> {
-    this._metadata ||= await this._loadMetadata();
-    const extent = this._metadata.fullExtent;
-    const spatialReference = this._metadata.spatialReference || extent?.spatialReference;
+    const metadata = await this._getMetadata();
+    const extent = metadata.fullExtent;
+    const spatialReference = metadata.spatialReference || extent?.spatialReference;
     return {
-      name: this._metadata.name || '',
-      title: this._metadata.name || '',
-      abstract: this._metadata.description || this._metadata.serviceDescription || '',
-      attributions: this._metadata.copyrightText ? [this._metadata.copyrightText] : undefined,
+      name: metadata.name || '',
+      title: metadata.name || '',
+      abstract: metadata.description || metadata.serviceDescription || '',
+      attributions: metadata.copyrightText ? [metadata.copyrightText] : undefined,
       minZoom: 0,
-      maxZoom: this._metadata.tileInfo?.lods?.length
-        ? Math.max(...this._metadata.tileInfo.lods.map(lod => lod.level))
+      maxZoom: metadata.tileInfo?.lods?.length
+        ? Math.max(...metadata.tileInfo.lods.map(lod => lod.level))
         : undefined,
       boundingBox: extent
         ? [
@@ -104,11 +109,8 @@ export class ArcGISMapTileSource
   async getTile(parameters: GetTileParameters, signal?: AbortSignal): Promise<ImageType | null> {
     const options = this.options['arcgis-map-server'] || {};
     const mode = options.mode || 'auto';
-    if (mode === 'auto' && !this._metadata) {
-      this._metadata = await this._loadMetadata();
-    }
-    const metadata = this._metadata;
-    const useCachedTiles = mode === 'cached' || (mode === 'auto' && Boolean(metadata?.tileInfo));
+    const metadata = mode === 'auto' ? await this._getMetadata() : null;
+    const useCachedTiles = mode === 'cached' || (mode === 'auto' && isCompatibleCache(metadata));
     const tileURL = useCachedTiles
       ? this.getTileURL(parameters)
       : this.getExportTileURL(parameters, options.tileSize || 256);
@@ -176,6 +178,7 @@ export class ArcGISMapTileSource
     return url.toString();
   }
 
+  /** Fetches the MapServer metadata document and applies configured parameters. */
   private async _loadMetadata(): Promise<ArcGISMapServerMetadata> {
     const configuredMetadata = this.options['arcgis-map-server']?.metadata;
     if (configuredMetadata) return configuredMetadata;
@@ -195,12 +198,42 @@ export class ArcGISMapTileSource
     return response.json();
   }
 
+  /** Returns cached metadata and shares a single request among concurrent callers. */
+  private async _getMetadata(): Promise<ArcGISMapServerMetadata> {
+    if (this._metadata) return this._metadata;
+    if (!this._metadataPromise) {
+      this._metadataPromise = this._loadMetadata();
+    }
+    try {
+      const metadata = await this._metadataPromise;
+      this._metadata = metadata;
+      return metadata;
+    } finally {
+      this._metadataPromise = null;
+    }
+  }
+
+  /** Selects a service endpoint for a tile using a stable URL-pool mapping. */
   private getServiceURL(parameters: GetTileParameters): string {
     const urls = this.options['arcgis-map-server']?.urls;
     return urls?.length ? urls[(parameters.x + parameters.y) % urls.length] : this.url;
   }
 }
 
+function isCompatibleCache(metadata: ArcGISMapServerMetadata | null): boolean {
+  const tileInfo = metadata?.tileInfo;
+  if (!tileInfo || tileInfo.rows !== 256 || tileInfo.cols !== 256) return false;
+  const spatialReference = tileInfo.spatialReference || metadata?.spatialReference;
+  const wkid = (spatialReference as {wkid?: number; latestWkid?: number} | undefined)?.wkid;
+  if (wkid !== 3857 && wkid !== 102100 && wkid !== 102113) return false;
+  const origin = tileInfo.origin;
+  return (
+    !origin ||
+    (Math.abs(origin.x + 20037508.342789244) < 1 && Math.abs(origin.y - 20037508.342789244) < 1)
+  );
+}
+
+/** Calculates the Web Mercator extent represented by an XYZ tile. */
 function getWebMercatorTileBounds(parameters: GetTileParameters): [number, number, number, number] {
   const worldSize = 20037508.342789244;
   const tileCount = 2 ** parameters.z;

--- a/modules/wms/src/arcgis/arcgis-map-tile-source-loader.ts
+++ b/modules/wms/src/arcgis/arcgis-map-tile-source-loader.ts
@@ -82,6 +82,7 @@ export class ArcGISMapTileSource
     const metadata = await this._getMetadata();
     const extent = metadata.fullExtent;
     const spatialReference = metadata.spatialReference || extent?.spatialReference;
+    const spatialReferenceWkid = (spatialReference as {wkid?: number} | undefined)?.wkid;
     return {
       name: metadata.name || '',
       title: metadata.name || '',
@@ -98,8 +99,8 @@ export class ArcGISMapTileSource
           ]
         : undefined,
       layer: {
-        name: this._metadata.name || '',
-        srs: spatialReference?.wkid ? [`EPSG:${spatialReference.wkid}`] : [],
+        name: metadata.name || '',
+        srs: spatialReferenceWkid ? [`EPSG:${spatialReferenceWkid}`] : [],
         layers: []
       }
     };

--- a/modules/wms/src/arcgis/arcgis-map-tile-source-loader.ts
+++ b/modules/wms/src/arcgis/arcgis-map-tile-source-loader.ts
@@ -18,12 +18,20 @@ import {DataSource} from '@loaders.gl/loader-utils';
 /** Options for an ArcGIS cached MapServer tile source. */
 export type ArcGISMapTileSourceLoaderOptions = DataSourceOptions & {
   'arcgis-map-server'?: {
+    /** Select cached tiles, dynamic export tiles, or automatic metadata-based selection. */
+    mode?: 'cached' | 'dynamic' | 'auto';
+    /** Tile size used for dynamic export requests. */
+    tileSize?: number;
     /** Optional custom tile URL template. */
     urlTemplate?: string;
+    /** Optional service URL pool for simple request distribution. */
+    urls?: string[];
     /** Additional query parameters sent to the metadata endpoint. */
     parameters?: Record<string, string>;
     /** Metadata document supplied by the application. */
     metadata?: ArcGISMapServerMetadata;
+    /** Default parameters forwarded to MapServer `export` requests. */
+    exportParameters?: Record<string, string | number | boolean>;
   };
 };
 
@@ -35,8 +43,17 @@ export type ArcGISMapServerMetadata = {
   copyrightText?: string;
   fullExtent?: {xmin: number; ymin: number; xmax: number; ymax: number; spatialReference?: unknown};
   spatialReference?: unknown;
-  tileInfo?: {lods?: {level: number}[]; rows?: number; cols?: number; format?: string};
+  tileInfo?: {
+    lods?: {level: number}[];
+    rows?: number;
+    cols?: number;
+    format?: string;
+    spatialReference?: unknown;
+  };
 };
+
+/** Parameters that can be changed between ArcGIS map tile requests. */
+export type ArcGISMapTileParameters = Record<string, string | number | boolean>;
 
 /** ArcGIS MapServer source for cached `/tile/{z}/{y}/{x}` image tiles. */
 export class ArcGISMapTileSource
@@ -47,6 +64,7 @@ export class ArcGISMapTileSource
   readonly mimeType = 'image/png';
 
   private _metadata: any | null = null;
+  private _runtimeParameters: ArcGISMapTileParameters = {};
 
   /** Creates an ArcGIS MapServer tile source. */
   constructor(url: string, options: ArcGISMapTileSourceLoaderOptions = {}, coreApi?: CoreAPI) {
@@ -84,7 +102,17 @@ export class ArcGISMapTileSource
 
   /** Fetches and decodes one cached ArcGIS tile. */
   async getTile(parameters: GetTileParameters, signal?: AbortSignal): Promise<ImageType | null> {
-    const response = await this.fetch(this.getTileURL(parameters), signal ? {signal} : undefined);
+    const options = this.options['arcgis-map-server'] || {};
+    const mode = options.mode || 'auto';
+    if (mode === 'auto' && !this._metadata) {
+      this._metadata = await this._loadMetadata();
+    }
+    const metadata = this._metadata;
+    const useCachedTiles = mode === 'cached' || (mode === 'auto' && Boolean(metadata?.tileInfo));
+    const tileURL = useCachedTiles
+      ? this.getTileURL(parameters)
+      : this.getExportTileURL(parameters, options.tileSize || 256);
+    const response = await this.fetch(tileURL, signal ? {signal} : undefined);
     if (!response.ok) {
       throw new Error(
         `ArcGIS MapServer tile request failed: ${response.status} ${response.statusText}`
@@ -114,8 +142,37 @@ export class ArcGISMapTileSource
       );
       return templateURL.toString();
     }
-    const url = new URL(this.url);
+    const url = new URL(this.getServiceURL(parameters));
     url.pathname = `${url.pathname.replace(/\/$/, '')}/tile/${parameters.z}/${parameters.y}/${parameters.x}`;
+    return url.toString();
+  }
+
+  /** Updates parameters applied to subsequent dynamic MapServer export requests. */
+  updateParameters(parameters: ArcGISMapTileParameters): void {
+    this._runtimeParameters = {...this._runtimeParameters, ...parameters};
+  }
+
+  /** Builds a dynamic MapServer `export` request for one web-mercator tile. */
+  getExportTileURL(parameters: GetTileParameters, tileSize?: number): string {
+    const options = this.options['arcgis-map-server'] || {};
+    const resolvedTileSize = tileSize || options.tileSize || 256;
+    const [west, south, east, north] = getWebMercatorTileBounds(parameters);
+    const url = new URL(this.getServiceURL(parameters));
+    url.pathname = `${url.pathname.replace(/\/$/, '')}/export`;
+    const searchParameters: ArcGISMapTileParameters = {
+      f: 'image',
+      bbox: `${west},${south},${east},${north}`,
+      bboxSR: 3857,
+      imageSR: 3857,
+      size: `${resolvedTileSize},${resolvedTileSize}`,
+      format: 'png32',
+      transparent: true,
+      ...options.exportParameters,
+      ...this._runtimeParameters
+    };
+    for (const [key, value] of Object.entries(searchParameters)) {
+      url.searchParams.set(key, String(value));
+    }
     return url.toString();
   }
 
@@ -137,6 +194,22 @@ export class ArcGISMapTileSource
     }
     return response.json();
   }
+
+  private getServiceURL(parameters: GetTileParameters): string {
+    const urls = this.options['arcgis-map-server']?.urls;
+    return urls?.length ? urls[(parameters.x + parameters.y) % urls.length] : this.url;
+  }
+}
+
+function getWebMercatorTileBounds(parameters: GetTileParameters): [number, number, number, number] {
+  const worldSize = 20037508.342789244;
+  const tileCount = 2 ** parameters.z;
+  const tileSize = (worldSize * 2) / tileCount;
+  const west = -worldSize + parameters.x * tileSize;
+  const east = west + tileSize;
+  const north = worldSize - parameters.y * tileSize;
+  const south = north - tileSize;
+  return [west, south, east, north];
 }
 
 /** Source loader for ArcGIS cached MapServer tiles. */

--- a/modules/wms/src/index.ts
+++ b/modules/wms/src/index.ts
@@ -91,6 +91,11 @@ export {
   ArcGISMapTileSourceLoader,
   ArcGISMapTileSource
 } from './arcgis/arcgis-map-tile-source-loader';
+export type {ArcGISImageTileSourceLoaderOptions} from './arcgis/arcgis-image-tile-source-loader';
+export {
+  ArcGISImageTileSourceLoader,
+  ArcGISImageTileSource
+} from './arcgis/arcgis-image-tile-source-loader';
 
 export {ImageSource} from '@loaders.gl/loader-utils';
 export type {ImageType} from '@loaders.gl/images';

--- a/modules/wms/test/arcgis/arcgis-server.spec.ts
+++ b/modules/wms/test/arcgis/arcgis-server.spec.ts
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import test from 'test/utils/vitest-tape';
+import {expect, test as vitestTest} from 'vitest';
 
 import {
   _ArcGISFeatureServerSourceLoader as ArcGISFeatureServerSourceLoader,
@@ -31,44 +32,41 @@ test('ArcGISMapTileSource#getTileURL preserves endpoint parameters', t => {
   t.end();
 });
 
-test('ArcGISMapTileSource builds dynamic export tiles and updates parameters', t => {
+vitestTest('ArcGISMapTileSource builds dynamic export tiles and updates parameters', () => {
   const source = new ArcGISMapTileSource('https://example.com/MapServer', {
     'arcgis-map-server': {mode: 'dynamic', tileSize: 512}
   });
   source.updateParameters({layers: 'show:0', format: 'jpgpng'});
   const url = new URL(source.getExportTileURL({x: 1, y: 2, z: 3}));
-  t.equal(url.pathname, '/MapServer/export');
-  t.equal(url.searchParams.get('size'), '512,512');
-  t.equal(url.searchParams.get('layers'), 'show:0');
-  t.equal(url.searchParams.get('format'), 'jpgpng');
-  t.end();
+  expect(url.pathname).toBe('/MapServer/export');
+  expect(url.searchParams.get('size')).toBe('512,512');
+  expect(url.searchParams.get('layers')).toBe('show:0');
+  expect(url.searchParams.get('format')).toBe('jpgpng');
 });
 
-test('ArcGISMapTileSource distributes requests across configured service URLs', t => {
+vitestTest('ArcGISMapTileSource distributes requests across configured service URLs', () => {
   const source = new ArcGISMapTileSource('https://example.com/MapServer', {
     'arcgis-map-server': {
       urls: ['https://tiles-a.example.com/MapServer', 'https://tiles-b.example.com/MapServer']
     }
   });
   const url = new URL(source.getTileURL({x: 1, y: 0, z: 0}));
-  t.equal(url.origin, 'https://tiles-b.example.com');
-  t.end();
+  expect(url.origin).toBe('https://tiles-b.example.com');
 });
 
-test('ArcGISImageTileSource builds exportImage tile requests', t => {
+vitestTest('ArcGISImageTileSource builds exportImage tile requests', () => {
   const source = new ArcGISImageTileSource('https://example.com/ImageServer', {
     'arcgis-image-server-tiles': {tileSize: 512, parameters: {time: '2020-01-01'}}
   });
   source.updateParameters({renderingRule: '{"rasterFunction":"Hillshade"}'});
   const url = new URL(source.getTileURL({x: 0, y: 0, z: 0}));
-  t.equal(url.pathname, '/ImageServer/exportImage');
-  t.equal(url.searchParams.get('size'), '512,512');
-  t.equal(url.searchParams.get('time'), '2020-01-01');
-  t.equal(url.searchParams.get('renderingRule'), '{"rasterFunction":"Hillshade"}');
-  t.end();
+  expect(url.pathname).toBe('/ImageServer/exportImage');
+  expect(url.searchParams.get('size')).toBe('512,512');
+  expect(url.searchParams.get('time')).toBe('2020-01-01');
+  expect(url.searchParams.get('renderingRule')).toBe('{"rasterFunction":"Hillshade"}');
 });
 
-test('ArcGISImageTileSource distributes requests across configured service URLs', t => {
+vitestTest('ArcGISImageTileSource distributes requests across configured service URLs', () => {
   const source = new ArcGISImageTileSource('https://example.com/ImageServer', {
     'arcgis-image-server-tiles': {
       urls: [
@@ -78,8 +76,7 @@ test('ArcGISImageTileSource distributes requests across configured service URLs'
     }
   });
   const url = new URL(source.getTileURL({x: 1, y: 0, z: 0}));
-  t.equal(url.origin, 'https://imagery-b.example.com');
-  t.end();
+  expect(url.origin).toBe('https://imagery-b.example.com');
 });
 
 test('ArcGISImageSource#metadataURL', t => {

--- a/modules/wms/test/arcgis/arcgis-server.spec.ts
+++ b/modules/wms/test/arcgis/arcgis-server.spec.ts
@@ -7,6 +7,7 @@ import test from 'test/utils/vitest-tape';
 import {
   _ArcGISFeatureServerSourceLoader as ArcGISFeatureServerSourceLoader,
   _ArcGISImageServerSourceLoader as ArcGISImageServerSourceLoader,
+  ArcGISImageTileSource,
   ArcGISMapTileSource
 } from '@loaders.gl/wms';
 
@@ -27,6 +28,57 @@ test('ArcGISMapTileSource#getTileURL preserves endpoint parameters', t => {
   const url = new URL(source.getTileURL({x: 3, y: 4, z: 5}));
   t.equal(url.pathname, '/MapServer/tile/5/4/3');
   t.equal(url.searchParams.get('token'), 'abc');
+  t.end();
+});
+
+test('ArcGISMapTileSource builds dynamic export tiles and updates parameters', t => {
+  const source = new ArcGISMapTileSource('https://example.com/MapServer', {
+    'arcgis-map-server': {mode: 'dynamic', tileSize: 512}
+  });
+  source.updateParameters({layers: 'show:0', format: 'jpgpng'});
+  const url = new URL(source.getExportTileURL({x: 1, y: 2, z: 3}));
+  t.equal(url.pathname, '/MapServer/export');
+  t.equal(url.searchParams.get('size'), '512,512');
+  t.equal(url.searchParams.get('layers'), 'show:0');
+  t.equal(url.searchParams.get('format'), 'jpgpng');
+  t.end();
+});
+
+test('ArcGISMapTileSource distributes requests across configured service URLs', t => {
+  const source = new ArcGISMapTileSource('https://example.com/MapServer', {
+    'arcgis-map-server': {
+      urls: ['https://tiles-a.example.com/MapServer', 'https://tiles-b.example.com/MapServer']
+    }
+  });
+  const url = new URL(source.getTileURL({x: 1, y: 0, z: 0}));
+  t.equal(url.origin, 'https://tiles-b.example.com');
+  t.end();
+});
+
+test('ArcGISImageTileSource builds exportImage tile requests', t => {
+  const source = new ArcGISImageTileSource('https://example.com/ImageServer', {
+    'arcgis-image-server-tiles': {tileSize: 512, parameters: {time: '2020-01-01'}}
+  });
+  source.updateParameters({renderingRule: '{"rasterFunction":"Hillshade"}'});
+  const url = new URL(source.getTileURL({x: 0, y: 0, z: 0}));
+  t.equal(url.pathname, '/ImageServer/exportImage');
+  t.equal(url.searchParams.get('size'), '512,512');
+  t.equal(url.searchParams.get('time'), '2020-01-01');
+  t.equal(url.searchParams.get('renderingRule'), '{"rasterFunction":"Hillshade"}');
+  t.end();
+});
+
+test('ArcGISImageTileSource distributes requests across configured service URLs', t => {
+  const source = new ArcGISImageTileSource('https://example.com/ImageServer', {
+    'arcgis-image-server-tiles': {
+      urls: [
+        'https://imagery-a.example.com/ImageServer',
+        'https://imagery-b.example.com/ImageServer'
+      ]
+    }
+  });
+  const url = new URL(source.getTileURL({x: 1, y: 0, z: 0}));
+  t.equal(url.origin, 'https://imagery-b.example.com');
   t.end();
 });
 

--- a/website/src/examples/tiles/arcgis-image-server-tiles.mdx
+++ b/website/src/examples/tiles/arcgis-image-server-tiles.mdx
@@ -1,0 +1,12 @@
+---
+title: "ArcGIS ImageServer Tiles"
+---
+
+import {ClientExample} from '../../components';
+import {WmsDocsTabs} from '@site/src/components/docs/wms-docs-tabs';
+
+# ArcGIS ImageServer Tiles
+
+<WmsDocsTabs active="arcgis-image-server-example" />
+
+<ClientExample kind="wms" format="ArcGIS ImageServer tiles" />


### PR DESCRIPTION
## Goals

Advance loaders.gl's geospatial service support beyond basic protocol parity by making ArcGIS services first-class deck.gl tile sources with service-aware routing and runtime rendering controls.

## Changes

- Add automatic cached `/tile` versus dynamic `/export` selection for ArcGIS MapServer sources.
- Add dynamic export parameters, configurable tile size, runtime `updateParameters`, and service URL pools.
- Add `ArcGISImageTileSourceLoader` for ImageServer `/exportImage` tile requests.
- Add ArcGIS ImageServer tile and MapServer dynamic examples to the website and service documentation.
- Add focused tests for dynamic requests, runtime parameters, endpoint query preservation, and URL pools.

## Validation

- `yarn build`
- `yarn build-workers`
- `yarn test-node`
- `yarn test-headless`
- `yarn lint fix`
- `cd website && yarn build`
