### PR TITLE
fix(tiles): use math.gl region bounding boxes

### DIFF
--- a/modules/3d-tiles/package.json
+++ b/modules/3d-tiles/package.json
@@ -77,9 +77,9 @@
     "@loaders.gl/math": "5.0.0-alpha.2",
     "@loaders.gl/tiles": "5.0.0-alpha.2",
     "@loaders.gl/zip": "5.0.0-alpha.2",
-    "@math.gl/core": "^4.1.0",
-    "@math.gl/culling": "^4.1.0",
-    "@math.gl/geospatial": "^4.1.0",
+    "@math.gl/core": "4.2.0-alpha.5",
+    "@math.gl/culling": "4.2.0-alpha.5",
+    "@math.gl/geospatial": "4.2.0-alpha.5",
     "long": "^5.2.1",
     "zod": "^4.1.12"
   },

--- a/modules/arrow/package.json
+++ b/modules/arrow/package.json
@@ -79,7 +79,7 @@
     "@loaders.gl/schema-utils": "5.0.0-alpha.2",
     "@loaders.gl/wkt": "5.0.0-alpha.2",
     "@loaders.gl/worker-utils": "5.0.0-alpha.2",
-    "@math.gl/polygon": "^4.1.0",
+    "@math.gl/polygon": "4.2.0-alpha.5",
     "apache-arrow": ">= 17.0.0"
   },
   "peerDependencies": {

--- a/modules/deck-layers/package.json
+++ b/modules/deck-layers/package.json
@@ -53,6 +53,6 @@
     "@luma.gl/core": "^9.3.2",
     "@luma.gl/engine": "^9.3.2",
     "@luma.gl/shadertools": "^9.3.2",
-    "@math.gl/culling": "^4.1.0"
+    "@math.gl/culling": "4.2.0-alpha.5"
   }
 }

--- a/modules/geoarrow/package.json
+++ b/modules/geoarrow/package.json
@@ -57,7 +57,7 @@
     "@loaders.gl/loader-utils": "5.0.0-alpha.2",
     "@loaders.gl/schema": "5.0.0-alpha.2",
     "@loaders.gl/schema-utils": "5.0.0-alpha.2",
-    "@math.gl/polygon": "^4.1.0",
+    "@math.gl/polygon": "4.2.0-alpha.5",
     "apache-arrow": ">= 17.0.0"
   },
   "peerDependencies": {

--- a/modules/gis/package.json
+++ b/modules/gis/package.json
@@ -48,7 +48,7 @@
     "@loaders.gl/schema-utils": "5.0.0-alpha.2",
     "@mapbox/vector-tile": "^1.3.1",
     "@math.gl/crs": "^4.2.0-alpha.5",
-    "@math.gl/polygon": "^4.1.0",
+    "@math.gl/polygon": "4.2.0-alpha.5",
     "apache-arrow": ">= 17.0.0",
     "pbf": "^3.2.1",
     "zod": "^4.1.12"

--- a/modules/gltf/package.json
+++ b/modules/gltf/package.json
@@ -73,7 +73,7 @@
     "@loaders.gl/schema": "5.0.0-alpha.2",
     "@loaders.gl/schema-utils": "5.0.0-alpha.2",
     "@loaders.gl/textures": "5.0.0-alpha.2",
-    "@math.gl/core": "^4.1.0",
+    "@math.gl/core": "4.2.0-alpha.5",
     "meshoptimizer": "^1.2.0",
     "zod": "^4.1.12"
   },

--- a/modules/i3s/package.json
+++ b/modules/i3s/package.json
@@ -74,10 +74,10 @@
     "@loaders.gl/textures": "5.0.0-alpha.2",
     "@loaders.gl/tiles": "5.0.0-alpha.2",
     "@loaders.gl/zip": "5.0.0-alpha.2",
-    "@math.gl/core": "^4.1.0",
+    "@math.gl/core": "4.2.0-alpha.5",
     "@math.gl/crs": "^4.2.0-alpha.5",
-    "@math.gl/culling": "^4.1.0",
-    "@math.gl/geospatial": "^4.1.0",
+    "@math.gl/culling": "4.2.0-alpha.5",
+    "@math.gl/geospatial": "4.2.0-alpha.5",
     "zod": "^4.1.12"
   },
   "peerDependencies": {

--- a/modules/math/package.json
+++ b/modules/math/package.json
@@ -39,7 +39,7 @@
     "pre-build": "echo \"Nothing to build in @loaders.gl/math\""
   },
   "dependencies": {
-    "@math.gl/core": "^4.1.0"
+    "@math.gl/core": "4.2.0-alpha.5"
   },
   "peerDependencies": {
     "@loaders.gl/core": "~5.0.0-alpha.0"

--- a/modules/mvt/package.json
+++ b/modules/mvt/package.json
@@ -65,7 +65,7 @@
     "@loaders.gl/loader-utils": "5.0.0-alpha.2",
     "@loaders.gl/schema": "5.0.0-alpha.2",
     "@loaders.gl/schema-utils": "5.0.0-alpha.2",
-    "@math.gl/polygon": "^4.1.0",
+    "@math.gl/polygon": "4.2.0-alpha.5",
     "@probe.gl/stats": "^4.1.1",
     "pbf": "^3.2.1",
     "zod": "^4.1.12"

--- a/modules/potree/package.json
+++ b/modules/potree/package.json
@@ -64,7 +64,7 @@
     "@loaders.gl/math": "5.0.0-alpha.2",
     "@loaders.gl/schema": "5.0.0-alpha.2",
     "@loaders.gl/schema-utils": "5.0.0-alpha.2",
-    "@math.gl/core": "^4.1.0",
+    "@math.gl/core": "4.2.0-alpha.5",
     "@math.gl/crs": "^4.2.0-alpha.5",
     "@math.gl/proj4": "^4.2.0-alpha.5",
     "zod": "^4.1.12"

--- a/modules/schema-utils/package.json
+++ b/modules/schema-utils/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@loaders.gl/schema": "5.0.0-alpha.2",
-    "@math.gl/types": "^4.1.0",
+    "@math.gl/types": "4.2.0-alpha.5",
     "@types/geojson": "^7946.0.7",
     "apache-arrow": ">= 17.0.0"
   },

--- a/modules/textures/package.json
+++ b/modules/textures/package.json
@@ -94,7 +94,7 @@
     "@loaders.gl/loader-utils": "5.0.0-alpha.2",
     "@loaders.gl/schema": "5.0.0-alpha.2",
     "@loaders.gl/worker-utils": "5.0.0-alpha.2",
-    "@math.gl/types": "^4.1.0",
+    "@math.gl/types": "4.2.0-alpha.5",
     "ktx-parse": "^0.7.0",
     "zod": "^4.1.12"
   },

--- a/modules/tiles/package.json
+++ b/modules/tiles/package.json
@@ -45,10 +45,10 @@
     "@loaders.gl/loader-utils": "5.0.0-alpha.2",
     "@loaders.gl/math": "5.0.0-alpha.2",
     "@loaders.gl/schema": "5.0.0-alpha.2",
-    "@math.gl/core": "^4.1.0",
-    "@math.gl/culling": "^4.1.0",
-    "@math.gl/geospatial": "^4.1.0",
-    "@math.gl/web-mercator": "^4.1.0",
+    "@math.gl/core": "4.2.0-alpha.5",
+    "@math.gl/culling": "4.2.0-alpha.5",
+    "@math.gl/geospatial": "4.2.0-alpha.5",
+    "@math.gl/web-mercator": "4.2.0-alpha.5",
     "@probe.gl/stats": "^4.1.1"
   },
   "devDependencies": {

--- a/modules/tiles/src/tileset-3d/helpers/bounding-volume.ts
+++ b/modules/tiles/src/tileset-3d/helpers/bounding-volume.ts
@@ -4,9 +4,9 @@
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 
 /* eslint-disable */
-import {Quaternion, Vector3, Matrix3, Matrix4, degrees} from '@math.gl/core';
+import {Quaternion, Vector3, Matrix3, degrees} from '@math.gl/core';
 import {BoundingSphere, OrientedBoundingBox} from '@math.gl/culling';
-import {Ellipsoid} from '@math.gl/geospatial';
+import {Ellipsoid, makeOBBFromRegion} from '@math.gl/geospatial';
 import {assert} from '@loaders.gl/loader-utils';
 
 // const scratchProjectedBoundingSphere = new BoundingSphere();
@@ -18,12 +18,6 @@ function defined(x) {
 // const scratchMatrix = new Matrix3();
 const scratchPoint = new Vector3();
 const scratchScale = new Vector3();
-const scratchNorthWest = new Vector3();
-const scratchSouthEast = new Vector3();
-const scratchCenter = new Vector3();
-const scratchXAxis = new Vector3();
-const scratchYAxis = new Vector3();
-const scratchZAxis = new Vector3();
 // const scratchRectangle = new Rectangle();
 // const scratchOrientedBoundingBox = new OrientedBoundingBox();
 // const scratchTransform = new Matrix4();
@@ -44,7 +38,7 @@ export function createBoundingVolume(boundingVolumeHeader, transform, result?) {
     return createBox(boundingVolumeHeader.box, transform, result);
   }
   if (boundingVolumeHeader.region) {
-    return createObbFromRegion(boundingVolumeHeader.region);
+    return makeOBBFromRegion(boundingVolumeHeader.region);
   }
 
   if (boundingVolumeHeader.sphere) {
@@ -219,52 +213,6 @@ function createSphere(sphere, transform, result?) {
   }
 
   return new BoundingSphere(center, radius);
-}
-
-/**
- * Create OrientedBoundingBox instance from region 3D tiles bounding volume
- * @param region - region 3D tiles bounding volume
- * @returns OrientedBoundingBox instance
- */
-function createObbFromRegion(region: number[]): OrientedBoundingBox {
-  // [west, south, east, north, minimum height, maximum height]
-  // Latitudes and longitudes are in the WGS 84 datum as defined in EPSG 4979 and are in radians.
-  // Heights are in meters above (or below) the WGS 84 ellipsoid.
-  const [west, south, east, north, minHeight, maxHeight] = region;
-
-  const northWest = Ellipsoid.WGS84.cartographicToCartesian(
-    [degrees(west), degrees(north), minHeight],
-    scratchNorthWest
-  );
-  const southEast = Ellipsoid.WGS84.cartographicToCartesian(
-    [degrees(east), degrees(south), maxHeight],
-    scratchSouthEast
-  );
-  const centerInCartesian = new Vector3().addVectors(northWest, southEast).multiplyByScalar(0.5);
-  Ellipsoid.WGS84.cartesianToCartographic(centerInCartesian, scratchCenter);
-
-  Ellipsoid.WGS84.cartographicToCartesian(
-    [degrees(east), scratchCenter[1], scratchCenter[2]],
-    scratchXAxis
-  );
-  Ellipsoid.WGS84.cartographicToCartesian(
-    [scratchCenter[0], degrees(north), scratchCenter[2]],
-    scratchYAxis
-  );
-  Ellipsoid.WGS84.cartographicToCartesian(
-    [scratchCenter[0], scratchCenter[1], maxHeight],
-    scratchZAxis
-  );
-
-  return createBox(
-    [
-      ...centerInCartesian,
-      ...scratchXAxis.subtract(centerInCartesian),
-      ...scratchYAxis.subtract(centerInCartesian),
-      ...scratchZAxis.subtract(centerInCartesian)
-    ],
-    new Matrix4()
-  );
 }
 
 /**

--- a/modules/tiles/test/tileset/helpers/bounding-volume.spec.ts
+++ b/modules/tiles/test/tileset/helpers/bounding-volume.spec.ts
@@ -2,36 +2,31 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {createBoundingVolume} from '../../../src/tileset-3d/helpers/bounding-volume';
-import {Matrix4} from '@math.gl/core';
+import {degrees, Matrix4} from '@math.gl/core';
 import {OrientedBoundingBox} from '@math.gl/culling';
-import {areNumberArraysEqual} from '../../test-utils/compareArrays';
+import {Ellipsoid} from '@math.gl/geospatial';
 
-test('Tiles bounding-volume#createBoundingVolume - should convert region to obb', t => {
-  const result = createBoundingVolume(
-    {
-      region: [
-        0.7853981633974483, 0.22689280275926285, 0.8028514559173916, 0.24434609527920614,
-        -17.29296875, 2493.5625
-      ]
-    },
-    new Matrix4()
-  );
-  t.ok(result instanceof OrientedBoundingBox);
-  t.ok(
-    areNumberArraysEqual(result.center, [4348195.679745842, 4424932.075472673, 1479471.892147189])
-  );
-  t.ok(
-    areNumberArraysEqual(
-      result.halfAxes,
-      // biome-ignore format: preserve intentional fixture layout
-      [
-        -38691.151309899986, 37690.50114047807, -2.3283064365386963e-10, 
-        -9209.347353689373, -9371.872726273723, 53695.496290528914, 
-        1176.6872740909457, 1197.4532991172746, 403.06533637456596
-      ]
-    )
-  );
-  t.end();
+test('Tiles bounding-volume#createBoundingVolume - bounds Cesium OSM region', () => {
+  // Root region reported by Cesium OSM Buildings in loaders.gl issue #3144.
+  const region = [
+    -3.1415925942485985, -1.4599681618940228, 3.141545370875028, 1.4502639200680947,
+    -385.0565011513918, 5967.300616082603
+  ];
+  const result = createBoundingVolume({region}, new Matrix4());
+
+  expect(result).toBeInstanceOf(OrientedBoundingBox);
+  expect(result.center.every(Number.isFinite)).toBe(true);
+  expect(result.halfAxes.every(Number.isFinite)).toBe(true);
+
+  const [, south, , north, minimumHeight, maximumHeight] = region;
+  for (const longitude of [-180, -90, 0, 90, 179]) {
+    for (const latitude of [degrees(south), 0, degrees(north)]) {
+      for (const height of [minimumHeight, maximumHeight]) {
+        const point = Ellipsoid.WGS84.cartographicToCartesian([longitude, latitude, height]);
+        expect(result.distanceTo(point)).toBeLessThan(1e-5);
+      }
+    }
+  }
 });

--- a/modules/tiles/test/tileset/tile-3d.spec.ts
+++ b/modules/tiles/test/tileset/tile-3d.spec.ts
@@ -45,7 +45,7 @@ const TILE_HEADER_WITH_BOUNDING_REGION = {
   refine: 'REPLACE',
   children: [],
   boundingVolume: {
-    region: [-1.2, -1.2, 0.0, 0.0, -30, -34]
+    region: [-1.2, -1.2, 0.0, 0.0, -34, -30]
   }
 };
 
@@ -57,11 +57,11 @@ const TILE_HEADER_WITH_CONTENT_BOUNDING_REGION = {
   content: {
     url: '0/0.b3dm',
     boundingVolume: {
-      region: [-1.2, -1.2, 0, 0, -30, -34]
+      region: [-1.2, -1.2, 0, 0, -34, -30]
     }
   },
   boundingVolume: {
-    region: [-1.2, -1.2, 0, 0, -30, -34]
+    region: [-1.2, -1.2, 0, 0, -34, -30]
   }
 };
 */

--- a/package.json
+++ b/package.json
@@ -95,11 +95,20 @@
   "pre-push": "pre-push",
   "resolutions_notes": [
     "Ensure we use recent typescript",
-    "apache-arrow version should be aligned with parquet-wasm version"
+    "apache-arrow version should be aligned with parquet-wasm version",
+    "Keep math.gl alpha packages aligned across loaders.gl and other vis.gl dependencies"
   ],
   "resolutions": {
     "apache-arrow": "^21.2.0",
     "typescript": "^6.0.3",
+    "@math.gl/core": "4.2.0-alpha.5",
+    "@math.gl/culling": "4.2.0-alpha.5",
+    "@math.gl/geoid": "4.2.0-alpha.5",
+    "@math.gl/geospatial": "4.2.0-alpha.5",
+    "@math.gl/polygon": "4.2.0-alpha.5",
+    "@math.gl/sun": "4.2.0-alpha.5",
+    "@math.gl/types": "4.2.0-alpha.5",
+    "@math.gl/web-mercator": "4.2.0-alpha.5",
     "@loaders.gl/3d-tiles": "^5.0.0-alpha.0",
     "@loaders.gl/compression": "^5.0.0-alpha.0",
     "@loaders.gl/core": "^5.0.0-alpha.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5128,9 +5128,9 @@ __metadata:
     "@loaders.gl/math": "npm:5.0.0-alpha.2"
     "@loaders.gl/tiles": "npm:5.0.0-alpha.2"
     "@loaders.gl/zip": "npm:5.0.0-alpha.2"
-    "@math.gl/core": "npm:^4.1.0"
-    "@math.gl/culling": "npm:^4.1.0"
-    "@math.gl/geospatial": "npm:^4.1.0"
+    "@math.gl/core": "npm:4.2.0-alpha.5"
+    "@math.gl/culling": "npm:4.2.0-alpha.5"
+    "@math.gl/geospatial": "npm:4.2.0-alpha.5"
     long: "npm:^5.2.1"
     zod: "npm:^4.1.12"
   peerDependencies:
@@ -5148,7 +5148,7 @@ __metadata:
     "@loaders.gl/schema-utils": "npm:5.0.0-alpha.2"
     "@loaders.gl/wkt": "npm:5.0.0-alpha.2"
     "@loaders.gl/worker-utils": "npm:5.0.0-alpha.2"
-    "@math.gl/polygon": "npm:^4.1.0"
+    "@math.gl/polygon": "npm:4.2.0-alpha.5"
     apache-arrow: "npm:>= 17.0.0"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
@@ -5282,7 +5282,7 @@ __metadata:
     "@luma.gl/core": "npm:^9.3.2"
     "@luma.gl/engine": "npm:^9.3.2"
     "@luma.gl/shadertools": "npm:^9.3.2"
-    "@math.gl/culling": "npm:^4.1.0"
+    "@math.gl/culling": "npm:4.2.0-alpha.5"
   languageName: unknown
   linkType: soft
 
@@ -5338,7 +5338,7 @@ __metadata:
     "@loaders.gl/loader-utils": "npm:5.0.0-alpha.2"
     "@loaders.gl/schema": "npm:5.0.0-alpha.2"
     "@loaders.gl/schema-utils": "npm:5.0.0-alpha.2"
-    "@math.gl/polygon": "npm:^4.1.0"
+    "@math.gl/polygon": "npm:4.2.0-alpha.5"
     apache-arrow: "npm:>= 17.0.0"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
@@ -5386,7 +5386,7 @@ __metadata:
     "@loaders.gl/schema-utils": "npm:5.0.0-alpha.2"
     "@mapbox/vector-tile": "npm:^1.3.1"
     "@math.gl/crs": "npm:^4.2.0-alpha.5"
-    "@math.gl/polygon": "npm:^4.1.0"
+    "@math.gl/polygon": "npm:4.2.0-alpha.5"
     "@math.gl/proj4": "npm:^4.2.0-alpha.5"
     apache-arrow: "npm:>= 17.0.0"
     pbf: "npm:^3.2.1"
@@ -5406,7 +5406,7 @@ __metadata:
     "@loaders.gl/schema": "npm:5.0.0-alpha.2"
     "@loaders.gl/schema-utils": "npm:5.0.0-alpha.2"
     "@loaders.gl/textures": "npm:5.0.0-alpha.2"
-    "@math.gl/core": "npm:^4.1.0"
+    "@math.gl/core": "npm:4.2.0-alpha.5"
     meshoptimizer: "npm:^1.2.0"
     zod: "npm:^4.1.12"
   peerDependencies:
@@ -5436,10 +5436,10 @@ __metadata:
     "@loaders.gl/textures": "npm:5.0.0-alpha.2"
     "@loaders.gl/tiles": "npm:5.0.0-alpha.2"
     "@loaders.gl/zip": "npm:5.0.0-alpha.2"
-    "@math.gl/core": "npm:^4.1.0"
+    "@math.gl/core": "npm:4.2.0-alpha.5"
     "@math.gl/crs": "npm:^4.2.0-alpha.5"
-    "@math.gl/culling": "npm:^4.1.0"
-    "@math.gl/geospatial": "npm:^4.1.0"
+    "@math.gl/culling": "npm:4.2.0-alpha.5"
+    "@math.gl/geospatial": "npm:4.2.0-alpha.5"
     zod: "npm:^4.1.12"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
@@ -5538,7 +5538,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@loaders.gl/math@workspace:modules/math"
   dependencies:
-    "@math.gl/core": "npm:^4.1.0"
+    "@math.gl/core": "npm:4.2.0-alpha.5"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
   languageName: unknown
@@ -5567,7 +5567,7 @@ __metadata:
     "@loaders.gl/loader-utils": "npm:5.0.0-alpha.2"
     "@loaders.gl/schema": "npm:5.0.0-alpha.2"
     "@loaders.gl/schema-utils": "npm:5.0.0-alpha.2"
-    "@math.gl/polygon": "npm:^4.1.0"
+    "@math.gl/polygon": "npm:4.2.0-alpha.5"
     "@probe.gl/stats": "npm:^4.1.1"
     "@types/pbf": "npm:^3.0.2"
     pbf: "npm:^3.2.1"
@@ -5707,7 +5707,7 @@ __metadata:
     "@loaders.gl/math": "npm:5.0.0-alpha.2"
     "@loaders.gl/schema": "npm:5.0.0-alpha.2"
     "@loaders.gl/schema-utils": "npm:5.0.0-alpha.2"
-    "@math.gl/core": "npm:^4.1.0"
+    "@math.gl/core": "npm:4.2.0-alpha.5"
     "@math.gl/crs": "npm:^4.2.0-alpha.5"
     "@math.gl/proj4": "npm:^4.2.0-alpha.5"
     zod: "npm:^4.1.12"
@@ -5731,7 +5731,7 @@ __metadata:
   resolution: "@loaders.gl/schema-utils@workspace:modules/schema-utils"
   dependencies:
     "@loaders.gl/schema": "npm:5.0.0-alpha.2"
-    "@math.gl/types": "npm:^4.1.0"
+    "@math.gl/types": "npm:4.2.0-alpha.5"
     "@types/geojson": "npm:^7946.0.7"
     apache-arrow: "npm:>= 17.0.0"
   peerDependencies:
@@ -5835,7 +5835,7 @@ __metadata:
     "@loaders.gl/loader-utils": "npm:5.0.0-alpha.2"
     "@loaders.gl/schema": "npm:5.0.0-alpha.2"
     "@loaders.gl/worker-utils": "npm:5.0.0-alpha.2"
-    "@math.gl/types": "npm:^4.1.0"
+    "@math.gl/types": "npm:4.2.0-alpha.5"
     ktx-parse: "npm:^0.7.0"
     zod: "npm:^4.1.12"
   peerDependencies:
@@ -5899,10 +5899,10 @@ __metadata:
     "@loaders.gl/loader-utils": "npm:5.0.0-alpha.2"
     "@loaders.gl/math": "npm:5.0.0-alpha.2"
     "@loaders.gl/schema": "npm:5.0.0-alpha.2"
-    "@math.gl/core": "npm:^4.1.0"
-    "@math.gl/culling": "npm:^4.1.0"
-    "@math.gl/geospatial": "npm:^4.1.0"
-    "@math.gl/web-mercator": "npm:^4.1.0"
+    "@math.gl/core": "npm:4.2.0-alpha.5"
+    "@math.gl/culling": "npm:4.2.0-alpha.5"
+    "@math.gl/geospatial": "npm:4.2.0-alpha.5"
+    "@math.gl/web-mercator": "npm:4.2.0-alpha.5"
     "@probe.gl/stats": "npm:^4.1.1"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
@@ -6354,15 +6354,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@math.gl/core@npm:4.1.0, @math.gl/core@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@math.gl/core@npm:4.1.0"
-  dependencies:
-    "@math.gl/types": "npm:4.1.0"
-  checksum: 10c0/495934dc2be0b60cd6ff2cc16a0215608c9254919db741a0074b6b41cef9a0543c7f790eda7d529afa102d2937490608ef75fcc64c789ef2876ae750fd0ed3d6
-  languageName: node
-  linkType: hard
-
 "@math.gl/core@npm:4.2.0-alpha.5":
   version: 4.2.0-alpha.5
   resolution: "@math.gl/core@npm:4.2.0-alpha.5"
@@ -6379,41 +6370,42 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@math.gl/culling@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@math.gl/culling@npm:4.1.0"
+"@math.gl/culling@npm:4.2.0-alpha.5":
+  version: 4.2.0-alpha.5
+  resolution: "@math.gl/culling@npm:4.2.0-alpha.5"
   dependencies:
-    "@math.gl/core": "npm:4.1.0"
-    "@math.gl/types": "npm:4.1.0"
-  checksum: 10c0/4489e6379ea4f24480b5a40e6a7dfa90e985b8af4d1051c493cf207e685cf5a09877bad6503f2e53384001fa041c89cb8cf35934570b48acce51b2b94cbfcde5
+    "@math.gl/core": "npm:4.2.0-alpha.5"
+    "@math.gl/types": "npm:4.2.0-alpha.5"
+  checksum: 10c0/208c8f4128e44fb1828c3ba05c9b1b1ceb2da6207c088a51c0ca2a010e1de690e2548fbd423f5bb61663e3dcbbd4653d2e5bc6bbfe8325e6860a7d6334fa1af4
   languageName: node
   linkType: hard
 
-"@math.gl/geoid@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@math.gl/geoid@npm:4.1.0"
+"@math.gl/geoid@npm:4.2.0-alpha.5":
+  version: 4.2.0-alpha.5
+  resolution: "@math.gl/geoid@npm:4.2.0-alpha.5"
   dependencies:
-    "@math.gl/core": "npm:4.1.0"
-  checksum: 10c0/06b664112e10bcb78853d4887721abebe1113d39d9a3f3fabb49d2ce7c2bf48a582f0427a5ab842fc89a67c0c9cb39f75fba97cb69c7d2fe81177b216dec39a2
+    "@math.gl/core": "npm:4.2.0-alpha.5"
+  checksum: 10c0/d2a75bbfb5379f0c0d6bb631f77df258eb248816b5b9463c164b1b352f41128a4323a001395cfc8df1f8224da41b527a7993579ee354cb6a6dcea4a209f9f67b
   languageName: node
   linkType: hard
 
-"@math.gl/geospatial@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@math.gl/geospatial@npm:4.1.0"
+"@math.gl/geospatial@npm:4.2.0-alpha.5":
+  version: 4.2.0-alpha.5
+  resolution: "@math.gl/geospatial@npm:4.2.0-alpha.5"
   dependencies:
-    "@math.gl/core": "npm:4.1.0"
-    "@math.gl/types": "npm:4.1.0"
-  checksum: 10c0/fb7c24dc82dbc32e9982782cda256b242e1a42eb8db69f28fff5653e459d068b44af5dc5eab1da45e43f3502ee4cd741033b656b2adbc7dfc687702a25db7ec2
+    "@math.gl/core": "npm:4.2.0-alpha.5"
+    "@math.gl/culling": "npm:4.2.0-alpha.5"
+    "@math.gl/types": "npm:4.2.0-alpha.5"
+  checksum: 10c0/09db9a0ab10943481d5ec692a8ac742249c9723421004433fc14efe6657cc3c50282a8a08c09bdfce11a9d209fcf81cbd010206fd673fdc991eaa84031312b51
   languageName: node
   linkType: hard
 
-"@math.gl/polygon@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@math.gl/polygon@npm:4.1.0"
+"@math.gl/polygon@npm:4.2.0-alpha.5":
+  version: 4.2.0-alpha.5
+  resolution: "@math.gl/polygon@npm:4.2.0-alpha.5"
   dependencies:
-    "@math.gl/core": "npm:4.1.0"
-  checksum: 10c0/0fcfb489c5613ddff6dd0cbea65084e10fa9a3523fb87a36a4fdf10057d12d2a99f1ebd93da6e72b45db0783fb8cd9cff704765473372a8db580faaf50c85ab5
+    "@math.gl/core": "npm:4.2.0-alpha.5"
+  checksum: 10c0/fabd8b3a10a4021bc3cc4d30b3e6b080d13684477c3e0c058d71b54478e86af6b08c13fc6c68f11ac7029f9bdbd13c77d04918b7d028fd0750747fb4030154c8
   languageName: node
   linkType: hard
 
@@ -6428,17 +6420,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@math.gl/sun@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@math.gl/sun@npm:4.1.0"
-  checksum: 10c0/baf813f3134124a1701c5f64cc8725fdb1d8d4c9e47c7fbd0d2e960d823f776d35312f82c62a09dcb140ea31d42b3945aa781066495291df190566ae17b5857b
-  languageName: node
-  linkType: hard
-
-"@math.gl/types@npm:4.1.0, @math.gl/types@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@math.gl/types@npm:4.1.0"
-  checksum: 10c0/3c4dfa5ac5c9e2cef24d31f56b89c1dde785a5d70fd1a7030386346cb7dd4fa2cce5ba983b89842c1971492e30870dd22a078d64893f9c66887e38367bf992fa
+"@math.gl/sun@npm:4.2.0-alpha.5":
+  version: 4.2.0-alpha.5
+  resolution: "@math.gl/sun@npm:4.2.0-alpha.5"
+  checksum: 10c0/c3f363e80d9f92a7f3992670e2b4ea5f704167dfcfab9fdc91f4431e233863ddaa5b228046aa2f0781dee7dabe6e084972b4ebf855291268e32381f419d8449a
   languageName: node
   linkType: hard
 
@@ -6449,12 +6434,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@math.gl/web-mercator@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@math.gl/web-mercator@npm:4.1.0"
+"@math.gl/web-mercator@npm:4.2.0-alpha.5":
+  version: 4.2.0-alpha.5
+  resolution: "@math.gl/web-mercator@npm:4.2.0-alpha.5"
   dependencies:
-    "@math.gl/core": "npm:4.1.0"
-  checksum: 10c0/7aa4921b9442da75664ef517f41de65b1eae9970d7eee61d14d2eb0b332e1af6203785e8d198376a8ab5924d62b24856d648ff6478cca95b14d3a8d82822ef93
+    "@math.gl/core": "npm:4.2.0-alpha.5"
+  checksum: 10c0/b16ec2627ac3449626396afcd6a8adc57e8cbbe72f37b4cbd4da5e97a58f16670bd20759c05aaac021f3018dfb14c75eee581b48cd8bdcda3af391911dafc448
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Goals

- Use the landed math.gl `makeOBBFromRegion` implementation for 3D Tiles region volumes.
- Correctly handle Cesium OSM Buildings' near-global region.
- Consume the published math.gl alpha containing visgl/math.gl#111.

## Changes

- Update loaders.gl module dependencies on `@math.gl/*` to `4.2.0-alpha.5` and align workspace resolutions.
- Replace the local region OBB implementation with `makeOBBFromRegion`.
- Add a near-global Cesium OSM regression test.
- Correct invalid test-fixture height ordering exposed by math.gl validation.

Supersedes #3176.

## Validation

- `yarn build`
- `yarn build-workers`
- `yarn lint fix`
- `yarn test-audit`
- `yarn test-node` — 44 files, 326 tests passed
- Focused Chromium tests — 2 files, 17 tests passed

The full Chromium suite also exposed one unrelated pre-existing FlatGeobuf reprojection failure.