### PR TITLE
test: expand Draco and SQL coverage

### DIFF
--- a/modules/draco/test/draco-options.spec.ts
+++ b/modules/draco/test/draco-options.spec.ts
@@ -1,0 +1,44 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+
+import {DracoLoader} from '@loaders.gl/draco';
+import {Draco3DLoaderWithParser} from '../src/draco3d-loader-with-parser';
+import {DracoJavaScriptLoaderWithParser} from '../src/draco-javascript-loader-with-parser';
+import {DracoWASMLoaderWithParser} from '../src/draco-wasm-loader-with-parser';
+
+test.each([
+  ['wasm', DracoWASMLoaderWithParser],
+  ['javascript', DracoJavaScriptLoaderWithParser],
+  ['js', DracoJavaScriptLoaderWithParser],
+  ['draco3d', Draco3DLoaderWithParser]
+])('DracoLoader accepts the %s backend option', async (backend, expectedLoader) => {
+  const loader = await DracoLoader.preload?.('', {
+    draco: {backend}
+  });
+
+  expect(loader).toBe(expectedLoader);
+});
+
+test('DracoLoader defaults to the configured platform backend', async () => {
+  const loader = await DracoLoader.preload?.('');
+  expect(loader).toBe(
+    DracoLoader.options.draco.backend === 'wasm'
+      ? DracoWASMLoaderWithParser
+      : DracoJavaScriptLoaderWithParser
+  );
+});
+
+test('DracoLoader rejects unsupported backend options', async () => {
+  await expect(
+    DracoLoader.preload?.('', {draco: {backend: 'unsupported' as never}})
+  ).rejects.toThrow('unsupported backend');
+});
+
+test('Draco3D parser requires an injected draco3d module', async () => {
+  await expect(Draco3DLoaderWithParser.parse(new ArrayBuffer(0), {})).rejects.toThrow(
+    'requires options.modules.draco3d'
+  );
+});

--- a/modules/sql/test/arrow-query.spec.ts
+++ b/modules/sql/test/arrow-query.spec.ts
@@ -47,6 +47,45 @@ test('ArrowTableSource exposes shared metadata and bounded scan batches', async 
   expect(batches[0].data.schema.fields.map(field => field.name)).toEqual(['value']);
 });
 
+test('ArrowTableSource assigns coordinate, time, and attribute roles', async () => {
+  const source = new ArrowTableSource(
+    makeArrowTable({
+      longitude: [1],
+      lat: [2],
+      elevation: [3],
+      event_time: [4],
+      label: ['x'],
+      y: [5],
+      z: [6],
+      altitude: [7],
+      time: [8],
+      updatedTimestamp: [9]
+    })
+  );
+
+  const metadata = await source.getQueryMetadata();
+  expect(metadata.columns.map(column => [column.name, column.role])).toEqual([
+    ['longitude', 'longitude'],
+    ['lat', 'latitude'],
+    ['elevation', 'attribute'],
+    ['event_time', 'time'],
+    ['label', 'attribute'],
+    ['y', 'y'],
+    ['z', 'z'],
+    ['altitude', 'attribute'],
+    ['time', 'time'],
+    ['updatedTimestamp', 'time']
+  ]);
+});
+
+test('ArrowTableSource rejects already-aborted metadata requests', async () => {
+  const controller = new AbortController();
+  controller.abort();
+  const source = new ArrowTableSource(makeArrowTable({value: [1]}));
+
+  await expect(source.getQueryMetadata({signal: controller.signal})).rejects.toThrow(/aborted/);
+});
+
 test('queryArrowTable filters, projects, and limits Arrow data', () => {
   const table = makeArrowTable({
     year: [2023, 2024, 2025, 2026],

--- a/modules/sql/test/duckdb-sql-source.node.spec.ts
+++ b/modules/sql/test/duckdb-sql-source.node.spec.ts
@@ -2,52 +2,40 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {createDataSource} from '@loaders.gl/core';
 import {DuckDBSQLDataSource, DuckDBSQLSource} from '@loaders.gl/sql';
-
-test('DuckDBSQLSource#createDataSource selects DuckDB source from URL', t => {
+test('DuckDBSQLSource#createDataSource selects DuckDB source from URL', () => {
   const dataSource = createDataSource('duckdb:///:memory:', [DuckDBSQLSource], {
     duckdb: {}
   });
-
-  t.ok(dataSource instanceof DuckDBSQLDataSource, 'returns DuckDBSQLDataSource');
-  t.end();
+  expect(dataSource instanceof DuckDBSQLDataSource, 'returns DuckDBSQLDataSource').toBeTruthy();
 });
-
-test('DuckDBSQLSource executes queries and exposes metadata', async t => {
+test('DuckDBSQLSource executes queries and exposes metadata', async () => {
   const dataSource = createDataSource('duckdb:///:memory:', [DuckDBSQLSource], {
     duckdb: {}
   }) as DuckDBSQLDataSource;
-
   await dataSource.queryRows(
     'CREATE TABLE numbers AS SELECT 1 AS value UNION ALL SELECT 2 AS value'
   );
-
   const rows = await dataSource.queryRows('SELECT * FROM numbers ORDER BY value');
-  t.deepEqual(rows, [{value: 1}, {value: 2}], 'returns object rows');
-
+  expect(rows, 'returns object rows').toEqual([{value: 1}, {value: 2}]);
   const plannedRows = await dataSource.queryRows({
     tableName: 'numbers',
     columns: ['value'],
     predicate: {op: '>=', args: [{property: 'value'}, 2]},
     limit: 1
   });
-  t.deepEqual(plannedRows, [{value: 2}], 'compiles and executes a portable table query');
-
+  expect(plannedRows, 'compiles and executes a portable table query').toEqual([{value: 2}]);
   const arrowTable = await dataSource.queryArrow('SELECT * FROM numbers ORDER BY value');
-  t.equal(arrowTable.data.numRows, 2, 'returns Arrow table rows');
-  t.equal(arrowTable.data.get(0)?.toJSON()?.value, 1, 'returns Arrow table data');
-
+  expect(arrowTable.data.numRows, 'returns Arrow table rows').toBe(2);
+  expect(arrowTable.data.get(0)?.toJSON()?.value, 'returns Arrow table data').toBe(1);
   const tables = await dataSource.listTables();
-  t.ok(
+  expect(
     tables.some(table => table.tableName === 'numbers'),
     'lists created tables'
-  );
-
+  ).toBeTruthy();
   const schema = await dataSource.getTableSchema({tableName: 'numbers', schemaName: 'main'});
-  t.equal(schema.fields[0]?.name, 'value', 'returns table schema');
-
+  expect(schema.fields[0]?.name, 'returns table schema').toBe('value');
   await dataSource.close();
-  t.end();
 });

--- a/modules/sql/test/snowflake-sql-source.spec.ts
+++ b/modules/sql/test/snowflake-sql-source.spec.ts
@@ -2,20 +2,19 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {createDataSource} from '@loaders.gl/core';
 import {SnowflakeSQLDataSource, SnowflakeSQLSource} from '@loaders.gl/sql';
-
-test('SnowflakeSQLSource#createDataSource selects Snowflake source from URL', t => {
+test('SnowflakeSQLSource#createDataSource selects Snowflake source from URL', () => {
   const dataSource = createDataSource('sql+snowflake://example-account', [SnowflakeSQLSource], {
     snowflake: {token: 'token'}
   });
-
-  t.ok(dataSource instanceof SnowflakeSQLDataSource, 'returns SnowflakeSQLDataSource');
-  t.end();
+  expect(
+    dataSource instanceof SnowflakeSQLDataSource,
+    'returns SnowflakeSQLDataSource'
+  ).toBeTruthy();
 });
-
-test('SnowflakeSQLSource executes SQL API queries through fetch', async t => {
+test('SnowflakeSQLSource executes SQL API queries through fetch', async () => {
   const fetchResponse = async (_url: string, requestInit?: RequestInit) => {
     if (requestInit?.method === 'POST') {
       return new Response(
@@ -33,7 +32,6 @@ test('SnowflakeSQLSource executes SQL API queries through fetch', async t => {
         }
       );
     }
-
     return new Response(
       JSON.stringify({
         data: [['extra', 4]]
@@ -44,7 +42,6 @@ test('SnowflakeSQLSource executes SQL API queries through fetch', async t => {
       }
     );
   };
-
   const dataSource = createDataSource('sql+snowflake://example-account', [SnowflakeSQLSource], {
     core: {
       loadOptions: {
@@ -55,25 +52,15 @@ test('SnowflakeSQLSource executes SQL API queries through fetch', async t => {
     },
     snowflake: {token: 'token'}
   }) as SnowflakeSQLDataSource;
-
   const rows = await dataSource.queryRows('SELECT * FROM demo');
-  t.deepEqual(
-    rows,
-    [
-      {name: 'demo', count: 2},
-      {name: 'extra', count: 4}
-    ],
-    'returns SQL API rows across partitions'
-  );
-
+  expect(rows, 'returns SQL API rows across partitions').toEqual([
+    {name: 'demo', count: 2},
+    {name: 'extra', count: 4}
+  ]);
   const arrowTable = await dataSource.queryArrow('SELECT * FROM demo');
-  t.equal(arrowTable.data.numRows, 2, 'returns Arrow table fallback across partitions');
-  t.equal(arrowTable.data.get(0)?.toJSON()?.name, 'demo', 'maps response rows to Arrow output');
-  t.equal(
-    arrowTable.data.get(1)?.toJSON()?.name,
-    'extra',
-    'includes partition rows in Arrow output'
+  expect(arrowTable.data.numRows, 'returns Arrow table fallback across partitions').toBe(2);
+  expect(arrowTable.data.get(0)?.toJSON()?.name, 'maps response rows to Arrow output').toBe('demo');
+  expect(arrowTable.data.get(1)?.toJSON()?.name, 'includes partition rows in Arrow output').toBe(
+    'extra'
   );
-
-  t.end();
 });

--- a/modules/sql/test/sql-source.spec.ts
+++ b/modules/sql/test/sql-source.spec.ts
@@ -2,11 +2,15 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import type {Schema} from '@loaders.gl/schema';
-
-import {SQLDataSource, registerSQLAdapter, getSQLAdapterFactory} from '@loaders.gl/sql';
-
+import {
+  SQLDataSource,
+  getSQLAdapterFactory,
+  parseSQLPredicate,
+  registerSQLAdapter
+} from '@loaders.gl/sql';
+import {convertRowsToArrowTable} from '../src/sql-utils';
 import type {
   SQLAdapter,
   SQLCatalogInfo,
@@ -16,18 +20,15 @@ import type {
   SQLSourceOptions,
   SQLTableInfo
 } from '@loaders.gl/sql';
-
 class StubSQLDataSource extends SQLDataSource {
   constructor(data: string, options: SQLSourceOptions, sourceType = 'stub-sql') {
     super(data, options, sourceType);
   }
-
   async getResolvedMetadata(): Promise<SQLMetadata> {
     return await this.getMetadata();
   }
 }
-
-test('registerSQLAdapter stores adapter factories', t => {
+test('registerSQLAdapter stores adapter factories', () => {
   const factory = async (): Promise<SQLAdapter> => ({
     capabilities: {
       supportsArrow: false,
@@ -53,14 +54,10 @@ test('registerSQLAdapter stores adapter factories', t => {
       return [];
     }
   });
-
   registerSQLAdapter('registered-sql', factory);
-
-  t.equal(getSQLAdapterFactory('registered-sql'), factory, 'returns registered factory');
-  t.end();
+  expect(getSQLAdapterFactory('registered-sql'), 'returns registered factory').toBe(factory);
 });
-
-test('SQLDataSource caches metadata, falls back to Arrow conversion, and resets on close', async t => {
+test('SQLDataSource caches metadata, falls back to Arrow conversion, and resets on close', async () => {
   let connectCount = 0;
   let closeCount = 0;
   let metadataCallCount = 0;
@@ -105,49 +102,157 @@ test('SQLDataSource caches metadata, falls back to Arrow conversion, and resets 
       return [{value: 1}, {value: 2}];
     }
   });
-
   const source = new StubSQLDataSource('sql://stub', {
     sql: {
       nodeAdapterFactory: adapterFactory,
       browserAdapterFactory: adapterFactory
     }
   });
-
   const firstMetadata = await source.getResolvedMetadata();
   const secondMetadata = await source.getResolvedMetadata();
-  t.equal(connectCount, 1, 'connects adapter once');
-  t.equal(metadataCallCount, 3, 'loads metadata once');
-  t.equal(firstMetadata, secondMetadata, 'returns cached metadata promise result');
-
+  expect(connectCount, 'connects adapter once').toBe(1);
+  expect(metadataCallCount, 'loads metadata once').toBe(3);
+  expect(firstMetadata, 'returns cached metadata promise result').toBe(secondMetadata);
   const arrowTable = await source.queryArrow('SELECT * FROM nulls');
-  t.equal(arrowTable.shape, 'arrow-table', 'returns Arrow table shape');
-  t.equal(arrowTable.data.numRows, 2, 'converts row results into Arrow rows');
-  t.equal(arrowTable.data.get(1)?.toJSON()?.value, 3, 'preserves row data after conversion');
-
+  expect(arrowTable.shape, 'returns Arrow table shape').toBe('arrow-table');
+  expect(arrowTable.data.numRows, 'converts row results into Arrow rows').toBe(2);
+  expect(arrowTable.data.get(1)?.toJSON()?.value, 'preserves row data after conversion').toBe(3);
   await source.close();
-  t.equal(closeCount, 1, 'closes adapter');
-
+  expect(closeCount, 'closes adapter').toBe(1);
   await source.getResolvedMetadata();
-  t.equal(connectCount, 2, 'recreates adapter after close');
-  t.equal(metadataCallCount, 6, 'reloads metadata after close clears cache');
-  t.end();
+  expect(connectCount, 'recreates adapter after close').toBe(2);
+  expect(metadataCallCount, 'reloads metadata after close clears cache').toBe(6);
 });
 
-test('SQLDataSource reports missing adapters with source context', async t => {
-  const source = new StubSQLDataSource('sql://missing', {}, 'missing-sql');
-
-  await t.rejects(
-    async () => {
-      try {
-        await source.queryRows('SELECT 1');
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        t.ok(message.includes('missing-sql'), 'preserves source type in the reported error');
-        throw error;
-      }
+test('SQLDataSource delegates discovery and both query result paths', async () => {
+  const calls: Array<[string, unknown]> = [];
+  const nativeArrowTable = convertRowsToArrowTable([{value: 9}]);
+  let closeCount = 0;
+  const adapterFactory = async (): Promise<SQLAdapter> => ({
+    capabilities: {
+      supportsArrow: true,
+      supportsMetadata: true,
+      runtime: 'both',
+      isDynamic: true
     },
-    /SQL adapter/,
-    'reports missing adapter failures'
+    async connect(): Promise<void> {
+      calls.push(['connect', null]);
+    },
+    async close(): Promise<void> {
+      closeCount++;
+    },
+    async listCatalogs(): Promise<SQLCatalogInfo[]> {
+      return [{catalogName: 'catalog'}];
+    },
+    async listSchemas(catalogName?: string): Promise<SQLSchemaInfo[]> {
+      calls.push(['listSchemas', catalogName]);
+      return [{catalogName, schemaName: 'public'}];
+    },
+    async listTables(options): Promise<SQLTableInfo[]> {
+      calls.push(['listTables', options]);
+      return [{...options, tableName: 'numbers'}];
+    },
+    async getTableSchema(options): Promise<Schema> {
+      calls.push(['getTableSchema', options]);
+      return {fields: [{name: 'value', type: 'int32', nullable: false}], metadata: {}};
+    },
+    async executeRows(sqlText, options): Promise<Record<string, unknown>[]> {
+      calls.push(['executeRows', {sqlText, options}]);
+      return [{value: 2}];
+    },
+    async executeArrow(sqlText, options) {
+      calls.push(['executeArrow', {sqlText, options}]);
+      return nativeArrowTable;
+    }
+  });
+  const source = new StubSQLDataSource(
+    'duckdb:///:memory:',
+    {sql: {nodeAdapterFactory: adapterFactory, browserAdapterFactory: adapterFactory}},
+    'duckdb-sql'
   );
-  t.end();
+
+  await source.close();
+  expect(closeCount).toBe(0);
+  await expect(source.listCatalogs()).resolves.toEqual([{catalogName: 'catalog'}]);
+  await expect(source.listSchemas('catalog')).resolves.toEqual([
+    {catalogName: 'catalog', schemaName: 'public'}
+  ]);
+  await expect(source.listTables({catalogName: 'catalog', schemaName: 'public'})).resolves.toEqual([
+    {catalogName: 'catalog', schemaName: 'public', tableName: 'numbers'}
+  ]);
+  await expect(
+    source.getTableSchema({catalogName: 'catalog', schemaName: 'public', tableName: 'numbers'})
+  ).resolves.toMatchObject({fields: [{name: 'value'}]});
+
+  const rows = await source.queryRows(
+    {
+      tableName: 'numbers',
+      columns: ['value'],
+      predicate: parseSQLPredicate('value >= :minimum', {preserveParameters: true}),
+      limit: 1
+    },
+    {parameters: {minimum: 2}}
+  );
+  expect(rows).toEqual([{value: 2}]);
+  const compiledCall = calls.find(call => call[0] === 'executeRows')?.[1] as {
+    sqlText: string;
+    options: SQLQueryOptions;
+  };
+  expect(compiledCall.sqlText).toContain('WHERE ("value" >= ?)');
+  expect(compiledCall.options.parameters).toEqual([2]);
+
+  await expect(source.queryArrow('SELECT 9 AS value')).resolves.toBe(nativeArrowTable);
+  expect(calls.some(call => call[0] === 'executeArrow')).toBe(true);
+  await source.close();
+  expect(closeCount).toBe(1);
+});
+
+test('SQLDataSource uses registered factories and rejects unsupported portable dialects', async () => {
+  const adapterFactory = async (): Promise<SQLAdapter> => ({
+    capabilities: {
+      supportsArrow: false,
+      supportsMetadata: false,
+      runtime: 'both',
+      isDynamic: false
+    },
+    async connect(): Promise<void> {},
+    async close(): Promise<void> {},
+    async listCatalogs(): Promise<SQLCatalogInfo[]> {
+      return [];
+    },
+    async listSchemas(): Promise<SQLSchemaInfo[]> {
+      return [];
+    },
+    async listTables(): Promise<SQLTableInfo[]> {
+      return [];
+    },
+    async getTableSchema(): Promise<Schema> {
+      return {fields: [], metadata: {}};
+    },
+    async executeRows(): Promise<Record<string, unknown>[]> {
+      return [{registered: true}];
+    }
+  });
+  registerSQLAdapter('registry-sql', adapterFactory);
+  const source = new StubSQLDataSource('sql://registry', {}, 'registry-sql');
+
+  await expect(source.queryRows('SELECT 1')).resolves.toEqual([{registered: true}]);
+  await expect(source.queryRows({tableName: 'numbers'})).rejects.toThrow(
+    /Portable table queries are not supported/
+  );
+});
+test('SQLDataSource reports missing adapters with source context', async () => {
+  const source = new StubSQLDataSource('sql://missing', {}, 'missing-sql');
+  await expect(async () => {
+    try {
+      await source.queryRows('SELECT 1');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      expect(
+        message.includes('missing-sql'),
+        'preserves source type in the reported error'
+      ).toBeTruthy();
+      throw error;
+    }
+  }, 'reports missing adapter failures').rejects.toThrow(/SQL adapter/);
 });

--- a/modules/sql/test/sql-utils.spec.ts
+++ b/modules/sql/test/sql-utils.spec.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
-
+import {expect, test} from 'vitest';
 import {
   convertRowsToArrowTable,
   convertSQLColumnsToSchema,
@@ -11,35 +10,35 @@ import {
   getQualifiedTableName,
   quoteSqlIdentifier
 } from '../src/sql-utils';
-
-test('sql-utils escapes SQL strings and identifiers', t => {
-  t.equal(escapeSqlString("O'Reilly"), "O''Reilly", 'escapes single quotes');
-  t.equal(quoteSqlIdentifier('has"quote'), '"has""quote"', 'escapes double quotes');
-  t.equal(
+test('sql-utils escapes SQL strings and identifiers', () => {
+  expect(escapeSqlString("O'Reilly"), 'escapes single quotes').toBe("O''Reilly");
+  expect(quoteSqlIdentifier('has"quote'), 'escapes double quotes').toBe('"has""quote"');
+  expect(
     getQualifiedTableName({
       catalogName: 'analytics',
       schemaName: 'public',
       tableName: 'events'
     }),
-    '"analytics"."public"."events"',
     'quotes qualified table names'
+  ).toBe('"analytics"."public"."events"');
+  expect(getQualifiedTableName({tableName: 'events'})).toBe('"events"');
+  expect(getQualifiedTableName({schemaName: 'public', tableName: 'events'})).toBe(
+    '"public"."events"'
   );
-  t.end();
 });
-
-test('sql-utils converts rows to Arrow tables and infers nullable primitive types', t => {
+test('sql-utils converts rows to Arrow tables and infers nullable primitive types', () => {
   const table = convertRowsToArrowTable([{value: null}, {value: 7}]);
-  t.equal(table.data.numRows, 2, 'creates arrow rows');
-  t.equal(table.schema.fields[0]?.name, 'value', 'retains field name');
-  t.equal(table.data.get(1)?.toJSON()?.value, 7, 'preserves later primitive values');
-
+  expect(table.data.numRows, 'creates arrow rows').toBe(2);
+  expect(table.schema.fields[0]?.name, 'retains field name').toBe('value');
+  expect(table.data.get(1)?.toJSON()?.value, 'preserves later primitive values').toBe(7);
   const emptyTable = convertRowsToArrowTable([]);
-  t.equal(emptyTable.data.numRows, 0, 'handles empty row sets');
-  t.equal(emptyTable.schema.fields.length, 0, 'returns empty schema for empty row sets');
-  t.end();
-});
+  expect(emptyTable.data.numRows, 'handles empty row sets').toBe(0);
+  expect(emptyTable.schema.fields.length, 'returns empty schema for empty row sets').toBe(0);
 
-test('sql-utils maps SQL column metadata to ordered schema fields', t => {
+  const populatedTable = convertRowsToArrowTable([{active: true, label: 'ready'}]);
+  expect(populatedTable.schema.fields.map(field => field.type)).toEqual(['bool', 'utf8']);
+});
+test('sql-utils maps SQL column metadata to ordered schema fields', () => {
   const schema = convertSQLColumnsToSchema([
     {
       columnName: 'created_at',
@@ -60,14 +59,39 @@ test('sql-utils maps SQL column metadata to ordered schema fields', t => {
       ordinalPosition: 3
     }
   ]);
-
-  t.deepEqual(
+  expect(
     schema.fields.map(field => field.name),
-    ['id', 'created_at', 'payload'],
     'sorts columns by ordinal position'
-  );
-  t.equal(schema.fields[0]?.type, 'int64', 'maps bigint columns');
-  t.equal(schema.fields[1]?.type, 'timestamp-millisecond', 'maps timestamp columns');
-  t.equal(schema.fields[2]?.type, 'binary', 'maps blob columns');
-  t.end();
+  ).toEqual(['id', 'created_at', 'payload']);
+  expect(schema.fields[0]?.type, 'maps bigint columns').toBe('int64');
+  expect(schema.fields[1]?.type, 'maps timestamp columns').toBe('timestamp-millisecond');
+  expect(schema.fields[2]?.type, 'maps blob columns').toBe('binary');
+});
+
+test.each([
+  ['BIGINT', 'int64'],
+  ['HUGEINT', 'int64'],
+  ['LONG', 'int64'],
+  ['INTEGER', 'int32'],
+  ['SMALLINT', 'int32'],
+  ['TINYINT', 'int32'],
+  ['DOUBLE PRECISION', 'float64'],
+  ['FLOAT8', 'float64'],
+  ['REAL', 'float64'],
+  ['FLOAT', 'float64'],
+  ['DECIMAL(10, 2)', 'float64'],
+  ['NUMERIC', 'float64'],
+  ['BOOLEAN', 'bool'],
+  ['DATE', 'date-day'],
+  ['TIME WITH TIME ZONE', 'timestamp-millisecond'],
+  ['TIMESTAMP', 'timestamp-millisecond'],
+  ['BLOB', 'binary'],
+  ['VARBINARY', 'binary'],
+  ['VARCHAR', 'utf8']
+])('sql-utils maps %s SQL types to %s', (sqlType, expectedType) => {
+  const schema = convertSQLColumnsToSchema([
+    {columnName: 'value', sqlType, nullable: true, ordinalPosition: 1}
+  ]);
+
+  expect(schema.fields[0]?.type).toBe(expectedType);
 });


### PR DESCRIPTION
## Goals

- Raise coverage in the low-coverage Draco and SQL packages with focused backend, adapter, metadata, query, and type-mapping tests.
- Continue reducing tape compatibility usage by migrating SQL tests to native Vitest.

## Changes

- Add native Draco backend selection, default backend, invalid backend, and injected-module error coverage.
- Exercise SQLDataSource discovery, registered factories, portable query compilation, native Arrow execution, fallback Arrow conversion, lifecycle behavior, and missing-adapter errors.
- Cover Arrow semantic roles, request cancellation, qualified names, primitive schema inference, and SQL type mapping branches.
- Migrate four SQL test files from the tape compatibility shim to native Vitest.

## Validation

- `yarn build`
- `yarn lint fix`
- `yarn test-audit`
- `yarn test-node` (333 passed, 6 skipped)
- Focused headless Chromium suite for all changed SQL and Draco specs (71 passed)