### PR TITLE
feat(wms): add streaming GML and normalized service capabilities

### DIFF
--- a/docs/modules/wms/api-reference/gml-loader.md
+++ b/docs/modules/wms/api-reference/gml-loader.md
@@ -37,7 +37,22 @@ const data = await load(url, GMLLoader, options);
 
 ## Parsed Data Format
 
-The `GMLLoader` only supports parsing the standard geospatial subset of features (points, multipoints, lines, linestrings, polygons and multipolygons), on a "best effort" basis. Because of this, the `GMLLoader` is treated as a geospatial loader and can return GeoJSON style output.
+The `GMLLoader` supports the standard geospatial subset of geometries (points, multipoints, lines, linestrings, polygons and multipolygons), and GML `FeatureCollection` documents are returned as GeoJSON-style feature collections with feature IDs and properties.
+
+For large WFS responses, the parser-bearing loader also supports incremental feature batches:
+
+```typescript
+import {GMLLoader} from '@loaders.gl/wms/bundled';
+
+for await (const batch of GMLLoader.parseInBatches!(response.body as any, {
+  gml: {batchSize: 500}
+})) {
+  renderFeatures(batch.features);
+}
+```
+
+The streaming path emits complete `featureMember` elements as soon as they are available and keeps
+the final incomplete fragment buffered until the response ends.
 
 ## Options
 

--- a/docs/modules/wms/api-reference/service-capabilities.md
+++ b/docs/modules/wms/api-reference/service-capabilities.md
@@ -1,0 +1,15 @@
+# Service capabilities
+
+The WMS module exposes a protocol-neutral `ServiceCapabilities` shape for applications that need
+to inspect WMS, WMTS, WFS, and ArcGIS services without branching on every service's native metadata
+model.
+
+```typescript
+import {normalizeWMTSCapabilities} from '@loaders.gl/wms';
+
+const capabilities = normalizeWMTSCapabilities(wmtsCapabilities, serviceUrl);
+console.log(capabilities.layers, capabilities.crs, capabilities.formats);
+```
+
+The normalizers preserve the native response under `formatSpecificMetadata` while exposing common
+service identity, layers, coordinate systems, formats, and operations.

--- a/modules/wms/src/gml-loader-with-parser.ts
+++ b/modules/wms/src/gml-loader-with-parser.ts
@@ -36,34 +36,136 @@ async function* parseGMLInBatches(
   options?: GMLLoaderOptions
 ): AsyncIterable<GMLFeatureCollection> {
   const decoder = new TextDecoder();
-  let text = '';
+  const parser = new GMLFeatureStreamParser();
   let features: GMLFeatureCollection['features'] = [];
   const batchSize = options?.gml?.batchSize || 1000;
-  const featureMemberPattern =
-    /<(?:[A-Za-z_][\w.-]*:)?featureMember\b[^>]*>[\s\S]*?<\/(?:[A-Za-z_][\w.-]*:)?featureMember\s*>/g;
 
   for await (const chunk of iterator) {
-    text += decoder.decode(chunk instanceof ArrayBuffer ? new Uint8Array(chunk) : chunk, {
-      stream: true
-    });
-    let consumedTextLength = 0;
-    let match: RegExpExecArray | null = featureMemberPattern.exec(text);
-    while (match) {
-      consumedTextLength = featureMemberPattern.lastIndex;
-      const parsed = parseGML(match[0], options);
+    const fragments = parser.push(
+      decoder.decode(chunk instanceof ArrayBuffer ? new Uint8Array(chunk) : chunk, {
+        stream: true
+      })
+    );
+    for (const fragment of fragments) {
+      const parsed = parseGMLFeatureFragment(fragment, options);
       if (parsed && parsed.type === 'FeatureCollection') features.push(...parsed.features);
       if (features.length >= batchSize) {
         yield {type: 'FeatureCollection', features: features.splice(0, batchSize)};
       }
-      match = featureMemberPattern.exec(text);
-    }
-    if (consumedTextLength > 0) {
-      text = text.slice(consumedTextLength);
-      featureMemberPattern.lastIndex = 0;
     }
   }
-  text += decoder.decode();
-  const parsed = parseGML(text, options);
-  if (parsed && parsed.type === 'FeatureCollection') features.push(...parsed.features);
+  for (const fragment of parser.finish(decoder.decode())) {
+    const parsed = parseGMLFeatureFragment(fragment, options);
+    if (parsed && parsed.type === 'FeatureCollection') features.push(...parsed.features);
+  }
   if (features.length) yield {type: 'FeatureCollection', features};
+}
+
+function parseGMLFeatureFragment(
+  fragment: string,
+  options?: GMLLoaderOptions
+): Geometry | GMLFeatureCollection | null {
+  return fragment.match(/<[^/!?][^>]*featureMember\b/i)
+    ? parseGML(fragment, options)
+    : parseGML(`<gml:featureMember>${fragment}</gml:featureMember>`, options);
+}
+
+class GMLFeatureStreamParser {
+  private _text = '';
+  private _insideFeatureMembers = false;
+  private _featureMemberStart = -1;
+  private _featureMemberDepth = 0;
+  private _featureStart = -1;
+  private _featureDepth = 0;
+
+  push(text: string): string[] {
+    this._text += text;
+    return this._scan(false);
+  }
+
+  finish(text: string): string[] {
+    this._text += text;
+    return this._scan(true);
+  }
+
+  private _scan(isFinal: boolean): string[] {
+    const fragments: string[] = [];
+    const tokenPattern =
+      /<!--[\s\S]*?-->|<\?[\s\S]*?\?>|<\/?\s*([A-Za-z_][\w.-]*(?::[A-Za-z_][\w.-]*)?)\b[^>]*?>/g;
+    let consumedTextLength = 0;
+    let match: RegExpExecArray | null = tokenPattern.exec(this._text);
+    while (match) {
+      const token = match[0];
+      if (token.startsWith('<!--') || token.startsWith('<?')) {
+        match = tokenPattern.exec(this._text);
+        continue;
+      }
+      const localName = match[1].split(':').pop()!;
+      const isClosing = token.startsWith('</');
+      const isSelfClosing = /\/\s*>$/.test(token);
+
+      if (!isClosing && localName === 'featureMember') {
+        this._featureMemberStart = match.index;
+        this._featureMemberDepth = isSelfClosing ? 0 : 1;
+        if (isSelfClosing) {
+          fragments.push(this._text.slice(this._featureMemberStart, tokenPattern.lastIndex));
+          consumedTextLength = tokenPattern.lastIndex;
+          this._featureMemberStart = -1;
+        }
+        match = tokenPattern.exec(this._text);
+        continue;
+      }
+      if (this._featureMemberDepth > 0) {
+        if (!isClosing && !isSelfClosing) this._featureMemberDepth++;
+        if (isClosing) this._featureMemberDepth--;
+        if (this._featureMemberDepth === 0) {
+          fragments.push(this._text.slice(this._featureMemberStart, tokenPattern.lastIndex));
+          consumedTextLength = tokenPattern.lastIndex;
+          this._featureMemberStart = -1;
+        }
+        match = tokenPattern.exec(this._text);
+        continue;
+      }
+
+      if (!isClosing && localName === 'featureMembers') {
+        this._insideFeatureMembers = true;
+        match = tokenPattern.exec(this._text);
+        continue;
+      }
+      if (
+        this._insideFeatureMembers &&
+        this._featureDepth === 0 &&
+        !isClosing &&
+        localName !== 'featureMembers'
+      ) {
+        this._featureStart = match.index;
+        this._featureDepth = isSelfClosing ? 0 : 1;
+        if (isSelfClosing) {
+          fragments.push(this._text.slice(this._featureStart, tokenPattern.lastIndex));
+          consumedTextLength = tokenPattern.lastIndex;
+          this._featureStart = -1;
+        }
+        match = tokenPattern.exec(this._text);
+        continue;
+      }
+      if (this._featureDepth > 0) {
+        if (!isClosing && !isSelfClosing) this._featureDepth++;
+        if (isClosing) this._featureDepth--;
+        if (this._featureDepth === 0) {
+          fragments.push(this._text.slice(this._featureStart, tokenPattern.lastIndex));
+          consumedTextLength = tokenPattern.lastIndex;
+          this._featureStart = -1;
+        }
+      }
+      if (isClosing && localName === 'featureMembers') this._insideFeatureMembers = false;
+      match = tokenPattern.exec(this._text);
+    }
+
+    if (consumedTextLength > 0) {
+      this._text = this._text.slice(consumedTextLength);
+    } else if (isFinal && this._text.trim()) {
+      this._text = '';
+    }
+    return fragments;
+  }
 }

--- a/modules/wms/src/gml-loader-with-parser.ts
+++ b/modules/wms/src/gml-loader-with-parser.ts
@@ -3,14 +3,14 @@
 // Copyright (c) vis.gl contributors
 
 import type {LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';
-import type {Geometry} from './lib/parsers/gml/parse-gml';
+import type {GMLFeatureCollection, Geometry} from './lib/parsers/gml/parse-gml';
 import {parseGML} from './lib/parsers/gml/parse-gml';
 import {GMLLoader as GMLLoaderMetadata} from './gml-loader';
 
 const {preload: _GMLLoaderPreload, ...GMLLoaderMetadataWithoutPreload} = GMLLoaderMetadata;
 
 export type GMLLoaderOptions = LoaderOptions & {
-  gml?: {};
+  gml?: {batchSize?: number};
 };
 
 /**
@@ -20,5 +20,50 @@ export const GMLLoaderWithParser = {
   ...GMLLoaderMetadataWithoutPreload,
   parse: async (arrayBuffer: ArrayBuffer, options?: GMLLoaderOptions) =>
     parseGML(new TextDecoder().decode(arrayBuffer), options),
-  parseTextSync: (text: string, options?: GMLLoaderOptions) => parseGML(text, options)
-} as const satisfies LoaderWithParser<Geometry | null, never, GMLLoaderOptions>;
+  parseTextSync: (text: string, options?: GMLLoaderOptions) => parseGML(text, options),
+  parseInBatches: parseGMLInBatches
+} as const satisfies LoaderWithParser<
+  Geometry | GMLFeatureCollection | null,
+  GMLFeatureCollection,
+  GMLLoaderOptions
+>;
+
+/** Parses GML feature-member fragments as they become available from a fetch stream. */
+async function* parseGMLInBatches(
+  iterator:
+    | AsyncIterable<ArrayBufferLike | ArrayBufferView>
+    | Iterable<ArrayBufferLike | ArrayBufferView>,
+  options?: GMLLoaderOptions
+): AsyncIterable<GMLFeatureCollection> {
+  const decoder = new TextDecoder();
+  let text = '';
+  let features: GMLFeatureCollection['features'] = [];
+  const batchSize = options?.gml?.batchSize || 1000;
+  const featureMemberPattern =
+    /<(?:[A-Za-z_][\w.-]*:)?featureMember\b[^>]*>[\s\S]*?<\/(?:[A-Za-z_][\w.-]*:)?featureMember\s*>/g;
+
+  for await (const chunk of iterator) {
+    text += decoder.decode(chunk instanceof ArrayBuffer ? new Uint8Array(chunk) : chunk, {
+      stream: true
+    });
+    let consumedTextLength = 0;
+    let match: RegExpExecArray | null = featureMemberPattern.exec(text);
+    while (match) {
+      consumedTextLength = featureMemberPattern.lastIndex;
+      const parsed = parseGML(match[0], options);
+      if (parsed && parsed.type === 'FeatureCollection') features.push(...parsed.features);
+      if (features.length >= batchSize) {
+        yield {type: 'FeatureCollection', features: features.splice(0, batchSize)};
+      }
+      match = featureMemberPattern.exec(text);
+    }
+    if (consumedTextLength > 0) {
+      text = text.slice(consumedTextLength);
+      featureMemberPattern.lastIndex = 0;
+    }
+  }
+  text += decoder.decode();
+  const parsed = parseGML(text, options);
+  if (parsed && parsed.type === 'FeatureCollection') features.push(...parsed.features);
+  if (features.length) yield {type: 'FeatureCollection', features};
+}

--- a/modules/wms/src/gml-loader.ts
+++ b/modules/wms/src/gml-loader.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import type {Loader, LoaderOptions} from '@loaders.gl/loader-utils';
-import type {Geometry} from './lib/parsers/gml/parse-gml';
+import type {GMLFeatureCollection, Geometry} from './lib/parsers/gml/parse-gml';
 
 import {GMLFormat} from './wms-format';
 // __VERSION__ is injected by babel-plugin-version-inline
@@ -11,7 +11,10 @@ import {GMLFormat} from './wms-format';
 const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
 export type GMLLoaderOptions = LoaderOptions & {
-  gml?: {};
+  gml?: {
+    /** Number of feature members emitted in each streaming batch. */
+    batchSize?: number;
+  };
 };
 
 /** Preloads the parser-bearing GML loader implementation. */
@@ -42,7 +45,11 @@ export const GMLLoader = {
     gml: {}
   },
   preload
-} as const satisfies Loader<Geometry | null, never, GMLLoaderOptions>;
+} as const satisfies Loader<
+  Geometry | GMLFeatureCollection | null,
+  GMLFeatureCollection,
+  GMLLoaderOptions
+>;
 
 function testXMLFile(text: string): boolean {
   // TODO - There could be space first.

--- a/modules/wms/src/index.ts
+++ b/modules/wms/src/index.ts
@@ -81,6 +81,15 @@ export type {WMTSSourceLoaderOptions} from './wmts-source-loader';
 export {WMTSSourceLoader, WMTSImageTileSource} from './wmts-source-loader';
 export {WFSSourceLoader, WFSVectorSource} from './wfs-source-loader';
 
+export type {GeoServiceType, ServiceCapabilities} from './service-capabilities';
+export {
+  normalizeWMSCapabilities,
+  normalizeWMTSCapabilities,
+  normalizeWFSCapabilities,
+  normalizeTileServiceCapabilities,
+  normalizeVectorServiceCapabilities
+} from './service-capabilities';
+
 // ArcGIS SourceLoaders
 
 export {getArcGISServices as _getArcGISServices} from './arcgis/arcgis-server';

--- a/modules/wms/src/lib/parsers/gml/parse-gml.ts
+++ b/modules/wms/src/lib/parsers/gml/parse-gml.ts
@@ -27,6 +27,20 @@ import {deepStrictEqual} from './deep-strict-equal';
 import {parseXMLTextSync} from '../xml/parse-xml-text';
 import rewind from '@turf/rewind';
 
+/** A GeoJSON feature decoded from a GML feature member. */
+export type GMLFeature = {
+  type: 'Feature';
+  id?: string;
+  geometry: Geometry | null;
+  properties: Record<string, unknown>;
+};
+
+/** A collection of features decoded from a GML feature collection. */
+export type GMLFeatureCollection = {
+  type: 'FeatureCollection';
+  features: GMLFeature[];
+};
+
 function noTransform(...coords) {
   return coords;
 }
@@ -47,14 +61,57 @@ export type ParseGMLContext = {
  * Parses a typed data structure from raw XML for GML features
  * @note Error handlings is fairly weak
  */
-export function parseGML(text: string, options) {
+export function parseGML(text: string, options): Geometry | GMLFeatureCollection | null {
   // GeoJSON | null {
   const parsedXML = parseXMLTextSync(text, options);
 
   options = {transformCoords: noTransform, stride: 2, ...options};
+  const featureCollection = parseGMLFeatureCollection(parsedXML, options);
+  if (featureCollection) {
+    return featureCollection;
+  }
   const context = createChildContext(parsedXML, options, {});
 
   return parseGMLToGeometry(parsedXML, options, context);
+}
+
+/** Parses a GML feature collection, returning null when the document is a bare geometry. */
+export function parseGMLFeatureCollection(
+  inputXML: any,
+  options: ParseGMLOptions = {}
+): GMLFeatureCollection | null {
+  const featureMembers = findFeatureMembers(inputXML);
+  if (featureMembers.length === 0) {
+    return null;
+  }
+  return {
+    type: 'FeatureCollection',
+    features: featureMembers.map(featureMember => parseGMLFeature(featureMember, options))
+  };
+}
+
+/** Parses one GML feature member into a GeoJSON feature. */
+export function parseGMLFeature(inputXML: any, options: ParseGMLOptions = {}): GMLFeature {
+  const feature = unwrapFeatureMember(inputXML);
+  const geometryElement = findGeometryElement(feature);
+  const geometry = geometryElement
+    ? parseGMLToGeometry(
+        {[geometryElement.key]: geometryElement.value},
+        options,
+        createChildContext(feature, options, {})
+      )
+    : null;
+  const properties: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(feature || {})) {
+    if (key === 'attributes' || key === geometryElement?.key || key.startsWith('gml:')) {
+      continue;
+    }
+    properties[stripNamespace(key)] = extractXMLValue(value);
+  }
+
+  const id = findFeatureId(feature);
+  return {type: 'Feature', id: id ? String(id) : undefined, geometry, properties};
 }
 
 /** Parse a GeoJSON geometry from GML XML */
@@ -517,6 +574,101 @@ export function parseMultiSurface(
 }
 
 // Helpers
+
+/** Finds feature members in either a GML feature collection or a parsed member fragment. */
+function findFeatureMembers(root: any): any[] {
+  if (!root || typeof root !== 'object') return [];
+  for (const [key, value] of Object.entries(root)) {
+    if (stripNamespace(key) === 'featureMember') {
+      return Array.isArray(value) ? value : [value];
+    }
+    if (stripNamespace(key) === 'featureMembers') {
+      const members: any[] = [];
+      for (const member of Array.isArray(value) ? value : [value]) {
+        for (const [featureKey, featureValue] of Object.entries(member || {})) {
+          if (featureKey !== 'attributes') {
+            for (const item of Array.isArray(featureValue) ? featureValue : [featureValue]) {
+              members.push({[featureKey]: item});
+            }
+          }
+        }
+      }
+      return members;
+    }
+    if (key !== 'attributes' && value && typeof value === 'object') {
+      const nested = findFeatureMembers(Array.isArray(value) ? value[0] : value);
+      if (nested.length) return nested;
+    }
+  }
+  return [];
+}
+
+/** Removes the wrapper around a parsed GML feature member. */
+function unwrapFeatureMember(member: any): any {
+  if (!member || typeof member !== 'object') return {};
+  const entries = Object.entries(member).filter(([key]) => key !== 'attributes');
+  return entries.length === 1 && !stripNamespace(entries[0][0]).startsWith('gml:')
+    ? entries[0][1]
+    : member;
+}
+
+/** Locates the first GML geometry child of a feature. */
+function findGeometryElement(feature: any): {key: string; value: any} | null {
+  if (!feature || typeof feature !== 'object') return null;
+  for (const [key, value] of Object.entries(feature)) {
+    if (key.startsWith('gml:') && GEOMETRY_NAMES.has(stripNamespace(key))) {
+      return {key, value: Array.isArray(value) ? value[0] : value};
+    }
+    if (key !== 'attributes' && value && typeof value === 'object') {
+      const nested = findGeometryElement(Array.isArray(value) ? value[0] : value);
+      if (nested) return nested;
+    }
+  }
+  return null;
+}
+
+const GEOMETRY_NAMES = new Set([
+  'Point',
+  'MultiPoint',
+  'LineString',
+  'Curve',
+  'MultiLineString',
+  'MultiCurve',
+  'Polygon',
+  'Rectangle',
+  'Surface',
+  'MultiPolygon',
+  'MultiSurface'
+]);
+
+function stripNamespace(key: string): string {
+  return key.includes(':') ? key.slice(key.indexOf(':') + 1) : key;
+}
+
+function extractXMLValue(value: any): unknown {
+  if (Array.isArray(value)) return value.map(extractXMLValue);
+  if (value && typeof value === 'object') {
+    if ('value' in value) return extractXMLValue(value.value);
+    if ('#text' in value) return value['#text'];
+  }
+  return value;
+}
+
+function findFeatureId(value: any): string | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const directId = value.id || value['gml:id'] || value.fid;
+  if (directId !== undefined && typeof directId !== 'object') return String(directId);
+  const attributes = value.attributes;
+  if (attributes) {
+    const id = attributes.id || attributes['gml:id'] || attributes.fid;
+    if (id !== undefined) return String(id);
+  }
+  for (const child of Object.values(value)) {
+    const id = findFeatureId(child);
+    if (id) return id;
+  }
+  return undefined;
+}
 
 function textOf(el: any): string {
   if (typeof el === 'number') {

--- a/modules/wms/src/lib/parsers/gml/parse-gml.ts
+++ b/modules/wms/src/lib/parsers/gml/parse-gml.ts
@@ -104,7 +104,11 @@ export function parseGMLFeature(inputXML: any, options: ParseGMLOptions = {}): G
   const properties: Record<string, unknown> = {};
 
   for (const [key, value] of Object.entries(feature || {})) {
-    if (key === 'attributes' || key === geometryElement?.key || key.startsWith('gml:')) {
+    if (
+      key === 'attributes' ||
+      key === geometryElement?.propertyKey ||
+      key.startsWith('gml:')
+    ) {
       continue;
     }
     properties[stripNamespace(key)] = extractXMLValue(value);
@@ -613,14 +617,21 @@ function unwrapFeatureMember(member: any): any {
 }
 
 /** Locates the first GML geometry child of a feature. */
-function findGeometryElement(feature: any): {key: string; value: any} | null {
+function findGeometryElement(
+  feature: any,
+  propertyKey?: string
+): {key: string; value: any; propertyKey: string} | null {
   if (!feature || typeof feature !== 'object') return null;
   for (const [key, value] of Object.entries(feature)) {
     if (key.startsWith('gml:') && GEOMETRY_NAMES.has(stripNamespace(key))) {
-      return {key, value: Array.isArray(value) ? value[0] : value};
+      return {
+        key,
+        value: Array.isArray(value) ? value[0] : value,
+        propertyKey: propertyKey || key
+      };
     }
     if (key !== 'attributes' && value && typeof value === 'object') {
-      const nested = findGeometryElement(Array.isArray(value) ? value[0] : value);
+      const nested = findGeometryElement(Array.isArray(value) ? value[0] : value, propertyKey || key);
       if (nested) return nested;
     }
   }
@@ -662,10 +673,6 @@ function findFeatureId(value: any): string | undefined {
   if (attributes) {
     const id = attributes.id || attributes['gml:id'] || attributes.fid;
     if (id !== undefined) return String(id);
-  }
-  for (const child of Object.values(value)) {
-    const id = findFeatureId(child);
-    if (id) return id;
   }
   return undefined;
 }

--- a/modules/wms/src/service-capabilities.ts
+++ b/modules/wms/src/service-capabilities.ts
@@ -1,0 +1,169 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {TileSourceMetadata, VectorSourceMetadata} from '@loaders.gl/loader-utils';
+import type {WMSCapabilities} from './lib/parsers/wms/parse-wms-capabilities';
+import type {WMTSCapabilities} from './lib/parsers/wmts/parse-wmts-capabilities';
+import type {WFSCapabilities} from './lib/parsers/wfs/parse-wfs-capabilities';
+
+/** Protocol-neutral service families understood by the geospatial service loaders. */
+export type GeoServiceType =
+  | 'wms'
+  | 'wmts'
+  | 'wfs'
+  | 'csw'
+  | 'arcgis-map-server'
+  | 'arcgis-image-server'
+  | 'arcgis-feature-server'
+  | 'unknown';
+
+/** A normalized description of a discoverable geospatial service. */
+export type ServiceCapabilities = {
+  /** Stable service URL. */
+  url?: string;
+  /** Protocol or vendor service family. */
+  type: GeoServiceType;
+  /** Machine-readable service identifier. */
+  name: string;
+  /** Human-readable service title. */
+  title?: string;
+  /** Service description. */
+  abstract?: string;
+  /** Supported coordinate reference systems. */
+  crs: string[];
+  /** Advertised response formats. */
+  formats: string[];
+  /** Named layers or feature types. */
+  layers: Array<{name: string; title?: string; crs?: string[]; bounds?: number[]}>;
+  /** Supported request names, when advertised. */
+  operations: string[];
+  /** Original protocol-specific capability document. */
+  formatSpecificMetadata?: Record<string, unknown>;
+};
+
+/** Normalizes WMS capabilities into the shared service contract. */
+export function normalizeWMSCapabilities(
+  capabilities: WMSCapabilities,
+  url?: string
+): ServiceCapabilities {
+  return {
+    url,
+    type: 'wms',
+    name: capabilities.name,
+    title: capabilities.title,
+    abstract: capabilities.abstract,
+    crs: unique(capabilities.layers.flatMap(layer => layer.crs || [])),
+    formats: unique(
+      Object.values(capabilities.requests || {}).flatMap(request => request.mimeTypes || [])
+    ),
+    layers: flattenLayers(capabilities.layers),
+    operations: Object.keys(capabilities.requests || {}),
+    formatSpecificMetadata: capabilities as unknown as Record<string, unknown>
+  };
+}
+
+/** Normalizes WMTS capabilities into the shared service contract. */
+export function normalizeWMTSCapabilities(
+  capabilities: WMTSCapabilities,
+  url?: string
+): ServiceCapabilities {
+  const layers = capabilities.contents.layers;
+  return {
+    url,
+    type: 'wmts',
+    name: layers[0]?.identifier || '',
+    title: capabilities.serviceIdentification?.title,
+    abstract: capabilities.serviceIdentification?.abstract,
+    crs: unique(
+      capabilities.contents.tileMatrixSets
+        .map(tileMatrixSet => tileMatrixSet.supportedCRS)
+        .filter((value): value is string => Boolean(value))
+    ),
+    formats: unique(layers.flatMap(layer => layer.formats)),
+    layers: layers.map(layer => ({
+      name: layer.identifier,
+      title: layer.title,
+      bounds: layer.bounds
+    })),
+    operations: Object.keys(capabilities.operationsMetadata || {}),
+    formatSpecificMetadata: capabilities as unknown as Record<string, unknown>
+  };
+}
+
+/** Normalizes WFS capabilities into the shared service contract. */
+export function normalizeWFSCapabilities(
+  capabilities: WFSCapabilities,
+  url?: string
+): ServiceCapabilities {
+  const layers = capabilities.contents?.layers || [];
+  return {
+    url,
+    type: 'wfs',
+    name: capabilities.serviceIdentification?.serviceType || '',
+    title: capabilities.serviceIdentification?.title,
+    crs: [],
+    formats: [],
+    layers: layers.map(layer => ({name: layer.identifier, title: layer.title})),
+    operations: Object.keys(capabilities.operationsMetadata || {}),
+    formatSpecificMetadata: capabilities as unknown as Record<string, unknown>
+  };
+}
+
+/** Adapts normalized tile metadata to the shared service contract. */
+export function normalizeTileServiceCapabilities(
+  metadata: TileSourceMetadata,
+  type: Extract<GeoServiceType, 'wmts' | 'arcgis-map-server' | 'arcgis-image-server'>,
+  url?: string
+): ServiceCapabilities {
+  return {
+    url,
+    type,
+    name: metadata.name || '',
+    title: metadata.title,
+    abstract: metadata.abstract,
+    crs: metadata.layer?.srs || [],
+    formats: metadata.format ? [metadata.format] : [],
+    layers: metadata.layer ? [{name: metadata.layer.name, title: metadata.layer.title}] : [],
+    operations: ['GetTile'],
+    formatSpecificMetadata: metadata as Record<string, unknown>
+  };
+}
+
+/** Adapts normalized vector metadata to the shared service contract. */
+export function normalizeVectorServiceCapabilities(
+  metadata: VectorSourceMetadata,
+  type: Extract<GeoServiceType, 'wfs' | 'arcgis-feature-server'>,
+  url?: string
+): ServiceCapabilities {
+  return {
+    url,
+    type,
+    name: metadata.name,
+    title: metadata.title,
+    abstract: metadata.abstract,
+    crs: unique(metadata.layers.flatMap(layer => layer.crs || [])),
+    formats: ['application/geo+json', 'application/vnd.apache.arrow.file'],
+    layers: metadata.layers.map(layer => ({name: layer.name || '', title: layer.title})),
+    operations: ['GetFeature'],
+    formatSpecificMetadata: metadata.formatSpecificMetadata
+  };
+}
+
+function flattenLayers(layers: WMSCapabilities['layers']): ServiceCapabilities['layers'] {
+  return layers.flatMap(layer => [
+    {
+      name: layer.name || '',
+      title: layer.title,
+      crs: layer.crs,
+      bounds: layer.geographicBoundingBox
+        ? [...layer.geographicBoundingBox[0], ...layer.geographicBoundingBox[1]]
+        : undefined
+    },
+    ...flattenLayers(layer.layers || [])
+  ]);
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))];
+}

--- a/modules/wms/src/service-capabilities.ts
+++ b/modules/wms/src/service-capabilities.ts
@@ -53,7 +53,7 @@ export function normalizeWMSCapabilities(
     name: capabilities.name,
     title: capabilities.title,
     abstract: capabilities.abstract,
-    crs: unique(capabilities.layers.flatMap(layer => layer.crs || [])),
+    crs: unique(flattenLayers(capabilities.layers).flatMap(layer => layer.crs || [])),
     formats: unique(
       Object.values(capabilities.requests || {}).flatMap(request => request.mimeTypes || [])
     ),
@@ -103,7 +103,7 @@ export function normalizeWFSCapabilities(
     name: capabilities.serviceIdentification?.serviceType || '',
     title: capabilities.serviceIdentification?.title,
     crs: [],
-    formats: [],
+    formats: unique(layers.flatMap(layer => layer.formats || [])),
     layers: layers.map(layer => ({name: layer.identifier, title: layer.title})),
     operations: Object.keys(capabilities.operationsMetadata || {}),
     formatSpecificMetadata: capabilities as unknown as Record<string, unknown>

--- a/modules/wms/test/gml/gml-loader.spec.ts
+++ b/modules/wms/test/gml/gml-loader.spec.ts
@@ -11,8 +11,10 @@ import {GML_V3_TESTS} from '@loaders.gl/wms/test/data/gml/v3/tests';
 // import {validateLoader} from 'test/common/conformance';
 
 import {_GMLLoader as GMLLoader} from '@loaders.gl/wms';
+import {GMLLoader as GMLParserLoader} from '@loaders.gl/wms/bundled';
 import type {GeoJSON} from '@loaders.gl/schema';
 import {parse} from '@loaders.gl/core';
+import {expect, test as vitestTest} from 'vitest';
 
 const VALID_TEST = {
   'v3/envelope.xml': true,
@@ -57,6 +59,30 @@ test('GMLLoader#parse', async t => {
   }
 
   t.end();
+});
+
+vitestTest('GMLLoader parses feature collections', () => {
+  const xml = `<?xml version="1.0"?><gml:FeatureCollection xmlns:gml="http://www.opengis.net/gml" xmlns:app="urn:app"><gml:featureMember><app:place gml:id="place.1"><app:name>One</app:name><app:shape><gml:Point><gml:pos>1 2</gml:pos></gml:Point></app:shape></app:place></gml:featureMember><gml:featureMember><app:place gml:id="place.2"><app:name>Two</app:name><app:shape><gml:Point><gml:pos>3 4</gml:pos></gml:Point></app:shape></app:place></gml:featureMember></gml:FeatureCollection>`;
+  const collection = GMLParserLoader.parseTextSync!(xml) as any;
+  expect(collection.type).toBe('FeatureCollection');
+  expect(collection.features).toHaveLength(2);
+  expect(collection.features[0].id).toBe('place.1');
+  expect(collection.features[0].properties.name).toBe('One');
+  expect(collection.features[1].geometry.coordinates).toEqual([3, 4]);
+});
+
+vitestTest('GMLLoader parses feature members incrementally', async () => {
+  const chunks = [
+    new TextEncoder().encode(
+      '<gml:featureMember xmlns:gml="http://www.opengis.net/gml"><app:place xmlns:app="urn:app"><app:shape><gml:Point><gml:pos>1 2</gml:pos></gml:Point></app:shape></app:place></gml:featureMember>'
+    ),
+    new TextEncoder().encode(
+      '<gml:featureMember xmlns:gml="http://www.opengis.net/gml"><app:place xmlns:app="urn:app"><app:shape><gml:Point><gml:pos>3 4</gml:pos></gml:Point></app:shape></app:place></gml:featureMember>'
+    )
+  ];
+  const batches = [];
+  for await (const batch of GMLParserLoader.parseInBatches!(chunks)) batches.push(batch);
+  expect(batches.flatMap(batch => batch.features)).toHaveLength(2);
 });
 
 /*

--- a/modules/wms/test/gml/gml-loader.spec.ts
+++ b/modules/wms/test/gml/gml-loader.spec.ts
@@ -68,6 +68,7 @@ vitestTest('GMLLoader parses feature collections', () => {
   expect(collection.features).toHaveLength(2);
   expect(collection.features[0].id).toBe('place.1');
   expect(collection.features[0].properties.name).toBe('One');
+  expect(collection.features[0].properties.shape).toBeUndefined();
   expect(collection.features[1].geometry.coordinates).toEqual([3, 4]);
 });
 
@@ -83,6 +84,23 @@ vitestTest('GMLLoader parses feature members incrementally', async () => {
   const batches = [];
   for await (const batch of GMLParserLoader.parseInBatches!(chunks)) batches.push(batch);
   expect(batches.flatMap(batch => batch.features)).toHaveLength(2);
+});
+
+vitestTest('GMLLoader batches plural featureMembers without retaining the container', async () => {
+  const chunks = [
+    new TextEncoder().encode(
+      '<gml:FeatureCollection><gml:featureMembers><app:place xmlns:app="urn:app"><app:name>One</app:name><app:shape><gml:Point><gml:pos>1 2</gml:pos></gml:Point></app:shape></app:place>'
+    ),
+    new TextEncoder().encode(
+      '<app:place xmlns:app="urn:app"><app:name>Two</app:name><app:shape><gml:Point><gml:pos>3 4</gml:pos></gml:Point></app:shape></app:place></gml:featureMembers></gml:FeatureCollection>'
+    )
+  ];
+  const batches = [];
+  for await (const batch of GMLParserLoader.parseInBatches!(chunks, {gml: {batchSize: 1}})) {
+    batches.push(batch);
+  }
+  expect(batches.flatMap(batch => batch.features)).toHaveLength(2);
+  expect(batches).toHaveLength(2);
 });
 
 /*

--- a/modules/wms/test/index.ts
+++ b/modules/wms/test/index.ts
@@ -32,3 +32,4 @@ import './gml/gml-loader.spec';
 
 import './wms/wms-source.spec';
 import './arcgis/arcgis-server.spec';
+import './service-capabilities.spec';

--- a/modules/wms/test/service-capabilities.spec.ts
+++ b/modules/wms/test/service-capabilities.spec.ts
@@ -1,0 +1,56 @@
+import {expect, test} from 'vitest';
+import {normalizeWMSCapabilities, normalizeWMTSCapabilities} from '@loaders.gl/wms';
+
+test('normalizes WMS capabilities into shared service metadata', () => {
+  const normalized = normalizeWMSCapabilities(
+    {
+      name: 'maps',
+      title: 'Maps',
+      keywords: [],
+      layers: [
+        {
+          name: 'roads',
+          title: 'Roads',
+          keywords: [],
+          crs: ['EPSG:3857'],
+          geographicBoundingBox: [
+            [-1, -2],
+            [3, 4]
+          ]
+        }
+      ],
+      requests: {GetMap: {mimeTypes: ['image/png']}}
+    } as any,
+    'https://example.com/wms'
+  );
+  expect(normalized).toMatchObject({
+    type: 'wms',
+    name: 'maps',
+    url: 'https://example.com/wms',
+    crs: ['EPSG:3857'],
+    formats: ['image/png']
+  });
+  expect(normalized.layers[0].bounds).toEqual([-1, -2, 3, 4]);
+});
+
+test('normalizes WMTS matrix CRS and formats', () => {
+  const normalized = normalizeWMTSCapabilities({
+    serviceIdentification: {title: 'Tiles'},
+    operationsMetadata: {GetTile: {}},
+    contents: {
+      layers: [
+        {
+          identifier: 'roads',
+          formats: ['image/png'],
+          styles: [],
+          tileMatrixSetLinks: [],
+          resourceURLs: []
+        }
+      ],
+      tileMatrixSets: [{identifier: 'web', supportedCRS: 'EPSG:3857', matrices: []}]
+    }
+  });
+  expect(normalized.type).toBe('wmts');
+  expect(normalized.crs).toEqual(['EPSG:3857']);
+  expect(normalized.operations).toEqual(['GetTile']);
+});


### PR DESCRIPTION
## Goals

Advance geospatial service support with first-class streaming GML and a protocol-neutral capability model.

## Changes

- Parse GML FeatureCollection documents into GeoJSON-style features with IDs, properties, and supported geometries.
- Add incremental `parseInBatches` support for streamed GML `featureMember` responses with configurable batch size.
- Add typed `ServiceCapabilities` plus normalizers for WMS, WMTS, WFS, tile, and vector metadata.
- Add focused browser tests, test-audit coverage, and API documentation.

## Verification

- `yarn lint fix`
- `yarn build`
- `yarn test-node` — 326 passed, 6 skipped
- `yarn test-headless` — 2,528 passed, 47 skipped
- `yarn test-audit` — 0 violations

Closes tranche 7 and tranche 8 of the geospatial services roadmap.