### PR TITLE
fix: suppress Vite classic-worker import warnings

### DIFF
--- a/modules/textures/src/basis-worker.ts
+++ b/modules/textures/src/basis-worker.ts
@@ -4,4 +4,4 @@
 
 // Classic-worker entrypoint that lazily loads the ESM worker implementation.
 // This keeps `importScripts` available in the worker (used by library loading).
-import(new URL('./workers/basis-worker.js', import.meta.url).toString());
+import(/* @vite-ignore */ new URL('./workers/basis-worker.js', import.meta.url).toString());

--- a/modules/textures/src/compressed-texture-worker.ts
+++ b/modules/textures/src/compressed-texture-worker.ts
@@ -3,4 +3,6 @@
 // Copyright (c) vis.gl contributors
 
 // Classic-worker entrypoint that lazily loads the ESM worker implementation.
-import(new URL('./workers/compressed-texture-worker.js', import.meta.url).toString());
+import(
+  /* @vite-ignore */ new URL('./workers/compressed-texture-worker.js', import.meta.url).toString()
+);

--- a/modules/textures/src/crunch-worker.ts
+++ b/modules/textures/src/crunch-worker.ts
@@ -3,4 +3,4 @@
 // Copyright (c) vis.gl contributors
 
 // Classic-worker entrypoint that lazily loads the ESM worker implementation.
-import(new URL('./workers/crunch-worker.js', import.meta.url).toString());
+import(/* @vite-ignore */ new URL('./workers/crunch-worker.js', import.meta.url).toString());

--- a/modules/textures/src/ktx2-basis-writer-worker.ts
+++ b/modules/textures/src/ktx2-basis-writer-worker.ts
@@ -3,4 +3,6 @@
 // Copyright (c) vis.gl contributors
 
 // Classic-worker entrypoint that lazily loads the ESM worker implementation.
-import(new URL('./workers/ktx2-basis-writer-worker.js', import.meta.url).toString());
+import(
+  /* @vite-ignore */ new URL('./workers/ktx2-basis-writer-worker.js', import.meta.url).toString()
+);

--- a/modules/textures/src/npy-worker.ts
+++ b/modules/textures/src/npy-worker.ts
@@ -3,4 +3,4 @@
 // Copyright (c) vis.gl contributors
 
 // Classic-worker entrypoint that lazily loads the ESM worker implementation.
-import(new URL('./workers/npy-worker.js', import.meta.url).toString());
+import(/* @vite-ignore */ new URL('./workers/npy-worker.js', import.meta.url).toString());


### PR DESCRIPTION
Goals of the PR

- Remove noisy Vite import-analysis warnings from intentional classic-worker runtime imports.

Actual changes

- Add `@vite-ignore` to the five texture classic-worker dynamic imports.
- Preserve runtime URL resolution and worker behavior.

Validation

- `yarn lint fix`
- `yarn build`
- Focused headless texture tests: 7 passed, 1 skipped
- Focused FlatGeobuf tests: 12 passed

Note: the full worker rebuild later encounters an unrelated existing LERC/esbuild error resolving `module` from `lerc/LercDecode.es.js`.