### PR TITLE
feat(wms): implement tranches 11-12

### DIFF
--- a/docs/modules/wms/api-reference/crs-and-tile-grids.md
+++ b/docs/modules/wms/api-reference/crs-and-tile-grids.md
@@ -1,0 +1,18 @@
+# CRS and tile-grid intelligence
+
+The WMS package exposes utilities for services that use different CRS spellings:
+
+```js
+import {normalizeServiceCRS, selectServiceCRS} from '@loaders.gl/wms';
+
+normalizeServiceCRS('urn:ogc:def:crs:EPSG::3857'); // 'EPSG:3857'
+selectServiceCRS('EPSG:3857', ['EPSG:4326', 'EPSG:3857']); // 'EPSG:3857'
+```
+
+`WMTSImageTileSource` uses these rules when capabilities list multiple linked tile matrix sets.
+Set `wmts.crs` to select the compatible matrix set, and the source uses the matrix's declared
+identifier (for example `L04`) rather than assuming that a zoom level is its identifier.
+
+The axis-order helper reports the conventional service order for the common geographic CRS:
+`EPSG:4326` is `yx`, while `CRS:84` and projected CRSs are `xy`. Applications should still follow
+the individual service's capabilities when constructing coordinate arrays.

--- a/docs/modules/wms/services/arcgis-image-server.md
+++ b/docs/modules/wms/services/arcgis-image-server.md
@@ -77,6 +77,7 @@ returns decoded `LERCData` values without an image round trip.
 ## Example
 
 - [ArcGIS Image Server example](/examples/tiles/arcgis-image-server)
+- [ArcGIS ImageServer analytical LERC example](/examples/tiles/arcgis-image-server-lerc)
 - [ArcGIS ImageServer tiles example](/examples/tiles/arcgis-image-server-tiles)
 
 ## References

--- a/docs/modules/wms/services/arcgis-image-server.md
+++ b/docs/modules/wms/services/arcgis-image-server.md
@@ -52,6 +52,28 @@ const tileSource = createDataSource(url, [ArcGISImageTileSourceLoader], {
 tileSource.updateParameters({renderingRule: JSON.stringify({rasterFunction: 'Hillshade'})});
 ```
 
+## Analytical LERC rasters
+
+ArcGIS ImageServer can return [LERC](https://esri.github.io/lerc/) instead of a display image.
+Use `exportRaster` when the result should remain a typed, analysis-ready raster:
+
+```js
+const raster = await source.exportRaster({
+  bbox: [-122.5, 37.7, -122.3, 37.85],
+  bboxSR: 'EPSG:4326',
+  imageSR: 'EPSG:4326',
+  width: 512,
+  height: 512,
+  format: 'lerc',
+  pixelType: 'F32'
+});
+
+// raster.pixels contains one typed array per band; raster.mask carries validity.
+```
+
+For tile workflows, set `format: 'lerc'` under `arcgis-image-server-tiles`. The tile source then
+returns decoded `LERCData` values without an image round trip.
+
 ## Example
 
 - [ArcGIS Image Server example](/examples/tiles/arcgis-image-server)

--- a/modules/wms/package.json
+++ b/modules/wms/package.json
@@ -60,6 +60,7 @@
   "dependencies": {
     "@loaders.gl/gis": "5.0.0-alpha.2",
     "@loaders.gl/images": "5.0.0-alpha.2",
+    "@loaders.gl/lerc": "5.0.0-alpha.2",
     "@loaders.gl/loader-utils": "5.0.0-alpha.2",
     "@loaders.gl/schema": "5.0.0-alpha.2",
     "@loaders.gl/xml": "5.0.0-alpha.2",

--- a/modules/wms/src/arcgis/arcgis-image-server-source-loader.ts
+++ b/modules/wms/src/arcgis/arcgis-image-server-source-loader.ts
@@ -12,6 +12,8 @@ import type {
   GetImageParameters
 } from '@loaders.gl/loader-utils';
 import {DataSource, ImageSource} from '@loaders.gl/loader-utils';
+import type {LERCData} from '@loaders.gl/lerc';
+import {LERCLoader} from '@loaders.gl/lerc';
 
 /** Options for the ArcGIS ImageServer source. */
 export type ArcGISImageSourceLoaderProps = DataSourceOptions & {
@@ -34,7 +36,7 @@ export type ArcGISExportImageParameters = {
   /** Spatial reference of the returned image. */
   imageSR?: string | number;
   /** Requested image format. */
-  format?: 'jpgpng' | 'png' | 'png8' | 'png24' | 'jpg' | 'bmp' | 'gif' | 'tiff' | 'png32';
+  format?: 'jpgpng' | 'png' | 'png8' | 'png24' | 'jpg' | 'bmp' | 'gif' | 'tiff' | 'png32' | 'lerc';
   /** Requested pixel type. */
   pixelType?: 'U1' | 'U2' | 'U4' | 'U8' | 'S8' | 'U16' | 'S16' | 'U32' | 'S32' | 'F32' | 'F64';
   /** NoData pixel value. */
@@ -139,6 +141,23 @@ export class ArcGISImageSource
     await this.checkResponse(response);
     const arrayBuffer = await response.arrayBuffer();
     return (await this.coreApi.parse(arrayBuffer, ImageLoader, this.loadOptions)) as ImageType;
+  }
+
+  /** Requests an analytical LERC raster from the ArcGIS ImageServer endpoint. */
+  async exportRaster(
+    options: ArcGISExportImageParameters,
+    signal?: AbortSignal
+  ): Promise<LERCData> {
+    const response = await this.fetch(
+      this.exportImageURL({...options, format: 'lerc'}),
+      signal ? {signal} : undefined
+    );
+    await this.checkResponse(response);
+    return (await this.coreApi.parse(
+      await response.arrayBuffer(),
+      LERCLoader,
+      this.loadOptions
+    )) as LERCData;
   }
 
   /** Builds a metadata URL for the ArcGIS ImageServer endpoint. */

--- a/modules/wms/src/arcgis/arcgis-image-tile-source-loader.ts
+++ b/modules/wms/src/arcgis/arcgis-image-tile-source-loader.ts
@@ -36,8 +36,8 @@ export class ArcGISImageTileSource
   extends DataSource<string, ArcGISImageTileSourceLoaderOptions>
   implements TileSource
 {
-  /** MIME type rendered by the generic deck.gl tile adapter. */
-  readonly mimeType = 'image/png';
+  /** MIME type represented by the tile response. */
+  readonly mimeType: string;
 
   /** Cached ImageServer metadata. */
   private _metadata: any | null = null;
@@ -49,6 +49,7 @@ export class ArcGISImageTileSource
   /** Creates an ArcGIS ImageServer tile source. */
   constructor(url: string, options: ArcGISImageTileSourceLoaderOptions = {}, coreApi?: CoreAPI) {
     super(url.replace(/\/$/, ''), options, ArcGISImageTileSourceLoader.defaultOptions, coreApi);
+    this.mimeType = this._getResponseFormat() === 'lerc' ? 'application/octet-stream' : 'image/png';
     this.getTileData = this.getTileData.bind(this);
   }
 
@@ -87,8 +88,7 @@ export class ArcGISImageTileSource
         `ArcGIS ImageServer tile request failed: ${response.status} ${response.statusText}`
       );
     }
-    const loader =
-      this.options['arcgis-image-server-tiles']?.format === 'lerc' ? LERCLoader : ImageLoader;
+    const loader = this._getResponseFormat() === 'lerc' ? LERCLoader : ImageLoader;
     return (await this.coreApi.parse(
       await response.arrayBuffer(),
       loader,
@@ -119,7 +119,7 @@ export class ArcGISImageTileSource
       bboxSR: 3857,
       imageSR: 3857,
       size: `${resolvedTileSize},${resolvedTileSize}`,
-      format: options.format || 'png32',
+      format: this._getResponseFormat(),
       transparent: true,
       ...options.parameters,
       ...this._runtimeParameters
@@ -160,6 +160,13 @@ export class ArcGISImageTileSource
   private getServiceURL(parameters: GetTileParameters): string {
     const urls = this.options['arcgis-image-server-tiles']?.urls;
     return urls?.length ? urls[(parameters.x + parameters.y) % urls.length] : this.url;
+  }
+
+  /** Returns the response format after applying configured and runtime overrides. */
+  private _getResponseFormat(): 'png32' | 'lerc' {
+    const options = this.options['arcgis-image-server-tiles'] || {};
+    const format = this._runtimeParameters.format || options.parameters?.format || options.format;
+    return format === 'lerc' ? 'lerc' : 'png32';
   }
 }
 

--- a/modules/wms/src/arcgis/arcgis-image-tile-source-loader.ts
+++ b/modules/wms/src/arcgis/arcgis-image-tile-source-loader.ts
@@ -14,6 +14,8 @@ import type {
   TileSourceMetadata
 } from '@loaders.gl/loader-utils';
 import {DataSource} from '@loaders.gl/loader-utils';
+import type {LERCData} from '@loaders.gl/lerc';
+import {LERCLoader} from '@loaders.gl/lerc';
 
 /** Options for the ArcGIS ImageServer tile source. */
 export type ArcGISImageTileSourceLoaderOptions = DataSourceOptions & {
@@ -24,6 +26,8 @@ export type ArcGISImageTileSourceLoaderOptions = DataSourceOptions & {
     urls?: string[];
     /** Additional exportImage parameters. */
     parameters?: Record<string, string | number | boolean>;
+    /** Response format, using LERC for analytical raster tiles. */
+    format?: 'png32' | 'lerc';
   };
 };
 
@@ -73,22 +77,27 @@ export class ArcGISImageTileSource
   }
 
   /** Fetches one ImageServer export tile. */
-  async getTile(parameters: GetTileParameters, signal?: AbortSignal): Promise<ImageType | null> {
+  async getTile(
+    parameters: GetTileParameters,
+    signal?: AbortSignal
+  ): Promise<ImageType | LERCData | null> {
     const response = await this.fetch(this.getTileURL(parameters), signal ? {signal} : undefined);
     if (!response.ok) {
       throw new Error(
         `ArcGIS ImageServer tile request failed: ${response.status} ${response.statusText}`
       );
     }
+    const loader =
+      this.options['arcgis-image-server-tiles']?.format === 'lerc' ? LERCLoader : ImageLoader;
     return (await this.coreApi.parse(
       await response.arrayBuffer(),
-      ImageLoader,
+      loader,
       this.loadOptions
     )) as ImageType;
   }
 
   /** Fetches a tile using the deck.gl-compatible request shape. */
-  async getTileData(parameters: GetTileDataParameters): Promise<ImageType | null> {
+  async getTileData(parameters: GetTileDataParameters): Promise<ImageType | LERCData | null> {
     return this.getTile(parameters.index, parameters.signal);
   }
 
@@ -110,7 +119,7 @@ export class ArcGISImageTileSource
       bboxSR: 3857,
       imageSR: 3857,
       size: `${resolvedTileSize},${resolvedTileSize}`,
-      format: 'png32',
+      format: options.format || 'png32',
       transparent: true,
       ...options.parameters,
       ...this._runtimeParameters

--- a/modules/wms/src/crs-utils.ts
+++ b/modules/wms/src/crs-utils.ts
@@ -1,0 +1,47 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** A CRS identifier accepted by OGC and ArcGIS services. */
+export type ServiceCRS = string | number;
+
+/** Normalizes common OGC and ArcGIS CRS spellings to a stable identifier. */
+export function normalizeServiceCRS(crs: ServiceCRS | undefined): string | undefined {
+  if (crs === undefined || crs === null) return undefined;
+  if (typeof crs === 'number') return `EPSG:${crs}`;
+  const value = crs.trim();
+  if (!value) return undefined;
+  const upperValue = value.toUpperCase();
+  if (upperValue === 'CRS:84' || upperValue.endsWith('/CRS84')) return 'CRS:84';
+  const epsgMatch = /(?:EPSG[:/]|::)(\d+)$/i.exec(value);
+  return epsgMatch ? `EPSG:${epsgMatch[1]}` : upperValue;
+}
+
+/** Returns whether two CRS identifiers refer to the same service coordinate system. */
+export function areServiceCRSEquivalent(
+  firstCRS: ServiceCRS | undefined,
+  secondCRS: ServiceCRS | undefined
+): boolean {
+  const first = normalizeServiceCRS(firstCRS);
+  const second = normalizeServiceCRS(secondCRS);
+  if (!first || !second) return false;
+  if (first === second) return true;
+  const webMercatorCRS = new Set(['EPSG:3857', 'EPSG:900913', 'EPSG:102100', 'EPSG:102113']);
+  return webMercatorCRS.has(first) && webMercatorCRS.has(second);
+}
+
+/** Selects the first supported CRS compatible with a requested CRS. */
+export function selectServiceCRS(
+  requestedCRS: ServiceCRS | undefined,
+  supportedCRS: readonly ServiceCRS[]
+): string | undefined {
+  if (!supportedCRS.length) return normalizeServiceCRS(requestedCRS);
+  return (
+    supportedCRS.find(crs => areServiceCRSEquivalent(requestedCRS, crs)) || supportedCRS[0]
+  ).toString();
+}
+
+/** Returns the conventional axis order used in service request coordinates. */
+export function getServiceCRSAxisOrder(crs: ServiceCRS | undefined): 'xy' | 'yx' {
+  return normalizeServiceCRS(crs) === 'EPSG:4326' ? 'yx' : 'xy';
+}

--- a/modules/wms/src/crs-utils.ts
+++ b/modules/wms/src/crs-utils.ts
@@ -13,7 +13,7 @@ export function normalizeServiceCRS(crs: ServiceCRS | undefined): string | undef
   if (!value) return undefined;
   const upperValue = value.toUpperCase();
   if (upperValue === 'CRS:84' || upperValue.endsWith('/CRS84')) return 'CRS:84';
-  const epsgMatch = /(?:EPSG[:/]|::)(\d+)$/i.exec(value);
+  const epsgMatch = /(?:EPSG[:/]|::)(?:\d+\/)?(\d+)$/i.exec(value);
   return epsgMatch ? `EPSG:${epsgMatch[1]}` : upperValue;
 }
 

--- a/modules/wms/src/index.ts
+++ b/modules/wms/src/index.ts
@@ -79,6 +79,13 @@ export {CSWCatalogSource, CSWSourceLoader} from './csw-source-loader';
 export {WMSSourceLoader, WMSImageSource} from './wms-source-loader';
 export type {WMTSSourceLoaderOptions} from './wmts-source-loader';
 export {WMTSSourceLoader, WMTSImageTileSource} from './wmts-source-loader';
+export type {ServiceCRS} from './crs-utils';
+export {
+  normalizeServiceCRS,
+  areServiceCRSEquivalent,
+  selectServiceCRS,
+  getServiceCRSAxisOrder
+} from './crs-utils';
 export {WFSSourceLoader, WFSVectorSource} from './wfs-source-loader';
 
 export type {GeoServiceType, ServiceCapabilities} from './service-capabilities';

--- a/modules/wms/src/wmts-source-loader.ts
+++ b/modules/wms/src/wmts-source-loader.ts
@@ -16,6 +16,7 @@ import type {
 import {DataSource} from '@loaders.gl/loader-utils';
 import type {WMTSCapabilities, WMTSLayer} from './lib/parsers/wmts/parse-wmts-capabilities';
 import {parseWMTSCapabilities} from './lib/parsers/wmts/parse-wmts-capabilities';
+import {selectServiceCRS, type ServiceCRS} from './crs-utils';
 
 /** Options for a WMTS tile source. */
 export type WMTSSourceLoaderOptions = DataSourceOptions & {
@@ -35,6 +36,8 @@ export type WMTSSourceLoaderOptions = DataSourceOptions & {
     /** Capabilities document or URL used to derive layer and tile matrix options. */
     capabilities?: WMTSCapabilities;
     capabilitiesUrl?: string;
+    /** Preferred coordinate reference system for matrix-set selection. */
+    crs?: ServiceCRS;
   };
 };
 
@@ -102,12 +105,17 @@ export class WMTSImageTileSource
       resource.format ? resource.format === (parameters.format || wmts.format) : true
     );
     const urlTemplate = wmts.urlTemplate || resourceURL?.template;
+    const tileMatrixSet = this._getTileMatrixSet(layer);
+    const tileMatrix =
+      tileMatrixSet?.matrices.find(matrix => matrix.identifier === String(parameters.z)) ||
+      tileMatrixSet?.matrices[parameters.z];
+    const tileMatrixIdentifier = tileMatrix?.identifier || String(parameters.z);
     if (urlTemplate) {
       return urlTemplate
-        .replaceAll('{TileMatrix}', String(parameters.z))
+        .replaceAll('{TileMatrix}', tileMatrixIdentifier)
         .replaceAll('{TileRow}', String(parameters.y))
         .replaceAll('{TileCol}', String(parameters.x))
-        .replaceAll('{TileMatrixSet}', wmts.tileMatrixSet || '');
+        .replaceAll('{TileMatrixSet}', tileMatrixSet?.identifier || wmts.tileMatrixSet || '');
     }
     const url = new URL(this.url);
     const searchParameters = new URLSearchParams({
@@ -116,8 +124,8 @@ export class WMTSImageTileSource
       VERSION: '1.0.0',
       LAYER: parameters.layers ? String(parameters.layers) : wmts.layer || layer?.identifier || '',
       STYLE: wmts.style || 'default',
-      TILEMATRIXSET: wmts.tileMatrixSet || layer?.tileMatrixSetLinks[0]?.tileMatrixSet || '',
-      TILEMATRIX: String(parameters.z),
+      TILEMATRIXSET: tileMatrixSet?.identifier || wmts.tileMatrixSet || '',
+      TILEMATRIX: tileMatrixIdentifier,
       TILEROW: String(parameters.y),
       TILECOL: String(parameters.x),
       FORMAT: parameters.format || wmts.format || 'image/png',
@@ -151,6 +159,33 @@ export class WMTSImageTileSource
     return capabilities?.contents.layers.find(
       layer => !layerName || layer.identifier === layerName
     );
+  }
+
+  private _getTileMatrixSet(layer: WMTSLayer | undefined) {
+    const capabilities = this._capabilities;
+    const wmts = this.options.wmts || {};
+    const linkedIdentifiers = layer?.tileMatrixSetLinks.map(link => link.tileMatrixSet) || [];
+    const candidates =
+      capabilities?.contents.tileMatrixSets.filter(tileMatrixSet =>
+        linkedIdentifiers.includes(tileMatrixSet.identifier)
+      ) || [];
+    const requestedCRS = wmts.crs;
+    if (wmts.tileMatrixSet) {
+      return capabilities?.contents.tileMatrixSets.find(
+        tileMatrixSet => tileMatrixSet.identifier === wmts.tileMatrixSet
+      );
+    }
+    if (candidates.length) {
+      const selectedCRS = selectServiceCRS(
+        requestedCRS,
+        candidates.map(tileMatrixSet => tileMatrixSet.supportedCRS || '')
+      );
+      return (
+        candidates.find(tileMatrixSet => tileMatrixSet.supportedCRS === selectedCRS) ||
+        candidates[0]
+      );
+    }
+    return undefined;
   }
 }
 

--- a/modules/wms/src/wmts-source-loader.ts
+++ b/modules/wms/src/wmts-source-loader.ts
@@ -161,6 +161,7 @@ export class WMTSImageTileSource
     );
   }
 
+  /** Selects a linked tile matrix set using an explicit identifier or compatible CRS. */
   private _getTileMatrixSet(layer: WMTSLayer | undefined) {
     const capabilities = this._capabilities;
     const wmts = this.options.wmts || {};

--- a/modules/wms/test/arcgis/arcgis-server.spec.ts
+++ b/modules/wms/test/arcgis/arcgis-server.spec.ts
@@ -79,6 +79,16 @@ vitestTest('ArcGISImageTileSource distributes requests across configured service
   expect(url.origin).toBe('https://imagery-b.example.com');
 });
 
+vitestTest('ArcGISImageTileSource parses the effective response format', () => {
+  const source = new ArcGISImageTileSource('https://example.com/ImageServer', {
+    'arcgis-image-server-tiles': {format: 'lerc', parameters: {format: 'png32'}}
+  });
+  expect(new URL(source.getTileURL({x: 0, y: 0, z: 0})).searchParams.get('format')).toBe('png32');
+  expect(source.mimeType).toBe('image/png');
+  source.updateParameters({format: 'png32'});
+  expect(new URL(source.getTileURL({x: 0, y: 0, z: 0})).searchParams.get('format')).toBe('png32');
+});
+
 test('ArcGISImageSource#metadataURL', t => {
   const source = ArcGISImageServerSourceLoader.createDataSource(IMAGE_SERVER_URL, {});
 
@@ -112,7 +122,7 @@ test('ArcGISImageSource#exportImageURL', t => {
   t.end();
 });
 
-test('ArcGISImageSource#exportImageURL supports LERC analytical rasters', t => {
+vitestTest('ArcGISImageSource#exportImageURL supports LERC analytical rasters', () => {
   const source = ArcGISImageServerSourceLoader.createDataSource(IMAGE_SERVER_URL, {});
   const exportRasterUrl = new URL(
     source.exportImageURL({
@@ -123,9 +133,8 @@ test('ArcGISImageSource#exportImageURL supports LERC analytical rasters', t => {
       pixelType: 'F32'
     })
   );
-  t.equal(exportRasterUrl.searchParams.get('format'), 'lerc');
-  t.equal(exportRasterUrl.searchParams.get('pixelType'), 'F32');
-  t.end();
+  expect(exportRasterUrl.searchParams.get('format')).toBe('lerc');
+  expect(exportRasterUrl.searchParams.get('pixelType')).toBe('F32');
 });
 
 test('ArcGISImageSource#getMetadata', async t => {

--- a/modules/wms/test/arcgis/arcgis-server.spec.ts
+++ b/modules/wms/test/arcgis/arcgis-server.spec.ts
@@ -112,6 +112,22 @@ test('ArcGISImageSource#exportImageURL', t => {
   t.end();
 });
 
+test('ArcGISImageSource#exportImageURL supports LERC analytical rasters', t => {
+  const source = ArcGISImageServerSourceLoader.createDataSource(IMAGE_SERVER_URL, {});
+  const exportRasterUrl = new URL(
+    source.exportImageURL({
+      bbox: [1, 2, 3, 4],
+      width: 128,
+      height: 128,
+      format: 'lerc',
+      pixelType: 'F32'
+    })
+  );
+  t.equal(exportRasterUrl.searchParams.get('format'), 'lerc');
+  t.equal(exportRasterUrl.searchParams.get('pixelType'), 'F32');
+  t.end();
+});
+
 test('ArcGISImageSource#getMetadata', async t => {
   const source = ArcGISImageServerSourceLoader.createDataSource(IMAGE_SERVER_URL, {});
   source.fetch = async () =>

--- a/modules/wms/test/crs-utils.spec.ts
+++ b/modules/wms/test/crs-utils.spec.ts
@@ -1,0 +1,17 @@
+import test from 'test/utils/vitest-tape';
+import {
+  areServiceCRSEquivalent,
+  getServiceCRSAxisOrder,
+  normalizeServiceCRS,
+  selectServiceCRS
+} from '@loaders.gl/wms';
+
+test('service CRS utilities normalize OGC and ArcGIS identifiers', t => {
+  t.equal(normalizeServiceCRS('urn:ogc:def:crs:EPSG::3857'), 'EPSG:3857');
+  t.equal(normalizeServiceCRS('CRS:84'), 'CRS:84');
+  t.ok(areServiceCRSEquivalent('EPSG:900913', 3857));
+  t.equal(selectServiceCRS('EPSG:3857', ['EPSG:4326', 'EPSG:900913']), 'EPSG:900913');
+  t.equal(getServiceCRSAxisOrder('EPSG:4326'), 'yx');
+  t.equal(getServiceCRSAxisOrder('CRS:84'), 'xy');
+  t.end();
+});

--- a/modules/wms/test/crs-utils.spec.ts
+++ b/modules/wms/test/crs-utils.spec.ts
@@ -1,4 +1,4 @@
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {
   areServiceCRSEquivalent,
   getServiceCRSAxisOrder,
@@ -6,12 +6,12 @@ import {
   selectServiceCRS
 } from '@loaders.gl/wms';
 
-test('service CRS utilities normalize OGC and ArcGIS identifiers', t => {
-  t.equal(normalizeServiceCRS('urn:ogc:def:crs:EPSG::3857'), 'EPSG:3857');
-  t.equal(normalizeServiceCRS('CRS:84'), 'CRS:84');
-  t.ok(areServiceCRSEquivalent('EPSG:900913', 3857));
-  t.equal(selectServiceCRS('EPSG:3857', ['EPSG:4326', 'EPSG:900913']), 'EPSG:900913');
-  t.equal(getServiceCRSAxisOrder('EPSG:4326'), 'yx');
-  t.equal(getServiceCRSAxisOrder('CRS:84'), 'xy');
-  t.end();
+test('service CRS utilities normalize OGC and ArcGIS identifiers', () => {
+  expect(normalizeServiceCRS('urn:ogc:def:crs:EPSG::3857')).toBe('EPSG:3857');
+  expect(normalizeServiceCRS('http://www.opengis.net/def/crs/EPSG/0/3857')).toBe('EPSG:3857');
+  expect(normalizeServiceCRS('CRS:84')).toBe('CRS:84');
+  expect(areServiceCRSEquivalent('EPSG:900913', 3857)).toBe(true);
+  expect(selectServiceCRS('EPSG:3857', ['EPSG:4326', 'EPSG:900913'])).toBe('EPSG:900913');
+  expect(getServiceCRSAxisOrder('EPSG:4326')).toBe('yx');
+  expect(getServiceCRSAxisOrder('CRS:84')).toBe('xy');
 });

--- a/modules/wms/test/wmts/wmts-source.spec.ts
+++ b/modules/wms/test/wmts/wmts-source.spec.ts
@@ -87,3 +87,41 @@ test('WMTSImageTileSource derives URL options from capabilities', async t => {
   t.equal(source.getTileURL({x: 1, y: 2, z: 3}), 'https://tiles.example/3/2/1.png');
   t.end();
 });
+
+test('WMTSImageTileSource selects CRS-compatible matrix identifiers', async t => {
+  const source = new WMTSImageTileSource('https://example.com/wmts', {
+    wmts: {
+      layer: 'imagery',
+      crs: 'EPSG:3857',
+      capabilities: {
+        contents: {
+          layers: [
+            {
+              identifier: 'imagery',
+              formats: ['image/png'],
+              styles: [],
+              tileMatrixSetLinks: [
+                {tileMatrixSet: 'Geographic'},
+                {tileMatrixSet: 'WebMercatorQuad'}
+              ],
+              resourceURLs: [
+                {template: 'https://tiles.example/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}'}
+              ]
+            }
+          ],
+          tileMatrixSets: [
+            {identifier: 'Geographic', supportedCRS: 'EPSG:4326', matrices: [{identifier: '4'}]},
+            {
+              identifier: 'WebMercatorQuad',
+              supportedCRS: 'EPSG:3857',
+              matrices: [{identifier: 'L04'}]
+            }
+          ]
+        }
+      }
+    }
+  });
+  await source.getMetadata();
+  t.equal(source.getTileURL({x: 1, y: 2, z: 0}), 'https://tiles.example/WebMercatorQuad/L04/2/1');
+  t.end();
+});

--- a/modules/wms/test/wmts/wmts-source.spec.ts
+++ b/modules/wms/test/wmts/wmts-source.spec.ts
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import test from 'test/utils/vitest-tape';
+import {expect, test as vitestTest} from 'vitest';
 import {WMTSSourceLoader, WMTSImageTileSource} from '@loaders.gl/wms';
 import {WMTSCapabilitiesLoader} from '@loaders.gl/wms';
 
@@ -88,7 +89,7 @@ test('WMTSImageTileSource derives URL options from capabilities', async t => {
   t.end();
 });
 
-test('WMTSImageTileSource selects CRS-compatible matrix identifiers', async t => {
+vitestTest('WMTSImageTileSource selects CRS-compatible matrix identifiers', async () => {
   const source = new WMTSImageTileSource('https://example.com/wmts', {
     wmts: {
       layer: 'imagery',
@@ -122,6 +123,7 @@ test('WMTSImageTileSource selects CRS-compatible matrix identifiers', async t =>
     }
   });
   await source.getMetadata();
-  t.equal(source.getTileURL({x: 1, y: 2, z: 0}), 'https://tiles.example/WebMercatorQuad/L04/2/1');
-  t.end();
+  expect(source.getTileURL({x: 1, y: 2, z: 0})).toBe(
+    'https://tiles.example/WebMercatorQuad/L04/2/1'
+  );
 });

--- a/modules/wms/tsconfig.json
+++ b/modules/wms/tsconfig.json
@@ -13,5 +13,6 @@
     {"path": "../images"},
     {"path": "../loader-utils"},
     {"path": "../schema"}
+    ,{"path": "../lerc"}
   ]
 }

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -138,6 +138,7 @@ const config = {
             '@loaders.gl/json': resolve('../modules/json/src'),
             '@loaders.gl/kml': resolve('../modules/kml/src'),
             '@loaders.gl/las': resolve('../modules/las/src'),
+            '@loaders.gl/lerc': resolve('../modules/lerc/src'),
             '@loaders.gl/loader-utils': resolve('../modules/loader-utils/src'),
             '@loaders.gl/math': resolve('../modules/math/src'),
             '@loaders.gl/mlt': resolve('../modules/mlt/src'),

--- a/website/package.json
+++ b/website/package.json
@@ -45,6 +45,7 @@
     "@loaders.gl/i3s": "workspace:*",
     "@loaders.gl/json": "workspace:*",
     "@loaders.gl/las": "workspace:*",
+    "@loaders.gl/lerc": "workspace:*",
     "@loaders.gl/loader-utils": "workspace:*",
     "@loaders.gl/obj": "workspace:*",
     "@loaders.gl/orc": "workspace:*",

--- a/website/src/examples/tiles/arcgis-image-server-lerc.mdx
+++ b/website/src/examples/tiles/arcgis-image-server-lerc.mdx
@@ -1,0 +1,35 @@
+---
+title: "ArcGIS ImageServer Analytical LERC"
+---
+
+import {WmsDocsTabs} from '@site/src/components/docs/wms-docs-tabs';
+
+# ArcGIS ImageServer Analytical LERC
+
+<WmsDocsTabs active="arcgis-image-server-example" />
+
+ArcGIS ImageServer can return analysis-ready LERC rasters instead of display images:
+
+```ts
+import {createDataSource} from '@loaders.gl/core';
+import {_ArcGISImageServerSourceLoader} from '@loaders.gl/wms';
+
+const source = createDataSource(url, [_ArcGISImageServerSourceLoader], {
+  core: {type: 'arcgis-image-server'}
+});
+
+const raster = await source.exportRaster({
+  bbox: [-122.5, 37.7, -122.3, 37.85],
+  bboxSR: 'EPSG:4326',
+  imageSR: 'EPSG:4326',
+  width: 512,
+  height: 512,
+  format: 'lerc',
+  pixelType: 'F32'
+});
+
+console.log(raster.width, raster.height, raster.pixels[0]);
+```
+
+The returned typed arrays and mask are suitable for classification, statistics, and raster
+processing without converting through an image format.

--- a/yarn.lock
+++ b/yarn.lock
@@ -5512,7 +5512,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@loaders.gl/lerc@workspace:modules/lerc":
+"@loaders.gl/lerc@npm:5.0.0-alpha.2, @loaders.gl/lerc@workspace:modules/lerc":
   version: 0.0.0-use.local
   resolution: "@loaders.gl/lerc@workspace:modules/lerc"
   dependencies:
@@ -5953,6 +5953,7 @@ __metadata:
   dependencies:
     "@loaders.gl/gis": "npm:5.0.0-alpha.2"
     "@loaders.gl/images": "npm:5.0.0-alpha.2"
+    "@loaders.gl/lerc": "npm:5.0.0-alpha.2"
     "@loaders.gl/loader-utils": "npm:5.0.0-alpha.2"
     "@loaders.gl/schema": "npm:5.0.0-alpha.2"
     "@loaders.gl/xml": "npm:5.0.0-alpha.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5512,7 +5512,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@loaders.gl/lerc@npm:5.0.0-alpha.2, @loaders.gl/lerc@workspace:modules/lerc":
+"@loaders.gl/lerc@npm:5.0.0-alpha.2, @loaders.gl/lerc@workspace:*, @loaders.gl/lerc@workspace:modules/lerc":
   version: 0.0.0-use.local
   resolution: "@loaders.gl/lerc@workspace:modules/lerc"
   dependencies:
@@ -27953,6 +27953,7 @@ __metadata:
     "@loaders.gl/i3s": "workspace:*"
     "@loaders.gl/json": "workspace:*"
     "@loaders.gl/las": "workspace:*"
+    "@loaders.gl/lerc": "workspace:*"
     "@loaders.gl/loader-utils": "workspace:*"
     "@loaders.gl/obj": "workspace:*"
     "@loaders.gl/orc": "workspace:*"


### PR DESCRIPTION
## Goals

- Advance service support with CRS-aware WMTS tile-grid negotiation.
- Make ArcGIS ImageServer useful for analysis-ready raster workflows.

## Changes

- Normalize common OGC and ArcGIS CRS identifiers, compare Web Mercator aliases, select compatible CRSs, and expose axis-order metadata.
- Select WMTS tile matrix sets from capabilities using the requested CRS and use declared matrix identifiers in REST/KVP URLs.
- Add ArcGIS ImageServer LERC export support via `exportRaster`.
- Add optional LERC responses for ArcGIS ImageServer tile sources.
- Add focused CRS, WMTS, and ArcGIS tests plus API documentation.

## Verification

- `yarn lint fix`
- `yarn build`
- `yarn build-workers`
- `yarn test-node` (333 passed, 6 skipped)
- Focused Chromium tests (25 passed)
- `yarn test-audit` (0 violations)