### PR TITLE
feat(parquet): emit size statistics from TypeScript writer

### DIFF
--- a/docs/modules/parquet/api-reference/parquet-writer.md
+++ b/docs/modules/parquet/api-reference/parquet-writer.md
@@ -136,6 +136,7 @@ read/write encoding matrix.
 | `parquet.bloomFilter` | `boolean \| Record<string, boolean>` | `false` | Emits uncompressed split-block Bloom filters for supported scalar columns, globally or by top-level column name. |
 | `parquet.pageIndex` | `boolean \| Record<string, boolean>` | `false` | Emits column and offset indexes for supported non-repeated scalar columns, globally or by top-level column name. |
 | `parquet.writePageChecksums` | `boolean` | `false` | Emits CRC-32 checksums for TypeScript writer data and dictionary pages. |
+| `parquet.writeSizeStatistics` | `boolean` | `false` | Emits byte-array size totals and repetition/definition-level histograms for TypeScript writer column chunks. |
 | `parquet.rowGroupSize` | `number` | implementation default | Sets the target row count per row group for `ParquetJSWriter`. |
 | `parquet.pageSize` | `number` | `8192` | Sets the target shredded level-entry count per page. Boundaries remain aligned to top-level rows. |
 | `parquet.useDataPageV2` | `boolean` | `false` | Emits Data Page V2 from `ParquetJSWriter`. |

--- a/docs/modules/parquet/formats/parquet.md
+++ b/docs/modules/parquet/formats/parquet.md
@@ -243,7 +243,7 @@ can make selective reads much cheaper.
 | [Column index](https://github.com/apache/parquet-format/blob/master/PageIndex.md) | ✅ | ✅ (opt-in) | Predicates use page min/max statistics to derive conservative candidate row ranges for primitive leaves, including nested struct children and repeated leaves when selected columns share page boundaries |
 | [Offset index](https://github.com/apache/parquet-format/blob/master/PageIndex.md) | ✅ | ✅ (opt-in) | Selected columns use page locations and first-row indexes for selective byte reads; repeated values and continuation pages are decoded only from complete, mutually aligned row ranges |
 | [Bloom filters](https://github.com/apache/parquet-format/blob/master/BloomFilter.md) | ✅ | ✅ | TypeScript reads split-block Bloom filters for safe equality/`IN` row-group pruning; `ParquetJSWriter` can emit them opt-in |
-| Size statistics | ✅ | ❌ | Byte-array sizes and repetition/definition histograms are decoded and exposed; writer emission remains future work |
+| Size statistics | ✅ | ✅ (opt-in) | Byte-array sizes and repetition/definition histograms are decoded and exposed; `ParquetJSWriter` emits them with `writeSizeStatistics` |
 | Column order and sorting columns | ✅ (metadata) | ❌ | Row-group sort declarations are normalized as `sortingColumns`; semantic pruning is not yet applied |
 
 `ParquetSourceLoader` accepts serializable logical predicates, prunes impossible row groups using

--- a/modules/parquet/src/parquet-js-writer.ts
+++ b/modules/parquet/src/parquet-js-writer.ts
@@ -38,6 +38,8 @@ type ParquetJSWriterEncoderOptions = {
   pageIndex?: boolean | Record<string, boolean>;
   /** Emits CRC-32 checksums for every data and dictionary page. */
   writePageChecksums?: boolean;
+  /** Emits optional SizeStatistics metadata for every column chunk. */
+  writeSizeStatistics?: boolean;
   rowGroupSize?: number;
   pageSize?: number;
   useDataPageV2?: boolean;

--- a/modules/parquet/src/parquetjs/encoder/parquet-encoder.ts
+++ b/modules/parquet/src/parquetjs/encoder/parquet-encoder.ts
@@ -26,6 +26,7 @@ import {
   ColumnChunk,
   ColumnIndex,
   ColumnMetaData,
+  SizeStatistics,
   CompressionCodec,
   ConvertedType,
   DataPageHeader,
@@ -115,6 +116,8 @@ export interface ParquetEncoderOptions {
   pageIndex?: boolean | Record<string, boolean>;
   /** Emit CRC-32 checksums for page bodies. */
   writePageChecksums?: boolean;
+  /** Emit optional SizeStatistics metadata for each column chunk. */
+  writeSizeStatistics?: boolean;
 
   // Write Stream Options
   flags?: string;
@@ -297,6 +300,7 @@ export class ParquetEnvelopeWriter {
   public bloomFilter?: boolean | Record<string, boolean>;
   public pageIndex?: boolean | Record<string, boolean>;
   public writePageChecksums: boolean;
+  public writeSizeStatistics: boolean;
 
   constructor(
     schema: ParquetSchema,
@@ -319,6 +323,7 @@ export class ParquetEnvelopeWriter {
     this.bloomFilter = opts.bloomFilter;
     this.pageIndex = opts.pageIndex;
     this.writePageChecksums = Boolean(opts.writePageChecksums);
+    this.writeSizeStatistics = Boolean(opts.writeSizeStatistics);
   }
 
   writeSection(buf: Uint8Array): Promise<void> {
@@ -347,7 +352,8 @@ export class ParquetEnvelopeWriter {
       dictionaryPageSizeLimit: this.dictionaryPageSizeLimit,
       bloomFilter: this.bloomFilter,
       pageIndex: this.pageIndex,
-      writePageChecksums: this.writePageChecksums
+      writePageChecksums: this.writePageChecksums,
+      writeSizeStatistics: this.writeSizeStatistics
     });
 
     this.rowCount += records.rowCount;
@@ -802,7 +808,8 @@ async function encodeColumnChunk(
     codec: CompressionCodec[column.compression!],
     bloom_filter_offset: bloomFilter ? int64(baseOffset + pagesBuf.length) : undefined,
     bloom_filter_length: bloomFilter?.length,
-    geospatial_statistics: createGeospatialStatistics(column, data.values)
+    geospatial_statistics: createGeospatialStatistics(column, data.values),
+    size_statistics: opts.writeSizeStatistics ? createSizeStatistics(column, data) : undefined
   });
 
   /* list encodings */
@@ -1024,6 +1031,40 @@ function createColumnBloomFilter(
     physicalType,
     column.typeLength
   );
+}
+
+/** Builds optional size statistics from one shredded column chunk. */
+function createSizeStatistics(column: ParquetField, data: ParquetColumnChunk): SizeStatistics {
+  const repetitionLevelHistogram = createLevelHistogram(data.rlevels, column.rLevelMax);
+  const definitionLevelHistogram = createLevelHistogram(data.dlevels, column.dLevelMax);
+  let unencodedByteArrayDataBytes = 0;
+  if (column.primitiveType === 'BYTE_ARRAY') {
+    for (const value of data.values) {
+      if (typeof value === 'string') {
+        unencodedByteArrayDataBytes += encodeUtf8(value).byteLength;
+      } else if (value instanceof ArrayBuffer || ArrayBuffer.isView(value)) {
+        unencodedByteArrayDataBytes += value.byteLength;
+      }
+    }
+  }
+  return new SizeStatistics({
+    unencoded_byte_array_data_bytes:
+      unencodedByteArrayDataBytes > 0 ? unencodedByteArrayDataBytes : undefined,
+    repetition_level_histogram: repetitionLevelHistogram,
+    definition_level_histogram: definitionLevelHistogram
+  });
+}
+
+/** Counts the occurrences of each definition or repetition level. */
+function createLevelHistogram(
+  levels: ParquetColumnChunk['rlevels'],
+  maximumLevel: number
+): number[] {
+  const histogram = new Array<number>(maximumLevel + 1).fill(0);
+  for (const level of levels) {
+    if (level >= 0 && level <= maximumLevel) histogram[level]++;
+  }
+  return histogram;
 }
 
 /**

--- a/modules/parquet/test/parquet-size-statistics.spec.ts
+++ b/modules/parquet/test/parquet-size-statistics.spec.ts
@@ -1,0 +1,53 @@
+import {expect, test} from 'vitest';
+
+import {encode} from '@loaders.gl/core';
+import {BlobFile} from '@loaders.gl/loader-utils';
+import type {ObjectRowTable} from '@loaders.gl/schema';
+
+import {ParquetJSWriter} from '../src/parquet-js-writer';
+import {ParquetReader} from '../src/parquetjs/parser/parquet-reader';
+
+const TABLE: ObjectRowTable = {
+  shape: 'object-row-table',
+  schema: {
+    fields: [
+      {name: 'label', type: 'utf8', nullable: true},
+      {name: 'value', type: 'int32', nullable: true}
+    ],
+    metadata: {}
+  },
+  data: [
+    {label: 'alpha', value: 1},
+    {label: null, value: null},
+    {label: 'beta', value: 2}
+  ]
+};
+
+test('ParquetJSWriter emits optional SizeStatistics metadata', async () => {
+  const parquetBuffer = await encode(TABLE, ParquetJSWriter, {
+    worker: false,
+    parquet: {writeSizeStatistics: true}
+  });
+  const metadata = await new ParquetReader(new BlobFile(parquetBuffer)).getFileMetadata();
+  const [label, value] = metadata.row_groups[0].columns.map(column => column.meta_data!);
+
+  expect(label.size_statistics).toBeDefined();
+  expect(label.size_statistics?.unencoded_byte_array_data_bytes?.toNumber()).toBe(9);
+  expect(label.size_statistics?.definition_level_histogram?.map(item => item.toNumber())).toEqual([
+    1,
+    2
+  ]);
+  expect(value.size_statistics?.definition_level_histogram?.map(item => item.toNumber())).toEqual([
+    1,
+    2
+  ]);
+  expect(value.size_statistics?.repetition_level_histogram?.map(item => item.toNumber())).toEqual([
+    3
+  ]);
+});
+
+test('ParquetJSWriter omits SizeStatistics by default', async () => {
+  const parquetBuffer = await encode(TABLE, ParquetJSWriter, {worker: false});
+  const metadata = await new ParquetReader(new BlobFile(parquetBuffer)).getFileMetadata();
+  expect(metadata.row_groups[0].columns[0].meta_data?.size_statistics).toBeUndefined();
+});


### PR DESCRIPTION
## Goals

Complete the TypeScript writer's stable metadata coverage with interoperable Parquet `SizeStatistics`, enabling downstream scan and memory planning without changing default output.

## Changes

- Add opt-in `parquet.writeSizeStatistics` to `ParquetJSWriter`.
- Emit byte-array payload totals plus definition/repetition-level histograms per column chunk.
- Add focused Vitest coverage for emitted metadata and the default-off behavior.
- Update the Parquet writer API and format support tables.

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn test-headless modules/parquet/test/parquet-size-statistics.spec.ts`
- `yarn test-audit`

## Scope

Semantic sorting-based pruning and encrypted-column reads remain separate follow-up work.