### PR TITLE
feat(copc): decode atomic nodes in LAS workers

### DIFF
--- a/docs/modules/copc/api-reference/copc-source-loader.md
+++ b/docs/modules/copc/api-reference/copc-source-loader.md
@@ -33,11 +33,13 @@ The created data source exposes the point-cloud tile methods used by `PointCloud
 - `getMetadata()` returns COPC metadata, inferred bounds, and an initial view state.
 - `getRootTile()` returns the root octree tile header.
 - `getChildren(tile)` returns available child tile headers.
-- `loadTileContent(tile)` returns normalized point positions, optional colors, point count, and cartographic origin.
+- `loadTileContent(tile, options)` returns normalized point positions, optional colors, point count, and cartographic origin. `options.signal` cancels queued work, the active range request, or worker decode.
 - `loadTileContentInBatches(tile, options)` yields normalized Arrow point tables progressively as the selected node range is fetched. `options.batchSize` controls the maximum points per table, `options.columns` selects the attributes listed below, and `options.signal` cancels the request/decode.
 - `loadHierarchyInBatches(options)` yields hierarchy pages and their discovered nodes as they are fetched.
 
-The source uses the native TypeScript COPC and LAZ readers for PDRF 6-8. `loadTileContentInBatches` splits the node range into requests and emits rows as soon as the requested independent layers arrive. PDRF 7 RGB waits for Point14 and RGB; PDRF 8 RGB/NIR waits for the layers requested through `options.columns`. `options.rangeChunkSize` controls request size, while `options.rangeConcurrency` can fetch later ranges ahead of in-order decoding.
+The source uses the native TypeScript COPC and LAZ readers for PDRF 6-8. Atomic `loadTileContent` calls created through `@loaders.gl/core` use the package's single prebuilt TypeScript LAS worker pool when workers are enabled; direct source construction and unavailable workers fall back to main-thread decoding. `copc.decodeConcurrency` bounds each source's combined node fetch and decode work to control peak compressed and decoded memory.
+
+`loadTileContentInBatches` remains on the calling thread because its async iterator is the streaming boundary. It splits the node range into requests and emits rows as soon as the requested independent layers arrive. PDRF 7 RGB waits for Point14 and RGB; PDRF 8 RGB/NIR waits for the layers requested through `options.columns`. `options.rangeChunkSize` controls request size, while `options.rangeConcurrency` can fetch later ranges ahead of in-order decoding.
 
 ## Options
 
@@ -46,6 +48,7 @@ The source uses the native TypeScript COPC and LAZ readers for PDRF 6-8. `loadTi
 | `copc.sourceCoordinateSystem` | `string` | Auto-detected from COPC WKT | Coordinate system definition used when the source metadata does not include WKT. |
 | `copc.rangeChunkSize` | `number` | `65536` | Default byte size for TypeScript COPC node range requests. |
 | `copc.rangeConcurrency` | `number` | `1` | Maximum number of node ranges fetched ahead of decoding. Results are still decoded and yielded in range order. |
+| `copc.decodeConcurrency` | `number` | `core.maxConcurrency` or `3` | Maximum number of complete atomic node fetches and worker decodes active for one source. |
 
 ### Progressive Columns
 

--- a/docs/modules/copc/formats/copc.md
+++ b/docs/modules/copc/formats/copc.md
@@ -30,9 +30,10 @@ The primary `@loaders.gl/copc` implementation is TypeScript-only. It does not re
 | PDRF 8 | **Full** | PDRF 7 plus progressive NIR decoding. |
 | LAZ codec | **Full for COPC** | Layered LASzip compressor 3, arithmetic coder 0, Point14/RGB14/RGBNIR14/Byte14 item versions 2-4. |
 | Arrow table output | **Full** | Atomic and batched APIs return Arrow tables directly without an intermediate object-per-point representation. |
+| Parallel atomic node decoding | **Full** | Atomic node loads created through `@loaders.gl/core` share the single prebuilt TypeScript LAS worker pool. Fetch plus decode concurrency is bounded per source. |
 | Selective field decoding | **Full** | Unrequested LAZ field layers are skipped, avoiding arithmetic decoder state, output arrays, and point traversal for those fields. |
 | Progressive node decoding | **Full at layer boundaries** | Node byte ranges are fed incrementally. Rows are emitted when all compressed layers required by the requested columns are available. |
-| Cancellation | **Full** | Abort signals are checked during hierarchy traversal, range loading, and progressive point decoding. |
+| Cancellation | **Full** | Abort signals cancel queued atomic loads, active range requests and worker jobs, hierarchy traversal, and progressive point decoding. |
 | COPC writing | **Full for represented attributes** | Writes LAS 1.4 PDRF 6-8, variable LAZ chunks, a version 0 chunk table, COPC info VLR, and a range-pageable hierarchy EVLR. |
 | Waveform PDRF 9/10 | **Not part of COPC 1.0** | COPC 1.0 permits only PDRF 6, 7, and 8. |
 

--- a/docs/modules/las/formats/las.md
+++ b/docs/modules/las/formats/las.md
@@ -246,12 +246,11 @@ A range-aware COPC reader first reads the LAS header and COPC VLRs, then reads t
 
 ## Remaining Roadmap
 
-Within the documented version, PDRF, and codec matrix, the TypeScript implementation now covers complete-file LAS/LAZ parsing, PDRF 0-10 point records, fixed and variable LAZ chunk tables, selective layered decoding, progressive PDRF 6-8 delivery, classification flags, LAZ writing, typed Extra Bytes, native COPC hierarchy and range parsing, independently validated paged COPC writing, seeded split conformance, malformed-input handling, and memory and throughput regression gates. The remaining work is ordered by value to the primary LAS 1.4 and COPC rendering path.
+Within the documented version, PDRF, and codec matrix, the TypeScript implementation now covers complete-file LAS/LAZ parsing, PDRF 0-10 point records, fixed and variable LAZ chunk tables, selective layered decoding, progressive PDRF 6-8 delivery, classification flags, LAZ writing, typed Extra Bytes, native COPC hierarchy and range parsing, bounded parallel COPC node decoding through the single TypeScript LAS worker, independently validated paged COPC writing, seeded split conformance, malformed-input handling, and memory and throughput regression gates. The remaining work is ordered by value to the primary LAS 1.4 and COPC rendering path.
 
 | Order | Work item | Impact | Cost | Acceptance target |
 | --- | --- | --- | --- | --- |
-| 1 | Add parallel node and chunk decoding | High for large datasets | High | Decode independent COPC nodes or LAZ chunks across a bounded worker pool while preserving batch order, cancellation, memory limits, and the single prebuilt TypeScript worker policy. |
-| 2 | Complete progressive delivery outside PDRF 6-8 | Medium | Medium | Deliver PDRF 9/10 waveform-reference and typed Extra Bytes rows when their required layered ranges arrive instead of waiting for a complete chunk. |
-| 3 | Replace legacy LAZ bounded replay | Low for COPC, medium for older LAZ | High | Preserve resumable arithmetic and item state for PDRF 0-5 so one-byte and arbitrary input splits make forward progress without replaying compressed input. |
-| 4 | Add waveform sample payload access | Low for COPC, specialized elsewhere | High | Range-read internal waveform EVLRs and external WDP data, apply waveform descriptors, and expose samples without losing exact packet-reference offsets. |
-| 5 | Complete LAS 1.5 conformance and writing | Medium | Medium | Enforce LAS 1.5 header, WKT, and PDRF rules; add broader fixtures; and emit LAS 1.5 only after independent-reader interoperability is demonstrated. |
+| 1 | Complete progressive delivery outside PDRF 6-8 | Medium | Medium | Deliver PDRF 9/10 waveform-reference and typed Extra Bytes rows when their required layered ranges arrive instead of waiting for a complete chunk. |
+| 2 | Replace legacy LAZ bounded replay | Low for COPC, medium for older LAZ | High | Preserve resumable arithmetic and item state for PDRF 0-5 so one-byte and arbitrary input splits make forward progress without replaying compressed input. |
+| 3 | Add waveform sample payload access | Low for COPC, specialized elsewhere | High | Range-read internal waveform EVLRs and external WDP data, apply waveform descriptors, and expose samples without losing exact packet-reference offsets. |
+| 4 | Complete LAS 1.5 conformance and writing | Medium | Medium | Enforce LAS 1.5 header, WKT, and PDRF rules; add broader fixtures; and emit LAS 1.5 only after independent-reader interoperability is demonstrated. |

--- a/modules/copc/src/copc-source-loader.ts
+++ b/modules/copc/src/copc-source-loader.ts
@@ -8,12 +8,14 @@ import type {
   CoreAPI,
   SourceLoader,
   DataSourceOptions,
+  StrictLoaderOptions,
   TileSource,
   TileSourceMetadata,
   GetTileParameters,
   GetTileDataParameters
 } from '@loaders.gl/loader-utils';
 import {
+  canParseWithWorker,
   createLAZChunkDecoderCursor,
   createLAZChunkDecoder,
   BlobFile,
@@ -21,12 +23,14 @@ import {
   HttpFile,
   isBrowser,
   NodeFile,
+  parseWithWorker,
   type ReadableFile
 } from '@loaders.gl/loader-utils';
 import {createScanQueryMetadata, type PointCloudQueryCapabilities} from '@loaders.gl/loader-utils';
 import {Proj4Projection, type Proj4CRSDefinition} from '@math.gl/proj4';
 import {
   createLASTypedExtraBytesAttributes,
+  LASLoader,
   populateLASTypedExtraBytes,
   type LASTypedExtraBytesAttribute
 } from '@loaders.gl/las';
@@ -137,7 +141,15 @@ export type COPCSourceLoaderOptions = DataSourceOptions & {
     rangeChunkSize?: number;
     /** Maximum number of COPC node ranges fetched ahead of decode. */
     rangeConcurrency?: number;
+    /** Maximum number of complete COPC nodes fetched and decoded concurrently. */
+    decodeConcurrency?: number;
   };
+};
+
+/** Options for one complete COPC tile-content load. */
+export type COPCTileContentLoadOptions = {
+  /** Cancel a queued range request or active worker decode. */
+  signal?: AbortSignal;
 };
 
 /** Options for progressive COPC point batches. */
@@ -265,11 +277,19 @@ export class COPCTileSource
   protected _hierarchy: COPCHierarchy | null = null;
   protected _pageLoadPromises: Map<string, Promise<void>> = new Map();
   protected _closePromise: Promise<void> | null = null;
+  /** Bounds complete node fetches and worker decodes to control peak memory. */
+  protected readonly _nodeDecodeSemaphore: AsyncSemaphore;
 
   constructor(data: string | Blob, options: COPCSourceLoaderOptions, coreApi?: CoreAPI) {
     super(data, options, COPCSourceLoader.defaultOptions, coreApi);
     this._readableFile = createCOPCReadableFile(data, this.url, this.fetch);
     this._readRange = createCachedCOPCRangeReader(this._readableFile);
+    const decodeConcurrency =
+      this.options.copc?.decodeConcurrency ?? this.loadOptions.core?.maxConcurrency ?? 3;
+    if (!Number.isSafeInteger(decodeConcurrency) || decodeConcurrency < 1) {
+      throw new Error('COPC decodeConcurrency must be a positive integer');
+    }
+    this._nodeDecodeSemaphore = new AsyncSemaphore(decodeConcurrency);
     this._initPromise = this._initCopc(this.url || 'Blob');
     this.metadata = this.getMetadata();
   }
@@ -430,17 +450,30 @@ export class COPCTileSource
     return await this.getNodeById(formatCOPCKey(parameters.nodeIndex));
   }
 
-  async loadTileContent(tile: {id: string}) {
-    const {copc} = await this._initPromise;
-    const node = await this.getNodeById(tile.id);
-    if (!node) {
-      return null;
+  /** Load one complete COPC node, using the shared LAS worker pool when available. */
+  async loadTileContent(tile: {id: string}, options: COPCTileContentLoadOptions = {}) {
+    const release = await this._nodeDecodeSemaphore.acquire(options.signal);
+    try {
+      throwIfCOPCLoadAborted(options.signal);
+      const {copc} = await this._initPromise;
+      const node = await this.getNodeById(tile.id);
+      if (!node) {
+        return null;
+      }
+
+      const nativeOrigin = this.getNativeTileCenter(tile.id);
+      const cartographicOrigin = this.projectPoint(nativeOrigin);
+
+      return await this.loadTypeScriptTileContent(
+        copc,
+        node,
+        nativeOrigin,
+        cartographicOrigin,
+        options.signal
+      );
+    } finally {
+      release();
     }
-
-    const nativeOrigin = this.getNativeTileCenter(tile.id);
-    const cartographicOrigin = this.projectPoint(nativeOrigin);
-
-    return await this.loadTypeScriptTileContent(copc, node, nativeOrigin, cartographicOrigin);
   }
 
   /**
@@ -776,10 +809,27 @@ export class COPCTileSource
     copc: COPCFile,
     node: COPCHierarchyNode,
     nativeOrigin: number[],
-    cartographicOrigin: number[]
+    cartographicOrigin: number[],
+    signal?: AbortSignal
   ) {
     const pointCount = node.pointCount;
-    const compressed = await loadCOPCNodeData(this._readRange, node);
+    const compressed = await loadCOPCNodeData(this._readRange, node, signal);
+    const workerPointData = await this.decodeNodeOnWorker(copc, node, compressed, signal);
+    if (workerPointData) {
+      this.transformTilePositions(
+        workerPointData.nativePositions,
+        workerPointData.positions,
+        nativeOrigin,
+        cartographicOrigin
+      );
+      return this.createTileContentResult(
+        pointCount,
+        workerPointData.positions,
+        workerPointData.colors,
+        cartographicOrigin
+      );
+    }
+
     const nativePositions = new Float64Array(pointCount * 3);
     const positions = new Float32Array(pointCount * 3);
     const colors = pointFormatHasColor(copc.header.pointDataRecordFormat)
@@ -808,6 +858,81 @@ export class COPCTileSource
 
     this.transformTilePositions(nativePositions, positions, nativeOrigin, cartographicOrigin);
     return this.createTileContentResult(pointCount, positions, colors, cartographicOrigin);
+  }
+
+  /** Decode one complete node in the shared LAS worker pool when workers are available. */
+  protected async decodeNodeOnWorker(
+    copc: COPCFile,
+    node: COPCHierarchyNode,
+    compressed: Uint8Array,
+    signal?: AbortSignal
+  ): Promise<{
+    nativePositions: Float64Array;
+    positions: Float32Array;
+    colors: Uint16Array | null;
+  } | null> {
+    const workerOptions = this.getNodeWorkerOptions(copc, node);
+    if (!this.hasCoreApi || !canParseWithWorker(LASLoader, workerOptions)) {
+      return null;
+    }
+    const input = getStandaloneArrayBuffer(compressed);
+    const mesh = (await parseWithWorker(
+      LASLoader,
+      input,
+      workerOptions,
+      undefined,
+      undefined,
+      signal
+    )) as Mesh;
+    const nativePositions = mesh.attributes.POSITION?.value;
+    const colors = mesh.attributes.COLOR_0?.value || null;
+    if (
+      !(nativePositions instanceof Float64Array) ||
+      nativePositions.length !== node.pointCount * 3
+    ) {
+      throw new Error('COPC LAS worker returned invalid positions');
+    }
+    if (
+      colors !== null &&
+      (!(colors instanceof Uint16Array) || colors.length !== node.pointCount * 3)
+    ) {
+      throw new Error('COPC LAS worker returned invalid colors');
+    }
+    return {
+      nativePositions,
+      positions: new Float32Array(node.pointCount * 3),
+      colors
+    };
+  }
+
+  /** Build the serializable standalone-chunk request consumed by the LAS worker. */
+  protected getNodeWorkerOptions(copc: COPCFile, node: COPCHierarchyNode): StrictLoaderOptions {
+    const columns = pointFormatHasColor(copc.header.pointDataRecordFormat)
+      ? ['POSITION', 'COLOR_0']
+      : ['POSITION'];
+    return {
+      ...this.loadOptions,
+      core: {
+        ...this.loadOptions.core,
+        worker: this.loadOptions.core?.worker ?? true,
+        maxConcurrency:
+          this.options.copc?.decodeConcurrency ?? this.loadOptions.core?.maxConcurrency ?? 3
+      },
+      las: {
+        ...this.loadOptions.las,
+        shape: 'mesh',
+        fp64: true,
+        colorDepth: 16,
+        columns,
+        _chunk: {
+          metadata: {
+            ...getCOPCLAZChunkMetadata(copc, node.pointCount),
+            scale: copc.header.scale,
+            offset: copc.header.offset
+          }
+        }
+      }
+    };
   }
 
   /** Transform decoded native positions into tile-relative render coordinates. */
@@ -1450,6 +1575,99 @@ function createCOPCReadableFile(
   return new NodeFile(url, 'r');
 }
 
+/** Return a transferable buffer without detaching a shared range-cache allocation. */
+function getStandaloneArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  if (
+    bytes.buffer instanceof ArrayBuffer &&
+    bytes.byteOffset === 0 &&
+    bytes.byteLength === bytes.buffer.byteLength
+  ) {
+    return bytes.buffer;
+  }
+  return bytes.slice().buffer;
+}
+
+/** Throw an AbortError when a complete COPC node load has been cancelled. */
+function throwIfCOPCLoadAborted(signal?: AbortSignal): void {
+  if (!signal?.aborted) {
+    return;
+  }
+  throw createCOPCAbortError();
+}
+
+/** Create the consistent cancellation error used by queued node loads. */
+function createCOPCAbortError(): Error {
+  const error = new Error('COPC tile content load was aborted');
+  error.name = 'AbortError';
+  return error;
+}
+
+type AsyncSemaphoreWaiter = {
+  resolve: (release: () => void) => void;
+  reject: (error: Error) => void;
+  signal?: AbortSignal;
+  abort?: () => void;
+};
+
+/** Small FIFO semaphore that bounds fetched and decoded COPC nodes together. */
+class AsyncSemaphore {
+  private activeCount = 0;
+  private readonly waiters: AsyncSemaphoreWaiter[] = [];
+
+  constructor(private readonly capacity: number) {}
+
+  /** Acquire one slot, waiting in request order when the source is saturated. */
+  acquire(signal?: AbortSignal): Promise<() => void> {
+    throwIfCOPCLoadAborted(signal);
+    if (this.activeCount < this.capacity) {
+      this.activeCount++;
+      return Promise.resolve(this.createRelease());
+    }
+
+    return new Promise((resolve, reject) => {
+      const waiter: AsyncSemaphoreWaiter = {resolve, reject, signal};
+      if (signal) {
+        waiter.abort = () => {
+          const waiterIndex = this.waiters.indexOf(waiter);
+          if (waiterIndex >= 0) {
+            this.waiters.splice(waiterIndex, 1);
+            reject(createCOPCAbortError());
+          }
+        };
+        signal.addEventListener('abort', waiter.abort, {once: true});
+      }
+      this.waiters.push(waiter);
+      if (signal?.aborted) {
+        waiter.abort?.();
+      }
+    });
+  }
+
+  /** Create an idempotent release closure for one active slot. */
+  private createRelease(): () => void {
+    let released = false;
+    return () => {
+      if (!released) {
+        released = true;
+        this.release();
+      }
+    };
+  }
+
+  /** Hand the current slot to the next waiter or return it to capacity. */
+  private release(): void {
+    const waiter = this.waiters.shift();
+    if (!waiter) {
+      this.activeCount--;
+      return;
+    }
+    if (waiter.signal && waiter.abort) {
+      waiter.signal.removeEventListener('abort', waiter.abort);
+    }
+    waiter.resolve(this.createRelease());
+  }
+}
+
 /** Cache the metadata prefix while retaining exact reads for hierarchy and node ranges. */
 function createCachedCOPCRangeReader(readableFile: ReadableFile): COPCRangeReader {
   const prefixPromise = Promise.resolve(readableFile.stat?.()).then(async stat => {
@@ -1458,11 +1676,11 @@ function createCachedCOPCRangeReader(readableFile: ReadableFile): COPCRangeReade
   });
   return async (begin, end, signal) => {
     if (signal?.aborted) {
-      throw new Error('COPC range request was aborted');
+      throw createCOPCAbortError();
     }
     const prefix = await prefixPromise;
     if (signal?.aborted) {
-      throw new Error('COPC range request was aborted');
+      throw createCOPCAbortError();
     }
     if (begin >= 0 && end <= prefix.byteLength) {
       return prefix.subarray(begin, end);

--- a/modules/copc/src/index.ts
+++ b/modules/copc/src/index.ts
@@ -7,7 +7,8 @@ export type {
   COPCHierarchyBatch,
   COPCHierarchyBatchOptions,
   COPCTileContent,
-  COPCTileContentBatchOptions
+  COPCTileContentBatchOptions,
+  COPCTileContentLoadOptions
 } from './copc-source-loader';
 export type {COPCWriterOptions} from './copc-writer';
 export {COPCFormat} from './copc-format';

--- a/modules/copc/src/lib/copc-reader.ts
+++ b/modules/copc/src/lib/copc-reader.ts
@@ -583,11 +583,11 @@ async function readExactRange(
     throw new Error(`Invalid COPC byte range ${begin}-${end}`);
   }
   if (signal?.aborted) {
-    throw new Error('COPC range request was aborted');
+    throw createCOPCAbortError();
   }
   const bytes = await readRange(begin, end, signal);
   if (signal?.aborted) {
-    throw new Error('COPC range request was aborted');
+    throw createCOPCAbortError();
   }
   if (bytes.byteLength !== end - begin) {
     throw new Error(
@@ -595,6 +595,13 @@ async function readExactRange(
     );
   }
   return bytes;
+}
+
+/** Create the consistent cancellation error used by native COPC range helpers. */
+function createCOPCAbortError(): Error {
+  const error = new Error('COPC range request was aborted');
+  error.name = 'AbortError';
+  return error;
 }
 
 /** Validate one non-empty hierarchy page range. */

--- a/modules/copc/test/copc-source.spec.ts
+++ b/modules/copc/test/copc-source.spec.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import test from 'test/utils/vitest-tape';
-import {expect, test as vitestTest} from 'vitest';
+import {expect, test as vitestTest, vi} from 'vitest';
 import {validateWriter} from 'test/common/conformance';
 import {createDataSource, encodeSync, fetchFile, isBrowser, parse} from '@loaders.gl/core';
 import {
@@ -12,7 +12,8 @@ import {
   COPCWriter,
   loadCOPCHierarchyPage,
   loadCOPCNodeData,
-  openCOPC
+  openCOPC,
+  type COPCRangeReader
 } from '@loaders.gl/copc';
 import {LASLoader} from '@loaders.gl/las';
 import {decodeLAZChunk, decodeLAZChunkTable} from '@loaders.gl/loader-utils';
@@ -24,7 +25,7 @@ const ELLIPSOID_BROWSER_URL = new URL('./data/ellipsoid.copc.laz', import.meta.u
 /** Test surface for the protected progressive range iterator. */
 class TestCOPCTileSource extends COPCTileSource {
   /** Replace the byte-range getter after normal source initialization. */
-  setRangeGetter(getter: (begin: number, end: number) => Promise<Uint8Array>): void {
+  setRangeGetter(getter: COPCRangeReader): void {
     this._readRange = getter;
   }
 
@@ -116,6 +117,171 @@ test('COPCSourceLoader#loads tile content with TypeScript LAZ decoder', async t 
   );
   t.end();
 });
+
+vitestTest('COPCSourceLoader#uses the shared TypeScript LAS worker for atomic nodes', async () => {
+  const blob = await createEllipsoidBlob();
+  const workerSource = createDataSource(blob, [COPCSourceLoader], {
+    core: {
+      type: 'copc',
+      loadOptions: {
+        core: {worker: true, reuseWorkers: false, _workerType: 'test'}
+      }
+    },
+    copc: {decodeConcurrency: 2}
+  });
+  const mainThreadSource = COPCSourceLoader.createDataSource(blob, {
+    core: {loadOptions: {core: {worker: false}}}
+  });
+  await Promise.all([workerSource.initialize(), mainThreadSource.initialize()]);
+  const rootTile = await workerSource.getRootTile();
+  const decodeNodeOnWorker = vi.spyOn(workerSource as any, 'decodeNodeOnWorker');
+
+  const [workerContent, mainThreadContent] = await Promise.all([
+    workerSource.loadTileContent(rootTile),
+    mainThreadSource.loadTileContent(rootTile)
+  ]);
+
+  expect(decodeNodeOnWorker).toHaveBeenCalledOnce();
+  expect(await decodeNodeOnWorker.mock.results[0].value).not.toBeNull();
+  expect(readCOPCContentColumn(workerContent, 'POSITION')).toEqual(
+    readCOPCContentColumn(mainThreadContent, 'POSITION')
+  );
+  expect(readCOPCContentColumn(workerContent, 'COLOR_0')).toEqual(
+    readCOPCContentColumn(mainThreadContent, 'COLOR_0')
+  );
+
+  const repeatedContent = await workerSource.loadTileContent(rootTile);
+  expect(readCOPCContentColumn(repeatedContent, 'POSITION')).toEqual(
+    readCOPCContentColumn(workerContent, 'POSITION')
+  );
+  expect((await workerSource.getChildren(rootTile)).length).toBeGreaterThan(0);
+});
+
+vitestTest.each([6, 7, 8] as const)(
+  'COPCSourceLoader#worker matches main-thread PDRF %i node decoding',
+  async pointDataRecordFormat => {
+    const blob = createWorkerCOPCBlob(pointDataRecordFormat);
+    const workerSource = createDataSource(blob, [COPCSourceLoader], {
+      core: {
+        type: 'copc',
+        loadOptions: {core: {worker: true, _workerType: 'test'}}
+      },
+      copc: {decodeConcurrency: 2}
+    });
+    const mainThreadSource = COPCSourceLoader.createDataSource(blob, {
+      core: {loadOptions: {core: {worker: false}}}
+    });
+    await Promise.all([workerSource.initialize(), mainThreadSource.initialize()]);
+    const rootTile = await workerSource.getRootTile();
+    const decodeNodeOnWorker = vi.spyOn(workerSource as any, 'decodeNodeOnWorker');
+    const [workerContent, mainThreadContent] = await Promise.all([
+      workerSource.loadTileContent(rootTile),
+      mainThreadSource.loadTileContent(rootTile)
+    ]);
+
+    expect(await decodeNodeOnWorker.mock.results[0].value).not.toBeNull();
+    expect(readCOPCContentColumn(workerContent, 'POSITION')).toEqual(
+      readCOPCContentColumn(mainThreadContent, 'POSITION')
+    );
+    expect(readCOPCContentColumn(workerContent, 'COLOR_0')).toEqual(
+      readCOPCContentColumn(mainThreadContent, 'COLOR_0')
+    );
+    const repeatedContent = await workerSource.loadTileContent(rootTile);
+    expect(readCOPCContentColumn(repeatedContent, 'POSITION')).toEqual(
+      readCOPCContentColumn(workerContent, 'POSITION')
+    );
+  }
+);
+
+vitestTest('COPCSourceLoader#bounds complete node fetch and decode concurrency', async () => {
+  const sourceBytes = new Uint8Array(await (await fetchFile(ELLIPSOID_BROWSER_URL)).arrayBuffer());
+  const source = new TestCOPCTileSource(new Blob([sourceBytes]), {
+    copc: {decodeConcurrency: 2},
+    core: {loadOptions: {core: {worker: false}}}
+  });
+  await source.initialize();
+  const rootTile = await source.getRootTile();
+  let activeRequestCount = 0;
+  let maximumActiveRequestCount = 0;
+  source.setRangeGetter(async (begin, end) => {
+    activeRequestCount++;
+    maximumActiveRequestCount = Math.max(maximumActiveRequestCount, activeRequestCount);
+    await new Promise(resolve => setTimeout(resolve, 10));
+    activeRequestCount--;
+    return sourceBytes.slice(begin, end);
+  });
+
+  const contents = await Promise.all(
+    Array.from({length: 5}, () => source.loadTileContent(rootTile))
+  );
+  expect(maximumActiveRequestCount).toBe(2);
+  expect(contents.every(content => content?.pointCount === rootTile.pointCount)).toBe(true);
+});
+
+vitestTest(
+  'COPCSourceLoader#cancels an atomic node queued behind the concurrency bound',
+  async () => {
+    const sourceBytes = new Uint8Array(
+      await (await fetchFile(ELLIPSOID_BROWSER_URL)).arrayBuffer()
+    );
+    const source = new TestCOPCTileSource(new Blob([sourceBytes]), {
+      copc: {decodeConcurrency: 1},
+      core: {loadOptions: {core: {worker: false}}}
+    });
+    await source.initialize();
+    const rootTile = await source.getRootTile();
+    let releaseRange!: () => void;
+    let markRangeStarted!: () => void;
+    const rangeStarted = new Promise<void>(resolve => {
+      markRangeStarted = resolve;
+    });
+    const rangeReleased = new Promise<void>(resolve => {
+      releaseRange = resolve;
+    });
+    let requestCount = 0;
+    source.setRangeGetter(async (begin, end) => {
+      requestCount++;
+      markRangeStarted();
+      await rangeReleased;
+      return sourceBytes.slice(begin, end);
+    });
+
+    const activeLoad = source.loadTileContent(rootTile);
+    await rangeStarted;
+    const abortController = new AbortController();
+    const queuedLoad = source.loadTileContent(rootTile, {signal: abortController.signal});
+    abortController.abort();
+
+    await expect(queuedLoad).rejects.toMatchObject({name: 'AbortError'});
+    expect(requestCount).toBe(1);
+    releaseRange();
+    await expect(activeLoad).resolves.toMatchObject({pointCount: rootTile.pointCount});
+  }
+);
+
+vitestTest('COPCSourceLoader#reports native range cancellation as AbortError', async () => {
+  const abortController = new AbortController();
+  abortController.abort();
+  await expect(
+    loadCOPCNodeData(
+      async () => new Uint8Array(1),
+      {pointCount: 1, pointDataOffset: 0, pointDataLength: 1},
+      abortController.signal
+    )
+  ).rejects.toMatchObject({name: 'AbortError'});
+});
+
+vitestTest.each([0, 1.5])(
+  'COPCSourceLoader#rejects invalid decode concurrency %s',
+  decodeConcurrency => {
+    expect(
+      () =>
+        new TestCOPCTileSource(new Blob(), {
+          copc: {decodeConcurrency}
+        })
+    ).toThrow('COPC decodeConcurrency must be a positive integer');
+  }
+);
 
 vitestTest('COPCSourceLoader#streams TypeScript tile content as Arrow batches', async () => {
   const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {});
@@ -634,6 +800,43 @@ function createCOPCWriterMesh() {
   };
 }
 
+/** Create one small single-node COPC fixture for a modern point format. */
+function createWorkerCOPCBlob(pointDataRecordFormat: 6 | 7 | 8): Blob {
+  const baseMesh = createCOPCWriterMesh();
+  const attributes =
+    pointDataRecordFormat === 6
+      ? {
+          POSITION: baseMesh.attributes.POSITION,
+          gpsTime: baseMesh.attributes.gpsTime
+        }
+      : pointDataRecordFormat === 8
+        ? {
+            ...baseMesh.attributes,
+            nir: {
+              value: Uint16Array.from(
+                {length: baseMesh.attributes.POSITION.value.length / 3},
+                (_, index) => index * 101
+              ),
+              size: 1
+            }
+          }
+        : baseMesh.attributes;
+  const mesh = {
+    ...baseMesh,
+    attributes,
+    schema: deduceMeshSchema(attributes, {topology: 'point-list', mode: '0'})
+  };
+  return new Blob([
+    encodeSync(mesh, COPCWriter, {
+      copc: {
+        nodePointLimit: 64,
+        pointDataRecordFormat,
+        scale: [0.01, 0.01, 0.01]
+      }
+    })
+  ]);
+}
+
 /** Recursively load every hierarchy page through its declared byte range. */
 async function loadCompleteHierarchy(
   getter: (begin: number, end: number) => Promise<Uint8Array>,
@@ -695,6 +898,19 @@ function readFlatPositions(positions: ArrayLike<number>): string[] {
     result.push([positions[index], positions[index + 1], positions[index + 2]].join(','));
   }
   return result;
+}
+
+/** Flatten one fixed-size-list Arrow column from COPC tile content. */
+function readCOPCContentColumn(
+  content: Awaited<ReturnType<COPCTileSource['loadTileContent']>>,
+  columnName: 'POSITION' | 'COLOR_0'
+): number[] {
+  const column = content?.data.data.getChild(columnName);
+  const values: number[] = [];
+  for (let index = 0; index < (column?.length || 0); index++) {
+    values.push(...(column?.get(index)?.toArray() || []));
+  }
+  return values;
 }
 
 /** Read a little-endian UInt64 that fits in JavaScript's safe integer range. */

--- a/modules/las/src/las-loader.ts
+++ b/modules/las/src/las-loader.ts
@@ -7,16 +7,32 @@ import type {MeshArrowTable} from '@loaders.gl/schema';
 import {convertTableToMesh} from '@loaders.gl/schema-utils';
 import {LAS_LOADER_METADATA, type LASLoaderOptions} from './las-loader-shared';
 import type {LASMesh} from './lib/las-types';
-import {parseLAS, parseLASInBatches, type LASArrowTable} from './lib/typescript/parse-las';
+import {
+  decodeLAZChunkToArrowTable,
+  parseLAS,
+  parseLASInBatches,
+  type LASArrowTable,
+  type LAZChunkArrowTableMetadata
+} from './lib/typescript/parse-las';
+
+type LASWorkerChunkRequest = {
+  metadata: LAZChunkArrowTableMetadata;
+};
+
+type LASWorkerOptions = LASLoaderOptions & {
+  las?: LASLoaderOptions['las'] & {
+    _chunk?: LASWorkerChunkRequest;
+  };
+};
 
 /** Parser-bearing TypeScript-only LAS loader implementation. */
 export const LASLoaderWithParser = {
   ...LAS_LOADER_METADATA,
   worker: true,
   parse: async (arrayBuffer: ArrayBuffer, options?: LASLoaderOptions) =>
-    convertLASMesh(parseLAS(arrayBuffer, options), options),
+    convertLASMesh(parseLASTable(arrayBuffer, options), options),
   parseSync: (arrayBuffer: ArrayBuffer, options?: LASLoaderOptions) =>
-    convertLASMesh(parseLAS(arrayBuffer, options), options),
+    convertLASMesh(parseLASTable(arrayBuffer, options), options),
   parseInBatches: async function* (arrayBufferIterator, options?: LASLoaderOptions) {
     yield* convertLASMeshBatches(parseLASInBatches(arrayBufferIterator, options), options);
   }
@@ -25,6 +41,14 @@ export const LASLoaderWithParser = {
   LASMesh | MeshArrowTable,
   LASLoaderOptions
 >;
+
+/** Parse a complete LAS file or an internal standalone worker chunk request. */
+function parseLASTable(arrayBuffer: ArrayBuffer, options?: LASLoaderOptions): LASArrowTable {
+  const chunkRequest = (options as LASWorkerOptions | undefined)?.las?._chunk;
+  return chunkRequest
+    ? decodeLAZChunkToArrowTable(arrayBuffer, chunkRequest.metadata, options || {})
+    : parseLAS(arrayBuffer, options);
+}
 
 function convertLASMesh(
   table: LASArrowTable,

--- a/modules/las/src/lib/typescript/parse-las.ts
+++ b/modules/las/src/lib/typescript/parse-las.ts
@@ -51,6 +51,14 @@ type LASDecodedChunk = {
   header: LASHeader;
 };
 
+/** Metadata needed to decode one standalone LAZ chunk into LAS Arrow columns. */
+export type LAZChunkArrowTableMetadata = LAZChunkMetadata & {
+  /** LAS coordinate scales applied to encoded XYZ integers. */
+  scale: [number, number, number];
+  /** LAS coordinate offsets applied to encoded XYZ integers. */
+  offset: [number, number, number];
+};
+
 const DEFAULT_BATCH_SIZE = 1000 * 100;
 const LASF_SIGNATURE = 0x4653414c;
 const LAS_14_HEADER_LENGTH = 375;
@@ -187,6 +195,49 @@ export function parseLAS(arrayBuffer: ArrayBuffer, options: LASLoaderOptions = {
   );
 }
 
+/** Decode one complete modern LAZ chunk directly into selected Arrow columns. */
+export function decodeLAZChunkToArrowTable(
+  compressed: ArrayBuffer | ArrayBufferView,
+  metadata: LAZChunkArrowTableMetadata,
+  options: LASLoaderOptions
+): LASArrowTable {
+  if (metadata.pointDataRecordFormat < 6 || metadata.pointDataRecordFormat > 8) {
+    throw new Error(
+      `LASLoader: standalone Arrow chunk decode supports PDRF 6-8; received ${metadata.pointDataRecordFormat}`
+    );
+  }
+  const pointCount = metadata.pointCount;
+  const header: LASHeader = {
+    pointsOffset: 0,
+    pointsFormatId: metadata.pointDataRecordFormat,
+    pointsStructSize: metadata.pointDataRecordLength,
+    pointsCount: pointCount,
+    scale: metadata.scale,
+    offset: metadata.offset,
+    maxs: [0, 0, 0],
+    mins: [0, 0, 0],
+    totalToRead: pointCount,
+    totalRead: pointCount,
+    hasColor: hasPointColor(metadata.pointDataRecordFormat),
+    versionAsString: '1.4',
+    isCompressed: true,
+    headerSize: LAS_14_HEADER_LENGTH,
+    vlrCount: 0
+  };
+  const state = createPointDataBatchState(pointCount, header, options);
+  if (state.waveforms || state.extraBytes || state.typedExtraBytes) {
+    throw new Error('LASLoader: standalone Arrow chunk decode only supports direct LAZ columns');
+  }
+  const cursor = createLAZChunkDecoderCursor(compressed, metadata);
+  const decodedPointCount = cursor.decodeIntoPointData(state.target, pointCount);
+  if (decodedPointCount !== pointCount) {
+    throw new Error(
+      `LASLoader: standalone LAZ chunk produced ${decodedPointCount} points; expected ${pointCount}`
+    );
+  }
+  return makePointDataStateArrowTable(header, state, pointCount, options, true);
+}
+
 /** Decode one complete modern LAZ file directly into its represented Arrow columns. */
 function parseCompleteLAZFileToArrowTable(
   bytes: Uint8Array,
@@ -224,13 +275,27 @@ function parseCompleteLAZFileToArrowTable(
       `LASLoader: decoded ${decodedPointCount} modern LAZ points; expected ${pointCount}`
     );
   }
-  const colors = state.colors
-    ? state.colors
-    : state.rawColors
-      ? convertRawColorsToUint8(state.rawColors, pointCount, options)
-      : null;
+  return makePointDataStateArrowTable(header, state, pointCount, options);
+}
+
+/** Convert one fully populated point-data state into its Arrow table. */
+function makePointDataStateArrowTable(
+  header: LASHeader,
+  state: PointDataBatchState,
+  pointCount: number,
+  options: LASLoaderOptions,
+  preserveRawColors: boolean = false
+): LASArrowTable {
+  const colors =
+    preserveRawColors && state.rawColors
+      ? state.rawColors
+      : state.colors
+        ? state.colors
+        : state.rawColors
+          ? convertRawColorsToUint8(state.rawColors, pointCount, options)
+          : null;
   return makeLASArrowTableFromAttributes(
-    {...header, pointsOffset: 0, totalRead: pointCount},
+    {...header, pointsOffset: 0, pointsCount: pointCount, totalRead: pointCount},
     state.positions,
     colors,
     state.intensities,
@@ -1390,7 +1455,7 @@ function parseLASArrowTableBatch(
 function makeLASArrowTableFromAttributes(
   lasHeader: LASHeader,
   positions: Float32Array | Float64Array,
-  colors: Uint8Array | null,
+  colors: Uint8Array | Uint16Array | null,
   intensities: Uint16Array | null,
   classifications: Uint8Array | null,
   syntheticFlags: Uint8Array | null,
@@ -1433,7 +1498,7 @@ function makeLASArrowTableFromAttributes(
     attributes.overlap = {value: overlapFlags, size: 1};
   }
   if (colors) {
-    attributes.COLOR_0 = {value: colors, size: 4};
+    attributes.COLOR_0 = {value: colors, size: colors instanceof Uint16Array ? 3 : 4};
   }
   if (gpsTimes) {
     attributes.GPS_TIME = {value: gpsTimes, size: 1};

--- a/modules/loader-utils/src/lib/worker-loader-utils/parse-with-worker.ts
+++ b/modules/loader-utils/src/lib/worker-loader-utils/parse-with-worker.ts
@@ -45,19 +45,26 @@ export function canParseWithWorker(loader: Loader, options?: StrictLoaderOptions
 /**
  * this function expects that the worker function sends certain messages,
  * this can be automated if the worker is wrapper by a call to createLoaderWorker in @loaders.gl/loader-utils.
+ * @param loader Loader metadata used to select the worker pool.
+ * @param data Input transferred to the worker.
+ * @param options Loader and worker options.
+ * @param context Serializable loader context.
+ * @param parseOnMainThread Callback for worker requests that must run on the calling thread.
+ * @param signal Optional cancellation signal for this worker job.
  */
 export async function parseWithWorker(
   loader: Loader,
   data: any,
   options?: StrictLoaderOptions,
   context?: LoaderContext,
-  parseOnMainThread?: ParseOnMainThread
+  parseOnMainThread?: ParseOnMainThread,
+  signal?: AbortSignal
 ) {
-  const signal = getWorkerAbortSignal(options);
+  const workerSignal = signal || getWorkerAbortSignal(options);
   const result = await processOnWorker(
     loader,
     data,
-    {...getWorkerOptions(options), signal},
+    {...getWorkerOptions(options), signal: workerSignal},
     {
       process: async (input, processOptions, _workerContext, parseContext) => {
         if (!parseOnMainThread) {


### PR DESCRIPTION
## Goals

- Complete the highest-impact remaining LAS reader roadmap tranche.
- Decode independent atomic COPC nodes across the existing TypeScript LAS worker pool.
- Bound fetch/decode memory and preserve cancellation, direct Arrow decoding, and main-thread fallback.

## Changes

- Adds internal standalone LAZ chunk requests to the primary LAS worker for PDRF 6-8.
- Routes atomic COPC node loads created through `@loaders.gl/core` through the one packaged LAS worker; progressive async iteration stays on the calling thread.
- Bounds complete node fetch plus decode work per source with `copc.decodeConcurrency`.
- Cancels queued loads, active range requests, and worker jobs through `AbortSignal`.
- Preserves 16-bit COPC RGB and copies only cached range subviews before transfer, avoiding cache detachment.
- Adds browser parity for PDRF 6/7/8, concurrency, cancellation, repeated-cache, and Node fallback coverage.
- Updates the COPC feature/API docs and advances the LAS remaining roadmap to four tranches.

## Validation

- `yarn build`
- `yarn build-workers`
- `yarn lint fix`
- `yarn test-audit`
- `yarn test-headless modules/copc/test/copc-source.spec.ts` (28 passed)
- `yarn test-headless modules/copc/test/lib/copc-reader.spec.ts` (5 passed)
- `yarn test-headless modules/las/test/typescript-laz.spec.ts` (8 passed)
- `yarn test-node modules/copc/test/copc-source.node.spec.ts` (2 passed)
- `yarn bench las` (PDRF 7 render cursor 2.33M points/s; selective streaming 2.07M points/s; streaming copy, concatenation, raw-batch, and decoded-chunk allocation counters remain zero)
