### PR TITLE
feat(parquet): complete writer statistics metadata

### DIFF
--- a/docs/modules/parquet/api-reference/parquet-writer.md
+++ b/docs/modules/parquet/api-reference/parquet-writer.md
@@ -135,6 +135,8 @@ read/write encoding matrix.
 | `parquet.dictionaryPageSizeLimit` | `number` | `1048576` | Maximum uncompressed PLAIN dictionary payload in bytes; oversized dictionaries fall back for the complete chunk. |
 | `parquet.bloomFilter` | `boolean \| Record<string, boolean>` | `false` | Emits uncompressed split-block Bloom filters for supported scalar columns, globally or by top-level column name. |
 | `parquet.pageIndex` | `boolean \| Record<string, boolean>` | `false` | Emits column and offset indexes for supported non-repeated scalar columns, globally or by top-level column name. |
+| `parquet.writeStatistics` | `boolean \| Record<string, boolean>` | `false` | Emits standard min/max/null-count statistics for supported scalar column chunks, globally or by top-level column name. |
+| `parquet.sortingColumns` | `readonly {column: string; descending?: boolean; nullsFirst?: boolean}[]` | `undefined` | Declares the row-group sort order using top-level or dotted nested leaf names. The writer does not sort rows. |
 | `parquet.writePageChecksums` | `boolean` | `false` | Emits CRC-32 checksums for TypeScript writer data and dictionary pages. |
 | `parquet.writeSizeStatistics` | `boolean` | `false` | Emits byte-array size totals and repetition/definition-level histograms for TypeScript writer column chunks. |
 | `parquet.rowGroupSize` | `number` | implementation default | Sets the target row count per row group for `ParquetJSWriter`. |

--- a/docs/modules/parquet/api-reference/parquet-writer.md
+++ b/docs/modules/parquet/api-reference/parquet-writer.md
@@ -135,7 +135,7 @@ read/write encoding matrix.
 | `parquet.dictionaryPageSizeLimit` | `number` | `1048576` | Maximum uncompressed PLAIN dictionary payload in bytes; oversized dictionaries fall back for the complete chunk. |
 | `parquet.bloomFilter` | `boolean \| Record<string, boolean>` | `false` | Emits uncompressed split-block Bloom filters for supported scalar columns, globally or by top-level column name. |
 | `parquet.pageIndex` | `boolean \| Record<string, boolean>` | `false` | Emits column and offset indexes for supported non-repeated scalar columns, globally or by top-level column name. |
-| `parquet.writeStatistics` | `boolean \| Record<string, boolean>` | `false` | Emits standard min/max/null-count statistics for supported scalar column chunks, globally or by top-level column name. |
+| `parquet.writeStatistics` | `boolean \| Record<string, boolean>` | `false` | Emits standard min/max/null-count statistics for supported scalar column chunks and data pages, globally or by top-level column name. |
 | `parquet.sortingColumns` | `readonly {column: string; descending?: boolean; nullsFirst?: boolean}[]` | `undefined` | Declares the row-group sort order using top-level or dotted nested leaf names. The writer does not sort rows. |
 | `parquet.writePageChecksums` | `boolean` | `false` | Emits CRC-32 checksums for TypeScript writer data and dictionary pages. |
 | `parquet.writeSizeStatistics` | `boolean` | `false` | Emits byte-array size totals and repetition/definition-level histograms for TypeScript writer column chunks. |

--- a/docs/modules/parquet/formats/parquet.md
+++ b/docs/modules/parquet/formats/parquet.md
@@ -239,7 +239,7 @@ can make selective reads much cheaper.
 | File and schema metadata | ✅ | ✅ | Footer is cached by `ParquetSourceLoader` |
 | Row-group and column-chunk offsets | ✅ | ✅ | Drive byte-range projection and row-group selection |
 | Column-chunk min/max/null/distinct statistics | ✅ | ✅ (opt-in) | Drive conservative `ParquetSource` predicate pushdown; `ParquetJSWriter` emits min/max/null-count statistics with `writeStatistics` |
-| Page statistics in page headers | ⚠️ | ❌ | Thrift fields are decoded but not exposed as a pruning API |
+| Page statistics in page headers | ⚠️ | ✅ (opt-in) | Thrift fields are decoded; `ParquetJSWriter` emits min/max/null-count page statistics with `writeStatistics` |
 | [Column index](https://github.com/apache/parquet-format/blob/master/PageIndex.md) | ✅ | ✅ (opt-in) | Predicates use page min/max statistics to derive conservative candidate row ranges for primitive leaves, including nested struct children and repeated leaves when selected columns share page boundaries |
 | [Offset index](https://github.com/apache/parquet-format/blob/master/PageIndex.md) | ✅ | ✅ (opt-in) | Selected columns use page locations and first-row indexes for selective byte reads; repeated values and continuation pages are decoded only from complete, mutually aligned row ranges |
 | [Bloom filters](https://github.com/apache/parquet-format/blob/master/BloomFilter.md) | ✅ | ✅ | TypeScript reads split-block Bloom filters for safe equality/`IN` row-group pruning; `ParquetJSWriter` can emit them opt-in |

--- a/docs/modules/parquet/formats/parquet.md
+++ b/docs/modules/parquet/formats/parquet.md
@@ -238,13 +238,13 @@ can make selective reads much cheaper.
 | ------- | ------- | -------- | ---------------- |
 | File and schema metadata | ✅ | ✅ | Footer is cached by `ParquetSourceLoader` |
 | Row-group and column-chunk offsets | ✅ | ✅ | Drive byte-range projection and row-group selection |
-| Column-chunk min/max/null/distinct statistics | ✅ | ❌ | Drive conservative `ParquetSource` predicate pushdown and remain exposed in metadata |
+| Column-chunk min/max/null/distinct statistics | ✅ | ✅ (opt-in) | Drive conservative `ParquetSource` predicate pushdown; `ParquetJSWriter` emits min/max/null-count statistics with `writeStatistics` |
 | Page statistics in page headers | ⚠️ | ❌ | Thrift fields are decoded but not exposed as a pruning API |
 | [Column index](https://github.com/apache/parquet-format/blob/master/PageIndex.md) | ✅ | ✅ (opt-in) | Predicates use page min/max statistics to derive conservative candidate row ranges for primitive leaves, including nested struct children and repeated leaves when selected columns share page boundaries |
 | [Offset index](https://github.com/apache/parquet-format/blob/master/PageIndex.md) | ✅ | ✅ (opt-in) | Selected columns use page locations and first-row indexes for selective byte reads; repeated values and continuation pages are decoded only from complete, mutually aligned row ranges |
 | [Bloom filters](https://github.com/apache/parquet-format/blob/master/BloomFilter.md) | ✅ | ✅ | TypeScript reads split-block Bloom filters for safe equality/`IN` row-group pruning; `ParquetJSWriter` can emit them opt-in |
 | Size statistics | ✅ | ✅ (opt-in) | Byte-array sizes and repetition/definition histograms are decoded and exposed; `ParquetJSWriter` emits them with `writeSizeStatistics` |
-| Column order and sorting columns | ✅ (metadata) | ❌ | Row-group sort declarations are normalized as `sortingColumns`; semantic pruning is not yet applied |
+| Column order and sorting columns | ✅ (metadata) | ✅ (declaration) | Row-group sort declarations are normalized as `sortingColumns`; `ParquetJSWriter` can emit declarations but does not sort rows or apply semantic pruning |
 
 `ParquetSourceLoader` accepts serializable logical predicates, prunes impossible row groups using
 footer statistics and split-block Bloom filters, and uses column/offset indexes to avoid irrelevant
@@ -286,7 +286,7 @@ corpora run in the slow lane.
 The TypeScript implementation is aiming for complete stable-format read support. The largest known
 gaps are currently:
 
-1. semantic sorting-based pruning and writer-side size-statistics emission; and
+1. semantic sorting-based pruning and writer-side statistics/page-statistics completeness; and
 2. encrypted-column range reads, including page/index modules and key-rotation safeguards.
 
 Preview features such as [ALP](https://github.com/apache/parquet-format/pull/557), [PFOR](https://github.com/apache/parquet-format/pull/579), and the upstream [format-versioning RFCs](https://github.com/apache/parquet-format/pulls?q=is%3Apr+versioning) are tracked separately from stable-format completeness.

--- a/modules/parquet/src/index.ts
+++ b/modules/parquet/src/index.ts
@@ -100,7 +100,11 @@ export {
 } from './parquet-source-capabilities';
 
 export {ParquetWriter} from './parquet-writer';
-export type {ParquetJSWriterEncoding, ParquetJSWriterOptions} from './parquet-js-writer';
+export type {
+  ParquetJSWriterEncoding,
+  ParquetJSWriterOptions,
+  ParquetSortingColumnOption
+} from './parquet-js-writer';
 export {ParquetJSWriter} from './parquet-js-writer';
 
 export {

--- a/modules/parquet/src/parquet-js-writer.ts
+++ b/modules/parquet/src/parquet-js-writer.ts
@@ -9,6 +9,9 @@ import {convertTable, deduceTableSchema} from '@loaders.gl/schema-utils';
 import {normalizeParquetOptions} from './lib/utils/normalize-parquet-options';
 import {encodeTableToParquetJs} from './lib/encoders/encode-table-to-parquet-js';
 import {ParquetFormat} from './parquet-format';
+import type {ParquetSortingColumnOption} from './parquetjs/encoder/parquet-encoder';
+
+export type {ParquetSortingColumnOption} from './parquetjs/encoder/parquet-encoder';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
@@ -40,6 +43,10 @@ type ParquetJSWriterEncoderOptions = {
   writePageChecksums?: boolean;
   /** Emits optional SizeStatistics metadata for every column chunk. */
   writeSizeStatistics?: boolean;
+  /** Emits min/max/null-count statistics for every column chunk. */
+  writeStatistics?: boolean | Record<string, boolean>;
+  /** Declares row-group sort keys using top-level or dotted nested leaf names. */
+  sortingColumns?: readonly ParquetSortingColumnOption[];
   rowGroupSize?: number;
   pageSize?: number;
   useDataPageV2?: boolean;

--- a/modules/parquet/src/parquetjs/encoder/parquet-encoder.ts
+++ b/modules/parquet/src/parquetjs/encoder/parquet-encoder.ts
@@ -466,7 +466,8 @@ async function encodeDataPage(
   data: ParquetColumnChunk,
   valueEncoding: ParquetCodec = column.encoding!,
   valueBitWidth?: number,
-  writePageChecksums = false
+  writePageChecksums = false,
+  statistics?: Statistics
 ): Promise<{
   header: PageHeader;
   headerSize: number;
@@ -517,7 +518,8 @@ async function encodeDataPage(
       num_values: data.count,
       encoding: Encoding[valueEncoding] as any,
       definition_level_encoding: Encoding[PARQUET_RDLVL_ENCODING], // [PARQUET_RDLVL_ENCODING],
-      repetition_level_encoding: Encoding[PARQUET_RDLVL_ENCODING] // [PARQUET_RDLVL_ENCODING]
+      repetition_level_encoding: Encoding[PARQUET_RDLVL_ENCODING], // [PARQUET_RDLVL_ENCODING]
+      statistics
     }),
     uncompressed_page_size: dataBuf.length,
     compressed_page_size: compressedBuf.length,
@@ -540,7 +542,8 @@ async function encodeDataPageV2(
   rowCount: number,
   valueEncoding: ParquetCodec = column.encoding!,
   valueBitWidth?: number,
-  writePageChecksums = false
+  writePageChecksums = false,
+  statistics?: Statistics
 ): Promise<{
   header: PageHeader;
   headerSize: number;
@@ -592,7 +595,8 @@ async function encodeDataPageV2(
       encoding: Encoding[valueEncoding] as any,
       definition_levels_byte_length: dLevelsBuf.length,
       repetition_levels_byte_length: rLevelsBuf.length,
-      is_compressed: column.compression !== 'UNCOMPRESSED'
+      is_compressed: column.compression !== 'UNCOMPRESSED',
+      statistics
     }),
     uncompressed_page_size: rLevelsBuf.length + dLevelsBuf.length + valuesBuf.length,
     compressed_page_size: rLevelsBuf.length + dLevelsBuf.length + compressedBuf.length,
@@ -768,14 +772,20 @@ async function encodeColumnChunk(
           plannedPage.rowCount,
           valueEncoding,
           dictionaryPlan?.bitWidth,
-          opts.writePageChecksums
+          opts.writePageChecksums,
+          isStatisticsEnabled(opts.writeStatistics, column)
+            ? createColumnStatistics(column, plannedPage.data)
+            : undefined
         )
       : await encodeDataPage(
           column,
           pageData,
           valueEncoding,
           dictionaryPlan?.bitWidth,
-          opts.writePageChecksums
+          opts.writePageChecksums,
+          isStatisticsEnabled(opts.writeStatistics, column)
+            ? createColumnStatistics(column, plannedPage.data)
+            : undefined
         );
     pageLocations.push(
       new PageLocation({

--- a/modules/parquet/src/parquetjs/encoder/parquet-encoder.ts
+++ b/modules/parquet/src/parquetjs/encoder/parquet-encoder.ts
@@ -27,6 +27,8 @@ import {
   ColumnIndex,
   ColumnMetaData,
   SizeStatistics,
+  Statistics,
+  SortingColumn,
   CompressionCodec,
   ConvertedType,
   DataPageHeader,
@@ -118,6 +120,10 @@ export interface ParquetEncoderOptions {
   writePageChecksums?: boolean;
   /** Emit optional SizeStatistics metadata for each column chunk. */
   writeSizeStatistics?: boolean;
+  /** Emit optional min/max/null-count statistics for each column chunk. */
+  writeStatistics?: boolean | Record<string, boolean>;
+  /** Declare the row-group sort order using top-level or dotted leaf column names. */
+  sortingColumns?: readonly ParquetSortingColumnOption[];
 
   // Write Stream Options
   flags?: string;
@@ -127,6 +133,16 @@ export interface ParquetEncoderOptions {
   autoClose?: boolean;
   start?: number;
 }
+
+/** Writer-facing declaration for one row-group sort key. */
+export type ParquetSortingColumnOption = {
+  /** Top-level field name or dotted nested leaf path. */
+  column: string;
+  /** Sort direction; defaults to ascending. */
+  descending?: boolean;
+  /** Whether null values sort before non-null values; defaults to false. */
+  nullsFirst?: boolean;
+};
 
 /**
  * Write a parquet file to an output stream. The ParquetEncoder will perform
@@ -301,6 +317,8 @@ export class ParquetEnvelopeWriter {
   public pageIndex?: boolean | Record<string, boolean>;
   public writePageChecksums: boolean;
   public writeSizeStatistics: boolean;
+  public writeStatistics?: boolean | Record<string, boolean>;
+  public sortingColumns?: readonly ParquetSortingColumnOption[];
 
   constructor(
     schema: ParquetSchema,
@@ -324,6 +342,8 @@ export class ParquetEnvelopeWriter {
     this.pageIndex = opts.pageIndex;
     this.writePageChecksums = Boolean(opts.writePageChecksums);
     this.writeSizeStatistics = Boolean(opts.writeSizeStatistics);
+    this.writeStatistics = opts.writeStatistics;
+    this.sortingColumns = opts.sortingColumns;
   }
 
   writeSection(buf: Uint8Array): Promise<void> {
@@ -353,7 +373,9 @@ export class ParquetEnvelopeWriter {
       bloomFilter: this.bloomFilter,
       pageIndex: this.pageIndex,
       writePageChecksums: this.writePageChecksums,
-      writeSizeStatistics: this.writeSizeStatistics
+      writeSizeStatistics: this.writeSizeStatistics,
+      writeStatistics: this.writeStatistics,
+      sortingColumns: this.sortingColumns
     });
 
     this.rowCount += records.rowCount;
@@ -809,7 +831,10 @@ async function encodeColumnChunk(
     bloom_filter_offset: bloomFilter ? int64(baseOffset + pagesBuf.length) : undefined,
     bloom_filter_length: bloomFilter?.length,
     geospatial_statistics: createGeospatialStatistics(column, data.values),
-    size_statistics: opts.writeSizeStatistics ? createSizeStatistics(column, data) : undefined
+    size_statistics: opts.writeSizeStatistics ? createSizeStatistics(column, data) : undefined,
+    statistics: isStatisticsEnabled(opts.writeStatistics, column)
+      ? createColumnStatistics(column, data)
+      : undefined
   });
 
   /* list encodings */
@@ -1055,6 +1080,35 @@ function createSizeStatistics(column: ParquetField, data: ParquetColumnChunk): S
   });
 }
 
+/** Returns whether standard column statistics are enabled for one top-level field. */
+function isStatisticsEnabled(
+  option: boolean | Record<string, boolean> | undefined,
+  column: ParquetField
+): boolean {
+  return option === true || option?.[column.path[0]] === true;
+}
+
+/** Builds conservative standard min/max/null-count statistics for one column chunk. */
+function createColumnStatistics(
+  column: ParquetField,
+  data: ParquetColumnChunk
+): Statistics | undefined {
+  if (!column.primitiveType || !isPageIndexPhysicalType(column.primitiveType)) {
+    return undefined;
+  }
+  const statistics = new Statistics({
+    null_count: column.rLevelMax === 0 ? data.count - data.values.length : undefined,
+    is_min_value_exact: true,
+    is_max_value_exact: true
+  });
+  if (data.values.length === 0) return statistics;
+  const bounds = getPageBounds(data.values, column.primitiveType, column.typeLength);
+  if (!bounds) return undefined;
+  statistics.min_value = bounds.min;
+  statistics.max_value = bounds.max;
+  return statistics;
+}
+
 /** Counts the occurrences of each definition or repetition level. */
 function createLevelHistogram(
   levels: ParquetColumnChunk['rlevels'],
@@ -1065,6 +1119,33 @@ function createLevelHistogram(
     if (level >= 0 && level <= maximumLevel) histogram[level]++;
   }
   return histogram;
+}
+
+/** Converts writer-facing sort keys into Parquet leaf-column indexes. */
+function createSortingColumns(
+  schema: ParquetSchema,
+  sortingColumns: readonly ParquetSortingColumnOption[] | undefined
+): SortingColumn[] | undefined {
+  if (!sortingColumns?.length) return undefined;
+  const leafFields = schema.fieldList.filter(field => !field.isNested);
+  const usedColumnIndexes = new Set<number>();
+  return sortingColumns.map(sortKey => {
+    const columnIndex = leafFields.findIndex(
+      field => field.name === sortKey.column || field.path.join('.') === sortKey.column
+    );
+    if (columnIndex < 0) {
+      throw new Error(`Unknown Parquet sorting column ${sortKey.column}`);
+    }
+    if (usedColumnIndexes.has(columnIndex)) {
+      throw new Error(`Duplicate Parquet sorting column ${sortKey.column}`);
+    }
+    usedColumnIndexes.add(columnIndex);
+    return new SortingColumn({
+      column_idx: columnIndex,
+      descending: Boolean(sortKey.descending),
+      nulls_first: Boolean(sortKey.nullsFirst)
+    });
+  });
 }
 
 /**
@@ -1081,7 +1162,8 @@ async function encodeRowGroup(
   const metadata = new RowGroup({
     num_rows: int64(data.rowCount),
     columns: [],
-    total_byte_size: int64(0)
+    total_byte_size: int64(0),
+    sorting_columns: createSortingColumns(schema, opts.sortingColumns)
   });
 
   let body: Uint8Array = new Uint8Array(0);

--- a/modules/parquet/test/parquet-size-statistics.spec.ts
+++ b/modules/parquet/test/parquet-size-statistics.spec.ts
@@ -80,6 +80,25 @@ test('ParquetJSWriter records declared row-group sorting columns', async () => {
   ]);
 });
 
+test('ParquetJSWriter emits page statistics for V1 and V2 data pages', async () => {
+  for (const useDataPageV2 of [false, true]) {
+    const parquetBuffer = await encode(TABLE, ParquetJSWriter, {
+      worker: false,
+      parquet: {pageSize: 1, writeStatistics: true, useDataPageV2}
+    });
+    const reader = new ParquetReader(new BlobFile(parquetBuffer));
+    const metadata = await reader.getFileMetadata();
+    const rowGroup = await reader.readRowGroup(await reader.getSchema(), metadata.row_groups[0], []);
+    const pageHeaders = rowGroup.columnData.label.pageHeaders;
+
+    expect(pageHeaders).toHaveLength(3);
+    expect(pageHeaders[0].data_page_header?.statistics?.min_value?.length ??
+      pageHeaders[0].data_page_header_v2?.statistics?.min_value?.length).toBeGreaterThan(0);
+    expect(pageHeaders[1].data_page_header?.statistics?.null_count?.toNumber() ??
+      pageHeaders[1].data_page_header_v2?.statistics?.null_count?.toNumber()).toBe(1);
+  }
+});
+
 test('ParquetJSWriter omits SizeStatistics by default', async () => {
   const parquetBuffer = await encode(TABLE, ParquetJSWriter, {worker: false});
   const metadata = await new ParquetReader(new BlobFile(parquetBuffer)).getFileMetadata();

--- a/modules/parquet/test/parquet-size-statistics.spec.ts
+++ b/modules/parquet/test/parquet-size-statistics.spec.ts
@@ -26,11 +26,17 @@ const TABLE: ObjectRowTable = {
 test('ParquetJSWriter emits optional SizeStatistics metadata', async () => {
   const parquetBuffer = await encode(TABLE, ParquetJSWriter, {
     worker: false,
-    parquet: {writeSizeStatistics: true}
+    parquet: {writeSizeStatistics: true, writeStatistics: true}
   });
   const metadata = await new ParquetReader(new BlobFile(parquetBuffer)).getFileMetadata();
   const [label, value] = metadata.row_groups[0].columns.map(column => column.meta_data!);
 
+  expect(new TextDecoder().decode(label.statistics?.min_value)).toBe('alpha');
+  expect(new TextDecoder().decode(label.statistics?.max_value)).toBe('beta');
+  expect(label.statistics?.null_count?.toNumber()).toBe(1);
+  expect(value.statistics?.min_value?.[0]).toBe(1);
+  expect(value.statistics?.max_value?.[0]).toBe(2);
+  expect(value.statistics?.null_count?.toNumber()).toBe(1);
   expect(label.size_statistics).toBeDefined();
   expect(label.size_statistics?.unencoded_byte_array_data_bytes?.toNumber()).toBe(9);
   expect(label.size_statistics?.definition_level_histogram?.map(item => item.toNumber())).toEqual([
@@ -43,6 +49,34 @@ test('ParquetJSWriter emits optional SizeStatistics metadata', async () => {
   ]);
   expect(value.size_statistics?.repetition_level_histogram?.map(item => item.toNumber())).toEqual([
     3
+  ]);
+});
+
+test('ParquetJSWriter supports per-column standard statistics', async () => {
+  const parquetBuffer = await encode(TABLE, ParquetJSWriter, {
+    worker: false,
+    parquet: {writeStatistics: {label: true}}
+  });
+  const metadata = await new ParquetReader(new BlobFile(parquetBuffer)).getFileMetadata();
+  const [label, value] = metadata.row_groups[0].columns.map(column => column.meta_data!);
+
+  expect(label.statistics).toBeDefined();
+  expect(value.statistics).toBeUndefined();
+});
+
+test('ParquetJSWriter records declared row-group sorting columns', async () => {
+  const parquetBuffer = await encode(TABLE, ParquetJSWriter, {
+    worker: false,
+    parquet: {sortingColumns: [{column: 'label'}, {column: 'value', descending: true, nullsFirst: true}]}
+  });
+  const metadata = await new ParquetReader(new BlobFile(parquetBuffer)).getFileMetadata();
+  expect(metadata.row_groups[0].sorting_columns?.map(column => ({
+    columnIndex: column.column_idx,
+    descending: column.descending,
+    nullsFirst: column.nulls_first
+  }))).toEqual([
+    {columnIndex: 0, descending: false, nullsFirst: false},
+    {columnIndex: 1, descending: true, nullsFirst: true}
   ]);
 });
 


### PR DESCRIPTION
## Goals

Advance stable Parquet writer interoperability with standard statistics and explicit row-group sort metadata while preserving the default output path.

## Changes

- Add opt-in `parquet.writeStatistics` for standard min/max/null-count statistics on column chunks and Data Page V1/V2 headers.
- Add `parquet.sortingColumns` declarations with top-level and dotted nested leaf-name resolution.
- Validate unknown and duplicate sort keys before writing metadata.
- Export the sorting option type from the Parquet package.
- Extend Vitest coverage for column statistics, page statistics, per-column selection, and sorting metadata.
- Update writer API and Parquet format support documentation.

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn test-headless modules/parquet/test/parquet-size-statistics.spec.ts modules/parquet/test/parquet-writer-pages.spec.ts`
- `yarn test-audit`

## Scope

This PR does not claim semantic sorted-range pruning, modular encryption completion, or proposal-stage ALP/PFOR/VECTOR support. Those remain separate follow-up work.