### PR TITLE
fix(parquet): harden writer statistics metadata

### DIFF
--- a/docs/modules/parquet/formats/parquet.md
+++ b/docs/modules/parquet/formats/parquet.md
@@ -173,7 +173,7 @@ uses, while each page identifies its actual value encoding.
 | `PLAIN` | All physical types | ✅ | ✅ | Required baseline encoding |
 | `PLAIN_DICTIONARY` | All physical types | ✅ | ❌ | Deprecated dictionary identifier |
 | `RLE` | Boolean, levels, dictionary indexes | ✅ | ✅ | Writer uses it for definition/repetition levels |
-| `BIT_PACKED` | Legacy levels | ❌ | ❌ | Deprecated and superseded by the RLE/bit-packing hybrid |
+| `BIT_PACKED` | Legacy levels | ✅ | ❌ | Deprecated and superseded by the RLE/bit-packing hybrid; supported for legacy page-level compatibility |
 | `DELTA_BINARY_PACKED` | `INT32`, `INT64` | ✅ | ✅ | Effective for ordered integer sequences |
 | `DELTA_LENGTH_BYTE_ARRAY` | `BYTE_ARRAY` | ✅ | ✅ | Delta-encodes lengths followed by concatenated bytes |
 | `DELTA_BYTE_ARRAY` | `BYTE_ARRAY`, `FIXED_LEN_BYTE_ARRAY` | ✅ | ✅ | Prefix/suffix encoding for related byte strings |

--- a/docs/modules/parquet/formats/parquet.md
+++ b/docs/modules/parquet/formats/parquet.md
@@ -283,10 +283,21 @@ The compatibility suite uses checked-in files from
 maintained browser-capable implementations. Required tests are hermetic; large and exhaustive
 corpora run in the slow lane.
 
-The TypeScript implementation is aiming for complete stable-format read support. The largest known
-gaps are currently:
+The current implementation status is tracked in the following broad work tranches. A check mark
+means the capability is usable in the TypeScript reader; it does not imply that every producer
+variant has been exhaustively certified.
 
-1. semantic sorting-based pruning and writer-side statistics/page-statistics completeness; and
-2. encrypted-column range reads, including page/index modules and key-rotation safeguards.
+| Tranche | Status | Remaining work |
+| ------- | ------ | -------------- |
+| Statistics-driven pruning | ✅ foundation | Use declared sort order for semantic page/row-group pruning and keep selective-range cost estimates aligned with late materialization |
+| Modular encryption | ⚠️ footer foundation | Decrypt column metadata and page/index modules for range reads; add key rotation and cross-implementation fixtures |
+| Logical and legacy parity | ⚠️ expanding | Broaden INT96 and legacy encoding coverage; preserve Arrow fidelity for every logical annotation |
+| Conformance and scale gate | ⚠️ ongoing | Run the Apache corpus, nested/repeated matrices, all stable codecs, differential checks, and large-file benchmarks in the slow lane |
+| Emerging-format lab | 🧪 experimental | Track ALP, PFOR, VECTOR, and format-versioning proposals behind explicit experimental flags; do not advertise them as stable support |
 
-Preview features such as [ALP](https://github.com/apache/parquet-format/pull/557), [PFOR](https://github.com/apache/parquet-format/pull/579), and the upstream [format-versioning RFCs](https://github.com/apache/parquet-format/pulls?q=is%3Apr+versioning) are tracked separately from stable-format completeness.
+The recent follow-up work adds conservative logical-statistics handling, repeated-page safety,
+zero-valued size statistics, and legacy `BIT_PACKED` level decoding. Preview features such as
+[ALP](https://github.com/apache/parquet-format/pull/557),
+[PFOR](https://github.com/apache/parquet-format/pull/579), and the upstream
+[format-versioning RFCs](https://github.com/apache/parquet-format/pulls?q=is%3Apr+versioning) remain
+separate from stable-format completeness.

--- a/modules/parquet/src/lib/parquet-page-index.ts
+++ b/modules/parquet/src/lib/parquet-page-index.ts
@@ -506,6 +506,20 @@ function hasCompatiblePageBoundaries(
   if (!hasRepeatedLeaf) {
     return true;
   }
+  // Offset indexes identify the first logical row represented by each page, but do not
+  // expose repetition levels. Equal starts therefore indicate a continuation page whose
+  // boundary cannot be proven safe for a selective read; retain the full-column fallback.
+  if (
+    columnChunks.some(columnChunk => {
+      const pages = pageLocations[JSON.stringify(columnChunk.meta_data!.path_in_schema)];
+      return pages.some(
+        (page, pageIndex) =>
+          pageIndex > 0 && page.firstRowIndex === pages[pageIndex - 1].firstRowIndex
+      );
+    })
+  ) {
+    return false;
+  }
   const signatures = columnChunks.map(columnChunk => {
     const pages = pageLocations[JSON.stringify(columnChunk.meta_data!.path_in_schema)];
     return pages.map(page => `${page.firstRowIndex}:${page.endRowIndex}`).join('|');

--- a/modules/parquet/src/parquetjs/codecs/index.ts
+++ b/modules/parquet/src/parquetjs/codecs/index.ts
@@ -23,6 +23,10 @@ export const PARQUET_CODECS: Record<ParquetCodec, ParquetCodecKit> = {
     encodeValues: RLE.encodeValues,
     decodeValues: RLE.decodeValues
   },
+  BIT_PACKED: {
+    encodeValues: RLE.encodeBitPackedValues,
+    decodeValues: RLE.decodeBitPackedValues
+  },
   // Using the PLAIN_DICTIONARY enum value is deprecated in the Parquet 2.0 specification.
   PLAIN_DICTIONARY: {
     // @ts-ignore

--- a/modules/parquet/src/parquetjs/codecs/rle.ts
+++ b/modules/parquet/src/parquetjs/codecs/rle.ts
@@ -143,6 +143,85 @@ export function decodeValues(
   return output;
 }
 
+/** Encodes legacy Parquet BIT_PACKED values, including the optional page length envelope. */
+export function encodeBitPackedValues(
+  type: PrimitiveType,
+  values: any[],
+  options: ParquetCodecOptions
+): Uint8Array {
+  if (!('bitWidth' in options)) {
+    throw new Error('bitWidth is required');
+  }
+  const bitWidth = options.bitWidth!;
+  if (!Number.isInteger(bitWidth) || bitWidth < 0 || bitWidth > 32) {
+    throw new Error(`invalid bit width: ${bitWidth}`);
+  }
+  if (type !== 'BOOLEAN' && type !== 'INT32' && type !== 'INT64') {
+    throw new Error(`unsupported type: ${type}`);
+  }
+  const paddedValueCount = Math.ceil(values.length / 8) * 8;
+  const encoded = new Uint8Array(Math.ceil((paddedValueCount * bitWidth) / 8));
+  for (let valueIndex = 0; valueIndex < values.length; valueIndex++) {
+    let value = Number(values[valueIndex]);
+    for (let bitIndex = 0; bitIndex < bitWidth; bitIndex++) {
+      if (value & (1 << bitIndex)) {
+        const packedBit = valueIndex * bitWidth + bitIndex;
+        encoded[Math.floor(packedBit / 8)] |= 1 << (packedBit % 8);
+      }
+    }
+  }
+  if (options.disableEnvelope) {
+    return encoded;
+  }
+  const envelope = new Uint8Array(encoded.length + 4);
+  writeUInt32LE(envelope, encoded.length, 0);
+  envelope.set(encoded, 4);
+  return envelope;
+}
+
+/** Decodes legacy Parquet BIT_PACKED values, including the optional page length envelope. */
+export function decodeBitPackedValues(
+  type: PrimitiveType,
+  cursor: CursorBuffer,
+  count: number,
+  options: ParquetCodecOptions
+): ParquetValueBuffer {
+  if (!('bitWidth' in options)) {
+    throw new Error('bitWidth is required');
+  }
+  const bitWidth = options.bitWidth!;
+  if (!Number.isInteger(bitWidth) || bitWidth < 0 || bitWidth > 64) {
+    throw new Error(`invalid bit width: ${bitWidth}`);
+  }
+  if (!Number.isInteger(count) || count < 0) {
+    throw new Error(`invalid value count: ${count}`);
+  }
+  const envelopeEnd = options.disableEnvelope
+    ? undefined
+    : (() => {
+        assertReadable(cursor, 4);
+        const length =
+          cursor.buffer[cursor.offset] |
+          (cursor.buffer[cursor.offset + 1] << 8) |
+          (cursor.buffer[cursor.offset + 2] << 16) |
+          (cursor.buffer[cursor.offset + 3] << 24);
+        cursor.offset += 4;
+        if (length < 0) throw new Error('invalid BIT_PACKED length');
+        assertReadable(cursor, length);
+        return cursor.offset + length;
+      })();
+  const paddedValueCount = Math.ceil(count / 8) * 8;
+  const packedByteLength = Math.ceil((paddedValueCount * bitWidth) / 8);
+  assertReadable(cursor, packedByteLength);
+  const {output, outputOffset} = getParquetValueOutput(options, count);
+  decodeBitPackedRun(cursor, paddedValueCount, count, bitWidth, output, outputOffset);
+  if (envelopeEnd !== undefined) {
+    if (cursor.offset > envelopeEnd) throw new Error('invalid BIT_PACKED length');
+    cursor.offset = envelopeEnd;
+  }
+  return output;
+}
+
 /** Decodes one complete bit-packed run directly into the caller's output array. */
 function decodeBitPackedRun(
   cursor: CursorBuffer,

--- a/modules/parquet/src/parquetjs/encoder/parquet-encoder.ts
+++ b/modules/parquet/src/parquetjs/encoder/parquet-encoder.ts
@@ -1084,7 +1084,7 @@ function createSizeStatistics(column: ParquetField, data: ParquetColumnChunk): S
   }
   return new SizeStatistics({
     unencoded_byte_array_data_bytes:
-      unencodedByteArrayDataBytes > 0 ? unencodedByteArrayDataBytes : undefined,
+      column.primitiveType === 'BYTE_ARRAY' ? unencodedByteArrayDataBytes : undefined,
     repetition_level_histogram: repetitionLevelHistogram,
     definition_level_histogram: definitionLevelHistogram
   });

--- a/modules/parquet/src/parquetjs/encoder/parquet-encoder.ts
+++ b/modules/parquet/src/parquetjs/encoder/parquet-encoder.ts
@@ -1103,7 +1103,11 @@ function createColumnStatistics(
   column: ParquetField,
   data: ParquetColumnChunk
 ): Statistics | undefined {
-  if (!column.primitiveType || !isPageIndexPhysicalType(column.primitiveType)) {
+  if (
+    !column.primitiveType ||
+    !isPageIndexPhysicalType(column.primitiveType) ||
+    !supportsStatisticsSortOrder(column)
+  ) {
     return undefined;
   }
   const statistics = new Statistics({
@@ -1117,6 +1121,19 @@ function createColumnStatistics(
   statistics.min_value = bounds.min;
   statistics.max_value = bounds.max;
   return statistics;
+}
+
+/** Returns whether the physical representation preserves the logical sort order. */
+function supportsStatisticsSortOrder(column: ParquetField): boolean {
+  const logicalType = column.logicalType?.type || column.originalType;
+  if (logicalType === 'FLOAT16') return false;
+  if (logicalType === 'DECIMAL' || logicalType?.startsWith('DECIMAL_')) {
+    return column.primitiveType !== 'BYTE_ARRAY' && column.primitiveType !== 'FIXED_LEN_BYTE_ARRAY';
+  }
+  if (logicalType === 'INTEGER' || logicalType?.startsWith('UINT_')) {
+    return column.logicalType?.isSigned !== false && !logicalType.startsWith('UINT_');
+  }
+  return true;
 }
 
 /** Counts the occurrences of each definition or repetition level. */
@@ -1141,7 +1158,9 @@ function createSortingColumns(
   const usedColumnIndexes = new Set<number>();
   return sortingColumns.map(sortKey => {
     const columnIndex = leafFields.findIndex(
-      field => field.name === sortKey.column || field.path.join('.') === sortKey.column
+      field =>
+        (field.path.length === 1 && field.name === sortKey.column) ||
+        (field.path.length > 1 && field.path.join('.') === sortKey.column)
     );
     if (columnIndex < 0) {
       throw new Error(`Unknown Parquet sorting column ${sortKey.column}`);

--- a/modules/parquet/src/parquetjs/schema/declare.ts
+++ b/modules/parquet/src/parquetjs/schema/declare.ts
@@ -11,6 +11,7 @@ import type {ParquetValueBuffer} from '../codecs/declare';
 export type ParquetCodec =
   | 'PLAIN'
   | 'RLE'
+  | 'BIT_PACKED'
   | 'PLAIN_DICTIONARY'
   | 'RLE_DICTIONARY'
   | 'DELTA_BINARY_PACKED'

--- a/modules/parquet/test/parquet-page-index-api.spec.ts
+++ b/modules/parquet/test/parquet-page-index-api.spec.ts
@@ -10,9 +10,22 @@ import {OffsetIndex, PageLocation, SizeStatistics} from '../src/parquetjs/parque
 import {serializeThrift} from '../src/parquetjs/utils/read-utils';
 import {Uint8ArrayCompactProtocol} from '../src/parquetjs/utils/uint8-array-compact-protocol';
 import {Uint8ArrayTransport} from '../src/parquetjs/utils/uint8-array-transport';
+import {PARQUET_CODECS} from '../src/parquetjs/codecs';
 import {createParquetModuleAad, decryptParquetModule} from '../src/lib/parquet-encryption';
 
 describe('Parquet page-index public helpers', () => {
+  test('decodes legacy BIT_PACKED level values', () => {
+    const encoded = PARQUET_CODECS.BIT_PACKED.encodeValues('INT32', [0, 1, 2, 3, 4], {
+      bitWidth: 3
+    });
+    const decoded = PARQUET_CODECS.BIT_PACKED.decodeValues(
+      'INT32',
+      {buffer: encoded, offset: 0, size: encoded.length},
+      5,
+      {bitWidth: 3}
+    );
+    expect(decoded).toEqual([0, 1, 2, 3, 4]);
+  });
   test('decodes physical page statistics using logical field types', () => {
     const schema = new ParquetSchema({value: {type: 'INT32'}});
     expect(

--- a/modules/parquet/test/parquet-repeated-page.spec.ts
+++ b/modules/parquet/test/parquet-repeated-page.spec.ts
@@ -60,3 +60,41 @@ test('ParquetReader selectively reads repeated columns when page boundaries alig
   ).toEqual(['hundred', 'hundred-one']);
   await file.close();
 });
+
+test('Parquet page pruning falls back when a repeated row crosses a page boundary', async () => {
+  const parquetBuffer = await encode(
+    {
+      shape: 'object-row-table',
+      schema: {
+        fields: [
+          {name: 'id', type: {type: 'list', children: [{name: 'element', type: 'int32'}]}},
+          {name: 'tags', type: {type: 'list', children: [{name: 'element', type: 'utf8'}]}}
+        ],
+        metadata: {}
+      },
+      data: [
+        {id: [0, 1, 2], tags: ['zero', 'one', 'two']},
+        {id: [100, 101, 102], tags: ['hundred', 'hundred-one', 'hundred-two']}
+      ]
+    } satisfies ObjectRowTable,
+    ParquetJSWriter,
+    {worker: false, parquet: {pageSize: 2, pageIndex: {id: true, tags: true}}}
+  );
+  const file = new BlobFile(new Blob([parquetBuffer]));
+  const reader = new ParquetReader(file);
+  const metadata = await reader.getFileMetadata();
+  const schema = await reader.getSchema();
+  const rowGroup = metadata.row_groups[0];
+  const selectedColumnPaths = rowGroup.columns.map(column => column.meta_data!.path_in_schema);
+
+  const plan = await createParquetPagePruningPlan(
+    file,
+    rowGroup,
+    schema,
+    selectedColumnPaths,
+    {op: '>=', args: [{property: 'id'}, 100]}
+  );
+
+  expect(plan).toBeUndefined();
+  await file.close();
+});

--- a/modules/parquet/test/parquet-size-statistics.spec.ts
+++ b/modules/parquet/test/parquet-size-statistics.spec.ts
@@ -80,6 +80,27 @@ test('ParquetJSWriter records declared row-group sorting columns', async () => {
   ]);
 });
 
+test('ParquetJSWriter rejects ambiguous bare nested sorting names', async () => {
+  const nestedTable: ObjectRowTable = {
+    shape: 'object-row-table',
+    schema: {
+      fields: [
+        {name: 'left', type: {type: 'struct', children: [{name: 'id', type: 'int32'}]}},
+        {name: 'right', type: {type: 'struct', children: [{name: 'id', type: 'int32'}]}}
+      ],
+      metadata: {}
+    },
+    data: [{left: {id: 1}, right: {id: 2}}]
+  };
+
+  await expect(
+    encode(nestedTable, ParquetJSWriter, {
+      worker: false,
+      parquet: {sortingColumns: [{column: 'id'}]}
+    })
+  ).rejects.toThrow('Unknown Parquet sorting column id');
+});
+
 test('ParquetJSWriter emits page statistics for V1 and V2 data pages', async () => {
   for (const useDataPageV2 of [false, true]) {
     const parquetBuffer = await encode(TABLE, ParquetJSWriter, {

--- a/modules/parquet/test/parquet-size-statistics.spec.ts
+++ b/modules/parquet/test/parquet-size-statistics.spec.ts
@@ -64,6 +64,24 @@ test('ParquetJSWriter supports per-column standard statistics', async () => {
   expect(value.statistics).toBeUndefined();
 });
 
+test('ParquetJSWriter records zero byte-array totals for empty values', async () => {
+  const emptyLabelTable: ObjectRowTable = {
+    ...TABLE,
+    data: [
+      {label: '', value: 1},
+      {label: null, value: 2}
+    ]
+  };
+  const parquetBuffer = await encode(emptyLabelTable, ParquetJSWriter, {
+    worker: false,
+    parquet: {writeSizeStatistics: true}
+  });
+  const metadata = await new ParquetReader(new BlobFile(parquetBuffer)).getFileMetadata();
+  const [label] = metadata.row_groups[0].columns.map(column => column.meta_data!);
+
+  expect(label.size_statistics?.unencoded_byte_array_data_bytes?.toNumber()).toBe(0);
+});
+
 test('ParquetJSWriter records declared row-group sorting columns', async () => {
   const parquetBuffer = await encode(TABLE, ParquetJSWriter, {
     worker: false,


### PR DESCRIPTION
## Goal

Follow up on landed Parquet changes to make writer metadata safe for logical ordering, complete for empty byte arrays, and unambiguous for nested schemas while expanding legacy-format compatibility.

## Changes

- Omit exact column statistics when the physical representation cannot preserve the logical sort order (FLOAT16, byte/fixed decimal, and unsigned integer logical types).
- Require dotted paths for nested sorting columns while retaining short names for top-level leaves.
- Emit an explicit zero `unencoded_byte_array_data_bytes` for BYTE_ARRAY chunks containing only empty/null values.
- Fall back to full-column repeated reads when offset-index row starts reveal continuation pages whose repetition boundary cannot be proven from the index.
- Decode legacy BIT_PACKED level sections, including their page-length envelope.
- Add regression tests for each compatibility and safety case.
- Clarify the five broad completion tranches in the Parquet format documentation, including the remaining encryption, conformance, semantic-sorting, and experimental-format work.

## Validation

- `yarn build`
- `yarn test-headless modules/parquet/test/parquet-page-index-api.spec.ts modules/parquet/test/parquet-repeated-page.spec.ts modules/parquet/test/parquet-size-statistics.spec.ts`
- `yarn test-audit`
- `yarn lint fix`
- `git diff --check`

Follow-up to review feedback on landed #3740, #3720, and #3744. ALP/PFOR/VECTOR encodings and encrypted-column writer/range-read support remain explicitly experimental/future work rather than being overstated as stable support.