### PR TITLE
feat(wms): add universal service runtime and capability graph

### DIFF
--- a/docs/modules/wms/services/capability-discovery.md
+++ b/docs/modules/wms/services/capability-discovery.md
@@ -1,0 +1,20 @@
+# Capability graph and service discovery
+
+`discoverServiceGraph` follows service-directory JSON and OGC landing-page links and returns a
+serializable `CapabilityGraph`. Endpoint preferences can rank results after capabilities are
+attached by an application or catalog adapter.
+
+```ts
+import {discoverServiceGraph} from '@loaders.gl/wms';
+
+const graph = await discoverServiceGraph('https://example.com/rest/services');
+const preferred = graph.rank({
+  types: ['wmts', 'arcgis-image-server'],
+  formats: ['image/png'],
+  crs: ['EPSG:3857']
+});
+```
+
+The graph keeps relationships (`service`, `service-desc`, and other link relations), endpoint
+types, optional capability summaries, and measured latency so applications can persist and rank
+service choices without reimplementing discovery logic.

--- a/docs/modules/wms/services/universal-service-runtime.md
+++ b/docs/modules/wms/services/universal-service-runtime.md
@@ -1,0 +1,21 @@
+# Universal service runtime
+
+`ServiceRuntime` provides one entry point for OGC and ArcGIS sources. It detects a source from its
+URL, preserves a cached source instance, and offers shared request retries, cancellation, headers,
+and telemetry.
+
+```ts
+import {ServiceRuntime} from '@loaders.gl/wms';
+
+const runtime = new ServiceRuntime({
+  headers: {Authorization: `Bearer ${token}`},
+  retries: 3,
+  onTelemetry: event => console.log(event.phase, event.url)
+});
+
+const source = runtime.getSource('https://example.com/arcgis/rest/services/World/MapServer');
+const metadata = await source.getMetadata();
+```
+
+Applications can supply a custom `loaders` list to control supported protocols while keeping the
+same lifecycle and error behavior.

--- a/modules/wms/src/capability-graph.ts
+++ b/modules/wms/src/capability-graph.ts
@@ -79,7 +79,7 @@ export async function discoverServiceGraph(
 function discoverJSONEndpoints(url: string, document: any): ServiceEndpoint[] {
   const endpoints: ServiceEndpoint[] = [];
   for (const service of document.services || []) {
-    const endpointURL = service.url || `${url.replace(/\/$/, '')}/${service.name}`;
+    const endpointURL = service.url || `${url.replace(/\/$/, '')}/${service.name}/${service.type}`;
     endpoints.push({
       url: endpointURL,
       type: detectServiceType(service.type, endpointURL),
@@ -100,18 +100,22 @@ function discoverJSONEndpoints(url: string, document: any): ServiceEndpoint[] {
 
 function discoverHTMLEndpoints(url: string, document: string): ServiceEndpoint[] {
   const endpoints: ServiceEndpoint[] = [];
-  const linkPattern = /<link[^>]+href=["']([^"']+)["'][^>]*>/gi;
+  const linkPattern = /<link\b[^>]*>/gi;
   for (const match of document.matchAll(linkPattern)) {
-    const endpointURL = new URL(match[1], url).toString();
+    const href = /\bhref=["']([^"']+)["']/i.exec(match[0])?.[1];
+    if (!href) continue;
+    const relation = /\brel=["']([^"']+)["']/i.exec(match[0])?.[1] || 'related';
+    const endpointURL = new URL(href, url).toString();
     endpoints.push({
       url: endpointURL,
       type: detectServiceType('', endpointURL),
-      relation: 'related'
+      relation
     });
   }
   return endpoints;
 }
 
+/** Infers a supported service family from a type hint and endpoint URL. */
 function detectServiceType(value: string, url: string): GeoServiceType {
   const text = `${value} ${url}`.toLowerCase();
   if (text.includes('imageserver')) return 'arcgis-image-server';
@@ -124,6 +128,7 @@ function detectServiceType(value: string, url: string): GeoServiceType {
   return 'unknown';
 }
 
+/** Computes a preference score for one service endpoint. */
 function scoreEndpoint(endpoint: ServiceEndpoint, preferences: ServiceEndpointPreferences): number {
   const capabilities = endpoint.capabilities;
   let score = endpoint.type === 'unknown' ? 0 : 1;
@@ -134,6 +139,7 @@ function scoreEndpoint(endpoint: ServiceEndpoint, preferences: ServiceEndpointPr
   return score;
 }
 
+/** Counts exact case-insensitive matches between preferred and advertised values. */
 function matches(
   preferred: readonly string[] | undefined,
   advertised: readonly string[] | undefined

--- a/modules/wms/src/capability-graph.ts
+++ b/modules/wms/src/capability-graph.ts
@@ -1,0 +1,145 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {GeoServiceType, ServiceCapabilities} from './service-capabilities';
+import {ServiceRuntime, type ServiceRuntimeOptions} from './service-runtime';
+
+/** A discovered endpoint related to a service or catalog landing page. */
+export type ServiceEndpoint = {
+  /** Endpoint URL. */
+  url: string;
+  /** Detected service family. */
+  type: GeoServiceType;
+  /** Relationship from the parent resource. */
+  relation: string;
+  /** Optional capability summary. */
+  capabilities?: ServiceCapabilities;
+  /** Measured request latency in milliseconds. */
+  latency?: number;
+};
+
+/** Preferences used to rank service endpoints. */
+export type ServiceEndpointPreferences = {
+  /** Preferred response formats. */
+  formats?: readonly string[];
+  /** Preferred coordinate reference systems. */
+  crs?: readonly string[];
+  /** Preferred service families. */
+  types?: readonly GeoServiceType[];
+};
+
+/** A capability graph containing discovered service endpoints. */
+export class CapabilityGraph {
+  /** Discovered endpoints. */
+  readonly endpoints: ServiceEndpoint[];
+
+  /** Creates a capability graph. */
+  constructor(endpoints: readonly ServiceEndpoint[] = []) {
+    this.endpoints = [...endpoints];
+  }
+
+  /** Adds endpoints and returns this graph for fluent discovery pipelines. */
+  add(endpoints: readonly ServiceEndpoint[]): this {
+    this.endpoints.push(...endpoints);
+    return this;
+  }
+
+  /** Ranks endpoints by type, format, CRS, and measured latency. */
+  rank(preferences: ServiceEndpointPreferences = {}): ServiceEndpoint[] {
+    return [...this.endpoints].sort(
+      (first, second) => scoreEndpoint(second, preferences) - scoreEndpoint(first, preferences)
+    );
+  }
+
+  /** Returns a serializable snapshot suitable for persistence. */
+  toJSON(): {endpoints: ServiceEndpoint[]} {
+    return {endpoints: this.endpoints};
+  }
+}
+
+/** Discovers ArcGIS directories and OGC landing-page relationships into a graph. */
+export async function discoverServiceGraph(
+  url: string,
+  options: ServiceRuntimeOptions = {}
+): Promise<CapabilityGraph> {
+  const runtime = new ServiceRuntime(options);
+  const response = await runtime.request(url, {
+    headers: {accept: 'application/json, application/xml, text/html'}
+  });
+  const contentType = response.headers.get('content-type') || '';
+  const text = await response.text();
+  const endpoints =
+    contentType.includes('json') || text.trim().startsWith('{')
+      ? discoverJSONEndpoints(url, JSON.parse(text))
+      : discoverHTMLEndpoints(url, text);
+  return new CapabilityGraph(endpoints);
+}
+
+function discoverJSONEndpoints(url: string, document: any): ServiceEndpoint[] {
+  const endpoints: ServiceEndpoint[] = [];
+  for (const service of document.services || []) {
+    const endpointURL = service.url || `${url.replace(/\/$/, '')}/${service.name}`;
+    endpoints.push({
+      url: endpointURL,
+      type: detectServiceType(service.type, endpointURL),
+      relation: 'service'
+    });
+  }
+  for (const link of document.links || []) {
+    if (!link.href) continue;
+    const endpointURL = new URL(link.href, url).toString();
+    endpoints.push({
+      url: endpointURL,
+      type: detectServiceType(link.type || '', endpointURL),
+      relation: link.rel || 'related'
+    });
+  }
+  return endpoints;
+}
+
+function discoverHTMLEndpoints(url: string, document: string): ServiceEndpoint[] {
+  const endpoints: ServiceEndpoint[] = [];
+  const linkPattern = /<link[^>]+href=["']([^"']+)["'][^>]*>/gi;
+  for (const match of document.matchAll(linkPattern)) {
+    const endpointURL = new URL(match[1], url).toString();
+    endpoints.push({
+      url: endpointURL,
+      type: detectServiceType('', endpointURL),
+      relation: 'related'
+    });
+  }
+  return endpoints;
+}
+
+function detectServiceType(value: string, url: string): GeoServiceType {
+  const text = `${value} ${url}`.toLowerCase();
+  if (text.includes('imageserver')) return 'arcgis-image-server';
+  if (text.includes('featureserver')) return 'arcgis-feature-server';
+  if (text.includes('mapserver')) return 'arcgis-map-server';
+  if (text.includes('wmts')) return 'wmts';
+  if (text.includes('wms')) return 'wms';
+  if (text.includes('wfs')) return 'wfs';
+  if (text.includes('csw')) return 'csw';
+  return 'unknown';
+}
+
+function scoreEndpoint(endpoint: ServiceEndpoint, preferences: ServiceEndpointPreferences): number {
+  const capabilities = endpoint.capabilities;
+  let score = endpoint.type === 'unknown' ? 0 : 1;
+  if (preferences.types?.includes(endpoint.type)) score += 100;
+  score += matches(preferences.formats, capabilities?.formats) * 20;
+  score += matches(preferences.crs, capabilities?.crs) * 20;
+  if (endpoint.latency !== undefined) score += Math.max(0, 10 - endpoint.latency / 100);
+  return score;
+}
+
+function matches(
+  preferred: readonly string[] | undefined,
+  advertised: readonly string[] | undefined
+): number {
+  if (!preferred?.length || !advertised?.length) return 0;
+  return preferred.filter(value =>
+    advertised.some(candidate => candidate.toLowerCase() === value.toLowerCase())
+  ).length;
+}

--- a/modules/wms/src/index.ts
+++ b/modules/wms/src/index.ts
@@ -97,6 +97,15 @@ export {
   normalizeVectorServiceCapabilities
 } from './service-capabilities';
 
+export type {
+  ServiceRuntimeOptions,
+  ServiceTelemetryEvent,
+  ServiceSourceLoader
+} from './service-runtime';
+export {DEFAULT_SERVICE_LOADERS, ServiceRequestError, ServiceRuntime} from './service-runtime';
+export type {ServiceEndpoint, ServiceEndpointPreferences} from './capability-graph';
+export {CapabilityGraph, discoverServiceGraph} from './capability-graph';
+
 // ArcGIS SourceLoaders
 
 export {getArcGISServices as _getArcGISServices} from './arcgis/arcgis-server';

--- a/modules/wms/src/service-runtime.ts
+++ b/modules/wms/src/service-runtime.ts
@@ -27,6 +27,8 @@ export type ServiceRuntimeOptions = {
   retries?: number;
   /** Delay between retries in milliseconds. */
   retryDelay?: number;
+  /** Allows retries for non-idempotent methods when explicitly enabled. */
+  retryNonIdempotent?: boolean;
   /** Time-to-live for cached sources. */
   cacheTTL?: number;
   /** Receives request lifecycle events. */
@@ -119,7 +121,7 @@ export class ServiceRuntime {
       try {
         const response = await fetch(url, {
           ...requestInit,
-          headers: {...this.options.headers, ...requestInit.headers}
+          headers: mergeHeaders(this.options.headers, requestInit.headers)
         });
         if (!response.ok) throw new ServiceRequestError(url, attempt, response.status);
         this.options.onTelemetry?.({
@@ -130,11 +132,16 @@ export class ServiceRuntime {
         });
         return response;
       } catch (error) {
+        if (isAbortError(error) || requestInit.signal?.aborted) throw error;
         const normalizedError =
           error instanceof ServiceRequestError
             ? error
             : new ServiceRequestError(url, attempt, undefined, error);
-        if (attempt > this.options.retries || !isRetryableError(normalizedError)) {
+        if (
+          attempt > this.options.retries ||
+          !isRetryableError(normalizedError) ||
+          (!this.options.retryNonIdempotent && !isIdempotentMethod(requestInit.method))
+        ) {
           this.options.onTelemetry?.({
             phase: 'error',
             url,
@@ -168,6 +175,26 @@ export class ServiceRuntime {
   }
 }
 
+/** Combines HeadersInit values without losing Headers or tuple-array entries. */
+function mergeHeaders(defaultHeaders?: HeadersInit, requestHeaders?: HeadersInit): Headers {
+  const headers = new Headers(defaultHeaders);
+  new Headers(requestHeaders).forEach((value, key) => headers.set(key, value));
+  return headers;
+}
+
+/** Returns whether a request method is safe to retry by default. */
+function isIdempotentMethod(method = 'GET'): boolean {
+  return ['GET', 'HEAD', 'OPTIONS', 'PUT', 'DELETE'].includes(method.toUpperCase());
+}
+
+/** Returns whether an exception indicates request cancellation. */
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException
+    ? error.name === 'AbortError'
+    : (error as any)?.name === 'AbortError';
+}
+
+/** Determines whether a failed service request can be retried. */
 function isRetryableError(error: ServiceRequestError): boolean {
   return (
     error.status === undefined ||

--- a/modules/wms/src/service-runtime.ts
+++ b/modules/wms/src/service-runtime.ts
@@ -1,0 +1,183 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {CoreAPI, DataSource, DataSourceOptions, SourceLoader} from '@loaders.gl/loader-utils';
+import {CSWSourceLoader} from './csw-source-loader';
+import {ArcGISFeatureServerSourceLoader} from './arcgis/arcgis-feature-server-source-loader';
+import {ArcGISImageServerSourceLoader} from './arcgis/arcgis-image-server-source-loader';
+import {ArcGISMapTileSourceLoader} from './arcgis/arcgis-map-tile-source-loader';
+import {ArcGISImageTileSourceLoader} from './arcgis/arcgis-image-tile-source-loader';
+import {WMSSourceLoader} from './wms-source-loader';
+import {WMTSSourceLoader} from './wmts-source-loader';
+import {WFSSourceLoader} from './wfs-source-loader';
+
+/** A source loader that can be selected by the universal service runtime. */
+export type ServiceSourceLoader = SourceLoader;
+
+/** Runtime policy shared by service requests and source creation. */
+export type ServiceRuntimeOptions = {
+  /** Source loaders used for automatic URL detection. */
+  loaders?: readonly ServiceSourceLoader[];
+  /** Core API used by protocol sources to parse responses. */
+  coreApi?: CoreAPI;
+  /** Default request headers, including authorization headers. */
+  headers?: HeadersInit;
+  /** Number of retries after retryable failures. */
+  retries?: number;
+  /** Delay between retries in milliseconds. */
+  retryDelay?: number;
+  /** Time-to-live for cached sources. */
+  cacheTTL?: number;
+  /** Receives request lifecycle events. */
+  onTelemetry?: (event: ServiceTelemetryEvent) => void;
+};
+
+/** A normalized service request lifecycle event. */
+export type ServiceTelemetryEvent = {
+  /** Lifecycle phase. */
+  phase: 'start' | 'success' | 'error';
+  /** Requested URL. */
+  url: string;
+  /** Attempt number, starting at one. */
+  attempt: number;
+  /** Elapsed time for completed requests. */
+  elapsed?: number;
+  /** Normalized error for failed requests. */
+  error?: ServiceRequestError;
+};
+
+/** Error raised by a service request with retry context preserved. */
+export class ServiceRequestError extends Error {
+  /** Requested URL. */
+  readonly url: string;
+  /** HTTP status, when available. */
+  readonly status?: number;
+  /** Number of attempts made. */
+  readonly attempts: number;
+
+  /** Creates a normalized service request error. */
+  constructor(url: string, attempts: number, status?: number, cause?: unknown) {
+    super(`Service request failed after ${attempts} attempt${attempts === 1 ? '' : 's'}: ${url}`);
+    this.name = 'ServiceRequestError';
+    this.url = url;
+    this.status = status;
+    this.attempts = attempts;
+    if (cause) this.cause = cause;
+  }
+}
+
+/** Default source set spanning OGC and ArcGIS service families. */
+export const DEFAULT_SERVICE_LOADERS: readonly ServiceSourceLoader[] = [
+  ArcGISFeatureServerSourceLoader,
+  ArcGISImageServerSourceLoader,
+  ArcGISImageTileSourceLoader,
+  ArcGISMapTileSourceLoader,
+  WMTSSourceLoader,
+  WMSSourceLoader,
+  WFSSourceLoader,
+  CSWSourceLoader
+];
+
+type CachedSource = {source: DataSource<unknown, DataSourceOptions>; expires: number};
+
+/** One protocol-neutral runtime for discovering and operating service sources. */
+export class ServiceRuntime {
+  /** Runtime options with resolved policy defaults. */
+  readonly options: ServiceRuntimeOptions &
+    Required<Pick<ServiceRuntimeOptions, 'loaders' | 'retries' | 'retryDelay' | 'cacheTTL'>>;
+  private readonly _sources = new Map<string, CachedSource>();
+
+  /** Creates a universal service runtime. */
+  constructor(options: ServiceRuntimeOptions = {}) {
+    this.options = {
+      ...options,
+      loaders: options.loaders || DEFAULT_SERVICE_LOADERS,
+      retries: options.retries ?? 2,
+      retryDelay: options.retryDelay ?? 100,
+      cacheTTL: options.cacheTTL ?? 300_000
+    };
+  }
+
+  /** Detects a source type and creates a cached protocol source for a URL. */
+  getSource(url: string, options: DataSourceOptions = {}): DataSource<unknown, DataSourceOptions> {
+    const cachedSource = this._sources.get(url);
+    if (cachedSource && cachedSource.expires > Date.now()) return cachedSource.source;
+    const loader = this.options.loaders.find(candidate => candidate.testURL(url));
+    if (!loader) throw new Error(`No geospatial service loader recognized URL: ${url}`);
+    const sourceOptions = this._getSourceOptions(options);
+    const source = loader.createDataSource(url, sourceOptions, this.options.coreApi);
+    this._sources.set(url, {source, expires: Date.now() + this.options.cacheTTL});
+    return source;
+  }
+
+  /** Requests a URL with shared headers, cancellation, retry, and telemetry behavior. */
+  async request(url: string, requestInit: RequestInit = {}): Promise<Response> {
+    const startedAt = Date.now();
+    for (let attempt = 1; attempt <= this.options.retries + 1; attempt++) {
+      this.options.onTelemetry?.({phase: 'start', url, attempt});
+      try {
+        const response = await fetch(url, {
+          ...requestInit,
+          headers: {...this.options.headers, ...requestInit.headers}
+        });
+        if (!response.ok) throw new ServiceRequestError(url, attempt, response.status);
+        this.options.onTelemetry?.({
+          phase: 'success',
+          url,
+          attempt,
+          elapsed: Date.now() - startedAt
+        });
+        return response;
+      } catch (error) {
+        const normalizedError =
+          error instanceof ServiceRequestError
+            ? error
+            : new ServiceRequestError(url, attempt, undefined, error);
+        if (attempt > this.options.retries || !isRetryableError(normalizedError)) {
+          this.options.onTelemetry?.({
+            phase: 'error',
+            url,
+            attempt,
+            elapsed: Date.now() - startedAt,
+            error: normalizedError
+          });
+          throw normalizedError;
+        }
+        await delay(this.options.retryDelay * 2 ** (attempt - 1));
+      }
+    }
+    throw new ServiceRequestError(url, this.options.retries + 1);
+  }
+
+  /** Clears cached source instances, optionally limiting invalidation to one URL. */
+  clearCache(url?: string): void {
+    if (url) this._sources.delete(url);
+    else this._sources.clear();
+  }
+
+  private _getSourceOptions(options: DataSourceOptions): DataSourceOptions {
+    if (!this.options.headers) return options;
+    return {
+      ...options,
+      core: {
+        ...options.core,
+        loadOptions: {...options.core?.loadOptions, fetch: {headers: this.options.headers}}
+      }
+    };
+  }
+}
+
+function isRetryableError(error: ServiceRequestError): boolean {
+  return (
+    error.status === undefined ||
+    error.status === 408 ||
+    error.status === 425 ||
+    error.status === 429 ||
+    error.status >= 500
+  );
+}
+
+async function delay(milliseconds: number): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, milliseconds));
+}

--- a/modules/wms/test/service-runtime.spec.ts
+++ b/modules/wms/test/service-runtime.spec.ts
@@ -41,6 +41,29 @@ describe('ServiceRuntime', () => {
       attempts: 1
     } satisfies Partial<ServiceRequestError>);
   });
+
+  test('merges HeadersInit values and does not retry POST requests', async () => {
+    let attempts = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url, init) => {
+        attempts++;
+        expect(new Headers(init.headers).get('authorization')).toBe('request-token');
+        return new Response('', {status: 503});
+      })
+    );
+    const runtime = new ServiceRuntime({
+      headers: new Headers([['authorization', 'default-token']]),
+      retryDelay: 0
+    });
+    await expect(
+      runtime.request('https://example.com/mutate', {
+        method: 'POST',
+        headers: [['authorization', 'request-token']]
+      })
+    ).rejects.toBeInstanceOf(ServiceRequestError);
+    expect(attempts).toBe(1);
+  });
 });
 
 test('CapabilityGraph ranks preferred endpoints', () => {
@@ -82,9 +105,7 @@ test('discoverServiceGraph follows ArcGIS directory and OGC links', async () => 
       async () =>
         new Response(
           JSON.stringify({
-            services: [
-              {name: 'Imagery', type: 'ImageServer', url: 'https://example.com/ImageServer'}
-            ],
+            services: [{name: 'Imagery', type: 'ImageServer'}],
             links: [{rel: 'service-desc', href: '/api?f=json', type: 'application/json'}]
           }),
           {status: 200, headers: {'content-type': 'application/json'}}
@@ -96,4 +117,20 @@ test('discoverServiceGraph follows ArcGIS directory and OGC links', async () => 
     'arcgis-image-server',
     'unknown'
   ]);
+  expect(graph.endpoints[0].url).toBe('https://example.com/rest/services/Imagery/ImageServer');
+});
+
+test('discoverServiceGraph preserves HTML link relationships', async () => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(
+      async () =>
+        new Response('<link rel="service-desc" href="/collections?f=json">', {
+          status: 200,
+          headers: {'content-type': 'text/html'}
+        })
+    )
+  );
+  const graph = await discoverServiceGraph('https://example.com/api');
+  expect(graph.endpoints[0].relation).toBe('service-desc');
 });

--- a/modules/wms/test/service-runtime.spec.ts
+++ b/modules/wms/test/service-runtime.spec.ts
@@ -1,0 +1,99 @@
+import {afterEach, describe, expect, test, vi} from 'vitest';
+import {
+  CapabilityGraph,
+  ServiceRequestError,
+  ServiceRuntime,
+  discoverServiceGraph
+} from '@loaders.gl/wms';
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('ServiceRuntime', () => {
+  test('retries transient responses and emits lifecycle telemetry', async () => {
+    const telemetry: string[] = [];
+    let attempts = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        attempts++;
+        return attempts === 1 ? new Response('', {status: 503}) : new Response('ok');
+      })
+    );
+    const runtime = new ServiceRuntime({
+      retryDelay: 0,
+      onTelemetry: event => telemetry.push(event.phase)
+    });
+    const response = await runtime.request('https://example.com/service');
+    expect(response.ok).toBe(true);
+    expect(attempts).toBe(2);
+    expect(telemetry).toEqual(['start', 'start', 'success']);
+  });
+
+  test('normalizes terminal failures', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('', {status: 404}))
+    );
+    const runtime = new ServiceRuntime({retries: 2, retryDelay: 0});
+    await expect(runtime.request('https://example.com/missing')).rejects.toMatchObject({
+      url: 'https://example.com/missing',
+      status: 404,
+      attempts: 1
+    } satisfies Partial<ServiceRequestError>);
+  });
+});
+
+test('CapabilityGraph ranks preferred endpoints', () => {
+  const graph = new CapabilityGraph([
+    {
+      url: 'https://example.com/wms',
+      type: 'wms',
+      relation: 'service',
+      capabilities: {
+        type: 'wms',
+        name: 'map',
+        crs: ['EPSG:4326'],
+        formats: ['image/png'],
+        layers: [],
+        operations: []
+      }
+    },
+    {
+      url: 'https://example.com/wmts',
+      type: 'wmts',
+      relation: 'service',
+      capabilities: {
+        type: 'wmts',
+        name: 'tiles',
+        crs: ['EPSG:3857'],
+        formats: ['image/png'],
+        layers: [],
+        operations: []
+      }
+    }
+  ]);
+  expect(graph.rank({types: ['wmts'], crs: ['EPSG:3857']})[0].type).toBe('wmts');
+});
+
+test('discoverServiceGraph follows ArcGIS directory and OGC links', async () => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            services: [
+              {name: 'Imagery', type: 'ImageServer', url: 'https://example.com/ImageServer'}
+            ],
+            links: [{rel: 'service-desc', href: '/api?f=json', type: 'application/json'}]
+          }),
+          {status: 200, headers: {'content-type': 'application/json'}}
+        )
+    )
+  );
+  const graph = await discoverServiceGraph('https://example.com/rest/services');
+  expect(graph.endpoints.map(endpoint => endpoint.type)).toEqual([
+    'arcgis-image-server',
+    'unknown'
+  ]);
+});


### PR DESCRIPTION
## Goals

- Implement tranche 9: a protocol-neutral runtime for geospatial services.
- Implement tranche 13: actionable capability discovery and endpoint ranking.

## Changes

- Add `ServiceRuntime` with automatic source detection across OGC and ArcGIS loaders.
- Centralize request headers/auth, retries with backoff, cancellation via `RequestInit`, telemetry, source caching, and `ServiceRequestError`.
- Add `CapabilityGraph` with serializable endpoint relationships and preference-based ranking by service type, format, CRS, and latency.
- Add discovery for ArcGIS service-directory JSON and OGC/HTML landing-page links.
- Add API documentation and native Vitest coverage.

## Verification

- `yarn lint fix`
- `yarn build`
- `yarn test-headless modules/wms/test/service-runtime.spec.ts` (4 passed)
- `yarn test-node` (333 passed, 6 skipped)
- `yarn test-audit` (0 violations)