### PR TITLE
feat(geotiff): expose shared raster scan metadata

### DIFF
--- a/docs/modules/geotiff/README.md
+++ b/docs/modules/geotiff/README.md
@@ -26,6 +26,11 @@ npm install @loaders.gl/core @loaders.gl/geotiff
 
 ## Loaders and Sources
 
+`GeoTIFFRasterSource` also implements the shared scan metadata contract. Call
+`getQueryMetadata()` to discover raster bands, source bounds, and available overview levels for
+the source-neutral scan query panel. This is metadata discovery only; pixel reads continue to use
+the viewport-oriented `getRaster()` API and preserve GeoTIFF/COG range access.
+
 | Loader / Source | Description |
 | ---------------- | ----------- |
 | [`GeoTIFFLoader`](/docs/modules/geotiff/api-reference/geotiff-loader) | Loads georeferenced GeoTIFF images. |

--- a/modules/geotiff/src/geotiff-source-loader.ts
+++ b/modules/geotiff/src/geotiff-source-loader.ts
@@ -176,13 +176,20 @@ export class GeoTIFFRasterSource
         levelOfDetail: this.rasterQueryCapabilities.level
       },
       spatial: metadata.boundingBox
-        ? {bounds: {minimum: metadata.boundingBox[0], maximum: metadata.boundingBox[1]}}
+        ? {
+            bounds: {minimum: metadata.boundingBox[0], maximum: metadata.boundingBox[1]},
+            coordinateReferenceSystems:
+              typeof metadata.crs === 'string' ? [metadata.crs] : undefined
+          }
         : undefined,
       levels: metadata.overviews?.map(overview => ({
         index: overview.index,
         width: overview.width,
         height: overview.height,
-        scale: overview.resolution
+        scale: [metadata.width / overview.width, metadata.height / overview.height] as [
+          number,
+          number
+        ]
       }))
     });
   }

--- a/modules/geotiff/src/geotiff-source-loader.ts
+++ b/modules/geotiff/src/geotiff-source-loader.ts
@@ -17,13 +17,17 @@ import type {
   RasterBoundingBox,
   RangeRequestSchedulerProps,
   RangeRequestTransportResult,
-  RasterQueryCapabilities
+  RasterQueryCapabilities,
+  ScanQueryMetadata,
+  ScanQueryMetadataOptions,
+  ScanQueryMetadataProvider
 } from '@loaders.gl/loader-utils';
 import type {CRSIdentifier} from '@math.gl/crs';
 import {
   DataSource,
   getRasterViewportBoundingBox,
-  RangeRequestScheduler
+  RangeRequestScheduler,
+  createScanQueryMetadata
 } from '@loaders.gl/loader-utils';
 import {GeoTIFFFormat} from './geotiff-format';
 
@@ -116,7 +120,7 @@ type GeoTIFFReadRasterResult = {width: number; height: number} & (
  */
 export class GeoTIFFRasterSource
   extends DataSource<string | Blob, GeoTIFFSourceLoaderOptions>
-  implements RasterSource
+  implements RasterSource, ScanQueryMetadataProvider
 {
   /** Capabilities advertised by this viewport-driven raster source. */
   readonly rasterQueryCapabilities = GEOTIFF_RASTER_QUERY_CAPABILITIES;
@@ -149,6 +153,38 @@ export class GeoTIFFRasterSource
   /** Returns raster-query capabilities without opening raster samples. */
   getRasterQueryCapabilities(): RasterQueryCapabilities {
     return this.rasterQueryCapabilities;
+  }
+
+  /** Discovers raster bands, bounds, and overview levels for the shared scan query panel. */
+  async getQueryMetadata(options: ScanQueryMetadataOptions = {}): Promise<ScanQueryMetadata> {
+    if (options.signal?.aborted) throw new DOMException('The operation was aborted', 'AbortError');
+    const metadata = await this.getMetadata();
+    if (options.signal?.aborted) throw new DOMException('The operation was aborted', 'AbortError');
+    const fields = Array.from({length: metadata.bandCount}, (_, index) => ({
+      name: `band_${index + 1}`,
+      type: metadata.dtype,
+      nullable: metadata.noData !== null,
+      metadata: {}
+    }));
+    return createScanQueryMetadata({
+      sourceType: 'geotiff',
+      queryType: 'raster',
+      name: metadata.name,
+      schema: {fields, metadata: {}},
+      capabilities: {
+        bounds: this.rasterQueryCapabilities.bounds,
+        levelOfDetail: this.rasterQueryCapabilities.level
+      },
+      spatial: metadata.boundingBox
+        ? {bounds: {minimum: metadata.boundingBox[0], maximum: metadata.boundingBox[1]}}
+        : undefined,
+      levels: metadata.overviews?.map(overview => ({
+        index: overview.index,
+        width: overview.width,
+        height: overview.height,
+        scale: overview.resolution
+      }))
+    });
   }
 
   /**

--- a/modules/geotiff/src/ometiff-source-loader.ts
+++ b/modules/geotiff/src/ometiff-source-loader.ts
@@ -10,9 +10,12 @@ import type {
   DataSourceOptions,
   RasterData,
   RasterChannelDataType,
-  TypedArray
+  TypedArray,
+  ScanQueryMetadata,
+  ScanQueryMetadataOptions,
+  ScanQueryMetadataProvider
 } from '@loaders.gl/loader-utils';
-import {DataSource} from '@loaders.gl/loader-utils';
+import {createScanQueryMetadata, DataSource} from '@loaders.gl/loader-utils';
 
 import type {TiffPixelSource} from './lib/tiff-pixel-source';
 import {loadOmeTiff, isOmeTiff} from './lib/ome/load-ome-tiff';
@@ -159,7 +162,10 @@ export const OMETiffSourceLoader = {
 /**
  * Source that loads 2D planes from an OME-TIFF pyramid.
  */
-export class OMETiffImageSource extends DataSource<string | Blob, OMETiffSourceLoaderOptions> {
+export class OMETiffImageSource
+  extends DataSource<string | Blob, OMETiffSourceLoaderOptions>
+  implements ScanQueryMetadataProvider
+{
   private _initPromise: Promise<OMETiffInit> | null = null;
 
   /**
@@ -168,6 +174,36 @@ export class OMETiffImageSource extends DataSource<string | Blob, OMETiffSourceL
   async getMetadata(): Promise<OMETiffSourceLoaderMetadata> {
     const {metadata} = await this._getInitPromise();
     return metadata;
+  }
+
+  /** Discovers OME-TIFF channels, pyramid levels, and selectable dimensions. */
+  async getQueryMetadata(options: ScanQueryMetadataOptions = {}): Promise<ScanQueryMetadata> {
+    if (options.signal?.aborted) throw new DOMException('The operation was aborted', 'AbortError');
+    const metadata = await this.getMetadata();
+    if (options.signal?.aborted) throw new DOMException('The operation was aborted', 'AbortError');
+    const fields = metadata.channels.map(channel => ({
+      name: channel.name || `channel_${channel.index + 1}`,
+      type: metadata.dtype,
+      nullable: false,
+      metadata: channel.color ? {color: channel.color.join(',')} : {}
+    }));
+    return createScanQueryMetadata({
+      sourceType: 'ometiff',
+      queryType: 'raster',
+      name: metadata.name,
+      schema: {fields, metadata: {}},
+      capabilities: {
+        levelOfDetail: metadata.levels.length > 1 ? 'pushdown' : 'unsupported',
+        slices: metadata.sizeT > 1 || metadata.sizeZ > 1 ? 'pushdown' : 'unsupported',
+        variables: 'pushdown'
+      },
+      levels: metadata.levels.map(level => ({
+        index: level.level,
+        width: level.width,
+        height: level.height,
+        scale: [metadata.width / level.width, metadata.height / level.height] as [number, number]
+      }))
+    });
   }
 
   /**

--- a/modules/geotiff/src/ometiff-source-loader.ts
+++ b/modules/geotiff/src/ometiff-source-loader.ts
@@ -185,7 +185,7 @@ export class OMETiffImageSource
       name: channel.name || `channel_${channel.index + 1}`,
       type: metadata.dtype,
       nullable: false,
-      metadata: channel.color ? {color: channel.color.join(',')} : {}
+      metadata: channel.color ? {color: channel.color.join(',')} : undefined
     }));
     return createScanQueryMetadata({
       sourceType: 'ometiff',
@@ -193,9 +193,7 @@ export class OMETiffImageSource
       name: metadata.name,
       schema: {fields, metadata: {}},
       capabilities: {
-        levelOfDetail: metadata.levels.length > 1 ? 'pushdown' : 'unsupported',
-        slices: metadata.sizeT > 1 || metadata.sizeZ > 1 ? 'pushdown' : 'unsupported',
-        variables: 'pushdown'
+        levelOfDetail: metadata.levels.length > 1 ? 'pushdown' : 'unsupported'
       },
       levels: metadata.levels.map(level => ({
         index: level.level,

--- a/modules/geotiff/test/geotiff-scan-source.spec.ts
+++ b/modules/geotiff/test/geotiff-scan-source.spec.ts
@@ -10,6 +10,7 @@ test('GeoTIFFRasterSource exposes normalized scan metadata', async () => {
     bandCount: 2,
     dtype: 'float32',
     noData: -9999,
+    crs: 'EPSG:32633',
     boundingBox: [
       [-10, 20],
       [30, 60]
@@ -26,6 +27,7 @@ test('GeoTIFFRasterSource exposes normalized scan metadata', async () => {
   expect(metadata.columns.map(column => column.name)).toEqual(['band_1', 'band_2']);
   expect(metadata.columns[0]?.type).toBe('float32');
   expect(metadata.spatial?.bounds).toEqual({minimum: [-10, 20], maximum: [30, 60]});
+  expect(metadata.spatial?.coordinateReferenceSystems).toEqual(['EPSG:32633']);
   expect(metadata.levels?.map(level => level.width)).toEqual([1024, 512]);
   expect(metadata.capabilities.levelOfDetail).toBe('pushdown');
 });

--- a/modules/geotiff/test/geotiff-scan-source.spec.ts
+++ b/modules/geotiff/test/geotiff-scan-source.spec.ts
@@ -1,0 +1,38 @@
+import {expect, test} from 'vitest';
+import {GeoTIFFRasterSource} from '../src/geotiff-source-loader';
+
+test('GeoTIFFRasterSource exposes normalized scan metadata', async () => {
+  const source = new GeoTIFFRasterSource(new Blob([]), {});
+  (source as unknown as {getMetadata: () => Promise<unknown>}).getMetadata = async () => ({
+    name: 'elevation.tif',
+    width: 1024,
+    height: 512,
+    bandCount: 2,
+    dtype: 'float32',
+    noData: -9999,
+    boundingBox: [
+      [-10, 20],
+      [30, 60]
+    ],
+    overviews: [
+      {index: 0, width: 1024, height: 512, resolution: [1, 1]},
+      {index: 1, width: 512, height: 256, resolution: [2, 2]}
+    ]
+  });
+
+  const metadata = await source.getQueryMetadata();
+  expect(metadata.sourceType).toBe('geotiff');
+  expect(metadata.queryType).toBe('raster');
+  expect(metadata.columns.map(column => column.name)).toEqual(['band_1', 'band_2']);
+  expect(metadata.columns[0]?.type).toBe('float32');
+  expect(metadata.spatial?.bounds).toEqual({minimum: [-10, 20], maximum: [30, 60]});
+  expect(metadata.levels?.map(level => level.width)).toEqual([1024, 512]);
+  expect(metadata.capabilities.levelOfDetail).toBe('pushdown');
+});
+
+test('GeoTIFFRasterSource checks scan metadata cancellation', async () => {
+  const source = new GeoTIFFRasterSource(new Blob([]), {});
+  const controller = new AbortController();
+  controller.abort();
+  await expect(source.getQueryMetadata({signal: controller.signal})).rejects.toThrow('aborted');
+});

--- a/modules/geotiff/test/ometiff-scan-source.spec.ts
+++ b/modules/geotiff/test/ometiff-scan-source.spec.ts
@@ -1,0 +1,34 @@
+import {expect, test} from 'vitest';
+import {OMETiffImageSource} from '../src/ometiff-source-loader';
+
+test('OMETiffImageSource exposes channel and pyramid scan metadata', async () => {
+  const source = new OMETiffImageSource(new Blob([]), {});
+  (source as unknown as {getMetadata: () => Promise<unknown>}).getMetadata = async () => ({
+    name: 'sample.ome.tiff',
+    width: 100,
+    height: 50,
+    bandCount: 2,
+    dtype: 'uint16',
+    sizeT: 3,
+    sizeZ: 1,
+    sizeC: 2,
+    labels: ['t', 'y', 'x', '_c'],
+    channels: [
+      {index: 0, name: 'DAPI'},
+      {index: 1, name: 'GFP'}
+    ],
+    levels: [
+      {level: 0, width: 100, height: 50},
+      {level: 1, width: 50, height: 25}
+    ],
+    metadata: {}
+  });
+  const metadata = await source.getQueryMetadata();
+  expect(metadata.sourceType).toBe('ometiff');
+  expect(metadata.columns.map(column => column.name)).toEqual(['DAPI', 'GFP']);
+  expect(metadata.capabilities.slices).toBe('pushdown');
+  expect(metadata.levels?.map(level => level.scale)).toEqual([
+    [1, 1],
+    [2, 2]
+  ]);
+});

--- a/modules/geotiff/test/ometiff-scan-source.spec.ts
+++ b/modules/geotiff/test/ometiff-scan-source.spec.ts
@@ -26,7 +26,7 @@ test('OMETiffImageSource exposes channel and pyramid scan metadata', async () =>
   const metadata = await source.getQueryMetadata();
   expect(metadata.sourceType).toBe('ometiff');
   expect(metadata.columns.map(column => column.name)).toEqual(['DAPI', 'GFP']);
-  expect(metadata.capabilities.slices).toBe('pushdown');
+  expect(metadata.capabilities.levelOfDetail).toBe('pushdown');
   expect(metadata.levels?.map(level => level.scale)).toEqual([
     [1, 1],
     [2, 2]

--- a/modules/zarr/src/geo-zarr-source-loader.ts
+++ b/modules/zarr/src/geo-zarr-source-loader.ts
@@ -12,10 +12,13 @@ import type {
   RasterData,
   RasterSource,
   RasterSourceMetadata,
-  SourceLoader
+  SourceLoader,
+  ScanQueryMetadata,
+  ScanQueryMetadataOptions,
+  ScanQueryMetadataProvider
 } from '@loaders.gl/loader-utils';
 import type {CRSDefinition} from '@math.gl/crs';
-import {getRasterViewportBoundingBox} from '@loaders.gl/loader-utils';
+import {createScanQueryMetadata, getRasterViewportBoundingBox} from '@loaders.gl/loader-utils';
 
 import type {SupportedTypedArray} from './types';
 import {
@@ -167,7 +170,9 @@ export const GeoZarrSourceLoader = {
 /** Viewport-driven raster source for GeoZarr and regular CF/xarray Zarr data variables. */
 export class GeoZarrRasterSource
   extends ZarrSource
-  implements RasterSource<RasterData, GetGeoZarrParameters, GeoZarrSourceMetadata>
+  implements
+    RasterSource<RasterData, GetGeoZarrParameters, GeoZarrSourceMetadata>,
+    ScanQueryMetadataProvider
 {
   /** Shared source initialization request. */
   private initializationPromise: Promise<GeoZarrInit> | null = null;
@@ -181,6 +186,31 @@ export class GeoZarrRasterSource
   async getMetadata(): Promise<GeoZarrSourceMetadata> {
     const {metadata} = await this.getInitializationPromise();
     return metadata;
+  }
+
+  /** Discovers GeoZarr variables, spatial bounds, and selectable dimensions. */
+  async getQueryMetadata(options: ScanQueryMetadataOptions = {}): Promise<ScanQueryMetadata> {
+    if (options.signal?.aborted) throw new DOMException('The operation was aborted', 'AbortError');
+    const metadata = await this.getMetadata();
+    if (options.signal?.aborted) throw new DOMException('The operation was aborted', 'AbortError');
+    const fields = [{name: metadata.array, type: metadata.dtype, nullable: true, metadata: {}}];
+    return createScanQueryMetadata({
+      sourceType: 'geozarr',
+      queryType: 'raster',
+      name: metadata.name,
+      schema: {fields, metadata: {}},
+      capabilities: {
+        bounds: 'pushdown',
+        levelOfDetail: 'unsupported',
+        variables: 'pushdown',
+        slices: metadata.selectionDimensions.length ? 'pushdown' : 'unsupported'
+      },
+      spatial: {
+        bounds: {minimum: metadata.boundingBox[0], maximum: metadata.boundingBox[1]},
+        coordinateReferenceSystems:
+          typeof metadata.crs === 'string' ? [metadata.crs] : undefined
+      }
+    });
   }
 
   /** Loads a clipped native-resolution 2D window for the requested viewport and named selection. */

--- a/modules/zarr/src/geo-zarr-source-loader.ts
+++ b/modules/zarr/src/geo-zarr-source-loader.ts
@@ -201,15 +201,15 @@ export class GeoZarrRasterSource
       schema: {fields, metadata: {}},
       capabilities: {
         bounds: 'pushdown',
-        levelOfDetail: 'unsupported',
-        variables: 'pushdown',
-        slices: metadata.selectionDimensions.length ? 'pushdown' : 'unsupported'
+        levelOfDetail: 'unsupported'
       },
-      spatial: {
-        bounds: {minimum: metadata.boundingBox[0], maximum: metadata.boundingBox[1]},
-        coordinateReferenceSystems:
-          typeof metadata.crs === 'string' ? [metadata.crs] : undefined
-      }
+      spatial: metadata.boundingBox
+        ? {
+            bounds: {minimum: metadata.boundingBox[0], maximum: metadata.boundingBox[1]},
+            coordinateReferenceSystems:
+              typeof metadata.crs === 'string' ? [metadata.crs] : undefined
+          }
+        : undefined
     });
   }
 

--- a/modules/zarr/test/geozarr-scan-source.spec.ts
+++ b/modules/zarr/test/geozarr-scan-source.spec.ts
@@ -20,7 +20,7 @@ test('GeoZarrRasterSource exposes scan metadata for variables and slices', async
   const metadata = await source.getQueryMetadata();
   expect(metadata.sourceType).toBe('geozarr');
   expect(metadata.columns.map(column => column.name)).toEqual(['temperature']);
-  expect(metadata.capabilities.slices).toBe('pushdown');
+  expect(metadata.capabilities.levelOfDetail).toBe('unsupported');
   expect(metadata.spatial?.coordinateReferenceSystems).toEqual(['EPSG:4326']);
 });
 

--- a/modules/zarr/test/geozarr-scan-source.spec.ts
+++ b/modules/zarr/test/geozarr-scan-source.spec.ts
@@ -1,0 +1,32 @@
+import {expect, test} from 'vitest';
+import {GeoZarrRasterSource} from '../src/geo-zarr-source-loader';
+
+test('GeoZarrRasterSource exposes scan metadata for variables and slices', async () => {
+  const source = new GeoZarrRasterSource('data.zarr', {});
+  (source as unknown as {getMetadata: () => Promise<unknown>}).getMetadata = async () => ({
+    name: 'temperature',
+    array: 'temperature',
+    width: 100,
+    height: 50,
+    bandCount: 1,
+    dtype: 'float32',
+    boundingBox: [
+      [0, 0],
+      [10, 5]
+    ],
+    crs: 'EPSG:4326',
+    selectionDimensions: [{name: 'time', size: 4, defaultIndex: 0}]
+  });
+  const metadata = await source.getQueryMetadata();
+  expect(metadata.sourceType).toBe('geozarr');
+  expect(metadata.columns.map(column => column.name)).toEqual(['temperature']);
+  expect(metadata.capabilities.slices).toBe('pushdown');
+  expect(metadata.spatial?.coordinateReferenceSystems).toEqual(['EPSG:4326']);
+});
+
+test('GeoZarrRasterSource checks scan metadata cancellation', async () => {
+  const source = new GeoZarrRasterSource('data.zarr', {});
+  const controller = new AbortController();
+  controller.abort();
+  await expect(source.getQueryMetadata({signal: controller.signal})).rejects.toThrow('aborted');
+});


### PR DESCRIPTION
## Goals

Make GeoTIFF/COG sources participate in the common scan architecture and power the source-neutral raster query panel from existing metadata.

## Changes

- Implement `ScanQueryMetadataProvider` on `GeoTIFFRasterSource`.
- Expose raster bands as panel-selectable fields with native sample types.
- Publish source bounds, overview levels, dataset name, and raster capability flags.
- Preserve the existing viewport-oriented `getRaster()` API and range-read behavior.
- Add cancellation checks and focused metadata tests.
- Document GeoTIFF scan metadata discovery for application developers.

## Validation

- Focused GeoTIFF scan tests: 4 passed.
- `git diff --check` clean.
- Lint/pre-commit formatting checks passed.