### PR TITLE
fix(parquet): apply logical ordering guard to page indexes

### DIFF
--- a/modules/parquet/src/parquetjs/encoder/parquet-encoder.ts
+++ b/modules/parquet/src/parquetjs/encoder/parquet-encoder.ts
@@ -856,14 +856,16 @@ async function encodeColumnChunk(
   const metadataOffset = baseOffset + pagesBuf.length + (bloomFilter?.length || 0);
   const metadataEncoded = serializeThrift(metadata);
   const offsetIndexOffset = pageIndexes ? metadataOffset + metadataEncoded.length : undefined;
-  const columnIndexOffset = pageIndexes
+  const columnIndexOffset = pageIndexes?.columnIndex
     ? metadataOffset + metadataEncoded.length + pageIndexes.offsetIndex.length
     : undefined;
   const body = concatUint8Arrays([
     pagesBuf,
     ...(bloomFilter ? [bloomFilter] : []),
     metadataEncoded,
-    ...(pageIndexes ? [pageIndexes.offsetIndex, pageIndexes.columnIndex] : [])
+    ...(pageIndexes
+      ? [pageIndexes.offsetIndex, ...(pageIndexes.columnIndex ? [pageIndexes.columnIndex] : [])]
+      : [])
   ]);
   return {
     body,
@@ -872,7 +874,7 @@ async function encodeColumnChunk(
     offsetIndexOffset,
     offsetIndexLength: pageIndexes?.offsetIndex.length,
     columnIndexOffset,
-    columnIndexLength: pageIndexes?.columnIndex.length
+    columnIndexLength: pageIndexes?.columnIndex?.length
   };
 }
 
@@ -881,15 +883,19 @@ function createColumnPageIndexes(
   column: ParquetField,
   plannedPages: ReturnType<typeof planColumnPages>,
   pageLocations: PageLocation[]
-): {offsetIndex: Uint8Array; columnIndex: Uint8Array} | undefined {
+): {offsetIndex: Uint8Array; columnIndex?: Uint8Array} | undefined {
   if (
     !column.primitiveType ||
     !isPageIndexPhysicalType(column.primitiveType) ||
-    !supportsStatisticsSortOrder(column) ||
     plannedPages.length !== pageLocations.length ||
     plannedPages.length === 0
   ) {
     return undefined;
+  }
+
+  const offsetIndex = serializeThrift(new OffsetIndex({page_locations: pageLocations}));
+  if (!supportsStatisticsSortOrder(column)) {
+    return {offsetIndex};
   }
 
   const nullPages: boolean[] = [];
@@ -917,7 +923,7 @@ function createColumnPageIndexes(
   }
 
   return {
-    offsetIndex: serializeThrift(new OffsetIndex({page_locations: pageLocations})),
+    offsetIndex,
     columnIndex: serializeThrift(
       new ColumnIndex({
         null_pages: nullPages,

--- a/modules/parquet/src/parquetjs/encoder/parquet-encoder.ts
+++ b/modules/parquet/src/parquetjs/encoder/parquet-encoder.ts
@@ -885,6 +885,7 @@ function createColumnPageIndexes(
   if (
     !column.primitiveType ||
     !isPageIndexPhysicalType(column.primitiveType) ||
+    !supportsStatisticsSortOrder(column) ||
     plannedPages.length !== pageLocations.length ||
     plannedPages.length === 0
   ) {

--- a/modules/parquet/test/parquet-size-statistics.spec.ts
+++ b/modules/parquet/test/parquet-size-statistics.spec.ts
@@ -152,7 +152,7 @@ test('ParquetJSWriter omits unsafe page indexes for unsigned logical values', as
   const column = metadata.row_groups[0].columns[0];
 
   expect(column.column_index_offset).toBeUndefined();
-  expect(column.offset_index_offset).toBeUndefined();
+  expect(column.offset_index_offset).toBeDefined();
 });
 
 test('ParquetJSWriter omits SizeStatistics by default', async () => {

--- a/modules/parquet/test/parquet-size-statistics.spec.ts
+++ b/modules/parquet/test/parquet-size-statistics.spec.ts
@@ -138,6 +138,23 @@ test('ParquetJSWriter emits page statistics for V1 and V2 data pages', async () 
   }
 });
 
+test('ParquetJSWriter omits unsafe page indexes for unsigned logical values', async () => {
+  const parquetBuffer = await encode(
+    {
+      shape: 'object-row-table',
+      schema: {fields: [{name: 'value', type: 'uint64', nullable: false}], metadata: {}},
+      data: [{value: 1n}, {value: 18_446_744_073_709_551_615n}]
+    } satisfies ObjectRowTable,
+    ParquetJSWriter,
+    {worker: false, parquet: {pageIndex: true}}
+  );
+  const metadata = await new ParquetReader(new BlobFile(parquetBuffer)).getFileMetadata();
+  const column = metadata.row_groups[0].columns[0];
+
+  expect(column.column_index_offset).toBeUndefined();
+  expect(column.offset_index_offset).toBeUndefined();
+});
+
 test('ParquetJSWriter omits SizeStatistics by default', async () => {
   const parquetBuffer = await encode(TABLE, ParquetJSWriter, {worker: false});
   const metadata = await new ParquetReader(new BlobFile(parquetBuffer)).getFileMetadata();


### PR DESCRIPTION
## Goal

Close the remaining review gap from landed Parquet statistics work: page indexes must obey the same logical-order safety rules as row-group and page-header statistics.

## Changes

- Skip column/offset index generation for logical values whose physical bounds cannot preserve logical ordering (including unsigned integers, FLOAT16, and byte/fixed decimals).
- Add a regression test proving unsigned logical columns do not publish unsafe page indexes.

## Validation

- `yarn test-headless modules/parquet/test/parquet-size-statistics.spec.ts modules/parquet/test/parquet-page-index-api.spec.ts`
- `yarn test-audit`
- `yarn lint fix`
- `git diff --check`

Follow-up to the review comment on merged #3745.