### PR TITLE
feat(las): range-read waveform sample payloads

### DIFF
--- a/docs/modules/las/README.md
+++ b/docs/modules/las/README.md
@@ -5,7 +5,7 @@ current LAS/LAZ projection-record support and vertical/compound CRS roadmap.
 
 The `@loaders.gl/las` module supports the [LASER file format](/docs/modules/las/formats/las) (LAS) and its compressed version (LAZ).
 
-`LASLoader` supports LAZ point formats 0-10 for documented LASzip codec combinations. Arrow output exposes positions, intensity, classification, RGB, GPS time, and NIR where present, while the raw APIs preserve complete supported point records. See the [LAS/LAZ implementation limits](/docs/modules/las/formats/las#current-implementation-limits) for exact codec, point-format, fixture, and streaming details.
+`LASLoader` supports LAZ point formats 0-10 for documented LASzip codec combinations. Arrow output exposes positions, intensity, classification, RGB, GPS time, NIR, waveform references, and Extra Bytes where present, while the raw APIs preserve complete supported point records. Waveform helpers range-read internal LAS or external WDP sample packets on demand. See the [LAS/LAZ implementation limits](/docs/modules/las/formats/las#current-implementation-limits) for exact codec, point-format, fixture, and streaming details.
 
 ## Installation
 

--- a/docs/modules/las/api-reference/las-loader.md
+++ b/docs/modules/las/api-reference/las-loader.md
@@ -70,9 +70,31 @@ Applications that need a compatibility loader in a worker can build one and prov
 
 ## TypeScript LAZ Streaming
 
-`LASLoader.parseInBatches` consumes compressed LAZ input incrementally. Legacy interleaved PDRF 0-5 chunks can emit complete Arrow batches before the current compressed chunk or file has finished arriving. Layered PDRF 6-10 table parsing emits after the compressed field ranges required by `las.columns` arrive. PDRF 9/10 waveform-reference rows can precede trailing Extra Bytes; raw or typed Extra Bytes are projected directly once their Byte14 layers arrive. Complete-buffer `parse` uses the same direct-column path instead of allocating and reparsing complete raw records. Legacy Point10/GPS/RGB/Byte item version 2, WavePacket13 item version 1, and modern item versions 2-4 are supported. Legacy LASzip item version 1 uses a different codec and is rejected. `GPS_TIME`, `NIR`, `synthetic`, `keyPoint`, `withheld`, `overlap`, `scanAngle`, `userData`, `pointSourceId`, `returnNumber`, `numberOfReturns`, `scannerChannel`, `scanDirectionFlag`, and `edgeOfFlightLine` are available as typed Arrow columns for records that contain them. Legacy PDRF 0-5 records report `overlap` as zero because that flag was introduced with PDRF 6. `WAVEFORM` exposes PDRF 4/5/9/10 packet references as fixed-width 29-byte rows. `EXTRA_BYTES` exposes raw bytes by default, or descriptor-defined numeric attributes through `las.extraBytes: 'typed'`. Waveform sample payloads are not loaded. The raw chunk decoder remains available when complete LAS point records, including currently unexposed fields, are required.
+`LASLoader.parseInBatches` consumes compressed LAZ input incrementally. Legacy interleaved PDRF 0-5 chunks can emit complete Arrow batches before the current compressed chunk or file has finished arriving. Layered PDRF 6-10 table parsing emits after the compressed field ranges required by `las.columns` arrive. PDRF 9/10 waveform-reference rows can precede trailing Extra Bytes; raw or typed Extra Bytes are projected directly once their Byte14 layers arrive. Complete-buffer `parse` uses the same direct-column path instead of allocating and reparsing complete raw records. Legacy Point10/GPS/RGB/Byte item version 2, WavePacket13 item version 1, and modern item versions 2-4 are supported. Legacy LASzip item version 1 uses a different codec and is rejected. `GPS_TIME`, `NIR`, `synthetic`, `keyPoint`, `withheld`, `overlap`, `scanAngle`, `userData`, `pointSourceId`, `returnNumber`, `numberOfReturns`, `scannerChannel`, `scanDirectionFlag`, and `edgeOfFlightLine` are available as typed Arrow columns for records that contain them. Legacy PDRF 0-5 records report `overlap` as zero because that flag was introduced with PDRF 6. `WAVEFORM` exposes PDRF 4/5/9/10 packet references as fixed-width 29-byte rows. `EXTRA_BYTES` exposes raw bytes by default, or descriptor-defined numeric attributes through `las.extraBytes: 'typed'`. Waveform sample payloads are loaded separately through the range APIs below. The raw chunk decoder remains available when complete LAS point records, including currently unexposed fields, are required.
 
 Atomic TypeScript parses attach typed file metadata to `loaderData.metadata`. This includes the public header identity and creation fields, raw VLR and EVLR records, Extra Bytes descriptors, waveform packet descriptors, WKT projection records, and GeoTIFF payloads. EVLR payloads are retained when they are present in the supplied complete buffer; streaming batches expose the header before later EVLR data is available.
+
+## Waveform Sample Access
+
+PDRF 4, 5, 9, and 10 store a fixed-width packet reference with each point, while the variable-length sample packet lives in an internal LAS waveform data record or a companion WDP file. The loader keeps the exact uint64 packet offset in the `WAVEFORM` Arrow column. Waveform helpers parse that reference and issue a byte-range read only when samples are requested:
+
+```typescript
+import {
+  parseLASWaveformPacketReference,
+  readLASWaveformPacket
+} from '@loaders.gl/las';
+import {HttpFile} from '@loaders.gl/loader-utils';
+
+const metadata = table.loaderData.metadata;
+const waveformRow = table.data.getChild('WAVEFORM').get(pointIndex);
+const reference = parseLASWaveformPacketReference(Uint8Array.from(waveformRow));
+
+// Use the LAS URL for internal data or the companion WDP URL for external data.
+const waveformSource = new HttpFile(waveformUrl);
+const packet = await readLASWaveformPacket(waveformSource, reference, metadata);
+```
+
+`packet.samples` contains unsigned integer samples and `packet.amplitudes` applies the descriptor's digitizer gain and offset. `readLASWaveformPackets` performs bounded concurrent range reads while preserving reference order. The standard LAS waveform compression type 0 and sample widths from 2 through 32 bits are supported; nonzero waveform compression types are rejected. Packet offsets remain `bigint` throughout.
 
 For layered PDRF 6-10 chunks, omitted intensity, classification, RGB, GPS time, and NIR columns do not allocate output arrays or construct arithmetic decoders for those independent layers. Legacy PDRF 0-5 fields share an interleaved entropy stream, so column selection avoids output allocation and extraction but cannot skip the corresponding entropy decoding.
 

--- a/docs/modules/las/formats/las.md
+++ b/docs/modules/las/formats/las.md
@@ -35,10 +35,10 @@ LAS file versions and LASzip codec versions are independent. A claim such as "LA
 | GPS time | Exposed as `GPS_TIME` for PDRF 1, 3-5, and 6-10. |
 | NIR | Exposed as `NIR` for PDRF 8 and 10. |
 | Classification, return, and scanner flags | `synthetic`, `keyPoint`, `withheld`, `overlap`, return fields, flight-line flags, and scanner channel are exposed as typed Arrow columns. Legacy PDRF 0-5 records report `overlap` as zero. |
-| Waveform packet fields | PDRF 4/5/9/10 packet references are exposed as the optional fixed-width `WAVEFORM` Arrow column. Waveform sample payload handling is not implemented. |
+| Waveform packet fields | PDRF 4/5/9/10 packet references are exposed as the optional fixed-width `WAVEFORM` Arrow column. Exact uint64 offsets, waveform descriptor VLRs, internal LAS and external WDP range reads, 2-32-bit uncompressed samples, and descriptor-scaled amplitudes are supported through the waveform helper APIs. |
 | Extra bytes | Extra Bytes VLR descriptors are exposed as typed metadata; the raw per-point payload is available through `EXTRA_BYTES`, or descriptor-defined numeric attributes through `las.extraBytes: 'typed'`. Scalar data types 1-6 and 9-10 plus deprecated 2-component and 3-component vector codes based on those scalar types are supported with per-component descriptor scale/offset. 64-bit integer types 7-8 and vector codes based on them remain raw-only. Raw Extra Bytes are opt-in when `las.columns` is omitted; list `EXTRA_BYTES` explicitly. Typed Extra Bytes are included by default when `las.extraBytes: 'typed'` and `las.columns` is omitted. |
 | VLRs, EVLRs, CRS, WKT, GeoTIFF records | VLRs and complete EVLRs are preserved in metadata. WKT CRS records (coordinate-system and math-transform), GeoTIFF CRS payloads and resolved GeoKey entries, Extra Bytes, waveform descriptors, and LASzip records are recognized. Full CRS reprojection is outside the loader. |
-| `parseInBatches` | Incremental for uncompressed LAS and fixed-size LAZ chunks. Legacy LAZ preserves arithmetic and item state across input chunks without replay; layered PDRF 6-10 emits selected Arrow rows once their required layers arrive. Waveform references do not wait for trailing Extra Bytes, while raw or typed Extra Bytes become ready after their Byte14 layers arrive. |
+| `parseInBatches` | Incremental for uncompressed LAS and fixed-size LAZ chunks. Legacy LAZ preserves arithmetic and item state across input chunks without replay; layered PDRF 6-10 emits selected Arrow rows once their required layers arrive. Waveform references do not wait for trailing Extra Bytes, while raw or typed Extra Bytes become ready after their Byte14 layers arrive. Variable-length waveform samples are intentionally separate range reads. |
 
 ### TypeScript LAS Writer
 
@@ -122,7 +122,7 @@ Compressed field layers are decoded as bounded ranges of the original chunk inst
 
 `decodeLAZChunk()` and the raw cursor API continue to decode every field and return complete LAS point records byte-for-byte. A cursor cannot switch between raw and selective output, or change its selected fields, after decoding starts because skipped arithmetic streams cannot be resumed at the corresponding point.
 
-Dedicated PDRF 4-10 fixtures compare every raw decoded byte and every represented Arrow attribute against matching uncompressed LAS records. LASzip-generated PDRF 4/5 fixtures validate legacy WavePacket13 and PDRF 5 field ordering. A current-LASzip PDRF 7 fixture verifies Point14, RGB14, and Byte14 item version 4 across all four scanner-channel contexts while retaining a LAS 1.4 header. The bundled COPC decoder misdecodes that fixture's RGB values after scanner-channel changes, and bundled laz-rs rejects item version 4, so current LASzip plus uncompressed LAS provide its correctness oracle. PDRF 8 coverage includes NIR, GPS time, Extra Bytes, and scanner-channel transitions. PDRF 9/10 coverage exercises all waveform-offset predictor modes, exact 64-bit offsets above `Number.MAX_SAFE_INTEGER`, packet sizes, float vector fields, GPS time, NIR, and Extra Bytes. LASzip-generated LAS 1.5 PDRF 9/10 fixtures additionally verify item version 4 across all four scanner-channel contexts. The `WAVEFORM` column is populated from the lossless packet reference bytes; waveform sample payloads and Extra Bytes remain separate follow-up representations.
+Dedicated PDRF 4-10 fixtures compare every raw decoded byte and every represented Arrow attribute against matching uncompressed LAS records. LASzip-generated PDRF 4/5 fixtures validate legacy WavePacket13 and PDRF 5 field ordering. A current-LASzip PDRF 7 fixture verifies Point14, RGB14, and Byte14 item version 4 across all four scanner-channel contexts while retaining a LAS 1.4 header. The bundled COPC decoder misdecodes that fixture's RGB values after scanner-channel changes, and bundled laz-rs rejects item version 4, so current LASzip plus uncompressed LAS provide its correctness oracle. PDRF 8 coverage includes NIR, GPS time, Extra Bytes, and scanner-channel transitions. PDRF 9/10 coverage exercises all waveform-offset predictor modes, exact 64-bit offsets above `Number.MAX_SAFE_INTEGER`, packet sizes, float vector fields, GPS time, NIR, and Extra Bytes. LASzip-generated LAS 1.5 PDRF 9/10 fixtures additionally verify item version 4 across all four scanner-channel contexts. The `WAVEFORM` column is populated from the lossless packet reference bytes; sample payloads remain separate on-demand range reads instead of variable-width point-table columns.
 
 The slow conformance lane feeds PDRF 4-10 fixtures through multiple seeded arbitrary byte boundaries and compares every decoded point byte with independently generated uncompressed LAS records. It also rejects malformed headers, point-data offsets, chunk-table pointers, and truncated chunk tables. Fixed-chunk parsing validates the trailing chunk table after progressive point delivery, so a malformed file cannot complete successfully even when its point layers were independently decodable. The reader also supports LASzip's legal `-1` pointer layout for non-seekable writers, validates the table at the decoded fixed-chunk boundary, and verifies that the final eight-byte footer points back to that table without retaining intervening EVLR data.
 
@@ -163,7 +163,7 @@ LAS 1.5 does not change the basic LAS idea: the public header identifies the fil
 | LAS 1.5 uncompressed PDRF 9-10 | Yes | Raw point readers for waveform packet reference fields. |
 | LAZ 1.5 PDRF 6-8 | Yes, by compressed chunk | LASzip item version 4 context switching is supported; broader LAS 1.5 fixture coverage remains desirable. |
 | LAZ 1.5 PDRF 9-10 | Yes, at layered field boundaries | PDRF 9 and 10 item version 4 are validated across all scanner channels. Selected waveform references can be emitted before trailing Extra Bytes and are preserved byte-for-byte. |
-| LAS/LAZ 1.5 waveform payload bytes | Partial | Preserve point references first; waveform payload EVLR or external WDP streaming is separate follow-up work. |
+| LAS/LAZ 1.5 waveform payload bytes | Yes, on demand | Exact packet references select waveform descriptor VLRs and range-read internal LAS or external WDP packet bytes. Compression type 0 and sample widths 2-32 bits are decoded and scaled. |
 
 ## LAS 1.4
 
@@ -228,6 +228,20 @@ Notes:
 | 9 | LAS 1.4 | PDRF 6 + waveform packet reference. |
 | 10 | LAS 1.4 | PDRF 7 + waveform packet reference. |
 
+## Waveform Packet Layout
+
+PDRF 4, 5, 9, and 10 append a 29-byte reference to each point record. The reference contains a waveform descriptor index, an unsigned 64-bit packet offset, packet byte length, return-point location, and three parametric direction values. Descriptor index `n` selects the `LASF_Spec` waveform descriptor VLR with record ID `n + 99`; index zero means that the point has no waveform packet.
+
+LAS global-encoding bit 1 selects waveform data stored inside the LAS file and bit 2 selects a companion WDP file. These bits are mutually exclusive. For internal data, a packet's absolute file position is:
+
+```text
+public-header waveform data offset + point-record waveform packet offset
+```
+
+For external WDP data, the point-record offset is already relative to the beginning of the WDP waveform data packet record. `readLASWaveformPacket` applies the correct rule and uses `ReadableFile.read()` to request only the packet range. Supply the LAS source for internal storage or the companion WDP source for external storage.
+
+Waveform descriptor compression type 0 stores unsigned samples without an additional waveform codec. The TypeScript helper decodes 2-32-bit little-endian packed samples and exposes both raw integer values and amplitudes calculated as `digitizerOffset + digitizerGain * sample`. Nonzero waveform compression types are not supported. Packet references and public-header offsets remain `bigint`, including values above `Number.MAX_SAFE_INTEGER`.
+
 ## COPC Range Layout
 
 COPC is a LAZ 1.4 file with additional layout rules that make it efficient for HTTP range requests and other random-access readers. A COPC file must use PDRF 6, 7, or 8, must contain a COPC `info` VLR, and must contain a COPC `hierarchy` VLR.
@@ -246,9 +260,8 @@ A range-aware COPC reader first reads the LAS header and COPC VLRs, then reads t
 
 ## Remaining Roadmap
 
-Within the documented version, PDRF, and codec matrix, the TypeScript implementation now covers complete-file LAS/LAZ parsing, PDRF 0-10 point records, fixed and variable LAZ chunk tables, stateful legacy and selective layered streaming, progressive PDRF 6-10 delivery, direct raw and typed Extra Bytes projection, classification flags, LAZ writing, native COPC hierarchy and range parsing, bounded parallel COPC node decoding through the single TypeScript LAS worker, independently validated paged COPC writing, seeded split conformance, malformed-input handling, and memory and throughput regression gates. The remaining work is ordered by value to the primary LAS 1.4 and COPC rendering path.
+Within the documented version, PDRF, and codec matrix, the TypeScript implementation now covers complete-file LAS/LAZ parsing, PDRF 0-10 point records, fixed and variable LAZ chunk tables, stateful legacy and selective layered streaming, progressive PDRF 6-10 delivery, direct raw and typed Extra Bytes projection, classification flags, on-demand internal LAS and external WDP waveform sample access, LAZ writing, native COPC hierarchy and range parsing, bounded parallel COPC node decoding through the single TypeScript LAS worker, independently validated paged COPC writing, seeded split conformance, malformed-input handling, and memory and throughput regression gates. The remaining format work is broader LAS 1.5 conformance rather than the primary LAS 1.4/COPC rendering path.
 
 | Order | Work item | Impact | Cost | Acceptance target |
 | --- | --- | --- | --- | --- |
-| 1 | Add waveform sample payload access | Low for COPC, specialized elsewhere | High | Range-read internal waveform EVLRs and external WDP data, apply waveform descriptors, and expose samples without losing exact packet-reference offsets. |
-| 2 | Complete LAS 1.5 conformance and writing | Medium | Medium | Enforce LAS 1.5 header, WKT, and PDRF rules; add broader fixtures; and emit LAS 1.5 only after independent-reader interoperability is demonstrated. |
+| 1 | Complete LAS 1.5 conformance and writing | Medium | Medium | Enforce LAS 1.5 header, WKT, and PDRF rules; add broader fixtures; and emit LAS 1.5 only after independent-reader interoperability is demonstrated. |

--- a/modules/las/src/bundled.ts
+++ b/modules/las/src/bundled.ts
@@ -10,6 +10,20 @@ export {LAZPerfLoaderWithParser as LAZPerfLoader} from './lazperf-loader';
 export {LAZRsLoaderWithParser as LAZRsLoader} from './laz-rs-loader';
 export {decodeLAZFileInBatches} from './lib/typescript/parse-las';
 export {
+  decodeLASWaveformSamples,
+  getLASWaveformStorage,
+  parseLASWaveformPacketReference,
+  readLASWaveformPacket,
+  readLASWaveformPackets,
+  scaleLASWaveformSamples
+} from './lib/las-waveform';
+export type {
+  LASWaveformPacket,
+  LASWaveformPacketReference,
+  LASWaveformReadOptions,
+  LASWaveformStorage
+} from './lib/las-waveform';
+export {
   NeedsMoreData,
   createLAZChunkDecoder,
   createLAZChunkEncoder,

--- a/modules/las/src/index.ts
+++ b/modules/las/src/index.ts
@@ -21,6 +21,20 @@ export type {
   LASWaveformPacketDescriptor
 } from './lib/las-types';
 export {
+  decodeLASWaveformSamples,
+  getLASWaveformStorage,
+  parseLASWaveformPacketReference,
+  readLASWaveformPacket,
+  readLASWaveformPackets,
+  scaleLASWaveformSamples
+} from './lib/las-waveform';
+export type {
+  LASWaveformPacket,
+  LASWaveformPacketReference,
+  LASWaveformReadOptions,
+  LASWaveformStorage
+} from './lib/las-waveform';
+export {
   createLASTypedExtraBytesAttributes,
   createLASTypedExtraBytesValue,
   parseLASExtraBytes,

--- a/modules/las/src/lib/las-types.ts
+++ b/modules/las/src/lib/las-types.ts
@@ -113,6 +113,8 @@ export type LASMetadata = {
   fileSourceId: number;
   /** Global encoding bit field from the public header. */
   globalEncoding: number;
+  /** Start of the internal waveform data packet record, preserved as an exact uint64. */
+  waveformDataOffset?: bigint;
   /** Project identifier as a UUID string. */
   projectId: string;
   /** System identifier string. */

--- a/modules/las/src/lib/las-waveform.ts
+++ b/modules/las/src/lib/las-waveform.ts
@@ -1,0 +1,290 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {ReadableFile} from '@loaders.gl/loader-utils';
+import type {LASMetadata, LASWaveformPacketDescriptor} from './las-types';
+
+const WAVEFORM_PACKET_REFERENCE_BYTE_LENGTH = 29;
+const INTERNAL_WAVEFORM_DATA_MASK = 1 << 1;
+const EXTERNAL_WAVEFORM_DATA_MASK = 1 << 2;
+
+/** Location of waveform packet data selected by the LAS global-encoding field. */
+export type LASWaveformStorage = 'internal' | 'external';
+
+/** Lossless fields stored in one PDRF 4, 5, 9, or 10 waveform packet reference. */
+export type LASWaveformPacketReference = {
+  /** Waveform descriptor index; descriptor VLR record id is this value plus 99. */
+  descriptorIndex: number;
+  /** Packet byte offset relative to the waveform data packet record. */
+  byteOffset: bigint;
+  /** Packet byte length. */
+  byteLength: number;
+  /** Temporal offset in picoseconds from the waveform anchor to this return. */
+  returnPointLocation: number;
+  /** Parametric XYZ offsets per picosecond. */
+  parametricOffset: [number, number, number];
+};
+
+/** Decoded waveform packet and the metadata required to interpret its samples. */
+export type LASWaveformPacket = {
+  /** Original lossless point-record reference. */
+  reference: LASWaveformPacketReference;
+  /** Descriptor selected by the packet reference. */
+  descriptor: LASWaveformPacketDescriptor;
+  /** Absolute byte offset read from the supplied LAS or WDP source. */
+  sourceByteOffset: bigint;
+  /** Exact packet bytes read from the source. */
+  data: Uint8Array;
+  /** Unsigned integer sample values decoded from the packet. */
+  samples: Uint32Array;
+  /** Sample amplitudes after applying descriptor gain and offset. */
+  amplitudes: Float64Array;
+};
+
+/** Options for waveform packet range reads. */
+export type LASWaveformReadOptions = {
+  /** Abort signal forwarded to the underlying range read. */
+  signal?: AbortSignal;
+  /** Maximum simultaneous reads used by `readLASWaveformPackets`. */
+  concurrency?: number;
+};
+
+/**
+ * Parses one fixed-width LAS waveform packet reference without losing its 64-bit offset.
+ * @param data Buffer or view containing the reference.
+ * @param byteOffset Byte offset of the reference within `data`.
+ * @returns Parsed packet reference.
+ */
+export function parseLASWaveformPacketReference(
+  data: ArrayBuffer | ArrayBufferView,
+  byteOffset = 0
+): LASWaveformPacketReference {
+  const bytes = getUint8Array(data);
+  if (
+    !Number.isInteger(byteOffset) ||
+    byteOffset < 0 ||
+    byteOffset + WAVEFORM_PACKET_REFERENCE_BYTE_LENGTH > bytes.byteLength
+  ) {
+    throw new Error('LAS waveform packet reference is truncated');
+  }
+  const dataView = new DataView(
+    bytes.buffer,
+    bytes.byteOffset + byteOffset,
+    WAVEFORM_PACKET_REFERENCE_BYTE_LENGTH
+  );
+  return {
+    descriptorIndex: dataView.getUint8(0),
+    byteOffset: dataView.getBigUint64(1, true),
+    byteLength: dataView.getUint32(9, true),
+    returnPointLocation: dataView.getFloat32(13, true),
+    parametricOffset: [
+      dataView.getFloat32(17, true),
+      dataView.getFloat32(21, true),
+      dataView.getFloat32(25, true)
+    ]
+  };
+}
+
+/**
+ * Returns the waveform storage selected by LAS global-encoding bits.
+ * @param metadata Parsed LAS metadata.
+ * @returns Internal or external storage, or `null` when the file declares neither.
+ */
+export function getLASWaveformStorage(metadata: LASMetadata): LASWaveformStorage | null {
+  const hasInternalData = Boolean(metadata.globalEncoding & INTERNAL_WAVEFORM_DATA_MASK);
+  const hasExternalData = Boolean(metadata.globalEncoding & EXTERNAL_WAVEFORM_DATA_MASK);
+  if (hasInternalData && hasExternalData) {
+    throw new Error('LAS waveform data cannot be both internal and external');
+  }
+  return hasInternalData ? 'internal' : hasExternalData ? 'external' : null;
+}
+
+/**
+ * Decodes uncompressed 2-32 bit LAS waveform samples.
+ * @param data Exact waveform packet bytes.
+ * @param descriptor Waveform descriptor selected by the point record.
+ * @returns Unsigned integer waveform samples.
+ */
+export function decodeLASWaveformSamples(
+  data: Uint8Array,
+  descriptor: LASWaveformPacketDescriptor
+): Uint32Array {
+  const requiredByteLength = validateLASWaveformDescriptor(descriptor);
+  if (data.byteLength < requiredByteLength) {
+    throw new Error(
+      `LAS waveform packet is truncated: expected ${requiredByteLength} bytes, received ${data.byteLength}`
+    );
+  }
+
+  const bitsPerSample = descriptor.bitsPerSample;
+  const samples = new Uint32Array(descriptor.numberOfSamples);
+  const sampleDivisor = 2 ** bitsPerSample;
+  let bitBuffer = 0;
+  let availableBitCount = 0;
+  let sourceByteIndex = 0;
+  for (let sampleIndex = 0; sampleIndex < samples.length; sampleIndex++) {
+    while (availableBitCount < bitsPerSample) {
+      bitBuffer += data[sourceByteIndex++] * 2 ** availableBitCount;
+      availableBitCount += 8;
+    }
+    samples[sampleIndex] = bitBuffer % sampleDivisor;
+    bitBuffer = Math.floor(bitBuffer / sampleDivisor);
+    availableBitCount -= bitsPerSample;
+  }
+  return samples;
+}
+
+/** Validates one waveform descriptor and returns its uncompressed packet byte length. */
+function validateLASWaveformDescriptor(descriptor: LASWaveformPacketDescriptor): number {
+  if (descriptor.compressionType !== 0) {
+    throw new Error(`LAS waveform compression type ${descriptor.compressionType} is not supported`);
+  }
+  const bitsPerSample = descriptor.bitsPerSample;
+  if (!Number.isInteger(bitsPerSample) || bitsPerSample < 2 || bitsPerSample > 32) {
+    throw new Error(
+      `LAS waveform bits per sample must be between 2 and 32; received ${bitsPerSample}`
+    );
+  }
+  if (!Number.isInteger(descriptor.numberOfSamples) || descriptor.numberOfSamples < 0) {
+    throw new Error(`LAS waveform sample count ${descriptor.numberOfSamples} is invalid`);
+  }
+  const requiredByteLength = Math.ceil((descriptor.numberOfSamples * bitsPerSample) / 8);
+  if (!Number.isSafeInteger(requiredByteLength) || requiredByteLength < 0) {
+    throw new Error(`LAS waveform sample count ${descriptor.numberOfSamples} is invalid`);
+  }
+  return requiredByteLength;
+}
+
+/**
+ * Applies waveform descriptor gain and offset to integer samples.
+ * @param samples Unsigned integer waveform samples.
+ * @param descriptor Waveform descriptor containing gain and offset.
+ * @returns Scaled sample amplitudes.
+ */
+export function scaleLASWaveformSamples(
+  samples: Uint32Array,
+  descriptor: LASWaveformPacketDescriptor
+): Float64Array {
+  const amplitudes = new Float64Array(samples.length);
+  for (let sampleIndex = 0; sampleIndex < samples.length; sampleIndex++) {
+    amplitudes[sampleIndex] =
+      descriptor.digitizerOffset + descriptor.digitizerGain * samples[sampleIndex];
+  }
+  return amplitudes;
+}
+
+/**
+ * Range-reads and decodes one internal LAS or external WDP waveform packet.
+ *
+ * Supply the LAS file when `metadata.globalEncoding` declares internal waveform data and the
+ * companion WDP file when it declares external waveform data.
+ *
+ * @param source Random-access LAS or WDP source selected by the file's global-encoding field.
+ * @param reference Lossless waveform packet reference from a point record.
+ * @param metadata Parsed metadata from the owning LAS file.
+ * @param options Range-read options.
+ * @returns Decoded waveform packet.
+ */
+export async function readLASWaveformPacket(
+  source: ReadableFile,
+  reference: LASWaveformPacketReference,
+  metadata: LASMetadata,
+  options: LASWaveformReadOptions = {}
+): Promise<LASWaveformPacket> {
+  const storage = getLASWaveformStorage(metadata);
+  if (!storage) {
+    throw new Error('LAS file does not declare internal or external waveform data');
+  }
+  if (reference.descriptorIndex === 0) {
+    throw new Error('LAS waveform descriptor index 0 does not reference a waveform packet');
+  }
+  const descriptorRecordId = reference.descriptorIndex + 99;
+  const descriptor = metadata.waveformPacketDescriptors.find(
+    candidate => candidate.recordId === descriptorRecordId
+  );
+  if (!descriptor) {
+    throw new Error(`LAS waveform descriptor VLR ${descriptorRecordId} is missing`);
+  }
+  const requiredByteLength = validateLASWaveformDescriptor(descriptor);
+  if (!Number.isInteger(reference.byteLength) || reference.byteLength < requiredByteLength) {
+    throw new Error(
+      `LAS waveform packet size ${reference.byteLength} is smaller than the descriptor requires (${requiredByteLength})`
+    );
+  }
+  const sourceByteOffset =
+    storage === 'internal'
+      ? getInternalWaveformSourceOffset(metadata) + reference.byteOffset
+      : reference.byteOffset;
+  const arrayBuffer = await source.read(sourceByteOffset, reference.byteLength, options.signal);
+  if (arrayBuffer.byteLength !== reference.byteLength) {
+    throw new Error(
+      `LAS waveform range read returned ${arrayBuffer.byteLength} bytes; expected ${reference.byteLength}`
+    );
+  }
+  const data = new Uint8Array(arrayBuffer);
+  const samples = decodeLASWaveformSamples(data, descriptor);
+  return {
+    reference,
+    descriptor,
+    sourceByteOffset,
+    data,
+    samples,
+    amplitudes: scaleLASWaveformSamples(samples, descriptor)
+  };
+}
+
+/**
+ * Range-reads multiple waveform packets with bounded concurrency.
+ * @param source Random-access LAS or WDP source selected by the file's global-encoding field.
+ * @param references Waveform packet references in desired result order.
+ * @param metadata Parsed metadata from the owning LAS file.
+ * @param options Range-read and concurrency options.
+ * @returns Decoded waveform packets in input order.
+ */
+export async function readLASWaveformPackets(
+  source: ReadableFile,
+  references: Iterable<LASWaveformPacketReference>,
+  metadata: LASMetadata,
+  options: LASWaveformReadOptions = {}
+): Promise<LASWaveformPacket[]> {
+  const referenceArray = Array.from(references);
+  const concurrency = options.concurrency ?? 8;
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    throw new Error(
+      `LAS waveform read concurrency must be a positive integer; received ${concurrency}`
+    );
+  }
+  const packets = new Array<LASWaveformPacket>(referenceArray.length);
+  let nextReferenceIndex = 0;
+
+  /** Reads packet references from the shared index until none remain. */
+  const readNextPackets = async (): Promise<void> => {
+    while (nextReferenceIndex < referenceArray.length) {
+      const referenceIndex = nextReferenceIndex++;
+      packets[referenceIndex] = await readLASWaveformPacket(
+        source,
+        referenceArray[referenceIndex],
+        metadata,
+        options
+      );
+    }
+  };
+
+  const workerCount = Math.min(concurrency, referenceArray.length);
+  await Promise.all(Array.from({length: workerCount}, () => readNextPackets()));
+  return packets;
+}
+
+function getInternalWaveformSourceOffset(metadata: LASMetadata): bigint {
+  if (metadata.waveformDataOffset === undefined) {
+    throw new Error('LAS internal waveform data offset is missing from the public header');
+  }
+  return metadata.waveformDataOffset;
+}
+
+function getUint8Array(data: ArrayBuffer | ArrayBufferView): Uint8Array {
+  return data instanceof ArrayBuffer
+    ? new Uint8Array(data)
+    : new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+}

--- a/modules/las/src/lib/las-waveform.ts
+++ b/modules/las/src/lib/las-waveform.ts
@@ -276,6 +276,7 @@ export async function readLASWaveformPackets(
   return packets;
 }
 
+/** Return the exact internal waveform packet-record base offset from the LAS public header. */
 function getInternalWaveformSourceOffset(metadata: LASMetadata): bigint {
   if (metadata.waveformDataOffset === undefined) {
     throw new Error('LAS internal waveform data offset is missing from the public header');
@@ -283,6 +284,7 @@ function getInternalWaveformSourceOffset(metadata: LASMetadata): bigint {
   return metadata.waveformDataOffset;
 }
 
+/** Create a byte view that preserves an input view's byte offset and byte length. */
 function getUint8Array(data: ArrayBuffer | ArrayBufferView): Uint8Array {
   return data instanceof ArrayBuffer
     ? new Uint8Array(data)

--- a/modules/las/src/lib/typescript/parse-las.ts
+++ b/modules/las/src/lib/typescript/parse-las.ts
@@ -994,6 +994,10 @@ function parseLASMetadata(arrayBuffer: ArrayBufferLike, header: LASHeader): LASM
   const metadata: LASMetadata = {
     fileSourceId: dataView.getUint16(4, true),
     globalEncoding: dataView.getUint16(6, true),
+    waveformDataOffset:
+      versionParts[0] > 1 || (versionParts[0] === 1 && versionParts[1] >= 3)
+        ? dataView.getBigUint64(227, true)
+        : undefined,
     projectId: formatLASProjectId(new Uint8Array(arrayBuffer, 8, 16)),
     systemIdentifier: readLASString(new Uint8Array(arrayBuffer), 26, 32),
     generatingSoftware: readLASString(new Uint8Array(arrayBuffer), 58, 32),
@@ -1093,7 +1097,7 @@ function parseTypedLASMetadataRecord(
   }
   if (record.userId === 'LASF_Spec' && record.recordId === 4) {
     metadata.extraBytes.push(...parseLASExtraBytes(data));
-  } else if (record.userId === 'LASF_Spec' && record.recordId >= 100 && record.recordId <= 355) {
+  } else if (record.userId === 'LASF_Spec' && record.recordId >= 100 && record.recordId <= 354) {
     metadata.waveformPacketDescriptors.push(parseLASWaveformDescriptor(record.recordId, data));
   } else if (record.userId === 'LASF_Projection' && record.recordId === 2111) {
     metadata.wktMathTransform = decodeLASString(data);
@@ -1689,9 +1693,9 @@ function getColorOffset(pointsFormatId: number): number {
 function getWaveformOffset(pointsFormatId: number): number {
   switch (pointsFormatId) {
     case 4:
-      return 29;
+      return 28;
     case 5:
-      return 35;
+      return 34;
     case 9:
       return 30;
     case 10:

--- a/modules/las/src/unbundled.ts
+++ b/modules/las/src/unbundled.ts
@@ -9,6 +9,20 @@ export {LAZPerfLoader} from './lazperf-loader-types';
 export {LAZRsLoader} from './laz-rs-loader-types';
 export {decodeLAZFileInBatches} from './lib/typescript/parse-las';
 export {
+  decodeLASWaveformSamples,
+  getLASWaveformStorage,
+  parseLASWaveformPacketReference,
+  readLASWaveformPacket,
+  readLASWaveformPackets,
+  scaleLASWaveformSamples
+} from './lib/las-waveform';
+export type {
+  LASWaveformPacket,
+  LASWaveformPacketReference,
+  LASWaveformReadOptions,
+  LASWaveformStorage
+} from './lib/las-waveform';
+export {
   NeedsMoreData,
   createLAZChunkDecoder,
   createLAZChunkEncoder,

--- a/modules/las/test/las-loader.spec.ts
+++ b/modules/las/test/las-loader.spec.ts
@@ -744,6 +744,7 @@ test('LASLoader#metadata parses LAS 1.4 CRS and waveform records', () => {
   dataView.setUint16(94, headerSize, true);
   dataView.setUint32(96, pointsOffset, true);
   dataView.setUint32(100, records.length, true);
+  dataView.setBigUint64(227, 0x123456789abcdef0n, true);
   bytes[104] = 0;
   dataView.setUint16(105, 20, true);
   bytes.set(Uint8Array.from([0x78, 0x56, 0x34, 0x12, 0x34, 0x12, 0x78, 0x56]), 8);
@@ -756,6 +757,7 @@ test('LASLoader#metadata parses LAS 1.4 CRS and waveform records', () => {
 
   const metadata = parseLASHeader(arrayBuffer).metadata!;
   expect(metadata.projectId).toBe('12345678-1234-5678-9abcdef012345678');
+  expect(metadata.waveformDataOffset).toBe(0x123456789abcdef0n);
   expect(metadata.wkt).toBe('GEOGCS["coordinate-system"]');
   expect(metadata.wktMathTransform).toBe('PARAM_MT["transform"]');
   expect(metadata.geotiff?.keys).toEqual(

--- a/modules/las/test/las-waveform.spec.ts
+++ b/modules/las/test/las-waveform.spec.ts
@@ -1,0 +1,333 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+import {ArrayBufferFile, type ReadableFile} from '@loaders.gl/loader-utils';
+import type {MeshArrowTable} from '@loaders.gl/schema';
+import {LASLoaderWithParser} from '../src/las-loader';
+import {
+  decodeLASWaveformSamples,
+  getLASWaveformStorage,
+  parseLASWaveformPacketReference,
+  readLASWaveformPacket,
+  readLASWaveformPackets,
+  scaleLASWaveformSamples
+} from '../src';
+import type {LASMetadata, LASWaveformPacketDescriptor} from '../src';
+
+describe('LAS waveform packet references', () => {
+  test('preserves uint64 offsets and ArrayBufferView byte offsets', () => {
+    const bytes = new Uint8Array(37);
+    const dataView = new DataView(bytes.buffer, 4, 29);
+    dataView.setUint8(0, 7);
+    dataView.setBigUint64(1, 0x123456789abcdef0n, true);
+    dataView.setUint32(9, 4096, true);
+    dataView.setFloat32(13, 0.25, true);
+    dataView.setFloat32(17, 1.5, true);
+    dataView.setFloat32(21, -2.5, true);
+    dataView.setFloat32(25, 3.5, true);
+
+    expect(parseLASWaveformPacketReference(bytes.subarray(3, 34), 1)).toEqual({
+      descriptorIndex: 7,
+      byteOffset: 0x123456789abcdef0n,
+      byteLength: 4096,
+      returnPointLocation: 0.25,
+      parametricOffset: [1.5, -2.5, 3.5]
+    });
+    expect(() => parseLASWaveformPacketReference(bytes.subarray(4, 32))).toThrow(/truncated/);
+  });
+
+  test('resolves mutually exclusive global-encoding storage bits', () => {
+    expect(getLASWaveformStorage(createMetadata({globalEncoding: 0}))).toBeNull();
+    expect(getLASWaveformStorage(createMetadata({globalEncoding: 2}))).toBe('internal');
+    expect(getLASWaveformStorage(createMetadata({globalEncoding: 4}))).toBe('external');
+    expect(() => getLASWaveformStorage(createMetadata({globalEncoding: 6}))).toThrow(
+      /both internal and external/
+    );
+  });
+});
+
+describe('LAS waveform sample decoding', () => {
+  test.each([
+    {bitsPerSample: 2, samples: [0, 1, 2, 3, 3, 2, 1, 0]},
+    {bitsPerSample: 12, samples: [0, 1, 2047, 4095, 37]},
+    {bitsPerSample: 32, samples: [0, 1, 0x7fffffff, 0xffffffff]}
+  ])('decodes $bitsPerSample-bit little-endian packed samples', fixture => {
+    const descriptor = createDescriptor({
+      bitsPerSample: fixture.bitsPerSample,
+      numberOfSamples: fixture.samples.length
+    });
+    const data = packUnsignedSamples(fixture.samples, fixture.bitsPerSample);
+    expect(Array.from(decodeLASWaveformSamples(data, descriptor))).toEqual(fixture.samples);
+  });
+
+  test('applies descriptor gain and offset', () => {
+    const descriptor = createDescriptor({digitizerGain: 1.5, digitizerOffset: -2.5});
+    expect(Array.from(scaleLASWaveformSamples(Uint32Array.of(0, 2, 4), descriptor))).toEqual([
+      -2.5, 0.5, 3.5
+    ]);
+  });
+
+  test('rejects unsupported compression, sample widths, and truncated packets', () => {
+    expect(() =>
+      decodeLASWaveformSamples(Uint8Array.of(0), createDescriptor({compressionType: 1}))
+    ).toThrow(/compression type 1/);
+    expect(() =>
+      decodeLASWaveformSamples(Uint8Array.of(0), createDescriptor({bitsPerSample: 1}))
+    ).toThrow(/between 2 and 32/);
+    expect(() =>
+      decodeLASWaveformSamples(Uint8Array.of(0), createDescriptor({numberOfSamples: -1}))
+    ).toThrow(/sample count -1 is invalid/);
+    expect(() =>
+      decodeLASWaveformSamples(
+        Uint8Array.of(0),
+        createDescriptor({bitsPerSample: 16, numberOfSamples: 2})
+      )
+    ).toThrow(/truncated/);
+  });
+});
+
+describe('LAS waveform range reads', () => {
+  test('range-reads internal packets relative to the public-header waveform offset', async () => {
+    const sourceBytes = new Uint8Array(256);
+    sourceBytes.set([1, 2, 3, 4], 124);
+    const reads: Array<{start: number | bigint | undefined; length: number | undefined}> = [];
+    const source = createRecordingFile(sourceBytes.buffer, reads);
+    const metadata = createMetadata({
+      globalEncoding: 2,
+      waveformDataOffset: 64n,
+      waveformPacketDescriptors: [
+        createDescriptor({numberOfSamples: 4, digitizerGain: 2, digitizerOffset: -1})
+      ]
+    });
+    const reference = createReference({byteOffset: 60n, byteLength: 4});
+
+    const packet = await readLASWaveformPacket(source, reference, metadata);
+
+    expect(reads).toEqual([{start: 124n, length: 4}]);
+    expect(packet.sourceByteOffset).toBe(124n);
+    expect(Array.from(packet.data)).toEqual([1, 2, 3, 4]);
+    expect(Array.from(packet.samples)).toEqual([1, 2, 3, 4]);
+    expect(Array.from(packet.amplitudes)).toEqual([1, 3, 5, 7]);
+  });
+
+  test('range-reads external WDP packets from their reference offsets', async () => {
+    const sourceBytes = new Uint8Array(128);
+    sourceBytes.set([5, 6], 60);
+    const metadata = createMetadata({
+      globalEncoding: 4,
+      waveformPacketDescriptors: [createDescriptor({numberOfSamples: 2})]
+    });
+    const packet = await readLASWaveformPacket(
+      new ArrayBufferFile(sourceBytes.buffer),
+      createReference({byteOffset: 60n, byteLength: 2}),
+      metadata
+    );
+
+    expect(packet.sourceByteOffset).toBe(60n);
+    expect(Array.from(packet.samples)).toEqual([5, 6]);
+  });
+
+  test('reads multiple packets concurrently while preserving input order', async () => {
+    const sourceBytes = new Uint8Array(128);
+    sourceBytes.set([4, 3, 2, 1], 60);
+    const metadata = createMetadata({
+      globalEncoding: 4,
+      waveformPacketDescriptors: [createDescriptor({numberOfSamples: 2})]
+    });
+    const packets = await readLASWaveformPackets(
+      new ArrayBufferFile(sourceBytes.buffer),
+      [
+        createReference({byteOffset: 62n, byteLength: 2}),
+        createReference({byteOffset: 60n, byteLength: 2})
+      ],
+      metadata,
+      {concurrency: 2}
+    );
+
+    expect(packets.map(packet => Array.from(packet.samples))).toEqual([
+      [2, 1],
+      [4, 3]
+    ]);
+    await expect(
+      readLASWaveformPackets(new ArrayBufferFile(sourceBytes.buffer), [], metadata)
+    ).resolves.toEqual([]);
+    await expect(
+      readLASWaveformPackets(new ArrayBufferFile(sourceBytes.buffer), [], metadata, {
+        concurrency: 0
+      })
+    ).rejects.toThrow(/positive integer/);
+  });
+
+  test('reports missing storage, offsets, descriptors, and short reads', async () => {
+    const source = new ArrayBufferFile(new ArrayBuffer(4));
+    const reference = createReference({byteLength: 4});
+    await expect(readLASWaveformPacket(source, reference, createMetadata())).rejects.toThrow(
+      /does not declare/
+    );
+    await expect(
+      readLASWaveformPacket(
+        source,
+        reference,
+        createMetadata({
+          globalEncoding: 2,
+          waveformPacketDescriptors: [createDescriptor({numberOfSamples: 4})]
+        })
+      )
+    ).rejects.toThrow(/offset is missing/);
+    await expect(
+      readLASWaveformPacket(
+        source,
+        createReference({descriptorIndex: 0, byteLength: 0}),
+        createMetadata({globalEncoding: 4})
+      )
+    ).rejects.toThrow(/index 0/);
+    await expect(
+      readLASWaveformPacket(source, reference, createMetadata({globalEncoding: 4}))
+    ).rejects.toThrow(/descriptor VLR 100 is missing/);
+    await expect(
+      readLASWaveformPacket(
+        source,
+        createReference({byteOffset: 10n, byteLength: 4}),
+        createMetadata({
+          globalEncoding: 4,
+          waveformPacketDescriptors: [createDescriptor({numberOfSamples: 4})]
+        })
+      )
+    ).rejects.toThrow(/range read returned 0 bytes/);
+  });
+
+  test('forwards abort signals to the range source', async () => {
+    const abortController = new AbortController();
+    abortController.abort();
+    const metadata = createMetadata({
+      globalEncoding: 4,
+      waveformPacketDescriptors: [createDescriptor()]
+    });
+    await expect(
+      readLASWaveformPacket(
+        new ArrayBufferFile(Uint8Array.of(1).buffer),
+        createReference(),
+        metadata,
+        {signal: abortController.signal}
+      )
+    ).rejects.toThrow(/aborted/);
+  });
+});
+
+test('LASLoader extracts the complete legacy PDRF 4 waveform reference', () => {
+  const headerSize = 235;
+  const pointDataRecordLength = 57;
+  const arrayBuffer = new ArrayBuffer(headerSize + pointDataRecordLength);
+  const bytes = new Uint8Array(arrayBuffer);
+  const dataView = new DataView(arrayBuffer);
+  dataView.setUint32(0, 0x4653414c, true);
+  bytes[24] = 1;
+  bytes[25] = 3;
+  dataView.setUint16(94, headerSize, true);
+  dataView.setUint32(96, headerSize, true);
+  bytes[104] = 4;
+  dataView.setUint16(105, pointDataRecordLength, true);
+  dataView.setUint32(107, 1, true);
+  dataView.setFloat64(131, 1, true);
+  dataView.setFloat64(139, 1, true);
+  dataView.setFloat64(147, 1, true);
+  const waveformOffset = headerSize + 28;
+  dataView.setUint8(waveformOffset, 7);
+  dataView.setBigUint64(waveformOffset + 1, 0x123456789abcdef0n, true);
+  dataView.setUint32(waveformOffset + 9, 16, true);
+
+  const table = LASLoaderWithParser.parseSync!(arrayBuffer, {
+    las: {shape: 'arrow-table', columns: ['POSITION', 'WAVEFORM']}
+  }) as MeshArrowTable;
+  const waveform = table.data.getChild('WAVEFORM')?.get(0) as Iterable<number>;
+
+  expect(Array.from(waveform)[0]).toBe(7);
+  expect(parseLASWaveformPacketReference(Uint8Array.from(waveform))).toMatchObject({
+    descriptorIndex: 7,
+    byteOffset: 0x123456789abcdef0n,
+    byteLength: 16
+  });
+});
+
+/** Creates a complete metadata object with waveform-specific overrides. */
+function createMetadata(overrides: Partial<LASMetadata> = {}): LASMetadata {
+  return {
+    fileSourceId: 0,
+    globalEncoding: 0,
+    projectId: '00000000-0000-0000-0000-000000000000',
+    systemIdentifier: '',
+    generatingSoftware: '',
+    creationDayOfYear: 0,
+    creationYear: 0,
+    headerSize: 375,
+    vlrCount: 0,
+    vlrs: [],
+    evlrs: [],
+    extraBytes: [],
+    waveformPacketDescriptors: [],
+    ...overrides
+  };
+}
+
+/** Creates one waveform descriptor with deterministic uncompressed defaults. */
+function createDescriptor(
+  overrides: Partial<LASWaveformPacketDescriptor> = {}
+): LASWaveformPacketDescriptor {
+  return {
+    recordId: 100,
+    bitsPerSample: 8,
+    compressionType: 0,
+    numberOfSamples: 1,
+    temporalSampleSpacing: 250,
+    digitizerGain: 1,
+    digitizerOffset: 0,
+    ...overrides
+  };
+}
+
+/** Creates one waveform packet reference with deterministic defaults. */
+function createReference(
+  overrides: Partial<ReturnType<typeof parseLASWaveformPacketReference>> = {}
+): ReturnType<typeof parseLASWaveformPacketReference> {
+  return {
+    descriptorIndex: 1,
+    byteOffset: 0n,
+    byteLength: 1,
+    returnPointLocation: 0,
+    parametricOffset: [0, 0, 0],
+    ...overrides
+  };
+}
+
+/** Packs unsigned integer samples in LAS little-endian bit order. */
+function packUnsignedSamples(samples: number[], bitsPerSample: number): Uint8Array {
+  const bytes = new Uint8Array(Math.ceil((samples.length * bitsPerSample) / 8));
+  let bitOffset = 0;
+  for (const sample of samples) {
+    for (let bitIndex = 0; bitIndex < bitsPerSample; bitIndex++) {
+      if (Math.floor(sample / 2 ** bitIndex) % 2) {
+        bytes[Math.floor(bitOffset / 8)] |= 1 << (bitOffset % 8);
+      }
+      bitOffset++;
+    }
+  }
+  return bytes;
+}
+
+/** Wraps an ArrayBuffer file and records each requested range. */
+function createRecordingFile(
+  arrayBuffer: ArrayBuffer,
+  reads: Array<{start: number | bigint | undefined; length: number | undefined}>
+): ReadableFile {
+  const file = new ArrayBufferFile(arrayBuffer);
+  return {
+    ...file,
+    read: async (start, length, signal) => {
+      reads.push({start, length});
+      return file.read(start, length, signal);
+    },
+    close: () => file.close()
+  };
+}


### PR DESCRIPTION
## Goals

- Complete read-side waveform support without loading waveform payloads during normal point-cloud parsing.
- Preserve exact LAS uint64 offsets and support both internal LAS and external WDP packet storage.
- Keep the common COPC/PDRF 7 path unchanged and leave writer work out of scope.

## Changes

- Adds public helpers to parse waveform references, determine storage, range-read one or many packets, decode standard uncompressed 2-32 bit samples, and apply descriptor gain/offset.
- Parses the LAS 1.3+ internal waveform-data offset as a bigint and fixes legacy PDRF 4/5 waveform descriptor-byte offsets.
- Uses bounded-concurrency ReadableFile range requests while preserving input order.
- Rejects missing descriptors, contradictory storage flags, unsupported compression, truncated packets, and invalid sample definitions deterministically.
- Exports the waveform APIs from root, bundled, and unbundled entry points.
- Updates LAS support tables and loader documentation with internal/external packet layout and an HttpFile usage example.

## Validation

- `yarn build`
- `yarn test-node` (49 files, 351 passed, 6 skipped)
- `yarn build-workers && yarn test-headless` (454 files, 2706 passed, 38 skipped)
- focused LAS browser tests after rebase (31 passed)
- `yarn test-audit` (563 files, 0 violations)
- focused coverage for `las-waveform.ts`: 97.56% lines, 94.73% branches, 100% functions
- website production build