### PR TITLE
feat(wms): add minimal OGC API sources

### DIFF
--- a/docs/docs-sidebar.json
+++ b/docs/docs-sidebar.json
@@ -77,7 +77,8 @@
       "modules/wms/formats/wmts",
       "modules/wms/services/arcgis-map-server",
       "modules/wms/services/arcgis-image-server",
-      "modules/wms/services/arcgis-feature-server"
+      "modules/wms/services/arcgis-feature-server",
+      "modules/wms/services/ogc-api"
     ]
   },
   {

--- a/docs/modules/wms/README.md
+++ b/docs/modules/wms/README.md
@@ -26,6 +26,27 @@ The `@loaders.gl/wms` module provides support for a subset of the OGC Web Servic
 | [**WMC**](/docs/modules/wms/formats/wmc) (Web Map Context)                          | No           | Used in WMS clients to save the configuration of maps and to load them again later. Can also be exchanged between different clients. |
 | [**OWS Context**](/docs/modules/wms/formats/ows-context) (OGC Web Services Context) | No           | Allows configured information resources to be passed between applications primarily as a collection of services.                     |
 
+The module also includes minimal adapters for the modern OGC API family. These adapters cover
+landing pages, collections, basic GeoJSON Features queries, and advertised tile templates. They
+are intentionally not a full conformance implementation; advanced filtering and service-specific
+extensions remain available through the regular loaders.gl fetch APIs.
+
+```js
+import {OGCAPIFeaturesSourceLoader} from '@loaders.gl/wms';
+import {createDataSource} from '@loaders.gl/core';
+
+const source = createDataSource('https://demo.ldproxy.net/daraa', [OGCAPIFeaturesSourceLoader], {
+  'ogc-api': {collectionId: 'VegetationSrf'}
+});
+const features = await source.getFeatures({
+  layers: 'VegetationSrf',
+  boundingBox: [
+    [12.4, 41.8],
+    [12.6, 42.0]
+  ]
+});
+```
+
 ## API
 
 Support for the protocols is provided in the form of:

--- a/docs/modules/wms/services/ogc-api.md
+++ b/docs/modules/wms/services/ogc-api.md
@@ -1,0 +1,52 @@
+# OGC API
+
+The `@loaders.gl/wms` module provides a deliberately small compatibility layer for modern OGC
+APIs. It supports the common discovery shape and the two most useful data paths for applications:
+feature collections and tiled resources.
+
+## Features
+
+```js
+import {OGCAPIFeaturesSourceLoader} from '@loaders.gl/wms';
+import {createDataSource} from '@loaders.gl/core';
+
+const source = createDataSource('https://demo.ldproxy.net/daraa', [OGCAPIFeaturesSourceLoader], {
+  'ogc-api': {collectionId: 'VegetationSrf'}
+});
+
+const metadata = await source.getMetadata();
+const page = await source.getFeatures({
+  layers: 'VegetationSrf',
+  boundingBox: [
+    [12.4, 41.8],
+    [12.6, 42.0]
+  ]
+});
+```
+
+The result is a loaders.gl GeoJSON table. The adapter sends the standard `bbox` and optional `crs`
+query parameters. Paging links and advanced filters can be followed directly using the underlying
+fetch function when needed.
+
+## Tiles
+
+The tiles adapter expands a server-advertised template. Both OGC API names and conventional XYZ
+placeholders are accepted:
+
+```js
+import {OGCAPITilesSourceLoader} from '@loaders.gl/wms';
+
+const source = OGCAPITilesSourceLoader.createDataSource('https://example.com/api', {
+  'ogc-api': {
+    tileTemplate: 'https://example.com/api/tiles/{tileMatrix}/{tileRow}/{tileCol}.png'
+  }
+});
+
+const tileBytes = await source.getTile({z: 3, x: 4, y: 5});
+```
+
+This is intentionally a minimal adapter. It does not attempt to implement every OGC API extension,
+server-side filter language, or conformance class.
+
+For a live feature-service example, see the [ldproxy demo](https://demo.ldproxy.net/daraa). Live
+services are not used by the test suite; repository fixtures remain the source of truth for CI.

--- a/modules/wms/src/index.ts
+++ b/modules/wms/src/index.ts
@@ -87,6 +87,18 @@ export {
   getServiceCRSAxisOrder
 } from './crs-utils';
 export {WFSSourceLoader, WFSVectorSource} from './wfs-source-loader';
+export type {
+  OGCAPICollection,
+  OGCAPILandingPage,
+  OGCAPILink,
+  OGCAPISourceOptions
+} from './ogc-api-source-loader';
+export {
+  OGCAPIFeaturesSource,
+  OGCAPIFeaturesSourceLoader,
+  OGCAPITilesSource,
+  OGCAPITilesSourceLoader
+} from './ogc-api-source-loader';
 
 export type {GeoServiceType, ServiceCapabilities} from './service-capabilities';
 export {

--- a/modules/wms/src/ogc-api-source-loader.ts
+++ b/modules/wms/src/ogc-api-source-loader.ts
@@ -1,0 +1,234 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {
+  CoreAPI,
+  DataSourceOptions,
+  GetFeaturesParameters,
+  GetTileDataParameters,
+  GetTileParameters,
+  SourceLoader,
+  TileSource,
+  TileSourceMetadata,
+  VectorSource,
+  VectorSourceData,
+  VectorSourceMetadata
+} from '@loaders.gl/loader-utils';
+import {DataSource} from '@loaders.gl/loader-utils';
+import type {GeoJSONTable, Schema} from '@loaders.gl/schema';
+
+/** Options shared by the minimal OGC API source adapters. */
+export type OGCAPISourceOptions = DataSourceOptions & {
+  /** Optional collection identifier for an OGC API Features source. */
+  'ogc-api'?: {collectionId?: string; tileTemplate?: string};
+};
+
+/** A small representation of an OGC API link. */
+export type OGCAPILink = {href: string; rel?: string; type?: string; title?: string};
+
+/** A minimal OGC API collection description. */
+export type OGCAPICollection = {
+  id: string;
+  title?: string;
+  description?: string;
+  extent?: {spatial?: {bbox?: number[][]}; temporal?: unknown};
+  crs?: string[];
+  links?: OGCAPILink[];
+};
+
+/** The normalized landing page returned by an OGC API service. */
+export type OGCAPILandingPage = {
+  title?: string;
+  description?: string;
+  links?: OGCAPILink[];
+};
+
+/** Minimal OGC API Features source. */
+export class OGCAPIFeaturesSource
+  extends DataSource<string, OGCAPISourceOptions>
+  implements VectorSource
+{
+  /** Creates an OGC API Features source. */
+  constructor(url: string, options: OGCAPISourceOptions = {}, coreApi?: CoreAPI) {
+    super(url.replace(/\/$/, ''), options, OGCAPIFeaturesSourceLoader.defaultOptions, coreApi);
+  }
+
+  /** Returns the landing page metadata. */
+  async getLandingPage(): Promise<OGCAPILandingPage> {
+    return (await this.fetchJSON(this.url)) as OGCAPILandingPage;
+  }
+
+  /** Lists the feature collections advertised by the service. */
+  async getCollections(): Promise<OGCAPICollection[]> {
+    const response = (await this.fetchJSON(`${this.url}/collections`)) as {
+      collections?: OGCAPICollection[];
+    };
+    return response.collections || [];
+  }
+
+  /** Returns normalized metadata for the selected collection. */
+  async getMetadata(): Promise<VectorSourceMetadata> {
+    const collections = await this.getCollections();
+    const collection = this.getCollection(collections);
+    return {
+      name: collection?.id || this.getCollectionId(),
+      title: collection?.title,
+      abstract: collection?.description,
+      keywords: [],
+      layers: collection ? [toVectorLayer(collection)] : []
+    };
+  }
+
+  /** Returns a minimal schema; OGC API schema extensions remain optional. */
+  async getSchema(): Promise<Schema> {
+    return {fields: [], metadata: {}};
+  }
+
+  /** Fetches a page of GeoJSON features using the standard bbox parameters. */
+  async getFeatures(parameters: GetFeaturesParameters): Promise<VectorSourceData> {
+    const collectionId = this.getCollectionId(parameters.layers);
+    const url = new URL(`${this.url}/collections/${encodeURIComponent(collectionId)}/items`);
+    url.searchParams.set('bbox', flattenBoundingBox(parameters.boundingBox).join(','));
+    if (parameters.crs) url.searchParams.set('crs', parameters.crs);
+    const response = await this.fetchJSON(url.toString());
+    if (!isFeatureCollection(response)) {
+      throw new Error('OGC API Features response was not a GeoJSON FeatureCollection');
+    }
+    return {shape: 'geojson-table', ...response} as GeoJSONTable;
+  }
+
+  private async fetchJSON(url: string): Promise<unknown> {
+    const response = await this.fetch(url, {headers: {Accept: 'application/json'}});
+    if (!response.ok) throw new Error(`OGC API request failed: ${response.status}`);
+    return response.json();
+  }
+
+  private getCollection(collections: OGCAPICollection[]): OGCAPICollection | undefined {
+    const collectionId = this.getCollectionId();
+    return collections.find(collection => collection.id === collectionId) || collections[0];
+  }
+
+  private getCollectionId(layers?: string | string[]): string {
+    const configuredId = this.options['ogc-api']?.collectionId;
+    const layerId = Array.isArray(layers) ? layers[0] : layers;
+    if (configuredId || layerId) return configuredId || layerId!;
+    const match = this.url.match(/\/collections\/([^/]+)/);
+    if (match) return decodeURIComponent(match[1]);
+    return '';
+  }
+}
+
+/** Source loader for minimal OGC API Features support. */
+export const OGCAPIFeaturesSourceLoader = {
+  dataType: null as unknown as OGCAPIFeaturesSource,
+  batchType: null as never,
+  name: 'OGC API Features',
+  id: 'ogc-api-features',
+  module: 'wms',
+  version: '0.0.0',
+  extensions: [],
+  mimeTypes: ['application/geo+json'],
+  type: 'ogc-api-features',
+  fromUrl: true,
+  fromBlob: false,
+  options: {'ogc-api': {}},
+  defaultOptions: {'ogc-api': {}},
+  testURL: (url: string): boolean => /\/collections(?:\/|$)|ogc[/-]?api[/-]features/i.test(url),
+  createDataSource: (url: string, options: OGCAPISourceOptions = {}, coreApi?: CoreAPI) =>
+    new OGCAPIFeaturesSource(url, options, coreApi)
+} as const satisfies SourceLoader<OGCAPIFeaturesSource>;
+
+/** Minimal OGC API Tiles source that follows a discovered tile template. */
+export class OGCAPITilesSource
+  extends DataSource<string, OGCAPISourceOptions>
+  implements TileSource
+{
+  /** Creates an OGC API Tiles source. */
+  constructor(url: string, options: OGCAPISourceOptions = {}, coreApi?: CoreAPI) {
+    super(url.replace(/\/$/, ''), options, OGCAPITilesSourceLoader.defaultOptions, coreApi);
+  }
+
+  /** Returns basic tileset metadata from the service landing page. */
+  async getMetadata(): Promise<TileSourceMetadata> {
+    const landingPage = (await this.fetchJSON(this.url)) as OGCAPILandingPage;
+    const tileLink = landingPage.links?.find(link => link.rel?.includes('tileset'));
+    return {name: landingPage.title || '', title: landingPage.title, format: tileLink?.type};
+  }
+
+  /** Fetches raw bytes for one tile from an advertised template. */
+  async getTile(parameters: GetTileParameters): Promise<ArrayBuffer | null> {
+    const url = this.getTileURL(parameters);
+    const response = await this.fetch(url, {headers: {Accept: 'application/octet-stream'}});
+    if (!response.ok) throw new Error(`OGC API Tiles request failed: ${response.status}`);
+    return response.arrayBuffer();
+  }
+
+  /** Fetches a tile using the deck.gl-compatible request shape. */
+  async getTileData(parameters: GetTileDataParameters): Promise<ArrayBuffer | null> {
+    return this.getTile(parameters.index);
+  }
+
+  /** Expands a `{tileMatrix}`, `{tileRow}`, and `{tileCol}` template. */
+  getTileURL(parameters: GetTileParameters): string {
+    const template = this.options['ogc-api']?.tileTemplate;
+    if (!template) throw new Error('OGC API Tiles requires ogc-api.tileTemplate');
+    return template
+      .replaceAll('{tileMatrix}', String(parameters.z))
+      .replaceAll('{tileRow}', String(parameters.y))
+      .replaceAll('{tileCol}', String(parameters.x))
+      .replaceAll('{z}', String(parameters.z))
+      .replaceAll('{y}', String(parameters.y))
+      .replaceAll('{x}', String(parameters.x));
+  }
+
+  private async fetchJSON(url: string): Promise<unknown> {
+    const response = await this.fetch(url, {headers: {Accept: 'application/json'}});
+    if (!response.ok) throw new Error(`OGC API request failed: ${response.status}`);
+    return response.json();
+  }
+}
+
+/** Source loader for minimal OGC API Tiles support. */
+export const OGCAPITilesSourceLoader = {
+  dataType: null as unknown as OGCAPITilesSource,
+  batchType: null as never,
+  name: 'OGC API Tiles',
+  id: 'ogc-api-tiles',
+  module: 'wms',
+  version: '0.0.0',
+  extensions: [],
+  mimeTypes: [],
+  type: 'ogc-api-tiles',
+  fromUrl: true,
+  fromBlob: false,
+  options: {},
+  defaultOptions: {},
+  testURL: (url: string): boolean => /\/tiles(?:\/|$)|ogc[/-]?api[/-]tiles/i.test(url),
+  createDataSource: (url: string, options: OGCAPISourceOptions = {}, coreApi?: CoreAPI) =>
+    new OGCAPITilesSource(url, options, coreApi)
+} as const satisfies SourceLoader<OGCAPITilesSource>;
+
+function flattenBoundingBox(boundingBox: GetFeaturesParameters['boundingBox']): number[] {
+  return [boundingBox[0][0], boundingBox[0][1], boundingBox[1][0], boundingBox[1][1]];
+}
+
+function isFeatureCollection(value: unknown): value is Pick<GeoJSONTable, 'type' | 'features'> {
+  return Boolean(value && typeof value === 'object' && (value as any).type === 'FeatureCollection');
+}
+
+function toVectorLayer(collection: OGCAPICollection) {
+  const bbox = collection.extent?.spatial?.bbox?.[0];
+  return {
+    name: collection.id,
+    title: collection.title,
+    crs: collection.crs,
+    boundingBox: bbox
+      ? [
+          [bbox[0], bbox[1]],
+          [bbox[2], bbox[3]]
+        ]
+      : undefined,
+    layers: []
+  };
+}

--- a/modules/wms/src/ogc-api-source-loader.ts
+++ b/modules/wms/src/ogc-api-source-loader.ts
@@ -17,6 +17,10 @@ import type {
 } from '@loaders.gl/loader-utils';
 import {DataSource} from '@loaders.gl/loader-utils';
 import type {GeoJSONTable, Schema} from '@loaders.gl/schema';
+import {
+  convertFeaturesToWKBArrowTable,
+  convertGeojsonToBinaryFeatureCollection
+} from '@loaders.gl/gis';
 
 /** Options shared by the minimal OGC API source adapters. */
 export type OGCAPISourceOptions = DataSourceOptions & {
@@ -56,12 +60,12 @@ export class OGCAPIFeaturesSource
 
   /** Returns the landing page metadata. */
   async getLandingPage(): Promise<OGCAPILandingPage> {
-    return (await this.fetchJSON(this.url)) as OGCAPILandingPage;
+    return (await this.fetchJSON(this.getServiceURL())) as OGCAPILandingPage;
   }
 
   /** Lists the feature collections advertised by the service. */
   async getCollections(): Promise<OGCAPICollection[]> {
-    const response = (await this.fetchJSON(`${this.url}/collections`)) as {
+    const response = (await this.fetchJSON(`${this.getServiceURL()}/collections`)) as {
       collections?: OGCAPICollection[];
     };
     return response.collections || [];
@@ -88,27 +92,45 @@ export class OGCAPIFeaturesSource
   /** Fetches a page of GeoJSON features using the standard bbox parameters. */
   async getFeatures(parameters: GetFeaturesParameters): Promise<VectorSourceData> {
     const collectionId = this.getCollectionId(parameters.layers);
-    const url = new URL(`${this.url}/collections/${encodeURIComponent(collectionId)}/items`);
+    const collectionURL = /\/collections\/[^/]+$/.test(this.url)
+      ? `${this.url}/items`
+      : `${this.getServiceURL()}/collections/${encodeURIComponent(collectionId)}/items`;
+    const url = new URL(collectionURL);
     url.searchParams.set('bbox', flattenBoundingBox(parameters.boundingBox).join(','));
     if (parameters.crs) url.searchParams.set('crs', parameters.crs);
-    const response = await this.fetchJSON(url.toString());
+    const response = await this.fetchJSON(
+      url.toString(),
+      'application/geo+json, application/json;q=0.9'
+    );
     if (!isFeatureCollection(response)) {
       throw new Error('OGC API Features response was not a GeoJSON FeatureCollection');
     }
-    return {shape: 'geojson-table', ...response} as GeoJSONTable;
+    const geoJSONTable = {shape: 'geojson-table', ...response} as GeoJSONTable;
+    switch (parameters.format || 'geojson') {
+      case 'binary':
+        return convertGeojsonToBinaryFeatureCollection(geoJSONTable.features);
+      case 'arrow':
+        return convertFeaturesToWKBArrowTable(geoJSONTable.features);
+      case 'geojson':
+      default:
+        return geoJSONTable;
+    }
   }
 
-  private async fetchJSON(url: string): Promise<unknown> {
-    const response = await this.fetch(url, {headers: {Accept: 'application/json'}});
+  /** Fetches and decodes a JSON representation from the service. */
+  private async fetchJSON(url: string, accept = 'application/json'): Promise<unknown> {
+    const response = await this.fetch(url, {headers: {Accept: accept}});
     if (!response.ok) throw new Error(`OGC API request failed: ${response.status}`);
     return response.json();
   }
 
+  /** Selects the requested collection from a collections response. */
   private getCollection(collections: OGCAPICollection[]): OGCAPICollection | undefined {
     const collectionId = this.getCollectionId();
     return collections.find(collection => collection.id === collectionId) || collections[0];
   }
 
+  /** Returns the configured collection identifier or the first URL collection segment. */
   private getCollectionId(layers?: string | string[]): string {
     const configuredId = this.options['ogc-api']?.collectionId;
     const layerId = Array.isArray(layers) ? layers[0] : layers;
@@ -116,6 +138,11 @@ export class OGCAPIFeaturesSource
     const match = this.url.match(/\/collections\/([^/]+)/);
     if (match) return decodeURIComponent(match[1]);
     return '';
+  }
+
+  /** Returns the service root for both landing-page and collection URLs. */
+  private getServiceURL(): string {
+    return this.url.replace(/\/collections\/[^/]+$/, '');
   }
 }
 
@@ -209,14 +236,17 @@ export const OGCAPITilesSourceLoader = {
     new OGCAPITilesSource(url, options, coreApi)
 } as const satisfies SourceLoader<OGCAPITilesSource>;
 
+/** Converts the loaders.gl nested bounding box into the OGC comma-separated form. */
 function flattenBoundingBox(boundingBox: GetFeaturesParameters['boundingBox']): number[] {
   return [boundingBox[0][0], boundingBox[0][1], boundingBox[1][0], boundingBox[1][1]];
 }
 
+/** Checks that a decoded response has the required GeoJSON feature-collection marker. */
 function isFeatureCollection(value: unknown): value is Pick<GeoJSONTable, 'type' | 'features'> {
   return Boolean(value && typeof value === 'object' && (value as any).type === 'FeatureCollection');
 }
 
+/** Converts an OGC collection extent into the normalized source-layer shape. */
 function toVectorLayer(collection: OGCAPICollection) {
   const bbox = collection.extent?.spatial?.bbox?.[0];
   return {
@@ -224,10 +254,10 @@ function toVectorLayer(collection: OGCAPICollection) {
     title: collection.title,
     crs: collection.crs,
     boundingBox: bbox
-      ? [
+      ? ([
           [bbox[0], bbox[1]],
           [bbox[2], bbox[3]]
-        ]
+        ] as [[number, number], [number, number]])
       : undefined,
     layers: []
   };

--- a/modules/wms/test/index.ts
+++ b/modules/wms/test/index.ts
@@ -33,3 +33,4 @@ import './gml/gml-loader.spec';
 import './wms/wms-source.spec';
 import './arcgis/arcgis-server.spec';
 import './service-capabilities.spec';
+import './ogc-api-source.spec';

--- a/modules/wms/test/ogc-api-source.spec.ts
+++ b/modules/wms/test/ogc-api-source.spec.ts
@@ -1,0 +1,59 @@
+import test from 'test/utils/vitest-tape';
+import {OGCAPIFeaturesSourceLoader, OGCAPITilesSourceLoader} from '@loaders.gl/wms';
+
+const OGC_API_URL = 'https://example.com/ogcapi';
+
+test('OGCAPIFeaturesSource#getCollections and getMetadata', async t => {
+  const source = OGCAPIFeaturesSourceLoader.createDataSource(OGC_API_URL, {});
+  source.fetch = async url => {
+    if (url.endsWith('/collections')) {
+      return new Response(
+        JSON.stringify({
+          collections: [
+            {id: 'roads', title: 'Roads', crs: ['http://www.opengis.net/def/crs/OGC/1.3/CRS84']}
+          ]
+        }),
+        {headers: {'content-type': 'application/json'}}
+      );
+    }
+    return new Response(JSON.stringify({title: 'Demo API'}));
+  };
+
+  const metadata = await source.getMetadata();
+  t.equal(metadata.name, 'roads');
+  t.equal(metadata.layers[0].title, 'Roads');
+  t.end();
+});
+
+test('OGCAPIFeaturesSource#getFeatures uses standard bbox query', async t => {
+  const source = OGCAPIFeaturesSourceLoader.createDataSource(OGC_API_URL, {
+    'ogc-api': {collectionId: 'roads'}
+  });
+  source.fetch = async url => {
+    t.equal(
+      url,
+      `${OGC_API_URL}/collections/roads/items?bbox=-10%2C-5%2C10%2C5&crs=CRS84`,
+      'uses OGC API query parameters'
+    );
+    return new Response(JSON.stringify({type: 'FeatureCollection', features: []}));
+  };
+
+  const result = await source.getFeatures({
+    layers: 'roads',
+    boundingBox: [
+      [-10, -5],
+      [10, 5]
+    ],
+    crs: 'CRS84'
+  });
+  t.equal(result.shape, 'geojson-table');
+  t.end();
+});
+
+test('OGCAPITilesSource#getTileURL expands both OGC and XYZ templates', t => {
+  const source = OGCAPITilesSourceLoader.createDataSource(OGC_API_URL, {
+    'ogc-api': {tileTemplate: `${OGC_API_URL}/tiles/{tileMatrix}/{tileRow}/{tileCol}.png`}
+  });
+  t.equal(source.getTileURL({z: 3, x: 4, y: 5}), `${OGC_API_URL}/tiles/3/5/4.png`);
+  t.end();
+});

--- a/modules/wms/test/ogc-api-source.spec.ts
+++ b/modules/wms/test/ogc-api-source.spec.ts
@@ -1,9 +1,9 @@
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {OGCAPIFeaturesSourceLoader, OGCAPITilesSourceLoader} from '@loaders.gl/wms';
 
 const OGC_API_URL = 'https://example.com/ogcapi';
 
-test('OGCAPIFeaturesSource#getCollections and getMetadata', async t => {
+test('OGCAPIFeaturesSource#getCollections and getMetadata', async () => {
   const source = OGCAPIFeaturesSourceLoader.createDataSource(OGC_API_URL, {});
   source.fetch = async url => {
     if (url.endsWith('/collections')) {
@@ -20,21 +20,17 @@ test('OGCAPIFeaturesSource#getCollections and getMetadata', async t => {
   };
 
   const metadata = await source.getMetadata();
-  t.equal(metadata.name, 'roads');
-  t.equal(metadata.layers[0].title, 'Roads');
-  t.end();
+  expect(metadata.name).toBe('roads');
+  expect(metadata.layers[0].title).toBe('Roads');
 });
 
-test('OGCAPIFeaturesSource#getFeatures uses standard bbox query', async t => {
+test('OGCAPIFeaturesSource#getFeatures uses standard bbox query', async () => {
   const source = OGCAPIFeaturesSourceLoader.createDataSource(OGC_API_URL, {
     'ogc-api': {collectionId: 'roads'}
   });
-  source.fetch = async url => {
-    t.equal(
-      url,
-      `${OGC_API_URL}/collections/roads/items?bbox=-10%2C-5%2C10%2C5&crs=CRS84`,
-      'uses OGC API query parameters'
-    );
+  source.fetch = async (url, options) => {
+    expect(url).toBe(`${OGC_API_URL}/collections/roads/items?bbox=-10%2C-5%2C10%2C5&crs=CRS84`);
+    expect(new Headers(options?.headers).get('accept')).toContain('application/geo+json');
     return new Response(JSON.stringify({type: 'FeatureCollection', features: []}));
   };
 
@@ -46,14 +42,56 @@ test('OGCAPIFeaturesSource#getFeatures uses standard bbox query', async t => {
     ],
     crs: 'CRS84'
   });
-  t.equal(result.shape, 'geojson-table');
-  t.end();
+  expect(result.shape).toBe('geojson-table');
 });
 
-test('OGCAPITilesSource#getTileURL expands both OGC and XYZ templates', t => {
+test('OGCAPIFeaturesSource supports binary and Arrow output', async () => {
+  const source = OGCAPIFeaturesSourceLoader.createDataSource(OGC_API_URL, {
+    'ogc-api': {collectionId: 'roads'}
+  });
+  source.fetch = async () =>
+    new Response(
+      JSON.stringify({
+        type: 'FeatureCollection',
+        features: [
+          {type: 'Feature', geometry: {type: 'Point', coordinates: [1, 2]}, properties: {}}
+        ]
+      })
+    );
+  const parameters = {
+    layers: 'roads',
+    boundingBox: [
+      [-1, -1],
+      [1, 1]
+    ]
+  } as const;
+  expect((await source.getFeatures({...parameters, format: 'binary'})).shape).toBe(
+    'binary-feature-collection'
+  );
+  expect((await source.getFeatures({...parameters, format: 'arrow'})).shape).toBe('arrow-table');
+});
+
+test('OGCAPIFeaturesSource handles a collection URL', async () => {
+  const source = OGCAPIFeaturesSourceLoader.createDataSource(
+    `${OGC_API_URL}/collections/roads`,
+    {}
+  );
+  source.fetch = async url => {
+    expect(url).toBe(`${OGC_API_URL}/collections/roads/items?bbox=-1%2C-1%2C1%2C1`);
+    return new Response(JSON.stringify({type: 'FeatureCollection', features: []}));
+  };
+  await source.getFeatures({
+    layers: 'roads',
+    boundingBox: [
+      [-1, -1],
+      [1, 1]
+    ]
+  });
+});
+
+test('OGCAPITilesSource#getTileURL expands OGC templates', () => {
   const source = OGCAPITilesSourceLoader.createDataSource(OGC_API_URL, {
     'ogc-api': {tileTemplate: `${OGC_API_URL}/tiles/{tileMatrix}/{tileRow}/{tileCol}.png`}
   });
-  t.equal(source.getTileURL({z: 3, x: 4, y: 5}), `${OGC_API_URL}/tiles/3/5/4.png`);
-  t.end();
+  expect(source.getTileURL({z: 3, x: 4, y: 5})).toBe(`${OGC_API_URL}/tiles/3/5/4.png`);
 });


### PR DESCRIPTION
## Goals

- Add lightweight OGC API compatibility without introducing a universal service abstraction.
- Provide a practical Features and Tiles path using existing loaders.gl source types.
- Keep tests hermetic and examples independent of live service availability.

## Changes

- Add `OGCAPIFeaturesSource` and `OGCAPIFeaturesSourceLoader`.
- Add `OGCAPITilesSource` and `OGCAPITilesSourceLoader` with OGC and XYZ template expansion.
- Add normalized landing-page, collection, and link types.
- Add GeoJSON Features bbox/CRS querying and basic metadata discovery.
- Add hermetic source tests and OGC API documentation with an optional ldproxy example.
- Export the new APIs from `@loaders.gl/wms`.

## Validation

- `yarn build`
- `yarn test-node`
- `yarn test-headless modules/wms/test/ogc-api-source.spec.ts`
- `yarn lint fix`
- Website build succeeds with existing documentation warnings.