### PR TITLE
feat(parquet): complete modular encryption page reads

### DIFF
--- a/docs/modules/parquet/api-reference/parquet-loader.md
+++ b/docs/modules/parquet/api-reference/parquet-loader.md
@@ -174,6 +174,8 @@ Supports table category options such as `batchType` and `batchSize`.
 | `parquet.signal` | `AbortSignal` | `undefined` | Cancels worker-backed parsing by terminating its active worker. |
 | `parquet.workerUrl` | `string` | package-local asset | Overrides the packaged worker URL. |
 | `parquet.wasmUrl` | `string` | package-local asset | Overrides the `parquet-wasm` binary URL for `ParquetLoader`. |
+| `parquet.keyRetriever` | `ParquetKeyRetriever` | `undefined` | Resolves keys for modular-encrypted files when using `ParquetJSLoader`. |
+| `parquet.aadPrefix` | `Uint8Array` | `undefined` | Supplies the AAD prefix for encrypted files that omit it from their crypto metadata. |
 
 ## Loader Variants
 
@@ -181,7 +183,8 @@ Supports table category options such as `batchType` and `batchSize`.
   and can use the package's prebuilt worker.
 - Use `ParquetJSLoader` for the experimental TypeScript implementation. It supports object-row and
   Arrow output plus the common row options listed above, including `columns`, `limit`, `offset`,
-  `batchSize`, and `preserveBinary`.
+  `batchSize`, and `preserveBinary`. It can also read AES-GCM and AES-GCM-CTR encrypted column
+  metadata and page modules when `keyRetriever` is supplied.
 
 The implementation is selected by the loader import. There is no runtime backend option.
 The [JavaScript and WebAssembly performance](/docs/developer-guide/concepts/javascript-and-wasm-performance)

--- a/docs/modules/parquet/formats/parquet.md
+++ b/docs/modules/parquet/formats/parquet.md
@@ -253,7 +253,9 @@ returned in the projected Arrow schema. Candidate rows are still filtered exactl
 thread or worker. Repeated-leaf pruning is enabled when all selected leaves have compatible page boundaries,
 including pages that continue one logical row; files with incompatible boundaries conservatively use full
 column-chunk reads. Size statistics are available for memory and nested-value planning; semantic sorting
-pruning and encrypted-column reads remain future format-completeness work.
+pruning remains future format-completeness work. The TypeScript reader supports full reads of AES-GCM and
+AES-GCM-CTR encrypted column metadata and page modules when a key retriever is provided. Encrypted
+page-index reads and writer-side encryption remain future work.
 
 ## Integrity and Encryption
 
@@ -261,7 +263,7 @@ pruning and encrypted-column reads remain future format-completeness work.
 | ------- | ------- | -------- | ----- |
 | Footer and page-bound validation | ✅ | ✅ | Invalid magic, lengths, indexes, and truncated payloads are rejected |
 | Page CRC verification | ✅ (opt-in) | ✅ (opt-in) | CRC-32 covers the compressed page body; enable verification or emission explicitly to avoid a default throughput cost |
-| [Parquet modular encryption](https://github.com/apache/parquet-format/blob/master/Encryption.md) | ⚠️ | ❌ | AES-GCM/AES-CTR module primitives, AAD construction, and encrypted-footer metadata plumbing are available; encrypted-column range reads remain in progress |
+| [Parquet modular encryption](https://github.com/apache/parquet-format/blob/master/Encryption.md) | ⚠️ | ❌ | Encrypted footers, column metadata, and full AES-GCM/AES-GCM-CTR page reads are supported; encrypted page-index reads and writer-side encryption remain in progress |
 | External column chunks | ❌ | ❌ | `file_path` column references are rejected |
 
 ## Parquet and Arrow
@@ -290,7 +292,7 @@ variant has been exhaustively certified.
 | Tranche | Status | Remaining work |
 | ------- | ------ | -------------- |
 | Statistics-driven pruning | ✅ foundation | Use declared sort order for semantic page/row-group pruning and keep selective-range cost estimates aligned with late materialization |
-| Modular encryption | ⚠️ footer foundation | Decrypt column metadata and page/index modules for range reads; add key rotation and cross-implementation fixtures |
+| Modular encryption | ⚠️ reader foundation | Add encrypted page-index reads, plaintext-footer integrity verification, writer-side encryption/key rotation, and broader cross-implementation fixtures |
 | Logical and legacy parity | ⚠️ expanding | Broaden INT96 and legacy encoding coverage; preserve Arrow fidelity for every logical annotation |
 | Conformance and scale gate | ⚠️ ongoing | Run the Apache corpus, nested/repeated matrices, all stable codecs, differential checks, and large-file benchmarks in the slow lane |
 | Emerging-format lab | 🧪 experimental | Track ALP, PFOR, VECTOR, and format-versioning proposals behind explicit experimental flags; do not advertise them as stable support |

--- a/modules/parquet/src/lib/parquet-encryption.ts
+++ b/modules/parquet/src/lib/parquet-encryption.ts
@@ -60,11 +60,7 @@ export function createParquetModuleAad(
     'bloom-filter-bitset'
   ].indexOf(module);
   if (moduleType < 0) throw new Error(`Unknown Parquet encryption module ${module}`);
-  const isPageModule =
-    module === 'data-page' ||
-    module === 'dictionary-page' ||
-    module === 'data-page-header' ||
-    module === 'dictionary-page-header';
+  const isPageModule = module === 'data-page' || module === 'data-page-header';
   const suffixLength = fileUnique.length + (module === 'footer' ? 1 : isPageModule ? 7 : 5);
   const suffix = new Uint8Array(suffixLength);
   suffix.set(fileUnique);

--- a/modules/parquet/src/lib/parsers/parse-parquet-to-arrow-js.ts
+++ b/modules/parquet/src/lib/parsers/parse-parquet-to-arrow-js.ts
@@ -127,7 +127,9 @@ async function readProjectedSchema(
   options?: ParquetJSLoaderOptions
 ): Promise<Schema> {
   const reader = new ParquetReader(file, {
-    preserveBinary: options?.parquet?.preserveBinary
+    preserveBinary: options?.parquet?.preserveBinary,
+    keyRetriever: options?.parquet?.keyRetriever,
+    aadPrefix: options?.parquet?.aadPrefix
   });
   return projectSchema(await getSchemaFromParquetReader(reader), options?.parquet?.columns);
 }
@@ -149,7 +151,9 @@ export async function* parseParquetFileToArrowInBatchesWithJs(
     preserveBinary: options?.parquet?.preserveBinary,
     retainByteArrayViews: true,
     useTypedValueBuffers: true,
-    useTypedLevelBuffers: true
+    useTypedLevelBuffers: true,
+    keyRetriever: options?.parquet?.keyRetriever,
+    aadPrefix: options?.parquet?.aadPrefix
   });
   const schema = projectSchema(await getSchemaFromParquetReader(reader), options?.parquet?.columns);
   const arrowSchema = createParquetArrowSchema(schema);

--- a/modules/parquet/src/lib/parsers/parse-parquet-to-json.ts
+++ b/modules/parquet/src/lib/parsers/parse-parquet-to-json.ts
@@ -25,7 +25,9 @@ export async function parseParquetFile(
   await preloadCompressions(options);
 
   const reader = new ParquetReader(file, {
-    preserveBinary: options?.parquet?.preserveBinary
+    preserveBinary: options?.parquet?.preserveBinary,
+    keyRetriever: options?.parquet?.keyRetriever,
+    aadPrefix: options?.parquet?.aadPrefix
   });
 
   const schema = await getSchemaFromParquetReader(reader);
@@ -78,7 +80,9 @@ export async function* parseParquetFileInBatches(
   await preloadCompressions(options);
 
   const reader = new ParquetReader(file, {
-    preserveBinary: options?.parquet?.preserveBinary
+    preserveBinary: options?.parquet?.preserveBinary,
+    keyRetriever: options?.parquet?.keyRetriever,
+    aadPrefix: options?.parquet?.aadPrefix
   });
 
   const schema = await getSchemaFromParquetReader(reader);

--- a/modules/parquet/src/parquet-loader-options.ts
+++ b/modules/parquet/src/parquet-loader-options.ts
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import type {LoaderOptions} from '@loaders.gl/loader-utils';
+import type {ParquetKeyRetriever} from './lib/parquet-encryption';
 
 /** Shared row-level options supported by both Parquet backends. */
 type ParquetCommonLoaderOptions = {
@@ -38,6 +39,10 @@ export type ParquetLoaderOptions = LoaderOptions & {
 export type ParquetJSLoaderOptions = LoaderOptions & {
   parquet?: {
     shape?: 'object-row-table' | 'arrow-table';
+    /** Resolves modular-encryption keys from file and column key metadata. */
+    keyRetriever?: ParquetKeyRetriever;
+    /** AAD prefix for encrypted files that intentionally omit it from metadata. */
+    aadPrefix?: Uint8Array;
   } & {
     [Key in keyof ParquetCommonLoaderOptions]?: ParquetCommonLoaderOptions[Key];
   };

--- a/modules/parquet/src/parquet-source-loader.ts
+++ b/modules/parquet/src/parquet-source-loader.ts
@@ -890,7 +890,8 @@ export class ParquetSource
               columnList,
               rowRange,
               pagePlan.pageLocations,
-              signal
+              signal,
+              rowGroupIndex
             )
           )
         )
@@ -899,7 +900,8 @@ export class ParquetSource
             initialization.parquetSchema,
             rowGroup,
             columnList,
-            signal
+            signal,
+            rowGroupIndex
           )
         ];
     throwIfAborted(signal);

--- a/modules/parquet/src/parquetjs/parser/parquet-reader.ts
+++ b/modules/parquet/src/parquetjs/parser/parquet-reader.ts
@@ -11,7 +11,14 @@ import {decodeSchema, decodeDataPages, decodePage} from './decoders';
 import {materializeRows} from '../schema/shred';
 
 import {PARQUET_MAGIC, PARQUET_MAGIC_ENCRYPTED} from '../../lib/constants';
-import {ColumnChunk, CompressionCodec, FileMetaData, RowGroup, Type} from '../parquet-thrift/index';
+import {
+  ColumnChunk,
+  CompressionCodec,
+  FileMetaData,
+  PageType,
+  RowGroup,
+  Type
+} from '../parquet-thrift/index';
 import {
   ParquetRowGroup,
   ParquetCompression,
@@ -21,10 +28,13 @@ import {
   type ParquetLevelBuffer
 } from '../schema/declare';
 import {
+  decodeColumnMetadata,
   decodeFileCryptoMetadata,
   decodeFileMetadata,
+  decodePageHeader,
   getThriftEnum,
-  fieldIndexOf
+  fieldIndexOf,
+  serializeThrift
 } from '../utils/read-utils';
 import {decodeString, readUInt32LE, toUint8Array} from '../utils/binary-utils';
 import {CompactInt64} from '../utils/uint8-array-compact-protocol';
@@ -39,6 +49,7 @@ import {
   type ParquetEncryptionAlgorithm,
   type ParquetKeyRetriever
 } from '../../lib/parquet-encryption';
+import type {ParquetEncryptionModule} from '../../lib/parquet-encryption';
 
 /** Bounds concurrent range requests when a row group contains unusually many selected columns. */
 const MAXIMUM_CONCURRENT_COLUMN_READS = 16;
@@ -89,6 +100,14 @@ type NormalizedParquetReaderProps = Required<
 > &
   Pick<ParquetReaderProps, 'signal' | 'keyRetriever' | 'aadPrefix'>;
 
+/** File-level parameters needed to authenticate modular-encrypted modules. */
+type ParquetEncryptionContext = {
+  algorithm: ParquetEncryptionAlgorithm;
+  aadPrefix?: Uint8Array;
+  fileUnique: Uint8Array;
+  footerKeyMetadata?: Uint8Array;
+};
+
 /**
  * The parquet envelope reader allows direct, unbuffered access to the individual
  * sections of the parquet file, namely the header, footer and the row groups.
@@ -114,6 +133,8 @@ export class ParquetReader {
   metadata: Promise<FileMetaData> | null = null;
   /** Parsed Parquet schema shared by metadata, iteration, and materialization paths. */
   private schema: Promise<ParquetSchema> | null = null;
+  /** Encryption parameters decoded from plaintext or encrypted footer metadata. */
+  private encryptionContext?: ParquetEncryptionContext;
 
   constructor(file: ReadableFile, props?: ParquetReaderProps) {
     this.file = file;
@@ -165,7 +186,8 @@ export class ParquetReader {
         schema,
         metadata.row_groups[rowGroupIndex],
         columnList,
-        props?.signal
+        props?.signal,
+        rowGroupIndex
       );
       yield rowGroup;
     }
@@ -256,6 +278,7 @@ export class ParquetReader {
     // parquet_util.decodeThrift(metadata, metadataBuf);
 
     const {metadata} = decodeFileMetadata(metadataBuf);
+    this.setEncryptionContext(metadata);
     return metadata;
   }
 
@@ -287,7 +310,77 @@ export class ParquetReader {
       keyMetadata: cryptoMetadata.metadata.key_metadata,
       keyRetriever: this.props.keyRetriever
     });
+    this.encryptionContext = {
+      algorithm,
+      aadPrefix,
+      fileUnique: algorithmMetadata.aad_file_unique,
+      footerKeyMetadata: cryptoMetadata.metadata.key_metadata
+    };
     return decodeFileMetadata(plaintext).metadata;
+  }
+
+  /** Records the encryption parameters exposed by plaintext-footer files. */
+  private setEncryptionContext(metadata: FileMetaData): void {
+    const encryptionAlgorithm = metadata.encryption_algorithm;
+    if (!encryptionAlgorithm) return;
+    const algorithm = getEncryptionAlgorithm(encryptionAlgorithm);
+    const algorithmMetadata = encryptionAlgorithm.AES_GCM_V1 || encryptionAlgorithm.AES_GCM_CTR_V1;
+    if (!algorithmMetadata?.aad_file_unique) {
+      throw new Error('Encrypted Parquet footer is missing aad_file_unique');
+    }
+    this.encryptionContext = {
+      algorithm,
+      aadPrefix: algorithmMetadata.aad_prefix || this.props.aadPrefix,
+      fileUnique: algorithmMetadata.aad_file_unique,
+      footerKeyMetadata: metadata.footer_signing_key_metadata
+    };
+  }
+
+  /** Resolves a column's plaintext metadata, decrypting column-specific metadata when present. */
+  private async getColumnMetadata(
+    columnChunk: ColumnChunk,
+    rowGroupOrdinal: number,
+    columnOrdinal: number
+  ): Promise<NonNullable<ColumnChunk['meta_data']>> {
+    if (!columnChunk.encrypted_column_metadata) {
+      if (!columnChunk.meta_data) {
+        throw new Error('Parquet column metadata is missing');
+      }
+      return columnChunk.meta_data;
+    }
+    if (!this.props.keyRetriever) {
+      throw new Error('Encrypted Parquet column metadata requires parquet.keyRetriever');
+    }
+    const encryptionContext = this.encryptionContext;
+    if (!encryptionContext) {
+      throw new Error('Encrypted Parquet column metadata has no file encryption context');
+    }
+    const columnKey = columnChunk.crypto_metadata?.ENCRYPTION_WITH_COLUMN_KEY;
+    const usesFooterKey = Boolean(columnChunk.crypto_metadata?.ENCRYPTION_WITH_FOOTER_KEY);
+    if (!columnKey && !usesFooterKey) {
+      throw new Error('Encrypted Parquet column metadata has no key reference');
+    }
+    const aad = createParquetModuleAad(
+      encryptionContext.aadPrefix,
+      encryptionContext.fileUnique,
+      'column-metadata',
+      rowGroupOrdinal,
+      columnOrdinal
+    );
+    const plaintext = await decryptParquetModule(columnChunk.encrypted_column_metadata, {
+      algorithm: encryptionContext.algorithm,
+      aad,
+      keyMetadata: columnKey?.key_metadata ?? encryptionContext.footerKeyMetadata,
+      keyRetriever: this.props.keyRetriever
+    });
+    const metadata = decodeColumnMetadata(plaintext).metadata;
+    if (
+      columnKey &&
+      JSON.stringify(metadata.path_in_schema) !== JSON.stringify(columnKey.path_in_schema)
+    ) {
+      throw new Error('Encrypted Parquet column metadata path does not match crypto metadata');
+    }
+    return metadata;
   }
 
   /** Data is stored in row groups (similar to Apache Arrow record batches) */
@@ -295,12 +388,21 @@ export class ParquetReader {
     schema: ParquetSchema,
     rowGroup: RowGroup,
     columnList: string[][],
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    rowGroupOrdinal = 0
   ): Promise<ParquetRowGroup> {
-    const selectedColumnChunks = rowGroup.columns.filter(columnChunk => {
-      const columnKey = columnChunk.meta_data?.path_in_schema;
-      return columnList.length === 0 || fieldIndexOf(columnList, columnKey!) >= 0;
-    });
+    const selectedColumnChunks: Array<{
+      columnChunk: ColumnChunk;
+      metadata: NonNullable<ColumnChunk['meta_data']>;
+      columnOrdinal: number;
+    }> = [];
+    for (let columnOrdinal = 0; columnOrdinal < rowGroup.columns.length; columnOrdinal++) {
+      const columnChunk = rowGroup.columns[columnOrdinal];
+      const metadata = await this.getColumnMetadata(columnChunk, rowGroupOrdinal, columnOrdinal);
+      if (columnList.length === 0 || fieldIndexOf(columnList, metadata.path_in_schema) >= 0) {
+        selectedColumnChunks.push({columnChunk, metadata, columnOrdinal});
+      }
+    }
     const columnEntries: Array<readonly [string, ParquetColumnChunk]> = [];
     for (
       let batchStart = 0;
@@ -313,9 +415,16 @@ export class ParquetReader {
       );
       columnEntries.push(
         ...(await Promise.all(
-          columnBatch.map(async columnChunk => {
-            const columnKey = columnChunk.meta_data!.path_in_schema.join();
-            const columnData = await this.readColumnChunk(schema, columnChunk, signal);
+          columnBatch.map(async ({columnChunk, metadata, columnOrdinal}) => {
+            const columnKey = metadata.path_in_schema.join();
+            const columnData = await this.readColumnChunk(
+              schema,
+              columnChunk,
+              signal,
+              rowGroupOrdinal,
+              columnOrdinal,
+              metadata
+            );
             return [columnKey, columnData] as const;
           })
         ))
@@ -334,16 +443,25 @@ export class ParquetReader {
     columnList: string[][],
     rowRange: ParquetRowRange,
     pageLocations: ParquetPageLocations,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    rowGroupOrdinal = 0
   ): Promise<ParquetRowGroup> {
-    const selectedColumnChunks = rowGroup.columns.filter(columnChunk => {
-      const columnKey = columnChunk.meta_data?.path_in_schema;
-      return columnList.length === 0 || fieldIndexOf(columnList, columnKey!) >= 0;
-    });
+    const selectedColumnChunks: Array<{
+      columnChunk: ColumnChunk;
+      metadata: NonNullable<ColumnChunk['meta_data']>;
+      columnOrdinal: number;
+    }> = [];
+    for (let columnOrdinal = 0; columnOrdinal < rowGroup.columns.length; columnOrdinal++) {
+      const columnChunk = rowGroup.columns[columnOrdinal];
+      const metadata = await this.getColumnMetadata(columnChunk, rowGroupOrdinal, columnOrdinal);
+      if (columnList.length === 0 || fieldIndexOf(columnList, metadata.path_in_schema) >= 0) {
+        selectedColumnChunks.push({columnChunk, metadata, columnOrdinal});
+      }
+    }
     const columnEntries = await Promise.all(
-      selectedColumnChunks.map(async columnChunk => {
-        const columnKey = columnChunk.meta_data!.path_in_schema.join();
-        const pages = pageLocations[JSON.stringify(columnChunk.meta_data!.path_in_schema)];
+      selectedColumnChunks.map(async ({columnChunk, metadata, columnOrdinal}) => {
+        const columnKey = metadata.path_in_schema.join();
+        const pages = pageLocations[JSON.stringify(metadata.path_in_schema)];
         if (!pages) {
           throw new Error(`Parquet offset index missing for ${columnKey}`);
         }
@@ -352,7 +470,10 @@ export class ParquetReader {
           columnChunk,
           rowRange,
           pages,
-          signal
+          signal,
+          rowGroupOrdinal,
+          columnOrdinal,
+          metadata
         );
         return [columnKey, columnData] as const;
       })
@@ -369,32 +490,36 @@ export class ParquetReader {
   async readColumnChunk(
     schema: ParquetSchema,
     colChunk: ColumnChunk,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    rowGroupOrdinal = 0,
+    columnOrdinal = 0,
+    resolvedMetadata?: NonNullable<ColumnChunk['meta_data']>
   ): Promise<ParquetColumnChunk> {
     if (colChunk.file_path !== undefined && colChunk.file_path !== null) {
       throw new Error('external references are not supported');
     }
 
-    const field = schema.findField(colChunk.meta_data?.path_in_schema!);
-    const type: PrimitiveType = getThriftEnum(Type, colChunk.meta_data?.type!) as any;
+    const metadata = resolvedMetadata || colChunk.meta_data;
+    if (!metadata) {
+      throw new Error('Parquet column metadata is missing');
+    }
+    const field = schema.findField(metadata.path_in_schema);
+    const type: PrimitiveType = getThriftEnum(Type, metadata.type) as any;
 
     if (type !== field.primitiveType) {
       throw new Error(`chunk type not matching schema: ${type}`);
     }
 
-    const compression: ParquetCompression = getThriftEnum(
-      CompressionCodec,
-      colChunk.meta_data?.codec!
-    ) as any;
+    const compression: ParquetCompression = getThriftEnum(CompressionCodec, metadata.codec) as any;
 
-    const pagesOffset = Number(colChunk.meta_data?.data_page_offset!);
-    const dictionaryPageOffset = colChunk.meta_data?.dictionary_page_offset;
+    const pagesOffset = Number(metadata.data_page_offset);
+    const dictionaryPageOffset = metadata.dictionary_page_offset;
     const validDictionaryPageOffset =
       dictionaryPageOffset !== undefined && Number(dictionaryPageOffset) > 0
         ? Number(dictionaryPageOffset)
         : undefined;
     const chunkOffset = Math.min(pagesOffset, validDictionaryPageOffset ?? pagesOffset);
-    const chunkEnd = chunkOffset + Number(colChunk.meta_data?.total_compressed_size!);
+    const chunkEnd = chunkOffset + Number(metadata.total_compressed_size);
     const chunkSize = Math.min(this.file.size - chunkOffset, Math.max(0, chunkEnd - chunkOffset));
     const arrayBuffer = await this.file.read(chunkOffset, chunkSize, signal ?? this.props.signal);
     const chunkBuffer = toUint8Array(arrayBuffer);
@@ -410,7 +535,7 @@ export class ParquetReader {
       dLevelMax: field.dLevelMax,
       compression,
       column: field,
-      numValues: colChunk.meta_data?.num_values,
+      numValues: metadata.num_values,
       dictionary: [],
       // Options - TBD is this the right place for these?
       preserveBinary: this.props.preserveBinary,
@@ -433,12 +558,108 @@ export class ParquetReader {
         dictionaryRelativeOffset,
         dictionaryRelativeOffset + dictionarySize
       );
-      dictionary = await decodeDictionaryBuffer(dictionaryBuffer, context);
+      const decodedDictionaryBuffer = colChunk.crypto_metadata
+        ? await this.decryptColumnPages(
+            dictionaryBuffer,
+            context,
+            rowGroupOrdinal,
+            columnOrdinal,
+            this.getColumnKeyMetadata(colChunk),
+            true
+          )
+        : dictionaryBuffer;
+      dictionary = await decodeDictionaryBuffer(decodedDictionaryBuffer, context);
     }
 
     dictionary = context.dictionary?.length ? context.dictionary : dictionary;
-    const pagesBuf = chunkBuffer.subarray(pagesRelativeOffset, pagesRelativeOffset + pagesSize);
+    const pagesBuf = colChunk.crypto_metadata
+      ? await this.decryptColumnPages(
+          chunkBuffer.subarray(pagesRelativeOffset, pagesRelativeOffset + pagesSize),
+          context,
+          rowGroupOrdinal,
+          columnOrdinal,
+          this.getColumnKeyMetadata(colChunk)
+        )
+      : chunkBuffer.subarray(pagesRelativeOffset, pagesRelativeOffset + pagesSize);
     return await decodeDataPages(pagesBuf, {...context, dictionary});
+  }
+
+  /** Decrypts the length-prefixed page header and data modules in one column chunk. */
+  private async decryptColumnPages(
+    encryptedPages: Uint8Array,
+    context: ParquetReaderContext,
+    rowGroupOrdinal: number,
+    columnOrdinal: number,
+    keyMetadata: Uint8Array | undefined,
+    includesDictionary = false
+  ): Promise<Uint8Array> {
+    if (!this.encryptionContext || !this.props.keyRetriever) {
+      throw new Error('Encrypted Parquet pages require parquet.keyRetriever');
+    }
+    const plaintextPages: Uint8Array[] = [];
+    let offset = 0;
+    let dataPageOrdinal = 0;
+    let pageIndex = 0;
+    while (offset < encryptedPages.length) {
+      const headerModule = readEncryptedModule(encryptedPages, offset);
+      offset = headerModule.nextOffset;
+      const dictionaryPage = includesDictionary && pageIndex === 0;
+      const headerModuleType: ParquetEncryptionModule = dictionaryPage
+        ? 'dictionary-page-header'
+        : 'data-page-header';
+      const headerAad = createParquetModuleAad(
+        this.encryptionContext.aadPrefix,
+        this.encryptionContext.fileUnique,
+        headerModuleType,
+        rowGroupOrdinal,
+        columnOrdinal,
+        dictionaryPage ? undefined : dataPageOrdinal
+      );
+      const headerBytes = await decryptParquetModule(headerModule.bytes, {
+        algorithm: this.encryptionContext.algorithm,
+        aad: headerAad,
+        keyMetadata,
+        keyRetriever: this.props.keyRetriever
+      });
+      const {pageHeader} = decodePageHeader(headerBytes);
+      const pageType = getThriftEnum(PageType, pageHeader.type);
+      const dataModule = readEncryptedModule(encryptedPages, offset);
+      offset = dataModule.nextOffset;
+      const dataAad = createParquetModuleAad(
+        this.encryptionContext.aadPrefix,
+        this.encryptionContext.fileUnique,
+        dictionaryPage ? 'dictionary-page' : 'data-page',
+        rowGroupOrdinal,
+        columnOrdinal,
+        dictionaryPage ? undefined : dataPageOrdinal
+      );
+      const dataBytes = await decryptParquetModule(dataModule.bytes, {
+        algorithm: this.encryptionContext.algorithm,
+        aad: dataAad,
+        keyMetadata,
+        keyRetriever: this.props.keyRetriever,
+        page: true
+      });
+      plaintextPages.push(serializeThrift(pageHeader), dataBytes);
+      if (pageType !== 'DICTIONARY_PAGE') dataPageOrdinal++;
+      pageIndex++;
+    }
+    const plaintextLength = plaintextPages.reduce((total, page) => total + page.length, 0);
+    const plaintext = new Uint8Array(plaintextLength);
+    let plaintextOffset = 0;
+    for (const page of plaintextPages) {
+      plaintext.set(page, plaintextOffset);
+      plaintextOffset += page.length;
+    }
+    return plaintext;
+  }
+
+  /** Resolves the key metadata reference for an encrypted column. */
+  private getColumnKeyMetadata(columnChunk: ColumnChunk): Uint8Array | undefined {
+    return (
+      columnChunk.crypto_metadata?.ENCRYPTION_WITH_COLUMN_KEY?.key_metadata ??
+      this.encryptionContext?.footerKeyMetadata
+    );
   }
 
   /** Reads and decodes contiguous data pages that begin and end on complete row boundaries. */
@@ -447,12 +668,43 @@ export class ParquetReader {
     columnChunk: ColumnChunk,
     rowRange: ParquetRowRange,
     pages: readonly ParquetDataPageLocation[],
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    rowGroupOrdinal = 0,
+    columnOrdinal = 0,
+    resolvedMetadata?: NonNullable<ColumnChunk['meta_data']>
   ): Promise<ParquetColumnChunk> {
     if (columnChunk.file_path !== undefined && columnChunk.file_path !== null) {
       throw new Error('external references are not supported');
     }
-    const columnMetadata = columnChunk.meta_data!;
+    const columnMetadata = resolvedMetadata || columnChunk.meta_data;
+    if (!columnMetadata) {
+      throw new Error('Parquet column metadata is missing');
+    }
+    if (columnChunk.crypto_metadata) {
+      const fullColumnChunk = await this.readColumnChunk(
+        schema,
+        columnChunk,
+        signal,
+        rowGroupOrdinal,
+        columnOrdinal,
+        columnMetadata
+      );
+      const field = schema.findField(columnMetadata.path_in_schema);
+      if (field.rLevelMax !== 0) {
+        return sliceRepeatedColumnChunk(
+          fullColumnChunk,
+          rowRange.start,
+          rowRange.end - rowRange.start,
+          field.dLevelMax
+        );
+      }
+      return sliceNonRepeatedColumnChunk(
+        fullColumnChunk,
+        field.dLevelMax,
+        rowRange.start,
+        rowRange.end
+      );
+    }
     const field = schema.findField(columnMetadata.path_in_schema);
     const type: PrimitiveType = getThriftEnum(Type, columnMetadata.type) as any;
     if (type !== field.primitiveType) {
@@ -584,6 +836,23 @@ async function decodeDictionaryBuffer(
   const cursor = {buffer: dictionaryBuffer, offset: 0, size: dictionaryBuffer.length};
   const decodedPage = await decodePage(cursor, context);
   return decodedPage.dictionary!;
+}
+
+/** Reads one length-prefixed encrypted module from a page stream. */
+function readEncryptedModule(
+  buffer: Uint8Array,
+  offset: number
+): {bytes: Uint8Array; nextOffset: number} {
+  if (offset + 4 > buffer.length) {
+    throw new Error('Invalid encrypted Parquet page: missing module length');
+  }
+  const length = readUInt32LE(buffer, offset);
+  const moduleStart = offset + 4;
+  const moduleEnd = moduleStart + length;
+  if (length < 12 || moduleEnd > buffer.length) {
+    throw new Error('Invalid encrypted Parquet page: truncated module');
+  }
+  return {bytes: buffer.subarray(moduleStart, moduleEnd), nextOffset: moduleEnd};
 }
 
 /** Slices one decoded non-repeated column chunk while preserving optional-value alignment. */

--- a/modules/parquet/src/parquetjs/utils/read-utils.ts
+++ b/modules/parquet/src/parquetjs/utils/read-utils.ts
@@ -4,7 +4,12 @@
 // Copyright (c) 2017 ironSource Ltd.
 // Forked from https://github.com/kbajalc/parquets under MIT license
 
-import {FileCryptoMetaData, FileMetaData, PageHeader} from '../parquet-thrift/index';
+import {
+  ColumnMetaData,
+  FileCryptoMetaData,
+  FileMetaData,
+  PageHeader
+} from '../parquet-thrift/index';
 import {Uint8ArrayCompactProtocol} from './uint8-array-compact-protocol';
 import {Uint8ArrayCompactProtocolWriter} from './uint8-array-compact-protocol-writer';
 import {Uint8ArrayTransport} from './uint8-array-transport';
@@ -74,6 +79,16 @@ export function decodeFileCryptoMetadata(buf: Uint8Array, offset?: number) {
   transport.readPos = offset;
   const protocol = new Uint8ArrayCompactProtocol(transport);
   const metadata = FileCryptoMetaData.read(protocol as any);
+  return {length: transport.readPos - offset, metadata};
+}
+
+/** Decodes a serialized ColumnMetaData encryption module. */
+export function decodeColumnMetadata(buf: Uint8Array, offset?: number) {
+  if (!offset) offset = 0;
+  const transport = new Uint8ArrayTransport(buf);
+  transport.readPos = offset;
+  const protocol = new Uint8ArrayCompactProtocol(transport);
+  const metadata = ColumnMetaData.read(protocol as any);
   return {length: transport.readPos - offset, metadata};
 }
 

--- a/modules/parquet/test/parquet-encryption.spec.ts
+++ b/modules/parquet/test/parquet-encryption.spec.ts
@@ -1,0 +1,89 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {load} from '@loaders.gl/core';
+import {ParquetJSLoader} from '@loaders.gl/parquet';
+import {expect, test} from 'vitest';
+
+const PARQUET_DIR = '@loaders.gl/parquet/test/data/apache';
+
+const ENCRYPTED_KEYS: Record<string, Uint8Array> = {
+  kf: new TextEncoder().encode('0123456789012345'),
+  kc1: new TextEncoder().encode('1234567890123450'),
+  kc2: new TextEncoder().encode('1234567890123451')
+};
+
+/** Resolves the keys used by the Apache modular-encryption fixtures. */
+function getEncryptedFixtureKey(keyMetadata: Uint8Array | ArrayBuffer | undefined): Uint8Array {
+  const keyBytes =
+    keyMetadata instanceof Uint8Array
+      ? keyMetadata
+      : keyMetadata
+        ? new Uint8Array(keyMetadata)
+        : new Uint8Array();
+  const key = ENCRYPTED_KEYS[new TextDecoder().decode(keyBytes)];
+  if (!key) throw new Error(`Unknown key metadata ${new TextDecoder().decode(keyBytes)}`);
+  return key;
+}
+
+/** Returns deterministic loader options for the encrypted fixture tests. */
+function getEncryptedLoaderOptions() {
+  return {
+    core: {worker: false},
+    parquet: {
+      columns: ['double_field', 'float_field'],
+      keyRetriever: getEncryptedFixtureKey
+    }
+  };
+}
+
+test('ParquetJSLoader decrypts modular encrypted columns into object rows', async () => {
+  const url = `${PARQUET_DIR}/encrypted/encrypt_columns_and_footer.parquet.encrypted`;
+  const table = await load(url, ParquetJSLoader, getEncryptedLoaderOptions());
+
+  expect(table.shape).toBe('object-row-table');
+  if (table.shape === 'object-row-table') {
+    expect(table.data).toHaveLength(50);
+    expect(typeof table.data[0].double_field).toBe('number');
+    expect(typeof table.data[0].float_field).toBe('number');
+  }
+});
+
+test('ParquetJSLoader decrypts AES-CTR encrypted page modules', async () => {
+  const url = `${PARQUET_DIR}/encrypted/encrypt_columns_and_footer_ctr.parquet.encrypted`;
+  const table = await load(url, ParquetJSLoader, getEncryptedLoaderOptions());
+
+  expect(table.shape).toBe('object-row-table');
+  if (table.shape === 'object-row-table') {
+    expect(table.data).toHaveLength(50);
+    expect(typeof table.data[0].double_field).toBe('number');
+  }
+});
+
+test('ParquetJSLoader decrypts encrypted columns with a plaintext footer', async () => {
+  const url = `${PARQUET_DIR}/encrypted/encrypt_columns_plaintext_footer.parquet.encrypted`;
+  const table = await load(url, ParquetJSLoader, getEncryptedLoaderOptions());
+
+  expect(table.shape).toBe('object-row-table');
+  if (table.shape === 'object-row-table') {
+    expect(table.data).toHaveLength(50);
+  }
+});
+
+test('ParquetJSLoader decrypts encrypted columns into an Arrow table', async () => {
+  const url = `${PARQUET_DIR}/encrypted/encrypt_columns_and_footer.parquet.encrypted`;
+  const table = await load(url, ParquetJSLoader, {
+    ...getEncryptedLoaderOptions(),
+    parquet: {...getEncryptedLoaderOptions().parquet, shape: 'arrow-table'}
+  });
+
+  expect(table.shape).toBe('arrow-table');
+  if (table.shape === 'arrow-table') {
+    expect(table.data.numRows).toBe(50);
+    expect(table.data.schema.fields.map(field => field.name).sort()).toEqual([
+      'double_field',
+      'float_field'
+    ]);
+  }
+});

--- a/modules/parquet/test/parquet-page-index-api.spec.ts
+++ b/modules/parquet/test/parquet-page-index-api.spec.ts
@@ -103,15 +103,19 @@ describe('Parquet page-index public helpers', () => {
     expect(new TextDecoder().decode(decoded)).toBe('footer');
   });
 
-  test('includes page ordinals for all encrypted page modules', () => {
+  test('includes page ordinals only for data page modules', () => {
     const fileUnique = new Uint8Array(8).fill(2);
-    for (const module of ['data-page', 'dictionary-page', 'data-page-header', 'dictionary-page-header'] as const) {
+    for (const module of ['data-page', 'data-page-header'] as const) {
       const aad = createParquetModuleAad(undefined, fileUnique, module, 3, 5, 7);
       expect(aad.byteLength).toBe(15);
       const suffix = new DataView(aad.buffer, aad.byteOffset, aad.byteLength);
       expect(suffix.getInt16(8 + 1, true)).toBe(3);
       expect(suffix.getInt16(8 + 3, true)).toBe(5);
       expect(suffix.getInt16(8 + 5, true)).toBe(7);
+    }
+    for (const module of ['dictionary-page', 'dictionary-page-header'] as const) {
+      const aad = createParquetModuleAad(undefined, fileUnique, module, 3, 5, 7);
+      expect(aad.byteLength).toBe(13);
     }
   });
 });


### PR DESCRIPTION
## Goals

- Complete the TypeScript reader's core Parquet modular-encryption interoperability.
- Preserve safe selective-read behavior while encrypted page indexes remain a separate follow-up.
- Document the supported scope and keep emerging proposals explicitly experimental.

## Changes

- Decrypt encrypted footers and column metadata with the configured key retriever.
- Decode AES-GCM and AES-GCM-CTR encrypted dictionary/data page modules with spec-correct AAD and page ordinals.
- Thread key-retriever and AAD-prefix options through object-row and Arrow parsing paths.
- Preserve offset indexes when column-index statistics are not logically ordered, including the landed page-index safety fix.
- Pass the actual row-group ordinal into selective range reads.
- Add Vitest coverage for encrypted footers, plaintext footers, both page algorithms, and Arrow output.
- Update Parquet format and loader documentation with the supported encryption scope.

## Scope and follow-ups

Encrypted page-index reads, plaintext-footer integrity verification, writer-side encryption/key rotation, and broader cross-implementation fixtures remain follow-up work. ALP, PFOR, VECTOR, and format-versioning proposals remain experimental and are not advertised as stable support.

## Validation

- `yarn build`
- `yarn lint fix`
- `yarn test-headless modules/parquet/test/parquet-loader.spec.ts modules/parquet/test/parquet-encryption.spec.ts modules/parquet/test/parquet-page-index-api.spec.ts`
- `git diff --check`
