### PR TITLE
feat(scan): add residual predicates to CSV and NDJSON

### DIFF
--- a/docs/developer-guide/common-scan-architecture.md
+++ b/docs/developer-guide/common-scan-architecture.md
@@ -29,7 +29,7 @@ different query model, such as tiles or raster windows, rather than a relational
 | Delta Lake / Lance | Partial | Read-only metadata and Arrow-batch paths exist; common snapshot/fragment planning and predicate pushdown are incomplete. |
 | COPC / Potree | Partial | Point-cloud metadata, coordinate roles, hierarchy bounds, level-of-detail, spacing, and capability discovery are available; full common point streaming is source-specific. |
 | GeoTIFF / COG / Zarr / GeoZarr / OME-Zarr | Partial | Raster window, band/channel, overview/level, and multidimensional selection APIs are available with shared query validation and capabilities. |
-| NetCDF | Planned | The loader is available; the shared multidimensional raster scan contract is not yet wired in. |
+| NetCDF | Partial | Header-only scan metadata exposes variables, dimensions, attributes, and file statistics; data reads and slice pushdown remain follow-up work. |
 | MVT / PMTiles / 3D Tiles / I3S | Specialized | Use tile and tileset source APIs; tile addressing and level-of-detail remain outside `TableQuery`. |
 | WMS / WFS / STAC and other services | Specialized | Use the service or catalog query APIs; they are not normalized into the table scan contract. |
 
@@ -710,7 +710,7 @@ exposed yet. A residual predicate is still correct; it simply cannot avoid decod
 | LAS / LAZ / PLY / PCD / splats | Planned | header | sequential attribute decode | residual unless indexed | planned | P2 |
 | GeoTIFF / COG | Foundation | TIFF/overview metadata | bands/windows | window pushdown | tile-local / typed arrays | P1 |
 | Zarr / GeoZarr / OME-Zarr | Foundation | group/array metadata | variables/channels | chunk/window pushdown | chunked / typed arrays | P1 |
-| NetCDF | Planned | file dimensions/variables | variables/slices | window/slice pushdown | chunked / typed arrays | P1 |
+| NetCDF | Foundation | file dimensions/variables | metadata only | planned window/slice pushdown | planned chunked / typed arrays | P1 |
 | Terrain / LERC | Planned | tile/codec metadata | bands/tiles | tile bounds | tile streams | P2 |
 | MVT / PMTiles | Specialized | tile/catalog metadata | feature-layer selection | tile bounds, optional residual table view | tile streams | P2 |
 | 3D Tiles / I3S | Specialized | tileset metadata | tile content | volume/LOD pushdown | tile streams | P2 |

--- a/docs/modules/netcdf/api-reference/README.md
+++ b/docs/modules/netcdf/api-reference/README.md
@@ -3,3 +3,19 @@
 ![ogc-logo](../../../images/logos/ogc-logo-60.png)
 
 OGC network Common Data Form (netCDF) standards suite
+
+## Scan metadata
+
+`NetCDFSource` and `NetCDFSourceLoader` expose NetCDF classic and 64-bit-offset headers through
+the shared scan architecture. `getQueryMetadata()` discovers variable names, portable scalar
+types, variable attributes, dimensions, and file size without decoding data arrays. This makes
+NetCDF files usable by source-neutral query panels today; projection, filtering, limits, and
+chunked slice reads are intentionally reported as unsupported until a data-scan executor is added.
+
+```ts
+import {NetCDFSource} from '@loaders.gl/netcdf/netcdf-source-loader';
+
+const source = new NetCDFSource('weather.nc', {});
+const metadata = await source.getQueryMetadata();
+console.log(metadata.columns, metadata.schema.metadata);
+```

--- a/modules/csv/src/csv-source.ts
+++ b/modules/csv/src/csv-source.ts
@@ -1,4 +1,9 @@
-import {createScanQueryMetadata, validateTableQueryLimit} from '@loaders.gl/loader-utils';
+import {
+  createScanQueryMetadata,
+  filterColumnarRowIndices,
+  validateColumnarPredicate,
+  validateTableQueryLimit
+} from '@loaders.gl/loader-utils';
 import type {
   CoreAPI,
   DataSourceOptions,
@@ -40,9 +45,10 @@ export class CSVTableSource
       options.limit === undefined ? Number.POSITIVE_INFINITY : Math.max(0, options.limit);
     for await (const batch of this.parseBatches(options.signal)) {
       if (remaining <= 0) return;
-      const projectedBatch = projectBatch(batch, options.columns);
+      const filteredBatch = filterBatch(batch, options.predicate);
+      const projectedBatch = projectBatch(filteredBatch, options.columns);
       if (projectedBatch.length <= remaining) {
-        remaining -= batch.length;
+        remaining -= projectedBatch.length;
         yield projectedBatch;
       } else {
         yield truncateBatch(projectedBatch, remaining);
@@ -60,7 +66,7 @@ export class CSVTableSource
         schema: batch.schema,
         capabilities: {
           table: {
-            predicate: 'unsupported',
+            predicate: 'residual',
             projection: 'pushdown',
             limit: 'pushdown',
             streaming: true,
@@ -167,4 +173,16 @@ function projectBatch(batch: TableBatch, columns?: readonly string[]): TableBatc
   if (batch.shape === 'arrow-table')
     return {...batch, data: batch.data.select([...columns])} as TableBatch;
   return batch;
+}
+
+function filterBatch(batch: TableBatch, predicate: TableScanReadOptions['predicate']): TableBatch {
+  if (!predicate || batch.shape !== 'object-row-table') return batch;
+  const rows = batch.data;
+  const columnNames = new Set(batch.schema?.fields.map(field => field.name) || []);
+  validateColumnarPredicate(predicate, columnNames);
+  const columns = Object.fromEntries(
+    [...columnNames].map(name => [name, rows.map(row => row[name])])
+  );
+  const rowIndices = filterColumnarRowIndices(predicate, columns, rows.length);
+  return {...batch, data: rowIndices.map(rowIndex => rows[rowIndex]), length: rowIndices.length};
 }

--- a/modules/csv/src/csv-source.ts
+++ b/modules/csv/src/csv-source.ts
@@ -183,6 +183,6 @@ function filterBatch(batch: TableBatch, predicate: TableScanReadOptions['predica
   const columns = Object.fromEntries(
     [...columnNames].map(name => [name, rows.map(row => row[name])])
   );
-  const rowIndices = filterColumnarRowIndices(predicate, columns, rows.length);
+  const rowIndices = filterColumnarRowIndices(predicate as never, columns, rows.length);
   return {...batch, data: rowIndices.map(rowIndex => rows[rowIndex]), length: rowIndices.length};
 }

--- a/modules/csv/test/csv-source.cross.spec.ts
+++ b/modules/csv/test/csv-source.cross.spec.ts
@@ -11,6 +11,17 @@ test('CSVTableSource discovers schema and applies projection and limit', async (
   expect(batches[0]?.data).toEqual([{value: 1}]);
 });
 
+test('CSVTableSource applies residual predicates before projection and limit', async () => {
+  const source = new CSVTableSource(new Blob(['name,value\na,1\nb,2\nc,3\n']));
+  const batches = [];
+  for await (const batch of source.read({predicate: {op: '>', args: [{property: 'value'}, 1]}}))
+    batches.push(batch);
+  expect(batches.flatMap(batch => batch.data)).toEqual([
+    {name: 'b', value: 2},
+    {name: 'c', value: 3}
+  ]);
+});
+
 test('CSVTableSource rejects invalid limits and forwards aborts', async () => {
   const source = new CSVTableSource(new Blob(['a\n1\n']));
   await expect(async () => {

--- a/modules/json/src/ndjson-source.ts
+++ b/modules/json/src/ndjson-source.ts
@@ -1,4 +1,9 @@
-import {createScanQueryMetadata, validateTableQueryLimit} from '@loaders.gl/loader-utils';
+import {
+  createScanQueryMetadata,
+  filterColumnarRowIndices,
+  validateColumnarPredicate,
+  validateTableQueryLimit
+} from '@loaders.gl/loader-utils';
 import type {
   CoreAPI,
   DataSourceOptions,
@@ -39,7 +44,8 @@ export class NDJSONTableSource
       options.limit === undefined ? Number.POSITIVE_INFINITY : Math.max(0, options.limit);
     for await (const batch of this.parseBatches(options.signal)) {
       if (remaining <= 0) return;
-      const projectedBatch = projectBatch(batch, options.columns);
+      const filteredBatch = filterBatch(batch, options.predicate);
+      const projectedBatch = projectBatch(filteredBatch, options.columns);
       if (projectedBatch.length <= remaining) {
         remaining -= projectedBatch.length;
         yield projectedBatch;
@@ -59,7 +65,7 @@ export class NDJSONTableSource
           schema: batch.schema,
           capabilities: {
             table: {
-              predicate: 'unsupported',
+              predicate: 'residual',
               projection: 'pushdown',
               limit: 'pushdown',
               streaming: true,
@@ -162,4 +168,16 @@ function projectBatch(batch: TableBatch, columns?: readonly string[]): TableBatc
     } as TableBatch;
   if (batch.shape === 'arrow-table') return {...batch, data: batch.data.select([...columns])};
   return batch;
+}
+
+function filterBatch(batch: TableBatch, predicate: TableScanReadOptions['predicate']): TableBatch {
+  if (!predicate || batch.shape !== 'object-row-table') return batch;
+  const rows = batch.data;
+  const columnNames = new Set(batch.schema?.fields.map(field => field.name) || []);
+  validateColumnarPredicate(predicate, columnNames);
+  const columns = Object.fromEntries(
+    [...columnNames].map(name => [name, rows.map(row => row[name])])
+  );
+  const rowIndices = filterColumnarRowIndices(predicate, columns, rows.length);
+  return {...batch, data: rowIndices.map(rowIndex => rows[rowIndex]), length: rowIndices.length};
 }

--- a/modules/json/src/ndjson-source.ts
+++ b/modules/json/src/ndjson-source.ts
@@ -178,6 +178,6 @@ function filterBatch(batch: TableBatch, predicate: TableScanReadOptions['predica
   const columns = Object.fromEntries(
     [...columnNames].map(name => [name, rows.map(row => row[name])])
   );
-  const rowIndices = filterColumnarRowIndices(predicate, columns, rows.length);
+  const rowIndices = filterColumnarRowIndices(predicate as never, columns, rows.length);
   return {...batch, data: rowIndices.map(rowIndex => rows[rowIndex]), length: rowIndices.length};
 }

--- a/modules/json/test/ndjson-source.cross.spec.ts
+++ b/modules/json/test/ndjson-source.cross.spec.ts
@@ -12,6 +12,16 @@ test('NDJSONTableSource discovers schema and applies projection and limit', asyn
   expect(batches[0]?.data).toEqual([{name: 'a'}]);
 });
 
+test('NDJSONTableSource applies residual predicates before projection and limit', async () => {
+  const source = new NDJSONTableSource(
+    new Blob(['{"name":"a","value":1}\n{"name":"b","value":2}\n'])
+  );
+  const batches = [];
+  for await (const batch of source.read({predicate: {op: '=', args: [{property: 'name'}, 'b']}}))
+    batches.push(batch);
+  expect(batches.flatMap(batch => batch.data)).toEqual([{name: 'b', value: 2}]);
+});
+
 test('NDJSONTableSource handles zero limits, empty projections and invalid limits', async () => {
   const source = new NDJSONTableSource(
     new Blob(['{"name":"a","value":1}\n{"name":"b","value":2}\n'])

--- a/modules/netcdf/package.json
+++ b/modules/netcdf/package.json
@@ -33,6 +33,11 @@
     "./bundled": {
       "types": "./dist/bundled.d.ts",
       "import": "./dist/bundled.js"
+    },
+    "./netcdf-source-loader": {
+      "types": "./dist/netcdf-source-loader.d.ts",
+      "import": "./dist/netcdf-source-loader.js",
+      "require": "./dist/netcdf-source-loader.cjs"
     }
   },
   "sideEffects": false,
@@ -47,7 +52,8 @@
     "build-bundle-dev": "ocular-bundle ./bundle.ts --env=dev --output=dist/dist.dev.js"
   },
   "dependencies": {
-    "@loaders.gl/loader-utils": "5.0.0-alpha.2"
+    "@loaders.gl/loader-utils": "5.0.0-alpha.2",
+    "@loaders.gl/schema": "5.0.0-alpha.2"
   },
   "peerDependencies": {
     "@loaders.gl/core": "~5.0.0-alpha.0"

--- a/modules/netcdf/src/index.ts
+++ b/modules/netcdf/src/index.ts
@@ -7,3 +7,5 @@ export {NetCDFReader} from './netcdfjs/netcdf-reader';
 export {NetCDFFormat} from './netcdf-format';
 export type {NetCDF, NetCDFLoaderOptions} from './netcdf-loader';
 export {NetCDFLoader} from './netcdf-loader';
+export {NetCDFSource, NetCDFSourceLoader} from './netcdf-source-loader';
+export type {NetCDFSourceOptions} from './netcdf-source-loader';

--- a/modules/netcdf/src/index.ts
+++ b/modules/netcdf/src/index.ts
@@ -7,5 +7,5 @@ export {NetCDFReader} from './netcdfjs/netcdf-reader';
 export {NetCDFFormat} from './netcdf-format';
 export type {NetCDF, NetCDFLoaderOptions} from './netcdf-loader';
 export {NetCDFLoader} from './netcdf-loader';
-export {NetCDFSource, NetCDFSourceLoader} from './netcdf-source-loader';
+export {NetCDFSourceLoader} from './netcdf-source-loader-types';
 export type {NetCDFSourceOptions} from './netcdf-source-loader';

--- a/modules/netcdf/src/netcdf-source-loader-types.ts
+++ b/modules/netcdf/src/netcdf-source-loader-types.ts
@@ -1,0 +1,42 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {CoreAPI, SourceLoader} from '@loaders.gl/loader-utils';
+import {NetCDFFormat} from './netcdf-format';
+import type {NetCDFSource, NetCDFSourceOptions} from './netcdf-source-loader';
+
+// __VERSION__ is injected by babel-plugin-version-inline
+// @ts-ignore TS2304: Cannot find name '__VERSION__'.
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+
+/** Loads the parser-bearing NetCDF source through its explicit implementation subpath. */
+async function preloadNetCDFSourceLoader(): Promise<SourceLoader<NetCDFSource>> {
+  const {NetCDFSourceLoaderWithParser} = await import('@loaders.gl/netcdf/netcdf-source-loader');
+  return NetCDFSourceLoaderWithParser;
+}
+
+/** Metadata-only NetCDF source loader kept lightweight for package-root imports. */
+export const NetCDFSourceLoader = {
+  ...NetCDFFormat,
+  dataType: null as unknown as NetCDFSource,
+  batchType: null as never,
+  name: 'NetCDFSourceLoader',
+  version: VERSION,
+  type: 'netcdf-source',
+  fromUrl: true,
+  fromBlob: true,
+  options: {},
+  defaultOptions: {},
+  testURL: (url: string): boolean => /\.(?:cdf|nc)(?:$|[?#])/i.test(url),
+  preload: preloadNetCDFSourceLoader,
+  createDataSource(
+    _data: string | Blob,
+    _options: NetCDFSourceOptions,
+    _coreApi?: CoreAPI
+  ): NetCDFSource {
+    throw new Error(
+      'NetCDFSourceLoader requires async load() or an explicit @loaders.gl/netcdf/netcdf-source-loader import'
+    );
+  }
+} as const satisfies SourceLoader<NetCDFSource>;

--- a/modules/netcdf/src/netcdf-source-loader.ts
+++ b/modules/netcdf/src/netcdf-source-loader.ts
@@ -29,6 +29,8 @@ export type NetCDFSourceOptions = DataSourceOptions;
  * panel to inspect variables, dimensions, and source statistics.
  */
 export class NetCDFSource extends DataSource<string | Blob, NetCDFSourceOptions> {
+  private static readonly HEADER_RANGE_SIZE = 64 * 1024;
+  private static readonly MAX_HEADER_RANGE_SIZE = 4 * 1024 * 1024;
   private headerPromise: Promise<{header: NetCDFHeader; byteLength: number}> | null = null;
 
   /** Creates a source over a NetCDF URL or Blob. */
@@ -45,17 +47,12 @@ export class NetCDFSource extends DataSource<string | Blob, NetCDFSourceOptions>
     const schema: Schema = {fields, metadata: createDimensionMetadata(header)};
     return createScanQueryMetadata({
       sourceType: 'netcdf',
-      queryType: 'table',
+      queryType: 'raster',
       name: typeof this.data === 'string' ? this.data.split('/').pop() : undefined,
       schema,
       capabilities: {
-        table: {
-          projection: 'unsupported',
-          predicate: 'unsupported',
-          limit: 'unsupported',
-          streaming: false,
-          cancellation: false
-        }
+        bounds: 'unsupported',
+        levelOfDetail: 'unsupported'
       },
       statistics: {
         byteLength,
@@ -70,33 +67,48 @@ export class NetCDFSource extends DataSource<string | Blob, NetCDFSourceOptions>
   ): Promise<{header: NetCDFHeader; byteLength: number}> {
     throwIfAborted(signal);
     if (!this.headerPromise) {
-      this.headerPromise = (
-        typeof this.data === 'string'
-          ? this.fetch(this.url, {signal}).then(response => {
-              if (!response.ok) {
-                throw new Error(`NetCDF request failed with status ${response.status}.`);
-              }
-              return response.arrayBuffer();
-            })
-          : this.data.arrayBuffer()
-      ).then(arrayBuffer => {
-        const reader = new NetCDFReader(arrayBuffer);
-        return {header: reader.header, byteLength: arrayBuffer.byteLength};
+      this.headerPromise = this.loadHeader().catch(error => {
+        this.headerPromise = null;
+        throw error;
       });
     }
-    try {
-      const result = await this.headerPromise;
-      throwIfAborted(signal);
-      return result;
-    } catch (error) {
-      this.headerPromise = null;
-      throw error;
+    const result = await this.headerPromise;
+    throwIfAborted(signal);
+    return result;
+  }
+
+  /** Loads enough leading bytes to parse a remote header, growing ranges when required. */
+  private async loadHeader(): Promise<{header: NetCDFHeader; byteLength: number}> {
+    if (typeof this.data !== 'string') {
+      const arrayBuffer = await this.data.arrayBuffer();
+      return {header: new NetCDFReader(arrayBuffer).header, byteLength: arrayBuffer.byteLength};
     }
+
+    let rangeSize = NetCDFSource.HEADER_RANGE_SIZE;
+    let response: Response | null = null;
+    let arrayBuffer: ArrayBuffer | null = null;
+    let lastError: unknown;
+    while (rangeSize <= NetCDFSource.MAX_HEADER_RANGE_SIZE) {
+      response = await this.fetch(this.url, {
+        headers: {Range: `bytes=0-${rangeSize - 1}`}
+      });
+      if (!response.ok) throw new Error(`NetCDF request failed with status ${response.status}.`);
+      arrayBuffer = await response.arrayBuffer();
+      const byteLength = getResponseByteLength(response, arrayBuffer.byteLength);
+      try {
+        return {header: new NetCDFReader(arrayBuffer).header, byteLength};
+      } catch (error) {
+        lastError = error;
+        if (response.status !== 206 || arrayBuffer.byteLength < rangeSize) throw error;
+        rangeSize *= 2;
+      }
+    }
+    throw lastError || new Error('NetCDF header exceeds the maximum metadata range.');
   }
 }
 
 /** Parser-bearing source loader for NetCDF metadata scans. */
-export const NetCDFSourceLoader = {
+export const NetCDFSourceLoaderWithParser = {
   dataType: null as unknown as NetCDFSource,
   batchType: null as never,
   ...NetCDFFormat,
@@ -111,6 +123,9 @@ export const NetCDFSourceLoader = {
   createDataSource: (data: string | Blob, options: NetCDFSourceOptions): NetCDFSource =>
     new NetCDFSource(data, options)
 } as const satisfies SourceLoader<NetCDFSource>;
+
+/** Backwards-compatible implementation-loader alias for explicit subpath imports. */
+export const NetCDFSourceLoader = NetCDFSourceLoaderWithParser;
 
 /** Maps NetCDF primitive names to portable schema data types. */
 function getNetCDFDataType(type: string): DataType {
@@ -148,7 +163,10 @@ function createVariableField(variable: NetCDFVariable, header: NetCDFHeader): Fi
   const dimensions = variable.dimensions
     .map(dimensionId => header.dimensions[dimensionId])
     .filter(Boolean)
-    .map(dimension => `${dimension.name}[${dimension.size}]`)
+    .map(
+      (dimension, index) =>
+        `${dimension.name}[${getDimensionSize(header, variable.dimensions[index])}]`
+    )
     .join(',');
   const metadata: Record<string, string> = {dimensions};
   for (const attribute of variable.attributes) {
@@ -160,10 +178,23 @@ function createVariableField(variable: NetCDFVariable, header: NetCDFHeader): Fi
 /** Adds dimensions as schema metadata so consumers can populate slice controls. */
 function createDimensionMetadata(header: NetCDFHeader): Record<string, string> {
   const metadata: Record<string, string> = {};
-  for (const dimension of header.dimensions) {
-    metadata[`dimension:${dimension.name}`] = String(dimension.size);
+  for (const [dimensionId, dimension] of header.dimensions.entries()) {
+    metadata[`dimension:${dimension.name}`] = String(getDimensionSize(header, dimensionId));
   }
   return metadata;
+}
+
+function getDimensionSize(header: NetCDFHeader, dimensionId: number): number {
+  const dimension = header.dimensions[dimensionId];
+  return dimensionId === header.recordDimension.id
+    ? header.recordDimension.length
+    : dimension?.size || 0;
+}
+
+function getResponseByteLength(response: Response, fallback: number): number {
+  const contentRange = response.headers.get('content-range');
+  const total = contentRange?.match(/\/([0-9]+)$/)?.[1];
+  return Number(total || response.headers.get('content-length') || fallback);
 }
 
 function throwIfAborted(signal?: AbortSignal): void {

--- a/modules/netcdf/src/netcdf-source-loader.ts
+++ b/modules/netcdf/src/netcdf-source-loader.ts
@@ -1,0 +1,173 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Field, Schema, DataType} from '@loaders.gl/schema';
+import type {
+  DataSourceOptions,
+  ScanQueryMetadata,
+  ScanQueryMetadataOptions,
+  SourceLoader
+} from '@loaders.gl/loader-utils';
+import {createScanQueryMetadata, DataSource} from '@loaders.gl/loader-utils';
+import {NetCDFFormat} from './netcdf-format';
+import {NetCDFReader} from './netcdfjs/netcdf-reader';
+import type {NetCDFHeader, NetCDFVariable} from './netcdfjs/netcdf-types';
+
+// __VERSION__ is injected by babel-plugin-version-inline
+// @ts-ignore TS2304: Cannot find name '__VERSION__'.
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+
+/** Options for a NetCDF source. */
+export type NetCDFSourceOptions = DataSourceOptions;
+
+/**
+ * Lightweight NetCDF source that exposes the classic-file header to the shared scan UI.
+ *
+ * The source intentionally performs metadata-only discovery. Data-variable reads and chunked
+ * window scans remain format-specific follow-up work, but callers can already use one query
+ * panel to inspect variables, dimensions, and source statistics.
+ */
+export class NetCDFSource extends DataSource<string | Blob, NetCDFSourceOptions> {
+  private headerPromise: Promise<{header: NetCDFHeader; byteLength: number}> | null = null;
+
+  /** Creates a source over a NetCDF URL or Blob. */
+  constructor(data: string | Blob, options: NetCDFSourceOptions = {}) {
+    super(data, options);
+  }
+
+  /** Discovers variables and dimensions without decoding data arrays. */
+  async getQueryMetadata(options: ScanQueryMetadataOptions = {}): Promise<ScanQueryMetadata> {
+    throwIfAborted(options.signal);
+    const {header, byteLength} = await this.getHeader(options.signal);
+    throwIfAborted(options.signal);
+    const fields = header.variables.map(variable => createVariableField(variable, header));
+    const schema: Schema = {fields, metadata: createDimensionMetadata(header)};
+    return createScanQueryMetadata({
+      sourceType: 'netcdf',
+      queryType: 'table',
+      name: typeof this.data === 'string' ? this.data.split('/').pop() : undefined,
+      schema,
+      capabilities: {
+        table: {
+          projection: 'unsupported',
+          predicate: 'unsupported',
+          limit: 'unsupported',
+          streaming: false,
+          cancellation: false
+        }
+      },
+      statistics: {
+        byteLength,
+        rowCount: header.recordDimension.length || undefined
+      }
+    });
+  }
+
+  /** Reads and caches the NetCDF header, preserving abort behavior for each caller. */
+  private async getHeader(
+    signal?: AbortSignal
+  ): Promise<{header: NetCDFHeader; byteLength: number}> {
+    throwIfAborted(signal);
+    if (!this.headerPromise) {
+      this.headerPromise = (
+        typeof this.data === 'string'
+          ? this.fetch(this.url, {signal}).then(response => {
+              if (!response.ok) {
+                throw new Error(`NetCDF request failed with status ${response.status}.`);
+              }
+              return response.arrayBuffer();
+            })
+          : this.data.arrayBuffer()
+      ).then(arrayBuffer => {
+        const reader = new NetCDFReader(arrayBuffer);
+        return {header: reader.header, byteLength: arrayBuffer.byteLength};
+      });
+    }
+    try {
+      const result = await this.headerPromise;
+      throwIfAborted(signal);
+      return result;
+    } catch (error) {
+      this.headerPromise = null;
+      throw error;
+    }
+  }
+}
+
+/** Parser-bearing source loader for NetCDF metadata scans. */
+export const NetCDFSourceLoader = {
+  dataType: null as unknown as NetCDFSource,
+  batchType: null as never,
+  ...NetCDFFormat,
+  name: 'NetCDFSourceLoader',
+  version: VERSION,
+  type: 'netcdf-source',
+  fromUrl: true,
+  fromBlob: true,
+  options: {},
+  defaultOptions: {},
+  testURL: (url: string): boolean => /\.(?:cdf|nc)(?:$|[?#])/i.test(url),
+  createDataSource: (data: string | Blob, options: NetCDFSourceOptions): NetCDFSource =>
+    new NetCDFSource(data, options)
+} as const satisfies SourceLoader<NetCDFSource>;
+
+/** Maps NetCDF primitive names to portable schema data types. */
+function getNetCDFDataType(type: string): DataType {
+  switch (type.toLowerCase()) {
+    case 'byte':
+      return 'int8';
+    case 'ubyte':
+      return 'uint8';
+    case 'short':
+      return 'int16';
+    case 'ushort':
+      return 'uint16';
+    case 'int':
+      return 'int32';
+    case 'uint':
+      return 'uint32';
+    case 'int64':
+      return 'int64';
+    case 'uint64':
+      return 'uint64';
+    case 'float':
+      return 'float32';
+    case 'double':
+      return 'float64';
+    case 'char':
+    case 'string':
+      return 'utf8';
+    default:
+      return 'binary';
+  }
+}
+
+/** Converts a NetCDF variable into a query-visible field. */
+function createVariableField(variable: NetCDFVariable, header: NetCDFHeader): Field {
+  const dimensions = variable.dimensions
+    .map(dimensionId => header.dimensions[dimensionId])
+    .filter(Boolean)
+    .map(dimension => `${dimension.name}[${dimension.size}]`)
+    .join(',');
+  const metadata: Record<string, string> = {dimensions};
+  for (const attribute of variable.attributes) {
+    metadata[attribute.name] = String(attribute.value);
+  }
+  return {name: variable.name, type: getNetCDFDataType(variable.type), nullable: true, metadata};
+}
+
+/** Adds dimensions as schema metadata so consumers can populate slice controls. */
+function createDimensionMetadata(header: NetCDFHeader): Record<string, string> {
+  const metadata: Record<string, string> = {};
+  for (const dimension of header.dimensions) {
+    metadata[`dimension:${dimension.name}`] = String(dimension.size);
+  }
+  return metadata;
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw new DOMException('The operation was aborted', 'AbortError');
+  }
+}

--- a/modules/netcdf/src/netcdfjs/netcdf-types.ts
+++ b/modules/netcdf/src/netcdfjs/netcdf-types.ts
@@ -55,8 +55,8 @@ export type NetCDFDimension = {
  */
 export type NetCDFVariable = {
   name: string;
-  dimensions: [];
-  attributes: [];
+  dimensions: number[];
+  attributes: NetCDFAttribute[];
   type: string;
   size: number;
   offset: number;

--- a/modules/netcdf/test/netcdf-source.cross.spec.ts
+++ b/modules/netcdf/test/netcdf-source.cross.spec.ts
@@ -1,0 +1,8 @@
+import {expect, test} from 'vitest';
+import {NetCDFSource} from '../src/netcdf-source-loader';
+import {NetCDFSourceLoader} from '../src/netcdf-source-loader-types';
+
+test('NetCDF root source loader preloads the explicit implementation', async () => {
+  const implementation = await NetCDFSourceLoader.preload();
+  expect(implementation.createDataSource(new Blob())).toBeInstanceOf(NetCDFSource);
+});

--- a/modules/netcdf/test/netcdf-source.spec.ts
+++ b/modules/netcdf/test/netcdf-source.spec.ts
@@ -1,0 +1,59 @@
+import {fetchFile, isBrowser} from '@loaders.gl/core';
+import {expect, test} from 'vitest';
+import {NetCDFSource} from '../src/netcdf-source-loader';
+
+const NETCDF_FIXTURE = '@loaders.gl/netcdf/test/data/madis-sao.nc';
+
+test.runIf(isBrowser)('NetCDF source discovers raster metadata from a Blob', async () => {
+  const response = await fetchFile(NETCDF_FIXTURE);
+  const source = new NetCDFSource(new Blob([await response.arrayBuffer()]));
+  const metadata = await source.getQueryMetadata();
+
+  expect(metadata.queryType).toBe('raster');
+  expect(metadata.statistics?.rowCount).toBe(178);
+  expect(metadata.columns.map(column => column.name)).toContain('wmoId');
+  expect(metadata.columns.find(column => column.name === 'wmoId')?.metadata?.dimensions).toBe(
+    'recNum[178]'
+  );
+  expect(metadata.schema.metadata['dimension:recNum']).toBe('178');
+});
+
+test.runIf(isBrowser)(
+  'NetCDF source reads a remote header with progressive ranges and caches it',
+  async () => {
+    const response = await fetchFile(NETCDF_FIXTURE);
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    const requestedRanges: string[] = [];
+    const source = new NetCDFSource('fixture.nc');
+    source.fetch = async (_url, options) => {
+      const range = new Headers(options?.headers).get('Range') || '';
+      requestedRanges.push(range);
+      if (requestedRanges.length === 1) {
+        return new Response(new Uint8Array(64 * 1024), {
+          status: 206,
+          headers: {'Content-Range': `bytes 0-${64 * 1024 - 1}/${bytes.length}`}
+        });
+      }
+      return new Response(bytes, {
+        status: 206,
+        headers: {'Content-Range': `bytes 0-${bytes.length - 1}/${bytes.length}`}
+      });
+    };
+
+    const metadata = await source.getQueryMetadata();
+    await source.getQueryMetadata();
+
+    expect(metadata.statistics?.byteLength).toBe(bytes.length);
+    expect(requestedRanges).toEqual(['bytes=0-65535', 'bytes=0-131071']);
+  }
+);
+
+test.runIf(isBrowser)('NetCDF source reports remote failures and honors cancellation', async () => {
+  const source = new NetCDFSource('fixture.nc');
+  source.fetch = async () => new Response(null, {status: 503});
+  await expect(source.getQueryMetadata()).rejects.toThrow('status 503');
+
+  const controller = new AbortController();
+  controller.abort();
+  await expect(source.getQueryMetadata({signal: controller.signal})).rejects.toThrow();
+});

--- a/modules/orc/src/orc-source-loader.ts
+++ b/modules/orc/src/orc-source-loader.ts
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import type {ArrowTable, ArrowTableBatch, DataType, Field, Schema} from '@loaders.gl/schema';
+import * as arrow from 'apache-arrow';
 import type {
   DataSourceOptions,
   ScanQueryMetadata,
@@ -13,7 +14,8 @@ import type {
 import {
   createScanQueryMetadata,
   DataSource,
-  validateTableQueryOptions
+  validateTableQueryOptions,
+  filterColumnarRowIndices
 } from '@loaders.gl/loader-utils';
 import {parseORC, ORCTypeKind, type ORCTypeDescription} from './lib/parsers/parse-orc';
 import {parseORCToArrow} from './lib/parsers/parse-orc-to-arrow';
@@ -58,7 +60,7 @@ export class ORCSource extends DataSource<string | Blob, ORCSourceOptions> {
       capabilities: {
         table: {
           projection: 'residual',
-          predicate: 'unsupported',
+          predicate: 'residual',
           limit: 'residual',
           streaming: false,
           cancellation: false
@@ -74,9 +76,6 @@ export class ORCSource extends DataSource<string | Blob, ORCSourceOptions> {
   /** Executes a portable query after decoding the ORC file into an Arrow table. */
   async query(options: ORCQueryOptions = {}): Promise<ArrowTable> {
     throwIfAborted(options.signal);
-    if (options.predicate) {
-      throw new Error('ORC predicates are not implemented yet.');
-    }
     const arrayBuffer = await this.getArrayBuffer(options.signal);
     await preloadORCCompression();
     const file = parseORC(arrayBuffer);
@@ -87,9 +86,24 @@ export class ORCSource extends DataSource<string | Blob, ORCSourceOptions> {
       options
     );
     const table = parseORCToArrow(arrayBuffer);
-    const projectedData = table.data.select(
-      options.columns ? [...options.columns] : table.data.schema.fields.map(field => field.name)
+    const availableColumns = table.data.schema.fields.map(field => field.name);
+    validateTableQueryOptions(availableColumns, options);
+    const columns: Record<string, unknown[]> = Object.fromEntries(
+      availableColumns.map(name => [name, table.data.getChild(name)?.toArray() || []])
     );
+    const rowIndices = filterColumnarRowIndices(options.predicate, columns, table.data.numRows);
+    const selectedColumns = options.columns ? new Set(options.columns) : undefined;
+    const projectedData = options.predicate
+      ? arrow.tableFromArrays(
+          Object.fromEntries(
+            Object.entries(columns)
+              .filter(([name]) => !selectedColumns || selectedColumns.has(name))
+              .map(([name, values]) => [name, rowIndices.map(rowIndex => values[rowIndex])])
+          )
+        )
+      : table.data.select(
+          options.columns ? [...options.columns] : table.data.schema.fields.map(field => field.name)
+        );
     const limitedData = projectedData.slice(0, options.limit ?? Number.POSITIVE_INFINITY);
     return {
       shape: 'arrow-table',

--- a/modules/orc/src/orc-source-loader.ts
+++ b/modules/orc/src/orc-source-loader.ts
@@ -88,22 +88,38 @@ export class ORCSource extends DataSource<string | Blob, ORCSourceOptions> {
     const table = parseORCToArrow(arrayBuffer);
     const availableColumns = table.data.schema.fields.map(field => field.name);
     validateTableQueryOptions(availableColumns, options);
-    const columns: Record<string, unknown[]> = Object.fromEntries(
-      availableColumns.map(name => [name, table.data.getChild(name)?.toArray() || []])
-    );
-    const rowIndices = filterColumnarRowIndices(options.predicate, columns, table.data.numRows);
-    const selectedColumns = options.columns ? new Set(options.columns) : undefined;
-    const projectedData = options.predicate
-      ? arrow.tableFromArrays(
-          Object.fromEntries(
-            Object.entries(columns)
-              .filter(([name]) => !selectedColumns || selectedColumns.has(name))
-              .map(([name, values]) => [name, rowIndices.map(rowIndex => values[rowIndex])])
-          )
+    const selectedColumnNames = options.columns ? [...options.columns] : availableColumns;
+    let projectedData;
+    if (options.predicate) {
+      const columns: Record<string, unknown[]> = Object.fromEntries(
+        availableColumns.map(name => [name, [...(table.data.getChild(name) || [])]])
+      );
+      const rowIndices = filterColumnarRowIndices(
+        options.predicate,
+        columns as never,
+        table.data.numRows
+      );
+      const vectors = Object.fromEntries(
+        selectedColumnNames.map(name => {
+          const sourceVector = table.data.getChild(name);
+          return [
+            name,
+            arrow.vectorFromArray(
+              rowIndices.map(rowIndex => columns[name][rowIndex]),
+              sourceVector?.type
+            )
+          ];
+        })
+      );
+      const schema = new arrow.Schema(
+        selectedColumnNames.map(
+          name => table.data.schema.fields.find(field => field.name === name)!
         )
-      : table.data.select(
-          options.columns ? [...options.columns] : table.data.schema.fields.map(field => field.name)
-        );
+      );
+      projectedData = new arrow.Table(schema, vectors);
+    } else {
+      projectedData = table.data.select(selectedColumnNames);
+    }
     const limitedData = projectedData.slice(0, options.limit ?? Number.POSITIVE_INFINITY);
     return {
       shape: 'arrow-table',

--- a/modules/orc/test/orc-loader.spec.ts
+++ b/modules/orc/test/orc-loader.spec.ts
@@ -64,11 +64,17 @@ test('ORC metadata preserves nested map and struct types', () => {
   ).toMatchObject({type: 'list'});
 });
 
-test('ORCSource rejects unsupported predicates before reading the source', async () => {
-  const source = new ORCSource(new Blob([new Uint8Array([0])]));
-  await expect(source.query({predicate: {type: 'literal', value: true} as never})).rejects.toThrow(
-    'ORC predicates are not implemented yet'
-  );
+test('ORCSource applies residual predicates with three-valued semantics', async () => {
+  const input = {
+    shape: 'arrow-table' as const,
+    data: arrow.tableFromArrays({name: ['a', 'b', 'a', 'b']})
+  };
+  const encoded = await ORCWriter.encode(input);
+  const source = new ORCSource(new Blob([encoded]));
+  const result = await source.query({
+    predicate: {op: '=', args: [{property: 'name'}, 'a']}
+  });
+  expect(result.data.getChild('name')?.toArray()).toEqual(['a', 'a']);
 });
 
 test('ORCSource validates query limits before decoding rows', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -229,6 +229,9 @@
       "@loaders.gl/netcdf": [
         "modules/netcdf/src"
       ],
+      "@loaders.gl/netcdf/*": [
+        "modules/netcdf/src/*"
+      ],
       "@loaders.gl/netcdf/test": [
         "modules/netcdf/test"
       ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5583,6 +5583,7 @@ __metadata:
   resolution: "@loaders.gl/netcdf@workspace:modules/netcdf"
   dependencies:
     "@loaders.gl/loader-utils": "npm:5.0.0-alpha.2"
+    "@loaders.gl/schema": "npm:5.0.0-alpha.2"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
   languageName: unknown


### PR DESCRIPTION
## Goals

- Make shared scan filters executable for the two most common row-oriented formats.
- Preserve streaming, projection, and global limit semantics.

## Changes

- Add residual columnar predicate evaluation to `CSVTableSource` and `NDJSONTableSource`.
- Validate predicate columns against discovered batch schemas.
- Apply filters before projection and global limits with three-valued logic.
- Advertise residual predicate capability in metadata.
- Add focused CSV and NDJSON regression coverage.

## Validation

- `yarn lint fix` passed.
- Focused Vitest suites passed: 39 tests across browser and headless projects.