### PR TITLE
feat(wms): add ArcGIS VectorTileServer source

### DIFF
--- a/docs/docs-sidebar.json
+++ b/docs/docs-sidebar.json
@@ -78,7 +78,8 @@
       "modules/wms/services/arcgis-map-server",
       "modules/wms/services/arcgis-image-server",
       "modules/wms/services/arcgis-feature-server",
-      "modules/wms/services/ogc-api"
+      "modules/wms/services/ogc-api",
+      "modules/wms/services/arcgis-vector-tile-server"
     ]
   },
   {

--- a/docs/modules/wms/services/arcgis-vector-tile-server.md
+++ b/docs/modules/wms/services/arcgis-vector-tile-server.md
@@ -1,0 +1,25 @@
+# ArcGIS VectorTileServer
+
+`ArcGISVectorTileServerSourceLoader` provides a source adapter for ArcGIS vector tile services.
+It loads service metadata, exposes the ArcGIS tile grid, constructs PBF tile URLs, and exposes the
+published Mapbox style and sprite resources.
+
+```js
+import {ArcGISVectorTileServerSourceLoader} from '@loaders.gl/wms';
+import {createDataSource} from '@loaders.gl/core';
+
+const source = createDataSource(
+  'https://example.com/arcgis/rest/services/World/VectorTileServer',
+  [ArcGISVectorTileServerSourceLoader]
+);
+
+const metadata = await source.getMetadata();
+const tileBytes = await source.getTile({z: 4, x: 6, y: 7});
+```
+
+The adapter returns raw PBF bytes so applications can decode them with the existing
+`@loaders.gl/mvt` loader. Authentication and request overrides are supplied through the normal
+load-options mechanism.
+
+ArcGIS documents the service resource at
+[Vector Tile Service](https://developers.arcgis.com/rest/services-reference/enterprise/vector-tile-service/).

--- a/modules/wms/src/arcgis/arcgis-vector-tile-server-source-loader.ts
+++ b/modules/wms/src/arcgis/arcgis-vector-tile-server-source-loader.ts
@@ -1,0 +1,174 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {
+  CoreAPI,
+  DataSourceOptions,
+  GetTileDataParameters,
+  GetTileParameters,
+  SourceLoader,
+  TileSourceMetadata,
+  TileSource
+} from '@loaders.gl/loader-utils';
+import {DataSource} from '@loaders.gl/loader-utils';
+
+/** ArcGIS vector tile service metadata. */
+export type ArcGISVectorTileServiceMetadata = {
+  /** Human-readable service description. */
+  serviceDescription?: string;
+  /** Map name exposed by the service. */
+  mapName?: string;
+  /** Tile grid information. */
+  tileInfo?: {
+    /** Tile width in pixels. */
+    cols?: number;
+    /** Tile height in pixels. */
+    rows?: number;
+    /** Tile format, normally pbf. */
+    format?: string;
+    /** Tile origin. */
+    origin?: {x: number; y: number};
+    /** Tile grid spatial reference. */
+    spatialReference?: {wkid?: number; latestWkid?: number};
+    /** Levels of detail. */
+    lods?: Array<{level: number; resolution: number; scale?: number}>;
+  };
+  /** Full service extent. */
+  fullExtent?: {xmin: number; ymin: number; xmax: number; ymax: number};
+  /** Initial service extent. */
+  initialExtent?: {xmin: number; ymin: number; xmax: number; ymax: number};
+};
+
+/** Options for the ArcGIS VectorTileServer source. */
+export type ArcGISVectorTileServerSourceLoaderOptions = DataSourceOptions & {
+  'arcgis-vector-tile-server'?: {
+    /** Optional MVT parser options. */
+    mvt?: Record<string, unknown>;
+  };
+};
+
+/** A source for ArcGIS VectorTileServer metadata and PBF tiles. */
+export class ArcGISVectorTileServerSource
+  extends DataSource<string, ArcGISVectorTileServerSourceLoaderOptions>
+  implements TileSource
+{
+  /** Cached service metadata request. */
+  private serviceMetadata: Promise<ArcGISVectorTileServiceMetadata> | null = null;
+
+  /** Creates an ArcGIS VectorTileServer source. */
+  constructor(
+    url: string,
+    options: ArcGISVectorTileServerSourceLoaderOptions = {},
+    coreApi?: CoreAPI
+  ) {
+    super(
+      url.replace(/\/$/, ''),
+      options,
+      ArcGISVectorTileServerSourceLoader.defaultOptions,
+      coreApi
+    );
+  }
+
+  /** Returns normalized service and tile-grid metadata. */
+  async getMetadata(): Promise<TileSourceMetadata> {
+    const metadata = await this.getServiceMetadata();
+    const tileInfo = metadata.tileInfo;
+    const lods = tileInfo?.lods || [];
+    const extent = metadata.fullExtent || metadata.initialExtent;
+    return {
+      name: metadata.mapName || this.url.split('/').pop() || '',
+      title: metadata.mapName,
+      abstract: metadata.serviceDescription,
+      format: 'application/vnd.mapbox-vector-tile',
+      minZoom: lods[0]?.level,
+      maxZoom: lods.at(-1)?.level,
+      boundingBox: extent
+        ? [
+            [extent.xmin, extent.ymin],
+            [extent.xmax, extent.ymax]
+          ]
+        : undefined,
+      layer: {
+        name: metadata.mapName || '',
+        srs: tileInfo?.spatialReference ? [getSpatialReference(tileInfo.spatialReference)] : [],
+        layers: []
+      },
+      formatHeader: {
+        tileInfo,
+        styleURL: this.getStyleURL(),
+        spriteURL: this.getSpriteURL()
+      }
+    };
+  }
+
+  /** Fetches one raw PBF tile from the ArcGIS tile endpoint. */
+  async getTile(parameters: GetTileParameters): Promise<ArrayBuffer | null> {
+    const response = await this.fetch(this.getTileURL(parameters), {
+      headers: {Accept: 'application/vnd.mapbox-vector-tile, application/x-protobuf'}
+    });
+    if (!response.ok) return null;
+    return response.arrayBuffer();
+  }
+
+  /** Provides raw PBF tiles through the deck.gl source interface. */
+  async getTileData(parameters: GetTileDataParameters): Promise<ArrayBuffer | null> {
+    return this.getTile(parameters.index);
+  }
+
+  /** Builds the ArcGIS cached vector tile URL. */
+  getTileURL(parameters: GetTileParameters): string {
+    return `${this.url}/tile/${parameters.z}/${parameters.y}/${parameters.x}.pbf`;
+  }
+
+  /** Returns the service metadata URL. */
+  getMetadataURL(): string {
+    return `${this.url}?f=pjson`;
+  }
+
+  /** Returns the ArcGIS Mapbox style resource URL. */
+  getStyleURL(): string {
+    return `${this.url}/resources/styles/root.json`;
+  }
+
+  /** Returns the ArcGIS sprite resource base URL. */
+  getSpriteURL(): string {
+    return `${this.url}/resources/styles/sprites`;
+  }
+
+  private async getServiceMetadata(): Promise<ArcGISVectorTileServiceMetadata> {
+    this.serviceMetadata ||= this.fetch(this.getMetadataURL()).then(async response => {
+      if (!response.ok)
+        throw new Error(`ArcGIS VectorTileServer request failed: ${response.status}`);
+      return (await response.json()) as ArcGISVectorTileServiceMetadata;
+    });
+    return this.serviceMetadata;
+  }
+}
+
+/** Source loader for ArcGIS VectorTileServer services. */
+export const ArcGISVectorTileServerSourceLoader = {
+  dataType: null as unknown as ArcGISVectorTileServerSource,
+  batchType: null as never,
+  name: 'ArcGIS VectorTileServer',
+  id: 'arcgis-vector-tile-server',
+  module: 'wms',
+  version: '0.0.0',
+  extensions: [],
+  mimeTypes: ['application/vnd.mapbox-vector-tile', 'application/x-protobuf'],
+  type: 'arcgis-vector-tile-server',
+  fromUrl: true,
+  fromBlob: false,
+  options: {'arcgis-vector-tile-server': {}},
+  defaultOptions: {'arcgis-vector-tile-server': {}},
+  testURL: (url: string): boolean => /\/vectortileserver(?:\/|$)/i.test(url),
+  createDataSource: (
+    url: string,
+    options: ArcGISVectorTileServerSourceLoaderOptions = {},
+    coreApi?: CoreAPI
+  ) => new ArcGISVectorTileServerSource(url, options, coreApi)
+} as const satisfies SourceLoader<ArcGISVectorTileServerSource>;
+
+function getSpatialReference(spatialReference: {wkid?: number; latestWkid?: number}): string {
+  return `EPSG:${spatialReference.latestWkid || spatialReference.wkid}`;
+}

--- a/modules/wms/src/arcgis/arcgis-vector-tile-server-source-loader.ts
+++ b/modules/wms/src/arcgis/arcgis-vector-tile-server-source-loader.ts
@@ -55,6 +55,8 @@ export class ArcGISVectorTileServerSource
 {
   /** Cached service metadata request. */
   private serviceMetadata: Promise<ArcGISVectorTileServiceMetadata> | null = null;
+  /** Query parameters supplied with the service URL, such as an access token. */
+  private readonly serviceQueryParameters: URLSearchParams;
 
   /** Creates an ArcGIS VectorTileServer source. */
   constructor(
@@ -62,12 +64,15 @@ export class ArcGISVectorTileServerSource
     options: ArcGISVectorTileServerSourceLoaderOptions = {},
     coreApi?: CoreAPI
   ) {
+    const serviceURL = new URL(url);
+    serviceURL.pathname = serviceURL.pathname.replace(/\/$/, '');
     super(
-      url.replace(/\/$/, ''),
+      `${serviceURL.origin}${serviceURL.pathname}`,
       options,
       ArcGISVectorTileServerSourceLoader.defaultOptions,
       coreApi
     );
+    this.serviceQueryParameters = new URLSearchParams(serviceURL.search);
   }
 
   /** Returns normalized service and tile-grid metadata. */
@@ -103,8 +108,9 @@ export class ArcGISVectorTileServerSource
   }
 
   /** Fetches one raw PBF tile from the ArcGIS tile endpoint. */
-  async getTile(parameters: GetTileParameters): Promise<ArrayBuffer | null> {
+  async getTile(parameters: GetTileParameters, signal?: AbortSignal): Promise<ArrayBuffer | null> {
     const response = await this.fetch(this.getTileURL(parameters), {
+      signal,
       headers: {Accept: 'application/vnd.mapbox-vector-tile, application/x-protobuf'}
     });
     if (!response.ok) return null;
@@ -113,29 +119,32 @@ export class ArcGISVectorTileServerSource
 
   /** Provides raw PBF tiles through the deck.gl source interface. */
   async getTileData(parameters: GetTileDataParameters): Promise<ArrayBuffer | null> {
-    return this.getTile(parameters.index);
+    return this.getTile(parameters.index, parameters.signal);
   }
 
   /** Builds the ArcGIS cached vector tile URL. */
   getTileURL(parameters: GetTileParameters): string {
-    return `${this.url}/tile/${parameters.z}/${parameters.y}/${parameters.x}.pbf`;
+    return this.getResourceURL(`/tile/${parameters.z}/${parameters.y}/${parameters.x}.pbf`);
   }
 
   /** Returns the service metadata URL. */
   getMetadataURL(): string {
-    return `${this.url}?f=pjson`;
+    const url = new URL(this.getResourceURL(''));
+    url.searchParams.set('f', 'pjson');
+    return url.toString();
   }
 
   /** Returns the ArcGIS Mapbox style resource URL. */
   getStyleURL(): string {
-    return `${this.url}/resources/styles/root.json`;
+    return this.getResourceURL('/resources/styles/root.json');
   }
 
   /** Returns the ArcGIS sprite resource base URL. */
   getSpriteURL(): string {
-    return `${this.url}/resources/styles/sprites`;
+    return this.getResourceURL('/resources/sprites/sprite');
   }
 
+  /** Loads and caches the ArcGIS VectorTileServer metadata document. */
   private async getServiceMetadata(): Promise<ArcGISVectorTileServiceMetadata> {
     this.serviceMetadata ||= this.fetch(this.getMetadataURL()).then(async response => {
       if (!response.ok)
@@ -143,6 +152,16 @@ export class ArcGISVectorTileServerSource
       return (await response.json()) as ArcGISVectorTileServiceMetadata;
     });
     return this.serviceMetadata;
+  }
+
+  /** Builds a resource URL while retaining service query parameters. */
+  private getResourceURL(resourcePath: string): string {
+    const url = new URL(this.url);
+    url.pathname = `${url.pathname.replace(/\/$/, '')}${resourcePath}`;
+    for (const [key, value] of this.serviceQueryParameters) {
+      url.searchParams.set(key, value);
+    }
+    return url.toString();
   }
 }
 
@@ -169,6 +188,7 @@ export const ArcGISVectorTileServerSourceLoader = {
   ) => new ArcGISVectorTileServerSource(url, options, coreApi)
 } as const satisfies SourceLoader<ArcGISVectorTileServerSource>;
 
+/** Converts an ArcGIS spatial reference to an EPSG identifier. */
 function getSpatialReference(spatialReference: {wkid?: number; latestWkid?: number}): string {
   return `EPSG:${spatialReference.latestWkid || spatialReference.wkid}`;
 }

--- a/modules/wms/src/index.ts
+++ b/modules/wms/src/index.ts
@@ -123,6 +123,14 @@ export {CapabilityGraph, discoverServiceGraph} from './capability-graph';
 export {getArcGISServices as _getArcGISServices} from './arcgis/arcgis-server';
 export {ArcGISFeatureServerSourceLoader as _ArcGISFeatureServerSourceLoader} from './arcgis/arcgis-feature-server-source-loader';
 export {ArcGISImageServerSourceLoader as _ArcGISImageServerSourceLoader} from './arcgis/arcgis-image-server-source-loader';
+export type {
+  ArcGISVectorTileServiceMetadata,
+  ArcGISVectorTileServerSourceLoaderOptions
+} from './arcgis/arcgis-vector-tile-server-source-loader';
+export {
+  ArcGISVectorTileServerSource,
+  ArcGISVectorTileServerSourceLoader
+} from './arcgis/arcgis-vector-tile-server-source-loader';
 export type {ArcGISMapTileSourceLoaderOptions} from './arcgis/arcgis-map-tile-source-loader';
 export {
   ArcGISMapTileSourceLoader,

--- a/modules/wms/src/service-runtime.ts
+++ b/modules/wms/src/service-runtime.ts
@@ -8,6 +8,7 @@ import {ArcGISFeatureServerSourceLoader} from './arcgis/arcgis-feature-server-so
 import {ArcGISImageServerSourceLoader} from './arcgis/arcgis-image-server-source-loader';
 import {ArcGISMapTileSourceLoader} from './arcgis/arcgis-map-tile-source-loader';
 import {ArcGISImageTileSourceLoader} from './arcgis/arcgis-image-tile-source-loader';
+import {ArcGISVectorTileServerSourceLoader} from './arcgis/arcgis-vector-tile-server-source-loader';
 import {WMSSourceLoader} from './wms-source-loader';
 import {WMTSSourceLoader} from './wmts-source-loader';
 import {WFSSourceLoader} from './wfs-source-loader';
@@ -74,6 +75,7 @@ export const DEFAULT_SERVICE_LOADERS: readonly ServiceSourceLoader[] = [
   ArcGISFeatureServerSourceLoader,
   ArcGISImageServerSourceLoader,
   ArcGISImageTileSourceLoader,
+  ArcGISVectorTileServerSourceLoader,
   ArcGISMapTileSourceLoader,
   WMTSSourceLoader,
   WMSSourceLoader,

--- a/modules/wms/test/arcgis/arcgis-vector-tile-server-source.spec.ts
+++ b/modules/wms/test/arcgis/arcgis-vector-tile-server-source.spec.ts
@@ -1,0 +1,54 @@
+import {expect, test} from 'vitest';
+import {ArcGISVectorTileServerSourceLoader} from '@loaders.gl/wms';
+
+const VECTOR_TILE_SERVER_URL = 'https://example.com/arcgis/rest/services/World/VectorTileServer';
+
+const SERVICE_METADATA = {
+  serviceDescription: 'World vector tiles',
+  mapName: 'World',
+  tileInfo: {
+    format: 'pbf',
+    spatialReference: {wkid: 102100, latestWkid: 3857},
+    lods: [
+      {level: 0, resolution: 156543.033928, scale: 591657527.591555},
+      {level: 1, resolution: 78271.516964, scale: 295828763.795777}
+    ]
+  },
+  fullExtent: {xmin: -20037508, ymin: -20037508, xmax: 20037508, ymax: 20037508}
+};
+
+test('ArcGISVectorTileServerSource exposes tile metadata and resources', async () => {
+  const source = ArcGISVectorTileServerSourceLoader.createDataSource(VECTOR_TILE_SERVER_URL, {});
+  source.fetch = async () => new Response(JSON.stringify(SERVICE_METADATA));
+
+  const metadata = await source.getMetadata();
+  expect(metadata.name).toBe('World');
+  expect(metadata.minZoom).toBe(0);
+  expect(metadata.maxZoom).toBe(1);
+  expect(metadata.layer?.srs).toEqual(['EPSG:3857']);
+  expect(metadata.formatHeader).toMatchObject({
+    styleURL: `${VECTOR_TILE_SERVER_URL}/resources/styles/root.json`,
+    spriteURL: `${VECTOR_TILE_SERVER_URL}/resources/styles/sprites`
+  });
+});
+
+test('ArcGISVectorTileServerSource builds standard resource URLs', () => {
+  const source = ArcGISVectorTileServerSourceLoader.createDataSource(VECTOR_TILE_SERVER_URL, {});
+  expect(source.getMetadataURL()).toBe(`${VECTOR_TILE_SERVER_URL}?f=pjson`);
+  expect(source.getStyleURL()).toBe(`${VECTOR_TILE_SERVER_URL}/resources/styles/root.json`);
+  expect(source.getTileURL({z: 4, x: 6, y: 7})).toBe(`${VECTOR_TILE_SERVER_URL}/tile/4/7/6.pbf`);
+});
+
+test('ArcGISVectorTileServerSource fetches raw PBF tiles', async () => {
+  const source = ArcGISVectorTileServerSourceLoader.createDataSource(VECTOR_TILE_SERVER_URL, {});
+  const tileBytes = new Uint8Array([1, 2, 3, 4]);
+  source.fetch = async (url, options) => {
+    expect(url).toBe(`${VECTOR_TILE_SERVER_URL}/tile/2/5/4.pbf`);
+    expect(new Headers(options?.headers).get('accept')).toContain(
+      'application/vnd.mapbox-vector-tile'
+    );
+    return new Response(tileBytes);
+  };
+  const result = await source.getTile({z: 2, x: 4, y: 5});
+  expect(new Uint8Array(result!)).toEqual(tileBytes);
+});

--- a/modules/wms/test/arcgis/arcgis-vector-tile-server-source.spec.ts
+++ b/modules/wms/test/arcgis/arcgis-vector-tile-server-source.spec.ts
@@ -28,7 +28,7 @@ test('ArcGISVectorTileServerSource exposes tile metadata and resources', async (
   expect(metadata.layer?.srs).toEqual(['EPSG:3857']);
   expect(metadata.formatHeader).toMatchObject({
     styleURL: `${VECTOR_TILE_SERVER_URL}/resources/styles/root.json`,
-    spriteURL: `${VECTOR_TILE_SERVER_URL}/resources/styles/sprites`
+    spriteURL: `${VECTOR_TILE_SERVER_URL}/resources/sprites/sprite`
   });
 });
 
@@ -36,7 +36,19 @@ test('ArcGISVectorTileServerSource builds standard resource URLs', () => {
   const source = ArcGISVectorTileServerSourceLoader.createDataSource(VECTOR_TILE_SERVER_URL, {});
   expect(source.getMetadataURL()).toBe(`${VECTOR_TILE_SERVER_URL}?f=pjson`);
   expect(source.getStyleURL()).toBe(`${VECTOR_TILE_SERVER_URL}/resources/styles/root.json`);
+  expect(source.getSpriteURL()).toBe(`${VECTOR_TILE_SERVER_URL}/resources/sprites/sprite`);
   expect(source.getTileURL({z: 4, x: 6, y: 7})).toBe(`${VECTOR_TILE_SERVER_URL}/tile/4/7/6.pbf`);
+});
+
+test('ArcGISVectorTileServerSource preserves service query parameters', () => {
+  const source = ArcGISVectorTileServerSourceLoader.createDataSource(
+    `${VECTOR_TILE_SERVER_URL}?token=abc`,
+    {}
+  );
+  expect(source.getMetadataURL()).toBe(`${VECTOR_TILE_SERVER_URL}?token=abc&f=pjson`);
+  expect(source.getTileURL({z: 4, x: 6, y: 7})).toBe(
+    `${VECTOR_TILE_SERVER_URL}/tile/4/7/6.pbf?token=abc`
+  );
 });
 
 test('ArcGISVectorTileServerSource fetches raw PBF tiles', async () => {
@@ -47,8 +59,9 @@ test('ArcGISVectorTileServerSource fetches raw PBF tiles', async () => {
     expect(new Headers(options?.headers).get('accept')).toContain(
       'application/vnd.mapbox-vector-tile'
     );
+    expect(options?.signal).toBeDefined();
     return new Response(tileBytes);
   };
-  const result = await source.getTile({z: 2, x: 4, y: 5});
+  const result = await source.getTile({z: 2, x: 4, y: 5}, new AbortController().signal);
   expect(new Uint8Array(result!)).toEqual(tileBytes);
 });

--- a/modules/wms/test/index.ts
+++ b/modules/wms/test/index.ts
@@ -32,5 +32,6 @@ import './gml/gml-loader.spec';
 
 import './wms/wms-source.spec';
 import './arcgis/arcgis-server.spec';
+import './arcgis/arcgis-vector-tile-server-source.spec';
 import './service-capabilities.spec';
 import './ogc-api-source.spec';


### PR DESCRIPTION
## Goals

- Add first-class access to the widely deployed ArcGIS VectorTileServer service.
- Expose service metadata, tile-grid information, PBF tile requests, and style resources.
- Keep the adapter concrete and avoid coupling `@loaders.gl/wms` to the MVT source implementation.

## Changes

- Add `ArcGISVectorTileServerSource` and `ArcGISVectorTileServerSourceLoader`.
- Normalize ArcGIS `tileInfo`, LODs, spatial reference, and service extents into `TileSourceMetadata`.
- Add standard `/tile/{level}/{row}/{column}.pbf` URL generation.
- Expose metadata, style, and sprite resource URLs.
- Return raw PBF bytes for use with the existing `@loaders.gl/mvt` loader.
- Add hermetic metadata, URL, and tile-fetch tests.
- Add service documentation and sidebar navigation.

## Validation

- `yarn build`
- `yarn test-node` (351 passed, 6 skipped)
- `yarn test-headless modules/wms/test/arcgis/arcgis-vector-tile-server-source.spec.ts` (3 passed)
- `yarn lint fix`
- Website build succeeds; existing unrelated Docusaurus warnings remain.