### PR TITLE
feat(parquet): secure selective encrypted reads

### DIFF
--- a/docs/modules/parquet/api-reference/parquet-loader.md
+++ b/docs/modules/parquet/api-reference/parquet-loader.md
@@ -176,6 +176,7 @@ Supports table category options such as `batchType` and `batchSize`.
 | `parquet.wasmUrl` | `string` | package-local asset | Overrides the `parquet-wasm` binary URL for `ParquetLoader`. |
 | `parquet.keyRetriever` | `ParquetKeyRetriever` | `undefined` | Resolves keys for modular-encrypted files when using `ParquetJSLoader`. |
 | `parquet.aadPrefix` | `Uint8Array` | `undefined` | Supplies the AAD prefix for encrypted files that omit it from their crypto metadata. |
+| `parquet.verifyFooterSignature` | `boolean` | `true` | Verifies plaintext-footer signatures on modular-encrypted files when a `keyRetriever` is supplied. |
 
 ## Loader Variants
 
@@ -184,7 +185,8 @@ Supports table category options such as `batchType` and `batchSize`.
 - Use `ParquetJSLoader` for the experimental TypeScript implementation. It supports object-row and
   Arrow output plus the common row options listed above, including `columns`, `limit`, `offset`,
   `batchSize`, and `preserveBinary`. It can also read AES-GCM and AES-GCM-CTR encrypted column
-  metadata and page modules when `keyRetriever` is supplied.
+  metadata, page indexes, Bloom filters, and page modules when `keyRetriever` is supplied. Plaintext
+  footer signatures are verified by default.
 
 The implementation is selected by the loader import. There is no runtime backend option.
 The [JavaScript and WebAssembly performance](/docs/developer-guide/concepts/javascript-and-wasm-performance)

--- a/docs/modules/parquet/api-reference/parquet-source-loader.md
+++ b/docs/modules/parquet/api-reference/parquet-source-loader.md
@@ -359,6 +359,9 @@ individual read.
 | `parquet.headers` | `HeadersInit` | `undefined` | Headers forwarded to all remote Parquet requests. |
 | `parquet.preserveBinary` | `boolean` | `false` | Binary-value policy used by TypeScript-backed column reads. |
 | `parquet.verifyPageChecksums` | `boolean` | `false` | Verifies CRC-32 page bodies when the file provides page checksums; checksum-enabled reads use the TypeScript path. |
+| `parquet.verifyFooterSignature` | `boolean` | `true` | Verifies plaintext-footer signatures on modular-encrypted files when a `keyRetriever` is supplied. |
+| `parquet.keyRetriever` | `ParquetKeyRetriever` | `undefined` | Resolves keys for modular-encrypted metadata, indexes, Bloom filters, and pages. |
+| `parquet.aadPrefix` | `Uint8Array` | `undefined` | Supplies the AAD prefix for encrypted files that omit it from their crypto metadata. |
 | `parquet.onTelemetry` | `(event: ParquetTelemetryEvent) => void` | `undefined` | Receives cumulative transport, pruning, decode, and batch telemetry events. |
 | `parquet.workerUrl` | `string` | package-local worker | Overrides the selective source worker URL for explicit asset hosting. |
 | `parquet.rowGroups` / `read.rowGroups` | `number[]` | all row groups | Row-group indexes to fetch, in output order. |

--- a/docs/modules/parquet/formats/parquet.md
+++ b/docs/modules/parquet/formats/parquet.md
@@ -253,9 +253,10 @@ returned in the projected Arrow schema. Candidate rows are still filtered exactl
 thread or worker. Repeated-leaf pruning is enabled when all selected leaves have compatible page boundaries,
 including pages that continue one logical row; files with incompatible boundaries conservatively use full
 column-chunk reads. Size statistics are available for memory and nested-value planning; semantic sorting
-pruning remains future format-completeness work. The TypeScript reader supports full reads of AES-GCM and
-AES-GCM-CTR encrypted column metadata and page modules when a key retriever is provided. Encrypted
-page-index reads and writer-side encryption remain future work.
+pruning remains future format-completeness work. The TypeScript reader supports AES-GCM and
+AES-GCM-CTR encrypted column metadata, page indexes, Bloom filters, and page modules when a key retriever
+is provided. Encrypted sources conservatively stay on the caller thread because worker key-transfer
+protocols are not yet part of the public API; writer-side encryption remains future work.
 
 ## Integrity and Encryption
 
@@ -263,7 +264,7 @@ page-index reads and writer-side encryption remain future work.
 | ------- | ------- | -------- | ----- |
 | Footer and page-bound validation | ✅ | ✅ | Invalid magic, lengths, indexes, and truncated payloads are rejected |
 | Page CRC verification | ✅ (opt-in) | ✅ (opt-in) | CRC-32 covers the compressed page body; enable verification or emission explicitly to avoid a default throughput cost |
-| [Parquet modular encryption](https://github.com/apache/parquet-format/blob/master/Encryption.md) | ⚠️ | ❌ | Encrypted footers, column metadata, and full AES-GCM/AES-GCM-CTR page reads are supported; encrypted page-index reads and writer-side encryption remain in progress |
+| [Parquet modular encryption](https://github.com/apache/parquet-format/blob/master/Encryption.md) | ⚠️ | ❌ | Encrypted footers, column metadata, page indexes, Bloom filters, and AES-GCM/AES-GCM-CTR page reads are supported; writer-side encryption remains future work |
 | External column chunks | ❌ | ❌ | `file_path` column references are rejected |
 
 ## Parquet and Arrow

--- a/modules/parquet/src/index.ts
+++ b/modules/parquet/src/index.ts
@@ -114,7 +114,10 @@ export {
   type ParquetPageStatistics
 } from './lib/parquet-page-index';
 export {
+  createParquetModuleAad,
   decryptParquetModule,
+  readParquetEncryptedModule,
+  verifyParquetFooterSignature,
   type ParquetDecryptModuleOptions,
   type ParquetEncryptionAlgorithm,
   type ParquetKeyRetriever

--- a/modules/parquet/src/lib/parquet-encryption.ts
+++ b/modules/parquet/src/lib/parquet-encryption.ts
@@ -38,6 +38,23 @@ export type ParquetDecryptModuleOptions = {
   page?: boolean;
 };
 
+/** Reads one length-prefixed encrypted Parquet module from a serialized range. */
+export function readParquetEncryptedModule(
+  buffer: Uint8Array,
+  offset = 0
+): {bytes: Uint8Array; nextOffset: number} {
+  if (offset + 4 > buffer.length) {
+    throw new Error('Invalid encrypted Parquet module: missing module length');
+  }
+  const length = new DataView(buffer.buffer, buffer.byteOffset + offset, 4).getUint32(0, true);
+  const moduleStart = offset + 4;
+  const moduleEnd = moduleStart + length;
+  if (length < 12 || moduleEnd > buffer.length) {
+    throw new Error('Invalid encrypted Parquet module: truncated module');
+  }
+  return {bytes: buffer.subarray(moduleStart, moduleEnd), nextOffset: moduleEnd};
+}
+
 /** Builds the AAD required by the Parquet modular-encryption specification. */
 export function createParquetModuleAad(
   aadPrefix: Uint8Array | undefined,
@@ -116,6 +133,46 @@ export async function decryptParquetModule(
   return new Uint8Array(plaintext);
 }
 
+/** Verifies a plaintext-footer signature by authenticating the serialized footer bytes. */
+export async function verifyParquetFooterSignature(
+  footerBytes: Uint8Array,
+  signature: Uint8Array,
+  options: {
+    algorithm: ParquetEncryptionAlgorithm;
+    aad: Uint8Array;
+    keyMetadata?: Uint8Array;
+    keyRetriever: ParquetKeyRetriever;
+  }
+): Promise<void> {
+  if (signature.byteLength !== 28) {
+    throw new Error(
+      `Invalid Parquet plaintext-footer signature length ${signature.byteLength}; expected 28`
+    );
+  }
+  const keyMaterial = await options.keyRetriever(options.keyMetadata, {
+    algorithm: options.algorithm,
+    aad: options.aad
+  });
+  const cryptoKey = await getCryptoKey(keyMaterial, options.algorithm, false, ['encrypt']);
+  const encryptedFooter = new Uint8Array(
+    await getCryptoProvider().encrypt(
+      {
+        name: 'AES-GCM',
+        iv: signature.subarray(0, 12) as unknown as BufferSource,
+        additionalData: options.aad as unknown as BufferSource
+      },
+      cryptoKey,
+      footerBytes as unknown as BufferSource
+    )
+  );
+  const calculatedTag = encryptedFooter.subarray(encryptedFooter.byteLength - 16);
+  for (let index = 0; index < 16; index++) {
+    if (calculatedTag[index] !== signature[12 + index]) {
+      throw new Error('Parquet plaintext-footer signature verification failed');
+    }
+  }
+}
+
 function hasLengthPrefix(bytes: Uint8Array): boolean {
   if (bytes.length < 4) return false;
   const length = new DataView(bytes.buffer, bytes.byteOffset, 4).getUint32(0, true);
@@ -132,7 +189,8 @@ function makeCounter(nonce: Uint8Array): Uint8Array {
 async function getCryptoKey(
   keyMaterial: ArrayBuffer | ArrayBufferView,
   algorithm: ParquetEncryptionAlgorithm,
-  page?: boolean
+  page?: boolean,
+  usages: KeyUsage[] = ['decrypt']
 ): Promise<CryptoKey> {
   const keyBytes = toUint8Array(keyMaterial);
   if (keyBytes.byteLength !== 16 && keyBytes.byteLength !== 24 && keyBytes.byteLength !== 32) {
@@ -143,7 +201,7 @@ async function getCryptoKey(
     keyBytes as unknown as BufferSource,
     page && algorithm === 'AES_GCM_CTR_V1' ? {name: 'AES-CTR'} : {name: 'AES-GCM'},
     false,
-    ['decrypt']
+    usages
   );
 }
 

--- a/modules/parquet/src/lib/parquet-page-index.ts
+++ b/modules/parquet/src/lib/parquet-page-index.ts
@@ -77,6 +77,23 @@ export type ParquetPagePruningPlan = {
   prunedRowCount: number;
 };
 
+/** Decrypts an encrypted page-index module before Thrift decoding. */
+export type ParquetPageIndexDecryptor = (
+  bytes: Uint8Array,
+  module: 'column-index' | 'offset-index',
+  rowGroupOrdinal: number,
+  columnOrdinal: number,
+  columnChunk: ColumnChunk
+) => Promise<Uint8Array>;
+
+/** Optional controls for reading page indexes from a Parquet source. */
+export type ParquetPagePruningOptions = {
+  /** Row-group ordinal used when constructing encrypted-module AAD. */
+  rowGroupOrdinal?: number;
+  /** Decrypts encrypted index modules; omitted for plaintext files. */
+  decryptModule?: ParquetPageIndexDecryptor;
+};
+
 /** Logical statistics attached to one data page. */
 export type ParquetPageStatistics = {
   min?: unknown;
@@ -105,7 +122,8 @@ export async function createParquetPagePruningPlan(
   schema: ParquetSchema,
   selectedColumnPaths: readonly string[][],
   predicate: ParquetPredicate,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  options?: ParquetPagePruningOptions
 ): Promise<ParquetPagePruningPlan | undefined> {
   const rowCount = Number(rowGroup.num_rows);
   const selectedColumnChunks = getSelectedColumnChunks(rowGroup, selectedColumnPaths);
@@ -122,6 +140,7 @@ export async function createParquetPagePruningPlan(
 
   await Promise.all(
     selectedColumnChunks.map(async columnChunk => {
+      const columnOrdinal = rowGroup.columns.indexOf(columnChunk);
       const path = columnChunk.meta_data!.path_in_schema;
       const pathKey = JSON.stringify(path);
       const offsetIndexRange = getParquetIndexRange(
@@ -139,7 +158,16 @@ export async function createParquetPagePruningPlan(
       );
       let pages: ParquetDataPageLocation[];
       try {
-        pages = decodeOffsetIndex(toUint8Array(offsetIndexBytes), rowCount);
+        const decryptedBytes = options?.decryptModule
+          ? await options.decryptModule(
+              toUint8Array(offsetIndexBytes),
+              'offset-index',
+              options.rowGroupOrdinal ?? 0,
+              columnOrdinal,
+              columnChunk
+            )
+          : toUint8Array(offsetIndexBytes);
+        pages = decodeOffsetIndex(decryptedBytes, rowCount);
       } catch {
         return;
       }
@@ -164,9 +192,18 @@ export async function createParquetPagePruningPlan(
       );
       const field = schema.findField(path);
       try {
+        const decryptedBytes = options?.decryptModule
+          ? await options.decryptModule(
+              toUint8Array(columnIndexBytes),
+              'column-index',
+              options.rowGroupOrdinal ?? 0,
+              columnOrdinal,
+              columnChunk
+            )
+          : toUint8Array(columnIndexBytes);
         pageStatistics[pathKey] = {
           pages,
-          statistics: decodeParquetColumnIndex(toUint8Array(columnIndexBytes), pages, field)
+          statistics: decodeParquetColumnIndex(decryptedBytes, pages, field)
         };
       } catch {
         return;

--- a/modules/parquet/src/lib/parsers/parse-parquet-to-arrow-js.ts
+++ b/modules/parquet/src/lib/parsers/parse-parquet-to-arrow-js.ts
@@ -128,6 +128,7 @@ async function readProjectedSchema(
 ): Promise<Schema> {
   const reader = new ParquetReader(file, {
     preserveBinary: options?.parquet?.preserveBinary,
+    verifyFooterSignature: options?.parquet?.verifyFooterSignature,
     keyRetriever: options?.parquet?.keyRetriever,
     aadPrefix: options?.parquet?.aadPrefix
   });
@@ -152,6 +153,7 @@ export async function* parseParquetFileToArrowInBatchesWithJs(
     retainByteArrayViews: true,
     useTypedValueBuffers: true,
     useTypedLevelBuffers: true,
+    verifyFooterSignature: options?.parquet?.verifyFooterSignature,
     keyRetriever: options?.parquet?.keyRetriever,
     aadPrefix: options?.parquet?.aadPrefix
   });

--- a/modules/parquet/src/lib/parsers/parse-parquet-to-json.ts
+++ b/modules/parquet/src/lib/parsers/parse-parquet-to-json.ts
@@ -26,6 +26,7 @@ export async function parseParquetFile(
 
   const reader = new ParquetReader(file, {
     preserveBinary: options?.parquet?.preserveBinary,
+    verifyFooterSignature: options?.parquet?.verifyFooterSignature,
     keyRetriever: options?.parquet?.keyRetriever,
     aadPrefix: options?.parquet?.aadPrefix
   });
@@ -81,6 +82,7 @@ export async function* parseParquetFileInBatches(
 
   const reader = new ParquetReader(file, {
     preserveBinary: options?.parquet?.preserveBinary,
+    verifyFooterSignature: options?.parquet?.verifyFooterSignature,
     keyRetriever: options?.parquet?.keyRetriever,
     aadPrefix: options?.parquet?.aadPrefix
   });

--- a/modules/parquet/src/parquet-js-loader-types.ts
+++ b/modules/parquet/src/parquet-js-loader-types.ts
@@ -21,6 +21,7 @@ const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 const DEFAULT_PARQUET_JS_OPTIONS = {
   columns: undefined,
   preserveBinary: false,
+  verifyFooterSignature: true,
   shape: 'object-row-table' as const
 };
 

--- a/modules/parquet/src/parquet-js-loader.ts
+++ b/modules/parquet/src/parquet-js-loader.ts
@@ -25,7 +25,8 @@ const {preload: _ParquetJSLoaderPreload, ...ParquetJSLoaderMetadataWithoutPreloa
 /** Default option bag for the experimental parquetjs plain-row loader. */
 const DEFAULT_PARQUET_JS_OPTIONS = {
   columns: undefined,
-  preserveBinary: false
+  preserveBinary: false,
+  verifyFooterSignature: true
 };
 
 /** Parser-bearing TypeScript-only Parquet loader implementation. */

--- a/modules/parquet/src/parquet-loader-options.ts
+++ b/modules/parquet/src/parquet-loader-options.ts
@@ -43,6 +43,8 @@ export type ParquetJSLoaderOptions = LoaderOptions & {
     keyRetriever?: ParquetKeyRetriever;
     /** AAD prefix for encrypted files that intentionally omit it from metadata. */
     aadPrefix?: Uint8Array;
+    /** Verify plaintext-footer signatures when present. Enabled by default. */
+    verifyFooterSignature?: boolean;
   } & {
     [Key in keyof ParquetCommonLoaderOptions]?: ParquetCommonLoaderOptions[Key];
   };

--- a/modules/parquet/src/parquet-source-loader-types.ts
+++ b/modules/parquet/src/parquet-source-loader-types.ts
@@ -48,6 +48,7 @@ export const ParquetSourceLoader = {
       headers: undefined,
       preserveBinary: false,
       verifyPageChecksums: false,
+      verifyFooterSignature: true,
       onTelemetry: undefined,
       workerUrl: undefined,
       wasmUrl: undefined
@@ -71,6 +72,7 @@ export const ParquetSourceLoader = {
       headers: undefined!,
       preserveBinary: false,
       verifyPageChecksums: false,
+      verifyFooterSignature: true,
       onTelemetry: undefined!,
       workerUrl: undefined!,
       wasmUrl: undefined!

--- a/modules/parquet/src/parquet-source-loader.ts
+++ b/modules/parquet/src/parquet-source-loader.ts
@@ -694,6 +694,7 @@ export class ParquetSource
         if (phase.phase === 'projection' && predicateProvedEmpty) {
           continue;
         }
+        await initialization.reader.resolveColumnMetadata(rowGroup, rowGroupIndex, phase.columns);
         const pagePlan = phase.predicate
           ? await createParquetPagePruningPlan(
               initialization.file,

--- a/modules/parquet/src/parquet-source-loader.ts
+++ b/modules/parquet/src/parquet-source-loader.ts
@@ -424,7 +424,8 @@ export class ParquetSource
       const projectedSchema = projectSchema(initialization.schema, columns);
       const projectedColumnNames = columns.length ? new Set(columns) : undefined;
       const workerOptions = this.getWorkerOptions(concurrency, readContext.abortController.signal);
-      const decodeOnWorker = canDecodeParquetSourceOnWorker(workerOptions);
+      const decodeOnWorker =
+        canDecodeParquetSourceOnWorker(workerOptions) && !initialization.reader.encrypted;
       const scheduledReads = new Map<number, Promise<SettledParquetRowGroupRead>>();
       let nextPositionToSchedule = 0;
       let remainingRows = readOptions.limit ?? Number.POSITIVE_INFINITY;
@@ -700,7 +701,18 @@ export class ParquetSource
               initialization.parquetSchema,
               phase.columns,
               phase.predicate,
-              signal
+              signal,
+              {
+                rowGroupOrdinal: rowGroupIndex,
+                decryptModule: (bytes, module, rowGroupOrdinal, columnOrdinal, columnChunk) =>
+                  initialization.reader.decryptIndexModule(
+                    bytes,
+                    module,
+                    rowGroupOrdinal,
+                    columnOrdinal,
+                    columnChunk
+                  )
+              }
             )
           : undefined;
         plans.push(
@@ -856,7 +868,18 @@ export class ParquetSource
           initialization.parquetSchema,
           columnList,
           predicate,
-          signal
+          signal,
+          {
+            rowGroupOrdinal: rowGroupIndex,
+            decryptModule: (bytes, module, rowGroupOrdinal, columnOrdinal, columnChunk) =>
+              initialization.reader.decryptIndexModule(
+                bytes,
+                module,
+                rowGroupOrdinal,
+                columnOrdinal,
+                columnChunk
+              )
+          }
         )
       : undefined;
     if (pagePlan) {
@@ -1110,6 +1133,7 @@ export class ParquetSource
       const reader = new ParquetReader(file, {
         preserveBinary: this.options.parquet?.preserveBinary,
         verifyPageChecksums: this.options.parquet?.verifyPageChecksums,
+        verifyFooterSignature: this.options.parquet?.verifyFooterSignature,
         keyRetriever: this.options.parquet?.keyRetriever,
         aadPrefix: this.options.parquet?.aadPrefix,
         signal
@@ -1919,12 +1943,31 @@ async function filterParquetRowGroupsWithBloomFilters(
       if (!field.primitiveType) continue;
       let filter: ReturnType<typeof decodeParquetSplitBlockBloomFilter>;
       try {
+        const rawColumnOrdinal = initialization.fileMetadata.row_groups[
+          rowGroupIndex
+        ].columns.findIndex(
+          columnChunk =>
+            JSON.stringify(columnChunk.meta_data?.path_in_schema) ===
+            JSON.stringify(probe.column.path)
+        );
+        const rawColumnChunk =
+          rawColumnOrdinal >= 0
+            ? initialization.fileMetadata.row_groups[rowGroupIndex].columns[rawColumnOrdinal]
+            : undefined;
         const data = await initialization.file.read(
           probe.column.bloomFilterOffset,
           probe.column.bloomFilterByteLength,
           signal
         );
-        filter = decodeParquetSplitBlockBloomFilter(toUint8Array(data));
+        const decodedBloomFilter = rawColumnChunk
+          ? await initialization.reader.decryptBloomFilter(
+              toUint8Array(data),
+              rowGroupIndex,
+              rawColumnOrdinal,
+              rawColumnChunk
+            )
+          : toUint8Array(data);
+        filter = decodeParquetSplitBlockBloomFilter(decodedBloomFilter);
         filtersRead++;
         bytesRead += data.byteLength;
       } catch {

--- a/modules/parquet/src/parquet-source-types.ts
+++ b/modules/parquet/src/parquet-source-types.ts
@@ -479,6 +479,8 @@ export type ParquetSourceLoaderOptions = DataSourceOptions & {
     keyRetriever?: ParquetKeyRetriever;
     /** AAD prefix for encrypted files that intentionally omit it from metadata. */
     aadPrefix?: Uint8Array;
+    /** Verify plaintext-footer signatures when present. Enabled by default. */
+    verifyFooterSignature?: boolean;
     /** Receives cumulative transport, pruning, decode, and batch telemetry events. */
     onTelemetry?: (event: ParquetTelemetryEvent) => void;
     /** Overrides the package-local worker used for selective source decoding. */

--- a/modules/parquet/src/parquetjs/parser/parquet-reader.ts
+++ b/modules/parquet/src/parquetjs/parser/parquet-reader.ts
@@ -291,7 +291,6 @@ export class ParquetReader {
     const decoded = decodeFileMetadata(metadataBuf);
     const {metadata} = decoded;
     this.setEncryptionContext(metadata);
-    await this.resolveEncryptedColumnMetadata(metadata);
     if (this.props.verifyFooterSignature && this.encryptionContext?.footerSigningKeyMetadata) {
       // The compact-protocol decoder may consume bytes from the signature that
       // happen to look like valid Thrift fields. The format defines the
@@ -355,7 +354,6 @@ export class ParquetReader {
       footerKeyMetadata: cryptoMetadata.metadata.key_metadata
     };
     const metadata = decodeFileMetadata(plaintext).metadata;
-    await this.resolveEncryptedColumnMetadata(metadata);
     return metadata;
   }
 
@@ -376,19 +374,30 @@ export class ParquetReader {
     };
   }
 
-  /** Resolves encrypted column metadata so source planning can inspect all column references. */
-  private async resolveEncryptedColumnMetadata(metadata: FileMetaData): Promise<void> {
-    for (let rowGroupOrdinal = 0; rowGroupOrdinal < metadata.row_groups.length; rowGroupOrdinal++) {
-      const rowGroup = metadata.row_groups[rowGroupOrdinal];
-      for (let columnOrdinal = 0; columnOrdinal < rowGroup.columns.length; columnOrdinal++) {
-        const columnChunk = rowGroup.columns[columnOrdinal];
-        if (columnChunk.encrypted_column_metadata) {
-          columnChunk.meta_data = await this.getColumnMetadata(
-            columnChunk,
-            rowGroupOrdinal,
-            columnOrdinal
-          );
-        }
+  /** Resolves only the selected encrypted columns, using crypto metadata paths before decryption. */
+  async resolveColumnMetadata(
+    rowGroup: RowGroup,
+    rowGroupOrdinal: number,
+    selectedColumnPaths?: readonly string[][]
+  ): Promise<void> {
+    for (let columnOrdinal = 0; columnOrdinal < rowGroup.columns.length; columnOrdinal++) {
+      const columnChunk = rowGroup.columns[columnOrdinal];
+      const path = getColumnChunkPath(columnChunk);
+      if (
+        selectedColumnPaths &&
+        path &&
+        !selectedColumnPaths.some(
+          selectedPath => fieldIndexOf([Array.from(selectedPath)], path) >= 0
+        )
+      ) {
+        continue;
+      }
+      if (columnChunk.encrypted_column_metadata && !columnChunk.meta_data) {
+        columnChunk.meta_data = await this.getColumnMetadata(
+          columnChunk,
+          rowGroupOrdinal,
+          columnOrdinal
+        );
       }
     }
   }
@@ -524,6 +533,7 @@ export class ParquetReader {
     signal?: AbortSignal,
     rowGroupOrdinal = 0
   ): Promise<ParquetRowGroup> {
+    await this.resolveColumnMetadata(rowGroup, rowGroupOrdinal, columnList);
     const selectedColumnChunks: Array<{
       columnChunk: ColumnChunk;
       metadata: NonNullable<ColumnChunk['meta_data']>;
@@ -531,6 +541,10 @@ export class ParquetReader {
     }> = [];
     for (let columnOrdinal = 0; columnOrdinal < rowGroup.columns.length; columnOrdinal++) {
       const columnChunk = rowGroup.columns[columnOrdinal];
+      const path = getColumnChunkPath(columnChunk);
+      if (columnList.length > 0 && (!path || fieldIndexOf(columnList, path) < 0)) {
+        continue;
+      }
       const metadata = await this.getColumnMetadata(columnChunk, rowGroupOrdinal, columnOrdinal);
       if (columnList.length === 0 || fieldIndexOf(columnList, metadata.path_in_schema) >= 0) {
         selectedColumnChunks.push({columnChunk, metadata, columnOrdinal});
@@ -579,6 +593,7 @@ export class ParquetReader {
     signal?: AbortSignal,
     rowGroupOrdinal = 0
   ): Promise<ParquetRowGroup> {
+    await this.resolveColumnMetadata(rowGroup, rowGroupOrdinal, columnList);
     const selectedColumnChunks: Array<{
       columnChunk: ColumnChunk;
       metadata: NonNullable<ColumnChunk['meta_data']>;
@@ -586,6 +601,10 @@ export class ParquetReader {
     }> = [];
     for (let columnOrdinal = 0; columnOrdinal < rowGroup.columns.length; columnOrdinal++) {
       const columnChunk = rowGroup.columns[columnOrdinal];
+      const path = getColumnChunkPath(columnChunk);
+      if (columnList.length > 0 && (!path || fieldIndexOf(columnList, path) < 0)) {
+        continue;
+      }
       const metadata = await this.getColumnMetadata(columnChunk, rowGroupOrdinal, columnOrdinal);
       if (columnList.length === 0 || fieldIndexOf(columnList, metadata.path_in_schema) >= 0) {
         selectedColumnChunks.push({columnChunk, metadata, columnOrdinal});
@@ -969,6 +988,14 @@ export class ParquetReader {
     const pagesBuf = toUint8Array(arrayBuffer);
     return await decodeDictionaryBuffer(pagesBuf, context);
   }
+}
+
+/** Returns a column path available without decrypting column metadata when possible. */
+function getColumnChunkPath(columnChunk: ColumnChunk): string[] | undefined {
+  return (
+    columnChunk.meta_data?.path_in_schema ??
+    columnChunk.crypto_metadata?.ENCRYPTION_WITH_COLUMN_KEY?.path_in_schema
+  );
 }
 
 /** Decodes one dictionary page from an already-read column-chunk range. */

--- a/modules/parquet/src/parquetjs/parser/parquet-reader.ts
+++ b/modules/parquet/src/parquetjs/parser/parquet-reader.ts
@@ -46,6 +46,8 @@ import type {
 import {
   createParquetModuleAad,
   decryptParquetModule,
+  readParquetEncryptedModule,
+  verifyParquetFooterSignature,
   type ParquetEncryptionAlgorithm,
   type ParquetKeyRetriever
 } from '../../lib/parquet-encryption';
@@ -77,6 +79,8 @@ export type ParquetReaderProps = {
   useTypedLevelBuffers?: boolean;
   /** Verify page-header CRC values when present. Disabled by default for throughput. */
   verifyPageChecksums?: boolean;
+  /** Verify plaintext-footer signatures when present. Enabled by default. */
+  verifyFooterSignature?: boolean;
   /** Abort signal forwarded to every underlying random-access read. */
   signal?: AbortSignal;
   /** Resolves modular-encryption keys from the file's key metadata. */
@@ -106,6 +110,7 @@ type ParquetEncryptionContext = {
   aadPrefix?: Uint8Array;
   fileUnique: Uint8Array;
   footerKeyMetadata?: Uint8Array;
+  footerSigningKeyMetadata?: Uint8Array;
 };
 
 /**
@@ -123,6 +128,7 @@ export class ParquetReader {
     useTypedValueBuffers: false,
     useTypedLevelBuffers: false,
     verifyPageChecksums: false,
+    verifyFooterSignature: true,
     signal: undefined,
     keyRetriever: undefined,
     aadPrefix: undefined
@@ -139,6 +145,11 @@ export class ParquetReader {
   constructor(file: ReadableFile, props?: ParquetReaderProps) {
     this.file = file;
     this.props = {...ParquetReader.defaultProps, ...props};
+  }
+
+  /** Whether the decoded footer describes an encrypted Parquet file. */
+  get encrypted(): boolean {
+    return Boolean(this.encryptionContext);
   }
 
   close(): void {
@@ -277,8 +288,35 @@ export class ParquetReader {
     // let metadata = new parquet_thrift.FileMetaData();
     // parquet_util.decodeThrift(metadata, metadataBuf);
 
-    const {metadata} = decodeFileMetadata(metadataBuf);
+    const decoded = decodeFileMetadata(metadataBuf);
+    const {metadata} = decoded;
     this.setEncryptionContext(metadata);
+    await this.resolveEncryptedColumnMetadata(metadata);
+    if (this.props.verifyFooterSignature && this.encryptionContext?.footerSigningKeyMetadata) {
+      // The compact-protocol decoder may consume bytes from the signature that
+      // happen to look like valid Thrift fields. The format defines the
+      // signature as the final fixed 28 bytes of the footer range, so use the
+      // physical boundary rather than the decoder's consumed length.
+      const signatureOffset = metadataBuf.byteLength - 28;
+      if (signatureOffset < decoded.length) {
+        throw new Error('Invalid Parquet plaintext-footer signature boundary');
+      }
+      const signature = metadataBuf.subarray(signatureOffset);
+      const encryptionContext = this.encryptionContext;
+      if (!this.props.keyRetriever) {
+        throw new Error('Signed Parquet footer requires parquet.keyRetriever');
+      }
+      await verifyParquetFooterSignature(metadataBuf.subarray(0, signatureOffset), signature, {
+        algorithm: encryptionContext.algorithm,
+        aad: createParquetModuleAad(
+          encryptionContext.aadPrefix,
+          encryptionContext.fileUnique,
+          'footer'
+        ),
+        keyMetadata: encryptionContext.footerSigningKeyMetadata,
+        keyRetriever: this.props.keyRetriever
+      });
+    }
     return metadata;
   }
 
@@ -316,7 +354,9 @@ export class ParquetReader {
       fileUnique: algorithmMetadata.aad_file_unique,
       footerKeyMetadata: cryptoMetadata.metadata.key_metadata
     };
-    return decodeFileMetadata(plaintext).metadata;
+    const metadata = decodeFileMetadata(plaintext).metadata;
+    await this.resolveEncryptedColumnMetadata(metadata);
+    return metadata;
   }
 
   /** Records the encryption parameters exposed by plaintext-footer files. */
@@ -332,8 +372,98 @@ export class ParquetReader {
       algorithm,
       aadPrefix: algorithmMetadata.aad_prefix || this.props.aadPrefix,
       fileUnique: algorithmMetadata.aad_file_unique,
-      footerKeyMetadata: metadata.footer_signing_key_metadata
+      footerSigningKeyMetadata: metadata.footer_signing_key_metadata
     };
+  }
+
+  /** Resolves encrypted column metadata so source planning can inspect all column references. */
+  private async resolveEncryptedColumnMetadata(metadata: FileMetaData): Promise<void> {
+    for (let rowGroupOrdinal = 0; rowGroupOrdinal < metadata.row_groups.length; rowGroupOrdinal++) {
+      const rowGroup = metadata.row_groups[rowGroupOrdinal];
+      for (let columnOrdinal = 0; columnOrdinal < rowGroup.columns.length; columnOrdinal++) {
+        const columnChunk = rowGroup.columns[columnOrdinal];
+        if (columnChunk.encrypted_column_metadata) {
+          columnChunk.meta_data = await this.getColumnMetadata(
+            columnChunk,
+            rowGroupOrdinal,
+            columnOrdinal
+          );
+        }
+      }
+    }
+  }
+
+  /** Decrypts one encrypted column index or offset index module for selective planning. */
+  async decryptIndexModule(
+    bytes: Uint8Array,
+    module: 'column-index' | 'offset-index',
+    rowGroupOrdinal: number,
+    columnOrdinal: number,
+    columnChunk: ColumnChunk
+  ): Promise<Uint8Array> {
+    if (!columnChunk.crypto_metadata) return bytes;
+    const encryptionContext = this.encryptionContext;
+    if (!encryptionContext || !this.props.keyRetriever) {
+      throw new Error('Encrypted Parquet indexes require parquet.keyRetriever');
+    }
+    const aad = createParquetModuleAad(
+      encryptionContext.aadPrefix,
+      encryptionContext.fileUnique,
+      module,
+      rowGroupOrdinal,
+      columnOrdinal
+    );
+    return await decryptParquetModule(bytes, {
+      algorithm: encryptionContext.algorithm,
+      aad,
+      keyMetadata: this.getColumnKeyMetadata(columnChunk),
+      keyRetriever: this.props.keyRetriever
+    });
+  }
+
+  /** Decrypts the encrypted Bloom-filter header and bitset modules for one column chunk. */
+  async decryptBloomFilter(
+    bytes: Uint8Array,
+    rowGroupOrdinal: number,
+    columnOrdinal: number,
+    columnChunk: ColumnChunk
+  ): Promise<Uint8Array> {
+    if (!columnChunk.crypto_metadata) return bytes;
+    const encryptionContext = this.encryptionContext;
+    if (!encryptionContext || !this.props.keyRetriever) {
+      throw new Error('Encrypted Parquet Bloom filters require parquet.keyRetriever');
+    }
+    const header = readParquetEncryptedModule(bytes);
+    const bitset = readParquetEncryptedModule(bytes, header.nextOffset);
+    const keyMetadata = this.getColumnKeyMetadata(columnChunk);
+    const headerBytes = await decryptParquetModule(header.bytes, {
+      algorithm: encryptionContext.algorithm,
+      aad: createParquetModuleAad(
+        encryptionContext.aadPrefix,
+        encryptionContext.fileUnique,
+        'bloom-filter-header',
+        rowGroupOrdinal,
+        columnOrdinal
+      ),
+      keyMetadata,
+      keyRetriever: this.props.keyRetriever
+    });
+    const bitsetBytes = await decryptParquetModule(bitset.bytes, {
+      algorithm: encryptionContext.algorithm,
+      aad: createParquetModuleAad(
+        encryptionContext.aadPrefix,
+        encryptionContext.fileUnique,
+        'bloom-filter-bitset',
+        rowGroupOrdinal,
+        columnOrdinal
+      ),
+      keyMetadata,
+      keyRetriever: this.props.keyRetriever
+    });
+    const plaintext = new Uint8Array(headerBytes.byteLength + bitsetBytes.byteLength);
+    plaintext.set(headerBytes);
+    plaintext.set(bitsetBytes, headerBytes.byteLength);
+    return plaintext;
   }
 
   /** Resolves a column's plaintext metadata, decrypting column-specific metadata when present. */
@@ -370,7 +500,10 @@ export class ParquetReader {
     const plaintext = await decryptParquetModule(columnChunk.encrypted_column_metadata, {
       algorithm: encryptionContext.algorithm,
       aad,
-      keyMetadata: columnKey?.key_metadata ?? encryptionContext.footerKeyMetadata,
+      keyMetadata:
+        columnKey?.key_metadata ??
+        encryptionContext.footerKeyMetadata ??
+        encryptionContext.footerSigningKeyMetadata,
       keyRetriever: this.props.keyRetriever
     });
     const metadata = decodeColumnMetadata(plaintext).metadata;
@@ -591,17 +724,18 @@ export class ParquetReader {
     rowGroupOrdinal: number,
     columnOrdinal: number,
     keyMetadata: Uint8Array | undefined,
-    includesDictionary = false
+    includesDictionary = false,
+    dataPageOrdinalStart = 0
   ): Promise<Uint8Array> {
     if (!this.encryptionContext || !this.props.keyRetriever) {
       throw new Error('Encrypted Parquet pages require parquet.keyRetriever');
     }
     const plaintextPages: Uint8Array[] = [];
     let offset = 0;
-    let dataPageOrdinal = 0;
+    let dataPageOrdinal = dataPageOrdinalStart;
     let pageIndex = 0;
     while (offset < encryptedPages.length) {
-      const headerModule = readEncryptedModule(encryptedPages, offset);
+      const headerModule = readParquetEncryptedModule(encryptedPages, offset);
       offset = headerModule.nextOffset;
       const dictionaryPage = includesDictionary && pageIndex === 0;
       const headerModuleType: ParquetEncryptionModule = dictionaryPage
@@ -623,7 +757,7 @@ export class ParquetReader {
       });
       const {pageHeader} = decodePageHeader(headerBytes);
       const pageType = getThriftEnum(PageType, pageHeader.type);
-      const dataModule = readEncryptedModule(encryptedPages, offset);
+      const dataModule = readParquetEncryptedModule(encryptedPages, offset);
       offset = dataModule.nextOffset;
       const dataAad = createParquetModuleAad(
         this.encryptionContext.aadPrefix,
@@ -658,7 +792,8 @@ export class ParquetReader {
   private getColumnKeyMetadata(columnChunk: ColumnChunk): Uint8Array | undefined {
     return (
       columnChunk.crypto_metadata?.ENCRYPTION_WITH_COLUMN_KEY?.key_metadata ??
-      this.encryptionContext?.footerKeyMetadata
+      this.encryptionContext?.footerKeyMetadata ??
+      this.encryptionContext?.footerSigningKeyMetadata
     );
   }
 
@@ -680,31 +815,7 @@ export class ParquetReader {
     if (!columnMetadata) {
       throw new Error('Parquet column metadata is missing');
     }
-    if (columnChunk.crypto_metadata) {
-      const fullColumnChunk = await this.readColumnChunk(
-        schema,
-        columnChunk,
-        signal,
-        rowGroupOrdinal,
-        columnOrdinal,
-        columnMetadata
-      );
-      const field = schema.findField(columnMetadata.path_in_schema);
-      if (field.rLevelMax !== 0) {
-        return sliceRepeatedColumnChunk(
-          fullColumnChunk,
-          rowRange.start,
-          rowRange.end - rowRange.start,
-          field.dLevelMax
-        );
-      }
-      return sliceNonRepeatedColumnChunk(
-        fullColumnChunk,
-        field.dLevelMax,
-        rowRange.start,
-        rowRange.end
-      );
-    }
+    const encrypted = Boolean(columnChunk.crypto_metadata);
     const field = schema.findField(columnMetadata.path_in_schema);
     const type: PrimitiveType = getThriftEnum(Type, columnMetadata.type) as any;
     if (type !== field.primitiveType) {
@@ -749,7 +860,17 @@ export class ParquetReader {
       const dictionaryBuffer = toUint8Array(
         await this.file.read(dictionaryPageOffset, dictionaryLength, signal ?? this.props.signal)
       );
-      dictionary = await decodeDictionaryBuffer(dictionaryBuffer, context);
+      const decodedDictionaryBuffer = encrypted
+        ? await this.decryptColumnPages(
+            dictionaryBuffer,
+            context,
+            rowGroupOrdinal,
+            columnOrdinal,
+            this.getColumnKeyMetadata(columnChunk),
+            true
+          )
+        : dictionaryBuffer;
+      dictionary = await decodeDictionaryBuffer(decodedDictionaryBuffer, context);
     }
 
     if (field.rLevelMax !== 0) {
@@ -763,7 +884,18 @@ export class ParquetReader {
             signal ?? this.props.signal
           )
         );
-        const probe = await decodeDataPages(probeBuffer, {...context, dictionary});
+        const decodedProbeBuffer = encrypted
+          ? await this.decryptColumnPages(
+              probeBuffer,
+              context,
+              rowGroupOrdinal,
+              columnOrdinal,
+              this.getColumnKeyMetadata(columnChunk),
+              false,
+              firstPageIndex
+            )
+          : probeBuffer;
+        const probe = await decodeDataPages(decodedProbeBuffer, {...context, dictionary});
         if (probe.rlevels[0] === 0) {
           break;
         }
@@ -774,7 +906,18 @@ export class ParquetReader {
     const dataBuffer = toUint8Array(
       await this.file.read(firstPage.offset, dataLength, signal ?? this.props.signal)
     );
-    const decoded = await decodeDataPages(dataBuffer, {...context, dictionary});
+    const decodedDataBuffer = encrypted
+      ? await this.decryptColumnPages(
+          dataBuffer,
+          context,
+          rowGroupOrdinal,
+          columnOrdinal,
+          this.getColumnKeyMetadata(columnChunk),
+          false,
+          firstPageIndex
+        )
+      : dataBuffer;
+    const decoded = await decodeDataPages(decodedDataBuffer, {...context, dictionary});
     if (field.rLevelMax !== 0) {
       const rowStart = rowRange.start - firstPage.firstRowIndex;
       return sliceRepeatedColumnChunk(
@@ -836,23 +979,6 @@ async function decodeDictionaryBuffer(
   const cursor = {buffer: dictionaryBuffer, offset: 0, size: dictionaryBuffer.length};
   const decodedPage = await decodePage(cursor, context);
   return decodedPage.dictionary!;
-}
-
-/** Reads one length-prefixed encrypted module from a page stream. */
-function readEncryptedModule(
-  buffer: Uint8Array,
-  offset: number
-): {bytes: Uint8Array; nextOffset: number} {
-  if (offset + 4 > buffer.length) {
-    throw new Error('Invalid encrypted Parquet page: missing module length');
-  }
-  const length = readUInt32LE(buffer, offset);
-  const moduleStart = offset + 4;
-  const moduleEnd = moduleStart + length;
-  if (length < 12 || moduleEnd > buffer.length) {
-    throw new Error('Invalid encrypted Parquet page: truncated module');
-  }
-  return {bytes: buffer.subarray(moduleStart, moduleEnd), nextOffset: moduleEnd};
 }
 
 /** Slices one decoded non-repeated column chunk while preserving optional-value alignment. */

--- a/modules/parquet/test/parquet-encryption.spec.ts
+++ b/modules/parquet/test/parquet-encryption.spec.ts
@@ -3,7 +3,11 @@
 // Copyright (c) vis.gl contributors
 
 import {load} from '@loaders.gl/core';
-import {ParquetJSLoader} from '@loaders.gl/parquet';
+import {
+  ParquetJSLoader,
+  createParquetModuleAad,
+  verifyParquetFooterSignature
+} from '@loaders.gl/parquet';
 import {expect, test} from 'vitest';
 
 const PARQUET_DIR = '@loaders.gl/parquet/test/data/apache';
@@ -86,4 +90,57 @@ test('ParquetJSLoader decrypts encrypted columns into an Arrow table', async () 
       'float_field'
     ]);
   }
+});
+
+test('verifies plaintext-footer signatures and rejects tampering', async () => {
+  const footerBytes = new TextEncoder().encode('serialized parquet footer');
+  const fileUnique = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+  const aad = createParquetModuleAad(undefined, fileUnique, 'footer');
+  const key = new TextEncoder().encode('0123456789012345');
+  const cryptoKey = await globalThis.crypto.subtle.importKey(
+    'raw',
+    key,
+    {name: 'AES-GCM'},
+    false,
+    ['encrypt', 'decrypt']
+  );
+  const nonce = new Uint8Array(12);
+  nonce.set([9, 8, 7, 6, 5, 4, 3, 2, 1]);
+  const encrypted = new Uint8Array(
+    await globalThis.crypto.subtle.encrypt(
+      {name: 'AES-GCM', iv: nonce, additionalData: aad},
+      cryptoKey,
+      footerBytes
+    )
+  );
+  const signature = new Uint8Array(28);
+  signature.set(nonce);
+  signature.set(encrypted.subarray(encrypted.length - 16), 12);
+  const keyRetriever = () => key;
+
+  await expect(
+    globalThis.crypto.subtle.decrypt(
+      {name: 'AES-GCM', iv: nonce, additionalData: aad},
+      cryptoKey,
+      encrypted
+    )
+  ).resolves.toEqual(footerBytes.buffer);
+
+  await verifyParquetFooterSignature(footerBytes, signature, {
+    algorithm: 'AES_GCM_V1',
+    aad,
+    keyMetadata: new TextEncoder().encode('footer'),
+    keyRetriever
+  });
+
+  const tamperedFooter = footerBytes.slice();
+  tamperedFooter[0] ^= 1;
+  await expect(
+    verifyParquetFooterSignature(tamperedFooter, signature, {
+      algorithm: 'AES_GCM_V1',
+      aad,
+      keyMetadata: new TextEncoder().encode('footer'),
+      keyRetriever
+    })
+  ).rejects.toThrow();
 });

--- a/modules/parquet/test/parquet-encryption.spec.ts
+++ b/modules/parquet/test/parquet-encryption.spec.ts
@@ -92,6 +92,26 @@ test('ParquetJSLoader decrypts encrypted columns into an Arrow table', async () 
   }
 });
 
+test('ParquetJSLoader does not retrieve keys for unprojected encrypted columns', async () => {
+  const requestedKeyMetadata: string[] = [];
+  const keyRetriever = (keyMetadata: Uint8Array | undefined) => {
+    const keyId = keyMetadata ? new TextDecoder().decode(keyMetadata) : '';
+    requestedKeyMetadata.push(keyId);
+    return ENCRYPTED_KEYS[keyId];
+  };
+  const url = `${PARQUET_DIR}/encrypted/encrypt_columns_and_footer.parquet.encrypted`;
+  const table = await load(url, ParquetJSLoader, {
+    core: {worker: false},
+    parquet: {
+      columns: ['double_field'],
+      keyRetriever
+    }
+  });
+
+  expect(table.data).toHaveLength(50);
+  expect(new Set(requestedKeyMetadata)).not.toEqual(new Set(['kf', 'kc1', 'kc2']));
+});
+
 test('verifies plaintext-footer signatures and rejects tampering', async () => {
   const footerBytes = new TextEncoder().encode('serialized parquet footer');
   const fileUnique = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);


### PR DESCRIPTION
## Goals

- Complete the reader-side modular-encryption work needed for authenticated selective Parquet scans.
- Preserve page-index and Bloom-filter pruning when metadata and indexes are encrypted.
- Verify plaintext-footer integrity while keeping the public API explicit and opt-out capable.

## Changes

- Decrypt encrypted column and offset indexes with Parquet module AADs, row-group ordinals, and column ordinals before page pruning.
- Decrypt split-block Bloom-filter header and bitset modules before row-group filtering.
- Keep encrypted selective page reads range-based instead of falling back to full column chunks, including dictionary and repeated-page ranges.
- Verify the 28-byte plaintext-footer signature by authenticating the serialized footer with AES-GCM.
- Add `parquet.verifyFooterSignature` (default `true`) and document encrypted metadata, indexes, Bloom filters, and page reads.
- Keep encrypted source decoding on the caller thread until worker key-transfer support is public.

## Validation

- `yarn build`
- `yarn test-node`
- `yarn test-headless modules/parquet/test/parquet-encryption.spec.ts modules/parquet/test/parquet-page-index-api.spec.ts`
- `yarn lint fix`

Reference: [Apache Parquet modular encryption](https://github.com/apache/parquet-format/blob/master/Encryption.md).

Writer-side encryption and encrypted worker decoding remain intentionally separate follow-up work.