### PR TITLE
feat(scan): execute portable relational operators

### DIFF
--- a/docs/developer-guide/common-scan-architecture.md
+++ b/docs/developer-guide/common-scan-architecture.md
@@ -682,9 +682,10 @@ The roadmap is therefore format-support-first. Each tranche must ship three thin
    but expose shared discovery, bounds, time, level-of-detail, explain, and cancellation metadata.
    Where a source returns feature tables (for example MVT or WFS), offer an explicit table-scan view;
    keep tile addressing and rendering controls outside `TableQuery`.
-7. **Portable relational growth.** Promote ordering, scalar expressions, aggregates, unions, and
-   equi-joins from logical planning to execution only after at least two real backends pass identical
-   conformance tests. Arrow and DuckDB are the first pair; Parquet/Iceberg and GPU are follow-ons.
+7. **Portable relational growth — first slice landed.** Arrow and DuckDB now execute the shared
+   ordering, scalar-expression, and grouped-aggregate request shape. The next slice is unions and
+   equi-joins, which must retain source ordering, duplicate-column rules, and explicit join semantics
+   across at least two backends before they become part of the default panel.
 8. **GPU and acceleration.** Lower the same plan to luma.gl/WGSL masks or indices, add deferred or
    materialized compaction, and compare GPU/CPU explain telemetry. Add spatial predicates and nearest
    neighbor only when indexed CPU, GPU, and remote-source strategies have compatible semantics.
@@ -723,6 +724,31 @@ the primary progress report for the roadmap.
 
 The desired end state is not one monolithic engine. It is a family of specialized planners and
 executors that agree on what a query means.
+
+### Relational first slice
+
+The first relational tranche deliberately stays small enough to run without a database ingest. An
+in-memory Arrow table can evaluate computed numeric columns, stable multi-key ordering (including
+explicit null placement), and `count`, `sum`, `min`, `max`, and `avg` aggregates. DuckDB receives the
+same immutable options through the SQL compiler, with identifiers quoted and arithmetic guarded
+against division by zero. Both executors apply filtering before expressions, ordering before the
+global limit, and projection after computed or aggregate columns are available.
+
+```ts
+const query = {
+  predicate: parseSQLPredicate("status = 'active'"),
+  expressions: [{name: 'revenue', expression: {op: 'multiply', left: 'price', right: 'quantity'}}],
+  columns: ['category', 'revenue'],
+  orderBy: [{column: 'revenue', direction: 'desc', nulls: 'last'}],
+  limit: 100
+};
+```
+
+The Arrow executor remains intentionally row-oriented for this proof of concept: it materializes
+only the rows needed by the relational operators and returns a bounded Arrow table. This gives
+format adapters and the GPU executor a conformance target without committing them to the same
+physical implementation. Union and join planning remains metadata-only until child-source
+resolution and duplicate-column naming are standardized.
 
 ## Point-cloud participation
 

--- a/modules/loader-utils/src/lib/scan-utils/relational-query.ts
+++ b/modules/loader-utils/src/lib/scan-utils/relational-query.ts
@@ -145,6 +145,7 @@ export function planRelationalQuery<
     tablePlan[0] = Object.freeze({kind: 'scan', columns: Object.freeze([...scanColumns])});
   }
   for (const expression of expressionNames) available.add(expression);
+  for (const aggregate of aggregateNames) available.add(aggregate);
   for (const key of options.orderBy || []) {
     if (!available.has(key.column))
       throw new Error(`Relational order column not found: ${key.column}`);
@@ -154,6 +155,9 @@ export function planRelationalQuery<
   }
   for (const aggregate of options.aggregates || []) {
     if (!aggregate.name) throw new Error('Relational aggregate names must be non-empty.');
+    if (aggregate.function !== 'count' && !aggregate.column) {
+      throw new Error(`Relational aggregate ${aggregate.function} requires a column.`);
+    }
     if (aggregate.column && !available.has(aggregate.column)) {
       throw new Error(`Relational aggregate column not found: ${aggregate.column}`);
     }

--- a/modules/loader-utils/src/lib/scan-utils/relational-query.ts
+++ b/modules/loader-utils/src/lib/scan-utils/relational-query.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {ColumnarPredicate} from './columnar-predicate';
+import type {ColumnarPredicate, ColumnarPredicateProperty} from './columnar-predicate';
 import type {TableQueryOptions} from './table-query';
 import {planTableQuery} from './table-query';
 
@@ -42,31 +42,39 @@ export type RelationalAggregate = Readonly<{
 }>;
 
 /** A relational child query used by unions and joins. */
-export type RelationalChildQuery<PredicateT extends ColumnarPredicate = ColumnarPredicate> =
-  Readonly<{
-    /** Logical source name. */
-    source: string;
-    /** Portable table query applied to the child. */
-    query?: TableQueryOptions<PredicateT>;
-  }>;
+export type RelationalChildQuery<
+  PredicateT extends ColumnarPredicate<unknown, ColumnarPredicateProperty> = ColumnarPredicate<
+    unknown,
+    ColumnarPredicateProperty
+  >
+> = Readonly<{
+  /** Logical source name. */
+  source: string;
+  /** Portable table query applied to the child. */
+  query?: TableQueryOptions<PredicateT>;
+}>;
 
 /** Portable relational extensions layered on top of a table scan. */
-export type RelationalQueryOptions<PredicateT extends ColumnarPredicate = ColumnarPredicate> =
-  TableQueryOptions<PredicateT> &
-    Readonly<{
-      /** Computed columns evaluated before projection. */
-      expressions?: readonly RelationalExpression[];
-      /** Stable ordering applied before the global limit. */
-      orderBy?: readonly RelationalOrderKey[];
-      /** Grouping keys for aggregate output. */
-      groupBy?: readonly string[];
-      /** Aggregate output definitions. */
-      aggregates?: readonly RelationalAggregate[];
-      /** Additional child queries to concatenate. */
-      union?: readonly RelationalChildQuery<PredicateT>[];
-      /** Optional equi-join child and key mapping. */
-      join?: Readonly<{child: RelationalChildQuery<PredicateT>; left: string; right: string}>;
-    }>;
+export type RelationalQueryOptions<
+  PredicateT extends ColumnarPredicate<unknown, ColumnarPredicateProperty> = ColumnarPredicate<
+    unknown,
+    ColumnarPredicateProperty
+  >
+> = TableQueryOptions<PredicateT> &
+  Readonly<{
+    /** Computed columns evaluated before projection. */
+    expressions?: readonly RelationalExpression[];
+    /** Stable ordering applied before the global limit. */
+    orderBy?: readonly RelationalOrderKey[];
+    /** Grouping keys for aggregate output. */
+    groupBy?: readonly string[];
+    /** Aggregate output definitions. */
+    aggregates?: readonly RelationalAggregate[];
+    /** Additional child queries to concatenate. */
+    union?: readonly RelationalChildQuery<PredicateT>[];
+    /** Optional equi-join child and key mapping. */
+    join?: Readonly<{child: RelationalChildQuery<PredicateT>; left: string; right: string}>;
+  }>;
 
 /** Logical operator in a relational query plan. */
 export type RelationalPlanStep = Readonly<{
@@ -75,7 +83,12 @@ export type RelationalPlanStep = Readonly<{
 }>;
 
 /** Validates and normalizes the relational extensions without executing them. */
-export function planRelationalQuery<PredicateT extends ColumnarPredicate = ColumnarPredicate>(
+export function planRelationalQuery<
+  PredicateT extends ColumnarPredicate<unknown, ColumnarPredicateProperty> = ColumnarPredicate<
+    unknown,
+    ColumnarPredicateProperty
+  >
+>(
   sourceColumnNames: readonly string[],
   options: RelationalQueryOptions<PredicateT> = {}
 ): {
@@ -91,20 +104,31 @@ export function planRelationalQuery<PredicateT extends ColumnarPredicate = Colum
     }
     expressionNames.add(expression.name);
   }
+  const aggregateNames = new Set((options.aggregates || []).map(aggregate => aggregate.name));
   const requiredColumns = new Set<string>();
+  const availableColumns = new Set(sourceColumnNames);
   for (const expression of options.expressions || []) {
-    if (expression.expression.op === 'column') requiredColumns.add(expression.expression.column);
-    if ('left' in expression.expression) {
-      requiredColumns.add(expression.expression.left);
-      requiredColumns.add(expression.expression.right);
+    const definition = expression.expression;
+    if (definition.op === 'column') {
+      validateRelationalColumnReference(definition.column, availableColumns);
+      if (available.has(definition.column)) requiredColumns.add(definition.column);
     }
+    if ('left' in definition) {
+      validateRelationalColumnReference(definition.left, availableColumns);
+      validateRelationalColumnReference(definition.right, availableColumns);
+      if (available.has(definition.left)) requiredColumns.add(definition.left);
+      if (available.has(definition.right)) requiredColumns.add(definition.right);
+    }
+    availableColumns.add(expression.name);
   }
   for (const key of options.orderBy || []) requiredColumns.add(key.column);
   for (const key of options.groupBy || []) requiredColumns.add(key);
   for (const aggregate of options.aggregates || []) {
     if (aggregate.column) requiredColumns.add(aggregate.column);
   }
-  const outputColumns = options.columns?.filter(column => !expressionNames.has(column));
+  const outputColumns = options.columns?.filter(
+    column => !expressionNames.has(column) && !aggregateNames.has(column)
+  );
   const tablePlan = [
     ...planTableQuery(sourceColumnNames, {
       ...options,
@@ -147,4 +171,14 @@ export function planRelationalQuery<PredicateT extends ColumnarPredicate = Colum
   if (options.union?.length) relationalSteps.push({kind: 'union', detail: options.union});
   if (options.join) relationalSteps.push({kind: 'join', detail: options.join});
   return {tablePlan, relationalSteps: Object.freeze(relationalSteps)};
+}
+
+/** Validates that an expression operand refers to a source or earlier computed column. */
+function validateRelationalColumnReference(
+  columnName: string,
+  availableColumns: ReadonlySet<string>
+): void {
+  if (!availableColumns.has(columnName)) {
+    throw new Error(`Relational expression column not found: ${columnName}`);
+  }
 }

--- a/modules/loader-utils/src/lib/scan-utils/table-query.ts
+++ b/modules/loader-utils/src/lib/scan-utils/table-query.ts
@@ -85,6 +85,12 @@ export type TableQueryCapabilities = Readonly<{
   streaming: boolean;
   /** Whether active and queued physical work observes cancellation. */
   cancellation: boolean;
+  /** Whether scalar expressions can be evaluated before projection. */
+  expressions?: TableQueryOperatorSupport;
+  /** Whether output rows can be ordered before the global limit. */
+  orderBy?: TableQueryOperatorSupport;
+  /** Whether grouped aggregate output is supported. */
+  aggregates?: TableQueryOperatorSupport;
 }>;
 
 /**

--- a/modules/sql/src/arrow-table-source.ts
+++ b/modules/sql/src/arrow-table-source.ts
@@ -16,7 +16,7 @@ import {
   queryArrowTable
 } from './query-arrow-table';
 import type {ArrowQueryOptions} from './query-arrow-table';
-import type {TableQueryExplain, TableQueryOptions} from './table-query';
+import type {TableQueryExplain} from './table-query';
 
 /** In-memory source options; the source owns the supplied Arrow table. */
 export type ArrowTableSourceOptions = DataSourceOptions;
@@ -54,7 +54,7 @@ export class ArrowTableSource extends DataSource<ArrowTable, ArrowTableSourceOpt
   }
 
   /** Explains a portable query without evaluating table rows. */
-  explain(options: TableQueryOptions = {}): TableQueryExplain {
+  explain(options: ArrowQueryOptions = {}): TableQueryExplain {
     return explainArrowTableQuery(this.data, options);
   }
 

--- a/modules/sql/src/compile-table-query.ts
+++ b/modules/sql/src/compile-table-query.ts
@@ -97,19 +97,22 @@ export function compileSQLTableQuery(
 function compileProjection(query: SQLTableQuery): string {
   const expressions = query.expressions || [];
   const expressionByName = new Map(expressions.map(expression => [expression.name, expression]));
+  const aggregates = query.aggregates || [];
+  const aggregateByName = new Map(aggregates.map(aggregate => [aggregate.name, aggregate]));
   const columns = query.columns === undefined ? undefined : [...query.columns];
   const projectionColumns =
     columns ||
     (query.groupBy?.length || query.aggregates?.length ? [...(query.groupBy || [])] : []);
   const selections = projectionColumns.map(column => {
     const expression = expressionByName.get(column);
-    return expression
-      ? `${compileRelationalExpression(expression.expression)} AS ${quoteSQLIdentifier(expression.name)}`
+    if (expression) {
+      return `${compileRelationalExpression(expression.expression)} AS ${quoteSQLIdentifier(expression.name)}`;
+    }
+    const aggregate = aggregateByName.get(column);
+    return aggregate
+      ? `${compileAggregate(aggregate)} AS ${quoteSQLIdentifier(aggregate.name)}`
       : quoteSQLIdentifier(column);
   });
-  for (const aggregate of query.aggregates || []) {
-    selections.push(`${compileAggregate(aggregate)} AS ${quoteSQLIdentifier(aggregate.name)}`);
-  }
   if (!selections.length)
     return expressions.length
       ? expressions
@@ -118,7 +121,13 @@ function compileProjection(query: SQLTableQuery): string {
               `${compileRelationalExpression(expression.expression)} AS ${quoteSQLIdentifier(expression.name)}`
           )
           .join(', ')
-      : '*';
+      : aggregates.length
+        ? aggregates
+            .map(
+              aggregate => `${compileAggregate(aggregate)} AS ${quoteSQLIdentifier(aggregate.name)}`
+            )
+            .join(', ')
+        : '*';
   return selections.join(', ');
 }
 
@@ -272,6 +281,8 @@ function validateRelationalQuery(query: SQLTableQuery): void {
   }
   for (const aggregate of query.aggregates || []) {
     validateSQLIdentifier(aggregate.name);
+    if (aggregate.function !== 'count' && !aggregate.column)
+      throw new Error(`Relational aggregate ${aggregate.function} requires a column.`);
     if (aggregate.column) validateSQLIdentifier(aggregate.column);
   }
 }

--- a/modules/sql/src/compile-table-query.ts
+++ b/modules/sql/src/compile-table-query.ts
@@ -11,6 +11,11 @@ import {
   type SQLPredicateValue
 } from './sql-predicate-types';
 import type {TableQueryOptions} from './table-query';
+import type {
+  RelationalAggregate,
+  RelationalExpression,
+  RelationalOrderKey
+} from '@loaders.gl/loader-utils';
 
 /** SQL dialects supported by the portable table-query compiler. */
 export type SQLTableQueryDialect = 'duckdb' | 'snowflake';
@@ -24,6 +29,14 @@ export type SQLTableQuery = TableQueryOptions &
     schemaName?: string;
     /** Optional catalog containing the schema. */
     catalogName?: string;
+    /** Computed columns evaluated before projection. */
+    expressions?: readonly RelationalExpression[];
+    /** Stable ordering applied before the global limit. */
+    orderBy?: readonly RelationalOrderKey[];
+    /** Grouping keys for aggregate output. */
+    groupBy?: readonly string[];
+    /** Aggregate output definitions. */
+    aggregates?: readonly RelationalAggregate[];
   }>;
 
 /** Options controlling portable table-query compilation. */
@@ -59,8 +72,7 @@ export function compileSQLTableQuery(
     namedParameters: options.parameters,
     parameters: []
   };
-  const projection =
-    query.columns === undefined ? '*' : query.columns.map(quoteSQLIdentifier).join(', ');
+  const projection = compileProjection(query);
   const table = [query.catalogName, query.schemaName, query.tableName]
     .filter((identifier): identifier is string => identifier !== undefined)
     .map(quoteSQLIdentifier)
@@ -69,10 +81,80 @@ export function compileSQLTableQuery(
   if (query.predicate) {
     clauses.push(`WHERE ${compileSQLPredicate(query.predicate, context)}`);
   }
+  if (query.groupBy?.length) {
+    clauses.push(`GROUP BY ${query.groupBy.map(quoteSQLIdentifier).join(', ')}`);
+  }
+  if (query.orderBy?.length) {
+    clauses.push(`ORDER BY ${query.orderBy.map(compileOrderKey).join(', ')}`);
+  }
   if (query.limit !== undefined) {
     clauses.push(`LIMIT ${query.limit}`);
   }
   return {sql: clauses.join('\n'), parameters: context.parameters};
+}
+
+/** Compiles the SELECT list, including computed and aggregate output columns. */
+function compileProjection(query: SQLTableQuery): string {
+  const expressions = query.expressions || [];
+  const expressionByName = new Map(expressions.map(expression => [expression.name, expression]));
+  const columns = query.columns === undefined ? undefined : [...query.columns];
+  const projectionColumns =
+    columns ||
+    (query.groupBy?.length || query.aggregates?.length ? [...(query.groupBy || [])] : []);
+  const selections = projectionColumns.map(column => {
+    const expression = expressionByName.get(column);
+    return expression
+      ? `${compileRelationalExpression(expression.expression)} AS ${quoteSQLIdentifier(expression.name)}`
+      : quoteSQLIdentifier(column);
+  });
+  for (const aggregate of query.aggregates || []) {
+    selections.push(`${compileAggregate(aggregate)} AS ${quoteSQLIdentifier(aggregate.name)}`);
+  }
+  if (!selections.length)
+    return expressions.length
+      ? expressions
+          .map(
+            expression =>
+              `${compileRelationalExpression(expression.expression)} AS ${quoteSQLIdentifier(expression.name)}`
+          )
+          .join(', ')
+      : '*';
+  return selections.join(', ');
+}
+
+/** Compiles one portable scalar expression into quoted SQL. */
+function compileRelationalExpression(expression: RelationalExpression['expression']): string {
+  switch (expression.op) {
+    case 'column':
+      return quoteSQLIdentifier(expression.column);
+    case 'literal':
+      return expression.value === null
+        ? 'NULL'
+        : typeof expression.value === 'string'
+          ? `'${expression.value.replace(/'/g, "''")}'`
+          : String(expression.value);
+    case 'add':
+      return `(${quoteSQLIdentifier(expression.left)} + ${quoteSQLIdentifier(expression.right)})`;
+    case 'subtract':
+      return `(${quoteSQLIdentifier(expression.left)} - ${quoteSQLIdentifier(expression.right)})`;
+    case 'multiply':
+      return `(${quoteSQLIdentifier(expression.left)} * ${quoteSQLIdentifier(expression.right)})`;
+    case 'divide':
+      return `(${quoteSQLIdentifier(expression.left)} / NULLIF(${quoteSQLIdentifier(expression.right)}, 0))`;
+  }
+}
+
+/** Compiles one portable aggregate function call. */
+function compileAggregate(aggregate: RelationalAggregate): string {
+  const column = aggregate.column ? quoteSQLIdentifier(aggregate.column) : '*';
+  return `${aggregate.function.toUpperCase()}(${column})`;
+}
+
+/** Compiles one ordering key with explicit direction and null placement. */
+function compileOrderKey(orderKey: RelationalOrderKey): string {
+  const direction = orderKey.direction?.toUpperCase() || 'ASC';
+  const nulls = orderKey.nulls ? ` NULLS ${orderKey.nulls.toUpperCase()}` : '';
+  return `${quoteSQLIdentifier(orderKey.column)} ${direction}${nulls}`;
 }
 
 /** Compiles one portable predicate node while collecting bound scalar values. */
@@ -162,6 +244,36 @@ function validateSQLTableQuery(query: SQLTableQuery): void {
     throw new Error('Table query limit must be a non-negative safe integer.');
   }
   if (query.predicate) validateSQLPredicate(query.predicate);
+  validateRelationalQuery(query);
+}
+
+/** Validates relational identifiers and enum values before SQL generation. */
+function validateRelationalQuery(query: SQLTableQuery): void {
+  const expressionNames = new Set<string>();
+  for (const expression of query.expressions || []) {
+    validateSQLIdentifier(expression.name);
+    if (expressionNames.has(expression.name))
+      throw new Error(`Relational expression duplicates column: ${expression.name}`);
+    expressionNames.add(expression.name);
+    const definition = expression.expression;
+    if (definition.op === 'column') validateSQLIdentifier(definition.column);
+    if ('left' in definition) {
+      validateSQLIdentifier(definition.left);
+      validateSQLIdentifier(definition.right);
+    }
+  }
+  for (const column of query.groupBy || []) validateSQLIdentifier(column);
+  for (const key of query.orderBy || []) {
+    validateSQLIdentifier(key.column);
+    if (key.direction && key.direction !== 'asc' && key.direction !== 'desc')
+      throw new Error(`Invalid order direction: ${key.direction}`);
+    if (key.nulls && key.nulls !== 'first' && key.nulls !== 'last')
+      throw new Error(`Invalid null placement: ${key.nulls}`);
+  }
+  for (const aggregate of query.aggregates || []) {
+    validateSQLIdentifier(aggregate.name);
+    if (aggregate.column) validateSQLIdentifier(aggregate.column);
+  }
 }
 
 /** Rejects empty or NUL-containing identifiers before quoting them. */

--- a/modules/sql/src/index.ts
+++ b/modules/sql/src/index.ts
@@ -64,6 +64,11 @@ export type {
   SQLTableQueryDialect
 } from './compile-table-query';
 export type {
+  RelationalAggregate,
+  RelationalExpression,
+  RelationalOrderKey
+} from '@loaders.gl/loader-utils';
+export type {
   TableQueryFilterStep,
   TableQueryLimitStep,
   TableQueryOptions,

--- a/modules/sql/src/query-arrow-table.ts
+++ b/modules/sql/src/query-arrow-table.ts
@@ -5,6 +5,7 @@
 import * as arrow from 'apache-arrow';
 import type {ArrowTable} from '@loaders.gl/schema';
 import {convertArrowToSchema} from '@loaders.gl/schema-utils';
+import {convertRowsToArrowTable} from './sql-utils';
 
 import {
   isSQLPredicateParameter,
@@ -27,6 +28,12 @@ import {
   type TableQueryProjectStep,
   type TableQueryScanStep
 } from './table-query';
+import type {
+  RelationalAggregate,
+  RelationalExpression,
+  RelationalOrderKey
+} from '@loaders.gl/loader-utils';
+import {planRelationalQuery} from '@loaders.gl/loader-utils';
 export {ARROW_TABLE_QUERY_CAPABILITIES} from './table-query-capabilities';
 
 /** Options for the lightweight in-memory Arrow query executor. */
@@ -34,6 +41,14 @@ export type ArrowQueryOptions = TableQueryOptions &
   Readonly<{
     /** Cancels the query before or during predicate evaluation. */
     signal?: AbortSignal;
+    /** Computed columns evaluated before ordering and projection. */
+    expressions?: readonly RelationalExpression[];
+    /** Stable ordering applied before the global limit. */
+    orderBy?: readonly RelationalOrderKey[];
+    /** Grouping keys and aggregate definitions for relational output. */
+    groupBy?: readonly string[];
+    /** Aggregate definitions evaluated after filtering and expressions. */
+    aggregates?: readonly RelationalAggregate[];
   }>;
 
 /** Explains an Arrow table query without materializing or scanning table rows. */
@@ -59,6 +74,10 @@ export function queryArrowTable(
   options: ArrowQueryOptions = {}
 ): ArrowTable {
   throwIfAborted(options.signal);
+
+  if (hasRelationalOperators(options)) {
+    return queryArrowTableRelational(sourceTable, options);
+  }
 
   const sourceData = sourceTable.data;
   const plan = planTableQuery(
@@ -100,6 +119,205 @@ export function queryArrowTable(
     outputColumns[field.name] = arrow.vectorFromArray(values, sourceColumn.type);
   }
   return wrapArrowTable(new arrow.Table(projectedData.schema, outputColumns));
+}
+
+/** Executes the relational subset that can be evaluated against one in-memory Arrow table. */
+function queryArrowTableRelational(
+  sourceTable: ArrowTable,
+  options: ArrowQueryOptions
+): ArrowTable {
+  const sourceData = sourceTable.data;
+  const sourceColumnNames = sourceData.schema.fields.map(field => field.name);
+  const relationalPlan = planRelationalQuery(sourceColumnNames, options);
+  const scanStep = relationalPlan.tablePlan.find(step => step.kind === 'scan');
+  if (!scanStep || scanStep.kind !== 'scan') {
+    throw new Error('Arrow relational query plan is missing a scan step.');
+  }
+  const scannedTable = wrapArrowTable(sourceData.select([...scanStep.columns]));
+  const filteredTable = queryArrowTable(scannedTable, {
+    predicate: options.predicate,
+    columns: scanStep.columns,
+    signal: options.signal
+  });
+  let rows = arrowTableToRows(filteredTable.data);
+
+  for (const expression of options.expressions || []) {
+    for (const row of rows) {
+      row[expression.name] = evaluateRelationalExpression(expression, row);
+    }
+  }
+
+  if (options.orderBy?.length) {
+    const orderBy = options.orderBy;
+    rows = rows
+      .map((row, index) => ({row, index}))
+      .sort((left, right) => compareRows(left.row, right.row, orderBy) || left.index - right.index)
+      .map(entry => entry.row);
+  }
+
+  if (options.groupBy?.length || options.aggregates?.length) {
+    rows = aggregateRows(rows, options.groupBy || [], options.aggregates || []);
+  }
+
+  const outputColumns =
+    options.columns ||
+    (options.groupBy?.length || options.aggregates?.length
+      ? [...(options.groupBy || []), ...(options.aggregates || []).map(aggregate => aggregate.name)]
+      : sourceColumnNames);
+  const outputRows = rows.map(row => {
+    const output: Record<string, unknown> = {};
+    for (const columnName of outputColumns) {
+      if (!(columnName in row)) {
+        throw new Error(`Arrow relational query column not found: ${columnName}`);
+      }
+      output[columnName] = row[columnName];
+    }
+    return output;
+  });
+  const limit = options.limit === undefined ? outputRows.length : options.limit;
+  return convertRowsToArrowTable(outputRows.slice(0, limit));
+}
+
+/** Returns whether the query uses any in-memory relational operator. */
+function hasRelationalOperators(options: ArrowQueryOptions): boolean {
+  return Boolean(
+    options.expressions?.length ||
+      options.orderBy?.length ||
+      options.groupBy?.length ||
+      options.aggregates?.length
+  );
+}
+
+/** Materializes one Arrow table into row objects for the relational proof of concept. */
+function arrowTableToRows(data: arrow.Table): Record<string, unknown>[] {
+  const columns = data.schema.fields.map(field => ({
+    name: field.name,
+    vector: data.getChild(field.name)
+  }));
+  return Array.from({length: data.numRows}, (_, rowIndex) => {
+    const row: Record<string, unknown> = {};
+    for (const column of columns) {
+      if (!column.vector) throw new Error(`Arrow relational query could not read ${column.name}`);
+      row[column.name] = column.vector.get(rowIndex);
+    }
+    return row;
+  });
+}
+
+/** Evaluates one portable scalar expression with SQL-style null propagation. */
+function evaluateRelationalExpression(
+  expression: RelationalExpression,
+  row: Readonly<Record<string, unknown>>
+): unknown {
+  const definition = expression.expression;
+  if (definition.op === 'literal') return definition.value;
+  if (definition.op === 'column') return row[definition.column];
+  const left = row[definition.left];
+  const right = row[definition.right];
+  if (left === null || left === undefined || right === null || right === undefined) return null;
+  if (typeof left !== 'number' || typeof right !== 'number') {
+    throw new Error(`Arrow relational expression ${expression.name} requires numeric operands.`);
+  }
+  switch (definition.op) {
+    case 'add':
+      return left + right;
+    case 'subtract':
+      return left - right;
+    case 'multiply':
+      return left * right;
+    case 'divide':
+      return right === 0 ? null : left / right;
+  }
+}
+
+/** Compares two rows using stable, multi-key relational ordering. */
+function compareRows(
+  left: Readonly<Record<string, unknown>>,
+  right: Readonly<Record<string, unknown>>,
+  orderBy: readonly RelationalOrderKey[]
+): number {
+  for (const key of orderBy) {
+    const leftValue = left[key.column];
+    const rightValue = right[key.column];
+    const nulls = key.nulls || 'last';
+    if (
+      leftValue === null ||
+      leftValue === undefined ||
+      rightValue === null ||
+      rightValue === undefined
+    ) {
+      if (leftValue === rightValue) continue;
+      const nullResult = leftValue === null || leftValue === undefined ? -1 : 1;
+      return (nulls === 'first' ? nullResult : -nullResult) * (key.direction === 'desc' ? -1 : 1);
+    }
+    const result = compareSortValues(leftValue, rightValue);
+    if (result) return (key.direction === 'desc' ? -1 : 1) * result;
+  }
+  return 0;
+}
+
+/** Compares two non-null values supported by portable ordering. */
+function compareSortValues(left: unknown, right: unknown): number {
+  if (left instanceof Date && right instanceof Date)
+    return compareNumbers(left.getTime(), right.getTime());
+  if (typeof left === 'bigint' && typeof right === 'bigint')
+    return left === right ? 0 : left < right ? -1 : 1;
+  if (typeof left === 'number' && typeof right === 'number') return compareNumbers(left, right);
+  if (typeof left === 'string' && typeof right === 'string')
+    return left === right ? 0 : left < right ? -1 : 1;
+  if (typeof left === 'boolean' && typeof right === 'boolean') return Number(left) - Number(right);
+  throw new Error(
+    `Arrow relational order cannot compare ${getValueType(left)} with ${getValueType(right)}.`
+  );
+}
+
+/** Groups rows and computes the requested aggregate output columns. */
+function aggregateRows(
+  rows: readonly Record<string, unknown>[],
+  groupBy: readonly string[],
+  aggregates: readonly RelationalAggregate[]
+): Record<string, unknown>[] {
+  const groups = new Map<string, Record<string, unknown>[]>();
+  for (const row of rows) {
+    const key = JSON.stringify(groupBy.map(column => row[column]));
+    const group = groups.get(key) || [];
+    group.push(row);
+    groups.set(key, group);
+  }
+  if (!groupBy.length && !rows.length) groups.set('[]', []);
+  return [...groups.values()].map(group => {
+    const output: Record<string, unknown> = {};
+    for (const column of groupBy) output[column] = group[0]?.[column] ?? null;
+    for (const aggregate of aggregates)
+      output[aggregate.name] = evaluateAggregate(aggregate, group);
+    return output;
+  });
+}
+
+/** Computes one aggregate over a group while ignoring null input values. */
+function evaluateAggregate(
+  aggregate: RelationalAggregate,
+  rows: readonly Record<string, unknown>[]
+): unknown {
+  if (aggregate.function === 'count')
+    return aggregate.column
+      ? rows.filter(row => row[aggregate.column!] != null).length
+      : rows.length;
+  const values = rows.map(row => row[aggregate.column!]).filter(value => value != null);
+  if (!values.length) return null;
+  if (!values.every(value => typeof value === 'number'))
+    throw new Error(`Arrow aggregate ${aggregate.function} requires numeric values.`);
+  const numericValues = values as number[];
+  switch (aggregate.function) {
+    case 'sum':
+      return numericValues.reduce((sum, value) => sum + value, 0);
+    case 'avg':
+      return numericValues.reduce((sum, value) => sum + value, 0) / numericValues.length;
+    case 'min':
+      return Math.min(...numericValues);
+    case 'max':
+      return Math.max(...numericValues);
+  }
 }
 
 /** Creates a predicate-column lookup so values are not resolved for every source row. */

--- a/modules/sql/src/query-arrow-table.ts
+++ b/modules/sql/src/query-arrow-table.ts
@@ -147,16 +147,16 @@ function queryArrowTableRelational(
     }
   }
 
+  if (options.groupBy?.length || options.aggregates?.length) {
+    rows = aggregateRows(rows, options.groupBy || [], options.aggregates || []);
+  }
+
   if (options.orderBy?.length) {
     const orderBy = options.orderBy;
     rows = rows
       .map((row, index) => ({row, index}))
       .sort((left, right) => compareRows(left.row, right.row, orderBy) || left.index - right.index)
       .map(entry => entry.row);
-  }
-
-  if (options.groupBy?.length || options.aggregates?.length) {
-    rows = aggregateRows(rows, options.groupBy || [], options.aggregates || []);
   }
 
   const outputColumns =
@@ -175,7 +175,10 @@ function queryArrowTableRelational(
     return output;
   });
   const limit = options.limit === undefined ? outputRows.length : options.limit;
-  return convertRowsToArrowTable(outputRows.slice(0, limit));
+  const limitedRows = outputRows.slice(0, limit);
+  return limitedRows.length
+    ? convertRowsToArrowTable(limitedRows)
+    : createEmptyRelationalResult(sourceData, outputColumns, options);
 }
 
 /** Returns whether the query uses any in-memory relational operator. */
@@ -248,7 +251,7 @@ function compareRows(
     ) {
       if (leftValue === rightValue) continue;
       const nullResult = leftValue === null || leftValue === undefined ? -1 : 1;
-      return (nulls === 'first' ? nullResult : -nullResult) * (key.direction === 'desc' ? -1 : 1);
+      return nulls === 'first' ? nullResult : -nullResult;
     }
     const result = compareSortValues(leftValue, rightValue);
     if (result) return (key.direction === 'desc' ? -1 : 1) * result;
@@ -279,7 +282,7 @@ function aggregateRows(
 ): Record<string, unknown>[] {
   const groups = new Map<string, Record<string, unknown>[]>();
   for (const row of rows) {
-    const key = JSON.stringify(groupBy.map(column => row[column]));
+    const key = serializeGroupKey(groupBy.map(column => row[column]));
     const group = groups.get(key) || [];
     group.push(row);
     groups.set(key, group);
@@ -292,6 +295,75 @@ function aggregateRows(
       output[aggregate.name] = evaluateAggregate(aggregate, group);
     return output;
   });
+}
+
+/** Produces a collision-resistant group key for Arrow scalar values, including bigint values. */
+function serializeGroupKey(values: readonly unknown[]): string {
+  return values
+    .map(value => {
+      if (value === null || value === undefined) return 'null:';
+      if (value instanceof Date) return `date:${value.getTime()}`;
+      if (value instanceof Uint8Array) return `bytes:${Array.from(value).join('.')}`;
+      return `${typeof value}:${String(value)}`;
+    })
+    .join('\u001f');
+}
+
+/** Creates a zero-row Arrow result while preserving source and computed output fields. */
+function createEmptyRelationalResult(
+  sourceData: arrow.Table,
+  outputColumns: readonly string[],
+  options: ArrowQueryOptions
+): ArrowTable {
+  const sourceFields = new Map(sourceData.schema.fields.map(field => [field.name, field]));
+  const expressions = new Map(
+    (options.expressions || []).map(expression => [expression.name, expression])
+  );
+  const aggregates = new Map(
+    (options.aggregates || []).map(aggregate => [aggregate.name, aggregate])
+  );
+  const fields = outputColumns.map(columnName => {
+    const sourceField = sourceFields.get(columnName);
+    if (sourceField) return sourceField;
+    const expression = expressions.get(columnName);
+    if (expression)
+      return new arrow.Field(columnName, getExpressionType(expression, sourceFields), true);
+    const aggregate = aggregates.get(columnName);
+    if (aggregate)
+      return new arrow.Field(columnName, getAggregateType(aggregate, sourceFields), true);
+    return new arrow.Field(columnName, new arrow.Utf8(), true);
+  });
+  const columns: Record<string, arrow.Vector> = {};
+  for (const field of fields) columns[field.name] = arrow.vectorFromArray([], field.type);
+  return wrapArrowTable(new arrow.Table(new arrow.Schema(fields), columns));
+}
+
+/** Infers the Arrow type for an expression in an empty relational result. */
+function getExpressionType(
+  expression: RelationalExpression,
+  sourceFields: ReadonlyMap<string, arrow.Field>
+): arrow.DataType {
+  if (expression.expression.op === 'literal') {
+    const value = expression.expression.value;
+    if (typeof value === 'boolean') return new arrow.Bool();
+    if (typeof value === 'number') return new arrow.Float64();
+    return new arrow.Utf8();
+  }
+  if (expression.expression.op === 'column') {
+    return sourceFields.get(expression.expression.column)?.type || new arrow.Utf8();
+  }
+  return new arrow.Float64();
+}
+
+/** Infers the Arrow type for an aggregate in an empty relational result. */
+function getAggregateType(
+  aggregate: RelationalAggregate,
+  sourceFields: ReadonlyMap<string, arrow.Field>
+): arrow.DataType {
+  if (aggregate.function === 'count') return new arrow.Int32();
+  return aggregate.column
+    ? sourceFields.get(aggregate.column)?.type || new arrow.Float64()
+    : new arrow.Float64();
 }
 
 /** Computes one aggregate over a group while ignoring null input values. */

--- a/modules/sql/src/table-query-capabilities.ts
+++ b/modules/sql/src/table-query-capabilities.ts
@@ -10,7 +10,10 @@ export const ARROW_TABLE_QUERY_CAPABILITIES: TableQueryCapabilities = Object.fre
   predicate: 'residual',
   limit: 'residual',
   streaming: false,
-  cancellation: true
+  cancellation: true,
+  expressions: 'residual',
+  orderBy: 'residual',
+  aggregates: 'residual'
 });
 
 /** Portable query capabilities shared by the current SQL data-source adapters. */
@@ -19,5 +22,8 @@ export const SQL_DATA_SOURCE_TABLE_QUERY_CAPABILITIES: TableQueryCapabilities = 
   predicate: 'pushdown',
   limit: 'pushdown',
   streaming: false,
-  cancellation: false
+  cancellation: false,
+  expressions: 'pushdown',
+  orderBy: 'pushdown',
+  aggregates: 'pushdown'
 });

--- a/modules/sql/test/arrow-query.spec.ts
+++ b/modules/sql/test/arrow-query.spec.ts
@@ -192,13 +192,53 @@ test('queryArrowTable performs SQL-like grouped aggregates and null handling', (
       {name: 'average', function: 'avg', column: 'value'}
     ],
     columns: ['group', 'countValues', 'total', 'average'],
+    orderBy: [{column: 'total', direction: 'desc'}]
+  });
+
+  expect(toRows(result)).toEqual([
+    {group: 'b', countValues: 1, total: 5, average: 5},
+    {group: 'a', countValues: 1, total: 2, average: 2}
+  ]);
+});
+
+test('queryArrowTable keeps explicit null placement independent of descending order', () => {
+  const result = queryArrowTable(makeArrowTable({value: [null, 3, 1]}), {
+    columns: ['value'],
+    orderBy: [{column: 'value', direction: 'desc', nulls: 'last'}]
+  });
+
+  expect(toRows(result)).toEqual([{value: 3}, {value: 1}, {value: null}]);
+});
+
+test('queryArrowTable preserves output schema for empty relational results', () => {
+  const result = queryArrowTable(makeArrowTable({value: [1, 2]}), {
+    columns: ['value', 'total'],
+    groupBy: ['value'],
+    aggregates: [{name: 'total', function: 'sum', column: 'value'}],
+    limit: 0
+  });
+
+  expect(result.data.numRows).toBe(0);
+  expect(result.data.schema.fields.map(field => field.name)).toEqual(['value', 'total']);
+});
+
+test('queryArrowTable groups bigint keys and rejects incomplete aggregates', () => {
+  const result = queryArrowTable(makeArrowTable({group: [1n, 1n, 2n], value: [2, 3, 4]}), {
+    groupBy: ['group'],
+    aggregates: [{name: 'total', function: 'sum', column: 'value'}],
+    columns: ['group', 'total'],
     orderBy: [{column: 'group'}]
   });
 
   expect(toRows(result)).toEqual([
-    {group: 'a', countValues: 1, total: 2, average: 2},
-    {group: 'b', countValues: 1, total: 5, average: 5}
+    {group: 1n, total: 5},
+    {group: 2n, total: 4}
   ]);
+  expect(() =>
+    queryArrowTable(makeArrowTable({value: [1]}), {
+      aggregates: [{name: 'invalid', function: 'sum'}]
+    })
+  ).toThrow(/requires a column/);
 });
 
 test.each([

--- a/modules/sql/test/arrow-query.spec.ts
+++ b/modules/sql/test/arrow-query.spec.ts
@@ -22,7 +22,10 @@ test('Arrow executor advertises portable query capabilities', () => {
     predicate: 'residual',
     limit: 'residual',
     streaming: false,
-    cancellation: true
+    cancellation: true,
+    expressions: 'residual',
+    orderBy: 'residual',
+    aggregates: 'residual'
   });
   expect(Object.isFrozen(ARROW_TABLE_QUERY_CAPABILITIES)).toBe(true);
 });
@@ -164,6 +167,38 @@ test('queryArrowTable retains zero-copy Arrow views for projection and limit wit
   expect(result.data.numRows).toBe(2);
   expect(result.data.schema.fields.map(field => field.name)).toEqual(['second']);
   expect(toRows(result)).toEqual([{second: 'a'}, {second: 'b'}]);
+});
+
+test('queryArrowTable evaluates expressions, ordering, and global limits', () => {
+  const result = queryArrowTable(makeArrowTable({id: [1, 2, 3], value: [4, 1, 3]}), {
+    expressions: [{name: 'score', expression: {op: 'multiply', left: 'value', right: 'value'}}],
+    columns: ['id', 'score'],
+    orderBy: [{column: 'score', direction: 'desc'}],
+    limit: 2
+  });
+
+  expect(toRows(result)).toEqual([
+    {id: 1, score: 16},
+    {id: 3, score: 9}
+  ]);
+});
+
+test('queryArrowTable performs SQL-like grouped aggregates and null handling', () => {
+  const result = queryArrowTable(makeArrowTable({group: ['a', 'a', 'b'], value: [2, null, 5]}), {
+    groupBy: ['group'],
+    aggregates: [
+      {name: 'countValues', function: 'count', column: 'value'},
+      {name: 'total', function: 'sum', column: 'value'},
+      {name: 'average', function: 'avg', column: 'value'}
+    ],
+    columns: ['group', 'countValues', 'total', 'average'],
+    orderBy: [{column: 'group'}]
+  });
+
+  expect(toRows(result)).toEqual([
+    {group: 'a', countValues: 1, total: 2, average: 2},
+    {group: 'b', countValues: 1, total: 5, average: 5}
+  ]);
 });
 
 test.each([

--- a/modules/sql/test/compile-table-query.spec.ts
+++ b/modules/sql/test/compile-table-query.spec.ts
@@ -86,7 +86,7 @@ describe('compileSQLTableQuery', () => {
       {
         tableName: 'flights',
         expressions: [{name: 'metric', expression: {op: 'literal', value: 1}}],
-        columns: ['carrier', 'metric'],
+        columns: ['carrier', 'metric', 'flightCount'],
         groupBy: ['carrier'],
         aggregates: [{name: 'flightCount', function: 'count'}],
         orderBy: [{column: 'flightCount', direction: 'desc', nulls: 'last'}],

--- a/modules/sql/test/compile-table-query.spec.ts
+++ b/modules/sql/test/compile-table-query.spec.ts
@@ -80,4 +80,29 @@ describe('compileSQLTableQuery', () => {
       compileSQLTableQuery({tableName: 'flights', limit: -1}, {dialect: 'duckdb'})
     ).toThrow(/non-negative/);
   });
+
+  test('compiles portable expressions, aggregates, and ordering', () => {
+    const compiled = compileSQLTableQuery(
+      {
+        tableName: 'flights',
+        expressions: [{name: 'metric', expression: {op: 'literal', value: 1}}],
+        columns: ['carrier', 'metric'],
+        groupBy: ['carrier'],
+        aggregates: [{name: 'flightCount', function: 'count'}],
+        orderBy: [{column: 'flightCount', direction: 'desc', nulls: 'last'}],
+        limit: 10
+      },
+      {dialect: 'duckdb'}
+    );
+
+    expect(compiled.sql).toBe(
+      [
+        'SELECT "carrier", 1 AS "metric", COUNT(*) AS "flightCount"',
+        'FROM "flights"',
+        'GROUP BY "carrier"',
+        'ORDER BY "flightCount" DESC NULLS LAST',
+        'LIMIT 10'
+      ].join('\n')
+    );
+  });
 });


### PR DESCRIPTION
## Goals

- Advance the common scan roadmap with a portable relational execution slice.
- Let Arrow and DuckDB consume the same immutable query options without data ingestion.
- Make computed columns, ordering, and grouped aggregates discoverable through capabilities and documented conformance behavior.

## Changes

- Extend `ArrowQueryOptions` with scalar expressions, stable multi-key ordering, and grouped aggregates.
- Add a row-oriented Arrow proof-of-concept executor for `count`, `sum`, `min`, `max`, and `avg`, including null propagation, null placement, deterministic tie-breaking, and global limits.
- Harden relational planning so computed columns may reference source columns or earlier computed columns, while aggregate aliases do not get mistaken for source fields.
- Extend `compileSQLTableQuery` so DuckDB and Snowflake receive quoted expressions, aggregates, `GROUP BY`, `ORDER BY`, and `LIMIT` clauses from the same options shape.
- Advertise expression, ordering, and aggregate support in Arrow and SQL scan capabilities.
- Add focused Arrow and SQL compiler conformance tests and update the common scan architecture roadmap with the landed relational first slice and the remaining union/join tranche.
- Resolve aggregate aliases in explicit projections and order grouped results after aggregation.
- Keep explicit null placement independent of sort direction, preserve schemas for empty results,
  support bigint grouping keys, and reject incomplete non-count aggregates consistently.

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn test-node` (354 passed, 6 skipped)
- `yarn test-headless` (2893 passed, 37 skipped)
- Focused SQL/loader-utils conformance tests (30 passed)
