### PR TITLE
feat(gltf): improve glTF 1 to 2 normalization

### DIFF
--- a/docs/modules/gltf/api-reference/gltf-loader.md
+++ b/docs/modules/gltf/api-reference/gltf-loader.md
@@ -23,6 +23,12 @@ A glTF file contains a hierarchical scenegraph description that can be used to i
 
 \* From [![Website shields.io](https://img.shields.io/badge/v2.3-blue.svg?style=flat-square)](http://shields.io), the `GLTFLoader` offers optional, best-effort support for converting older glTF v1 files to glTF v2 format (`options.gltf.normalize: true`). This conversion has a number of limitations and the parsed data structure may be only partially converted to glTF v2, causing issues to show up later e.g. when attempting to render the scenegraphs.
 
+For applications that need explicit conversion diagnostics, `normalizeGLTFV1()` returns a report
+listing unsupported legacy features. Use `normalize: 'strict'` to reject those features instead of
+continuing with a best-effort conversion. `convertGLTFV1ToGLTF2()` performs the same conversion on
+a cloned JSON document and leaves the caller's asset untouched. Legacy techniques, programs, and
+shaders are preserved under `json.extras.gltf1Resources`; they are not guessed into PBR materials.
+
 ## Usage
 
 ```

--- a/modules/gltf/src/index.ts
+++ b/modules/gltf/src/index.ts
@@ -165,6 +165,12 @@ export {
   type GLTFTextureReferences
 } from './lib/api/gltf-iterator';
 export {postProcessGLTF} from './lib/api/post-process-gltf';
+export {
+  convertGLTFV1ToGLTF2,
+  normalizeGLTFV1,
+  type GLTFV1NormalizationOptions,
+  type GLTFV1NormalizationReport
+} from './lib/api/normalize-gltf-v1';
 export {getMemoryUsageGLTF as _getMemoryUsageGLTF} from './lib/gltf-utils/gltf-utils';
 export {
   findGLTFFileIndex,

--- a/modules/gltf/src/lib/api/normalize-gltf-v1.ts
+++ b/modules/gltf/src/lib/api/normalize-gltf-v1.ts
@@ -4,6 +4,7 @@
 
 /* eslint-disable camelcase */
 import * as KHR_binary_glTF from '../extensions/KHR_binary_gltf';
+import type {GLTFWithBuffers} from '../types/gltf-types';
 
 // Binary format changes (mainly implemented by GLBLoader)
 // https://github.com/KhronosGroup/glTF/tree/master/extensions/1.0/Khronos/KHR_binary_glTF
@@ -80,6 +81,26 @@ const GLTF_KEYS = {
   texture: 'textures'
 };
 
+/** Diagnostics emitted while converting a glTF 1 asset to glTF 2. */
+export type GLTFV1NormalizationReport = {
+  /** Whether a glTF 1 asset was detected and converted. */
+  converted: boolean;
+  /** Whether the input JSON was mutated in place. */
+  mutated: boolean;
+  /** Features that could not be represented without loss. */
+  unsupported: string[];
+  /** Non-fatal conversion notes. */
+  warnings: string[];
+};
+
+/** Options for glTF 1 to glTF 2 conversion. */
+export type GLTFV1NormalizationOptions = {
+  /** Enable conversion. `'strict'` rejects unsupported features; other values are best effort. */
+  normalize?: boolean | 'best-effort' | 'strict';
+  /** Mutate the supplied JSON. Defaults to true for backwards compatibility. */
+  mutate?: boolean;
+};
+
 /**
  * Converts (normalizes) glTF v1 to v2
  */
@@ -100,6 +121,13 @@ class GLTFV1Normalizer {
   };
 
   json;
+  report: GLTFV1NormalizationReport = {
+    converted: false,
+    mutated: true,
+    unsupported: [],
+    warnings: []
+  };
+  strict = false;
 
   // constructor() {}
 
@@ -109,7 +137,15 @@ class GLTFV1Normalizer {
    * @param options
    * @param options normalize Whether to actually normalize
    */
-  normalize(gltf, options) {
+  normalize(gltf, options: GLTFV1NormalizationOptions = {}): GLTFV1NormalizationReport {
+    if (options.mutate === false) {
+      const converted = {...gltf, json: JSON.parse(JSON.stringify(gltf.json))};
+      const report = new GLTFV1Normalizer().normalize(converted, {...options, mutate: true});
+      report.mutated = false;
+      return report;
+    }
+    this.strict = options.normalize === 'strict';
+    this.report.mutated = true;
     this.json = gltf.json;
     const json = gltf.json;
 
@@ -117,7 +153,7 @@ class GLTFV1Normalizer {
     switch (json.asset && json.asset.version) {
       // We are converting to v2 format. Return if there is nothing to do
       case '2.0':
-        return;
+        return this.report;
 
       // This class is written to convert 1.0
       case undefined:
@@ -127,13 +163,16 @@ class GLTFV1Normalizer {
       default:
         // eslint-disable-next-line no-undef, no-console
         console.warn(`glTF: Unknown version ${json.asset.version}`);
-        return;
+        this._warning(`Unknown glTF version ${json.asset.version}`);
+        return this.report;
     }
 
     if (!options.normalize) {
       // We are still missing a few conversion tricks, remove once addressed
       throw new Error('glTF v1 is not supported.');
     }
+
+    this.report.converted = true;
 
     // eslint-disable-next-line no-undef, no-console
     console.warn('Converting glTF v1 to glTF v2 format. This is experimental and may fail.');
@@ -154,6 +193,24 @@ class GLTFV1Normalizer {
     this._updateObjects(json);
 
     this._updateMaterial(json);
+    this._updateAnimations(json);
+    this._updateNodes(json);
+    this._preserveLegacyResources(json);
+    this._finishReport();
+    return this.report;
+  }
+
+  /** Record a feature that requires a lossy best-effort conversion. */
+  _unsupported(feature: string): void {
+    this.report.unsupported.push(feature);
+    if (this.strict) {
+      throw new Error(`glTF v1 normalization does not support ${feature}`);
+    }
+  }
+
+  /** Add a diagnostic without rejecting conversion. */
+  _warning(message: string): void {
+    this.report.warnings.push(message);
   }
 
   // asset is now required, #642 https://github.com/KhronosGroup/glTF/issues/639
@@ -296,22 +353,126 @@ class GLTFV1Normalizer {
    */
   _updateMaterial(json) {
     for (const material of json.materials) {
-      material.pbrMetallicRoughness = {
-        baseColorFactor: [1, 1, 1, 1],
-        metallicFactor: 1,
-        roughnessFactor: 1
+      material.extras = {
+        ...material.extras,
+        gltf1: {technique: material.technique, values: material.values}
       };
 
       const textureId =
-        material.values?.tex || material.values?.texture2d_0 || material.values?.diffuseTex;
+        material.values?.tex ||
+        material.values?.texture2d_0 ||
+        material.values?.diffuseTex ||
+        material.values?.diffuse;
       const textureIndex = json.textures.findIndex(texture => texture.id === textureId);
       if (textureIndex !== -1) {
+        material.pbrMetallicRoughness ||= {
+          baseColorFactor: [1, 1, 1, 1],
+          metallicFactor: 1,
+          roughnessFactor: 1
+        };
         material.pbrMetallicRoughness.baseColorTexture = {index: textureIndex};
+      } else if (material.technique || material.values) {
+        this._unsupported(`material technique ${material.technique || '<unnamed>'}`);
       }
+    }
+  }
+
+  /** Convert glTF 1 animation sampler maps and channel targets to glTF 2 arrays and indices. */
+  _updateAnimations(json): void {
+    for (const animation of json.animations || []) {
+      if (!animation.samplers || Array.isArray(animation.samplers)) {
+        continue;
+      }
+      const samplerIndices: Record<string, number> = {};
+      const samplers: any[] = [];
+      const parameters = animation.parameters || {};
+      for (const samplerId of Object.keys(animation.samplers)) {
+        const sampler = animation.samplers[samplerId];
+        const input = parameters[sampler.input] || sampler.input;
+        const output = parameters[sampler.output] || sampler.output;
+        sampler.input = this._convertIdToIndex(input, 'accessor');
+        sampler.output = this._convertIdToIndex(output, 'accessor');
+        sampler.interpolation ||= 'LINEAR';
+        samplerIndices[samplerId] = samplers.length;
+        samplers.push(sampler);
+      }
+      animation.samplers = samplers;
+      for (const channel of animation.channels || []) {
+        if (typeof channel.sampler === 'string') {
+          channel.sampler = samplerIndices[channel.sampler];
+        }
+        if (channel.target?.id !== undefined) {
+          channel.target.node = this._convertIdToIndex(channel.target.id, 'node');
+          delete channel.target.id;
+        }
+      }
+    }
+  }
+
+  /** Split glTF 1 nodes that reference multiple meshes into glTF 2-compatible nodes. */
+  _updateNodes(json): void {
+    const nodes = json.nodes || [];
+    for (let nodeIndex = 0; nodeIndex < nodes.length; nodeIndex++) {
+      const node = nodes[nodeIndex];
+      if (!Array.isArray(node.meshes)) {
+        continue;
+      }
+      const meshIndices = node.meshes;
+      delete node.meshes;
+      node.mesh = meshIndices.shift();
+      for (const meshIndex of meshIndices) {
+        const extraNode = {...node, mesh: meshIndex, children: undefined};
+        delete extraNode.id;
+        nodes.push(extraNode);
+        node.children ||= [];
+        node.children.push(nodes.length - 1);
+      }
+    }
+  }
+
+  /** Preserve v1 techniques, programs, and shaders without pretending they are PBR materials. */
+  _preserveLegacyResources(json): void {
+    const resources = {};
+    for (const resourceName of ['techniques', 'programs', 'shaders']) {
+      if (json[resourceName]) {
+        resources[resourceName] = json[resourceName];
+        delete json[resourceName];
+        this._unsupported(`legacy ${resourceName}`);
+      }
+    }
+    if (Object.keys(resources).length) {
+      json.extras = {...json.extras, gltf1Resources: resources};
+    }
+  }
+
+  /** Finalize report diagnostics. */
+  _finishReport(): void {
+    if (this.report.unsupported.length) {
+      this._warning(
+        `Converted glTF v1 with unsupported features: ${this.report.unsupported.join(', ')}`
+      );
     }
   }
 }
 
-export function normalizeGLTFV1(gltf, options = {}) {
+/** Normalize a glTF 1 asset in place, preserving the historical loader behavior. */
+export function normalizeGLTFV1(
+  gltf: GLTFWithBuffers,
+  options: GLTFV1NormalizationOptions = {}
+): GLTFV1NormalizationReport {
   return new GLTFV1Normalizer().normalize(gltf, options);
+}
+
+/** Convert glTF 1 JSON without mutating the caller-owned asset or its binary buffers. */
+export function convertGLTFV1ToGLTF2(
+  gltf: GLTFWithBuffers,
+  options: Omit<GLTFV1NormalizationOptions, 'mutate'> = {}
+): GLTFWithBuffers & {normalizationReport: GLTFV1NormalizationReport} {
+  const converted = {...gltf, json: JSON.parse(JSON.stringify(gltf.json))};
+  const normalizationReport = normalizeGLTFV1(converted, {
+    normalize: options.normalize || 'best-effort',
+    mutate: true
+  });
+  normalizationReport.mutated = false;
+  return {...converted, normalizationReport};
 }

--- a/modules/gltf/src/lib/api/normalize-gltf-v1.ts
+++ b/modules/gltf/src/lib/api/normalize-gltf-v1.ts
@@ -121,12 +121,14 @@ class GLTFV1Normalizer {
   };
 
   json;
+  /** Diagnostics collected during this normalization pass. */
   report: GLTFV1NormalizationReport = {
     converted: false,
-    mutated: true,
+    mutated: false,
     unsupported: [],
     warnings: []
   };
+  /** Whether unsupported legacy features should abort conversion. */
   strict = false;
 
   // constructor() {}
@@ -145,7 +147,6 @@ class GLTFV1Normalizer {
       return report;
     }
     this.strict = options.normalize === 'strict';
-    this.report.mutated = true;
     this.json = gltf.json;
     const json = gltf.json;
 
@@ -173,6 +174,7 @@ class GLTFV1Normalizer {
     }
 
     this.report.converted = true;
+    this.report.mutated = true;
 
     // eslint-disable-next-line no-undef, no-console
     console.warn('Converting glTF v1 to glTF v2 format. This is experimental and may fail.');
@@ -423,6 +425,10 @@ class GLTFV1Normalizer {
       for (const meshIndex of meshIndices) {
         const extraNode = {...node, mesh: meshIndex, children: undefined};
         delete extraNode.id;
+        delete extraNode.matrix;
+        delete extraNode.translation;
+        delete extraNode.rotation;
+        delete extraNode.scale;
         nodes.push(extraNode);
         node.children ||= [];
         node.children.push(nodes.length - 1);

--- a/modules/gltf/src/lib/parsers/parse-gltf.ts
+++ b/modules/gltf/src/lib/parsers/parse-gltf.ts
@@ -24,7 +24,7 @@ import {normalizeGLTFV1} from '../api/normalize-gltf-v1';
 
 /**  */
 export type ParseGLTFOptions = ParseGLBOptions & {
-  normalize?: boolean;
+  normalize?: boolean | 'best-effort' | 'strict';
   loadImages?: boolean;
   /** Load linked and embedded buffers; required for meshopt decompression. @default true */
   loadBuffers?: boolean;

--- a/modules/gltf/test/lib/api/normalize-gltf-v1.cross.spec.ts
+++ b/modules/gltf/test/lib/api/normalize-gltf-v1.cross.spec.ts
@@ -17,6 +17,7 @@ describe('glTF 1 normalization', () => {
     expect(gltf.json.nodes?.[0].mesh).toBe(0);
     expect(gltf.json.nodes?.[0].children).toEqual([1]);
     expect(gltf.json.nodes?.[1].mesh).toBe(1);
+    expect(gltf.json.nodes?.[1].translation).toBeUndefined();
     expect(gltf.json.animations?.[0].samplers?.[0]).toMatchObject({input: 0, output: 0});
     expect(gltf.json.animations?.[0].channels?.[0]).toMatchObject({
       sampler: 0,
@@ -63,6 +64,15 @@ describe('glTF 1 normalization', () => {
     expect(report.mutated).toBe(false);
     expect(JSON.stringify(gltf.json)).toBe(originalJson);
   });
+
+  test('reports no mutation for assets that do not require conversion', () => {
+    const gltf = {json: {asset: {version: '2.0'}}, buffers: []} as GLTFWithBuffers;
+
+    const report = normalizeGLTFV1(gltf, {normalize: true});
+
+    expect(report.converted).toBe(false);
+    expect(report.mutated).toBe(false);
+  });
 });
 
 /** Create a compact glTF 1 object-map asset with representative legacy relationships. */
@@ -74,7 +84,7 @@ function makeGLTFV1(): GLTFWithBuffers {
       scene: 'scene0',
       scenes: {scene0: {nodes: ['node0']}},
       nodes: {
-        node0: {meshes: ['mesh0', 'mesh1']}
+        node0: {meshes: ['mesh0', 'mesh1'], translation: [1, 2, 3]}
       },
       meshes: {
         mesh0: {primitives: [{attributes: {POSITION: 'accessor0'}}]},

--- a/modules/gltf/test/lib/api/normalize-gltf-v1.cross.spec.ts
+++ b/modules/gltf/test/lib/api/normalize-gltf-v1.cross.spec.ts
@@ -1,0 +1,101 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+import {convertGLTFV1ToGLTF2, normalizeGLTFV1} from '@loaders.gl/gltf';
+import type {GLTFWithBuffers} from '../../../src/lib/types/gltf-types';
+
+describe('glTF 1 normalization', () => {
+  test('converts object maps, multi-mesh nodes, and animation references', () => {
+    const gltf = makeGLTFV1();
+    const report = normalizeGLTFV1(gltf, {normalize: true});
+
+    expect(report.converted).toBe(true);
+    expect(gltf.json.asset?.version).toBe('2.0');
+    expect(gltf.json.meshes).toHaveLength(2);
+    expect(gltf.json.nodes?.[0].mesh).toBe(0);
+    expect(gltf.json.nodes?.[0].children).toEqual([1]);
+    expect(gltf.json.nodes?.[1].mesh).toBe(1);
+    expect(gltf.json.animations?.[0].samplers?.[0]).toMatchObject({input: 0, output: 0});
+    expect(gltf.json.animations?.[0].channels?.[0]).toMatchObject({
+      sampler: 0,
+      target: {node: 0, path: 'translation'}
+    });
+  });
+
+  test('preserves legacy techniques in extras and reports them', () => {
+    const gltf = makeGLTFV1();
+    gltf.json.techniques = {technique0: {parameters: {}}};
+    const report = normalizeGLTFV1(gltf, {normalize: true});
+
+    expect(report.unsupported).toContain('legacy techniques');
+    expect(gltf.json.extras?.gltf1Resources.techniques).toEqual({technique0: {parameters: {}}});
+    expect(gltf.json.techniques).toBeUndefined();
+  });
+
+  test('strict mode rejects unsupported legacy resources', () => {
+    const gltf = makeGLTFV1();
+    gltf.json.programs = {program0: {vertexShader: 'shader0'}};
+
+    expect(() => normalizeGLTFV1(gltf, {normalize: 'strict'})).toThrow(/legacy programs/);
+  });
+
+  test('offers a non-mutating conversion entry point', () => {
+    const gltf = makeGLTFV1();
+    const originalJson = JSON.stringify(gltf.json);
+
+    const converted = convertGLTFV1ToGLTF2(gltf);
+
+    expect(JSON.stringify(gltf.json)).toBe(originalJson);
+    expect(converted.json).not.toBe(gltf.json);
+    expect(converted.json.asset?.version).toBe('2.0');
+    expect(converted.normalizationReport.mutated).toBe(false);
+  });
+
+  test('supports non-mutating normalization through the report API', () => {
+    const gltf = makeGLTFV1();
+    const originalJson = JSON.stringify(gltf.json);
+
+    const report = normalizeGLTFV1(gltf, {normalize: true, mutate: false});
+
+    expect(report.converted).toBe(true);
+    expect(report.mutated).toBe(false);
+    expect(JSON.stringify(gltf.json)).toBe(originalJson);
+  });
+});
+
+/** Create a compact glTF 1 object-map asset with representative legacy relationships. */
+function makeGLTFV1(): GLTFWithBuffers {
+  const source = new Float32Array([0, 0, 0]);
+  return {
+    json: {
+      asset: {version: '1.0'},
+      scene: 'scene0',
+      scenes: {scene0: {nodes: ['node0']}},
+      nodes: {
+        node0: {meshes: ['mesh0', 'mesh1']}
+      },
+      meshes: {
+        mesh0: {primitives: [{attributes: {POSITION: 'accessor0'}}]},
+        mesh1: {primitives: [{attributes: {POSITION: 'accessor0'}}]}
+      },
+      accessors: {
+        accessor0: {bufferView: 'bufferView0', componentType: 5126, count: 1, type: 'VEC3'}
+      },
+      bufferViews: {
+        bufferView0: {buffer: 'buffer0', byteLength: source.byteLength}
+      },
+      buffers: {
+        buffer0: {byteLength: source.byteLength, type: 'arraybuffer'}
+      },
+      animations: {
+        animation0: {
+          samplers: {sampler0: {input: 'accessor0', output: 'accessor0'}},
+          channels: [{sampler: 'sampler0', target: {id: 'node0', path: 'translation'}}]
+        }
+      }
+    },
+    buffers: [{arrayBuffer: source.buffer, byteOffset: 0, byteLength: source.byteLength}]
+  } as GLTFWithBuffers;
+}


### PR DESCRIPTION
## Goals
- Make glTF 1→2 normalization explicit, diagnosable, and safer for downstream consumers.
- Improve structural conversion for real legacy assets without inventing modern material semantics.

## Changes
- Add `GLTFV1NormalizationReport` with unsupported-feature diagnostics and strict/best-effort modes.
- Add `convertGLTFV1ToGLTF2()` for non-mutating conversion; preserve the existing in-place loader path.
- Convert animation sampler maps, parameter indirection, and channel node targets.
- Split glTF 1 multi-mesh nodes into glTF 2-compatible nodes.
- Preserve legacy techniques, programs, and shaders under `json.extras.gltf1Resources`; avoid overwriting existing PBR material data.
- Recognize common diffuse texture values and expose the APIs from `@loaders.gl/gltf`.
- Add cross-runtime fixture tests for structural conversion, diagnostics, strict mode, and non-mutation.

## Validation
- `yarn lint fix`
- `yarn build`
- `yarn test-node` (359 passed, 6 skipped)
- focused glTF headless loader tests (15 passed)

The full headless suite was also attempted; unrelated WASM serving failures occurred for compression and parquet tests in the isolated worktree.