### PR TITLE
feat(parquet): enable encrypted source workers

### DIFF
--- a/docs/modules/parquet/formats/parquet.md
+++ b/docs/modules/parquet/formats/parquet.md
@@ -255,8 +255,8 @@ including pages that continue one logical row; files with incompatible boundarie
 column-chunk reads. Size statistics are available for memory and nested-value planning; semantic sorting
 pruning remains future format-completeness work. The TypeScript reader supports AES-GCM and
 AES-GCM-CTR encrypted column metadata, page indexes, Bloom filters, and page modules when a key retriever
-is provided. Encrypted sources conservatively stay on the caller thread because worker key-transfer
-protocols are not yet part of the public API; writer-side encryption remains future work.
+is provided. Encrypted source reads resolve selected data keys on the caller thread and transfer only
+the required key material to the worker; writer-side encryption remains future work.
 
 ## Integrity and Encryption
 

--- a/modules/parquet/src/lib/parquet-source-worker-decoder.ts
+++ b/modules/parquet/src/lib/parquet-source-worker-decoder.ts
@@ -12,6 +12,7 @@ import type {RowGroup} from '../parquetjs/parquet-thrift/index';
 import {ParquetReader} from '../parquetjs/parser/parquet-reader';
 import {ParquetSchema} from '../parquetjs/schema/schema';
 import {ParquetSourceWorkerFile} from './parquet-source-worker-file';
+import type {ParquetKeyRetriever} from './parquet-encryption';
 import type {
   ParquetSourceWorkerBatch,
   ParquetSourceWorkerColumnChunk,
@@ -26,7 +27,13 @@ export async function decodeParquetSourceWorkerInput(
   await preloadCompressions();
   const file = new ParquetSourceWorkerFile(input.fileByteLength, input.ranges);
   const schema = new ParquetSchema(input.schemaDefinition);
-  const keyRetriever = input.encryption ? createWorkerKeyRetriever(input.columnChunks) : undefined;
+  const keyRetriever = input.encryption
+    ? createWorkerKeyRetriever(
+        input.columnChunks,
+        input.encryption.aadPrefix?.byteLength ?? 0,
+        input.encryption.fileUnique.byteLength
+      )
+    : undefined;
   const reader = new ParquetReader(file, {
     preserveBinary: input.preserveBinary,
     verifyPageChecksums: input.verifyPageChecksums,
@@ -191,18 +198,39 @@ function createWorkerRowGroup(input: ParquetSourceWorkerInput): RowGroup {
 }
 
 /** Creates a worker-local key retriever from caller-resolved transferable keys. */
-function createWorkerKeyRetriever(
-  columnChunks: readonly ParquetSourceWorkerColumnChunk[]
-): (keyMetadata: Uint8Array | undefined) => Uint8Array {
-  return keyMetadata => {
-    const matchingColumn = columnChunks.find(columnChunk =>
+export function createWorkerKeyRetriever(
+  columnChunks: readonly ParquetSourceWorkerColumnChunk[],
+  aadPrefixByteLength: number,
+  fileUniqueByteLength: number
+): ParquetKeyRetriever {
+  return (keyMetadata, context) => {
+    const columnOrdinal = getColumnOrdinalFromAad(
+      context.aad,
+      aadPrefixByteLength,
+      fileUniqueByteLength
+    );
+    const metadataMatches = columnChunks.filter(columnChunk =>
       equalBytes(keyMetadata, columnChunk.keyMetadata && new Uint8Array(columnChunk.keyMetadata))
     );
+    const matchingColumn =
+      metadataMatches.find(columnChunk => columnChunk.columnOrdinal === columnOrdinal) ??
+      (metadataMatches.length === 1 ? metadataMatches[0] : undefined);
     if (!matchingColumn?.keyMaterial) {
       throw new Error('Encrypted Parquet worker key was not transferred for the selected column');
     }
     return new Uint8Array(matchingColumn.keyMaterial);
   };
+}
+
+/** Extracts the physical column ordinal encoded in a page-module AAD suffix. */
+function getColumnOrdinalFromAad(
+  aad: Uint8Array,
+  aadPrefixByteLength: number,
+  fileUniqueByteLength: number
+): number | undefined {
+  const columnOrdinalOffset = aadPrefixByteLength + fileUniqueByteLength + 3;
+  if (columnOrdinalOffset + 2 > aad.byteLength) return undefined;
+  return new DataView(aad.buffer, aad.byteOffset + columnOrdinalOffset, 2).getInt16(0, true);
 }
 
 /** Compares optional key metadata without exposing key material in structured-clone state. */

--- a/modules/parquet/src/lib/parquet-source-worker-decoder.ts
+++ b/modules/parquet/src/lib/parquet-source-worker-decoder.ts
@@ -14,6 +14,7 @@ import {ParquetSchema} from '../parquetjs/schema/schema';
 import {ParquetSourceWorkerFile} from './parquet-source-worker-file';
 import type {
   ParquetSourceWorkerBatch,
+  ParquetSourceWorkerColumnChunk,
   ParquetSourceWorkerInput,
   ParquetSourceWorkerResult
 } from './parquet-source-worker-types';
@@ -25,20 +26,40 @@ export async function decodeParquetSourceWorkerInput(
   await preloadCompressions();
   const file = new ParquetSourceWorkerFile(input.fileByteLength, input.ranges);
   const schema = new ParquetSchema(input.schemaDefinition);
+  const keyRetriever = input.encryption ? createWorkerKeyRetriever(input.columnChunks) : undefined;
   const reader = new ParquetReader(file, {
     preserveBinary: input.preserveBinary,
-    verifyPageChecksums: input.verifyPageChecksums
+    verifyPageChecksums: input.verifyPageChecksums,
+    encryptionContext: input.encryption
+      ? {
+          algorithm: input.encryption.algorithm,
+          aadPrefix: input.encryption.aadPrefix
+            ? new Uint8Array(input.encryption.aadPrefix)
+            : undefined,
+          fileUnique: new Uint8Array(input.encryption.fileUnique)
+        }
+      : undefined,
+    keyRetriever
   });
   const rowGroup = createWorkerRowGroup(input);
 
   const decodeStartTime = getCurrentTime();
-  const decodedRowGroups = input.pagePlan
-    ? await Promise.all(
-        input.pagePlan.rowRanges.map(rowRange =>
-          reader.readRowGroupRange(schema, rowGroup, [], rowRange, input.pagePlan!.pageLocations)
+  let decodedRowGroups;
+  try {
+    decodedRowGroups = input.pagePlan
+      ? await Promise.all(
+          input.pagePlan.rowRanges.map(rowRange =>
+            reader.readRowGroupRange(schema, rowGroup, [], rowRange, input.pagePlan!.pageLocations)
+          )
         )
-      )
-    : [await reader.readRowGroup(schema, rowGroup, [])];
+      : [await reader.readRowGroup(schema, rowGroup, [])];
+  } catch (error) {
+    throw new Error(
+      `Parquet worker decode failed: ${
+        error instanceof Error ? `${error.name}: ${error.message}` : String(error)
+      }`
+    );
+  }
   const columns = concatenateMaterializedColumns(
     decodedRowGroups.map(decodedRowGroup => schema.materializeColumns(decodedRowGroup))
   );
@@ -136,21 +157,64 @@ function createWorkerRowGroup(input: ParquetSourceWorkerInput): RowGroup {
   return {
     num_rows: input.rowCount,
     total_byte_size: input.uncompressedByteLength,
-    columns: input.columnChunks.map(columnChunk => ({
-      file_path: columnChunk.filePath,
-      meta_data: {
-        type: columnChunk.physicalType,
-        codec: columnChunk.compressionCodec,
-        path_in_schema: columnChunk.path,
-        num_values: columnChunk.valueCount,
-        total_compressed_size: columnChunk.compressedByteLength,
-        total_uncompressed_size: columnChunk.uncompressedByteLength,
-        data_page_offset: columnChunk.dataPageOffset,
-        dictionary_page_offset: columnChunk.dictionaryPageOffset,
-        encodings: []
+    columns: input.columnChunks.map((columnChunk, index) => {
+      const result = {
+        file_path: columnChunk.filePath,
+        parquetColumnOrdinal: columnChunk.columnOrdinal ?? index,
+        meta_data: {
+          type: columnChunk.physicalType,
+          codec: columnChunk.compressionCodec,
+          path_in_schema: columnChunk.path,
+          num_values: columnChunk.valueCount,
+          total_compressed_size: columnChunk.compressedByteLength,
+          total_uncompressed_size: columnChunk.uncompressedByteLength,
+          data_page_offset: columnChunk.dataPageOffset,
+          dictionary_page_offset: columnChunk.dictionaryPageOffset,
+          encodings: []
+        }
+      } as unknown as RowGroup['columns'][number];
+      if (columnChunk.encrypted) {
+        result.crypto_metadata = (columnChunk.keyMetadata
+          ? {
+              ENCRYPTION_WITH_COLUMN_KEY: {
+                path_in_schema: columnChunk.path,
+                key_metadata: new Uint8Array(columnChunk.keyMetadata)
+              }
+            }
+          : {
+              ENCRYPTION_WITH_FOOTER_KEY: {}
+            }) as unknown as RowGroup['columns'][number]['crypto_metadata'];
       }
-    }))
+      return result;
+    })
   } as unknown as RowGroup;
+}
+
+/** Creates a worker-local key retriever from caller-resolved transferable keys. */
+function createWorkerKeyRetriever(
+  columnChunks: readonly ParquetSourceWorkerColumnChunk[]
+): (keyMetadata: Uint8Array | undefined) => Uint8Array {
+  return keyMetadata => {
+    const matchingColumn = columnChunks.find(columnChunk =>
+      equalBytes(keyMetadata, columnChunk.keyMetadata && new Uint8Array(columnChunk.keyMetadata))
+    );
+    if (!matchingColumn?.keyMaterial) {
+      throw new Error('Encrypted Parquet worker key was not transferred for the selected column');
+    }
+    return new Uint8Array(matchingColumn.keyMaterial);
+  };
+}
+
+/** Compares optional key metadata without exposing key material in structured-clone state. */
+function equalBytes(
+  firstBytes: Uint8Array | undefined,
+  secondBytes: Uint8Array | undefined
+): boolean {
+  if (!firstBytes || !secondBytes) return !firstBytes && !secondBytes;
+  return (
+    firstBytes.length === secondBytes.length &&
+    firstBytes.every((value, index) => value === secondBytes[index])
+  );
 }
 
 /** Returns a monotonic timestamp when available and falls back to wall-clock time. */

--- a/modules/parquet/src/lib/parquet-source-worker-types.ts
+++ b/modules/parquet/src/lib/parquet-source-worker-types.ts
@@ -7,6 +7,7 @@ import type {StrictLoaderOptions} from '@loaders.gl/loader-utils';
 import type {Schema} from '@loaders.gl/schema';
 
 import type {ParquetPredicate} from '../parquet-source-types';
+import type {ParquetEncryptionAlgorithm} from './parquet-encryption';
 import type {ParquetPagePruningPlan} from './parquet-page-index';
 import type {SchemaDefinition} from '../parquetjs/schema/declare';
 
@@ -38,6 +39,24 @@ export type ParquetSourceWorkerColumnChunk = {
   dataPageOffset: number;
   /** Absolute offset of the dictionary page, when present. */
   dictionaryPageOffset?: number;
+  /** Physical column ordinal in the original Parquet row group. */
+  columnOrdinal?: number;
+  /** Whether this column chunk's page modules are encrypted. */
+  encrypted?: boolean;
+  /** Key metadata identifying the column key, when present. */
+  keyMetadata?: ArrayBuffer;
+  /** Raw data key resolved by the caller before worker transfer. */
+  keyMaterial?: ArrayBuffer;
+};
+
+/** File-level encryption context transferred to a worker for encrypted page reads. */
+export type ParquetSourceWorkerEncryption = {
+  /** Modular-encryption algorithm selected by the file. */
+  algorithm: ParquetEncryptionAlgorithm;
+  /** Optional caller-supplied AAD prefix. */
+  aadPrefix?: ArrayBuffer;
+  /** Random per-file AAD suffix component. */
+  fileUnique: ArrayBuffer;
 };
 
 /** Transferable input for one worker-backed Parquet source row-group decode. */
@@ -62,6 +81,8 @@ export type ParquetSourceWorkerInput = {
   predicate?: ParquetPredicate;
   /** Selective data-page plan prepared from column and offset indexes on the caller thread. */
   pagePlan?: ParquetPagePruningPlan;
+  /** Encryption context and resolved keys needed for encrypted worker decoding. */
+  encryption?: ParquetSourceWorkerEncryption;
   /** Whether BYTE_ARRAY values stay binary during logical conversion. */
   preserveBinary: boolean;
   /** Whether page CRC values are verified while decoding in the worker. */

--- a/modules/parquet/src/parquet-source-loader.ts
+++ b/modules/parquet/src/parquet-source-loader.ts
@@ -425,7 +425,8 @@ export class ParquetSource
       const projectedColumnNames = columns.length ? new Set(columns) : undefined;
       const workerOptions = this.getWorkerOptions(concurrency, readContext.abortController.signal);
       const decodeOnWorker =
-        canDecodeParquetSourceOnWorker(workerOptions) && !initialization.reader.encrypted;
+        canDecodeParquetSourceOnWorker(workerOptions) &&
+        (!initialization.reader.encrypted || Boolean(this.options.parquet?.keyRetriever));
       const scheduledReads = new Map<number, Promise<SettledParquetRowGroupRead>>();
       let nextPositionToSchedule = 0;
       let remainingRows = readOptions.limit ?? Number.POSITIVE_INFINITY;
@@ -862,6 +863,7 @@ export class ParquetSource
       );
     }
     const rowGroup = initialization.fileMetadata.row_groups[rowGroupIndex];
+    await initialization.reader.resolveColumnMetadata(rowGroup, rowGroupIndex, columnList);
     const pagePlan = predicate
       ? await createParquetPagePruningPlan(
           initialization.file,
@@ -998,6 +1000,26 @@ export class ParquetSource
     );
     throwIfAborted(signal);
 
+    const workerColumnChunks = await Promise.all(
+      selectedColumnChunks.map(async columnChunk => {
+        const descriptor = createParquetSourceWorkerColumnChunk(columnChunk);
+        descriptor.columnOrdinal = rowGroup.columns.indexOf(columnChunk);
+        if (columnChunk.crypto_metadata) {
+          const columnOrdinal = rowGroup.columns.indexOf(columnChunk);
+          const key = await initialization.reader.getColumnKeyForWorker(
+            columnChunk,
+            rowGroupIndex,
+            columnOrdinal
+          );
+          descriptor.encrypted = true;
+          descriptor.keyMetadata = key.keyMetadata?.slice().buffer;
+          descriptor.keyMaterial = key.keyMaterial.slice().buffer;
+        }
+        return descriptor;
+      })
+    );
+    const encryptionContext = initialization.reader.getEncryptionContextForWorker();
+
     let workerResult: ParquetSourceWorkerResult;
     try {
       workerResult = await decodeParquetSourceRowGroupOnWorker(
@@ -1007,11 +1029,18 @@ export class ParquetSource
           uncompressedByteLength: Number(rowGroup.total_byte_size),
           schemaDefinition: initialization.parquetSchema.schema,
           projectedSchema,
-          columnChunks: selectedColumnChunks.map(createParquetSourceWorkerColumnChunk),
+          columnChunks: workerColumnChunks,
           ranges,
           batchSize: batchSize || Math.max(Number(rowGroup.num_rows), 1),
           predicate: predicate ? copyParquetPredicate(predicate) : undefined,
           pagePlan,
+          encryption: encryptionContext
+            ? {
+                algorithm: encryptionContext.algorithm,
+                aadPrefix: encryptionContext.aadPrefix?.slice().buffer,
+                fileUnique: encryptionContext.fileUnique.slice().buffer
+              }
+            : undefined,
           preserveBinary: Boolean(this.options.parquet?.preserveBinary),
           verifyPageChecksums: Boolean(this.options.parquet?.verifyPageChecksums)
         },

--- a/modules/parquet/src/parquetjs/parser/parquet-reader.ts
+++ b/modules/parquet/src/parquetjs/parser/parquet-reader.ts
@@ -87,6 +87,8 @@ export type ParquetReaderProps = {
   keyRetriever?: ParquetKeyRetriever;
   /** AAD prefix for files that intentionally omit it from FileCryptoMetaData. */
   aadPrefix?: Uint8Array;
+  /** Pre-resolved encryption context used by worker-local readers. */
+  encryptionContext?: ParquetReaderEncryptionContext;
 };
 
 /** Properties for initializing a ParquetRowGroupReader */
@@ -100,9 +102,9 @@ export type ParquetIterationProps = {
 };
 
 type NormalizedParquetReaderProps = Required<
-  Omit<ParquetReaderProps, 'signal' | 'keyRetriever' | 'aadPrefix'>
+  Omit<ParquetReaderProps, 'signal' | 'keyRetriever' | 'aadPrefix' | 'encryptionContext'>
 > &
-  Pick<ParquetReaderProps, 'signal' | 'keyRetriever' | 'aadPrefix'>;
+  Pick<ParquetReaderProps, 'signal' | 'keyRetriever' | 'aadPrefix' | 'encryptionContext'>;
 
 /** File-level parameters needed to authenticate modular-encrypted modules. */
 type ParquetEncryptionContext = {
@@ -112,6 +114,12 @@ type ParquetEncryptionContext = {
   footerKeyMetadata?: Uint8Array;
   footerSigningKeyMetadata?: Uint8Array;
 };
+
+/** File-level encryption parameters needed to decrypt worker-transferred page modules. */
+export type ParquetReaderEncryptionContext = Pick<
+  ParquetEncryptionContext,
+  'algorithm' | 'aadPrefix' | 'fileUnique' | 'footerKeyMetadata'
+>;
 
 /**
  * The parquet envelope reader allows direct, unbuffered access to the individual
@@ -131,7 +139,8 @@ export class ParquetReader {
     verifyFooterSignature: true,
     signal: undefined,
     keyRetriever: undefined,
-    aadPrefix: undefined
+    aadPrefix: undefined,
+    encryptionContext: undefined
   };
 
   props: NormalizedParquetReaderProps;
@@ -145,11 +154,53 @@ export class ParquetReader {
   constructor(file: ReadableFile, props?: ParquetReaderProps) {
     this.file = file;
     this.props = {...ParquetReader.defaultProps, ...props};
+    this.encryptionContext = this.props.encryptionContext;
   }
 
   /** Whether the decoded footer describes an encrypted Parquet file. */
   get encrypted(): boolean {
     return Boolean(this.encryptionContext);
+  }
+
+  /** Returns a cloneable snapshot of the file encryption context for worker decoding. */
+  getEncryptionContextForWorker(): ParquetReaderEncryptionContext | undefined {
+    const encryptionContext = this.encryptionContext;
+    if (!encryptionContext) return undefined;
+    return {
+      algorithm: encryptionContext.algorithm,
+      aadPrefix: encryptionContext.aadPrefix && new Uint8Array(encryptionContext.aadPrefix),
+      fileUnique: new Uint8Array(encryptionContext.fileUnique),
+      footerKeyMetadata:
+        encryptionContext.footerKeyMetadata && new Uint8Array(encryptionContext.footerKeyMetadata)
+    };
+  }
+
+  /** Resolves one column key on the caller thread before transferring encrypted ranges. */
+  async getColumnKeyForWorker(
+    columnChunk: ColumnChunk,
+    rowGroupOrdinal: number,
+    columnOrdinal: number
+  ): Promise<{keyMetadata?: Uint8Array; keyMaterial: Uint8Array}> {
+    if (!this.encryptionContext || !this.props.keyRetriever) {
+      throw new Error('Encrypted Parquet worker reads require parquet.keyRetriever');
+    }
+    const keyMetadata = this.getColumnKeyMetadata(columnChunk);
+    const keyMaterial = await this.props.keyRetriever(keyMetadata, {
+      algorithm: this.encryptionContext.algorithm,
+      aad: createParquetModuleAad(
+        this.encryptionContext.aadPrefix,
+        this.encryptionContext.fileUnique,
+        'data-page',
+        rowGroupOrdinal,
+        columnOrdinal,
+        0
+      )
+    });
+    const keyBytes =
+      keyMaterial instanceof ArrayBuffer
+        ? new Uint8Array(keyMaterial)
+        : new Uint8Array(keyMaterial.buffer, keyMaterial.byteOffset, keyMaterial.byteLength);
+    return {keyMetadata, keyMaterial: keyBytes};
   }
 
   close(): void {
@@ -396,7 +447,7 @@ export class ParquetReader {
         columnChunk.meta_data = await this.getColumnMetadata(
           columnChunk,
           rowGroupOrdinal,
-          columnOrdinal
+          getPhysicalColumnOrdinal(columnChunk, columnOrdinal)
         );
       }
     }
@@ -545,9 +596,14 @@ export class ParquetReader {
       if (columnList.length > 0 && (!path || fieldIndexOf(columnList, path) < 0)) {
         continue;
       }
-      const metadata = await this.getColumnMetadata(columnChunk, rowGroupOrdinal, columnOrdinal);
+      const physicalColumnOrdinal = getPhysicalColumnOrdinal(columnChunk, columnOrdinal);
+      const metadata = await this.getColumnMetadata(
+        columnChunk,
+        rowGroupOrdinal,
+        physicalColumnOrdinal
+      );
       if (columnList.length === 0 || fieldIndexOf(columnList, metadata.path_in_schema) >= 0) {
-        selectedColumnChunks.push({columnChunk, metadata, columnOrdinal});
+        selectedColumnChunks.push({columnChunk, metadata, columnOrdinal: physicalColumnOrdinal});
       }
     }
     const columnEntries: Array<readonly [string, ParquetColumnChunk]> = [];
@@ -605,9 +661,14 @@ export class ParquetReader {
       if (columnList.length > 0 && (!path || fieldIndexOf(columnList, path) < 0)) {
         continue;
       }
-      const metadata = await this.getColumnMetadata(columnChunk, rowGroupOrdinal, columnOrdinal);
+      const physicalColumnOrdinal = getPhysicalColumnOrdinal(columnChunk, columnOrdinal);
+      const metadata = await this.getColumnMetadata(
+        columnChunk,
+        rowGroupOrdinal,
+        physicalColumnOrdinal
+      );
       if (columnList.length === 0 || fieldIndexOf(columnList, metadata.path_in_schema) >= 0) {
-        selectedColumnChunks.push({columnChunk, metadata, columnOrdinal});
+        selectedColumnChunks.push({columnChunk, metadata, columnOrdinal: physicalColumnOrdinal});
       }
     }
     const columnEntries = await Promise.all(
@@ -995,6 +1056,14 @@ function getColumnChunkPath(columnChunk: ColumnChunk): string[] | undefined {
   return (
     columnChunk.meta_data?.path_in_schema ??
     columnChunk.crypto_metadata?.ENCRYPTION_WITH_COLUMN_KEY?.path_in_schema
+  );
+}
+
+/** Returns the original row-group ordinal for a worker-reduced column list. */
+function getPhysicalColumnOrdinal(columnChunk: ColumnChunk, fallbackOrdinal: number): number {
+  return (
+    (columnChunk as ColumnChunk & {parquetColumnOrdinal?: number}).parquetColumnOrdinal ??
+    fallbackOrdinal
   );
 }
 

--- a/modules/parquet/test/parquet-encryption.spec.ts
+++ b/modules/parquet/test/parquet-encryption.spec.ts
@@ -10,6 +10,7 @@ import {
   verifyParquetFooterSignature
 } from '@loaders.gl/parquet';
 import type {ParquetSource} from '@loaders.gl/parquet/parquet-source-loader';
+import {createWorkerKeyRetriever} from '../src/lib/parquet-source-worker-decoder';
 import {expect, test} from 'vitest';
 
 const PARQUET_DIR = '@loaders.gl/parquet/test/data/apache';
@@ -131,6 +132,32 @@ test('ParquetSource decrypts encrypted pages in a worker', async () => {
 
   expect(batches.reduce((count, batch) => count + batch.rowCount, 0)).toBe(50);
   expect(batches[0]?.data.getChild('double_field')?.toArray().length).toBeGreaterThan(0);
+});
+
+test('worker key lookup uses the encrypted column ordinal', async () => {
+  const firstKey = new Uint8Array([1, 2, 3]).buffer;
+  const secondKey = new Uint8Array([4, 5, 6]).buffer;
+  const sharedMetadata = new Uint8Array([7, 8]).buffer;
+  const keyRetriever = createWorkerKeyRetriever(
+    [
+      {columnOrdinal: 0, keyMetadata: sharedMetadata, keyMaterial: firstKey},
+      {columnOrdinal: 1, keyMetadata: sharedMetadata, keyMaterial: secondKey}
+    ],
+    0,
+    2
+  );
+  const aad = new Uint8Array(9);
+  aad.set([9, 9], 0);
+  aad[2] = 2;
+  new DataView(aad.buffer).setInt16(3, 0, true);
+  new DataView(aad.buffer).setInt16(5, 1, true);
+
+  expect(
+    keyRetriever(new Uint8Array(sharedMetadata), {
+      algorithm: 'AES_GCM_V1',
+      aad
+    })
+  ).toEqual(new Uint8Array(secondKey));
 });
 
 test('verifies plaintext-footer signatures and rejects tampering', async () => {

--- a/modules/parquet/test/parquet-encryption.spec.ts
+++ b/modules/parquet/test/parquet-encryption.spec.ts
@@ -5,9 +5,11 @@
 import {load} from '@loaders.gl/core';
 import {
   ParquetJSLoader,
+  ParquetSourceLoader,
   createParquetModuleAad,
   verifyParquetFooterSignature
 } from '@loaders.gl/parquet';
+import type {ParquetSource} from '@loaders.gl/parquet/parquet-source-loader';
 import {expect, test} from 'vitest';
 
 const PARQUET_DIR = '@loaders.gl/parquet/test/data/apache';
@@ -110,6 +112,25 @@ test('ParquetJSLoader does not retrieve keys for unprojected encrypted columns',
 
   expect(table.data).toHaveLength(50);
   expect(new Set(requestedKeyMetadata)).not.toEqual(new Set(['kf', 'kc1', 'kc2']));
+});
+
+test('ParquetSource decrypts encrypted pages in a worker', async () => {
+  const url = `${PARQUET_DIR}/encrypted/encrypt_columns_and_footer.parquet.encrypted`;
+  const source = (await load(url, ParquetSourceLoader, {
+    core: {worker: true, reuseWorkers: false, _workerType: 'test'},
+    parquet: {
+      columns: ['double_field'],
+      keyRetriever: getEncryptedFixtureKey
+    }
+  })) as ParquetSource;
+  const batches = [];
+  for await (const batch of source.read({columns: ['double_field']})) {
+    batches.push(batch);
+  }
+  await source.close();
+
+  expect(batches.reduce((count, batch) => count + batch.rowCount, 0)).toBe(50);
+  expect(batches[0]?.data.getChild('double_field')?.toArray().length).toBeGreaterThan(0);
 });
 
 test('verifies plaintext-footer signatures and rejects tampering', async () => {


### PR DESCRIPTION
## Goals

- Run encrypted `ParquetSource` page decoding on the existing worker path when callers provide a key retriever.
- Preserve authenticated modular-encryption behavior without sending key-retrieval callbacks across the worker boundary.

## Changes

- Resolve only selected data keys on the caller thread and transfer key bytes, key metadata, and file encryption context to the worker.
- Reconstruct the minimal encrypted column metadata in the worker and decrypt AES-GCM/AES-GCM-CTR page modules there.
- Preserve original physical column ordinals so module AAD remains correct when projection reduces the worker column list.
- Keep the caller-thread fallback when encrypted input has no key retriever.
- Add a Chromium regression test for encrypted `ParquetSource` decoding and update the Parquet format notes.

## Validation

- `yarn build`
- `yarn build-workers`
- `yarn test-node`
- `yarn test-headless modules/parquet/test/parquet-source-loader.spec.ts modules/parquet/test/parquet-encryption.spec.ts modules/parquet/test/parquet-page-index-api.spec.ts`
- `yarn lint fix`