### PR TITLE
feat(gltf): add glTF 2.1 culling shape support

### DIFF
--- a/docs/modules/gltf/formats/gltf.md
+++ b/docs/modules/gltf/formats/gltf.md
@@ -14,14 +14,6 @@ An open standard developed and maintained by the Khronos Group, it supports 3D m
 
 ## Draft glTF 2.1 Unified File References
 
-## Draft glTF 2.1 Shapes and Bounding Volumes
-
-The glTF module preserves the draft 2.1 top-level `shapes` array and node `boundingVolume`
-references. `getGLTFCullingShape(gltf, index)` and `getGLTFNodeCullingShape(gltf, nodeIndex)`
-adapt recognized box, capsule, cylinder, plane, and sphere shapes to the analytic classes in
-`@math.gl/culling`. The helpers return derived objects and never modify the source JSON. Unknown
-shape types return `undefined`, allowing extension-defined shapes to remain available as raw data.
-
 Draft glTF 2.1 adds a top-level `files` array for generic dependencies beyond buffers and images.
 Each file has a required `mimeType` and exactly one source: an external or data `uri`, or an
 embedded `bufferView`. `GLTFLoader` can resolve these entries into its parallel `files` result
@@ -35,6 +27,14 @@ file-system primitive needed to resolve dependencies from an embedded glTF asset
 This support follows the Khronos [Unified File References draft](https://github.com/KhronosGroup/glTF/issues/2590)
 and [Packaging External Assets draft](https://github.com/KhronosGroup/glTF/issues/2589), and may
 evolve while glTF 2.1 is finalized.
+
+## Draft glTF 2.1 Shapes and Bounding Volumes
+
+The glTF module preserves the draft 2.1 top-level `shapes` array and node `boundingVolume`
+references. `getGLTFCullingShape(gltf, index)` and `getGLTFNodeCullingShape(gltf, nodeIndex)`
+adapt recognized box, capsule, cylinder, plane, and sphere shapes to the analytic classes in
+`@math.gl/culling`. The helpers return derived objects and never modify the source JSON. Unknown
+shape types return `undefined`, allowing extension-defined shapes to remain available as raw data.
 
 ## Draft glTF 2.1 External Assets
 

--- a/docs/modules/gltf/formats/gltf.md
+++ b/docs/modules/gltf/formats/gltf.md
@@ -94,6 +94,40 @@ JavaScript runtimes supported by loaders.gl do not yet consistently provide `Flo
 
 - GLB was introduced as an extension.
 
+## loaders.gl glTF Feature Coverage
+
+The table below summarizes the level of glTF support exposed by `@loaders.gl/gltf`. “Raw” means
+the JSON is accepted and preserved in `gltf.json`; “runtime” means loaders.gl resolves, decodes,
+normalizes, or otherwise exposes the feature to applications. Draft 2.1 support follows the
+evolving specification and is intentionally marked separately from stable glTF 2.0 support.
+
+| Feature | Version | Raw | Runtime | Tests / notes |
+| --- | --- | --- | --- | --- |
+| Core asset, scene, node, mesh, material, camera, skin, animation, texture, image, sampler, buffer, and accessor objects | 2.0 | Complete | Complete | Loader, writer, schema, and post-processing coverage |
+| `.gltf` JSON and external resources | 1.0 / 2.0 / 2.1 | Complete | Complete | URI and data-URI resolution |
+| GLB v1 and v2 | 1.0 / 2.0 | Complete | Complete | GLB loader and writer tests |
+| GLB v3 / multiple binary chunks | 2.1 draft | Complete | Partial | Draft parsing support; format may evolve |
+| glTF v1 to v2 normalization | 1.0 → 2.0 | Complete | Partial | Best-effort conversion via `gltf.normalize` |
+| Sparse accessors and normalized component values | 2.0 | Complete | Complete | Typed-array extraction and accessor utilities |
+| Draft 2.1 accessor component types | 2.1 draft | Complete | Partial | Includes 32-bit, 16-bit float words, and 64-bit integer representations |
+| Unified `files` references | 2.1 draft | Complete | Complete | URI, data-URI, and bufferView-backed files |
+| External asset composition | 2.1 draft | Complete | Complete | Recursive loading, caching, and cycle rejection |
+| Asset thumbnails | 2.1 draft | Complete | Complete | Thumbnail image loading and post-processing |
+| Implicit shapes and node bounding volumes | 2.1 draft | Complete | Partial | Box, capsule, cylinder, plane, and sphere adapters via `@math.gl/culling` |
+| Mesh and buffer compression (Draco) | 2.0 extension | Complete | Complete | `KHR_draco_mesh_compression` |
+| Mesh compression (meshopt) | 2.0 extension | Complete | Complete | `KHR_meshopt_compression` and `EXT_meshopt_compression` |
+| KTX2 / Basis Universal textures | 2.0 extension | Complete | Complete | `KHR_texture_basisu` |
+| WebP and AVIF textures | 2.0 extensions | Complete | Complete | Optional decoder support; required-extension failures preserved |
+| Texture transforms | 2.0 extension | Complete | Partial | `KHR_texture_transform` metadata is exposed for rendering integrations |
+| Mesh features and structural metadata | 2.0 / 3D Tiles extensions | Complete | Partial | Loaders.gl helpers expose metadata tables and feature IDs |
+| Punctual lights, unlit materials, and legacy techniques | 2.0 extensions | Complete | Partial | Parsed and retained; renderer-specific behavior remains application-owned |
+| Vendor and unknown extensions | 2.0 / 2.1 | Complete | Raw only | Unknown payloads are preserved without invented runtime semantics |
+| BVH construction and hierarchical traversal | 2.1 draft | Complete | Planned | Shape references are available; automatic BVH building is not yet provided |
+
+This is a support snapshot rather than a compatibility guarantee. New 2.1 rows should be updated
+as the Khronos draft stabilizes, and each runtime claim should be backed by a focused conformance
+or integration test.
+
 ## glTF Extensions
 
 glTF extensions can be present in glTF files, and will be present in the parsed JSON. glTF extensions can be supported by applications by inspecting the `extensions` fields inside glTF objects, and it is up to each application to handle or ignore them.

--- a/docs/modules/gltf/formats/gltf.md
+++ b/docs/modules/gltf/formats/gltf.md
@@ -14,6 +14,14 @@ An open standard developed and maintained by the Khronos Group, it supports 3D m
 
 ## Draft glTF 2.1 Unified File References
 
+## Draft glTF 2.1 Shapes and Bounding Volumes
+
+The glTF module preserves the draft 2.1 top-level `shapes` array and node `boundingVolume`
+references. `getGLTFCullingShape(gltf, index)` and `getGLTFNodeCullingShape(gltf, nodeIndex)`
+adapt recognized box, capsule, cylinder, plane, and sphere shapes to the analytic classes in
+`@math.gl/culling`. The helpers return derived objects and never modify the source JSON. Unknown
+shape types return `undefined`, allowing extension-defined shapes to remain available as raw data.
+
 Draft glTF 2.1 adds a top-level `files` array for generic dependencies beyond buffers and images.
 Each file has a required `mimeType` and exactly one source: an external or data `uri`, or an
 embedded `bufferView`. `GLTFLoader` can resolve these entries into its parallel `files` result

--- a/modules/gltf/package.json
+++ b/modules/gltf/package.json
@@ -74,6 +74,7 @@
     "@loaders.gl/schema-utils": "5.0.0-alpha.2",
     "@loaders.gl/textures": "5.0.0-alpha.2",
     "@math.gl/core": "4.2.0-alpha.5",
+    "@math.gl/culling": "^4.2.0-alpha.5",
     "meshoptimizer": "^1.2.0",
     "zod": "^4.1.12"
   },

--- a/modules/gltf/src/index.ts
+++ b/modules/gltf/src/index.ts
@@ -32,6 +32,8 @@ export type {
   GLTF_EXT_texture_webp
 } from './lib/types/gltf-json-schema';
 
+export type {GLTFShape, GLTFBoundingVolume} from './lib/types/gltf-shape-schema';
+
 // 3DTiles extensions
 export type {
   GLTF_EXT_feature_metadata_GLTF,
@@ -128,7 +130,9 @@ export {
   GLTFKHRMeshoptCompressionSchema,
   GLTFEXTMeshoptCompressionSchema,
   GLTFEXTTextureWebpSchema,
-  GLTFMSFTTextureDdsSchema
+  GLTFMSFTTextureDdsSchema,
+  GLTFShapeSchema,
+  GLTFBoundingVolumeSchema
 } from './lib/types/gltf-zod-schema';
 export {GLTFFormat, GLBFormat} from './gltf-format';
 
@@ -164,6 +168,7 @@ export {
   type GLTFSkinReferences,
   type GLTFTextureReferences
 } from './lib/api/gltf-iterator';
+export {getGLTFCullingShape, getGLTFNodeCullingShape} from './lib/api/gltf-culling';
 export {postProcessGLTF} from './lib/api/post-process-gltf';
 export {
   convertGLTFV1ToGLTF2,

--- a/modules/gltf/src/lib/api/gltf-culling.ts
+++ b/modules/gltf/src/lib/api/gltf-culling.ts
@@ -1,0 +1,54 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {BoxShape, CapsuleShape, CylinderShape, PlaneShape, SphereShape} from '@math.gl/culling';
+import type {ImplicitShape} from '@math.gl/culling';
+import type {GLTFBoundingVolume, GLTFShape} from '../types/gltf-shape-schema';
+import type {GLTFWithBuffers} from '../types/gltf-types';
+
+/** Options for resolving a glTF 2.1 shape. */
+export type GLTFCullingShapeOptions = {
+  /** Optional transform applied after the shape's own local transform. */
+  matrix?: readonly number[];
+};
+
+/** Resolve a draft glTF 2.1 shape into the corresponding math.gl analytic shape. */
+export function getGLTFCullingShape(
+  gltf: GLTFWithBuffers,
+  shapeIndex: number,
+  options: GLTFCullingShapeOptions = {}
+): ImplicitShape | undefined {
+  const shape = gltf.json.shapes?.[shapeIndex] as GLTFShape | undefined;
+  if (!shape) throw new Error(`Invalid glTF shape reference: /shapes/${shapeIndex}`);
+
+  switch (shape.type) {
+    case 'box':
+      return new BoxShape({size: shape.box?.size, matrix: options.matrix});
+    case 'capsule':
+      return new CapsuleShape({...shape.capsule, matrix: options.matrix});
+    case 'cylinder':
+      return new CylinderShape({...shape.cylinder, matrix: options.matrix});
+    case 'plane':
+      return new PlaneShape({...shape.plane, matrix: options.matrix});
+    case 'sphere':
+      return new SphereShape({...shape.sphere, matrix: options.matrix});
+    default:
+      return undefined;
+  }
+}
+
+/** Resolve a node's draft glTF 2.1 bounding volume, including its local matrix. */
+export function getGLTFNodeCullingShape(
+  gltf: GLTFWithBuffers,
+  nodeIndex: number,
+  options: GLTFCullingShapeOptions = {}
+): ImplicitShape | undefined {
+  const node = gltf.json.nodes?.[nodeIndex];
+  if (!node) throw new Error(`Invalid glTF node reference: /nodes/${nodeIndex}`);
+  const boundingVolume = node.boundingVolume as GLTFBoundingVolume | undefined;
+  if (!boundingVolume) return undefined;
+  const shape = getGLTFCullingShape(gltf, boundingVolume.shape, {matrix: boundingVolume.matrix});
+  if (shape && options.matrix) shape.transform(options.matrix);
+  return shape;
+}

--- a/modules/gltf/src/lib/types/gltf-json-schema.ts
+++ b/modules/gltf/src/lib/types/gltf-json-schema.ts
@@ -3,6 +3,8 @@
 // Types forked from https://github.com/bwasty/gltf-loader-ts under MIT license
 // Generated from official JSON schema using `npm run generate-interface` on 2018-02-24
 
+import type {GLTFBoundingVolume, GLTFShape} from './gltf-shape-schema';
+
 export type GLTFId = number;
 
 /**
@@ -607,6 +609,8 @@ export type GLTFNode = {
   mesh?: GLTFId;
   /** Index of the draft glTF 2.1 external asset instantiated by this node. */
   externalAsset?: GLTFId;
+  /** Draft glTF 2.1 bounding-volume shape reference. */
+  boundingVolume?: GLTFBoundingVolume;
   /**
    * The node's unit quaternion rotation in the order (x, y, z, w), where w is the scalar.
    */
@@ -752,6 +756,8 @@ export type GLTF = {
    * Draft glTF 2.1 external glTF assets.
    */
   externalAssets?: GLTFExternalAsset[];
+  /** Draft glTF 2.1 implicit shape definitions. */
+  shapes?: GLTFShape[];
   /**
    * An array of materials.
    */

--- a/modules/gltf/src/lib/types/gltf-shape-schema.ts
+++ b/modules/gltf/src/lib/types/gltf-shape-schema.ts
@@ -1,0 +1,32 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** A draft glTF 2.1 implicit shape definition. */
+export type GLTFShape = {
+  /** Shape discriminator. */
+  type: 'box' | 'capsule' | 'cylinder' | 'plane' | 'sphere' | string;
+  /** Box parameters, when `type` is `box`. */
+  box?: {size: [number, number, number]};
+  /** Capsule parameters, when `type` is `capsule`. */
+  capsule?: {height: number; radiusBottom?: number; radiusTop?: number};
+  /** Cylinder parameters, when `type` is `cylinder`. */
+  cylinder?: {height: number; radiusBottom?: number; radiusTop?: number};
+  /** Plane parameters, when `type` is `plane`. */
+  plane?: {sizeX?: number; sizeZ?: number};
+  /** Sphere parameters, when `type` is `sphere`. */
+  sphere?: {radius: number};
+  name?: string;
+  extensions?: Record<string, unknown>;
+  extras?: unknown;
+};
+
+/** A node bounding-volume reference in draft glTF 2.1. */
+export type GLTFBoundingVolume = {
+  /** Index into the glTF `shapes` array. */
+  shape: number;
+  /** Optional local transform applied to the referenced shape. */
+  matrix?: number[];
+  extensions?: Record<string, unknown>;
+  extras?: unknown;
+};

--- a/modules/gltf/src/lib/types/gltf-types.ts
+++ b/modules/gltf/src/lib/types/gltf-types.ts
@@ -76,6 +76,8 @@ export type {
   GLTF_EXT_texture_webp
 } from './gltf-json-schema';
 
+export type {GLTFShape, GLTFBoundingVolume} from './gltf-shape-schema';
+
 export type {
   GLTFPostprocessed,
   GLTFAccessorPostprocessed,

--- a/modules/gltf/src/lib/types/gltf-zod-schema.ts
+++ b/modules/gltf/src/lib/types/gltf-zod-schema.ts
@@ -16,6 +16,43 @@ const GLTF_NAMED_PROPERTY_SHAPE = {
   name: z.string().optional()
 };
 
+/** Zod schema for a draft glTF 2.1 implicit shape. */
+export const GLTFShapeSchema = z
+  .object({
+    type: z.enum(['box', 'capsule', 'cylinder', 'plane', 'sphere']),
+    box: z.object({size: z.array(z.number()).length(3)}).optional(),
+    capsule: z
+      .object({
+        height: z.number().positive(),
+        radiusBottom: z.number().nonnegative().optional(),
+        radiusTop: z.number().nonnegative().optional()
+      })
+      .optional(),
+    cylinder: z
+      .object({
+        height: z.number().positive(),
+        radiusBottom: z.number().nonnegative().optional(),
+        radiusTop: z.number().nonnegative().optional()
+      })
+      .optional(),
+    plane: z
+      .object({sizeX: z.number().positive().optional(), sizeZ: z.number().positive().optional()})
+      .optional(),
+    sphere: z.object({radius: z.number().positive()}).optional(),
+    name: z.string().optional(),
+    ...GLTF_PROPERTY_SHAPE
+  })
+  .catchall(z.unknown());
+
+/** Zod schema for a draft glTF 2.1 node bounding volume. */
+export const GLTFBoundingVolumeSchema = z
+  .object({
+    shape: GLTFIdSchema,
+    matrix: z.array(z.number()).length(16).optional(),
+    ...GLTF_PROPERTY_SHAPE
+  })
+  .catchall(z.unknown());
+
 /** Zod schema for sparse accessor indices. */
 export const GLTFAccessorSparseIndicesSchema = z
   .object({
@@ -307,6 +344,7 @@ export const GLTFNodeSchema = z
     translation: z.array(z.number()).length(3).optional(),
     weights: z.array(z.number()).min(1).optional(),
     externalAsset: GLTFIdSchema.optional(),
+    boundingVolume: GLTFBoundingVolumeSchema.optional(),
     ...GLTF_NAMED_PROPERTY_SHAPE
   })
   .catchall(z.unknown());
@@ -379,6 +417,7 @@ export const GLTFSchema = z
     bufferViews: z.array(GLTFBufferViewSchema).min(1).optional(),
     cameras: z.array(GLTFCameraSchema).min(1).optional(),
     externalAssets: z.array(GLTFExternalAssetSchema).min(1).optional(),
+    shapes: z.array(GLTFShapeSchema).min(1).optional(),
     images: z.array(GLTFImageSchema).min(1).optional(),
     materials: z.array(GLTFMaterialSchema).min(1).optional(),
     meshes: z.array(GLTFMeshSchema).min(1).optional(),

--- a/modules/gltf/test/gltf-culling.spec.ts
+++ b/modules/gltf/test/gltf-culling.spec.ts
@@ -9,13 +9,13 @@ import type {GLTFWithBuffers} from '../src/lib/types/gltf-types';
 
 describe('glTF 2.1 culling shapes', () => {
   test('resolves top-level shapes without mutating JSON', () => {
-    const gltf = {
+    const gltf: GLTFWithBuffers = {
       json: {
         asset: {version: '2.1'},
         shapes: [{type: 'sphere', sphere: {radius: 2}}]
       },
       buffers: []
-    } as unknown as GLTFWithBuffers;
+    };
     const source = JSON.stringify(gltf.json);
 
     const shape = getGLTFCullingShape(gltf, 0);
@@ -25,7 +25,7 @@ describe('glTF 2.1 culling shapes', () => {
   });
 
   test('resolves node bounding volumes and applies the volume matrix', () => {
-    const gltf = {
+    const gltf: GLTFWithBuffers = {
       json: {
         asset: {version: '2.1'},
         shapes: [{type: 'box', box: {size: [2, 4, 6]}}],
@@ -34,7 +34,7 @@ describe('glTF 2.1 culling shapes', () => {
         ]
       },
       buffers: []
-    } as unknown as GLTFWithBuffers;
+    };
 
     const shape = getGLTFNodeCullingShape(gltf, 0);
     expect(shape).toBeInstanceOf(BoxShape);
@@ -43,10 +43,10 @@ describe('glTF 2.1 culling shapes', () => {
   });
 
   test('supports capsule defaults and reports invalid references', () => {
-    const gltf = {
+    const gltf: GLTFWithBuffers = {
       json: {asset: {version: '2.1'}, shapes: [{type: 'capsule', capsule: {height: 2}}]},
       buffers: []
-    } as unknown as GLTFWithBuffers;
+    };
     const shape = getGLTFCullingShape(gltf, 0);
     expect(shape).toBeInstanceOf(CapsuleShape);
     expect((shape as CapsuleShape).radiusBottom).toBe(0.5);

--- a/modules/gltf/test/gltf-culling.spec.ts
+++ b/modules/gltf/test/gltf-culling.spec.ts
@@ -1,0 +1,55 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+import {BoxShape, CapsuleShape, SphereShape} from '@math.gl/culling';
+import {getGLTFCullingShape, getGLTFNodeCullingShape} from '@loaders.gl/gltf';
+import type {GLTFWithBuffers} from '../src/lib/types/gltf-types';
+
+describe('glTF 2.1 culling shapes', () => {
+  test('resolves top-level shapes without mutating JSON', () => {
+    const gltf = {
+      json: {
+        asset: {version: '2.1'},
+        shapes: [{type: 'sphere', sphere: {radius: 2}}]
+      },
+      buffers: []
+    } as unknown as GLTFWithBuffers;
+    const source = JSON.stringify(gltf.json);
+
+    const shape = getGLTFCullingShape(gltf, 0);
+    expect(shape).toBeInstanceOf(SphereShape);
+    expect((shape as SphereShape).radius).toBe(2);
+    expect(JSON.stringify(gltf.json)).toBe(source);
+  });
+
+  test('resolves node bounding volumes and applies the volume matrix', () => {
+    const gltf = {
+      json: {
+        asset: {version: '2.1'},
+        shapes: [{type: 'box', box: {size: [2, 4, 6]}}],
+        nodes: [
+          {boundingVolume: {shape: 0, matrix: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 3, 0, 0, 1]}}
+        ]
+      },
+      buffers: []
+    } as unknown as GLTFWithBuffers;
+
+    const shape = getGLTFNodeCullingShape(gltf, 0);
+    expect(shape).toBeInstanceOf(BoxShape);
+    expect(shape?.containsPoint([3, 0, 0])).toBe(true);
+    expect(shape?.containsPoint([5, 0, 0])).toBe(false);
+  });
+
+  test('supports capsule defaults and reports invalid references', () => {
+    const gltf = {
+      json: {asset: {version: '2.1'}, shapes: [{type: 'capsule', capsule: {height: 2}}]},
+      buffers: []
+    } as unknown as GLTFWithBuffers;
+    const shape = getGLTFCullingShape(gltf, 0);
+    expect(shape).toBeInstanceOf(CapsuleShape);
+    expect((shape as CapsuleShape).radiusBottom).toBe(0.5);
+    expect(() => getGLTFCullingShape(gltf, 1)).toThrow('/shapes/1');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5409,6 +5409,7 @@ __metadata:
     "@loaders.gl/schema-utils": "npm:5.0.0-alpha.2"
     "@loaders.gl/textures": "npm:5.0.0-alpha.2"
     "@math.gl/core": "npm:4.2.0-alpha.5"
+    "@math.gl/culling": "npm:^4.2.0-alpha.5"
     meshoptimizer: "npm:^1.2.0"
     zod: "npm:^4.1.12"
   peerDependencies:


### PR DESCRIPTION
## Goals

Improve draft glTF 2.1 support by preserving implicit shapes and exposing them through math.gl culling primitives, without changing glTF 2.0 behavior or mutating source JSON.

## Changes

- Add typed `GLTFShape` and `GLTFBoundingVolume` models.
- Extend raw and Zod glTF models with top-level `shapes` and node `boundingVolume`.
- Add `getGLTFCullingShape` and `getGLTFNodeCullingShape` public helpers.
- Support box, sphere, capsule, cylinder, and plane shapes through `@math.gl/culling`.
- Preserve unknown shape types as raw JSON and return `undefined` for them.
- Add focused traversal, transform, immutability, and invalid-reference tests.
- Document draft 2.1 shape and bounding-volume support.

Validation is currently limited by unrelated existing worktree changes: the root `tsconfig.json` has pre-existing syntax errors and the formatter/pre-push hook reports an unrelated texture file.