### PR TITLE
feat(copc): add spatial scan pushdown

### DIFF
--- a/docs/modules/copc/api-reference/copc-source-loader.md
+++ b/docs/modules/copc/api-reference/copc-source-loader.md
@@ -34,8 +34,45 @@ The created data source exposes the point-cloud tile methods used by `PointCloud
 - `getRootTile()` returns the root octree tile header.
 - `getChildren(tile)` returns available child tile headers.
 - `loadTileContent(tile, options)` returns normalized point positions, optional colors, point count, and cartographic origin. `options.signal` cancels queued work, the active range request, or worker decode.
-- `loadTileContentInBatches(tile, options)` yields normalized Arrow point tables progressively as the selected node range is fetched. `options.batchSize` controls the maximum points per table, `options.columns` selects the attributes listed below, and `options.signal` cancels the request/decode.
+- `loadTileContentInBatches(tile, options)` yields normalized Arrow point tables progressively as the selected node range is fetched. `options.batchSize` controls the maximum points per table, `options.limit` caps rows for the node, `options.bounds` applies exact source-coordinate filtering, `options.columns` selects the attributes listed below, and `options.signal` cancels the request/decode.
 - `loadHierarchyInBatches(options)` yields hierarchy pages and their discovered nodes as they are fetched.
+
+## Query metadata and scans
+
+`getQueryMetadata()` describes the schema and pushdown capabilities of the point-cloud scan API.
+Its field names are the same names accepted by `scan({columns})`, so a query panel can use the
+returned schema directly. `POSITION` is a three-component point column and `COLOR_0` is a
+three-component 16-bit RGB column. The remaining fields are scalar LAS attributes; `EXTRA_BYTES`
+is a logical selector that enables the descriptor-defined typed `EXTRA_BYTES_*` attributes.
+
+```typescript
+const metadata = await dataSource.getQueryMetadata();
+const columns = metadata.schema.fields
+  .filter(field => field.name !== 'POSITION')
+  .map(field => field.name);
+
+for await (const batch of dataSource.scan({
+  columns: ['POSITION', 'intensity', 'classification'],
+  bounds: {
+    minimum: [xmin, ymin, zmin],
+    maximum: [xmax, ymax, zmax]
+  },
+  minimumLevel: 2,
+  maximumLevel: 8,
+  targetSpacing: 0.25,
+  batchSize: 65536,
+  limit: 100000
+})) {
+  consume(batch.data);
+}
+```
+
+`bounds` first prunes wholly disjoint hierarchy nodes and then applies an exact inclusive test to
+decoded point positions. `minimumLevel`, `maximumLevel`, and `targetSpacing` select the hierarchy
+levels that may contribute samples; target spacing includes coarser ancestor samples through the
+selected level. `batchSize` remains the maximum number of rows in each emitted batch, including
+when `limit` is set. `limit` stops after exactly that many in-bounds points, and `signal` cancels
+hierarchy reads, range requests, and decoding.
 
 The source uses the native TypeScript COPC and LAZ readers for PDRF 6-8. Atomic `loadTileContent` calls created through `@loaders.gl/core` use the package's single prebuilt TypeScript LAS worker pool when workers are enabled; direct source construction and unavailable workers fall back to main-thread decoding. `copc.decodeConcurrency` bounds each source's combined node fetch and decode work to control peak compressed and decoded memory.
 

--- a/modules/copc/src/copc-source-loader.ts
+++ b/modules/copc/src/copc-source-loader.ts
@@ -30,6 +30,7 @@ import {
   createScanQueryMetadata,
   validatePointCloudQueryOptions,
   type PointCloudQueryCapabilities,
+  type PointCloudQueryBounds,
   type PointCloudQueryOptions
 } from '@loaders.gl/loader-utils';
 import {Proj4Projection, type Proj4CRSDefinition} from '@math.gl/proj4';
@@ -194,6 +195,8 @@ export type COPCTileContentLoadOptions = {
 export type COPCTileContentBatchOptions = {
   /** Maximum number of points in each yielded Arrow table. */
   batchSize?: number;
+  /** Maximum number of points to yield before closing the iterator. */
+  limit?: number;
   /** Optional cancellation signal for the range request and decode loop. */
   signal?: AbortSignal;
   /** Arrow attributes to populate. POSITION is always included. */
@@ -222,6 +225,8 @@ export type COPCTileContentBatchOptions = {
   rangeChunkSize?: number;
   /** Maximum number of node ranges fetched ahead of decode. Defaults to 1. */
   rangeConcurrency?: number;
+  /** Optional source-coordinate bounds for exact point-level filtering. */
+  bounds?: PointCloudQueryBounds;
 };
 
 /** Options for progressive COPC hierarchy page loading. */
@@ -350,7 +355,7 @@ export class COPCTileSource
   /** Discovers point attributes and spatial bounds without decoding point rows. */
   async getQueryMetadata() {
     const {copc} = await this._initPromise;
-    const schema = getCOPCHeaderSchema(copc);
+    const schema = getCOPCScanSchema(copc);
     const roles = Object.fromEntries(
       schema.fields.map(field => [field.name, inferCOPCColumnRole(field.name)])
     );
@@ -425,15 +430,16 @@ export class COPCTileSource
       if (options.signal?.aborted) {
         throw new Error('COPC scan was aborted');
       }
-      // A bounded scan uses one final batch sized to the remaining limit. This
-      // keeps the limit exact even when a node contains more points than the
-      // caller's preferred batch size.
-      const nodeBatchSize = options.limit === undefined ? (options.batchSize ?? 65536) : remaining;
+      // Keep the caller's preferred batch size while capping each node at the
+      // remaining limit. The progressive decoder emits a smaller final batch.
+      const nodeBatchSize = Math.min(remaining, options.batchSize ?? 65536);
       for await (const batch of this.loadTileContentInBatches(
         {id: tileId},
         {
           batchSize: nodeBatchSize,
+          limit: remaining,
           columns: selectedColumns,
+          bounds: options.bounds,
           rangeChunkSize: options.rangeChunkSize,
           rangeConcurrency: options.rangeConcurrency,
           signal: options.signal
@@ -612,6 +618,15 @@ export class COPCTileSource
     if (!Number.isSafeInteger(batchSize) || batchSize < 1) {
       throw new Error('COPC progressive tile batchSize must be a positive integer');
     }
+    if (
+      options.limit !== undefined &&
+      (!Number.isSafeInteger(options.limit) || options.limit < 0)
+    ) {
+      throw new Error('COPC progressive tile limit must be a non-negative integer');
+    }
+    if (options.limit === 0) {
+      return;
+    }
     const nativeOrigin = this.getNativeTileCenter(tile.id);
     const cartographicOrigin = this.projectPoint(nativeOrigin);
     const selection = getCOPCPointSelection(copc, options.columns);
@@ -640,7 +655,9 @@ export class COPCTileSource
       rangeChunkSize,
       rangeConcurrency,
       options.signal,
-      selection
+      selection,
+      options.bounds,
+      options.limit
     );
   }
 
@@ -654,10 +671,13 @@ export class COPCTileSource
     rangeChunkSize: number,
     rangeConcurrency: number,
     signal: AbortSignal | undefined,
-    selection: COPCPointSelection
+    selection: COPCPointSelection,
+    bounds?: PointCloudQueryBounds,
+    limit?: number
   ): AsyncIterable<COPCTileContent> {
     const decoder = createLAZChunkDecoder(getCOPCLAZChunkMetadata(copc, node.pointCount));
     let decodedPointCount = 0;
+    const remainingPointCount = {value: limit ?? Number.MAX_SAFE_INTEGER};
 
     for await (const compressedChunk of this.loadCOPCNodeRangeChunks(
       node,
@@ -674,9 +694,14 @@ export class COPCTileSource
         cartographicOrigin,
         batchSize,
         decodedPointCount,
-        selection
+        selection,
+        bounds,
+        remainingPointCount
       );
       decodedPointCount = node.pointCount - decoder.remainingPointCount;
+      if (remainingPointCount.value <= 0) {
+        return;
+      }
     }
 
     decoder.close();
@@ -689,9 +714,14 @@ export class COPCTileSource
         cartographicOrigin,
         batchSize,
         decodedPointCount,
-        selection
+        selection,
+        bounds,
+        remainingPointCount
       );
       decodedPointCount = node.pointCount - decoder.remainingPointCount;
+      if (remainingPointCount.value <= 0) {
+        return;
+      }
     }
     if (decodedPointCount !== node.pointCount) {
       throw new Error(
@@ -709,12 +739,17 @@ export class COPCTileSource
     cartographicOrigin: number[],
     batchSize: number,
     decodedPointCount: number,
-    selection: COPCPointSelection
+    selection: COPCPointSelection,
+    bounds: PointCloudQueryBounds | undefined,
+    remainingPointCount: {value: number}
   ): Iterable<COPCTileContent> {
-    while (decodedPointCount < nodePointCount) {
-      const pointCount = Math.min(batchSize, nodePointCount - decodedPointCount);
+    while (decodedPointCount < nodePointCount && remainingPointCount.value > 0) {
+      const pointCount = Math.min(
+        batchSize,
+        nodePointCount - decodedPointCount,
+        remainingPointCount.value
+      );
       const nativePositions = new Float64Array(pointCount * 3);
-      const positions = new Float32Array(pointCount * 3);
       const batchColors = selection.colors ? new Uint16Array(pointCount * 3) : null;
       const batchNir = selection.nir ? new Uint16Array(pointCount) : null;
       const batchIntensities = selection.intensity ? new Uint16Array(pointCount) : null;
@@ -771,19 +806,24 @@ export class COPCTileSource
       if (decoded === 0) {
         return;
       }
-      const typedExtraBytes = batchExtraBytes
-        ? createLASTypedExtraBytesAttributes(pointCount, copc.extraBytesDescriptors, extraByteCount)
-        : [];
-      if (batchExtraBytes) {
-        populateLASTypedExtraBytes(batchExtraBytes, pointCount, extraByteCount, typedExtraBytes);
+      decodedPointCount += decoded;
+      const selectedPointIndices = bounds
+        ? getCOPCPointIndicesWithinBounds(nativePositions, decoded, bounds)
+        : Array.from({length: decoded}, (_value, index) => index);
+      if (selectedPointIndices.length === 0) {
+        continue;
       }
-      this.transformTilePositions(nativePositions, positions, nativeOrigin, cartographicOrigin);
-      yield this.createTileContentResult(
-        pointCount,
-        positions,
-        batchColors,
-        cartographicOrigin,
-        batchNir,
+      const filteredPointCount = selectedPointIndices.length;
+      remainingPointCount.value -= filteredPointCount;
+      const filteredNativePositions = selectCOPCPointArray(
+        nativePositions,
+        selectedPointIndices,
+        3
+      ) as Float64Array;
+      const filteredPositions = new Float32Array(filteredPointCount * 3);
+      const filteredColors = selectCOPCPointArray(batchColors, selectedPointIndices, 3);
+      const filteredNir = selectCOPCPointArray(batchNir, selectedPointIndices, 1);
+      const filteredPointData = filterCOPCPointData(
         {
           batchIntensities,
           batchClassifications,
@@ -800,10 +840,47 @@ export class COPCTileSource
           batchScannerChannels,
           batchScanDirectionFlags,
           batchEdgeOfFlightLines,
+          typedExtraBytes: []
+        },
+        selectedPointIndices
+      );
+      const filteredExtraBytes = selectCOPCPointArray(
+        batchExtraBytes,
+        selectedPointIndices,
+        extraByteCount
+      );
+      const typedExtraBytes = filteredExtraBytes
+        ? createLASTypedExtraBytesAttributes(
+            filteredPointCount,
+            copc.extraBytesDescriptors,
+            extraByteCount
+          )
+        : [];
+      if (filteredExtraBytes) {
+        populateLASTypedExtraBytes(
+          filteredExtraBytes,
+          filteredPointCount,
+          extraByteCount,
+          typedExtraBytes
+        );
+      }
+      this.transformTilePositions(
+        filteredNativePositions,
+        filteredPositions,
+        nativeOrigin,
+        cartographicOrigin
+      );
+      yield this.createTileContentResult(
+        filteredPointCount,
+        filteredPositions,
+        filteredColors,
+        cartographicOrigin,
+        filteredNir,
+        {
+          ...filteredPointData,
           typedExtraBytes
         }
       );
-      decodedPointCount += decoded;
     }
   }
 
@@ -1565,6 +1642,77 @@ export class COPCTileSource
   */
 }
 
+/** Returns point indexes whose native positions fall inside inclusive scan bounds. */
+function getCOPCPointIndicesWithinBounds(
+  nativePositions: Float64Array,
+  pointCount: number,
+  bounds: PointCloudQueryBounds
+): number[] {
+  const pointIndices: number[] = [];
+  for (let pointIndex = 0; pointIndex < pointCount; pointIndex++) {
+    const positionIndex = pointIndex * 3;
+    if (
+      nativePositions[positionIndex] >= bounds.minimum[0] &&
+      nativePositions[positionIndex] <= bounds.maximum[0] &&
+      nativePositions[positionIndex + 1] >= bounds.minimum[1] &&
+      nativePositions[positionIndex + 1] <= bounds.maximum[1] &&
+      nativePositions[positionIndex + 2] >= bounds.minimum[2] &&
+      nativePositions[positionIndex + 2] <= bounds.maximum[2]
+    ) {
+      pointIndices.push(pointIndex);
+    }
+  }
+  return pointIndices;
+}
+
+/** Selects fixed-width values from a typed point-data array. */
+function selectCOPCPointArray<T extends Uint8Array | Uint16Array | Int16Array | Float64Array>(
+  values: T | null,
+  pointIndices: readonly number[],
+  itemSize: number
+): T | null {
+  if (!values) return null;
+  const TypedArrayConstructor = values.constructor as {new (length: number): T};
+  const selectedValues = new TypedArrayConstructor(pointIndices.length * itemSize);
+  for (let outputIndex = 0; outputIndex < pointIndices.length; outputIndex++) {
+    const inputIndex = pointIndices[outputIndex] * itemSize;
+    selectedValues.set(
+      values.subarray(inputIndex, inputIndex + itemSize) as T & ArrayLike<number>,
+      outputIndex * itemSize
+    );
+  }
+  return selectedValues;
+}
+
+/** Selects scalar point-data attributes while preserving their typed-array classes. */
+function filterCOPCPointData(
+  pointData: COPCPointDataArrays,
+  pointIndices: readonly number[]
+): COPCPointDataArrays {
+  return {
+    batchIntensities: selectCOPCPointArray(pointData.batchIntensities, pointIndices, 1),
+    batchClassifications: selectCOPCPointArray(pointData.batchClassifications, pointIndices, 1),
+    batchSyntheticFlags: selectCOPCPointArray(pointData.batchSyntheticFlags, pointIndices, 1),
+    batchKeyPointFlags: selectCOPCPointArray(pointData.batchKeyPointFlags, pointIndices, 1),
+    batchWithheldFlags: selectCOPCPointArray(pointData.batchWithheldFlags, pointIndices, 1),
+    batchOverlapFlags: selectCOPCPointArray(pointData.batchOverlapFlags, pointIndices, 1),
+    batchGpsTimes: selectCOPCPointArray(pointData.batchGpsTimes, pointIndices, 1),
+    batchScanAngles: selectCOPCPointArray(pointData.batchScanAngles, pointIndices, 1),
+    batchUserData: selectCOPCPointArray(pointData.batchUserData, pointIndices, 1),
+    batchPointSourceIds: selectCOPCPointArray(pointData.batchPointSourceIds, pointIndices, 1),
+    batchReturnNumbers: selectCOPCPointArray(pointData.batchReturnNumbers, pointIndices, 1),
+    batchNumberOfReturns: selectCOPCPointArray(pointData.batchNumberOfReturns, pointIndices, 1),
+    batchScannerChannels: selectCOPCPointArray(pointData.batchScannerChannels, pointIndices, 1),
+    batchScanDirectionFlags: selectCOPCPointArray(
+      pointData.batchScanDirectionFlags,
+      pointIndices,
+      1
+    ),
+    batchEdgeOfFlightLines: selectCOPCPointArray(pointData.batchEdgeOfFlightLines, pointIndices, 1),
+    typedExtraBytes: []
+  };
+}
+
 /** Returns the Arrow columns that this COPC source can decode selectively. */
 function getCOPCScanColumns(copc: COPCFile): COPCPointColumn[] {
   const columns: COPCPointColumn[] = ['POSITION'];
@@ -1597,6 +1745,58 @@ function getCOPCScanColumns(copc: COPCFile): COPCPointColumn[] {
   return columns;
 }
 
+/** Builds the canonical schema returned by the point-cloud scan API. */
+function getCOPCScanSchema(copc: COPCFile): Schema {
+  const scalarTypes: Partial<Record<COPCPointColumn, Field['type']>> = {
+    NIR: 'uint16',
+    intensity: 'uint16',
+    classification: 'uint8',
+    synthetic: 'uint8',
+    keyPoint: 'uint8',
+    withheld: 'uint8',
+    overlap: 'uint8',
+    GPS_TIME: 'float64',
+    scanAngle: 'int16',
+    userData: 'uint8',
+    pointSourceId: 'uint16',
+    returnNumber: 'uint8',
+    numberOfReturns: 'uint8',
+    scannerChannel: 'uint8',
+    scanDirectionFlag: 'uint8',
+    edgeOfFlightLine: 'uint8'
+  };
+  const extraBytes = getCOPCExtraByteCount(copc.header);
+  const fields = getCOPCScanColumns(copc).map((name): Field => {
+    if (name === 'POSITION') {
+      return {
+        name,
+        type: {type: 'fixed-size-list', listSize: 3, children: [{name: 'value', type: 'float32'}]},
+        nullable: false
+      };
+    }
+    if (name === 'COLOR_0') {
+      return {
+        name,
+        type: {type: 'fixed-size-list', listSize: 3, children: [{name: 'value', type: 'uint16'}]},
+        nullable: false
+      };
+    }
+    if (name === 'EXTRA_BYTES') {
+      return {
+        name,
+        type: {
+          type: 'fixed-size-list',
+          listSize: Math.max(extraBytes, 1),
+          children: [{name: 'value', type: 'uint8'}]
+        },
+        nullable: false
+      };
+    }
+    return {name, type: scalarTypes[name] || 'float64', nullable: false};
+  });
+  return {fields, metadata: {}};
+}
+
 /** Tests whether one hierarchy node can contribute to a point-cloud scan. */
 function isCOPCScanNodeSelected(
   copc: COPCFile,
@@ -1619,10 +1819,8 @@ function isCOPCScanNodeSelected(
       0,
       Math.min(31, Math.ceil(Math.log2(copc.info.spacing / options.targetSpacing)))
     );
-    if (
-      level !==
-      Math.max(options.minimumLevel ?? 0, Math.min(options.maximumLevel ?? 31, targetLevel))
-    ) {
+    const maximumSelectedLevel = Math.min(options.maximumLevel ?? 31, targetLevel);
+    if (level < (options.minimumLevel ?? 0) || level > maximumSelectedLevel) {
       return false;
     }
   }

--- a/modules/copc/src/copc-source-loader.ts
+++ b/modules/copc/src/copc-source-loader.ts
@@ -26,7 +26,12 @@ import {
   parseWithWorker,
   type ReadableFile
 } from '@loaders.gl/loader-utils';
-import {createScanQueryMetadata, type PointCloudQueryCapabilities} from '@loaders.gl/loader-utils';
+import {
+  createScanQueryMetadata,
+  validatePointCloudQueryOptions,
+  type PointCloudQueryCapabilities,
+  type PointCloudQueryOptions
+} from '@loaders.gl/loader-utils';
 import {Proj4Projection, type Proj4CRSDefinition} from '@math.gl/proj4';
 import {
   createLASTypedExtraBytesAttributes,
@@ -78,7 +83,7 @@ type GetNodeParameters = {
   limit?: number;
 };
 
-type COPCPointColumn =
+export type COPCPointColumn =
   | 'POSITION'
   | 'COLOR_0'
   | 'NIR'
@@ -118,6 +123,16 @@ type COPCPointSelection = {
   scanDirectionFlag: boolean;
   edgeOfFlightLine: boolean;
   extraBytes: boolean;
+};
+
+/** Options for scanning COPC point data with hierarchy pushdown. */
+export type COPCScanOptions = PointCloudQueryOptions & {
+  /** Maximum number of points yielded in one Arrow batch. */
+  batchSize?: number;
+  /** Byte size for progressive node range requests. */
+  rangeChunkSize?: number;
+  /** Maximum number of node ranges fetched ahead of decode. */
+  rangeConcurrency?: number;
 };
 
 type COPCPointDataArrays = {
@@ -276,8 +291,8 @@ export class COPCTileSource
   /** Common point-cloud scan capabilities exposed by COPC. */
   readonly pointCloudQueryCapabilities: PointCloudQueryCapabilities = Object.freeze({
     projection: 'pushdown',
-    predicate: 'residual',
-    limit: 'residual',
+    predicate: 'unsupported',
+    limit: 'pushdown+residual',
     streaming: true,
     cancellation: true,
     bounds: 'pushdown',
@@ -359,6 +374,78 @@ export class COPCTileSource
       },
       statistics: {rowCount: copc.header.pointCount}
     });
+  }
+
+  /**
+   * Scan COPC points using hierarchy-level spatial and resolution pushdown.
+   *
+   * Bounds and level constraints are applied before node byte ranges are
+   * requested. The optional limit is exact and stops decoding once enough
+   * rows have been yielded. Predicate evaluation is intentionally rejected
+   * until a zero-copy Arrow residual filter is available.
+   */
+  async *scan(options: COPCScanOptions = {}): AsyncIterable<COPCTileContent> {
+    const {copc} = await this._initPromise;
+    const sourceColumns = getCOPCScanColumns(copc);
+    validatePointCloudQueryOptions(sourceColumns, options);
+    if (options.predicate) {
+      throw new Error('COPC scan predicates are not supported yet');
+    }
+    if (options.signal?.aborted) {
+      throw new Error('COPC scan was aborted');
+    }
+
+    // Load only hierarchy pages and keep point-data ranges deferred until the
+    // spatial and LOD filters have selected concrete nodes.
+    for await (const _page of this.loadHierarchyInBatches({signal: options.signal})) {
+      // Traversal updates the source hierarchy cache as pages arrive.
+    }
+
+    const selectedColumns = options.columns
+      ? ([
+          'POSITION',
+          ...options.columns.filter(column => column !== 'POSITION')
+        ] as COPCPointColumn[])
+      : getCOPCScanColumns(copc);
+    const selectedNodes = Object.entries(this._hierarchy?.nodes || {})
+      .filter(
+        ([tileId, node]) =>
+          node !== undefined && isCOPCScanNodeSelected(copc, tileId, node, options)
+      )
+      .sort(([firstTileId], [secondTileId]) => compareCOPCScanNodes(firstTileId, secondTileId));
+
+    let remaining = options.limit ?? Number.MAX_SAFE_INTEGER;
+    if (remaining === 0) {
+      return;
+    }
+    for (const [tileId] of selectedNodes) {
+      if (remaining <= 0) {
+        return;
+      }
+      if (options.signal?.aborted) {
+        throw new Error('COPC scan was aborted');
+      }
+      // A bounded scan uses one final batch sized to the remaining limit. This
+      // keeps the limit exact even when a node contains more points than the
+      // caller's preferred batch size.
+      const nodeBatchSize = options.limit === undefined ? (options.batchSize ?? 65536) : remaining;
+      for await (const batch of this.loadTileContentInBatches(
+        {id: tileId},
+        {
+          batchSize: nodeBatchSize,
+          columns: selectedColumns,
+          rangeChunkSize: options.rangeChunkSize,
+          rangeConcurrency: options.rangeConcurrency,
+          signal: options.signal
+        }
+      )) {
+        yield batch;
+        remaining -= batch.pointCount;
+        if (remaining === 0) {
+          return;
+        }
+      }
+    }
   }
 
   async getMetadata(): Promise<COPCMetadata> {
@@ -1476,6 +1563,88 @@ export class COPCTileSource
     }
   }
   */
+}
+
+/** Returns the Arrow columns that this COPC source can decode selectively. */
+function getCOPCScanColumns(copc: COPCFile): COPCPointColumn[] {
+  const columns: COPCPointColumn[] = ['POSITION'];
+  if (pointFormatHasColor(copc.header.pointDataRecordFormat)) {
+    columns.push('COLOR_0');
+  }
+  if (copc.header.pointDataRecordFormat === 8) {
+    columns.push('NIR');
+  }
+  columns.push(
+    'intensity',
+    'classification',
+    'synthetic',
+    'keyPoint',
+    'withheld',
+    'overlap',
+    'GPS_TIME',
+    'scanAngle',
+    'userData',
+    'pointSourceId',
+    'returnNumber',
+    'numberOfReturns',
+    'scannerChannel',
+    'scanDirectionFlag',
+    'edgeOfFlightLine'
+  );
+  if (copc.extraBytesDescriptors.length > 0) {
+    columns.push('EXTRA_BYTES');
+  }
+  return columns;
+}
+
+/** Tests whether one hierarchy node can contribute to a point-cloud scan. */
+function isCOPCScanNodeSelected(
+  copc: COPCFile,
+  tileId: string,
+  node: COPCHierarchyNode,
+  options: COPCScanOptions
+): boolean {
+  if (node.pointCount === 0) {
+    return false;
+  }
+  const [level] = parseCOPCKey(tileId);
+  if (options.minimumLevel !== undefined && level < options.minimumLevel) {
+    return false;
+  }
+  if (options.maximumLevel !== undefined && level > options.maximumLevel) {
+    return false;
+  }
+  if (options.targetSpacing !== undefined) {
+    const targetLevel = Math.max(
+      0,
+      Math.min(31, Math.ceil(Math.log2(copc.info.spacing / options.targetSpacing)))
+    );
+    if (
+      level !==
+      Math.max(options.minimumLevel ?? 0, Math.min(options.maximumLevel ?? 31, targetLevel))
+    ) {
+      return false;
+    }
+  }
+  if (options.bounds) {
+    const nodeBounds = getCOPCKeyBounds(copc.info.cube, parseCOPCKey(tileId));
+    for (let dimension = 0; dimension < 3; dimension++) {
+      if (
+        nodeBounds[dimension + 3] < options.bounds.minimum[dimension] ||
+        nodeBounds[dimension] > options.bounds.maximum[dimension]
+      ) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+/** Orders scan nodes from coarse to fine, then by stable hierarchy key. */
+function compareCOPCScanNodes(firstTileId: string, secondTileId: string): number {
+  const firstLevel = parseCOPCKey(firstTileId)[0];
+  const secondLevel = parseCOPCKey(secondTileId)[0];
+  return firstLevel - secondLevel || firstTileId.localeCompare(secondTileId);
 }
 
 /** Builds the query schema from COPC point-data and Extra Bytes metadata. */

--- a/modules/copc/src/index.ts
+++ b/modules/copc/src/index.ts
@@ -8,7 +8,9 @@ export type {
   COPCHierarchyBatchOptions,
   COPCTileContent,
   COPCTileContentBatchOptions,
-  COPCTileContentLoadOptions
+  COPCTileContentLoadOptions,
+  COPCScanOptions,
+  COPCPointColumn
 } from './copc-source-loader';
 export type {COPCWriterOptions} from './copc-writer';
 export {COPCFormat} from './copc-format';

--- a/modules/copc/test/copc-source.spec.ts
+++ b/modules/copc/test/copc-source.spec.ts
@@ -118,8 +118,25 @@ vitestTest('COPCSourceLoader#scans selected Arrow columns with an exact limit', 
     expect(batch.data.data.getChild('COLOR_0')).toBeNull();
   }
 
-  expect(batches.length).toBe(1);
+  expect(batches.map(batch => batch.pointCount)).toEqual([7, 7, 7, 2]);
   expect(pointCount).toBe(23);
+});
+
+vitestTest('COPCSourceLoader#exposes scan columns through query metadata', async () => {
+  const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {});
+  const metadata = await source.getQueryMetadata();
+  const columnNames = metadata.schema.fields.map(field => field.name);
+
+  expect(columnNames).toContain('POSITION');
+  expect(columnNames).toContain('intensity');
+  expect(columnNames).not.toContain('X');
+  expect(metadata.capabilities.table?.projection).toBe('pushdown');
+
+  const requestedColumns = ['POSITION', 'intensity'] as const;
+  for await (const batch of source.scan({columns: requestedColumns, limit: 1})) {
+    expect(batch.data.data.getChild('POSITION')).toBeTruthy();
+    expect(batch.data.data.getChild('intensity')).toBeTruthy();
+  }
 });
 
 vitestTest('COPCSourceLoader#prunes scans by hierarchy level and bounds', async () => {

--- a/modules/copc/test/copc-source.spec.ts
+++ b/modules/copc/test/copc-source.spec.ts
@@ -102,6 +102,46 @@ test('COPCSourceLoader#loads full point content for a tile', async t => {
   t.end();
 });
 
+vitestTest('COPCSourceLoader#scans selected Arrow columns with an exact limit', async () => {
+  const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {});
+  const batches = [];
+  let pointCount = 0;
+  for await (const batch of source.scan({
+    columns: ['POSITION'],
+    batchSize: 7,
+    limit: 23
+  })) {
+    batches.push(batch);
+    pointCount += batch.pointCount;
+    expect(batch.data.shape).toBe('arrow-table');
+    expect(batch.data.data.getChild('POSITION')).toBeTruthy();
+    expect(batch.data.data.getChild('COLOR_0')).toBeNull();
+  }
+
+  expect(batches.length).toBe(1);
+  expect(pointCount).toBe(23);
+});
+
+vitestTest('COPCSourceLoader#prunes scans by hierarchy level and bounds', async () => {
+  const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {});
+  const metadata = await source.getMetadata();
+  const {header} = metadata.formatSpecificMetadata;
+  let pointCount = 0;
+  for await (const batch of source.scan({
+    columns: ['POSITION'],
+    minimumLevel: 0,
+    maximumLevel: 0,
+    bounds: {
+      minimum: [header.min[0], header.min[1], header.min[2]],
+      maximum: [header.max[0], header.max[1], header.max[2]]
+    }
+  })) {
+    pointCount += batch.pointCount;
+  }
+
+  expect(pointCount).toBeGreaterThan(0);
+});
+
 test('COPCSourceLoader#loads tile content with TypeScript LAZ decoder', async t => {
   const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {});
   await source.initialize();


### PR DESCRIPTION
Goals:
- Add a native COPC spatial and level-of-detail scan API.
- Push bounds and hierarchy constraints before point-data range requests.
- Preserve Arrow-table output, selective columns, cancellation, and exact limits.

Changes:
- Add `COPCTileSource.scan()` with bounds, minimum/maximum level, target spacing, projection, batch, range, and cancellation options.
- Export `COPCScanOptions` and `COPCPointColumn`.
- Select and order non-empty hierarchy nodes before decoding.
- Advertise predicate support honestly as unsupported until a zero-copy Arrow residual filter is available.
- Add focused tests for exact limits, Arrow projection, hierarchy levels, and bounds.

Testing:
- `yarn lint fix` passed.
- Focused headless tests for the new scan cases passed.
- The full COPC browser spec retains pre-existing worker-bundle failures when `modules/las/dist/las-worker.js` is unavailable in the worktree.