### PR TITLE
test: expand GIS binary utility coverage

### DIFF
--- a/modules/gis/test/utils/binary-reader-writer.spec.ts
+++ b/modules/gis/test/utils/binary-reader-writer.spec.ts
@@ -1,0 +1,77 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+import {BinaryReader} from '../../src/lib/utils/binary-reader';
+import {BinaryWriter} from '../../src/lib/utils/binary-writer';
+
+describe('BinaryReader', () => {
+  test('reads primitive values with little-endian encoding', () => {
+    const writer = new BinaryWriter(32);
+    writer.writeUInt8(0xfe);
+    writer.writeUInt16LE(0x1234);
+    writer.writeUInt32LE(0x12345678);
+    writer.writeInt8(-2);
+    writer.writeInt16LE(-1234);
+    writer.writeInt32LE(-12345678);
+    writer.writeFloatLE(1.25);
+    writer.writeDoubleLE(Math.PI);
+
+    const reader = new BinaryReader(writer.getArrayBuffer());
+    expect(reader.readUInt8()).toBe(0xfe);
+    expect(reader.readUInt16()).toBe(0x1234);
+    expect(reader.readUInt32()).toBe(0x12345678);
+    expect(reader.readInt8()).toBe(-2);
+    expect(reader.readInt16()).toBe(-1234);
+    expect(reader.readInt32()).toBe(-12345678);
+    expect(reader.readFloat()).toBeCloseTo(1.25);
+    expect(reader.readDouble()).toBe(Math.PI);
+    expect(reader.byteOffset).toBe(26);
+  });
+
+  test('reads big-endian values and variable-length integers', () => {
+    const writer = new BinaryWriter(32);
+    writer.writeUInt16BE(0x1234);
+    writer.writeUInt32BE(0x12345678);
+    writer.writeInt16BE(-1234);
+    writer.writeInt32BE(-12345678);
+    writer.writeFloatBE(1.25);
+    writer.writeDoubleBE(Math.PI);
+
+    const reader = new BinaryReader(writer.getArrayBuffer(), true);
+    expect(reader.readUInt16()).toBe(0x1234);
+    expect(reader.readUInt32()).toBe(0x12345678);
+    expect(reader.readInt16()).toBe(-1234);
+    expect(reader.readInt32()).toBe(-12345678);
+    expect(reader.readFloat()).toBeCloseTo(1.25);
+    expect(reader.readDouble()).toBe(Math.PI);
+
+    const variableLengthReader = new BinaryReader(new Uint8Array([0xac, 0x02, 0x01]).buffer);
+    expect(variableLengthReader.readVarInt()).toBe(300);
+    expect(variableLengthReader.readVarInt()).toBe(1);
+  });
+});
+
+describe('BinaryWriter', () => {
+  test('writes typed arrays and buffers while returning only written bytes', () => {
+    const writer = new BinaryWriter(32);
+    writer.writeTypedArray(new Uint8Array([1, 2, 3]));
+    writer.writeBuffer(new Uint8Array([4, 5]).buffer);
+
+    expect(Array.from(new Uint8Array(writer.getArrayBuffer()))).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  test('encodes variable-length integers and grows when enabled', () => {
+    const writer = new BinaryWriter(1, true);
+    expect(writer.writeVarInt(300)).toBe(2);
+    expect(writer.writeVarInt(1)).toBe(1);
+    expect(Array.from(new Uint8Array(writer.getArrayBuffer()))).toEqual([0xac, 0x02, 0x01]);
+  });
+
+  test('rejects overflow when resizing is disabled', () => {
+    const writer = new BinaryWriter(1);
+    writer.writeUInt8(1);
+    expect(() => writer.writeUInt8(2)).toThrow('BinaryWriter overflow');
+  });
+});

--- a/modules/gis/test/utils/hex-transcoder.spec.ts
+++ b/modules/gis/test/utils/hex-transcoder.spec.ts
@@ -1,38 +1,32 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {HexWKBLoader} from '@loaders.gl/wkt';
-
+import {decodeHex, encodeHex} from '../../src/lib/utils/hex-transcoder';
 const isHexWKB = HexWKBLoader.testText;
-
-test('datasetUtils.isHexWKB', t => {
-  t.notOk(isHexWKB(''), 'empty string is not a valid hex wkb');
-
+test('datasetUtils.isHexWKB', () => {
+  expect(isHexWKB(''), 'empty string is not a valid hex wkb').toBeFalsy();
   // @ts-ignore null is not a string
-  t.notOk(isHexWKB(null), 'null is not a valid hex wkb');
-
+  expect(isHexWKB(null), 'null is not a valid hex wkb').toBeFalsy();
   const countyFIPS = '06075';
-  t.notOk(isHexWKB(countyFIPS), 'FIPS code should not be a valid hex wkb');
-
+  expect(isHexWKB(countyFIPS), 'FIPS code should not be a valid hex wkb').toBeFalsy();
   const h3Code = '8a2a1072b59ffff';
-  t.notOk(isHexWKB(h3Code), 'H3 code should not be a valid hex wkb');
-
+  expect(isHexWKB(h3Code), 'H3 code should not be a valid hex wkb').toBeFalsy();
   const randomHexStr = '8a2a1072b59ffff';
-  t.notOk(isHexWKB(randomHexStr), 'A random hex string should not be a valid hex wkb');
-
+  expect(isHexWKB(randomHexStr), 'A random hex string should not be a valid hex wkb').toBeFalsy();
   const validWkt = '0101000000000000000000f03f0000000000000040';
-  t.ok(isHexWKB(validWkt), 'A valid hex wkb should be valid');
-
+  expect(isHexWKB(validWkt), 'A valid hex wkb should be valid').toBeTruthy();
   const validEWkt = '0101000020e6100000000000000000f03f0000000000000040';
-  t.ok(isHexWKB(validEWkt), 'A valid hex ewkb should be valid');
-
+  expect(isHexWKB(validEWkt), 'A valid hex ewkb should be valid').toBeTruthy();
   const validWktNDR = '00000000013ff0000000000000400000000000000040';
-  t.ok(isHexWKB(validWktNDR), 'A valid hex wkb in NDR should be valid');
-
+  expect(isHexWKB(validWktNDR), 'A valid hex wkb in NDR should be valid').toBeTruthy();
   const validEWktNDR = '0020000001000013ff0000000000400000000000000040';
-  t.ok(isHexWKB(validEWktNDR), 'A valid hex ewkb in NDR should be valid');
+  expect(isHexWKB(validEWktNDR), 'A valid hex ewkb in NDR should be valid').toBeTruthy();
+});
 
-  t.end();
+test('hex transcoder round-trips bytes and handles empty input', () => {
+  const bytes = new Uint8Array([0, 1, 15, 16, 127, 128, 255]);
+
+  expect(encodeHex(bytes)).toBe('00010f107f80ff');
+  expect(Array.from(decodeHex('00010f107f80ff'))).toEqual(Array.from(bytes));
+  expect(encodeHex(new Uint8Array())).toBe('');
+  expect(Array.from(decodeHex(''))).toEqual([]);
 });


### PR DESCRIPTION
## Goals

- Continue moving loaders.gl coverage toward 90% with compact, high-signal tests.
- Convert another remaining Tape test to native Vitest without increasing CI test cost.

## Changes

- Add native Vitest coverage for GIS BinaryReader primitive, endian, and varint decoding.
- Add native Vitest coverage for GIS BinaryWriter primitive storage, typed arrays, buffers, varints, resizing, and overflow behavior.
- Convert the GIS hex-transcoder test from Tape to Vitest.
- Add direct hex encode/decode round-trip and empty-input assertions.
- Avoid 3D Tiles entirely.

## Validation

- Focused Chromium tests: 7 passed.
- BinaryReader statement coverage: 100% (36/36).
- BinaryWriter statement coverage: 100% (76/76).
- Test audit: 585 files, 0 Tape, 0 violations.
- `yarn lint fix` and `git diff --check` clean.