### PR TITLE
feat(scan): add portable unions and joins

### DIFF
--- a/docs/developer-guide/common-scan-architecture.md
+++ b/docs/developer-guide/common-scan-architecture.md
@@ -682,10 +682,10 @@ The roadmap is therefore format-support-first. Each tranche must ship three thin
    but expose shared discovery, bounds, time, level-of-detail, explain, and cancellation metadata.
    Where a source returns feature tables (for example MVT or WFS), offer an explicit table-scan view;
    keep tile addressing and rendering controls outside `TableQuery`.
-7. **Portable relational growth — first slice landed.** Arrow and DuckDB now execute the shared
-   ordering, scalar-expression, and grouped-aggregate request shape. The next slice is unions and
-   equi-joins, which must retain source ordering, duplicate-column rules, and explicit join semantics
-   across at least two backends before they become part of the default panel.
+7. **Portable relational growth — second slice landed.** Arrow and DuckDB now execute the shared
+   ordering, scalar-expression, grouped-aggregate, `UNION ALL`, and equi-join request shapes. The
+   next slice is planner-level source resolution and duplicate-column naming for larger federated
+   plans before these operators become part of the default panel.
 8. **GPU and acceleration.** Lower the same plan to luma.gl/WGSL masks or indices, add deferred or
    materialized compaction, and compare GPU/CPU explain telemetry. Add spatial predicates and nearest
    neighbor only when indexed CPU, GPU, and remote-source strategies have compatible semantics.
@@ -747,8 +747,10 @@ const query = {
 The Arrow executor remains intentionally row-oriented for this proof of concept: it materializes
 only the rows needed by the relational operators and returns a bounded Arrow table. This gives
 format adapters and the GPU executor a conformance target without committing them to the same
-physical implementation. Union and join planning remains metadata-only until child-source
-resolution and duplicate-column naming are standardized.
+physical implementation. In-memory unions resolve named child tables through an explicit table map;
+joins expose child fields with a source-qualified name and use SQL inner-join null semantics. SQL
+backends compile the same child relations to `UNION ALL` and qualified `JOIN` statements, leaving
+source registration and federated catalog resolution to the next tranche.
 
 ## Point-cloud participation
 

--- a/modules/sql/src/compile-table-query.ts
+++ b/modules/sql/src/compile-table-query.ts
@@ -17,6 +17,14 @@ import type {
   RelationalOrderKey
 } from '@loaders.gl/loader-utils';
 
+/** A named child relation using the SQL module's property-oriented predicate AST. */
+type SQLChildQuery = Readonly<{
+  /** Logical source name resolved by the SQL data source. */
+  source: string;
+  /** Optional query applied to the child relation before combining it. */
+  query?: TableQueryOptions;
+}>;
+
 /** SQL dialects supported by the portable table-query compiler. */
 export type SQLTableQueryDialect = 'duckdb' | 'snowflake';
 
@@ -37,6 +45,10 @@ export type SQLTableQuery = TableQueryOptions &
     groupBy?: readonly string[];
     /** Aggregate output definitions. */
     aggregates?: readonly RelationalAggregate[];
+    /** Additional tables concatenated with `UNION ALL`. */
+    union?: readonly SQLChildQuery[];
+    /** Optional equi-join child table and key mapping. */
+    join?: Readonly<{child: SQLChildQuery; left: string; right: string}>;
   }>;
 
 /** Options controlling portable table-query compilation. */
@@ -72,25 +84,57 @@ export function compileSQLTableQuery(
     namedParameters: options.parameters,
     parameters: []
   };
+  return {
+    sql: compileTableStatement(query, context),
+    parameters: context.parameters
+  };
+}
+
+/** Compiles one table statement while sharing parameter bindings with child relations. */
+function compileTableStatement(query: SQLTableQuery, context: SQLCompilationContext): string {
   const projection = compileProjection(query);
   const table = [query.catalogName, query.schemaName, query.tableName]
     .filter((identifier): identifier is string => identifier !== undefined)
     .map(quoteSQLIdentifier)
     .join('.');
-  const clauses = [`SELECT ${projection}`, `FROM ${table}`];
+  const fromClause = query.join ? compileJoinFromClause(query, table, context) : `FROM ${table}`;
+  const clauses = [`SELECT ${projection}`, fromClause];
   if (query.predicate) {
     clauses.push(`WHERE ${compileSQLPredicate(query.predicate, context)}`);
   }
   if (query.groupBy?.length) {
     clauses.push(`GROUP BY ${query.groupBy.map(quoteSQLIdentifier).join(', ')}`);
   }
-  if (query.orderBy?.length) {
-    clauses.push(`ORDER BY ${query.orderBy.map(compileOrderKey).join(', ')}`);
+  let sql = clauses.join('\n');
+  for (const child of query.union || []) {
+    const childQuery: SQLTableQuery = {
+      tableName: child.source,
+      ...(child.query || {})
+    };
+    validateSQLTableQuery(childQuery);
+    sql = `${sql}\nUNION ALL\n${compileTableStatement(childQuery, context)}`;
   }
-  if (query.limit !== undefined) {
-    clauses.push(`LIMIT ${query.limit}`);
-  }
-  return {sql: clauses.join('\n'), parameters: context.parameters};
+  if (query.orderBy?.length) sql += `\nORDER BY ${query.orderBy.map(compileOrderKey).join(', ')}`;
+  if (query.limit !== undefined) sql += `\nLIMIT ${query.limit}`;
+  return sql;
+}
+
+/** Compiles a base table and optional child relation for an equi-join. */
+function compileJoinFromClause(
+  query: SQLTableQuery,
+  table: string,
+  context: SQLCompilationContext
+): string {
+  const join = query.join;
+  if (!join) return `FROM ${table}`;
+  validateSQLIdentifier(join.child.source);
+  validateSQLIdentifier(join.left);
+  validateSQLIdentifier(join.right);
+  const childTable = quoteSQLIdentifier(join.child.source);
+  const rightRelation = join.child.query
+    ? `(${compileTableStatement({tableName: join.child.source, ...join.child.query}, context)})`
+    : childTable;
+  return `FROM ${table} JOIN ${rightRelation} AS ${childTable} ON ${table}.${quoteSQLIdentifier(join.left)} = ${childTable}.${quoteSQLIdentifier(join.right)}`;
 }
 
 /** Compiles the SELECT list, including computed and aggregate output columns. */

--- a/modules/sql/src/compile-table-query.ts
+++ b/modules/sql/src/compile-table-query.ts
@@ -112,7 +112,9 @@ function compileTableStatement(query: SQLTableQuery, context: SQLCompilationCont
       ...(child.query || {})
     };
     validateSQLTableQuery(childQuery);
-    sql = `${sql}\nUNION ALL\n${compileTableStatement(childQuery, context)}`;
+    const childSQL = compileTableStatement(childQuery, context);
+    const branchSQL = hasBranchLocalModifiers(childQuery) ? `(${childSQL})` : childSQL;
+    sql = `${sql}\nUNION ALL\n${branchSQL}`;
   }
   if (query.orderBy?.length) sql += `\nORDER BY ${query.orderBy.map(compileOrderKey).join(', ')}`;
   if (query.limit !== undefined) sql += `\nLIMIT ${query.limit}`;
@@ -155,7 +157,7 @@ function compileProjection(query: SQLTableQuery): string {
     const aggregate = aggregateByName.get(column);
     return aggregate
       ? `${compileAggregate(aggregate)} AS ${quoteSQLIdentifier(aggregate.name)}`
-      : quoteSQLIdentifier(column);
+      : compileProjectionColumn(column, query);
   });
   if (!selections.length)
     return expressions.length
@@ -173,6 +175,19 @@ function compileProjection(query: SQLTableQuery): string {
             .join(', ')
         : '*';
   return selections.join(', ');
+}
+
+/** Quotes a projection column, qualifying joined child fields component-wise. */
+function compileProjectionColumn(column: string, query: SQLTableQuery): string {
+  const childSource = query.join?.child.source;
+  return childSource && column.startsWith(`${childSource}.`)
+    ? column.split('.').map(quoteSQLIdentifier).join('.')
+    : quoteSQLIdentifier(column);
+}
+
+/** Returns whether a UNION child contains modifiers that must remain branch-local. */
+function hasBranchLocalModifiers(query: SQLTableQuery): boolean {
+  return Boolean(query.limit !== undefined || query.orderBy?.length || query.union?.length);
 }
 
 /** Compiles one portable scalar expression into quoted SQL. */

--- a/modules/sql/src/query-arrow-table.ts
+++ b/modules/sql/src/query-arrow-table.ts
@@ -36,6 +36,14 @@ import type {
 import {planRelationalQuery} from '@loaders.gl/loader-utils';
 export {ARROW_TABLE_QUERY_CAPABILITIES} from './table-query-capabilities';
 
+/** A named child relation using the SQL module's property-oriented predicate AST. */
+type ArrowChildQuery = Readonly<{
+  /** Logical source name resolved through the query's table map. */
+  source: string;
+  /** Optional query applied to the child relation before combining it. */
+  query?: TableQueryOptions;
+}>;
+
 /** Options for the lightweight in-memory Arrow query executor. */
 export type ArrowQueryOptions = TableQueryOptions &
   Readonly<{
@@ -49,6 +57,12 @@ export type ArrowQueryOptions = TableQueryOptions &
     groupBy?: readonly string[];
     /** Aggregate definitions evaluated after filtering and expressions. */
     aggregates?: readonly RelationalAggregate[];
+    /** Additional Arrow tables concatenated in source order before relational operators. */
+    union?: readonly ArrowChildQuery[];
+    /** Optional equi-join against a table supplied in `tables`. */
+    join?: Readonly<{child: ArrowChildQuery; left: string; right: string}>;
+    /** Named in-memory child tables used by union and join operators. */
+    tables?: Readonly<Record<string, ArrowTable>>;
   }>;
 
 /** Explains an Arrow table query without materializing or scanning table rows. */
@@ -74,6 +88,13 @@ export function queryArrowTable(
   options: ArrowQueryOptions = {}
 ): ArrowTable {
   throwIfAborted(options.signal);
+
+  if (options.join && hasRelationalOperatorsExceptJoin(options)) {
+    throw new Error('Arrow joins cannot yet be combined with other relational operators.');
+  }
+  if (options.join && !hasRelationalOperatorsExceptJoin(options)) {
+    return queryArrowJoin(sourceTable, options);
+  }
 
   if (hasRelationalOperators(options)) {
     return queryArrowTableRelational(sourceTable, options);
@@ -128,7 +149,8 @@ function queryArrowTableRelational(
 ): ArrowTable {
   const sourceData = sourceTable.data;
   const sourceColumnNames = sourceData.schema.fields.map(field => field.name);
-  const relationalPlan = planRelationalQuery(sourceColumnNames, options);
+  // The shared planner is predicate-generic; this executor supplies the narrower SQL AST.
+  const relationalPlan = planRelationalQuery(sourceColumnNames, options as never);
   const scanStep = relationalPlan.tablePlan.find(step => step.kind === 'scan');
   if (!scanStep || scanStep.kind !== 'scan') {
     throw new Error('Arrow relational query plan is missing a scan step.');
@@ -140,6 +162,17 @@ function queryArrowTableRelational(
     signal: options.signal
   });
   let rows = arrowTableToRows(filteredTable.data);
+
+  for (const child of options.union || []) {
+    const childTable = options.tables?.[child.source];
+    if (!childTable) throw new Error(`Arrow union source not found: ${child.source}`);
+    const childResult = queryArrowTable(childTable, {
+      ...(child.query || {}),
+      columns: scanStep.columns,
+      signal: options.signal
+    });
+    rows = rows.concat(arrowTableToRows(childResult.data));
+  }
 
   for (const expression of options.expressions || []) {
     for (const row of rows) {
@@ -187,8 +220,72 @@ function hasRelationalOperators(options: ArrowQueryOptions): boolean {
     options.expressions?.length ||
       options.orderBy?.length ||
       options.groupBy?.length ||
-      options.aggregates?.length
+      options.aggregates?.length ||
+      options.union?.length ||
+      options.join
   );
+}
+
+/** Returns whether a join is the only relational operator requested. */
+function hasRelationalOperatorsExceptJoin(options: ArrowQueryOptions): boolean {
+  return Boolean(
+    options.expressions?.length ||
+      options.orderBy?.length ||
+      options.groupBy?.length ||
+      options.aggregates?.length ||
+      options.union?.length
+  );
+}
+
+/** Executes a bounded nested-loop equi-join for small in-memory Arrow proof-of-concept tables. */
+function queryArrowJoin(sourceTable: ArrowTable, options: ArrowQueryOptions): ArrowTable {
+  const join = options.join;
+  if (!join) throw new Error('Arrow join query is missing a join definition.');
+  const childTable = options.tables?.[join.child.source];
+  if (!childTable) throw new Error(`Arrow join source not found: ${join.child.source}`);
+  const leftResult = queryArrowTable(sourceTable, {
+    predicate: options.predicate,
+    columns: undefined,
+    signal: options.signal
+  });
+  const rightResult = queryArrowTable(childTable, {
+    ...(join.child.query || {}),
+    signal: options.signal
+  });
+  const leftRows = arrowTableToRows(leftResult.data);
+  const rightRows = arrowTableToRows(rightResult.data);
+  const rightPrefix = `${join.child.source}.`;
+  const defaultOutputColumns = [
+    ...sourceTable.data.schema.fields.map(field => field.name),
+    ...rightResult.data.schema.fields.map(field => `${rightPrefix}${field.name}`)
+  ];
+  const rows: Record<string, unknown>[] = [];
+  for (const leftRow of leftRows) {
+    for (const rightRow of rightRows) {
+      if (
+        leftRow[join.left] !== null &&
+        leftRow[join.left] !== undefined &&
+        rightRow[join.right] !== null &&
+        rightRow[join.right] !== undefined &&
+        compareSortValues(leftRow[join.left], rightRow[join.right]) === 0
+      ) {
+        rows.push({
+          ...leftRow,
+          ...Object.fromEntries(
+            Object.entries(rightRow).map(([key, value]) => [`${rightPrefix}${key}`, value])
+          )
+        });
+      }
+    }
+  }
+  const outputColumns = options.columns || defaultOutputColumns;
+  const outputRows = rows.map(row =>
+    Object.fromEntries(outputColumns.map(column => [column, row[column]]))
+  );
+  const limitedRows = outputRows.slice(0, options.limit);
+  return limitedRows.length
+    ? convertRowsToArrowTable(limitedRows)
+    : createEmptyRelationalResult(sourceTable.data, outputColumns, options);
 }
 
 /** Materializes one Arrow table into row objects for the relational proof of concept. */

--- a/modules/sql/src/query-arrow-table.ts
+++ b/modules/sql/src/query-arrow-table.ts
@@ -89,6 +89,10 @@ export function queryArrowTable(
 ): ArrowTable {
   throwIfAborted(options.signal);
 
+  if (options.join) {
+    validateArrowJoinQuery(sourceTable, options);
+  }
+
   if (options.join && hasRelationalOperatorsExceptJoin(options)) {
     throw new Error('Arrow joins cannot yet be combined with other relational operators.');
   }
@@ -168,7 +172,7 @@ function queryArrowTableRelational(
     if (!childTable) throw new Error(`Arrow union source not found: ${child.source}`);
     const childResult = queryArrowTable(childTable, {
       ...(child.query || {}),
-      columns: scanStep.columns,
+      columns: getUnionChildColumns(sourceColumnNames, options),
       signal: options.signal
     });
     rows = rows.concat(arrowTableToRows(childResult.data));
@@ -212,6 +216,42 @@ function queryArrowTableRelational(
   return limitedRows.length
     ? convertRowsToArrowTable(limitedRows)
     : createEmptyRelationalResult(sourceData, outputColumns, options);
+}
+
+/** Derives the source columns a UNION child needs without inheriting base-only predicate columns. */
+function getUnionChildColumns(
+  sourceColumnNames: readonly string[],
+  options: ArrowQueryOptions
+): string[] {
+  const expressionNames = new Set((options.expressions || []).map(expression => expression.name));
+  const aggregateNames = new Set((options.aggregates || []).map(aggregate => aggregate.name));
+  const outputColumns =
+    options.columns ||
+    (options.groupBy?.length || options.aggregates?.length
+      ? [...(options.groupBy || []), ...(options.aggregates || []).map(aggregate => aggregate.name)]
+      : sourceColumnNames);
+  const requiredColumns = new Set(
+    outputColumns.filter(column => !expressionNames.has(column) && !aggregateNames.has(column))
+  );
+
+  for (const expression of options.expressions || []) {
+    const definition = expression.expression;
+    if (definition.op === 'column') requiredColumns.add(definition.column);
+    if ('left' in definition) {
+      requiredColumns.add(definition.left);
+      requiredColumns.add(definition.right);
+    }
+  }
+  for (const key of options.orderBy || []) {
+    if (!expressionNames.has(key.column) && !aggregateNames.has(key.column)) {
+      requiredColumns.add(key.column);
+    }
+  }
+  for (const column of options.groupBy || []) requiredColumns.add(column);
+  for (const aggregate of options.aggregates || []) {
+    if (aggregate.column) requiredColumns.add(aggregate.column);
+  }
+  return sourceColumnNames.filter(column => requiredColumns.has(column));
 }
 
 /** Returns whether the query uses any in-memory relational operator. */
@@ -285,7 +325,70 @@ function queryArrowJoin(sourceTable: ArrowTable, options: ArrowQueryOptions): Ar
   const limitedRows = outputRows.slice(0, options.limit);
   return limitedRows.length
     ? convertRowsToArrowTable(limitedRows)
-    : createEmptyRelationalResult(sourceTable.data, outputColumns, options);
+    : createEmptyRelationalResult(
+        sourceTable.data,
+        outputColumns,
+        options,
+        new Map(
+          rightResult.data.schema.fields.map(field => [
+            `${rightPrefix}${field.name}`,
+            new arrow.Field(
+              `${rightPrefix}${field.name}`,
+              field.type,
+              field.nullable,
+              field.metadata
+            )
+          ])
+        )
+      );
+}
+
+/** Validates root and child projections before dispatching to the join executor. */
+function validateArrowJoinQuery(sourceTable: ArrowTable, options: ArrowQueryOptions): void {
+  const join = options.join;
+  if (!join) return;
+  const sourceColumnNames = sourceTable.data.schema.fields.map(field => field.name);
+  const childTable = options.tables?.[join.child.source];
+  if (!childTable) throw new Error(`Arrow join source not found: ${join.child.source}`);
+  const childColumnNames = childTable.data.schema.fields.map(field => field.name);
+  if (!sourceColumnNames.includes(join.left)) {
+    throw new Error(`Arrow join column not found: ${join.left}`);
+  }
+  if (!childColumnNames.includes(join.right)) {
+    throw new Error(`Arrow join column not found: ${join.right}`);
+  }
+
+  const childPrefix = `${join.child.source}.`;
+  const rootColumns = options.columns?.filter(column => !column.startsWith(childPrefix));
+  planTableQuery(sourceColumnNames, {
+    predicate: options.predicate,
+    columns: rootColumns?.length ? rootColumns : undefined,
+    limit: options.limit,
+    signal: options.signal
+  });
+
+  const childQuery = join.child.query || {};
+  planTableQuery(childColumnNames, childQuery);
+  const childOutputColumns = childQuery.columns || childColumnNames;
+  if (!childOutputColumns.includes(join.right)) {
+    throw new Error(`Arrow join child projection must include: ${join.right}`);
+  }
+  const projectedChildColumns =
+    options.columns?.filter(column => column.startsWith(childPrefix)) || [];
+  const seenChildColumns = new Set<string>();
+  for (const projectedColumn of projectedChildColumns) {
+    const childColumn = projectedColumn.slice(childPrefix.length);
+    if (!childColumnNames.includes(childColumn)) {
+      throw new Error(`Arrow join column not found: ${projectedColumn}`);
+    }
+    if (seenChildColumns.has(childColumn)) {
+      throw new Error(`Arrow query column was selected more than once: ${projectedColumn}`);
+    }
+    seenChildColumns.add(childColumn);
+    if (!childOutputColumns.includes(childColumn)) {
+      throw new Error(`Arrow join child projection does not include: ${childColumn}`);
+    }
+  }
 }
 
 /** Materializes one Arrow table into row objects for the relational proof of concept. */
@@ -410,7 +513,8 @@ function serializeGroupKey(values: readonly unknown[]): string {
 function createEmptyRelationalResult(
   sourceData: arrow.Table,
   outputColumns: readonly string[],
-  options: ArrowQueryOptions
+  options: ArrowQueryOptions,
+  additionalFields?: ReadonlyMap<string, arrow.Field>
 ): ArrowTable {
   const sourceFields = new Map(sourceData.schema.fields.map(field => [field.name, field]));
   const expressions = new Map(
@@ -422,6 +526,8 @@ function createEmptyRelationalResult(
   const fields = outputColumns.map(columnName => {
     const sourceField = sourceFields.get(columnName);
     if (sourceField) return sourceField;
+    const additionalField = additionalFields?.get(columnName);
+    if (additionalField) return additionalField;
     const expression = expressions.get(columnName);
     if (expression)
       return new arrow.Field(columnName, getExpressionType(expression, sourceFields), true);

--- a/modules/sql/test/arrow-query.spec.ts
+++ b/modules/sql/test/arrow-query.spec.ts
@@ -271,6 +271,43 @@ test('queryArrowTable unions child tables and performs an equi-join', () => {
   ).toThrow(/cannot yet be combined/);
 });
 
+test('queryArrowTable does not require base-only predicate columns in UNION children', () => {
+  const result = queryArrowTable(makeArrowTable({id: [1, 2], active: [true, false]}), {
+    columns: ['id'],
+    predicate: parseSQLPredicate('active = TRUE'),
+    union: [{source: 'archive'}],
+    tables: {archive: makeArrowTable({id: [3]})}
+  });
+
+  expect(toRows(result)).toEqual([{id: 1}, {id: 3}]);
+});
+
+test('queryArrowTable validates join projections and preserves empty child field types', () => {
+  const sourceTable = makeArrowTable({id: [1]});
+  const childTable = makeArrowTable({id: [1], value: [42]});
+  const join = {child: {source: 'lookup'}, left: 'id', right: 'id'} as const;
+  const tables = {lookup: childTable};
+
+  expect(() => queryArrowTable(sourceTable, {join, tables, limit: -1})).toThrow(/non-negative/);
+  expect(() => queryArrowTable(sourceTable, {join, tables, columns: ['missing']})).toThrow(
+    /column not found/
+  );
+  expect(() => queryArrowTable(sourceTable, {join, tables, columns: ['lookup.missing']})).toThrow(
+    /lookup\.missing/
+  );
+
+  const emptyResult = queryArrowTable(sourceTable, {
+    join,
+    tables,
+    columns: ['id', 'lookup.value'],
+    limit: 0
+  });
+  expect(emptyResult.data.numRows).toBe(0);
+  expect(
+    emptyResult.data.schema.fields.find(field => field.name === 'lookup.value')?.type.toString()
+  ).toBe(childTable.data.schema.fields.find(field => field.name === 'value')?.type.toString());
+});
+
 test.each([
   [{columns: ['missing']}, /column not found/],
   [{columns: ['value', 'value']}, /more than once/],

--- a/modules/sql/test/arrow-query.spec.ts
+++ b/modules/sql/test/arrow-query.spec.ts
@@ -241,6 +241,36 @@ test('queryArrowTable groups bigint keys and rejects incomplete aggregates', () 
   ).toThrow(/requires a column/);
 });
 
+test('queryArrowTable unions child tables and performs an equi-join', () => {
+  const archived = makeArrowTable({id: [3], value: [30]});
+  const unionResult = queryArrowTable(makeArrowTable({id: [1, 2], value: [10, 20]}), {
+    columns: ['id', 'value'],
+    union: [{source: 'archive', query: {columns: ['id', 'value']}}],
+    tables: {archive: archived},
+    orderBy: [{column: 'id'}]
+  });
+  expect(toRows(unionResult)).toEqual([
+    {id: 1, value: 10},
+    {id: 2, value: 20},
+    {id: 3, value: 30}
+  ]);
+
+  const joined = queryArrowTable(makeArrowTable({id: [1, 2], value: [10, 20]}), {
+    columns: ['id', 'lookup.code'],
+    join: {child: {source: 'lookup'}, left: 'id', right: 'id'},
+    tables: {lookup: makeArrowTable({id: [2], code: ['two']})}
+  });
+  expect(toRows(joined)).toEqual([{id: 2, 'lookup.code': 'two'}]);
+
+  expect(() =>
+    queryArrowTable(makeArrowTable({id: [1]}), {
+      join: {child: {source: 'lookup'}, left: 'id', right: 'id'},
+      union: [{source: 'lookup'}],
+      tables: {lookup: archived}
+    })
+  ).toThrow(/cannot yet be combined/);
+});
+
 test.each([
   [{columns: ['missing']}, /column not found/],
   [{columns: ['value', 'value']}, /more than once/],

--- a/modules/sql/test/compile-table-query.spec.ts
+++ b/modules/sql/test/compile-table-query.spec.ts
@@ -125,6 +125,25 @@ describe('compileSQLTableQuery', () => {
       ].join('\n')
     );
 
+    const limitedUnion = compileSQLTableQuery(
+      {
+        tableName: 'flights',
+        columns: ['carrier'],
+        union: [{source: 'archived_flights', query: {columns: ['carrier'], limit: 1}}]
+      },
+      {dialect: 'duckdb'}
+    );
+    expect(limitedUnion.sql).toBe(
+      [
+        'SELECT "carrier"',
+        'FROM "flights"',
+        'UNION ALL',
+        '(SELECT "carrier"',
+        'FROM "archived_flights"',
+        'LIMIT 1)'
+      ].join('\n')
+    );
+
     const join = compileSQLTableQuery(
       {
         tableName: 'flights',
@@ -136,6 +155,16 @@ describe('compileSQLTableQuery', () => {
     expect(join.sql).toContain(
       'JOIN "airlines" AS "airlines" ON "flights"."carrier" = "airlines"."code"'
     );
+
+    const joinedProjection = compileSQLTableQuery(
+      {
+        tableName: 'flights',
+        columns: ['airlines.name'],
+        join: {child: {source: 'airlines'}, left: 'carrier', right: 'code'}
+      },
+      {dialect: 'duckdb'}
+    );
+    expect(joinedProjection.sql).toContain('SELECT "airlines"."name"');
   });
 
   test('rejects non-count aggregates without an input column', () => {

--- a/modules/sql/test/compile-table-query.spec.ts
+++ b/modules/sql/test/compile-table-query.spec.ts
@@ -105,4 +105,45 @@ describe('compileSQLTableQuery', () => {
       ].join('\n')
     );
   });
+
+  test('compiles unions and qualified equi-joins', () => {
+    const union = compileSQLTableQuery(
+      {
+        tableName: 'flights',
+        columns: ['carrier'],
+        union: [{source: 'archived_flights', query: {columns: ['carrier']}}]
+      },
+      {dialect: 'duckdb'}
+    );
+    expect(union.sql).toBe(
+      [
+        'SELECT "carrier"',
+        'FROM "flights"',
+        'UNION ALL',
+        'SELECT "carrier"',
+        'FROM "archived_flights"'
+      ].join('\n')
+    );
+
+    const join = compileSQLTableQuery(
+      {
+        tableName: 'flights',
+        columns: ['carrier'],
+        join: {child: {source: 'airlines'}, left: 'carrier', right: 'code'}
+      },
+      {dialect: 'duckdb'}
+    );
+    expect(join.sql).toContain(
+      'JOIN "airlines" AS "airlines" ON "flights"."carrier" = "airlines"."code"'
+    );
+  });
+
+  test('rejects non-count aggregates without an input column', () => {
+    expect(() =>
+      compileSQLTableQuery(
+        {tableName: 'flights', aggregates: [{name: 'total', function: 'sum'}]},
+        {dialect: 'duckdb'}
+      )
+    ).toThrow(/requires a column/);
+  });
 });


### PR DESCRIPTION
## Goals

Extend the common scan query shape with the next relational tranche: portable `UNION ALL` and
inner equi-joins that can execute against in-memory Arrow tables or compile to SQL for DuckDB and
other supported dialects.

## Changes

- Add named child relations to `ArrowQueryOptions` and `SQLTableQuery`.
- Execute ordered Arrow unions through an explicit source-to-table map.
- Execute bounded nested-loop Arrow inner joins with source-qualified child columns and SQL null
  matching semantics.
- Compile unions and joins to parameter-compatible SQL while sharing placeholder bindings across
  child predicates.
- Reject unsupported combinations of Arrow joins with other relational operators instead of
  silently dropping the join.
- Add focused Arrow executor and SQL compiler conformance tests, including child projection,
  duplicate-safe qualified output, missing-source validation, and aggregate validation.
- Update the common scan architecture roadmap and implementation notes for the landed tranche and
  the next source-resolution work.

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn test-node`
- Focused Chromium tests: 29 tests passed
- Full Chromium coverage suite: 478 files / 2,858 tests passed (coverage artifact partitioning is
  handled by CI's coverage workflow)
