### PR TITLE
feat(tiles): expose skip LOD replacement traversal

### DIFF
--- a/docs/modules/3d-tiles/concepts/tile-hierarchy-and-refinement.md
+++ b/docs/modules/3d-tiles/concepts/tile-hierarchy-and-refinement.md
@@ -33,7 +33,12 @@ While a child subtree is loading, its existing tile stays the traversal boundary
 
 `ADD` means descendants augment their ancestors. The parent remains part of the result, so descendant requests can safely wait briefly while the camera moves.
 
-Some source traversers support skip-LOD replacement: a ready ancestor can remain as coverage while traversal jumps to deeper descendants. Progressive-resolution descendants needed for initial broad coverage remain urgent even in this mode.
+Set `skipLevelOfDetail: true` to enable skip-LOD replacement traversal. A ready replacement ancestor
+remains selected while traversal jumps over intermediate levels, so a deep tree can begin showing
+detail before every level is ready. The ancestor is fallback coverage, not a second LOD target: once
+descendants are available they refine independently, and progressive-resolution descendants remain
+urgent. The tradeoff is temporary overdraw and potentially higher bandwidth while the camera is
+moving. The default is `false`, preserving traditional all-required-children replacement behavior.
 
 ## Visibility, Selection, and Requests
 

--- a/docs/modules/tiles/api-reference/tileset-3d.md
+++ b/docs/modules/tiles/api-reference/tileset-3d.md
@@ -208,6 +208,15 @@ For formulas, projection-specific behavior, transform scaling, and tuning guidan
 ^default 8 \*
 ^exception `maximumScreenSpaceError` must be greater than or equal to zero.
 
+### skipLevelOfDetail : Boolean
+
+Enables skip-LOD replacement traversal. When enabled, traversal may descend past one or more
+hierarchy levels without waiting for every intermediate child, while keeping ready replacement
+ancestors selected as temporary coverage. This can improve first-detail latency on deep trees at
+the cost of temporary ancestor/descendant overdraw. `ADD` refinement is unaffected.
+
+^default false
+
 ### cacheBytes : Number
 
 The soft target in bytes for estimated tile content retained by the cache. The estimate includes

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -299,6 +299,7 @@ A minor release that includes:
 - **Region bounding volumes** - Geographic regions that cross the antimeridian now produce tight traversal OBBs instead of spanning the long way around the globe; polar and zero-height regions remain finite.
 - **Transform-correct LOD** Geometric error is scaled conservatively by composed tile and tileset transforms without compounding after runtime updates.
 - **Projection-correct SSE** Orthographic viewports use `metersPerPixel`, while perspective and orthographic traversal consistently use logical pixels without a second device-pixel-ratio correction.
+- **Skip-LOD replacement traversal** `Tileset3D` now exposes `skipLevelOfDetail`; enabled traversals retain ready replacement ancestors as fallback coverage while descending through deep hierarchies.
 - **Dynamic SSE** Perspective traversal can reduce distant, horizon-facing refinement with view-dependent density and height falloff while leaving orthographic and I3S LOD behavior unchanged.
 - **Same-frame dynamic SSE transforms** Animated local tilesets refresh the root transform before density calculation, and tilted oriented boxes derive height from every rotated half axis.
 - **Required-extension validation** Unsupported `extensionsRequired` values fail before normalization or dependent network access; unknown `extensionsUsed` values remain forward-compatible.

--- a/modules/tiles/src/tileset-3d/common/tileset-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tileset-3d.ts
@@ -74,6 +74,12 @@ export type Tileset3DProps = {
   modelMatrix?: Matrix4;
 
   maximumScreenSpaceError?: number;
+  /**
+   * Enables replacement traversal that may skip hierarchy levels while retaining ready ancestors
+   * as coverage. This trades temporary overdraw for faster refinement on deep trees.
+   * @default false
+   */
+  skipLevelOfDetail?: boolean;
   /** Enables perspective dynamic SSE to reduce distant, horizon-facing refinement. */
   dynamicScreenSpaceError?: boolean;
   /** Base dynamic SSE fog density in inverse meters. */
@@ -139,6 +145,8 @@ type Props = {
   onTraversalComplete: (selectedTiles: Tile3D[]) => Tile3D[];
   onUpdate: () => void;
   maximumScreenSpaceError: number;
+  /** Whether replacement traversal may skip levels while retaining ancestor coverage. */
+  skipLevelOfDetail: boolean;
   /** Whether perspective dynamic SSE is enabled. */
   dynamicScreenSpaceError: boolean;
   /** Base dynamic SSE fog density in inverse meters. */
@@ -264,6 +272,7 @@ const DEFAULT_PROPS: Props = {
   foveatedInterpolationCallback: interpolateLinearly,
   foveatedTimeDelay: 0.2,
   maximumScreenSpaceError: 8,
+  skipLevelOfDetail: false,
   dynamicScreenSpaceError: true,
   dynamicScreenSpaceErrorDensity: 2.0e-4,
   dynamicScreenSpaceErrorFactor: 24,

--- a/modules/tiles/src/tileset-3d/common/tileset-traverser.ts
+++ b/modules/tiles/src/tileset-3d/common/tileset-traverser.ts
@@ -140,7 +140,9 @@ export class TilesetTraverser {
         // Always load tiles in the base traversal
         // Select tiles that can't refine further
         this.loadTile(tile, frameState);
-        if (stoppedRefining) {
+        // Skip-LOD keeps a ready ancestor selected while descendants stream in. This prevents
+        // replacement holes when traversal jumps over one or more hierarchy levels.
+        if (stoppedRefining || this.options.skipLevelOfDetail) {
           this.selectTile(tile, frameState);
         }
       }
@@ -293,9 +295,9 @@ export class TilesetTraverser {
   }
 
   shouldSelectTile(tile: Tile3D): boolean {
-    // if select tile is in current frame
-    // and content available
-    return tile.contentAvailable && !this.options.skipLevelOfDetail;
+    // Content availability is the only selection prerequisite. Skip-LOD retains ready ancestors
+    // as fallback coverage, so it must not suppress selection globally.
+    return tile.contentAvailable;
   }
 
   /** Decide if tile LoD (level of detail) is not sufficient under current viewport */

--- a/modules/tiles/test/tileset/tileset-3d-traversal.slow.spec.ts
+++ b/modules/tiles/test/tileset/tileset-3d-traversal.slow.spec.ts
@@ -13,6 +13,8 @@ import {Tiles3DLoader} from '@loaders.gl/3d-tiles';
 // import {loadTileset} from '../utils/load-utils';
 // Parent tile with content and four child tiles with content
 const TILESET_URL = '@loaders.gl/3d-tiles/test/data/CesiumJS/Tilesets/Tileset/tileset.json';
+const TILESET_REPLACEMENT_URL =
+  '@loaders.gl/3d-tiles/test/data/CesiumJS/Tilesets/TilesetReplacement1/tileset.json';
 const ASYNC_TRAVERSAL_TIMEOUT = 10000;
 /*
 // Parent tile with no content and four child tiles with content
@@ -260,4 +262,25 @@ test('Tileset3D#loadTiles option', async () => {
   tileset.update(viewport);
   await new Promise(resolve => setTimeout(resolve, 300));
   expect(tileLoadCounter).toBe(0);
+});
+
+test('Tileset3D#skipLevelOfDetail retains replacement ancestors as coverage', async () => {
+  expect.assertions(3);
+  const tilesetJson = await load(TILESET_REPLACEMENT_URL, Tiles3DLoader);
+  const viewport = VIEWPORTS[0];
+  let tileLoadCounter = 0;
+  const tileset = new Tileset3D(new Tiles3DSource({...tilesetJson, coreApi}), {
+    maximumScreenSpaceError: 0,
+    skipLevelOfDetail: true,
+    onTileLoad: () => {
+      tileset.update(viewport);
+      tileLoadCounter++;
+    }
+  });
+  tileset.update(viewport);
+  await waitForCondition(() => tileLoadCounter > 0, ASYNC_TRAVERSAL_TIMEOUT);
+  tileset.update(viewport);
+  expect(tileset.options.skipLevelOfDetail).toBe(true);
+  expect(tileset.selectedTiles.some(tile => tile.depth === 0)).toBe(true);
+  expect(tileset.selectedTiles.length).toBeGreaterThan(1);
 });


### PR DESCRIPTION
## Goals

- Advance the 3D Tiles Cesium-parity roadmap with a usable, documented skip-LOD replacement mode.
- Preserve visual coverage while deep replacement hierarchies stream in, without changing the default traversal behavior.

This partially addresses tracker #1245's dedicated skip-LOD traversal row. A future tranche can add Cesium's full independent skip traverser, ancestor fallback heuristics, and mixed-content ordering.

## Changes

- Add the public `Tileset3DProps.skipLevelOfDetail` option, defaulting to `false` for backwards compatibility.
- Make skip-LOD available to the shared traverser through the normal typed `Tileset3D` options path.
- Retain ready replacement ancestors as selected fallback coverage while descendants are loading or traversal skips intermediate levels.
- Keep `ADD` refinement semantics unchanged and preserve existing request-priority/foveation behavior.
- Add a slow fixture-backed traversal regression covering replacement ancestor coverage with skip-LOD enabled.
- Document the option, its overdraw/bandwidth tradeoff, and its interaction with SSE and refinement.
- Add a 5.0 What's New entry.

## Validation

- `yarn lint fix`
- `yarn test-audit` — 584 files, 0 Tape, 49 skips, 0 violations
- Scheduler/priority, traverser setup, and tileset runtime suites — 23 tests passed
- Slow traversal conformance suite — 6 tests passed

`yarn build` reached package builds but was interrupted during the repository-wide worker prebuild after unrelated worker processes were terminated by the local execution timeout. CI should run the authoritative clean build.
