### PR TITLE
perf(copc): write tile-relative positions directly

### DIFF
--- a/modules/copc/src/copc-source-loader.ts
+++ b/modules/copc/src/copc-source-loader.ts
@@ -749,7 +749,9 @@ export class COPCTileSource
         nodePointCount - decodedPointCount,
         remainingPointCount.value
       );
-      const nativePositions = new Float64Array(pointCount * 3);
+      const directRelativePositions = !this._projection && !bounds;
+      const nativePositions = directRelativePositions ? null : new Float64Array(pointCount * 3);
+      const positions = new Float32Array(pointCount * 3);
       const batchColors = selection.colors ? new Uint16Array(pointCount * 3) : null;
       const batchNir = selection.nir ? new Uint16Array(pointCount) : null;
       const batchIntensities = selection.intensity ? new Uint16Array(pointCount) : null;
@@ -775,7 +777,10 @@ export class COPCTileSource
         : null;
       const decoded = decoder.readPointDataBatch(
         {
-          positions: nativePositions,
+          positions: directRelativePositions ? positions : nativePositions!,
+          positionOrigin: directRelativePositions
+            ? (nativeOrigin as [number, number, number])
+            : undefined,
           rawColors: batchColors,
           nir: batchNir,
           intensities: batchIntensities,
@@ -808,47 +813,68 @@ export class COPCTileSource
       }
       decodedPointCount += decoded;
       const selectedPointIndices = bounds
-        ? getCOPCPointIndicesWithinBounds(nativePositions, decoded, bounds)
-        : Array.from({length: decoded}, (_value, index) => index);
-      if (selectedPointIndices.length === 0) {
+        ? getCOPCPointIndicesWithinBounds(nativePositions!, decoded, bounds)
+        : null;
+      if (selectedPointIndices && selectedPointIndices.length === 0) {
         continue;
       }
-      const filteredPointCount = selectedPointIndices.length;
+      const filteredPointCount = selectedPointIndices?.length ?? decoded;
       remainingPointCount.value -= filteredPointCount;
-      const filteredNativePositions = selectCOPCPointArray(
-        nativePositions,
-        selectedPointIndices,
-        3
-      ) as Float64Array;
-      const filteredPositions = new Float32Array(filteredPointCount * 3);
-      const filteredColors = selectCOPCPointArray(batchColors, selectedPointIndices, 3);
-      const filteredNir = selectCOPCPointArray(batchNir, selectedPointIndices, 1);
-      const filteredPointData = filterCOPCPointData(
-        {
-          batchIntensities,
-          batchClassifications,
-          batchSyntheticFlags,
-          batchKeyPointFlags,
-          batchWithheldFlags,
-          batchOverlapFlags,
-          batchGpsTimes,
-          batchScanAngles,
-          batchUserData,
-          batchPointSourceIds,
-          batchReturnNumbers,
-          batchNumberOfReturns,
-          batchScannerChannels,
-          batchScanDirectionFlags,
-          batchEdgeOfFlightLines,
-          typedExtraBytes: []
-        },
-        selectedPointIndices
-      );
-      const filteredExtraBytes = selectCOPCPointArray(
-        batchExtraBytes,
-        selectedPointIndices,
-        extraByteCount
-      );
+      const filteredNativePositions = bounds
+        ? (selectCOPCPointArray(nativePositions!, selectedPointIndices!, 3) as Float64Array)
+        : nativePositions;
+      const filteredPositions = directRelativePositions
+        ? positions
+        : new Float32Array(filteredPointCount * 3);
+      const filteredColors = bounds
+        ? selectCOPCPointArray(batchColors, selectedPointIndices!, 3)
+        : batchColors;
+      const filteredNir = bounds
+        ? selectCOPCPointArray(batchNir, selectedPointIndices!, 1)
+        : batchNir;
+      const filteredPointData = bounds
+        ? filterCOPCPointData(
+            {
+              batchIntensities,
+              batchClassifications,
+              batchSyntheticFlags,
+              batchKeyPointFlags,
+              batchWithheldFlags,
+              batchOverlapFlags,
+              batchGpsTimes,
+              batchScanAngles,
+              batchUserData,
+              batchPointSourceIds,
+              batchReturnNumbers,
+              batchNumberOfReturns,
+              batchScannerChannels,
+              batchScanDirectionFlags,
+              batchEdgeOfFlightLines,
+              typedExtraBytes: []
+            },
+            selectedPointIndices!
+          )
+        : {
+            batchIntensities,
+            batchClassifications,
+            batchSyntheticFlags,
+            batchKeyPointFlags,
+            batchWithheldFlags,
+            batchOverlapFlags,
+            batchGpsTimes,
+            batchScanAngles,
+            batchUserData,
+            batchPointSourceIds,
+            batchReturnNumbers,
+            batchNumberOfReturns,
+            batchScannerChannels,
+            batchScanDirectionFlags,
+            batchEdgeOfFlightLines,
+            typedExtraBytes: []
+          };
+      const filteredExtraBytes = bounds
+        ? selectCOPCPointArray(batchExtraBytes, selectedPointIndices!, extraByteCount)
+        : batchExtraBytes;
       const typedExtraBytes = filteredExtraBytes
         ? createLASTypedExtraBytesAttributes(
             filteredPointCount,
@@ -864,12 +890,14 @@ export class COPCTileSource
           typedExtraBytes
         );
       }
-      this.transformTilePositions(
-        filteredNativePositions,
-        filteredPositions,
-        nativeOrigin,
-        cartographicOrigin
-      );
+      if (!directRelativePositions) {
+        this.transformTilePositions(
+          filteredNativePositions!,
+          filteredPositions,
+          nativeOrigin,
+          cartographicOrigin
+        );
+      }
       yield this.createTileContentResult(
         filteredPointCount,
         filteredPositions,

--- a/modules/loader-utils/src/lib/laz/laz-chunk-decoder.ts
+++ b/modules/loader-utils/src/lib/laz/laz-chunk-decoder.ts
@@ -3168,7 +3168,8 @@ class PointFormat6Decompressor implements PointDecompressor {
         classifications,
         scale,
         offset,
-        targetPointIndex++
+        targetPointIndex++,
+        target.positionOrigin
       );
       writeGpsTimeToPointDataTarget(point, target, targetPointIndex - 1);
       writePoint14MetadataToPointDataTarget(point, target, targetPointIndex - 1);
@@ -3308,7 +3309,8 @@ class PointFormat7Decompressor implements PointDecompressor {
         classifications,
         scale,
         offset,
-        targetPointIndex
+        targetPointIndex,
+        target.positionOrigin
       );
       writeGpsTimeToPointDataTarget(point, target, targetPointIndex);
       writePoint14MetadataToPointDataTarget(point, target, targetPointIndex);
@@ -3482,7 +3484,8 @@ class PointFormat8Decompressor implements PointDecompressor {
         classifications,
         scale,
         offset,
-        targetPointIndex
+        targetPointIndex,
+        target.positionOrigin
       );
       writeGpsTimeToPointDataTarget(point, target, targetPointIndex);
       writePoint14MetadataToPointDataTarget(point, target, targetPointIndex);
@@ -3652,7 +3655,8 @@ class PointFormat9Decompressor implements PointDecompressor {
         classifications,
         scale,
         offset,
-        targetPointIndex++
+        targetPointIndex++,
+        target.positionOrigin
       );
       writeGpsTimeToPointDataTarget(point, target, targetPointIndex - 1);
       writePoint14MetadataToPointDataTarget(point, target, targetPointIndex - 1);
@@ -3846,7 +3850,8 @@ class PointFormat10Decompressor implements PointDecompressor {
         classifications,
         scale,
         offset,
-        targetPointIndex
+        targetPointIndex,
+        target.positionOrigin
       );
       writeGpsTimeToPointDataTarget(point, target, targetPointIndex);
       writePoint14MetadataToPointDataTarget(point, target, targetPointIndex);

--- a/modules/loader-utils/src/lib/laz/laz-chunk-decoder.ts
+++ b/modules/loader-utils/src/lib/laz/laz-chunk-decoder.ts
@@ -27,6 +27,8 @@ export type LAZChunkDecoderOptions = {
 export type LAZPointDataTarget = {
   /** XYZ positions populated with LAS scale and offset applied. */
   positions: Float32Array | Float64Array;
+  /** Optional native-coordinate origin subtracted while positions are written. */
+  positionOrigin?: readonly [number, number, number];
   /** Optional point intensity values. Omit to skip the independent Point14 intensity layer. */
   intensities?: Uint16Array | null;
   /** Optional point classification values. Omit to skip the independent Point14 class layer. */
@@ -4119,7 +4121,8 @@ function writePoint14ToPointDataTarget(
     target.classifications,
     target.scale,
     target.offset,
-    targetPointIndex
+    targetPointIndex,
+    target.positionOrigin
   );
   writeGpsTimeToPointDataTarget(point, target, targetPointIndex);
   writePoint14MetadataToPointDataTarget(point, target, targetPointIndex);
@@ -4132,12 +4135,13 @@ function writePoint14ToPointDataArrays(
   classifications: Uint8Array | null | undefined,
   scale: [number, number, number],
   offset: [number, number, number],
-  targetPointIndex: number
+  targetPointIndex: number,
+  positionOrigin?: readonly [number, number, number]
 ): void {
   const positionOffset = targetPointIndex * 3;
-  positions[positionOffset] = point.x * scale[0] + offset[0];
-  positions[positionOffset + 1] = point.y * scale[1] + offset[1];
-  positions[positionOffset + 2] = point.z * scale[2] + offset[2];
+  positions[positionOffset] = point.x * scale[0] + offset[0] - (positionOrigin?.[0] ?? 0);
+  positions[positionOffset + 1] = point.y * scale[1] + offset[1] - (positionOrigin?.[1] ?? 0);
+  positions[positionOffset + 2] = point.z * scale[2] + offset[2] - (positionOrigin?.[2] ?? 0);
   if (intensities) {
     intensities[targetPointIndex] = point.intensity;
   }


### PR DESCRIPTION
Goals:
- Reduce allocations in the primary unprojected COPC streaming path.
- Preserve exact Arrow output and bounds-filtered/projected behavior.

Changes:
- Add an optional position origin to the TypeScript LAZ point-data target.
- Write scaled positions directly into tile-relative Float32 output for unprojected COPC batches.
- Avoid the native Float64 position buffer and identity point-index allocation in that path.
- Keep native coordinates for CRS projection and residual bounds filtering.

Validation:
- `yarn lint fix` passed.
- Focused COPC headless tests passed: 4 tests.
- Existing full-suite worker-bundle failures are unrelated to this change when `modules/las/dist/las-worker.js` is unavailable.