### PR TITLE
perf(parquet): cache encryption keys per reader

### DIFF
--- a/modules/parquet/src/parquet-source-loader.ts
+++ b/modules/parquet/src/parquet-source-loader.ts
@@ -760,6 +760,7 @@ export class ParquetSource
     }
     await this.readableFile?.close();
     const initialization = await this.initializationPromise?.catch(() => null);
+    initialization?.reader.close();
     if (initialization?.file !== this.readableFile) {
       await initialization?.file.close();
     }

--- a/modules/parquet/src/parquetjs/parser/parquet-reader.ts
+++ b/modules/parquet/src/parquetjs/parser/parquet-reader.ts
@@ -218,11 +218,23 @@ export class ParquetReader {
       throw new Error('Encrypted Parquet requires parquet.keyRetriever');
     }
     return (keyMetadata, context) => {
-      const cacheKey = createEncryptionKeyCacheKey(context.algorithm, keyMetadata);
+      const encryptionContext = this.encryptionContext;
+      const cacheKey = createEncryptionKeyCacheKey(
+        context.algorithm,
+        keyMetadata,
+        context.aad,
+        encryptionContext?.aadPrefix?.byteLength ?? this.props.aadPrefix?.byteLength,
+        encryptionContext?.fileUnique.byteLength
+      );
       let keyPromise = this.encryptionKeyCache.get(cacheKey);
       if (!keyPromise) {
         keyPromise = Promise.resolve().then(() => keyRetriever(keyMetadata, context));
         this.encryptionKeyCache.set(cacheKey, keyPromise);
+        void keyPromise.catch(() => {
+          if (this.encryptionKeyCache.get(cacheKey) === keyPromise) {
+            this.encryptionKeyCache.delete(cacheKey);
+          }
+        });
       }
       return keyPromise;
     };
@@ -1079,12 +1091,36 @@ function getColumnChunkPath(columnChunk: ColumnChunk): string[] | undefined {
   );
 }
 
-/** Builds a stable cache key from the algorithm and optional Parquet key metadata. */
+/** Builds a stable cache key while preserving module scope for context-dependent key providers. */
 function createEncryptionKeyCacheKey(
   algorithm: ParquetEncryptionAlgorithm,
-  keyMetadata: Uint8Array | undefined
+  keyMetadata: Uint8Array | undefined,
+  aad: Uint8Array,
+  aadPrefixByteLength: number | undefined,
+  fileUniqueByteLength: number | undefined
 ): string {
-  return `${algorithm}:${keyMetadata ? Array.from(keyMetadata).join(',') : 'footer'}`;
+  const metadataKey = keyMetadata ? Array.from(keyMetadata).join(',') : 'footer';
+  if (fileUniqueByteLength === undefined) {
+    return `${algorithm}:${metadataKey}:aad:${Array.from(aad).join(',')}`;
+  }
+
+  const moduleOffset = (aadPrefixByteLength ?? 0) + fileUniqueByteLength;
+  if (moduleOffset + 5 > aad.byteLength) {
+    return `${algorithm}:${metadataKey}:aad:${Array.from(aad).join(',')}`;
+  }
+
+  const moduleType = aad[moduleOffset];
+  if (moduleType === 0) {
+    return `${algorithm}:${metadataKey}:footer`;
+  }
+  const view = new DataView(
+    aad.buffer,
+    aad.byteOffset + moduleOffset,
+    aad.byteLength - moduleOffset
+  );
+  const rowGroupOrdinal = view.getInt16(1, true);
+  const columnOrdinal = view.getInt16(3, true);
+  return `${algorithm}:${metadataKey}:module:${moduleType}:row-group:${rowGroupOrdinal}:column:${columnOrdinal}`;
 }
 
 /** Returns the original row-group ordinal for a worker-reduced column list. */

--- a/modules/parquet/src/parquetjs/parser/parquet-reader.ts
+++ b/modules/parquet/src/parquetjs/parser/parquet-reader.ts
@@ -150,6 +150,8 @@ export class ParquetReader {
   private schema: Promise<ParquetSchema> | null = null;
   /** Encryption parameters decoded from plaintext or encrypted footer metadata. */
   private encryptionContext?: ParquetEncryptionContext;
+  /** Resolved keys shared by encrypted modules in this reader instance. */
+  private readonly encryptionKeyCache = new Map<string, Promise<ArrayBuffer | ArrayBufferView>>();
 
   constructor(file: ReadableFile, props?: ParquetReaderProps) {
     this.file = file;
@@ -204,8 +206,26 @@ export class ParquetReader {
   }
 
   close(): void {
+    this.encryptionKeyCache.clear();
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.file.close();
+  }
+
+  /** Returns a reader-scoped key resolver that avoids repeating key-provider work per module. */
+  private getCachedKeyRetriever(): ParquetKeyRetriever {
+    const keyRetriever = this.props.keyRetriever;
+    if (!keyRetriever) {
+      throw new Error('Encrypted Parquet requires parquet.keyRetriever');
+    }
+    return (keyMetadata, context) => {
+      const cacheKey = createEncryptionKeyCacheKey(context.algorithm, keyMetadata);
+      let keyPromise = this.encryptionKeyCache.get(cacheKey);
+      if (!keyPromise) {
+        keyPromise = Promise.resolve().then(() => keyRetriever(keyMetadata, context));
+        this.encryptionKeyCache.set(cacheKey, keyPromise);
+      }
+      return keyPromise;
+    };
   }
 
   // HIGH LEVEL METHODS
@@ -364,7 +384,7 @@ export class ParquetReader {
           'footer'
         ),
         keyMetadata: encryptionContext.footerSigningKeyMetadata,
-        keyRetriever: this.props.keyRetriever
+        keyRetriever: this.getCachedKeyRetriever()
       });
     }
     return metadata;
@@ -396,7 +416,7 @@ export class ParquetReader {
       algorithm,
       aad,
       keyMetadata: cryptoMetadata.metadata.key_metadata,
-      keyRetriever: this.props.keyRetriever
+      keyRetriever: this.getCachedKeyRetriever()
     });
     this.encryptionContext = {
       algorithm,
@@ -477,7 +497,7 @@ export class ParquetReader {
       algorithm: encryptionContext.algorithm,
       aad,
       keyMetadata: this.getColumnKeyMetadata(columnChunk),
-      keyRetriever: this.props.keyRetriever
+      keyRetriever: this.getCachedKeyRetriever()
     });
   }
 
@@ -506,7 +526,7 @@ export class ParquetReader {
         columnOrdinal
       ),
       keyMetadata,
-      keyRetriever: this.props.keyRetriever
+      keyRetriever: this.getCachedKeyRetriever()
     });
     const bitsetBytes = await decryptParquetModule(bitset.bytes, {
       algorithm: encryptionContext.algorithm,
@@ -518,7 +538,7 @@ export class ParquetReader {
         columnOrdinal
       ),
       keyMetadata,
-      keyRetriever: this.props.keyRetriever
+      keyRetriever: this.getCachedKeyRetriever()
     });
     const plaintext = new Uint8Array(headerBytes.byteLength + bitsetBytes.byteLength);
     plaintext.set(headerBytes);
@@ -564,7 +584,7 @@ export class ParquetReader {
         columnKey?.key_metadata ??
         encryptionContext.footerKeyMetadata ??
         encryptionContext.footerSigningKeyMetadata,
-      keyRetriever: this.props.keyRetriever
+      keyRetriever: this.getCachedKeyRetriever()
     });
     const metadata = decodeColumnMetadata(plaintext).metadata;
     if (
@@ -833,7 +853,7 @@ export class ParquetReader {
         algorithm: this.encryptionContext.algorithm,
         aad: headerAad,
         keyMetadata,
-        keyRetriever: this.props.keyRetriever
+        keyRetriever: this.getCachedKeyRetriever()
       });
       const {pageHeader} = decodePageHeader(headerBytes);
       const pageType = getThriftEnum(PageType, pageHeader.type);
@@ -851,7 +871,7 @@ export class ParquetReader {
         algorithm: this.encryptionContext.algorithm,
         aad: dataAad,
         keyMetadata,
-        keyRetriever: this.props.keyRetriever,
+        keyRetriever: this.getCachedKeyRetriever(),
         page: true
       });
       plaintextPages.push(serializeThrift(pageHeader), dataBytes);
@@ -1057,6 +1077,14 @@ function getColumnChunkPath(columnChunk: ColumnChunk): string[] | undefined {
     columnChunk.meta_data?.path_in_schema ??
     columnChunk.crypto_metadata?.ENCRYPTION_WITH_COLUMN_KEY?.path_in_schema
   );
+}
+
+/** Builds a stable cache key from the algorithm and optional Parquet key metadata. */
+function createEncryptionKeyCacheKey(
+  algorithm: ParquetEncryptionAlgorithm,
+  keyMetadata: Uint8Array | undefined
+): string {
+  return `${algorithm}:${keyMetadata ? Array.from(keyMetadata).join(',') : 'footer'}`;
 }
 
 /** Returns the original row-group ordinal for a worker-reduced column list. */

--- a/modules/parquet/test/parquet-encryption.spec.ts
+++ b/modules/parquet/test/parquet-encryption.spec.ts
@@ -160,6 +160,26 @@ test('worker key lookup uses the encrypted column ordinal', async () => {
   ).toEqual(new Uint8Array(secondKey));
 });
 
+test('ParquetReader resolves each encrypted key once per reader', async () => {
+  const requestedKeyMetadata: string[] = [];
+  const keyRetriever = (keyMetadata: Uint8Array | undefined) => {
+    const keyId = keyMetadata ? new TextDecoder().decode(keyMetadata) : '';
+    requestedKeyMetadata.push(keyId);
+    return ENCRYPTED_KEYS[keyId];
+  };
+  const url = `${PARQUET_DIR}/encrypted/encrypt_columns_and_footer.parquet.encrypted`;
+
+  await load(url, ParquetJSLoader, {
+    core: {worker: false},
+    parquet: {
+      columns: ['double_field', 'float_field'],
+      keyRetriever
+    }
+  });
+
+  expect(requestedKeyMetadata.length).toBe(new Set(requestedKeyMetadata).size);
+});
+
 test('verifies plaintext-footer signatures and rejects tampering', async () => {
   const footerBytes = new TextEncoder().encode('serialized parquet footer');
   const fileUnique = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);

--- a/modules/parquet/test/parquet-encryption.spec.ts
+++ b/modules/parquet/test/parquet-encryption.spec.ts
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {load} from '@loaders.gl/core';
+import {fetchFile, load} from '@loaders.gl/core';
+import {ArrayBufferFile} from '@loaders.gl/loader-utils';
 import {
   ParquetJSLoader,
+  ParquetReader,
   ParquetSourceLoader,
   createParquetModuleAad,
   verifyParquetFooterSignature
@@ -161,10 +163,13 @@ test('worker key lookup uses the encrypted column ordinal', async () => {
 });
 
 test('ParquetReader resolves each encrypted key once per reader', async () => {
-  const requestedKeyMetadata: string[] = [];
-  const keyRetriever = (keyMetadata: Uint8Array | undefined) => {
+  const requestedKeyScopes: string[] = [];
+  const keyRetriever = (keyMetadata: Uint8Array | undefined, context: {aad: Uint8Array}) => {
     const keyId = keyMetadata ? new TextDecoder().decode(keyMetadata) : '';
-    requestedKeyMetadata.push(keyId);
+    const moduleType = context.aad[8];
+    const isPageModule = moduleType === 2 || moduleType === 4;
+    const scopeAad = isPageModule ? context.aad.subarray(0, context.aad.length - 2) : context.aad;
+    requestedKeyScopes.push(`${keyId}:${Array.from(scopeAad).join(',')}`);
     return ENCRYPTED_KEYS[keyId];
   };
   const url = `${PARQUET_DIR}/encrypted/encrypt_columns_and_footer.parquet.encrypted`;
@@ -177,7 +182,30 @@ test('ParquetReader resolves each encrypted key once per reader', async () => {
     }
   });
 
-  expect(requestedKeyMetadata.length).toBe(new Set(requestedKeyMetadata).size);
+  expect(requestedKeyScopes.length).toBe(new Set(requestedKeyScopes).size);
+});
+
+test('ParquetReader retries rejected encrypted key resolutions', async () => {
+  const response = await fetchFile(
+    `${PARQUET_DIR}/encrypted/encrypt_columns_and_footer.parquet.encrypted`
+  );
+  const arrayBuffer = await response.arrayBuffer();
+  let attempts = 0;
+  const reader = new ParquetReader(new ArrayBufferFile(arrayBuffer), {
+    keyRetriever: (keyMetadata: Uint8Array | undefined) => {
+      attempts++;
+      if (attempts === 1) {
+        throw new Error('transient key provider failure');
+      }
+      return getEncryptedFixtureKey(keyMetadata);
+    }
+  });
+
+  await expect(reader.readFooter()).rejects.toThrow('transient key provider failure');
+  const metadata = await reader.readFooter();
+  expect(metadata.num_rows?.toNumber()).toBe(50);
+  expect(attempts).toBe(2);
+  reader.close();
 });
 
 test('verifies plaintext-footer signatures and rejects tampering', async () => {


### PR DESCRIPTION
## Goals

- Reduce repeated key-provider and Web Crypto setup during encrypted Parquet scans.
- Preserve the existing key-retriever API while keeping cached key material isolated to one reader.

## Changes

- Cache resolved keys by encryption algorithm and key metadata for each `ParquetReader`.
- Reuse the cache for encrypted footer, column metadata, page-index, Bloom-filter, and page decryptions.
- Clear cached key material when the reader closes.
- Add regression coverage proving each encrypted fixture key is requested once per reader.

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn build-workers`
- `yarn test-node`
- `yarn test-headless modules/parquet/test/parquet-encryption.spec.ts`
- `yarn test-headless modules/parquet/test/parquet-source-loader.spec.ts modules/parquet/test/parquet-page-index-api.spec.ts`
