### PR TITLE
feat(gltf): add GLB v3 writer and feature coverage

### DIFF
--- a/docs/modules/gltf/api-reference/glb-loader.md
+++ b/docs/modules/gltf/api-reference/glb-loader.md
@@ -36,6 +36,7 @@ const gltf = await load(url, GLBLoader);
 Remarks:
 
 - Parses GLB v2 encoded data.
+- Parses draft GLB v3 encoded data, including 64-bit file/chunk lengths and multiple binary chunks.
 - Parses GLB v1 encoded data (enabling support for the glTF v1 `KHR_binary_gltf` extension). Parsed GLB v1 data is returned in the standard `GLB` format.
 - Extracts multiple binary chunks if present (this is supported by the GLB specification but is not used in the glTF specification).
 

--- a/docs/modules/gltf/formats/glb.md
+++ b/docs/modules/gltf/formats/glb.md
@@ -42,3 +42,19 @@ a `uri`. GLB versions 1 and 2 retain their existing implicit buffer behavior.
 
 This support follows the Khronos [Multiple Binary Chunks in GLB draft](https://github.com/KhronosGroup/glTF/issues/2611)
 and may evolve while glTF 2.1 is finalized.
+
+## Writing GLB v3
+
+`GLBWriter` continues to emit GLB v2 by default. Pass `glb: {version: 3}` to opt into the draft
+v3 container. The input can provide multiple `binChunks` and optional generic `chunks`; each
+buffer's `chunk` index in the JSON remains the application's responsibility and is preserved
+unchanged.
+
+```typescript
+import {GLBWriter} from '@loaders.gl/gltf';
+
+const encoded = GLBWriter.encodeSync(glb, {glb: {version: 3}});
+```
+
+The v3 writer emits 64-bit lengths and currently supports the defined zero chunk encoding only.
+It rejects unsupported encodings and lengths outside JavaScript's safe integer range.

--- a/docs/modules/gltf/formats/gltf.md
+++ b/docs/modules/gltf/formats/gltf.md
@@ -14,14 +14,6 @@ An open standard developed and maintained by the Khronos Group, it supports 3D m
 
 ## Draft glTF 2.1 Unified File References
 
-## Draft glTF 2.1 Shapes and Bounding Volumes
-
-The glTF module preserves the draft 2.1 top-level `shapes` array and node `boundingVolume`
-references. `getGLTFCullingShape(gltf, index)` and `getGLTFNodeCullingShape(gltf, nodeIndex)`
-adapt recognized box, capsule, cylinder, plane, and sphere shapes to the analytic classes in
-`@math.gl/culling`. The helpers return derived objects and never modify the source JSON. Unknown
-shape types return `undefined`, allowing extension-defined shapes to remain available as raw data.
-
 Draft glTF 2.1 adds a top-level `files` array for generic dependencies beyond buffers and images.
 Each file has a required `mimeType` and exactly one source: an external or data `uri`, or an
 embedded `bufferView`. `GLTFLoader` can resolve these entries into its parallel `files` result

--- a/docs/modules/gltf/formats/gltf.md
+++ b/docs/modules/gltf/formats/gltf.md
@@ -107,6 +107,7 @@ evolving specification and is intentionally marked separately from stable glTF 2
 | `.gltf` JSON and external resources | 1.0 / 2.0 / 2.1 | Complete | Complete | URI and data-URI resolution |
 | GLB v1 and v2 | 1.0 / 2.0 | Complete | Complete | GLB loader and writer tests |
 | GLB v3 / multiple binary chunks | 2.1 draft | Complete | Partial | Draft parsing support; format may evolve |
+| GLB v3 writing and round-trip serialization | 2.1 draft | Complete | Complete | Opt-in `GLBWriter` path with 64-bit lengths and multiple BIN chunks |
 | glTF v1 to v2 normalization | 1.0 → 2.0 | Complete | Partial | Best-effort conversion via `gltf.normalize` |
 | Sparse accessors and normalized component values | 2.0 | Complete | Complete | Typed-array extraction and accessor utilities |
 | Draft 2.1 accessor component types | 2.1 draft | Complete | Partial | Includes 32-bit, 16-bit float words, and 64-bit integer representations |
@@ -114,6 +115,10 @@ evolving specification and is intentionally marked separately from stable glTF 2
 | External asset composition | 2.1 draft | Complete | Complete | Recursive loading, caching, and cycle rejection |
 | Asset thumbnails | 2.1 draft | Complete | Complete | Thumbnail image loading and post-processing |
 | Implicit shapes and node bounding volumes | 2.1 draft | Complete | Partial | Box, capsule, cylinder, plane, and sphere adapters via `@math.gl/culling` |
+| WebGPU accessor transforms | 2.0 / 2.1 | Complete | Partial | GPU-oriented derived views are available without rewriting accessor JSON |
+| WebGPU texture format mapping | 2.0 / 2.1 | Complete | Planned | Raw image MIME and texture metadata are preserved; normalized GPU descriptors are the next tranche |
+| WebGPU sampler constants | 2.0 / 2.1 | Complete | Planned | Sampler JSON is preserved; WebGPU address/filter enum mapping is not yet a public helper |
+| WebGPU upload descriptors | 2.0 / 2.1 | Complete | Planned | Future non-mutating descriptors will combine image data, format, dimensions, and sampler state |
 | Mesh and buffer compression (Draco) | 2.0 extension | Complete | Complete | `KHR_draco_mesh_compression` |
 | Mesh compression (meshopt) | 2.0 extension | Complete | Complete | `KHR_meshopt_compression` and `EXT_meshopt_compression` |
 | KTX2 / Basis Universal textures | 2.0 extension | Complete | Complete | `KHR_texture_basisu` |

--- a/docs/modules/gltf/formats/gltf.md
+++ b/docs/modules/gltf/formats/gltf.md
@@ -14,6 +14,14 @@ An open standard developed and maintained by the Khronos Group, it supports 3D m
 
 ## Draft glTF 2.1 Unified File References
 
+## Draft glTF 2.1 Shapes and Bounding Volumes
+
+The glTF module preserves the draft 2.1 top-level `shapes` array and node `boundingVolume`
+references. `getGLTFCullingShape(gltf, index)` and `getGLTFNodeCullingShape(gltf, nodeIndex)`
+adapt recognized box, capsule, cylinder, plane, and sphere shapes to the analytic classes in
+`@math.gl/culling`. The helpers return derived objects and never modify the source JSON. Unknown
+shape types return `undefined`, allowing extension-defined shapes to remain available as raw data.
+
 Draft glTF 2.1 adds a top-level `files` array for generic dependencies beyond buffers and images.
 Each file has a required `mimeType` and exactly one source: an external or data `uri`, or an
 embedded `bufferView`. `GLTFLoader` can resolve these entries into its parallel `files` result

--- a/modules/gltf/src/glb-writer.ts
+++ b/modules/gltf/src/glb-writer.ts
@@ -9,6 +9,8 @@ import {encodeGLBSync} from './lib/encoders/encode-glb';
 import {VERSION} from './lib/utils/version';
 import {GLBFormat} from './gltf-format';
 
+export type {GLBChunk} from './lib/types/glb-types';
+
 export type GLBWriterOptions = WriterOptions & {
   glb?: GLBEncodeOptions;
 };
@@ -30,14 +32,15 @@ export const GLBWriter = {
 
 function encodeSync(glb, options) {
   const {byteOffset = 0} = options ?? {};
+  const glbOptions = options?.glb ?? {};
 
   // Calculate length and allocate buffer
-  const byteLength = encodeGLBSync(glb, null, byteOffset, options);
+  const byteLength = encodeGLBSync(glb, null, byteOffset, glbOptions);
   const arrayBuffer = new ArrayBuffer(byteLength);
 
   // Encode into buffer
   const dataView = new DataView(arrayBuffer);
-  encodeGLBSync(glb, dataView, byteOffset, options);
+  encodeGLBSync(glb, dataView, byteOffset, glbOptions);
 
   return arrayBuffer;
 }

--- a/modules/gltf/src/index.ts
+++ b/modules/gltf/src/index.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 /* eslint-disable camelcase, indent */
-export type {GLB} from './lib/types/glb-types';
+export type {GLB, GLBChunk} from './lib/types/glb-types';
 
 // Raw GLTF Types (i.e. not post-processed)
 export type {

--- a/modules/gltf/src/lib/encoders/encode-glb.ts
+++ b/modules/gltf/src/lib/encoders/encode-glb.ts
@@ -7,7 +7,8 @@ import {
   copyPaddedStringToDataView,
   copyPaddedArrayBufferToDataView
 } from '@loaders.gl/loader-utils';
-// import type {GLB} from '../types/glb-types';
+import type {GLB, GLBChunk} from '../types/glb-types';
+import type {GLTFWithBuffers} from '../types/gltf-types';
 
 const MAGIC_glTF = 0x46546c67; // glTF in ASCII
 const MAGIC_JSON = 0x4e4f534a; // JSON in ASCII
@@ -15,7 +16,11 @@ const MAGIC_BIN = 0x004e4942; // BIN\0 in ASCII
 
 const LE = true; // Binary GLTF is little endian.
 
-export type GLBEncodeOptions = {};
+export type GLBEncodeOptions = {
+  /** GLB version to encode. Defaults to the input version or v2. */
+  version?: number;
+  [key: string]: unknown;
+};
 
 /**
  * Encode the full GLB buffer with header etc
@@ -30,12 +35,21 @@ export type GLBEncodeOptions = {};
  * @todo type GLB argument
  */
 export function encodeGLBSync(
-  glb,
+  glb: GLB | GLTFWithBuffers,
   dataView: DataView | null,
   byteOffset = 0,
   options: GLBEncodeOptions = {}
 ) {
-  const {magic = MAGIC_glTF, version = 2, json = {}, binary} = glb;
+  const magic = MAGIC_glTF;
+  const version = options.version ?? ('version' in glb ? glb.version : 2);
+  const json = glb.json ?? {};
+
+  if (version === 3) return encodeGLBV3(glb, dataView, byteOffset, magic, json);
+  if (version !== 2) throw new Error(`Unsupported GLB writer version ${version}.`);
+  const binary =
+    'binChunks' in glb
+      ? (glb.binary ?? glb.binChunks?.[0]?.arrayBuffer)
+      : glb.buffers?.[0]?.arrayBuffer;
 
   const byteOffsetStart = byteOffset;
 
@@ -77,7 +91,7 @@ export function encodeGLBSync(
     }
     byteOffset += 8; // GLB_CHUNK_HEADER_SIZE
 
-    byteOffset = copyPaddedArrayBufferToDataView(dataView, byteOffset, binary, 4);
+    byteOffset = copyPaddedArrayBufferToDataView(dataView, byteOffset, new Uint8Array(binary), 4);
 
     // Now we know the BIN chunk length so we can write it.
     if (dataView) {
@@ -93,4 +107,76 @@ export function encodeGLBSync(
   }
 
   return byteOffset;
+}
+
+/** Encode a draft GLB v3 container with 64-bit file and chunk lengths. */
+function encodeGLBV3(
+  glb: GLB | GLTFWithBuffers,
+  dataView: DataView | null,
+  byteOffset: number,
+  magic: number,
+  json: Record<string, unknown>
+): number {
+  const byteOffsetStart = byteOffset;
+  const chunks: GLBChunk[] = [
+    {type: MAGIC_JSON, arrayBuffer: encodeJSON(json)},
+    ...(('chunks' in glb ? glb.chunks : []) ?? []),
+    ...('binChunks' in glb
+      ? (glb.binChunks ?? []).map(chunk => ({type: MAGIC_BIN, arrayBuffer: chunk.arrayBuffer}))
+      : (glb.buffers ?? []).map(buffer => ({type: MAGIC_BIN, arrayBuffer: buffer.arrayBuffer})))
+  ];
+
+  if (dataView) {
+    dataView.setUint32(byteOffset, magic, LE);
+    dataView.setUint32(byteOffset + 4, 3, LE);
+    setUint64(dataView, byteOffset + 8, 0, 'GLB file length');
+  }
+  byteOffset += 16;
+
+  for (const chunk of chunks) {
+    const encoding = chunk.encoding ?? 0;
+    if (encoding !== 0) throw new Error(`Unsupported GLB chunk encoding ${encoding}.`);
+    const byteOffsetChunkHeader = byteOffset;
+    if (dataView) {
+      dataView.setUint32(byteOffset, chunk.type, LE);
+      dataView.setUint32(byteOffset + 4, encoding, LE);
+      setUint64(dataView, byteOffset + 8, 0, 'GLB chunk length');
+    }
+    byteOffset += 16;
+    byteOffset = copyPaddedArrayBufferToDataView(
+      dataView,
+      byteOffset,
+      new Uint8Array(chunk.arrayBuffer),
+      4
+    );
+    if (dataView) {
+      setUint64(
+        dataView,
+        byteOffsetChunkHeader + 8,
+        byteOffset - byteOffsetChunkHeader - 16,
+        'GLB chunk length'
+      );
+    }
+  }
+
+  if (dataView) {
+    setUint64(dataView, byteOffsetStart + 8, byteOffset - byteOffsetStart, 'GLB file length');
+  }
+  return byteOffset;
+}
+
+function encodeJSON(json: Record<string, unknown>): ArrayBuffer {
+  const jsonString = JSON.stringify(json);
+  const byteLength = new TextEncoder().encode(jsonString).byteLength;
+  const paddedByteLength = Math.ceil(byteLength / 4) * 4;
+  const arrayBuffer = new ArrayBuffer(paddedByteLength);
+  const dataView = new DataView(arrayBuffer);
+  copyPaddedStringToDataView(dataView, 0, jsonString, 4);
+  return arrayBuffer;
+}
+
+function setUint64(dataView: DataView, byteOffset: number, value: number, label: string): void {
+  if (!Number.isSafeInteger(value) || value < 0)
+    throw new Error(`${label} is outside the safe integer range.`);
+  dataView.setBigUint64(byteOffset, BigInt(value), LE);
 }

--- a/modules/gltf/src/lib/encoders/encode-glb.ts
+++ b/modules/gltf/src/lib/encoders/encode-glb.ts
@@ -48,8 +48,10 @@ export function encodeGLBSync(
   if (version !== 2) throw new Error(`Unsupported GLB writer version ${version}.`);
   const binary =
     'binChunks' in glb
-      ? (glb.binary ?? glb.binChunks?.[0]?.arrayBuffer)
-      : glb.buffers?.[0]?.arrayBuffer;
+      ? glb.binary
+        ? new Uint8Array(glb.binary)
+        : glb.binChunks?.[0] && getChunkBytes(glb.binChunks[0])
+      : glb.buffers?.[0] && getChunkBytes(glb.buffers[0]);
 
   const byteOffsetStart = byteOffset;
 
@@ -91,7 +93,7 @@ export function encodeGLBSync(
     }
     byteOffset += 8; // GLB_CHUNK_HEADER_SIZE
 
-    byteOffset = copyPaddedArrayBufferToDataView(dataView, byteOffset, new Uint8Array(binary), 4);
+    byteOffset = copyPaddedArrayBufferToDataView(dataView, byteOffset, binary, 4);
 
     // Now we know the BIN chunk length so we can write it.
     if (dataView) {
@@ -122,8 +124,14 @@ function encodeGLBV3(
     {type: MAGIC_JSON, arrayBuffer: encodeJSON(json)},
     ...(('chunks' in glb ? glb.chunks : []) ?? []),
     ...('binChunks' in glb
-      ? (glb.binChunks ?? []).map(chunk => ({type: MAGIC_BIN, arrayBuffer: chunk.arrayBuffer}))
-      : (glb.buffers ?? []).map(buffer => ({type: MAGIC_BIN, arrayBuffer: buffer.arrayBuffer})))
+      ? (glb.binChunks ?? []).map(chunk => ({
+          type: MAGIC_BIN,
+          arrayBuffer: getChunkBytes(chunk).slice().buffer
+        }))
+      : (glb.buffers ?? []).map(buffer => ({
+          type: MAGIC_BIN,
+          arrayBuffer: getChunkBytes(buffer).slice().buffer
+        })))
   ];
 
   if (dataView) {
@@ -163,6 +171,14 @@ function encodeGLBV3(
     setUint64(dataView, byteOffsetStart + 8, byteOffset - byteOffsetStart, 'GLB file length');
   }
   return byteOffset;
+}
+
+function getChunkBytes(chunk: {
+  arrayBuffer: ArrayBuffer;
+  byteOffset: number;
+  byteLength: number;
+}): Uint8Array {
+  return new Uint8Array(chunk.arrayBuffer, chunk.byteOffset, chunk.byteLength);
 }
 
 function encodeJSON(json: Record<string, unknown>): ArrayBuffer {

--- a/modules/gltf/src/lib/types/glb-types.ts
+++ b/modules/gltf/src/lib/types/glb-types.ts
@@ -10,6 +10,16 @@ export type GLBBinChunk = {
   arrayBuffer: ArrayBuffer;
 };
 
+/** A non-JSON chunk that can be emitted in a GLB v3 container. */
+export type GLBChunk = {
+  /** Four-byte chunk type, stored as a little-endian unsigned integer. */
+  type: number;
+  /** Chunk payload. */
+  arrayBuffer: ArrayBuffer;
+  /** GLB v3 chunk encoding. Only zero is currently defined. */
+  encoding?: number;
+};
+
 export type GLB = {
   type: string;
   /** Binary glTF container version. */
@@ -27,4 +37,8 @@ export type GLB = {
   /** Zero-based index of the glTF JSON chunk in the GLB container. */
   jsonChunkIndex: number;
   binChunks: GLBBinChunk[];
+  /** Optional generic chunks to preserve or emit in GLB v3. */
+  chunks?: GLBChunk[];
+  /** Legacy single BIN payload accepted by the writer. */
+  binary?: ArrayBuffer;
 };

--- a/modules/gltf/test/glb-writer.spec.ts
+++ b/modules/gltf/test/glb-writer.spec.ts
@@ -6,8 +6,87 @@ import test from 'test/utils/vitest-tape';
 import {validateWriter} from 'test/common/conformance';
 
 import {GLBWriter} from '@loaders.gl/gltf';
+import {parseSync} from '@loaders.gl/core';
+import {GLBLoader} from '@loaders.gl/gltf/bundled';
 
 test('GLBWriter#loader conformance', t => {
   validateWriter(t, GLBWriter, 'GLBWriter');
+  t.end();
+});
+
+test('GLBWriter#encodeSync(v3) round trips multiple binary chunks', t => {
+  const glb = {
+    type: 'glTF',
+    version: 3,
+    header: {byteOffset: 0, byteLength: 0, hasBinChunk: true},
+    json: {
+      asset: {version: '2.1'},
+      buffers: [
+        {byteLength: 4, chunk: 1},
+        {byteLength: 4, chunk: 2}
+      ]
+    },
+    jsonChunkIndex: 0,
+    binChunks: [
+      {
+        chunkIndex: 1,
+        byteOffset: 0,
+        byteLength: 4,
+        arrayBuffer: new Uint8Array([1, 2, 3, 4]).buffer
+      },
+      {
+        chunkIndex: 2,
+        byteOffset: 0,
+        byteLength: 4,
+        arrayBuffer: new Uint8Array([5, 6, 7, 8]).buffer
+      }
+    ]
+  };
+
+  const encoded = GLBWriter.encodeSync(glb);
+  const decoded = parseSync(encoded, GLBLoader);
+  t.equal(decoded.version, 3, 'writes GLB v3');
+  t.equal(decoded.json.asset.version, '2.1', 'round trips JSON');
+  t.deepEqual(
+    decoded.binChunks.map(chunk =>
+      Array.from(new Uint8Array(chunk.arrayBuffer, chunk.byteOffset, chunk.byteLength))
+    ),
+    [
+      [1, 2, 3, 4],
+      [5, 6, 7, 8]
+    ],
+    'round trips all BIN chunks'
+  );
+  t.end();
+});
+
+test('GLBWriter#encodeSync(v2) remains the default', t => {
+  const glb = {
+    type: 'glTF',
+    version: 2,
+    header: {byteOffset: 0, byteLength: 0, hasBinChunk: true},
+    json: {asset: {version: '2.0'}},
+    jsonChunkIndex: 0,
+    binChunks: [
+      {chunkIndex: 1, byteOffset: 0, byteLength: 2, arrayBuffer: new Uint8Array([1, 2]).buffer}
+    ]
+  };
+  const encoded = GLBWriter.encodeSync(glb);
+  const decoded = parseSync(encoded, GLBLoader);
+  t.equal(decoded.version, 2, 'defaults to GLB v2');
+  t.end();
+});
+
+test('GLBWriter#encodeSync(v3) rejects unsupported chunk encodings', t => {
+  const glb = {
+    type: 'glTF',
+    version: 3,
+    header: {byteOffset: 0, byteLength: 0, hasBinChunk: false},
+    json: {asset: {version: '2.1'}},
+    jsonChunkIndex: 0,
+    binChunks: [],
+    chunks: [{type: 0x54534554, encoding: 1, arrayBuffer: new ArrayBuffer(0)}]
+  };
+  t.throws(() => GLBWriter.encodeSync(glb), /Unsupported GLB chunk encoding 1/);
   t.end();
 });

--- a/modules/gltf/test/glb-writer.spec.ts
+++ b/modules/gltf/test/glb-writer.spec.ts
@@ -2,91 +2,89 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import tapeTest from 'test/utils/vitest-tape';
 import {validateWriter} from 'test/common/conformance';
+import {describe, expect, test} from 'vitest';
 
 import {GLBWriter} from '@loaders.gl/gltf';
 import {parseSync} from '@loaders.gl/core';
 import {GLBLoader} from '@loaders.gl/gltf/bundled';
 
-test('GLBWriter#loader conformance', t => {
+tapeTest('GLBWriter#loader conformance', t => {
   validateWriter(t, GLBWriter, 'GLBWriter');
   t.end();
 });
 
-test('GLBWriter#encodeSync(v3) round trips multiple binary chunks', t => {
-  const glb = {
-    type: 'glTF',
-    version: 3,
-    header: {byteOffset: 0, byteLength: 0, hasBinChunk: true},
-    json: {
-      asset: {version: '2.1'},
-      buffers: [
-        {byteLength: 4, chunk: 1},
-        {byteLength: 4, chunk: 2}
-      ]
-    },
-    jsonChunkIndex: 0,
-    binChunks: [
-      {
-        chunkIndex: 1,
-        byteOffset: 0,
-        byteLength: 4,
-        arrayBuffer: new Uint8Array([1, 2, 3, 4]).buffer
+describe('GLBWriter', () => {
+  test('encodeSync(v3) round trips multiple binary chunks', () => {
+    const glb = {
+      type: 'glTF',
+      version: 3,
+      header: {byteOffset: 0, byteLength: 0, hasBinChunk: true},
+      json: {
+        asset: {version: '2.1'},
+        buffers: [
+          {byteLength: 4, chunk: 1},
+          {byteLength: 4, chunk: 2}
+        ]
       },
-      {
-        chunkIndex: 2,
-        byteOffset: 0,
-        byteLength: 4,
-        arrayBuffer: new Uint8Array([5, 6, 7, 8]).buffer
-      }
-    ]
-  };
+      jsonChunkIndex: 0,
+      binChunks: [
+        {
+          chunkIndex: 1,
+          byteOffset: 1,
+          byteLength: 4,
+          arrayBuffer: new Uint8Array([0, 1, 2, 3, 4, 0]).buffer
+        },
+        {
+          chunkIndex: 2,
+          byteOffset: 1,
+          byteLength: 4,
+          arrayBuffer: new Uint8Array([0, 5, 6, 7, 8, 0]).buffer
+        }
+      ]
+    };
 
-  const encoded = GLBWriter.encodeSync(glb);
-  const decoded = parseSync(encoded, GLBLoader);
-  t.equal(decoded.version, 3, 'writes GLB v3');
-  t.equal(decoded.json.asset.version, '2.1', 'round trips JSON');
-  t.deepEqual(
-    decoded.binChunks.map(chunk =>
-      Array.from(new Uint8Array(chunk.arrayBuffer, chunk.byteOffset, chunk.byteLength))
-    ),
-    [
+    const encoded = GLBWriter.encodeSync(glb);
+    const decoded = parseSync(encoded, GLBLoader);
+    expect(decoded.version).toBe(3);
+    expect(decoded.json.asset.version).toBe('2.1');
+    expect(
+      decoded.binChunks.map(chunk =>
+        Array.from(new Uint8Array(chunk.arrayBuffer, chunk.byteOffset, chunk.byteLength))
+      )
+    ).toEqual([
       [1, 2, 3, 4],
       [5, 6, 7, 8]
-    ],
-    'round trips all BIN chunks'
-  );
-  t.end();
-});
+    ]);
+  });
 
-test('GLBWriter#encodeSync(v2) remains the default', t => {
-  const glb = {
-    type: 'glTF',
-    version: 2,
-    header: {byteOffset: 0, byteLength: 0, hasBinChunk: true},
-    json: {asset: {version: '2.0'}},
-    jsonChunkIndex: 0,
-    binChunks: [
-      {chunkIndex: 1, byteOffset: 0, byteLength: 2, arrayBuffer: new Uint8Array([1, 2]).buffer}
-    ]
-  };
-  const encoded = GLBWriter.encodeSync(glb);
-  const decoded = parseSync(encoded, GLBLoader);
-  t.equal(decoded.version, 2, 'defaults to GLB v2');
-  t.end();
-});
+  test('encodeSync(v2) remains the default', () => {
+    const glb = {
+      type: 'glTF',
+      version: 2,
+      header: {byteOffset: 0, byteLength: 0, hasBinChunk: true},
+      json: {asset: {version: '2.0'}},
+      jsonChunkIndex: 0,
+      binChunks: [
+        {chunkIndex: 1, byteOffset: 0, byteLength: 2, arrayBuffer: new Uint8Array([1, 2]).buffer}
+      ]
+    };
+    const encoded = GLBWriter.encodeSync(glb);
+    const decoded = parseSync(encoded, GLBLoader);
+    expect(decoded.version).toBe(2);
+  });
 
-test('GLBWriter#encodeSync(v3) rejects unsupported chunk encodings', t => {
-  const glb = {
-    type: 'glTF',
-    version: 3,
-    header: {byteOffset: 0, byteLength: 0, hasBinChunk: false},
-    json: {asset: {version: '2.1'}},
-    jsonChunkIndex: 0,
-    binChunks: [],
-    chunks: [{type: 0x54534554, encoding: 1, arrayBuffer: new ArrayBuffer(0)}]
-  };
-  t.throws(() => GLBWriter.encodeSync(glb), /Unsupported GLB chunk encoding 1/);
-  t.end();
+  test('encodeSync(v3) rejects unsupported chunk encodings', () => {
+    const glb = {
+      type: 'glTF',
+      version: 3,
+      header: {byteOffset: 0, byteLength: 0, hasBinChunk: false},
+      json: {asset: {version: '2.1'}},
+      jsonChunkIndex: 0,
+      binChunks: [],
+      chunks: [{type: 0x54534554, encoding: 1, arrayBuffer: new ArrayBuffer(0)}]
+    };
+    expect(() => GLBWriter.encodeSync(glb)).toThrow(/Unsupported GLB chunk encoding 1/);
+  });
 });


### PR DESCRIPTION
## Goals
- Make draft glTF/GLB 2.1 capabilities visible in the feature matrix.
- Add opt-in GLB v3 writing while preserving the existing GLB v2 default.

## Changes
- Add `GLBWriter` support for draft GLB v3 headers, 64-bit lengths, multiple BIN chunks, and generic chunks.
- Keep v2 encoding behavior as the default and accept `GLTFWithBuffers` inputs.
- Add focused round-trip and validation tests.
- Document GLB v3 writing and glTF/WebGPU feature coverage.

## Validation
- `yarn lint fix`
- `yarn test-node`
- `yarn build`