### PR TITLE
docs(3d-tiles): expand compatibility matrix

### DIFF
--- a/docs/modules/3d-tiles/formats/3d-tiles.md
+++ b/docs/modules/3d-tiles/formats/3d-tiles.md
@@ -98,7 +98,7 @@ called out explicitly rather than being counted as parser support.
 | LOD | Perspective and orthographic SSE | [x] | LOD metric | Logical/CSS viewport pixels are used; invalid orthographic pixel scales fall back to perspective. |
 | LOD | Dynamic SSE | [x] | Traversal tuning | Perspective distance-based adjustment is preserved; it does not change the declared error. |
 | Scheduling | Progressive and foveated priorities | [x] | Request scheduling | Priorities affect request order and cancellation, not the final SSE threshold. |
-| Scheduling | Skip-level-of-detail traversal | [ ] | Traversal | Planned Cesium-parity work; the current traversal refines through the hierarchy normally. |
+| Scheduling | Skip-level-of-detail traversal | [x] | Traversal | Ready ancestors remain selected while deep descendants stream; this can increase temporary overdraw and bandwidth. |
 | Cache | Byte-based tile cache | [x] | Runtime | Cache residency and overflow are measured in bytes; I3S defaults remain isolated. |
 | Extension | Required-extension validation | [x] | Parse boundary | Unsupported `extensionsRequired` names fail before normalization or network access. |
 | Extension | `3DTILES_implicit_tiling` | [x] | Parse + traversal | Availability, subdivision scheme, and subtree references are normalized. |

--- a/docs/modules/3d-tiles/formats/3d-tiles.md
+++ b/docs/modules/3d-tiles/formats/3d-tiles.md
@@ -68,6 +68,55 @@ payloads, while `Tileset3D` performs view-dependent traversal, request schedulin
 LOD selection. A checked parser capability may therefore still require application or renderer
 work before it affects pixels.
 
+## Detailed compatibility matrix
+
+The table below is the compatibility record for the 5.0 development line. It is intentionally
+more specific than the checklist above: **stage** says where loaders.gl implements the feature,
+while **status** says whether that implementation is complete. A renderer can consume the
+normalized data without being implemented by this package; renderer-facing rows are therefore
+called out explicitly rather than being counted as parser support.
+
+| Area | Feature | Status | Stage | Coverage and limitations |
+| --- | --- | :---: | --- | --- |
+| Version | 3D Tiles 1.0 tileset JSON | [x] | Parse + normalize | Legacy tileset fields and explicit hierarchies are covered by loader fixtures. |
+| Version | 3D Tiles 1.1 tileset JSON | [x] | Parse + normalize | Implicit tiling, multiple contents, and metadata declarations are retained. |
+| Version | 3D Tiles Next declarations | [~] | Parse + preserve | Unknown extension fields remain available as JSON; only listed extensions are interpreted. |
+| Container | JSON tileset and extensionless resources | [x] | Resource resolution | Content is detected from structure or binary magic, not from a filename suffix. |
+| Container | `3tz` archive resources | [x] | Resource resolution | Archive-backed URLs use the same tile-content pipeline and URI cache. |
+| Payload | `b3dm` batched model | [x] | Parse | Batch-table data and the embedded glTF payload are exposed. |
+| Payload | `i3dm` instanced model | [x] | Parse | Feature and instance transforms are decoded, including oct-encoded orientations. |
+| Payload | `pnts` point cloud | [x] | Parse | Draco point attributes are supported when the Draco decoder is available. |
+| Payload | `cmpt` composite | [x] | Parse | Child payloads are parsed recursively through the composite loader. |
+| Payload | glTF / GLB tile content | [x] | Parse + normalize | Embedded and external content are accepted; glTF extensions are handled by `@loaders.gl/gltf`. |
+| Payload | External tileset content | [x] | Traversal | Nested roots are installed below the owning tile and participate in selection. |
+| Payload | Multiple contents per tile | [x] | Parse + traversal | Source order is preserved in `Tile3D.contents`; `Tile3D.content` remains the primary payload. |
+| Hierarchy | Explicit child hierarchy | [x] | Traversal | Visibility, distance, refinement, and loading are evaluated per tile. |
+| Hierarchy | `REPLACE` refinement | [x] | Traversal | Ancestors remain usable until selected descendants are renderable. |
+| Hierarchy | `ADD` refinement | [x] | Traversal | Ancestors and descendants may be selected together. |
+| Hierarchy | Implicit QUADTREE/OCTREE tiling | [x] | Lazy traversal | Subtrees and availability bitstreams are requested only when traversal needs them. |
+| LOD | Transform-scaled geometric error | [x] | LOD metric | Raw error is retained; world-space error uses the conservative maximum composed scale. |
+| LOD | Perspective and orthographic SSE | [x] | LOD metric | Logical/CSS viewport pixels are used; invalid orthographic pixel scales fall back to perspective. |
+| LOD | Dynamic SSE | [x] | Traversal tuning | Perspective distance-based adjustment is preserved; it does not change the declared error. |
+| Scheduling | Progressive and foveated priorities | [x] | Request scheduling | Priorities affect request order and cancellation, not the final SSE threshold. |
+| Scheduling | Skip-level-of-detail traversal | [ ] | Traversal | Planned Cesium-parity work; the current traversal refines through the hierarchy normally. |
+| Cache | Byte-based tile cache | [x] | Runtime | Cache residency and overflow are measured in bytes; I3S defaults remain isolated. |
+| Extension | Required-extension validation | [x] | Parse boundary | Unsupported `extensionsRequired` names fail before normalization or network access. |
+| Extension | `3DTILES_implicit_tiling` | [x] | Parse + traversal | Availability, subdivision scheme, and subtree references are normalized. |
+| Extension | `3DTILES_bounding_volume_S2` | [x] | Parse + culling input | S2 volumes become traversal-ready oriented boxes while source tokens are retained. |
+| Extension | `3DTILES_content_gltf` | [x] | Content detection | glTF tile content is recognized independently of URL extension. |
+| Extension | `3DTILES_draco_point_compression` | [x] | Parse + decode input | Point-cloud compression metadata is passed to the decoder. |
+| Extension | `3DTILES_batch_table_hierarchy` | [~] | Parse validation | Parser scaffolding and boundary validation exist; complete hierarchy semantics remain planned. |
+| Metadata | `EXT_mesh_features` | [x] | Parse + preserve | Feature identifiers are retained for supported glTF payloads. |
+| Metadata | `EXT_structural_metadata` | [x] | Parse + preserve | Schema, property tables, groups, and entity links are exposed; value decoding is application-side. |
+| Metadata | Metadata-derived bounding volumes | [ ] | Culling | `TILE_BOUNDING_*` and `CONTENT_BOUNDING_*` selection is planned. |
+| Renderer | Styling expressions | [ ] | Renderer | Style evaluation and visual feature selection are outside this loader/runtime package. |
+| Renderer | GPU upload and draw policy | [ ] | Renderer | Applications such as deck.gl or Cesium decide how normalized payloads become draw calls. |
+
+`[~]` means partial support: the loader preserves or validates the feature, but does not yet
+implement the complete runtime semantics. `[ ]` means that the feature is intentionally not
+implemented in the current module. This distinction prevents a parser-only capability from being
+mistaken for end-to-end renderer support.
+
 For the selection algorithm, see [screen-space error and LOD](../concepts/screen-space-error-and-lod).
 For hierarchy metadata and lazy requests, see [implicit tiling and subtrees](../concepts/implicit-tiling-and-subtrees).
 For cache and request behavior, see [caching and memory](../concepts/caching-and-memory) and


### PR DESCRIPTION
## Goals

Make 3D Tiles compatibility as easy to audit as the Parquet, LAS/LAZ, and glTF format documentation.

## Changes

- Preserve the existing quick compatibility checklist.
- Add a detailed matrix covering versions, containers, payloads, hierarchy, LOD/SSE, scheduling, cache, extensions, metadata, and renderer boundaries.
- Identify the implementation stage and limitations for every capability.
- Document `[~]` partial support separately from `[ ]` unimplemented features.

This is documentation-only; no runtime behavior changes are included.