### PR TITLE
fix(3d-tiles): traverse batch hierarchy parents correctly

### DIFF
--- a/modules/3d-tiles/src/lib/classes/tile-3d-batch-table-hierarchy.ts
+++ b/modules/3d-tiles/src/lib/classes/tile-3d-batch-table-hierarchy.ts
@@ -156,10 +156,10 @@ export function traverseHierarchy(hierarchy, instanceIndex, endConditionCallback
 
   const parentCounts = hierarchy.parentCounts;
   const parentIds = hierarchy.parentIds;
-  if (parentIds) {
+  if (!parentIds) {
     return endConditionCallback(hierarchy, instanceIndex);
   }
-  if (parentCounts > 0) {
+  if (parentCounts) {
     return traverseHierarchyMultipleParents(hierarchy, instanceIndex, endConditionCallback);
   }
   return traverseHierarchySingleParent(hierarchy, instanceIndex, endConditionCallback);

--- a/modules/3d-tiles/src/lib/classes/tile-3d-batch-table-hierarchy.ts
+++ b/modules/3d-tiles/src/lib/classes/tile-3d-batch-table-hierarchy.ts
@@ -10,6 +10,12 @@
 // @ts-nocheck
 const defined = x => x !== undefined;
 
+// Reused traversal scratch state. These are module-local so a hierarchy query does not allocate
+// temporary arrays on every feature lookup; the marker separates concurrent logical traversals.
+const scratchVisited = [];
+const scratchStack = [];
+let marker = 0;
+
 /** Throws an error when a hierarchy invariant is violated. */
 function assert(condition, message) {
   if (!condition) {
@@ -156,10 +162,10 @@ export function traverseHierarchy(hierarchy, instanceIndex, endConditionCallback
 
   const parentCounts = hierarchy.parentCounts;
   const parentIds = hierarchy.parentIds;
-  if (!parentIds) {
+  if (parentIds) {
     return endConditionCallback(hierarchy, instanceIndex);
   }
-  if (parentCounts) {
+  if (parentCounts > 0) {
     return traverseHierarchyMultipleParents(hierarchy, instanceIndex, endConditionCallback);
   }
   return traverseHierarchySingleParent(hierarchy, instanceIndex, endConditionCallback);
@@ -223,7 +229,7 @@ function traverseHierarchySingleParent(hierarchy, instanceIndex, endConditionCal
     hasParent = parentId !== instanceIndex;
     instanceIndex = parentId;
   }
-  return undefined;
+  throw new Error('traverseHierarchySingleParent');
 }
 
 // DEBUG CODE

--- a/modules/3d-tiles/src/lib/classes/tile-3d-batch-table-hierarchy.ts
+++ b/modules/3d-tiles/src/lib/classes/tile-3d-batch-table-hierarchy.ts
@@ -10,8 +10,6 @@
 // @ts-nocheck
 const defined = x => x !== undefined;
 
-// Reused traversal scratch state. These are module-local so a hierarchy query does not allocate
-// temporary arrays on every feature lookup; the marker separates concurrent logical traversals.
 const scratchVisited = [];
 const scratchStack = [];
 let marker = 0;
@@ -162,10 +160,10 @@ export function traverseHierarchy(hierarchy, instanceIndex, endConditionCallback
 
   const parentCounts = hierarchy.parentCounts;
   const parentIds = hierarchy.parentIds;
-  if (parentIds) {
+  if (!parentIds) {
     return endConditionCallback(hierarchy, instanceIndex);
   }
-  if (parentCounts > 0) {
+  if (parentCounts) {
     return traverseHierarchyMultipleParents(hierarchy, instanceIndex, endConditionCallback);
   }
   return traverseHierarchySingleParent(hierarchy, instanceIndex, endConditionCallback);
@@ -229,7 +227,7 @@ function traverseHierarchySingleParent(hierarchy, instanceIndex, endConditionCal
     hasParent = parentId !== instanceIndex;
     instanceIndex = parentId;
   }
-  throw new Error('traverseHierarchySingleParent');
+  return undefined;
 }
 
 // DEBUG CODE

--- a/modules/3d-tiles/src/lib/classes/tile-3d-batch-table-hierarchy.ts
+++ b/modules/3d-tiles/src/lib/classes/tile-3d-batch-table-hierarchy.ts
@@ -223,7 +223,7 @@ function traverseHierarchySingleParent(hierarchy, instanceIndex, endConditionCal
     hasParent = parentId !== instanceIndex;
     instanceIndex = parentId;
   }
-  throw new Error('traverseHierarchySingleParent');
+  return undefined;
 }
 
 // DEBUG CODE

--- a/modules/3d-tiles/src/lib/classes/tile-3d-batch-table.ts
+++ b/modules/3d-tiles/src/lib/classes/tile-3d-batch-table.ts
@@ -79,7 +79,9 @@ export default class Tile3DBatchTableParser {
       const result = traverseHierarchy(this._hierarchy, batchId, (hierarchy, instanceIndex) => {
         const classId = hierarchy.classIds[instanceIndex];
         const instanceClass = hierarchy.classes[classId];
-        return instanceClass.name === className;
+        // Returning undefined keeps walking when this class does not match. The hierarchy
+        // traverser treats any defined value as a successful match.
+        return instanceClass.name === className ? true : undefined;
       });
       return defined(result);
     }
@@ -257,7 +259,7 @@ export default class Tile3DBatchTableParser {
     const result = traverseHierarchy(this._hierarchy, batchId, (hierarchy, instanceIndex) => {
       const classId = hierarchy.classIds[instanceIndex];
       const instances = hierarchy.classes[classId].instances;
-      return defined(instances[name]);
+      return defined(instances[name]) ? true : undefined;
     });
 
     return defined(result);
@@ -289,7 +291,7 @@ export default class Tile3DBatchTableParser {
         }
         return clone(propertyValues[indexInClass], true);
       }
-      return null;
+      return undefined;
     });
   }
 
@@ -308,7 +310,7 @@ export default class Tile3DBatchTableParser {
         }
         return true;
       }
-      return false;
+      return undefined;
     });
     return defined(result);
   }

--- a/modules/3d-tiles/test/lib/classes/tile-3d-batch-table-hierarchy.spec.ts
+++ b/modules/3d-tiles/test/lib/classes/tile-3d-batch-table-hierarchy.spec.ts
@@ -7,6 +7,7 @@
 
 import { expect, test } from "vitest";
 import Tile3DBatchTableParser from '../../../src/lib/classes/tile-3d-batch-table';
+import {traverseHierarchy} from '../../../src/lib/classes/tile-3d-batch-table-hierarchy';
 import {loadRootTile} from '../utils/load-utils';
 const BATCH_TABLE_HIERARCHY_URL = '@loaders.gl/3d-tiles/test/data/CesiumJS/Hierarchy/BatchTableHierarchy/tileset.json';
 const BATCH_TABLE_HIERARCHY_BINARY_URL = '@loaders.gl/3d-tiles/test/data/CesiumJS/Hierarchy/BatchTableHierarchyBinary/tileset.json';
@@ -191,30 +192,21 @@ test('Tile3DBatchTableParser#validates hierarchy with multiple parents', () => {
     })).not.toThrow();
 });
 
-test('Tile3DBatchTableParser#traverses multiple parents for inherited properties', () => {
-    const batchTable = new Tile3DBatchTableParser(
-        {
-            HIERARCHY: {
-                instancesLength: 4,
-                classIds: [0, 1, 1, 2],
-                parentCounts: [2, 1, 1, 0],
-                parentIds: [1, 2, 3, 3],
-                classes: [
-                    {name: 'window', length: 1, instances: {window_name: ['window0']}},
-                    {name: 'door', length: 2, instances: {door_name: ['door0', 'door1']}},
-                    {name: 'building', length: 1, instances: {building_name: ['building0']}}
-                ]
-            }
-        },
-        null,
-        4,
-        {'3DTILES_batch_table_hierarchy': true}
-    );
+test('traverseHierarchy#walks multiple parents until a match', () => {
+    const hierarchy = {
+        classIds: [0, 1, 1, 2],
+        parentCounts: [2, 1, 1, 0],
+        parentIndexes: [0, 2, 3, 4],
+        parentIds: [1, 2, 3, 3]
+    };
+    const visitedInstances = [];
+    const result = traverseHierarchy(hierarchy, 0, (currentHierarchy, instanceIndex) => {
+        visitedInstances.push(instanceIndex);
+        return currentHierarchy.classIds[instanceIndex] === 2 ? true : undefined;
+    });
 
-    expect(batchTable.isClass(0, 'building')).toBe(true);
-    expect(batchTable.hasProperty(0, 'building_name')).toBe(true);
-    expect(batchTable.getProperty(0, 'building_name')).toBe('building0');
-    expect(batchTable.isClass(0, 'missing')).toBe(false);
+    expect(result).toBe(true);
+    expect(visitedInstances).toEqual([0, 2, 3]);
 });
 test('Tile3DBatchTableParser#validates hierarchy with multiple parents (2)', () => {
     //             zone

--- a/modules/3d-tiles/test/lib/classes/tile-3d-batch-table-hierarchy.spec.ts
+++ b/modules/3d-tiles/test/lib/classes/tile-3d-batch-table-hierarchy.spec.ts
@@ -7,7 +7,6 @@
 
 import { expect, test } from "vitest";
 import Tile3DBatchTableParser from '../../../src/lib/classes/tile-3d-batch-table';
-import {traverseHierarchy} from '../../../src/lib/classes/tile-3d-batch-table-hierarchy';
 import {loadRootTile} from '../utils/load-utils';
 const BATCH_TABLE_HIERARCHY_URL = '@loaders.gl/3d-tiles/test/data/CesiumJS/Hierarchy/BatchTableHierarchy/tileset.json';
 const BATCH_TABLE_HIERARCHY_BINARY_URL = '@loaders.gl/3d-tiles/test/data/CesiumJS/Hierarchy/BatchTableHierarchyBinary/tileset.json';
@@ -192,22 +191,6 @@ test('Tile3DBatchTableParser#validates hierarchy with multiple parents', () => {
     })).not.toThrow();
 });
 
-test('traverseHierarchy#walks multiple parents until a match', () => {
-    const hierarchy = {
-        classIds: [0, 1, 1, 2],
-        parentCounts: [2, 1, 1, 0],
-        parentIndexes: [0, 2, 3, 4],
-        parentIds: [1, 2, 3, 3]
-    };
-    const visitedInstances = [];
-    const result = traverseHierarchy(hierarchy, 0, (currentHierarchy, instanceIndex) => {
-        visitedInstances.push(instanceIndex);
-        return currentHierarchy.classIds[instanceIndex] === 2 ? true : undefined;
-    });
-
-    expect(result).toBe(true);
-    expect(visitedInstances).toEqual([0, 2, 3]);
-});
 test('Tile3DBatchTableParser#validates hierarchy with multiple parents (2)', () => {
     //             zone
     //             / |  \

--- a/modules/3d-tiles/test/lib/classes/tile-3d-batch-table-hierarchy.spec.ts
+++ b/modules/3d-tiles/test/lib/classes/tile-3d-batch-table-hierarchy.spec.ts
@@ -190,6 +190,32 @@ test('Tile3DBatchTableParser#validates hierarchy with multiple parents', () => {
         '3DTILES_batch_table_hierarchy': true
     })).not.toThrow();
 });
+
+test('Tile3DBatchTableParser#traverses multiple parents for inherited properties', () => {
+    const batchTable = new Tile3DBatchTableParser(
+        {
+            HIERARCHY: {
+                instancesLength: 4,
+                classIds: [0, 1, 1, 2],
+                parentCounts: [2, 1, 1, 0],
+                parentIds: [1, 2, 3, 3],
+                classes: [
+                    {name: 'window', length: 1, instances: {window_name: ['window0']}},
+                    {name: 'door', length: 2, instances: {door_name: ['door0', 'door1']}},
+                    {name: 'building', length: 1, instances: {building_name: ['building0']}}
+                ]
+            }
+        },
+        null,
+        4,
+        {'3DTILES_batch_table_hierarchy': true}
+    );
+
+    expect(batchTable.isClass(0, 'building')).toBe(true);
+    expect(batchTable.hasProperty(0, 'building_name')).toBe(true);
+    expect(batchTable.getProperty(0, 'building_name')).toBe('building0');
+    expect(batchTable.isClass(0, 'missing')).toBe(false);
+});
 test('Tile3DBatchTableParser#validates hierarchy with multiple parents (2)', () => {
     //             zone
     //             / |  \


### PR DESCRIPTION
## Goals

Advance Cesium parity for `3DTILES_batch_table_hierarchy` without claiming the incomplete renderer-shaped port is complete.

## Changes

- Correctly dispatch hierarchy traversal between no-parent, single-parent, and multiple-parent representations.
- Continue walking when a class/property does not match instead of treating a negative lookup as a terminal result.
- Add a focused regression test covering inherited class and property lookup through multiple parents.

## Validation

The targeted headless test is included. Local execution is currently blocked by an unrelated dirty-checkout import failure in `modules/loader-utils` (`bindColumnarPredicateParameters` is missing from the modified working tree); CI should run against the clean branch.