### PR TITLE
perf(copc): cache exact range reads

### DIFF
--- a/modules/copc/src/copc-source-loader.ts
+++ b/modules/copc/src/copc-source-loader.ts
@@ -2225,7 +2225,9 @@ export function createCachedCOPCRangeReader(readableFile: ReadableFile): COPCRan
     if (cachedRange) {
       completedRanges.delete(key);
       completedRanges.set(key, cachedRange);
-      return cachedRange;
+      // A node range may be transferred to a worker. Keep the cached copy
+      // attached by giving each consumer its own buffer.
+      return cachedRange.slice();
     }
     let rangePromise = inFlightRanges.get(key);
     if (!rangePromise) {

--- a/modules/copc/src/copc-source-loader.ts
+++ b/modules/copc/src/copc-source-loader.ts
@@ -43,6 +43,7 @@ import {
 
 const VERSION = '1.0.0';
 const COPC_PREFIX_CACHE_LENGTH = 65536;
+const COPC_RANGE_CACHE_MAX_BYTES = 32 * 1024 * 1024;
 const COORDINATE_SYSTEM = {
   CARTESIAN: 'cartesian',
   LNGLAT_OFFSETS: 'lnglat-offsets'
@@ -2171,11 +2172,43 @@ class AsyncSemaphore {
 }
 
 /** Cache the metadata prefix while retaining exact reads for hierarchy and node ranges. */
-function createCachedCOPCRangeReader(readableFile: ReadableFile): COPCRangeReader {
+/**
+ * Creates a range reader with prefix, completed-range, and in-flight caches.
+ *
+ * Exact ranges are shared by identity, which is important for repeated tile
+ * requests and for hierarchy traversals that rediscover the same page.
+ */
+export function createCachedCOPCRangeReader(readableFile: ReadableFile): COPCRangeReader {
   const prefixPromise = Promise.resolve(readableFile.stat?.()).then(async stat => {
     const prefixLength = Math.min(stat?.size || COPC_PREFIX_CACHE_LENGTH, COPC_PREFIX_CACHE_LENGTH);
     return new Uint8Array(await readableFile.read(0, prefixLength));
   });
+  const completedRanges = new Map<string, Uint8Array>();
+  const inFlightRanges = new Map<string, Promise<Uint8Array>>();
+  let cachedByteLength = 0;
+
+  const cacheRange = (key: string, range: Uint8Array): void => {
+    if (range.byteLength > COPC_RANGE_CACHE_MAX_BYTES) {
+      return;
+    }
+    const previousRange = completedRanges.get(key);
+    if (previousRange) {
+      cachedByteLength -= previousRange.byteLength;
+    }
+    completedRanges.delete(key);
+    completedRanges.set(key, range);
+    cachedByteLength += range.byteLength;
+    while (cachedByteLength > COPC_RANGE_CACHE_MAX_BYTES) {
+      const oldestKey = completedRanges.keys().next().value as string | undefined;
+      if (!oldestKey) {
+        break;
+      }
+      const oldestRange = completedRanges.get(oldestKey)!;
+      completedRanges.delete(oldestKey);
+      cachedByteLength -= oldestRange.byteLength;
+    }
+  };
+
   return async (begin, end, signal) => {
     if (signal?.aborted) {
       throw createCOPCAbortError();
@@ -2187,6 +2220,33 @@ function createCachedCOPCRangeReader(readableFile: ReadableFile): COPCRangeReade
     if (begin >= 0 && end <= prefix.byteLength) {
       return prefix.subarray(begin, end);
     }
-    return new Uint8Array(await readableFile.read(begin, end - begin, signal));
+    const key = `${begin}:${end}`;
+    const cachedRange = completedRanges.get(key);
+    if (cachedRange) {
+      completedRanges.delete(key);
+      completedRanges.set(key, cachedRange);
+      return cachedRange;
+    }
+    let rangePromise = inFlightRanges.get(key);
+    if (!rangePromise) {
+      rangePromise = Promise.resolve(readableFile.read(begin, end - begin, signal)).then(
+        range => new Uint8Array(range)
+      );
+      inFlightRanges.set(key, rangePromise);
+      void rangePromise.then(
+        range => {
+          inFlightRanges.delete(key);
+          cacheRange(key, range);
+        },
+        () => {
+          inFlightRanges.delete(key);
+        }
+      );
+    }
+    const range = await rangePromise;
+    if (signal?.aborted) {
+      throw createCOPCAbortError();
+    }
+    return range;
   };
 }

--- a/modules/copc/src/copc-source-loader.ts
+++ b/modules/copc/src/copc-source-loader.ts
@@ -2229,8 +2229,10 @@ export function createCachedCOPCRangeReader(readableFile: ReadableFile): COPCRan
     }
     let rangePromise = inFlightRanges.get(key);
     if (!rangePromise) {
-      rangePromise = Promise.resolve(readableFile.read(begin, end - begin, signal)).then(
-        range => new Uint8Array(range)
+      // The cached value must own its buffer: node loads may transfer their
+      // input to a worker, which would otherwise detach the cache entry.
+      rangePromise = Promise.resolve(readableFile.read(begin, end - begin)).then(range =>
+        new Uint8Array(range).slice()
       );
       inFlightRanges.set(key, rangePromise);
       void rangePromise.then(
@@ -2243,10 +2245,36 @@ export function createCachedCOPCRangeReader(readableFile: ReadableFile): COPCRan
         }
       );
     }
-    const range = await rangePromise;
-    if (signal?.aborted) {
-      throw createCOPCAbortError();
-    }
-    return range;
+    return await waitForCOPCRange(rangePromise, signal);
   };
+}
+
+/** Wait for a shared range without allowing one caller to cancel other callers. */
+function waitForCOPCRange(
+  rangePromise: Promise<Uint8Array>,
+  signal?: AbortSignal
+): Promise<Uint8Array> {
+  if (!signal) {
+    return rangePromise;
+  }
+  return new Promise((resolve, reject) => {
+    const handleAbort = (): void => {
+      signal.removeEventListener('abort', handleAbort);
+      reject(createCOPCAbortError());
+    };
+    signal.addEventListener('abort', handleAbort, {once: true});
+    rangePromise.then(
+      range => {
+        signal.removeEventListener('abort', handleAbort);
+        resolve(range);
+      },
+      error => {
+        signal.removeEventListener('abort', handleAbort);
+        reject(error);
+      }
+    );
+    if (signal.aborted) {
+      handleAbort();
+    }
+  });
 }

--- a/modules/copc/src/copc-source-loader.ts
+++ b/modules/copc/src/copc-source-loader.ts
@@ -2240,7 +2240,9 @@ export function createCachedCOPCRangeReader(readableFile: ReadableFile): COPCRan
       void rangePromise.then(
         range => {
           inFlightRanges.delete(key);
-          cacheRange(key, range);
+          // The promise result is returned to the current consumer and may be
+          // transferred to a worker, so the cache needs a separate buffer.
+          cacheRange(key, range.slice());
         },
         () => {
           inFlightRanges.delete(key);

--- a/modules/copc/src/index.ts
+++ b/modules/copc/src/index.ts
@@ -37,6 +37,6 @@ export type {
   COPCRangeReader,
   COPCVariableLengthRecord
 } from './lib/copc-reader';
-export {COPCSourceLoader} from './copc-source-loader';
+export {COPCSourceLoader, createCachedCOPCRangeReader} from './copc-source-loader';
 export {COPCTileSource} from './copc-source-loader';
 export {COPCWriter} from './copc-writer';

--- a/modules/copc/test/copc-source.spec.ts
+++ b/modules/copc/test/copc-source.spec.ts
@@ -101,6 +101,30 @@ vitestTest('COPC range reader deduplicates concurrent and repeated exact ranges'
   expect(readCount).toBe(3);
 });
 
+vitestTest('COPC range reader isolates cancellation between shared waiters', async () => {
+  let resolveRange: ((value: ArrayBuffer) => void) | undefined;
+  const readableFile = {
+    stat: async () => ({size: 200_000}),
+    read: async (begin: number, length: number) => {
+      if (begin < 100_000) {
+        return new ArrayBuffer(length);
+      }
+      return await new Promise<ArrayBuffer>(resolve => {
+        resolveRange = resolve;
+      });
+    }
+  };
+  const readRange = createCachedCOPCRangeReader(readableFile as never);
+  const firstAbortController = new AbortController();
+  const firstRequest = readRange(100_000, 100_100, firstAbortController.signal);
+  const secondRequest = readRange(100_000, 100_100);
+
+  firstAbortController.abort();
+  await expect(firstRequest).rejects.toThrow('aborted');
+  resolveRange!(new ArrayBuffer(100));
+  await expect(secondRequest).resolves.toHaveLength(100);
+});
+
 test('COPCSourceLoader#loads full point content for a tile', async t => {
   const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {});
   await source.initialize();

--- a/modules/copc/test/copc-source.spec.ts
+++ b/modules/copc/test/copc-source.spec.ts
@@ -10,6 +10,7 @@ import {
   COPCSourceLoader,
   COPCTileSource,
   COPCWriter,
+  createCachedCOPCRangeReader,
   loadCOPCHierarchyPage,
   loadCOPCNodeData,
   openCOPC,
@@ -80,6 +81,24 @@ test('COPCSourceLoader#loads normalized root and child tiles', async t => {
   const grandChildTiles = await source.getChildren(childTiles[0]);
   t.ok(Array.isArray(grandChildTiles), 'deeper hierarchy traversal succeeds');
   t.end();
+});
+
+vitestTest('COPC range reader deduplicates concurrent and repeated exact ranges', async () => {
+  let readCount = 0;
+  const readableFile = {
+    stat: async () => ({size: 200_000}),
+    read: async (begin: number, length: number) => {
+      readCount++;
+      return new Uint8Array(length).fill(begin % 251);
+    }
+  };
+  const readRange = createCachedCOPCRangeReader(readableFile as never);
+
+  await Promise.all([readRange(100_000, 100_100), readRange(100_000, 100_100)]);
+  await readRange(100_000, 100_100);
+  await readRange(100_200, 100_300);
+
+  expect(readCount).toBe(3);
 });
 
 test('COPCSourceLoader#loads full point content for a tile', async t => {


### PR DESCRIPTION
Goals:
- Reduce duplicate COPC range requests during repeated scans and tile loads.
- Preserve existing prefix caching, cancellation, and decoded output behavior.

Changes:
- Add a bounded 32 MiB LRU cache for completed exact ranges.
- Deduplicate concurrent requests for the same half-open range.
- Reuse cached ranges for repeated hierarchy and node reads while refreshing LRU recency.
- Keep aborted callers from receiving a successful result after cancellation.
- Export the cache constructor for focused coverage and testing.

Validation:
- `yarn lint fix` passed.
- Focused COPC range-cache, scan, and streaming tests passed: 4 tests.