### PR TITLE
feat(scan): add optional Arrow scan engine

### DIFF
--- a/docs/developer-guide/common-scan-architecture.md
+++ b/docs/developer-guide/common-scan-architecture.md
@@ -194,6 +194,29 @@ Keeping the common contracts in loader-utils avoids making Parquet or GPU code d
 adapter. SQL retains compatibility exports from `@loaders.gl/sql/table-query` while new generic
 planners can import the lower-level contract directly.
 
+### Optional scan runtime
+
+Applications that want the shared planner and reference executor can opt into the single
+`@loaders.gl/scan` package:
+
+```ts
+import {createScanEngine, parseSQLPredicate} from '@loaders.gl/scan';
+
+const engine = await createScanEngine();
+const result = engine.query(table, {
+  predicate: parseSQLPredicate('population >= 1000000'),
+  columns: ['name', 'population'],
+  limit: 100
+});
+```
+
+Arrow is the built-in reference backend. The factory is asynchronous so optional backends can be
+loaded later without adding backend-specific imports to application code. Format adapters continue
+to import only the lightweight contracts from `@loaders.gl/loader-utils`; importing a format or
+loading metadata does not require the scan runtime. The proof-of-concept backend registry is
+intentionally internal to this one public package rather than exposing a family of backend
+subpaths.
+
 ## Predicates and SQL semantics
 
 Portable predicates use a small JSON-shaped tree:

--- a/modules/scan/README.md
+++ b/modules/scan/README.md
@@ -1,0 +1,35 @@
+# @loaders.gl/scan
+
+Optional scan planning and execution for loaders.gl.
+
+The package has one public entry point. Arrow is the built-in reference executor and establishes
+the portable query semantics used by future backends.
+
+```typescript
+import {createScanEngine, parseSQLPredicate} from '@loaders.gl/scan';
+
+const engine = await createScanEngine();
+const result = engine.query(table, {
+  predicate: parseSQLPredicate('population >= 1000000'),
+  columns: ['name', 'population'],
+  limit: 100
+});
+```
+
+Optional backends can register a lazy loader without adding backend-specific imports to application
+code:
+
+```typescript
+import {createScanEngine, registerScanBackend} from '@loaders.gl/scan';
+
+registerScanBackend('custom', async () => {
+  const {createCustomBackend} = await import('./custom-backend');
+  return createCustomBackend();
+});
+
+const engine = await createScanEngine({backend: 'custom'});
+```
+
+Format packages should depend on the lightweight scan contracts in `@loaders.gl/loader-utils` and
+should not import this package merely to expose metadata or a native scan adapter. Applications opt
+into this package when they want the shared planner or Arrow executor.

--- a/modules/scan/bundle.ts
+++ b/modules/scan/bundle.ts
@@ -1,0 +1,5 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export * from './src/index';

--- a/modules/scan/package.json
+++ b/modules/scan/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@loaders.gl/scan",
+  "description": "Optional scan planning and execution for loaders.gl",
+  "version": "5.0.0-alpha.2",
+  "license": "MIT",
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/visgl/loaders.gl"
+  },
+  "keywords": [
+    "scan",
+    "arrow",
+    "query",
+    "columnar",
+    "geospatial"
+  ],
+  "types": "dist/index.d.ts",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "sideEffects": false,
+  "files": [
+    "src",
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "pre-build": "npm run build-bundle && npm run build-bundle -- --env=dev",
+    "build-bundle": "ocular-bundle ./bundle.ts --output=dist/dist.min.js"
+  },
+  "dependencies": {
+    "@loaders.gl/loader-utils": "5.0.0-alpha.2",
+    "@loaders.gl/schema": "5.0.0-alpha.2",
+    "@loaders.gl/sql": "5.0.0-alpha.2"
+  },
+  "devDependencies": {
+    "@loaders.gl/schema-utils": "5.0.0-alpha.2",
+    "apache-arrow": ">= 17.0.0"
+  }
+}

--- a/modules/scan/src/index.ts
+++ b/modules/scan/src/index.ts
@@ -1,0 +1,23 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export {createScanEngine, registerScanBackend} from './scan-engine';
+export type {
+  ScanBackend,
+  ScanBackendLoader,
+  ScanBackendName,
+  ScanEngine,
+  ScanEngineOptions
+} from './scan-engine';
+
+// Re-export the query vocabulary from one optional entry point for applications. Format adapters
+// should continue importing the lightweight contracts from @loaders.gl/loader-utils.
+export {parseSQLPredicate} from '@loaders.gl/sql';
+export type {ArrowQueryOptions, SQLPredicate} from '@loaders.gl/sql';
+export type {
+  RelationalAggregate,
+  RelationalExpression,
+  RelationalOrderKey,
+  TableQueryOptions
+} from '@loaders.gl/loader-utils';

--- a/modules/scan/src/scan-engine.ts
+++ b/modules/scan/src/scan-engine.ts
@@ -1,0 +1,84 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {ArrowTable} from '@loaders.gl/schema';
+import {
+  explainArrowTableQuery,
+  queryArrowTable,
+  type ArrowQueryOptions,
+  type SQLPredicate
+} from '@loaders.gl/sql';
+import type {TableQueryExplain} from '@loaders.gl/loader-utils';
+
+/** Names accepted by the optional scan engine factory. */
+export type ScanBackendName = 'arrow' | (string & {});
+
+/** A backend implementation for the proof-of-concept Arrow table surface. */
+export type ScanBackend = Readonly<{
+  /** Stable backend name reported by the engine. */
+  name: ScanBackendName;
+  /** Executes a query over one in-memory Arrow table. */
+  query(sourceTable: ArrowTable, options?: ArrowQueryOptions): ArrowTable;
+  /** Explains a query without evaluating table rows. */
+  explain(sourceTable: ArrowTable, options?: ArrowQueryOptions): TableQueryExplain<SQLPredicate>;
+}>;
+
+/** Lazy loader used to register an optional scan backend. */
+export type ScanBackendLoader = () => ScanBackend | Promise<ScanBackend>;
+
+/** Options for creating a scan engine. */
+export type ScanEngineOptions = Readonly<{
+  /** Backend to use. Arrow is the built-in reference backend. */
+  backend?: ScanBackendName;
+}>;
+
+/** Stable application-facing scan engine returned by {@link createScanEngine}. */
+export type ScanEngine = ScanBackend;
+
+const scanBackendLoaders = new Map<ScanBackendName, ScanBackendLoader>();
+
+const arrowScanBackend: ScanBackend = Object.freeze({
+  name: 'arrow',
+  query: queryArrowTable,
+  explain: explainArrowTableQuery
+});
+
+scanBackendLoaders.set('arrow', () => arrowScanBackend);
+
+/**
+ * Registers a lazy scan backend without adding it to the default bundle.
+ *
+ * This is the extension point for future DuckDB and GPU implementations. The backend package can
+ * register a dynamic loader from application code while the public import remains
+ * `@loaders.gl/scan`.
+ */
+export function registerScanBackend(name: ScanBackendName, loader: ScanBackendLoader): void {
+  if (!name || !loader) {
+    throw new Error('A scan backend name and loader are required');
+  }
+  scanBackendLoaders.set(name, loader);
+}
+
+/**
+ * Creates the configured scan engine.
+ *
+ * The factory is asynchronous even for Arrow so optional backends can be loaded lazily later
+ * without changing the application-facing API.
+ */
+export async function createScanEngine(options: ScanEngineOptions = {}): Promise<ScanEngine> {
+  const backendName = options.backend || 'arrow';
+  const loader = scanBackendLoaders.get(backendName);
+  if (!loader) {
+    throw new Error(
+      `Scan backend "${backendName}" is not registered. The proof of concept includes "arrow".`
+    );
+  }
+  const backend = await loader();
+  if (backend.name !== backendName) {
+    throw new Error(
+      `Scan backend loader returned "${backend.name}" while "${backendName}" was requested.`
+    );
+  }
+  return backend;
+}

--- a/modules/scan/test/scan-engine.spec.ts
+++ b/modules/scan/test/scan-engine.spec.ts
@@ -1,0 +1,48 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import * as arrow from 'apache-arrow';
+import {expect, test} from 'vitest';
+import type {ArrowTable} from '@loaders.gl/schema';
+import {convertArrowToSchema} from '@loaders.gl/schema-utils';
+import {createScanEngine, parseSQLPredicate, registerScanBackend} from '@loaders.gl/scan';
+
+test('creates the Arrow reference engine by default', async () => {
+  const engine = await createScanEngine();
+  const result = engine.query(makeArrowTable({name: ['a', 'b'], value: [1, 2]}), {
+    predicate: parseSQLPredicate('value >= 2'),
+    columns: ['name'],
+    limit: 1
+  });
+
+  expect(engine.name).toBe('arrow');
+  expect(result.data.schema.fields.map(field => field.name)).toEqual(['name']);
+  expect(result.data.toArray().map(row => row?.toJSON())).toEqual([{name: 'b'}]);
+});
+
+test('loads a registered backend through the same root API', async () => {
+  registerScanBackend('test', async () => ({
+    name: 'test',
+    query: sourceTable => sourceTable,
+    explain: () => ({}) as never
+  }));
+
+  const engine = await createScanEngine({backend: 'test'});
+  const table = makeArrowTable({value: [1]});
+
+  expect(engine.name).toBe('test');
+  expect(engine.query(table)).toBe(table);
+});
+
+test('reports unavailable backends clearly', async () => {
+  await expect(createScanEngine({backend: 'duckdb'})).rejects.toThrow(
+    'Scan backend "duckdb" is not registered'
+  );
+});
+
+/** Wraps simple test columns in the loaders.gl Arrow table shape. */
+function makeArrowTable(columns: Record<string, readonly unknown[]>): ArrowTable {
+  const data = arrow.tableFromArrays(columns);
+  return {shape: 'arrow-table', schema: convertArrowToSchema(data.schema), data};
+}

--- a/modules/scan/test/scan-engine.spec.ts
+++ b/modules/scan/test/scan-engine.spec.ts
@@ -35,6 +35,35 @@ test('loads a registered backend through the same root API', async () => {
   expect(engine.query(table)).toBe(table);
 });
 
+test('validates backend registrations and loader names', async () => {
+  expect(() => registerScanBackend('' as never, () => ({}) as never)).toThrow(
+    'A scan backend name and loader are required'
+  );
+  expect(() => registerScanBackend('invalid-loader', undefined as never)).toThrow(
+    'A scan backend name and loader are required'
+  );
+
+  registerScanBackend('mismatch', () => ({
+    name: 'different',
+    query: sourceTable => sourceTable,
+    explain: () => ({}) as never
+  }));
+  await expect(createScanEngine({backend: 'mismatch'})).rejects.toThrow(
+    'returned "different" while "mismatch" was requested'
+  );
+});
+
+test('explains Arrow queries through the same engine', async () => {
+  const engine = await createScanEngine({backend: 'arrow'});
+  const explanation = engine.explain(makeArrowTable({value: [1]}), {
+    predicate: parseSQLPredicate('value >= 1'),
+    columns: ['value'],
+    limit: 1
+  });
+
+  expect(explanation.plan.map(step => step.kind)).toEqual(['scan', 'filter', 'project', 'limit']);
+});
+
 test('reports unavailable backends clearly', async () => {
   await expect(createScanEngine({backend: 'duckdb'})).rejects.toThrow(
     'Scan backend "duckdb" is not registered'

--- a/modules/scan/tsconfig.json
+++ b/modules/scan/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "references": [
+    {"path": "../loader-utils"},
+    {"path": "../schema"},
+    {"path": "../sql"}
+  ]
+}

--- a/test/coverage-thresholds.json
+++ b/test/coverage-thresholds.json
@@ -557,6 +557,21 @@
         "branches": 76
       }
     },
+    "@loaders.gl/scan": {
+      "path": "modules/scan",
+      "browser": {
+        "statements": 100,
+        "lines": 100,
+        "functions": 100,
+        "branches": 100
+      },
+      "merged": {
+        "statements": 100,
+        "lines": 100,
+        "functions": 100,
+        "branches": 100
+      }
+    },
     "@loaders.gl/shapefile": {
       "path": "modules/shapefile",
       "browser": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -277,6 +277,12 @@
       "@loaders.gl/sql": [
         "modules/sql/src"
       ],
+      "@loaders.gl/scan": [
+        "modules/scan/src"
+      ],
+      "@loaders.gl/scan/test": [
+        "modules/scan/test"
+      ],
       "@loaders.gl/sql/test": [
         "modules/sql/test"
       ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5710,6 +5710,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@loaders.gl/scan@workspace:modules/scan":
+  version: 0.0.0-use.local
+  resolution: "@loaders.gl/scan@workspace:modules/scan"
+  dependencies:
+    "@loaders.gl/loader-utils": "npm:5.0.0-alpha.2"
+    "@loaders.gl/schema": "npm:5.0.0-alpha.2"
+    "@loaders.gl/schema-utils": "npm:5.0.0-alpha.2"
+    "@loaders.gl/sql": "npm:5.0.0-alpha.2"
+    apache-arrow: "npm:>= 17.0.0"
+  languageName: unknown
+  linkType: soft
+
 "@loaders.gl/scene@npm:^5.0.0-alpha.0, @loaders.gl/scene@workspace:modules/scene":
   version: 0.0.0-use.local
   resolution: "@loaders.gl/scene@workspace:modules/scene"


### PR DESCRIPTION
## Goals

- Introduce a single optional `@loaders.gl/scan` entry point for shared scan planning and execution.
- Keep Arrow as the foundational reference backend without adding an import subpath zoo.
- Establish a lazy backend extension point for future DuckDB and GPU executors while preserving lightweight format adapters.

## Changes

- Add the new `@loaders.gl/scan` workspace package.
- Provide `createScanEngine`, `registerScanBackend`, and shared query vocabulary exports.
- Wire the built-in Arrow executor through the existing portable SQL predicate and table-query APIs.
- Add focused headless tests for default Arrow execution, custom lazy backends, and unavailable backends.
- Document the optional runtime boundary and package ownership in the common scan architecture guide.
- Leave existing `loader-utils` contracts and format adapters compatible for incremental migration.

## Validation

- `yarn build-modules`
- `yarn test-headless modules/scan/test/scan-engine.spec.ts`
- `yarn lint fix`
- `git diff --check`