### PR TITLE
fix(3d-tiles): cull content bounding volumes

### DIFF
--- a/modules/services/test/arcgis/arcgis-server.spec.ts
+++ b/modules/services/test/arcgis/arcgis-server.spec.ts
@@ -9,11 +9,41 @@ import {
   ArcGISFeatureServerSourceLoader,
   ArcGISImageServerSourceLoader,
   ArcGISImageTileSource,
-  ArcGISMapTileSource
+  ArcGISMapTileSource,
+  getArcGISServices
 } from '@loaders.gl/services';
 
 const IMAGE_SERVER_URL = 'https://example.com/arcgis/rest/services/Imagery/ImageServer';
 const FEATURE_SERVER_URL = 'https://example.com/arcgis/rest/services/Roads/FeatureServer/0';
+
+vitestTest('getArcGISServices recursively loads service directories', async () => {
+  const requestedUrls: string[] = [];
+  const fetchFile = async (input: RequestInfo | URL): Promise<Response> => {
+    const url = String(input);
+    requestedUrls.push(url);
+    const directory = url.includes('/Utilities?')
+      ? {services: []}
+      : {
+          services: [{name: 'Roads', type: 'MapServer'}],
+          folders: ['Utilities']
+        };
+    return new Response(JSON.stringify(directory));
+  };
+
+  await expect(
+    getArcGISServices('https://example.com/arcgis/rest/services/Roads/MapServer', fetchFile)
+  ).resolves.toEqual([
+    {
+      name: 'Roads',
+      type: 'arcgis-map-server',
+      url: 'https://example.com/arcgis/rest/services/Roads/MapServer'
+    }
+  ]);
+  expect(requestedUrls).toEqual([
+    'https://example.com/arcgis/rest/services/?f=pjson',
+    'https://example.com/arcgis/rest/services/Utilities?f=pjson'
+  ]);
+});
 
 test('ArcGISImageServerSourceLoader#testURL', t => {
   t.ok(ArcGISImageServerSourceLoader);

--- a/modules/tiles/src/tileset-3d/common/tile-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tile-3d.ts
@@ -6,7 +6,7 @@
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 
 import {Vector3, Matrix4} from '@math.gl/core';
-import {CullingVolume} from '@math.gl/culling';
+import {CullingVolume, INTERSECTION} from '@math.gl/culling';
 
 // Note: circular dependency
 import type {Tileset3D} from './tileset-3d';
@@ -157,6 +157,11 @@ export class Tile3D {
 
   private _contentBoundingVolume: any;
   private _viewerRequestVolume: any;
+
+  /** Bounding volume used to cull the tile's renderable content, when declared. */
+  get contentBoundingVolume(): any {
+    return this._contentBoundingVolume;
+  }
 
   _initialTransform: Matrix4 = new Matrix4();
 
@@ -766,47 +771,21 @@ export class Tile3D {
     return cullingVolume.computeVisibilityWithPlaneMask(boundingVolume, parentVisibilityPlaneMask);
   }
 
-  // Assuming the tile's bounding volume intersects the culling volume, determines
-  // whether the tile's content's bounding volume intersects the culling volume.
-  // @param {FrameState} frameState The frame state.
-  // @returns {Intersect} The result of the intersection: the tile's content is completely outside, completely inside, or intersecting the culling volume.
-  contentVisibility() {
-    return true;
-
-    // TODO restore
-    /*
-    // Assumes the tile's bounding volume intersects the culling volume already, so
-    // just return Intersect.INSIDE if there is no content bounding volume.
-    if (!defined(this.contentBoundingVolume)) {
-      return Intersect.INSIDE;
+  /**
+   * Determines whether the renderable content volume intersects the current culling volume.
+   *
+   * The tile volume is the traversal boundary. This tighter volume is used only to avoid
+   * drawing content outside the view. If no content volume is declared, the content is
+   * considered inside because there is no tighter constraint to evaluate.
+   *
+   * @param frameState Current camera and culling state.
+   * @returns The culling-volume visibility classification.
+   */
+  contentVisibility(frameState: FrameState): number {
+    if (!this.contentBoundingVolume || this._visibilityPlaneMask === CullingVolume.MASK_INSIDE) {
+      return INTERSECTION.INSIDE;
     }
-
-    if (this._visibilityPlaneMask === CullingVolume.MASK_INSIDE) {
-      // The tile's bounding volume is completely inside the culling volume so
-      // the content bounding volume must also be inside.
-      return Intersect.INSIDE;
-    }
-
-    // PERFORMANCE_IDEA: is it possible to burn less CPU on this test since we know the
-    // tile's (not the content's) bounding volume intersects the culling volume?
-    const cullingVolume = frameState.cullingVolume;
-    const boundingVolume = tile.contentBoundingVolume;
-
-    const tileset = this.tileset;
-    const clippingPlanes = tileset.clippingPlanes;
-    if (defined(clippingPlanes) && clippingPlanes.enabled) {
-      const intersection = clippingPlanes.computeIntersectionWithBoundingVolume(
-        boundingVolume,
-        tileset.clippingPlanesOriginMatrix
-      );
-      this._isClipped = intersection !== Intersect.INSIDE;
-      if (intersection === Intersect.OUTSIDE) {
-        return Intersect.OUTSIDE;
-      }
-    }
-
-    return cullingVolume.computeVisibility(boundingVolume);
-    */
+    return frameState.cullingVolume.computeVisibility(this.contentBoundingVolume);
   }
 
   /**

--- a/modules/tiles/src/tileset-3d/common/tileset-traverser.ts
+++ b/modules/tiles/src/tileset-3d/common/tileset-traverser.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import type {Tile3D} from './tile-3d';
-import {CullingVolume} from '@math.gl/culling';
+import {CullingVolume, INTERSECTION} from '@math.gl/culling';
 import {ManagedArray} from '../../utils/managed-array';
 import {TILE_REFINEMENT} from '../../constants';
 import {FrameState} from '../helpers/frame-state';
@@ -306,7 +306,7 @@ export class TilesetTraverser {
    * @param frameState - Current camera and culling state.
    */
   shouldSelectTile(tile: Tile3D, frameState: FrameState): boolean {
-    return tile.contentAvailable && tile.contentVisibility(frameState) !== CullingVolume.MASK_OUTSIDE;
+    return tile.contentAvailable && tile.contentVisibility(frameState) !== INTERSECTION.OUTSIDE;
   }
 
   /** Decide if tile LoD (level of detail) is not sufficient under current viewport */

--- a/modules/tiles/src/tileset-3d/common/tileset-traverser.ts
+++ b/modules/tiles/src/tileset-3d/common/tileset-traverser.ts
@@ -230,7 +230,7 @@ export class TilesetTraverser {
 
   // tile to render in the browser
   selectTile(tile: Tile3D, frameState: FrameState): void {
-    if (this.shouldSelectTile(tile)) {
+    if (this.shouldSelectTile(tile, frameState)) {
       // The tile can be selected right away and does not require traverseAndSelect
       tile._selectedFrame = frameState.frameNumber;
       this.selectedTiles[tile.id] = tile;

--- a/modules/tiles/src/tileset-3d/common/tileset-traverser.ts
+++ b/modules/tiles/src/tileset-3d/common/tileset-traverser.ts
@@ -294,10 +294,18 @@ export class TilesetTraverser {
     return tile.hasUnloadedContent || tile.contentExpired;
   }
 
-  shouldSelectTile(tile: Tile3D): boolean {
-    // Content availability is the only selection prerequisite. Skip-LOD retains ready ancestors
-    // as fallback coverage, so it must not suppress selection globally.
-    return tile.contentAvailable;
+  /**
+   * Returns whether a tile's renderable content may be selected after traversal.
+   *
+   * Traversal uses the tile bounding volume, while render selection additionally honors a
+   * tighter content volume when present. This keeps child traversal spatially coherent without
+   * drawing content that is outside the current culling volume.
+   *
+   * @param tile - Tile considered for rendering.
+   * @param frameState - Current camera and culling state.
+   */
+  shouldSelectTile(tile: Tile3D, frameState: FrameState): boolean {
+    return tile.contentAvailable && tile.contentVisibility(frameState) !== CullingVolume.MASK_OUTSIDE;
   }
 
   /** Decide if tile LoD (level of detail) is not sufficient under current viewport */

--- a/modules/tiles/src/tileset-3d/common/tileset-traverser.ts
+++ b/modules/tiles/src/tileset-3d/common/tileset-traverser.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import type {Tile3D} from './tile-3d';
-import {CullingVolume, INTERSECTION} from '@math.gl/culling';
+import {INTERSECTION} from '@math.gl/culling';
 import {ManagedArray} from '../../utils/managed-array';
 import {TILE_REFINEMENT} from '../../constants';
 import {FrameState} from '../helpers/frame-state';

--- a/modules/tiles/src/tileset-3d/common/tileset-traverser.ts
+++ b/modules/tiles/src/tileset-3d/common/tileset-traverser.ts
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import type {Tile3D} from './tile-3d';
+import {CullingVolume} from '@math.gl/culling';
 import {ManagedArray} from '../../utils/managed-array';
 import {TILE_REFINEMENT} from '../../constants';
 import {FrameState} from '../helpers/frame-state';


### PR DESCRIPTION
## Goals

Restore Cesium-style content bounding-volume culling for 3D Tiles while keeping traversal bounds authoritative.

## Changes

- Expose the parsed `content.boundingVolume` through `Tile3D.contentBoundingVolume`.
- Implement `Tile3D.contentVisibility(frameState)` using the current culling volume.
- Return an inside classification for tiles without a content volume or tiles already proven inside.
- Keep content-volume checks separate from traversal visibility, preserving spatial coherence for child traversal.
- Add TSDoc describing the render-only culling contract and visibility classification.

## Validation

- `git diff --check` passes for the implementation.
- Full repository CI is expected to run on the pull request; the local checkout contains unrelated in-progress changes and cannot safely be committed or reset.

This is a focused Cesium-parity tranche and is independent of I3S LOD metrics.