### PR TITLE
feat(parquet): add encrypted footer writer support

### DIFF
--- a/docs/modules/parquet/formats/parquet.md
+++ b/docs/modules/parquet/formats/parquet.md
@@ -256,7 +256,9 @@ column-chunk reads. Size statistics are available for memory and nested-value pl
 pruning remains future format-completeness work. The TypeScript reader supports AES-GCM and
 AES-GCM-CTR encrypted column metadata, page indexes, Bloom filters, and page modules when a key retriever
 is provided. Encrypted source reads resolve selected data keys on the caller thread and transfer only
-the required key material to the worker; writer-side encryption remains future work.
+the required key material to the worker. `ParquetJSWriter` can now emit an encrypted footer with
+caller-supplied key metadata and a key retriever; column metadata, pages, indexes, and Bloom filters
+remain plaintext on the writer path until a later tranche.
 
 ## Integrity and Encryption
 
@@ -264,7 +266,7 @@ the required key material to the worker; writer-side encryption remains future w
 | ------- | ------- | -------- | ----- |
 | Footer and page-bound validation | ✅ | ✅ | Invalid magic, lengths, indexes, and truncated payloads are rejected |
 | Page CRC verification | ✅ (opt-in) | ✅ (opt-in) | CRC-32 covers the compressed page body; enable verification or emission explicitly to avoid a default throughput cost |
-| [Parquet modular encryption](https://github.com/apache/parquet-format/blob/master/Encryption.md) | ⚠️ | ❌ | Encrypted footers, column metadata, page indexes, Bloom filters, and AES-GCM/AES-GCM-CTR page reads are supported; writer-side encryption remains future work |
+| [Parquet modular encryption](https://github.com/apache/parquet-format/blob/master/Encryption.md) | ⚠️ | ⚠️ | Reader supports encrypted footers, column metadata, page indexes, Bloom filters, and AES-GCM/AES-GCM-CTR page reads; `ParquetJSWriter` emits encrypted footers, while encrypted columns/pages/indexes remain future work |
 | External column chunks | ❌ | ❌ | `file_path` column references are rejected |
 
 ## Parquet and Arrow
@@ -293,7 +295,7 @@ variant has been exhaustively certified.
 | Tranche | Status | Remaining work |
 | ------- | ------ | -------------- |
 | Statistics-driven pruning | ✅ foundation | Use declared sort order for semantic page/row-group pruning and keep selective-range cost estimates aligned with late materialization |
-| Modular encryption | ⚠️ reader foundation | Add encrypted page-index reads, plaintext-footer integrity verification, writer-side encryption/key rotation, and broader cross-implementation fixtures |
+| Modular encryption | ⚠️ expanding | Add writer-side encrypted column/page/index modules, key rotation, and broader cross-implementation fixtures |
 | Logical and legacy parity | ⚠️ expanding | Broaden INT96 and legacy encoding coverage; preserve Arrow fidelity for every logical annotation |
 | Conformance and scale gate | ⚠️ ongoing | Run the Apache corpus, nested/repeated matrices, all stable codecs, differential checks, and large-file benchmarks in the slow lane |
 | Emerging-format lab | 🧪 experimental | Track ALP, PFOR, VECTOR, and format-versioning proposals behind explicit experimental flags; do not advertise them as stable support |

--- a/modules/parquet/src/index.ts
+++ b/modules/parquet/src/index.ts
@@ -103,7 +103,8 @@ export {ParquetWriter} from './parquet-writer';
 export type {
   ParquetJSWriterEncoding,
   ParquetJSWriterOptions,
-  ParquetSortingColumnOption
+  ParquetSortingColumnOption,
+  ParquetWriterEncryptionOptions
 } from './parquet-js-writer';
 export {ParquetJSWriter} from './parquet-js-writer';
 
@@ -116,6 +117,7 @@ export {
 export {
   createParquetModuleAad,
   decryptParquetModule,
+  encryptParquetModule,
   readParquetEncryptedModule,
   verifyParquetFooterSignature,
   type ParquetDecryptModuleOptions,

--- a/modules/parquet/src/lib/parquet-encryption.ts
+++ b/modules/parquet/src/lib/parquet-encryption.ts
@@ -24,6 +24,20 @@ export type ParquetKeyRetriever = (
   context: {algorithm: ParquetEncryptionAlgorithm; aad: Uint8Array}
 ) => Promise<ArrayBuffer | ArrayBufferView> | ArrayBuffer | ArrayBufferView;
 
+/** Writer configuration for an encrypted Parquet footer. */
+export type ParquetWriterEncryptionOptions = {
+  /** Encryption algorithm used for the footer and advertised in FileCryptoMetaData. */
+  algorithm?: ParquetEncryptionAlgorithm;
+  /** Optional key metadata passed to the key retriever and stored in FileCryptoMetaData. */
+  keyMetadata?: Uint8Array;
+  /** AAD prefix included in the file crypto metadata when provided. */
+  aadPrefix?: Uint8Array;
+  /** Eight-byte file identifier used in module AAD; generated when omitted. */
+  fileUnique?: Uint8Array;
+  /** Resolves the footer key without putting key material in writer options. */
+  keyRetriever: ParquetKeyRetriever;
+};
+
 /** Options used when decrypting one serialized Parquet module. */
 export type ParquetDecryptModuleOptions = {
   /** Encryption algorithm selected by the file crypto metadata. */
@@ -133,6 +147,41 @@ export async function decryptParquetModule(
   return new Uint8Array(plaintext);
 }
 
+/** Encrypts one Parquet footer module as nonce-prefixed AES-GCM bytes. */
+export async function encryptParquetModule(
+  plaintext: ArrayBuffer | ArrayBufferView,
+  options: {
+    algorithm: ParquetEncryptionAlgorithm;
+    aad: Uint8Array;
+    keyMetadata?: Uint8Array;
+    keyRetriever: ParquetKeyRetriever;
+  }
+): Promise<Uint8Array> {
+  const keyMaterial = await options.keyRetriever(options.keyMetadata, {
+    algorithm: options.algorithm,
+    aad: options.aad
+  });
+  const cryptoKey = await getCryptoKey(keyMaterial, options.algorithm, false, ['encrypt']);
+  const nonce = new Uint8Array(12);
+  const cryptoProvider = getCryptoProvider();
+  getCryptoRandomValues(nonce);
+  const ciphertext = new Uint8Array(
+    await cryptoProvider.encrypt(
+      {
+        name: 'AES-GCM',
+        iv: nonce as unknown as BufferSource,
+        additionalData: options.aad as unknown as BufferSource
+      },
+      cryptoKey,
+      toUint8Array(plaintext) as unknown as BufferSource
+    )
+  );
+  const encryptedModule = new Uint8Array(nonce.byteLength + ciphertext.byteLength);
+  encryptedModule.set(nonce);
+  encryptedModule.set(ciphertext, nonce.byteLength);
+  return encryptedModule;
+}
+
 /** Verifies a plaintext-footer signature by authenticating the serialized footer bytes. */
 export async function verifyParquetFooterSignature(
   footerBytes: Uint8Array,
@@ -209,6 +258,19 @@ function getCryptoProvider(): SubtleCrypto {
   const cryptoProvider = globalThis.crypto?.subtle;
   if (!cryptoProvider) throw new Error('Parquet encryption requires Web Crypto support');
   return cryptoProvider;
+}
+
+/** Fills a nonce with cryptographically secure random bytes. */
+function getCryptoRandomValues(array: Uint8Array): Uint8Array {
+  const cryptoProvider = globalThis.crypto;
+  if (!cryptoProvider?.getRandomValues) {
+    throw new Error('Parquet encryption requires Web Crypto random values');
+  }
+  const getRandomValues = cryptoProvider.getRandomValues.bind(cryptoProvider) as unknown as (
+    value: Uint8Array
+  ) => Uint8Array;
+  getRandomValues(array);
+  return array;
 }
 
 function toUint8Array(value: ArrayBuffer | ArrayBufferView): Uint8Array {

--- a/modules/parquet/src/parquet-js-writer.ts
+++ b/modules/parquet/src/parquet-js-writer.ts
@@ -10,8 +10,10 @@ import {normalizeParquetOptions} from './lib/utils/normalize-parquet-options';
 import {encodeTableToParquetJs} from './lib/encoders/encode-table-to-parquet-js';
 import {ParquetFormat} from './parquet-format';
 import type {ParquetSortingColumnOption} from './parquetjs/encoder/parquet-encoder';
+import type {ParquetWriterEncryptionOptions} from './lib/parquet-encryption';
 
 export type {ParquetSortingColumnOption} from './parquetjs/encoder/parquet-encoder';
+export type {ParquetWriterEncryptionOptions} from './lib/parquet-encryption';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
@@ -47,6 +49,8 @@ type ParquetJSWriterEncoderOptions = {
   writeStatistics?: boolean | Record<string, boolean>;
   /** Declares row-group sort keys using top-level or dotted nested leaf names. */
   sortingColumns?: readonly ParquetSortingColumnOption[];
+  /** Encrypt the footer using Parquet modular encryption. */
+  encryption?: ParquetWriterEncryptionOptions;
   rowGroupSize?: number;
   pageSize?: number;
   useDataPageV2?: boolean;

--- a/modules/parquet/src/parquetjs/encoder/parquet-encoder.ts
+++ b/modules/parquet/src/parquetjs/encoder/parquet-encoder.ts
@@ -96,6 +96,7 @@ import {
  */
 const PARQUET_MAGIC = 'PAR1';
 const PARQUET_MAGIC_BYTES = encodeUtf8(PARQUET_MAGIC);
+const PARQUET_MAGIC_ENCRYPTED_BYTES = encodeUtf8(PARQUET_MAGIC_ENCRYPTED);
 
 /**
  * Parquet File Format Version
@@ -368,7 +369,7 @@ export class ParquetEnvelopeWriter {
    * Encode the parquet file header
    */
   writeHeader(): Promise<void> {
-    return this.writeSection(PARQUET_MAGIC_BYTES);
+    return this.writeSection(this.encryption ? PARQUET_MAGIC_ENCRYPTED_BYTES : PARQUET_MAGIC_BYTES);
   }
 
   /**
@@ -1338,7 +1339,7 @@ async function encodeEncryptedFooter(
   const algorithmParameters = {
     aad_prefix: options.aadPrefix && new Uint8Array(options.aadPrefix),
     aad_file_unique: fileUnique,
-    supply_aad_prefix: options.aadPrefix ? true : undefined
+    supply_aad_prefix: undefined
   };
   const encryptionAlgorithm =
     algorithm === 'AES_GCM_CTR_V1'

--- a/modules/parquet/src/parquetjs/encoder/parquet-encoder.ts
+++ b/modules/parquet/src/parquetjs/encoder/parquet-encoder.ts
@@ -82,6 +82,14 @@ import {
   encodeParquetSplitBlockBloomFilter
 } from '../../lib/parquet-bloom-filter';
 import {BoundaryOrder} from '../parquet-thrift/BoundaryOrder';
+import {EncryptionAlgorithm} from '../parquet-thrift/EncryptionAlgorithm';
+import {FileCryptoMetaData} from '../parquet-thrift/FileCryptoMetaData';
+import {PARQUET_MAGIC_ENCRYPTED} from '../../lib/constants';
+import {
+  createParquetModuleAad,
+  encryptParquetModule,
+  type ParquetWriterEncryptionOptions
+} from '../../lib/parquet-encryption';
 
 /**
  * Parquet File Magic String
@@ -124,6 +132,8 @@ export interface ParquetEncoderOptions {
   writeStatistics?: boolean | Record<string, boolean>;
   /** Declare the row-group sort order using top-level or dotted leaf column names. */
   sortingColumns?: readonly ParquetSortingColumnOption[];
+  /** Encrypt the footer using Parquet modular encryption. */
+  encryption?: ParquetWriterEncryptionOptions;
 
   // Write Stream Options
   flags?: string;
@@ -319,6 +329,8 @@ export class ParquetEnvelopeWriter {
   public writeSizeStatistics: boolean;
   public writeStatistics?: boolean | Record<string, boolean>;
   public sortingColumns?: readonly ParquetSortingColumnOption[];
+  /** Optional modular-encryption configuration for the footer. */
+  public encryption?: ParquetWriterEncryptionOptions;
 
   constructor(
     schema: ParquetSchema,
@@ -344,6 +356,7 @@ export class ParquetEnvelopeWriter {
     this.writeSizeStatistics = Boolean(opts.writeSizeStatistics);
     this.writeStatistics = opts.writeStatistics;
     this.sortingColumns = opts.sortingColumns;
+    this.encryption = opts.encryption;
   }
 
   writeSection(buf: Uint8Array): Promise<void> {
@@ -386,15 +399,18 @@ export class ParquetEnvelopeWriter {
   /**
    * Write the parquet file footer
    */
-  writeFooter(userMetadata: Record<string, string>): Promise<void> {
+  async writeFooter(userMetadata: Record<string, string>): Promise<void> {
     if (!userMetadata) {
       // tslint:disable-next-line:no-parameter-reassignment
       userMetadata = {};
     }
 
-    return this.writeSection(
-      encodeFooter(this.schema, this.rowCount, this.rowGroups, userMetadata)
-    );
+    const footer = encodeFooter(this.schema, this.rowCount, this.rowGroups, userMetadata);
+    if (!this.encryption) {
+      await this.writeSection(footer);
+      return;
+    }
+    await this.writeSection(await encodeEncryptedFooter(footer, this.encryption));
   }
 
   /**
@@ -1307,6 +1323,56 @@ function encodeFooter(
   writeUInt32LE(footerEncoded, metadataEncoded.length, metadataEncoded.length);
   footerEncoded.set(PARQUET_MAGIC_BYTES, metadataEncoded.length + 4);
   return footerEncoded;
+}
+
+/** Wraps a serialized footer in Parquet modular-encryption metadata and AES-GCM. */
+async function encodeEncryptedFooter(
+  footer: Uint8Array,
+  options: ParquetWriterEncryptionOptions
+): Promise<Uint8Array> {
+  const algorithm = options.algorithm ?? 'AES_GCM_V1';
+  const fileUnique = options.fileUnique ? new Uint8Array(options.fileUnique) : createFileUnique();
+  if (fileUnique.byteLength !== 8) {
+    throw new Error(`Parquet encrypted footer file_unique must be 8 bytes`);
+  }
+  const algorithmParameters = {
+    aad_prefix: options.aadPrefix && new Uint8Array(options.aadPrefix),
+    aad_file_unique: fileUnique,
+    supply_aad_prefix: options.aadPrefix ? true : undefined
+  };
+  const encryptionAlgorithm =
+    algorithm === 'AES_GCM_CTR_V1'
+      ? new EncryptionAlgorithm({AES_GCM_CTR_V1: algorithmParameters})
+      : new EncryptionAlgorithm({AES_GCM_V1: algorithmParameters});
+  const cryptoMetadata = serializeThrift(
+    new FileCryptoMetaData({
+      encryption_algorithm: encryptionAlgorithm,
+      key_metadata: options.keyMetadata && new Uint8Array(options.keyMetadata)
+    })
+  );
+  const footerMetadata = footer.subarray(0, footer.byteLength - 8);
+  const encryptedFooter = await encryptParquetModule(footerMetadata, {
+    algorithm,
+    aad: createParquetModuleAad(options.aadPrefix, fileUnique, 'footer'),
+    keyMetadata: options.keyMetadata,
+    keyRetriever: options.keyRetriever
+  });
+  const metadataSize = cryptoMetadata.byteLength + encryptedFooter.byteLength;
+  const trailer = new Uint8Array(8);
+  writeUInt32LE(trailer, metadataSize, 0);
+  trailer.set(encodeUtf8(PARQUET_MAGIC_ENCRYPTED), 4);
+  return concatUint8Arrays([cryptoMetadata, encryptedFooter, trailer]);
+}
+
+/** Generates the eight-byte file identifier required by Parquet module AAD. */
+function createFileUnique(): Uint8Array {
+  const fileUnique = new Uint8Array(8);
+  const cryptoProvider = globalThis.crypto;
+  if (!cryptoProvider?.getRandomValues) {
+    throw new Error('Parquet encrypted footer requires Web Crypto random values');
+  }
+  cryptoProvider.getRandomValues(fileUnique);
+  return fileUnique;
 }
 
 /** Returns an explicit or inferred modern logical annotation for a writer field. */

--- a/modules/parquet/src/unbundled.ts
+++ b/modules/parquet/src/unbundled.ts
@@ -31,6 +31,7 @@ export {
 export {
   createParquetModuleAad,
   decryptParquetModule,
+  encryptParquetModule,
   type ParquetDecryptModuleOptions,
   type ParquetEncryptionAlgorithm,
   type ParquetKeyRetriever

--- a/modules/parquet/test/parquet-writer-encryption.spec.ts
+++ b/modules/parquet/test/parquet-writer-encryption.spec.ts
@@ -1,0 +1,57 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {encode, load} from '@loaders.gl/core';
+import {ParquetJSLoader, ParquetJSWriter} from '@loaders.gl/parquet';
+import type {ObjectRowTable} from '@loaders.gl/schema';
+import {expect, test} from 'vitest';
+
+const INPUT: ObjectRowTable = {
+  shape: 'object-row-table',
+  schema: {
+    fields: [
+      {name: 'id', type: 'int32', nullable: false},
+      {name: 'label', type: 'utf8', nullable: false}
+    ],
+    metadata: {}
+  },
+  data: [
+    {id: 1, label: 'one'},
+    {id: 2, label: 'two'},
+    {id: 3, label: 'three'}
+  ]
+};
+
+const KEY = new TextEncoder().encode('0123456789abcdef');
+const KEY_METADATA = new TextEncoder().encode('writer-footer-key');
+const FILE_UNIQUE = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+
+test.each(['AES_GCM_V1', 'AES_GCM_CTR_V1'] as const)(
+  'ParquetJSWriter emits a decryptable encrypted footer with %s',
+  async algorithm => {
+    const parquetBuffer = await encode(INPUT, ParquetJSWriter, {
+      worker: false,
+      parquet: {
+        encryption: {
+          algorithm,
+          fileUnique: FILE_UNIQUE,
+          keyMetadata: KEY_METADATA,
+          keyRetriever: () => KEY
+        }
+      }
+    });
+    const output = await load(parquetBuffer, ParquetJSLoader, {
+      core: {worker: false},
+      parquet: {
+        keyRetriever: keyMetadata => {
+          expect(keyMetadata).toEqual(KEY_METADATA);
+          return KEY;
+        }
+      }
+    });
+
+    expect(output).toMatchObject({shape: 'object-row-table', data: INPUT.data});
+    expect(new TextDecoder().decode(new Uint8Array(parquetBuffer).slice(-4))).toBe('PARE');
+  }
+);

--- a/modules/parquet/test/parquet-writer-encryption.spec.ts
+++ b/modules/parquet/test/parquet-writer-encryption.spec.ts
@@ -51,6 +51,7 @@ test.each(['AES_GCM_V1', 'AES_GCM_CTR_V1'] as const)(
       }
     });
 
+    expect(new TextDecoder().decode(new Uint8Array(parquetBuffer).slice(0, 4))).toBe('PARE');
     expect(output).toMatchObject({shape: 'object-row-table', data: INPUT.data});
     expect(new TextDecoder().decode(new Uint8Array(parquetBuffer).slice(-4))).toBe('PARE');
   }


### PR DESCRIPTION
## Goals

- Add a standards-aligned first writer tranche for Parquet modular encryption.
- Let browser-capable TypeScript users produce encrypted-footer files without exposing raw key material in writer options.

## Changes

- Add `ParquetJSWriter` encryption options for `AES_GCM_V1` and `AES_GCM_CTR_V1` footer metadata.
- Resolve the footer key through the existing `ParquetKeyRetriever` contract and authenticate the encrypted footer with Parquet module AAD.
- Emit the `FileCryptoMetaData` envelope and `PARE` trailer expected by encrypted-footer readers.
- Generate or accept the required eight-byte file identifier and use Web Crypto for nonce generation and AES-GCM encryption.
- Add round-trip coverage for both advertised algorithms and document the remaining encrypted column/page/index writer work.

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn test-node`
- `yarn test-headless modules/parquet/test/parquet-writer-encryption.spec.ts modules/parquet/test/parquet-writer-pages.spec.ts modules/parquet/test/parquet-writer-dictionary.spec.ts`
