### PR TITLE
feat(services): complete ArcGIS service tranches 2-4 and 12

### DIFF
--- a/modules/services/README.md
+++ b/modules/services/README.md
@@ -6,4 +6,30 @@ This package is the home for ArcGIS REST service integrations including FeatureS
 
 ArcGIS sources are owned and exported exclusively by this package. OGC protocol implementations, including WMS, WMTS, WFS, GML, and CSW, are exported by `@loaders.gl/wms`.
 
+```ts
+import {createDataSource} from '@loaders.gl/core';
+import {
+  ArcGISFeatureServerSourceLoader,
+  ArcGISImageServerSourceLoader,
+  ArcGISMapTileSourceLoader
+} from '@loaders.gl/services';
+
+const features = await createDataSource(
+  'https://example.com/arcgis/rest/services/Roads/FeatureServer/0',
+  [ArcGISFeatureServerSourceLoader]
+);
+
+const imagery = await createDataSource(
+  'https://example.com/arcgis/rest/services/Elevation/ImageServer',
+  [ArcGISImageServerSourceLoader]
+);
+
+const mapTiles = await createDataSource(
+  'https://example.com/arcgis/rest/services/World/MapServer',
+  [ArcGISMapTileSourceLoader]
+);
+```
+
+The same source adapters provide normalized metadata and the generic vector, image, and tile APIs used by loaders.gl and deck.gl integrations.
+
 For documentation, visit the [loaders.gl website](https://loaders.gl/docs).

--- a/modules/services/README.md
+++ b/modules/services/README.md
@@ -16,17 +16,20 @@ import {
 
 const features = await createDataSource(
   'https://example.com/arcgis/rest/services/Roads/FeatureServer/0',
-  [ArcGISFeatureServerSourceLoader]
+  [ArcGISFeatureServerSourceLoader],
+  {}
 );
 
 const imagery = await createDataSource(
   'https://example.com/arcgis/rest/services/Elevation/ImageServer',
-  [ArcGISImageServerSourceLoader]
+  [ArcGISImageServerSourceLoader],
+  {}
 );
 
 const mapTiles = await createDataSource(
   'https://example.com/arcgis/rest/services/World/MapServer',
-  [ArcGISMapTileSourceLoader]
+  [ArcGISMapTileSourceLoader],
+  {}
 );
 ```
 

--- a/modules/services/src/arcgis/arcgis-feature-server-source-loader.ts
+++ b/modules/services/src/arcgis/arcgis-feature-server-source-loader.ts
@@ -65,7 +65,6 @@ export type ArcGISFeatureServerSourceLoaderOptions = DataSourceOptions & {
 };
 
 /**
- * @ndeprecated This is a WIP, not fully implemented
  * @see https://developers.arcgis.com/rest/services-reference/enterprise/feature-service.htm
  */
 export const ArcGISFeatureServerSourceLoader = {
@@ -73,7 +72,7 @@ export const ArcGISFeatureServerSourceLoader = {
   batchType: null as never,
   name: 'ArcGISFeatureServer',
   id: 'arcgis-feature-server',
-  module: 'wms',
+  module: 'services',
   version: '0.0.0',
   extensions: [],
   mimeTypes: [],

--- a/modules/services/src/arcgis/arcgis-image-server-source-loader.ts
+++ b/modules/services/src/arcgis/arcgis-image-server-source-loader.ts
@@ -64,7 +64,7 @@ export const ArcGISImageServerSourceLoader = {
   batchType: null as never,
   name: 'ArcGISImageServer',
   id: 'arcgis-image-server',
-  module: 'wms',
+  module: 'services',
   version: '0.0.0',
   extensions: [],
   mimeTypes: [],

--- a/modules/services/src/arcgis/arcgis-image-tile-source-loader.ts
+++ b/modules/services/src/arcgis/arcgis-image-tile-source-loader.ts
@@ -176,7 +176,7 @@ export const ArcGISImageTileSourceLoader = {
   batchType: null as never,
   name: 'ArcGIS ImageServer tiles',
   id: 'arcgis-image-server-tiles',
-  module: 'wms',
+  module: 'services',
   version: '0.0.0',
   extensions: [],
   mimeTypes: [],

--- a/modules/services/src/arcgis/arcgis-map-tile-source-loader.ts
+++ b/modules/services/src/arcgis/arcgis-map-tile-source-loader.ts
@@ -252,7 +252,7 @@ export const ArcGISMapTileSourceLoader = {
   batchType: null as never,
   name: 'ArcGIS MapServer tiles',
   id: 'arcgis-map-server',
-  module: 'wms',
+  module: 'services',
   version: '0.0.0',
   extensions: [],
   mimeTypes: [],

--- a/modules/services/src/arcgis/arcgis-vector-tile-server-source-loader.ts
+++ b/modules/services/src/arcgis/arcgis-vector-tile-server-source-loader.ts
@@ -171,7 +171,7 @@ export const ArcGISVectorTileServerSourceLoader = {
   batchType: null as never,
   name: 'ArcGIS VectorTileServer',
   id: 'arcgis-vector-tile-server',
-  module: 'wms',
+  module: 'services',
   version: '0.0.0',
   extensions: [],
   mimeTypes: ['application/vnd.mapbox-vector-tile', 'application/x-protobuf'],

--- a/modules/services/test/arcgis/arcgis-server.spec.ts
+++ b/modules/services/test/arcgis/arcgis-server.spec.ts
@@ -137,6 +137,42 @@ vitestTest('ArcGISImageSource#exportImageURL supports LERC analytical rasters', 
   expect(exportRasterUrl.searchParams.get('pixelType')).toBe('F32');
 });
 
+vitestTest('ArcGISImageSource#exportRaster requests and returns typed raster data', async () => {
+  const source = ArcGISImageServerSourceLoader.createDataSource(IMAGE_SERVER_URL, {});
+  const raster = {
+    width: 2,
+    height: 1,
+    pixelType: 'F32',
+    statistics: [{minValue: 1, maxValue: 2}],
+    pixels: [new Float32Array([1, 2])],
+    mask: null,
+    depthCount: 1
+  };
+  let parsedLoader;
+  source.fetch = async url => {
+    const requestURL = new URL(url);
+    expect(requestURL.pathname).toBe('/arcgis/rest/services/Imagery/ImageServer/exportImage');
+    expect(requestURL.searchParams.get('format')).toBe('lerc');
+    expect(requestURL.searchParams.get('pixelType')).toBe('F32');
+    return new Response(new Uint8Array([1, 2, 3]));
+  };
+  source.coreApi.parse = async (_data, loader) => {
+    parsedLoader = loader;
+    return raster;
+  };
+
+  const result = await source.exportRaster({
+    bbox: [1, 2, 3, 4],
+    width: 2,
+    height: 1,
+    pixelType: 'F32'
+  });
+
+  expect(parsedLoader).toBeDefined();
+  expect(result).toBe(raster);
+  expect(result.pixels[0]).toBeInstanceOf(Float32Array);
+});
+
 test('ArcGISImageSource#getMetadata', async t => {
   const source = ArcGISImageServerSourceLoader.createDataSource(IMAGE_SERVER_URL, {});
   source.fetch = async () =>

--- a/modules/services/test/arcgis/arcgis-server.spec.ts
+++ b/modules/services/test/arcgis/arcgis-server.spec.ts
@@ -4,6 +4,7 @@
 
 import test from 'test/utils/vitest-tape';
 import {expect, test as vitestTest} from 'vitest';
+import {LERCLoader} from '@loaders.gl/lerc';
 
 import {
   ArcGISFeatureServerSourceLoader,
@@ -138,7 +139,6 @@ vitestTest('ArcGISImageSource#exportImageURL supports LERC analytical rasters', 
 });
 
 vitestTest('ArcGISImageSource#exportRaster requests and returns typed raster data', async () => {
-  const source = ArcGISImageServerSourceLoader.createDataSource(IMAGE_SERVER_URL, {});
   const raster = {
     width: 2,
     height: 1,
@@ -149,6 +149,16 @@ vitestTest('ArcGISImageSource#exportRaster requests and returns typed raster dat
     depthCount: 1
   };
   let parsedLoader;
+  const source = ArcGISImageServerSourceLoader.createDataSource(
+    IMAGE_SERVER_URL,
+    {},
+    {
+      parse: async (_data, loader) => {
+        parsedLoader = loader;
+        return raster;
+      }
+    }
+  );
   source.fetch = async url => {
     const requestURL = new URL(url);
     expect(requestURL.pathname).toBe('/arcgis/rest/services/Imagery/ImageServer/exportImage');
@@ -156,11 +166,6 @@ vitestTest('ArcGISImageSource#exportRaster requests and returns typed raster dat
     expect(requestURL.searchParams.get('pixelType')).toBe('F32');
     return new Response(new Uint8Array([1, 2, 3]));
   };
-  source.coreApi.parse = async (_data, loader) => {
-    parsedLoader = loader;
-    return raster;
-  };
-
   const result = await source.exportRaster({
     bbox: [1, 2, 3, 4],
     width: 2,
@@ -168,7 +173,7 @@ vitestTest('ArcGISImageSource#exportRaster requests and returns typed raster dat
     pixelType: 'F32'
   });
 
-  expect(parsedLoader).toBeDefined();
+  expect(parsedLoader).toBe(LERCLoader);
   expect(result).toBe(raster);
   expect(result.pixels[0]).toBeInstanceOf(Float32Array);
 });

--- a/modules/services/test/services-module.spec.ts
+++ b/modules/services/test/services-module.spec.ts
@@ -19,6 +19,14 @@ describe('@loaders.gl/services', () => {
     expect(ArcGISVectorTileServerSourceLoader.id).toBe('arcgis-vector-tile-server');
   });
 
+  test('identifies services-owned loaders', () => {
+    expect(ArcGISFeatureServerSourceLoader.module).toBe('services');
+    expect(ArcGISImageServerSourceLoader.module).toBe('services');
+    expect(ArcGISMapTileSourceLoader.module).toBe('services');
+    expect(ArcGISImageTileSourceLoader.module).toBe('services');
+    expect(ArcGISVectorTileServerSourceLoader.module).toBe('services');
+  });
+
   test('finds service loaders by id or type', () => {
     expect(getServiceLoader('ArcGIS-Feature-Server')).toBe(ArcGISFeatureServerSourceLoader);
     expect(getServiceLoader('arcgis-vector-tile-server')).toBe(ArcGISVectorTileServerSourceLoader);


### PR DESCRIPTION
Goals of this PR

- Complete the productization and hardening work for the existing WMTS/ArcGIS tile and ArcGIS FeatureServer/ImageServer capabilities.
- Make the services ownership explicit and provide a concise usage path for applications.
- Verify analytical LERC raster requests and typed-array output.

Actual changes

- Mark all ArcGIS source loaders as owned by the `services` module instead of `wms`.
- Remove the stale WIP/deprecation annotation from the ArcGIS FeatureServer source loader.
- Add a package README example covering FeatureServer, ImageServer, and MapServer sources.
- Add an explicit services-module ownership test for the complete ArcGIS loader family.
- Add an analytical `exportRaster` test verifying LERC request parameters and typed raster pixels.

Scope note

The underlying WMTS, ArcGIS tile, FeatureServer, ImageServer, and LERC implementations already landed in earlier work. This PR completes tranches 2–4 and 12 as consolidation, public usage documentation, metadata correctness, and focused hardening rather than duplicating those implementations.

Validation

- `yarn lint fix`
- `yarn build`
- `yarn test-headless modules/services/test` (29 passed)
- `yarn test-audit` (0 violations)