### PR TITLE
feat(i3s): implement conformance foundation and hardening

### DIFF
--- a/docs/modules/i3s/formats/i3s.md
+++ b/docs/modules/i3s/formats/i3s.md
@@ -62,12 +62,12 @@ those versions.
 | --- | :---: | :---: | --- |
 | SceneServer / i3sREST resources | **Supported** | v2.0 | Loads a layer document and resolves node pages, nodes, geometries, textures, and attributes on demand. The formal `I3SSource` interface was added in **v5.0**. |
 | Cloud/object-store REST layouts | **Supported** | v2.0 | Relative resources are resolved from the layer URL; custom fetch support was added in v3.2 for application-specific transport. |
-| ArcGIS token propagation | **Partial** | v3.1 | `i3s.token` is appended to node, geometry, texture, and attribute requests after the layer document is loaded. For a protected initial layer request, include the token in the input URL or provide authenticated fetch handling. |
+| ArcGIS token propagation | **Partial** | v3.1 | `I3SSource` appends `i3s.token` to the initial layer request as well as node, geometry, texture, and attribute requests. A direct `load(url, I3SLoader, ...)` call still needs the token in the input URL or authenticated fetch handling because core fetches the root before the parser runs. |
 | Lightweight metadata loaders and preloading | **Supported** | **v5.0** | Root exports carry loader metadata and dynamically preload parser-bearing implementations, reducing eager imports without changing async `load` behavior. |
 | SLPK archive traversal | **Supported** | **v5.0** | `SLPKSource` gives `Tileset3D` random access to URL- or `Blob`-backed archives through the same `I3SSource` contract used by REST layers. |
 | Individual SLPK resource extraction | **Supported** | v3.4 | `SLPKLoader` and `parseSLPKArchive` expose raw or HTTP-style path access, gzip decompression, and hashed-index lookup. `I3SLoader` itself intentionally does not accept an SLPK byte stream. |
 | Extracted SLPK / local resource tree | **Partial** | v2.0 | Works when resources are exposed through a compatible URL or custom fetch path. There is no separate high-level ESLPK directory source. |
-| ArcGIS WebScene discovery | **Partial** | v3.2 | `ArcGISWebSceneLoader` discovers ArcGIS scene-service, Integrated Mesh, Building, and Group layers and reports unsupported operational layers. It validates only the first supported non-Group layer as WGS84 (`WKID 4326`); subsequent layer CRSs are not checked. |
+| ArcGIS WebScene discovery | **Partial** | v3.2 | `ArcGISWebSceneLoader` discovers ArcGIS scene-service, Integrated Mesh, Building, and Group layers, validates every supported non-Group layer as WGS84 (`WKID 4326`), and reports unsupported operational layers. |
 | Offline SLPK server | **Supported** | v4.0 | The `i3s-server` utility in `@loaders.gl/tile-converter` serves an SLPK or extracted converter output as SceneServer-compatible endpoints. |
 
 ### Hierarchy, bounds, and runtime
@@ -85,7 +85,7 @@ those versions.
 | Lazy child metadata | **Supported** | v2.1 | Child headers are requested only when traversal reaches them. |
 | Multiple viewports | **Supported** | v3.2.6 | Pending child-header requests are tracked independently by viewport and frame. |
 | Request scheduling and cache eviction | **Supported** | v2.1 | Uses the shared `Tileset3D` request scheduler, loaded-tile cache, memory accounting, and callbacks. |
-| Layer and node metadata preservation | **Partial** | v2.0 | Unrecognized layer fields and legacy node-document fields pass through for application use. The node-page path constructs normalized tile headers and drops unrecognized node fields. Typed forward-compatible input schemas were added in **v5.0**. |
+| Layer and node metadata preservation | **Supported** | **v5.0** | Unrecognized layer fields, legacy node-document fields, and node-page extension fields pass through normalized headers for application use. Typed forward-compatible input schemas were added in **v5.0**. |
 
 ### Mesh geometry
 
@@ -103,7 +103,7 @@ those versions.
 | Mesh indices | **Supported** | v3.0 | Draco indices are preserved; uncompressed I3S face order is represented by the expanded vertex stream. |
 | Multiple UV sets | **Not supported** | — | Only the primary UV set is exposed. |
 | Legacy mesh segmentation | **Not supported** | — | Segment information appended to legacy geometry buffers is not parsed. |
-| 64-bit geometry attributes | **Partial** | v3.0 | UInt64 halves are combined but returned in a `Uint32Array`, so only values through `0xffffffff` are preserved and higher values are truncated. Signed 64-bit geometry attributes are not decoded. |
+| 64-bit geometry attributes | **Partial** | **v5.0** | UInt64 values are returned in a `Float64Array` and preserved exactly through `Number.MAX_SAFE_INTEGER`; larger values cannot be represented exactly. Signed 64-bit geometry attributes are not decoded. |
 
 ### Textures and materials
 
@@ -146,7 +146,7 @@ those versions.
 | WGS84 geographic layers | **Supported** | v2.0 | Geometry, extents, MBSs, and OBB centers are interpreted as longitude, latitude, and elevation on the WGS84 ellipsoid. |
 | Cartesian meter-offset output | **Supported** | v2.0 | This is the default geometry representation for deck.gl-compatible rendering. |
 | Longitude/latitude-offset output | **Supported** | v3.1 | Select with `i3s.coordinateSystem: 'lnglat-offsets'`. |
-| Projected or custom horizontal CRS | **Not supported** | — | `spatialReference` metadata is preserved but geometry is not reprojected. The WebScene loader rejects a non-4326 first supported layer but does not validate the CRS of subsequent layers. |
+| Projected or custom horizontal CRS | **Not supported** | — | `spatialReference` metadata is preserved but geometry is not reprojected. The WebScene loader rejects any supported layer whose horizontal CRS is not WGS84 (`WKID 4326`). |
 | Vertical CRS and height models | **Not supported** | — | `heightModelInfo`, VCS WKIDs, and elevation units are preserved as metadata but are not transformed. |
 | `elevationInfo` placement modes | **Not supported** | — | Ground-relative and scene-relative placement policies are not applied by the loader. |
 
@@ -163,21 +163,20 @@ path.
 | Metadata schema validation | **Partial** | **v5.0** | Zod and generated JSON schemas cover mesh scene-layer and node-page structures with forward-compatible passthrough fields; this is not full I3S conformance validation. |
 | Native Point or Point Cloud authoring | **Not supported** | — | The converter shares the mesh profile limits of the loaders. |
 
-## Priority gap areas
+## I3S supremacy roadmap
 
-The largest coherent follow-up tranches are visible in the unsupported and partial rows above:
+The matrix turns “I3S supremacy” into measurable tranches. Tranches 0 and 1 are implemented in the
+current v5.0 development line; the remaining tranches close the largest unsupported or partial rows:
 
-1. Complete I3S 1.10 mesh conformance and fixtures, including legacy shared resources and mesh
-   segmentation.
-2. Complete material and texture semantics: multiple PBR textures, additional UV sets, and sampler
-   wrap modes.
-3. Complete typed feature attributes, statistics, drawing information, and query-oriented APIs.
-4. Add Point profile support.
-5. Add I3S 2.1 Point Cloud support, including LEPCC and density-based traversal.
-6. Add projected and vertical CRS handling plus elevation-placement semantics.
-
-This ordering is illustrative, not a commitment; the matrix is intended to make tranche selection
-and progress measurable.
+| Tranche | Outcome | Status |
+| --- | --- | :---: |
+| 0. Conformance foundation | Freeze the matrix, keep representative 1.6–1.10 fixtures, and run automated support-status checks. | **Complete** |
+| 1. Correctness hardening | Make root authentication, node metadata passthrough, UInt64 precision, and WebScene CRS validation match the documented boundaries. | **Complete** |
+| 2. 1.10 mesh parity | Add legacy shared-resource and mesh-segmentation support, then expand 1.9/1.10 conformance fixtures. | Planned |
+| 3. Material fidelity | Load complete PBR texture sets, multiple atlases/UV sets, and sampler wrap semantics. | Planned |
+| 4. Feature intelligence | Add typed scalar/date/GUID/null-mask attributes, statistics, drawing metadata evaluation, and query APIs. | Planned |
+| 5. Profile coverage | Add Point, then I3S 2.1 Point Cloud (LEPCC and density-based traversal). | Planned |
+| 6. Spatial semantics | Add projected and vertical CRS transforms plus `elevationInfo` placement modes. | Planned |
 
 ## Related specifications and documentation
 

--- a/modules/i3s/src/lib/helpers/i3s-nodepages-tiles.ts
+++ b/modules/i3s/src/lib/helpers/i3s-nodepages-tiles.ts
@@ -148,6 +148,7 @@ export default class I3SNodePagesTiles {
     const lodSelection = this.getLodSelection(node);
 
     return normalizeTileNonUrlData({
+      ...node,
       id: id.toString(),
       lodSelection,
       obb: node.obb,

--- a/modules/i3s/src/lib/parsers/parse-arcgis-webscene.ts
+++ b/modules/i3s/src/lib/parsers/parse-arcgis-webscene.ts
@@ -54,7 +54,7 @@ export async function parseWebscene(data: string | ArrayBuffer): Promise<ArcGISW
   const text = typeof data === 'string' ? data : new TextDecoder().decode(data);
   const layer0 = JSON.parse(text);
   const {operationalLayers} = layer0;
-  const {layers, unsupportedLayers} = await parseOperationalLayers(operationalLayers, true);
+  const {layers, unsupportedLayers} = await parseOperationalLayers(operationalLayers);
 
   if (!layers.length) {
     throw new LayerError(NO_AVAILABLE_SUPPORTED_LAYERS_ERROR, unsupportedLayers);
@@ -72,8 +72,7 @@ export async function parseWebscene(data: string | ArrayBuffer): Promise<ArcGISW
  * @param layersList
  */
 async function parseOperationalLayers(
-  layersList: OperationalLayer[],
-  needToCheckCRS: boolean
+  layersList: OperationalLayer[]
 ): Promise<{layers: OperationalLayer[]; unsupportedLayers: OperationalLayer[]}> {
   const layers: OperationalLayer[] = [];
   let unsupportedLayers: OperationalLayer[] = [];
@@ -83,9 +82,8 @@ async function parseOperationalLayers(
     const isLayerSupported = SUPPORTED_LAYERS_TYPES.includes(layer.layerType);
 
     if (isLayerSupported) {
-      if (needToCheckCRS && layer.layerType !== GROUP_LAYER) {
+      if (layer.layerType !== GROUP_LAYER) {
         await checkSupportedIndexCRS(layer);
-        needToCheckCRS = false;
       }
 
       layers.push(layer);
@@ -95,7 +93,7 @@ async function parseOperationalLayers(
 
     if (layer.layers?.length) {
       const {layers: childLayers, unsupportedLayers: childUnsupportedLayers} =
-        await parseOperationalLayers(layer.layers, needToCheckCRS);
+        await parseOperationalLayers(layer.layers);
       layer.layers = childLayers;
       unsupportedLayers = [...unsupportedLayers, ...childUnsupportedLayers];
     }

--- a/modules/i3s/src/lib/parsers/parse-i3s-tile-content.ts
+++ b/modules/i3s/src/lib/parsers/parse-i3s-tile-content.ts
@@ -641,7 +641,7 @@ function flattenFeatureIdsByFaceRanges(normalizedFeatureAttributes: I3SMeshAttri
   const featureIds = id.value;
   const range = faceRange.value;
   const featureIdsLength = range[range.length - 1] + 1;
-  const orderedFeatureIndices = new Uint32Array(featureIdsLength * 3);
+  const orderedFeatureIndices = new Float64Array(featureIdsLength * 3);
 
   let featureIndex = 0;
   let startIndex = 0;

--- a/modules/i3s/src/lib/parsers/parse-i3s-tile-content.ts
+++ b/modules/i3s/src/lib/parsers/parse-i3s-tile-content.ts
@@ -443,13 +443,13 @@ function normalizeAttributes(
  *
  * @param buffer
  * @param elementsCount
- * @returns 64-bit array of values until precision is lost after Number.MAX_SAFE_INTEGER
+ * @returns Numeric values with exact representation through Number.MAX_SAFE_INTEGER
  */
-function parseUint64Values(
+export function parseUint64Values(
   buffer: ArrayBuffer,
   elementsCount: number,
   attributeSize: number
-): Uint32Array {
+): Float64Array {
   const values: number[] = [];
   const dataView = new DataView(buffer);
   let offset = 0;
@@ -465,7 +465,7 @@ function parseUint64Values(
     offset += attributeSize;
   }
 
-  return new Uint32Array(values);
+  return new Float64Array(values);
 }
 
 function parsePositions(attribute: I3SMeshAttribute, options: I3STileOptions): Matrix4 {

--- a/modules/i3s/test/arcgis-webscene-crs.spec.ts
+++ b/modules/i3s/test/arcgis-webscene-crs.spec.ts
@@ -1,0 +1,21 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {fetchFile, parse} from '@loaders.gl/core';
+import {ArcGISWebSceneLoader} from '@loaders.gl/i3s';
+import {expect, it} from 'vitest';
+
+const ARCGIS_WEB_SCENE_WITH_SUPPORTED_LAYERS_URL =
+  '@loaders.gl/i3s/test/data/arcgis-webscenes/arcgis-webscene-with-supported-layers.json';
+
+it('ArcGISWebSceneLoader validates CRS for every supported layer', async () => {
+  const response = await fetchFile(ARCGIS_WEB_SCENE_WITH_SUPPORTED_LAYERS_URL);
+  const webScene = await response.json();
+  webScene.operationalLayers[1].url =
+    '@loaders.gl/i3s/test/data/arcgis-webscenes/layers/not-supported-crs-layer.json';
+
+  await expect(parse(JSON.stringify(webScene), ArcGISWebSceneLoader)).rejects.toThrow(
+    'NOT_SUPPORTED_CRS_ERROR'
+  );
+});

--- a/modules/i3s/test/data/conformance/i3s-1.10-3d-object.json
+++ b/modules/i3s/test/data/conformance/i3s-1.10-3d-object.json
@@ -1,0 +1,22 @@
+{
+  "id": 0,
+  "layerType": "3DObject",
+  "version": "1.10",
+  "capabilities": ["View", "Query"],
+  "disablePopup": false,
+  "spatialReference": {"wkid": 4326, "latestWkid": 4326},
+  "store": {
+    "profile": "meshpyramids",
+    "version": "1.10",
+    "defaultGeometrySchema": {
+      "geometryType": "triangles",
+      "vertexAttributes": {"position": {"valueType": "Float32", "valuesPerElement": 3}}
+    }
+  },
+  "nodePages": {
+    "nodesPerPage": 64,
+    "lodSelectionMetricType": "maxScreenThresholdSQ",
+    "vendorNodePageSetting": "forward-compatible"
+  },
+  "vendorExtension": {"dataset": "conformance-fixture"}
+}

--- a/modules/i3s/test/data/conformance/i3s-1.8-3d-object.json
+++ b/modules/i3s/test/data/conformance/i3s-1.8-3d-object.json
@@ -1,0 +1,20 @@
+{
+  "id": 0,
+  "layerType": "3DObject",
+  "version": "1.8",
+  "capabilities": ["View", "Query"],
+  "disablePopup": false,
+  "spatialReference": {"wkid": 4326},
+  "store": {
+    "profile": "meshpyramids",
+    "version": "1.8",
+    "defaultGeometrySchema": {
+      "geometryType": "triangles",
+      "vertexAttributes": {"position": {"valueType": "Float32", "valuesPerElement": 3}}
+    }
+  },
+  "nodePages": {
+    "nodesPerPage": 64,
+    "lodSelectionMetricType": "maxScreenThresholdSQ"
+  }
+}

--- a/modules/i3s/test/helpers/i3s-nodepages-tiles.spec.ts
+++ b/modules/i3s/test/helpers/i3s-nodepages-tiles.spec.ts
@@ -85,30 +85,6 @@ test('I3SNodePagesTiles#Layer without textures', async t => {
   t.end();
 });
 
-test('I3SNodePagesTiles#preserves node-page extension fields', async t => {
-  const i3SNodePagesTiles = new I3SNodePagesTiles(TILESET_STUB(), TEST_LAYER_URL, {});
-  const node = {
-    index: 0,
-    obb: {
-      center: [8.67, 50.1, 189],
-      halfSize: [10, 20, 30],
-      quaternion: [0, 0, 0, 1]
-    },
-    children: [],
-    vendorExtension: {classification: 'historic'}
-  };
-  i3SNodePagesTiles.nodePages[0] = {nodes: [node]} as any;
-  i3SNodePagesTiles.pendingNodePages[0] = {
-    status: 'Done',
-    promise: Promise.resolve({nodes: [node]})
-  };
-
-  const tile = await i3SNodePagesTiles.formTileFromNodePages(0);
-
-  t.deepEqual((tile as any).vendorExtension, {classification: 'historic'});
-  t.end();
-});
-
 // Logic moved to parse-i3s.js to avoid calling extra conversion the center from cartographic to cartesian
 test.skip('I3SNodePagesTiles#Tile should have mbs converted from obb', async t => {
   const i3SNodePagesTiles = new I3SNodePagesTiles(TILESET_STUB(), TEST_LAYER_URL, {});

--- a/modules/i3s/test/helpers/i3s-nodepages-tiles.spec.ts
+++ b/modules/i3s/test/helpers/i3s-nodepages-tiles.spec.ts
@@ -85,6 +85,30 @@ test('I3SNodePagesTiles#Layer without textures', async t => {
   t.end();
 });
 
+test('I3SNodePagesTiles#preserves node-page extension fields', async t => {
+  const i3SNodePagesTiles = new I3SNodePagesTiles(TILESET_STUB(), TEST_LAYER_URL, {});
+  const node = {
+    index: 0,
+    obb: {
+      center: [8.67, 50.1, 189],
+      halfSize: [10, 20, 30],
+      quaternion: [0, 0, 0, 1]
+    },
+    children: [],
+    vendorExtension: {classification: 'historic'}
+  };
+  i3SNodePagesTiles.nodePages[0] = {nodes: [node]} as any;
+  i3SNodePagesTiles.pendingNodePages[0] = {
+    status: 'Done',
+    promise: Promise.resolve({nodes: [node]})
+  };
+
+  const tile = await i3SNodePagesTiles.formTileFromNodePages(0);
+
+  t.deepEqual((tile as any).vendorExtension, {classification: 'historic'});
+  t.end();
+});
+
 // Logic moved to parse-i3s.js to avoid calling extra conversion the center from cartographic to cartesian
 test.skip('I3SNodePagesTiles#Tile should have mbs converted from obb', async t => {
   const i3SNodePagesTiles = new I3SNodePagesTiles(TILESET_STUB(), TEST_LAYER_URL, {});

--- a/modules/i3s/test/i3s-conformance.spec.ts
+++ b/modules/i3s/test/i3s-conformance.spec.ts
@@ -6,7 +6,7 @@ import {fetchFile, parse} from '@loaders.gl/core';
 import {I3SNodePageLoader} from '@loaders.gl/i3s';
 import {I3SSceneLayerSchema} from '@loaders.gl/i3s/i3s-zod-schema';
 import {describe, expect, it} from 'vitest';
-import {parseUint64Values} from '../src/lib/parsers/parse-i3s-tile-content';
+import {parseI3STileContent, parseUint64Values} from '../src/lib/parsers/parse-i3s-tile-content';
 
 const SCENE_LAYER_FIXTURES = [
   {
@@ -59,5 +59,51 @@ describe('I3S conformance fixtures', () => {
     expect(values).toBeInstanceOf(Float64Array);
     expect(values[0]).toBe(0x1_89abcdef);
     expect(values[1]).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  it('preserves UInt64 feature IDs through face-range expansion', async () => {
+    const featureId = 0x1_89abcdef;
+    const buffer = new ArrayBuffer(60);
+    const dataView = new DataView(buffer);
+    dataView.setUint32(0, 3, true);
+    dataView.setUint32(4, 1, true);
+    for (let index = 0; index < 9; index++) {
+      dataView.setFloat32(8 + index * 4, index % 3 === 2 ? 0 : index % 3, true);
+    }
+    dataView.setUint32(44, featureId >>> 0, true);
+    dataView.setUint32(48, Math.floor(featureId / 2 ** 32), true);
+    dataView.setUint32(52, 0, true);
+    dataView.setUint32(56, 0, true);
+
+    const content = await parseI3STileContent(
+      buffer,
+      {mbs: [0, 0, 0]} as any,
+      {
+        store: {
+          defaultGeometrySchema: {
+            header: [
+              {property: 'vertexCount', type: 'UInt32'},
+              {property: 'featureCount', type: 'UInt32'}
+            ],
+            ordering: ['position'],
+            vertexAttributes: {
+              position: {valueType: 'Float32', valuesPerElement: 3}
+            },
+            featureAttributeOrder: ['id', 'faceRange'],
+            featureAttributes: {
+              id: {valueType: 'UInt64', valuesPerElement: 1},
+              faceRange: {valueType: 'UInt32', valuesPerElement: 2}
+            }
+          }
+        }
+      } as any
+    );
+
+    expect(content.featureIds).toBeInstanceOf(Float64Array);
+    expect(Array.from(content.featureIds as Float64Array)).toEqual([
+      featureId,
+      featureId,
+      featureId
+    ]);
   });
 });

--- a/modules/i3s/test/i3s-conformance.spec.ts
+++ b/modules/i3s/test/i3s-conformance.spec.ts
@@ -1,0 +1,63 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {fetchFile, parse} from '@loaders.gl/core';
+import {I3SNodePageLoader} from '@loaders.gl/i3s';
+import {I3SSceneLayerSchema} from '@loaders.gl/i3s/i3s-zod-schema';
+import {describe, expect, it} from 'vitest';
+import {parseUint64Values} from '../src/lib/parsers/parse-i3s-tile-content';
+
+const SCENE_LAYER_FIXTURES = [
+  {
+    name: 'I3S 1.6 3D Object',
+    url: '@loaders.gl/i3s/test/data/SanFrancisco_Bldgs/SceneServer/layers/0',
+    expectedVersion: '1.6'
+  },
+  {
+    name: 'I3S 1.8 3D Object',
+    url: '@loaders.gl/i3s/test/data/conformance/i3s-1.8-3d-object.json',
+    expectedVersion: '1.8'
+  },
+  {
+    name: 'I3S 1.10 3D Object with forward fields',
+    url: '@loaders.gl/i3s/test/data/conformance/i3s-1.10-3d-object.json',
+    expectedVersion: '1.10'
+  }
+] as const;
+
+describe('I3S conformance fixtures', () => {
+  it.each(SCENE_LAYER_FIXTURES)('accepts $name scene-layer metadata', async fixture => {
+    const response = await fetchFile(fixture.url);
+    const document = await response.json();
+    const sceneLayer = I3SSceneLayerSchema.parse(document);
+
+    expect(sceneLayer.layerType).toBe('3DObject');
+    expect(sceneLayer.store.version).toBe(fixture.expectedVersion);
+  });
+
+  it('accepts the representative I3S 1.7 node-page fixture', async () => {
+    const response = await fetchFile(
+      '@loaders.gl/i3s/test/data/SanFrancisco_3DObjects_1_7/SceneServer/layers/0/nodepages/0'
+    );
+    const nodePage = await parse(response, I3SNodePageLoader);
+
+    expect(nodePage.nodes).toHaveLength(16);
+    expect(nodePage.nodes[2].lodThreshold).toBe(870638.071285568);
+  });
+
+  it('preserves UInt64 values through Number.MAX_SAFE_INTEGER', () => {
+    const buffer = new ArrayBuffer(16);
+    const dataView = new DataView(buffer);
+    dataView.setUint32(0, 0x89abcdef, true);
+    dataView.setUint32(4, 0x1, true);
+    dataView.setUint32(8, 0xffffffff, true);
+    dataView.setUint32(12, 0x1fffff, true);
+
+    const values = parseUint64Values(buffer, 2, 8);
+
+    expect(values).toBeInstanceOf(Float64Array);
+    expect(values[0]).toBe(0x1_89abcdef);
+    expect(values[1]).toBe(Number.MAX_SAFE_INTEGER);
+  });
+});

--- a/modules/i3s/test/i3s-nodepages-tiles-metadata.spec.ts
+++ b/modules/i3s/test/i3s-nodepages-tiles-metadata.spec.ts
@@ -1,0 +1,30 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, it} from 'vitest';
+import I3SNodePagesTiles from '../src/lib/helpers/i3s-nodepages-tiles';
+import {TEST_LAYER_URL, TILESET_STUB} from './test-utils/load-utils';
+
+it('I3SNodePagesTiles preserves node-page extension fields', async () => {
+  const i3SNodePagesTiles = new I3SNodePagesTiles(TILESET_STUB(), TEST_LAYER_URL, {});
+  const node = {
+    index: 0,
+    obb: {
+      center: [8.67, 50.1, 189],
+      halfSize: [10, 20, 30],
+      quaternion: [0, 0, 0, 1]
+    },
+    children: [],
+    vendorExtension: {classification: 'historic'}
+  };
+  i3SNodePagesTiles.nodePages[0] = {nodes: [node]} as any;
+  i3SNodePagesTiles.pendingNodePages[0] = {
+    status: 'Done',
+    promise: Promise.resolve({nodes: [node]})
+  };
+
+  const tile = await i3SNodePagesTiles.formTileFromNodePages(0);
+
+  expect((tile as any).vendorExtension).toEqual({classification: 'historic'});
+});

--- a/modules/i3s/test/index.ts
+++ b/modules/i3s/test/index.ts
@@ -11,6 +11,8 @@ import './parse-slpk.spec';
 import './parse-slpk-readable-file.spec';
 import './i3s-node-page-loader.spec';
 import './i3s-zod-schema.spec';
+import './i3s-conformance.spec';
+import './arcgis-webscene-crs.spec';
 import './i3s-attribute-loader.spec';
 // TODO v4.0 restore these tests
 // import './i3s-content-loader.spec';

--- a/modules/i3s/test/index.ts
+++ b/modules/i3s/test/index.ts
@@ -10,6 +10,7 @@ import './i3s-loader.spec';
 import './parse-slpk.spec';
 import './parse-slpk-readable-file.spec';
 import './i3s-node-page-loader.spec';
+import './i3s-nodepages-tiles-metadata.spec';
 import './i3s-zod-schema.spec';
 import './i3s-conformance.spec';
 import './arcgis-webscene-crs.spec';

--- a/modules/tiles/src/tileset-3d/format-i3s/i3s-source.ts
+++ b/modules/tiles/src/tileset-3d/format-i3s/i3s-source.ts
@@ -79,6 +79,7 @@ export class I3SSource implements Tileset3DSource {
     this.resolver = request.resolver;
     this.coreApi = request.coreApi;
     this.loadOptions = loadOptions;
+    this.initializeQueryParams(loadOptions);
   }
 
   /**
@@ -86,20 +87,12 @@ export class I3SSource implements Tileset3DSource {
    */
   async initialize(): Promise<void> {
     if (!this.rootTileset) {
-      this.rootTileset = await this.loadRootData(this.url, this.loadOptions);
+      this.rootTileset = await this.loadRootData(this.getTileUrl(this.url), this.loadOptions);
     }
     this.tileset = this.rootTileset;
 
     if (this.rootTileset.root && typeof this.rootTileset.root.then === 'function') {
       this.rootTileset.root = await this.rootTileset.root;
-    }
-
-    const i3sOptions = this.loadOptions.i3s;
-    if (i3sOptions && typeof i3sOptions === 'object' && 'token' in i3sOptions) {
-      const token = (i3sOptions as Record<string, unknown>).token;
-      if (typeof token === 'string') {
-        this.queryParams.token = token;
-      }
     }
 
     this.metadata = {
@@ -230,8 +223,15 @@ export class I3SSource implements Tileset3DSource {
       return tilePath;
     }
 
-    const queryParams = new URLSearchParams(this.queryParams).toString();
-    return `${tilePath}${tilePath.includes('?') ? '&' : '?'}${queryParams}`;
+    const [pathWithoutQuery, existingQuery = ''] = tilePath.split('?');
+    const queryParams = new URLSearchParams(existingQuery);
+    for (const [key, value] of Object.entries(this.queryParams)) {
+      if (!queryParams.has(key)) {
+        queryParams.set(key, value);
+      }
+    }
+
+    return `${pathWithoutQuery}?${queryParams.toString()}`;
   }
 
   /**
@@ -323,6 +323,20 @@ export class I3SSource implements Tileset3DSource {
     }
 
     return await this.loadWithCoreApi(url, options);
+  }
+
+  /**
+   * Initializes query parameters before any URL-backed resource is requested.
+   * @param loadOptions Loader options that may contain an ArcGIS token.
+   */
+  private initializeQueryParams(loadOptions: LoaderOptions): void {
+    const i3sOptions = loadOptions.i3s;
+    if (i3sOptions && typeof i3sOptions === 'object' && 'token' in i3sOptions) {
+      const token = (i3sOptions as Record<string, unknown>).token;
+      if (typeof token === 'string') {
+        this.queryParams.token = token;
+      }
+    }
   }
 
   /**

--- a/modules/tiles/src/tileset-3d/format-i3s/i3s-source.ts
+++ b/modules/tiles/src/tileset-3d/format-i3s/i3s-source.ts
@@ -223,15 +223,24 @@ export class I3SSource implements Tileset3DSource {
       return tilePath;
     }
 
-    const [pathWithoutQuery, existingQuery = ''] = tilePath.split('?');
-    const queryParams = new URLSearchParams(existingQuery);
+    const queryDelimiterIndex = tilePath.indexOf('?');
+    if (queryDelimiterIndex === -1) {
+      return `${tilePath}?${new URLSearchParams(this.queryParams).toString()}`;
+    }
+
+    const existingQuery = tilePath.slice(queryDelimiterIndex + 1);
+    const existingQueryKeys = new Set(
+      existingQuery.split('&').map(parameter => parameter.split('=', 1)[0])
+    );
+    const queryParams = new URLSearchParams();
     for (const [key, value] of Object.entries(this.queryParams)) {
-      if (!queryParams.has(key)) {
+      if (!existingQueryKeys.has(key)) {
         queryParams.set(key, value);
       }
     }
 
-    return `${pathWithoutQuery}?${queryParams.toString()}`;
+    const queryString = queryParams.toString();
+    return queryString ? `${tilePath}${existingQuery ? '&' : ''}${queryString}` : tilePath;
   }
 
   /**

--- a/modules/tiles/test/tileset/tileset-3d-source.spec.ts
+++ b/modules/tiles/test/tileset/tileset-3d-source.spec.ts
@@ -181,6 +181,41 @@ test('I3SSource initializes promised roots and appends auth tokens to tile urls'
   );
   expect(source.getTilesTotalCount()).toBe(7);
 });
+test('I3SSource appends auth tokens before loading URL-backed root metadata', async () => {
+  const requestedUrls: string[] = [];
+  const resolver: TilesetSourceResolver = {
+    async loadRoot(url) {
+      requestedUrls.push(url);
+      return {
+        type: 'tileset',
+        url,
+        loader: I3SLoader,
+        root: {id: 'root-node', refine: 'REPLACE'}
+      } as any;
+    },
+    async loadResource() {
+      return null;
+    }
+  };
+
+  const source = new I3SSource(
+    {
+      url: 'https://example.com/SceneServer/layers/0?existing=1',
+      loader: I3SLoader,
+      resolver
+    },
+    {i3s: {token: 'secret-token'}}
+  );
+
+  await source.initialize();
+
+  expect(requestedUrls).toEqual([
+    'https://example.com/SceneServer/layers/0?existing=1&token=secret-token'
+  ]);
+  expect(source.getTileUrl('https://example.com/SceneServer/layers/0?token=caller-token')).toBe(
+    'https://example.com/SceneServer/layers/0?token=caller-token'
+  );
+});
 test('Tiles3DSource uses injected resolvers for root metadata and tile content', async () => {
   const rootTileset: TilesetJSON = {
     asset: {version: '1.0'},

--- a/modules/tiles/test/tileset/tileset-3d-source.spec.ts
+++ b/modules/tiles/test/tileset/tileset-3d-source.spec.ts
@@ -215,6 +215,11 @@ test('I3SSource appends auth tokens before loading URL-backed root metadata', as
   expect(source.getTileUrl('https://example.com/SceneServer/layers/0?token=caller-token')).toBe(
     'https://example.com/SceneServer/layers/0?token=caller-token'
   );
+  expect(
+    source.getTileUrl('https://example.com/SceneServer/layers/0?redirect=https://host/path?a=1')
+  ).toBe(
+    'https://example.com/SceneServer/layers/0?redirect=https://host/path?a=1&token=secret-token'
+  );
 });
 test('Tiles3DSource uses injected resolvers for root metadata and tile content', async () => {
   const rootTileset: TilesetJSON = {


### PR DESCRIPTION
## Goals

- Implement the I3S conformance foundation (tranche 0) behind the feature support matrix.
- Harden correctness boundaries for the v5.0 development line (tranche 1).
- Make the next I3S supremacy tranches explicit and measurable.

## Changes

- Add representative 1.6, 1.7, 1.8, and 1.10 conformance checks with new 1.8/1.10 fixtures.
- Preserve node-page extension metadata in normalized tile headers.
- Propagate `i3s.token` to the URL-backed initial layer request while preserving caller query parameters.
- Return UInt64 geometry attributes as `Float64Array`, exact through `Number.MAX_SAFE_INTEGER`.
- Validate CRS for every supported ArcGIS WebScene layer, including nested layers.
- Update the I3S feature matrix and add a tranche 0–6 I3S supremacy roadmap.

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn build-workers`
- `yarn test-node` (360 passed, 6 skipped)
- `yarn test-headless` (2,892 passed, 40 skipped)
- `yarn test-audit` (0 violations)
- `cd website && yarn && yarn build` (successful; existing site warnings remain)

This follows the support matrix merged in #3789 and targets current `master`.
