### PR TITLE
feat(scan): add shared package boundary and panel examples

### DIFF
--- a/docs/developer-guide/common-scan-architecture.md
+++ b/docs/developer-guide/common-scan-architecture.md
@@ -217,6 +217,25 @@ loading metadata does not require the scan runtime. The proof-of-concept backend
 intentionally internal to this one public package rather than exposing a family of backend
 subpaths.
 
+The same optional package is also the application-facing home for the source-neutral query state
+and metadata vocabulary:
+
+```ts
+import type {ScanQuery, ScanQueryMetadata} from '@loaders.gl/scan';
+
+const query: ScanQuery = {columns: ['name'], limit: 25};
+async function describe(source: {getQueryMetadata(): Promise<ScanQueryMetadata>}) {
+  return await source.getQueryMetadata();
+}
+```
+
+`ScanQuery` is intentionally a control-state shape, not a promise that every source supports every
+field. An adapter normalizes the values it understands and reports the rest through metadata
+capabilities. This keeps the panel reusable without making React, a database client, or a GPU
+runtime a dependency of the scan package. Format packages continue to implement the contracts from
+`@loaders.gl/loader-utils`, so applications that do not use scanning pay no scan-runtime bundle
+cost.
+
 ## Predicates and SQL semantics
 
 Portable predicates use a small JSON-shaped tree:
@@ -681,27 +700,30 @@ The roadmap is therefore format-support-first. Each tranche must ship three thin
 0. **Contract and reference implementation — landed.** Keep the generic predicates, immutable
    `TableQueryOptions`, point-cloud and raster siblings, canonical planning, late-bound parameters,
    capability vocabulary, ordered scan tasks, Arrow execution, and lazy DuckDB compilation stable.
-1. **Panel everywhere — next priority.** Add a small adapter shim for every existing source that can
-   expose a schema or header. Populate projection, limit, bounds, level, band, variable, and time
-   controls from metadata rather than hard-coded examples. Add a support badge and an explain preview
-   to each compatible example. This tranche is successful when users can try the same panel against
-   the sources marked “Ready” or “Foundation” in the matrix below.
-2. **Tabular and vector coverage.** Finish Arrow/GeoArrow as the conformance executor, then bring
+1. **Optional package boundary — implemented in this stack.** Keep query state, metadata contracts,
+   and the reference runtime in `@loaders.gl/scan`, while format adapters retain lightweight
+   `@loaders.gl/loader-utils` dependencies. No UI or GPU code crosses this boundary.
+2. **Panel everywhere — implemented for the first linear sources in this stack.** The shared panel
+   now consumes the package-level metadata/query types, renders discovered raster overviews, and is
+   exercised by FlatGeobuf, Parquet, Iceberg, CSV, and Arrow examples. The next increment adds a
+   support badge and explain preview to each compatible example, then expands the panel to every
+   source marked “Ready” or “Foundation” in the matrix below.
+3. **Tabular and vector coverage.** Finish Arrow/GeoArrow as the conformance executor, then bring
    ORC, CSV, JSONL, GeoPackage, Shapefile, MLT, and existing FlatGeobuf paths to scan parity. Start
    with schema/projection/limit and residual predicates; add stripe, row-index, packed-index, or
    byte-range pruning only where the format can prove it safely.
-3. **Cloud and versioned tables.** Complete Parquet/Iceberg parity, then add Delta Lake and Lance
+4. **Cloud and versioned tables.** Complete Parquet/Iceberg parity, then add Delta Lake and Lance
    snapshot/fragment planners. Reuse delete semantics, hidden required columns, task ordering,
    global limits, and explain output. Do not create format-specific predicate ASTs.
-4. **Point-cloud coverage.** Turn COPC and Potree foundations into bounded Arrow point batches with
+5. **Point-cloud coverage.** Turn COPC and Potree foundations into bounded Arrow point batches with
    bounds pushdown, ordered hierarchy tasks, residual attribute predicates, and global point limits.
    Add LAS/LAZ as a sequential fallback and PLY/PCD/splats as metadata-first adapters where their
    native formats cannot prune remotely.
-5. **Raster and multidimensional coverage.** Complete GeoTIFF/COG and Zarr/GeoZarr/OME-Zarr scan
+6. **Raster and multidimensional coverage.** Complete GeoTIFF/COG and Zarr/GeoZarr/OME-Zarr scan
    requests, then wire NetCDF. Add terrain/heightmap and LERC-backed sources through the same raster
    panel. Standardize window, resolution/overview, band/channel, variable, dimension slice, typed
    output, and chunk telemetry without pretending pixels are table rows.
-6. **Tiles and services bridge.** Keep MVT, PMTiles, 3D Tiles, I3S, WMS, WFS, and STAC specialized,
+7. **Tiles and services bridge.** Keep MVT, PMTiles, 3D Tiles, I3S, WMS, WFS, and STAC specialized,
    but expose shared discovery, bounds, time, level-of-detail, explain, and cancellation metadata.
    Where a source returns feature tables (for example MVT or WFS), offer an explicit table-scan view;
    keep tile addressing and rendering controls outside `TableQuery`.
@@ -726,7 +748,8 @@ exposed yet. A residual predicate is still correct; it simply cannot avoid decod
 | Parquet / Iceberg | Ready | footer/catalog | pushdown | statistics + residual | global / batches | maintain and extend |
 | FlatGeobuf | Ready | header/index | Arrow properties | bbox pushdown, scalar residual | bounded / batches | maintain and panel |
 | ORC | Planned | loader metadata only | planned | planned row-index/statistics | planned | P2 |
-| CSV / JSONL | Planned | header/sample | parser-dependent | residual | planned chunks | P2 |
+| CSV | Ready | header/sample | parser projection | residual | global / batches | P1 |
+| JSONL | Planned | header/sample | planned | planned residual | planned chunks | P2 |
 | GeoPackage / Shapefile / MLT | Planned | container/header | planned | planned spatial or residual | planned | P2 |
 | Delta Lake | Planned | loader not yet present | planned | planned log/deletion-vector pruning | planned | P1 |
 | Lance | Foundation | manifest/fragments | format-native | fragments + residual | global / batches | P1 |

--- a/modules/scan/README.md
+++ b/modules/scan/README.md
@@ -33,3 +33,19 @@ const engine = await createScanEngine({backend: 'custom'});
 Format packages should depend on the lightweight scan contracts in `@loaders.gl/loader-utils` and
 should not import this package merely to expose metadata or a native scan adapter. Applications opt
 into this package when they want the shared planner or Arrow executor.
+
+The package also provides the application-facing query state and metadata vocabulary used by
+metadata-driven controls. These are deliberately framework-neutral:
+
+```typescript
+import type {ScanQuery, ScanQueryMetadata} from '@loaders.gl/scan';
+
+const query: ScanQuery = {columns: ['name'], limit: 25};
+async function discover(source: {getQueryMetadata(): Promise<ScanQueryMetadata>}) {
+  return await source.getQueryMetadata();
+}
+```
+
+`ScanQuery` is a portable control shape. Sources normalize unsupported fields and advertise their
+actual capabilities through `ScanQueryMetadata`; no React, GPU, or database dependency is pulled
+into applications that only use a format loader.

--- a/modules/scan/src/index.ts
+++ b/modules/scan/src/index.ts
@@ -21,3 +21,26 @@ export type {
   RelationalOrderKey,
   TableQueryOptions
 } from '@loaders.gl/loader-utils';
+
+export {createScanQueryMetadata} from '@loaders.gl/loader-utils';
+export type {
+  CreateScanQueryMetadataOptions,
+  PointCloudQueryBounds,
+  PointCloudQueryCapabilities,
+  PointCloudQueryOptions,
+  RasterQueryCapabilities,
+  RasterQueryOptions,
+  ScanBounds,
+  ScanColumnMetadata,
+  ScanColumnRole,
+  ScanQueryCapabilities,
+  ScanQueryMetadata,
+  ScanQueryMetadataOptions,
+  ScanQueryMetadataProvider,
+  ScanRasterLevel,
+  ScanSourceStatistics,
+  ScanSpatialMetadata,
+  TableScanReadOptions,
+  TableScanSource
+} from '@loaders.gl/loader-utils';
+export type {ScanQuery} from './scan-query';

--- a/modules/scan/src/scan-query.ts
+++ b/modules/scan/src/scan-query.ts
@@ -1,0 +1,27 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/**
+ * Source-neutral values emitted by a scan query editor.
+ *
+ * This type is deliberately smaller than any one format's executor options. Applications can
+ * pass it between metadata-driven controls and adapters, which may normalize or ignore values
+ * that are not supported by a particular source family.
+ */
+export type ScanQuery = Readonly<{
+  /** Output columns; an empty selection means all columns. */
+  columns?: readonly string[];
+  /** Maximum number of rows, features, or points to return. */
+  limit?: number;
+  /** Optional source-coordinate bounding box in minX, minY, maxX, maxY order. */
+  boundingBox?: readonly [number, number, number, number];
+  /** Optional raster overview or point-cloud hierarchy level. */
+  level?: number;
+  /** Optional point-cloud minimum hierarchy level. */
+  minimumLevel?: number;
+  /** Optional point-cloud maximum hierarchy level. */
+  maximumLevel?: number;
+  /** Optional point-cloud target spacing. */
+  targetSpacing?: number;
+}>;

--- a/modules/scan/test/scan-engine.spec.ts
+++ b/modules/scan/test/scan-engine.spec.ts
@@ -6,7 +6,12 @@ import * as arrow from 'apache-arrow';
 import {expect, test} from 'vitest';
 import type {ArrowTable} from '@loaders.gl/schema';
 import {convertArrowToSchema} from '@loaders.gl/schema-utils';
-import {createScanEngine, parseSQLPredicate, registerScanBackend} from '@loaders.gl/scan';
+import {
+  createScanEngine,
+  createScanQueryMetadata,
+  parseSQLPredicate,
+  registerScanBackend
+} from '@loaders.gl/scan';
 
 test('creates the Arrow reference engine by default', async () => {
   const engine = await createScanEngine();
@@ -19,6 +24,27 @@ test('creates the Arrow reference engine by default', async () => {
   expect(engine.name).toBe('arrow');
   expect(result.data.schema.fields.map(field => field.name)).toEqual(['name']);
   expect(result.data.toArray().map(row => row?.toJSON())).toEqual([{name: 'b'}]);
+});
+
+test('exposes the shared metadata vocabulary from the optional scan package', () => {
+  const table = makeArrowTable({name: ['a'], value: [1]});
+  const metadata = createScanQueryMetadata({
+    sourceType: 'test',
+    queryType: 'table',
+    schema: table.schema,
+    capabilities: {
+      table: {
+        predicate: 'residual',
+        projection: 'pushdown',
+        limit: 'pushdown',
+        streaming: true,
+        cancellation: true
+      }
+    }
+  });
+
+  expect(metadata.columns.map(column => column.name)).toEqual(['name', 'value']);
+  expect(Object.isFrozen(metadata)).toBe(true);
 });
 
 test('loads a registered backend through the same root API', async () => {

--- a/website/package.json
+++ b/website/package.json
@@ -51,6 +51,7 @@
     "@loaders.gl/orc": "workspace:*",
     "@loaders.gl/parquet": "workspace:*",
     "@loaders.gl/ply": "workspace:*",
+    "@loaders.gl/scan": "workspace:*",
     "@loaders.gl/scene": "workspace:*",
     "@loaders.gl/schema": "workspace:*",
     "@loaders.gl/schema-utils": "workspace:*",

--- a/website/src/components/docs/arrow-scan-live-example.tsx
+++ b/website/src/components/docs/arrow-scan-live-example.tsx
@@ -1,45 +1,41 @@
 import React, {useEffect, useState} from 'react';
-import type {FlatGeobufReadOptions} from '@loaders.gl/flatgeobuf';
+import {ArrowTableSource} from '@loaders.gl/arrow';
 import type {ArrowTable} from '@loaders.gl/schema';
-import {FlatGeobufVectorSource} from '@loaders.gl/flatgeobuf';
 import type {ScanQueryMetadata} from '@loaders.gl/scan';
 import {ScanQueryPanel, type ScanQueryPanelState} from './scan-query-panel';
 
-type FlatGeobufDemoState = Readonly<{
+type ArrowScanDemoState = Readonly<{
   metadata?: ScanQueryMetadata;
   table?: ArrowTable;
   error?: string;
   loading: boolean;
 }>;
 
-const DEFAULT_FLATGEOBUF_URL =
-  'https://raw.githubusercontent.com/visgl/loaders.gl/master/modules/flatgeobuf/test/data/countries.fgb';
+const DEFAULT_ARROW_URL =
+  'https://raw.githubusercontent.com/visgl/loaders.gl/master/modules/arrow/test/data/arrow/simple.arrow';
 
-/** Demonstrates metadata-driven projection, limit, and bbox controls over FlatGeobuf. */
-export function FlatGeobufScanLiveExample(): JSX.Element {
-  const [url, setUrl] = useState(DEFAULT_FLATGEOBUF_URL);
+/** Demonstrates the shared metadata-driven scan panel on an Arrow IPC source. */
+export function ArrowScanLiveExample(): JSX.Element {
+  const [url, setUrl] = useState(DEFAULT_ARROW_URL);
   const [query, setQuery] = useState<ScanQueryPanelState>({});
   const [submittedQuery, setSubmittedQuery] = useState<ScanQueryPanelState>({});
-  const [state, setState] = useState<FlatGeobufDemoState>({loading: true});
+  const [state, setState] = useState<ArrowScanDemoState>({loading: true});
 
   useEffect(() => {
     let mounted = true;
-    const source = new FlatGeobufVectorSource(url, {flatgeobuf: {format: 'arrow'}});
+    const source = new ArrowTableSource(url);
     setState({loading: true});
     void (async () => {
       try {
         const metadata = await source.getQueryMetadata();
-        const options: FlatGeobufReadOptions = {
+        let table: ArrowTable | undefined;
+        for await (const batch of source.read({
           columns: submittedQuery.columns,
-          limit: submittedQuery.limit,
-          boundingBox: submittedQuery.boundingBox
-            ? [
-                [submittedQuery.boundingBox[0], submittedQuery.boundingBox[1]],
-                [submittedQuery.boundingBox[2], submittedQuery.boundingBox[3]]
-              ]
-            : undefined
-        };
-        const table = await source.query(options);
+          limit: submittedQuery.limit
+        })) {
+          table = batch.data;
+          break;
+        }
         if (mounted) setState({metadata, table, loading: false});
       } catch (error) {
         if (mounted) setState({loading: false, error: error instanceof Error ? error.message : String(error)});
@@ -52,9 +48,9 @@ export function FlatGeobufScanLiveExample(): JSX.Element {
 
   return (
     <div>
-      <label htmlFor="flatgeobuf-scan-url">FlatGeobuf URL</label>
+      <label htmlFor="arrow-scan-url">Arrow IPC URL</label>
       <input
-        id="flatgeobuf-scan-url"
+        id="arrow-scan-url"
         style={{display: 'block', width: '100%', margin: '6px 0', padding: 7}}
         value={url}
         onChange={event => setUrl(event.target.value)}
@@ -67,22 +63,20 @@ export function FlatGeobufScanLiveExample(): JSX.Element {
           setQuery(nextQuery);
           setSubmittedQuery(nextQuery);
         }}
-        title="FlatGeobuf scan parameters"
+        title="Arrow scan parameters"
       />
       {state.error ? <p role="alert">{state.error}</p> : null}
-      {state.table ? <FlatGeobufPreview table={state.table} /> : null}
+      {state.table ? <ArrowPreview table={state.table} /> : null}
     </div>
   );
 }
 
-function FlatGeobufPreview({table}: {table: ArrowTable}): JSX.Element {
+function ArrowPreview({table}: {table: ArrowTable}): JSX.Element {
   const columns = table.schema.fields.map(field => field.name);
   const rowCount = Math.min(table.data.numRows, 5);
   return (
     <div style={{overflowX: 'auto'}}>
-      <p>
-        <strong>Arrow result:</strong> {table.data.numRows} rows · {columns.length} columns
-      </p>
+      <p><strong>Arrow result:</strong> {table.data.numRows} rows · {columns.length} columns</p>
       <table>
         <thead><tr>{columns.map(column => <th key={column}>{column}</th>)}</tr></thead>
         <tbody>

--- a/website/src/components/docs/arrow-scan-live-example.tsx
+++ b/website/src/components/docs/arrow-scan-live-example.tsx
@@ -71,6 +71,7 @@ export function ArrowScanLiveExample(): JSX.Element {
   );
 }
 
+/** Renders a compact preview of the first rows returned by an Arrow scan. */
 function ArrowPreview({table}: {table: ArrowTable}): JSX.Element {
   const columns = table.schema.fields.map(field => field.name);
   const rowCount = Math.min(table.data.numRows, 5);
@@ -91,6 +92,7 @@ function ArrowPreview({table}: {table: ArrowTable}): JSX.Element {
   );
 }
 
+/** Formats one Arrow value for the compact example table. */
 function formatCell(value: unknown): string {
   if (value === null || value === undefined) return '—';
   if (typeof value === 'object') return '[value]';

--- a/website/src/components/docs/csv-scan-live-example.tsx
+++ b/website/src/components/docs/csv-scan-live-example.tsx
@@ -45,7 +45,7 @@ export function CSVScanLiveExample(): JSX.Element {
     };
   }, [url, submittedQuery]);
 
-  const columns = state.metadata?.columns.map(column => column.name) || [];
+  const columns = submittedQuery.columns || state.metadata?.columns.map(column => column.name) || [];
   return (
     <div>
       <label htmlFor="csv-scan-url">CSV URL</label>
@@ -71,6 +71,7 @@ export function CSVScanLiveExample(): JSX.Element {
   );
 }
 
+/** Renders a compact preview of the projected rows returned by a CSV scan. */
 function CSVPreview({columns, rows}: {columns: readonly string[]; rows: readonly Record<string, unknown>[]}): JSX.Element {
   return (
     <div style={{overflowX: 'auto'}}>
@@ -89,6 +90,7 @@ function CSVPreview({columns, rows}: {columns: readonly string[]; rows: readonly
   );
 }
 
+/** Formats one CSV value for the compact example table. */
 function formatCell(value: unknown): string {
   if (value === null || value === undefined) return '—';
   if (typeof value === 'object') return '[value]';

--- a/website/src/components/docs/csv-scan-live-example.tsx
+++ b/website/src/components/docs/csv-scan-live-example.tsx
@@ -1,0 +1,96 @@
+import React, {useEffect, useState} from 'react';
+import {CSVTableSource} from '@loaders.gl/csv';
+import type {ScanQueryMetadata} from '@loaders.gl/scan';
+import {ScanQueryPanel, type ScanQueryPanelState} from './scan-query-panel';
+
+type CSVScanDemoState = Readonly<{
+  metadata?: ScanQueryMetadata;
+  rows?: readonly Record<string, unknown>[];
+  error?: string;
+  loading: boolean;
+}>;
+
+const DEFAULT_CSV_URL =
+  'https://raw.githubusercontent.com/visgl/loaders.gl/master/modules/csv/test/data/sample.csv';
+
+/** Demonstrates the shared metadata-driven scan panel on a forward-only CSV source. */
+export function CSVScanLiveExample(): JSX.Element {
+  const [url, setUrl] = useState(DEFAULT_CSV_URL);
+  const [query, setQuery] = useState<ScanQueryPanelState>({});
+  const [submittedQuery, setSubmittedQuery] = useState<ScanQueryPanelState>({});
+  const [state, setState] = useState<CSVScanDemoState>({loading: true});
+
+  useEffect(() => {
+    let mounted = true;
+    const source = new CSVTableSource(url);
+    setState({loading: true});
+    void (async () => {
+      try {
+        const metadata = await source.getQueryMetadata();
+        const rows: Record<string, unknown>[] = [];
+        for await (const batch of source.read({
+          columns: submittedQuery.columns,
+          limit: submittedQuery.limit
+        })) {
+          if (batch.shape === 'object-row-table') rows.push(...batch.data);
+          if (rows.length >= 5) break;
+        }
+        if (mounted) setState({metadata, rows: rows.slice(0, 5), loading: false});
+      } catch (error) {
+        if (mounted) setState({loading: false, error: error instanceof Error ? error.message : String(error)});
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [url, submittedQuery]);
+
+  const columns = state.metadata?.columns.map(column => column.name) || [];
+  return (
+    <div>
+      <label htmlFor="csv-scan-url">CSV URL</label>
+      <input
+        id="csv-scan-url"
+        style={{display: 'block', width: '100%', margin: '6px 0', padding: 7}}
+        value={url}
+        onChange={event => setUrl(event.target.value)}
+      />
+      <ScanQueryPanel
+        metadata={state.metadata}
+        loading={state.loading}
+        value={query}
+        onApply={nextQuery => {
+          setQuery(nextQuery);
+          setSubmittedQuery(nextQuery);
+        }}
+        title="CSV scan parameters"
+      />
+      {state.error ? <p role="alert">{state.error}</p> : null}
+      {state.rows ? <CSVPreview columns={columns} rows={state.rows} /> : null}
+    </div>
+  );
+}
+
+function CSVPreview({columns, rows}: {columns: readonly string[]; rows: readonly Record<string, unknown>[]}): JSX.Element {
+  return (
+    <div style={{overflowX: 'auto'}}>
+      <p><strong>Streamed CSV rows:</strong> showing {rows.length} rows</p>
+      <table>
+        <thead><tr>{columns.map(column => <th key={column}>{column}</th>)}</tr></thead>
+        <tbody>
+          {rows.map((row, rowIndex) => (
+            <tr key={rowIndex}>
+              {columns.map(column => <td key={column}>{formatCell(row[column])}</td>)}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function formatCell(value: unknown): string {
+  if (value === null || value === undefined) return '—';
+  if (typeof value === 'object') return '[value]';
+  return String(value);
+}

--- a/website/src/components/docs/iceberg-scan-live-example.tsx
+++ b/website/src/components/docs/iceberg-scan-live-example.tsx
@@ -2,7 +2,7 @@ import React, {useEffect, useState} from 'react';
 import styled from 'styled-components';
 import type {Table as ArrowTable} from 'apache-arrow';
 import type {ParquetPredicate} from '@loaders.gl/parquet';
-import type {ScanQueryMetadata} from '@loaders.gl/loader-utils';
+import type {ScanQueryMetadata} from '@loaders.gl/scan';
 import {ExampleUrlInputCard, type UrlOption} from 'examples/website/shared/url-input-card';
 import {ScanQueryPanel, type ScanQueryPanelState} from './scan-query-panel';
 

--- a/website/src/components/docs/parquet-scan-live-example.tsx
+++ b/website/src/components/docs/parquet-scan-live-example.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect, useState} from 'react';
 import type {ParquetSource} from '@loaders.gl/parquet';
 import type {ArrowTable} from '@loaders.gl/schema';
-import type {ScanQueryMetadata} from '@loaders.gl/loader-utils';
+import type {ScanQueryMetadata} from '@loaders.gl/scan';
 import {ScanQueryPanel, type ScanQueryPanelState} from './scan-query-panel';
 
 type ParquetDemoState = Readonly<{

--- a/website/src/components/docs/scan-query-panel.tsx
+++ b/website/src/components/docs/scan-query-panel.tsx
@@ -1,24 +1,9 @@
 import React, {useEffect, useId, useState} from 'react';
 import styled from 'styled-components';
-import type {ScanQueryMetadata} from '@loaders.gl/loader-utils';
+import type {ScanQuery, ScanQueryMetadata} from '@loaders.gl/scan';
 
 /** State emitted by the reusable scan-query controls. */
-export type ScanQueryPanelState = Readonly<{
-  /** Output columns; an empty selection means all columns. */
-  columns?: readonly string[];
-  /** Maximum number of rows to return. */
-  limit?: number;
-  /** Optional source-coordinate bounding box in minX, minY, maxX, maxY order. */
-  boundingBox?: readonly [number, number, number, number];
-  /** Optional raster overview or point-cloud minimum hierarchy level. */
-  level?: number;
-  /** Optional point-cloud minimum hierarchy level. */
-  minimumLevel?: number;
-  /** Optional point-cloud maximum hierarchy level. */
-  maximumLevel?: number;
-  /** Optional point-cloud target spacing. */
-  targetSpacing?: number;
-}>;
+export type ScanQueryPanelState = ScanQuery;
 
 /** Props for a source-neutral query-parameter panel. */
 export type ScanQueryPanelProps = Readonly<{
@@ -70,10 +55,14 @@ export function ScanQueryPanel({
   }, [value]);
 
   const columns = metadata?.columns || [];
+  const isPointCloud = metadata?.queryType === 'point-cloud';
   const hasLimit = metadata?.capabilities.table?.limit && metadata.capabilities.table.limit !== 'unsupported';
   const hasBounds = metadata?.capabilities.bounds && metadata.capabilities.bounds !== 'unsupported';
-  const hasLevel = metadata?.capabilities.levelOfDetail && metadata.capabilities.levelOfDetail !== 'unsupported';
-  const isPointCloud = metadata?.queryType === 'point-cloud';
+  const hasLevel = Boolean(
+    metadata?.levels?.length ||
+      (metadata?.capabilities.levelOfDetail && metadata.capabilities.levelOfDetail !== 'unsupported')
+  );
+  const hasRasterLevels = !isPointCloud && Boolean(metadata?.levels?.length);
   const sourceBounds = metadata?.spatial?.bounds;
   const toggleColumn = (name: string): void => {
     setSelectedColumns(current =>
@@ -147,16 +136,31 @@ export function ScanQueryPanel({
             {hasLevel ? (
               <FieldGroup>
                 <FieldLabel htmlFor={`${panelId}-level`}>{isPointCloud ? 'Minimum level' : 'Overview level'}</FieldLabel>
-                <TextInput
-                  id={`${panelId}-level`}
-                  inputMode="numeric"
-                  min="0"
-                  placeholder="Native/default"
-                  value={isPointCloud ? minimumLevelText : levelText}
-                  onChange={event =>
-                    isPointCloud ? setMinimumLevelText(event.target.value) : setLevelText(event.target.value)
-                  }
-                />
+                {hasRasterLevels ? (
+                  <Select
+                    id={`${panelId}-level`}
+                    value={levelText}
+                    onChange={event => setLevelText(event.target.value)}
+                  >
+                    <option value="">Native/default</option>
+                    {metadata.levels?.map(level => (
+                      <option key={level.index} value={level.index}>
+                        Level {level.index} ({level.width} × {level.height})
+                      </option>
+                    ))}
+                  </Select>
+                ) : (
+                  <TextInput
+                    id={`${panelId}-level`}
+                    inputMode="numeric"
+                    min="0"
+                    placeholder="Native/default"
+                    value={isPointCloud ? minimumLevelText : levelText}
+                    onChange={event =>
+                      isPointCloud ? setMinimumLevelText(event.target.value) : setLevelText(event.target.value)
+                    }
+                  />
+                )}
               </FieldGroup>
             ) : null}
             {isPointCloud && hasLevel ? (
@@ -310,6 +314,13 @@ const TextInput = styled.input`
   border: 1px solid #d0d5dd;
   border-radius: 5px;
   padding: 7px;
+`;
+const Select = styled.select`
+  min-width: 180px;
+  border: 1px solid #d0d5dd;
+  border-radius: 5px;
+  padding: 7px;
+  background: white;
 `;
 const ApplyButton = styled.button`
   margin-top: 12px;

--- a/website/src/examples-sidebar.js
+++ b/website/src/examples-sidebar.js
@@ -23,7 +23,15 @@ const sidebars = {
     {
       type: 'category',
       label: 'Table Formats',
-      items: ['table/arrow', 'table/parquet', 'table/avro', 'table/orc', 'table/csv']
+      items: [
+        'table/arrow',
+        'table/arrow-scan',
+        'table/parquet',
+        'table/avro',
+        'table/orc',
+        'table/csv',
+        'table/csv-scan'
+      ]
     },
     {
       type: 'category',

--- a/website/src/examples/table/arrow-scan.mdx
+++ b/website/src/examples/table/arrow-scan.mdx
@@ -1,0 +1,13 @@
+---
+title: "Arrow scan"
+hide_title: true
+---
+
+import {ArrowScanLiveExample} from '@site/src/components/docs/arrow-scan-live-example';
+
+# Arrow scan
+
+Arrow IPC sources provide schema discovery and ordered batch reads. The same metadata-driven panel
+used by spatial sources can therefore control a lightweight columnar scan.
+
+<ArrowScanLiveExample />

--- a/website/src/examples/table/csv-scan.mdx
+++ b/website/src/examples/table/csv-scan.mdx
@@ -1,0 +1,13 @@
+---
+title: "CSV scan"
+hide_title: true
+---
+
+import {CSVScanLiveExample} from '@site/src/components/docs/csv-scan-live-example';
+
+# CSV scan
+
+The CSV source exposes its schema before streaming rows. The shared scan panel uses that metadata
+to offer projection and limit controls without loading the complete file into memory.
+
+<CSVScanLiveExample />

--- a/yarn.lock
+++ b/yarn.lock
@@ -5710,7 +5710,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@loaders.gl/scan@workspace:modules/scan":
+"@loaders.gl/scan@workspace:*, @loaders.gl/scan@workspace:modules/scan":
   version: 0.0.0-use.local
   resolution: "@loaders.gl/scan@workspace:modules/scan"
   dependencies:
@@ -27986,6 +27986,7 @@ __metadata:
     "@loaders.gl/orc": "workspace:*"
     "@loaders.gl/parquet": "workspace:*"
     "@loaders.gl/ply": "workspace:*"
+    "@loaders.gl/scan": "workspace:*"
     "@loaders.gl/scene": "workspace:*"
     "@loaders.gl/schema": "workspace:*"
     "@loaders.gl/schema-utils": "workspace:*"


### PR DESCRIPTION
## Goals

- Make the optional `@loaders.gl/scan` package the stable application-facing boundary for shared scan state and metadata.
- Make the metadata-driven scan panel reusable across linear table sources as well as spatial sources.
- Keep format loaders lightweight and defer GPU integration.

## Changes

- Add the framework-neutral `ScanQuery` control-state type and re-export scan metadata contracts and `createScanQueryMetadata` from `@loaders.gl/scan`.
- Update scan documentation and roadmap to describe the package boundary, bundle-size intent, and tranche status.
- Update the shared panel to consume scan-package types and render discovered raster overview levels while preserving point-cloud minimum/maximum level semantics.
- Add CSV and Arrow scan examples with schema discovery, projection, limits, and bounded previews; add both pages to the table examples sidebar.
- Switch existing FlatGeobuf, Parquet, and Iceberg scan examples to the shared scan-package metadata type.
- Add package/lockfile wiring and a scan-root metadata export test.

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn test-headless modules/scan/test/scan-engine.spec.ts`
- `cd website && yarn build`

This PR is intentionally stacked on `codex/scan-package-poc` (PR #3788).
