### PR TITLE
feat(3d-tiles): expose viewer request volumes

### DIFF
--- a/docs/modules/tiles/api-reference/tile-3d.md
+++ b/docs/modules/tiles/api-reference/tile-3d.md
@@ -28,6 +28,10 @@ Returns `true` when traversal may request a source-managed lazy child-header gro
 
 A bounding volume that encloses a tile or its content. Exactly one box, region, or sphere property is required. ([`Reference`](https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/master/specification#bounding-volume))
 
+###### `viewerRequestVolume` (BoundingVolume | null)
+
+The transformed volume that limits when this tile may be requested. It is `null` when the tile does not declare a viewer request volume. This volume affects traversal/request eligibility, not render-content culling.
+
 ###### `id` (Number`|`String)
 
 A unique number for the tile in the tileset. Default to the url of the tile.

--- a/modules/tiles/src/tileset-3d/common/tile-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tile-3d.ts
@@ -158,6 +158,11 @@ export class Tile3D {
   private _contentBoundingVolume: any;
   private _viewerRequestVolume: any;
 
+  /** Bounding volume that limits when this tile may be requested, when declared. */
+  get viewerRequestVolume(): any {
+    return this._viewerRequestVolume;
+  }
+
   _initialTransform: Matrix4 = new Matrix4();
 
   // Used by traverser, cannot be marked private


### PR DESCRIPTION
## Goals

Expose the parsed 3D Tiles `viewerRequestVolume` through the public `Tile3D` API for runtime inspection and renderer integration.

## Changes

- Add a documented `Tile3D.viewerRequestVolume` accessor.
- Preserve the existing private volume lifecycle and request-volume behavior.
- Clarify that this volume gates requests/traversal eligibility rather than render culling.

## Validation

- The change is a focused, type-safe accessor with no behavior change to traversal.
- CI will run the repository build and test matrix on the pull request.