### PR TITLE
feat(wms): production GML and streaming WFS epic

### DIFF
--- a/docs/modules/wms/formats/gml.md
+++ b/docs/modules/wms/formats/gml.md
@@ -11,9 +11,9 @@ GML serves as a modeling language for geographic systems as well as an open inte
 
 ## Limitations
 
-GML is a very ambitious format, with a large set of primitives and many ways to express similar geometries by composing different primitives. Parsing GML is generally considered challenging, even when the goal is only to support the "GeoJSON subset" of primitives. Because of this, full support for GML is currently out of scope for loaders.gl.
+GML is a very ambitious format, with a large set of primitives and many ways to express similar geometries by composing different primitives. Parsing GML is generally considered challenging, even when the goal is only to support the "GeoJSON subset" of primitives. Because of this, full support for every GML application schema is currently out of scope for loaders.gl. The parser supports streaming feature members and the common GML 2/3 geometry subset used by WFS services.
 
-The `GMLLoader` only supports parsing the standard geospatial subset of features (points, multipoints, lines, linestrings, polygons and multipolygons), on a "best effort" basis. Because of this, the `GMLLoader` is treated as a geospatial loader and can return GeoJSON style output.
+The `GMLLoader` supports parsing the standard geospatial subset of features (points, multipoints, lines, linestrings, polygons and multipolygons), on a "best effort" basis. Its `parseInBatches` entry point emits feature collections as GML members arrive, so WFS responses do not need to be buffered in full. Because of this, the `GMLLoader` is treated as a geospatial loader and can return GeoJSON style output.
 
 A fun read that illustrates the challenge is the [GML madness](http://erouault.blogspot.com/2014/04/gml-madness.html) article by Even Rouault.
 

--- a/docs/modules/wms/formats/wfs.md
+++ b/docs/modules/wms/formats/wfs.md
@@ -37,6 +37,30 @@ The WFS standard specifies a number of "request types" that a standards-complian
 
 Note that the response to `GetCapabilities` contains information about which request types are supported
 
+## Streaming feature access
+
+`WFSSourceLoader` accepts GeoJSON and GML `GetFeature` responses. GeoJSON remains the default;
+request GML explicitly when a service does not provide GeoJSON, or use the streaming API for
+large feature collections:
+
+```ts
+const source = WFSSourceLoader.createDataSource(url, {
+  wfs: {wfsParameters: {outputFormat: 'application/vnd.ogc.gml'}}
+});
+
+for await (const batch of source.getFeaturesInBatches(
+  {boundingBox: [[-10, 35], [10, 55]], layers: ['roads'], crs: 'EPSG:4326'},
+  {batchSize: 1000}
+)) {
+  // Each batch is an Arrow table by default.
+  consume(batch);
+}
+```
+
+The batch API parses GML feature members incrementally and supports `geojson`, `binary`, and
+Arrow output through the usual `format` parameter. Complete GML responses are converted to the
+same normalized vector-source outputs.
+
 ## Features
 
 A WFS server usually serves the map in a bitmap format, e.g. PNG, GIF, JPEG. In addition, vector graphics can be included, such as points, lines, curves and text, expressed in SVG or WebCGM format. The MIME types of the `GetMap` request can be inspected in the response to the `GetCapabilities` request.

--- a/modules/services/src/arcgis/arcgis-server.ts
+++ b/modules/services/src/arcgis/arcgis-server.ts
@@ -28,7 +28,7 @@ async function loadServiceDirectory(
   fetch: FetchLike,
   path: string[]
 ): Promise<Service[]> {
-  const serviceUrl = `${serverUrl}/${path.join('/')}`;
+  const serviceUrl = path.length ? `${serverUrl}/${path.join('/')}` : serverUrl;
 
   const response = await fetch(`${serviceUrl}?f=pjson`);
   const directory = await response.json();
@@ -54,7 +54,7 @@ function extractServices(directory: unknown, url: string): Service[] {
     services.push({
       name: service.name,
       type: `arcgis-${service.type.toLocaleLowerCase().replace('server', '-server')}`,
-      url: `${url}${service.name}/${service.type}`
+      url: `${url}/${service.name}/${service.type}`
     });
   }
   return services;

--- a/modules/services/test/services-module.spec.ts
+++ b/modules/services/test/services-module.spec.ts
@@ -6,6 +6,7 @@ import {
   ArcGISVectorTileServerSourceLoader,
   getServiceLoader
 } from '../src/index';
+import {getArcGISServices} from '../src/arcgis/arcgis-server';
 import * as bundledServices from '../src/bundled';
 import * as unbundledServices from '../src/unbundled';
 import {describe, expect, test} from 'vitest';
@@ -28,5 +29,40 @@ describe('@loaders.gl/services', () => {
   test('keeps the package entrypoints wired to the public exports', () => {
     expect(bundledServices.ArcGISFeatureServerSourceLoader).toBe(ArcGISFeatureServerSourceLoader);
     expect(unbundledServices.ArcGISFeatureServerSourceLoader).toBe(ArcGISFeatureServerSourceLoader);
+  });
+
+  test('discovers services from ArcGIS server directories', async () => {
+    const requests: string[] = [];
+    const services = await getArcGISServices(
+      'https://example.com/arcgis/rest/services/Roads/FeatureServer',
+      async url => {
+        requests.push(url);
+        return new Response(
+          JSON.stringify(
+            url.includes('/Public?')
+              ? {services: [{name: 'Basemap', type: 'MapServer'}]}
+              : {
+                  services: [{name: 'Roads', type: 'FeatureServer'}],
+                  folders: ['Public']
+                }
+          )
+        );
+      }
+    );
+
+    expect(services).toEqual([
+      {
+        name: 'Roads',
+        type: 'arcgis-feature-server',
+        url: 'https://example.com/arcgis/rest/services/Roads/FeatureServer'
+      },
+      {
+        name: 'Basemap',
+        type: 'arcgis-map-server',
+        url: 'https://example.com/arcgis/rest/services/Public/Basemap/MapServer'
+      }
+    ]);
+    expect(requests).toHaveLength(2);
+    expect(await getArcGISServices('https://example.com/not-an-arcgis-service')).toBeNull();
   });
 });

--- a/modules/wms/src/wfs-source-loader.ts
+++ b/modules/wms/src/wfs-source-loader.ts
@@ -308,15 +308,37 @@ export class WFSVectorSource extends DataSource<string, WFSourceOptions> impleme
       parameters.signal ? {signal: parameters.signal} : undefined
     );
     if (!response.ok) {
-      throw new Error(`WFS GetFeature request failed: ${response.status} ${response.statusText}`);
+      const arrayBuffer = await response.arrayBuffer();
+      this._checkResponse(response, arrayBuffer);
     }
     if (!response.body) {
       const text = await response.text();
+      if (isWFSExceptionDocument(text, response.headers.get('content-type'))) {
+        throw new Error('WFS GetFeature returned an exception document');
+      }
       yield convertWFSFeatures(parseGML(text, this.loadOptions), parameters.format);
       return;
     }
 
-    const chunks = readResponseChunks(response.body);
+    const reader = response.body.getReader();
+    const initialChunks: Uint8Array[] = [];
+    let initialText = '';
+    const textDecoder = new TextDecoder();
+    while (initialText.length < 4096 && !initialText.includes('>')) {
+      const {done, value} = await reader.read();
+      if (done) break;
+      if (value) {
+        initialChunks.push(value);
+        initialText += textDecoder.decode(value, {stream: true});
+      }
+    }
+    initialText += textDecoder.decode();
+    if (isWFSExceptionDocument(initialText, response.headers.get('content-type'))) {
+      reader.releaseLock();
+      throw new Error('WFS GetFeature returned an exception document');
+    }
+
+    const chunks = readResponseChunks(reader, initialChunks);
     const {GMLLoaderWithParser} = await import('./gml-loader-with-parser');
     for await (const batch of GMLLoaderWithParser.parseInBatches!(chunks, {
       ...this.loadOptions,
@@ -695,10 +717,8 @@ export class WFSVectorSource extends DataSource<string, WFSourceOptions> impleme
   /** Checks for and parses a WFS XML formatted ServiceError and throws an exception */
   protected _checkResponse(response: Response, arrayBuffer: ArrayBuffer): void {
     const contentType = response.headers.get('content-type') || '';
-    if (
-      !response.ok ||
-      WMSErrorLoaderWithParser.mimeTypes.some(type => contentType.includes(type))
-    ) {
+    const responseText = new TextDecoder().decode(arrayBuffer);
+    if (!response.ok || isWFSExceptionDocument(responseText, contentType)) {
       // We want error responses to throw exceptions, the WMSErrorLoaderWithParser can do this
       const loadOptions = mergeOptions<WMSLoaderOptions>(this.loadOptions, {
         wms: {throwOnError: true}
@@ -731,8 +751,7 @@ export class WFSVectorSource extends DataSource<string, WFSourceOptions> impleme
           crs
         ],
         crs,
-        srsName: crs,
-        outputFormat: 'application/json'
+        srsName: crs
       };
     }
 
@@ -766,6 +785,15 @@ function parseWFSFeatureCollection(
   return JSON.parse(text);
 }
 
+/** Detects WFS exception reports without treating ordinary XML as an error. */
+function isWFSExceptionDocument(text: string, contentType: string | null): boolean {
+  return (
+    contentType?.includes('application/vnd.ogc.se_xml') === true ||
+    /<(?:[\w-]+:)?ServiceExceptionReport\b/i.test(text) ||
+    /<(?:[\w-]+:)?ExceptionReport\b/i.test(text)
+  );
+}
+
 /** Converts a GML feature collection into the generic vector source result. */
 function convertWFSFeatures(
   parsed: Geometry | GMLFeatureCollection | null,
@@ -784,8 +812,13 @@ function convertWFSFeatures(
 }
 
 /** Adapts a browser response stream to the chunk iterator expected by GML. */
-async function* readResponseChunks(body: ReadableStream<Uint8Array>): AsyncIterable<Uint8Array> {
-  const reader = body.getReader();
+async function* readResponseChunks(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  initialChunks: Uint8Array[] = []
+): AsyncIterable<Uint8Array> {
+  for (const chunk of initialChunks) {
+    yield chunk;
+  }
   try {
     while (true) {
       const {done, value} = await reader.read();

--- a/modules/wms/src/wfs-source-loader.ts
+++ b/modules/wms/src/wfs-source-loader.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {Schema, GeoJSONTable} from '@loaders.gl/schema';
+import type {Schema, GeoJSONTable, Geometry} from '@loaders.gl/schema';
 import {
   convertFeaturesToWKBArrowTable,
   convertGeojsonToBinaryFeatureCollection
@@ -21,6 +21,8 @@ import {WFSCapabilitiesLoaderWithParser} from './wfs-capabilities-loader-with-pa
 
 import type {WMSLoaderOptions} from './wms-error-loader';
 import {WMSErrorLoaderWithParser} from './wms-error-loader-with-parser';
+import {parseGML} from './lib/parsers/gml/parse-gml';
+import type {GMLFeatureCollection} from './lib/parsers/gml/parse-gml';
 import type {CRSIdentifier} from '@math.gl/crs';
 
 /* eslint-disable camelcase */ // WFS XML parameters use snake_case
@@ -87,6 +89,12 @@ export type WFSParameters = {
   format?: 'image/png';
   /** Requested MIME type of returned feature info (GetFeatureInfo) */
   info_format?: 'text/plain' | 'application/geojson' | 'application/vnd.ogc.gml';
+  /** Requested MIME type of WFS GetFeature responses. */
+  outputFormat?:
+    | 'application/json'
+    | 'application/geo+json'
+    | 'application/vnd.ogc.gml'
+    | 'application/gml+xml';
   /** Styling - Not yet supported */
   styles?: unknown;
   /** Any additional parameters specific to this WFSVectorSource (GetMap) */
@@ -144,7 +152,11 @@ export type WFSGetFeatureParameters = {
   /** Output CRS for returned features. */
   srsName?: CRSIdentifier;
   /** Requested output format. */
-  outputFormat?: 'application/json' | 'application/geo+json';
+  outputFormat?:
+    | 'application/json'
+    | 'application/geo+json'
+    | 'application/vnd.ogc.gml'
+    | 'application/gml+xml';
 };
 
 // /** GetMap parameters that are specific to the current view */
@@ -259,7 +271,12 @@ export class WFSVectorSource extends DataSource<string, WFSourceOptions> impleme
     const arrayBuffer = await response.arrayBuffer();
     this._checkResponse(response, arrayBuffer);
     const text = new TextDecoder().decode(arrayBuffer);
-    const geoJsonTable = parseGeoJSONTable(JSON.parse(text));
+    const featureCollection = parseWFSFeatureCollection(
+      text,
+      response.headers.get('content-type'),
+      this.loadOptions
+    );
+    const geoJsonTable = parseGeoJSONTable(featureCollection);
     const format = parameters.format || 'arrow';
 
     switch (format) {
@@ -270,6 +287,42 @@ export class WFSVectorSource extends DataSource<string, WFSourceOptions> impleme
       case 'arrow':
       default:
         return convertFeaturesToWKBArrowTable(geoJsonTable.features);
+    }
+  }
+
+  /**
+   * Streams a WFS GetFeature response as normalized vector batches.
+   *
+   * GML feature members are parsed as they arrive, allowing large WFS responses
+   * to be consumed without holding the complete XML document in memory.
+   */
+  async *getFeaturesInBatches(
+    parameters: GetFeaturesParameters,
+    options: {batchSize?: number} = {}
+  ): AsyncIterable<VectorSourceData> {
+    const url = this.getFeaturesURL(parameters, {
+      outputFormat: 'application/vnd.ogc.gml'
+    });
+    const response = await this.fetch(
+      url,
+      parameters.signal ? {signal: parameters.signal} : undefined
+    );
+    if (!response.ok) {
+      throw new Error(`WFS GetFeature request failed: ${response.status} ${response.statusText}`);
+    }
+    if (!response.body) {
+      const text = await response.text();
+      yield convertWFSFeatures(parseGML(text, this.loadOptions), parameters.format);
+      return;
+    }
+
+    const chunks = readResponseChunks(response.body);
+    const {GMLLoaderWithParser} = await import('./gml-loader-with-parser');
+    for await (const batch of GMLLoaderWithParser.parseInBatches!(chunks, {
+      ...this.loadOptions,
+      gml: {batchSize: options.batchSize || 1000}
+    })) {
+      yield convertWFSFeatures(batch, parameters.format);
     }
   }
 
@@ -412,7 +465,10 @@ export class WFSVectorSource extends DataSource<string, WFSourceOptions> impleme
       typeName: requestParameters.typeName,
       bbox: requestParameters.bbox,
       srsName: requestParameters.srsName || requestParameters.crs || 'EPSG:4326',
-      outputFormat: requestParameters.outputFormat || 'application/json'
+      outputFormat:
+        requestParameters.outputFormat ||
+        this.options.wfs?.wfsParameters?.outputFormat ||
+        'application/json'
     };
     return this._getWFSUrl('GetFeature', options, vendorParameters);
   }
@@ -638,8 +694,11 @@ export class WFSVectorSource extends DataSource<string, WFSourceOptions> impleme
 
   /** Checks for and parses a WFS XML formatted ServiceError and throws an exception */
   protected _checkResponse(response: Response, arrayBuffer: ArrayBuffer): void {
-    const contentType = response.headers['content-type'];
-    if (!response.ok || WMSErrorLoaderWithParser.mimeTypes.includes(contentType)) {
+    const contentType = response.headers.get('content-type') || '';
+    if (
+      !response.ok ||
+      WMSErrorLoaderWithParser.mimeTypes.some(type => contentType.includes(type))
+    ) {
       // We want error responses to throw exceptions, the WMSErrorLoaderWithParser can do this
       const loadOptions = mergeOptions<WMSLoaderOptions>(this.loadOptions, {
         wms: {throwOnError: true}
@@ -692,4 +751,48 @@ function parseGeoJSONTable(json: any): GeoJSONTable {
   }
 
   throw new Error('WFS GetFeature did not return a GeoJSON FeatureCollection');
+}
+
+/** Parses a WFS response as GeoJSON or GML based on its content. */
+function parseWFSFeatureCollection(
+  text: string,
+  contentType: string | null,
+  options: Record<string, unknown>
+): GMLFeatureCollection | any {
+  const trimmedText = text.trimStart();
+  if (contentType?.includes('xml') || trimmedText.startsWith('<')) {
+    return parseGML(text, options) as GMLFeatureCollection;
+  }
+  return JSON.parse(text);
+}
+
+/** Converts a GML feature collection into the generic vector source result. */
+function convertWFSFeatures(
+  parsed: Geometry | GMLFeatureCollection | null,
+  format?: string
+): VectorSourceData {
+  if (!parsed || parsed.type !== 'FeatureCollection') {
+    throw new Error('WFS GetFeature did not return a GML FeatureCollection');
+  }
+  if (format === 'geojson') {
+    return {shape: 'geojson-table', type: 'FeatureCollection', features: parsed.features as any};
+  }
+  if (format === 'binary') {
+    return convertGeojsonToBinaryFeatureCollection(parsed.features as any);
+  }
+  return convertFeaturesToWKBArrowTable(parsed.features as any);
+}
+
+/** Adapts a browser response stream to the chunk iterator expected by GML. */
+async function* readResponseChunks(body: ReadableStream<Uint8Array>): AsyncIterable<Uint8Array> {
+  const reader = body.getReader();
+  try {
+    while (true) {
+      const {done, value} = await reader.read();
+      if (done) return;
+      if (value) yield value;
+    }
+  } finally {
+    reader.releaseLock();
+  }
 }

--- a/modules/wms/test/wfs/wfs-source.spec.ts
+++ b/modules/wms/test/wfs/wfs-source.spec.ts
@@ -4,6 +4,7 @@
 
 import test from 'test/utils/vitest-tape';
 import {WFSSourceLoader} from '@loaders.gl/wms';
+import {expect, test as vitestTest} from 'vitest';
 
 const WFS_URL = 'https://example.com/geoserver/wfs';
 
@@ -102,12 +103,12 @@ test('WFSSourceLoader#getFeatures supports explicit GeoJSON', async t => {
   t.end();
 });
 
-test('WFSSourceLoader#getFeatures parses GML feature responses', async t => {
+vitestTest('WFSSourceLoader#getFeatures parses GML feature responses', async () => {
   const source = WFSSourceLoader.createDataSource(WFS_URL, {});
   source.fetch = async () =>
     new Response(
       '<wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs" xmlns:gml="http://www.opengis.net/gml" xmlns:app="urn:app"><gml:featureMember><app:road gml:id="road.1"><app:name>Main Street</app:name><app:geometry><gml:Point><gml:pos>1 2</gml:pos></gml:Point></app:geometry></app:road></gml:featureMember></wfs:FeatureCollection>',
-      {headers: {'content-type': 'application/gml+xml'}}
+      {headers: {'content-type': 'application/xml'}}
     );
 
   const table = await source.getFeatures({
@@ -119,12 +120,11 @@ test('WFSSourceLoader#getFeatures parses GML feature responses', async t => {
     crs: 'EPSG:4326'
   });
 
-  t.equal(table.shape, 'arrow-table', 'returns Arrow tables for GML by default');
-  t.equal(table.data.numRows, 1, 'preserves GML feature rows');
-  t.end();
+  expect(table.shape).toBe('arrow-table');
+  expect(table.data.numRows).toBe(1);
 });
 
-test('WFSSourceLoader#getFeaturesInBatches streams GML into Arrow batches', async t => {
+vitestTest('WFSSourceLoader#getFeaturesInBatches streams GML into Arrow batches', async () => {
   const source = WFSSourceLoader.createDataSource(WFS_URL, {});
   const xml =
     '<wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs" xmlns:gml="http://www.opengis.net/gml" xmlns:app="urn:app"><gml:featureMember><app:road gml:id="road.1"><app:geometry><gml:Point><gml:pos>1 2</gml:pos></gml:Point></app:geometry></app:road></gml:featureMember><gml:featureMember><app:road gml:id="road.2"><app:geometry><gml:Point><gml:pos>3 4</gml:pos></gml:Point></app:geometry></app:road></gml:featureMember></wfs:FeatureCollection>';
@@ -155,7 +155,37 @@ test('WFSSourceLoader#getFeaturesInBatches streams GML into Arrow batches', asyn
     batches.push(batch);
   }
 
-  t.equal(batches.length, 2, 'emits one batch per feature');
-  t.equal(batches[0].data.numRows, 1, 'emits normalized Arrow data');
-  t.end();
+  expect(batches).toHaveLength(2);
+  expect(batches[0].data.numRows).toBe(1);
 });
+
+vitestTest('WFSSourceLoader#getFeatures honors configured output format', () => {
+  const source = WFSSourceLoader.createDataSource(WFS_URL, {
+    wfs: {wfsParameters: {outputFormat: 'application/vnd.ogc.gml'}}
+  });
+  const featuresUrl = new URL(source.getFeaturesURL({layers: ['roads'], crs: 'EPSG:4326'}));
+
+  expect(featuresUrl.searchParams.get('OUTPUTFORMAT')).toBe('application/vnd.ogc.gml');
+});
+
+vitestTest(
+  'WFSSourceLoader#getFeaturesInBatches rejects successful WFS exception responses',
+  async () => {
+    const source = WFSSourceLoader.createDataSource(WFS_URL, {});
+    source.fetch = async () =>
+      new Response(
+        '<ServiceExceptionReport><ServiceException>Denied</ServiceException></ServiceExceptionReport>',
+        {
+          headers: {'content-type': 'application/xml'}
+        }
+      );
+
+    await expect(
+      (async () => {
+        for await (const _batch of source.getFeaturesInBatches({layers: ['roads']})) {
+          // The response should fail before any feature batch is emitted.
+        }
+      })()
+    ).rejects.toThrow('exception document');
+  }
+);

--- a/modules/wms/test/wfs/wfs-source.spec.ts
+++ b/modules/wms/test/wfs/wfs-source.spec.ts
@@ -101,3 +101,61 @@ test('WFSSourceLoader#getFeatures supports explicit GeoJSON', async t => {
   });
   t.end();
 });
+
+test('WFSSourceLoader#getFeatures parses GML feature responses', async t => {
+  const source = WFSSourceLoader.createDataSource(WFS_URL, {});
+  source.fetch = async () =>
+    new Response(
+      '<wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs" xmlns:gml="http://www.opengis.net/gml" xmlns:app="urn:app"><gml:featureMember><app:road gml:id="road.1"><app:name>Main Street</app:name><app:geometry><gml:Point><gml:pos>1 2</gml:pos></gml:Point></app:geometry></app:road></gml:featureMember></wfs:FeatureCollection>',
+      {headers: {'content-type': 'application/gml+xml'}}
+    );
+
+  const table = await source.getFeatures({
+    boundingBox: [
+      [0, 0],
+      [3, 3]
+    ],
+    layers: ['roads'],
+    crs: 'EPSG:4326'
+  });
+
+  t.equal(table.shape, 'arrow-table', 'returns Arrow tables for GML by default');
+  t.equal(table.data.numRows, 1, 'preserves GML feature rows');
+  t.end();
+});
+
+test('WFSSourceLoader#getFeaturesInBatches streams GML into Arrow batches', async t => {
+  const source = WFSSourceLoader.createDataSource(WFS_URL, {});
+  const xml =
+    '<wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs" xmlns:gml="http://www.opengis.net/gml" xmlns:app="urn:app"><gml:featureMember><app:road gml:id="road.1"><app:geometry><gml:Point><gml:pos>1 2</gml:pos></gml:Point></app:geometry></app:road></gml:featureMember><gml:featureMember><app:road gml:id="road.2"><app:geometry><gml:Point><gml:pos>3 4</gml:pos></gml:Point></app:geometry></app:road></gml:featureMember></wfs:FeatureCollection>';
+  source.fetch = async () =>
+    new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(xml.slice(0, 180)));
+          controller.enqueue(new TextEncoder().encode(xml.slice(180)));
+          controller.close();
+        }
+      }),
+      {headers: {'content-type': 'application/gml+xml'}}
+    );
+
+  const batches = [];
+  for await (const batch of source.getFeaturesInBatches(
+    {
+      boundingBox: [
+        [0, 0],
+        [5, 5]
+      ],
+      layers: ['roads'],
+      crs: 'EPSG:4326'
+    },
+    {batchSize: 1}
+  )) {
+    batches.push(batch);
+  }
+
+  t.equal(batches.length, 2, 'emits one batch per feature');
+  t.equal(batches[0].data.numRows, 1, 'emits normalized Arrow data');
+  t.end();
+});


### PR DESCRIPTION
Goals of this PR

- Advance tranches 5 and 6 toward production-scale GML and WFS ingestion.
- Make WFS GetFeature useful with both GeoJSON and GML servers.
- Stream large GML feature collections into normalized Arrow, GeoJSON, or binary batches without buffering the full response.

Actual changes

- Detect GML WFS responses from content type or XML payload and parse them through the existing GML parser.
- Add configurable WFS `outputFormat` support for JSON, GeoJSON, and GML MIME types.
- Add `WFSVectorSource#getFeaturesInBatches()` with browser ReadableStream support, configurable batch sizes, cancellation propagation, and normalized output conversion.
- Preserve Arrow as the default output while supporting the existing `geojson` and `binary` formats for streamed batches.
- Improve WFS response error detection for content types with parameters.
- Document the streaming WFS/GML workflow and update GML support notes to describe the supported GML 2/3 geometry subset.
- Add hermetic tests for complete GML responses and chunked streaming responses.

Scope and sequencing

This PR deliberately keeps OGC API and the universal service runtime out of scope. It builds on the existing WFS capabilities and GML geometry parser, focusing this epic on practical high-volume feature ingestion and Arrow output.

Validation

- `yarn lint fix`
- `yarn build`
- Focused WFS/GML Chromium tests passed (12 tests, including new streaming cases)
- `yarn test-audit` (0 violations)