### PR TITLE
test(copc): migrate source suite to Vitest

### DIFF
--- a/modules/copc/test/copc-source.spec.ts
+++ b/modules/copc/test/copc-source.spec.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
-import {expect, test as vitestTest, vi} from 'vitest';
+import {expect, test, vi} from 'vitest';
 import {validateWriter} from 'test/common/conformance';
 import {createDataSource, encodeSync, fetchFile, isBrowser, parse} from '@loaders.gl/core';
 import {
@@ -44,12 +43,11 @@ class TestCOPCTileSource extends COPCTileSource {
   }
 }
 
-test('COPCWriter#writer conformance', t => {
-  validateWriter(t, COPCWriter, 'COPCWriter');
-  t.end();
+test('COPCWriter#writer conformance', () => {
+  validateWriter(COPCWriter, 'COPCWriter');
 });
 
-test('COPCSourceLoader#creates a source through createDataSource', async t => {
+test('COPCSourceLoader#creates a source through createDataSource', async () => {
   const dataSource = createDataSource(await createEllipsoidSourceData(), [COPCSourceLoader], {
     core: {
       type: 'copc'
@@ -57,32 +55,27 @@ test('COPCSourceLoader#creates a source through createDataSource', async t => {
     copc: {}
   });
 
-  t.ok(dataSource instanceof COPCTileSource, 'createDataSource returns a COPC tile source');
-  t.end();
+  expect(dataSource).toBeInstanceOf(COPCTileSource);
 });
 
-test('COPCSourceLoader#loads normalized root and child tiles', async t => {
+test('COPCSourceLoader#loads normalized root and child tiles', async () => {
   const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {});
   await source.initialize();
 
   const rootTile = await source.getRootTile();
   const childTiles = await source.getChildren(rootTile);
 
-  t.equal(rootTile.id, '0-0-0-0', 'root tile id uses COPC key format');
-  t.ok(rootTile.pointCount > 0, 'root tile point count is exposed');
-  t.ok(rootTile.boundingVolume.radius > 0, 'root tile has a bounding volume');
-  t.ok(childTiles.length > 0, 'child tile headers are exposed');
-  t.ok(
-    childTiles.every(tile => tile.geometricError < rootTile.geometricError),
-    'child tiles refine geometric error'
-  );
+  expect(rootTile.id).toBe('0-0-0-0');
+  expect(rootTile.pointCount).toBeGreaterThan(0);
+  expect(rootTile.boundingVolume.radius).toBeGreaterThan(0);
+  expect(childTiles.length).toBeGreaterThan(0);
+  expect(childTiles.every(tile => tile.geometricError < rootTile.geometricError)).toBe(true);
 
   const grandChildTiles = await source.getChildren(childTiles[0]);
-  t.ok(Array.isArray(grandChildTiles), 'deeper hierarchy traversal succeeds');
-  t.end();
+  expect(Array.isArray(grandChildTiles)).toBe(true);
 });
 
-test('COPCSourceLoader#loads full point content for a tile', async t => {
+test('COPCSourceLoader#loads full point content for a tile', async () => {
   const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {});
   await source.initialize();
 
@@ -91,34 +84,24 @@ test('COPCSourceLoader#loads full point content for a tile', async t => {
   const tile = childTiles[0] || rootTile;
   const content = await source.loadTileContent(tile);
 
-  t.ok(content, 'tile content loads');
-  t.equal(
-    content?.data.data.getChild('POSITION')?.length,
-    content?.pointCount,
-    'Arrow table contains one position row per point'
-  );
-  t.equal(content?.data.shape, 'arrow-table', 'tile content is returned as an Arrow table');
-  t.ok(content?.cartographicOrigin.length === 3, 'content includes a coordinate origin');
-  t.end();
+  expect(content).toBeTruthy();
+  expect(content?.data.data.getChild('POSITION')?.length).toBe(content?.pointCount);
+  expect(content?.data.shape).toBe('arrow-table');
+  expect(content?.cartographicOrigin.length).toBe(3);
 });
 
-test('COPCSourceLoader#loads tile content with TypeScript LAZ decoder', async t => {
+test('COPCSourceLoader#loads tile content with TypeScript LAZ decoder', async () => {
   const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {});
   await source.initialize();
 
   const rootTile = await source.getRootTile();
   const content = await source.loadTileContent(rootTile);
 
-  t.ok(content, 'tile content loads');
-  t.equal(
-    content?.data.data.getChild('POSITION')?.length,
-    content?.pointCount,
-    'Arrow table contains one position row per point'
-  );
-  t.end();
+  expect(content).toBeTruthy();
+  expect(content?.data.data.getChild('POSITION')?.length).toBe(content?.pointCount);
 });
 
-vitestTest('COPCSourceLoader#implements the TileSource getTileData contract', async () => {
+test('COPCSourceLoader#implements the TileSource getTileData contract', async () => {
   const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {});
   await source.initialize();
 
@@ -134,7 +117,7 @@ vitestTest('COPCSourceLoader#implements the TileSource getTileData contract', as
   expect((content as any)?.pointCount).toBe(rootTile.pointCount);
 });
 
-vitestTest('COPCSourceLoader#applies selected columns to atomic TypeScript decoding', async () => {
+test('COPCSourceLoader#applies selected columns to atomic TypeScript decoding', async () => {
   const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {
     core: {loadOptions: {core: {worker: false}}}
   });
@@ -153,7 +136,7 @@ vitestTest('COPCSourceLoader#applies selected columns to atomic TypeScript decod
   expect(content?.data.data.getChild('scanAngle')).toBeFalsy();
 });
 
-vitestTest('COPCSourceLoader#uses the shared TypeScript LAS worker for atomic nodes', async () => {
+test('COPCSourceLoader#uses the shared TypeScript LAS worker for atomic nodes', async () => {
   const blob = await createEllipsoidBlob();
   const workerSource = createDataSource(blob, [COPCSourceLoader], {
     core: {
@@ -192,43 +175,42 @@ vitestTest('COPCSourceLoader#uses the shared TypeScript LAS worker for atomic no
   expect((await workerSource.getChildren(rootTile)).length).toBeGreaterThan(0);
 });
 
-vitestTest.each([6, 7, 8] as const)(
-  'COPCSourceLoader#worker matches main-thread PDRF %i node decoding',
-  async pointDataRecordFormat => {
-    const blob = createWorkerCOPCBlob(pointDataRecordFormat);
-    const workerSource = createDataSource(blob, [COPCSourceLoader], {
-      core: {
-        type: 'copc',
-        loadOptions: {core: {worker: true, _workerType: 'test'}}
-      },
-      copc: {decodeConcurrency: 2}
-    });
-    const mainThreadSource = COPCSourceLoader.createDataSource(blob, {
-      core: {loadOptions: {core: {worker: false}}}
-    });
-    await Promise.all([workerSource.initialize(), mainThreadSource.initialize()]);
-    const rootTile = await workerSource.getRootTile();
-    const decodeNodeOnWorker = vi.spyOn(workerSource as any, 'decodeNodeOnWorker');
-    const [workerContent, mainThreadContent] = await Promise.all([
-      workerSource.loadTileContent(rootTile),
-      mainThreadSource.loadTileContent(rootTile)
-    ]);
+test.each([
+  6, 7, 8
+] as const)('COPCSourceLoader#worker matches main-thread PDRF %i node decoding', async pointDataRecordFormat => {
+  const blob = createWorkerCOPCBlob(pointDataRecordFormat);
+  const workerSource = createDataSource(blob, [COPCSourceLoader], {
+    core: {
+      type: 'copc',
+      loadOptions: {core: {worker: true, _workerType: 'test'}}
+    },
+    copc: {decodeConcurrency: 2}
+  });
+  const mainThreadSource = COPCSourceLoader.createDataSource(blob, {
+    core: {loadOptions: {core: {worker: false}}}
+  });
+  await Promise.all([workerSource.initialize(), mainThreadSource.initialize()]);
+  const rootTile = await workerSource.getRootTile();
+  const decodeNodeOnWorker = vi.spyOn(workerSource as any, 'decodeNodeOnWorker');
+  const [workerContent, mainThreadContent] = await Promise.all([
+    workerSource.loadTileContent(rootTile),
+    mainThreadSource.loadTileContent(rootTile)
+  ]);
 
-    expect(await decodeNodeOnWorker.mock.results[0].value).not.toBeNull();
-    expect(readCOPCContentColumn(workerContent, 'POSITION')).toEqual(
-      readCOPCContentColumn(mainThreadContent, 'POSITION')
-    );
-    expect(readCOPCContentColumn(workerContent, 'COLOR_0')).toEqual(
-      readCOPCContentColumn(mainThreadContent, 'COLOR_0')
-    );
-    const repeatedContent = await workerSource.loadTileContent(rootTile);
-    expect(readCOPCContentColumn(repeatedContent, 'POSITION')).toEqual(
-      readCOPCContentColumn(workerContent, 'POSITION')
-    );
-  }
-);
+  expect(await decodeNodeOnWorker.mock.results[0].value).not.toBeNull();
+  expect(readCOPCContentColumn(workerContent, 'POSITION')).toEqual(
+    readCOPCContentColumn(mainThreadContent, 'POSITION')
+  );
+  expect(readCOPCContentColumn(workerContent, 'COLOR_0')).toEqual(
+    readCOPCContentColumn(mainThreadContent, 'COLOR_0')
+  );
+  const repeatedContent = await workerSource.loadTileContent(rootTile);
+  expect(readCOPCContentColumn(repeatedContent, 'POSITION')).toEqual(
+    readCOPCContentColumn(workerContent, 'POSITION')
+  );
+});
 
-vitestTest('COPCSourceLoader#bounds complete node fetch and decode concurrency', async () => {
+test('COPCSourceLoader#bounds complete node fetch and decode concurrency', async () => {
   const sourceBytes = new Uint8Array(await (await fetchFile(ELLIPSOID_BROWSER_URL)).arrayBuffer());
   const source = new TestCOPCTileSource(new Blob([sourceBytes]), {
     copc: {decodeConcurrency: 2},
@@ -253,48 +235,43 @@ vitestTest('COPCSourceLoader#bounds complete node fetch and decode concurrency',
   expect(contents.every(content => content?.pointCount === rootTile.pointCount)).toBe(true);
 });
 
-vitestTest(
-  'COPCSourceLoader#cancels an atomic node queued behind the concurrency bound',
-  async () => {
-    const sourceBytes = new Uint8Array(
-      await (await fetchFile(ELLIPSOID_BROWSER_URL)).arrayBuffer()
-    );
-    const source = new TestCOPCTileSource(new Blob([sourceBytes]), {
-      copc: {decodeConcurrency: 1},
-      core: {loadOptions: {core: {worker: false}}}
-    });
-    await source.initialize();
-    const rootTile = await source.getRootTile();
-    let releaseRange!: () => void;
-    let markRangeStarted!: () => void;
-    const rangeStarted = new Promise<void>(resolve => {
-      markRangeStarted = resolve;
-    });
-    const rangeReleased = new Promise<void>(resolve => {
-      releaseRange = resolve;
-    });
-    let requestCount = 0;
-    source.setRangeGetter(async (begin, end) => {
-      requestCount++;
-      markRangeStarted();
-      await rangeReleased;
-      return sourceBytes.slice(begin, end);
-    });
+test('COPCSourceLoader#cancels an atomic node queued behind the concurrency bound', async () => {
+  const sourceBytes = new Uint8Array(await (await fetchFile(ELLIPSOID_BROWSER_URL)).arrayBuffer());
+  const source = new TestCOPCTileSource(new Blob([sourceBytes]), {
+    copc: {decodeConcurrency: 1},
+    core: {loadOptions: {core: {worker: false}}}
+  });
+  await source.initialize();
+  const rootTile = await source.getRootTile();
+  let releaseRange!: () => void;
+  let markRangeStarted!: () => void;
+  const rangeStarted = new Promise<void>(resolve => {
+    markRangeStarted = resolve;
+  });
+  const rangeReleased = new Promise<void>(resolve => {
+    releaseRange = resolve;
+  });
+  let requestCount = 0;
+  source.setRangeGetter(async (begin, end) => {
+    requestCount++;
+    markRangeStarted();
+    await rangeReleased;
+    return sourceBytes.slice(begin, end);
+  });
 
-    const activeLoad = source.loadTileContent(rootTile);
-    await rangeStarted;
-    const abortController = new AbortController();
-    const queuedLoad = source.loadTileContent(rootTile, {signal: abortController.signal});
-    abortController.abort();
+  const activeLoad = source.loadTileContent(rootTile);
+  await rangeStarted;
+  const abortController = new AbortController();
+  const queuedLoad = source.loadTileContent(rootTile, {signal: abortController.signal});
+  abortController.abort();
 
-    await expect(queuedLoad).rejects.toMatchObject({name: 'AbortError'});
-    expect(requestCount).toBe(1);
-    releaseRange();
-    await expect(activeLoad).resolves.toMatchObject({pointCount: rootTile.pointCount});
-  }
-);
+  await expect(queuedLoad).rejects.toMatchObject({name: 'AbortError'});
+  expect(requestCount).toBe(1);
+  releaseRange();
+  await expect(activeLoad).resolves.toMatchObject({pointCount: rootTile.pointCount});
+});
 
-vitestTest('COPCSourceLoader#reports native range cancellation as AbortError', async () => {
+test('COPCSourceLoader#reports native range cancellation as AbortError', async () => {
   const abortController = new AbortController();
   abortController.abort();
   await expect(
@@ -306,19 +283,16 @@ vitestTest('COPCSourceLoader#reports native range cancellation as AbortError', a
   ).rejects.toMatchObject({name: 'AbortError'});
 });
 
-vitestTest.each([0, 1.5])(
-  'COPCSourceLoader#rejects invalid decode concurrency %s',
-  decodeConcurrency => {
-    expect(
-      () =>
-        new TestCOPCTileSource(new Blob(), {
-          copc: {decodeConcurrency}
-        })
-    ).toThrow('COPC decodeConcurrency must be a positive integer');
-  }
-);
+test.each([0, 1.5])('COPCSourceLoader#rejects invalid decode concurrency %s', decodeConcurrency => {
+  expect(
+    () =>
+      new TestCOPCTileSource(new Blob(), {
+        copc: {decodeConcurrency}
+      })
+  ).toThrow('COPC decodeConcurrency must be a positive integer');
+});
 
-vitestTest('COPCSourceLoader#streams TypeScript tile content as Arrow batches', async () => {
+test('COPCSourceLoader#streams TypeScript tile content as Arrow batches', async () => {
   const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {});
   await source.initialize();
 
@@ -356,7 +330,7 @@ vitestTest('COPCSourceLoader#streams TypeScript tile content as Arrow batches', 
   expect(streamedColors).toEqual(expectedColors);
 });
 
-vitestTest('COPCSourceLoader#selects progressive point-data columns', async () => {
+test('COPCSourceLoader#selects progressive point-data columns', async () => {
   const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {});
   await source.initialize();
 
@@ -412,7 +386,7 @@ vitestTest('COPCSourceLoader#selects progressive point-data columns', async () =
   expect(firstBatch?.data.data.getChild('edgeOfFlightLine')).toBeTruthy();
 });
 
-test('COPCSourceLoader#streams position-only TypeScript tile batches', async t => {
+test('COPCSourceLoader#streams position-only TypeScript tile batches', async () => {
   const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {});
   await source.initialize();
 
@@ -425,7 +399,7 @@ test('COPCSourceLoader#streams position-only TypeScript tile batches', async t =
     columns: ['POSITION'],
     rangeChunkSize: 257
   })) {
-    t.notOk(batch.data.data.getChild('COLOR_0'), 'color output is omitted');
+    expect(batch.data.data.getChild('COLOR_0')).toBeFalsy();
     const positions = batch.data.data.getChild('POSITION');
     for (let index = 0; index < batch.pointCount; index++) {
       streamedPositions.push(...(positions?.get(index)?.toArray() || []));
@@ -436,11 +410,10 @@ test('COPCSourceLoader#streams position-only TypeScript tile batches', async t =
   for (let index = 0; index < rootTile.pointCount; index++) {
     expectedPositions.push(...(atomicPositions?.get(index)?.toArray() || []));
   }
-  t.deepEqual(streamedPositions, expectedPositions, 'position-only batches match atomic output');
-  t.end();
+  expect(streamedPositions).toEqual(expectedPositions);
 });
 
-vitestTest('COPCSourceLoader#streams hierarchy pages', async () => {
+test('COPCSourceLoader#streams hierarchy pages', async () => {
   const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {});
   const batches = [];
   for await (const batch of source.loadHierarchyInBatches({maxPages: 1})) {
@@ -452,7 +425,7 @@ vitestTest('COPCSourceLoader#streams hierarchy pages', async () => {
   expect(batches[0]?.nodes['0-0-0-0']).toBeTruthy();
 });
 
-vitestTest('COPCSourceLoader#handles abandoned prefetched range failures', async () => {
+test('COPCSourceLoader#handles abandoned prefetched range failures', async () => {
   const source = new TestCOPCTileSource(await createEllipsoidSourceData(), {});
   await source.initialize();
   let requestCount = 0;
@@ -484,13 +457,13 @@ vitestTest('COPCSourceLoader#handles abandoned prefetched range failures', async
   }
 });
 
-vitestTest('COPCSourceLoader#does not create children beyond depth 31', async () => {
+test('COPCSourceLoader#does not create children beyond depth 31', async () => {
   const source = new TestCOPCTileSource(await createEllipsoidSourceData(), {});
   await source.initialize();
   expect(source.readChildKeys('31-2147483647-2147483647-2147483647')).toEqual([]);
 });
 
-vitestTest('COPCSourceLoader#includes typed Extra Bytes dimensions in its schema', async () => {
+test('COPCSourceLoader#includes typed Extra Bytes dimensions in its schema', async () => {
   const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {});
   const metadata = await source.getMetadata();
   const copc = metadata.formatSpecificMetadata;
@@ -516,7 +489,7 @@ vitestTest('COPCSourceLoader#includes typed Extra Bytes dimensions in its schema
     nullable: false
   });
 });
-test('COPCSourceLoader#loads tile content from a Blob', async t => {
+test('COPCSourceLoader#loads tile content from a Blob', async () => {
   const blob = await createEllipsoidBlob();
   const source = COPCSourceLoader.createDataSource(blob, {});
   await source.initialize();
@@ -524,16 +497,11 @@ test('COPCSourceLoader#loads tile content from a Blob', async t => {
   const rootTile = await source.getRootTile();
   const content = await source.loadTileContent(rootTile);
 
-  t.ok(content, 'Blob-backed tile content loads');
-  t.equal(
-    content?.data.data.getChild('POSITION')?.length,
-    content?.pointCount,
-    'Blob-backed Arrow table contains one position row per point'
-  );
-  t.end();
+  expect(content).toBeTruthy();
+  expect(content?.data.data.getChild('POSITION')?.length).toBe(content?.pointCount);
 });
 
-test('COPCSourceLoader#derives cartographic view metadata from the dataset', async t => {
+test('COPCSourceLoader#derives cartographic view metadata from the dataset', async () => {
   const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {});
 
   const metadata = await source.getMetadata();
@@ -541,30 +509,15 @@ test('COPCSourceLoader#derives cartographic view metadata from the dataset', asy
   const firstPoint = await source.getPoints({nodeIndex: [0, 0, 0, 0]});
   const viewState = source.getViewState();
 
-  t.ok(
-    Array.isArray(metadata.viewState.cartographicCenter),
-    'metadata includes a cartographic center'
-  );
-  t.ok(metadata.viewState.zoom > 0, 'metadata includes an inferred zoom');
-  t.deepEqual(
-    metadata.viewState.cartographicCenter,
-    viewState.cartographicCenter,
-    'metadata view state matches the source view state'
-  );
-  t.equal(
-    metadata.formatSpecificMetadata.header.pointDataRecordFormat,
-    7,
-    'native metadata exposes the COPC point format'
-  );
-  t.ok(
-    schema.fields.some(field => field.name === 'ScannerChannel'),
-    'native schema exposes modern LAS fields without decoding the root node'
-  );
-  t.equal(firstPoint?.length, schema.fields.length, 'native point values match the source schema');
-  t.end();
+  expect(Array.isArray(metadata.viewState.cartographicCenter)).toBe(true);
+  expect(metadata.viewState.zoom).toBeGreaterThan(0);
+  expect(metadata.viewState.cartographicCenter).toEqual(viewState.cartographicCenter);
+  expect(metadata.formatSpecificMetadata.header.pointDataRecordFormat).toBe(7);
+  expect(schema.fields.some(field => field.name === 'ScannerChannel')).toBe(true);
+  expect(firstPoint?.length).toBe(schema.fields.length);
 });
 
-test('COPCWriter#encodes range-readable octree nodes', async t => {
+test('COPCWriter#encodes range-readable octree nodes', async () => {
   const mesh = createCOPCWriterMesh();
   const arrayBuffer = encodeSync(mesh, COPCWriter, {
     copc: {nodePointLimit: 4, maximumDepth: 4, pointDataRecordFormat: 7, scale: [0.01, 0.01, 0.01]}
@@ -580,25 +533,22 @@ test('COPCWriter#encodes range-readable octree nodes', async t => {
   const nodes = Object.values(hierarchy.nodes);
   const rootNode = hierarchy.nodes['0-0-0-0'];
 
-  t.equal(copc.header.pointDataRecordFormat, 7, 'writes PDRF 7');
-  t.equal(copc.header.pointCount, mesh.attributes.POSITION.value.length / 3, 'writes point count');
-  t.equal(copc.header.globalEncoding & 16, 16, 'sets the WKT global encoding bit');
-  t.ok(rootNode, 'writes a root hierarchy node');
-  t.equal(rootNode.pointCount, 4, 'root node respects the point target');
-  t.ok(nodes.length > 1, 'partitions points into child nodes');
-  t.equal(
-    nodes.reduce((pointCount, node) => pointCount + node.pointCount, 0),
-    copc.header.pointCount,
-    'hierarchy assigns every point exactly once'
+  expect(copc.header.pointDataRecordFormat).toBe(7);
+  expect(copc.header.pointCount).toBe(mesh.attributes.POSITION.value.length / 3);
+  expect(copc.header.globalEncoding & 16).toBe(16);
+  expect(rootNode).toBeTruthy();
+  expect(rootNode.pointCount).toBe(4);
+  expect(nodes.length).toBeGreaterThan(1);
+  expect(nodes.reduce((pointCount, node) => pointCount + node.pointCount, 0)).toBe(
+    copc.header.pointCount
   );
-  t.ok(
+  expect(
     ranges.some(
       ([begin, end]) =>
         begin === copc.info.rootHierarchyPage.pageOffset &&
         end - begin === copc.info.rootHierarchyPage.pageLength
-    ),
-    'hierarchy is loaded through its declared byte range'
-  );
+    )
+  ).toBe(true);
 
   const pointDataPositions: string[] = [];
   for (const node of nodes) {
@@ -610,16 +560,10 @@ test('COPCWriter#encodes range-readable octree nodes', async t => {
     });
     pointDataPositions.push(...readPointPositions(rawPointData, copc.header));
   }
-  t.deepEqual(
-    pointDataPositions.sort(),
-    readMeshPositions(mesh).sort(),
-    'independent node chunks preserve every source position'
-  );
+  expect(pointDataPositions.sort()).toEqual(readMeshPositions(mesh).sort());
   const lasData = await parse(arrayBuffer.slice(0), LASLoader, {core: {worker: false}});
-  t.deepEqual(
-    readFlatPositions(lasData.attributes.POSITION.value).sort(),
-    readMeshPositions(mesh).sort(),
-    'ordinary variable-chunk LAZ parsing preserves every source position'
+  expect(readFlatPositions(lasData.attributes.POSITION.value).sort()).toEqual(
+    readMeshPositions(mesh).sort()
   );
 
   const dataView = new DataView(arrayBuffer);
@@ -638,11 +582,9 @@ test('COPCWriter#encodes range-readable octree nodes', async t => {
       variable: true
     }
   );
-  t.equal(chunkCount, nodes.length, 'variable chunk table covers every hierarchy node');
-  t.equal(
-    chunkTable.reduce((pointCount, chunk) => pointCount + chunk.pointCount, 0),
-    copc.header.pointCount,
-    'variable chunk table preserves node point counts'
+  expect(chunkCount).toBe(nodes.length);
+  expect(chunkTable.reduce((pointCount, chunk) => pointCount + chunk.pointCount, 0)).toBe(
+    copc.header.pointCount
   );
 
   const source = COPCSourceLoader.createDataSource(blob, {});
@@ -650,12 +592,11 @@ test('COPCWriter#encodes range-readable octree nodes', async t => {
   const rootTile = await source.getRootTile();
   const childTiles = await source.getChildren(rootTile);
   const content = await source.loadTileContent(childTiles[0] || rootTile);
-  t.ok(childTiles.length > 0, 'range source exposes generated child tiles');
-  t.ok(content?.pointCount, 'range source decodes generated tile content');
-  t.end();
+  expect(childTiles.length).toBeGreaterThan(0);
+  expect(content?.pointCount).toBeTruthy();
 });
 
-vitestTest('COPCWriter writes range-readable hierarchy pages and GPS bounds', async () => {
+test('COPCWriter writes range-readable hierarchy pages and GPS bounds', async () => {
   const mesh = createCOPCWriterMesh();
   const arrayBuffer = encodeSync(mesh, COPCWriter, {
     copc: {
@@ -709,27 +650,20 @@ vitestTest('COPCWriter writes range-readable hierarchy pages and GPS bounds', as
   expect(pages).toHaveLength(hierarchy.pageCount);
 });
 
-test('COPCWriter#validates organization options', t => {
+test('COPCWriter#validates organization options', () => {
   const mesh = createCOPCWriterMesh();
-  t.throws(
-    () => encodeSync(mesh, COPCWriter, {copc: {nodePointLimit: 0}}),
-    /invalid node point limit/,
-    'rejects an empty node target'
+  expect(() => encodeSync(mesh, COPCWriter, {copc: {nodePointLimit: 0}})).toThrow(
+    /invalid node point limit/
   );
-  t.throws(
-    () => encodeSync(mesh, COPCWriter, {copc: {maximumDepth: 31}}),
-    /invalid maximum depth/,
-    'rejects octree depths outside Int32 key coordinates'
+  expect(() => encodeSync(mesh, COPCWriter, {copc: {maximumDepth: 31}})).toThrow(
+    /invalid maximum depth/
   );
-  t.throws(
-    () => encodeSync(mesh, COPCWriter, {copc: {hierarchyPageDepth: 0}}),
-    /invalid hierarchy page depth/,
-    'rejects empty hierarchy pages'
+  expect(() => encodeSync(mesh, COPCWriter, {copc: {hierarchyPageDepth: 0}})).toThrow(
+    /invalid hierarchy page depth/
   );
-  t.end();
 });
 
-test('COPCWriter#defaults to PDRF 6 without colors', async t => {
+test('COPCWriter#defaults to PDRF 6 without colors', async () => {
   const coloredMesh = createCOPCWriterMesh();
   const attributes = {POSITION: coloredMesh.attributes.POSITION};
   const mesh = {
@@ -746,13 +680,12 @@ test('COPCWriter#defaults to PDRF 6 without colors', async t => {
   const copc = await openCOPC(getter);
   const hierarchy = await loadCOPCHierarchyPage(getter, copc.info.rootHierarchyPage);
 
-  t.equal(copc.header.pointDataRecordFormat, 6, 'selects PDRF 6');
-  t.equal(copc.wkt, 'LOCAL_CS["loaders.gl test"]', 'writes an optional WKT VLR');
-  t.ok(hierarchy.nodes['0-0-0-0'], 'PDRF 6 hierarchy is readable');
-  t.end();
+  expect(copc.header.pointDataRecordFormat).toBe(6);
+  expect(copc.wkt).toBe('LOCAL_CS["loaders.gl test"]');
+  expect(hierarchy.nodes['0-0-0-0']).toBeTruthy();
 });
 
-vitestTest('COPCWriter preserves PDRF 8 NIR values across paged nodes', async () => {
+test('COPCWriter preserves PDRF 8 NIR values across paged nodes', async () => {
   const baseMesh = createCOPCWriterMesh();
   const pointCount = baseMesh.attributes.POSITION.value.length / 3;
   const nir = Uint16Array.from({length: pointCount}, (_, index) => index * 101);

--- a/modules/csv/test/csv-arrow-table.spec.ts
+++ b/modules/csv/test/csv-arrow-table.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {
   load,
   loadInBatches,
@@ -40,130 +40,106 @@ const CSV_SAMPLE_URL_EMPTY_LINES = '@loaders.gl/csv/test/data/sample-empty-line.
 const CSV_NO_HEADER_URL = '@loaders.gl/csv/test/data/numbers-100-no-header.csv';
 const TSV_BRAZIL = '@loaders.gl/csv/test/data/tsv/brazil.tsv';
 
-test('CSVLoader#root export includes metadata loader', t => {
-  t.equal(typeof CSVLoader.preload, 'function', 'root CSVLoader exposes preload');
-  t.notOk('parse' in CSVLoader, 'root CSVLoader does not expose parse');
-  t.notOk('parseInBatches' in CSVLoader, 'root CSVLoader does not expose parseInBatches');
-  t.equal(CSVWorkerLoader, CSVLoader, 'CSVWorkerLoader aliases CSVLoader');
-  t.notOk('CSVLoaderWithParser' in csv, 'root does not export CSVLoaderWithParser');
-  t.notOk('CSVArrowLoader' in csv, 'root does not export CSVArrowLoader');
-  t.notOk('CSVArrowWriter' in csv, 'root does not export CSVArrowWriter');
-  t.end();
+test('CSVLoader#root export includes metadata loader', () => {
+  expect(typeof CSVLoader.preload).toBe('function');
+  expect('parse' in CSVLoader).toBe(false);
+  expect('parseInBatches' in CSVLoader).toBe(false);
+  expect(CSVWorkerLoader).toBe(CSVLoader);
+  expect('CSVLoaderWithParser' in csv).toBe(false);
+  expect('CSVArrowLoader' in csv).toBe(false);
+  expect('CSVArrowWriter' in csv).toBe(false);
 });
 
-test('CSVLoader#bundled export includes parser methods', t => {
-  t.equal(typeof BundledCSVLoader.parse, 'function', 'bundled CSVLoader exposes parse');
-  t.equal(
-    typeof BundledCSVLoader.parseInBatches,
-    'function',
-    'bundled CSVLoader exposes parseInBatches'
-  );
-  t.equal(BundledCSVWorkerLoader, BundledCSVLoader, 'bundled CSVWorkerLoader aliases CSVLoader');
-  t.end();
+test('CSVLoader#bundled export includes parser methods', () => {
+  expect(typeof BundledCSVLoader.parse).toBe('function');
+  expect(typeof BundledCSVLoader.parseInBatches).toBe('function');
+  expect(BundledCSVWorkerLoader).toBe(BundledCSVLoader);
 });
 
-test('CSVLoader#unbundled export preloads parser implementation', async t => {
-  t.equal(preloadSync(UnbundledCSVLoader), null, 'unbundled CSVLoader is not preloaded initially');
-  t.equal(UnbundledCSVWorkerLoader, UnbundledCSVLoader, 'worker alias points to CSVLoader');
-  t.equal(typeof UnbundledCSVLoader.preload, 'function', 'unbundled CSVLoader exposes preload');
-  t.notOk('parse' in UnbundledCSVLoader, 'unbundled CSVLoader does not expose parse');
-  t.notOk('parseSync' in UnbundledCSVLoader, 'unbundled CSVLoader does not expose parseSync');
-  t.notOk(
-    'parseInBatches' in UnbundledCSVLoader,
-    'unbundled CSVLoader does not expose parseInBatches'
-  );
+test('CSVLoader#unbundled export preloads parser implementation', async () => {
+  expect(preloadSync(UnbundledCSVLoader)).toBe(null);
+  expect(UnbundledCSVWorkerLoader).toBe(UnbundledCSVLoader);
+  expect(typeof UnbundledCSVLoader.preload).toBe('function');
+  expect('parse' in UnbundledCSVLoader).toBe(false);
+  expect('parseSync' in UnbundledCSVLoader).toBe(false);
+  expect('parseInBatches' in UnbundledCSVLoader).toBe(false);
 
   const table = await parse('city,population\nParis,2148000', UnbundledCSVLoader, {
     core: {worker: false},
     csv: {shape: 'arrow-table', header: true}
   });
-  t.equal(table.shape, 'arrow-table', 'parse returns Arrow table shape');
-  t.equal(table.data.numRows, 1, 'returns Arrow rows');
-  t.equal(table.data.getChild('city')?.get(0), 'Paris', 'returns Arrow column values');
+  expect(table.shape).toBe('arrow-table');
+  expect(table.data.numRows).toBe(1);
+  expect(table.data.getChild('city')?.get(0)).toBe('Paris');
 
   const parserLoader = await preload(UnbundledCSVLoader);
-  t.equal(typeof parserLoader.parse, 'function', 'preload returns parser-bearing CSVLoader');
-  t.equal(preloadSync(UnbundledCSVLoader), parserLoader, 'preloadSync returns cached CSVLoader');
-  t.end();
+  expect(typeof parserLoader.parse).toBe('function');
+  expect(preloadSync(UnbundledCSVLoader)).toBe(parserLoader);
 });
 
-test('CSVLoader#loadInBatches(numbers-100.csv)', async t => {
+test('CSVLoader#loadInBatches(numbers-100.csv)', async () => {
   const iterator = await loadInBatches(CSV_NUMBERS_100_URL, CSVLoader, {
     core: {worker: false, batchSize: 40},
     csv: {shape: 'arrow-table', dynamicTyping: false, skipEmptyLines: false}
   });
 
-  t.ok(isIterator(iterator) || isAsyncIterable(iterator), 'loadInBatches returned iterator');
+  expect(isIterator(iterator) || isAsyncIterable(iterator)).toBe(true);
 
   let batchCount = 0;
   for await (const batch of iterator) {
-    t.ok(batch.data instanceof arrow.Table, 'returns arrow RecordBatch');
-    // t.comment(`BATCH: ${batch.length}`);
+    expect(batch.data).toBeInstanceOf(arrow.Table);
     batchCount++;
   }
-  t.equal(batchCount, 3, 'Correct number of batches received');
-
-  t.end();
+  expect(batchCount).toBe(3);
 });
 
-test('CSVLoader#loadInBatches(numbers-10000.csv)', async t => {
+test('CSVLoader#loadInBatches(numbers-10000.csv)', async () => {
   const iterator = await loadInBatches(CSV_NUMBERS_10000_URL, CSVLoader, {
     core: {worker: false, batchSize: 2000},
     csv: {shape: 'arrow-table', dynamicTyping: false, skipEmptyLines: false}
   });
-  t.ok(isIterator(iterator) || isAsyncIterable(iterator), 'loadInBatches returned iterator');
+  expect(isIterator(iterator) || isAsyncIterable(iterator)).toBe(true);
 
   let batchCount = 0;
   for await (const batch of iterator) {
-    t.ok(batch.data instanceof arrow.Table, 'returns arrow RecordBatch');
-    // t.comment(`BATCH: ${batch.length}`);
+    expect(batch.data).toBeInstanceOf(arrow.Table);
     batchCount++;
   }
-  t.equal(batchCount, 5, 'Correct number of batches received');
-
-  t.end();
+  expect(batchCount).toBe(5);
 });
 
-test('CSVLoader#loadInBatches(incidents.csv)', async t => {
+test('CSVLoader#loadInBatches(incidents.csv)', async () => {
   const iterator = await loadInBatches(CSV_INCIDENTS_URL_QUOTES, CSVLoader, {
     core: {worker: false},
     csv: {shape: 'arrow-table', dynamicTyping: false, skipEmptyLines: false}
   });
-  t.ok(isIterator(iterator) || isAsyncIterable(iterator), 'loadInBatches returned iterator');
+  expect(isIterator(iterator) || isAsyncIterable(iterator)).toBe(true);
 
   let batchCount = 0;
   for await (const batch of iterator) {
-    t.ok(batch.data instanceof arrow.Table, 'returns arrow RecordBatch');
-    // t.comment(`BATCH: ${batch.length}`);
+    expect(batch.data).toBeInstanceOf(arrow.Table);
     batchCount++;
   }
-  t.equal(batchCount, 1, 'Correct number of batches received');
-
-  t.end();
+  expect(batchCount).toBe(1);
 });
 
-test('CSVLoader#load(numbers-100.csv)', async t => {
+test('CSVLoader#load(numbers-100.csv)', async () => {
   const table = await load(CSV_NUMBERS_100_URL, CSVLoader, {
     core: {worker: false},
     csv: {shape: 'arrow-table', dynamicTyping: false, skipEmptyLines: false}
   });
 
-  t.ok(table.data instanceof arrow.Table, 'returns arrow table');
-  t.equal(table.data.numRows, 100, 'respects header detection and excludes header row');
+  expect(table.data).toBeInstanceOf(arrow.Table);
+  expect(table.data.numRows).toBe(100);
 
   const zipColumn = table.data.getChildAt(1);
-  t.equal(zipColumn?.get(0), '09857', 'retains leading zeroes by parsing as strings');
+  expect(zipColumn?.get(0)).toBe('09857');
 
   const fieldTypeNames = table.data.schema.fields.map(field => field.type.toString());
-  t.ok(
-    fieldTypeNames.every(typeName => typeName === 'Utf8'),
-    'all columns are Utf8'
-  );
-
-  t.end();
+  expect(fieldTypeNames.every(typeName => typeName === 'Utf8')).toBe(true);
 });
 
-test('CSVLoader#load prefers supported Arrow Utf8View columns', async t => {
+test('CSVLoader#load prefers supported Arrow Utf8View columns', async () => {
   const table = await load(CSV_NUMBERS_100_URL, CSVLoader, {
     core: {worker: false},
     csv: {
@@ -174,19 +150,14 @@ test('CSVLoader#load prefers supported Arrow Utf8View columns', async t => {
     }
   });
 
-  t.ok(
-    table.data.schema.fields.every(field => field.type.constructor.name === 'Utf8View'),
-    'all Arrow columns use Utf8View'
+  expect(table.data.schema.fields.every(field => field.type.constructor.name === 'Utf8View')).toBe(
+    true
   );
-  t.ok(
-    table.schema.fields.every(field => field.type === 'utf8-view'),
-    'reports Utf8View in the loaders.gl schema'
-  );
-  t.equal(table.data.getChildAt(1)?.get(0), '09857', 'preserves column values');
-  t.end();
+  expect(table.schema.fields.every(field => field.type === 'utf8-view')).toBe(true);
+  expect(table.data.getChildAt(1)?.get(0)).toBe('09857');
 });
 
-test('CSVLoader#parseInBatches reports supported Arrow Utf8View columns', async t => {
+test('CSVLoader#parseInBatches reports supported Arrow Utf8View columns', async () => {
   const csvBuffer = new TextEncoder().encode('name\nArrow\nView\n');
   const preloadedLoader = await preload(CSVLoader);
   const iterator = await parseInBatches([csvBuffer], preloadedLoader, {
@@ -202,15 +173,14 @@ test('CSVLoader#parseInBatches reports supported Arrow Utf8View columns', async 
 
   let rowCount = 0;
   for await (const batch of iterator) {
-    t.equal(batch.data.schema.fields[0]?.type.constructor.name, 'Utf8View');
-    t.equal(batch.schema?.fields[0]?.type, 'utf8-view', 'reports the effective batch schema');
+    expect(batch.data.schema.fields[0]?.type.constructor.name).toBe('Utf8View');
+    expect(batch.schema?.fields[0]?.type).toBe('utf8-view');
     rowCount += batch.length;
   }
-  t.equal(rowCount, 2, 'returns all view-backed rows');
-  t.end();
+  expect(rowCount).toBe(2);
 });
 
-test('CSVLoader#load matches CSVLoader output across fixture cases', async t => {
+test('CSVLoader#load matches CSVLoader output across fixture cases', async () => {
   const cases: Array<{
     name: string;
     url: string;
@@ -306,20 +276,18 @@ test('CSVLoader#load matches CSVLoader output across fixture cases', async t => 
   for (const {name, url, shape, options} of cases) {
     const csvLoaderTable = await load(url, CSVLoader, options);
     const {shape: csvShape, ...arrowOptions} = options.csv;
-    t.equal(csvShape, shape, `${name}: uses expected CSVLoader row shape`);
+    expect(csvShape).toBe(shape);
     const arrowTable = await load(url, CSVLoader, {
       core: {worker: false},
       csv: {...arrowOptions, shape: 'arrow-table'}
     });
     const arrowRows = materializeArrowTableRows(arrowTable, shape);
 
-    t.deepEqual(arrowRows, csvLoaderTable.data, `${name}: arrow-table matches CSVLoader`);
+    expect(arrowRows).toEqual(csvLoaderTable.data);
   }
-
-  t.end();
 });
 
-test('CSVLoader#parseInBatches matches CSVLoader output across fixture cases', async t => {
+test('CSVLoader#parseInBatches matches CSVLoader output across fixture cases', async () => {
   const cases: Array<{
     name: string;
     url: string;
@@ -375,13 +343,11 @@ test('CSVLoader#parseInBatches matches CSVLoader output across fixture cases', a
   for (const {name, url, options} of cases) {
     const csvLoaderRows = await collectCSVLoaderBatchRows(url, options);
     const arrowRows = await collectCSVArrowTableBatchRows(url, options);
-    t.deepEqual(arrowRows, csvLoaderRows, `${name}: arrow-table batches match CSVLoader`);
+    expect(arrowRows).toEqual(csvLoaderRows);
   }
-
-  t.end();
 });
 
-test('CSVLoader#parse handles raw UTF-8 and quoted fields without string tokenization', async t => {
+test('CSVLoader#parse handles raw UTF-8 and quoted fields without string tokenization', async () => {
   const csvText = 'name,note\nÅsa,mañana\nBob,"x,y"\n"Eve","hello\nthere"\n"Dan","b""c"\n';
   const csvBuffer = new TextEncoder().encode(csvText);
   const preloadedLoader = await preload(CSVLoader);
@@ -396,15 +362,13 @@ test('CSVLoader#parse handles raw UTF-8 and quoted fields without string tokeniz
     }
   });
 
-  t.equal(table.data.numRows, 4, 'returns all data rows');
-  t.equal(table.data.numCols, 2, 'returns all columns');
-  t.equal(table.data.getChild('name')?.get(0), 'Åsa', 'keeps non-ascii UTF-8 values');
-  t.equal(table.data.getChild('note')?.get(0), 'mañana', 'keeps non-ascii UTF-8 values');
-  t.equal(table.data.getChild('note')?.get(1), 'x,y', 'keeps delimiters inside quotes');
-  t.equal(table.data.getChild('note')?.get(2), 'hello\nthere', 'keeps newlines inside quotes');
-  t.equal(table.data.getChild('note')?.get(3), 'b"c', 'unescapes doubled quotes');
-
-  t.end();
+  expect(table.data.numRows).toBe(4);
+  expect(table.data.numCols).toBe(2);
+  expect(table.data.getChild('name')?.get(0)).toBe('Åsa');
+  expect(table.data.getChild('note')?.get(0)).toBe('mañana');
+  expect(table.data.getChild('note')?.get(1)).toBe('x,y');
+  expect(table.data.getChild('note')?.get(2)).toBe('hello\nthere');
+  expect(table.data.getChild('note')?.get(3)).toBe('b"c');
 });
 
 async function collectCSVLoaderBatchRows(
@@ -505,7 +469,7 @@ function materializeArrowCellValue(value: unknown): unknown {
   return value;
 }
 
-test('CSVLoader#parse byte path handles TSV, duplicate headers, and missing cells', async t => {
+test('CSVLoader#parse byte path handles TSV, duplicate headers, and missing cells', async () => {
   const csvText = 'a\ta\n1\t2\n3\n';
   const csvBuffer = new TextEncoder().encode(csvText);
   const preloadedLoader = await preload(CSVLoader);
@@ -520,20 +484,14 @@ test('CSVLoader#parse byte path handles TSV, duplicate headers, and missing cell
     }
   });
 
-  t.deepEqual(
-    table.data.schema.fields.map(field => field.name),
-    ['a', 'a.1'],
-    'deduplicates header names'
-  );
-  t.equal(table.data.getChild('a')?.get(0), '1', 'auto-detects tab delimiter');
-  t.equal(table.data.getChild('a.1')?.get(0), '2', 'reads second tab-delimited column');
-  t.equal(table.data.getChild('a')?.get(1), '3', 'reads rows with missing trailing cells');
-  t.equal(table.data.getChild('a.1')?.get(1), null, 'marks missing trailing cells as null');
-
-  t.end();
+  expect(table.data.schema.fields.map(field => field.name)).toEqual(['a', 'a.1']);
+  expect(table.data.getChild('a')?.get(0)).toBe('1');
+  expect(table.data.getChild('a.1')?.get(0)).toBe('2');
+  expect(table.data.getChild('a')?.get(1)).toBe('3');
+  expect(table.data.getChild('a.1')?.get(1)).toBe(null);
 });
 
-test('CSVLoader#parse only adds __parsed_extra for Papa-compatible extra cells', async t => {
+test('CSVLoader#parse only adds __parsed_extra for Papa-compatible extra cells', async () => {
   const noExtraText = 'A,B,C\nx,1,some text\ny,2,other text\n\n';
   const noExtraBuffer = new TextEncoder().encode(noExtraText);
   const preloadedLoader = await preload(CSVLoader);
@@ -546,10 +504,7 @@ test('CSVLoader#parse only adds __parsed_extra for Papa-compatible extra cells',
     }
   });
 
-  t.notOk(
-    noExtraTable.data.getChild('__parsed_extra'),
-    'does not add __parsed_extra when rows do not have extra cells'
-  );
+  expect(noExtraTable.data.getChild('__parsed_extra')).toBe(null);
 
   const extraText = 'A,B,C\nx,1,some text\n,,,\ny,2,other text\n';
   const extraBuffer = new TextEncoder().encode(extraText);
@@ -562,10 +517,7 @@ test('CSVLoader#parse only adds __parsed_extra for Papa-compatible extra cells',
     }
   });
 
-  t.ok(
-    extraTable.data.getChild('__parsed_extra'),
-    'adds __parsed_extra for Papa-compatible header rows with extra cells'
-  );
+  expect(extraTable.data.getChild('__parsed_extra')).toBeTruthy();
 
   const headerlessExtraTable = await parse(extraBuffer.buffer, preloadedLoader, {
     core: {worker: false},
@@ -576,15 +528,10 @@ test('CSVLoader#parse only adds __parsed_extra for Papa-compatible extra cells',
     }
   });
 
-  t.notOk(
-    headerlessExtraTable.data.getChild('__parsed_extra'),
-    'does not add __parsed_extra when header object semantics are not requested'
-  );
-
-  t.end();
+  expect(headerlessExtraTable.data.getChild('__parsed_extra')).toBe(null);
 });
 
-test('CSVLoader#loadInBatches(numbers-100.csv, utf8 columns)', async t => {
+test('CSVLoader#loadInBatches(numbers-100.csv, utf8 columns)', async () => {
   const iterator = await loadInBatches(CSV_NUMBERS_100_URL, CSVLoader, {
     core: {worker: false, batchSize: 40},
     csv: {shape: 'arrow-table', dynamicTyping: false, skipEmptyLines: false}
@@ -592,22 +539,17 @@ test('CSVLoader#loadInBatches(numbers-100.csv, utf8 columns)', async t => {
 
   let rowCount = 0;
   for await (const batch of iterator) {
-    t.ok(batch.data instanceof arrow.Table, 'returns arrow table batch');
+    expect(batch.data).toBeInstanceOf(arrow.Table);
     const fieldTypeNames = batch.data.schema.fields.map(field => field.type.toString());
-    t.ok(
-      fieldTypeNames.every(typeName => typeName === 'Utf8'),
-      'all batch columns are Utf8'
-    );
+    expect(fieldTypeNames.every(typeName => typeName === 'Utf8')).toBe(true);
 
     rowCount += batch.data.numRows;
   }
 
-  t.equal(rowCount, 100, 'returns all data rows across batches');
-
-  t.end();
+  expect(rowCount).toBe(100);
 });
 
-test('CSVLoader#load(numbers-100.csv, dynamicTyping true)', async t => {
+test('CSVLoader#load(numbers-100.csv, dynamicTyping true)', async () => {
   const table = await load(CSV_NUMBERS_100_URL, CSVLoader, {
     core: {worker: false},
     csv: {
@@ -616,22 +558,17 @@ test('CSVLoader#load(numbers-100.csv, dynamicTyping true)', async t => {
     }
   });
 
-  t.ok(table.data instanceof arrow.Table, 'returns arrow table');
-  t.equal(table.data.numRows, 100, 'respects header detection and excludes header row');
+  expect(table.data).toBeInstanceOf(arrow.Table);
+  expect(table.data.numRows).toBe(100);
 
   const zipColumn = table.data.getChildAt(1);
-  t.equal(zipColumn?.get(0), 9857, 'applies dynamic typing by default');
+  expect(zipColumn?.get(0)).toBe(9857);
 
   const fieldTypeNames = table.data.schema.fields.map(field => field.type.toString());
-  t.ok(
-    fieldTypeNames.every(typeName => typeName === 'Float64'),
-    'numeric columns are typed'
-  );
-
-  t.end();
+  expect(fieldTypeNames.every(typeName => typeName === 'Float64')).toBe(true);
 });
 
-test('CSVLoader#load(numbers-100.csv, dynamicTyping false)', async t => {
+test('CSVLoader#load(numbers-100.csv, dynamicTyping false)', async () => {
   const table = await load(CSV_NUMBERS_100_URL, CSVLoader, {
     core: {worker: false},
     csv: {
@@ -640,22 +577,17 @@ test('CSVLoader#load(numbers-100.csv, dynamicTyping false)', async t => {
     }
   });
 
-  t.ok(table.data instanceof arrow.Table, 'returns arrow table');
-  t.equal(table.data.numRows, 100, 'respects header detection and excludes header row');
+  expect(table.data).toBeInstanceOf(arrow.Table);
+  expect(table.data.numRows).toBe(100);
 
   const zipColumn = table.data.getChildAt(1);
-  t.equal(zipColumn?.get(0), '09857', 'keeps strings when dynamic typing is disabled');
+  expect(zipColumn?.get(0)).toBe('09857');
 
   const fieldTypeNames = table.data.schema.fields.map(field => field.type.toString());
-  t.ok(
-    fieldTypeNames.every(typeName => typeName === 'Utf8'),
-    'all columns are Utf8'
-  );
-
-  t.end();
+  expect(fieldTypeNames.every(typeName => typeName === 'Utf8')).toBe(true);
 });
 
-test('CSVLoader#loadInBatches(numbers-100.csv, dynamicTyping true)', async t => {
+test('CSVLoader#loadInBatches(numbers-100.csv, dynamicTyping true)', async () => {
   const iterator = await loadInBatches(CSV_NUMBERS_100_URL, CSVLoader, {
     core: {worker: false, batchSize: 40},
     csv: {
@@ -666,22 +598,17 @@ test('CSVLoader#loadInBatches(numbers-100.csv, dynamicTyping true)', async t => 
 
   let rowCount = 0;
   for await (const batch of iterator) {
-    t.ok(batch.data instanceof arrow.Table, 'returns arrow table batch');
+    expect(batch.data).toBeInstanceOf(arrow.Table);
     const fieldTypeNames = batch.data.schema.fields.map(field => field.type.toString());
-    t.ok(
-      fieldTypeNames.every(typeName => typeName === 'Float64'),
-      'all batch columns are typed'
-    );
+    expect(fieldTypeNames.every(typeName => typeName === 'Float64')).toBe(true);
 
     rowCount += batch.data.numRows;
   }
 
-  t.equal(rowCount, 100, 'returns all data rows across batches');
-
-  t.end();
+  expect(rowCount).toBe(100);
 });
 
-test('CSVLoader#parseInBatches freezes schema after first typed batch', async t => {
+test('CSVLoader#parseInBatches freezes schema after first typed batch', async () => {
   const csvText = 'value\n1\nfoo\n';
   const csvBuffer = new TextEncoder().encode(csvText);
   const preloadedLoader = await preload(CSVLoader);
@@ -704,22 +631,20 @@ test('CSVLoader#parseInBatches freezes schema after first typed batch', async t 
     batches.push(batch);
   }
 
-  t.equal(batches.length, 2, 'returns one row per batch');
+  expect(batches.length).toBe(2);
 
   const firstBatchColumnTypeName = batches[0]?.data.schema.fields[0]?.type.toString();
   const secondBatchColumnTypeName = batches[1]?.data.schema.fields[0]?.type.toString();
-  t.equal(firstBatchColumnTypeName, 'Float64', 'first batch infers float64');
-  t.equal(secondBatchColumnTypeName, 'Float64', 'second batch keeps frozen float64 schema');
+  expect(firstBatchColumnTypeName).toBe('Float64');
+  expect(secondBatchColumnTypeName).toBe('Float64');
 
   const firstBatchValue = batches[0]?.data.getChildAt(0)?.get(0);
   const secondBatchValue = batches[1]?.data.getChildAt(0)?.get(0);
-  t.equal(firstBatchValue, 1, 'first batch keeps typed numeric value');
-  t.equal(secondBatchValue, null, 'second batch coerces incompatible string value to null');
-
-  t.end();
+  expect(firstBatchValue).toBe(1);
+  expect(secondBatchValue).toBe(null);
 });
 
-test('CSVLoader#worker transport serializes and hydrates Arrow table results', async t => {
+test('CSVLoader#worker transport serializes and hydrates Arrow table results', async () => {
   const table = await parse('city,population\nParis,2148000', CSVLoader, {
     core: {worker: false},
     csv: {
@@ -735,34 +660,20 @@ test('CSVLoader#worker transport serializes and hydrates Arrow table results', a
     shape: 'arrow-table';
     data: {transport: string; getChild?: unknown};
   };
-  t.equal(serialized.shape, 'arrow-table', 'serialized result keeps table wrapper shape');
-  t.equal(serialized.data.transport, 'arrow-js', 'serialized result uses Arrow JS transport');
-  t.notOk(serialized.data.getChild, 'serialized data is plain transport payload');
+  expect(serialized.shape).toBe('arrow-table');
+  expect(serialized.data.transport).toBe('arrow-js');
+  expect(serialized.data.getChild).toBeFalsy();
 
   const hydrated = deserializeCSVWorkerResult(serialized) as ArrowTable;
-  t.ok(hydrated.data instanceof arrow.Table, 'hydrated result restores real Arrow table');
-  t.equal(hydrated.data.getChild('city')?.get(0), 'Paris', 'hydrated result keeps values');
+  expect(hydrated.data).toBeInstanceOf(arrow.Table);
+  expect(hydrated.data.getChild('city')?.get(0)).toBe('Paris');
 
   const serializedWithDeprecatedOption = serializeCSVWorkerResult(table, {
     workerTransferBufferCopy: 'none'
   } as any) as {data: {transport: string}};
-  t.equal(
-    serializedWithDeprecatedOption.data.transport,
-    'arrow-js',
-    'deprecated buffer copy option is accepted'
-  );
+  expect(serializedWithDeprecatedOption.data.transport).toBe('arrow-js');
 
   const plainResult = {shape: 'object-row-table', data: [{city: 'Paris'}]};
-  t.equal(
-    serializeCSVWorkerResult(plainResult),
-    plainResult,
-    'serialize leaves non-Arrow results untouched'
-  );
-  t.equal(
-    deserializeCSVWorkerResult(plainResult),
-    plainResult,
-    'deserialize leaves non-Arrow results untouched'
-  );
-
-  t.end();
+  expect(serializeCSVWorkerResult(plainResult)).toBe(plainResult);
+  expect(deserializeCSVWorkerResult(plainResult)).toBe(plainResult);
 });


### PR DESCRIPTION
## Goals

- Move coverage in the high-impact COPC source-loader paths.
- Continue the Tape-to-Vitest migration by removing the remaining Tape shim from the COPC source suite.
- Preserve the existing fixture coverage without adding runtime-heavy cases.

## Changes

- Migrate `modules/copc/test/copc-source.spec.ts` to native Vitest `test`, `test.each`, and `expect` APIs.
- Preserve coverage for COPC hierarchy traversal, TypeScript LAZ decoding, progressive batches, range reads, worker parity, writer validation, and generated PDRF variants.
- Remove Tape assertion messages and `t.end()` calls while retaining the behavioral checks.

## Validation

- `yarn test-headless modules/copc/test/copc-source.spec.ts`
- `yarn test-headless-cover modules/copc/test/copc-source.spec.ts`
- `yarn test-audit`
- `yarn lint fix`
- `yarn build`
- `yarn build-workers`
- `git diff --check`

The focused suite passes all 30 tests. Focused coverage reports `copc-source-loader.ts` at 84.31% statements and 85.99% lines; the COPC package reports 88.97% statements. The test audit reports 589 files, 0 Tape files, and 0 violations.