### PR TITLE
feat(3d-tiles): support multiple content bounding volumes

### DIFF
--- a/docs/modules/tiles/api-reference/tile-3d.md
+++ b/docs/modules/tiles/api-reference/tile-3d.md
@@ -28,6 +28,10 @@ Returns `true` when traversal may request a source-managed lazy child-header gro
 
 A bounding volume that encloses a tile or its content. Exactly one box, region, or sphere property is required. ([`Reference`](https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/master/specification#bounding-volume))
 
+###### `contentBoundingVolumes` (BoundingVolume[])
+
+The transformed content bounding volumes, one for each content entry that declares a `boundingVolume`. The array is empty when no content entry declares one. These volumes are for render culling; traversal continues to use the tile's `boundingVolume`.
+
 ###### `viewerRequestVolume` (BoundingVolume | null)
 
 The transformed volume that limits when this tile may be requested. It is `null` when the tile does not declare a viewer request volume. This volume affects traversal/request eligibility, not render-content culling.

--- a/modules/tiles/src/tileset-3d/common/tile-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tile-3d.ts
@@ -156,7 +156,13 @@ export class Tile3D {
   private _visible: boolean | undefined = undefined;
 
   private _contentBoundingVolume: any;
+  private _contentBoundingVolumes: any[] = [];
   private _viewerRequestVolume: any;
+
+  /** Transformed bounding volumes for all content entries that declare one. */
+  get contentBoundingVolumes(): any[] {
+    return this._contentBoundingVolumes;
+  }
 
   /** Bounding volume that limits when this tile may be requested, when declared. */
   get viewerRequestVolume(): any {
@@ -937,6 +943,7 @@ export class Tile3D {
 
   _initializeBoundingVolumes(tileHeader) {
     this._contentBoundingVolume = null;
+    this._contentBoundingVolumes = [];
     this._viewerRequestVolume = null;
 
     this._updateBoundingVolume(tileHeader);
@@ -1047,24 +1054,12 @@ export class Tile3D {
       );
     }
 
-    const content = header.content;
-    if (!content) {
-      return;
-    }
-
-    // TODO Cesium specific
-    // Non-leaf tiles may have a content bounding-volume, which is a tight-fit bounding volume
-    // around only the features in the tile. This box is useful for culling for rendering,
-    // but not for culling for traversing the tree since it does not guarantee spatial coherence, i.e.,
-    // since it only bounds features in the tile, not the entire tile, children may be
-    // outside of this box.
-    if (content.boundingVolume) {
-      this._contentBoundingVolume = createBoundingVolume(
-        content.boundingVolume,
-        this.computedTransform,
-        this._contentBoundingVolume
-      );
-    }
+    const contentHeaders = Array.isArray(header.content) ? header.content : [header.content];
+    const contentVolumes = contentHeaders.filter(contentHeader => contentHeader?.boundingVolume);
+    this._contentBoundingVolumes = contentVolumes.map(contentHeader =>
+      createBoundingVolume(contentHeader.boundingVolume, this.computedTransform)
+    );
+    this._contentBoundingVolume = this._contentBoundingVolumes[0] || null;
   }
 
   /**

--- a/modules/tiles/src/tileset-3d/common/tile-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tile-3d.ts
@@ -155,7 +155,6 @@ export class Tile3D {
   private _visibilityPlaneMask: any;
   private _visible: boolean | undefined = undefined;
 
-  private _contentBoundingVolume: any;
   private _contentBoundingVolumes: any[] = [];
   private _viewerRequestVolume: any;
 
@@ -942,7 +941,6 @@ export class Tile3D {
   }
 
   _initializeBoundingVolumes(tileHeader) {
-    this._contentBoundingVolume = null;
     this._contentBoundingVolumes = [];
     this._viewerRequestVolume = null;
 
@@ -1059,7 +1057,6 @@ export class Tile3D {
     this._contentBoundingVolumes = contentVolumes.map(contentHeader =>
       createBoundingVolume(contentHeader.boundingVolume, this.computedTransform)
     );
-    this._contentBoundingVolume = this._contentBoundingVolumes[0] || null;
   }
 
   /**


### PR DESCRIPTION
## Goals

Improve 3D Tiles 1.1+ compatibility for tiles with multiple content entries.

## Changes

- Preserve every transformed content bounding volume declared by a tile.
- Add the `Tile3D.contentBoundingVolumes` accessor.
- Keep the existing traversal bounding volume authoritative for hierarchy traversal.
- Document the new API and render-culling semantics.

## Validation

- Focused implementation and documentation change.
- CI will run the build, tests, lint, and documentation checks.