### PR TITLE
feat(loader-utils): add shared request and range caches

### DIFF
--- a/docs/developer-guide/using-range-requests.md
+++ b/docs/developer-guide/using-range-requests.md
@@ -26,6 +26,23 @@ The scheduler:
 - issues the merged HTTP `Range` request
 - slices the merged response back into one promise per original tile
 
+## Caching
+
+Scheduling and caching are separate layers. `RangeRequestScheduler` combines compatible transport
+work, while `RangeRequestCache` retains completed bytes and deduplicates exact requests that are
+already in flight. Keeping those responsibilities separate lets Sources choose a memory budget
+without changing request batching behavior.
+
+`RangeRequestCache` follows the same insertion-order LRU model used by loaders.gl tile caches. It
+supports entry and byte limits, protects pending requests from eviction, and serves a requested
+range from a larger cached interval. Every cache hit returns standalone bytes so application code
+cannot mutate or detach cache-owned storage. Large ranges that exceed the byte budget bypass the
+cache rather than being copied and immediately evicted.
+
+Use `RequestCache` for ordinary keyed asynchronous resources such as parsed 3D Tiles subtrees, and
+`RangeRequestCache` for random-access file bytes. Frame-aware tile content caches remain specialized
+because they must protect visible tiles and coordinate resource unloading.
+
 This is automatic for PMTiles URL Sources. Callers can keep using `getTile()` or
 `getTileData()`.
 

--- a/docs/docs-sidebar.json
+++ b/docs/docs-sidebar.json
@@ -266,7 +266,9 @@
           "modules/loader-utils/api-reference/readable-file",
           "modules/loader-utils/api-reference/http-file",
           "modules/loader-utils/api-reference/request-scheduler",
+          "modules/loader-utils/api-reference/request-cache",
           "modules/loader-utils/api-reference/range-request-scheduler",
+          "modules/loader-utils/api-reference/range-request-cache",
           "modules/loader-utils/api-reference/parse-with-context"
         ]
       },

--- a/docs/modules/loader-utils/README.md
+++ b/docs/modules/loader-utils/README.md
@@ -9,4 +9,6 @@ The `@loaders.gl/loader-utils` contains utilities for creating loaders.
 - [`HttpFile`](/docs/modules/loader-utils/api-reference/http-file) validates random-access HTTP reads and remote object identity.
 - [`RequestScheduler`](/docs/modules/loader-utils/api-reference/request-scheduler) limits asynchronous request concurrency.
 - [`RangeRequestScheduler`](/docs/modules/loader-utils/api-reference/range-request-scheduler) coalesces compatible byte ranges.
+- [`RequestCache`](/docs/modules/loader-utils/api-reference/request-cache) deduplicates and bounds ordinary asynchronous request results.
+- [`RangeRequestCache`](/docs/modules/loader-utils/api-reference/range-request-cache) caches exact and contained byte ranges.
 - [`CachedUriResolver`](/docs/modules/loader-utils/api-reference/cached-uri-resolver) resolves resource references against one stable base and memoizes repeated derivations for a caller-controlled lifetime.

--- a/docs/modules/loader-utils/api-reference/range-request-cache.md
+++ b/docs/modules/loader-utils/api-reference/range-request-cache.md
@@ -1,0 +1,73 @@
+# RangeRequestCache
+
+- _Framework_: JavaScript
+- _Module_: [`@loaders.gl/loader-utils`](https://www.npmjs.com/package/@loaders.gl/loader-utils)
+
+`RangeRequestCache` is the byte-range counterpart to [`RequestCache`](./request-cache). It caches
+exact byte ranges, serves contained subranges, shares concurrent exact loads, and returns a new
+`ArrayBuffer` to every caller so cached storage cannot be detached or mutated accidentally.
+Ranges larger than `maxBytes` bypass storage and are returned directly, avoiding a copy that would
+be immediately evicted.
+
+```ts
+import {RangeRequestCache, RangeRequestScheduler} from '@loaders.gl/loader-utils';
+
+const scheduler = new RangeRequestScheduler({batchDelayMs: 0});
+const cache = new RangeRequestCache({maxBytes: 8 * 1024 * 1024});
+
+const bytes = await cache.read({
+  sourceId: `${url}#${etag}`,
+  offset,
+  length,
+  signal,
+  fetchRange: (rangeOffset, rangeLength, rangeSignal) =>
+    scheduler.fetch({
+      url,
+      sourceId: `${url}#${etag}`,
+      offset: rangeOffset,
+      length: rangeLength,
+      signal: rangeSignal
+    })
+});
+```
+
+The cache and scheduler have separate responsibilities:
+
+- `RangeRequestScheduler` batches and coalesces transport work.
+- `RangeRequestCache` reuses completed bytes and deduplicates in-flight exact reads.
+
+Use a versioned `sourceId`, such as URL plus ETag, when the remote object can change during the
+cache lifetime.
+
+## Constructor
+
+### `new RangeRequestCache(props?)`
+
+| Property | Type | Default | Description |
+| --- | --- | --- | --- |
+| `maxEntries` | `number` | `Infinity` | Maximum settled ranges retained. |
+| `maxBytes` | `number` | `Infinity` | Maximum range bytes retained. |
+| `onEvent` | `(event) => void` | | Receives hit, miss, store, and eviction events. |
+
+## Methods
+
+### `read(request)`
+
+Returns an exact cached range, a slice of a containing range, or loads one exact range through
+`fetchRange`.
+
+### `get(sourceId, offset, length, signal?)`
+
+Returns an exact or contained cached range without starting a request.
+
+### `set(sourceId, offset, arrayBuffer)`
+
+Seeds cache-owned bytes. The input is copied.
+
+### `deleteSource(sourceId)`
+
+Removes all ranges for one source or object version.
+
+### `clear()`
+
+Removes retained bytes and aborts pending requests.

--- a/docs/modules/loader-utils/api-reference/range-request-scheduler.md
+++ b/docs/modules/loader-utils/api-reference/range-request-scheduler.md
@@ -6,6 +6,8 @@
 </p>
 
 `RangeRequestScheduler` is a low-level utility for coalescing nearby byte-range requests.
+It can be composed with [`RangeRequestCache`](./range-request-cache) when completed ranges should
+also be retained for reuse.
 It is used by `PMTilesSourceLoader` and can be reused by other byte-range-addressable Sources.
 
 ```typescript

--- a/docs/modules/loader-utils/api-reference/request-cache.md
+++ b/docs/modules/loader-utils/api-reference/request-cache.md
@@ -1,0 +1,64 @@
+# RequestCache
+
+- _Framework_: JavaScript
+- _Module_: [`@loaders.gl/loader-utils`](https://www.npmjs.com/package/@loaders.gl/loader-utils)
+
+`RequestCache` is a source-scoped, bounded LRU cache for asynchronous request results. It shares
+concurrent requests, retains settled results by recency, and can enforce both entry-count and byte
+budgets.
+
+```ts
+import {RequestCache} from '@loaders.gl/loader-utils';
+
+const cache = new RequestCache<ArrayBuffer>({
+  maxEntries: 32,
+  maxBytes: 8 * 1024 * 1024,
+  getByteLength: value => value.byteLength
+});
+
+const data = await cache.getOrLoad('subtree.json', signal => fetch(url, {signal}).then(r => r.arrayBuffer()));
+```
+
+Pending requests are not evicted. Each caller can supply its own abort signal; one caller aborting
+does not cancel a request still needed by another caller. The cache aborts the underlying request
+when every waiter has aborted or when the cache is cleared.
+
+## Constructor
+
+### `new RequestCache(props?)`
+
+| Property | Type | Default | Description |
+| --- | --- | --- | --- |
+| `maxEntries` | `number` | `Infinity` | Maximum settled entries retained. |
+| `maxBytes` | `number` | `Infinity` | Maximum estimated bytes retained. |
+| `getByteLength` | `(value) => number` | `() => 0` | Estimates one settled value's retained bytes. |
+| `onRemove` | `(key, reason) => void` | | Receives deletion, eviction, abort, error, replacement, and clear events. |
+
+## Methods
+
+### `get(key, signal?)`
+
+Returns the cached promise and updates its LRU position, or `undefined` on a miss.
+
+### `getOrLoad(key, load, signal?)`
+
+Returns an existing request or starts one shared request. Failed and fully aborted requests are
+removed so a later call can retry.
+
+### `set(key, value)`
+
+Stores an already available value.
+
+### `delete(key)`
+
+Removes one entry and aborts it when it is still pending.
+
+### `clear()`
+
+Removes all entries and aborts all pending requests.
+
+## Cache roles
+
+`RequestCache` owns generic request-result reuse. Tile content caches remain specialized because
+they protect visible tiles and coordinate GPU/resource unloading. `RangeRequestCache` adds byte
+interval containment and immutable slices for random-access formats.

--- a/modules/copc/src/copc-source-loader.ts
+++ b/modules/copc/src/copc-source-loader.ts
@@ -24,6 +24,7 @@ import {
   isBrowser,
   NodeFile,
   parseWithWorker,
+  RangeRequestCache,
   type ReadableFile
 } from '@loaders.gl/loader-utils';
 import {createScanQueryMetadata, type PointCloudQueryCapabilities} from '@loaders.gl/loader-utils';
@@ -1777,20 +1778,24 @@ class AsyncSemaphore {
 
 /** Cache the metadata prefix while retaining exact reads for hierarchy and node ranges. */
 function createCachedCOPCRangeReader(readableFile: ReadableFile): COPCRangeReader {
+  const cache = new RangeRequestCache({maxEntries: 1, maxBytes: COPC_PREFIX_CACHE_LENGTH});
+  const sourceId = 'copc-metadata-prefix';
   const prefixPromise = Promise.resolve(readableFile.stat?.()).then(async stat => {
     const prefixLength = Math.min(stat?.size || COPC_PREFIX_CACHE_LENGTH, COPC_PREFIX_CACHE_LENGTH);
-    return new Uint8Array(await readableFile.read(0, prefixLength));
+    const prefix = await readableFile.read(0, prefixLength);
+    cache.set(sourceId, 0, prefix);
   });
   return async (begin, end, signal) => {
     if (signal?.aborted) {
       throw createCOPCAbortError();
     }
-    const prefix = await prefixPromise;
+    await prefixPromise;
     if (signal?.aborted) {
       throw createCOPCAbortError();
     }
-    if (begin >= 0 && end <= prefix.byteLength) {
-      return prefix.subarray(begin, end);
+    const cached = await cache.get(sourceId, begin, end - begin, signal);
+    if (cached) {
+      return new Uint8Array(cached);
     }
     return new Uint8Array(await readableFile.read(begin, end - begin, signal));
   };

--- a/modules/loader-utils/src/index.ts
+++ b/modules/loader-utils/src/index.ts
@@ -145,6 +145,11 @@ export {
 
 // REQUEST UTILS
 export {default as RequestScheduler} from './lib/request-utils/request-scheduler';
+export {RequestCache} from './lib/request-utils/request-cache';
+export type {
+  RequestCacheProps,
+  RequestCacheRemovalReason
+} from './lib/request-utils/request-cache';
 export {parseContentType} from './lib/request-utils/parse-content-type';
 export {
   RangeRequestScheduler,
@@ -160,6 +165,12 @@ export type {
   RangeRequestTransportResult,
   RangeStats
 } from './lib/request-utils/range-request-scheduler';
+export {RangeRequestCache} from './lib/request-utils/range-request-cache';
+export type {
+  CachedRangeRequest,
+  RangeRequestCacheEvent,
+  RangeRequestCacheProps
+} from './lib/request-utils/range-request-cache';
 
 // LAZ DECODER UTILS
 export {

--- a/modules/loader-utils/src/lib/request-utils/range-request-cache.ts
+++ b/modules/loader-utils/src/lib/request-utils/range-request-cache.ts
@@ -138,7 +138,9 @@ export class RangeRequestCache {
       if (signal?.aborted) {
         throw createAbortError();
       }
-      return await fetchRange(offset, length, signal || new AbortController().signal);
+      const arrayBuffer = await fetchRange(offset, length, signal || new AbortController().signal);
+      validateResponseLength(arrayBuffer, length);
+      return arrayBuffer;
     }
     const key = getRangeKey(sourceId, offset, length);
     const placeholder: CachedRange = {
@@ -153,11 +155,7 @@ export class RangeRequestCache {
         key,
         async cacheSignal => {
           const arrayBuffer = await fetchRange(offset, length, cacheSignal);
-          if (arrayBuffer.byteLength !== length) {
-            throw new Error(
-              `Range request returned ${arrayBuffer.byteLength} bytes; expected ${length}`
-            );
-          }
+          validateResponseLength(arrayBuffer, length);
           const loadedRange = {...placeholder, arrayBuffer};
           this.registerRange(key, loadedRange);
           this.onEvent?.({type: 'store', sourceId, offset, length});
@@ -261,6 +259,15 @@ function validateRange(offset: number, length: number): void {
   }
   if (!Number.isSafeInteger(offset + length)) {
     throw new Error('Byte range end must be a safe integer');
+  }
+}
+
+/** Rejects transport responses that do not exactly cover the requested range. */
+function validateResponseLength(arrayBuffer: ArrayBuffer, expectedLength: number): void {
+  if (arrayBuffer.byteLength !== expectedLength) {
+    throw new Error(
+      `Range request returned ${arrayBuffer.byteLength} bytes; expected ${expectedLength}`
+    );
   }
 }
 

--- a/modules/loader-utils/src/lib/request-utils/range-request-cache.ts
+++ b/modules/loader-utils/src/lib/request-utils/range-request-cache.ts
@@ -1,0 +1,272 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {RequestCache, type RequestCacheRemovalReason} from './request-cache';
+
+/** Event emitted by a {@link RangeRequestCache}. */
+export type RangeRequestCacheEvent = {
+  /** Cache operation represented by this event. */
+  type: 'hit' | 'miss' | 'store' | 'evict';
+  /** Stable identifier for the byte-addressable source. */
+  sourceId: string;
+  /** Requested or stored byte offset. */
+  offset: number;
+  /** Requested or stored byte length. */
+  length: number;
+};
+
+/** Options for {@link RangeRequestCache}. */
+export type RangeRequestCacheProps = {
+  /** Maximum number of settled ranges retained. */
+  maxEntries?: number;
+  /** Maximum bytes retained across settled ranges. */
+  maxBytes?: number;
+  /** Called for cache hits, misses, stores, and evictions. */
+  onEvent?: (event: RangeRequestCacheEvent) => void;
+};
+
+/** One byte-range request handled by {@link RangeRequestCache.read}. */
+export type CachedRangeRequest = {
+  /** Stable identifier for the byte-addressable source and object version. */
+  sourceId: string;
+  /** Start byte offset. */
+  offset: number;
+  /** Number of bytes to read. */
+  length: number;
+  /** Optional caller cancellation signal. */
+  signal?: AbortSignal;
+  /** Fetches one exact byte range when it is not cached. */
+  fetchRange: (offset: number, length: number, signal: AbortSignal) => Promise<ArrayBuffer>;
+};
+
+type CachedRange = {
+  sourceId: string;
+  offset: number;
+  length: number;
+  arrayBuffer: ArrayBuffer;
+};
+
+/**
+ * LRU cache for immutable byte ranges.
+ *
+ * Exact and contained reads share cached storage while every caller receives a standalone copy.
+ * Concurrent exact reads share one abort-aware request. Use a source id that includes an ETag or
+ * equivalent version when a URL can change during the cache lifetime.
+ */
+export class RangeRequestCache {
+  private readonly cache: RequestCache<CachedRange>;
+  private readonly rangesBySource = new Map<string, Map<string, CachedRange>>();
+  private readonly onEvent?: (event: RangeRequestCacheEvent) => void;
+
+  /** Creates a bounded byte-range cache. */
+  constructor(props: RangeRequestCacheProps = {}) {
+    this.onEvent = props.onEvent;
+    this.cache = new RequestCache<CachedRange>({
+      maxEntries: props.maxEntries,
+      maxBytes: props.maxBytes,
+      getByteLength: range => range.length,
+      onRemove: (key, reason) => this.handleRemoval(key, reason)
+    });
+  }
+
+  /** Number of pending and settled ranges tracked by this cache. */
+  get size(): number {
+    return this.cache.size;
+  }
+
+  /** Maximum bytes retained across settled range entries. */
+  get maxBytes(): number {
+    return this.cache.maxBytes;
+  }
+
+  /** Number of byte-range requests that have not settled. */
+  get pendingSize(): number {
+    return this.cache.pendingSize;
+  }
+
+  /** Bytes retained by settled range entries. */
+  get byteLength(): number {
+    return this.cache.byteLength;
+  }
+
+  /** Seeds one completed byte range and copies it into cache-owned storage. */
+  set(sourceId: string, offset: number, arrayBuffer: ArrayBuffer): void {
+    validateRange(offset, arrayBuffer.byteLength);
+    const range: CachedRange = {
+      sourceId,
+      offset,
+      length: arrayBuffer.byteLength,
+      arrayBuffer: arrayBuffer.slice(0)
+    };
+    const key = getRangeKey(sourceId, offset, range.length);
+    this.cache.delete(key);
+    this.registerRange(key, range);
+    this.cache.set(key, range);
+    this.onEvent?.({type: 'store', sourceId, offset, length: range.length});
+  }
+
+  /** Returns an exact or contained cached range as a standalone buffer. */
+  async get(
+    sourceId: string,
+    offset: number,
+    length: number,
+    signal?: AbortSignal
+  ): Promise<ArrayBuffer | undefined> {
+    validateRange(offset, length);
+    const match = this.findContainingRange(sourceId, offset, length);
+    if (!match) {
+      return undefined;
+    }
+    const range = await this.cache.get(match.key, signal);
+    if (!range) {
+      return undefined;
+    }
+    this.onEvent?.({type: 'hit', sourceId, offset, length});
+    return sliceRange(range, offset, length);
+  }
+
+  /** Returns a cached range or loads and retains one exact range. */
+  async read(request: CachedRangeRequest): Promise<ArrayBuffer> {
+    const {sourceId, offset, length, signal, fetchRange} = request;
+    const cached = await this.get(sourceId, offset, length, signal);
+    if (cached) {
+      return cached;
+    }
+    this.onEvent?.({type: 'miss', sourceId, offset, length});
+    if (this.cache.maxEntries === 0 || length > this.cache.maxBytes) {
+      if (signal?.aborted) {
+        throw createAbortError();
+      }
+      return await fetchRange(offset, length, signal || new AbortController().signal);
+    }
+    const key = getRangeKey(sourceId, offset, length);
+    const placeholder: CachedRange = {
+      sourceId,
+      offset,
+      length,
+      arrayBuffer: new ArrayBuffer(0)
+    };
+    this.registerRange(key, placeholder);
+    try {
+      const range = await this.cache.getOrLoad(
+        key,
+        async cacheSignal => {
+          const arrayBuffer = await fetchRange(offset, length, cacheSignal);
+          if (arrayBuffer.byteLength !== length) {
+            throw new Error(
+              `Range request returned ${arrayBuffer.byteLength} bytes; expected ${length}`
+            );
+          }
+          const loadedRange = {...placeholder, arrayBuffer};
+          this.registerRange(key, loadedRange);
+          this.onEvent?.({type: 'store', sourceId, offset, length});
+          return loadedRange;
+        },
+        signal
+      );
+      return sliceRange(range, offset, length);
+    } catch (error) {
+      if (!this.cache.has(key)) {
+        this.unregisterRange(key, sourceId);
+      }
+      throw error;
+    }
+  }
+
+  /** Removes every range associated with one source or object version. */
+  deleteSource(sourceId: string): void {
+    const ranges = this.rangesBySource.get(sourceId);
+    if (!ranges) return;
+    for (const key of Array.from(ranges.keys())) {
+      this.cache.delete(key);
+    }
+  }
+
+  /** Aborts pending range requests and clears retained bytes. */
+  clear(): void {
+    this.cache.clear();
+    this.rangesBySource.clear();
+  }
+
+  private findContainingRange(
+    sourceId: string,
+    offset: number,
+    length: number
+  ): {key: string; range: CachedRange} | undefined {
+    const ranges = this.rangesBySource.get(sourceId);
+    if (!ranges) return undefined;
+    const endOffset = offset + length;
+    let match: {key: string; range: CachedRange} | undefined;
+    for (const [key, range] of ranges) {
+      if (
+        range.offset <= offset &&
+        range.offset + range.length >= endOffset &&
+        (!match || range.length < match.range.length)
+      ) {
+        match = {key, range};
+      }
+    }
+    return match;
+  }
+
+  private registerRange(key: string, range: CachedRange): void {
+    let ranges = this.rangesBySource.get(range.sourceId);
+    if (!ranges) {
+      ranges = new Map();
+      this.rangesBySource.set(range.sourceId, ranges);
+    }
+    ranges.set(key, range);
+  }
+
+  private handleRemoval(key: string, reason: RequestCacheRemovalReason): void {
+    for (const [sourceId, ranges] of this.rangesBySource) {
+      const range = ranges.get(key);
+      if (!range) continue;
+      ranges.delete(key);
+      if (ranges.size === 0) {
+        this.rangesBySource.delete(sourceId);
+      }
+      if (reason === 'evict') {
+        this.onEvent?.({type: 'evict', sourceId, offset: range.offset, length: range.length});
+      }
+      return;
+    }
+  }
+
+  private unregisterRange(key: string, sourceId: string): void {
+    const ranges = this.rangesBySource.get(sourceId);
+    ranges?.delete(key);
+    if (ranges?.size === 0) {
+      this.rangesBySource.delete(sourceId);
+    }
+  }
+}
+
+/** Returns a stable exact-range cache key. */
+function getRangeKey(sourceId: string, offset: number, length: number): string {
+  return `${sourceId}\u0000${offset}:${length}`;
+}
+
+/** Copies one requested interval out of a cached containing range. */
+function sliceRange(range: CachedRange, offset: number, length: number): ArrayBuffer {
+  const relativeOffset = offset - range.offset;
+  return range.arrayBuffer.slice(relativeOffset, relativeOffset + length);
+}
+
+/** Validates one non-negative safe-integer byte range. */
+function validateRange(offset: number, length: number): void {
+  if (!Number.isSafeInteger(offset) || !Number.isSafeInteger(length) || offset < 0 || length < 0) {
+    throw new Error('Byte ranges must use non-negative safe integers');
+  }
+  if (!Number.isSafeInteger(offset + length)) {
+    throw new Error('Byte range end must be a safe integer');
+  }
+}
+
+/** Creates the standard abort error for an already-cancelled uncached range read. */
+function createAbortError(): Error {
+  const error = new Error('Request aborted');
+  error.name = 'AbortError';
+  return error;
+}

--- a/modules/loader-utils/src/lib/request-utils/request-cache.ts
+++ b/modules/loader-utils/src/lib/request-utils/request-cache.ts
@@ -1,0 +1,296 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** Reason why an entry was removed from a {@link RequestCache}. */
+export type RequestCacheRemovalReason =
+  | 'delete'
+  | 'evict'
+  | 'clear'
+  | 'abort'
+  | 'error'
+  | 'replace';
+
+/** Options for {@link RequestCache}. */
+export type RequestCacheProps<Value> = {
+  /** Maximum number of settled entries retained. Pending requests are never evicted. */
+  maxEntries?: number;
+  /** Maximum estimated bytes retained across settled entries. */
+  maxBytes?: number;
+  /** Returns the estimated byte length of one settled value. */
+  getByteLength?: (value: Value) => number;
+  /** Called after an entry leaves the cache. */
+  onRemove?: (key: string, reason: RequestCacheRemovalReason) => void;
+};
+
+type RequestCacheEntry<Value> = {
+  promise: Promise<Value>;
+  controller?: AbortController;
+  pending: boolean;
+  waiterCount: number;
+  byteLength: number;
+};
+
+const DEFAULT_MAX_ENTRIES = Number.POSITIVE_INFINITY;
+const DEFAULT_MAX_BYTES = Number.POSITIVE_INFINITY;
+
+/**
+ * Source-scoped LRU cache for asynchronous request results.
+ *
+ * Concurrent callers share one request. Settled entries are retained in least-recently-used order
+ * and bounded by both entry count and estimated byte length. Pending entries are protected from LRU
+ * eviction; their transport is aborted only after every waiting caller has aborted.
+ */
+export class RequestCache<Value> {
+  /** Maximum number of settled entries retained by this cache. */
+  readonly maxEntries: number;
+  /** Maximum estimated bytes retained by this cache. */
+  readonly maxBytes: number;
+
+  private readonly getByteLength: (value: Value) => number;
+  private readonly onRemove?: (key: string, reason: RequestCacheRemovalReason) => void;
+  private readonly entries = new Map<string, RequestCacheEntry<Value>>();
+  private retainedByteLength = 0;
+
+  /** Creates a request cache with optional entry and byte limits. */
+  constructor(props: RequestCacheProps<Value> = {}) {
+    this.maxEntries = validateLimit(props.maxEntries, DEFAULT_MAX_ENTRIES, 'maxEntries');
+    this.maxBytes = validateLimit(props.maxBytes, DEFAULT_MAX_BYTES, 'maxBytes');
+    this.getByteLength = props.getByteLength || (() => 0);
+    this.onRemove = props.onRemove;
+  }
+
+  /** Number of pending and settled entries currently tracked. */
+  get size(): number {
+    return this.entries.size;
+  }
+
+  /** Number of requests that have not settled. */
+  get pendingSize(): number {
+    let pendingSize = 0;
+    for (const entry of this.entries.values()) {
+      pendingSize += entry.pending ? 1 : 0;
+    }
+    return pendingSize;
+  }
+
+  /** Estimated bytes retained by settled entries. */
+  get byteLength(): number {
+    return this.retainedByteLength;
+  }
+
+  /** Returns a cached request and updates its LRU position. */
+  get(key: string, signal?: AbortSignal): Promise<Value> | undefined {
+    const entry = this.entries.get(key);
+    if (!entry) {
+      return undefined;
+    }
+    this.touch(key, entry);
+    return this.waitForEntry(key, entry, signal);
+  }
+
+  /** Returns whether a pending or settled entry exists without updating its LRU position. */
+  has(key: string): boolean {
+    return this.entries.has(key);
+  }
+
+  /** Stores an already available value and returns it. */
+  set(key: string, value: Value): Value {
+    this.removeEntry(key, 'replace');
+    const byteLength = getValidByteLength(this.getByteLength(value));
+    const entry: RequestCacheEntry<Value> = {
+      promise: Promise.resolve(value),
+      pending: false,
+      waiterCount: 0,
+      byteLength
+    };
+    this.entries.set(key, entry);
+    this.retainedByteLength += byteLength;
+    this.trim();
+    return value;
+  }
+
+  /**
+   * Returns a cached value or starts one shared request.
+   *
+   * The loader receives a cache-owned abort signal. One caller aborting only rejects that caller;
+   * the shared request is cancelled when no waiters remain.
+   */
+  getOrLoad(
+    key: string,
+    load: (signal: AbortSignal) => Promise<Value>,
+    signal?: AbortSignal
+  ): Promise<Value> {
+    const cached = this.get(key, signal);
+    if (cached) {
+      return cached;
+    }
+    if (signal?.aborted) {
+      return Promise.reject(createAbortError());
+    }
+
+    const controller = new AbortController();
+    let resolveRequest: (value: Value) => void;
+    let rejectRequest: (error: unknown) => void;
+    const promise = new Promise<Value>((resolve, reject) => {
+      resolveRequest = resolve;
+      rejectRequest = reject;
+    });
+    const entry: RequestCacheEntry<Value> = {
+      promise,
+      controller,
+      pending: true,
+      waiterCount: 0,
+      byteLength: 0
+    };
+    this.entries.set(key, entry);
+    void entry.promise.then(
+      value => this.handleLoadedValue(key, entry, value),
+      () => this.handleLoadError(key, entry)
+    );
+    try {
+      void Promise.resolve(load(controller.signal)).then(resolveRequest!, rejectRequest!);
+    } catch (error) {
+      rejectRequest!(error);
+    }
+    return this.waitForEntry(key, entry, signal);
+  }
+
+  /** Removes one cached or pending request. */
+  delete(key: string): boolean {
+    return this.removeEntry(key, 'delete');
+  }
+
+  /** Aborts pending requests and removes every entry. */
+  clear(): void {
+    for (const key of Array.from(this.entries.keys())) {
+      this.removeEntry(key, 'clear');
+    }
+  }
+
+  private handleLoadedValue(key: string, entry: RequestCacheEntry<Value>, value: Value): void {
+    if (this.entries.get(key) !== entry) {
+      return;
+    }
+    entry.pending = false;
+    entry.controller = undefined;
+    try {
+      entry.byteLength = getValidByteLength(this.getByteLength(value));
+    } catch {
+      this.removeEntry(key, 'error');
+      return;
+    }
+    this.retainedByteLength += entry.byteLength;
+    this.trim();
+  }
+
+  private handleLoadError(key: string, entry: RequestCacheEntry<Value>): void {
+    if (this.entries.get(key) === entry) {
+      this.removeEntry(key, entry.controller?.signal.aborted ? 'abort' : 'error');
+    }
+  }
+
+  private waitForEntry(
+    key: string,
+    entry: RequestCacheEntry<Value>,
+    signal?: AbortSignal
+  ): Promise<Value> {
+    if (signal?.aborted) {
+      return Promise.reject(createAbortError());
+    }
+    if (!entry.pending) {
+      return entry.promise;
+    }
+
+    entry.waiterCount++;
+    return new Promise<Value>((resolve, reject) => {
+      let waiting = true;
+      const finishWaiting = (): void => {
+        if (!waiting) return;
+        waiting = false;
+        signal?.removeEventListener('abort', handleAbort);
+        entry.waiterCount--;
+      };
+      const handleAbort = (): void => {
+        if (!waiting) return;
+        finishWaiting();
+        reject(createAbortError());
+        if (entry.pending && entry.waiterCount === 0 && this.entries.get(key) === entry) {
+          this.removeEntry(key, 'abort');
+        }
+      };
+      signal?.addEventListener('abort', handleAbort, {once: true});
+      void entry.promise.then(
+        value => {
+          if (!waiting) return;
+          finishWaiting();
+          resolve(value);
+        },
+        error => {
+          if (!waiting) return;
+          finishWaiting();
+          reject(error);
+        }
+      );
+    });
+  }
+
+  private touch(key: string, entry: RequestCacheEntry<Value>): void {
+    this.entries.delete(key);
+    this.entries.set(key, entry);
+  }
+
+  private trim(): void {
+    let settledEntryCount = this.entries.size - this.pendingSize;
+    if (settledEntryCount <= this.maxEntries && this.retainedByteLength <= this.maxBytes) {
+      return;
+    }
+    for (const [key, entry] of this.entries) {
+      if (!entry.pending) {
+        this.removeEntry(key, 'evict');
+        settledEntryCount--;
+      }
+      if (settledEntryCount <= this.maxEntries && this.retainedByteLength <= this.maxBytes) {
+        break;
+      }
+    }
+  }
+
+  private removeEntry(key: string, reason: RequestCacheRemovalReason): boolean {
+    const entry = this.entries.get(key);
+    if (!entry) {
+      return false;
+    }
+    this.entries.delete(key);
+    this.retainedByteLength -= entry.byteLength;
+    if (entry.pending) {
+      entry.controller?.abort();
+    }
+    this.onRemove?.(key, reason);
+    return true;
+  }
+}
+
+/** Creates the standard cross-runtime abort error used by request caches. */
+function createAbortError(): Error {
+  const error = new Error('Request aborted');
+  error.name = 'AbortError';
+  return error;
+}
+
+/** Validates a non-negative cache limit and applies its default. */
+function validateLimit(value: number | undefined, fallback: number, name: string): number {
+  const limit = value ?? fallback;
+  if (limit < 0 || Number.isNaN(limit)) {
+    throw new Error(`${name} must be a non-negative number`);
+  }
+  return limit;
+}
+
+/** Normalizes one user-supplied entry-size estimate. */
+function getValidByteLength(value: number): number {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error('Request cache entry byte length must be a non-negative finite number');
+  }
+  return value;
+}

--- a/modules/loader-utils/test/lib/request-utils/request-cache.spec.ts
+++ b/modules/loader-utils/test/lib/request-utils/request-cache.spec.ts
@@ -193,6 +193,20 @@ test('RangeRequestCache bypasses storage and copies for oversized ranges', async
   expect(cache.byteLength).toBe(0);
 });
 
+test('RangeRequestCache validates responses when storage is bypassed', async () => {
+  const cache = new RangeRequestCache({maxBytes: 2});
+
+  await expect(
+    cache.read({
+      sourceId: 'source',
+      offset: 0,
+      length: 4,
+      fetchRange: async () => new Uint8Array([0, 1, 2]).buffer
+    })
+  ).rejects.toThrow('expected 4');
+  expect(cache.size).toBe(0);
+});
+
 test('RangeRequestCache deletes source ranges and reports evictions', async () => {
   const events: string[] = [];
   const cache = new RangeRequestCache({

--- a/modules/loader-utils/test/lib/request-utils/request-cache.spec.ts
+++ b/modules/loader-utils/test/lib/request-utils/request-cache.spec.ts
@@ -1,0 +1,223 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {RequestCache, RangeRequestCache} from '@loaders.gl/loader-utils';
+import {expect, test, vi} from 'vitest';
+
+test('RequestCache shares concurrent loads and retains settled values', async () => {
+  const cache = new RequestCache<number>();
+  const load = vi.fn(async () => 42);
+
+  const [first, second] = await Promise.all([
+    cache.getOrLoad('answer', load),
+    cache.getOrLoad('answer', load)
+  ]);
+  const third = await cache.get('answer');
+
+  expect([first, second, third]).toEqual([42, 42, 42]);
+  expect(load).toHaveBeenCalledOnce();
+  expect(cache.size).toBe(1);
+  expect(cache.pendingSize).toBe(0);
+});
+
+test('RequestCache evicts settled entries in LRU order by count', async () => {
+  const cache = new RequestCache<number>({maxEntries: 2});
+  cache.set('first', 1);
+  cache.set('second', 2);
+  await cache.get('first');
+  cache.set('third', 3);
+
+  expect(await cache.get('first')).toBe(1);
+  expect(cache.get('second')).toBeUndefined();
+  expect(await cache.get('third')).toBe(3);
+});
+
+test('RequestCache observes byte limits without evicting pending requests', async () => {
+  let resolvePending: ((value: Uint8Array) => void) | undefined;
+  const cache = new RequestCache<Uint8Array>({
+    maxBytes: 4,
+    getByteLength: value => value.byteLength
+  });
+  const pending = cache.getOrLoad(
+    'pending',
+    () =>
+      new Promise(resolve => {
+        resolvePending = resolve;
+      })
+  );
+  cache.set('settled', new Uint8Array([1, 2, 3, 4]));
+
+  expect(cache.pendingSize).toBe(1);
+  await Promise.resolve();
+  resolvePending?.(new Uint8Array([5, 6, 7, 8]));
+  await pending;
+
+  expect(cache.pendingSize).toBe(0);
+  expect(cache.byteLength).toBe(4);
+  expect(cache.get('pending')).toBeUndefined();
+  expect(await cache.get('settled')).toEqual(new Uint8Array([1, 2, 3, 4]));
+});
+
+test('RequestCache isolates caller aborts and aborts transport after the last waiter', async () => {
+  const firstController = new AbortController();
+  const secondController = new AbortController();
+  let transportSignal: AbortSignal | undefined;
+  const cache = new RequestCache<number>();
+  const load = (signal: AbortSignal): Promise<number> => {
+    transportSignal = signal;
+    return new Promise((_resolve, reject) => {
+      signal.addEventListener('abort', () => reject(signal.reason), {once: true});
+    });
+  };
+
+  const first = cache.getOrLoad('shared', load, firstController.signal);
+  const second = cache.getOrLoad('shared', load, secondController.signal);
+  firstController.abort();
+
+  await expect(first).rejects.toMatchObject({name: 'AbortError'});
+  expect(transportSignal?.aborted).toBe(false);
+
+  secondController.abort();
+  await expect(second).rejects.toMatchObject({name: 'AbortError'});
+  expect(transportSignal?.aborted).toBe(true);
+  expect(cache.size).toBe(0);
+});
+
+test('RequestCache removes failed requests so callers can retry', async () => {
+  const cache = new RequestCache<number>();
+  await expect(
+    cache.getOrLoad('retry', async () => {
+      throw new Error('failed');
+    })
+  ).rejects.toThrow('failed');
+
+  await expect(cache.getOrLoad('retry', async () => 7)).resolves.toBe(7);
+});
+
+test('RequestCache reports removal reasons and aborts pending work when cleared', async () => {
+  const removals: Array<[string, string]> = [];
+  const cache = new RequestCache<number>({
+    onRemove: (key, reason) => removals.push([key, reason])
+  });
+  cache.set('replace', 1);
+  cache.set('replace', 2);
+  cache.set('delete', 3);
+  cache.delete('delete');
+  const pending = cache.getOrLoad(
+    'pending',
+    signal =>
+      new Promise((_resolve, reject) => {
+        signal.addEventListener('abort', () => reject(new Error('transport aborted')), {
+          once: true
+        });
+      })
+  );
+
+  cache.clear();
+
+  await expect(pending).rejects.toThrow('transport aborted');
+  expect(removals).toEqual([
+    ['replace', 'replace'],
+    ['delete', 'delete'],
+    ['replace', 'clear'],
+    ['pending', 'clear']
+  ]);
+  expect(cache.size).toBe(0);
+});
+
+test('RequestCache validates limits and ignores invalid asynchronous size estimates', async () => {
+  expect(() => new RequestCache({maxEntries: -1})).toThrow('maxEntries');
+  const cache = new RequestCache<number>({getByteLength: () => Number.POSITIVE_INFINITY});
+
+  await expect(cache.getOrLoad('value', async () => 1)).resolves.toBe(1);
+  await Promise.resolve();
+
+  expect(cache.size).toBe(0);
+});
+
+test('RangeRequestCache serves contained immutable range copies', async () => {
+  const events: string[] = [];
+  const cache = new RangeRequestCache({onEvent: event => events.push(event.type)});
+  cache.set('source', 10, new Uint8Array([10, 11, 12, 13, 14, 15]).buffer);
+
+  const first = await cache.get('source', 12, 3);
+  expect(Array.from(new Uint8Array(first!))).toEqual([12, 13, 14]);
+  new Uint8Array(first!)[0] = 255;
+  const second = await cache.get('source', 12, 3);
+
+  expect(Array.from(new Uint8Array(second!))).toEqual([12, 13, 14]);
+  expect(events).toEqual(['store', 'hit', 'hit']);
+});
+
+test('RangeRequestCache shares exact loads and isolates source identities', async () => {
+  const cache = new RangeRequestCache();
+  const fetchRange = vi.fn(
+    async (offset: number, length: number) =>
+      new Uint8Array(length).map((_, index) => offset + index).buffer
+  );
+
+  const [first, second] = await Promise.all([
+    cache.read({sourceId: 'first', offset: 4, length: 3, fetchRange}),
+    cache.read({sourceId: 'first', offset: 4, length: 3, fetchRange})
+  ]);
+  await cache.read({sourceId: 'second', offset: 4, length: 3, fetchRange});
+
+  expect(Array.from(new Uint8Array(first))).toEqual([4, 5, 6]);
+  expect(Array.from(new Uint8Array(second))).toEqual([4, 5, 6]);
+  expect(fetchRange).toHaveBeenCalledTimes(2);
+});
+
+test('RangeRequestCache evicts ranges using a byte budget', async () => {
+  const cache = new RangeRequestCache({maxBytes: 4});
+  cache.set('source', 0, new Uint8Array([0, 1, 2, 3]).buffer);
+  cache.set('source', 4, new Uint8Array([4, 5, 6, 7]).buffer);
+
+  expect(await cache.get('source', 0, 1)).toBeUndefined();
+  expect(Array.from(new Uint8Array((await cache.get('source', 4, 4))!))).toEqual([4, 5, 6, 7]);
+  expect(cache.byteLength).toBe(4);
+});
+
+test('RangeRequestCache bypasses storage and copies for oversized ranges', async () => {
+  const cache = new RangeRequestCache({maxBytes: 2});
+  const source = new Uint8Array([0, 1, 2, 3]).buffer;
+  const result = await cache.read({
+    sourceId: 'source',
+    offset: 0,
+    length: 4,
+    fetchRange: async () => source
+  });
+
+  expect(result).toBe(source);
+  expect(cache.size).toBe(0);
+  expect(cache.byteLength).toBe(0);
+});
+
+test('RangeRequestCache deletes source ranges and reports evictions', async () => {
+  const events: string[] = [];
+  const cache = new RangeRequestCache({
+    maxEntries: 1,
+    onEvent: event => events.push(`${event.type}:${event.sourceId}:${event.offset}`)
+  });
+  cache.set('first', 0, new Uint8Array([1]).buffer);
+  cache.set('second', 0, new Uint8Array([2]).buffer);
+
+  expect(events).toContain('evict:first:0');
+  cache.deleteSource('second');
+  expect(await cache.get('second', 0, 1)).toBeUndefined();
+  expect(cache.size).toBe(0);
+});
+
+test('RangeRequestCache rejects malformed ranges and short responses', async () => {
+  const cache = new RangeRequestCache();
+  await expect(
+    cache.read({
+      sourceId: 'source',
+      offset: 0,
+      length: 2,
+      fetchRange: async () => new Uint8Array([1]).buffer
+    })
+  ).rejects.toThrow('expected 2');
+  expect(cache.size).toBe(0);
+  expect(() => cache.set('source', -1, new ArrayBuffer(0))).toThrow('non-negative safe integers');
+});

--- a/modules/parquet/src/lib/sources/parquet-range-file.ts
+++ b/modules/parquet/src/lib/sources/parquet-range-file.ts
@@ -140,32 +140,37 @@ export class ParquetRangeFile implements ReadableFile {
       return new ArrayBuffer(0);
     }
 
-    return await this.cache.read({
-      sourceId: getVersionedSourceId(this.url, this.version),
-      offset,
-      length,
-      signal,
-      fetchRange: async (rangeOffset, rangeLength, cacheSignal) =>
-        await this.scheduler.scheduleRequest({
-          sourceId: getVersionedSourceId(this.url, this.version),
-          offset: rangeOffset,
-          length: rangeLength,
-          signal: cacheSignal,
-          fetchRange: async (transportOffset, transportLength, transportSignal) => {
-            const result = await this.fetchExactRange(
-              transportOffset,
-              transportLength,
-              transportSignal,
-              true
-            );
-            return {
-              arrayBuffer: result.arrayBuffer,
-              status: result.response.status,
-              transportBytes: result.arrayBuffer.byteLength
-            };
-          }
-        })
-    });
+    const abortContext = createCombinedAbortSignal(signal, this.closeController.signal);
+    try {
+      return await this.cache.read({
+        sourceId: getVersionedSourceId(this.url, this.version),
+        offset,
+        length,
+        signal: abortContext.signal,
+        fetchRange: async (rangeOffset, rangeLength, cacheSignal) =>
+          await this.scheduler.scheduleRequest({
+            sourceId: getVersionedSourceId(this.url, this.version),
+            offset: rangeOffset,
+            length: rangeLength,
+            signal: cacheSignal,
+            fetchRange: async (transportOffset, transportLength, transportSignal) => {
+              const result = await this.fetchExactRange(
+                transportOffset,
+                transportLength,
+                transportSignal,
+                true
+              );
+              return {
+                arrayBuffer: result.arrayBuffer,
+                status: result.response.status,
+                transportBytes: result.arrayBuffer.byteLength
+              };
+            }
+          })
+      });
+    } finally {
+      abortContext.dispose();
+    }
   }
 
   /** Returns file length information without another HTTP request. */

--- a/modules/parquet/src/lib/sources/parquet-range-file.ts
+++ b/modules/parquet/src/lib/sources/parquet-range-file.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import type {ReadableFile, Stat} from '@loaders.gl/loader-utils';
-import {RangeRequestScheduler} from '@loaders.gl/loader-utils';
+import {RangeRequestCache, RangeRequestScheduler} from '@loaders.gl/loader-utils';
 
 import type {ParquetObjectVersion, ParquetRangeRequestOptions} from '../../parquet-source-types';
 
@@ -47,6 +47,8 @@ type ContentRange = {
   total: number;
 };
 
+const DEFAULT_RANGE_CACHE_BYTES = 65536;
+
 /** Strict HTTP range-backed file with Parquet object-version validation. */
 export class ParquetRangeFile implements ReadableFile {
   /** URL used as the file handle. */
@@ -64,8 +66,8 @@ export class ParquetRangeFile implements ReadableFile {
   private readonly scheduler: RangeRequestScheduler;
   /** Aborts all active requests when the file is closed. */
   private readonly closeController = new AbortController();
-  /** Exact ranges already loaded during initialization. */
-  private readonly cache = new Map<string, ArrayBuffer>();
+  /** Bounded cache for repeated metadata and small range reads. */
+  private readonly cache: RangeRequestCache;
   /** Remote object byte length discovered from `Content-Range`. */
   private fileByteLength = 0;
   /** Object validators captured by the opening range request. */
@@ -80,6 +82,14 @@ export class ParquetRangeFile implements ReadableFile {
     this.fetch = options.fetch;
     this.headers = options.headers;
     this.onTelemetry = options.onTelemetry;
+    this.cache = new RangeRequestCache({
+      maxBytes: DEFAULT_RANGE_CACHE_BYTES,
+      onEvent: event => {
+        if (event.type === 'hit') {
+          this.onTelemetry?.({type: 'cache-hit', cacheHits: 1});
+        }
+      }
+    });
     this.scheduler =
       options.rangeRequests?.scheduler ||
       new RangeRequestScheduler({
@@ -113,7 +123,7 @@ export class ParquetRangeFile implements ReadableFile {
     const result = await this.fetchExactRange(0, 4, signal, false);
     this.fileByteLength = result.contentRange.total;
     this.version = getObjectVersion(result.response.headers);
-    this.cache.set(getRangeKey(0, 4), result.arrayBuffer);
+    this.cache.set(getVersionedSourceId(this.url, this.version), 0, result.arrayBuffer);
     return this;
   }
 
@@ -130,36 +140,32 @@ export class ParquetRangeFile implements ReadableFile {
       return new ArrayBuffer(0);
     }
 
-    const cached = this.cache.get(getRangeKey(offset, length));
-    if (cached) {
-      this.onTelemetry?.({type: 'cache-hit', cacheHits: 1});
-      return cached.slice(0);
-    }
-
-    const abortContext = createCombinedAbortSignal(signal, this.closeController.signal);
-    try {
-      return await this.scheduler.scheduleRequest({
-        sourceId: getVersionedSourceId(this.url, this.version),
-        offset,
-        length,
-        signal: abortContext.signal,
-        fetchRange: async (transportOffset, transportLength, transportSignal) => {
-          const result = await this.fetchExactRange(
-            transportOffset,
-            transportLength,
-            transportSignal,
-            true
-          );
-          return {
-            arrayBuffer: result.arrayBuffer,
-            status: result.response.status,
-            transportBytes: result.arrayBuffer.byteLength
-          };
-        }
-      });
-    } finally {
-      abortContext.dispose();
-    }
+    return await this.cache.read({
+      sourceId: getVersionedSourceId(this.url, this.version),
+      offset,
+      length,
+      signal,
+      fetchRange: async (rangeOffset, rangeLength, cacheSignal) =>
+        await this.scheduler.scheduleRequest({
+          sourceId: getVersionedSourceId(this.url, this.version),
+          offset: rangeOffset,
+          length: rangeLength,
+          signal: cacheSignal,
+          fetchRange: async (transportOffset, transportLength, transportSignal) => {
+            const result = await this.fetchExactRange(
+              transportOffset,
+              transportLength,
+              transportSignal,
+              true
+            );
+            return {
+              arrayBuffer: result.arrayBuffer,
+              status: result.response.status,
+              transportBytes: result.arrayBuffer.byteLength
+            };
+          }
+        })
+    });
   }
 
   /** Returns file length information without another HTTP request. */
@@ -321,11 +327,6 @@ function assertObjectVersion(expected: ParquetObjectVersion, actual: ParquetObje
   ) {
     throw new Error('Parquet object Last-Modified changed while it was being read');
   }
-}
-
-/** Creates a cache key for one exact range. */
-function getRangeKey(offset: number, length: number): string {
-  return `${offset}:${length}`;
 }
 
 /** Creates a scheduler identity that isolates object versions. */

--- a/modules/parquet/test/parquet-source-loader.spec.ts
+++ b/modules/parquet/test/parquet-source-loader.spec.ts
@@ -25,6 +25,7 @@ import {
 import {getSchemaFromParquetReader} from '../src/lib/parsers/get-parquet-schema';
 import {decodeParquetSourceWorkerInput} from '../src/lib/parquet-source-worker-decoder';
 import type {ParquetSourceWorkerInput} from '../src/lib/parquet-source-worker-types';
+import {ParquetRangeFile} from '../src/lib/sources/parquet-range-file';
 import {ParquetReader} from '../src/parquetjs/parser/parquet-reader';
 
 const FIXTURE_URL = '@loaders.gl/parquet/test/data/apache/good/alltypes_plain.parquet';
@@ -616,6 +617,43 @@ test('ParquetSourceLoader#abort and close cancel initialization', async () => {
   await expect(closeRequest).rejects.toThrow(/abort/i);
   await expect(closeSource.getMetadata()).rejects.toThrow(/closed/i);
   });
+
+test('ParquetRangeFile#close cancels oversized uncached reads', async (t) => {
+  const fileByteLength = 100_000;
+  let requestCount = 0;
+  let markReadStarted: () => void = () => {};
+  const readStarted = new Promise<void>(resolve => {
+    markReadStarted = resolve;
+  });
+  const file = new ParquetRangeFile(REMOTE_URL, {
+    fetch: async (_url, options = {}) => {
+      requestCount++;
+      if (requestCount === 1) {
+        return new Response(new Uint8Array(4), {
+          status: 206,
+          headers: {'Content-Range': `bytes 0-3/${fileByteLength}`, ETag: '"fixture-v1"'}
+        });
+      }
+      markReadStarted();
+      return await new Promise<Response>((_resolve, reject) => {
+        const rejectAborted = () => reject(createAbortError());
+        if (options.signal?.aborted) {
+          rejectAborted();
+        } else {
+          options.signal?.addEventListener('abort', rejectAborted, {once: true});
+        }
+      });
+    }
+  });
+
+  await file.open();
+  const read = file.read(4, 70_000);
+  await readStarted;
+  await file.close();
+
+  await t.rejects(read, /abort/i, 'close aborts a read larger than the cache budget');
+  t.end();
+});
 
 /** Loads the shared Parquet fixture into memory for deterministic transport tests. */
 async function loadFixture(url = FIXTURE_URL): Promise<ArrayBuffer> {

--- a/modules/parquet/test/parquet-source-loader.spec.ts
+++ b/modules/parquet/test/parquet-source-loader.spec.ts
@@ -618,7 +618,7 @@ test('ParquetSourceLoader#abort and close cancel initialization', async () => {
   await expect(closeSource.getMetadata()).rejects.toThrow(/closed/i);
   });
 
-test('ParquetRangeFile#close cancels oversized uncached reads', async (t) => {
+test('ParquetRangeFile#close cancels oversized uncached reads', async () => {
   const fileByteLength = 100_000;
   let requestCount = 0;
   let markReadStarted: () => void = () => {};
@@ -651,8 +651,7 @@ test('ParquetRangeFile#close cancels oversized uncached reads', async (t) => {
   await readStarted;
   await file.close();
 
-  await t.rejects(read, /abort/i, 'close aborts a read larger than the cache budget');
-  t.end();
+  await expect(read).rejects.toThrow(/abort/i);
 });
 
 /** Loads the shared Parquet fixture into memory for deterministic transport tests. */

--- a/modules/tiles/src/tileset-3d/format-3d-tiles/tiles-3d-source.ts
+++ b/modules/tiles/src/tileset-3d/format-3d-tiles/tiles-3d-source.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {path} from '@loaders.gl/loader-utils';
+import {path, RequestCache} from '@loaders.gl/loader-utils';
 import {Ellipsoid} from '@math.gl/geospatial';
 import {Vector3} from '@math.gl/core';
 import type {CoreAPI, LoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';
@@ -92,12 +92,8 @@ export class Tiles3DSource implements Tileset3DSource {
   private readonly queryParams: Record<string, string> = {};
   /** Final request URLs cached by unmodified tile content URL. */
   private readonly tileUrlCache: Map<string, string> = new Map();
-  /** Parsed subtree promises keyed by final source URL for request deduplication and LRU reuse. */
-  private readonly implicitSubtreeCache: Map<string, Promise<ParsedImplicitSubtree>> = new Map();
-  /** URLs whose subtree resource requests have not settled. */
-  private readonly pendingImplicitSubtreeUrls: Set<string> = new Set();
-  /** Maximum number of settled parsed subtrees retained by this source. */
-  private readonly maximumCachedSubtrees: number;
+  /** Parsed subtree requests keyed by final source URL for deduplication and LRU reuse. */
+  private readonly implicitSubtreeCache: RequestCache<ParsedImplicitSubtree>;
   /** Mutable counters exposed as a defensive snapshot through {@link getImplicitTilingStats}. */
   private readonly implicitTilingStats: Omit<
     ImplicitTilingStats,
@@ -132,9 +128,10 @@ export class Tiles3DSource implements Tileset3DSource {
     const maximumCachedSubtrees = Number(
       (loadOptions['3d-tiles'] as Record<string, unknown> | undefined)?.maximumCachedSubtrees
     );
-    this.maximumCachedSubtrees = Number.isFinite(maximumCachedSubtrees)
+    const maximumCacheEntries = Number.isFinite(maximumCachedSubtrees)
       ? Math.max(0, Math.floor(maximumCachedSubtrees))
       : DEFAULT_MAXIMUM_CACHED_SUBTREES;
+    this.implicitSubtreeCache = new RequestCache({maxEntries: maximumCacheEntries});
   }
 
   /**
@@ -147,7 +144,6 @@ export class Tiles3DSource implements Tileset3DSource {
     this.destroyed = true;
     this.tileUrlCache.clear();
     this.implicitSubtreeCache.clear();
-    this.pendingImplicitSubtreeUrls.clear();
   }
 
   /**
@@ -356,8 +352,8 @@ export class Tiles3DSource implements Tileset3DSource {
   getImplicitTilingStats(): ImplicitTilingStats {
     return {
       ...this.implicitTilingStats,
-      cachedSubtrees: this.implicitSubtreeCache.size - this.pendingImplicitSubtreeUrls.size,
-      pendingSubtrees: this.pendingImplicitSubtreeUrls.size
+      cachedSubtrees: this.implicitSubtreeCache.size - this.implicitSubtreeCache.pendingSize,
+      pendingSubtrees: this.implicitSubtreeCache.pendingSize
     };
   }
 
@@ -534,33 +530,21 @@ export class Tiles3DSource implements Tileset3DSource {
     const cachedSubtree = this.implicitSubtreeCache.get(subtreeUrl);
     if (cachedSubtree) {
       this.implicitTilingStats.cacheHits++;
-      this.implicitSubtreeCache.delete(subtreeUrl);
-      this.implicitSubtreeCache.set(subtreeUrl, cachedSubtree);
       return await cachedSubtree;
     }
 
     this.implicitTilingStats.requestedSubtrees++;
-    this.pendingImplicitSubtreeUrls.add(subtreeUrl);
     const loaderOptions = (this.loadOptions[this.loader.id] as Record<string, unknown>) || {};
-    const subtreePromise = this.loadResourceData(subtreeUrl, {
-      ...this.loadOptions,
-      [this.loader.id]: {
-        ...loaderOptions,
-        isTileset: false,
-        isSubtree: true
-      }
-    }) as Promise<ParsedImplicitSubtree>;
-    this.implicitSubtreeCache.set(subtreeUrl, subtreePromise);
-
-    try {
-      return await subtreePromise;
-    } catch (error) {
-      this.implicitSubtreeCache.delete(subtreeUrl);
-      throw error;
-    } finally {
-      this.pendingImplicitSubtreeUrls.delete(subtreeUrl);
-      this.trimImplicitSubtreeCache();
-    }
+    return await this.implicitSubtreeCache.getOrLoad(subtreeUrl, async () => {
+      return (await this.loadResourceData(subtreeUrl, {
+        ...this.loadOptions,
+        [this.loader.id]: {
+          ...loaderOptions,
+          isTileset: false,
+          isSubtree: true
+        }
+      })) as ParsedImplicitSubtree;
+    });
   }
 
   /**
@@ -594,21 +578,6 @@ export class Tiles3DSource implements Tileset3DSource {
       }
     }
     return materializedTileCount;
-  }
-
-  /** Evicts least-recently-used settled subtree entries until the configured bound is met. */
-  private trimImplicitSubtreeCache(): void {
-    if (this.implicitSubtreeCache.size <= this.maximumCachedSubtrees) {
-      return;
-    }
-    for (const subtreeUrl of this.implicitSubtreeCache.keys()) {
-      if (!this.pendingImplicitSubtreeUrls.has(subtreeUrl)) {
-        this.implicitSubtreeCache.delete(subtreeUrl);
-      }
-      if (this.implicitSubtreeCache.size <= this.maximumCachedSubtrees) {
-        break;
-      }
-    }
   }
 }
 


### PR DESCRIPTION
## Goals

- Establish one reusable cache layer for asynchronous requests and byte ranges.
- Align range-based formats with the insertion-order LRU semantics already used by tile caches.
- Keep request scheduling, byte caching, and visibility-aware tile eviction as separate responsibilities.

## Changes

- Add `RequestCache` with entry/byte limits, in-flight deduplication, caller-isolated aborts, retry after failure, and removal hooks.
- Add `RangeRequestCache` with exact and contained range hits, immutable slices, versioned source identities, byte-budget eviction, telemetry, and oversized-range bypass.
- Migrate the 3D Tiles implicit subtree cache, COPC metadata prefix cache, and Parquet initialization/small-range cache to the shared implementations.
- Keep frame-aware tile content caches and PMTiles semantic caches specialized rather than layering competing policies over them.
- Document both cache APIs and their relationship to `RangeRequestScheduler` and specialized tile caches.
- Add focused coverage for LRU behavior, byte limits, pending requests, aborts, retries, immutable range reads, source isolation, and eviction.

## Validation

- `yarn build`
- `yarn test-node` (361 passed)
- `yarn test-headless` (2,936 passed)
- `yarn test-audit` (0 violations)
- `website/yarn build`
