### PR TITLE
feat(services): add ArcGIS capability graph

### DIFF
--- a/docs/modules/i3s/formats/i3s.md
+++ b/docs/modules/i3s/formats/i3s.md
@@ -163,9 +163,9 @@ path.
 | Metadata schema validation | **Partial** | **v5.0** | Zod and generated JSON schemas cover mesh scene-layer and node-page structures with forward-compatible passthrough fields; this is not full I3S conformance validation. |
 | Native Point or Point Cloud authoring | **Not supported** | — | The converter shares the mesh profile limits of the loaders. |
 
-## I3S supremacy roadmap
+## I3S roadmap
 
-The matrix turns “I3S supremacy” into measurable tranches. Tranches 0 and 1 are implemented in the
+The matrix turns I3S priorities into measurable tranches. Tranches 0 and 1 are implemented in the
 current v5.0 development line; the remaining tranches close the largest unsupported or partial rows:
 
 | Tranche | Outcome | Status |

--- a/docs/modules/services/README.md
+++ b/docs/modules/services/README.md
@@ -10,3 +10,20 @@ such as WMS, WMTS, WFS, GML, and CSW remain in [`@loaders.gl/wms`](/docs/modules
 ```bash
 npm install @loaders.gl/services @loaders.gl/core
 ```
+
+## Capability discovery
+
+For applications that need to choose among services, the module can discover an ArcGIS REST
+directory and normalize the advertised service family, formats, and coordinate systems. The
+capability graph is intentionally separate from source loading, so direct source construction
+remains the simplest path when the endpoint is already known.
+
+```ts
+import {discoverArcGISCapabilities, selectArcGISService} from '@loaders.gl/services';
+
+const graph = await discoverArcGISCapabilities('https://example.com/arcgis/rest/services');
+const imagery = graph && selectArcGISService(graph, {kind: 'image', format: 'lerc'});
+```
+
+Discovery performs one metadata request per discovered service. Pass a custom `fetch` function when
+using authentication, a proxy, or a test transport.

--- a/docs/modules/services/README.md
+++ b/docs/modules/services/README.md
@@ -14,7 +14,7 @@ npm install @loaders.gl/services @loaders.gl/core
 ## Capability discovery
 
 For applications that need to choose among services, the module can discover an ArcGIS REST
-directory and normalize the advertised service family, formats, and coordinate systems. The
+ directory and normalize the shared service capability contract: service family, formats, and coordinate systems. The
 capability graph is intentionally separate from source loading, so direct source construction
 remains the simplest path when the endpoint is already known.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -46,3 +46,28 @@ While no loader support has been removed, the flavor of the loaders.gl framework
 
 - The `shape` option that was introduced in loaders.gl v3 to allow loaders to return different data formats is now deprecated and will be removed in many places.
 - Instead, applications can use utilities in the `@loaders.gl/schema-utils` and `@loaders.gl/gis` modules to convert for Apache Arrow and Apache GeoArrow to more traditional (but less efficient) JavaScript formats.
+
+## Geospatial service supremacy roadmap
+
+The service roadmap favors protocol depth and useful normalized outputs over a large universal
+abstraction. Costs are relative engineering estimates; impact describes the user-facing result.
+
+| Tranche | Scope | Status | Cost | Impact |
+| --- | --- | --- | --- | --- |
+| 1 | Dedicated `@loaders.gl/services` module and ArcGIS source ownership | Complete | M | Clear package boundary for ArcGIS, Cesium ION, and future providers |
+| 2 | ArcGIS FeatureServer vector source and normalized Arrow/GeoJSON output | Complete | M | Production vector-service ingestion |
+| 3 | ArcGIS ImageServer imagery and analytical LERC output | Complete | M | Analysis-ready raster services |
+| 4 | ArcGIS MapServer and VectorTileServer tile sources | Complete | M | Cached, dynamic, and vector tile access |
+| 5 | WFS request normalization and GeoJSON/GML response handling | Complete | M | Reliable OGC feature-service access |
+| 6 | High-volume SAX GML parsing and streaming WFS batches | Complete | L | Large WFS responses without whole-document buffering |
+| 7 | WMTS matrix sets and ArcGIS tile-grid negotiation | Planned | L | Correct tile requests across heterogeneous grids |
+| 8 | CRS normalization, axis order, reprojection-aware requests, and edge cases | Planned | XL | Correct behavior across projections, antimeridian, and polar regions |
+| 9 | Shared service lifecycle for retries, cancellation, caching, auth, and telemetry | Planned | XL | Consistent operational behavior without protocol-specific duplication |
+| 10 | Deep GML/WFS conformance, paging, filtering, schema-aware properties, and fixtures | In progress | XL | Production-scale standards interoperability |
+| 11 | Capability-driven source configuration and endpoint negotiation | Planned | L | Better defaults when applications provide incomplete service information |
+| 12 | Analytical raster preservation: NoData, bands, statistics, and rendering rules | Complete | L | Faithful scientific imagery workflows |
+| 13 | ArcGIS capability graph and requirement-based service selection | Assumed complete | M | Discover, compare, and select service endpoints explicitly |
+
+The next high-leverage work is tranches 7–11. Tranche 9 remains deliberately deferred until the
+protocol-specific sources demonstrate a concrete shared lifecycle need; it should not become a
+second opaque framework layered over `DataSource`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -47,7 +47,7 @@ While no loader support has been removed, the flavor of the loaders.gl framework
 - The `shape` option that was introduced in loaders.gl v3 to allow loaders to return different data formats is now deprecated and will be removed in many places.
 - Instead, applications can use utilities in the `@loaders.gl/schema-utils` and `@loaders.gl/gis` modules to convert for Apache Arrow and Apache GeoArrow to more traditional (but less efficient) JavaScript formats.
 
-## Geospatial service supremacy roadmap
+## Geospatial service roadmap
 
 The service roadmap favors protocol depth and useful normalized outputs over a large universal
 abstraction. Costs are relative engineering estimates; impact describes the user-facing result.

--- a/modules/loader-utils/src/index.ts
+++ b/modules/loader-utils/src/index.ts
@@ -342,6 +342,7 @@ export type {
 } from './lib/scan-utils/table-query-explain';
 
 export type {CatalogSource, CatalogSourceCapabilities} from './lib/sources/catalog-source';
+export type {GeoServiceType, ServiceCapabilities} from './lib/sources/service-capabilities';
 
 export {ImageSource} from './lib/sources/image-source';
 export type {ImageType} from './lib/sources/utils/image-type';

--- a/modules/loader-utils/src/lib/sources/service-capabilities.ts
+++ b/modules/loader-utils/src/lib/sources/service-capabilities.ts
@@ -1,0 +1,38 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** Protocol-neutral service families understood by geospatial service sources. */
+export type GeoServiceType =
+  | 'wms'
+  | 'wmts'
+  | 'wfs'
+  | 'csw'
+  | 'arcgis-map-server'
+  | 'arcgis-image-server'
+  | 'arcgis-feature-server'
+  | 'unknown';
+
+/** A normalized description of a discoverable geospatial service. */
+export type ServiceCapabilities = {
+  /** Stable service URL. */
+  url?: string;
+  /** Protocol or vendor service family. */
+  type: GeoServiceType;
+  /** Machine-readable service identifier. */
+  name: string;
+  /** Human-readable service title. */
+  title?: string;
+  /** Service description. */
+  abstract?: string;
+  /** Supported coordinate reference systems. */
+  crs: string[];
+  /** Advertised response formats. */
+  formats: string[];
+  /** Named layers or feature types. */
+  layers: Array<{name: string; title?: string; crs?: string[]; bounds?: number[]}>;
+  /** Supported request names, when advertised. */
+  operations: string[];
+  /** Original protocol-specific capability document. */
+  formatSpecificMetadata?: Record<string, unknown>;
+};

--- a/modules/services/src/arcgis/arcgis-capability-graph.ts
+++ b/modules/services/src/arcgis/arcgis-capability-graph.ts
@@ -102,7 +102,7 @@ function normalizeServiceCapabilities(
 ): ArcGISServiceCapabilities {
   const serviceType = service.type;
   const kind = getServiceKind(serviceType);
-  const formats = getServiceFormats(kind, metadata);
+  const formats = getServiceFormats(metadata);
   const crs = getServiceCrs(metadata);
   return {
     ...service,
@@ -123,10 +123,7 @@ function getServiceKind(serviceType: string): ArcGISServiceCapabilities['kind'] 
 }
 
 /** Extracts and canonicalizes formats advertised by an ArcGIS service. */
-function getServiceFormats(
-  kind: ArcGISServiceCapabilities['kind'],
-  metadata: Record<string, unknown>
-): string[] {
+function getServiceFormats(metadata: Record<string, unknown>): string[] {
   const formats = new Set<string>();
   const supportedFormats = metadata.supportedQueryFormats;
   if (typeof supportedFormats === 'string') {
@@ -138,7 +135,6 @@ function getServiceFormats(
   }
   const tileInfo = metadata.tileInfo as {format?: string} | undefined;
   if (typeof tileInfo?.format === 'string') formats.add(tileInfo.format.toLowerCase());
-  if (kind === 'vector') formats.add('geojson');
   return [...formats].sort();
 }
 

--- a/modules/services/src/arcgis/arcgis-capability-graph.ts
+++ b/modules/services/src/arcgis/arcgis-capability-graph.ts
@@ -1,0 +1,155 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {getArcGISServices} from './arcgis-server';
+import type {Service as ArcGISService} from './arcgis-server';
+
+/** Normalized capabilities discovered from one ArcGIS REST service. */
+export type ArcGISServiceCapabilities = ArcGISService & {
+  /** Stable identifier for the discovered service. */
+  id: string;
+  /** Broad service family used for selection. */
+  kind: 'vector' | 'image' | 'tile' | 'unknown';
+  /** Response or source formats advertised by the service. */
+  formats: string[];
+  /** WKID-based coordinate systems advertised by the service. */
+  crs: string[];
+  /** Raw service metadata for provider-specific consumers. */
+  metadata: Record<string, unknown>;
+};
+
+/** A normalized graph of services discovered below an ArcGIS REST directory. */
+export type ArcGISCapabilityGraph = {
+  /** URL used as the discovery root. */
+  rootUrl: string;
+  /** Services discovered below the root, including normalized capabilities. */
+  nodes: ArcGISServiceCapabilities[];
+};
+
+/** Requirements used to select the best matching service node. */
+export type ArcGISServiceSelection = {
+  /** Preferred service family. */
+  kind?: ArcGISServiceCapabilities['kind'];
+  /** Required response or source format. */
+  format?: string;
+  /** Preferred coordinate system. */
+  crs?: string;
+};
+
+/** Options controlling ArcGIS capability discovery. */
+export type ArcGISCapabilityGraphOptions = {
+  /** Optional fetch implementation for hermetic tests and custom transports. */
+  fetch?: typeof fetch;
+};
+
+/**
+ * Discovers an ArcGIS REST directory and normalizes the capabilities of each service.
+ *
+ * Capability requests are explicit and independent from source loading. Applications that
+ * already know the endpoint can continue using the source classes directly.
+ */
+export async function discoverArcGISCapabilities(
+  url: string,
+  options: ArcGISCapabilityGraphOptions = {}
+): Promise<ArcGISCapabilityGraph | null> {
+  const fetchFile = options.fetch || fetch;
+  const services = await getArcGISServices(url, fetchFile);
+  if (!services) return null;
+
+  const nodes = await Promise.all(
+    services.map(async service => {
+      const metadata = await fetchServiceMetadata(service.url, fetchFile);
+      return normalizeServiceCapabilities(service, metadata);
+    })
+  );
+
+  return {rootUrl: url, nodes};
+}
+
+/** Selects the first service satisfying all supplied requirements. */
+export function selectArcGISService(
+  graph: ArcGISCapabilityGraph,
+  requirements: ArcGISServiceSelection = {}
+): ArcGISServiceCapabilities | undefined {
+  return graph.nodes.find(node => {
+    if (requirements.kind && node.kind !== requirements.kind) return false;
+    if (requirements.format && !node.formats.includes(requirements.format.toLowerCase()))
+      return false;
+    if (requirements.crs && !node.crs.includes(requirements.crs)) return false;
+    return true;
+  });
+}
+
+/** Fetches one service's provider-specific metadata document. */
+async function fetchServiceMetadata(
+  serviceUrl: string,
+  fetchFile: typeof fetch
+): Promise<Record<string, unknown>> {
+  const url = new URL(serviceUrl);
+  url.searchParams.set('f', 'pjson');
+  const response = await fetchFile(url.toString());
+  if (!response.ok) {
+    throw new Error(`ArcGIS service metadata request failed: ${response.status}`);
+  }
+  return (await response.json()) as Record<string, unknown>;
+}
+
+/** Combines directory information and metadata into a normalized capability node. */
+function normalizeServiceCapabilities(
+  service: ArcGISService,
+  metadata: Record<string, unknown>
+): ArcGISServiceCapabilities {
+  const serviceType = service.type;
+  const kind = getServiceKind(serviceType);
+  const formats = getServiceFormats(kind, metadata);
+  const crs = getServiceCrs(metadata);
+  return {
+    ...service,
+    id: service.url,
+    kind,
+    formats,
+    crs,
+    metadata
+  };
+}
+
+/** Maps an ArcGIS service type to the generic source family. */
+function getServiceKind(serviceType: string): ArcGISServiceCapabilities['kind'] {
+  if (serviceType.includes('feature')) return 'vector';
+  if (serviceType.includes('image')) return 'image';
+  if (serviceType.includes('map') || serviceType.includes('vector-tile')) return 'tile';
+  return 'unknown';
+}
+
+/** Extracts and canonicalizes formats advertised by an ArcGIS service. */
+function getServiceFormats(
+  kind: ArcGISServiceCapabilities['kind'],
+  metadata: Record<string, unknown>
+): string[] {
+  const formats = new Set<string>();
+  const supportedFormats = metadata.supportedQueryFormats;
+  if (typeof supportedFormats === 'string') {
+    for (const format of supportedFormats.split(',')) formats.add(format.trim().toLowerCase());
+  }
+  const imageFormats = metadata.supportedImageFormatTypes;
+  if (typeof imageFormats === 'string') {
+    for (const format of imageFormats.split(',')) formats.add(format.trim().toLowerCase());
+  }
+  const tileInfo = metadata.tileInfo as {format?: string} | undefined;
+  if (typeof tileInfo?.format === 'string') formats.add(tileInfo.format.toLowerCase());
+  if (kind === 'vector') formats.add('geojson');
+  return [...formats].sort();
+}
+
+/** Extracts unique EPSG identifiers from common ArcGIS metadata locations. */
+function getServiceCrs(metadata: Record<string, unknown>): string[] {
+  const spatialReferences = new Set<string>();
+  for (const value of [metadata.spatialReference, (metadata.fullExtent as any)?.spatialReference]) {
+    const spatialReference = value as {wkid?: number; latestWkid?: number} | undefined;
+    for (const wkid of [spatialReference?.wkid, spatialReference?.latestWkid]) {
+      if (wkid) spatialReferences.add(`EPSG:${wkid}`);
+    }
+  }
+  return [...spatialReferences].sort();
+}

--- a/modules/services/src/arcgis/arcgis-capability-graph.ts
+++ b/modules/services/src/arcgis/arcgis-capability-graph.ts
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {getArcGISServices} from './arcgis-server';
+import type {ServiceCapabilities} from '@loaders.gl/loader-utils';
 import type {Service as ArcGISService} from './arcgis-server';
 
 /** Normalized capabilities discovered from one ArcGIS REST service. */
@@ -11,10 +12,8 @@ export type ArcGISServiceCapabilities = ArcGISService & {
   id: string;
   /** Broad service family used for selection. */
   kind: 'vector' | 'image' | 'tile' | 'unknown';
-  /** Response or source formats advertised by the service. */
-  formats: string[];
-  /** WKID-based coordinate systems advertised by the service. */
-  crs: string[];
+  /** Shared normalized service capability contract. */
+  capabilities: ServiceCapabilities;
   /** Raw service metadata for provider-specific consumers. */
   metadata: Record<string, unknown>;
 };
@@ -74,9 +73,12 @@ export function selectArcGISService(
 ): ArcGISServiceCapabilities | undefined {
   return graph.nodes.find(node => {
     if (requirements.kind && node.kind !== requirements.kind) return false;
-    if (requirements.format && !node.formats.includes(requirements.format.toLowerCase()))
+    if (
+      requirements.format &&
+      !node.capabilities.formats.includes(requirements.format.toLowerCase())
+    )
       return false;
-    if (requirements.crs && !node.crs.includes(requirements.crs)) return false;
+    if (requirements.crs && !node.capabilities.crs.includes(requirements.crs)) return false;
     return true;
   });
 }
@@ -104,14 +106,35 @@ function normalizeServiceCapabilities(
   const kind = getServiceKind(serviceType);
   const formats = getServiceFormats(metadata);
   const crs = getServiceCrs(metadata);
+  const capabilities: ServiceCapabilities = {
+    url: service.url,
+    type: getServiceCapabilityType(kind),
+    name: service.name,
+    title: typeof metadata.name === 'string' ? metadata.name : undefined,
+    abstract: typeof metadata.description === 'string' ? metadata.description : undefined,
+    crs,
+    formats,
+    layers: [],
+    operations: [],
+    formatSpecificMetadata: metadata
+  };
   return {
     ...service,
     id: service.url,
     kind,
-    formats,
-    crs,
+    capabilities,
     metadata
   };
+}
+
+/** Maps a discovered ArcGIS family to the shared service capability type. */
+function getServiceCapabilityType(
+  kind: ArcGISServiceCapabilities['kind']
+): ServiceCapabilities['type'] {
+  if (kind === 'vector') return 'arcgis-feature-server';
+  if (kind === 'image') return 'arcgis-image-server';
+  if (kind === 'tile') return 'arcgis-map-server';
+  return 'unknown';
 }
 
 /** Maps an ArcGIS service type to the generic source family. */

--- a/modules/services/src/arcgis/arcgis-server.ts
+++ b/modules/services/src/arcgis/arcgis-server.ts
@@ -33,7 +33,7 @@ async function loadServiceDirectory(
   const response = await fetch(`${serviceUrl}?f=pjson`);
   const directory = await response.json();
 
-  const services = extractServices(directory, serviceUrl);
+  const services = extractServices(directory, serviceUrl, serverUrl);
 
   const folders = (directory.folders || []) as string[];
   const promises = folders.map(folder =>
@@ -47,14 +47,14 @@ async function loadServiceDirectory(
   return services;
 }
 
-function extractServices(directory: unknown, url: string): Service[] {
+function extractServices(directory: unknown, url: string, serverUrl: string): Service[] {
   const arcgisServices = ((directory as any).services || []) as {name: string; type: string}[];
   const services: Service[] = [];
   for (const service of arcgisServices) {
     services.push({
       name: service.name,
       type: `arcgis-${service.type.toLocaleLowerCase().replace('server', '-server')}`,
-      url: `${url}/${service.name}/${service.type}`
+      url: `${service.name.includes('/') ? serverUrl : url}/${service.name}/${service.type}`
     });
   }
   return services;

--- a/modules/services/src/index.ts
+++ b/modules/services/src/index.ts
@@ -7,6 +7,16 @@
  */
 export {getArcGISServices} from './arcgis/arcgis-server';
 export type {Service as ArcGISService} from './arcgis/arcgis-server';
+export {
+  discoverArcGISCapabilities,
+  selectArcGISService
+} from './arcgis/arcgis-capability-graph';
+export type {
+  ArcGISCapabilityGraph,
+  ArcGISCapabilityGraphOptions,
+  ArcGISServiceCapabilities,
+  ArcGISServiceSelection
+} from './arcgis/arcgis-capability-graph';
 
 /** ArcGIS FeatureServer source and loader. */
 export {

--- a/modules/services/test/services-module.spec.ts
+++ b/modules/services/test/services-module.spec.ts
@@ -110,8 +110,10 @@ describe('@loaders.gl/services', () => {
 
     expect(graph?.nodes[0]).toMatchObject({
       kind: 'image',
-      formats: ['jpeg', 'lerc', 'png'],
-      crs: ['EPSG:3857']
+      capabilities: {
+        formats: ['jpeg', 'lerc', 'png'],
+        crs: ['EPSG:3857']
+      }
     });
     expect(selectArcGISService(graph!, {kind: 'image', format: 'lerc'})?.name).toBe('Imagery');
     expect(selectArcGISService(graph!, {kind: 'vector'})).toBeUndefined();
@@ -129,7 +131,7 @@ describe('@loaders.gl/services', () => {
         )
     });
 
-    expect(graph?.nodes[0].formats).toEqual(['json']);
+    expect(graph?.nodes[0].capabilities.formats).toEqual(['json']);
     expect(selectArcGISService(graph!, {format: 'geojson'})).toBeUndefined();
   });
 });

--- a/modules/services/test/services-module.spec.ts
+++ b/modules/services/test/services-module.spec.ts
@@ -76,6 +76,22 @@ describe('@loaders.gl/services', () => {
     expect(await getArcGISServices('https://example.com/not-an-arcgis-service')).toBeNull();
   });
 
+  test('resolves qualified service names from ArcGIS folder directories', async () => {
+    const services = await getArcGISServices(
+      'https://example.com/arcgis/rest/services',
+      async url =>
+        new Response(
+          JSON.stringify(
+            url.endsWith('/services?f=pjson')
+              ? {folders: ['AGP']}
+              : {services: [{name: 'AGP/Census', type: 'MapServer'}]}
+          )
+        )
+    );
+
+    expect(services?.[0].url).toBe('https://example.com/arcgis/rest/services/AGP/Census/MapServer');
+  });
+
   test('normalizes and selects ArcGIS service capabilities', async () => {
     const graph = await discoverArcGISCapabilities('https://example.com/arcgis/rest/services', {
       fetch: async url => {
@@ -99,5 +115,21 @@ describe('@loaders.gl/services', () => {
     });
     expect(selectArcGISService(graph!, {kind: 'image', format: 'lerc'})?.name).toBe('Imagery');
     expect(selectArcGISService(graph!, {kind: 'vector'})).toBeUndefined();
+  });
+
+  test('does not infer unsupported GeoJSON output', async () => {
+    const graph = await discoverArcGISCapabilities('https://example.com/arcgis/rest/services', {
+      fetch: async url =>
+        new Response(
+          JSON.stringify(
+            url.endsWith('/services?f=pjson')
+              ? {services: [{name: 'Legacy', type: 'FeatureServer'}]}
+              : {supportedQueryFormats: 'JSON'}
+          )
+        )
+    });
+
+    expect(graph?.nodes[0].formats).toEqual(['json']);
+    expect(selectArcGISService(graph!, {format: 'geojson'})).toBeUndefined();
   });
 });

--- a/modules/services/test/services-module.spec.ts
+++ b/modules/services/test/services-module.spec.ts
@@ -4,7 +4,9 @@ import {
   ArcGISImageTileSourceLoader,
   ArcGISMapTileSourceLoader,
   ArcGISVectorTileServerSourceLoader,
-  getServiceLoader
+  discoverArcGISCapabilities,
+  getServiceLoader,
+  selectArcGISService
 } from '../src/index';
 import {getArcGISServices} from '../src/arcgis/arcgis-server';
 import * as bundledServices from '../src/bundled';
@@ -72,5 +74,30 @@ describe('@loaders.gl/services', () => {
     ]);
     expect(requests).toHaveLength(2);
     expect(await getArcGISServices('https://example.com/not-an-arcgis-service')).toBeNull();
+  });
+
+  test('normalizes and selects ArcGIS service capabilities', async () => {
+    const graph = await discoverArcGISCapabilities('https://example.com/arcgis/rest/services', {
+      fetch: async url => {
+        if (url.endsWith('/services?f=pjson')) {
+          return new Response(JSON.stringify({services: [{name: 'Imagery', type: 'ImageServer'}]}));
+        }
+        return new Response(
+          JSON.stringify({
+            supportedImageFormatTypes: 'PNG,JPEG,LERC',
+            spatialReference: {wkid: 3857},
+            fullExtent: {spatialReference: {latestWkid: 3857}}
+          })
+        );
+      }
+    });
+
+    expect(graph?.nodes[0]).toMatchObject({
+      kind: 'image',
+      formats: ['jpeg', 'lerc', 'png'],
+      crs: ['EPSG:3857']
+    });
+    expect(selectArcGISService(graph!, {kind: 'image', format: 'lerc'})?.name).toBe('Imagery');
+    expect(selectArcGISService(graph!, {kind: 'vector'})).toBeUndefined();
   });
 });

--- a/modules/wms/src/service-capabilities.ts
+++ b/modules/wms/src/service-capabilities.ts
@@ -3,44 +3,12 @@
 // Copyright (c) vis.gl contributors
 
 import type {TileSourceMetadata, VectorSourceMetadata} from '@loaders.gl/loader-utils';
+import type {GeoServiceType, ServiceCapabilities} from '@loaders.gl/loader-utils';
 import type {WMSCapabilities} from './lib/parsers/wms/parse-wms-capabilities';
 import type {WMTSCapabilities} from './lib/parsers/wmts/parse-wmts-capabilities';
 import type {WFSCapabilities} from './lib/parsers/wfs/parse-wfs-capabilities';
 
-/** Protocol-neutral service families understood by the geospatial service loaders. */
-export type GeoServiceType =
-  | 'wms'
-  | 'wmts'
-  | 'wfs'
-  | 'csw'
-  | 'arcgis-map-server'
-  | 'arcgis-image-server'
-  | 'arcgis-feature-server'
-  | 'unknown';
-
-/** A normalized description of a discoverable geospatial service. */
-export type ServiceCapabilities = {
-  /** Stable service URL. */
-  url?: string;
-  /** Protocol or vendor service family. */
-  type: GeoServiceType;
-  /** Machine-readable service identifier. */
-  name: string;
-  /** Human-readable service title. */
-  title?: string;
-  /** Service description. */
-  abstract?: string;
-  /** Supported coordinate reference systems. */
-  crs: string[];
-  /** Advertised response formats. */
-  formats: string[];
-  /** Named layers or feature types. */
-  layers: Array<{name: string; title?: string; crs?: string[]; bounds?: number[]}>;
-  /** Supported request names, when advertised. */
-  operations: string[];
-  /** Original protocol-specific capability document. */
-  formatSpecificMetadata?: Record<string, unknown>;
-};
+export type {GeoServiceType, ServiceCapabilities} from '@loaders.gl/loader-utils';
 
 /** Normalizes WMS capabilities into the shared service contract. */
 export function normalizeWMSCapabilities(


### PR DESCRIPTION
## Goals

- Add explicit capability discovery for ArcGIS REST service directories.
- Make endpoint selection possible without introducing a second opaque service runtime.
- Document the next service-supremacy roadmap tranche and its boundaries.

## Changes

- Add `discoverArcGISCapabilities` to discover directory services and fetch per-service metadata.
- Normalize ArcGIS service kind, advertised formats, CRS identifiers, and raw metadata.
- Add `selectArcGISService` for requirement-based endpoint selection.
- Export the capability graph types and APIs from `@loaders.gl/services`.
- Add hermetic discovery/selection tests, including recursive directories.
- Update the services docs and roadmap tranche table.

## Validation

- `yarn lint fix`
- `yarn test-headless modules/services/test/services-module.spec.ts`
- `yarn test-audit`
- `yarn build`
