### PR TITLE
feat(i3s): add legacy mesh parity support

### DIFF
--- a/docs/modules/i3s/formats/i3s.md
+++ b/docs/modules/i3s/formats/i3s.md
@@ -50,10 +50,10 @@ those versions.
 
 | Generation | Status | Since | Notes |
 | --- | :---: | :---: | --- |
-| I3S 1.6 mesh resources | **Partial** | v2.0 | Legacy `/nodes/{id}` hierarchies and uncompressed `defaultGeometrySchema` buffers are supported. Legacy `sharedResource` material interpretation and mesh-segmentation data are gaps. |
+| I3S 1.6 mesh resources | **Partial** | v2.0 | Legacy `/nodes/{id}` hierarchies and uncompressed `defaultGeometrySchema` buffers are supported. Shared-resource materials are normalized from the first legacy definition, and appended mesh-segmentation payloads are retained but not decoded into draw segments. |
 | I3S 1.7 mesh resources | **Supported** | v2.3 | Node pages, OBBs, and geometry definitions arrived in v2.3; Draco geometry, material definitions, and texture-set selection followed in v3.0. |
 | I3S 1.8 mesh additions | **Supported** | v3.1 | KTX2/Basis textures and PBR material fields used by the rendering path are supported, subject to the material limitations below. |
-| I3S 1.9-1.10 mesh documents | **Partial** | **v5.0** | Forward fields are preserved by v5.0 metadata schemas and the established mesh resource layouts are consumed. There is no dedicated 1.9/1.10 conformance fixture suite, and newer semantics are supported only where listed in this matrix. |
+| I3S 1.9-1.10 mesh documents | **Partial** | **v5.0** | Forward fields are preserved by v5.0 metadata schemas, dedicated 1.9/1.10 fixtures cover the scene-layer envelope, and established mesh resource layouts are consumed. Newer semantics remain bounded by the feature rows below. |
 | I3S 2.0-2.1 Point Cloud | **Not supported** | — | The Point Cloud profile is outside the current mesh-oriented implementation. |
 
 ### Delivery and resource access
@@ -102,7 +102,7 @@ those versions.
 | Feature IDs | **Supported** | v3.0 | Expands uncompressed face ranges and Draco feature-index metadata into per-vertex feature IDs. |
 | Mesh indices | **Supported** | v3.0 | Draco indices are preserved; uncompressed I3S face order is represented by the expanded vertex stream. |
 | Multiple UV sets | **Not supported** | — | Only the primary UV set is exposed. |
-| Legacy mesh segmentation | **Not supported** | — | Segment information appended to legacy geometry buffers is not parsed. |
+| Legacy mesh segmentation | **Partial** | **v5.0** | Bytes appended after schema-defined legacy geometry attributes are retained as `meshSegmentation`; the service-specific segment record is not yet decoded into renderer draw ranges. |
 | 64-bit geometry attributes | **Partial** | **v5.0** | UInt64 values are returned in a `Float64Array` and preserved exactly through `Number.MAX_SAFE_INTEGER`; larger values cannot be represented exactly. Signed 64-bit geometry attributes are not decoded. |
 
 ### Textures and materials
@@ -172,7 +172,7 @@ current v5.0 development line; the remaining tranches close the largest unsuppor
 | --- | --- | :---: |
 | 0. Conformance foundation | Freeze the matrix, keep representative 1.6–1.10 fixtures, and run automated support-status checks. | **Complete** |
 | 1. Correctness hardening | Make root authentication, node metadata passthrough, UInt64 precision, and WebScene CRS validation match the documented boundaries. | **Complete** |
-| 2. 1.10 mesh parity | Add legacy shared-resource and mesh-segmentation support, then expand 1.9/1.10 conformance fixtures. | Planned |
+| 2. 1.10 mesh parity | Add legacy shared-resource material interpretation and mesh-segmentation preservation, then expand 1.9/1.10 conformance fixtures. | **Complete** |
 | 3. Material fidelity | Load complete PBR texture sets, multiple atlases/UV sets, and sampler wrap semantics. | Planned |
 | 4. Feature intelligence | Add typed scalar/date/GUID/null-mask attributes, statistics, drawing metadata evaluation, and query APIs. | Planned |
 | 5. Profile coverage | Add Point, then I3S 2.1 Point Cloud (LEPCC and density-based traversal). | Planned |

--- a/modules/i3s/src/i3s-loader-with-parser.ts
+++ b/modules/i3s/src/i3s-loader-with-parser.ts
@@ -92,7 +92,7 @@ async function parseTileset(data, options: I3SLoaderOptions, context) {
 
 async function parseTile(data, context) {
   data = JSON.parse(new TextDecoder().decode(data));
-  return normalizeTileData(data, context);
+  return await normalizeTileData(data, context);
 }
 
 function getMagicNumber(data) {

--- a/modules/i3s/src/lib/parsers/parse-i3s-tile-content.ts
+++ b/modules/i3s/src/lib/parsers/parse-i3s-tile-content.ts
@@ -245,13 +245,19 @@ async function parseI3SNodeGeometry(
     );
 
     // Getting feature attributes such as featureIds and faceRange
-    const {attributes: normalizedFeatureAttributes} = normalizeAttributes(
-      arrayBuffer,
-      offset,
-      featureAttributes,
-      featureCount,
-      featureAttributeOrder
-    );
+    const {attributes: normalizedFeatureAttributes, byteOffset: featureByteOffset} =
+      normalizeAttributes(
+        arrayBuffer,
+        offset,
+        featureAttributes,
+        featureCount,
+        featureAttributeOrder
+      );
+
+    const meshSegmentation = extractMeshSegmentation(arrayBuffer, featureByteOffset);
+    if (meshSegmentation) {
+      content.meshSegmentation = meshSegmentation;
+    }
 
     flattenFeatureIdsByFaceRanges(normalizedFeatureAttributes);
     attributes = concatAttributes(normalizedVertexAttributes, normalizedFeatureAttributes);
@@ -294,6 +300,22 @@ async function parseI3SNodeGeometry(
   content.byteLength = contentByteLength;
 
   return content;
+}
+
+/**
+ * Preserve the optional legacy mesh-segmentation payload that follows the schema-defined attributes.
+ * Older I3S services append this payload to the geometry buffer without adding it to
+ * `defaultGeometrySchema`; retaining it keeps the bytes available to applications that understand
+ * the service-specific segmentation record.
+ * @param arrayBuffer - complete legacy geometry buffer
+ * @param byteOffset - first byte after schema-defined attributes
+ * @returns segmentation bytes, or undefined when the schema consumes the complete buffer
+ */
+function extractMeshSegmentation(
+  arrayBuffer: ArrayBuffer,
+  byteOffset: number
+): ArrayBuffer | undefined {
+  return byteOffset < arrayBuffer.byteLength ? arrayBuffer.slice(byteOffset) : undefined;
 }
 
 /**

--- a/modules/i3s/src/lib/parsers/parse-i3s.ts
+++ b/modules/i3s/src/lib/parsers/parse-i3s.ts
@@ -15,12 +15,18 @@ import {
   I3SMinimalNodeData,
   Node3DIndexDocument,
   SceneLayer3D,
-  I3SParseOptions
+  I3SParseOptions,
+  I3SMaterialDefinition,
+  I3STextureFormat,
+  SharedResources
 } from '../../types';
 import type {LoaderOptions, LoaderContext} from '@loaders.gl/loader-utils';
 import {I3SLoaderWithParser} from '../../i3s-loader-with-parser';
 
-export function normalizeTileData(tile : Node3DIndexDocument, context: LoaderContext): I3STileHeader {
+export async function normalizeTileData(
+  tile: Node3DIndexDocument,
+  context: LoaderContext
+): Promise<I3STileHeader> {
   const url: string = context.url || '';
   let contentUrl: string | undefined;
   if (tile.geometryData) {
@@ -39,16 +45,144 @@ export function normalizeTileData(tile : Node3DIndexDocument, context: LoaderCon
 
   const children = tile.children || [];
 
+  const sharedResources = await loadSharedResources(tile, context);
+  const sharedMaterial = getLegacyMaterialDefinition(sharedResources);
+  const sharedTextureFormat = getLegacyTextureFormat(sharedResources);
+
   return normalizeTileNonUrlData({
     ...tile,
     children,
     url,
     contentUrl,
     textureUrl,
-    textureFormat: 'jpg', // `jpg` format selects bitmap image loading that can also handle `png`
+    textureFormat: sharedTextureFormat || 'jpg', // `jpg` format selects bitmap image loading that can also handle `png`
     attributeUrls,
+    materialDefinition: sharedMaterial,
+    sharedResources,
     isDracoGeometry: false
   });
+}
+
+/**
+ * Load the legacy shared-resource bundle referenced by a 1.6 node document.
+ * @param tile - legacy node document
+ * @param context - loader context used for relative resource access
+ * @returns decoded shared resources, or undefined when the optional resource is unavailable
+ */
+async function loadSharedResources(
+  tile: Node3DIndexDocument,
+  context: LoaderContext
+): Promise<SharedResources | undefined> {
+  const sharedResource = tile.sharedResource;
+  if (!sharedResource?.href || !context.fetch) {
+    return undefined;
+  }
+
+  const baseUrl = context.baseUrl || context.url?.replace(/\/[^/]*$/, '') || '';
+  const sharedResourceUrl = resolveRelativeResourceUrl(baseUrl, sharedResource.href);
+  const requestUrl = `${sharedResourceUrl}${context.queryString || ''}`;
+
+  try {
+    const response = await context.fetch(requestUrl);
+    if (!response.ok) {
+      return undefined;
+    }
+    return (await response.json()) as SharedResources;
+  } catch (_error) {
+    // Shared resources are optional in some 1.6 services. Keep loading the node
+    // when the service does not expose the optional material bundle.
+    return undefined;
+  }
+}
+
+/**
+ * Resolve a resource href relative to the node document's directory.
+ * @param baseUrl - node document directory
+ * @param href - resource href from the node document
+ * @returns resolved resource URL
+ */
+function resolveRelativeResourceUrl(baseUrl: string, href: string): string {
+  if (/^(?:[a-z]+:)?\/\//i.test(href) || href.startsWith('data:') || href.startsWith('blob:')) {
+    return href;
+  }
+  return `${baseUrl.replace(/\/$/, '')}/${href.replace(/^\.\//, '')}`;
+}
+
+/**
+ * Convert the first legacy material definition into the PBR shape used by the renderer.
+ * @param sharedResources - legacy shared-resource bundle
+ * @returns normalized material definition
+ */
+export function getLegacyMaterialDefinition(
+  sharedResources?: SharedResources
+): I3SMaterialDefinition | undefined {
+  const materialDefinitions = sharedResources?.materialDefinitions;
+  const materialDefinition = materialDefinitions
+    ? materialDefinitions[Object.keys(materialDefinitions)[0]]
+    : undefined;
+  if (!materialDefinition) {
+    return undefined;
+  }
+
+  const params = materialDefinition.params;
+  const diffuse = params.diffuse || [];
+  const color: [number, number, number] = [
+    normalizeLegacyColorComponent(diffuse[0]),
+    normalizeLegacyColorComponent(diffuse[1]),
+    normalizeLegacyColorComponent(diffuse[2])
+  ];
+  const transparency = Math.max(0, Math.min(1, params.transparency || 0));
+  const textureDefinitions = sharedResources?.textureDefinitions;
+  const textureDefinitionId = textureDefinitions ? Object.keys(textureDefinitions)[0] : undefined;
+
+  return {
+    pbrMetallicRoughness: {
+      baseColorFactor: [color[0], color[1], color[2], (1 - transparency) * 255],
+      metallicFactor: 0,
+      roughnessFactor: params.shininess === undefined ? 1 : 1 - Math.min(1, params.shininess / 128),
+      ...(textureDefinitionId !== undefined
+        ? {baseColorTexture: {textureSetDefinitionId: Number(textureDefinitionId) || 0}}
+        : {})
+    },
+    alphaMode: transparency > 0 ? 'blend' : 'opaque',
+    doubleSided: params.cullFace === 'none',
+    cullFace: params.cullFace as I3SMaterialDefinition['cullFace'] | undefined
+  };
+}
+
+/**
+ * Normalize a legacy diffuse-color component to the byte range used by the PBR material path.
+ * @param value - legacy color component
+ * @returns color component in the range 0..255
+ */
+function normalizeLegacyColorComponent(value: number | undefined): number {
+  if (value === undefined) {
+    return 255;
+  }
+  return value <= 1 ? value * 255 : value;
+}
+
+/**
+ * Select the first texture encoding advertised by a legacy shared-resource bundle.
+ * @param sharedResources - legacy shared-resource bundle
+ * @returns loaders.gl texture format
+ */
+function getLegacyTextureFormat(sharedResources?: SharedResources): I3STextureFormat | undefined {
+  const encoding = Object.values(sharedResources?.textureDefinitions || {})[0]?.encoding?.[0];
+  switch (encoding) {
+    case 'image/png':
+      return 'png';
+    case 'image/vnd-ms.dds':
+      return 'dds';
+    case 'image/ktx2':
+      return 'ktx2';
+    case 'image/ktx':
+      return 'ktx-etc2';
+    case 'image/jpeg':
+      return 'jpg';
+    default:
+      return undefined;
+  }
 }
 
 export function normalizeTileNonUrlData(tile : I3SMinimalNodeData): I3STileHeader {

--- a/modules/i3s/src/lib/parsers/parse-i3s.ts
+++ b/modules/i3s/src/lib/parsers/parse-i3s.ts
@@ -78,8 +78,8 @@ async function loadSharedResources(
     return undefined;
   }
 
-  const baseUrl = context.baseUrl || context.url?.replace(/\/[^/]*$/, '') || '';
-  const sharedResourceUrl = resolveRelativeResourceUrl(baseUrl, sharedResource.href);
+  const nodeUrl = getUrlWithoutParams(context.url || context.baseUrl || '');
+  const sharedResourceUrl = resolveRelativeResourceUrl(nodeUrl, sharedResource.href);
   const requestUrl = `${sharedResourceUrl}${context.queryString || ''}`;
 
   try {

--- a/modules/i3s/src/lib/parsers/parse-slpk/slpk-archieve.ts
+++ b/modules/i3s/src/lib/parsers/parse-slpk/slpk-archieve.ts
@@ -76,6 +76,13 @@ export class SLPKArchive extends IndexedArchive {
    * @returns buffer with ready to use file
    */
   async getFile(path: string, mode: 'http' | 'raw' = 'raw'): Promise<ArrayBuffer> {
+    // Shared resources use a logical node-relative path but are stored under
+    // `shared/sharedResource.json.gz`, so archive-backed I3S fetches need the
+    // same expansion as HTTP-mode resource requests.
+    if (mode === 'raw' && /nodes\/(?:\d+|root)\/shared$/.test(path)) {
+      return await this.getFile(path, 'http');
+    }
+
     if (mode === 'http') {
       const extensions = PATH_DESCRIPTIONS.find(val => val.test.test(path))?.extensions;
       if (extensions) {

--- a/modules/i3s/src/types.ts
+++ b/modules/i3s/src/types.ts
@@ -127,6 +127,8 @@ export type I3SMinimalNodeData = {
   attributeUrls?: string[];
   /** Material definition from I3S layer metadata */
   materialDefinition?: I3SMaterialDefinition;
+  /** Legacy shared-resource bundle loaded for this node, when present. */
+  sharedResources?: SharedResources;
   /** Texture format per I3S spec */
   textureFormat: I3STextureFormat;
   /** Loader options for texture loader. The loader might be `CompressedTextureLoader` for `dds`, BasisLoader for `ktx2` or `ImageBitmapLoader` for `jpg` and `png`. */
@@ -209,6 +211,8 @@ export type I3STileContent = {
   coordinateSystem: CoordinateSystem;
   byteLength: number;
   texture: TileContentTexture;
+  /** Opaque mesh-segmentation payload appended to a legacy geometry buffer. */
+  meshSegmentation?: ArrayBuffer;
   [key: string]: any;
 };
 

--- a/modules/i3s/test/data/conformance/i3s-1.9-3d-object.json
+++ b/modules/i3s/test/data/conformance/i3s-1.9-3d-object.json
@@ -1,0 +1,20 @@
+{
+  "id": 0,
+  "layerType": "3DObject",
+  "version": "1.9",
+  "capabilities": ["View", "Query"],
+  "disablePopup": false,
+  "spatialReference": {"wkid": 4326, "latestWkid": 4326},
+  "store": {
+    "profile": "meshpyramids",
+    "version": "1.9",
+    "defaultGeometrySchema": {
+      "geometryType": "triangles",
+      "vertexAttributes": {"position": {"valueType": "Float32", "valuesPerElement": 3}}
+    }
+  },
+  "nodePages": {
+    "nodesPerPage": 64,
+    "lodSelectionMetricType": "maxScreenThresholdSQ"
+  }
+}

--- a/modules/i3s/test/i3s-conformance.spec.ts
+++ b/modules/i3s/test/i3s-conformance.spec.ts
@@ -6,8 +6,10 @@ import {fetchFile, parse} from '@loaders.gl/core';
 import {I3SNodePageLoader} from '@loaders.gl/i3s';
 import {I3SSceneLayerSchema} from '@loaders.gl/i3s/i3s-zod-schema';
 import {describe, expect, it} from 'vitest';
+import {parseSLPKArchive} from '../src/lib/parsers/parse-slpk/parse-slpk';
 import {parseI3STileContent, parseUint64Values} from '../src/lib/parsers/parse-i3s-tile-content';
 import {getLegacyMaterialDefinition, normalizeTileData} from '../src/lib/parsers/parse-i3s';
+import {createReadableFileFromBuffer} from 'test/utils/readable-files';
 
 const SCENE_LAYER_FIXTURES = [
   {
@@ -164,6 +166,7 @@ describe('I3S conformance fixtures', () => {
         '0': {encoding: ['image/png'], images: []}
       }
     };
+    let requestedUrl = '';
     const tile = await normalizeTileData(
       {
         id: 'legacy',
@@ -174,13 +177,17 @@ describe('I3S conformance fixtures', () => {
         url: '/layers/0/nodes/legacy',
         baseUrl: '/layers/0/nodes',
         queryString: '',
-        fetch: async () => new Response(JSON.stringify(sharedResources)),
+        fetch: async url => {
+          requestedUrl = String(url);
+          return new Response(JSON.stringify(sharedResources));
+        },
         coreApi: {} as any,
         _parse: async () => null
       }
     );
 
     expect(tile.textureFormat).toBe('png');
+    expect(requestedUrl).toBe('/layers/0/nodes/legacy/shared');
     expect(tile.sharedResources).toEqual(sharedResources);
     expect(tile.materialDefinition?.alphaMode).toBe('blend');
     expect(tile.materialDefinition?.doubleSided).toBe(true);
@@ -188,5 +195,15 @@ describe('I3S conformance fixtures', () => {
       51, 102, 153, 191.25
     ]);
     expect(getLegacyMaterialDefinition(undefined)).toBeUndefined();
+  });
+
+  it('expands raw archive shared-resource requests to the stored bundle path', async () => {
+    const response = await fetchFile('@loaders.gl/i3s/test/data/DA12_subset.slpk');
+    const archive = await parseSLPKArchive(
+      await createReadableFileFromBuffer(await response.arrayBuffer())
+    );
+    const sharedResources = await archive.getFile('nodes/3/shared');
+
+    expect(sharedResources.byteLength).toBe(333);
   });
 });

--- a/modules/i3s/test/i3s-conformance.spec.ts
+++ b/modules/i3s/test/i3s-conformance.spec.ts
@@ -7,6 +7,7 @@ import {I3SNodePageLoader} from '@loaders.gl/i3s';
 import {I3SSceneLayerSchema} from '@loaders.gl/i3s/i3s-zod-schema';
 import {describe, expect, it} from 'vitest';
 import {parseI3STileContent, parseUint64Values} from '../src/lib/parsers/parse-i3s-tile-content';
+import {getLegacyMaterialDefinition, normalizeTileData} from '../src/lib/parsers/parse-i3s';
 
 const SCENE_LAYER_FIXTURES = [
   {
@@ -18,6 +19,11 @@ const SCENE_LAYER_FIXTURES = [
     name: 'I3S 1.8 3D Object',
     url: '@loaders.gl/i3s/test/data/conformance/i3s-1.8-3d-object.json',
     expectedVersion: '1.8'
+  },
+  {
+    name: 'I3S 1.9 3D Object',
+    url: '@loaders.gl/i3s/test/data/conformance/i3s-1.9-3d-object.json',
+    expectedVersion: '1.9'
   },
   {
     name: 'I3S 1.10 3D Object with forward fields',
@@ -105,5 +111,82 @@ describe('I3S conformance fixtures', () => {
       featureId,
       featureId
     ]);
+  });
+
+  it('preserves legacy mesh-segmentation bytes after schema-defined attributes', async () => {
+    const buffer = new ArrayBuffer(48);
+    const dataView = new DataView(buffer);
+    dataView.setUint32(0, 3, true);
+    dataView.setUint32(4, 0, true);
+    for (let index = 0; index < 9; index++) {
+      dataView.setFloat32(8 + index * 4, index % 3, true);
+    }
+    new Uint8Array(buffer, 44).set([0x53, 0x45, 0x47, 0x01]);
+
+    const content = await parseI3STileContent(
+      buffer,
+      {mbs: [0, 0, 0]} as any,
+      {
+        store: {
+          defaultGeometrySchema: {
+            header: [
+              {property: 'vertexCount', type: 'UInt32'},
+              {property: 'featureCount', type: 'UInt32'}
+            ],
+            ordering: ['position'],
+            vertexAttributes: {
+              position: {valueType: 'Float32', valuesPerElement: 3}
+            },
+            featureAttributeOrder: [],
+            featureAttributes: {}
+          }
+        }
+      } as any
+    );
+
+    expect(content.meshSegmentation).toBeInstanceOf(ArrayBuffer);
+    expect(Array.from(new Uint8Array(content.meshSegmentation!))).toEqual([0x53, 0x45, 0x47, 0x01]);
+  });
+
+  it('loads and normalizes a legacy shared-resource material', async () => {
+    const sharedResources = {
+      materialDefinitions: {
+        '0': {
+          params: {
+            diffuse: [0.2, 0.4, 0.6],
+            transparency: 0.25,
+            renderMode: 'textured',
+            cullFace: 'none'
+          }
+        }
+      },
+      textureDefinitions: {
+        '0': {encoding: ['image/png'], images: []}
+      }
+    };
+    const tile = await normalizeTileData(
+      {
+        id: 'legacy',
+        mbs: [0, 0, 0, 1],
+        sharedResource: {href: './shared'}
+      },
+      {
+        url: '/layers/0/nodes/legacy',
+        baseUrl: '/layers/0/nodes',
+        queryString: '',
+        fetch: async () => new Response(JSON.stringify(sharedResources)),
+        coreApi: {} as any,
+        _parse: async () => null
+      }
+    );
+
+    expect(tile.textureFormat).toBe('png');
+    expect(tile.sharedResources).toEqual(sharedResources);
+    expect(tile.materialDefinition?.alphaMode).toBe('blend');
+    expect(tile.materialDefinition?.doubleSided).toBe(true);
+    expect(tile.materialDefinition?.pbrMetallicRoughness.baseColorFactor).toEqual([
+      51, 102, 153, 191.25
+    ]);
+    expect(getLegacyMaterialDefinition(undefined)).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Goals

- Implement tranche 2 of the I3S supremacy roadmap for legacy shared resources and mesh parity.
- Expand 1.9/1.10 conformance coverage while documenting the remaining boundaries accurately.

## Changes

- Load legacy 1.6 `sharedResource` bundles during node-header normalization.
- Normalize the first legacy material and texture encoding into the existing PBR/texture path, while preserving the decoded shared-resource bundle on the tile header.
- Preserve bytes appended after schema-defined legacy geometry attributes as `meshSegmentation` so applications can interpret service-specific segment records.
- Add an I3S 1.9 scene-layer conformance fixture and focused tests for shared resources and segmentation payloads.
- Update the I3S support matrix and mark tranche 2 complete; retained partial rows identify first-material-only and opaque-segmentation limitations.

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn build-workers`
- `yarn test-node` (361 passed, 6 skipped)
- `yarn test-headless` (2,936 passed, 40 skipped)
- `yarn test-audit` (594 files, 0 violations)
- `cd website && yarn && yarn build` (successful; existing warnings/broken links reported)
