### PR TITLE
feat(3d-tiles): preserve content volumes and support clipping culling

### DIFF
--- a/docs/modules/tiles/api-reference/tile-3d.md
+++ b/docs/modules/tiles/api-reference/tile-3d.md
@@ -26,6 +26,10 @@ Returns `true` when traversal may request a source-managed lazy child-header gro
 
 ###### `boundingVolume` (BoundingVolume)
 
+###### `contentVisibility(frameState)`
+
+Returns the render-content visibility classification after culling against the viewport and any optional world-space clipping planes. Clipping planes affect rendering only; hierarchy traversal continues to use the tile bounding volume.
+
 A bounding volume that encloses a tile or its content. Exactly one box, region, or sphere property is required. ([`Reference`](https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/master/specification#bounding-volume))
 
 ###### `viewerRequestVolume` (BoundingVolume | null)

--- a/modules/tiles/src/tileset-3d/common/tile-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tile-3d.ts
@@ -156,6 +156,7 @@ export class Tile3D {
   private _visible: boolean | undefined = undefined;
 
   private _contentBoundingVolume: any;
+  private _contentBoundingVolumes: any[] = [];
   /** Source content-volume headers retained after render content is unloaded. */
   private _contentBoundingVolumeHeaders: any[] = [];
   private _viewerRequestVolume: any;
@@ -787,19 +788,33 @@ export class Tile3D {
    * @returns The content visibility classification.
    */
   contentVisibility(frameState: FrameState): number {
-    if (!this.contentBoundingVolume || this._visibilityPlaneMask === CullingVolume.MASK_INSIDE) {
-      return INTERSECTION.INSIDE;
-    }
-    const visibility = frameState.cullingVolume.computeVisibility(this.contentBoundingVolume);
-    if (visibility === INTERSECTION.OUTSIDE) {
-      return visibility;
-    }
-    for (const clippingPlane of frameState.clippingPlanes || []) {
-      if (this.contentBoundingVolume.intersectPlane(clippingPlane) === INTERSECTION.OUTSIDE) {
-        return INTERSECTION.OUTSIDE;
+    const contentVolumes = this._contentBoundingVolumes.length
+      ? this._contentBoundingVolumes
+      : [this.boundingVolume];
+    let visibleVolume = false;
+    let intersectingVolume = false;
+    for (const contentVolume of contentVolumes) {
+      if (this._visibilityPlaneMask !== CullingVolume.MASK_INSIDE) {
+        const visibility = frameState.cullingVolume.computeVisibility(contentVolume);
+        if (visibility === INTERSECTION.OUTSIDE) {
+          continue;
+        }
+        intersectingVolume = intersectingVolume || visibility === INTERSECTION.INTERSECTING;
+      }
+      let clipped = false;
+      for (const clippingPlane of frameState.clippingPlanes || []) {
+        if (contentVolume.intersectPlane(clippingPlane) === INTERSECTION.OUTSIDE) {
+          clipped = true;
+          break;
+        }
+      }
+      if (!clipped) {
+        visibleVolume = true;
+        break;
       }
     }
-    return visibility;
+    return visibleVolume ? (intersectingVolume ? INTERSECTION.INTERSECTING : INTERSECTION.INSIDE) : INTERSECTION.OUTSIDE;
+  }
   }
 
   /**
@@ -1048,13 +1063,10 @@ export class Tile3D {
         : [content]
       : this._contentBoundingVolumeHeaders;
     const contentHeader = contentHeaders.find(headerEntry => headerEntry?.boundingVolume);
-    if (contentHeader?.boundingVolume) {
-      this._contentBoundingVolume = createBoundingVolume(
-        contentHeader.boundingVolume,
-        this.computedTransform,
-        this._contentBoundingVolume
-      );
-    }
+    this._contentBoundingVolumes = contentHeaders
+      .filter(headerEntry => headerEntry?.boundingVolume)
+      .map(headerEntry => createBoundingVolume(headerEntry.boundingVolume, this.computedTransform));
+    this._contentBoundingVolume = this._contentBoundingVolumes[0] || null;
   }
 
   /**

--- a/modules/tiles/src/tileset-3d/common/tile-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tile-3d.ts
@@ -1066,6 +1066,12 @@ export class Tile3D {
     this._contentBoundingVolumes = contentHeaders
       .filter(headerEntry => headerEntry?.boundingVolume)
       .map(headerEntry => createBoundingVolume(headerEntry.boundingVolume, this.computedTransform));
+    if (
+      !contentHeaders.length ||
+      contentHeaders.some(headerEntry => !headerEntry?.boundingVolume)
+    ) {
+      this._contentBoundingVolumes.push(this.boundingVolume);
+    }
     this._contentBoundingVolume = this._contentBoundingVolumes[0] || null;
   }
 

--- a/modules/tiles/src/tileset-3d/common/tile-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tile-3d.ts
@@ -813,8 +813,11 @@ export class Tile3D {
         break;
       }
     }
-    return visibleVolume ? (intersectingVolume ? INTERSECTION.INTERSECTING : INTERSECTION.INSIDE) : INTERSECTION.OUTSIDE;
-  }
+    return visibleVolume
+      ? intersectingVolume
+        ? INTERSECTION.INTERSECTING
+        : INTERSECTION.INSIDE
+      : INTERSECTION.OUTSIDE;
   }
 
   /**

--- a/modules/tiles/src/tileset-3d/common/tile-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tile-3d.ts
@@ -6,7 +6,7 @@
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 
 import {Vector3, Matrix4} from '@math.gl/core';
-import {CullingVolume} from '@math.gl/culling';
+import {CullingVolume, INTERSECTION, Plane} from '@math.gl/culling';
 
 // Note: circular dependency
 import type {Tileset3D} from './tileset-3d';

--- a/modules/tiles/src/tileset-3d/common/tile-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tile-3d.ts
@@ -156,7 +156,14 @@ export class Tile3D {
   private _visible: boolean | undefined = undefined;
 
   private _contentBoundingVolume: any;
+  /** Source content-volume headers retained after render content is unloaded. */
+  private _contentBoundingVolumeHeaders: any[] = [];
   private _viewerRequestVolume: any;
+
+  /** Bounding volume used to cull the tile's renderable content, when declared. */
+  get contentBoundingVolume(): any {
+    return this._contentBoundingVolume;
+  }
 
   /** Bounding volume that limits when this tile may be requested, when declared. */
   get viewerRequestVolume(): any {
@@ -771,47 +778,28 @@ export class Tile3D {
     return cullingVolume.computeVisibilityWithPlaneMask(boundingVolume, parentVisibilityPlaneMask);
   }
 
-  // Assuming the tile's bounding volume intersects the culling volume, determines
-  // whether the tile's content's bounding volume intersects the culling volume.
-  // @param {FrameState} frameState The frame state.
-  // @returns {Intersect} The result of the intersection: the tile's content is completely outside, completely inside, or intersecting the culling volume.
-  contentVisibility() {
-    return true;
-
-    // TODO restore
-    /*
-    // Assumes the tile's bounding volume intersects the culling volume already, so
-    // just return Intersect.INSIDE if there is no content bounding volume.
-    if (!defined(this.contentBoundingVolume)) {
-      return Intersect.INSIDE;
+  /**
+   * Determines whether renderable content intersects the view and configured clipping planes.
+   *
+   * Clipping planes are render-only constraints; traversal continues to use the tile volume.
+   *
+   * @param frameState Current camera, culling, and optional clipping-plane state.
+   * @returns The content visibility classification.
+   */
+  contentVisibility(frameState: FrameState): number {
+    if (!this.contentBoundingVolume || this._visibilityPlaneMask === CullingVolume.MASK_INSIDE) {
+      return INTERSECTION.INSIDE;
     }
-
-    if (this._visibilityPlaneMask === CullingVolume.MASK_INSIDE) {
-      // The tile's bounding volume is completely inside the culling volume so
-      // the content bounding volume must also be inside.
-      return Intersect.INSIDE;
+    const visibility = frameState.cullingVolume.computeVisibility(this.contentBoundingVolume);
+    if (visibility === INTERSECTION.OUTSIDE) {
+      return visibility;
     }
-
-    // PERFORMANCE_IDEA: is it possible to burn less CPU on this test since we know the
-    // tile's (not the content's) bounding volume intersects the culling volume?
-    const cullingVolume = frameState.cullingVolume;
-    const boundingVolume = tile.contentBoundingVolume;
-
-    const tileset = this.tileset;
-    const clippingPlanes = tileset.clippingPlanes;
-    if (defined(clippingPlanes) && clippingPlanes.enabled) {
-      const intersection = clippingPlanes.computeIntersectionWithBoundingVolume(
-        boundingVolume,
-        tileset.clippingPlanesOriginMatrix
-      );
-      this._isClipped = intersection !== Intersect.INSIDE;
-      if (intersection === Intersect.OUTSIDE) {
-        return Intersect.OUTSIDE;
+    for (const clippingPlane of frameState.clippingPlanes || []) {
+      if (this.contentBoundingVolume.intersectPlane(clippingPlane) === INTERSECTION.OUTSIDE) {
+        return INTERSECTION.OUTSIDE;
       }
     }
-
-    return cullingVolume.computeVisibility(boundingVolume);
-    */
+    return visibility;
   }
 
   /**
@@ -937,6 +925,7 @@ export class Tile3D {
 
   _initializeBoundingVolumes(tileHeader) {
     this._contentBoundingVolume = null;
+    this._contentBoundingVolumeHeaders = [];
     this._viewerRequestVolume = null;
 
     this._updateBoundingVolume(tileHeader);
@@ -1048,19 +1037,20 @@ export class Tile3D {
     }
 
     const content = header.content;
-    if (!content) {
-      return;
+    if (content) {
+      this._contentBoundingVolumeHeaders = (Array.isArray(content) ? content : [content]).filter(
+        contentHeader => contentHeader?.boundingVolume
+      );
     }
-
-    // TODO Cesium specific
-    // Non-leaf tiles may have a content bounding-volume, which is a tight-fit bounding volume
-    // around only the features in the tile. This box is useful for culling for rendering,
-    // but not for culling for traversing the tree since it does not guarantee spatial coherence, i.e.,
-    // since it only bounds features in the tile, not the entire tile, children may be
-    // outside of this box.
-    if (content.boundingVolume) {
+    const contentHeaders = content
+      ? Array.isArray(content)
+        ? content
+        : [content]
+      : this._contentBoundingVolumeHeaders;
+    const contentHeader = contentHeaders.find(headerEntry => headerEntry?.boundingVolume);
+    if (contentHeader?.boundingVolume) {
       this._contentBoundingVolume = createBoundingVolume(
-        content.boundingVolume,
+        contentHeader.boundingVolume,
         this.computedTransform,
         this._contentBoundingVolume
       );

--- a/modules/tiles/src/tileset-3d/common/tile-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tile-3d.ts
@@ -6,7 +6,7 @@
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 
 import {Vector3, Matrix4} from '@math.gl/core';
-import {CullingVolume, INTERSECTION, Plane} from '@math.gl/culling';
+import {CullingVolume, INTERSECTION} from '@math.gl/culling';
 
 // Note: circular dependency
 import type {Tileset3D} from './tileset-3d';

--- a/modules/tiles/src/tileset-3d/helpers/frame-state.ts
+++ b/modules/tiles/src/tileset-3d/helpers/frame-state.ts
@@ -27,6 +27,8 @@ export type FrameState = {
   topDownViewport: GeospatialViewport; // Use it to calculate projected radius for a tile
   height: number;
   cullingVolume: CullingVolume;
+  /** Optional world-space clipping planes applied to render-content culling. */
+  clippingPlanes?: Plane[];
   frameNumber: number; // TODO: This can be the same between updates, what number is unique for between updates?
   sseDenominator: number; // Assumes fovy = 60 degrees
   /** View-dependent density used by perspective dynamic screen-space error for this traversal. */

--- a/modules/tiles/src/tileset-3d/helpers/frame-state.ts
+++ b/modules/tiles/src/tileset-3d/helpers/frame-state.ts
@@ -163,6 +163,7 @@ export function getFrameState(
     topDownViewport,
     height,
     cullingVolume,
+    clippingPlanes: viewport.clippingPlanes,
     frameNumber, // TODO: This can be the same between updates, what number is unique for between updates?
     sseDenominator: 1.15, // Assumes fovy = 60 degrees
     // Tileset3D fills this immediately before traversal because it depends on the root volume.

--- a/modules/tiles/src/types.ts
+++ b/modules/tiles/src/types.ts
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {Vector3} from '@math.gl/core';
+import type {Plane} from '@math.gl/culling';
 
 export type BoundingRectangle = {
   width: number;
@@ -26,6 +27,8 @@ export type Viewport = {
    * Orthographic 3D Tiles traversal requires a positive, finite value to calculate SSE.
    */
   metersPerPixel?: number;
+  /** Optional world-space clipping planes used to cull renderable tile content. */
+  clippingPlanes?: Plane[];
   distanceScales: {
     unitsPerMeter: number[];
     metersPerUnit: number[];


### PR DESCRIPTION
## Goals

Complete the next two Cesium-parity tranches for 3D Tiles content culling.

## Changes

- Retain source content-volume metadata so transform updates after unload/reload rebuild render-culling volumes.
- Add optional world-space clipping planes to the structural viewport and traversal frame state.
- Apply clipping planes to content visibility while keeping tile volumes authoritative for hierarchy traversal.
- Add TSDoc and API documentation for lifecycle and clipping semantics.

## Validation

- Strict TypeScript issue from the previous multi-content tranche is addressed.
- CI will run build, tests, lint, and website checks on the pull request.

Related roadmap tranches: 9 (content-volume lifecycle tests/behavior) and 10 (clipping-plane-aware culling).