### PR TITLE
test(las): migrate TypeScript LAZ suite to Vitest

### DIFF
--- a/modules/las/test/typescript-laz.spec.ts
+++ b/modules/las/test/typescript-laz.spec.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
-import {expect, test as vitestTest} from 'vitest';
+import {expect, test} from 'vitest';
 import {fetchFile, isBrowser, parse} from '@loaders.gl/core';
 import {LASLoader} from '@loaders.gl/las';
 import {
@@ -105,7 +104,7 @@ const FIXTURES: LAZFixture[] = [
   }
 ];
 
-test('TypeScript LAZ raw streaming preserves PDRF 4-10 records', async t => {
+test('TypeScript LAZ raw streaming preserves PDRF 4-10 records', async () => {
   for (const fixture of FIXTURES) {
     const [lasArrayBuffer, lazArrayBuffer] = await Promise.all([
       loadArrayBuffer(fixture.lasUrl),
@@ -122,17 +121,12 @@ test('TypeScript LAZ raw streaming preserves PDRF 4-10 records', async t => {
 
     const expected = getLASPointData(lasArrayBuffer, fixture.pointDataRecordLength);
     const actual = concatenateUint8Arrays(decodedBatches);
-    t.equal(
-      actual.byteLength,
-      expected.byteLength,
-      `${fixture.label} raw record byte length matches LAS`
-    );
-    t.deepEqual(actual, expected, `${fixture.label} raw records match LAS`);
+    expect(actual.byteLength).toBe(expected.byteLength);
+    expect(actual).toEqual(expected);
   }
-  t.end();
 }, 60000);
 
-test('TypeScript LAZ complete and split parsing preserve Arrow attributes', async t => {
+test('TypeScript LAZ complete and split parsing preserve Arrow attributes', async () => {
   for (const fixture of FIXTURES) {
     const [lasArrayBuffer, lazArrayBuffer] = await Promise.all([
       loadArrayBuffer(fixture.lasUrl),
@@ -147,24 +141,15 @@ test('TypeScript LAZ complete and split parsing preserve Arrow attributes', asyn
     );
 
     for (const attributeName of Object.keys(expected) as Array<keyof CollectedAttributes>) {
-      t.equal(
-        complete[attributeName].length,
-        expected[attributeName].length,
-        `${fixture.label} complete ${attributeName} length matches LAS`
-      );
-      t.equal(
-        streamed[attributeName].length,
-        expected[attributeName].length,
-        `${fixture.label} split ${attributeName} length matches LAS`
-      );
+      expect(complete[attributeName].length).toBe(expected[attributeName].length);
+      expect(streamed[attributeName].length).toBe(expected[attributeName].length);
     }
-    t.deepEqual(complete, expected, `${fixture.label} complete parse matches LAS`);
-    t.deepEqual(streamed, expected, `${fixture.label} split parse matches LAS`);
+    expect(complete).toEqual(expected);
+    expect(streamed).toEqual(expected);
   }
-  t.end();
 }, 60000);
 
-test('TypeScript LAZ selective Point14 targets decode only requested layers', async t => {
+test('TypeScript LAZ selective Point14 targets decode only requested layers', async () => {
   const fixture = FIXTURES.find(({pointDataRecordFormat}) => pointDataRecordFormat === 7)!;
   const lazArrayBuffer = await loadArrayBuffer(fixture.lazUrl);
   const {compressed, metadata} = getFirstLAZChunk(lazArrayBuffer, fixture);
@@ -179,7 +164,7 @@ test('TypeScript LAZ selective Point14 targets decode only requested layers', as
     {
       label: 'positions only',
       createTarget: () => createPointDataTarget(metadata.pointCount),
-      validate: target => t.deepEqual(target.positions, expected.positions, 'positions match')
+      validate: target => expect(target.positions).toEqual(expected.positions)
     },
     {
       label: 'intensity only',
@@ -187,7 +172,7 @@ test('TypeScript LAZ selective Point14 targets decode only requested layers', as
         ...createPointDataTarget(metadata.pointCount),
         intensities: new Uint16Array(metadata.pointCount)
       }),
-      validate: target => t.deepEqual(target.intensities, expected.intensities, 'intensity matches')
+      validate: target => expect(target.intensities).toEqual(expected.intensities)
     },
     {
       label: 'classification only',
@@ -195,8 +180,7 @@ test('TypeScript LAZ selective Point14 targets decode only requested layers', as
         ...createPointDataTarget(metadata.pointCount),
         classifications: new Uint8Array(metadata.pointCount)
       }),
-      validate: target =>
-        t.deepEqual(target.classifications, expected.classifications, 'classification matches')
+      validate: target => expect(target.classifications).toEqual(expected.classifications)
     },
     {
       label: 'classification flags only',
@@ -208,10 +192,10 @@ test('TypeScript LAZ selective Point14 targets decode only requested layers', as
         overlapFlags: new Uint8Array(metadata.pointCount)
       }),
       validate: target => {
-        t.deepEqual(target.syntheticFlags, expected.syntheticFlags, 'synthetic flags match');
-        t.deepEqual(target.keyPointFlags, expected.keyPointFlags, 'key-point flags match');
-        t.deepEqual(target.withheldFlags, expected.withheldFlags, 'withheld flags match');
-        t.deepEqual(target.overlapFlags, expected.overlapFlags, 'overlap flags match');
+        expect(target.syntheticFlags).toEqual(expected.syntheticFlags);
+        expect(target.keyPointFlags).toEqual(expected.keyPointFlags);
+        expect(target.withheldFlags).toEqual(expected.withheldFlags);
+        expect(target.overlapFlags).toEqual(expected.overlapFlags);
       }
     },
     {
@@ -220,37 +204,29 @@ test('TypeScript LAZ selective Point14 targets decode only requested layers', as
         ...createPointDataTarget(metadata.pointCount),
         rawColors: new Uint16Array(metadata.pointCount * 3)
       }),
-      validate: target => t.deepEqual(target.rawColors, expected.rawColors, 'RGB matches')
+      validate: target => expect(target.rawColors).toEqual(expected.rawColors)
     }
   ];
 
   for (const selection of targets) {
     const target = selection.createTarget();
     const cursor = createLAZChunkDecoderCursor(compressed, metadata);
-    t.equal(
-      cursor.decodeIntoPointData(target, metadata.pointCount),
-      metadata.pointCount,
-      `${selection.label} decodes every point`
-    );
+    expect(cursor.decodeIntoPointData(target, metadata.pointCount)).toBe(metadata.pointCount);
     selection.validate(target);
   }
 
   const lockedTarget = createPointDataTarget(metadata.pointCount);
   const lockedCursor = createLAZChunkDecoderCursor(compressed, metadata);
   lockedCursor.decodeIntoPointData(lockedTarget, 1);
-  t.throws(
-    () =>
-      lockedCursor.decodeIntoPointData(
-        {...lockedTarget, classifications: new Uint8Array(metadata.pointCount)},
-        1
-      ),
-    /Cannot change selected point-data fields/,
-    'selection cannot change after decoding begins'
-  );
-  t.end();
+  expect(() =>
+    lockedCursor.decodeIntoPointData(
+      {...lockedTarget, classifications: new Uint8Array(metadata.pointCount)},
+      1
+    )
+  ).toThrow(/Cannot change selected point-data fields/);
 }, 60000);
 
-test('TypeScript LAZ skips unrequested RGB and auxiliary PDRF 8-10 layers', async t => {
+test('TypeScript LAZ skips unrequested RGB and auxiliary PDRF 8-10 layers', async () => {
   for (const fixture of FIXTURES.filter(({pointDataRecordFormat}) =>
     [8, 9, 10].includes(pointDataRecordFormat)
   )) {
@@ -261,21 +237,12 @@ test('TypeScript LAZ skips unrequested RGB and auxiliary PDRF 8-10 layers', asyn
     const target = createPointDataTarget(metadata.pointCount);
     const cursor = createLAZChunkDecoderCursor(compressed, metadata);
 
-    t.equal(
-      cursor.decodeIntoPointData(target, metadata.pointCount),
-      metadata.pointCount,
-      `${fixture.label} positions-only target decodes every point`
-    );
-    t.deepEqual(
-      target.positions,
-      expected.positions,
-      `${fixture.label} positions match raw records`
-    );
+    expect(cursor.decodeIntoPointData(target, metadata.pointCount)).toBe(metadata.pointCount);
+    expect(target.positions).toEqual(expected.positions);
   }
-  t.end();
 }, 60000);
 
-vitestTest('TypeScript LAZ progressively delivers PDRF 8 RGB and NIR', async () => {
+test('TypeScript LAZ progressively delivers PDRF 8 RGB and NIR', async () => {
   const fixture = FIXTURES.find(({pointDataRecordFormat}) => pointDataRecordFormat === 8)!;
   const lazArrayBuffer = await loadArrayBuffer(fixture.lazUrl);
   const {compressed, metadata} = getFirstLAZChunk(lazArrayBuffer, fixture);
@@ -341,7 +308,7 @@ vitestTest('TypeScript LAZ progressively delivers PDRF 8 RGB and NIR', async () 
   expect(nir).toEqual(expectedNir);
 });
 
-vitestTest.each(
+test.each(
   FIXTURES.filter(({pointDataRecordFormat}) => [9, 10].includes(pointDataRecordFormat))
 )('TypeScript LAZ progressively delivers $label waveform references', async fixture => {
   const lazArrayBuffer = await loadArrayBuffer(fixture.lazUrl);
@@ -401,7 +368,7 @@ vitestTest.each(
   expect(progressiveTarget.waveforms).toEqual(expectedWaveforms);
 });
 
-vitestTest.each(
+test.each(
   FIXTURES.filter(({pointDataRecordFormat}) => [9, 10].includes(pointDataRecordFormat))
 )('TypeScript LAZ parser yields $label waveform rows before trailing layers', async fixture => {
   const [lasArrayBuffer, lazArrayBuffer] = await Promise.all([
@@ -433,7 +400,7 @@ vitestTest.each(
   await batches.return?.();
 });
 
-vitestTest('TypeScript LAZ does not wait for unrequested Point14 layers', async () => {
+test('TypeScript LAZ does not wait for unrequested Point14 layers', async () => {
   const fixture = FIXTURES.find(({pointDataRecordFormat}) => pointDataRecordFormat === 7)!;
   const lazArrayBuffer = await loadArrayBuffer(fixture.lazUrl);
   const {compressed, metadata} = getFirstLAZChunk(lazArrayBuffer, fixture);
@@ -482,7 +449,7 @@ vitestTest('TypeScript LAZ does not wait for unrequested Point14 layers', async 
   expect(classifications).toEqual(expectedClassifications);
 });
 
-test('TypeScript LAZ validates VLR codecs and truncated input', async t => {
+test('TypeScript LAZ validates VLR codecs and truncated input', async () => {
   const fixture = FIXTURES.find(({pointDataRecordFormat}) => pointDataRecordFormat === 7)!;
   const source = await loadArrayBuffer(fixture.lazUrl);
   const vlrDataOffset = findLASZipVLRDataOffset(source);
@@ -513,20 +480,16 @@ test('TypeScript LAZ validates VLR codecs and truncated input', async t => {
   for (const fixtureCase of cases) {
     const corrupted = source.slice(0);
     fixtureCase.mutate(new DataView(corrupted));
-    t.throws(() => parseLAS(corrupted), fixtureCase.error, `rejects invalid ${fixtureCase.label}`);
+    expect(() => parseLAS(corrupted)).toThrow(fixtureCase.error);
   }
 
-  t.throws(
-    () => parseLAS(source.slice(0, source.byteLength - 32)),
-    /needs more|truncated|beyond input|incomplete LAZ chunk table/i,
-    'rejects truncated compressed point data'
+  expect(() => parseLAS(source.slice(0, source.byteLength - 32))).toThrow(
+    /needs more|truncated|beyond input|incomplete LAZ chunk table/i
   );
-  t.end();
 });
 
-test('LASLoader primary TypeScript variant uses its packaged worker', async t => {
+test('LASLoader primary TypeScript variant uses its packaged worker', async () => {
   if (!isBrowser) {
-    t.end();
     return;
   }
 
@@ -539,18 +502,11 @@ test('LASLoader primary TypeScript variant uses its packaged worker', async t =>
     core: {worker: false}
   })) as LASMesh;
 
-  t.equal(workerResult.header.vertexCount, POINT_COUNT, 'TypeScript worker decodes LAS 1.4 PDRF 7');
-  t.deepEqual(
-    workerResult.attributes.POSITION.value,
-    mainThreadResult.attributes.POSITION.value,
-    'worker positions match main-thread TypeScript output'
+  expect(workerResult.header.vertexCount).toBe(POINT_COUNT);
+  expect(workerResult.attributes.POSITION.value).toEqual(
+    mainThreadResult.attributes.POSITION.value
   );
-  t.deepEqual(
-    workerResult.attributes.COLOR_0.value,
-    mainThreadResult.attributes.COLOR_0.value,
-    'worker colors match main-thread TypeScript output'
-  );
-  t.end();
+  expect(workerResult.attributes.COLOR_0.value).toEqual(mainThreadResult.attributes.COLOR_0.value);
 });
 
 /** Load one local LAS/LAZ fixture. */

--- a/modules/orc/test/index.ts
+++ b/modules/orc/test/index.ts
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import * as arrow from 'apache-arrow';
 import {parseORC} from '../src/lib/parsers/parse-orc';
 import {ORCLoaderWithParser} from '../src/orc-loader';
 import {ORCWriter} from '../src/orc-writer';
 
-test('ORCLoader#parse validates the ORC envelope', t => {
+test('ORCLoader#parse validates the ORC envelope', () => {
   const postscript = Uint8Array.from([0x08, 0x04, 0x10, 0x00, 0x18, 0x00, 0x20, 0x01, 0x28, 0x00]);
   const footer = Uint8Array.from([0x30, 0x2a]);
   const bytes = new Uint8Array(3 + footer.length + postscript.length + 1);
@@ -17,70 +17,65 @@ test('ORCLoader#parse validates the ORC envelope', t => {
   bytes.set(postscript, 3 + footer.length);
   bytes[bytes.length - 1] = postscript.length;
   const result = parseORC(bytes.buffer);
-  t.equal(result.format, 'orc');
-  t.equal(result.postscript.compression, 'NONE');
-  t.equal(result.footer.numberOfRows, 42);
-  t.end();
+  expect(result.format).toBe('orc');
+  expect(result.postscript.compression).toBe('NONE');
+  expect(result.footer.numberOfRows).toBe(42);
 });
 
-test('ORCLoader#parse returns an Arrow table', async t => {
+test('ORCLoader#parse returns an Arrow table', async () => {
   const output = await ORCWriter.encode({
     shape: 'object-row-table',
     schema: {fields: [{name: 'id', type: 'int32'}], metadata: {}},
     data: []
   });
   const result = await ORCLoaderWithParser.parse(output);
-  t.equal(result.shape, 'arrow-table');
-  if (result.shape === 'arrow-table') t.equal(result.data.numRows, 0);
-  t.end();
+  expect(result.shape).toBe('arrow-table');
+  if (result.shape === 'arrow-table') expect(result.data.numRows).toBe(0);
 });
 
-test('ORCWriter#encode writes an empty ORC file', async t => {
+test('ORCWriter#encode writes an empty ORC file', async () => {
   const output = await ORCWriter.encode({
     shape: 'arrow-table',
     data: arrow.tableFromArrays({id: []})
   });
   const result = parseORC(output);
-  t.equal(result.postscript.compression, 'NONE');
-  t.equal(result.footer.numberOfRows, 0);
-  t.equal(result.footer.typeCount, 2);
-  t.end();
+  expect(result.postscript.compression).toBe('NONE');
+  expect(result.footer.numberOfRows).toBe(0);
+  expect(result.footer.typeCount).toBe(2);
 });
 
-test('ORCWriter#encode round-trips primitive Arrow columns', async t => {
+test('ORCWriter#encode round-trips primitive Arrow columns', async () => {
   const output = await ORCWriter.encode({
     shape: 'arrow-table',
     data: arrow.tableFromArrays({id: [1, 2, 3], name: ['a', 'bb', '']})
   });
   const result = await ORCLoaderWithParser.parse(output);
-  t.equal(result.shape, 'arrow-table');
+  expect(result.shape).toBe('arrow-table');
   if (result.shape === 'arrow-table') {
-    t.deepEqual(result.data.toArray(), [
+    expect(result.data.toArray()).toEqual([
       {id: 1, name: 'a'},
       {id: 2, name: 'bb'},
       {id: 3, name: ''}
     ]);
   }
-  t.end();
 });
 
-test('ORCWriter#encode round-trips null-present columns', async t => {
+test('ORCWriter#encode round-trips null-present columns', async () => {
   const output = await ORCWriter.encode({
     shape: 'arrow-table',
     data: arrow.tableFromArrays({id: [1, null, 3], name: ['a', null, 'c']})
   });
   const result = await ORCLoaderWithParser.parse(output);
-  t.equal(result.shape, 'arrow-table');
+  expect(result.shape).toBe('arrow-table');
   if (result.shape === 'arrow-table')
-    t.deepEqual(result.data.toArray(), [
+    expect(result.data.toArray()).toEqual([
       {id: 1, name: 'a'},
       {id: null, name: null},
       {id: 3, name: 'c'}
     ]);
-  t.end();
 });
 
-test('ORCWriter#encode round-trips multiple stripes', async t => {
+test('ORCWriter#encode round-trips multiple stripes', async () => {
   const output = await ORCWriter.encode(
     {
       shape: 'arrow-table',
@@ -89,19 +84,18 @@ test('ORCWriter#encode round-trips multiple stripes', async t => {
     {orc: {stripeSize: 2}}
   );
   const parsed = parseORC(output);
-  t.equal(parsed.footer.stripeCount, 2);
+  expect(parsed.footer.stripeCount).toBe(2);
   const result = await ORCLoaderWithParser.parse(output);
   if (result.shape === 'arrow-table')
-    t.deepEqual(result.data.toArray(), [
+    expect(result.data.toArray()).toEqual([
       {id: 1, name: 'a'},
       {id: 2, name: 'b'},
       {id: 3, name: 'c'},
       {id: 4, name: 'd'}
     ]);
-  t.end();
 });
 
-test('ORCLoader#parse reads stripe metadata', t => {
+test('ORCLoader#parse reads stripe metadata', () => {
   const stripe = Uint8Array.from([0x08, 0x06, 0x10, 0x02, 0x18, 0x04, 0x20, 0x03, 0x28, 0x0a]);
   const footer = Uint8Array.from([0x1a, stripe.length, ...stripe, 0x30, 0x0a]);
   const postscript = Uint8Array.from([0x08, footer.length, 0x10, 0x00, 0x18, 0x00, 0x20, 0x01]);
@@ -111,13 +105,12 @@ test('ORCLoader#parse reads stripe metadata', t => {
   bytes.set(postscript, 3 + footer.length);
   bytes[bytes.length - 1] = postscript.length;
   const result = parseORC(bytes.buffer);
-  t.equal(result.footer.stripeCount, 1);
-  t.equal(result.footer.stripes[0].offset, 3);
-  t.equal(result.footer.stripes[0].numberOfRows, 10);
-  t.end();
+  expect(result.footer.stripeCount).toBe(1);
+  expect(result.footer.stripes[0].offset).toBe(3);
+  expect(result.footer.stripes[0].numberOfRows).toBe(10);
 });
 
-test('ORCLoader#parse decodes an uncompressed RLEv2 delta integer column', async t => {
+test('ORCLoader#parse decodes an uncompressed RLEv2 delta integer column', async () => {
   const data = Uint8Array.from([0xc0, 0x02, 0x14, 0x04]);
   const stripeFooter = encodeMessage([
     [
@@ -167,13 +160,12 @@ test('ORCLoader#parse decodes an uncompressed RLEv2 delta integer column', async
   bytes[bytes.length - 1] = postscript.length;
 
   const result = await ORCLoaderWithParser.parse(bytes.buffer);
-  t.equal(result.shape, 'arrow-table');
+  expect(result.shape).toBe('arrow-table');
   if (result.shape === 'arrow-table')
-    t.deepEqual(result.data.getChild('id')?.toArray(), new Int32Array([10, 12, 14]));
-  t.end();
+    expect(result.data.getChild('id')?.toArray()).toEqual(new Int32Array([10, 12, 14]));
 });
 
-test('ORCLoader#parse decodes dictionary-encoded string columns', async t => {
+test('ORCLoader#parse decodes dictionary-encoded string columns', async () => {
   const indexes = Uint8Array.from([0x42, 0x02, 0x20]);
   const lengths = Uint8Array.from([0x44, 0x01, 0x50]);
   const dictionary = new TextEncoder().encode('abb');
@@ -249,10 +241,9 @@ test('ORCLoader#parse decodes dictionary-encoded string columns', async t => {
   bytes[bytes.length - 1] = postscript.length;
 
   const result = await ORCLoaderWithParser.parse(bytes.buffer);
-  t.equal(result.shape, 'arrow-table');
+  expect(result.shape).toBe('arrow-table');
   if (result.shape === 'arrow-table')
-    t.deepEqual(result.data.getChild('name')?.toArray(), ['a', 'bb', 'a']);
-  t.end();
+    expect(result.data.getChild('name')?.toArray()).toEqual(['a', 'bb', 'a']);
 });
 
 function concatBytes(...arrays: Uint8Array[]): Uint8Array {


### PR DESCRIPTION
## Goals

- Increase coverage for the high-impact TypeScript LAS parser.
- Continue the Tape-to-Vitest migration for the PDRF 4–10 LAZ/Arrow behavior matrix.
- Keep the existing slow-suite classification and avoid adding runtime-heavy fixtures.

## Changes

- Migrate `modules/las/test/typescript-laz.spec.ts` to native Vitest `test` and `expect` APIs.
- Preserve coverage for complete and split LAZ streaming, PDRF 4–10 attributes, selective Point14 targets, malformed VLR/truncated input, and packaged-worker parity.
- Migrate the stale undiscovered `modules/orc/test/index.ts` entrypoint away from the Tape compatibility shim; the active ORC `*.spec.ts` suite remains unchanged.
- Remove Tape assertion messages and `t.end()` calls without changing production code.

## Validation

- `yarn build`
- `yarn build-workers`
- `yarn test-headless modules/las/test/typescript-laz.spec.ts`
- `yarn test-headless-cover modules/las/test/typescript-laz.spec.ts`
- `yarn test-audit`
- `yarn lint fix`
- `git diff --check`

The focused LAS suite passes all 12 tests. Focused `modules/las/src/lib/typescript/parse-las.ts` coverage is 68.01% statements, 78.43% functions, 66.86% branches, and 68.54% lines. The test audit reports 594 files, 0 Tape files, and 0 violations.