### PR TITLE
fix(3d-tiles): restore content volume culling

### DIFF
--- a/modules/tiles/src/tileset-3d/common/tile-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tile-3d.ts
@@ -6,7 +6,7 @@
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 
 import {Vector3, Matrix4} from '@math.gl/core';
-import {CullingVolume} from '@math.gl/culling';
+import {CullingVolume, INTERSECTION} from '@math.gl/culling';
 
 // Note: circular dependency
 import type {Tileset3D} from './tileset-3d';
@@ -776,47 +776,31 @@ export class Tile3D {
     return cullingVolume.computeVisibilityWithPlaneMask(boundingVolume, parentVisibilityPlaneMask);
   }
 
-  // Assuming the tile's bounding volume intersects the culling volume, determines
-  // whether the tile's content's bounding volume intersects the culling volume.
-  // @param {FrameState} frameState The frame state.
-  // @returns {Intersect} The result of the intersection: the tile's content is completely outside, completely inside, or intersecting the culling volume.
-  contentVisibility() {
-    return true;
-
-    // TODO restore
-    /*
-    // Assumes the tile's bounding volume intersects the culling volume already, so
-    // just return Intersect.INSIDE if there is no content bounding volume.
-    if (!defined(this.contentBoundingVolume)) {
-      return Intersect.INSIDE;
-    }
-
-    if (this._visibilityPlaneMask === CullingVolume.MASK_INSIDE) {
-      // The tile's bounding volume is completely inside the culling volume so
-      // the content bounding volume must also be inside.
-      return Intersect.INSIDE;
-    }
-
-    // PERFORMANCE_IDEA: is it possible to burn less CPU on this test since we know the
-    // tile's (not the content's) bounding volume intersects the culling volume?
-    const cullingVolume = frameState.cullingVolume;
-    const boundingVolume = tile.contentBoundingVolume;
-
-    const tileset = this.tileset;
-    const clippingPlanes = tileset.clippingPlanes;
-    if (defined(clippingPlanes) && clippingPlanes.enabled) {
-      const intersection = clippingPlanes.computeIntersectionWithBoundingVolume(
-        boundingVolume,
-        tileset.clippingPlanesOriginMatrix
-      );
-      this._isClipped = intersection !== Intersect.INSIDE;
-      if (intersection === Intersect.OUTSIDE) {
-        return Intersect.OUTSIDE;
+  /**
+   * Determines whether renderable content intersects the current culling volume.
+   * Traversal continues to use the tile volume; content volumes only constrain rendering.
+   * @param frameState Current camera and culling state.
+   * @returns Content visibility classification.
+   */
+  contentVisibility(frameState: FrameState): number {
+    const contentVolumes = this.contentBoundingVolumes.length
+      ? this.contentBoundingVolumes
+      : [this.boundingVolume];
+    let intersecting = false;
+    for (const contentVolume of contentVolumes) {
+      const visibility =
+        this._visibilityPlaneMask === CullingVolume.MASK_INSIDE
+          ? INTERSECTION.INSIDE
+          : frameState.cullingVolume.computeVisibility(contentVolume);
+      if (visibility === INTERSECTION.OUTSIDE) {
+        continue;
+      }
+      intersecting = intersecting || visibility === INTERSECTION.INTERSECTING;
+      if (!intersecting) {
+        return INTERSECTION.INSIDE;
       }
     }
-
-    return cullingVolume.computeVisibility(boundingVolume);
-    */
+    return intersecting ? INTERSECTION.INTERSECTING : INTERSECTION.OUTSIDE;
   }
 
   /**

--- a/modules/tiles/src/tileset-3d/common/tileset-traverser.ts
+++ b/modules/tiles/src/tileset-3d/common/tileset-traverser.ts
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import type {Tile3D} from './tile-3d';
+import {INTERSECTION} from '@math.gl/culling';
 import {ManagedArray} from '../../utils/managed-array';
 import {TILE_REFINEMENT} from '../../constants';
 import {FrameState} from '../helpers/frame-state';
@@ -230,7 +231,7 @@ export class TilesetTraverser {
 
   // tile to render in the browser
   selectTile(tile: Tile3D, frameState: FrameState): void {
-    if (this.shouldSelectTile(tile)) {
+    if (this.shouldSelectTile(tile, frameState)) {
       // The tile can be selected right away and does not require traverseAndSelect
       tile._selectedFrame = frameState.frameNumber;
       this.selectedTiles[tile.id] = tile;
@@ -294,10 +295,13 @@ export class TilesetTraverser {
     return tile.hasUnloadedContent || tile.contentExpired;
   }
 
-  shouldSelectTile(tile: Tile3D): boolean {
-    // Content availability is the only selection prerequisite. Skip-LOD retains ready ancestors
-    // as fallback coverage, so it must not suppress selection globally.
-    return tile.contentAvailable;
+  /**
+   * Returns whether a tile's content is available and visible for rendering.
+   * @param tile Tile considered for rendering.
+   * @param frameState Current culling state.
+   */
+  shouldSelectTile(tile: Tile3D, frameState: FrameState): boolean {
+    return tile.contentAvailable && tile.contentVisibility(frameState) !== INTERSECTION.OUTSIDE;
   }
 
   /** Decide if tile LoD (level of detail) is not sufficient under current viewport */


### PR DESCRIPTION
## Goals

Restore Cesium-style content bounding-volume culling for 3D Tiles on top of the latest master, without carrying the conflicted branch history from #3790.

## Changes

- Implement `Tile3D.contentVisibility(frameState)` using all transformed content volumes.
- Fall back to the tile bounding volume when content volumes are absent.
- Apply content visibility during tile selection while keeping traversal based on the tile volume.
- Preserve multi-content and viewer-request-volume changes already landed in master.

## Validation

- Rebased cleanly onto current master.
- The previous conflicted PR #3790 is superseded by this branch.
- CI will run the full build and test matrix.