### PR TITLE
feat(i3s): decode typed numeric attributes

### DIFF
--- a/docs/modules/i3s/formats/i3s.md
+++ b/docs/modules/i3s/formats/i3s.md
@@ -132,7 +132,8 @@ those versions.
 | OID32 and UInt32 attributes | **Supported** | v2.3 | Object IDs and common unsigned integer values are decoded. |
 | Float64 attributes | **Supported** | v2.3 | Double-precision attribute values are decoded. |
 | Int16 attributes | **Supported** | v3.1 | Used by tested Building Scene Layer attribute resources. |
-| Other declared scalar types | **Partial** | v2.3 | The generic fallback reads UInt32. Int32, Int64, UInt64, Float32, dates, GUIDs, and null masks do not have complete type-specific decoding. |
+| Typed numeric attributes (UInt8/16/32/64, Int16/32/64, Float32/64) | **Supported** | **v5.0** | Declared numeric types are decoded into matching typed arrays; 64-bit integers use `Float64Array` and are exact through `Number.MAX_SAFE_INTEGER`. |
+| Date, GUID, and null-mask attributes | **Partial** | v2.3 | Date/GUID conversion and explicit null-mask propagation remain open feature-intelligence work. |
 | Coded-value domains | **Supported** | v3.0 | Numeric domain codes are mapped to their display names when loading a selected feature. |
 | Attribute-driven colorization | **Supported** | v3.3 | Numeric attributes can replace or multiply vertex colors through `colorsByAttribute`. |
 | Layer statistics | **Partial** | v2.0 | Statistics metadata passes through; raw SLPK statistics extraction was added in v3.4. There is no typed statistics loader or query API. |
@@ -174,7 +175,7 @@ current v5.0 development line; the remaining tranches close the largest unsuppor
 | 1. Correctness hardening | Make root authentication, node metadata passthrough, UInt64 precision, and WebScene CRS validation match the documented boundaries. | **Complete** |
 | 2. 1.10 mesh parity | Add legacy shared-resource material interpretation and mesh-segmentation preservation, then expand 1.9/1.10 conformance fixtures. | **Complete** |
 | 3. Material fidelity | Load complete PBR texture sets, preserve multiple referenced atlases, and carry sampler wrap semantics into material metadata. | **Complete** |
-| 4. Feature intelligence | Add typed scalar/date/GUID/null-mask attributes, statistics, drawing metadata evaluation, and query APIs. | Planned |
+| 4. Feature intelligence | Add typed scalar/date/GUID/null-mask attributes, statistics, drawing metadata evaluation, and query APIs. | **In progress** (typed numeric attributes complete in v5.0) |
 | 5. Profile coverage | Add Point, then I3S 2.1 Point Cloud (LEPCC and density-based traversal). | Planned |
 | 6. Spatial semantics | Add projected and vertical CRS transforms plus `elevationInfo` placement modes. | Planned |
 

--- a/modules/i3s/src/lib/parsers/parse-i3s-attribute.ts
+++ b/modules/i3s/src/lib/parsers/parse-i3s-attribute.ts
@@ -44,12 +44,100 @@ function parseAttribute(attributeType, arrayBuffer: ArrayBuffer): Attribute {
     case OBJECT_ID_ATTRIBUTE_TYPE:
       return parseShortNumberAttribute(arrayBuffer);
     case FLOAT_64_TYPE:
-      return parseFloatAttribute(arrayBuffer);
+    case 'Float32':
+    case 'UInt8':
+    case 'UInt16':
+    case 'UInt32':
+    case 'UInt64':
     case INT_16_ATTRIBUTE_TYPE:
-      return parseInt16ShortNumberAttribute(arrayBuffer);
+    case 'Int32':
+    case 'Int64':
+      return parseNumericAttribute(attributeType, arrayBuffer);
     default:
       return parseShortNumberAttribute(arrayBuffer);
   }
+}
+
+/**
+ * Parse a fixed-width numeric attribute using its declared I3S value type.
+ * @param attributeType - I3S numeric value type
+ * @param arrayBuffer - encoded attribute payload
+ * @returns decoded numeric values
+ */
+function parseNumericAttribute(attributeType: string, arrayBuffer: ArrayBuffer): TypedArray {
+  const valueOffset =
+    attributeType === 'Float64' || attributeType === 'Int64' || attributeType === 'UInt64' ? 8 : 4;
+
+  if (attributeType === 'UInt64' || attributeType === 'Int64') {
+    return parseInt64Attribute(attributeType, arrayBuffer, valueOffset);
+  }
+
+  const TypedArrayType = getNumericAttributeConstructor(attributeType);
+  const valueCount = Math.floor(
+    (arrayBuffer.byteLength - valueOffset) / TypedArrayType.BYTES_PER_ELEMENT
+  );
+  return new TypedArrayType(arrayBuffer, valueOffset, valueCount);
+}
+
+/**
+ * Resolve the JavaScript typed-array constructor for an I3S numeric value type.
+ * @param attributeType - I3S numeric value type
+ * @returns typed-array constructor
+ */
+function getNumericAttributeConstructor(
+  attributeType: string
+):
+  | Uint8ArrayConstructor
+  | Uint16ArrayConstructor
+  | Uint32ArrayConstructor
+  | Int16ArrayConstructor
+  | Int32ArrayConstructor
+  | Float32ArrayConstructor
+  | Float64ArrayConstructor {
+  switch (attributeType) {
+    case 'UInt8':
+      return Uint8Array;
+    case 'UInt16':
+      return Uint16Array;
+    case 'UInt32':
+      return Uint32Array;
+    case 'Int16':
+      return Int16Array;
+    case 'Int32':
+      return Int32Array;
+    case 'Float32':
+      return Float32Array;
+    case 'Float64':
+      return Float64Array;
+    default:
+      throw new Error(`Unsupported I3S numeric attribute type: ${attributeType}`);
+  }
+}
+
+/**
+ * Decode 64-bit integer attributes into numbers, preserving values within the safe integer range.
+ * @param attributeType - I3S signedness
+ * @param arrayBuffer - encoded attribute payload
+ * @param valueOffset - byte offset of the values
+ * @returns numeric values represented as Float64Array
+ */
+function parseInt64Attribute(
+  attributeType: 'UInt64' | 'Int64',
+  arrayBuffer: ArrayBuffer,
+  valueOffset: number
+): Float64Array {
+  const valueCount = Math.floor((arrayBuffer.byteLength - valueOffset) / 8);
+  const values = new Float64Array(valueCount);
+  const dataView = new DataView(arrayBuffer, valueOffset);
+  for (let index = 0; index < valueCount; index++) {
+    const byteOffset = index * 8;
+    const integerValue =
+      attributeType === 'UInt64'
+        ? dataView.getBigUint64(byteOffset, true)
+        : dataView.getBigInt64(byteOffset, true);
+    values[index] = Number(integerValue);
+  }
+  return values;
 }
 
 /**
@@ -61,28 +149,6 @@ function parseAttribute(attributeType, arrayBuffer: ArrayBuffer): Attribute {
 function parseShortNumberAttribute(arrayBuffer: ArrayBuffer): Uint32Array {
   const countOffset = 4;
   return new Uint32Array(arrayBuffer, countOffset);
-}
-
-/**
- * Parse Int16 short number attribute.
- * Parsing of such data is not documented. Added to handle Building Scene Layer Tileset attributes data.
- * @param  arrayBuffer
- * @returns
- */
-function parseInt16ShortNumberAttribute(arrayBuffer: ArrayBuffer): Int16Array {
-  const countOffset = 4;
-  return new Int16Array(arrayBuffer, countOffset);
-}
-
-/**
- * Parse float attribute.
- * Double Spec - https://github.com/Esri/i3s-spec/blob/master/docs/1.7/attributeStorageInfo.cmn.md
- * @param  arrayBuffer
- * @returns
- */
-function parseFloatAttribute(arrayBuffer: ArrayBuffer): Float64Array {
-  const countOffset = 8;
-  return new Float64Array(arrayBuffer, countOffset);
 }
 
 /**

--- a/modules/i3s/test/i3s-conformance.spec.ts
+++ b/modules/i3s/test/i3s-conformance.spec.ts
@@ -7,6 +7,7 @@ import {I3SNodePageLoader} from '@loaders.gl/i3s';
 import {I3SSceneLayerSchema} from '@loaders.gl/i3s/i3s-zod-schema';
 import {describe, expect, it} from 'vitest';
 import {parseSLPKArchive} from '../src/lib/parsers/parse-slpk/parse-slpk';
+import {parseI3STileAttribute} from '../src/lib/parsers/parse-i3s-attribute';
 import {parseI3STileContent, parseUint64Values} from '../src/lib/parsers/parse-i3s-tile-content';
 import {getLegacyMaterialDefinition, normalizeTileData} from '../src/lib/parsers/parse-i3s';
 import {createReadableFileFromBuffer} from 'test/utils/readable-files';
@@ -67,6 +68,39 @@ describe('I3S conformance fixtures', () => {
     expect(values).toBeInstanceOf(Float64Array);
     expect(values[0]).toBe(0x1_89abcdef);
     expect(values[1]).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  it('decodes declared numeric feature attribute types', () => {
+    const int32Buffer = new ArrayBuffer(12);
+    const int32View = new DataView(int32Buffer);
+    int32View.setInt32(4, -7, true);
+    int32View.setInt32(8, 42, true);
+    const int32 = parseI3STileAttribute(int32Buffer, {
+      attributeName: 'LEVEL',
+      attributeType: 'Int32'
+    }).LEVEL;
+
+    const float32Buffer = new ArrayBuffer(12);
+    const float32View = new DataView(float32Buffer);
+    float32View.setFloat32(4, 1.5, true);
+    float32View.setFloat32(8, -2.25, true);
+    const float32 = parseI3STileAttribute(float32Buffer, {
+      attributeName: 'HEIGHT',
+      attributeType: 'Float32'
+    }).HEIGHT;
+
+    const uint64Buffer = new ArrayBuffer(24);
+    const uint64View = new DataView(uint64Buffer);
+    uint64View.setBigUint64(8, 0x1_0000_0001n, true);
+    uint64View.setBigUint64(16, 0x1_ffff_ffff_ffff_ffn, true);
+    const uint64 = parseI3STileAttribute(uint64Buffer, {
+      attributeName: 'GLOBAL_ID',
+      attributeType: 'UInt64'
+    }).GLOBAL_ID;
+
+    expect(Array.from(int32 as Int32Array)).toEqual([-7, 42]);
+    expect(Array.from(float32 as Float32Array)).toEqual([1.5, -2.25]);
+    expect(Array.from(uint64 as Float64Array)).toEqual([0x1_0000_0001, 0x1_ffff_ffff_ffff_ff]);
   });
 
   it('preserves UInt64 feature IDs through face-range expansion', async () => {


### PR DESCRIPTION
## Goals

- Start tranche 4 (feature intelligence) by making declared numeric attribute types decode correctly.
- Keep the I3S support matrix accurate about what loaders.gl supports in the v5.0 development line.

## Changes

- Decode UInt8/UInt16/UInt32/UInt64, Int16/Int32/Int64, and Float32/Float64 attribute payloads using their declared types.
- Decode 64-bit integer attributes into `Float64Array`, preserving values exactly through `Number.MAX_SAFE_INTEGER`.
- Add native Vitest conformance coverage for signed 32-bit, 32-bit float, and unsigned 64-bit attributes.
- Update the I3S feature table and roadmap to mark typed numeric attributes complete while leaving dates, GUIDs, null masks, statistics, drawing evaluation, and query APIs as remaining tranche-4 work.

## Validation

- `node node_modules/typescript/bin/tsc -p modules/i3s/tsconfig.json --noEmit`
- `yarn lint fix`
- `yarn test-headless modules/i3s/test/i3s-conformance.spec.ts` (11 passed)
- `yarn test-headless modules/i3s/test/i3s-attribute-loader.spec.ts` (17 passed)

Depends on #3808 (material fidelity).
