### PR TITLE
test(mlt): expand coverage and migrate source tests

### DIFF
--- a/modules/mlt/test/mlt-source.spec.ts
+++ b/modules/mlt/test/mlt-source.spec.ts
@@ -2,61 +2,102 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import type {Feature} from '@loaders.gl/schema';
 
 import {MLTSourceLoader} from '@loaders.gl/mlt';
 import {MLTLoaderWithParser as MLTLoader} from '../src/mlt-loader-with-parser';
 import {getURLFromTemplate} from '../src/mlt-source-loader';
 
-test('MLTSourceLoader#testURL', t => {
-  t.true(MLTSourceLoader.testURL('https://server/{z}/{x}/{y}.mlt'));
-  t.true(MLTSourceLoader.testURL('https://server/{z}/{x}/{-y}.mlt'));
-  t.true(MLTSourceLoader.testURL('https://server/tiles-mlt/plain'));
-  t.true(MLTSourceLoader.testURL('https://server/tiles.mlt'));
-  t.end();
+test('MLTSourceLoader#testURL', () => {
+  expect(MLTSourceLoader.testURL('https://server/{z}/{x}/{y}.mlt')).toBe(true);
+  expect(MLTSourceLoader.testURL('https://server/{z}/{x}/{-y}.mlt')).toBe(true);
+  expect(MLTSourceLoader.testURL('https://server/tiles-mlt/plain')).toBe(true);
+  expect(MLTSourceLoader.testURL('https://server/tiles.mlt')).toBe(true);
+  expect(MLTSourceLoader.testURL('https://server/tiles.json')).toBe(false);
 });
 
-test('MLTSourceLoader#getURLFromTemplate', t => {
-  t.is(
-    getURLFromTemplate('https://server/{z}/{x}/{y}', 1, 2, 3, '.mlt'),
+test('MLTSourceLoader#getURLFromTemplate', () => {
+  expect(getURLFromTemplate('https://server/{z}/{x}/{y}', 1, 2, 3, '.mlt')).toBe(
     'https://server/3/1/2.mlt'
   );
-  t.is(
-    getURLFromTemplate('https://server/{z}/{x}/{y}.mlt', 1, 2, 3, ''),
+  expect(getURLFromTemplate('https://server/{z}/{x}/{y}.mlt', 1, 2, 3, '')).toBe(
     'https://server/3/1/2.mlt'
   );
-  t.is(
-    getURLFromTemplate('https://server/{z}/{x}/{y}', 1, 2, 3, '.mvt'),
+  expect(getURLFromTemplate('https://server/{z}/{x}/{y}', 1, 2, 3, '.mvt')).toBe(
     'https://server/3/1/2.mvt'
   );
-  t.is(getURLFromTemplate('https://server/{z}/{x}/{y}.mvt', 1, 2, 3), 'https://server/3/1/2.mvt');
-  t.is(
-    getURLFromTemplate('https://server/{z}/{x}/{y}.mvt', 1, 2, 3, '.mlt'),
+  expect(getURLFromTemplate('https://server/{z}/{x}/{y}.mvt', 1, 2, 3)).toBe(
     'https://server/3/1/2.mvt'
   );
-  t.end();
+  expect(getURLFromTemplate('https://server/{z}/{x}/{y}.mvt', 1, 2, 3, '.mlt')).toBe(
+    'https://server/3/1/2.mvt'
+  );
 });
 
-test('MLTTileSource#getTileURL', t => {
+test('MLTTileSource#getTileURL', () => {
   const tmsSource = MLTSourceLoader.createDataSource('https://example.com/tiles', {});
-  t.equal(tmsSource.getTileURL(1, 2, 3), 'https://example.com/tiles/3/1/2.mlt');
+  expect(tmsSource.getTileURL(1, 2, 3)).toBe('https://example.com/tiles/3/1/2.mlt');
 
   const templateSource = MLTSourceLoader.createDataSource('https://example.com/tiles/{z}/{x}/{y}', {
     mlt: {extension: '.mvt'}
   });
-  t.equal(templateSource.getTileURL(1, 2, 3), 'https://example.com/tiles/3/1/2.mvt');
+  expect(templateSource.getTileURL(1, 2, 3)).toBe('https://example.com/tiles/3/1/2.mvt');
 
   const templateSourceWithExt = MLTSourceLoader.createDataSource(
     'https://example.com/tiles/{z}/{x}/{y}',
     {mlt: {extension: '.mvt'}}
   );
-  t.equal(templateSourceWithExt.getTileURL(1, 2, 3), 'https://example.com/tiles/3/1/2.mvt');
-
-  t.end();
+  expect(templateSourceWithExt.getTileURL(1, 2, 3)).toBe('https://example.com/tiles/3/1/2.mvt');
 });
 
-test('MLTTileSource#getTileData returns Feature[] by default', async t => {
+test('MLTTileSource#getSchema and default metadata', async () => {
+  const source = MLTSourceLoader.createDataSource('https://example.com/tiles', {
+    core: {attributions: ['base']}
+  });
+
+  expect(await source.getSchema()).toEqual({fields: [], metadata: {}});
+  expect(await source.getMetadata()).toEqual({minZoom: 0, maxZoom: 30, attributions: ['base']});
+});
+
+test('MLTTileSource#reads metadata with both zoom key styles', async () => {
+  const source = MLTSourceLoader.createDataSource('https://example.com/tiles', {
+    core: {attributions: ['base']},
+    mlt: {metadataUrl: 'data:application/json,%7B%7D'}
+  });
+  source.fetch = async () =>
+    new Response(JSON.stringify({minzoom: 2, maxZoom: 12, attributions: ['server'], name: 'demo'}));
+
+  await expect(source.getMetadata()).resolves.toEqual({
+    minzoom: 2,
+    maxZoom: 12,
+    minZoom: 2,
+    attributions: ['base', 'server'],
+    name: 'demo'
+  });
+});
+
+test('MLTTileSource#falls back when metadata fetch or JSON parsing fails', async () => {
+  const source = MLTSourceLoader.createDataSource('https://example.com/tiles', {
+    mlt: {metadataUrl: 'data:application/json,%7B%7D'}
+  });
+  source.fetch = async () => new Response('missing', {status: 404, statusText: 'Not Found'});
+  await expect(source.getMetadata()).resolves.toEqual({minZoom: 0, maxZoom: 30, attributions: []});
+
+  source.fetch = async () => new Response('{');
+  await expect(source.getMetadata()).resolves.toEqual({minZoom: 0, maxZoom: 30, attributions: []});
+});
+
+test('MLTTileSource#getTile returns data or null for HTTP responses', async () => {
+  const source = MLTSourceLoader.createDataSource('https://example.com/tiles', {});
+  source.fetch = async () => new Response(new Uint8Array([1, 2, 3]));
+  expect(await source.getTile({x: 1, y: 2, z: 3})).toEqual(new Uint8Array([1, 2, 3]).buffer);
+
+  source.fetch = async () => new Response('missing', {status: 404, statusText: 'Not Found'});
+  expect(await source.getTile({x: 1, y: 2, z: 3})).toBeNull();
+});
+
+test('MLTTileSource#getTileData returns Feature[] by default', async () => {
   const feature = {
     type: 'Feature',
     geometry: {type: 'Point', coordinates: [0, 0]},
@@ -79,17 +120,17 @@ test('MLTTileSource#getTileData returns Feature[] by default', async t => {
       id: '1/2/3',
       bbox: {west: 0, north: 0, east: 0, south: 0}
     });
-    t.equal((parseOptions.options as {mlt?: {shape?: string}})?.mlt?.shape, 'geojson-table');
-    t.equal((parseOptions.options as {mlt?: {coordinates?: string}})?.mlt?.coordinates, 'wgs84');
-    t.deepEqual(tile, [feature]);
+    expect((parseOptions.options as {mlt?: {shape?: string}})?.mlt?.shape).toBe('geojson-table');
+    expect((parseOptions.options as {mlt?: {coordinates?: string}})?.mlt?.coordinates).toBe(
+      'wgs84'
+    );
+    expect(tile).toEqual([feature]);
   } finally {
     MLTLoader.parse = originalParse;
   }
-
-  t.end();
 });
 
-test('MLTTileSource#supports table shape by converting to Feature[]', async t => {
+test('MLTTileSource#supports table shape by converting to Feature[]', async () => {
   const feature = {
     type: 'Feature',
     geometry: {type: 'Point', coordinates: [1, 2]},
@@ -113,15 +154,13 @@ test('MLTTileSource#supports table shape by converting to Feature[]', async t =>
       id: '1/2/3',
       bbox: {west: 0, north: 0, east: 0, south: 0}
     });
-    t.deepEqual(tile, [feature]);
+    expect(tile).toEqual([feature]);
   } finally {
     MLTLoader.parse = originalParse;
   }
-
-  t.end();
 });
 
-test('MLTTileSource#supports Arrow table shape', async t => {
+test('MLTTileSource#supports Arrow table shape', async () => {
   const originalParse = MLTLoader.parse;
   MLTLoader.parse = (async () => ({
     shape: 'arrow-table',
@@ -139,10 +178,8 @@ test('MLTTileSource#supports Arrow table shape', async t => {
       id: '1/2/3',
       bbox: {west: 0, north: 0, east: 0, south: 0}
     });
-    t.equal((tile as {shape?: string})?.shape, 'arrow-table');
+    expect((tile as {shape?: string})?.shape).toBe('arrow-table');
   } finally {
     MLTLoader.parse = originalParse;
   }
-
-  t.end();
 });

--- a/modules/mlt/test/parse-mlt.spec.ts
+++ b/modules/mlt/test/parse-mlt.spec.ts
@@ -122,4 +122,23 @@ describe('parseMLT', () => {
       'require a tileIndex'
     );
   });
+
+  test('ignores malformed tables, features, points, and geometry types', () => {
+    decodeTileMock.mockReturnValue({
+      malformed: null,
+      invalid: {
+        name: 'invalid',
+        features: [
+          {geometry: {type: 0, coordinates: [[]]}},
+          {geometry: {type: 99, coordinates: []}}
+        ]
+      },
+      empty: {name: 'empty', features: []},
+      notAFeatureTable: {name: 'not-a-table'}
+    } as any);
+
+    const result = parseMLT(new Uint8Array([1]).buffer) as any;
+
+    expect(result.features).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Goals

- Raise coverage for the low-baseline MLT package with first-party boundary tests.
- Continue the migration from the Tape compatibility shim to native Vitest.
- Keep the added cases fast, deterministic, and hermetic.

## Changes

- Migrate `modules/mlt/test/mlt-source.spec.ts` to native Vitest `test` and `expect` APIs.
- Add MLT source coverage for URL detection, metadata defaults and parsing, metadata failures, schema access, tile fetch success/failure, and existing output-shape paths.
- Add parser boundary coverage for malformed feature tables, missing geometry, invalid points, and unsupported geometry types.
- Make no production-code changes.

## Validation

- `yarn lint fix`
- `yarn test-headless modules/mlt/test/parse-mlt.spec.ts modules/mlt/test/mlt-loader.spec.ts modules/mlt/test/mlt-source.spec.ts`
- `yarn test-headless-cover modules/mlt/test/parse-mlt.spec.ts modules/mlt/test/mlt-loader.spec.ts modules/mlt/test/mlt-source.spec.ts`
- `yarn test-audit`
- `git diff --check`

The focused suite passes all 20 tests. Focused MLT source coverage is 92.4% statements and 93.58% lines; `parse-mlt.ts` is 95.41% statements. The test audit reports 594 files, 0 Tape files, and 0 violations.