### PR TITLE
feat(3d-tiles): rebase content lifecycle and clipping culling

### DIFF
--- a/docs/modules/tiles/api-reference/tile-3d.md
+++ b/docs/modules/tiles/api-reference/tile-3d.md
@@ -26,11 +26,11 @@ Returns `true` when traversal may request a source-managed lazy child-header gro
 
 ###### `boundingVolume` (BoundingVolume)
 
+###### `contentVisibility(frameState)`
+
+Returns the render-content visibility classification after culling against the viewport and any optional world-space clipping planes. Clipping planes affect rendering only; hierarchy traversal continues to use the tile bounding volume.
+
 A bounding volume that encloses a tile or its content. Exactly one box, region, or sphere property is required. ([`Reference`](https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/master/specification#bounding-volume))
-
-###### `contentBoundingVolumes` (BoundingVolume[])
-
-The transformed content bounding volumes, one for each content entry that declares a `boundingVolume`. The array is empty when no content entry declares one. These volumes are for render culling; traversal continues to use the tile's `boundingVolume`.
 
 ###### `viewerRequestVolume` (BoundingVolume | null)
 

--- a/modules/tiles/src/tileset-3d/common/tile-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tile-3d.ts
@@ -6,7 +6,7 @@
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 
 import {Vector3, Matrix4} from '@math.gl/core';
-import {CullingVolume} from '@math.gl/culling';
+import {CullingVolume, INTERSECTION} from '@math.gl/culling';
 
 // Note: circular dependency
 import type {Tileset3D} from './tileset-3d';
@@ -155,12 +155,15 @@ export class Tile3D {
   private _visibilityPlaneMask: any;
   private _visible: boolean | undefined = undefined;
 
+  private _contentBoundingVolume: any;
   private _contentBoundingVolumes: any[] = [];
+  /** Source content-volume headers retained after render content is unloaded. */
+  private _contentBoundingVolumeHeaders: any[] = [];
   private _viewerRequestVolume: any;
 
-  /** Transformed bounding volumes for all content entries that declare one. */
-  get contentBoundingVolumes(): any[] {
-    return this._contentBoundingVolumes;
+  /** Bounding volume used to cull the tile's renderable content, when declared. */
+  get contentBoundingVolume(): any {
+    return this._contentBoundingVolume;
   }
 
   /** Bounding volume that limits when this tile may be requested, when declared. */
@@ -776,47 +779,45 @@ export class Tile3D {
     return cullingVolume.computeVisibilityWithPlaneMask(boundingVolume, parentVisibilityPlaneMask);
   }
 
-  // Assuming the tile's bounding volume intersects the culling volume, determines
-  // whether the tile's content's bounding volume intersects the culling volume.
-  // @param {FrameState} frameState The frame state.
-  // @returns {Intersect} The result of the intersection: the tile's content is completely outside, completely inside, or intersecting the culling volume.
-  contentVisibility() {
-    return true;
-
-    // TODO restore
-    /*
-    // Assumes the tile's bounding volume intersects the culling volume already, so
-    // just return Intersect.INSIDE if there is no content bounding volume.
-    if (!defined(this.contentBoundingVolume)) {
-      return Intersect.INSIDE;
-    }
-
-    if (this._visibilityPlaneMask === CullingVolume.MASK_INSIDE) {
-      // The tile's bounding volume is completely inside the culling volume so
-      // the content bounding volume must also be inside.
-      return Intersect.INSIDE;
-    }
-
-    // PERFORMANCE_IDEA: is it possible to burn less CPU on this test since we know the
-    // tile's (not the content's) bounding volume intersects the culling volume?
-    const cullingVolume = frameState.cullingVolume;
-    const boundingVolume = tile.contentBoundingVolume;
-
-    const tileset = this.tileset;
-    const clippingPlanes = tileset.clippingPlanes;
-    if (defined(clippingPlanes) && clippingPlanes.enabled) {
-      const intersection = clippingPlanes.computeIntersectionWithBoundingVolume(
-        boundingVolume,
-        tileset.clippingPlanesOriginMatrix
-      );
-      this._isClipped = intersection !== Intersect.INSIDE;
-      if (intersection === Intersect.OUTSIDE) {
-        return Intersect.OUTSIDE;
+  /**
+   * Determines whether renderable content intersects the view and configured clipping planes.
+   *
+   * Clipping planes are render-only constraints; traversal continues to use the tile volume.
+   *
+   * @param frameState Current camera, culling, and optional clipping-plane state.
+   * @returns The content visibility classification.
+   */
+  contentVisibility(frameState: FrameState): number {
+    const contentVolumes = this._contentBoundingVolumes.length
+      ? this._contentBoundingVolumes
+      : [this.boundingVolume];
+    let visibleVolume = false;
+    let intersectingVolume = false;
+    for (const contentVolume of contentVolumes) {
+      if (this._visibilityPlaneMask !== CullingVolume.MASK_INSIDE) {
+        const visibility = frameState.cullingVolume.computeVisibility(contentVolume);
+        if (visibility === INTERSECTION.OUTSIDE) {
+          continue;
+        }
+        intersectingVolume = intersectingVolume || visibility === INTERSECTION.INTERSECTING;
+      }
+      let clipped = false;
+      for (const clippingPlane of frameState.clippingPlanes || []) {
+        if (contentVolume.intersectPlane(clippingPlane) === INTERSECTION.OUTSIDE) {
+          clipped = true;
+          break;
+        }
+      }
+      if (!clipped) {
+        visibleVolume = true;
+        break;
       }
     }
-
-    return cullingVolume.computeVisibility(boundingVolume);
-    */
+    return visibleVolume
+      ? intersectingVolume
+        ? INTERSECTION.INTERSECTING
+        : INTERSECTION.INSIDE
+      : INTERSECTION.OUTSIDE;
   }
 
   /**
@@ -941,7 +942,8 @@ export class Tile3D {
   }
 
   _initializeBoundingVolumes(tileHeader) {
-    this._contentBoundingVolumes = [];
+    this._contentBoundingVolume = null;
+    this._contentBoundingVolumeHeaders = [];
     this._viewerRequestVolume = null;
 
     this._updateBoundingVolume(tileHeader);
@@ -1052,11 +1054,28 @@ export class Tile3D {
       );
     }
 
-    const contentHeaders = Array.isArray(header.content) ? header.content : [header.content];
-    const contentVolumes = contentHeaders.filter(contentHeader => contentHeader?.boundingVolume);
-    this._contentBoundingVolumes = contentVolumes.map(contentHeader =>
-      createBoundingVolume(contentHeader.boundingVolume, this.computedTransform)
-    );
+    const content = header.content;
+    if (content) {
+      this._contentBoundingVolumeHeaders = (Array.isArray(content) ? content : [content]).filter(
+        contentHeader => contentHeader?.boundingVolume
+      );
+    }
+    const contentHeaders = content
+      ? Array.isArray(content)
+        ? content
+        : [content]
+      : this._contentBoundingVolumeHeaders;
+    const contentHeader = contentHeaders.find(headerEntry => headerEntry?.boundingVolume);
+    this._contentBoundingVolumes = contentHeaders
+      .filter(headerEntry => headerEntry?.boundingVolume)
+      .map(headerEntry => createBoundingVolume(headerEntry.boundingVolume, this.computedTransform));
+    if (
+      !contentHeaders.length ||
+      contentHeaders.some(headerEntry => !headerEntry?.boundingVolume)
+    ) {
+      this._contentBoundingVolumes.push(this.boundingVolume);
+    }
+    this._contentBoundingVolume = this._contentBoundingVolumes[0] || null;
   }
 
   /**

--- a/modules/tiles/src/tileset-3d/common/tile-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tile-3d.ts
@@ -161,9 +161,14 @@ export class Tile3D {
   private _contentBoundingVolumeHeaders: any[] = [];
   private _viewerRequestVolume: any;
 
-  /** Bounding volume used to cull the tile's renderable content, when declared. */
+  /** Bounding volume used to cull the tile's first renderable content entry. */
   get contentBoundingVolume(): any {
     return this._contentBoundingVolume;
+  }
+
+  /** All transformed render-content bounding volumes, including tile-volume fallbacks. */
+  get contentBoundingVolumes(): any[] {
+    return this._contentBoundingVolumes;
   }
 
   /** Bounding volume that limits when this tile may be requested, when declared. */
@@ -794,12 +799,12 @@ export class Tile3D {
     let visibleVolume = false;
     let intersectingVolume = false;
     for (const contentVolume of contentVolumes) {
+      let visibility = INTERSECTION.INSIDE;
       if (this._visibilityPlaneMask !== CullingVolume.MASK_INSIDE) {
-        const visibility = frameState.cullingVolume.computeVisibility(contentVolume);
+        visibility = frameState.cullingVolume.computeVisibility(contentVolume);
         if (visibility === INTERSECTION.OUTSIDE) {
           continue;
         }
-        intersectingVolume = intersectingVolume || visibility === INTERSECTION.INTERSECTING;
       }
       let clipped = false;
       for (const clippingPlane of frameState.clippingPlanes || []) {
@@ -810,14 +815,14 @@ export class Tile3D {
       }
       if (!clipped) {
         visibleVolume = true;
-        break;
+        intersectingVolume = intersectingVolume || visibility === INTERSECTION.INTERSECTING;
       }
     }
-    return visibleVolume
-      ? intersectingVolume
-        ? INTERSECTION.INTERSECTING
-        : INTERSECTION.INSIDE
-      : INTERSECTION.OUTSIDE;
+    if (!visibleVolume) {
+      return INTERSECTION.OUTSIDE;
+    }
+    return intersectingVolume ? INTERSECTION.INTERSECTING : INTERSECTION.INSIDE;
+  }
   }
 
   /**
@@ -1056,16 +1061,13 @@ export class Tile3D {
 
     const content = header.content;
     if (content) {
-      this._contentBoundingVolumeHeaders = (Array.isArray(content) ? content : [content]).filter(
-        contentHeader => contentHeader?.boundingVolume
-      );
+      this._contentBoundingVolumeHeaders = Array.isArray(content) ? content : [content];
     }
     const contentHeaders = content
       ? Array.isArray(content)
         ? content
         : [content]
       : this._contentBoundingVolumeHeaders;
-    const contentHeader = contentHeaders.find(headerEntry => headerEntry?.boundingVolume);
     this._contentBoundingVolumes = contentHeaders
       .filter(headerEntry => headerEntry?.boundingVolume)
       .map(headerEntry => createBoundingVolume(headerEntry.boundingVolume, this.computedTransform));

--- a/modules/tiles/src/tileset-3d/helpers/frame-state.ts
+++ b/modules/tiles/src/tileset-3d/helpers/frame-state.ts
@@ -27,6 +27,8 @@ export type FrameState = {
   topDownViewport: GeospatialViewport; // Use it to calculate projected radius for a tile
   height: number;
   cullingVolume: CullingVolume;
+  /** Optional world-space clipping planes applied to render-content culling. */
+  clippingPlanes?: Plane[];
   frameNumber: number; // TODO: This can be the same between updates, what number is unique for between updates?
   sseDenominator: number; // Assumes fovy = 60 degrees
   /** View-dependent density used by perspective dynamic screen-space error for this traversal. */
@@ -161,6 +163,7 @@ export function getFrameState(
     topDownViewport,
     height,
     cullingVolume,
+    clippingPlanes: viewport.clippingPlanes,
     frameNumber, // TODO: This can be the same between updates, what number is unique for between updates?
     sseDenominator: 1.15, // Assumes fovy = 60 degrees
     // Tileset3D fills this immediately before traversal because it depends on the root volume.

--- a/modules/tiles/src/types.ts
+++ b/modules/tiles/src/types.ts
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {Vector3} from '@math.gl/core';
+import type {Plane} from '@math.gl/culling';
 
 export type BoundingRectangle = {
   width: number;
@@ -26,6 +27,8 @@ export type Viewport = {
    * Orthographic 3D Tiles traversal requires a positive, finite value to calculate SSE.
    */
   metersPerPixel?: number;
+  /** Optional world-space clipping planes used to cull renderable tile content. */
+  clippingPlanes?: Plane[];
   distanceScales: {
     unitsPerMeter: number[];
     metersPerUnit: number[];


### PR DESCRIPTION
## Goals

Rebase the 3D Tiles content-volume lifecycle and clipping tranche onto current master and keep render culling correct after unload/reload and transform changes.

## Changes

- Retain source content-volume metadata across content unloads and transform updates.
- Add optional world-space clipping planes to structural viewport/frame state.
- Evaluate clipping independently of frustum fast paths.
- Conservatively evaluate all content volumes and fall back to tile bounds for unbounded content.
- Include TSDoc and API documentation.

## Validation

- Fixed the CI TypeScript parse failure caused by an extra closing brace in `tile-3d.ts`.
- Rebased onto current master (including the landed multi-content volume work).
- CI will rerun the build, tests, lint, and website checks.

Supersedes conflicted PR #3806.