### PR TITLE
test(flatgeobuf): migrate loader suites to Vitest

### DIFF
--- a/modules/flatgeobuf/test/flatgeobuf-loader.spec.ts
+++ b/modules/flatgeobuf/test/flatgeobuf-loader.spec.ts
@@ -4,12 +4,11 @@
 
 /* eslint-disable camelcase */
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {validateLoader} from 'test/common/conformance';
 import {FlatGeobufLoader} from '@loaders.gl/flatgeobuf';
 import {setLoaderOptions, load, loadInBatches} from '@loaders.gl/core';
 import {convertGeoArrowToTable, getGeoMetadata} from '@loaders.gl/geoarrow';
-
 const FLATGEOBUF_COUNTRIES_DATA_URL = '@loaders.gl/flatgeobuf/test/data/countries.fgb';
 const FGB_METADATA = {
   metadata: {
@@ -53,30 +52,21 @@ const FGB_METADATA = {
     }
   ]
 };
-
 setLoaderOptions({
   _workerType: 'test'
 });
-
-test('FlatGeobufLoader#loader conformance', t => {
-  validateLoader(t, FlatGeobufLoader, 'FlatGeobufLoader');
-  t.end();
+test('FlatGeobufLoader#loader conformance', () => {
+  validateLoader(FlatGeobufLoader, 'FlatGeobufLoader');
 });
-
-test('FlatGeobufLoader#load', async t => {
+test('FlatGeobufLoader#load', async () => {
   const geojsonTable = await load(FLATGEOBUF_COUNTRIES_DATA_URL, FlatGeobufLoader, {
     core: {worker: false}
   });
-  t.equal(geojsonTable.features.length, 179);
-  t.equal(geojsonTable.schema.fields.length, 2);
-  t.deepEqual(
-    geojsonTable.schema.fields.map(field => field.name),
-    ['id', 'name']
-  );
-  t.end();
+  expect(geojsonTable.features.length).toBe(179);
+  expect(geojsonTable.schema.fields.length).toBe(2);
+  expect(geojsonTable.schema.fields.map(field => field.name)).toEqual(['id', 'name']);
 });
-
-test('FlatGeobufLoader#load arrow-table round-trips to GeoJSON', async t => {
+test('FlatGeobufLoader#load arrow-table round-trips to GeoJSON', async () => {
   const arrowTable = await load(FLATGEOBUF_COUNTRIES_DATA_URL, FlatGeobufLoader, {
     core: {worker: false},
     flatgeobuf: {shape: 'arrow-table'}
@@ -84,41 +74,32 @@ test('FlatGeobufLoader#load arrow-table round-trips to GeoJSON', async t => {
   const geojsonTable = await load(FLATGEOBUF_COUNTRIES_DATA_URL, FlatGeobufLoader, {
     core: {worker: false}
   });
-
-  t.equal(arrowTable.shape, 'arrow-table', 'returns Arrow table shape');
-  t.equal(arrowTable.data.numRows, geojsonTable.features.length, 'preserves row count');
-  t.equal(arrowTable.schema.fields.length, 3, 'adds a geometry field');
-  t.equal(arrowTable.schema.fields[2].name, 'geometry', 'geometry field appended');
-  t.equal(arrowTable.schema.fields[2].type.type, 'list', 'geometry field is a nested Arrow list');
-  t.equal(
+  expect(arrowTable.shape, 'returns Arrow table shape').toBe('arrow-table');
+  expect(arrowTable.data.numRows, 'preserves row count').toBe(geojsonTable.features.length);
+  expect(arrowTable.schema.fields.length, 'adds a geometry field').toBe(3);
+  expect(arrowTable.schema.fields[2].name, 'geometry field appended').toBe('geometry');
+  expect(arrowTable.schema.fields[2].type.type, 'geometry field is a nested Arrow list').toBe(
+    'list'
+  );
+  expect(
     arrowTable.schema.fields[2].metadata?.['ARROW:extension:name'],
-    'geoarrow.multipolygon',
     'geometry field includes native GeoArrow metadata'
-  );
-
+  ).toBe('geoarrow.multipolygon');
   const geoMetadata = getGeoMetadata(arrowTable.schema.metadata);
-  t.equal(geoMetadata?.primary_column, 'geometry', 'geo metadata primary column is set');
-  t.equal(
-    geoMetadata?.columns.geometry.encoding,
-    'multipolygon',
-    'geo metadata uses native encoding'
+  expect(geoMetadata?.primary_column, 'geo metadata primary column is set').toBe('geometry');
+  expect(geoMetadata?.columns.geometry.encoding, 'geo metadata uses native encoding').toBe(
+    'multipolygon'
   );
-  t.deepEqual(
+  expect(
     geoMetadata?.columns.geometry.geometry_types,
-    ['MultiPolygon'],
     'geo metadata captures FlatGeobuf geometry type'
-  );
-
+  ).toEqual(['MultiPolygon']);
   const roundTripped = convertGeoArrowToTable(arrowTable.data, 'geojson-table');
-  t.deepEqual(
-    normalizeFeatures(roundTripped.features),
-    normalizeFeatures(geojsonTable.features),
-    'Arrow output round-trips to GeoJSON'
+  expect(normalizeFeatures(roundTripped.features), 'Arrow output round-trips to GeoJSON').toEqual(
+    normalizeFeatures(geojsonTable.features)
   );
-  t.end();
 });
-
-test('FlatGeobufLoader#load arrow-table reprojects like geojson-table', async t => {
+test('FlatGeobufLoader#load arrow-table reprojects like geojson-table', async () => {
   const arrowTable = await load(FLATGEOBUF_COUNTRIES_DATA_URL, FlatGeobufLoader, {
     core: {worker: false},
     flatgeobuf: {shape: 'arrow-table'},
@@ -128,63 +109,45 @@ test('FlatGeobufLoader#load arrow-table reprojects like geojson-table', async t 
     core: {worker: false},
     gis: {reproject: true, _targetCrs: 'EPSG:3857'}
   });
-
   const roundTripped = convertGeoArrowToTable(arrowTable.data, 'geojson-table');
-
-  t.deepEqual(
+  expect(
     normalizeFeatures(roundTripped.features),
-    normalizeFeatures(geojsonTable.features),
     'reprojected Arrow output matches GeoJSON output'
-  );
-  t.end();
+  ).toEqual(normalizeFeatures(geojsonTable.features));
 });
-
-test('FlatGeobufLoader#loadInBatches', async t => {
+test('FlatGeobufLoader#loadInBatches', async () => {
   const iterator = await loadInBatches(FLATGEOBUF_COUNTRIES_DATA_URL, FlatGeobufLoader, {
     core: {worker: false}
   });
-  t.ok(iterator);
-
+  expect(iterator).toBeTruthy();
   const features: any[] = [];
   for await (const feature of iterator) {
     features.push(feature);
   }
-
-  // t.equal(features.length, 179);
-  t.ok(features.length);
-  t.end();
+  expect(features.length).toBeTruthy();
 });
-
-test('FlatGeobufLoader#loadInBatches arrow-table yields stable schema', async t => {
+test('FlatGeobufLoader#loadInBatches arrow-table yields stable schema', async () => {
   const iterator = await loadInBatches(FLATGEOBUF_COUNTRIES_DATA_URL, FlatGeobufLoader, {
     core: {worker: false},
     flatgeobuf: {shape: 'arrow-table'}
   });
-
   let arrowTable = null;
   let schema = null;
-
   for await (const batch of iterator) {
     schema ||= batch.schema;
-    t.deepEqual(batch.schema, schema, 'batch schema remains stable');
+    expect(batch.schema, 'batch schema remains stable').toEqual(schema);
     arrowTable = batch;
   }
-
-  t.ok(schema, 'Arrow batches expose schema');
-
+  expect(schema, 'Arrow batches expose schema').toBeTruthy();
   const roundTripped = convertGeoArrowToTable(arrowTable.data, 'geojson-table');
   const geojsonTable = await load(FLATGEOBUF_COUNTRIES_DATA_URL, FlatGeobufLoader, {
     core: {worker: false}
   });
-
-  t.deepEqual(
+  expect(
     normalizeFeatures(roundTripped.features),
-    normalizeFeatures(geojsonTable.features),
     'batched Arrow output round-trips to GeoJSON'
-  );
-  t.end();
+  ).toEqual(normalizeFeatures(geojsonTable.features));
 });
-
 function normalizeFeatures(features: any[]) {
   return features.map(feature => ({
     ...feature,
@@ -192,12 +155,10 @@ function normalizeFeatures(features: any[]) {
     properties: {...(feature.properties || {})}
   }));
 }
-
 function normalizeGeometry(geometry: any) {
   if (!geometry) {
     return geometry;
   }
-
   switch (geometry.type) {
     case 'MultiPoint':
       return geometry.coordinates.length === 1

--- a/modules/flatgeobuf/test/flatgeobuf-source-loader.spec.ts
+++ b/modules/flatgeobuf/test/flatgeobuf-source-loader.spec.ts
@@ -2,12 +2,11 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {createDataSource, fetchFile, resolvePath} from '@loaders.gl/core';
 import {FlatGeobufSourceLoader, FlatGeobufVectorSource} from '@loaders.gl/flatgeobuf';
 import {convertBinaryFeatureCollectionToGeojson} from '@loaders.gl/gis';
 import {convertGeoArrowToTable} from '@loaders.gl/geoarrow';
-
 const FLATGEOBUF_COUNTRIES_DATA_URL = resolvePath('@loaders.gl/flatgeobuf/test/data/countries.fgb');
 const REMOTE_FGB_URL = 'https://example.com/countries.fgb';
 const NARROW_BOUNDING_BOX: [[number, number], [number, number]] = [
@@ -18,8 +17,7 @@ const EMPTY_BOUNDING_BOX: [[number, number], [number, number]] = [
   [0, -90],
   [1, -89]
 ];
-
-test('FlatGeobufSourceLoader#createDataSource selects FlatGeobuf source from URL', async t => {
+test('FlatGeobufSourceLoader#createDataSource selects FlatGeobuf source from URL', async () => {
   const source = createDataSource(REMOTE_FGB_URL, [FlatGeobufSourceLoader], {
     core: {
       loadOptions: {
@@ -30,50 +28,42 @@ test('FlatGeobufSourceLoader#createDataSource selects FlatGeobuf source from URL
     },
     flatgeobuf: {}
   });
-
-  t.ok(source instanceof FlatGeobufVectorSource, 'returns FlatGeobufVectorSource');
-  t.end();
+  expect(source instanceof FlatGeobufVectorSource, 'returns FlatGeobufVectorSource').toBeTruthy();
 });
-
-test('FlatGeobufSourceLoader#getSchema and getMetadata expose header metadata', async t => {
+test('FlatGeobufSourceLoader#getSchema and getMetadata expose header metadata', async () => {
   const source = await createSource();
   const schema = await source.getSchema();
   const metadata = await source.getMetadata();
   const metadataWithFormatSpecific = await source.getMetadata({formatSpecificMetadata: true});
-
-  t.equal(schema.fields.length, 2, 'returns the property schema');
-  t.deepEqual(
+  expect(schema.fields.length, 'returns the property schema').toBe(2);
+  expect(
     schema.fields.map(field => field.name),
-    ['id', 'name'],
     'schema fields follow the FlatGeobuf header'
-  );
-  t.equal(metadata.name, 'countries', 'infers dataset name from URL');
-  t.equal(metadata.layers.length, 1, 'returns one dataset layer');
-  t.equal(metadata.layers[0]?.name, 'countries', 'layer name matches dataset');
-  t.ok(Array.isArray(metadata.layers[0]?.crs), 'metadata exposes CRS list');
-  t.equal(metadata.formatSpecificMetadata, undefined, 'raw metadata is opt-in');
-  t.ok(metadataWithFormatSpecific.formatSpecificMetadata, 'returns raw metadata on request');
-  t.end();
+  ).toEqual(['id', 'name']);
+  expect(metadata.name, 'infers dataset name from URL').toBe('countries');
+  expect(metadata.layers.length, 'returns one dataset layer').toBe(1);
+  expect(metadata.layers[0]?.name, 'layer name matches dataset').toBe('countries');
+  expect(Array.isArray(metadata.layers[0]?.crs), 'metadata exposes CRS list').toBeTruthy();
+  expect(metadata.formatSpecificMetadata, 'raw metadata is opt-in').toBe(undefined);
+  expect(
+    metadataWithFormatSpecific.formatSpecificMetadata,
+    'returns raw metadata on request'
+  ).toBeTruthy();
 });
-
-test('FlatGeobufVectorSource#getQueryMetadata discovers panel controls from the header', async t => {
+test('FlatGeobufVectorSource#getQueryMetadata discovers panel controls from the header', async () => {
   const source = await createSource();
   const queryMetadata = await source.getQueryMetadata();
-
-  t.equal(queryMetadata.sourceType, 'flatgeobuf', 'identifies the source adapter');
-  t.deepEqual(
+  expect(queryMetadata.sourceType, 'identifies the source adapter').toBe('flatgeobuf');
+  expect(
     queryMetadata.columns.map(column => column.name),
-    ['id', 'name', 'geometry'],
     'includes every query-visible column'
-  );
-  t.equal(queryMetadata.columns[2]?.role, 'geometry', 'identifies the geometry control');
-  t.equal(queryMetadata.capabilities.bounds, 'pushdown', 'advertises packed R-tree pruning');
-  t.ok(queryMetadata.spatial?.bounds, 'discovers dataset bounds');
-  t.equal(queryMetadata.statistics?.rowCount, 179, 'discovers feature count');
-  t.end();
+  ).toEqual(['id', 'name', 'geometry']);
+  expect(queryMetadata.columns[2]?.role, 'identifies the geometry control').toBe('geometry');
+  expect(queryMetadata.capabilities.bounds, 'advertises packed R-tree pruning').toBe('pushdown');
+  expect(queryMetadata.spatial?.bounds, 'discovers dataset bounds').toBeTruthy();
+  expect(queryMetadata.statistics?.rowCount, 'discovers feature count').toBe(179);
 });
-
-test('FlatGeobufSourceLoader#getFeatures returns matching feature sets across formats', async t => {
+test('FlatGeobufSourceLoader#getFeatures returns matching feature sets across formats', async () => {
   const source = await createSource();
   const defaultTable = await source.getFeatures({
     layers: 'countries',
@@ -94,38 +84,30 @@ test('FlatGeobufSourceLoader#getFeatures returns matching feature sets across fo
     boundingBox: NARROW_BOUNDING_BOX,
     format: 'arrow'
   });
-
-  t.equal(defaultTable.shape, 'arrow-table', 'returns Arrow tables by default');
-  t.equal(geojson.shape, 'geojson-table', 'returns GeoJSON tables');
-  t.ok(geojson.features.length > 0, 'returns matching features');
-  t.ok(geojson.features.length < 179, 'uses indexed subset instead of full dataset');
-
+  expect(defaultTable.shape, 'returns Arrow tables by default').toBe('arrow-table');
+  expect(geojson.shape, 'returns GeoJSON tables').toBe('geojson-table');
+  expect(geojson.features.length > 0, 'returns matching features').toBeTruthy();
+  expect(geojson.features.length < 179, 'uses indexed subset instead of full dataset').toBeTruthy();
   const binaryGeojson = convertBinaryFeatureCollectionToGeojson(binary);
-  t.deepEqual(
-    getFeatureKeys(binaryGeojson.features || []),
-    getFeatureKeys(geojson.features),
+  expect(
+    getFeatureKeys(binaryGeojson as any),
     'binary source output round-trips to the same features'
-  );
-
-  t.equal(arrow.shape, 'arrow-table', 'returns Arrow tables');
+  ).toEqual(getFeatureKeys(geojson.features));
+  expect(arrow.shape, 'returns Arrow tables').toBe('arrow-table');
   const geometryField = arrow.schema.fields[arrow.schema.fields.length - 1];
-  t.equal(geometryField?.name, 'geometry', 'Arrow schema appends geometry');
-  t.equal(
+  expect(geometryField?.name, 'Arrow schema appends geometry').toBe('geometry');
+  expect(
     geometryField?.metadata?.['ARROW:extension:name'],
-    'geoarrow.multipolygon',
     'Arrow geometry uses native GeoArrow encoding'
-  );
-  t.ok(arrow.schema.metadata?.geo, 'Arrow schema includes geo metadata');
+  ).toBe('geoarrow.multipolygon');
+  expect(arrow.schema.metadata?.geo, 'Arrow schema includes geo metadata').toBeTruthy();
   const arrowGeojson = convertGeoArrowToTable(arrow.data, 'geojson-table');
-  t.deepEqual(
+  expect(
     getFeatureKeys(arrowGeojson.features),
-    getFeatureKeys(geojson.features),
     'Arrow source output round-trips to the same features'
-  );
-  t.end();
+  ).toEqual(getFeatureKeys(geojson.features));
 });
-
-test('FlatGeobufSourceLoader#getFeatures reprojects Arrow and GeoJSON consistently', async t => {
+test('FlatGeobufSourceLoader#getFeatures reprojects Arrow and GeoJSON consistently', async () => {
   const source = await createSource();
   const geojson = await source.getFeatures({
     layers: 'countries',
@@ -140,16 +122,12 @@ test('FlatGeobufSourceLoader#getFeatures reprojects Arrow and GeoJSON consistent
     crs: 'EPSG:3857'
   });
   const arrowGeojson = convertGeoArrowToTable(arrow.data, 'geojson-table');
-
-  t.deepEqual(
+  expect(
     getFeatureKeys(arrowGeojson.features),
-    getFeatureKeys(geojson.features),
     'reprojected Arrow source output matches GeoJSON source output'
-  );
-  t.end();
+  ).toEqual(getFeatureKeys(geojson.features));
 });
-
-test('FlatGeobufSourceLoader#getFeatures returns empty valid tables for no-match bboxes', async t => {
+test('FlatGeobufSourceLoader#getFeatures returns empty valid tables for no-match bboxes', async () => {
   const source = await createSource();
   const geojson = await source.getFeatures({
     layers: 'countries',
@@ -166,18 +144,14 @@ test('FlatGeobufSourceLoader#getFeatures returns empty valid tables for no-match
     boundingBox: EMPTY_BOUNDING_BOX,
     format: 'arrow'
   });
-
-  t.equal(geojson.features.length, 0, 'empty GeoJSON response is valid');
-  t.equal(
-    (convertBinaryFeatureCollectionToGeojson(binary).features || []).length,
-    0,
+  expect(geojson.features.length, 'empty GeoJSON response is valid').toBe(0);
+  expect(
+    (convertBinaryFeatureCollectionToGeojson(binary) as any).length,
     'empty binary response is valid'
-  );
-  t.equal(arrow.data.numRows, 0, 'empty Arrow response preserves schema');
-  t.end();
+  ).toBe(0);
+  expect(arrow.data.numRows, 'empty Arrow response preserves schema').toBe(0);
 });
-
-test('FlatGeobufVectorSource#query combines bbox pruning with portable projection and limit', async t => {
+test('FlatGeobufVectorSource#query combines bbox pruning with portable projection and limit', async () => {
   const source = await createSource();
   const table = await source.query({
     boundingBox: NARROW_BOUNDING_BOX,
@@ -185,18 +159,16 @@ test('FlatGeobufVectorSource#query combines bbox pruning with portable projectio
     predicate: {op: '<>', args: [{property: 'id'}, '']},
     limit: 2
   });
-
-  t.deepEqual(
+  expect(
     table.schema.fields.map(field => field.name),
-    ['name'],
     'projects requested fields'
+  ).toEqual(['name']);
+  expect(table.data.numRows, 'applies a global limit after the residual predicate').toBe(2);
+  expect(source.tableQueryCapabilities.predicate, 'reports conservative capability').toBe(
+    'residual'
   );
-  t.equal(table.data.numRows, 2, 'applies a global limit after the residual predicate');
-  t.equal(source.tableQueryCapabilities.predicate, 'residual', 'reports conservative capability');
-  t.end();
 });
-
-test('FlatGeobufVectorSource#explain reports relational and spatial planning', async t => {
+test('FlatGeobufVectorSource#explain reports relational and spatial planning', async () => {
   const source = await createSource();
   const explanation = await source.explain({
     boundingBox: NARROW_BOUNDING_BOX,
@@ -204,15 +176,12 @@ test('FlatGeobufVectorSource#explain reports relational and spatial planning', a
     predicate: {op: '<>', args: [{property: 'id'}, '']},
     limit: 2
   });
-
-  t.deepEqual(explanation.outputColumns, ['name'], 'reports visible output columns');
-  t.deepEqual(explanation.requiredColumns, ['id', 'name'], 'retains hidden predicate columns');
-  t.equal(explanation.spatial.enabled, true, 'reports requested bounds');
-  t.equal(explanation.spatial.support, 'pushdown', 'reports packed R-tree pushdown');
-  t.end();
+  expect(explanation.outputColumns, 'reports visible output columns').toEqual(['name']);
+  expect(explanation.requiredColumns, 'retains hidden predicate columns').toEqual(['id', 'name']);
+  expect(explanation.spatial.enabled, 'reports requested bounds').toBe(true);
+  expect(explanation.spatial.support, 'reports packed R-tree pushdown').toBe('pushdown');
 });
-
-test('FlatGeobufSourceLoader#getFeatures respects abort signals', async t => {
+test('FlatGeobufSourceLoader#getFeatures respects abort signals', async () => {
   const abortController = new AbortController();
   const delayedSource = createDataSource(REMOTE_FGB_URL, [FlatGeobufSourceLoader], {
     core: {
@@ -224,27 +193,23 @@ test('FlatGeobufSourceLoader#getFeatures respects abort signals', async t => {
     },
     flatgeobuf: {}
   }) as FlatGeobufVectorSource;
-
   await delayedSource.getMetadata();
-
   const pending = delayedSource.getFeatures({
     layers: 'countries',
     boundingBox: NARROW_BOUNDING_BOX,
     format: 'geojson',
     signal: abortController.signal
   });
-
   abortController.abort();
-
   try {
     await pending;
-    t.fail('expected request to abort');
+    (() => {
+      throw new Error('expected request to abort');
+    })();
   } catch (error) {
-    t.equal((error as Error).name, 'AbortError', 'throws AbortError');
+    expect((error as Error).name, 'throws AbortError').toBe('AbortError');
   }
-  t.end();
 });
-
 async function createSource(fetchOverride?: typeof fetch): Promise<FlatGeobufVectorSource> {
   const fetch = fetchOverride || (await createRangeFetch());
   return createDataSource(REMOTE_FGB_URL, [FlatGeobufSourceLoader], {
@@ -258,30 +223,24 @@ async function createSource(fetchOverride?: typeof fetch): Promise<FlatGeobufVec
     flatgeobuf: {}
   }) as FlatGeobufVectorSource;
 }
-
 async function createRangeFetch(options: {delayMs?: number} = {}) {
   const bytes = new Uint8Array(
     await (await fetchFile(FLATGEOBUF_COUNTRIES_DATA_URL)).arrayBuffer()
   );
-
   return async (_url: string, requestInit?: RequestInit) => {
     const signal = requestInit?.signal;
     if (signal?.aborted) {
       throw createAbortError();
     }
-
     if (options.delayMs) {
       await waitForDelay(options.delayMs, signal);
     }
-
     const headers = new Headers(requestInit?.headers);
     const rangeHeader = headers.get('Range');
     const match = rangeHeader?.match(/^bytes=(\d+)-(\d+)$/);
-
     if (!match) {
       return new Response(bytes, {status: 200});
     }
-
     const start = Number(match[1]);
     const end = Math.min(Number(match[2]), bytes.byteLength - 1);
     return new Response(bytes.subarray(start, end + 1), {
@@ -292,7 +251,6 @@ async function createRangeFetch(options: {delayMs?: number} = {}) {
     });
   };
 }
-
 function normalizeFeatures(features: any[]) {
   return features
     .map(feature => ({
@@ -302,23 +260,19 @@ function normalizeFeatures(features: any[]) {
     }))
     .sort(compareFeatures);
 }
-
 function getFeatureKeys(features: any[]) {
   return normalizeFeatures(features).map(
     feature => `${feature.properties?.id || ''}|${feature.properties?.name || ''}`
   );
 }
-
 function normalizeGeometry(geometry: any) {
   if (!geometry) {
     return geometry;
   }
-
   const normalizedGeometry = {
     ...geometry,
     coordinates: roundCoordinates(geometry.coordinates)
   };
-
   switch (geometry.type) {
     case 'MultiPoint':
       return normalizedGeometry.coordinates.length === 1
@@ -336,44 +290,36 @@ function normalizeGeometry(geometry: any) {
       return normalizedGeometry;
   }
 }
-
 function waitForDelay(delayMs: number, signal?: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
     const timeoutId = setTimeout(() => {
       cleanup();
       resolve();
     }, delayMs);
-
     const abort = () => {
       cleanup();
       reject(createAbortError());
     };
-
     const cleanup = () => {
       clearTimeout(timeoutId);
       signal?.removeEventListener('abort', abort);
     };
-
     signal?.addEventListener('abort', abort, {once: true});
   });
 }
-
 function createAbortError(): Error {
   const error = new Error('Aborted');
   error.name = 'AbortError';
   return error;
 }
-
 function compareFeatures(left: any, right: any): number {
   const leftKey = `${left.properties?.id || ''}|${left.properties?.name || ''}`;
   const rightKey = `${right.properties?.id || ''}|${right.properties?.name || ''}`;
   return leftKey.localeCompare(rightKey);
 }
-
 function roundCoordinates(coordinates: any): any {
   if (Array.isArray(coordinates)) {
     return coordinates.map(value => roundCoordinates(value));
   }
-
   return typeof coordinates === 'number' ? Number(coordinates.toFixed(6)) : coordinates;
 }


### PR DESCRIPTION
## Goals

- Raise coverage for the low-baseline FlatGeobuf package with its existing fixture-backed integration matrix.
- Continue the migration from the Tape compatibility shim to native Vitest.
- Keep the loader and source checks fast, deterministic, and hermetic.

## Changes

- Migrate `modules/flatgeobuf/test/flatgeobuf-loader.spec.ts` to native Vitest `test` and `expect` APIs.
- Migrate `modules/flatgeobuf/test/flatgeobuf-source-loader.spec.ts` to native Vitest `test` and `expect` APIs.
- Preserve coverage for GeoJSON, binary, Arrow, reprojection, batching, spatial filtering, query planning, metadata, and abort behavior.
- Correct the stale binary round-trip assertion to use the converter’s actual `Feature[]` return value.
- Make no production-code changes.

## Validation

- `yarn lint fix`
- `yarn test-headless modules/flatgeobuf/test/flatgeobuf-loader.spec.ts modules/flatgeobuf/test/flatgeobuf-source-loader.spec.ts modules/flatgeobuf/test/reader-coverage.spec.ts`
- `yarn test-headless-cover modules/flatgeobuf/test/flatgeobuf-loader.spec.ts modules/flatgeobuf/test/flatgeobuf-source-loader.spec.ts modules/flatgeobuf/test/reader-coverage.spec.ts`
- `yarn test-audit`
- `git diff --check`

The focused suite passes all 32 tests. Focused FlatGeobuf source coverage is 92.68% statements, 95.38% lines, and 92.3% functions. The test audit reports 597 files, 0 Tape files, and 0 violations.