### PR TITLE
feat(scan): conclude existing format support

### DIFF
--- a/docs/developer-guide/common-scan-architecture.md
+++ b/docs/developer-guide/common-scan-architecture.md
@@ -14,29 +14,41 @@ they share is the logical meaning of a query and a small set of execution invari
 
 ## Format-family support at a glance
 
-This is the end-user view of the architecture. “Supported” means a source can be used through the
-common scan contract today. “Partial” means useful metadata or Arrow reading exists, but some
-operators or pushdown opportunities remain source-specific. “Specialized” means the format has a
-different query model, such as tiles or raster windows, rather than a relational table scan.
+This is the end-user view of the architecture. The statuses are deliberately conclusive:
 
-| Format family | Status | What is supported |
-| --- | --- | --- |
-| Arrow / GeoArrow | Partial | In-memory projection, predicates, and limits; GeoArrow extension-column conformance is still expanding. |
-| Parquet / Iceberg | Supported | Schema discovery, projection, filtering, global limits, streaming Arrow batches, cancellation, and metadata pruning. |
-| FlatGeobuf | Supported | Arrow feature queries, R-tree bounding-box pruning, residual attribute filtering, projection, and limits. |
-| DuckDB / Snowflake SQL | Supported | Raw SQL plus the portable table query with safe parameter binding. |
-| CSV / JSONL / ORC | Planned | Existing loaders are available; common chunk, stripe, and row-index scans are next. |
-| Delta Lake | Supported (read-only snapshots) | Versioned transaction-log replay, active-file planning, Parquet projection/filtering, global limits, streaming Arrow batches, cancellation, and explain output; deletion-vector rows are rejected until decoding is available. |
-| Lance | Partial | Read-only metadata and Arrow-batch paths exist; common snapshot/fragment planning and predicate pushdown are incomplete. |
-| COPC / Potree | Partial | Point-cloud metadata, coordinate roles, hierarchy bounds, level-of-detail, spacing, and capability discovery are available; full common point streaming is source-specific. |
-| GeoTIFF / COG / Zarr / GeoZarr / OME-Zarr | Partial | Raster window, band/channel, overview/level, and multidimensional selection APIs are available with shared query validation and capabilities. |
-| NetCDF | Partial | Header-only scan metadata exposes variables, dimensions, attributes, and file statistics; data reads and slice pushdown remain follow-up work. |
-| MVT / PMTiles / 3D Tiles / I3S | Specialized | Use tile and tileset source APIs; tile addressing and level-of-detail remain outside `TableQuery`. |
-| WMS / WFS / STAC and other services | Specialized | Use the service or catalog query APIs; they are not normalized into the table scan contract. |
+- **Supported** means query metadata names a common execution method that works today. The details
+  say which operations are pushed down and which are evaluated after decoding.
+- **Metadata only** means the source can populate discovery UI but does not claim a common scan
+  executor. Its metadata includes a concrete reason and the panel disables execution.
+- **Not implemented** means the format has no common scan adapter.
+- **Outside protocol** means the format intentionally uses a specialized tile, service, or catalog
+  API instead of pretending to implement a scan.
 
-The matrix describes the public experience, not identical physical performance. A source may accept
-the same logical query while evaluating some operators after decoding; capability metadata and
-explain output identify what was pushed down and what remained residual.
+| Format or source | Status | Common entry point | Supported scope |
+| --- | --- | --- | --- |
+| In-memory Arrow / GeoArrow | Supported | `read()` | Portable predicates, projection, limit, expressions, ordering, aggregates, unions, and joins; `query()` also returns a materialized table. |
+| Arrow IPC | Supported | `read()` | Schema discovery, projection, global limit, cancellation, and streaming Arrow batches; predicates are rejected. |
+| Parquet / Iceberg | Supported | `read()` | Projection, predicate and metadata pruning, global limits, cancellation, and streaming Arrow batches. |
+| Delta Lake | Supported | `read()` | Read-only versioned snapshot replay, active-file planning, Parquet filtering, global limits, cancellation, and explain output; tables with deletion vectors are rejected explicitly until decoding is available. |
+| FlatGeobuf | Supported | `read()` | R-tree bounding-box pruning, residual predicates, projection, limits, cancellation, and Arrow feature batches. |
+| CSV | Supported | `read()` | Streaming projection and limit with residual predicates. |
+| NDJSON / JSONL | Supported | `read()` | Streaming projection and limit with residual predicates. |
+| ORC | Supported | `read()` | Materialized Arrow reads with residual projection, predicate, and limit. |
+| GeoPackage | Supported | `read()` | Selected feature-table discovery and materialized Arrow reads with residual projection, predicate, and limit. |
+| GeoTIFF / COG | Supported | `getRaster()` | Bounds and overview selection, bands, typed output, and validated raster queries. |
+| OME-TIFF | Supported | `getRaster()` | Multiscale levels, channels, slices, typed output, and validated raster queries. |
+| GeoZarr / OME-Zarr | Supported | `getRaster()` | Chunk-aligned bounds, channels or variables, multiscale levels, slices, and typed output. |
+| COPC / Potree | Metadata only | — | Schema, coordinate roles, hierarchy bounds, levels, and spacing are discoverable; use the existing tile APIs for point data. |
+| NetCDF | Metadata only | — | Variables, dimensions, attributes, and file statistics are discoverable; common variable and dimension-slice reads are not implemented. |
+| Lance / Shapefile / MLT / LAS / LAZ / PLY / PCD | Not implemented | — | Their existing loaders or specialized sources do not expose the common scan contract. |
+| DuckDB / Snowflake SQL | Supported | `query()` | Compiles the portable table query to bound SQL; this is a backend rather than a file-format adapter. |
+| MVT / PMTiles / 3D Tiles / I3S | Outside protocol | — | Use tile and tileset source APIs; tile addressing and level-of-detail remain outside `TableQuery`. |
+| WMS / WFS / STAC and other services | Outside protocol | — | Use the service or catalog APIs; they are not normalized into the scan contract. |
+
+The matrix describes the public experience, not identical physical performance. A residual
+operator is still supported and correct; it simply does not avoid decoding work. Each scan-aware
+source publishes the same conclusion through `ScanQueryMetadata.execution`, so documentation and
+query panels do not have to infer support from a collection of capabilities.
 
 ## Why a common scan architecture?
 
@@ -497,6 +509,9 @@ rows:
 type ScanQueryMetadata = Readonly<{
   sourceType: string;
   queryType: 'table' | 'point-cloud' | 'raster';
+  execution:
+    | {status: 'supported'; method: 'read' | 'query' | 'getRaster' | 'scan'}
+    | {status: 'metadata-only'; reason: string};
   name?: string;
   description?: string;
   schema: Schema;
@@ -506,6 +521,10 @@ type ScanQueryMetadata = Readonly<{
   statistics?: {rowCount?: number | bigint; byteLength?: number | bigint};
 }>;
 ```
+
+`execution` is the authoritative support conclusion. A supported source names the common method
+applications can call; a metadata-only source supplies the concrete missing capability. The helper
+rejects methods that do not match the query family, such as `read()` for a raster query.
 
 `schema` is the authoritative execution schema. `columns` is a panel-ready view of those fields
 that adds semantic roles such as `identifier`, `geometry`, `x`, `y`, `z`, `time`, `intensity`, or
@@ -532,6 +551,7 @@ A framework-specific panel can remain outside the scan core. Its data flow is sm
 
 ```text
 source.getQueryMetadata()
+    -> execution status / disabled reason
     -> column projection picker
     -> typed predicate builder
     -> named parameter inputs
@@ -657,9 +677,10 @@ documentation examples. The panel currently exposes three source-neutral control
 - a global row limit, enabled only when the source advertises limit support;
 - a source-coordinate bounding box when `metadata.spatial` and bounds pushdown are available.
 
-The panel emits the same immutable query shape consumed by a source's `query()` or `scan()` method.
-This keeps Iceberg, FlatGeobuf, Arrow, and future COPC/Potree or raster examples visually
-consistent while preserving their physical executors. A source may add a format-specific editor
+For supported sources, the panel emits the same immutable query shape consumed by `read()`,
+`query()`, `getRaster()`, or `scan()`. For metadata-only sources it still shows the discovered
+schema but disables Apply and explains the missing executor. This keeps Iceberg, FlatGeobuf, Arrow,
+point-cloud, and raster examples visually consistent without overstating their physical support. A source may add a format-specific editor
 alongside the panel—for example, the Iceberg example retains its SQL/predicate editor—without
 duplicating schema discovery or projection/limit controls.
 
@@ -704,73 +725,71 @@ The roadmap is therefore format-support-first. Each tranche must ship three thin
 1. **Optional package boundary — implemented in this stack.** Keep query state, metadata contracts,
    and the reference runtime in `@loaders.gl/scan`, while format adapters retain lightweight
    `@loaders.gl/loader-utils` dependencies. No UI or GPU code crosses this boundary.
-2. **Panel everywhere — implemented for the first linear sources in this stack.** The shared panel
-   now consumes the package-level metadata/query types, renders discovered raster overviews, and is
-   exercised by FlatGeobuf, Parquet, Iceberg, CSV, and Arrow examples. The next increment adds a
-   support badge and explain preview to each compatible example, then expands the panel to every
-   source marked “Ready” or “Foundation” in the matrix below.
-3. **Tabular and vector coverage.** Finish Arrow/GeoArrow as the conformance executor, then bring
-   ORC, CSV, JSONL, GeoPackage, Shapefile, MLT, and existing FlatGeobuf paths to scan parity. Start
-   with schema/projection/limit and residual predicates; add stripe, row-index, packed-index, or
-   byte-range pruning only where the format can prove it safely.
-4. **Cloud and versioned tables — Delta read-only snapshot slice implemented in this stack.**
-   `DeltaTableSource` replays versioned transaction logs, plans active Parquet fragments, and reuses
-   hidden required columns, task ordering, global limits, and explain output. The remaining Delta
-   work is deliberately separate: checkpoint discovery, CDC, deletion-vector decoding, and writes.
-   Continue the same snapshot/fragment approach for Lance without creating format-specific
-   predicate ASTs.
-5. **Point-cloud coverage.** Turn COPC and Potree foundations into bounded Arrow point batches with
-   bounds pushdown, ordered hierarchy tasks, residual attribute predicates, and global point limits.
-   Add LAS/LAZ as a sequential fallback and PLY/PCD/splats as metadata-first adapters where their
-   native formats cannot prune remotely.
-6. **Raster and multidimensional coverage.** Complete GeoTIFF/COG and Zarr/GeoZarr/OME-Zarr scan
-   requests, then wire NetCDF. Add terrain/heightmap and LERC-backed sources through the same raster
-   panel. Standardize window, resolution/overview, band/channel, variable, dimension slice, typed
-   output, and chunk telemetry without pretending pixels are table rows.
+2. **Panel everywhere — concluded for support signaling.** The shared panel consumes package-level
+   metadata/query types, renders discovered raster overviews, and is exercised by FlatGeobuf,
+   Parquet, Iceberg, CSV, and Arrow examples. It now shows the source's declared execution method
+   and disables Apply with the source-provided reason for metadata-only adapters.
+3. **Existing tabular and vector adapters — concluded.** In-memory Arrow, Arrow IPC, ORC, CSV,
+   NDJSON, GeoPackage, and FlatGeobuf expose common executors. GeoPackage now closes the last
+   residual-execution gap in this set. Shapefile and MLT are explicitly not implemented rather than
+   being left in a planned state. Physical stripe, row-index, packed-index, and byte-range pruning
+   remain performance improvements and do not change the support conclusion.
+4. **Existing cloud and versioned tables — concluded.** Parquet, Iceberg, and Delta Lake read-only
+   snapshots expose common execution. Delta replays versioned transaction logs and plans active
+   Parquet fragments; checkpoint discovery, CDC, deletion-vector decoding, and writes remain
+   separate format features. Lance is explicitly not implemented.
+5. **Point-cloud execution — open and unambiguous.** COPC and Potree expose query metadata but not a
+   common executor, so they are `metadata-only` with a reason and the panel cannot submit a scan.
+   Completing this tranche requires bounded Arrow point batches with ordered hierarchy traversal,
+   exact bounds and residual predicates, and a global limit. LAS/LAZ, PLY, PCD, and splats have no
+   common adapter.
+6. **Existing raster adapters — concluded; NetCDF execution remains open.** GeoTIFF/COG, OME-TIFF,
+   GeoZarr, and OME-Zarr execute validated raster queries through `getRaster()`. NetCDF is
+   `metadata-only` until variable and dimension-slice reads exist. Terrain and LERC have no common
+   adapter.
 7. **Tiles and services bridge.** Keep MVT, PMTiles, 3D Tiles, I3S, WMS, WFS, and STAC specialized,
    but expose shared discovery, bounds, time, level-of-detail, explain, and cancellation metadata.
    Where a source returns feature tables (for example MVT or WFS), offer an explicit table-scan view;
    keep tile addressing and rendering controls outside `TableQuery`.
-7. **Portable relational growth — second slice landed.** Arrow and DuckDB now execute the shared
+8. **Portable relational growth — second slice landed.** Arrow and DuckDB now execute the shared
    ordering, scalar-expression, grouped-aggregate, `UNION ALL`, and equi-join request shapes. The
    next slice is planner-level source resolution and duplicate-column naming for larger federated
    plans before these operators become part of the default panel.
-8. **GPU and acceleration.** Lower the same plan to luma.gl/WGSL masks or indices, add deferred or
+9. **GPU and acceleration — deferred.** Lower the same plan to luma.gl/WGSL masks or indices, add deferred or
    materialized compaction, and compare GPU/CPU explain telemetry. Add spatial predicates and nearest
    neighbor only when indexed CPU, GPU, and remote-source strategies have compatible semantics.
 
 ### Format-support scorecard
 
-This is the end-user support view. “Ready” means the source can populate the shared panel and execute
-the listed controls correctly today. “Foundation” means metadata/capabilities exist but the scan
-adapter is incomplete. “Planned” means the normal loader exists, but no common scan contract is
-exposed yet. A residual predicate is still correct; it simply cannot avoid decoding work.
+This repeats the end-user support view beside the implementation roadmap so progress cannot drift
+back into “foundation” or “planned” gray zones. “Supported,” “Metadata only,” “Not implemented,”
+and “Outside protocol” have the exact meanings defined at the top of this page.
 
-| Family and representative sources | Status | Discovery | Projection / selection | Filter / spatial controls | Limit / stream | Priority |
-| --- | --- | --- | --- | --- | --- | --- |
-| Arrow / GeoArrow | Foundation | schema for Arrow tables | zero-copy/residual | residual, null-safe | yes / batches | P1: add common source and panel adapter |
-| Parquet / Iceberg | Ready | footer/catalog | pushdown | statistics + residual | global / batches | maintain and extend |
-| FlatGeobuf | Ready | header/index | Arrow properties | bbox pushdown, scalar residual | bounded / batches | maintain and panel |
-| ORC | Planned | loader metadata only | planned | planned row-index/statistics | planned | P2 |
-| CSV | Ready | header/sample | parser projection | residual | global / batches | P1 |
-| JSONL | Planned | header/sample | planned | planned residual | planned chunks | P2 |
-| GeoPackage / Shapefile / MLT | Planned | container/header | planned | planned spatial or residual | planned | P2 |
-| Delta Lake | Ready (read-only snapshots) | versioned transaction-log replay | Parquet projection | Parquet pushdown; deletion vectors rejected explicitly | global / batches | P1: checkpoints, CDC, and deletion-vector decoding |
-| Lance | Foundation | manifest/fragments | format-native | fragments + residual | global / batches | P1 |
-| COPC / Potree | Foundation | header/hierarchy | point attributes | bounds pushdown, attribute residual | planned global / batches | P1 |
-| LAS / LAZ / PLY / PCD / splats | Planned | header | sequential attribute decode | residual unless indexed | planned | P2 |
-| GeoTIFF / COG | Foundation | TIFF/overview metadata | bands/windows | window pushdown | tile-local / typed arrays | P1 |
-| Zarr / GeoZarr / OME-Zarr | Foundation | group/array metadata | variables/channels | chunk/window pushdown | chunked / typed arrays | P1 |
-| NetCDF | Foundation | file dimensions/variables | metadata only | planned window/slice pushdown | planned chunked / typed arrays | P1 |
-| Terrain / LERC | Planned | tile/codec metadata | bands/tiles | tile bounds | tile streams | P2 |
-| MVT / PMTiles | Specialized | tile/catalog metadata | feature-layer selection | tile bounds, optional residual table view | tile streams | P2 |
-| 3D Tiles / I3S | Specialized | tileset metadata | tile content | volume/LOD pushdown | tile streams | P2 |
-| WMS / WFS / STAC | Specialized | service/catalog metadata | layer/asset selection | server-specific bounds/time | response streams | P3 |
+| Family and representative sources | Status | Execution | Correct behavior today | Remaining work |
+| --- | --- | --- | --- | --- |
+| In-memory Arrow / GeoArrow | Supported | `read()` | Portable relational execution; materialized `query()` is also available | Optimize vector paths and expand GeoArrow conformance |
+| Arrow IPC | Supported | `read()` | Projection, global limit, cancellation, Arrow batches | Predicate execution |
+| Parquet / Iceberg | Supported | `read()` | Pushdown plus residual filtering and streaming | More pruning and explain detail |
+| Delta Lake | Supported | `read()` | Versioned snapshot replay, active-file planning, Parquet filtering, and explicit deletion-vector rejection | Checkpoints, CDC, and deletion-vector decoding |
+| FlatGeobuf | Supported | `read()` | Bounding-box pushdown and residual table query | More packed-index telemetry |
+| CSV / NDJSON | Supported | `read()` | Streaming projection and limit, residual predicates | Byte-range and record-index pruning |
+| ORC | Supported | `read()` | Materialized residual table query | Stripe and row-index pruning |
+| GeoPackage | Supported | `read()` | Materialized residual feature-table query | SQL and spatial-index pushdown |
+| Shapefile / MLT / Lance | Not implemented | — | No common scan claims | Add adapters only when end-to-end execution is available |
+| COPC / Potree | Metadata only | — | Schema and hierarchy discovery | Common ordered point-batch executor |
+| LAS / LAZ / PLY / PCD / splats | Not implemented | — | No common scan claims | Decide which formats justify sequential adapters |
+| GeoTIFF / COG / OME-TIFF | Supported | `getRaster()` | Windows, bands/channels, levels, typed output | More chunk telemetry and pushdown |
+| GeoZarr / OME-Zarr | Supported | `getRaster()` | Chunk-aligned windows, channels, levels, slices | More variable and dimension UI |
+| NetCDF | Metadata only | — | Variable and dimension discovery | Variable and dimension-slice executor |
+| Terrain / LERC | Not implemented | — | No common scan claims | Raster adapter design |
+| MVT / PMTiles / 3D Tiles / I3S | Outside protocol | — | Specialized tile APIs | Optional explicit feature-table views |
+| WMS / WFS / STAC | Outside protocol | — | Specialized service and catalog APIs | Shared discovery metadata where useful |
 
 “Pushdown” is a promise about avoiding physical work, not merely accepting an option. Every adapter
 must report `residual` when it decodes rows, features, points, or chunks before evaluating a filter.
-The scorecard should be updated whenever a source gains a panel, adapter, or conformance slice; it is
-the primary progress report for the roadmap.
+The scorecard changes only when a source gains or loses a working common entry point. Optimization
+tranches update the behavior and remaining-work columns without downgrading correct residual
+execution to an ambiguous intermediate status.
 
 The desired end state is not one monolithic engine. It is a family of specialized planners and
 executors that agree on what a query means.

--- a/modules/arrow/src/arrow-source.ts
+++ b/modules/arrow/src/arrow-source.ts
@@ -62,6 +62,7 @@ export class ArrowTableSource
       return createScanQueryMetadata({
         sourceType: 'arrow',
         queryType: 'table',
+        execution: {status: 'supported', method: 'read'},
         schema: {fields: arrowSchema.fields as never, metadata: {}},
         capabilities: {
           table: {

--- a/modules/arrow/test/arrow-source.cross.spec.ts
+++ b/modules/arrow/test/arrow-source.cross.spec.ts
@@ -6,6 +6,7 @@ test('ArrowTableSource discovers schema and applies projection and limit', async
   const bytes = arrow.tableToIPC(arrow.tableFromArrays({name: ['a', 'b'], value: [1, 2]}));
   const source = new ArrowTableSource(new Blob([bytes]));
   const metadata = await source.getQueryMetadata();
+  expect(metadata.execution).toEqual({status: 'supported', method: 'read'});
   expect(metadata.columns.map(column => column.name)).toEqual(['name', 'value']);
   const batches = [];
   for await (const batch of source.read({columns: ['value'], limit: 1})) batches.push(batch);

--- a/modules/copc/src/copc-source-loader.ts
+++ b/modules/copc/src/copc-source-loader.ts
@@ -343,6 +343,10 @@ export class COPCTileSource
     return createScanQueryMetadata({
       sourceType: 'copc',
       queryType: 'point-cloud',
+      execution: {
+        status: 'metadata-only',
+        reason: 'Common point-cloud scan traversal is not implemented; use the COPC tile APIs.'
+      },
       schema,
       capabilities: {
         table: this.pointCloudQueryCapabilities,

--- a/modules/copc/test/copc-source.spec.ts
+++ b/modules/copc/test/copc-source.spec.ts
@@ -58,6 +58,18 @@ test('COPCSourceLoader#creates a source through createDataSource', async () => {
   expect(dataSource).toBeInstanceOf(COPCTileSource);
 });
 
+test('COPCSourceLoader#conclusively reports metadata-only common scan support', async () => {
+  const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {});
+  const metadata = await source.getQueryMetadata();
+
+  expect(metadata.queryType).toBe('point-cloud');
+  expect(metadata.execution).toEqual({
+    status: 'metadata-only',
+    reason: 'Common point-cloud scan traversal is not implemented; use the COPC tile APIs.'
+  });
+  await source.close();
+});
+
 test('COPCSourceLoader#loads normalized root and child tiles', async () => {
   const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {});
   await source.initialize();

--- a/modules/csv/src/csv-source.ts
+++ b/modules/csv/src/csv-source.ts
@@ -63,6 +63,7 @@ export class CSVTableSource
       return createScanQueryMetadata({
         sourceType: 'csv',
         queryType: 'table',
+        execution: {status: 'supported', method: 'read'},
         schema: batch.schema,
         capabilities: {
           table: {

--- a/modules/csv/test/csv-source.cross.spec.ts
+++ b/modules/csv/test/csv-source.cross.spec.ts
@@ -4,6 +4,7 @@ import {CSVSourceLoader, CSVTableSource} from '../src/csv-source';
 test('CSVTableSource discovers schema and applies projection and limit', async () => {
   const source = new CSVTableSource(new Blob(['name,value\na,1\nb,2\n']));
   const metadata = await source.getQueryMetadata();
+  expect(metadata.execution).toEqual({status: 'supported', method: 'read'});
   expect(metadata.columns.map(column => column.name)).toEqual(['name', 'value']);
   const batches = [];
   for await (const batch of source.read({columns: ['value'], limit: 1})) batches.push(batch);

--- a/modules/flatgeobuf/src/flatgeobuf-source-loader.ts
+++ b/modules/flatgeobuf/src/flatgeobuf-source-loader.ts
@@ -111,6 +111,7 @@ export class FlatGeobufVectorSource extends DataSource<string, FlatGeobufSourceL
     return createScanQueryMetadata({
       sourceType: 'flatgeobuf',
       queryType: 'table',
+      execution: {status: 'supported', method: 'read'},
       name: info.layerName,
       description: info.header.description,
       schema: info.querySchema,

--- a/modules/flatgeobuf/test/flatgeobuf-source-loader.spec.ts
+++ b/modules/flatgeobuf/test/flatgeobuf-source-loader.spec.ts
@@ -54,6 +54,10 @@ test('FlatGeobufVectorSource#getQueryMetadata discovers panel controls from the 
   const source = await createSource();
   const queryMetadata = await source.getQueryMetadata();
   expect(queryMetadata.sourceType, 'identifies the source adapter').toBe('flatgeobuf');
+  expect(queryMetadata.execution, 'identifies the common execution entry point').toEqual({
+    status: 'supported',
+    method: 'read'
+  });
   expect(
     queryMetadata.columns.map(column => column.name),
     'includes every query-visible column'

--- a/modules/geopackage/src/geopackage-source-loader.ts
+++ b/modules/geopackage/src/geopackage-source-loader.ts
@@ -7,14 +7,24 @@ import type {
   DataSourceOptions,
   ScanQueryMetadata,
   ScanQueryMetadataOptions,
-  SourceLoader
+  SourceLoader,
+  TableScanReadOptions,
+  TableScanSource
 } from '@loaders.gl/loader-utils';
-import {createScanQueryMetadata, DataSource} from '@loaders.gl/loader-utils';
-import type {ArrowTable} from '@loaders.gl/schema';
+import {
+  createScanQueryMetadata,
+  DataSource,
+  filterColumnarRowIndices,
+  validateTableQueryOptions
+} from '@loaders.gl/loader-utils';
+import type {ArrowTable, ArrowTableBatch, Schema} from '@loaders.gl/schema';
+import {convertArrowToSchema} from '@loaders.gl/schema-utils';
+import * as arrow from 'apache-arrow';
 
 import type {GeoPackageLoaderOptions} from './geopackage-loader';
 import {
   DEFAULT_SQLJS_CDN,
+  getGeoPackageArrowSchema,
   listGeoPackageVectorTables,
   loadGeoPackageDatabase,
   parseGeoPackageToArrow,
@@ -27,6 +37,8 @@ import {GeoPackageFormat} from './geopackage-format';
 const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
 export type GeoPackageSourceTableMetadata = {
+  /** Query-visible WKB Arrow schema for this feature table. */
+  schema: Schema;
   name: string;
   identifier?: string;
   description?: string;
@@ -88,7 +100,10 @@ export const GeoPackageSource = {
 /**
  * GeoPackage data source that exposes vector table metadata and Arrow table reads.
  */
-export class GeoPackageDataSource extends DataSource<string | Blob, GeoPackageSourceOptions> {
+export class GeoPackageDataSource
+  extends DataSource<string | Blob, GeoPackageSourceOptions>
+  implements TableScanSource<ArrowTableBatch>
+{
   private arrayBufferPromise: Promise<ArrayBuffer> | null = null;
   private metadataPromise: Promise<GeoPackageSourceMetadata> | null = null;
 
@@ -112,28 +127,24 @@ export class GeoPackageDataSource extends DataSource<string | Blob, GeoPackageSo
     throwIfAborted(options.signal);
     const selectedTable = metadata.tables.find(table => table.isDefault) || metadata.tables[0];
     if (!selectedTable) throw new Error('GeoPackage contains no vector feature tables');
-    const table = await this.getTable(selectedTable.name);
-    throwIfAborted(options.signal);
-    const fieldNames = new Set(table.data.schema.fields.map(field => field.name));
+    const fieldNames = new Set(selectedTable.schema.fields.map(field => field.name));
     const geometryColumnName = fieldNames.has('geometry')
       ? 'geometry'
       : fieldNames.has(selectedTable.geometryColumnName)
         ? selectedTable.geometryColumnName
         : undefined;
-    const schemaMetadata = table.data.schema.metadata
-      ? Object.fromEntries(table.data.schema.metadata)
-      : {};
     return createScanQueryMetadata({
       sourceType: 'geopackage',
       queryType: 'table',
+      execution: {status: 'supported', method: 'read'},
       name: selectedTable.identifier || selectedTable.name,
       description: selectedTable.description,
-      schema: {fields: table.data.schema.fields as never, metadata: schemaMetadata},
+      schema: selectedTable.schema,
       columnRoles: geometryColumnName ? {[geometryColumnName]: 'geometry'} : undefined,
       capabilities: {
         table: {
           projection: 'residual',
-          predicate: 'unsupported',
+          predicate: 'residual',
           limit: 'residual',
           streaming: false,
           cancellation: false
@@ -154,6 +165,26 @@ export class GeoPackageDataSource extends DataSource<string | Blob, GeoPackageSo
     return parseGeoPackageToArrow(arrayBuffer, this.getLoaderOptions(tableName));
   }
 
+  /** Executes projection, residual predicates, and a global limit on the selected feature table. */
+  async query(options: TableScanReadOptions = {}): Promise<ArrowTable> {
+    throwIfAborted(options.signal);
+    const table = await this.getTable();
+    throwIfAborted(options.signal);
+    return queryGeoPackageTable(table, options);
+  }
+
+  /** Executes a common table scan as one bounded Arrow batch. */
+  async *read(options: TableScanReadOptions = {}): AsyncIterableIterator<ArrowTableBatch> {
+    const table = await this.query(options);
+    yield {
+      batchType: 'data',
+      shape: 'arrow-table',
+      schema: table.schema,
+      data: table.data,
+      length: table.data.numRows
+    };
+  }
+
   private async loadMetadata(): Promise<GeoPackageSourceMetadata> {
     const arrayBuffer = await this.getArrayBuffer();
     const database = await loadGeoPackageDatabase(
@@ -168,6 +199,7 @@ export class GeoPackageDataSource extends DataSource<string | Blob, GeoPackageSo
 
     return {
       tables: vectorTables.map(vectorTable => ({
+        schema: getGeoPackageArrowSchema(database, vectorTable),
         name: vectorTable.name,
         identifier: vectorTable.identifier,
         description: vectorTable.description,
@@ -226,6 +258,46 @@ export class GeoPackageDataSource extends DataSource<string | Blob, GeoPackageSo
       }
     };
   }
+}
+
+/** Applies the portable table query to a materialized GeoPackage feature table. */
+function queryGeoPackageTable(table: ArrowTable, options: TableScanReadOptions): ArrowTable {
+  const availableColumns = table.data.schema.fields.map(field => field.name);
+  validateTableQueryOptions(availableColumns, options);
+  const selectedColumns = options.columns ? [...options.columns] : availableColumns;
+  let data: arrow.Table;
+
+  if (options.predicate) {
+    const columns = Object.fromEntries(
+      availableColumns.map(name => [name, [...(table.data.getChild(name) || [])]])
+    );
+    const rowIndices = filterColumnarRowIndices(
+      options.predicate as never,
+      columns as never,
+      table.data.numRows
+    );
+    const vectors = Object.fromEntries(
+      selectedColumns.map(name => {
+        const sourceVector = table.data.getChild(name);
+        return [
+          name,
+          arrow.vectorFromArray(
+            rowIndices.map(rowIndex => columns[name][rowIndex]),
+            sourceVector?.type
+          )
+        ];
+      })
+    );
+    const schema = new arrow.Schema(
+      selectedColumns.map(name => table.data.schema.fields.find(field => field.name === name)!)
+    );
+    data = new arrow.Table(schema, vectors);
+  } else {
+    data = table.data.select(selectedColumns);
+  }
+
+  data = data.slice(0, options.limit ?? Number.POSITIVE_INFINITY);
+  return {shape: 'arrow-table', schema: convertArrowToSchema(data.schema), data};
 }
 
 function throwIfAborted(signal?: AbortSignal): void {

--- a/modules/geopackage/src/lib/parse-geopackage.ts
+++ b/modules/geopackage/src/lib/parse-geopackage.ts
@@ -285,7 +285,7 @@ export function getGeoPackageArrowTable(
   const columns = queryResult?.columns || [];
   const values = queryResult?.values || [];
   const projection = getProjection(vectorTable, projections, options);
-  const schema = getArrowSchema(database, vectorTable);
+  const schema = getGeoPackageArrowSchema(database, vectorTable);
   const tableBuilder = new ArrowTableBuilder(schema);
 
   for (const row of values) {
@@ -502,7 +502,11 @@ function getSchema(database: Database, tableName: string): Schema {
   return {fields, metadata: {}};
 }
 
-function getArrowSchema(database: Database, vectorTable: GeoPackageVectorTableInfo): Schema {
+/** Reads a selected GeoPackage feature-table schema without materializing its rows. */
+export function getGeoPackageArrowSchema(
+  database: Database,
+  vectorTable: GeoPackageVectorTableInfo
+): Schema {
   const statement = database.prepare(`PRAGMA table_info(\`${vectorTable.name}\`)`);
   const fields: Field[] = [];
 

--- a/modules/geopackage/test/geopackage-scan-metadata.spec.ts
+++ b/modules/geopackage/test/geopackage-scan-metadata.spec.ts
@@ -12,14 +12,38 @@ test.runIf(isBrowser)(
     const source = new GeoPackageDataSource(new Blob([await response.arrayBuffer()]), {
       geopackage: {}
     });
+    source.getTable = async () => {
+      throw new Error('metadata discovery must not materialize feature rows');
+    };
     const metadata = await source.getQueryMetadata();
 
     expect(metadata.queryType).toBe('table');
+    expect(metadata.execution).toEqual({status: 'supported', method: 'read'});
     expect(metadata.columns.map(column => column.name)).toContain('geometry');
     expect(metadata.columns.find(column => column.name === 'geometry')?.role).toBe('geometry');
     expect(metadata.capabilities.table?.projection).toBe('residual');
   }
 );
+
+test('GeoPackage source executes projection, residual predicates, and limits', async () => {
+  const source = new GeoPackageDataSource(new Blob([]), {geopackage: {}});
+  source.getTable = async () => ({
+    shape: 'arrow-table',
+    data: arrow.tableFromArrays({name: ['a', 'b', 'a'], value: [1, 2, 3]})
+  });
+
+  const result = await source.query({
+    predicate: {op: '=', args: [{property: 'name'}, 'a']},
+    columns: ['value'],
+    limit: 1
+  });
+  expect(result.data.schema.fields.map(field => field.name)).toEqual(['value']);
+  expect(Array.from(result.data.getChild('value')?.toArray() || [])).toEqual([1]);
+
+  const batch = await source.read({limit: 2})[Symbol.asyncIterator]().next();
+  expect(batch.value?.length).toBe(2);
+  await expect(source.query({limit: -1})).rejects.toThrow('non-negative safe integer');
+});
 
 test.runIf(isBrowser)(
   'GeoPackage source handles missing defaults, bounds, and geometry fields',
@@ -29,6 +53,10 @@ test.runIf(isBrowser)(
     source.getMetadata = async () => ({
       tables: [
         {
+          schema: {
+            fields: [{name: 'value', type: 'float64', nullable: true}],
+            metadata: {}
+          },
           name: 'fallback',
           geometryColumnName: 'missing',
           geometryTypeName: 'POINT',
@@ -53,6 +81,10 @@ test.runIf(isBrowser)(
     source.getMetadata = async () => ({
       tables: [
         {
+          schema: {
+            fields: [{name: 'geom', type: 'binary', nullable: true}],
+            metadata: {}
+          },
           name: 'geometry',
           identifier: 'identified',
           description: 'description',

--- a/modules/geotiff/src/geotiff-source-loader.ts
+++ b/modules/geotiff/src/geotiff-source-loader.ts
@@ -169,6 +169,7 @@ export class GeoTIFFRasterSource
     return createScanQueryMetadata({
       sourceType: 'geotiff',
       queryType: 'raster',
+      execution: {status: 'supported', method: 'getRaster'},
       name: metadata.name,
       schema: {fields, metadata: {}},
       capabilities: {

--- a/modules/geotiff/src/ometiff-source-loader.ts
+++ b/modules/geotiff/src/ometiff-source-loader.ts
@@ -190,6 +190,7 @@ export class OMETiffImageSource
     return createScanQueryMetadata({
       sourceType: 'ometiff',
       queryType: 'raster',
+      execution: {status: 'supported', method: 'getRaster'},
       name: metadata.name,
       schema: {fields, metadata: {}},
       capabilities: {

--- a/modules/geotiff/test/geotiff-scan-source.spec.ts
+++ b/modules/geotiff/test/geotiff-scan-source.spec.ts
@@ -24,6 +24,7 @@ test('GeoTIFFRasterSource exposes normalized scan metadata', async () => {
   const metadata = await source.getQueryMetadata();
   expect(metadata.sourceType).toBe('geotiff');
   expect(metadata.queryType).toBe('raster');
+  expect(metadata.execution).toEqual({status: 'supported', method: 'getRaster'});
   expect(metadata.columns.map(column => column.name)).toEqual(['band_1', 'band_2']);
   expect(metadata.columns[0]?.type).toBe('float32');
   expect(metadata.spatial?.bounds).toEqual({minimum: [-10, 20], maximum: [30, 60]});

--- a/modules/geotiff/test/ometiff-scan-source.spec.ts
+++ b/modules/geotiff/test/ometiff-scan-source.spec.ts
@@ -25,6 +25,7 @@ test('OMETiffImageSource exposes channel and pyramid scan metadata', async () =>
   });
   const metadata = await source.getQueryMetadata();
   expect(metadata.sourceType).toBe('ometiff');
+  expect(metadata.execution).toEqual({status: 'supported', method: 'getRaster'});
   expect(metadata.columns.map(column => column.name)).toEqual(['DAPI', 'GFP']);
   expect(metadata.capabilities.levelOfDetail).toBe('pushdown');
   expect(metadata.levels?.map(level => level.scale)).toEqual([

--- a/modules/json/src/ndjson-source.ts
+++ b/modules/json/src/ndjson-source.ts
@@ -62,6 +62,7 @@ export class NDJSONTableSource
         return createScanQueryMetadata({
           sourceType: 'ndjson',
           queryType: 'table',
+          execution: {status: 'supported', method: 'read'},
           schema: batch.schema,
           capabilities: {
             table: {

--- a/modules/json/test/ndjson-source.cross.spec.ts
+++ b/modules/json/test/ndjson-source.cross.spec.ts
@@ -6,6 +6,7 @@ test('NDJSONTableSource discovers schema and applies projection and limit', asyn
     new Blob(['{"name":"a","value":1}\n{"name":"b","value":2}\n'])
   );
   const metadata = await source.getQueryMetadata();
+  expect(metadata.execution).toEqual({status: 'supported', method: 'read'});
   expect(metadata.columns.map(column => column.name)).toEqual(['name', 'value']);
   const batches = [];
   for await (const batch of source.read({columns: ['name'], limit: 1})) batches.push(batch);

--- a/modules/loader-utils/src/index.ts
+++ b/modules/loader-utils/src/index.ts
@@ -307,6 +307,8 @@ export type {
   ScanBounds,
   ScanColumnMetadata,
   ScanColumnRole,
+  ScanExecutionMethod,
+  ScanExecutionSupport,
   ScanQueryCapabilities,
   ScanQueryMetadata,
   ScanQueryMetadataOptions,

--- a/modules/loader-utils/src/lib/scan-utils/scan-query-metadata.ts
+++ b/modules/loader-utils/src/lib/scan-utils/scan-query-metadata.ts
@@ -89,12 +89,37 @@ export type ScanSourceStatistics = Readonly<{
   byteLength?: number | bigint;
 }>;
 
+/** Common source method that executes the query described by scan metadata. */
+export type ScanExecutionMethod = 'read' | 'query' | 'getRaster' | 'scan';
+
+/**
+ * Conclusive execution status advertised by a scan-aware source.
+ *
+ * `supported` identifies the common method applications can call today. `metadata-only` means the
+ * source can populate discovery UI but deliberately does not claim common scan execution.
+ */
+export type ScanExecutionSupport =
+  | Readonly<{
+      /** The source executes common scan requests. */
+      status: 'supported';
+      /** Public source method that executes the request. */
+      method: ScanExecutionMethod;
+    }>
+  | Readonly<{
+      /** The source only supports query metadata discovery. */
+      status: 'metadata-only';
+      /** Concrete missing execution capability shown to users and documentation tooling. */
+      reason: string;
+    }>;
+
 /** Metadata used to populate a source-neutral query editor before executing a scan. */
 export type ScanQueryMetadata = Readonly<{
   /** Stable adapter or format identifier. */
   sourceType: string;
   /** Query family used to enable table, point-cloud, or raster controls. */
   queryType: 'table' | 'point-cloud' | 'raster';
+  /** Conclusive common execution status and entry point. */
+  execution: ScanExecutionSupport;
   /** Optional source display name. */
   name?: string;
   /** Optional source description. */
@@ -157,6 +182,8 @@ export type CreateScanQueryMetadataOptions = Readonly<{
   sourceType: string;
   /** Query family used to enable specialized controls. */
   queryType: ScanQueryMetadata['queryType'];
+  /** Conclusive common execution status and entry point. */
+  execution: ScanExecutionSupport;
   /** Complete query-visible schema. */
   schema: Schema;
   /** Portable and source-family-specific execution capabilities. */
@@ -183,6 +210,7 @@ export type CreateScanQueryMetadataOptions = Readonly<{
 export function createScanQueryMetadata(
   options: CreateScanQueryMetadataOptions
 ): ScanQueryMetadata {
+  validateScanExecutionSupport(options.queryType, options.execution);
   const schema: Schema = Object.freeze({
     fields: Object.freeze(
       options.schema.fields.map(field =>
@@ -206,6 +234,7 @@ export function createScanQueryMetadata(
   return Object.freeze({
     sourceType: options.sourceType,
     queryType: options.queryType,
+    execution: Object.freeze({...options.execution}),
     name: options.name,
     description: options.description,
     schema,
@@ -239,6 +268,30 @@ export function createScanQueryMetadata(
         )
       : undefined
   });
+}
+
+/** Ensures supported metadata names an entry point appropriate for its query family. */
+function validateScanExecutionSupport(
+  queryType: ScanQueryMetadata['queryType'],
+  execution: ScanExecutionSupport
+): void {
+  if (execution.status === 'metadata-only') {
+    if (!execution.reason.trim()) {
+      throw new Error('Metadata-only scan support requires a concrete reason');
+    }
+    return;
+  }
+
+  const validMethods: Record<ScanQueryMetadata['queryType'], readonly ScanExecutionMethod[]> = {
+    table: ['read', 'query'],
+    raster: ['getRaster'],
+    'point-cloud': ['scan']
+  };
+  if (!validMethods[queryType].includes(execution.method)) {
+    throw new Error(
+      `Scan execution method "${execution.method}" is not valid for ${queryType} queries`
+    );
+  }
 }
 
 function getNonEmptyMetadataValue(

--- a/modules/loader-utils/test/lib/scan-utils/scan-query-metadata.spec.ts
+++ b/modules/loader-utils/test/lib/scan-utils/scan-query-metadata.spec.ts
@@ -10,6 +10,7 @@ describe('createScanQueryMetadata', () => {
     const metadata = createScanQueryMetadata({
       sourceType: 'example',
       queryType: 'table',
+      execution: {status: 'supported', method: 'read'},
       schema: {
         fields: [
           {
@@ -65,6 +66,8 @@ describe('createScanQueryMetadata', () => {
       maximum: [180, 90]
     });
     expect(Object.isFrozen(metadata)).toBe(true);
+    expect(metadata.execution).toEqual({status: 'supported', method: 'read'});
+    expect(Object.isFrozen(metadata.execution)).toBe(true);
     expect(Object.isFrozen(metadata.columns)).toBe(true);
     expect(Object.isFrozen(metadata.schema.fields)).toBe(true);
   });
@@ -73,6 +76,7 @@ describe('createScanQueryMetadata', () => {
     const metadata = createScanQueryMetadata({
       sourceType: 'omezarr',
       queryType: 'raster',
+      execution: {status: 'supported', method: 'getRaster'},
       schema: {fields: [], metadata: {}},
       capabilities: {levelOfDetail: 'pushdown'},
       levels: [{index: 0, width: 1024, height: 512, scale: [1, 1]}]
@@ -81,5 +85,29 @@ describe('createScanQueryMetadata', () => {
     expect(metadata.levels).toEqual([{index: 0, width: 1024, height: 512, scale: [1, 1]}]);
     expect(Object.isFrozen(metadata.levels)).toBe(true);
     expect(Object.isFrozen(metadata.levels?.[0])).toBe(true);
+  });
+
+  test('requires a concrete reason for metadata-only sources', () => {
+    expect(() =>
+      createScanQueryMetadata({
+        sourceType: 'example',
+        queryType: 'point-cloud',
+        execution: {status: 'metadata-only', reason: '   '},
+        schema: {fields: [], metadata: {}},
+        capabilities: {}
+      })
+    ).toThrow('requires a concrete reason');
+  });
+
+  test('rejects execution methods from another query family', () => {
+    expect(() =>
+      createScanQueryMetadata({
+        sourceType: 'example',
+        queryType: 'raster',
+        execution: {status: 'supported', method: 'read'},
+        schema: {fields: [], metadata: {}},
+        capabilities: {}
+      })
+    ).toThrow('not valid for raster queries');
   });
 });

--- a/modules/netcdf/src/netcdf-source-loader.ts
+++ b/modules/netcdf/src/netcdf-source-loader.ts
@@ -48,6 +48,10 @@ export class NetCDFSource extends DataSource<string | Blob, NetCDFSourceOptions>
     return createScanQueryMetadata({
       sourceType: 'netcdf',
       queryType: 'raster',
+      execution: {
+        status: 'metadata-only',
+        reason: 'Common NetCDF variable and dimension-slice execution is not implemented.'
+      },
       name: typeof this.data === 'string' ? this.data.split('/').pop() : undefined,
       schema,
       capabilities: {

--- a/modules/netcdf/test/netcdf-source.spec.ts
+++ b/modules/netcdf/test/netcdf-source.spec.ts
@@ -10,6 +10,10 @@ test.runIf(isBrowser)('NetCDF source discovers raster metadata from a Blob', asy
   const metadata = await source.getQueryMetadata();
 
   expect(metadata.queryType).toBe('raster');
+  expect(metadata.execution).toEqual({
+    status: 'metadata-only',
+    reason: 'Common NetCDF variable and dimension-slice execution is not implemented.'
+  });
   expect(metadata.statistics?.rowCount).toBe(178);
   expect(metadata.columns.map(column => column.name)).toContain('wmoId');
   expect(metadata.columns.find(column => column.name === 'wmoId')?.metadata?.dimensions).toBe(

--- a/modules/orc/src/orc-source-loader.ts
+++ b/modules/orc/src/orc-source-loader.ts
@@ -56,6 +56,7 @@ export class ORCSource extends DataSource<string | Blob, ORCSourceOptions> {
     return createScanQueryMetadata({
       sourceType: 'orc',
       queryType: 'table',
+      execution: {status: 'supported', method: 'read'},
       schema,
       capabilities: {
         table: {

--- a/modules/orc/test/orc-loader.spec.ts
+++ b/modules/orc/test/orc-loader.spec.ts
@@ -27,6 +27,7 @@ test('ORCSource exposes footer metadata and shared projection/limit reads', asyn
 
   const metadata = await source.getQueryMetadata();
   expect(metadata.sourceType).toBe('orc');
+  expect(metadata.execution).toEqual({status: 'supported', method: 'read'});
   expect(metadata.columns.map(column => column.name)).toEqual(['name']);
   expect(metadata.statistics?.rowCount).toBe(4);
 

--- a/modules/parquet/src/delta-source.ts
+++ b/modules/parquet/src/delta-source.ts
@@ -68,6 +68,7 @@ export class DeltaTableSource
     return createScanQueryMetadata({
       sourceType: 'delta',
       queryType: 'table',
+      execution: {status: 'supported', method: 'read'},
       name: this.data instanceof Blob ? undefined : this.data,
       schema,
       capabilities: {table: PARQUET_TABLE_QUERY_CAPABILITIES},

--- a/modules/parquet/src/parquet-source-loader.ts
+++ b/modules/parquet/src/parquet-source-loader.ts
@@ -291,6 +291,7 @@ export class ParquetSource
     return createScanQueryMetadata({
       sourceType: 'parquet',
       queryType: 'table',
+      execution: {status: 'supported', method: 'read'},
       name: metadata.name,
       schema,
       capabilities: {table: this.tableQueryCapabilities},

--- a/modules/parquet/test/parquet-source-loader.spec.ts
+++ b/modules/parquet/test/parquet-source-loader.spec.ts
@@ -106,6 +106,7 @@ test('ParquetSource#getQueryMetadata exposes panel-ready schema and statistics',
 
   expect(metadata.sourceType).toBe('parquet');
   expect(metadata.queryType).toBe('table');
+  expect(metadata.execution).toEqual({status: 'supported', method: 'read'});
   expect(metadata.columns.length > 0).toBeTruthy();
   expect(metadata.capabilities.table?.projection).toBe('pushdown');
   expect(Number(metadata.statistics?.rowCount) > 0).toBeTruthy();

--- a/modules/potree/src/lib/potree-node-source.ts
+++ b/modules/potree/src/lib/potree-node-source.ts
@@ -148,6 +148,10 @@ export class PotreeNodesSource extends DataSource<string, PotreeSourceLoaderOpti
     return createScanQueryMetadata({
       sourceType: 'potree',
       queryType: 'point-cloud',
+      execution: {
+        status: 'metadata-only',
+        reason: 'Common point-cloud scan traversal is not implemented; use the Potree tile APIs.'
+      },
       schema,
       capabilities: {
         table: this.pointCloudQueryCapabilities,

--- a/modules/potree/test/potree-source.spec.ts
+++ b/modules/potree/test/potree-source.spec.ts
@@ -78,6 +78,7 @@ test('PotreeSourceLoader#exposes point-cloud query metadata', async t => {
 
   const metadata = await source.getQueryMetadata();
   t.equal(metadata.queryType, 'point-cloud');
+  t.equal(metadata.execution.status, 'metadata-only');
   t.ok(metadata.columns.some(column => column.role === 'color'));
   t.equal(metadata.capabilities.bounds, 'pushdown');
   t.equal(metadata.spatial?.bounds?.minimum.length, 3);

--- a/modules/scan/README.md
+++ b/modules/scan/README.md
@@ -49,3 +49,21 @@ async function discover(source: {getQueryMetadata(): Promise<ScanQueryMetadata>}
 `ScanQuery` is a portable control shape. Sources normalize unsupported fields and advertise their
 actual capabilities through `ScanQueryMetadata`; no React, GPU, or database dependency is pulled
 into applications that only use a format loader.
+
+Metadata also makes the execution conclusion explicit:
+
+```typescript
+const metadata = await source.getQueryMetadata();
+
+if (metadata.execution.status === 'supported') {
+  console.log(`Execute with source.${metadata.execution.method}()`);
+} else {
+  console.log(`Discovery only: ${metadata.execution.reason}`);
+}
+```
+
+A supported table source names `read()` or `query()`, a raster source names `getRaster()`, and a
+point-cloud source names `scan()`. Metadata-only sources must supply a user-facing reason. This
+keeps query panels and support documentation from inferring readiness from optimization
+capabilities: a residual operator is fully supported even though it performs more work, while a
+metadata-only source never presents an executable scan.

--- a/modules/scan/src/index.ts
+++ b/modules/scan/src/index.ts
@@ -33,6 +33,8 @@ export type {
   ScanBounds,
   ScanColumnMetadata,
   ScanColumnRole,
+  ScanExecutionMethod,
+  ScanExecutionSupport,
   ScanQueryCapabilities,
   ScanQueryMetadata,
   ScanQueryMetadataOptions,

--- a/modules/scan/test/scan-engine.spec.ts
+++ b/modules/scan/test/scan-engine.spec.ts
@@ -31,6 +31,7 @@ test('exposes the shared metadata vocabulary from the optional scan package', ()
   const metadata = createScanQueryMetadata({
     sourceType: 'test',
     queryType: 'table',
+    execution: {status: 'supported', method: 'read'},
     schema: table.schema,
     capabilities: {
       table: {

--- a/modules/sql/src/arrow-table-source.ts
+++ b/modules/sql/src/arrow-table-source.ts
@@ -41,6 +41,7 @@ export class ArrowTableSource extends DataSource<ArrowTable, ArrowTableSourceOpt
     return createScanQueryMetadata({
       sourceType: 'arrow-table',
       queryType: 'table',
+      execution: {status: 'supported', method: 'read'},
       schema,
       capabilities: {table: ARROW_TABLE_QUERY_CAPABILITIES},
       columnRoles: getArrowColumnRoles(schema.fields.map(field => field.name)),

--- a/modules/sql/test/arrow-query.spec.ts
+++ b/modules/sql/test/arrow-query.spec.ts
@@ -35,6 +35,7 @@ test('ArrowTableSource exposes shared metadata and bounded scan batches', async 
 
   const metadata = await source.getQueryMetadata();
   expect(metadata.queryType).toBe('table');
+  expect(metadata.execution).toEqual({status: 'supported', method: 'read'});
   expect(metadata.columns.map(column => [column.name, column.role])).toEqual([
     ['x', 'x'],
     ['value', 'attribute']

--- a/modules/zarr/src/geo-zarr-source-loader.ts
+++ b/modules/zarr/src/geo-zarr-source-loader.ts
@@ -197,6 +197,7 @@ export class GeoZarrRasterSource
     return createScanQueryMetadata({
       sourceType: 'geozarr',
       queryType: 'raster',
+      execution: {status: 'supported', method: 'getRaster'},
       name: metadata.name,
       schema: {fields, metadata: {}},
       capabilities: {

--- a/modules/zarr/src/ome-zarr-source-loader.ts
+++ b/modules/zarr/src/ome-zarr-source-loader.ts
@@ -355,6 +355,7 @@ export class OMEZarrImageSource extends ZarrSource implements ScanQueryMetadataP
     return createScanQueryMetadata({
       sourceType: 'omezarr',
       queryType: 'raster',
+      execution: {status: 'supported', method: 'getRaster'},
       name: metadata.name,
       description: 'OME-Zarr multiscale image',
       schema: {fields: [], metadata: {}},

--- a/modules/zarr/test/geozarr-scan-source.spec.ts
+++ b/modules/zarr/test/geozarr-scan-source.spec.ts
@@ -19,6 +19,7 @@ test('GeoZarrRasterSource exposes scan metadata for variables and slices', async
   });
   const metadata = await source.getQueryMetadata();
   expect(metadata.sourceType).toBe('geozarr');
+  expect(metadata.execution).toEqual({status: 'supported', method: 'getRaster'});
   expect(metadata.columns.map(column => column.name)).toEqual(['temperature']);
   expect(metadata.capabilities.levelOfDetail).toBe('unsupported');
   expect(metadata.spatial?.coordinateReferenceSystems).toEqual(['EPSG:4326']);

--- a/modules/zarr/test/ome-zarr-source.browser.spec.ts
+++ b/modules/zarr/test/ome-zarr-source.browser.spec.ts
@@ -28,6 +28,7 @@ test('OMEZarrSourceLoader supports browser-relative store URLs', async t => {
 test('OMEZarrImageSource reads metadata and channel data in browsers', async t => {
   const source = createInMemoryOMEZarrSource();
   const metadata = await source.getMetadata();
+  const queryMetadata = await source.getQueryMetadata();
   const planarRaster = await source.getRaster({channels: [0, 2]});
   const interleavedRaster = await source.getRaster({channels: [0, 1], interleaved: true});
 
@@ -36,6 +37,7 @@ test('OMEZarrImageSource reads metadata and channel data in browsers', async t =
   t.equal(metadata.height, 2);
   t.equal(metadata.bandCount, 3);
   t.equal(metadata.dtype, 'uint8');
+  t.deepEqual(queryMetadata.execution, {status: 'supported', method: 'getRaster'});
   t.deepEqual(metadata.labels, ['t', 'c', 'z', 'y', 'x']);
   t.deepEqual(metadata.tileSize, {width: 3, height: 2});
   t.deepEqual(metadata.channels, [

--- a/website/src/components/docs/scan-query-panel.tsx
+++ b/website/src/components/docs/scan-query-panel.tsx
@@ -55,6 +55,8 @@ export function ScanQueryPanel({
   }, [value]);
 
   const columns = metadata?.columns || [];
+  const execution = metadata?.execution;
+  const isExecutable = execution?.status === 'supported';
   const isPointCloud = metadata?.queryType === 'point-cloud';
   const hasLimit = metadata?.capabilities.table?.limit && metadata.capabilities.table.limit !== 'unsupported';
   const hasBounds = metadata?.capabilities.bounds && metadata.capabilities.bounds !== 'unsupported';
@@ -85,12 +87,20 @@ export function ScanQueryPanel({
       {metadata ? (
         <>
           <MetadataSummary>
+            <SupportBadge $supported={isExecutable}>
+              {execution?.status === 'supported'
+                ? `Scan supported · ${execution.method}`
+                : 'Metadata only'}
+            </SupportBadge>
             <span>{columns.length} columns</span>
             {metadata.statistics?.rowCount !== undefined ? <span>{String(metadata.statistics.rowCount)} rows</span> : null}
             {metadata.spatial?.coordinateReferenceSystems?.[0] ? (
               <span>{metadata.spatial.coordinateReferenceSystems[0]}</span>
             ) : null}
           </MetadataSummary>
+          {execution?.status === 'metadata-only' ? (
+            <SupportMessage>{execution.reason}</SupportMessage>
+          ) : null}
           <FieldGroup>
             <FieldLabel>Output columns</FieldLabel>
             <ColumnGrid>
@@ -192,6 +202,7 @@ export function ScanQueryPanel({
           </InlineFields>
           <ApplyButton
             type="button"
+            disabled={!isExecutable}
             onClick={() => {
               const limit = limitText.trim() ? Number(limitText) : undefined;
               const boundingBox = parseBounds(boundingBoxText);
@@ -210,7 +221,7 @@ export function ScanQueryPanel({
               });
             }}
           >
-            Apply scan parameters
+            {isExecutable ? 'Apply scan parameters' : 'Scan execution unavailable'}
           </ApplyButton>
         </>
       ) : (
@@ -269,6 +280,18 @@ const MetadataSummary = styled.div`
   color: #475467;
   font-size: 0.82rem;
   margin-bottom: 10px;
+`;
+const SupportBadge = styled.span<{$supported: boolean}>`
+  border-radius: 999px;
+  padding: 2px 8px;
+  color: ${({$supported}) => ($supported ? '#067647' : '#7a2e0e')};
+  background: ${({$supported}) => ($supported ? '#ecfdf3' : '#fff4ed')};
+  font-weight: 600;
+`;
+const SupportMessage = styled.div`
+  margin: -4px 0 12px;
+  color: #7a2e0e;
+  font-size: 0.82rem;
 `;
 const FieldGroup = styled.div`
   display: flex;
@@ -330,6 +353,11 @@ const ApplyButton = styled.button`
   color: white;
   background: #475467;
   cursor: pointer;
+
+  &:disabled {
+    background: #98a2b3;
+    cursor: not-allowed;
+  }
 `;
 const EmptyState = styled.div`
   color: #667085;


### PR DESCRIPTION
## Goals

- Replace ambiguous scan-readiness labels with a conclusive, machine-readable support contract.
- Finish existing work-in-progress format adapters before expanding into more format families.
- Make scan metadata, the shared query panel, and the end-user roadmap report the same support truth.

## Changes

- Add a required `ScanQueryMetadata.execution` discriminated union that declares either a supported common entry point (`read`, `query`, `getRaster`, or `scan`) or a concrete metadata-only reason.
- Validate that supported execution methods match the scan family and freeze the declaration with the rest of the metadata.
- Classify every existing scan-aware adapter as supported or metadata-only, including Arrow, CSV, NDJSON, ORC, FlatGeobuf, Parquet, Iceberg/Delta, SQL, raster, point-cloud, and NetCDF sources.
- Complete GeoPackage as a `TableScanSource`: discover schema without decoding the feature table and execute residual predicate, projection, and global-limit queries while preserving Arrow vector types and cancellation behavior.
- Update the shared scan panel to show the declared execution status and method, explain metadata-only limitations, and disable unavailable execution.
- Rewrite the end-user support matrix and roadmap around only four conclusive states: Supported, Metadata only, Not implemented, and Outside protocol. Keep physical pushdown and optimization work separate from correctness support.
- Add focused contract, adapter, GeoPackage execution, and UI-facing metadata coverage.

## Verification

- `yarn lint fix`
- `yarn build`
- `yarn build-workers`
- `yarn test-node` — 360 passed, 6 skipped on the final rebased tree
- `yarn test-headless` — full suite: 2,972 passed, 40 skipped; final-rebase affected suite: 46 passed
- `yarn test-audit` — 0 violations
- `yarn test-coverage-check` — 0 violations across 53 packages
- `cd website && yarn build` — successful (with existing Docusaurus warnings)
