### PR TITLE
feat(3d-tiles): rebase content lifecycle and clipping culling

### DIFF
--- a/docs/modules/tiles/api-reference/tile-3d.md
+++ b/docs/modules/tiles/api-reference/tile-3d.md
@@ -26,11 +26,11 @@ Returns `true` when traversal may request a source-managed lazy child-header gro
 
 ###### `boundingVolume` (BoundingVolume)
 
+###### `contentVisibility(frameState)`
+
+Returns the render-content visibility classification after culling against the viewport and any optional world-space clipping planes. Clipping planes affect rendering only; hierarchy traversal continues to use the tile bounding volume.
+
 A bounding volume that encloses a tile or its content. Exactly one box, region, or sphere property is required. ([`Reference`](https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/master/specification#bounding-volume))
-
-###### `contentBoundingVolumes` (BoundingVolume[])
-
-The transformed content bounding volumes, one for each content entry that declares a `boundingVolume`. The array is empty when no content entry declares one. These volumes are for render culling; traversal continues to use the tile's `boundingVolume`.
 
 ###### `viewerRequestVolume` (BoundingVolume | null)
 

--- a/modules/tiles/src/tileset-3d/common/tile-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tile-3d.ts
@@ -155,10 +155,18 @@ export class Tile3D {
   private _visibilityPlaneMask: any;
   private _visible: boolean | undefined = undefined;
 
+  private _contentBoundingVolume: any;
   private _contentBoundingVolumes: any[] = [];
+  /** Source content-volume headers retained after render content is unloaded. */
+  private _contentBoundingVolumeHeaders: any[] = [];
   private _viewerRequestVolume: any;
 
-  /** Transformed bounding volumes for all content entries that declare one. */
+  /** Bounding volume used to cull the tile's first renderable content entry. */
+  get contentBoundingVolume(): any {
+    return this._contentBoundingVolume;
+  }
+
+  /** All transformed render-content bounding volumes, including tile-volume fallbacks. */
   get contentBoundingVolumes(): any[] {
     return this._contentBoundingVolumes;
   }
@@ -777,30 +785,44 @@ export class Tile3D {
   }
 
   /**
-   * Determines whether renderable content intersects the current culling volume.
-   * Traversal continues to use the tile volume; content volumes only constrain rendering.
-   * @param frameState Current camera and culling state.
-   * @returns Content visibility classification.
+   * Determines whether renderable content intersects the view and configured clipping planes.
+   *
+   * Clipping planes are render-only constraints; traversal continues to use the tile volume.
+   *
+   * @param frameState Current camera, culling, and optional clipping-plane state.
+   * @returns The content visibility classification.
    */
   contentVisibility(frameState: FrameState): number {
-    const contentVolumes = this.contentBoundingVolumes.length
-      ? this.contentBoundingVolumes
+    const contentVolumes = this._contentBoundingVolumes.length
+      ? this._contentBoundingVolumes
       : [this.boundingVolume];
-    let intersecting = false;
+    let visibleVolume = false;
+    let intersectingVolume = false;
     for (const contentVolume of contentVolumes) {
-      const visibility =
-        this._visibilityPlaneMask === CullingVolume.MASK_INSIDE
-          ? INTERSECTION.INSIDE
-          : frameState.cullingVolume.computeVisibility(contentVolume);
-      if (visibility === INTERSECTION.OUTSIDE) {
-        continue;
+      let visibility = INTERSECTION.INSIDE;
+      if (this._visibilityPlaneMask !== CullingVolume.MASK_INSIDE) {
+        visibility = frameState.cullingVolume.computeVisibility(contentVolume);
+        if (visibility === INTERSECTION.OUTSIDE) {
+          continue;
+        }
       }
-      intersecting = intersecting || visibility === INTERSECTION.INTERSECTING;
-      if (!intersecting) {
-        return INTERSECTION.INSIDE;
+      let clipped = false;
+      for (const clippingPlane of frameState.clippingPlanes || []) {
+        if (contentVolume.intersectPlane(clippingPlane) === INTERSECTION.OUTSIDE) {
+          clipped = true;
+          break;
+        }
+      }
+      if (!clipped) {
+        visibleVolume = true;
+        intersectingVolume = intersectingVolume || visibility === INTERSECTION.INTERSECTING;
       }
     }
-    return intersecting ? INTERSECTION.INTERSECTING : INTERSECTION.OUTSIDE;
+    if (!visibleVolume) {
+      return INTERSECTION.OUTSIDE;
+    }
+    return intersectingVolume ? INTERSECTION.INTERSECTING : INTERSECTION.INSIDE;
+  }
   }
 
   /**
@@ -925,7 +947,8 @@ export class Tile3D {
   }
 
   _initializeBoundingVolumes(tileHeader) {
-    this._contentBoundingVolumes = [];
+    this._contentBoundingVolume = null;
+    this._contentBoundingVolumeHeaders = [];
     this._viewerRequestVolume = null;
 
     this._updateBoundingVolume(tileHeader);
@@ -1036,11 +1059,25 @@ export class Tile3D {
       );
     }
 
-    const contentHeaders = Array.isArray(header.content) ? header.content : [header.content];
-    const contentVolumes = contentHeaders.filter(contentHeader => contentHeader?.boundingVolume);
-    this._contentBoundingVolumes = contentVolumes.map(contentHeader =>
-      createBoundingVolume(contentHeader.boundingVolume, this.computedTransform)
-    );
+    const content = header.content;
+    if (content) {
+      this._contentBoundingVolumeHeaders = Array.isArray(content) ? content : [content];
+    }
+    const contentHeaders = content
+      ? Array.isArray(content)
+        ? content
+        : [content]
+      : this._contentBoundingVolumeHeaders;
+    this._contentBoundingVolumes = contentHeaders
+      .filter(headerEntry => headerEntry?.boundingVolume)
+      .map(headerEntry => createBoundingVolume(headerEntry.boundingVolume, this.computedTransform));
+    if (
+      !contentHeaders.length ||
+      contentHeaders.some(headerEntry => !headerEntry?.boundingVolume)
+    ) {
+      this._contentBoundingVolumes.push(this.boundingVolume);
+    }
+    this._contentBoundingVolume = this._contentBoundingVolumes[0] || null;
   }
 
   /**

--- a/modules/tiles/src/tileset-3d/common/tile-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tile-3d.ts
@@ -823,7 +823,6 @@ export class Tile3D {
     }
     return intersectingVolume ? INTERSECTION.INTERSECTING : INTERSECTION.INSIDE;
   }
-  }
 
   /**
    * Computes the (potentially approximate) distance from the closest point of the tile's bounding volume to the camera.

--- a/modules/tiles/src/tileset-3d/common/tile-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tile-3d.ts
@@ -799,7 +799,7 @@ export class Tile3D {
     let visibleVolume = false;
     let intersectingVolume = false;
     for (const contentVolume of contentVolumes) {
-      let visibility = INTERSECTION.INSIDE;
+      let visibility: number = INTERSECTION.INSIDE;
       if (this._visibilityPlaneMask !== CullingVolume.MASK_INSIDE) {
         visibility = frameState.cullingVolume.computeVisibility(contentVolume);
         if (visibility === INTERSECTION.OUTSIDE) {

--- a/modules/tiles/src/tileset-3d/common/tile-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tile-3d.ts
@@ -1067,15 +1067,15 @@ export class Tile3D {
         ? content
         : [content]
       : this._contentBoundingVolumeHeaders;
-    this._contentBoundingVolumes = contentHeaders
-      .filter(headerEntry => headerEntry?.boundingVolume)
-      .map(headerEntry => createBoundingVolume(headerEntry.boundingVolume, this.computedTransform));
-    if (
-      !contentHeaders.length ||
-      contentHeaders.some(headerEntry => !headerEntry?.boundingVolume)
-    ) {
-      this._contentBoundingVolumes.push(this.boundingVolume);
-    }
+    // Preserve source order: an unbounded content entry uses the tile volume at its
+    // corresponding index rather than being appended after bounded sibling entries.
+    this._contentBoundingVolumes = contentHeaders.length
+      ? contentHeaders.map(headerEntry =>
+          headerEntry?.boundingVolume
+            ? createBoundingVolume(headerEntry.boundingVolume, this.computedTransform)
+            : this.boundingVolume
+        )
+      : [this.boundingVolume];
     this._contentBoundingVolume = this._contentBoundingVolumes[0] || null;
   }
 

--- a/modules/tiles/src/tileset-3d/helpers/frame-state.ts
+++ b/modules/tiles/src/tileset-3d/helpers/frame-state.ts
@@ -27,6 +27,8 @@ export type FrameState = {
   topDownViewport: GeospatialViewport; // Use it to calculate projected radius for a tile
   height: number;
   cullingVolume: CullingVolume;
+  /** Optional world-space clipping planes applied to render-content culling. */
+  clippingPlanes?: Plane[];
   frameNumber: number; // TODO: This can be the same between updates, what number is unique for between updates?
   sseDenominator: number; // Assumes fovy = 60 degrees
   /** View-dependent density used by perspective dynamic screen-space error for this traversal. */
@@ -161,6 +163,7 @@ export function getFrameState(
     topDownViewport,
     height,
     cullingVolume,
+    clippingPlanes: viewport.clippingPlanes,
     frameNumber, // TODO: This can be the same between updates, what number is unique for between updates?
     sseDenominator: 1.15, // Assumes fovy = 60 degrees
     // Tileset3D fills this immediately before traversal because it depends on the root volume.

--- a/modules/tiles/src/types.ts
+++ b/modules/tiles/src/types.ts
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {Vector3} from '@math.gl/core';
+import type {Plane} from '@math.gl/culling';
 
 export type BoundingRectangle = {
   width: number;
@@ -26,6 +27,8 @@ export type Viewport = {
    * Orthographic 3D Tiles traversal requires a positive, finite value to calculate SSE.
    */
   metersPerPixel?: number;
+  /** Optional world-space clipping planes used to cull renderable tile content. */
+  clippingPlanes?: Plane[];
   distanceScales: {
     unitsPerMeter: number[];
     metersPerUnit: number[];


### PR DESCRIPTION
## Goals

Rebase the 3D Tiles content-volume lifecycle and clipping tranche onto the latest `master`, carrying forward the review fixes and removing the CI syntax failure.

## Changes

- Retain source content-volume metadata across content unloads and transform updates.
- Support plural content volumes while preserving unbounded-content fallback markers.
- Aggregate visibility across all surviving content volumes before applying clipping planes.
- Add optional world-space clipping planes to structural viewport/frame state.
- Keep clipping as render-content culling while traversal continues to use tile bounds.
- Include focused TSDoc and API documentation for the lifecycle and culling behavior.

## Validation

- Branch is based on latest `master` (`a55081b`, including #3815).
- Removed the duplicate closing brace that caused the previous TypeScript build failure.
- All review comments from #3814 were addressed in the carried-forward changes:
  - plural `contentBoundingVolumes` is preserved;
  - unbounded content markers are retained;
  - visibility is aggregated across all surviving content volumes.
- CI will rerun build, tests, lint, coverage, and documentation checks.

Supersedes #3814 and #3806.