### PR TITLE
feat(services): complete tile-grid and CRS tranches

### DIFF
--- a/docs/modules/services/README.md
+++ b/docs/modules/services/README.md
@@ -19,10 +19,21 @@ capability graph is intentionally separate from source loading, so direct source
 remains the simplest path when the endpoint is already known.
 
 ```ts
-import {discoverArcGISCapabilities, selectArcGISService} from '@loaders.gl/services';
+import {
+  createServiceSource,
+  discoverArcGISCapabilities,
+  selectArcGISService
+} from '@loaders.gl/services';
+import {coreApi} from '@loaders.gl/core';
 
 const graph = await discoverArcGISCapabilities('https://example.com/arcgis/rest/services');
 const imagery = graph && selectArcGISService(graph, {kind: 'image', format: 'lerc'});
+const source = imagery && createServiceSource(
+  imagery.url,
+  {},
+  imagery.capabilities.type,
+  coreApi
+);
 ```
 
 Discovery performs one metadata request per discovered service. Pass a custom `fetch` function when

--- a/modules/loader-utils/src/index.ts
+++ b/modules/loader-utils/src/index.ts
@@ -370,7 +370,7 @@ export type {
   VectorSourceMetadata
 } from './lib/sources/vector-source';
 
-export type {TileSource} from './lib/sources/tile-source';
+export type {TileSource, TileGrid} from './lib/sources/tile-source';
 export type {TileSourceMetadata, GetTileParameters} from './lib/sources/tile-source';
 export type {GetTileDataBatchResult, GetTileDataParameters} from './lib/sources/tile-source';
 export {getTileDataBatch} from './lib/sources/tile-source-utils';

--- a/modules/loader-utils/src/lib/sources/service-capabilities.ts
+++ b/modules/loader-utils/src/lib/sources/service-capabilities.ts
@@ -9,6 +9,7 @@ export type GeoServiceType =
   | 'wfs'
   | 'csw'
   | 'arcgis-map-server'
+  | 'arcgis-vector-tile-server'
   | 'arcgis-image-server'
   | 'arcgis-feature-server'
   | 'unknown';

--- a/modules/loader-utils/src/lib/sources/tile-source.ts
+++ b/modules/loader-utils/src/lib/sources/tile-source.ts
@@ -53,6 +53,8 @@ export type TileSourceMetadata = {
   maxZoom?: number;
   /** Bounding box of tiles in this tileset `[[w, s], [e, n]]`  */
   boundingBox?: [min: [x: number, y: number], max: [x: number, y: number]];
+  /** Advertised tile grid, when the service exposes matrix or level metadata. */
+  tileGrid?: TileGrid;
 
   /** Layer information */
   layer?: {
@@ -62,6 +64,20 @@ export type TileSourceMetadata = {
     boundingBox?: [number, number, number, number];
     layers: TileSourceLayer[];
   };
+};
+
+/** Normalized tile matrix information shared by WMTS and vendor tile services. */
+export type TileGrid = {
+  /** Coordinate reference system used by the grid. */
+  crs?: CRSIdentifier;
+  /** Tile width and height in pixels. */
+  tileSize?: [number, number];
+  /** Top-left origin in grid coordinates. */
+  origin?: [number, number];
+  /** Matrix identifiers in zoom order. */
+  matrixIds?: string[];
+  /** Matrix width and height in tile units in zoom order. */
+  matrixSizes?: Array<[number, number]>;
 };
 
 /**

--- a/modules/services/src/arcgis/arcgis-capability-graph.ts
+++ b/modules/services/src/arcgis/arcgis-capability-graph.ts
@@ -108,7 +108,7 @@ function normalizeServiceCapabilities(
   const crs = getServiceCrs(metadata);
   const capabilities: ServiceCapabilities = {
     url: service.url,
-    type: getServiceCapabilityType(kind),
+    type: getServiceCapabilityType(serviceType),
     name: service.name,
     title: typeof metadata.name === 'string' ? metadata.name : undefined,
     abstract: typeof metadata.description === 'string' ? metadata.description : undefined,
@@ -128,12 +128,13 @@ function normalizeServiceCapabilities(
 }
 
 /** Maps a discovered ArcGIS family to the shared service capability type. */
-function getServiceCapabilityType(
-  kind: ArcGISServiceCapabilities['kind']
-): ServiceCapabilities['type'] {
-  if (kind === 'vector') return 'arcgis-feature-server';
-  if (kind === 'image') return 'arcgis-image-server';
-  if (kind === 'tile') return 'arcgis-map-server';
+function getServiceCapabilityType(serviceType: string): ServiceCapabilities['type'] {
+  if (serviceType.includes('vectortile') || serviceType.includes('vector-tile')) {
+    return 'arcgis-vector-tile-server';
+  }
+  if (serviceType.includes('feature')) return 'arcgis-feature-server';
+  if (serviceType.includes('image')) return 'arcgis-image-server';
+  if (serviceType.includes('map')) return 'arcgis-map-server';
   return 'unknown';
 }
 
@@ -141,7 +142,12 @@ function getServiceCapabilityType(
 function getServiceKind(serviceType: string): ArcGISServiceCapabilities['kind'] {
   if (serviceType.includes('feature')) return 'vector';
   if (serviceType.includes('image')) return 'image';
-  if (serviceType.includes('map') || serviceType.includes('vector-tile')) return 'tile';
+  if (
+    serviceType.includes('map') ||
+    serviceType.includes('vectortile') ||
+    serviceType.includes('vector-tile')
+  )
+    return 'tile';
   return 'unknown';
 }
 

--- a/modules/services/src/arcgis/arcgis-map-tile-source-loader.ts
+++ b/modules/services/src/arcgis/arcgis-map-tile-source-loader.ts
@@ -102,7 +102,22 @@ export class ArcGISMapTileSource
         name: metadata.name || '',
         srs: spatialReferenceWkid ? [`EPSG:${spatialReferenceWkid}`] : [],
         layers: []
-      }
+      },
+      tileGrid: metadata.tileInfo
+        ? {
+            crs: (metadata.tileInfo.spatialReference as {wkid?: number} | undefined)?.wkid
+              ? `EPSG:${(metadata.tileInfo.spatialReference as {wkid: number}).wkid}`
+              : undefined,
+            tileSize:
+              metadata.tileInfo.rows && metadata.tileInfo.cols
+                ? [metadata.tileInfo.cols, metadata.tileInfo.rows]
+                : undefined,
+            origin: metadata.tileInfo.origin
+              ? [metadata.tileInfo.origin.x, metadata.tileInfo.origin.y]
+              : undefined,
+            matrixIds: metadata.tileInfo.lods?.map(lod => String(lod.level))
+          }
+        : undefined
     };
   }
 

--- a/modules/services/src/arcgis/arcgis-vector-tile-server-source-loader.ts
+++ b/modules/services/src/arcgis/arcgis-vector-tile-server-source-loader.ts
@@ -180,7 +180,7 @@ export const ArcGISVectorTileServerSourceLoader = {
   fromBlob: false,
   options: {'arcgis-vector-tile-server': {}},
   defaultOptions: {'arcgis-vector-tile-server': {}},
-  testURL: (url: string): boolean => /\/vectortileserver(?:\/|$)/i.test(url),
+  testURL: (url: string): boolean => /\/vectortileserver(?:[\/?#]|$)/i.test(url),
   createDataSource: (
     url: string,
     options: ArcGISVectorTileServerSourceLoaderOptions = {},

--- a/modules/services/src/index.ts
+++ b/modules/services/src/index.ts
@@ -63,4 +63,4 @@ export type {
 } from './arcgis/arcgis-vector-tile-server-source-loader';
 
 export type {ServiceLoader} from './service-registry';
-export {getServiceLoader} from './service-registry';
+export {createServiceSource, getServiceLoader} from './service-registry';

--- a/modules/services/src/service-registry.ts
+++ b/modules/services/src/service-registry.ts
@@ -7,6 +7,7 @@ import {ArcGISImageServerSourceLoader} from './arcgis/arcgis-image-server-source
 import {ArcGISImageTileSourceLoader} from './arcgis/arcgis-image-tile-source-loader';
 import {ArcGISMapTileSourceLoader} from './arcgis/arcgis-map-tile-source-loader';
 import {ArcGISVectorTileServerSourceLoader} from './arcgis/arcgis-vector-tile-server-source-loader';
+import type {CoreAPI, DataSource, DataSourceOptions} from '@loaders.gl/loader-utils';
 
 /** A source loader currently exposed through the services package. */
 export type ServiceLoader =
@@ -37,4 +38,27 @@ export function getServiceLoader(serviceType: string): ServiceLoader | undefined
     serviceLoader =>
       serviceLoader.id === normalizedServiceType || serviceLoader.type === normalizedServiceType
   );
+}
+
+/**
+ * Creates a service source from an explicit capability type or URL detection.
+ *
+ * The optional type should come from normalized service capabilities. When it is
+ * omitted, the small registry tests each known service loader in declaration order.
+ * A CoreAPI is required because image and tile sources decode responses through
+ * the application's configured loaders.gl core integration.
+ */
+export function createServiceSource(
+  url: string,
+  options: DataSourceOptions = {},
+  serviceType: string | undefined,
+  coreApi: CoreAPI
+): DataSource<unknown, DataSourceOptions> {
+  const serviceLoader = serviceType
+    ? getServiceLoader(serviceType)
+    : SERVICE_LOADERS.find(loader => loader.testURL(url));
+  if (!serviceLoader) {
+    throw new Error(`No service loader recognized type or URL: ${serviceType || url}`);
+  }
+  return serviceLoader.createDataSource(url, options, coreApi);
 }

--- a/modules/services/test/arcgis/arcgis-server.spec.ts
+++ b/modules/services/test/arcgis/arcgis-server.spec.ts
@@ -55,6 +55,33 @@ vitestTest('ArcGISMapTileSource distributes requests across configured service U
   expect(url.origin).toBe('https://tiles-b.example.com');
 });
 
+vitestTest('ArcGISMapTileSource exposes its cached tile grid', async () => {
+  const source = new ArcGISMapTileSource('https://example.com/MapServer', {
+    'arcgis-map-server': {
+      metadata: {
+        name: 'Basemap',
+        spatialReference: {wkid: 3857},
+        tileInfo: {
+          rows: 256,
+          cols: 256,
+          origin: {x: -20037508, y: 20037508},
+          spatialReference: {wkid: 3857},
+          lods: [{level: 0}, {level: 1}]
+        }
+      }
+    }
+  });
+
+  expect(await source.getMetadata()).toMatchObject({
+    tileGrid: {
+      crs: 'EPSG:3857',
+      tileSize: [256, 256],
+      origin: [-20037508, 20037508],
+      matrixIds: ['0', '1']
+    }
+  });
+});
+
 vitestTest('ArcGISImageTileSource builds exportImage tile requests', () => {
   const source = new ArcGISImageTileSource('https://example.com/ImageServer', {
     'arcgis-image-server-tiles': {tileSize: 512, parameters: {time: '2020-01-01'}}

--- a/modules/services/test/arcgis/arcgis-server.spec.ts
+++ b/modules/services/test/arcgis/arcgis-server.spec.ts
@@ -55,6 +55,52 @@ vitestTest('ArcGISMapTileSource distributes requests across configured service U
   expect(url.origin).toBe('https://tiles-b.example.com');
 });
 
+vitestTest('ArcGISMapTileSource fetches and decodes cached tiles', async () => {
+  let parseCount = 0;
+  const source = new ArcGISMapTileSource(
+    'https://example.com/MapServer',
+    {'arcgis-map-server': {mode: 'cached'}},
+    {
+      parse: async () => {
+        parseCount++;
+        return {width: 1, height: 1};
+      }
+    } as never
+  );
+  source.fetch = async () => new Response(new Uint8Array([1, 2, 3]));
+
+  expect(await source.getTile({x: 1, y: 2, z: 3})).toEqual({width: 1, height: 1});
+  expect(parseCount).toBe(1);
+});
+
+vitestTest('ArcGISMapTileSource falls back to dynamic export for incompatible caches', async () => {
+  const source = new ArcGISMapTileSource(
+    'https://example.com/MapServer',
+    {
+      'arcgis-map-server': {
+        mode: 'auto',
+        metadata: {tileInfo: {rows: 512, cols: 512}}
+      }
+    },
+    {parse: async () => ({width: 1, height: 1})} as never
+  );
+  let requestedURL = '';
+  source.fetch = async url => {
+    requestedURL = url;
+    return new Response(new Uint8Array([1]));
+  };
+
+  await source.getTile({x: 0, y: 0, z: 0});
+  expect(new URL(requestedURL).pathname).toBe('/MapServer/export');
+});
+
+vitestTest('ArcGISMapTileSource expands custom tile URL templates', () => {
+  const source = new ArcGISMapTileSource('https://example.com/MapServer', {
+    'arcgis-map-server': {urlTemplate: 'https://tiles.example/{z}/{y}/{x}.png?token=abc'}
+  });
+  expect(source.getTileURL({x: 3, y: 4, z: 5})).toBe('https://tiles.example/5/4/3.png?token=abc');
+});
+
 vitestTest('ArcGISMapTileSource exposes its cached tile grid', async () => {
   const source = new ArcGISMapTileSource('https://example.com/MapServer', {
     'arcgis-map-server': {

--- a/modules/services/test/services-module.spec.ts
+++ b/modules/services/test/services-module.spec.ts
@@ -134,4 +134,22 @@ describe('@loaders.gl/services', () => {
     expect(graph?.nodes[0].capabilities.formats).toEqual(['json']);
     expect(selectArcGISService(graph!, {format: 'geojson'})).toBeUndefined();
   });
+
+  test('normalizes VectorTileServer directory entries', async () => {
+    const graph = await discoverArcGISCapabilities('https://example.com/arcgis/rest/services', {
+      fetch: async url =>
+        new Response(
+          JSON.stringify(
+            url.endsWith('/services?f=pjson')
+              ? {services: [{name: 'Basemap', type: 'VectorTileServer'}]}
+              : {tileInfo: {format: 'pbf'}}
+          )
+        )
+    });
+
+    expect(graph?.nodes[0]).toMatchObject({
+      kind: 'tile',
+      capabilities: {type: 'arcgis-vector-tile-server', formats: ['pbf']}
+    });
+  });
 });

--- a/modules/services/test/services-module.spec.ts
+++ b/modules/services/test/services-module.spec.ts
@@ -4,10 +4,12 @@ import {
   ArcGISImageTileSourceLoader,
   ArcGISMapTileSourceLoader,
   ArcGISVectorTileServerSourceLoader,
+  createServiceSource,
   discoverArcGISCapabilities,
   getServiceLoader,
   selectArcGISService
 } from '../src/index';
+import {coreApi} from '@loaders.gl/core';
 import {getArcGISServices} from '../src/arcgis/arcgis-server';
 import * as bundledServices from '../src/bundled';
 import * as unbundledServices from '../src/unbundled';
@@ -34,6 +36,28 @@ describe('@loaders.gl/services', () => {
     expect(getServiceLoader('ArcGIS-Feature-Server')).toBe(ArcGISFeatureServerSourceLoader);
     expect(getServiceLoader('arcgis-vector-tile-server')).toBe(ArcGISVectorTileServerSourceLoader);
     expect(getServiceLoader('unknown-service')).toBeUndefined();
+  });
+
+  test('creates a source from normalized capability type or URL', () => {
+    expect(
+      createServiceSource(
+        'https://example.com/arcgis/rest/services/Basemap/VectorTileServer',
+        {},
+        'arcgis-vector-tile-server',
+        coreApi
+      )
+    ).toBeInstanceOf(Object);
+    expect(
+      createServiceSource(
+        'https://example.com/arcgis/rest/services/Roads/FeatureServer/0',
+        {},
+        undefined,
+        coreApi
+      )
+    ).toBeInstanceOf(Object);
+    expect(() =>
+      createServiceSource('https://example.com/service', {}, 'unknown', coreApi)
+    ).toThrow('No service loader recognized type or URL');
   });
 
   test('keeps the package entrypoints wired to the public exports', () => {

--- a/modules/wms/src/capability-graph.ts
+++ b/modules/wms/src/capability-graph.ts
@@ -120,6 +120,7 @@ function detectServiceType(value: string, url: string): GeoServiceType {
   const text = `${value} ${url}`.toLowerCase();
   if (text.includes('imageserver')) return 'arcgis-image-server';
   if (text.includes('featureserver')) return 'arcgis-feature-server';
+  if (text.includes('vectortileserver')) return 'arcgis-vector-tile-server';
   if (text.includes('mapserver')) return 'arcgis-map-server';
   if (text.includes('wmts')) return 'wmts';
   if (text.includes('wms')) return 'wms';

--- a/modules/wms/src/index.ts
+++ b/modules/wms/src/index.ts
@@ -87,6 +87,7 @@ export {
   getServiceCRSAxisOrder
 } from './crs-utils';
 export {WFSSourceLoader, WFSVectorSource} from './wfs-source-loader';
+export type {WFSVersion} from './wfs-source-loader';
 export type {
   OGCAPICollection,
   OGCAPILandingPage,

--- a/modules/wms/src/wfs-source-loader.ts
+++ b/modules/wms/src/wfs-source-loader.ts
@@ -31,7 +31,7 @@ import {getServiceCRSAxisOrder, normalizeServiceCRS} from './crs-utils';
 /** Properties for creating a enw WFS service */
 export type WFSourceOptions = DataSourceOptions & {
   wfs?: {
-    /** In 1.3.0, replaces references to EPSG:4326 with CRS:84 */
+    /** In WFS 2.0.0, replaces references to EPSG:4326 with CRS:84. */
     substituteCRS84?: boolean;
     /** Default WFS parameters. If not provided here, must be provided in the various request */
     wfsParameters?: WFSParameters;
@@ -39,6 +39,9 @@ export type WFSourceOptions = DataSourceOptions & {
     vendorParameters?: Record<string, unknown>;
   };
 };
+
+/** WFS protocol versions supported by the source URL builder. */
+export type WFSVersion = '1.1.0' | '2.0.0';
 
 /**
  * @deprecated This is a WIP, not fully implemented
@@ -78,7 +81,7 @@ export const WFSSourceLoader = {
  */
 export type WFSParameters = {
   /** WFS version (all requests) */
-  version?: '1.3.0' | '1.1.1';
+  version?: WFSVersion;
   /** Layers to render (GetMap, GetFeatureInfo) */
   layers?: string[];
   /** list of layers to query.. (GetFeatureInfo) */
@@ -86,6 +89,8 @@ export type WFSParameters = {
 
   /** Coordinate Reference System (CRS) for the image (not the bounding box) */
   crs?: CRSIdentifier;
+  /** Output/input CRS parameter used by GetFeature requests. */
+  srsName?: CRSIdentifier;
   /** Requested format for the return image (GetMap, GetLegendGraphic) */
   format?: 'image/png';
   /** Requested MIME type of returned feature info (GetFeatureInfo) */
@@ -109,13 +114,13 @@ export type WFSParameters = {
 /** Parameters for GetCapabilities */
 export type WFSGetCapabilitiesParameters = {
   /** In case the endpoint supports multiple WFS versions */
-  version?: '1.3.0' | '1.1.1';
+  version?: WFSVersion;
 };
 
 /** Parameters for GetMap */
 export type WFSGetMapParameters = {
   /** In case the endpoint supports multiple WFS versions */
-  version?: '1.3.0' | '1.1.1';
+  version?: WFSVersion;
   /** bounding box of the requested map image `[[w, s], [e, n]]`  */
   // boundingBox: [min: [x: number, y: number], max: [x: number, y: number]];
   /** bounding box of the requested map image @deprecated Use .boundingBox */
@@ -143,7 +148,7 @@ export type WFSGetMapParameters = {
 /** Parameters for GetFeature. */
 export type WFSGetFeatureParameters = {
   /** In case the endpoint supports multiple WFS versions. */
-  version?: '1.3.0' | '1.1.1';
+  version?: WFSVersion;
   /** Requested feature types. */
   typeName?: string | string[];
   /** Bounding box filter, optionally suffixed with the bbox CRS. */
@@ -178,7 +183,7 @@ export type WFSGetFeatureParameters = {
  */
 export type WFSGetFeatureInfoParameters = {
   /** In case the endpoint supports multiple WFS versions */
-  version?: '1.3.0' | '1.1.1';
+  version?: WFSVersion;
   /** x coordinate for the feature info request */
   x: number;
   /** y coordinate for the feature info request */
@@ -220,13 +225,13 @@ export type WFSGetFeatureInfoViewParameters = {
 /** Parameters for DescribeLayer */
 export type WFSDescribeLayerParameters = {
   /** In case the endpoint supports multiple WFS versions */
-  version?: '1.3.0' | '1.1.1';
+  version?: WFSVersion;
 };
 
 /** Parameters for GetLegendGraphic */
 export type WFSGetLegendGraphicParameters = {
   /** In case the endpoint supports multiple WFS versions */
-  version?: '1.3.0' | '1.1.1';
+  version?: WFSVersion;
 };
 
 //
@@ -447,7 +452,7 @@ export class WFSVectorSource extends DataSource<string, WFSourceOptions> impleme
     vendorParameters?: Record<string, unknown>
   ): string {
     const options: Required<WFSGetCapabilitiesParameters> = {
-      version: wfsParameters?.version || this.options.wfs?.wfsParameters?.version || '1.3.0',
+      version: wfsParameters?.version || this.options.wfs?.wfsParameters?.version || '2.0.0',
       ...wfsParameters
     };
     return this._getWFSUrl('GetCapabilities', options, vendorParameters);
@@ -483,8 +488,8 @@ export class WFSVectorSource extends DataSource<string, WFSourceOptions> impleme
     vendorParameters?: Record<string, unknown>
   ): string {
     const requestParameters = this._normalizeGetFeatureParameters(parameters);
-    const options: WFSGetFeatureParameters & {version: '1.3.0' | '1.1.1'} = {
-      version: requestParameters.version || '1.3.0',
+    const options: WFSGetFeatureParameters & {version: WFSVersion} = {
+      version: requestParameters.version || '2.0.0',
       typeName: requestParameters.typeName,
       bbox: requestParameters.bbox,
       srsName: requestParameters.srsName || requestParameters.crs || 'EPSG:4326',
@@ -575,7 +580,7 @@ export class WFSVectorSource extends DataSource<string, WFSourceOptions> impleme
    * */
   protected _getWFSUrl(
     request: string,
-    wfsParameters: {version?: '1.3.0' | '1.1.1'; [key: string]: unknown},
+    wfsParameters: {version?: WFSVersion; [key: string]: unknown},
     vendorParameters?: Record<string, unknown>
   ): string {
     let url = this.url;
@@ -621,25 +626,25 @@ export class WFSVectorSource extends DataSource<string, WFSourceOptions> impleme
     // Substitute by key
     switch (key) {
       case 'crs':
-        // CRS was called SRS before WFS 1.3.0
-        if (wfsParameters.version !== '1.3.0') {
+        // WFS 1.1.0 uses SRS; WFS 2.0.0 uses CRS.
+        if (wfsParameters.version !== '2.0.0') {
           key = 'srs';
           // } else if (this.substituteCRS84 && value === 'EPSG:4326') {
-          //   /** In 1.3.0, replaces references to 'EPSG:4326' with the new backwards compatible CRS:84 */
+          //   /** In WFS 2.0.0, replace EPSG:4326 with the backwards-compatible CRS:84. */
           //   // Substitute by value
           //   value = 'CRS:84';
         }
         break;
 
       case 'srs':
-        // CRS was called SRS before WFS 1.3.0
-        if (wfsParameters.version === '1.3.0') {
+        // WFS 1.1.0 uses SRS; WFS 2.0.0 uses CRS.
+        if (wfsParameters.version === '2.0.0') {
           key = 'crs';
         }
         break;
 
       case 'bbox':
-        // Coordinate order is flipped for certain CRS in WFS 1.3.0
+        // Coordinate order is flipped for certain CRS in WFS 1.1.0 and 2.0.0.
         const bbox = this._flipBoundingBox(value, wfsParameters);
         if (bbox) {
           value = bbox;
@@ -651,17 +656,15 @@ export class WFSVectorSource extends DataSource<string, WFSourceOptions> impleme
         break;
 
       case 'x':
-        // i is the parameter used in WFS 1.3
-        // TODO - change parameter to `i` and convert to `x` if not 1.3
-        if (wfsParameters.version === '1.3.0') {
+        // i is the parameter used in WFS 2.0.0.
+        if (wfsParameters.version === '2.0.0') {
           key = 'i';
         }
         break;
 
       case 'y':
-        // j is the parameter used in WFS 1.3
-        // TODO - change parameter to `j` and convert to `y` if not 1.3
-        if (wfsParameters.version === '1.3.0') {
+        // j is the parameter used in WFS 2.0.0.
+        if (wfsParameters.version === '2.0.0') {
           key = 'j';
         }
         break;
@@ -677,7 +680,7 @@ export class WFSVectorSource extends DataSource<string, WFSourceOptions> impleme
       : `${key}=${value ? String(value) : ''}`;
   }
 
-  /** Coordinate order is flipped for certain CRS in WFS 1.3.0 */
+  /** Coordinate order is flipped for certain CRS in WFS 1.1.0 and 2.0.0. */
   _flipBoundingBox(
     bboxValue: unknown,
     wfsParameters: WFSParameters
@@ -689,7 +692,7 @@ export class WFSVectorSource extends DataSource<string, WFSourceOptions> impleme
 
     const normalizedCRS = normalizeServiceCRS(wfsParameters.crs || wfsParameters.srsName);
     const flipCoordinates =
-      wfsParameters.version === '1.3.0' &&
+      (wfsParameters.version === '1.1.0' || wfsParameters.version === '2.0.0') &&
       getServiceCRSAxisOrder(normalizedCRS) === 'yx' &&
       !(this.options.wfs?.substituteCRS84 && normalizedCRS === 'EPSG:4326');
 
@@ -740,7 +743,7 @@ export class WFSVectorSource extends DataSource<string, WFSourceOptions> impleme
     if ('boundingBox' in parameters) {
       const crs = parameters.crs || 'EPSG:4326';
       return {
-        version: this.options.wfs?.wfsParameters?.version || '1.3.0',
+        version: this.options.wfs?.wfsParameters?.version || '2.0.0',
         typeName: parameters.layers,
         bbox: [
           parameters.boundingBox[0][0],

--- a/modules/wms/src/wfs-source-loader.ts
+++ b/modules/wms/src/wfs-source-loader.ts
@@ -24,6 +24,7 @@ import {WMSErrorLoaderWithParser} from './wms-error-loader-with-parser';
 import {parseGML} from './lib/parsers/gml/parse-gml';
 import type {GMLFeatureCollection} from './lib/parsers/gml/parse-gml';
 import type {CRSIdentifier} from '@math.gl/crs';
+import {getServiceCRSAxisOrder, normalizeServiceCRS} from './crs-utils';
 
 /* eslint-disable camelcase */ // WFS XML parameters use snake_case
 
@@ -686,13 +687,11 @@ export class WFSVectorSource extends DataSource<string, WFSourceOptions> impleme
       return null;
     }
 
-    const flipCoordinates = false;
-    // // Only affects WFS 1.3.0
-    // wfsParameters.version === '1.3.0' &&
-    // // Flip if we are dealing with a CRS that was flipped in 1.3.0
-    // this.flipCRS.includes(wfsParameters.crs || '') &&
-    // // Don't flip if we are substituting EPSG:4326 with CRS:84
-    // !(this.substituteCRS84 && wfsParameters.crs === 'EPSG:4326');
+    const normalizedCRS = normalizeServiceCRS(wfsParameters.crs || wfsParameters.srsName);
+    const flipCoordinates =
+      wfsParameters.version === '1.3.0' &&
+      getServiceCRSAxisOrder(normalizedCRS) === 'yx' &&
+      !(this.options.wfs?.substituteCRS84 && normalizedCRS === 'EPSG:4326');
 
     const bbox = bboxValue as
       | [number, number, number, number]

--- a/modules/wms/src/wmts-source-loader.ts
+++ b/modules/wms/src/wmts-source-loader.ts
@@ -10,6 +10,7 @@ import type {
   GetTileDataParameters,
   GetTileParameters,
   SourceLoader,
+  TileGrid,
   TileSource,
   TileSourceMetadata
 } from '@loaders.gl/loader-utils';
@@ -193,7 +194,7 @@ export class WMTSImageTileSource
 }
 
 /** Converts a WMTS matrix set into the shared tile-grid metadata shape. */
-function toTileGrid(tileMatrixSet: WMTSTileMatrixSet | undefined) {
+function toTileGrid(tileMatrixSet: WMTSTileMatrixSet | undefined): TileGrid | undefined {
   if (!tileMatrixSet) return undefined;
   const firstMatrix = tileMatrixSet.matrices[0];
   return {

--- a/modules/wms/src/wmts-source-loader.ts
+++ b/modules/wms/src/wmts-source-loader.ts
@@ -78,7 +78,8 @@ export class WMTSImageTileSource
             [layer.bounds[2], layer.bounds[3]]
           ]
         : undefined,
-      layer: {name: wmts.layer || layer?.identifier || '', layers: []}
+      layer: {name: wmts.layer || layer?.identifier || '', layers: []},
+      tileGrid: toTileGrid(this._getTileMatrixSet(layer))
     };
   }
 
@@ -189,6 +190,23 @@ export class WMTSImageTileSource
     }
     return undefined;
   }
+}
+
+/** Converts a WMTS matrix set into the shared tile-grid metadata shape. */
+function toTileGrid(tileMatrixSet: WMTSTileMatrixSet | undefined) {
+  if (!tileMatrixSet) return undefined;
+  const firstMatrix = tileMatrixSet.matrices[0];
+  return {
+    crs: tileMatrixSet.supportedCRS,
+    tileSize: firstMatrix?.tileWidth
+      ? [firstMatrix.tileWidth, firstMatrix.tileHeight || firstMatrix.tileWidth]
+      : undefined,
+    origin: firstMatrix?.topLeftCorner,
+    matrixIds: tileMatrixSet.matrices.map(matrix => matrix.identifier),
+    matrixSizes: tileMatrixSet.matrices
+      .filter(matrix => matrix.matrixWidth !== undefined && matrix.matrixHeight !== undefined)
+      .map(matrix => [matrix.matrixWidth!, matrix.matrixHeight!])
+  };
 }
 
 /** Selects the advertised WMTS matrix identifier for a deck.gl zoom level. */

--- a/modules/wms/test/wfs/wfs-source.spec.ts
+++ b/modules/wms/test/wfs/wfs-source.spec.ts
@@ -24,7 +24,7 @@ test('WFSSourceLoader#getFeaturesURL', t => {
   t.equal(featuresUrl.origin + featuresUrl.pathname, WFS_URL, 'keeps the base WFS URL');
   t.equal(featuresUrl.searchParams.get('SERVICE'), 'WFS');
   t.equal(featuresUrl.searchParams.get('REQUEST'), 'GetFeature');
-  t.equal(featuresUrl.searchParams.get('VERSION'), '1.3.0');
+  t.equal(featuresUrl.searchParams.get('VERSION'), '2.0.0');
   t.equal(featuresUrl.searchParams.get('TYPENAME'), 'roads,bridges');
   t.equal(featuresUrl.searchParams.get('BBOX'), '2,1,4,3,EPSG:4326');
   t.equal(featuresUrl.searchParams.get('SRSNAME'), 'EPSG:4326');
@@ -39,7 +39,7 @@ test('WFSSourceLoader#getCapabilitiesURL defaults version', t => {
   t.equal(capabilitiesUrl.origin + capabilitiesUrl.pathname, WFS_URL, 'keeps the base WFS URL');
   t.equal(capabilitiesUrl.searchParams.get('SERVICE'), 'WFS');
   t.equal(capabilitiesUrl.searchParams.get('REQUEST'), 'GetCapabilities');
-  t.equal(capabilitiesUrl.searchParams.get('VERSION'), '1.3.0');
+  t.equal(capabilitiesUrl.searchParams.get('VERSION'), '2.0.0');
   t.end();
 });
 

--- a/modules/wms/test/wfs/wfs-source.spec.ts
+++ b/modules/wms/test/wfs/wfs-source.spec.ts
@@ -43,6 +43,34 @@ test('WFSSourceLoader#getCapabilitiesURL defaults version', t => {
   t.end();
 });
 
+test('WFSSourceLoader#getFeaturesURL supports WFS 1.1.0 parameter conventions', t => {
+  const source = WFSSourceLoader.createDataSource(WFS_URL, {});
+  const featuresUrl = new URL(
+    source.getFeaturesURL({
+      version: '1.1.0',
+      typeName: 'roads',
+      bbox: [1, 2, 3, 4],
+      crs: 'EPSG:3857'
+    })
+  );
+
+  t.equal(featuresUrl.searchParams.get('VERSION'), '1.1.0');
+  t.equal(featuresUrl.searchParams.get('BBOX'), '1,2,3,4');
+  t.equal(featuresUrl.searchParams.get('SRSNAME'), 'EPSG:3857');
+
+  const mapUrl = new URL(
+    source.getMapURL({
+      version: '1.1.0',
+      bbox: [1, 2, 3, 4],
+      width: 256,
+      height: 256,
+      crs: 'EPSG:3857'
+    })
+  );
+  t.equal(mapUrl.searchParams.get('SRS'), 'EPSG:3857');
+  t.end();
+});
+
 test('WFSSourceLoader#getFeatures returns Arrow by default', async t => {
   const source = WFSSourceLoader.createDataSource(WFS_URL, {});
   const featureCollection = {

--- a/modules/wms/test/wfs/wfs-source.spec.ts
+++ b/modules/wms/test/wfs/wfs-source.spec.ts
@@ -26,7 +26,7 @@ test('WFSSourceLoader#getFeaturesURL', t => {
   t.equal(featuresUrl.searchParams.get('REQUEST'), 'GetFeature');
   t.equal(featuresUrl.searchParams.get('VERSION'), '1.3.0');
   t.equal(featuresUrl.searchParams.get('TYPENAME'), 'roads,bridges');
-  t.equal(featuresUrl.searchParams.get('BBOX'), '1,2,3,4,EPSG:4326');
+  t.equal(featuresUrl.searchParams.get('BBOX'), '2,1,4,3,EPSG:4326');
   t.equal(featuresUrl.searchParams.get('SRSNAME'), 'EPSG:4326');
   t.equal(featuresUrl.searchParams.get('OUTPUTFORMAT'), 'application/json');
   t.end();

--- a/modules/wms/test/wmts/wmts-source.spec.ts
+++ b/modules/wms/test/wmts/wmts-source.spec.ts
@@ -235,3 +235,35 @@ test('WMTSImageTileSource uses advertised identifiers for KVP requests', async (
   await source.getMetadata();
   expect(new URL(source.getTileURL({x: 1, y: 2, z: 1})).searchParams.get('TILEMATRIX')).toBe('1g');
 });
+
+test('WMTSImageTileSource preserves an exact advertised matrix identifier', async () => {
+  const source = new WMTSImageTileSource('https://example.com/wmts', {
+    wmts: {
+      layer: 'imagery',
+      tileMatrixSet: 'Custom',
+      capabilities: {
+        contents: {
+          layers: [
+            {
+              identifier: 'imagery',
+              formats: ['image/png'],
+              styles: [],
+              tileMatrixSetLinks: [{tileMatrixSet: 'Custom'}],
+              resourceURLs: [{template: 'https://tiles.example/{TileMatrix}'}]
+            }
+          ],
+          tileMatrixSets: [
+            {
+              identifier: 'Custom',
+              supportedCRS: 'EPSG:3857',
+              matrices: [{identifier: '5'}]
+            }
+          ]
+        }
+      }
+    }
+  });
+
+  await source.getMetadata();
+  expect(source.getTileURL({x: 0, y: 0, z: 5})).toBe('https://tiles.example/5');
+});

--- a/modules/wms/test/wmts/wmts-source.spec.ts
+++ b/modules/wms/test/wmts/wmts-source.spec.ts
@@ -157,6 +157,53 @@ test('WMTSImageTileSource uses advertised nonnumeric matrix identifiers', async 
   expect(source.getTileURL({x: 1, y: 2, z: 1})).toBe('https://tiles.example/1g/2/1.png');
 });
 
+test('WMTSImageTileSource exposes the selected tile grid', async () => {
+  const source = new WMTSImageTileSource('https://example.com/wmts', {
+    wmts: {
+      layer: 'imagery',
+      tileMatrixSet: 'WebMercatorQuad',
+      capabilities: {
+        contents: {
+          layers: [
+            {
+              identifier: 'imagery',
+              formats: ['image/png'],
+              styles: [],
+              tileMatrixSetLinks: [{tileMatrixSet: 'WebMercatorQuad'}],
+              resourceURLs: []
+            }
+          ],
+          tileMatrixSets: [
+            {
+              identifier: 'WebMercatorQuad',
+              supportedCRS: 'EPSG:3857',
+              matrices: [
+                {
+                  identifier: '0',
+                  tileWidth: 256,
+                  tileHeight: 256,
+                  topLeftCorner: [-20037508, 20037508],
+                  matrixWidth: 1,
+                  matrixHeight: 1
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  });
+
+  const metadata = await source.getMetadata();
+  expect(metadata.tileGrid).toEqual({
+    crs: 'EPSG:3857',
+    tileSize: [256, 256],
+    origin: [-20037508, 20037508],
+    matrixIds: ['0'],
+    matrixSizes: [[1, 1]]
+  });
+});
+
 test('WMTSImageTileSource uses advertised identifiers for KVP requests', async () => {
   const source = new WMTSImageTileSource('https://example.com/wmts', {
     wmts: {


### PR DESCRIPTION
## Goals

- Complete tranche 7 with shared tile-grid metadata for WMTS and ArcGIS cached tiles.
- Complete tranche 8 with standards-aware CRS axis order for WFS 1.3 requests.
- Keep grid and CRS information in existing normalized source metadata rather than adding a second runtime abstraction.

## Changes

- Add the shared `TileGrid` metadata type to `@loaders.gl/loader-utils`.
- Expose selected WMTS matrix-set CRS, tile size, origin, identifiers, and matrix dimensions.
- Expose ArcGIS MapServer cached tile-grid metadata.
- Apply the existing CRS normalization and axis-order utilities to WFS 1.3 BBOX requests.
- Add focused WMTS, ArcGIS, WFS, and CRS regression tests.

## Validation

- `yarn lint fix`
- `yarn test-headless modules/wms/test/wmts/wmts-source.spec.ts modules/wms/test/wfs/wfs-source.spec.ts modules/wms/test/crs-utils.spec.ts modules/services/test/arcgis/arcgis-server.spec.ts`
- `yarn test-audit`
- `yarn build`
