### PR TITLE
feat(i3s): normalize date and null attributes

### DIFF
--- a/docs/modules/i3s/formats/i3s.md
+++ b/docs/modules/i3s/formats/i3s.md
@@ -133,7 +133,9 @@ those versions.
 | Float64 attributes | **Supported** | v2.3 | Double-precision attribute values are decoded. |
 | Int16 attributes | **Supported** | v3.1 | Used by tested Building Scene Layer attribute resources. |
 | Typed numeric attributes (UInt8/16/32/64, Int16/32/64, Float32/64) | **Supported** | **v5.0** | Declared numeric types are decoded into matching typed arrays; 64-bit integers use `Float64Array` and are exact through `Number.MAX_SAFE_INTEGER`. |
-| Date, GUID, and null-mask attributes | **Partial** | v2.3 | Date/GUID conversion and explicit null-mask propagation remain open feature-intelligence work. |
+| Date attributes | **Supported** | **v5.0** | `esriFieldTypeDate` values are normalized to ISO 8601 UTC strings from epoch-millisecond payloads. |
+| GUID and GlobalID attributes | **Supported** | **v5.0** | GUID string payloads are preserved after UTF-8 and null-terminator decoding. |
+| Null numeric values | **Supported** | **v5.0** | Numeric `NaN` sentinels are returned as `null`; unavailable resources retain the legacy empty-string fallback. |
 | Coded-value domains | **Supported** | v3.0 | Numeric domain codes are mapped to their display names when loading a selected feature. |
 | Attribute-driven colorization | **Supported** | v3.3 | Numeric attributes can replace or multiply vertex colors through `colorsByAttribute`. |
 | Layer statistics | **Partial** | v2.0 | Statistics metadata passes through; raw SLPK statistics extraction was added in v3.4. There is no typed statistics loader or query API. |
@@ -175,7 +177,7 @@ current v5.0 development line; the remaining tranches close the largest unsuppor
 | 1. Correctness hardening | Make root authentication, node metadata passthrough, UInt64 precision, and WebScene CRS validation match the documented boundaries. | **Complete** |
 | 2. 1.10 mesh parity | Add legacy shared-resource material interpretation and mesh-segmentation preservation, then expand 1.9/1.10 conformance fixtures. | **Complete** |
 | 3. Material fidelity | Load complete PBR texture sets, preserve multiple referenced atlases, and carry sampler wrap semantics into material metadata. | **Complete** |
-| 4. Feature intelligence | Add typed scalar/date/GUID/null-mask attributes, statistics, drawing metadata evaluation, and query APIs. | **In progress** (typed numeric attributes complete in v5.0) |
+| 4. Feature intelligence | Add typed scalar/date/GUID/null-mask attributes, statistics, drawing metadata evaluation, and query APIs. | **In progress** (typed scalar/date/GUID/null semantics complete in v5.0) |
 | 5. Profile coverage | Add Point, then I3S 2.1 Point Cloud (LEPCC and density-based traversal). | Planned |
 | 6. Spatial semantics | Add projected and vertical CRS transforms plus `elevationInfo` placement modes. | Planned |
 

--- a/modules/i3s/src/i3s-attribute-loader-with-parser.ts
+++ b/modules/i3s/src/i3s-attribute-loader-with-parser.ts
@@ -6,6 +6,7 @@ import type {LoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';
 import {resolvePath} from '@loaders.gl/loader-utils';
 import type {I3SLoaderOptions} from './i3s-loader';
 import type {I3STileAttributes} from './lib/parsers/parse-i3s-attribute';
+import type {Field} from './types';
 import {parseI3STileAttribute} from './lib/parsers/parse-i3s-attribute';
 import {getUrlWithToken} from './lib/utils/url-utils';
 import {I3SAttributeLoader as I3SAttributeLoaderMetadata} from './i3s-attribute-loader';
@@ -189,9 +190,15 @@ function getFeatureAttributesByIndex(
 
   for (let index = 0; index < attributeStorageInfo.length; index++) {
     const attributeName = attributeStorageInfo[index].name;
-    const codedValues = getAttributeCodedValues(attributeName, tilesetFields);
+    const attributeField = getAttributeField(attributeName, tilesetFields);
+    const codedValues = attributeField?.domain?.codedValues || [];
     const attribute = getAttributeByIndexAndAttributeName(attributes, index, attributeName);
-    attributesObject[attributeName] = formatAttributeValue(attribute, featureIdIndex, codedValues);
+    attributesObject[attributeName] = formatAttributeValue(
+      attribute,
+      featureIdIndex,
+      codedValues,
+      attributeField?.type
+    );
   }
 
   return attributesObject;
@@ -202,12 +209,8 @@ function getFeatureAttributesByIndex(
  * @param attributeName
  * @param tilesetFields
  */
-function getAttributeCodedValues(attributeName, tilesetFields) {
-  const attributeField = tilesetFields.find(
-    field => field.name === attributeName || field.alias === attributeName
-  );
-
-  return attributeField?.domain?.codedValues || [];
+function getAttributeField(attributeName: string, tilesetFields: Field[]): Field | undefined {
+  return tilesetFields.find(field => field.name === attributeName || field.alias === attributeName);
 }
 
 /**
@@ -230,16 +233,29 @@ function getAttributeByIndexAndAttributeName(attributes, index, attributesName) 
  * Do formatting of attribute values or return empty string.
  * @param {Array} attribute
  * @param {Number} featureIdIndex
- * @returns {String}
+ * @param fieldType - optional ArcGIS field type used for semantic formatting
+ * @returns {String|null}
  */
-function formatAttributeValue(attribute, featureIdIndex, codedValues) {
+function formatAttributeValue(attribute, featureIdIndex, codedValues, fieldType?: string) {
   let value = EMPTY_VALUE;
 
   if (attribute && featureIdIndex in attribute) {
+    const rawValue = attribute[featureIdIndex];
+    if (typeof rawValue === 'number' && Number.isNaN(rawValue)) {
+      return null;
+    }
     // eslint-disable-next-line no-control-regex
-    value = String(attribute[featureIdIndex])
-      .replace(/\u0000|NaN/g, '')
+    value = String(rawValue)
+      .replace(/\u0000/g, '')
       .trim();
+  }
+
+  if (fieldType === 'esriFieldTypeDate' && value) {
+    const numericValue = Number(value);
+    const parsedDate = Number.isFinite(numericValue) ? new Date(numericValue) : new Date(value);
+    if (!Number.isNaN(parsedDate.getTime())) {
+      value = parsedDate.toISOString();
+    }
   }
 
   // Check if coded values are existed. If so we use them.

--- a/modules/i3s/test/i3s-conformance.spec.ts
+++ b/modules/i3s/test/i3s-conformance.spec.ts
@@ -10,6 +10,7 @@ import {parseSLPKArchive} from '../src/lib/parsers/parse-slpk/parse-slpk';
 import {parseI3STileAttribute} from '../src/lib/parsers/parse-i3s-attribute';
 import {parseI3STileContent, parseUint64Values} from '../src/lib/parsers/parse-i3s-tile-content';
 import {getLegacyMaterialDefinition, normalizeTileData} from '../src/lib/parsers/parse-i3s';
+import {loadFeatureAttributes} from '../src/i3s-attribute-loader-with-parser';
 import {createReadableFileFromBuffer} from 'test/utils/readable-files';
 
 const SCENE_LAYER_FIXTURES = [
@@ -101,6 +102,84 @@ describe('I3S conformance fixtures', () => {
     expect(Array.from(int32 as Int32Array)).toEqual([-7, 42]);
     expect(Array.from(float32 as Float32Array)).toEqual([1.5, -2.25]);
     expect(Array.from(uint64 as Float64Array)).toEqual([0x1_0000_0001, 0x1_ffff_ffff_ffff_ff]);
+  });
+
+  it('formats date fields and preserves null numeric values', async () => {
+    const objectIdsBuffer = new ArrayBuffer(12);
+    const objectIdsView = new DataView(objectIdsBuffer);
+    objectIdsView.setUint32(4, 7, true);
+    objectIdsView.setUint32(8, 8, true);
+
+    const datesBuffer = new ArrayBuffer(24);
+    const datesView = new DataView(datesBuffer);
+    datesView.setFloat64(8, Date.UTC(2024, 0, 1), true);
+    datesView.setFloat64(16, Date.UTC(2024, 0, 2, 3, 4, 5), true);
+
+    const nullValuesBuffer = new ArrayBuffer(24);
+    const nullValuesView = new DataView(nullValuesBuffer);
+    nullValuesView.setFloat64(8, 10, true);
+    nullValuesView.setFloat64(16, Number.NaN, true);
+
+    const guidValues = [
+      '{11111111-1111-1111-1111-111111111111}\0',
+      '{22222222-2222-2222-2222-222222222222}\0'
+    ];
+    const encodedGuidValues = guidValues.map(value => new TextEncoder().encode(value));
+    const guidsBuffer = new ArrayBuffer(
+      16 + encodedGuidValues[0].byteLength + encodedGuidValues[1].byteLength
+    );
+    const guidsView = new DataView(guidsBuffer);
+    guidsView.setUint32(0, guidValues.length, true);
+    guidsView.setUint32(8, encodedGuidValues[0].byteLength, true);
+    guidsView.setUint32(12, encodedGuidValues[1].byteLength, true);
+    new Uint8Array(guidsBuffer, 16).set(encodedGuidValues[0]);
+    new Uint8Array(guidsBuffer, 16 + encodedGuidValues[0].byteLength).set(encodedGuidValues[1]);
+
+    const responses: Record<string, ArrayBuffer> = {
+      '/attributes/objectids': objectIdsBuffer,
+      '/attributes/dates': datesBuffer,
+      '/attributes/guids': guidsBuffer,
+      '/attributes/nulls': nullValuesBuffer
+    };
+    const attributes = await loadFeatureAttributes(
+      {
+        tileset: {
+          tileset: {
+            attributeStorageInfo: [
+              {name: 'OBJECTID', objectIds: []},
+              {name: 'BuildDate', attributeValues: {valueType: 'Float64'}},
+              {name: 'AssetGuid', attributeValues: {valueType: 'String'}},
+              {name: 'OptionalHeight', attributeValues: {valueType: 'Float64'}}
+            ],
+            fields: [
+              {name: 'OBJECTID', type: 'esriFieldTypeOID'},
+              {name: 'BuildDate', type: 'esriFieldTypeDate'},
+              {name: 'AssetGuid', type: 'esriFieldTypeGUID'},
+              {name: 'OptionalHeight', type: 'esriFieldTypeDouble'}
+            ]
+          }
+        },
+        header: {
+          attributeUrls: [
+            '/attributes/objectids',
+            '/attributes/dates',
+            '/attributes/guids',
+            '/attributes/nulls'
+          ]
+        }
+      },
+      8,
+      {
+        fetch: async url => new Response(responses[String(url).split('?')[0]])
+      }
+    );
+
+    expect(attributes).toEqual({
+      OBJECTID: '8',
+      BuildDate: '2024-01-02T03:04:05.000Z',
+      AssetGuid: '{22222222-2222-2222-2222-222222222222}',
+      OptionalHeight: null
+    });
   });
 
   it('preserves UInt64 feature IDs through face-range expansion', async () => {


### PR DESCRIPTION
## Goals

- Continue tranche 4 (feature intelligence) with semantic date, GUID, and null-value handling for selected feature attributes.
- Keep the I3S support matrix explicit about the v5.0 behavior now covered by loaders.gl.

## Changes

- Normalize `esriFieldTypeDate` values from epoch milliseconds to ISO 8601 UTC strings.
- Preserve UTF-8 GUID and GlobalID payloads after removing I3S null terminators.
- Return `null` for numeric `NaN` null sentinels while retaining the legacy empty-string fallback for unavailable resources.
- Add native Vitest coverage using synthetic date, GUID, and null-valued attribute resources.
- Update the I3S feature table and tranche roadmap.

## Validation

- `node node_modules/typescript/bin/tsc -p modules/i3s/tsconfig.json --noEmit`
- `yarn lint fix`
- `yarn test-headless modules/i3s/test/i3s-conformance.spec.ts` (13 passed)
- `yarn test-headless modules/i3s/test/i3s-attribute-loader.spec.ts` (17 passed)

The typed numeric foundation from the merged feature-intelligence work is already reflected in the current I3S support matrix.
