### PR TITLE
feat(services): add capability-driven source creation

### DIFF
--- a/docs/modules/services/README.md
+++ b/docs/modules/services/README.md
@@ -19,10 +19,19 @@ capability graph is intentionally separate from source loading, so direct source
 remains the simplest path when the endpoint is already known.
 
 ```ts
-import {discoverArcGISCapabilities, selectArcGISService} from '@loaders.gl/services';
+import {
+  createServiceSource,
+  discoverArcGISCapabilities,
+  selectArcGISService
+} from '@loaders.gl/services';
 
 const graph = await discoverArcGISCapabilities('https://example.com/arcgis/rest/services');
 const imagery = graph && selectArcGISService(graph, {kind: 'image', format: 'lerc'});
+const source = imagery && createServiceSource(
+  imagery.url,
+  {},
+  imagery.capabilities.type
+);
 ```
 
 Discovery performs one metadata request per discovered service. Pass a custom `fetch` function when

--- a/docs/modules/services/README.md
+++ b/docs/modules/services/README.md
@@ -24,13 +24,15 @@ import {
   discoverArcGISCapabilities,
   selectArcGISService
 } from '@loaders.gl/services';
+import {coreApi} from '@loaders.gl/core';
 
 const graph = await discoverArcGISCapabilities('https://example.com/arcgis/rest/services');
 const imagery = graph && selectArcGISService(graph, {kind: 'image', format: 'lerc'});
 const source = imagery && createServiceSource(
   imagery.url,
   {},
-  imagery.capabilities.type
+  imagery.capabilities.type,
+  coreApi
 );
 ```
 

--- a/modules/services/src/arcgis/arcgis-vector-tile-server-source-loader.ts
+++ b/modules/services/src/arcgis/arcgis-vector-tile-server-source-loader.ts
@@ -180,7 +180,7 @@ export const ArcGISVectorTileServerSourceLoader = {
   fromBlob: false,
   options: {'arcgis-vector-tile-server': {}},
   defaultOptions: {'arcgis-vector-tile-server': {}},
-  testURL: (url: string): boolean => /\/vectortileserver(?:\/|$)/i.test(url),
+  testURL: (url: string): boolean => /\/vectortileserver(?:[\/?#]|$)/i.test(url),
   createDataSource: (
     url: string,
     options: ArcGISVectorTileServerSourceLoaderOptions = {},

--- a/modules/services/src/index.ts
+++ b/modules/services/src/index.ts
@@ -63,4 +63,4 @@ export type {
 } from './arcgis/arcgis-vector-tile-server-source-loader';
 
 export type {ServiceLoader} from './service-registry';
-export {getServiceLoader} from './service-registry';
+export {createServiceSource, getServiceLoader} from './service-registry';

--- a/modules/services/src/service-registry.ts
+++ b/modules/services/src/service-registry.ts
@@ -45,12 +45,14 @@ export function getServiceLoader(serviceType: string): ServiceLoader | undefined
  *
  * The optional type should come from normalized service capabilities. When it is
  * omitted, the small registry tests each known service loader in declaration order.
+ * A CoreAPI is required because image and tile sources decode responses through
+ * the application's configured loaders.gl core integration.
  */
 export function createServiceSource(
   url: string,
   options: DataSourceOptions = {},
-  serviceType?: string,
-  coreApi?: CoreAPI
+  serviceType: string | undefined,
+  coreApi: CoreAPI
 ): DataSource<unknown, DataSourceOptions> {
   const serviceLoader = serviceType
     ? getServiceLoader(serviceType)

--- a/modules/services/src/service-registry.ts
+++ b/modules/services/src/service-registry.ts
@@ -7,6 +7,7 @@ import {ArcGISImageServerSourceLoader} from './arcgis/arcgis-image-server-source
 import {ArcGISImageTileSourceLoader} from './arcgis/arcgis-image-tile-source-loader';
 import {ArcGISMapTileSourceLoader} from './arcgis/arcgis-map-tile-source-loader';
 import {ArcGISVectorTileServerSourceLoader} from './arcgis/arcgis-vector-tile-server-source-loader';
+import type {CoreAPI, DataSource, DataSourceOptions} from '@loaders.gl/loader-utils';
 
 /** A source loader currently exposed through the services package. */
 export type ServiceLoader =
@@ -37,4 +38,25 @@ export function getServiceLoader(serviceType: string): ServiceLoader | undefined
     serviceLoader =>
       serviceLoader.id === normalizedServiceType || serviceLoader.type === normalizedServiceType
   );
+}
+
+/**
+ * Creates a service source from an explicit capability type or URL detection.
+ *
+ * The optional type should come from normalized service capabilities. When it is
+ * omitted, the small registry tests each known service loader in declaration order.
+ */
+export function createServiceSource(
+  url: string,
+  options: DataSourceOptions = {},
+  serviceType?: string,
+  coreApi?: CoreAPI
+): DataSource<unknown, DataSourceOptions> {
+  const serviceLoader = serviceType
+    ? getServiceLoader(serviceType)
+    : SERVICE_LOADERS.find(loader => loader.testURL(url));
+  if (!serviceLoader) {
+    throw new Error(`No service loader recognized type or URL: ${serviceType || url}`);
+  }
+  return serviceLoader.createDataSource(url, options, coreApi);
 }

--- a/modules/services/test/services-module.spec.ts
+++ b/modules/services/test/services-module.spec.ts
@@ -9,6 +9,7 @@ import {
   getServiceLoader,
   selectArcGISService
 } from '../src/index';
+import {coreApi} from '@loaders.gl/core';
 import {getArcGISServices} from '../src/arcgis/arcgis-server';
 import * as bundledServices from '../src/bundled';
 import * as unbundledServices from '../src/unbundled';
@@ -42,15 +43,21 @@ describe('@loaders.gl/services', () => {
       createServiceSource(
         'https://example.com/arcgis/rest/services/Basemap/VectorTileServer',
         {},
-        'arcgis-vector-tile-server'
+        'arcgis-vector-tile-server',
+        coreApi
       )
     ).toBeInstanceOf(Object);
     expect(
-      createServiceSource('https://example.com/arcgis/rest/services/Roads/FeatureServer/0')
+      createServiceSource(
+        'https://example.com/arcgis/rest/services/Roads/FeatureServer/0',
+        {},
+        undefined,
+        coreApi
+      )
     ).toBeInstanceOf(Object);
-    expect(() => createServiceSource('https://example.com/service', {}, 'unknown')).toThrow(
-      'No service loader recognized type or URL'
-    );
+    expect(() =>
+      createServiceSource('https://example.com/service', {}, 'unknown', coreApi)
+    ).toThrow('No service loader recognized type or URL');
   });
 
   test('keeps the package entrypoints wired to the public exports', () => {

--- a/modules/services/test/services-module.spec.ts
+++ b/modules/services/test/services-module.spec.ts
@@ -4,6 +4,7 @@ import {
   ArcGISImageTileSourceLoader,
   ArcGISMapTileSourceLoader,
   ArcGISVectorTileServerSourceLoader,
+  createServiceSource,
   discoverArcGISCapabilities,
   getServiceLoader,
   selectArcGISService
@@ -34,6 +35,22 @@ describe('@loaders.gl/services', () => {
     expect(getServiceLoader('ArcGIS-Feature-Server')).toBe(ArcGISFeatureServerSourceLoader);
     expect(getServiceLoader('arcgis-vector-tile-server')).toBe(ArcGISVectorTileServerSourceLoader);
     expect(getServiceLoader('unknown-service')).toBeUndefined();
+  });
+
+  test('creates a source from normalized capability type or URL', () => {
+    expect(
+      createServiceSource(
+        'https://example.com/arcgis/rest/services/Basemap/VectorTileServer',
+        {},
+        'arcgis-vector-tile-server'
+      )
+    ).toBeInstanceOf(Object);
+    expect(
+      createServiceSource('https://example.com/arcgis/rest/services/Roads/FeatureServer/0')
+    ).toBeInstanceOf(Object);
+    expect(() => createServiceSource('https://example.com/service', {}, 'unknown')).toThrow(
+      'No service loader recognized type or URL'
+    );
   });
 
   test('keeps the package entrypoints wired to the public exports', () => {

--- a/modules/wms/src/capability-graph.ts
+++ b/modules/wms/src/capability-graph.ts
@@ -120,6 +120,7 @@ function detectServiceType(value: string, url: string): GeoServiceType {
   const text = `${value} ${url}`.toLowerCase();
   if (text.includes('imageserver')) return 'arcgis-image-server';
   if (text.includes('featureserver')) return 'arcgis-feature-server';
+  if (text.includes('vectortileserver')) return 'arcgis-vector-tile-server';
   if (text.includes('mapserver')) return 'arcgis-map-server';
   if (text.includes('wmts')) return 'wmts';
   if (text.includes('wms')) return 'wms';


### PR DESCRIPTION
## Goals

Make capability discovery directly actionable while keeping service selection explicit and lightweight.

## Changes

- Add `createServiceSource` to create an ArcGIS service source from a normalized capability type or URL detection.
- Recognize ArcGIS VectorTileServer endpoints in the shared capability graph.
- Export and document the source-selection helper.
- Add focused tests for capability-type and URL-based source creation and unknown-service errors.

## Validation

- `yarn lint fix`
- `yarn test-headless modules/services/test/services-module.spec.ts modules/wms/test/service-runtime.spec.ts`
- `yarn test-audit`
- `yarn build`

This PR is stacked on #3819 and should be rebased onto `master` after #3819 lands.
