### PR TITLE
docs(3d-tiles): repair API section boundaries

### DIFF
--- a/docs/modules/tiles/api-reference/tile-3d.md
+++ b/docs/modules/tiles/api-reference/tile-3d.md
@@ -26,11 +26,15 @@ Returns `true` when traversal may request a source-managed lazy child-header gro
 
 ###### `boundingVolume` (BoundingVolume)
 
+A bounding volume that encloses a tile or its content. Exactly one box, region, or sphere property is required. ([`Reference`](https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/master/specification#bounding-volume))
+
+###### `contentBoundingVolumes` (BoundingVolume[])
+
+The transformed render-content bounding volumes, one for each content entry. Entries without an explicit content volume use the tile's transformed `boundingVolume` at the same index. These volumes are used for render culling; hierarchy traversal continues to use the tile's `boundingVolume`.
+
 ###### `contentVisibility(frameState)`
 
 Returns the render-content visibility classification after culling against the viewport and any optional world-space clipping planes. Clipping planes affect rendering only; hierarchy traversal continues to use the tile bounding volume.
-
-A bounding volume that encloses a tile or its content. Exactly one box, region, or sphere property is required. ([`Reference`](https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/master/specification#bounding-volume))
 
 ###### `viewerRequestVolume` (BoundingVolume | null)
 


### PR DESCRIPTION
## Goals

Repair the 3D Tiles API reference formatting regression introduced by #3817 and keep the documentation navigation readable.

## Changes

- Keep the `boundingVolume` description under its own heading.
- Restore the `contentBoundingVolumes` API entry.
- Place `contentVisibility(frameState)` in a separate section with its own description.
- Preserve source-order fallback behavior in the API documentation.

## Audit

Reviewed documentation files changed by recent module PRs; no other heading/description boundary regressions were found in that set.

Supersedes #3824.