### PR TITLE
feat(i3s): add statistics resource loading

### DIFF
--- a/docs/modules/i3s/api-reference/i3s-loader.md
+++ b/docs/modules/i3s/api-reference/i3s-loader.md
@@ -241,6 +241,9 @@ The returned object is keyed by each descriptor's `key`; an unavailable resource
 import {loadStatistics} from '@loaders.gl/i3s';
 
 const statistics = await loadStatistics(sceneLayer.statisticsInfo, {
+  core: {baseUrl: sceneLayer.url},
   i3s: {token}
 });
 ```
+
+Set `core.baseUrl` to the loaded layer URL when descriptors use relative `href` values.

--- a/docs/modules/i3s/api-reference/i3s-loader.md
+++ b/docs/modules/i3s/api-reference/i3s-loader.md
@@ -230,3 +230,17 @@ After content is loaded, the following fields are guaranteed. But different tile
 | `attributes.normals`   | `Object` | `{value, type, size, normalized}` |
 | `attributes.colors`    | `Object` | `{value, type, size, normalized}` |
 | `attributes.texCoords` | `Object` | `{value, type, size, normalized}` |
+
+### Layer statistics
+
+Use `loadStatistics` to fetch the resources listed in a scene layer's `statisticsInfo` array.
+The returned object is keyed by each descriptor's `key`; an unavailable resource is represented by
+`null` so other fields can still be consumed.
+
+```typescript
+import {loadStatistics} from '@loaders.gl/i3s';
+
+const statistics = await loadStatistics(sceneLayer.statisticsInfo, {
+  i3s: {token}
+});
+```

--- a/docs/modules/i3s/formats/i3s.md
+++ b/docs/modules/i3s/formats/i3s.md
@@ -168,8 +168,10 @@ path.
 
 ## I3S roadmap
 
-The matrix turns I3S priorities into measurable tranches. Tranches 0 and 1 are implemented in the
-current v5.0 development line; the remaining tranches close the largest unsupported or partial rows:
+The matrix turns I3S priorities into measurable tranches. **I3S supremacy** means that every current
+mesh and point profile has either end-to-end support or an explicit, tested boundary, with renderer-
+ready semantics and conformance fixtures. The tranche list below is the delivery sequence; the
+sub-tranches under feature intelligence keep the remaining gaps independently shippable:
 
 | Tranche | Outcome | Status |
 | --- | --- | :---: |
@@ -177,9 +179,16 @@ current v5.0 development line; the remaining tranches close the largest unsuppor
 | 1. Correctness hardening | Make root authentication, node metadata passthrough, UInt64 precision, and WebScene CRS validation match the documented boundaries. | **Complete** |
 | 2. 1.10 mesh parity | Add legacy shared-resource material interpretation and mesh-segmentation preservation, then expand 1.9/1.10 conformance fixtures. | **Complete** |
 | 3. Material fidelity | Load complete PBR texture sets, preserve multiple referenced atlases, and carry sampler wrap semantics into material metadata. | **Complete** |
-| 4. Feature intelligence | Add typed scalar/date/GUID/null-mask attributes, statistics, drawing metadata evaluation, and query APIs. | **In progress** (typed attributes and statistics loading complete in v5.0) |
-| 5. Profile coverage | Add Point, then I3S 2.1 Point Cloud (LEPCC and density-based traversal). | Planned |
+| 4a. Feature attribute semantics | Decode declared numeric types, dates, GUIDs, coded domains, and null sentinels with deterministic output. | **Complete** |
+| 4b. Layer statistics | Load typed `StatsInfo` resources, preserve missing-field isolation, and expose stable keys to applications. | **Complete** (**v5.0**) |
+| 4c. Drawing and popup intelligence | Evaluate renderer, visual variables, labels, and popup expressions while preserving unsupported definitions. | Planned |
+| 4d. Query and aggregation | Add server-side attribute query/filter helpers and client-side statistics aggregation over loaded features. | Planned |
+| 5. Profile coverage | Add Point, then I3S 2.1 Point Cloud (LEPCC and density-based traversal), including profile-specific attributes. | Planned |
 | 6. Spatial semantics | Add projected and vertical CRS transforms plus `elevationInfo` placement modes. | Planned |
+| 7. Validation and authoring parity | Expand schema validation and converter fixtures until supported loader and authoring paths have matching conformance guarantees. | Planned |
+
+The next high-value tranche is **4c**, followed by **4d**. Tranches 5–7 close the remaining profile,
+coordinate-system, and authoring gaps needed for full supremacy.
 
 ## Related specifications and documentation
 

--- a/docs/modules/i3s/formats/i3s.md
+++ b/docs/modules/i3s/formats/i3s.md
@@ -138,7 +138,7 @@ those versions.
 | Null numeric values | **Supported** | **v5.0** | Numeric `NaN` sentinels are returned as `null`; unavailable resources retain the legacy empty-string fallback. |
 | Coded-value domains | **Supported** | v3.0 | Numeric domain codes are mapped to their display names when loading a selected feature. |
 | Attribute-driven colorization | **Supported** | v3.3 | Numeric attributes can replace or multiply vertex colors through `colorsByAttribute`. |
-| Layer statistics | **Partial** | v2.0 | Statistics metadata passes through; raw SLPK statistics extraction was added in v3.4. There is no typed statistics loader or query API. |
+| Layer statistics | **Supported** | **v5.0** | `loadStatistics` fetches typed `StatsInfo` resources keyed by `statisticsInfo.key`; unavailable fields resolve to `null`. Query and client-side aggregation APIs remain open. |
 | Popup and drawing metadata | **Partial** | v2.0 | Metadata passes through for applications; popup expressions, renderer definitions, labels, and visual variables are not evaluated by the loader. |
 | Server-side attribute query/filter | **Not supported** | — | The client loads node-local attribute resources; it does not implement SceneServer query operations. |
 
@@ -177,7 +177,7 @@ current v5.0 development line; the remaining tranches close the largest unsuppor
 | 1. Correctness hardening | Make root authentication, node metadata passthrough, UInt64 precision, and WebScene CRS validation match the documented boundaries. | **Complete** |
 | 2. 1.10 mesh parity | Add legacy shared-resource material interpretation and mesh-segmentation preservation, then expand 1.9/1.10 conformance fixtures. | **Complete** |
 | 3. Material fidelity | Load complete PBR texture sets, preserve multiple referenced atlases, and carry sampler wrap semantics into material metadata. | **Complete** |
-| 4. Feature intelligence | Add typed scalar/date/GUID/null-mask attributes, statistics, drawing metadata evaluation, and query APIs. | **In progress** (typed scalar/date/GUID/null semantics complete in v5.0) |
+| 4. Feature intelligence | Add typed scalar/date/GUID/null-mask attributes, statistics, drawing metadata evaluation, and query APIs. | **In progress** (typed attributes and statistics loading complete in v5.0) |
 | 5. Profile coverage | Add Point, then I3S 2.1 Point Cloud (LEPCC and density-based traversal). | Planned |
 | 6. Spatial semantics | Add projected and vertical CRS transforms plus `elevationInfo` placement modes. | Planned |
 

--- a/modules/i3s/src/i3s-attribute-loader-with-parser.ts
+++ b/modules/i3s/src/i3s-attribute-loader-with-parser.ts
@@ -252,7 +252,10 @@ function formatAttributeValue(attribute, featureIdIndex, codedValues, fieldType?
 
   if (fieldType === 'esriFieldTypeDate' && value) {
     const numericValue = Number(value);
-    const parsedDate = Number.isFinite(numericValue) ? new Date(numericValue) : new Date(value);
+    const dateValue = Number.isFinite(numericValue)
+      ? numericValue
+      : appendUtcToOffsetFreeDate(value);
+    const parsedDate = new Date(dateValue);
     if (!Number.isNaN(parsedDate.getTime())) {
       value = parsedDate.toISOString();
     }
@@ -265,4 +268,13 @@ function formatAttributeValue(attribute, featureIdIndex, codedValues, fieldType?
   }
 
   return value;
+}
+
+/**
+ * Make an ISO date-time without an explicit offset deterministic across runtimes.
+ * @param value - date value from an I3S attribute resource
+ * @returns value with an explicit UTC suffix when it is offset-free
+ */
+function appendUtcToOffsetFreeDate(value: string): string {
+  return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?$/.test(value) ? `${value}Z` : value;
 }

--- a/modules/i3s/src/i3s-attribute-loader-with-parser.ts
+++ b/modules/i3s/src/i3s-attribute-loader-with-parser.ts
@@ -276,5 +276,5 @@ function formatAttributeValue(attribute, featureIdIndex, codedValues, fieldType?
  * @returns value with an explicit UTC suffix when it is offset-free
  */
 function appendUtcToOffsetFreeDate(value: string): string {
-  return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?$/.test(value) ? `${value}Z` : value;
+  return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?$/.test(value) ? `${value}Z` : value;
 }

--- a/modules/i3s/src/i3s-statistics.ts
+++ b/modules/i3s/src/i3s-statistics.ts
@@ -44,15 +44,37 @@ async function loadStatistic(
   statistic: StatisticsInfo,
   options: LoaderOptions & {i3s?: {token?: string | null}}
 ): Promise<StatsInfo | null> {
-  const url = getUrlWithToken(statistic.href, options.i3s?.token || null);
+  const baseUrl = options.core?.baseUrl || options.baseUri;
+  const resolvedUrl = resolveStatisticsUrl(statistic.href, baseUrl);
+  const url = getUrlWithToken(resolvedUrl, options.i3s?.token || null);
   try {
-    const response = await fetchStatisticsResource(url, options.fetch);
+    const fetchOptions = options.core?.fetch ?? options.fetch;
+    const response = await fetchStatisticsResource(url, fetchOptions);
     if (!response.ok) {
       return null;
     }
     return (await response.json()) as StatsInfo;
   } catch (_error) {
     return null;
+  }
+}
+
+/**
+ * Resolve a statistics resource href against the layer URL supplied by the caller.
+ * @param href - resource href from `statisticsInfo`
+ * @param baseUrl - loaded layer URL or canonical loader base URL
+ * @returns an absolute resource URL when a base URL is available
+ */
+function resolveStatisticsUrl(href: string, baseUrl?: string): string {
+  if (!baseUrl || /^(?:[a-z]+:)?\/\//i.test(href) || href.startsWith('data:')) {
+    return href;
+  }
+
+  try {
+    const directoryUrl = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+    return new URL(href, directoryUrl).toString();
+  } catch (_error) {
+    return `${baseUrl.replace(/\/$/, '')}/${href.replace(/^\.\//, '')}`;
   }
 }
 

--- a/modules/i3s/src/i3s-statistics.ts
+++ b/modules/i3s/src/i3s-statistics.ts
@@ -1,0 +1,73 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {LoaderOptions} from '@loaders.gl/loader-utils';
+import type {StatisticsInfo, StatsInfo} from './types';
+import {getUrlWithToken} from './lib/utils/url-utils';
+
+/** Typed statistics keyed by the `statisticsInfo.key` value. */
+export type I3SStatistics = Record<string, StatsInfo | null>;
+
+/**
+ * Load the statistics resources advertised by an I3S scene layer.
+ *
+ * Failed or unavailable resources are represented as `null` so one missing field does not prevent
+ * callers from consuming the remaining layer statistics.
+ * @param statisticsInfo - scene-layer statistics resource descriptors
+ * @param options - fetch and I3S token options
+ * @returns statistics keyed by descriptor key
+ */
+export async function loadStatistics(
+  statisticsInfo: StatisticsInfo[] | undefined,
+  options: LoaderOptions & {i3s?: {token?: string | null}} = {}
+): Promise<I3SStatistics> {
+  if (!statisticsInfo?.length) {
+    return {};
+  }
+
+  const entries = await Promise.all(
+    statisticsInfo.map(
+      async statistic => [statistic.key, await loadStatistic(statistic, options)] as const
+    )
+  );
+  return Object.fromEntries(entries);
+}
+
+/**
+ * Load one statistics resource.
+ * @param statistic - statistics resource descriptor
+ * @param options - fetch and I3S token options
+ * @returns decoded statistics or null when unavailable
+ */
+async function loadStatistic(
+  statistic: StatisticsInfo,
+  options: LoaderOptions & {i3s?: {token?: string | null}}
+): Promise<StatsInfo | null> {
+  const url = getUrlWithToken(statistic.href, options.i3s?.token || null);
+  try {
+    const response = await fetchStatisticsResource(url, options.fetch);
+    if (!response.ok) {
+      return null;
+    }
+    return (await response.json()) as StatsInfo;
+  } catch (_error) {
+    return null;
+  }
+}
+
+/**
+ * Fetch a statistics resource with either a custom loader fetch function or request options.
+ * @param url - resource URL
+ * @param fetchOptions - custom fetch function or RequestInit
+ * @returns resource response
+ */
+async function fetchStatisticsResource(
+  url: string,
+  fetchOptions: LoaderOptions['fetch']
+): Promise<Response> {
+  if (typeof fetchOptions === 'function') {
+    return await fetchOptions(url);
+  }
+  return await fetch(url, fetchOptions as RequestInit | undefined);
+}

--- a/modules/i3s/src/index.ts
+++ b/modules/i3s/src/index.ts
@@ -66,3 +66,5 @@ export {parseSLPKArchive} from './lib/parsers/parse-slpk/parse-slpk';
 export {LayerError} from './lib/parsers/parse-arcgis-webscene';
 export {customizeColors} from './lib/utils/customize-colors';
 export {type I3STileAttributes} from './lib/parsers/parse-i3s-attribute';
+export {loadStatistics} from './i3s-statistics';
+export type {I3SStatistics} from './i3s-statistics';

--- a/modules/i3s/test/i3s-conformance.spec.ts
+++ b/modules/i3s/test/i3s-conformance.spec.ts
@@ -11,6 +11,7 @@ import {parseI3STileAttribute} from '../src/lib/parsers/parse-i3s-attribute';
 import {parseI3STileContent, parseUint64Values} from '../src/lib/parsers/parse-i3s-tile-content';
 import {getLegacyMaterialDefinition, normalizeTileData} from '../src/lib/parsers/parse-i3s';
 import {loadFeatureAttributes} from '../src/i3s-attribute-loader-with-parser';
+import {loadStatistics} from '../src/i3s-statistics';
 import {createReadableFileFromBuffer} from 'test/utils/readable-files';
 
 const SCENE_LAYER_FIXTURES = [
@@ -115,6 +116,20 @@ describe('I3S conformance fixtures', () => {
     datesView.setFloat64(8, Date.UTC(2024, 0, 1), true);
     datesView.setFloat64(16, Date.UTC(2024, 0, 2, 3, 4, 5), true);
 
+    const stringDateValues = ['2024-01-01T00:00:00\0', '2024-01-02T03:04:05\0'];
+    const encodedStringDateValues = stringDateValues.map(value => new TextEncoder().encode(value));
+    const stringDatesBuffer = new ArrayBuffer(
+      16 + encodedStringDateValues[0].byteLength + encodedStringDateValues[1].byteLength
+    );
+    const stringDatesView = new DataView(stringDatesBuffer);
+    stringDatesView.setUint32(0, stringDateValues.length, true);
+    stringDatesView.setUint32(8, encodedStringDateValues[0].byteLength, true);
+    stringDatesView.setUint32(12, encodedStringDateValues[1].byteLength, true);
+    new Uint8Array(stringDatesBuffer, 16).set(encodedStringDateValues[0]);
+    new Uint8Array(stringDatesBuffer, 16 + encodedStringDateValues[0].byteLength).set(
+      encodedStringDateValues[1]
+    );
+
     const nullValuesBuffer = new ArrayBuffer(24);
     const nullValuesView = new DataView(nullValuesBuffer);
     nullValuesView.setFloat64(8, 10, true);
@@ -138,6 +153,7 @@ describe('I3S conformance fixtures', () => {
     const responses: Record<string, ArrayBuffer> = {
       '/attributes/objectids': objectIdsBuffer,
       '/attributes/dates': datesBuffer,
+      '/attributes/string-dates': stringDatesBuffer,
       '/attributes/guids': guidsBuffer,
       '/attributes/nulls': nullValuesBuffer
     };
@@ -148,12 +164,14 @@ describe('I3S conformance fixtures', () => {
             attributeStorageInfo: [
               {name: 'OBJECTID', objectIds: []},
               {name: 'BuildDate', attributeValues: {valueType: 'Float64'}},
+              {name: 'CreatedDate', attributeValues: {valueType: 'String'}},
               {name: 'AssetGuid', attributeValues: {valueType: 'String'}},
               {name: 'OptionalHeight', attributeValues: {valueType: 'Float64'}}
             ],
             fields: [
               {name: 'OBJECTID', type: 'esriFieldTypeOID'},
               {name: 'BuildDate', type: 'esriFieldTypeDate'},
+              {name: 'CreatedDate', type: 'esriFieldTypeDate'},
               {name: 'AssetGuid', type: 'esriFieldTypeGUID'},
               {name: 'OptionalHeight', type: 'esriFieldTypeDouble'}
             ]
@@ -163,6 +181,7 @@ describe('I3S conformance fixtures', () => {
           attributeUrls: [
             '/attributes/objectids',
             '/attributes/dates',
+            '/attributes/string-dates',
             '/attributes/guids',
             '/attributes/nulls'
           ]
@@ -177,8 +196,31 @@ describe('I3S conformance fixtures', () => {
     expect(attributes).toEqual({
       OBJECTID: '8',
       BuildDate: '2024-01-02T03:04:05.000Z',
+      CreatedDate: '2024-01-02T03:04:05.000Z',
       AssetGuid: '{22222222-2222-2222-2222-222222222222}',
       OptionalHeight: null
+    });
+  });
+
+  it('loads typed layer statistics and isolates missing resources', async () => {
+    const statistics = await loadStatistics(
+      [
+        {key: 'height', name: 'Height', href: '/statistics/height'},
+        {key: 'missing', name: 'Missing', href: '/statistics/missing'}
+      ],
+      {
+        fetch: async url => {
+          if (String(url).endsWith('/missing')) {
+            return new Response(null, {status: 404});
+          }
+          return new Response(JSON.stringify({count: 2, min: 1, max: 3, avg: 2}));
+        }
+      }
+    );
+
+    expect(statistics).toEqual({
+      height: {count: 2, min: 1, max: 3, avg: 2},
+      missing: null
     });
   });
 

--- a/modules/i3s/test/i3s-conformance.spec.ts
+++ b/modules/i3s/test/i3s-conformance.spec.ts
@@ -116,7 +116,7 @@ describe('I3S conformance fixtures', () => {
     datesView.setFloat64(8, Date.UTC(2024, 0, 1), true);
     datesView.setFloat64(16, Date.UTC(2024, 0, 2, 3, 4, 5), true);
 
-    const stringDateValues = ['2024-01-01T00:00:00\0', '2024-01-02T03:04:05\0'];
+    const stringDateValues = ['2024-01-01T00:00:00\0', '2024-01-02T03:04\0'];
     const encodedStringDateValues = stringDateValues.map(value => new TextEncoder().encode(value));
     const stringDatesBuffer = new ArrayBuffer(
       16 + encodedStringDateValues[0].byteLength + encodedStringDateValues[1].byteLength
@@ -196,32 +196,59 @@ describe('I3S conformance fixtures', () => {
     expect(attributes).toEqual({
       OBJECTID: '8',
       BuildDate: '2024-01-02T03:04:05.000Z',
-      CreatedDate: '2024-01-02T03:04:05.000Z',
+      CreatedDate: '2024-01-02T03:04:00.000Z',
       AssetGuid: '{22222222-2222-2222-2222-222222222222}',
       OptionalHeight: null
     });
   });
 
   it('loads typed layer statistics and isolates missing resources', async () => {
+    const requestedUrls: string[] = [];
     const statistics = await loadStatistics(
       [
-        {key: 'height', name: 'Height', href: '/statistics/height'},
-        {key: 'missing', name: 'Missing', href: '/statistics/missing'}
+        {key: 'height', name: 'Height', href: './statistics/height'},
+        {key: 'missing', name: 'Missing', href: './statistics/missing'}
       ],
       {
-        fetch: async url => {
-          if (String(url).endsWith('/missing')) {
-            return new Response(null, {status: 404});
+        core: {
+          baseUrl: 'https://example.com/layers/0',
+          fetch: async url => {
+            requestedUrls.push(String(url));
+            if (String(url).includes('/missing')) {
+              return new Response(null, {status: 404});
+            }
+            return new Response(JSON.stringify({count: 2, min: 1, max: 3, avg: 2}));
           }
-          return new Response(JSON.stringify({count: 2, min: 1, max: 3, avg: 2}));
-        }
+        },
+        i3s: {token: 'secret'}
       }
     );
 
+    expect(requestedUrls).toEqual([
+      'https://example.com/layers/0/statistics/height?token=secret',
+      'https://example.com/layers/0/statistics/missing?token=secret'
+    ]);
     expect(statistics).toEqual({
       height: {count: 2, min: 1, max: 3, avg: 2},
       missing: null
     });
+  });
+
+  it('keeps absolute statistics URLs unchanged', async () => {
+    const statistics = await loadStatistics(
+      [{key: 'height', name: 'Height', href: 'https://cdn.example.com/statistics/height'}],
+      {
+        core: {
+          baseUrl: 'https://example.com/layers/0',
+          fetch: async url => {
+            expect(url).toBe('https://cdn.example.com/statistics/height');
+            return new Response(JSON.stringify({count: 1}));
+          }
+        }
+      }
+    );
+
+    expect(statistics).toEqual({height: {count: 1}});
   });
 
   it('preserves UInt64 feature IDs through face-range expansion', async () => {


### PR DESCRIPTION
## Goals

- Continue the I3S feature-intelligence tranche with typed layer statistics loading.
- Close the outstanding #3821 review feedback by making offset-free string dates deterministic UTC values.

## Changes

- Add `loadStatistics` and the `I3SStatistics` result type to the I3S public API.
- Fetch `statisticsInfo` resources concurrently, key results by descriptor `key`, and isolate unavailable resources as `null`.
- Apply I3S tokens to statistics requests and document the API.
- Add conformance coverage for string-backed date normalization and statistics failures.
- Update the I3S support matrix and roadmap for the v5.0 statistics capability.

## Validation

- `yarn lint fix`
- `node node_modules/typescript/bin/tsc -p modules/i3s/tsconfig.json --noEmit`
- `yarn test-headless modules/i3s/test/i3s-conformance.spec.ts modules/i3s/test/i3s-attribute-loader.spec.ts`

Related: follow-up to #3821 review feedback.
