### PR TITLE
feat(3d-tiles): add metadata topology and semantic bounds

### DIFF
--- a/docs/modules/3d-tiles/formats/3d-tiles.md
+++ b/docs/modules/3d-tiles/formats/3d-tiles.md
@@ -58,7 +58,7 @@ provides a visual implementation for that feature.
 | `EXT_mesh_features` | [x] | Feature identifiers are preserved for supported glTF payloads. |
 | `EXT_structural_metadata` | [x] | Schema and property-table metadata are exposed where present. |
 | Metadata topology preservation | [x] | Schema, groups, tileset/tile/content entities, and implicit-subtree references are retained for application-level interpretation. Value/class decoding is not included. |
-| Metadata-derived bounding volumes | [ ] | `TILE_BOUNDING_*` and `CONTENT_BOUNDING_*` semantics are planned. |
+| Metadata-derived bounding volumes | [x] | Direct numeric `TILE_BOUNDING_*` and `CONTENT_BOUNDING_*` semantic arrays are normalized; property-table value decoding remains application-owned. |
 | Styling expressions | [ ] | Rendering-side style evaluation is not provided by this module. |
 
 ## How to read the matrix
@@ -108,7 +108,7 @@ called out explicitly rather than being counted as parser support.
 | Extension | `3DTILES_batch_table_hierarchy` | [~] | Parse validation | Parser scaffolding and boundary validation exist; complete hierarchy semantics remain planned. |
 | Metadata | `EXT_mesh_features` | [x] | Parse + preserve | Feature identifiers are retained for supported glTF payloads. |
 | Metadata | `EXT_structural_metadata` | [x] | Parse + preserve | Schema, property tables, groups, and entity links are exposed; value decoding is application-side. |
-| Metadata | Metadata-derived bounding volumes | [ ] | Culling | `TILE_BOUNDING_*` and `CONTENT_BOUNDING_*` selection is planned. |
+| Metadata | Metadata-derived bounding volumes | [x] | Culling | Direct numeric semantic arrays are normalized into tile/content volumes; property-table decoding remains application-owned. |
 | Renderer | Styling expressions | [ ] | Renderer | Style evaluation and visual feature selection are outside this loader/runtime package. |
 | Renderer | GPU upload and draw policy | [ ] | Renderer | Applications such as deck.gl or Cesium decide how normalized payloads become draw calls. |
 

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -5,6 +5,12 @@
 
 ## v5.0 (In Development)
 
+### 3D Tiles
+
+- Expose tileset metadata topology (`schema`, `schemaUri`, `groups`, `metadata`, and `statistics`) on the shared `Tileset3D` runtime for application inspection.
+- Normalize direct numeric `TILE_BOUNDING_*` and `CONTENT_BOUNDING_*` metadata semantics into traversal-ready bounding volumes while preserving explicit volume precedence.
+
+
 Release Date: 2026
 
 **Highlights**

--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile-header.ts
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile-header.ts
@@ -70,7 +70,9 @@ function normalizeTileContents(
   const normalizedContents = contentEntries.map(contentEntry => {
     return {
       ...contentEntry,
-      boundingVolume: normalizeS2BoundingVolume(contentEntry.boundingVolume),
+      boundingVolume: normalizeS2BoundingVolume(
+        contentEntry.boundingVolume || getMetadataBoundingVolume(contentEntry.metadata, 'CONTENT')
+      ),
       uri: contentEntry.uri,
       url: contentEntry.url
     };
@@ -118,7 +120,9 @@ export function normalizeTileData(
   }
   const normalizedContents = normalizeTileContents(tile.content, resourceResolver);
   const tileContentUrl = normalizedContents.contentUrls[0];
-  const boundingVolume = normalizeS2BoundingVolume(tile.boundingVolume) as Tile3DBoundingVolume;
+  const boundingVolume = normalizeS2BoundingVolume(
+    tile.boundingVolume || getMetadataBoundingVolume(tile.metadata, 'TILE')
+  ) as Tile3DBoundingVolume;
   const viewerRequestVolume = normalizeS2BoundingVolume(tile.viewerRequestVolume);
   const tilePostprocessed: Tiles3DTileJSONPostprocessed = {
     ...tile,
@@ -136,6 +140,46 @@ export function normalizeTileData(
   };
 
   return tilePostprocessed;
+}
+
+/**
+ * Resolves a metadata-derived tile or content bounding volume when the source exposes a direct
+ * semantic value. Property-table decoding is intentionally left to the metadata consumer; this
+ * helper only recognizes numeric arrays already materialized in the metadata entity.
+ *
+ * @param metadata - Tile or content metadata entity.
+ * @param scope - Semantic scope, either `TILE` or `CONTENT`.
+ * @returns A normalized source bounding volume, or `undefined` when no supported semantic is present.
+ */
+function getMetadataBoundingVolume(
+  metadata: Tiles3DTileJSON['metadata'] | undefined,
+  scope: 'TILE' | 'CONTENT'
+): Tile3DBoundingVolume | undefined {
+  const properties = metadata?.properties;
+  if (!properties) {
+    return undefined;
+  }
+  const semanticNames = [
+    `${scope}_BOUNDING_BOX`,
+    `${scope}_BOUNDING_REGION`,
+    `${scope}_BOUNDING_SPHERE`
+  ];
+  for (const semanticName of semanticNames) {
+    const value = properties[semanticName];
+    if (!Array.isArray(value) || !value.every(component => typeof component === 'number')) {
+      continue;
+    }
+    if (semanticName.endsWith('_BOX') && value.length === 12) {
+      return {box: value};
+    }
+    if (semanticName.endsWith('_REGION') && value.length === 6) {
+      return {region: value};
+    }
+    if (semanticName.endsWith('_SPHERE') && value.length === 4) {
+      return {sphere: value};
+    }
+  }
+  return undefined;
 }
 
 /**
@@ -265,7 +309,9 @@ export async function normalizeImplicitTileHeaders(
   void context;
   const normalizedTile: Tiles3DTileJSON = {
     ...tile,
-    boundingVolume: normalizeS2BoundingVolume(tile.boundingVolume) as Tile3DBoundingVolume,
+    boundingVolume: normalizeS2BoundingVolume(
+      tile.boundingVolume || getMetadataBoundingVolume(tile.metadata, 'TILE')
+    ) as Tile3DBoundingVolume,
     content: tile.content,
     viewerRequestVolume: normalizeS2BoundingVolume(tile.viewerRequestVolume)
   };

--- a/modules/3d-tiles/test/lib/parsers/parse-3d-tile-header.spec.ts
+++ b/modules/3d-tiles/test/lib/parsers/parse-3d-tile-header.spec.ts
@@ -45,3 +45,18 @@ test('normalizeTileData#corectly resolves different styles of URLs', async () =>
     expect(normalizedTile?.contentUrl, 'url should be resolved correctly').toBe(resolvedUrl);
   }
 });
+
+
+test('normalizeTileData#derives metadata bounding volume semantics', () => {
+  const normalizedTile = normalizeTileData(
+    {
+      metadata: {properties: {TILE_BOUNDING_SPHERE: [1, 2, 3, 4]}},
+      content: {uri: 'tile.b3dm', metadata: {properties: {CONTENT_BOUNDING_REGION: [0, 0, 1, 1, 0, 10]}}}
+    } as any,
+    'https://example.com/tiles'
+  );
+  expect(normalizedTile?.boundingVolume).toEqual({sphere: [1, 2, 3, 4]});
+  expect((normalizedTile?.content as any)?.boundingVolume).toEqual({
+    region: [0, 0, 1, 1, 0, 10]
+  });
+});

--- a/modules/tiles/src/tileset-3d/common/tileset-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tileset-3d.ts
@@ -323,6 +323,16 @@ export class Tileset3D {
   root: Tile3D | null = null;
   roots: Record<string, Tile3D> = {};
   asset: Record<string, any> = {};
+  /** Inline metadata schema declared by the source tileset, when present. */
+  schema: Record<string, any> | null = null;
+  /** External metadata schema URI declared by the source tileset, when present. */
+  schemaUri: string | null = null;
+  /** Metadata groups declared by the source tileset, in source order. */
+  groups: Array<Record<string, any>> = [];
+  /** Tileset-wide metadata entity, preserved without property-table decoding. */
+  metadata: Record<string, any> | null = null;
+  /** Tileset statistics metadata, preserved for application-level inspection. */
+  statistics: unknown = null;
 
   description = '';
   properties: any;
@@ -1061,6 +1071,12 @@ export class Tileset3D {
     this.refine = metadata.refine;
     this.contentFormats = this.source.contentFormats;
     this.asset = this.source.asset || this.asset;
+    const tileset = metadata.tileset as Record<string, any>;
+    this.schema = tileset.schema || null;
+    this.schemaUri = tileset.schemaUri || null;
+    this.groups = tileset.groups || [];
+    this.metadata = tileset.metadata || null;
+    this.statistics = tileset.statistics ?? null;
     this.properties = this.source.properties ?? this.properties;
     this.extras = this.source.extras ?? this.extras;
     if (this.options.attributions?.length) {


### PR DESCRIPTION
## Goals

Advance the 3D Tiles Cesium-parity roadmap with the next two high-impact metadata tranches: complete runtime metadata topology exposure and metadata-derived bounding volumes.

## Changes

- Expose `schema`, `schemaUri`, `groups`, tileset `metadata`, and `statistics` on `Tileset3D` while preserving the raw source payload for application-level interpretation.
- Resolve direct numeric `TILE_BOUNDING_BOX`, `TILE_BOUNDING_REGION`, and `TILE_BOUNDING_SPHERE` metadata semantics when an explicit tile volume is absent.
- Resolve corresponding `CONTENT_BOUNDING_*` semantics for content entries, preserving explicit content-volume precedence.
- Keep S2 normalization and transform handling unchanged after semantic resolution.
- Add focused parser coverage and update the 3D Tiles compatibility matrix and What's New notes.

## Scope and limitations

This tranche intentionally preserves property-table references without decoding them. Applications that decode property-table values can feed the same semantic shapes into their own metadata layer; a follow-up can connect decoded tables without changing the traversal contract.

## Validation

CI will run build, lint, node/headless tests, coverage, and website checks. The branch is based on latest `master` (`069372d`).