### PR TITLE
test: migrate shapefile suites to Vitest

### DIFF
--- a/modules/shapefile/test/dbf-arrow-loader.spec.ts
+++ b/modules/shapefile/test/dbf-arrow-loader.spec.ts
@@ -2,14 +2,12 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {setLoaderOptions, fetchFile, parse} from '@loaders.gl/core';
 import {DBFLoader} from '@loaders.gl/shapefile';
-
 setLoaderOptions({
   _workerType: 'test'
 });
-
 const SHAPEFILE_JS_DATA_FOLDER = '@loaders.gl/shapefile/test/data/shapefile-js';
 const SHAPEFILE_JS_TEST_FILES = [
   'boolean-property',
@@ -26,25 +24,18 @@ const SHAPEFILE_JS_TEST_FILES = [
   'string-property',
   'utf8-property'
 ];
-
-test('DBFLoader#parse arrow-table', async t => {
+test('DBFLoader#parse arrow-table', async () => {
   for (const testFileName of SHAPEFILE_JS_TEST_FILES) {
     const encoding = testFileName === 'latin1-property' ? 'latin1' : 'utf8';
     const options = {worker: false, dbf: {encoding, shape: 'arrow-table' as const}};
-
     let response = await fetchFile(`${SHAPEFILE_JS_DATA_FOLDER}/${testFileName}.json`);
     const {features} = await response.json();
-
     response = await fetchFile(`${SHAPEFILE_JS_DATA_FOLDER}/${testFileName}.dbf`);
     const body = await response.arrayBuffer();
-
     const table = await parse(body, DBFLoader, options);
-
     for (let i = 0; i < features.length; i++) {
       const row = table.data.get(i)!.toJSON();
-      t.deepEqual(row, features[i].properties, testFileName);
+      expect(row, testFileName).toEqual(features[i].properties);
     }
   }
-
-  t.end();
 });

--- a/modules/shapefile/test/dbf-loader.spec.ts
+++ b/modules/shapefile/test/dbf-loader.spec.ts
@@ -2,14 +2,12 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {setLoaderOptions, fetchFile, parse} from '@loaders.gl/core';
 import {DBFLoader} from '@loaders.gl/shapefile';
-
 setLoaderOptions({
   _workerType: 'test'
 });
-
 const SHAPEFILE_JS_DATA_FOLDER = '@loaders.gl/shapefile/test/data/shapefile-js';
 const SHAPEFILE_JS_TEST_FILES = [
   'boolean-property',
@@ -26,25 +24,19 @@ const SHAPEFILE_JS_TEST_FILES = [
   'string-property',
   'utf8-property'
 ];
-
-test('Shapefile JS DBF tests', async t => {
+test('Shapefile JS DBF tests', async () => {
   for (const testFileName of SHAPEFILE_JS_TEST_FILES) {
     let response = await fetchFile(`${SHAPEFILE_JS_DATA_FOLDER}/${testFileName}.dbf`);
     const body = await response.arrayBuffer();
     const options = {core: {worker: false}, dbf: {encoding: 'utf8', shape: 'rows' as const}};
-
     if (testFileName === 'latin1-property') {
       options.dbf.encoding = 'latin1';
     }
     const output = await parse(body, DBFLoader, options);
-
     response = await fetchFile(`${SHAPEFILE_JS_DATA_FOLDER}/${testFileName}.json`);
     const {features} = await response.json();
-
     for (let i = 0; i < features.length; i++) {
-      t.deepEqual(output[i], features[i].properties, testFileName);
+      expect(output[i], testFileName).toEqual(features[i].properties);
     }
   }
-
-  t.end();
 });

--- a/modules/shapefile/test/shapefile-arrow-loader.spec.ts
+++ b/modules/shapefile/test/shapefile-arrow-loader.spec.ts
@@ -2,18 +2,16 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {validateLoader} from 'test/common/conformance';
 import {setLoaderOptions, fetchFile, load, loadInBatches} from '@loaders.gl/core';
 import {ShapefileLoader} from '@loaders.gl/shapefile';
 import {convertWKBTableToGeoJSON} from '@loaders.gl/gis';
 import {getGeoMetadata} from '@loaders.gl/geoarrow';
-
 setLoaderOptions({
   _workerType: 'test',
   worker: false
 });
-
 const SHAPEFILE_JS_DATA_FOLDER = '@loaders.gl/shapefile/test/data/shapefile-js';
 const TEST_FILES = [
   'points',
@@ -23,13 +21,10 @@ const TEST_FILES = [
   'utf8-property',
   'empty'
 ];
-
-test('ShapefileLoader#loader conformance', t => {
-  validateLoader(t, ShapefileLoader, 'ShapefileLoader');
-  t.end();
+test('ShapefileLoader#loader conformance', () => {
+  validateLoader(ShapefileLoader, 'ShapefileLoader');
 });
-
-test('ShapefileLoader#load arrow-table fixtures round-trip to GeoJSON', async t => {
+test('ShapefileLoader#load arrow-table fixtures round-trip to GeoJSON', async () => {
   for (const testFileName of TEST_FILES) {
     const filename = `${SHAPEFILE_JS_DATA_FOLDER}/${testFileName}.shp`;
     const table = await load(filename, ShapefileLoader, {shapefile: {shape: 'arrow-table'}});
@@ -37,32 +32,25 @@ test('ShapefileLoader#load arrow-table fixtures round-trip to GeoJSON', async t 
       shapefile: {shape: 'arrow-table'}
     });
     const geoMetadata = getGeoMetadata(table.schema.metadata);
-    t.equal(
-      geoMetadata?.primary_column,
-      'geometry',
-      `${testFileName}: geo metadata primary column`
+    expect(geoMetadata?.primary_column, `${testFileName}: geo metadata primary column`).toBe(
+      'geometry'
     );
-
     const rows = getRowsFromArrowTable(table);
     const roundTripped = convertWKBTableToGeoJSON(
       {shape: 'object-row-table', schema: table.schema, data: rows},
       table.schema
     );
-
     const response = await fetchFile(`${SHAPEFILE_JS_DATA_FOLDER}/${testFileName}.json`);
     const expected = await response.json();
-    t.deepEqual(
-      getRowsFromArrowTable(table),
-      getRowsFromArrowTable(explicitArrowTable),
-      `${testFileName}: arrow-table output is stable`
+    expect(getRowsFromArrowTable(table), `${testFileName}: arrow-table output is stable`).toEqual(
+      getRowsFromArrowTable(explicitArrowTable)
     );
-    t.deepEqual(roundTripped.features, expected.features, `${testFileName}: features round-trip`);
+    expect(roundTripped.features, `${testFileName}: features round-trip`).toEqual(
+      expected.features
+    );
   }
-
-  t.end();
 });
-
-test('ShapefileLoader#load arrow-table reprojects like v3 output', async t => {
+test('ShapefileLoader#load arrow-table reprojects like v3 output', async () => {
   const filename = `${SHAPEFILE_JS_DATA_FOLDER}/points.shp`;
   const arrowTable = await load(filename, ShapefileLoader, {
     shapefile: {shape: 'arrow-table'},
@@ -72,36 +60,35 @@ test('ShapefileLoader#load arrow-table reprojects like v3 output', async t => {
     shapefile: {shape: 'v3'},
     gis: {reproject: true, _targetCrs: 'EPSG:3857'}
   });
-
   const rows = getRowsFromArrowTable(arrowTable);
   const roundTripped = convertWKBTableToGeoJSON(
     {shape: 'object-row-table', schema: arrowTable.schema, data: rows},
     arrowTable.schema
   );
-
-  t.deepEqual(roundTripped.features, shapeTable.data, 'reprojected features match ShapefileLoader');
-  t.end();
+  expect(roundTripped.features, 'reprojected features match ShapefileLoader').toEqual(
+    shapeTable.data
+  );
 });
-
-test('ShapefileLoader#load arrow-table stores WKB in one contiguous Arrow values buffer', async t => {
+test('ShapefileLoader#load arrow-table stores WKB in one contiguous Arrow values buffer', async () => {
   const filename = `${SHAPEFILE_JS_DATA_FOLDER}/points.shp`;
   const table = await load(filename, ShapefileLoader, {shapefile: {shape: 'arrow-table'}});
   const rows = getRowsFromArrowTable(table);
   const recordBatch = table.data.batches[0];
   const geometryFieldIndex = table.schema.fields.findIndex(field => field.name === 'geometry');
   const geometryData = recordBatch.data.children[geometryFieldIndex];
-
-  t.equal(geometryData.valueOffsets.length, rows.length + 1, 'geometry offsets cover every row');
-  t.equal(
-    geometryData.valueOffsets[geometryData.valueOffsets.length - 1],
-    geometryData.values.byteLength,
-    'last offset points to the end of one values buffer'
+  expect(geometryData.valueOffsets.length, 'geometry offsets cover every row').toBe(
+    rows.length + 1
   );
-  t.ok(geometryData.values instanceof Uint8Array, 'geometry values are stored as a byte buffer');
-  t.end();
+  expect(
+    geometryData.valueOffsets[geometryData.valueOffsets.length - 1],
+    'last offset points to the end of one values buffer'
+  ).toBe(geometryData.values.byteLength);
+  expect(
+    geometryData.values instanceof Uint8Array,
+    'geometry values are stored as a byte buffer'
+  ).toBeTruthy();
 });
-
-test('ShapefileLoader#load arrow-table can emit typed GeoArrow point geometry', async t => {
+test('ShapefileLoader#load arrow-table can emit typed GeoArrow point geometry', async () => {
   const filename = `${SHAPEFILE_JS_DATA_FOLDER}/points.shp`;
   const table = await load(filename, ShapefileLoader, {
     shapefile: {shape: 'arrow-table', geoarrowEncoding: 'geoarrow'}
@@ -111,23 +98,19 @@ test('ShapefileLoader#load arrow-table can emit typed GeoArrow point geometry', 
   const geometryFieldIndex = table.schema.fields.findIndex(field => field.name === 'geometry');
   const geometryField = table.data.schema.fields[geometryFieldIndex];
   const geometryData = recordBatch.data.children[geometryFieldIndex];
-
-  t.equal(
-    geoMetadata?.columns.geometry.encoding,
-    'point',
-    'geo metadata records typed point encoding'
+  expect(geoMetadata?.columns.geometry.encoding, 'geo metadata records typed point encoding').toBe(
+    'point'
   );
-  t.equal(
+  expect(
     geometryField.metadata.get('ARROW:extension:name'),
-    'geoarrow.point',
     'geometry field has GeoArrow point extension'
+  ).toBe('geoarrow.point');
+  expect(geometryData.length, 'geometry data has one row per feature').toBe(table.data.numRows);
+  expect(geometryData.children[0].values.length, 'coordinates are dense').toBe(
+    table.data.numRows * 2
   );
-  t.equal(geometryData.length, table.data.numRows, 'geometry data has one row per feature');
-  t.equal(geometryData.children[0].values.length, table.data.numRows * 2, 'coordinates are dense');
-  t.end();
 });
-
-test('ShapefileLoader#loadInBatches arrow-table yields stable Arrow schema', async t => {
+test('ShapefileLoader#loadInBatches arrow-table yields stable Arrow schema', async () => {
   for (const testFileName of TEST_FILES) {
     const filename = `${SHAPEFILE_JS_DATA_FOLDER}/${testFileName}.shp`;
     const batches = await loadInBatches(filename, ShapefileLoader, {
@@ -141,68 +124,54 @@ test('ShapefileLoader#loadInBatches arrow-table yields stable Arrow schema', asy
         continue;
       }
       schema ||= batch.schema;
-      t.deepEqual(batch.schema, schema, `${testFileName}: batch schema is stable`);
+      expect(batch.schema, `${testFileName}: batch schema is stable`).toEqual(schema);
       collectedRows.push(...getRowsFromArrowTable(batch));
     }
-
     const roundTripped = convertWKBTableToGeoJSON(
       {shape: 'object-row-table', schema, data: collectedRows},
       schema
     );
     const response = await fetchFile(`${SHAPEFILE_JS_DATA_FOLDER}/${testFileName}.json`);
     const expected = await response.json();
-    t.deepEqual(
-      roundTripped.features,
-      expected.features,
-      `${testFileName}: batched features round-trip`
+    expect(roundTripped.features, `${testFileName}: batched features round-trip`).toEqual(
+      expected.features
     );
   }
-
-  t.end();
 });
-
-test('ShapefileLoader#loadInBatches arrow-table yields Arrow batches', async t => {
+test('ShapefileLoader#loadInBatches arrow-table yields Arrow batches', async () => {
   const filename = `${SHAPEFILE_JS_DATA_FOLDER}/points.shp`;
   const batches = await loadInBatches(filename, ShapefileLoader, {
     shapefile: {shape: 'arrow-table'},
     metadata: true
   });
-
   let sawDataBatch = false;
   for await (const batch of batches) {
     if (batch?.batchType === 'metadata') {
       continue;
     }
     sawDataBatch = true;
-    t.equal(batch.shape, 'arrow-table', 'main loader yields arrow-table batches');
+    expect(batch.shape, 'main loader yields arrow-table batches').toBe('arrow-table');
     break;
   }
-
-  t.ok(sawDataBatch, 'main loader produced at least one Arrow batch');
-  t.end();
+  expect(sawDataBatch, 'main loader produced at least one Arrow batch').toBeTruthy();
 });
-
-test('ShapefileLoader#loadInBatches arrow-table respects batchSize', async t => {
+test('ShapefileLoader#loadInBatches arrow-table respects batchSize', async () => {
   const filename = `${SHAPEFILE_JS_DATA_FOLDER}/points.shp`;
   const batches = await loadInBatches(filename, ShapefileLoader, {
     shapefile: {shape: 'arrow-table', batchSize: 1}
   });
   const response = await fetchFile(`${SHAPEFILE_JS_DATA_FOLDER}/points.json`);
   const expected = await response.json();
-
   let batchCount = 0;
   for await (const batch of batches) {
     if (batch?.batchType === 'metadata' || batch.length === 0) {
       continue;
     }
     batchCount++;
-    t.equal(batch.length, 1, 'emits requested row batch size');
+    expect(batch.length, 'emits requested row batch size').toBe(1);
   }
-
-  t.equal(batchCount, expected.features.length, 'emits one Arrow batch per point');
-  t.end();
+  expect(batchCount, 'emits one Arrow batch per point').toBe(expected.features.length);
 });
-
 function getRowsFromArrowTable(table): Record<string, unknown>[] {
   const rows: Record<string, unknown>[] = [];
   for (let rowIndex = 0; rowIndex < table.data.numRows; rowIndex++) {

--- a/modules/shapefile/test/shapefile-loader.slow.spec.ts
+++ b/modules/shapefile/test/shapefile-loader.slow.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {
   setLoaderOptions,
   fetchFile,
@@ -15,13 +15,11 @@ import {
 import {ShapefileLoader} from '@loaders.gl/shapefile';
 import {DBFLoaderWithParser as DBFLoader} from '../src/dbf-loader-with-parser';
 import {Proj4Projection} from '@math.gl/proj4';
-import {tapeEqualsEpsilon} from 'test/utils/tape-assertions';
-
+import {equals, withEpsilon} from '@math.gl/core';
 setLoaderOptions({
   _workerType: 'test',
   worker: false
 });
-
 const SHAPEFILE_JS_DATA_FOLDER = '@loaders.gl/shapefile/test/data/shapefile-js';
 const SHAPEFILE_JS_TEST_FILES = {
   'boolean-property': null,
@@ -45,17 +43,15 @@ const SHAPEFILE_JS_TEST_FILES = {
   'string-property': null,
   'utf8-property': null
 };
-
-test('ShapefileLoader#load (from browser File objects)', async t => {
+test('ShapefileLoader#load (from browser File objects)', async () => {
   if (typeof File !== 'undefined') {
     // test `File` load (browser)
-    t.comment('...FILE LOAD STARTING. FAILED FETCHES EXPECTED');
+    console.log('...FILE LOAD STARTING. FAILED FETCHES EXPECTED');
     for (const testFileName in SHAPEFILE_JS_TEST_FILES) {
       const fileList = await getFileList(testFileName);
       SHAPEFILE_JS_TEST_FILES[testFileName] = fileList;
     }
-    t.comment('...FILE LOAD COMPLETE');
-
+    console.log('...FILE LOAD COMPLETE');
     for (const testFileName in SHAPEFILE_JS_TEST_FILES) {
       const fileList = SHAPEFILE_JS_TEST_FILES[testFileName];
       const fileSystem = new BrowserFileSystem(fileList);
@@ -64,28 +60,19 @@ test('ShapefileLoader#load (from browser File objects)', async t => {
       const filename = `${testFileName}.shp`;
       // @ts-ignore
       const data = await load(filename, ShapefileLoader, {fetch, shapefile: {shape: 'v3'}});
-      // t.comment(`${filename}: ${JSON.stringify(data).slice(0, 70)}`);
-
-      testShapefileData(t, testFileName, data);
+      testShapefileData(testFileName, data);
     }
   }
-  t.end();
 });
-
-test('ShapefileLoader#load (from files or URLs)', async t => {
+test('ShapefileLoader#load (from files or URLs)', async () => {
   // test file load (node) or URL load (browser)
   for (const testFileName in SHAPEFILE_JS_TEST_FILES) {
     const filename = `${SHAPEFILE_JS_DATA_FOLDER}/${testFileName}.shp`;
     const data = await load(filename, ShapefileLoader, {shapefile: {shape: 'v3'}});
-    // t.comment(`${filename}: ${JSON.stringify(data).slice(0, 70)}`);
-
-    await testShapefileData(t, testFileName, data);
+    await testShapefileData(testFileName, data);
   }
-
-  t.end();
 });
-
-test('ShapefileLoader#load and reproject (from files or URLs)', async t => {
+test('ShapefileLoader#load and reproject (from files or URLs)', async () => {
   // test file load (node) or URL load (browser)
   const testFileName = 'points';
   const filename = `${SHAPEFILE_JS_DATA_FOLDER}/${testFileName}.shp`;
@@ -93,67 +80,56 @@ test('ShapefileLoader#load and reproject (from files or URLs)', async t => {
     shapefile: {shape: 'v3'},
     gis: {reproject: true, _targetCrs: 'EPSG:3857'}
   });
-  // t.comment(`${filename}: ${JSON.stringify(data).slice(0, 70)}`);
-
   // Compare with parsed json
   // This is a special case with reprojected coordinates; otherwise use the
   // testShapefileData helper
   const response = await fetchFile(`${SHAPEFILE_JS_DATA_FOLDER}/${testFileName}.json`);
   const json = await response.json();
-
   const projection = new Proj4Projection({from: 'WGS84', to: 'EPSG:3857'});
-
   for (let i = 0; i < json.features.length; i++) {
     // @ts-ignore
     const shpFeature = data.data[i];
     const jsonFeature = json.features[i];
     const jsonPointGeom = projection.project(jsonFeature.geometry.coordinates);
-    tapeEqualsEpsilon(t, shpFeature.geometry.coordinates, jsonPointGeom, 0.00001);
+    expect(withEpsilon(0.00001, () => equals(shpFeature.geometry.coordinates, jsonPointGeom))).toBe(
+      true
+    );
   }
-
-  t.end();
 });
-
-test('ShapefileLoader#load passes dbf options to DBFLoader#parse', async t => {
+test('ShapefileLoader#load passes dbf options to DBFLoader#parse', async () => {
   if (isBrowser) {
-    t.comment('Skipping DBFLoader.parse option forwarding test in browser');
-    t.end();
+    console.log('Skipping DBFLoader.parse option forwarding test in browser');
     return;
   }
   const filename = `${SHAPEFILE_JS_DATA_FOLDER}/points.shp`;
   const dbfWorkerUrl = 'custom.dbf.worker.js';
   const originalParse = DBFLoader.parse;
   let receivedOptions = null;
-
   DBFLoader.parse = async (arrayBuffer, options) => {
     receivedOptions = options;
     return originalParse(arrayBuffer, options);
   };
-
   try {
     await load(filename, ShapefileLoader, {
       shapefile: {shape: 'v3'},
       dbf: {workerUrl: dbfWorkerUrl}
     });
-    t.equal(receivedOptions?.dbf?.workerUrl, dbfWorkerUrl, 'ShapefileLoader forwards dbf options');
+    expect(receivedOptions?.dbf?.workerUrl, 'ShapefileLoader forwards dbf options').toBe(
+      dbfWorkerUrl
+    );
   } finally {
     DBFLoader.parse = originalParse;
   }
-
-  t.end();
 });
-
-test('ShapefileLoader#selectLoader (from arrayBuffer data)', async t => {
+test('ShapefileLoader#selectLoader (from arrayBuffer data)', async () => {
   // test file load (node) or URL load (browser)
   const filename = `${SHAPEFILE_JS_DATA_FOLDER}/boolean-property.shp`;
   const response = await fetchFile(filename);
   const arrayBuffer = await response.arrayBuffer();
   const loader = await selectLoader(arrayBuffer, [ShapefileLoader]);
-  t.equal(loader && loader.id, 'shapefile', 'Select loader using SHP magic number');
-  t.end();
+  expect(loader && loader.id, 'Select loader using SHP magic number').toBe('shapefile');
 });
-
-test('ShapefileLoader#loadInBatches(URL)', async t => {
+test('ShapefileLoader#loadInBatches(URL)', async () => {
   // test file load (node) or URL load (browser)
   for (const testFileName in SHAPEFILE_JS_TEST_FILES) {
     const filename = `${SHAPEFILE_JS_DATA_FOLDER}/${testFileName}.shp`;
@@ -163,15 +139,11 @@ test('ShapefileLoader#loadInBatches(URL)', async t => {
       if (batch?.data) {
         data = batch;
       }
-      // t.comment(`${filename}: ${JSON.stringify(data).slice(0, 70)}`);
     }
-    await testShapefileData(t, testFileName, data);
+    await testShapefileData(testFileName, data);
   }
-
-  t.end();
 });
-
-test('ShapefileLoader#loadInBatches(File)', async t => {
+test('ShapefileLoader#loadInBatches(File)', async () => {
   // test file load (node) or URL load (browser)
   for (const testFileName in SHAPEFILE_JS_TEST_FILES) {
     if (testFileName === 'utf8-property') {
@@ -188,7 +160,6 @@ test('ShapefileLoader#loadInBatches(File)', async t => {
     } else {
       fileSystem = new BrowserFileSystem([]);
     }
-
     const filename = `${SHAPEFILE_JS_DATA_FOLDER}/${testFileName}.shp`;
     const response = await fetchFile(filename);
     const file = new File([await response.blob()], filename);
@@ -203,23 +174,18 @@ test('ShapefileLoader#loadInBatches(File)', async t => {
         data = batch;
       }
     }
-    await testShapefileData(t, testFileName, data);
+    await testShapefileData(testFileName, data);
   }
-
-  t.end();
 });
-
-test('ShapefileLoader#loadInBatches passes dbf options to DBFLoader#parseInBatches', async t => {
+test('ShapefileLoader#loadInBatches passes dbf options to DBFLoader#parseInBatches', async () => {
   const filename = `${SHAPEFILE_JS_DATA_FOLDER}/points.shp`;
   const dbfWorkerUrl = 'custom.dbf.worker.js';
   const originalParseInBatches = DBFLoader.parseInBatches;
   let receivedOptions = null;
-
   DBFLoader.parseInBatches = (arrayBufferIterator, options) => {
     receivedOptions = options;
     return originalParseInBatches(arrayBufferIterator, options);
   };
-
   try {
     const batches = await loadInBatches(filename, ShapefileLoader, {
       shapefile: {shape: 'v3'},
@@ -230,19 +196,14 @@ test('ShapefileLoader#loadInBatches passes dbf options to DBFLoader#parseInBatch
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const _ = batch;
     }
-    t.equal(
-      receivedOptions?.dbf?.workerUrl,
-      dbfWorkerUrl,
-      'ShapefileLoader forwards dbf options in batches'
+    expect(receivedOptions?.dbf?.workerUrl, 'ShapefileLoader forwards dbf options in batches').toBe(
+      dbfWorkerUrl
     );
   } finally {
     DBFLoader.parseInBatches = originalParseInBatches;
   }
-
-  t.end();
 });
-
-test('ShapefileLoader#loadInBatches when options.metadata: true', async t => {
+test('ShapefileLoader#loadInBatches when options.metadata: true', async () => {
   const testFileName = Object.keys(SHAPEFILE_JS_TEST_FILES)[0];
   const filename = `${SHAPEFILE_JS_DATA_FOLDER}/${testFileName}.shp`;
   const batches = await loadInBatches(filename, ShapefileLoader, {
@@ -252,13 +213,9 @@ test('ShapefileLoader#loadInBatches when options.metadata: true', async t => {
   let data;
   for await (const batch of batches) {
     data = batch;
-    // t.comment(`${filename}: ${JSON.stringify(data).slice(0, 70)}`);
   }
-  await testShapefileData(t, testFileName, data);
-
-  t.end();
+  await testShapefileData(testFileName, data);
 });
-
 async function getFileList(testFileName) {
   const EXTENSIONS = ['.shp', '.shx', '.dbf', '.cpg', '.prj'];
   const fileList = [];
@@ -272,8 +229,7 @@ async function getFileList(testFileName) {
   }
   return fileList;
 }
-
-async function testShapefileData(t, testFileName, data) {
+async function testShapefileData(testFileName, data) {
   // Exceptions for files that don't currently pass tests
   // TODO @kylebarron to fix
   const EXCEPTIONS = [
@@ -288,18 +244,14 @@ async function testShapefileData(t, testFileName, data) {
   if (EXCEPTIONS.some(exception => testFileName.includes(exception))) {
     return;
   }
-
   // Compare with parsed json
-
   const response = await fetchFile(`${SHAPEFILE_JS_DATA_FOLDER}/${testFileName}.json`);
   const json = await response.json();
-
   if (!data?.data) {
-    t.comment(`Skipping ${testFileName}: no parsed shapefile batch data`);
+    console.log(`Skipping ${testFileName}: no parsed shapefile batch data`);
     return;
   }
-
   for (let i = 0; i < json.features.length; i++) {
-    t.deepEqual(data.data[i], json.features[i]);
+    expect(data.data[i]).toEqual(json.features[i]);
   }
 }

--- a/modules/shapefile/test/shp-loader.spec.ts
+++ b/modules/shapefile/test/shp-loader.spec.ts
@@ -2,133 +2,100 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {setLoaderOptions, load, fetchFile} from '@loaders.gl/core';
 import {convertWKBToGeometry} from '@loaders.gl/gis';
 import {SHPLoader} from '@loaders.gl/shapefile';
-
 const SHAPEFILE_POLYGON_PATH = '@loaders.gl/shapefile/test/data/shapefile-js/polygons.shp';
 const SHAPEFILE_JS_DATA_FOLDER = '@loaders.gl/shapefile/test/data/shapefile-js';
 const SHAPEFILE_JS_POINT_TEST_FILES = ['points', 'multipoints'];
 const SHAPEFILE_JS_POLYLINE_TEST_FILES = ['polylines'];
 const SHAPEFILE_JS_POLYGON_TEST_FILES = ['polygons', 'multipolygon_with_holes'];
 const POINT_Z_TEST_FILE = 'point-z';
-
 setLoaderOptions({
   _workerType: 'test'
 });
-
 const WKB_OPTIONS = {shp: {shape: 'wkb' as const}};
-
-test('SHPLoader#load polygons', async t => {
+test('SHPLoader#load polygons', async () => {
   const result = await load(SHAPEFILE_POLYGON_PATH, SHPLoader, WKB_OPTIONS);
-
-  t.ok(result.header, 'A header received');
-  t.equal(result.geometries.length, 3, 'Correct number of rows received');
-  t.end();
+  expect(result.header, 'A header received').toBeTruthy();
+  expect(result.geometries.length, 'Correct number of rows received').toBe(3);
 });
-
-test('Shapefile JS Point tests', async t => {
+test('Shapefile JS Point tests', async () => {
   for (const testFileName of SHAPEFILE_JS_POINT_TEST_FILES) {
     const output = await load(
       `${SHAPEFILE_JS_DATA_FOLDER}/${testFileName}.shp`,
       SHPLoader,
       WKB_OPTIONS
     );
-
     const response = await fetchFile(`${SHAPEFILE_JS_DATA_FOLDER}/${testFileName}.json`);
     const json = await response.json();
-
     for (let i = 0; i < json.features.length; i++) {
-      t.deepEqual(
+      expect(
         convertWKBToGeometry(toArrayBuffer(output.geometries[i])),
-        json.features[i].geometry,
         `${testFileName}: point geometry matches`
-      );
+      ).toEqual(json.features[i].geometry);
     }
   }
-
-  t.end();
 });
-
-test('SHPLoader#Null Shape records in typed shapefile', async t => {
+test('SHPLoader#Null Shape records in typed shapefile', async () => {
   const output = await load(`${SHAPEFILE_JS_DATA_FOLDER}/null.shp`, SHPLoader, WKB_OPTIONS);
-
-  t.equal(output.header.type, 1, 'fixture is a Point shapefile');
-  t.equal(output.geometries.length, 9, 'all records are preserved');
-  t.equal(output.geometries.filter(Boolean).length, 5, 'non-null point records are parsed');
-  t.equal(
+  expect(output.header.type, 'fixture is a Point shapefile').toBe(1);
+  expect(output.geometries.length, 'all records are preserved').toBe(9);
+  expect(output.geometries.filter(Boolean).length, 'non-null point records are parsed').toBe(5);
+  expect(
     output.geometries.filter(geometry => geometry === null).length,
-    4,
     'null records are parsed'
-  );
-  t.end();
+  ).toBe(4);
 });
-
-test('Shapefile JS Polyline tests', async t => {
+test('Shapefile JS Polyline tests', async () => {
   for (const testFileName of SHAPEFILE_JS_POLYLINE_TEST_FILES) {
     const output = await load(
       `${SHAPEFILE_JS_DATA_FOLDER}/${testFileName}.shp`,
       SHPLoader,
       WKB_OPTIONS
     );
-
     const response = await fetchFile(`${SHAPEFILE_JS_DATA_FOLDER}/${testFileName}.json`);
     const json = await response.json();
-
     for (let i = 0; i < json.features.length; i++) {
-      t.deepEqual(
+      expect(
         convertWKBToGeometry(toArrayBuffer(output.geometries[i])),
-        json.features[i].geometry,
         `${testFileName}: line geometry matches`
-      );
+      ).toEqual(json.features[i].geometry);
     }
   }
-
-  t.end();
 });
-
-test('Shapefile JS Polygon tests', async t => {
+test('Shapefile JS Polygon tests', async () => {
   for (const testFileName of SHAPEFILE_JS_POLYGON_TEST_FILES) {
     const output = await load(
       `${SHAPEFILE_JS_DATA_FOLDER}/${testFileName}.shp`,
       SHPLoader,
       WKB_OPTIONS
     );
-
     const response = await fetchFile(`${SHAPEFILE_JS_DATA_FOLDER}/${testFileName}.json`);
     const json = await response.json();
-
     for (let i = 0; i < json.features.length; i++) {
-      t.deepEqual(
+      expect(
         convertWKBToGeometry(toArrayBuffer(output.geometries[i])),
-        json.features[i].geometry,
         `${testFileName}: polygon geometry matches`
-      );
+      ).toEqual(json.features[i].geometry);
     }
   }
-
-  t.end();
 });
-
-test('SHPLoader#_maxDimensions', async t => {
+test('SHPLoader#_maxDimensions', async () => {
   const output2d = await load(`${SHAPEFILE_JS_DATA_FOLDER}/${POINT_Z_TEST_FILE}.shp`, SHPLoader, {
     shp: {_maxDimensions: 2, shape: 'wkb'}
   });
   const geometry2d = convertWKBToGeometry(toArrayBuffer(output2d.geometries[0]));
-  t.equal(geometry2d.coordinates.length, 2);
-
+  expect(geometry2d.coordinates.length).toBe(2);
   const defaultOutput = await load(
     `${SHAPEFILE_JS_DATA_FOLDER}/${POINT_Z_TEST_FILE}.shp`,
     SHPLoader,
     WKB_OPTIONS
   );
   const defaultGeometry = convertWKBToGeometry(toArrayBuffer(defaultOutput.geometries[0]));
-  t.equal(defaultGeometry.coordinates.length, 4);
-
-  t.end();
+  expect(defaultGeometry.coordinates.length).toBe(4);
 });
-
 function toArrayBuffer(wkb: Uint8Array): ArrayBuffer {
   return wkb.buffer.slice(wkb.byteOffset, wkb.byteOffset + wkb.byteLength) as ArrayBuffer;
 }

--- a/modules/shapefile/test/streaming/binary-chunk-reader.spec.ts
+++ b/modules/shapefile/test/streaming/binary-chunk-reader.spec.ts
@@ -2,152 +2,114 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {_BinaryChunkReader as BinaryChunkReader} from '@loaders.gl/shapefile';
-
 const buf1 = new Uint8Array([1, 2, 3]).buffer;
 const buf2 = new Uint8Array([4, 5, 6]).buffer;
 const buf3 = new Uint8Array([7, 8, 9]).buffer;
-
-test('BinaryChunkReader', t => {
+test('BinaryChunkReader', () => {
   const reader = new BinaryChunkReader();
-  t.ok(reader);
-  t.end();
+  expect(reader).toBeTruthy();
 });
-
-test('BinaryChunkReader#add arrayBuffers', t => {
+test('BinaryChunkReader#add arrayBuffers', () => {
   const reader = new BinaryChunkReader();
   reader.write(buf1);
   reader.write(buf2);
-  t.equals(reader.arrayBuffers.length, 2);
-  t.end();
+  expect(reader.arrayBuffers.length).toBe(2);
 });
-
-test('BinaryChunkReader#findBufferOffsets single view', t => {
+test('BinaryChunkReader#findBufferOffsets single view', () => {
   const reader = new BinaryChunkReader();
   reader.write(buf1);
   reader.write(buf2);
   reader.write(buf3);
-
   let bufferOffsets = reader.findBufferOffsets(2);
-  t.deepEquals(bufferOffsets, [[0, [0, 2]]]);
-
+  expect(bufferOffsets).toEqual([[0, [0, 2]]]);
   reader.skip(1);
   bufferOffsets = reader.findBufferOffsets(2);
-  t.deepEquals(bufferOffsets, [[0, [1, 3]]]);
-
+  expect(bufferOffsets).toEqual([[0, [1, 3]]]);
   reader.skip(2);
   bufferOffsets = reader.findBufferOffsets(2);
-  t.deepEquals(bufferOffsets, [[1, [0, 2]]]);
-
+  expect(bufferOffsets).toEqual([[1, [0, 2]]]);
   reader.skip(3);
   bufferOffsets = reader.findBufferOffsets(1);
-  t.deepEquals(bufferOffsets, [[2, [0, 1]]]);
-
+  expect(bufferOffsets).toEqual([[2, [0, 1]]]);
   bufferOffsets = reader.findBufferOffsets(3);
-  t.deepEquals(bufferOffsets, [[2, [0, 3]]]);
-
-  t.end();
+  expect(bufferOffsets).toEqual([[2, [0, 3]]]);
 });
-
-test('BinaryChunkReader#findBufferOffsets multiple views', t => {
+test('BinaryChunkReader#findBufferOffsets multiple views', () => {
   const reader = new BinaryChunkReader();
   reader.write(buf1);
   reader.write(buf2);
   reader.write(buf3);
-
   let bufferOffsets = reader.findBufferOffsets(5);
-  t.deepEquals(bufferOffsets, [
+  expect(bufferOffsets).toEqual([
     [0, [0, 3]],
     [1, [0, 2]]
   ]);
-
   reader.skip(2);
   bufferOffsets = reader.findBufferOffsets(5);
-  t.deepEquals(bufferOffsets, [
+  expect(bufferOffsets).toEqual([
     [0, [2, 3]],
     [1, [0, 3]],
     [2, [0, 1]]
   ]);
-
   bufferOffsets = reader.findBufferOffsets(2);
-  t.deepEquals(bufferOffsets, [
+  expect(bufferOffsets).toEqual([
     [0, [2, 3]],
     [1, [0, 1]]
   ]);
-  t.end();
 });
-
-test('BinaryChunkReader#getDataView single source array', t => {
+test('BinaryChunkReader#getDataView single source array', () => {
   const reader = new BinaryChunkReader();
   reader.write(buf1);
   reader.write(buf2);
   reader.write(buf3);
-
   let view = reader.getDataView(2);
-  t.equals(view?.getUint8(0), 1);
-  t.equals(view?.getUint8(1), 2);
-
+  expect(view?.getUint8(0)).toBe(1);
+  expect(view?.getUint8(1)).toBe(2);
   reader.skip(2);
   view = reader.getDataView(2);
-  t.equals(view?.getUint8(0), 5);
-  t.equals(view?.getUint8(1), 6);
-  t.end();
+  expect(view?.getUint8(0)).toBe(5);
+  expect(view?.getUint8(1)).toBe(6);
 });
-
-test('BinaryChunkReader#getDataView multiple source arrays', t => {
+test('BinaryChunkReader#getDataView multiple source arrays', () => {
   const reader = new BinaryChunkReader();
   reader.write(buf1);
   reader.write(buf2);
   reader.write(buf3);
-
   reader.skip(2);
   let view = reader.getDataView(2);
-  t.equals(view?.getUint8(0), 3);
-  t.equals(view?.getUint8(1), 4);
-
+  expect(view?.getUint8(0)).toBe(3);
+  expect(view?.getUint8(1)).toBe(4);
   view = reader.getDataView(4);
-  t.equals(view?.getUint8(0), 5);
-  t.equals(view?.getUint8(1), 6);
-  t.equals(view?.getUint8(2), 7);
-  t.equals(view?.getUint8(3), 8);
-  t.end();
+  expect(view?.getUint8(0)).toBe(5);
+  expect(view?.getUint8(1)).toBe(6);
+  expect(view?.getUint8(2)).toBe(7);
+  expect(view?.getUint8(3)).toBe(8);
 });
-
-test('BinaryChunkReader#disposeBuffers', t => {
+test('BinaryChunkReader#disposeBuffers', () => {
   const reader = new BinaryChunkReader();
   reader.write(buf1);
   reader.write(buf2);
   reader.write(buf3);
-
   reader.skip(2);
-  t.equals(reader.arrayBuffers.length, 3);
-
+  expect(reader.arrayBuffers.length).toBe(3);
   reader.getDataView(1);
-  t.equals(reader.arrayBuffers.length, 2);
-
+  expect(reader.arrayBuffers.length).toBe(2);
   reader.getDataView(3);
-  t.equals(reader.arrayBuffers.length, 1);
-
+  expect(reader.arrayBuffers.length).toBe(1);
   reader.getDataView(3);
-  t.equals(reader.arrayBuffers.length, 0);
-  t.end();
+  expect(reader.arrayBuffers.length).toBe(0);
 });
-
-test('BinaryChunkReader#disposeBuffers with maxRewindBytes', t => {
+test('BinaryChunkReader#disposeBuffers with maxRewindBytes', () => {
   const reader = new BinaryChunkReader({maxRewindBytes: 2});
   reader.write(buf1);
   reader.write(buf2);
   reader.write(buf3);
-
   reader.skip(2);
-  t.equals(reader.arrayBuffers.length, 3);
-
+  expect(reader.arrayBuffers.length).toBe(3);
   reader.getDataView(2);
-  t.equals(reader.arrayBuffers.length, 3);
-
+  expect(reader.arrayBuffers.length).toBe(3);
   reader.getDataView(1);
-  t.equals(reader.arrayBuffers.length, 2);
-
-  t.end();
+  expect(reader.arrayBuffers.length).toBe(2);
 });

--- a/modules/shapefile/test/streaming/zip-batch-iterators.spec.ts
+++ b/modules/shapefile/test/streaming/zip-batch-iterators.spec.ts
@@ -2,12 +2,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import type {ObjectRowTableBatch, ArrayRowTableBatch} from '@loaders.gl/schema';
 import {_zipBatchIterators as zipBatchIterators} from '@loaders.gl/shapefile';
-
 type RowTableBatch = ObjectRowTableBatch | ArrayRowTableBatch;
-
 type TestCase = {
   title: string;
   iterator1: Iterator<RowTableBatch>;
@@ -15,7 +13,6 @@ type TestCase = {
   shape: 'object-row-table' | 'array-row-table';
   result: RowTableBatch[];
 };
-
 const TEST_CASES: TestCase[] = [
   {
     title: 'empty iterators',
@@ -26,15 +23,13 @@ const TEST_CASES: TestCase[] = [
   }
   // TODO - add some non-trivial cases
 ];
-
-test('zipBatchIterators', async t => {
+test('zipBatchIterators', async () => {
   for (const tc of TEST_CASES) {
     const zippedIterator = zipBatchIterators(tc.iterator1, tc.iterator2, tc.shape);
     const batches: RowTableBatch[] = [];
     for await (const batch of zippedIterator) {
       batches.push(batch);
     }
-    t.deepEquals(batches, tc.result, tc.title);
+    expect(batches, tc.title).toEqual(tc.result);
   }
-  t.end();
 });


### PR DESCRIPTION
## Goals

- Migrate the remaining shapefile Tape-backed suites to native Vitest.
- Improve executable coverage for the shapefile loader, DBF/SHP paths, and streaming helpers.
- Keep the existing large fixture matrix in its designated slow lane.

## Changes

- Migrated seven shapefile test suites from the Tape compatibility helper to native Vitest.
- Replaced Tape assertions and comments with Vitest expectations.
- Preserved the slow shapefile fixture suite as a slow test.
- Removed all active Tape compatibility imports from the migrated suites.
- No production code or coverage thresholds changed.

## Validation

- `yarn build`
- `yarn build-workers`
- `yarn lint fix`
- `yarn test-audit` (597 files, 0 Tape, 0 violations)
- Focused headless tests: 25 passed
- Focused slow tests: 9 passed
- Focused browser and slow coverage collection completed successfully