### PR TITLE
feat(scan): complete point-cloud and NetCDF execution

### DIFF
--- a/docs/developer-guide/common-scan-architecture.md
+++ b/docs/developer-guide/common-scan-architecture.md
@@ -38,8 +38,8 @@ This is the end-user view of the architecture. The statuses are deliberately con
 | GeoTIFF / COG | Supported | `getRaster()` | Bounds and overview selection, bands, typed output, and validated raster queries. |
 | OME-TIFF | Supported | `getRaster()` | Multiscale levels, channels, slices, typed output, and validated raster queries. |
 | GeoZarr / OME-Zarr | Supported | `getRaster()` | Chunk-aligned bounds, channels or variables, multiscale levels, slices, and typed output. |
-| COPC / Potree | Metadata only | — | Schema, coordinate roles, hierarchy bounds, levels, and spacing are discoverable; use the existing tile APIs for point data. |
-| NetCDF | Metadata only | — | Variables, dimensions, attributes, and file statistics are discoverable; common variable and dimension-slice reads are not implemented. |
+| COPC / Potree | Supported | `scan()` | Ordered hierarchy traversal, bounds and level-of-detail pruning, residual attribute predicates, caller-ordered projection, global limits, cancellation, and Arrow point batches. |
+| NetCDF | Supported | `getRaster()` | Numeric variable selection, named half-open dimension slices, typed output, cancellation, and validated raster queries. |
 | Lance / Shapefile / MLT / LAS / LAZ / PLY / PCD | Not implemented | — | Their existing loaders or specialized sources do not expose the common scan contract. |
 | DuckDB / Snowflake SQL | Supported | `query()` | Compiles the portable table query to bound SQL; this is a backend rather than a file-format adapter. |
 | MVT / PMTiles / 3D Tiles / I3S | Outside protocol | — | Use tile and tileset source APIs; tile addressing and level-of-detail remain outside `TableQuery`. |
@@ -738,15 +738,15 @@ The roadmap is therefore format-support-first. Each tranche must ship three thin
    snapshots expose common execution. Delta replays versioned transaction logs and plans active
    Parquet fragments; checkpoint discovery, CDC, deletion-vector decoding, and writes remain
    separate format features. Lance is explicitly not implemented.
-5. **Point-cloud execution — open and unambiguous.** COPC and Potree expose query metadata but not a
-   common executor, so they are `metadata-only` with a reason and the panel cannot submit a scan.
-   Completing this tranche requires bounded Arrow point batches with ordered hierarchy traversal,
-   exact bounds and residual predicates, and a global limit. LAS/LAZ, PLY, PCD, and splats have no
-   common adapter.
-6. **Existing raster adapters — concluded; NetCDF execution remains open.** GeoTIFF/COG, OME-TIFF,
-   GeoZarr, and OME-Zarr execute validated raster queries through `getRaster()`. NetCDF is
-   `metadata-only` until variable and dimension-slice reads exist. Terrain and LERC have no common
-   adapter.
+5. **Point-cloud execution — concluded.** COPC and Potree execute the shared point-cloud query through
+   `scan()`. A common breadth-first hierarchy planner applies bounds, levels, and target spacing;
+   adapters then apply exact bounds, residual predicates, caller-ordered projection, and one global
+   limit while emitting bounded Arrow point batches. LAS/LAZ, PLY, PCD, and splats remain explicitly
+   not implemented rather than partially supported.
+6. **Existing raster adapters — concluded.** GeoTIFF/COG, OME-TIFF, GeoZarr, OME-Zarr, and NetCDF
+   execute validated raster queries through `getRaster()`. NetCDF supports numeric variable reads
+   and named dimension index or half-open range slices with typed output. Terrain and LERC remain
+   explicitly not implemented.
 7. **Tiles and services bridge.** Keep MVT, PMTiles, 3D Tiles, I3S, WMS, WFS, and STAC specialized,
    but expose shared discovery, bounds, time, level-of-detail, explain, and cancellation metadata.
    Where a source returns feature tables (for example MVT or WFS), offer an explicit table-scan view;
@@ -776,11 +776,11 @@ and “Outside protocol” have the exact meanings defined at the top of this pa
 | ORC | Supported | `read()` | Materialized residual table query | Stripe and row-index pruning |
 | GeoPackage | Supported | `read()` | Materialized residual feature-table query | SQL and spatial-index pushdown |
 | Shapefile / MLT / Lance | Not implemented | — | No common scan claims | Add adapters only when end-to-end execution is available |
-| COPC / Potree | Metadata only | — | Schema and hierarchy discovery | Common ordered point-batch executor |
+| COPC / Potree | Supported | `scan()` | Ordered hierarchy selection, exact bounds, residual predicates, projection, global limit, cancellation, and Arrow batches | Finer decoder projection and hierarchy telemetry |
 | LAS / LAZ / PLY / PCD / splats | Not implemented | — | No common scan claims | Decide which formats justify sequential adapters |
 | GeoTIFF / COG / OME-TIFF | Supported | `getRaster()` | Windows, bands/channels, levels, typed output | More chunk telemetry and pushdown |
 | GeoZarr / OME-Zarr | Supported | `getRaster()` | Chunk-aligned windows, channels, levels, slices | More variable and dimension UI |
-| NetCDF | Metadata only | — | Variable and dimension discovery | Variable and dimension-slice executor |
+| NetCDF | Supported | `getRaster()` | Numeric variables, named dimension index/range slices, typed output, and cancellation | Range reads, chunk pruning, and broader NetCDF variants |
 | Terrain / LERC | Not implemented | — | No common scan claims | Raster adapter design |
 | MVT / PMTiles / 3D Tiles / I3S | Outside protocol | — | Specialized tile APIs | Optional explicit feature-table views |
 | WMS / WFS / STAC | Outside protocol | — | Specialized service and catalog APIs | Shared discovery metadata where useful |
@@ -850,8 +850,10 @@ to emit its own limit.
 non-finite or inverted bounds, invalid hierarchy levels, and non-positive spacing. A point-cloud
 adapter advertises table capabilities plus `bounds`, `levelOfDetail`, and `spacing` support.
 
-COPC is the first physical target because its hierarchy pages, node bounds, point counts, and LAZ
-chunks create a clean pruning ladder:
+COPC and Potree implement the same deterministic breadth-first hierarchy planner. Bounds prune
+whole subtrees, `minimumLevel` suppresses coarse payloads while preserving traversal,
+`maximumLevel` stops descent, and `targetSpacing` selects the first acceptable resolution. Their
+hierarchy pages, node bounds, point counts, and encoded chunks create a clean pruning ladder:
 
 ```text
 PointCloudQueryOptions
@@ -865,12 +867,12 @@ PointCloudQueryOptions
     -> Arrow or GeoArrow point batches
 ```
 
-Potree can reuse the logical query, metadata roles, hierarchy selection interface, scan executor,
-and result batches. Its physical adapter remains separate because Potree versions differ in
-metadata, hierarchy storage, point encoding, and URL layout. Initial Potree support can conservatively
-advertise bounds and level selection as pushdown while keeping scalar attribute predicates residual.
+The physical adapters remain separate because COPC and Potree differ in metadata, hierarchy
+storage, point encoding, and URL layout. Both conservatively advertise hierarchy bounds, level, and
+spacing selection as pushdown while keeping scalar attribute predicates and final point bounds
+residual. COPC minimizes requested LAZ attributes; Potree currently decodes complete point records.
 
-Both adapters should expose `x`, `y`, and `z` roles even when their native attribute names use LAS
+Both adapters expose `x`, `y`, and `z` roles even when their native attribute names use LAS
 conventions such as `X`, `Y`, and `Z`. Intensity, classification, color, GPS time, and point-source
 identifier roles allow the same query panel to render useful typed controls without embedding COPC
 or Potree naming rules in UI code.
@@ -933,6 +935,12 @@ GeoTIFF contributes internal tile offsets, overview selection, and COG byte rang
 OME-Zarr contribute array metadata, chunk coordinates, multiscale levels, dimension labels, and
 codec pipelines. Both can lower to the same `ScanTask` executor while preserving their natural
 typed-array result forms.
+
+NetCDF selects numeric variables and applies slices by discovered dimension name. A numeric slice
+selects one index and removes that dimension; a tuple uses half-open `[start, stop)` semantics and
+retains it. The current classic-file executor materializes the source before slicing, so slicing is
+reported as residual even though the result is fully supported. Range reads and chunk pruning are
+future physical optimizations, not prerequisites for the common `getRaster()` contract.
 
 Cross-domain operations belong above the physical scan layer. For example, sampling a raster at
 Arrow point coordinates or joining a raster window with vector features may coordinate a

--- a/modules/copc/README.md
+++ b/modules/copc/README.md
@@ -2,6 +2,9 @@
 
 [loaders.gl](https://loaders.gl/docs) is a collection of framework-independent 3D and geospatial parsers and encoders.
 
-This module contains range-based loaders and a writer for the COPC format.
+This module contains range-based loaders, a writer, and a point-cloud scan source for the COPC
+format. `COPCTileSource.scan()` executes portable point-cloud queries with hierarchy bounds and
+level-of-detail pruning, residual predicates, projection, global limits, cancellation, and bounded
+Arrow batches.
 
 For documentation please visit the [website](https://loaders.gl).

--- a/modules/copc/src/copc-source-loader.ts
+++ b/modules/copc/src/copc-source-loader.ts
@@ -1629,6 +1629,15 @@ const COPC_SCAN_COLUMN_MAP: Readonly<Record<string, COPCPointColumn>> = Object.f
   Infrared: 'NIR'
 });
 
+const COPC_BOOLEAN_COLUMN_NAMES = new Set([
+  'ScanDirectionFlag',
+  'EdgeOfFlightLine',
+  'Synthetic',
+  'KeyPoint',
+  'Withheld',
+  'Overlap'
+]);
+
 /** Maps query-visible COPC fields to the smallest decoder attribute set. */
 function getCOPCDecoderColumns(columnNames: readonly string[], schema: Schema): COPCPointColumn[] {
   const standardColumnNames = new Set(Object.keys(COPC_SCAN_COLUMN_MAP));
@@ -1664,6 +1673,9 @@ function getCOPCScanValue(
   const value = normalizeArrowValue(
     data.data.getChild(decoderColumn || columnName)?.get(pointIndex)
   );
+  if (COPC_BOOLEAN_COLUMN_NAMES.has(columnName) && typeof value === 'number') {
+    return value !== 0;
+  }
   return columnName === 'ScanAngle' && typeof value === 'number' ? value * 0.006 : value;
 }
 

--- a/modules/copc/src/copc-source-loader.ts
+++ b/modules/copc/src/copc-source-loader.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {Schema, Field, Mesh, MeshArrowTable} from '@loaders.gl/schema';
-import {convertMeshToTable} from '@loaders.gl/schema-utils';
+import type {Schema, Field, Mesh, MeshArrowTable, ArrowTableBatch} from '@loaders.gl/schema';
+import {ArrowTableBuilder, convertMeshToTable} from '@loaders.gl/schema-utils';
 import type {
   CoreAPI,
   SourceLoader,
@@ -23,8 +23,15 @@ import {
   HttpFile,
   isBrowser,
   NodeFile,
+  filterColumnarRowIndices,
+  getColumnarPredicateColumns,
   parseWithWorker,
   RangeRequestCache,
+  selectPointCloudScanTiles,
+  validatePointCloudQueryOptions,
+  type PointCloudScanReadOptions,
+  type PointCloudScanSource,
+  type PointCloudScanTile,
   type ReadableFile
 } from '@loaders.gl/loader-utils';
 import {createScanQueryMetadata, type PointCloudQueryCapabilities} from '@loaders.gl/loader-utils';
@@ -272,7 +279,7 @@ export const COPCSourceLoader = {
  */
 export class COPCTileSource
   extends DataSource<string | Blob, COPCSourceLoaderOptions>
-  implements TileSource
+  implements TileSource, PointCloudScanSource<ArrowTableBatch>
 {
   /** Common point-cloud scan capabilities exposed by COPC. */
   readonly pointCloudQueryCapabilities: PointCloudQueryCapabilities = Object.freeze({
@@ -343,10 +350,7 @@ export class COPCTileSource
     return createScanQueryMetadata({
       sourceType: 'copc',
       queryType: 'point-cloud',
-      execution: {
-        status: 'metadata-only',
-        reason: 'Common point-cloud scan traversal is not implemented; use the COPC tile APIs.'
-      },
+      execution: {status: 'supported', method: 'scan'},
       schema,
       capabilities: {
         table: this.pointCloudQueryCapabilities,
@@ -364,6 +368,123 @@ export class COPCTileSource
       },
       statistics: {rowCount: copc.header.pointCount}
     });
+  }
+
+  /**
+   * Scans selected COPC hierarchy nodes as ordered Arrow point batches.
+   *
+   * Hierarchy bounds, levels, spacing, and requested decoder attributes are pushed down. Exact
+   * point bounds and portable attribute predicates are evaluated before the global point limit.
+   */
+  async *scan(options: PointCloudScanReadOptions = {}): AsyncIterableIterator<ArrowTableBatch> {
+    const {copc} = await this._initPromise;
+    const schema = getCOPCHeaderSchema(copc);
+    const sourceColumnNames = schema.fields.map(field => field.name);
+    validatePointCloudQueryOptions(sourceColumnNames, options);
+    const batchSize = validatePointCloudScanBatchSize(options.batchSize);
+    if (options.limit === 0) return;
+
+    const outputColumnNames = options.columns ? [...options.columns] : sourceColumnNames;
+    const predicateColumnNames = options.predicate
+      ? getColumnarPredicateColumns(options.predicate)
+      : [];
+    const requiredColumnNames = new Set([...outputColumnNames, ...predicateColumnNames]);
+    requiredColumnNames.add('X');
+    if (options.bounds) {
+      requiredColumnNames.add('X');
+      requiredColumnNames.add('Y');
+      requiredColumnNames.add('Z');
+    }
+    const outputSchema: Schema = {
+      fields: outputColumnNames.map(
+        columnName => schema.fields.find(field => field.name === columnName)!
+      ),
+      metadata: schema.metadata
+    };
+    const decoderColumns = getCOPCDecoderColumns([...requiredColumnNames], schema);
+    const rootTile = this.getCOPCScanTile(await this.getRootTile());
+    let remainingPointCount = options.limit ?? Number.POSITIVE_INFINITY;
+
+    for await (const tile of selectPointCloudScanTiles(
+      rootTile,
+      async parent => (await this.getChildren(parent)).map(child => this.getCOPCScanTile(child)),
+      options
+    )) {
+      for await (const content of this.loadTileContentInBatches(
+        {id: tile.id},
+        {batchSize, signal: options.signal, columns: decoderColumns}
+      )) {
+        throwIfCOPCLoadAborted(options.signal);
+        const columns = this.getCOPCScanColumns(content, [...requiredColumnNames], options.bounds);
+        const rowCount = columns.X.length;
+        const matchingRowIndices = filterColumnarRowIndices(
+          options.predicate,
+          columns,
+          rowCount
+        ).slice(0, remainingPointCount);
+        if (matchingRowIndices.length === 0) continue;
+
+        const builder = new ArrowTableBuilder(outputSchema);
+        for (const rowIndex of matchingRowIndices) {
+          builder.addArrayRow(outputColumnNames.map(columnName => columns[columnName][rowIndex]));
+        }
+        const batch = builder.finishBatch();
+        if (batch) yield batch;
+        remainingPointCount -= matchingRowIndices.length;
+        if (remainingPointCount === 0) return;
+      }
+    }
+  }
+
+  /** Converts a normalized COPC tile header to the source-coordinate planner shape. */
+  protected getCOPCScanTile(tile: {
+    id: string;
+    level: number;
+    pointCount: number;
+    geometricError: number;
+  }): PointCloudScanTile {
+    const [minimum, maximum] = this.getNativeTileBounds(tile.id);
+    return {
+      id: tile.id,
+      level: tile.level,
+      pointCount: tile.pointCount,
+      geometricError: tile.geometricError,
+      bounds: {
+        minimum: [minimum[0], minimum[1], minimum[2]],
+        maximum: [maximum[0], maximum[1], maximum[2]]
+      }
+    };
+  }
+
+  /** Extracts query-visible source-coordinate columns from one decoded COPC batch. */
+  protected getCOPCScanColumns(
+    content: COPCTileContent,
+    columnNames: readonly string[],
+    bounds?: PointCloudScanReadOptions['bounds']
+  ): Record<string, unknown[]> {
+    const columns = Object.fromEntries(
+      columnNames.map(columnName => [columnName, [] as unknown[]])
+    );
+    const positionVector = content.data.data.getChild('POSITION');
+    for (let pointIndex = 0; pointIndex < content.pointCount; pointIndex++) {
+      const offsetPosition = readArrowListValue(positionVector?.get(pointIndex));
+      const projectedPosition = [
+        Number(offsetPosition[0]) + content.cartographicOrigin[0],
+        Number(offsetPosition[1]) + content.cartographicOrigin[1],
+        Number(offsetPosition[2]) + content.cartographicOrigin[2]
+      ];
+      const sourcePosition = this._projection
+        ? this._projection.unproject(projectedPosition)
+        : projectedPosition;
+      if (bounds && !isPointInsideBounds(sourcePosition, bounds)) continue;
+
+      for (const columnName of columnNames) {
+        columns[columnName].push(
+          getCOPCScanValue(content.data, columnName, pointIndex, sourcePosition)
+        );
+      }
+    }
+    return columns;
   }
 
   async getMetadata(): Promise<COPCMetadata> {
@@ -1481,6 +1602,106 @@ export class COPCTileSource
     }
   }
   */
+}
+
+const COPC_SCAN_COLUMN_MAP: Readonly<Record<string, COPCPointColumn>> = Object.freeze({
+  X: 'POSITION',
+  Y: 'POSITION',
+  Z: 'POSITION',
+  Intensity: 'intensity',
+  ReturnNumber: 'returnNumber',
+  NumberOfReturns: 'numberOfReturns',
+  ScanDirectionFlag: 'scanDirectionFlag',
+  EdgeOfFlightLine: 'edgeOfFlightLine',
+  Classification: 'classification',
+  Synthetic: 'synthetic',
+  KeyPoint: 'keyPoint',
+  Withheld: 'withheld',
+  Overlap: 'overlap',
+  ScannerChannel: 'scannerChannel',
+  ScanAngle: 'scanAngle',
+  UserData: 'userData',
+  PointSourceId: 'pointSourceId',
+  GpsTime: 'GPS_TIME',
+  Red: 'COLOR_0',
+  Green: 'COLOR_0',
+  Blue: 'COLOR_0',
+  Infrared: 'NIR'
+});
+
+/** Maps query-visible COPC fields to the smallest decoder attribute set. */
+function getCOPCDecoderColumns(columnNames: readonly string[], schema: Schema): COPCPointColumn[] {
+  const standardColumnNames = new Set(Object.keys(COPC_SCAN_COLUMN_MAP));
+  const schemaColumnNames = new Set(schema.fields.map(field => field.name));
+  const decoderColumns = new Set<COPCPointColumn>(['POSITION']);
+  for (const columnName of columnNames) {
+    const decoderColumn = COPC_SCAN_COLUMN_MAP[columnName];
+    if (decoderColumn) {
+      decoderColumns.add(decoderColumn);
+    } else if (schemaColumnNames.has(columnName) && !standardColumnNames.has(columnName)) {
+      decoderColumns.add('EXTRA_BYTES');
+    }
+  }
+  return [...decoderColumns];
+}
+
+/** Reads one query-visible COPC value from decoded Arrow attributes. */
+function getCOPCScanValue(
+  data: MeshArrowTable,
+  columnName: string,
+  pointIndex: number,
+  sourcePosition: readonly number[]
+): unknown {
+  if (columnName === 'X') return sourcePosition[0];
+  if (columnName === 'Y') return sourcePosition[1];
+  if (columnName === 'Z') return sourcePosition[2];
+
+  if (columnName === 'Red' || columnName === 'Green' || columnName === 'Blue') {
+    const color = readArrowListValue(data.data.getChild('COLOR_0')?.get(pointIndex));
+    return color[columnName === 'Red' ? 0 : columnName === 'Green' ? 1 : 2];
+  }
+  const decoderColumn = COPC_SCAN_COLUMN_MAP[columnName];
+  const value = normalizeArrowValue(
+    data.data.getChild(decoderColumn || columnName)?.get(pointIndex)
+  );
+  return columnName === 'ScanAngle' && typeof value === 'number' ? value * 0.006 : value;
+}
+
+/** Normalizes Arrow scalar and fixed-size-list values for predicate evaluation and builders. */
+function normalizeArrowValue(value: unknown): unknown {
+  if (value && typeof value === 'object' && 'toArray' in value) {
+    return Array.from((value as {toArray(): ArrayLike<unknown>}).toArray());
+  }
+  return value;
+}
+
+/** Reads an Arrow list scalar into ordinary numeric values. */
+function readArrowListValue(value: unknown): unknown[] {
+  const normalizedValue = normalizeArrowValue(value);
+  if (Array.isArray(normalizedValue)) return normalizedValue;
+  if (ArrayBuffer.isView(normalizedValue)) {
+    return Array.from(normalizedValue as unknown as ArrayLike<unknown>);
+  }
+  return [];
+}
+
+/** Returns whether one source-coordinate point lies inside inclusive query bounds. */
+function isPointInsideBounds(
+  point: readonly number[],
+  bounds: NonNullable<PointCloudScanReadOptions['bounds']>
+): boolean {
+  return point.every(
+    (coordinate, dimension) =>
+      coordinate >= bounds.minimum[dimension] && coordinate <= bounds.maximum[dimension]
+  );
+}
+
+/** Validates and returns the requested point batch size. */
+function validatePointCloudScanBatchSize(batchSize = 65536): number {
+  if (!Number.isSafeInteger(batchSize) || batchSize < 1) {
+    throw new Error('Point cloud scan batchSize must be a positive safe integer.');
+  }
+  return batchSize;
 }
 
 /** Builds the query schema from COPC point-data and Extra Bytes metadata. */

--- a/modules/copc/test/copc-source.spec.ts
+++ b/modules/copc/test/copc-source.spec.ts
@@ -101,6 +101,26 @@ test('COPCSourceLoader#scans bounded projected Arrow point batches with a global
   await source.close();
 });
 
+test('COPCSourceLoader#normalizes boolean predicates and preserves empty projections', async () => {
+  const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {
+    core: {loadOptions: {core: {worker: false}}}
+  });
+  const batches = [];
+
+  for await (const batch of source.scan({
+    columns: [],
+    predicate: {op: '=', args: [{property: 'Synthetic'}, false]},
+    maximumLevel: 0,
+    limit: 2
+  })) {
+    batches.push(batch);
+  }
+
+  expect(batches.map(batch => batch.length)).toEqual([2]);
+  expect(batches[0].data.numCols).toBe(0);
+  await source.close();
+});
+
 test('COPCSourceLoader#validates scan batch size and cancellation', async () => {
   const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {});
   const invalidScan = source.scan({batchSize: 0});

--- a/modules/copc/test/copc-source.spec.ts
+++ b/modules/copc/test/copc-source.spec.ts
@@ -58,15 +58,58 @@ test('COPCSourceLoader#creates a source through createDataSource', async () => {
   expect(dataSource).toBeInstanceOf(COPCTileSource);
 });
 
-test('COPCSourceLoader#conclusively reports metadata-only common scan support', async () => {
+test('COPCSourceLoader#conclusively reports common scan support', async () => {
   const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {});
   const metadata = await source.getQueryMetadata();
 
   expect(metadata.queryType).toBe('point-cloud');
-  expect(metadata.execution).toEqual({
-    status: 'metadata-only',
-    reason: 'Common point-cloud scan traversal is not implemented; use the COPC tile APIs.'
+  expect(metadata.execution).toEqual({status: 'supported', method: 'scan'});
+  await source.close();
+});
+
+test('COPCSourceLoader#scans bounded projected Arrow point batches with a global limit', async () => {
+  const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {
+    core: {loadOptions: {core: {worker: false}}}
   });
+  const metadata = await source.getQueryMetadata();
+  const bounds = metadata.spatial?.bounds;
+  expect(bounds).toBeTruthy();
+  const batches = [];
+
+  for await (const batch of source.scan({
+    columns: ['X', 'Y', 'Z', 'Intensity'],
+    predicate: {op: '>=', args: [{property: 'Intensity'}, 0]},
+    bounds: {
+      minimum: bounds!.minimum as [number, number, number],
+      maximum: bounds!.maximum as [number, number, number]
+    },
+    maximumLevel: 0,
+    limit: 25,
+    batchSize: 10
+  })) {
+    batches.push(batch);
+  }
+
+  expect(batches.reduce((length, batch) => length + batch.length, 0)).toBe(25);
+  expect(batches.every(batch => batch.length <= 10)).toBe(true);
+  expect(batches[0].schema.fields.map(field => field.name)).toEqual(['X', 'Y', 'Z', 'Intensity']);
+  for (const batch of batches) {
+    for (const columnName of ['X', 'Y', 'Z', 'Intensity']) {
+      expect(batch.data.getChild(columnName)).toBeTruthy();
+    }
+  }
+  await source.close();
+});
+
+test('COPCSourceLoader#validates scan batch size and cancellation', async () => {
+  const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {});
+  const invalidScan = source.scan({batchSize: 0});
+  await expect(invalidScan.next()).rejects.toThrow('batchSize');
+
+  const controller = new AbortController();
+  controller.abort();
+  const cancelledScan = source.scan({signal: controller.signal});
+  await expect(cancelledScan.next()).rejects.toMatchObject({name: 'AbortError'});
   await source.close();
 });
 

--- a/modules/loader-utils/src/index.ts
+++ b/modules/loader-utils/src/index.ts
@@ -293,7 +293,11 @@ export type {
   RelationalQueryOptions
 } from './lib/scan-utils/relational-query';
 export {createScanQueryMetadata} from './lib/scan-utils/scan-query-metadata';
-export {validatePointCloudQueryOptions} from './lib/scan-utils/point-cloud-query';
+export {
+  intersectPointCloudBounds,
+  selectPointCloudScanTiles,
+  validatePointCloudQueryOptions
+} from './lib/scan-utils/point-cloud-query';
 export {
   planTableQuery,
   validateTableQueryLimit,
@@ -313,6 +317,8 @@ export type {
   ScanQueryMetadata,
   ScanQueryMetadataOptions,
   ScanQueryMetadataProvider,
+  PointCloudScanReadOptions,
+  PointCloudScanSource,
   TableScanReadOptions,
   TableScanSource,
   ScanRasterLevel,
@@ -322,7 +328,9 @@ export type {
 export type {
   PointCloudQueryBounds,
   PointCloudQueryCapabilities,
-  PointCloudQueryOptions
+  PointCloudQueryOptions,
+  PointCloudScanChildrenLoader,
+  PointCloudScanTile
 } from './lib/scan-utils/point-cloud-query';
 export type {
   ColumnarComparisonPredicate,

--- a/modules/loader-utils/src/lib/scan-utils/point-cloud-query.ts
+++ b/modules/loader-utils/src/lib/scan-utils/point-cloud-query.ts
@@ -44,6 +44,25 @@ export type PointCloudQueryCapabilities = TableQueryCapabilities &
     spacing: TableQueryOperatorSupport;
   }>;
 
+/** One hierarchy node considered by a portable point-cloud scan planner. */
+export type PointCloudScanTile = Readonly<{
+  /** Stable source-defined node identifier. */
+  id: string;
+  /** Zero-based hierarchy level. */
+  level: number;
+  /** Number of points stored by this node. */
+  pointCount: number;
+  /** Source spacing or geometric error represented by this node. */
+  geometricError: number;
+  /** Three-dimensional node bounds in the source coordinate system. */
+  bounds: PointCloudQueryBounds;
+}>;
+
+/** Loads the direct children of one portable point-cloud scan tile. */
+export type PointCloudScanChildrenLoader<TileT extends PointCloudScanTile = PointCloudScanTile> = (
+  tile: TileT
+) => Promise<readonly TileT[]>;
+
 /** Validates a point-cloud query against the attributes exposed by one source. */
 export function validatePointCloudQueryOptions<
   ValueT,
@@ -69,6 +88,65 @@ export function validatePointCloudQueryOptions<
   }
 }
 
+/**
+ * Selects point-cloud hierarchy nodes in deterministic breadth-first order.
+ *
+ * Bounds reject whole subtrees. Maximum level and target spacing stop descent after the selected
+ * node, while minimum level suppresses coarser node payloads without suppressing their children.
+ */
+export async function* selectPointCloudScanTiles<TileT extends PointCloudScanTile>(
+  rootTile: TileT,
+  loadChildren: PointCloudScanChildrenLoader<TileT>,
+  options: PointCloudQueryOptions = {}
+): AsyncIterableIterator<TileT> {
+  const pendingTiles: TileT[] = [rootTile];
+  const minimumLevel = options.minimumLevel ?? 0;
+
+  while (pendingTiles.length > 0) {
+    throwIfPointCloudScanAborted(options.signal);
+    const tile = pendingTiles.shift()!;
+    if (options.bounds && !intersectPointCloudBounds(tile.bounds, options.bounds)) {
+      continue;
+    }
+
+    const satisfiesMinimumLevel = tile.level >= minimumLevel;
+    if (satisfiesMinimumLevel) {
+      yield tile;
+    }
+
+    const reachedMaximumLevel =
+      options.maximumLevel !== undefined && tile.level >= options.maximumLevel;
+    const reachedTargetSpacing =
+      satisfiesMinimumLevel &&
+      options.targetSpacing !== undefined &&
+      tile.geometricError <= options.targetSpacing;
+    if (reachedMaximumLevel || reachedTargetSpacing) {
+      continue;
+    }
+
+    const children = [...(await loadChildren(tile))].sort((left, right) =>
+      left.id.localeCompare(right.id)
+    );
+    pendingTiles.push(...children);
+  }
+}
+
+/** Returns whether two inclusive point-cloud bounds intersect. */
+export function intersectPointCloudBounds(
+  left: PointCloudQueryBounds,
+  right: PointCloudQueryBounds
+): boolean {
+  for (let dimension = 0; dimension < 3; dimension++) {
+    if (
+      left.maximum[dimension] < right.minimum[dimension] ||
+      left.minimum[dimension] > right.maximum[dimension]
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function validatePointCloudBounds(bounds: PointCloudQueryBounds | undefined): void {
   if (!bounds) {
     return;
@@ -88,5 +166,11 @@ function validatePointCloudBounds(bounds: PointCloudQueryBounds | undefined): vo
 function validateHierarchyLevel(level: number | undefined, name: string): void {
   if (level !== undefined && (!Number.isSafeInteger(level) || level < 0)) {
     throw new Error(`Point cloud query ${name} must be a non-negative safe integer.`);
+  }
+}
+
+function throwIfPointCloudScanAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw new DOMException('The operation was aborted', 'AbortError');
   }
 }

--- a/modules/loader-utils/src/lib/scan-utils/raster-query.ts
+++ b/modules/loader-utils/src/lib/scan-utils/raster-query.ts
@@ -18,7 +18,7 @@ export type RasterQueryOptions = Readonly<{
   variables?: readonly string[];
   /** Numeric channel indices to include in the result. */
   channels?: readonly number[];
-  /** Non-spatial dimension selections, such as time or elevation. */
+  /** Non-spatial dimension indices or half-open `[start, stop)` ranges. */
   slices?: Readonly<Record<string, number | readonly [number, number]>>;
 }>;
 

--- a/modules/loader-utils/src/lib/scan-utils/scan-query-metadata.ts
+++ b/modules/loader-utils/src/lib/scan-utils/scan-query-metadata.ts
@@ -9,6 +9,8 @@ import type {
   TableQueryOperatorSupport,
   TableQueryOptions
 } from './table-query';
+import type {PointCloudQueryOptions} from './point-cloud-query';
+import type {RasterQueryCapabilities} from './raster-query';
 
 /** Semantic role used by query editors to choose appropriate controls for a column. */
 export type ScanColumnRole =
@@ -79,6 +81,8 @@ export type ScanQueryCapabilities = Readonly<{
   bounds?: TableQueryOperatorSupport;
   /** Hierarchy or resolution selection support for point clouds and multiscale rasters. */
   levelOfDetail?: TableQueryOperatorSupport;
+  /** Raster variable, slice, window, streaming, and cancellation support. */
+  raster?: RasterQueryCapabilities;
 }>;
 
 /** Lightweight source statistics obtained without materializing result rows. */
@@ -174,6 +178,19 @@ export type TableScanSource<
 > = ScanQueryMetadataProvider & {
   /** Reads the query result as ordered batches without changing the logical query semantics. */
   read(options?: TableScanReadOptions<PredicateT>): AsyncIterable<BatchT>;
+};
+
+/** Point-cloud scan options with a bound on each emitted Arrow batch. */
+export type PointCloudScanReadOptions = PointCloudQueryOptions &
+  Readonly<{
+    /** Maximum number of retained points in each emitted batch. */
+    batchSize?: number;
+  }>;
+
+/** Shared point-cloud scan contract implemented by hierarchy-backed sources. */
+export type PointCloudScanSource<BatchT = unknown> = ScanQueryMetadataProvider & {
+  /** Reads selected hierarchy nodes as ordered, globally limited point batches. */
+  scan(options?: PointCloudScanReadOptions): AsyncIterable<BatchT>;
 };
 
 /** Inputs used to derive normalized query metadata from a loaders.gl schema. */

--- a/modules/loader-utils/test/lib/scan-utils/point-cloud-query.spec.ts
+++ b/modules/loader-utils/test/lib/scan-utils/point-cloud-query.spec.ts
@@ -3,7 +3,12 @@
 // Copyright (c) vis.gl contributors
 
 import {describe, expect, test} from 'vitest';
-import {validatePointCloudQueryOptions} from '../../../src';
+import {
+  intersectPointCloudBounds,
+  selectPointCloudScanTiles,
+  validatePointCloudQueryOptions,
+  type PointCloudScanTile
+} from '../../../src';
 
 describe('validatePointCloudQueryOptions', () => {
   test('accepts table semantics with spatial and hierarchy constraints', () => {
@@ -29,3 +34,74 @@ describe('validatePointCloudQueryOptions', () => {
     expect(() => validatePointCloudQueryOptions(['X'], options)).toThrow(expectedMessage);
   });
 });
+
+describe('selectPointCloudScanTiles', () => {
+  const tiles: Record<string, PointCloudScanTile & {children: readonly string[]}> = {
+    root: createTile('root', 0, 8, [0, 0, 0], [8, 8, 8], ['b', 'a']),
+    a: createTile('a', 1, 4, [0, 0, 0], [4, 8, 8], ['a1']),
+    b: createTile('b', 1, 4, [4, 0, 0], [8, 8, 8], ['b1']),
+    a1: createTile('a1', 2, 2, [0, 0, 0], [4, 4, 4], []),
+    b1: createTile('b1', 2, 2, [4, 0, 0], [8, 4, 4], [])
+  };
+
+  test('orders nodes, prunes bounds, and stops at target spacing', async () => {
+    const selected: string[] = [];
+    for await (const tile of selectPointCloudScanTiles(
+      tiles.root,
+      async tile => tile.children.map(childId => tiles[childId]),
+      {
+        bounds: {minimum: [0, 0, 0], maximum: [4, 8, 8]},
+        minimumLevel: 1,
+        targetSpacing: 4
+      }
+    )) {
+      selected.push(tile.id);
+    }
+    expect(selected).toEqual(['a', 'b']);
+  });
+
+  test('honors maximum level and cancellation', async () => {
+    const selected: string[] = [];
+    for await (const tile of selectPointCloudScanTiles(
+      tiles.root,
+      async tile => tile.children.map(childId => tiles[childId]),
+      {maximumLevel: 1}
+    )) {
+      selected.push(tile.id);
+    }
+    expect(selected).toEqual(['root', 'a', 'b']);
+
+    const controller = new AbortController();
+    controller.abort();
+    const iterator = selectPointCloudScanTiles(tiles.root, async () => [], {
+      signal: controller.signal
+    });
+    await expect(iterator.next()).rejects.toMatchObject({name: 'AbortError'});
+  });
+
+  test('tests inclusive three-dimensional intersections', () => {
+    expect(
+      intersectPointCloudBounds(
+        {minimum: [0, 0, 0], maximum: [1, 1, 1]},
+        {minimum: [1, 1, 1], maximum: [2, 2, 2]}
+      )
+    ).toBe(true);
+    expect(
+      intersectPointCloudBounds(
+        {minimum: [0, 0, 0], maximum: [1, 1, 1]},
+        {minimum: [2, 2, 2], maximum: [3, 3, 3]}
+      )
+    ).toBe(false);
+  });
+});
+
+function createTile(
+  id: string,
+  level: number,
+  geometricError: number,
+  minimum: [number, number, number],
+  maximum: [number, number, number],
+  children: readonly string[]
+): PointCloudScanTile & {children: readonly string[]} {
+  return {id, level, geometricError, pointCount: 1, bounds: {minimum, maximum}, children};
+}

--- a/modules/netcdf/README.md
+++ b/modules/netcdf/README.md
@@ -1,5 +1,8 @@
 # @loaders.gl/netcdf
 
-This module contains a geometry loader for NetCDF.
+This module contains a raster source for NetCDF. `NetCDFSource.getRaster()` selects numeric
+variables and applies named dimension index or half-open range slices, returning typed raster data.
+The source publishes its variables, dimensions, attributes, execution method, and raster query
+capabilities through common scan metadata.
 
 [loaders.gl](https://loaders.gl/docs) is a collection of framework-independent visualization-focused loaders (parsers).

--- a/modules/netcdf/src/index.ts
+++ b/modules/netcdf/src/index.ts
@@ -8,4 +8,4 @@ export {NetCDFFormat} from './netcdf-format';
 export type {NetCDF, NetCDFLoaderOptions} from './netcdf-loader';
 export {NetCDFLoader} from './netcdf-loader';
 export {NetCDFSourceLoader} from './netcdf-source-loader-types';
-export type {NetCDFSourceOptions} from './netcdf-source-loader';
+export type {NetCDFRasterQueryOptions, NetCDFSourceOptions} from './netcdf-source-loader';

--- a/modules/netcdf/src/netcdf-source-loader.ts
+++ b/modules/netcdf/src/netcdf-source-loader.ts
@@ -5,11 +5,19 @@
 import type {Field, Schema, DataType} from '@loaders.gl/schema';
 import type {
   DataSourceOptions,
+  RasterChannelDataType,
+  RasterData,
+  RasterQueryCapabilities,
+  RasterQueryOptions,
   ScanQueryMetadata,
   ScanQueryMetadataOptions,
   SourceLoader
 } from '@loaders.gl/loader-utils';
-import {createScanQueryMetadata, DataSource} from '@loaders.gl/loader-utils';
+import {
+  createScanQueryMetadata,
+  DataSource,
+  validateRasterQueryOptions
+} from '@loaders.gl/loader-utils';
 import {NetCDFFormat} from './netcdf-format';
 import {NetCDFReader} from './netcdfjs/netcdf-reader';
 import type {NetCDFHeader, NetCDFVariable} from './netcdfjs/netcdf-types';
@@ -21,17 +29,30 @@ const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 /** Options for a NetCDF source. */
 export type NetCDFSourceOptions = DataSourceOptions;
 
+/** Common NetCDF variable and dimension-slice request. */
+export type NetCDFRasterQueryOptions = RasterQueryOptions &
+  Readonly<{
+    /** Cancels the file request and cooperative slice materialization. */
+    signal?: AbortSignal;
+  }>;
+
 /**
- * Lightweight NetCDF source that exposes the classic-file header to the shared scan UI.
- *
- * The source intentionally performs metadata-only discovery. Data-variable reads and chunked
- * window scans remain format-specific follow-up work, but callers can already use one query
- * panel to inspect variables, dimensions, and source statistics.
+ * NetCDF classic source with header-only discovery and typed variable/slice execution.
  */
 export class NetCDFSource extends DataSource<string | Blob, NetCDFSourceOptions> {
   private static readonly HEADER_RANGE_SIZE = 64 * 1024;
   private static readonly MAX_HEADER_RANGE_SIZE = 4 * 1024 * 1024;
   private headerPromise: Promise<{header: NetCDFHeader; byteLength: number}> | null = null;
+
+  /** Capabilities of the NetCDF variable and dimension-slice executor. */
+  readonly rasterQueryCapabilities: RasterQueryCapabilities = Object.freeze({
+    bounds: 'unsupported',
+    level: 'unsupported',
+    variables: 'pushdown',
+    slices: 'residual',
+    streaming: false,
+    cancellation: true
+  });
 
   /** Creates a source over a NetCDF URL or Blob. */
   constructor(data: string | Blob, options: NetCDFSourceOptions = {}) {
@@ -48,21 +69,105 @@ export class NetCDFSource extends DataSource<string | Blob, NetCDFSourceOptions>
     return createScanQueryMetadata({
       sourceType: 'netcdf',
       queryType: 'raster',
-      execution: {
-        status: 'metadata-only',
-        reason: 'Common NetCDF variable and dimension-slice execution is not implemented.'
-      },
+      execution: {status: 'supported', method: 'getRaster'},
       name: typeof this.data === 'string' ? this.data.split('/').pop() : undefined,
       schema,
       capabilities: {
         bounds: 'unsupported',
-        levelOfDetail: 'unsupported'
+        levelOfDetail: 'unsupported',
+        raster: this.rasterQueryCapabilities
       },
       statistics: {
         byteLength,
         rowCount: header.recordDimension.length || undefined
       }
     });
+  }
+
+  /**
+   * Reads selected numeric variables and applies named dimension slices.
+   *
+   * Multiple variables must retain the same shape and numeric type so they can be returned as
+   * ordinary raster bands. Leading dimensions are folded into height and the final dimension is
+   * exposed as width; the original dimension names and shape remain in result metadata.
+   */
+  async getRaster(options: NetCDFRasterQueryOptions = {}): Promise<RasterData> {
+    validateRasterQueryOptions(options);
+    validateNetCDFUnsupportedRasterOptions(options);
+    throwIfAborted(options.signal);
+    const reader = await this.loadReader(options.signal);
+    throwIfAborted(options.signal);
+    validateNetCDFSliceNames(reader.header, options.slices);
+    const variables = selectNetCDFVariables(reader.header, options.variables);
+    const results = variables.map(variable => {
+      throwIfAborted(options.signal);
+      const dimensionNames = variable.dimensions.map(
+        dimensionId => reader.header.dimensions[dimensionId]?.name || `dimension_${dimensionId}`
+      );
+      const dimensionSizes = variable.dimensions.map(dimensionId =>
+        getDimensionSize(reader.header, dimensionId)
+      );
+      const values = flattenNetCDFValues(reader.getDataVariable(variable));
+      const selection = selectNetCDFValues(
+        values,
+        dimensionNames,
+        dimensionSizes,
+        options.slices || {},
+        options.signal
+      );
+      const dtype = getNetCDFRasterDataType(variable.type);
+      return {
+        variable,
+        dimensionNames: selection.dimensionNames,
+        shape: selection.shape,
+        data: createNetCDFTypedArray(selection.values, dtype),
+        dtype
+      };
+    });
+    const reference = results[0];
+    for (const result of results.slice(1)) {
+      if (result.dtype !== reference.dtype || !arraysEqual(result.shape, reference.shape)) {
+        throw new Error(
+          'NetCDF raster variables must retain the same shape and numeric type after slicing.'
+        );
+      }
+    }
+    const width = reference.shape.at(-1) ?? 1;
+    const height =
+      reference.shape.length < 2
+        ? 1
+        : reference.shape.slice(0, -1).reduce((product, size) => product * size, 1);
+    const noData = getNetCDFNoDataValue(reference.variable);
+
+    return {
+      data: results.length === 1 ? reference.data : results.map(result => result.data),
+      width,
+      height,
+      bandCount: results.length,
+      dtype: reference.dtype,
+      interleaved: false,
+      noData,
+      metadata: {
+        variables: results.map(result => result.variable.name),
+        dimensions: reference.dimensionNames,
+        shape: reference.shape,
+        slices: {...options.slices}
+      }
+    };
+  }
+
+  /** Loads a complete NetCDF reader for selected-variable execution. */
+  private async loadReader(signal?: AbortSignal): Promise<NetCDFReader> {
+    let arrayBuffer: ArrayBuffer;
+    if (typeof this.data === 'string') {
+      const response = await this.fetch(this.url, {signal});
+      if (!response.ok) throw new Error(`NetCDF request failed with status ${response.status}.`);
+      arrayBuffer = await response.arrayBuffer();
+    } else {
+      arrayBuffer = await this.data.arrayBuffer();
+    }
+    throwIfAborted(signal);
+    return new NetCDFReader(arrayBuffer);
   }
 
   /** Reads and caches the NetCDF header, preserving abort behavior for each caller. */
@@ -160,6 +265,221 @@ function getNetCDFDataType(type: string): DataType {
     default:
       return 'binary';
   }
+}
+
+type NetCDFTypedArray =
+  | Int8Array
+  | Uint8Array
+  | Int16Array
+  | Uint16Array
+  | Int32Array
+  | Uint32Array
+  | Float32Array
+  | Float64Array;
+
+type NetCDFValueSelection = {
+  values: number[];
+  dimensionNames: string[];
+  shape: number[];
+};
+
+/** Rejects raster operations that have no NetCDF classic interpretation. */
+function validateNetCDFUnsupportedRasterOptions(options: NetCDFRasterQueryOptions): void {
+  if (options.bounds) throw new Error('NetCDF raster bounds are not supported.');
+  if (options.level !== undefined) throw new Error('NetCDF raster levels are not supported.');
+  if (options.width !== undefined || options.height !== undefined) {
+    throw new Error('NetCDF raster resampling is not supported.');
+  }
+  if (options.channels?.length) {
+    throw new Error('NetCDF uses named variables instead of numeric channels.');
+  }
+}
+
+/** Selects and validates query-visible numeric NetCDF variables. */
+function selectNetCDFVariables(
+  header: NetCDFHeader,
+  requestedVariableNames?: readonly string[]
+): NetCDFVariable[] {
+  const defaultVariable = header.variables.find(
+    variable => variable.dimensions.length > 0 && isNetCDFRasterDataType(variable.type)
+  );
+  const variableNames = requestedVariableNames?.length
+    ? [...requestedVariableNames]
+    : defaultVariable
+      ? [defaultVariable.name]
+      : [];
+  if (variableNames.length === 0) {
+    throw new Error('NetCDF contains no numeric variables that can be read as raster data.');
+  }
+  if (new Set(variableNames).size !== variableNames.length) {
+    throw new Error('NetCDF raster variables must not contain duplicates.');
+  }
+  return variableNames.map(variableName => {
+    const variable = header.variables.find(candidate => candidate.name === variableName);
+    if (!variable) throw new Error(`NetCDF variable not found: ${variableName}`);
+    getNetCDFRasterDataType(variable.type);
+    return variable;
+  });
+}
+
+/** Validates slice names against file-level dimensions. */
+function validateNetCDFSliceNames(
+  header: NetCDFHeader,
+  slices: NetCDFRasterQueryOptions['slices']
+): void {
+  const dimensionNames = new Set(header.dimensions.map(dimension => dimension.name));
+  for (const dimensionName of Object.keys(slices || {})) {
+    if (!dimensionNames.has(dimensionName)) {
+      throw new Error(`NetCDF dimension not found: ${dimensionName}`);
+    }
+  }
+}
+
+/** Applies named dimension indices and half-open ranges to row-major variable values. */
+function selectNetCDFValues(
+  values: readonly unknown[],
+  dimensionNames: readonly string[],
+  dimensionSizes: readonly number[],
+  slices: NonNullable<NetCDFRasterQueryOptions['slices']>,
+  signal?: AbortSignal
+): NetCDFValueSelection {
+  const selectors = dimensionNames.map((dimensionName, dimensionIndex) => {
+    const size = dimensionSizes[dimensionIndex];
+    const slice = slices[dimensionName];
+    if (slice === undefined) return {start: 0, stop: size, remove: false};
+    if (typeof slice !== 'number') {
+      const [start, stop] = slice;
+      if (
+        !Number.isSafeInteger(start) ||
+        !Number.isSafeInteger(stop) ||
+        start < 0 ||
+        stop < start ||
+        stop > size
+      ) {
+        throw new Error(
+          `NetCDF slice ${dimensionName} must be a valid half-open range within 0..${size}.`
+        );
+      }
+      return {start, stop, remove: false};
+    }
+    if (!Number.isSafeInteger(slice) || slice < 0 || slice >= size) {
+      throw new Error(`NetCDF slice ${dimensionName} must be an index within 0..${size - 1}.`);
+    }
+    return {start: slice, stop: slice + 1, remove: true};
+  });
+  const strides = dimensionSizes.map((_, dimensionIndex) =>
+    dimensionSizes
+      .slice(dimensionIndex + 1)
+      .reduce((product, dimensionSize) => product * dimensionSize, 1)
+  );
+  const selectedValues: number[] = [];
+
+  const visitDimension = (dimensionIndex: number, flatOffset: number): void => {
+    throwIfAborted(signal);
+    if (dimensionIndex === selectors.length) {
+      const value = values[flatOffset];
+      if (typeof value !== 'number') {
+        throw new Error('NetCDF raster variables must contain numeric values.');
+      }
+      selectedValues.push(value);
+      return;
+    }
+    const selector = selectors[dimensionIndex];
+    for (let index = selector.start; index < selector.stop; index++) {
+      visitDimension(dimensionIndex + 1, flatOffset + index * strides[dimensionIndex]);
+    }
+  };
+  visitDimension(0, 0);
+
+  return {
+    values: selectedValues,
+    dimensionNames: dimensionNames.filter((_, index) => !selectors[index].remove),
+    shape: selectors
+      .map(selector => selector.stop - selector.start)
+      .filter((_, index) => !selectors[index].remove)
+  };
+}
+
+/** Flattens the nested arrays emitted by NetCDFReader into file-order scalar values. */
+function flattenNetCDFValues(values: unknown): unknown[] {
+  if (Array.isArray(values)) return values.flatMap(flattenNetCDFValues);
+  if (ArrayBuffer.isView(values)) {
+    return Array.from(values as unknown as ArrayLike<unknown>);
+  }
+  return [values];
+}
+
+/** Returns whether a NetCDF primitive can be represented by RasterData. */
+function isNetCDFRasterDataType(type: string): boolean {
+  try {
+    getNetCDFRasterDataType(type);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Maps a NetCDF numeric primitive to the common raster channel type. */
+function getNetCDFRasterDataType(type: string): RasterChannelDataType {
+  switch (type.toLowerCase()) {
+    case 'byte':
+      return 'int8';
+    case 'ubyte':
+      return 'uint8';
+    case 'short':
+      return 'int16';
+    case 'ushort':
+      return 'uint16';
+    case 'int':
+      return 'int32';
+    case 'uint':
+      return 'uint32';
+    case 'float':
+      return 'float32';
+    case 'double':
+      return 'float64';
+    default:
+      throw new Error(`NetCDF variable type is not supported as raster data: ${type}`);
+  }
+}
+
+/** Materializes numeric values in the selected NetCDF primitive type. */
+function createNetCDFTypedArray(
+  values: readonly number[],
+  dtype: RasterChannelDataType
+): NetCDFTypedArray {
+  switch (dtype) {
+    case 'int8':
+      return Int8Array.from(values);
+    case 'uint8':
+      return Uint8Array.from(values);
+    case 'int16':
+      return Int16Array.from(values);
+    case 'uint16':
+      return Uint16Array.from(values);
+    case 'int32':
+      return Int32Array.from(values);
+    case 'uint32':
+      return Uint32Array.from(values);
+    case 'float32':
+      return Float32Array.from(values);
+    case 'float64':
+      return Float64Array.from(values);
+  }
+}
+
+/** Reads the conventional fill or missing-value attribute when it is numeric. */
+function getNetCDFNoDataValue(variable: NetCDFVariable): number | null {
+  const attribute = variable.attributes.find(
+    candidate => candidate.name === '_FillValue' || candidate.name === 'missing_value'
+  );
+  const value = Number(attribute?.value);
+  return attribute && Number.isFinite(value) ? value : null;
+}
+
+/** Compares small raster shape arrays. */
+function arraysEqual(left: readonly number[], right: readonly number[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
 }
 
 /** Converts a NetCDF variable into a query-visible field. */

--- a/modules/netcdf/src/netcdfjs/netcdf-reader.ts
+++ b/modules/netcdf/src/netcdfjs/netcdf-reader.ts
@@ -159,7 +159,7 @@ export class NetCDFReader {
 
     if (variable.record) {
       // record variable case
-      return readRecord(this.buffer, variable, this.header.recordDimension);
+      return readRecord(this.buffer, variable, this.header.recordDimension, this.header.dimensions);
     }
     // non-record variable case
     return readNonRecord(this.buffer, variable);

--- a/modules/netcdf/src/netcdfjs/read-data.ts
+++ b/modules/netcdf/src/netcdfjs/read-data.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 import type {IOBuffer} from '../iobuffer/iobuffer';
-import type {NetCDFRecordDimension, NetCDFVariable} from './netcdf-types';
+import type {NetCDFDimension, NetCDFRecordDimension, NetCDFVariable} from './netcdf-types';
 import {readType, str2num, num2bytes} from './read-type';
 
 // const STREAMING = 4294967295;
@@ -36,16 +36,22 @@ export function readNonRecord(
  * @param buffer - Buffer for the file data
  * @param variable - Variable metadata
  * @param recordDimension - Record dimension metadata
+ * @param dimensions - Declared file dimensions used to exclude record padding
  * @return - Data of the element
  */
 export function readRecord(
   buffer: IOBuffer,
   variable: NetCDFVariable,
-  recordDimension: NetCDFRecordDimension
+  recordDimension: NetCDFRecordDimension,
+  dimensions: NetCDFDimension[]
 ): (string | number | number[] | Uint8Array)[] {
   // variable type
   const type = str2num(variable.type);
-  const width = variable.size ? variable.size / num2bytes(type) : 1;
+  // NetCDF stores each record variable on a four-byte boundary. `variable.size` includes that
+  // padding, so derive the logical element count from the declared non-record dimensions.
+  const width = variable.dimensions
+    .filter(dimensionId => dimensionId !== recordDimension.id)
+    .reduce((elementCount, dimensionId) => elementCount * dimensions[dimensionId].size, 1);
 
   // size of the data
   // TODO streaming data

--- a/modules/netcdf/test/netcdf-source.spec.ts
+++ b/modules/netcdf/test/netcdf-source.spec.ts
@@ -10,16 +10,54 @@ test.runIf(isBrowser)('NetCDF source discovers raster metadata from a Blob', asy
   const metadata = await source.getQueryMetadata();
 
   expect(metadata.queryType).toBe('raster');
-  expect(metadata.execution).toEqual({
-    status: 'metadata-only',
-    reason: 'Common NetCDF variable and dimension-slice execution is not implemented.'
-  });
+  expect(metadata.execution).toEqual({status: 'supported', method: 'getRaster'});
+  expect(metadata.capabilities.raster?.variables).toBe('pushdown');
+  expect(metadata.capabilities.raster?.slices).toBe('residual');
   expect(metadata.statistics?.rowCount).toBe(178);
   expect(metadata.columns.map(column => column.name)).toContain('wmoId');
   expect(metadata.columns.find(column => column.name === 'wmoId')?.metadata?.dimensions).toBe(
     'recNum[178]'
   );
   expect(metadata.schema.metadata['dimension:recNum']).toBe('178');
+});
+
+test.runIf(isBrowser)('NetCDF source reads typed variable dimension slices', async () => {
+  const response = await fetchFile(NETCDF_FIXTURE);
+  const source = new NetCDFSource(new Blob([await response.arrayBuffer()]));
+  const raster = await source.getRaster({
+    variables: ['wmoId'],
+    slices: {recNum: [1, 4]}
+  });
+
+  expect(raster.width).toBe(3);
+  expect(raster.height).toBe(1);
+  expect(raster.bandCount).toBe(1);
+  expect(raster.dtype).toBe('int32');
+  expect(Array.from(raster.data as Int32Array).slice(0, 2)).toEqual([71415, 71408]);
+  expect(raster.metadata).toMatchObject({
+    variables: ['wmoId'],
+    dimensions: ['recNum'],
+    shape: [3]
+  });
+});
+
+test.runIf(isBrowser)('NetCDF source validates variables, slices, and cancellation', async () => {
+  const response = await fetchFile(NETCDF_FIXTURE);
+  const source = new NetCDFSource(new Blob([await response.arrayBuffer()]));
+
+  await expect(source.getRaster({variables: ['missing']})).rejects.toThrow('variable not found');
+  await expect(
+    source.getRaster({variables: ['wmoId'], slices: {recNum: [0, 1000]}})
+  ).rejects.toThrow('half-open range');
+  await expect(source.getRaster({variables: ['wmoId'], slices: {missing: 0}})).rejects.toThrow(
+    'dimension not found'
+  );
+
+  const controller = new AbortController();
+  controller.abort();
+  await expect(
+    source.getRaster({variables: ['wmoId'], signal: controller.signal})
+  ).rejects.toMatchObject({name: 'AbortError'});
 });
 
 test.runIf(isBrowser)(

--- a/modules/netcdf/test/read-data.spec.ts
+++ b/modules/netcdf/test/read-data.spec.ts
@@ -1,0 +1,37 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import {IOBuffer} from '../src/iobuffer/iobuffer';
+import {readRecord} from '../src/netcdfjs/read-data';
+import type {
+  NetCDFDimension,
+  NetCDFRecordDimension,
+  NetCDFVariable
+} from '../src/netcdfjs/netcdf-types';
+
+test('readRecord excludes four-byte padding from short record variables', () => {
+  const buffer = new IOBuffer(new Uint8Array([0, 10, 0, 0, 0, 20, 0, 0])).setBigEndian();
+  const variable: NetCDFVariable = {
+    name: 'value',
+    dimensions: [0, 1],
+    attributes: [],
+    type: 'short',
+    size: 4,
+    offset: 0,
+    record: true
+  };
+  const recordDimension: NetCDFRecordDimension = {
+    length: 2,
+    id: 0,
+    name: 'record',
+    recordStep: 4
+  };
+  const dimensions: NetCDFDimension[] = [
+    {name: 'record', size: 0, recordId: 0, recordName: 'record'},
+    {name: 'sample', size: 1, recordId: 0, recordName: 'record'}
+  ];
+
+  expect(readRecord(buffer, variable, recordDimension, dimensions)).toEqual([10, 20]);
+});

--- a/modules/potree/README.md
+++ b/modules/potree/README.md
@@ -2,6 +2,11 @@
 
 This module contains loaders for the [potree](https://github.com/potree/potree) format.
 
+`PotreeNodesSource.scan()` executes portable point-cloud queries with hierarchy bounds and
+level-of-detail pruning, residual predicates, projection, global limits, cancellation, and bounded
+Arrow batches. Potree attributes including positions, colors, intensity, classification, and
+encoded normals are available to the scan schema when present in the source metadata.
+
 `PotreeMetadataSchema` is available from the `@loaders.gl/potree/potree-metadata-schema` subpath for runtime validation. The package root exports the corresponding `PotreeMetadata` TypeScript type without loading Zod. The equivalent generated JSON Schema is available from `@loaders.gl/potree/potree-metadata.schema.json`.
 
 [loaders.gl](https://loaders.gl/docs) is a collection of framework-independent 3D and geospatial loaders (parsers).

--- a/modules/potree/src/lib/potree-node-source.ts
+++ b/modules/potree/src/lib/potree-node-source.ts
@@ -3,16 +3,35 @@
 // Copyright (c) vis.gl contributors
 
 import type {PotreeSourceLoaderOptions} from '../potree-source-loader';
-import type {CoreAPI, Loader, LoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';
+import type {
+  CoreAPI,
+  Loader,
+  LoaderOptions,
+  LoaderWithParser,
+  PointCloudScanReadOptions,
+  PointCloudScanSource,
+  PointCloudScanTile
+} from '@loaders.gl/loader-utils';
 import {
   createScanQueryMetadata,
   DataSource,
+  filterColumnarRowIndices,
+  getColumnarPredicateColumns,
   resolvePath,
+  selectPointCloudScanTiles,
+  validatePointCloudQueryOptions,
   type PointCloudQueryCapabilities
 } from '@loaders.gl/loader-utils';
 import {LASLoader} from '@loaders.gl/las';
-import type {DataType, Field, Mesh, MeshArrowTable} from '@loaders.gl/schema';
-import {convertMeshToTable} from '@loaders.gl/schema-utils';
+import type {
+  ArrowTableBatch,
+  DataType,
+  Field,
+  Mesh,
+  MeshArrowTable,
+  Schema
+} from '@loaders.gl/schema';
+import {ArrowTableBuilder, convertMeshToTable} from '@loaders.gl/schema-utils';
 import {PotreeBoundingBox, PotreeMetadata} from '../types/potree-metadata';
 import {
   POTreeNode,
@@ -51,10 +70,13 @@ export interface PotreeNodeMesh extends LASMesh {
  * @version 1.7 - @see https://github.com/potree/potree/blob/1.7/docs/potree-file-format.md
  * @note Point cloud nodes tile source
  */
-export class PotreeNodesSource extends DataSource<string, PotreeSourceLoaderOptions> {
+export class PotreeNodesSource
+  extends DataSource<string, PotreeSourceLoaderOptions>
+  implements PointCloudScanSource<ArrowTableBatch>
+{
   /** Common point-cloud scan capabilities exposed by Potree metadata and hierarchy nodes. */
   readonly pointCloudQueryCapabilities: PointCloudQueryCapabilities = Object.freeze({
-    projection: 'pushdown',
+    projection: 'residual',
     predicate: 'residual',
     limit: 'residual',
     streaming: true,
@@ -148,10 +170,7 @@ export class PotreeNodesSource extends DataSource<string, PotreeSourceLoaderOpti
     return createScanQueryMetadata({
       sourceType: 'potree',
       queryType: 'point-cloud',
-      execution: {
-        status: 'metadata-only',
-        reason: 'Common point-cloud scan traversal is not implemented; use the Potree tile APIs.'
-      },
+      execution: {status: 'supported', method: 'scan'},
       schema,
       capabilities: {
         table: this.pointCloudQueryCapabilities,
@@ -174,6 +193,101 @@ export class PotreeNodesSource extends DataSource<string, PotreeSourceLoaderOpti
         : undefined,
       statistics: this.metadata?.points === undefined ? undefined : {rowCount: this.metadata.points}
     });
+  }
+
+  /**
+   * Scans Potree hierarchy nodes into ordered, globally limited Arrow point batches.
+   *
+   * Node bounds, hierarchy levels, and target spacing avoid unrelated node reads. Attribute
+   * predicates and exact point bounds are evaluated residually after each selected node decode.
+   */
+  async *scan(options: PointCloudScanReadOptions = {}): AsyncIterableIterator<ArrowTableBatch> {
+    await this.initPromise;
+    const schema: Schema = {
+      fields: getPotreeSchemaFields(this.metadata?.pointAttributes || []),
+      metadata: {}
+    };
+    const sourceColumnNames = schema.fields.map(field => field.name);
+    validatePointCloudQueryOptions(sourceColumnNames, options);
+    const batchSize = validatePotreeScanBatchSize(options.batchSize);
+    if (options.limit === 0) return;
+
+    const outputColumnNames = options.columns ? [...options.columns] : sourceColumnNames;
+    const predicateColumnNames = options.predicate
+      ? getColumnarPredicateColumns(options.predicate)
+      : [];
+    const requiredColumnNames = new Set([...outputColumnNames, ...predicateColumnNames]);
+    const positionColumnNames = sourceColumnNames.includes('POSITION_CARTESIAN')
+      ? ['POSITION_CARTESIAN']
+      : ['X', 'Y', 'Z'];
+    for (const positionColumnName of positionColumnNames) {
+      requiredColumnNames.add(positionColumnName);
+    }
+    const outputSchema: Schema = {
+      fields: outputColumnNames.map(
+        columnName => schema.fields.find(field => field.name === columnName)!
+      ),
+      metadata: schema.metadata
+    };
+    const rootTile = this.getPotreeScanTile(await this.getRootTile());
+    let remainingPointCount = options.limit ?? Number.POSITIVE_INFINITY;
+
+    for await (const tile of selectPointCloudScanTiles(
+      rootTile,
+      async parent => (await this.getChildren(parent)).map(child => this.getPotreeScanTile(child)),
+      options
+    )) {
+      throwIfPotreeScanAborted(options.signal);
+      const nodeContent = await this.loadNodeContent(this.getNodeName(tile.id), {
+        signal: options.signal
+      });
+      throwIfPotreeScanAborted(options.signal);
+      if (!nodeContent) continue;
+      const columns = getPotreeScanColumns(
+        nodeContent,
+        [...requiredColumnNames],
+        options.bounds,
+        Boolean(this.projection)
+      );
+      const rowCount = columns[positionColumnNames[0]].length;
+      const matchingRowIndices = filterColumnarRowIndices(
+        options.predicate,
+        columns,
+        rowCount
+      ).slice(0, remainingPointCount);
+
+      for (let batchOffset = 0; batchOffset < matchingRowIndices.length; batchOffset += batchSize) {
+        const batchRowIndices = matchingRowIndices.slice(batchOffset, batchOffset + batchSize);
+        const builder = new ArrowTableBuilder(outputSchema);
+        for (const rowIndex of batchRowIndices) {
+          builder.addArrayRow(outputColumnNames.map(columnName => columns[columnName][rowIndex]));
+        }
+        const batch = builder.finishBatch();
+        if (batch) yield batch;
+        remainingPointCount -= batchRowIndices.length;
+        if (remainingPointCount === 0) return;
+      }
+    }
+  }
+
+  /** Converts one Potree hierarchy header to source-coordinate scan-planner metadata. */
+  private getPotreeScanTile(tile: {
+    id: string;
+    level: number;
+    pointCount: number;
+    geometricError: number;
+  }): PointCloudScanTile {
+    const bounds = this.getNativeNodeBounds(tile.id);
+    return {
+      id: tile.id,
+      level: tile.level,
+      pointCount: tile.pointCount,
+      geometricError: tile.geometricError,
+      bounds: {
+        minimum: [bounds.lx, bounds.ly, bounds.lz],
+        maximum: [bounds.ux, bounds.uy, bounds.uz]
+      }
+    };
   }
 
   /** Is data set supported */
@@ -210,7 +324,10 @@ export class PotreeNodesSource extends DataSource<string, PotreeSourceLoaderOpti
    * @param nodeName name of a node, string of numbers in range 0..7
    * @return node content geometry or null if the node doesn't exist
    */
-  async loadNodeContent(nodeName: string): Promise<PotreeNodeMesh | null> {
+  async loadNodeContent(
+    nodeName: string,
+    options: {signal?: AbortSignal} = {}
+  ): Promise<PotreeNodeMesh | null> {
     await this.initPromise;
 
     if (!this.isSupported()) {
@@ -231,7 +348,8 @@ export class PotreeNodesSource extends DataSource<string, PotreeSourceLoaderOpti
       const result = (await this.loadWithCoreApi(
         this.getNodeContentUrl(nodeName, contentExtension),
         loader,
-        loaderOptions
+        loaderOptions,
+        options.signal
       )) as PotreeNodeMesh & {
         header?: {boundingBox?: [number[], number[]]; vertexCount?: number};
         attributes: Record<string, any>;
@@ -386,13 +504,26 @@ export class PotreeNodesSource extends DataSource<string, PotreeSourceLoaderOpti
   private async loadWithCoreApi<T>(
     url: string,
     loader: LoaderWithParser<T, never, LoaderOptions>,
-    options?: LoaderOptions
+    options?: LoaderOptions,
+    signal?: AbortSignal
   ): Promise<T> {
+    throwIfPotreeScanAborted(signal);
     if (this.hasCoreApi) {
-      return (await this.coreApi.load(url, loader as Loader, options || this.loadOptions)) as T;
+      const loaderOptions = options || this.loadOptions;
+      const cancellableOptions = signal
+        ? {
+            ...loaderOptions,
+            core: {
+              ...loaderOptions.core,
+              fetch: (resource: string, requestInit?: RequestInit) =>
+                this.fetch(resource, {...requestInit, signal})
+            }
+          }
+        : loaderOptions;
+      return (await this.coreApi.load(url, loader as Loader, cancellableOptions)) as T;
     }
 
-    const response = await this.fetch(url);
+    const response = await this.fetch(url, {signal});
     if (!response.ok) {
       throw new Error(`Failed to load Potree resource: ${response.status} ${response.statusText}`);
     }
@@ -402,6 +533,7 @@ export class PotreeNodesSource extends DataSource<string, PotreeSourceLoaderOpti
       throw new Error(`Loader ${loader.id} does not support parse()`);
     }
 
+    throwIfPotreeScanAborted(signal);
     return await loader.parse(arrayBuffer, options || this.loadOptions);
   }
 
@@ -899,6 +1031,84 @@ export class PotreeNodesSource extends DataSource<string, PotreeSourceLoaderOpti
   }
 }
 
+/** Extracts query-visible source-coordinate columns from one decoded Potree node. */
+function getPotreeScanColumns(
+  mesh: PotreeNodeMesh,
+  columnNames: readonly string[],
+  bounds: PointCloudScanReadOptions['bounds'],
+  positionsAreOffsets: boolean
+): Record<string, unknown[]> {
+  const columns = Object.fromEntries(columnNames.map(columnName => [columnName, [] as unknown[]]));
+  const positions = mesh.attributes.POSITION?.value as Float32Array | Float64Array | undefined;
+  if (!positions) return columns;
+  const nativeOrigin = positionsAreOffsets
+    ? getNativeOriginFromBoundingBox(mesh.header?.boundingBox)
+    : [0, 0, 0];
+  const pointCount = Math.floor(positions.length / 3);
+
+  for (let pointIndex = 0; pointIndex < pointCount; pointIndex++) {
+    const positionIndex = pointIndex * 3;
+    const sourcePosition = [
+      positions[positionIndex] + nativeOrigin[0],
+      positions[positionIndex + 1] + nativeOrigin[1],
+      positions[positionIndex + 2] + nativeOrigin[2]
+    ];
+    if (bounds && !isPotreePointInsideBounds(sourcePosition, bounds)) continue;
+
+    for (const columnName of columnNames) {
+      columns[columnName].push(getPotreeScanValue(mesh, columnName, pointIndex, sourcePosition));
+    }
+  }
+  return columns;
+}
+
+/** Reads one query-visible value from a Potree mesh attribute. */
+function getPotreeScanValue(
+  mesh: PotreeNodeMesh,
+  columnName: string,
+  pointIndex: number,
+  sourcePosition: readonly number[]
+): unknown {
+  if (columnName === 'X') return sourcePosition[0];
+  if (columnName === 'Y') return sourcePosition[1];
+  if (columnName === 'Z') return sourcePosition[2];
+  if (columnName === 'POSITION_CARTESIAN') return [...sourcePosition];
+
+  const attribute = mesh.attributes[columnName];
+  if (!attribute) return null;
+  const size = attribute.size || 1;
+  const values = attribute.value as unknown as ArrayLike<unknown>;
+  if (size === 1) return values[pointIndex];
+  const valueOffset = pointIndex * size;
+  return Array.from({length: size}, (_, componentIndex) => values[valueOffset + componentIndex]);
+}
+
+/** Returns whether a decoded Potree point lies within inclusive source bounds. */
+function isPotreePointInsideBounds(
+  point: readonly number[],
+  bounds: NonNullable<PointCloudScanReadOptions['bounds']>
+): boolean {
+  return point.every(
+    (coordinate, dimension) =>
+      coordinate >= bounds.minimum[dimension] && coordinate <= bounds.maximum[dimension]
+  );
+}
+
+/** Validates and returns the maximum retained point count per Potree batch. */
+function validatePotreeScanBatchSize(batchSize = 65536): number {
+  if (!Number.isSafeInteger(batchSize) || batchSize < 1) {
+    throw new Error('Point cloud scan batchSize must be a positive safe integer.');
+  }
+  return batchSize;
+}
+
+/** Throws a standard cancellation error for Potree scan work. */
+function throwIfPotreeScanAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw new DOMException('The operation was aborted', 'AbortError');
+  }
+}
+
 /** Builds query-visible fields from Potree point-attribute metadata. */
 function getPotreeSchemaFields(pointAttributes: PotreeMetadata['pointAttributes']): Field[] {
   if (!Array.isArray(pointAttributes)) {
@@ -919,19 +1129,30 @@ function getPotreeSchemaFields(pointAttributes: PotreeMetadata['pointAttributes'
 /** Maps one Potree attribute identifier to a loaders.gl field. */
 function getPotreeField(attribute: string): Field | undefined {
   const fieldTypes: Record<string, {name: string; type: DataType}> = {
-    POSITION_CARTESIAN: {name: 'POSITION_CARTESIAN', type: 'float32'},
-    RGBA_PACKED: {name: 'RGBA_PACKED', type: 'uint8'},
-    COLOR_PACKED: {name: 'COLOR_PACKED', type: 'uint8'},
-    RGB_PACKED: {name: 'RGB_PACKED', type: 'uint8'},
-    NORMAL_FLOATS: {name: 'NORMAL_FLOATS', type: 'float32'},
+    POSITION_CARTESIAN: {
+      name: 'POSITION_CARTESIAN',
+      type: getPotreeListType('float32', 3)
+    },
+    RGBA_PACKED: {name: 'RGBA_PACKED', type: getPotreeListType('uint8', 3)},
+    COLOR_PACKED: {name: 'COLOR_PACKED', type: getPotreeListType('uint8', 3)},
+    RGB_PACKED: {name: 'RGB_PACKED', type: getPotreeListType('uint8', 3)},
+    NORMAL_FLOATS: {name: 'NORMAL_FLOATS', type: getPotreeListType('float32', 3)},
     INTENSITY: {name: 'INTENSITY', type: 'uint16'},
     CLASSIFICATION: {name: 'CLASSIFICATION', type: 'uint8'},
-    NORMAL_SPHEREMAPPED: {name: 'NORMAL_SPHEREMAPPED', type: 'uint8'},
+    NORMAL_SPHEREMAPPED: {
+      name: 'NORMAL_SPHEREMAPPED',
+      type: getPotreeListType('uint8', 2)
+    },
     NORMAL_OCT16: {name: 'NORMAL_OCT16', type: 'uint16'},
-    NORMAL: {name: 'NORMAL', type: 'float32'}
+    NORMAL: {name: 'NORMAL', type: getPotreeListType('float32', 3)}
   };
   const fieldType = fieldTypes[attribute];
   return fieldType ? {...fieldType, nullable: false} : undefined;
+}
+
+/** Creates a portable fixed-size-list type for packed Potree attributes. */
+function getPotreeListType(type: DataType, listSize: number): DataType {
+  return {type: 'fixed-size-list', listSize, children: [{name: 'value', type}]};
 }
 
 /** Infers a query-panel semantic role from a Potree attribute name. */

--- a/modules/potree/src/lib/potree-node-source.ts
+++ b/modules/potree/src/lib/potree-node-source.ts
@@ -164,13 +164,19 @@ export class PotreeNodesSource
   /** Discovers point attributes and hierarchy bounds without loading node content. */
   async getQueryMetadata() {
     await this.initPromise;
+    const isSupported = this.isSupported();
     const fields = getPotreeSchemaFields(this.metadata?.pointAttributes || []);
     const schema = {fields, metadata: {}};
     const bounds = this.nativeHierarchyBoundingBox || this.boundingBox;
     return createScanQueryMetadata({
       sourceType: 'potree',
       queryType: 'point-cloud',
-      execution: {status: 'supported', method: 'scan'},
+      execution: isSupported
+        ? {status: 'supported', method: 'scan'}
+        : {
+            status: 'metadata-only',
+            reason: 'This Potree version or point-attribute layout is not supported by the scanner.'
+          },
       schema,
       capabilities: {
         table: this.pointCloudQueryCapabilities,
@@ -203,6 +209,9 @@ export class PotreeNodesSource
    */
   async *scan(options: PointCloudScanReadOptions = {}): AsyncIterableIterator<ArrowTableBatch> {
     await this.initPromise;
+    if (!this.isSupported()) {
+      throw new Error('This Potree version or point-attribute layout is not supported.');
+    }
     const schema: Schema = {
       fields: getPotreeSchemaFields(this.metadata?.pointAttributes || []),
       metadata: {}

--- a/modules/potree/src/parsers/parse-potree-bin.ts
+++ b/modules/potree/src/parsers/parse-potree-bin.ts
@@ -27,8 +27,7 @@ type ResolvedPotreeBinOptions = {
 };
 
 /**
- * Parse a Potree 1.7 binary node into a minimal mesh.
- * The loader decodes only the attributes needed by the point-cloud tileset path.
+ * Parse a Potree 1.7 binary node into a typed point-attribute mesh.
  */
 export function parsePotreeBin(
   arrayBuffer: ArrayBuffer,
@@ -59,6 +58,24 @@ export function parsePotreeBin(
       pointAttribute === 'RGB_PACKED'
   );
   const colors = hasColor ? new Uint8Array(pointCount * 3) : null;
+  const intensities = resolvedOptions.pointAttributes.includes('INTENSITY')
+    ? new Uint16Array(pointCount)
+    : null;
+  const classifications = resolvedOptions.pointAttributes.includes('CLASSIFICATION')
+    ? new Uint8Array(pointCount)
+    : null;
+  const normalFloats = resolvedOptions.pointAttributes.includes('NORMAL_FLOATS')
+    ? new Float32Array(pointCount * 3)
+    : null;
+  const normals = resolvedOptions.pointAttributes.includes('NORMAL')
+    ? new Float32Array(pointCount * 3)
+    : null;
+  const sphereMappedNormals = resolvedOptions.pointAttributes.includes('NORMAL_SPHEREMAPPED')
+    ? new Uint8Array(pointCount * 2)
+    : null;
+  const oct16Normals = resolvedOptions.pointAttributes.includes('NORMAL_OCT16')
+    ? new Uint16Array(pointCount)
+    : null;
 
   for (let pointIndex = 0; pointIndex < pointCount; pointIndex++) {
     let attributeByteOffset = pointIndex * pointByteSize;
@@ -93,6 +110,47 @@ export function parsePotreeBin(
           break;
         }
 
+        case 'INTENSITY':
+          intensities![pointIndex] = dataView.getUint16(attributeByteOffset, true);
+          attributeByteOffset += 2;
+          break;
+
+        case 'CLASSIFICATION':
+          classifications![pointIndex] = dataView.getUint8(attributeByteOffset);
+          attributeByteOffset += 1;
+          break;
+
+        case 'NORMAL_FLOATS': {
+          const normalIndex = pointIndex * 3;
+          normalFloats![normalIndex] = dataView.getFloat32(attributeByteOffset, true);
+          normalFloats![normalIndex + 1] = dataView.getFloat32(attributeByteOffset + 4, true);
+          normalFloats![normalIndex + 2] = dataView.getFloat32(attributeByteOffset + 8, true);
+          attributeByteOffset += 12;
+          break;
+        }
+
+        case 'NORMAL': {
+          const normalIndex = pointIndex * 3;
+          normals![normalIndex] = dataView.getFloat32(attributeByteOffset, true);
+          normals![normalIndex + 1] = dataView.getFloat32(attributeByteOffset + 4, true);
+          normals![normalIndex + 2] = dataView.getFloat32(attributeByteOffset + 8, true);
+          attributeByteOffset += 12;
+          break;
+        }
+
+        case 'NORMAL_SPHEREMAPPED': {
+          const normalIndex = pointIndex * 2;
+          sphereMappedNormals![normalIndex] = dataView.getUint8(attributeByteOffset);
+          sphereMappedNormals![normalIndex + 1] = dataView.getUint8(attributeByteOffset + 1);
+          attributeByteOffset += 2;
+          break;
+        }
+
+        case 'NORMAL_OCT16':
+          oct16Normals![pointIndex] = dataView.getUint16(attributeByteOffset, true);
+          attributeByteOffset += 2;
+          break;
+
         default:
           attributeByteOffset += getPotreeAttributeByteSize(pointAttribute);
           break;
@@ -104,6 +162,10 @@ export function parsePotreeBin(
     POSITION: {
       value: positions,
       size: 3
+    },
+    POSITION_CARTESIAN: {
+      value: positions,
+      size: 3
     }
   };
 
@@ -112,7 +174,30 @@ export function parsePotreeBin(
       value: colors,
       size: 3
     };
+    const colorAttributeName = resolvedOptions.pointAttributes.find(
+      pointAttribute =>
+        pointAttribute === 'COLOR_PACKED' ||
+        pointAttribute === 'RGBA_PACKED' ||
+        pointAttribute === 'RGB_PACKED'
+    );
+    if (colorAttributeName) {
+      attributes[colorAttributeName] = {value: colors, size: 3};
+    }
   }
+  if (intensities) attributes.INTENSITY = {value: intensities, size: 1};
+  if (classifications) attributes.CLASSIFICATION = {value: classifications, size: 1};
+  if (normalFloats) {
+    attributes.NORMAL_FLOATS = {value: normalFloats, size: 3};
+  }
+  if (normals) {
+    attributes.NORMAL = {value: normals, size: 3};
+  } else if (normalFloats) {
+    attributes.NORMAL = {value: normalFloats, size: 3};
+  }
+  if (sphereMappedNormals) {
+    attributes.NORMAL_SPHEREMAPPED = {value: sphereMappedNormals, size: 2};
+  }
+  if (oct16Normals) attributes.NORMAL_OCT16 = {value: oct16Normals, size: 1};
 
   const mesh: Mesh = {
     loader: 'potree',

--- a/modules/potree/test/parsers/parse-potree-coverage.spec.ts
+++ b/modules/potree/test/parsers/parse-potree-coverage.spec.ts
@@ -59,7 +59,7 @@ describe('Potree parser branches', () => {
     ).toThrow('missing parent node r7');
   });
 
-  test('decodes positions, packed colors, skipped attributes, and Arrow output', () => {
+  test('decodes positions, packed colors, typed attributes, and Arrow output', () => {
     const pointAttributes = [
       'POSITION_CARTESIAN',
       'RGB_PACKED',
@@ -96,6 +96,12 @@ describe('Potree parser branches', () => {
     }) as any;
     expect(Array.from(mesh.attributes.POSITION.value)).toEqual([51, -98, 153]);
     expect(Array.from(mesh.attributes.COLOR_0.value)).toEqual([19, 20, 21]);
+    expect(Array.from(mesh.attributes.INTENSITY.value)).toEqual([6167]);
+    expect(Array.from(mesh.attributes.NORMAL_SPHEREMAPPED.value)).toEqual([25, 26]);
+    expect(Array.from(mesh.attributes.NORMAL_OCT16.value)).toEqual([7195]);
+    expect(Array.from(mesh.attributes.CLASSIFICATION.value)).toEqual([29]);
+    expect(mesh.attributes.NORMAL_FLOATS.value).toHaveLength(3);
+    expect(mesh.attributes.NORMAL.value).toHaveLength(3);
     expect(mesh.header.boundingBox).toEqual([
       [51, -98, 153],
       [51, -98, 153]

--- a/modules/potree/test/potree-source.spec.ts
+++ b/modules/potree/test/potree-source.spec.ts
@@ -99,6 +99,30 @@ test('PotreeSourceLoader#scans ordered Arrow point batches with a global limit',
   expect(batches[0].data.getChild('COLOR_PACKED')).toBeTruthy();
 });
 
+test('PotreeSourceLoader#preserves rows in an empty projection', async () => {
+  const source = PotreeSourceLoader.createDataSource(POTREE_BIN_URL, {});
+  const batches = [];
+
+  for await (const batch of source.scan({columns: [], maximumLevel: 0, limit: 2})) {
+    batches.push(batch);
+  }
+
+  expect(batches.map(batch => batch.length)).toEqual([2]);
+  expect(batches[0].data.numCols).toBe(0);
+});
+
+test('PotreeSourceLoader#does not advertise unsupported datasets as executable', async () => {
+  const source = PotreeSourceLoader.createDataSource(POTREE_BIN_URL, {});
+  await source.initialize();
+  source.metadata!.version = '2.0';
+
+  const metadata = await source.getQueryMetadata();
+  expect(metadata.execution).toMatchObject({status: 'metadata-only'});
+
+  const scan = source.scan();
+  await expect(scan.next()).rejects.toThrow('not supported');
+});
+
 test('PotreeSourceLoader#validates scan batch size and cancellation', async () => {
   const source = PotreeSourceLoader.createDataSource(POTREE_BIN_URL, {});
   const invalidScan = source.scan({batchSize: 0});

--- a/modules/potree/test/potree-source.spec.ts
+++ b/modules/potree/test/potree-source.spec.ts
@@ -2,49 +2,37 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {PotreeSourceLoader} from '@loaders.gl/potree';
 
 const POTREE_BIN_URL = '@loaders.gl/potree/test/data/lion_takanawa';
 
-test('PotreeSourceLoader#initialize', async t => {
-  const DS = PotreeSourceLoader;
-  const source = DS.createDataSource(POTREE_BIN_URL, {});
-  t.notOk(source.isReady);
+test('PotreeSourceLoader#initialize', async () => {
+  const source = PotreeSourceLoader.createDataSource(POTREE_BIN_URL, {});
+  expect(source.isReady).toBe(false);
 
   await source.init();
 
-  t.ok(source.isReady);
-  t.equal(source.metadata?.version, '1.7');
-  t.equal(source.root?.header.childCount, 6);
-  t.ok(source.isSupported());
-  t.end();
+  expect(source.isReady).toBe(true);
+  expect(source.metadata?.version).toBe('1.7');
+  expect(source.root?.header.childCount).toBe(6);
+  expect(source.isSupported()).toBe(true);
 });
 
-test('PotreeSourceLoader#loadNodeContent - loads binary point content', async t => {
-  const DS = PotreeSourceLoader;
-  const source = DS.createDataSource(POTREE_BIN_URL, {});
-
+test('PotreeSourceLoader#loadNodeContent decodes typed point attributes', async () => {
+  const source = PotreeSourceLoader.createDataSource(POTREE_BIN_URL, {});
   await source.initialize();
 
   const nodeContent = await source.loadNodeContent('0');
-  t.ok(nodeContent, 'node content is returned');
-  t.equals(nodeContent?.header?.vertexCount, 4511, 'vertex count matches hierarchy');
-  t.equals(
-    nodeContent?.attributes.positions?.value.length,
-    4511 * 3,
-    'positions are decoded for every point'
-  );
-  t.equals(
-    nodeContent?.attributes.colors?.value.length,
-    4511 * 3,
-    'packed colors are decoded for every point'
-  );
 
-  t.end();
+  expect(nodeContent).toBeTruthy();
+  expect(nodeContent?.header?.vertexCount).toBe(4511);
+  expect(nodeContent?.attributes.positions?.value.length).toBe(4511 * 3);
+  expect(nodeContent?.attributes.colors?.value.length).toBe(4511 * 3);
+  expect(nodeContent?.attributes.NORMAL_SPHEREMAPPED?.value.length).toBe(4511 * 2);
 });
 
-test('PotreeSourceLoader#exposes normalized tile headers and bounds', async t => {
+test('PotreeSourceLoader#exposes normalized tile headers and bounds', async () => {
   const source = PotreeSourceLoader.createDataSource(POTREE_BIN_URL, {});
   await source.initialize();
 
@@ -52,35 +40,72 @@ test('PotreeSourceLoader#exposes normalized tile headers and bounds', async t =>
   const childTiles = await source.getChildren(rootTile);
   const childZero = childTiles.find(tile => tile.id === 'r0');
 
-  t.equal(rootTile.id, 'r', 'root tile id is normalized');
-  t.equal(rootTile.level, 0, 'root tile level is preserved');
-  t.ok(rootTile.boundingVolume.radius > 0, 'root tile has a bounding volume');
-  t.ok(childTiles.length > 0, 'child tile headers are available');
-  t.ok(childZero, 'expected child tile exists');
+  expect(rootTile.id).toBe('r');
+  expect(rootTile.level).toBe(0);
+  expect(rootTile.boundingVolume.radius).toBeGreaterThan(0);
+  expect(childTiles.length).toBeGreaterThan(0);
+  expect(childZero).toBeTruthy();
 
-  if (childZero) {
-    const [rootMinBounds, rootMaxBounds] = rootTile.boundingVolume.cartographicBounds;
-    const [childMinBounds, childMaxBounds] = childZero.boundingVolume.cartographicBounds;
-    t.equal(childMinBounds[0], rootMinBounds[0], 'child 0 keeps lower x bound');
-    t.equal(childMaxBounds[0], (rootMinBounds[0] + rootMaxBounds[0]) / 2, 'child 0 splits x');
-    t.equal(childMinBounds[1], rootMinBounds[1], 'child 0 keeps lower y bound');
-    t.equal(childMaxBounds[1], (rootMinBounds[1] + rootMaxBounds[1]) / 2, 'child 0 splits y');
-    t.equal(childMinBounds[2], rootMinBounds[2], 'child 0 keeps lower z bound');
-    t.equal(childMaxBounds[2], (rootMinBounds[2] + rootMaxBounds[2]) / 2, 'child 0 splits z');
-  }
-
-  t.end();
+  const [rootMinimum, rootMaximum] = rootTile.boundingVolume.cartographicBounds;
+  const [childMinimum, childMaximum] = childZero!.boundingVolume.cartographicBounds;
+  expect(childMinimum[0]).toBe(rootMinimum[0]);
+  expect(childMaximum[0]).toBe((rootMinimum[0] + rootMaximum[0]) / 2);
+  expect(childMinimum[1]).toBe(rootMinimum[1]);
+  expect(childMaximum[1]).toBe((rootMinimum[1] + rootMaximum[1]) / 2);
+  expect(childMinimum[2]).toBe(rootMinimum[2]);
+  expect(childMaximum[2]).toBe((rootMinimum[2] + rootMaximum[2]) / 2);
 });
 
-test('PotreeSourceLoader#exposes point-cloud query metadata', async t => {
+test('PotreeSourceLoader#exposes conclusive point-cloud scan metadata', async () => {
   const source = PotreeSourceLoader.createDataSource(POTREE_BIN_URL, {});
   await source.initialize();
 
   const metadata = await source.getQueryMetadata();
-  t.equal(metadata.queryType, 'point-cloud');
-  t.equal(metadata.execution.status, 'metadata-only');
-  t.ok(metadata.columns.some(column => column.role === 'color'));
-  t.equal(metadata.capabilities.bounds, 'pushdown');
-  t.equal(metadata.spatial?.bounds?.minimum.length, 3);
-  t.end();
+
+  expect(metadata.queryType).toBe('point-cloud');
+  expect(metadata.execution).toEqual({status: 'supported', method: 'scan'});
+  expect(metadata.columns.some(column => column.role === 'color')).toBe(true);
+  expect(metadata.capabilities.bounds).toBe('pushdown');
+  expect(metadata.capabilities.table?.projection).toBe('residual');
+  expect(metadata.spatial?.bounds?.minimum).toHaveLength(3);
+});
+
+test('PotreeSourceLoader#scans ordered Arrow point batches with a global limit', async () => {
+  const source = PotreeSourceLoader.createDataSource(POTREE_BIN_URL, {});
+  const metadata = await source.getQueryMetadata();
+  const bounds = metadata.spatial?.bounds;
+  expect(bounds).toBeTruthy();
+  const batches = [];
+
+  for await (const batch of source.scan({
+    columns: ['POSITION_CARTESIAN', 'COLOR_PACKED'],
+    bounds: {
+      minimum: bounds!.minimum as [number, number, number],
+      maximum: bounds!.maximum as [number, number, number]
+    },
+    maximumLevel: 1,
+    limit: 25,
+    batchSize: 10
+  })) {
+    batches.push(batch);
+  }
+
+  expect(batches.map(batch => batch.length)).toEqual([10, 10, 5]);
+  expect(batches[0].schema.fields.map(field => field.name)).toEqual([
+    'POSITION_CARTESIAN',
+    'COLOR_PACKED'
+  ]);
+  expect(batches[0].data.getChild('POSITION_CARTESIAN')).toBeTruthy();
+  expect(batches[0].data.getChild('COLOR_PACKED')).toBeTruthy();
+});
+
+test('PotreeSourceLoader#validates scan batch size and cancellation', async () => {
+  const source = PotreeSourceLoader.createDataSource(POTREE_BIN_URL, {});
+  const invalidScan = source.scan({batchSize: 0});
+  await expect(invalidScan.next()).rejects.toThrow('batchSize');
+
+  const controller = new AbortController();
+  controller.abort();
+  const cancelledScan = source.scan({signal: controller.signal});
+  await expect(cancelledScan.next()).rejects.toMatchObject({name: 'AbortError'});
 });

--- a/modules/scan/README.md
+++ b/modules/scan/README.md
@@ -67,3 +67,14 @@ point-cloud source names `scan()`. Metadata-only sources must supply a user-faci
 keeps query panels and support documentation from inferring readiness from optimization
 capabilities: a residual operator is fully supported even though it performs more work, while a
 metadata-only source never presents an executable scan.
+
+Point-cloud sources implement `PointCloudScanSource` and can share
+`selectPointCloudScanTiles()`. The planner traverses hierarchy nodes in deterministic breadth-first
+order, prunes by bounds, level, and spacing, and leaves exact point bounds and attribute predicates
+to the physical adapter. COPC and Potree use this contract to emit bounded Arrow batches with one
+global limit.
+
+Raster sources implement `getRaster()` and publish raster-specific capabilities independently of
+table operators. NetCDF supports numeric variable selection and named dimension index or half-open
+range slices. GeoTIFF, OME-TIFF, GeoZarr, and OME-Zarr retain their format-specific window, level,
+channel, and chunk planners behind the same metadata vocabulary.

--- a/modules/scan/src/index.ts
+++ b/modules/scan/src/index.ts
@@ -22,12 +22,21 @@ export type {
   TableQueryOptions
 } from '@loaders.gl/loader-utils';
 
-export {createScanQueryMetadata} from '@loaders.gl/loader-utils';
+export {
+  createScanQueryMetadata,
+  intersectPointCloudBounds,
+  selectPointCloudScanTiles,
+  validatePointCloudQueryOptions
+} from '@loaders.gl/loader-utils';
 export type {
   CreateScanQueryMetadataOptions,
   PointCloudQueryBounds,
   PointCloudQueryCapabilities,
   PointCloudQueryOptions,
+  PointCloudScanChildrenLoader,
+  PointCloudScanReadOptions,
+  PointCloudScanSource,
+  PointCloudScanTile,
   RasterQueryCapabilities,
   RasterQueryOptions,
   ScanBounds,

--- a/modules/schema-utils/src/lib/table/batch-builder/arrow-table-builder.ts
+++ b/modules/schema-utils/src/lib/table/batch-builder/arrow-table-builder.ts
@@ -86,7 +86,7 @@ export class ArrowTableBuilder {
   finishBatch(): ArrowTableBatch | null {
     const arrowRecordBatch = this._getArrowRecordBatch();
     this.arrowBuilders.forEach(builder => builder.finish());
-    if (arrowRecordBatch.numCols === 0) {
+    if (arrowRecordBatch.numCols === 0 && arrowRecordBatch.numRows === 0) {
       return null;
     }
     return {

--- a/modules/schema-utils/test/lib/schema/convert-arrow-schema.spec.ts
+++ b/modules/schema-utils/test/lib/schema/convert-arrow-schema.spec.ts
@@ -128,6 +128,18 @@ test('ArrowTableBuilder#view types round-trip through IPC', () => {
   ]);
 });
 
+test('ArrowTableBuilder#finishBatch preserves rows in a zero-column projection', () => {
+  const builder = new ArrowTableBuilder({fields: [], metadata: {}});
+  builder.addArrayRow([]);
+  builder.addArrayRow([]);
+
+  const batch = builder.finishBatch();
+
+  expect(batch?.length).toBe(2);
+  expect(batch?.data.numRows).toBe(2);
+  expect(batch?.data.numCols).toBe(0);
+});
+
 test.each(
   PRIMITIVE_ARROW_TYPES
 )('%s type round-trips through serialized schema', (_, type, dataType) => {


### PR DESCRIPTION
## Goals

- Conclude the common point-cloud execution tranche for COPC and Potree.
- Conclude the remaining existing-raster tranche by adding NetCDF variable and dimension-slice execution.
- Replace discovery-only roadmap states with conclusive, tested support claims.

## Changes

- Adds a lightweight PointCloudScanSource contract and deterministic breadth-first hierarchy planner with bounds, level, spacing, and cancellation handling.
- Implements COPCTileSource.scan() with decoder projection, hierarchy pruning, exact point bounds, residual predicates, caller-ordered projection, a global limit, and bounded Arrow batches.
- Implements PotreeNodesSource.scan() with the same portable semantics and extends the Potree binary parser to expose typed intensity, classification, color, position, and normal attributes.
- Implements NetCDFSource.getRaster() for numeric variables and named dimension index or half-open range slices, including typed output, no-data metadata, cancellation, and explicit unsupported-operation errors.
- Publishes point-cloud and raster capabilities through shared scan metadata and re-exports the portable contracts from @loaders.gl/scan.
- Updates the scan architecture support matrix, tranche roadmap, scorecard, and module documentation to mark COPC, Potree, and NetCDF as supported.
- Adds planner, source execution, validation, cancellation, parser, projection, batching, and global-limit coverage.

## Verification

- yarn lint fix
- yarn build
- yarn build-workers
- yarn test-node (51 files, 360 passed, 6 skipped)
- yarn test-headless (492 files passed, 1 skipped; 2,984 tests passed, 40 skipped)
- focused scan suites after rebasing (5 files, 56 tests passed)
- yarn test-audit (0 violations)
- browser and Node coverage merge plus yarn test-coverage-check (0 violations)
- website yarn build

This PR is rebased onto current master and contains one implementation commit.
