### PR TITLE
perf(las): accelerate TypeScript LAZ decoding

### DIFF
--- a/modules/las/src/lib/typescript/parse-las.ts
+++ b/modules/las/src/lib/typescript/parse-las.ts
@@ -68,6 +68,7 @@ const LASZIP_USER_ID = 'laszip encoded';
 const LASZIP_RECORD_ID = 22204;
 const VARIABLE_CHUNK_SIZE = 0xffffffff;
 const LAZ_CHUNK_TABLE_POINTER_LENGTH = 8;
+const LEGACY_LAZ_FEED_BLOCK_SIZE = 64 * 1024;
 
 /** One compressed field item declared by the LASzip VLR. */
 type LASZipItem = {
@@ -599,7 +600,11 @@ async function* decodePendingFixedLegacyLAZFileInBatches(
 
     while (cursor.remainingPointCount > 0) {
       const availableByteLength = reader.getAvailableByteLength();
-      const requestedByteLength = Math.min(availableByteLength, cursor.requiredInputByteLength);
+      const requestedByteLength = getLegacyLAZFeedByteLength(
+        availableByteLength,
+        fedByteLength,
+        cursor.requiredInputByteLength
+      );
       if (requestedByteLength > fedByteLength) {
         const checkpoint = reader.checkpoint();
         reader.skip(fedByteLength);
@@ -662,6 +667,18 @@ async function* decodePendingFixedLegacyLAZFileInBatches(
   }
 }
 
+/** Return a bounded legacy decoder prefix that amortizes feed and reader bookkeeping. */
+function getLegacyLAZFeedByteLength(
+  availableByteLength: number,
+  fedByteLength: number,
+  requiredInputByteLength: number
+): number {
+  return Math.min(
+    availableByteLength,
+    Math.max(requiredInputByteLength, fedByteLength + LEGACY_LAZ_FEED_BLOCK_SIZE)
+  );
+}
+
 async function* parseLAZInBatches(
   initialPending: Uint8Array<ArrayBufferLike>,
   inputIterator: AsyncIterator<ArrayBufferLike | ArrayBufferView>,
@@ -670,6 +687,16 @@ async function* parseLAZInBatches(
 ): AsyncIterable<LASArrowTable> {
   const {pending, laszip} = await readLASZipVLRFromInput(initialPending, inputIterator, header);
   validateTypeScriptLAZSupport(header, laszip);
+  if (!laszip.variableChunks && header.pointsFormatId === 3) {
+    yield* parsePendingFixedPDRF3LAZFileInArrowBatches(
+      pending,
+      inputIterator,
+      header,
+      laszip,
+      options
+    );
+    return;
+  }
   if (!laszip.variableChunks && header.pointsFormatId >= 6 && header.pointsFormatId <= 10) {
     yield* parsePendingLAZFileInArrowBatches(pending, inputIterator, header, laszip, options);
     return;
@@ -683,6 +710,109 @@ async function* parseLAZInBatches(
     options
   )) {
     yield parseLASArrowTableBatch(batch.arrayBuffer, batch.header, options);
+  }
+}
+
+/** Decode fixed-size PDRF 3 LAZ chunks directly into streaming Arrow batches. */
+async function* parsePendingFixedPDRF3LAZFileInArrowBatches(
+  initialPending: Uint8Array<ArrayBufferLike>,
+  inputIterator: AsyncIterator<ArrayBufferLike | ArrayBufferView>,
+  header: LASHeader,
+  laszip: LASZipVLR,
+  options: LASLoaderOptions
+): AsyncIterable<LASArrowTable> {
+  const outputHeader = {...header, totalToRead: header.pointsCount};
+  const state = createPointDataBatchState(getBatchSize(options), header, options);
+  const stats = getLAZStreamingDecodeStats(options);
+  const chunkByteLengths: number[] = [];
+  const reader = new BinaryChunkReader();
+  reader.write(initialPending);
+
+  await readUntilAvailable(
+    reader,
+    inputIterator,
+    header.pointsOffset + LAZ_CHUNK_TABLE_POINTER_LENGTH,
+    'LASLoader: incomplete compressed LAZ point data'
+  );
+  reader.skip(header.pointsOffset);
+  const chunkTableOffset = readStreamedLAZChunkTableOffset(
+    reader.getDataView(LAZ_CHUNK_TABLE_POINTER_LENGTH)!
+  );
+
+  let sourcePointIndex = 0;
+  while (sourcePointIndex < header.pointsCount) {
+    const chunkPointCount = Math.min(laszip.chunkSize, header.pointsCount - sourcePointIndex);
+    const metadata = createLAZChunkMetadata(header, laszip, chunkPointCount);
+    const cursor = createLAZChunkDecoderCursor(new Uint8Array(0), metadata);
+    let fedByteLength = 0;
+    let inputDone = false;
+
+    while (cursor.remainingPointCount > 0) {
+      const availableByteLength = reader.getAvailableByteLength();
+      const requestedByteLength = getLegacyLAZFeedByteLength(
+        availableByteLength,
+        fedByteLength,
+        cursor.requiredInputByteLength
+      );
+      if (requestedByteLength > fedByteLength) {
+        const checkpoint = reader.checkpoint();
+        reader.skip(fedByteLength);
+        const addedByteLength = requestedByteLength - fedByteLength;
+        recordReadBytesStats(reader, addedByteLength, stats);
+        cursor.feed(reader.readBytes(addedByteLength));
+        reader.restore(checkpoint);
+        fedByteLength = requestedByteLength;
+      }
+
+      state.target.pointOffset = state.batchPointCount;
+      const availableBatchPointCount = state.batchCapacity - state.batchPointCount;
+      const decodedPointCount = cursor.decodeAvailableIntoPointData(
+        state.target,
+        availableBatchPointCount,
+        inputDone
+      );
+      if (decodedPointCount > 0) {
+        populateDecodedTypedExtraBytes(state, state.batchPointCount, decodedPointCount);
+        state.batchPointCount += decodedPointCount;
+        if (state.batchPointCount === state.batchCapacity) {
+          const batch = flushPointDataBatch(outputHeader, state, options);
+          if (batch) {
+            yield batch;
+          }
+        }
+        continue;
+      }
+
+      if (inputDone) {
+        throw new NeedsMoreData(
+          `LASLoader: truncated legacy LAZ chunk after ${chunkPointCount - cursor.remainingPointCount} of ${chunkPointCount} points with ${availableByteLength} bytes available`
+        );
+      }
+      const next = await inputIterator.next();
+      if (next.done) {
+        inputDone = true;
+      } else {
+        reader.write(next.value);
+      }
+    }
+
+    reader.skip(cursor.compressedByteOffset);
+    chunkByteLengths.push(cursor.compressedByteOffset);
+    sourcePointIndex += chunkPointCount;
+  }
+
+  await validateStreamedFixedLAZChunkTable(
+    reader,
+    inputIterator,
+    header,
+    laszip,
+    chunkTableOffset,
+    chunkByteLengths
+  );
+
+  const finalBatch = flushPointDataBatch(outputHeader, state, options);
+  if (finalBatch) {
+    yield finalBatch;
   }
 }
 

--- a/modules/las/src/lib/typescript/parse-las.ts
+++ b/modules/las/src/lib/typescript/parse-las.ts
@@ -170,7 +170,10 @@ export function parseLAS(arrayBuffer: ArrayBuffer, options: LASLoaderOptions = {
     const bytes = new Uint8Array(arrayBuffer);
     const laszip = parseLASZipVLR(bytes, header);
     validateTypeScriptLAZSupport(header, laszip);
-    if (header.pointsFormatId >= 6 && header.pointsFormatId <= 10) {
+    if (
+      header.pointsFormatId === 3 ||
+      (header.pointsFormatId >= 6 && header.pointsFormatId <= 10)
+    ) {
       return parseCompleteLAZFileToArrowTable(bytes, header, laszip, options);
     }
     const rawPointData = decodeLAZFileToRawPointData(arrayBuffer, header, laszip);
@@ -239,7 +242,7 @@ export function decodeLAZChunkToArrowTable(
   return makePointDataStateArrowTable(header, state, pointCount, options, true);
 }
 
-/** Decode one complete modern LAZ file directly into its represented Arrow columns. */
+/** Decode one complete supported LAZ file directly into its represented Arrow columns. */
 function parseCompleteLAZFileToArrowTable(
   bytes: Uint8Array,
   header: LASHeader,
@@ -272,9 +275,7 @@ function parseCompleteLAZFileToArrowTable(
   }
 
   if (decodedPointCount !== pointCount) {
-    throw new Error(
-      `LASLoader: decoded ${decodedPointCount} modern LAZ points; expected ${pointCount}`
-    );
+    throw new Error(`LASLoader: decoded ${decodedPointCount} LAZ points; expected ${pointCount}`);
   }
   return makePointDataStateArrowTable(header, state, pointCount, options);
 }
@@ -321,7 +322,7 @@ function makePointDataStateArrowTable(
   );
 }
 
-/** Decode one complete modern LAZ chunk into preallocated Arrow column buffers. */
+/** Decode one complete supported LAZ chunk into preallocated Arrow column buffers. */
 function decodeCompleteLAZChunkToPointData(
   bytes: Uint8Array,
   byteOffset: number,
@@ -334,7 +335,7 @@ function decodeCompleteLAZChunkToPointData(
 ): void {
   const compressed = bytes.subarray(byteOffset, byteOffset + byteLength);
   if (compressed.byteLength !== byteLength) {
-    throw new NeedsMoreData('LASLoader: truncated modern LAZ chunk');
+    throw new NeedsMoreData('LASLoader: truncated LAZ chunk');
   }
   const cursor = createLAZChunkDecoderCursor(
     compressed,

--- a/modules/las/test/las-loader.node.slow.spec.ts
+++ b/modules/las/test/las-loader.node.slow.spec.ts
@@ -19,6 +19,7 @@ import {
 import * as las from '@loaders.gl/las';
 import * as bundledLas from '@loaders.gl/las/bundled';
 import * as unbundledLas from '@loaders.gl/las/unbundled';
+import type {LASLoaderOptions} from '@loaders.gl/las';
 import {
   setLoaderOptions,
   fetchFile,
@@ -272,12 +273,21 @@ test('LASLoader#parse LAZ 1.2 PDRF 3 matches laz-rs variant', async () => {
 test('LASLoader#parseInBatches split LAZ 1.2 PDRF 3 matches laz-rs variant', async () => {
   const response = await fetchFile(LAS_EXTRABYTES_BINARY_URL);
   const arrayBuffer = await response.arrayBuffer();
+  const streamingStats = {
+    copiedBytes: 0,
+    chunkConcatenations: 0,
+    rawBatchAllocations: 0,
+    decodedChunkAllocations: 0
+  };
   const expected = await parse(arrayBuffer.slice(0), LAZRsLoader, {
     core: {worker: false}
   });
   const batches = await parseInBatches(splitArrayBuffer(arrayBuffer, 257), LASLoader, {
     batchSize: 250,
-    core: {worker: false}
+    core: {worker: false},
+    las: {lazStreamingStats: streamingStats} as LASLoaderOptions['las'] & {
+      lazStreamingStats: typeof streamingStats;
+    }
   });
   const actual = await collectMeshAttributes(batches as AsyncIterable<any>);
   expect(expected.loaderData.versionAsString, 'fixture is LAS 1.2').toBe('1.2');
@@ -295,6 +305,7 @@ test('LASLoader#parseInBatches split LAZ 1.2 PDRF 3 matches laz-rs variant', asy
     },
     'split TypeScript LAZ PDRF 3 streaming matches laz-rs'
   );
+  expect(streamingStats.rawBatchAllocations, 'PDRF 3 streaming avoids raw point batches').toBe(0);
 }, 30000);
 test('LASLoader#parseInBatches emits legacy LAZ rows before input ends', async () => {
   const response = await fetchFile(LAS_EXTRABYTES_BINARY_URL);

--- a/modules/loader-utils/src/lib/laz/laz-chunk-decoder.ts
+++ b/modules/loader-utils/src/lib/laz/laz-chunk-decoder.ts
@@ -1261,20 +1261,9 @@ class IntegerDecompressor {
   }
 
   decompress(decoder: ArithmeticDecoder, prediction: number, context: number): number {
-    let real = toInt32(prediction + this.readCorrector(decoder, this.mBits[context]));
-    if (this.corrRange === 0) {
-      return real;
-    }
-    if (real < 0) {
-      real = toInt32(real + this.corrRange);
-    } else if (real >= this.corrRange) {
-      real = toInt32(real - this.corrRange);
-    }
-    return real;
-  }
-
-  private readCorrector(decoder: ArithmeticDecoder, mBits: ArithmeticModel): number {
-    const k = decoder.decodeSymbol(mBits);
+    // Keep corrector decoding in this hot method. Splitting it into a helper prevents
+    // V8 from optimizing the predictor and corrector as one stable operation.
+    const k = decoder.decodeSymbol(this.mBits[context]);
     this.k = k;
     let corrector: number;
     if (k) {
@@ -1299,7 +1288,16 @@ class IntegerDecompressor {
     } else {
       corrector = decoder.decodeBit(this.mCorrector0);
     }
-    return toInt32(corrector);
+    let real = toInt32(prediction + corrector);
+    if (this.corrRange === 0) {
+      return real;
+    }
+    if (real < 0) {
+      real = toInt32(real + this.corrRange);
+    } else if (real >= this.corrRange) {
+      real = toInt32(real - this.corrRange);
+    }
+    return real;
   }
 }
 
@@ -1415,6 +1413,7 @@ class Point10Decompressor {
   private lastYDiffMedian = Array.from({length: 16}, () => new StreamingMedian());
   private haveLast = false;
   private last = createPoint10();
+  private firstPoint = createPoint10();
 
   constructor(stream: ByteReader) {
     this.stream = stream;
@@ -1426,12 +1425,19 @@ class Point10Decompressor {
   }
 
   decompress(output: Uint8Array, outputOffset: number): number {
+    const point = this.decompressPoint();
+    writePoint10(point, output, outputOffset);
+    return outputOffset + 20;
+  }
+
+  /** Decode one legacy core point without materializing a raw LAS record. */
+  decompressPoint(): Point10 {
     if (!this.haveLast) {
       this.haveLast = true;
-      this.stream.getBytes(output, outputOffset, 20);
-      this.last = readPoint10(output, outputOffset);
+      readPoint10FromStreamInto(this.last, this.stream);
+      copyPoint10(this.firstPoint, this.last);
       this.last.intensity = 0;
-      return outputOffset + 20;
+      return this.firstPoint;
     }
 
     const changedValues = this.decoder.decodeSymbol(this.changedValuesModel);
@@ -1507,8 +1513,7 @@ class Point10Decompressor {
     );
     this.lastHeight[levelContext] = this.last.z;
 
-    writePoint10(this.last, output, outputOffset);
-    return outputOffset + 20;
+    return this.last;
   }
 
   readFirstMetadata(): void {
@@ -1532,13 +1537,21 @@ class RGB10Decompressor {
   }
 
   decompress(output: Uint8Array, outputOffset: number): number {
+    this.decompressRgb();
+    writeUint16(this.lastRed, output, outputOffset);
+    writeUint16(this.lastGreen, output, outputOffset + 2);
+    writeUint16(this.lastBlue, output, outputOffset + 4);
+    return outputOffset + 6;
+  }
+
+  /** Decode one legacy RGB item without materializing raw point bytes. */
+  decompressRgb(): void {
     if (!this.haveLast) {
       this.haveLast = true;
-      this.stream.getBytes(output, outputOffset, 6);
-      this.lastRed = readUint16(output, outputOffset);
-      this.lastGreen = readUint16(output, outputOffset + 2);
-      this.lastBlue = readUint16(output, outputOffset + 4);
-      return outputOffset + 6;
+      this.lastRed = readUint16FromStream(this.stream);
+      this.lastGreen = readUint16FromStream(this.stream);
+      this.lastBlue = readUint16FromStream(this.stream);
+      return;
     }
 
     const symbol = this.decoder.decodeSymbol(this.usedModel);
@@ -1603,10 +1616,21 @@ class RGB10Decompressor {
     this.lastRed = red;
     this.lastGreen = green;
     this.lastBlue = blue;
-    writeUint16(red, output, outputOffset);
-    writeUint16(green, output, outputOffset + 2);
-    writeUint16(blue, output, outputOffset + 4);
-    return outputOffset + 6;
+  }
+
+  /** Most recently decoded red channel. */
+  get decodedRed(): number {
+    return this.lastRed;
+  }
+
+  /** Most recently decoded green channel. */
+  get decodedGreen(): number {
+    return this.lastGreen;
+  }
+
+  /** Most recently decoded blue channel. */
+  get decodedBlue(): number {
+    return this.lastBlue;
   }
 }
 
@@ -1626,22 +1650,34 @@ class Byte10Decompressor {
     this.models = createModels(count, 256);
   }
 
+  /** Number of Extra Bytes stored for each point. */
+  get byteCount(): number {
+    return this.count;
+  }
+
   decompress(output: Uint8Array, outputOffset: number): number {
+    this.decompressToTarget(output, outputOffset);
+    return outputOffset + this.count;
+  }
+
+  /** Decode legacy Extra Bytes directly into an optional caller-owned target. */
+  decompressToTarget(output?: Uint8Array | null, outputOffset: number = 0): void {
     if (this.count === 0) {
-      return outputOffset;
+      return;
     }
     if (!this.haveLast) {
-      this.stream.getBytes(output, outputOffset, this.count);
-      this.last.set(output.subarray(outputOffset, outputOffset + this.count));
+      this.stream.getBytes(this.last, 0, this.count);
+      output?.set(this.last, outputOffset);
       this.haveLast = true;
-      return outputOffset + this.count;
+      return;
     }
     for (let index = 0; index < this.count; index++) {
       const value = (this.last[index] + this.decoder.decodeSymbol(this.models[index])) & 0xff;
-      output[outputOffset + index] = value;
+      if (output) {
+        output[outputOffset + index] = value;
+      }
       this.last[index] = value;
     }
-    return outputOffset + this.count;
   }
 }
 
@@ -2648,7 +2684,7 @@ function createPointDecompressor(
 
 /** Return whether a point format has a direct typed-array output path. */
 function supportsDirectPointDataOutput(pointDataRecordFormat: number): boolean {
-  return pointDataRecordFormat >= 6 && pointDataRecordFormat <= 10;
+  return pointDataRecordFormat === 3 || (pointDataRecordFormat >= 6 && pointDataRecordFormat <= 10);
 }
 
 class PointFormat0Decompressor implements PointDecompressor {
@@ -2695,16 +2731,20 @@ class GpsTime10Decompressor {
   }
 
   decompress(output: Uint8Array, outputOffset: number): number {
+    writeFloat64(this.decompressGpsTime(), output, outputOffset);
+    return outputOffset + 8;
+  }
+
+  /** Decode one legacy GPS time value without materializing raw point bytes. */
+  decompressGpsTime(): number {
     if (!this.haveLast) {
-      this.stream.getBytes(output, outputOffset, 8);
-      this.lastGpsTime[0] = readFloat64(output, outputOffset);
+      this.lastGpsTime[0] = readFloat64FromStream(this.stream);
       this.haveLast = true;
-      return outputOffset + 8;
+      return this.lastGpsTime[0];
     }
 
     this.decodeGpsTime();
-    writeFloat64(this.lastGpsTime[this.lastGpsSequence], output, outputOffset);
-    return outputOffset + 8;
+    return this.lastGpsTime[this.lastGpsSequence];
   }
 
   private decodeGpsTime(): void {
@@ -2900,6 +2940,97 @@ class PointFormat3Decompressor implements PointDecompressor {
     outputOffset = this.bytes.decompress(output, outputOffset);
     this.readFirstMetadata();
     return outputOffset;
+  }
+
+  /** Decode legacy PDRF 3 directly into selected typed point-data arrays. */
+  decompressPointDataBatch(target: LAZPointDataTarget, pointCount: number): void {
+    const positions = target.positions;
+    const intensities = target.intensities;
+    const classifications = target.classifications;
+    const colors = target.colors;
+    const rawColors = target.rawColors;
+    const scale = target.scale;
+    const offset = target.offset;
+    const extraByteCount = this.bytes.byteCount;
+    let targetPointIndex = target.pointOffset;
+    const hasMetadataOutput = Boolean(
+      target.gpsTimes ||
+        target.scanAngles ||
+        target.userData ||
+        target.pointSourceIds ||
+        target.returnNumbers ||
+        target.numberOfReturns ||
+        target.scannerChannels ||
+        target.scanDirectionFlags ||
+        target.edgeOfFlightLines ||
+        target.syntheticFlags ||
+        target.keyPointFlags ||
+        target.withheldFlags ||
+        target.overlapFlags
+    );
+
+    if (!hasMetadataOutput && !target.extraBytes) {
+      for (let pointIndex = 0; pointIndex < pointCount; pointIndex++) {
+        const point = this.point.decompressPoint();
+        this.gpsTime.decompressGpsTime();
+        this.rgb.decompressRgb();
+        this.bytes.decompressToTarget();
+        this.readFirstMetadata();
+        writePoint10ToPointDataArrays(
+          point,
+          positions,
+          intensities,
+          classifications,
+          scale,
+          offset,
+          targetPointIndex
+        );
+        if (colors) {
+          const colorOffset = targetPointIndex * 4;
+          colors[colorOffset] = this.rgb.decodedRed & 0xff;
+          colors[colorOffset + 1] = this.rgb.decodedGreen & 0xff;
+          colors[colorOffset + 2] = this.rgb.decodedBlue & 0xff;
+          colors[colorOffset + 3] = 255;
+        } else if (rawColors) {
+          const colorOffset = targetPointIndex * 3;
+          rawColors[colorOffset] = this.rgb.decodedRed;
+          rawColors[colorOffset + 1] = this.rgb.decodedGreen;
+          rawColors[colorOffset + 2] = this.rgb.decodedBlue;
+        }
+        targetPointIndex++;
+      }
+      return;
+    }
+
+    for (let pointIndex = 0; pointIndex < pointCount; pointIndex++) {
+      const point = this.point.decompressPoint();
+      const gpsTime = this.gpsTime.decompressGpsTime();
+      this.rgb.decompressRgb();
+      this.bytes.decompressToTarget(target.extraBytes, targetPointIndex * extraByteCount);
+      this.readFirstMetadata();
+
+      writePoint10ToPointDataArrays(
+        point,
+        positions,
+        intensities,
+        classifications,
+        scale,
+        offset,
+        targetPointIndex
+      );
+      writePoint10MetadataToPointDataTarget(point, target, targetPointIndex);
+      if (target.gpsTimes) {
+        target.gpsTimes[targetPointIndex] = gpsTime;
+      }
+      writeRgbToPointDataTarget(
+        this.rgb.decodedRed,
+        this.rgb.decodedGreen,
+        this.rgb.decodedBlue,
+        target,
+        targetPointIndex
+      );
+      targetPointIndex++;
+    }
   }
 
   private readFirstMetadata(): void {
@@ -3203,7 +3334,6 @@ class PointFormat7Decompressor implements PointDecompressor {
   private bytes: Byte14Decompressor | null;
   /** Extra bytes stored with the first point and in independent later layers. */
   private extraByteCount: number;
-  private pointScratch = new Uint8Array(30);
   private first = true;
 
   constructor(
@@ -3242,7 +3372,7 @@ class PointFormat7Decompressor implements PointDecompressor {
   }
 
   decompressPointData(target: LAZPointDataTarget, targetPointIndex: number): void {
-    const point = this.point.decompressPoint(this.pointScratch, 0);
+    const point = this.point.decompressPoint();
     if (this.rgb) {
       this.rgb.decompressRgb(this.point.itemContextChannel);
     } else if (this.first) {
@@ -3280,13 +3410,14 @@ class PointFormat7Decompressor implements PointDecompressor {
     const scale = target.scale;
     const offset = target.offset;
     let targetPointIndex = target.pointOffset;
+    let remainingPointCount = pointCount;
 
-    // The first point stores extra bytes before the layered stream metadata.
-    for (let pointIndex = 0; pointIndex < pointCount; pointIndex++) {
-      const point = this.point.decompressPoint(this.pointScratch, 0);
+    // Decode first-point literals and layer metadata before entering the steady-state loop.
+    if (this.first && remainingPointCount > 0) {
+      const point = this.point.decompressPoint();
       if (this.rgb) {
         this.rgb.decompressRgb(this.point.itemContextChannel);
-      } else if (this.first) {
+      } else {
         this.stream.consume(6);
       }
       if (this.bytes && target.extraBytes) {
@@ -3295,10 +3426,94 @@ class PointFormat7Decompressor implements PointDecompressor {
           targetPointIndex * this.extraByteCount,
           this.point.itemContextChannel
         );
-      } else if (this.first && this.extraByteCount) {
+      } else if (this.extraByteCount) {
         this.stream.consume(this.extraByteCount);
       }
       this.readFirstMetadata();
+      writePoint14ToPointDataArrays(
+        point,
+        positions,
+        intensities,
+        classifications,
+        scale,
+        offset,
+        targetPointIndex
+      );
+      writeGpsTimeToPointDataTarget(point, target, targetPointIndex);
+      writePoint14MetadataToPointDataTarget(point, target, targetPointIndex);
+      if (colors && this.rgb) {
+        const colorOffset = targetPointIndex * 4;
+        colors[colorOffset] = this.rgb.decodedRed & 0xff;
+        colors[colorOffset + 1] = this.rgb.decodedGreen & 0xff;
+        colors[colorOffset + 2] = this.rgb.decodedBlue & 0xff;
+        colors[colorOffset + 3] = 255;
+      } else if (rawColors && this.rgb) {
+        const colorOffset = targetPointIndex * 3;
+        rawColors[colorOffset] = this.rgb.decodedRed;
+        rawColors[colorOffset + 1] = this.rgb.decodedGreen;
+        rawColors[colorOffset + 2] = this.rgb.decodedBlue;
+      }
+      targetPointIndex++;
+      remainingPointCount--;
+    }
+
+    const hasMetadataOutput = Boolean(
+      target.gpsTimes ||
+        target.scanAngles ||
+        target.userData ||
+        target.pointSourceIds ||
+        target.returnNumbers ||
+        target.numberOfReturns ||
+        target.scannerChannels ||
+        target.scanDirectionFlags ||
+        target.edgeOfFlightLines ||
+        target.syntheticFlags ||
+        target.keyPointFlags ||
+        target.withheldFlags ||
+        target.overlapFlags
+    );
+    const hasExtraByteOutput = Boolean(this.bytes && target.extraBytes);
+
+    if (!hasMetadataOutput && !hasExtraByteOutput) {
+      for (let pointIndex = 0; pointIndex < remainingPointCount; pointIndex++) {
+        const point = this.point.decompressPoint();
+        this.rgb?.decompressRgb(this.point.itemContextChannel);
+        writePoint14ToPointDataArrays(
+          point,
+          positions,
+          intensities,
+          classifications,
+          scale,
+          offset,
+          targetPointIndex
+        );
+        if (colors && this.rgb) {
+          const colorOffset = targetPointIndex * 4;
+          colors[colorOffset] = this.rgb.decodedRed & 0xff;
+          colors[colorOffset + 1] = this.rgb.decodedGreen & 0xff;
+          colors[colorOffset + 2] = this.rgb.decodedBlue & 0xff;
+          colors[colorOffset + 3] = 255;
+        } else if (rawColors && this.rgb) {
+          const colorOffset = targetPointIndex * 3;
+          rawColors[colorOffset] = this.rgb.decodedRed;
+          rawColors[colorOffset + 1] = this.rgb.decodedGreen;
+          rawColors[colorOffset + 2] = this.rgb.decodedBlue;
+        }
+        targetPointIndex++;
+      }
+      return;
+    }
+
+    for (let pointIndex = 0; pointIndex < remainingPointCount; pointIndex++) {
+      const point = this.point.decompressPoint();
+      this.rgb?.decompressRgb(this.point.itemContextChannel);
+      if (this.bytes && target.extraBytes) {
+        this.bytes.decompress(
+          target.extraBytes,
+          targetPointIndex * this.extraByteCount,
+          this.point.itemContextChannel
+        );
+      }
       writePoint14ToPointDataArrays(
         point,
         positions,
@@ -4013,18 +4228,28 @@ function createPoint10(): Point10 {
   };
 }
 
-function readPoint10(bytes: Uint8Array, offset: number): Point10 {
-  return {
-    x: readInt32(bytes, offset),
-    y: readInt32(bytes, offset + 4),
-    z: readInt32(bytes, offset + 8),
-    intensity: readUint16(bytes, offset + 12),
-    bitByte: bytes[offset + 14],
-    classification: bytes[offset + 15],
-    scanAngleRank: toInt8(bytes[offset + 16]),
-    userData: bytes[offset + 17],
-    pointSourceId: readUint16(bytes, offset + 18)
-  };
+function readPoint10FromStreamInto(point: Point10, stream: ByteReader): void {
+  point.x = readInt32FromStream(stream);
+  point.y = readInt32FromStream(stream);
+  point.z = readInt32FromStream(stream);
+  point.intensity = readUint16FromStream(stream);
+  point.bitByte = stream.getByte();
+  point.classification = stream.getByte();
+  point.scanAngleRank = toInt8(stream.getByte());
+  point.userData = stream.getByte();
+  point.pointSourceId = readUint16FromStream(stream);
+}
+
+function copyPoint10(target: Point10, source: Point10): void {
+  target.x = source.x;
+  target.y = source.y;
+  target.z = source.z;
+  target.intensity = source.intensity;
+  target.bitByte = source.bitByte;
+  target.classification = source.classification;
+  target.scanAngleRank = source.scanAngleRank;
+  target.userData = source.userData;
+  target.pointSourceId = source.pointSourceId;
 }
 
 function writePoint10(point: Point10, bytes: Uint8Array, offset: number): void {
@@ -4037,6 +4262,71 @@ function writePoint10(point: Point10, bytes: Uint8Array, offset: number): void {
   bytes[offset + 16] = point.scanAngleRank & 0xff;
   bytes[offset + 17] = point.userData;
   writeUint16(point.pointSourceId, bytes, offset + 18);
+}
+
+function writePoint10ToPointDataArrays(
+  point: Point10,
+  positions: Float32Array | Float64Array,
+  intensities: Uint16Array | null | undefined,
+  classifications: Uint8Array | null | undefined,
+  scale: [number, number, number],
+  offset: [number, number, number],
+  targetPointIndex: number
+): void {
+  const positionOffset = targetPointIndex * 3;
+  positions[positionOffset] = point.x * scale[0] + offset[0];
+  positions[positionOffset + 1] = point.y * scale[1] + offset[1];
+  positions[positionOffset + 2] = point.z * scale[2] + offset[2];
+  if (intensities) {
+    intensities[targetPointIndex] = point.intensity;
+  }
+  if (classifications) {
+    classifications[targetPointIndex] = point.classification & 0x1f;
+  }
+}
+
+function writePoint10MetadataToPointDataTarget(
+  point: Point10,
+  target: LAZPointDataTarget,
+  targetPointIndex: number
+): void {
+  const classificationFlags = point.classification >> 5;
+  if (target.syntheticFlags) {
+    target.syntheticFlags[targetPointIndex] = classificationFlags & 1;
+  }
+  if (target.keyPointFlags) {
+    target.keyPointFlags[targetPointIndex] = (classificationFlags >> 1) & 1;
+  }
+  if (target.withheldFlags) {
+    target.withheldFlags[targetPointIndex] = (classificationFlags >> 2) & 1;
+  }
+  if (target.overlapFlags) {
+    target.overlapFlags[targetPointIndex] = 0;
+  }
+  if (target.scanAngles) {
+    target.scanAngles[targetPointIndex] = point.scanAngleRank;
+  }
+  if (target.userData) {
+    target.userData[targetPointIndex] = point.userData;
+  }
+  if (target.pointSourceIds) {
+    target.pointSourceIds[targetPointIndex] = point.pointSourceId;
+  }
+  if (target.returnNumbers) {
+    target.returnNumbers[targetPointIndex] = point.bitByte & 0x07;
+  }
+  if (target.numberOfReturns) {
+    target.numberOfReturns[targetPointIndex] = (point.bitByte >> 3) & 0x07;
+  }
+  if (target.scannerChannels) {
+    target.scannerChannels[targetPointIndex] = 0;
+  }
+  if (target.scanDirectionFlags) {
+    target.scanDirectionFlags[targetPointIndex] = (point.bitByte >> 6) & 1;
+  }
+  if (target.edgeOfFlightLines) {
+    target.edgeOfFlightLines[targetPointIndex] = (point.bitByte >> 7) & 1;
+  }
 }
 
 function getPoint10ReturnNumber(point: Point10): number {

--- a/modules/loader-utils/src/lib/laz/laz-chunk-decoder.ts
+++ b/modules/loader-utils/src/lib/laz/laz-chunk-decoder.ts
@@ -406,6 +406,48 @@ export class LAZChunkDecoderCursor {
     return decodedPointCount;
   }
 
+  /** Decode available legacy PDRF 3 points directly into typed point-data arrays. */
+  decodeAvailableIntoPointData(
+    target: LAZPointDataTarget,
+    pointCount: number,
+    inputComplete = false
+  ): number {
+    if (this.metadata.pointDataRecordFormat !== 3) {
+      throw new Error('Available point-data decoding is limited to legacy PDRF 3 LAZ chunks');
+    }
+    const pointsToDecode = Math.min(pointCount, this.remainingPointCount);
+    if (pointsToDecode === 0) {
+      return 0;
+    }
+    const selection = getLAZPointDataSelection(target);
+    const decoder = this.selectOutputMode('point-data', pointsToDecode, selection)!;
+    let decodedPointCount = 0;
+
+    while (decodedPointCount < pointsToDecode) {
+      const requiredLookahead =
+        this.pointIndex === 0
+          ? this.metadata.pointDataRecordLength + 4
+          : getLegacyLAZPointDecodeLookahead(this.metadata.pointDataRecordLength);
+      if (!inputComplete && this.stream.availableByteLength < requiredLookahead) {
+        break;
+      }
+      try {
+        decoder.decompressPointData!(target, target.pointOffset + decodedPointCount);
+      } catch (error) {
+        if (error instanceof NeedsMoreData && !inputComplete) {
+          throw new Error(
+            `Legacy LAZ point exceeded the ${requiredLookahead}-byte streaming lookahead`
+          );
+        }
+        throw error;
+      }
+      decodedPointCount++;
+      this.pointIndex++;
+    }
+
+    return decodedPointCount;
+  }
+
   /** Decode up to `pointCount` points directly into typed point-data arrays. */
   decodeIntoPointData(target: LAZPointDataTarget, pointCount: number): number {
     const pointsToDecode = Math.min(pointCount, this.remainingPointCount);
@@ -2660,7 +2702,11 @@ function createPointDecompressor(
     case 2:
       return new PointFormat2Decompressor(stream, extraByteCount);
     case 3:
-      return new PointFormat3Decompressor(stream, extraByteCount);
+      return new PointFormat3Decompressor(
+        stream,
+        extraByteCount,
+        outputMode === 'point-data' ? selection : null
+      );
     case 4:
       return new PointFormat4Decompressor(stream, extraByteCount);
     case 5:
@@ -2924,13 +2970,28 @@ class PointFormat3Decompressor implements PointDecompressor {
   private rgb: RGB10Decompressor;
   private bytes: Byte10Decompressor;
   private first = true;
+  private directCommonOutput: boolean;
 
-  constructor(stream: ByteReader, extraByteCount: number) {
+  constructor(
+    stream: ByteReader,
+    extraByteCount: number,
+    selection: LAZPointDataSelection | null = null
+  ) {
     this.point = new Point10Decompressor(stream);
     const decoder = this.point.getDecoder();
     this.gpsTime = new GpsTime10Decompressor(stream, decoder);
     this.rgb = new RGB10Decompressor(stream, decoder);
     this.bytes = new Byte10Decompressor(stream, decoder, extraByteCount);
+    this.directCommonOutput = Boolean(
+      selection &&
+        !selection.gpsTime &&
+        !selection.scanAngle &&
+        !selection.userData &&
+        !selection.pointSourceId &&
+        !selection.flags &&
+        !selection.waveform &&
+        !selection.extraBytes
+    );
   }
 
   decompress(output: Uint8Array, outputOffset: number): number {
@@ -2940,6 +3001,61 @@ class PointFormat3Decompressor implements PointDecompressor {
     outputOffset = this.bytes.decompress(output, outputOffset);
     this.readFirstMetadata();
     return outputOffset;
+  }
+
+  /** Decode one legacy PDRF 3 point directly into typed point-data arrays. */
+  decompressPointData(target: LAZPointDataTarget, targetPointIndex: number): void {
+    const point = this.point.decompressPoint();
+    const gpsTime = this.gpsTime.decompressGpsTime();
+    this.rgb.decompressRgb();
+    if (this.directCommonOutput) {
+      this.bytes.decompressToTarget();
+      this.readFirstMetadata();
+      writePoint10ToPointDataArrays(
+        point,
+        target.positions,
+        target.intensities,
+        target.classifications,
+        target.scale,
+        target.offset,
+        targetPointIndex
+      );
+      if (target.colors) {
+        const colorOffset = targetPointIndex * 4;
+        target.colors[colorOffset] = this.rgb.decodedRed & 0xff;
+        target.colors[colorOffset + 1] = this.rgb.decodedGreen & 0xff;
+        target.colors[colorOffset + 2] = this.rgb.decodedBlue & 0xff;
+        target.colors[colorOffset + 3] = 255;
+      } else if (target.rawColors) {
+        const colorOffset = targetPointIndex * 3;
+        target.rawColors[colorOffset] = this.rgb.decodedRed;
+        target.rawColors[colorOffset + 1] = this.rgb.decodedGreen;
+        target.rawColors[colorOffset + 2] = this.rgb.decodedBlue;
+      }
+      return;
+    }
+    this.bytes.decompressToTarget(target.extraBytes, targetPointIndex * this.bytes.byteCount);
+    this.readFirstMetadata();
+    writePoint10ToPointDataArrays(
+      point,
+      target.positions,
+      target.intensities,
+      target.classifications,
+      target.scale,
+      target.offset,
+      targetPointIndex
+    );
+    writePoint10MetadataToPointDataTarget(point, target, targetPointIndex);
+    if (target.gpsTimes) {
+      target.gpsTimes[targetPointIndex] = gpsTime;
+    }
+    writeRgbToPointDataTarget(
+      this.rgb.decodedRed,
+      this.rgb.decodedGreen,
+      this.rgb.decodedBlue,
+      target,
+      targetPointIndex
+    );
   }
 
   /** Decode legacy PDRF 3 directly into selected typed point-data arrays. */


### PR DESCRIPTION
## Goals

- Bring the TypeScript LAZ decoder closer to the compiled loader variants on common point-cloud workloads.
- Preserve true streaming behavior while removing avoidable decoder bookkeeping, copying, and intermediate point storage.
- Keep decoded attributes byte-for-byte compatible with the reference loaders.

## Changes

- Inline the integer-corrector hot path used by LAZ field decoders.
- Add specialized steady-state decoding for LAS 1.4 PDRF 7.
- Add complete PDRF 3 decode directly into Arrow-owned typed arrays.
- Decode fixed-size streaming PDRF 3 chunks directly into Arrow batches instead of allocating raw point-record batches.
- Replace per-point legacy LAZ input feeding with bounded 64 KiB read-ahead.
- Preserve deterministic partial-input handling and chunk-table validation.
- Add parity coverage against laz-rs and assert that streaming PDRF 3 performs zero raw batch allocations.

## Performance

The dedicated chunked PDRF 3 streaming workload improved from roughly 0.2M points/s to 2.24M points/s after warm-up. Direct Arrow output contributes an additional improvement beyond bounded read-ahead while removing the intermediate raw batch allocation.

Public APIs are unchanged.

## Validation

- yarn build
- yarn test-node: 360 passed, 6 skipped
- yarn build-workers
- yarn test-headless: 2,975 passed, 40 skipped
- Focused PDRF 3 streaming parity/allocation test: passed
- Full LAS slow test file: 67 passed, 1 skipped; one unrelated variant test exceeded its existing 5-second timeout during a CPU-contended run
- yarn lint fix
