### PR TITLE
fix(3d-tiles): correct schema-aware metadata bounds

### DIFF
--- a/docs/modules/3d-tiles/formats/3d-tiles.md
+++ b/docs/modules/3d-tiles/formats/3d-tiles.md
@@ -58,7 +58,7 @@ provides a visual implementation for that feature.
 | `EXT_mesh_features` | [x] | Feature identifiers are preserved for supported glTF payloads. |
 | `EXT_structural_metadata` | [x] | Schema and property-table metadata are exposed where present. |
 | Metadata topology preservation | [x] | Schema, groups, tileset/tile/content entities, and implicit-subtree references are retained for application-level interpretation. Value/class decoding is not included. |
-| Metadata-derived bounding volumes | [ ] | `TILE_BOUNDING_*` and `CONTENT_BOUNDING_*` semantics are planned. |
+| Metadata-derived bounding volumes | [x] | Direct numeric `TILE_BOUNDING_*` and `CONTENT_BOUNDING_*` semantic arrays are normalized; property-table value decoding remains application-owned. |
 | Styling expressions | [ ] | Rendering-side style evaluation is not provided by this module. |
 
 ## How to read the matrix
@@ -108,7 +108,7 @@ called out explicitly rather than being counted as parser support.
 | Extension | `3DTILES_batch_table_hierarchy` | [~] | Parse validation | Parser scaffolding and boundary validation exist; complete hierarchy semantics remain planned. |
 | Metadata | `EXT_mesh_features` | [x] | Parse + preserve | Feature identifiers are retained for supported glTF payloads. |
 | Metadata | `EXT_structural_metadata` | [x] | Parse + preserve | Schema, property tables, groups, and entity links are exposed; value decoding is application-side. |
-| Metadata | Metadata-derived bounding volumes | [ ] | Culling | `TILE_BOUNDING_*` and `CONTENT_BOUNDING_*` selection is planned. |
+| Metadata | Metadata-derived bounding volumes | [x] | Culling | Direct numeric semantic arrays are normalized into tile/content volumes; property-table decoding remains application-owned. |
 | Renderer | Styling expressions | [ ] | Renderer | Style evaluation and visual feature selection are outside this loader/runtime package. |
 | Renderer | GPU upload and draw policy | [ ] | Renderer | Applications such as deck.gl or Cesium decide how normalized payloads become draw calls. |
 

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -8,7 +8,7 @@
 ### 3D Tiles
 
 - Expose tileset metadata topology (`schema`, `schemaUri`, `groups`, `metadata`, and `statistics`) on the shared `Tileset3D` runtime for application inspection.
-- Normalize direct numeric `TILE_BOUNDING_*` and `CONTENT_BOUNDING_*` metadata semantics into traversal-ready bounding volumes while preserving explicit volume precedence.
+- Normalize direct numeric `TILE_BOUNDING_*` and `CONTENT_BOUNDING_*` metadata semantics into traversal-ready bounding volumes with metadata semantics taking precedence over ordinary header volumes.
 
 
 Release Date: 2026

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -5,6 +5,12 @@
 
 ## v5.0 (In Development)
 
+### 3D Tiles
+
+- Expose tileset metadata topology (`schema`, `schemaUri`, `groups`, `metadata`, and `statistics`) on the shared `Tileset3D` runtime for application inspection.
+- Normalize direct numeric `TILE_BOUNDING_*` and `CONTENT_BOUNDING_*` metadata semantics into traversal-ready bounding volumes while preserving explicit volume precedence.
+
+
 Release Date: 2026
 
 **Highlights**

--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile-header.ts
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile-header.ts
@@ -275,7 +275,12 @@ export async function normalizeTileHeaders(
           resourceResolver
         );
       } else {
-        childHeaderPostprocessed = normalizeTileData(childHeader, basePath, resourceResolver, tileset.schema);
+        childHeaderPostprocessed = normalizeTileData(
+          childHeader,
+          basePath,
+          resourceResolver,
+          tileset.schema
+        );
       }
 
       if (childHeaderPostprocessed) {
@@ -320,7 +325,11 @@ export async function normalizeImplicitTileHeaders(
     content: tile.content,
     viewerRequestVolume: normalizeS2BoundingVolume(tile.viewerRequestVolume)
   };
-  const normalizedContents = normalizeTileContents(normalizedTile.content, resourceResolver, tileset.schema);
+  const normalizedContents = normalizeTileContents(
+    normalizedTile.content,
+    resourceResolver,
+    tileset.schema
+  );
   const maximumLevel = Number.isFinite(implicitTilingExtension.availableLevels)
     ? implicitTilingExtension.availableLevels - 1
     : implicitTilingExtension.maximumLevel;

--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile-header.ts
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile-header.ts
@@ -60,7 +60,8 @@ function getTileType(tile: Tiles3DTileJSON, tileContentUrl: string = ''): TILE_T
  */
 function normalizeTileContents(
   content: Tiles3DTileJSON['content'],
-  resourceResolver: CachedUriResolver
+  resourceResolver: CachedUriResolver,
+  schema?: Tiles3DTilesetJSON['schema']
 ): {content?: Tiles3DTileJSONPostprocessed['content']; contentUrls: string[]} {
   if (!content) {
     return {content: undefined, contentUrls: []};
@@ -70,7 +71,9 @@ function normalizeTileContents(
   const normalizedContents = contentEntries.map(contentEntry => {
     return {
       ...contentEntry,
-      boundingVolume: normalizeS2BoundingVolume(contentEntry.boundingVolume),
+      boundingVolume: normalizeS2BoundingVolume(
+        getMetadataBoundingVolume(contentEntry.metadata, 'CONTENT', schema) || contentEntry.boundingVolume
+      ),
       uri: contentEntry.uri,
       url: contentEntry.url
     };
@@ -111,14 +114,17 @@ function getRefine(refine?: string): TILE_REFINEMENT | string | undefined {
 export function normalizeTileData(
   tile: Tiles3DTileJSON | null,
   basePath: string,
-  resourceResolver: CachedUriResolver = new CachedUriResolver(basePath)
+  resourceResolver: CachedUriResolver = new CachedUriResolver(basePath),
+  schema?: Tiles3DTilesetJSON['schema']
 ): Tiles3DTileJSONPostprocessed | null {
   if (!tile) {
     return null;
   }
-  const normalizedContents = normalizeTileContents(tile.content, resourceResolver);
+  const normalizedContents = normalizeTileContents(tile.content, resourceResolver, schema);
   const tileContentUrl = normalizedContents.contentUrls[0];
-  const boundingVolume = normalizeS2BoundingVolume(tile.boundingVolume) as Tile3DBoundingVolume;
+  const boundingVolume = normalizeS2BoundingVolume(
+    getMetadataBoundingVolume(tile.metadata, 'TILE', schema) || tile.boundingVolume
+  ) as Tile3DBoundingVolume;
   const viewerRequestVolume = normalizeS2BoundingVolume(tile.viewerRequestVolume);
   const tilePostprocessed: Tiles3DTileJSONPostprocessed = {
     ...tile,
@@ -136,6 +142,42 @@ export function normalizeTileData(
   };
 
   return tilePostprocessed;
+}
+
+/**
+ * Resolves a metadata-derived tile or content bounding volume from the declared class schema.
+ *
+ * Metadata property identifiers are application-defined; the semantic lives on the matching class
+ * property definition. Only already-materialized numeric arrays are handled here, while property
+ * table decoding remains the responsibility of the metadata consumer.
+ *
+ * @param metadata - Tile or content metadata entity.
+ * @param scope - Semantic scope, either `TILE` or `CONTENT`.
+ * @param schema - Inline tileset metadata schema, when available.
+ * @returns A source bounding volume, or `undefined` when no matching semantic is present.
+ */
+function getMetadataBoundingVolume(
+  metadata: Tiles3DTileJSON['metadata'] | undefined,
+  scope: 'TILE' | 'CONTENT',
+  schema?: Tiles3DTilesetJSON['schema']
+): Tile3DBoundingVolume | undefined {
+  const classDefinition = metadata?.class && schema?.classes?.[metadata.class];
+  const propertyDefinitions = (
+    classDefinition as {properties?: Record<string, {semantic?: string}>} | undefined
+  )?.properties;
+  for (const [propertyId, value] of Object.entries(metadata?.properties || {})) {
+    const semantic = propertyDefinitions?.[propertyId]?.semantic;
+    if (!semantic?.startsWith(`${scope}_BOUNDING_`) || !Array.isArray(value)) {
+      continue;
+    }
+    if (!value.every(component => typeof component === 'number')) {
+      continue;
+    }
+    if (semantic === `${scope}_BOUNDING_BOX` && value.length === 12) return {box: value};
+    if (semantic === `${scope}_BOUNDING_REGION` && value.length === 6) return {region: value};
+    if (semantic === `${scope}_BOUNDING_SPHERE` && value.length === 4) return {sphere: value};
+  }
+  return undefined;
 }
 
 /**
@@ -202,7 +244,7 @@ export async function normalizeTileHeaders(
       resourceResolver
     );
   } else {
-    root = normalizeTileData(tileset.root, basePath, resourceResolver);
+    root = normalizeTileData(tileset.root, basePath, resourceResolver, tileset.schema);
   }
 
   const stack: any[] = [];
@@ -226,7 +268,7 @@ export async function normalizeTileHeaders(
           resourceResolver
         );
       } else {
-        childHeaderPostprocessed = normalizeTileData(childHeader, basePath, resourceResolver);
+        childHeaderPostprocessed = normalizeTileData(childHeader, basePath, resourceResolver, tileset.schema);
       }
 
       if (childHeaderPostprocessed) {
@@ -265,7 +307,9 @@ export async function normalizeImplicitTileHeaders(
   void context;
   const normalizedTile: Tiles3DTileJSON = {
     ...tile,
-    boundingVolume: normalizeS2BoundingVolume(tile.boundingVolume) as Tile3DBoundingVolume,
+    boundingVolume: normalizeS2BoundingVolume(
+      tile.boundingVolume || getMetadataBoundingVolume(tile.metadata, 'TILE')
+    ) as Tile3DBoundingVolume,
     content: tile.content,
     viewerRequestVolume: normalizeS2BoundingVolume(tile.viewerRequestVolume)
   };

--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile-header.ts
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile-header.ts
@@ -315,12 +315,12 @@ export async function normalizeImplicitTileHeaders(
   const normalizedTile: Tiles3DTileJSON = {
     ...tile,
     boundingVolume: normalizeS2BoundingVolume(
-      tile.boundingVolume || getMetadataBoundingVolume(tile.metadata, 'TILE')
+      getMetadataBoundingVolume(tile.metadata, 'TILE', tileset.schema) || tile.boundingVolume
     ) as Tile3DBoundingVolume,
     content: tile.content,
     viewerRequestVolume: normalizeS2BoundingVolume(tile.viewerRequestVolume)
   };
-  const normalizedContents = normalizeTileContents(normalizedTile.content, resourceResolver);
+  const normalizedContents = normalizeTileContents(normalizedTile.content, resourceResolver, tileset.schema);
   const maximumLevel = Number.isFinite(implicitTilingExtension.availableLevels)
     ? implicitTilingExtension.availableLevels - 1
     : implicitTilingExtension.maximumLevel;

--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile-header.ts
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile-header.ts
@@ -72,7 +72,8 @@ function normalizeTileContents(
     return {
       ...contentEntry,
       boundingVolume: normalizeS2BoundingVolume(
-        getMetadataBoundingVolume(contentEntry.metadata, 'CONTENT', schema) || contentEntry.boundingVolume
+        getMetadataBoundingVolume(contentEntry.metadata, 'CONTENT', schema) ||
+          contentEntry.boundingVolume
       ),
       uri: contentEntry.uri,
       url: contentEntry.url

--- a/modules/3d-tiles/src/lib/parsers/parse-3d-tile-header.ts
+++ b/modules/3d-tiles/src/lib/parsers/parse-3d-tile-header.ts
@@ -174,9 +174,15 @@ function getMetadataBoundingVolume(
     if (!value.every(component => typeof component === 'number')) {
       continue;
     }
-    if (semantic === `${scope}_BOUNDING_BOX` && value.length === 12) return {box: value};
-    if (semantic === `${scope}_BOUNDING_REGION` && value.length === 6) return {region: value};
-    if (semantic === `${scope}_BOUNDING_SPHERE` && value.length === 4) return {sphere: value};
+    if (semantic === `${scope}_BOUNDING_BOX` && value.length === 12) {
+      return {box: value};
+    }
+    if (semantic === `${scope}_BOUNDING_REGION` && value.length === 6) {
+      return {region: value};
+    }
+    if (semantic === `${scope}_BOUNDING_SPHERE` && value.length === 4) {
+      return {sphere: value};
+    }
   }
   return undefined;
 }

--- a/modules/3d-tiles/test/lib/parsers/parse-3d-tile-header.spec.ts
+++ b/modules/3d-tiles/test/lib/parsers/parse-3d-tile-header.spec.ts
@@ -48,19 +48,20 @@ test('normalizeTileData#corectly resolves different styles of URLs', async () =>
 
 
 test('normalizeTileData#derives metadata bounding volume semantics', () => {
-  const normalizedTile = normalizeTileData(
-    {
-      metadata: {class: 'tile', properties: {bounds: [1, 2, 3, 4]}},
-      content: {uri: 'tile.b3dm', metadata: {class: 'content', properties: {bounds: [0, 0, 1, 1, 0, 10]}}},
-      schema: {
-        classes: {
-          tile: {properties: {bounds: {semantic: 'TILE_BOUNDING_SPHERE'}}},
-          content: {properties: {bounds: {semantic: 'CONTENT_BOUNDING_REGION'}}}
-        }
-      }
-    } as any,
-    'https://example.com/tiles'
-  );
+  const tile = {
+    metadata: {class: 'tile', properties: {bounds: [1, 2, 3, 4]}},
+    content: {
+      uri: 'tile.b3dm',
+      metadata: {class: 'content', properties: {bounds: [0, 0, 1, 1, 0, 10]}}
+    }
+  } as any;
+  const schema = {
+    classes: {
+      tile: {properties: {bounds: {semantic: 'TILE_BOUNDING_SPHERE'}}},
+      content: {properties: {bounds: {semantic: 'CONTENT_BOUNDING_REGION'}}}
+    }
+  } as any;
+  const normalizedTile = normalizeTileData(tile, 'https://example.com/tiles', undefined, schema);
   expect(normalizedTile?.boundingVolume).toEqual({sphere: [1, 2, 3, 4]});
   expect((normalizedTile?.content as any)?.boundingVolume).toEqual({
     region: [0, 0, 1, 1, 0, 10]

--- a/modules/3d-tiles/test/lib/parsers/parse-3d-tile-header.spec.ts
+++ b/modules/3d-tiles/test/lib/parsers/parse-3d-tile-header.spec.ts
@@ -46,7 +46,6 @@ test('normalizeTileData#corectly resolves different styles of URLs', async () =>
   }
 });
 
-
 test('normalizeTileData#derives metadata bounding volume semantics', () => {
   const tile = {
     metadata: {class: 'tile', properties: {bounds: [1, 2, 3, 4]}},

--- a/modules/3d-tiles/test/lib/parsers/parse-3d-tile-header.spec.ts
+++ b/modules/3d-tiles/test/lib/parsers/parse-3d-tile-header.spec.ts
@@ -50,8 +50,14 @@ test('normalizeTileData#corectly resolves different styles of URLs', async () =>
 test('normalizeTileData#derives metadata bounding volume semantics', () => {
   const normalizedTile = normalizeTileData(
     {
-      metadata: {properties: {TILE_BOUNDING_SPHERE: [1, 2, 3, 4]}},
-      content: {uri: 'tile.b3dm', metadata: {properties: {CONTENT_BOUNDING_REGION: [0, 0, 1, 1, 0, 10]}}}
+      metadata: {class: 'tile', properties: {bounds: [1, 2, 3, 4]}},
+      content: {uri: 'tile.b3dm', metadata: {class: 'content', properties: {bounds: [0, 0, 1, 1, 0, 10]}}},
+      schema: {
+        classes: {
+          tile: {properties: {bounds: {semantic: 'TILE_BOUNDING_SPHERE'}}},
+          content: {properties: {bounds: {semantic: 'CONTENT_BOUNDING_REGION'}}}
+        }
+      }
     } as any,
     'https://example.com/tiles'
   );

--- a/modules/3d-tiles/test/lib/parsers/parse-3d-tile-header.spec.ts
+++ b/modules/3d-tiles/test/lib/parsers/parse-3d-tile-header.spec.ts
@@ -45,3 +45,18 @@ test('normalizeTileData#corectly resolves different styles of URLs', async () =>
     expect(normalizedTile?.contentUrl, 'url should be resolved correctly').toBe(resolvedUrl);
   }
 });
+
+
+test('normalizeTileData#derives metadata bounding volume semantics', () => {
+  const normalizedTile = normalizeTileData(
+    {
+      metadata: {properties: {TILE_BOUNDING_SPHERE: [1, 2, 3, 4]}},
+      content: {uri: 'tile.b3dm', metadata: {properties: {CONTENT_BOUNDING_REGION: [0, 0, 1, 1, 0, 10]}}}
+    } as any,
+    'https://example.com/tiles'
+  );
+  expect(normalizedTile?.boundingVolume).toEqual({sphere: [1, 2, 3, 4]});
+  expect((normalizedTile?.content as any)?.boundingVolume).toEqual({
+    region: [0, 0, 1, 1, 0, 10]
+  });
+});

--- a/modules/tiles/src/tileset-3d/common/tileset-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tileset-3d.ts
@@ -323,6 +323,16 @@ export class Tileset3D {
   root: Tile3D | null = null;
   roots: Record<string, Tile3D> = {};
   asset: Record<string, any> = {};
+  /** Inline metadata schema declared by the source tileset, when present. */
+  schema: Record<string, any> | null = null;
+  /** External metadata schema URI declared by the source tileset, when present. */
+  schemaUri: string | null = null;
+  /** Metadata groups declared by the source tileset, in source order. */
+  groups: Array<Record<string, any>> = [];
+  /** Tileset-wide metadata entity, preserved without property-table decoding. */
+  metadata: Record<string, any> | null = null;
+  /** Tileset statistics metadata, preserved for application-level inspection. */
+  statistics: unknown = null;
 
   description = '';
   properties: any;
@@ -1061,6 +1071,12 @@ export class Tileset3D {
     this.refine = metadata.refine;
     this.contentFormats = this.source.contentFormats;
     this.asset = this.source.asset || this.asset;
+    const tileset = metadata.tileset as Record<string, any>;
+    this.schema = tileset.schema || null;
+    this.schemaUri = tileset.schemaUri || null;
+    this.groups = tileset.groups || [];
+    this.metadata = tileset.metadata || null;
+    this.statistics = tileset.statistics ?? null;
     this.properties = this.source.properties ?? this.properties;
     this.extras = this.source.extras ?? this.extras;
     if (this.options.attributions?.length) {


### PR DESCRIPTION
## Goals

Correct the metadata tranche that landed in #3827, addressing review feedback and the lint failure.

## Changes

- Resolve `TILE_BOUNDING_*` and `CONTENT_BOUNDING_*` through the declared metadata class schema rather than property-name guesses.
- Give metadata-derived bounds precedence over ordinary header bounds, as required by the semantic contract.
- Preserve explicit S2 normalization and transform handling.
- Format the new parser test to satisfy repository lint.

## Validation

The previous CI run showed the TypeScript build passing; only lint failed on the added test. This follow-up is rebased on latest `master` (`3d2ffda`) and includes the corrected schema-aware implementation and formatting.

Follows up on #3827.