### PR TITLE
perf(csv): accelerate Arrow parsing hot paths

### DIFF
--- a/modules/csv/src/csv-arrow-table-parser.ts
+++ b/modules/csv/src/csv-arrow-table-parser.ts
@@ -22,6 +22,7 @@ import * as arrow from 'apache-arrow';
 import type {CSVLoaderOptions} from './csv-loader-options';
 import {CSV_LOADER_OPTIONS} from './csv-loader-options';
 import {CSVLoaderWithParser} from './csv-loader-with-parser';
+import {copyByteRange} from './lib/utils/copy-byte-range';
 import {
   parseRawArrowCSVInBatches,
   parseRawArrowCSVTable,
@@ -149,10 +150,16 @@ export async function parseCSVTextAsArrow(
   }
   const rawArrowCSVOptions = createRawArrowTableCSVOptions(normalizedOptions);
 
+  const directlyNumericTable = tryParseTypedNumericCSVText(csvText, csvOptions);
+  if (directlyNumericTable) {
+    return directlyNumericTable;
+  }
+
   if (shouldTryTypedUnquotedCSVText(csvText, csvOptions)) {
     const directlyTypedTable = tryParseTypedUnquotedCSVBytes(
       UTF8_ENCODER.encode(csvText),
-      csvOptions
+      csvOptions,
+      true
     );
     if (directlyTypedTable) {
       return directlyTypedTable;
@@ -317,11 +324,257 @@ function shouldApplyDynamicTyping(csvOptions: ArrowTableCSVOptions): boolean {
 type DirectTypedColumn = {
   /** Dynamically typed values or raw UTF-8 sentinels. */
   values: DynamicColumnValue[];
+  /** Narrowest type observed so far, promoted permanently to UTF-8 after mixed input. */
+  inferredDataType: TypedColumnDataType | null;
+  /** Whether every value can be copied directly from its retained source byte range. */
+  hasOnlyRawUtf8OrNull: boolean;
   /** Inclusive source offsets, allocated only after a raw UTF-8 value is observed. */
   valueStarts: number[] | null;
   /** Exclusive source offsets, allocated only after a raw UTF-8 value is observed. */
   valueEnds: number[] | null;
 };
+
+/** Validated dimensions for a direct numeric CSV text parse. */
+type DirectNumericCSVTextDimensions = {
+  /** Number of data rows. */
+  rowCount: number;
+  /** Number of fields in every data row. */
+  columnCount: number;
+};
+
+/** Parses an unquoted, non-null unsigned-integer matrix directly into Float64 Arrow columns. */
+function tryParseTypedNumericCSVText(
+  csvText: string,
+  csvOptions: ArrowTableCSVOptions
+): ArrowTable | null {
+  if (!canUseDirectTypedUnquotedParser(csvOptions) || csvText.length === 0) {
+    return null;
+  }
+
+  const delimiter = getDirectTextDelimiter(csvText, csvOptions);
+  if (delimiter === null) {
+    return null;
+  }
+
+  const headerEnd = findDirectTextRowEnd(csvText, 0);
+  const quoteCharacter = (csvOptions.quoteChar || '"').charCodeAt(0);
+  for (let characterIndex = 0; characterIndex < headerEnd.end; characterIndex++) {
+    if (csvText.charCodeAt(characterIndex) === quoteCharacter) {
+      return null;
+    }
+  }
+
+  const headerRow = decodeDirectTextHeaderRow(csvText, 0, headerEnd.end, delimiter);
+  const dimensions = validateDirectNumericCSVText(
+    csvText,
+    headerEnd.nextStart,
+    delimiter,
+    headerRow.length
+  );
+  if (!dimensions || dimensions.rowCount === 0) {
+    return null;
+  }
+
+  const columns = headerRow.map(() => new Float64Array(dimensions.rowCount));
+  let rowIndex = 0;
+  let columnIndex = 0;
+  let value = 0;
+
+  for (
+    let characterIndex = headerEnd.nextStart;
+    characterIndex < csvText.length;
+    characterIndex++
+  ) {
+    const character = csvText.charCodeAt(characterIndex);
+    if (character >= 48 && character <= 57) {
+      value = value * 10 + character - 48;
+      continue;
+    }
+
+    columns[columnIndex][rowIndex] = value;
+    value = 0;
+    columnIndex++;
+    if (character === delimiter) {
+      continue;
+    }
+
+    rowIndex++;
+    columnIndex = 0;
+    if (character === 13 && csvText.charCodeAt(characterIndex + 1) === 10) {
+      characterIndex++;
+    }
+  }
+
+  if (dimensions.columnCount === 1 || columnIndex > 0) {
+    columns[columnIndex][rowIndex] = value;
+  }
+
+  return createDirectNumericArrowTable(headerRow, columns, dimensions.rowCount);
+}
+
+/** Validates integer-only data rows and returns their exact dimensions. */
+function validateDirectNumericCSVText(
+  csvText: string,
+  dataStart: number,
+  delimiter: number,
+  expectedColumnCount: number
+): DirectNumericCSVTextDimensions | null {
+  let rowCount = 0;
+  let columnIndex = 0;
+  let fieldHasDigit = false;
+
+  for (let characterIndex = dataStart; characterIndex < csvText.length; characterIndex++) {
+    const character = csvText.charCodeAt(characterIndex);
+    if (character >= 48 && character <= 57) {
+      fieldHasDigit = true;
+      continue;
+    }
+    if (!fieldHasDigit) {
+      return null;
+    }
+    fieldHasDigit = false;
+    columnIndex++;
+
+    if (character === delimiter) {
+      if (columnIndex >= expectedColumnCount) {
+        return null;
+      }
+      continue;
+    }
+    if (character !== 10 && character !== 13) {
+      return null;
+    }
+    if (columnIndex !== expectedColumnCount) {
+      return null;
+    }
+
+    rowCount++;
+    columnIndex = 0;
+    if (character === 13 && csvText.charCodeAt(characterIndex + 1) === 10) {
+      characterIndex++;
+    }
+  }
+
+  if (fieldHasDigit) {
+    columnIndex++;
+    rowCount++;
+  }
+  return columnIndex === 0 || columnIndex === expectedColumnCount
+    ? {rowCount, columnCount: expectedColumnCount}
+    : null;
+}
+
+/** Selects an explicit or header-inferred delimiter for direct string parsing. */
+function getDirectTextDelimiter(csvText: string, csvOptions: ArrowTableCSVOptions): number | null {
+  const configuredDelimiter = (csvOptions as ArrowTableCSVOptions & {delimiter?: string}).delimiter;
+  if (configuredDelimiter) {
+    return configuredDelimiter.length === 1 && configuredDelimiter.charCodeAt(0) < 128
+      ? configuredDelimiter.charCodeAt(0)
+      : null;
+  }
+
+  const headerEnd = findDirectTextRowEnd(csvText, 0).end;
+  let selectedDelimiter: number | null = null;
+  let selectedCount = -1;
+  for (const candidate of csvOptions.delimitersToGuess || [',', '\t', '|', ';']) {
+    if (candidate.length !== 1 || candidate.charCodeAt(0) >= 128) {
+      continue;
+    }
+    const candidateCode = candidate.charCodeAt(0);
+    let candidateCount = 0;
+    for (let characterIndex = 0; characterIndex < headerEnd; characterIndex++) {
+      if (csvText.charCodeAt(characterIndex) === candidateCode) {
+        candidateCount++;
+      }
+    }
+    if (candidateCount > selectedCount) {
+      selectedDelimiter = candidateCode;
+      selectedCount = candidateCount;
+    }
+  }
+  return selectedDelimiter;
+}
+
+/** Finds one unquoted row boundary in string input. */
+function findDirectTextRowEnd(csvText: string, rowStart: number): {end: number; nextStart: number} {
+  for (let characterIndex = rowStart; characterIndex < csvText.length; characterIndex++) {
+    const character = csvText.charCodeAt(characterIndex);
+    if (character === 10 || character === 13) {
+      return {
+        end: characterIndex,
+        nextStart:
+          character === 13 && csvText.charCodeAt(characterIndex + 1) === 10
+            ? characterIndex + 2
+            : characterIndex + 1
+      };
+    }
+  }
+  return {end: csvText.length, nextStart: csvText.length};
+}
+
+/** Decodes and deduplicates a direct-parser header from string input. */
+function decodeDirectTextHeaderRow(
+  csvText: string,
+  rowStart: number,
+  rowEnd: number,
+  delimiter: number
+): string[] {
+  const headerRow: string[] = [];
+  const observedColumnNames = new Set<string>();
+  let fieldStart = rowStart;
+  for (let characterIndex = rowStart; characterIndex <= rowEnd; characterIndex++) {
+    if (characterIndex !== rowEnd && csvText.charCodeAt(characterIndex) !== delimiter) {
+      continue;
+    }
+    const originalColumnName = csvText.slice(fieldStart, characterIndex);
+    let columnName = originalColumnName;
+    let duplicateIndex = 1;
+    while (observedColumnNames.has(columnName)) {
+      columnName = `${originalColumnName}.${duplicateIndex}`;
+      duplicateIndex++;
+    }
+    observedColumnNames.add(columnName);
+    headerRow.push(columnName);
+    fieldStart = characterIndex + 1;
+  }
+  return headerRow;
+}
+
+/** Creates an Arrow table from final numeric column buffers without intermediate values. */
+function createDirectNumericArrowTable(
+  headerRow: string[],
+  columns: Float64Array[],
+  rowCount: number
+): ArrowTable {
+  const schema: Schema = {
+    fields: headerRow.map(name => ({name, type: 'float64', nullable: true})),
+    metadata: {
+      'loaders.gl#format': 'csv',
+      'loaders.gl#loader': 'CSVLoader'
+    }
+  };
+  const arrowSchema = convertSchemaToArrow(schema, {viewTypes: 'never'});
+  const arrowColumns = columns.map(
+    data =>
+      new arrow.Vector([
+        arrow.makeData({type: new arrow.Float64(), data, length: rowCount, nullCount: 0})
+      ])
+  );
+  const data = new arrow.Table([
+    new arrow.RecordBatch(
+      arrowSchema,
+      new arrow.Data(
+        new arrow.Struct(arrowSchema.fields),
+        0,
+        rowCount,
+        0,
+        undefined,
+        arrowColumns.map(column => column.data[0])
+      )
+    )
+  ]);
+  return {shape: 'arrow-table', schema, data};
+}
 
 /** Checks whether string input can enter the direct typed unquoted parser. */
 function shouldTryTypedUnquotedCSVText(csvText: string, csvOptions: ArrowTableCSVOptions): boolean {
@@ -332,14 +585,15 @@ function shouldTryTypedUnquotedCSVText(csvText: string, csvOptions: ArrowTableCS
 /** Parses common unquoted typed CSV directly into final Arrow columns when options are compatible. */
 function tryParseTypedUnquotedCSVBytes(
   bytes: Uint8Array,
-  csvOptions: ArrowTableCSVOptions
+  csvOptions: ArrowTableCSVOptions,
+  hasAlreadyCheckedQuotes: boolean = false
 ): ArrowTable | null {
   if (!canUseDirectTypedUnquotedParser(csvOptions) || bytes.length === 0) {
     return null;
   }
 
   const quoteByte = (csvOptions.quoteChar || '"').charCodeAt(0);
-  if (bytes.indexOf(quoteByte) !== -1) {
+  if (!hasAlreadyCheckedQuotes && bytes.indexOf(quoteByte) !== -1) {
     return null;
   }
 
@@ -351,6 +605,8 @@ function tryParseTypedUnquotedCSVBytes(
   const headerRow = decodeDirectHeaderRow(bytes, 0, headerEnd.end, delimiterByte);
   const columns: DirectTypedColumn[] = headerRow.map(() => ({
     values: [],
+    inferredDataType: null,
+    hasOnlyRawUtf8OrNull: true,
     valueStarts: null,
     valueEnds: null
   }));
@@ -500,8 +756,23 @@ function appendDirectTypedField(
   if (!column) {
     return;
   }
-  const dynamicValue = parseRawUtf8ValueWithDynamicTyping(bytes, valueStart, valueEnd);
+  const dynamicValue =
+    column.inferredDataType === 'utf8' && valueStart !== valueEnd
+      ? RAW_UTF8_VALUE
+      : parseRawUtf8ValueWithDynamicTyping(bytes, valueStart, valueEnd);
   column.values.push(dynamicValue);
+
+  if (dynamicValue !== null) {
+    const valueDataType = getTypedColumnDataType(dynamicValue);
+    if (column.inferredDataType === null) {
+      column.inferredDataType = valueDataType;
+    } else if (column.inferredDataType !== valueDataType) {
+      column.inferredDataType = 'utf8';
+    }
+    if (dynamicValue !== RAW_UTF8_VALUE) {
+      column.hasOnlyRawUtf8OrNull = false;
+    }
+  }
 
   if (dynamicValue === RAW_UTF8_VALUE && !column.valueStarts) {
     column.valueStarts = new Array(column.values.length - 1).fill(0);
@@ -520,7 +791,7 @@ function buildDirectTypedArrowTable(
   columns: DirectTypedColumn[],
   rowCount: number
 ): ArrowTable {
-  const typedColumnDataTypes = columns.map(column => deduceTypedColumnDataType(column.values));
+  const typedColumnDataTypes = columns.map(column => column.inferredDataType ?? 'utf8');
   const typedSchema: Schema = {
     fields: headerRow.map((name, columnIndex) => ({
       name,
@@ -535,11 +806,17 @@ function buildDirectTypedArrowTable(
   const typedArrowSchema = convertSchemaToArrow(typedSchema, {viewTypes: 'never'});
   const typedArrowColumns = columns.map((column, columnIndex) => {
     const typedColumnDataType = typedColumnDataTypes[columnIndex];
-    if (
-      typedColumnDataType === 'utf8' &&
-      column.values.every(value => value === null || value === RAW_UTF8_VALUE)
-    ) {
+    if (typedColumnDataType === 'utf8' && column.hasOnlyRawUtf8OrNull) {
       return createDirectUtf8Column(bytes, column);
+    }
+
+    if (typedColumnDataType !== 'utf8') {
+      return createTypedArrowColumn(
+        column.values,
+        typedColumnDataType,
+        typedArrowSchema.fields[columnIndex].type,
+        null
+      );
     }
 
     const typedValues = column.values.map((value, rowIndex) =>
@@ -603,8 +880,7 @@ function createDirectUtf8Column(bytes: Uint8Array, column: DirectTypedColumn): a
     }
     const valueStart = column.valueStarts![rowIndex];
     const valueEnd = column.valueEnds![rowIndex];
-    data.set(bytes.subarray(valueStart, valueEnd), dataOffset);
-    dataOffset += valueEnd - valueStart;
+    dataOffset = copyByteRange(bytes, valueStart, valueEnd, data, dataOffset);
     if (nullBitmap) {
       nullBitmap[rowIndex >> 3] |= 1 << (rowIndex % 8);
     }
@@ -794,6 +1070,22 @@ function parseRawUtf8ValueWithDynamicTyping(
     firstNonWhitespaceValue === 46 ||
     (firstNonWhitespaceValue >= 48 && firstNonWhitespaceValue <= 57);
   if (mightBeNumber) {
+    if (firstNonWhitespaceByte === valueStart && firstNonWhitespaceValue >= 48) {
+      let integerValue = 0;
+      let byteIndex = valueStart;
+      while (byteIndex < valueEnd) {
+        const byte = valueBytes[byteIndex];
+        if (byte < 48 || byte > 57) {
+          break;
+        }
+        integerValue = integerValue * 10 + byte - 48;
+        byteIndex++;
+      }
+      if (byteIndex === valueEnd) {
+        return integerValue;
+      }
+    }
+
     const numberValue = parseUTF8Number(valueBytes, valueStart, valueEnd);
     if (numberValue !== undefined) {
       return numberValue;
@@ -1056,9 +1348,16 @@ function createTypedUtf8Column(typedValues: unknown[], rawArrowColumn: arrow.Vec
 /** Creates a directly populated Arrow boolean vector. */
 function createTypedBooleanColumn(typedValues: unknown[]): arrow.Vector {
   const data = new Uint8Array(Math.ceil(typedValues.length / 8));
-  const {nullBitmap, nullCount} = createTypedNullBitmap(typedValues);
+  const nullBitmap = createOptionalTypedNullBitmap(typedValues);
+  let nullCount = 0;
   for (let rowIndex = 0; rowIndex < typedValues.length; rowIndex++) {
-    if (typedValues[rowIndex] === true) {
+    const typedValue = typedValues[rowIndex];
+    if (typedValue === null) {
+      nullCount++;
+    } else if (nullBitmap) {
+      nullBitmap[rowIndex >> 3] |= 1 << (rowIndex % 8);
+    }
+    if (typedValue === true) {
       data[rowIndex >> 3] |= 1 << (rowIndex % 8);
     }
   }
@@ -1076,12 +1375,31 @@ function createTypedBooleanColumn(typedValues: unknown[]): arrow.Vector {
 
 /** Creates a directly populated Arrow floating-point vector. */
 function createTypedFloatColumn(typedValues: unknown[]): arrow.Vector {
+  const nullBitmap = createOptionalTypedNullBitmap(typedValues);
+  if (!nullBitmap) {
+    return new arrow.Vector([
+      arrow.makeData({
+        type: new arrow.Float64(),
+        data: Float64Array.from(typedValues as number[]),
+        length: typedValues.length,
+        nullCount: 0
+      })
+    ]);
+  }
+
   const data = new Float64Array(typedValues.length);
-  const {nullBitmap, nullCount} = createTypedNullBitmap(typedValues);
+  let nullCount = 0;
   for (let rowIndex = 0; rowIndex < typedValues.length; rowIndex++) {
     const typedValue = typedValues[rowIndex];
-    if (typeof typedValue === 'number') {
-      data[rowIndex] = typedValue;
+    if (typedValue === null) {
+      nullCount++;
+    } else {
+      if (nullBitmap) {
+        nullBitmap[rowIndex >> 3] |= 1 << (rowIndex % 8);
+      }
+      if (typeof typedValue === 'number') {
+        data[rowIndex] = typedValue;
+      }
     }
   }
 
@@ -1099,11 +1417,19 @@ function createTypedFloatColumn(typedValues: unknown[]): arrow.Vector {
 /** Creates a directly populated Arrow millisecond-date vector. */
 function createTypedDateColumn(typedValues: unknown[]): arrow.Vector {
   const data = new BigInt64Array(typedValues.length);
-  const {nullBitmap, nullCount} = createTypedNullBitmap(typedValues);
+  const nullBitmap = createOptionalTypedNullBitmap(typedValues);
+  let nullCount = 0;
   for (let rowIndex = 0; rowIndex < typedValues.length; rowIndex++) {
     const typedValue = typedValues[rowIndex];
-    if (typedValue instanceof Date) {
-      data[rowIndex] = BigInt(typedValue.valueOf());
+    if (typedValue === null) {
+      nullCount++;
+    } else {
+      if (nullBitmap) {
+        nullBitmap[rowIndex >> 3] |= 1 << (rowIndex % 8);
+      }
+      if (typedValue instanceof Date) {
+        data[rowIndex] = BigInt(typedValue.valueOf());
+      }
     }
   }
 
@@ -1118,21 +1444,9 @@ function createTypedDateColumn(typedValues: unknown[]): arrow.Vector {
   ]);
 }
 
-/** Creates the validity bitmap needed by a typed primitive Arrow column. */
-function createTypedNullBitmap(typedValues: unknown[]): {
-  nullBitmap: Uint8Array | undefined;
-  nullCount: number;
-} {
-  let nullCount = 0;
-  const nullBitmap = new Uint8Array(Math.ceil(typedValues.length / 8));
-  for (let rowIndex = 0; rowIndex < typedValues.length; rowIndex++) {
-    if (typedValues[rowIndex] === null) {
-      nullCount++;
-    } else {
-      nullBitmap[rowIndex >> 3] |= 1 << (rowIndex % 8);
-    }
-  }
-  return {nullBitmap: nullCount > 0 ? nullBitmap : undefined, nullCount};
+/** Allocates a validity bitmap only when a typed primitive column contains nulls. */
+function createOptionalTypedNullBitmap(typedValues: unknown[]): Uint8Array | undefined {
+  return typedValues.includes(null) ? new Uint8Array(Math.ceil(typedValues.length / 8)) : undefined;
 }
 
 /** Reads an Arrow list column back to nullable JS arrays for table rebuilding. */

--- a/modules/csv/src/lib/parsers/parse-raw-arrow-csv-bytes.ts
+++ b/modules/csv/src/lib/parsers/parse-raw-arrow-csv-bytes.ts
@@ -7,6 +7,7 @@ import {getArrowViewTypeSupport} from '@loaders.gl/schema-utils';
 import * as arrow from 'apache-arrow';
 
 import type {CSVRawArrowOptions} from './parse-csv-to-arrow';
+import {copyByteRange} from '../utils/copy-byte-range';
 
 /** Normalized ASCII-byte CSV options used by the raw Arrow byte parser. */
 type CSVByteParserOptions = {
@@ -1091,21 +1092,6 @@ class RawArrowUtf8ColumnBuilder {
     this.valueOffsets[this.valueOffsetCount] = valueOffset;
     this.valueOffsetCount++;
   }
-}
-
-/** Copies one byte range into a target and returns the next write offset. */
-function copyByteRange(
-  source: Uint8Array,
-  start: number,
-  end: number,
-  target: Uint8Array,
-  targetStart: number
-): number {
-  const byteLength = end - start;
-  if (byteLength > 0) {
-    target.set(source.subarray(start, end), targetStart);
-  }
-  return targetStart + byteLength;
 }
 
 /** Counts fields in a byte range that contains unquoted delimiter bytes. */

--- a/modules/csv/src/lib/utils/copy-byte-range.ts
+++ b/modules/csv/src/lib/utils/copy-byte-range.ts
@@ -1,0 +1,29 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+const SHORT_COPY_MAX_LENGTH = 32;
+
+/**
+ * Copies a byte range using the faster Chromium strategy for its length.
+ *
+ * Callers are responsible for supplying valid source and target ranges.
+ */
+export function copyByteRange(
+  source: Uint8Array,
+  start: number,
+  end: number,
+  target: Uint8Array,
+  targetStart: number
+): number {
+  const byteLength = end - start;
+  if (byteLength <= SHORT_COPY_MAX_LENGTH) {
+    for (let byteIndex = start; byteIndex < end; byteIndex++) {
+      target[targetStart] = source[byteIndex];
+      targetStart++;
+    }
+    return targetStart;
+  }
+  target.set(source.subarray(start, end), targetStart);
+  return targetStart + byteLength;
+}

--- a/modules/csv/test/csv-fast-path.spec.ts
+++ b/modules/csv/test/csv-fast-path.spec.ts
@@ -89,6 +89,41 @@ describe('CSV optimized parsing paths', () => {
     expect(getArrowColumnValues(table, 'enabled')).toEqual([true, false]);
   });
 
+  test('parses an integer matrix directly into numeric Arrow columns', async () => {
+    const table = await CSVLoader.parseText('a,b,c\r\n1,2,3\r\n4,5,6', {
+      csv: {header: true, shape: 'arrow-table', dynamicTyping: true}
+    });
+
+    expect(table.schema?.fields.map(field => field.type)).toEqual([
+      'float64',
+      'float64',
+      'float64'
+    ]);
+    expect(getArrowColumnValues(table, 'a')).toEqual([1, 4]);
+    expect(getArrowColumnValues(table, 'b')).toEqual([2, 5]);
+    expect(getArrowColumnValues(table, 'c')).toEqual([3, 6]);
+  });
+
+  test('parses a single integer column without a final newline', async () => {
+    const table = await CSVLoader.parseText('value\r\n1\r\n2', {
+      csv: {header: true, shape: 'arrow-table', dynamicTyping: true}
+    });
+
+    expect(table.schema?.fields.map(field => field.type)).toEqual(['float64']);
+    expect(getArrowColumnValues(table, 'value')).toEqual([1, 2]);
+  });
+
+  test('preserves nulls and source strings in mixed typed columns', async () => {
+    const table = await CSVLoader.parseText('id,label,optional\n1,item-1,\n2,item-2,+2\n', {
+      csv: {header: true, shape: 'arrow-table', dynamicTyping: true}
+    });
+
+    expect(table.schema?.fields.map(field => field.type)).toEqual(['float64', 'utf8', 'utf8']);
+    expect(getArrowColumnValues(table, 'id')).toEqual([1, 2]);
+    expect(getArrowColumnValues(table, 'label')).toEqual(['item-1', 'item-2']);
+    expect(getArrowColumnValues(table, 'optional')).toEqual([null, '+2']);
+  });
+
   test('preserves custom delimiter inference for row output', async () => {
     const table = await CSVLoader.parseText('city^count\nParis^42\n', {
       csv: {


### PR DESCRIPTION
## Goals

- Materially improve end-to-end Arrow CSV parsing throughput across the existing browser benchmark matrix.
- Remove the worst typed/wide regression without weakening benchmark work or changing output semantics.
- Preserve CSV correctness, public API compatibility, and streaming/chunk-boundary behavior.

## Changes

- Add a conservative full-string fast path for headered, unquoted, unsigned-integer matrices that validates the CSV and writes directly into final `Float64Array` Arrow columns.
- Track inferred column types and raw UTF-8 state incrementally in the direct typed parser, avoiding repeated type scans and per-cell dynamic dispatch after a column is known to be UTF-8.
- Reuse retained UTF-8 byte ranges and construct primitive Arrow vectors directly, avoiding intermediate value remapping where possible.
- Use a measured hybrid byte-copy strategy: tight loops for short CSV cells and `Uint8Array#set` for longer ranges.
- Avoid duplicate quote scans, fast-path unsigned integer conversion, and allocate primitive validity bitmaps only for columns that contain nulls.
- Add focused Vitest coverage for direct numeric matrices, CRLF, no-final-newline single-column input, and mixed typed/null/string fallback behavior. Existing one-byte streaming chunk tests remain green.

## Performance

Operations/second, higher is better, 2,000 rows. Results are from sequential fresh production website builds on the same machine with all other benchmark servers stopped. The `master` build used `3d2ffda1c0`; subsequent `master` commits did not touch CSV or the benchmark page.

| Scenario | master Arrow | PR Arrow | Change | PR uDSV |
| --- | ---: | ---: | ---: | ---: |
| Unquoted, untyped | 4.00M | 6.63M | +66% | 8.57M |
| Unquoted, typed | 3.48M | 4.38M | +26% | 6.72M |
| Quoted/escaped, untyped | 3.40M | 4.26M | +25% | 3.06M |
| Quoted/escaped, typed | 2.46M | 2.80M | +14% | 2.90M |
| Tab, untyped | 4.24M | 6.49M | +53% | 8.20M |
| Tab, typed | 3.50M | 4.48M | +28% | 6.71M |
| 40 columns, untyped | 366K | 690K | +89% | 863K |
| 40 columns, typed | 318K | 1.23M | +287% | 623K |
| UTF-8, untyped | 3.37M | 4.71M | +40% | 7.10M |
| UTF-8, typed | 2.72M | 3.65M | +34% | 6.38M |
| `sample-very-long.csv`, untyped | 2.99M | 3.79M | +27% | 8.44M |
| `sample-very-long.csv`, typed | 2.24M | 3.00M | +34% | 7.47M |

The PR improves Arrow in all 12 scenarios. Arrow is 1.39x faster than uDSV for quoted/untyped input and 1.97x faster for the 40-column typed case. uDSV remains faster in the string-heavy unquoted cases; this PR does not claim otherwise.

## Compatibility and streaming

- No public APIs or option semantics change.
- The numeric specialization is gated to compatible full-string `parseText` options and falls back to the existing parser for quotes, nulls, signed/decimal values, comments, skipped lines, alternate view types, and other unsupported cases.
- Streaming parsing is unchanged; existing tests split quoted and UTF-8 data into one-byte chunks and pass with dynamic typing both enabled and disabled.

## Validation

- `yarn lint fix`
- `yarn test-audit`
- `yarn build`
- `yarn build-workers`
- `yarn test-node` — 360 passed, 6 skipped
- `yarn test-headless` — 2,978 passed, 40 skipped
- `yarn test-headless modules/csv/test` — 121 passed
- `yarn test-headless modules/csv/test/csv-fast-path.spec.ts` — 13 passed after rebase
- `cd website && yarn build`

