### PR TITLE
feat(scan): bridge vector tiles and feature services

### DIFF
--- a/docs/developer-guide/common-scan-architecture.md
+++ b/docs/developer-guide/common-scan-architecture.md
@@ -747,10 +747,12 @@ The roadmap is therefore format-support-first. Each tranche must ship three thin
    execute validated raster queries through `getRaster()`. NetCDF supports numeric variable reads
    and named dimension index or half-open range slices with typed output. Terrain and LERC remain
    explicitly not implemented.
-7. **Tiles and services bridge.** Keep MVT, PMTiles, 3D Tiles, I3S, WMS, WFS, and STAC specialized,
-   but expose shared discovery, bounds, time, level-of-detail, explain, and cancellation metadata.
-   Where a source returns feature tables (for example MVT or WFS), offer an explicit table-scan view;
-   keep tile addressing and rendering controls outside `TableQuery`.
+7. **Tiles and services bridge — feature-table slice landed.** MVT/PMTiles vector tiles and bounded
+   WFS/ArcGIS feature requests can now be bound through opt-in `@loaders.gl/scan` adapters. The
+   physical tile address, layers, bounds, and CRS remain outside `TableQuery`; the resolved Arrow
+   feature table exposes shared metadata, explain, cancellation, residual predicates, projection,
+   relational operators, and limits. 3D Tiles, I3S, WMS imagery, and STAC remain specialized while
+   shared time, level-of-detail, and non-table discovery metadata are still open.
 8. **Portable relational growth — second slice landed.** Arrow and DuckDB now execute the shared
    ordering, scalar-expression, grouped-aggregate, `UNION ALL`, and equi-join request shapes. The
    next slice is planner-level source resolution and duplicate-column naming for larger federated
@@ -782,8 +784,10 @@ and “Outside protocol” have the exact meanings defined at the top of this pa
 | GeoZarr / OME-Zarr | Supported | `getRaster()` | Chunk-aligned windows, channels, levels, slices | More variable and dimension UI |
 | NetCDF | Supported | `getRaster()` | Numeric variables, named dimension index/range slices, typed output, and cancellation | Range reads, chunk pruning, and broader NetCDF variants |
 | Terrain / LERC | Not implemented | — | No common scan claims | Raster adapter design |
-| MVT / PMTiles / 3D Tiles / I3S | Outside protocol | — | Specialized tile APIs | Optional explicit feature-table views |
-| WMS / WFS / STAC | Outside protocol | — | Specialized service and catalog APIs | Shared discovery metadata where useful |
+| MVT / PMTiles | Outside protocol; optional table view | `read()` after binding a vector tile | Tile addressing stays specialized; Arrow feature rows use portable residual queries | Cross-tile planning and tile-statistics discovery |
+| 3D Tiles / I3S | Outside protocol | — | Specialized tile APIs | Shared bounds, time, level-of-detail, and explain metadata |
+| WFS / ArcGIS FeatureServer | Outside protocol; optional table view | `read()` after binding a bounded request | Service controls stay specialized; Arrow feature rows use portable residual queries | DescribeFeatureType schema discovery and server-side filter translation |
+| WMS / STAC | Outside protocol | — | Specialized imagery and catalog APIs | Shared time and non-table discovery metadata |
 
 “Pushdown” is a promise about avoiding physical work, not merely accepting an option. Every adapter
 must report `residual` when it decodes rows, features, points, or chunks before evaluating a filter.

--- a/modules/loader-utils/src/lib/sources/tile-source.ts
+++ b/modules/loader-utils/src/lib/sources/tile-source.ts
@@ -109,6 +109,8 @@ export type GetTileParameters = {
   styles?: unknown;
   /** requested format for the return image (in case of bitmap tiles) */
   format?: 'image/png';
+  /** Abort signal for canceling metadata, range, and tile-content requests. */
+  signal?: AbortSignal;
 };
 
 /** deck.gl compatibility: parameters for TileSource.getTileData() */

--- a/modules/mvt/src/mvt-source-loader.ts
+++ b/modules/mvt/src/mvt-source-loader.ts
@@ -241,14 +241,17 @@ export class MVTTileSource
     arrayBuffer: ArrayBuffer,
     tileParams: GetTileParameters
   ): Promise<VectorTile | null> {
+    const inheritedMVTOptions = (this.loadOptions as MVTLoaderOptions)?.mvt;
+    const selectedLayers = normalizeTileLayers(tileParams.layers) || inheritedMVTOptions?.layers;
     const loadOptions: MVTLoaderOptions = {
+      ...this.loadOptions,
       mvt: {
-        shape: this.options.mvt?.shape || 'geojson-table',
+        ...inheritedMVTOptions,
+        shape: this.options.mvt?.shape || inheritedMVTOptions?.shape || 'geojson-table',
         coordinates: 'wgs84',
         tileIndex: {x: tileParams.x, y: tileParams.y, z: tileParams.z},
-        ...(this.loadOptions as MVTLoaderOptions)?.mvt
-      },
-      ...this.loadOptions
+        layers: selectedLayers
+      }
     };
 
     return (await this.coreApi.parse(arrayBuffer, MVTLoader, loadOptions)) as VectorTile;
@@ -270,6 +273,12 @@ export class MVTTileSource
         throw new Error(this.schema);
     }
   }
+}
+
+/** Normalizes a non-empty tile layer selection for the MVT decoder. */
+function normalizeTileLayers(layers?: string | string[]): string[] | undefined {
+  const normalizedLayers = typeof layers === 'string' ? [layers] : layers;
+  return normalizedLayers?.length ? normalizedLayers : undefined;
 }
 
 export function isURLTemplate(s: string): boolean {

--- a/modules/mvt/src/mvt-source-loader.ts
+++ b/modules/mvt/src/mvt-source-loader.ts
@@ -162,7 +162,10 @@ export class MVTTileSource
   async getTile(parameters: GetTileParameters): Promise<ArrayBuffer | null> {
     const {x, y, z} = parameters;
     const tileUrl = this.getTileURL(x, y, z);
-    const response = await this.fetch(tileUrl);
+    const response = await this.fetch(
+      tileUrl,
+      parameters.signal ? {signal: parameters.signal} : undefined
+    );
     if (!response.ok) {
       this.reportError(
         new Error(`${response.status} ${response.statusText}`),

--- a/modules/mvt/test/mvt-source-cancellation.spec.ts
+++ b/modules/mvt/test/mvt-source-cancellation.spec.ts
@@ -1,0 +1,28 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import {MVTTileSource} from '../src/mvt-source-loader';
+
+test('MVTTileSource#getTile forwards cancellation to the tile request', async () => {
+  const controller = new AbortController();
+  let receivedSignal: AbortSignal | null = null;
+  const source = new MVTTileSource('https://example.com/{z}/{x}/{y}.pbf', {
+    core: {
+      loadOptions: {
+        core: {
+          fetch: async (url, options) => {
+            if (String(url).endsWith('tilejson.json')) return new Response(null, {status: 404});
+            receivedSignal = options?.signal || null;
+            return new Response(new Uint8Array([1, 2, 3]));
+          }
+        }
+      }
+    }
+  });
+
+  await source.getTile({x: 0, y: 0, z: 0, signal: controller.signal});
+  await source.metadata;
+  expect(receivedSignal).toBe(controller.signal);
+});

--- a/modules/mvt/test/mvt-source-cancellation.spec.ts
+++ b/modules/mvt/test/mvt-source-cancellation.spec.ts
@@ -3,6 +3,8 @@
 // Copyright (c) vis.gl contributors
 
 import {expect, test} from 'vitest';
+import type {CoreAPI} from '@loaders.gl/loader-utils';
+import type {MVTLoaderOptions} from '../src/mvt-loader';
 import {MVTTileSource} from '../src/mvt-source-loader';
 
 test('MVTTileSource#getTile forwards cancellation to the tile request', async () => {
@@ -25,4 +27,36 @@ test('MVTTileSource#getTile forwards cancellation to the tile request', async ()
   await source.getTile({x: 0, y: 0, z: 0, signal: controller.signal});
   await source.metadata;
   expect(receivedSignal).toBe(controller.signal);
+});
+
+test('MVTTileSource#getVectorTile forwards requested layers to the decoder', async () => {
+  let receivedOptions: MVTLoaderOptions | undefined;
+  const coreApi = {
+    async parse(_data: unknown, _loaders: unknown, options: MVTLoaderOptions) {
+      receivedOptions = options;
+      return {shape: 'arrow-table'};
+    }
+  } as unknown as CoreAPI;
+  const source = new MVTTileSource(
+    'https://example.com/{z}/{x}/{y}.pbf',
+    {
+      mvt: {metadataUrl: null, shape: 'arrow-table'},
+      core: {
+        loadOptions: {
+          core: {fetch: async () => new Response(new Uint8Array([1]))},
+          mvt: {layerProperty: 'sourceLayer', layers: ['fallback']}
+        }
+      }
+    },
+    coreApi
+  );
+
+  await source.getVectorTile({x: 2, y: 1, z: 3, layers: 'roads'});
+  expect(receivedOptions?.mvt).toMatchObject({
+    shape: 'arrow-table',
+    coordinates: 'wgs84',
+    tileIndex: {x: 2, y: 1, z: 3},
+    layerProperty: 'sourceLayer',
+    layers: ['roads']
+  });
 });

--- a/modules/pmtiles/src/pmtiles-source-loader.ts
+++ b/modules/pmtiles/src/pmtiles-source-loader.ts
@@ -134,7 +134,7 @@ export class PMTilesTileSource
     const {x, y, z} = tileParams;
     let rangeResponse;
     try {
-      rangeResponse = await this.getZxyBatched(z, x, y, (tileParams as any).signal);
+      rangeResponse = await this.getZxyBatched(z, x, y, tileParams.signal);
     } catch (error) {
       this.reportError(error, `Failed to fetch tile ${this.url} ${JSON.stringify(tileParams)}`);
       return null;

--- a/modules/pmtiles/src/pmtiles-source-loader.ts
+++ b/modules/pmtiles/src/pmtiles-source-loader.ts
@@ -185,14 +185,17 @@ export class PMTilesTileSource
 
   async getVectorTile(tileParams: GetTileParameters): Promise<VectorTile | null> {
     const arrayBuffer = await this.getTile(tileParams);
+    const inheritedMVTOptions = (this.loadOptions as MVTLoaderOptions)?.mvt;
+    const selectedLayers = normalizeTileLayers(tileParams.layers) || inheritedMVTOptions?.layers;
     const loadOptions: MVTLoaderOptions = {
+      ...this.loadOptions,
       mvt: {
-        shape: this.options.pmtiles?.shape || 'geojson-table',
+        ...inheritedMVTOptions,
+        shape: this.options.pmtiles?.shape || inheritedMVTOptions?.shape || 'geojson-table',
         coordinates: 'wgs84',
         tileIndex: {x: tileParams.x, y: tileParams.y, z: tileParams.z},
-        ...(this.loadOptions as MVTLoaderOptions)?.mvt
-      },
-      ...this.loadOptions
+        layers: selectedLayers
+      }
     };
 
     return arrayBuffer
@@ -241,6 +244,12 @@ export class PMTilesTileSource
         .then(tileRequest.resolve, tileRequest.reject);
     }
   }
+}
+
+/** Normalizes a non-empty tile layer selection for the MVT decoder. */
+function normalizeTileLayers(layers?: string | string[]): string[] | undefined {
+  const normalizedLayers = typeof layers === 'string' ? [layers] : layers;
+  return normalizedLayers?.length ? normalizedLayers : undefined;
 }
 
 type PendingTileRequest = {

--- a/modules/pmtiles/test/pmtiles-source-layers.spec.ts
+++ b/modules/pmtiles/test/pmtiles-source-layers.spec.ts
@@ -1,0 +1,37 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import type {CoreAPI} from '@loaders.gl/loader-utils';
+import type {MVTLoaderOptions} from '@loaders.gl/mvt';
+import {PMTilesTileSource} from '../src/pmtiles-source-loader';
+
+test('PMTilesTileSource#getVectorTile forwards requested layers to the decoder', async () => {
+  const receivedOptions: MVTLoaderOptions[] = [];
+  const source = Object.assign(Object.create(PMTilesTileSource.prototype), {
+    options: {pmtiles: {shape: 'arrow-table'}},
+    loadOptions: {mvt: {layerProperty: 'sourceLayer', layers: ['fallback']}},
+    coreApi: {
+      async parse(_data: unknown, _loaders: unknown, options: MVTLoaderOptions) {
+        receivedOptions.push(options);
+        return {shape: 'arrow-table'};
+      }
+    } as unknown as CoreAPI,
+    async getTile() {
+      return new ArrayBuffer(1);
+    }
+  }) as PMTilesTileSource;
+
+  await source.getVectorTile({x: 2, y: 1, z: 3, layers: ['roads']});
+  await source.getVectorTile({x: 2, y: 1, z: 3, layers: []});
+
+  expect(receivedOptions[0].mvt).toMatchObject({
+    shape: 'arrow-table',
+    coordinates: 'wgs84',
+    tileIndex: {x: 2, y: 1, z: 3},
+    layerProperty: 'sourceLayer',
+    layers: ['roads']
+  });
+  expect(receivedOptions[1].mvt?.layers).toEqual(['fallback']);
+});

--- a/modules/scan/README.md
+++ b/modules/scan/README.md
@@ -78,3 +78,34 @@ Raster sources implement `getRaster()` and publish raster-specific capabilities 
 table operators. NetCDF supports numeric variable selection and named dimension index or half-open
 range slices. GeoTIFF, OME-TIFF, GeoZarr, and OME-Zarr retain their format-specific window, level,
 channel, and chunk planners behind the same metadata vocabulary.
+
+## Addressed vector tables
+
+Specialized tile and service controls stay outside the portable relational query. Applications can
+bind one vector tile or one bounded feature request, then expose the resulting Arrow feature table
+through the same metadata, explain, and `read()` surface:
+
+```typescript
+import {VectorTileTableScanSource} from '@loaders.gl/scan';
+
+const tileTable = new VectorTileTableScanSource(mvtSource, {
+  sourceType: 'mvt-tile-table',
+  tile: {x: 2, y: 6, z: 4, layers: ['places']}
+});
+
+const metadata = await tileTable.getQueryMetadata();
+for await (const batch of tileTable.read({
+  predicate: parseSQLPredicate('population >= 1000000'),
+  columns: ['name', 'population'],
+  limit: 25
+})) {
+  // Arrow feature table batch
+}
+```
+
+Configure MVT and vector PMTiles sources with `shape: 'arrow-table'`. The corresponding
+`VectorFeatureTableScanSource` requests Arrow output from bounded vector sources such as WFS and
+ArcGIS FeatureServer. Tile coordinates, selected layers, service bounds, and CRS remain immutable
+source parameters; predicates, projection, ordering, aggregates, and limits remain portable query
+operators. Both adapters cache the addressed result between metadata discovery and execution, so a
+query panel does not repeat the network request.

--- a/modules/scan/package.json
+++ b/modules/scan/package.json
@@ -41,10 +41,10 @@
   "dependencies": {
     "@loaders.gl/loader-utils": "5.0.0-alpha.2",
     "@loaders.gl/schema": "5.0.0-alpha.2",
+    "@loaders.gl/schema-utils": "5.0.0-alpha.2",
     "@loaders.gl/sql": "5.0.0-alpha.2"
   },
   "devDependencies": {
-    "@loaders.gl/schema-utils": "5.0.0-alpha.2",
     "apache-arrow": ">= 17.0.0"
   }
 }

--- a/modules/scan/src/index.ts
+++ b/modules/scan/src/index.ts
@@ -55,3 +55,14 @@ export type {
   TableScanSource
 } from '@loaders.gl/loader-utils';
 export type {ScanQuery} from './scan-query';
+
+export {
+  AddressedVectorTableScanSource,
+  VectorFeatureTableScanSource,
+  VectorTileTableScanSource
+} from './vector-table-scan-source';
+export type {
+  VectorFeatureTableScanSourceOptions,
+  VectorTableScanSourceOptions,
+  VectorTileTableScanSourceOptions
+} from './vector-table-scan-source';

--- a/modules/scan/src/vector-table-scan-source.ts
+++ b/modules/scan/src/vector-table-scan-source.ts
@@ -133,9 +133,8 @@ export abstract class AddressedVectorTableScanSource {
   private async getTable(signal?: AbortSignal): Promise<ArrowTable> {
     throwIfAborted(signal);
     if (!this.tablePromise) {
-      this.tablePromise = this.loadTable(signal)
+      this.tablePromise = this.loadTable()
         .then(table => {
-          throwIfAborted(signal);
           if (!table) {
             throw new Error('The addressed vector selection did not return a feature table.');
           }
@@ -151,7 +150,7 @@ export abstract class AddressedVectorTableScanSource {
           throw error;
         });
     }
-    return await this.tablePromise;
+    return await waitForPromise(this.tablePromise, signal);
   }
 }
 
@@ -169,7 +168,10 @@ export class VectorTileTableScanSource extends AddressedVectorTableScanSource {
 
   /** Creates a portable table view over one vector tile. */
   constructor(source: VectorTileSource, options: VectorTileTableScanSourceOptions) {
-    const tile = Object.freeze({...options.tile});
+    const tile = Object.freeze({
+      ...options.tile,
+      layers: cloneAndFreezeLayers(options.tile.layers)
+    });
     super(options, {
       sourceType: 'vector-tile-table',
       description: `Vector tile ${tile.z}/${tile.x}/${tile.y}`,
@@ -202,7 +204,14 @@ export class VectorFeatureTableScanSource extends AddressedVectorTableScanSource
 
   /** Creates a portable table view over one bounded vector-service request. */
   constructor(source: VectorSource, options: VectorFeatureTableScanSourceOptions) {
-    const request = Object.freeze({...options.request});
+    const request = Object.freeze({
+      ...options.request,
+      layers: cloneAndFreezeLayers(options.request.layers),
+      boundingBox: Object.freeze([
+        Object.freeze([...options.request.boundingBox[0]]),
+        Object.freeze([...options.request.boundingBox[1]])
+      ]) as GetFeaturesParameters['boundingBox']
+    });
     const coordinateReferenceSystems = typeof request.crs === 'string' ? [request.crs] : undefined;
     super(options, {
       sourceType: 'vector-feature-table',
@@ -258,9 +267,34 @@ function normalizeLayers(layers: string | string[]): string[] {
   return Array.isArray(layers) ? layers : [layers];
 }
 
+/** Clones and freezes a possibly plural layer selection for an immutable physical address. */
+function cloneAndFreezeLayers<LayersT extends string | string[] | undefined>(
+  layers: LayersT
+): LayersT {
+  return (Array.isArray(layers) ? Object.freeze([...layers]) : layers) as LayersT;
+}
+
+/** Waits for a shared cached load while preserving one caller's independent cancellation. */
+async function waitForPromise<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) {
+    return await promise;
+  }
+  throwIfAborted(signal);
+  return await new Promise<T>((resolve, reject) => {
+    const abort = () => reject(getAbortReason(signal));
+    signal.addEventListener('abort', abort, {once: true});
+    void promise.then(resolve, reject).finally(() => signal.removeEventListener('abort', abort));
+  });
+}
+
 /** Throws before physical or residual work begins when cancellation was requested. */
 function throwIfAborted(signal?: AbortSignal): void {
   if (signal?.aborted) {
-    throw signal.reason || new DOMException('Request aborted', 'AbortError');
+    throw getAbortReason(signal);
   }
+}
+
+/** Returns the caller's cancellation reason or a portable AbortError fallback. */
+function getAbortReason(signal: AbortSignal): unknown {
+  return signal.reason || new DOMException('Request aborted', 'AbortError');
 }

--- a/modules/scan/src/vector-table-scan-source.ts
+++ b/modules/scan/src/vector-table-scan-source.ts
@@ -1,0 +1,266 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {ArrowTable, ArrowTableBatch} from '@loaders.gl/schema';
+import {convertArrowToSchema} from '@loaders.gl/schema-utils';
+import type {
+  GetFeaturesParameters,
+  GetTileParameters,
+  ScanQueryMetadata,
+  ScanQueryMetadataOptions,
+  ScanSpatialMetadata,
+  TableQueryExplain,
+  VectorSource,
+  VectorTileSource
+} from '@loaders.gl/loader-utils';
+import {createScanQueryMetadata} from '@loaders.gl/loader-utils';
+import {
+  ARROW_TABLE_QUERY_CAPABILITIES,
+  explainArrowTableQuery,
+  queryArrowTable,
+  type ArrowQueryOptions,
+  type SQLPredicate
+} from '@loaders.gl/sql';
+
+/** Shared display and provenance options for an addressed vector-table scan. */
+export type VectorTableScanSourceOptions = Readonly<{
+  /** Stable source type reported through query metadata. */
+  sourceType?: string;
+  /** Optional display name shown by metadata-driven query controls. */
+  name?: string;
+  /** Optional description of the addressed table view. */
+  description?: string;
+}>;
+
+/** Options that bind one vector tile before portable table-query planning begins. */
+export type VectorTileTableScanSourceOptions = VectorTableScanSourceOptions &
+  Readonly<{
+    /** Tile address and source-specific layer selection, deliberately outside `TableQuery`. */
+    tile: Omit<GetTileParameters, 'signal'>;
+  }>;
+
+/** Options that bind one bounded vector-service request before table-query planning begins. */
+export type VectorFeatureTableScanSourceOptions = VectorTableScanSourceOptions &
+  Readonly<{
+    /** Layers, bounds, and output CRS, deliberately outside `TableQuery`. */
+    request: Omit<GetFeaturesParameters, 'format' | 'signal'>;
+  }>;
+
+/**
+ * Base source for a physical vector selection that resolves to one Arrow feature table.
+ *
+ * The physical address is immutable and owned by a specialized adapter. Portable predicates,
+ * projection, ordering, aggregates, and limits are applied only after that selection resolves.
+ */
+export abstract class AddressedVectorTableScanSource {
+  /** Stable adapter type reported by `getQueryMetadata()`. */
+  readonly sourceType: string;
+  /** Optional display name shown by query controls. */
+  readonly name?: string;
+  /** Human-readable description of the bound physical selection. */
+  readonly description: string;
+  /** Spatial extent of the bound physical selection. */
+  readonly spatial?: ScanSpatialMetadata;
+
+  private tablePromise: Promise<ArrowTable> | null = null;
+
+  /** Creates a table-scan view over one immutable physical selection. */
+  protected constructor(
+    options: VectorTableScanSourceOptions,
+    defaults: Readonly<{
+      sourceType: string;
+      description: string;
+      spatial?: ScanSpatialMetadata;
+    }>
+  ) {
+    this.sourceType = options.sourceType || defaults.sourceType;
+    this.name = options.name;
+    this.description = options.description || defaults.description;
+    this.spatial = defaults.spatial;
+  }
+
+  /** Loads the physically addressed data as one Arrow table. */
+  protected abstract loadTable(signal?: AbortSignal): Promise<ArrowTable | null>;
+
+  /** Discovers the addressed result schema and portable residual-query capabilities. */
+  async getQueryMetadata(options: ScanQueryMetadataOptions = {}): Promise<ScanQueryMetadata> {
+    const table = await this.getTable(options.signal);
+    const schema = table.schema || convertArrowToSchema(table.data.schema);
+    return createScanQueryMetadata({
+      sourceType: this.sourceType,
+      queryType: 'table',
+      execution: {status: 'supported', method: 'read'},
+      name: this.name,
+      description: this.description,
+      schema,
+      capabilities: {
+        table: ARROW_TABLE_QUERY_CAPABILITIES,
+        bounds: 'unsupported',
+        levelOfDetail: 'unsupported'
+      },
+      columnRoles: inferVectorColumnRoles(schema.fields.map(field => field.name)),
+      spatial: this.spatial,
+      statistics: {rowCount: table.data.numRows}
+    });
+  }
+
+  /** Applies the portable Arrow query to the addressed feature table. */
+  async query(options: ArrowQueryOptions = {}): Promise<ArrowTable> {
+    const table = await this.getTable(options.signal);
+    return queryArrowTable(table, options);
+  }
+
+  /** Explains the residual Arrow plan after resolving the addressed feature table. */
+  async explain(options: ArrowQueryOptions = {}): Promise<TableQueryExplain<SQLPredicate>> {
+    const table = await this.getTable(options.signal);
+    return explainArrowTableQuery(table, options);
+  }
+
+  /** Emits the portable query result as one bounded Arrow batch. */
+  async *read(options: ArrowQueryOptions = {}): AsyncIterableIterator<ArrowTableBatch> {
+    const result = await this.query(options);
+    yield {
+      batchType: 'data',
+      shape: 'arrow-table',
+      schema: result.schema,
+      data: result.data,
+      length: result.data.numRows
+    };
+  }
+
+  /** Resolves and caches the addressed table while allowing failed loads to be retried. */
+  private async getTable(signal?: AbortSignal): Promise<ArrowTable> {
+    throwIfAborted(signal);
+    if (!this.tablePromise) {
+      this.tablePromise = this.loadTable(signal)
+        .then(table => {
+          throwIfAborted(signal);
+          if (!table) {
+            throw new Error('The addressed vector selection did not return a feature table.');
+          }
+          if (table.shape !== 'arrow-table') {
+            throw new Error(
+              'The addressed vector selection must return an Arrow table. Configure the source with shape "arrow-table".'
+            );
+          }
+          return table;
+        })
+        .catch(error => {
+          this.tablePromise = null;
+          throw error;
+        });
+    }
+    return await this.tablePromise;
+  }
+}
+
+/**
+ * Portable table-query view over one explicitly addressed vector tile.
+ *
+ * MVT and vector PMTiles sources participate when configured to return `shape: 'arrow-table'`.
+ * Tile coordinates and layer selection remain source parameters rather than relational operators.
+ */
+export class VectorTileTableScanSource extends AddressedVectorTableScanSource {
+  /** Specialized tile source that owns tile addressing and decoding. */
+  readonly source: VectorTileSource;
+  /** Immutable tile address bound to this table view. */
+  readonly tile: Omit<GetTileParameters, 'signal'>;
+
+  /** Creates a portable table view over one vector tile. */
+  constructor(source: VectorTileSource, options: VectorTileTableScanSourceOptions) {
+    const tile = Object.freeze({...options.tile});
+    super(options, {
+      sourceType: 'vector-tile-table',
+      description: `Vector tile ${tile.z}/${tile.x}/${tile.y}`,
+      spatial: {
+        bounds: getWGS84TileBounds(tile),
+        coordinateReferenceSystems: ['EPSG:4326']
+      }
+    });
+    this.source = source;
+    this.tile = tile;
+  }
+
+  /** Loads the bound vector tile using the source's requested Arrow output shape. */
+  protected loadTable(signal?: AbortSignal): Promise<ArrowTable | null> {
+    return this.source.getVectorTile({...this.tile, signal}) as Promise<ArrowTable | null>;
+  }
+}
+
+/**
+ * Portable table-query view over one explicitly bounded vector-service request.
+ *
+ * WFS and ArcGIS feature sources participate through their existing Arrow feature output. Layers,
+ * service bounds, and output CRS remain source parameters rather than relational operators.
+ */
+export class VectorFeatureTableScanSource extends AddressedVectorTableScanSource {
+  /** Specialized vector source that owns service request construction and parsing. */
+  readonly source: VectorSource;
+  /** Immutable bounded feature request bound to this table view. */
+  readonly request: Omit<GetFeaturesParameters, 'format' | 'signal'>;
+
+  /** Creates a portable table view over one bounded vector-service request. */
+  constructor(source: VectorSource, options: VectorFeatureTableScanSourceOptions) {
+    const request = Object.freeze({...options.request});
+    const coordinateReferenceSystems = typeof request.crs === 'string' ? [request.crs] : undefined;
+    super(options, {
+      sourceType: 'vector-feature-table',
+      description: `Vector feature request for ${normalizeLayers(request.layers).join(', ')}`,
+      spatial: {
+        bounds: {
+          minimum: Object.freeze([...request.boundingBox[0]]),
+          maximum: Object.freeze([...request.boundingBox[1]])
+        },
+        coordinateReferenceSystems
+      }
+    });
+    this.source = source;
+    this.request = request;
+  }
+
+  /** Loads the bound service request through the source's Arrow feature output. */
+  protected loadTable(signal?: AbortSignal): Promise<ArrowTable | null> {
+    return this.source.getFeatures({
+      ...this.request,
+      format: 'arrow',
+      signal
+    }) as Promise<ArrowTable | null>;
+  }
+}
+
+/** Returns the WGS84 extent of one XYZ tile address. */
+function getWGS84TileBounds(tile: Pick<GetTileParameters, 'x' | 'y' | 'z'>) {
+  const scale = 2 ** tile.z;
+  return {
+    minimum: [(tile.x / scale) * 360 - 180, tileYToLatitude(tile.y + 1, scale)],
+    maximum: [((tile.x + 1) / scale) * 360 - 180, tileYToLatitude(tile.y, scale)]
+  };
+}
+
+/** Converts one XYZ tile row to its WGS84 latitude edge. */
+function tileYToLatitude(tileY: number, scale: number): number {
+  return (Math.atan(Math.sinh(Math.PI * (1 - (2 * tileY) / scale))) * 180) / Math.PI;
+}
+
+/** Infers the small semantic-role set useful for vector feature query controls. */
+function inferVectorColumnRoles(columnNames: readonly string[]) {
+  return Object.fromEntries(
+    columnNames.map(columnName => [
+      columnName,
+      columnName.toLowerCase() === 'geometry' ? 'geometry' : 'attribute'
+    ])
+  ) as Readonly<Record<string, 'geometry' | 'attribute'>>;
+}
+
+/** Normalizes a single layer name to the service API's list shape. */
+function normalizeLayers(layers: string | string[]): string[] {
+  return Array.isArray(layers) ? layers : [layers];
+}
+
+/** Throws before physical or residual work begins when cancellation was requested. */
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw signal.reason || new DOMException('Request aborted', 'AbortError');
+  }
+}

--- a/modules/scan/test/vector-table-scan-source.spec.ts
+++ b/modules/scan/test/vector-table-scan-source.spec.ts
@@ -20,6 +20,7 @@ import {
 test('VectorTileTableScanSource binds tile addressing outside the portable query', async () => {
   const sourceTable = makeArrowTable({id: [1, 2, 3], value: [10, 20, 30]});
   const requestedTiles: GetTileParameters[] = [];
+  const tileLayers = ['roads'];
   const source = {
     async getMetadata() {
       return {minZoom: 0, maxZoom: 10};
@@ -42,8 +43,9 @@ test('VectorTileTableScanSource binds tile addressing outside the portable query
     sourceType: 'mvt-tile-table',
     name: 'Roads',
     description: 'Addressed roads tile',
-    tile: {x: 2, y: 1, z: 2, layers: ['roads']}
+    tile: {x: 2, y: 1, z: 2, layers: tileLayers}
   });
+  tileLayers.push('mutated');
 
   const metadata = await scanSource.getQueryMetadata();
   expect(metadata).toMatchObject({
@@ -71,6 +73,7 @@ test('VectorTileTableScanSource binds tile addressing outside the portable query
   expect(Array.from(batches[0].data.getChild('id')?.toArray() || [])).toEqual([2]);
   expect(requestedTiles).toHaveLength(1);
   expect(requestedTiles[0]).toMatchObject({x: 2, y: 1, z: 2, layers: ['roads']});
+  expect(Object.isFrozen(scanSource.tile.layers)).toBe(true);
 });
 
 test('VectorFeatureTableScanSource binds service controls and requests Arrow output', async () => {
@@ -173,6 +176,7 @@ test('addressed vector scans propagate cancellation and reject non-Arrow output'
 test('addressed vector scans infer missing schema and optional service metadata', async () => {
   const data = arrow.tableFromArrays({id: [1]});
   const sourceTable = {shape: 'arrow-table', data} as ArrowTable;
+  const requests: GetFeaturesParameters[] = [];
   const source = {
     async getSchema() {
       return convertArrowToSchema(data.schema);
@@ -180,25 +184,81 @@ test('addressed vector scans infer missing schema and optional service metadata'
     async getMetadata() {
       return {name: 'features', keywords: [], layers: []};
     },
-    async getFeatures() {
+    async getFeatures(parameters: GetFeaturesParameters) {
+      requests.push(parameters);
       return sourceTable;
     }
   } as VectorSource;
+  const layers = ['roads', 'buildings'];
+  const boundingBox: GetFeaturesParameters['boundingBox'] = [
+    [0, 0],
+    [1, 1]
+  ];
   const scanSource = new VectorFeatureTableScanSource(source, {
     request: {
-      layers: ['roads', 'buildings'],
-      boundingBox: [
-        [0, 0],
-        [1, 1]
-      ]
+      layers,
+      boundingBox
     }
   });
+  layers.push('mutated');
+  boundingBox[0][0] = 10;
 
   const metadata = await scanSource.getQueryMetadata();
   expect(metadata.sourceType).toBe('vector-feature-table');
   expect(metadata.description).toBe('Vector feature request for roads, buildings');
   expect(metadata.columns.map(column => column.name)).toEqual(['id']);
   expect(metadata.spatial?.coordinateReferenceSystems).toBeUndefined();
+  expect(requests[0]).toMatchObject({
+    layers: ['roads', 'buildings'],
+    boundingBox: [
+      [0, 0],
+      [1, 1]
+    ]
+  });
+  expect(Object.isFrozen(scanSource.request.layers)).toBe(true);
+  expect(Object.isFrozen(scanSource.request.boundingBox)).toBe(true);
+  expect(Object.isFrozen(scanSource.request.boundingBox[0])).toBe(true);
+});
+
+test('addressed vector scans isolate shared loads from caller cancellation', async () => {
+  const sourceTable = makeArrowTable({id: [1]});
+  let resolveLoad!: (table: ArrowTable) => void;
+  let loadCount = 0;
+  let physicalSignal: AbortSignal | undefined;
+  const source = {
+    async getMetadata() {
+      return {};
+    },
+    async getTile() {
+      return null;
+    },
+    async getTileData() {
+      return null;
+    },
+    async getSchema() {
+      return sourceTable.schema;
+    },
+    getVectorTile(parameters: GetTileParameters) {
+      loadCount++;
+      physicalSignal = parameters.signal;
+      return new Promise<ArrowTable>(resolve => {
+        resolveLoad = resolve;
+      });
+    }
+  } satisfies VectorTileSource;
+  const scanSource = new VectorTileTableScanSource(source, {tile: {x: 0, y: 0, z: 0}});
+  const cancelledController = new AbortController();
+  const successfulController = new AbortController();
+
+  const cancelledMetadata = scanSource.getQueryMetadata({signal: cancelledController.signal});
+  const successfulQuery = scanSource.query({signal: successfulController.signal});
+  cancelledController.abort();
+
+  await expect(cancelledMetadata).rejects.toMatchObject({name: 'AbortError'});
+  resolveLoad(sourceTable);
+  await expect(successfulQuery).resolves.toMatchObject({shape: 'arrow-table'});
+  expect(loadCount).toBe(1);
+  expect(physicalSignal).toBeUndefined();
 });
 
 /** Creates a loaders.gl Arrow table from ordinary named arrays. */

--- a/modules/scan/test/vector-table-scan-source.spec.ts
+++ b/modules/scan/test/vector-table-scan-source.spec.ts
@@ -1,0 +1,210 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import * as arrow from 'apache-arrow';
+import {expect, test} from 'vitest';
+import type {
+  GetFeaturesParameters,
+  GetTileParameters,
+  VectorSource,
+  VectorTileSource
+} from '@loaders.gl/loader-utils';
+import type {ArrowTable} from '@loaders.gl/schema';
+import {convertArrowToSchema} from '@loaders.gl/schema-utils';
+import {
+  VectorFeatureTableScanSource,
+  VectorTileTableScanSource
+} from '../src/vector-table-scan-source';
+
+test('VectorTileTableScanSource binds tile addressing outside the portable query', async () => {
+  const sourceTable = makeArrowTable({id: [1, 2, 3], value: [10, 20, 30]});
+  const requestedTiles: GetTileParameters[] = [];
+  const source = {
+    async getMetadata() {
+      return {minZoom: 0, maxZoom: 10};
+    },
+    async getTile() {
+      return null;
+    },
+    async getTileData() {
+      return null;
+    },
+    async getSchema() {
+      return sourceTable.schema;
+    },
+    async getVectorTile(parameters: GetTileParameters) {
+      requestedTiles.push(parameters);
+      return sourceTable;
+    }
+  } satisfies VectorTileSource;
+  const scanSource = new VectorTileTableScanSource(source, {
+    sourceType: 'mvt-tile-table',
+    name: 'Roads',
+    description: 'Addressed roads tile',
+    tile: {x: 2, y: 1, z: 2, layers: ['roads']}
+  });
+
+  const metadata = await scanSource.getQueryMetadata();
+  expect(metadata).toMatchObject({
+    sourceType: 'mvt-tile-table',
+    queryType: 'table',
+    execution: {status: 'supported', method: 'read'},
+    name: 'Roads',
+    description: 'Addressed roads tile',
+    statistics: {rowCount: 3}
+  });
+  expect(metadata.columns.map(column => column.name)).toEqual(['id', 'value']);
+  expect(metadata.capabilities.bounds).toBe('unsupported');
+  expect(metadata.spatial?.bounds?.minimum[0]).toBe(0);
+  expect(metadata.spatial?.bounds?.maximum[0]).toBe(90);
+
+  const batches = [];
+  for await (const batch of scanSource.read({
+    predicate: {op: '>', args: [{property: 'value'}, 10]},
+    columns: ['id'],
+    limit: 1
+  })) {
+    batches.push(batch);
+  }
+  expect(batches.map(batch => batch.length)).toEqual([1]);
+  expect(Array.from(batches[0].data.getChild('id')?.toArray() || [])).toEqual([2]);
+  expect(requestedTiles).toHaveLength(1);
+  expect(requestedTiles[0]).toMatchObject({x: 2, y: 1, z: 2, layers: ['roads']});
+});
+
+test('VectorFeatureTableScanSource binds service controls and requests Arrow output', async () => {
+  const sourceTable = makeArrowTable({geometry: ['first', 'second'], score: [1, 2]});
+  const requests: GetFeaturesParameters[] = [];
+  const source = {
+    async getSchema() {
+      return sourceTable.schema;
+    },
+    async getMetadata() {
+      return {name: 'features', keywords: [], layers: []};
+    },
+    async getFeatures(parameters: GetFeaturesParameters) {
+      requests.push(parameters);
+      return sourceTable;
+    }
+  } as VectorSource;
+  const scanSource = new VectorFeatureTableScanSource(source, {
+    sourceType: 'wfs-feature-table',
+    request: {
+      layers: 'buildings',
+      boundingBox: [
+        [-10, -5],
+        [10, 5]
+      ],
+      crs: 'EPSG:4326'
+    }
+  });
+
+  const metadata = await scanSource.getQueryMetadata();
+  expect(metadata.columns.find(column => column.name === 'geometry')?.role).toBe('geometry');
+  expect(metadata.spatial).toEqual({
+    bounds: {minimum: [-10, -5], maximum: [10, 5]},
+    coordinateReferenceSystems: ['EPSG:4326']
+  });
+  expect(requests[0]).toMatchObject({layers: 'buildings', format: 'arrow'});
+
+  const explanation = await scanSource.explain({columns: ['score'], limit: 1});
+  expect(explanation.plan.map(operator => operator.kind)).toEqual(['scan', 'project', 'limit']);
+  expect(explanation.operators.projection).toEqual({enabled: true, support: 'residual'});
+  expect(explanation.operators.limit).toEqual({enabled: true, support: 'residual'});
+  expect(requests).toHaveLength(1);
+});
+
+test('addressed vector scans propagate cancellation and reject non-Arrow output', async () => {
+  let requestCount = 0;
+  const source = {
+    async getMetadata() {
+      return {};
+    },
+    async getTile() {
+      return null;
+    },
+    async getTileData() {
+      return null;
+    },
+    async getSchema() {
+      return {fields: [], metadata: {}};
+    },
+    async getVectorTile() {
+      requestCount++;
+      return {shape: 'geojson-table', type: 'FeatureCollection', features: []} as const;
+    }
+  } satisfies VectorTileSource;
+  const cancelledSource = new VectorTileTableScanSource(source, {
+    tile: {x: 0, y: 0, z: 0}
+  });
+  const controller = new AbortController();
+  controller.abort();
+
+  await expect(cancelledSource.getQueryMetadata({signal: controller.signal})).rejects.toMatchObject(
+    {
+      name: 'AbortError'
+    }
+  );
+  expect(requestCount).toBe(0);
+
+  const missingReasonSignal = {aborted: true, reason: undefined} as AbortSignal;
+  await expect(
+    cancelledSource.getQueryMetadata({signal: missingReasonSignal})
+  ).rejects.toMatchObject({name: 'AbortError'});
+
+  const emptySource = new VectorTileTableScanSource(
+    {
+      ...source,
+      async getVectorTile() {
+        return null;
+      }
+    },
+    {tile: {x: 0, y: 0, z: 0}}
+  );
+  await expect(emptySource.getQueryMetadata()).rejects.toThrow('did not return a feature table');
+
+  const invalidSource = new VectorTileTableScanSource(source, {tile: {x: 0, y: 0, z: 0}});
+  await expect(invalidSource.getQueryMetadata()).rejects.toThrow('shape "arrow-table"');
+  await expect(invalidSource.getQueryMetadata()).rejects.toThrow('shape "arrow-table"');
+  expect(requestCount).toBe(2);
+});
+
+test('addressed vector scans infer missing schema and optional service metadata', async () => {
+  const data = arrow.tableFromArrays({id: [1]});
+  const sourceTable = {shape: 'arrow-table', data} as ArrowTable;
+  const source = {
+    async getSchema() {
+      return convertArrowToSchema(data.schema);
+    },
+    async getMetadata() {
+      return {name: 'features', keywords: [], layers: []};
+    },
+    async getFeatures() {
+      return sourceTable;
+    }
+  } as VectorSource;
+  const scanSource = new VectorFeatureTableScanSource(source, {
+    request: {
+      layers: ['roads', 'buildings'],
+      boundingBox: [
+        [0, 0],
+        [1, 1]
+      ]
+    }
+  });
+
+  const metadata = await scanSource.getQueryMetadata();
+  expect(metadata.sourceType).toBe('vector-feature-table');
+  expect(metadata.description).toBe('Vector feature request for roads, buildings');
+  expect(metadata.columns.map(column => column.name)).toEqual(['id']);
+  expect(metadata.spatial?.coordinateReferenceSystems).toBeUndefined();
+});
+
+/** Creates a loaders.gl Arrow table from ordinary named arrays. */
+function makeArrowTable(
+  columns: Record<string, arrow.TypedArray | readonly unknown[]>
+): ArrowTable {
+  const data = arrow.tableFromArrays(columns);
+  return {shape: 'arrow-table', schema: convertArrowToSchema(data.schema), data};
+}

--- a/modules/sql/src/query-arrow-table.ts
+++ b/modules/sql/src/query-arrow-table.ts
@@ -19,7 +19,6 @@ import {
 } from './sql-predicate-types';
 import {
   getSQLPredicateColumnNames,
-  explainTableQuery,
   planTableQuery,
   type TableQueryFilterStep,
   type TableQueryLimitStep,
@@ -33,8 +32,13 @@ import type {
   RelationalExpression,
   RelationalOrderKey
 } from '@loaders.gl/loader-utils';
-import {planRelationalQuery} from '@loaders.gl/loader-utils';
-export {ARROW_TABLE_QUERY_CAPABILITIES} from './table-query-capabilities';
+import {
+  explainTableQuery as explainColumnarTableQuery,
+  planRelationalQuery
+} from '@loaders.gl/loader-utils';
+import {ARROW_TABLE_QUERY_CAPABILITIES} from './table-query-capabilities';
+import {validateSQLPredicate} from './sql-predicate-schema';
+export {ARROW_TABLE_QUERY_CAPABILITIES};
 
 /** A named child relation using the SQL module's property-oriented predicate AST. */
 type ArrowChildQuery = Readonly<{
@@ -67,9 +71,13 @@ export type ArrowQueryOptions = TableQueryOptions &
 
 /** Explains an Arrow table query without materializing or scanning table rows. */
 export function explainArrowTableQuery(sourceTable: ArrowTable, options: ArrowQueryOptions = {}) {
-  return explainTableQuery(
+  if (options.predicate) {
+    validateSQLPredicate(options.predicate);
+  }
+  return explainColumnarTableQuery(
     sourceTable.data.schema.fields.map(field => field.name),
-    options
+    options,
+    ARROW_TABLE_QUERY_CAPABILITIES
   );
 }
 

--- a/modules/sql/test/arrow-query.spec.ts
+++ b/modules/sql/test/arrow-query.spec.ts
@@ -30,6 +30,21 @@ test('Arrow executor advertises portable query capabilities', () => {
   expect(Object.isFrozen(ARROW_TABLE_QUERY_CAPABILITIES)).toBe(true);
 });
 
+test('Arrow executor explains operators as residual work', () => {
+  const source = new ArrowTableSource(makeArrowTable({id: [1], value: [10]}));
+  const explanation = source.explain({
+    predicate: {op: '>', args: [{property: 'value'}, 5]},
+    columns: ['id'],
+    limit: 1
+  });
+
+  expect(explanation.operators).toEqual({
+    projection: {enabled: true, support: 'residual'},
+    predicate: {enabled: true, support: 'residual'},
+    limit: {enabled: true, support: 'residual'}
+  });
+});
+
 test('ArrowTableSource exposes shared metadata and bounded scan batches', async () => {
   const source = new ArrowTableSource(makeArrowTable({x: [1, 2], value: [10, 20]}));
 


### PR DESCRIPTION
## Goals

- Land the first conclusive tiles/services bridge while keeping physical tile and service controls outside the portable `TableQuery` AST.
- Let MVT, vector PMTiles, WFS, and ArcGIS FeatureServer results reuse the shared Arrow scan/query surface through the opt-in `@loaders.gl/scan` package.
- Preserve lightweight format imports, truthful residual-query diagnostics, and cooperative cancellation.

## Changes

- Add `VectorTileTableScanSource` and `VectorFeatureTableScanSource` adapters that bind one physical tile or bounded service request, then expose metadata, query, explain, and read operations over the resulting Arrow feature table.
- Cache the addressed Arrow result across metadata discovery and query execution, infer feature-column roles and spatial metadata, and reject null or non-Arrow source output with actionable errors.
- Add `AbortSignal` to `GetTileParameters`, forward it through MVT tile fetches, and remove PMTiles' untyped signal access.
- Correct the Arrow executor's existing explain path so it reports residual operators consistently with `ARROW_TABLE_QUERY_CAPABILITIES` instead of SQL-source pushdown.
- Document addressed vector tables and update roadmap tranche 7 and the end-user support scorecard.
- Add owning and integration tests for addressing boundaries, metadata, bounds, caching, schema inference, filtering, projection, limit, explain, cancellation, invalid output, and retry behavior.

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn build-workers`
- `yarn test-audit`
- `yarn test-node` — 360 passed, 6 skipped
- `yarn test-headless` — 3009 passed, 40 skipped
- focused post-rebase Chromium suite — 29 passed
- full Node + Chromium coverage and Chromium-only coverage
- `yarn test-coverage-check` — 53 packages, 0 violations; new scan adapter at 100% statements, lines, functions, and branches
