### PR TITLE
test: migrate GIS and MVT suites to Vitest

### DIFF
--- a/modules/gis/test/binary-features/arrow-binary-feature-collection.spec.ts
+++ b/modules/gis/test/binary-features/arrow-binary-feature-collection.spec.ts
@@ -2,56 +2,46 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {
   convertArrowBinaryFeatureCollectionToBinaryFeatureCollection,
   convertBinaryFeatureCollectionToArrowBinaryFeatureCollection,
   convertGeometryValuesToBinaryFeatureCollection
 } from '@loaders.gl/gis';
-
-test('gis#arrow-binary-feature-collection wraps renderable binary features in Arrow tables', t => {
+test('gis#arrow-binary-feature-collection wraps renderable binary features in Arrow tables', () => {
   const binaryFeatures = convertGeometryValuesToBinaryFeatureCollection(
     ['POINT (1 2)', 'LINESTRING (0 0, 1 1, 2 2)', 'POLYGON ((0 0, 3 0, 3 3, 0 0))'],
     {geometryEncoding: 'wkt'}
   );
   const arrowBinaryFeatures =
     convertBinaryFeatureCollectionToArrowBinaryFeatureCollection(binaryFeatures);
-
-  t.equal(
+  expect(
     String(arrowBinaryFeatures.points?.table.schema.fields[0].type),
-    'List<FixedSizeList[2]<Float64>>',
     'wraps point geometry in a list of coordinates'
-  );
-  t.equal(
+  ).toBe('List<FixedSizeList[2]<Float64>>');
+  expect(
     String(arrowBinaryFeatures.lines?.table.schema.fields[0].type),
-    'List<FixedSizeList[2]<Float64>>',
     'wraps line geometry in a list of coordinates'
-  );
-  t.equal(
+  ).toBe('List<FixedSizeList[2]<Float64>>');
+  expect(
     String(arrowBinaryFeatures.polygons?.table.schema.fields[0].type),
-    'List<List<FixedSizeList[2]<Float64>>>',
     'wraps polygon geometry in nested Arrow lists'
-  );
-  t.equal(
+  ).toBe('List<List<FixedSizeList[2]<Float64>>>');
+  expect(
     String(arrowBinaryFeatures.polygons?.table.getChild('polygonIndices')?.type),
-    'List<Uint32>',
     'stores raw polygon indices as a sidecar Arrow column'
-  );
-  t.equal(
+  ).toBe('List<Uint32>');
+  expect(
     arrowBinaryFeatures.lines?.table.getChild('geometry')?.data[0].valueOffsets.buffer,
-    binaryFeatures.lines?.pathIndices.value.buffer,
     'reuses line path offsets without copying'
-  );
-  t.equal(
+  ).toBe(binaryFeatures.lines?.pathIndices.value.buffer);
+  expect(
     arrowBinaryFeatures.lines?.table.getChild('geometry')?.data[0].children[0].children[0].values
       .buffer,
-    binaryFeatures.lines?.positions.value.buffer,
     'reuses line coordinate values without copying'
-  );
-  t.end();
+  ).toBe(binaryFeatures.lines?.positions.value.buffer);
 });
-
-test('gis#arrow-binary-feature-collection round-trips binary feature collections', t => {
+test('gis#arrow-binary-feature-collection round-trips binary feature collections', () => {
   const binaryFeatures = convertGeometryValuesToBinaryFeatureCollection(
     ['MULTIPOINT ((1 2), (3 4))', 'LINESTRING (0 0, 1 1)', 'POLYGON ((0 0, 2 0, 2 2, 0 0))'],
     {geometryEncoding: 'wkt'}
@@ -68,66 +58,52 @@ test('gis#arrow-binary-feature-collection round-trips binary feature collections
     value: new Float32Array([3, 3, 3, 3]),
     size: 1
   };
-
   const arrowBinaryFeatures =
     convertBinaryFeatureCollectionToArrowBinaryFeatureCollection(binaryFeatures);
   const roundTrippedBinaryFeatures =
     convertArrowBinaryFeatureCollectionToBinaryFeatureCollection(arrowBinaryFeatures);
-
-  t.deepEqual(
+  expect(
     Array.from(roundTrippedBinaryFeatures.points?.positions.value || []),
-    Array.from(binaryFeatures.points?.positions.value || []),
     'round-trips point positions'
-  );
-  t.deepEqual(
+  ).toEqual(Array.from(binaryFeatures.points?.positions.value || []));
+  expect(
     Array.from(roundTrippedBinaryFeatures.lines?.pathIndices.value || []),
-    Array.from(binaryFeatures.lines?.pathIndices.value || []),
     'round-trips line path indices'
-  );
-  t.deepEqual(
+  ).toEqual(Array.from(binaryFeatures.lines?.pathIndices.value || []));
+  expect(
     Array.from(roundTrippedBinaryFeatures.polygons?.polygonIndices.value || []),
-    Array.from(binaryFeatures.polygons?.polygonIndices.value || []),
     'round-trips polygon indices'
-  );
-  t.deepEqual(
+  ).toEqual(Array.from(binaryFeatures.polygons?.polygonIndices.value || []));
+  expect(
     Array.from(roundTrippedBinaryFeatures.polygons?.primitivePolygonIndices.value || []),
-    Array.from(binaryFeatures.polygons?.primitivePolygonIndices.value || []),
     'round-trips primitive polygon indices'
-  );
-  t.deepEqual(
+  ).toEqual(Array.from(binaryFeatures.polygons?.primitivePolygonIndices.value || []));
+  expect(
     Array.from(roundTrippedBinaryFeatures.polygons?.triangles?.value || []),
-    Array.from(binaryFeatures.polygons?.triangles?.value || []),
     'round-trips polygon triangles'
-  );
-  t.deepEqual(
+  ).toEqual(Array.from(binaryFeatures.polygons?.triangles?.value || []));
+  expect(
     Array.from(roundTrippedBinaryFeatures.points?.numericProps.weight.value || []),
-    [1, 1],
     'round-trips point numeric props'
-  );
-  t.deepEqual(
+  ).toEqual([1, 1]);
+  expect(
     Array.from(roundTrippedBinaryFeatures.lines?.numericProps.weight.value || []),
-    [2, 2],
     'round-trips line numeric props'
-  );
-  t.deepEqual(
+  ).toEqual([2, 2]);
+  expect(
     Array.from(roundTrippedBinaryFeatures.polygons?.numericProps.weight.value || []),
-    [3, 3, 3, 3],
     'round-trips polygon numeric props'
-  );
-  t.equal(
+  ).toEqual([3, 3, 3, 3]);
+  expect(
     roundTrippedBinaryFeatures.lines?.positions.value.buffer,
-    binaryFeatures.lines?.positions.value.buffer,
     'round-trips line positions zero-copy'
-  );
-  t.equal(
+  ).toBe(binaryFeatures.lines?.positions.value.buffer);
+  expect(
     roundTrippedBinaryFeatures.lines?.pathIndices.value.buffer,
-    binaryFeatures.lines?.pathIndices.value.buffer,
     'round-trips line offsets zero-copy'
-  );
-  t.equal(
+  ).toBe(binaryFeatures.lines?.pathIndices.value.buffer);
+  expect(
     roundTrippedBinaryFeatures.polygons?.polygonIndices.value.buffer,
-    binaryFeatures.polygons?.polygonIndices.value.buffer,
     'round-trips polygon indices zero-copy'
-  );
-  t.end();
+  ).toBe(binaryFeatures.polygons?.polygonIndices.value.buffer);
 });

--- a/modules/gis/test/binary-features/binary-to-geojson.spec.ts
+++ b/modules/gis/test/binary-features/binary-to-geojson.spec.ts
@@ -2,104 +2,75 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-/* eslint-disable max-depth */
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import type {BinaryFeatureCollection, FeatureCollection} from '@loaders.gl/schema';
 import {fetchFile} from '@loaders.gl/core';
 import {binaryToGeojson, convertBinaryGeometryToGeometry} from '@loaders.gl/gis';
-
 import {GEOMETRY_TEST_CASES} from '@loaders.gl/gis/test/data/binary-features/geometry-test-cases';
 import {EMPTY_BINARY_DATA} from '@loaders.gl/gis/test/data/binary-features/empty_binary';
-
 const FEATURE_COLLECTION_TEST_CASES =
   '@loaders.gl/gis/test/data/binary-features/featurecollection.json';
-
 type FeatureCollectionTestCase = {
   geoJSON: FeatureCollection;
   binary: BinaryFeatureCollection;
 };
-
-test('binary-to-geojson feature collections', async t => {
+test('binary-to-geojson feature collections', async () => {
   const response = await fetchFile(FEATURE_COLLECTION_TEST_CASES);
   const json = (await response.json()) as Record<string, FeatureCollectionTestCase>;
-
   // `mixed` test case fails test, disable until we land fix
   // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
   const {mixed, ...TEST_CASES} = parseTestCases(json);
-
   for (const testCase of Object.values(TEST_CASES)) {
     if (testCase.geoJSON && testCase.binary) {
-      t.deepEqual(binaryToGeojson(testCase.binary), testCase.geoJSON.features);
-      // t.deepEqual(binaryToGeoJson(testCase.binary), testCase.geoJSON.features);
+      expect(binaryToGeojson(testCase.binary)).toEqual(testCase.geoJSON.features);
     }
   }
-
-  t.end();
 });
-
-test('binary-to-geojson geometries', t => {
+test('binary-to-geojson geometries', () => {
   for (const testCase of GEOMETRY_TEST_CASES) {
     const binaryData = testCase.binary;
-    t.deepEqual(convertBinaryGeometryToGeometry(binaryData), testCase.geoJSON);
-    // t.deepEqual(binaryToGeoJson(binaryData, binaryData.type, 'geometry'), testCase.geoJSON);
+    expect(convertBinaryGeometryToGeometry(binaryData)).toEqual(testCase.geoJSON);
   }
-
-  t.end();
 });
-
-test('binary-to-geojson !isHeterogeneousType', async t => {
+test('binary-to-geojson !isHeterogeneousType', async () => {
   const response = await fetchFile(FEATURE_COLLECTION_TEST_CASES);
   const json = await response.json();
   // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
   const {mixed, ...TEST_CASES} = parseTestCases(json);
   for (const testCase of Object.values(TEST_CASES)) {
     const binaryData = testCase.binary;
-    t.deepEqual(binaryToGeojson(binaryData), testCase.geoJSON.features);
+    expect(binaryToGeojson(binaryData)).toEqual(testCase.geoJSON.features);
   }
-
-  t.end();
 });
-
-test('binary-to-geojson from empty binary object returns empty features array', t => {
+test('binary-to-geojson from empty binary object returns empty features array', () => {
   const geojson = binaryToGeojson(EMPTY_BINARY_DATA);
-  t.ok(Array.isArray(geojson));
+  expect(Array.isArray(geojson)).toBeTruthy();
   // @ts-ignore binaryToGeojson typings are too loose
-  t.equal(geojson?.length, 0);
-
-  t.end();
+  expect(geojson?.length).toBe(0);
 });
-
-test('binary-to-geojson getSingleFeature', async t => {
+test('binary-to-geojson getSingleFeature', async () => {
   const response = await fetchFile(FEATURE_COLLECTION_TEST_CASES);
   const json = await response.json();
   const TEST_CASES = parseTestCases(json);
-
   for (const testCase of Object.values(TEST_CASES)) {
     if (testCase.geoJSON && testCase.binary) {
       for (let i = 0; i < testCase.geoJSON.features.length; ++i) {
-        t.deepEqual(
-          binaryToGeojson(testCase.binary, {globalFeatureId: i}),
+        expect(binaryToGeojson(testCase.binary, {globalFeatureId: i})).toEqual(
           testCase.geoJSON.features[i]
         );
       }
     }
   }
-
-  t.end();
 });
-
-test('binary-to-geojson getSingleFeature fail', async t => {
+test('binary-to-geojson getSingleFeature fail', async () => {
   const response = await fetchFile(FEATURE_COLLECTION_TEST_CASES);
   const json = await response.json();
   const testCase = parseTestCases(json).point;
-  t.throws(
+  expect(
     () => binaryToGeojson(testCase.binary, {globalFeatureId: -1}),
     'throws when globalFeatureId is not found'
-  );
-
-  t.end();
+  ).toThrow();
 });
-
 /** @note Mutatis mutandis - Mutates input object */
 function parseTestCases(
   testCases: Record<string, FeatureCollectionTestCase>

--- a/modules/gis/test/binary-features/geojson-to-binary.spec.ts
+++ b/modules/gis/test/binary-features/geojson-to-binary.spec.ts
@@ -2,12 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-/* eslint-disable max-statements */
-// @ts-nocheck
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {fetchFile} from '@loaders.gl/core';
 import {geojsonToBinary, getGeometryInfo, _extractNumericPropTypes} from '@loaders.gl/gis';
-
 // Sample GeoJSON data derived from examples in GeoJSON specification
 // https://tools.ietf.org/html/rfc7946#appendix-A
 // All features have 2D coordinates
@@ -16,12 +13,10 @@ const FEATURES_2D = '@loaders.gl/gis/test/data/binary-features/2d_features.json'
 const FEATURES_3D = '@loaders.gl/gis/test/data/binary-features/3d_features.json';
 // Some features have 3D coordinates
 const FEATURES_MIXED = '@loaders.gl/gis/test/data/binary-features/mixed_features.json';
-
 // Example GeoJSON with no properties
 const GEOJSON_NO_PROPERTIES =
   '@loaders.gl/gis/test/data/binary-features/geojson_no_properties.json';
-
-test('gis#geojson-to-binary geometry info 2D features, no properties', async t => {
+test('gis#geojson-to-binary geometry info 2D features, no properties', async () => {
   const response = await fetchFile(FEATURES_2D);
   const {features} = await response.json();
   const geometryInfo = getGeometryInfo(features);
@@ -37,21 +32,18 @@ test('gis#geojson-to-binary geometry info 2D features, no properties', async t =
     polygonFeaturesCount,
     coordLength
   } = geometryInfo;
-
-  t.equal(pointPositionsCount, 3);
-  t.equal(pointFeaturesCount, 2);
-  t.equal(linePositionsCount, 6);
-  t.equal(linePathsCount, 3);
-  t.equal(lineFeaturesCount, 2);
-  t.equal(polygonPositionsCount, 30);
-  t.equal(polygonObjectsCount, 4);
-  t.equal(polygonRingsCount, 6);
-  t.equal(polygonFeaturesCount, 3);
-  t.equal(coordLength, 2);
-  t.end();
+  expect(pointPositionsCount).toBe(3);
+  expect(pointFeaturesCount).toBe(2);
+  expect(linePositionsCount).toBe(6);
+  expect(linePathsCount).toBe(3);
+  expect(lineFeaturesCount).toBe(2);
+  expect(polygonPositionsCount).toBe(30);
+  expect(polygonObjectsCount).toBe(4);
+  expect(polygonRingsCount).toBe(6);
+  expect(polygonFeaturesCount).toBe(3);
+  expect(coordLength).toBe(2);
 });
-
-test('gis#geojson-to-binary geometry info 3D features, no properties', async t => {
+test('gis#geojson-to-binary geometry info 3D features, no properties', async () => {
   const response = await fetchFile(FEATURES_3D);
   const {features} = await response.json();
   const geometryInfo = getGeometryInfo(features);
@@ -67,21 +59,18 @@ test('gis#geojson-to-binary geometry info 3D features, no properties', async t =
     polygonFeaturesCount,
     coordLength
   } = geometryInfo;
-
-  t.equal(pointPositionsCount, 3);
-  t.equal(pointFeaturesCount, 2);
-  t.equal(linePositionsCount, 6);
-  t.equal(linePathsCount, 3);
-  t.equal(lineFeaturesCount, 2);
-  t.equal(polygonPositionsCount, 30);
-  t.equal(polygonObjectsCount, 4);
-  t.equal(polygonRingsCount, 6);
-  t.equal(polygonFeaturesCount, 3);
-  t.equal(coordLength, 3);
-  t.end();
+  expect(pointPositionsCount).toBe(3);
+  expect(pointFeaturesCount).toBe(2);
+  expect(linePositionsCount).toBe(6);
+  expect(linePathsCount).toBe(3);
+  expect(lineFeaturesCount).toBe(2);
+  expect(polygonPositionsCount).toBe(30);
+  expect(polygonObjectsCount).toBe(4);
+  expect(polygonRingsCount).toBe(6);
+  expect(polygonFeaturesCount).toBe(3);
+  expect(coordLength).toBe(3);
 });
-
-test('gis#geojson-to-binary geometry info mixed-dimension features, no properties', async t => {
+test('gis#geojson-to-binary geometry info mixed-dimension features, no properties', async () => {
   const response = await fetchFile(FEATURES_MIXED);
   const {features} = await response.json();
   const geometryInfo = getGeometryInfo(features);
@@ -97,101 +86,80 @@ test('gis#geojson-to-binary geometry info mixed-dimension features, no propertie
     polygonFeaturesCount,
     coordLength
   } = geometryInfo;
-
-  t.equal(pointPositionsCount, 3);
-  t.equal(pointFeaturesCount, 2);
-  t.equal(linePositionsCount, 6);
-  t.equal(linePathsCount, 3);
-  t.equal(lineFeaturesCount, 2);
-  t.equal(polygonPositionsCount, 30);
-  t.equal(polygonObjectsCount, 4);
-  t.equal(polygonRingsCount, 6);
-  t.equal(polygonFeaturesCount, 3);
-  t.equal(coordLength, 3);
-
+  expect(pointPositionsCount).toBe(3);
+  expect(pointFeaturesCount).toBe(2);
+  expect(linePositionsCount).toBe(6);
+  expect(linePathsCount).toBe(3);
+  expect(lineFeaturesCount).toBe(2);
+  expect(polygonPositionsCount).toBe(30);
+  expect(polygonObjectsCount).toBe(4);
+  expect(polygonRingsCount).toBe(6);
+  expect(polygonFeaturesCount).toBe(3);
+  expect(coordLength).toBe(3);
   const {points, lines, polygons} = geojsonToBinary(features);
-
   // 3D size
-  t.equal(points.positions.size, 3);
-  t.equal(lines.positions.size, 3);
-  t.equal(polygons.positions.size, 3);
-
+  expect(points.positions.size).toBe(3);
+  expect(lines.positions.size).toBe(3);
+  expect(polygons.positions.size).toBe(3);
   // Test value equality, missing third dimension imputed as 0
-  t.deepEqual(points.positions.value, [100, 0, 1, 100, 0, 0, 101, 1, 0]);
-  t.deepEqual(
-    lines.positions.value,
-    [100, 0, 0, 101, 1, 0, 100, 0, 2, 101, 1, 0, 102, 2, 0, 103, 3, 0]
-  );
-  t.end();
+  expect(Array.from(points.positions.value)).toEqual([100, 0, 1, 100, 0, 0, 101, 1, 0]);
+  expect(Array.from(lines.positions.value)).toEqual([
+    100, 0, 0, 101, 1, 0, 100, 0, 2, 101, 1, 0, 102, 2, 0, 103, 3, 0
+  ]);
 });
-
-test('gis#geojson-to-binary numericPropTypes 2D features, no properties', async t => {
+test('gis#geojson-to-binary numericPropTypes 2D features, no properties', async () => {
   const response = await fetchFile(FEATURES_2D);
   const {features} = await response.json();
   const numericPropTypes = _extractNumericPropTypes(features);
-  t.deepEquals(numericPropTypes, []);
-  t.end();
+  expect(numericPropTypes).toEqual({});
 });
-
-test('gis#geojson-to-binary properties', async t => {
+test('gis#geojson-to-binary properties', async () => {
   const response = await fetchFile(FEATURES_2D);
   const {features} = await response.json();
-
   // Add properties to features
   // Uniform string, missing in some features
   features[0].properties.string1 = 'string';
   features[1].properties.string1 = 'string';
-
   // Uniform string, in all features
   for (const feature of features) {
     feature.properties.string2 = 'string';
   }
-
   // Mixed string/numeric, missing in some features
   features[0].properties.mixed1 = 'mixed';
   features[1].properties.mixed1 = 1;
-
   // Mixed string/numeric, in all features
   for (const feature of features) {
     feature.properties.mixed2 = 'string';
   }
   features[0].properties.mixed2 = 1;
-
   // Uniform integer, missing in some features
   features[0].properties.int1 = 0;
   features[1].properties.int1 = 1;
-
   // Uniform integer, in all features
   for (const feature of features) {
     feature.properties.int2 = 1;
   }
-
   // Mixed 32/64bit ints
   const LARGE = 80650000088;
   for (const feature of features) {
     feature.properties.int3 = 1;
   }
   features[1].properties.int3 = LARGE;
-
   // Uniform float, missing in some features
   features[0].properties.float1 = 3.14;
   features[1].properties.float1 = 2.14;
-
   // Uniform float, in all features
   for (const feature of features) {
     feature.properties.float2 = 3.14;
   }
-
   // Mixed int/float, missing in some features
   features[0].properties.numeric1 = 1;
   features[1].properties.numeric1 = 2.14;
-
   // Mixed int/float, in all features
   for (const feature of features) {
     feature.properties.numeric2 = 3.14;
   }
   features[0].properties.numeric2 = 1;
-
   const numericPropTypes = _extractNumericPropTypes(features);
   const expectedNumericPropTypes = {
     string1: Array,
@@ -206,35 +174,29 @@ test('gis#geojson-to-binary properties', async t => {
     numeric1: Float64Array,
     numeric2: Float64Array
   };
-  t.deepEquals(numericPropTypes, expectedNumericPropTypes);
+  expect(numericPropTypes).toEqual(expectedNumericPropTypes);
   const expectedNumericPropKeys = Object.keys(expectedNumericPropTypes).filter(
     k => expectedNumericPropTypes[k] !== Array
   );
-
   const {points, lines, polygons} = geojsonToBinary(features);
-
   // Check numeric properties keys exist
-  t.deepEquals(Object.keys(points.numericProps), expectedNumericPropKeys);
-  t.deepEquals(Object.keys(lines.numericProps), expectedNumericPropKeys);
-  t.deepEquals(Object.keys(polygons.numericProps), expectedNumericPropKeys);
-
+  expect(Object.keys(points.numericProps)).toEqual(expectedNumericPropKeys);
+  expect(Object.keys(lines.numericProps)).toEqual(expectedNumericPropKeys);
+  expect(Object.keys(polygons.numericProps)).toEqual(expectedNumericPropKeys);
   // Verify accessor size
-  t.equal(points.numericProps.int1.size, 1);
-  t.equal(lines.numericProps.int1.size, 1);
-  t.equal(polygons.numericProps.int1.size, 1);
-
+  expect(points.numericProps.int1.size).toBe(1);
+  expect(lines.numericProps.int1.size).toBe(1);
+  expect(polygons.numericProps.int1.size).toBe(1);
   // Verify value length
-  t.equal(points.numericProps.int1.value.length, 3);
-  t.equal(lines.numericProps.int1.value.length, 6);
-  t.equal(polygons.numericProps.int1.value.length, 30);
-
+  expect(points.numericProps.int1.value.length).toBe(3);
+  expect(lines.numericProps.int1.value.length).toBe(6);
+  expect(polygons.numericProps.int1.value.length).toBe(30);
   // Verify selected values
-  t.deepEquals(points.numericProps.int2.value, new Float32Array(3).fill(1));
-  t.deepEquals(points.numericProps.int3.value, new Float64Array([1, LARGE, LARGE]));
-  t.deepEquals(points.numericProps.float2.value, new Float64Array(3).fill(3.14));
-
+  expect(points.numericProps.int2.value).toEqual(new Float32Array(3).fill(1));
+  expect(points.numericProps.int3.value).toEqual(new Float64Array([1, LARGE, LARGE]));
+  expect(points.numericProps.float2.value).toEqual(new Float64Array(3).fill(3.14));
   // Verify point string property objects
-  t.deepEquals(points.properties, [
+  expect(points.properties).toEqual([
     {
       string1: 'string',
       string2: 'string',
@@ -248,9 +210,8 @@ test('gis#geojson-to-binary properties', async t => {
       mixed2: 'string'
     }
   ]);
-
   // Verify linestring string property objects
-  t.deepEquals(lines.properties, [
+  expect(lines.properties).toEqual([
     {
       string2: 'string',
       mixed2: 'string'
@@ -260,105 +221,88 @@ test('gis#geojson-to-binary properties', async t => {
       mixed2: 'string'
     }
   ]);
-  t.end();
 });
-
-test('gis#geojson-to-binary 2D features, no properties', async t => {
+test('gis#geojson-to-binary 2D features, no properties', async () => {
   const response = await fetchFile(FEATURES_2D);
   const {features} = await response.json();
   const {points, lines, polygons} = geojsonToBinary(features);
-
   // 2D size
-  t.equal(points.positions.size, 2);
-  t.equal(lines.positions.size, 2);
-  t.equal(polygons.positions.size, 2);
-
+  expect(points.positions.size).toBe(2);
+  expect(lines.positions.size).toBe(2);
+  expect(polygons.positions.size).toBe(2);
   // Other arrays have coordinate size 1
-  t.equal(points.globalFeatureIds.size, 1);
-  t.equal(points.featureIds.size, 1);
-  t.equal(lines.pathIndices.size, 1);
-  t.equal(lines.globalFeatureIds.size, 1);
-  t.equal(lines.featureIds.size, 1);
-  t.equal(polygons.polygonIndices.size, 1);
-  t.equal(polygons.primitivePolygonIndices.size, 1);
-  t.equal(polygons.globalFeatureIds.size, 1);
-  t.equal(polygons.featureIds.size, 1);
-
+  expect(points.globalFeatureIds.size).toBe(1);
+  expect(points.featureIds.size).toBe(1);
+  expect(lines.pathIndices.size).toBe(1);
+  expect(lines.globalFeatureIds.size).toBe(1);
+  expect(lines.featureIds.size).toBe(1);
+  expect(polygons.polygonIndices.size).toBe(1);
+  expect(polygons.primitivePolygonIndices.size).toBe(1);
+  expect(polygons.globalFeatureIds.size).toBe(1);
+  expect(polygons.featureIds.size).toBe(1);
   // Point value equality
-  t.deepEqual(points.positions.value, [100, 0, 100, 0, 101, 1]);
-  t.deepEqual(points.globalFeatureIds.value, [0, 1, 1]);
-
+  expect(Array.from(points.positions.value)).toEqual([100, 0, 100, 0, 101, 1]);
+  expect(Array.from(points.globalFeatureIds.value)).toEqual([0, 1, 1]);
   // LineString value equality
-  t.deepEqual(lines.pathIndices.value, [0, 2, 4, 6]);
-  t.deepEqual(lines.positions.value, [100, 0, 101, 1, 100, 0, 101, 1, 102, 2, 103, 3]);
-  t.deepEqual(lines.globalFeatureIds.value, [2, 2, 3, 3, 3, 3]);
-
+  expect(Array.from(lines.pathIndices.value)).toEqual([0, 2, 4, 6]);
+  expect(Array.from(lines.positions.value)).toEqual([
+    100, 0, 101, 1, 100, 0, 101, 1, 102, 2, 103, 3
+  ]);
+  expect(Array.from(lines.globalFeatureIds.value)).toEqual([2, 2, 3, 3, 3, 3]);
   // Polygon value equality
   const polygonFeatures = features.filter(f =>
     ['Polygon', 'MultiPolygon'].includes(f.geometry.type)
   );
   const expectedPolygonPositions = flatten(polygonFeatures.map(f => f.geometry.coordinates));
-
-  t.deepEqual(polygons.polygonIndices.value, [0, 5, 15, 20, 30]);
-  t.deepEqual(polygons.primitivePolygonIndices.value, [0, 5, 10, 15, 20, 25, 30]);
-  t.deepEqual(polygons.positions.value, Float32Array.from(expectedPolygonPositions));
-  t.deepEqual(
-    polygons.globalFeatureIds.value,
-    [4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6]
-  );
-  t.end();
+  expect(Array.from(polygons.polygonIndices.value)).toEqual([0, 5, 15, 20, 30]);
+  expect(Array.from(polygons.primitivePolygonIndices.value)).toEqual([0, 5, 10, 15, 20, 25, 30]);
+  expect(polygons.positions.value).toEqual(Float32Array.from(expectedPolygonPositions));
+  expect(Array.from(polygons.globalFeatureIds.value)).toEqual([
+    4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6
+  ]);
 });
-
-test('gis#geojson-to-binary 3D features', async t => {
+test('gis#geojson-to-binary 3D features', async () => {
   const response = await fetchFile(FEATURES_3D);
   const {features} = await response.json();
   const {points, lines, polygons} = geojsonToBinary(features);
-
   // 3D size
-  t.equal(points.positions.size, 3);
-  t.equal(lines.positions.size, 3);
-  t.equal(polygons.positions.size, 3);
-
+  expect(points.positions.size).toBe(3);
+  expect(lines.positions.size).toBe(3);
+  expect(polygons.positions.size).toBe(3);
   // Other arrays have coordinate size 1
-  t.equal(points.globalFeatureIds.size, 1);
-  t.equal(points.featureIds.size, 1);
-  t.equal(lines.pathIndices.size, 1);
-  t.equal(lines.globalFeatureIds.size, 1);
-  t.equal(lines.featureIds.size, 1);
-  t.equal(polygons.polygonIndices.size, 1);
-  t.equal(polygons.primitivePolygonIndices.size, 1);
-  t.equal(polygons.globalFeatureIds.size, 1);
-  t.equal(polygons.featureIds.size, 1);
-
+  expect(points.globalFeatureIds.size).toBe(1);
+  expect(points.featureIds.size).toBe(1);
+  expect(lines.pathIndices.size).toBe(1);
+  expect(lines.globalFeatureIds.size).toBe(1);
+  expect(lines.featureIds.size).toBe(1);
+  expect(polygons.polygonIndices.size).toBe(1);
+  expect(polygons.primitivePolygonIndices.size).toBe(1);
+  expect(polygons.globalFeatureIds.size).toBe(1);
+  expect(polygons.featureIds.size).toBe(1);
   // Point value equality
-  t.deepEqual(points.positions.value, [100, 0, 1, 100, 0, 2, 101, 1, 3]);
-  t.deepEqual(points.globalFeatureIds.value, [0, 1, 1]);
-
+  expect(Array.from(points.positions.value)).toEqual([100, 0, 1, 100, 0, 2, 101, 1, 3]);
+  expect(Array.from(points.globalFeatureIds.value)).toEqual([0, 1, 1]);
   // LineString value equality
   const lineFeatures = features.filter(f =>
     ['LineString', 'MultiLineString'].includes(f.geometry.type)
   );
   const expectedLinePositions = flatten(lineFeatures.map(f => f.geometry.coordinates));
-  t.deepEqual(lines.pathIndices.value, [0, 2, 4, 6]);
-  t.deepEqual(lines.positions.value, Float32Array.from(expectedLinePositions));
-  t.deepEqual(lines.globalFeatureIds.value, [2, 2, 3, 3, 3, 3]);
-
+  expect(Array.from(lines.pathIndices.value)).toEqual([0, 2, 4, 6]);
+  expect(lines.positions.value).toEqual(Float32Array.from(expectedLinePositions));
+  expect(Array.from(lines.globalFeatureIds.value)).toEqual([2, 2, 3, 3, 3, 3]);
   // Polygon value equality
   const polygonFeatures = features.filter(f =>
     ['Polygon', 'MultiPolygon'].includes(f.geometry.type)
   );
   const expectedPolygonPositions = flatten(polygonFeatures.map(f => f.geometry.coordinates));
-  t.deepEqual(polygons.polygonIndices.value, [0, 5, 15, 20, 30]);
-  t.deepEqual(polygons.primitivePolygonIndices.value, [0, 5, 10, 15, 20, 25, 30]);
-  t.deepEqual(polygons.positions.value, Float32Array.from(expectedPolygonPositions));
-  t.end();
+  expect(Array.from(polygons.polygonIndices.value)).toEqual([0, 5, 15, 20, 30]);
+  expect(Array.from(polygons.primitivePolygonIndices.value)).toEqual([0, 5, 10, 15, 20, 25, 30]);
+  expect(polygons.positions.value).toEqual(Float32Array.from(expectedPolygonPositions));
 });
-
 // eslint-disable-next-line complexity
-test('gis#geojson-to-binary position, featureId data types', async t => {
+test('gis#geojson-to-binary position, featureId data types', async () => {
   const response = await fetchFile(FEATURES_2D);
   const {features} = await response.json();
-
   // Duplicate features so that there are >65535 total features but <65535 of
   // any one geometry type
   const duplicateCount = 65535 * 2;
@@ -366,49 +310,44 @@ test('gis#geojson-to-binary position, featureId data types', async t => {
   for (let i = 0; i < duplicateCount; i++) {
     testFeatures.push(features[i % features.length]);
   }
-
   const options = {PositionDataType: Float64Array};
   const {points, lines, polygons} = geojsonToBinary(testFeatures, options);
-
-  t.ok(points && points.positions.value instanceof Float64Array);
-  t.ok(points && points.globalFeatureIds.value instanceof Uint32Array);
-  t.ok(points && points.featureIds.value instanceof Uint16Array);
-  t.ok(lines && lines.positions.value instanceof Float64Array);
-  t.ok(lines && lines.globalFeatureIds.value instanceof Uint32Array);
-  t.ok(lines && lines.featureIds.value instanceof Uint16Array);
-  t.ok(lines && lines.pathIndices.value instanceof Uint32Array);
-  t.ok(polygons && polygons.positions.value instanceof Float64Array);
-  t.ok(polygons && polygons.globalFeatureIds.value instanceof Uint32Array);
-  t.ok(polygons && polygons.featureIds.value instanceof Uint16Array);
-  t.ok(polygons && polygons.polygonIndices.value instanceof Uint32Array);
-  t.ok(polygons && polygons.primitivePolygonIndices.value instanceof Uint32Array);
-  t.end();
+  expect(points && points.positions.value instanceof Float64Array).toBeTruthy();
+  expect(points && points.globalFeatureIds.value instanceof Uint32Array).toBeTruthy();
+  expect(points && points.featureIds.value instanceof Uint16Array).toBeTruthy();
+  expect(lines && lines.positions.value instanceof Float64Array).toBeTruthy();
+  expect(lines && lines.globalFeatureIds.value instanceof Uint32Array).toBeTruthy();
+  expect(lines && lines.featureIds.value instanceof Uint16Array).toBeTruthy();
+  expect(lines && lines.pathIndices.value instanceof Uint32Array).toBeTruthy();
+  expect(polygons && polygons.positions.value instanceof Float64Array).toBeTruthy();
+  expect(polygons && polygons.globalFeatureIds.value instanceof Uint32Array).toBeTruthy();
+  expect(polygons && polygons.featureIds.value instanceof Uint16Array).toBeTruthy();
+  expect(polygons && polygons.polygonIndices.value instanceof Uint32Array).toBeTruthy();
+  expect(polygons && polygons.primitivePolygonIndices.value instanceof Uint32Array).toBeTruthy();
 });
-
-test('gis#geojson-to-binary with empty properties', async t => {
+test('gis#geojson-to-binary with empty properties', async () => {
   const response = await fetchFile(GEOJSON_NO_PROPERTIES);
   const {features} = await response.json();
   const {points, lines, polygons} = geojsonToBinary(features);
-
-  t.ok(points.properties[0] instanceof Object && points.properties[0].length === undefined);
-  t.ok(lines.properties[0] instanceof Object && lines.properties[0].length === undefined);
-  t.ok(polygons.properties[0] instanceof Object && polygons.properties[0].length === undefined);
-  t.end();
+  expect(
+    points.properties[0] instanceof Object && points.properties[0].length === undefined
+  ).toBeTruthy();
+  expect(
+    lines.properties[0] instanceof Object && lines.properties[0].length === undefined
+  ).toBeTruthy();
+  expect(
+    polygons.properties[0] instanceof Object && polygons.properties[0].length === undefined
+  ).toBeTruthy();
 });
-
-test('gis#geojson-to-binary triangulation', async t => {
+test('gis#geojson-to-binary triangulation', async () => {
   const response = await fetchFile(GEOJSON_NO_PROPERTIES);
   const {features} = await response.json();
   const binary = geojsonToBinary(features);
-
-  t.ok(binary.polygons.triangles);
-  t.deepEqual(binary.polygons.triangles.value, [3, 0, 1, 1, 2, 3]);
-
+  expect(binary.polygons.triangles).toBeTruthy();
+  expect(Array.from(binary.polygons.triangles.value)).toEqual([3, 0, 1, 1, 2, 3]);
   const binaryNoTriangles = geojsonToBinary(features, {triangulate: false});
-  t.notOk(binaryNoTriangles.polygons.triangles);
-  t.end();
+  expect(binaryNoTriangles.polygons.triangles).toBeFalsy();
 });
-
 function flatten(arr) {
   return arr.reduce(function (flat, toFlatten) {
     return flat.concat(Array.isArray(toFlatten) ? flatten(toFlatten) : toFlatten);

--- a/modules/gis/test/binary-features/geojson-to-flat-geojson.spec.ts
+++ b/modules/gis/test/binary-features/geojson-to-flat-geojson.spec.ts
@@ -2,11 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-// @ts-nocheck
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {fetchFile} from '@loaders.gl/core';
 import {geojsonToFlatGeojson} from '@loaders.gl/gis';
-
 // Sample GeoJSON data derived from examples in GeoJSON specification
 // https://tools.ietf.org/html/rfc7946#appendix-A
 // All features have 2D coordinates
@@ -15,290 +13,195 @@ const FEATURES_2D = '@loaders.gl/gis/test/data/binary-features/2d_features.json'
 const FEATURES_3D = '@loaders.gl/gis/test/data/binary-features/3d_features.json';
 // Some features have 3D coordinates
 const FEATURES_MIXED = '@loaders.gl/gis/test/data/binary-features/mixed_features.json';
-
-test('gis#geojson-to-flat-geojson 2D', async t => {
+test('gis#geojson-to-flat-geojson 2D', async () => {
   const response = await fetchFile(FEATURES_2D);
   const {features} = await response.json();
-
   const flatFeatures = geojsonToFlatGeojson(features);
   const [point, multiPoint, lineString, multiLineString, polygon, polygonWithHole, multiPolygon] =
     flatFeatures;
-
   // Point
-  t.deepEquals(point.geometry.data, [100, 0], 'flat Point data should be equivalent');
-  t.deepEquals(point.geometry.indices, [0], 'flat Point indices should be equivalent');
-
+  expect(point.geometry.data, 'flat Point data should be equivalent').toEqual([100, 0]);
+  expect(point.geometry.indices, 'flat Point indices should be equivalent').toEqual([0]);
   // MultiPoint
-  t.deepEquals(
-    multiPoint.geometry.data,
-    [100, 0, 101, 1],
-    'flat MultiPoint data should be equivalent'
-  );
-  t.deepEquals(multiPoint.geometry.indices, [0, 2], 'flat MultiPoint indices should be equivalent');
-
+  expect(multiPoint.geometry.data, 'flat MultiPoint data should be equivalent').toEqual([
+    100, 0, 101, 1
+  ]);
+  expect(multiPoint.geometry.indices, 'flat MultiPoint indices should be equivalent').toEqual([
+    0, 2
+  ]);
   // LineString
-  t.deepEquals(
-    lineString.geometry.data,
-    [100, 0, 101, 1],
-    'flat LineString data should be equivalent'
-  );
-  t.deepEquals(lineString.geometry.indices, [0], 'flat LineString indices should be equivalent');
-
+  expect(lineString.geometry.data, 'flat LineString data should be equivalent').toEqual([
+    100, 0, 101, 1
+  ]);
+  expect(lineString.geometry.indices, 'flat LineString indices should be equivalent').toEqual([0]);
   // MultiLineString
-  t.deepEquals(
-    multiLineString.geometry.data,
-    [100, 0, 101, 1, 102, 2, 103, 3],
-    'flat MultiLineString data should be equivalent'
-  );
-  t.deepEquals(
+  expect(multiLineString.geometry.data, 'flat MultiLineString data should be equivalent').toEqual([
+    100, 0, 101, 1, 102, 2, 103, 3
+  ]);
+  expect(
     multiLineString.geometry.indices,
-    [0, 4],
     'flat MultiLineString indices should be equivalent'
-  );
-
+  ).toEqual([0, 4]);
   // Polygon
-  t.deepEquals(
-    polygon.geometry.data,
-    [100, 0, 101, 0, 101, 1, 100, 1, 100, 0],
-    'flat Polygon data should be equivalent'
-  );
-  t.deepEquals(polygon.geometry.indices, [[0]], 'flat Polygon indices should be equivalent');
-  t.deepEquals(polygon.geometry.areas, [[-1]], 'flat Polygon areas should be equivalent');
-
+  expect(polygon.geometry.data, 'flat Polygon data should be equivalent').toEqual([
+    100, 0, 101, 0, 101, 1, 100, 1, 100, 0
+  ]);
+  expect(polygon.geometry.indices, 'flat Polygon indices should be equivalent').toEqual([[0]]);
+  expect(polygon.geometry.areas, 'flat Polygon areas should be equivalent').toEqual([[-1]]);
   // Polygon (hole)
-  t.deepEquals(
-    polygonWithHole.geometry.data,
-    [
-      100, 0, 101, 0, 101, 1, 100, 1, 100, 0, 100.8, 0.8, 100.8, 0.2, 100.2, 0.2, 100.2, 0.8, 100.8,
-      0.8
-    ],
-    'flat Polygon (hole) data should be equivalent'
-  );
-  t.deepEquals(
+  expect(polygonWithHole.geometry.data, 'flat Polygon (hole) data should be equivalent').toEqual([
+    100, 0, 101, 0, 101, 1, 100, 1, 100, 0, 100.8, 0.8, 100.8, 0.2, 100.2, 0.2, 100.2, 0.8, 100.8,
+    0.8
+  ]);
+  expect(
     polygonWithHole.geometry.indices,
-    [[0, 10]],
     'flat Polygon (hole) indices should be equivalent'
-  );
-  t.deepEquals(
-    polygonWithHole.geometry.areas,
-    [[-1, 0.3599999999999966]],
-    'flat Polygon (hole) areas should be equivalent'
-  );
-
+  ).toEqual([[0, 10]]);
+  expect(polygonWithHole.geometry.areas, 'flat Polygon (hole) areas should be equivalent').toEqual([
+    [-1, 0.3599999999999966]
+  ]);
   // MultiPolygon
-  t.deepEquals(
-    multiPolygon.geometry.data,
-    [
-      102, 2, 103, 2, 103, 3, 102, 3, 102, 2, 100, 0, 101, 0, 101, 1, 100, 1, 100, 0, 100.2, 0.2,
-      100.2, 0.8, 100.8, 0.8, 100.8, 0.2, 100.2, 0.2
-    ],
-    'flat MultiPolygon data should be equivalent'
-  );
-  t.deepEquals(
-    multiPolygon.geometry.indices,
-    [[0], [10, 20]],
-    'flat MultiPolygon indices should be equivalent'
-  );
-  t.deepEquals(
-    multiPolygon.geometry.areas,
-    [[-1], [-1, 0.3599999999999966]],
-    'flat MultiPolygon areas should be equivalent'
-  );
-
-  t.end();
+  expect(multiPolygon.geometry.data, 'flat MultiPolygon data should be equivalent').toEqual([
+    102, 2, 103, 2, 103, 3, 102, 3, 102, 2, 100, 0, 101, 0, 101, 1, 100, 1, 100, 0, 100.2, 0.2,
+    100.2, 0.8, 100.8, 0.8, 100.8, 0.2, 100.2, 0.2
+  ]);
+  expect(multiPolygon.geometry.indices, 'flat MultiPolygon indices should be equivalent').toEqual([
+    [0],
+    [10, 20]
+  ]);
+  expect(multiPolygon.geometry.areas, 'flat MultiPolygon areas should be equivalent').toEqual([
+    [-1],
+    [-1, 0.3599999999999966]
+  ]);
 });
-
-test('gis#geojson-to-flat-geojson 3D', async t => {
+test('gis#geojson-to-flat-geojson 3D', async () => {
   const response = await fetchFile(FEATURES_3D);
   const {features} = await response.json();
-
   const flatFeatures = geojsonToFlatGeojson(features);
   const [point, multiPoint, lineString, multiLineString, polygon, polygonWithHole, multiPolygon] =
     flatFeatures;
-
   // Point
-  t.deepEquals(point.geometry.data, [100, 0, 1], 'flat Point data should be equivalent');
-  t.deepEquals(point.geometry.indices, [0], 'flat Point indices should be equivalent');
-
+  expect(point.geometry.data, 'flat Point data should be equivalent').toEqual([100, 0, 1]);
+  expect(point.geometry.indices, 'flat Point indices should be equivalent').toEqual([0]);
   // MultiPoint
-  t.deepEquals(
-    multiPoint.geometry.data,
-    [100, 0, 2, 101, 1, 3],
-    'flat MultiPoint data should be equivalent'
-  );
-  t.deepEquals(multiPoint.geometry.indices, [0, 3], 'flat MultiPoint indices should be equivalent');
-
+  expect(multiPoint.geometry.data, 'flat MultiPoint data should be equivalent').toEqual([
+    100, 0, 2, 101, 1, 3
+  ]);
+  expect(multiPoint.geometry.indices, 'flat MultiPoint indices should be equivalent').toEqual([
+    0, 3
+  ]);
   // LineString
-  t.deepEquals(
-    lineString.geometry.data,
-    [100, 0, 4, 101, 1, 5],
-    'flat LineString data should be equivalent'
-  );
-  t.deepEquals(lineString.geometry.indices, [0], 'flat LineString indices should be equivalent');
-
+  expect(lineString.geometry.data, 'flat LineString data should be equivalent').toEqual([
+    100, 0, 4, 101, 1, 5
+  ]);
+  expect(lineString.geometry.indices, 'flat LineString indices should be equivalent').toEqual([0]);
   // MultiLineString
-  t.deepEquals(
-    multiLineString.geometry.data,
-    [100, 0, 6, 101, 1, 7, 102, 2, 8, 103, 3, 9],
-    'flat MultiLineString data should be equivalent'
-  );
-  t.deepEquals(
+  expect(multiLineString.geometry.data, 'flat MultiLineString data should be equivalent').toEqual([
+    100, 0, 6, 101, 1, 7, 102, 2, 8, 103, 3, 9
+  ]);
+  expect(
     multiLineString.geometry.indices,
-    [0, 6],
     'flat MultiLineString indices should be equivalent'
-  );
-
+  ).toEqual([0, 6]);
   // Polygon
-  t.deepEquals(
-    polygon.geometry.data,
-    [100, 0, 10, 101, 0, 11, 101, 1, 12, 100, 1, 13, 100, 0, 14],
-    'flat Polygon data should be equivalent'
-  );
-  t.deepEquals(polygon.geometry.indices, [[0]], 'flat Polygon indices should be equivalent');
-  t.deepEquals(polygon.geometry.areas, [[-1]], 'flat Polygon areas should be equivalent');
-
+  expect(polygon.geometry.data, 'flat Polygon data should be equivalent').toEqual([
+    100, 0, 10, 101, 0, 11, 101, 1, 12, 100, 1, 13, 100, 0, 14
+  ]);
+  expect(polygon.geometry.indices, 'flat Polygon indices should be equivalent').toEqual([[0]]);
+  expect(polygon.geometry.areas, 'flat Polygon areas should be equivalent').toEqual([[-1]]);
   // Polygon (hole)
-  t.deepEquals(
-    polygonWithHole.geometry.data,
-    [
-      100, 0, 15, 101, 0, 16, 101, 1, 17, 100, 1, 18, 100, 0, 19, 100.8, 0.8, 20, 100.8, 0.2, 21,
-      100.2, 0.2, 22, 100.2, 0.8, 23, 100.8, 0.8, 24
-    ],
-    'flat Polygon (hole) data should be equivalent'
-  );
-  t.deepEquals(
+  expect(polygonWithHole.geometry.data, 'flat Polygon (hole) data should be equivalent').toEqual([
+    100, 0, 15, 101, 0, 16, 101, 1, 17, 100, 1, 18, 100, 0, 19, 100.8, 0.8, 20, 100.8, 0.2, 21,
+    100.2, 0.2, 22, 100.2, 0.8, 23, 100.8, 0.8, 24
+  ]);
+  expect(
     polygonWithHole.geometry.indices,
-    [[0, 15]],
     'flat Polygon (hole) indices should be equivalent'
-  );
-  t.deepEquals(
-    polygonWithHole.geometry.areas,
-    [[-1, 0.3599999999999966]],
-    'flat Polygon (hole) areas should be equivalent'
-  );
-
+  ).toEqual([[0, 15]]);
+  expect(polygonWithHole.geometry.areas, 'flat Polygon (hole) areas should be equivalent').toEqual([
+    [-1, 0.3599999999999966]
+  ]);
   // MultiPolygon
-  t.deepEquals(
-    multiPolygon.geometry.data,
-    [
-      102, 2, 25, 103, 2, 26, 103, 3, 27, 102, 3, 28, 102, 2, 29, 100, 0, 30, 101, 0, 31, 101, 1,
-      32, 100, 1, 33, 100, 0, 34, 100.2, 0.2, 35, 100.2, 0.8, 36, 100.8, 0.8, 37, 100.8, 0.2, 38,
-      100.2, 0.2, 39
-    ],
-    'flat MultiPolygon data should be equivalent'
-  );
-  t.deepEquals(
-    multiPolygon.geometry.indices,
-    [[0], [15, 30]],
-    'flat MultiPolygon indices should be equivalent'
-  );
-  t.deepEquals(
-    multiPolygon.geometry.areas,
-    [[-1], [-1, 0.3599999999999966]],
-    'flat MultiPolygon areas should be equivalent'
-  );
-
-  t.end();
+  expect(multiPolygon.geometry.data, 'flat MultiPolygon data should be equivalent').toEqual([
+    102, 2, 25, 103, 2, 26, 103, 3, 27, 102, 3, 28, 102, 2, 29, 100, 0, 30, 101, 0, 31, 101, 1, 32,
+    100, 1, 33, 100, 0, 34, 100.2, 0.2, 35, 100.2, 0.8, 36, 100.8, 0.8, 37, 100.8, 0.2, 38, 100.2,
+    0.2, 39
+  ]);
+  expect(multiPolygon.geometry.indices, 'flat MultiPolygon indices should be equivalent').toEqual([
+    [0],
+    [15, 30]
+  ]);
+  expect(multiPolygon.geometry.areas, 'flat MultiPolygon areas should be equivalent').toEqual([
+    [-1],
+    [-1, 0.3599999999999966]
+  ]);
 });
-
-test('gis#geojson-to-flat-geojson Mixed', async t => {
+test('gis#geojson-to-flat-geojson Mixed', async () => {
   const response = await fetchFile(FEATURES_MIXED);
   const {features} = await response.json();
-
   const flatFeatures = geojsonToFlatGeojson(features, {coordLength: 3});
   const [point, multiPoint, lineString, multiLineString, polygon, polygonWithHole, multiPolygon] =
     flatFeatures;
-
   // Point
-  t.deepEquals(point.geometry.data, [100, 0, 1], 'flat Point data should be equivalent');
-  t.deepEquals(point.geometry.indices, [0], 'flat Point indices should be equivalent');
-
+  expect(point.geometry.data, 'flat Point data should be equivalent').toEqual([100, 0, 1]);
+  expect(point.geometry.indices, 'flat Point indices should be equivalent').toEqual([0]);
   // MultiPoint
-  t.deepEquals(
-    multiPoint.geometry.data,
-    [100, 0, 0, 101, 1, 0],
-    'flat MultiPoint data should be equivalent'
-  );
-  t.deepEquals(multiPoint.geometry.indices, [0, 3], 'flat MultiPoint indices should be equivalent');
-
+  expect(multiPoint.geometry.data, 'flat MultiPoint data should be equivalent').toEqual([
+    100, 0, 0, 101, 1, 0
+  ]);
+  expect(multiPoint.geometry.indices, 'flat MultiPoint indices should be equivalent').toEqual([
+    0, 3
+  ]);
   // LineString
-  t.deepEquals(
-    lineString.geometry.data,
-    [100, 0, 0, 101, 1, 0],
-    'flat LineString data should be equivalent'
-  );
-  t.deepEquals(lineString.geometry.indices, [0], 'flat LineString indices should be equivalent');
-
+  expect(lineString.geometry.data, 'flat LineString data should be equivalent').toEqual([
+    100, 0, 0, 101, 1, 0
+  ]);
+  expect(lineString.geometry.indices, 'flat LineString indices should be equivalent').toEqual([0]);
   // MultiLineString
-  t.deepEquals(
-    multiLineString.geometry.data,
-    [100, 0, 2, 101, 1, 0, 102, 2, 0, 103, 3, 0],
-    'flat MultiLineString data should be equivalent'
-  );
-  t.deepEquals(
+  expect(multiLineString.geometry.data, 'flat MultiLineString data should be equivalent').toEqual([
+    100, 0, 2, 101, 1, 0, 102, 2, 0, 103, 3, 0
+  ]);
+  expect(
     multiLineString.geometry.indices,
-    [0, 6],
     'flat MultiLineString indices should be equivalent'
-  );
-
+  ).toEqual([0, 6]);
   // Polygon
-  t.deepEquals(
-    polygon.geometry.data,
-    [100, 0, 0, 101, 0, 0, 101, 1, 0, 100, 1, 0, 100, 0, 3],
-    'flat Polygon data should be equivalent'
-  );
-  t.deepEquals(polygon.geometry.indices, [[0]], 'flat Polygon indices should be equivalent');
-  t.deepEquals(polygon.geometry.areas, [[-1]], 'flat Polygon areas should be equivalent');
-
+  expect(polygon.geometry.data, 'flat Polygon data should be equivalent').toEqual([
+    100, 0, 0, 101, 0, 0, 101, 1, 0, 100, 1, 0, 100, 0, 3
+  ]);
+  expect(polygon.geometry.indices, 'flat Polygon indices should be equivalent').toEqual([[0]]);
+  expect(polygon.geometry.areas, 'flat Polygon areas should be equivalent').toEqual([[-1]]);
   // Polygon (hole)
-  t.deepEquals(
-    polygonWithHole.geometry.data,
-    [
-      100, 0, 0, 101, 0, 0, 101, 1, 0, 100, 1, 0, 100, 0, 0, 100.8, 0.8, 0, 100.8, 0.2, 0, 100.2,
-      0.2, 0, 100.2, 0.8, 0, 100.8, 0.8, 0
-    ],
-    'flat Polygon (hole) data should be equivalent'
-  );
-  t.deepEquals(
+  expect(polygonWithHole.geometry.data, 'flat Polygon (hole) data should be equivalent').toEqual([
+    100, 0, 0, 101, 0, 0, 101, 1, 0, 100, 1, 0, 100, 0, 0, 100.8, 0.8, 0, 100.8, 0.2, 0, 100.2, 0.2,
+    0, 100.2, 0.8, 0, 100.8, 0.8, 0
+  ]);
+  expect(
     polygonWithHole.geometry.indices,
-    [[0, 15]],
     'flat Polygon (hole) indices should be equivalent'
-  );
-  t.deepEquals(
-    polygonWithHole.geometry.areas,
-    [[-1, 0.3599999999999966]],
-    'flat Polygon (hole) areas should be equivalent'
-  );
-
+  ).toEqual([[0, 15]]);
+  expect(polygonWithHole.geometry.areas, 'flat Polygon (hole) areas should be equivalent').toEqual([
+    [-1, 0.3599999999999966]
+  ]);
   // MultiPolygon
-  t.deepEquals(
-    multiPolygon.geometry.data,
-    [
-      102, 2, 0, 103, 2, 0, 103, 3, 0, 102, 3, 0, 102, 2, 0, 100, 0, 0, 101, 0, 0, 101, 1, 0, 100,
-      1, 0, 100, 0, 0, 100.2, 0.2, 0, 100.2, 0.8, 0, 100.8, 0.8, 0, 100.8, 0.2, 0, 100.2, 0.2, 0
-    ],
-    'flat MultiPolygon data should be equivalent'
-  );
-  t.deepEquals(
-    multiPolygon.geometry.indices,
-    [[0], [15, 30]],
-    'flat MultiPolygon indices should be equivalent'
-  );
-  t.deepEquals(
-    multiPolygon.geometry.areas,
-    [[-1], [-1, 0.3599999999999966]],
-    'flat MultiPolygon areas should be equivalent'
-  );
-
-  t.end();
+  expect(multiPolygon.geometry.data, 'flat MultiPolygon data should be equivalent').toEqual([
+    102, 2, 0, 103, 2, 0, 103, 3, 0, 102, 3, 0, 102, 2, 0, 100, 0, 0, 101, 0, 0, 101, 1, 0, 100, 1,
+    0, 100, 0, 0, 100.2, 0.2, 0, 100.2, 0.8, 0, 100.8, 0.8, 0, 100.8, 0.2, 0, 100.2, 0.2, 0
+  ]);
+  expect(multiPolygon.geometry.indices, 'flat MultiPolygon indices should be equivalent').toEqual([
+    [0],
+    [15, 30]
+  ]);
+  expect(multiPolygon.geometry.areas, 'flat MultiPolygon areas should be equivalent').toEqual([
+    [-1],
+    [-1, 0.3599999999999966]
+  ]);
 });
-
 // eslint-disable-next-line max-statements
-test('gis#geojson-to-flat-geojson winding', async t => {
+test('gis#geojson-to-flat-geojson winding', async () => {
   const response = await fetchFile(FEATURES_2D);
   const {features} = await response.json();
   const polygons = features.slice(4);
-
   // Manually reverse winding for all shapes
   for (const {geometry} of polygons) {
     if (geometry.type === 'Polygon') {
@@ -309,118 +212,77 @@ test('gis#geojson-to-flat-geojson winding', async t => {
       });
     }
   }
-
   let flatFeatures = geojsonToFlatGeojson(JSON.parse(JSON.stringify(polygons)), {
     fixRingWinding: true
   });
   let [polygon, polygonWithHole, multiPolygon] = flatFeatures;
-
   // Polygon
-  t.deepEquals(
-    polygon.geometry.data,
-    [100, 0, 101, 0, 101, 1, 100, 1, 100, 0],
-    'flat Polygon data should be equivalent'
-  );
-  t.deepEquals(polygon.geometry.indices, [[0]], 'flat Polygon indices should be equivalent');
-  t.deepEquals(polygon.geometry.areas, [[-1]], 'flat Polygon areas should be equivalent');
-
+  expect(polygon.geometry.data, 'flat Polygon data should be equivalent').toEqual([
+    100, 0, 101, 0, 101, 1, 100, 1, 100, 0
+  ]);
+  expect(polygon.geometry.indices, 'flat Polygon indices should be equivalent').toEqual([[0]]);
+  expect(polygon.geometry.areas, 'flat Polygon areas should be equivalent').toEqual([[-1]]);
   // Polygon (hole)
-  t.deepEquals(
-    polygonWithHole.geometry.data,
-    [
-      100, 0, 101, 0, 101, 1, 100, 1, 100, 0, 100.8, 0.8, 100.8, 0.2, 100.2, 0.2, 100.2, 0.8, 100.8,
-      0.8
-    ],
-    'flat Polygon (hole) data should be equivalent'
-  );
-  t.deepEquals(
+  expect(polygonWithHole.geometry.data, 'flat Polygon (hole) data should be equivalent').toEqual([
+    100, 0, 101, 0, 101, 1, 100, 1, 100, 0, 100.8, 0.8, 100.8, 0.2, 100.2, 0.2, 100.2, 0.8, 100.8,
+    0.8
+  ]);
+  expect(
     polygonWithHole.geometry.indices,
-    [[0, 10]],
     'flat Polygon (hole) indices should be equivalent'
-  );
-  t.deepEquals(
-    polygonWithHole.geometry.areas,
-    [[-1, 0.3599999999999966]],
-    'flat Polygon (hole) areas should be equivalent'
-  );
-
+  ).toEqual([[0, 10]]);
+  expect(polygonWithHole.geometry.areas, 'flat Polygon (hole) areas should be equivalent').toEqual([
+    [-1, 0.3599999999999966]
+  ]);
   // MultiPolygon
-  t.deepEquals(
-    multiPolygon.geometry.data,
-    [
-      102, 2, 103, 2, 103, 3, 102, 3, 102, 2, 100, 0, 101, 0, 101, 1, 100, 1, 100, 0, 100.2, 0.2,
-      100.2, 0.8, 100.8, 0.8, 100.8, 0.2, 100.2, 0.2
-    ],
-    'flat MultiPolygon data should be equivalent'
-  );
-  t.deepEquals(
-    multiPolygon.geometry.indices,
-    [[0], [10, 20]],
-    'flat MultiPolygon indices should be equivalent'
-  );
-  t.deepEquals(
-    multiPolygon.geometry.areas,
-    [[-1], [-1, 0.3599999999999966]],
-    'flat MultiPolygon areas should be equivalent'
-  );
-
+  expect(multiPolygon.geometry.data, 'flat MultiPolygon data should be equivalent').toEqual([
+    102, 2, 103, 2, 103, 3, 102, 3, 102, 2, 100, 0, 101, 0, 101, 1, 100, 1, 100, 0, 100.2, 0.2,
+    100.2, 0.8, 100.8, 0.8, 100.8, 0.2, 100.2, 0.2
+  ]);
+  expect(multiPolygon.geometry.indices, 'flat MultiPolygon indices should be equivalent').toEqual([
+    [0],
+    [10, 20]
+  ]);
+  expect(multiPolygon.geometry.areas, 'flat MultiPolygon areas should be equivalent').toEqual([
+    [-1],
+    [-1, 0.3599999999999966]
+  ]);
   // Repeat tests without ring winding fix
   flatFeatures = geojsonToFlatGeojson(polygons, {fixRingWinding: false});
   [polygon, polygonWithHole, multiPolygon] = flatFeatures;
-
   // Polygon
-  t.deepEquals(
-    polygon.geometry.data,
-    [100, 0, 100, 1, 101, 1, 101, 0, 100, 0],
-    'flat Polygon data should be reversed'
-  );
-  t.deepEquals(polygon.geometry.indices, [[0]], 'flat Polygon indices should be equivalent');
-  t.deepEquals(polygon.geometry.areas, [[1]], 'flat Polygon areas should be negated');
-
+  expect(polygon.geometry.data, 'flat Polygon data should be reversed').toEqual([
+    100, 0, 100, 1, 101, 1, 101, 0, 100, 0
+  ]);
+  expect(polygon.geometry.indices, 'flat Polygon indices should be equivalent').toEqual([[0]]);
+  expect(polygon.geometry.areas, 'flat Polygon areas should be negated').toEqual([[1]]);
   // Polygon (hole)
-  t.deepEquals(
-    polygonWithHole.geometry.data,
-    [
-      100, 0, 100, 1, 101, 1, 101, 0, 100, 0, 100.8, 0.8, 100.2, 0.8, 100.2, 0.2, 100.8, 0.2, 100.8,
-      0.8
-    ],
-    'flat Polygon (hole) data should be reversed'
-  );
-  t.deepEquals(
+  expect(polygonWithHole.geometry.data, 'flat Polygon (hole) data should be reversed').toEqual([
+    100, 0, 100, 1, 101, 1, 101, 0, 100, 0, 100.8, 0.8, 100.2, 0.8, 100.2, 0.2, 100.8, 0.2, 100.8,
+    0.8
+  ]);
+  expect(
     polygonWithHole.geometry.indices,
-    [[0, 10]],
     'flat Polygon (hole) indices should be equivalent'
-  );
-  t.deepEquals(
-    polygonWithHole.geometry.areas,
-    [[1, -0.3599999999999966]],
-    'flat Polygon (hole) areas should be negated'
-  );
-
+  ).toEqual([[0, 10]]);
+  expect(polygonWithHole.geometry.areas, 'flat Polygon (hole) areas should be negated').toEqual([
+    [1, -0.3599999999999966]
+  ]);
   // MultiPolygon
-  t.deepEquals(
-    multiPolygon.geometry.data,
-    [
-      102, 2, 102, 3, 103, 3, 103, 2, 102, 2, 100, 0, 100, 1, 101, 1, 101, 0, 100, 0, 100.2, 0.2,
-      100.8, 0.2, 100.8, 0.8, 100.2, 0.8, 100.2, 0.2
-    ],
-    'flat MultiPolygon data should be reversed'
-  );
-  t.deepEquals(
-    multiPolygon.geometry.indices,
-    [[0], [10, 20]],
-    'flat MultiPolygon indices should be equivalent'
-  );
-  t.deepEquals(
-    multiPolygon.geometry.areas,
-    [[1], [1, -0.3599999999999966]],
-    'flat MultiPolygon areas should be negated'
-  );
-
-  t.end();
+  expect(multiPolygon.geometry.data, 'flat MultiPolygon data should be reversed').toEqual([
+    102, 2, 102, 3, 103, 3, 103, 2, 102, 2, 100, 0, 100, 1, 101, 1, 101, 0, 100, 0, 100.2, 0.2,
+    100.8, 0.2, 100.8, 0.8, 100.2, 0.8, 100.2, 0.2
+  ]);
+  expect(multiPolygon.geometry.indices, 'flat MultiPolygon indices should be equivalent').toEqual([
+    [0],
+    [10, 20]
+  ]);
+  expect(multiPolygon.geometry.areas, 'flat MultiPolygon areas should be negated').toEqual([
+    [1],
+    [1, -0.3599999999999966]
+  ]);
 });
-
-test('gis#geojson-to-flat-geojson invalid type', async t => {
+test('gis#geojson-to-flat-geojson invalid type', async () => {
   const features = [
     {
       id: 0,
@@ -431,9 +293,7 @@ test('gis#geojson-to-flat-geojson invalid type', async t => {
       }
     }
   ];
-
-  t.throws(() => geojsonToFlatGeojson(features), 'throws when type is GeometryCollection');
-
+  expect(() => geojsonToFlatGeojson(features), 'throws when type is GeometryCollection').toThrow();
   features[0].geometry.type = 'Invalid';
-  t.throws(() => geojsonToFlatGeojson(features), 'throws when type is Invalid');
+  expect(() => geojsonToFlatGeojson(features), 'throws when type is Invalid').toThrow();
 });

--- a/modules/gis/test/binary-features/transform.spec.ts
+++ b/modules/gis/test/binary-features/transform.spec.ts
@@ -2,12 +2,11 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {BinaryFeatureCollection, Feature} from '@loaders.gl/schema';
 import {transformBinaryCoords, transformGeoJsonCoords} from '@loaders.gl/gis';
 import {Proj4Projection} from '@math.gl/proj4';
-
-test('gis#reproject GeoJSON', t => {
+test('gis#reproject GeoJSON', () => {
   const projection = new Proj4Projection({from: 'WGS84', to: 'EPSG:3857'});
   const inputGeoJson: Feature[] = [
     {
@@ -29,13 +28,10 @@ test('gis#reproject GeoJSON', t => {
       properties: {}
     }
   ];
-
   const out = transformGeoJsonCoords(inputGeoJson, coord => projection.project(coord));
-  t.deepEqual(out, expectedGeoJson);
-  t.end();
+  expect(out).toEqual(expectedGeoJson);
 });
-
-test('gis#reproject binary', t => {
+test('gis#reproject binary', () => {
   const projection = new Proj4Projection({from: 'WGS84', to: 'EPSG:3857'});
   const binaryData: BinaryFeatureCollection = {
     shape: 'binary-feature-collection',
@@ -50,7 +46,6 @@ test('gis#reproject binary', t => {
       properties: [{string1: 'a'}, {string1: 'b'}]
     }
   };
-
   const expectedBinaryData: BinaryFeatureCollection = {
     shape: 'binary-feature-collection',
     points: {
@@ -64,8 +59,6 @@ test('gis#reproject binary', t => {
       properties: [{string1: 'a'}, {string1: 'b'}]
     }
   };
-
   const out = transformBinaryCoords(binaryData, coord => projection.project(coord));
-  t.deepEqual(out, expectedBinaryData);
-  t.end();
+  expect(out).toEqual(expectedBinaryData);
 });

--- a/modules/gis/test/geoarrow/convert-geoarrow-to-binary-geometry.spec.ts
+++ b/modules/gis/test/geoarrow/convert-geoarrow-to-binary-geometry.spec.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test, {Test} from 'test/utils/vitest-tape';
-
+import {expect, test} from 'vitest';
 import {
   getBinaryGeometryTemplate,
   getGeometryColumnsFromSchema,
@@ -12,7 +11,6 @@ import {
 import {convertArrowToSchema} from '@loaders.gl/schema-utils';
 import {load} from '@loaders.gl/core';
 import {ArrowLoader} from '@loaders.gl/arrow';
-
 import {
   GEOARROW_POINT_FILE,
   GEOARROW_MULTIPOINT_FILE,
@@ -22,7 +20,6 @@ import {
   GEOARROW_MULTIPOLYGON_FILE,
   GEOARROW_MULTIPOLYGON_HOLE_FILE
 } from '@loaders.gl/arrow/test/data/geoarrow/test-cases';
-
 const expectedPointBinaryGeometry = {
   binaryGeometries: [
     {
@@ -55,7 +52,6 @@ const expectedPointBinaryGeometry = {
     [2, 2]
   ]
 };
-
 const expectedMultiPointBinaryGeometry = {
   binaryGeometries: [
     {
@@ -88,7 +84,6 @@ const expectedMultiPointBinaryGeometry = {
     [3.5, 3.5]
   ]
 };
-
 const expectedLineBinaryGeometry = {
   binaryGeometries: [
     {
@@ -121,7 +116,6 @@ const expectedLineBinaryGeometry = {
     [2.5, 2.5]
   ]
 };
-
 const expectedMultiLineBinaryGeometry = {
   binaryGeometries: [
     {
@@ -157,7 +151,6 @@ const expectedMultiLineBinaryGeometry = {
     [6.5, 6.5]
   ]
 };
-
 const expectedPolygonBinaryGeometry = {
   binaryGeometries: [
     {
@@ -199,7 +192,6 @@ const expectedPolygonBinaryGeometry = {
     [10.5, 10.5]
   ]
 };
-
 const expectedMultiPolygonBinaryGeometry = {
   binaryGeometries: [
     {
@@ -239,7 +231,6 @@ const expectedMultiPolygonBinaryGeometry = {
   featureTypes: {polygon: true, point: false, line: false},
   meanCenters: [[1.5, 1.5]]
 };
-
 const expectedMultiPolygonHolesBinaryGeometry = {
   binaryGeometries: [
     {
@@ -299,7 +290,6 @@ const expectedMultiPolygonHolesBinaryGeometry = {
     [11.166666666666666, 11.166666666666666]
   ]
 };
-
 const testCases = [
   [GEOARROW_POINT_FILE, expectedPointBinaryGeometry],
   [GEOARROW_MULTIPOINT_FILE, expectedMultiPointBinaryGeometry],
@@ -309,17 +299,12 @@ const testCases = [
   [GEOARROW_MULTIPOLYGON_FILE, expectedMultiPolygonBinaryGeometry],
   [GEOARROW_MULTIPOLYGON_HOLE_FILE, expectedMultiPolygonHolesBinaryGeometry]
 ];
-
-test('ArrowUtils#convertGeoArrowToBinaryFeatureCollection', async t => {
+test('ArrowUtils#convertGeoArrowToBinaryFeatureCollection', async () => {
   for (const testCase of testCases) {
-    await testGetBinaryGeometriesFromArrow(t, testCase[0], testCase[1]);
+    await testGetBinaryGeometriesFromArrow(testCase[0], testCase[1]);
   }
-
-  t.end();
 });
-
 async function testGetBinaryGeometriesFromArrow(
-  t: Test,
   arrowFile,
   expectedBinaryGeometries
 ): Promise<void> {
@@ -327,25 +312,37 @@ async function testGetBinaryGeometriesFromArrow(
     core: {worker: false},
     arrow: {shape: 'arrow-table'}
   });
-
-  t.equal(arrowTable.shape, 'arrow-table');
-
+  expect(arrowTable.shape).toBe('arrow-table');
   if (arrowTable.shape === 'arrow-table') {
     const table = arrowTable.data;
     const geoColumn = table.getChild('geometry');
-    t.notEqual(geoColumn, null, 'geoColumn is not null');
-
+    expect(geoColumn, 'geoColumn is not null').not.toBe(null);
     const schema = convertArrowToSchema(table.schema);
     const geometryColumns = getGeometryColumnsFromSchema(schema);
     const encoding = geometryColumns.geometry.encoding;
-
-    t.notEqual(encoding, undefined, 'encoding is not undefined');
+    expect(encoding, 'encoding is not undefined').not.toBe(undefined);
     if (geoColumn && encoding) {
       const options = {calculateMeanCenters: true, triangulate: true};
       const binaryData = convertGeoArrowToBinaryFeatureCollection(geoColumn, encoding, options);
-      t.deepEqual(binaryData, expectedBinaryGeometries, 'binary geometries are correct');
+      expect(normalizeTypedArrays(binaryData), 'binary geometries are correct').toEqual(
+        normalizeTypedArrays(expectedBinaryGeometries)
+      );
     }
   }
-
   return Promise.resolve();
+}
+
+function normalizeTypedArrays(value: unknown): unknown {
+  if (ArrayBuffer.isView(value)) {
+    return Array.from(value as ArrayLike<unknown>);
+  }
+  if (Array.isArray(value)) {
+    return value.map(normalizeTypedArrays);
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => [key, normalizeTypedArrays(nestedValue)])
+    );
+  }
+  return value;
 }

--- a/modules/gis/test/geoarrow/convert-geoarrow-to-geojson.spec.ts
+++ b/modules/gis/test/geoarrow/convert-geoarrow-to-geojson.spec.ts
@@ -2,27 +2,22 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test, {Test} from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {
   GEOARROW_TEST_CASES,
   GEOARROW_ENCODINGS
 } from '@loaders.gl/arrow/test/data/geoarrow/test-cases';
-
 import {load} from '@loaders.gl/core';
 import type {FeatureCollection} from '@loaders.gl/schema';
 import {convertArrowToSchema} from '@loaders.gl/schema-utils';
 import {getGeometryColumnsFromSchema, convertGeoArrowGeometryToGeoJSON} from '@loaders.gl/geoarrow';
 import {ArrowLoader} from '@loaders.gl/arrow';
-
-test('ArrowUtils#convertGeoArrowGeometryToGeoJSON', async t => {
+test('ArrowUtils#convertGeoArrowGeometryToGeoJSON', async () => {
   for (const testCase of GEOARROW_TEST_CASES) {
-    await testParseFromArrow(t, testCase[0], testCase[1]);
+    await testParseFromArrow(testCase[0], testCase[1]);
   }
-  t.end();
 });
-
 async function testParseFromArrow(
-  t: Test,
   arrowFile: string,
   expectedGeojson: FeatureCollection
 ): Promise<void> {
@@ -30,49 +25,38 @@ async function testParseFromArrow(
     core: {worker: false},
     arrow: {shape: 'arrow-table'}
   });
-
-  t.equal(arrowTable.shape, 'arrow-table');
-
+  expect(arrowTable.shape).toBe('arrow-table');
   if (arrowTable.shape === 'arrow-table') {
     const table = arrowTable.data;
     // check if the arrow table is loaded correctly
-    t.equal(
-      table.numRows,
-      expectedGeojson.features.length,
-      `arrow table has ${expectedGeojson.features.length} row`
+    expect(table.numRows, `arrow table has ${expectedGeojson.features.length} row`).toBe(
+      expectedGeojson.features.length
     );
-
     const colNames = [...Object.keys(expectedGeojson.features[0].properties || {}), 'geometry'];
-    t.equal(table.numCols, colNames.length, `arrow table has ${colNames.length} columns`);
-
+    expect(table.numCols, `arrow table has ${colNames.length} columns`).toBe(colNames.length);
     // check fields exist in arrow table schema
     table.schema.fields.map(field =>
-      t.equal(colNames.includes(field.name), true, `arrow table has ${field.name} column`)
+      expect(colNames.includes(field.name), `arrow table has ${field.name} column`).toBe(true)
     );
-
     const schema = convertArrowToSchema(table.schema);
     const geometryColumns = getGeometryColumnsFromSchema(schema);
-
     // check 'geometry' is in geometryColumns (geometryColumns is a Map object)
-    t.equal(Boolean(geometryColumns.geometry), true, 'geometryColumns has geometry column');
-
+    expect(Boolean(geometryColumns.geometry), 'geometryColumns has geometry column').toBe(true);
     // get encoding from geometryColumns['geometry']
     const encoding = geometryColumns.geometry.encoding!;
-
     // check encoding is one of GEOARROW_ENCODINGS
-    t.ok(Object.values(GEOARROW_ENCODINGS).includes(encoding), 'valid GeoArrow encoding');
-
+    expect(
+      Object.values(GEOARROW_ENCODINGS).includes(encoding),
+      'valid GeoArrow encoding'
+    ).toBeTruthy();
     // get first geometry from arrow geometry column
     const firstArrowGeometry = table.getChild('geometry')?.get(0);
-
     // parse arrow geometry to geojson feature
     const firstGeometry = convertGeoArrowGeometryToGeoJSON(firstArrowGeometry, encoding);
-
     // check if geometry in firstFeature is equal to the original geometry in expectedPointGeojson
-    t.deepEqual(
+    expect(
       firstGeometry,
-      expectedGeojson.features[0].geometry,
       'firstFeature.geometry is equal to expectedGeojson.features[0].geometry'
-    );
+    ).toEqual(expectedGeojson.features[0].geometry);
   }
 }

--- a/modules/gis/test/geoarrow/wkb-geoarrow-utils.spec.ts
+++ b/modules/gis/test/geoarrow/wkb-geoarrow-utils.spec.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
-
+import {expect, test} from 'vitest';
 import type {Geometry, Schema} from '@loaders.gl/schema';
 import {
   convertWKBToGeometry,
@@ -18,8 +17,7 @@ import {
   unpackGeoMetadata,
   unpackJSONStringMetadata
 } from '@loaders.gl/gis';
-
-test('geoarrow WKB helpers round-trip metadata for object and Map containers', t => {
+test('geoarrow WKB helpers round-trip metadata for object and Map containers', () => {
   const geoMetadata = {
     version: '1.1.0',
     primary_column: 'geometry',
@@ -30,63 +28,51 @@ test('geoarrow WKB helpers round-trip metadata for object and Map containers', t
       }
     }
   };
-
   const objectMetadata: Record<string, string> = {};
   setGeoMetadata(objectMetadata, geoMetadata);
-  t.deepEqual(getGeoMetadata(objectMetadata), geoMetadata, 'round-trips object metadata');
-
+  expect(getGeoMetadata(objectMetadata), 'round-trips object metadata').toEqual(geoMetadata);
   const mapMetadata = new Map<string, string>();
   setGeoMetadata(mapMetadata, geoMetadata);
-  t.deepEqual(getGeoMetadata(mapMetadata), geoMetadata, 'round-trips map metadata');
+  expect(getGeoMetadata(mapMetadata), 'round-trips map metadata').toEqual(geoMetadata);
   unpackGeoMetadata(mapMetadata);
-  t.equal(mapMetadata.get('geo.version'), '1.1.0', 'unpacks geo metadata');
-
+  expect(mapMetadata.get('geo.version'), 'unpacks geo metadata').toBe('1.1.0');
   objectMetadata.pandas = JSON.stringify({index_columns: ['id']});
   unpackJSONStringMetadata(objectMetadata, 'pandas');
-  t.equal(objectMetadata['pandas.index_columns'], '["id"]', 'unpacks arbitrary JSON metadata keys');
-  t.end();
+  expect(objectMetadata['pandas.index_columns'], 'unpacks arbitrary JSON metadata keys').toBe(
+    '["id"]'
+  );
 });
-
-test('geoarrow WKB helpers build Arrow Binary buffers from WKB values', t => {
+test('geoarrow WKB helpers build Arrow Binary buffers from WKB values', () => {
   const firstPoint = encodeWKBGeometryValue({type: 'Point', coordinates: [1, 2]})!;
   const secondPoint = encodeWKBGeometryValue({type: 'Point', coordinates: [3, 4]})!;
   const geometryData = makeWKBGeometryData([firstPoint, null, secondPoint]);
-
-  t.deepEqual(
+  expect(
     [...geometryData.valueOffsets],
-    [
-      0,
-      firstPoint.byteLength,
-      firstPoint.byteLength,
-      firstPoint.byteLength + secondPoint.byteLength
-    ],
     'offsets account for null rows without adding bytes'
+  ).toEqual([
+    0,
+    firstPoint.byteLength,
+    firstPoint.byteLength,
+    firstPoint.byteLength + secondPoint.byteLength
+  ]);
+  expect(geometryData.nullBitmap, 'null bitmap marks valid rows').toEqual(
+    new Uint8Array([0b00000101])
   );
-  t.deepEqual(
-    geometryData.nullBitmap,
-    new Uint8Array([0b00000101]),
-    'null bitmap marks valid rows'
+  expect(geometryData.nullCount, 'null count is set').toBe(1);
+  expect(geometryData.values.byteLength, 'values contain contiguous WKB bytes').toBe(
+    firstPoint.byteLength + secondPoint.byteLength
   );
-  t.equal(geometryData.nullCount, 1, 'null count is set');
-  t.equal(
-    geometryData.values.byteLength,
-    firstPoint.byteLength + secondPoint.byteLength,
-    'values contain contiguous WKB bytes'
-  );
-  t.deepEqual(
+  expect(
     convertWKBToGeometry(
       geometryData.values.buffer.slice(
         geometryData.valueOffsets[2],
         geometryData.valueOffsets[3]
       ) as ArrayBuffer
     ),
-    {type: 'Point', coordinates: [3, 4]},
     'second non-null geometry decodes from contiguous values'
-  );
-  t.end();
+  ).toEqual({type: 'Point', coordinates: [3, 4]});
 });
-
-test('geoarrow WKB helpers build Arrow Binary buffers from writer callbacks', t => {
+test('geoarrow WKB helpers build Arrow Binary buffers from writer callbacks', () => {
   const geometryData = makeWKBGeometryDataFromWriters([
     builder => {
       builder.beginPoint();
@@ -99,36 +85,33 @@ test('geoarrow WKB helpers build Arrow Binary buffers from writer callbacks', t 
       builder.writeCoordinate(5, 6);
     }
   ]);
-
-  t.deepEqual([...geometryData.valueOffsets], [0, 21, 21, 62], 'writer offsets are measured');
-  t.deepEqual(geometryData.nullBitmap, new Uint8Array([0b00000101]), 'writer null bitmap is set');
-  t.equal(geometryData.nullCount, 1, 'writer null count is set');
-  t.deepEqual(
+  expect([...geometryData.valueOffsets], 'writer offsets are measured').toEqual([0, 21, 21, 62]);
+  expect(geometryData.nullBitmap, 'writer null bitmap is set').toEqual(
+    new Uint8Array([0b00000101])
+  );
+  expect(geometryData.nullCount, 'writer null count is set').toBe(1);
+  expect(
     convertWKBToGeometry(
       geometryData.values.buffer.slice(
         geometryData.valueOffsets[2],
         geometryData.valueOffsets[3]
       ) as ArrayBuffer
     ),
-    {
-      type: 'LineString',
-      coordinates: [
-        [3, 4],
-        [5, 6]
-      ]
-    },
     'writer output decodes from contiguous values'
-  );
-  t.end();
+  ).toEqual({
+    type: 'LineString',
+    coordinates: [
+      [3, 4],
+      [5, 6]
+    ]
+  });
 });
-
-test('geoarrow WKB helpers update schema metadata and infer geometry types', t => {
+test('geoarrow WKB helpers update schema metadata and infer geometry types', () => {
   const geometryField = makeWKBGeometryField('geometry');
   const schema: Schema = {
     fields: [geometryField],
     metadata: {}
   };
-
   setWKBGeometrySchemaMetadata(schema, {
     geometryColumnName: 'geometry',
     geometryTypes: inferGeoParquetGeometryTypes([
@@ -142,42 +125,30 @@ test('geoarrow WKB helpers update schema metadata and infer geometry types', t =
       }
     ] as Geometry[])
   });
-
-  t.deepEqual(
-    getGeoMetadata(schema.metadata),
-    {
-      version: '1.1.0',
-      primary_column: 'geometry',
-      columns: {
-        geometry: {
-          encoding: 'wkb',
-          geometry_types: ['Point', 'LineString Z']
-        }
+  expect(getGeoMetadata(schema.metadata), 'adds WKB geo metadata to schema').toEqual({
+    version: '1.1.0',
+    primary_column: 'geometry',
+    columns: {
+      geometry: {
+        encoding: 'wkb',
+        geometry_types: ['Point', 'LineString Z']
       }
-    },
-    'adds WKB geo metadata to schema'
-  );
-  t.equal(
+    }
+  });
+  expect(
     geometryField.metadata?.['ARROW:extension:name'],
-    'geoarrow.wkb',
     'adds GeoArrow field metadata for WKB geometry columns'
-  );
-  t.end();
+  ).toBe('geoarrow.wkb');
 });
-
-test('geoarrow WKB helpers encode Geometry and pass through byte values', t => {
+test('geoarrow WKB helpers encode Geometry and pass through byte values', () => {
   const geometryBytes = encodeWKBGeometryValue({type: 'Point', coordinates: [1, 2]});
-  t.ok(geometryBytes instanceof Uint8Array, 'encodes GeoJSON geometry to bytes');
-
+  expect(geometryBytes instanceof Uint8Array, 'encodes GeoJSON geometry to bytes').toBeTruthy();
   const inputBytes = new Uint8Array([1, 2, 3, 4]);
   const outputBytes = encodeWKBGeometryValue(inputBytes);
-  t.deepEqual([...outputBytes!], [1, 2, 3, 4], 'passes through typed array bytes');
-  t.notEqual(outputBytes, inputBytes, 'returns a copy of passed-through bytes');
-
-  t.throws(
+  expect([...outputBytes!], 'passes through typed array bytes').toEqual([1, 2, 3, 4]);
+  expect(outputBytes, 'returns a copy of passed-through bytes').not.toBe(inputBytes);
+  expect(
     () => encodeWKBGeometryValue('POINT (1 2)' as unknown as Geometry),
-    /Expected a Geometry, ArrayBuffer, ArrayBufferView, or null for WKB encoding/,
     'rejects non-WKB string values'
-  );
-  t.end();
+  ).toThrow(/Expected a Geometry, ArrayBuffer, ArrayBufferView, or null for WKB encoding/);
 });

--- a/modules/gis/test/geometry-converters/wkb/convert-binary-geometry-to-wkb.spec.ts
+++ b/modules/gis/test/geometry-converters/wkb/convert-binary-geometry-to-wkb.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import type {BinaryGeometry} from '@loaders.gl/schema';
 import {convert} from '@loaders.gl/schema-utils';
 import {
@@ -15,35 +15,30 @@ import {
   reprojectWKBInPlace,
   writeBinaryGeometryToWKB
 } from '@loaders.gl/gis';
-
-test('convertBinaryGeometryToWKB#Point', t => {
+test('convertBinaryGeometryToWKB#Point', () => {
   const geometry = makePoint([1, 2]);
   const wkb = convertBinaryGeometryToWKB(geometry);
-
-  t.deepEqual(convertWKBToGeometry(toArrayBuffer(wkb!)), {type: 'Point', coordinates: [1, 2]});
-  t.deepEqual(convert(geometry, 'wkb', [GeometryConverter]), wkb);
-  t.equal(getBinaryGeometryWKBSize(geometry), wkb!.byteLength, 'measured byte length matches WKB');
-  t.end();
+  expect(convertWKBToGeometry(toArrayBuffer(wkb!))).toEqual({type: 'Point', coordinates: [1, 2]});
+  expect(convert(geometry, 'wkb', [GeometryConverter])).toEqual(wkb);
+  expect(getBinaryGeometryWKBSize(geometry), 'measured byte length matches WKB').toBe(
+    wkb!.byteLength
+  );
 });
-
-test('convertBinaryGeometryToWKB#LineString', t => {
+test('convertBinaryGeometryToWKB#LineString', () => {
   const geometry = makeLineString([
     [1, 2],
     [3, 4]
   ]);
   const wkb = convertBinaryGeometryToWKB(geometry);
-
-  t.deepEqual(convertWKBToGeometry(toArrayBuffer(wkb!)), {
+  expect(convertWKBToGeometry(toArrayBuffer(wkb!))).toEqual({
     type: 'LineString',
     coordinates: [
       [1, 2],
       [3, 4]
     ]
   });
-  t.end();
 });
-
-test('convertBinaryGeometryToWKB#Polygon', t => {
+test('convertBinaryGeometryToWKB#Polygon', () => {
   const geometry = makePolygon([
     [0, 0],
     [1, 0],
@@ -52,8 +47,7 @@ test('convertBinaryGeometryToWKB#Polygon', t => {
     [0, 0]
   ]);
   const wkb = convertBinaryGeometryToWKB(geometry);
-
-  t.deepEqual(convertWKBToGeometry(toArrayBuffer(wkb!)), {
+  expect(convertWKBToGeometry(toArrayBuffer(wkb!))).toEqual({
     type: 'Polygon',
     coordinates: [
       [
@@ -65,20 +59,18 @@ test('convertBinaryGeometryToWKB#Polygon', t => {
       ]
     ]
   });
-  t.end();
 });
-
-test('convertBinaryGeometryToWKB#reprojectWKBInPlace', t => {
+test('convertBinaryGeometryToWKB#reprojectWKBInPlace', () => {
   const wkb = convertBinaryGeometryToWKB(makePoint([1, 2, 9]), {hasZ: true})!;
   const reprojected = reprojectWKBInPlace(wkb, ([x, y]) => [x + 10, y + 20]);
-
-  t.equal(reprojected, wkb);
-  t.deepEqual(convertWKBToGeometry(toArrayBuffer(wkb)), {type: 'Point', coordinates: [11, 22, 9]});
-  t.end();
+  expect(reprojected).toBe(wkb);
+  expect(convertWKBToGeometry(toArrayBuffer(wkb))).toEqual({
+    type: 'Point',
+    coordinates: [11, 22, 9]
+  });
 });
-
-test('convertBinaryGeometryToWKB#inferBinaryGeometryTypes', t => {
-  t.deepEqual(
+test('convertBinaryGeometryToWKB#inferBinaryGeometryTypes', () => {
+  expect(
     inferBinaryGeometryTypes([
       makePoint([1, 2]),
       makeLineString([
@@ -86,13 +78,10 @@ test('convertBinaryGeometryToWKB#inferBinaryGeometryTypes', t => {
         [4, 5, 6]
       ]),
       null
-    ]),
-    ['Point', 'LineString Z']
-  );
-  t.end();
+    ])
+  ).toEqual(['Point', 'LineString Z']);
 });
-
-test('WKBBuilder#incremental geometry writers measure and write the same bytes', t => {
+test('WKBBuilder#incremental geometry writers measure and write the same bytes', () => {
   const geometryWriters = [
     (builder: WKBBuilder) => {
       builder.beginPoint();
@@ -136,23 +125,20 @@ test('WKBBuilder#incremental geometry writers measure and write the same bytes',
       builder.writeCoordinate(0, 0);
     }
   ];
-
   for (const geometryWriter of geometryWriters) {
     const measureBuilder = new WKBBuilder({mode: 'measure'});
     geometryWriter(measureBuilder);
     const byteLength = measureBuilder.finishGeometry();
-
     const values = new Uint8Array(byteLength);
     const writeBuilder = new WKBBuilder({mode: 'write', target: values});
     geometryWriter(writeBuilder);
-    t.equal(writeBuilder.finishGeometry(), byteLength, 'writer byte length matches measure pass');
-    t.ok(convertWKBToGeometry(toArrayBuffer(values)), 'written WKB decodes');
+    expect(writeBuilder.finishGeometry(), 'writer byte length matches measure pass').toBe(
+      byteLength
+    );
+    expect(convertWKBToGeometry(toArrayBuffer(values)), 'written WKB decodes').toBeTruthy();
   }
-
-  t.end();
 });
-
-test('WKBBuilder#buildGeometryArray builds offsets, values and null bitmap', t => {
+test('WKBBuilder#buildGeometryArray builds offsets, values and null bitmap', () => {
   const geometryWriters = [
     (builder: WKBBuilder) => {
       builder.beginPoint();
@@ -165,28 +151,22 @@ test('WKBBuilder#buildGeometryArray builds offsets, values and null bitmap', t =
     }
   ];
   const geometryArray = WKBBuilder.buildGeometryArray(geometryWriters);
-
-  t.deepEqual([...geometryArray.valueOffsets], [0, 21, 21, 42], 'offsets include null geometry');
-  t.deepEqual(
-    geometryArray.nullBitmap,
-    new Uint8Array([0b00000101]),
-    'null bitmap marks valid rows'
+  expect([...geometryArray.valueOffsets], 'offsets include null geometry').toEqual([0, 21, 21, 42]);
+  expect(geometryArray.nullBitmap, 'null bitmap marks valid rows').toEqual(
+    new Uint8Array([0b00000101])
   );
-  t.equal(geometryArray.nullCount, 1, 'null count is tracked');
-  t.deepEqual(
+  expect(geometryArray.nullCount, 'null count is tracked').toBe(1);
+  expect(
     convertWKBToGeometry(
       geometryArray.values.buffer.slice(
         geometryArray.valueOffsets[2],
         geometryArray.valueOffsets[3]
       ) as ArrayBuffer
     ),
-    {type: 'Point', coordinates: [3, 4]},
     'second non-null value decodes from contiguous values buffer'
-  );
-  t.end();
+  ).toEqual({type: 'Point', coordinates: [3, 4]});
 });
-
-test('writeBinaryGeometryToWKB#adapter matches convenience conversion', t => {
+test('writeBinaryGeometryToWKB#adapter matches convenience conversion', () => {
   const geometry = makeLineString([
     [1, 2, 3],
     [4, 5, 6]
@@ -194,24 +174,19 @@ test('writeBinaryGeometryToWKB#adapter matches convenience conversion', t => {
   const expected = convertBinaryGeometryToWKB(geometry, {hasZ: true})!;
   const values = new Uint8Array(getBinaryGeometryWKBSize(geometry, {hasZ: true}));
   const builder = new WKBBuilder({mode: 'write', target: values, hasZ: true});
-
   writeBinaryGeometryToWKB(builder, geometry);
-  t.equal(builder.finishGeometry(), values.byteLength, 'adapter wrote expected byte length');
-  t.deepEqual(values, expected, 'adapter output matches convenience conversion');
-  t.end();
+  expect(builder.finishGeometry(), 'adapter wrote expected byte length').toBe(values.byteLength);
+  expect(values, 'adapter output matches convenience conversion').toEqual(expected);
 });
-
 function makePoint(coordinates: number[]): BinaryGeometry {
   return {
     type: 'Point',
     positions: {value: new Float64Array(coordinates), size: coordinates.length}
   } as BinaryGeometry;
 }
-
 function toArrayBuffer(wkb: Uint8Array): ArrayBuffer {
   return wkb.buffer.slice(wkb.byteOffset, wkb.byteOffset + wkb.byteLength) as ArrayBuffer;
 }
-
 function makeLineString(coordinates: number[][]): BinaryGeometry {
   return {
     type: 'LineString',
@@ -222,7 +197,6 @@ function makeLineString(coordinates: number[][]): BinaryGeometry {
     pathIndices: {value: new Uint32Array([0, coordinates.length]), size: 1}
   } as BinaryGeometry;
 }
-
 function makePolygon(coordinates: number[][]): BinaryGeometry {
   return {
     type: 'Polygon',

--- a/modules/gis/test/geometry-converters/wkb/convert-geometry-to-wkb.spec.ts
+++ b/modules/gis/test/geometry-converters/wkb/convert-geometry-to-wkb.spec.ts
@@ -2,48 +2,35 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-/* eslint-disable no-continue */
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {fetchFile} from '@loaders.gl/core';
 import {parseTestCases} from '@loaders.gl/gis/test/data/wkt/parse-test-cases';
 import {convertGeometryToWKB} from '@loaders.gl/gis';
-
 const WKB_2D_TEST_CASES = '@loaders.gl/gis/test/data/wkt/wkb-testdata2d.json';
 const WKB_2D_NAN_TEST_CASES = '@loaders.gl/gis/test/data/wkt/wkb-testdata2d-nan.json';
 const WKB_Z_TEST_CASES = '@loaders.gl/gis/test/data/wkt/wkb-testdataZ.json';
 const WKB_Z_NAN_TEST_CASES = '@loaders.gl/gis/test/data/wkt/wkb-testdataZ-nan.json';
-
-test('convertGeometryToWKB#2D', async t => {
+test('convertGeometryToWKB#2D', async () => {
   const response = await fetchFile(WKB_2D_TEST_CASES);
   const TEST_CASES = parseTestCases(await response.json());
-
   for (const [title, testCase] of Object.entries(TEST_CASES)) {
     const {geoJSON, wkb} = testCase;
     const encoded = convertGeometryToWKB(geoJSON);
-    t.deepEqual(encoded, wkb, title);
+    expect(encoded, title).toEqual(wkb);
   }
-
-  t.end();
 });
-
-test('convertGeometryToWKB#2D NaN', async t => {
+test('convertGeometryToWKB#2D NaN', async () => {
   const response = await fetchFile(WKB_2D_NAN_TEST_CASES);
   const TEST_CASES = parseTestCases(await response.json());
-
   for (const [title, testCase] of Object.entries(TEST_CASES)) {
     const {geoJSON, wkb} = testCase;
     const encoded = convertGeometryToWKB(geoJSON);
-    t.deepEqual(encoded, wkb, title);
+    expect(encoded, title).toEqual(wkb);
   }
-
-  t.end();
 });
-
-test('convertGeometryToWKB#Z', async t => {
+test('convertGeometryToWKB#Z', async () => {
   const response = await fetchFile(WKB_Z_TEST_CASES);
   const TEST_CASES = parseTestCases(await response.json());
-
   for (const [title, testCase] of Object.entries(TEST_CASES)) {
     const {geoJSON, wkb} = testCase;
     // TODO - remove and fix empty handling
@@ -51,16 +38,12 @@ test('convertGeometryToWKB#Z', async t => {
       continue;
     }
     const encoded = convertGeometryToWKB(geoJSON, {wkb: {hasZ: true, hasM: false}});
-    t.deepEqual(encoded, wkb, title);
+    expect(encoded, title).toEqual(wkb);
   }
-
-  t.end();
 });
-
-test('convertGeometryToWKB#Z NaN', async t => {
+test('convertGeometryToWKB#Z NaN', async () => {
   const response = await fetchFile(WKB_Z_NAN_TEST_CASES);
   const TEST_CASES = parseTestCases(await response.json());
-
   for (const [title, testCase] of Object.entries(TEST_CASES)) {
     const {geoJSON, wkb} = testCase;
     // TODO - remove and fix empty handling
@@ -68,8 +51,6 @@ test('convertGeometryToWKB#Z NaN', async t => {
       continue;
     }
     const encoded = convertGeometryToWKB(geoJSON, {wkb: {hasZ: true, hasM: false}});
-    t.deepEqual(encoded, wkb, title);
+    expect(encoded, title).toEqual(wkb);
   }
-
-  t.end();
 });

--- a/modules/gis/test/table-converters/convert-geojson-to-arrow-table.spec.ts
+++ b/modules/gis/test/table-converters/convert-geojson-to-arrow-table.spec.ts
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test, {Test} from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {GEOARROW_TEST_CASES} from '@loaders.gl/arrow/test/data/geoarrow/test-cases';
-
 import {fetchFile, parse} from '@loaders.gl/core';
 import {Feature, FeatureCollection} from '@loaders.gl/schema';
 import {GeoArrowLoader} from '@loaders.gl/arrow';
@@ -13,16 +12,12 @@ import {
   getGeoMetadata,
   type LegacyGeoJSONCRS
 } from '@loaders.gl/gis';
-
-test('ArrowLoader#shape:geojson-table', async t => {
+test('ArrowLoader#shape:geojson-table', async () => {
   for (const testCase of GEOARROW_TEST_CASES) {
-    await testConversion(t, testCase[0], testCase[1]);
+    await testConversion(testCase[0], testCase[1]);
   }
-  t.end();
 });
-
 async function testConversion(
-  t: Test,
   arrowFile: string,
   expectedGeojson: FeatureCollection
 ): Promise<void> {
@@ -30,38 +25,28 @@ async function testConversion(
     core: {worker: false},
     arrow: {shape: 'geojson-table'}
   });
-
-  t.equal(table.shape, 'geojson-table');
-
+  expect(table.shape).toBe('geojson-table');
   if (table.shape === 'geojson-table') {
     // check if the arrow table is loaded correctly
-    t.equal(
-      table.features.length,
-      expectedGeojson.features.length,
-      `arrow table has ${expectedGeojson.features.length} row`
+    expect(table.features.length, `arrow table has ${expectedGeojson.features.length} row`).toBe(
+      expectedGeojson.features.length
     );
-
     // const colNames = [...Object.keys(expectedGeojson.features[0].properties || {}), 'geometry'];
     // t.equal(table.numCols, colNames.length, `arrow table has ${colNames.length} columns`);
-
     // // check fields exist in arrow table schema
     // table.schema.fields.map((field) =>
     //   t.equal(colNames.includes(field.name), true, `arrow table has ${field.name} column`)
     // );
-
     // get first geometry from arrow geometry column
     const firstFeature = table.features[0];
-
     // check if geometry in firstFeature is equal to the original geometry in expectedPointGeojson
-    t.deepEqual(
+    expect(
       firstFeature?.geometry,
-      expectedGeojson.features[0].geometry,
       'firstFeature.geometry is equal to expectedGeojson.features[0].geometry'
-    );
+    ).toEqual(expectedGeojson.features[0].geometry);
   }
 }
-
-test('convertFeaturesToGeoArrowTable#preserves arbitrary legacy GeoJSON CRS metadata', t => {
+test('convertFeaturesToGeoArrowTable#preserves arbitrary legacy GeoJSON CRS metadata', () => {
   const crs: LegacyGeoJSONCRS = {
     type: 'link',
     properties: {
@@ -76,22 +61,17 @@ test('convertFeaturesToGeoArrowTable#preserves arbitrary legacy GeoJSON CRS meta
   const extensionMetadata = JSON.parse(
     geometryField?.metadata?.['ARROW:extension:metadata'] || '{}'
   );
-
-  t.deepEqual(
+  expect(
     geometryColumnMetadata?.geojson_crs,
-    crs,
     'preserves raw legacy CRS on GeoParquet column metadata'
-  );
-  t.deepEqual(
+  ).toEqual(crs);
+  expect(
     extensionMetadata.geojson_crs,
-    crs,
     'preserves raw legacy CRS on GeoArrow field metadata'
-  );
-  t.equal(geometryColumnMetadata?.crs, undefined, 'does not map unknown CRS to GeoArrow CRS');
-  t.end();
+  ).toEqual(crs);
+  expect(geometryColumnMetadata?.crs, 'does not map unknown CRS to GeoArrow CRS').toBe(undefined);
 });
-
-test('convertFeaturesToGeoArrowTable#maps known legacy GeoJSON CRS metadata', t => {
+test('convertFeaturesToGeoArrowTable#maps known legacy GeoJSON CRS metadata', () => {
   const crs: LegacyGeoJSONCRS = {
     type: 'name',
     properties: {
@@ -105,23 +85,18 @@ test('convertFeaturesToGeoArrowTable#maps known legacy GeoJSON CRS metadata', t 
   const extensionMetadata = JSON.parse(
     geometryField?.metadata?.['ARROW:extension:metadata'] || '{}'
   );
-
-  t.deepEqual(geometryColumnMetadata?.geojson_crs, crs, 'preserves raw legacy CRS');
-  t.equal(
+  expect(geometryColumnMetadata?.geojson_crs, 'preserves raw legacy CRS').toEqual(crs);
+  expect(
     (geometryColumnMetadata?.crs as any)?.id?.authority,
-    'EPSG',
     'maps EPSG:4326 to GeoParquet CRS metadata'
-  );
-  t.equal(
+  ).toBe('EPSG');
+  expect(
     (extensionMetadata.crs as any)?.id?.code,
-    4326,
     'maps EPSG:4326 to GeoArrow field CRS metadata'
-  );
-  t.equal(extensionMetadata.crs_type, 'projjson', 'sets GeoArrow CRS metadata type');
-  t.end();
+  ).toBe(4326);
+  expect(extensionMetadata.crs_type, 'sets GeoArrow CRS metadata type').toBe('projjson');
 });
-
-test('convertFeaturesToGeoArrowTable#applies legacy GeoJSON CRS to custom geometry column', t => {
+test('convertFeaturesToGeoArrowTable#applies legacy GeoJSON CRS to custom geometry column', () => {
   const crs: LegacyGeoJSONCRS = {
     type: 'name',
     properties: {
@@ -137,17 +112,15 @@ test('convertFeaturesToGeoArrowTable#applies legacy GeoJSON CRS to custom geomet
   const extensionMetadata = JSON.parse(
     geometryField?.metadata?.['ARROW:extension:metadata'] || '{}'
   );
-
-  t.deepEqual(geoMetadata?.columns.geom.geojson_crs, crs, 'stores CRS under custom column');
-  t.equal(geoMetadata?.columns.geometry, undefined, 'does not create default geometry metadata');
-  t.equal(
-    (extensionMetadata.crs as any)?.id?.code,
-    'CRS84',
-    'maps CRS84 to GeoArrow field CRS metadata'
+  expect(geoMetadata?.columns.geom.geojson_crs, 'stores CRS under custom column').toEqual(crs);
+  expect(geoMetadata?.columns.geometry, 'does not create default geometry metadata').toBe(
+    undefined
   );
-  t.end();
+  expect(
+    (extensionMetadata.crs as any)?.id?.code,
+    'maps CRS84 to GeoArrow field CRS metadata'
+  ).toBe('CRS84');
 });
-
 function makePointFeatures(): Feature[] {
   return [
     {

--- a/modules/mvt/test/lib/parse-mvt-from-pbf.spec.ts
+++ b/modules/mvt/test/lib/parse-mvt-from-pbf.spec.ts
@@ -2,12 +2,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-// import type {BinaryFeatureCollection} from '@loaders.gl/schema';
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {parseMVT} from '../../src/lib/mvt-pbf/parse-mvt-from-pbf';
 import {fetchFile} from '@loaders.gl/core';
 // import {geojsonToBinary, binaryToGeojson} from '@loaders.gl/gis';
-
 const MVT_POINTS_DATA_URL = '@loaders.gl/mvt/test/data/mvt/points_4-2-6.mvt';
 // const MVT_LINES_DATA_URL = '@loaders.gl/mvt/test/data/mvt/lines_2-2-1.mvt';
 // const MVT_POLYGONS_DATA_URL = '@loaders.gl/mvt/test/data/mvt/polygons_10-133-325.mvt';
@@ -16,7 +14,6 @@ const MVT_POINTS_DATA_URL = '@loaders.gl/mvt/test/data/mvt/points_4-2-6.mvt';
 // const MVT_MULTIPLE_LAYERS_DATA_URL =
 //   '@loaders.gl/mvt/test/data/mvt/lines_10-501-386_multiplelayers.mvt';
 // const WITH_FEATURE_ID = '@loaders.gl/mvt/test/data/mvt/with_feature_id.mvt';
-
 // Test to sanity check that old method of parsing binary
 // format via an intermediate geojson step produces the
 // same result
@@ -27,325 +24,27 @@ const MVT_POINTS_DATA_URL = '@loaders.gl/mvt/test/data/mvt/points_4-2-6.mvt';
 //   MVT_POLYGON_ZERO_SIZE_HOLE_DATA_URL,
 //   MVT_MULTIPLE_LAYERS_DATA_URL
 // ];
-
 // Geometry Array Results
-
 // /// GeoJSON Results
 // import decodedPolygonsGeometry from '@loaders.gl/mvt/test/data/mvt-results/decoded_mvt_polygons_array.json' assert {type: 'json'};
-
 // // GeoJSON Results
 // import decodedPointsGeoJSON from '@loaders.gl/mvt/test/data/mvt-results/decoded_mvt_points.json' assert {type: 'json'};
 // import decodedLinesGeoJSON from '@loaders.gl/mvt/test/data/mvt-results/decoded_mvt_lines.json' assert {type: 'json'};
 // import decodedPolygonsGeoJSON from '@loaders.gl/mvt/test/data/mvt-results/decoded_mvt_polygons.json' assert {type: 'json'};
-
 // setLoaderOptions({
 //   _workerType: 'test'
 // });
-
-test('Point MVT to local coordinates JSON', async t => {
+test('Point MVT to local coordinates JSON', async () => {
   const response = await fetchFile(MVT_POINTS_DATA_URL);
   const mvtArrayBuffer = await response.arrayBuffer();
-
   const tile = parseMVT(mvtArrayBuffer);
-
-  t.deepEqual(tile.layers.layer0.length, 1, 'layer0 has 1 feature');
+  expect(tile.layers.layer0.length, 'layer0 has 1 feature').toEqual(1);
   // t.deepEqual(tile.layers.layer0.idColumn[0], 1, 'idColumn is 1');
-  t.deepEqual(tile.layers.layer0.geometryTypeColumn[0], 1, 'geometryTypeColumn is 1');
-  t.deepEqual(tile.layers.layer0.columns.cartodb_id[0], 3, 'cartodb_id is 3');
-  t.deepEqual(tile.layers.layer0.columns._cdb_feature_count[0], 1, '_cdb_feature_count is 1');
-  t.deepEqual(
-    tile.layers.layer0.schema.fields,
-    [
-      {name: 'cartodb_id', type: 'uint32', nullable: false},
-      {name: '_cdb_feature_count', type: 'uint32', nullable: false}
-    ],
-    'schema fields are correct'
-  );
-
-  //   {
-  //     type: 'Feature',
-  //     geometry: {
-  //       type: 'Point',
-  //       coordinates: [0.5576171875, 0.185546875]
-  //     },
-  //     properties: {
-  //       // eslint-disable-next-line camelcase
-  //       cartodb_id: 3,
-  //       // eslint-disable-next-line camelcase
-  //       _cdb_feature_count: 1,
-  //       layerName: 'layer0'
-  //     }
-  //   }
-  // ]);
-
-  t.end();
+  expect(tile.layers.layer0.geometryTypeColumn[0], 'geometryTypeColumn is 1').toEqual(1);
+  expect(tile.layers.layer0.columns.cartodb_id[0], 'cartodb_id is 3').toEqual(3);
+  expect(tile.layers.layer0.columns._cdb_feature_count[0], '_cdb_feature_count is 1').toEqual(1);
+  expect(tile.layers.layer0.schema.fields, 'schema fields are correct').toEqual([
+    {name: 'cartodb_id', type: 'uint32', nullable: false},
+    {name: '_cdb_feature_count', type: 'uint32', nullable: false}
+  ]);
 });
-
-// test('Line MVT to local coordinates JSON', async (t) => {
-//   const response = await fetchFile(MVT_LINES_DATA_URL);
-//   const mvtArrayBuffer = await response.arrayBuffer();
-
-//   const geometryJSON = await parse(mvtArrayBuffer, MVTLoader);
-//   t.deepEqual(geometryJSON, [
-//     {
-//       type: 'Feature',
-//       geometry: {
-//         type: 'LineString',
-//         coordinates: [
-//           [-0.00390625, 0.48876953125],
-//           [0.0009765625, 0.490234375]
-//         ]
-//       },
-//       properties: {
-//         // eslint-disable-next-line camelcase
-//         cartodb_id: 1,
-//         layerName: 'layer0'
-//       }
-//     }
-//   ]);
-
-//   t.end();
-// });
-
-// test('Polygon MVT to local coordinates JSON', async (t) => {
-//   const response = await fetchFile(MVT_POLYGONS_DATA_URL);
-//   const mvtArrayBuffer = await response.arrayBuffer();
-
-//   const geometryJSON = await parse(mvtArrayBuffer, MVTLoader);
-//   t.deepEqual(geometryJSON, decodedPolygonsGeometry);
-
-//   t.end();
-// });
-
-// test('MVTLoader#Parse Point MVT', async (t) => {
-//   for (const binary of [true, false]) {
-//     const outputFormat = binary ? 'binary' : 'geojson';
-//     const response = await fetchFile(MVT_POINTS_DATA_URL);
-//     const mvtArrayBuffer = await response.arrayBuffer();
-
-//     const loaderOptions: MVTLoaderOptions = {
-//       mvt: {
-//         coordinates: 'wgs84',
-//         tileIndex: {
-//           x: 2,
-//           y: 6,
-//           z: 4
-//         }
-//       }
-//     };
-//     if (binary) {
-//       loaderOptions.gis = {format: 'binary'};
-//     }
-
-//     loaderOptions.worker = false;
-//     const geometry = await parse(mvtArrayBuffer, MVTLoader, loaderOptions);
-//     let expected = decodedPointsGeoJSON;
-//     if (binary) {
-//       // @ts-ignore
-//       expected = geojsonToBinary(expected);
-//       t.ok(geometry.byteLength > 0);
-//       delete geometry.byteLength;
-//     }
-//     t.deepEqual(geometry, expected, `Parsed Point MVT as ${outputFormat}`);
-//   }
-//   t.end();
-// });
-
-// test('MVTLoader#Parse Lines MVT', async (t) => {
-//   for (const binary of [true, false]) {
-//     const outputFormat = binary ? 'binary' : 'geojson';
-
-//     const response = await fetchFile(MVT_LINES_DATA_URL);
-//     const mvtArrayBuffer = await response.arrayBuffer();
-
-//     const loaderOptions: MVTLoaderOptions = {
-//       mvt: {
-//         coordinates: 'wgs84',
-//         tileIndex: {
-//           x: 2,
-//           y: 1,
-//           z: 2
-//         }
-//       }
-//     };
-//     if (binary) {
-//       loaderOptions.gis = {format: 'binary'};
-//     }
-
-//     const geometry = await parse(mvtArrayBuffer, MVTLoader, loaderOptions);
-//     let expected = decodedLinesGeoJSON;
-//     if (binary) {
-//       // @ts-ignore
-//       expected = geojsonToBinary(expected);
-//       t.ok(geometry.byteLength > 0);
-//       delete geometry.byteLength;
-//     }
-//     t.deepEqual(geometry, expected, `Parsed Lines MVT as ${outputFormat}`);
-//   }
-//   t.end();
-// });
-
-// test('MVTLoader#Parse Polygons MVT', async (t) => {
-//   for (const binary of [true, false]) {
-//     const outputFormat = binary ? 'binary' : 'geojson';
-
-//     const response = await fetchFile(MVT_POLYGONS_DATA_URL);
-//     const mvtArrayBuffer = await response.arrayBuffer();
-
-//     const loaderOptions: MVTLoaderOptions = {
-//       mvt: {
-//         coordinates: 'wgs84',
-//         tileIndex: {
-//           x: 133,
-//           y: 325,
-//           z: 10
-//         }
-//       }
-//     };
-//     if (binary) {
-//       loaderOptions.gis = {format: 'binary'};
-//     }
-
-//     const geometry = await parse(mvtArrayBuffer, MVTLoader, loaderOptions);
-//     let expected = decodedPolygonsGeoJSON;
-//     if (binary) {
-//       // @ts-ignore
-//       expected = geojsonToBinary(expected, {fixRingWinding: false});
-//       t.ok(geometry.byteLength > 0);
-//       delete geometry.byteLength;
-//     }
-//     t.deepEqual(geometry, expected, `Parsed Polygons MVT as ${outputFormat}`);
-//   }
-//   t.end();
-// });
-
-// test('Should raise an error when coordinates param is wgs84 and tileIndex is missing', async (t) => {
-//   const response = await fetchFile(MVT_POINTS_DATA_URL);
-//   const mvtArrayBuffer = await response.arrayBuffer();
-
-//   const loaderOptions: MVTLoaderOptions = {
-//     mvt: {coordinates: 'wgs84'}
-//   };
-
-//   t.throws(() => parseSync(mvtArrayBuffer, MVTLoader, loaderOptions));
-
-//   t.end();
-// });
-
-// test('Should add layer name to custom property', async (t) => {
-//   const response = await fetchFile(MVT_POINTS_DATA_URL);
-//   const mvtArrayBuffer = await response.arrayBuffer();
-
-//   const loaderOptions: MVTLoaderOptions = {
-//     mvt: {layerProperty: 'layerSource'}
-//   };
-
-//   const geometryJSON = await parse(mvtArrayBuffer, MVTLoader, loaderOptions);
-//   t.equals(geometryJSON[0].properties.layerSource, 'layer0');
-
-//   t.end();
-// });
-
-// test('Should return features from selected layers when layers property is provided', async (t) => {
-//   const response = await fetchFile(MVT_MULTIPLE_LAYERS_DATA_URL);
-//   const mvtArrayBuffer = await response.arrayBuffer();
-
-//   const loaderOptions: MVTLoaderOptions = {
-//     mvt: {layers: ['layer1']}
-//   };
-
-//   const geometryJSON = await parse(mvtArrayBuffer, MVTLoader, loaderOptions);
-//   const anyFeatureFromAnotherLayer = geometryJSON.some(
-//     (feature) => feature.properties.layerName !== 'layer1'
-//   );
-//   t.false(anyFeatureFromAnotherLayer);
-//   t.equals(geometryJSON[0].properties.layerName, 'layer1');
-
-//   t.end();
-// });
-
-// test('Polygon MVT to local coordinates binary', async (t) => {
-//   const response = await fetchFile(MVT_POLYGONS_DATA_URL);
-//   const mvtArrayBuffer = await response.arrayBuffer();
-
-//   const geometryBinary = await parse(mvtArrayBuffer, MVTLoader, {gis: {format: 'binary'}});
-//   t.ok(geometryBinary.byteLength > 0);
-//   delete geometryBinary.byteLength;
-
-//   // @ts-ignore deduced type of 'Feature' is string...
-//   const expectedBinary = geojsonToBinary(decodedPolygonsGeometry);
-//   t.deepEqual(geometryBinary, expectedBinary);
-//   t.end();
-// });
-
-// test('MVTLoader#Parse geojson-to-binary', async (t) => {
-//   for (const filename of TEST_FILES) {
-//     const response = await fetchFile(filename);
-//     const mvtArrayBuffer = await response.arrayBuffer();
-//     const geojson = await parse(mvtArrayBuffer, MVTLoader);
-
-//     // Pass a fresh response otherwise get CI testing errors
-//     const response2 = await fetchFile(filename);
-//     const mvtArrayBuffer2 = await response2.arrayBuffer();
-//     const binary = await parse(mvtArrayBuffer2, MVTLoader, {gis: {format: 'binary'}});
-//     delete binary.byteLength;
-
-//     const expectedBinary = geojsonToBinary(geojson);
-//     t.deepEqual(expectedBinary, binary);
-//   }
-//   t.end();
-// });
-
-// test('Features with top-level id', async (t) => {
-//   const response = await fetchFile(WITH_FEATURE_ID);
-//   const mvtArrayBuffer = await response.arrayBuffer();
-
-//   const binary = await parse(mvtArrayBuffer, MVTLoader, {mvt: {shape: 'binary-geometry'}});
-//   t.ok(binary.points.fields.length, 'feature.id fields are preserved');
-//   t.ok(binary.lines.fields.length, 'feature.id fields are preserved');
-//   t.ok(binary.polygons.fields.length, 'feature.id fields are preserved');
-
-//   const feature = binaryToGeojson(binary, {
-//     globalFeatureId: binary.points.globalFeatureIds.value[0]
-//   });
-//   // @ts-ignore
-//   t.ok(feature.id, 'feature.id is restored');
-
-//   t.end();
-// });
-
-// test('Empty MVT must return empty binary format', async (t) => {
-//   const emptyMVTArrayBuffer = new Uint8Array();
-//   const geometryBinary = await parse(emptyMVTArrayBuffer, MVTLoader, {gis: {format: 'binary'}});
-//   t.ok(geometryBinary.points);
-//   t.ok(geometryBinary.lines);
-//   t.ok(geometryBinary.polygons);
-//   t.ok(geometryBinary.points.positions.size === 2);
-//   t.ok(geometryBinary.lines.positions.size === 2);
-//   t.ok(geometryBinary.polygons.positions.size === 2);
-
-//   t.end();
-// });
-
-// test('Triangulation is supported', async (t) => {
-//   const response = await fetchFile(MVT_POLYGONS_DATA_URL);
-//   const mvtArrayBuffer = await response.arrayBuffer();
-//   const geometry = await parse(mvtArrayBuffer, MVTLoader, {
-//     gis: {format: 'binary'}
-//   });
-
-//   // Closed polygon with 31 vertices (0===30)
-//   t.ok(geometry.polygons.positions);
-//   t.equals(geometry.polygons.positions.value.length, 62);
-
-//   t.ok(geometry.polygons.triangles);
-//   t.equals(geometry.polygons.triangles.value.length, 84);
-
-//   // Basic check that triangulation is valid
-//   const minI = Math.min(...geometry.polygons.triangles.value);
-//   const maxI = Math.max(...geometry.polygons.triangles.value);
-//   t.equals(minI, 0);
-//   t.equals(maxI, 29); // Don't expect to find 30 as closed polygon
-
-//   t.end();
-// });

--- a/modules/mvt/test/lib/utils/geometry-utils.spec.ts
+++ b/modules/mvt/test/lib/utils/geometry-utils.spec.ts
@@ -2,10 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-// import type {BinaryFeatureCollection} from '@loaders.gl/schema';
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {classifyRingsFlat} from '@loaders.gl/mvt/lib/utils/geometry-utils';
-
 const loadJSON = async (relativePath: string) => {
   const url = new URL(relativePath, import.meta.url);
   if (url.protocol === 'file:' && typeof window === 'undefined') {
@@ -15,46 +13,37 @@ const loadJSON = async (relativePath: string) => {
   const response = await fetch(url);
   return response.json();
 };
-
 const [ringsSingleRing, ringsRingAndHole, ringsTwoRings, ringsZeroSizeHole] = await Promise.all([
   loadJSON('../../data/rings/rings_single_ring.json'),
   loadJSON('../../data/rings/rings_ring_and_hole.json'),
   loadJSON('../../data/rings/rings_two_rings.json'),
   loadJSON('../../data/rings/rings_zero_size_hole.json')
 ]);
-
-test('classifyRingsFlat#single ring', async t => {
+test('classifyRingsFlat#single ring', async () => {
   const geom = {...ringsSingleRing};
   const classified = classifyRingsFlat(geom);
-  t.deepEqual(classified.areas, [[-0.02624368667602539]]);
-  t.deepEqual(classified.indices, [[0]]);
-  t.end();
+  expect(classified.areas).toEqual([[-0.02624368667602539]]);
+  expect(classified.indices).toEqual([[0]]);
 });
-
-test('classifyRingsFlat#ring and hole', async t => {
+test('classifyRingsFlat#ring and hole', async () => {
   const geom = {...ringsRingAndHole};
   const classified = classifyRingsFlat(geom);
-  t.deepEqual(classified.areas, [[-0.02624368667602539, 0.001363515853881836]]);
-  t.deepEqual(classified.indices, [[0, 10]]);
-  t.end();
+  expect(classified.areas).toEqual([[-0.02624368667602539, 0.001363515853881836]]);
+  expect(classified.indices).toEqual([[0, 10]]);
 });
-
-test('classifyRingsFlat#two rings', async t => {
+test('classifyRingsFlat#two rings', async () => {
   const geom = {...ringsTwoRings};
   const classified = classifyRingsFlat(geom);
-  t.deepEqual(classified.areas, [[-0.02624368667602539], [-0.001363515853881836]]);
-  t.deepEqual(classified.indices, [[0], [10]]);
-  t.end();
+  expect(classified.areas).toEqual([[-0.02624368667602539], [-0.001363515853881836]]);
+  expect(classified.indices).toEqual([[0], [10]]);
 });
-
-test('classifyRingsFlat#zero sized hole', async t => {
+test('classifyRingsFlat#zero sized hole', async () => {
   // In addition to checking the result,
   // verify that the data array is shortened
   const geom = {...ringsZeroSizeHole};
-  t.equal(geom.data.length, 20);
+  expect(geom.data.length).toBe(20);
   const classified = classifyRingsFlat(geom);
-  t.deepEqual(classified.areas, [[-0.44582176208496094]]);
-  t.deepEqual(classified.indices, [[0]]);
-  t.equal(classified.data.length, 12);
-  t.end();
+  expect(classified.areas).toEqual([[-0.44582176208496094]]);
+  expect(classified.indices).toEqual([[0]]);
+  expect(classified.data.length).toBe(12);
 });

--- a/modules/mvt/test/lib/vector-tiler/clip-features.spec.ts
+++ b/modules/mvt/test/lib/vector-tiler/clip-features.spec.ts
@@ -1,21 +1,17 @@
 // loaders.gl
-// SPDX-License-Identifier: MIT AND ISC
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
-// Forked from https://github.com/mapbox/geojson-vt under compatible ISC license
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 // @ts-ignore-error
 import {clipFeatures} from '@loaders.gl/mvt/lib/vector-tiler/features/clip-features';
-
 /* eslint comma-spacing:0*/
-
 const geom1 = [
   0, 0, 0, 50, 0, 0, 50, 10, 0, 20, 10, 0, 20, 20, 0, 30, 20, 0, 30, 30, 0, 50, 30, 0, 50, 40, 0,
   25, 40, 0, 25, 50, 0, 0, 50, 0, 0, 60, 0, 25, 60, 0
 ];
 const geom2 = [0, 0, 0, 50, 0, 0, 50, 10, 0, 0, 10, 0];
-
-test('VectorTiler#clipFeatures#clips polylines', t => {
+test('VectorTiler#clipFeatures#clips polylines', () => {
   const clipped = clipFeatures(
     [
       {geometry: geom1, type: 'LineString', tags: 1, minX: 0, minY: 0, maxX: 50, maxY: 60},
@@ -29,7 +25,6 @@ test('VectorTiler#clipFeatures#clips polylines', t => {
     Infinity,
     {}
   );
-
   const expected = [
     {
       id: null,
@@ -60,13 +55,9 @@ test('VectorTiler#clipFeatures#clips polylines', t => {
       maxY: 10
     }
   ];
-
-  t.equal(JSON.stringify(clipped), JSON.stringify(expected));
-
-  t.end();
+  expect(JSON.stringify(clipped)).toBe(JSON.stringify(expected));
 });
-
-test('VectorTiler#clipFeatures#clips lines with line metrics on', t => {
+test('VectorTiler#clipFeatures#clips lines with line metrics on', () => {
   const geom = geom1.slice();
   // @ts-expect-error
   geom.size = 0;
@@ -80,7 +71,6 @@ test('VectorTiler#clipFeatures#clips lines with line metrics on', t => {
   geom.start = 0;
   // @ts-expect-error
   geom.end = geom.size;
-
   const clipped = clipFeatures(
     [{geometry: geom, type: 'LineString', minX: 0, minY: 0, maxX: 50, maxY: 60}],
     1,
@@ -91,25 +81,17 @@ test('VectorTiler#clipFeatures#clips lines with line metrics on', t => {
     Infinity,
     {lineMetrics: true}
   );
-
-  t.same(
-    clipped.map(f => [f.geometry.start, f.geometry.end]),
-    [
-      [10, 40],
-      [70, 130],
-      [160, 200],
-      [230, 245]
-    ]
-  );
-
-  t.end();
+  expect(clipped.map(f => [f.geometry.start, f.geometry.end])).toEqual([
+    [10, 40],
+    [70, 130],
+    [160, 200],
+    [230, 245]
+  ]);
 });
-
 function closed(geometry) {
   return [geometry.concat(geometry.slice(0, 3))];
 }
-
-test('VectorTiler#clipFeatures#clips polygons', t => {
+test('VectorTiler#clipFeatures#clips polygons', () => {
   const clipped = clipFeatures(
     [
       {geometry: closed(geom1), type: 'Polygon', tags: 1, minX: 0, minY: 0, maxX: 50, maxY: 60},
@@ -123,7 +105,6 @@ test('VectorTiler#clipFeatures#clips polygons', t => {
     Infinity,
     {}
   );
-
   const expected = [
     {
       id: null,
@@ -151,13 +132,9 @@ test('VectorTiler#clipFeatures#clips polygons', t => {
       maxY: 10
     }
   ];
-
-  t.equal(JSON.stringify(clipped), JSON.stringify(expected));
-
-  t.end();
+  expect(JSON.stringify(clipped)).toBe(JSON.stringify(expected));
 });
-
-test('VectorTiler#clipFeatures#clips points', t => {
+test('VectorTiler#clipFeatures#clips points', () => {
   const clipped = clipFeatures(
     [
       {geometry: geom1, type: 'MultiPoint', tags: 1, minX: 0, minY: 0, maxX: 50, maxY: 60},
@@ -171,8 +148,7 @@ test('VectorTiler#clipFeatures#clips points', t => {
     Infinity,
     {}
   );
-
-  t.same(clipped, [
+  expect(clipped).toEqual([
     {
       id: null,
       type: 'MultiPoint',
@@ -185,6 +161,4 @@ test('VectorTiler#clipFeatures#clips points', t => {
       maxY: 60
     }
   ]);
-
-  t.end();
 });

--- a/modules/mvt/test/lib/vector-tiler/simplify-path.spec.ts
+++ b/modules/mvt/test/lib/vector-tiler/simplify-path.spec.ts
@@ -1,13 +1,10 @@
 // loaders.gl
-// SPDX-License-Identifier: MIT AND ISC
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
-// Forked from https://github.com/mapbox/geojson-vt under compatible ISC license
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {simplifyPath} from '@loaders.gl/mvt/lib/vector-tiler/features/simplify-path';
-
 /* eslint comma-spacing:0, no-shadow: 0*/
-
 const points = [
   [0.22455, 0.25015],
   [0.22691, 0.24419],
@@ -110,7 +107,6 @@ const points = [
   [0.85397, 0.47115],
   [0.86636, 0.48077]
 ];
-
 const simplified = [
   [0.22455, 0.25015],
   [0.26776, 0.21381],
@@ -147,36 +143,28 @@ const simplified = [
   [0.85397, 0.47115],
   [0.86636, 0.48077]
 ];
-
-test('GeoJSONVT#simplifyPath#simplifies points correctly with the given tolerance', t => {
+test('GeoJSONVT#simplifyPath#simplifies points correctly with the given tolerance', () => {
   const coords: number[] = [];
   for (let i = 0; i < points.length; i++) {
     coords.push(points[i][0], points[i][1], 0);
   }
-
   coords[2] = 1;
   coords[coords.length - 1] = 1;
   simplifyPath(coords, 0, coords.length - 3, 0.001 * 0.001);
-
   const result: number[][] = [];
   for (let i = 0; i < coords.length; i += 3) {
     if (coords[i + 2] > 0.005 * 0.005) {
       result.push([coords[i], coords[i + 1]]);
     }
   }
-  t.same(result, simplified);
-  t.end();
+  expect(result).toEqual(simplified);
 });
-
-test('GeoJSONVT#simplifyPath#does not throw max call stack error on bad long input', t => {
+test('GeoJSONVT#simplifyPath#does not throw max call stack error on bad long input', () => {
   const coords: number[][] = [];
   for (let i = 0; i < 1400; i++) {
     coords.push([0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]);
   }
-
-  t.doesNotThrow(() => {
+  expect(() => {
     simplifyPath(coords, 2e-15);
-  });
-
-  t.end();
+  }).not.toThrow();
 });

--- a/modules/mvt/test/map-style-loader.spec.ts
+++ b/modules/mvt/test/map-style-loader.spec.ts
@@ -2,18 +2,16 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {parse} from '@loaders.gl/core';
 import {validateLoader} from 'test/common/conformance';
 import {MapStyleLoader} from '@loaders.gl/mvt/bundled';
 import inlineStyleText from './data/map-style/inline.style.json?raw';
 import {resolveMapStyle, type MapStyle, type MapStyleLoadOptions} from '../src/index';
-
 const INLINE_STYLE_URL = new URL('./data/map-style/inline.style.json', import.meta.url);
 const STYLE_BASE_URL = 'https://example.com/styles/root.style.json';
 const TILEJSON_URL = 'https://example.com/styles/terrain.tilejson';
 const TILE_TEMPLATE_URL = 'https://example.com/styles/tiles/{z}/{x}/{y}.pbf';
-
 function createJsonResponse(json: unknown, ok = true, status = 200) {
   return {
     ok,
@@ -23,46 +21,33 @@ function createJsonResponse(json: unknown, ok = true, status = 200) {
     }
   };
 }
-
-test('MapStyleLoader#loader conformance', t => {
-  validateLoader(t, MapStyleLoader, 'MapStyleLoader');
-  t.end();
+test('MapStyleLoader#loader conformance', () => {
+  validateLoader(MapStyleLoader, 'MapStyleLoader');
 });
-
-test('MapStyleLoader#parse inline style fixture', async t => {
+test('MapStyleLoader#parse inline style fixture', async () => {
   const style = await parse(inlineStyleText, MapStyleLoader, {
     mapStyle: {baseUrl: INLINE_STYLE_URL.href}
   });
-
-  t.equal(style.version, 8, 'style version is preserved');
-  t.equal(style.layers.length, 1, 'style layers are loaded');
-  t.equal(style.sources['inline-source']?.type, 'vector', 'source metadata is preserved');
-  t.equal(
+  expect(style.version, 'style version is preserved').toBe(8);
+  expect(style.layers.length, 'style layers are loaded').toBe(1);
+  expect(style.sources['inline-source']?.type, 'source metadata is preserved').toBe('vector');
+  expect(
     style.sources['inline-source']?.tiles?.[0]?.includes('/tiles/{z}/{x}/{y}.mvt'),
-    true,
     'relative tile template is normalized'
-  );
-  t.deepEqual(
-    style.sources['inline-source']?.custom,
-    {preserved: true},
-    'unknown source fields are preserved'
-  );
-
-  t.end();
+  ).toBe(true);
+  expect(style.sources['inline-source']?.custom, 'unknown source fields are preserved').toEqual({
+    preserved: true
+  });
 });
-
-test('MapStyleLoader#parseText inline style fixture', async t => {
+test('MapStyleLoader#parseText inline style fixture', async () => {
   const style = await MapStyleLoader.parseText?.(inlineStyleText, {
     mapStyle: {baseUrl: INLINE_STYLE_URL.href}
   });
-
-  t.ok(style, 'parseText returns a resolved style');
-  t.equal(style?.version, 8, 'style version is preserved');
-  t.equal(style?.sources['inline-source']?.type, 'vector', 'source metadata is preserved');
-  t.end();
+  expect(style, 'parseText returns a resolved style').toBeTruthy();
+  expect(style?.version, 'style version is preserved').toBe(8);
+  expect(style?.sources['inline-source']?.type, 'source metadata is preserved').toBe('vector');
 });
-
-test('resolveMapStyle resolves relative tiles from baseUrl', async t => {
+test('resolveMapStyle resolves relative tiles from baseUrl', async () => {
   const style: MapStyle = {
     version: 8,
     sources: {
@@ -73,21 +58,15 @@ test('resolveMapStyle resolves relative tiles from baseUrl', async t => {
     },
     layers: [{id: 'land', type: 'fill', source: 'basemap'}]
   };
-
   const resolvedStyle = await resolveMapStyle(style, {
     mapStyle: {baseUrl: STYLE_BASE_URL}
   });
-
-  t.equal(
+  expect(
     resolvedStyle.sources.basemap.tiles?.[0],
-    'https://example.com/styles/tiles/{z}/{x}/{y}.mvt',
     'tile template is resolved against baseUrl'
-  );
-
-  t.end();
+  ).toBe('https://example.com/styles/tiles/{z}/{x}/{y}.mvt');
 });
-
-test('resolveMapStyle resolves TileJSON-backed sources', async t => {
+test('resolveMapStyle resolves TileJSON-backed sources', async () => {
   let requestedUrl = '';
   const resolvedStyle = await resolveMapStyle(
     {
@@ -116,25 +95,18 @@ test('resolveMapStyle resolves TileJSON-backed sources', async t => {
       }
     }
   );
-
-  t.equal(requestedUrl, TILEJSON_URL, 'relative TileJSON URL is resolved before fetch');
-  t.equal(resolvedStyle.sources.terrain.url, TILEJSON_URL, 'resolved source URL is stored');
-  t.equal(
+  expect(requestedUrl, 'relative TileJSON URL is resolved before fetch').toBe(TILEJSON_URL);
+  expect(resolvedStyle.sources.terrain.url, 'resolved source URL is stored').toBe(TILEJSON_URL);
+  expect(
     resolvedStyle.sources.terrain.tiles?.[0],
-    TILE_TEMPLATE_URL,
     'TileJSON tiles are resolved against the TileJSON URL'
+  ).toBe(TILE_TEMPLATE_URL);
+  expect(resolvedStyle.sources.terrain.minzoom, 'TileJSON fields are merged').toBe(2);
+  expect(resolvedStyle.sources.terrain.attribution, 'existing source fields are preserved').toBe(
+    'kept'
   );
-  t.equal(resolvedStyle.sources.terrain.minzoom, 2, 'TileJSON fields are merged');
-  t.equal(
-    resolvedStyle.sources.terrain.attribution,
-    'kept',
-    'existing source fields are preserved'
-  );
-
-  t.end();
 });
-
-test('MapStyleLoader honors custom fetch implementation', async t => {
+test('MapStyleLoader honors custom fetch implementation', async () => {
   const arrayBuffer = new TextEncoder().encode(
     JSON.stringify({
       version: 8,
@@ -157,62 +129,45 @@ test('MapStyleLoader honors custom fetch implementation', async t => {
       }
     }
   };
-
   const style = await parse(arrayBuffer, MapStyleLoader, options);
-
-  t.deepEqual(requestedUrls, [TILEJSON_URL], 'custom fetch is used for source resolution');
-  t.equal(style.sources.basemap.tiles?.[0], 'https://example.com/styles/tiles/{z}/{x}/{y}.mvt');
-
-  t.end();
+  expect(requestedUrls, 'custom fetch is used for source resolution').toEqual([TILEJSON_URL]);
+  expect(style.sources.basemap.tiles?.[0]).toBe('https://example.com/styles/tiles/{z}/{x}/{y}.mvt');
 });
-
-test('resolveMapStyle preserves extra fields and initializes empty collections', async t => {
+test('resolveMapStyle preserves extra fields and initializes empty collections', async () => {
   const style = await resolveMapStyle({
     version: 8,
     metadata: {theme: 'test'},
     custom: {enabled: true}
   });
-
-  t.deepEqual(style.sources, {}, 'sources default to an empty object');
-  t.deepEqual(style.layers, [], 'layers default to an empty array');
-  t.deepEqual(style.custom, {enabled: true}, 'extra top-level fields are preserved');
-
-  t.end();
+  expect(style.sources, 'sources default to an empty object').toEqual({});
+  expect(style.layers, 'layers default to an empty array').toEqual([]);
+  expect(style.custom, 'extra top-level fields are preserved').toEqual({enabled: true});
 });
-
-test('MapStyleLoader rejects invalid JSON', async t => {
-  await t.rejects(
-    async () => await MapStyleLoader.parse(new TextEncoder().encode('{"version":8').buffer, {}),
-    /JSON/,
+test('MapStyleLoader rejects invalid JSON', async () => {
+  await expect(
+    MapStyleLoader.parse(new TextEncoder().encode('{"version":8').buffer, {}),
     'invalid JSON is rejected'
-  );
-
-  t.end();
+  ).rejects.toThrow(/JSON/);
 });
-
-test('resolveMapStyle rejects invalid fetched TileJSON', async t => {
-  await t.rejects(
-    async () =>
-      await resolveMapStyle(
-        {
-          version: 8,
-          sources: {
-            basemap: {
-              type: 'vector',
-              url: './terrain.tilejson'
-            }
-          }
-        },
-        {
-          mapStyle: {
-            baseUrl: STYLE_BASE_URL,
-            fetch: async () => createJsonResponse('not-an-object') as Response
+test('resolveMapStyle rejects invalid fetched TileJSON', async () => {
+  await expect(
+    resolveMapStyle(
+      {
+        version: 8,
+        sources: {
+          basemap: {
+            type: 'vector',
+            url: './terrain.tilejson'
           }
         }
-      ),
-    /Invalid input/,
+      },
+      {
+        mapStyle: {
+          baseUrl: STYLE_BASE_URL,
+          fetch: async () => createJsonResponse('not-an-object') as Response
+        }
+      }
+    ),
     'invalid fetched TileJSON is rejected'
-  );
-
-  t.end();
+  ).rejects.toThrow(/Invalid input/);
 });

--- a/modules/mvt/test/mvt-loader.spec.ts
+++ b/modules/mvt/test/mvt-loader.spec.ts
@@ -2,12 +2,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-// import type {BinaryFeatureCollection} from '@loaders.gl/schema';
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {MVTLoader, MVTLoaderOptions} from '@loaders.gl/mvt';
 import {setLoaderOptions, fetchFile, parse, parseSync} from '@loaders.gl/core';
 import {geojsonToBinary, binaryToGeojson} from '@loaders.gl/gis';
-
 const MVT_POINTS_DATA_URL = '@loaders.gl/mvt/test/data/mvt/points_4-2-6.mvt';
 const MVT_LINES_DATA_URL = '@loaders.gl/mvt/test/data/mvt/lines_2-2-1.mvt';
 const MVT_POLYGONS_DATA_URL = '@loaders.gl/mvt/test/data/mvt/polygons_10-133-325.mvt';
@@ -16,9 +14,7 @@ const MVT_POLYGON_ZERO_SIZE_HOLE_DATA_URL =
 const MVT_MULTIPLE_LAYERS_DATA_URL =
   '@loaders.gl/mvt/test/data/mvt/lines_10-501-386_multiplelayers.mvt';
 const WITH_FEATURE_ID = '@loaders.gl/mvt/test/data/mvt/with_feature_id.mvt';
-
 // Geometry Array Results
-
 // // GeoJSON Results
 const loadJSON = async (relativePath: string) => {
   const url = new URL(relativePath, import.meta.url);
@@ -29,27 +25,22 @@ const loadJSON = async (relativePath: string) => {
   const response = await fetch(url);
   return response.json();
 };
-
 const decodedPolygonsGeometry = await loadJSON(
   './data/mvt-results/decoded_mvt_polygons_array.json'
 );
-
 // GeoJSON Results
 const decodedPointsGeoJSON = await loadJSON('./data/mvt-results/decoded_mvt_points.json');
 const decodedLinesGeoJSON = await loadJSON('./data/mvt-results/decoded_mvt_lines.json');
 const decodedPolygonsGeoJSON = await loadJSON('./data/mvt-results/decoded_mvt_polygons.json');
-
 setLoaderOptions({
   _workerType: 'test'
 });
-
-test('Point MVT to local coordinates JSON', async t => {
+test('Point MVT to local coordinates JSON', async () => {
   const response = await fetchFile(MVT_POINTS_DATA_URL);
   const mvtArrayBuffer = await response.arrayBuffer();
-
   const geometryTable = await parse(mvtArrayBuffer, MVTLoader);
-  t.equal(geometryTable.shape, 'geojson-table');
-  t.deepEqual(geometryTable.features, [
+  expect(geometryTable.shape).toBe('geojson-table');
+  expect(geometryTable.features).toEqual([
     {
       type: 'Feature',
       geometry: {
@@ -65,31 +56,23 @@ test('Point MVT to local coordinates JSON', async t => {
       }
     }
   ]);
-
-  t.end();
 });
-
-test('Point MVT to Arrow table', async t => {
+test('Point MVT to Arrow table', async () => {
   const response = await fetchFile(MVT_POINTS_DATA_URL);
   const mvtArrayBuffer = await response.arrayBuffer();
-
   const geometryTable = await parse(mvtArrayBuffer, MVTLoader, {
     mvt: {shape: 'arrow-table', coordinates: 'local', layerProperty: 'layerName'}
   });
-
-  t.equal(geometryTable.shape, 'arrow-table');
-  t.equal(geometryTable.data.getChild('geometry')?.length, 1, 'preserves feature rows');
-  t.ok(geometryTable.schema?.metadata?.geo, 'adds GeoArrow metadata');
-  t.end();
+  expect(geometryTable.shape).toBe('arrow-table');
+  expect(geometryTable.data.getChild('geometry')?.length, 'preserves feature rows').toBe(1);
+  expect(geometryTable.schema?.metadata?.geo, 'adds GeoArrow metadata').toBeTruthy();
 });
-
-test('Line MVT to local coordinates JSON', async t => {
+test('Line MVT to local coordinates JSON', async () => {
   const response = await fetchFile(MVT_LINES_DATA_URL);
   const mvtArrayBuffer = await response.arrayBuffer();
-
   const geometryTable = await parse(mvtArrayBuffer, MVTLoader);
-  t.equal(geometryTable.shape, 'geojson-table');
-  t.deepEqual(geometryTable.features, [
+  expect(geometryTable.shape).toBe('geojson-table');
+  expect(geometryTable.features).toEqual([
     {
       type: 'Feature',
       geometry: {
@@ -106,27 +89,19 @@ test('Line MVT to local coordinates JSON', async t => {
       }
     }
   ]);
-
-  t.end();
 });
-
-test('Polygon MVT to local coordinates JSON', async t => {
+test('Polygon MVT to local coordinates JSON', async () => {
   const response = await fetchFile(MVT_POLYGONS_DATA_URL);
   const mvtArrayBuffer = await response.arrayBuffer();
-
   const geometryTable = await parse(mvtArrayBuffer, MVTLoader);
-  t.equal(geometryTable.shape, 'geojson-table');
-  t.deepEqual(geometryTable.features, decodedPolygonsGeometry);
-
-  t.end();
+  expect(geometryTable.shape).toBe('geojson-table');
+  expect(geometryTable.features).toEqual(decodedPolygonsGeometry);
 });
-
-test('MVTLoader#Parse Point MVT', async t => {
+test('MVTLoader#Parse Point MVT', async () => {
   for (const binary of [true, false]) {
     const outputFormat = binary ? 'binary-geometry' : 'geojson-table';
     const response = await fetchFile(MVT_POINTS_DATA_URL);
     const mvtArrayBuffer = await response.arrayBuffer();
-
     const loaderOptions: MVTLoaderOptions = {
       mvt: {
         coordinates: 'wgs84',
@@ -138,7 +113,6 @@ test('MVTLoader#Parse Point MVT', async t => {
         }
       }
     };
-
     loaderOptions.worker = false;
     const geometry = await parse(mvtArrayBuffer, MVTLoader, loaderOptions);
     let expected = binary
@@ -147,21 +121,17 @@ test('MVTLoader#Parse Point MVT', async t => {
     if (binary) {
       // @ts-ignore
       expected = geojsonToBinary(expected);
-      t.ok(geometry.byteLength > 0);
+      expect(geometry.byteLength > 0).toBeTruthy();
       delete geometry.byteLength;
     }
-    t.deepEqual(geometry, expected, `Parsed Point MVT as ${outputFormat}`);
+    expect(geometry, `Parsed Point MVT as ${outputFormat}`).toEqual(expected);
   }
-  t.end();
 });
-
-test('MVTLoader#Parse Lines MVT', async t => {
+test('MVTLoader#Parse Lines MVT', async () => {
   for (const binary of [true, false]) {
     const outputFormat = binary ? 'binary-geometry' : 'geojson-table';
-
     const response = await fetchFile(MVT_LINES_DATA_URL);
     const mvtArrayBuffer = await response.arrayBuffer();
-
     const loaderOptions: MVTLoaderOptions = {
       mvt: {
         coordinates: 'wgs84',
@@ -173,7 +143,6 @@ test('MVTLoader#Parse Lines MVT', async t => {
         }
       }
     };
-
     const geometry = await parse(mvtArrayBuffer, MVTLoader, loaderOptions);
     let expected = binary
       ? decodedLinesGeoJSON
@@ -181,21 +150,17 @@ test('MVTLoader#Parse Lines MVT', async t => {
     if (binary) {
       // @ts-ignore
       expected = geojsonToBinary(expected);
-      t.ok(geometry.byteLength > 0);
+      expect(geometry.byteLength > 0).toBeTruthy();
       delete geometry.byteLength;
     }
-    t.deepEqual(geometry, expected, `Parsed Lines MVT as ${outputFormat}`);
+    expect(geometry, `Parsed Lines MVT as ${outputFormat}`).toEqual(expected);
   }
-  t.end();
 });
-
-test('MVTLoader#Parse Polygons MVT', async t => {
+test('MVTLoader#Parse Polygons MVT', async () => {
   for (const binary of [true, false]) {
     const outputFormat = binary ? 'binary-geometry' : 'geojson-table';
-
     const response = await fetchFile(MVT_POLYGONS_DATA_URL);
     const mvtArrayBuffer = await response.arrayBuffer();
-
     const loaderOptions: MVTLoaderOptions = {
       mvt: {
         coordinates: 'wgs84',
@@ -207,15 +172,14 @@ test('MVTLoader#Parse Polygons MVT', async t => {
         }
       }
     };
-
     const geometry = await parse(mvtArrayBuffer, MVTLoader, loaderOptions);
     if (binary) {
       const expected = geojsonToBinary(structuredClone(decodedPolygonsGeoJSON), {
         fixRingWinding: false
       });
-      t.ok(geometry.byteLength > 0);
+      expect(geometry.byteLength > 0).toBeTruthy();
       delete geometry.byteLength;
-      t.deepEqual(geometry, expected, `Parsed Polygons MVT as ${outputFormat}`);
+      expect(geometry, `Parsed Polygons MVT as ${outputFormat}`).toEqual(expected);
     } else {
       const expected = {
         shape: 'geojson-table',
@@ -226,73 +190,52 @@ test('MVTLoader#Parse Polygons MVT', async t => {
         ...geometry,
         features: normalizeGeoJsonFeatures(geometry.features)
       };
-      t.deepEqual(normalizedGeometry, expected, `Parsed Polygons MVT as ${outputFormat}`);
+      expect(normalizedGeometry, `Parsed Polygons MVT as ${outputFormat}`).toEqual(expected);
     }
   }
-  t.end();
 });
-
-test('Should raise an error when coordinates param is wgs84 and tileIndex is missing', async t => {
+test('Should raise an error when coordinates param is wgs84 and tileIndex is missing', async () => {
   const response = await fetchFile(MVT_POINTS_DATA_URL);
   const mvtArrayBuffer = await response.arrayBuffer();
-
   const loaderOptions: MVTLoaderOptions = {
     mvt: {coordinates: 'wgs84'}
   };
-
-  t.throws(() => parseSync(mvtArrayBuffer, MVTLoader, loaderOptions));
-
-  t.end();
+  expect(() => parseSync(mvtArrayBuffer, MVTLoader, loaderOptions)).toThrow();
 });
-
-test('Should add layer name to custom property', async t => {
+test('Should add layer name to custom property', async () => {
   const response = await fetchFile(MVT_POINTS_DATA_URL);
   const mvtArrayBuffer = await response.arrayBuffer();
-
   const loaderOptions: MVTLoaderOptions = {
     mvt: {layerProperty: 'layerSource'}
   };
-
   const geometryTable = await parse(mvtArrayBuffer, MVTLoader, loaderOptions);
-  t.equals(geometryTable.features[0].properties.layerSource, 'layer0');
-
-  t.end();
+  expect(geometryTable.features[0].properties.layerSource).toBe('layer0');
 });
-
-test('Should return features from selected layers when layers property is provided', async t => {
+test('Should return features from selected layers when layers property is provided', async () => {
   const response = await fetchFile(MVT_MULTIPLE_LAYERS_DATA_URL);
   const mvtArrayBuffer = await response.arrayBuffer();
-
   const loaderOptions: MVTLoaderOptions = {
     mvt: {layers: ['layer1']}
   };
-
   const geometryTable = await parse(mvtArrayBuffer, MVTLoader, loaderOptions);
   const anyFeatureFromAnotherLayer = geometryTable.features.some(
     feature => feature.properties.layerName !== 'layer1'
   );
-  t.false(anyFeatureFromAnotherLayer);
-  t.equals(geometryTable.features[0].properties.layerName, 'layer1');
-
-  t.end();
+  expect(anyFeatureFromAnotherLayer).toBe(false);
+  expect(geometryTable.features[0].properties.layerName).toBe('layer1');
 });
-
-test('Polygon MVT to local coordinates binary', async t => {
+test('Polygon MVT to local coordinates binary', async () => {
   const response = await fetchFile(MVT_POLYGONS_DATA_URL);
   const mvtArrayBuffer = await response.arrayBuffer();
-
   const geometryBinary = await parse(mvtArrayBuffer, MVTLoader, {
     mvt: {shape: 'binary-geometry'}
   });
-  t.ok(geometryBinary.byteLength > 0);
+  expect(geometryBinary.byteLength > 0).toBeTruthy();
   delete geometryBinary.byteLength;
-
   // @ts-ignore deduced type of 'Feature' is string...
   const expectedBinary = geojsonToBinary(decodedPolygonsGeometry);
-  t.deepEqual(geometryBinary, expectedBinary);
-  t.end();
+  expect(geometryBinary).toEqual(expectedBinary);
 });
-
 // Test to sanity check that old method of parsing binary
 // format via an intermediate geojson step produces the
 // same result
@@ -303,81 +246,62 @@ const TEST_FILES = [
   MVT_POLYGON_ZERO_SIZE_HOLE_DATA_URL,
   MVT_MULTIPLE_LAYERS_DATA_URL
 ];
-
-test('MVTLoader#Parse geojson-to-binary', async t => {
+test('MVTLoader#Parse geojson-to-binary', async () => {
   for (const filename of TEST_FILES) {
     const response = await fetchFile(filename);
     const mvtArrayBuffer = await response.arrayBuffer();
     const geojsonTable = await parse(mvtArrayBuffer, MVTLoader);
-
     // Pass a fresh response otherwise get CI testing errors
     const response2 = await fetchFile(filename);
     const mvtArrayBuffer2 = await response2.arrayBuffer();
     const binary = await parse(mvtArrayBuffer2, MVTLoader, {mvt: {shape: 'binary-geometry'}});
     delete binary.byteLength;
-
     const expectedBinary = geojsonToBinary(geojsonTable.features);
-    t.deepEqual(expectedBinary, binary);
+    expect(expectedBinary).toEqual(binary);
   }
-  t.end();
 });
-
-test('Features with top-level id', async t => {
+test('Features with top-level id', async () => {
   const response = await fetchFile(WITH_FEATURE_ID);
   const mvtArrayBuffer = await response.arrayBuffer();
-
   const binary = await parse(mvtArrayBuffer, MVTLoader, {mvt: {shape: 'binary-geometry'}});
-  t.ok(binary.points.fields.length, 'feature.id fields are preserved');
-  t.ok(binary.lines.fields.length, 'feature.id fields are preserved');
-  t.ok(binary.polygons.fields.length, 'feature.id fields are preserved');
-
+  expect(binary.points.fields.length, 'feature.id fields are preserved').toBeTruthy();
+  expect(binary.lines.fields.length, 'feature.id fields are preserved').toBeTruthy();
+  expect(binary.polygons.fields.length, 'feature.id fields are preserved').toBeTruthy();
   const feature = binaryToGeojson(binary, {
     globalFeatureId: binary.points.globalFeatureIds.value[0]
   });
   // @ts-ignore
-  t.ok(feature.id, 'feature.id is restored');
-
-  t.end();
+  expect(feature.id, 'feature.id is restored').toBeTruthy();
 });
-
-test('Empty MVT must return empty binary format', async t => {
+test('Empty MVT must return empty binary format', async () => {
   const emptyMVTArrayBuffer = new Uint8Array();
   const geometryBinary = await parse(emptyMVTArrayBuffer, MVTLoader, {
     mvt: {shape: 'binary-geometry'}
   });
-  t.ok(geometryBinary.points);
-  t.ok(geometryBinary.lines);
-  t.ok(geometryBinary.polygons);
-  t.ok(geometryBinary.points.positions.size === 2);
-  t.ok(geometryBinary.lines.positions.size === 2);
-  t.ok(geometryBinary.polygons.positions.size === 2);
-
-  t.end();
+  expect(geometryBinary.points).toBeTruthy();
+  expect(geometryBinary.lines).toBeTruthy();
+  expect(geometryBinary.polygons).toBeTruthy();
+  expect(geometryBinary.points.positions.size === 2).toBeTruthy();
+  expect(geometryBinary.lines.positions.size === 2).toBeTruthy();
+  expect(geometryBinary.polygons.positions.size === 2).toBeTruthy();
 });
-
-test('Triangulation is supported', async t => {
+test('Triangulation is supported', async () => {
   const response = await fetchFile(MVT_POLYGONS_DATA_URL);
   const mvtArrayBuffer = await response.arrayBuffer();
   const geometry = await parse(mvtArrayBuffer, MVTLoader, {
     mvt: {shape: 'binary-geometry'}
   });
-
   // Closed polygon with 31 vertices (0===30)
-  t.ok(geometry.polygons.positions);
-  t.equals(geometry.polygons.positions.value.length, 62);
-
-  t.ok(geometry.polygons.triangles);
-  t.equals(geometry.polygons.triangles.value.length, 84);
-
+  expect(geometry.polygons.positions).toBeTruthy();
+  expect(geometry.polygons.positions.value.length).toBe(62);
+  expect(geometry.polygons.triangles).toBeTruthy();
+  expect(geometry.polygons.triangles.value.length).toBe(84);
   // Basic check that triangulation is valid
   const minI = Math.min(...geometry.polygons.triangles.value);
   const maxI = Math.max(...geometry.polygons.triangles.value);
-  t.equals(minI, 0);
-  t.equals(maxI, 29); // Don't expect to find 30 as closed polygon
-
-  t.end();
+  expect(minI).toBe(0);
+  expect(maxI).toBe(29); // Don't expect to find 30 as closed polygon
 });
-
 /**
  * Copies GeoJSON features while normalizing projected coordinate precision for stable comparisons.
  *
@@ -393,7 +317,6 @@ function normalizeGeoJsonFeatures(features: any[]): any[] {
     }
   }));
 }
-
 /**
  * Rounds nested coordinates to avoid browser-specific floating-point projection drift.
  *

--- a/modules/mvt/test/mvt-source.spec.ts
+++ b/modules/mvt/test/mvt-source.spec.ts
@@ -2,107 +2,79 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {isBrowser} from '@loaders.gl/core';
-
 import {TILESETS} from './data/tilesets';
 import {MVTSourceLoader, MVTTileSource} from '@loaders.gl/mvt';
 import {isURLTemplate, getURLFromTemplate} from '../src/mvt-source-loader';
-
-test('MVTSourceLoader#urls', async t => {
+test('MVTSourceLoader#urls', async () => {
   if (!isBrowser) {
-    t.comment('MVTSourceLoader currently only supported in browser');
-    t.end();
+    console.log('MVTSourceLoader currently only supported in browser');
     return;
   }
   for (const tilesetUrl of TILESETS) {
     const source = new MVTSourceLoader({url: tilesetUrl});
-    t.ok(source);
+    expect(source).toBeTruthy();
     const metadata = await source.getMetadata();
-    t.ok(metadata);
-    // console.error(JSON.stringify(metadata.tileJSON, null, 2));
+    expect(metadata).toBeTruthy();
   }
-  t.end();
 });
-
-test('MVTSourceLoader#Blobs', async t => {
+test('MVTSourceLoader#Blobs', async () => {
   if (!isBrowser) {
-    t.comment('MVTSourceLoader currently only supported in browser');
-    t.end();
+    console.log('MVTSourceLoader currently only supported in browser');
     return;
   }
   for (const tilesetUrl of TILESETS) {
     const source = new MVTSourceLoader({url: tilesetUrl});
-    t.ok(source);
+    expect(source).toBeTruthy();
     const metadata = await source.getMetadata();
-    t.ok(metadata);
-    // console.error(JSON.stringify(metadata.tileJSON, null, 2));
+    expect(metadata).toBeTruthy();
   }
-  t.end();
 });
-
 const TEST_TEMPLATE = 'https://server.com/{z}/{x}/{y}.png';
 const TEST_TEMPLATE2 = 'https://server.com/{z}/{x}/{y}/{x}-{y}-{z}.png';
 const TEST_TEMPLATE_ARRAY = [
   'https://server.com/ep1/{x}/{y}.png',
   'https://server.com/ep2/{x}/{y}.png'
 ];
-
-test('isURLFromTemplate', t => {
-  t.true(isURLTemplate(TEST_TEMPLATE), 'single string template');
-  t.true(isURLTemplate(TEST_TEMPLATE2), 'single string template with multiple occurance');
-  // t.true(isURLTemplate(TEST_TEMPLATE_ARRAY), 'array of templates');
-  t.end();
-});
-
-test('getURLFromTemplate', t => {
-  t.is(
-    getURLFromTemplate(TEST_TEMPLATE, 1, 2, 0),
-    'https://server.com/0/1/2.png',
-    'single string template'
+test('isURLFromTemplate', () => {
+  expect(isURLTemplate(TEST_TEMPLATE), 'single string template').toBe(true);
+  expect(isURLTemplate(TEST_TEMPLATE2), 'single string template with multiple occurance').toBe(
+    true
   );
-  t.is(
+});
+test('getURLFromTemplate', () => {
+  expect(getURLFromTemplate(TEST_TEMPLATE, 1, 2, 0), 'single string template').toBe(
+    'https://server.com/0/1/2.png'
+  );
+  expect(
     getURLFromTemplate(TEST_TEMPLATE2, 1, 2, 0),
-    'https://server.com/0/1/2/1-2-0.png',
     'single string template with multiple occurance'
+  ).toBe('https://server.com/0/1/2/1-2-0.png');
+  expect(getURLFromTemplate(TEST_TEMPLATE_ARRAY, 1, 2, 0, '1-2-0'), 'array of templates').toBe(
+    'https://server.com/ep2/1/2.png'
   );
-  t.is(
-    getURLFromTemplate(TEST_TEMPLATE_ARRAY, 1, 2, 0, '1-2-0'),
-    'https://server.com/ep2/1/2.png',
-    'array of templates'
+  expect(getURLFromTemplate(TEST_TEMPLATE_ARRAY, 2, 2, 0, '2-2-0'), 'array of templates').toBe(
+    'https://server.com/ep1/2/2.png'
   );
-  t.is(
-    getURLFromTemplate(TEST_TEMPLATE_ARRAY, 2, 2, 0, '2-2-0'),
-    'https://server.com/ep1/2/2.png',
-    'array of templates'
+  expect(getURLFromTemplate(TEST_TEMPLATE_ARRAY, 17, 11, 5, '17-11-5'), 'array of templates').toBe(
+    'https://server.com/ep2/17/11.png'
   );
-  t.is(
-    getURLFromTemplate(TEST_TEMPLATE_ARRAY, 17, 11, 5, '17-11-5'),
-    'https://server.com/ep2/17/11.png',
-    'array of templates'
-  );
-  // t.is(getURLFromTemplate(null, 1, 2, 0), null, 'invalid template');
-  // t.is(getURLFromTemplate([], 1, 2, 0), null, 'empty array');
-  t.end();
 });
-
-test('MVTTileSource#getTileData returns null for text/html responses', async t => {
+test('MVTTileSource#getTileData returns null for text/html responses', async () => {
   const reportedErrors: Error[] = [];
   const source = makeContentTypeSource('text/html; charset=utf-8', '<html></html>', true, error =>
     reportedErrors.push(error)
   );
-
   const tileData = await source.getTileData({index: {x: 0, y: 0, z: 0}});
   await source.metadata;
-  t.equal(tileData, null, 'returns null for non-MVT response before parsing');
-  t.ok(
+  expect(tileData, 'returns null for non-MVT response before parsing').toBe(null);
+  expect(
     reportedErrors.some(error => error.message.includes('Unexpected tile content type text/html')),
     'reports ignored text through the source error callback'
-  );
-  t.end();
+  ).toBeTruthy();
 });
-
-test('MVTTileSource#getTile filters textual errors without rejecting custom binary types', async t => {
+test('MVTTileSource#getTile filters textual errors without rejecting custom binary types', async () => {
   const textualContentTypes = [
     'application/json',
     'application/problem+json',
@@ -113,9 +85,8 @@ test('MVTTileSource#getTile filters textual errors without rejecting custom bina
     const source = makeContentTypeSource(contentType, '{}', true);
     const tile = await source.getTile({x: 0, y: 0, z: 0, layers: []});
     await source.metadata;
-    t.equal(tile, null, `rejects ${contentType}`);
+    expect(tile, `rejects ${contentType}`).toBe(null);
   }
-
   const binarySource = makeContentTypeSource(
     'application/vnd.example.vector-tile',
     new Uint8Array([1, 2, 3]),
@@ -123,20 +94,16 @@ test('MVTTileSource#getTile filters textual errors without rejecting custom bina
   );
   const binaryTile = await binarySource.getTile({x: 0, y: 0, z: 0, layers: []});
   await binarySource.metadata;
-  t.deepEqual(Array.from(new Uint8Array(binaryTile!)), [1, 2, 3], 'accepts custom binary types');
-
+  expect(Array.from(new Uint8Array(binaryTile!)), 'accepts custom binary types').toEqual([1, 2, 3]);
   const emptySource = makeContentTypeSource(null, null, false, undefined, 204);
   const emptyTile = await emptySource.getTile({x: 0, y: 0, z: 0, layers: []});
   await emptySource.metadata;
-  t.equal(emptyTile?.byteLength, 0, 'returns a 204 empty tile as an empty ArrayBuffer');
-
+  expect(emptyTile?.byteLength, 'returns a 204 empty tile as an empty ArrayBuffer').toBe(0);
   const permissiveSource = makeContentTypeSource('text/plain', 'mislabeled tile');
   const permissiveTile = await permissiveSource.getTile({x: 0, y: 0, z: 0, layers: []});
   await permissiveSource.metadata;
-  t.ok(permissiveTile, 'allows textual content types by default');
-  t.end();
+  expect(permissiveTile, 'allows textual content types by default').toBeTruthy();
 });
-
 /** Creates an MVT source whose tile request returns a controlled content type and payload. */
 function makeContentTypeSource(
   contentType: string | null,
@@ -163,202 +130,3 @@ function makeContentTypeSource(
     }
   });
 }
-
-// TBA - TILE LOADING TESTS
-
-/*
-import test from 'test/utils/vitest-tape';
-import {validateLoader} from 'test/common/conformance';
-
-import {load} from '@loaders.gl/core';
-import {PMTilesLoader} from '@loaders.gl/pmtiles';
-
-import {PMTILESETS} from './data/tilesets';
-
-test('PMTilesLoader#loader conformance', (t) => {
-  validateLoader(t, PMTilesLoader, 'PMTilesLoader');
-  t.end();
-});
-
-test.skip('PMTilesLoader#load', async (t) => {
-  for (const tilesetUrl of PMTILESETS) {
-    const metadata = await load(tilesetUrl, PMTilesLoader);
-    t.ok(metadata);
-  }
-  t.end();
-});
-
-/*
-// echo '{"type":"Polygon","coordinates":[[[0,0],[0,1],[1,1],[1,0],[0,0]]]}' | ./tippecanoe -zg -o test_fixture_1.pmtiles
-test('cache getHeader', async (t) => {
-  const source = new TestFileSource('@loaders.gl/pmtiles/test/data/test_fixture_1.pmtiles', '1');
-  const cache = new SharedPromiseCache();
-  const header = await cache.getHeader(source);
-  t.strictEqual(header.rootDirectoryOffset, 127);
-  t.strictEqual(header.rootDirectoryLength, 25);
-  t.strictEqual(header.jsonMetadataOffset, 152);
-  t.strictEqual(header.jsonMetadataLength, 247);
-  t.strictEqual(header.leafDirectoryOffset, 0);
-  t.strictEqual(header.leafDirectoryLength, 0);
-  t.strictEqual(header.tileDataOffset, 399);
-  t.strictEqual(header.tileDataLength, 69);
-  t.strictEqual(header.numAddressedTiles, 1);
-  t.strictEqual(header.numTileEntries, 1);
-  t.strictEqual(header.numTileContents, 1);
-  t.strictEqual(header.clustered, false);
-  t.strictEqual(header.internalCompression, 2);
-  t.strictEqual(header.tileCompression, 2);
-  t.strictEqual(header.tileType, 1);
-  t.strictEqual(header.minZoom, 0);
-  t.strictEqual(header.maxZoom, 0);
-  t.strictEqual(header.minLon, 0);
-  t.strictEqual(header.minLat, 0);
-  // t.strictEqual(header.maxLon,1); // TODO fix me
-  t.strictEqual(header.maxLat, 1);
-});
-
-test('cache check against empty', async (t) => {
-  const source = new TestFileSource('@loaders.gl/pmtiles/test/data/empty.pmtiles', '1');
-  const cache = new SharedPromiseCache();
-  t.rejects(async () => {
-    await cache.getHeader(source);
-  });
-});
-
-test('cache check magic number', async (t) => {
-  const source = new TestFileSource('@loaders.gl/pmtiles/test/data/invalid.pmtiles', '1');
-  const cache = new SharedPromiseCache();
-  t.rejects(async () => {
-    await cache.getHeader(source);
-  });
-});
-
-test('cache check future spec version', async (t) => {
-  const source = new TestFileSource('@loaders.gl/pmtiles/test/data/invalid_v4.pmtiles', '1');
-  const cache = new SharedPromiseCache();
-  t.rejects(async () => {
-    await cache.getHeader(source);
-  });
-});
-
-test('cache getDirectory', async (t) => {
-  const source = new TestFileSource('@loaders.gl/pmtiles/test/data/test_fixture_1.pmtiles', '1');
-
-  let cache = new SharedPromiseCache(6400, false);
-  let header = await cache.getHeader(source);
-  t.strictEqual(cache.cache.size, 1);
-
-  cache = new SharedPromiseCache(6400, true);
-  header = await cache.getHeader(source);
-
-  // prepopulates the root directory
-  t.strictEqual(cache.cache.size, 2);
-
-  const directory = await cache.getDirectory(
-    source,
-    header.rootDirectoryOffset,
-    header.rootDirectoryLength,
-    header
-  );
-  t.strictEqual(directory.length, 1);
-  t.strictEqual(directory[0].tileId, 0);
-  t.strictEqual(directory[0].offset, 0);
-  t.strictEqual(directory[0].length, 69);
-  t.strictEqual(directory[0].runLength, 1);
-
-  for (const v of cache.cache.values()) {
-    t.ok(v.lastUsed > 0);
-  }
-});
-
-test('multiple sources in a single cache', async (t) => {
-  const cache = new SharedPromiseCache();
-  const source1 = new TestFileSource('@loaders.gl/pmtiles/test/data/test_fixture_1.pmtiles', '1');
-  const source2 = new TestFileSource('@loaders.gl/pmtiles/test/data/test_fixture_1.pmtiles', '2');
-  await cache.getHeader(source1);
-  t.strictEqual(cache.cache.size, 2);
-  await cache.getHeader(source2);
-  t.strictEqual(cache.cache.size, 4);
-});
-
-test('etags are part of key', async (t) => {
-  const cache = new SharedPromiseCache(6400, false);
-  const source = new TestFileSource('@loaders.gl/pmtiles/test/data/test_fixture_1.pmtiles', '1');
-  source.etag = 'etag_1';
-  let header = await cache.getHeader(source);
-  t.strictEqual(header.etag, 'etag_1');
-
-  source.etag = 'etag_2';
-
-  t.rejects(async () => {
-    await cache.getDirectory(
-      source,
-      header.rootDirectoryOffset,
-      header.rootDirectoryLength,
-      header
-    );
-  });
-
-  cache.invalidate(source, 'etag_2');
-  header = await cache.getHeader(source);
-  t.ok(
-    await cache.getDirectory(source, header.rootDirectoryOffset, header.rootDirectoryLength, header)
-  );
-});
-
-test.skip('soft failure on etag weirdness', async (t) => {
-  const cache = new SharedPromiseCache(6400, false);
-  const source = new TestFileSource('@loaders.gl/pmtiles/test/data/test_fixture_1.pmtiles', '1');
-  source.etag = 'etag_1';
-  let header = await cache.getHeader(source);
-  t.strictEqual(header.etag, 'etag_1');
-
-  source.etag = 'etag_2';
-
-  t.rejects(async () => {
-    await cache.getDirectory(
-      source,
-      header.rootDirectoryOffset,
-      header.rootDirectoryLength,
-      header
-    );
-  });
-
-  source.etag = 'etag_1';
-  cache.invalidate(source, 'etag_2');
-
-  header = await cache.getHeader(source);
-  t.strictEqual(header.etag, undefined);
-});
-
-test('cache pruning by byte size', async (t) => {
-  const cache = new SharedPromiseCache(2, false);
-  cache.cache.set('0', {lastUsed: 0, data: Promise.resolve([])});
-  cache.cache.set('1', {lastUsed: 1, data: Promise.resolve([])});
-  cache.cache.set('2', {lastUsed: 2, data: Promise.resolve([])});
-  cache.prune();
-  t.strictEqual(cache.cache.size, 2);
-  t.ok(cache.cache.get('2'));
-  t.ok(cache.cache.get('1'));
-  t.ok(!cache.cache.get('0'));
-});
-
-test('pmtiles get metadata', async (t) => {
-  const source = new TestFileSource('@loaders.gl/pmtiles/test/data/test_fixture_1.pmtiles', '1');
-  const p = new PMTiles(source);
-  const metadata = await p.getMetadata();
-  t.ok(metadata.name);
-});
-
-// echo '{"type":"Polygon","coordinates":[[[0,0],[0,1],[1,0],[0,0]]]}' | ./tippecanoe -zg -o test_fixture_2.pmtiles
-test('pmtiles handle retries', async (t) => {
-  const source = new TestFileSource('@loaders.gl/pmtiles/test/data/test_fixture_1.pmtiles', '1');
-  source.etag = '1';
-  const p = new PMTiles(source);
-  const metadata = await p.getMetadata();
-  t.ok(metadata.name);
-  source.etag = '2';
-  source.replaceData('@loaders.gl/pmtiles/test/data/test_fixture_2.pmtiles');
-  t.ok(await p.getZxy(0, 0, 0));
-});
-*/

--- a/modules/mvt/test/mvt-writer.spec.ts
+++ b/modules/mvt/test/mvt-writer.spec.ts
@@ -2,48 +2,33 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {encode, fetchFile, parse} from '@loaders.gl/core';
 import {MVTLoader, MVTWriter} from '@loaders.gl/mvt';
-
 const RECTANGLE_URL = '@loaders.gl/mvt/test/data/mapbox-vt-pbf-fixtures/rectangle.geojson';
 const RECTANGLE_TILE = '@loaders.gl/mvt/test/data/mapbox-vt-pbf-fixtures/rectangle-1.0.0.pbf';
-
-test('MVTWriter#import', async t => {
-  t.ok(MVTWriter, 'MVTWriter is defined');
-  t.end();
+test('MVTWriter#import', async () => {
+  expect(MVTWriter, 'MVTWriter is defined').toBeTruthy();
 });
-
 /** @todo - fix this test */
-test.skip('MVTWriter#encode', async t => {
+test.skip('MVTWriter#encode', async () => {
   const geojsonResponse = await fetchFile(RECTANGLE_URL);
   const geojson = await geojsonResponse.json();
-
   const arrayBuffer = await encode(geojson, MVTWriter, {mvt: {tileIndex: {x: 0, y: 0, z: 1}}});
-
   const fixtureResponse = await fetchFile(RECTANGLE_TILE);
   const expected = await fixtureResponse.arrayBuffer();
-
-  t.ok(arrayBuffer instanceof ArrayBuffer, 'MVTWriter encodes to ArrayBuffer');
-  t.deepEqual(new Uint8Array(arrayBuffer), new Uint8Array(expected));
-
-  t.end();
+  expect(arrayBuffer instanceof ArrayBuffer, 'MVTWriter encodes to ArrayBuffer').toBeTruthy();
+  expect(new Uint8Array(arrayBuffer)).toEqual(new Uint8Array(expected));
 });
-
-test('MVTWriter#roundtrip', async t => {
+test('MVTWriter#roundtrip', async () => {
   const tileIndex = {x: 2, y: 1, z: 2};
   const response = await fetchFile('@loaders.gl/mvt/test/data/mvt/lines_2-2-1.mvt');
   const sourceTile = await response.arrayBuffer();
-
   const loaderOptions = {mvt: {coordinates: 'local'}};
   const geojsonTable = await parse(sourceTile, MVTLoader, loaderOptions);
-
   const roundtripBuffer = await encode(geojsonTable.features, MVTWriter, {
     mvt: {layerName: 'layer0', tileIndex}
   });
   const roundtripGeojsonTable = await parse(roundtripBuffer, MVTLoader, loaderOptions);
-
-  t.deepEqual(roundtripGeojsonTable, geojsonTable, 'Roundtrip preserves GeoJSON features');
-
-  t.end();
+  expect(roundtripGeojsonTable, 'Roundtrip preserves GeoJSON features').toEqual(geojsonTable);
 });

--- a/modules/mvt/test/table-tile-source-full.spec.ts
+++ b/modules/mvt/test/table-tile-source-full.spec.ts
@@ -1,14 +1,11 @@
 // loaders.gl
-// SPDX-License-Identifier: MIT AND ISC
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
-// Forked from https://github.com/mapbox/geojson-vt under compatible ISC license
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {fetchFile} from '@loaders.gl/core';
 import {TableVectorTileSource, TableTileSourceLoaderOptions} from '@loaders.gl/mvt';
-
 const DATA_PATH = '@loaders.gl/mvt/test/data/geojson-vt';
-
 const TEST_CASES = [
   {
     inputFile: 'us-states.json',
@@ -55,50 +52,35 @@ const TEST_CASES = [
     options: {indexMaxZoom: 0, generateId: true}
   }
 ];
-
-test('GeoJSONVT#full tiling test', async t => {
+test('GeoJSONVT#full tiling test', async () => {
   for (const tc of TEST_CASES) {
     const {inputFile, expectedFile, options} = tc;
     const parsedGeojson = await getJSON(inputFile);
     const tiles = await genTiles(parsedGeojson, options);
-
     // fs.writeFileSync(path.join(__dirname, '/fixtures/' + expectedFile), JSON.stringify(tiles));
-    t.same(
-      tiles,
-      await getJSON(expectedFile),
-      `Tiling ${inputFile}: ${expectedFile.replace('-tiles.json', '')}`
+    expect(tiles, `Tiling ${inputFile}: ${expectedFile.replace('-tiles.json', '')}`).toEqual(
+      await getJSON(expectedFile)
     );
   }
-
-  t.end();
 });
-
-test('GeoJSONVT#throws on invalid GeoJSON', async t => {
-  await t.rejects(async () => {
+test('GeoJSONVT#throws on invalid GeoJSON', async () => {
+  await await expect(async () => {
     await genTiles({type: 'Pologon'});
-  });
-  t.end();
+  }).rejects.toBeDefined();
 });
-
-test('GeoJSONVT#empty geojson', async t => {
-  t.same({}, await genTiles(await getJSON('empty.json')));
-  t.end();
+test('GeoJSONVT#empty geojson', async () => {
+  expect({}).toEqual(await genTiles(await getJSON('empty.json')));
 });
-
-test('GeoJSONVT#null geometry', async t => {
+test('GeoJSONVT#null geometry', async () => {
   // should ignore features with null geometry
-  t.same({}, await genTiles(await getJSON('feature-null-geometry.json')));
-  t.end();
+  expect({}).toEqual(await genTiles(await getJSON('feature-null-geometry.json')));
 });
-
 // Helpers
-
 async function getJSON(name) {
   const response = await fetchFile(`${DATA_PATH}/${name}`);
   const json = await response.json();
   return json;
 }
-
 /** Generate tiles for a GeoJSON files */
 async function genTiles(
   data,
@@ -114,7 +96,6 @@ async function genTiles(
     'MultiPolygon',
     'GeometryCollection'
   ].includes(geojsonType);
-
   if (
     data?.shape !== 'geojson-table' &&
     !Array.isArray(data?.features) &&
@@ -153,9 +134,7 @@ async function genTiles(
     )
   });
   await source.ready;
-
   const output = {};
-
   for (const id in source.tiles) {
     const tile = source.tiles[id];
     const protoFeatures =
@@ -171,6 +150,5 @@ async function genTiles(
       id: feature.id
     }));
   }
-
   return output;
 }

--- a/modules/mvt/test/table-tile-source-multi-world.spec.ts
+++ b/modules/mvt/test/table-tile-source-multi-world.spec.ts
@@ -1,12 +1,10 @@
 // loaders.gl
-// SPDX-License-Identifier: MIT AND ISC
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
-// Forked from https://github.com/mapbox/geojson-vt under compatible ISC license
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {TableVectorTileSource} from '@loaders.gl/mvt';
 import type {GeoJSONTable, Feature} from '@loaders.gl/schema';
-
 const leftPoint = {
   type: 'Feature',
   properties: {},
@@ -15,7 +13,6 @@ const leftPoint = {
     type: 'Point'
   }
 } as const satisfies Feature;
-
 const rightPoint = {
   type: 'Feature',
   properties: {},
@@ -24,7 +21,6 @@ const rightPoint = {
     type: 'Point'
   }
 } as const satisfies Feature;
-
 function makeGeoJSONTable(feature: Feature): GeoJSONTable {
   return {
     shape: 'geojson-table',
@@ -32,28 +28,21 @@ function makeGeoJSONTable(feature: Feature): GeoJSONTable {
     features: [feature]
   };
 }
-
-test('GeoJSONVT#handle point only in the rightside world', async t => {
+test('GeoJSONVT#handle point only in the rightside world', async () => {
   const source = new TableVectorTileSource(makeGeoJSONTable(rightPoint), {});
   await source.ready;
   const tile = source.getProtoTile({z: 0, x: 0, y: 0});
-
-  t.equal(tile?.protoFeatures[0].geometry[0][0], 4096);
-  t.equal(tile?.protoFeatures[0].geometry[0][1], 2048);
-  t.end();
+  expect(tile?.protoFeatures[0].geometry[0][0]).toBe(4096);
+  expect(tile?.protoFeatures[0].geometry[0][1]).toBe(2048);
 });
-
-test('GeoJSONVT#handle point only in the leftside world', async t => {
+test('GeoJSONVT#handle point only in the leftside world', async () => {
   const source = new TableVectorTileSource(makeGeoJSONTable(leftPoint), {});
   await source.ready;
   const tile = source.getProtoTile({z: 0, x: 0, y: 0});
-
-  t.equal(tile?.protoFeatures[0].geometry[0][0], 0);
-  t.equal(tile?.protoFeatures[0].geometry[0][1], 2048);
-  t.end();
+  expect(tile?.protoFeatures[0].geometry[0][0]).toBe(0);
+  expect(tile?.protoFeatures[0].geometry[0][1]).toBe(2048);
 });
-
-test('GeoJSONVT#handle points in the leftside world and the rightside world', async t => {
+test('GeoJSONVT#handle points in the leftside world and the rightside world', async () => {
   const source = new TableVectorTileSource(
     {
       shape: 'geojson-table',
@@ -64,11 +53,8 @@ test('GeoJSONVT#handle points in the leftside world and the rightside world', as
   );
   await source.ready;
   const tile = source.getProtoTile({z: 0, x: 0, y: 0});
-
-  t.equal(tile?.protoFeatures[0].geometry[0][0], 0);
-  t.equal(tile?.protoFeatures[0].geometry[0][1], 2048);
-
-  t.equal(tile?.protoFeatures[1].geometry[0][0], 4096);
-  t.equal(tile?.protoFeatures[1].geometry[0][1], 2048);
-  t.end();
+  expect(tile?.protoFeatures[0].geometry[0][0]).toBe(0);
+  expect(tile?.protoFeatures[0].geometry[0][1]).toBe(2048);
+  expect(tile?.protoFeatures[1].geometry[0][0]).toBe(4096);
+  expect(tile?.protoFeatures[1].geometry[0][1]).toBe(2048);
 });

--- a/modules/mvt/test/table-tile-source.spec.ts
+++ b/modules/mvt/test/table-tile-source.spec.ts
@@ -1,16 +1,13 @@
 // loaders.gl
-// SPDX-License-Identifier: MIT AND ISC
+// SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
-// Forked from https://github.com/mapbox/geojson-vt under compatible ISC license
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {createDataSource, fetchFile, load} from '@loaders.gl/core';
 import {GeoJSONLoader} from '@loaders.gl/json';
 import {TableTileSourceLoader, TableVectorTileSource} from '@loaders.gl/mvt';
 import {Feature, GeoJSONTable, Geometry} from '@loaders.gl/schema';
-
 const DATA_PATH = '@loaders.gl/mvt/test/data/geojson-vt';
-
 const square = [
   {
     geometry: [
@@ -27,43 +24,29 @@ const square = [
     id: '42'
   }
 ];
-
-test('TableTileSourceLoader#getTile#us-states.json', async t => {
+test('TableTileSourceLoader#getTile#us-states.json', async () => {
   const geojson = await loadGeoJSONTable('us-states.json');
   const source = TableTileSourceLoader.createDataSource(geojson, {table: {coordinates: 'wgs84'}}); // , debug: 2});
   await source.ready;
-
   // Check that tiles are correctly generated
-
   let tile = source.getProtoTile({z: 7, x: 37, y: 48});
   const expected = await loadGeoJSONTable('us-states-z7-37-48.json');
-  t.same(tile?.protoFeatures, expected.features, 'z7-37-48');
-
+  expect(tile?.protoFeatures, 'z7-37-48').toEqual(expected.features);
   tile = source.getProtoTile({z: 9, x: 148, y: 192});
-  t.same(tile?.protoFeatures, square, 'z9-148-192 (clipped square)');
-
+  expect(tile?.protoFeatures, 'z9-148-192 (clipped square)').toEqual(square);
   // t.same(source.getProtoTile({z: 11, x: 592, y: 768})?.features, square, 'z11-592-768 (clipped square)');
-
   // Check non-existing tiles (no geometry in these tile indices => no tile generated)
-
   tile = source.getProtoTile({z: 11, x: 800, y: 400});
-  t.equal(tile, null, 'non-existing tile');
-
+  expect(tile, 'non-existing tile').toBe(null);
   tile = source.getProtoTile({z: -5, x: 123.25, y: 400.25});
-  t.equal(tile, null, 'invalid tile');
-
+  expect(tile, 'invalid tile').toBe(null);
   tile = source.getProtoTile({z: 25, x: 200, y: 200});
-  t.equal(tile, null, 'invalid tile');
-
+  expect(tile, 'invalid tile').toBe(null);
   // Check total number of tiles generated
-
   const total = source.stats.get('total').count;
-  t.equal(total, 37);
-
-  t.end();
+  expect(total).toBe(37);
 });
-
-test('TableTileSourceLoader#getTile#unbuffered tile left/right edges', async t => {
+test('TableTileSourceLoader#getTile#unbuffered tile left/right edges', async () => {
   const geojson = makeGeoJSONTable({
     type: 'LineString',
     coordinates: [
@@ -78,11 +61,10 @@ test('TableTileSourceLoader#getTile#unbuffered tile left/right edges', async t =
     }
   });
   await source.ready;
-
   let tile = source.getProtoTile({z: 2, x: 1, y: 1});
-  t.same(tile, null);
+  expect(tile).toEqual(null);
   tile = source.getProtoTile({z: 2, x: 2, y: 1});
-  t.same(tile?.protoFeatures, [
+  expect(tile?.protoFeatures).toEqual([
     {
       geometry: [
         [
@@ -94,10 +76,8 @@ test('TableTileSourceLoader#getTile#unbuffered tile left/right edges', async t =
       tags: null
     }
   ]);
-  t.end();
 });
-
-test('TableTileSourceLoader#getTile#unbuffered tile top/bottom edges', async t => {
+test('TableTileSourceLoader#getTile#unbuffered tile top/bottom edges', async () => {
   const geojson = makeGeoJSONTable({
     type: 'LineString',
     coordinates: [
@@ -112,8 +92,7 @@ test('TableTileSourceLoader#getTile#unbuffered tile top/bottom edges', async t =
     }
   });
   await source.ready;
-
-  t.same(source.getProtoTile({z: 2, x: 1, y: 0})?.protoFeatures, [
+  expect(source.getProtoTile({z: 2, x: 1, y: 0})?.protoFeatures).toEqual([
     {
       geometry: [
         [
@@ -125,11 +104,9 @@ test('TableTileSourceLoader#getTile#unbuffered tile top/bottom edges', async t =
       tags: null
     }
   ]);
-  t.same(source.getProtoTile({z: 2, x: 1, y: 1})?.protoFeatures, []);
-  t.end();
+  expect(source.getProtoTile({z: 2, x: 1, y: 1})?.protoFeatures).toEqual([]);
 });
-
-test('TableTileSourceLoader#getTile#polygon clipping on the boundary', async t => {
+test('TableTileSourceLoader#getTile#polygon clipping on the boundary', async () => {
   const geojson = makeGeoJSONTable({
     type: 'Polygon',
     coordinates: [
@@ -149,8 +126,7 @@ test('TableTileSourceLoader#getTile#polygon clipping on the boundary', async t =
     }
   });
   await source.ready;
-
-  t.same(source.getProtoTile({z: 5, x: 19, y: 9})?.protoFeatures, [
+  expect(source.getProtoTile({z: 5, x: 19, y: 9})?.protoFeatures).toEqual([
     {
       geometry: [
         [
@@ -165,11 +141,8 @@ test('TableTileSourceLoader#getTile#polygon clipping on the boundary', async t =
       tags: null
     }
   ]);
-
-  t.end();
 });
-
-test('TableTileSourceLoader#load#url input uses options.core.loaders', async t => {
+test('TableTileSourceLoader#load#url input uses options.core.loaders', async () => {
   const source = await load(`${DATA_PATH}/us-states.json`, TableTileSourceLoader, {
     core: {
       worker: false,
@@ -180,14 +153,14 @@ test('TableTileSourceLoader#load#url input uses options.core.loaders', async t =
       coordinates: 'wgs84'
     }
   });
-
-  t.ok(source instanceof TableVectorTileSource, 'load() returns a runtime tile source');
+  expect(
+    source instanceof TableVectorTileSource,
+    'load() returns a runtime tile source'
+  ).toBeTruthy();
   const metadata = await source.getMetadata();
-  t.equal(metadata.maxZoom, 14, 'metadata is available from the returned runtime source');
-  t.end();
+  expect(metadata.maxZoom, 'metadata is available from the returned runtime source').toBe(14);
 });
-
-test('TableTileSourceLoader#createDataSource#url input uses options.core.loaders', async t => {
+test('TableTileSourceLoader#createDataSource#url input uses options.core.loaders', async () => {
   const source = createDataSource(`${DATA_PATH}/us-states.json`, [TableTileSourceLoader], {
     core: {
       worker: false,
@@ -198,28 +171,25 @@ test('TableTileSourceLoader#createDataSource#url input uses options.core.loaders
       coordinates: 'wgs84'
     }
   });
-
-  t.ok(source instanceof TableVectorTileSource, 'createDataSource() returns a runtime tile source');
+  expect(
+    source instanceof TableVectorTileSource,
+    'createDataSource() returns a runtime tile source'
+  ).toBeTruthy();
   const metadata = await source.getMetadata();
-  t.equal(metadata.maxZoom, 14, 'metadata is available after parser-backed source creation');
-  t.end();
+  expect(metadata.maxZoom, 'metadata is available after parser-backed source creation').toBe(14);
 });
-
 // HELPERS
-
 function makeGeoJSONTable(geometry: Geometry): GeoJSONTable {
   const feature: Feature = {
     geometry,
     properties: null
   } as Feature;
-
   return {
     shape: 'geojson-table',
     type: 'FeatureCollection',
     features: [feature]
   };
 }
-
 async function loadGeoJSONTable(filename: string): Promise<GeoJSONTable> {
   const response = await fetchFile(`${DATA_PATH}/${filename}`);
   const json = await response.json();


### PR DESCRIPTION
## Goals

- Migrate two related geospatial modules from Tape compatibility tests to native Vitest.
- Increase executable coverage for GIS conversion and MVT parsing/source paths.
- Keep the grouped tranche hermetic and suitable for one review.

## Changes

- Migrated 11 GIS suites to native Vitest assertions and lifecycle handling.
- Migrated 11 MVT suites, including parser, loader, writer, source, map-style, and vector-tiler tests.
- Converted conformance helpers to native Vitest-compatible calls.
- Normalized typed-array comparisons and async rejection assertions for Vitest semantics.
- No production code or coverage thresholds changed.
- No 3D Tiles changes.

## Validation

- `yarn build`
- `yarn build-workers`
- `yarn lint fix`
- `yarn test-audit` (598 files, 0 Tape, 0 violations)
- Focused browser tests: 173 passed, 1 existing skip
- Focused Node tests: 360 passed, 6 existing skips
- Focused browser coverage collection completed successfully