### PR TITLE
feat(parquet): complete encryption and integrity tranches

### DIFF
--- a/docs/modules/parquet/api-reference/parquet-writer.md
+++ b/docs/modules/parquet/api-reference/parquet-writer.md
@@ -172,9 +172,12 @@ const parquetBuffer = await encode(table, ParquetJSWriter, {
 | `parquet.encryption.aadPrefix` | `Uint8Array` | `undefined` | Optional AAD prefix shared by encrypted modules. |
 | `parquet.encryption.fileUnique` | `Uint8Array` | generated | Eight-byte file identifier used to construct module AAD. |
 | `parquet.encryption.encryptColumns` | `boolean \| Record<string, boolean>` | `false` | Encrypt all columns or only named top-level columns with the footer key. |
+| `parquet.encryption.columnKeyMetadata` | `Record<string, Uint8Array>` | `undefined` | Assigns opaque key metadata per top-level column; columns use `ENCRYPTION_WITH_COLUMN_KEY` and may rotate independently. |
 | `parquet.encryption.keyRetriever` | `ParquetKeyRetriever` | required | Resolves the footer key without placing key bytes in the options object. |
+| `parquet.footerSignature` | `ParquetWriterFooterSignatureOptions` | `undefined` | Authenticates a plaintext footer with a 28-byte Parquet signature; mutually exclusive with encrypted footers. |
 
-Per-column keys, key rotation, and plaintext-footer signature generation remain follow-up work.
+Per-column keys, key rotation, and plaintext-footer signatures are opt-in. The key retriever receives
+the corresponding footer or column metadata and key material is never serialized into writer options.
 
 ## Writer Variants
 

--- a/docs/modules/parquet/formats/parquet.md
+++ b/docs/modules/parquet/formats/parquet.md
@@ -258,8 +258,8 @@ AES-GCM-CTR encrypted column metadata, page indexes, Bloom filters, and page mod
 is provided. Encrypted source reads resolve selected data keys on the caller thread and transfer only
 the required key material to the worker. `ParquetJSWriter` can now emit an encrypted footer with
 caller-supplied key metadata and a key retriever; column metadata, pages, indexes, and Bloom filters
-can also be encrypted for selected columns or all columns with the footer key. Per-column keys,
-key rotation, and plaintext-footer signature generation remain follow-up work.
+can also be encrypted for selected columns or all columns. Per-column key metadata enables independent
+keys and rotation, while plaintext-footer signatures authenticate unencrypted footer metadata.
 
 ## Integrity and Encryption
 
@@ -267,7 +267,7 @@ key rotation, and plaintext-footer signature generation remain follow-up work.
 | ------- | ------- | -------- | ----- |
 | Footer and page-bound validation | ✅ | ✅ | Invalid magic, lengths, indexes, and truncated payloads are rejected |
 | Page CRC verification | ✅ (opt-in) | ✅ (opt-in) | CRC-32 covers the compressed page body; enable verification or emission explicitly to avoid a default throughput cost |
-| [Parquet modular encryption](https://github.com/apache/parquet-format/blob/master/Encryption.md) | ✅ | ⚠️ | Reader supports encrypted footers, column metadata, page indexes, Bloom filters, and AES-GCM/AES-GCM-CTR page reads; `ParquetJSWriter` emits encrypted footers and optional footer-key column metadata/pages/indexes/Bloom filters. Per-column keys, rotation, and plaintext-footer signature writing remain future work |
+| [Parquet modular encryption](https://github.com/apache/parquet-format/blob/master/Encryption.md) | ✅ | ✅ (opt-in) | Reader and writer support encrypted footers, per-column metadata/pages/indexes/Bloom filters, AES-GCM/AES-GCM-CTR pages, independent column keys, and plaintext-footer signatures; external-key management remains the caller's responsibility |
 | External column chunks | ❌ | ❌ | `file_path` column references are rejected |
 
 ## Parquet and Arrow
@@ -298,7 +298,7 @@ rather than by individual missing methods.
 | ------- | ------ | ------ | ------------ |
 | Selective scan and physical planning | ✅ foundation | Footer statistics, Bloom filters, page/offset indexes, nested-leaf pruning, late materialization, and explainable range plans | Sorting-column semantics drive safe page/row-group pruning, and estimates describe the physical late-materialization plan |
 | Cloud-native table sources | ✅ read-only slice | Iceberg metadata/manifest planning and Delta snapshot replay dispatch selected files through `ParquetDatasetSource` | Checkpoints, CDC, deletion vectors, catalog discovery, and consistent snapshot/error semantics |
-| Modular encryption | ⚠️ expanding | Encrypted footer/column metadata, page/index/Bloom-filter reads, AES-GCM/AES-GCM-CTR pages, worker scans, and footer-key encrypted-column writing | Per-column keys, key rotation, plaintext-footer signature writing, and broader encrypted-file interoperability |
+| Modular encryption | ✅ opt-in | Encrypted footer/column metadata, page/index/Bloom-filter reads, AES-GCM/AES-GCM-CTR pages, worker scans, footer-key and per-column-key encrypted-column writing, and plaintext-footer signatures | Broader encrypted-file interoperability and external key-management guidance |
 | Logical and legacy parity | ⚠️ expanding | Logical Arrow mappings, nested LIST/MAP/VARIANT/geo types, legacy `BIT_PACKED` reads, and explicit `PLAIN_DICTIONARY` writes | Defined INT96 conversion, legacy nested/shredding variants, and exact Arrow fidelity across the stable logical-type matrix |
 | Conformance and scale gate | ⚠️ ongoing | Hermetic feature tests, differential checks, and representative browser benchmarks | Apache corpus plus nested/repeated cases, every stable codec/encoding, differential validation, and large-file/selective-range benchmarks pass in CI |
 | Emerging-format lab | 🧪 experimental | Tracking links and isolated capability flags | ALP, PFOR, VECTOR, and format-versioning experiments remain opt-in until an upstream format and interoperability fixtures stabilize |

--- a/modules/parquet/src/index.ts
+++ b/modules/parquet/src/index.ts
@@ -104,7 +104,8 @@ export type {
   ParquetJSWriterEncoding,
   ParquetJSWriterOptions,
   ParquetSortingColumnOption,
-  ParquetWriterEncryptionOptions
+  ParquetWriterEncryptionOptions,
+  ParquetWriterFooterSignatureOptions
 } from './parquet-js-writer';
 export {ParquetJSWriter} from './parquet-js-writer';
 
@@ -118,6 +119,7 @@ export {
   createParquetModuleAad,
   decryptParquetModule,
   encryptParquetModule,
+  createParquetFooterSignature,
   readParquetEncryptedModule,
   verifyParquetFooterSignature,
   type ParquetDecryptModuleOptions,

--- a/modules/parquet/src/lib/encoders/encode-table-to-parquet-js.ts
+++ b/modules/parquet/src/lib/encoders/encode-table-to-parquet-js.ts
@@ -76,6 +76,7 @@ function convertSchemaToParquetSchema(
     options.parquet?.pageIndex && typeof options.parquet.pageIndex === 'object'
       ? options.parquet.pageIndex
       : {};
+  const columnKeyMetadata = options.parquet?.encryption?.columnKeyMetadata || {};
   const fieldNames = new Set(schema.fields.map(field => field.name));
   const geoMetadata = getGeoMetadata(schema.metadata);
   for (const columnName of Object.keys(columnEncodings)) {
@@ -96,6 +97,11 @@ function convertSchemaToParquetSchema(
   for (const columnName of Object.keys(pageIndexColumns)) {
     if (!fieldNames.has(columnName)) {
       throw new Error(`ParquetJSWriter: Unknown page-index column "${columnName}"`);
+    }
+  }
+  for (const columnName of Object.keys(columnKeyMetadata)) {
+    if (!fieldNames.has(columnName)) {
+      throw new Error(`ParquetJSWriter: Unknown encryption column key "${columnName}"`);
     }
   }
 

--- a/modules/parquet/src/lib/parquet-encryption.ts
+++ b/modules/parquet/src/lib/parquet-encryption.ts
@@ -36,7 +36,23 @@ export type ParquetWriterEncryptionOptions = {
   fileUnique?: Uint8Array;
   /** Encrypt all data columns, or only the named top-level columns, with the footer key. */
   encryptColumns?: boolean | Record<string, boolean>;
+  /** Optional per-column key metadata, enabling column-key encryption and key rotation. */
+  columnKeyMetadata?: Record<string, Uint8Array>;
   /** Resolves the footer key without putting key material in writer options. */
+  keyRetriever: ParquetKeyRetriever;
+};
+
+/** Writer configuration for a plaintext footer authenticated by a Parquet signature. */
+export type ParquetWriterFooterSignatureOptions = {
+  /** Algorithm used to authenticate the footer signature. */
+  algorithm?: ParquetEncryptionAlgorithm;
+  /** Key metadata stored in FileMetaData and supplied to the key retriever. */
+  keyMetadata: Uint8Array;
+  /** AAD prefix included in the signature AAD when provided. */
+  aadPrefix?: Uint8Array;
+  /** Eight-byte file identifier used in the signature AAD; generated when omitted. */
+  fileUnique?: Uint8Array;
+  /** Resolves the signing key without putting key material in writer options. */
   keyRetriever: ParquetKeyRetriever;
 };
 
@@ -232,10 +248,48 @@ export async function verifyParquetFooterSignature(
   }
 }
 
+/** Creates the nonce and authentication tag used by a plaintext-footer signature. */
+export async function createParquetFooterSignature(
+  footerBytes: Uint8Array,
+  options: ParquetWriterFooterSignatureOptions
+): Promise<Uint8Array> {
+  const algorithm = options.algorithm ?? 'AES_GCM_V1';
+  const fileUnique = options.fileUnique ? new Uint8Array(options.fileUnique) : createFileUnique();
+  if (fileUnique.byteLength !== 8) {
+    throw new Error('Parquet plaintext-footer signature file_unique must be 8 bytes');
+  }
+  const aad = createParquetModuleAad(options.aadPrefix, fileUnique, 'footer');
+  const keyMaterial = await options.keyRetriever(options.keyMetadata, {algorithm, aad});
+  const cryptoKey = await getCryptoKey(keyMaterial, algorithm, false, ['encrypt']);
+  const nonce = new Uint8Array(12);
+  getCryptoRandomValues(nonce);
+  const encryptedFooter = new Uint8Array(
+    await getCryptoProvider().encrypt(
+      {
+        name: 'AES-GCM',
+        iv: nonce as unknown as BufferSource,
+        additionalData: aad as unknown as BufferSource
+      },
+      cryptoKey,
+      footerBytes as unknown as BufferSource
+    )
+  );
+  const signature = new Uint8Array(28);
+  signature.set(nonce);
+  signature.set(encryptedFooter.subarray(encryptedFooter.byteLength - 16), nonce.byteLength);
+  return signature;
+}
+
 function hasLengthPrefix(bytes: Uint8Array): boolean {
   if (bytes.length < 4) return false;
   const length = new DataView(bytes.buffer, bytes.byteOffset, 4).getUint32(0, true);
   return length === bytes.length - 4;
+}
+
+function createFileUnique(): Uint8Array {
+  const fileUnique = new Uint8Array(8);
+  getCryptoRandomValues(fileUnique);
+  return fileUnique;
 }
 
 function makeCounter(nonce: Uint8Array): Uint8Array {

--- a/modules/parquet/src/parquet-js-writer.ts
+++ b/modules/parquet/src/parquet-js-writer.ts
@@ -10,10 +10,16 @@ import {normalizeParquetOptions} from './lib/utils/normalize-parquet-options';
 import {encodeTableToParquetJs} from './lib/encoders/encode-table-to-parquet-js';
 import {ParquetFormat} from './parquet-format';
 import type {ParquetSortingColumnOption} from './parquetjs/encoder/parquet-encoder';
-import type {ParquetWriterEncryptionOptions} from './lib/parquet-encryption';
+import type {
+  ParquetWriterEncryptionOptions,
+  ParquetWriterFooterSignatureOptions
+} from './lib/parquet-encryption';
 
 export type {ParquetSortingColumnOption} from './parquetjs/encoder/parquet-encoder';
-export type {ParquetWriterEncryptionOptions} from './lib/parquet-encryption';
+export type {
+  ParquetWriterEncryptionOptions,
+  ParquetWriterFooterSignatureOptions
+} from './lib/parquet-encryption';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
@@ -52,6 +58,8 @@ type ParquetJSWriterEncoderOptions = {
   sortingColumns?: readonly ParquetSortingColumnOption[];
   /** Encrypt the footer using Parquet modular encryption. */
   encryption?: ParquetWriterEncryptionOptions;
+  /** Authenticate a plaintext footer with a Parquet modular-encryption signature. */
+  footerSignature?: ParquetWriterFooterSignatureOptions;
   rowGroupSize?: number;
   pageSize?: number;
   useDataPageV2?: boolean;

--- a/modules/parquet/src/parquetjs/encoder/parquet-encoder.ts
+++ b/modules/parquet/src/parquetjs/encoder/parquet-encoder.ts
@@ -84,14 +84,19 @@ import {
   encodeParquetSplitBlockBloomFilter
 } from '../../lib/parquet-bloom-filter';
 import {BoundaryOrder} from '../parquet-thrift/BoundaryOrder';
-import {EncryptionWithFooterKey} from '../parquet-thrift/ColumnCryptoMetaData';
+import {
+  EncryptionWithColumnKey,
+  EncryptionWithFooterKey
+} from '../parquet-thrift/ColumnCryptoMetaData';
 import {EncryptionAlgorithm} from '../parquet-thrift/EncryptionAlgorithm';
 import {FileCryptoMetaData} from '../parquet-thrift/FileCryptoMetaData';
 import {PARQUET_MAGIC_ENCRYPTED} from '../../lib/constants';
 import {
   createParquetModuleAad,
+  createParquetFooterSignature,
   encryptParquetModule,
-  type ParquetWriterEncryptionOptions
+  type ParquetWriterEncryptionOptions,
+  type ParquetWriterFooterSignatureOptions
 } from '../../lib/parquet-encryption';
 
 /**
@@ -138,6 +143,8 @@ export interface ParquetEncoderOptions {
   sortingColumns?: readonly ParquetSortingColumnOption[];
   /** Encrypt the footer using Parquet modular encryption. */
   encryption?: ParquetWriterEncryptionOptions;
+  /** Authenticate a plaintext footer with a Parquet modular-encryption signature. */
+  footerSignature?: ParquetWriterFooterSignatureOptions;
   /** Stable file identifier shared by encrypted column modules and the footer. */
   encryptionFileUnique?: Uint8Array;
   /** Zero-based row-group ordinal used by encrypted module AAD. */
@@ -339,6 +346,8 @@ export class ParquetEnvelopeWriter {
   public sortingColumns?: readonly ParquetSortingColumnOption[];
   /** Optional modular-encryption configuration for the footer. */
   public encryption?: ParquetWriterEncryptionOptions;
+  /** Optional plaintext-footer signature configuration. */
+  public footerSignature?: ParquetWriterFooterSignatureOptions;
   /** File identifier used for encrypted column-module AAD. */
   public encryptionFileUnique?: Uint8Array;
 
@@ -371,6 +380,23 @@ export class ParquetEnvelopeWriter {
           ...opts.encryption,
           fileUnique: opts.encryption.fileUnique
             ? new Uint8Array(opts.encryption.fileUnique)
+            : createFileUnique()
+        }
+      : undefined;
+    if (this.encryption && opts.footerSignature) {
+      throw new Error(
+        'Parquet footer encryption and plaintext-footer signatures are mutually exclusive'
+      );
+    }
+    this.footerSignature = opts.footerSignature
+      ? {
+          ...opts.footerSignature,
+          keyMetadata: new Uint8Array(opts.footerSignature.keyMetadata),
+          aadPrefix: opts.footerSignature.aadPrefix
+            ? new Uint8Array(opts.footerSignature.aadPrefix)
+            : undefined,
+          fileUnique: opts.footerSignature.fileUnique
+            ? new Uint8Array(opts.footerSignature.fileUnique)
             : createFileUnique()
         }
       : undefined;
@@ -428,7 +454,17 @@ export class ParquetEnvelopeWriter {
 
     const footer = encodeFooter(this.schema, this.rowCount, this.rowGroups, userMetadata);
     if (!this.encryption) {
-      await this.writeSection(footer);
+      await this.writeSection(
+        this.footerSignature
+          ? await encodeSignedFooter(
+              this.schema,
+              this.rowCount,
+              this.rowGroups,
+              userMetadata,
+              this.footerSignature
+            )
+          : footer
+      );
       return;
     }
     await this.writeSection(await encodeEncryptedFooter(footer, this.encryption));
@@ -842,13 +878,15 @@ async function encodeColumnChunk(
 
   const encryption = opts.encryption;
   const encryptedColumn = Boolean(encryption && shouldEncryptColumn(encryption, column));
+  const columnKeyMetadata = encryption ? getColumnKeyMetadata(encryption, column) : undefined;
   const pages = encryptedColumn
     ? await encryptParquetColumnPages(
         pageRecords,
         encryption!,
         opts.encryptionFileUnique!,
         opts.rowGroupOrdinal ?? 0,
-        columnOrdinal
+        columnOrdinal,
+        columnKeyMetadata
       )
     : pageRecords.map(record => record.page);
   let pageOffset = 0;
@@ -880,7 +918,8 @@ async function encodeColumnChunk(
           encryption!,
           opts.encryptionFileUnique!,
           opts.rowGroupOrdinal ?? 0,
-          columnOrdinal
+          columnOrdinal,
+          columnKeyMetadata
         )
       : bloomFilter;
   const pageIndexEnabled = opts.pageIndex === true || opts.pageIndex?.[column.path[0]] === true;
@@ -894,7 +933,8 @@ async function encodeColumnChunk(
           encryption!,
           opts.encryptionFileUnique!,
           opts.rowGroupOrdinal ?? 0,
-          columnOrdinal
+          columnOrdinal,
+          columnKeyMetadata
         )
       : pageIndexes;
 
@@ -979,11 +1019,18 @@ async function encodeColumnChunk(
               opts.rowGroupOrdinal ?? 0,
               columnOrdinal
             ),
-            keyMetadata: encryption!.keyMetadata,
+            keyMetadata: columnKeyMetadata ?? encryption!.keyMetadata,
             keyRetriever: encryption!.keyRetriever
           }),
           cryptoMetadata: new ColumnCryptoMetaData({
-            ENCRYPTION_WITH_FOOTER_KEY: new EncryptionWithFooterKey()
+            ...(columnKeyMetadata
+              ? {
+                  ENCRYPTION_WITH_COLUMN_KEY: new EncryptionWithColumnKey({
+                    path_in_schema: [...column.path],
+                    key_metadata: new Uint8Array(columnKeyMetadata)
+                  })
+                }
+              : {ENCRYPTION_WITH_FOOTER_KEY: new EncryptionWithFooterKey()})
           })
         }
       : {})
@@ -995,7 +1042,20 @@ function shouldEncryptColumn(
   options: ParquetWriterEncryptionOptions,
   column: ParquetField
 ): boolean {
-  return options.encryptColumns === true || options.encryptColumns?.[column.path[0]] === true;
+  return Boolean(
+    options.columnKeyMetadata?.[column.path[0]] ||
+      options.encryptColumns === true ||
+      options.encryptColumns?.[column.path[0]] === true
+  );
+}
+
+/** Returns a defensive copy of the key metadata assigned to one top-level column. */
+function getColumnKeyMetadata(
+  options: ParquetWriterEncryptionOptions,
+  column: ParquetField
+): Uint8Array | undefined {
+  const keyMetadata = options.columnKeyMetadata?.[column.path[0]];
+  return keyMetadata ? new Uint8Array(keyMetadata) : undefined;
 }
 
 /** Adds the four-byte module length required by encrypted page and Bloom-filter modules. */
@@ -1012,7 +1072,8 @@ async function encryptParquetColumnPages(
   options: ParquetWriterEncryptionOptions,
   fileUnique: Uint8Array,
   rowGroupOrdinal: number,
-  columnOrdinal: number
+  columnOrdinal: number,
+  keyMetadata?: Uint8Array
 ): Promise<Uint8Array[]> {
   const encryptedPages: Uint8Array[] = [];
   let dataPageOrdinal = 0;
@@ -1030,7 +1091,7 @@ async function encryptParquetColumnPages(
         columnOrdinal,
         pageRecord.dictionary ? undefined : dataPageOrdinal
       ),
-      keyMetadata: options.keyMetadata,
+      keyMetadata: keyMetadata ?? options.keyMetadata,
       keyRetriever: options.keyRetriever
     });
     const body = await encryptParquetModule(pageRecord.page.subarray(pageRecord.headerSize), {
@@ -1043,7 +1104,7 @@ async function encryptParquetColumnPages(
         columnOrdinal,
         pageRecord.dictionary ? undefined : dataPageOrdinal
       ),
-      keyMetadata: options.keyMetadata,
+      keyMetadata: keyMetadata ?? options.keyMetadata,
       keyRetriever: options.keyRetriever,
       page: true
     });
@@ -1061,13 +1122,14 @@ async function encryptParquetBloomFilter(
   options: ParquetWriterEncryptionOptions,
   fileUnique: Uint8Array,
   rowGroupOrdinal: number,
-  columnOrdinal: number
+  columnOrdinal: number,
+  keyMetadata?: Uint8Array
 ): Promise<Uint8Array> {
   const parsed = decodeParquetSplitBlockBloomFilter(bloomFilter);
   const algorithm = options.algorithm ?? 'AES_GCM_V1';
   const keyOptions = {
     algorithm,
-    keyMetadata: options.keyMetadata,
+    keyMetadata: keyMetadata ?? options.keyMetadata,
     keyRetriever: options.keyRetriever
   };
   const header = await encryptParquetModule(bloomFilter.subarray(0, parsed.headerByteLength), {
@@ -1099,7 +1161,8 @@ async function encryptParquetPageIndexes(
   options: ParquetWriterEncryptionOptions,
   fileUnique: Uint8Array,
   rowGroupOrdinal: number,
-  columnOrdinal: number
+  columnOrdinal: number,
+  keyMetadata?: Uint8Array
 ): Promise<{offsetIndex: Uint8Array; columnIndex?: Uint8Array}> {
   const algorithm = options.algorithm ?? 'AES_GCM_V1';
   const encryptIndex = (bytes: Uint8Array, module: 'offset-index' | 'column-index') =>
@@ -1112,7 +1175,7 @@ async function encryptParquetPageIndexes(
         rowGroupOrdinal,
         columnOrdinal
       ),
-      keyMetadata: options.keyMetadata,
+      keyMetadata: keyMetadata ?? options.keyMetadata,
       keyRetriever: options.keyRetriever
     });
   return {
@@ -1491,19 +1554,44 @@ async function encodeRowGroup(
 /**
  * Encode a parquet file metadata footer
  */
-function encodeFooter(
+function encodeFooterMetadata(
   schema: ParquetSchema,
   rowCount: number,
   rowGroups: RowGroup[],
-  userMetadata: Record<string, string>
+  userMetadata: Record<string, string>,
+  footerSignature?: ParquetWriterFooterSignatureOptions
 ): Uint8Array {
+  const signatureAlgorithm = footerSignature?.algorithm ?? 'AES_GCM_V1';
+  const signatureFileUnique = footerSignature?.fileUnique
+    ? new Uint8Array(footerSignature.fileUnique)
+    : undefined;
   const metadata = new FileMetaData({
     version: PARQUET_VERSION,
     created_by: 'parquets',
     num_rows: int64(rowCount),
     row_groups: rowGroups,
     schema: [],
-    key_value_metadata: []
+    key_value_metadata: [],
+    encryption_algorithm: footerSignature
+      ? new EncryptionAlgorithm({
+          ...(signatureAlgorithm === 'AES_GCM_CTR_V1'
+            ? {
+                AES_GCM_CTR_V1: {
+                  aad_prefix: footerSignature.aadPrefix,
+                  aad_file_unique: signatureFileUnique
+                }
+              }
+            : {
+                AES_GCM_V1: {
+                  aad_prefix: footerSignature.aadPrefix,
+                  aad_file_unique: signatureFileUnique
+                }
+              })
+        })
+      : undefined,
+    footer_signing_key_metadata: footerSignature
+      ? new Uint8Array(footerSignature.keyMetadata)
+      : undefined
   });
 
   for (const key in userMetadata) {
@@ -1554,12 +1642,44 @@ function encodeFooter(
     metadata.schema.push(schemaElem);
   }
 
-  const metadataEncoded = serializeThrift(metadata);
+  return serializeThrift(metadata);
+}
+
+/** Encodes an unsigned plaintext footer with its standard Parquet trailer. */
+function encodeFooter(
+  schema: ParquetSchema,
+  rowCount: number,
+  rowGroups: RowGroup[],
+  userMetadata: Record<string, string>
+): Uint8Array {
+  const metadataEncoded = encodeFooterMetadata(schema, rowCount, rowGroups, userMetadata);
   const footerEncoded = new Uint8Array(metadataEncoded.length + 8);
 
   footerEncoded.set(metadataEncoded);
   writeUInt32LE(footerEncoded, metadataEncoded.length, metadataEncoded.length);
   footerEncoded.set(PARQUET_MAGIC_BYTES, metadataEncoded.length + 4);
+  return footerEncoded;
+}
+
+/** Encodes a plaintext footer with its trailing 28-byte authenticated signature. */
+async function encodeSignedFooter(
+  schema: ParquetSchema,
+  rowCount: number,
+  rowGroups: RowGroup[],
+  userMetadata: Record<string, string>,
+  options: ParquetWriterFooterSignatureOptions
+): Promise<Uint8Array> {
+  const metadata = encodeFooterMetadata(schema, rowCount, rowGroups, userMetadata, options);
+  const signature = await createParquetFooterSignature(metadata, options);
+  const footerEncoded = new Uint8Array(metadata.length + signature.length + 8);
+  footerEncoded.set(metadata);
+  footerEncoded.set(signature, metadata.length);
+  writeUInt32LE(
+    footerEncoded,
+    metadata.length + signature.length,
+    metadata.length + signature.length
+  );
+  footerEncoded.set(PARQUET_MAGIC_BYTES, metadata.length + signature.length + 4);
   return footerEncoded;
 }
 

--- a/modules/parquet/src/parquetjs/encoder/parquet-encoder.ts
+++ b/modules/parquet/src/parquetjs/encoder/parquet-encoder.ts
@@ -375,19 +375,26 @@ export class ParquetEnvelopeWriter {
     this.writeSizeStatistics = Boolean(opts.writeSizeStatistics);
     this.writeStatistics = opts.writeStatistics;
     this.sortingColumns = opts.sortingColumns;
-    this.encryption = opts.encryption
-      ? {
-          ...opts.encryption,
-          fileUnique: opts.encryption.fileUnique
-            ? new Uint8Array(opts.encryption.fileUnique)
-            : createFileUnique()
-        }
+    const encryptionFileUnique = opts.encryption?.fileUnique
+      ? new Uint8Array(opts.encryption.fileUnique)
       : undefined;
-    if (this.encryption && opts.footerSignature) {
-      throw new Error(
-        'Parquet footer encryption and plaintext-footer signatures are mutually exclusive'
-      );
+    const footerSignatureFileUnique = opts.footerSignature?.fileUnique
+      ? new Uint8Array(opts.footerSignature.fileUnique)
+      : undefined;
+    if (
+      encryptionFileUnique &&
+      footerSignatureFileUnique &&
+      !encryptionFileUnique.every((value, index) => value === footerSignatureFileUnique[index])
+    ) {
+      throw new Error('Parquet encryption and footer signature file_unique values must match');
     }
+    const sharedFileUnique =
+      encryptionFileUnique ??
+      footerSignatureFileUnique ??
+      (opts.encryption || opts.footerSignature ? createFileUnique() : undefined);
+    this.encryption = opts.encryption
+      ? {...opts.encryption, fileUnique: new Uint8Array(sharedFileUnique!)}
+      : undefined;
     this.footerSignature = opts.footerSignature
       ? {
           ...opts.footerSignature,
@@ -395,12 +402,10 @@ export class ParquetEnvelopeWriter {
           aadPrefix: opts.footerSignature.aadPrefix
             ? new Uint8Array(opts.footerSignature.aadPrefix)
             : undefined,
-          fileUnique: opts.footerSignature.fileUnique
-            ? new Uint8Array(opts.footerSignature.fileUnique)
-            : createFileUnique()
+          fileUnique: new Uint8Array(sharedFileUnique!)
         }
       : undefined;
-    this.encryptionFileUnique = this.encryption?.fileUnique;
+    this.encryptionFileUnique = sharedFileUnique;
   }
 
   writeSection(buf: Uint8Array): Promise<void> {
@@ -412,7 +417,9 @@ export class ParquetEnvelopeWriter {
    * Encode the parquet file header
    */
   writeHeader(): Promise<void> {
-    return this.writeSection(this.encryption ? PARQUET_MAGIC_ENCRYPTED_BYTES : PARQUET_MAGIC_BYTES);
+    return this.writeSection(
+      this.encryption && !this.footerSignature ? PARQUET_MAGIC_ENCRYPTED_BYTES : PARQUET_MAGIC_BYTES
+    );
   }
 
   /**
@@ -452,19 +459,21 @@ export class ParquetEnvelopeWriter {
       userMetadata = {};
     }
 
+    if (this.footerSignature) {
+      await this.writeSection(
+        await encodeSignedFooter(
+          this.schema,
+          this.rowCount,
+          this.rowGroups,
+          userMetadata,
+          this.footerSignature
+        )
+      );
+      return;
+    }
     const footer = encodeFooter(this.schema, this.rowCount, this.rowGroups, userMetadata);
     if (!this.encryption) {
-      await this.writeSection(
-        this.footerSignature
-          ? await encodeSignedFooter(
-              this.schema,
-              this.rowCount,
-              this.rowGroups,
-              userMetadata,
-              this.footerSignature
-            )
-          : footer
-      );
+      await this.writeSection(footer);
       return;
     }
     await this.writeSection(await encodeEncryptedFooter(footer, this.encryption));

--- a/modules/parquet/src/unbundled.ts
+++ b/modules/parquet/src/unbundled.ts
@@ -32,9 +32,11 @@ export {
   createParquetModuleAad,
   decryptParquetModule,
   encryptParquetModule,
+  createParquetFooterSignature,
   type ParquetDecryptModuleOptions,
   type ParquetEncryptionAlgorithm,
-  type ParquetKeyRetriever
+  type ParquetKeyRetriever,
+  type ParquetWriterFooterSignatureOptions
 } from './lib/parquet-encryption';
 export {
   ParquetDatasetSource,

--- a/modules/parquet/test/parquet-writer-encryption.spec.ts
+++ b/modules/parquet/test/parquet-writer-encryption.spec.ts
@@ -26,8 +26,10 @@ const INPUT: ObjectRowTable = {
 };
 
 const KEY = new TextEncoder().encode('0123456789abcdef');
+const COLUMN_KEY = new TextEncoder().encode('fedcba9876543210');
 const KEY_METADATA = new TextEncoder().encode('writer-footer-key');
 const FILE_UNIQUE = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+const COLUMN_KEY_METADATA = new TextEncoder().encode('writer-label-key-v2');
 
 test.each(['AES_GCM_V1', 'AES_GCM_CTR_V1'] as const)(
   'ParquetJSWriter emits a decryptable encrypted footer with %s',
@@ -58,6 +60,85 @@ test.each(['AES_GCM_V1', 'AES_GCM_CTR_V1'] as const)(
     expect(new TextDecoder().decode(new Uint8Array(parquetBuffer).slice(-4))).toBe('PARE');
   }
 );
+
+test('ParquetJSWriter supports per-column encryption keys for key rotation', async () => {
+  const parquetBuffer = await encode(INPUT, ParquetJSWriter, {
+    worker: false,
+    parquet: {
+      pageSize: 1,
+      pageIndex: true,
+      encryption: {
+        fileUnique: FILE_UNIQUE,
+        keyMetadata: KEY_METADATA,
+        columnKeyMetadata: {label: COLUMN_KEY_METADATA},
+        encryptColumns: {label: true},
+        keyRetriever: keyMetadata => {
+          if (keyMetadata && new TextDecoder().decode(keyMetadata) === 'writer-label-key-v2') {
+            return COLUMN_KEY;
+          }
+          return KEY;
+        }
+      }
+    }
+  });
+
+  const output = await load(parquetBuffer, ParquetJSLoader, {
+    core: {worker: false},
+    parquet: {
+      keyRetriever: keyMetadata => {
+        const metadata = keyMetadata && new TextDecoder().decode(keyMetadata);
+        expect([KEY_METADATA, COLUMN_KEY_METADATA].some(value => new TextDecoder().decode(value) === metadata)).toBe(true);
+        return metadata === new TextDecoder().decode(COLUMN_KEY_METADATA) ? COLUMN_KEY : KEY;
+      }
+    }
+  });
+
+  expect(output).toMatchObject({shape: 'object-row-table', data: INPUT.data});
+});
+
+test('ParquetJSWriter emits a verifiable plaintext-footer signature', async () => {
+  const parquetBuffer = await encode(INPUT, ParquetJSWriter, {
+    worker: false,
+    parquet: {
+      footerSignature: {
+        fileUnique: FILE_UNIQUE,
+        keyMetadata: KEY_METADATA,
+        keyRetriever: keyMetadata => {
+          expect(keyMetadata).toEqual(KEY_METADATA);
+          return KEY;
+        }
+      }
+    }
+  });
+
+  const output = await load(parquetBuffer, ParquetJSLoader, {
+    core: {worker: false},
+    parquet: {
+      keyRetriever: keyMetadata => {
+        expect(keyMetadata).toEqual(KEY_METADATA);
+        return KEY;
+      }
+    }
+  });
+
+  expect(output).toMatchObject({shape: 'object-row-table', data: INPUT.data});
+  expect(new TextDecoder().decode(new Uint8Array(parquetBuffer).slice(-4))).toBe('PAR1');
+});
+
+test('ParquetJSWriter rejects unknown column encryption metadata', async () => {
+  await expect(
+    encode(INPUT, ParquetJSWriter, {
+      worker: false,
+      parquet: {
+        encryption: {
+          keyMetadata: KEY_METADATA,
+          columnKeyMetadata: {missing: COLUMN_KEY_METADATA},
+          keyRetriever: () => KEY
+        }
+      }
+    })
+  ).rejects.toThrow('Unknown encryption column key "missing"');
+});
 
 test.each(['AES_GCM_V1', 'AES_GCM_CTR_V1'] as const)(
   'ParquetJSWriter encrypts column pages, Bloom filters, and page indexes with %s',

--- a/modules/parquet/test/parquet-writer-encryption.spec.ts
+++ b/modules/parquet/test/parquet-writer-encryption.spec.ts
@@ -125,6 +125,45 @@ test('ParquetJSWriter emits a verifiable plaintext-footer signature', async () =
   expect(new TextDecoder().decode(new Uint8Array(parquetBuffer).slice(-4))).toBe('PAR1');
 });
 
+test('ParquetJSWriter combines a signed plaintext footer with encrypted columns', async () => {
+  const parquetBuffer = await encode(INPUT, ParquetJSWriter, {
+    worker: false,
+    parquet: {
+      encryption: {
+        fileUnique: FILE_UNIQUE,
+        keyMetadata: KEY_METADATA,
+        columnKeyMetadata: {label: COLUMN_KEY_METADATA},
+        encryptColumns: {label: true},
+        keyRetriever: keyMetadata =>
+          keyMetadata && new TextDecoder().decode(keyMetadata) === 'writer-label-key-v2'
+            ? COLUMN_KEY
+            : KEY
+      },
+      footerSignature: {
+        fileUnique: FILE_UNIQUE,
+        keyMetadata: KEY_METADATA,
+        keyRetriever: keyMetadata => {
+          expect(keyMetadata).toEqual(KEY_METADATA);
+          return KEY;
+        }
+      }
+    }
+  });
+
+  const output = await load(parquetBuffer, ParquetJSLoader, {
+    core: {worker: false},
+    parquet: {
+      keyRetriever: keyMetadata => {
+        const metadata = keyMetadata && new TextDecoder().decode(keyMetadata);
+        return metadata === new TextDecoder().decode(COLUMN_KEY_METADATA) ? COLUMN_KEY : KEY;
+      }
+    }
+  });
+
+  expect(output).toMatchObject({shape: 'object-row-table', data: INPUT.data});
+  expect(new TextDecoder().decode(new Uint8Array(parquetBuffer).slice(0, 4))).toBe('PAR1');
+});
+
 test('ParquetJSWriter rejects unknown column encryption metadata', async () => {
   await expect(
     encode(INPUT, ParquetJSWriter, {


### PR DESCRIPTION
## Goals

- Complete the writer-side modular-encryption key-management tranche.
- Add plaintext-footer integrity signatures using the existing Parquet crypto path.
- Make the new capabilities discoverable, validated, and covered by round-trip tests.

## Changes

- Add opt-in per-column key metadata for `ParquetJSWriter`, emitting standard `ENCRYPTION_WITH_COLUMN_KEY` metadata and using the selected key for column metadata, pages, Bloom filters, and page indexes.
- Preserve opaque key metadata throughout key retrieval so callers can rotate keys independently by column without serializing key material into writer options.
- Add plaintext-footer signatures with Parquet AAD, caller-controlled key metadata, and a fixed nonce/authentication-tag representation; reject combining a signed plaintext footer with an encrypted footer.
- Validate per-column encryption metadata against the writer schema and expose the public types and helper from both bundled and unbundled Parquet entry points.
- Add focused tests for independent column keys, signed-footer verification, and invalid column names.
- Update the Parquet writer reference and format support matrix to describe the completed opt-in capabilities and the remaining interoperability responsibilities.

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn test-headless modules/parquet/test/parquet-writer-encryption.spec.ts`

This branch is based on current `master` after #3820.
