### PR TITLE
test: migrate Arrow and schema-utils suites to Vitest

### DIFF
--- a/modules/arrow/test/arrow-loader.spec.ts
+++ b/modules/arrow/test/arrow-loader.spec.ts
@@ -2,11 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {validateLoader} from 'test/common/conformance';
-
 import * as fs from 'fs';
-
 import {ArrowLoader} from '@loaders.gl/arrow';
 import {
   isBrowser,
@@ -17,131 +15,105 @@ import {
   parse,
   parseInBatches
 } from '@loaders.gl/core';
-
 import {
   ARROW_SIMPLE,
   ARROW_DICTIONARY,
   ARROW_STRUCT,
   ARROW_BIOGRID_NODES
 } from './data/arrow/test-cases';
-
 const ArrowWorkerLoader = ArrowLoader;
-
 setLoaderOptions({
   _workerType: 'test'
 });
-
-test('ArrowLoader#loader conformance', t => {
-  validateLoader(t, ArrowLoader, 'ArrowLoader');
-  t.end();
+test('ArrowLoader#loader conformance', () => {
+  validateLoader(ArrowLoader, 'ArrowLoader');
 });
-
-test('ArrowLoader#parseSync(simple.arrow)', async t => {
+test('ArrowLoader#parseSync(simple.arrow)', async () => {
   const arrowTable = await parse(fetchFile(ARROW_SIMPLE), ArrowLoader, {
     core: {worker: false}
   });
   // Check loader specific results
-  t.equal(arrowTable.shape, 'columnar-table');
+  expect(arrowTable.shape).toBe('columnar-table');
   if (arrowTable.shape === 'columnar-table') {
-    t.ok(arrowTable.data.bar, 'bar column loaded');
-    t.ok(arrowTable.data.baz, 'baz column loaded');
-    t.ok(arrowTable.data.foo, 'foo column loaded');
+    expect(arrowTable.data.bar, 'bar column loaded').toBeTruthy();
+    expect(arrowTable.data.baz, 'baz column loaded').toBeTruthy();
+    expect(arrowTable.data.foo, 'foo column loaded').toBeTruthy();
   }
-  t.end();
 });
-
-test('ArrowLoader#parseSync(simple.arrow) type="object-row-table"', async t => {
+test('ArrowLoader#parseSync(simple.arrow) type="object-row-table"', async () => {
   const rowFormatTable = await parse(fetchFile(ARROW_SIMPLE), ArrowLoader, {
     core: {worker: false},
     arrow: {shape: 'object-row-table'}
   });
-  t.equal(rowFormatTable.shape, 'object-row-table');
+  expect(rowFormatTable.shape).toBe('object-row-table');
   if (rowFormatTable.shape === 'object-row-table') {
-    t.ok(rowFormatTable, 'Row based table loaded');
-    t.equal(rowFormatTable.data.length, 5);
-    t.deepEqual(rowFormatTable.data[0], {foo: 1, bar: 1, baz: 'aa'});
+    expect(rowFormatTable, 'Row based table loaded').toBeTruthy();
+    expect(rowFormatTable.data.length).toBe(5);
+    expect(rowFormatTable.data[0]).toEqual({foo: 1, bar: 1, baz: 'aa'});
   }
-  t.end();
 });
-
-test('ArrowLoader#parseSync(simple.arrow) supports core.shape', async t => {
+test('ArrowLoader#parseSync(simple.arrow) supports core.shape', async () => {
   const rowFormatTable = await parse(fetchFile(ARROW_SIMPLE), ArrowLoader, {
     core: {worker: false, shape: 'object-row-table'}
   });
-  t.equal(rowFormatTable.shape, 'object-row-table');
+  expect(rowFormatTable.shape).toBe('object-row-table');
   if (rowFormatTable.shape === 'object-row-table') {
-    t.equal(rowFormatTable.data.length, 5);
-    t.deepEqual(rowFormatTable.data[0], {foo: 1, bar: 1, baz: 'aa'});
+    expect(rowFormatTable.data.length).toBe(5);
+    expect(rowFormatTable.data[0]).toEqual({foo: 1, bar: 1, baz: 'aa'});
   }
-  t.end();
 });
-
-test('ArrowLoader#parseSync(simple.arrow) loader shape overrides core.shape', async t => {
+test('ArrowLoader#parseSync(simple.arrow) loader shape overrides core.shape', async () => {
   const rowFormatTable = await parse(fetchFile(ARROW_SIMPLE), ArrowLoader, {
     core: {worker: false, shape: 'array-row-table'},
     arrow: {shape: 'object-row-table'}
   });
-  t.equal(rowFormatTable.shape, 'object-row-table');
-  t.end();
+  expect(rowFormatTable.shape).toBe('object-row-table');
 });
-
 // This table has a dictionary id that is not safe to represent as a JavaScript number.
 // https://github.com/visgl/loaders.gl/pull/2632#issuecomment-1712001480
 // https://github.com/apache/arrow/blob/f1d2fc92f9d898fc067d46a0d032d9b117a2d7fc/js/src/ipc/metadata/message.ts#L389
-test('ArrowLoader#parseSync(dictionary.arrow)', async t => {
+test('ArrowLoader#parseSync(dictionary.arrow)', async () => {
   const columnarTable = await parse(fetchFile(ARROW_DICTIONARY), ArrowLoader);
-  t.equal(columnarTable.shape, 'columnar-table');
+  expect(columnarTable.shape).toBe('columnar-table');
   if (columnarTable.shape === 'columnar-table') {
-    t.ok(columnarTable.data['example-csv'], 'example-csv loaded');
+    expect(columnarTable.data['example-csv'], 'example-csv loaded').toBeTruthy();
   }
-  t.end();
 });
-
-test('ArrowLoader#parse(fetchFile(struct).arrow)', async t => {
+test('ArrowLoader#parse(fetchFile(struct).arrow)', async () => {
   const columns = await parse(fetchFile(ARROW_STRUCT), ArrowLoader);
   // Check loader specific results
-  t.equal(columns.shape, 'columnar-table');
+  expect(columns.shape).toBe('columnar-table');
   if (columns.shape === 'columnar-table') {
-    t.ok(columns.data.struct_nullable, 'struct_nullable loaded');
+    expect(columns.data.struct_nullable, 'struct_nullable loaded').toBeTruthy();
   }
-  t.end();
 });
-
 // TODO - Arrow worker seems to not bundle apache arrow lib?
-test('ArrowLoader#parse (WORKER)', async t => {
+test('ArrowLoader#parse (WORKER)', async () => {
   if (!isBrowser) {
-    t.comment('Worker is not usable in non-browser environments');
-    t.end();
+    console.log('Worker is not usable in non-browser environments');
     return;
   }
-
   const data = await parse(fetchFile(ARROW_SIMPLE), ArrowWorkerLoader);
-  t.ok(data, 'Data returned');
-  t.end();
+  expect(data, 'Data returned').toBeTruthy();
 });
-
-test('ArrowLoader#parseInBatches(async input)', async t => {
+test('ArrowLoader#parseInBatches(async input)', async () => {
   // TODO - parseInBatches should accept fetch response directly
   const response = await fetchFile(ARROW_BIOGRID_NODES);
   const data = await response.arrayBuffer();
   const asyncIterator = await parseInBatches(data, ArrowLoader);
   for await (const batch of asyncIterator) {
-    t.ok(batch, 'received batch');
+    expect(batch, 'received batch').toBeTruthy();
   }
-  t.end();
 });
-
 // TODO - Move node stream test to generic parseInBatches test?
-test('ArrowLoader#parseInBatches(Stream)', async t => {
+test('ArrowLoader#parseInBatches(Stream)', async () => {
   if (isBrowser) {
-    t.comment('Node stream test case only supported in Node');
-    t.end();
+    console.log('Node stream test case only supported in Node');
     return;
   }
   const stream = fs.createReadStream(resolvePath(ARROW_BIOGRID_NODES));
   const asyncIterator = await parseInBatches(makeIterator(stream), ArrowLoader);
   for await (const batch of asyncIterator) {
-    t.ok(batch, 'received batch');
+    expect(batch, 'received batch').toBeTruthy();
   }
-  t.end();
 });

--- a/modules/arrow/test/arrow-utils.spec.ts
+++ b/modules/arrow/test/arrow-utils.spec.ts
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import * as arrow from 'apache-arrow';
-
 import {
   IndexedArrowVector,
   IndexedArrowTable,
@@ -19,7 +18,6 @@ import {
   validateArrowTableSchema
 } from '@loaders.gl/arrow';
 import * as arrowTransport from '@loaders.gl/arrow/transport';
-
 type TestArrowColumns = {
   name: arrow.Utf8;
   score: arrow.Float64;
@@ -27,92 +25,94 @@ type TestArrowColumns = {
   payload: arrow.Binary;
   group: arrow.Utf8;
 };
-
 const RECORD_ID_FIELD = 'record_id';
 const DISPLAY_NAME_FIELD = 'display_name';
 const NEW_FIELD = 'new_field';
 const ITEM_COUNT_FIELD = 'item_count';
 const SOURCE_FLAG_FIELD = 'source_flag';
-
-test('ArrowUtils#IndexedArrowVector exposes indexed vector values', t => {
+test('ArrowUtils#IndexedArrowVector exposes indexed vector values', () => {
   const vector = arrow.vectorFromArray(['zero', 'one', 'two'], new arrow.Utf8());
   const typedIndexes = Int32Array.from([2, 0, 2]);
   const indexedVector = new IndexedArrowVector(vector, typedIndexes);
-
-  t.notEqual(indexedVector.indexes, typedIndexes, 'copies typed indexes by default');
-  t.equal(indexedVector.length, 3, 'has visible value count');
-  t.equal(indexedVector.get(0), 'two', 'gets visible value');
-  t.equal(indexedVector.get(3), null, 'returns null for out-of-range value access');
-  t.equal(indexedVector.get(0.5), null, 'returns null for fractional value access');
-  t.equal(indexedVector.at(-1), 'two', 'gets relative value');
-  t.equal(indexedVector.at(-4), null, 'returns null for relative value access before start');
-  t.deepEqual(indexedVector.slice(1).toArray(), ['zero', 'two'], 'slices indexed values');
-  t.deepEqual(Array.from(indexedVector), ['two', 'zero', 'two'], 'iterates indexed values');
-
-  t.throws(() => new IndexedArrowVector(vector, [-1]), RangeError, 'rejects negative indexes');
-  t.throws(() => new IndexedArrowVector(vector, [3]), RangeError, 'rejects out-of-range indexes');
-  t.throws(() => new IndexedArrowVector(vector, [0.5]), RangeError, 'rejects fractional indexes');
-  t.throws(
-    () => new IndexedArrowVector(vector, [Infinity]),
-    RangeError,
-    'rejects infinite indexes'
+  expect(indexedVector.indexes, 'copies typed indexes by default').not.toBe(typedIndexes);
+  expect(indexedVector.length, 'has visible value count').toBe(3);
+  expect(indexedVector.get(0), 'gets visible value').toBe('two');
+  expect(indexedVector.get(3), 'returns null for out-of-range value access').toBe(null);
+  expect(indexedVector.get(0.5), 'returns null for fractional value access').toBe(null);
+  expect(indexedVector.at(-1), 'gets relative value').toBe('two');
+  expect(indexedVector.at(-4), 'returns null for relative value access before start').toBe(null);
+  expect(indexedVector.slice(1).toArray(), 'slices indexed values').toEqual(['zero', 'two']);
+  expect(Array.from(indexedVector), 'iterates indexed values').toEqual(['two', 'zero', 'two']);
+  expect(() => new IndexedArrowVector(vector, [-1]), 'rejects negative indexes').toThrow(
+    RangeError
   );
-  t.end();
+  expect(() => new IndexedArrowVector(vector, [3]), 'rejects out-of-range indexes').toThrow(
+    RangeError
+  );
+  expect(() => new IndexedArrowVector(vector, [0.5]), 'rejects fractional indexes').toThrow(
+    RangeError
+  );
+  expect(() => new IndexedArrowVector(vector, [Infinity]), 'rejects infinite indexes').toThrow(
+    RangeError
+  );
 });
-
-test('ArrowUtils#IndexedArrowTable normalizes indexes and resolves rows and columns', t => {
+test('ArrowUtils#IndexedArrowTable normalizes indexes and resolves rows and columns', () => {
   const table = createTestTable();
   const indexedTable = new IndexedArrowTable(table, [2, 0, 1]);
-
-  t.deepEqual(Array.from(indexedTable.indexes), [2, 0, 1], 'normalizes row indexes');
-  t.equal(indexedTable.numRows, 3, 'has visible row count');
-  t.equal(indexedTable.numCols, 5, 'has column count');
-  t.equal(indexedTable.getRawIndex(1), 0, 'resolves raw row index');
-  t.equal(indexedTable.getRawIndex(99), null, 'returns null for invalid raw row lookup');
-  t.equal(indexedTable.getRawIndex(0.5), null, 'returns null for fractional raw row lookup');
-  t.equal(indexedTable.get(0)?.name, 'gamma', 'gets visible row');
-  t.equal(indexedTable.get(3), null, 'returns null for out-of-range row access');
-  t.equal(indexedTable.at(-1)?.name, 'beta', 'gets relative row');
-  t.equal(indexedTable.at(-4), null, 'returns null for relative row access before start');
-  t.equal(indexedTable.getValue(0, 'score'), 30, 'gets typed column value');
-  t.equal(indexedTable.getValue(0.5, 'score'), null, 'returns null for fractional value access');
-  t.equal(indexedTable.getValue(0, 'missing' as never), null, 'returns null for missing columns');
-  t.deepEqual(
-    indexedTable.getChild('name')?.toArray(),
-    ['gamma', 'alpha', 'beta'],
-    'gets child view'
+  expect(Array.from(indexedTable.indexes), 'normalizes row indexes').toEqual([2, 0, 1]);
+  expect(indexedTable.numRows, 'has visible row count').toBe(3);
+  expect(indexedTable.numCols, 'has column count').toBe(5);
+  expect(indexedTable.getRawIndex(1), 'resolves raw row index').toBe(0);
+  expect(indexedTable.getRawIndex(99), 'returns null for invalid raw row lookup').toBe(null);
+  expect(indexedTable.getRawIndex(0.5), 'returns null for fractional raw row lookup').toBe(null);
+  expect(indexedTable.get(0)?.name, 'gets visible row').toBe('gamma');
+  expect(indexedTable.get(3), 'returns null for out-of-range row access').toBe(null);
+  expect(indexedTable.at(-1)?.name, 'gets relative row').toBe('beta');
+  expect(indexedTable.at(-4), 'returns null for relative row access before start').toBe(null);
+  expect(indexedTable.getValue(0, 'score'), 'gets typed column value').toBe(30);
+  expect(indexedTable.getValue(0.5, 'score'), 'returns null for fractional value access').toBe(
+    null
   );
-  t.equal(indexedTable.getChild('name'), indexedTable.getChild('name'), 'caches child views');
-  t.equal(indexedTable.getChild('missing' as never), null, 'returns null for missing child view');
-  t.end();
+  expect(indexedTable.getValue(0, 'missing' as never), 'returns null for missing columns').toBe(
+    null
+  );
+  expect(indexedTable.getChild('name')?.toArray(), 'gets child view').toEqual([
+    'gamma',
+    'alpha',
+    'beta'
+  ]);
+  expect(indexedTable.getChild('name'), 'caches child views').toBe(indexedTable.getChild('name'));
+  expect(indexedTable.getChild('missing' as never), 'returns null for missing child view').toBe(
+    null
+  );
 });
-
-test('ArrowUtils#IndexedArrowTable validates and adopts indexes', t => {
+test('ArrowUtils#IndexedArrowTable validates and adopts indexes', () => {
   const table = createTestTable();
-
   const passthroughTable = new IndexedArrowTable(table);
-  t.deepEqual(Array.from(passthroughTable.indexes), [0, 1, 2], 'defaults to all rows in raw order');
-
+  expect(Array.from(passthroughTable.indexes), 'defaults to all rows in raw order').toEqual([
+    0, 1, 2
+  ]);
   const indexes = Int32Array.from([2, 0, 1]);
   const ownedIndexTable = IndexedArrowTable.fromOwnedIndexes(table, indexes);
-  t.equal(ownedIndexTable.indexes, indexes, 'adopts owned typed row indexes');
-
-  t.throws(() => new IndexedArrowTable(table, [0, 3]), RangeError, 'rejects out-of-range indexes');
-  t.throws(() => new IndexedArrowTable(table, [0, 0.5]), RangeError, 'rejects fractional indexes');
-  t.end();
+  expect(ownedIndexTable.indexes, 'adopts owned typed row indexes').toBe(indexes);
+  expect(() => new IndexedArrowTable(table, [0, 3]), 'rejects out-of-range indexes').toThrow(
+    RangeError
+  );
+  expect(() => new IndexedArrowTable(table, [0, 0.5]), 'rejects fractional indexes').toThrow(
+    RangeError
+  );
 });
-
-test('ArrowUtils#IndexedArrowTable supports temporary rows and array-like transforms', t => {
+test('ArrowUtils#IndexedArrowTable supports temporary rows and array-like transforms', () => {
   const table = createTestTable();
   const indexedTable = new IndexedArrowTable(table);
-
   const firstTemporaryRow = indexedTable.getTemporaryRow(2);
   const secondTemporaryRow = indexedTable.getTemporaryRow(0);
-  t.equal(secondTemporaryRow, firstTemporaryRow, 'reuses the same temporary row object');
-  t.equal(secondTemporaryRow?.name, 'alpha', 'updates temporary row values');
-  t.deepEqual(secondTemporaryRow?.payload, new Uint8Array([1, 2, 3]), 'updates binary row values');
-  t.equal(indexedTable.getTemporaryRow(99), null, 'returns null for invalid temporary row');
-
+  expect(secondTemporaryRow, 'reuses the same temporary row object').toBe(firstTemporaryRow);
+  expect(secondTemporaryRow?.name, 'updates temporary row values').toBe('alpha');
+  expect(secondTemporaryRow?.payload, 'updates binary row values').toEqual(
+    new Uint8Array([1, 2, 3])
+  );
+  expect(indexedTable.getTemporaryRow(99), 'returns null for invalid temporary row').toBe(null);
   const filteredTable = indexedTable.filter(
     (currentTable, rowIndex) => currentTable.getValue(rowIndex, 'active') ?? false
   );
@@ -121,37 +121,30 @@ test('ArrowUtils#IndexedArrowTable supports temporary rows and array-like transf
       (currentTable.getValue(rightRowIndex, 'score') ?? 0) -
       (currentTable.getValue(leftRowIndex, 'score') ?? 0)
   );
-
-  t.deepEqual(Array.from(filteredTable.indexes), [0, 2], 'filters rows by indexed column value');
-  t.deepEqual(Array.from(sortedTable.indexes), [2, 0], 'sorts visible rows');
-  t.equal(indexedTable.find(row => row?.name === 'alpha')?.score, 10, 'finds matching row');
-  t.equal(
+  expect(Array.from(filteredTable.indexes), 'filters rows by indexed column value').toEqual([0, 2]);
+  expect(Array.from(sortedTable.indexes), 'sorts visible rows').toEqual([2, 0]);
+  expect(indexedTable.find(row => row?.name === 'alpha')?.score, 'finds matching row').toBe(10);
+  expect(
     indexedTable.findIndex(row => row?.active === false),
-    1,
     'finds matching row index'
-  );
-  t.equal(
+  ).toBe(1);
+  expect(
     indexedTable.find(row => row?.name === 'missing'),
-    undefined,
     'find returns undefined'
-  );
-  t.equal(
+  ).toBe(undefined);
+  expect(
     indexedTable.findIndex(row => row?.name === 'missing'),
-    -1,
     'findIndex returns -1'
-  );
-  t.deepEqual(
+  ).toBe(-1);
+  expect(
     indexedTable
       .slice(1)
       .toArray()
       .map(row => row?.name),
-    ['beta', 'gamma'],
     'slices and materializes visible rows'
-  );
-  t.end();
+  ).toEqual(['beta', 'gamma']);
 });
-
-test('ArrowUtils#IndexedArrowTable concatenates and materializes indexed views', t => {
+test('ArrowUtils#IndexedArrowTable concatenates and materializes indexed views', () => {
   const leftTable = createTestTable();
   const rightTable = createTestTableFromRows([
     {
@@ -169,63 +162,48 @@ test('ArrowUtils#IndexedArrowTable concatenates and materializes indexed views',
       group: 'warm'
     }
   ]);
-
   const concatenated = new IndexedArrowTable(leftTable, [2, 0]).concat(
     new IndexedArrowTable(rightTable, [1, 0])
   );
-
-  t.equal(concatenated.table.numRows, 5, 'concatenates backing tables');
-  t.deepEqual(Array.from(concatenated.indexes), [2, 0, 4, 3], 'preserves visible row indexes');
-  t.deepEqual(
+  expect(concatenated.table.numRows, 'concatenates backing tables').toBe(5);
+  expect(Array.from(concatenated.indexes), 'preserves visible row indexes').toEqual([2, 0, 4, 3]);
+  expect(
     Array.from(concatenated, row => row?.name),
-    ['gamma', 'alpha', 'epsilon', 'delta'],
     'iterates concatenated rows'
-  );
-
+  ).toEqual(['gamma', 'alpha', 'epsilon', 'delta']);
   const sameTableConcatenated = new IndexedArrowTable(leftTable, [2]).concat(
     new IndexedArrowTable(leftTable, [0, 1])
   );
-  t.equal(sameTableConcatenated.table.numRows, 6, 'duplicates same backing table batches');
-  t.deepEqual(
-    Array.from(sameTableConcatenated.indexes),
-    [2, 3, 4],
-    'offsets same-table concat indexes'
-  );
-  t.deepEqual(
+  expect(sameTableConcatenated.table.numRows, 'duplicates same backing table batches').toBe(6);
+  expect(Array.from(sameTableConcatenated.indexes), 'offsets same-table concat indexes').toEqual([
+    2, 3, 4
+  ]);
+  expect(
     Array.from(sameTableConcatenated, row => row?.name),
-    ['gamma', 'alpha', 'beta'],
     'keeps same-table concat row access'
-  );
-
+  ).toEqual(['gamma', 'alpha', 'beta']);
   const emptyConcatenated = new IndexedArrowTable(leftTable, [1]).concat();
-  t.deepEqual(
+  expect(
     Array.from(emptyConcatenated, row => row?.name),
-    ['beta'],
     'supports empty concat'
-  );
-
+  ).toEqual(['beta']);
   const materializedTable = new IndexedArrowTable(leftTable, [2, 0, 2]).materializeArrowTable();
-  t.deepEqual(
+  expect(
     Array.from(materializedTable, row => row.name),
-    ['gamma', 'alpha', 'gamma'],
     'materializes indexed row order and duplicate indexes'
-  );
-  t.deepEqual(
+  ).toEqual(['gamma', 'alpha', 'gamma']);
+  expect(
     Array.from(materializedTable.getChild('score') ?? []),
-    [30, 10, 30],
     'materializes child column values'
-  );
-
+  ).toEqual([30, 10, 30]);
   const incompatibleTable = createArrowTable(
     new arrow.Schema([new arrow.Field('name', new arrow.Utf8(), false)]),
     {name: arrow.vectorFromArray(['delta'], new arrow.Utf8())}
   );
-  t.throws(
+  expect(
     () => new IndexedArrowTable(leftTable).concat(new IndexedArrowTable(incompatibleTable as any)),
-    /identical Arrow schemas/,
     'rejects incompatible schemas'
-  );
-
+  ).toThrow(/identical Arrow schemas/);
   const incompatibleNullabilityTable = createArrowTable(
     new arrow.Schema<TestArrowColumns>([
       new arrow.Field('name', new arrow.Utf8(), true),
@@ -242,16 +220,13 @@ test('ArrowUtils#IndexedArrowTable concatenates and materializes indexed views',
       group: arrow.vectorFromArray(['warm'], new arrow.Utf8())
     }
   );
-  t.throws(
+  expect(
     () =>
       new IndexedArrowTable(leftTable).concat(new IndexedArrowTable(incompatibleNullabilityTable)),
-    /identical Arrow schemas/,
     'rejects schemas with incompatible nullability'
-  );
-  t.end();
+  ).toThrow(/identical Arrow schemas/);
 });
-
-test('ArrowUtils#IndexedArrowTable concatenates filtered and sliced indexed views', t => {
+test('ArrowUtils#IndexedArrowTable concatenates filtered and sliced indexed views', () => {
   const leftView = new IndexedArrowTable(createTestTable()).filter(
     (table, rowIndex) => table.getValue(rowIndex, 'active') ?? false
   );
@@ -280,21 +255,16 @@ test('ArrowUtils#IndexedArrowTable concatenates filtered and sliced indexed view
       }
     ])
   ).slice(1);
-
   const concatenated = leftView.concat(rightView);
-
-  t.deepEqual(Array.from(concatenated.indexes), [0, 2, 4, 5], 'offsets derived view indexes');
-  t.equal(concatenated.get(2)?.name, 'epsilon', 'gets row after derived concat');
-  t.equal(concatenated.getValue(3, 'score'), 60, 'gets column value after derived concat');
-  t.deepEqual(
+  expect(Array.from(concatenated.indexes), 'offsets derived view indexes').toEqual([0, 2, 4, 5]);
+  expect(concatenated.get(2)?.name, 'gets row after derived concat').toBe('epsilon');
+  expect(concatenated.getValue(3, 'score'), 'gets column value after derived concat').toBe(60);
+  expect(
     concatenated.getChild('group')?.toArray(),
-    ['warm', 'warm', 'cool', 'warm'],
     'gets indexed child column after derived concat'
-  );
-  t.end();
+  ).toEqual(['warm', 'warm', 'cool', 'warm']);
 });
-
-test('ArrowUtils#MappedArrowTable supports keyed lookup and mapped transforms', t => {
+test('ArrowUtils#MappedArrowTable supports keyed lookup and mapped transforms', () => {
   const leftTable = createTestTableFromRows([
     {
       name: 'alpha-dup',
@@ -327,7 +297,6 @@ test('ArrowUtils#MappedArrowTable supports keyed lookup and mapped transforms', 
       group: 'warm'
     }
   ]);
-
   const concatenated = new MappedArrowTable(
     leftTable,
     new Map([
@@ -343,45 +312,40 @@ test('ArrowUtils#MappedArrowTable supports keyed lookup and mapped transforms', 
       ])
     )
   );
-
-  t.deepEqual(concatenated.rowKeys, ['dup', 'left', 'dup', 'right'], 'preserves duplicate keys');
-  t.deepEqual(Array.from(concatenated.indexes), [0, 1, 2, 3], 'offsets raw row indexes');
-  t.equal(concatenated.getRowIndex('dup'), 2, 'uses last-wins keyed lookup');
-  t.equal(concatenated.getRowIndex('missing'), null, 'returns null for missing key index');
-  t.equal(concatenated.getByKey('dup')?.name, 'beta-dup', 'gets row by key');
-  t.equal(concatenated.getByKey('missing'), null, 'returns null for missing keyed row');
-  t.equal(concatenated.getRowKey(99), null, 'returns null for invalid key lookup');
-  t.equal(concatenated.getRowKey(0.5), null, 'returns null for fractional key lookup');
-  t.equal(concatenated.atMapped(-1)?.name, 'beta-right', 'supports relative mapped access');
-  t.equal(concatenated.atMapped(-5), null, 'returns null for invalid relative mapped access');
-
+  expect(concatenated.rowKeys, 'preserves duplicate keys').toEqual(['dup', 'left', 'dup', 'right']);
+  expect(Array.from(concatenated.indexes), 'offsets raw row indexes').toEqual([0, 1, 2, 3]);
+  expect(concatenated.getRowIndex('dup'), 'uses last-wins keyed lookup').toBe(2);
+  expect(concatenated.getRowIndex('missing'), 'returns null for missing key index').toBe(null);
+  expect(concatenated.getByKey('dup')?.name, 'gets row by key').toBe('beta-dup');
+  expect(concatenated.getByKey('missing'), 'returns null for missing keyed row').toBe(null);
+  expect(concatenated.getRowKey(99), 'returns null for invalid key lookup').toBe(null);
+  expect(concatenated.getRowKey(0.5), 'returns null for fractional key lookup').toBe(null);
+  expect(concatenated.atMapped(-1)?.name, 'supports relative mapped access').toBe('beta-right');
+  expect(concatenated.atMapped(-5), 'returns null for invalid relative mapped access').toBe(null);
   const sliced = concatenated.slice(1, 3);
   const filtered = concatenated.filter((table, rowIndex) => table.getRowKey(rowIndex) === 'dup');
   const sorted = concatenated.sort(
     (table, leftRowIndex, rightRowIndex) =>
       (table.getValue(rightRowIndex, 'score') ?? 0) - (table.getValue(leftRowIndex, 'score') ?? 0)
   );
-
-  t.deepEqual(sliced.rowKeys, ['left', 'dup'], 'preserves mapped entries through slice');
-  t.equal(sliced.getByKey('dup')?.name, 'beta-dup', 'keeps sliced keyed lookup');
-  t.deepEqual(filtered.rowKeys, ['dup', 'dup'], 'preserves duplicate mapped keys through filter');
-  t.deepEqual(
+  expect(sliced.rowKeys, 'preserves mapped entries through slice').toEqual(['left', 'dup']);
+  expect(sliced.getByKey('dup')?.name, 'keeps sliced keyed lookup').toBe('beta-dup');
+  expect(filtered.rowKeys, 'preserves duplicate mapped keys through filter').toEqual([
+    'dup',
+    'dup'
+  ]);
+  expect(
     Array.from(filtered, row => row?.name),
-    ['alpha-dup', 'beta-dup'],
     'keeps filtered row order'
-  );
-  t.deepEqual(sorted.rowKeys, ['right', 'dup', 'left', 'dup'], 'sorts mapped row entries');
-  t.equal(sorted.getByKey('dup')?.name, 'alpha-dup', 'keeps last-wins lookup after sort');
-
-  t.throws(
+  ).toEqual(['alpha-dup', 'beta-dup']);
+  expect(sorted.rowKeys, 'sorts mapped row entries').toEqual(['right', 'dup', 'left', 'dup']);
+  expect(sorted.getByKey('dup')?.name, 'keeps last-wins lookup after sort').toBe('alpha-dup');
+  expect(
     () => new MappedArrowTable(leftTable, new Map([['bad', 2]])),
-    RangeError,
     'rejects out-of-range mapped indexes'
-  );
-  t.end();
+  ).toThrow(RangeError);
 });
-
-test('ArrowUtils#MappedArrowTable inherits indexed table materialization', t => {
+test('ArrowUtils#MappedArrowTable inherits indexed table materialization', () => {
   const table = createTestTable();
   const mappedTable = new MappedArrowTable(
     table,
@@ -390,98 +354,81 @@ test('ArrowUtils#MappedArrowTable inherits indexed table materialization', t => 
       ['alpha', 0]
     ])
   );
-
   const materializedTable = mappedTable.materializeArrowTable();
-
-  t.deepEqual(
+  expect(
     Array.from(materializedTable, row => row.name),
-    ['gamma', 'alpha'],
     'materializes mapped row order'
-  );
-  t.deepEqual(
+  ).toEqual(['gamma', 'alpha']);
+  expect(
     Array.from(materializedTable.getChild('group') ?? []),
-    ['warm', 'warm'],
     'materializes mapped child column'
-  );
-  t.end();
+  ).toEqual(['warm', 'warm']);
 });
-
-test('ArrowUtils#splitArrowBuffers reuses whole buffers', t => {
+test('ArrowUtils#splitArrowBuffers reuses whole buffers', () => {
   const values = new Float64Array([1, 2, 3]);
   const table = createFloat64Table(values);
   const splitTable = splitArrowBuffers(table);
   const originalDataBuffer = getDataBuffer(table);
   const splitDataBuffer = getDataBuffer(splitTable);
-
-  t.ok(splitTable instanceof arrow.Table, 'returns a real Arrow table');
-  t.deepEqual(Array.from(splitTable.getChild('value') ?? []), [1, 2, 3], 'preserves values');
-  t.equal(splitDataBuffer, originalDataBuffer, 'reuses whole-buffer typed array');
-  t.equal(splitDataBuffer?.buffer, values.buffer, 'reuses whole backing ArrayBuffer');
-  t.equal(splitTable.batches.length, table.batches.length, 'preserves batch count');
-  t.equal(splitTable.numRows, table.numRows, 'preserves row count');
-  t.end();
+  expect(splitTable instanceof arrow.Table, 'returns a real Arrow table').toBeTruthy();
+  expect(Array.from(splitTable.getChild('value') ?? []), 'preserves values').toEqual([1, 2, 3]);
+  expect(splitDataBuffer, 'reuses whole-buffer typed array').toBe(originalDataBuffer);
+  expect(splitDataBuffer?.buffer, 'reuses whole backing ArrayBuffer').toBe(values.buffer);
+  expect(splitTable.batches.length, 'preserves batch count').toBe(table.batches.length);
+  expect(splitTable.numRows, 'preserves row count').toBe(table.numRows);
 });
-
-test('ArrowUtils#splitArrowBuffers copies sliced primitive buffers', t => {
+test('ArrowUtils#splitArrowBuffers copies sliced primitive buffers', () => {
   const backingValues = new Float64Array([99, 1, 2, 3, 100]);
   const slicedValues = backingValues.subarray(1, 4);
   const table = createFloat64Table(slicedValues);
   const splitTable = splitArrowTableBuffers(table);
   const originalDataBuffer = getDataBuffer(table);
   const splitDataBuffer = getDataBuffer(splitTable);
-
-  t.deepEqual(Array.from(splitTable.getChild('value') ?? []), [1, 2, 3], 'preserves values');
-  t.equal(
-    originalDataBuffer?.byteOffset,
-    Float64Array.BYTES_PER_ELEMENT,
-    'original table remains sliced'
+  expect(Array.from(splitTable.getChild('value') ?? []), 'preserves values').toEqual([1, 2, 3]);
+  expect(originalDataBuffer?.byteOffset, 'original table remains sliced').toBe(
+    Float64Array.BYTES_PER_ELEMENT
   );
-  t.equal(originalDataBuffer?.buffer, backingValues.buffer, 'original table keeps backing buffer');
-  t.notEqual(splitDataBuffer?.buffer, backingValues.buffer, 'copies into a different ArrayBuffer');
-  t.equal(splitDataBuffer?.byteOffset, 0, 'copied typed array starts at byte offset zero');
-  t.equal(
-    splitDataBuffer?.byteLength,
-    splitDataBuffer?.buffer.byteLength,
-    'copied typed array spans its backing buffer'
+  expect(originalDataBuffer?.buffer, 'original table keeps backing buffer').toBe(
+    backingValues.buffer
   );
-  t.end();
+  expect(splitDataBuffer?.buffer, 'copies into a different ArrayBuffer').not.toBe(
+    backingValues.buffer
+  );
+  expect(splitDataBuffer?.byteOffset, 'copied typed array starts at byte offset zero').toBe(0);
+  expect(splitDataBuffer?.byteLength, 'copied typed array spans its backing buffer').toBe(
+    splitDataBuffer?.buffer.byteLength
+  );
 });
-
-test('ArrowUtils#splitArrowBuffers accepts RecordBatch Vector and Data', t => {
+test('ArrowUtils#splitArrowBuffers accepts RecordBatch Vector and Data', () => {
   const backingValues = new Float64Array([99, 1, 2, 3, 100]);
   const slicedValues = backingValues.subarray(1, 4);
   const table = createFloat64Table(slicedValues);
   const recordBatch = table.batches[0];
   const vector = table.getChild('value')!;
   const data = vector.data[0];
-
   const splitRecordBatch = splitArrowBuffers(recordBatch);
   const splitVector = splitArrowBuffers(vector);
   const splitData = splitArrowBuffers(data);
-
-  t.ok(splitRecordBatch instanceof arrow.RecordBatch, 'returns a real Arrow record batch');
-  t.ok(splitVector instanceof arrow.Vector, 'returns a real Arrow vector');
-  t.ok(splitData instanceof arrow.Data, 'returns a real Arrow data node');
-  t.deepEqual(Array.from(splitVector), [1, 2, 3], 'preserves vector values');
-  t.notEqual(
+  expect(
+    splitRecordBatch instanceof arrow.RecordBatch,
+    'returns a real Arrow record batch'
+  ).toBeTruthy();
+  expect(splitVector instanceof arrow.Vector, 'returns a real Arrow vector').toBeTruthy();
+  expect(splitData instanceof arrow.Data, 'returns a real Arrow data node').toBeTruthy();
+  expect(Array.from(splitVector), 'preserves vector values').toEqual([1, 2, 3]);
+  expect(
     splitRecordBatch.data.children[0].buffers[arrow.BufferType.DATA]?.buffer,
-    backingValues.buffer,
     'copies sliced record batch child buffer'
-  );
-  t.notEqual(
+  ).not.toBe(backingValues.buffer);
+  expect(
     splitVector.data[0].buffers[arrow.BufferType.DATA]?.buffer,
-    backingValues.buffer,
     'copies sliced vector buffer'
+  ).not.toBe(backingValues.buffer);
+  expect(splitData.buffers[arrow.BufferType.DATA]?.buffer, 'copies sliced data buffer').not.toBe(
+    backingValues.buffer
   );
-  t.notEqual(
-    splitData.buffers[arrow.BufferType.DATA]?.buffer,
-    backingValues.buffer,
-    'copies sliced data buffer'
-  );
-  t.end();
 });
-
-test('ArrowUtils#splitArrowBuffers copies sliced nested string buffers', t => {
+test('ArrowUtils#splitArrowBuffers copies sliced nested string buffers', () => {
   const offsetsBacking = new Int32Array([99, 0, 1, 3, 99]);
   const valuesBacking = new Uint8Array([99, 65, 66, 67, 99]);
   const offsets = offsetsBacking.subarray(1, 4);
@@ -492,56 +439,45 @@ test('ArrowUtils#splitArrowBuffers copies sliced nested string buffers', t => {
   const splitData = splitTable.getChild('name')!.data[0];
   const splitOffsetBuffer = splitData.buffers[arrow.BufferType.OFFSET];
   const splitValueBuffer = splitData.buffers[arrow.BufferType.DATA];
-
-  t.deepEqual(Array.from(splitTable.getChild('name') ?? []), ['A', 'BC'], 'preserves strings');
-  t.equal(originalData.buffers[arrow.BufferType.OFFSET]?.buffer, offsetsBacking.buffer);
-  t.equal(originalData.buffers[arrow.BufferType.DATA]?.buffer, valuesBacking.buffer);
-  t.notEqual(splitOffsetBuffer?.buffer, offsetsBacking.buffer, 'copies sliced offset buffer');
-  t.notEqual(splitValueBuffer?.buffer, valuesBacking.buffer, 'copies sliced string value buffer');
-  t.equal(splitOffsetBuffer?.byteOffset, 0, 'copied offset buffer starts at byte offset zero');
-  t.equal(splitValueBuffer?.byteOffset, 0, 'copied value buffer starts at byte offset zero');
-  t.equal(
-    splitOffsetBuffer?.byteLength,
-    splitOffsetBuffer?.buffer.byteLength,
-    'copied offset buffer spans its backing buffer'
+  expect(Array.from(splitTable.getChild('name') ?? []), 'preserves strings').toEqual(['A', 'BC']);
+  expect(originalData.buffers[arrow.BufferType.OFFSET]?.buffer).toBe(offsetsBacking.buffer);
+  expect(originalData.buffers[arrow.BufferType.DATA]?.buffer).toBe(valuesBacking.buffer);
+  expect(splitOffsetBuffer?.buffer, 'copies sliced offset buffer').not.toBe(offsetsBacking.buffer);
+  expect(splitValueBuffer?.buffer, 'copies sliced string value buffer').not.toBe(
+    valuesBacking.buffer
   );
-  t.equal(
-    splitValueBuffer?.byteLength,
-    splitValueBuffer?.buffer.byteLength,
-    'copied value buffer spans its backing buffer'
+  expect(splitOffsetBuffer?.byteOffset, 'copied offset buffer starts at byte offset zero').toBe(0);
+  expect(splitValueBuffer?.byteOffset, 'copied value buffer starts at byte offset zero').toBe(0);
+  expect(splitOffsetBuffer?.byteLength, 'copied offset buffer spans its backing buffer').toBe(
+    splitOffsetBuffer?.buffer.byteLength
   );
-  t.end();
+  expect(splitValueBuffer?.byteLength, 'copied value buffer spans its backing buffer').toBe(
+    splitValueBuffer?.buffer.byteLength
+  );
 });
-
-test('ArrowUtils#splitArrowBuffers can copy every internal buffer', t => {
+test('ArrowUtils#splitArrowBuffers can copy every internal buffer', () => {
   const values = new Float64Array([1, 2, 3]);
   const table = createFloat64Table(values);
   const splitTable = splitArrowBuffers(table, {copy: 'all'});
   const splitDataBuffer = getDataBuffer(splitTable);
-
-  t.deepEqual(Array.from(splitTable.getChild('value') ?? []), [1, 2, 3], 'preserves values');
-  t.notEqual(splitDataBuffer?.buffer, values.buffer, 'copies whole-buffer typed arrays on request');
-  t.end();
+  expect(Array.from(splitTable.getChild('value') ?? []), 'preserves values').toEqual([1, 2, 3]);
+  expect(splitDataBuffer?.buffer, 'copies whole-buffer typed arrays on request').not.toBe(
+    values.buffer
+  );
 });
-
-test('ArrowUtils#splitArrowBuffers can skip buffer copying', t => {
+test('ArrowUtils#splitArrowBuffers can skip buffer copying', () => {
   const backingValues = new Float64Array([99, 1, 2, 3, 100]);
   const slicedValues = backingValues.subarray(1, 4);
   const table = createFloat64Table(slicedValues);
   const splitTable = splitArrowBuffers(table, {copy: 'none'});
   const splitDataBuffer = getDataBuffer(splitTable);
-
-  t.deepEqual(Array.from(splitTable.getChild('value') ?? []), [1, 2, 3], 'preserves values');
-  t.equal(splitDataBuffer?.buffer, backingValues.buffer, 'reuses sliced backing buffer');
-  t.equal(
-    splitDataBuffer?.byteOffset,
-    Float64Array.BYTES_PER_ELEMENT,
-    'preserves sliced byte offset'
+  expect(Array.from(splitTable.getChild('value') ?? []), 'preserves values').toEqual([1, 2, 3]);
+  expect(splitDataBuffer?.buffer, 'reuses sliced backing buffer').toBe(backingValues.buffer);
+  expect(splitDataBuffer?.byteOffset, 'preserves sliced byte offset').toBe(
+    Float64Array.BYTES_PER_ELEMENT
   );
-  t.end();
 });
-
-test('ArrowUtils#dehydrateArrowTable and hydrateArrowTable round trip structured payloads', t => {
+test('ArrowUtils#dehydrateArrowTable and hydrateArrowTable round trip structured payloads', () => {
   const backingValues = new Float64Array([99, 1, 2, 3, 100]);
   const slicedValues = backingValues.subarray(1, 4);
   const table = createFloat64Table(slicedValues);
@@ -549,78 +485,61 @@ test('ArrowUtils#dehydrateArrowTable and hydrateArrowTable round trip structured
   const clonedPayload = structuredClone(dehydratedTable);
   const hydratedTable = hydrateArrowTable(clonedPayload);
   const hydratedDataBuffer = getDataBuffer(hydratedTable);
-
-  t.equal(dehydratedTable.shape, 'arrow-table', 'marks table shape');
-  t.equal(dehydratedTable.transport, 'arrow-js', 'marks Arrow JS transport');
-  t.ok(hydratedTable instanceof arrow.Table, 'hydrates a real Arrow table');
-  t.deepEqual(Array.from(hydratedTable.getChild('value') ?? []), [1, 2, 3], 'preserves values');
-  t.notEqual(hydratedDataBuffer?.buffer, backingValues.buffer, 'isolates sliced backing buffer');
-  t.equal(hydratedDataBuffer?.byteOffset, 0, 'hydrated buffer starts at byte offset zero');
-  t.equal(
-    hydratedDataBuffer?.byteLength,
-    hydratedDataBuffer?.buffer.byteLength,
-    'hydrated buffer spans its backing buffer'
+  expect(dehydratedTable.shape, 'marks table shape').toBe('arrow-table');
+  expect(dehydratedTable.transport, 'marks Arrow JS transport').toBe('arrow-js');
+  expect(hydratedTable instanceof arrow.Table, 'hydrates a real Arrow table').toBeTruthy();
+  expect(Array.from(hydratedTable.getChild('value') ?? []), 'preserves values').toEqual([1, 2, 3]);
+  expect(hydratedDataBuffer?.buffer, 'isolates sliced backing buffer').not.toBe(
+    backingValues.buffer
   );
-  t.end();
+  expect(hydratedDataBuffer?.byteOffset, 'hydrated buffer starts at byte offset zero').toBe(0);
+  expect(hydratedDataBuffer?.byteLength, 'hydrated buffer spans its backing buffer').toBe(
+    hydratedDataBuffer?.buffer.byteLength
+  );
 });
-
-test('ArrowUtils#transport subpath exports Arrow table transport utilities', t => {
-  t.equal(arrowTransport.dehydrateArrowTable, dehydrateArrowTable, 'exports dehydrateArrowTable');
-  t.equal(arrowTransport.hydrateArrowTable, hydrateArrowTable, 'exports hydrateArrowTable');
-  t.equal(
-    arrowTransport.serializeArrowTableToIPC,
-    serializeArrowTableToIPC,
-    'exports serializeArrowTableToIPC'
+test('ArrowUtils#transport subpath exports Arrow table transport utilities', () => {
+  expect(arrowTransport.dehydrateArrowTable, 'exports dehydrateArrowTable').toBe(
+    dehydrateArrowTable
   );
-  t.equal(
-    arrowTransport.deserializeArrowTableFromIPC,
-    deserializeArrowTableFromIPC,
-    'exports deserializeArrowTableFromIPC'
+  expect(arrowTransport.hydrateArrowTable, 'exports hydrateArrowTable').toBe(hydrateArrowTable);
+  expect(arrowTransport.serializeArrowTableToIPC, 'exports serializeArrowTableToIPC').toBe(
+    serializeArrowTableToIPC
   );
-  t.equal(arrowTransport.splitArrowBuffers, splitArrowBuffers, 'exports splitArrowBuffers');
-  t.equal(
-    arrowTransport.splitArrowTableBuffers,
-    splitArrowTableBuffers,
-    'exports splitArrowTableBuffers'
+  expect(arrowTransport.deserializeArrowTableFromIPC, 'exports deserializeArrowTableFromIPC').toBe(
+    deserializeArrowTableFromIPC
   );
-  t.end();
+  expect(arrowTransport.splitArrowBuffers, 'exports splitArrowBuffers').toBe(splitArrowBuffers);
+  expect(arrowTransport.splitArrowTableBuffers, 'exports splitArrowTableBuffers').toBe(
+    splitArrowTableBuffers
+  );
 });
-
-test('ArrowUtils#transport subpath round trips Arrow JS payloads', t => {
+test('ArrowUtils#transport subpath round trips Arrow JS payloads', () => {
   const table = createFloat64Table(new Float64Array([1, 2, 3]));
   const dehydratedTable = arrowTransport.dehydrateArrowTable(table);
   const hydratedTable = arrowTransport.hydrateArrowTable(structuredClone(dehydratedTable));
-
-  t.ok(hydratedTable instanceof arrow.Table, 'hydrates a real Arrow table');
-  t.deepEqual(Array.from(hydratedTable.getChild('value') ?? []), [1, 2, 3], 'preserves values');
-  t.end();
+  expect(hydratedTable instanceof arrow.Table, 'hydrates a real Arrow table').toBeTruthy();
+  expect(Array.from(hydratedTable.getChild('value') ?? []), 'preserves values').toEqual([1, 2, 3]);
 });
-
-test('ArrowUtils#serializeArrowTableToIPC and deserializeArrowTableFromIPC round trip IPC payloads', t => {
+test('ArrowUtils#serializeArrowTableToIPC and deserializeArrowTableFromIPC round trip IPC payloads', () => {
   const table = createUtf8Table(new Int32Array([0, 1, 3]), new Uint8Array([65, 66, 67]));
   const serializedTable = serializeArrowTableToIPC(table);
   const clonedPayload = structuredClone(serializedTable);
   const deserializedTable = deserializeArrowTableFromIPC(clonedPayload);
   const deserializedRawTable = deserializeArrowTableFromIPC(clonedPayload.data);
-
-  t.equal(serializedTable.shape, 'arrow-table', 'marks table shape');
-  t.equal(serializedTable.transport, 'arrow-ipc', 'marks Arrow IPC transport');
-  t.ok(serializedTable.data instanceof Uint8Array, 'returns IPC bytes');
-  t.ok(deserializedTable instanceof arrow.Table, 'deserializes a real Arrow table');
-  t.deepEqual(
+  expect(serializedTable.shape, 'marks table shape').toBe('arrow-table');
+  expect(serializedTable.transport, 'marks Arrow IPC transport').toBe('arrow-ipc');
+  expect(serializedTable.data instanceof Uint8Array, 'returns IPC bytes').toBeTruthy();
+  expect(deserializedTable instanceof arrow.Table, 'deserializes a real Arrow table').toBeTruthy();
+  expect(
     Array.from(deserializedTable.getChild('name') ?? []),
-    ['A', 'BC'],
     'preserves values from payload'
-  );
-  t.deepEqual(
+  ).toEqual(['A', 'BC']);
+  expect(
     Array.from(deserializedRawTable.getChild('name') ?? []),
-    ['A', 'BC'],
     'preserves values from raw IPC bytes'
-  );
-  t.end();
+  ).toEqual(['A', 'BC']);
 });
-
-test('ArrowUtils#validateArrowTableSchema validates expected Arrow schema fields', t => {
+test('ArrowUtils#validateArrowTableSchema validates expected Arrow schema fields', () => {
   const expectedSchema = new arrow.Schema([
     new arrow.Field(RECORD_ID_FIELD, new arrow.Utf8(), false),
     new arrow.Field(DISPLAY_NAME_FIELD, new arrow.Utf8(), true)
@@ -635,34 +554,29 @@ test('ArrowUtils#validateArrowTableSchema validates expected Arrow schema fields
     [DISPLAY_NAME_FIELD]: arrow.vectorFromArray(['Example record'], new arrow.Utf8()),
     [NEW_FIELD]: arrow.vectorFromArray(['value'], new arrow.Utf8())
   });
-
-  t.doesNotThrow(
+  expect(
     () => validateArrowTableSchema(extraFieldTable, expectedSchema, {schemaName: 'test schema'}),
     'accepts extra trailing fields by default'
-  );
-  t.throws(
+  ).not.toThrow();
+  expect(
     () =>
       validateArrowTableSchema(extraFieldTable, expectedSchema, {
         rejectExtraFields: true,
         schemaName: 'test strict schema'
       }),
-    /Unexpected fields: new_field/,
     'rejects extra fields in strict mode'
-  );
-
+  ).toThrow(/Unexpected fields: new_field/);
   const missingFieldTable = createArrowTable(
     new arrow.Schema([new arrow.Field(RECORD_ID_FIELD, new arrow.Utf8(), false)]),
     {[RECORD_ID_FIELD]: arrow.vectorFromArray(['record-1'], new arrow.Utf8())}
   );
-  t.throws(
+  expect(
     () =>
       validateArrowTableSchema(missingFieldTable, expectedSchema, {
         schemaName: 'sample records table'
       }),
-    /Missing fields: display_name/,
     'rejects missing expected fields'
-  );
-
+  ).toThrow(/Missing fields: display_name/);
   const wrongOrderTable = createArrowTable(
     new arrow.Schema([
       new arrow.Field(DISPLAY_NAME_FIELD, new arrow.Utf8(), true),
@@ -673,12 +587,10 @@ test('ArrowUtils#validateArrowTableSchema validates expected Arrow schema fields
       [RECORD_ID_FIELD]: arrow.vectorFromArray(['record-1'], new arrow.Utf8())
     }
   );
-  t.throws(
+  expect(
     () => validateArrowTableSchema(wrongOrderTable, expectedSchema),
-    /expected field record_id, got display_name/,
     'rejects fields in the wrong order'
-  );
-
+  ).toThrow(/expected field record_id, got display_name/);
   const wrongTypeTable = createArrowTable(
     new arrow.Schema([
       new arrow.Field(RECORD_ID_FIELD, new arrow.Float64(), false),
@@ -689,12 +601,10 @@ test('ArrowUtils#validateArrowTableSchema validates expected Arrow schema fields
       [DISPLAY_NAME_FIELD]: arrow.vectorFromArray(['Example record'], new arrow.Utf8())
     }
   );
-  t.throws(
+  expect(
     () => validateArrowTableSchema(wrongTypeTable, expectedSchema),
-    /record_id: expected type/,
     'rejects fields with the wrong Arrow type id'
-  );
-
+  ).toThrow(/record_id: expected type/);
   const wrongNestedTypeTable = createArrowTable(
     new arrow.Schema([
       new arrow.Field(
@@ -720,12 +630,10 @@ test('ArrowUtils#validateArrowTableSchema validates expected Arrow schema fields
     ),
     new arrow.Field(DISPLAY_NAME_FIELD, new arrow.Utf8(), true)
   ]);
-  t.throws(
+  expect(
     () => validateArrowTableSchema(wrongNestedTypeTable, nestedExpectedSchema),
-    /record_id: expected type List<Int32> .* got List<Float32>/,
     'rejects fields with the wrong nested Arrow type'
-  );
-
+  ).toThrow(/record_id: expected type List<Int32> .* got List<Float32>/);
   const wrongNullabilityTable = createArrowTable(
     new arrow.Schema([
       new arrow.Field(RECORD_ID_FIELD, new arrow.Utf8(), true),
@@ -736,15 +644,12 @@ test('ArrowUtils#validateArrowTableSchema validates expected Arrow schema fields
       [DISPLAY_NAME_FIELD]: arrow.vectorFromArray(['Example record'], new arrow.Utf8())
     }
   );
-  t.throws(
+  expect(
     () => validateArrowTableSchema(wrongNullabilityTable, expectedSchema),
-    /record_id: expected nullable=false, got nullable=true/,
     'rejects fields with wrong nullability'
-  );
-  t.end();
+  ).toThrow(/record_id: expected nullable=false, got nullable=true/);
 });
-
-test('ArrowUtils#renameArrowColumns renames selected fields', t => {
+test('ArrowUtils#renameArrowColumns renames selected fields', () => {
   const sourceSchema = new arrow.Schema([
     new arrow.Field(RECORD_ID_FIELD, new arrow.Utf8(), false),
     new arrow.Field(ITEM_COUNT_FIELD, new arrow.Float64(), true),
@@ -759,44 +664,36 @@ test('ArrowUtils#renameArrowColumns renames selected fields', t => {
     [ITEM_COUNT_FIELD]: arrow.vectorFromArray([3], new arrow.Float64()),
     [SOURCE_FLAG_FIELD]: arrow.vectorFromArray([true], new arrow.Bool())
   });
-
   const renamedTable = renameArrowColumns(table, sourceSchema, targetSchema, {
     [RECORD_ID_FIELD]: 'recordId',
     [ITEM_COUNT_FIELD]: 'itemCount'
   });
   const row = renamedTable.get(0);
-
-  t.deepEqual(
+  expect(
     renamedTable.schema.fields.map(field => field.name),
-    ['recordId', 'itemCount', SOURCE_FLAG_FIELD],
     'renames mapped columns and preserves untouched columns'
-  );
-  t.equal(row?.recordId, 'record-1', 'reads renamed string column');
-  t.equal(row?.itemCount, 3, 'reads renamed number column');
-  t.equal(row?.[SOURCE_FLAG_FIELD], true, 'reads untouched column');
-
-  t.throws(
+  ).toEqual(['recordId', 'itemCount', SOURCE_FLAG_FIELD]);
+  expect(row?.recordId, 'reads renamed string column').toBe('record-1');
+  expect(row?.itemCount, 'reads renamed number column').toBe(3);
+  expect(row?.[SOURCE_FLAG_FIELD], 'reads untouched column').toBe(true);
+  expect(
     () =>
       renameArrowColumns(table, sourceSchema, targetSchema, {
         [RECORD_ID_FIELD]: 'recordId',
         [ITEM_COUNT_FIELD]: 'recordId'
       }),
-    /Duplicate Arrow column name after rename: recordId/,
     'rejects duplicate output column names'
-  );
-
+  ).toThrow(/Duplicate Arrow column name after rename: recordId/);
   const mismatchedTargetSchema = new arrow.Schema([
     new arrow.Field('recordId', new arrow.Float64(), false)
   ]);
-  t.throws(
+  expect(
     () =>
       renameArrowColumns(table, sourceSchema, mismatchedTargetSchema, {
         [RECORD_ID_FIELD]: 'recordId'
       }),
-    /Unexpected Arrow schema for renamed field recordId/,
     'rejects renamed columns with mismatched target type'
-  );
-
+  ).toThrow(/Unexpected Arrow schema for renamed field recordId/);
   const missingSourceFieldSchema = new arrow.Schema([
     new arrow.Field(RECORD_ID_FIELD, new arrow.Utf8(), false),
     new arrow.Field(ITEM_COUNT_FIELD, new arrow.Float64(), true),
@@ -807,17 +704,14 @@ test('ArrowUtils#renameArrowColumns renames selected fields', t => {
     [ITEM_COUNT_FIELD]: arrow.vectorFromArray([3], new arrow.Float64()),
     [NEW_FIELD]: arrow.vectorFromArray(['value'], new arrow.Utf8())
   });
-  t.throws(
+  expect(
     () =>
       renameArrowColumns(missingSourceFieldTable, sourceSchema, targetSchema, {
         [RECORD_ID_FIELD]: 'recordId'
       }),
-    /source Arrow schema before column rename/,
     'rejects tables that do not match the source schema'
-  );
-  t.end();
+  ).toThrow(/source Arrow schema before column rename/);
 });
-
 /**
  * Builds one small Arrow table used by indexed and mapped view tests.
  */
@@ -846,7 +740,6 @@ function createTestTable(): arrow.Table<TestArrowColumns> {
     }
   ]);
 }
-
 /**
  * Builds one small Arrow table from explicit row objects for concat-oriented tests.
  */
@@ -891,33 +784,41 @@ function createTestTableFromRows(
     }
   );
 }
-
 /**
  * Builds an Arrow table with an explicit schema and column vector map.
  */
 function createArrowTable<T extends arrow.TypeMap>(
   schema: arrow.Schema<T>,
-  columns: {[P in keyof T]: arrow.Vector<T[P]>}
+  columns: {
+    [P in keyof T]: arrow.Vector<T[P]>;
+  }
 ): arrow.Table<T> {
   return new (arrow.Table as any)(schema, columns) as arrow.Table<T>;
 }
-
 /**
  * Builds a one-column Float64 Arrow table from a caller-provided typed array.
  */
-function createFloat64Table(values: Float64Array): arrow.Table<{value: arrow.Float64}> {
+function createFloat64Table(values: Float64Array): arrow.Table<{
+  value: arrow.Float64;
+}> {
   const type = new arrow.Float64();
   const vector = new arrow.Vector([
     new arrow.Data(type, 0, values.length, 0, {[arrow.BufferType.DATA]: values} as any)
   ]);
-  const schema = new arrow.Schema<{value: arrow.Float64}>([new arrow.Field('value', type, false)]);
+  const schema = new arrow.Schema<{
+    value: arrow.Float64;
+  }>([new arrow.Field('value', type, false)]);
   return createArrowTable(schema, {value: vector});
 }
-
 /**
  * Builds a one-column Utf8 Arrow table from caller-provided offset and value buffers.
  */
-function createUtf8Table(offsets: Int32Array, values: Uint8Array): arrow.Table<{name: arrow.Utf8}> {
+function createUtf8Table(
+  offsets: Int32Array,
+  values: Uint8Array
+): arrow.Table<{
+  name: arrow.Utf8;
+}> {
   const type = new arrow.Utf8();
   const vector = new arrow.Vector([
     new arrow.Data(type, 0, offsets.length - 1, 0, {
@@ -925,13 +826,18 @@ function createUtf8Table(offsets: Int32Array, values: Uint8Array): arrow.Table<{
       [arrow.BufferType.DATA]: values
     } as any)
   ]);
-  const schema = new arrow.Schema<{name: arrow.Utf8}>([new arrow.Field('name', type, false)]);
+  const schema = new arrow.Schema<{
+    name: arrow.Utf8;
+  }>([new arrow.Field('name', type, false)]);
   return createArrowTable(schema, {name: vector});
 }
-
 /**
  * Gets the internal DATA buffer for the Float64 test table.
  */
-function getDataBuffer(table: arrow.Table<{value: arrow.Float64}>): Float64Array | undefined {
+function getDataBuffer(
+  table: arrow.Table<{
+    value: arrow.Float64;
+  }>
+): Float64Array | undefined {
   return table.getChild('value')?.data[0].buffers[arrow.BufferType.DATA];
 }

--- a/modules/arrow/test/arrow-writer.spec.ts
+++ b/modules/arrow/test/arrow-writer.spec.ts
@@ -2,44 +2,34 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {validateWriter} from 'test/common/conformance';
-
 import {parseSync, encodeSync} from '@loaders.gl/core';
 import {ArrowWriter} from '@loaders.gl/arrow';
 import {ArrowLoader} from '@loaders.gl/arrow/bundled';
-
-test('ArrowWriter#writer conformance', t => {
-  validateWriter(t, ArrowWriter, 'ArrowWriter');
-  t.end();
+test('ArrowWriter#writer conformance', () => {
+  validateWriter(ArrowWriter, 'ArrowWriter');
 });
-
-test('ArrowWriter#encode', async t => {
+test('ArrowWriter#encode', async () => {
   const LENGTH = 2000;
-
   const rainAmounts = Float32Array.from({length: LENGTH}, () =>
     Number((Math.random() * 20).toFixed(1))
   );
-
   const rainDates = Array.from(
     {length: LENGTH},
     (_, i) => new Date(Date.now() - 1000 * 60 * 60 * 24 * i)
   );
-
   const arraysData = [
     {array: rainAmounts, name: 'precipitation', type: 0},
     {array: rainDates, name: 'date', type: 1}
   ];
-
   const arrayBuffer = encodeSync(arraysData, ArrowWriter);
-  t.ok(arrayBuffer);
-
+  expect(arrayBuffer).toBeTruthy();
   const table = parseSync(arrayBuffer, ArrowLoader);
-  t.ok(table);
-  t.equals(table.shape, 'columnar-table');
+  expect(table).toBeTruthy();
+  expect(table.shape).toBe('columnar-table');
   if (table.shape === 'columnar-table') {
-    t.ok(table.data.precipitation);
-    t.equals(table.data.precipitation.length, LENGTH);
+    expect(table.data.precipitation).toBeTruthy();
+    expect(table.data.precipitation.length).toBe(LENGTH);
   }
-  t.end();
 });

--- a/modules/arrow/test/convert-arrow-variable-width.spec.ts
+++ b/modules/arrow/test/convert-arrow-variable-width.spec.ts
@@ -2,65 +2,54 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import * as arrow from 'apache-arrow';
-
 import {
   convertArrowTableVariableWidthTypes,
   convertArrowVariableWidthVector
 } from '@loaders.gl/arrow';
 import {getArrowViewTypeSupport, serializeArrowType} from '@loaders.gl/schema-utils';
-
-test('ArrowVariableWidth#convertArrowVariableWidthVector converts Utf8 in both directions', t => {
+test('ArrowVariableWidth#convertArrowVariableWidthVector converts Utf8 in both directions', () => {
   const firstChunk = arrow.vectorFromArray(['short', null], new arrow.Utf8());
   const secondChunk = arrow.vectorFromArray(
     ['a string long enough to use an out-of-line view buffer'],
     new arrow.Utf8()
   );
   const utf8Vector = new arrow.Vector([...firstChunk.data, ...secondChunk.data]);
-
   const viewVector = convertArrowVariableWidthVector(utf8Vector, {viewTypes: 'require'});
-  t.equal(serializeArrowType(viewVector.type), 'utf8-view', 'converts Utf8 to Utf8View');
-  t.equal(viewVector.data.length, 2, 'preserves chunk boundaries');
-  t.deepEqual(Array.from(viewVector), Array.from(utf8Vector), 'preserves values and nulls');
-
+  expect(serializeArrowType(viewVector.type), 'converts Utf8 to Utf8View').toBe('utf8-view');
+  expect(viewVector.data.length, 'preserves chunk boundaries').toBe(2);
+  expect(Array.from(viewVector), 'preserves values and nulls').toEqual(Array.from(utf8Vector));
   const standardVector = convertArrowVariableWidthVector(viewVector);
-  t.equal(serializeArrowType(standardVector.type), 'utf8', 'converts Utf8View to Utf8');
-  t.equal(standardVector.data.length, 2, 'preserves converted chunk boundaries');
-  t.deepEqual(Array.from(standardVector), Array.from(utf8Vector), 'round trips values and nulls');
-  t.equal(
-    convertArrowVariableWidthVector(standardVector),
-    standardVector,
-    'returns an already selected type without copying'
+  expect(serializeArrowType(standardVector.type), 'converts Utf8View to Utf8').toBe('utf8');
+  expect(standardVector.data.length, 'preserves converted chunk boundaries').toBe(2);
+  expect(Array.from(standardVector), 'round trips values and nulls').toEqual(
+    Array.from(utf8Vector)
   );
-  t.end();
+  expect(
+    convertArrowVariableWidthVector(standardVector),
+    'returns an already selected type without copying'
+  ).toBe(standardVector);
 });
-
-test('ArrowVariableWidth#convertArrowVariableWidthVector converts Binary in both directions', t => {
+test('ArrowVariableWidth#convertArrowVariableWidthVector converts Binary in both directions', () => {
   const binaryVector = arrow.vectorFromArray(
     [new Uint8Array([1, 2, 3]), null, new Uint8Array(20).fill(4)],
     new arrow.Binary()
   );
-
   const viewVector = convertArrowVariableWidthVector(binaryVector, {viewTypes: 'require'});
-  t.equal(serializeArrowType(viewVector.type), 'binary-view', 'converts Binary to BinaryView');
-  t.deepEqual(
+  expect(serializeArrowType(viewVector.type), 'converts Binary to BinaryView').toBe('binary-view');
+  expect(
     Array.from(viewVector, value => (value ? Array.from(value) : value)),
-    Array.from(binaryVector, value => (value ? Array.from(value) : value)),
     'preserves binary values and nulls'
-  );
-
+  ).toEqual(Array.from(binaryVector, value => (value ? Array.from(value) : value)));
   const standardVector = convertArrowVariableWidthVector(viewVector, {viewTypes: 'never'});
-  t.equal(serializeArrowType(standardVector.type), 'binary', 'converts BinaryView to Binary');
-  t.deepEqual(
+  expect(serializeArrowType(standardVector.type), 'converts BinaryView to Binary').toBe('binary');
+  expect(
     Array.from(standardVector, value => (value ? Array.from(value) : value)),
-    Array.from(binaryVector, value => (value ? Array.from(value) : value)),
     'round trips binary values and nulls'
-  );
-  t.end();
+  ).toEqual(Array.from(binaryVector, value => (value ? Array.from(value) : value)));
 });
-
-test('ArrowVariableWidth#convertArrowTableVariableWidthTypes converts eligible columns', t => {
+test('ArrowVariableWidth#convertArrowTableVariableWidthTypes converts eligible columns', () => {
   const text = arrow.vectorFromArray(['alpha', 'a sufficiently long beta value'], new arrow.Utf8());
   const payload = arrow.vectorFromArray(
     [new Uint8Array([1]), new Uint8Array(16).fill(2)],
@@ -68,44 +57,32 @@ test('ArrowVariableWidth#convertArrowTableVariableWidthTypes converts eligible c
   );
   const score = arrow.vectorFromArray([1, 2], new arrow.Int32());
   const table = new arrow.Table({text, payload, score});
-
   const viewTable = convertArrowTableVariableWidthTypes(table, {viewTypes: 'require'});
-  t.equal(serializeArrowType(viewTable.getChild('text')!.type), 'utf8-view', 'converts text');
-  t.equal(
-    serializeArrowType(viewTable.getChild('payload')!.type),
-    'binary-view',
-    'converts binary'
+  expect(serializeArrowType(viewTable.getChild('text')!.type), 'converts text').toBe('utf8-view');
+  expect(serializeArrowType(viewTable.getChild('payload')!.type), 'converts binary').toBe(
+    'binary-view'
   );
-  t.equal(
+  expect(
     viewTable.getChild('score')!.data[0],
-    score.data[0],
     'preserves non-variable-width column data without copying'
-  );
-  t.deepEqual(viewTable.toArray(), table.toArray(), 'preserves table rows');
-
+  ).toBe(score.data[0]);
+  expect(viewTable.toArray(), 'preserves table rows').toEqual(table.toArray());
   const standardTable = convertArrowTableVariableWidthTypes(viewTable);
-  t.equal(serializeArrowType(standardTable.getChild('text')!.type), 'utf8', 'normalizes text');
-  t.equal(
-    serializeArrowType(standardTable.getChild('payload')!.type),
-    'binary',
-    'normalizes binary'
+  expect(serializeArrowType(standardTable.getChild('text')!.type), 'normalizes text').toBe('utf8');
+  expect(serializeArrowType(standardTable.getChild('payload')!.type), 'normalizes binary').toBe(
+    'binary'
   );
-  t.equal(
+  expect(
     convertArrowTableVariableWidthTypes(standardTable),
-    standardTable,
     'returns an unchanged table without copying'
-  );
-  t.end();
+  ).toBe(standardTable);
 });
-
-test('ArrowVariableWidth#runtime support and input validation', t => {
+test('ArrowVariableWidth#runtime support and input validation', () => {
   const support = getArrowViewTypeSupport();
-  t.equal(support.utf8View, true, 'test runtime provides Utf8View');
-  t.equal(support.binaryView, true, 'test runtime provides BinaryView');
-  t.throws(
+  expect(support.utf8View, 'test runtime provides Utf8View').toBe(true);
+  expect(support.binaryView, 'test runtime provides BinaryView').toBe(true);
+  expect(
     () => convertArrowVariableWidthVector(arrow.vectorFromArray([1, 2], new arrow.Int32())),
-    /Expected an Arrow Utf8, Utf8View, Binary, or BinaryView vector/,
     'rejects unrelated vectors'
-  );
-  t.end();
+  ).toThrow(/Expected an Arrow Utf8, Utf8View, Binary, or BinaryView vector/);
 });

--- a/modules/arrow/test/tighten-arrow-table-schema-nullability.spec.ts
+++ b/modules/arrow/test/tighten-arrow-table-schema-nullability.spec.ts
@@ -2,62 +2,51 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import * as arrow from 'apache-arrow';
 import {convertArrowToSchema} from '@loaders.gl/schema-utils';
 import {tightenArrowTableSchemaNullability} from '@loaders.gl/arrow';
-
 import type {ArrowTable} from '@loaders.gl/schema';
-
-test('tightenArrowTableSchemaNullability#tightens nullable fields without nulls', async t => {
+test('tightenArrowTableSchemaNullability#tightens nullable fields without nulls', async () => {
   const table = makeTestArrowTable({
     values: ['a', 'b', 'c'],
     nullable: true
   });
-
   const tightenedTable = tightenArrowTableSchemaNullability(table);
-
-  t.equal(tightenedTable.schema?.fields[0].nullable, false, 'loaders.gl schema is tightened');
-  t.equal(tightenedTable.data.schema.fields[0].nullable, false, 'Arrow schema is tightened');
-  t.equal(tightenedTable.data.getChildAt(0)?.get(1), 'b', 'column values are preserved');
-  t.notEqual(tightenedTable.data, table.data, 'Arrow table wrapper is replaced');
-  t.end();
+  expect(tightenedTable.schema?.fields[0].nullable, 'loaders.gl schema is tightened').toBe(false);
+  expect(tightenedTable.data.schema.fields[0].nullable, 'Arrow schema is tightened').toBe(false);
+  expect(tightenedTable.data.getChildAt(0)?.get(1), 'column values are preserved').toBe('b');
+  expect(tightenedTable.data, 'Arrow table wrapper is replaced').not.toBe(table.data);
 });
-
-test('tightenArrowTableSchemaNullability#keeps nullable fields with nulls', async t => {
+test('tightenArrowTableSchemaNullability#keeps nullable fields with nulls', async () => {
   const table = makeTestArrowTable({
     values: ['a', null, 'c'],
     nullable: true
   });
-
   const tightenedTable = tightenArrowTableSchemaNullability(table);
-
-  t.equal(tightenedTable, table, 'table is reused when nullability is unchanged');
-  t.equal(tightenedTable.schema?.fields[0].nullable, true, 'loaders.gl schema stays nullable');
-  t.equal(tightenedTable.data.schema.fields[0].nullable, true, 'Arrow schema stays nullable');
-  t.end();
+  expect(tightenedTable, 'table is reused when nullability is unchanged').toBe(table);
+  expect(tightenedTable.schema?.fields[0].nullable, 'loaders.gl schema stays nullable').toBe(true);
+  expect(tightenedTable.data.schema.fields[0].nullable, 'Arrow schema stays nullable').toBe(true);
 });
-
-test('tightenArrowTableSchemaNullability#keeps non-nullable fields unchanged', async t => {
+test('tightenArrowTableSchemaNullability#keeps non-nullable fields unchanged', async () => {
   const table = makeTestArrowTable({
     values: ['a', 'b', 'c'],
     nullable: false
   });
-
   const tightenedTable = tightenArrowTableSchemaNullability(table);
-
-  t.equal(tightenedTable, table, 'table is reused when schema is already non-nullable');
-  t.equal(tightenedTable.schema?.fields[0].nullable, false, 'loaders.gl schema stays non-nullable');
-  t.equal(tightenedTable.data.schema.fields[0].nullable, false, 'Arrow schema stays non-nullable');
-  t.end();
+  expect(tightenedTable, 'table is reused when schema is already non-nullable').toBe(table);
+  expect(tightenedTable.schema?.fields[0].nullable, 'loaders.gl schema stays non-nullable').toBe(
+    false
+  );
+  expect(tightenedTable.data.schema.fields[0].nullable, 'Arrow schema stays non-nullable').toBe(
+    false
+  );
 });
-
 /** Test table construction options. */
 type TestArrowTableOptions = {
   values: (string | null)[];
   nullable: boolean;
 };
-
 /** Creates a single-column ArrowTable with explicit field nullability. */
 function makeTestArrowTable(options: TestArrowTableOptions): ArrowTable {
   const vector = arrow.vectorFromArray(options.values, new arrow.Utf8());
@@ -72,7 +61,6 @@ function makeTestArrowTable(options: TestArrowTableOptions): ArrowTable {
     })
   );
   const data = new arrow.Table([recordBatch]);
-
   return {
     shape: 'arrow-table',
     schema: convertArrowToSchema(data.schema),

--- a/modules/arrow/test/triangulate-on-worker.spec.ts
+++ b/modules/arrow/test/triangulate-on-worker.spec.ts
@@ -1,9 +1,12 @@
 // loaders.gl
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
-
 import * as arrow from 'apache-arrow';
-import test from 'test/utils/vitest-tape';
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
 import {
   triangulateOnWorker,
   triangulateWKBColumnOnWorker,
@@ -21,75 +24,37 @@ import {
   GEOARROW_POINT_FILE,
   GEOARROW_POLYGON_WKB_FILE
 } from '@loaders.gl/arrow/test/data/geoarrow/test-cases';
-
 // WORKER TESTS
-test('TriangulationWorker#plumbing', async t => {
+test('TriangulationWorker#plumbing', async () => {
   const sourceData = {
     operation: 'test',
     data: new ArrayBuffer(100)
   };
-
   const triangulatedData = await processOnWorker(
     TriangulationWorker,
     sourceData,
     getTriangulationWorkerOptions()
   );
-
-  t.ok(triangulatedData, 'Triangulation worker echoed input data');
-
-  t.rejects(
-    () =>
-      processOnWorker(TriangulationWorker, {operation: 'error'}, getTriangulationWorkerOptions()),
+  expect(triangulatedData, 'Triangulation worker echoed input data').toBeTruthy();
+  await expect(
+    processOnWorker(TriangulationWorker, {operation: 'error'}, getTriangulationWorkerOptions()),
     'Triangulation worker throws on incorrect operation'
-  );
-
+  ).rejects.toBeDefined();
   if (!isBrowser) {
     const workerFarm = WorkerFarm.getWorkerFarm({});
     workerFarm.destroy();
   }
-
-  t.end();
 });
-
-test.skip('triangulateOnWorker', async t => {
-  t.ok(triangulateOnWorker, 'triangulateOnWorker imported ok');
-  /*
-  const triangulatedData = await triangulateOnWorker(
-    {
-      data: new ArrayBuffer(100)
-    },
-    {
-      _workerType: 'test'
-    }
-  );
-
-  t.equal(triangulatedData.operation, 'test', 'Triangulation worker got correct return type');
-  if (triangulatedData.operation === 'test') {
-    t.equal(triangulatedData.data?.byteLength, 100, 'Triangulation worker echoed input data');
-  }
-
-  // t.rejec(() => await processOnWorker(TriangulationWorker, sourceData, {
-  //   operation: 'error',
-  //   _workerType: 'test'
-  // }), 'Triangulation worker throws on incorrect operation');
-
-  if (!isBrowser) {
-    const workerFarm = WorkerFarm.getWorkerFarm({});
-    workerFarm.destroy();
-  }
-  */
-  t.end();
+test.skip('triangulateOnWorker', async () => {
+  expect(triangulateOnWorker, 'triangulateOnWorker imported ok').toBeTruthy();
 });
-
-test('parseGeoArrowOnWorker', async t => {
+test('parseGeoArrowOnWorker', async () => {
   const arrowFile = await fetchFile(GEOARROW_POINT_FILE);
   const arrowContent = await arrowFile.arrayBuffer();
   const arrowTable = arrow.tableFromIPC(arrowContent);
-
   // simulate parsing 1st batch/chunk of the arrow data in web worker from e.g. kepler
   const geometryColumn = arrowTable.getChild('geometry');
   const geometryChunk = geometryColumn?.data[0];
-
   if (geometryChunk) {
     const parseGeoArrowInput: ParseGeoArrowInput = {
       operation: 'parse-geoarrow',
@@ -100,87 +65,68 @@ test('parseGeoArrowOnWorker', async t => {
       calculateMeanCenters: true,
       triangle: false
     };
-
     const parsedGeoArrowData = await parseGeoArrowOnWorker(parseGeoArrowInput, {
       ...getTriangulationWorkerOptions()
     });
-
     // kepler should await for the result from web worker and render the binary geometries
     const {binaryGeometries, bounds, featureTypes, meanCenters} =
       parsedGeoArrowData.binaryDataFromGeoArrow!;
-    t.ok(binaryGeometries, 'ParseGeoArrow worker returned binaryGeometries');
-    t.ok(bounds, 'ParseGeoArrow worker returned binaryGeometries');
-    t.ok(featureTypes, 'ParseGeoArrow worker returned featureTypes');
-    t.ok(meanCenters, 'ParseGeoArrow worker returned meanCenters');
+    expect(binaryGeometries, 'ParseGeoArrow worker returned binaryGeometries').toBeTruthy();
+    expect(bounds, 'ParseGeoArrow worker returned binaryGeometries').toBeTruthy();
+    expect(featureTypes, 'ParseGeoArrow worker returned featureTypes').toBeTruthy();
+    expect(meanCenters, 'ParseGeoArrow worker returned meanCenters').toBeTruthy();
   }
-  t.end();
 });
-
-test('triangulateWKBColumnOnWorker', async t => {
+test('triangulateWKBColumnOnWorker', async () => {
   const arrowFile = await fetchFile(GEOARROW_POLYGON_WKB_FILE);
   const arrowContent = await arrowFile.arrayBuffer();
   const arrowTable = arrow.tableFromIPC(arrowContent);
   const geometryColumn = arrowTable.getChild('geometry');
   const geometryChunk = geometryColumn?.data[0];
-
   if (geometryChunk) {
     const triangulateWKBColumnInput: TriangulateWKBColumnInput = {
       operation: 'triangulate-wkb-column',
       chunkData: getWorkerChunkData(geometryChunk),
       chunkIndex: 0
     };
-
     const result = await triangulateWKBColumnOnWorker(triangulateWKBColumnInput, {
       ...getTriangulationWorkerOptions()
     });
     const vertexIndexColumn = arrow.makeVector(rebuildWorkerChunkData(result.vertexIndexColumn));
     const vertexColumn = arrow.makeVector(rebuildWorkerChunkData(result.vertexColumn));
-
-    t.equals(result.chunkIndex, 0, 'worker preserves chunk index');
-    t.equals(
-      vertexIndexColumn.length,
-      geometryColumn?.length,
-      'vertex index column has one row per input geometry'
+    expect(result.chunkIndex, 'worker preserves chunk index').toBe(0);
+    expect(vertexIndexColumn.length, 'vertex index column has one row per input geometry').toBe(
+      geometryColumn?.length
     );
-    t.equals(
-      vertexColumn.length,
-      geometryColumn?.length,
-      'vertex column has one row per input geometry'
+    expect(vertexColumn.length, 'vertex column has one row per input geometry').toBe(
+      geometryColumn?.length
     );
-    t.ok(vertexIndexColumn.get(0)?.length > 0, 'first geometry has triangle indices');
-    t.ok(vertexColumn.get(0)?.length > 0, 'first geometry has vertices');
+    expect(
+      vertexIndexColumn.get(0)?.length > 0,
+      'first geometry has triangle indices'
+    ).toBeTruthy();
+    expect(vertexColumn.get(0)?.length > 0, 'first geometry has vertices').toBeTruthy();
   }
-
   if (!isBrowser) {
     const workerFarm = WorkerFarm.getWorkerFarm({});
     workerFarm.destroy();
   }
-
-  t.end();
 });
-
-test('triangulateWKBGeometryColumn', async t => {
+test('triangulateWKBGeometryColumn', async () => {
   const arrowFile = await fetchFile(GEOARROW_POLYGON_WKB_FILE);
   const arrowContent = await arrowFile.arrayBuffer();
   const arrowTable = arrow.tableFromIPC(arrowContent);
   const geometryColumn = arrowTable.getChild('geometry') as arrow.Vector<arrow.Binary> | null;
-
   if (geometryColumn) {
     const {vertexIndices, vertices} = triangulateWKBGeometryColumn(geometryColumn);
-
-    t.equals(
-      vertexIndices.length,
-      geometryColumn.length,
-      'vertex index column length matches input'
+    expect(vertexIndices.length, 'vertex index column length matches input').toBe(
+      geometryColumn.length
     );
-    t.equals(vertices.length, geometryColumn.length, 'vertex column length matches input');
-    t.ok(vertexIndices.get(0)?.length > 0, 'first geometry has triangle indices');
-    t.ok(vertices.get(0)?.length > 0, 'first geometry has vertices');
+    expect(vertices.length, 'vertex column length matches input').toBe(geometryColumn.length);
+    expect(vertexIndices.get(0)?.length > 0, 'first geometry has triangle indices').toBeTruthy();
+    expect(vertices.get(0)?.length > 0, 'first geometry has vertices').toBeTruthy();
   }
-
-  t.end();
 });
-
 /**
  * Copies an Arrow data chunk into the structured-cloneable shape used by the worker tests.
  * @param geometryChunk Arrow data chunk.
@@ -204,7 +150,6 @@ function getWorkerChunkData(
     dictionary: chunkCopy.dictionary
   };
 }
-
 /**
  * Returns runtime-specific options for the triangulation worker tests.
  * @returns Worker options that use the local browser worker or built Node worker bundle.
@@ -214,7 +159,6 @@ function getTriangulationWorkerOptions(): WorkerOptions {
     ? {_workerType: 'test'}
     : {triangulation: {workerUrl: 'modules/arrow/dist/triangulation-worker-node.js'}};
 }
-
 /**
  * Rebuilds an Arrow data chunk returned by the worker.
  * @param chunkData Worker chunk payload.

--- a/modules/arrow/test/utf8-utils.spec.ts
+++ b/modules/arrow/test/utf8-utils.spec.ts
@@ -2,11 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
-
+import {expect, test} from 'vitest';
 import {compareUTF8, parseUTF8BigInt, parseUTF8Boolean, parseUTF8Number} from '@loaders.gl/arrow';
-
-test('UTF8Utils#compareUTF8', t => {
+test('UTF8Utils#compareUTF8', () => {
   const bytes = new Uint8Array([
     0x70, 0x72, 0x65, 0x66, 0x69, 0x78, 0x3a, 0x61, 0x70, 0x70, 0x6c, 0x65, 0x7c, 0x62, 0x61, 0x6e,
     0x61, 0x6e, 0x61, 0x7c, 0xc3, 0xa4, 0x70, 0x70, 0x6c, 0x65, 0x7c, 0x61, 0x70, 0x70, 0x6c, 0x65,
@@ -20,137 +18,111 @@ test('UTF8Utils#compareUTF8', t => {
   const encodedAppleEnd = 26;
   const secondAppleStart = encodedAppleEnd + 1;
   const secondAppleEnd = 32;
-
-  t.equal(
+  expect(
     compareUTF8(bytes, appleStart, appleEnd, bytes, secondAppleStart, secondAppleEnd),
-    0,
     'compares equal byte ranges'
-  );
-  t.equal(
+  ).toBe(0);
+  expect(
     compareUTF8(bytes, appleStart, appleEnd, bytes, bananaStart, bananaEnd),
-    -1,
     'orders lower ASCII range before higher ASCII range'
-  );
-  t.equal(
+  ).toBe(-1);
+  expect(
     compareUTF8(bytes, bananaStart, bananaEnd, bytes, appleStart, appleEnd),
-    1,
     'orders higher ASCII range after lower ASCII range'
-  );
-  t.equal(
+  ).toBe(1);
+  expect(
     compareUTF8(bytes, appleStart, appleEnd, bytes, encodedAppleStart, encodedAppleEnd),
-    -1,
     'orders ASCII bytes before non-ASCII UTF-8 bytes'
-  );
-
+  ).toBe(-1);
   const prefixBytes = new Uint8Array([0x61, 0x7c, 0x61, 0x61]);
-  t.equal(compareUTF8(prefixBytes, 0, 1, prefixBytes, 2, 4), -1, 'orders prefix first');
-  t.equal(compareUTF8(prefixBytes, 2, 4, prefixBytes, 0, 1), 1, 'orders longer prefix match last');
-  t.equal(compareUTF8(prefixBytes, 0, 0, prefixBytes, 0, 0), 0, 'compares empty ranges');
-  t.throws(
+  expect(compareUTF8(prefixBytes, 0, 1, prefixBytes, 2, 4), 'orders prefix first').toBe(-1);
+  expect(compareUTF8(prefixBytes, 2, 4, prefixBytes, 0, 1), 'orders longer prefix match last').toBe(
+    1
+  );
+  expect(compareUTF8(prefixBytes, 0, 0, prefixBytes, 0, 0), 'compares empty ranges').toBe(0);
+  expect(
     () => compareUTF8(prefixBytes, -1, 1, prefixBytes, 0, 1),
-    /Invalid UTF-8 byte range/,
     'throws on invalid byte ranges'
-  );
-  t.throws(
+  ).toThrow(/Invalid UTF-8 byte range/);
+  expect(
     () => compareUTF8(prefixBytes, 0, 5, prefixBytes, 0, 1),
-    /Invalid UTF-8 byte range/,
     'throws when a byte range exceeds the buffer'
-  );
-
-  t.end();
+  ).toThrow(/Invalid UTF-8 byte range/);
 });
-
-test('UTF8Utils#parseUTF8Number', t => {
+test('UTF8Utils#parseUTF8Number', () => {
   const bytes = new Uint8Array([
     0x78, 0x7c, 0x2d, 0x34, 0x32, 0x7c, 0x20, 0x20, 0x33, 0x2e, 0x35, 0x65, 0x32, 0x20, 0x20, 0x7c,
     0x2d, 0x2e, 0x32, 0x35, 0x7c, 0x31, 0x2e, 0x7c, 0x2e, 0x7c, 0x31, 0x65, 0x7c, 0x49, 0x6e, 0x66,
     0x69, 0x6e, 0x69, 0x74, 0x79, 0x7c, 0x31, 0x2c, 0x30, 0x30, 0x30, 0x7c, 0x30, 0x2e, 0x33, 0x7c,
     0x79
   ]);
-
-  t.equal(parseUTF8Number(bytes, 2, 5), -42, 'parses signed integer numbers');
-  t.equal(parseUTF8Number(bytes, 6, 15), 350, 'parses trimmed decimal exponent numbers');
-  t.equal(parseUTF8Number(bytes, 16, 20), -0.25, 'parses leading-decimal numbers');
-  t.equal(parseUTF8Number(bytes, 21, 23), 1, 'parses trailing-decimal numbers');
-  t.equal(parseUTF8Number(bytes, 24, 25), undefined, 'rejects decimal point without digits');
-  t.equal(parseUTF8Number(bytes, 26, 28), undefined, 'rejects exponent without digits');
-  t.equal(parseUTF8Number(bytes, 29, 37), undefined, 'rejects Infinity');
-  t.equal(parseUTF8Number(bytes, 38, 43), undefined, 'rejects formatted numbers');
-  t.equal(parseUTF8Number(bytes, 44, 47), 0.3, 'parses decimals without incremental scale error');
-  t.equal(parseUTF8Number(bytes, 0, 0), undefined, 'rejects empty ranges');
-
+  expect(parseUTF8Number(bytes, 2, 5), 'parses signed integer numbers').toBe(-42);
+  expect(parseUTF8Number(bytes, 6, 15), 'parses trimmed decimal exponent numbers').toBe(350);
+  expect(parseUTF8Number(bytes, 16, 20), 'parses leading-decimal numbers').toBe(-0.25);
+  expect(parseUTF8Number(bytes, 21, 23), 'parses trailing-decimal numbers').toBe(1);
+  expect(parseUTF8Number(bytes, 24, 25), 'rejects decimal point without digits').toBe(undefined);
+  expect(parseUTF8Number(bytes, 26, 28), 'rejects exponent without digits').toBe(undefined);
+  expect(parseUTF8Number(bytes, 29, 37), 'rejects Infinity').toBe(undefined);
+  expect(parseUTF8Number(bytes, 38, 43), 'rejects formatted numbers').toBe(undefined);
+  expect(parseUTF8Number(bytes, 44, 47), 'parses decimals without incremental scale error').toBe(
+    0.3
+  );
+  expect(parseUTF8Number(bytes, 0, 0), 'rejects empty ranges').toBe(undefined);
   const extraBytes = new Uint8Array([
     0x2b, 0x31, 0x32, 0x7c, 0x31, 0x65, 0x2d, 0x32, 0x7c, 0x31, 0x65, 0x2b, 0x32, 0x7c, 0x09, 0x37,
     0x0d, 0x7c, 0x2b, 0x7c, 0x2d
   ]);
-  t.equal(parseUTF8Number(extraBytes, 0, 3), 12, 'parses plus-signed numbers');
-  t.equal(parseUTF8Number(extraBytes, 4, 8), 0.01, 'parses negative exponent numbers');
-  t.equal(parseUTF8Number(extraBytes, 9, 13), 100, 'parses plus-signed exponent numbers');
-  t.equal(parseUTF8Number(extraBytes, 14, 17), 7, 'trims ASCII control whitespace');
-  t.equal(parseUTF8Number(extraBytes, 18, 19), undefined, 'rejects plus sign without digits');
-  t.equal(parseUTF8Number(extraBytes, 20, 21), undefined, 'rejects minus sign without digits');
-  t.throws(
-    () => parseUTF8Number(extraBytes, 3, 2),
-    /Invalid UTF-8 byte range/,
-    'throws on invalid number byte ranges'
+  expect(parseUTF8Number(extraBytes, 0, 3), 'parses plus-signed numbers').toBe(12);
+  expect(parseUTF8Number(extraBytes, 4, 8), 'parses negative exponent numbers').toBe(0.01);
+  expect(parseUTF8Number(extraBytes, 9, 13), 'parses plus-signed exponent numbers').toBe(100);
+  expect(parseUTF8Number(extraBytes, 14, 17), 'trims ASCII control whitespace').toBe(7);
+  expect(parseUTF8Number(extraBytes, 18, 19), 'rejects plus sign without digits').toBe(undefined);
+  expect(parseUTF8Number(extraBytes, 20, 21), 'rejects minus sign without digits').toBe(undefined);
+  expect(() => parseUTF8Number(extraBytes, 3, 2), 'throws on invalid number byte ranges').toThrow(
+    /Invalid UTF-8 byte range/
   );
-
-  t.end();
 });
-
-test('UTF8Utils#parseUTF8BigInt', t => {
+test('UTF8Utils#parseUTF8BigInt', () => {
   const bytes = new Uint8Array([
     0x78, 0x7c, 0x2d, 0x34, 0x32, 0x7c, 0x20, 0x2b, 0x39, 0x30, 0x30, 0x37, 0x31, 0x39, 0x39, 0x32,
     0x35, 0x34, 0x37, 0x34, 0x30, 0x39, 0x39, 0x33, 0x20, 0x7c, 0x31, 0x32, 0x2e, 0x35, 0x7c, 0x31,
     0x65, 0x33, 0x7c
   ]);
-
-  t.equal(parseUTF8BigInt(bytes, 2, 5), -42n, 'parses signed bigint values');
-  t.equal(
+  expect(parseUTF8BigInt(bytes, 2, 5), 'parses signed bigint values').toBe(-42n);
+  expect(
     parseUTF8BigInt(bytes, 6, 25),
-    9007199254740993n,
     'parses trimmed bigint values beyond safe integer range'
-  );
-  t.equal(parseUTF8BigInt(bytes, 26, 30), undefined, 'rejects decimal bigint values');
-  t.equal(parseUTF8BigInt(bytes, 31, 34), undefined, 'rejects exponent bigint values');
-  t.equal(parseUTF8BigInt(bytes, 0, 0), undefined, 'rejects empty ranges');
-
+  ).toBe(9007199254740993n);
+  expect(parseUTF8BigInt(bytes, 26, 30), 'rejects decimal bigint values').toBe(undefined);
+  expect(parseUTF8BigInt(bytes, 31, 34), 'rejects exponent bigint values').toBe(undefined);
+  expect(parseUTF8BigInt(bytes, 0, 0), 'rejects empty ranges').toBe(undefined);
   const extraBytes = new Uint8Array([0x2b, 0x37, 0x7c, 0x2b, 0x7c, 0x20, 0x2d, 0x20]);
-  t.equal(parseUTF8BigInt(extraBytes, 0, 2), 7n, 'parses plus-signed bigint values');
-  t.equal(parseUTF8BigInt(extraBytes, 3, 4), undefined, 'rejects plus-only bigint values');
-  t.equal(parseUTF8BigInt(extraBytes, 5, 8), undefined, 'rejects minus-only bigint values');
-  t.throws(
+  expect(parseUTF8BigInt(extraBytes, 0, 2), 'parses plus-signed bigint values').toBe(7n);
+  expect(parseUTF8BigInt(extraBytes, 3, 4), 'rejects plus-only bigint values').toBe(undefined);
+  expect(parseUTF8BigInt(extraBytes, 5, 8), 'rejects minus-only bigint values').toBe(undefined);
+  expect(
     () => parseUTF8BigInt(extraBytes, Number.NaN, 1),
-    /Invalid UTF-8 byte range/,
     'throws on invalid bigint byte ranges'
-  );
-
-  t.end();
+  ).toThrow(/Invalid UTF-8 byte range/);
 });
-
-test('UTF8Utils#parseUTF8Boolean', t => {
+test('UTF8Utils#parseUTF8Boolean', () => {
   const bytes = new Uint8Array([
     0x78, 0x7c, 0x74, 0x72, 0x75, 0x65, 0x7c, 0x46, 0x41, 0x4c, 0x53, 0x45, 0x7c, 0x20, 0x54, 0x72,
     0x75, 0x65, 0x20, 0x7c, 0x30, 0x7c, 0x79, 0x65, 0x73, 0x7c
   ]);
-
-  t.equal(parseUTF8Boolean(bytes, 2, 6), true, 'parses true');
-  t.equal(parseUTF8Boolean(bytes, 7, 12), false, 'parses uppercase false');
-  t.equal(parseUTF8Boolean(bytes, 13, 19), true, 'parses mixed-case trimmed true');
-  t.equal(parseUTF8Boolean(bytes, 20, 21), undefined, 'rejects numeric booleans');
-  t.equal(parseUTF8Boolean(bytes, 22, 25), undefined, 'rejects non-boolean text');
-  t.equal(parseUTF8Boolean(bytes, 0, 0), undefined, 'rejects empty ranges');
-
+  expect(parseUTF8Boolean(bytes, 2, 6), 'parses true').toBe(true);
+  expect(parseUTF8Boolean(bytes, 7, 12), 'parses uppercase false').toBe(false);
+  expect(parseUTF8Boolean(bytes, 13, 19), 'parses mixed-case trimmed true').toBe(true);
+  expect(parseUTF8Boolean(bytes, 20, 21), 'rejects numeric booleans').toBe(undefined);
+  expect(parseUTF8Boolean(bytes, 22, 25), 'rejects non-boolean text').toBe(undefined);
+  expect(parseUTF8Boolean(bytes, 0, 0), 'rejects empty ranges').toBe(undefined);
   const extraBytes = new Uint8Array([
     0x66, 0x61, 0x6c, 0x73, 0x65, 0x7c, 0x54, 0x52, 0x55, 0x45, 0x53
   ]);
-  t.equal(parseUTF8Boolean(extraBytes, 0, 5), false, 'parses lowercase false');
-  t.equal(parseUTF8Boolean(extraBytes, 6, 11), undefined, 'rejects boolean prefixes');
-  t.throws(
+  expect(parseUTF8Boolean(extraBytes, 0, 5), 'parses lowercase false').toBe(false);
+  expect(parseUTF8Boolean(extraBytes, 6, 11), 'rejects boolean prefixes').toBe(undefined);
+  expect(
     () => parseUTF8Boolean(extraBytes, 0, 12),
-    /Invalid UTF-8 byte range/,
     'throws on invalid boolean byte ranges'
-  );
-
-  t.end();
+  ).toThrow(/Invalid UTF-8 byte range/);
 });

--- a/modules/schema-utils/test/lib/converters/convert.spec.ts
+++ b/modules/schema-utils/test/lib/converters/convert.spec.ts
@@ -2,11 +2,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {makeTableFromData, convert, type Converter, TableConverter} from '@loaders.gl/schema-utils';
 import {ArrowConverter} from '@loaders.gl/arrow';
-
-test('convert() selects direct converter over longer path', async t => {
+test('convert() selects direct converter over longer path', async () => {
   const calls: string[] = [];
   const directConverter: Converter<'start' | 'middle' | 'target'> = {
     id: 'direct',
@@ -14,7 +13,15 @@ test('convert() selects direct converter over longer path', async t => {
     to: ['target'],
     convert(input, targetShape) {
       calls.push(`direct:${targetShape}`);
-      return {shape: targetShape, value: (input as {value: number}).value + 10};
+      return {
+        shape: targetShape,
+        value:
+          (
+            input as {
+              value: number;
+            }
+          ).value + 10
+      };
     }
   };
   const firstHopConverter: Converter<'start' | 'middle' | 'target'> = {
@@ -23,7 +30,15 @@ test('convert() selects direct converter over longer path', async t => {
     to: ['middle'],
     convert(input, targetShape) {
       calls.push(`first-hop:${targetShape}`);
-      return {shape: targetShape, value: (input as {value: number}).value + 1};
+      return {
+        shape: targetShape,
+        value:
+          (
+            input as {
+              value: number;
+            }
+          ).value + 1
+      };
     }
   };
   const secondHopConverter: Converter<'start' | 'middle' | 'target'> = {
@@ -32,23 +47,30 @@ test('convert() selects direct converter over longer path', async t => {
     to: ['target'],
     convert(input, targetShape) {
       calls.push(`second-hop:${targetShape}`);
-      return {shape: targetShape, value: (input as {value: number}).value + 1};
+      return {
+        shape: targetShape,
+        value:
+          (
+            input as {
+              value: number;
+            }
+          ).value + 1
+      };
     }
   };
-
   const result = convert({shape: 'start', value: 1}, 'target', [
     firstHopConverter,
     secondHopConverter,
     directConverter
-  ]) as {shape: string; value: number};
-
-  t.equal(result.shape, 'target', 'selected the target shape');
-  t.equal(result.value, 11, 'used the direct path result');
-  t.deepEqual(calls, ['direct:target'], 'only executed the direct converter');
-  t.end();
+  ]) as {
+    shape: string;
+    value: number;
+  };
+  expect(result.shape, 'selected the target shape').toBe('target');
+  expect(result.value, 'used the direct path result').toBe(11);
+  expect(calls, 'only executed the direct converter').toEqual(['direct:target']);
 });
-
-test('convert() rejects ambiguous source shape detection', async t => {
+test('convert() rejects ambiguous source shape detection', async () => {
   const firstConverter: Converter<'alpha' | 'target'> = {
     id: 'alpha',
     from: ['alpha'],
@@ -71,56 +93,55 @@ test('convert() rejects ambiguous source shape detection', async t => {
       return input;
     }
   };
-
-  t.throws(
+  expect(
     () =>
       convert({value: 1}, 'target', [
         firstConverter as Converter<string>,
         secondConverter as Converter<string>
       ]),
-    /Ambiguous source shape/,
     'throws on ambiguous source shape'
-  );
-  t.end();
+  ).toThrow(/Ambiguous source shape/);
 });
-
-test('convert() forwards options to each step', async t => {
+test('convert() forwards options to each step', async () => {
   const seenOptions: unknown[] = [];
-  const converter: Converter<'start' | 'target', {flag: boolean}> = {
+  const converter: Converter<
+    'start' | 'target',
+    {
+      flag: boolean;
+    }
+  > = {
     id: 'options',
     from: ['start'],
     to: ['target'],
     convert(input, targetShape, options) {
       seenOptions.push(options);
-      return {...(input as {shape: string}), shape: targetShape};
+      return {
+        ...(input as {
+          shape: string;
+        }),
+        shape: targetShape
+      };
     }
   };
-
   convert({shape: 'start'}, 'target', [converter], {flag: true});
-  t.deepEqual(seenOptions, [{flag: true}], 'forwarded options to the step');
-  t.end();
+  expect(seenOptions, 'forwarded options to the step').toEqual([{flag: true}]);
 });
-
-test('convert() performs a real arrow roundtrip with explicit converters', async t => {
+test('convert() performs a real arrow roundtrip with explicit converters', async () => {
   const table = makeTableFromData([
     {name: 'alpha', value: 1},
     {name: 'beta', value: 2}
   ]);
-
   const arrowTable = convert(table, 'arrow', [ArrowConverter, TableConverter]);
   const roundTrippedTable = convert(arrowTable, 'object-row-table', [ArrowConverter]) as {
     shape: string;
     data: Array<Record<string, unknown>>;
   };
-
-  t.equal(roundTrippedTable.shape, 'object-row-table', 'returned the requested table shape');
-  t.deepEqual(
+  expect(roundTrippedTable.shape, 'returned the requested table shape').toBe('object-row-table');
+  expect(
     roundTrippedTable.data,
-    [
-      {name: 'alpha', value: 1},
-      {name: 'beta', value: 2}
-    ],
     'round-tripped table rows through the generic convert dispatcher'
-  );
-  t.end();
+  ).toEqual([
+    {name: 'alpha', value: 1},
+    {name: 'beta', value: 2}
+  ]);
 });

--- a/modules/schema-utils/test/lib/mesh/convert-mesh-to-table.spec.ts
+++ b/modules/schema-utils/test/lib/mesh/convert-mesh-to-table.spec.ts
@@ -2,110 +2,98 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import * as arrow from 'apache-arrow';
-
 import type {Mesh} from '@loaders.gl/schema';
 import {indexedMeshArrowSchema, meshArrowSchema} from '@loaders.gl/schema';
 import {convertMeshToTable, convertTableToMesh, deduceMeshSchema} from '@loaders.gl/schema-utils';
 import {validateArrowTableSchema} from '@loaders.gl/arrow';
-
-test('meshArrowSchema', t => {
-  t.equal(meshArrowSchema.fields.length, 1, 'mesh schema has one predefined field');
-
+test('meshArrowSchema', () => {
+  expect(meshArrowSchema.fields.length, 'mesh schema has one predefined field').toBe(1);
   const positionField = meshArrowSchema.fields[0];
-  t.equal(positionField.name, 'POSITION', 'position field is first');
-  t.notOk(positionField.nullable, 'position field is required');
-  t.ok(positionField.type instanceof arrow.FixedSizeList, 'position is a fixed-size list');
-  t.equal(positionField.type.listSize, 3, 'position has XYZ tuple size');
-  t.ok(positionField.type.children[0].type instanceof arrow.Float32, 'position values are float32');
-
-  t.end();
+  expect(positionField.name, 'position field is first').toBe('POSITION');
+  expect(positionField.nullable, 'position field is required').toBeFalsy();
+  expect(
+    positionField.type instanceof arrow.FixedSizeList,
+    'position is a fixed-size list'
+  ).toBeTruthy();
+  expect(positionField.type.listSize, 'position has XYZ tuple size').toBe(3);
+  expect(
+    positionField.type.children[0].type instanceof arrow.Float32,
+    'position values are float32'
+  ).toBeTruthy();
 });
-
-test('indexedMeshArrowSchema', t => {
-  t.equal(indexedMeshArrowSchema.fields.length, 2, 'indexed schema has two predefined fields');
-  t.equal(indexedMeshArrowSchema.fields[0].name, 'POSITION', 'position field is first');
-
+test('indexedMeshArrowSchema', () => {
+  expect(indexedMeshArrowSchema.fields.length, 'indexed schema has two predefined fields').toBe(2);
+  expect(indexedMeshArrowSchema.fields[0].name, 'position field is first').toBe('POSITION');
   const indicesField = indexedMeshArrowSchema.fields[1];
-  t.equal(indicesField.name, 'indices', 'indices field is second');
-  t.ok(indicesField.nullable, 'indices field is nullable');
-  t.ok(indicesField.type instanceof arrow.List, 'indices is a list');
-  t.ok(indicesField.type.children[0].type instanceof arrow.Int32, 'indices values are int32');
-
-  t.end();
+  expect(indicesField.name, 'indices field is second').toBe('indices');
+  expect(indicesField.nullable, 'indices field is nullable').toBeTruthy();
+  expect(indicesField.type instanceof arrow.List, 'indices is a list').toBeTruthy();
+  expect(
+    indicesField.type.children[0].type instanceof arrow.Int32,
+    'indices values are int32'
+  ).toBeTruthy();
 });
-
-test('convertMeshToTable#unindexed mesh Arrow table round trip', t => {
+test('convertMeshToTable#unindexed mesh Arrow table round trip', () => {
   const mesh = makeMesh();
   const table = convertMeshToTable(mesh, 'arrow-table');
-
-  t.equal(table.shape, 'arrow-table', 'table has arrow-table shape');
+  expect(table.shape, 'table has arrow-table shape').toBe('arrow-table');
   validateArrowTableSchema(table.data, meshArrowSchema, {schemaName: 'Mesh Arrow table'});
-  t.deepEqual(
+  expect(
     table.data.schema.fields.map(field => field.name),
-    ['POSITION', 'NORMAL', 'intensity'],
     'predefined position column is first'
-  );
+  ).toEqual(['POSITION', 'NORMAL', 'intensity']);
   const intensityColumn = table.data.getChild('intensity');
-  t.ok(intensityColumn, 'scalar intensity column is present');
-  t.notOk(
+  expect(intensityColumn, 'scalar intensity column is present').toBeTruthy();
+  expect(
     intensityColumn!.type instanceof arrow.FixedSizeList,
     'scalar intensity column is not a fixed-size list'
-  );
-  t.ok(intensityColumn!.type instanceof arrow.Uint16, 'scalar intensity column is uint16');
-  t.equal(intensityColumn!.get(0), 10, 'scalar intensity reads as a scalar');
-  t.notOk(table.data.getChild('indices'), 'indices column is absent');
-
+  ).toBeFalsy();
+  expect(
+    intensityColumn!.type instanceof arrow.Uint16,
+    'scalar intensity column is uint16'
+  ).toBeTruthy();
+  expect(intensityColumn!.get(0), 'scalar intensity reads as a scalar').toBe(10);
+  expect(table.data.getChild('indices'), 'indices column is absent').toBeFalsy();
   const roundTripMesh = convertTableToMesh(table);
-  t.notOk(roundTripMesh.indices, 'round trip mesh has no top-level indices');
-  t.deepEqual(
+  expect(roundTripMesh.indices, 'round trip mesh has no top-level indices').toBeFalsy();
+  expect(
     Array.from(roundTripMesh.attributes.POSITION.value),
-    Array.from(mesh.attributes.POSITION.value),
     'round trip preserves positions'
-  );
-  t.equal(roundTripMesh.attributes.POSITION.size, 3, 'round trip preserves position size');
-  t.deepEqual(
+  ).toEqual(Array.from(mesh.attributes.POSITION.value));
+  expect(roundTripMesh.attributes.POSITION.size, 'round trip preserves position size').toBe(3);
+  expect(
     Array.from(roundTripMesh.attributes.intensity.value),
-    [10, 20, 30],
     'round trip preserves scalar intensity'
-  );
-  t.equal(roundTripMesh.attributes.intensity.size, 1, 'round trip preserves scalar size');
-
-  t.end();
+  ).toEqual([10, 20, 30]);
+  expect(roundTripMesh.attributes.intensity.size, 'round trip preserves scalar size').toBe(1);
 });
-
-test('convertMeshToTable#indexed mesh Arrow table round trip', t => {
+test('convertMeshToTable#indexed mesh Arrow table round trip', () => {
   const mesh = makeMesh(new Uint16Array([0, 1, 2]));
   const table = convertMeshToTable(mesh, 'arrow-table');
   validateArrowTableSchema(table.data, indexedMeshArrowSchema, {
     schemaName: 'IndexedMesh Arrow table'
   });
-
-  t.deepEqual(
+  expect(
     table.data.schema.fields.map(field => field.name),
-    ['POSITION', 'indices', 'NORMAL', 'intensity'],
     'indexed schema fields are first'
-  );
-
+  ).toEqual(['POSITION', 'indices', 'NORMAL', 'intensity']);
   const indicesColumn = table.data.getChild('indices');
-  t.ok(indicesColumn, 'indices column is present');
-  t.deepEqual(Array.from(indicesColumn!.get(0)!), [0, 1, 2], 'indices are stored in row 0');
-  t.equal(indicesColumn!.get(1), null, 'remaining rows have null indices');
-
+  expect(indicesColumn, 'indices column is present').toBeTruthy();
+  expect(Array.from(indicesColumn!.get(0)!), 'indices are stored in row 0').toEqual([0, 1, 2]);
+  expect(indicesColumn!.get(1), 'remaining rows have null indices').toBe(null);
   const roundTripMesh = convertTableToMesh(table);
-  t.ok(roundTripMesh.indices, 'round trip mesh restores top-level indices');
-  t.notOk(roundTripMesh.attributes.indices, 'round trip mesh does not create an indices attribute');
-  t.deepEqual(
-    Array.from(roundTripMesh.indices!.value),
-    [0, 1, 2],
-    'round trip mesh preserves indices'
-  );
-
-  t.end();
+  expect(roundTripMesh.indices, 'round trip mesh restores top-level indices').toBeTruthy();
+  expect(
+    roundTripMesh.attributes.indices,
+    'round trip mesh does not create an indices attribute'
+  ).toBeFalsy();
+  expect(Array.from(roundTripMesh.indices!.value), 'round trip mesh preserves indices').toEqual([
+    0, 1, 2
+  ]);
 });
-
-test('convertTableToMesh#honors FixedSizeList chunk offsets', t => {
+test('convertTableToMesh#honors FixedSizeList chunk offsets', () => {
   const attributes = {
     POSITION: {
       value: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
@@ -132,19 +120,13 @@ test('convertTableToMesh#honors FixedSizeList chunk offsets', t => {
   const offsetTable = new arrow.Table(table.data.schema, {
     POSITION: new arrow.Vector([offsetPositionData])
   });
-
   const roundTripMesh = convertTableToMesh({...table, data: offsetTable});
-
-  t.deepEqual(
+  expect(
     Array.from(roundTripMesh.attributes.POSITION.value),
-    [1, 0, 0, 0, 1, 0],
     'round trip uses the chunk offset when flattening values'
-  );
-  t.equal(roundTripMesh.attributes.POSITION.size, 3, 'round trip preserves position size');
-
-  t.end();
+  ).toEqual([1, 0, 0, 0, 1, 0]);
+  expect(roundTripMesh.attributes.POSITION.size, 'round trip preserves position size').toBe(3);
 });
-
 function makeMesh(indices?: Uint16Array): Mesh {
   const attributes = {
     POSITION: {
@@ -162,7 +144,6 @@ function makeMesh(indices?: Uint16Array): Mesh {
   };
   const topology = indices ? 'triangle-list' : 'point-list';
   const mode = indices ? 4 : 0;
-
   return {
     schema: deduceMeshSchema(attributes, {topology, mode: String(mode)}),
     attributes,

--- a/modules/schema-utils/test/lib/schema/convert-arrow-schema.node.spec.ts
+++ b/modules/schema-utils/test/lib/schema/convert-arrow-schema.node.spec.ts
@@ -2,35 +2,26 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import * as arrow from 'apache-arrow';
-
 import {convertArrowToSchema, convertSchemaToArrow} from '@loaders.gl/schema-utils';
-
-test('convertArrowSchema handles FixedSizeBinary fields', t => {
+test('convertArrowSchema handles FixedSizeBinary fields', () => {
   const arrowSchema = new arrow.Schema([
     new arrow.Field('id', new arrow.Int32(), false),
     new arrow.Field('hash', new arrow.FixedSizeBinary(16), true)
   ]);
-
   const schema = convertArrowToSchema(arrowSchema);
-
-  t.deepEqual(
-    schema.fields[1].type,
-    {type: 'fixed-size-binary', byteWidth: 16},
-    'serializes fixed-size binary fields'
-  );
-
+  expect(schema.fields[1].type, 'serializes fixed-size binary fields').toEqual({
+    type: 'fixed-size-binary',
+    byteWidth: 16
+  });
   const roundTrippedSchema = convertSchemaToArrow(schema);
-  t.equal(
+  expect(
     roundTrippedSchema.fields[1].type.constructor,
-    arrow.FixedSizeBinary,
     'deserializes fixed-size binary fields'
-  );
-  t.equal(
+  ).toBe(arrow.FixedSizeBinary);
+  expect(
     (roundTrippedSchema.fields[1].type as arrow.FixedSizeBinary).byteWidth,
-    16,
     'preserves byte width'
-  );
-  t.end();
+  ).toBe(16);
 });

--- a/modules/schema-utils/test/lib/table/convert-table.spec.ts
+++ b/modules/schema-utils/test/lib/table/convert-table.spec.ts
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {makeTableFromData} from '@loaders.gl/schema-utils';
-
 // import * from '../../data/table/tables';
 import {
   // ALL_TYPES_DICTIONARY_PLAIN_TABLE,
@@ -25,9 +24,7 @@ import {
   // LZ4_RAW_COMPRESSED_PLAIN_TABLE,
   // NON_HADOOP_LZ4_COMPRESSED_PLAIN_TABLE
 } from '../../data/table/tables';
-
-test('makeTableFromData', async t => {
+test('makeTableFromData', async () => {
   const table = makeTableFromData(ALL_TYPES_PLAIN_PLAIN_TABLE);
-  t.equal(table.data.length, 8);
-  t.end();
+  expect(table.data.length).toBe(8);
 });

--- a/modules/schema-utils/test/lib/table/make-table-from-batches.spec.ts
+++ b/modules/schema-utils/test/lib/table/make-table-from-batches.spec.ts
@@ -2,14 +2,13 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {
   makeTableFromBatches,
   makeTableFromData,
   makeBatchFromTable,
   getTableLength
 } from '../../../src'; // '@loaders.gl/schema'; why don't we get typings?
-
 // import * from '../../data/table/tables';
 import {
   TABLES,
@@ -31,21 +30,17 @@ import {
   // LZ4_RAW_COMPRESSED_PLAIN_TABLE,
   // NON_HADOOP_LZ4_COMPRESSED_PLAIN_TABLE
 } from '../../data/table/tables';
-
-test.skip('makeTableFromBatches', async t => {
+test.skip('makeTableFromBatches', async () => {
   const tempTable = makeTableFromData(ALL_TYPES_PLAIN_PLAIN_TABLE);
   const batch = makeBatchFromTable(tempTable);
   const table = await makeTableFromBatches([batch]);
-  t.equal(getTableLength(table!), 8);
-  t.end();
+  expect(getTableLength(table!)).toBe(8);
 });
-
-test('makeTableFromBatches', async t => {
+test('makeTableFromBatches', async () => {
   for (const tc of TABLES) {
     const tempTable = makeTableFromData(tc.table);
     const batch = makeBatchFromTable(tempTable);
     const table = await makeTableFromBatches([batch]);
-    t.equal(getTableLength(table!), tc.length, tc.name);
+    expect(getTableLength(table!), tc.name).toBe(tc.length);
   }
-  t.end();
 });

--- a/modules/schema-utils/test/lib/table/make-table.spec.ts
+++ b/modules/schema-utils/test/lib/table/make-table.spec.ts
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {makeTableFromData} from '@loaders.gl/schema-utils';
-
 // import * from '../../data/table/tables';
 import {
   TABLES,
@@ -26,17 +25,13 @@ import {
   // LZ4_RAW_COMPRESSED_PLAIN_TABLE,
   // NON_HADOOP_LZ4_COMPRESSED_PLAIN_TABLE
 } from '../../data/table/tables';
-
-test.skip('makeTableFromData', async t => {
+test.skip('makeTableFromData', async () => {
   const table = makeTableFromData(ALL_TYPES_PLAIN_PLAIN_TABLE);
-  t.equal(table.data.length, 8);
-  t.end();
+  expect(table.data.length).toBe(8);
 });
-
-test('makeTableFromData', async t => {
+test('makeTableFromData', async () => {
   for (const tc of TABLES) {
     const table = makeTableFromData(tc.table);
-    t.equal(table.data.length, tc.length, tc.name);
+    expect(table.data.length, tc.name).toBe(tc.length);
   }
-  t.end();
 });


### PR DESCRIPTION
## Goals

- Migrate two related high-coverage modules from Tape compatibility tests to native Vitest.
- Preserve fast, hermetic test execution while grouping the work into one review.
- Continue shrinking the repository Tape allowlist without changing production behavior.

## Changes

- Migrated seven Arrow suites to native Vitest assertions and lifecycle handling.
- Migrated six schema-utils suites, including table, mesh, converter, and Arrow schema tests.
- Converted Arrow loader/writer conformance calls to native helper overloads.
- Preserved the Node-only Arrow schema test in its Node project.
- No production code or coverage thresholds changed.

## Validation

- `yarn build`
- `yarn build-workers`
- `yarn lint fix`
- `yarn test-audit` (598 files, 0 Tape, 0 violations)
- Focused browser tests: 167 passed, 3 existing skips
- Focused Node tests: 1 passed
- Focused browser coverage collection completed successfully