### PR TITLE
feat(wms): complete GML and WFS conformance tranche

### DIFF
--- a/docs/modules/wms/formats/gml.md
+++ b/docs/modules/wms/formats/gml.md
@@ -15,6 +15,24 @@ GML is a very ambitious format, with a large set of primitives and many ways to 
 
 The `GMLLoader` supports parsing the standard geospatial subset of features (points, multipoints, lines, linestrings, polygons and multipolygons), on a "best effort" basis. Its `parseInBatches` entry point emits feature collections as GML members arrive, so WFS responses do not need to be buffered in full. Because of this, the `GMLLoader` is treated as a geospatial loader and can return GeoJSON style output.
 
+GML 2 coordinate encodings (`coord` and `coordinates`) and GML 3 encodings (`pos`, `posList`,
+curves, surfaces, and dimensional positions) are accepted. Namespace prefixes are not required
+to be named `gml`; the parser matches the namespace-local names used by GML 2 and GML 3.2
+application schemas. When an application has a DescribeFeatureType schema, scalar property types
+can be supplied to preserve values while parsing:
+
+```ts
+import {GMLLoader} from '@loaders.gl/wms/bundled';
+
+const features = GMLLoader.parseTextSync!(xml, {
+  gml: {propertyTypes: {population: 'integer', active: 'boolean'}}
+});
+```
+
+Supported scalar type hints are `string`, `boolean`, `integer`, `number`, `date`, and `date-time`.
+Unknown or untyped properties remain strings or structured XML values, preserving the server
+response instead of guessing types.
+
 A fun read that illustrates the challenge is the [GML madness](http://erouault.blogspot.com/2014/04/gml-madness.html) article by Even Rouault.
 
 ## Examples

--- a/docs/modules/wms/formats/wfs.md
+++ b/docs/modules/wms/formats/wfs.md
@@ -61,6 +61,28 @@ The batch API parses GML feature members incrementally and supports `geojson`, `
 Arrow output through the usual `format` parameter. Complete GML responses are converted to the
 same normalized vector-source outputs.
 
+### Paging and filtering
+
+The typed `getFeaturesURL` API exposes the standard WFS query controls. WFS 2.0 uses `count` and
+`startIndex`; WFS 1.1 requests automatically translate `count` to `maxFeatures`:
+
+```ts
+const requestUrl = source.getFeaturesURL({
+  version: '2.0.0',
+  typeName: 'roads',
+  bbox: [-10, 35, 10, 55, 'EPSG:4326'],
+  count: 1000,
+  startIndex: 2000,
+  propertyName: ['name', 'geometry'],
+  filter: '<fes:Filter>...</fes:Filter>',
+  sortBy: 'name A'
+});
+```
+
+`resultType: 'hits'` can be used for servers that support count-only requests. Filter XML is
+passed through as a request parameter; applications should use their server's supported FES
+version and escape or encode user-controlled values before constructing it.
+
 ## Features
 
 A WFS server usually serves the map in a bitmap format, e.g. PNG, GIF, JPEG. In addition, vector graphics can be included, such as points, lines, curves and text, expressed in SVG or WebCGM format. The MIME types of the `GetMap` request can be inspected in the response to the `GetCapabilities` request.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -63,7 +63,7 @@ abstraction. Costs are relative engineering estimates; impact describes the user
 | 7 | WMTS matrix sets and ArcGIS tile-grid negotiation | Planned | L | Correct tile requests across heterogeneous grids |
 | 8 | CRS normalization, axis order, reprojection-aware requests, and edge cases | Planned | XL | Correct behavior across projections, antimeridian, and polar regions |
 | 9 | Shared service lifecycle for retries, cancellation, caching, auth, and telemetry | Planned | XL | Consistent operational behavior without protocol-specific duplication |
-| 10 | Deep GML/WFS conformance, paging, filtering, schema-aware properties, and fixtures | In progress | XL | Production-scale standards interoperability |
+| 10 | Deep GML/WFS conformance, paging, filtering, schema-aware properties, and fixtures | Complete | XL | Production-scale standards interoperability |
 | 11 | Capability-driven source configuration and endpoint negotiation | Planned | L | Better defaults when applications provide incomplete service information |
 | 12 | Analytical raster preservation: NoData, bands, statistics, and rendering rules | Complete | L | Faithful scientific imagery workflows |
 | 13 | ArcGIS capability graph and requirement-based service selection | Assumed complete | M | Discover, compare, and select service endpoints explicitly |

--- a/modules/wms/src/gml-loader-with-parser.ts
+++ b/modules/wms/src/gml-loader-with-parser.ts
@@ -3,14 +3,19 @@
 // Copyright (c) vis.gl contributors
 
 import type {LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';
-import type {GMLFeatureCollection, Geometry} from './lib/parsers/gml/parse-gml';
+import type {GMLFeatureCollection, Geometry, GMLPropertyType} from './lib/parsers/gml/parse-gml';
 import {parseGML} from './lib/parsers/gml/parse-gml';
 import {GMLLoader as GMLLoaderMetadata} from './gml-loader';
 
 const {preload: _GMLLoaderPreload, ...GMLLoaderMetadataWithoutPreload} = GMLLoaderMetadata;
 
 export type GMLLoaderOptions = LoaderOptions & {
-  gml?: {batchSize?: number};
+  gml?: {
+    /** Number of feature members emitted in each streaming batch. */
+    batchSize?: number;
+    /** XML Schema scalar types keyed by the local feature property name. */
+    propertyTypes?: Record<string, GMLPropertyType>;
+  };
 };
 
 /**
@@ -19,8 +24,9 @@ export type GMLLoaderOptions = LoaderOptions & {
 export const GMLLoaderWithParser = {
   ...GMLLoaderMetadataWithoutPreload,
   parse: async (arrayBuffer: ArrayBuffer, options?: GMLLoaderOptions) =>
-    parseGML(new TextDecoder().decode(arrayBuffer), options),
-  parseTextSync: (text: string, options?: GMLLoaderOptions) => parseGML(text, options),
+    parseGML(new TextDecoder().decode(arrayBuffer), options?.gml || options),
+  parseTextSync: (text: string, options?: GMLLoaderOptions) =>
+    parseGML(text, options?.gml || options),
   parseInBatches: parseGMLInBatches
 } as const satisfies LoaderWithParser<
   Geometry | GMLFeatureCollection | null,
@@ -47,7 +53,7 @@ async function* parseGMLInBatches(
       })
     );
     for (const fragment of fragments) {
-      const parsed = parseGMLFeatureFragment(fragment, options);
+      const parsed = parseGMLFeatureFragment(fragment, options?.gml || options);
       if (parsed && parsed.type === 'FeatureCollection') features.push(...parsed.features);
       if (features.length >= batchSize) {
         yield {type: 'FeatureCollection', features: features.splice(0, batchSize)};
@@ -55,7 +61,7 @@ async function* parseGMLInBatches(
     }
   }
   for (const fragment of parser.finish(decoder.decode())) {
-    const parsed = parseGMLFeatureFragment(fragment, options);
+    const parsed = parseGMLFeatureFragment(fragment, options?.gml || options);
     if (parsed && parsed.type === 'FeatureCollection') features.push(...parsed.features);
   }
   if (features.length) yield {type: 'FeatureCollection', features};
@@ -63,7 +69,7 @@ async function* parseGMLInBatches(
 
 function parseGMLFeatureFragment(
   fragment: string,
-  options?: GMLLoaderOptions
+  options?: GMLLoaderOptions['gml'] | GMLLoaderOptions
 ): Geometry | GMLFeatureCollection | null {
   return fragment.match(/<[^/!?][^>]*featureMember\b/i)
     ? parseGML(fragment, options)

--- a/modules/wms/src/gml-loader.ts
+++ b/modules/wms/src/gml-loader.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import type {Loader, LoaderOptions} from '@loaders.gl/loader-utils';
-import type {GMLFeatureCollection, Geometry} from './lib/parsers/gml/parse-gml';
+import type {GMLFeatureCollection, Geometry, GMLPropertyType} from './lib/parsers/gml/parse-gml';
 
 import {GMLFormat} from './wms-format';
 // __VERSION__ is injected by babel-plugin-version-inline
@@ -14,6 +14,8 @@ export type GMLLoaderOptions = LoaderOptions & {
   gml?: {
     /** Number of feature members emitted in each streaming batch. */
     batchSize?: number;
+    /** XML Schema scalar types keyed by the local feature property name. */
+    propertyTypes?: Record<string, GMLPropertyType>;
   };
 };
 

--- a/modules/wms/src/lib/parsers/gml/parse-gml.ts
+++ b/modules/wms/src/lib/parsers/gml/parse-gml.ts
@@ -497,8 +497,10 @@ export function parsePolygonOrRectangle(
 
   const pointLists: Position[][] = [parseExteriorOrInterior(exterior, options, childContext)];
 
-  const interiors = xml['gml:interior'];
-  for (const interior of Array.isArray(interiors) ? interiors : interiors ? [interiors] : []) {
+  const interiors = Object.entries(xml || {})
+    .filter(([key]) => stripNamespace(key) === 'interior')
+    .flatMap(([, value]) => (Array.isArray(value) ? value : [value]));
+  for (const interior of interiors) {
     pointLists.push(parseExteriorOrInterior(interior, options, childContext));
   }
 

--- a/modules/wms/src/lib/parsers/gml/parse-gml.ts
+++ b/modules/wms/src/lib/parsers/gml/parse-gml.ts
@@ -48,9 +48,21 @@ function noTransform(...coords) {
 export type {Geometry};
 
 export type ParseGMLOptions = {
-  transformCoords?: Function;
+  /** Coordinate transformation applied to every decoded position. */
+  transformCoords?: (...coordinates: number[]) => Position;
   stride?: 2 | 3 | 4;
+  /** Optional XML Schema types keyed by the local feature property name. */
+  propertyTypes?: Record<string, GMLPropertyType>;
 };
+
+/** XML Schema scalar types understood by the GML property decoder. */
+export type GMLPropertyType =
+  | 'string'
+  | 'boolean'
+  | 'integer'
+  | 'number'
+  | 'date'
+  | 'date-time';
 
 export type ParseGMLContext = {
   srsDimension?: number;
@@ -111,7 +123,8 @@ export function parseGMLFeature(inputXML: any, options: ParseGMLOptions = {}): G
     ) {
       continue;
     }
-    properties[stripNamespace(key)] = extractXMLValue(value);
+    const propertyName = stripNamespace(key);
+    properties[propertyName] = extractXMLValue(value, options.propertyTypes?.[propertyName]);
   }
 
   const id = findFeatureId(feature);
@@ -130,55 +143,55 @@ export function parseGMLToGeometry(
 
   const [name, xml] = getFirstKeyValue(inputXML);
 
-  switch (name) {
-    case 'gml:Point':
+  switch (stripNamespace(name)) {
+    case 'Point':
       geometry = {type: 'Point', coordinates: parsePoint(xml, options, childContext)};
       break;
 
-    case 'gml:MultiPoint':
+    case 'MultiPoint':
       geometry = {type: 'MultiPoint', coordinates: parseMultiPoint(xml, options, childContext)};
       break;
 
-    case 'gml:LineString':
+    case 'LineString':
       geometry = {
         type: 'LineString',
         coordinates: parseLinearRingOrLineString(xml, options, childContext)
       };
       break;
 
-    case 'gml:Curve':
+    case 'Curve':
       geometry = {type: 'LineString', coordinates: parseCurve(xml, options, childContext)};
       break;
 
-    case 'gml:MultiLineString':
-    case 'gml:MultiCurve':
+    case 'MultiLineString':
+    case 'MultiCurve':
       geometry = {
         type: 'MultiLineString',
         coordinates: parseMultiLineString(xml, options, childContext)
       };
       break;
 
-    case 'gml:MultiPolygon':
+    case 'MultiPolygon':
       geometry = {
         type: 'MultiPolygon',
         coordinates: parseMultiPolygon(xml, options, childContext)
       };
       break;
 
-    case 'gml:Polygon':
-    case 'gml:Rectangle':
+    case 'Polygon':
+    case 'Rectangle':
       geometry = {
         type: 'Polygon',
         coordinates: parsePolygonOrRectangle(xml, options, childContext)
       };
       break;
-    case 'gml:Surface':
+    case 'Surface':
       geometry = {
         type: 'MultiPolygon',
         coordinates: parseSurface(xml, options, childContext)
       };
       break;
-    case 'gml:MultiSurface':
+    case 'MultiSurface':
       geometry = {
         type: 'MultiPolygon',
         coordinates: parseMultiSurface(xml, options, childContext)
@@ -347,19 +360,19 @@ export function parseLinearRingOrLineString(
     points = parsePosList(posList, options, childContext);
   } else {
     for (const [childName, childXML] of Object.entries(xml)) {
-      switch (childName) {
-        case 'gml:Point':
+      switch (stripNamespace(childName)) {
+        case 'Point':
           points.push(parsePoint(childXML, options, childContext));
           break;
-        case 'gml:pos':
+        case 'pos':
           points.push(parsePos(childXML, options, childContext));
           break;
-        case 'gml:coord':
+        case 'coord':
           for (const coord of Array.isArray(childXML) ? childXML : [childXML]) {
             points.push(parseLegacyCoord(coord, options));
           }
           break;
-        case 'gml:coordinates':
+        case 'coordinates':
           points.push(...parseLegacyCoordinates(textOf(childXML), options, childContext));
           break;
         default:
@@ -382,8 +395,8 @@ export function parseCurveSegments(
   const points: Position[] = [];
 
   for (const [childName, childXML] of Object.entries(xml)) {
-    switch (childName) {
-      case 'gml:LineStringSegment':
+    switch (stripNamespace(childName)) {
+      case 'LineStringSegment':
         const points2 = parseLinearRingOrLineString(childXML, options, context);
 
         // remove overlapping
@@ -416,8 +429,8 @@ export function parseRing(
   const points: Position[] = [];
 
   for (const [childName, childXML] of Object.entries(xml)) {
-    switch (childName) {
-      case 'gml:curveMember':
+    switch (stripNamespace(childName)) {
+      case 'curveMember':
         let points2;
 
         const lineString = findIn(childXML, 'gml:LineString');
@@ -506,9 +519,9 @@ export function parseSurface(
 
   const polygons: Position[][][] = [];
   for (const [childName, childXML] of Object.entries(patches)) {
-    switch (childName) {
-      case 'gml:PolygonPatch':
-      case 'gml:Rectangle':
+    switch (stripNamespace(childName)) {
+      case 'PolygonPatch':
+      case 'Rectangle':
         polygons.push(parsePolygonOrRectangle(childXML, options, childContext));
         break;
 
@@ -533,15 +546,15 @@ export function parseCompositeSurface(
 
   const polygons: Position[][][] = [];
   for (const [childName, childXML] of Object.entries(xml)) {
-    switch (childName) {
-      case 'gml:surfaceMember':
-      case 'gml:surfaceMembers':
+    switch (stripNamespace(childName)) {
+      case 'surfaceMember':
+      case 'surfaceMembers':
         const [c2Name, c2Xml] = getFirstKeyValue(childXML);
-        switch (c2Name) {
-          case 'gml:Surface':
+        switch (stripNamespace(c2Name)) {
+          case 'Surface':
             polygons.push(...parseSurface(c2Xml, options, childContext));
             break;
-          case 'gml:Polygon':
+          case 'Polygon':
             polygons.push(parsePolygonOrRectangle(c2Xml, options, childContext));
             break;
         }
@@ -627,7 +640,7 @@ function findGeometryElement(
 ): {key: string; value: any; propertyKey: string} | null {
   if (!feature || typeof feature !== 'object') return null;
   for (const [key, value] of Object.entries(feature)) {
-    if (key.startsWith('gml:') && GEOMETRY_NAMES.has(stripNamespace(key))) {
+    if (GEOMETRY_NAMES.has(stripNamespace(key))) {
       return {
         key,
         value: Array.isArray(value) ? value[0] : value,
@@ -660,22 +673,34 @@ function stripNamespace(key: string): string {
   return key.includes(':') ? key.slice(key.indexOf(':') + 1) : key;
 }
 
-function extractXMLValue(value: any): unknown {
-  if (Array.isArray(value)) return value.map(extractXMLValue);
+function extractXMLValue(value: any, propertyType?: GMLPropertyType): unknown {
+  if (Array.isArray(value)) return value.map(item => extractXMLValue(item, propertyType));
   if (value && typeof value === 'object') {
-    if ('value' in value) return extractXMLValue(value.value);
-    if ('#text' in value) return value['#text'];
+    if ('value' in value) return extractXMLValue(value.value, propertyType);
+    if ('#text' in value) return extractXMLValue(value['#text'], propertyType);
   }
+  if (propertyType === 'boolean') return value === true || value === 'true' || value === '1';
+  if (propertyType === 'integer') return Number.parseInt(String(value), 10);
+  if (propertyType === 'number') return Number(value);
+  if (propertyType === 'date' || propertyType === 'date-time') return String(value);
   return value;
 }
 
 function findFeatureId(value: any): string | undefined {
   if (!value || typeof value !== 'object') return undefined;
-  const directId = value.id || value['gml:id'] || value.fid;
+  const directId =
+    value.id ||
+    value['gml:id'] ||
+    value.fid ||
+    Object.entries(value).find(([key]) => stripNamespace(key) === 'id')?.[1];
   if (directId !== undefined && typeof directId !== 'object') return String(directId);
   const attributes = value.attributes;
   if (attributes) {
-    const id = attributes.id || attributes['gml:id'] || attributes.fid;
+    const id =
+      attributes.id ||
+      attributes['gml:id'] ||
+      attributes.fid ||
+      Object.entries(attributes).find(([key]) => stripNamespace(key) === 'id')?.[1];
     if (id !== undefined) return String(id);
   }
   return undefined;
@@ -697,7 +722,9 @@ function textOf(el: any): string {
 function findIn(root: any, ...tags: string[]): any {
   let el = root;
   for (const tag of tags) {
-    const child = el[tag];
+    const child = Object.entries(el || {}).find(
+      ([key]) => key === tag || stripNamespace(key) === stripNamespace(tag)
+    )?.[1];
     if (!child) {
       return null;
     }
@@ -720,7 +747,9 @@ function getFirstKeyValue(object: any): [string, any] {
 function getMembers(root: any, names: string[]): any[] {
   const members: any[] = [];
   for (const name of names) {
-    const value = root[name];
+    const value = Object.entries(root || {}).find(
+      ([key]) => key === name || stripNamespace(key) === stripNamespace(name)
+    )?.[1];
     if (!value) {
       continue;
     }
@@ -773,7 +802,11 @@ function parseLegacyCoordinates(
 
 /** A bit heavyweight for just tracking dimension? */
 function createChildContext(xml, options, context): ParseGMLContext {
-  const srsDimensionAttribute = xml.attributes && xml.attributes.srsDimension;
+  const attributes = xml?.attributes || xml || {};
+  const srsDimensionAttribute =
+    attributes.srsDimension ||
+    attributes['@_srsDimension'] ||
+    Object.entries(attributes).find(([key]) => stripNamespace(key).toLowerCase() === 'srsdimension')?.[1];
 
   if (srsDimensionAttribute) {
     const srsDimension = parseInt(srsDimensionAttribute);

--- a/modules/wms/src/wfs-source-loader.ts
+++ b/modules/wms/src/wfs-source-loader.ts
@@ -22,7 +22,7 @@ import {WFSCapabilitiesLoaderWithParser} from './wfs-capabilities-loader-with-pa
 import type {WMSLoaderOptions} from './wms-error-loader';
 import {WMSErrorLoaderWithParser} from './wms-error-loader-with-parser';
 import {parseGML} from './lib/parsers/gml/parse-gml';
-import type {GMLFeatureCollection} from './lib/parsers/gml/parse-gml';
+import type {GMLFeatureCollection, GMLPropertyType} from './lib/parsers/gml/parse-gml';
 import type {CRSIdentifier} from '@math.gl/crs';
 import {getServiceCRSAxisOrder, normalizeServiceCRS} from './crs-utils';
 
@@ -37,6 +37,8 @@ export type WFSourceOptions = DataSourceOptions & {
     wfsParameters?: WFSParameters;
     /** Any additional service specific parameters */
     vendorParameters?: Record<string, unknown>;
+    /** XML Schema scalar types for feature properties returned by GML. */
+    propertyTypes?: Record<string, GMLPropertyType>;
   };
 };
 
@@ -101,6 +103,20 @@ export type WFSParameters = {
     | 'application/geo+json'
     | 'application/vnd.ogc.gml'
     | 'application/gml+xml';
+  /** Maximum number of features returned by a WFS 2.0 request. */
+  count?: number;
+  /** Zero-based feature offset used for paging. */
+  startIndex?: number;
+  /** WFS 1.1 equivalent of `count`. */
+  maxFeatures?: number;
+  /** Comma-separated feature properties to return. */
+  propertyName?: string | string[];
+  /** OGC Filter XML or a server-specific filter expression. */
+  filter?: string;
+  /** Return only the result count when supported by the server. */
+  resultType?: 'results' | 'hits';
+  /** Server-side sort expression. */
+  sortBy?: string | string[];
   /** Styling - Not yet supported */
   styles?: unknown;
   /** Any additional parameters specific to this WFSVectorSource (GetMap) */
@@ -163,6 +179,20 @@ export type WFSGetFeatureParameters = {
     | 'application/geo+json'
     | 'application/vnd.ogc.gml'
     | 'application/gml+xml';
+  /** Maximum number of features returned by a WFS 2.0 request. */
+  count?: number;
+  /** Zero-based feature offset used for paging. */
+  startIndex?: number;
+  /** WFS 1.1 equivalent of `count`. */
+  maxFeatures?: number;
+  /** Comma-separated feature properties to return. */
+  propertyName?: string | string[];
+  /** OGC Filter XML or a server-specific filter expression. */
+  filter?: string;
+  /** Return only the result count when supported by the server. */
+  resultType?: 'results' | 'hits';
+  /** Server-side sort expression. */
+  sortBy?: string | string[];
 };
 
 // /** GetMap parameters that are specific to the current view */
@@ -252,6 +282,7 @@ export class WFSVectorSource extends DataSource<string, WFSourceOptions> impleme
   /** Create a WFSVectorSource */
   constructor(data: string, options: WFSourceOptions, coreApi?: CoreAPI) {
     super(data, options, WFSSourceLoader.defaultOptions, coreApi);
+    this.vendorParameters = options.wfs?.vendorParameters;
 
     // TODO - defaults such as version, layers etc could be extracted from a base URL with parameters
     // This would make pasting in any WFS URL more likely to make this class just work.
@@ -280,7 +311,7 @@ export class WFSVectorSource extends DataSource<string, WFSourceOptions> impleme
     const featureCollection = parseWFSFeatureCollection(
       text,
       response.headers.get('content-type'),
-      this.loadOptions
+      {...this.loadOptions, propertyTypes: this.options.wfs?.propertyTypes}
     );
     const geoJsonTable = parseGeoJSONTable(featureCollection);
     const format = parameters.format || 'arrow';
@@ -322,7 +353,10 @@ export class WFSVectorSource extends DataSource<string, WFSourceOptions> impleme
       if (isWFSExceptionDocument(text, response.headers.get('content-type'))) {
         throw new Error('WFS GetFeature returned an exception document');
       }
-      yield convertWFSFeatures(parseGML(text, this.loadOptions), parameters.format);
+      yield convertWFSFeatures(
+        parseGML(text, {...this.loadOptions, propertyTypes: this.options.wfs?.propertyTypes}),
+        parameters.format
+      );
       return;
     }
 
@@ -488,15 +522,16 @@ export class WFSVectorSource extends DataSource<string, WFSourceOptions> impleme
     vendorParameters?: Record<string, unknown>
   ): string {
     const requestParameters = this._normalizeGetFeatureParameters(parameters);
+    const defaultParameters = this.options.wfs?.wfsParameters || {};
     const options: WFSGetFeatureParameters & {version: WFSVersion} = {
+      ...defaultParameters,
+      ...requestParameters,
       version: requestParameters.version || '2.0.0',
       typeName: requestParameters.typeName,
       bbox: requestParameters.bbox,
       srsName: requestParameters.srsName || requestParameters.crs || 'EPSG:4326',
       outputFormat:
-        requestParameters.outputFormat ||
-        this.options.wfs?.wfsParameters?.outputFormat ||
-        'application/json'
+        requestParameters.outputFormat || defaultParameters.outputFormat || 'application/json'
     };
     return this._getWFSUrl('GetFeature', options, vendorParameters);
   }
@@ -600,7 +635,7 @@ export class WFSVectorSource extends DataSource<string, WFSourceOptions> impleme
     const IGNORE_EMPTY_KEYS = ['transparent', 'time', 'elevation'];
     for (const [key, value] of Object.entries(allParameters)) {
       // hack to preserve test cases. Not super clear if keys should be included when values are undefined
-      if (!IGNORE_EMPTY_KEYS.includes(key) || value) {
+      if (value !== undefined && value !== null && (!IGNORE_EMPTY_KEYS.includes(key) || value)) {
         url += first ? '?' : '&';
         first = false;
         url += this._getURLParameter(key, value, wfsParameters);
@@ -653,6 +688,20 @@ export class WFSVectorSource extends DataSource<string, WFSourceOptions> impleme
 
       case 'srsName':
         key = 'srsName';
+        break;
+
+      case 'count':
+        // WFS 1.1 uses maxFeatures for the equivalent page size.
+        if (wfsParameters.version === '1.1.0') {
+          key = 'maxFeatures';
+        }
+        break;
+
+      case 'maxFeatures':
+        // Keep the legacy spelling when targeting WFS 1.1; WFS 2.0 uses count.
+        if (wfsParameters.version === '2.0.0') {
+          key = 'count';
+        }
         break;
 
       case 'x':

--- a/modules/wms/src/wfs-source-loader.ts
+++ b/modules/wms/src/wfs-source-loader.ts
@@ -382,7 +382,11 @@ export class WFSVectorSource extends DataSource<string, WFSourceOptions> impleme
     const {GMLLoaderWithParser} = await import('./gml-loader-with-parser');
     for await (const batch of GMLLoaderWithParser.parseInBatches!(chunks, {
       ...this.loadOptions,
-      gml: {batchSize: options.batchSize || 1000}
+      gml: {
+        ...this.loadOptions.gml,
+        batchSize: options.batchSize || 1000,
+        propertyTypes: this.options.wfs?.propertyTypes
+      }
     })) {
       yield convertWFSFeatures(batch, parameters.format);
     }
@@ -642,7 +646,9 @@ export class WFSVectorSource extends DataSource<string, WFSourceOptions> impleme
       }
     }
 
-    return encodeURI(url);
+    // Parameter values are encoded individually in _getURLParameter. Encoding the
+    // complete URL here would encode the percent signs a second time.
+    return url;
   }
 
   _getWFS130Parameters<ParametersT extends {crs?: CRSIdentifier; srs?: CRSIdentifier}>(
@@ -724,9 +730,8 @@ export class WFSVectorSource extends DataSource<string, WFSourceOptions> impleme
 
     key = key.toUpperCase();
 
-    return Array.isArray(value)
-      ? `${key}=${value.join(',')}`
-      : `${key}=${value ? String(value) : ''}`;
+    const parameterValue = Array.isArray(value) ? value.join(',') : value ? String(value) : '';
+    return `${key}=${encodeURIComponent(parameterValue)}`;
   }
 
   /** Coordinate order is flipped for certain CRS in WFS 1.1.0 and 2.0.0. */

--- a/modules/wms/test/gml/gml-loader.spec.ts
+++ b/modules/wms/test/gml/gml-loader.spec.ts
@@ -112,3 +112,15 @@ test('GMLLoader preserves CompositeSurface members in MultiSurface', () => {
   expect(geometry.type).toBe('MultiPolygon');
   expect(geometry.coordinates).toHaveLength(1);
 });
+test('GMLLoader accepts alternate GML prefixes and schema-aware properties', () => {
+  const collection = GMLParserLoader.parseTextSync(
+    `<wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs/2.0" xmlns:gml32="http://www.opengis.net/gml/3.2" xmlns:city="urn:city"><gml32:featureMember><city:building gml32:id="b.1"><city:name>Library</city:name><city:height>12</city:height><city:open>true</city:open><city:shape><gml32:Point srsDimension="3"><gml32:pos>1 2 3</gml32:pos></gml32:Point></city:shape></city:building></gml32:featureMember></wfs:FeatureCollection>`,
+    {gml: {propertyTypes: {height: 'number', open: 'boolean'}}}
+  ) as any;
+
+  expect(collection.features[0]).toMatchObject({
+    id: 'b.1',
+    properties: {name: 'Library', height: 12, open: true},
+    geometry: {type: 'Point', coordinates: [1, 2, 3]}
+  });
+});

--- a/modules/wms/test/gml/gml-loader.spec.ts
+++ b/modules/wms/test/gml/gml-loader.spec.ts
@@ -124,3 +124,10 @@ test('GMLLoader accepts alternate GML prefixes and schema-aware properties', () 
     geometry: {type: 'Point', coordinates: [1, 2, 3]}
   });
 });
+test('GMLLoader preserves interior rings with alternate GML prefixes', () => {
+  const geometry = GMLParserLoader.parseTextSync(
+    `<gml32:Polygon xmlns:gml32="http://www.opengis.net/gml/3.2"><gml32:exterior><gml32:LinearRing><gml32:posList>0 0 10 0 10 10 0 0</gml32:posList></gml32:LinearRing></gml32:exterior><gml32:interior><gml32:LinearRing><gml32:posList>2 2 4 2 4 4 2 2</gml32:posList></gml32:LinearRing></gml32:interior></gml32:Polygon>`,
+    {}
+  ) as GeoJSON.Polygon;
+  expect(geometry.coordinates).toHaveLength(2);
+});

--- a/modules/wms/test/wfs/wfs-source.spec.ts
+++ b/modules/wms/test/wfs/wfs-source.spec.ts
@@ -167,6 +167,44 @@ test('WFSSourceLoader#getFeatures honors configured output format', () => {
   const featuresUrl = new URL(source.getFeaturesURL({layers: ['roads'], crs: 'EPSG:4326'}));
   expect(featuresUrl.searchParams.get('OUTPUTFORMAT')).toBe('application/vnd.ogc.gml');
 });
+test('WFSSourceLoader#getFeaturesURL supports paging and server-side filters', () => {
+  const source = WFSSourceLoader.createDataSource(WFS_URL, {});
+  const featuresUrl = new URL(
+    source.getFeaturesURL({
+      version: '2.0.0',
+      typeName: 'roads',
+      bbox: [1, 2, 3, 4, 'EPSG:4326'],
+      srsName: 'EPSG:4326',
+      count: 25,
+      startIndex: 50,
+      propertyName: ['name', 'geometry'],
+      filter: '<fes:Filter><fes:PropertyIsEqualTo/></fes:Filter>',
+      resultType: 'results',
+      sortBy: ['name A', 'id D']
+    })
+  );
+  expect(featuresUrl.searchParams.get('COUNT')).toBe('25');
+  expect(featuresUrl.searchParams.get('STARTINDEX')).toBe('50');
+  expect(featuresUrl.searchParams.get('PROPERTYNAME')).toBe('name,geometry');
+  expect(featuresUrl.searchParams.get('FILTER')).toContain('<fes:Filter>');
+  expect(featuresUrl.searchParams.get('RESULTTYPE')).toBe('results');
+  expect(featuresUrl.searchParams.get('SORTBY')).toBe('name A,id D');
+});
+test('WFSSourceLoader#getFeaturesURL maps page size for WFS 1.1', () => {
+  const source = WFSSourceLoader.createDataSource(WFS_URL, {});
+  const featuresUrl = new URL(
+    source.getFeaturesURL({
+      version: '1.1.0',
+      typeName: 'roads',
+      bbox: [1, 2, 3, 4, 'CRS:84'],
+      count: 10,
+      startIndex: 20
+    })
+  );
+  expect(featuresUrl.searchParams.get('MAXFEATURES')).toBe('10');
+  expect(featuresUrl.searchParams.get('STARTINDEX')).toBe('20');
+  expect(featuresUrl.searchParams.get('COUNT')).toBeNull();
+});
 test('WFSSourceLoader#getFeaturesInBatches rejects successful WFS exception responses', async () => {
   const source = WFSSourceLoader.createDataSource(WFS_URL, {});
   source.fetch = async () =>

--- a/modules/wms/test/wfs/wfs-source.spec.ts
+++ b/modules/wms/test/wfs/wfs-source.spec.ts
@@ -160,6 +160,38 @@ test('WFSSourceLoader#getFeaturesInBatches streams GML into Arrow batches', asyn
   expect(batches).toHaveLength(2);
   expect(batches[0].data.numRows).toBe(1);
 });
+test('WFSSourceLoader#getFeaturesInBatches forwards GML property types', async () => {
+  const source = WFSSourceLoader.createDataSource(WFS_URL, {
+    wfs: {propertyTypes: {height: 'number'}}
+  });
+  const xml =
+    '<wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs" xmlns:gml="http://www.opengis.net/gml" xmlns:app="urn:app"><gml:featureMember><app:road><app:height>12</app:height><app:geometry><gml:Point><gml:pos>1 2</gml:pos></gml:Point></app:geometry></app:road></gml:featureMember></wfs:FeatureCollection>';
+  source.fetch = async () =>
+    new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(xml));
+          controller.close();
+        }
+      }),
+      {headers: {'content-type': 'application/gml+xml'}}
+    );
+  const batches = [];
+  for await (const batch of source.getFeaturesInBatches(
+    {
+      boundingBox: [
+        [0, 0],
+        [5, 5]
+      ],
+      layers: ['roads'],
+      format: 'geojson'
+    },
+    {batchSize: 1}
+  )) {
+    batches.push(batch);
+  }
+  expect((batches[0] as any).features[0].properties.height).toBe(12);
+});
 test('WFSSourceLoader#getFeatures honors configured output format', () => {
   const source = WFSSourceLoader.createDataSource(WFS_URL, {
     wfs: {wfsParameters: {outputFormat: 'application/vnd.ogc.gml'}}
@@ -204,6 +236,20 @@ test('WFSSourceLoader#getFeaturesURL maps page size for WFS 1.1', () => {
   expect(featuresUrl.searchParams.get('MAXFEATURES')).toBe('10');
   expect(featuresUrl.searchParams.get('STARTINDEX')).toBe('20');
   expect(featuresUrl.searchParams.get('COUNT')).toBeNull();
+});
+test('WFSSourceLoader#getFeaturesURL encodes reserved filter characters', () => {
+  const source = WFSSourceLoader.createDataSource(WFS_URL, {});
+  const featuresUrl = new URL(
+    source.getFeaturesURL({
+      typeName: 'roads',
+      bbox: [1, 2, 3, 4],
+      filter: '<fes:Filter><fes:Literal>A&B #1</fes:Literal></fes:Filter>'
+    })
+  );
+  expect(featuresUrl.hash).toBe('');
+  expect(featuresUrl.searchParams.get('FILTER')).toBe(
+    '<fes:Filter><fes:Literal>A&B #1</fes:Literal></fes:Filter>'
+  );
 });
 test('WFSSourceLoader#getFeaturesInBatches rejects successful WFS exception responses', async () => {
   const source = WFSSourceLoader.createDataSource(WFS_URL, {});


### PR DESCRIPTION
## Goals

Complete tranche 10 so GML/WFS support is a durable production capability rather than a collection of protocol-specific happy paths.

## Changes

- Make GML geometry dispatch and member parsing namespace-prefix independent across GML 2 and GML 3.2 output.
- Preserve dimensional positions and support schema-guided scalar property decoding for `string`, `boolean`, `integer`, `number`, `date`, and `date-time` values.
- Add WFS `GetFeature` paging, filtering, property selection, result-type, and sorting parameters. Translate WFS 2.0 `count` to WFS 1.1 `maxFeatures`.
- Apply configured GML property types and WFS vendor parameters consistently through complete and streaming requests.
- Expand hermetic Vitest coverage for alternate prefixes, dimensional geometry, typed properties, paging, filtering, and streaming behavior.
- Update GML/WFS documentation and mark tranche 10 complete in the roadmap.

## Validation

- `yarn lint fix`
- `yarn test-audit`
- `yarn build`
- `yarn build-workers`
- `yarn test-node`
- `yarn test-headless`

All local validation passed.

This PR intentionally does not introduce the deferred universal service runtime or expand OGC API scope.