### PR TITLE
perf(las): decode legacy LAZ directly into Arrow

### DIFF
--- a/modules/las/src/lib/typescript/parse-las.ts
+++ b/modules/las/src/lib/typescript/parse-las.ts
@@ -172,10 +172,7 @@ export function parseLAS(arrayBuffer: ArrayBuffer, options: LASLoaderOptions = {
     const bytes = new Uint8Array(arrayBuffer);
     const laszip = parseLASZipVLR(bytes, header);
     validateTypeScriptLAZSupport(header, laszip);
-    if (
-      header.pointsFormatId === 3 ||
-      (header.pointsFormatId >= 6 && header.pointsFormatId <= 10)
-    ) {
+    if (header.pointsFormatId <= 5 || (header.pointsFormatId >= 6 && header.pointsFormatId <= 10)) {
       return parseCompleteLAZFileToArrowTable(bytes, header, laszip, options);
     }
     const rawPointData = decodeLAZFileToRawPointData(arrayBuffer, header, laszip);
@@ -695,8 +692,8 @@ async function* parseLAZInBatches(
 ): AsyncIterable<LASArrowTable> {
   const {pending, laszip} = await readLASZipVLRFromInput(initialPending, inputIterator, header);
   validateTypeScriptLAZSupport(header, laszip);
-  if (!laszip.variableChunks && header.pointsFormatId === 3) {
-    yield* parsePendingFixedPDRF3LAZFileInArrowBatches(
+  if (!laszip.variableChunks && header.pointsFormatId <= 5) {
+    yield* parsePendingFixedLegacyLAZFileInArrowBatches(
       pending,
       inputIterator,
       header,
@@ -722,13 +719,13 @@ async function* parseLAZInBatches(
 }
 
 /**
- * Decode fixed-size PDRF 3 LAZ chunks directly into streaming Arrow batches.
+ * Decode fixed-size legacy LAZ chunks directly into streaming Arrow batches.
  *
- * This path intentionally parallels the raw legacy stream loop. Writing into Arrow-owned arrays
- * avoids allocating and reparsing an intermediate raw LAS point-record batch, while the cursor
- * still provides point-atomic suspension when more compressed input is required.
+ * This path intentionally parallels the raw legacy stream loop for PDRFs 0-5. Writing into
+ * Arrow-owned arrays avoids allocating and reparsing an intermediate raw LAS point-record batch,
+ * while the cursor still provides point-atomic suspension when more compressed input is required.
  */
-async function* parsePendingFixedPDRF3LAZFileInArrowBatches(
+async function* parsePendingFixedLegacyLAZFileInArrowBatches(
   initialPending: Uint8Array<ArrayBufferLike>,
   inputIterator: AsyncIterator<ArrayBufferLike | ArrayBufferView>,
   header: LASHeader,

--- a/modules/las/test/las-loader.node.slow.spec.ts
+++ b/modules/las/test/las-loader.node.slow.spec.ts
@@ -1271,16 +1271,14 @@ test('TypeScriptLAZ#decodes single-point legacy point format 0 chunk', () => {
     scale: [1, 1, 1] as [number, number, number],
     offset: [0, 0, 0] as [number, number, number]
   };
-  expect(
-    () => cursor.decodeIntoPointData(target, 1),
-    'legacy point formats reject direct point-data output'
-  ).toThrow(/does not support direct point-data output for point format 0/);
-  const rawOutput = new Uint8Array(expected.byteLength);
-  expect(
-    cursor.decodeInto(rawOutput, 0, 1),
-    'rejected direct output does not initialize or lock the cursor'
-  ).toBe(1);
-  expect(rawOutput, 'raw decode remains available after rejected direct output').toEqual(expected);
+  expect(cursor.decodeIntoPointData(target, 1), 'PDRF 0 supports direct point-data output').toBe(1);
+  expect(Array.from(target.positions), 'PDRF 0 positions are written directly').toEqual([
+    123456, -234567, 345678
+  ]);
+  expect(Array.from(target.intensities), 'PDRF 0 intensity is written directly').toEqual([321]);
+  expect(Array.from(target.classifications), 'PDRF 0 classification is written directly').toEqual([
+    2
+  ]);
 });
 test('TypeScriptLAZ#decodes single-point legacy point format 1 chunk', () => {
   const expected = new Uint8Array(28);
@@ -1295,6 +1293,23 @@ test('TypeScriptLAZ#decodes single-point legacy point format 1 chunk', () => {
     pointDataRecordLength: expected.byteLength
   });
   expect(actual, 'point format 1 first point and GPS time are preserved').toEqual(expected);
+  const target = {
+    positions: new Float64Array(3),
+    intensities: new Uint16Array(1),
+    classifications: new Uint8Array(1),
+    gpsTimes: new Float64Array(1),
+    pointOffset: 0,
+    scale: [1, 1, 1] as [number, number, number],
+    offset: [0, 0, 0] as [number, number, number]
+  };
+  const cursor = createLAZChunkDecoderCursor(compressed, {
+    pointCount: 1,
+    pointDataRecordFormat: 1,
+    pointDataRecordLength: expected.byteLength
+  });
+  expect(cursor.decodeIntoPointData(target, 1)).toBe(1);
+  expect(Array.from(target.positions)).toEqual([123456, -234567, 345678]);
+  expect(Array.from(target.gpsTimes)).toEqual([12345.25]);
 });
 test('TypeScriptLAZ#decodes single-point legacy point format 2 chunk', () => {
   const expected = new Uint8Array(26);
@@ -1311,6 +1326,23 @@ test('TypeScriptLAZ#decodes single-point legacy point format 2 chunk', () => {
     pointDataRecordLength: expected.byteLength
   });
   expect(actual, 'point format 2 first point and RGB are preserved').toEqual(expected);
+  const target = {
+    positions: new Float64Array(3),
+    intensities: new Uint16Array(1),
+    classifications: new Uint8Array(1),
+    rawColors: new Uint16Array(3),
+    pointOffset: 0,
+    scale: [1, 1, 1] as [number, number, number],
+    offset: [0, 0, 0] as [number, number, number]
+  };
+  const cursor = createLAZChunkDecoderCursor(compressed, {
+    pointCount: 1,
+    pointDataRecordFormat: 2,
+    pointDataRecordLength: expected.byteLength
+  });
+  expect(cursor.decodeIntoPointData(target, 1)).toBe(1);
+  expect(Array.from(target.positions)).toEqual([123456, -234567, 345678]);
+  expect(Array.from(target.rawColors)).toEqual([257, 1025, 4097]);
 });
 test('TypeScriptLAZ#decodes single-point legacy point format 3 chunk', () => {
   const expected = new Uint8Array(34);

--- a/modules/loader-utils/src/lib/laz/laz-chunk-decoder.ts
+++ b/modules/loader-utils/src/lib/laz/laz-chunk-decoder.ts
@@ -407,7 +407,7 @@ export class LAZChunkDecoderCursor {
   }
 
   /**
-   * Decode complete legacy PDRF 3 points directly into typed point-data arrays.
+   * Decode complete legacy PDRF 0-5 points directly into typed point-data arrays.
    *
    * The method preserves the point-atomic streaming contract of {@link decodeAvailableInto} but
    * bypasses raw LAS record materialization. It returns when the next point lacks compressed
@@ -418,8 +418,8 @@ export class LAZChunkDecoderCursor {
     pointCount: number,
     inputComplete = false
   ): number {
-    if (this.metadata.pointDataRecordFormat !== 3) {
-      throw new Error('Available point-data decoding is limited to legacy PDRF 3 LAZ chunks');
+    if (this.metadata.pointDataRecordFormat > 5) {
+      throw new Error('Available point-data decoding is limited to legacy PDRF 0-5 LAZ chunks');
     }
     const pointsToDecode = Math.min(pointCount, this.remainingPointCount);
     if (pointsToDecode === 0) {
@@ -428,6 +428,7 @@ export class LAZChunkDecoderCursor {
     const selection = getLAZPointDataSelection(target);
     const decoder = this.selectOutputMode('point-data', pointsToDecode, selection)!;
     let decodedPointCount = 0;
+    const targetPointOffset = target.pointOffset;
 
     while (decodedPointCount < pointsToDecode) {
       const requiredLookahead =
@@ -438,8 +439,14 @@ export class LAZChunkDecoderCursor {
         break;
       }
       try {
-        decoder.decompressPointData!(target, target.pointOffset + decodedPointCount);
+        target.pointOffset = targetPointOffset + decodedPointCount;
+        if (decoder.decompressPointData) {
+          decoder.decompressPointData(target, target.pointOffset);
+        } else {
+          decoder.decompressPointDataBatch!(target, 1);
+        }
       } catch (error) {
+        target.pointOffset = targetPointOffset;
         if (error instanceof NeedsMoreData && !inputComplete) {
           throw new Error(
             `Legacy LAZ point exceeded the ${requiredLookahead}-byte streaming lookahead`
@@ -450,6 +457,7 @@ export class LAZChunkDecoderCursor {
       decodedPointCount++;
       this.pointIndex++;
     }
+    target.pointOffset = targetPointOffset;
 
     return decodedPointCount;
   }
@@ -2737,7 +2745,7 @@ function createPointDecompressor(
 
 /** Return whether a point format has a direct typed-array output path. */
 function supportsDirectPointDataOutput(pointDataRecordFormat: number): boolean {
-  return pointDataRecordFormat === 3 || (pointDataRecordFormat >= 6 && pointDataRecordFormat <= 10);
+  return pointDataRecordFormat <= 5 || (pointDataRecordFormat >= 6 && pointDataRecordFormat <= 10);
 }
 
 class PointFormat0Decompressor implements PointDecompressor {
@@ -2755,6 +2763,29 @@ class PointFormat0Decompressor implements PointDecompressor {
     outputOffset = this.bytes.decompress(output, outputOffset);
     this.readFirstMetadata();
     return outputOffset;
+  }
+
+  /** Decode PDRF 0 points directly into represented Arrow columns. */
+  decompressPointData(target: LAZPointDataTarget, targetPointIndex: number): void {
+    const point = this.point.decompressPoint();
+    this.bytes.decompressToTarget(target.extraBytes, targetPointIndex * this.bytes.byteCount);
+    this.readFirstMetadata();
+    writePoint10ToPointDataArrays(
+      point,
+      target.positions,
+      target.intensities,
+      target.classifications,
+      target.scale,
+      target.offset,
+      targetPointIndex
+    );
+    writePoint10MetadataToPointDataTarget(point, target, targetPointIndex);
+  }
+
+  decompressPointDataBatch(target: LAZPointDataTarget, pointCount: number): void {
+    for (let pointIndex = 0; pointIndex < pointCount; pointIndex++) {
+      this.decompressPointData(target, target.pointOffset + pointIndex);
+    }
   }
 
   private readFirstMetadata(): void {
@@ -2934,6 +2965,33 @@ class PointFormat1Decompressor implements PointDecompressor {
     return outputOffset;
   }
 
+  /** Decode PDRF 1 points directly into represented Arrow columns. */
+  decompressPointData(target: LAZPointDataTarget, targetPointIndex: number): void {
+    const point = this.point.decompressPoint();
+    const gpsTime = this.gpsTime.decompressGpsTime();
+    this.bytes.decompressToTarget(target.extraBytes, targetPointIndex * this.bytes.byteCount);
+    this.readFirstMetadata();
+    writePoint10ToPointDataArrays(
+      point,
+      target.positions,
+      target.intensities,
+      target.classifications,
+      target.scale,
+      target.offset,
+      targetPointIndex
+    );
+    writePoint10MetadataToPointDataTarget(point, target, targetPointIndex);
+    if (target.gpsTimes) {
+      target.gpsTimes[targetPointIndex] = gpsTime;
+    }
+  }
+
+  decompressPointDataBatch(target: LAZPointDataTarget, pointCount: number): void {
+    for (let pointIndex = 0; pointIndex < pointCount; pointIndex++) {
+      this.decompressPointData(target, target.pointOffset + pointIndex);
+    }
+  }
+
   private readFirstMetadata(): void {
     if (this.first) {
       this.point.readFirstMetadata();
@@ -2961,6 +3019,37 @@ class PointFormat2Decompressor implements PointDecompressor {
     outputOffset = this.bytes.decompress(output, outputOffset);
     this.readFirstMetadata();
     return outputOffset;
+  }
+
+  /** Decode PDRF 2 points directly into represented Arrow columns. */
+  decompressPointData(target: LAZPointDataTarget, targetPointIndex: number): void {
+    const point = this.point.decompressPoint();
+    this.rgb.decompressRgb();
+    this.bytes.decompressToTarget(target.extraBytes, targetPointIndex * this.bytes.byteCount);
+    this.readFirstMetadata();
+    writePoint10ToPointDataArrays(
+      point,
+      target.positions,
+      target.intensities,
+      target.classifications,
+      target.scale,
+      target.offset,
+      targetPointIndex
+    );
+    writePoint10MetadataToPointDataTarget(point, target, targetPointIndex);
+    writeRgbToPointDataTarget(
+      this.rgb.decodedRed,
+      this.rgb.decodedGreen,
+      this.rgb.decodedBlue,
+      target,
+      targetPointIndex
+    );
+  }
+
+  decompressPointDataBatch(target: LAZPointDataTarget, pointCount: number): void {
+    for (let pointIndex = 0; pointIndex < pointCount; pointIndex++) {
+      this.decompressPointData(target, target.pointOffset + pointIndex);
+    }
   }
 
   private readFirstMetadata(): void {
@@ -3273,6 +3362,8 @@ class PointFormat4Decompressor implements PointDecompressor {
   private wavePacket: WavePacket13Decompressor;
   /** Extra Bytes decoder. */
   private bytes: Byte10Decompressor;
+  /** Reused sink for waveform references when the caller did not request WAVEFORM output. */
+  private waveformScratch = new Uint8Array(29);
   /** Whether the first raw items remain unread. */
   private first = true;
 
@@ -3292,6 +3383,38 @@ class PointFormat4Decompressor implements PointDecompressor {
     outputOffset = this.bytes.decompress(output, outputOffset);
     this.readFirstMetadata();
     return outputOffset;
+  }
+
+  /** Decode PDRF 4 points directly into represented Arrow columns and waveform references. */
+  decompressPointData(target: LAZPointDataTarget, targetPointIndex: number): void {
+    const point = this.point.decompressPoint();
+    const gpsTime = this.gpsTime.decompressGpsTime();
+    if (target.waveforms) {
+      this.wavePacket.decompressToTarget(target.waveforms, targetPointIndex * 29);
+    } else {
+      this.wavePacket.decompressToTarget(this.waveformScratch, 0);
+    }
+    this.bytes.decompressToTarget(target.extraBytes, targetPointIndex * this.bytes.byteCount);
+    this.readFirstMetadata();
+    writePoint10ToPointDataArrays(
+      point,
+      target.positions,
+      target.intensities,
+      target.classifications,
+      target.scale,
+      target.offset,
+      targetPointIndex
+    );
+    writePoint10MetadataToPointDataTarget(point, target, targetPointIndex);
+    if (target.gpsTimes) {
+      target.gpsTimes[targetPointIndex] = gpsTime;
+    }
+  }
+
+  decompressPointDataBatch(target: LAZPointDataTarget, pointCount: number): void {
+    for (let pointIndex = 0; pointIndex < pointCount; pointIndex++) {
+      this.decompressPointData(target, target.pointOffset + pointIndex);
+    }
   }
 
   /** Initialize the shared legacy arithmetic decoder after first raw items. */
@@ -3315,6 +3438,8 @@ class PointFormat5Decompressor implements PointDecompressor {
   private wavePacket: WavePacket13Decompressor;
   /** Extra Bytes decoder. */
   private bytes: Byte10Decompressor;
+  /** Reused sink for waveform references when the caller did not request WAVEFORM output. */
+  private waveformScratch = new Uint8Array(29);
   /** Whether the first raw items remain unread. */
   private first = true;
 
@@ -3336,6 +3461,46 @@ class PointFormat5Decompressor implements PointDecompressor {
     outputOffset = this.bytes.decompress(output, outputOffset);
     this.readFirstMetadata();
     return outputOffset;
+  }
+
+  /** Decode PDRF 5 points directly into represented Arrow columns and waveform references. */
+  decompressPointData(target: LAZPointDataTarget, targetPointIndex: number): void {
+    const point = this.point.decompressPoint();
+    const gpsTime = this.gpsTime.decompressGpsTime();
+    this.rgb.decompressRgb();
+    if (target.waveforms) {
+      this.wavePacket.decompressToTarget(target.waveforms, targetPointIndex * 29);
+    } else {
+      this.wavePacket.decompressToTarget(this.waveformScratch, 0);
+    }
+    this.bytes.decompressToTarget(target.extraBytes, targetPointIndex * this.bytes.byteCount);
+    this.readFirstMetadata();
+    writePoint10ToPointDataArrays(
+      point,
+      target.positions,
+      target.intensities,
+      target.classifications,
+      target.scale,
+      target.offset,
+      targetPointIndex
+    );
+    writePoint10MetadataToPointDataTarget(point, target, targetPointIndex);
+    if (target.gpsTimes) {
+      target.gpsTimes[targetPointIndex] = gpsTime;
+    }
+    writeRgbToPointDataTarget(
+      this.rgb.decodedRed,
+      this.rgb.decodedGreen,
+      this.rgb.decodedBlue,
+      target,
+      targetPointIndex
+    );
+  }
+
+  decompressPointDataBatch(target: LAZPointDataTarget, pointCount: number): void {
+    for (let pointIndex = 0; pointIndex < pointCount; pointIndex++) {
+      this.decompressPointData(target, target.pointOffset + pointIndex);
+    }
   }
 
   /** Initialize the shared legacy arithmetic decoder after first raw items. */


### PR DESCRIPTION
## Goals

Extend the TypeScript LAZ parser's no-materialization Arrow path to legacy LAS point data record formats, so common older LAZ files can stream directly into Arrow batches without allocating intermediate raw point records.

## Changes

- Add direct Arrow point writers for PDRF 0, 1, 2, 4, and 5.
- Preserve intensity, classification, GPS time, RGB, waveform references, and Extra Bytes when those columns are requested.
- Reuse one 29-byte waveform scratch buffer when waveform output is not selected.
- Extend complete-file and fixed-chunk streaming dispatch to legacy PDRFs 0–5.
- Keep point-atomic cursor decoding for split input and retain the optimized PDRF 3 path.
- Add direct-output parity coverage for PDRF 0, 1, and 2 and update the PDRF 0 contract test.

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn build-workers`
- `yarn test-node` (360 passed, 6 skipped)
- `yarn test-headless` (3004 passed, 40 skipped)
- Focused LAS slow legacy/waveform tests (9 passed)
- Focused PDRF 0/1/2 direct-output tests (3 passed)

The implementation is based on the existing PDRF 3 direct Arrow architecture and keeps the current WASM/Rust backends unchanged.
