### PR TITLE
feat(las): harden LAS 1.5 header parsing

### DIFF
--- a/docs/modules/las/formats/las.md
+++ b/docs/modules/las/formats/las.md
@@ -30,7 +30,7 @@ LAS file versions and LASzip codec versions are independent. A claim such as "LA
 | Capability | TypeScript status |
 | --- | --- |
 | Uncompressed LAS 1.0-1.4 | Partial. Reads common public-header fields and PDRF 0-10 record layouts. Dedicated conformance fixtures do not yet cover every header version/PDRF combination. |
-| LAS 1.5 | Partial. Extended point counts, typed header metadata, and PDRF 9/10 files are fixture-tested; full LAS 1.5 conformance rules are not complete. |
+| LAS 1.5 | Read support for the modern 1.5 form: validates the extended 393-byte header and PDRF 6-10 rule, parses Max/Min GPS Time and Time Offset, and fixture-tests PDRF 9/10. Writing and complete interoperability conformance remain future work. |
 | Arrow columns | `POSITION`, `intensity`, `classification`, `synthetic`, `keyPoint`, `withheld`, `overlap`, `COLOR_0`, `GPS_TIME`, `NIR`, `scanAngle`, `userData`, `pointSourceId`, `returnNumber`, `numberOfReturns`, `scannerChannel`, `scanDirectionFlag`, `edgeOfFlightLine`, `WAVEFORM`, and `EXTRA_BYTES` where present. `WAVEFORM` is a fixed-width 29-byte LAS waveform packet reference column; `EXTRA_BYTES` is the fixed-width raw user-byte payload from each point record. With `las.extraBytes: 'typed'`, `EXTRA_BYTES` produces one prefixed typed Arrow attribute per descriptor. `las.columns` selects optional output columns; `POSITION` is always returned. |
 | GPS time | Exposed as `GPS_TIME` for PDRF 1, 3-5, and 6-10. |
 | NIR | Exposed as `NIR` for PDRF 8 and 10. |
@@ -144,7 +144,7 @@ PDRF 7 performance checks combine deterministic memory invariants with conservat
 
 | Version | Point data record formats | Main additions | loaders.gl status |
 | --- | --- | --- | --- |
-| 1.5 | 6-10 in LAS 1.5 mode | Backward compatibility with LAS 1.1-1.4, stricter modern point record model, WKT CRS records. | Header/read compatibility in the TypeScript path; writing is not targeted. |
+| 1.5 | 6-10 in LAS 1.5 mode | Backward compatibility with LAS 1.1-1.4, stricter modern point record model, WKT CRS records, and an extended public header. | TypeScript reads and validates the modern header, parses its GPS-time fields, and decodes PDRF 6-10; writing is not targeted. |
 | 1.4 | 0-10 | 64-bit point counts and offsets, EVLR refinements, WKT CRS support, Extra Bytes VLR, modern PDRFs 6-10. | Reads uncompressed LAS 1.4 and decodes LAZ chunks for PDRF 0-10. |
 | 1.3 | 0-5 | EVLRs and waveform packet support. | TypeScript LAZ decoding supports all PDRFs, including raw PDRF 4/5 waveform references. |
 | 1.2 | 0-3 | RGB point formats and broader geospatial metadata conventions. | Read and write support for common uncompressed LAS attributes. |
@@ -264,4 +264,4 @@ Within the documented version, PDRF, and codec matrix, the TypeScript implementa
 
 | Order | Work item | Impact | Cost | Acceptance target |
 | --- | --- | --- | --- | --- |
-| 1 | Complete LAS 1.5 conformance and writing | Medium | Medium | Enforce LAS 1.5 header, WKT, and PDRF rules; add broader fixtures; and emit LAS 1.5 only after independent-reader interoperability is demonstrated. |
+| 1 | Complete LAS 1.5 conformance and writing | Medium | Medium | Add broader independent-reader fixtures, validate LAS 1.5 WKT and extension semantics, and emit LAS 1.5 only after interoperability is demonstrated. |

--- a/modules/las/src/lib/las-types.ts
+++ b/modules/las/src/lib/las-types.ts
@@ -127,6 +127,8 @@ export type LASMetadata = {
   creationYear: number;
   /** LAS header byte length. */
   headerSize: number;
+  /** LAS header extension bytes after the standard 393-byte LAS 1.5 header. */
+  userHeaderData?: Uint8Array;
   /** Number of VLRs before point data. */
   vlrCount: number;
   /** Offset of first EVLR, or zero when absent. */
@@ -184,6 +186,8 @@ export type LASHeader = {
   versionAsString?: string;
   isCompressed?: boolean;
   headerSize?: number;
+  /** LAS header extension bytes after the standard 393-byte LAS 1.5 header. */
+  userHeaderData?: Uint8Array;
   vlrCount?: number;
   metadata?: LASMetadata;
 };

--- a/modules/las/src/lib/typescript/parse-las.ts
+++ b/modules/las/src/lib/typescript/parse-las.ts
@@ -1067,7 +1067,11 @@ export function parseLASHeader(arrayBuffer: ArrayBufferLike): LASHeader {
 
   const versionMajor = dataView.getUint8(24);
   const versionMinor = dataView.getUint8(25);
+  if (versionMajor !== 1 || versionMinor > 5) {
+    throw new Error(`LASLoader: unsupported LAS version ${versionMajor}.${versionMinor}`);
+  }
   const headerSize = dataView.getUint16(94, true);
+  const globalEncoding = dataView.getUint16(6, true);
   const vlrCount = dataView.getUint32(100, true);
   const pointFormatByte = dataView.getUint8(104);
   const pointsFormatId = pointFormatByte & POINT_FORMAT_MASK;
@@ -1078,6 +1082,19 @@ export function parseLASHeader(arrayBuffer: ArrayBufferLike): LASHeader {
   const pointsCount = extendedPointCount || legacyPointCount;
   const pointsOffset = dataView.getUint32(96, true);
   const pointsStructSize = dataView.getUint16(105, true);
+  if (versionMinor === 5) {
+    if (headerSize < 393) {
+      throw new Error('LASLoader: LAS 1.5 header must be at least 393 bytes');
+    }
+    if (pointsFormatId < 6 || pointsFormatId > 10) {
+      throw new Error(
+        `LASLoader: LAS 1.5 requires point data record formats 6-10; received ${pointsFormatId}`
+      );
+    }
+    if ((globalEncoding & 0x10) === 0) {
+      throw new Error('LASLoader: LAS 1.5 requires the WKT global encoding flag');
+    }
+  }
   const scale: [number, number, number] = [
     dataView.getFloat64(131, true),
     dataView.getFloat64(139, true),
@@ -1114,7 +1131,11 @@ export function parseLASHeader(arrayBuffer: ArrayBufferLike): LASHeader {
     versionAsString: `${versionMajor}.${versionMinor}`,
     isCompressed,
     headerSize,
-    vlrCount
+    vlrCount,
+    userHeaderData:
+      versionMinor === 5 && headerSize > 393
+        ? new Uint8Array(arrayBuffer, 393, headerSize - 393).slice()
+        : undefined
   };
   if (hasCompleteLASMetadata(arrayBuffer, header)) {
     header.metadata = parseLASMetadata(arrayBuffer, header);
@@ -1149,9 +1170,13 @@ function parseLASMetadata(arrayBuffer: ArrayBufferLike, header: LASHeader): LASM
     creationDayOfYear: dataView.getUint16(90, true),
     creationYear: dataView.getUint16(92, true),
     headerSize: header.headerSize!,
+    userHeaderData: header.userHeaderData,
     vlrCount: header.vlrCount!,
     evlrOffset: evlrOffset || undefined,
     evlrCount: evlrCount || undefined,
+    maxGpsTime: versionParts[1] === 5 ? dataView.getFloat64(375, true) : undefined,
+    minGpsTime: versionParts[1] === 5 ? dataView.getFloat64(383, true) : undefined,
+    timeOffset: versionParts[1] === 5 ? dataView.getUint16(391, true) : undefined,
     pointsByReturn: parsePointsByReturn(dataView, isAtLeast14),
     vlrs,
     evlrs,

--- a/modules/las/test/las-streaming-conformance.node.slow.spec.ts
+++ b/modules/las/test/las-streaming-conformance.node.slow.spec.ts
@@ -77,6 +77,32 @@ const CONFORMANCE_FIXTURES: readonly ConformanceFixture[] = [
 ];
 
 describe('TypeScript LAZ streaming conformance', () => {
+  test('LAS 1.5 exposes and validates its extended header', async () => {
+    const source = await loadArrayBuffer('@loaders.gl/las/test/data/pdrf9-1.5.las');
+    const header = parseLASHeader(source);
+    expect(header.versionAsString).toBe('1.5');
+    expect(header.headerSize).toBeGreaterThanOrEqual(393);
+    expect(header.userHeaderData).toBeUndefined();
+    expect(header.metadata?.maxGpsTime).toBe(0);
+    expect(header.metadata?.minGpsTime).toBe(0);
+    expect(header.metadata?.timeOffset).toBe(0);
+    const extendedSource = source.slice(0);
+    const extendedDataView = new DataView(extendedSource);
+    extendedDataView.setUint16(94, 400, true);
+    new Uint8Array(extendedSource, 393, 7).set([1, 2, 3, 4, 5, 6, 7]);
+    const extendedHeader = parseLASHeader(extendedSource);
+    expect(Array.from(extendedHeader.userHeaderData!)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    expect(header.metadata?.userHeaderData).toEqual(header.userHeaderData);
+
+    const invalidPointFormat = source.slice(0, header.headerSize!);
+    new DataView(invalidPointFormat).setUint8(104, 5);
+    expect(() => parseLASHeader(invalidPointFormat)).toThrow(/LAS 1.5 requires point data record/);
+
+    const invalidHeader = source.slice(0, 375);
+    new DataView(invalidHeader).setUint16(94, 375, true);
+    expect(() => parseLASHeader(invalidHeader)).toThrow(/LAS 1.5 header must be at least 393/);
+  });
+
   test.each(
     CONFORMANCE_FIXTURES
   )('$label preserves every raw point byte across seeded arbitrary input splits', async fixture => {


### PR DESCRIPTION
## Goals

Harden the TypeScript LAS reader's LAS 1.5 support and make the current compatibility claim precise without changing LAS/LAZ writing.

## Changes

- Validate LAS version numbers accepted by the TypeScript header reader.
- Validate the LAS 1.5 extended header minimum size of 393 bytes.
- Enforce LAS 1.5 modern point data record formats 6-10.
- Parse LAS 1.5 Max GPS Time, Min GPS Time, and Time Offset fields, and preserve any bytes beyond the standard 393-byte header as `userHeaderData` on `LASHeader` and `LASMetadata`.
- Add fixture coverage for LAS 1.5 header metadata and malformed header/point-format combinations.
- Update LAS format support tables and remaining-roadmap status.

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn test-node` (360 passed, 6 skipped)
- Focused LAS 1.5 conformance test (1 passed)

LAS 1.5 writing remains intentionally out of scope for this read-conformance tranche.
