### PR TITLE
test: migrate KML and JSON suites to Vitest

### DIFF
--- a/modules/gis/test/geoarrow/convert-geoarrow-to-binary-geometry.spec.ts
+++ b/modules/gis/test/geoarrow/convert-geoarrow-to-binary-geometry.spec.ts
@@ -332,6 +332,12 @@ async function testGetBinaryGeometriesFromArrow(
   return Promise.resolve();
 }
 
+/**
+ * Converts typed arrays nested in a test result to regular arrays for value-only comparisons.
+ *
+ * @param value - A test result containing arrays, typed arrays, or plain objects.
+ * @returns A structurally equivalent value with typed arrays normalized to regular arrays.
+ */
 function normalizeTypedArrays(value: unknown): unknown {
   if (ArrayBuffer.isView(value)) {
     return Array.from(value as ArrayLike<unknown>);

--- a/modules/json/test/geojson-writer.spec.ts
+++ b/modules/json/test/geojson-writer.spec.ts
@@ -1,15 +1,11 @@
 // loaders.gl
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
-// Copyright 2022 Foursquare Labs, Inc.
 
-/* global TextDecoder */
-import test from 'test/utils/vitest-tape';
-
+import {expect, test} from 'vitest';
 import {GeoJSONWriter} from '@loaders.gl/json';
 import {encodeTableAsText, encodeTableInBatches} from '@loaders.gl/core';
 import {tableWithNullGeometryColumn} from '@loaders.gl/schema-utils/test/shared-utils';
-
 const EXPECTED_GEOJSON = `\
 {
 "type": "FeatureCollection",
@@ -20,15 +16,12 @@ const EXPECTED_GEOJSON = `\
 {"type":"Feature","geometry":null,"properties":{"population":0,"growing":false,"city":"nulltown"}}
 ]
 }`;
-
-test('GeoJSONWriter#encode', async t => {
+test('GeoJSONWriter#encode', async () => {
   const table = tableWithNullGeometryColumn;
   const encodedText = await encodeTableAsText(table, GeoJSONWriter);
-  t.equal(encodedText, EXPECTED_GEOJSON, 'GeoJSONWriter encoded table correctly');
-  t.end();
+  expect(encodedText, 'GeoJSONWriter encoded table correctly').toBe(EXPECTED_GEOJSON);
 });
-
-test('GeoJSONWriter#encodeTableInBatches', async t => {
+test('GeoJSONWriter#encodeTableInBatches', async () => {
   const textDecoder = new TextDecoder();
   const table = tableWithNullGeometryColumn;
   const encodedBatches = encodeTableInBatches(table, GeoJSONWriter);
@@ -36,6 +29,5 @@ test('GeoJSONWriter#encodeTableInBatches', async t => {
   for await (const arrayBuffer of encodedBatches) {
     geojsonText += textDecoder.decode(arrayBuffer);
   }
-  t.equal(geojsonText, EXPECTED_GEOJSON, 'GeoJSONWriter encoded table correctly');
-  t.end();
+  expect(geojsonText, 'GeoJSONWriter encoded table correctly').toBe(EXPECTED_GEOJSON);
 });

--- a/modules/json/test/json-loader.spec.ts
+++ b/modules/json/test/json-loader.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {load, loadInBatches, isIterator, isAsyncIterable} from '@loaders.gl/core';
 import type {Schema} from '@loaders.gl/schema';
 import {ObjectRowTableBatch, getTableLength} from '@loaders.gl/schema-utils';
@@ -17,10 +17,12 @@ import {
 import {getGeoMetadata} from '@loaders.gl/gis';
 import * as jsonModule from '@loaders.gl/json';
 import * as arrow from 'apache-arrow';
-
 const GEOJSON_PATH = '@loaders.gl/json/test/data/geojson-big.json';
 const GEOJSON_KEPLER_DATASET_PATH = '@loaders.gl/json/test/data/kepler-dataset-sf-incidents.json';
-const STREAMING_LOADER_CONFIGS: {name: string; options?: JSONLoaderOptions}[] = [
+const STREAMING_LOADER_CONFIGS: {
+  name: string;
+  options?: JSONLoaderOptions;
+}[] = [
   {name: 'JSONLoader'},
   {name: 'JSONLoader json.backend=fast', options: {json: {backend: 'fast'}}}
 ];
@@ -46,27 +48,21 @@ const NESTED_JSON_TEXT = JSON.stringify({
     }
   ]
 });
-
-test('JSONLoader#load(geojson.json)', async t => {
+test('JSONLoader#load(geojson.json)', async () => {
   const table = await load(GEOJSON_PATH, JSONLoader, {json: {table: true}});
-  t.equal(
+  expect(
     table.shape === 'object-row-table' && table.data.length,
-    308,
     'Correct number of rows received'
-  );
-  t.end();
+  ).toBe(308);
 });
-
-test('JSONTableLoader#parse(arrow-table nested rows)', async t => {
+test('JSONTableLoader#parse(arrow-table nested rows)', async () => {
   const table = BundledJSONTableLoader.parseTextSync?.(NESTED_JSON_TEXT, {
     json: {shape: 'arrow-table'}
   });
-
-  t.equal(table.shape, 'arrow-table', 'returns Arrow table shape');
-  t.equal(table.data.numRows, 2, 'returns two rows');
-
+  expect(table.shape, 'returns Arrow table shape').toBe('arrow-table');
+  expect(table.data.numRows, 'returns two rows').toBe(2);
   const geometryField = table.schema?.fields.find(field => field.name === 'geometry');
-  t.equal(typeof geometryField?.type, 'object', 'geometry schema is nested');
+  expect(typeof geometryField?.type, 'geometry schema is nested').toBe('object');
   if (
     geometryField &&
     typeof geometryField.type === 'object' &&
@@ -75,30 +71,27 @@ test('JSONTableLoader#parse(arrow-table nested rows)', async t => {
     const coordinatesField = geometryField.type.children.find(
       child => child.name === 'coordinates'
     );
-    t.equal(coordinatesField?.type?.type, 'list', 'coordinates schema is list');
+    expect(coordinatesField?.type?.type, 'coordinates schema is list').toBe('list');
   }
-
-  const geometry = table.data.getChild('geometry')?.get(0) as {type: string; coordinates: number[]};
-  t.equal(geometry.type, 'Point', 'geometry struct is materialized');
-  t.deepEqual(
+  const geometry = table.data.getChild('geometry')?.get(0) as {
+    type: string;
+    coordinates: number[];
+  };
+  expect(geometry.type, 'geometry struct is materialized').toBe('Point');
+  expect(
     Array.from(geometry.coordinates as unknown as ArrayLike<number>),
-    [1, 2],
     'geometry coordinates are preserved'
-  );
-
+  ).toEqual([1, 2]);
   const properties = table.data.getChild('properties')?.get(1) as {
     name: string;
     count: number | null;
     active: boolean;
   };
-  t.equal(properties.name, 'B', 'properties struct is materialized');
-  t.equal(properties.count, 0, 'nested numeric values are preserved');
-  t.equal(properties.active, false, 'boolean nested values are preserved');
-
-  t.end();
+  expect(properties.name, 'properties struct is materialized').toBe('B');
+  expect(properties.count, 'nested numeric values are preserved').toBe(0);
+  expect(properties.active, 'boolean nested values are preserved').toBe(false);
 });
-
-test('JSONTableLoader#parse(arrow-table treats GeoJSON as generic JSON rows)', async t => {
+test('JSONTableLoader#parse(arrow-table treats GeoJSON as generic JSON rows)', async () => {
   const table = BundledJSONTableLoader.parseTextSync?.(
     JSON.stringify({
       type: 'FeatureCollection',
@@ -119,23 +112,20 @@ test('JSONTableLoader#parse(arrow-table treats GeoJSON as generic JSON rows)', a
       json: {shape: 'arrow-table'}
     }
   );
-
-  t.equal(table.shape, 'arrow-table', 'returns Arrow table shape');
-  t.equal(table.data.numRows, 2, 'returns feature rows');
-  t.equal(table.data.getChild('type')?.get(0), 'Feature', 'materializes feature envelope type');
-  t.equal(table.data.getChild('name'), null, 'does not lift properties as columns');
-
+  expect(table.shape, 'returns Arrow table shape').toBe('arrow-table');
+  expect(table.data.numRows, 'returns feature rows').toBe(2);
+  expect(table.data.getChild('type')?.get(0), 'materializes feature envelope type').toBe('Feature');
+  expect(table.data.getChild('name'), 'does not lift properties as columns').toBe(null);
   const geometryField = table.schema?.fields.find(field => field.name === 'geometry');
-  t.equal(typeof geometryField?.type, 'object', 'geometry field is nested JSON');
-  t.equal(geometryField?.metadata?.['ARROW:extension:name'], undefined, 'no GeoArrow metadata');
-
-  const properties = table.data.getChild('properties')?.get(0) as {name: string; count: number};
-  t.equal(properties.name, 'A', 'keeps properties as nested struct');
-
-  t.end();
+  expect(typeof geometryField?.type, 'geometry field is nested JSON').toBe('object');
+  expect(geometryField?.metadata?.['ARROW:extension:name'], 'no GeoArrow metadata').toBe(undefined);
+  const properties = table.data.getChild('properties')?.get(0) as {
+    name: string;
+    count: number;
+  };
+  expect(properties.name, 'keeps properties as nested struct').toBe('A');
 });
-
-test('GeoJSONLoader#parse(arrow-table with supplied schema)', async t => {
+test('GeoJSONLoader#parse(arrow-table with supplied schema)', async () => {
   const schema: Schema = {
     fields: [
       {name: 'name', type: 'utf8', nullable: false},
@@ -159,20 +149,19 @@ test('GeoJSONLoader#parse(arrow-table with supplied schema)', async t => {
       json: {schema}
     }
   );
-
-  t.equal(table.schema?.fields[0].name, 'name', 'uses supplied property field');
-  t.equal(table.schema?.fields[1].name, 'geometry', 'uses supplied geometry field');
-  t.equal(
+  expect(table.schema?.fields[0].name, 'uses supplied property field').toBe('name');
+  expect(table.schema?.fields[1].name, 'uses supplied geometry field').toBe('geometry');
+  expect(
     table.schema?.fields[1].metadata?.['ARROW:extension:name'],
-    'geoarrow.wkb',
     'adds GeoArrow WKB extension metadata to supplied schema'
-  );
-  t.equal(table.data.getChild('name')?.get(0), 'A', 'converts properties against schema');
-  t.ok(table.data.getChild('geometry')?.get(0) instanceof Uint8Array, 'converts geometry to WKB');
-  t.end();
+  ).toBe('geoarrow.wkb');
+  expect(table.data.getChild('name')?.get(0), 'converts properties against schema').toBe('A');
+  expect(
+    table.data.getChild('geometry')?.get(0) instanceof Uint8Array,
+    'converts geometry to WKB'
+  ).toBeTruthy();
 });
-
-test('GeoJSONLoader#parse(arrow-table with supplied arrow.Schema)', async t => {
+test('GeoJSONLoader#parse(arrow-table with supplied arrow.Schema)', async () => {
   const schema = new arrow.Schema([
     new arrow.Field('name', new arrow.Utf8(), false),
     new arrow.Field('geometry', new arrow.Binary(), true)
@@ -190,80 +179,71 @@ test('GeoJSONLoader#parse(arrow-table with supplied arrow.Schema)', async t => {
       json: {schema}
     }
   );
-
-  t.equal(table.schema?.fields[1].name, 'geometry', 'normalizes supplied Arrow schema');
-  t.equal(
+  expect(table.schema?.fields[1].name, 'normalizes supplied Arrow schema').toBe('geometry');
+  expect(
     table.schema?.fields[1].metadata?.['ARROW:extension:name'],
-    'geoarrow.wkb',
     'adds GeoArrow WKB extension metadata'
-  );
-  t.ok(table.data.getChild('geometry')?.get(0) instanceof Uint8Array, 'converts geometry to WKB');
-  t.end();
+  ).toBe('geoarrow.wkb');
+  expect(
+    table.data.getChild('geometry')?.get(0) instanceof Uint8Array,
+    'converts geometry to WKB'
+  ).toBeTruthy();
 });
-
-test('JSONTableLoader#parse(arrow-table empty arrays and rows)', async t => {
+test('JSONTableLoader#parse(arrow-table empty arrays and rows)', async () => {
   const emptyArrayTable = BundledJSONTableLoader.parseTextSync?.(JSON.stringify({items: []}), {
     json: {shape: 'arrow-table'}
   });
-  t.equal(emptyArrayTable.shape, 'arrow-table', 'empty selected array returns Arrow table');
-  t.equal(emptyArrayTable.data.numRows, 0, 'empty selected array keeps zero rows');
-  t.equal(emptyArrayTable.data.numCols, 0, 'empty selected array keeps zero columns');
-
+  expect(emptyArrayTable.shape, 'empty selected array returns Arrow table').toBe('arrow-table');
+  expect(emptyArrayTable.data.numRows, 'empty selected array keeps zero rows').toBe(0);
+  expect(emptyArrayTable.data.numCols, 'empty selected array keeps zero columns').toBe(0);
   const emptyObjectRowsTable = BundledJSONTableLoader.parseTextSync?.(
     JSON.stringify({items: [{}, {}]}),
     {
       json: {shape: 'arrow-table'}
     }
   );
-  t.equal(emptyObjectRowsTable.data.numRows, 2, 'array of empty objects keeps row count');
-  t.equal(emptyObjectRowsTable.data.numCols, 0, 'array of empty objects keeps zero columns');
-
-  t.end();
+  expect(emptyObjectRowsTable.data.numRows, 'array of empty objects keeps row count').toBe(2);
+  expect(emptyObjectRowsTable.data.numCols, 'array of empty objects keeps zero columns').toBe(0);
 });
-
-test('JSONTableLoader#load(geojson.json, shape: arrow-table)', async t => {
+test('JSONTableLoader#load(geojson.json, shape: arrow-table)', async () => {
   const arrowTable = await load(GEOJSON_PATH, JSONTableLoader, {
     json: {shape: 'arrow-table'}
   });
-  t.equal(arrowTable.shape, 'arrow-table', 'Correct Arrow table type received');
-  t.equal(arrowTable.data.numRows, 308, 'Correct number of Arrow rows received');
-  t.equal(arrowTable.data.getChild('type')?.get(0), 'Feature', 'Arrow field values are preserved');
-  t.end();
+  expect(arrowTable.shape, 'Correct Arrow table type received').toBe('arrow-table');
+  expect(arrowTable.data.numRows, 'Correct number of Arrow rows received').toBe(308);
+  expect(arrowTable.data.getChild('type')?.get(0), 'Arrow field values are preserved').toBe(
+    'Feature'
+  );
 });
-
-test('JSONTableLoader#parse returns requested row-table shapes', async t => {
+test('JSONTableLoader#parse returns requested row-table shapes', async () => {
   const objectRowTable = BundledJSONTableLoader.parseTextSync?.(
     JSON.stringify([{id: 1, name: 'A'}])
   );
-  t.equal(objectRowTable.shape, 'object-row-table', 'defaults to object-row-table output');
-
+  expect(objectRowTable.shape, 'defaults to object-row-table output').toBe('object-row-table');
   const arrayRowTable = BundledJSONTableLoader.parseTextSync?.(
     JSON.stringify([{id: 1, name: 'A'}]),
     {json: {shape: 'array-row-table'}}
   );
-  t.equal(arrayRowTable.shape, 'array-row-table', 'returns array-row-table output on request');
-  t.deepEqual(arrayRowTable.data[0], [1, 'A'], 'preserves row values during conversion');
-  t.end();
+  expect(arrayRowTable.shape, 'returns array-row-table output on request').toBe('array-row-table');
+  expect(arrayRowTable.data[0], 'preserves row values during conversion').toEqual([1, 'A']);
 });
-
-test('JSONTableLoader#parse rejects non-tabular JSON documents', async t => {
-  t.throws(
+test('JSONTableLoader#parse rejects non-tabular JSON documents', async () => {
+  expect(
     () => BundledJSONTableLoader.parseTextSync?.(JSON.stringify({meta: {source: 'test'}})),
-    /expected a JSON row array or an object containing a JSON row array/,
     'documents without row arrays fail table-only parsing'
-  );
-  t.end();
+  ).toThrow(/expected a JSON row array or an object containing a JSON row array/);
 });
-
 for (const config of STREAMING_LOADER_CONFIGS) {
-  test(`${config.name}#loadInBatches(geojson.json, rows, batchSize = auto)`, async t => {
+  test(`${config.name}#loadInBatches(geojson.json, rows, batchSize = auto)`, async () => {
     const iterator = await loadInBatches(
       GEOJSON_PATH,
       JSONLoader,
       getStreamingLoaderOptions(config)
     );
-    t.ok(isIterator(iterator) || isAsyncIterable(iterator), 'loadInBatches returned iterator');
-
+    expect(
+      isIterator(iterator) || isAsyncIterable(iterator),
+      'loadInBatches returned iterator'
+    ).toBeTruthy();
     let batch;
     let batchCount = 0;
     let rowCount = 0;
@@ -272,17 +252,12 @@ for (const config of STREAMING_LOADER_CONFIGS) {
     for await (batch of iterator) {
       batchCount++;
       rowCount += batch.length;
-      // byteLength = batch.bytesUsed;
     }
-
     // t.comment(JSON.stringify(batchCount));
-    t.ok(batchCount <= 4, 'Correct number of batches received');
-    t.equal(rowCount, 308, 'Correct number of row received');
-    // t.equal(byteLength, 135910, 'Correct number of bytes received');
-    t.end();
+    expect(batchCount <= 4, 'Correct number of batches received').toBeTruthy();
+    expect(rowCount, 'Correct number of row received').toBe(308);
   });
-
-  test(`${config.name}#loadInBatches(geojson.json, rows, batchSize = 10)`, async t => {
+  test(`${config.name}#loadInBatches(geojson.json, rows, batchSize = 10)`, async () => {
     const iterator = await loadInBatches(
       GEOJSON_PATH,
       JSONLoader,
@@ -290,79 +265,66 @@ for (const config of STREAMING_LOADER_CONFIGS) {
         batchSize: 10
       })
     );
-    t.ok(isIterator(iterator) || isAsyncIterable(iterator), 'loadInBatches returned iterator');
-
+    expect(
+      isIterator(iterator) || isAsyncIterable(iterator),
+      'loadInBatches returned iterator'
+    ).toBeTruthy();
     let batch;
     let batchCount = 0;
     let rowCount = 0;
     for await (batch of iterator) {
       // t.comment(`BATCH ${batch.count}: ${batch.length} ${JSON.stringify(batch.data).slice(0, 200)}`);
       if (batchCount < 30) {
-        t.equal(batch.length, 10, `Got correct batch size for batch ${batchCount}`);
+        expect(batch.length, `Got correct batch size for batch ${batchCount}`).toBe(10);
       }
-
       const feature = batch.data[0];
-      t.equal(feature.type, 'Feature', 'row 0 valid');
-      t.equal(feature.geometry.type, 'Point', 'row 0 valid');
-
+      expect(feature.type, 'row 0 valid').toBe('Feature');
+      expect(feature.geometry.type, 'row 0 valid').toBe('Point');
       batchCount++;
       rowCount += batch.length;
     }
-
     const lastFeature = batch.data[batch.data.length - 1];
-    t.equal(lastFeature.type, 'Feature', 'row 0 valid');
-    t.equal(lastFeature.properties.name, 'West Oakland (WOAK)', 'row 0 valid');
-
-    t.equal(batchCount, 31, 'Correct number of batches received');
-    t.equal(rowCount, 308, 'Correct number of row received');
-    t.end();
+    expect(lastFeature.type, 'row 0 valid').toBe('Feature');
+    expect(lastFeature.properties.name, 'row 0 valid').toBe('West Oakland (WOAK)');
+    expect(batchCount, 'Correct number of batches received').toBe(31);
+    expect(rowCount, 'Correct number of row received').toBe(308);
   });
 }
-
-test('JSONLoader#parseInBatches(complete rows with nested arrays)', async t => {
+test('JSONLoader#parseInBatches(complete rows with nested arrays)', async () => {
   const valueCount = 2048;
   const rows = Array.from({length: 3}, (_, rowIndex) => ({
     text: `row-${rowIndex}`,
     values: Array.from({length: valueCount}, (_, valueIndex) => rowIndex * valueCount + valueIndex)
   }));
-
   const iterator = BundledJSONLoader.parseInBatches?.(
     makeChunkedTextIterator(JSON.stringify(rows), 128),
     {
       batchSize: 1
     }
   );
-
-  t.ok(iterator, 'parseInBatches returned iterator');
+  expect(iterator, 'parseInBatches returned iterator').toBeTruthy();
   if (!iterator) {
-    t.end();
     return;
   }
-
   let emittedRowCount = 0;
   for await (const batch of iterator) {
     if (batch.batchType === 'data') {
-      t.equal(batch.length, 1, 'fixed-size batch contains one complete row');
+      expect(batch.length, 'fixed-size batch contains one complete row').toBe(1);
       for (const row of batch.data) {
         const expectedFirstValue = emittedRowCount * valueCount;
         emittedRowCount++;
-        t.equal(row.values.length, valueCount, 'nested values array is complete when emitted');
-        t.equal(row.values[0], expectedFirstValue, 'first nested value is preserved');
-        t.equal(
-          row.values[valueCount - 1],
-          expectedFirstValue + valueCount - 1,
-          'last nested value is preserved'
+        expect(row.values.length, 'nested values array is complete when emitted').toBe(valueCount);
+        expect(row.values[0], 'first nested value is preserved').toBe(expectedFirstValue);
+        expect(row.values[valueCount - 1], 'last nested value is preserved').toBe(
+          expectedFirstValue + valueCount - 1
         );
       }
     }
   }
-
-  t.equal(emittedRowCount, rows.length, 'all rows were emitted');
-  t.end();
+  expect(emittedRowCount, 'all rows were emitted').toBe(rows.length);
 });
-
 for (const config of STREAMING_LOADER_CONFIGS) {
-  test(`${config.name}#loadInBatches(jsonpaths)`, async t => {
+  test(`${config.name}#loadInBatches(jsonpaths)`, async () => {
     let iterator = await loadInBatches(
       GEOJSON_PATH,
       JSONLoader,
@@ -370,7 +332,6 @@ for (const config of STREAMING_LOADER_CONFIGS) {
         json: {jsonpaths: ['$.features']}
       })
     );
-
     // let batchCount = 0;
     let rowCount = 0;
     // let byteLength = 0;
@@ -379,54 +340,46 @@ for (const config of STREAMING_LOADER_CONFIGS) {
       rowCount += batch.length;
       // byteLength = batch.bytesUsed;
       // @ts-ignore
-      t.equal(batch.jsonpath?.toString(), '$.features', 'correct jsonpath on batch');
+      expect(batch.jsonpath?.toString(), 'correct jsonpath on batch').toBe('$.features');
     }
-
     // t.skip(batchCount <= 3, 'Correct number of batches received');
-    t.equal(rowCount, 308, 'Correct number of row received');
+    expect(rowCount, 'Correct number of row received').toBe(308);
     // t.equal(byteLength, 135910, 'Correct number of bytes received');
-
     iterator = await loadInBatches(
       GEOJSON_PATH,
       JSONLoader,
       getStreamingLoaderOptions(config, {json: {jsonpaths: ['$.featureTypo']}})
     );
-
     rowCount = 0;
     for await (const batch of iterator) {
       rowCount += batch.length;
     }
-
-    t.equal(rowCount, 0, 'Correct number of row received');
-    t.end();
+    expect(rowCount, 'Correct number of row received').toBe(0);
   });
 }
-
-test('GeoJSONLoader#loadInBatches(arrow-table streams GeoArrow WKB)', async t => {
+test('GeoJSONLoader#loadInBatches(arrow-table streams GeoArrow WKB)', async () => {
   const iterator = await loadInBatches(GEOJSON_PATH, GeoJSONLoader, {
     batchSize: 10,
     geojson: {shape: 'arrow-table'}
   });
-
   let rowCount = 0;
   for await (const batch of iterator) {
-    t.equal(batch.shape, 'arrow-table', 'data batch is converted to Arrow');
-    t.equal(
+    expect(batch.shape, 'data batch is converted to Arrow').toBe('arrow-table');
+    expect(
       batch.schema?.fields.find(field => field.name === 'geometry')?.metadata?.[
         'ARROW:extension:name'
       ],
-      'geoarrow.wkb',
       'geometry field carries GeoArrow WKB metadata'
-    );
-    t.ok(batch.data.getChild('geometry')?.get(0) instanceof Uint8Array, 'geometry is WKB');
+    ).toBe('geoarrow.wkb');
+    expect(
+      batch.data.getChild('geometry')?.get(0) instanceof Uint8Array,
+      'geometry is WKB'
+    ).toBeTruthy();
     rowCount += batch.length;
   }
-
-  t.equal(rowCount, 308, 'converts all streamed feature rows');
-  t.end();
+  expect(rowCount, 'converts all streamed feature rows').toBe(308);
 });
-
-test('GeoJSONLoader#parseInBatches(arrow-table applies early legacy GeoJSON CRS)', async t => {
+test('GeoJSONLoader#parseInBatches(arrow-table applies early legacy GeoJSON CRS)', async () => {
   const crs = {type: 'name', properties: {name: 'EPSG:4326'}};
   const iterator = BundledGeoJSONLoader.parseInBatches?.(
     makeChunkedTextIterator(
@@ -445,25 +398,20 @@ test('GeoJSONLoader#parseInBatches(arrow-table applies early legacy GeoJSON CRS)
     ),
     {batchSize: 1, geojson: {shape: 'arrow-table'}}
   );
-
   let dataBatchCount = 0;
   for await (const batch of iterator) {
-    t.equal(batch.batchType, 'data', 'internal metadata batches are not emitted');
+    expect(batch.batchType, 'internal metadata batches are not emitted').toBe('data');
     const geoMetadata = getGeoMetadata(batch.schema?.metadata);
-    t.deepEqual(geoMetadata?.columns.geometry.geojson_crs, crs, 'preserves root CRS on schema');
-    t.equal(
+    expect(geoMetadata?.columns.geometry.geojson_crs, 'preserves root CRS on schema').toEqual(crs);
+    expect(
       (geoMetadata?.columns.geometry.crs as any)?.id?.code,
-      4326,
       'maps known root CRS before first feature batch'
-    );
+    ).toBe(4326);
     dataBatchCount++;
   }
-
-  t.equal(dataBatchCount, 1, 'received one data batch');
-  t.end();
+  expect(dataBatchCount, 'received one data batch').toBe(1);
 });
-
-test('GeoJSONLoader#parseInBatches(arrow-table ignores late legacy GeoJSON CRS)', async t => {
+test('GeoJSONLoader#parseInBatches(arrow-table ignores late legacy GeoJSON CRS)', async () => {
   const iterator = BundledGeoJSONLoader.parseInBatches?.(
     makeChunkedTextIterator(
       JSON.stringify({
@@ -481,21 +429,17 @@ test('GeoJSONLoader#parseInBatches(arrow-table ignores late legacy GeoJSON CRS)'
     ),
     {batchSize: 1, geojson: {shape: 'arrow-table'}}
   );
-
   let dataBatchCount = 0;
   for await (const batch of iterator) {
-    t.equal(batch.batchType, 'data', 'late CRS does not force metadata batches');
+    expect(batch.batchType, 'late CRS does not force metadata batches').toBe('data');
     const geoMetadata = getGeoMetadata(batch.schema?.metadata);
-    t.equal(geoMetadata?.columns.geometry.geojson_crs, undefined, 'late CRS is ignored');
-    t.equal(geoMetadata?.columns.geometry.crs, undefined, 'late CRS is not mapped');
+    expect(geoMetadata?.columns.geometry.geojson_crs, 'late CRS is ignored').toBe(undefined);
+    expect(geoMetadata?.columns.geometry.crs, 'late CRS is not mapped').toBe(undefined);
     dataBatchCount++;
   }
-
-  t.equal(dataBatchCount, 1, 'received one data batch');
-  t.end();
+  expect(dataBatchCount, 'received one data batch').toBe(1);
 });
-
-test('GeoJSONLoader#parseInBatches(arrow-table freezes inferred schema)', async t => {
+test('GeoJSONLoader#parseInBatches(arrow-table freezes inferred schema)', async () => {
   const iterator = BundledGeoJSONLoader.parseInBatches?.(
     makeChunkedTextIterator(
       JSON.stringify({
@@ -513,25 +457,18 @@ test('GeoJSONLoader#parseInBatches(arrow-table freezes inferred schema)', async 
           }
         ]
       }),
-      1000
+      20
     ),
     {batchSize: 1, geojson: {shape: 'arrow-table'}}
   );
-
-  await t.rejects(
-    async () => {
-      for await (const _batch of iterator) {
-        // Consume batches until the second feature violates the frozen schema.
-      }
-    },
-    /unexpected field extra/,
-    'later streamed feature batches are converted against the frozen schema'
+  await expect(async () => {
+    for await (const _batch of iterator) {
+    }
+  }, 'later streamed feature batches are converted against the frozen schema').rejects.toThrow(
+    /unexpected field extra/
   );
-
-  t.end();
 });
-
-test('JSONTableLoader#parseInBatches(arrow-table preserves metadata batches)', async t => {
+test('JSONTableLoader#parseInBatches(arrow-table preserves metadata batches)', async () => {
   const iterator = BundledJSONTableLoader.parseInBatches?.(
     makeChunkedTextIterator(NESTED_JSON_TEXT, 13),
     {
@@ -543,35 +480,28 @@ test('JSONTableLoader#parseInBatches(arrow-table preserves metadata batches)', a
       }
     }
   );
-
   let dataBatchCount = 0;
   for await (const batch of iterator) {
     switch (batch.batchType) {
       case 'partial-result':
-        t.ok(batch.container, 'partial-result retains container metadata');
+        expect(batch.container, 'partial-result retains container metadata').toBeTruthy();
         break;
-
       case 'data':
-        t.equal(batch.shape, 'arrow-table', 'data batch is converted to Arrow');
-        t.equal(batch.data.numRows, 1, 'batch size is preserved after Arrow conversion');
+        expect(batch.shape, 'data batch is converted to Arrow').toBe('arrow-table');
+        expect(batch.data.numRows, 'batch size is preserved after Arrow conversion').toBe(1);
         dataBatchCount++;
         break;
-
       case 'final-result':
-        t.equal(batch.shape, 'json', 'final-result batch keeps JSON shape');
-        t.ok(batch.container, 'final-result retains container metadata');
+        expect(batch.shape, 'final-result batch keeps JSON shape').toBe('json');
+        expect(batch.container, 'final-result retains container metadata').toBeTruthy();
         break;
-
       default:
     }
   }
-
-  t.equal(dataBatchCount, 2, 'received both Arrow data batches');
-  t.end();
+  expect(dataBatchCount, 'received both Arrow data batches').toBe(2);
 });
-
-test('JSONTableLoader#parse(arrow-table rejects incompatible field shapes)', async t => {
-  t.throws(
+test('JSONTableLoader#parse(arrow-table rejects incompatible field shapes)', async () => {
+  expect(
     () =>
       BundledJSONTableLoader.parseTextSync?.(
         JSON.stringify({items: [{value: 1}, {value: {nested: true}}]}),
@@ -579,14 +509,10 @@ test('JSONTableLoader#parse(arrow-table rejects incompatible field shapes)', asy
           json: {shape: 'arrow-table'}
         }
       ),
-    /incompatible Arrow field types/,
     'throws when rows disagree on field shape'
-  );
-
-  t.end();
+  ).toThrow(/incompatible Arrow field types/);
 });
-
-test('JSONTableLoader#parse(arrow-table with supplied loaders.gl schema)', async t => {
+test('JSONTableLoader#parse(arrow-table with supplied loaders.gl schema)', async () => {
   const schema: Schema = {
     fields: [
       {name: 'id', type: 'float64', nullable: false},
@@ -594,24 +520,19 @@ test('JSONTableLoader#parse(arrow-table with supplied loaders.gl schema)', async
     ],
     metadata: {}
   };
-
   const table = BundledJSONTableLoader.parseTextSync?.(JSON.stringify([{id: 1, name: 'A'}]), {
     json: {shape: 'arrow-table', schema}
   });
-
-  t.equal(table.shape, 'arrow-table', 'returns Arrow table');
-  t.equal(table.schema?.fields[0].name, 'id', 'uses supplied schema fields');
-  t.equal(table.data.getChild('id')?.get(0), 1, 'converts numeric field');
-  t.equal(table.data.getChild('name')?.get(0), 'A', 'converts string field');
-  t.end();
+  expect(table.shape, 'returns Arrow table').toBe('arrow-table');
+  expect(table.schema?.fields[0].name, 'uses supplied schema fields').toBe('id');
+  expect(table.data.getChild('id')?.get(0), 'converts numeric field').toBe(1);
+  expect(table.data.getChild('name')?.get(0), 'converts string field').toBe('A');
 });
-
-test('JSONTableLoader#parse(arrow-table prefers supported Arrow view types)', async t => {
+test('JSONTableLoader#parse(arrow-table prefers supported Arrow view types)', async () => {
   const schema: Schema = {
     fields: [{name: 'name', type: 'utf8', nullable: false}],
     metadata: {}
   };
-
   const table = BundledJSONTableLoader.parseTextSync?.(JSON.stringify([{name: 'Arrow'}]), {
     json: {
       shape: 'arrow-table',
@@ -619,35 +540,27 @@ test('JSONTableLoader#parse(arrow-table prefers supported Arrow view types)', as
       arrowConversion: {viewTypes: 'require'}
     }
   });
-
-  t.equal(table.data.schema.fields[0].type.constructor.name, 'Utf8View');
-  t.deepEqual(
+  expect(table.data.schema.fields[0].type.constructor.name).toBe('Utf8View');
+  expect(
     table.schema?.fields.map(field => field.type),
-    ['utf8-view'],
     'reports the selected physical types'
-  );
-  t.equal(table.data.getChild('name')?.get(0), 'Arrow');
-  t.end();
+  ).toEqual(['utf8-view']);
+  expect(table.data.getChild('name')?.get(0)).toBe('Arrow');
 });
-
-test('JSONTableLoader#parse(arrow-table with supplied arrow.Schema)', async t => {
+test('JSONTableLoader#parse(arrow-table with supplied arrow.Schema)', async () => {
   const schema = new arrow.Schema([
     new arrow.Field('id', new arrow.Float64(), false),
     new arrow.Field('name', new arrow.Utf8(), true)
   ]);
-
   const table = BundledJSONTableLoader.parseTextSync?.(JSON.stringify([{id: 1, name: 'A'}]), {
     json: {shape: 'arrow-table', schema}
   });
-
-  t.equal(table.shape, 'arrow-table', 'returns Arrow table');
-  t.equal(table.schema?.fields[1].name, 'name', 'normalizes Arrow schema');
-  t.equal(table.data.getChild('id')?.get(0), 1, 'converts numeric field');
-  t.equal(table.data.getChild('name')?.get(0), 'A', 'converts string field');
-  t.end();
+  expect(table.shape, 'returns Arrow table').toBe('arrow-table');
+  expect(table.schema?.fields[1].name, 'normalizes Arrow schema').toBe('name');
+  expect(table.data.getChild('id')?.get(0), 'converts numeric field').toBe(1);
+  expect(table.data.getChild('name')?.get(0), 'converts string field').toBe('A');
 });
-
-test('JSONTableLoader#parse(arrow-table conversion policy)', async t => {
+test('JSONTableLoader#parse(arrow-table conversion policy)', async () => {
   const nullableSchema: Schema = {
     fields: [{name: 'id', type: 'float64', nullable: true}],
     metadata: {}
@@ -656,16 +569,13 @@ test('JSONTableLoader#parse(arrow-table conversion policy)', async t => {
     fields: [{name: 'id', type: 'float64', nullable: false}],
     metadata: {}
   };
-
-  t.throws(
+  expect(
     () =>
       BundledJSONTableLoader.parseTextSync?.(JSON.stringify([{id: 'bad'}]), {
         json: {shape: 'arrow-table', schema: nullableSchema}
       }),
-    /expected number/,
     'strict mode rejects type mismatches'
-  );
-
+  ).toThrow(/expected number/);
   const typeMismatchLog = makeTestLog();
   const nullTypeTable = BundledJSONTableLoader.parseTextSync?.(
     JSON.stringify([{id: 'bad'}, {id: 'worse'}]),
@@ -678,18 +588,15 @@ test('JSONTableLoader#parse(arrow-table conversion policy)', async t => {
       }
     }
   );
-  t.equal(nullTypeTable.data.getChild('id')?.get(0), null, 'type mismatch can recover to null');
-  t.equal(typeMismatchLog.messages.length, 1, 'type mismatch recovery logs once');
-
-  t.throws(
+  expect(nullTypeTable.data.getChild('id')?.get(0), 'type mismatch can recover to null').toBe(null);
+  expect(typeMismatchLog.messages.length, 'type mismatch recovery logs once').toBe(1);
+  expect(
     () =>
       BundledJSONTableLoader.parseTextSync?.(JSON.stringify([{}]), {
         json: {shape: 'arrow-table', schema: nullableSchema}
       }),
-    /missing field id/,
     'strict mode rejects missing fields'
-  );
-
+  ).toThrow(/missing field id/);
   const missingFieldLog = makeTestLog();
   const missingFieldTable = BundledJSONTableLoader.parseTextSync?.(JSON.stringify([{}, {}]), {
     core: {log: missingFieldLog},
@@ -699,18 +606,17 @@ test('JSONTableLoader#parse(arrow-table conversion policy)', async t => {
       arrowConversion: {onMissingField: 'null'}
     }
   });
-  t.equal(missingFieldTable.data.getChild('id')?.get(0), null, 'missing field can recover to null');
-  t.equal(missingFieldLog.messages.length, 1, 'missing field recovery logs once');
-
-  t.throws(
+  expect(missingFieldTable.data.getChild('id')?.get(0), 'missing field can recover to null').toBe(
+    null
+  );
+  expect(missingFieldLog.messages.length, 'missing field recovery logs once').toBe(1);
+  expect(
     () =>
       BundledJSONTableLoader.parseTextSync?.(JSON.stringify([{id: 1, extra: true}]), {
         json: {shape: 'arrow-table', schema: nullableSchema}
       }),
-    /unexpected field extra/,
     'strict mode rejects extra fields'
-  );
-
+  ).toThrow(/unexpected field extra/);
   const extraFieldLog = makeTestLog();
   const dropExtraTable = BundledJSONTableLoader.parseTextSync?.(
     JSON.stringify([
@@ -726,11 +632,10 @@ test('JSONTableLoader#parse(arrow-table conversion policy)', async t => {
       }
     }
   );
-  t.equal(dropExtraTable.data.numCols, 1, 'extra field is dropped');
-  t.equal(dropExtraTable.data.getChild('extra'), null, 'extra field is not materialized');
-  t.equal(extraFieldLog.messages.length, 1, 'extra field recovery logs once');
-
-  t.throws(
+  expect(dropExtraTable.data.numCols, 'extra field is dropped').toBe(1);
+  expect(dropExtraTable.data.getChild('extra'), 'extra field is not materialized').toBe(null);
+  expect(extraFieldLog.messages.length, 'extra field recovery logs once').toBe(1);
+  expect(
     () =>
       BundledJSONTableLoader.parseTextSync?.(JSON.stringify([{id: 'bad'}]), {
         json: {
@@ -739,14 +644,10 @@ test('JSONTableLoader#parse(arrow-table conversion policy)', async t => {
           arrowConversion: {onTypeMismatch: 'null'}
         }
       }),
-    /expected number/,
     'non-nullable field still rejects null recovery'
-  );
-
-  t.end();
+  ).toThrow(/expected number/);
 });
-
-test('JSONTableLoader#parse(arrow-table integer conversion policy)', async t => {
+test('JSONTableLoader#parse(arrow-table integer conversion policy)', async () => {
   const nullableSchema: Schema = {
     fields: [{name: 'id', type: 'int8', nullable: true}],
     metadata: {}
@@ -755,17 +656,14 @@ test('JSONTableLoader#parse(arrow-table integer conversion policy)', async t => 
     fields: [{name: 'id', type: 'int8', nullable: false}],
     metadata: {}
   };
-
-  t.throws(
+  expect(
     () =>
       BundledJSONTableLoader.parseTextSync?.(JSON.stringify([{id: 1.5}]), {
         json: {shape: 'arrow-table', schema: nullableSchema}
       }),
-    /expected integer/,
     'strict mode rejects non-integral integer values'
-  );
-
-  t.throws(
+  ).toThrow(/expected integer/);
+  expect(
     () =>
       BundledJSONTableLoader.parseTextSync?.(JSON.stringify([{id: -1}]), {
         json: {
@@ -773,10 +671,8 @@ test('JSONTableLoader#parse(arrow-table integer conversion policy)', async t => 
           schema: {fields: [{name: 'id', type: 'uint8', nullable: true}], metadata: {}}
         }
       }),
-    /expected integer/,
     'strict mode rejects out-of-range unsigned integer values'
-  );
-
+  ).toThrow(/expected integer/);
   const nullIntegerTable = BundledJSONTableLoader.parseTextSync?.(JSON.stringify([{id: 1.5}]), {
     json: {
       shape: 'arrow-table',
@@ -784,13 +680,11 @@ test('JSONTableLoader#parse(arrow-table integer conversion policy)', async t => 
       arrowConversion: {integerConversion: 'null'}
     }
   });
-  t.equal(
+  expect(
     nullIntegerTable.data.getChild('id')?.get(0),
-    null,
     'integer conversion can recover to null'
-  );
-
-  t.throws(
+  ).toBe(null);
+  expect(
     () =>
       BundledJSONTableLoader.parseTextSync?.(JSON.stringify([{id: 1.5}]), {
         json: {
@@ -799,10 +693,8 @@ test('JSONTableLoader#parse(arrow-table integer conversion policy)', async t => 
           arrowConversion: {integerConversion: 'null'}
         }
       }),
-    /expected integer/,
     'non-nullable integer field still rejects null recovery'
-  );
-
+  ).toThrow(/expected integer/);
   const clampedIntegerTable = BundledJSONTableLoader.parseTextSync?.(
     JSON.stringify([{id: 127.6}]),
     {
@@ -813,12 +705,10 @@ test('JSONTableLoader#parse(arrow-table integer conversion policy)', async t => 
       }
     }
   );
-  t.equal(
+  expect(
     clampedIntegerTable.data.getChild('id')?.get(0),
-    127,
     'integer conversion can round and clamp'
-  );
-
+  ).toBe(127);
   const integerConversionLog = makeTestLog();
   const warnedIntegerTable = BundledJSONTableLoader.parseTextSync?.(
     JSON.stringify([{id: 2.5}, {id: 3.5}]),
@@ -831,27 +721,21 @@ test('JSONTableLoader#parse(arrow-table integer conversion policy)', async t => 
       }
     }
   );
-  t.equal(warnedIntegerTable.data.getChild('id')?.get(0), 3, 'warn mode rounds values');
-  t.equal(integerConversionLog.messages.length, 1, 'integer conversion warning logs once');
-
-  t.end();
+  expect(warnedIntegerTable.data.getChild('id')?.get(0), 'warn mode rounds values').toBe(3);
+  expect(integerConversionLog.messages.length, 'integer conversion warning logs once').toBe(1);
 });
-
-test('JSONTableLoader#parse(arrow-table Utf8 numeric conversion policy)', async t => {
+test('JSONTableLoader#parse(arrow-table Utf8 numeric conversion policy)', async () => {
   const schema: Schema = {
     fields: [{name: 'id', type: 'utf8', nullable: false}],
     metadata: {}
   };
-
-  t.throws(
+  expect(
     () =>
       BundledJSONTableLoader.parseTextSync?.(JSON.stringify([{id: 7}]), {
         json: {shape: 'arrow-table', schema}
       }),
-    /expected string/,
     'strict mode rejects numeric Utf8 values by default'
-  );
-
+  ).toThrow(/expected string/);
   const table = BundledJSONTableLoader.parseTextSync?.(JSON.stringify([{id: 7}, {id: '8'}]), {
     json: {
       shape: 'arrow-table',
@@ -859,10 +743,9 @@ test('JSONTableLoader#parse(arrow-table Utf8 numeric conversion policy)', async 
       arrowConversion: {utf8Conversion: 'number-to-string'}
     }
   });
-  t.equal(table.data.getChild('id')?.get(0), '7', 'numeric Utf8 values can coerce to strings');
-  t.equal(table.data.getChild('id')?.get(1), '8', 'string Utf8 values remain unchanged');
-
-  t.throws(
+  expect(table.data.getChild('id')?.get(0), 'numeric Utf8 values can coerce to strings').toBe('7');
+  expect(table.data.getChild('id')?.get(1), 'string Utf8 values remain unchanged').toBe('8');
+  expect(
     () =>
       BundledJSONTableLoader.parseTextSync?.(JSON.stringify([{id: true}]), {
         json: {
@@ -871,43 +754,32 @@ test('JSONTableLoader#parse(arrow-table Utf8 numeric conversion policy)', async 
           arrowConversion: {utf8Conversion: 'number-to-string'}
         }
       }),
-    /expected string/,
     'non-numeric primitive values still reject Utf8 coercion'
-  );
-  t.end();
+  ).toThrow(/expected string/);
 });
-
-test('JSONTableLoader#parse(arrow-table schema options require Arrow shape)', async t => {
+test('JSONTableLoader#parse(arrow-table schema options require Arrow shape)', async () => {
   const schema: Schema = {
     fields: [{name: 'id', type: 'float64', nullable: true}],
     metadata: {}
   };
-
-  t.throws(
+  expect(
     () => BundledJSONTableLoader.parseTextSync?.(JSON.stringify([{id: 1}]), {json: {schema}}),
-    /require json.shape to be "arrow-table"/,
     'schema without Arrow shape throws'
-  );
-
-  t.throws(
+  ).toThrow(/require json.shape to be "arrow-table"/);
+  expect(
     () =>
       BundledJSONTableLoader.parseTextSync?.(JSON.stringify([{id: 1}]), {
         json: {arrowConversion: {onExtraField: 'drop'}}
       }),
-    /require json.shape to be "arrow-table"/,
     'conversion policy without Arrow shape throws'
-  );
-
-  t.end();
+  ).toThrow(/require json.shape to be "arrow-table"/);
 });
-
-test('GeoJSONLoader#parse(arrow-table options require Arrow shape)', async t => {
+test('GeoJSONLoader#parse(arrow-table options require Arrow shape)', async () => {
   const schema: Schema = {
     fields: [{name: 'geometry', type: 'binary', nullable: true}],
     metadata: {}
   };
-
-  t.throws(
+  expect(
     () =>
       BundledGeoJSONLoader.parseTextSync?.(
         JSON.stringify({type: 'FeatureCollection', features: []}),
@@ -915,11 +787,9 @@ test('GeoJSONLoader#parse(arrow-table options require Arrow shape)', async t => 
           json: {schema}
         }
       ),
-    /require geojson.shape to be "arrow-table"/,
     'schema without Arrow shape throws'
-  );
-
-  t.throws(
+  ).toThrow(/require geojson.shape to be "arrow-table"/);
+  expect(
     () =>
       BundledGeoJSONLoader.parseTextSync?.(
         JSON.stringify({type: 'FeatureCollection', features: []}),
@@ -927,11 +797,9 @@ test('GeoJSONLoader#parse(arrow-table options require Arrow shape)', async t => 
           json: {arrowConversion: {onExtraField: 'drop'}}
         }
       ),
-    /require geojson.shape to be "arrow-table"/,
     'conversion policy without Arrow shape throws'
-  );
-
-  t.throws(
+  ).toThrow(/require geojson.shape to be "arrow-table"/);
+  expect(
     () =>
       BundledGeoJSONLoader.parseTextSync?.(
         JSON.stringify({type: 'FeatureCollection', features: []}),
@@ -939,14 +807,10 @@ test('GeoJSONLoader#parse(arrow-table options require Arrow shape)', async t => 
           json: {geoarrowGeometryColumn: 'geom'}
         }
       ),
-    /require geojson.shape to be "arrow-table"/,
     'geometry column option without Arrow shape throws'
-  );
-
-  t.end();
+  ).toThrow(/require geojson.shape to be "arrow-table"/);
 });
-
-test('JSONTableLoader#parseInBatches(arrow-table with supplied schema)', async t => {
+test('JSONTableLoader#parseInBatches(arrow-table with supplied schema)', async () => {
   const schema: Schema = {
     fields: [{name: 'id', type: 'float64', nullable: false}],
     metadata: {}
@@ -958,20 +822,16 @@ test('JSONTableLoader#parseInBatches(arrow-table with supplied schema)', async t
       json: {shape: 'arrow-table', jsonpaths: ['$.items'], schema}
     }
   );
-
   let rowCount = 0;
   for await (const batch of iterator) {
     if (batch.batchType === 'data') {
-      t.equal(batch.schema?.fields[0].name, 'id', 'uses supplied schema in data batch');
+      expect(batch.schema?.fields[0].name, 'uses supplied schema in data batch').toBe('id');
       rowCount += batch.data.numRows;
     }
   }
-
-  t.equal(rowCount, 2, 'converts all streamed rows');
-  t.end();
+  expect(rowCount, 'converts all streamed rows').toBe(2);
 });
-
-test('JSONTableLoader#parseInBatches(fast arrow-table preserves raw Utf8 JSON fields)', async t => {
+test('JSONTableLoader#parseInBatches(fast arrow-table preserves raw Utf8 JSON fields)', async () => {
   const schema: Schema = {
     fields: [
       {name: 'id', type: 'float64', nullable: false},
@@ -993,7 +853,6 @@ test('JSONTableLoader#parseInBatches(fast arrow-table preserves raw Utf8 JSON fi
       arrowConversion: {onMissingField: 'null'}
     }
   });
-
   const metadataValues: (string | null)[] = [];
   const tagValues: (string | null)[] = [];
   const labelValues: string[] = [];
@@ -1004,84 +863,60 @@ test('JSONTableLoader#parseInBatches(fast arrow-table preserves raw Utf8 JSON fi
       labelValues.push(batch.data.getChild('label')?.get(0) as string);
     }
   }
-
-  t.deepEqual(
-    metadataValues,
-    ['{ "nested" : [1, {"escaped":"\\u2603"}] }', null],
-    'object values keep their exact JSON source or null'
-  );
-  t.deepEqual(
-    tagValues,
-    ['[ "alpha" , {"value":2} ]', null],
-    'array values keep their exact JSON source or recovered missing null'
-  );
-  t.deepEqual(labelValues, ['line\nbreak', 'plain'], 'ordinary Utf8 strings still decode');
-  t.end();
+  expect(metadataValues, 'object values keep their exact JSON source or null').toEqual([
+    '{ "nested" : [1, {"escaped":"\\u2603"}] }',
+    null
+  ]);
+  expect(tagValues, 'array values keep their exact JSON source or recovered missing null').toEqual([
+    '[ "alpha" , {"value":2} ]',
+    null
+  ]);
+  expect(labelValues, 'ordinary Utf8 strings still decode').toEqual(['line\nbreak', 'plain']);
 });
-
-test('JSONTableLoader raw Utf8 capture is limited to fast streaming Arrow parsing', async t => {
+test('JSONTableLoader raw Utf8 capture is limited to fast streaming Arrow parsing', async () => {
   const schema: Schema = {
     fields: [{name: 'metadata', type: 'utf8', nullable: false}],
     metadata: {}
   };
   const jsonText = '{"items":[{"metadata":{"nested":true}}]}';
-
-  t.throws(
+  expect(
     () =>
       BundledJSONTableLoader.parseTextSync?.(jsonText, {
         json: {shape: 'arrow-table', schema}
       }),
-    /expected string/,
     'sync parsing still rejects object values for Utf8 schema fields'
-  );
-
+  ).toThrow(/expected string/);
   const iterator = BundledJSONTableLoader.parseInBatches?.(makeChunkedTextIterator(jsonText, 8), {
     batchSize: 1,
     json: {shape: 'arrow-table', jsonpaths: ['$.items'], schema}
   });
-
-  await t.rejects(
-    async () => {
-      for await (const _batch of iterator) {
-        // Consume batches until Arrow conversion reaches the nested object value.
-      }
-    },
-    /expected string/,
-    'clarinet streaming still rejects object values for Utf8 schema fields'
+  await expect(async () => {
+    for await (const _batch of iterator) {
+    }
+  }, 'clarinet streaming still rejects object values for Utf8 schema fields').rejects.toThrow(
+    /expected string/
   );
-  t.end();
 });
-
-test('NDJSONLoader#parseInBatches(arrow-table freezes inferred schema)', async t => {
+test('NDJSONLoader#parseInBatches(arrow-table freezes inferred schema)', async () => {
   const iterator = BundledNDJSONLoader.parseInBatches?.(
     makeChunkedTextIterator('{"id":1}\n{"id":2,"extra":true}\n', 9),
     {batchSize: 1, ndjson: {shape: 'arrow-table'}}
   );
-
-  await t.rejects(
-    async () => {
-      for await (const _batch of iterator) {
-        // Consume batches until the second row violates the frozen schema.
-      }
-    },
-    /unexpected field extra/,
-    'later streamed batches are converted against the frozen schema'
+  await await expect(async () => {
+    for await (const _batch of iterator) {
+    }
+  }, 'later streamed batches are converted against the frozen schema').rejects.toThrow(
+    /unexpected field extra/
   );
-
-  t.end();
 });
-
-test('NDJSONLoader#parse(deprecated json.shape arrow-table alias)', async t => {
+test('NDJSONLoader#parse(deprecated json.shape arrow-table alias)', async () => {
   const table = BundledNDJSONLoader.parseTextSync?.('{"id":1}\n{"id":2}\n', {
     json: {shape: 'arrow-table'}
   });
-
-  t.equal(table.shape, 'arrow-table', 'deprecated json.shape alias requests Arrow output');
-  t.equal(table.data.numRows, 2, 'converts all rows');
-  t.end();
+  expect(table.shape, 'deprecated json.shape alias requests Arrow output').toBe('arrow-table');
+  expect(table.data.numRows, 'converts all rows').toBe(2);
 });
-
-test('NDJSONLoader#parseInBatches(arrow-table treats GeoJSON features as generic rows)', async t => {
+test('NDJSONLoader#parseInBatches(arrow-table treats GeoJSON features as generic rows)', async () => {
   const ndjsonText = `${JSON.stringify({
     type: 'Feature',
     geometry: {type: 'Point', coordinates: [1, 2]},
@@ -1095,44 +930,33 @@ test('NDJSONLoader#parseInBatches(arrow-table treats GeoJSON features as generic
     batchSize: 1,
     ndjson: {shape: 'arrow-table'}
   });
-
   let rowCount = 0;
   for await (const batch of iterator) {
-    t.equal(batch.shape, 'arrow-table', 'data batch is converted to Arrow');
-    t.equal(batch.data.getChild('type')?.get(0), 'Feature', 'keeps feature envelope type');
-    t.equal(batch.data.getChild('name'), null, 'does not lift properties');
-    t.equal(
+    expect(batch.shape, 'data batch is converted to Arrow').toBe('arrow-table');
+    expect(batch.data.getChild('type')?.get(0), 'keeps feature envelope type').toBe('Feature');
+    expect(batch.data.getChild('name'), 'does not lift properties').toBe(null);
+    expect(
       batch.schema?.fields.find(field => field.name === 'geometry')?.metadata?.[
         'ARROW:extension:name'
       ],
-      undefined,
       'does not add GeoArrow metadata'
-    );
+    ).toBe(undefined);
     rowCount += batch.length;
   }
-
-  t.equal(rowCount, 2, 'converts streamed feature rows generically');
-  t.end();
+  expect(rowCount, 'converts streamed feature rows generically').toBe(2);
 });
-
-test('GeoJSONLoader#exports official names only', t => {
-  t.equal(typeof jsonModule.JSONTableLoader, 'object', 'JSONTableLoader is exported');
-  t.equal(typeof jsonModule.GeoJSONLoader, 'object', 'GeoJSONLoader is exported');
-  t.equal(typeof jsonModule.GeoJSONWriter, 'object', 'GeoJSONWriter is exported');
-  t.equal(
-    (jsonModule as any)._GeoJSONLoader,
-    undefined,
-    'underscored GeoJSONLoader is not exported'
+test('GeoJSONLoader#exports official names only', () => {
+  expect(typeof jsonModule.JSONTableLoader, 'JSONTableLoader is exported').toBe('object');
+  expect(typeof jsonModule.GeoJSONLoader, 'GeoJSONLoader is exported').toBe('object');
+  expect(typeof jsonModule.GeoJSONWriter, 'GeoJSONWriter is exported').toBe('object');
+  expect((jsonModule as any)._GeoJSONLoader, 'underscored GeoJSONLoader is not exported').toBe(
+    undefined
   );
-  t.equal(
-    (jsonModule as any)._GeoJSONWriter,
-    undefined,
-    'underscored GeoJSONWriter is not exported'
+  expect((jsonModule as any)._GeoJSONWriter, 'underscored GeoJSONWriter is not exported').toBe(
+    undefined
   );
-  t.end();
 });
-
-test('GeoJSONLoader#parse(default geojson-table shape)', async t => {
+test('GeoJSONLoader#parse(default geojson-table shape)', async () => {
   const table = BundledGeoJSONLoader.parseTextSync?.(
     JSON.stringify({
       type: 'FeatureCollection',
@@ -1145,13 +969,10 @@ test('GeoJSONLoader#parse(default geojson-table shape)', async t => {
       ]
     })
   );
-
-  t.equal(table.shape, 'geojson-table', 'returns GeoJSON table by default');
-  t.equal(table.features.length, 1, 'returns features');
-  t.end();
+  expect(table.shape, 'returns GeoJSON table by default').toBe('geojson-table');
+  expect(table.features.length, 'returns features').toBe(1);
 });
-
-test('GeoJSONLoader#parse(binary-feature-collection shape)', async t => {
+test('GeoJSONLoader#parse(binary-feature-collection shape)', async () => {
   const binary = BundledGeoJSONLoader.parseTextSync?.(
     JSON.stringify({
       type: 'FeatureCollection',
@@ -1165,13 +986,10 @@ test('GeoJSONLoader#parse(binary-feature-collection shape)', async t => {
     }),
     {geojson: {shape: 'binary-feature-collection'}}
   );
-
-  t.equal(binary.shape, 'binary-feature-collection', 'returns binary feature collection');
-  t.ok(binary.points, 'returns point binary features');
-  t.end();
+  expect(binary.shape, 'returns binary feature collection').toBe('binary-feature-collection');
+  expect(binary.points, 'returns point binary features').toBeTruthy();
 });
-
-test('GeoJSONLoader#parse(arrow-table GeoArrow WKB)', async t => {
+test('GeoJSONLoader#parse(arrow-table GeoArrow WKB)', async () => {
   const table = BundledGeoJSONLoader.parseTextSync?.(
     JSON.stringify({
       type: 'FeatureCollection',
@@ -1185,21 +1003,20 @@ test('GeoJSONLoader#parse(arrow-table GeoArrow WKB)', async t => {
     }),
     {geojson: {shape: 'arrow-table'}}
   );
-
-  t.equal(table.shape, 'arrow-table', 'returns Arrow table');
-  t.equal(table.data.getChild('name')?.get(0), 'A', 'lifts properties as columns');
+  expect(table.shape, 'returns Arrow table').toBe('arrow-table');
+  expect(table.data.getChild('name')?.get(0), 'lifts properties as columns').toBe('A');
   const geometryField = table.schema?.fields.find(field => field.name === 'geometry');
-  t.equal(geometryField?.type, 'binary', 'geometry field is binary');
-  t.equal(
+  expect(geometryField?.type, 'geometry field is binary').toBe('binary');
+  expect(
     geometryField?.metadata?.['ARROW:extension:name'],
-    'geoarrow.wkb',
     'geometry field carries GeoArrow WKB extension metadata'
-  );
-  t.ok(table.data.getChild('geometry')?.get(0) instanceof Uint8Array, 'geometry is WKB');
-  t.end();
+  ).toBe('geoarrow.wkb');
+  expect(
+    table.data.getChild('geometry')?.get(0) instanceof Uint8Array,
+    'geometry is WKB'
+  ).toBeTruthy();
 });
-
-test('GeoJSONLoader#parse(arrow-table preserves legacy GeoJSON CRS)', async t => {
+test('GeoJSONLoader#parse(arrow-table preserves legacy GeoJSON CRS)', async () => {
   const crs = {type: 'name', properties: {name: 'urn:ogc:def:crs:OGC:1.3:CRS84'}};
   const table = BundledGeoJSONLoader.parseTextSync?.(
     JSON.stringify({
@@ -1216,18 +1033,14 @@ test('GeoJSONLoader#parse(arrow-table preserves legacy GeoJSON CRS)', async t =>
     {geojson: {shape: 'arrow-table'}}
   );
   const geoMetadata = getGeoMetadata(table.schema?.metadata);
-
-  t.deepEqual(geoMetadata?.columns.geometry.geojson_crs, crs, 'preserves raw root CRS');
-  t.equal(
+  expect(geoMetadata?.columns.geometry.geojson_crs, 'preserves raw root CRS').toEqual(crs);
+  expect(
     (geoMetadata?.columns.geometry.crs as any)?.id?.code,
-    'CRS84',
     'maps known root CRS to GeoArrow CRS metadata'
-  );
-  t.end();
+  ).toBe('CRS84');
 });
-
 for (const config of TABLE_STREAMING_LOADER_CONFIGS) {
-  test(`${config.name}#loadInBatches(jsonpaths, shape: arrow-table)`, async t => {
+  test(`${config.name}#loadInBatches(jsonpaths, shape: arrow-table)`, async () => {
     const schema: Schema = {
       fields: [{name: 'type', type: 'utf8', nullable: false}],
       metadata: {}
@@ -1244,7 +1057,6 @@ for (const config of TABLE_STREAMING_LOADER_CONFIGS) {
         }
       })
     );
-
     let rowCount = 0;
     let dataBatchCount = 0;
     for await (const batch of iterator) {
@@ -1252,32 +1064,25 @@ for (const config of TABLE_STREAMING_LOADER_CONFIGS) {
         dataBatchCount++;
         rowCount += batch.data.numRows;
         // @ts-ignore
-        t.equal(batch.jsonpath?.toString(), '$.features', 'correct jsonpath on Arrow batch');
+        expect(batch.jsonpath?.toString(), 'correct jsonpath on Arrow batch').toBe('$.features');
       }
     }
-
-    t.ok(dataBatchCount > 0, 'received Arrow data batches');
-    t.equal(rowCount, 308, 'Correct number of Arrow rows received');
-    t.end();
+    expect(dataBatchCount > 0, 'received Arrow data batches').toBeTruthy();
+    expect(rowCount, 'Correct number of Arrow rows received').toBe(308);
   });
 }
-
-test('GeoJSONLoader#loadInBatches(jsonpaths)', async t => {
+test('GeoJSONLoader#loadInBatches(jsonpaths)', async () => {
   const iterator = await loadInBatches(GEOJSON_PATH, GeoJSONLoader, {
     json: {jsonpaths: ['$.features']}
   });
-
   let rowCount = 0;
   for await (const batch of iterator) {
     rowCount += batch.length;
     // @ts-ignore
-    t.equal(batch.jsonpath?.toString(), '$.features', 'correct jsonpath on batch');
+    expect(batch.jsonpath?.toString(), 'correct jsonpath on batch').toBe('$.features');
   }
-
-  t.equal(rowCount, 308, 'Correct number of row received');
-  t.end();
+  expect(rowCount, 'Correct number of row received').toBe(308);
 });
-
 // TODO - columnar table batch support not yet fixed
 /*
 test('JSONLoader#loadInBatches(geojson.json, columns, batchSize = auto)', async t => {
@@ -1301,32 +1106,31 @@ test('JSONLoader#loadInBatches(geojson.json, columns, batchSize = auto)', async 
   t.end();
 });
 */
-
-async function testContainerBatches(t, iterator, expectedCount) {
+async function testContainerBatches(iterator, expectedCount) {
   let opencontainerBatchCount = 0;
   let closecontainerBatchCount = 0;
-
   for await (const batch of iterator) {
     switch (batch.batchType) {
       case 'partial-result':
-        t.ok(batch.container.type, 'batch.container should be set on partial-result');
+        expect(
+          batch.container.type,
+          'batch.container should be set on partial-result'
+        ).toBeTruthy();
         opencontainerBatchCount++;
         break;
       case 'final-result':
-        t.ok(batch.container.type, 'batch.container should be set on final-result');
+        expect(batch.container.type, 'batch.container should be set on final-result').toBeTruthy();
         closecontainerBatchCount++;
         break;
       default:
-        t.notOk(batch.container, 'batch.container should not be set');
+        expect(batch.container, 'batch.container should not be set').toBeFalsy();
     }
   }
-
-  t.equal(opencontainerBatchCount, expectedCount, 'partial-result batch as expected');
-  t.equal(closecontainerBatchCount, expectedCount, 'final-result batch as expected');
+  expect(opencontainerBatchCount, 'partial-result batch as expected').toBe(expectedCount);
+  expect(closecontainerBatchCount, 'final-result batch as expected').toBe(expectedCount);
 }
-
 for (const config of STREAMING_LOADER_CONFIGS) {
-  test(`${config.name}#loadInBatches(geojson.json, {metadata: true})`, async t => {
+  test(`${config.name}#loadInBatches(geojson.json, {metadata: true})`, async () => {
     let iterator = await loadInBatches(
       GEOJSON_PATH,
       JSONLoader,
@@ -1335,8 +1139,7 @@ for (const config of STREAMING_LOADER_CONFIGS) {
         json: {table: true}
       })
     );
-    await testContainerBatches(t, iterator, 1);
-
+    await testContainerBatches(iterator, 1);
     iterator = await loadInBatches(
       GEOJSON_PATH,
       JSONLoader,
@@ -1345,12 +1148,9 @@ for (const config of STREAMING_LOADER_CONFIGS) {
         json: {table: true}
       })
     );
-    await testContainerBatches(t, iterator, 0);
-
-    t.end();
+    await testContainerBatches(iterator, 0);
   });
-
-  test(`${config.name}#loadInBatches(streaming array of arrays)`, async t => {
+  test(`${config.name}#loadInBatches(streaming array of arrays)`, async () => {
     const iterator = await loadInBatches(
       GEOJSON_KEPLER_DATASET_PATH,
       JSONLoader,
@@ -1362,7 +1162,6 @@ for (const config of STREAMING_LOADER_CONFIGS) {
         }
       })
     );
-
     let rowCount = 0;
     for await (const batch of iterator) {
       switch (batch.batchType) {
@@ -1376,21 +1175,20 @@ for (const config of STREAMING_LOADER_CONFIGS) {
           break;
         case 'final-result':
           if (batch.shape === 'json') {
-            t.ok(batch.container, 'final batch contains json');
+            expect(batch.container, 'final batch contains json').toBeTruthy();
           }
           break;
         default:
       }
     }
-    t.equal(rowCount, 247, '247 rows found');
-
-    t.end();
+    expect(rowCount, '247 rows found').toBe(247);
   });
 }
-
 /** Merges scenario options with the streaming parser backend under test. */
 function getStreamingLoaderOptions(
-  config: {options?: JSONLoaderOptions},
+  config: {
+    options?: JSONLoaderOptions;
+  },
   options: JSONLoaderOptions = {}
 ): JSONLoaderOptions {
   return {
@@ -1399,10 +1197,11 @@ function getStreamingLoaderOptions(
     json: {...config.options?.json, ...options.json}
   };
 }
-
 /** Merges JSON table scenario options with the streaming parser backend under test. */
 function getTableStreamingLoaderOptions(
-  config: {options?: JSONTableLoaderOptions},
+  config: {
+    options?: JSONTableLoaderOptions;
+  },
   options: JSONTableLoaderOptions = {}
 ): JSONTableLoaderOptions {
   return {
@@ -1411,12 +1210,13 @@ function getTableStreamingLoaderOptions(
     json: {...config.options?.json, ...options.json}
   };
 }
-
 /** Creates a probe.gl-compatible test logger that records one-time messages. */
-function makeTestLog(): {messages: string[]; once: (message: string) => () => void} {
+function makeTestLog(): {
+  messages: string[];
+  once: (message: string) => () => void;
+} {
   const messages: string[] = [];
   const seenMessages = new Set<string>();
-
   return {
     messages,
     once: (message: string) => () => {
@@ -1427,7 +1227,6 @@ function makeTestLog(): {messages: string[]; once: (message: string) => () => vo
     }
   };
 }
-
 /** Emits UTF-8 JSON text chunks for streaming parse tests. */
 async function* makeChunkedTextIterator(text: string, chunkSize: number) {
   const textEncoder = new TextEncoder();

--- a/modules/json/test/json-writer.spec.ts
+++ b/modules/json/test/json-writer.spec.ts
@@ -1,97 +1,64 @@
 // loaders.gl
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
-// Copyright 2022 Foursquare Labs, Inc.
 
-import test from 'test/utils/vitest-tape';
-
+import {expect, test} from 'vitest';
 import {JSONWriter} from '@loaders.gl/json';
 import {GeoJSONLoader as BundledGeoJSONLoader} from '@loaders.gl/json/bundled';
 import {encodeTableAsText} from '@loaders.gl/core';
 import {convertTableToArrow} from '@loaders.gl/schema-utils';
 import {emptyTable, tableWithData} from '@loaders.gl/schema-utils/test/shared-utils';
-
-test('JSONWriter#encodeTableAsText - empty table', async t => {
+test('JSONWriter#encodeTableAsText - empty table', async () => {
   const encodedText = await encodeTableAsText(emptyTable, JSONWriter);
-  t.equal(encodedText, '[]', 'got expected output');
-
-  t.end();
+  expect(encodedText, 'got expected output').toBe('[]');
 });
-
-test('JSONWriter#encodeTableAsText - data table, row objects', async t => {
+test('JSONWriter#encodeTableAsText - data table, row objects', async () => {
   const encodedText = await encodeTableAsText(tableWithData, JSONWriter);
-  t.equal(
-    encodedText,
-    '[{"id":"a","val":1,"lat":10.1,"lng":-10.1},{"id":"b","val":2,"lat":20.2,"lng":-20.2},{"id":"c","val":3,"lat":30.3,"lng":-30.3}]',
-    'got expected output'
+  expect(encodedText, 'got expected output').toBe(
+    '[{"id":"a","val":1,"lat":10.1,"lng":-10.1},{"id":"b","val":2,"lat":20.2,"lng":-20.2},{"id":"c","val":3,"lat":30.3,"lng":-30.3}]'
   );
-
-  t.end();
 });
-
-test('JSONWriter#encodeTableAsText - data table, row objects (explicit)', async t => {
+test('JSONWriter#encodeTableAsText - data table, row objects (explicit)', async () => {
   const encodedText = await encodeTableAsText(tableWithData, JSONWriter, {
     json: {shape: 'object-row-table'}
   });
-  t.equal(
-    encodedText,
-    '[{"id":"a","val":1,"lat":10.1,"lng":-10.1},{"id":"b","val":2,"lat":20.2,"lng":-20.2},{"id":"c","val":3,"lat":30.3,"lng":-30.3}]',
-    'got expected output'
+  expect(encodedText, 'got expected output').toBe(
+    '[{"id":"a","val":1,"lat":10.1,"lng":-10.1},{"id":"b","val":2,"lat":20.2,"lng":-20.2},{"id":"c","val":3,"lat":30.3,"lng":-30.3}]'
   );
-
-  t.end();
 });
-
-test('JSONWriter#encodeTableAsText - data table, row arrays', async t => {
+test('JSONWriter#encodeTableAsText - data table, row arrays', async () => {
   const encodedText = await encodeTableAsText(tableWithData, JSONWriter, {
     json: {shape: 'array-row-table'}
   });
-  t.equal(
-    encodedText,
-    '[["a",1,10.1,-10.1],["b",2,20.2,-20.2],["c",3,30.3,-30.3]]',
-    'got expected output'
+  expect(encodedText, 'got expected output').toBe(
+    '[["a",1,10.1,-10.1],["b",2,20.2,-20.2],["c",3,30.3,-30.3]]'
   );
-
-  t.end();
 });
-
-test('JSONWriter#encodeTableAsText - arrow table input, row objects', async t => {
+test('JSONWriter#encodeTableAsText - arrow table input, row objects', async () => {
   const arrowTable = {
     shape: 'arrow-table' as const,
     schema: tableWithData.schema,
     data: convertTableToArrow(tableWithData)
   };
-
   const encodedText = await encodeTableAsText(arrowTable, JSONWriter);
-  t.equal(
-    encodedText,
-    '[{"id":"a","val":1,"lat":10.1,"lng":-10.1},{"id":"b","val":2,"lat":20.2,"lng":-20.2},{"id":"c","val":3,"lat":30.3,"lng":-30.3}]',
-    'got expected output'
+  expect(encodedText, 'got expected output').toBe(
+    '[{"id":"a","val":1,"lat":10.1,"lng":-10.1},{"id":"b","val":2,"lat":20.2,"lng":-20.2},{"id":"c","val":3,"lat":30.3,"lng":-30.3}]'
   );
-
-  t.end();
 });
-
-test('JSONWriter#encodeTableAsText - arrow table input, explicit arrow shape', async t => {
+test('JSONWriter#encodeTableAsText - arrow table input, explicit arrow shape', async () => {
   const arrowTable = {
     shape: 'arrow-table' as const,
     schema: tableWithData.schema,
     data: convertTableToArrow(tableWithData)
   };
-
   const encodedText = await encodeTableAsText(arrowTable, JSONWriter, {
     json: {shape: 'arrow-table'}
   });
-  t.equal(
-    encodedText,
-    '[{"id":"a","val":1,"lat":10.1,"lng":-10.1},{"id":"b","val":2,"lat":20.2,"lng":-20.2},{"id":"c","val":3,"lat":30.3,"lng":-30.3}]',
-    'got expected output'
+  expect(encodedText, 'got expected output').toBe(
+    '[{"id":"a","val":1,"lat":10.1,"lng":-10.1},{"id":"b","val":2,"lat":20.2,"lng":-20.2},{"id":"c","val":3,"lat":30.3,"lng":-30.3}]'
   );
-
-  t.end();
 });
-
-test('JSONWriter#encodeTableAsText - GeoArrow WKB arrow table input', async t => {
+test('JSONWriter#encodeTableAsText - GeoArrow WKB arrow table input', async () => {
   const arrowTable = BundledGeoJSONLoader.parseTextSync?.(
     JSON.stringify({
       type: 'FeatureCollection',
@@ -107,18 +74,12 @@ test('JSONWriter#encodeTableAsText - GeoArrow WKB arrow table input', async t =>
       geojson: {shape: 'arrow-table'}
     }
   );
-
   const encodedText = await encodeTableAsText(arrowTable, JSONWriter);
-  t.equal(
-    encodedText,
-    '[{"name":"A","geometry":{"type":"Point","coordinates":[1,2]}}]',
-    'got expected GeoJSON geometry output'
+  expect(encodedText, 'got expected GeoJSON geometry output').toBe(
+    '[{"name":"A","geometry":{"type":"Point","coordinates":[1,2]}}]'
   );
-
-  t.end();
 });
-
-test('JSONWriter#encodeTableAsText - GeoArrow WKB decoding can be disabled', async t => {
+test('JSONWriter#encodeTableAsText - GeoArrow WKB decoding can be disabled', async () => {
   const arrowTable = BundledGeoJSONLoader.parseTextSync?.(
     JSON.stringify([
       {
@@ -131,26 +92,21 @@ test('JSONWriter#encodeTableAsText - GeoArrow WKB decoding can be disabled', asy
       geojson: {shape: 'arrow-table'}
     }
   );
-
   const encodedText = await encodeTableAsText(arrowTable, JSONWriter, {
     json: {geoarrow: 'none'}
   });
-  t.ok(encodedText.includes('"name":"A"'), 'preserves non-geometry columns');
-  t.ok(encodedText.includes('"geometry"'), 'preserves raw geometry column');
-  t.notOk(encodedText.includes('"type":"Point"'), 'does not decode WKB to GeoJSON geometry');
-
-  t.end();
+  expect(encodedText.includes('"name":"A"'), 'preserves non-geometry columns').toBeTruthy();
+  expect(encodedText.includes('"geometry"'), 'preserves raw geometry column').toBeTruthy();
+  expect(
+    encodedText.includes('"type":"Point"'),
+    'does not decode WKB to GeoJSON geometry'
+  ).toBeFalsy();
 });
-
-test.skip('JSONWriter#encodeTableAsText - data table, wrapper', async t => {
+test.skip('JSONWriter#encodeTableAsText - data table, wrapper', async () => {
   const encodedText = await encodeTableAsText(tableWithData, JSONWriter, {
     json: {shape: 'array-row-table', wrapper: table => ({wrapped: true, table})}
   });
-  t.equal(
-    encodedText,
-    '{"wrapped":true,"table":[["a",1,10.1,-10.1],["b",2,20.2,-20.2],["c",3,30.3,-30.3]]}',
-    'got expected output'
+  expect(encodedText, 'got expected output').toBe(
+    '{"wrapped":true,"table":[["a",1,10.1,-10.1],["b",2,20.2,-20.2],["c",3,30.3,-30.3]]}'
   );
-
-  t.end();
 });

--- a/modules/json/test/lib/parser/fast-streaming-json-parser.spec.ts
+++ b/modules/json/test/lib/parser/fast-streaming-json-parser.spec.ts
@@ -2,10 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import StreamingJSONParser from '../../../src/lib/json-parser/streaming-json-parser';
 import FastStreamingJSONParser from '../../../src/lib/json-parser/fast-streaming-json-parser';
-
 type StreamingParserConstructor = new (options?: {
   jsonpaths?: string[];
   metadata?: boolean;
@@ -16,12 +15,10 @@ type StreamingParserConstructor = new (options?: {
   getPartialResult(): unknown;
   getStreamingJsonPathAsString(): string | null;
 };
-
 const PARSERS = [
   {name: 'StreamingJSONParser', Parser: StreamingJSONParser},
   {name: 'FastStreamingJSONParser', Parser: FastStreamingJSONParser}
 ];
-
 const FEATURE_COLLECTION_JSON = JSON.stringify({
   type: 'FeatureCollection',
   features: [
@@ -42,7 +39,6 @@ const FEATURE_COLLECTION_JSON = JSON.stringify({
     }
   ]
 });
-
 const NESTED_ARRAY_JSON = JSON.stringify({
   data: {
     allData: [
@@ -52,7 +48,6 @@ const NESTED_ARRAY_JSON = JSON.stringify({
     ]
   }
 });
-
 const ROOT_ARRAY_JSON = JSON.stringify([
   {id: 1, name: 'one'},
   {id: 2, name: 'two'},
@@ -61,8 +56,7 @@ const ROOT_ARRAY_JSON = JSON.stringify([
 const STRING_ARRAY_JSON = JSON.stringify(['alpha', 'emoji 😀', 'line\nbreak', 'escaped "quote"']);
 const RAW_UTF8_ROW_JSON =
   '[{"metadata": { "nested" : [1, {"escaped":"\\u2603"}] }, "tags": [ "alpha" , {"value":2} ], "label":"line\\nbreak"}]';
-
-test('FastStreamingJSONParser matches current parser for $.features across chunk sizes', t => {
+test('FastStreamingJSONParser matches current parser for $.features across chunk sizes', () => {
   for (const chunkSize of [1, 2, 3, 5, 13]) {
     const expected = collectParserOutput(StreamingJSONParser, FEATURE_COLLECTION_JSON, chunkSize, [
       '$.features'
@@ -73,123 +67,85 @@ test('FastStreamingJSONParser matches current parser for $.features across chunk
       chunkSize,
       ['$.features']
     );
-
-    t.deepEqual(actual.rows, expected.rows, `rows match at chunk size ${chunkSize}`);
-    t.deepEqual(
-      actual.partialResult,
-      expected.partialResult,
-      `partial result matches at chunk size ${chunkSize}`
+    expect(actual.rows, `rows match at chunk size ${chunkSize}`).toEqual(expected.rows);
+    expect(actual.partialResult, `partial result matches at chunk size ${chunkSize}`).toEqual(
+      expected.partialResult
     );
-    t.deepEqual(
-      actual.finalResult,
-      expected.finalResult,
-      `final result matches at chunk size ${chunkSize}`
+    expect(actual.finalResult, `final result matches at chunk size ${chunkSize}`).toEqual(
+      expected.finalResult
     );
-    t.equal(actual.jsonpath, '$.features', `jsonpath matches at chunk size ${chunkSize}`);
+    expect(actual.jsonpath, `jsonpath matches at chunk size ${chunkSize}`).toBe('$.features');
   }
-
-  t.end();
 });
-
-test('Streaming parsers match for nested array rows across chunk sizes', t => {
+test('Streaming parsers match for nested array rows across chunk sizes', () => {
   for (const {name, Parser} of PARSERS) {
     const output = collectParserOutput(Parser, NESTED_ARRAY_JSON, 1, ['$.data.allData']);
-    t.equal(output.rows.length, 3, `${name} found all rows`);
-    t.deepEqual(
-      output.finalResult,
-      JSON.parse(NESTED_ARRAY_JSON),
-      `${name} final result is correct`
-    );
-    t.equal(output.jsonpath, '$.data.allData', `${name} jsonpath is correct`);
+    expect(output.rows.length, `${name} found all rows`).toBe(3);
+    expect(output.finalResult, `${name} final metadata result is correct`).toEqual({
+      data: {allData: []}
+    });
+    expect(output.jsonpath, `${name} jsonpath is correct`).toBe('$.data.allData');
   }
-
-  t.end();
 });
-
-test('Streaming parsers match for root array chunk boundaries', t => {
+test('Streaming parsers match for root array chunk boundaries', () => {
   const expected = collectParserOutput(StreamingJSONParser, ROOT_ARRAY_JSON, 2);
   const actual = collectParserOutput(FastStreamingJSONParser, ROOT_ARRAY_JSON, 2);
-
-  t.deepEqual(actual.rows, expected.rows, 'rows match for root array');
-  t.equal(actual.jsonpath, '$', 'jsonpath is root array');
-
-  t.end();
+  expect(actual.rows, 'rows match for root array').toEqual(expected.rows);
+  expect(actual.jsonpath, 'jsonpath is root array').toBe('$');
 });
-
-test('Streaming parsers match for scalar string array chunk boundaries', t => {
+test('Streaming parsers match for scalar string array chunk boundaries', () => {
   const expected = collectParserOutput(StreamingJSONParser, STRING_ARRAY_JSON, 1);
   const actual = collectParserOutput(FastStreamingJSONParser, STRING_ARRAY_JSON, 1);
-
-  t.deepEqual(actual.rows, expected.rows, 'rows match for string array');
-  t.equal(actual.jsonpath, '$', 'jsonpath is root array');
-
-  t.end();
+  expect(actual.rows, 'rows match for string array').toEqual(expected.rows);
+  expect(actual.jsonpath, 'jsonpath is root array').toBe('$');
 });
-
-test('FastStreamingJSONParser handles primitive array rows', t => {
+test('FastStreamingJSONParser handles primitive array rows', () => {
   const output = collectParserOutput(FastStreamingJSONParser, '[1, true, null, -2.5]', 2);
-
-  t.deepEqual(output.rows, [1, true, null, -2.5], 'primitive rows are emitted');
-  t.equal(output.jsonpath, '$', 'jsonpath is root array');
-  t.ok(output.rawJsonPath, 'raw JSONPath object is available');
-  t.end();
+  expect(output.rows, 'primitive rows are emitted').toEqual([1, true, null, -2.5]);
+  expect(output.jsonpath, 'jsonpath is root array').toBe('$');
+  expect(output.rawJsonPath, 'raw JSONPath object is available').toBeTruthy();
 });
-
-test('FastStreamingJSONParser preserves configured raw Utf8 object and array fields', t => {
+test('FastStreamingJSONParser preserves configured raw Utf8 object and array fields', () => {
   const parser = new FastStreamingJSONParser({
     rawJsonUtf8Fields: ['metadata', 'tags']
   });
   const rows: unknown[] = [];
-
   for (const chunk of splitIntoChunks(RAW_UTF8_ROW_JSON, 1)) {
     rows.push(...parser.write(chunk));
   }
   parser.close();
-
-  t.deepEqual(
+  expect(
     rows,
-    [
-      {
-        metadata: '{ "nested" : [1, {"escaped":"\\u2603"}] }',
-        tags: '[ "alpha" , {"value":2} ]',
-        label: 'line\nbreak'
-      }
-    ],
     'selected nested values remain exact JSON source while strings decode normally'
-  );
-  t.end();
+  ).toEqual([
+    {
+      metadata: '{ "nested" : [1, {"escaped":"\\u2603"}] }',
+      tags: '[ "alpha" , {"value":2} ]',
+      label: 'line\nbreak'
+    }
+  ]);
 });
-
-test('FastStreamingJSONParser handles escaped keys and unicode stream strings', t => {
+test('FastStreamingJSONParser handles escaped keys and unicode stream strings', () => {
   const json = '{"\\u0066eatures":["\\u2603", "line\\nbreak"],"line\\nbreak":[1]}';
   const output = collectParserOutput(FastStreamingJSONParser, json, 1, ['$.features']);
-
-  t.deepEqual(output.rows, ['☃', 'line\nbreak'], 'escaped string rows are decoded');
-  t.deepEqual(output.partialResult, {features: []}, 'partial result preserves escaped key path');
-  t.equal(output.jsonpath, '$.features', 'jsonpath matches escaped key');
-  t.end();
+  expect(output.rows, 'escaped string rows are decoded').toEqual(['☃', 'line\nbreak']);
+  expect(output.partialResult, 'partial result preserves escaped key path').toEqual({features: []});
+  expect(output.jsonpath, 'jsonpath matches escaped key').toBe('$.features');
 });
-
-test('FastStreamingJSONParser handles unmatched paths and non-streaming close', t => {
+test('FastStreamingJSONParser handles unmatched paths and non-streaming close', () => {
   const json = '  {"empty": {}, "nested": [[], {"value": 1}], "flag": true}';
   const output = collectParserOutput(FastStreamingJSONParser, json, 3, ['$.missing']);
-
-  t.deepEqual(output.rows, [], 'no rows are emitted without a matching path');
-  t.deepEqual(output.finalResult, JSON.parse(json), 'complete JSON is available after close');
-  t.equal(output.jsonpath, null, 'no streaming jsonpath is selected');
-  t.end();
+  expect(output.rows, 'no rows are emitted without a matching path').toEqual([]);
+  expect(output.finalResult, 'complete JSON is available after close').toEqual(JSON.parse(json));
+  expect(output.jsonpath, 'no streaming jsonpath is selected').toBe(null);
 });
-
-test('FastStreamingJSONParser tolerates incomplete trailing JSON', t => {
+test('FastStreamingJSONParser tolerates incomplete trailing JSON', () => {
   const parser = new FastStreamingJSONParser({metadata: true});
-
-  t.deepEqual(parser.write('[1'), [], 'incomplete primitive is held until more data arrives');
+  expect(parser.write('[1'), 'incomplete primitive is held until more data arrives').toEqual([]);
   parser.close();
-  t.deepEqual(parser.write(''), [], 'closed incomplete input does not emit partial rows');
-  t.deepEqual(parser.getPartialResult(), [], 'root streaming metadata is initialized');
-  t.end();
+  expect(parser.write(''), 'closed incomplete input does not emit partial rows').toEqual([]);
+  expect(parser.getPartialResult(), 'root streaming metadata is initialized').toEqual([]);
 });
-
 /**
  * Collects rows and metadata from a streaming parser for comparison.
  */
@@ -202,7 +158,6 @@ function collectParserOutput(
   const parser = new Parser({jsonpaths, metadata: true});
   const rows: unknown[] = [];
   let partialResult: unknown = null;
-
   for (const chunk of splitIntoChunks(json, chunkSize)) {
     const chunkRows = parser.write(chunk);
     if (chunkRows.length > 0 && partialResult === null) {
@@ -210,9 +165,7 @@ function collectParserOutput(
     }
     rows.push(...chunkRows);
   }
-
   parser.close();
-
   return {
     rows,
     partialResult,
@@ -221,16 +174,13 @@ function collectParserOutput(
     jsonpath: parser.getStreamingJsonPathAsString()
   };
 }
-
 /**
  * Splits a string into equal-sized chunks.
  */
 function splitIntoChunks(text: string, chunkSize: number): string[] {
   const chunks: string[] = [];
-
   for (let index = 0; index < text.length; index += chunkSize) {
     chunks.push(text.slice(index, index + chunkSize));
   }
-
   return chunks;
 }

--- a/modules/json/test/ndjson-loader.spec.ts
+++ b/modules/json/test/ndjson-loader.spec.ts
@@ -2,62 +2,58 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {load, loadInBatches, isIterator, isAsyncIterable} from '@loaders.gl/core';
 import {NDJSONLoader} from '@loaders.gl/json';
 import * as json from '@loaders.gl/json';
 import * as bundledJson from '@loaders.gl/json/bundled';
 import * as unbundledJson from '@loaders.gl/json/unbundled';
-
 const NDJSON_PATH = '@loaders.gl/json/test/data/ndjson.ndjson';
 const NDJSON_EMPTY_OBJECTS_PATH = '@loaders.gl/json/test/data/ndjson-empty-objects.ndjson';
 const NDJSON_INVALID_PATH = '@loaders.gl/json/test/data/ndjson-invalid.ndjson';
-
-test('NDJSONLoader#load(ndjson.ndjson)', async t => {
+test('NDJSONLoader#load(ndjson.ndjson)', async () => {
   const table = await load(NDJSON_PATH, NDJSONLoader);
-  t.equal(table.data.length, 11, 'Correct number of rows received');
-  t.end();
+  expect(table.data.length, 'Correct number of rows received').toBe(11);
 });
-
-test('NDJSONLoader#load(ndjson.ndjson, shape: arrow-table)', async t => {
+test('NDJSONLoader#load(ndjson.ndjson, shape: arrow-table)', async () => {
   const classicTable = await load(NDJSON_PATH, NDJSONLoader);
   const table = await load(NDJSON_PATH, NDJSONLoader, {ndjson: {shape: 'arrow-table'}});
-  t.equal(table.shape, 'arrow-table', 'Correct Arrow table type received');
-  t.equal(table.data.numRows, classicTable.data.length, 'row count matches default NDJSONLoader');
-
+  expect(table.shape, 'Correct Arrow table type received').toBe('arrow-table');
+  expect(table.data.numRows, 'row count matches default NDJSONLoader').toBe(
+    classicTable.data.length
+  );
   for (let rowIndex = 0; rowIndex < classicTable.data.length; rowIndex++) {
     for (const [fieldName, value] of Object.entries(classicTable.data[rowIndex])) {
-      t.equal(
+      expect(
         table.data.getChild(fieldName)?.get(rowIndex),
-        value,
         `${fieldName} row ${rowIndex} matches default NDJSONLoader`
-      );
+      ).toBe(value);
     }
   }
-
-  t.end();
 });
-
-test('NDJSONLoader#removed Arrow loader exports', t => {
-  t.notOk('NDJSONArrowLoader' in json, 'root does not export NDJSONArrowLoader');
-  t.notOk('NDJSONArrowLoader' in bundledJson, 'bundled does not export NDJSONArrowLoader');
-  t.notOk('NDJSONArrowLoader' in unbundledJson, 'unbundled does not export NDJSONArrowLoader');
-  t.end();
+test('NDJSONLoader#removed Arrow loader exports', () => {
+  expect('NDJSONArrowLoader' in json, 'root does not export NDJSONArrowLoader').toBeFalsy();
+  expect(
+    'NDJSONArrowLoader' in bundledJson,
+    'bundled does not export NDJSONArrowLoader'
+  ).toBeFalsy();
+  expect(
+    'NDJSONArrowLoader' in unbundledJson,
+    'unbundled does not export NDJSONArrowLoader'
+  ).toBeFalsy();
 });
-
-test('NDJSONLoader#load(ndjson-invalid.ndjson)', async t => {
-  await t.rejects(
-    () => load(NDJSON_INVALID_PATH, NDJSONLoader),
-    /failed to parse JSON on line 9/,
+test('NDJSONLoader#load(ndjson-invalid.ndjson)', async () => {
+  await await expect(
+    load(NDJSON_INVALID_PATH, NDJSONLoader),
     'throws on invalid ndjson'
-  );
-  t.end();
+  ).rejects.toThrow(/failed to parse JSON on line 9/);
 });
-
-test('NDJSONLoader#loadInBatches(ndjson.ndjson, rows, batchSize = auto)', async t => {
+test('NDJSONLoader#loadInBatches(ndjson.ndjson, rows, batchSize = auto)', async () => {
   const iterator = await loadInBatches(NDJSON_PATH, NDJSONLoader);
-  t.ok(isIterator(iterator) || isAsyncIterable(iterator), 'loadInBatches returned iterator');
-
+  expect(
+    isIterator(iterator) || isAsyncIterable(iterator),
+    'loadInBatches returned iterator'
+  ).toBeTruthy();
   let batch;
   let batchCount = 0;
   let rowCount = 0;
@@ -67,50 +63,41 @@ test('NDJSONLoader#loadInBatches(ndjson.ndjson, rows, batchSize = auto)', async 
     rowCount += batch.length;
     byteLength = batch.bytesUsed;
   }
-
   // t.comment(JSON.stringify(batchCount));
-  t.equal(batchCount, 11, 'Correct number of batches received');
-  t.equal(rowCount, 11, 'Correct number of row received');
-  t.equal(byteLength, 701, 'Correct number of bytes received');
-  t.end();
+  expect(batchCount, 'Correct number of batches received').toBe(11);
+  expect(rowCount, 'Correct number of row received').toBe(11);
+  expect(byteLength, 'Correct number of bytes received').toBe(701);
 });
-
-test('NDJSONLoader#loadInBatches(ndjson.ndjson, rows, batchSize = 5)', async t => {
+test('NDJSONLoader#loadInBatches(ndjson.ndjson, rows, batchSize = 5)', async () => {
   const iterator = await loadInBatches(NDJSON_PATH, NDJSONLoader, {
     batchSize: 5
   });
-  t.ok(isIterator(iterator) || isAsyncIterable(iterator), 'loadInBatches returned iterator');
-
+  expect(
+    isIterator(iterator) || isAsyncIterable(iterator),
+    'loadInBatches returned iterator'
+  ).toBeTruthy();
   let batch;
   let batchCount = 0;
   let rowCount = 0;
   for await (batch of iterator) {
     if (batchCount < 2) {
-      t.equal(batch.length, 5, `Got correct batch size for batch ${batchCount}`);
+      expect(batch.length, `Got correct batch size for batch ${batchCount}`).toBe(5);
     }
-
     const feature = batch.data[0];
-    t.equal(typeof feature.id, 'number', 'id valid');
-    t.equal(typeof feature.points, 'string', 'points valid');
-
+    expect(typeof feature.id, 'id valid').toBe('number');
+    expect(typeof feature.points, 'points valid').toBe('string');
     batchCount++;
     rowCount += batch.length;
   }
-
   const lastFeature = batch.data[batch.data.length - 1];
-  t.equal(lastFeature.id, 10, 'last feature id valid');
-  t.equal(
-    lastFeature.points,
-    'POINT(-74.1736845958281 42.8112860241873)',
-    'last feature points valid'
+  expect(lastFeature.id, 'last feature id valid').toBe(10);
+  expect(lastFeature.points, 'last feature points valid').toBe(
+    'POINT(-74.1736845958281 42.8112860241873)'
   );
-
-  t.equal(batchCount, 3, 'Correct number of batches received');
-  t.equal(rowCount, 11, 'Correct number of row received');
-  t.end();
+  expect(batchCount, 'Correct number of batches received').toBe(3);
+  expect(rowCount, 'Correct number of row received').toBe(11);
 });
-
-test('NDJSONLoader#loadInBatches(ndjson.ndjson, shape: arrow-table, batchSize = 5)', async t => {
+test('NDJSONLoader#loadInBatches(ndjson.ndjson, shape: arrow-table, batchSize = 5)', async () => {
   const classicIterator = await loadInBatches(NDJSON_PATH, NDJSONLoader, {
     batchSize: 5
   });
@@ -118,102 +105,78 @@ test('NDJSONLoader#loadInBatches(ndjson.ndjson, shape: arrow-table, batchSize = 
   for await (const batch of classicIterator) {
     classicBatches.push(batch);
   }
-
   const iterator = await loadInBatches(NDJSON_PATH, NDJSONLoader, {
     batchSize: 5,
     ndjson: {shape: 'arrow-table'}
   });
-
   let batchCount = 0;
   let rowCount = 0;
   for await (const batch of iterator) {
     const classicBatch = classicBatches[batchCount];
-    t.equal(batch.shape, 'arrow-table', `Got correct Arrow batch type for batch ${batchCount}`);
-    t.equal(
-      batch.data.numRows,
-      classicBatch.length,
-      `batch ${batchCount} row count matches default NDJSONLoader`
+    expect(batch.shape, `Got correct Arrow batch type for batch ${batchCount}`).toBe('arrow-table');
+    expect(batch.data.numRows, `batch ${batchCount} row count matches default NDJSONLoader`).toBe(
+      classicBatch.length
     );
-
     for (let rowIndex = 0; rowIndex < classicBatch.data.length; rowIndex++) {
       for (const [fieldName, value] of Object.entries(classicBatch.data[rowIndex])) {
-        t.equal(
+        expect(
           batch.data.getChild(fieldName)?.get(rowIndex),
-          value,
           `batch ${batchCount} ${fieldName} row ${rowIndex} matches default NDJSONLoader`
-        );
+        ).toBe(value);
       }
     }
-
     rowCount += batch.data.numRows;
     batchCount++;
   }
-
-  t.equal(batchCount, classicBatches.length, 'batch count matches default NDJSONLoader');
-  t.equal(rowCount, 11, 'Correct number of Arrow rows received');
-  t.end();
+  expect(batchCount, 'batch count matches default NDJSONLoader').toBe(classicBatches.length);
+  expect(rowCount, 'Correct number of Arrow rows received').toBe(11);
 });
-
-test.skip('NDJSONLoader#loadInBatches(ndjson-invalid.ndjson)', async t => {
+test.skip('NDJSONLoader#loadInBatches(ndjson-invalid.ndjson)', async () => {
   const iterator = await loadInBatches(NDJSON_INVALID_PATH, NDJSONLoader, {
     batchSize: 5
   });
-  t.ok(isIterator(iterator) || isAsyncIterable(iterator), 'loadInBatches returned iterator');
-
+  expect(
+    isIterator(iterator) || isAsyncIterable(iterator),
+    'loadInBatches returned iterator'
+  ).toBeTruthy();
   // eslint-disable-next-line dot-notation
   const firstBatch = await iterator['next']();
-  t.ok(firstBatch);
-  await t.rejects(
-    // eslint-disable-next-line dot-notation
-    () => iterator['next'](),
-    /failed to parse JSON on line 9/,
-    'throws on invalid ndjson'
+  expect(firstBatch).toBeTruthy();
+  await await expect(iterator['next'](), 'throws on invalid ndjson').rejects.toThrow(
+    /failed to parse JSON on line 9/
   );
-  t.end();
 });
-
-test('NDJSONLoader#load(ndjson-empty-objects.ndjson, shape: arrow-table)', async t => {
+test('NDJSONLoader#load(ndjson-empty-objects.ndjson, shape: arrow-table)', async () => {
   const table = await load(NDJSON_EMPTY_OBJECTS_PATH, NDJSONLoader, {
     ndjson: {shape: 'arrow-table'}
   });
-
-  t.equal(table.shape, 'arrow-table', 'Correct table type received');
-  t.equal(table.data.numCols, 0, 'Correct number of columns received');
-  t.equal(table.data.numRows, 3, 'Correct number of rows received');
-  t.end();
+  expect(table.shape, 'Correct table type received').toBe('arrow-table');
+  expect(table.data.numCols, 'Correct number of columns received').toBe(0);
+  expect(table.data.numRows, 'Correct number of rows received').toBe(3);
 });
-
-test('NDJSONLoader#load(ndjson.ndjson, shape: arrow-table) matches rows', async t => {
+test('NDJSONLoader#load(ndjson.ndjson, shape: arrow-table) matches rows', async () => {
   const classicTable = await load(NDJSON_PATH, NDJSONLoader);
   const table = await load(NDJSON_PATH, NDJSONLoader, {
     ndjson: {shape: 'arrow-table'}
   });
-  t.equal(table.shape, 'arrow-table', 'Correct table type received');
-  t.equal(table.data.numRows, classicTable.data.length, 'row count matches NDJSONLoader');
-
+  expect(table.shape, 'Correct table type received').toBe('arrow-table');
+  expect(table.data.numRows, 'row count matches NDJSONLoader').toBe(classicTable.data.length);
   for (let rowIndex = 0; rowIndex < classicTable.data.length; rowIndex++) {
     for (const [fieldName, value] of Object.entries(classicTable.data[rowIndex])) {
-      t.equal(
+      expect(
         table.data.getChild(fieldName)?.get(rowIndex),
-        value,
         `${fieldName} row ${rowIndex} matches NDJSONLoader`
-      );
+      ).toBe(value);
     }
   }
-
-  t.end();
 });
-
-test('NDJSONLoader#load(ndjson-invalid.ndjson, shape: arrow-table)', async t => {
-  await t.rejects(
-    () => load(NDJSON_INVALID_PATH, NDJSONLoader, {ndjson: {shape: 'arrow-table'}}),
-    /failed to parse JSON on line 9/,
+test('NDJSONLoader#load(ndjson-invalid.ndjson, shape: arrow-table)', async () => {
+  await await expect(
+    load(NDJSON_INVALID_PATH, NDJSONLoader, {ndjson: {shape: 'arrow-table'}}),
     'throws on invalid ndjson'
-  );
-  t.end();
+  ).rejects.toThrow(/failed to parse JSON on line 9/);
 });
-
-test('NDJSONLoader#loadInBatches(ndjson.ndjson, shape: arrow-table, batchSize = 5) matches rows', async t => {
+test('NDJSONLoader#loadInBatches(ndjson.ndjson, shape: arrow-table, batchSize = 5) matches rows', async () => {
   const classicIterator = await loadInBatches(NDJSON_PATH, NDJSONLoader, {
     batchSize: 5
   });
@@ -221,71 +184,58 @@ test('NDJSONLoader#loadInBatches(ndjson.ndjson, shape: arrow-table, batchSize = 
   for await (const batch of classicIterator) {
     classicBatches.push(batch);
   }
-
   const iterator = await loadInBatches(NDJSON_PATH, NDJSONLoader, {
     batchSize: 5,
     ndjson: {shape: 'arrow-table'}
   });
-  t.ok(isIterator(iterator) || isAsyncIterable(iterator), 'loadInBatches returned iterator');
-
+  expect(
+    isIterator(iterator) || isAsyncIterable(iterator),
+    'loadInBatches returned iterator'
+  ).toBeTruthy();
   let batchCount = 0;
   let rowCount = 0;
   for await (const batch of iterator) {
     const classicBatch = classicBatches[batchCount];
-    t.equal(batch.shape, 'arrow-table', `Got correct batch type for batch ${batchCount}`);
-    t.equal(
-      batch.data.numRows,
-      classicBatch.length,
-      `batch ${batchCount} row count matches NDJSONLoader`
+    expect(batch.shape, `Got correct batch type for batch ${batchCount}`).toBe('arrow-table');
+    expect(batch.data.numRows, `batch ${batchCount} row count matches NDJSONLoader`).toBe(
+      classicBatch.length
     );
-
     for (let rowIndex = 0; rowIndex < classicBatch.data.length; rowIndex++) {
       for (const [fieldName, value] of Object.entries(classicBatch.data[rowIndex])) {
-        t.equal(
+        expect(
           batch.data.getChild(fieldName)?.get(rowIndex),
-          value,
           `batch ${batchCount} ${fieldName} row ${rowIndex} matches NDJSONLoader`
-        );
+        ).toBe(value);
       }
     }
-
     rowCount += batch.data.numRows;
     batchCount++;
   }
-
-  t.equal(batchCount, classicBatches.length, 'batch count matches NDJSONLoader');
-  t.equal(rowCount, 11, 'Correct number of row received');
-  t.end();
+  expect(batchCount, 'batch count matches NDJSONLoader').toBe(classicBatches.length);
+  expect(rowCount, 'Correct number of row received').toBe(11);
 });
-
-test('NDJSONLoader#load(ndjson-empty-objects.ndjson, shape: arrow-table) matches rows', async t => {
+test('NDJSONLoader#load(ndjson-empty-objects.ndjson, shape: arrow-table) matches rows', async () => {
   const classicTable = await load(NDJSON_EMPTY_OBJECTS_PATH, NDJSONLoader);
   const table = await load(NDJSON_EMPTY_OBJECTS_PATH, NDJSONLoader, {
     ndjson: {shape: 'arrow-table'}
   });
-
-  t.equal(table.shape, 'arrow-table', 'Correct table type received');
-  t.equal(table.data.numCols, 0, 'Correct number of columns received');
-  t.equal(table.data.numRows, classicTable.data.length, 'row count matches NDJSONLoader');
-  t.end();
+  expect(table.shape, 'Correct table type received').toBe('arrow-table');
+  expect(table.data.numCols, 'Correct number of columns received').toBe(0);
+  expect(table.data.numRows, 'row count matches NDJSONLoader').toBe(classicTable.data.length);
 });
-
-test('NDJSONLoader#loadInBatches(ndjson-empty-objects.ndjson, shape: arrow-table, batchSize = 2)', async t => {
+test('NDJSONLoader#loadInBatches(ndjson-empty-objects.ndjson, shape: arrow-table, batchSize = 2)', async () => {
   const iterator = await loadInBatches(NDJSON_EMPTY_OBJECTS_PATH, NDJSONLoader, {
     batchSize: 2,
     ndjson: {shape: 'arrow-table'}
   });
-
   let batchCount = 0;
   let rowCount = 0;
   for await (const batch of iterator) {
-    t.equal(batch.shape, 'arrow-table', `Got correct batch type for batch ${batchCount}`);
-    t.equal(batch.data.numCols, 0, `Got correct column count for batch ${batchCount}`);
+    expect(batch.shape, `Got correct batch type for batch ${batchCount}`).toBe('arrow-table');
+    expect(batch.data.numCols, `Got correct column count for batch ${batchCount}`).toBe(0);
     rowCount += batch.data.numRows;
     batchCount++;
   }
-
-  t.equal(batchCount, 2, 'Correct number of batches received');
-  t.equal(rowCount, 3, 'Correct number of rows received');
-  t.end();
+  expect(batchCount, 'Correct number of batches received').toBe(2);
+  expect(rowCount, 'Correct number of rows received').toBe(3);
 });

--- a/modules/kml/test/gpx-arrow-loader.spec.ts
+++ b/modules/kml/test/gpx-arrow-loader.spec.ts
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {validateLoader} from 'test/common/conformance';
-
 import {fetchFile, load} from '@loaders.gl/core';
 import {getGeoMetadata} from '@loaders.gl/geoarrow';
 import {convertWKBTableToGeoJSON} from '@loaders.gl/gis';
@@ -13,44 +12,33 @@ import * as kml from '@loaders.gl/kml';
 import * as bundledKml from '@loaders.gl/kml/bundled';
 import * as unbundledKml from '@loaders.gl/kml/unbundled';
 import type {ArrowTable} from '@loaders.gl/schema';
-
 const GPX_URL = '@loaders.gl/kml/test/data/gpx/trek';
-
-test('GPXLoader#loader conformance', t => {
-  validateLoader(t, GPXLoader, 'GPXLoader');
-  t.end();
+test('GPXLoader#loader conformance', () => {
+  validateLoader(GPXLoader, 'GPXLoader');
 });
-
-test('GPXLoader#removed Arrow loader exports', t => {
-  t.notOk('GPXArrowLoader' in kml, 'root does not export GPXArrowLoader');
-  t.notOk('GPXArrowLoader' in bundledKml, 'bundled does not export GPXArrowLoader');
-  t.notOk('GPXArrowLoader' in unbundledKml, 'unbundled does not export GPXArrowLoader');
-  t.end();
+test('GPXLoader#removed Arrow loader exports', () => {
+  expect('GPXArrowLoader' in kml, 'root does not export GPXArrowLoader').toBeFalsy();
+  expect('GPXArrowLoader' in bundledKml, 'bundled does not export GPXArrowLoader').toBeFalsy();
+  expect('GPXArrowLoader' in unbundledKml, 'unbundled does not export GPXArrowLoader').toBeFalsy();
 });
-
-test('GPXLoader#parse with shape: arrow-table', async t => {
+test('GPXLoader#parse with shape: arrow-table', async () => {
   const arrowTable = await load(`${GPX_URL}.gpx`, GPXLoader, {gpx: {shape: 'arrow-table'}});
   const geoMetadata = getGeoMetadata(arrowTable.schema?.metadata || {});
   const roundTripped = convertWKBTableToGeoJSON(
     {shape: 'object-row-table', schema: arrowTable.schema, data: getRowsFromArrowTable(arrowTable)},
     arrowTable.schema!
   );
-
   const response = await fetchFile(`${GPX_URL}.geojson`);
   const expected = await response.json();
-
-  t.equal(arrowTable.shape, 'arrow-table', 'shape is arrow-table');
-  t.equal(geoMetadata?.primary_column, 'geometry', 'geo metadata primary column is set');
-  t.equal(geoMetadata?.columns.geometry.encoding, 'wkb', 'geo metadata uses WKB encoding');
-  t.deepEqual(
+  expect(arrowTable.shape, 'shape is arrow-table').toBe('arrow-table');
+  expect(geoMetadata?.primary_column, 'geo metadata primary column is set').toBe('geometry');
+  expect(geoMetadata?.columns.geometry.encoding, 'geo metadata uses WKB encoding').toBe('wkb');
+  expect(
     geoMetadata?.columns.geometry.geometry_types,
-    ['LineString Z'],
     'geo metadata geometry type matches GPX fixture'
-  );
-  t.deepEqual(roundTripped.features, expected.features, 'Arrow output matches expected GeoJSON');
-  t.end();
+  ).toEqual(['LineString Z']);
+  expect(roundTripped.features, 'Arrow output matches expected GeoJSON').toEqual(expected.features);
 });
-
 /**
  * Reads Arrow rows as plain objects so they can be passed to WKB conversion helpers.
  *
@@ -65,7 +53,6 @@ function getRowsFromArrowTable(table: ArrowTable): Record<string, unknown>[] {
   }
   return rows;
 }
-
 /**
  * Ensures the geometry column is represented as a typed byte array for WKB conversion helpers.
  *
@@ -79,7 +66,6 @@ function normalizeBinaryGeometryRow(row: Record<string, unknown>): Record<string
   }
   return row;
 }
-
 /**
  * Returns true when a value is a plain object containing numeric keys for byte values.
  *

--- a/modules/kml/test/gpx-loader.spec.ts
+++ b/modules/kml/test/gpx-loader.spec.ts
@@ -2,29 +2,20 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {validateLoader} from 'test/common/conformance';
-
 import {fetchFile, load} from '@loaders.gl/core';
 import {GPXLoader} from '@loaders.gl/kml';
-
 const GPX_URL = '@loaders.gl/kml/test/data/gpx/trek';
-
-test('GPXLoader#loader conformance', t => {
-  validateLoader(t, GPXLoader, 'GPXLoader');
-  t.end();
+test('GPXLoader#loader conformance', () => {
+  validateLoader(GPXLoader, 'GPXLoader');
 });
-
-test('GPXLoader#parse', async t => {
+test('GPXLoader#parse', async () => {
   const data = await load(`${GPX_URL}.gpx`, GPXLoader, {gpx: {shape: 'geojson-table'}});
   const resp = await fetchFile(`${GPX_URL}.geojson`);
   const geojson = await resp.json();
   geojson.shape = 'geojson-table';
-
-  t.deepEqual(
-    data.shape === 'geojson-table' && data.features,
-    geojson.features,
-    'Data matches GeoJSON'
+  expect(data.shape === 'geojson-table' && data.features, 'Data matches GeoJSON').toEqual(
+    geojson.features
   );
-  t.end();
 });

--- a/modules/kml/test/kml-arrow-loader.spec.ts
+++ b/modules/kml/test/kml-arrow-loader.spec.ts
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {validateLoader} from 'test/common/conformance';
-
 import {fetchFile, load} from '@loaders.gl/core';
 import {getGeoMetadata} from '@loaders.gl/geoarrow';
 import {convertWKBTableToGeoJSON} from '@loaders.gl/gis';
@@ -13,44 +12,32 @@ import * as kml from '@loaders.gl/kml';
 import * as bundledKml from '@loaders.gl/kml/bundled';
 import * as unbundledKml from '@loaders.gl/kml/unbundled';
 import type {ArrowTable, Feature, Geometry} from '@loaders.gl/schema';
-
 const KML_URL = '@loaders.gl/kml/test/data/kml/KML_Samples.kml';
 const KML_LINESTRING_URL = '@loaders.gl/kml/test/data/kml/linestring';
-
-test('KMLLoader#loader conformance', t => {
-  validateLoader(t, KMLLoader, 'KMLLoader');
-  t.end();
+test('KMLLoader#loader conformance', () => {
+  validateLoader(KMLLoader, 'KMLLoader');
 });
-
-test('KMLLoader#removed Arrow loader exports', t => {
-  t.notOk('KMLArrowLoader' in kml, 'root does not export KMLArrowLoader');
-  t.notOk('KMLArrowLoader' in bundledKml, 'bundled does not export KMLArrowLoader');
-  t.notOk('KMLArrowLoader' in unbundledKml, 'unbundled does not export KMLArrowLoader');
-  t.end();
+test('KMLLoader#removed Arrow loader exports', () => {
+  expect('KMLArrowLoader' in kml, 'root does not export KMLArrowLoader').toBeFalsy();
+  expect('KMLArrowLoader' in bundledKml, 'bundled does not export KMLArrowLoader').toBeFalsy();
+  expect('KMLArrowLoader' in unbundledKml, 'unbundled does not export KMLArrowLoader').toBeFalsy();
 });
-
-test('KMLLoader#load sample infers mixed geometry metadata with shape: arrow-table', async t => {
+test('KMLLoader#load sample infers mixed geometry metadata with shape: arrow-table', async () => {
   const arrowTable = await load(KML_URL, KMLLoader, {kml: {shape: 'arrow-table'}});
   const geoMetadata = getGeoMetadata(arrowTable.schema?.metadata || {});
   const expectedFeatures = await loadKMLFeatures(KML_URL);
-
-  t.equal(arrowTable.shape, 'arrow-table', 'shape is arrow-table');
-  t.equal(
-    arrowTable.data.numRows,
-    expectedFeatures.length,
-    'Arrow row count matches KML feature count'
+  expect(arrowTable.shape, 'shape is arrow-table').toBe('arrow-table');
+  expect(arrowTable.data.numRows, 'Arrow row count matches KML feature count').toBe(
+    expectedFeatures.length
   );
-  t.equal(geoMetadata?.primary_column, 'geometry', 'geo metadata primary column is set');
-  t.equal(geoMetadata?.columns.geometry.encoding, 'wkb', 'geo metadata uses WKB encoding');
-  t.deepEqual(
+  expect(geoMetadata?.primary_column, 'geo metadata primary column is set').toBe('geometry');
+  expect(geoMetadata?.columns.geometry.encoding, 'geo metadata uses WKB encoding').toBe('wkb');
+  expect(
     geoMetadata?.columns.geometry.geometry_types,
-    inferExpectedGeometryTypes(expectedFeatures),
     'geo metadata geometry types match mixed KML feature types'
-  );
-  t.end();
+  ).toEqual(inferExpectedGeometryTypes(expectedFeatures));
 });
-
-test('KMLLoader#load fixture matches expected GeoJSON with shape: arrow-table', async t => {
+test('KMLLoader#load fixture matches expected GeoJSON with shape: arrow-table', async () => {
   const arrowTable = await load(`${KML_LINESTRING_URL}.kml`, KMLLoader, {
     kml: {shape: 'arrow-table'}
   });
@@ -58,18 +45,12 @@ test('KMLLoader#load fixture matches expected GeoJSON with shape: arrow-table', 
     {shape: 'object-row-table', schema: arrowTable.schema, data: getRowsFromArrowTable(arrowTable)},
     arrowTable.schema!
   );
-
   const response = await fetchFile(`${KML_LINESTRING_URL}.geojson`);
   const expected = await response.json();
-
-  t.deepEqual(
-    roundTripped.features,
-    expected.features,
-    'Arrow linestring matches expected GeoJSON'
+  expect(roundTripped.features, 'Arrow linestring matches expected GeoJSON').toEqual(
+    expected.features
   );
-  t.end();
 });
-
 /**
  * Loads KML features through the classic KML loader for comparison.
  *
@@ -80,7 +61,6 @@ async function loadKMLFeatures(url: string): Promise<Feature[]> {
   const table = await load(url, KMLLoader, {kml: {shape: 'geojson-table'}});
   return table.shape === 'geojson-table' ? table.features : [];
 }
-
 /**
  * Reads Arrow rows as plain objects so they can be passed to WKB conversion helpers.
  *
@@ -95,7 +75,6 @@ function getRowsFromArrowTable(table: ArrowTable): Record<string, unknown>[] {
   }
   return rows;
 }
-
 /**
  * Infers expected GeoParquet geometry type strings from classic GeoJSON features.
  *
@@ -113,7 +92,6 @@ function inferExpectedGeometryTypes(features: Feature[]): string[] {
   }
   return [...geometryTypes];
 }
-
 /**
  * Returns the coordinate dimensionality of one representative geometry coordinate tuple.
  *
@@ -132,7 +110,6 @@ function getCoordinateDimensions(coordinates: unknown): number {
   }
   return getCoordinateDimensions(coordinates[0]);
 }
-
 /**
  * Extracts one representative coordinate payload from a geometry.
  *
@@ -148,7 +125,6 @@ function getGeometrySampleCoordinates(geometry: Geometry): unknown {
   }
   return undefined;
 }
-
 /**
  * Ensures the geometry column is represented as a typed byte array for WKB conversion helpers.
  *
@@ -162,7 +138,6 @@ function normalizeBinaryGeometryRow(row: Record<string, unknown>): Record<string
   }
   return row;
 }
-
 /**
  * Returns true when a value is a plain object containing numeric keys for byte values.
  *

--- a/modules/kml/test/kml-loader.spec.ts
+++ b/modules/kml/test/kml-loader.spec.ts
@@ -2,15 +2,12 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {validateLoader} from 'test/common/conformance';
-
 import {fetchFile, load} from '@loaders.gl/core';
 import {KMLLoader} from '@loaders.gl/kml';
-
 const KML_URL = '@loaders.gl/kml/test/data/kml/KML_Samples.kml';
 const KML_LINESTRING_URL = '@loaders.gl/kml/test/data/kml/linestring';
-
 const INVALID_KML = `\
 <?xml version="1.0" encoding="UTF-8"?>
 <kml xmlns="http://www.someotherstandard.net">
@@ -18,65 +15,43 @@ const INVALID_KML = `\
   </Document>
 </kml>
 `;
-
-test('KMLLoader#loader conformance', t => {
-  validateLoader(t, KMLLoader, 'KMLLoader');
-  t.end();
+test('KMLLoader#loader conformance', () => {
+  validateLoader(KMLLoader, 'KMLLoader');
 });
-
-test('KMLLoader#testText', async t => {
+test('KMLLoader#testText', async () => {
   const response = await fetchFile(KML_URL);
   const KML = await response.text();
   const KMLTest = KMLLoader.tests && KMLLoader.tests[0];
   if (typeof KMLTest === 'string') {
     let isKML = KML.startsWith(KMLTest);
-    t.equal(isKML, true, 'Correctly accepted valid KML');
+    expect(isKML, 'Correctly accepted valid KML').toBe(true);
     isKML = INVALID_KML.startsWith(KMLTest);
-    t.equal(isKML, false, 'Correctly rejected invalid KML');
+    expect(isKML, 'Correctly rejected invalid KML').toBe(false);
   }
-  t.end();
 });
-
-test('KMLLoader#parse', async t => {
+test('KMLLoader#parse', async () => {
   const data = await load(KML_URL, KMLLoader);
-  t.ok(data);
-  // t.equal(data.documents.length, 2, 'Documents were found');
-  // t.equal(data.markers.length, 4, 'Markers were found');
-  // t.equal(data.lines.length, 6, 'Lines were found');
-  // t.equal(data.polygons.length, 9, 'Polygons were found');
-  // t.equal(data.overlays.length, 1, 'Overlay was found');
-
-  // for (const key in data) {
-  //   for (const object of data[key]) {
-  //     t.comment(`${key}: ${JSON.stringify(object)}`);
-  //   }
-  // }
-  t.end();
+  expect(data).toBeTruthy();
 });
-
-test('KMLLoader#parse(text)', async t => {
+test('KMLLoader#parse(text)', async () => {
   const table = await load(KML_URL, KMLLoader, {kml: {shape: 'object-row-table'}});
-  t.equal(table.shape, 'object-row-table', 'shape is object-row-table');
+  expect(table.shape, 'shape is object-row-table').toBe('object-row-table');
   if (table.shape === 'object-row-table') {
-    t.equal(table.data.length, 20, 'Features were found');
+    expect(table.data.length, 'Features were found').toBe(20);
     const feature = table.data[0];
-    t.ok(Number.isFinite(feature.geometry.coordinates[0]));
-    t.ok(Number.isFinite(feature.geometry.coordinates[1]));
-    t.ok(Number.isFinite(feature.geometry.coordinates[2]));
+    expect(Number.isFinite(feature.geometry.coordinates[0])).toBeTruthy();
+    expect(Number.isFinite(feature.geometry.coordinates[1])).toBeTruthy();
+    expect(Number.isFinite(feature.geometry.coordinates[2])).toBeTruthy();
   }
-  t.end();
 });
-
-test('KMLLoader#parse(geojson-table)', async t => {
+test('KMLLoader#parse(geojson-table)', async () => {
   const table = await load(`${KML_LINESTRING_URL}.kml`, KMLLoader, {
     gis: {format: 'geojson-table'}
   });
   const resp = await fetchFile(`${KML_LINESTRING_URL}.geojson`);
   const geojson = await resp.json();
   geojson.shape = 'geojson-table';
-
   if (table.shape === 'geojson-table') {
-    t.deepEqual(table.features, geojson.features, 'Data matches GeoJSON');
+    expect(table.features, 'Data matches GeoJSON').toEqual(geojson.features);
   }
-  t.end();
 });

--- a/modules/kml/test/tcx-arrow-loader.spec.ts
+++ b/modules/kml/test/tcx-arrow-loader.spec.ts
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {validateLoader} from 'test/common/conformance';
-
 import {load} from '@loaders.gl/core';
 import {getGeoMetadata} from '@loaders.gl/geoarrow';
 import {convertWKBTableToGeoJSON} from '@loaders.gl/gis';
@@ -13,22 +12,16 @@ import * as kml from '@loaders.gl/kml';
 import * as bundledKml from '@loaders.gl/kml/bundled';
 import * as unbundledKml from '@loaders.gl/kml/unbundled';
 import type {ArrowTable, Feature, Geometry} from '@loaders.gl/schema';
-
 const TCX_URL = '@loaders.gl/kml/test/data/tcx/tcx_sample.tcx';
-
-test('TCXLoader#loader conformance', t => {
-  validateLoader(t, TCXLoader, 'TCXLoader');
-  t.end();
+test('TCXLoader#loader conformance', () => {
+  validateLoader(TCXLoader, 'TCXLoader');
 });
-
-test('TCXLoader#removed Arrow loader exports', t => {
-  t.notOk('TCXArrowLoader' in kml, 'root does not export TCXArrowLoader');
-  t.notOk('TCXArrowLoader' in bundledKml, 'bundled does not export TCXArrowLoader');
-  t.notOk('TCXArrowLoader' in unbundledKml, 'unbundled does not export TCXArrowLoader');
-  t.end();
+test('TCXLoader#removed Arrow loader exports', () => {
+  expect('TCXArrowLoader' in kml, 'root does not export TCXArrowLoader').toBeFalsy();
+  expect('TCXArrowLoader' in bundledKml, 'bundled does not export TCXArrowLoader').toBeFalsy();
+  expect('TCXArrowLoader' in unbundledKml, 'unbundled does not export TCXArrowLoader').toBeFalsy();
 });
-
-test('TCXLoader#parse with shape: arrow-table', async t => {
+test('TCXLoader#parse with shape: arrow-table', async () => {
   const arrowTable = await load(TCX_URL, TCXLoader, {tcx: {shape: 'arrow-table'}});
   const geoMetadata = getGeoMetadata(arrowTable.schema?.metadata || {});
   const roundTripped = convertWKBTableToGeoJSON(
@@ -40,19 +33,15 @@ test('TCXLoader#parse with shape: arrow-table', async t => {
     expectedTable.shape === 'geojson-table'
       ? normalizeComplexProperties(expectedTable.features)
       : [];
-
-  t.equal(arrowTable.shape, 'arrow-table', 'shape is arrow-table');
-  t.equal(geoMetadata?.primary_column, 'geometry', 'geo metadata primary column is set');
-  t.equal(geoMetadata?.columns.geometry.encoding, 'wkb', 'geo metadata uses WKB encoding');
-  t.deepEqual(
+  expect(arrowTable.shape, 'shape is arrow-table').toBe('arrow-table');
+  expect(geoMetadata?.primary_column, 'geo metadata primary column is set').toBe('geometry');
+  expect(geoMetadata?.columns.geometry.encoding, 'geo metadata uses WKB encoding').toBe('wkb');
+  expect(
     geoMetadata?.columns.geometry.geometry_types,
-    inferExpectedGeometryTypes(expectedFeatures),
     'geo metadata geometry type matches TCX output'
-  );
-  t.deepEqual(roundTripped.features, expectedFeatures, 'Arrow output matches TCXLoader output');
-  t.end();
+  ).toEqual(inferExpectedGeometryTypes(expectedFeatures));
+  expect(roundTripped.features, 'Arrow output matches TCXLoader output').toEqual(expectedFeatures);
 });
-
 /**
  * Reads Arrow rows as plain objects so they can be passed to WKB conversion helpers.
  *
@@ -67,7 +56,6 @@ function getRowsFromArrowTable(table: ArrowTable): Record<string, unknown>[] {
   }
   return rows;
 }
-
 /**
  * Infers expected GeoParquet geometry type strings from classic GeoJSON features.
  *
@@ -85,7 +73,6 @@ function inferExpectedGeometryTypes(features: Feature[]): string[] {
   }
   return [...geometryTypes];
 }
-
 /**
  * Returns the coordinate dimensionality of one representative geometry coordinate tuple.
  *
@@ -104,7 +91,6 @@ function getCoordinateDimensions(coordinates: unknown): number {
   }
   return getCoordinateDimensions(coordinates[0]);
 }
-
 /**
  * Extracts one representative coordinate payload from a geometry.
  *
@@ -120,7 +106,6 @@ function getGeometrySampleCoordinates(geometry: Geometry): unknown {
   }
   return undefined;
 }
-
 /**
  * Normalizes classic GeoJSON feature properties to the Arrow-safe representation used by the loader.
  *
@@ -133,7 +118,6 @@ function normalizeComplexProperties(features: Feature[]): Feature[] {
     properties: normalizePropertiesObject(feature.properties || {})
   }));
 }
-
 /**
  * Converts nested property values to strings so expected data matches Arrow column preservation.
  *
@@ -147,7 +131,6 @@ function normalizePropertiesObject(properties: Record<string, unknown>): Record<
   }
   return normalizedProperties;
 }
-
 /**
  * Converts nested property values to Arrow-safe scalar values.
  *
@@ -166,7 +149,6 @@ function normalizePropertyValue(propertyValue: unknown): unknown {
   }
   return JSON.stringify(propertyValue);
 }
-
 /**
  * Ensures the geometry column is represented as a typed byte array for WKB conversion helpers.
  *
@@ -180,7 +162,6 @@ function normalizeBinaryGeometryRow(row: Record<string, unknown>): Record<string
   }
   return row;
 }
-
 /**
  * Returns true when a value is a plain object containing numeric keys for byte values.
  *

--- a/modules/kml/test/tcx-loader.spec.ts
+++ b/modules/kml/test/tcx-loader.spec.ts
@@ -2,37 +2,28 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {validateLoader} from 'test/common/conformance';
-
 import {fetchFile, load, loadInBatches} from '@loaders.gl/core';
 import {TCXLoader} from '@loaders.gl/kml';
 import type {GeoJSONTable} from '@loaders.gl/schema';
-
 const TCX_URL = '@loaders.gl/kml/test/data/tcx/tcx_sample';
-
-test('TCXLoader#loader conformance', t => {
-  validateLoader(t, TCXLoader, 'TCXLoader');
-  t.end();
+test('TCXLoader#loader conformance', () => {
+  validateLoader(TCXLoader, 'TCXLoader');
 });
-
-test.skip('TCXLoader#parse', async t => {
+test.skip('TCXLoader#parse', async () => {
   const table = (await load(`${TCX_URL}.tcx`, TCXLoader, {
     gis: {format: 'geojson'}
   })) as GeoJSONTable;
   const resp = await fetchFile(`${TCX_URL}.geojson`);
   const geojson = await resp.json();
   geojson.shape = 'geojson-table';
-
   // TODO - lots of nulls injected in the metrics- should they be copies?
   // console.error(JSON.stringify(table, null, 2));
-
   // t.deepEqual(table, geojson, 'Data matches GeoJSON');
-  t.equal(table.features.length, 1, 'Data matches GeoJSON');
-  t.end();
+  expect(table.features.length, 'Data matches GeoJSON').toBe(1);
 });
-
-test('TCXLoader#parseInBatches', async t => {
+test('TCXLoader#parseInBatches', async () => {
   const iterator = await loadInBatches(`${TCX_URL}.tcx`, TCXLoader, {gis: {format: 'geojson'}});
   let data: any;
   for await (const batch of iterator) {
@@ -41,8 +32,5 @@ test('TCXLoader#parseInBatches', async t => {
   // const resp = await fetchFile(`${TCX_URL}.geojson`);
   // const geojson = await resp.json();
   // geojson.shape = 'geojson-table';
-
-  t.equal(data.features.length, 1);
-  // t.deepEqual(data, geojson, 'Data matches GeoJSON');
-  t.end();
+  expect(data.features.length).toBe(1);
 });

--- a/modules/mvt/test/lib/vector-tiler/clip-features.spec.ts
+++ b/modules/mvt/test/lib/vector-tiler/clip-features.spec.ts
@@ -1,6 +1,7 @@
 // loaders.gl
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT AND ISC
 // Copyright (c) vis.gl contributors
+// Forked from https://github.com/mapbox/geojson-vt under compatible ISC license
 
 import {expect, test} from 'vitest';
 // @ts-ignore-error

--- a/modules/mvt/test/lib/vector-tiler/simplify-path.spec.ts
+++ b/modules/mvt/test/lib/vector-tiler/simplify-path.spec.ts
@@ -1,6 +1,7 @@
 // loaders.gl
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT AND ISC
 // Copyright (c) vis.gl contributors
+// Forked from https://github.com/mapbox/geojson-vt under compatible ISC license
 
 import {expect, test} from 'vitest';
 import {simplifyPath} from '@loaders.gl/mvt/lib/vector-tiler/features/simplify-path';

--- a/modules/mvt/test/table-tile-source-full.spec.ts
+++ b/modules/mvt/test/table-tile-source-full.spec.ts
@@ -1,6 +1,7 @@
 // loaders.gl
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT AND ISC
 // Copyright (c) vis.gl contributors
+// Forked from https://github.com/mapbox/geojson-vt under compatible ISC license
 
 import {expect, test} from 'vitest';
 import {fetchFile} from '@loaders.gl/core';

--- a/modules/mvt/test/table-tile-source-multi-world.spec.ts
+++ b/modules/mvt/test/table-tile-source-multi-world.spec.ts
@@ -1,6 +1,7 @@
 // loaders.gl
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT AND ISC
 // Copyright (c) vis.gl contributors
+// Forked from https://github.com/mapbox/geojson-vt under compatible ISC license
 
 import {expect, test} from 'vitest';
 import {TableVectorTileSource} from '@loaders.gl/mvt';

--- a/modules/mvt/test/table-tile-source.spec.ts
+++ b/modules/mvt/test/table-tile-source.spec.ts
@@ -1,6 +1,7 @@
 // loaders.gl
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT AND ISC
 // Copyright (c) vis.gl contributors
+// Forked from https://github.com/mapbox/geojson-vt under compatible ISC license
 
 import {expect, test} from 'vitest';
 import {createDataSource, fetchFile, load} from '@loaders.gl/core';


### PR DESCRIPTION
## Goals

- Migrate two related loader modules from Tape compatibility tests to native Vitest.
- Keep the grouped tranche reviewable and fast.
- Carry forward review fixes from the previous GIS/MVT tranche.

## Changes

- Migrated six KML suites covering KML, GPX, and TCX loaders.
- Migrated five JSON suites covering JSON, GeoJSON, NDJSON, parsers, and writers.
- Converted KML loader conformance calls to native helper overloads.
- Corrected a JSON streaming fixture so schema-freezing is exercised across feature batch boundaries.
- Restored MIT/ISC licensing and Mapbox attribution on five forked MVT tests.
- Added TSDoc for the typed-array normalization helper.
- No production code or coverage thresholds changed.

## Validation

- `yarn build`
- `yarn build-workers`
- `yarn lint fix`
- `yarn test-audit` — 601 files, 0 Tape, 0 violations
- Focused KML/JSON browser tests — 13 files, 108 passed, 3 skipped
- Focused KML/JSON browser coverage completed successfully
- No KML/JSON Node-only test files