### PR TITLE
feat(parquet): close INT96 logical parity tranche

### DIFF
--- a/docs/modules/parquet/api-reference/parquet-loader.md
+++ b/docs/modules/parquet/api-reference/parquet-loader.md
@@ -176,6 +176,7 @@ Supports table category options such as `batchType` and `batchSize`.
 | `parquet.wasmUrl` | `string` | package-local asset | Overrides the `parquet-wasm` binary URL for `ParquetLoader`. |
 | `parquet.keyRetriever` | `ParquetKeyRetriever` | `undefined` | Resolves keys for modular-encrypted files when using `ParquetJSLoader`. |
 | `parquet.aadPrefix` | `Uint8Array` | `undefined` | Supplies the AAD prefix for encrypted files that omit it from their crypto metadata. |
+| `parquet.int96AsTimestamp` | `boolean` | `false` for object rows, `true` for TypeScript Arrow output | Decodes legacy INT96 physical values as signed epoch-nanosecond timestamps. |
 | `parquet.verifyFooterSignature` | `boolean` | `true` | Verifies plaintext-footer signatures on modular-encrypted files when a `keyRetriever` is supplied. |
 
 ## Loader Variants

--- a/docs/modules/parquet/api-reference/parquet-source-loader.md
+++ b/docs/modules/parquet/api-reference/parquet-source-loader.md
@@ -358,6 +358,7 @@ individual read.
 | `core.reuseWorkers` | `boolean` | `true` in browsers | Reuses selective source workers between row-group jobs. |
 | `parquet.headers` | `HeadersInit` | `undefined` | Headers forwarded to all remote Parquet requests. |
 | `parquet.preserveBinary` | `boolean` | `false` | Binary-value policy used by TypeScript-backed column reads. |
+| `parquet.int96AsTimestamp` | `boolean` | `false` | Decodes legacy INT96 physical values as epoch-nanosecond timestamps in the source schema and batches. |
 | `parquet.verifyPageChecksums` | `boolean` | `false` | Verifies CRC-32 page bodies when the file provides page checksums; checksum-enabled reads use the TypeScript path. |
 | `parquet.verifyFooterSignature` | `boolean` | `true` | Verifies plaintext-footer signatures on modular-encrypted files when a `keyRetriever` is supplied. |
 | `parquet.keyRetriever` | `ParquetKeyRetriever` | `undefined` | Resolves keys for modular-encrypted metadata, indexes, Bloom filters, and pages. |

--- a/docs/modules/parquet/formats/parquet.md
+++ b/docs/modules/parquet/formats/parquet.md
@@ -88,7 +88,7 @@ as a compatibility fallback.
 | `BOOLEAN` | One bit per value in plain encoding | ✅ | ✅ | Nulls are represented by definition levels, not value bits |
 | `INT32` | 32-bit little-endian signed integer | ✅ | ✅ | Also carries dates, narrow integers, and some decimals |
 | `INT64` | 64-bit little-endian signed integer | ✅ | ✅ | Preserved as exact `bigint` when required |
-| `INT96` | 12-byte legacy integer | ⚠️ | ⚠️ | Deprecated; no complete portable logical interpretation |
+| `INT96` | 12-byte legacy timestamp | ✅ (Arrow) | ⚠️ | TypeScript Arrow output can decode the canonical Julian-day plus nanoseconds representation as `timestamp-nanosecond`; object-row compatibility remains opt-in via `int96AsTimestamp` |
 | `FLOAT` | IEEE-754 binary32, little endian | ✅ | ✅ | Maps to Arrow Float32 |
 | `DOUBLE` | IEEE-754 binary64, little endian | ✅ | ✅ | Maps to Arrow Float64 |
 | `BYTE_ARRAY` | 32-bit length followed by bytes | ✅ | ✅ | Used for binary, strings, JSON, BSON, and arbitrary precision decimals |
@@ -299,7 +299,7 @@ rather than by individual missing methods.
 | Selective scan and physical planning | ✅ foundation | Footer statistics, Bloom filters, page/offset indexes, nested-leaf pruning, late materialization, and explainable range plans | Sorting-column semantics drive safe page/row-group pruning, and estimates describe the physical late-materialization plan |
 | Cloud-native table sources | ✅ read-only slice | Iceberg metadata/manifest planning and Delta snapshot replay dispatch selected files through `ParquetDatasetSource` | Checkpoints, CDC, deletion vectors, catalog discovery, and consistent snapshot/error semantics |
 | Modular encryption | ✅ opt-in | Encrypted footer/column metadata, page/index/Bloom-filter reads, AES-GCM/AES-GCM-CTR pages, worker scans, footer-key and per-column-key encrypted-column writing, and plaintext-footer signatures | Broader encrypted-file interoperability and external key-management guidance |
-| Logical and legacy parity | ⚠️ expanding | Logical Arrow mappings, nested LIST/MAP/VARIANT/geo types, legacy `BIT_PACKED` reads, and explicit `PLAIN_DICTIONARY` writes | Defined INT96 conversion, legacy nested/shredding variants, and exact Arrow fidelity across the stable logical-type matrix |
+| Logical and legacy parity | ✅ core Arrow path | Logical Arrow mappings, canonical INT96 timestamp decoding, nested LIST/MAP/VARIANT/geo types, legacy `BIT_PACKED` reads, and explicit `PLAIN_DICTIONARY` writes | Legacy nested/shredding variants, object-row compatibility policy, and exact Arrow fidelity across the remaining stable logical-type matrix |
 | Conformance and scale gate | ⚠️ ongoing | Hermetic feature tests, differential checks, and representative browser benchmarks | Apache corpus plus nested/repeated cases, every stable codec/encoding, differential validation, and large-file/selective-range benchmarks pass in CI |
 | Emerging-format lab | 🧪 experimental | Tracking links and isolated capability flags | ALP, PFOR, VECTOR, and format-versioning experiments remain opt-in until an upstream format and interoperability fixtures stabilize |
 

--- a/modules/parquet/src/lib/arrow/convert-schema-from-parquet.ts
+++ b/modules/parquet/src/lib/arrow/convert-schema-from-parquet.ts
@@ -52,9 +52,10 @@ export const PARQUET_TYPE_MAPPING: {[type in ParquetType]: DataType} = {
 
 export function convertParquetSchema(
   parquetSchema: ParquetSchema,
-  parquetMetadata: FileMetaData | null
+  parquetMetadata: FileMetaData | null,
+  options?: {int96AsTimestamp?: boolean}
 ): Schema {
-  const fields = getFields(parquetSchema.schema);
+  const fields = getFields(parquetSchema.schema, options);
   const metadata = parquetMetadata && getSchemaMetadata(parquetMetadata);
 
   const schema: Schema = {
@@ -65,21 +66,25 @@ export function convertParquetSchema(
   return schema;
 }
 
-function getFields(schema: SchemaDefinition): Field[] {
+function getFields(schema: SchemaDefinition, options?: {int96AsTimestamp?: boolean}): Field[] {
   const fields: Field[] = [];
 
   for (const name in schema) {
-    fields.push(getField(name, schema[name]));
+    fields.push(getField(name, schema[name], options));
   }
 
   return fields;
 }
 
 /** Converts one Parquet field, preserving repeated values as Arrow lists. */
-function getField(name: string, field: FieldDefinition): Field {
+function getField(
+  name: string,
+  field: FieldDefinition,
+  options?: {int96AsTimestamp?: boolean}
+): Field {
   const elementField: Field = {
     name,
-    type: getFieldValueType(field),
+    type: getFieldValueType(field, options),
     nullable: Boolean(field.optional),
     metadata: getFieldMetadata(field)
   };
@@ -100,9 +105,12 @@ function getField(name: string, field: FieldDefinition): Field {
 }
 
 /** Converts a nested Parquet definition into its corresponding Arrow data type. */
-function getFieldValueType(field: FieldDefinition): DataType {
+function getFieldValueType(
+  field: FieldDefinition,
+  options?: {int96AsTimestamp?: boolean}
+): DataType {
   if (!field.fields) {
-    return getFieldType(field);
+    return getFieldType(field, options);
   }
 
   if (field.logicalType?.type === 'LIST') {
@@ -110,7 +118,7 @@ function getFieldValueType(field: FieldDefinition): DataType {
     if (!element) {
       // Preserve unusual legacy LIST layouts as structs. Their group names and
       // repetition levels are still available to the row-materialization path.
-      return {type: 'struct', children: getFields(field.fields)};
+      return {type: 'struct', children: getFields(field.fields, options)};
     }
     if (
       (element.logicalType?.type === 'LIST' &&
@@ -121,14 +129,14 @@ function getFieldValueType(field: FieldDefinition): DataType {
       // Preserve nested legacy wrappers. Arrow's high-level List/Map type
       // cannot describe the historical wrapper shape without changing the
       // object-row contract used by existing callers.
-      return {type: 'struct', children: getFields(field.fields)};
+      return {type: 'struct', children: getFields(field.fields, options)};
     }
     return {
       type: 'list',
       children: [
         {
           name: 'element',
-          type: getFieldValueType(element),
+          type: getFieldValueType(element, options),
           nullable: Boolean(element.optional)
         }
       ]
@@ -142,7 +150,7 @@ function getFieldValueType(field: FieldDefinition): DataType {
     if (!key || !value) {
       // Preserve unusual legacy MAP layouts as structs rather than rejecting a
       // file whose converted annotation does not follow the standard wrapper.
-      return {type: 'struct', children: getFields(field.fields)};
+      return {type: 'struct', children: getFields(field.fields, options)};
     }
     return {
       type: 'map',
@@ -153,8 +161,12 @@ function getFieldValueType(field: FieldDefinition): DataType {
           type: {
             type: 'struct',
             children: [
-              {name: 'key', type: getFieldValueType(key), nullable: false},
-              {name: 'value', type: getFieldValueType(value), nullable: Boolean(value.optional)}
+              {name: 'key', type: getFieldValueType(key, options), nullable: false},
+              {
+                name: 'value',
+                type: getFieldValueType(value, options),
+                nullable: Boolean(value.optional)
+              }
             ]
           },
           nullable: false
@@ -163,7 +175,7 @@ function getFieldValueType(field: FieldDefinition): DataType {
     };
   }
 
-  return {type: 'struct', children: getFields(field.fields)};
+  return {type: 'struct', children: getFields(field.fields, options)};
 }
 
 /** Returns whether a nested LIST follows the standard list/list/element wrapper. */
@@ -177,7 +189,10 @@ function isStandardMapDefinition(field: FieldDefinition): boolean {
 }
 
 /** Returns the exact serialized Arrow type for one decoded Parquet field. */
-function getFieldType(field: FieldDefinition): DataType {
+function getFieldType(field: FieldDefinition, options?: {int96AsTimestamp?: boolean}): DataType {
+  if (field.type === 'INT96' && options?.int96AsTimestamp) {
+    return 'timestamp-nanosecond';
+  }
   if (field.logicalType?.type === 'DECIMAL') {
     const precision = field.precision ?? field.presision;
     const scale = field.scale;

--- a/modules/parquet/src/lib/parquet-page-index.ts
+++ b/modules/parquet/src/lib/parquet-page-index.ts
@@ -90,6 +90,8 @@ export type ParquetPageIndexDecryptor = (
 export type ParquetPagePruningOptions = {
   /** Row-group ordinal used when constructing encrypted-module AAD. */
   rowGroupOrdinal?: number;
+  /** Decode legacy INT96 page statistics as epoch nanoseconds. */
+  int96AsTimestamp?: boolean;
   /** Decrypts encrypted index modules; omitted for plaintext files. */
   decryptModule?: ParquetPageIndexDecryptor;
 };
@@ -203,7 +205,7 @@ export async function createParquetPagePruningPlan(
           : toUint8Array(columnIndexBytes);
         pageStatistics[pathKey] = {
           pages,
-          statistics: decodeParquetColumnIndex(decryptedBytes, pages, field)
+          statistics: decodeParquetColumnIndex(decryptedBytes, pages, field, options)
         };
       } catch {
         return;
@@ -404,7 +406,8 @@ function getPredicateRowRanges(
 export function decodeParquetColumnIndex(
   bytes: Uint8Array,
   pages: readonly ParquetDataPageLocation[],
-  field: ParquetField
+  field: ParquetField,
+  options?: Pick<ParquetPagePruningOptions, 'int96AsTimestamp'>
 ): ParquetPageStatistics[] {
   const protocol = new Uint8ArrayCompactProtocol(new Uint8ArrayTransport(bytes));
   const columnIndex = ColumnIndex.read(protocol as any);
@@ -419,10 +422,10 @@ export function decodeParquetColumnIndex(
   return pages.map((_page, pageIndex) => ({
     min: columnIndex.null_pages[pageIndex]
       ? undefined
-      : decodeParquetPageStatisticsValue(columnIndex.min_values[pageIndex], field),
+      : decodeParquetPageStatisticsValue(columnIndex.min_values[pageIndex], field, options),
     max: columnIndex.null_pages[pageIndex]
       ? undefined
-      : decodeParquetPageStatisticsValue(columnIndex.max_values[pageIndex], field),
+      : decodeParquetPageStatisticsValue(columnIndex.max_values[pageIndex], field, options),
     nullCount:
       columnIndex.null_counts?.[pageIndex] !== undefined
         ? Number(columnIndex.null_counts[pageIndex])
@@ -435,7 +438,11 @@ export function decodeParquetColumnIndex(
 }
 
 /** Decodes one physical page-index statistic and applies its Parquet logical annotation. */
-export function decodeParquetPageStatisticsValue(bytes: Uint8Array, field: ParquetField): unknown {
+export function decodeParquetPageStatisticsValue(
+  bytes: Uint8Array,
+  field: ParquetField,
+  options?: Pick<ParquetPagePruningOptions, 'int96AsTimestamp'>
+): unknown {
   let primitiveValue: unknown;
   switch (field.primitiveType) {
     case 'BOOLEAN':
@@ -456,6 +463,18 @@ export function decodeParquetPageStatisticsValue(bytes: Uint8Array, field: Parqu
       primitiveValue = readDoubleLE(bytes, 0);
       break;
     case 'INT96':
+      if (options?.int96AsTimestamp && bytes.byteLength >= 12) {
+        const dataView = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+        const nanosecondsOfDay = dataView.getBigUint64(0, true);
+        if (nanosecondsOfDay < 86_400_000_000_000n) {
+          primitiveValue =
+            (BigInt(dataView.getInt32(8, true)) - 2440588n) * 86_400_000_000_000n +
+            nanosecondsOfDay;
+          break;
+        }
+      }
+      primitiveValue = copyUint8Array(bytes);
+      break;
     case 'BYTE_ARRAY':
     case 'FIXED_LEN_BYTE_ARRAY':
       primitiveValue = copyUint8Array(bytes);

--- a/modules/parquet/src/lib/parquet-source-worker-decoder.ts
+++ b/modules/parquet/src/lib/parquet-source-worker-decoder.ts
@@ -36,6 +36,7 @@ export async function decodeParquetSourceWorkerInput(
     : undefined;
   const reader = new ParquetReader(file, {
     preserveBinary: input.preserveBinary,
+    int96AsTimestamp: input.int96AsTimestamp,
     verifyPageChecksums: input.verifyPageChecksums,
     encryptionContext: input.encryption
       ? {

--- a/modules/parquet/src/lib/parquet-source-worker-types.ts
+++ b/modules/parquet/src/lib/parquet-source-worker-types.ts
@@ -85,6 +85,8 @@ export type ParquetSourceWorkerInput = {
   encryption?: ParquetSourceWorkerEncryption;
   /** Whether BYTE_ARRAY values stay binary during logical conversion. */
   preserveBinary: boolean;
+  /** Whether legacy INT96 values decode as epoch-nanosecond timestamps. */
+  int96AsTimestamp: boolean;
   /** Whether page CRC values are verified while decoding in the worker. */
   verifyPageChecksums: boolean;
 };

--- a/modules/parquet/src/lib/parsers/get-parquet-schema.ts
+++ b/modules/parquet/src/lib/parsers/get-parquet-schema.ts
@@ -12,7 +12,9 @@ import {applyGeoParquetToFieldMetadata} from '../geo/geospatial-metadata';
 export async function getSchemaFromParquetReader(reader: ParquetReader): Promise<Schema> {
   const parquetSchema = await reader.getSchema();
   const parquetMetadata = await reader.getFileMetadata();
-  const schema = convertParquetSchema(parquetSchema, parquetMetadata);
+  const schema = convertParquetSchema(parquetSchema, parquetMetadata, {
+    int96AsTimestamp: reader.int96AsTimestamp
+  });
   applyGeoParquetToFieldMetadata(schema);
   unpackGeoMetadata(schema.metadata);
   unpackJSONStringMetadata(schema.metadata, 'pandas');

--- a/modules/parquet/src/lib/parsers/parse-parquet-to-arrow-js.ts
+++ b/modules/parquet/src/lib/parsers/parse-parquet-to-arrow-js.ts
@@ -128,6 +128,7 @@ async function readProjectedSchema(
 ): Promise<Schema> {
   const reader = new ParquetReader(file, {
     preserveBinary: options?.parquet?.preserveBinary,
+    int96AsTimestamp: options?.parquet?.int96AsTimestamp ?? true,
     verifyFooterSignature: options?.parquet?.verifyFooterSignature,
     keyRetriever: options?.parquet?.keyRetriever,
     aadPrefix: options?.parquet?.aadPrefix
@@ -150,6 +151,7 @@ export async function* parseParquetFileToArrowInBatchesWithJs(
 
   const reader = new ParquetReader(file, {
     preserveBinary: options?.parquet?.preserveBinary,
+    int96AsTimestamp: options?.parquet?.int96AsTimestamp ?? true,
     retainByteArrayViews: true,
     useTypedValueBuffers: true,
     useTypedLevelBuffers: true,
@@ -667,6 +669,13 @@ function createRawPrimitiveArrowArrayView(
   ) {
     return values.subarray(start, end);
   }
+  if (
+    parquetField.primitiveType === 'INT96' &&
+    arrowType instanceof arrow.TimestampNanosecond &&
+    values instanceof BigInt64Array
+  ) {
+    return values.subarray(start, end);
+  }
   return undefined;
 }
 
@@ -714,6 +723,9 @@ function createRawPrimitiveArrowArray(
       arrowType instanceof arrow.TimestampMicrosecond ||
       arrowType instanceof arrow.TimestampNanosecond)
   ) {
+    return new BigInt64Array(rowCount);
+  }
+  if (parquetField.primitiveType === 'INT96' && arrowType instanceof arrow.TimestampNanosecond) {
     return new BigInt64Array(rowCount);
   }
   if (parquetField.primitiveType === 'INT64' && arrowType instanceof arrow.Uint64) {

--- a/modules/parquet/src/lib/parsers/parse-parquet-to-columns.ts
+++ b/modules/parquet/src/lib/parsers/parse-parquet-to-columns.ts
@@ -40,7 +40,9 @@ export async function* parseParquetFileInColumnarBatches(
 ): AsyncIterable<ColumnarTableBatch> {
   await preloadCompressions(options);
 
-  const reader = new ParquetReader(file);
+  const reader = new ParquetReader(file, {
+    int96AsTimestamp: options?.parquet?.int96AsTimestamp
+  });
 
   // Extract schema and geo metadata
   const schema = await getSchemaFromParquetReader(reader);

--- a/modules/parquet/src/lib/parsers/parse-parquet-to-json.ts
+++ b/modules/parquet/src/lib/parsers/parse-parquet-to-json.ts
@@ -26,6 +26,7 @@ export async function parseParquetFile(
 
   const reader = new ParquetReader(file, {
     preserveBinary: options?.parquet?.preserveBinary,
+    int96AsTimestamp: options?.parquet?.int96AsTimestamp,
     verifyFooterSignature: options?.parquet?.verifyFooterSignature,
     keyRetriever: options?.parquet?.keyRetriever,
     aadPrefix: options?.parquet?.aadPrefix
@@ -82,6 +83,7 @@ export async function* parseParquetFileInBatches(
 
   const reader = new ParquetReader(file, {
     preserveBinary: options?.parquet?.preserveBinary,
+    int96AsTimestamp: options?.parquet?.int96AsTimestamp,
     verifyFooterSignature: options?.parquet?.verifyFooterSignature,
     keyRetriever: options?.parquet?.keyRetriever,
     aadPrefix: options?.parquet?.aadPrefix

--- a/modules/parquet/src/parquet-loader-options.ts
+++ b/modules/parquet/src/parquet-loader-options.ts
@@ -12,6 +12,8 @@ type ParquetCommonLoaderOptions = {
   batchSize?: number;
   columns?: string[];
   preserveBinary?: boolean;
+  /** Decode legacy INT96 values as Arrow timestamp-nanosecond values. */
+  int96AsTimestamp?: boolean;
 };
 
 /** Additional options supported by the wasm-backed Parquet reader. */

--- a/modules/parquet/src/parquet-source-loader.ts
+++ b/modules/parquet/src/parquet-source-loader.ts
@@ -707,6 +707,7 @@ export class ParquetSource
               signal,
               {
                 rowGroupOrdinal: rowGroupIndex,
+                int96AsTimestamp: Boolean(this.options.parquet?.int96AsTimestamp),
                 decryptModule: (bytes, module, rowGroupOrdinal, columnOrdinal, columnChunk) =>
                   initialization.reader.decryptIndexModule(
                     bytes,
@@ -876,6 +877,7 @@ export class ParquetSource
           signal,
           {
             rowGroupOrdinal: rowGroupIndex,
+            int96AsTimestamp: Boolean(this.options.parquet?.int96AsTimestamp),
             decryptModule: (bytes, module, rowGroupOrdinal, columnOrdinal, columnChunk) =>
               initialization.reader.decryptIndexModule(
                 bytes,
@@ -1044,6 +1046,7 @@ export class ParquetSource
               }
             : undefined,
           preserveBinary: Boolean(this.options.parquet?.preserveBinary),
+          int96AsTimestamp: Boolean(this.options.parquet?.int96AsTimestamp),
           verifyPageChecksums: Boolean(this.options.parquet?.verifyPageChecksums)
         },
         workerOptions
@@ -1164,6 +1167,7 @@ export class ParquetSource
     try {
       const reader = new ParquetReader(file, {
         preserveBinary: this.options.parquet?.preserveBinary,
+        int96AsTimestamp: this.options.parquet?.int96AsTimestamp,
         verifyPageChecksums: this.options.parquet?.verifyPageChecksums,
         verifyFooterSignature: this.options.parquet?.verifyFooterSignature,
         keyRetriever: this.options.parquet?.keyRetriever,

--- a/modules/parquet/src/parquet-source-types.ts
+++ b/modules/parquet/src/parquet-source-types.ts
@@ -473,6 +473,8 @@ export type ParquetSourceLoaderOptions = DataSourceOptions & {
     headers?: HeadersInit;
     /** Preserve binary values when the TypeScript decoder is used for later reads. */
     preserveBinary?: boolean;
+    /** Decode legacy INT96 values as epoch-nanosecond timestamps. */
+    int96AsTimestamp?: boolean;
     /** Verify page-header CRC values in TypeScript reads. */
     verifyPageChecksums?: boolean;
     /** Resolves modular-encryption keys from file and column key metadata. */

--- a/modules/parquet/src/parquetjs/codecs/declare.ts
+++ b/modules/parquet/src/parquetjs/codecs/declare.ts
@@ -37,6 +37,8 @@ export interface ParquetCodecOptions {
   dictionary?: readonly unknown[];
   /** Preserve decoded INT64 values as bigint instead of converting them to number. */
   int64AsBigInt?: boolean;
+  /** Decode legacy INT96 physical values as epoch nanoseconds instead of raw numbers. */
+  int96AsTimestamp?: boolean;
 }
 
 export interface ParquetCodecKit {

--- a/modules/parquet/src/parquetjs/codecs/plain.ts
+++ b/modules/parquet/src/parquetjs/codecs/plain.ts
@@ -24,6 +24,11 @@ import {
   writeUInt32LE
 } from '../utils/binary-utils';
 
+const JULIAN_DAY_UNIX_EPOCH = 2440588n;
+const NANOSECONDS_PER_DAY = 86_400_000_000_000n;
+const INT64_MIN = -(1n << 63n);
+const INT64_MAX = (1n << 63n) - 1n;
+
 export function encodeValues(
   type: PrimitiveType,
   values: any[],
@@ -166,12 +171,26 @@ function decodeValues_INT96(
   const {output, outputOffset} = getParquetValueOutput(options, count);
   const dataView = getCursorDataView(cursor);
   for (let i = 0; i < count; i++) {
-    const low = Number(dataView.getBigInt64(cursor.offset, true));
-    const high = dataView.getUint32(cursor.offset + 8, true);
-    if (high === 0xffffffff) {
-      output[outputOffset + i] = ~-low + 1; // truncate to 64 actual precision
+    if (options.int96AsTimestamp) {
+      const nanosecondsOfDay = dataView.getBigUint64(cursor.offset, true);
+      if (nanosecondsOfDay >= NANOSECONDS_PER_DAY) {
+        throw new Error(`Invalid INT96 nanoseconds of day: ${nanosecondsOfDay}`);
+      }
+      const julianDay = BigInt(dataView.getInt32(cursor.offset + 8, true));
+      const epochNanoseconds =
+        (julianDay - JULIAN_DAY_UNIX_EPOCH) * NANOSECONDS_PER_DAY + nanosecondsOfDay;
+      if (epochNanoseconds < INT64_MIN || epochNanoseconds > INT64_MAX) {
+        throw new Error(`INT96 timestamp is outside the signed 64-bit range: ${epochNanoseconds}`);
+      }
+      output[outputOffset + i] = epochNanoseconds;
     } else {
-      output[outputOffset + i] = low; // truncate to 64 actual precision
+      const low = Number(dataView.getBigInt64(cursor.offset, true));
+      const high = dataView.getUint32(cursor.offset + 8, true);
+      if (high === 0xffffffff) {
+        output[outputOffset + i] = ~-low + 1; // truncate to 64 actual precision
+      } else {
+        output[outputOffset + i] = low; // truncate to 64 actual precision
+      }
     }
     cursor.offset += 12;
   }

--- a/modules/parquet/src/parquetjs/parser/decoders.ts
+++ b/modules/parquet/src/parquetjs/parser/decoders.ts
@@ -518,7 +518,8 @@ async function decodeDataPage(
     output: target?.values,
     outputOffset: target?.valueOffset,
     dictionary: isDictionaryEncoding(valueEncoding) ? target?.dictionary : undefined,
-    int64AsBigInt: shouldDecodeInt64AsBigInt(context)
+    int64AsBigInt: shouldDecodeInt64AsBigInt(context),
+    int96AsTimestamp: context.int96AsTimestamp
   };
 
   const values = decodeValues(
@@ -643,7 +644,8 @@ async function decodeDataPageV2(
     output: target?.values,
     outputOffset: target?.valueOffset,
     dictionary: isDictionaryEncoding(valueEncoding) ? target?.dictionary : undefined,
-    int64AsBigInt: shouldDecodeInt64AsBigInt(context)
+    int64AsBigInt: shouldDecodeInt64AsBigInt(context),
+    int96AsTimestamp: context.int96AsTimestamp
   };
 
   const values = decodeValues(
@@ -739,6 +741,7 @@ function createParquetColumnValueBuffer(
     case 'INT64':
       return new BigInt64Array(capacity);
     case 'INT96':
+      return context.int96AsTimestamp ? new BigInt64Array(capacity) : new Float64Array(capacity);
     case 'DOUBLE':
       return new Float64Array(capacity);
     case 'FLOAT':
@@ -839,7 +842,8 @@ async function decodeDictionaryPage(
     {
       ...context,
       typeLength: context.column.typeLength,
-      int64AsBigInt: shouldDecodeInt64AsBigInt(context)
+      int64AsBigInt: shouldDecodeInt64AsBigInt(context),
+      int96AsTimestamp: context.int96AsTimestamp
     } as ParquetCodecOptions
   );
 

--- a/modules/parquet/src/parquetjs/parser/parquet-reader.ts
+++ b/modules/parquet/src/parquetjs/parser/parquet-reader.ts
@@ -79,6 +79,8 @@ export type ParquetReaderProps = {
   useTypedLevelBuffers?: boolean;
   /** Verify page-header CRC values when present. Disabled by default for throughput. */
   verifyPageChecksums?: boolean;
+  /** Decode legacy INT96 values as epoch nanoseconds for Arrow timestamp columns. */
+  int96AsTimestamp?: boolean;
   /** Verify plaintext-footer signatures when present. Enabled by default. */
   verifyFooterSignature?: boolean;
   /** Abort signal forwarded to every underlying random-access read. */
@@ -136,6 +138,7 @@ export class ParquetReader {
     useTypedValueBuffers: false,
     useTypedLevelBuffers: false,
     verifyPageChecksums: false,
+    int96AsTimestamp: false,
     verifyFooterSignature: true,
     signal: undefined,
     keyRetriever: undefined,
@@ -162,6 +165,11 @@ export class ParquetReader {
   /** Whether the decoded footer describes an encrypted Parquet file. */
   get encrypted(): boolean {
     return Boolean(this.encryptionContext);
+  }
+
+  /** Whether this reader decodes legacy INT96 values as epoch nanoseconds. */
+  get int96AsTimestamp(): boolean {
+    return this.props.int96AsTimestamp;
   }
 
   /** Returns a cloneable snapshot of the file encryption context for worker decoding. */
@@ -787,7 +795,8 @@ export class ParquetReader {
       retainByteArrayViews: this.props.retainByteArrayViews,
       useTypedValueBuffers: this.props.useTypedValueBuffers,
       useTypedLevelBuffers: this.props.useTypedLevelBuffers,
-      verifyPageChecksums: this.props.verifyPageChecksums
+      verifyPageChecksums: this.props.verifyPageChecksums,
+      int96AsTimestamp: this.props.int96AsTimestamp
     };
 
     let dictionary: any[] | undefined;
@@ -962,7 +971,8 @@ export class ParquetReader {
       preserveBinary: this.props.preserveBinary,
       retainByteArrayViews: this.props.retainByteArrayViews,
       useTypedValueBuffers: this.props.useTypedValueBuffers,
-      verifyPageChecksums: this.props.verifyPageChecksums
+      verifyPageChecksums: this.props.verifyPageChecksums,
+      int96AsTimestamp: this.props.int96AsTimestamp
     };
 
     let dictionary: any[] | undefined;

--- a/modules/parquet/src/parquetjs/schema/declare.ts
+++ b/modules/parquet/src/parquetjs/schema/declare.ts
@@ -204,6 +204,8 @@ export interface ParquetReaderContext {
   useTypedLevelBuffers?: boolean;
   /** Verify a page-header CRC when one is present. */
   verifyPageChecksums?: boolean;
+  /** Decode legacy INT96 physical values as epoch nanoseconds. */
+  int96AsTimestamp?: boolean;
 }
 
 /** Mutable storage for decoded Parquet repetition and definition levels. */

--- a/modules/parquet/test/parquet-int96.spec.ts
+++ b/modules/parquet/test/parquet-int96.spec.ts
@@ -1,0 +1,57 @@
+import {expect, test} from 'vitest';
+
+import {convertParquetSchema} from '../src/lib/arrow/convert-schema-from-parquet';
+import {PARQUET_CODECS} from '../src/parquetjs/codecs';
+import {ParquetSchema} from '../src/parquetjs/schema/schema';
+
+const JULIAN_DAY_UNIX_EPOCH = 2440588;
+
+test('INT96 decoder can produce canonical epoch nanoseconds', () => {
+  const bytes = new Uint8Array(12);
+  const dataView = new DataView(bytes.buffer);
+  dataView.setBigUint64(0, 1_234_567_890n, true);
+  dataView.setInt32(8, JULIAN_DAY_UNIX_EPOCH, true);
+
+  const cursor = {buffer: bytes, offset: 0};
+  const values = PARQUET_CODECS.PLAIN.decodeValues('INT96', cursor, 1, {
+    int96AsTimestamp: true
+  });
+
+  expect(values).toEqual([1_234_567_890n]);
+  expect(cursor.offset).toBe(12);
+});
+
+test('INT96 decoder rejects an invalid nanoseconds-of-day value', () => {
+  const bytes = new Uint8Array(12);
+  const dataView = new DataView(bytes.buffer);
+  dataView.setBigUint64(0, 86_400_000_000_000n, true);
+  dataView.setInt32(8, JULIAN_DAY_UNIX_EPOCH, true);
+
+  expect(() =>
+    PARQUET_CODECS.PLAIN.decodeValues('INT96', {buffer: bytes, offset: 0}, 1, {
+      int96AsTimestamp: true
+    })
+  ).toThrow('Invalid INT96 nanoseconds of day');
+});
+
+test('INT96 decoder rejects timestamps outside the Arrow nanosecond range', () => {
+  const bytes = new Uint8Array(12);
+  const dataView = new DataView(bytes.buffer);
+  dataView.setBigUint64(0, 0n, true);
+  dataView.setInt32(8, 3_000_000, true);
+
+  expect(() =>
+    PARQUET_CODECS.PLAIN.decodeValues('INT96', {buffer: bytes, offset: 0}, 1, {
+      int96AsTimestamp: true
+    })
+  ).toThrow('outside the signed 64-bit range');
+});
+
+test('INT96 schema mapping is opt-in for timestamp Arrow output', () => {
+  const parquetSchema = new ParquetSchema({event_time: {type: 'INT96', optional: false}});
+
+  expect(convertParquetSchema(parquetSchema, null).fields[0].type).toBe('float64');
+  expect(
+    convertParquetSchema(parquetSchema, null, {int96AsTimestamp: true}).fields[0].type
+  ).toBe('timestamp-nanosecond');
+});

--- a/modules/parquet/test/parquet-page-index.spec.ts
+++ b/modules/parquet/test/parquet-page-index.spec.ts
@@ -52,6 +52,21 @@ describe('Parquet page-index pruning', () => {
     ).toBe(0xffffffffffffffffn);
   });
 
+  test('decodes canonical INT96 page statistics when timestamp mode is enabled', () => {
+    const bytes = new Uint8Array(12);
+    const dataView = new DataView(bytes.buffer);
+    dataView.setBigUint64(0, 987_654_321n, true);
+    dataView.setInt32(8, 2440588, true);
+
+    expect(
+      decodeParquetPageStatisticsValue(
+        bytes,
+        {primitiveType: 'INT96'} as ParquetField,
+        {int96AsTimestamp: true}
+      )
+    ).toBe(987_654_321n);
+  });
+
   test('rejects optional index ranges outside the containing file', () => {
     expect(getParquetIndexRange(80n, 20, 100)).toEqual({offset: 80, length: 20});
     expect(getParquetIndexRange(80n, 21, 100)).toBeUndefined();

--- a/modules/parquet/test/parquet-source-loader.spec.ts
+++ b/modules/parquet/test/parquet-source-loader.spec.ts
@@ -748,6 +748,7 @@ async function createParquetSourceWorkerInput(
     ranges,
     batchSize: 1,
     preserveBinary: false,
+    int96AsTimestamp: false,
     verifyPageChecksums: false
   };
 }


### PR DESCRIPTION
## Goals

- Close the remaining stable logical-type compatibility gap for legacy Parquet `INT96` timestamps.
- Make TypeScript Arrow output faithful to the canonical Parquet representation on caller-thread and worker-backed source scans.
- Document the compatibility policy clearly while preserving the existing object-row behavior unless explicitly changed.

## Changes

- Decode canonical `INT96` values (Julian day plus nanoseconds of day) to signed epoch nanoseconds using `BigInt64Array`.
- Map `INT96` to Arrow `timestamp-nanosecond` in the TypeScript Arrow path, including nested schema traversal and raw vector construction.
- Decode canonical INT96 page-index statistics so timestamp predicates can participate in selective range planning.
- Propagate the `int96AsTimestamp` option through loader, source, column, JSON, and worker-reader paths.
- Keep legacy raw-number decoding available for object-row and compatibility callers via the explicit option.
- Add validation for invalid nanoseconds-of-day values and focused Vitest coverage for codec and schema behavior.
- Update Parquet format and API documentation and mark the core Arrow logical-parity tranche complete.

## Validation

- `yarn lint fix`
- `yarn test-headless modules/parquet/test/parquet-int96.spec.ts modules/parquet/test/parquet-source-loader.spec.ts`
- `yarn build`

This PR builds on the encryption, selective-scan, and conformance foundations already merged to `master`; it does not claim support for proposed ALP, PFOR, or VECTOR encodings.
