### PR TITLE
feat(las): validate LAS 1.5 header semantics

### DIFF
--- a/modules/las/src/lib/typescript/parse-las.ts
+++ b/modules/las/src/lib/typescript/parse-las.ts
@@ -1091,6 +1091,21 @@ export function parseLASHeader(arrayBuffer: ArrayBufferLike): LASHeader {
     if ((globalEncoding & 0x10) === 0) {
       throw new Error('LASLoader: LAS 1.5 requires the WKT global encoding flag');
     }
+    if ((globalEncoding & 0xffa0) !== 0) {
+      throw new Error('LASLoader: LAS 1.5 Global Encoding contains reserved bits');
+    }
+    if ((globalEncoding & 0x40) !== 0 && (globalEncoding & 0x01) === 0) {
+      throw new Error('LASLoader: LAS 1.5 Time Offset Flag requires GPS Time Type');
+    }
+    const maxGpsTime = dataView.getFloat64(375, true);
+    const minGpsTime = dataView.getFloat64(383, true);
+    if (
+      !Number.isFinite(maxGpsTime) ||
+      !Number.isFinite(minGpsTime) ||
+      (maxGpsTime !== 0 && minGpsTime !== 0 && maxGpsTime < minGpsTime)
+    ) {
+      throw new Error('LASLoader: LAS 1.5 GPS time range is invalid');
+    }
   }
   const scale: [number, number, number] = [
     dataView.getFloat64(131, true),

--- a/modules/las/test/las-streaming-conformance.node.slow.spec.ts
+++ b/modules/las/test/las-streaming-conformance.node.slow.spec.ts
@@ -101,6 +101,22 @@ describe('TypeScript LAZ streaming conformance', () => {
     const invalidHeader = source.slice(0, 375);
     new DataView(invalidHeader).setUint16(94, 375, true);
     expect(() => parseLASHeader(invalidHeader)).toThrow(/LAS 1.5 header must be at least 393/);
+
+    const invalidFlags = source.slice(0);
+    new DataView(invalidFlags).setUint16(6, 0x30, true);
+    expect(() => parseLASHeader(invalidFlags)).toThrow(/Global Encoding contains reserved bits/);
+
+    const invalidTimeFlags = source.slice(0);
+    new DataView(invalidTimeFlags).setUint16(6, 0x50, true);
+    expect(() => parseLASHeader(invalidTimeFlags)).toThrow(
+      /Time Offset Flag requires GPS Time Type/
+    );
+
+    const invalidTimeRange = source.slice(0);
+    const invalidTimeRangeView = new DataView(invalidTimeRange);
+    invalidTimeRangeView.setFloat64(375, 1, true);
+    invalidTimeRangeView.setFloat64(383, 2, true);
+    expect(() => parseLASHeader(invalidTimeRange)).toThrow(/GPS time range is invalid/);
   });
 
   test.each(


### PR DESCRIPTION
## Goals

- Tighten LAS 1.5 header conformance for the TypeScript LAS/LAZ reader.
- Reject invalid Global Encoding and GPS-time metadata before decoding points.

## Changes

- Validate reserved LAS 1.5 Global Encoding bits.
- Enforce that the Time Offset Flag is only used with GPS time.
- Validate finite and ordered LAS 1.5 Max/Min GPS Time values.
- Add regression coverage for each invalid-header case.

## Validation

- `yarn lint fix`
- `yarn test-slow modules/las/test/las-streaming-conformance.node.slow.spec.ts -t "LAS 1.5 exposes"`
- `yarn test-node`

The existing LAS 1.5 implementation landed in PR #3844; this PR contains only the follow-up semantic checks.
