### PR TITLE
test: migrate GLTF and textures suites to Vitest

### DIFF
--- a/modules/gltf/test/glb-loader.spec.ts
+++ b/modules/gltf/test/glb-loader.spec.ts
@@ -2,97 +2,70 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-/* eslint-disable max-len */
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {validateLoader} from 'test/common/conformance';
-
 import {load, parseSync, fetchFile} from '@loaders.gl/core';
 import {GLBLoader} from '@loaders.gl/gltf/bundled';
 import {createGLBV3} from './test-utils/create-glb-v3';
-
 const GLTF_BINARY_URL = '@loaders.gl/gltf/test/data/gltf-2.0/2CylinderEngine.glb';
 const GLB_V1_TILE_CESIUM_AIR_URL = '@loaders.gl/gltf/test/data/3d-tiles/Cesium_Air.glb';
-
-test('GLBLoader#loader conformance', t => {
-  validateLoader(t, GLBLoader, 'GLBLoader');
-  t.end();
+test('GLBLoader#loader conformance', () => {
+  validateLoader(GLBLoader, 'GLBLoader');
 });
-
-test('GLBLoader#parseSync(v2)', async t => {
+test('GLBLoader#parseSync(v2)', async () => {
   const response = await fetchFile(GLTF_BINARY_URL);
   const data = await response.arrayBuffer();
   const glbv2 = parseSync(data, GLBLoader);
-  t.equal(glbv2.version, 2, 'GLBLoader returned correct glb version');
-  t.equal(glbv2.json.asset.version, '2.0', 'GLBLoader returned correct gltf version');
-
-  t.end();
+  expect(glbv2.version, 'GLBLoader returned correct glb version').toBe(2);
+  expect(glbv2.json.asset.version, 'GLBLoader returned correct gltf version').toBe('2.0');
 });
-
-test('GLBLoader#load(v2)', async t => {
+test('GLBLoader#load(v2)', async () => {
   const glbv2 = await load(GLTF_BINARY_URL, GLBLoader);
-  t.equal(glbv2.version, 2, 'GLBLoader returned correct glb version');
-  t.equal(glbv2.json.asset.version, '2.0', 'GLBLoader returned correct gltf version');
-  t.end();
+  expect(glbv2.version, 'GLBLoader returned correct glb version').toBe(2);
+  expect(glbv2.json.asset.version, 'GLBLoader returned correct gltf version').toBe('2.0');
 });
-
-test('GLBLoader#load(v1)', async t => {
+test('GLBLoader#load(v1)', async () => {
   const glbv1 = await load(GLB_V1_TILE_CESIUM_AIR_URL, GLBLoader);
-  t.equal(glbv1.version, 1, 'GLBLoader returned correct glb version');
-  t.equal(glbv1.json.asset.version, '1.0', 'GLBLoader returned parsed data');
-  t.end();
+  expect(glbv1.version, 'GLBLoader returned correct glb version').toBe(1);
+  expect(glbv1.json.asset.version, 'GLBLoader returned parsed data').toBe('1.0');
 });
-
-test('GLBLoader#parseSync(v3)', t => {
+test('GLBLoader#parseSync(v3)', () => {
   const data = createGLBV3({asset: {version: '2.1'}}, [new Uint8Array([1, 2, 3, 4])]);
   const glbv3 = parseSync(data, GLBLoader);
-
-  t.equal(glbv3.version, 3, 'GLBLoader returned correct glb version');
-  t.equal(glbv3.header.byteLength, data.byteLength, 'GLBLoader read the 64-bit file length');
-  t.equal(glbv3.json.asset.version, '2.1', 'GLBLoader returned correct gltf version');
-  t.equal(glbv3.jsonChunkIndex, 0, 'GLBLoader records the JSON chunk index');
-  t.equal(glbv3.binChunks.length, 1, 'GLBLoader returned the BIN chunk');
-  t.equal(glbv3.binChunks[0].chunkIndex, 1, 'GLBLoader records the BIN chunk index');
-  t.equal(glbv3.binChunks[0].byteLength, 4, 'GLBLoader read the 64-bit chunk length');
-
-  t.end();
+  expect(glbv3.version, 'GLBLoader returned correct glb version').toBe(3);
+  expect(glbv3.header.byteLength, 'GLBLoader read the 64-bit file length').toBe(data.byteLength);
+  expect(glbv3.json.asset.version, 'GLBLoader returned correct gltf version').toBe('2.1');
+  expect(glbv3.jsonChunkIndex, 'GLBLoader records the JSON chunk index').toBe(0);
+  expect(glbv3.binChunks.length, 'GLBLoader returned the BIN chunk').toBe(1);
+  expect(glbv3.binChunks[0].chunkIndex, 'GLBLoader records the BIN chunk index').toBe(1);
+  expect(glbv3.binChunks[0].byteLength, 'GLBLoader read the 64-bit chunk length').toBe(4);
 });
-
-test('GLBLoader#parseSync(v3) preserves absolute chunk indices', t => {
+test('GLBLoader#parseSync(v3) preserves absolute chunk indices', () => {
   const data = createGLBV3(
     {asset: {version: '2.1'}},
     [new Uint8Array([1, 2, 3, 4]), new Uint8Array([5, 6, 7, 8])],
     [{type: 0x54534554, data: new Uint8Array([9, 10, 11, 12])}]
   );
   const glbv3 = parseSync(data, GLBLoader);
-
-  t.equal(glbv3.jsonChunkIndex, 1, 'finds the first JSON chunk after a custom chunk');
-  t.deepEqual(
+  expect(glbv3.jsonChunkIndex, 'finds the first JSON chunk after a custom chunk').toBe(1);
+  expect(
     glbv3.binChunks.map(chunk => chunk.chunkIndex),
-    [2, 3],
     'records BIN indices in the full chunk sequence'
-  );
-  t.end();
+  ).toEqual([2, 3]);
 });
-
-test('GLBLoader#parseSync(v3) rejects unsupported chunk encoding', t => {
+test('GLBLoader#parseSync(v3) rejects unsupported chunk encoding', () => {
   const data = createGLBV3({asset: {version: '2.1'}});
   const dataView = new DataView(data);
   dataView.setUint32(20, 1, true);
-
-  t.throws(() => parseSync(data, GLBLoader), /Unsupported GLB chunk encoding 1/);
-  t.end();
+  expect(() => parseSync(data, GLBLoader)).toThrow(/Unsupported GLB chunk encoding 1/);
 });
-
-test('GLBLoader#parseSync(v3) rejects unsafe 64-bit lengths', t => {
+test('GLBLoader#parseSync(v3) rejects unsafe 64-bit lengths', () => {
   const data = new ArrayBuffer(16);
   const dataView = new DataView(data);
   dataView.setUint32(0, 0x46546c67, true);
   dataView.setUint32(4, 3, true);
   dataView.setBigUint64(8, BigInt(Number.MAX_SAFE_INTEGER) + 1n, true);
-
-  t.throws(
-    () => parseSync(data, GLBLoader),
+  expect(() => parseSync(data, GLBLoader)).toThrow(
     /GLB byte length exceeds JavaScript's safe integer range/
   );
-  t.end();
 });

--- a/modules/gltf/test/glb-writer.spec.ts
+++ b/modules/gltf/test/glb-writer.spec.ts
@@ -2,19 +2,14 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import tapeTest from 'test/utils/vitest-tape';
 import {validateWriter} from 'test/common/conformance';
 import {describe, expect, test} from 'vitest';
-
 import {GLBWriter} from '@loaders.gl/gltf';
 import {parseSync} from '@loaders.gl/core';
 import {GLBLoader} from '@loaders.gl/gltf/bundled';
-
-tapeTest('GLBWriter#loader conformance', t => {
-  validateWriter(t, GLBWriter, 'GLBWriter');
-  t.end();
+test('GLBWriter#loader conformance', () => {
+  validateWriter(GLBWriter, 'GLBWriter');
 });
-
 describe('GLBWriter', () => {
   test('encodeSync(v3) round trips multiple binary chunks', () => {
     const glb = {
@@ -44,7 +39,6 @@ describe('GLBWriter', () => {
         }
       ]
     };
-
     const encoded = GLBWriter.encodeSync(glb);
     const decoded = parseSync(encoded, GLBLoader);
     expect(decoded.version).toBe(3);
@@ -58,7 +52,6 @@ describe('GLBWriter', () => {
       [5, 6, 7, 8]
     ]);
   });
-
   test('encodeSync(v2) remains the default', () => {
     const glb = {
       type: 'glTF',
@@ -74,7 +67,6 @@ describe('GLBWriter', () => {
     const decoded = parseSync(encoded, GLBLoader);
     expect(decoded.version).toBe(2);
   });
-
   test('encodeSync(v3) rejects unsupported chunk encodings', () => {
     const glb = {
       type: 'glTF',

--- a/modules/gltf/test/gltf-loader.spec.ts
+++ b/modules/gltf/test/gltf-loader.spec.ts
@@ -2,49 +2,38 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-/* eslint-disable max-len */
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {validateLoader} from 'test/common/conformance';
-
 import {registerLoaders, load, parse, parseSync, fetchFile} from '@loaders.gl/core';
 import {GLTFLoader, postProcessGLTF, type GLTFLoaderOptions} from '@loaders.gl/gltf';
 import {DracoLoader} from '@loaders.gl/draco';
 import {ImageBitmapLoader} from '@loaders.gl/images';
 import {getGLTFImageOptions} from '../src/lib/parsers/parse-gltf';
 import {createGLBV3} from './test-utils/create-glb-v3';
-
 const GLTF_BINARY_URL = '@loaders.gl/gltf/test/data/gltf-2.0/2CylinderEngine.glb';
 const GLTF_JSON_URL = '@loaders.gl/gltf/test/data/gltf-2.0/2CylinderEngine.gltf';
 const PNG_DATA_URL =
   'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACAQMAAABIeJ9nAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAGUExURf///wAAAFXC034AAAAMSURBVAjXY3BgaAAAAUQAwetZAwkAAAAASUVORK5CYII=';
-
 // Extracted from Cesium 3D Tiles
 const GLB_TILE_WITH_DRACO_URL = '@loaders.gl/gltf/test/data/3d-tiles/143.glb';
 const GLB_V1_TILE_CESIUM_AIR_URL = '@loaders.gl/gltf/test/data/3d-tiles/Cesium_Air.glb';
 const GLB_TILE_URL = '@loaders.gl/gltf/test/data/3d-tiles/tile.glb';
-
-test('GLTFLoader#loader conformance', t => {
-  validateLoader(t, GLTFLoader, 'GLTFLoader');
-  t.end();
+test('GLTFLoader#loader conformance', () => {
+  validateLoader(GLTFLoader, 'GLTFLoader');
 });
-
-test('GLTFLoader#parseSync()', async t => {
+test('GLTFLoader#parseSync()', async () => {
   const response = await fetchFile(GLTF_JSON_URL);
   const data = await response.text();
-
-  t.throws(() => parseSync(data, GLTFLoader), 'GLTFLoader throws when synchronously parsing gltfs');
-
-  t.end();
+  expect(
+    () => parseSync(data, GLTFLoader),
+    'GLTFLoader throws when synchronously parsing gltfs'
+  ).toThrow();
 });
-
-test('GLTFLoader#load(binary)', async t => {
+test('GLTFLoader#load(binary)', async () => {
   const data = await load(GLTF_BINARY_URL, GLTFLoader);
-  t.ok(data.json.asset, 'GLTFLoader returned parsed data');
-
-  t.end();
+  expect(data.json.asset, 'GLTFLoader returned parsed data').toBeTruthy();
 });
-
-test('GLTFLoader#parse() loads a draft glTF 2.1 thumbnail image', async t => {
+test('GLTFLoader#parse() loads a draft glTF 2.1 thumbnail image', async () => {
   const gltf = await parse(
     JSON.stringify({
       asset: {version: '2.1', thumbnail: 0},
@@ -52,12 +41,9 @@ test('GLTFLoader#parse() loads a draft glTF 2.1 thumbnail image', async t => {
     }),
     GLTFLoader
   );
-
-  t.ok(gltf.images?.[0], 'loads an image referenced only by asset.thumbnail');
-  t.end();
+  expect(gltf.images?.[0], 'loads an image referenced only by asset.thumbnail').toBeTruthy();
 });
-
-test('GLTFLoader#parse(v3) resolves explicit buffer chunk indices', async t => {
+test('GLTFLoader#parse(v3) resolves explicit buffer chunk indices', async () => {
   const data = createGLBV3(
     {
       asset: {version: '2.1'},
@@ -69,7 +55,6 @@ test('GLTFLoader#parse(v3) resolves explicit buffer chunk indices', async t => {
     [new Uint8Array([1, 2, 3, 4]), new Uint8Array([5, 6, 7, 8])],
     [{type: 0x54534554, data: new Uint8Array([9, 10, 11, 12])}]
   );
-
   const gltf = await parse(data, GLTFLoader, {gltf: {loadBuffers: true, loadImages: false}});
   const firstBuffer = new Uint8Array(
     gltf.buffers[0].arrayBuffer,
@@ -81,13 +66,10 @@ test('GLTFLoader#parse(v3) resolves explicit buffer chunk indices', async t => {
     gltf.buffers[1].byteOffset,
     gltf.buffers[1].byteLength
   );
-
-  t.deepEqual(Array.from(firstBuffer), [5, 6, 7, 8], 'resolves buffer 0 from chunk 3');
-  t.deepEqual(Array.from(secondBuffer), [1, 2, 3, 4], 'resolves buffer 1 from chunk 2');
-  t.end();
+  expect(Array.from(firstBuffer), 'resolves buffer 0 from chunk 3').toEqual([5, 6, 7, 8]);
+  expect(Array.from(secondBuffer), 'resolves buffer 1 from chunk 2').toEqual([1, 2, 3, 4]);
 });
-
-test('GLTFLoader#parse(v3) preserves legacy implicit buffer mapping', async t => {
+test('GLTFLoader#parse(v3) preserves legacy implicit buffer mapping', async () => {
   const data = createGLBV3({asset: {version: '2.1'}, buffers: [{byteLength: 4}]}, [
     new Uint8Array([1, 2, 3, 4])
   ]);
@@ -97,41 +79,30 @@ test('GLTFLoader#parse(v3) preserves legacy implicit buffer mapping', async t =>
     gltf.buffers[0].byteOffset,
     gltf.buffers[0].byteLength
   );
-
-  t.deepEqual(Array.from(buffer), [1, 2, 3, 4], 'maps the classic JSON-then-BIN layout');
-  t.end();
+  expect(Array.from(buffer), 'maps the classic JSON-then-BIN layout').toEqual([1, 2, 3, 4]);
 });
-
-test('GLTFLoader#parse(v3) rejects implicit buffers outside the legacy layout', async t => {
+test('GLTFLoader#parse(v3) rejects implicit buffers outside the legacy layout', async () => {
   const data = createGLBV3(
     {asset: {version: '2.1'}, buffers: [{byteLength: 4}]},
     [new Uint8Array([1, 2, 3, 4])],
     [{type: 0x54534554, data: new Uint8Array([9, 10, 11, 12])}]
   );
-
-  await t.rejects(
+  await expect(
     parse(data, GLTFLoader, {gltf: {loadBuffers: true, loadImages: false}}),
-    /buffer 0 without a uri must define a valid GLB v3 chunk/,
     'does not replace an unresolved buffer with zero-filled bytes'
-  );
-  t.end();
+  ).rejects.toThrow(/buffer 0 without a uri must define a valid GLB v3 chunk/);
 });
-
-test('GLTFLoader#parse(v3) rejects missing buffer chunks', async t => {
+test('GLTFLoader#parse(v3) rejects missing buffer chunks', async () => {
   const data = createGLBV3({
     asset: {version: '2.1'},
     buffers: [{byteLength: 4, chunk: 2}]
   });
-
-  await t.rejects(
+  await expect(
     parse(data, GLTFLoader, {gltf: {loadBuffers: true, loadImages: false}}),
-    /buffer 0 references missing GLB BIN chunk 2/,
     'rejects a chunk index that does not select a BIN chunk'
-  );
-  t.end();
+  ).rejects.toThrow(/buffer 0 references missing GLB BIN chunk 2/);
 });
-
-test('GLTFLoader#parse(v3) loads embedded glTF 2.1 files', async t => {
+test('GLTFLoader#parse(v3) loads embedded glTF 2.1 files', async () => {
   const data = createGLBV3(
     {
       asset: {version: '2.1'},
@@ -145,39 +116,28 @@ test('GLTFLoader#parse(v3) loads embedded glTF 2.1 files', async t => {
     gltf: {loadBuffers: true, loadFiles: true, loadImages: false}
   });
   const file = gltf.files?.[0];
-  t.ok(file, 'returns a parallel resolved file entry');
+  expect(file, 'returns a parallel resolved file entry').toBeTruthy();
   if (!file) {
-    t.end();
     return;
   }
-
-  t.equal(file.name, 'nested.glb', 'preserves the virtual package name');
-  t.deepEqual(
+  expect(file.name, 'preserves the virtual package name').toBe('nested.glb');
+  expect(
     Array.from(new Uint8Array(file.arrayBuffer, file.byteOffset, file.byteLength)),
-    [1, 2, 3, 4],
     'loads file bytes from its buffer view'
-  );
-  t.end();
+  ).toEqual([1, 2, 3, 4]);
 });
-
-test('GLTFLoader#load(binary)', async t => {
+test('GLTFLoader#load(binary)', async () => {
   const data = await load(GLTF_BINARY_URL, GLTFLoader);
-  t.ok(data.buffers, 'GLTFLoader without post-processing returned data.buffers');
-  t.ok(data.images, 'GLTFLoader without post-processing returned data.images');
-  t.ok(data.json, 'GLTFLoader without post-processing returned data.json');
-
-  t.ok((data as any)._glb, 'GLTFLoader without post-processing returned data._glb');
-
-  t.end();
+  expect(data.buffers, 'GLTFLoader without post-processing returned data.buffers').toBeTruthy();
+  expect(data.images, 'GLTFLoader without post-processing returned data.images').toBeTruthy();
+  expect(data.json, 'GLTFLoader without post-processing returned data.json').toBeTruthy();
+  expect((data as any)._glb, 'GLTFLoader without post-processing returned data._glb').toBeTruthy();
 });
-
-test('GLTFLoader#load(text)', async t => {
+test('GLTFLoader#load(text)', async () => {
   const data = await load(GLTF_JSON_URL, GLTFLoader, {gltf: {loadImages: false}});
-  t.ok(data.json.asset, 'GLTFLoader returned parsed data');
-  t.end();
+  expect(data.json.asset, 'GLTFLoader returned parsed data').toBeTruthy();
 });
-
-test('GLTFLoader#Basis image options', t => {
+test('GLTFLoader#Basis image options', () => {
   const loaderOptions: GLTFLoaderOptions = {
     core: {worker: true},
     basis: {
@@ -185,77 +145,53 @@ test('GLTFLoader#Basis image options', t => {
       containerFormat: 'ktx2'
     }
   };
-
   const imageOptions = getGLTFImageOptions(loaderOptions, 'image/ktx2');
-
-  t.deepEqual(
+  expect(
     imageOptions.basis,
-    {
-      supportedTextureFormats: ['bc3-rgba-unorm'],
-      containerFormat: 'ktx2',
-      format: 'auto'
-    },
     'preserves automatic selection until the worker can inspect the source codec'
-  );
-  t.equal(imageOptions.core?.worker, true, 'preserves core options');
-  t.equal(imageOptions.core?.mimeType, 'image/ktx2', 'sets the image MIME type');
-  t.notOk(loaderOptions.basis?.format, 'does not mutate the supplied options');
-
+  ).toEqual({
+    supportedTextureFormats: ['bc3-rgba-unorm'],
+    containerFormat: 'ktx2',
+    format: 'auto'
+  });
+  expect(imageOptions.core?.worker, 'preserves core options').toBe(true);
+  expect(imageOptions.core?.mimeType, 'sets the image MIME type').toBe('image/ktx2');
+  expect(loaderOptions.basis?.format, 'does not mutate the supplied options').toBeFalsy();
   const explicitFormatOptions = getGLTFImageOptions({
     basis: {
       format: 'rgba32'
     }
   });
-
-  t.deepEqual(
-    explicitFormatOptions.basis,
-    {
-      format: 'rgba32'
-    },
-    'preserves an explicit Basis format'
-  );
-  t.end();
+  expect(explicitFormatOptions.basis, 'preserves an explicit Basis format').toEqual({
+    format: 'rgba32'
+  });
 });
-
-test('GLTFLoader#load(3d tile GLB)', async t => {
+test('GLTFLoader#load(3d tile GLB)', async () => {
   const result = await load(GLB_TILE_URL, [GLTFLoader, DracoLoader]);
-  t.ok(result, 'Test that GLB from 3D tile parses');
-
+  expect(result, 'Test that GLB from 3D tile parses').toBeTruthy();
   const result2 = await load(GLB_TILE_WITH_DRACO_URL, [GLTFLoader, DracoLoader, ImageBitmapLoader]);
-  t.ok(result2, 'Parses Draco GLB with supplied DracoLoader');
-
+  expect(result2, 'Parses Draco GLB with supplied DracoLoader').toBeTruthy();
   // TODO - prone to flakiness since we have async unregisterLoaders calls
   registerLoaders([DracoLoader, ImageBitmapLoader]);
-
   const gltf2 = await load(GLB_TILE_WITH_DRACO_URL, GLTFLoader);
-  t.ok(gltf2, 'Parses Draco GLB with default registered DracoLoader');
-
-  t.end();
+  expect(gltf2, 'Parses Draco GLB with default registered DracoLoader').toBeTruthy();
 });
-
-test('GLTFLoader#load(glTF v1)', async t => {
-  await t.rejects(
+test('GLTFLoader#load(glTF v1)', async () => {
+  await expect(
     load(GLB_V1_TILE_CESIUM_AIR_URL, GLTFLoader, {gltf: {normalize: false}}),
-    /glTF v1 is not supported/,
     'glTF v1 generates error message'
-  );
-
+  ).rejects.toThrow(/glTF v1 is not supported/);
   const gltf1 = await load(GLB_V1_TILE_CESIUM_AIR_URL, GLTFLoader, {gltf: {normalize: true}});
-  t.ok(gltf1, 'glTF v1 was normalized without errors');
-
-  t.end();
+  expect(gltf1, 'glTF v1 was normalized without errors').toBeTruthy();
 });
-
 // Check load options
-
-test('GLTFLoader#options+postProcessGLTF', async t => {
+test('GLTFLoader#options+postProcessGLTF', async () => {
   const gltfWithBuffers = await load(GLTF_BINARY_URL, GLTFLoader);
   const data = postProcessGLTF(gltfWithBuffers);
   const value = data.meshes[0].primitives[0].attributes.POSITION.value;
-  t.ok(
+  expect(
     ArrayBuffer.isView(value),
     'GLTFLoader+postProcessGLTF() resolves accessor value as typed array'
-  );
-  t.equal(value.length, 6036, 'GLTFLoader+postProcessGLTF() resolves accessor value length');
-  t.end();
+  ).toBeTruthy();
+  expect(value.length, 'GLTFLoader+postProcessGLTF() resolves accessor value length').toBe(6036);
 });

--- a/modules/gltf/test/gltf-writer.spec.ts
+++ b/modules/gltf/test/gltf-writer.spec.ts
@@ -2,17 +2,12 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-/* eslint-disable camelcase */
-/* eslint-disable max-len */
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {validateWriter} from 'test/common/conformance';
-
 import {parse, encodeSync, encode, load} from '@loaders.gl/core';
 import {GLTFLoader, GLTFWriter, GLTFScenegraph, postProcessGLTF} from '@loaders.gl/gltf';
 import {ImageWriter} from '@loaders.gl/images';
-
 const GLTF_BINARY_URL = '@loaders.gl/gltf/test/data/3d-tiles/143.glb';
-
 const EXTRA_DATA = {extraData: 1};
 const APP_DATA = {vizData: 2};
 const EXTENSION_DATA_1 = {extData: 3};
@@ -21,46 +16,33 @@ const REQUIRED_EXTENSION_1 = 'UBER_extension_1';
 const REQUIRED_EXTENSION_2 = 'UBER_extension_2';
 const USED_EXTENSION_1 = 'UBER_extension_3';
 const USED_EXTENSION_2 = 'UBER_extension_4';
-
-test('GLTFWriter#loader conformance', t => {
-  validateWriter(t, GLTFWriter, 'GLTFWriter');
-  t.end();
+test('GLTFWriter#loader conformance', () => {
+  validateWriter(GLTFWriter, 'GLTFWriter');
 });
-
-test('GLTFWriter#encode', async t => {
+test('GLTFWriter#encode', async () => {
   const gltfBuilder = new GLTFScenegraph();
   gltfBuilder.addApplicationData('viz', APP_DATA);
   gltfBuilder.addExtraData('test', EXTRA_DATA);
-
   gltfBuilder.registerUsedExtension(USED_EXTENSION_1);
   gltfBuilder.registerRequiredExtension(REQUIRED_EXTENSION_1);
   gltfBuilder.addExtension(USED_EXTENSION_2, EXTENSION_DATA_1);
   gltfBuilder.addRequiredExtension(REQUIRED_EXTENSION_2, EXTENSION_DATA_2);
-
   const arrayBuffer = encodeSync(gltfBuilder.gltf, GLTFWriter);
-
   const gltf = await parse(arrayBuffer, GLTFLoader);
   const gltfScenegraph = new GLTFScenegraph(gltf);
-
   const appData = gltfScenegraph.getApplicationData('viz');
   const extraData = gltfScenegraph.getExtraData('test');
-
-  t.ok(appData, 'usedExtensions was found');
-  t.ok(extraData, 'extraData was found');
-
+  expect(appData, 'usedExtensions was found').toBeTruthy();
+  expect(extraData, 'extraData was found').toBeTruthy();
   const usedExtensions = gltfScenegraph.getUsedExtensions();
   const requiredExtensions = gltfScenegraph.getRequiredExtensions();
   const extension1 = gltfScenegraph.getExtension(USED_EXTENSION_2);
   const extension2 = gltfScenegraph.getExtension(REQUIRED_EXTENSION_2);
-
-  t.ok(usedExtensions, 'usedExtensions was found');
-  t.ok(requiredExtensions, 'requiredExtensions was found');
-  t.ok(extension1, 'extension1 was found');
-  t.ok(extension2, 'extension2 was found');
-
-  t.end();
+  expect(usedExtensions, 'usedExtensions was found').toBeTruthy();
+  expect(requiredExtensions, 'requiredExtensions was found').toBeTruthy();
+  expect(extension1, 'extension1 was found').toBeTruthy();
+  expect(extension2, 'extension2 was found').toBeTruthy();
 });
-
 const gltfWithExtension = {
   json: {
     asset: {version: '1'},
@@ -87,7 +69,6 @@ const gltfWithExtension = {
     ]
   }
 };
-
 const gltfJsonWithExtensionEncodedExpected = {
   asset: {
     version: '1'
@@ -138,7 +119,6 @@ const gltfJsonWithExtensionEncodedExpected = {
     }
   ]
 };
-
 const arrayBufferExpected = new Uint8Array([
   103, 108, 84, 70, 2, 0, 0, 0, 200, 1, 0, 0, 144, 1, 0, 0, 74, 83, 79, 78, 123, 34, 97, 115, 115,
   101, 116, 34, 58, 123, 34, 118, 101, 114, 115, 105, 111, 110, 34, 58, 34, 49, 34, 125, 44, 34,
@@ -162,21 +142,16 @@ const arrayBufferExpected = new Uint8Array([
   116, 104, 34, 58, 50, 56, 125, 93, 125, 32, 32, 28, 0, 0, 0, 66, 73, 78, 0, 4, 0, 0, 0, 4, 0, 0,
   0, 4, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0
 ]).buffer;
-
-test('GLTFWriter#encode with extensions', async t => {
+test('GLTFWriter#encode with extensions', async () => {
   const gltfBuilder = new GLTFScenegraph(gltfWithExtension);
   const arrayBuffer = encodeSync(gltfBuilder.gltf, GLTFWriter);
-  t.deepEqual(gltfBuilder.gltf.json, gltfJsonWithExtensionEncodedExpected);
-  t.deepEqual(arrayBuffer, arrayBufferExpected);
-
-  t.end();
+  expect(gltfBuilder.gltf.json).toEqual(gltfJsonWithExtensionEncodedExpected);
+  expect(arrayBuffer).toEqual(arrayBufferExpected);
 });
-
-test('GLTFWriter#Should build a GLTF object with GLTFScenegraph builder functions', async t => {
+test('GLTFWriter#Should build a GLTF object with GLTFScenegraph builder functions', async () => {
   const gltfWithBuffers = await load(GLTF_BINARY_URL, GLTFLoader);
   const inputData = postProcessGLTF(gltfWithBuffers);
   const gltfBuilder = new GLTFScenegraph();
-
   const meshIndex = gltfBuilder.addMesh({attributes: inputData.meshes[0].primitives[0].attributes});
   const nodeIndex = gltfBuilder.addNode({meshIndex});
   const sceneIndex = gltfBuilder.addScene({nodeIndices: [nodeIndex]});
@@ -194,69 +169,48 @@ test('GLTFWriter#Should build a GLTF object with GLTFScenegraph builder function
     };
     gltfBuilder.addMaterial(pbrMaterialInfo);
   }
-
   gltfBuilder.createBinaryChunk();
-
-  checkJson(t, gltfBuilder);
-
+  checkJson(gltfBuilder);
   const gltfBuffer = encodeSync(gltfBuilder.gltf, GLTFWriter);
-
   const gltf = await parse(gltfBuffer, GLTFLoader);
-
-  checkJson(t, new GLTFScenegraph(gltf));
-  t.end();
+  checkJson(new GLTFScenegraph(gltf));
 });
-
-test('GLTFWriter#should write extra data to binary chunk', async t => {
+test('GLTFWriter#should write extra data to binary chunk', async () => {
   const gltfWithBuffers1 = await load(GLTF_BINARY_URL, GLTFLoader);
   const inputData = postProcessGLTF(gltfWithBuffers1);
-
   const gltfWithBuffers2 = await load(GLTF_BINARY_URL, GLTFLoader, {
     gltf: {decompressMeshes: false}
   });
   const gltfScenegraph = new GLTFScenegraph(gltfWithBuffers2);
-
   const meshIndex = gltfScenegraph.addMesh({
     attributes: inputData.meshes[0].primitives[0].attributes
   });
-
-  t.equal(meshIndex, 1);
-
+  expect(meshIndex).toBe(1);
   gltfScenegraph.createBinaryChunk();
-
-  t.ok(gltfScenegraph.gltf.json.meshes?.[0].primitives[0]);
-  t.equal(
+  expect(gltfScenegraph.gltf.json.meshes?.[0].primitives[0]).toBeTruthy();
+  expect(
     gltfScenegraph.gltf.json.meshes?.[0].primitives[0].attributes.POSITION,
-    1,
     'Input data should not be parsed'
-  );
-
+  ).toBe(1);
   // Encode to buffer
   const gltfBuffer = encodeSync(gltfScenegraph.gltf, GLTFWriter);
-
   // Now parse the generated buffer
   const gltfWithBuffers3 = await parse(gltfBuffer, GLTFLoader);
   const gltf = postProcessGLTF(gltfWithBuffers3);
-
-  t.ok(gltf);
-  t.ok(gltf.meshes[1]);
-  t.equal(
-    gltf.meshes[1].primitives[0].attributes.POSITION.value.byteLength,
+  expect(gltf).toBeTruthy();
+  expect(gltf.meshes[1]).toBeTruthy();
+  expect(gltf.meshes[1].primitives[0].attributes.POSITION.value.byteLength).toBe(
     inputData.meshes[0].primitives[0].attributes.POSITION.value.byteLength
   );
-  t.ok(gltf.meshes[0]);
-  t.end();
+  expect(gltf.meshes[0]).toBeTruthy();
 });
-
-test('GLTFWriter#should write extra data to binary chunk twice', async t => {
+test('GLTFWriter#should write extra data to binary chunk twice', async () => {
   const gltfWithBuffers = await load(GLTF_BINARY_URL, GLTFLoader);
   const inputData = postProcessGLTF(gltfWithBuffers);
-
   const data = await load(GLTF_BINARY_URL, GLTFLoader, {
     gltf: {decompressMeshes: false}
   });
   const gltfScenegraph = new GLTFScenegraph(data);
-
   gltfScenegraph.addMesh({
     attributes: {positions: inputData.meshes[0].primitives[0].attributes.POSITION}
   });
@@ -264,42 +218,30 @@ test('GLTFWriter#should write extra data to binary chunk twice', async t => {
   const imageBuffer = await encode(inputData.images?.[0]?.image, ImageWriter);
   gltfScenegraph.addImage(imageBuffer, 'image/jpeg');
   gltfScenegraph.createBinaryChunk();
-  t.ok(gltfScenegraph);
-
+  expect(gltfScenegraph).toBeTruthy();
   const gltfBuffer = encodeSync(gltfScenegraph.gltf, GLTFWriter);
-
   const gltfWithBuffers2 = await parse(gltfBuffer, GLTFLoader);
   const gltf = postProcessGLTF(gltfWithBuffers2);
-
-  t.ok(gltf);
-  t.ok(gltf.meshes[1]);
-  t.equal(
-    gltf.meshes[1].primitives[0].attributes.POSITION.value.byteLength,
+  expect(gltf).toBeTruthy();
+  expect(gltf.meshes[1]).toBeTruthy();
+  expect(gltf.meshes[1].primitives[0].attributes.POSITION.value.byteLength).toBe(
     inputData.meshes[0].primitives[0].attributes.POSITION.value.byteLength
   );
-
-  t.ok(gltf.images[2]);
-  t.end();
+  expect(gltf.images[2]).toBeTruthy();
 });
-
-function checkJson(t, gltfBuilder) {
-  t.ok(gltfBuilder);
-  t.ok(gltfBuilder.json);
-  t.ok(gltfBuilder.json.accessors);
-  t.equal(gltfBuilder.json.accessors.length, 2);
-
-  t.ok(gltfBuilder.json.buffers[0]);
-
-  t.equal(gltfBuilder.json.buffers[0].byteLength, 383372);
-
-  t.ok(gltfBuilder.json.bufferViews);
-  t.equal(gltfBuilder.json.bufferViews.length, 3);
-
-  t.ok(gltfBuilder.json.images[0]);
-  t.deepEqual(gltfBuilder.json.images[0], {bufferView: 2, mimeType: 'image/jpeg'});
-
-  t.ok(gltfBuilder.json.meshes);
-  t.deepEqual(gltfBuilder.json.meshes[0], {
+function checkJson(gltfBuilder) {
+  expect(gltfBuilder).toBeTruthy();
+  expect(gltfBuilder.json).toBeTruthy();
+  expect(gltfBuilder.json.accessors).toBeTruthy();
+  expect(gltfBuilder.json.accessors.length).toBe(2);
+  expect(gltfBuilder.json.buffers[0]).toBeTruthy();
+  expect(gltfBuilder.json.buffers[0].byteLength).toBe(383372);
+  expect(gltfBuilder.json.bufferViews).toBeTruthy();
+  expect(gltfBuilder.json.bufferViews.length).toBe(3);
+  expect(gltfBuilder.json.images[0]).toBeTruthy();
+  expect(gltfBuilder.json.images[0]).toEqual({bufferView: 2, mimeType: 'image/jpeg'});
+  expect(gltfBuilder.json.meshes).toBeTruthy();
+  expect(gltfBuilder.json.meshes[0]).toEqual({
     primitives: [{attributes: {POSITION: 0, TEXCOORD_0: 1}, mode: 4}]
   });
 }

--- a/modules/gltf/test/lib/api/gltf-scenegraph-accessors.spec.ts
+++ b/modules/gltf/test/lib/api/gltf-scenegraph-accessors.spec.ts
@@ -2,83 +2,60 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-/* eslint-disable max-len */
-import test from 'test/utils/vitest-tape';
-
+import {expect, test} from 'vitest';
 import {GLTFScenegraph, GLTFLoader} from '@loaders.gl/gltf';
 import {load} from '@loaders.gl/core';
-
 // Extracted from Cesium 3D Tiles
 const GLB_TILE_WITH_DRACO_URL = '@loaders.gl/gltf/test/data/3d-tiles/143.glb';
-
 const GLB_MESHOPT_GEOMETRY_URL = '@loaders.gl/gltf/test/data/meshopt/pirate.glb';
 const GLB_KTX2_GEOMETRY_URL = '@loaders.gl/3d-tiles/test/data/CesiumJS/VNext/agi-ktx2/0/0.glb';
-
-test('GLTFScenegraph#ctor', t => {
+test('GLTFScenegraph#ctor', () => {
   const gltfScenegraph = new GLTFScenegraph();
-  t.ok(gltfScenegraph);
-  t.end();
+  expect(gltfScenegraph).toBeTruthy();
 });
-
-test('GLTFScenegraph#should detect meshopt content', async t => {
+test('GLTFScenegraph#should detect meshopt content', async () => {
   const gltf = await load(GLB_MESHOPT_GEOMETRY_URL, GLTFLoader, {
     gltf: {decompressMeshes: true}
   });
   const gltfScenegraph = new GLTFScenegraph(gltf);
-  t.ok(gltfScenegraph);
-  t.deepEquals(
-    gltfScenegraph.getRemovedExtensions(),
-    ['EXT_meshopt_compression'],
-    'removedExtions === meshopt'
-  );
-  t.deepEquals(
-    gltfScenegraph.getUsedExtensions(),
-    ['KHR_mesh_quantization'],
-    'usedExtensions no longer contain meshopt'
-  );
-  t.end();
+  expect(gltfScenegraph).toBeTruthy();
+  expect(gltfScenegraph.getRemovedExtensions(), 'removedExtions === meshopt').toEqual([
+    'EXT_meshopt_compression'
+  ]);
+  expect(gltfScenegraph.getUsedExtensions(), 'usedExtensions no longer contain meshopt').toEqual([
+    'KHR_mesh_quantization'
+  ]);
 });
-
-test('GLTFScenegraph#should detect meshopt and ktx2 content', async t => {
+test('GLTFScenegraph#should detect meshopt and ktx2 content', async () => {
   const gltf = await load(GLB_KTX2_GEOMETRY_URL, GLTFLoader, {
     gltf: {decompressMeshes: false}
   });
   const gltfScenegraph = new GLTFScenegraph(gltf);
-  t.ok(gltfScenegraph);
-  t.deepEquals(gltfScenegraph.getRemovedExtensions(), [
+  expect(gltfScenegraph).toBeTruthy();
+  expect(gltfScenegraph.getRemovedExtensions()).toEqual([
     'KHR_texture_basisu',
     'KHR_materials_unlit'
   ]);
-  t.deepEquals(gltfScenegraph.gltf.json.extensionsUsed, []);
-  t.end();
+  expect(gltfScenegraph.gltf.json.extensionsUsed).toEqual([]);
 });
-
-test('GLTFScenegraph#BufferView indices resolve correctly', async t => {
+test('GLTFScenegraph#BufferView indices resolve correctly', async () => {
   const gltf = await load(GLB_TILE_WITH_DRACO_URL, GLTFLoader, {
     gltf: {decompressMeshes: true}
   });
-
   const gltfScenegraph = new GLTFScenegraph(gltf);
-
-  t.deepEquals(gltfScenegraph.getRemovedExtensions(), [
+  expect(gltfScenegraph.getRemovedExtensions()).toEqual([
     'KHR_draco_mesh_compression',
     'KHR_materials_unlit'
   ]);
-  t.deepEquals(gltfScenegraph.gltf.json.extensionsUsed, []);
-
+  expect(gltfScenegraph.gltf.json.extensionsUsed).toEqual([]);
   // @ts-expect-error
-  t.equals(gltfScenegraph.json.bufferViews.length, 4, 'gltf bufferView count as expected');
-
-  t.equals(
+  expect(gltfScenegraph.json.bufferViews.length, 'gltf bufferView count as expected').toBe(4);
+  expect(
     gltfScenegraph.getTypedArrayForBufferView(0).byteOffset,
-    2868,
     'first bufferView offset correct'
-  );
-  t.equals(
+  ).toBe(2868);
+  expect(
     gltfScenegraph.getTypedArrayForBufferView(1).byteOffset,
-    70432,
     'second bufferView offset correct'
-  );
-
-  t.end();
+  ).toBe(70432);
 });

--- a/modules/gltf/test/lib/api/gltf-scenegraph-modifiers.spec.ts
+++ b/modules/gltf/test/lib/api/gltf-scenegraph-modifiers.spec.ts
@@ -2,54 +2,39 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-/* eslint-disable max-len */
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {load} from '@loaders.gl/core';
-
 import {GLTFLoader, GLTFScenegraph, postProcessGLTF} from '@loaders.gl/gltf';
-
 const GLTF_BINARY_URL = '@loaders.gl/gltf/test/data/3d-tiles/143.glb';
-
 // biome-ignore format: preserve intentional fixture layout
 const PNG1x1 = new Uint8Array([
-  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00,
-  0x0d, 0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
-  0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89,
-  0x00, 0x00, 0x00, 0x0a, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x63,
-  0x00, 0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0a
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00,
+    0x0d, 0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
+    0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89,
+    0x00, 0x00, 0x00, 0x0a, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x63,
+    0x00, 0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0a
 ]);
-
-test('GLTFScenegraph#ctor', t => {
+test('GLTFScenegraph#ctor', () => {
   const gltfScenegraph = new GLTFScenegraph();
-  t.ok(gltfScenegraph);
-  t.end();
+  expect(gltfScenegraph).toBeTruthy();
 });
-
-test('GLTFScenegraph#addImage', t => {
+test('GLTFScenegraph#addImage', () => {
   // Smallest valid png
   const gltfScenegraph = new GLTFScenegraph();
-
   // t.throws(() => gltfScenegraph.addImage(PNG1x1), 'addImage() throws if no MIMEType');
-
   const imageIndex = gltfScenegraph.addImage(PNG1x1);
-  t.equal(imageIndex, 0, 'Image index should be 0');
-
+  expect(imageIndex, 'Image index should be 0').toBe(0);
   // t.equals(gltfScenegraph.json.buffers.length, 1, 'gltf buffer added as expected');
-  t.equals(gltfScenegraph.json.bufferViews?.length, 1, 'gltf bufferView added as expected');
-  t.equals(gltfScenegraph.json.images?.length, 1, 'gltf image set as expected');
-
+  expect(gltfScenegraph.json.bufferViews?.length, 'gltf bufferView added as expected').toBe(1);
+  expect(gltfScenegraph.json.images?.length, 'gltf image set as expected').toBe(1);
   // @ts-expect-error
   const {bufferView, mimeType} = gltfScenegraph.json.images[0];
-  t.equal(bufferView, 0, 'bufferView index is 0');
-  t.equal(mimeType, 'image/png', 'mimeType is png');
-
-  t.end();
+  expect(bufferView, 'bufferView index is 0').toBe(0);
+  expect(mimeType, 'mimeType is png').toBe('image/png');
 });
-
-test('GLTFScenegraph#Should be able to write custom attribute', async t => {
+test('GLTFScenegraph#Should be able to write custom attribute', async () => {
   const gltfWithBuffers = await load(GLTF_BINARY_URL, GLTFLoader);
   const inputData = postProcessGLTF(gltfWithBuffers);
-
   const gltfBuilder = new GLTFScenegraph();
   gltfBuilder.addMesh({
     attributes: {
@@ -57,45 +42,33 @@ test('GLTFScenegraph#Should be able to write custom attribute', async t => {
       _BATCHID: inputData.meshes[0].primitives[0].attributes.TEXCOORD_0
     }
   });
-  t.ok(gltfBuilder.gltf.json.meshes?.[0]);
-  t.ok(gltfBuilder.gltf.json.meshes?.[0].primitives[0].attributes._BATCHID);
-
-  t.end();
+  expect(gltfBuilder.gltf.json.meshes?.[0]).toBeTruthy();
+  expect(gltfBuilder.gltf.json.meshes?.[0].primitives[0].attributes._BATCHID).toBeTruthy();
 });
-
-test('GLTFScenegraph#Should calculate min and max arrays for accessor', async t => {
+test('GLTFScenegraph#Should calculate min and max arrays for accessor', async () => {
   const gltfWithBuffers = await load(GLTF_BINARY_URL, GLTFLoader);
   const inputData = postProcessGLTF(gltfWithBuffers);
-
   // addMesh does not yet support adding additional accessor attributes, and does not auto calculate them
   delete inputData.meshes[0].primitives[0].attributes.POSITION.min;
   delete inputData.meshes[0].primitives[0].attributes.POSITION.max;
-
   const gltfBuilder = new GLTFScenegraph();
   gltfBuilder.addMesh({
     attributes: {
       POSITION: inputData.meshes[0].primitives[0].attributes.POSITION
     }
   });
-  t.ok(gltfBuilder.gltf.json.accessors?.[0]);
-  t.deepEqual(
-    gltfBuilder.gltf.json.accessors?.[0].min,
-    [-2316.5927734375, -3864.65771484375, -3551.852294921875]
-  );
-  t.deepEqual(
-    gltfBuilder.gltf.json.accessors?.[0].max,
-    [2647.046875, 4302.39111328125, 3733.835205078125]
-  );
-
-  t.end();
+  expect(gltfBuilder.gltf.json.accessors?.[0]).toBeTruthy();
+  expect(gltfBuilder.gltf.json.accessors?.[0].min).toEqual([
+    -2316.5927734375, -3864.65771484375, -3551.852294921875
+  ]);
+  expect(gltfBuilder.gltf.json.accessors?.[0].max).toEqual([
+    2647.046875, 4302.39111328125, 3733.835205078125
+  ]);
 });
-
-test('GLTFScenegraph#Nodes should store `matrix` transformation data', async t => {
+test('GLTFScenegraph#Nodes should store `matrix` transformation data', async () => {
   const gltfWithBuffers = await load(GLTF_BINARY_URL, GLTFLoader);
   const inputData = postProcessGLTF(gltfWithBuffers);
-
   const gltfBuilder = new GLTFScenegraph();
-
   const meshIndex = gltfBuilder.addMesh({
     attributes: {
       POSITION: inputData.meshes[0].primitives[0].attributes.POSITION
@@ -103,13 +76,10 @@ test('GLTFScenegraph#Nodes should store `matrix` transformation data', async t =
   });
   const inputMatrix = [1, 0, 0, 0, 0, 0, -1, 0, 0, 1, 0, 0, 0, 0, 0, 1];
   const nodeIndex = gltfBuilder.addNode({meshIndex, matrix: inputMatrix});
-  t.ok(gltfBuilder.gltf.json.nodes?.[nodeIndex]);
+  expect(gltfBuilder.gltf.json.nodes?.[nodeIndex]).toBeTruthy();
   const testMatrix = [1, 0, 0, 0, 0, 0, -1, 0, 0, 1, 0, 0, 0, 0, 0, 1];
-  t.deepEqual(gltfBuilder.gltf.json.nodes?.[nodeIndex].matrix, testMatrix);
-
+  expect(gltfBuilder.gltf.json.nodes?.[nodeIndex].matrix).toEqual(testMatrix);
   const nodeIndex2 = gltfBuilder.addNode({meshIndex});
-  t.ok(gltfBuilder.gltf.json.nodes?.[nodeIndex2]);
-  t.notOk(gltfBuilder.gltf.json.nodes?.[nodeIndex2].matrix);
-
-  t.end();
+  expect(gltfBuilder.gltf.json.nodes?.[nodeIndex2]).toBeTruthy();
+  expect(gltfBuilder.gltf.json.nodes?.[nodeIndex2].matrix).toBeFalsy();
 });

--- a/modules/gltf/test/lib/api/post-process-gltf.spec.ts
+++ b/modules/gltf/test/lib/api/post-process-gltf.spec.ts
@@ -2,13 +2,14 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-/* eslint-disable max-len, camelcase */
-import test from 'test/utils/vitest-tape';
-
+import {expect, test} from 'vitest';
 import type {GLTFWithBuffers, GLTFPostprocessed} from '@loaders.gl/gltf';
 import {postProcessGLTF} from '@loaders.gl/gltf';
-
-const TEST_CASES: {name: string; input: GLTFWithBuffers; output: Partial<GLTFPostprocessed>}[] = [
+const TEST_CASES: {
+  name: string;
+  input: GLTFWithBuffers;
+  output: Partial<GLTFPostprocessed>;
+}[] = [
   {
     name: 'Simple scene',
     input: {
@@ -48,16 +49,13 @@ const TEST_CASES: {name: string; input: GLTFWithBuffers; output: Partial<GLTFPos
     }
   }
 ];
-
-test('gltf#postProcessGLTF', t => {
+test('gltf#postProcessGLTF', () => {
   for (const testCase of TEST_CASES) {
     const json = postProcessGLTF(testCase.input as unknown as GLTFWithBuffers);
-    t.deepEqual(json, testCase.output, testCase.name);
+    expect(json, testCase.name).toEqual(testCase.output);
   }
-  t.end();
 });
-
-test('gltf#postProcessGLTF resolves a draft glTF 2.1 thumbnail', t => {
+test('gltf#postProcessGLTF resolves a draft glTF 2.1 thumbnail', () => {
   const json = postProcessGLTF({
     json: {
       asset: {version: '2.1', thumbnail: 0},
@@ -66,13 +64,12 @@ test('gltf#postProcessGLTF resolves a draft glTF 2.1 thumbnail', t => {
     buffers: [],
     images: [{width: 2, height: 2}]
   } as unknown as GLTFWithBuffers);
-
-  t.equal(json.asset.thumbnail, json.images[0], 'resolves the thumbnail to the processed image');
-  t.equal(json.asset.thumbnail?.image.width, 2, 'preserves the decoded thumbnail image');
-  t.end();
+  expect(json.asset.thumbnail, 'resolves the thumbnail to the processed image').toBe(
+    json.images[0]
+  );
+  expect(json.asset.thumbnail?.image.width, 'preserves the decoded thumbnail image').toBe(2);
 });
-
-test('gltf#postProcessGLTF normalizes indexed LINE_LOOP topology without mutating source data', t => {
+test('gltf#postProcessGLTF normalizes indexed LINE_LOOP topology without mutating source data', () => {
   const sourceIndices = new Uint16Array([3, 1, 4, 2]);
   const source = {
     json: {
@@ -93,24 +90,19 @@ test('gltf#postProcessGLTF normalizes indexed LINE_LOOP topology without mutatin
       }
     ]
   } as GLTFWithBuffers;
-
   const json = postProcessGLTF(source);
   const primitive = json.meshes[0].primitives[0];
-
-  t.equal(primitive.mode, 1, 'converts LINE_LOOP to LINES');
-  t.deepEqual(
+  expect(primitive.mode, 'converts LINE_LOOP to LINES').toBe(1);
+  expect(
     Array.from(primitive.indices?.value || []),
-    [3, 1, 1, 4, 4, 2, 2, 3],
     'expands the loop into line-list indices'
-  );
-  t.equal(primitive.indices?.componentType, 5123, 'uses portable unsigned-short indices');
-  t.equal(source.json.meshes?.[0].primitives[0].mode, 2, 'preserves the source primitive mode');
-  t.equal(source.json.accessors?.[0].count, 4, 'preserves the source index accessor');
-  t.deepEqual(Array.from(sourceIndices), [3, 1, 4, 2], 'preserves the source index buffer');
-  t.end();
+  ).toEqual([3, 1, 1, 4, 4, 2, 2, 3]);
+  expect(primitive.indices?.componentType, 'uses portable unsigned-short indices').toBe(5123);
+  expect(source.json.meshes?.[0].primitives[0].mode, 'preserves the source primitive mode').toBe(2);
+  expect(source.json.accessors?.[0].count, 'preserves the source index accessor').toBe(4);
+  expect(Array.from(sourceIndices), 'preserves the source index buffer').toEqual([3, 1, 4, 2]);
 });
-
-test('gltf#postProcessGLTF normalizes non-indexed TRIANGLE_FAN topology', t => {
+test('gltf#postProcessGLTF normalizes non-indexed TRIANGLE_FAN topology', () => {
   const json = postProcessGLTF({
     json: {
       asset: {version: '2.0'},
@@ -120,19 +112,15 @@ test('gltf#postProcessGLTF normalizes non-indexed TRIANGLE_FAN topology', t => {
     buffers: []
   } as GLTFWithBuffers);
   const primitive = json.meshes[0].primitives[0];
-
-  t.equal(primitive.mode, 4, 'converts TRIANGLE_FAN to TRIANGLES');
-  t.deepEqual(
+  expect(primitive.mode, 'converts TRIANGLE_FAN to TRIANGLES').toBe(4);
+  expect(
     Array.from(primitive.indices?.value || []),
-    [0, 1, 2, 0, 2, 3],
     'expands the fan into triangle-list indices'
-  );
-  t.equal(primitive.indices?.count, 6, 'updates the generated index count');
-  t.equal(primitive.indices?.max?.[0], 3, 'records the generated maximum index');
-  t.end();
+  ).toEqual([0, 1, 2, 0, 2, 3]);
+  expect(primitive.indices?.count, 'updates the generated index count').toBe(6);
+  expect(primitive.indices?.max?.[0], 'records the generated maximum index').toBe(3);
 });
-
-test('gltf#postProcessGLTF materializes an implicit-zero index accessor', t => {
+test('gltf#postProcessGLTF materializes an implicit-zero index accessor', () => {
   const json = postProcessGLTF({
     json: {
       asset: {version: '2.0'},
@@ -144,18 +132,14 @@ test('gltf#postProcessGLTF materializes an implicit-zero index accessor', t => {
     },
     buffers: []
   } as GLTFWithBuffers);
-
   const primitive = json.meshes[0].primitives[0];
-  t.equal(primitive.mode, 1, 'converts LINE_LOOP to LINES');
-  t.deepEqual(
+  expect(primitive.mode, 'converts LINE_LOOP to LINES').toBe(1);
+  expect(
     Array.from(primitive.indices?.value || []),
-    [0, 0, 0, 0, 0, 0],
     'uses the accessor implicit-zero values'
-  );
-  t.end();
+  ).toEqual([0, 0, 0, 0, 0, 0]);
 });
-
-test('gltf#postProcessGLTF applies sparse-only index accessor substitutions', t => {
+test('gltf#postProcessGLTF applies sparse-only index accessor substitutions', () => {
   const sparseData = new Uint8Array([1, 3, 5, 0, 2, 0]);
   const json = postProcessGLTF({
     json: {
@@ -182,13 +166,10 @@ test('gltf#postProcessGLTF applies sparse-only index accessor substitutions', t 
     },
     buffers: [{arrayBuffer: sparseData.buffer, byteOffset: 0, byteLength: sparseData.byteLength}]
   } as GLTFWithBuffers);
-
   const primitive = json.meshes[0].primitives[0];
-  t.equal(primitive.mode, 1, 'converts LINE_LOOP to LINES');
-  t.deepEqual(
+  expect(primitive.mode, 'converts LINE_LOOP to LINES').toBe(1);
+  expect(
     Array.from(primitive.indices?.value || []),
-    [0, 5, 5, 0, 0, 2, 2, 0],
     'applies sparse substitutions to the implicit-zero base'
-  );
-  t.end();
+  ).toEqual([0, 5, 5, 0, 0, 2, 2, 0]);
 });

--- a/modules/gltf/test/lib/extensions/EXT_feature_metadata.spec.ts
+++ b/modules/gltf/test/lib/extensions/EXT_feature_metadata.spec.ts
@@ -2,36 +2,28 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-/* eslint-disable camelcase */
-import test from 'test/utils/vitest-tape';
-
+import {expect, test} from 'vitest';
 // @ts-expect-error
 import {decodeExtensions} from '@loaders.gl/gltf/lib/api/gltf-extensions';
-
-test('gltf#EXT_feature_metadata - Should do nothing if no "EXT_feature_metadata" extension', async t => {
+test('gltf#EXT_feature_metadata - Should do nothing if no "EXT_feature_metadata" extension', async () => {
   const gltfWithFeatureTextures = {
     json: {
       extensionsUsed: ['EXT_feature_metadata'],
       extensions: {}
     }
   };
-
   const options = {gltf: {loadImages: true, loadBuffers: true}};
   await decodeExtensions(gltfWithFeatureTextures, options);
-
   const expectedResult = {
     json: {
       extensionsUsed: ['EXT_feature_metadata'],
       extensions: {}
     }
   };
-
   // Modifies input
-  t.deepEqual(gltfWithFeatureTextures.json, expectedResult.json);
-  t.end();
+  expect(gltfWithFeatureTextures.json).toEqual(expectedResult.json);
 });
-
-test('gltf#EXT_feature_metadata - Should handle String feature attributes', async t => {
+test('gltf#EXT_feature_metadata - Should handle String feature attributes', async () => {
   const GLTF_WITH_STRING_PROPERTIES = {
     buffers: [
       {
@@ -76,10 +68,8 @@ test('gltf#EXT_feature_metadata - Should handle String feature attributes', asyn
       }
     }
   };
-
   const options = {gltf: {loadImages: true, loadBuffers: true}};
   await decodeExtensions(GLTF_WITH_STRING_PROPERTIES, options);
-
   const expectedResult = {
     buffers: [
       {
@@ -128,13 +118,10 @@ test('gltf#EXT_feature_metadata - Should handle String feature attributes', asyn
       }
     }
   };
-
   // Modifies input
-  t.deepEqual(GLTF_WITH_STRING_PROPERTIES.json, expectedResult.json);
-  t.end();
+  expect(GLTF_WITH_STRING_PROPERTIES.json).toEqual(expectedResult.json);
 });
-
-test('gltf#EXT_feature_metadata - Should handle number feature attributes', async t => {
+test('gltf#EXT_feature_metadata - Should handle number feature attributes', async () => {
   const binaryBufferData = [
     65, 76, 48, 49, 51, 65, 76, 48, 49, 51, 65, 76, 48, 49, 51, 65, 76, 48, 49, 51, 65, 76, 48, 49,
     51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 10, 0, 0, 0, 15, 0, 0, 0, 20, 0, 0, 0, 25, 0,
@@ -202,10 +189,8 @@ test('gltf#EXT_feature_metadata - Should handle number feature attributes', asyn
       }
     }
   };
-
   const options = {gltf: {loadImages: true, loadBuffers: true}};
   await decodeExtensions(GLTF_WITH_EXTENSION, options);
-
   const expectedJson = {
     extensionsUsed: ['EXT_feature_metadata'],
     bufferViews: [
@@ -277,14 +262,10 @@ test('gltf#EXT_feature_metadata - Should handle number feature attributes', asyn
       }
     }
   };
-
   // Modifies input
-  t.deepEqual(GLTF_WITH_EXTENSION.json, expectedJson);
-
-  t.end();
+  expect(GLTF_WITH_EXTENSION.json).toEqual(expectedJson);
 });
-
-test('gltf#EXT_feature_metadata - Should handle feature texture attributes', async t => {
+test('gltf#EXT_feature_metadata - Should handle feature texture attributes', async () => {
   const GLTF_WITH_TEXTURES = {
     buffers: [
       {
@@ -302,7 +283,6 @@ test('gltf#EXT_feature_metadata - Should handle feature texture attributes', asy
         data: new Uint8Array([24, 24, 24, 255, 28, 28, 28, 255, 35, 35, 35, 255, 24, 24, 24, 255])
       }
     ],
-
     json: {
       accessors: [
         {
@@ -380,10 +360,8 @@ test('gltf#EXT_feature_metadata - Should handle feature texture attributes', asy
       ]
     }
   };
-
   const options = {gltf: {loadImages: true, loadBuffers: true}};
   await decodeExtensions(GLTF_WITH_TEXTURES, options);
-
   const expectedResult = {
     buf: {
       arrayBuffer: new Uint32Array([0, 1, 2, 0]).buffer,
@@ -392,19 +370,14 @@ test('gltf#EXT_feature_metadata - Should handle feature texture attributes', asy
     },
     data: [24, 35, 28]
   };
-
-  t.deepEqual(GLTF_WITH_TEXTURES.buffers[1], expectedResult.buf);
-
+  expect(GLTF_WITH_TEXTURES.buffers[1]).toEqual(expectedResult.buf);
   const featureTextures = GLTF_WITH_TEXTURES.json.extensions.EXT_feature_metadata.featureTextures;
-  t.deepEqual(
+  expect(
     // @ts-expect-error
-    featureTextures['r3dm::uncertainty_ce90sum'].properties['r3dm::uncertainty_ce90sum'].data,
-    expectedResult.data
-  );
-  t.end();
+    featureTextures['r3dm::uncertainty_ce90sum'].properties['r3dm::uncertainty_ce90sum'].data
+  ).toEqual(expectedResult.data);
 });
-
-test('gltf#EXT_feature_metadata - Should handle arrays', async t => {
+test('gltf#EXT_feature_metadata - Should handle arrays', async () => {
   const binaryBufferData = [
     0, 0, 0, 125, 125, 125, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 0, 0, 100, 100, 0, 125, 63, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -567,10 +540,8 @@ test('gltf#EXT_feature_metadata - Should handle arrays', async t => {
       extensionsUsed: ['EXT_feature_metadata']
     }
   };
-
   const options = {gltf: {loadImages: true, loadBuffers: true}};
   await decodeExtensions(GLTF_WITH_EXTENSION, options);
-
   const expectedResult = {
     colorData: [
       {
@@ -616,17 +587,15 @@ test('gltf#EXT_feature_metadata - Should handle arrays', async t => {
     ],
     nameData: ['never_classified', 'undef', '', '', '', '', 'building', 'untrusted_ground']
   };
-
   const EXT_feature_metadata = GLTF_WITH_EXTENSION.json.extensions.EXT_feature_metadata;
-  t.deepEqual(
+  expect(
     // @ts-expect-error
-    EXT_feature_metadata.featureTables['owt::lulc'].properties.color.data,
-    expectedResult.colorData
-  );
-  t.deepEqual(
+    Array.from(EXT_feature_metadata.featureTables['owt::lulc'].properties.color.data, value =>
+      Array.from(value)
+    )
+  ).toEqual(expectedResult.colorData.map(value => Object.values(value)));
+  expect(
     // @ts-expect-error
-    EXT_feature_metadata.featureTables['owt::lulc'].properties.name.data,
-    expectedResult.nameData
-  );
-  t.end();
+    EXT_feature_metadata.featureTables['owt::lulc'].properties.name.data
+  ).toEqual(expectedResult.nameData);
 });

--- a/modules/gltf/test/lib/extensions/EXT_mesh_features.spec.ts
+++ b/modules/gltf/test/lib/extensions/EXT_mesh_features.spec.ts
@@ -2,12 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-/* eslint-disable camelcase */
-import test from 'test/utils/vitest-tape';
-
+import {expect, test} from 'vitest';
 import {decodeExtensions, encodeExtensions} from '../../../src/lib/api/gltf-extensions';
 import {GLTFScenegraph, createExtMeshFeatures, type GLTF} from '@loaders.gl/gltf';
-
 const binaryBufferData = [
   0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 1, 33, 223, 70, 43, 39,
   58, 199, 113, 55, 81, 71, 94, 21, 60, 71, 154, 68, 219, 198, 113, 55, 81, 199, 183, 210, 225, 198,
@@ -15,9 +12,7 @@ const binaryBufferData = [
   0, 0, 0, 63, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 63, 0, 0, 0, 0, 0, 0, 0, 63, 0, 0, 0, 63, 0, 1, 10,
   0, 68, 82, 89, 71, 82, 79, 85, 78, 68, 0, 108, 60, 0, 95, 5, 0, 1, 3, 0, 0
 ];
-
 const binaryBufferDataAlligned = binaryBufferData.concat([0, 0]);
-
 const getGltfWithExtension = () => ({
   buffers: [
     {
@@ -175,20 +170,15 @@ const getGltfWithExtension = () => ({
     ]
   }
 });
-
-test('gltf#EXT_mesh_features - Should decode', async t => {
+test('gltf#EXT_mesh_features - Should decode', async () => {
   const options = {gltf: {loadImages: true, loadBuffers: true}};
   const gltf = getGltfWithExtension();
   gltf.buffers[0].arrayBuffer = new Uint8Array(binaryBufferDataAlligned).buffer;
   await decodeExtensions(gltf, options);
-
-  t.deepEqual(
-    gltf.json.meshes[0].primitives[0].extensions.EXT_mesh_features.featureIds[0].data,
+  expect(gltf.json.meshes[0].primitives[0].extensions.EXT_mesh_features.featureIds[0].data).toEqual(
     [1, 1, 1, 1]
   );
-  t.end();
 });
-
 const PRIMITIVE_EXPECTED = {
   attributes: {TEXCOORD_0: 2, POSITION: 1, _FEATURE_ID_0: 3},
   indices: 0,
@@ -213,23 +203,21 @@ const PRIMITIVE_EXPECTED = {
     }
   }
 };
-
-test('gltf#EXT_mesh_features - Should encode featureIDs', t => {
+test('gltf#EXT_mesh_features - Should encode featureIDs', () => {
   const gltf = getGltfWithExtension();
   gltf.buffers[0].arrayBuffer = new Uint8Array(binaryBufferDataAlligned).buffer;
-
-  const scenegraph = new GLTFScenegraph(gltf as unknown as {json: GLTF});
+  const scenegraph = new GLTFScenegraph(
+    gltf as unknown as {
+      json: GLTF;
+    }
+  );
   const primitive = gltf.json.meshes[0].primitives[0];
   const featureIds = [4, 4, 4, 3, 0, 1, 2];
   const tableIndex = 8;
-
   createExtMeshFeatures(scenegraph, primitive, featureIds, tableIndex);
   encodeExtensions(scenegraph.gltf, {});
-
-  t.deepEqual(primitive, PRIMITIVE_EXPECTED);
-  t.end();
+  expect(primitive).toEqual(PRIMITIVE_EXPECTED);
 });
-
 const GLTF_JSON_ROUNDTRIP_EXPECTED = {
   asset: {
     version: '2.0'
@@ -285,17 +273,12 @@ const GLTF_JSON_ROUNDTRIP_EXPECTED = {
 const BUFFER_ROUNDTRIP_EXPECTED = new Uint8Array(
   binaryBufferData.concat([1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0])
 ).buffer;
-
-test('gltf#EXT_mesh_features - Roundtrip encode/decode', async t => {
+test('gltf#EXT_mesh_features - Roundtrip encode/decode', async () => {
   const options = {gltf: {loadImages: true, loadBuffers: true}};
   const gltf = getGltfWithExtension();
   gltf.buffers[0].arrayBuffer = new Uint8Array(binaryBufferDataAlligned).buffer;
-
   await decodeExtensions(gltf, options);
   const gltfBin = encodeExtensions(gltf, options);
-
-  t.deepEqual(gltfBin.json, GLTF_JSON_ROUNDTRIP_EXPECTED);
-
-  t.deepEqual(gltfBin.buffers[0].arrayBuffer, BUFFER_ROUNDTRIP_EXPECTED);
-  t.end();
+  expect(gltfBin.json).toEqual(GLTF_JSON_ROUNDTRIP_EXPECTED);
+  expect(gltfBin.buffers[0].arrayBuffer).toEqual(BUFFER_ROUNDTRIP_EXPECTED);
 });

--- a/modules/gltf/test/lib/extensions/EXT_structural_metadata.spec.ts
+++ b/modules/gltf/test/lib/extensions/EXT_structural_metadata.spec.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-/* eslint-disable camelcase */
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {decodeExtensions, encodeExtensions} from '../../../src/lib/api/gltf-extensions';
 import {
   GLTFScenegraph,
@@ -11,8 +10,7 @@ import {
   type PropertyAttribute,
   GLTF_EXT_structural_metadata_GLTF
 } from '@loaders.gl/gltf';
-
-test('gltf#EXT_structural_metadata - Should decode', async t => {
+test('gltf#EXT_structural_metadata - Should decode', async () => {
   const binaryBufferData = [
     0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 1, 33, 223, 70, 43, 39,
     58, 199, 113, 55, 81, 71, 94, 21, 60, 71, 154, 68, 219, 198, 113, 55, 81, 199, 183, 210, 225,
@@ -106,10 +104,8 @@ test('gltf#EXT_structural_metadata - Should decode', async t => {
       }
     }
   };
-
   const options = {gltf: {loadImages: true, loadBuffers: true}};
   await decodeExtensions(GLTF_WITH_EXTENSION, options);
-
   const expectedJson = {
     extensionsUsed: ['EXT_structural_metadata', 'EXT_mesh_features'],
     buffers: [{byteLength: 126}],
@@ -190,12 +186,9 @@ test('gltf#EXT_structural_metadata - Should decode', async t => {
       }
     }
   };
-
   // Modifies input
-  t.deepEqual(GLTF_WITH_EXTENSION.json, expectedJson);
-  t.end();
+  expect(GLTF_WITH_EXTENSION.json).toEqual(expectedJson);
 });
-
 const ATTRIBUTES: PropertyAttribute[] = [
   {
     name: 'OBJECTID',
@@ -221,7 +214,6 @@ const ATTRIBUTES: PropertyAttribute[] = [
     values: [31.46, 31.49, 31.49, 31.49]
   }
 ];
-
 const EXPECTED_GLTF_JSON_WITH_EXTENSION = {
   asset: {
     version: '2.0',
@@ -287,54 +279,42 @@ const EXPECTED_GLTF_JSON_WITH_EXTENSION = {
     {buffer: 0, byteOffset: 88, byteLength: 32}
   ]
 };
-
-test('gltf#EXT_structural_metadata - Should encode', async t => {
+test('gltf#EXT_structural_metadata - Should encode', async () => {
   const scenegraph = new GLTFScenegraph();
   const tableIndex = createExtStructuralMetadata(scenegraph, ATTRIBUTES);
   const gltfBin = encodeExtensions(scenegraph.gltf, {});
   const scenegraph1 = new GLTFScenegraph(gltfBin);
   scenegraph1.createBinaryChunk();
-
-  t.equal(tableIndex, 0);
-  t.equal(scenegraph1.gltf.buffers[0].byteLength, 120);
-
-  t.deepEqual(
-    JSON.stringify(scenegraph1.gltf.json),
+  expect(tableIndex).toBe(0);
+  expect(scenegraph1.gltf.buffers[0].byteLength).toBe(120);
+  expect(JSON.stringify(scenegraph1.gltf.json)).toEqual(
     JSON.stringify(EXPECTED_GLTF_JSON_WITH_EXTENSION)
   );
-  t.end();
 });
-
-test('gltf#EXT_structural_metadata - Roundtrip encoding/decoding', async t => {
+test('gltf#EXT_structural_metadata - Roundtrip encoding/decoding', async () => {
   const scenegraph = new GLTFScenegraph();
   createExtStructuralMetadata(scenegraph, ATTRIBUTES);
   const gltfBin = encodeExtensions(scenegraph.gltf, {});
-
   const scenegraph1 = new GLTFScenegraph(gltfBin);
   scenegraph1.createBinaryChunk();
-
   const options = {gltf: {loadImages: true, loadBuffers: true}};
   await decodeExtensions(scenegraph1.gltf, options);
-
   const scenegraph2 = new GLTFScenegraph(scenegraph1.gltf);
   scenegraph2.createBinaryChunk();
-
   for (const attr of ATTRIBUTES) {
     const name = attr.name;
     const ext = scenegraph2.gltf.json.extensions
       ?.EXT_structural_metadata as GLTF_EXT_structural_metadata_GLTF;
     const data = ext.propertyTables?.[0].properties?.[name].data;
     if (ext.schema?.classes?.schemaClassId.properties[name].type === 'STRING') {
-      t.deepEqual(JSON.stringify(data), JSON.stringify(attr.values));
+      expect(JSON.stringify(data)).toEqual(JSON.stringify(attr.values));
     } else {
       const dataArray: number[] = [...(data as any)];
-      t.deepEqual(JSON.stringify(dataArray), JSON.stringify(attr.values));
+      expect(JSON.stringify(dataArray)).toEqual(JSON.stringify(attr.values));
     }
   }
-  t.end();
 });
-
-test('gltf#EXT_structural_metadata - Should decode variable-length string arrays', async t => {
+test('gltf#EXT_structural_metadata - Should decode variable-length string arrays', async () => {
   // 3 features with variable-length string arrays
   // Feature 0: ["hello", "world"] (2 strings)
   // Feature 1: [] (0 strings)
@@ -344,7 +324,6 @@ test('gltf#EXT_structural_metadata - Should decode variable-length string arrays
   // - values: "helloworldfoobar" (16 bytes)
   // - stringOffsets (UINT8): [0, 5, 10, 13, 16] (5 bytes)
   // - arrayOffsets (UINT8): [0, 2, 2, 4] (4 bytes)
-
   const binaryBufferData = [
     // values: "helloworldfoobar" (offset 0, length 16)
     104,
@@ -375,7 +354,6 @@ test('gltf#EXT_structural_metadata - Should decode variable-length string arrays
     2,
     4
   ];
-
   const GLTF_WITH_STRING_ARRAY = {
     buffers: [
       {
@@ -428,19 +406,15 @@ test('gltf#EXT_structural_metadata - Should decode variable-length string arrays
       }
     }
   };
-
   const options = {gltf: {loadImages: true, loadBuffers: true}};
   await decodeExtensions(GLTF_WITH_STRING_ARRAY, options);
-
   const ext = GLTF_WITH_STRING_ARRAY.json.extensions
     .EXT_structural_metadata as GLTF_EXT_structural_metadata_GLTF;
   const tagsData = ext.propertyTables?.[0].properties?.tags.data;
-
   // Verify variable-length string arrays are correctly decoded
-  t.deepEqual(
-    tagsData,
-    [['hello', 'world'], [], ['foo', 'bar']],
-    'Variable-length string arrays decoded correctly'
-  );
-  t.end();
+  expect(tagsData, 'Variable-length string arrays decoded correctly').toEqual([
+    ['hello', 'world'],
+    [],
+    ['foo', 'bar']
+  ]);
 });

--- a/modules/gltf/test/lib/extensions/KHR_lights_punctual.spec.ts
+++ b/modules/gltf/test/lib/extensions/KHR_lights_punctual.spec.ts
@@ -2,12 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-/* eslint-disable camelcase */
-import test from 'test/utils/vitest-tape';
-
+import {expect, test} from 'vitest';
 // @ts-expect-error
 import {decodeExtensions} from '@loaders.gl/gltf/lib/api/gltf-extensions';
-
 const TEST_CASES = [
   {
     name: 'KHR_lights_punctual',
@@ -54,12 +51,10 @@ const TEST_CASES = [
     }
   }
 ];
-
-test('gltf#KHR_lights_punctuals', async t => {
+test('gltf#KHR_lights_punctuals', async () => {
   for (const testCase of TEST_CASES) {
     await decodeExtensions(testCase.input);
     // Modifies input
-    t.deepEqual(testCase.input.json, testCase.output, testCase.name);
+    expect(testCase.input.json, testCase.name).toEqual(testCase.output);
   }
-  t.end();
 });

--- a/modules/gltf/test/lib/extensions/KHR_materials_unlit.spec.ts
+++ b/modules/gltf/test/lib/extensions/KHR_materials_unlit.spec.ts
@@ -2,12 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-/* eslint-disable camelcase */
-import test from 'test/utils/vitest-tape';
-
+import {expect, test} from 'vitest';
 // @ts-expect-error
 import {decodeExtensions} from '@loaders.gl/gltf/lib/api/gltf-extensions';
-
 const TEST_CASES = [
   {
     name: 'KHR_materials_unlit',
@@ -48,12 +45,10 @@ const TEST_CASES = [
     }
   }
 ];
-
-test('gltf#KHR_materials_unlit', async t => {
+test('gltf#KHR_materials_unlit', async () => {
   for (const testCase of TEST_CASES) {
     await decodeExtensions(testCase.input);
     // Modifies input
-    t.deepEqual(testCase.input.json, testCase.output, testCase.name);
+    expect(testCase.input.json, testCase.name).toEqual(testCase.output);
   }
-  t.end();
 });

--- a/modules/gltf/test/lib/extensions/KHR_meshopt_compression.spec.ts
+++ b/modules/gltf/test/lib/extensions/KHR_meshopt_compression.spec.ts
@@ -2,76 +2,65 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {load} from '@loaders.gl/core';
 import {GLTFLoader, GLTFScenegraph} from '@loaders.gl/gltf';
 import {
   decodeMeshoptCompression,
   validateMeshoptCompressionExclusivity
 } from '../../../src/lib/extensions/meshopt-compression';
-
 const KHR_MESHOPT_CUBE_URL =
   '@loaders.gl/gltf/test/data/meshopt/MeshoptCubeTest/glTF-Meshopt/MeshoptCubeTest.gltf';
-
-test('KHR_meshopt_compression#decodes official version 1 fixture', async t => {
+test('KHR_meshopt_compression#decodes official version 1 fixture', async () => {
   const gltf = await load(KHR_MESHOPT_CUBE_URL, GLTFLoader, {
     gltf: {decompressMeshes: true, loadBuffers: true, loadImages: false}
   });
   const scenegraph = new GLTFScenegraph(gltf);
-
-  t.ok(
+  expect(
     scenegraph.getRemovedExtensions().includes('KHR_meshopt_compression'),
     'records KHR_meshopt_compression as processed'
-  );
-  t.notOk(
+  ).toBeTruthy();
+  expect(
     scenegraph.getUsedExtensions().includes('KHR_meshopt_compression'),
     'removes KHR_meshopt_compression from extensionsUsed'
-  );
-  t.notOk(
+  ).toBeFalsy();
+  expect(
     scenegraph.getRequiredExtensions().includes('KHR_meshopt_compression'),
     'removes KHR_meshopt_compression from extensionsRequired'
-  );
-  t.ok(
+  ).toBeFalsy();
+  expect(
     gltf.json.buffers?.every(buffer => !buffer.extensions?.KHR_meshopt_compression),
     'removes fallback markers from destination buffers'
-  );
-  t.ok(
+  ).toBeTruthy();
+  expect(
     gltf.json.bufferViews?.every(bufferView => !bufferView.extensions?.KHR_meshopt_compression),
     'removes processed buffer-view extension objects'
-  );
-
+  ).toBeTruthy();
   const losslessAccessorPairs = [
     [8, 92, 'positions'],
     [9, 93, 'normals']
   ] as const;
   for (const [uncompressedAccessorIndex, compressedAccessorIndex, label] of losslessAccessorPairs) {
-    t.deepEqual(
+    expect(
       scenegraph.getTypedArrayForAccessor(compressedAccessorIndex),
-      scenegraph.getTypedArrayForAccessor(uncompressedAccessorIndex),
       `version 1 ${label} match the uncompressed reference`
-    );
+    ).toEqual(scenegraph.getTypedArrayForAccessor(uncompressedAccessorIndex));
   }
-
   const uncompressedColors = scenegraph.getTypedArrayForAccessor(10) as Uint8Array;
   const compressedColors = scenegraph.getTypedArrayForAccessor(94) as Uint8Array;
-  t.ok(
+  expect(
     Array.from(compressedColors).every(
       (component, componentIndex) => Math.abs(component - uncompressedColors[componentIndex]) <= 1
     ),
     'COLOR-filtered values stay within the expected one-byte rounding tolerance'
-  );
-
+  ).toBeTruthy();
   const uncompressedIndices = scenegraph.getTypedArrayForAccessor(11) as Uint16Array;
   const compressedIndices = scenegraph.getTypedArrayForAccessor(95) as Uint16Array;
-  t.deepEqual(
+  expect(
     getCanonicalTriangleIndices(compressedIndices),
-    getCanonicalTriangleIndices(uncompressedIndices),
     'triangle indices match the reference independent of cyclic vertex rotation'
-  );
-
-  t.end();
+  ).toEqual(getCanonicalTriangleIndices(uncompressedIndices));
 });
-
 /**
  * Rotates each triangle so equivalent cyclic index orderings compare identically.
  *
@@ -93,9 +82,8 @@ function getCanonicalTriangleIndices(indices: Uint16Array): number[] {
   }
   return canonicalIndices;
 }
-
-test('KHR_meshopt_compression#rejects KHR and EXT on one buffer view', t => {
-  t.throws(
+test('KHR_meshopt_compression#rejects KHR and EXT on one buffer view', () => {
+  expect(
     () =>
       validateMeshoptCompressionExclusivity({
         asset: {version: '2.0'},
@@ -110,10 +98,9 @@ test('KHR_meshopt_compression#rejects KHR and EXT on one buffer view', t => {
           }
         ]
       }),
-    /bufferView 0 cannot use both KHR_meshopt_compression and EXT_meshopt_compression/,
     'rejects the mutually exclusive buffer-view combination'
-  );
-  t.throws(
+  ).toThrow(/bufferView 0 cannot use both KHR_meshopt_compression and EXT_meshopt_compression/);
+  expect(
     () =>
       validateMeshoptCompressionExclusivity({
         asset: {version: '2.0'},
@@ -127,13 +114,10 @@ test('KHR_meshopt_compression#rejects KHR and EXT on one buffer view', t => {
           }
         ]
       }),
-    /buffer 0 cannot use both KHR_meshopt_compression and EXT_meshopt_compression/,
     'rejects the mutually exclusive buffer fallback combination'
-  );
-  t.end();
+  ).toThrow(/buffer 0 cannot use both KHR_meshopt_compression and EXT_meshopt_compression/);
 });
-
-test('KHR_meshopt_compression#preserves declarations when decoding fails', async t => {
+test('KHR_meshopt_compression#preserves declarations when decoding fails', async () => {
   const sourceBytes = new Uint8Array([0]);
   const destinationBytes = new Uint8Array(4);
   const gltf = {
@@ -174,27 +158,24 @@ test('KHR_meshopt_compression#preserves declarations when decoding fails', async
     ],
     images: []
   };
-
-  await t.rejects(
+  await expect(
     decodeMeshoptCompression(
       gltf,
       {gltf: {decompressMeshes: true, loadBuffers: true}},
       'KHR_meshopt_compression'
     ),
-    /Malformed buffer data/,
     'reports malformed compressed data'
-  );
-  t.ok(
+  ).rejects.toThrow(/Malformed buffer data/);
+  expect(
     gltf.json.bufferViews[0].extensions.KHR_meshopt_compression,
     'retains the buffer-view declaration'
-  );
-  t.ok(
+  ).toBeTruthy();
+  expect(
     gltf.json.buffers[1].extensions.KHR_meshopt_compression,
     'retains the fallback-buffer marker'
-  );
-  t.ok(
+  ).toBeTruthy();
+  expect(
     gltf.json.extensionsRequired.includes('KHR_meshopt_compression'),
     'retains the required capability declaration'
-  );
-  t.end();
+  ).toBeTruthy();
 });

--- a/modules/gltf/test/lib/gltf-utils/external-assets.spec.ts
+++ b/modules/gltf/test/lib/gltf-utils/external-assets.spec.ts
@@ -2,12 +2,11 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {parse} from '@loaders.gl/core';
 import {GLTFLoader} from '@loaders.gl/gltf';
 import {createGLBV3} from '../../test-utils/create-glb-v3';
-
-test('GLTFLoader#loads URI external assets and their relative dependencies', async t => {
+test('GLTFLoader#loads URI external assets and their relative dependencies', async () => {
   const fetchedUrls: string[] = [];
   const child = {
     asset: {version: '2.1'},
@@ -22,7 +21,6 @@ test('GLTFLoader#loads URI external assets and their relative dependencies', asy
     ],
     nodes: [{externalAsset: 0}, {externalAsset: 1}]
   };
-
   const gltf = await parse(new TextEncoder().encode(JSON.stringify(root)), GLTFLoader, {
     core: {
       baseUrl: 'https://example.com/models/root.gltf',
@@ -39,24 +37,19 @@ test('GLTFLoader#loads URI external assets and their relative dependencies', asy
     },
     gltf: {loadExternalAssets: true, loadImages: false}
   });
-
   const childAsset = gltf.externalAssets?.[0];
-  t.ok(childAsset, 'parses the referenced child asset');
-  t.equal(gltf.externalAssets?.[1], childAsset, 'caches repeated references to the same file');
-  t.deepEqual(
-    fetchedUrls,
-    ['https://example.com/models/child/child.gltf', 'https://example.com/models/child/child.bin'],
-    'resolves child dependencies relative to the child asset URI'
-  );
-  t.deepEqual(
+  expect(childAsset, 'parses the referenced child asset').toBeTruthy();
+  expect(gltf.externalAssets?.[1], 'caches repeated references to the same file').toBe(childAsset);
+  expect(fetchedUrls, 'resolves child dependencies relative to the child asset URI').toEqual([
+    'https://example.com/models/child/child.gltf',
+    'https://example.com/models/child/child.bin'
+  ]);
+  expect(
     Array.from(new Uint8Array(childAsset!.buffers[0].arrayBuffer)),
-    [1, 2, 3, 4],
     'loads the child buffer'
-  );
-  t.end();
+  ).toEqual([1, 2, 3, 4]);
 });
-
-test('GLTFLoader#resolves embedded external asset dependencies from the package', async t => {
+test('GLTFLoader#resolves embedded external asset dependencies from the package', async () => {
   const child = new TextEncoder().encode(
     JSON.stringify({
       asset: {version: '2.1'},
@@ -67,7 +60,6 @@ test('GLTFLoader#resolves embedded external asset dependencies from the package'
   const binary = new Uint8Array(child.byteLength + childBuffer.byteLength);
   binary.set(child);
   binary.set(childBuffer, child.byteLength);
-
   const data = createGLBV3(
     {
       asset: {version: '2.1'},
@@ -85,31 +77,25 @@ test('GLTFLoader#resolves embedded external asset dependencies from the package'
     },
     [binary]
   );
-
   const gltf = await parse(data, GLTFLoader, {
     gltf: {loadBuffers: true, loadExternalAssets: true, loadImages: false}
   });
   const childAsset = gltf.externalAssets?.[0];
-
-  t.ok(childAsset, 'parses the child JSON from its buffer view');
-  t.deepEqual(
+  expect(childAsset, 'parses the child JSON from its buffer view').toBeTruthy();
+  expect(
     Array.from(new Uint8Array(childAsset!.buffers[0].arrayBuffer)),
-    [5, 6, 7, 8],
     'resolves the child URI through the containing files array'
-  );
-  t.ok(gltf.files?.[1], 'caches the package dependency in the parent files array');
-  t.end();
+  ).toEqual([5, 6, 7, 8]);
+  expect(gltf.files?.[1], 'caches the package dependency in the parent files array').toBeTruthy();
 });
-
-test('GLTFLoader#rejects cyclical external assets', async t => {
+test('GLTFLoader#rejects cyclical external assets', async () => {
   const recursiveAsset = JSON.stringify({
     asset: {version: '2.1'},
     files: [{mimeType: 'model/gltf+json', uri: './child.gltf'}],
     externalAssets: [{file: 0}],
     nodes: [{externalAsset: 0}]
   });
-
-  await t.rejects(
+  await expect(
     parse(new TextEncoder().encode(recursiveAsset), GLTFLoader, {
       core: {
         baseUrl: 'https://example.com/root.gltf',
@@ -117,8 +103,6 @@ test('GLTFLoader#rejects cyclical external assets', async t => {
       },
       gltf: {loadExternalAssets: true, loadImages: false}
     }),
-    /external asset cycle detected at https:\/\/example.com\/child.gltf/,
     'rejects recursive references before awaiting the cached parse'
-  );
-  t.end();
+  ).rejects.toThrow(/external asset cycle detected at https:\/\/example.com\/child.gltf/);
 });

--- a/modules/gltf/test/lib/gltf-utils/gltf-accessor-component-types.spec.ts
+++ b/modules/gltf/test/lib/gltf-utils/gltf-accessor-component-types.spec.ts
@@ -2,11 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
-
+import {expect, test} from 'vitest';
 import {GLTFScenegraph, postProcessGLTF} from '@loaders.gl/gltf';
 import type {BigTypedArray} from '@loaders.gl/schema';
-
 const TEST_CASES: {
   name: string;
   componentType: number;
@@ -26,8 +24,7 @@ const TEST_CASES: {
     source: new BigUint64Array([9007199254740993n, 18446744073709551615n])
   }
 ];
-
-test('glTF 2.1 accessor component types', t => {
+test('glTF 2.1 accessor component types', () => {
   for (const testCase of TEST_CASES) {
     const gltf = {
       json: {
@@ -51,36 +48,25 @@ test('glTF 2.1 accessor component types', t => {
         }
       ]
     };
-
     const scenegraph = new GLTFScenegraph(gltf);
     const scenegraphValues = scenegraph.getTypedArrayForAccessor(0);
-    t.equal(scenegraphValues.constructor, testCase.source.constructor, `${testCase.name} type`);
-    t.deepEqual(
-      Array.from(scenegraphValues),
-      Array.from(testCase.source),
-      `${testCase.name} values`
+    expect(scenegraphValues.constructor, `${testCase.name} type`).toBe(testCase.source.constructor);
+    expect(Array.from(scenegraphValues), `${testCase.name} values`).toEqual(
+      Array.from(testCase.source)
     );
-
     const processed = postProcessGLTF(gltf);
     const processedValues = processed.accessors[0].value;
-    t.equal(
-      processedValues.constructor,
-      testCase.source.constructor,
-      `${testCase.name} postprocessed type`
+    expect(processedValues.constructor, `${testCase.name} postprocessed type`).toBe(
+      testCase.source.constructor
     );
-    t.deepEqual(
-      Array.from(processedValues),
-      Array.from(testCase.source),
-      `${testCase.name} postprocessed values`
+    expect(Array.from(processedValues), `${testCase.name} postprocessed values`).toEqual(
+      Array.from(testCase.source)
     );
   }
-  t.end();
 });
-
-test('GLTFScenegraph#addBinaryBuffer accepts 64-bit integer arrays', t => {
+test('GLTFScenegraph#addBinaryBuffer accepts 64-bit integer arrays', () => {
   const gltf = {json: {asset: {version: '2.1'}}, buffers: []};
   const scenegraph = new GLTFScenegraph(gltf);
-
   scenegraph.addBinaryBuffer(new BigInt64Array([-1n, 1n]), {
     size: 1,
     min: [-1n],
@@ -91,11 +77,8 @@ test('GLTFScenegraph#addBinaryBuffer accepts 64-bit integer arrays', t => {
     min: [0n],
     max: [2n]
   });
-
-  t.deepEqual(
+  expect(
     gltf.json.accessors?.map(accessor => accessor.componentType),
-    [5134, 5135],
     'maps signed and unsigned 64-bit constructors to glTF component types'
-  );
-  t.end();
+  ).toEqual([5134, 5135]);
 });

--- a/modules/gltf/test/lib/gltf-utils/gltf-attribute-utils.spec.ts
+++ b/modules/gltf/test/lib/gltf-utils/gltf-attribute-utils.spec.ts
@@ -2,17 +2,14 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {
   getGLTFAccessors,
   getGLTFAccessor
   // @ts-expect-error
 } from '@loaders.gl/gltf/lib/gltf-utils/gltf-attribute-utils';
-
 // Check if an attribute contains indices
-
-test('getGLTFAccessors', t => {
-  t.ok(getGLTFAccessors);
-  t.ok(getGLTFAccessor);
-  t.end();
+test('getGLTFAccessors', () => {
+  expect(getGLTFAccessors).toBeTruthy();
+  expect(getGLTFAccessor).toBeTruthy();
 });

--- a/modules/gltf/test/lib/gltf-utils/resolve-gltf-file.spec.ts
+++ b/modules/gltf/test/lib/gltf-utils/resolve-gltf-file.spec.ts
@@ -2,12 +2,11 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import type {LoaderContext} from '@loaders.gl/loader-utils';
 import type {GLTFWithBuffers} from '@loaders.gl/gltf';
 import {findGLTFFileIndex, resolveGLTFFile} from '@loaders.gl/gltf';
-
-test('resolveGLTFFile#resolves embedded package files by name', async t => {
+test('resolveGLTFFile#resolves embedded package files by name', async () => {
   const arrayBuffer = new Uint8Array([0, 1, 2, 3, 4, 5]).buffer;
   const gltf = {
     json: {
@@ -18,7 +17,6 @@ test('resolveGLTFFile#resolves embedded package files by name', async t => {
     buffers: [{arrayBuffer, byteOffset: 0, byteLength: 6}],
     files: [null]
   } as unknown as GLTFWithBuffers;
-
   const file = await resolveGLTFFile(
     gltf,
     'nested/model.glb',
@@ -27,19 +25,15 @@ test('resolveGLTFFile#resolves embedded package files by name', async t => {
       throw new Error('embedded files must not fetch');
     })
   );
-
-  t.equal(file.mimeType, 'model/gltf-binary', 'preserves the declared MIME type');
-  t.equal(file.byteOffset, 1, 'preserves the buffer view byte offset');
-  t.deepEqual(
+  expect(file.mimeType, 'preserves the declared MIME type').toBe('model/gltf-binary');
+  expect(file.byteOffset, 'preserves the buffer view byte offset').toBe(1);
+  expect(
     Array.from(new Uint8Array(file.arrayBuffer, file.byteOffset, file.byteLength)),
-    [1, 2, 3, 4],
     'returns the embedded bytes without copying'
-  );
-  t.equal(gltf.files?.[0], file, 'caches the resolved file in the parallel files array');
-  t.end();
+  ).toEqual([1, 2, 3, 4]);
+  expect(gltf.files?.[0], 'caches the resolved file in the parallel files array').toBe(file);
 });
-
-test('resolveGLTFFile#fetches URI files relative to the containing asset', async t => {
+test('resolveGLTFFile#fetches URI files relative to the containing asset', async () => {
   let fetchedUrl = '';
   const gltf = {
     json: {
@@ -54,20 +48,16 @@ test('resolveGLTFFile#fetches URI files relative to the containing asset', async
     return new Response(new Uint8Array([7, 8, 9]));
   });
   context.baseUrl = 'https://example.com/models';
-
   const file = await resolveGLTFFile(gltf, 'media/audio.mp3', {}, context);
-
-  t.equal(fetchedUrl, 'https://example.com/models/media/audio.mp3', 'resolves the relative URI');
-  t.equal(file.url, fetchedUrl, 'records the resolved source URL');
-  t.deepEqual(
-    Array.from(new Uint8Array(file.arrayBuffer)),
-    [7, 8, 9],
-    'returns fetched file bytes'
+  expect(fetchedUrl, 'resolves the relative URI').toBe(
+    'https://example.com/models/media/audio.mp3'
   );
-  t.end();
+  expect(file.url, 'records the resolved source URL').toBe(fetchedUrl);
+  expect(Array.from(new Uint8Array(file.arrayBuffer)), 'returns fetched file bytes').toEqual([
+    7, 8, 9
+  ]);
 });
-
-test('resolveGLTFFile#rejects unsuccessful URI responses', async t => {
+test('resolveGLTFFile#rejects unsuccessful URI responses', async () => {
   const gltf = {
     json: {
       asset: {version: '2.1'},
@@ -76,22 +66,18 @@ test('resolveGLTFFile#rejects unsuccessful URI responses', async t => {
     buffers: [],
     files: [null]
   } as unknown as GLTFWithBuffers;
-
-  await t.rejects(
+  await expect(
     resolveGLTFFile(
       gltf,
       0,
       {core: {baseUrl: 'https://example.com/model.gltf'}},
       createLoaderContext(async () => new Response('not found', {status: 404}))
     ),
-    /Failed to fetch glTF file missing.bin: HTTP 404/,
     'does not cache an HTTP error body as a resolved file'
-  );
-  t.equal(gltf.files?.[0], null, 'leaves the file cache empty');
-  t.end();
+  ).rejects.toThrow(/Failed to fetch glTF file missing.bin: HTTP 404/);
+  expect(gltf.files?.[0], 'leaves the file cache empty').toBe(null);
 });
-
-test('findGLTFFileIndex#rejects ambiguous virtual package references', t => {
+test('findGLTFFileIndex#rejects ambiguous virtual package references', () => {
   const gltf = {
     json: {
       asset: {version: '2.1'},
@@ -103,16 +89,11 @@ test('findGLTFFileIndex#rejects ambiguous virtual package references', t => {
     buffers: [],
     files: [null, null]
   } as unknown as GLTFWithBuffers;
-
-  t.throws(
-    () => findGLTFFileIndex(gltf, 'shared.bin'),
-    /package file reference shared.bin is ambiguous/,
-    'requires a unique package mapping'
+  expect(() => findGLTFFileIndex(gltf, 'shared.bin'), 'requires a unique package mapping').toThrow(
+    /package file reference shared.bin is ambiguous/
   );
-  t.end();
 });
-
-test('resolveGLTFFile#requires exactly one file source', async t => {
+test('resolveGLTFFile#requires exactly one file source', async () => {
   const gltf = {
     json: {
       asset: {version: '2.1'},
@@ -127,15 +108,11 @@ test('resolveGLTFFile#requires exactly one file source', async t => {
     buffers: [],
     files: [null]
   } as unknown as GLTFWithBuffers;
-
-  await t.rejects(
+  await expect(
     resolveGLTFFile(gltf, 0, {}, createLoaderContext(globalThis.fetch)),
-    /must define exactly one of uri or bufferView/,
     'rejects conflicting URI and buffer view sources'
-  );
-  t.end();
+  ).rejects.toThrow(/must define exactly one of uri or bufferView/);
 });
-
 /** Create the minimum loader context needed by the file resolver. */
 function createLoaderContext(fetch: typeof globalThis.fetch): LoaderContext {
   return {fetch} as LoaderContext;

--- a/modules/gltf/test/lib/gltf-utils/resolve-url.spec.ts
+++ b/modules/gltf/test/lib/gltf-utils/resolve-url.spec.ts
@@ -2,22 +2,16 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 // @ts-expect-error
 import {resolveUrl} from '@loaders.gl/gltf/lib/gltf-utils/resolve-url';
-
-test('resolveUrl#resolves relative urls against document urls', t => {
-  t.equal(
+test('resolveUrl#resolves relative urls against document urls', () => {
+  expect(
     resolveUrl('buffer.bin', {core: {baseUrl: 'https://example.com/models/model.gltf'}}),
-    'https://example.com/models/buffer.bin',
     'resolves relative URLs against the source document directory'
-  );
-
-  t.equal(
+  ).toBe('https://example.com/models/buffer.bin');
+  expect(
     resolveUrl('buffer.bin', {core: {baseUrl: 'https://example.com/models/'}}),
-    'https://example.com/models/buffer.bin',
     'preserves directory base URLs'
-  );
-
-  t.end();
+  ).toBe('https://example.com/models/buffer.bin');
 });

--- a/modules/gltf/test/lib/utils/encode-utils.spec.ts
+++ b/modules/gltf/test/lib/utils/encode-utils.spec.ts
@@ -2,18 +2,14 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-/* eslint-disable max-len */
-import test from 'test/utils/vitest-tape';
-
+import {expect, test} from 'vitest';
 import {copyPaddedStringToDataView} from '@loaders.gl/loader-utils';
-
-test('encode-utils', t => {
+test('encode-utils', () => {
   const STRING = 'abcdef';
   const byteLength = copyPaddedStringToDataView(null, 0, STRING, 4);
-  t.equals(byteLength, 8); // padded
+  expect(byteLength).toBe(8); // padded
   const arrayBuffer = new ArrayBuffer(byteLength);
   const dataView = new DataView(arrayBuffer);
   const finalLength = copyPaddedStringToDataView(dataView, 0, STRING, 4);
-  t.equals(finalLength, 8);
-  t.end();
+  expect(finalLength).toBe(8);
 });

--- a/modules/gltf/test/meshopt/meshopt-decoder.spec.ts
+++ b/modules/gltf/test/meshopt/meshopt-decoder.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {
   isMeshoptSupported,
   meshoptDecodeVertexBuffer,
@@ -11,13 +11,10 @@ import {
   meshoptDecodeGltfBuffer
   // @ts-expect-error
 } from '@loaders.gl/gltf/meshopt/meshopt-decoder';
-
-test('meshopt#isMeshoptSupported', async t => {
-  t.ok(isMeshoptSupported(), 'meshopt is supported');
-  t.end();
+test('meshopt#isMeshoptSupported', async () => {
+  expect(isMeshoptSupported(), 'meshopt is supported').toBeTruthy();
 });
-
-test('meshopt#decodeVertexBufferV1', async t => {
+test('meshopt#decodeVertexBufferV1', async () => {
   const encoded = new Uint8Array([
     0xa1, 0xee, 0xaa, 0xee, 0x00, 0x4b, 0x4b, 0x4b, 0x00, 0x00, 0x4b, 0x00, 0x00, 0x7d, 0x7d, 0x7d,
     0x00, 0x00, 0x7d, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -28,14 +25,10 @@ test('meshopt#decodeVertexBufferV1', async t => {
     0, 0, 0, 244, 1, 44, 1, 44, 1, 0, 0, 0, 0, 244, 1, 244, 1
   ]);
   const result = new Uint8Array(expected.length);
-
   await meshoptDecodeVertexBuffer(result, 4, 12, encoded);
-
-  t.deepEqual(result, expected, 'decodes version 1 attribute streams');
-  t.end();
+  expect(result, 'decodes version 1 attribute streams').toEqual(expected);
 });
-
-test('meshopt#decodeFilterColor', async t => {
+test('meshopt#decodeFilterColor', async () => {
   const encoded = new Uint8Array([
     0xa0, 0x01, 0x3f, 0x00, 0x00, 0x00, 0x7e, 0x7d, 0x4c, 0x01, 0x3f, 0x00, 0x00, 0x00, 0xfd, 0xfd,
     0xfe, 0x01, 0x3f, 0x00, 0x00, 0x00, 0x83, 0x82, 0x80, 0x01, 0x3f, 0x00, 0x00, 0x00, 0x7d, 0x3f,
@@ -47,14 +40,10 @@ test('meshopt#decodeFilterColor', async t => {
     254, 1, 0, 255, 0, 254, 0, 128, 1, 0, 255, 64, 102, 102, 102, 191
   ]);
   const result = new Uint8Array(expected.length);
-
   await meshoptDecodeGltfBuffer(result, 4, 4, encoded, 'ATTRIBUTES', 'COLOR');
-
-  t.deepEqual(result, expected, 'applies the Khronos COLOR post-decode filter');
-  t.end();
+  expect(result, 'applies the Khronos COLOR post-decode filter').toEqual(expected);
 });
-
-test('meshopt#decodeVertexBuffer', async t => {
+test('meshopt#decodeVertexBuffer', async () => {
   const encoded = new Uint8Array([
     0xa0, 0x01, 0x3f, 0x00, 0x00, 0x00, 0x58, 0x57, 0x58, 0x01, 0x26, 0x00, 0x00, 0x00, 0x01, 0x0c,
     0x00, 0x00, 0x00, 0x58, 0x01, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x3f, 0x00,
@@ -63,96 +52,66 @@ test('meshopt#decodeVertexBuffer', async t => {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00
   ]);
-
   const expected = new Uint8Array([
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 44, 1, 0, 0, 0, 0, 0, 0, 244, 1, 0, 0, 0, 0, 44, 1, 0, 0, 0,
     0, 0, 0, 244, 1, 44, 1, 44, 1, 0, 0, 0, 0, 244, 1, 244, 1
   ]);
-
   const result = new Uint8Array(expected.length);
   await meshoptDecodeVertexBuffer(result, 4, 12, encoded);
-
-  t.deepEqual(result, expected);
-  t.end();
+  expect(result).toEqual(expected);
 });
-
-test('meshopt#decodeIndexBuffer16', async t => {
+test('meshopt#decodeIndexBuffer16', async () => {
   const encoded = new Uint8Array([
     0xe0, 0xf0, 0x10, 0xfe, 0xff, 0xf0, 0x0c, 0xff, 0x02, 0x02, 0x02, 0x00, 0x76, 0x87, 0x56, 0x67,
     0x78, 0xa9, 0x86, 0x65, 0x89, 0x68, 0x98, 0x01, 0x69, 0x00, 0x00
   ]);
-
   const expected = new Uint16Array([0, 1, 2, 2, 1, 3, 4, 6, 5, 7, 8, 9]);
-
   const result = new Uint16Array(expected.length);
   await meshoptDecodeIndexBuffer(new Uint8Array(result.buffer), 12, 2, encoded);
-
-  t.deepEqual(result, expected);
-  t.end();
+  expect(result).toEqual(expected);
 });
-
-test('meshopt#decodeIndexBuffer32', async t => {
+test('meshopt#decodeIndexBuffer32', async () => {
   const encoded = new Uint8Array([
     0xe0, 0xf0, 0x10, 0xfe, 0xff, 0xf0, 0x0c, 0xff, 0x02, 0x02, 0x02, 0x00, 0x76, 0x87, 0x56, 0x67,
     0x78, 0xa9, 0x86, 0x65, 0x89, 0x68, 0x98, 0x01, 0x69, 0x00, 0x00
   ]);
-
   const expected = new Uint32Array([0, 1, 2, 2, 1, 3, 4, 6, 5, 7, 8, 9]);
-
   const result = new Uint32Array(expected.length);
   await meshoptDecodeIndexBuffer(new Uint8Array(result.buffer), 12, 4, encoded);
-
-  t.deepEqual(result, expected);
-  t.end();
+  expect(result).toEqual(expected);
 });
-
-test('meshopt#decodeIndexBufferV1', async t => {
+test('meshopt#decodeIndexBufferV1', async () => {
   const encoded = new Uint8Array([
     0xe1, 0xf0, 0x10, 0xfe, 0x1f, 0x3d, 0x00, 0x0a, 0x00, 0x76, 0x87, 0x56, 0x67, 0x78, 0xa9, 0x86,
     0x65, 0x89, 0x68, 0x98, 0x01, 0x69, 0x00, 0x00
   ]);
-
   const expected = new Uint32Array([0, 1, 2, 2, 1, 3, 0, 1, 2, 2, 1, 5, 2, 1, 4]);
-
   const result = new Uint32Array(expected.length);
   await meshoptDecodeIndexBuffer(new Uint8Array(result.buffer), 15, 4, encoded);
-
-  t.deepEqual(result, expected);
-  t.end();
+  expect(result).toEqual(expected);
 });
-
-test('meshopt#decodeIndexSequence', async t => {
+test('meshopt#decodeIndexSequence', async () => {
   const encoded = new Uint8Array([
     0xd1, 0x00, 0x04, 0xcd, 0x01, 0x04, 0x07, 0x98, 0x1f, 0x00, 0x00, 0x00, 0x00
   ]);
-
   const expected = new Uint32Array([0, 1, 51, 2, 49, 1000]);
-
   const result = new Uint32Array(expected.length);
   await meshoptDecodeIndexSequence(new Uint8Array(result.buffer), 6, 4, encoded);
-
-  t.deepEqual(result, expected);
-  t.end();
+  expect(result).toEqual(expected);
 });
-
-test('meshopt#decodeFilterOct8', async t => {
+test('meshopt#decodeFilterOct8', async () => {
   const encoded = new Uint8Array([
     0xa0, 0x01, 0x07, 0x00, 0x00, 0x00, 0x1e, 0x01, 0x3f, 0x00, 0x00, 0x00, 0x8b, 0x8c, 0xfd, 0x00,
     0x01, 0x26, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x01, 0x7f, 0x00
   ]);
-
   const expected = new Uint8Array([0, 1, 127, 0, 0, 159, 82, 1, 255, 1, 127, 0, 1, 130, 241, 1]);
-
   const result = new Uint8Array(expected.length);
   await meshoptDecodeVertexBuffer(new Uint8Array(result.buffer), 4, 4, encoded, /* filter= */ 1);
-
-  t.deepEqual(result, expected);
-  t.end();
+  expect(result).toEqual(expected);
 });
-
-test('meshopt#decodeFilterOct12', async t => {
+test('meshopt#decodeFilterOct12', async () => {
   const encoded = new Uint8Array([
     0xa0, 0x01, 0x0f, 0x00, 0x00, 0x00, 0x3d, 0x5a, 0x01, 0x0f, 0x00, 0x00, 0x00, 0x0e, 0x0d, 0x01,
     0x3f, 0x00, 0x00, 0x00, 0x9a, 0x99, 0x26, 0x01, 0x3f, 0x00, 0x00, 0x00, 0x0e, 0x0d, 0x0a, 0x00,
@@ -160,19 +119,14 @@ test('meshopt#decodeFilterOct12', async t => {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x01, 0x00, 0xff, 0x07, 0x00, 0x00
   ]);
-
   const expected = new Uint16Array([
     0, 16, 32767, 0, 0, 32621, 3088, 1, 32764, 16, 471, 0, 307, 28541, 16093, 1
   ]);
-
   const result = new Uint16Array(expected.length);
   await meshoptDecodeVertexBuffer(new Uint8Array(result.buffer), 4, 8, encoded, /* filter= */ 1);
-
-  t.deepEqual(result, expected);
-  t.end();
+  expect(result).toEqual(expected);
 });
-
-test('meshopt#decodeFilterQuat12', async t => {
+test('meshopt#decodeFilterQuat12', async () => {
   const encoded = new Uint8Array([
     0xa0, 0x01, 0x0f, 0x00, 0x00, 0x00, 0x3d, 0x5a, 0x01, 0x0f, 0x00, 0x00, 0x00, 0x0e, 0x0d, 0x01,
     0x3f, 0x00, 0x00, 0x00, 0x9a, 0x99, 0x26, 0x01, 0x3f, 0x00, 0x00, 0x00, 0x0e, 0x0d, 0x0a, 0x00,
@@ -180,31 +134,22 @@ test('meshopt#decodeFilterQuat12', async t => {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x01, 0x00, 0x00, 0x00, 0xfc, 0x07
   ]);
-
   const expected = new Uint16Array([
     32767, 0, 11, 0, 0, 25013, 0, 21166, 11, 0, 23504, 22830, 158, 14715, 0, 29277
   ]);
-
   const result = new Uint16Array(expected.length);
   await meshoptDecodeVertexBuffer(new Uint8Array(result.buffer), 4, 8, encoded, /* filter= */ 2);
-
-  t.deepEqual(result, expected);
-  t.end();
+  expect(result).toEqual(expected);
 });
-
-test('meshopt#decodeFilterExp', async t => {
+test('meshopt#decodeFilterExp', async () => {
   const encoded = new Uint8Array([
     0xa0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0xff, 0xf7, 0xff, 0xff, 0x02, 0xff, 0xff, 0x7f,
     0xfe
   ]);
-
   const expected = new Uint32Array([0, 0x3fc00000, 0xc2100000, 0x49fffffe]);
-
   const result = new Uint32Array(expected.length);
   await meshoptDecodeVertexBuffer(new Uint8Array(result.buffer), 1, 16, encoded, /* filter= */ 3);
-
-  t.deepEqual(result, expected);
-  t.end();
+  expect(result).toEqual(expected);
 });

--- a/modules/textures/test/basis-loader.spec.ts
+++ b/modules/textures/test/basis-loader.spec.ts
@@ -2,345 +2,201 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-/* eslint-disable camelcase */
-import test from 'test/utils/vitest-tape';
-
-import {BasisLoader} from '@loaders.gl/textures';
-import {load, setLoaderOptions, isBrowser} from '@loaders.gl/core';
-import {
-  GL_COMPRESSED_RGB_ETC1_WEBGL,
-  GL_COMPRESSED_RGB_PVRTC_4BPPV1_IMG,
-  GL_COMPRESSED_RGB_S3TC_DXT1_EXT,
-  GL_COMPRESSED_RGBA8_ETC2_EAC,
-  GL_COMPRESSED_RGBA_ASTC_4x4_KHR,
-  GL_COMPRESSED_RGBA_BPTC_UNORM_EXT,
-  GL_COMPRESSED_RGBA_PVRTC_4BPPV1_IMG,
-  GL_COMPRESSED_RGBA_S3TC_DXT5_EXT,
-  GL_RGBA8
-} from '../src/lib/gl-extensions';
-import {withBasisTranscodingLock} from '../src/lib/parsers/parse-basis';
-
+import { expect, test } from "vitest";
+import { BasisLoader } from '@loaders.gl/textures';
+import { load, setLoaderOptions, isBrowser } from '@loaders.gl/core';
+import { GL_COMPRESSED_RGB_ETC1_WEBGL, GL_COMPRESSED_RGB_PVRTC_4BPPV1_IMG, GL_COMPRESSED_RGB_S3TC_DXT1_EXT, GL_COMPRESSED_RGBA8_ETC2_EAC, GL_COMPRESSED_RGBA_ASTC_4x4_KHR, GL_COMPRESSED_RGBA_BPTC_UNORM_EXT, GL_COMPRESSED_RGBA_PVRTC_4BPPV1_IMG, GL_COMPRESSED_RGBA_S3TC_DXT5_EXT, GL_RGBA8 } from '../src/lib/gl-extensions';
+import { withBasisTranscodingLock } from '../src/lib/parsers/parse-basis';
 const BASIS_TEST_URL = '@loaders.gl/textures/test/data/alpha3.basis';
 const KTX2_BASIS_TEST_URL = '@loaders.gl/textures/test/data/kodim23.ktx2';
-
 setLoaderOptions({
-  _workerType: 'test',
-  CDN: null
+    _workerType: 'test',
+    CDN: null
 });
-
-test('BasisLoader#imports', (t) => {
-  t.ok(BasisLoader, 'BasisLoader defined');
-  t.end();
+test('BasisLoader#imports', () => {
+    expect(BasisLoader, 'BasisLoader defined').toBeTruthy();
 });
-
-test('BasisLoader#load(URL, worker: false)', async (t) => {
-  const images = await load(BASIS_TEST_URL, BasisLoader, {
-    core: {worker: false}
-  });
-
-  const image = images[0][0];
-
-  t.ok(image, 'image loaded successfully from URL');
-
-  t.equals(image.shape, 'texture-level', 'image shape is correct');
-  t.equals(image.width, 768, 'image width is correct');
-  t.equals(image.height, 512, 'image height is correct');
-  if (isBrowser) {
-    t.equals(image.compressed, true, 'image is compressed');
-    t.equals(image.data.byteLength, 393216, 'image `data.byteLength` is correct');
-  } else {
-    t.equals(image.compressed, false, 'image is compressed');
-    t.equals(image.data.byteLength, 1572864, 'image `data.byteLength` is correct');
-    t.equals(image.textureFormat, 'rgba8unorm', 'image `textureFormat` is correct');
-  }
-
-  t.ok(ArrayBuffer.isView(image.data), 'image data is `ArrayBuffer`');
-
-  t.end();
-});
-
-test('BasisLoader#load(URL, worker: true)', async (t) => {
-  const images = await load(BASIS_TEST_URL, BasisLoader, {worker: true, _nodeWorkers: true});
-
-  const image = images[0][0];
-
-  t.ok(image, 'image loaded successfully from URL');
-
-  t.equals(image.width, 768, 'image width is correct');
-  t.equals(image.height, 512, 'image height is correct');
-  t.equals(image.compressed, false, 'image height is correct');
-  t.equals(image.textureFormat, 'rgba8unorm', 'image `textureFormat` is correct');
-
-  t.ok(ArrayBuffer.isView(image.data), 'image data is `ArrayBuffer`');
-  t.equals(image.data.byteLength, 1572864, 'image `data.byteLength` is correct');
-
-  t.end();
-});
-
-test('BasisLoader#auto-select a target format', async (t) => {
-  // Can't auto-select format in worker because gl context isn't not available on a worker thread
-  const images = await load(BASIS_TEST_URL, BasisLoader, {
-    core: {worker: false},
-    basis: {format: 'auto'}
-  });
-
-  const image = images[0][0];
-
-  if (isBrowser) {
-    t.ok(
-      typeof image.format === 'number' &&
-        [
-          GL_COMPRESSED_RGBA_ASTC_4x4_KHR,
-          GL_COMPRESSED_RGBA_BPTC_UNORM_EXT,
-          GL_COMPRESSED_RGB_S3TC_DXT1_EXT,
-          GL_COMPRESSED_RGBA_S3TC_DXT5_EXT,
-          GL_COMPRESSED_RGBA8_ETC2_EAC,
-          GL_COMPRESSED_RGB_PVRTC_4BPPV1_IMG,
-          GL_COMPRESSED_RGBA_PVRTC_4BPPV1_IMG,
-          GL_COMPRESSED_RGB_ETC1_WEBGL
-        ].includes(image.format),
-      'Browser supports one of GPU textures formats'
-    );
-    t.ok(image.compressed, 'Basis transcodes to compressed texture');
-  } else {
-    t.equals(image.format, GL_RGBA8, 'Basis transcodes alpha textures to RGBA8 in NodeJS');
-    t.notOk(image.compressed, "Basis can't transcode to compressed texture in NodeJS");
-  }
-
-  t.end();
-});
-
-test('BasisLoader#transcode to explicit format', async (t) => {
-  const images = await load(BASIS_TEST_URL, BasisLoader, {
-    worker: true,
-    _nodeWorkers: true,
-    basis: {
-      format: {
-        alpha: 'BC3',
-        noAlpha: 'BC1'
-      }
-    }
-  });
-
-  const image = images[0][0];
-
-  t.equals(
-    image.format,
-    GL_COMPRESSED_RGBA_S3TC_DXT5_EXT,
-    'The texture was transcoded to DXT fromat'
-  );
-  t.equals(image.textureFormat, 'bc3-rgba-unorm', 'The texture exposes the WebGPU format');
-  t.ok(image.compressed, 'Basis transcodes to compressed texture');
-
-  t.end();
-});
-
-test('BasisLoader#auto-selects format from supportedTextureFormats', async (t) => {
-  const images = await load(BASIS_TEST_URL, BasisLoader, {
-    core: {worker: false},
-    basis: {
-      format: 'auto',
-      supportedTextureFormats: ['bc3-rgba-unorm']
-    }
-  });
-
-  const image = images[0][0];
-
-  t.equals(
-    image.format,
-    GL_COMPRESSED_RGBA_S3TC_DXT5_EXT,
-    'BasisLoader selects the matching WebGL format'
-  );
-  t.equals(image.textureFormat, 'bc3-rgba-unorm', 'BasisLoader sets the selected texture format');
-  t.end();
-});
-
-test('BasisLoader#auto-select a decoder format', async (t) => {
-  const images = await load(BASIS_TEST_URL, BasisLoader, {
-    worker: true,
-    basis: {
-      format: 'astc-4x4',
-      containerFormat: 'auto'
-    }
-  });
-  const image = images[0][0];
-  t.ok(image, 'Transcode .basis');
-
-  const ktx2Images = await load(KTX2_BASIS_TEST_URL, BasisLoader, {
-    worker: true,
-    _nodeWorkers: true,
-    basis: {
-      format: 'astc-4x4',
-      containerFormat: 'auto'
-    }
-  });
-  const ktx2Image = ktx2Images[0];
-  t.ok(ktx2Image, 'Transcode .ktx2');
-  t.is(ktx2Image.length, 10, 'Transcode .ktx2 mips');
-
-  t.end();
-});
-
-test('BasisLoader#uses injected transcoder modules', async (t) => {
-  class FakeBasisFile {
-    constructor(data: Uint8Array) {
-      t.equals(data.byteLength, 4, 'forwards the provided payload to the injected BasisFile')
-    }
-
-    startTranscoding() {
-      return true
-    }
-
-    getNumImages() {
-      return 1
-    }
-
-    getNumLevels() {
-      return 1
-    }
-
-    getImageWidth() {
-      return 2
-    }
-
-    getImageHeight() {
-      return 2
-    }
-
-    getHasAlpha() {
-      return false
-    }
-
-    getBasisTexFormat() {
-      return 0
-    }
-
-    isHDR() {
-      return false
-    }
-
-    getBlockWidth() {
-      return 4
-    }
-
-    getBlockHeight() {
-      return 4
-    }
-
-    getImageTranscodedSizeInBytes() {
-      return 8
-    }
-
-    transcodeImage(decodedData: Uint8Array) {
-      decodedData.set([1, 2, 3, 4, 5, 6, 7, 8])
-      return true
-    }
-
-    close() {}
-
-    delete() {}
-  }
-
-  const images = await load(new Uint8Array([1, 2, 3, 4]).buffer, BasisLoader, {
-    core: {worker: false},
-    basis: {
-      format: 'rgb565',
-      containerFormat: 'basis'
-    },
-    modules: {
-      basis: {BasisFile: FakeBasisFile}
-    }
-  })
-
-  const image = images[0][0]
-
-  t.equals(image.width, 2, 'uses the injected BasisFile implementation')
-  t.equals(image.height, 2, 'returns the injected texture height')
-  t.equals(image.data.byteLength, 8, 'returns the injected transcoded payload size')
-  t.end()
-})
-
-test('BasisLoader#serializes Basis transcoding work', async (t) => {
-  const events: string[] = [];
-  let activeTranscodes = 0;
-
-  const runTranscode = async (label: string, delayMs: number) =>
-    await withBasisTranscodingLock(async () => {
-      events.push(`${label}:start`);
-      activeTranscodes++;
-      t.equals(activeTranscodes, 1, `${label} runs with exclusive access`);
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
-      activeTranscodes--;
-      events.push(`${label}:end`);
-      return label;
+test('BasisLoader#load(URL, worker: false)', async () => {
+    const images = await load(BASIS_TEST_URL, BasisLoader, {
+        core: { worker: false }
     });
-
-  const [first, second] = await Promise.all([runTranscode('first', 20), runTranscode('second', 0)]);
-
-  t.equals(first, 'first', 'first transcode resolves');
-  t.equals(second, 'second', 'second transcode resolves');
-  t.deepEqual(
-    events,
-    ['first:start', 'first:end', 'second:start', 'second:end'],
-    'concurrent requests are serialized'
-  );
-  t.end();
-})
-
-
-// test('BasisLoader#formats', async t => {
-//   for (const testCase of TEST_CASES) {
-//     await testLoadImage(t, testCase);
-//   }
-//   t.end();
-// });
-
-/*
-test('loadImageTexture#worker', t => {
-  if (typeof Worker === 'undefined') {
-    t.comment('loadImageTexture only works under browser');
-    t.end();
-    return;
-  }
-
-  const worker = new LoadImageWorker();
-  let testIndex = 0;
-
-  const runTest = index => {
-    const testCase = TEST_CASES[index];
-    if (!testCase) {
-      t.end();
-      return;
+    const image = images[0][0];
+    expect(image, 'image loaded successfully from URL').toBeTruthy();
+    expect(image.shape, 'image shape is correct').toBe('texture-level');
+    expect(image.width, 'image width is correct').toBe(768);
+    expect(image.height, 'image height is correct').toBe(512);
+    if (isBrowser) {
+        expect(image.compressed, 'image is compressed').toBe(true);
+        expect(image.data.byteLength, 'image `data.byteLength` is correct').toBe(393216);
     }
-    if (testCase.worker === false) {
-      // the current loader does not support loading from dataURL in a worker
-      runTest(testIndex++);
-      return;
+    else {
+        expect(image.compressed, 'image is compressed').toBe(false);
+        expect(image.data.byteLength, 'image `data.byteLength` is correct').toBe(1572864);
+        expect(image.textureFormat, 'image `textureFormat` is correct').toBe('rgba8unorm');
     }
-
-    const {title, width, height} = testCase;
-    // t.comment(title);
-
-    let {url} = testCase;
-    url = url.startsWith('data:') ? url : resolvePath(CONTENT_BASE + url);
-
-    worker.onmessage = ({data}) => {
-      if (data.error) {
-        t.fail(data.error);
-      } else {
-        t.ok(data.image, 'loadImageTexture loaded data from url');
-        t.ok(
-          data.image.width === width && data.image.height === height,
-          'loaded image has correct content'
-        );
-      }
-
-      runTest(testIndex++);
-    };
-
-    worker.postMessage(url);
-  };
-
-  runTest(testIndex++);
+    expect(ArrayBuffer.isView(image.data), 'image data is `ArrayBuffer`').toBeTruthy();
 });
-*/
+test('BasisLoader#load(URL, worker: true)', async () => {
+    const images = await load(BASIS_TEST_URL, BasisLoader, { worker: true, _nodeWorkers: true });
+    const image = images[0][0];
+    expect(image, 'image loaded successfully from URL').toBeTruthy();
+    expect(image.width, 'image width is correct').toBe(768);
+    expect(image.height, 'image height is correct').toBe(512);
+    expect(image.compressed, 'image height is correct').toBe(false);
+    expect(image.textureFormat, 'image `textureFormat` is correct').toBe('rgba8unorm');
+    expect(ArrayBuffer.isView(image.data), 'image data is `ArrayBuffer`').toBeTruthy();
+    expect(image.data.byteLength, 'image `data.byteLength` is correct').toBe(1572864);
+});
+test('BasisLoader#auto-select a target format', async () => {
+    // Can't auto-select format in worker because gl context isn't not available on a worker thread
+    const images = await load(BASIS_TEST_URL, BasisLoader, {
+        core: { worker: false },
+        basis: { format: 'auto' }
+    });
+    const image = images[0][0];
+    if (isBrowser) {
+        expect(typeof image.format === 'number' &&
+            [
+                GL_COMPRESSED_RGBA_ASTC_4x4_KHR,
+                GL_COMPRESSED_RGBA_BPTC_UNORM_EXT,
+                GL_COMPRESSED_RGB_S3TC_DXT1_EXT,
+                GL_COMPRESSED_RGBA_S3TC_DXT5_EXT,
+                GL_COMPRESSED_RGBA8_ETC2_EAC,
+                GL_COMPRESSED_RGB_PVRTC_4BPPV1_IMG,
+                GL_COMPRESSED_RGBA_PVRTC_4BPPV1_IMG,
+                GL_COMPRESSED_RGB_ETC1_WEBGL
+            ].includes(image.format), 'Browser supports one of GPU textures formats').toBeTruthy();
+        expect(image.compressed, 'Basis transcodes to compressed texture').toBeTruthy();
+    }
+    else {
+        expect(image.format, 'Basis transcodes alpha textures to RGBA8 in NodeJS').toBe(GL_RGBA8);
+        expect(image.compressed, "Basis can't transcode to compressed texture in NodeJS").toBeFalsy();
+    }
+});
+test('BasisLoader#transcode to explicit format', async () => {
+    const images = await load(BASIS_TEST_URL, BasisLoader, {
+        worker: true,
+        _nodeWorkers: true,
+        basis: {
+            format: {
+                alpha: 'BC3',
+                noAlpha: 'BC1'
+            }
+        }
+    });
+    const image = images[0][0];
+    expect(image.format, 'The texture was transcoded to DXT fromat').toBe(GL_COMPRESSED_RGBA_S3TC_DXT5_EXT);
+    expect(image.textureFormat, 'The texture exposes the WebGPU format').toBe('bc3-rgba-unorm');
+    expect(image.compressed, 'Basis transcodes to compressed texture').toBeTruthy();
+});
+test('BasisLoader#auto-selects format from supportedTextureFormats', async () => {
+    const images = await load(BASIS_TEST_URL, BasisLoader, {
+        core: { worker: false },
+        basis: {
+            format: 'auto',
+            supportedTextureFormats: ['bc3-rgba-unorm']
+        }
+    });
+    const image = images[0][0];
+    expect(image.format, 'BasisLoader selects the matching WebGL format').toBe(GL_COMPRESSED_RGBA_S3TC_DXT5_EXT);
+    expect(image.textureFormat, 'BasisLoader sets the selected texture format').toBe('bc3-rgba-unorm');
+});
+test('BasisLoader#auto-select a decoder format', async () => {
+    const images = await load(BASIS_TEST_URL, BasisLoader, {
+        worker: true,
+        basis: {
+            format: 'astc-4x4',
+            containerFormat: 'auto'
+        }
+    });
+    const image = images[0][0];
+    expect(image, 'Transcode .basis').toBeTruthy();
+    const ktx2Images = await load(KTX2_BASIS_TEST_URL, BasisLoader, {
+        worker: true,
+        _nodeWorkers: true,
+        basis: {
+            format: 'astc-4x4',
+            containerFormat: 'auto'
+        }
+    });
+    const ktx2Image = ktx2Images[0];
+    expect(ktx2Image, 'Transcode .ktx2').toBeTruthy();
+    expect(ktx2Image.length, 'Transcode .ktx2 mips').toBe(10);
+});
+test('BasisLoader#uses injected transcoder modules', async () => {
+    class FakeBasisFile {
+        constructor(data: Uint8Array) {
+            expect(data.byteLength, 'forwards the provided payload to the injected BasisFile').toBe(4);
+        }
+        startTranscoding() {
+            return true;
+        }
+        getNumImages() {
+            return 1;
+        }
+        getNumLevels() {
+            return 1;
+        }
+        getImageWidth() {
+            return 2;
+        }
+        getImageHeight() {
+            return 2;
+        }
+        getHasAlpha() {
+            return false;
+        }
+        getBasisTexFormat() {
+            return 0;
+        }
+        isHDR() {
+            return false;
+        }
+        getBlockWidth() {
+            return 4;
+        }
+        getBlockHeight() {
+            return 4;
+        }
+        getImageTranscodedSizeInBytes() {
+            return 8;
+        }
+        transcodeImage(decodedData: Uint8Array) {
+            decodedData.set([1, 2, 3, 4, 5, 6, 7, 8]);
+            return true;
+        }
+        close() { }
+        delete() { }
+    }
+    const images = await load(new Uint8Array([1, 2, 3, 4]).buffer, BasisLoader, {
+        core: { worker: false },
+        basis: {
+            format: 'rgb565',
+            containerFormat: 'basis'
+        },
+        modules: {
+            basis: { BasisFile: FakeBasisFile }
+        }
+    });
+    const image = images[0][0];
+    expect(image.width, 'uses the injected BasisFile implementation').toBe(2);
+    expect(image.height, 'returns the injected texture height').toBe(2);
+    expect(image.data.byteLength, 'returns the injected transcoded payload size').toBe(8);
+});
+test('BasisLoader#serializes Basis transcoding work', async () => {
+    const events: string[] = [];
+    let activeTranscodes = 0;
+    const runTranscode = async (label: string, delayMs: number) => await withBasisTranscodingLock(async () => {
+        events.push(`${label}:start`);
+        activeTranscodes++;
+        expect(activeTranscodes, `${label} runs with exclusive access`).toBe(1);
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        activeTranscodes--;
+        events.push(`${label}:end`);
+        return label;
+    });
+    const [first, second] = await Promise.all([runTranscode('first', 20), runTranscode('second', 0)]);
+    expect(first, 'first transcode resolves').toBe('first');
+    expect(second, 'second transcode resolves').toBe('second');
+    expect(events, 'concurrent requests are serialized').toEqual(['first:start', 'first:end', 'second:start', 'second:end']);
+});

--- a/modules/textures/test/compressed-texture-loader.spec.ts
+++ b/modules/textures/test/compressed-texture-loader.spec.ts
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
-import {expect, test as vitestTest} from 'vitest';
-
+import {expect, test} from 'vitest';
 import {CompressedTextureLoader} from '@loaders.gl/textures';
 import {load, setLoaderOptions, isBrowser} from '@loaders.gl/core';
 import {
@@ -13,146 +11,111 @@ import {
   GL_COMPRESSED_RGBA_S3TC_DXT5_EXT,
   GL_COMPRESSED_SRGB_S3TC_DXT1_EXT
 } from '../src/lib/gl-extensions';
-
 const KTX_URL = '@loaders.gl/textures/test/data/test_etc1s.ktx2';
 const KTX2_URL = '@loaders.gl/textures/test/data/kodim23.ktx2';
 const DDS_URL = '@loaders.gl/textures/test/data/shannon-dxt5.dds';
 const PVR_URL = '@loaders.gl/textures/test/data/shannon-etc1.pvr';
-
 setLoaderOptions({
   _workerType: 'test'
 });
-
-test('CompressedTextureLoader#imports', t => {
-  t.ok(CompressedTextureLoader, 'CompressedTextureLoader defined');
-  t.end();
+test('CompressedTextureLoader#imports', () => {
+  expect(CompressedTextureLoader, 'CompressedTextureLoader defined').toBeTruthy();
 });
-
-test('CompressedTextureLoader#KTX', async t => {
+test('CompressedTextureLoader#KTX', async () => {
   const texture = await load(KTX_URL, CompressedTextureLoader);
-  t.ok(texture, 'KTX container loaded OK');
-  t.end();
+  expect(texture, 'KTX container loaded OK').toBeTruthy();
 });
-
-test('CompressedTextureLoader#KTX2 with BasisLoader', async t => {
+test('CompressedTextureLoader#KTX2 with BasisLoader', async () => {
   const texture = await load(KTX2_URL, CompressedTextureLoader, {
     'compressed-texture': {useBasis: true},
     basis: {format: 'bc1'}
   });
-  t.ok(texture, 'KTX2 container loaded OK');
-  t.equals(texture[0].format, GL_COMPRESSED_SRGB_S3TC_DXT1_EXT, 'KTX2 WebGL format is set');
-  t.equals(texture[0].textureFormat, 'bc1-rgb-unorm-srgb-webgl', 'KTX2 texture format is set');
-  t.end();
+  expect(texture, 'KTX2 container loaded OK').toBeTruthy();
+  expect(texture[0].format, 'KTX2 WebGL format is set').toBe(GL_COMPRESSED_SRGB_S3TC_DXT1_EXT);
+  expect(texture[0].textureFormat, 'KTX2 texture format is set').toBe('bc1-rgb-unorm-srgb-webgl');
 });
-
-test('CompressedTextureLoader#DDS', async t => {
+test('CompressedTextureLoader#DDS', async () => {
   const texture = await load(DDS_URL, CompressedTextureLoader);
-  t.ok(texture, 'DDS container loaded OK');
-  t.equals(texture[0].format, GL_COMPRESSED_RGBA_S3TC_DXT5_EXT, 'DDS WebGL format is set');
-  t.equals(texture[0].textureFormat, 'bc3-rgba-unorm', 'DDS texture format is set');
-  t.end();
+  expect(texture, 'DDS container loaded OK').toBeTruthy();
+  expect(texture[0].format, 'DDS WebGL format is set').toBe(GL_COMPRESSED_RGBA_S3TC_DXT5_EXT);
+  expect(texture[0].textureFormat, 'DDS texture format is set').toBe('bc3-rgba-unorm');
 });
-
-test('CompressedTextureLoader#PVR', async t => {
+test('CompressedTextureLoader#PVR', async () => {
   const texture = await load(PVR_URL, CompressedTextureLoader);
-  t.ok(texture, 'PVR container loaded OK');
-  t.equals(texture[0].format, GL_COMPRESSED_RGB_ETC1_WEBGL, 'PVR WebGL format is set');
-  t.equals(texture[0].textureFormat, 'etc1-rgb-unorm-webgl', 'PVR texture format is set');
-  t.end();
+  expect(texture, 'PVR container loaded OK').toBeTruthy();
+  expect(texture[0].format, 'PVR WebGL format is set').toBe(GL_COMPRESSED_RGB_ETC1_WEBGL);
+  expect(texture[0].textureFormat, 'PVR texture format is set').toBe('etc1-rgb-unorm-webgl');
 });
-
-vitestTest(
-  'CompressedTextureLoader#uses injected transcoder modules for KTX2 Basis textures',
-  async () => {
-    if (isBrowser) {
-      return;
-    }
-    class FakeKTX2File {
-      constructor(data: Uint8Array) {
-        expect(data.byteLength).toBe(4);
-      }
-
-      startTranscoding() {
-        return true;
-      }
-
-      isValid() {
-        return true;
-      }
-
-      getHeader() {
-        return {pixelDepth: 0};
-      }
-
-      getLayers() {
-        return 0;
-      }
-
-      getFaces() {
-        return 1;
-      }
-
-      getBasisTexFormat() {
-        return 0;
-      }
-
-      isHDR() {
-        return false;
-      }
-
-      isSRGB() {
-        return false;
-      }
-
-      getHasAlpha() {
-        return false;
-      }
-
-      getBlockWidth() {
-        return 4;
-      }
-
-      getBlockHeight() {
-        return 4;
-      }
-
-      getLevels() {
-        return 1;
-      }
-
-      getImageLevelInfo() {
-        return {
-          alphaFlag: false,
-          height: 2,
-          width: 2
-        };
-      }
-
-      getImageTranscodedSizeInBytes() {
-        return 8;
-      }
-
-      transcodeImage(decodedData: Uint8Array) {
-        decodedData.set([1, 2, 3, 4, 5, 6, 7, 8]);
-        return true;
-      }
-
-      close() {}
-
-      delete() {}
-    }
-
-    const texture = await load(new Uint8Array([1, 2, 3, 4]).buffer, CompressedTextureLoader, {
-      'compressed-texture': {useBasis: true},
-      basis: {format: 'bc1'},
-      modules: {
-        basis: {KTX2File: FakeKTX2File}
-      }
-    });
-
-    expect(texture[0].width).toBe(2);
-    expect(texture[0].height).toBe(2);
-    expect(texture[0].data.byteLength).toBe(8);
-    expect(texture[0].format).toBe(GL_COMPRESSED_RGB_S3TC_DXT1_EXT);
+test('CompressedTextureLoader#uses injected transcoder modules for KTX2 Basis textures', async () => {
+  if (isBrowser) {
+    return;
   }
-);
+  class FakeKTX2File {
+    constructor(data: Uint8Array) {
+      expect(data.byteLength).toBe(4);
+    }
+    startTranscoding() {
+      return true;
+    }
+    isValid() {
+      return true;
+    }
+    getHeader() {
+      return {pixelDepth: 0};
+    }
+    getLayers() {
+      return 0;
+    }
+    getFaces() {
+      return 1;
+    }
+    getBasisTexFormat() {
+      return 0;
+    }
+    isHDR() {
+      return false;
+    }
+    isSRGB() {
+      return false;
+    }
+    getHasAlpha() {
+      return false;
+    }
+    getBlockWidth() {
+      return 4;
+    }
+    getBlockHeight() {
+      return 4;
+    }
+    getLevels() {
+      return 1;
+    }
+    getImageLevelInfo() {
+      return {
+        alphaFlag: false,
+        height: 2,
+        width: 2
+      };
+    }
+    getImageTranscodedSizeInBytes() {
+      return 8;
+    }
+    transcodeImage(decodedData: Uint8Array) {
+      decodedData.set([1, 2, 3, 4, 5, 6, 7, 8]);
+      return true;
+    }
+    close() {}
+    delete() {}
+  }
+  const texture = await load(new Uint8Array([1, 2, 3, 4]).buffer, CompressedTextureLoader, {
+    'compressed-texture': {useBasis: true},
+    basis: {format: 'bc1'},
+    modules: {
+      basis: {KTX2File: FakeKTX2File}
+    }
+  });
+  expect(texture[0].width).toBe(2);
+  expect(texture[0].height).toBe(2);
+  expect(texture[0].data.byteLength).toBe(8);
+  expect(texture[0].format).toBe(GL_COMPRESSED_RGB_S3TC_DXT1_EXT);
+});

--- a/modules/textures/test/compressed-texture-writer.spec.ts
+++ b/modules/textures/test/compressed-texture-writer.spec.ts
@@ -2,16 +2,17 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {encodeURLtoURL, isBrowser} from '@loaders.gl/core';
 import {CompressedTextureWriter} from '@loaders.gl/textures';
 import {createTextureEncoder, loadTextureCompressorPack} from '../src/lib/encoders/encode-texture';
-
 export const IMAGE_URL = '@loaders.gl/images/test/data/img1-preview.png';
-
 /** Returns whether an error specifically reports that texture-compressor is missing. */
 function isTextureCompressorMissing(error: unknown): boolean {
-  const moduleError = error as {code?: string; message?: string};
+  const moduleError = error as {
+    code?: string;
+    message?: string;
+  };
   const isMissingModuleError =
     moduleError.code === 'MODULE_NOT_FOUND' || moduleError.code === 'ERR_MODULE_NOT_FOUND';
   const message = moduleError.message || '';
@@ -25,7 +26,6 @@ function isTextureCompressorMissing(error: unknown): boolean {
     (isMissingModuleError && nodeErrorNamesTextureCompressor) || viteErrorNamesTextureCompressor
   );
 }
-
 /** Returns whether the optional texture-compressor CLI is available locally. */
 async function isTextureCompressorAvailable(): Promise<boolean> {
   try {
@@ -38,82 +38,63 @@ async function isTextureCompressorAvailable(): Promise<boolean> {
     throw error;
   }
 }
-
-test('loadTextureCompressorPack resolves supported module exports', async t => {
+test('loadTextureCompressorPack resolves supported module exports', async () => {
   const directPack = async () => {};
   const defaultPack = async () => {};
-
-  t.equal(
+  expect(
     await loadTextureCompressorPack(async () => ({pack: directPack})),
-    directPack,
     'resolves a named pack export'
-  );
-  t.equal(
+  ).toBe(directPack);
+  expect(
     await loadTextureCompressorPack(async () => ({default: {pack: defaultPack}})),
-    defaultPack,
     'resolves a default pack export'
-  );
-  await t.rejects(
+  ).toBe(defaultPack);
+  await expect(
     loadTextureCompressorPack(async () => ({})),
-    /does not export pack\(\)/,
     'rejects an invalid module export'
-  );
-  t.end();
+  ).rejects.toThrow(/does not export pack\(\)/);
 });
-
-test('createTextureEncoder passes compression options to texture-compressor', async t => {
+test('createTextureEncoder passes compression options to texture-compressor', async () => {
   let receivedOptions: Record<string, unknown> | undefined;
   const encodeTexture = createTextureEncoder(async () => async options => {
     receivedOptions = options;
   });
-
   const outputUrl = await encodeTexture('input.png', 'output.ktx');
-
-  t.equal(outputUrl, 'output.ktx', 'returns the output URL');
-  t.deepEqual(
-    receivedOptions,
-    {
-      type: 's3tc',
-      compression: 'DXT1',
-      quality: 'normal',
-      input: 'input.png',
-      output: 'output.ktx'
-    },
-    'passes the expected compression options'
-  );
-  t.end();
+  expect(outputUrl, 'returns the output URL').toBe('output.ktx');
+  expect(receivedOptions, 'passes the expected compression options').toEqual({
+    type: 's3tc',
+    compression: 'DXT1',
+    quality: 'normal',
+    input: 'input.png',
+    output: 'output.ktx'
+  });
 });
-
-test('isTextureCompressorMissing only accepts a missing optional peer', t => {
-  t.ok(
+test('isTextureCompressorMissing only accepts a missing optional peer', () => {
+  expect(
     isTextureCompressorMissing({
       code: 'ERR_MODULE_NOT_FOUND',
       message: "Cannot find package 'texture-compressor' imported from encode-texture.ts"
     }),
     'recognizes the missing optional peer'
-  );
-  t.notOk(
+  ).toBeTruthy();
+  expect(
     isTextureCompressorMissing({
       code: 'MODULE_NOT_FOUND',
       message:
         "Cannot find module 'missing-transitive-package'\nRequire stack:\n- node_modules/texture-compressor/index.js"
     }),
     'does not hide a missing transitive dependency'
-  );
-  t.end();
+  ).toBeFalsy();
 });
-
-test('CompressedTextureWriter#write-and-read-image', async t => {
+test('CompressedTextureWriter#write-and-read-image', async () => {
   if (isBrowser) {
-    t.comment('CompressedTextureWriter only supported on Node.js');
-    t.end();
+    console.log('CompressedTextureWriter only supported on Node.js');
     return;
   }
   // The `texture-compressor` CLI is an optional, application-supplied prerequisite,
   // so skip (rather than fail) when it is not installed in this environment.
   if (!(await isTextureCompressorAvailable())) {
-    t.comment('texture-compressor CLI not available locally, skipping');
-    t.end();
+    console.log('texture-compressor CLI not available locally, skipping');
     return;
   }
   const outputFilename = await encodeURLtoURL(
@@ -122,6 +103,5 @@ test('CompressedTextureWriter#write-and-read-image', async t => {
     CompressedTextureWriter,
     {}
   );
-  t.ok(outputFilename, 'a filename was returned');
-  t.end();
+  expect(outputFilename, 'a filename was returned').toBeTruthy();
 });

--- a/modules/textures/test/crunch-loader.spec.ts
+++ b/modules/textures/test/crunch-loader.spec.ts
@@ -2,30 +2,23 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
-
+import {expect, test} from 'vitest';
 import {isBrowser, load, setLoaderOptions} from '@loaders.gl/core';
 import {CrunchWorkerLoader} from '@loaders.gl/textures';
-
 const CRUNCH_URL = '@loaders.gl/textures/test/data/shannon-dxt1.crn';
-
 setLoaderOptions({
   _workerType: 'test',
   CDN: null
 });
-
-test('CrunchWorkerLoader#imports', t => {
-  t.ok(CrunchWorkerLoader, 'CrunchWorkerLoader defined');
-  t.end();
+test('CrunchWorkerLoader#imports', () => {
+  expect(CrunchWorkerLoader, 'CrunchWorkerLoader defined').toBeTruthy();
 });
-
-test.skip('CrunchWorkerLoader#load', async t => {
+test.skip('CrunchWorkerLoader#load', async () => {
   // Decoder lib `src/libs/crunch.js` works only in browser
   if (isBrowser) {
     const texture = await load(CRUNCH_URL, CrunchWorkerLoader, {
       core: {worker: false}
     });
-    t.ok(texture, 'Crunch container loaded OK');
+    expect(texture, 'Crunch container loaded OK').toBeTruthy();
   }
-  t.end();
 });

--- a/modules/textures/test/ktx2-basis-universal-texture-writer.spec.ts
+++ b/modules/textures/test/ktx2-basis-universal-texture-writer.spec.ts
@@ -2,60 +2,46 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {load, encode} from '@loaders.gl/core';
 import {ImageBitmapLoader, getImageData} from '@loaders.gl/images';
 import {BasisLoader, KTX2BasisWriter, KTX2BasisWriterWorker} from '@loaders.gl/textures';
 import {isBrowser, processOnWorker, WorkerFarm} from '@loaders.gl/worker-utils';
-
 const shannonPNG = '@loaders.gl/textures/test/data/shannon.png';
 const shannonJPG = '@loaders.gl/textures/test/data/shannon.jpg';
-
-test('KTX2BasisUniversalTextureWriter#Should encode PNG', async t => {
+test('KTX2BasisUniversalTextureWriter#Should encode PNG', async () => {
   const image = getImageData(await load(shannonPNG, ImageBitmapLoader));
   const encodedData = await encode(image, KTX2BasisWriter);
   const transcodedImages = await load(encodedData, BasisLoader);
   const transcodedImage = transcodedImages[0][0];
-
-  t.ok(encodedData);
-  t.ok(transcodedImage);
-  t.equal(image.height, transcodedImage.height);
-  t.equal(image.width, transcodedImage.width);
-
-  t.end();
+  expect(encodedData).toBeTruthy();
+  expect(transcodedImage).toBeTruthy();
+  expect(image.height).toBe(transcodedImage.height);
+  expect(image.width).toBe(transcodedImage.width);
 });
-
-test('KTX2BasisUniversalTextureWriter # Worker # Should encode PNG', async t => {
+test('KTX2BasisUniversalTextureWriter # Worker # Should encode PNG', async () => {
   const image = getImageData(await load(shannonPNG, ImageBitmapLoader));
   const encodedData = await processOnWorker(KTX2BasisWriterWorker, image, {
     _workerType: 'test'
   });
   const transcodedImages = await load(encodedData, BasisLoader);
   const transcodedImage = transcodedImages[0][0];
-
-  t.ok(encodedData);
-  t.ok(transcodedImage);
-  t.equal(image.height, transcodedImage.height);
-  t.equal(image.width, transcodedImage.width);
-
+  expect(encodedData).toBeTruthy();
+  expect(transcodedImage).toBeTruthy();
+  expect(image.height).toBe(transcodedImage.height);
+  expect(image.width).toBe(transcodedImage.width);
   if (!isBrowser) {
     const workerFarm = WorkerFarm.getWorkerFarm({});
     workerFarm.destroy();
   }
-
-  t.end();
 });
-
-test('KTX2BasisUniversalTextureWriter#Should encode JPG', async t => {
+test('KTX2BasisUniversalTextureWriter#Should encode JPG', async () => {
   const image = getImageData(await load(shannonJPG, ImageBitmapLoader));
   const encodedData = await encode(image, KTX2BasisWriter);
   const transcodedImages = await load(encodedData, BasisLoader);
   const transcodedImage = transcodedImages[0][0];
-
-  t.ok(encodedData);
-  t.ok(transcodedImage);
-  t.equal(image.height, transcodedImage.height);
-  t.equal(image.width, transcodedImage.width);
-
-  t.end();
+  expect(encodedData).toBeTruthy();
+  expect(transcodedImage).toBeTruthy();
+  expect(image.height).toBe(transcodedImage.height);
+  expect(image.width).toBe(transcodedImage.width);
 });

--- a/modules/textures/test/lib/parsers/parse-dds.spec.ts
+++ b/modules/textures/test/lib/parsers/parse-dds.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {fetchFile} from '@loaders.gl/core';
 import {parseDDS} from '../../../src/lib/parsers/parse-dds';
 import {
@@ -14,7 +14,6 @@ import {
   GL_COMPRESSED_RGBA_S3TC_DXT5_EXT
 } from '../../../src/lib/gl-extensions';
 import {checkCompressedTexture} from '../../test-utils/check-compressed-texture';
-
 const TEST_CASES = [
   {
     url: '@loaders.gl/textures/test/data/shannon-dxt1.dds',
@@ -47,13 +46,11 @@ const TEST_CASES = [
     textureFormat: 'atc-rgbai-unorm-webgl'
   }
 ];
-
-test('CompressedTextureLoader#dds', async t => {
+test('CompressedTextureLoader#dds', async () => {
   for (const testCase of TEST_CASES) {
     const response = await fetchFile(testCase.url);
     const data = await response.arrayBuffer();
     const result = parseDDS(data);
-    checkCompressedTexture(t, result, testCase);
+    checkCompressedTexture(result, testCase);
   }
-  t.end();
 });

--- a/modules/textures/test/lib/parsers/parse-hdr.spec.ts
+++ b/modules/textures/test/lib/parsers/parse-hdr.spec.ts
@@ -2,30 +2,25 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
-
+import {expect, test} from 'vitest';
 import {GL_RGBA32F} from '../../../src/lib/gl-extensions';
 import {isHDR, parseHDR} from '../../../src/lib/parsers/parse-hdr';
-
-test('parseHDR#parses Radiance RLE data', t => {
+test('parseHDR#parses Radiance RLE data', () => {
   const texture = parseHDR(createRLEHDRBuffer('#?RADIANCE'));
   const level = texture.data[0];
   const data = level.data as Float32Array;
-
-  t.equal(texture.shape, 'texture', 'returns a texture payload');
-  t.equal(texture.type, '2d', 'returns a 2d texture');
-  t.equal(texture.data.length, 1, 'returns a single texture level');
-  t.equal(level.width, 8, 'width is parsed');
-  t.equal(level.height, 2, 'height is parsed');
-  t.equal(level.textureFormat, 'rgba32float', 'texture format is set');
-  t.equal(level.format, GL_RGBA32F, 'WebGL format is set');
-  t.ok(level.data instanceof Float32Array, 'pixel data is float32');
-  t.equal(data[0], 2, 'first pixel red is decoded from RGBE');
-  t.equal(data[3], 1, 'alpha is synthesized');
-  t.end();
+  expect(texture.shape, 'returns a texture payload').toBe('texture');
+  expect(texture.type, 'returns a 2d texture').toBe('2d');
+  expect(texture.data.length, 'returns a single texture level').toBe(1);
+  expect(level.width, 'width is parsed').toBe(8);
+  expect(level.height, 'height is parsed').toBe(2);
+  expect(level.textureFormat, 'texture format is set').toBe('rgba32float');
+  expect(level.format, 'WebGL format is set').toBe(GL_RGBA32F);
+  expect(level.data instanceof Float32Array, 'pixel data is float32').toBeTruthy();
+  expect(data[0], 'first pixel red is decoded from RGBE').toBe(2);
+  expect(data[3], 'alpha is synthesized').toBe(1);
 });
-
-test('parseHDR#parses application-facing metadata', t => {
+test('parseHDR#parses application-facing metadata', () => {
   const texture = parseHDR(
     createFlatHDRBuffer('#?RADIANCE', [
       'EXPOSURE=2',
@@ -37,109 +32,111 @@ test('parseHDR#parses application-facing metadata', t => {
       'VIEW=-vtv 0 0 1 0 1 0 45 45'
     ])
   );
-
-  t.deepEqual(
-    texture.metadata,
-    {
-      exposure: 2,
-      gamma: 1.8,
-      colorCorrection: [1, 0.5, 2],
-      pixelAspectRatio: 1.5,
-      primaries: [0.64, 0.33, 0.29, 0.6, 0.15, 0.06, 0.333, 0.333],
-      software: 'unit-test',
-      view: '-vtv 0 0 1 0 1 0 45 45'
-    },
-    'returns application-facing metadata'
-  );
-  t.end();
+  expect(texture.metadata, 'returns application-facing metadata').toEqual({
+    exposure: 2,
+    gamma: 1.8,
+    colorCorrection: [1, 0.5, 2],
+    pixelAspectRatio: 1.5,
+    primaries: [0.64, 0.33, 0.29, 0.6, 0.15, 0.06, 0.333, 0.333],
+    software: 'unit-test',
+    view: '-vtv 0 0 1 0 1 0 45 45'
+  });
 });
-
-test('parseHDR#parses RGBE flat data', t => {
+test('parseHDR#parses RGBE flat data', () => {
   const texture = parseHDR(createFlatHDRBuffer('#?RGBE'));
   const data = texture.data[0].data as Float32Array;
-
-  t.equal(texture.data[0].width, 2, 'width is parsed');
-  t.equal(texture.data[0].height, 1, 'height is parsed');
-  t.ok(Math.abs(data[0] - 128 * (2 / 255)) < 1e-6, 'flat red channel is decoded');
-  t.ok(Math.abs(data[1] - 64 * (2 / 255)) < 1e-6, 'flat green channel is decoded');
-  t.ok(Math.abs(data[2] - 32 * (2 / 255)) < 1e-6, 'flat blue channel is decoded');
-  t.equal(data[3], 1, 'flat alpha is synthesized');
-  t.equal(data[7], 1, 'second flat pixel alpha is synthesized');
-  t.end();
+  expect(texture.data[0].width, 'width is parsed').toBe(2);
+  expect(texture.data[0].height, 'height is parsed').toBe(1);
+  expect(Math.abs(data[0] - 128 * (2 / 255)) < 1e-6, 'flat red channel is decoded').toBeTruthy();
+  expect(Math.abs(data[1] - 64 * (2 / 255)) < 1e-6, 'flat green channel is decoded').toBeTruthy();
+  expect(Math.abs(data[2] - 32 * (2 / 255)) < 1e-6, 'flat blue channel is decoded').toBeTruthy();
+  expect(data[3], 'flat alpha is synthesized').toBe(1);
+  expect(data[7], 'second flat pixel alpha is synthesized').toBe(1);
 });
-
-test('parseHDR#detects valid headers', t => {
-  t.ok(isHDR(createRLEHDRBuffer('#?RADIANCE')), 'detects RADIANCE magic header');
-  t.ok(isHDR(createFlatHDRBuffer('#?RGBE')), 'detects RGBE magic header');
-  t.notOk(isHDR(asArrayBuffer(Uint8Array.from([0, 1, 2, 3]))), 'rejects non-HDR payloads');
-  t.end();
+test('parseHDR#detects valid headers', () => {
+  expect(isHDR(createRLEHDRBuffer('#?RADIANCE')), 'detects RADIANCE magic header').toBeTruthy();
+  expect(isHDR(createFlatHDRBuffer('#?RGBE')), 'detects RGBE magic header').toBeTruthy();
+  expect(
+    isHDR(asArrayBuffer(Uint8Array.from([0, 1, 2, 3]))),
+    'rejects non-HDR payloads'
+  ).toBeFalsy();
 });
-
-test('parseHDR#rejects missing format specifier', t => {
+test('parseHDR#rejects missing format specifier', () => {
   const buffer = createHeaderBuffer(['#?RADIANCE', '', '-Y 1 +X 1']);
-  t.throws(() => parseHDR(buffer), /missing format specifier/, 'requires format specifier');
-  t.end();
+  expect(() => parseHDR(buffer), 'requires format specifier').toThrow(/missing format specifier/);
 });
-
-test('parseHDR#rejects bad scanline data', t => {
+test('parseHDR#rejects bad scanline data', () => {
   const bytes = new Uint8Array(createRLEHDRBuffer('#?RADIANCE'));
   bytes[bytes.length - 2] = 0;
   const buffer = asArrayBuffer(bytes);
-
-  t.throws(() => parseHDR(buffer), /bad scanline data/, 'rejects malformed scanline runs');
-  t.end();
+  expect(() => parseHDR(buffer), 'rejects malformed scanline runs').toThrow(/bad scanline data/);
 });
-
-test('parseHDR#falls back to flat decode on false RLE probe', t => {
+test('parseHDR#falls back to flat decode on false RLE probe', () => {
   const texture = parseHDR(createFlatFalseRLEProbeHDRBuffer());
   const data = texture.data[0].data as Float32Array;
-
-  t.equal(texture.data[0].width, 8, 'width is parsed for flat scanlines');
-  t.equal(texture.data[0].height, 1, 'height is parsed for flat scanlines');
-  t.ok(Math.abs(data[0] - 4 / 255) < 1e-6, 'first pixel red is decoded from flat data');
-  t.ok(Math.abs(data[1] - 4 / 255) < 1e-6, 'first pixel green is decoded from flat data');
-  t.ok(Math.abs(data[2] - 14 / 255) < 1e-6, 'first pixel blue is decoded from flat data');
-  t.equal(data[3], 1, 'first pixel alpha is synthesized');
-  t.end();
+  expect(texture.data[0].width, 'width is parsed for flat scanlines').toBe(8);
+  expect(texture.data[0].height, 'height is parsed for flat scanlines').toBe(1);
+  expect(
+    Math.abs(data[0] - 4 / 255) < 1e-6,
+    'first pixel red is decoded from flat data'
+  ).toBeTruthy();
+  expect(
+    Math.abs(data[1] - 4 / 255) < 1e-6,
+    'first pixel green is decoded from flat data'
+  ).toBeTruthy();
+  expect(
+    Math.abs(data[2] - 14 / 255) < 1e-6,
+    'first pixel blue is decoded from flat data'
+  ).toBeTruthy();
+  expect(data[3], 'first pixel alpha is synthesized').toBe(1);
 });
-
-test('parseHDR#accepts flipped Radiance resolution strings', t => {
+test('parseHDR#accepts flipped Radiance resolution strings', () => {
   const texture = parseHDR(createOrientedFlatHDRBuffer('+Y 2 +X 2'));
   const data = texture.data[0].data as Float32Array;
-
-  t.equal(texture.data[0].width, 2, 'width is parsed for +Y +X');
-  t.equal(texture.data[0].height, 2, 'height is parsed for +Y +X');
-  t.ok(Math.abs(data[0] - 1) < 1e-6, 'top-left pixel is normalized into standard order');
-  t.ok(Math.abs(data[4] - 254 / 255) < 1e-6, 'top-right pixel is normalized into standard order');
-  t.ok(Math.abs(data[8] - 253 / 255) < 1e-6, 'bottom-left pixel is normalized into standard order');
-  t.ok(
+  expect(texture.data[0].width, 'width is parsed for +Y +X').toBe(2);
+  expect(texture.data[0].height, 'height is parsed for +Y +X').toBe(2);
+  expect(
+    Math.abs(data[0] - 1) < 1e-6,
+    'top-left pixel is normalized into standard order'
+  ).toBeTruthy();
+  expect(
+    Math.abs(data[4] - 254 / 255) < 1e-6,
+    'top-right pixel is normalized into standard order'
+  ).toBeTruthy();
+  expect(
+    Math.abs(data[8] - 253 / 255) < 1e-6,
+    'bottom-left pixel is normalized into standard order'
+  ).toBeTruthy();
+  expect(
     Math.abs(data[12] - 252 / 255) < 1e-6,
     'bottom-right pixel is normalized into standard order'
-  );
-  t.end();
+  ).toBeTruthy();
 });
-
-test('parseHDR#accepts rotated Radiance resolution strings', t => {
+test('parseHDR#accepts rotated Radiance resolution strings', () => {
   const texture = parseHDR(createOrientedFlatHDRBuffer('+X 2 -Y 2'));
   const data = texture.data[0].data as Float32Array;
-
-  t.equal(texture.data[0].width, 2, 'width is parsed for +X -Y');
-  t.equal(texture.data[0].height, 2, 'height is parsed for +X -Y');
-  t.ok(Math.abs(data[0] - 1) < 1e-6, 'top-left pixel is normalized after rotation');
-  t.ok(Math.abs(data[4] - 254 / 255) < 1e-6, 'top-right pixel is normalized after rotation');
-  t.ok(Math.abs(data[8] - 253 / 255) < 1e-6, 'bottom-left pixel is normalized after rotation');
-  t.ok(Math.abs(data[12] - 252 / 255) < 1e-6, 'bottom-right pixel is normalized after rotation');
-  t.end();
+  expect(texture.data[0].width, 'width is parsed for +X -Y').toBe(2);
+  expect(texture.data[0].height, 'height is parsed for +X -Y').toBe(2);
+  expect(Math.abs(data[0] - 1) < 1e-6, 'top-left pixel is normalized after rotation').toBeTruthy();
+  expect(
+    Math.abs(data[4] - 254 / 255) < 1e-6,
+    'top-right pixel is normalized after rotation'
+  ).toBeTruthy();
+  expect(
+    Math.abs(data[8] - 253 / 255) < 1e-6,
+    'bottom-left pixel is normalized after rotation'
+  ).toBeTruthy();
+  expect(
+    Math.abs(data[12] - 252 / 255) < 1e-6,
+    'bottom-right pixel is normalized after rotation'
+  ).toBeTruthy();
 });
-
 function createRLEHDRBuffer(magicHeader: '#?RADIANCE' | '#?RGBE'): ArrayBuffer {
   const header = createHeaderBuffer([magicHeader, 'FORMAT=32-bit_rle_rgbe', '', '-Y 2 +X 8']);
   const row1 = new Uint8Array([2, 2, 0, 8, 136, 255, 136, 0, 136, 0, 136, 129]);
   const row2 = new Uint8Array([2, 2, 0, 8, 8, 0, 1, 2, 3, 4, 5, 6, 7, 136, 10, 136, 20, 136, 128]);
-
   return joinBuffers(new Uint8Array(header), row1, row2);
 }
-
 function createFlatHDRBuffer(
   magicHeader: '#?RADIANCE' | '#?RGBE',
   metadataLines: string[] = []
@@ -152,10 +149,8 @@ function createFlatHDRBuffer(
     '-Y 1 +X 2'
   ]);
   const pixels = new Uint8Array([128, 64, 32, 129, 0, 0, 0, 0]);
-
   return joinBuffers(new Uint8Array(header), pixels);
 }
-
 function createOrientedFlatHDRBuffer(resolution: string): ArrayBuffer {
   const header = createHeaderBuffer(['#?RADIANCE', 'FORMAT=32-bit_rle_rgbe', '', resolution]);
   let redChannelValues: number[];
@@ -169,49 +164,38 @@ function createOrientedFlatHDRBuffer(resolution: string): ArrayBuffer {
     default:
       throw new Error(`Unhandled test resolution: ${resolution}`);
   }
-
   const pixels = new Uint8Array(redChannelValues.flatMap(red => [red, 0, 0, 128]));
-
   return joinBuffers(new Uint8Array(header), pixels);
 }
-
 function createFlatFalseRLEProbeHDRBuffer(): ArrayBuffer {
   const header = createHeaderBuffer(['#?RADIANCE', 'FORMAT=32-bit_rle_rgbe', '', '-Y 1 +X 8']);
   const pixels = new Uint8Array([
     2, 2, 7, 129, 1, 0, 0, 128, 2, 0, 0, 128, 3, 0, 0, 128, 4, 0, 0, 128, 5, 0, 0, 128, 6, 0, 0,
     128, 7, 0, 0, 128
   ]);
-
   return joinBuffers(new Uint8Array(header), pixels);
 }
-
 function createHeaderBuffer(lines: string[]): ArrayBuffer {
   const header = `${lines.join('\n')}\n`;
   const bytes = new Uint8Array(header.length);
-
   for (let index = 0; index < header.length; index++) {
     bytes[index] = header.charCodeAt(index);
   }
-
   return asArrayBuffer(bytes);
 }
-
 function joinBuffers(...chunks: Uint8Array[]): ArrayBuffer {
   let length = 0;
   for (const chunk of chunks) {
     length += chunk.length;
   }
-
   const result = new Uint8Array(length);
   let offset = 0;
   for (const chunk of chunks) {
     result.set(chunk, offset);
     offset += chunk.length;
   }
-
   return asArrayBuffer(result);
 }
-
 function asArrayBuffer(bytes: Uint8Array): ArrayBuffer {
   return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
 }

--- a/modules/textures/test/lib/parsers/parse-pvr.spec.ts
+++ b/modules/textures/test/lib/parsers/parse-pvr.spec.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-/* eslint-disable camelcase */
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {fetchFile} from '@loaders.gl/core';
 import {parsePVR} from '../../../src/lib/parsers/parse-pvr';
 import {
@@ -15,7 +14,6 @@ import {
   GL_COMPRESSED_SRGB8_ALPHA8_ASTC_10x10_KHR
 } from '../../../src/lib/gl-extensions';
 import {checkCompressedTexture} from '../../test-utils/check-compressed-texture';
-
 const TEST_CASES = [
   {
     url: '@loaders.gl/textures/test/data/shannon-pvrtc-2bpp-rgb.pvr',
@@ -48,13 +46,11 @@ const TEST_CASES = [
     textureFormat: 'astc-10x10-unorm-srgb'
   }
 ];
-
-test('CompressedTextureLoader#pvr', async t => {
+test('CompressedTextureLoader#pvr', async () => {
   for (const testCase of TEST_CASES) {
     const response = await fetchFile(testCase.url);
     const data = await response.arrayBuffer();
     const result = parsePVR(data);
-    checkCompressedTexture(t, result, testCase);
+    checkCompressedTexture(result, testCase);
   }
-  t.end();
 });

--- a/modules/textures/test/npy-loader.spec.ts
+++ b/modules/textures/test/npy-loader.spec.ts
@@ -2,50 +2,35 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {validateLoader} from 'test/common/conformance';
-
 import {NPYLoader, NPYWorkerLoader} from '@loaders.gl/textures';
 import {setLoaderOptions, load} from '@loaders.gl/core';
-
 const NPY_UINT8_URL = '@loaders.gl/textures/test/data/uint8.npy';
-
 setLoaderOptions({
   _workerType: 'test'
 });
-
-test('NPYLoader#loader objects', async t => {
-  validateLoader(t, NPYLoader, 'NPYLoader');
-  validateLoader(t, NPYWorkerLoader, 'NPYWorkerLoader');
-  t.end();
+test('NPYLoader#loader objects', async () => {
+  validateLoader(NPYLoader, 'NPYLoader');
+  validateLoader(NPYWorkerLoader, 'NPYWorkerLoader');
 });
-
-test('NPYLoader#parse', async t => {
+test('NPYLoader#parse', async () => {
   const {data, header} = await load(NPY_UINT8_URL, NPYLoader);
-
   const expectedData = new Uint8Array([1, 2, 3, 4]);
   // eslint-disable-next-line camelcase
   const expectedHeader = {descr: '|u1', fortran_order: false, shape: [4]};
-
-  t.deepEqual(data, expectedData, 'data matches');
-  t.deepEqual(header, expectedHeader, 'header matches');
-  t.end();
+  expect(data, 'data matches').toEqual(expectedData);
+  expect(header, 'header matches').toEqual(expectedHeader);
 });
-
-test('NPYWorkerLoader#parse', async t => {
+test('NPYWorkerLoader#parse', async () => {
   if (typeof Worker === 'undefined') {
-    t.comment('Worker is not usable in non-browser environments');
-    t.end();
+    console.log('Worker is not usable in non-browser environments');
     return;
   }
-
   const {data, header} = await load(NPY_UINT8_URL, NPYWorkerLoader);
-
   const expectedData = new Uint8Array([1, 2, 3, 4]);
   // eslint-disable-next-line camelcase
   const expectedHeader = {descr: '|u1', fortran_order: false, shape: [4]};
-
-  t.deepEqual(data, expectedData, 'data matches');
-  t.deepEqual(header, expectedHeader, 'header matches');
-  t.end();
+  expect(data, 'data matches').toEqual(expectedData);
+  expect(header, 'header matches').toEqual(expectedHeader);
 });

--- a/modules/textures/test/radiance-hdr-loader.spec.ts
+++ b/modules/textures/test/radiance-hdr-loader.spec.ts
@@ -2,81 +2,69 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
-
+import {expect, test} from 'vitest';
 import {load, setLoaderOptions} from '@loaders.gl/core';
 import {RadianceHDRLoader} from '@loaders.gl/textures';
 import {GL_RGBA32F} from '../src/lib/gl-extensions';
-
 const HDR_URL = '@loaders.gl/textures/test/data/simple-rle.hdr';
 const POLY_HAVEN_HDR_URL = '@loaders.gl/textures/test/data/venice_sunset_256.hdr';
-
 setLoaderOptions({
   _workerType: 'test'
 });
-
-test('RadianceHDRLoader#imports', t => {
-  t.ok(RadianceHDRLoader, 'RadianceHDRLoader defined');
-  t.end();
+test('RadianceHDRLoader#imports', () => {
+  expect(RadianceHDRLoader, 'RadianceHDRLoader defined').toBeTruthy();
 });
-
-test('RadianceHDRLoader#load(URL)', async t => {
+test('RadianceHDRLoader#load(URL)', async () => {
   const texture = await load(HDR_URL, RadianceHDRLoader);
   const level = texture.data[0];
-
-  t.equal(texture.shape, 'texture', 'returns a texture payload');
-  t.equal(texture.type, '2d', 'texture type is correct');
-  t.equal(texture.format, 'rgba32float', 'texture format is correct');
-  t.equal(texture.data.length, 1, 'returns a single texture level');
-  t.equal(level.shape, 'texture-level', 'level shape is correct');
-  t.equal(level.width, 8, 'width is correct');
-  t.equal(level.height, 2, 'height is correct');
-  t.equal(level.compressed, false, 'decoded data is uncompressed');
-  t.ok(level.data instanceof Float32Array, 'decoded data is float32');
-  t.equal(level.levelSize, level.data.byteLength, 'level size matches float data size');
-  t.equal(level.textureFormat, 'rgba32float', 'texture format is correct');
-  t.equal(level.format, GL_RGBA32F, 'WebGL format is correct');
-
+  expect(texture.shape, 'returns a texture payload').toBe('texture');
+  expect(texture.type, 'texture type is correct').toBe('2d');
+  expect(texture.format, 'texture format is correct').toBe('rgba32float');
+  expect(texture.data.length, 'returns a single texture level').toBe(1);
+  expect(level.shape, 'level shape is correct').toBe('texture-level');
+  expect(level.width, 'width is correct').toBe(8);
+  expect(level.height, 'height is correct').toBe(2);
+  expect(level.compressed, 'decoded data is uncompressed').toBe(false);
+  expect(level.data instanceof Float32Array, 'decoded data is float32').toBeTruthy();
+  expect(level.levelSize, 'level size matches float data size').toBe(level.data.byteLength);
+  expect(level.textureFormat, 'texture format is correct').toBe('rgba32float');
+  expect(level.format, 'WebGL format is correct').toBe(GL_RGBA32F);
   const data = level.data as Float32Array;
-  t.equal(data[0], 2, 'first pixel preserves bright intensity');
-  t.equal(data[1], 0, 'first pixel green is correct');
-  t.equal(data[2], 0, 'first pixel blue is correct');
-  t.equal(data[3], 1, 'first pixel alpha is synthesized');
-  t.ok(data[0] > 1, 'decoded data contains HDR values above 1');
-
+  expect(data[0], 'first pixel preserves bright intensity').toBe(2);
+  expect(data[1], 'first pixel green is correct').toBe(0);
+  expect(data[2], 'first pixel blue is correct').toBe(0);
+  expect(data[3], 'first pixel alpha is synthesized').toBe(1);
+  expect(data[0] > 1, 'decoded data contains HDR values above 1').toBeTruthy();
   const secondRowPixelOffset = (8 + 3) * 4;
-  t.ok(Math.abs(data[secondRowPixelOffset] - 3 / 255) < 1e-6, 'literal run red channel is decoded');
-  t.ok(
+  expect(
+    Math.abs(data[secondRowPixelOffset] - 3 / 255) < 1e-6,
+    'literal run red channel is decoded'
+  ).toBeTruthy();
+  expect(
     Math.abs(data[secondRowPixelOffset + 1] - 10 / 255) < 1e-6,
     'literal run green channel is decoded'
-  );
-  t.ok(
+  ).toBeTruthy();
+  expect(
     Math.abs(data[secondRowPixelOffset + 2] - 20 / 255) < 1e-6,
     'literal run blue channel is decoded'
-  );
-  t.equal(data[secondRowPixelOffset + 3], 1, 'literal run alpha is synthesized');
-
-  t.end();
+  ).toBeTruthy();
+  expect(data[secondRowPixelOffset + 3], 'literal run alpha is synthesized').toBe(1);
 });
-
-test('RadianceHDRLoader#load(Poly Haven URL)', async t => {
+test('RadianceHDRLoader#load(Poly Haven URL)', async () => {
   const texture = await load(POLY_HAVEN_HDR_URL, RadianceHDRLoader);
   const level = texture.data[0];
   const data = level.data as Float32Array;
-
-  t.equal(texture.shape, 'texture', 'returns a texture payload');
-  t.equal(texture.type, '2d', 'poly haven texture type is correct');
-  t.equal(texture.format, 'rgba32float', 'poly haven top-level format is correct');
-  t.equal(texture.data.length, 1, 'returns a single texture level');
-  t.equal(level.width, 256, 'poly haven width is correct');
-  t.equal(level.height, 128, 'poly haven height is correct');
-  t.equal(level.textureFormat, 'rgba32float', 'poly haven texture format is correct');
-  t.equal(level.format, GL_RGBA32F, 'poly haven WebGL format is correct');
-  t.ok(level.data instanceof Float32Array, 'poly haven data is float32');
-  t.ok(
+  expect(texture.shape, 'returns a texture payload').toBe('texture');
+  expect(texture.type, 'poly haven texture type is correct').toBe('2d');
+  expect(texture.format, 'poly haven top-level format is correct').toBe('rgba32float');
+  expect(texture.data.length, 'returns a single texture level').toBe(1);
+  expect(level.width, 'poly haven width is correct').toBe(256);
+  expect(level.height, 'poly haven height is correct').toBe(128);
+  expect(level.textureFormat, 'poly haven texture format is correct').toBe('rgba32float');
+  expect(level.format, 'poly haven WebGL format is correct').toBe(GL_RGBA32F);
+  expect(level.data instanceof Float32Array, 'poly haven data is float32').toBeTruthy();
+  expect(
     data.some(value => value > 1),
     'poly haven data keeps HDR intensity'
-  );
-
-  t.end();
+  ).toBeTruthy();
 });

--- a/modules/textures/test/test-utils/check-compressed-texture.ts
+++ b/modules/textures/test/test-utils/check-compressed-texture.ts
@@ -2,19 +2,21 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-export function checkCompressedTexture(t, imageData, testCase) {
-  t.ok(imageData instanceof Array);
-  t.ok(imageData.length > 0);
+import {expect} from 'vitest';
+
+export function checkCompressedTexture(imageData, testCase) {
+  expect(imageData instanceof Array).toBeTruthy();
+  expect(imageData.length > 0).toBeTruthy();
   for (const level of imageData) {
-    t.equals(level.shape, 'texture-level');
-    t.ok(level.compressed);
-    t.equals(level.format, testCase.format);
+    expect(level.shape).toBe('texture-level');
+    expect(level.compressed).toBeTruthy();
+    expect(level.format).toBe(testCase.format);
     if (testCase.textureFormat) {
-      t.equals(level.textureFormat, testCase.textureFormat);
+      expect(level.textureFormat).toBe(testCase.textureFormat);
     }
-    t.ok(level.data instanceof Uint8Array);
-    t.ok(isFinite(level.width));
-    t.ok(isFinite(level.height));
-    t.ok(isFinite(level.levelSize));
+    expect(level.data instanceof Uint8Array).toBeTruthy();
+    expect(isFinite(level.width)).toBeTruthy();
+    expect(isFinite(level.height)).toBeTruthy();
+    expect(isFinite(level.levelSize)).toBeTruthy();
   }
 }

--- a/modules/textures/test/texture-api/async-deep-map.spec.ts
+++ b/modules/textures/test/texture-api/async-deep-map.spec.ts
@@ -2,21 +2,17 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {asyncDeepMap} from '../../src/lib/texture-api/async-deep-map';
-
 const INPUT = {
   a: [1, 2, 3],
   b: 4
 };
-
 const OUTPUT = {
   a: [2, 4, 6],
   b: 8
 };
-
-test('asyncDeepMap#map', async t => {
+test('asyncDeepMap#map', async () => {
   // @ts-expect-error
-  t.deepEqual(await asyncDeepMap(INPUT, async n => Promise.resolve(2 * n)), OUTPUT);
-  t.end();
+  expect(await asyncDeepMap(INPUT, async n => Promise.resolve(2 * n))).toEqual(OUTPUT);
 });

--- a/modules/textures/test/texture-api/load-image.spec.ts
+++ b/modules/textures/test/texture-api/load-image.spec.ts
@@ -2,23 +2,22 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {fetchFile} from '@loaders.gl/core';
 import {loadImageTexture, loadImageTextureArray, loadImageTextureCube} from '@loaders.gl/textures';
 import {getImageData, getImageType, isImage} from '@loaders.gl/images';
-
 const LUT_URL = '@loaders.gl/images/test/data/ibl/brdfLUT.png';
 const PAPERMILL_URL = '@loaders.gl/images/test/data/ibl/papermill';
-
-test('loadImageTexture#mipLevels=0', async t => {
+test('loadImageTexture#mipLevels=0', async () => {
   const image = await loadImageTexture(LUT_URL, {fetch: fetchFile});
-  t.ok(isImage(image));
-  t.equal(getImageType(image), 'imagebitmap', 'returns the strict bitmap image type');
-  t.ok(getImageData(image).data.length > 0, 'bitmap result can be converted to raw pixel data');
-  t.end();
+  expect(isImage(image)).toBeTruthy();
+  expect(getImageType(image), 'returns the strict bitmap image type').toBe('imagebitmap');
+  expect(
+    getImageData(image).data.length > 0,
+    'bitmap result can be converted to raw pixel data'
+  ).toBeTruthy();
 });
-
-test('loadImageTexture#mipLevels=auto', async t => {
+test('loadImageTexture#mipLevels=auto', async () => {
   const mipmappedImage = await loadImageTexture(({lod}) => `specular/specular_back_${lod}.jpg`, {
     baseUrl: PAPERMILL_URL,
     fetch: fetchFile,
@@ -26,15 +25,13 @@ test('loadImageTexture#mipLevels=auto', async t => {
       mipLevels: 'auto'
     }
   });
-  t.ok(mipmappedImage.every(isImage));
-  t.ok(
+  expect(mipmappedImage.every(isImage)).toBeTruthy();
+  expect(
     mipmappedImage.every(image => getImageType(image) === 'imagebitmap'),
     'every mip level is returned as an ImageBitmap'
-  );
-  t.end();
+  ).toBeTruthy();
 });
-
-test('loadImageTextureArray#mipLevels=0', async t => {
+test('loadImageTextureArray#mipLevels=0', async () => {
   const images = await loadImageTextureArray(
     10,
     ({index}) => `specular/specular_back_${index}.jpg`,
@@ -43,16 +40,14 @@ test('loadImageTextureArray#mipLevels=0', async t => {
       fetch: fetchFile
     }
   );
-  t.equal(images.length, 10, 'loadArray loaded 10 images');
-  t.ok(images.every(isImage));
-  t.ok(
+  expect(images.length, 'loadArray loaded 10 images').toBe(10);
+  expect(images.every(isImage)).toBeTruthy();
+  expect(
     images.every(image => getImageType(image) === 'imagebitmap'),
     'every layer is an ImageBitmap'
-  );
-  t.end();
+  ).toBeTruthy();
 });
-
-test('loadImageTextureArray#mipLevels=auto', async t => {
+test('loadImageTextureArray#mipLevels=auto', async () => {
   const images = await loadImageTextureArray(
     1,
     ({index, lod}) => `specular/specular_back_${lod}.jpg`,
@@ -64,19 +59,17 @@ test('loadImageTextureArray#mipLevels=auto', async t => {
       }
     }
   );
-  t.equal(images.length, 1, 'loadArray loaded 1 image');
+  expect(images.length, 'loadArray loaded 1 image').toBe(1);
   images.every(imageMips => {
-    t.equal(imageMips.length, 10, 'array of mip images has correct length');
-    t.ok(imageMips.every(isImage), 'entry is a valid array of mip images');
-    t.ok(
+    expect(imageMips.length, 'array of mip images has correct length').toBe(10);
+    expect(imageMips.every(isImage), 'entry is a valid array of mip images').toBeTruthy();
+    expect(
       imageMips.every(image => getImageType(image) === 'imagebitmap'),
       'entry preserves the strict bitmap image type'
-    );
+    ).toBeTruthy();
   });
-  t.end();
 });
-
-test('loadImageTextureCube#mipLevels=0', async t => {
+test('loadImageTextureCube#mipLevels=0', async () => {
   const imageCube = await loadImageTextureCube(
     ({direction}) => `diffuse/diffuse_${direction}_0.jpg`,
     {
@@ -84,16 +77,14 @@ test('loadImageTextureCube#mipLevels=0', async t => {
       fetch: fetchFile
     }
   );
-  t.equal(Object.keys(imageCube).length, 6, 'image cube has 6 images');
+  expect(Object.keys(imageCube).length, 'image cube has 6 images').toBe(6);
   for (const face in imageCube) {
     const image = imageCube[face];
-    t.ok(isImage(image), `face ${face} is a valid image`);
-    t.equal(getImageType(image), 'imagebitmap', `face ${face} is returned as an ImageBitmap`);
+    expect(isImage(image), `face ${face} is a valid image`).toBeTruthy();
+    expect(getImageType(image), `face ${face} is returned as an ImageBitmap`).toBe('imagebitmap');
   }
-  t.end();
 });
-
-test('loadImageTextureCube#mipLevels=auto', async t => {
+test('loadImageTextureCube#mipLevels=auto', async () => {
   const imageCube = await loadImageTextureCube(
     ({direction, lod}) => `specular/specular_${direction}_${lod}.jpg`,
     {
@@ -104,27 +95,23 @@ test('loadImageTextureCube#mipLevels=auto', async t => {
       }
     }
   );
-  t.equal(Object.keys(imageCube).length, 6, 'image cube has 6 images');
+  expect(Object.keys(imageCube).length, 'image cube has 6 images').toBe(6);
   for (const face in imageCube) {
     const imageMips = imageCube[face];
-    t.equal(imageMips.length, 10, 'array of mip images has correct length');
-    t.ok(imageMips.every(isImage), `face ${face} is a valid array of mip images`);
-    t.ok(
+    expect(imageMips.length, 'array of mip images has correct length').toBe(10);
+    expect(imageMips.every(isImage), `face ${face} is a valid array of mip images`).toBeTruthy();
+    expect(
       imageMips.every(image => getImageType(image) === 'imagebitmap'),
       `face ${face} preserves the strict bitmap image type`
-    );
+    ).toBeTruthy();
   }
-  t.end();
 });
-
-test('loadImageTexture#rejects deprecated image output modes', async t => {
-  await t.rejects(
+test('loadImageTexture#rejects deprecated image output modes', async () => {
+  await expect(
     loadImageTexture(LUT_URL, {
       fetch: fetchFile,
       image: {type: 'data'}
     } as any),
-    /ImageBitmapLoader only accepts options\.image\.type='imagebitmap'/,
     'deprecated image output modes are rejected by the helper path'
-  );
-  t.end();
+  ).rejects.toThrow(/ImageBitmapLoader only accepts options\.image\.type='imagebitmap'/);
 });

--- a/modules/textures/test/texture-loader.spec.ts
+++ b/modules/textures/test/texture-loader.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {fetchFile, load, parse, selectLoader} from '@loaders.gl/core';
 import {getImageData, getImageType} from '@loaders.gl/images';
 import {
@@ -11,7 +11,6 @@ import {
   TextureCubeLoader,
   TextureLoader
 } from '@loaders.gl/textures';
-
 const IMAGE_TEXTURE_MANIFEST_URL =
   '@loaders.gl/textures/test/data/composite-image/image-texture.json';
 const IMAGE_TEXTURE_MIPMAP_MANIFEST_URL =
@@ -20,78 +19,71 @@ const IMAGE_TEXTURE_ARRAY_MANIFEST_URL =
   '@loaders.gl/textures/test/data/composite-image/image-texture-array.json';
 const IMAGE_TEXTURE_CUBE_MANIFEST_URL =
   '@loaders.gl/textures/test/data/composite-image/image-texture-cube.json';
-
-function checkImageTextureLevel(t, textureLevel, message: string) {
-  t.equal(textureLevel.shape, 'texture-level', `${message} has texture-level shape`);
-  t.notOk(textureLevel.compressed, `${message} is uncompressed`);
-  t.ok(textureLevel.width > 0, `${message} has width`);
-  t.ok(textureLevel.height > 0, `${message} has height`);
-  t.ok(textureLevel.data instanceof Uint8Array, `${message} uses a Uint8Array payload`);
-  t.equal(textureLevel.data.length, 0, `${message} uses an empty byte payload`);
-  t.equal(textureLevel.textureFormat, 'rgba8unorm', `${message} has canonical texture format`);
+function checkImageTextureLevel(textureLevel, message: string) {
+  expect(textureLevel.shape, `${message} has texture-level shape`).toBe('texture-level');
+  expect(textureLevel.compressed, `${message} is uncompressed`).toBeFalsy();
+  expect(textureLevel.width > 0, `${message} has width`).toBeTruthy();
+  expect(textureLevel.height > 0, `${message} has height`).toBeTruthy();
+  expect(
+    textureLevel.data instanceof Uint8Array,
+    `${message} uses a Uint8Array payload`
+  ).toBeTruthy();
+  expect(textureLevel.data.length, `${message} uses an empty byte payload`).toBe(0);
+  expect(textureLevel.textureFormat, `${message} has canonical texture format`).toBe('rgba8unorm');
   if (typeof ImageBitmap !== 'undefined') {
-    t.ok(textureLevel.imageBitmap instanceof ImageBitmap, `${message} preserves the ImageBitmap`);
-    t.equal(getImageType(textureLevel.imageBitmap), 'imagebitmap', `${message} is a bitmap`);
+    expect(
+      textureLevel.imageBitmap instanceof ImageBitmap,
+      `${message} preserves the ImageBitmap`
+    ).toBeTruthy();
+    expect(getImageType(textureLevel.imageBitmap), `${message} is a bitmap`).toBe('imagebitmap');
     const imageData = getImageData(textureLevel.imageBitmap);
-    t.equal(imageData.width, textureLevel.width, `${message} bitmap data preserves width`);
-    t.equal(imageData.height, textureLevel.height, `${message} bitmap data preserves height`);
+    expect(imageData.width, `${message} bitmap data preserves width`).toBe(textureLevel.width);
+    expect(imageData.height, `${message} bitmap data preserves height`).toBe(textureLevel.height);
   }
 }
-
-test('TextureLoader#load manifest', async t => {
+test('TextureLoader#load manifest', async () => {
   const texture = await load(IMAGE_TEXTURE_MANIFEST_URL, TextureLoader);
-  t.equal(texture.shape, 'texture', 'returns a texture');
-  t.equal(texture.type, '2d', 'returns a 2d texture');
-  t.equal(texture.data.length, 1, 'returns one level');
-  checkImageTextureLevel(t, texture.data[0], 'level 0');
-  t.end();
+  expect(texture.shape, 'returns a texture').toBe('texture');
+  expect(texture.type, 'returns a 2d texture').toBe('2d');
+  expect(texture.data.length, 'returns one level').toBe(1);
+  checkImageTextureLevel(texture.data[0], 'level 0');
 });
-
-test('TextureLoader#load mipmaps manifest', async t => {
+test('TextureLoader#load mipmaps manifest', async () => {
   const texture = await load(IMAGE_TEXTURE_MIPMAP_MANIFEST_URL, TextureLoader);
-  t.equal(texture.shape, 'texture', 'returns a texture');
-  t.equal(texture.type, '2d', 'returns a 2d texture');
-  t.equal(texture.data.length, 3, 'loads all mip levels');
+  expect(texture.shape, 'returns a texture').toBe('texture');
+  expect(texture.type, 'returns a 2d texture').toBe('2d');
+  expect(texture.data.length, 'loads all mip levels').toBe(3);
   texture.data.forEach((textureLevel, index) =>
-    checkImageTextureLevel(t, textureLevel, `level ${index}`)
+    checkImageTextureLevel(textureLevel, `level ${index}`)
   );
-  t.end();
 });
-
-test('TextureLoader#rejects deprecated image output modes', async t => {
-  await t.rejects(
+test('TextureLoader#rejects deprecated image output modes', async () => {
+  await expect(
     load(IMAGE_TEXTURE_MANIFEST_URL, TextureLoader, {image: {type: 'data'}} as any),
-    /ImageBitmapLoader only accepts options\.image\.type='imagebitmap'/,
     'manifest member parsing rejects deprecated image output modes'
-  );
-  t.end();
+  ).rejects.toThrow(/ImageBitmapLoader only accepts options\.image\.type='imagebitmap'/);
 });
-
-test('TextureArrayLoader#load manifest', async t => {
+test('TextureArrayLoader#load manifest', async () => {
   const texture = await load(IMAGE_TEXTURE_ARRAY_MANIFEST_URL, TextureArrayLoader);
-  t.equal(texture.shape, 'texture', 'returns a texture');
-  t.equal(texture.type, '2d-array', 'returns a 2d array texture');
-  t.equal(texture.data.length, 2, 'loads every layer');
+  expect(texture.shape, 'returns a texture').toBe('texture');
+  expect(texture.type, 'returns a 2d array texture').toBe('2d-array');
+  expect(texture.data.length, 'loads every layer').toBe(2);
   texture.data.forEach((layer, index) => {
-    t.equal(layer.length, 1, `layer ${index} has one mip level`);
-    checkImageTextureLevel(t, layer[0], `layer ${index} level 0`);
+    expect(layer.length, `layer ${index} has one mip level`).toBe(1);
+    checkImageTextureLevel(layer[0], `layer ${index} level 0`);
   });
-  t.end();
 });
-
-test('TextureCubeLoader#load manifest', async t => {
+test('TextureCubeLoader#load manifest', async () => {
   const texture = await load(IMAGE_TEXTURE_CUBE_MANIFEST_URL, TextureCubeLoader);
-  t.equal(texture.shape, 'texture', 'returns a texture');
-  t.equal(texture.type, 'cube', 'returns a cube texture');
-  t.equal(texture.data.length, 6, 'loads six cube faces');
+  expect(texture.shape, 'returns a texture').toBe('texture');
+  expect(texture.type, 'returns a cube texture').toBe('cube');
+  expect(texture.data.length, 'loads six cube faces').toBe(6);
   texture.data.forEach((faceLevels, index) => {
-    t.equal(faceLevels.length, 1, `face ${index} has one mip level`);
-    checkImageTextureLevel(t, faceLevels[0], `face ${index} level 0`);
+    expect(faceLevels.length, `face ${index} has one mip level`).toBe(1);
+    checkImageTextureLevel(faceLevels[0], `face ${index} level 0`);
   });
-  t.end();
 });
-
-test('TextureLoader#parse with core.baseUrl', async t => {
+test('TextureLoader#parse with core.baseUrl', async () => {
   const requestedUrls: string[] = [];
   const memberUrl = '@loaders.gl/images/test/data/ibl/brdfLUT.png';
   const fetch = async (url: string): Promise<Response> => {
@@ -101,35 +93,29 @@ test('TextureLoader#parse with core.baseUrl', async t => {
     }
     return await fetchFile(memberUrl);
   };
-
   const manifestText = JSON.stringify({
     shape: 'image-texture',
     image: '../../../../images/test/data/ibl/brdfLUT.png'
   });
-
   const texture = await parse(manifestText, TextureLoader, {
     fetch,
     core: {
       baseUrl: IMAGE_TEXTURE_MANIFEST_URL
     }
   });
-
-  t.equal(texture.type, '2d', 'resolves relative member URLs against core.baseUrl');
-  t.ok(
+  expect(texture.type, 'resolves relative member URLs against core.baseUrl').toBe('2d');
+  expect(
     requestedUrls[0]?.endsWith('images/test/data/ibl/brdfLUT.png'),
     'normalizes aliased relative member URLs against core.baseUrl'
-  );
-  checkImageTextureLevel(t, texture.data[0], 'level 0');
-  t.end();
+  ).toBeTruthy();
+  checkImageTextureLevel(texture.data[0], 'level 0');
 });
-
-test('TextureLoader#parse with extensionless core.baseUrl', async t => {
+test('TextureLoader#parse with extensionless core.baseUrl', async () => {
   const requestedUrls: string[] = [];
   const fetch = async (url: string): Promise<Response> => {
     requestedUrls.push(url);
     return await fetchFile('@loaders.gl/images/test/data/ibl/brdfLUT.png');
   };
-
   const texture = await parse(
     JSON.stringify({
       shape: 'image-texture',
@@ -143,18 +129,13 @@ test('TextureLoader#parse with extensionless core.baseUrl', async t => {
       }
     }
   );
-
-  t.equal(texture.type, '2d', 'resolves against the source manifest directory');
-  t.deepEqual(
-    requestedUrls,
-    ['https://example.com/manifests/member.png'],
-    'extensionless manifest URLs still resolve sibling members'
-  );
-  checkImageTextureLevel(t, texture.data[0], 'level 0');
-  t.end();
+  expect(texture.type, 'resolves against the source manifest directory').toBe('2d');
+  expect(requestedUrls, 'extensionless manifest URLs still resolve sibling members').toEqual([
+    'https://example.com/manifests/member.png'
+  ]);
+  checkImageTextureLevel(texture.data[0], 'level 0');
 });
-
-test('TextureLoader#template with auto mipLevels', async t => {
+test('TextureLoader#template with auto mipLevels', async () => {
   const requestedUrls: string[] = [];
   const specularImagePattern =
     /images\/test\/data\/ibl\/papermill\/specular\/specular_back_(\d+)\.jpg$/;
@@ -168,41 +149,35 @@ test('TextureLoader#template with auto mipLevels', async t => {
       `@loaders.gl/images/test/data/ibl/papermill/specular/specular_back_${match[1]}.jpg`
     );
   };
-
   const manifestText = JSON.stringify({
     shape: 'image-texture',
     mipLevels: 'auto',
     template: '../../../../images/test/data/ibl/papermill/specular/specular_back_{lod}.jpg'
   });
-
   const texture = await parse(manifestText, TextureLoader, {
     fetch,
     core: {
       baseUrl: IMAGE_TEXTURE_MIPMAP_MANIFEST_URL
     }
   });
-
-  t.equal(texture.type, '2d', 'returns a 2d texture');
-  t.equal(texture.data.length, 10, 'template source expands the auto mip chain');
-  t.ok(
+  expect(texture.type, 'returns a 2d texture').toBe('2d');
+  expect(texture.data.length, 'template source expands the auto mip chain').toBe(10);
+  expect(
     requestedUrls.some(url =>
       url.endsWith('images/test/data/ibl/papermill/specular/specular_back_0.jpg')
     ),
     'template source resolves aliased relative member URLs'
-  );
+  ).toBeTruthy();
   texture.data.forEach((textureLevel, index) =>
-    checkImageTextureLevel(t, textureLevel, `level ${index}`)
+    checkImageTextureLevel(textureLevel, `level ${index}`)
   );
-  t.end();
 });
-
-test('TextureLoader#template supports escaped braces', async t => {
+test('TextureLoader#template supports escaped braces', async () => {
   const requestedUrls: string[] = [];
   const fetch = async (url: string): Promise<Response> => {
     requestedUrls.push(url);
     return await fetchFile('@loaders.gl/images/test/data/ibl/brdfLUT.png');
   };
-
   const texture = await parse(
     JSON.stringify({
       shape: 'image-texture',
@@ -217,18 +192,13 @@ test('TextureLoader#template supports escaped braces', async t => {
       }
     }
   );
-
-  checkImageTextureLevel(t, texture.data[0], 'level 0');
-  t.equal(
-    decodeURIComponent(requestedUrls[0]),
-    'https://example.com/file{literal}.png',
-    'escaped braces are preserved'
+  checkImageTextureLevel(texture.data[0], 'level 0');
+  expect(decodeURIComponent(requestedUrls[0]), 'escaped braces are preserved').toBe(
+    'https://example.com/file{literal}.png'
   );
-  t.end();
 });
-
-test('TextureLoader#template reports invalid placeholders', async t => {
-  await t.rejects(
+test('TextureLoader#template reports invalid placeholders', async () => {
+  await expect(
     parse(
       JSON.stringify({
         shape: 'image-texture',
@@ -243,19 +213,15 @@ test('TextureLoader#template reports invalid placeholders', async t => {
         }
       }
     ),
-    /unsupported placeholder/,
     'invalid placeholders fail with a clear error'
-  );
-  t.end();
+  ).rejects.toThrow(/unsupported placeholder/);
 });
-
-test('TextureArrayLoader#template supports index placeholder', async t => {
+test('TextureArrayLoader#template supports index placeholder', async () => {
   const requestedUrls: string[] = [];
   const fetch = async (url: string): Promise<Response> => {
     requestedUrls.push(url);
     return await fetchFile('@loaders.gl/images/test/data/ibl/brdfLUT.png');
   };
-
   const texture = await parse(
     JSON.stringify({
       shape: 'image-texture-array',
@@ -272,49 +238,37 @@ test('TextureArrayLoader#template supports index placeholder', async t => {
       }
     }
   );
-
-  t.equal(texture.type, '2d-array', 'template array returns a 2d array texture');
-  t.equal(texture.data.length, 2, 'template array expands every layer');
+  expect(texture.type, 'template array returns a 2d array texture').toBe('2d-array');
+  expect(texture.data.length, 'template array expands every layer').toBe(2);
   texture.data.forEach((layer, index) =>
-    checkImageTextureLevel(t, layer[0], `layer ${index} level 0`)
+    checkImageTextureLevel(layer[0], `layer ${index} level 0`)
   );
-  t.deepEqual(
-    requestedUrls,
-    ['https://example.com/layer-0.png', 'https://example.com/layer-1.png'],
-    'index placeholder is expanded for each layer'
-  );
-  t.end();
+  expect(requestedUrls, 'index placeholder is expanded for each layer').toEqual([
+    'https://example.com/layer-0.png',
+    'https://example.com/layer-1.png'
+  ]);
 });
-
-test('TextureLoader#uses the top-level fetch function for members', async t => {
+test('TextureLoader#uses the top-level fetch function for members', async () => {
   const requestedUrls: string[] = [];
   const manifestUrl = 'https://example.com/image-texture.json';
   const memberUrl = 'https://example.com/member.png';
-
   const fetch = async (url: string): Promise<Response> => {
     requestedUrls.push(url);
-
     if (url === manifestUrl) {
       return new Response(JSON.stringify({shape: 'image-texture', image: 'member.png'}), {
         headers: {'Content-Type': 'application/json'}
       });
     }
-
     if (url === memberUrl) {
       return await fetchFile('@loaders.gl/images/test/data/ibl/brdfLUT.png');
     }
-
     throw new Error(`Unexpected URL ${url}`);
   };
-
   const texture = await load(manifestUrl, TextureLoader, {fetch});
-
-  checkImageTextureLevel(t, texture.data[0], 'level 0');
-  t.deepEqual(requestedUrls, [manifestUrl, memberUrl], 'top-level fetch is reused for members');
-  t.end();
+  checkImageTextureLevel(texture.data[0], 'level 0');
+  expect(requestedUrls, 'top-level fetch is reused for members').toEqual([manifestUrl, memberUrl]);
 });
-
-test('TextureLoader#uses top-level loaders for members', async t => {
+test('TextureLoader#uses top-level loaders for members', async () => {
   const manifestUrl = 'https://example.com/image-texture.json';
   const memberUrl = 'https://example.com/member.foo';
   const CustomMemberLoader = {
@@ -335,39 +289,31 @@ test('TextureLoader#uses top-level loaders for members', async t => {
       }
     ]
   };
-
   const fetch = async (url: string): Promise<Response> => {
     if (url === manifestUrl) {
       return new Response(JSON.stringify({shape: 'image-texture', image: 'member.foo'}), {
         headers: {'Content-Type': 'application/json'}
       });
     }
-
     if (url === memberUrl) {
       return new Response(new Uint8Array([1, 2, 3]), {
         headers: {'Content-Type': 'application/x.foo'}
       });
     }
-
     throw new Error(`Unexpected URL ${url}`);
   };
-
   const texture = await load(manifestUrl, [TextureLoader, CustomMemberLoader], {fetch});
-
-  t.equal(texture.type, '2d', 'member parsing still wraps into a 2d texture');
-  t.equal(texture.format, 'bc1-rgba-unorm', 'member parsing uses the custom loader result');
-  t.equal(texture.data[0].compressed, true, 'member level remains compressed');
-  t.deepEqual(Array.from(texture.data[0].data), [1, 2, 3], 'member level data is preserved');
-  t.end();
+  expect(texture.type, 'member parsing still wraps into a 2d texture').toBe('2d');
+  expect(texture.format, 'member parsing uses the custom loader result').toBe('bc1-rgba-unorm');
+  expect(texture.data[0].compressed, 'member level remains compressed').toBe(true);
+  expect(Array.from(texture.data[0].data), 'member level data is preserved').toEqual([1, 2, 3]);
 });
-
-test('TextureCubeLoader#template supports cube placeholders', async t => {
+test('TextureCubeLoader#template supports cube placeholders', async () => {
   const requestedUrls: string[] = [];
   const fetch = async (url: string): Promise<Response> => {
     requestedUrls.push(url);
     return await fetchFile('@loaders.gl/images/test/data/ibl/brdfLUT.png');
   };
-
   const texture = await parse(
     JSON.stringify({
       shape: 'image-texture-cube',
@@ -388,31 +334,23 @@ test('TextureCubeLoader#template supports cube placeholders', async t => {
       }
     }
   );
-
-  t.equal(texture.type, 'cube', 'template cube returns a cube texture');
-  t.equal(texture.data.length, 6, 'template cube expands every face');
-  t.deepEqual(
-    requestedUrls,
-    [
-      'https://example.com/cube-+X-right.png',
-      'https://example.com/cube--X-left.png',
-      'https://example.com/cube-+Y-top.png',
-      'https://example.com/cube--Y-bottom.png',
-      'https://example.com/cube-+Z-front.png',
-      'https://example.com/cube--Z-back.png'
-    ],
-    'cube placeholders are expanded for every face'
-  );
-  t.end();
+  expect(texture.type, 'template cube returns a cube texture').toBe('cube');
+  expect(texture.data.length, 'template cube expands every face').toBe(6);
+  expect(requestedUrls, 'cube placeholders are expanded for every face').toEqual([
+    'https://example.com/cube-+X-right.png',
+    'https://example.com/cube--X-left.png',
+    'https://example.com/cube-+Y-top.png',
+    'https://example.com/cube--Y-bottom.png',
+    'https://example.com/cube-+Z-front.png',
+    'https://example.com/cube--Z-back.png'
+  ]);
 });
-
-test('TextureCubeArrayLoader#template supports layer index and face placeholders', async t => {
+test('TextureCubeArrayLoader#template supports layer index and face placeholders', async () => {
   const requestedUrls: string[] = [];
   const fetch = async (url: string): Promise<Response> => {
     requestedUrls.push(url);
     return await fetchFile('@loaders.gl/images/test/data/ibl/brdfLUT.png');
   };
-
   const texture = await parse(
     JSON.stringify({
       shape: 'image-texture-cube-array',
@@ -447,23 +385,26 @@ test('TextureCubeArrayLoader#template supports layer index and face placeholders
       }
     }
   );
-
-  t.equal(texture.type, 'cube-array', 'cube array returns a cube-array texture');
-  t.equal(texture.data.length, 2, 'cube array returns one cubemap per layer');
-  t.equal(texture.data[0].length, 6, 'each layer contains six cube faces');
+  expect(texture.type, 'cube array returns a cube-array texture').toBe('cube-array');
+  expect(texture.data.length, 'cube array returns one cubemap per layer').toBe(2);
+  expect(texture.data[0].length, 'each layer contains six cube faces').toBe(6);
   texture.data.forEach((layer, layerIndex) =>
     layer.forEach((faceLevels, faceIndex) => {
-      t.equal(faceLevels.length, 1, `layer ${layerIndex} face ${faceIndex} has one mip level`);
-      checkImageTextureLevel(t, faceLevels[0], `layer ${layerIndex} face ${faceIndex} level 0`);
+      expect(faceLevels.length, `layer ${layerIndex} face ${faceIndex} has one mip level`).toBe(1);
+      checkImageTextureLevel(faceLevels[0], `layer ${layerIndex} face ${faceIndex} level 0`);
     })
   );
-  t.equal(requestedUrls.length, 12, 'all cube array members are loaded');
-  t.ok(requestedUrls.includes('https://example.com/cube-0-+X.png'), 'layer index 0 is expanded');
-  t.ok(requestedUrls.includes('https://example.com/cube-1--Z.png'), 'layer index 1 is expanded');
-  t.end();
+  expect(requestedUrls.length, 'all cube array members are loaded').toBe(12);
+  expect(
+    requestedUrls.includes('https://example.com/cube-0-+X.png'),
+    'layer index 0 is expanded'
+  ).toBeTruthy();
+  expect(
+    requestedUrls.includes('https://example.com/cube-1--Z.png'),
+    'layer index 1 is expanded'
+  ).toBeTruthy();
 });
-
-test('Texture loaders#select by shape', async t => {
+test('Texture loaders#select by shape', async () => {
   const loader = await selectLoader(
     JSON.stringify({
       shape: 'image-texture-array',
@@ -471,15 +412,11 @@ test('Texture loaders#select by shape', async t => {
     }),
     [TextureLoader, TextureArrayLoader, TextureCubeLoader, TextureCubeArrayLoader]
   );
-
-  t.is(loader, TextureArrayLoader, 'shape discriminator selects the matching loader');
-  t.end();
+  expect(loader, 'shape discriminator selects the matching loader').toBe(TextureArrayLoader);
 });
-
-test('Texture loaders#load selects by shape for JSON responses', async t => {
+test('Texture loaders#load selects by shape for JSON responses', async () => {
   const manifestUrl = 'https://example.com/texture-manifest';
   const memberUrl = 'https://example.com/member.png';
-
   const fetch = async (url: string): Promise<Response> => {
     if (url === manifestUrl) {
       return new Response(
@@ -492,22 +429,17 @@ test('Texture loaders#load selects by shape for JSON responses', async t => {
         }
       );
     }
-
     if (url === memberUrl) {
       return await fetchFile('@loaders.gl/images/test/data/ibl/brdfLUT.png');
     }
-
     throw new Error(`Unexpected URL ${url}`);
   };
-
   const texture = await load(
     manifestUrl,
     [TextureLoader, TextureArrayLoader, TextureCubeLoader, TextureCubeArrayLoader],
     {fetch}
   );
-
-  t.equal(texture.type, '2d-array', 'shape discriminator selects the matching manifest loader');
-  t.equal(texture.data.length, 1, 'loads the array layer through URL-based auto-selection');
-  checkImageTextureLevel(t, texture.data[0][0], 'layer 0 level 0');
-  t.end();
+  expect(texture.type, 'shape discriminator selects the matching manifest loader').toBe('2d-array');
+  expect(texture.data.length, 'loads the array layer through URL-based auto-selection').toBe(1);
+  checkImageTextureLevel(texture.data[0][0], 'layer 0 level 0');
 });

--- a/modules/textures/test/utils/format-utils.spec.ts
+++ b/modules/textures/test/utils/format-utils.spec.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
-
+import {expect, test} from 'vitest';
 import type {TextureFormat} from '@loaders.gl/schema';
 import {isBrowser} from '@loaders.gl/core';
 import {
@@ -19,95 +18,76 @@ import {
   getWebGLFormatFromTextureFormat
 } from '../../src/lib/utils/texture-format-map';
 import {GL_COMPRESSED_RGB_S3TC_DXT1_EXT} from '../../src/lib/gl-extensions';
-
-test('detectSupportedGPUTextureFormats', t => {
+test('detectSupportedGPUTextureFormats', () => {
   if (isBrowser) {
     // Minimal test as this is WebGL dependent
     const formats = detectSupportedGPUTextureFormats();
-    formats.forEach(format => t.ok(typeof format === 'string'));
-    t.end();
+    formats.forEach(format => expect(typeof format === 'string').toBeTruthy());
   } else {
     const formats = detectSupportedGPUTextureFormats();
-    t.equal(formats.size, 0);
-    t.end();
+    expect(formats.size).toBe(0);
   }
 });
-
-test('detectSupportedTextureFormats', t => {
+test('detectSupportedTextureFormats', () => {
   if (isBrowser) {
     const textureFormats = detectSupportedTextureFormats();
-    textureFormats.forEach(textureFormat => t.ok(typeof textureFormat === 'string'));
-    t.end();
+    textureFormats.forEach(textureFormat => expect(typeof textureFormat === 'string').toBeTruthy());
   } else {
     const textureFormats = detectSupportedTextureFormats();
-    t.equal(textureFormats.size, 0);
-    t.end();
+    expect(textureFormats.size).toBe(0);
   }
 });
-
-test('selectSupportedBasisFormat', t => {
-  t.deepEqual(
+test('selectSupportedBasisFormat', () => {
+  expect(
     selectSupportedBasisFormat(['astc-4x4-unorm']),
-    'astc-4x4',
     'ASTC texture formats select ASTC format'
-  );
-  t.deepEqual(
+  ).toEqual('astc-4x4');
+  expect(
     selectSupportedBasisFormat(['bc7-rgba-unorm']),
-    'bc7',
     'BC7 texture formats select canonical BC7'
-  );
-  t.deepEqual(
+  ).toEqual('bc7');
+  expect(
     selectSupportedBasisFormat(['bc3-rgba-unorm']),
-    {alpha: 'bc3', noAlpha: 'bc1'},
     'BC texture formats select BC formats'
-  );
-  t.deepEqual(
+  ).toEqual({alpha: 'bc3', noAlpha: 'bc1'});
+  expect(
     selectSupportedBasisFormat(['bc5-rg-unorm']),
-    {alpha: 'rgba32', noAlpha: 'rgb565'},
     'RGTC-only texture formats do not infer BC1/BC3 support'
-  );
-  t.equal(
+  ).toEqual({alpha: 'rgba32', noAlpha: 'rgb565'});
+  expect(
     selectSupportedBasisFormat(['etc2-rgba8unorm']),
-    'etc2',
     'ETC2 texture formats select ETC2 format'
-  );
-  t.deepEqual(
+  ).toBe('etc2');
+  expect(
     selectSupportedBasisFormat(['etc1-rgb-unorm-webgl']),
-    {alpha: 'rgba32', noAlpha: 'etc1'},
     'ETC1 extension texture formats select ETC1 format'
-  );
-  t.deepEqual(
-    selectSupportedBasisFormat([]),
-    {alpha: 'rgba32', noAlpha: 'rgb565'},
-    'fallback preserves alpha'
-  );
-  t.end();
+  ).toEqual({alpha: 'rgba32', noAlpha: 'etc1'});
+  expect(selectSupportedBasisFormat([]), 'fallback preserves alpha').toEqual({
+    alpha: 'rgba32',
+    noAlpha: 'rgb565'
+  });
 });
-
-test('getSupportedBasisFormats', t => {
+test('getSupportedBasisFormats', () => {
   const supportedBasisFormats = getSupportedBasisFormats([
     'bc3-rgba-unorm',
     'bc7-rgba-unorm',
     'etc2-rgba8unorm'
   ] as TextureFormat[]);
-
-  t.ok(supportedBasisFormats.includes('bc3'), 'BC formats are reported');
-  t.ok(supportedBasisFormats.includes('bc7'), 'BC7 formats are reported');
-  t.ok(supportedBasisFormats.includes('etc2'), 'ETC2 formats are reported');
-  t.ok(supportedBasisFormats.includes('rgb565'), 'fallback CPU format is always reported');
-  t.end();
+  expect(supportedBasisFormats.includes('bc3'), 'BC formats are reported').toBeTruthy();
+  expect(supportedBasisFormats.includes('bc7'), 'BC7 formats are reported').toBeTruthy();
+  expect(supportedBasisFormats.includes('etc2'), 'ETC2 formats are reported').toBeTruthy();
+  expect(
+    supportedBasisFormats.includes('rgb565'),
+    'fallback CPU format is always reported'
+  ).toBeTruthy();
 });
-
-test('texture format maps are reversible for known WebGL extension formats', t => {
-  t.equal(
+test('texture format maps are reversible for known WebGL extension formats', () => {
+  expect(
     getTextureFormatFromWebGLFormat(GL_COMPRESSED_RGB_S3TC_DXT1_EXT),
-    'bc1-rgb-unorm-webgl',
     'maps known WebGL compressed formats to canonical texture format strings'
-  );
-  t.equal(
+  ).toBe('bc1-rgb-unorm-webgl');
+  expect(
     getWebGLFormatFromTextureFormat('bc1-rgb-unorm-webgl'),
-    GL_COMPRESSED_RGB_S3TC_DXT1_EXT,
     'maps canonical texture format strings back to WebGL format constants'
-  );
-  t.end();
+  ).toBe(GL_COMPRESSED_RGB_S3TC_DXT1_EXT);
 });


### PR DESCRIPTION
## Goals

- Migrate the next high-impact loader test tranche from Tape compatibility tests to native Vitest.
- Increase GLTF and textures coverage without adding production code or extending the required test path.
- Keep the grouped change reviewable and compatible with the existing browser/slow test lanes.

## Changes

- Migrated 20 GLTF test suites, including loaders, writers, scenegraph APIs, extensions, utilities, and meshopt decoding.
- Migrated 14 textures test suites, including texture loaders, compressed formats, parsers, writers, image helpers, and format utilities.
- Converted shared compressed-texture assertions to native Vitest expectations.
- Normalized typed-array comparisons where Tape and Vitest differ in deep-equality behavior.
- Preserved the existing test fixtures, runtime lanes, and licensing headers.
- No production code or coverage thresholds changed.
- Excluded 3D Tiles from this tranche.

## Validation

- `yarn build`
- `yarn build-workers`
- `yarn lint fix`
- `yarn test-audit` — 601 files, 0 Tape, 0 violations
- Focused GLTF/textures browser tests — 46 files, 234 passed, 1 skipped
- Focused GLTF/textures browser coverage completed successfully