### PR TITLE
feat(wms): add WCS, OGC API Coverages, and EDR sources

### DIFF
--- a/docs/modules/wms/README.md
+++ b/docs/modules/wms/README.md
@@ -21,14 +21,15 @@ The `@loaders.gl/wms` module provides support for a subset of the OGC Web Servic
 | [**WFS**](/docs/modules/wms/formats/wfs) (Web Feature Service) protocol             | experimental | protocol for serving geo-referenced map features (geometries) over the internet.                                                     |
 | [**WMTS**](/docs/modules/wms/formats/wmts) (Web Map Tile Service) protocol          | experimental | protocol for serving pre-rendered or run-time computed georeferenced map tiles over the Internet.                                    |
 | [**GML**](/docs/modules/wms/formats/gml) (Geographic Markup Language) format        | experimental | an XML grammar that describes geographical features.                                                                                 |
-| [**WCS**](/docs/modules/wms/formats/wcs) (Web Coverage Service)                     | N            | Load coverage data (e.g. geotiff images for satellite data) from a server.                                                           |
+| [**WCS**](/docs/modules/wms/formats/wcs) (Web Coverage Service)                     | experimental | Load analytical coverage data (including binary and LERC responses) from a server.                                                  |
 | [**WMC**](/docs/modules/wms/formats/wmc) (Web Map Context)                          | No           | Used in WMS clients to save the configuration of maps and to load them again later. Can also be exchanged between different clients. |
 | [**OWS Context**](/docs/modules/wms/formats/ows-context) (OGC Web Services Context) | No           | Allows configured information resources to be passed between applications primarily as a collection of services.                     |
 
 The module also includes minimal adapters for the modern OGC API family. These adapters cover
-landing pages, collections, basic GeoJSON Features queries, and advertised tile templates. They
-are intentionally not a full conformance implementation; advanced filtering and service-specific
-extensions remain available through the regular loaders.gl fetch APIs.
+landing pages, collections, basic GeoJSON Features queries, advertised tile templates, coverage
+retrieval, and EDR queries. They are intentionally not a full conformance implementation;
+advanced filtering and service-specific extensions remain available through the regular loaders.gl
+fetch APIs.
 
 ```js
 import {OGCAPIFeaturesSourceLoader} from '@loaders.gl/wms';

--- a/docs/modules/wms/formats/wcs.md
+++ b/docs/modules/wms/formats/wcs.md
@@ -6,4 +6,27 @@ import {WmsDocsTabs} from '@site/src/components/docs/wms-docs-tabs';
 
 ![ogc-logo](../../../images/logos/ogc-logo-60.png)
 
-TBA
+WCS provides access to analytical geospatial coverages rather than rendered map images. The
+`@loaders.gl/wms` module exposes a focused source for capabilities discovery and `GetCoverage`
+requests.
+
+```js
+import {WCSCoverageSourceLoader} from '@loaders.gl/wms';
+
+const source = WCSCoverageSourceLoader.createDataSource('https://example.com/wcs', {
+  wcs: {
+    coverageId: 'elevation',
+    format: 'image/tiff'
+  }
+});
+
+const metadata = await source.getMetadata();
+const coverage = await source.getCoverage({
+  bbox: [-10, 40, 10, 50],
+  crs: 'http://www.opengis.net/def/crs/EPSG/0/4326'
+});
+```
+
+Binary responses are returned as `ArrayBuffer`. When `format` is a LERC media type and the source
+was created with a loaders.gl Core API, the response is decoded through `@loaders.gl/lerc` and
+returned as typed per-band arrays with statistics and masks preserved.

--- a/docs/modules/wms/services/ogc-api.md
+++ b/docs/modules/wms/services/ogc-api.md
@@ -2,7 +2,7 @@
 
 The `@loaders.gl/wms` module provides a deliberately small compatibility layer for modern OGC
 APIs. It supports the common discovery shape and the two most useful data paths for applications:
-feature collections and tiled resources.
+feature collections, tiled resources, coverages, and environmental observations.
 
 ## Features
 
@@ -47,6 +47,59 @@ const tileBytes = await source.getTile({z: 3, x: 4, y: 5});
 
 This is intentionally a minimal adapter. It does not attempt to implement every OGC API extension,
 server-side filter language, or conformance class.
+
+## Coverages
+
+The coverage adapter supports collection discovery and the standard collection coverage endpoint.
+It returns JSON coverage representations as objects and binary representations as `ArrayBuffer`
+values, leaving decoding to the appropriate loaders.
+
+```js
+import {OGCAPICoveragesSourceLoader} from '@loaders.gl/wms';
+
+const source = OGCAPICoveragesSourceLoader.createDataSource('https://example.com/ogcapi', {
+  'ogc-api-coverages': {collectionId: 'temperature'}
+});
+const coverage = await source.getCoverage({
+  bbox: [-10, 40, 10, 50],
+  subset: ['Lat(40,50)'],
+  format: 'application/json'
+});
+```
+
+## Environmental data
+
+OGC API EDR provides a small query client for position, area, radius, cube, trajectory, and
+corridor endpoints. The response is returned in the representation selected by the server,
+including GeoJSON and CoverageJSON.
+
+```js
+import {OGCAPIEDRSourceLoader} from '@loaders.gl/wms';
+
+const source = OGCAPIEDRSourceLoader.createDataSource('https://example.com/edr');
+const observations = await source.query({
+  collectionId: 'weather',
+  queryType: 'position',
+  coords: 'POINT(10 20)',
+  datetime: '2025-01-01',
+  parameterName: ['temperature', 'wind']
+});
+```
+
+## WCS
+
+`WCSCoverageSource` handles WCS `GetCapabilities` and `GetCoverage` requests. It preserves
+binary coverage responses and routes LERC responses through `@loaders.gl/lerc` when a Core API is
+available.
+
+```js
+import {WCSCoverageSourceLoader} from '@loaders.gl/wms';
+
+const source = WCSCoverageSourceLoader.createDataSource('https://example.com/wcs', {
+  wcs: {coverageId: 'elevation', format: 'image/tiff'}
+});
+const bytes = await source.getCoverage({bbox: [-10, 40, 10, 50]});
+```
 
 For a live feature-service example, see the [ldproxy demo](https://demo.ldproxy.net/daraa). Live
 services are not used by the test suite; repository fixtures remain the source of truth for CI.

--- a/modules/wms/src/index.ts
+++ b/modules/wms/src/index.ts
@@ -100,6 +100,26 @@ export {
   OGCAPITilesSource,
   OGCAPITilesSourceLoader
 } from './ogc-api-source-loader';
+export type {OGCAPIEDRQueryParameters, OGCAPIEDRSourceOptions} from './ogc-api-edr-source-loader';
+export {
+  OGCAPIEDRSource,
+  OGCAPIEDRSourceLoader
+} from './ogc-api-edr-source-loader';
+export type {
+  OGCAPICoveragesQueryParameters,
+  OGCAPICoveragesSourceOptions
+} from './ogc-api-coverages-source-loader';
+export {
+  OGCAPICoveragesSource,
+  OGCAPICoveragesSourceLoader
+} from './ogc-api-coverages-source-loader';
+export type {
+  WCSCoverage,
+  WCSCoverageMetadata,
+  WCSGetCoverageParameters,
+  WCSSourceOptions
+} from './wcs-source-loader';
+export {WCSCoverageSource, WCSCoverageSourceLoader} from './wcs-source-loader';
 
 export type {GeoServiceType, ServiceCapabilities} from './service-capabilities';
 export {

--- a/modules/wms/src/ogc-api-coverages-source-loader.ts
+++ b/modules/wms/src/ogc-api-coverages-source-loader.ts
@@ -1,0 +1,109 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {CoreAPI, DataSourceOptions, SourceLoader} from '@loaders.gl/loader-utils';
+import {DataSource} from '@loaders.gl/loader-utils';
+import type {OGCAPILandingPage, OGCAPICollection} from './ogc-api-source-loader';
+
+/** Options for an OGC API Coverages source. */
+export type OGCAPICoveragesSourceOptions = DataSourceOptions & {
+  /** Coverage request defaults. */
+  'ogc-api-coverages'?: {collectionId?: string; parameters?: Record<string, string>};
+};
+
+/** Parameters for a minimal OGC API Coverages query. */
+export type OGCAPICoveragesQueryParameters = {
+  /** Coverage collection identifier. */
+  collectionId?: string;
+  /** Bounding box in the requested CRS. */
+  bbox?: [number, number, number, number];
+  /** RFC 3339 instant or interval. */
+  datetime?: string;
+  /** Coverage dimension subsets, for example `Lat(40,45)`. */
+  subset?: string[];
+  /** Requested output media type. */
+  format?: string;
+  /** Additional query parameters. */
+  parameters?: Record<string, string | number | boolean>;
+  /** Abort signal for cancellation. */
+  signal?: AbortSignal;
+};
+
+/** Minimal OGC API Coverages source for discovery and coverage retrieval. */
+export class OGCAPICoveragesSource extends DataSource<string, OGCAPICoveragesSourceOptions> {
+  /** Creates an OGC API Coverages source. */
+  constructor(url: string, options: OGCAPICoveragesSourceOptions = {}, coreApi?: CoreAPI) {
+    super(url.replace(/\/$/, ''), options, OGCAPICoveragesSourceLoader.defaultOptions, coreApi);
+  }
+
+  /** Returns the OGC API landing page. */
+  async getLandingPage(): Promise<OGCAPILandingPage> {
+    return (await this.fetchJSON(this.url)) as OGCAPILandingPage;
+  }
+
+  /** Lists collections advertised by the service. */
+  async getCollections(): Promise<OGCAPICollection[]> {
+    const response = (await this.fetchJSON(`${this.url}/collections`)) as {
+      collections?: OGCAPICollection[];
+    };
+    return response.collections || [];
+  }
+
+  /** Fetches a coverage representation from a collection. */
+  async getCoverage(parameters: OGCAPICoveragesQueryParameters = {}): Promise<unknown> {
+    const collectionId = parameters.collectionId || this.options['ogc-api-coverages']?.collectionId;
+    if (!collectionId) throw new Error('OGC API Coverages request requires a collectionId');
+    const url = new URL(`${this.url}/collections/${encodeURIComponent(collectionId)}/coverage`);
+    const queryParameters = {
+      ...this.options['ogc-api-coverages']?.parameters,
+      ...parameters.parameters,
+      bbox: parameters.bbox?.join(','),
+      datetime: parameters.datetime,
+      subset: parameters.subset,
+      f: parameters.format
+    };
+    for (const [key, value] of Object.entries(queryParameters)) {
+      if (Array.isArray(value)) {
+        for (const item of value) url.searchParams.append(key, item);
+      } else if (value !== undefined) {
+        url.searchParams.set(key, String(value));
+      }
+    }
+    const response = await this.fetch(url.toString(), {
+      signal: parameters.signal,
+      headers: {Accept: parameters.format || 'application/json'}
+    });
+    if (!response.ok) throw new Error(`OGC API Coverages request failed: ${response.status}`);
+    const contentType = response.headers.get('content-type') || parameters.format || '';
+    return /json/i.test(contentType) ? response.json() : response.arrayBuffer();
+  }
+
+  /** Fetches and decodes a JSON service response. */
+  private async fetchJSON(url: string): Promise<unknown> {
+    const response = await this.fetch(url, {headers: {Accept: 'application/json'}});
+    if (!response.ok) throw new Error(`OGC API Coverages request failed: ${response.status}`);
+    return response.json();
+  }
+}
+
+/** Source loader for minimal OGC API Coverages support. */
+export const OGCAPICoveragesSourceLoader = {
+  dataType: null as unknown as OGCAPICoveragesSource,
+  batchType: null as never,
+  name: 'OGC API Coverages',
+  id: 'ogc-api-coverages',
+  module: 'wms',
+  version: '0.0.0',
+  extensions: [],
+  mimeTypes: ['application/json', 'image/tiff', 'application/octet-stream'],
+  type: 'ogc-api-coverages',
+  fromUrl: true,
+  fromBlob: false,
+  options: {'ogc-api-coverages': {}},
+  defaultOptions: {'ogc-api-coverages': {}},
+  testURL: (url: string): boolean =>
+    /(?:\/coverage(?:s)?(?:\/|$)|ogc[/-]?api[/-]?coverages)/i.test(url),
+  createDataSource: (url: string, options: OGCAPICoveragesSourceOptions = {}, coreApi?: CoreAPI) =>
+    new OGCAPICoveragesSource(url, options, coreApi)
+} as const satisfies SourceLoader<OGCAPICoveragesSource>;

--- a/modules/wms/src/ogc-api-edr-source-loader.ts
+++ b/modules/wms/src/ogc-api-edr-source-loader.ts
@@ -1,0 +1,124 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {CoreAPI, DataSourceOptions, SourceLoader} from '@loaders.gl/loader-utils';
+import {DataSource} from '@loaders.gl/loader-utils';
+import type {OGCAPILandingPage, OGCAPICollection} from './ogc-api-source-loader';
+
+/** Options for an OGC API EDR source. */
+export type OGCAPIEDRSourceOptions = DataSourceOptions & {
+  /** EDR request defaults. */
+  'ogc-api-edr'?: {collectionId?: string; parameters?: Record<string, string>};
+};
+
+/** Parameters shared by OGC API EDR query endpoints. */
+export type OGCAPIEDRQueryParameters = {
+  /** Collection identifier. */
+  collectionId?: string;
+  /** EDR query path, such as `position`, `area`, or `cube`. */
+  queryType: 'position' | 'radius' | 'area' | 'cube' | 'trajectory' | 'corridor';
+  /** Position or geometry encoded as required by the EDR server. */
+  coords?: string;
+  /** Bounding box in source coordinates. */
+  bbox?: [number, number, number, number];
+  /** RFC 3339 time or interval. */
+  datetime?: string;
+  /** Requested parameter identifiers. */
+  parameterName?: string | string[];
+  /** Vertical range or level. */
+  z?: string;
+  /** Requested CRS. */
+  crs?: string;
+  /** Response format. */
+  format?: string;
+  /** Additional query parameters. */
+  parameters?: Record<string, string | number | boolean>;
+  /** Abort signal for cancellation. */
+  signal?: AbortSignal;
+};
+
+/** Minimal OGC API EDR source for discovery and spatiotemporal queries. */
+export class OGCAPIEDRSource extends DataSource<string, OGCAPIEDRSourceOptions> {
+  /** Creates an EDR source. */
+  constructor(url: string, options: OGCAPIEDRSourceOptions = {}, coreApi?: CoreAPI) {
+    super(url.replace(/\/$/, ''), options, OGCAPIEDRSourceLoader.defaultOptions, coreApi);
+  }
+
+  /** Returns the EDR landing page. */
+  async getLandingPage(): Promise<OGCAPILandingPage> {
+    return (await this.fetchJSON(this.url)) as OGCAPILandingPage;
+  }
+
+  /** Lists collections advertised by the EDR service. */
+  async getCollections(): Promise<OGCAPICollection[]> {
+    const response = (await this.fetchJSON(`${this.url}/collections`)) as {
+      collections?: OGCAPICollection[];
+    };
+    return response.collections || [];
+  }
+
+  /** Executes a focused EDR spatiotemporal query and returns the advertised representation. */
+  async query(parameters: OGCAPIEDRQueryParameters): Promise<unknown> {
+    const collectionId = parameters.collectionId || this.options['ogc-api-edr']?.collectionId;
+    if (!collectionId) throw new Error('OGC API EDR query requires a collectionId');
+    const url = new URL(
+      `${this.url}/collections/${encodeURIComponent(collectionId)}/${parameters.queryType}`
+    );
+    const queryParameters = {
+      ...this.options['ogc-api-edr']?.parameters,
+      ...parameters.parameters,
+      coords: parameters.coords,
+      bbox: parameters.bbox?.join(','),
+      datetime: parameters.datetime,
+      parameter_name: Array.isArray(parameters.parameterName)
+        ? parameters.parameterName.join(',')
+        : parameters.parameterName,
+      z: parameters.z,
+      crs: parameters.crs,
+      f: parameters.format
+    };
+    for (const [key, value] of Object.entries(queryParameters)) {
+      if (value !== undefined) url.searchParams.set(key, String(value));
+    }
+    const response = await this.fetch(url.toString(), {
+      signal: parameters.signal,
+      headers: {Accept: parameters.format || 'application/geo+json, application/json;q=0.9'}
+    });
+    if (!response.ok) throw new Error(`OGC API EDR request failed: ${response.status}`);
+    return readResponse(response, parameters.format);
+  }
+
+  /** Fetches and decodes a JSON service response. */
+  private async fetchJSON(url: string): Promise<unknown> {
+    const response = await this.fetch(url, {headers: {Accept: 'application/json'}});
+    if (!response.ok) throw new Error(`OGC API EDR request failed: ${response.status}`);
+    return response.json();
+  }
+}
+
+/** Source loader for OGC API EDR services. */
+export const OGCAPIEDRSourceLoader = {
+  dataType: null as unknown as OGCAPIEDRSource,
+  batchType: null as never,
+  name: 'OGC API EDR',
+  id: 'ogc-api-edr',
+  module: 'wms',
+  version: '0.0.0',
+  extensions: [],
+  mimeTypes: ['application/json', 'application/geo+json'],
+  type: 'ogc-api-edr',
+  fromUrl: true,
+  fromBlob: false,
+  options: {'ogc-api-edr': {}},
+  defaultOptions: {'ogc-api-edr': {}},
+  testURL: (url: string): boolean => /(?:\/edr(?:\/|$)|ogc[/-]?api[/-]?edr)/i.test(url),
+  createDataSource: (url: string, options: OGCAPIEDRSourceOptions = {}, coreApi?: CoreAPI) =>
+    new OGCAPIEDRSource(url, options, coreApi)
+} as const satisfies SourceLoader<OGCAPIEDRSource>;
+
+/** Reads JSON or binary content according to the response headers. */
+async function readResponse(response: Response, format?: string): Promise<unknown> {
+  const contentType = response.headers.get('content-type') || format || '';
+  return /json/i.test(contentType) ? response.json() : response.arrayBuffer();
+}

--- a/modules/wms/src/ogc-api-edr-source-loader.ts
+++ b/modules/wms/src/ogc-api-edr-source-loader.ts
@@ -71,7 +71,7 @@ export class OGCAPIEDRSource extends DataSource<string, OGCAPIEDRSourceOptions> 
       coords: parameters.coords,
       bbox: parameters.bbox?.join(','),
       datetime: parameters.datetime,
-      parameter_name: Array.isArray(parameters.parameterName)
+      'parameter-name': Array.isArray(parameters.parameterName)
         ? parameters.parameterName.join(',')
         : parameters.parameterName,
       z: parameters.z,

--- a/modules/wms/src/service-runtime.ts
+++ b/modules/wms/src/service-runtime.ts
@@ -7,6 +7,9 @@ import {CSWSourceLoader} from './csw-source-loader';
 import {WMSSourceLoader} from './wms-source-loader';
 import {WMTSSourceLoader} from './wmts-source-loader';
 import {WFSSourceLoader} from './wfs-source-loader';
+import {OGCAPIEDRSourceLoader} from './ogc-api-edr-source-loader';
+import {OGCAPICoveragesSourceLoader} from './ogc-api-coverages-source-loader';
+import {WCSCoverageSourceLoader} from './wcs-source-loader';
 
 /** A source loader that can be selected by the universal service runtime. */
 export type ServiceSourceLoader = SourceLoader;
@@ -70,6 +73,9 @@ export const DEFAULT_SERVICE_LOADERS: readonly ServiceSourceLoader[] = [
   WMTSSourceLoader,
   WMSSourceLoader,
   WFSSourceLoader,
+  WCSCoverageSourceLoader,
+  OGCAPICoveragesSourceLoader,
+  OGCAPIEDRSourceLoader,
   CSWSourceLoader
 ];
 

--- a/modules/wms/src/wcs-source-loader.ts
+++ b/modules/wms/src/wcs-source-loader.ts
@@ -38,6 +38,8 @@ export type WCSGetCoverageParameters = {
   format?: string;
   /** WCS 2.x subset expressions, for example `Long(10,20)`. */
   subset?: string[];
+  /** Axis names used when converting bbox to WCS 2.x subset expressions. */
+  subsetAxes?: [string, string];
   /** Requested output width. */
   width?: number;
   /** Requested output height. */
@@ -80,23 +82,7 @@ export class WCSCoverageSource extends DataSource<string, WCSSourceOptions> {
 
   /** Returns normalized coverage metadata from GetCapabilities. */
   async getMetadata(): Promise<WCSCoverageMetadata> {
-    const capabilities = (await this.getCapabilities()) as any;
-    const coverages = Array.isArray(capabilities?.contents?.layers)
-      ? capabilities.contents.layers.map((coverage: any) => ({
-          identifier: coverage.identifier,
-          title: coverage.title,
-          format: coverage.formats,
-          boundingBox: coverage.bounds
-            ? [
-                coverage.bounds.left,
-                coverage.bounds.bottom,
-                coverage.bounds.right,
-                coverage.bounds.top
-              ]
-            : undefined
-        }))
-      : [];
-    return {title: capabilities?.serviceIdentification?.title, coverages};
+    return normalizeWCSMetadata(await this.getCapabilities());
   }
 
   /** Fetches a coverage and decodes LERC responses through the existing loader. */
@@ -126,17 +112,31 @@ export class WCSCoverageSource extends DataSource<string, WCSSourceOptions> {
   /** Builds a WCS 2.x GetCoverage URL. */
   getCoverageURL(parameters: WCSGetCoverageParameters = {}): string {
     const defaults = this.options.wcs || {};
+    const version = defaults.version || '2.0.1';
     const query: Record<string, string | number | boolean | readonly string[] | undefined> = {
       service: 'WCS',
       request: 'GetCoverage',
-      version: defaults.version || '2.0.1',
+      version,
       coverageId: parameters.coverageId || defaults.coverageId,
       format: parameters.format || defaults.format || 'image/tiff',
-      bbox: parameters.bbox?.join(','),
       subset: parameters.subset
     };
-    if (parameters.crs) query.subsetCRS = parameters.crs;
-    if (parameters.responseCRS) query.outputCRS = parameters.responseCRS;
+    if (version.startsWith('2')) {
+      const [firstAxis, secondAxis] = parameters.subsetAxes || ['Long', 'Lat'];
+      if (parameters.bbox) {
+        query.subset = [
+          `${firstAxis}(${parameters.bbox[0]},${parameters.bbox[2]})`,
+          `${secondAxis}(${parameters.bbox[1]},${parameters.bbox[3]})`,
+          ...(parameters.subset || [])
+        ];
+      }
+      if (parameters.crs) query.subsetCRS = parameters.crs;
+      if (parameters.responseCRS) query.outputCRS = parameters.responseCRS;
+    } else {
+      query.bbox = parameters.bbox?.join(',');
+      if (parameters.crs) query.crs = parameters.crs;
+      if (parameters.responseCRS) query.responseCRS = parameters.responseCRS;
+    }
     if (parameters.width) query.width = parameters.width;
     if (parameters.height) query.height = parameters.height;
     return this.createURL({...defaults.parameters, ...query, ...parameters.parameters});
@@ -186,4 +186,75 @@ export const WCSCoverageSourceLoader = {
 /** Checks a service response and reports a protocol-specific error. */
 async function checkResponse(response: Response, operation: string): Promise<void> {
   if (!response.ok) throw new Error(`${operation} request failed: ${response.status}`);
+}
+
+/** Normalizes both legacy and case-preserving WCS capability trees. */
+function normalizeWCSMetadata(capabilities: WCSCapabilities): WCSCoverageMetadata {
+  const rawCapabilities = capabilities as any;
+  const serviceIdentification = getProperty(
+    rawCapabilities,
+    'serviceIdentification',
+    'ServiceIdentification'
+  );
+  const contents = getProperty(rawCapabilities, 'contents', 'Contents') || {};
+  const rawCoverages = getProperty(
+    contents,
+    'layers',
+    'layer',
+    'CoverageSummary',
+    'coverageSummary'
+  );
+  const coverages = asArray(rawCoverages)
+    .map(coverage => {
+      const bounds = getProperty(coverage, 'bounds', 'BoundingBox', 'WGS84BoundingBox');
+      const lowerCorner = parseNumbers(getProperty(bounds, 'lowerCorner', 'LowerCorner'));
+      const upperCorner = parseNumbers(getProperty(bounds, 'upperCorner', 'UpperCorner'));
+      return {
+        identifier: readText(getProperty(coverage, 'identifier', 'Identifier')),
+        title: readText(getProperty(coverage, 'title', 'Title')) || undefined,
+        format: asArray(getProperty(coverage, 'formats', 'format', 'Format')).map(readText),
+        boundingBox:
+          lowerCorner.length >= 2 && upperCorner.length >= 2
+            ? ([lowerCorner[0], lowerCorner[1], upperCorner[0], upperCorner[1]] as [
+                number,
+                number,
+                number,
+                number
+              ])
+            : undefined
+      };
+    })
+    .filter(coverage => coverage.identifier);
+  return {
+    title: readText(getProperty(serviceIdentification, 'title', 'Title')) || undefined,
+    coverages
+  };
+}
+
+/** Reads a property using the key casing used by a WCS version. */
+function getProperty(value: any, ...names: string[]): any {
+  if (!value) return undefined;
+  for (const name of names) {
+    if (value[name] !== undefined) return value[name];
+  }
+  return undefined;
+}
+
+/** Converts a parser value into a list. */
+function asArray(value: any): any[] {
+  return value === undefined || value === null ? [] : Array.isArray(value) ? value : [value];
+}
+
+/** Extracts text from the XML parser's scalar or `#text` representation. */
+function readText(value: any): string {
+  return value === undefined || value === null
+    ? ''
+    : typeof value === 'object'
+      ? String(value['#text'] || '')
+      : String(value);
+}
+
+/** Parses an XML corner value into numeric coordinates. */
+function parseNumbers(value: any): number[] {
+  return readText(value).trim().split(/\s+/).map(Number).filter(Number.isFinite);
 }

--- a/modules/wms/src/wcs-source-loader.ts
+++ b/modules/wms/src/wcs-source-loader.ts
@@ -1,0 +1,189 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {LERCData} from '@loaders.gl/lerc';
+import {LERCLoader} from '@loaders.gl/lerc';
+import type {CoreAPI, DataSourceOptions, SourceLoader} from '@loaders.gl/loader-utils';
+import {DataSource} from '@loaders.gl/loader-utils';
+import type {WCSCapabilities} from './wip/lib/wcs/parse-wcs-capabilities';
+import {parseWCSCapabilities} from './wip/lib/wcs/parse-wcs-capabilities';
+
+/** Options for WCS coverage requests. */
+export type WCSSourceOptions = DataSourceOptions & {
+  /** WCS request defaults. */
+  wcs?: {
+    /** WCS protocol version. */
+    version?: string;
+    /** Default coverage identifier. */
+    coverageId?: string;
+    /** Default response media type. */
+    format?: string;
+    /** Additional service-specific parameters. */
+    parameters?: Record<string, string | number | boolean>;
+  };
+};
+
+/** Parameters for a WCS GetCoverage request. */
+export type WCSGetCoverageParameters = {
+  /** Coverage identifier, if not configured on the source. */
+  coverageId?: string;
+  /** Bounding box in source coordinates. */
+  bbox?: [number, number, number, number];
+  /** CRS of the bounding box. */
+  crs?: string;
+  /** CRS of the returned coverage. */
+  responseCRS?: string;
+  /** Requested response media type. */
+  format?: string;
+  /** WCS 2.x subset expressions, for example `Long(10,20)`. */
+  subset?: string[];
+  /** Requested output width. */
+  width?: number;
+  /** Requested output height. */
+  height?: number;
+  /** Additional service-specific parameters. */
+  parameters?: Record<string, string | number | boolean>;
+  /** Abort signal for cancellation. */
+  signal?: AbortSignal;
+};
+
+/** Response from a WCS GetCoverage request. */
+export type WCSCoverage = ArrayBuffer | LERCData;
+
+/** Minimal normalized WCS coverage metadata. */
+export type WCSCoverageMetadata = {
+  /** Service title. */
+  title?: string;
+  /** Advertised coverage identifiers. */
+  coverages: Array<{
+    identifier: string;
+    title?: string;
+    format?: string[];
+    boundingBox?: [number, number, number, number];
+  }>;
+};
+
+/** WCS source with capabilities and GetCoverage support. */
+export class WCSCoverageSource extends DataSource<string, WCSSourceOptions> {
+  /** Creates a WCS source. */
+  constructor(url: string, options: WCSSourceOptions = {}, coreApi?: CoreAPI) {
+    super(url.replace(/\/$/, ''), options, WCSCoverageSourceLoader.defaultOptions, coreApi);
+  }
+
+  /** Fetches and parses the WCS GetCapabilities document. */
+  async getCapabilities(): Promise<WCSCapabilities> {
+    const response = await this.fetch(this.getCapabilitiesURL());
+    await checkResponse(response, 'WCS GetCapabilities');
+    return parseWCSCapabilities(await response.text(), {});
+  }
+
+  /** Returns normalized coverage metadata from GetCapabilities. */
+  async getMetadata(): Promise<WCSCoverageMetadata> {
+    const capabilities = (await this.getCapabilities()) as any;
+    const coverages = Array.isArray(capabilities?.contents?.layers)
+      ? capabilities.contents.layers.map((coverage: any) => ({
+          identifier: coverage.identifier,
+          title: coverage.title,
+          format: coverage.formats,
+          boundingBox: coverage.bounds
+            ? [
+                coverage.bounds.left,
+                coverage.bounds.bottom,
+                coverage.bounds.right,
+                coverage.bounds.top
+              ]
+            : undefined
+        }))
+      : [];
+    return {title: capabilities?.serviceIdentification?.title, coverages};
+  }
+
+  /** Fetches a coverage and decodes LERC responses through the existing loader. */
+  async getCoverage(parameters: WCSGetCoverageParameters = {}): Promise<WCSCoverage> {
+    const response = await this.fetch(this.getCoverageURL(parameters), {
+      signal: parameters.signal,
+      headers: {Accept: parameters.format || this.getDefaultFormat()}
+    });
+    await checkResponse(response, 'WCS GetCoverage');
+    const format = parameters.format || this.getDefaultFormat();
+    const arrayBuffer = await response.arrayBuffer();
+    if (/lerc/i.test(format)) {
+      return (await this.coreApi.parse(arrayBuffer, LERCLoader, this.loadOptions)) as LERCData;
+    }
+    return arrayBuffer;
+  }
+
+  /** Builds a WCS GetCapabilities URL. */
+  getCapabilitiesURL(): string {
+    return this.createURL({
+      service: 'WCS',
+      request: 'GetCapabilities',
+      version: this.options.wcs?.version
+    });
+  }
+
+  /** Builds a WCS 2.x GetCoverage URL. */
+  getCoverageURL(parameters: WCSGetCoverageParameters = {}): string {
+    const defaults = this.options.wcs || {};
+    const query: Record<string, string | number | boolean | readonly string[] | undefined> = {
+      service: 'WCS',
+      request: 'GetCoverage',
+      version: defaults.version || '2.0.1',
+      coverageId: parameters.coverageId || defaults.coverageId,
+      format: parameters.format || defaults.format || 'image/tiff',
+      bbox: parameters.bbox?.join(','),
+      subset: parameters.subset
+    };
+    if (parameters.crs) query.subsetCRS = parameters.crs;
+    if (parameters.responseCRS) query.outputCRS = parameters.responseCRS;
+    if (parameters.width) query.width = parameters.width;
+    if (parameters.height) query.height = parameters.height;
+    return this.createURL({...defaults.parameters, ...query, ...parameters.parameters});
+  }
+
+  /** Returns the configured response format. */
+  private getDefaultFormat(): string {
+    return this.options.wcs?.format || 'image/tiff';
+  }
+
+  /** Adds WCS query parameters to the service URL. */
+  private createURL(
+    parameters: Record<string, string | number | boolean | readonly string[] | undefined>
+  ): string {
+    const url = new URL(this.url);
+    for (const [key, value] of Object.entries(parameters)) {
+      if (Array.isArray(value)) {
+        for (const item of value) url.searchParams.append(key, item);
+      } else if (value !== undefined) {
+        url.searchParams.set(key, String(value));
+      }
+    }
+    return url.toString();
+  }
+}
+
+/** Source loader for WCS coverage services. */
+export const WCSCoverageSourceLoader = {
+  dataType: null as unknown as WCSCoverageSource,
+  batchType: null as never,
+  name: 'WCS Coverage',
+  id: 'wcs-coverage',
+  module: 'wms',
+  version: '0.0.0',
+  extensions: [],
+  mimeTypes: ['application/xml', 'image/tiff', 'image/lerc'],
+  type: 'wcs-coverage',
+  fromUrl: true,
+  fromBlob: false,
+  options: {wcs: {}},
+  defaultOptions: {wcs: {}},
+  testURL: (url: string): boolean => /(?:wcs|GetCapabilities.*WCS|service=WCS)/i.test(url),
+  createDataSource: (url: string, options: WCSSourceOptions = {}, coreApi?: CoreAPI) =>
+    new WCSCoverageSource(url, options, coreApi)
+} as const satisfies SourceLoader<WCSCoverageSource>;
+
+/** Checks a service response and reports a protocol-specific error. */
+async function checkResponse(response: Response, operation: string): Promise<void> {
+  if (!response.ok) throw new Error(`${operation} request failed: ${response.status}`);
+}

--- a/modules/wms/test/coverage-services.spec.ts
+++ b/modules/wms/test/coverage-services.spec.ts
@@ -12,7 +12,8 @@ test('WCSCoverageSource builds GetCoverage requests and preserves binary respons
   source.fetch = async url => {
     expect(url).toContain('request=GetCoverage');
     expect(url).toContain('coverageId=elevation');
-    expect(url).toContain('bbox=1%2C2%2C3%2C4');
+    expect(url).toContain('subset=Long%281%2C3%29');
+    expect(url).toContain('subset=Lat%282%2C4%29');
     return new Response(new Uint8Array([1, 2, 3]), {
       headers: {'content-type': 'image/tiff'}
     });
@@ -44,7 +45,7 @@ test('OGC API EDR builds a position query with temporal and parameter filters', 
     expect(url).toContain('/collections/weather/position');
     expect(url).toContain('coords=POINT%2810+20%29');
     expect(url).toContain('datetime=2025-01-01');
-    expect(url).toContain('parameter_name=temperature%2Cwind');
+    expect(url).toContain('parameter-name=temperature%2Cwind');
     return new Response(JSON.stringify({type: 'CoverageJSON'}), {
       headers: {'content-type': 'application/json'}
     });

--- a/modules/wms/test/coverage-services.spec.ts
+++ b/modules/wms/test/coverage-services.spec.ts
@@ -1,0 +1,61 @@
+import {expect, test} from 'vitest';
+import {
+  OGCAPICoveragesSourceLoader,
+  OGCAPIEDRSourceLoader,
+  WCSCoverageSourceLoader
+} from '@loaders.gl/wms';
+
+test('WCSCoverageSource builds GetCoverage requests and preserves binary responses', async () => {
+  const source = WCSCoverageSourceLoader.createDataSource('https://example.com/geoserver/wcs', {
+    wcs: {coverageId: 'elevation', format: 'image/tiff'}
+  });
+  source.fetch = async url => {
+    expect(url).toContain('request=GetCoverage');
+    expect(url).toContain('coverageId=elevation');
+    expect(url).toContain('bbox=1%2C2%2C3%2C4');
+    return new Response(new Uint8Array([1, 2, 3]), {
+      headers: {'content-type': 'image/tiff'}
+    });
+  };
+  const response = await source.getCoverage({bbox: [1, 2, 3, 4], width: 32, height: 16});
+  expect(response).toBeInstanceOf(ArrayBuffer);
+});
+
+test('OGC API Coverages requests a collection subset and decodes JSON', async () => {
+  const source = OGCAPICoveragesSourceLoader.createDataSource('https://example.com/coverages', {
+    'ogc-api-coverages': {collectionId: 'temperature'}
+  });
+  source.fetch = async url => {
+    expect(url).toContain('/collections/temperature/coverage');
+    expect(url).toContain('bbox=-10%2C-5%2C10%2C5');
+    expect(url).toContain('subset=Lat%2840%2C45%29');
+    return new Response(JSON.stringify({type: 'Coverage', domain: {}}), {
+      headers: {'content-type': 'application/json'}
+    });
+  };
+  await expect(
+    source.getCoverage({bbox: [-10, -5, 10, 5], subset: ['Lat(40,45)']})
+  ).resolves.toMatchObject({type: 'Coverage'});
+});
+
+test('OGC API EDR builds a position query with temporal and parameter filters', async () => {
+  const source = OGCAPIEDRSourceLoader.createDataSource('https://example.com/edr');
+  source.fetch = async url => {
+    expect(url).toContain('/collections/weather/position');
+    expect(url).toContain('coords=POINT%2810+20%29');
+    expect(url).toContain('datetime=2025-01-01');
+    expect(url).toContain('parameter_name=temperature%2Cwind');
+    return new Response(JSON.stringify({type: 'CoverageJSON'}), {
+      headers: {'content-type': 'application/json'}
+    });
+  };
+  await expect(
+    source.query({
+      collectionId: 'weather',
+      queryType: 'position',
+      coords: 'POINT(10 20)',
+      datetime: '2025-01-01',
+      parameterName: ['temperature', 'wind']
+    })
+  ).resolves.toMatchObject({type: 'CoverageJSON'});
+});


### PR DESCRIPTION
## Goals

Add focused analytical and environmental service sources so applications can retrieve coverages and spatiotemporal observations without expanding the service abstraction into a full GIS SDK.

## Changes

- Add WCS capabilities discovery and WCS 2.x GetCoverage requests.
- Preserve binary WCS responses and decode LERC through the existing Core API and LERC loader.
- Add minimal OGC API Coverages discovery and collection coverage retrieval.
- Add OGC API EDR discovery and position, area, radius, cube, trajectory, and corridor query support.
- Register the new sources with the WMS exports and service runtime.
- Add hermetic request/response tests and documentation examples.

## Validation

- `yarn lint fix`
- Targeted TypeScript review found no diagnostics in the new source files.

The full repository build and Vitest setup are currently blocked by unrelated local loader-utils edits that remove columnar-predicate exports required by existing packages.