### PR TITLE
feat(las): add LAS 1.5 writer and codec compatibility

### DIFF
--- a/docs/modules/las/formats/las.md
+++ b/docs/modules/las/formats/las.md
@@ -44,8 +44,8 @@ LAS file versions and LASzip codec versions are independent. A claim such as "LA
 
 | Capability | TypeScript status |
 | --- | --- |
-| Uncompressed LAS writing | Partial. Supports LAS output for represented mesh/table fields. |
-| LAS versions | Versions 1.0-1.4 are selectable and LAS 1.5 is rejected. Round-trip coverage currently targets default LAS 1.2 and LAS 1.4/PDRF 7; full version conformance is not claimed. |
+| Uncompressed LAS writing | Partial. Supports LAS output for represented mesh/table fields, including LAS 1.5 modern records with WKT metadata. |
+| LAS versions | Versions 1.0-1.5 are selectable. LAS 1.5 requires `las.wkt` and modern PDRF 6-10. Round-trip coverage targets default LAS 1.2, LAS 1.4/PDRF 7, and LAS 1.5/PDRF 7; full version conformance is not claimed. |
 | Point data record formats | PDRF 0-10 are selectable. Position, intensity, classification, RGB, NIR, GPS time, return/scan fields, waveform packet references, and configured Extra Bytes are mapped from input attributes. Missing fields are zero-filled. |
 | LAZ writing | Supported for PDRF 0-10 with fixed-size or variable-size LASzip chunk tables. Legacy PDRFs use LASzip compressor 2/item version 2; modern PDRFs use layered compressor 3/item version 3. |
 | COPC writing | Supported by `@loaders.gl/copc` through its separate `COPCWriter` entry point. |
@@ -144,7 +144,7 @@ PDRF 7 performance checks combine deterministic memory invariants with conservat
 
 | Version | Point data record formats | Main additions | loaders.gl status |
 | --- | --- | --- | --- |
-| 1.5 | 6-10 in LAS 1.5 mode | Backward compatibility with LAS 1.1-1.4, stricter modern point record model, WKT CRS records, and an extended public header. | TypeScript reads and validates the modern header, parses its GPS-time fields, and decodes PDRF 6-10; writing is not targeted. |
+| 1.5 | 6-10 in LAS 1.5 mode | Backward compatibility with LAS 1.1-1.4, stricter modern point record model, WKT CRS records, and an extended public header. | TypeScript reads and validates the modern header, parses its GPS-time fields, decodes PDRF 6-10, and writes modern records when WKT metadata is supplied. |
 | 1.4 | 0-10 | 64-bit point counts and offsets, EVLR refinements, WKT CRS support, Extra Bytes VLR, modern PDRFs 6-10. | Reads uncompressed LAS 1.4 and decodes LAZ chunks for PDRF 0-10. |
 | 1.3 | 0-5 | EVLRs and waveform packet support. | TypeScript LAZ decoding supports all PDRFs, including raw PDRF 4/5 waveform references. |
 | 1.2 | 0-3 | RGB point formats and broader geospatial metadata conventions. | Read and write support for common uncompressed LAS attributes. |
@@ -264,4 +264,4 @@ Within the documented version, PDRF, and codec matrix, the TypeScript implementa
 
 | Order | Work item | Impact | Cost | Acceptance target |
 | --- | --- | --- | --- | --- |
-| 1 | Complete LAS 1.5 conformance and writing | Medium | Medium | Add broader independent-reader fixtures, validate LAS 1.5 WKT and extension semantics, and emit LAS 1.5 only after interoperability is demonstrated. |
+| 1 | Complete LAS 1.5 conformance and writing | Medium | Medium | Add broader independent-reader fixtures and validate LAS 1.5 output across WKT, extension, EVLR, and modern PDRF combinations. |

--- a/modules/las/src/las-writer.ts
+++ b/modules/las/src/las-writer.ts
@@ -20,6 +20,7 @@ const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
 const LAS_HEADER_LENGTH = 227;
 const LAS_1_4_HEADER_LENGTH = 375;
+const LAS_1_5_HEADER_LENGTH = 393;
 const VLR_HEADER_LENGTH = 54;
 const EXTRA_BYTES_DESCRIPTOR_LENGTH = 192;
 const DEFAULT_LAZ_CHUNK_SIZE = 50_000;
@@ -55,8 +56,14 @@ export type LASWriterOptions = WriterOptions & {
   las?: {
     /** Output container format. COPC has its own writer in @loaders.gl/copc. */
     format?: 'las' | 'laz';
-    /** LAS file version to write. LAS 1.5 writing is intentionally not supported. */
-    version?: '1.0' | '1.1' | '1.2' | '1.3' | '1.4';
+    /** LAS file version to write. LAS 1.5 requires a WKT CRS string. */
+    version?: '1.0' | '1.1' | '1.2' | '1.3' | '1.4' | '1.5';
+    /** WKT coordinate system required for LAS 1.5 output. */
+    wkt?: string;
+    /** Optional WKT math transform VLR for LAS 1.5 output. */
+    wktMathTransform?: string;
+    /** LAS 1.5 GPS time offset in the public header. */
+    timeOffset?: number;
     /** LAS point data record format to write. */
     pointDataRecordFormat?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
     /** Coordinate scale factors used to quantize positions into LAS integer coordinates. */
@@ -150,7 +157,17 @@ function encodeLASSync(data: Mesh | MeshArrowTable, options: LASWriterOptions = 
   }
   validateExtraBytesVLR(extraByteFields);
   const version = options.las?.version || (pointDataRecordFormat >= 6 ? '1.4' : '1.2');
-  const headerLength = version === '1.4' ? LAS_1_4_HEADER_LENGTH : LAS_HEADER_LENGTH;
+  const headerLength =
+    version === '1.5'
+      ? LAS_1_5_HEADER_LENGTH
+      : version === '1.4'
+        ? LAS_1_4_HEADER_LENGTH
+        : LAS_HEADER_LENGTH;
+  validateLASVersionOptions(version, pointDataRecordFormat, options);
+  const gpsTimeRange = getGpsTimeRange(gpsTimeAttribute, vertexCount);
+  if (version === '1.5' && options.las?.timeOffset && !gpsTimeAttribute) {
+    throw new Error('LASWriter: LAS 1.5 timeOffset requires a GPS time attribute');
+  }
   if (format === 'laz') {
     validateLAZOptions(version, pointDataRecordFormat, options.las?.chunkSize);
   }
@@ -219,7 +236,10 @@ function encodeLASSync(data: Mesh | MeshArrowTable, options: LASWriterOptions = 
     headerLength,
     pointDataRecordFormat,
     pointDataRecordLength,
-    returnCounts
+    returnCounts,
+    maxGpsTime: gpsTimeRange.maximum,
+    minGpsTime: gpsTimeRange.minimum,
+    timeOffset: options.las?.timeOffset || 0
   };
   if (format === 'laz') {
     return encodeLAZFile(
@@ -227,39 +247,72 @@ function encodeLASSync(data: Mesh | MeshArrowTable, options: LASWriterOptions = 
       writeParameters,
       options.las?.chunkSize,
       options.las?.variableChunkTable,
-      extraByteFields
+      extraByteFields,
+      options
     );
   }
 
-  const extraBytesVLR = encodeExtraBytesVLR(extraByteFields);
-  const pointDataOffset = headerLength + extraBytesVLR.byteLength;
+  const metadataVLR = encodeMetadataVLRs(extraByteFields, options);
+  const pointDataOffset = headerLength + metadataVLR.byteLength;
   const arrayBuffer = new ArrayBuffer(pointDataOffset + rawPointData.byteLength);
   writeHeader(new DataView(arrayBuffer), {
     ...writeParameters,
     pointDataOffset,
-    vlrCount: extraBytesVLR.byteLength ? 1 : 0
+    vlrCount: countMetadataVLRs(extraByteFields, options)
   });
   const bytes = new Uint8Array(arrayBuffer);
-  bytes.set(extraBytesVLR, headerLength);
+  bytes.set(metadataVLR, headerLength);
   bytes.set(rawPointData, pointDataOffset);
   return arrayBuffer;
 }
 
 /** Validate that the selected LAS header can represent the point record format. */
 function validatePointDataRecordVersion(version: string, pointDataRecordFormat: number): void {
+  const minimumVersionByPointFormat: Record<number, string> = {
+    0: '1.0',
+    1: '1.1',
+    2: '1.2',
+    3: '1.2'
+  };
+  const minimumVersion = minimumVersionByPointFormat[pointDataRecordFormat];
+  if (minimumVersion && version < minimumVersion) {
+    throw new Error(
+      `LASWriter: point data record format ${pointDataRecordFormat} requires LAS ${minimumVersion} or newer; received ${version}`
+    );
+  }
   if (
     pointDataRecordFormat >= 4 &&
     pointDataRecordFormat <= 5 &&
-    !['1.3', '1.4'].includes(version)
+    !['1.3', '1.4', '1.5'].includes(version)
   ) {
     throw new Error(
       `LASWriter: point data record format ${pointDataRecordFormat} requires LAS 1.3; received ${version}`
     );
   }
-  if (pointDataRecordFormat >= 6 && version !== '1.4') {
+  if (pointDataRecordFormat >= 6 && !['1.4', '1.5'].includes(version)) {
     throw new Error(
       `LASWriter: point data record format ${pointDataRecordFormat} requires LAS 1.4; received ${version}`
     );
+  }
+}
+
+/** Validate LAS 1.5 writer requirements before allocating point data. */
+function validateLASVersionOptions(
+  version: string,
+  pointDataRecordFormat: number,
+  options: LASWriterOptions
+): void {
+  if (version === '1.5') {
+    if (pointDataRecordFormat < 6 || pointDataRecordFormat > 10) {
+      throw new Error('LASWriter: LAS 1.5 output requires point data record format 6-10');
+    }
+    if (!options.las?.wkt?.trim()) {
+      throw new Error('LASWriter: LAS 1.5 output requires las.wkt');
+    }
+    const timeOffset = options.las?.timeOffset ?? 0;
+    if (!Number.isInteger(timeOffset) || timeOffset < 0 || timeOffset > 0xffff) {
+      throw new Error('LASWriter: LAS 1.5 timeOffset must be an unsigned 16-bit integer');
+    }
   }
 }
 
@@ -274,7 +327,7 @@ type LASWriteParameters = {
   /** Coordinate quantization offsets. */
   offset: [number, number, number];
   /** LAS file version. */
-  version: '1.0' | '1.1' | '1.2' | '1.3' | '1.4';
+  version: '1.0' | '1.1' | '1.2' | '1.3' | '1.4' | '1.5';
   /** Public header byte length. */
   headerLength: number;
   /** LAS point data record format. */
@@ -283,6 +336,12 @@ type LASWriteParameters = {
   pointDataRecordLength: number;
   /** Counts for the fifteen LAS 1.4 return-number buckets. */
   returnCounts: number[];
+  /** LAS 1.5 maximum GPS time, or zero when no GPS time is present. */
+  maxGpsTime: number;
+  /** LAS 1.5 minimum GPS time, or zero when no GPS time is present. */
+  minGpsTime: number;
+  /** LAS 1.5 GPS time offset. */
+  timeOffset: number;
 };
 
 /** Internal description of one encoded LAS Extra Bytes field. */
@@ -303,7 +362,8 @@ function encodeLAZFile(
   parameters: LASWriteParameters,
   requestedChunkSize?: number,
   variableChunkTable = false,
-  extraByteFields: LASExtraByteField[] = []
+  extraByteFields: LASExtraByteField[] = [],
+  options: LASWriterOptions = {}
 ): ArrayBuffer {
   const chunkSize = requestedChunkSize || DEFAULT_LAZ_CHUNK_SIZE;
   const laszipVLR = encodeLASzipVLR({
@@ -311,8 +371,8 @@ function encodeLAZFile(
     pointDataRecordLength: parameters.pointDataRecordLength,
     chunkSize: variableChunkTable ? VARIABLE_LAZ_CHUNK_SIZE : chunkSize
   });
-  const extraBytesVLR = encodeExtraBytesVLR(extraByteFields);
-  const pointDataOffset = parameters.headerLength + extraBytesVLR.byteLength + laszipVLR.byteLength;
+  const metadataVLR = encodeMetadataVLRs(extraByteFields, options);
+  const pointDataOffset = parameters.headerLength + metadataVLR.byteLength + laszipVLR.byteLength;
   const compressedChunks: Uint8Array[] = [];
   const chunkTableEntries: LAZChunkTableEntry[] = [];
 
@@ -349,11 +409,11 @@ function encodeLAZFile(
   writeHeader(dataView, {
     ...parameters,
     pointDataOffset,
-    vlrCount: extraBytesVLR.byteLength ? 2 : 1,
+    vlrCount: countMetadataVLRs(extraByteFields, options) + 1,
     compressed: true
   });
-  bytes.set(extraBytesVLR, parameters.headerLength);
-  bytes.set(laszipVLR, parameters.headerLength + extraBytesVLR.byteLength);
+  bytes.set(metadataVLR, parameters.headerLength);
+  bytes.set(laszipVLR, parameters.headerLength + metadataVLR.byteLength);
   writeUint64Fallback(dataView, pointDataOffset, chunkTableOffset);
   let compressedOffset = pointDataOffset + 8;
   for (const chunk of compressedChunks) {
@@ -458,6 +518,76 @@ function encodeExtraBytesVLR(fields: readonly LASExtraByteField[]): Uint8Array {
   return bytes;
 }
 
+/** Encode projection and Extra Bytes VLRs in the order used by the public header. */
+function encodeMetadataVLRs(
+  fields: readonly LASExtraByteField[],
+  options: LASWriterOptions
+): Uint8Array {
+  const records: Uint8Array[] = [];
+  if (options.las?.wktMathTransform) {
+    records.push(encodeProjectionVLR(2111, 'WKT Math Transform', options.las.wktMathTransform));
+  }
+  if (options.las?.wkt) {
+    records.push(encodeProjectionVLR(2112, 'WKT Coordinate System', options.las.wkt));
+  }
+  const extraBytesVLR = encodeExtraBytesVLR(fields);
+  if (extraBytesVLR.byteLength) {
+    records.push(extraBytesVLR);
+  }
+  const byteLength = records.reduce((total, record) => total + record.byteLength, 0);
+  const bytes = new Uint8Array(byteLength);
+  let offset = 0;
+  for (const record of records) {
+    bytes.set(record, offset);
+    offset += record.byteLength;
+  }
+  return bytes;
+}
+
+/** Encode one LAS WKT projection VLR. */
+function encodeProjectionVLR(recordId: 2111 | 2112, description: string, wkt: string): Uint8Array {
+  const payload = new TextEncoder().encode(wkt);
+  if (payload.byteLength > 0xffff) {
+    throw new Error(`LASWriter: WKT VLR ${recordId} exceeds the LAS VLR size limit`);
+  }
+  const bytes = new Uint8Array(VLR_HEADER_LENGTH + payload.byteLength);
+  const dataView = new DataView(bytes.buffer);
+  writeString(dataView, 2, 'LASF_Projection', 16);
+  dataView.setUint16(18, recordId, true);
+  dataView.setUint16(20, payload.byteLength, true);
+  writeString(dataView, 22, description, 32);
+  bytes.set(payload, VLR_HEADER_LENGTH);
+  return bytes;
+}
+
+/** Count the VLR records emitted by the metadata encoder. */
+function countMetadataVLRs(
+  fields: readonly LASExtraByteField[],
+  options: LASWriterOptions
+): number {
+  return (
+    (options.las?.wktMathTransform ? 1 : 0) + (options.las?.wkt ? 1 : 0) + (fields.length ? 1 : 0)
+  );
+}
+
+/** Return the finite GPS time range needed by the LAS 1.5 public header. */
+function getGpsTimeRange(
+  attribute: MeshAttribute | undefined,
+  vertexCount: number
+): {minimum: number; maximum: number} {
+  if (!attribute) {
+    return {minimum: 0, maximum: 0};
+  }
+  let minimum = Number(attribute.value[0]);
+  let maximum = minimum;
+  for (let vertexIndex = 1; vertexIndex < vertexCount; vertexIndex++) {
+    const value = Number(attribute.value[vertexIndex * attribute.size]);
+    minimum = Math.min(minimum, value);
+    maximum = Math.max(maximum, value);
+  }
+  return {minimum, maximum};
+}
+
 /** Validate that the Extra Bytes VLR payload fits its 16-bit length field. */
 function validateExtraBytesVLR(fields: readonly LASExtraByteField[]): void {
   const payloadByteLength = fields.length * EXTRA_BYTES_DESCRIPTOR_LENGTH;
@@ -474,7 +604,14 @@ function validateLAZOptions(
   pointDataRecordFormat: number,
   chunkSize?: number
 ): void {
-  if (pointDataRecordFormat <= 3 && !['1.2', '1.3', '1.4'].includes(version)) {
+  if (pointDataRecordFormat === 1 && !['1.1', '1.2', '1.3', '1.4', '1.5'].includes(version)) {
+    throw new Error(`LASWriter: LAZ PDRF 1 output requires LAS 1.1 or newer; received ${version}`);
+  }
+  if (
+    pointDataRecordFormat >= 2 &&
+    pointDataRecordFormat <= 3 &&
+    !['1.2', '1.3', '1.4', '1.5'].includes(version)
+  ) {
     throw new Error(
       `LASWriter: LAZ PDRF ${pointDataRecordFormat} output requires LAS 1.2 or newer; received ${version}`
     );
@@ -482,13 +619,13 @@ function validateLAZOptions(
   if (
     pointDataRecordFormat >= 4 &&
     pointDataRecordFormat <= 5 &&
-    !['1.3', '1.4'].includes(version)
+    !['1.3', '1.4', '1.5'].includes(version)
   ) {
     throw new Error(
       `LASWriter: LAZ PDRF ${pointDataRecordFormat} requires LAS 1.3 or newer; received ${version}`
     );
   }
-  if (pointDataRecordFormat >= 6 && version !== '1.4') {
+  if (pointDataRecordFormat >= 6 && !['1.4', '1.5'].includes(version)) {
     throw new Error(`LASWriter: LAZ output requires LAS 1.4; received ${version}`);
   }
   if (![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10].includes(pointDataRecordFormat)) {
@@ -759,11 +896,23 @@ function writeHeader(
   dataView.setUint32(100, parameters.vlrCount || 0, true);
   dataView.setUint8(104, parameters.pointDataRecordFormat | (parameters.compressed ? 0x80 : 0));
   dataView.setUint16(105, parameters.pointDataRecordLength, true);
-  dataView.setUint32(107, parameters.version === '1.4' ? 0 : parameters.vertexCount, true);
+  const isExtendedHeader = parameters.version === '1.4' || parameters.version === '1.5';
+  dataView.setUint32(107, isExtendedHeader ? 0 : parameters.vertexCount, true);
   for (let returnIndex = 0; returnIndex < 5; returnIndex++) {
     dataView.setUint32(
       111 + returnIndex * 4,
-      parameters.version === '1.4' ? 0 : parameters.returnCounts[returnIndex],
+      isExtendedHeader ? 0 : parameters.returnCounts[returnIndex],
+      true
+    );
+  }
+
+  if (parameters.version === '1.5') {
+    // LAS 1.5 requires WKT and stores the time range in the extended header.
+    dataView.setUint16(
+      6,
+      0x10 |
+        (parameters.maxGpsTime !== 0 || parameters.minGpsTime !== 0 ? 1 : 0) |
+        (parameters.timeOffset !== 0 ? 0x40 : 0),
       true
     );
   }
@@ -781,11 +930,16 @@ function writeHeader(
   dataView.setFloat64(211, parameters.boundingBox[1][2], true);
   dataView.setFloat64(219, parameters.boundingBox[0][2], true);
 
-  if (parameters.version === '1.4') {
+  if (isExtendedHeader) {
     writeUint64Fallback(dataView, 247, parameters.vertexCount);
     for (let returnIndex = 0; returnIndex < LAS_RETURN_BUCKET_COUNT; returnIndex++) {
       writeUint64Fallback(dataView, 255 + returnIndex * 8, parameters.returnCounts[returnIndex]);
     }
+  }
+  if (parameters.version === '1.5') {
+    dataView.setFloat64(375, parameters.maxGpsTime, true);
+    dataView.setFloat64(383, parameters.minGpsTime, true);
+    dataView.setUint16(391, parameters.timeOffset, true);
   }
 }
 

--- a/modules/las/src/las-writer.ts
+++ b/modules/las/src/las-writer.ts
@@ -239,7 +239,9 @@ function encodeLASSync(data: Mesh | MeshArrowTable, options: LASWriterOptions = 
     returnCounts,
     maxGpsTime: gpsTimeRange.maximum,
     minGpsTime: gpsTimeRange.minimum,
-    timeOffset: options.las?.timeOffset || 0
+    timeOffset: options.las?.timeOffset || 0,
+    hasGpsTime: Boolean(gpsTimeAttribute),
+    hasWkt: Boolean(options.las?.wkt)
   };
   if (format === 'laz') {
     return encodeLAZFile(
@@ -342,6 +344,10 @@ type LASWriteParameters = {
   minGpsTime: number;
   /** LAS 1.5 GPS time offset. */
   timeOffset: number;
+  /** Whether the input contained a GPS time attribute. */
+  hasGpsTime: boolean;
+  /** Whether a WKT coordinate-system VLR is emitted. */
+  hasWkt: boolean;
 };
 
 /** Internal description of one encoded LAS Extra Bytes field. */
@@ -546,7 +552,7 @@ function encodeMetadataVLRs(
 
 /** Encode one LAS WKT projection VLR. */
 function encodeProjectionVLR(recordId: 2111 | 2112, description: string, wkt: string): Uint8Array {
-  const payload = new TextEncoder().encode(wkt);
+  const payload = new TextEncoder().encode(`${wkt}\0`);
   if (payload.byteLength > 0xffff) {
     throw new Error(`LASWriter: WKT VLR ${recordId} exceeds the LAS VLR size limit`);
   }
@@ -910,11 +916,11 @@ function writeHeader(
     // LAS 1.5 requires WKT and stores the time range in the extended header.
     dataView.setUint16(
       6,
-      0x10 |
-        (parameters.maxGpsTime !== 0 || parameters.minGpsTime !== 0 ? 1 : 0) |
-        (parameters.timeOffset !== 0 ? 0x40 : 0),
+      0x10 | (parameters.hasGpsTime ? 1 : 0) | (parameters.timeOffset ? 0x40 : 0),
       true
     );
+  } else if (parameters.version === '1.4' && parameters.hasWkt) {
+    dataView.setUint16(6, 0x10, true);
   }
 
   dataView.setFloat64(131, parameters.scale[0], true);

--- a/modules/las/test/las-writer.spec.ts
+++ b/modules/las/test/las-writer.spec.ts
@@ -94,6 +94,33 @@ test('LASWriter#encode LAS 1.5 point format 7 with WKT metadata', async () => {
   expect(dataView.getUint16(6, true) & 0x10, 'sets the LAS 1.5 WKT flag').toBe(0x10);
   expect(data.loaderData.metadata?.wkt, 'round trips the WKT VLR').toBe('GEOGCRS["WGS 84"]');
 });
+test('LASWriter#sets WKT and GPS time flags independently', async () => {
+  const gpsMesh = {
+    ...mesh,
+    attributes: {
+      ...mesh.attributes,
+      gpsTime: {value: new Float64Array([0, 0, 0]), size: 1}
+    }
+  };
+  const arrayBuffer = await encode(gpsMesh, LASWriter, {
+    las: {
+      version: '1.5',
+      pointDataRecordFormat: 6,
+      wkt: 'GEOGCRS["WGS 84"]',
+      timeOffset: 10
+    }
+  });
+  const dataView = new DataView(arrayBuffer);
+  expect(dataView.getUint16(6, true) & 0x51, 'sets WKT, GPS time, and time offset flags').toBe(
+    0x51
+  );
+  expect(dataView.getUint16(391, true), 'writes the LAS 1.5 time offset').toBe(10);
+
+  const las14 = await encode(mesh, LASWriter, {
+    las: {version: '1.4', pointDataRecordFormat: 6, wkt: 'GEOGCRS["WGS 84"]'}
+  });
+  expect(new DataView(las14).getUint16(6, true) & 0x10, 'sets the LAS 1.4 WKT flag').toBe(0x10);
+});
 test('LASWriter#encodes fixed-chunk LAZ point formats 6-8', async () => {
   for (const pointDataRecordFormat of [6, 7, 8] as const) {
     const arrayBuffer = await encode(mesh, LASWriter, {

--- a/modules/las/test/las-writer.spec.ts
+++ b/modules/las/test/las-writer.spec.ts
@@ -78,6 +78,22 @@ test('LASWriter#encode LAS 1.4 point format 7', async () => {
     'TypeScript parser matches WASM parser for written classifications'
   ).toEqual(Array.from(wasmData.attributes.classification.value));
 });
+test('LASWriter#encode LAS 1.5 point format 7 with WKT metadata', async () => {
+  const arrayBuffer = await encode(mesh, LASWriter, {
+    las: {
+      version: '1.5',
+      pointDataRecordFormat: 7,
+      wkt: 'GEOGCRS["WGS 84"]'
+    }
+  });
+  const dataView = new DataView(arrayBuffer);
+  const data = await parse(arrayBuffer, LASLoader, {core: {worker: false}});
+  expect(data.loaderData.versionAsString, 'writes LAS 1.5 header').toBe('1.5');
+  expect(data.loaderData.headerSize, 'writes the LAS 1.5 header size').toBe(393);
+  expect(data.loaderData.pointsFormatId, 'writes modern point format 7').toBe(7);
+  expect(dataView.getUint16(6, true) & 0x10, 'sets the LAS 1.5 WKT flag').toBe(0x10);
+  expect(data.loaderData.metadata?.wkt, 'round trips the WKT VLR').toBe('GEOGCRS["WGS 84"]');
+});
 test('LASWriter#encodes fixed-chunk LAZ point formats 6-8', async () => {
   for (const pointDataRecordFormat of [6, 7, 8] as const) {
     const arrayBuffer = await encode(mesh, LASWriter, {
@@ -199,6 +215,10 @@ test('LASWriter#validates compressed output options', () => {
     new DataView(waveform!).getUint8(104) & 0x7f,
     'LAZ writer supports legacy waveform point formats'
   ).toBe(5);
+  const las11 = LASWriter.encodeSync?.(mesh, {
+    las: {format: 'laz', version: '1.1', pointDataRecordFormat: 1}
+  });
+  expect(new DataView(las11!).getUint8(25), 'LAZ PDRF 1 supports LAS 1.1').toBe(1);
   expect(
     () => LASWriter.encodeSync?.(mesh, {las: {format: 'laz', chunkSize: 0}}),
     'LAZ writer rejects empty chunks'


### PR DESCRIPTION
## Goals

- Complete the LAS 1.5 writer tranche for modern point records.
- Broaden valid legacy LAS/LAZ version coverage without weakening codec validation.
- Keep LAS 1.5 read conformance from PR #3849 as the foundation.

## Changes

- Add LAS 1.5 public-header writing with the 393-byte header layout.
- Emit mandatory WKT coordinate-system metadata and optional WKT math-transform metadata.
- Write LAS 1.5 Max/Min GPS Time and Time Offset fields with correct Global Encoding flags.
- Support LAS 1.5 output for modern PDRF 6-10 in LAS and LAZ containers.
- Allow valid PDRF 1/LAS 1.1 and legacy LAS version combinations.
- Add writer round-trip and compatibility regression tests.
- Update the LAS support matrix and remaining-roadmap documentation.

## Scope

PR #3849 already landed LAS 1.5 reader semantic validation. This PR contains the remaining writer and legacy-version compatibility work for the first three roadmap tranches. Unsupported LASzip entropy coders, pointwise compression, and legacy item version 1 remain explicitly rejected.

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn test-headless modules/las/test/las-writer.spec.ts`
- `yarn test-node`
