### PR TITLE
feat(scan): add managed append federation

### DIFF
--- a/docs/developer-guide/common-scan-architecture.md
+++ b/docs/developer-guide/common-scan-architecture.md
@@ -754,9 +754,11 @@ The roadmap is therefore format-support-first. Each tranche must ship three thin
    relational operators, and limits. 3D Tiles, I3S, WMS imagery, and STAC remain specialized while
    shared time, level-of-detail, and non-table discovery metadata are still open.
 8. **Portable relational growth — second slice landed.** Arrow and DuckDB now execute the shared
-   ordering, scalar-expression, grouped-aggregate, `UNION ALL`, and equi-join request shapes. The
-   next slice is planner-level source resolution and duplicate-column naming for larger federated
-   plans before these operators become part of the default panel.
+   ordering, scalar-expression, grouped-aggregate, `UNION ALL`, and equi-join request shapes.
+   Ordered append federation now resolves named `TableScanSource` instances through the existing
+   `DataSourceManager`, reconciles strict or union schemas with explicit column mappings, and
+   enforces source order, one global limit, cancellation, early termination, and batch provenance.
+   Managed multi-source joins remain outside this tranche.
 9. **GPU and acceleration — deferred.** Lower the same plan to luma.gl/WGSL masks or indices, add deferred or
    materialized compaction, and compare GPU/CPU explain telemetry. Add spatial predicates and nearest
    neighbor only when indexed CPU, GPU, and remote-source strategies have compatible semantics.
@@ -822,8 +824,60 @@ only the rows needed by the relational operators and returns a bounded Arrow tab
 format adapters and the GPU executor a conformance target without committing them to the same
 physical implementation. In-memory unions resolve named child tables through an explicit table map;
 joins expose child fields with a source-qualified name and use SQL inner-join null semantics. SQL
-backends compile the same child relations to `UNION ALL` and qualified `JOIN` statements, leaving
-source registration and federated catalog resolution to the next tranche.
+backends compile the same child relations to `UNION ALL` and qualified `JOIN` statements. The
+following managed append layer adds source registration and streaming resolution without extending
+that materialized join path into a distributed executor.
+
+### Managed append federation
+
+The first managed federation layer is an ordered append, not a distributed database. Applications
+register runtime sources once with `DataSourceManager`; `FederatedTableScanSource` subscribes to
+their stable ids while discovering metadata or producing batches. This intentionally aligns scan
+planning with the existing loaders.gl resource-management system:
+
+```text
+SourceLoader / application factory
+              |
+              v
+       DataSourceManager
+       (identity, lifetime,
+        deferred resolution)
+              |
+              v
+ FederatedTableScanSource
+ (schema plan, ordered append,
+  global query semantics)
+              |
+              v
+     Arrow batches + provenance
+```
+
+The manager remains format-agnostic and does not inspect query capabilities. The federated adapter
+requires each resolved object to publish supported table scan metadata and `read()`. Consequently,
+CSV, NDJSON, Parquet, Iceberg, Delta, ORC, GeoPackage, FlatGeobuf, Arrow IPC, or an application
+source can participate through the same registry when its concrete source implements that
+contract.
+
+Source-local queries use physical source names and run before reconciliation. Explicit mappings
+then rename fields into the federated namespace. Under `strict`, every mapped schema must contain
+the same fields with identical portable data types. Under `union`, columns are ordered by first
+appearance and a source that lacks a field contributes typed nulls. The global predicate,
+projection, and limit operate on this reconciled namespace. No implicit numeric widening, string
+conversion, or geometry coercion is performed.
+
+Execution is serial by design. This is what makes the following guarantees inexpensive and
+testable:
+
+1. source-list order is row order;
+2. a global limit counts rows after the global predicate;
+3. reaching the limit closes the current child iterator and avoids opening later sources;
+4. abort signals cover deferred source resolution as well as batch reads;
+5. each result batch identifies its source id, source position, and physical batch position; and
+6. manager subscriptions are released for completion, errors, cancellation, and early return.
+
+Parallel scheduling, managed-source joins, optimizer-selected source order, schema coercion, and
+distributed aggregation are explicit non-goals. The in-memory relational executor can still join
+or union already supplied Arrow tables; that is a separate materialized execution path.
 
 ## Point-cloud participation
 

--- a/docs/modules/loader-utils/api-reference/data-source-manager.md
+++ b/docs/modules/loader-utils/api-reference/data-source-manager.md
@@ -245,6 +245,33 @@ This split keeps responsibilities clear:
 - `DataSource` subclasses implement format-specific query APIs such as `getMetadata()`, `getTile()`, `getRaster()`, or SQL methods.
 - `DataSourceManager` handles object identity, subscriptions, replacement, and cleanup.
 
+### Use the manager for scan federation
+
+`@loaders.gl/scan` reuses this manager rather than defining a scan-only registry. Register each
+`TableScanSource` under a stable id, then reference those ids from `FederatedTableScanSource`:
+
+```ts
+import {DataSourceManager} from '@loaders.gl/loader-utils';
+import {FederatedTableScanSource} from '@loaders.gl/scan';
+
+const dataSourceManager = new DataSourceManager();
+dataSourceManager.add({dataSourceId: 'today', dataSource: todaySource});
+dataSourceManager.add({dataSourceId: 'archive', dataSource: archiveSource});
+
+const source = new FederatedTableScanSource(dataSourceManager, {
+  sources: [{dataSourceId: 'today'}, {dataSourceId: 'archive'}]
+});
+```
+
+The federated source owns no child source resources. It creates operation-scoped subscriptions for
+metadata discovery, explanation, and iteration, then releases them on completion, error,
+cancellation, a global-limit stop, or early iterator return. Non-persistent sources therefore keep
+the same pruning and lifecycle behavior they have for any other manager consumer.
+
+The dependency direction is intentional: `DataSourceManager` remains a lightweight,
+format-agnostic resource manager in `@loaders.gl/loader-utils`; the optional scan package adds
+schema reconciliation and ordered query execution on top.
+
 ### Integrate with DataSource subclasses
 
 Any subclass of `DataSource` can be managed. Subclasses do not need to know that a manager exists.

--- a/modules/scan/README.md
+++ b/modules/scan/README.md
@@ -79,6 +79,67 @@ table operators. NetCDF supports numeric variable selection and named dimension 
 range slices. GeoTIFF, OME-TIFF, GeoZarr, and OME-Zarr retain their format-specific window, level,
 channel, and chunk planners behind the same metadata vocabulary.
 
+## Ordered append federation
+
+`FederatedTableScanSource` exposes multiple managed table sources as one ordered Arrow stream. It
+uses `DataSourceManager` as the authoritative registry and resource owner; federation does not add
+a second loader registry, cache, or lifecycle system.
+
+```typescript
+import {DataSourceManager} from '@loaders.gl/loader-utils';
+import {FederatedTableScanSource, parseSQLPredicate} from '@loaders.gl/scan';
+
+const dataSourceManager = new DataSourceManager();
+dataSourceManager.add({dataSourceId: 'current', dataSource: currentSource});
+dataSourceManager.add({dataSourceId: 'archive', dataSource: archiveSource});
+
+const history = new FederatedTableScanSource(dataSourceManager, {
+  schemaPolicy: 'union',
+  sources: [
+    {dataSourceId: 'current'},
+    {
+      dataSourceId: 'archive',
+      query: {predicate: parseSQLPredicate('year >= 2020')},
+      columnMapping: {station_id: 'stationId'}
+    }
+  ]
+});
+
+for await (const batch of history.read({
+  columns: ['stationId', 'temperature'],
+  limit: 100
+})) {
+  console.log(batch.sourceId, batch.data);
+}
+```
+
+The source list is the stable result order: every surviving row from the first source precedes
+every surviving row from the second. Each source may have a source-local predicate, projection,
+and limit. Explicit `columnMapping` entries rename physical columns before schemas are compared.
+The global predicate and projection run against those mapped names.
+
+Two reconciliation policies are available:
+
+- `strict` (the default) requires every source to expose the same mapped column names and exact
+  portable data types. Physical column order may differ.
+- `union` creates columns in first-seen order and supplies typed nulls where a source lacks a
+  column. A column becomes nullable when it is absent from any source.
+
+The caller's limit is global, not per source. Once it is reached, the active iterator is closed and
+later sources are not opened. Cancellation is observed during asynchronous source resolution and
+between physical batches. Every emitted batch carries `sourceId`, `sourceIndex`, and
+`sourceBatchIndex`, while its metadata retains the original physical batch metadata under
+`sourceMetadata`.
+
+Metadata discovery, explanation, and reads subscribe to all referenced sources for the duration of
+the operation. Their `DataSourceManager` subscriptions are released on success, error,
+cancellation, a satisfied limit, or an early consumer return. This preserves the manager's existing
+replacement, deferred-id, non-persistent pruning, and lifecycle behavior.
+
+Append federation is deliberately not a distributed SQL engine. It does not reorder sources,
+parallelize reads, coerce incompatible data types, or join managed sources. It provides one
+predictable `UNION ALL`-style scan over sources that already implement `TableScanSource`.
+
 ## Addressed vector tables
 
 Specialized tile and service controls stay outside the portable relational query. Applications can

--- a/modules/scan/package.json
+++ b/modules/scan/package.json
@@ -42,9 +42,7 @@
     "@loaders.gl/loader-utils": "5.0.0-alpha.2",
     "@loaders.gl/schema": "5.0.0-alpha.2",
     "@loaders.gl/schema-utils": "5.0.0-alpha.2",
-    "@loaders.gl/sql": "5.0.0-alpha.2"
-  },
-  "devDependencies": {
+    "@loaders.gl/sql": "5.0.0-alpha.2",
     "apache-arrow": ">= 17.0.0"
   }
 }

--- a/modules/scan/src/federated-table-scan-source.ts
+++ b/modules/scan/src/federated-table-scan-source.ts
@@ -1,0 +1,591 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import * as arrow from 'apache-arrow';
+import {
+  createScanQueryMetadata,
+  explainTableQuery,
+  planTableQuery,
+  type DataSourceManager,
+  type ManageableDataSource,
+  type ScanQueryMetadata,
+  type ScanQueryMetadataOptions,
+  type TableQueryCapabilities,
+  type TableQueryExplain,
+  type TableScanReadOptions,
+  type TableScanSource
+} from '@loaders.gl/loader-utils';
+import type {
+  ArrowTable,
+  ArrowTableBatch,
+  DataType,
+  Field,
+  Schema,
+  TableBatch
+} from '@loaders.gl/schema';
+import {convertArrowToSchema, convertBatch, convertSchemaToArrow} from '@loaders.gl/schema-utils';
+import {queryArrowTable, type SQLPredicate} from '@loaders.gl/sql';
+
+/** Schema reconciliation modes supported by ordered append federation. */
+export type FederatedTableSchemaPolicy = 'strict' | 'union';
+
+/** One named table source participating in an ordered federated append. */
+export type FederatedTableSourceEntry = Readonly<{
+  /** Stable id resolved through the shared {@link DataSourceManager}. */
+  dataSourceId: string;
+  /** Source-local predicate, projection, and limit applied before schema reconciliation. */
+  query?: Omit<TableScanReadOptions<SQLPredicate>, 'signal'>;
+  /** Source-column to federated-column renames applied before compatibility checks. */
+  columnMapping?: Readonly<Record<string, string>>;
+}>;
+
+/** Options for an ordered federated table source. */
+export type FederatedTableScanSourceOptions = Readonly<{
+  /** Named sources appended in caller-specified order. */
+  sources: readonly FederatedTableSourceEntry[];
+  /** Strict requires matching columns; union null-fills missing columns. Defaults to strict. */
+  schemaPolicy?: FederatedTableSchemaPolicy;
+  /** Optional display name reported through scan metadata. */
+  name?: string;
+  /** Optional description reported through scan metadata. */
+  description?: string;
+}>;
+
+/** Provenance attached to every federated Arrow batch. */
+export type FederatedTableBatchProvenance = Readonly<{
+  /** Manager id of the source that emitted this batch. */
+  sourceId: string;
+  /** Zero-based source position in append order. */
+  sourceIndex: number;
+  /** Zero-based data-batch position within the source. */
+  sourceBatchIndex: number;
+  /** Original batch metadata supplied by the physical source. */
+  sourceMetadata?: unknown;
+}>;
+
+/** Arrow batch emitted by an ordered federated scan. */
+export type FederatedTableBatch = ArrowTableBatch<FederatedTableBatchProvenance> &
+  Readonly<{
+    /** Manager id of the source that emitted this batch. */
+    sourceId: string;
+    /** Zero-based source position in append order. */
+    sourceIndex: number;
+    /** Zero-based data-batch position within the source. */
+    sourceBatchIndex: number;
+  }>;
+
+/** Per-source diagnostics included in a federated explanation. */
+export type FederatedTableSourceExplain = Readonly<{
+  /** Manager id resolved for this source. */
+  sourceId: string;
+  /** Zero-based source position in append order. */
+  sourceIndex: number;
+  /** Physical source type reported by metadata discovery. */
+  sourceType: string;
+  /** Source columns visible after the source-local projection. */
+  sourceColumns: readonly string[];
+  /** Federated column names produced after explicit mappings. */
+  outputColumns: readonly string[];
+  /** Explicit source-column to federated-column mappings. */
+  columnMapping: Readonly<Record<string, string>>;
+}>;
+
+/** Serializable logical explanation for an ordered federated table scan. */
+export type FederatedTableScanExplain = TableQueryExplain<SQLPredicate> &
+  Readonly<{
+    /** Schema policy used to reconcile child sources. */
+    schemaPolicy: FederatedTableSchemaPolicy;
+    /** Sources in physical append order. */
+    sources: readonly FederatedTableSourceExplain[];
+  }>;
+
+/** Correctness capabilities of the federated append executor. */
+export const FEDERATED_TABLE_QUERY_CAPABILITIES: TableQueryCapabilities = Object.freeze({
+  predicate: 'residual',
+  projection: 'pushdown+residual',
+  limit: 'pushdown+residual',
+  streaming: true,
+  cancellation: true
+});
+
+type ManagedTableScanSource = ManageableDataSource & TableScanSource<TableBatch, SQLPredicate>;
+
+type MappedSourceField = Readonly<{
+  sourceName: string;
+  outputName: string;
+  field: Field;
+}>;
+
+type ResolvedFederatedSource = Readonly<{
+  entry: FederatedTableSourceEntry;
+  source: ManagedTableScanSource;
+  metadata: ScanQueryMetadata;
+  sourceIndex: number;
+  fields: readonly MappedSourceField[];
+  sourceNameByOutputName: ReadonlyMap<string, string>;
+}>;
+
+type FederatedTablePlan = Readonly<{
+  schema: Schema;
+  sources: readonly ResolvedFederatedSource[];
+}>;
+
+let nextFederatedSourceId = 0;
+
+/**
+ * Resolves managed table sources and appends their results as one ordered Arrow stream.
+ *
+ * `DataSourceManager` remains the single registry and lifecycle owner. This adapter subscribes for
+ * the duration of metadata discovery or iteration, so deferred and non-persistent sources use the
+ * same replacement, retention, and cleanup system as the rest of loaders.gl.
+ */
+export class FederatedTableScanSource
+  implements TableScanSource<FederatedTableBatch, SQLPredicate>
+{
+  /** Shared manager used as the authoritative named-source registry. */
+  readonly dataSourceManager: DataSourceManager;
+  /** Immutable sources in physical append order. */
+  readonly sources: readonly FederatedTableSourceEntry[];
+  /** Schema reconciliation policy. */
+  readonly schemaPolicy: FederatedTableSchemaPolicy;
+  /** Optional display name reported through scan metadata. */
+  readonly name?: string;
+  /** Human-readable description reported through scan metadata. */
+  readonly description: string;
+
+  private readonly instanceId = nextFederatedSourceId++;
+  private nextOperationId = 0;
+
+  /** Creates an ordered federated source backed by one shared DataSourceManager. */
+  constructor(dataSourceManager: DataSourceManager, options: FederatedTableScanSourceOptions) {
+    if (!options.sources.length) {
+      throw new Error('Federated table scans require at least one source.');
+    }
+    if (
+      options.schemaPolicy &&
+      options.schemaPolicy !== 'strict' &&
+      options.schemaPolicy !== 'union'
+    ) {
+      throw new Error(`Unsupported federated schema policy: ${options.schemaPolicy}`);
+    }
+    this.dataSourceManager = dataSourceManager;
+    this.sources = Object.freeze(options.sources.map(cloneSourceEntry));
+    this.schemaPolicy = options.schemaPolicy || 'strict';
+    this.name = options.name;
+    this.description = options.description || `${this.sources.length} ordered table sources`;
+  }
+
+  /** Discovers and reconciles every child schema without reading federated result batches. */
+  async getQueryMetadata(options: ScanQueryMetadataOptions = {}): Promise<ScanQueryMetadata> {
+    const consumerId = this.createConsumerId('metadata');
+    try {
+      const plan = await this.resolvePlan(consumerId, options.signal);
+      return createScanQueryMetadata({
+        sourceType: 'federated-table',
+        queryType: 'table',
+        execution: {status: 'supported', method: 'read'},
+        name: this.name,
+        description: this.description,
+        schema: plan.schema,
+        capabilities: {table: FEDERATED_TABLE_QUERY_CAPABILITIES},
+        statistics: getFederatedStatistics(plan.sources)
+      });
+    } finally {
+      this.dataSourceManager.unsubscribe({consumerId});
+    }
+  }
+
+  /** Explains source resolution, schema reconciliation, and the global table query. */
+  async explain(
+    options: TableScanReadOptions<SQLPredicate> = {}
+  ): Promise<FederatedTableScanExplain> {
+    const consumerId = this.createConsumerId('explain');
+    try {
+      const plan = await this.resolvePlan(consumerId, options.signal);
+      const explanation = explainTableQuery(
+        plan.schema.fields.map(field => field.name),
+        options,
+        FEDERATED_TABLE_QUERY_CAPABILITIES
+      );
+      return Object.freeze({
+        ...explanation,
+        schemaPolicy: this.schemaPolicy,
+        sources: Object.freeze(plan.sources.map(createSourceExplanation))
+      });
+    } finally {
+      this.dataSourceManager.unsubscribe({consumerId});
+    }
+  }
+
+  /**
+   * Emits source and batch ordered Arrow results with one global limit and batch provenance.
+   *
+   * Returning early from the iterator closes the active child iterator and releases every manager
+   * subscription. Later sources are never read once the global limit has been satisfied.
+   */
+  async *read(
+    options: TableScanReadOptions<SQLPredicate> = {}
+  ): AsyncIterableIterator<FederatedTableBatch> {
+    const consumerId = this.createConsumerId('read');
+    try {
+      const plan = await this.resolvePlan(consumerId, options.signal);
+      const scanStep = planTableQuery(
+        plan.schema.fields.map(field => field.name),
+        options
+      )[0] as Readonly<{columns: readonly string[]}>;
+      let remaining = options.limit ?? Number.POSITIVE_INFINITY;
+      if (remaining <= 0) return;
+
+      for (const resolvedSource of plan.sources) {
+        throwIfAborted(options.signal);
+        if (remaining <= 0) return;
+        const sourceReadOptions = createSourceReadOptions(
+          resolvedSource,
+          scanStep.columns,
+          remaining,
+          options
+        );
+        let sourceBatchIndex = 0;
+        for await (const batch of resolvedSource.source.read(sourceReadOptions)) {
+          throwIfAborted(options.signal);
+          if (remaining <= 0) return;
+          if (batch.batchType !== 'data' || batch.length <= 0) continue;
+          const canonicalTable = createCanonicalArrowTable(plan.schema, resolvedSource, batch);
+          const result = queryArrowTable(canonicalTable, {
+            predicate: options.predicate,
+            columns: options.columns,
+            limit: Number.isFinite(remaining) ? remaining : undefined,
+            signal: options.signal
+          });
+          const resultLength = result.data.numRows;
+          const currentSourceBatchIndex = sourceBatchIndex++;
+          if (!resultLength) continue;
+          const provenance: FederatedTableBatchProvenance = Object.freeze({
+            sourceId: resolvedSource.entry.dataSourceId,
+            sourceIndex: resolvedSource.sourceIndex,
+            sourceBatchIndex: currentSourceBatchIndex,
+            sourceMetadata: batch.metadata
+          });
+          yield {
+            batchType: 'data',
+            shape: 'arrow-table',
+            schema: convertArrowToSchema(result.data.schema),
+            data: result.data,
+            length: resultLength,
+            metadata: provenance,
+            sourceId: provenance.sourceId,
+            sourceIndex: provenance.sourceIndex,
+            sourceBatchIndex: provenance.sourceBatchIndex
+          };
+          remaining -= resultLength;
+        }
+      }
+    } finally {
+      this.dataSourceManager.unsubscribe({consumerId});
+    }
+  }
+
+  /** Resolves managed sources, discovers their schemas, and creates one compatibility plan. */
+  private async resolvePlan(consumerId: string, signal?: AbortSignal): Promise<FederatedTablePlan> {
+    const sources: ResolvedFederatedSource[] = [];
+    for (let sourceIndex = 0; sourceIndex < this.sources.length; sourceIndex++) {
+      throwIfAborted(signal);
+      const entry = this.sources[sourceIndex];
+      const source = await resolveManagedSource(
+        this.dataSourceManager,
+        entry.dataSourceId,
+        consumerId,
+        String(sourceIndex),
+        signal
+      );
+      if (typeof source.getQueryMetadata !== 'function' || typeof source.read !== 'function') {
+        throw new Error(`Managed source does not implement TableScanSource: ${entry.dataSourceId}`);
+      }
+      const metadata = await source.getQueryMetadata({signal});
+      if (metadata.execution.status !== 'supported' || metadata.execution.method !== 'read') {
+        throw new Error(`Federated table source does not support read(): ${entry.dataSourceId}`);
+      }
+      if (metadata.queryType !== 'table') {
+        throw new Error(`Federated source is not a table source: ${entry.dataSourceId}`);
+      }
+      const fields = resolveMappedFields(entry, metadata);
+      sources.push({
+        entry,
+        source,
+        metadata,
+        sourceIndex,
+        fields,
+        sourceNameByOutputName: new Map(fields.map(field => [field.outputName, field.sourceName]))
+      });
+    }
+    return Object.freeze({
+      schema: reconcileSchemas(sources, this.schemaPolicy),
+      sources: Object.freeze(sources)
+    });
+  }
+
+  /** Returns a collision-free manager consumer id for one operation. */
+  private createConsumerId(operation: string): string {
+    return `federated-table:${this.instanceId}:${operation}:${this.nextOperationId++}`;
+  }
+}
+
+/** Clones the public entry so later caller mutations cannot change a running plan. */
+function cloneSourceEntry(entry: FederatedTableSourceEntry): FederatedTableSourceEntry {
+  if (!entry.dataSourceId) {
+    throw new Error('Federated table source ids must be non-empty.');
+  }
+  return Object.freeze({
+    dataSourceId: entry.dataSourceId,
+    query: entry.query
+      ? Object.freeze({
+          ...entry.query,
+          columns: entry.query.columns ? Object.freeze([...entry.query.columns]) : undefined
+        })
+      : undefined,
+    columnMapping: entry.columnMapping ? Object.freeze({...entry.columnMapping}) : undefined
+  });
+}
+
+/** Selects source-local fields and applies explicit output names. */
+function resolveMappedFields(
+  entry: FederatedTableSourceEntry,
+  metadata: ScanQueryMetadata
+): readonly MappedSourceField[] {
+  const sourceFields = new Map(metadata.schema.fields.map(field => [field.name, field]));
+  for (const sourceName of Object.keys(entry.columnMapping || {})) {
+    if (!sourceFields.has(sourceName)) {
+      throw new Error(
+        `Federated column mapping source not found in ${entry.dataSourceId}: ${sourceName}`
+      );
+    }
+  }
+  const selectedNames = entry.query?.columns || metadata.schema.fields.map(field => field.name);
+  if (!selectedNames.length) {
+    throw new Error(`Federated source projection must not be empty: ${entry.dataSourceId}`);
+  }
+  const outputNames = new Set<string>();
+  return Object.freeze(
+    selectedNames.map(sourceName => {
+      const field = sourceFields.get(sourceName);
+      if (!field) {
+        throw new Error(
+          `Federated source column not found in ${entry.dataSourceId}: ${sourceName}`
+        );
+      }
+      const outputName = entry.columnMapping?.[sourceName] ?? sourceName;
+      if (!outputName) {
+        throw new Error(`Federated output column names must be non-empty: ${sourceName}`);
+      }
+      if (outputNames.has(outputName)) {
+        throw new Error(
+          `Federated column mapping creates duplicate output column in ${entry.dataSourceId}: ${outputName}`
+        );
+      }
+      outputNames.add(outputName);
+      return Object.freeze({sourceName, outputName, field});
+    })
+  );
+}
+
+/** Reconciles mapped fields using strict equality or first-seen union ordering. */
+function reconcileSchemas(
+  sources: readonly ResolvedFederatedSource[],
+  schemaPolicy: FederatedTableSchemaPolicy
+): Schema {
+  const outputFields = new Map<string, Field & {presentCount: number}>();
+  const firstSourceNames = sources[0].fields.map(field => field.outputName);
+  for (const source of sources) {
+    const sourceNames = new Set(source.fields.map(field => field.outputName));
+    if (schemaPolicy === 'strict') {
+      const missing = firstSourceNames.filter(name => !sourceNames.has(name));
+      const extra = source.fields
+        .map(field => field.outputName)
+        .filter(name => !firstSourceNames.includes(name));
+      if (missing.length || extra.length) {
+        throw new Error(
+          `Federated strict schema mismatch for ${source.entry.dataSourceId}: missing [${missing.join(', ')}], extra [${extra.join(', ')}]`
+        );
+      }
+    }
+    for (const mappedField of source.fields) {
+      const current = outputFields.get(mappedField.outputName);
+      if (current) {
+        if (!areDataTypesEqual(current.type, mappedField.field.type)) {
+          throw new Error(
+            `Federated column type mismatch for ${mappedField.outputName}: ${formatDataType(current.type)} versus ${formatDataType(mappedField.field.type)} in ${source.entry.dataSourceId}`
+          );
+        }
+        current.nullable = Boolean(current.nullable || mappedField.field.nullable);
+        current.presentCount++;
+      } else {
+        outputFields.set(mappedField.outputName, {
+          ...mappedField.field,
+          name: mappedField.outputName,
+          metadata: mappedField.field.metadata ? {...mappedField.field.metadata} : undefined,
+          presentCount: 1
+        });
+      }
+    }
+  }
+  const fields = [...outputFields.values()].map(({presentCount, ...field}) => ({
+    ...field,
+    nullable: Boolean(field.nullable || presentCount < sources.length)
+  }));
+  return {fields, metadata: {}};
+}
+
+/** Creates the source-local query required by the global canonical scan step. */
+function createSourceReadOptions(
+  source: ResolvedFederatedSource,
+  requiredOutputColumns: readonly string[],
+  remaining: number,
+  options: TableScanReadOptions<SQLPredicate>
+): TableScanReadOptions<SQLPredicate> {
+  const requiredSourceColumns = requiredOutputColumns
+    .map(outputName => source.sourceNameByOutputName.get(outputName))
+    .filter((sourceName): sourceName is string => Boolean(sourceName));
+  if (!requiredSourceColumns.length) {
+    requiredSourceColumns.push(source.fields[0].sourceName);
+  }
+  const sourceLimit = source.entry.query?.limit;
+  const globalLimitCanBePushed = options.predicate === undefined && Number.isFinite(remaining);
+  const limit = globalLimitCanBePushed
+    ? Math.min(sourceLimit ?? Number.POSITIVE_INFINITY, remaining)
+    : sourceLimit;
+  return {
+    ...source.entry.query,
+    columns: Object.freeze([...new Set(requiredSourceColumns)]),
+    limit: Number.isFinite(limit) ? limit : undefined,
+    signal: options.signal
+  };
+}
+
+/** Converts one physical batch to the reconciled Arrow schema, renaming and null-filling fields. */
+function createCanonicalArrowTable(
+  schema: Schema,
+  source: ResolvedFederatedSource,
+  batch: TableBatch
+): ArrowTable {
+  const arrowBatch = convertBatch(batch, 'arrow-table');
+  const arrowSchema = convertSchemaToArrow(schema);
+  const columns: Record<string, arrow.Vector> = {};
+  for (const field of arrowSchema.fields) {
+    const sourceName = source.sourceNameByOutputName.get(field.name);
+    const vector = sourceName ? arrowBatch.data.getChild(sourceName) : null;
+    columns[field.name] =
+      vector ||
+      arrow.vectorFromArray(
+        Array.from({length: arrowBatch.length}, () => null),
+        field.type
+      );
+  }
+  return {
+    shape: 'arrow-table',
+    schema,
+    data: new arrow.Table(arrowSchema, columns)
+  };
+}
+
+/** Returns exact aggregate row count only when child-local filters and limits cannot change it. */
+function getFederatedStatistics(
+  sources: readonly ResolvedFederatedSource[]
+): {rowCount?: number | bigint} | undefined {
+  if (
+    sources.some(
+      source =>
+        source.entry.query?.predicate ||
+        source.entry.query?.limit !== undefined ||
+        source.metadata.statistics?.rowCount === undefined
+    )
+  ) {
+    return undefined;
+  }
+  const counts = sources.map(source => source.metadata.statistics!.rowCount!);
+  return {
+    rowCount: counts.some(count => typeof count === 'bigint')
+      ? counts.reduce<bigint>((sum, count) => sum + BigInt(count), 0n)
+      : counts.reduce<number>((sum, count) => sum + Number(count), 0)
+  };
+}
+
+/** Creates serializable per-source explanation details. */
+function createSourceExplanation(source: ResolvedFederatedSource): FederatedTableSourceExplain {
+  return Object.freeze({
+    sourceId: source.entry.dataSourceId,
+    sourceIndex: source.sourceIndex,
+    sourceType: source.metadata.sourceType,
+    sourceColumns: Object.freeze(source.fields.map(field => field.sourceName)),
+    outputColumns: Object.freeze(source.fields.map(field => field.outputName)),
+    columnMapping: Object.freeze({...source.entry.columnMapping})
+  });
+}
+
+/** Compares portable data types, including nested types and typed union identifiers. */
+function areDataTypesEqual(left: DataType, right: DataType): boolean {
+  return formatDataType(left) === formatDataType(right);
+}
+
+/** Serializes a portable data type for diagnostics and deterministic equality checks. */
+function formatDataType(dataType: DataType): string {
+  return typeof dataType === 'string'
+    ? dataType
+    : JSON.stringify(dataType, (_key, value) =>
+        ArrayBuffer.isView(value) ? Array.from(value as unknown as ArrayLike<number>) : value
+      );
+}
+
+/** Resolves a current, asynchronous, or deferred source through one manager subscription. */
+function resolveManagedSource(
+  dataSourceManager: DataSourceManager,
+  dataSourceId: string,
+  consumerId: string,
+  requestId: string,
+  signal?: AbortSignal
+): Promise<ManagedTableScanSource> {
+  let resolveDeferredSource!: (source: ManagedTableScanSource) => void;
+  let rejectDeferredSource!: (error: unknown) => void;
+  const deferredSource = new Promise<ManagedTableScanSource>((resolve, reject) => {
+    resolveDeferredSource = resolve;
+    rejectDeferredSource = reject;
+  });
+  const managedSource = dataSourceManager.subscribe<ManagedTableScanSource>({
+    dataSourceId,
+    consumerId,
+    requestId,
+    onChange: source => {
+      if (source) {
+        void Promise.resolve(source).then(resolveDeferredSource, rejectDeferredSource);
+      }
+    }
+  });
+  if (managedSource === undefined) {
+    throw new Error(`Federated table source is not registered: ${dataSourceId}`);
+  }
+  return waitForPromise(
+    managedSource === null ? deferredSource : Promise.resolve(managedSource),
+    signal
+  );
+}
+
+/** Waits for a managed asynchronous source while preserving operation-local cancellation. */
+async function waitForPromise<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return await promise;
+  throwIfAborted(signal);
+  return await new Promise<T>((resolve, reject) => {
+    const abort = () => reject(getAbortReason(signal));
+    signal.addEventListener('abort', abort, {once: true});
+    void promise.then(resolve, reject).finally(() => signal.removeEventListener('abort', abort));
+  });
+}
+
+/** Throws the caller's abort reason between resolution, planning, and batch operations. */
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw getAbortReason(signal);
+}
+
+/** Returns a portable cancellation reason when AbortSignal.reason is unavailable. */
+function getAbortReason(signal: AbortSignal): unknown {
+  return signal.reason || new DOMException('Request aborted', 'AbortError');
+}

--- a/modules/scan/src/federated-table-scan-source.ts
+++ b/modules/scan/src/federated-table-scan-source.ts
@@ -6,6 +6,7 @@ import * as arrow from 'apache-arrow';
 import {
   createScanQueryMetadata,
   explainTableQuery,
+  getColumnarPredicateColumns,
   planTableQuery,
   type DataSourceManager,
   type ManageableDataSource,
@@ -154,7 +155,9 @@ export class FederatedTableScanSource
   /** Human-readable description reported through scan metadata. */
   readonly description: string;
 
+  /** Stable id used to isolate this adapter's manager subscriptions. */
   private readonly instanceId = nextFederatedSourceId++;
+  /** Monotonic id used to isolate overlapping operations on this adapter. */
   private nextOperationId = 0;
 
   /** Creates an ordered federated source backed by one shared DataSourceManager. */
@@ -246,12 +249,28 @@ export class FederatedTableScanSource
           remaining,
           options
         );
+        const sourceResidualPredicate = getSourceResidualPredicate(resolvedSource);
+        let sourceRemaining = resolvedSource.entry.query?.limit ?? Number.POSITIVE_INFINITY;
         let sourceBatchIndex = 0;
         for await (const batch of resolvedSource.source.read(sourceReadOptions)) {
           throwIfAborted(options.signal);
           if (remaining <= 0) return;
+          if (sourceRemaining <= 0) break;
           if (batch.batchType !== 'data' || batch.length <= 0) continue;
-          const canonicalTable = createCanonicalArrowTable(plan.schema, resolvedSource, batch);
+          const physicalTable = convertBatch(batch, 'arrow-table');
+          const sourceResult = queryArrowTable(physicalTable, {
+            predicate: sourceResidualPredicate,
+            limit: Number.isFinite(sourceRemaining) ? sourceRemaining : undefined,
+            signal: options.signal
+          });
+          sourceRemaining -= sourceResult.data.numRows;
+          const currentSourceBatchIndex = sourceBatchIndex++;
+          if (!sourceResult.data.numRows) continue;
+          const canonicalTable = createCanonicalArrowTable(
+            plan.schema,
+            resolvedSource,
+            sourceResult
+          );
           const result = queryArrowTable(canonicalTable, {
             predicate: options.predicate,
             columns: options.columns,
@@ -259,7 +278,6 @@ export class FederatedTableScanSource
             signal: options.signal
           });
           const resultLength = result.data.numRows;
-          const currentSourceBatchIndex = sourceBatchIndex++;
           if (!resultLength) continue;
           const provenance: FederatedTableBatchProvenance = Object.freeze({
             sourceId: resolvedSource.entry.dataSourceId,
@@ -443,9 +461,13 @@ function createSourceReadOptions(
   remaining: number,
   options: TableScanReadOptions<SQLPredicate>
 ): TableScanReadOptions<SQLPredicate> {
+  const sourceResidualPredicate = getSourceResidualPredicate(source);
   const requiredSourceColumns = requiredOutputColumns
     .map(outputName => source.sourceNameByOutputName.get(outputName))
     .filter((sourceName): sourceName is string => Boolean(sourceName));
+  if (sourceResidualPredicate) {
+    requiredSourceColumns.push(...getColumnarPredicateColumns(sourceResidualPredicate));
+  }
   if (!requiredSourceColumns.length) {
     requiredSourceColumns.push(source.fields[0].sourceName);
   }
@@ -457,27 +479,34 @@ function createSourceReadOptions(
   return {
     ...source.entry.query,
     columns: Object.freeze([...new Set(requiredSourceColumns)]),
-    limit: Number.isFinite(limit) ? limit : undefined,
+    predicate: sourceResidualPredicate ? undefined : source.entry.query?.predicate,
+    limit: sourceResidualPredicate ? undefined : Number.isFinite(limit) ? limit : undefined,
     signal: options.signal
   };
+}
+
+/** Returns the source-local predicate when the child requires residual execution. */
+function getSourceResidualPredicate(source: ResolvedFederatedSource): SQLPredicate | undefined {
+  return source.metadata.capabilities.table?.predicate === 'unsupported'
+    ? source.entry.query?.predicate
+    : undefined;
 }
 
 /** Converts one physical batch to the reconciled Arrow schema, renaming and null-filling fields. */
 function createCanonicalArrowTable(
   schema: Schema,
   source: ResolvedFederatedSource,
-  batch: TableBatch
+  physicalTable: ArrowTable
 ): ArrowTable {
-  const arrowBatch = convertBatch(batch, 'arrow-table');
   const arrowSchema = convertSchemaToArrow(schema);
   const columns: Record<string, arrow.Vector> = {};
   for (const field of arrowSchema.fields) {
     const sourceName = source.sourceNameByOutputName.get(field.name);
-    const vector = sourceName ? arrowBatch.data.getChild(sourceName) : null;
+    const vector = sourceName ? physicalTable.data.getChild(sourceName) : null;
     columns[field.name] =
       vector ||
       arrow.vectorFromArray(
-        Array.from({length: arrowBatch.length}, () => null),
+        Array.from({length: physicalTable.data.numRows}, () => null),
         field.type
       );
   }
@@ -529,11 +558,25 @@ function areDataTypesEqual(left: DataType, right: DataType): boolean {
 
 /** Serializes a portable data type for diagnostics and deterministic equality checks. */
 function formatDataType(dataType: DataType): string {
-  return typeof dataType === 'string'
-    ? dataType
-    : JSON.stringify(dataType, (_key, value) =>
-        ArrayBuffer.isView(value) ? Array.from(value as unknown as ArrayLike<number>) : value
-      );
+  return typeof dataType === 'string' ? dataType : JSON.stringify(canonicalizeValue(dataType));
+}
+
+/** Canonicalizes object keys while preserving array and typed-array element order. */
+function canonicalizeValue(value: unknown): unknown {
+  if (ArrayBuffer.isView(value)) {
+    return Array.from(value as unknown as ArrayLike<number>);
+  }
+  if (Array.isArray(value)) {
+    return value.map(canonicalizeValue);
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey))
+        .map(([key, child]) => [key, canonicalizeValue(child)])
+    );
+  }
+  return value;
 }
 
 /** Resolves a current, asynchronous, or deferred source through one manager subscription. */
@@ -550,23 +593,33 @@ function resolveManagedSource(
     resolveDeferredSource = resolve;
     rejectDeferredSource = reject;
   });
+  let sourceGeneration = 0;
+  const acceptSource = (
+    source: ManagedTableScanSource | Promise<ManagedTableScanSource> | null
+  ): void => {
+    const generation = ++sourceGeneration;
+    if (source) {
+      void Promise.resolve(source).then(
+        result => {
+          if (generation === sourceGeneration) resolveDeferredSource(result);
+        },
+        error => {
+          if (generation === sourceGeneration) rejectDeferredSource(error);
+        }
+      );
+    }
+  };
   const managedSource = dataSourceManager.subscribe<ManagedTableScanSource>({
     dataSourceId,
     consumerId,
     requestId,
-    onChange: source => {
-      if (source) {
-        void Promise.resolve(source).then(resolveDeferredSource, rejectDeferredSource);
-      }
-    }
+    onChange: acceptSource
   });
   if (managedSource === undefined) {
     throw new Error(`Federated table source is not registered: ${dataSourceId}`);
   }
-  return waitForPromise(
-    managedSource === null ? deferredSource : Promise.resolve(managedSource),
-    signal
-  );
+  acceptSource(managedSource || null);
+  return waitForPromise(deferredSource, signal);
 }
 
 /** Waits for a managed asynchronous source while preserving operation-local cancellation. */

--- a/modules/scan/src/index.ts
+++ b/modules/scan/src/index.ts
@@ -57,6 +57,20 @@ export type {
 export type {ScanQuery} from './scan-query';
 
 export {
+  FEDERATED_TABLE_QUERY_CAPABILITIES,
+  FederatedTableScanSource
+} from './federated-table-scan-source';
+export type {
+  FederatedTableBatch,
+  FederatedTableBatchProvenance,
+  FederatedTableScanExplain,
+  FederatedTableScanSourceOptions,
+  FederatedTableSchemaPolicy,
+  FederatedTableSourceEntry,
+  FederatedTableSourceExplain
+} from './federated-table-scan-source';
+
+export {
   AddressedVectorTableScanSource,
   VectorFeatureTableScanSource,
   VectorTileTableScanSource

--- a/modules/scan/test/federated-table-scan-source.cross.spec.ts
+++ b/modules/scan/test/federated-table-scan-source.cross.spec.ts
@@ -1,0 +1,95 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import * as arrow from 'apache-arrow';
+import {expect, test} from 'vitest';
+import {
+  createScanQueryMetadata,
+  DataSource,
+  DataSourceManager,
+  type DataSourceOptions,
+  type ScanQueryMetadata,
+  type TableScanReadOptions,
+  type TableScanSource
+} from '@loaders.gl/loader-utils';
+import type {ArrowTable, ArrowTableBatch} from '@loaders.gl/schema';
+import {convertArrowToSchema} from '@loaders.gl/schema-utils';
+import type {SQLPredicate} from '@loaders.gl/sql';
+import {FederatedTableScanSource, parseSQLPredicate} from '@loaders.gl/scan';
+
+test('FederatedTableScanSource has matching Node and browser execution semantics', async () => {
+  const dataSourceManager = new DataSourceManager();
+  dataSourceManager.add({
+    dataSourceId: 'memory',
+    dataSource: new CrossRuntimeTableSource()
+  });
+  const source = new FederatedTableScanSource(dataSourceManager, {
+    sources: [{dataSourceId: 'memory'}]
+  });
+
+  expect((await source.getQueryMetadata()).columns.map(column => column.name)).toEqual([
+    'id',
+    'score'
+  ]);
+  expect((await source.explain({columns: ['id']})).plan.map(step => step.kind)).toEqual([
+    'scan',
+    'project'
+  ]);
+
+  const rows: unknown[] = [];
+  for await (const batch of source.read({
+    predicate: parseSQLPredicate('score >= 20'),
+    columns: ['id']
+  })) {
+    rows.push(...batch.data.toArray().map(row => row?.toJSON()));
+  }
+  expect(rows).toEqual([{id: 2}]);
+});
+
+/** Minimal Arrow source used to execute the public federation contract in both runtimes. */
+class CrossRuntimeTableSource
+  extends DataSource<string, DataSourceOptions>
+  implements TableScanSource<ArrowTableBatch, SQLPredicate>
+{
+  /** Immutable in-memory Arrow table emitted by this source. */
+  private readonly table: ArrowTable;
+
+  /** Creates the deterministic two-row fixture. */
+  constructor() {
+    super('memory', {});
+    const data = arrow.tableFromArrays({id: [1, 2], score: [10, 20]});
+    this.table = {shape: 'arrow-table', schema: convertArrowToSchema(data.schema), data};
+  }
+
+  /** Reports the fixture schema without consuming rows. */
+  async getQueryMetadata(): Promise<ScanQueryMetadata> {
+    return createScanQueryMetadata({
+      sourceType: 'memory',
+      queryType: 'table',
+      execution: {status: 'supported', method: 'read'},
+      schema: this.table.schema!,
+      capabilities: {
+        table: {
+          predicate: 'unsupported',
+          projection: 'unsupported',
+          limit: 'unsupported',
+          streaming: true,
+          cancellation: true
+        }
+      },
+      statistics: {rowCount: this.table.data.numRows}
+    });
+  }
+
+  /** Emits the fixture as one physical batch for residual federation execution. */
+  async *read(_options: TableScanReadOptions<SQLPredicate> = {}): AsyncIterable<ArrowTableBatch> {
+    yield {
+      batchType: 'data',
+      shape: 'arrow-table',
+      schema: this.table.schema,
+      data: this.table.data,
+      length: this.table.data.numRows
+    };
+  }
+}

--- a/modules/scan/test/federated-table-scan-source.spec.ts
+++ b/modules/scan/test/federated-table-scan-source.spec.ts
@@ -1,0 +1,666 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import * as arrow from 'apache-arrow';
+import {describe, expect, test} from 'vitest';
+import {
+  createScanQueryMetadata,
+  DataSource,
+  DataSourceManager,
+  type DataSourceOptions,
+  type ScanQueryMetadata,
+  type TableScanReadOptions,
+  type TableScanSource
+} from '@loaders.gl/loader-utils';
+import type {ArrowTable, ArrowTableBatch, DataType, Schema} from '@loaders.gl/schema';
+import {convertArrowToSchema} from '@loaders.gl/schema-utils';
+import {queryArrowTable, type SQLPredicate} from '@loaders.gl/sql';
+import {FederatedTableScanSource, parseSQLPredicate} from '@loaders.gl/scan';
+
+const TEST_CAPABILITIES = Object.freeze({
+  predicate: 'residual' as const,
+  projection: 'pushdown' as const,
+  limit: 'pushdown' as const,
+  streaming: true,
+  cancellation: true
+});
+
+describe('FederatedTableScanSource', () => {
+  test('validates constructor options and zero-limit reads', async () => {
+    const dataSourceManager = new DataSourceManager();
+    const physicalSource = new TestTableScanSource('physical', [makeArrowTable({id: [1]})]);
+    dataSourceManager.add({dataSourceId: 'physical', dataSource: physicalSource});
+
+    expect(() => new FederatedTableScanSource(dataSourceManager, {sources: []})).toThrow(
+      'require at least one source'
+    );
+    expect(
+      () =>
+        new FederatedTableScanSource(dataSourceManager, {
+          sources: [{dataSourceId: 'physical'}],
+          schemaPolicy: 'invalid' as 'strict'
+        })
+    ).toThrow('Unsupported federated schema policy: invalid');
+    expect(
+      () =>
+        new FederatedTableScanSource(dataSourceManager, {
+          sources: [{dataSourceId: ''}]
+        })
+    ).toThrow('source ids must be non-empty');
+
+    const source = new FederatedTableScanSource(dataSourceManager, {
+      sources: [{dataSourceId: 'physical'}]
+    });
+    expect(await collectBatches(source.read({limit: 0}))).toEqual([]);
+    expect(physicalSource.readCount).toBe(0);
+  });
+
+  test('resolves manager sources and appends ordered batches with global provenance', async () => {
+    const dataSourceManager = new DataSourceManager();
+    const firstSource = new TestTableScanSource('first', [
+      makeArrowTable({stationId: [1, 2], score: [10, 20]})
+    ]);
+    const secondSource = new TestTableScanSource('second', [
+      makeArrowTable({id: [3, 4], score: [30, 40]})
+    ]);
+    dataSourceManager.add({dataSourceId: 'first', dataSource: firstSource});
+    dataSourceManager.add({dataSourceId: 'second', dataSource: secondSource});
+
+    const source = new FederatedTableScanSource(dataSourceManager, {
+      sources: [
+        {
+          dataSourceId: 'first',
+          query: {
+            predicate: parseSQLPredicate('score >= 20'),
+            columns: ['stationId', 'score']
+          },
+          columnMapping: {stationId: 'id'}
+        },
+        {dataSourceId: 'second'}
+      ]
+    });
+    const batches = await collectBatches(source.read({columns: ['id', 'score'], limit: 2}));
+
+    expect(batches.map(batch => batch.data.toArray().map(row => row?.toJSON()))).toEqual([
+      [{id: 2, score: 20}],
+      [{id: 3, score: 30}]
+    ]);
+    expect(batches.map(batch => batch.metadata)).toEqual([
+      {sourceId: 'first', sourceIndex: 0, sourceBatchIndex: 0, sourceMetadata: {partition: 0}},
+      {sourceId: 'second', sourceIndex: 1, sourceBatchIndex: 0, sourceMetadata: {partition: 0}}
+    ]);
+    expect(secondSource.readOptions[0]?.limit).toBe(1);
+    expect(secondSource.readOptions[0]?.columns).toEqual(['id', 'score']);
+  });
+
+  test('unions first-seen columns, applies mappings, and null-fills missing values', async () => {
+    const dataSourceManager = new DataSourceManager();
+    dataSourceManager.add({
+      dataSourceId: 'cities',
+      dataSource: new TestTableScanSource('cities', [makeArrowTable({id: [1], city: ['Oslo']})])
+    });
+    dataSourceManager.add({
+      dataSourceId: 'stations',
+      dataSource: new TestTableScanSource('stations', [
+        makeArrowTable({stationId: [2], elevation: [20]})
+      ])
+    });
+    const source = new FederatedTableScanSource(dataSourceManager, {
+      schemaPolicy: 'union',
+      sources: [
+        {dataSourceId: 'cities'},
+        {dataSourceId: 'stations', columnMapping: {stationId: 'id'}}
+      ]
+    });
+
+    const metadata = await source.getQueryMetadata();
+    expect(metadata.columns.map(column => [column.name, column.nullable])).toEqual([
+      ['id', true],
+      ['city', true],
+      ['elevation', true]
+    ]);
+    expect(metadata.statistics?.rowCount).toBe(2);
+
+    const batches = await collectBatches(
+      source.read({
+        predicate: parseSQLPredicate('city IS NULL'),
+        columns: ['id', 'elevation']
+      })
+    );
+    expect(batches.flatMap(batch => batch.data.toArray().map(row => row?.toJSON()))).toEqual([
+      {id: 2, elevation: 20}
+    ]);
+  });
+
+  test('validates strict schemas, mapped fields, and compatible types', async () => {
+    const missingManager = new DataSourceManager();
+    missingManager.add({
+      dataSourceId: 'a',
+      dataSource: new TestTableScanSource('a', [makeArrowTable({id: [1], value: [2]})])
+    });
+    missingManager.add({
+      dataSourceId: 'b',
+      dataSource: new TestTableScanSource('b', [makeArrowTable({id: [2]})])
+    });
+    await expect(
+      new FederatedTableScanSource(missingManager, {
+        sources: [{dataSourceId: 'a'}, {dataSourceId: 'b'}]
+      }).getQueryMetadata()
+    ).rejects.toThrow(/strict schema mismatch.*missing \[value\]/);
+
+    const typeManager = new DataSourceManager();
+    typeManager.add({
+      dataSourceId: 'numbers',
+      dataSource: new TestTableScanSource('numbers', [makeArrowTable({id: [1]})])
+    });
+    typeManager.add({
+      dataSourceId: 'strings',
+      dataSource: new TestTableScanSource('strings', [makeArrowTable({id: ['1']})])
+    });
+    await expect(
+      new FederatedTableScanSource(typeManager, {
+        schemaPolicy: 'union',
+        sources: [{dataSourceId: 'numbers'}, {dataSourceId: 'strings'}]
+      }).getQueryMetadata()
+    ).rejects.toThrow(/column type mismatch for id/);
+
+    await expect(
+      new FederatedTableScanSource(typeManager, {
+        sources: [{dataSourceId: 'numbers', columnMapping: {missing: 'id'}}]
+      }).getQueryMetadata()
+    ).rejects.toThrow(/mapping source not found.*missing/);
+
+    await expect(
+      new FederatedTableScanSource(typeManager, {
+        sources: [{dataSourceId: 'numbers', query: {columns: []}}]
+      }).getQueryMetadata()
+    ).rejects.toThrow(/projection must not be empty/);
+    await expect(
+      new FederatedTableScanSource(typeManager, {
+        sources: [{dataSourceId: 'numbers', query: {columns: ['missing']}}]
+      }).getQueryMetadata()
+    ).rejects.toThrow(/source column not found.*missing/);
+    await expect(
+      new FederatedTableScanSource(typeManager, {
+        sources: [{dataSourceId: 'numbers', columnMapping: {id: ''}}]
+      }).getQueryMetadata()
+    ).rejects.toThrow(/output column names must be non-empty/);
+
+    const duplicateManager = new DataSourceManager();
+    duplicateManager.add({
+      dataSourceId: 'duplicate',
+      dataSource: new TestTableScanSource('duplicate', [makeArrowTable({id: [1], alias: [2]})])
+    });
+    await expect(
+      new FederatedTableScanSource(duplicateManager, {
+        sources: [{dataSourceId: 'duplicate', columnMapping: {alias: 'id'}}]
+      }).getQueryMetadata()
+    ).rejects.toThrow(/duplicate output column.*id/);
+  });
+
+  test('resolves deferred sources and reports incompatible managed sources', async () => {
+    const dataSourceManager = new DataSourceManager();
+    await expect(
+      new FederatedTableScanSource(dataSourceManager, {
+        sources: [{dataSourceId: 'missing'}]
+      }).getQueryMetadata()
+    ).rejects.toThrow('not registered: missing');
+
+    const deferredSource = new FederatedTableScanSource(dataSourceManager, {
+      sources: [{dataSourceId: 'datasource://deferred'}]
+    });
+    const metadataPromise = deferredSource.getQueryMetadata();
+    dataSourceManager.add({
+      dataSourceId: 'deferred',
+      dataSource: Promise.resolve(new TestTableScanSource('deferred', [makeArrowTable({id: [1]})]))
+    });
+    await expect(metadataPromise).resolves.toMatchObject({sourceType: 'federated-table'});
+
+    dataSourceManager.add({
+      dataSourceId: 'plain',
+      dataSource: new DataSource('plain', {})
+    });
+    await expect(
+      new FederatedTableScanSource(dataSourceManager, {
+        sources: [{dataSourceId: 'plain'}]
+      }).getQueryMetadata()
+    ).rejects.toThrow('does not implement TableScanSource: plain');
+
+    const table = makeArrowTable({id: [1]});
+    const supportedMetadata = createTestMetadata('compatible', table);
+    dataSourceManager.add({
+      dataSourceId: 'metadata-only',
+      dataSource: new TestTableScanSource('metadata-only', [table], {
+        metadata: {
+          ...supportedMetadata,
+          execution: {status: 'metadata-only', reason: 'Discovery only'}
+        }
+      })
+    });
+    await expect(
+      new FederatedTableScanSource(dataSourceManager, {
+        sources: [{dataSourceId: 'metadata-only'}]
+      }).getQueryMetadata()
+    ).rejects.toThrow('does not support read(): metadata-only');
+
+    dataSourceManager.add({
+      dataSourceId: 'raster',
+      dataSource: new TestTableScanSource('raster', [table], {
+        metadata: {
+          ...supportedMetadata,
+          queryType: 'raster',
+          execution: {status: 'supported', method: 'read'}
+        } as ScanQueryMetadata
+      })
+    });
+    await expect(
+      new FederatedTableScanSource(dataSourceManager, {
+        sources: [{dataSourceId: 'raster'}]
+      }).getQueryMetadata()
+    ).rejects.toThrow('not a table source: raster');
+  });
+
+  test('stops later sources at the global limit and closes active iterators', async () => {
+    const dataSourceManager = new DataSourceManager();
+    const firstSource = new TestTableScanSource('first', [
+      makeArrowTable({id: [1, 2]}),
+      makeArrowTable({id: [3, 4]})
+    ]);
+    const secondSource = new TestTableScanSource('second', [makeArrowTable({id: [5]})]);
+    dataSourceManager.add({dataSourceId: 'first', dataSource: firstSource});
+    dataSourceManager.add({dataSourceId: 'second', dataSource: secondSource});
+    const source = new FederatedTableScanSource(dataSourceManager, {
+      sources: [{dataSourceId: 'first'}, {dataSourceId: 'second'}]
+    });
+
+    const batches = await collectBatches(source.read({limit: 1}));
+    expect(batches.flatMap(batch => batch.data.toArray().map(row => row?.toJSON()))).toEqual([
+      {id: 1}
+    ]);
+    expect(firstSource.iteratorCloseCount).toBe(1);
+    expect(secondSource.readCount).toBe(0);
+  });
+
+  test('skips empty batches and stops a child that ignores its pushed limit', async () => {
+    const dataSourceManager = new DataSourceManager();
+    const physicalSource = new TestTableScanSource(
+      'physical',
+      [makeArrowTable({id: [1]}), makeArrowTable({id: [2]})],
+      {ignoreLimit: true, prependEmptyBatch: true}
+    );
+    dataSourceManager.add({dataSourceId: 'physical', dataSource: physicalSource});
+    const source = new FederatedTableScanSource(dataSourceManager, {
+      sources: [{dataSourceId: 'physical'}]
+    });
+
+    const batches = await collectBatches(source.read({limit: 1}));
+    expect(batches.map(batch => batch.data.toArray()[0]?.toJSON())).toEqual([{id: 1}]);
+    expect(physicalSource.iteratorCloseCount).toBe(1);
+  });
+
+  test('requests a row-count column when a union source lacks all global columns', async () => {
+    const dataSourceManager = new DataSourceManager();
+    const idTable = makeArrowTable({id: [1]});
+    const valueTable = makeArrowTable({value: [2]});
+    const idSource = new TestTableScanSource('ids', [idTable], {
+      metadata: createTestMetadata('ids', idTable, {
+        fields: [{name: 'id', type: 'int32', nullable: false}],
+        metadata: {}
+      })
+    });
+    const valueSource = new TestTableScanSource('values', [valueTable], {
+      metadata: createTestMetadata('values', valueTable, {
+        fields: [{name: 'value', type: 'int32', nullable: false}],
+        metadata: {}
+      })
+    });
+    dataSourceManager.add({dataSourceId: 'ids', dataSource: idSource});
+    dataSourceManager.add({dataSourceId: 'values', dataSource: valueSource});
+    const source = new FederatedTableScanSource(dataSourceManager, {
+      schemaPolicy: 'union',
+      sources: [{dataSourceId: 'ids'}, {dataSourceId: 'values'}]
+    });
+
+    const metadata = await source.getQueryMetadata();
+    expect(metadata.columns.map(column => [column.name, column.type, column.nullable])).toEqual([
+      ['id', 'int32', true],
+      ['value', 'int32', true]
+    ]);
+    const batches = await collectBatches(
+      source.read({predicate: parseSQLPredicate('value IS NOT NULL'), columns: ['value']})
+    );
+    expect(batches.flatMap(batch => batch.data.toArray().map(row => row?.toJSON()))).toEqual([
+      {value: 2}
+    ]);
+    expect(idSource.readOptions[0]?.columns).toEqual(['id']);
+  });
+
+  test('merges nullability and compares structured union type ids', async () => {
+    const dataSourceManager = new DataSourceManager();
+    const table = makeArrowTable({id: [1]});
+    const nonNullableSchema: Schema = {
+      fields: [{name: 'id', type: 'int32', nullable: false}],
+      metadata: {}
+    };
+    const nullableSchema: Schema = {
+      fields: [{name: 'id', type: 'int32', nullable: true, metadata: {unit: 'count'}}],
+      metadata: {}
+    };
+    dataSourceManager.add({
+      dataSourceId: 'required',
+      dataSource: new TestTableScanSource('required', [table], {
+        metadata: {
+          ...createTestMetadata('required', table, nonNullableSchema),
+          schema: nonNullableSchema
+        }
+      })
+    });
+    dataSourceManager.add({
+      dataSourceId: 'nullable',
+      dataSource: new TestTableScanSource('nullable', [table], {
+        metadata: createTestMetadata('nullable', table, nullableSchema)
+      })
+    });
+    const metadata = await new FederatedTableScanSource(dataSourceManager, {
+      sources: [{dataSourceId: 'required'}, {dataSourceId: 'nullable'}]
+    }).getQueryMetadata();
+    expect(metadata.columns[0]?.nullable).toBe(true);
+
+    const unionType: DataType = {
+      type: 'sparse-union',
+      typeIds: new Int32Array([3]),
+      children: [{name: 'member', type: 'int32'}],
+      typeIdToChildIndex: {3: 0}
+    };
+    const unionSchema: Schema = {
+      fields: [{name: 'choice', type: unionType, nullable: false}],
+      metadata: {}
+    };
+    const unionManager = new DataSourceManager();
+    unionManager.add({
+      dataSourceId: 'one',
+      dataSource: new TestTableScanSource('one', [table], {
+        metadata: createTestMetadata('one', table, unionSchema)
+      })
+    });
+    unionManager.add({
+      dataSourceId: 'two',
+      dataSource: new TestTableScanSource('two', [table], {
+        metadata: createTestMetadata('two', table, unionSchema)
+      })
+    });
+    await expect(
+      new FederatedTableScanSource(unionManager, {
+        sources: [{dataSourceId: 'one'}, {dataSourceId: 'two'}]
+      }).getQueryMetadata()
+    ).resolves.toMatchObject({columns: [{name: 'choice'}]});
+  });
+
+  test('reports statistics only when every source count is exact', async () => {
+    const table = makeArrowTable({id: [1]});
+    const dataSourceManager = new DataSourceManager();
+    dataSourceManager.add({
+      dataSourceId: 'big',
+      dataSource: new TestTableScanSource('big', [table], {
+        metadata: createTestMetadata('big', table, table.schema!, 2n)
+      })
+    });
+    dataSourceManager.add({
+      dataSourceId: 'small',
+      dataSource: new TestTableScanSource('small', [table], {
+        metadata: createTestMetadata('small', table, table.schema!, 1)
+      })
+    });
+    const exactSource = new FederatedTableScanSource(dataSourceManager, {
+      sources: [{dataSourceId: 'big'}, {dataSourceId: 'small'}]
+    });
+    expect((await exactSource.getQueryMetadata()).statistics?.rowCount).toBe(3n);
+
+    const filteredSource = new FederatedTableScanSource(dataSourceManager, {
+      sources: [
+        {dataSourceId: 'big', query: {predicate: parseSQLPredicate('id > 0')}},
+        {dataSourceId: 'small'}
+      ]
+    });
+    expect((await filteredSource.getQueryMetadata()).statistics).toBeUndefined();
+
+    const limitedSource = new FederatedTableScanSource(dataSourceManager, {
+      sources: [{dataSourceId: 'big', query: {limit: 1}}, {dataSourceId: 'small'}]
+    });
+    expect((await limitedSource.getQueryMetadata()).statistics).toBeUndefined();
+
+    const unknownMetadata = createTestMetadata('unknown', table);
+    dataSourceManager.add({
+      dataSourceId: 'unknown',
+      dataSource: new TestTableScanSource('unknown', [table], {
+        metadata: {...unknownMetadata, statistics: undefined}
+      })
+    });
+    const unknownSource = new FederatedTableScanSource(dataSourceManager, {
+      sources: [{dataSourceId: 'unknown'}]
+    });
+    expect((await unknownSource.getQueryMetadata()).statistics).toBeUndefined();
+  });
+
+  test('releases manager subscriptions when a consumer returns early', async () => {
+    const dataSourceManager = new DataSourceManager();
+    const firstSource = new TestTableScanSource('first', [
+      makeArrowTable({id: [1]}),
+      makeArrowTable({id: [2]})
+    ]);
+    const secondSource = new TestTableScanSource('second', [makeArrowTable({id: [3]})]);
+    dataSourceManager.add({dataSourceId: 'first', dataSource: firstSource, persistent: false});
+    dataSourceManager.add({dataSourceId: 'second', dataSource: secondSource, persistent: false});
+    const source = new FederatedTableScanSource(dataSourceManager, {
+      sources: [{dataSourceId: 'first'}, {dataSourceId: 'second'}]
+    });
+
+    for await (const _batch of source.read()) break;
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(firstSource.iteratorCloseCount).toBe(1);
+    expect(secondSource.readCount).toBe(0);
+    expect(dataSourceManager.contains('first')).toBe(false);
+    expect(dataSourceManager.contains('second')).toBe(false);
+  });
+
+  test('observes cancellation between physical batches', async () => {
+    const dataSourceManager = new DataSourceManager();
+    const physicalSource = new TestTableScanSource('physical', [
+      makeArrowTable({id: [1]}),
+      makeArrowTable({id: [2]})
+    ]);
+    dataSourceManager.add({dataSourceId: 'physical', dataSource: physicalSource});
+    const source = new FederatedTableScanSource(dataSourceManager, {
+      sources: [{dataSourceId: 'physical'}]
+    });
+    const controller = new AbortController();
+    const iterator = source.read({signal: controller.signal})[Symbol.asyncIterator]();
+
+    expect((await iterator.next()).value?.data.toArray()[0]?.toJSON()).toEqual({id: 1});
+    controller.abort(new Error('cancel federated scan'));
+    await expect(iterator.next()).rejects.toThrow('cancel federated scan');
+    expect(physicalSource.iteratorCloseCount).toBe(1);
+  });
+
+  test('cancels deferred resolution and normalizes a missing abort reason', async () => {
+    const dataSourceManager = new DataSourceManager();
+    const pendingSource = new FederatedTableScanSource(dataSourceManager, {
+      sources: [{dataSourceId: 'datasource://pending'}]
+    });
+    const controller = new AbortController();
+    const metadataPromise = pendingSource.getQueryMetadata({signal: controller.signal});
+    dataSourceManager.add({
+      dataSourceId: 'pending',
+      dataSource: null,
+      forceUpdate: true,
+      persistent: false
+    });
+    controller.abort(new Error('cancel source resolution'));
+    await expect(metadataPromise).rejects.toThrow('cancel source resolution');
+
+    const missingReasonSignal = {
+      aborted: true,
+      reason: null
+    } as AbortSignal;
+    await expect(pendingSource.getQueryMetadata({signal: missingReasonSignal})).rejects.toThrow(
+      'Request aborted'
+    );
+  });
+
+  test('explains resolved source order and immutable column mappings', async () => {
+    const dataSourceManager = new DataSourceManager();
+    dataSourceManager.add({
+      dataSourceId: 'source',
+      dataSource: new TestTableScanSource('source', [makeArrowTable({sourceId: [1], value: [2]})])
+    });
+    const mapping = {sourceId: 'id'};
+    const source = new FederatedTableScanSource(dataSourceManager, {
+      sources: [{dataSourceId: 'source', columnMapping: mapping}]
+    });
+    mapping.sourceId = 'mutated';
+
+    const explanation = await source.explain({columns: ['id'], limit: 1});
+    expect(explanation.schemaPolicy).toBe('strict');
+    expect(explanation.plan.map(step => step.kind)).toEqual(['scan', 'project', 'limit']);
+    expect(explanation.sources).toEqual([
+      {
+        sourceId: 'source',
+        sourceIndex: 0,
+        sourceType: 'source',
+        sourceColumns: ['sourceId', 'value'],
+        outputColumns: ['id', 'value'],
+        columnMapping: {sourceId: 'id'}
+      }
+    ]);
+    expect(Object.isFrozen(source.sources[0].columnMapping)).toBe(true);
+  });
+});
+
+/** Deterministic in-memory table source used by federation conformance tests. */
+class TestTableScanSource
+  extends DataSource<string, DataSourceOptions>
+  implements TableScanSource<ArrowTableBatch, SQLPredicate>
+{
+  /** Source-local read options received by each operation. */
+  readonly readOptions: TableScanReadOptions<SQLPredicate>[] = [];
+  /** Number of physical read iterators opened. */
+  readCount = 0;
+  /** Number of physical iterators closed through completion or early return. */
+  iteratorCloseCount = 0;
+
+  private readonly tables: readonly ArrowTable[];
+  private readonly testOptions: TestTableScanSourceOptions;
+
+  /** Creates a deterministic source with one or more physical batches. */
+  constructor(
+    sourceType: string,
+    tables: readonly ArrowTable[],
+    testOptions: TestTableScanSourceOptions = {}
+  ) {
+    super(sourceType, {});
+    this.tables = tables;
+    this.testOptions = testOptions;
+  }
+
+  /** Reports the schema and exact row count without consuming a physical iterator. */
+  async getQueryMetadata(): Promise<ScanQueryMetadata> {
+    return (
+      this.testOptions.metadata ||
+      createTestMetadata(
+        this.data,
+        this.tables[0],
+        this.tables[0].schema!,
+        this.tables.reduce((sum, table) => sum + table.data.numRows, 0)
+      )
+    );
+  }
+
+  /** Applies the source-local query independently from the federated global query. */
+  async *read(
+    options: TableScanReadOptions<SQLPredicate> = {}
+  ): AsyncIterableIterator<ArrowTableBatch> {
+    this.readCount++;
+    this.readOptions.push(options);
+    let remaining = this.testOptions.ignoreLimit
+      ? Number.POSITIVE_INFINITY
+      : (options.limit ?? Number.POSITIVE_INFINITY);
+    try {
+      if (this.testOptions.prependEmptyBatch) {
+        const data = arrow.tableFromArrays({id: []});
+        yield {
+          batchType: 'data',
+          shape: 'arrow-table',
+          schema: convertArrowToSchema(data.schema),
+          data,
+          length: 0,
+          metadata: {partition: -1}
+        };
+      }
+      for (let batchIndex = 0; batchIndex < this.tables.length && remaining > 0; batchIndex++) {
+        if (options.signal?.aborted) throw options.signal.reason;
+        const result = queryArrowTable(this.tables[batchIndex], {
+          ...options,
+          limit: this.testOptions.ignoreLimit
+            ? undefined
+            : Number.isFinite(remaining)
+              ? remaining
+              : undefined
+        });
+        if (!result.data.numRows) continue;
+        remaining -= result.data.numRows;
+        yield {
+          batchType: 'data',
+          shape: 'arrow-table',
+          schema: result.schema,
+          data: result.data,
+          length: result.data.numRows,
+          metadata: {partition: batchIndex}
+        };
+      }
+    } finally {
+      this.iteratorCloseCount++;
+    }
+  }
+}
+
+/** Test-only controls for deterministic physical source behavior. */
+type TestTableScanSourceOptions = Readonly<{
+  /** Overrides discovered metadata. */
+  metadata?: ScanQueryMetadata;
+  /** Simulates a source that accepts but ignores limit pushdown. */
+  ignoreLimit?: boolean;
+  /** Emits an empty physical batch before data batches. */
+  prependEmptyBatch?: boolean;
+}>;
+
+/** Wraps simple columns in the loaders.gl Arrow table shape. */
+function makeArrowTable(columns: Record<string, readonly unknown[]>): ArrowTable {
+  const data = arrow.tableFromArrays(columns);
+  return {shape: 'arrow-table', schema: convertArrowToSchema(data.schema), data};
+}
+
+/** Creates supported table metadata with an optional schema and exact row count. */
+function createTestMetadata(
+  sourceType: string,
+  table: ArrowTable,
+  schema: Schema = table.schema!,
+  rowCount: number | bigint = table.data.numRows
+): ScanQueryMetadata {
+  return createScanQueryMetadata({
+    sourceType,
+    queryType: 'table',
+    execution: {status: 'supported', method: 'read'},
+    schema,
+    capabilities: {table: TEST_CAPABILITIES},
+    statistics: {rowCount}
+  });
+}
+
+/** Collects all federated batches without materializing them into one table. */
+async function collectBatches(batches: AsyncIterable<ArrowTableBatch>): Promise<ArrowTableBatch[]> {
+  const result: ArrowTableBatch[] = [];
+  for await (const batch of batches) result.push(batch);
+  return result;
+}

--- a/modules/scan/test/federated-table-scan-source.spec.ts
+++ b/modules/scan/test/federated-table-scan-source.spec.ts
@@ -94,6 +94,50 @@ describe('FederatedTableScanSource', () => {
     expect(secondSource.readOptions[0]?.columns).toEqual(['id', 'score']);
   });
 
+  test('executes unsupported source predicates residually before source-local limits', async () => {
+    const dataSourceManager = new DataSourceManager();
+    const filteredTable = makeArrowTable({id: [1], score: [10]});
+    const selectedTable = makeArrowTable({id: [2], score: [20]});
+    const finalTable = makeArrowTable({id: [3], score: [30]});
+    const metadata = createTestMetadata('arrow-ipc', filteredTable, filteredTable.schema!, 3);
+    const physicalSource = new TestTableScanSource(
+      'arrow-ipc',
+      [filteredTable, selectedTable, finalTable],
+      {
+        ignoreLimit: true,
+        metadata: {
+          ...metadata,
+          capabilities: {
+            table: {...TEST_CAPABILITIES, predicate: 'unsupported'}
+          }
+        }
+      }
+    );
+    dataSourceManager.add({dataSourceId: 'arrow-ipc', dataSource: physicalSource});
+    const source = new FederatedTableScanSource(dataSourceManager, {
+      sources: [
+        {
+          dataSourceId: 'arrow-ipc',
+          query: {
+            predicate: parseSQLPredicate('score >= 20'),
+            columns: ['id'],
+            limit: 1
+          }
+        }
+      ]
+    });
+
+    const batches = await collectBatches(source.read());
+    expect(batches.flatMap(batch => batch.data.toArray().map(row => row?.toJSON()))).toEqual([
+      {id: 2}
+    ]);
+    expect(physicalSource.readOptions[0]).toMatchObject({
+      columns: ['id', 'score'],
+      predicate: undefined,
+      limit: undefined
+    });
+  });
+
   test('unions first-seen columns, applies mappings, and null-fills missing values', async () => {
     const dataSourceManager = new DataSourceManager();
     dataSourceManager.add({
@@ -395,6 +439,38 @@ describe('FederatedTableScanSource', () => {
         sources: [{dataSourceId: 'one'}, {dataSourceId: 'two'}]
       }).getQueryMetadata()
     ).resolves.toMatchObject({columns: [{name: 'choice'}]});
+
+    const firstDecimal = {type: 'decimal', bitWidth: 128, precision: 10, scale: 2} as const;
+    const secondDecimal = {
+      scale: 2,
+      precision: 10,
+      bitWidth: 128,
+      type: 'decimal'
+    } as const;
+    const decimalManager = new DataSourceManager();
+    decimalManager.add({
+      dataSourceId: 'first-decimal',
+      dataSource: new TestTableScanSource('first-decimal', [table], {
+        metadata: createTestMetadata('first-decimal', table, {
+          fields: [{name: 'amount', type: firstDecimal, nullable: false}],
+          metadata: {}
+        })
+      })
+    });
+    decimalManager.add({
+      dataSourceId: 'second-decimal',
+      dataSource: new TestTableScanSource('second-decimal', [table], {
+        metadata: createTestMetadata('second-decimal', table, {
+          fields: [{name: 'amount', type: secondDecimal, nullable: false}],
+          metadata: {}
+        })
+      })
+    });
+    await expect(
+      new FederatedTableScanSource(decimalManager, {
+        sources: [{dataSourceId: 'first-decimal'}, {dataSourceId: 'second-decimal'}]
+      }).getQueryMetadata()
+    ).resolves.toMatchObject({columns: [{name: 'amount'}]});
   });
 
   test('reports statistics only when every source count is exact', async () => {
@@ -507,6 +583,46 @@ describe('FederatedTableScanSource', () => {
     await expect(pendingSource.getQueryMetadata({signal: missingReasonSignal})).rejects.toThrow(
       'Request aborted'
     );
+  });
+
+  test('ignores superseded asynchronous source resolutions and reports current failures', async () => {
+    const dataSourceManager = new DataSourceManager();
+    let resolveFirst!: (source: TestTableScanSource) => void;
+    let rejectSecond!: (error: Error) => void;
+    let resolveThird!: (source: TestTableScanSource) => void;
+    const firstPromise = new Promise<TestTableScanSource>(resolve => {
+      resolveFirst = resolve;
+    });
+    const secondPromise = new Promise<TestTableScanSource>((_resolve, reject) => {
+      rejectSecond = reject;
+    });
+    const thirdPromise = new Promise<TestTableScanSource>(resolve => {
+      resolveThird = resolve;
+    });
+    dataSourceManager.add({dataSourceId: 'replaceable', dataSource: firstPromise});
+    const source = new FederatedTableScanSource(dataSourceManager, {
+      sources: [{dataSourceId: 'replaceable'}]
+    });
+    const metadataPromise = source.getQueryMetadata();
+    await Promise.resolve();
+    dataSourceManager.add({dataSourceId: 'replaceable', dataSource: secondPromise});
+    dataSourceManager.add({dataSourceId: 'replaceable', dataSource: thirdPromise});
+    resolveFirst(new TestTableScanSource('stale', [makeArrowTable({stale: [1]})]));
+    rejectSecond(new Error('superseded failure'));
+    resolveThird(new TestTableScanSource('current', [makeArrowTable({current: [2]})]));
+    await expect(metadataPromise).resolves.toMatchObject({columns: [{name: 'current'}]});
+
+    const failedManager = new DataSourceManager();
+    const failedSource = new FederatedTableScanSource(failedManager, {
+      sources: [{dataSourceId: 'datasource://failed'}]
+    });
+    const failedMetadata = failedSource.getQueryMetadata();
+    failedManager.add({
+      dataSourceId: 'failed',
+      dataSource: Promise.reject(new Error('managed source failed')),
+      persistent: false
+    });
+    await expect(failedMetadata).rejects.toThrow('managed source failed');
   });
 
   test('explains resolved source order and immutable column mappings', async () => {


### PR DESCRIPTION
## Goals

- Resolve named scan sources through the existing `DataSourceManager` so loaders.gl has one source registry and lifecycle system.
- Provide a lightweight, deterministic `UNION ALL`-style execution path without expanding into managed multi-table joins.
- Make cross-source schema compatibility, missing columns, mappings, ordering, limits, cancellation, and provenance explicit and testable.

## Changes

- Add `FederatedTableScanSource` to `@loaders.gl/scan` with operation-scoped `DataSourceManager` subscriptions for current, asynchronous, and deferred sources.
- Add ordered append execution with source-local predicates/projections/limits followed by global predicate, projection, and limit semantics.
- Add `strict` schema reconciliation for exact mapped column/type compatibility and `union` reconciliation with first-seen column order and typed null filling.
- Add explicit physical-to-federated column mappings and reject missing, empty, duplicate, or type-incompatible mappings.
- Attach source id, source index, physical batch index, and original physical metadata to every output batch.
- Stop and close active iterators as soon as the global limit is satisfied; avoid opening later sources and release all manager subscriptions on completion, error, cancellation, or early return.
- Export the executor, capabilities, options, explanation, and provenance types from the scan package.
- Document the registry/resource-manager alignment, schema contract, execution guarantees, supported format participation, and intentional non-goals in the scan architecture, scan README, and `DataSourceManager` reference.
- Add exhaustive browser conformance tests for registry resolution, deferred sources, schema policies, mappings, null filling, statistics, cancellation, early termination, limit pushdown, stubborn child sources, provenance, explanations, and validation failures.

## Validation

- `yarn lint fix`
- `node ./scripts/build-modules-parallel.mjs` — all 57 modules built
- `yarn build-workers`
- `yarn test-node` — 360 passed, 6 skipped
- `yarn test-headless` — 3,046 passed, 40 skipped
- `yarn test-audit` — 0 violations
- focused Chromium coverage for `federated-table-scan-source.ts` — 100% statements, branches, functions, and lines
