### PR TITLE
perf(csv): parse ASCII text directly into Arrow

### DIFF
--- a/modules/csv/src/csv-arrow-table-parser.ts
+++ b/modules/csv/src/csv-arrow-table-parser.ts
@@ -621,10 +621,9 @@ function tryParseTypedUnquotedCSVBytes(
   }
   const headerEnd = findDirectRowEnd(bytes, 0);
   const headerRow = decodeDirectHeaderRow(bytes, 0, headerEnd.end, delimiterByte);
-  const initialColumnCapacity = Math.max(
-    1024,
-    Math.ceil(bytes.length / (Math.max(headerRow.length, 1) * 8))
-  );
+  // Keep aggregate speculative typed storage proportional to input size. A large per-column
+  // minimum can exhaust memory for valid CSV files with tens of thousands of shallow columns.
+  const initialColumnCapacity = calculateInitialTypedColumnCapacity(bytes.length, headerRow.length);
   const columns: DirectTypedColumn[] = headerRow.map(() => ({
     values: [],
     initialCapacity: initialColumnCapacity,
@@ -678,6 +677,17 @@ function tryParseTypedUnquotedCSVBytes(
   }
 
   return buildDirectTypedArrowTable(bytes, headerRow, columns, rowCount);
+}
+
+/**
+ * Calculates per-column speculative storage for the direct typed parser.
+ * @internal
+ */
+export function calculateInitialTypedColumnCapacity(
+  byteLength: number,
+  columnCount: number
+): number {
+  return Math.max(1, Math.ceil(byteLength / (Math.max(columnCount, 1) * 8)));
 }
 
 /** Checks the conservative option set supported by the direct unquoted typed parser. */

--- a/modules/csv/src/lib/parsers/parse-csv-to-arrow.ts
+++ b/modules/csv/src/lib/parsers/parse-csv-to-arrow.ts
@@ -18,7 +18,7 @@ import type {CSVLoaderOptions} from '../../csv-loader-options';
 import {CSV_LOADER_OPTIONS} from '../../csv-loader-options';
 import Papa from '../../papaparse/papaparse';
 import AsyncIteratorStreamer from '../../papaparse/async-iterator-streamer';
-import {parseRawArrowCSVBytes} from './parse-raw-arrow-csv-bytes';
+import {parseRawArrowCSVASCIIText, parseRawArrowCSVBytes} from './parse-raw-arrow-csv-bytes';
 
 /** CSV options accepted by the internal Arrow table parser. */
 export type CSVRawArrowOptions = Omit<NonNullable<CSVLoaderOptions['csv']>, 'shape' | 'header'> & {
@@ -77,6 +77,11 @@ export async function parseRawArrowCSVText(
   const csvOptions = createRawArrowCSVOptions(options);
   if (shouldUsePapaCompatibleSkipEmptyLines(csvOptions)) {
     return parseRawArrowCSVTextWithPapa(csvText, options, csvOptions);
+  }
+
+  const rawASCIIArrowTable = parseRawArrowCSVASCIIText(csvText, csvOptions);
+  if (rawASCIIArrowTable) {
+    return rawASCIIArrowTable;
   }
 
   const encodedCSVText = textEncoder.encode(csvText);

--- a/modules/csv/src/lib/parsers/parse-raw-arrow-csv-bytes.ts
+++ b/modules/csv/src/lib/parsers/parse-raw-arrow-csv-bytes.ts
@@ -35,6 +35,7 @@ const CARRIAGE_RETURN = 13;
 const LINE_FEED = 10;
 const SPACE = 32;
 const TAB = 9;
+const ASCII_TEXT_PROBE_LENGTH = 256;
 
 const FLOAT = /^\s*-?(\d*\.?\d+|\d+\.?\d*)(e[-+]?\d+)?\s*$/i;
 const ISO_DATE =
@@ -77,6 +78,65 @@ export function parseRawArrowCSVBytes(
 
   const parser = new RawArrowCSVByteParser(bytes, parserOptions);
   return parser.parseTable();
+}
+
+/**
+ * Parses explicit-delimiter, unquoted ASCII CSV text directly into an Arrow Utf8 table.
+ *
+ * Returns `null` when the input or options require the general UTF-8 byte parser.
+ */
+export function parseRawArrowCSVASCIIText(
+  csvText: string,
+  csvOptions: CSVRawArrowOptions
+): ArrowTable | null {
+  const parserOptions = getCSVASCIITextParserOptions(csvOptions);
+  if (!parserOptions) {
+    return null;
+  }
+
+  const probeLength = Math.min(csvText.length, ASCII_TEXT_PROBE_LENGTH);
+  for (let characterIndex = 0; characterIndex < probeLength; characterIndex++) {
+    const characterCode = csvText.charCodeAt(characterIndex);
+    if (characterCode === parserOptions.quote || characterCode >= 128) {
+      return null;
+    }
+  }
+
+  const parser = new RawArrowUnquotedCSVTextParser(csvText, parserOptions);
+  return parser.parseTable();
+}
+
+/** Returns parser options for the direct unquoted ASCII text path. */
+function getCSVASCIITextParserOptions(csvOptions: CSVRawArrowOptions): CSVByteParserOptions | null {
+  const shouldUseUtf8View =
+    csvOptions.viewTypes === 'require' ||
+    (csvOptions.viewTypes === 'prefer' && getArrowViewTypeSupport().utf8View);
+  if (shouldUseUtf8View || csvOptions.comments || csvOptions.skipEmptyLines) {
+    return null;
+  }
+
+  const quoteChar = csvOptions.quoteChar || '"';
+  const escapeChar = csvOptions.escapeChar || '"';
+  const configuredDelimiter = (csvOptions as CSVRawArrowOptions & {delimiter?: string}).delimiter;
+  if (
+    quoteChar.length !== 1 ||
+    quoteChar.charCodeAt(0) >= 128 ||
+    escapeChar !== quoteChar ||
+    !configuredDelimiter ||
+    configuredDelimiter.length !== 1 ||
+    configuredDelimiter.charCodeAt(0) >= 128
+  ) {
+    return null;
+  }
+
+  return {
+    delimiter: configuredDelimiter.charCodeAt(0),
+    quote: quoteChar.charCodeAt(0),
+    columnPrefix: csvOptions.columnPrefix || 'column',
+    header: csvOptions.header ?? false,
+    dynamicTyping: Boolean(csvOptions.dynamicTyping),
+    skipEmptyLines: false
+  };
 }
 
 /** Returns byte parser options when the CSV options are safe for the raw byte fast path. */
@@ -859,6 +919,145 @@ class RawArrowUnquotedCSVByteParser {
   }
 }
 
+/** Single-string parser for CSV text containing only unquoted ASCII fields. */
+class RawArrowUnquotedCSVTextParser {
+  /** Source CSV text. */
+  private readonly csvText: string;
+  /** Normalized parser options. */
+  private readonly options: CSVByteParserOptions;
+  /** Header transformer that makes duplicate column names unique. */
+  private readonly duplicateColumnTransformer = createDuplicateColumnTransformer();
+
+  /** Creates a direct ASCII text parser. */
+  constructor(csvText: string, options: CSVByteParserOptions) {
+    this.csvText = csvText;
+    this.options = options;
+  }
+
+  /** Parses the text or returns `null` when it requires the general UTF-8 parser. */
+  parseTable(): ArrowTable | null {
+    if (this.csvText.length === 0) {
+      return createRawArrowTable([], []);
+    }
+
+    let dataStart = 0;
+    const firstRow = this.findRowEnd(0);
+    const isHeader = this.options.header === 'auto' ? true : Boolean(this.options.header);
+    let headerRow: string[];
+
+    if (isHeader) {
+      const decodedHeaderRow = this.decodeHeaderRow(0, firstRow.end);
+      if (!decodedHeaderRow) {
+        return null;
+      }
+      headerRow = decodedHeaderRow;
+      dataStart = firstRow.nextStart;
+    } else {
+      headerRow = generateHeader(
+        this.options.columnPrefix,
+        countDelimitedTextFields(this.csvText, 0, firstRow.end, this.options.delimiter)
+      );
+    }
+
+    const columnBuilders = createRawArrowColumnBuilders(headerRow, this.csvText.length);
+    if (!this.appendDataRows(dataStart, columnBuilders)) {
+      return null;
+    }
+    return createRawArrowTable(headerRow, columnBuilders);
+  }
+
+  /** Appends data rows and reports whether every field was unquoted ASCII. */
+  private appendDataRows(start: number, columnBuilders: RawArrowUtf8ColumnBuilder[]): boolean {
+    if (start >= this.csvText.length) {
+      return true;
+    }
+
+    const columnCount = columnBuilders.length;
+    const delimiter = this.options.delimiter;
+    const quote = this.options.quote;
+    let fieldStart = start;
+    let columnIndex = 0;
+
+    for (let characterIndex = start; characterIndex <= this.csvText.length; characterIndex++) {
+      const characterCode = this.csvText.charCodeAt(characterIndex);
+      if (characterCode === quote || characterCode >= 128) {
+        return false;
+      }
+      if (
+        characterCode !== delimiter &&
+        characterCode !== LINE_FEED &&
+        characterCode !== CARRIAGE_RETURN &&
+        characterIndex !== this.csvText.length
+      ) {
+        continue;
+      }
+
+      const columnBuilder = columnBuilders[columnIndex];
+      if (columnBuilder) {
+        columnBuilder.appendASCIITextRange(this.csvText, fieldStart, characterIndex);
+      }
+      columnIndex++;
+
+      if (characterCode === delimiter) {
+        fieldStart = characterIndex + 1;
+        continue;
+      }
+
+      for (; columnIndex < columnCount; columnIndex++) {
+        columnBuilders[columnIndex].appendNull();
+      }
+      columnIndex = 0;
+
+      if (
+        characterCode === CARRIAGE_RETURN &&
+        this.csvText.charCodeAt(characterIndex + 1) === LINE_FEED
+      ) {
+        characterIndex++;
+      }
+      fieldStart = characterIndex + 1;
+      if (fieldStart >= this.csvText.length) {
+        break;
+      }
+    }
+    return true;
+  }
+
+  /** Decodes and deduplicates an ASCII header row. */
+  private decodeHeaderRow(start: number, end: number): string[] | null {
+    const headerRow: string[] = [];
+    let fieldStart = start;
+    for (let characterIndex = start; characterIndex <= end; characterIndex++) {
+      const characterCode = this.csvText.charCodeAt(characterIndex);
+      if (characterCode === this.options.quote || characterCode >= 128) {
+        return null;
+      }
+      if (characterIndex === end || characterCode === this.options.delimiter) {
+        headerRow.push(
+          this.duplicateColumnTransformer(this.csvText.slice(fieldStart, characterIndex))
+        );
+        fieldStart = characterIndex + 1;
+      }
+    }
+    return headerRow;
+  }
+
+  /** Locates the end of one row and the beginning of the next. */
+  private findRowEnd(start: number): {end: number; nextStart: number} {
+    for (let characterIndex = start; characterIndex < this.csvText.length; characterIndex++) {
+      const characterCode = this.csvText.charCodeAt(characterIndex);
+      if (characterCode === LINE_FEED || characterCode === CARRIAGE_RETURN) {
+        const nextStart =
+          characterCode === CARRIAGE_RETURN &&
+          this.csvText.charCodeAt(characterIndex + 1) === LINE_FEED
+            ? characterIndex + 2
+            : characterIndex + 1;
+        return {end: characterIndex, nextStart};
+      }
+    }
+    return {end: this.csvText.length, nextStart: this.csvText.length};
+  }
+}
+
 /** Accumulates unescaped quoted field bytes without converting the field to a string. */
 class ByteRangeBuilder {
   private data: Uint8Array;
@@ -969,6 +1168,18 @@ class RawArrowUtf8ColumnBuilder {
   /** Appends a non-null value from a byte range. */
   appendRange(source: Uint8Array, start: number, end: number): void {
     this.appendValue(source, start, end);
+  }
+
+  /** Appends a non-null value from a previously validated ASCII text range. */
+  appendASCIITextRange(source: string, start: number, end: number): void {
+    const characterLength = end - start;
+    this.reserveData(characterLength);
+    for (let characterIndex = start; characterIndex < end; characterIndex++) {
+      this.data[this.dataLength] = source.charCodeAt(characterIndex);
+      this.dataLength++;
+    }
+    this.appendValueOffset(this.dataLength);
+    this.setValid(this.valueOffsetCount - 2);
   }
 
   /** Appends an escaped quoted value by collapsing doubled quote bytes. */
@@ -1104,6 +1315,22 @@ function countDelimitedFields(
   let fieldCount = 1;
   for (let byteIndex = start; byteIndex < end; byteIndex++) {
     if (bytes[byteIndex] === delimiter) {
+      fieldCount++;
+    }
+  }
+  return fieldCount;
+}
+
+/** Counts fields in an unquoted text range. */
+function countDelimitedTextFields(
+  csvText: string,
+  start: number,
+  end: number,
+  delimiter: number
+): number {
+  let fieldCount = 1;
+  for (let characterIndex = start; characterIndex < end; characterIndex++) {
+    if (csvText.charCodeAt(characterIndex) === delimiter) {
       fieldCount++;
     }
   }

--- a/modules/csv/test/csv-fast-path.spec.ts
+++ b/modules/csv/test/csv-fast-path.spec.ts
@@ -5,6 +5,7 @@
 import {parseInBatches} from '@loaders.gl/core';
 import {CSVLoader} from '@loaders.gl/csv/bundled';
 import {describe, expect, test} from 'vitest';
+import {calculateInitialTypedColumnCapacity} from '../src/csv-arrow-table-parser';
 
 /** Reads one Arrow column into ordinary JavaScript values for assertions. */
 function getArrowColumnValues(table: any, columnName: string): unknown[] {
@@ -126,6 +127,22 @@ describe('CSV optimized parsing paths', () => {
 
     expect(table.schema?.fields.map(field => field.type)).toEqual(['float64']);
     expect(getArrowColumnValues(table, 'value')).toEqual([1, 2]);
+  });
+
+  test('bounds speculative typed storage for shallow high-cardinality input', async () => {
+    const columnCount = 5000;
+    const header = Array.from({length: columnCount}, (_, columnIndex) => `c${columnIndex}`);
+    const values = Array.from({length: columnCount}, (_, columnIndex) => String(columnIndex));
+    const csvBytes = new TextEncoder().encode(`${header.join(',')}\n${values.join(',')}\n`);
+
+    expect(calculateInitialTypedColumnCapacity(csvBytes.length, columnCount)).toBeLessThan(4);
+
+    const table = await CSVLoader.parse(csvBytes.buffer, {
+      csv: {header: true, shape: 'arrow-table', dynamicTyping: true, skipEmptyLines: false}
+    });
+    expect(table.data.numCols).toBe(columnCount);
+    expect(table.data.numRows).toBe(1);
+    expect(table.data.getChildAt(columnCount - 1)?.get(0)).toBe(columnCount - 1);
   });
 
   test('preserves nulls and source strings in mixed typed columns', async () => {

--- a/modules/csv/test/parse-raw-arrow-csv-bytes.spec.ts
+++ b/modules/csv/test/parse-raw-arrow-csv-bytes.spec.ts
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {describe, expect, test} from 'vitest';
+import {csvParse} from 'd3-dsv';
 
 import {
   parseCSVArrayBufferAsArrow,
@@ -10,7 +11,10 @@ import {
   parseCSVTextAsArrow
 } from '../src/csv-arrow-table-parser';
 import {parseRawArrowCSVTable, parseRawArrowCSVText} from '../src/lib/parsers/parse-csv-to-arrow';
-import {parseRawArrowCSVBytes} from '../src/lib/parsers/parse-raw-arrow-csv-bytes';
+import {
+  parseRawArrowCSVASCIIText,
+  parseRawArrowCSVBytes
+} from '../src/lib/parsers/parse-raw-arrow-csv-bytes';
 
 /** Encodes a CSV fixture for the byte parser. */
 function encode(text: string): ArrayBuffer {
@@ -18,6 +22,33 @@ function encode(text: string): ArrayBuffer {
 }
 
 describe('raw Arrow CSV parser', () => {
+  test('matches d3-dsv string contents on the unquoted ASCII text fast path', async () => {
+    const csvRows = ['id,value,name'];
+    for (let rowIndex = 0; rowIndex < 2000; rowIndex++) {
+      csvRows.push(`${rowIndex},${rowIndex * 2},name-${rowIndex}`);
+    }
+    const csvText = `${csvRows.join('\n')}\n`;
+    const d3Rows = csvParse(csvText).map(row => ({...row}));
+    const table = await parseCSVTextAsArrow(csvText, {
+      csv: {header: true, delimiter: ',', dynamicTyping: false}
+    });
+
+    expect(table.schema.fields.map(field => field.name)).toEqual(['id', 'value', 'name']);
+    expect(toRows(table)).toEqual(d3Rows);
+  });
+
+  test('falls back from the ASCII text fast path for general CSV input and options', () => {
+    const options = {header: true, delimiter: ',', dynamicTyping: false} as const;
+
+    expect(toRows(parseRawArrowCSVASCIIText('a,b\r\n1,2\r\n', options)!)).toEqual([
+      {a: '1', b: '2'}
+    ]);
+    expect(parseRawArrowCSVASCIIText('a,b\n"1",2\n', options)).toBeNull();
+    expect(parseRawArrowCSVASCIIText('a,b\ncafé,2\n', options)).toBeNull();
+    expect(parseRawArrowCSVASCIIText('a,b\n1,2\n', {...options, skipEmptyLines: true})).toBeNull();
+    expect(parseRawArrowCSVASCIIText('a,b\n1,2\n', {header: true})).toBeNull();
+  });
+
   test('parses unquoted rows, headers, guessed delimiters, and dynamic typing', async () => {
     const table = await parseRawArrowCSVTable(encode('name,value\nalpha,1\nbeta,2\n'), {
       csv: {header: true, dynamicTyping: false}

--- a/website/src/examples/benchmarks-app.tsx
+++ b/website/src/examples/benchmarks-app.tsx
@@ -20,7 +20,13 @@ const SAMPLE_CSV_URL =
   'https://raw.githubusercontent.com/visgl/loaders.gl/master/modules/csv/test/data/sample-very-long.csv';
 const ROW_COUNT = 2000;
 const WIDE_COLUMN_COUNT = 40;
-const BENCHMARK_OPTIONS = {minIterations: 3, unit: 'rows'};
+const BENCHMARK_OPTIONS = {minIterations: 5, time: 100, unit: 'rows'};
+
+// Keep these labels synchronized with the exact versions resolved in yarn.lock.
+const CSV_LOADER_DISPLAY_NAME = 'CSVLoader v5.0.0-alpha.2 (arrow-table)';
+const D3_DSV_DISPLAY_NAME = 'd3-dsv v1.2.0';
+const UDSV_DISPLAY_NAME = 'uDSV v0.7.3';
+const PAPAPARSE_DISPLAY_NAME = 'PapaParse v5.5.3';
 
 const SI_MULTIPLIERS: Record<string, number> = {
   K: 1e3,
@@ -468,7 +474,7 @@ function getCSVLoaderBenchmarks(
   //   }
   // };
   return [
-    {name: 'CSVLoader (arrow-table)', loader: CSVLoader, options: arrowOptions}
+    {name: CSV_LOADER_DISPLAY_NAME, loader: CSVLoader, options: arrowOptions}
     // Keep the row-table control available for future investigations without adding a second
     // loaders.gl result to the Arrow-focused competitive page.
     // {name: 'CSVLoader', loader: CSVLoader, options: csvOptions}
@@ -513,14 +519,14 @@ function addD3ParseBenchmark(
   scenario: BenchmarkScenario,
   dynamicTyping: boolean
 ): void {
-  bench.addAsync(
-    createBenchmarkId('d3-dsv', {
+  bench.add(
+    createBenchmarkId(D3_DSV_DISPLAY_NAME, {
       dynamicTyping,
       operation: 'parseText',
       scenario: scenario.name
     }),
     {...BENCHMARK_OPTIONS, multiplier: scenario.rowCount},
-    async () =>
+    () =>
       scenario.delimiter === '\t'
         ? tsvParse(scenario.text, dynamicTyping ? autoType : undefined)
         : csvParse(scenario.text, dynamicTyping ? autoType : undefined)
@@ -538,14 +544,14 @@ function addPapaParseNPMBenchmark(
   scenario: BenchmarkScenario,
   dynamicTyping: boolean
 ): void {
-  bench.addAsync(
-    createBenchmarkId('PapaParse npm', {
+  bench.add(
+    createBenchmarkId(PAPAPARSE_DISPLAY_NAME, {
       dynamicTyping,
       operation: 'parseText',
       scenario: scenario.name
     }),
     {...BENCHMARK_OPTIONS, multiplier: scenario.rowCount},
-    async () =>
+    () =>
       PapaParseNPM.parse(scenario.text, {
         header: true,
         dynamicTyping,
@@ -565,14 +571,14 @@ function addUDSVParseBenchmark(
   scenario: BenchmarkScenario,
   dynamicTyping: boolean
 ): void {
-  bench.addAsync(
-    createBenchmarkId('uDSV', {
+  bench.add(
+    createBenchmarkId(UDSV_DISPLAY_NAME, {
       dynamicTyping,
       operation: 'parseText',
       scenario: scenario.name
     }),
     {...BENCHMARK_OPTIONS, multiplier: scenario.rowCount},
-    async () => {
+    () => {
       const schema = inferSchema(scenario.text, {col: scenario.delimiter});
       const parser = initParser(schema);
       return dynamicTyping ? parser.typedObjs(scenario.text) : parser.stringObjs(scenario.text);
@@ -609,7 +615,7 @@ function getBenchmarkDisplayName(benchmarkId: string): string {
  * @returns Whether the row is a loaders.gl benchmark.
  */
 function isLoadersGLBenchmarkName(displayName: string): boolean {
-  return displayName === 'CSVLoader (arrow-table)' || displayName === 'CSVLoader';
+  return displayName === CSV_LOADER_DISPLAY_NAME || displayName === 'CSVLoader';
 }
 
 /**


### PR DESCRIPTION
## Goals

- Increase `CSVLoader` Arrow-table throughput for common unquoted ASCII `parseText` input without changing parsing semantics or the public API.
- Preserve the existing general UTF-8, quoted-field, dynamic-typing, ArrayBuffer, and streaming paths as correctness fallbacks.
- Make the competitive browser benchmark more stable, transparent, and fair to native synchronous parsers.

## Changes

- Parse explicit-delimiter, unquoted ASCII text directly from the JavaScript string into Arrow UTF-8 column buffers, avoiding the whole-input `TextEncoder` allocation and copy.
- Probe conservatively and fall back to the existing UTF-8 byte parser for quotes, non-ASCII text, unsupported options, inferred delimiters, and skip-empty-lines behavior.
- Bound speculative typed-column storage by input size and column count instead of allocating a 1,024-value minimum per column; this avoids excessive memory use for valid shallow CSV files with thousands of columns.
- Add native Vitest coverage that:
  - compares all 6,000 generated cell strings with `d3-dsv`;
  - verifies CRLF handling and quoted, UTF-8, option, and delimiter fallbacks;
  - parses a 5,000-column typed Arrow table while checking the bounded capacity calculation.
- Improve the website benchmark by:
  - showing exact versions for loaders.gl, d3-dsv, uDSV, and PapaParse;
  - timing synchronous competitors through their native synchronous APIs rather than Promise-wrapping them;
  - increasing each sample from the default 80 ms / 3 iterations to 100 ms / 5 iterations for lower variance.

## Performance

Representative focused Chromium result for the same 2,000-row unquoted/untyped fixture and end-to-end Arrow output:

- Before: 8.14M rows/s
- After: 11.0M rows/s
- Improvement: approximately 35%

Representative production benchmark page after switching competitors to their native execution model (rows/s, higher is better):

| Scenario | CSVLoader Arrow | d3-dsv 1.2.0 | uDSV 0.7.3 | PapaParse 5.5.3 |
| --- | ---: | ---: | ---: | ---: |
| Unquoted, untyped | 6.99M | 7.93M | 7.57M | 2.15M |
| Unquoted, typed | 3.99M | 4.38M | 5.42M | 1.83M |
| Quoted, untyped | 3.50M | 2.64M | 2.21M | 1.24M |
| Wide 40-column, typed | 943K | 365K | 572K | 133K |
| UTF-8, untyped | 6.23M | 6.19M | 6.15M | 2.11M |

Browser benchmark values naturally vary with JIT, focus, and host load. No competitor performs Arrow construction or loaders.gl post-processing inside its timed section.

## Compatibility

- No public API changes.
- Streaming remains on the existing incremental parser and retains chunk-boundary behavior.
- Quoted fields, escaped quotes, embedded delimiters/newlines, CRLF, UTF-8, dynamic typing, headers, empty cells, and fallback options retain their existing paths and behavior.

## Validation

- `yarn install`
- `yarn lint fix`
- `yarn test-audit`
- `yarn test-headless modules/csv/test/parse-raw-arrow-csv-bytes.spec.ts modules/csv/test/csv-fast-path.spec.ts` (29 tests)
- `yarn build`
- `yarn build-workers`
- `yarn test-node` (51 files, 360 passed, 6 skipped)
- `yarn test-headless` (499 files passed, 1 skipped; 3,041 tests passed, 40 skipped)
- `cd website && yarn install`
- `cd website && yarn build`

