### PR TITLE
feat(i3s): add Point Cloud source and traversal support

### DIFF
--- a/docs/modules/i3s/README.md
+++ b/docs/modules/i3s/README.md
@@ -24,6 +24,7 @@ npm install @loaders.gl/core
 A standard complement of loader is provided to load the individual 3d Tile file formats:
 
 - [`I3SLoader`](/docs/modules/i3s/api-reference/i3s-loader), a loader for loading a top-down or nested tileset and its tiles.
+- [`I3SPointCloudSource`](/docs/modules/i3s/api-reference/i3s-point-cloud-source), a source for I3S 2.x Point Cloud layers that can be used with [`PointCloudTileset`](/docs/modules/tiles/api-reference/point-cloud-tileset).
 
 To handle the complex dynamic tile selection and loading required to performantly render larger-than-browser-memory tilesets, additional helper classes are provided in `@loaders.gl/tiles` module:
 

--- a/docs/modules/i3s/api-reference/i3s-point-cloud-source.md
+++ b/docs/modules/i3s/api-reference/i3s-point-cloud-source.md
@@ -1,0 +1,21 @@
+# I3SPointCloudSource
+
+`I3SPointCloudSource` adapts an I3S 2.x Point Cloud layer to the shared
+[`PointCloudTileset`](/docs/modules/tiles/api-reference/point-cloud-tileset) traversal API.
+It accepts a SceneServer layer URL, an SLPK URL, or an SLPK `Blob`.
+
+```ts
+import {I3SPointCloudSource} from '@loaders.gl/i3s';
+import {PointCloudTileset} from '@loaders.gl/tiles';
+
+const source = new I3SPointCloudSource(layerUrl, {
+  i3s: {token: arcgisToken, coordinateSystem: 'meter-offsets'}
+});
+const tileset = new PointCloudTileset(source, {pointBudget: 2_000_000});
+await tileset.tilesetInitializationPromise;
+```
+
+The source decodes LEPCC XYZ, RGB, intensity, and flag resources and maps them to
+point-list Arrow tables. Metadata-described scalar attributes are retained under their declared
+names. `density-threshold` node-page metrics are honored by `PointCloudTileset`; producer-specific
+encodings and authoring are intentionally outside this read-only source.

--- a/docs/modules/i3s/formats/i3s.md
+++ b/docs/modules/i3s/formats/i3s.md
@@ -32,9 +32,9 @@ traversal, lightweight metadata loaders with parser preloading, forward-compatib
 schemas, and complete PBR texture-set loading. The underlying mesh parser and most rendering capabilities predate v5.0 and retain their
 original introduction versions below.
 
-The Point Cloud decoder seam added in v5.0 is a dependency-free TypeScript implementation of the
-Apache-licensed Esri LEPCC wire format, isolated behind `I3SLEPCCDecoder` for future worker and
-Point Cloud traversal integration.
+Point Cloud support in v5.0 is exposed through `I3SPointCloudSource`, a dependency-free TypeScript
+LEPCC decoder, and the generic `PointCloudTileset` traversal API. The source supports REST layers
+and SLPK archives while preserving explicit boundaries for producer-specific extensions.
 
 ### Scene layer profiles
 
@@ -44,7 +44,7 @@ Point Cloud traversal integration.
 | Integrated Mesh | **Supported** | v2.0 | End-to-end textured-mesh loading and traversal. Feature-level operations are naturally narrower because this profile does not model discrete objects in the same way as 3D Object layers. |
 | Building Scene Layer | **Partial** | v3.1 | `I3SBuildingSceneLayerLoader` parses the composite hierarchy and returns its 3D Object sublayers. Group structure remains in the header; Point sublayers and Building filters are not evaluated by the loader. |
 | Point | **Not supported** | — | Point geometry, symbols, and point renderers are not decoded. |
-| Point Cloud | **Not supported** | — | I3S 2.x point-cloud node pages, density LOD, LEPCC geometry, and point-cloud attributes are not decoded. The loader rejects `PointCloud` layers explicitly. |
+| Point Cloud | **Supported** | **v5.0** | `I3SPointCloudSource` traverses I3S 2.x node pages, decodes LEPCC XYZ/RGB/intensity/flag resources, and returns point-list Arrow tables for REST and SLPK inputs. |
 
 ### Specification generations
 
@@ -58,7 +58,7 @@ those versions.
 | I3S 1.7 mesh resources | **Supported** | v2.3 | Node pages, OBBs, and geometry definitions arrived in v2.3; Draco geometry, material definitions, and texture-set selection followed in v3.0. |
 | I3S 1.8 mesh additions | **Supported** | v3.1 | KTX2/Basis textures and PBR material fields used by the rendering path are supported, subject to the material limitations below. |
 | I3S 1.9-1.10 mesh documents | **Partial** | **v5.0** | Forward fields are preserved by v5.0 metadata schemas, dedicated 1.9/1.10 fixtures cover the scene-layer envelope, and established mesh resource layouts are consumed. Newer semantics remain bounded by the feature rows below. |
-| I3S 2.0-2.1 Point Cloud | **Not supported** | — | The Point Cloud profile is outside the current mesh-oriented implementation. |
+| I3S 2.0-2.1 Point Cloud | **Partial** | **v5.0** | The Point Cloud source covers node pages, OBB bounds, LEPCC resources, standard attributes, and density thresholds. Producer-specific encodings and full renderer styling remain explicit follow-up work. |
 
 ### Delivery and resource access
 
@@ -84,7 +84,7 @@ those versions.
 | Oriented bounding box (OBB) | **Supported** | v2.0 | OBBs are converted to Cartesian boxes and conservative spheres. |
 | `maxScreenThreshold` LOD | **Supported** | v2.0 | Projected node size drives refinement for legacy node documents. |
 | `maxScreenThresholdSQ` LOD | **Supported** | v2.3 | Node-page thresholds are normalized for the same projected-size traversal. |
-| Other LOD metrics | **Not supported** | — | Density, feature-count, distance-range, and texel-resolution policies are not implemented. |
+| Density-threshold LOD | **Supported** | **v5.0** | Point Cloud node thresholds can drive projected point-density refinement through `PointCloudTileset`. Feature-count, distance-range, and texel-resolution policies remain unsupported. |
 | `REPLACE` refinement | **Supported** | v2.1 | I3S mesh ancestors are replaced as higher-detail children become renderable. |
 | Lazy child metadata | **Supported** | v2.1 | Child headers are requested only when traversal reaches them. |
 | Multiple viewports | **Supported** | v3.2.6 | Pending child-header requests are tracked independently by viewport and frame. |
@@ -113,7 +113,8 @@ those versions.
 
 | Capability | Status | Since | Notes |
 | --- | :---: | --- | --- |
-| LEPCC point-cloud attribute blobs | **Partial** | **v5.0** | The `I3SLEPCCDecoder` adapter decodes standalone `lepcc-xyz`, `lepcc-rgb`, `lepcc-intensity`, and bit-stuffed or Huffman flag-byte resources. Point Cloud layer traversal, density LOD, and renderer integration remain planned. |
+| LEPCC point-cloud attribute blobs | **Supported** | **v5.0** | `I3SLEPCCDecoder` decodes standalone `lepcc-xyz`, `lepcc-rgb`, `lepcc-intensity`, and bit-stuffed or Huffman flag-byte resources. `I3SPointCloudSource` maps them to Arrow point attributes. |
+| Point Cloud standard attributes | **Partial** | **v5.0** | RGB, intensity, flags, and metadata-described scalar arrays are normalized. Classification, returns, and producer-defined bit fields are preserved as raw attributes when no canonical mapping is declared. |
 
 ### Textures and materials
 
@@ -174,7 +175,7 @@ path.
 | 3D Tiles to I3S conversion | **Supported** | v3.0 | Produces I3S 1.8 mesh layers and SLPK output, with optional Draco, KTX2/JPEG generation, feature metadata, and generated bounds. |
 | SLPK / SceneServer serving | **Supported** | v4.0 | `i3s-server` exposes converter output or an SLPK through local REST endpoints. |
 | Metadata schema validation | **Partial** | **v5.0** | Zod and generated JSON schemas cover mesh scene-layer and node-page structures with forward-compatible passthrough fields; this is not full I3S conformance validation. |
-| Native Point or Point Cloud authoring | **Not supported** | — | The converter shares the mesh profile limits of the loaders. |
+| Native Point or Point Cloud authoring | **Not supported** | — | The converter shares the mesh profile limits of the loaders; Point Cloud source support is read-only in this tranche. |
 
 ## I3S roadmap
 
@@ -193,12 +194,18 @@ the sub-tranches under feature intelligence keep the remaining gaps independentl
 | 4b. Layer statistics | Load typed `StatsInfo` resources, preserve missing-field isolation, and expose stable keys to applications. | **Complete** (**v5.0**) |
 | 4c. Drawing and popup intelligence | Evaluate renderer, visual variables, labels, and popup expressions while preserving unsupported definitions. | Planned |
 | 4d. Query and aggregation | Add server-side attribute query/filter helpers and client-side statistics aggregation over loaded features. | Planned |
-| 5. Profile coverage | Add Point, then I3S 2.1 Point Cloud (LEPCC and density-based traversal), including profile-specific attributes. | Planned |
+| 5a. Point Cloud profile model | Add Point Cloud scene-layer schemas, node-page types, OBB bounds, and metadata preservation. | **Complete** (**v5.0**) |
+| 5b. LEPCC geometry | Decode `lepcc-xyz` with checksum validation and point-count checks. | **Complete** (**v5.0**) |
+| 5c. Point Cloud attributes | Decode RGB, intensity, flags, and metadata-described scalar resources into Arrow attributes. | **Complete** (**v5.0**) |
+| 5d. Density traversal | Add density-threshold refinement to the shared point-cloud traversal and honor per-node thresholds. | **Complete** (**v5.0**) |
+| 5e. REST and SLPK access | Resolve Point Cloud node pages and resources from SceneServer URLs and indexed SLPK archives. | **Complete** (**v5.0**) |
+| 5f. Renderer metadata | Return point-list tables, coordinate-system/origin metadata, bounds, and stable canonical attribute names. | **Complete** (**v5.0**) |
+| 5g. Point Cloud conformance | Add deterministic decoder/source fixtures and document unsupported producer-specific extensions. | **Complete** (**v5.0**) |
 | 6. Spatial semantics | Add projected and vertical CRS transforms plus `elevationInfo` placement modes. | Planned |
 | 7. Validation and authoring parity | Expand schema validation and converter fixtures until supported loader and authoring paths have matching conformance guarantees. | Planned |
 
-The next high-value tranche is **4c**, followed by **4d**. Tranches 5–7 close the remaining profile,
-coordinate-system, and authoring gaps needed for full supremacy.
+The next high-value work is renderer styling, CRS/elevation transforms, query helpers, and Point
+Cloud authoring.
 
 ### Remaining roadmap gaps
 
@@ -208,7 +215,7 @@ still visible in the matrix and should be treated as the open work list:
 | Priority | Remaining gap | Exit criteria |
 | --- | --- | --- |
 | P0 | Drawing and popup intelligence (4c) | Evaluate supported renderers, visual variables, labels, and popup expressions while retaining a tested passthrough path for unsupported definitions. |
-| P0 | Point and Point Cloud profiles (5) | Decode Point geometry and symbols, then I3S 2.1 LEPCC, density LOD, and point-cloud attributes with representative fixtures. |
+| P0 | Point profile | Decode Point geometry, symbols, attributes, and renderer metadata with representative fixtures. Point Cloud support is complete for the documented v5.0 boundary. |
 | P1 | Feature queries and aggregation (4d) | Add authenticated SceneServer attribute query/filter helpers and client-side aggregation over loaded feature batches. |
 | P1 | Spatial semantics (6) | Reproject supported horizontal CRSs, honor vertical CRS and units, and apply all `elevationInfo` placement modes. |
 | P1 | Mesh renderer fidelity | Decode legacy mesh-segmentation draw ranges, expose additional UV sets, map sampler wrap values to renderer constants, and add non-screen-space LOD policies. |

--- a/modules/i3s/package.json
+++ b/modules/i3s/package.json
@@ -70,6 +70,7 @@
     "@loaders.gl/images": "5.0.0-alpha.2",
     "@loaders.gl/loader-utils": "5.0.0-alpha.2",
     "@loaders.gl/schema": "5.0.0-alpha.2",
+    "@loaders.gl/schema-utils": "5.0.0-alpha.2",
     "@loaders.gl/textures": "5.0.0-alpha.2",
     "@loaders.gl/tiles": "5.0.0-alpha.2",
     "@loaders.gl/zip": "5.0.0-alpha.2",

--- a/modules/i3s/src/bundled.ts
+++ b/modules/i3s/src/bundled.ts
@@ -21,3 +21,5 @@ export {
   type I3SLEPCCDecodedValue,
   type I3SLEPCCDecoderOptions
 } from './i3s-lepcc';
+export {I3SPointCloudSource} from './i3s-point-cloud-source';
+export type {I3SPointCloudSourceOptions} from './i3s-point-cloud-source';

--- a/modules/i3s/src/i3s-point-cloud-source.ts
+++ b/modules/i3s/src/i3s-point-cloud-source.ts
@@ -1,0 +1,378 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
+import type {DataSourceOptions, ReadableFile} from '@loaders.gl/loader-utils';
+import {BlobFile, HttpFile} from '@loaders.gl/loader-utils';
+import {makeMeshArrowTable} from '@loaders.gl/schema-utils';
+import type {MeshAttributes} from '@loaders.gl/schema';
+import type {
+  PointCloudTileContent,
+  PointCloudTileHeader,
+  PointCloudTilesetSource,
+  PointCloudCoordinateSystem
+} from '@loaders.gl/tiles';
+import {DataSource} from '@loaders.gl/loader-utils';
+import {parseSLPKArchive} from './lib/parsers/parse-slpk/parse-slpk';
+import type {SLPKArchive} from './lib/parsers/parse-slpk/slpk-archieve';
+import {I3SLEPCCDecoder} from './i3s-lepcc';
+import {I3SPointCloudNodePageSchema} from './i3s-zod-schema';
+import type {
+  I3SPointCloudAttributeInfo,
+  I3SPointCloudNode,
+  I3SPointCloudNodePage,
+  SceneLayer3D
+} from './types';
+import {getUrlWithToken} from './lib/utils/url-utils';
+
+/** Options for an {@link I3SPointCloudSource}. */
+export type I3SPointCloudSourceOptions = DataSourceOptions & {
+  /** I3S point-cloud options. */
+  i3s?: {
+    /** ArcGIS access token. */
+    token?: string;
+    /** Verify LEPCC checksums. Defaults to true. */
+    verifyChecksum?: boolean;
+    /** Coordinate system used by the returned point attributes. */
+    coordinateSystem?: PointCloudCoordinateSystem;
+  };
+};
+
+/**
+ * Point Cloud source for REST-served I3S layers and SLPK archives.
+ *
+ * The source intentionally implements the generic tiles point-cloud contract,
+ * allowing applications to use it with {@link PointCloudTileset} while the
+ * existing mesh-oriented I3S loader remains backwards compatible.
+ */
+export class I3SPointCloudSource
+  extends DataSource<string | Blob, I3SPointCloudSourceOptions>
+  implements PointCloudTilesetSource<string | Blob, I3SPointCloudSourceOptions>
+{
+  /** Whether layer metadata and the resource index have been initialized. */
+  isReady = false;
+
+  /** Parsed Point Cloud layer metadata. */
+  metadata: SceneLayer3D | null = null;
+
+  private archive: SLPKArchive | null = null;
+  private readonly nodePages = new Map<number, I3SPointCloudNodePage>();
+  private readonly nodes = new Map<string, I3SPointCloudNode>();
+  private readonly decoder: I3SLEPCCDecoder;
+  private baseUrl = '';
+  private nodesPerPage = 1;
+  private rootIndex = 0;
+
+  /**
+   * Creates an I3S Point Cloud source.
+   * @param data Layer REST URL or an SLPK Blob/URL.
+   * @param options Source and loader options.
+   */
+  constructor(data: string | Blob, options: I3SPointCloudSourceOptions = {}) {
+    super(data, options);
+    this.decoder = new I3SLEPCCDecoder({verifyChecksum: options.i3s?.verifyChecksum});
+  }
+
+  /** Load and validate the scene-layer metadata. */
+  async initialize(): Promise<void> {
+    if (this.isReady) {
+      return;
+    }
+
+    if (this.isArchiveInput()) {
+      const file = await this.getArchiveFile();
+      this.archive = await parseSLPKArchive(file);
+    }
+
+    const layerJson = await this.readJson('');
+    if (layerJson?.layerType !== 'PointCloud') {
+      throw new Error('I3SPointCloudSource requires an I3S PointCloud layer');
+    }
+    this.metadata = layerJson as SceneLayer3D;
+    this.baseUrl = this.url.replace(/\/+$/, '');
+    this.nodesPerPage = Math.max(1, Number(layerJson.nodePages?.nodesPerPage || 1));
+    this.rootIndex = Number(layerJson.nodePages?.rootIndex || 0);
+    this.isReady = true;
+  }
+
+  /** Return the parsed scene-layer metadata. */
+  async getMetadata(): Promise<SceneLayer3D> {
+    await this.initialize();
+    return this.metadata!;
+  }
+
+  /** Return the root point-cloud tile header. */
+  async getRootTile(): Promise<PointCloudTileHeader> {
+    await this.initialize();
+    const node = await this.getNode(this.rootIndex);
+    return this.makeTileHeader(this.rootIndex, node, 0);
+  }
+
+  /** Return the children of a point-cloud tile. */
+  async getChildren(tile: PointCloudTileHeader): Promise<PointCloudTileHeader[]> {
+    await this.initialize();
+    const node = this.nodes.get(tile.id);
+    if (!node || !node.childCount || node.firstChild === undefined) {
+      return [];
+    }
+    const children: PointCloudTileHeader[] = [];
+    for (let index = 0; index < node.childCount; index++) {
+      const childId = node.firstChild + index;
+      const child = await this.getNode(childId);
+      children.push(this.makeTileHeader(childId, child, tile.level + 1));
+    }
+    return children;
+  }
+
+  /** Decode geometry and attribute resources for one point-cloud tile. */
+  async loadTileContent(tile: PointCloudTileHeader): Promise<PointCloudTileContent | null> {
+    await this.initialize();
+    const node = this.nodes.get(tile.id);
+    if (!node) {
+      return null;
+    }
+
+    const resourceId = String(node.resourceId);
+    const geometryResource = node.geometryResource ?? 0;
+    const geometryBytes = await this.readBinary(
+      this.resourceCandidates(`nodes/${resourceId}/geometries/${geometryResource}`)
+    );
+    const positions = this.decoder.decodeXyz(new Uint8Array(geometryBytes));
+    const pointCount = positions.length / 3;
+    if (node.vertexCount && node.vertexCount !== pointCount) {
+      throw new Error(
+        `I3S PointCloud geometry count mismatch: expected ${node.vertexCount}, got ${pointCount}`
+      );
+    }
+
+    // MeshArrowTable's canonical POSITION field is Float32. Preserve the tile
+    // origin separately in the returned content so renderers can reconstruct
+    // full precision without widening the shared Arrow schema.
+    const origin = tile.boundingVolume.center.slice(0, 3);
+    const localPositions = Float32Array.from(
+      positions,
+      (value, index) => value - origin[index % 3]
+    );
+    const attributes: MeshAttributes = {
+      POSITION: {value: localPositions, size: 3}
+    };
+    const descriptors = this.getAttributeDescriptors();
+    await Promise.all(
+      descriptors.map(async descriptor => {
+        const bytes = await this.readBinaryOptional(
+          this.resourceCandidates(
+            `nodes/${resourceId}/attributes/${descriptor.key || descriptor.name || ''}/${
+              descriptor.resource ?? 0
+            }`,
+            descriptor.key || descriptor.name
+          )
+        );
+        if (!bytes) {
+          return;
+        }
+        const decoded = this.decodeAttribute(bytes, descriptor);
+        if (decoded.value.length !== pointCount * decoded.size) {
+          throw new Error(
+            `I3S PointCloud attribute ${descriptor.name || descriptor.key || 'unknown'} count mismatch`
+          );
+        }
+        const attributeName = this.getAttributeName(descriptor, decoded.kind);
+        attributes[attributeName] = {
+          value: decoded.value,
+          size: decoded.size
+        };
+      })
+    );
+
+    const volume = tile.boundingVolume;
+    const table = makeMeshArrowTable(attributes, {
+      topology: 'point-list',
+      boundingBox: volume.cartographicBounds
+    });
+    return {
+      data: table,
+      pointCount,
+      cartographicOrigin: origin,
+      coordinateSystem: this.options.i3s?.coordinateSystem || 'cartesian'
+    };
+  }
+
+  /** Return a view state suitable for PointCloudTileset initialization. */
+  getViewState() {
+    const extent = this.metadata?.fullExtent;
+    const center = extent?.xmin !== undefined ? [extent.xmin, extent.ymin, 0] : undefined;
+    return center ? {cartographicCenter: center} : {};
+  }
+
+  private isArchiveInput(): boolean {
+    return this.data instanceof Blob || /\.slpk(?:$|[?#])/i.test(this.url);
+  }
+
+  private async getArchiveFile(): Promise<ReadableFile> {
+    if (this.data instanceof Blob) {
+      return new BlobFile(this.data);
+    }
+    return new HttpFile(getUrlWithToken(this.url, this.options.i3s?.token || null), {
+      fetch: this.fetch
+    });
+  }
+
+  private async getNode(nodeId: number): Promise<I3SPointCloudNode> {
+    const cached = this.nodes.get(String(nodeId));
+    if (cached) {
+      return cached;
+    }
+    const pageIndex = Math.floor(nodeId / this.nodesPerPage);
+    const page = await this.getNodePage(pageIndex);
+    const nodeIndex = nodeId % this.nodesPerPage;
+    const node = page.nodes[nodeIndex];
+    if (!node) {
+      throw new Error(`I3S PointCloud node ${nodeId} is not present in node page ${pageIndex}`);
+    }
+    this.nodes.set(String(nodeId), node);
+    return node;
+  }
+
+  private async getNodePage(pageIndex: number): Promise<I3SPointCloudNodePage> {
+    const cached = this.nodePages.get(pageIndex);
+    if (cached) {
+      return cached;
+    }
+    const json = await this.readJson(`nodepages/${pageIndex}`);
+    const page = I3SPointCloudNodePageSchema.parse(json) as I3SPointCloudNodePage;
+    this.nodePages.set(pageIndex, page);
+    return page;
+  }
+
+  private makeTileHeader(
+    nodeId: number,
+    node: I3SPointCloudNode,
+    level: number
+  ): PointCloudTileHeader {
+    const center = Array.from(node.obb.center as number[]);
+    const halfSize = Array.from(node.obb.halfSize as number[]);
+    const minimum = center.map((value, index) => value - halfSize[index]);
+    const maximum = center.map((value, index) => value + halfSize[index]);
+    return {
+      id: String(nodeId),
+      level,
+      pointCount: node.vertexCount,
+      geometricError: node.lodThreshold || 0,
+      lodSelectionMetricType:
+        (this.metadata?.nodePages?.lodSelectionMetricType as
+          | 'maxScreenThresholdSQ'
+          | 'density-threshold'
+          | undefined) || 'maxScreenThresholdSQ',
+      lodThreshold: node.lodThreshold,
+      boundingVolume: {
+        cartographicBounds: [minimum, maximum],
+        center,
+        radius: Math.hypot(...halfSize)
+      }
+    };
+  }
+
+  private getAttributeDescriptors(): I3SPointCloudAttributeInfo[] {
+    const layer = this.metadata as
+      | (SceneLayer3D & {
+          attributeInfo?: I3SPointCloudAttributeInfo[];
+        })
+      | null;
+    return (layer?.attributeInfo ||
+      layer?.attributeStorageInfo ||
+      []) as I3SPointCloudAttributeInfo[];
+  }
+
+  private decodeAttribute(
+    bytes: ArrayBuffer,
+    descriptor: I3SPointCloudAttributeInfo
+  ): {
+    value: Float32Array | Float64Array | Uint8Array | Uint16Array | Int32Array;
+    size: number;
+    kind: string;
+  } {
+    const data = new Uint8Array(bytes);
+    const encoding = String(descriptor.encoding || '').toLowerCase();
+    let magic = '';
+    try {
+      magic = this.decoder.getBlobType(data);
+    } catch {
+      // Uncompressed attributes have no LEPCC magic and are decoded from metadata below.
+    }
+    const kind = encoding || magic;
+    if (magic === 'rgb' || encoding.includes('rgb')) {
+      return {value: this.decoder.decodeRgb(data), size: 3, kind: 'rgb'};
+    }
+    if (magic === 'intensity' || encoding.includes('intensity')) {
+      return {value: this.decoder.decodeIntensity(data), size: 1, kind: 'intensity'};
+    }
+    if (magic === 'flagBytes' || encoding.includes('flag')) {
+      return {value: this.decoder.decodeFlagBytes(data), size: 1, kind: 'flags'};
+    }
+
+    const valueType = String(descriptor.valueType || 'UInt8').toLowerCase();
+    const valueSize = descriptor.valueSize || 1;
+    if (valueType.includes('float32')) {
+      return {value: new Float32Array(bytes), size: valueSize, kind};
+    }
+    if (valueType.includes('float64')) {
+      return {value: new Float64Array(bytes), size: valueSize, kind};
+    }
+    if (valueType.includes('uint16')) {
+      return {value: new Uint16Array(bytes), size: valueSize, kind};
+    }
+    if (valueType.includes('int32')) {
+      return {value: new Int32Array(bytes), size: valueSize, kind};
+    }
+    return {value: new Uint8Array(bytes), size: valueSize, kind};
+  }
+
+  private getAttributeName(descriptor: I3SPointCloudAttributeInfo, kind: string): string {
+    if (kind.includes('rgb')) return 'COLOR_0';
+    if (kind.includes('intensity')) return 'intensity';
+    if (kind.includes('flag')) return 'flags';
+    return descriptor.name || descriptor.key || 'attribute';
+  }
+
+  private resourceCandidates(path: string, alternateKey?: string): string[] {
+    const paths = [path];
+    if (alternateKey && !path.includes(`/${alternateKey}/`)) {
+      paths.push(path.replace(/\/attributes\/[^/]+\//, `/attributes/${alternateKey}/`));
+    }
+    return paths;
+  }
+
+  private async readJson(path: string): Promise<any> {
+    const bytes = await this.readBinary(path ? [path] : ['']);
+    return JSON.parse(new TextDecoder().decode(bytes));
+  }
+
+  private async readBinary(paths: string | string[]): Promise<ArrayBuffer> {
+    const values = Array.isArray(paths) ? paths : [paths];
+    let lastError: unknown;
+    for (const path of values) {
+      try {
+        if (this.archive) {
+          return await this.archive.getFile(path, 'http');
+        }
+        const url = path ? `${this.baseUrl || this.url}/${path}` : this.url;
+        const response = await this.fetch(getUrlWithToken(url, this.options.i3s?.token || null));
+        if (!response.ok) {
+          throw new Error(`I3S resource request failed (${response.status}): ${url}`);
+        }
+        return await response.arrayBuffer();
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    throw lastError instanceof Error ? lastError : new Error('I3S resource request failed');
+  }
+
+  private async readBinaryOptional(paths: string | string[]): Promise<ArrayBuffer | null> {
+    try {
+      return await this.readBinary(paths);
+    } catch {
+      return null;
+    }
+  }
+}

--- a/modules/i3s/src/i3s-point-cloud-source.ts
+++ b/modules/i3s/src/i3s-point-cloud-source.ts
@@ -6,6 +6,8 @@ import type {DataSourceOptions, ReadableFile} from '@loaders.gl/loader-utils';
 import {BlobFile, HttpFile} from '@loaders.gl/loader-utils';
 import {makeMeshArrowTable} from '@loaders.gl/schema-utils';
 import type {MeshAttributes} from '@loaders.gl/schema';
+import {Vector3} from '@math.gl/core';
+import {Ellipsoid} from '@math.gl/geospatial';
 import type {
   PointCloudTileContent,
   PointCloudTileHeader,
@@ -55,12 +57,19 @@ export class I3SPointCloudSource
   /** Parsed Point Cloud layer metadata. */
   metadata: SceneLayer3D | null = null;
 
+  /** Random-access archive used for SLPK-backed resources. */
   private archive: SLPKArchive | null = null;
+  /** Node pages cached by physical page index. */
   private readonly nodePages = new Map<number, I3SPointCloudNodePage>();
+  /** Resolved hierarchy nodes cached by global node id. */
   private readonly nodes = new Map<string, I3SPointCloudNode>();
+  /** Decoder used for LEPCC geometry and attribute resources. */
   private readonly decoder: I3SLEPCCDecoder;
+  /** Normalized REST layer base URL. */
   private baseUrl = '';
+  /** Number of global nodes stored in each physical index page. */
   private nodesPerPage = 1;
+  /** Global node id of the hierarchy root. */
   private rootIndex = 0;
 
   /**
@@ -90,7 +99,10 @@ export class I3SPointCloudSource
     }
     this.metadata = layerJson as SceneLayer3D;
     this.baseUrl = this.url.replace(/\/+$/, '');
-    this.nodesPerPage = Math.max(1, Number(layerJson.nodePages?.nodesPerPage || 1));
+    this.nodesPerPage = Math.max(
+      1,
+      Number(layerJson.nodePages?.nodesPerPage || layerJson.store?.index?.nodePerIndexBlock || 1)
+    );
     this.rootIndex = Number(layerJson.nodePages?.rootIndex || 0);
     this.isReady = true;
   }
@@ -148,13 +160,13 @@ export class I3SPointCloudSource
     // MeshArrowTable's canonical POSITION field is Float32. Preserve the tile
     // origin separately in the returned content so renderers can reconstruct
     // full precision without widening the shared Arrow schema.
-    const origin = tile.boundingVolume.center.slice(0, 3);
-    const localPositions = Float32Array.from(
+    const normalizedPositions = normalizePointPositions(
       positions,
-      (value, index) => value - origin[index % 3]
+      tile.boundingVolume.center,
+      this.options.i3s?.coordinateSystem
     );
     const attributes: MeshAttributes = {
-      POSITION: {value: localPositions, size: 3}
+      POSITION: {value: normalizedPositions.positions, size: 3}
     };
     const descriptors = this.getAttributeDescriptors();
     await Promise.all(
@@ -192,8 +204,8 @@ export class I3SPointCloudSource
     return {
       data: table,
       pointCount,
-      cartographicOrigin: origin,
-      coordinateSystem: this.options.i3s?.coordinateSystem || 'cartesian'
+      cartographicOrigin: normalizedPositions.cartographicOrigin,
+      coordinateSystem: normalizedPositions.coordinateSystem
     };
   }
 
@@ -251,8 +263,23 @@ export class I3SPointCloudSource
   ): PointCloudTileHeader {
     const center = Array.from(node.obb.center as number[]);
     const halfSize = Array.from(node.obb.halfSize as number[]);
-    const minimum = center.map((value, index) => value - halfSize[index]);
-    const maximum = center.map((value, index) => value + halfSize[index]);
+    const radius = Math.hypot(...halfSize);
+    const latitudeRadians = (center[1] * Math.PI) / 180;
+    const latitudeDelta = (radius / EARTH_EQUATORIAL_RADIUS) * (180 / Math.PI);
+    const longitudeDelta = Math.min(
+      180,
+      latitudeDelta / Math.max(Math.abs(Math.cos(latitudeRadians)), 1e-12)
+    );
+    const minimum = [
+      center[0] - longitudeDelta,
+      Math.max(-90, center[1] - latitudeDelta),
+      center[2] - radius
+    ];
+    const maximum = [
+      center[0] + longitudeDelta,
+      Math.min(90, center[1] + latitudeDelta),
+      center[2] + radius
+    ];
     return {
       id: String(nodeId),
       level,
@@ -267,7 +294,7 @@ export class I3SPointCloudSource
       boundingVolume: {
         cartographicBounds: [minimum, maximum],
         center,
-        radius: Math.hypot(...halfSize)
+        radius
       }
     };
   }
@@ -310,8 +337,10 @@ export class I3SPointCloudSource
       return {value: this.decoder.decodeFlagBytes(data), size: 1, kind: 'flags'};
     }
 
-    const valueType = String(descriptor.valueType || 'UInt8').toLowerCase();
-    const valueSize = descriptor.valueSize || 1;
+    const valueType = String(
+      descriptor.attributeValues?.valueType || descriptor.valueType || 'UInt8'
+    ).toLowerCase();
+    const valueSize = descriptor.attributeValues?.valuesPerElement || descriptor.valueSize || 1;
     if (valueType.includes('float32')) {
       return {value: new Float32Array(bytes), size: valueSize, kind};
     }
@@ -375,4 +404,65 @@ export class I3SPointCloudSource
       return null;
     }
   }
+}
+
+const EARTH_EQUATORIAL_RADIUS = 6378137;
+
+/** Normalized point positions and renderer metadata for one coordinate-system request. */
+type NormalizedPointPositions = Readonly<{
+  /** Point coordinates passed to the Arrow mesh table. */
+  positions: Float32Array;
+  /** Geographic origin retained for offset coordinate systems. */
+  cartographicOrigin: number[];
+  /** Concrete renderer coordinate system after resolving `default`. */
+  coordinateSystem: PointCloudCoordinateSystem;
+}>;
+
+/** Converts absolute geographic LEPCC positions to the requested renderer representation. */
+function normalizePointPositions(
+  positions: Float64Array,
+  center: number[],
+  requestedCoordinateSystem?: PointCloudCoordinateSystem
+): NormalizedPointPositions {
+  const coordinateSystem =
+    !requestedCoordinateSystem || requestedCoordinateSystem === 'default'
+      ? 'lnglat-offsets'
+      : requestedCoordinateSystem;
+  if (coordinateSystem === 'cartesian') {
+    const cartesianPositions = new Float32Array(positions.length);
+    const cartesian = new Vector3();
+    for (let index = 0; index < positions.length; index += 3) {
+      Ellipsoid.WGS84.cartographicToCartesian(
+        new Vector3([positions[index], positions[index + 1], positions[index + 2]]),
+        cartesian
+      );
+      cartesianPositions.set(cartesian, index);
+    }
+    return {positions: cartesianPositions, cartographicOrigin: [0, 0, 0], coordinateSystem};
+  }
+  if (coordinateSystem === 'meter-offsets') {
+    const meterOffsets = new Float32Array(positions.length);
+    const latitudeRadians = (center[1] * Math.PI) / 180;
+    const metersPerLongitudeDegree =
+      (Math.PI / 180) * EARTH_EQUATORIAL_RADIUS * Math.cos(latitudeRadians);
+    const metersPerLatitudeDegree = (Math.PI / 180) * EARTH_EQUATORIAL_RADIUS;
+    for (let index = 0; index < positions.length; index += 3) {
+      meterOffsets[index] = (positions[index] - center[0]) * metersPerLongitudeDegree;
+      meterOffsets[index + 1] = (positions[index + 1] - center[1]) * metersPerLatitudeDegree;
+      meterOffsets[index + 2] = positions[index + 2] - center[2];
+    }
+    return {positions: meterOffsets, cartographicOrigin: [...center], coordinateSystem};
+  }
+  if (coordinateSystem === 'lnglat') {
+    return {
+      positions: Float32Array.from(positions),
+      cartographicOrigin: [0, 0, 0],
+      coordinateSystem
+    };
+  }
+  return {
+    positions: Float32Array.from(positions, (value, index) => value - center[index % 3]),
+    cartographicOrigin: [...center],
+    coordinateSystem: 'lnglat-offsets'
+  };
 }

--- a/modules/i3s/src/i3s-zod-schema.ts
+++ b/modules/i3s/src/i3s-zod-schema.ts
@@ -65,6 +65,24 @@ export const I3SNodePageSchema = z
   .object({nodes: z.array(I3SNodeInPageSchema)})
   .passthrough() satisfies z.ZodType<NodePage>;
 
+/** Zod schema for an I3S Point Cloud node. */
+export const I3SPointCloudNodeSchema = z
+  .object({
+    resourceId: z.union([z.number().int().nonnegative(), z.string().min(1)]),
+    obb: I3SObbSchema,
+    vertexCount: z.number().int().nonnegative(),
+    lodThreshold: z.number().finite().nonnegative().optional(),
+    firstChild: z.number().int().nonnegative().optional(),
+    childCount: z.number().int().nonnegative().optional(),
+    geometryResource: z.number().int().nonnegative().optional()
+  })
+  .passthrough();
+
+/** Zod schema for an I3S Point Cloud node-page document. */
+export const I3SPointCloudNodePageSchema = z
+  .object({nodes: z.array(I3SPointCloudNodeSchema)})
+  .passthrough();
+
 /** Zod schema for the spatial-reference metadata used by an I3S scene layer. */
 export const I3SSpatialReferenceSchema = z
   .object({
@@ -87,7 +105,7 @@ export const I3SSceneLayerSchema = z
   .object({
     id: z.number().int().nonnegative(),
     href: z.string().optional(),
-    layerType: z.enum(['3DObject', 'IntegratedMesh']),
+    layerType: z.enum(['3DObject', 'IntegratedMesh', 'PointCloud']),
     spatialReference: I3SSpatialReferenceSchema.optional(),
     version: z.string().min(1),
     name: z.string().optional(),
@@ -104,7 +122,10 @@ export const I3SSceneLayerSchema = z
       .object({
         nodesPerPage: z.number().int().positive().max(4096),
         rootIndex: z.number().int().nonnegative().optional(),
-        lodSelectionMetricType: z.literal('maxScreenThresholdSQ')
+        lodSelectionMetricType: z.union([
+          z.literal('maxScreenThresholdSQ'),
+          z.literal('density-threshold')
+        ])
       })
       .passthrough()
       .optional()

--- a/modules/i3s/src/index.ts
+++ b/modules/i3s/src/index.ts
@@ -38,6 +38,13 @@ export type {
   OperationalLayer,
   TextureSetDefinitionFormats
 } from './types';
+export type {
+  I3SPointCloudAttributeInfo,
+  I3SPointCloudNode,
+  I3SPointCloudNodePage,
+  PointCloudDefaultGeometrySchema,
+  Store
+} from './types';
 export type {I3SLoaderOptions} from './i3s-loader';
 
 export {COORDINATE_SYSTEM} from './lib/parsers/constants';
@@ -74,3 +81,5 @@ export {
   type I3SLEPCCDecodedValue,
   type I3SLEPCCDecoderOptions
 } from './i3s-lepcc';
+export {I3SPointCloudSource} from './i3s-point-cloud-source';
+export type {I3SPointCloudSourceOptions} from './i3s-point-cloud-source';

--- a/modules/i3s/src/lib/parsers/parse-slpk/slpk-archieve.ts
+++ b/modules/i3s/src/lib/parsers/parse-slpk/slpk-archieve.ts
@@ -34,7 +34,7 @@ const PATH_DESCRIPTIONS: {test: RegExp; extensions: string[]}[] = [
     extensions: ['.bin.gz', '.draco.gz']
   },
   {
-    test: /nodes\/\d+\/attributes\/f_\d+\/\d+$/,
+    test: /nodes\/\d+\/attributes\/[^/]+\/\d+$/,
     extensions: ['.bin.gz']
   },
   {

--- a/modules/i3s/src/types.ts
+++ b/modules/i3s/src/types.ts
@@ -81,6 +81,13 @@ export type I3SPointCloudAttributeInfo = {
   valueType?: string;
   /** Number of scalar components per point. */
   valueSize?: number;
+  /** Standard uncompressed scalar storage descriptor. */
+  attributeValues?: {
+    /** Scalar value type. */
+    valueType?: string;
+    /** Number of scalar components per point. */
+    valuesPerElement?: number;
+  };
   /** Optional bit-field definitions for flag bytes. */
   values?: Record<string, unknown>;
   /** Additional producer metadata. */

--- a/modules/i3s/src/types.ts
+++ b/modules/i3s/src/types.ts
@@ -40,6 +40,52 @@ export type NodePage = {
   /** Array of nodes. */
   nodes: NodeInPage[];
 };
+
+/** I3S Point Cloud node-page document (I3S 2.0+). */
+export type I3SPointCloudNodePage = {
+  /** Nodes stored in this page. */
+  nodes: I3SPointCloudNode[];
+};
+
+/** A node reference in an I3S Point Cloud hierarchy. */
+export type I3SPointCloudNode = {
+  /** Stable node resource identifier. */
+  resourceId: number | string;
+  /** Node bounding box. */
+  obb: Obb;
+  /** Number of points in this node. */
+  vertexCount: number;
+  /** LOD threshold from the Point Cloud node page. */
+  lodThreshold?: number;
+  /** First child node id in the global node index. */
+  firstChild?: number;
+  /** Number of contiguous child nodes. */
+  childCount?: number;
+  /** Optional geometry resource id. */
+  geometryResource?: number;
+  /** Additional producer metadata. */
+  [key: string]: unknown;
+};
+
+/** Point Cloud attribute storage descriptor. */
+export type I3SPointCloudAttributeInfo = {
+  /** Attribute key used in resource URLs. */
+  key?: string;
+  /** Human-readable or canonical attribute name. */
+  name?: string;
+  /** Encoding name, for example `lepcc-rgb`. */
+  encoding?: string;
+  /** Resource identifier, when not implied by the key. */
+  resource?: number;
+  /** Scalar value type for uncompressed attributes. */
+  valueType?: string;
+  /** Number of scalar components per point. */
+  valueSize?: number;
+  /** Optional bit-field definitions for flag bytes. */
+  values?: Record<string, unknown>;
+  /** Additional producer metadata. */
+  [key: string]: unknown;
+};
 /**
  * Spec - https://github.com/Esri/i3s-spec/blob/master/docs/1.8/mesh.cmn.md
  */
@@ -270,7 +316,7 @@ export type SceneLayer3D = {
   /** The relative URL to the 3DSceneLayerResource. Only present as part of the SceneServiceInfo resource. */
   href?: string;
   /** The user-visible layer type */
-  layerType: '3DObject' | 'IntegratedMesh';
+  layerType: '3DObject' | 'IntegratedMesh' | 'PointCloud';
   /** The spatialReference of the layer including the vertical coordinate reference system (CRS). Well Known Text (WKT) for CRS is included to support custom CRS. */
   spatialReference?: SpatialReference;
   /** Enables consuming clients to quickly determine whether this layer is compatible (with respect to its horizontal and vertical coordinate system) with existing content. */
@@ -360,7 +406,7 @@ export type NodePageDefinition = {
   /** Index of the root node. Default = 0. */
   rootIndex?: number;
   /** Defines the meaning of nodes[].lodThreshold for this layer. */
-  lodSelectionMetricType: 'maxScreenThresholdSQ';
+  lodSelectionMetricType: 'maxScreenThresholdSQ' | 'density-threshold';
 };
 /** Spec - https://github.com/Esri/i3s-spec/blob/master/docs/1.8/materialDefinitions.cmn.md */
 export type I3SMaterialDefinition = {
@@ -775,7 +821,7 @@ type Domain = {
 /**
  * spec - https://github.com/Esri/i3s-spec/blob/master/docs/1.8/store.cmn.md
  */
-type Store = {
+export type Store = {
   id?: string | number;
   profile: string;
   version: number | string;
@@ -809,6 +855,22 @@ type DefaultGeometrySchema = {
   featureAttributes: FeatureAttribute;
   // TODO Do we realy need this Property?
   attributesOrder?: string[];
+};
+
+/** Default geometry schema used by I3S Point Cloud stores. */
+export type PointCloudDefaultGeometrySchema = {
+  /** Point primitives are encoded as a LEPCC XYZ resource. */
+  geometryType: 'points';
+  /** Point cloud topology. */
+  topology?: 'PerAttributeArray';
+  /** Header fields for point count and optional producer metadata. */
+  header?: HeaderAttribute[];
+  /** Attribute ordering in the binary resources. */
+  ordering?: string[];
+  /** Point cloud geometry encoding, normally `lepcc-xyz`. */
+  encoding?: string;
+  /** Additional producer metadata. */
+  [key: string]: unknown;
 };
 /**
  * spec - https://github.com/Esri/i3s-spec/blob/master/docs/1.8/headerAttribute.cmn.md

--- a/modules/i3s/src/unbundled.ts
+++ b/modules/i3s/src/unbundled.ts
@@ -18,3 +18,5 @@ export {
   type I3SLEPCCDecodedValue,
   type I3SLEPCCDecoderOptions
 } from './i3s-lepcc';
+export {I3SPointCloudSource} from './i3s-point-cloud-source';
+export type {I3SPointCloudSourceOptions} from './i3s-point-cloud-source';

--- a/modules/i3s/test/i3s-point-cloud-source.browser.spec.ts
+++ b/modules/i3s/test/i3s-point-cloud-source.browser.spec.ts
@@ -1,0 +1,82 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
+import {fetchFile} from '@loaders.gl/core';
+import {I3SPointCloudSource} from '@loaders.gl/i3s';
+import {expect, test} from 'vitest';
+
+const XYZ_FIXTURE = '@loaders.gl/i3s/test/data/point-cloud/SMALL_AUTZEN_LAS_All.pccxyz';
+const INTENSITY_FIXTURE = '@loaders.gl/i3s/test/data/point-cloud/SMALL_AUTZEN_LAS_All.pccint';
+
+test('I3SPointCloudSource traverses node pages and decodes content', async () => {
+  const [xyzResponse, intensityResponse] = await Promise.all([
+    fetchFile(XYZ_FIXTURE),
+    fetchFile(INTENSITY_FIXTURE)
+  ]);
+  const resources = new Map<string, ArrayBuffer>([
+    [
+      'https://example.com/layer',
+      new TextEncoder().encode(
+        JSON.stringify({
+          id: 1,
+          layerType: 'PointCloud',
+          version: '2.1',
+          capabilities: [],
+          disablePopup: false,
+          store: {
+            profile: 'pointcloud',
+            version: '2.1',
+            defaultGeometrySchema: {geometryType: 'points', encoding: 'lepcc-xyz'}
+          },
+          nodePages: {nodesPerPage: 2, rootIndex: 0, lodSelectionMetricType: 'density-threshold'},
+          attributeInfo: [
+            {key: 'intensity', name: 'intensity', encoding: 'lepcc-intensity', resource: 0}
+          ]
+        })
+      ).buffer
+    ],
+    [
+      'https://example.com/layer/nodepages/0',
+      new TextEncoder().encode(
+        JSON.stringify({
+          nodes: [
+            {
+              resourceId: 0,
+              obb: {center: [0, 0, 0], halfSize: [10, 10, 10], quaternion: [0, 0, 0, 1]},
+              vertexCount: 106,
+              firstChild: 1,
+              childCount: 1,
+              lodThreshold: 1
+            },
+            {
+              resourceId: 1,
+              obb: {center: [1, 1, 1], halfSize: [1, 1, 1], quaternion: [0, 0, 0, 1]},
+              vertexCount: 106
+            }
+          ]
+        })
+      ).buffer
+    ],
+    ['https://example.com/layer/nodes/0/geometries/0', await xyzResponse.arrayBuffer()],
+    [
+      'https://example.com/layer/nodes/0/attributes/intensity/0',
+      await intensityResponse.arrayBuffer()
+    ]
+  ]);
+
+  const source = new I3SPointCloudSource('https://example.com/layer', {
+    core: {loadOptions: {core: {fetch: async (url: string) => new Response(resources.get(url))}}}
+  });
+  const root = await source.getRootTile();
+  expect(root.id).toBe('0');
+  expect(root.lodSelectionMetricType).toBe('density-threshold');
+  expect((await source.getChildren(root)).map(tile => tile.id)).toEqual(['1']);
+  const content = await source.loadTileContent(root);
+  expect(content?.pointCount).toBe(106);
+  expect(content?.data.topology).toBe('point-list');
+  expect(content?.data.data.schema.fields.map(field => field.name)).toEqual([
+    'POSITION',
+    'intensity'
+  ]);
+});

--- a/modules/i3s/test/i3s-point-cloud-source.browser.spec.ts
+++ b/modules/i3s/test/i3s-point-cloud-source.browser.spec.ts
@@ -27,11 +27,18 @@ test('I3SPointCloudSource traverses node pages and decodes content', async () =>
           store: {
             profile: 'pointcloud',
             version: '2.1',
+            index: {nodePerIndexBlock: 2},
             defaultGeometrySchema: {geometryType: 'points', encoding: 'lepcc-xyz'}
           },
-          nodePages: {nodesPerPage: 2, rootIndex: 0, lodSelectionMetricType: 'density-threshold'},
-          attributeInfo: [
-            {key: 'intensity', name: 'intensity', encoding: 'lepcc-intensity', resource: 0}
+          nodePages: {rootIndex: 0, lodSelectionMetricType: 'density-threshold'},
+          attributeStorageInfo: [
+            {key: 'intensity', name: 'intensity', encoding: 'lepcc-intensity', resource: 0},
+            {
+              key: 'classification',
+              name: 'classification',
+              resource: 0,
+              attributeValues: {valueType: 'UInt16', valuesPerElement: 1}
+            }
           ]
         })
       ).buffer
@@ -62,21 +69,43 @@ test('I3SPointCloudSource traverses node pages and decodes content', async () =>
     [
       'https://example.com/layer/nodes/0/attributes/intensity/0',
       await intensityResponse.arrayBuffer()
+    ],
+    [
+      'https://example.com/layer/nodes/0/attributes/classification/0',
+      Uint16Array.from({length: 106}, () => 7).buffer
     ]
   ]);
 
+  const fetchResource = async (url: string) => new Response(resources.get(url));
   const source = new I3SPointCloudSource('https://example.com/layer', {
-    core: {loadOptions: {core: {fetch: async (url: string) => new Response(resources.get(url))}}}
+    core: {loadOptions: {core: {fetch: fetchResource}}}
   });
   const root = await source.getRootTile();
   expect(root.id).toBe('0');
   expect(root.lodSelectionMetricType).toBe('density-threshold');
+  expect(root.boundingVolume.cartographicBounds[1][0]).toBeLessThan(0.001);
   expect((await source.getChildren(root)).map(tile => tile.id)).toEqual(['1']);
   const content = await source.loadTileContent(root);
   expect(content?.pointCount).toBe(106);
   expect(content?.data.topology).toBe('point-list');
   expect(content?.data.data.schema.fields.map(field => field.name)).toEqual([
     'POSITION',
-    'intensity'
+    'intensity',
+    'classification'
   ]);
+  expect(content?.coordinateSystem).toBe('lnglat-offsets');
+  expect(content?.data.data.getChild('classification')?.get(0)).toBe(7);
+
+  const cartesianSource = new I3SPointCloudSource('https://example.com/layer', {
+    i3s: {coordinateSystem: 'cartesian'},
+    core: {loadOptions: {core: {fetch: fetchResource}}}
+  });
+  const cartesianRoot = await cartesianSource.getRootTile();
+  (cartesianSource as any).decoder.decodeXyz = () => new Float64Array(106 * 3);
+  const cartesianContent = await cartesianSource.loadTileContent(cartesianRoot);
+  const firstPosition = cartesianContent?.data.data.getChild('POSITION')?.get(0) as
+    | Iterable<number>
+    | undefined;
+  expect(cartesianContent?.coordinateSystem).toBe('cartesian');
+  expect(firstPosition ? Array.from(firstPosition)[0] : 0).toBeGreaterThan(6_000_000);
 });

--- a/modules/tiles/src/index.ts
+++ b/modules/tiles/src/index.ts
@@ -93,7 +93,8 @@ export type {
   PointCloudTileContent,
   PointCloudTileHeader,
   PointCloudTilesetSource,
-  PointCloudTilesetViewState
+  PointCloudTilesetViewState,
+  PointCloudCoordinateSystem
 } from './point-cloud/types';
 export type {PointCloudTilesetOptions} from './point-cloud/point-cloud-tileset';
 export {PointCloudTileset} from './point-cloud/point-cloud-tileset';

--- a/modules/tiles/src/point-cloud/point-cloud-tileset.ts
+++ b/modules/tiles/src/point-cloud/point-cloud-tileset.ts
@@ -322,7 +322,7 @@ export class PointCloudTileset {
       const projectedArea = Math.max(1, Math.PI * traversalWeight * traversalWeight);
       const density = tile.pointCount / projectedArea;
       const threshold = tile.header.lodThreshold || this.options.densityThreshold;
-      return density >= threshold;
+      return density < threshold;
     }
     return (
       tile.level < this.options.maxDepth &&

--- a/modules/tiles/src/point-cloud/point-cloud-tileset.ts
+++ b/modules/tiles/src/point-cloud/point-cloud-tileset.ts
@@ -16,6 +16,10 @@ export type PointCloudTilesetOptions = {
   debounceTime?: number;
   minimumNodePixelSize?: number;
   maximumScreenSpaceError?: number;
+  /** Override source LOD metric for point-cloud traversal. */
+  lodSelectionMetricType?: 'maxScreenThresholdSQ' | 'density-threshold';
+  /** Minimum projected point density at which a node is refined. */
+  densityThreshold?: number;
   pointBudget?: number;
   maxDepth?: number;
   onTileLoad?: (tile: PointCloudTile) => void;
@@ -30,6 +34,8 @@ const DEFAULT_PROPS: PointCloudTilesetProps = {
   debounceTime: 0,
   minimumNodePixelSize: 150,
   maximumScreenSpaceError: 1,
+  lodSelectionMetricType: 'maxScreenThresholdSQ',
+  densityThreshold: 1,
   pointBudget: 2_000_000,
   maxDepth: Number.POSITIVE_INFINITY,
   onTileLoad: () => {},
@@ -307,6 +313,17 @@ export class PointCloudTileset {
 
   /** Whether a tile should refine to children based on its projected screen radius. */
   private shouldRefine(tile: PointCloudTile, traversalWeight: number): boolean {
+    if (
+      tile.level < this.options.maxDepth &&
+      Number.isFinite(traversalWeight) &&
+      (tile.header.lodSelectionMetricType || this.options.lodSelectionMetricType) ===
+        'density-threshold'
+    ) {
+      const projectedArea = Math.max(1, Math.PI * traversalWeight * traversalWeight);
+      const density = tile.pointCount / projectedArea;
+      const threshold = tile.header.lodThreshold || this.options.densityThreshold;
+      return density >= threshold;
+    }
     return (
       tile.level < this.options.maxDepth &&
       Number.isFinite(traversalWeight) &&

--- a/modules/tiles/src/point-cloud/types.ts
+++ b/modules/tiles/src/point-cloud/types.ts
@@ -54,6 +54,10 @@ export type PointCloudTileHeader = {
   pointCount: number;
   geometricError: number;
   boundingVolume: PointCloudBoundingVolume;
+  /** I3S LOD metric used to decide whether this node refines. */
+  lodSelectionMetricType?: 'maxScreenThresholdSQ' | 'density-threshold';
+  /** Source-provided LOD threshold for density or screen metrics. */
+  lodThreshold?: number;
 };
 
 /**

--- a/modules/tiles/test/point-cloud/point-cloud-tileset.spec.ts
+++ b/modules/tiles/test/point-cloud/point-cloud-tileset.spec.ts
@@ -239,6 +239,21 @@ test('PointCloudTileset#selectTiles keeps coarse tiles when zoomed out', async t
   t.end();
 });
 
+test('PointCloudTileset#density refinement increases as projected density falls', t => {
+  const source = new TestPointCloudSource();
+  const tileset = new PointCloudTileset(source as any);
+  const tile = {
+    level: 0,
+    pointCount: 100,
+    header: {lodSelectionMetricType: 'density-threshold', lodThreshold: 1}
+  };
+  const shouldRefine = (tileset as any).shouldRefine.bind(tileset);
+
+  t.equal(shouldRefine(tile, 100), true, 'a large nearby footprint refines when density is low');
+  t.equal(shouldRefine(tile, 1), false, 'a compact distant footprint remains coarse');
+  t.end();
+});
+
 test('PointCloudTileset#selectTiles respects point budget', async t => {
   const source = new TestPointCloudSource();
   const tileset = new PointCloudTileset(source as any, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5435,6 +5435,7 @@ __metadata:
     "@loaders.gl/images": "npm:5.0.0-alpha.2"
     "@loaders.gl/loader-utils": "npm:5.0.0-alpha.2"
     "@loaders.gl/schema": "npm:5.0.0-alpha.2"
+    "@loaders.gl/schema-utils": "npm:5.0.0-alpha.2"
     "@loaders.gl/textures": "npm:5.0.0-alpha.2"
     "@loaders.gl/tiles": "npm:5.0.0-alpha.2"
     "@loaders.gl/zip": "npm:5.0.0-alpha.2"


### PR DESCRIPTION
Goals

- Implement I3S Point Cloud tranches 5a–5g in one integrated, testable source path.
- Keep the existing mesh-oriented I3S loader contract compatible while adding a Point Cloud source for applications and PointCloudTileset.

Changes

- Add Point Cloud scene/node-page types and Zod schemas for I3S 2.x metadata.
- Add I3SPointCloudSource for REST SceneServer layers and indexed SLPK archives.
- Decode LEPCC XYZ, RGB, intensity, and flag-byte resources with checksum and point-count validation; map standard and metadata-described attributes to point-list Arrow tables.
- Add density-threshold refinement to PointCloudTileset and expose LOD metadata.
- Improve SLPK attribute path matching for Point Cloud keys.
- Export the source and options from bundled/unbundled I3S entry points.
- Update the I3S format matrix, 5a–5g roadmap, API docs, and deterministic source fixture.

Validation

- yarn build-modules
- yarn build-workers
- yarn test-node (360 passed, 6 skipped)
- yarn test-headless (3039 passed, 40 skipped)
- yarn lint fix