### PR TITLE
test: migrate all remaining suites to Vitest

### DIFF
--- a/modules/bson/test/bson-loader.spec.ts
+++ b/modules/bson/test/bson-loader.spec.ts
@@ -1,48 +1,21 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {load} from '@loaders.gl/core';
 import {BSONLoader} from '@loaders.gl/bson';
 // import corruptScenarios from './data/js-bson/corrupt';
-
 const TAGS_BSON_URL = '@loaders.gl/bson/test/data/js-bson/mongodump.airpair.tags.bson';
 const MINI_BSON_URL = '@loaders.gl/bson/test/data/js-bson/test.bson';
-
-test('BSONLoader#load(test.bson)', async t => {
+test('BSONLoader#load(test.bson)', async () => {
   const data = await load(MINI_BSON_URL, BSONLoader);
   // t.comment(JSON.stringify(data));
-  t.ok(data, 'Data received');
-  t.end();
+  expect(data, 'Data received').toBeTruthy();
 });
-
-test('BSONLoader#load(mongodump.airpair.tags.bson)', async t => {
-  await t.rejects(
-    load(TAGS_BSON_URL, BSONLoader),
+test('BSONLoader#load(mongodump.airpair.tags.bson)', async () => {
+  await expect(load(TAGS_BSON_URL, BSONLoader)).rejects.toThrow(
     /detected a concatenated BSON dump with 50 documents/
   );
-  t.end();
 });
-
-test('BSONLoader#load(mongodump.airpair.tags.bson, concatenatedDocuments=first)', async t => {
+test('BSONLoader#load(mongodump.airpair.tags.bson, concatenatedDocuments=first)', async () => {
   const data = await load(TAGS_BSON_URL, BSONLoader, {bson: {concatenatedDocuments: 'first'}});
-  t.equal(data._id.toString(), '514825fa2a26ea0200000006');
-  t.ok(String(data.desc).includes('Android'), 'loads first document contents');
-  t.end();
+  expect(data._id.toString()).toBe('514825fa2a26ea0200000006');
+  expect(String(data.desc).includes('Android'), 'loads first document contents').toBeTruthy();
 });
-
-// TODO - skip because of Node.js Bbuffer dependency
-// test('BSON Compliance - corrupt scenarios', async (t) => {
-//   for (let i = 0; i < corruptScenarios.documents.length; i++) {
-//     const doc = corruptScenarios.documents[i];
-//     if (!doc.skip) {
-//       // Create a buffer containing the payload
-//       const buffer = Buffer.from(doc.encoded, 'hex');
-//       // Attempt to deserialize
-//       t.throws(() => parseSync(buffer, BSONLoader), `Throws ${doc.error}`);
-//     }
-//   }
-
-//   t.end();
-// });

--- a/modules/compression/test/bzip2-xz-compression.spec.ts
+++ b/modules/compression/test/bzip2-xz-compression.spec.ts
@@ -1,28 +1,18 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {BZip2Compression} from '@loaders.gl/compression/bzip2-compression';
 import {XZCompression} from '@loaders.gl/compression/xz-compression';
-
 const EXPECTED = 'compact codec test\n';
 const BZIP2_DATA = 'QlpoOTFBWSZTWSiDZ48AAANRgAAQQAAuAswAIAAxANNNBANGRzWtAxEyWR6l4u5IpwoSBRBs8eA=';
 const XZ_DATA =
   '/Td6WFoAAATm1rRGBMAXEyEBFgAAAAAAAAAAAFRp7t4BABJjb21wYWN0IGNvZGVjIHRlc3QKAADq+49W0BUVDQABMxPFkVNQH7bzfQEAAAAABFla';
-
-test('BZip2Compression#decompress', async t => {
+test('BZip2Compression#decompress', async () => {
   const output = await new BZip2Compression().decompress(decode(BZIP2_DATA));
-  t.equal(new TextDecoder().decode(output), EXPECTED);
-  t.end();
+  expect(new TextDecoder().decode(output)).toBe(EXPECTED);
 });
-
-test('XZCompression#decompress', async t => {
+test('XZCompression#decompress', async () => {
   const output = await new XZCompression().decompress(decode(XZ_DATA));
-  t.equal(new TextDecoder().decode(output), EXPECTED);
-  t.end();
+  expect(new TextDecoder().decode(output)).toBe(EXPECTED);
 });
-
 function decode(value: string): ArrayBuffer {
   const bytes = Uint8Array.from(atob(value), character => character.charCodeAt(0));
   return bytes.buffer;

--- a/modules/compression/test/compression.spec.ts
+++ b/modules/compression/test/compression.spec.ts
@@ -1,9 +1,4 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-/** @typedef {import('@loaders.gl/compression').Compression} Compression */
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {NoCompression} from '@loaders.gl/compression/no-compression';
 import {GZipCompression} from '@loaders.gl/compression/gzip-compression';
 import {DeflateCompression} from '@loaders.gl/compression/deflate-compression';
@@ -26,15 +21,12 @@ import {
   supportsNativeDecompressionStream,
   type NativeDecompressionTestFormat
 } from './utils/native-decompression-test-utils';
-
 // Import big dependencies
-
 // import brotli from 'brotli'; - brotli has problems with decompress in browsers
 import brotliDecompress from 'brotli/decompress';
 import lz4js from 'lz4js';
 // import lzo from 'lzo';
 import {ZstdCodec} from 'zstd-codec';
-
 // Inject large dependencies through Compression constructor options
 const modules = {
   // brotli has problems with decompress in browsers
@@ -48,9 +40,7 @@ const modules = {
   // lzo,
   'zstd-codec': ZstdCodec
 };
-
 const TEST_DATA = getData();
-
 const TEST_CASES = [
   {
     title: 'binary',
@@ -81,7 +71,6 @@ const TEST_CASES = [
     }
   }
 ];
-
 /** @type {Compression[]} */
 const COMPRESSIONS = [
   new NoCompression({modules}),
@@ -93,12 +82,10 @@ const COMPRESSIONS = [
   new SnappyCompression({modules}),
   new ZstdCompression({modules})
 ];
-
 if (!isBrowser) {
   COMPRESSIONS.push();
 }
-
-test('compression#atomic', async t => {
+test('compression#atomic', async () => {
   for (const compression of COMPRESSIONS) {
     // brotli compress import issue
     if (!compression.isSupported || compression.name === 'brotli') {
@@ -107,36 +94,29 @@ test('compression#atomic', async t => {
     for (const tc of TEST_CASES) {
       const {title} = tc;
       const {name} = compression;
-      t.comment(`Testing ${name}(${title})`);
+      console.log(`Testing ${name}(${title})`);
       const compressedData = await compression.compress(tc.data);
       const compressedLength = tc.compression?.[compression.name]?.compressedLength;
       if (compressedLength) {
-        t.equal(
-          compressedData.byteLength,
-          compressedLength,
-          `${name}(${title}) compressed length correct`
+        expect(compressedData.byteLength, `${name}(${title}) compressed length correct`).toBe(
+          compressedLength
         );
       }
       const uncompressedData = await compression.decompress(compressedData);
-      t.ok(
+      expect(
         compareArrayBuffers(tc.data, uncompressedData),
         `${name}(${title}) decompressed data equals original`
-      );
+      ).toBeTruthy();
     }
   }
-
-  t.end();
 });
-
 // BATCHED TESTS
-
-test('compression#batched', async t => {
+test('compression#batched', async () => {
   const inputChunks = [
     new Uint8Array([1, 2, 3]).buffer,
     new Uint8Array([4, 5, 6]).buffer,
     new Uint8Array([7, 8, 9]).buffer
   ];
-
   for (const compression of COMPRESSIONS) {
     // brotli compress import issue
     if (!compression.isSupported || compression.name === 'brotli') {
@@ -145,55 +125,44 @@ test('compression#batched', async t => {
     for (const tc of TEST_CASES) {
       const {title} = tc;
       const {name} = compression;
-
       // Test empty batches
       let compressedBatches = compression.compressBatches(inputChunks);
       const compressedData = await concatenateArrayBuffersAsync(compressedBatches);
       if (name === 'gzip') {
-        t.equals(compressedData.byteLength, 29, `${name}(${title}) batches: length correct`); // Header overhead
+        expect(compressedData.byteLength, `${name}(${title}) batches: length correct`).toBe(29); // Header overhead
       }
-
       // test chained iterators
       compressedBatches = compression.compressBatches(inputChunks);
-
       const decompressedBatches = compression.decompressBatches(compressedBatches);
-
       const inputData = concatenateArrayBuffers(...inputChunks);
       const decompressedData = await concatenateArrayBuffersAsync(decompressedBatches);
-
-      t.ok(
+      expect(
         compareArrayBuffers(inputData, decompressedData),
         `${name}(${title}) batches: compress/decompress identical`
-      );
+      ).toBeTruthy();
     }
   }
-  t.end();
 });
-
-test('native decompression#real DecompressionStream formats', async t => {
+test('native decompression#real DecompressionStream formats', async () => {
   for (const format of Object.keys(
     NATIVE_DECOMPRESSION_FIXTURES
   ) as NativeDecompressionTestFormat[]) {
     if (!(await supportsNativeDecompressionStream(format))) {
-      t.comment(`${format} DecompressionStream is not available in this runtime`);
+      console.log(`${format} DecompressionStream is not available in this runtime`);
       continue;
     }
-
     const nativeFormats: NativeDecompressionTestFormat[] = [];
     const restoreDecompressionStream = installRecordingDecompressionStream(nativeFormats);
-
     try {
       const compressedData = new Uint8Array(NATIVE_DECOMPRESSION_FIXTURES[format]).buffer;
-
       const decompressedData = await decompressWithNativeDecompressionStream(
         compressedData,
         format
       );
-      t.ok(
+      expect(
         decompressedData && compareArrayBuffers(NATIVE_DECOMPRESSION_TEST_DATA, decompressedData),
         `native atomic ${format} decompression works`
-      );
-
+      ).toBeTruthy();
       const splitIndex = Math.max(1, Math.floor(compressedData.byteLength / 2));
       const compressedBatches = [
         compressedData.slice(0, splitIndex),
@@ -203,114 +172,91 @@ test('native decompression#real DecompressionStream formats', async t => {
         compressedBatches,
         format
       );
-      t.ok(decompressedBatches, `native batched ${format} stream is created`);
+      expect(decompressedBatches, `native batched ${format} stream is created`).toBeTruthy();
       const decompressedBatchData = await concatenateArrayBuffersAsync(decompressedBatches);
-      t.ok(
+      expect(
         compareArrayBuffers(NATIVE_DECOMPRESSION_TEST_DATA, decompressedBatchData),
         `native batched ${format} decompression works`
-      );
-      t.deepEqual(
+      ).toBeTruthy();
+      expect(
         nativeFormats,
-        [format, format],
         `${format} uses the native stream for atomic and batched decompression`
-      );
+      ).toEqual([format, format]);
     } finally {
       restoreDecompressionStream();
     }
   }
-
-  t.end();
 });
-
-test('native decompression#mocked zstd atomic and batched', async t => {
+test('native decompression#mocked zstd atomic and batched', async () => {
   const formats: string[] = [];
   const restoreDecompressionStream = installMockDecompressionStream({
     formats,
     supportedFormats: ['zstd']
   });
-
   try {
     const inputBatches = [new Uint8Array([1, 2, 3]).buffer, new Uint8Array([4, 5, 6]).buffer];
     const inputData = concatenateArrayBuffers(...inputBatches);
-
     const decompressedData = await decompressWithNativeDecompressionStream(inputData, 'zstd');
-    t.ok(
+    expect(
       decompressedData && compareArrayBuffers(inputData, decompressedData),
       'native atomic zstd needs no codec'
-    );
-
+    ).toBeTruthy();
     const decompressedBatches = decompressBatchesWithNativeDecompressionStream(
       inputBatches,
       'zstd'
     );
-    t.ok(decompressedBatches, 'native batched zstd stream is created');
+    expect(decompressedBatches, 'native batched zstd stream is created').toBeTruthy();
     const decompressedBatchData = await concatenateArrayBuffersAsync(decompressedBatches);
-    t.ok(
+    expect(
       compareArrayBuffers(inputData, decompressedBatchData),
       'native batched zstd needs no codec'
-    );
-    t.deepEqual(formats, ['zstd', 'zstd'], 'zstd maps to the native zstd format');
+    ).toBeTruthy();
+    expect(formats, 'zstd maps to the native zstd format').toEqual(['zstd', 'zstd']);
   } finally {
     restoreDecompressionStream();
   }
-
-  t.end();
 });
-
-test('native decompression#unsupported formats return null', async t => {
+test('native decompression#unsupported formats return null', async () => {
   const formats: string[] = [];
   const restoreDecompressionStream = installMockDecompressionStream({
     formats,
     supportedFormats: []
   });
-
   try {
     const inputData = new Uint8Array([1, 2, 3]).buffer;
-    t.equal(
+    expect(
       await decompressWithNativeDecompressionStream(inputData, 'zstd'),
-      null,
       'atomic unsupported format returns null'
-    );
-    t.equal(
+    ).toBe(null);
+    expect(
       decompressBatchesWithNativeDecompressionStream([inputData], 'zstd'),
-      null,
       'batched unsupported format returns null'
-    );
-    t.deepEqual(formats, ['zstd', 'zstd'], 'both paths probe the requested format');
+    ).toBe(null);
+    expect(formats, 'both paths probe the requested format').toEqual(['zstd', 'zstd']);
   } finally {
     restoreDecompressionStream();
   }
-
-  t.end();
 });
-
-test('native decompression#stream failures propagate', async t => {
+test('native decompression#stream failures propagate', async () => {
   const restoreDecompressionStream = installMockDecompressionStream({
     formats: [],
     supportedFormats: ['zstd'],
     failWith: new Error('mock native decompression failed')
   });
-
   try {
     const inputData = new Uint8Array([1, 2, 3]).buffer;
-    await t.rejects(
+    await expect(
       decompressWithNativeDecompressionStream(inputData, 'zstd'),
-      /mock native decompression failed/,
       'native stream errors propagate'
-    );
+    ).rejects.toThrow(/mock native decompression failed/);
   } finally {
     restoreDecompressionStream();
   }
-
-  t.end();
 });
-
 // WORKER TESTS
-test('gzip#worker', async t => {
+test('gzip#worker', async () => {
   const {binaryData} = getData();
-
-  t.equal(binaryData.byteLength, 100000, 'Length correct');
-
+  expect(binaryData.byteLength, 'Length correct').toBe(100000);
   const compressedData = await processOnWorker(CompressionWorker, binaryData.slice(0), {
     compression: 'gzip',
     operation: 'compress',
@@ -319,9 +265,7 @@ test('gzip#worker', async t => {
       level: 6
     }
   });
-
-  t.equal(compressedData.byteLength, 12819, 'Length correct');
-
+  expect(compressedData.byteLength, 'Length correct').toBe(12819);
   const decompressdData = await processOnWorker(CompressionWorker, compressedData, {
     compression: 'gzip',
     operation: 'decompress',
@@ -330,86 +274,68 @@ test('gzip#worker', async t => {
       level: 6
     }
   });
-
-  t.equal(decompressdData.byteLength, 100000, 'Length correct');
-
-  t.ok(compareArrayBuffers(decompressdData, binaryData), 'compress/decompress level 6');
-
+  expect(decompressdData.byteLength, 'Length correct').toBe(100000);
+  expect(
+    compareArrayBuffers(decompressdData, binaryData),
+    'compress/decompress level 6'
+  ).toBeTruthy();
   if (!isBrowser) {
     const workerFarm = WorkerFarm.getWorkerFarm({});
     workerFarm.destroy();
   }
-
-  t.end();
 });
-
-test('lz4#worker', async t => {
+test('lz4#worker', async () => {
   const {binaryData} = getData();
-
-  t.equal(binaryData.byteLength, 100000, 'Length correct');
-
+  expect(binaryData.byteLength, 'Length correct').toBe(100000);
   const compressedData = await processOnWorker(CompressionWorker, binaryData.slice(0), {
     compression: 'lz4',
     operation: 'compress',
     _workerType: 'test'
   });
-
-  t.equal(compressedData.byteLength, 12331, 'Length correct');
-
+  expect(compressedData.byteLength, 'Length correct').toBe(12331);
   const decompressdData = await processOnWorker(CompressionWorker, compressedData, {
     compression: 'lz4',
     operation: 'decompress',
     _workerType: 'test'
   });
-
-  t.equal(decompressdData.byteLength, 100000, 'Length correct');
-
-  t.ok(compareArrayBuffers(decompressdData, binaryData), 'compress/decompress level 6');
-
+  expect(decompressdData.byteLength, 'Length correct').toBe(100000);
+  expect(
+    compareArrayBuffers(decompressdData, binaryData),
+    'compress/decompress level 6'
+  ).toBeTruthy();
   if (!isBrowser) {
     const workerFarm = WorkerFarm.getWorkerFarm({});
     workerFarm.destroy();
   }
-
-  t.end();
 });
-
-test.skip('zstd#worker', async t => {
+test.skip('zstd#worker', async () => {
   if (!isBrowser) {
-    t.end();
     return;
   }
-
   const {binaryData} = getData();
-
-  t.equal(binaryData.byteLength, 100000, 'Length correct');
-
+  expect(binaryData.byteLength, 'Length correct').toBe(100000);
   const compressedData = await processOnWorker(CompressionWorker, binaryData.slice(0), {
     compression: 'zstd',
     operation: 'compress',
     _workerType: 'test'
   });
-
-  t.equal(compressedData.byteLength, 11936, 'Length correct');
-
+  expect(compressedData.byteLength, 'Length correct').toBe(11936);
   const decompressdData = await processOnWorker(CompressionWorker, compressedData, {
     compression: 'zstd',
     operation: 'decompress',
     _workerType: 'test'
   });
-
-  t.equal(decompressdData.byteLength, 100000, 'Length correct');
-
-  t.ok(compareArrayBuffers(decompressdData, binaryData), 'compress/decompress level 6');
-  t.end();
+  expect(decompressdData.byteLength, 'Length correct').toBe(100000);
+  expect(
+    compareArrayBuffers(decompressdData, binaryData),
+    'compress/decompress level 6'
+  ).toBeTruthy();
 });
-
 type MockDecompressionStreamOptions = {
   formats: string[];
   supportedFormats: string[];
   failWith?: Error;
 };
-
 /**
  * Installs a deterministic DecompressionStream double and returns a restorer.
  *
@@ -418,18 +344,15 @@ type MockDecompressionStreamOptions = {
  */
 function installMockDecompressionStream(options: MockDecompressionStreamOptions): () => void {
   const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'DecompressionStream');
-
   class MockDecompressionStream {
     readonly readable: ReadableStream<Uint8Array>;
     readonly writable: WritableStream<BufferSource>;
-
     /** Creates a mock native decompression stream for supported formats. */
     constructor(format: string) {
       options.formats.push(format);
       if (!options.supportedFormats.includes(format)) {
         throw new TypeError('mock compression format is unsupported');
       }
-
       const transformStream = new TransformStream<BufferSource, Uint8Array>({
         transform(chunk, controller) {
           if (options.failWith) {
@@ -442,13 +365,11 @@ function installMockDecompressionStream(options: MockDecompressionStreamOptions)
       this.writable = transformStream.writable;
     }
   }
-
   Object.defineProperty(globalThis, 'DecompressionStream', {
     configurable: true,
     writable: true,
     value: MockDecompressionStream
   });
-
   return () => {
     if (originalDescriptor) {
       Object.defineProperty(globalThis, 'DecompressionStream', originalDescriptor);
@@ -457,7 +378,6 @@ function installMockDecompressionStream(options: MockDecompressionStreamOptions)
     }
   };
 }
-
 /**
  * Copies a native stream input chunk into a Uint8Array.
  *

--- a/modules/crypto/test/crypto-worker.spec.ts
+++ b/modules/crypto/test/crypto-worker.spec.ts
@@ -1,78 +1,51 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {processOnWorker, isBrowser, WorkerFarm} from '@loaders.gl/worker-utils';
 import {CryptoWorker, CryptoJSWorker} from '@loaders.gl/crypto';
 import {getBinaryData} from './test-utils/test-utils';
-
-test('CryptoWorker', async t => {
+test('CryptoWorker', async () => {
   const {binaryData} = getBinaryData();
-
-  t.equal(binaryData.byteLength, 100000, 'Length correct');
-
+  expect(binaryData.byteLength, 'Length correct').toBe(100000);
   let hash = await processOnWorker(CryptoWorker, binaryData.slice(0), {
     operation: 'crc32',
     _workerType: 'test'
   });
-
-  t.equal(hash, 'khuskQ==', 'CRC32 Hash correct');
-
+  expect(hash, 'CRC32 Hash correct').toBe('khuskQ==');
   hash = await processOnWorker(CryptoWorker, binaryData.slice(0), {
     operation: 'crc32c',
     workerLocation: 'test'
   });
-
-  t.equal(hash, 'PDGE8A==', 'CRC32c Hash correct');
-
+  expect(hash, 'CRC32c Hash correct').toBe('PDGE8A==');
   hash = await processOnWorker(CryptoWorker, binaryData.slice(0), {
     operation: 'md5',
     _workerType: 'test'
   });
-
-  t.equal(hash, 'YnxTb+lyen1CsNkpmLv+qA==', 'MD5 Hash correct');
-
+  expect(hash, 'MD5 Hash correct').toBe('YnxTb+lyen1CsNkpmLv+qA==');
   // Destroy all workers in NodeJS
   if (!isBrowser) {
     const workerFarm = WorkerFarm.getWorkerFarm({});
     workerFarm.destroy();
   }
-
-  t.end();
 });
-
 // CryptoJSWorker is disabled
-test.skip('CryptoJSWorker', async t => {
+test.skip('CryptoJSWorker', async () => {
   if (!isBrowser) {
-    t.end();
     return;
   }
-
   const {binaryData} = getBinaryData();
-
-  t.equal(binaryData.byteLength, 100000, 'Length correct');
-
+  expect(binaryData.byteLength, 'Length correct').toBe(100000);
   let hash = await processOnWorker(CryptoJSWorker, binaryData.slice(0), {
     operation: 'crc32',
     _workerType: 'test'
   });
-
-  t.equal(hash, 'beRTbw==', 'CRC32 Hash correct');
-
+  expect(hash, 'CRC32 Hash correct').toBe('beRTbw==');
   hash = await processOnWorker(CryptoJSWorker, binaryData.slice(0), {
     operation: 'crc32c',
     _workerType: 'test'
   });
-
-  t.equal(hash, '==', 'CRC32c Hash correct');
-
+  expect(hash, 'CRC32c Hash correct').toBe('==');
   hash = await processOnWorker(CryptoJSWorker, binaryData.slice(0), {
     operation: 'md5',
     _workerType: 'test'
   });
-
-  t.equal(hash, '==', 'CRC32c Hash correct');
-
-  t.end();
+  expect(hash, 'CRC32c Hash correct').toBe('==');
 });

--- a/modules/crypto/test/crypto.spec.ts
+++ b/modules/crypto/test/crypto.spec.ts
@@ -1,18 +1,10 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {fetchFile, loadInBatches, NullLoader, isBrowser} from '@loaders.gl/core';
 import {CRC32Hash, CRC32CHash, MD5Hash, SHA256Hash, NodeHash} from '@loaders.gl/crypto';
 import {getBinaryData} from './test-utils/test-utils';
-
 import CryptoJS from 'crypto-js';
-
 const modules = {CryptoJS};
-
 const {binaryData, repeatedData} = getBinaryData();
-
 const TEST_CASES = [
   {
     title: 'streaming CSV',
@@ -46,34 +38,26 @@ const TEST_CASES = [
     }
   }
 ];
-
 const HASHES = [new CRC32Hash(), new CRC32CHash(), new MD5Hash(), new SHA256Hash({modules})];
-
-test('crypto#atomic hashes', async t => {
+test('crypto#atomic hashes', async () => {
   await loadTestCaseData();
-
   for (const tc of TEST_CASES) {
     // test each test case against all precomputed digests/hashes
     for (const algorithm in tc.digests) {
       const cryptoHash = getHash(algorithm);
-
       const hash = await cryptoHash.hash(tc.data, 'base64');
       const expectedHash = tc.digests[algorithm];
-      t.equal(hash, expectedHash, `${algorithm} hash is correct for ${tc.title}`);
+      expect(hash, `${algorithm} hash is correct for ${tc.title}`).toBe(expectedHash);
     }
   }
-
-  t.end();
 });
-
-test('crypto#streaming hashes', async t => {
+test('crypto#streaming hashes', async () => {
   for (const tc of TEST_CASES) {
     // test each test case against all precomputed digests/hashes
     for (const algorithm in tc.digests) {
       if (tc.url) {
         const cryptoHash1 = getHash(algorithm);
         const Hash = cryptoHash1.constructor;
-
         let hash;
         // @ts-expect-error
         const cryptoHash = new Hash({
@@ -83,50 +67,33 @@ test('crypto#streaming hashes', async t => {
             }
           }
         });
-
         const nullIterator = await loadInBatches(tc.url, NullLoader, {
           transforms: [cryptoHash.hashBatches]
         });
-
         // @ts-ignore
         // eslint-disable-next-line no-unused-vars, no-empty, max-depth, @typescript-eslint/no-unused-vars
         for await (const _batch of nullIterator) {
         }
-
-        t.equal(hash, tc.digests[algorithm], `${algorithm} hash is correct for ${tc.title}`);
+        expect(hash, `${algorithm} hash is correct for ${tc.title}`).toBe(tc.digests[algorithm]);
       }
     }
   }
-
-  t.end();
 });
-
 // EXTRA TESTS NOT COVERED BY TEST CASES
-
-test('NodeHash#hash', async t => {
+test('NodeHash#hash', async () => {
   if (!isBrowser) {
     const cryptoHash = new NodeHash({crypto: {algorithm: 'SHA256'}});
-
     let hash = await cryptoHash.hash(binaryData, 'base64');
-    t.equal(
-      hash,
-      'gsoMi29gqdIBCEdTdRJW8VPFx5PQyFPTF4Lv7TJ4eQw=',
-      'binary data SHA256 hash is correct'
+    expect(hash, 'binary data SHA256 hash is correct').toBe(
+      'gsoMi29gqdIBCEdTdRJW8VPFx5PQyFPTF4Lv7TJ4eQw='
     );
-
     hash = await cryptoHash.hash(repeatedData, 'base64');
-    t.equal(
-      hash,
-      'bSCTuOJei5XsmAnqtmm2Aw/2EvUHldNdAxYb3mjSK9s=',
-      'repeated data SHA256 hash is correct'
+    expect(hash, 'repeated data SHA256 hash is correct').toBe(
+      'bSCTuOJei5XsmAnqtmm2Aw/2EvUHldNdAxYb3mjSK9s='
     );
   }
-
-  t.end();
 });
-
 // HELPERS
-
 function getHash(algorithm) {
   const hash = HASHES.find(hash_ => hash_.name === algorithm);
   if (!hash) {
@@ -134,7 +101,6 @@ function getHash(algorithm) {
   }
   return hash;
 }
-
 async function loadTestCaseData() {
   for (const tc of TEST_CASES) {
     if (tc.url) {

--- a/modules/crypto/test/lib/crypto-hash.spec.ts
+++ b/modules/crypto/test/lib/crypto-hash.spec.ts
@@ -1,37 +1,24 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-/** eslint-disable @typescript-eslint/unbound-method */
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {compareArrayBuffers, getBinaryData} from '../test-utils/test-utils';
 import {concatenateArrayBuffers, concatenateArrayBuffersAsync} from '@loaders.gl/loader-utils';
 import {fetchFile, loadInBatches} from '@loaders.gl/core';
 import {CSVLoader} from '@loaders.gl/csv';
 import {CryptoHash} from '@loaders.gl/crypto';
 import CryptoJS from 'crypto-js';
-
 const CSV_URL = '@loaders.gl/csv/test/data/sample-very-long.csv';
 /** Externally computed hash: `openssl md5 -binary sample-very-long.json | openssl base64` */
 const CSV_MD5 = 'zmLuuVSkigYR9r5FcsKkCw==';
-
-test('CryptoHash#hash(CSV, against external hash)', async t => {
+test('CryptoHash#hash(CSV, against external hash)', async () => {
   const response = await fetchFile(CSV_URL);
   const data = await response.arrayBuffer();
-
   const hash = await new CryptoHash({modules: {CryptoJS}, crypto: {algorithm: 'MD5'}}).hash(
     data,
     'base64'
   );
-  t.equal(hash, CSV_MD5, 'repeated data MD5 hash is correct');
-
-  t.end();
+  expect(hash, 'repeated data MD5 hash is correct').toBe(CSV_MD5);
 });
-
-test('CryptoHash#iterator(CSV stream, against external hash)', async t => {
+test('CryptoHash#iterator(CSV stream, against external hash)', async () => {
   let hash;
-
   const cryptoHash = new CryptoHash({
     modules: {CryptoJS},
     crypto: {
@@ -41,49 +28,34 @@ test('CryptoHash#iterator(CSV stream, against external hash)', async t => {
       }
     }
   });
-
   const csvIterator = await loadInBatches(CSV_URL, CSVLoader, {
     transforms: [cryptoHash.hashBatches.bind(cryptoHash)]
   });
-
   let csv;
   for await (const batch of csvIterator) {
     csv = batch;
   }
-  t.ok(Array.isArray(csv?.data), 'parsing from wrapped iterator works');
-
-  t.equal(hash, CSV_MD5, 'streaming MD5 hash is correct');
-
-  t.end();
+  expect(Array.isArray(csv?.data), 'parsing from wrapped iterator works').toBeTruthy();
+  expect(hash, 'streaming MD5 hash is correct').toBe(CSV_MD5);
 });
-
-test('CryptoHash#hash(MD5 = default)', async t => {
+test('CryptoHash#hash(MD5 = default)', async () => {
   const {binaryData, repeatedData} = getBinaryData();
-
   const cryptoHash = new CryptoHash({
     modules: {CryptoJS},
     crypto: {algorithm: 'MD5'}
   });
-
   let hash = await cryptoHash.hash(binaryData, 'base64');
-
-  t.equal(hash, 'YnxTb+lyen1CsNkpmLv+qA==', 'binary data MD5 hash is correct');
-
+  expect(hash, 'binary data MD5 hash is correct').toBe('YnxTb+lyen1CsNkpmLv+qA==');
   hash = await cryptoHash.hash(repeatedData, 'base64');
-  t.equal(hash, '2d4uZUoLXXO/XWJGnrVl5Q==', 'repeated data MD5 hash is correct');
-
-  t.end();
+  expect(hash, 'repeated data MD5 hash is correct').toBe('2d4uZUoLXXO/XWJGnrVl5Q==');
 });
-
-test('CryptoHash#hashBatches(small chunks)', async t => {
+test('CryptoHash#hashBatches(small chunks)', async () => {
   const inputChunks = [
     new Uint8Array([1, 2, 3]).buffer,
     new Uint8Array([4, 5, 6]).buffer,
     new Uint8Array([7, 8, 9]).buffer
   ];
-
   let hash;
-
   const crypto = new CryptoHash({
     modules: {CryptoJS},
     crypto: {
@@ -93,26 +65,20 @@ test('CryptoHash#hashBatches(small chunks)', async t => {
       }
     }
   });
-
   // @ts-ignore
   const hashIterator = crypto.hashBatches(inputChunks);
-
   const inputData = concatenateArrayBuffers(...inputChunks);
   const transformedData = await concatenateArrayBuffersAsync(hashIterator);
-
-  t.equal(hash, 'hZbBr1WxS3syARKUT8uFNg==', 'CryptoHash generated correct hash');
-  t.ok(compareArrayBuffers(inputData, transformedData), 'CryptoHash passed through data');
-
-  t.end();
+  expect(hash, 'CryptoHash generated correct hash').toBe('hZbBr1WxS3syARKUT8uFNg==');
+  expect(
+    compareArrayBuffers(inputData, transformedData),
+    'CryptoHash passed through data'
+  ).toBeTruthy();
 });
-
-test('CryptoHash#batches(100K)', async t => {
+test('CryptoHash#batches(100K)', async () => {
   const {binaryData} = getBinaryData();
-
   const inputChunks = [binaryData];
-
   let hash;
-
   const cryptoHash = new CryptoHash({
     modules: {CryptoJS},
     crypto: {
@@ -122,14 +88,13 @@ test('CryptoHash#batches(100K)', async t => {
       }
     }
   });
-
   // @ts-ignore
   const hashIterator = cryptoHash.hashBatches(inputChunks);
   const inputData = concatenateArrayBuffers(...inputChunks);
   const transformedData = await concatenateArrayBuffersAsync(hashIterator);
-
-  t.equal(hash, 'YnxTb+lyen1CsNkpmLv+qA==', 'CryptoHash generated correct hash');
-  t.ok(compareArrayBuffers(inputData, transformedData), 'CryptoHash passed through data');
-
-  t.end();
+  expect(hash, 'CryptoHash generated correct hash').toBe('YnxTb+lyen1CsNkpmLv+qA==');
+  expect(
+    compareArrayBuffers(inputData, transformedData),
+    'CryptoHash passed through data'
+  ).toBeTruthy();
 });

--- a/modules/crypto/test/lib/md5-wasm.spec.ts
+++ b/modules/crypto/test/lib/md5-wasm.spec.ts
@@ -1,36 +1,24 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
-
+import {expect, test} from 'vitest';
 import md5WASM from '../../src/lib/algorithms/md5-wasm';
-
 const textEncoder = new TextEncoder();
-
-test('md5WASM#hash supports ArrayBuffer and Uint8Array inputs', async t => {
+test('md5WASM#hash supports ArrayBuffer and Uint8Array inputs', async () => {
   const input = textEncoder.encode('array md5 input');
   const arrayBufferInput = input.buffer.slice(0);
-
   const hashFromTypedArray = await runMd5(input);
   const hashFromArrayBuffer = await runMd5(arrayBufferInput);
-
-  t.equal(hashFromTypedArray, 'debde7239b0aafd48eccd2d048e80c3a', 'hash matches expected value');
-  t.equal(hashFromArrayBuffer, hashFromTypedArray, 'ArrayBuffer input hashes match');
-
-  t.end();
+  expect(hashFromTypedArray, 'hash matches expected value').toBe(
+    'debde7239b0aafd48eccd2d048e80c3a'
+  );
+  expect(hashFromArrayBuffer, 'ArrayBuffer input hashes match').toBe(hashFromTypedArray);
 });
-
-test('md5WASM#hash works when Buffer is undefined', async t => {
+test('md5WASM#hash works when Buffer is undefined', async () => {
   const originalBuffer = globalThis.Buffer;
   // @ts-ignore Buffer is intentionally overridden for this test
   globalThis.Buffer = undefined;
-
   try {
     const input = textEncoder.encode('bufferless md5 input');
     const hash = await runMd5(input);
-
-    t.equal(hash, 'c2cccb15893fdb77c499a18ee750c51b', 'hash generated without Buffer present');
+    expect(hash, 'hash generated without Buffer present').toBe('c2cccb15893fdb77c499a18ee750c51b');
   } finally {
     if (typeof originalBuffer === 'undefined') {
       delete globalThis.Buffer;
@@ -38,10 +26,7 @@ test('md5WASM#hash works when Buffer is undefined', async t => {
       globalThis.Buffer = originalBuffer;
     }
   }
-
-  t.end();
 });
-
 function runMd5(data: ArrayBuffer | Uint8Array): Promise<string> {
   return new Promise((resolve, reject) => {
     md5WASM(data).then(resolve).catch(reject);

--- a/modules/crypto/test/lib/utils/digest-utils.spec.ts
+++ b/modules/crypto/test/lib/utils/digest-utils.spec.ts
@@ -1,10 +1,5 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {encodeNumber, encodeHex, encodeBase64} from '@loaders.gl/crypto';
-
 const loadJSON = async (relativePath: string) => {
   const url = new URL(relativePath, import.meta.url);
   if (url.protocol === 'file:' && typeof window === 'undefined') {
@@ -14,31 +9,22 @@ const loadJSON = async (relativePath: string) => {
   const response = await fetch(url);
   return response.json();
 };
-
 const TEST_CASES = await loadJSON('../crc32c-test-cases.json');
-
-test('encodeHexToBase64#crc32 test cases', t => {
+test('encodeHexToBase64#crc32 test cases', () => {
   for (const type in TEST_CASES) {
     const set = TEST_CASES[type];
-
     for (const tc of set.cases) {
       if (!tc.charset) {
         tc.expected = encodeNumber(tc.want, 'base64');
-        t.ok(tc.expected, `${tc.want} encodeed to ${tc.expected}`);
+        expect(tc.expected, `${tc.want} encodeed to ${tc.expected}`).toBeTruthy();
       }
     }
-
     set.expected = encodeHex(set.want.toString(16), 'base64');
   }
-  t.end();
 });
-
-test('encodeHexToBase64', t => {
-  t.equal(encodeHex('f85d741', 'base64'), 'D4XXQQ==', 'encode zero leading hex correctly');
-  t.end();
+test('encodeHexToBase64', () => {
+  expect(encodeHex('f85d741', 'base64'), 'encode zero leading hex correctly').toBe('D4XXQQ==');
 });
-
-test('encodeBase64ToHex', t => {
-  t.equal(encodeBase64('D4XXQQ==', 'hex'), '0f85d741');
-  t.end();
+test('encodeBase64ToHex', () => {
+  expect(encodeBase64('D4XXQQ==', 'hex')).toBe('0f85d741');
 });

--- a/modules/csv/src/papaparse/papa-parser.ts
+++ b/modules/csv/src/papaparse/papa-parser.ts
@@ -63,6 +63,9 @@ export class ChunkStreamer {
     meta: {}
   };
 
+  /** Reads and parses the next input chunk. */
+  _nextChunk(): void {}
+
   constructor(config: CSVParserConfig) {
     // Deep-copy the config so we can edit it
     const configCopy = {...config};
@@ -202,6 +205,9 @@ export class ParserHandle {
     errors: [],
     meta: {}
   };
+
+  /** Streamer that owns this parser handle. */
+  streamer!: ChunkStreamer;
 
   constructor(_config: CSVParserConfig) {
     // One goal is to minimize the use of regular expressions...

--- a/modules/csv/src/papaparse/papa-parser.ts
+++ b/modules/csv/src/papaparse/papa-parser.ts
@@ -135,7 +135,7 @@ export class ChunkStreamer {
       this._completed = true;
     }
 
-    // if (!finishedIncludingPreview && (!results || !results.meta.paused)) this._nextChunk();
+    if (!finishedIncludingPreview && (!results || !results.meta.paused)) this._nextChunk();
 
     // eslint-disable-next-line consistent-return
     return results;
@@ -289,13 +289,13 @@ export class ParserHandle {
     this._paused = true;
     this._parser.abort();
     this._input = this._input.substr(this._parser.getCharIndex());
+    this.streamer._partialLine = '';
     this._parser = null;
     this._parserConfig = null;
   }
 
   resume() {
     this._paused = false;
-    // @ts-expect-error
     this.streamer.parseChunk(this._input, true);
   }
 

--- a/modules/csv/test/csv-loader.spec.ts
+++ b/modules/csv/test/csv-loader.spec.ts
@@ -1,10 +1,5 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {validateLoader} from 'test/common/conformance';
-
 import {
   load,
   loadInBatches,
@@ -26,7 +21,6 @@ import {
 import * as csv from '@loaders.gl/csv';
 import {getGeoMetadata} from '@loaders.gl/gis';
 import {getTableLength} from '@loaders.gl/schema-utils';
-
 // Small CSV Sample Files
 const CSV_SAMPLE_URL = '@loaders.gl/csv/test/data/sample.csv';
 const CSV_SAMPLE_VERY_LONG_URL = '@loaders.gl/csv/test/data/sample-very-long.csv';
@@ -37,637 +31,188 @@ const CSV_INCIDENTS_URL_QUOTES = '@loaders.gl/csv/test/data/sf_incidents-small.c
 const CSV_NO_HEADER_URL = '@loaders.gl/csv/test/data/numbers-100-no-header.csv';
 const CSV_GEOSPATIAL_WKT_URL = '@loaders.gl/csv/test/data/geospatial-points-wkt.csv';
 const CSV_GEOSPATIAL_WKB_URL = '@loaders.gl/csv/test/data/geospatial-points-wkb.csv';
-
 const TSV_BRAZIL = '@loaders.gl/csv/test/data/tsv/brazil.tsv';
-
-test('CSVLoader#loader conformance', t => {
-  validateLoader(t, CSVLoader, 'CSVLoader');
-  t.end();
+test('CSVLoader#loader conformance', () => {
+  validateLoader(CSVLoader, 'CSVLoader');
 });
-
-test('CSV root loaders expose metadata loaders and deprecated WorkerLoader aliases', t => {
-  t.equal(typeof CSVLoader.preload, 'function', 'CSVLoader exposes preload');
-  t.notOk('parse' in CSVLoader, 'CSVLoader does not expose parse');
-  t.notOk('parseInBatches' in CSVLoader, 'CSVLoader does not expose parseInBatches');
-  t.equal(CSVWorkerLoader, CSVLoader, 'CSVWorkerLoader aliases CSVLoader');
-  t.notOk('CSVLoaderWithParser' in csv, 'root package does not export CSVLoaderWithParser');
-  t.end();
+test('CSV root loaders expose metadata loaders and deprecated WorkerLoader aliases', () => {
+  expect(typeof CSVLoader.preload, 'CSVLoader exposes preload').toBe('function');
+  expect('parse' in CSVLoader, 'CSVLoader does not expose parse').toBeFalsy();
+  expect('parseInBatches' in CSVLoader, 'CSVLoader does not expose parseInBatches').toBeFalsy();
+  expect(CSVWorkerLoader, 'CSVWorkerLoader aliases CSVLoader').toBe(CSVLoader);
+  expect(
+    'CSVLoaderWithParser' in csv,
+    'root package does not export CSVLoaderWithParser'
+  ).toBeFalsy();
 });
-
-test('CSV bundled loaders expose parser methods and deprecated WorkerLoader aliases', t => {
-  t.equal(typeof BundledCSVLoader.parse, 'function', 'bundled CSVLoader exposes parse');
-  t.equal(
-    typeof BundledCSVLoader.parseInBatches,
-    'function',
-    'bundled CSVLoader exposes parseInBatches'
+test('CSV bundled loaders expose parser methods and deprecated WorkerLoader aliases', () => {
+  expect(typeof BundledCSVLoader.parse, 'bundled CSVLoader exposes parse').toBe('function');
+  expect(typeof BundledCSVLoader.parseInBatches, 'bundled CSVLoader exposes parseInBatches').toBe(
+    'function'
   );
-  t.equal(BundledCSVWorkerLoader, BundledCSVLoader, 'bundled CSVWorkerLoader aliases CSVLoader');
-  t.end();
+  expect(BundledCSVWorkerLoader, 'bundled CSVWorkerLoader aliases CSVLoader').toBe(
+    BundledCSVLoader
+  );
 });
-
-test('CSV unbundled metadata loaders expose preload and deprecated WorkerLoader aliases', async t => {
-  t.equal(preloadSync(UnbundledCSVLoader), null, 'unbundled CSVLoader is not preloaded initially');
-  t.equal(typeof UnbundledCSVLoader.preload, 'function', 'unbundled CSVLoader exposes preload');
-  t.notOk('parse' in UnbundledCSVLoader, 'unbundled CSVLoader does not expose parse');
-  t.notOk('parseSync' in UnbundledCSVLoader, 'unbundled CSVLoader does not expose parseSync');
-  t.notOk(
+test('CSV unbundled metadata loaders expose preload and deprecated WorkerLoader aliases', async () => {
+  expect(preloadSync(UnbundledCSVLoader), 'unbundled CSVLoader is not preloaded initially').toBe(
+    null
+  );
+  expect(typeof UnbundledCSVLoader.preload, 'unbundled CSVLoader exposes preload').toBe('function');
+  expect('parse' in UnbundledCSVLoader, 'unbundled CSVLoader does not expose parse').toBeFalsy();
+  expect(
+    'parseSync' in UnbundledCSVLoader,
+    'unbundled CSVLoader does not expose parseSync'
+  ).toBeFalsy();
+  expect(
     'parseInBatches' in UnbundledCSVLoader,
     'unbundled CSVLoader does not expose parseInBatches'
+  ).toBeFalsy();
+  expect(UnbundledCSVWorkerLoader, 'unbundled CSVWorkerLoader aliases CSVLoader').toBe(
+    UnbundledCSVLoader
   );
-  t.equal(
-    UnbundledCSVWorkerLoader,
-    UnbundledCSVLoader,
-    'unbundled CSVWorkerLoader aliases CSVLoader'
-  );
-
   const parsedTable = await parse('city,population\nParis,2148000', UnbundledCSVLoader, {
     csv: {header: true, shape: 'object-row-table'}
   });
-  t.equal(parsedTable.shape, 'object-row-table', 'parse works with unbundled CSVLoader');
+  expect(parsedTable.shape, 'parse works with unbundled CSVLoader').toBe('object-row-table');
   if (parsedTable.shape === 'object-row-table') {
-    t.deepEqual(parsedTable.data[0], {city: 'Paris', population: 2148000});
+    expect(parsedTable.data[0]).toEqual({city: 'Paris', population: 2148000});
   }
-
   const preloadedLoader = await preload(UnbundledCSVLoader);
-  t.equal(typeof preloadedLoader.parse, 'function', 'preload returns parser-bearing CSV loader');
-  t.equal(
-    preloadSync(UnbundledCSVLoader),
-    preloadedLoader,
-    'preloadSync returns cached CSV loader'
+  expect(typeof preloadedLoader.parse, 'preload returns parser-bearing CSV loader').toBe(
+    'function'
   );
-  t.end();
+  expect(preloadSync(UnbundledCSVLoader), 'preloadSync returns cached CSV loader').toBe(
+    preloadedLoader
+  );
 });
-test('CSVLoader#load(states.csv)', async t => {
+test('CSVLoader#load(states.csv)', async () => {
   const table = await load(CSV_STATES_URL, CSVLoader);
-  t.equal(getTableLength(table), 110);
-  t.end();
+  expect(getTableLength(table)).toBe(110);
 });
-
-test('CSVLoader#load(numbers-100.csv, shape: arrow-table)', async t => {
+test('CSVLoader#load(numbers-100.csv, shape: arrow-table)', async () => {
   const table = await load(CSV_NO_HEADER_URL, CSVLoader, {
     core: {worker: false},
     csv: {header: false, shape: 'arrow-table'}
   });
-
-  t.equal(table.shape, 'arrow-table', 'Got correct table shape');
-  t.equal(table.data.numRows, 100, 'Got correct row count');
-  t.equal(table.data.getChildAt(0)?.get(0), 1, 'Got correct first value');
-  t.end();
+  expect(table.shape, 'Got correct table shape').toBe('arrow-table');
+  expect(table.data.numRows, 'Got correct row count').toBe(100);
+  expect(table.data.getChildAt(0)?.get(0), 'Got correct first value').toBe(1);
 });
-
-test('CSVLoader#load(geospatial-points-wkt.csv, detectGeometryColumns)', async t => {
+test('CSVLoader#load(geospatial-points-wkt.csv, detectGeometryColumns)', async () => {
   const table = await load(CSV_GEOSPATIAL_WKT_URL, CSVLoader, {
     csv: {shape: 'object-row-table', detectGeometryColumns: true}
   });
-
-  t.equal(table.shape, 'object-row-table', 'Got correct table shape');
+  expect(table.shape, 'Got correct table shape').toBe('object-row-table');
   if (table.shape === 'object-row-table') {
     const geometryField = table.schema?.fields.find(field => field.name === 'geometry');
     const geoMetadata = getGeoMetadata(table.schema?.metadata);
-
-    t.equal(geometryField?.type, 'binary', 'WKT geometry field is converted to a binary column');
-    t.equal(
+    expect(geometryField?.type, 'WKT geometry field is converted to a binary column').toBe(
+      'binary'
+    );
+    expect(
       geometryField?.metadata?.['ARROW:extension:name'],
-      'geoarrow.wkb',
       'WKT geometry field is annotated as WKB'
+    ).toBe('geoarrow.wkb');
+    expect(geoMetadata?.primary_column, 'Geo metadata primary column is set').toBe('geometry');
+    expect(geoMetadata?.columns.geometry.encoding, 'Geo metadata includes WKB encoding').toBe(
+      'wkb'
     );
-    t.equal(geoMetadata?.primary_column, 'geometry', 'Geo metadata primary column is set');
-    t.equal(geoMetadata?.columns.geometry.encoding, 'wkb', 'Geo metadata includes WKB encoding');
-    t.equal(
+    expect(
       geoMetadata?.columns.geometry.geometry_types[0],
-      'Point',
       'Geo metadata includes inferred geometry type'
-    );
-    t.ok(table.data[0].geometry instanceof Uint8Array, 'WKT geometry value is encoded as WKB');
+    ).toBe('Point');
+    expect(
+      table.data[0].geometry instanceof Uint8Array,
+      'WKT geometry value is encoded as WKB'
+    ).toBeTruthy();
   }
-  t.end();
 });
-
-test('CSVLoader#load(geospatial-points-wkt.csv, detectGeometryColumns, source geometry)', async t => {
+test('CSVLoader#load(geospatial-points-wkt.csv, detectGeometryColumns, source geometry)', async () => {
   const table = await load(CSV_GEOSPATIAL_WKT_URL, CSVLoader, {
     csv: {shape: 'object-row-table', detectGeometryColumns: true, geometryEncoding: 'source'}
   });
-
-  t.equal(table.shape, 'object-row-table', 'Got correct table shape');
+  expect(table.shape, 'Got correct table shape').toBe('object-row-table');
   if (table.shape === 'object-row-table') {
     const geometryField = table.schema?.fields.find(field => field.name === 'geometry');
     const geoMetadata = getGeoMetadata(table.schema?.metadata);
-
-    t.equal(geometryField?.type, 'utf8', 'WKT geometry field is a string column');
-    t.equal(
+    expect(geometryField?.type, 'WKT geometry field is a string column').toBe('utf8');
+    expect(
       geometryField?.metadata?.['ARROW:extension:name'],
-      'geoarrow.wkt',
       'WKT geometry field is annotated'
+    ).toBe('geoarrow.wkt');
+    expect(geoMetadata?.columns.geometry.encoding, 'Geo metadata includes WKT encoding').toBe(
+      'wkt'
     );
-    t.equal(geoMetadata?.columns.geometry.encoding, 'wkt', 'Geo metadata includes WKT encoding');
-    t.equal(table.data[0].geometry, 'POINT (-122.3933 37.7955)', 'WKT geometry value is preserved');
+    expect(table.data[0].geometry, 'WKT geometry value is preserved').toBe(
+      'POINT (-122.3933 37.7955)'
+    );
   }
-  t.end();
 });
-
-test('CSVLoader#load(geospatial-points-wkb.csv, detectGeometryColumns)', async t => {
+test('CSVLoader#load(geospatial-points-wkb.csv, detectGeometryColumns)', async () => {
   const table = await load(CSV_GEOSPATIAL_WKB_URL, CSVLoader, {
     csv: {shape: 'array-row-table', detectGeometryColumns: true}
   });
-
-  t.equal(table.shape, 'array-row-table', 'Got correct table shape');
+  expect(table.shape, 'Got correct table shape').toBe('array-row-table');
   if (table.shape === 'array-row-table') {
     const wkbField = table.schema?.fields.find(field => field.name === 'wkb');
     const geoMetadata = getGeoMetadata(table.schema?.metadata);
-
-    t.equal(wkbField?.type, 'binary', 'WKB geometry field is a binary column');
-    t.equal(
-      wkbField?.metadata?.['ARROW:extension:name'],
-      'geoarrow.wkb',
-      'WKB geometry field is annotated'
+    expect(wkbField?.type, 'WKB geometry field is a binary column').toBe('binary');
+    expect(wkbField?.metadata?.['ARROW:extension:name'], 'WKB geometry field is annotated').toBe(
+      'geoarrow.wkb'
     );
-    t.equal(geoMetadata?.columns.wkb.encoding, 'wkb', 'Geo metadata includes WKB encoding');
-    t.ok(table.data[0][2] instanceof Uint8Array, 'WKB geometry value is decoded');
+    expect(geoMetadata?.columns.wkb.encoding, 'Geo metadata includes WKB encoding').toBe('wkb');
+    expect(table.data[0][2] instanceof Uint8Array, 'WKB geometry value is decoded').toBeTruthy();
   }
-  t.end();
 });
-
 // eslint-disable-next-line max-statements
-test('CSVLoader#load', async t => {
+test('CSVLoader#load', async () => {
   const table = await load(CSV_SAMPLE_URL, CSVLoader, {csv: {shape: 'object-row-table'}});
-  t.assert(table.shape === 'object-row-table', 'Got correct table shape');
+  expect(table.shape, 'Got correct table shape').toBe('object-row-table');
   if (table.shape === 'object-row-table') {
-    t.is(getTableLength(table), 2, 'Got correct table size, correctly inferred no header');
-    t.deepEqual(table.data[0], {column1: 'A', column2: 'B', column3: 1}, 'Got correct first row');
+    expect(getTableLength(table), 'Got correct table size, correctly inferred no header').toBe(2);
+    expect(table.data[0], 'Got correct first row').toEqual({
+      column1: 'A',
+      column2: 'B',
+      column3: 1
+    });
   }
-
   const table1 = await load(CSV_SAMPLE_URL, CSVLoader, {
     csv: {shape: 'object-row-table', header: true}
   });
-
-  t.assert(table1.shape === 'object-row-table', 'Got correct table shape');
+  expect(table1.shape, 'Got correct table shape').toBe('object-row-table');
   if (table1.shape === 'object-row-table') {
-    t.is(getTableLength(table1), 1, 'Got correct table size, forced first row as header');
-    t.deepEqual(table1.data[0], {A: 'X', B: 'Y', 1: 2}, 'Got correct first row');
+    expect(getTableLength(table1), 'Got correct table size, forced first row as header').toBe(1);
+    expect(table1.data[0], 'Got correct first row').toEqual({A: 'X', B: 'Y', 1: 2});
   }
-
   const table2 = await load(CSV_SAMPLE_URL, CSVLoader, {csv: {shape: 'array-row-table'}});
-  t.assert(table2.shape === 'array-row-table', 'Got correct table shape');
+  expect(table2.shape, 'Got correct table shape').toBe('array-row-table');
   if (table2.shape === 'array-row-table') {
-    t.is(getTableLength(table2), 2, 'Got correct table size');
-    t.deepEqual(
-      table2.data,
-      [
-        ['A', 'B', 1],
-        ['X', 'Y', 2]
-      ],
-      'Got correct array content'
-    );
+    expect(getTableLength(table2), 'Got correct table size').toBe(2);
+    expect(table2.data, 'Got correct array content').toEqual([
+      ['A', 'B', 1],
+      ['X', 'Y', 2]
+    ]);
   }
-
   const table3 = await load(CSV_SAMPLE_VERY_LONG_URL, CSVLoader, {
     csv: {shape: 'object-row-table'}
   });
-  t.assert(table3.shape === 'object-row-table', 'Got correct table shape');
+  expect(table3.shape, 'Got correct table shape').toBe('object-row-table');
   if (table3.shape === 'object-row-table') {
-    t.is(getTableLength(table3), 2000, 'Got correct table size');
-    t.deepEqual(
-      table3.data[0],
-      {
-        TLD: 'ABC',
-        'meaning of life': 42,
-        placeholder: 'Lorem ipsum dolor sit'
-      },
-      'Got correct first row'
-    );
+    expect(getTableLength(table3), 'Got correct table size').toBe(2000);
+    expect(table3.data[0], 'Got correct first row').toEqual({
+      TLD: 'ABC',
+      'meaning of life': 42,
+      placeholder: 'Lorem ipsum dolor sit'
+    });
   }
-
   const table4 = await load(CSV_INCIDENTS_URL_QUOTES, CSVLoader, {
     csv: {shape: 'object-row-table'}
   });
-  t.assert(table4.shape === 'object-row-table', 'Got correct table shape');
+  expect(table4.shape, 'Got correct table shape').toBe('object-row-table');
   if (table4.shape === 'object-row-table') {
-    t.is(getTableLength(table4), 499, 'Got correct table size (csv with quotes)');
-    t.deepEqual(
-      table4.data[0],
-      {
-        IncidntNum: 160919032,
-        Category: 'VANDALISM',
-        Descript: 'MALICIOUS MISCHIEF, VANDALISM OF VEHICLES',
-        DayOfWeek: 'Friday',
-        DateTime: '11/11/16 7:00',
-        PdDistrict: 'MISSION',
-        Address: '1400 Block of UTAH ST',
-        Resolution: 'NONE',
-        Longitude: -122.4052518,
-        Latitude: 37.75152496
-      },
-      'Got correct first row (csv with quotes)'
-    );
-  }
-  t.end();
-});
-
-test('CSVLoader#load(sample.csv, duplicate column names)', async t => {
-  const table = await load(CSV_SAMPLE_URL_DUPLICATE_COLS, CSVLoader, {
-    csv: {shape: 'object-row-table'}
-  });
-  t.assert(table.shape === 'object-row-table', 'Got correct table shape');
-  if (table.shape === 'object-row-table') {
-    t.is(getTableLength(table), 3, 'Got correct table size');
-    t.deepEqual(
-      table.data,
-      [
-        {A: 'x', B: 1, 'A.1': 'y', 'A.1.1': 'z', 'A.2': 'w', 'B.1': 2},
-        {A: 'y', B: 29, 'A.1': 'z', 'A.1.1': 'y', 'A.2': 'w', 'B.1': 19},
-        {A: 'x', B: 1, 'A.1': 'y', 'A.1.1': 'z', 'A.2': 'w', 'B.1': 2}
-      ],
-      'dataset should be parsed with the corrected duplicate headers'
-    );
-  }
-
-  const table2 = await load(CSV_SAMPLE_URL_DUPLICATE_COLS, CSVLoader, {
-    csv: {shape: 'array-row-table', header: false}
-  });
-  t.assert(table2.shape === 'array-row-table', 'Got correct table shape');
-  if (table2.shape === 'array-row-table') {
-    t.is(getTableLength(table2), 4, 'Got correct table size');
-    t.deepEqual(
-      table2.data,
-      [
-        ['A', 'B', 'A', 'A.1', 'A', 'B'],
-        ['x', 1, 'y', 'z', 'w', 2],
-        ['y', 29, 'z', 'y', 'w', 19],
-        ['x', 1, 'y', 'z', 'w', 2]
-      ],
-      'dataset should be parsed correctly as the array rows'
-    );
-  }
-});
-
-// TSV
-
-test('CSVLoader#load(brazil.tsv)', async t => {
-  const table = await load(TSV_BRAZIL, CSVLoader);
-  t.equal(getTableLength(table), 10);
-  t.end();
-});
-
-// loadInBatches
-
-test('CSVLoader#loadInBatches(sample.csv, columns)', async t => {
-  const iterator = await loadInBatches(CSV_SAMPLE_URL, CSVLoader, {
-    csv: {
-      shape: 'columnar-table'
-    }
-  });
-  t.ok(isAsyncIterable(iterator), 'loadInBatches returned iterator');
-
-  let batchCount = 0;
-  for await (const batch of iterator) {
-    // t.comment(`BATCH ${batch.count}: ${batch.length} ${JSON.stringify(batch.data).slice(0, 200)}`);
-    t.equal(batch.length, 2, 'Got correct batch size');
-
-    t.equal(batch.shape, 'columnar-table', 'Got correct batch shape');
-    if (batch.shape === 'columnar-table') {
-      t.ok(validateColumn(batch.data.column1, batch.length, 'string'), 'column 0 valid');
-      t.ok(validateColumn(batch.data.column2, batch.length, 'string'), 'column 1 valid');
-      t.ok(validateColumn(batch.data.column3, batch.length, 'float'), 'column 2 valid');
-    }
-
-    batchCount++;
-  }
-  t.equal(batchCount, 1, 'Correct number of batches received');
-  t.end();
-});
-
-test('CSVLoader#loadInBatches(geospatial-points-wkt.csv, detectGeometryColumns)', async t => {
-  const iterator = await loadInBatches(CSV_GEOSPATIAL_WKT_URL, CSVLoader, {
-    csv: {shape: 'columnar-table', detectGeometryColumns: true},
-    batchSize: 2
-  });
-
-  let firstBatch: any = null;
-  for await (const batch of iterator) {
-    firstBatch = firstBatch || batch;
-  }
-
-  t.equal(firstBatch?.shape, 'columnar-table', 'Got correct batch shape');
-  if (firstBatch?.shape === 'columnar-table') {
-    const geometryField = firstBatch.schema?.fields.find(field => field.name === 'geometry');
-    const geoMetadata = getGeoMetadata(firstBatch.schema?.metadata);
-
-    t.equal(firstBatch.length, 3, 'Got correct batch size');
-    t.equal(
-      geometryField?.metadata?.['ARROW:extension:name'],
-      'geoarrow.wkb',
-      'WKT batch geometry field is annotated as WKB'
-    );
-    t.equal(geoMetadata?.columns.geometry.encoding, 'wkb', 'Batch geo metadata includes encoding');
-    t.ok(firstBatch.data.geometry[0] instanceof Uint8Array, 'WKT batch geometry value is encoded');
-  }
-  t.end();
-});
-
-test('CSVLoader#load(geospatial-points-wkt.csv, arrow-table, detectGeometryColumns)', async t => {
-  const table = await load(CSV_GEOSPATIAL_WKT_URL, CSVLoader, {
-    core: {worker: false},
-    csv: {shape: 'arrow-table', detectGeometryColumns: true}
-  });
-
-  t.equal(table.shape, 'arrow-table', 'Got correct table shape');
-  const geometryField = table.schema?.fields.find(field => field.name === 'geometry');
-  const geoMetadata = getGeoMetadata(table.schema?.metadata);
-
-  t.equal(geometryField?.type, 'binary', 'WKT Arrow geometry field is binary');
-  t.equal(
-    geometryField?.metadata?.['ARROW:extension:name'],
-    'geoarrow.wkb',
-    'WKT Arrow geometry field is annotated as WKB'
-  );
-  t.equal(
-    geoMetadata?.columns.geometry.encoding,
-    'wkb',
-    'Arrow geo metadata includes WKB encoding'
-  );
-  t.ok(table.data.getChild('geometry')?.get(0) instanceof Uint8Array, 'Arrow geometry is WKB');
-  t.end();
-});
-
-test('CSVLoader#loadInBatches(numbers-100.csv, shape: arrow-table)', async t => {
-  const iterator = await loadInBatches(CSV_STATES_URL, CSVLoader, {
-    core: {worker: false, batchSize: 40},
-    csv: {shape: 'arrow-table'}
-  });
-
-  let batchCount = 0;
-  let rowCount = 0;
-  for await (const batch of iterator) {
-    t.equal(batch.shape, 'arrow-table', `Got correct Arrow batch shape for batch ${batchCount}`);
-    rowCount += batch.data.numRows;
-    batchCount++;
-  }
-
-  t.ok(batchCount >= 1, 'Received one or more batches');
-  t.equal(rowCount, 110, 'Correct number of rows received');
-  t.end();
-});
-
-test('CSVLoader#loadInBatches(sample-very-long.csv, columns)', async t => {
-  const batchSize = 25;
-  const iterator = await loadInBatches(CSV_SAMPLE_VERY_LONG_URL, CSVLoader, {
-    csv: {
-      shape: 'columnar-table'
-    },
-    batchSize
-  });
-
-  let batchCount = 0;
-  for await (const batch of iterator) {
-    // t.comment(`BATCH ${batch.count}: ${batch.length} ${JSON.stringify(batch.data).slice(0, 200)}`);
-    t.equal(batch.length, batchSize, 'Got correct batch size');
-
-    t.equal(batch.shape, 'columnar-table', 'Got correct batch shape');
-    if (batch.shape === 'columnar-table') {
-      t.ok(validateColumn(batch.data.TLD, batch.length, 'string'), 'column TLD valid');
-      t.ok(
-        validateColumn(batch.data['meaning of life'], batch.length, 'float'),
-        'column meaning of life valid'
-      );
-      t.ok(
-        validateColumn(batch.data.placeholder, batch.length, 'string'),
-        'column placeholder valid'
-      );
-    }
-    batchCount++;
-    if (batchCount === 5) {
-      break;
-    }
-  }
-  t.equal(batchCount, 5, 'Correct number of batches received');
-
-  t.end();
-});
-
-test('CSVLoader#loadInBatches(sample.csv, array-rows)', async t => {
-  const iterator = await loadInBatches(CSV_SAMPLE_URL, CSVLoader, {shape: 'array-row-table'});
-
-  let batchCount = 0;
-  for await (const batch of iterator) {
-    // t.comment(`BATCH ${batch.count}: ${batch.length} ${JSON.stringify(batch.data).slice(0, 200)}`);
-    t.equal(batch.shape, 'array-row-table', 'Got correct batch shape');
-    if (batch.shape === 'array-row-table') {
-      t.equal(batch.length, 2, 'Got correct batch size');
-      t.deepEqual(batch.data[0], ['A', 'B', 1], 'Got correct first row');
-    }
-    batchCount++;
-  }
-  t.equal(batchCount, 1, 'Correct number of batches received');
-
-  t.end();
-});
-
-test('CSVLoader#loadInBatches(sample.csv, object-rows)', async t => {
-  const iterator = await loadInBatches(CSV_SAMPLE_URL, CSVLoader, {
-    csv: {shape: 'object-row-table'}
-  });
-
-  let batchCount = 0;
-  for await (const batch of iterator) {
-    t.equal(batch.shape, 'object-row-table', 'Got correct batch shape');
-    if (batch.shape === 'object-row-table') {
-      // t.comment(
-      //   `BATCH ${batch.count}: ${batch.length} ${JSON.stringify(batch.data).slice(0, 200)}`
-      // );
-      t.equal(batch.length, 2, 'Got correct batch size');
-      t.deepEqual(batch.data[0], {column1: 'A', column2: 'B', column3: 1}, 'Got correct first row');
-    }
-    batchCount++;
-  }
-  t.equal(batchCount, 1, 'Correct number of batches received');
-
-  t.end();
-});
-
-test('CSVLoader#loadInBatches(sample.csv, arrays, header)', async t => {
-  let iterator = await loadInBatches(CSV_SAMPLE_URL, CSVLoader, {
-    csv: {
-      shape: 'array-row-table',
-      header: false
-    }
-  });
-
-  let batchCount = 0;
-  for await (const batch of iterator) {
-    // t.comment(`BATCH ${batch.count}: ${batch.length} ${JSON.stringify(batch.data).slice(0, 200)}`);
-    t.equal(batch.shape, 'array-row-table', 'Got correct batch shape');
-    if (batch.shape === 'array-row-table') {
-      t.equal(batch.length, 2, 'Got correct batch size');
-      t.deepEqual(batch.data[0], ['A', 'B', 1], 'Got correct first row');
-    }
-    batchCount++;
-  }
-  t.equal(batchCount, 1, 'Correct number of batches received');
-
-  iterator = await loadInBatches(CSV_SAMPLE_URL, CSVLoader, {
-    csv: {header: false, shape: 'object-row-table'}
-  });
-
-  batchCount = 0;
-  for await (const batch of iterator) {
-    // t.comment(`BATCH ${batch.count}: ${batch.length} ${JSON.stringify(batch.data).slice(0, 200)}`);
-    t.equal(batch.shape, 'object-row-table', 'Got correct batch shape');
-    if (batch.shape === 'object-row-table') {
-      t.equal(batch.length, 2, 'Got correct batch size');
-      t.deepEqual(batch.data[0], {column1: 'A', column2: 'B', column3: 1}, 'Got correct first row');
-    }
-    batchCount++;
-  }
-  t.equal(batchCount, 1, 'Correct number of batches received');
-
-  t.end();
-});
-
-test('CSVLoader#loadInBatches(no header, row format, prefix)', async t => {
-  const batchSize = 25;
-  const iterator = await loadInBatches(CSV_NO_HEADER_URL, CSVLoader, {
-    csv: {
-      shape: 'object-row-table',
-      columnPrefix: 'column_'
-    },
-    batchSize
-  });
-
-  for await (const batch of iterator) {
-    t.equal(batch.shape, 'object-row-table', 'Got correct batch shape');
-    if (batch.shape === 'object-row-table') {
-      // t.comment(JSON.stringify(batch.data[0]));
-      t.ok(batch.data[0].column_1, 'first column has a value');
-      t.ok(batch.data[0].column_2, 'second column has a value value');
-      t.ok(batch.data[0].column_3, 'third column has a value');
-    }
-  }
-
-  t.end();
-});
-
-test('CSVLoader#loadInBatches(sample.csv, no dynamicTyping)', async t => {
-  const iterator = await loadInBatches(CSV_SAMPLE_URL, CSVLoader, {
-    csv: {
-      shape: 'columnar-table',
-      dynamicTyping: false,
-      // We explicitly set the header, since without dynamicTyping the first
-      // row might be detected as a header (all values would be string)
-      header: false
-    }
-  });
-
-  let rowCount = 0;
-  for await (const batch of iterator) {
-    // t.comment(`BATCH ${batch.count}: ${batch.length} ${JSON.stringify(batch.data).slice(0, 200)}`);
-    t.equal(batch.shape, 'columnar-table', 'Got correct batch shape');
-    if (batch.shape === 'columnar-table') {
-      t.equal(getTableLength(batch), 2, 'Got correct batch size');
-
-      t.ok(validateColumn(batch.data.column1, batch.length, 'string'), 'column 0 valid');
-      t.ok(validateColumn(batch.data.column2, batch.length, 'string'), 'column 1 valid');
-      t.ok(
-        validateColumn(batch.data.column3, batch.length, 'string'),
-        'column 2 is a string and is valid'
-      );
-    }
-
-    rowCount = rowCount + batch.length;
-  }
-  t.equal(rowCount, 2, 'Correct number of rows received');
-  t.end();
-});
-
-test('CSVLoader#loadInBatches(sample.csv, duplicate columns)', async t => {
-  const iterator = await loadInBatches(CSV_SAMPLE_URL_DUPLICATE_COLS, CSVLoader, {
-    csv: {shape: 'object-row-table'}
-  });
-
-  const rows: any[] = [];
-
-  for await (const batch of iterator) {
-    if (batch.shape === 'object-row-table') {
-      rows.push(...batch.data);
-    }
-  }
-
-  t.is(rows.length, 3, 'Got correct table size');
-  t.deepEqual(
-    rows,
-    [
-      {A: 'x', B: 1, 'A.1': 'y', 'A.1.1': 'z', 'A.2': 'w', 'B.1': 2},
-      {A: 'y', B: 29, 'A.1': 'z', 'A.1.1': 'y', 'A.2': 'w', 'B.1': 19},
-      {A: 'x', B: 1, 'A.1': 'y', 'A.1.1': 'z', 'A.2': 'w', 'B.1': 2}
-    ],
-    'dataset should be parsed with the corrected duplicate headers'
-  );
-
-  const iterator2 = await loadInBatches(CSV_SAMPLE_URL_DUPLICATE_COLS, CSVLoader, {
-    csv: {shape: 'array-row-table'}
-  });
-
-  const rows2: any[] = [];
-
-  for await (const batch of iterator2) {
-    if (batch.shape === 'array-row-table') {
-      rows2.push(...batch.data);
-    }
-  }
-
-  t.is(rows2.length, 3, 'Got correct table size');
-  t.deepEqual(
-    rows2,
-    [
-      ['x', 1, 'y', 'z', 'w', 2],
-      ['y', 29, 'z', 'y', 'w', 19],
-      ['x', 1, 'y', 'z', 'w', 2]
-    ],
-    'dataset should be parsed correctly as array rows'
-  );
-});
-
-test('CSVLoader#loadInBatches(skipEmptyLines greedy)', async t => {
-  const iterator = await loadInBatches(CSV_SAMPLE_URL_EMPTY_LINES, CSVLoader, {
-    csv: {shape: 'object-row-table', skipEmptyLines: 'greedy'}
-  });
-
-  const rows: unknown[] = [];
-
-  for await (const batch of iterator) {
-    t.equal(batch.shape, 'object-row-table', 'Got correct batch shape');
-    if (batch.shape === 'object-row-table') {
-      rows.push(...batch.data);
-    }
-  }
-
-  t.is(rows.length, 2, 'Got correct table size');
-  t.deepEqual(
-    rows,
-    [
-      {A: 'x', B: 1, C: 'some text'},
-      {A: 'y', B: 2, C: 'other text'}
-    ],
-    'dataset should be parsed with the correct content'
-  );
-  t.end();
-});
-
-test('CSVLoader#loadInBatches(csv with quotes)', async t => {
-  const iterator = await loadInBatches(CSV_INCIDENTS_URL_QUOTES, CSVLoader, {
-    csv: {shape: 'object-row-table'}
-  });
-
-  const rows: unknown[] = [];
-  for await (const batch of iterator) {
-    t.equal(batch.shape, 'object-row-table', 'Got correct batch shape');
-    if (batch.shape === 'object-row-table') {
-      rows.push(...batch.data);
-    }
-  }
-  t.is(rows.length, 499, 'Got the correct table size');
-  t.deepEqual(
-    rows[0],
-    {
+    expect(getTableLength(table4), 'Got correct table size (csv with quotes)').toBe(499);
+    expect(table4.data[0], 'Got correct first row (csv with quotes)').toEqual({
       IncidntNum: 160919032,
       Category: 'VANDALISM',
       Descript: 'MALICIOUS MISCHIEF, VANDALISM OF VEHICLES',
@@ -678,18 +223,375 @@ test('CSVLoader#loadInBatches(csv with quotes)', async t => {
       Resolution: 'NONE',
       Longitude: -122.4052518,
       Latitude: 37.75152496
-    },
-    'Got correct first row (csv with quotes)'
-  );
-  t.end();
+    });
+  }
 });
-
-test('CSVLoader#parseInBatches preserves UTF-8 characters split across chunks after preload', async t => {
+test('CSVLoader#load(sample.csv, duplicate column names)', async () => {
+  const table = await load(CSV_SAMPLE_URL_DUPLICATE_COLS, CSVLoader, {
+    csv: {shape: 'object-row-table'}
+  });
+  expect(table.shape, 'Got correct table shape').toBe('object-row-table');
+  if (table.shape === 'object-row-table') {
+    expect(getTableLength(table), 'Got correct table size').toBe(3);
+    expect(table.data, 'dataset should be parsed with the corrected duplicate headers').toEqual([
+      {A: 'x', B: 1, 'A.1': 'y', 'A.1.1': 'z', 'A.2': 'w', 'B.1': 2},
+      {A: 'y', B: 29, 'A.1': 'z', 'A.1.1': 'y', 'A.2': 'w', 'B.1': 19},
+      {A: 'x', B: 1, 'A.1': 'y', 'A.1.1': 'z', 'A.2': 'w', 'B.1': 2}
+    ]);
+  }
+  const table2 = await load(CSV_SAMPLE_URL_DUPLICATE_COLS, CSVLoader, {
+    csv: {shape: 'array-row-table', header: false}
+  });
+  expect(table2.shape, 'Got correct table shape').toBe('array-row-table');
+  if (table2.shape === 'array-row-table') {
+    expect(getTableLength(table2), 'Got correct table size').toBe(4);
+    expect(table2.data, 'dataset should be parsed correctly as the array rows').toEqual([
+      ['A', 'B', 'A', 'A.1', 'A', 'B'],
+      ['x', 1, 'y', 'z', 'w', 2],
+      ['y', 29, 'z', 'y', 'w', 19],
+      ['x', 1, 'y', 'z', 'w', 2]
+    ]);
+  }
+});
+// TSV
+test('CSVLoader#load(brazil.tsv)', async () => {
+  const table = await load(TSV_BRAZIL, CSVLoader);
+  expect(getTableLength(table)).toBe(10);
+});
+// loadInBatches
+test('CSVLoader#loadInBatches(sample.csv, columns)', async () => {
+  const iterator = await loadInBatches(CSV_SAMPLE_URL, CSVLoader, {
+    csv: {
+      shape: 'columnar-table'
+    }
+  });
+  expect(isAsyncIterable(iterator), 'loadInBatches returned iterator').toBeTruthy();
+  let batchCount = 0;
+  for await (const batch of iterator) {
+    // t.comment(`BATCH ${batch.count}: ${batch.length} ${JSON.stringify(batch.data).slice(0, 200)}`);
+    expect(batch.length, 'Got correct batch size').toBe(2);
+    expect(batch.shape, 'Got correct batch shape').toBe('columnar-table');
+    if (batch.shape === 'columnar-table') {
+      expect(
+        validateColumn(batch.data.column1, batch.length, 'string'),
+        'column 0 valid'
+      ).toBeTruthy();
+      expect(
+        validateColumn(batch.data.column2, batch.length, 'string'),
+        'column 1 valid'
+      ).toBeTruthy();
+      expect(
+        validateColumn(batch.data.column3, batch.length, 'float'),
+        'column 2 valid'
+      ).toBeTruthy();
+    }
+    batchCount++;
+  }
+  expect(batchCount, 'Correct number of batches received').toBe(1);
+});
+test('CSVLoader#loadInBatches(geospatial-points-wkt.csv, detectGeometryColumns)', async () => {
+  const iterator = await loadInBatches(CSV_GEOSPATIAL_WKT_URL, CSVLoader, {
+    csv: {shape: 'columnar-table', detectGeometryColumns: true},
+    batchSize: 2
+  });
+  let firstBatch: any = null;
+  for await (const batch of iterator) {
+    firstBatch = firstBatch || batch;
+  }
+  expect(firstBatch?.shape, 'Got correct batch shape').toBe('columnar-table');
+  if (firstBatch?.shape === 'columnar-table') {
+    const geometryField = firstBatch.schema?.fields.find(field => field.name === 'geometry');
+    const geoMetadata = getGeoMetadata(firstBatch.schema?.metadata);
+    expect(firstBatch.length, 'Got correct batch size').toBe(3);
+    expect(
+      geometryField?.metadata?.['ARROW:extension:name'],
+      'WKT batch geometry field is annotated as WKB'
+    ).toBe('geoarrow.wkb');
+    expect(geoMetadata?.columns.geometry.encoding, 'Batch geo metadata includes encoding').toBe(
+      'wkb'
+    );
+    expect(
+      firstBatch.data.geometry[0] instanceof Uint8Array,
+      'WKT batch geometry value is encoded'
+    ).toBeTruthy();
+  }
+});
+test('CSVLoader#load(geospatial-points-wkt.csv, arrow-table, detectGeometryColumns)', async () => {
+  const table = await load(CSV_GEOSPATIAL_WKT_URL, CSVLoader, {
+    core: {worker: false},
+    csv: {shape: 'arrow-table', detectGeometryColumns: true}
+  });
+  expect(table.shape, 'Got correct table shape').toBe('arrow-table');
+  const geometryField = table.schema?.fields.find(field => field.name === 'geometry');
+  const geoMetadata = getGeoMetadata(table.schema?.metadata);
+  expect(geometryField?.type, 'WKT Arrow geometry field is binary').toBe('binary');
+  expect(
+    geometryField?.metadata?.['ARROW:extension:name'],
+    'WKT Arrow geometry field is annotated as WKB'
+  ).toBe('geoarrow.wkb');
+  expect(geoMetadata?.columns.geometry.encoding, 'Arrow geo metadata includes WKB encoding').toBe(
+    'wkb'
+  );
+  expect(
+    table.data.getChild('geometry')?.get(0) instanceof Uint8Array,
+    'Arrow geometry is WKB'
+  ).toBeTruthy();
+});
+test('CSVLoader#loadInBatches(numbers-100.csv, shape: arrow-table)', async () => {
+  const iterator = await loadInBatches(CSV_STATES_URL, CSVLoader, {
+    core: {worker: false, batchSize: 40},
+    csv: {shape: 'arrow-table'}
+  });
+  let batchCount = 0;
+  let rowCount = 0;
+  for await (const batch of iterator) {
+    expect(batch.shape, `Got correct Arrow batch shape for batch ${batchCount}`).toBe(
+      'arrow-table'
+    );
+    rowCount += batch.data.numRows;
+    batchCount++;
+  }
+  expect(batchCount >= 1, 'Received one or more batches').toBeTruthy();
+  expect(rowCount, 'Correct number of rows received').toBe(110);
+});
+test('CSVLoader#loadInBatches(sample-very-long.csv, columns)', async () => {
+  const batchSize = 25;
+  const iterator = await loadInBatches(CSV_SAMPLE_VERY_LONG_URL, CSVLoader, {
+    csv: {
+      shape: 'columnar-table'
+    },
+    batchSize
+  });
+  let batchCount = 0;
+  for await (const batch of iterator) {
+    // t.comment(`BATCH ${batch.count}: ${batch.length} ${JSON.stringify(batch.data).slice(0, 200)}`);
+    expect(batch.length, 'Got correct batch size').toBe(batchSize);
+    expect(batch.shape, 'Got correct batch shape').toBe('columnar-table');
+    if (batch.shape === 'columnar-table') {
+      expect(
+        validateColumn(batch.data.TLD, batch.length, 'string'),
+        'column TLD valid'
+      ).toBeTruthy();
+      expect(
+        validateColumn(batch.data['meaning of life'], batch.length, 'float'),
+        'column meaning of life valid'
+      ).toBeTruthy();
+      expect(
+        validateColumn(batch.data.placeholder, batch.length, 'string'),
+        'column placeholder valid'
+      ).toBeTruthy();
+    }
+    batchCount++;
+    if (batchCount === 5) {
+      break;
+    }
+  }
+  expect(batchCount, 'Correct number of batches received').toBe(5);
+});
+test('CSVLoader#loadInBatches(sample.csv, array-rows)', async () => {
+  const iterator = await loadInBatches(CSV_SAMPLE_URL, CSVLoader, {shape: 'array-row-table'});
+  let batchCount = 0;
+  for await (const batch of iterator) {
+    // t.comment(`BATCH ${batch.count}: ${batch.length} ${JSON.stringify(batch.data).slice(0, 200)}`);
+    expect(batch.shape, 'Got correct batch shape').toBe('array-row-table');
+    if (batch.shape === 'array-row-table') {
+      expect(batch.length, 'Got correct batch size').toBe(2);
+      expect(batch.data[0], 'Got correct first row').toEqual(['A', 'B', 1]);
+    }
+    batchCount++;
+  }
+  expect(batchCount, 'Correct number of batches received').toBe(1);
+});
+test('CSVLoader#loadInBatches(sample.csv, object-rows)', async () => {
+  const iterator = await loadInBatches(CSV_SAMPLE_URL, CSVLoader, {
+    csv: {shape: 'object-row-table'}
+  });
+  let batchCount = 0;
+  for await (const batch of iterator) {
+    expect(batch.shape, 'Got correct batch shape').toBe('object-row-table');
+    if (batch.shape === 'object-row-table') {
+      // t.comment(
+      //   `BATCH ${batch.count}: ${batch.length} ${JSON.stringify(batch.data).slice(0, 200)}`
+      // );
+      expect(batch.length, 'Got correct batch size').toBe(2);
+      expect(batch.data[0], 'Got correct first row').toEqual({
+        column1: 'A',
+        column2: 'B',
+        column3: 1
+      });
+    }
+    batchCount++;
+  }
+  expect(batchCount, 'Correct number of batches received').toBe(1);
+});
+test('CSVLoader#loadInBatches(sample.csv, arrays, header)', async () => {
+  let iterator = await loadInBatches(CSV_SAMPLE_URL, CSVLoader, {
+    csv: {
+      shape: 'array-row-table',
+      header: false
+    }
+  });
+  let batchCount = 0;
+  for await (const batch of iterator) {
+    // t.comment(`BATCH ${batch.count}: ${batch.length} ${JSON.stringify(batch.data).slice(0, 200)}`);
+    expect(batch.shape, 'Got correct batch shape').toBe('array-row-table');
+    if (batch.shape === 'array-row-table') {
+      expect(batch.length, 'Got correct batch size').toBe(2);
+      expect(batch.data[0], 'Got correct first row').toEqual(['A', 'B', 1]);
+    }
+    batchCount++;
+  }
+  expect(batchCount, 'Correct number of batches received').toBe(1);
+  iterator = await loadInBatches(CSV_SAMPLE_URL, CSVLoader, {
+    csv: {header: false, shape: 'object-row-table'}
+  });
+  batchCount = 0;
+  for await (const batch of iterator) {
+    // t.comment(`BATCH ${batch.count}: ${batch.length} ${JSON.stringify(batch.data).slice(0, 200)}`);
+    expect(batch.shape, 'Got correct batch shape').toBe('object-row-table');
+    if (batch.shape === 'object-row-table') {
+      expect(batch.length, 'Got correct batch size').toBe(2);
+      expect(batch.data[0], 'Got correct first row').toEqual({
+        column1: 'A',
+        column2: 'B',
+        column3: 1
+      });
+    }
+    batchCount++;
+  }
+  expect(batchCount, 'Correct number of batches received').toBe(1);
+});
+test('CSVLoader#loadInBatches(no header, row format, prefix)', async () => {
+  const batchSize = 25;
+  const iterator = await loadInBatches(CSV_NO_HEADER_URL, CSVLoader, {
+    csv: {
+      shape: 'object-row-table',
+      columnPrefix: 'column_'
+    },
+    batchSize
+  });
+  for await (const batch of iterator) {
+    expect(batch.shape, 'Got correct batch shape').toBe('object-row-table');
+    if (batch.shape === 'object-row-table') {
+      // t.comment(JSON.stringify(batch.data[0]));
+      expect(batch.data[0].column_1, 'first column has a value').toBeTruthy();
+      expect(batch.data[0].column_2, 'second column has a value value').toBeTruthy();
+      expect(batch.data[0].column_3, 'third column has a value').toBeTruthy();
+    }
+  }
+});
+test('CSVLoader#loadInBatches(sample.csv, no dynamicTyping)', async () => {
+  const iterator = await loadInBatches(CSV_SAMPLE_URL, CSVLoader, {
+    csv: {
+      shape: 'columnar-table',
+      dynamicTyping: false,
+      // We explicitly set the header, since without dynamicTyping the first
+      // row might be detected as a header (all values would be string)
+      header: false
+    }
+  });
+  let rowCount = 0;
+  for await (const batch of iterator) {
+    // t.comment(`BATCH ${batch.count}: ${batch.length} ${JSON.stringify(batch.data).slice(0, 200)}`);
+    expect(batch.shape, 'Got correct batch shape').toBe('columnar-table');
+    if (batch.shape === 'columnar-table') {
+      expect(getTableLength(batch), 'Got correct batch size').toBe(2);
+      expect(
+        validateColumn(batch.data.column1, batch.length, 'string'),
+        'column 0 valid'
+      ).toBeTruthy();
+      expect(
+        validateColumn(batch.data.column2, batch.length, 'string'),
+        'column 1 valid'
+      ).toBeTruthy();
+      expect(
+        validateColumn(batch.data.column3, batch.length, 'string'),
+        'column 2 is a string and is valid'
+      ).toBeTruthy();
+    }
+    rowCount = rowCount + batch.length;
+  }
+  expect(rowCount, 'Correct number of rows received').toBe(2);
+});
+test('CSVLoader#loadInBatches(sample.csv, duplicate columns)', async () => {
+  const iterator = await loadInBatches(CSV_SAMPLE_URL_DUPLICATE_COLS, CSVLoader, {
+    csv: {shape: 'object-row-table'}
+  });
+  const rows: any[] = [];
+  for await (const batch of iterator) {
+    if (batch.shape === 'object-row-table') {
+      rows.push(...batch.data);
+    }
+  }
+  expect(rows.length, 'Got correct table size').toBe(3);
+  expect(rows, 'dataset should be parsed with the corrected duplicate headers').toEqual([
+    {A: 'x', B: 1, 'A.1': 'y', 'A.1.1': 'z', 'A.2': 'w', 'B.1': 2},
+    {A: 'y', B: 29, 'A.1': 'z', 'A.1.1': 'y', 'A.2': 'w', 'B.1': 19},
+    {A: 'x', B: 1, 'A.1': 'y', 'A.1.1': 'z', 'A.2': 'w', 'B.1': 2}
+  ]);
+  const iterator2 = await loadInBatches(CSV_SAMPLE_URL_DUPLICATE_COLS, CSVLoader, {
+    csv: {shape: 'array-row-table'}
+  });
+  const rows2: any[] = [];
+  for await (const batch of iterator2) {
+    if (batch.shape === 'array-row-table') {
+      rows2.push(...batch.data);
+    }
+  }
+  expect(rows2.length, 'Got correct table size').toBe(3);
+  expect(rows2, 'dataset should be parsed correctly as array rows').toEqual([
+    ['x', 1, 'y', 'z', 'w', 2],
+    ['y', 29, 'z', 'y', 'w', 19],
+    ['x', 1, 'y', 'z', 'w', 2]
+  ]);
+});
+test('CSVLoader#loadInBatches(skipEmptyLines greedy)', async () => {
+  const iterator = await loadInBatches(CSV_SAMPLE_URL_EMPTY_LINES, CSVLoader, {
+    csv: {shape: 'object-row-table', skipEmptyLines: 'greedy'}
+  });
+  const rows: unknown[] = [];
+  for await (const batch of iterator) {
+    expect(batch.shape, 'Got correct batch shape').toBe('object-row-table');
+    if (batch.shape === 'object-row-table') {
+      rows.push(...batch.data);
+    }
+  }
+  expect(rows.length, 'Got correct table size').toBe(2);
+  expect(rows, 'dataset should be parsed with the correct content').toEqual([
+    {A: 'x', B: 1, C: 'some text'},
+    {A: 'y', B: 2, C: 'other text'}
+  ]);
+});
+test('CSVLoader#loadInBatches(csv with quotes)', async () => {
+  const iterator = await loadInBatches(CSV_INCIDENTS_URL_QUOTES, CSVLoader, {
+    csv: {shape: 'object-row-table'}
+  });
+  const rows: unknown[] = [];
+  for await (const batch of iterator) {
+    expect(batch.shape, 'Got correct batch shape').toBe('object-row-table');
+    if (batch.shape === 'object-row-table') {
+      rows.push(...batch.data);
+    }
+  }
+  expect(rows.length, 'Got the correct table size').toBe(499);
+  expect(rows[0], 'Got correct first row (csv with quotes)').toEqual({
+    IncidntNum: 160919032,
+    Category: 'VANDALISM',
+    Descript: 'MALICIOUS MISCHIEF, VANDALISM OF VEHICLES',
+    DayOfWeek: 'Friday',
+    DateTime: '11/11/16 7:00',
+    PdDistrict: 'MISSION',
+    Address: '1400 Block of UTAH ST',
+    Resolution: 'NONE',
+    Longitude: -122.4052518,
+    Latitude: 37.75152496
+  });
+});
+test('CSVLoader#parseInBatches preserves UTF-8 characters split across chunks after preload', async () => {
   const csvText = 'city\nZürich\n東京\n';
   const csvBytes = new TextEncoder().encode(csvText);
   const splitIndex = csvBytes.indexOf(0xc3) + 1;
   const preloadedLoader = await preload(CSVLoader);
-
   const iterator = await parseInBatches(
     [csvBytes.subarray(0, splitIndex), csvBytes.subarray(splitIndex)],
     preloadedLoader,
@@ -700,28 +602,21 @@ test('CSVLoader#parseInBatches preserves UTF-8 characters split across chunks af
       }
     }
   );
-
   const rows: unknown[] = [];
   for await (const batch of iterator) {
     if (batch.shape === 'object-row-table') {
       rows.push(...batch.data);
     }
   }
-
-  t.deepEqual(rows, [{city: 'Zürich'}, {city: '東京'}], 'preserves split UTF-8 characters');
-  t.end();
+  expect(rows, 'preserves split UTF-8 characters').toEqual([{city: 'Zürich'}, {city: '東京'}]);
 });
-
-test('CSV parser loaders are available through direct implementation imports', async t => {
+test('CSV parser loaders are available through direct implementation imports', async () => {
   const preloadedLoader = await preload(CSVLoader);
   const csvTable = await parse('city,population\nParis,2148000', preloadedLoader, {
     csv: {shape: 'object-row-table'}
   });
-
-  t.equal(csvTable.shape, 'object-row-table', 'preloaded CSV loader parses text directly');
-  t.end();
+  expect(csvTable.shape, 'preloaded CSV loader parses text directly').toBe('object-row-table');
 });
-
 function validateColumn(column, length, type) {
   if (column.length !== length) {
     return `column length should be ${length}`;
@@ -731,14 +626,11 @@ function validateColumn(column, length, type) {
     case 'string':
       validator = d => typeof d === 'string';
       break;
-
     case 'float':
       validator = d => Number.isFinite(d);
       break;
-
     default:
       return null;
   }
-
   return column.every(validator) ? true : `column elements are not all ${type}s`;
 }

--- a/modules/csv/test/csv-writer.spec.ts
+++ b/modules/csv/test/csv-writer.spec.ts
@@ -1,23 +1,15 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-// Copyright 2022 Foursquare Labs, Inc.
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {CSVLoader, CSVWriterOptions, CSVWriter} from '@loaders.gl/csv';
 import {encodeTableAsText, parse, preload} from '@loaders.gl/core';
-
 import {Table} from '@loaders.gl/schema';
 import {convertTable} from '@loaders.gl/schema-utils';
 import {makeTestTable, tableWithGeometryColumn} from '@loaders.gl/schema-utils/test/shared-utils';
-
 type TestCase = {
   name: string;
   options?: CSVWriterOptions;
   input: Table;
   expected: any;
 };
-
 const cases: TestCase[] = [
   {
     name: 'empty table',
@@ -139,17 +131,13 @@ b,2
 c,3`
   }
 ];
-
-test('CSVWriter ', async t => {
+test('CSVWriter ', async () => {
   for (const {name, input, options, expected} of cases) {
     const output = await encodeTableAsText(input, CSVWriter, options);
-    t.equal(output, expected, name);
+    expect(output, name).toBe(expected);
   }
-
-  t.end();
 });
-
-test('CSVWriter#arrow-table ', async t => {
+test('CSVWriter#arrow-table ', async () => {
   const preloadedLoader = await preload(CSVLoader);
   for (const {name, input, options, expected} of cases) {
     const arrowInput =
@@ -164,8 +152,6 @@ test('CSVWriter#arrow-table ', async t => {
             }
           });
     const output = await encodeTableAsText(arrowInput, CSVWriter, options);
-    t.equal(output, expected, name);
+    expect(output, name).toBe(expected);
   }
-
-  t.end();
 });

--- a/modules/csv/test/papaparse/papaparse.spec.ts
+++ b/modules/csv/test/papaparse/papaparse.spec.ts
@@ -263,13 +263,13 @@ const CUSTOM_TESTS = [
         chunkSize: 10,
         chunk(response, h) {
           updates.push(response.data);
-          if (!first) return;
+          if (!first) {
+            callback(updates);
+            return;
+          }
           handle = h;
           handle.pause();
           first = false;
-        },
-        complete() {
-          callback(updates);
         }
       });
       setTimeout(() => {
@@ -288,10 +288,8 @@ const CUSTOM_TESTS = [
           if (response.data.length) {
             updates.push(response.data);
             handle.abort();
+            callback(updates);
           }
-        },
-        complete(response) {
-          callback(updates);
         }
       });
     }
@@ -533,31 +531,40 @@ test('papaparse#Parse Tests', () => {
     }
   }
 });
-test('Parse Async Tests', () => {
-  for (const testCase of PARSE_ASYNC_TESTS) {
-    if (!testCase.disabled) {
-      const config: any = testCase.config;
-      config.complete = function (actual) {
-        expect(JSON.stringify(actual.errors), testCase.description).toEqual(
-          JSON.stringify(testCase.expected.errors)
-        );
-        expect(actual.data, testCase.description).toEqual(testCase.expected.data);
-      };
-      config.error = function (err) {
-        throw err;
-      };
-      Papa.parse(testCase.input, config);
-    }
-  }
+test.each(
+  PARSE_ASYNC_TESTS.filter(testCase => !testCase.disabled)
+)('papaparse#Parse Async Tests: $description', async testCase => {
+  await new Promise<void>((resolve, reject) => {
+    Papa.parse(testCase.input, {
+      ...testCase.config,
+      complete(actual) {
+        try {
+          expect(JSON.stringify(actual.errors), testCase.description).toEqual(
+            JSON.stringify(testCase.expected.errors)
+          );
+          expect(actual.data, testCase.description).toEqual(testCase.expected.data);
+          resolve();
+        } catch (error) {
+          reject(error);
+        }
+      },
+      error: reject
+    });
+  });
 });
-test('papaparse#Custom Tests', () => {
-  for (const testCase of CUSTOM_TESTS) {
-    if (!testCase.disabled) {
-      testCase.run(function (actual) {
+test.each(
+  CUSTOM_TESTS.filter(testCase => !testCase.disabled)
+)('papaparse#Custom Tests: $description', async testCase => {
+  await new Promise<void>((resolve, reject) => {
+    testCase.run(actual => {
+      try {
         expect(JSON.stringify(actual), testCase.description).toEqual(
           JSON.stringify(testCase.expected)
         );
-      });
-    }
-  }
+        resolve();
+      } catch (error) {
+        reject(error);
+      }
+    });
+  });
 });

--- a/modules/csv/test/papaparse/papaparse.spec.ts
+++ b/modules/csv/test/papaparse/papaparse.spec.ts
@@ -1,22 +1,10 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-// Copyright (c) 2015 Matthew Holt
-
-// This is a fork of papaparse v5.0.0-beta.0 under MIT license
-// https://github.com/mholt/PapaParse
-
-/* eslint-disable quotes, no-var, prefer-template, curly */
-import test from 'test/utils/vitest-tape';
-
+import {expect, test} from 'vitest';
 import Papa from '../../src/papaparse/papaparse';
 import {CORE_PARSER_TESTS, PARSE_TESTS, PARSE_ASYNC_TESTS} from './csv-test-cases';
-
 const __dirname = import.meta.dirname;
 const BASE_PATH = `${__dirname}/../../data/csv/`;
 const FILES_ENABLED = false;
 const XHR_ENABLED = false;
-
 const CUSTOM_TESTS = [
   {
     description: 'Complete is called with all results if neither step nor chunk is defined',
@@ -518,312 +506,58 @@ const CUSTOM_TESTS = [
     }
   }
 ];
-
-test('papaparse#Core Parser Tests', t => {
+test('papaparse#Core Parser Tests', () => {
   for (const testCase of CORE_PARSER_TESTS) {
     if (!testCase.disabled) {
       // @ts-ignore
       var actual = new Papa.Parser(testCase.config).parse(testCase.input);
-      t.deepEqual(
-        JSON.stringify(actual.errors),
-        JSON.stringify(testCase.expected.errors),
-        testCase.description
+      expect(JSON.stringify(actual.errors), testCase.description).toEqual(
+        JSON.stringify(testCase.expected.errors)
       );
-      t.deepEqual(actual.data, testCase.expected.data, testCase.description);
+      expect(actual.data, testCase.description).toEqual(testCase.expected.data);
     }
   }
-  t.end();
 });
-
-test('papaparse#Parse Tests', t => {
+test('papaparse#Parse Tests', () => {
   for (const testCase of PARSE_TESTS) {
     if (!testCase.disabled) {
       const actual = Papa.parse(testCase.input, testCase.config);
       // allows for testing the meta object if present in the test
       if (testCase.expected.meta) {
-        t.deepEqual(actual.meta, testCase.expected.meta, testCase.description);
+        expect(actual.meta, testCase.description).toEqual(testCase.expected.meta);
       }
-      t.deepEqual(
-        JSON.stringify(actual.errors),
-        JSON.stringify(testCase.expected.errors),
-        testCase.description
+      expect(JSON.stringify(actual.errors), testCase.description).toEqual(
+        JSON.stringify(testCase.expected.errors)
       );
-      t.deepEqual(actual.data, testCase.expected.data, testCase.description);
+      expect(actual.data, testCase.description).toEqual(testCase.expected.data);
     }
   }
-  t.end();
 });
-
-test('Parse Async Tests', t => {
+test('Parse Async Tests', () => {
   for (const testCase of PARSE_ASYNC_TESTS) {
     if (!testCase.disabled) {
       const config: any = testCase.config;
-
       config.complete = function (actual) {
-        t.deepEqual(
-          JSON.stringify(actual.errors),
-          JSON.stringify(testCase.expected.errors),
-          testCase.description
+        expect(JSON.stringify(actual.errors), testCase.description).toEqual(
+          JSON.stringify(testCase.expected.errors)
         );
-        t.deepEqual(actual.data, testCase.expected.data, testCase.description);
-        t.end();
+        expect(actual.data, testCase.description).toEqual(testCase.expected.data);
       };
-
       config.error = function (err) {
-        t.end();
         throw err;
       };
-
       Papa.parse(testCase.input, config);
     }
   }
 });
-
-test('papaparse#Custom Tests', t => {
+test('papaparse#Custom Tests', () => {
   for (const testCase of CUSTOM_TESTS) {
     if (!testCase.disabled) {
       testCase.run(function (actual) {
-        t.deepEqual(
-          JSON.stringify(actual),
-          JSON.stringify(testCase.expected),
-          testCase.description
+        expect(JSON.stringify(actual), testCase.description).toEqual(
+          JSON.stringify(testCase.expected)
         );
-        t.end();
       });
     }
   }
 });
-
-/*
-function assertLongSampleParsedCorrectly(parsedCsv) {
-  assert.equal(8, parsedCsv.data.length);
-  assert.deepEqual(parsedCsv.data[0], [
-    'Grant',
-    'Dyer',
-    'Donec.elementum@orciluctuset.example',
-    '2013-11-23T02:30:31-08:00',
-    '2014-05-31T01:06:56-07:00',
-    'Magna Ut Associates',
-    'ljenkins'
-  ]);
-  assert.deepEqual(parsedCsv.data[7], [
-    'Talon',
-    'Salinas',
-    'posuere.vulputate.lacus@Donecsollicitudin.example',
-    '2015-01-31T09:19:02-08:00',
-    '2014-12-17T04:59:18-08:00',
-    'Aliquam Iaculis Incorporate',
-    'Phasellus@Quisquetincidunt.example'
-  ]);
-  assert.deepEqual(parsedCsv.meta, {
-    delimiter: ",",
-    linebreak: "\n",
-    aborted: false,
-    truncated: false,
-    cursor: 1209
-  });
-  assert.equal(parsedCsv.errors.length, 0);
-}
-
-test('CSVLoader#PapaParse', t => {
-  it('synchronously parsed CSV should be correctly parsed', () => {
-    assertLongSampleParsedCorrectly(Papa.parse(longSampleRawCsv));
-  });
-
-  it('asynchronously parsed CSV should be correctly parsed', function(done) {
-    Papa.parse(longSampleRawCsv, {
-      complete(parsedCsv) {
-        assertLongSampleParsedCorrectly(parsedCsv);
-        done();
-      },
-    });
-  });
-
-  it('asynchronously parsed streaming CSV should be correctly parsed', function(done) {
-    Papa.parse(fs.createReadStream(__dirname + '/long-sample.csv', 'utf8'), {
-      complete(parsedCsv) {
-        assertLongSampleParsedCorrectly(parsedCsv);
-        done();
-      },
-    });
-  });
-
-  it('reports the correct row number on FieldMismatch errors', function(done) {
-    Papa.parse(fs.createReadStream(__dirname + '/verylong-sample.csv'), {
-      header: true,
-      fastMode: true,
-      complete(parsedCsv) {
-        assert.deepEqual(parsedCsv.errors, [
-          {
-            type: "FieldMismatch",
-            code: "TooFewFields",
-            message: "Too few fields: expected 3 fields but parsed 2",
-            row: 498
-          },
-          {
-            type: "FieldMismatch",
-            code: "TooFewFields",
-            message: "Too few fields: expected 3 fields but parsed 2",
-            row: 998
-          },
-          {
-            type: "FieldMismatch",
-            code: "TooFewFields",
-            message: "Too few fields: expected 3 fields but parsed 2",
-            row: 1498
-          },
-          {
-            type: "FieldMismatch",
-            code: "TooFewFields",
-            message: "Too few fields: expected 3 fields but parsed 2",
-            row: 1998
-          }
-        ]);
-        assert.strictEqual(2000, parsedCsv.data.length);
-        done();
-      },
-    });
-  });
-
-  it('piped streaming CSV should be correctly parsed', function(done) {
-    const data: any[] = [];
-    var readStream = fs.createReadStream(__dirname + '/long-sample.csv', 'utf8');
-    var csvStream = readStream.pipe(Papa.parse(Papa.NODE_STREAM_INPUT));
-    csvStream.on('data', function(item) {
-      data.push(item);
-    });
-    csvStream.on('end', () => {
-      assert.deepEqual(data[0], [
-        'Grant',
-        'Dyer',
-        'Donec.elementum@orciluctuset.example',
-        '2013-11-23T02:30:31-08:00',
-        '2014-05-31T01:06:56-07:00',
-        'Magna Ut Associates',
-        'ljenkins'
-      ]);
-      assert.deepEqual(data[7], [
-        'Talon',
-        'Salinas',
-        'posuere.vulputate.lacus@Donecsollicitudin.example',
-        '2015-01-31T09:19:02-08:00',
-        '2014-12-17T04:59:18-08:00',
-        'Aliquam Iaculis Incorporate',
-        'Phasellus@Quisquetincidunt.example'
-      ]);
-      done();
-    });
-  });
-
-  it('should support pausing and resuming on same tick when streaming', function(done) {
-    var rows = [];
-    Papa.parse(fs.createReadStream(__dirname + '/long-sample.csv', 'utf8'), {
-      chunk(results, parser) {
-        rows = rows.concat(results.data);
-        parser.pause();
-        parser.resume();
-      },
-      error(err) {
-        done(new Error(err));
-      },
-      complete() {
-        assert.deepEqual(rows[0], [
-          'Grant',
-          'Dyer',
-          'Donec.elementum@orciluctuset.example',
-          '2013-11-23T02:30:31-08:00',
-          '2014-05-31T01:06:56-07:00',
-          'Magna Ut Associates',
-          'ljenkins'
-        ]);
-        assert.deepEqual(rows[7], [
-          'Talon',
-          'Salinas',
-          'posuere.vulputate.lacus@Donecsollicitudin.example',
-          '2015-01-31T09:19:02-08:00',
-          '2014-12-17T04:59:18-08:00',
-          'Aliquam Iaculis Incorporate',
-          'Phasellus@Quisquetincidunt.example'
-        ]);
-        done();
-      }
-    });
-  });
-
-  it('should support pausing and resuming asynchronously when streaming', function(done) {
-    var rows = [];
-    Papa.parse(fs.createReadStream(__dirname + '/long-sample.csv', 'utf8'), {
-      chunk(results, parser) {
-        rows = rows.concat(results.data);
-        parser.pause();
-        setTimeout(() => {
-          parser.resume();
-        }, 200);
-      },
-      error(err) {
-        done(new Error(err));
-      },
-      complete() {
-        assert.deepEqual(rows[0], [
-          'Grant',
-          'Dyer',
-          'Donec.elementum@orciluctuset.example',
-          '2013-11-23T02:30:31-08:00',
-          '2014-05-31T01:06:56-07:00',
-          'Magna Ut Associates',
-          'ljenkins'
-        ]);
-        assert.deepEqual(rows[7], [
-          'Talon',
-          'Salinas',
-          'posuere.vulputate.lacus@Donecsollicitudin.example',
-          '2015-01-31T09:19:02-08:00',
-          '2014-12-17T04:59:18-08:00',
-          'Aliquam Iaculis Incorporate',
-          'Phasellus@Quisquetincidunt.example'
-        ]);
-        done();
-      }
-    });
-  });
-
-  it('handles errors in beforeFirstChunk', function(done) {
-    var expectedError = new Error('test');
-    Papa.parse(fs.createReadStream(__dirname + '/long-sample.csv', 'utf8'), {
-      beforeFirstChunk() {
-        throw expectedError;
-      },
-      error(err) {
-        assert.deepEqual(err, expectedError);
-        done();
-      }
-    });
-  });
-
-  it('handles errors in chunk', function(done) {
-    var expectedError = new Error('test');
-    Papa.parse(fs.createReadStream(__dirname + '/long-sample.csv', 'utf8'), {
-      chunk() {
-        throw expectedError;
-      },
-      error(err) {
-        assert.deepEqual(err, expectedError);
-        done();
-      }
-    });
-  });
-
-  it('handles errors in step', function(done) {
-    var expectedError = new Error('test');
-    Papa.parse(fs.createReadStream(__dirname + '/long-sample.csv', 'utf8'), {
-      step() {
-        throw expectedError;
-      },
-      error(err) {
-        assert.deepEqual(err, expectedError);
-        done();
-      }
-    });
-  });
-});
-*/

--- a/modules/draco/test/draco-arrow-loader.spec.ts
+++ b/modules/draco/test/draco-arrow-loader.spec.ts
@@ -1,11 +1,5 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-/* eslint-disable max-len */
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {validateLoader} from 'test/common/conformance';
-
 import {DracoLoader} from '@loaders.gl/draco';
 import * as draco from '@loaders.gl/draco';
 import * as bundledDraco from '@loaders.gl/draco/bundled';
@@ -14,28 +8,27 @@ import {setLoaderOptions, load, isBrowser} from '@loaders.gl/core';
 import {validateArrowTableSchema} from '@loaders.gl/arrow';
 import {indexedMeshArrowSchema, meshArrowSchema} from '@loaders.gl/schema';
 import draco3d from 'draco3d';
-
 const BUNNY_DRC_URL = '@loaders.gl/draco/test/data/bunny.drc';
 const CESIUM_TILE_URL = '@loaders.gl/draco/test/data/cesium-tile.drc';
-
 setLoaderOptions({
   _workerType: 'test'
 });
-
-test('DracoLoader#loader conformance', t => {
-  validateLoader(t, DracoLoader, 'DracoLoader');
-  t.end();
+test('DracoLoader#loader conformance', () => {
+  validateLoader(DracoLoader, 'DracoLoader');
 });
-
-test('DracoLoader#removed Arrow loader exports', t => {
-  t.notOk('DracoArrowLoader' in draco, 'root does not export DracoArrowLoader');
-  t.notOk('DracoArrowLoader' in bundledDraco, 'bundled does not export DracoArrowLoader');
-  t.notOk('DracoArrowLoader' in unbundledDraco, 'unbundled does not export DracoArrowLoader');
-  t.end();
+test('DracoLoader#removed Arrow loader exports', () => {
+  expect('DracoArrowLoader' in draco, 'root does not export DracoArrowLoader').toBeFalsy();
+  expect(
+    'DracoArrowLoader' in bundledDraco,
+    'bundled does not export DracoArrowLoader'
+  ).toBeFalsy();
+  expect(
+    'DracoArrowLoader' in unbundledDraco,
+    'unbundled does not export DracoArrowLoader'
+  ).toBeFalsy();
 });
-
-test('DracoLoader#parse(mainthread, shape: arrow-table)', async t => {
-  if (skipBrowserDracoWasmTest(t)) {
+test('DracoLoader#parse(mainthread, shape: arrow-table)', async () => {
+  if (skipBrowserDracoWasmTest()) {
     return;
   }
   const table = await load(BUNNY_DRC_URL, DracoLoader, {
@@ -44,16 +37,14 @@ test('DracoLoader#parse(mainthread, shape: arrow-table)', async t => {
   });
   // validateMeshCategoryData(t, data);
   const {data} = table;
-  validateDracoMeshArrowTable(t, table);
-  t.equal(data.numRows, 104502 / 3, 'number of rows is correct');
+  validateDracoMeshArrowTable(table);
+  expect(data.numRows, 'number of rows is correct').toBe(104502 / 3);
   const positions = data.getChild('POSITION')!;
-  t.ok(positions, 'POSITION attribute was found');
-  t.ok(data.schema, 'Has arrow-like schema');
-  t.end();
+  expect(positions, 'POSITION attribute was found').toBeTruthy();
+  expect(data.schema, 'Has arrow-like schema').toBeTruthy();
 });
-
-test('DracoLoader#draco3d npm package with shape: arrow-table', async t => {
-  if (skipBrowserDracoWasmTest(t)) {
+test('DracoLoader#draco3d npm package with shape: arrow-table', async () => {
+  if (skipBrowserDracoWasmTest()) {
     return;
   }
   const table = await load(BUNNY_DRC_URL, DracoLoader, {
@@ -65,32 +56,27 @@ test('DracoLoader#draco3d npm package with shape: arrow-table', async t => {
   });
   const {data} = table;
   // validateMeshCategoryData(t, data);
-  validateDracoMeshArrowTable(t, table);
-  t.ok(data.getChild('POSITION'), 'POSITION attribute was found');
-  t.end();
+  validateDracoMeshArrowTable(table);
+  expect(data.getChild('POSITION'), 'POSITION attribute was found').toBeTruthy();
 });
-
-test('DracoLoader#parse custom attributes(mainthread, shape: arrow-table)', async t => {
-  if (skipBrowserDracoWasmTest(t)) {
+test('DracoLoader#parse custom attributes(mainthread, shape: arrow-table)', async () => {
+  if (skipBrowserDracoWasmTest()) {
     return;
   }
   let table = await load(CESIUM_TILE_URL, DracoLoader, {
     worker: false,
     draco: {shape: 'arrow-table'}
   });
-  validateDracoMeshArrowTable(t, table);
+  validateDracoMeshArrowTable(table);
   const {data} = table;
-  t.equal(
+  expect(
     data.getChild('CUSTOM_ATTRIBUTE_2')?.data[0].length,
-    173210,
     'Custom (Intensity) attribute was found'
-  );
-  t.equal(
+  ).toBe(173210);
+  expect(
     data.getChild('CUSTOM_ATTRIBUTE_3')?.data[0].length,
-    173210,
     'Custom (Classification) attribute was found'
-  );
-
+  ).toBe(173210);
   table = await load(CESIUM_TILE_URL, DracoLoader, {
     worker: false,
     draco: {
@@ -101,43 +87,35 @@ test('DracoLoader#parse custom attributes(mainthread, shape: arrow-table)', asyn
       }
     }
   });
-  validateDracoMeshArrowTable(t, table);
-  t.equal(
-    table.data.getChild('Intensity')?.data[0].length,
-    173210,
-    'Intensity attribute was found'
+  validateDracoMeshArrowTable(table);
+  expect(table.data.getChild('Intensity')?.data[0].length, 'Intensity attribute was found').toBe(
+    173210
   );
-  t.equal(
+  expect(
     table.data.getChild('Classification')?.data[0].length,
-    173210,
     'Classification attribute was found'
-  );
-
-  t.end();
+  ).toBe(173210);
 });
-
 /**
  * Skips Draco Arrow tests that depend on direct WASM module initialization in browser runs.
  */
-function skipBrowserDracoWasmTest(t) {
+function skipBrowserDracoWasmTest() {
   if (isBrowser) {
-    t.comment('Skipping Draco WASM main-thread test in browser');
-    t.end();
+    console.log('Skipping Draco WASM main-thread test in browser');
     return true;
   }
   return false;
 }
-
 /**
  * Validates a Draco Arrow mesh table against the shared Mesh or IndexedMesh Arrow schema.
  */
-function validateDracoMeshArrowTable(t, table) {
+function validateDracoMeshArrowTable(table) {
   const expectedSchema = table.data.getChild('indices') ? indexedMeshArrowSchema : meshArrowSchema;
-  t.doesNotThrow(
+  expect(
     () =>
       validateArrowTableSchema(table.data, expectedSchema, {
         schemaName: 'DracoLoader Mesh table'
       }),
     'Draco Arrow table matches the expected mesh Arrow schema'
-  );
+  ).not.toThrow();
 }

--- a/modules/draco/test/draco-compression-ratio.spec.ts
+++ b/modules/draco/test/draco-compression-ratio.spec.ts
@@ -1,49 +1,36 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-/* eslint-disable max-len */
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {fetchFile, parse, encode} from '@loaders.gl/core';
 // import {getMeshSize} from '@loaders.gl/schema-utils';
 import {DracoWriter, DracoLoader} from '@loaders.gl/draco';
 import {validateMeshCategoryData} from 'test/common/conformance';
 import {isBrowser} from '@loaders.gl/worker-utils';
-
 const POSITIONS_URL = '@loaders.gl/draco/test/data/raw-attribute-buffers/lidar-positions.bin';
 const COLORS_URL = '@loaders.gl/draco/test/data/raw-attribute-buffers/lidar-colors.bin';
-
-test('DracoWriter#compressRawBuffers', async t => {
+test('DracoWriter#compressRawBuffers', async () => {
   if (isBrowser) {
-    t.comment('Skipping Draco WASM writer test in browser');
-    t.end();
+    console.log('Skipping Draco WASM writer test in browser');
     return;
   }
   const POSITIONS = await fetchFile(POSITIONS_URL).then(response => response.arrayBuffer());
   const COLORS = await fetchFile(COLORS_URL).then(response => response.arrayBuffer());
-
   const attributes = {
     POSITION: new Float32Array(POSITIONS),
     COLOR_0: new Uint8ClampedArray(COLORS)
   };
-
   // t.comment(
   //   `Encoding ${attributes.POSITION.length} positions, ${attributes.COLOR_0.length} colors...`
   // );
-
   // Encode mesh
   // TODO - Replace with draco writer
   const compressedMesh = await encode({attributes}, DracoWriter, {draco: {pointcloud: true}});
   // const meshSize = getMeshSize(attributes);
   // const ratio = meshSize / compressedMesh.byteLength;
   // t.comment(`Draco compression ${compressedMesh.byteLength} bytes, ratio ${ratio.toFixed(1)}`);
-
   // Ensure we can parse it
   const data2 = await parse(compressedMesh, DracoLoader);
-  validateMeshCategoryData(t, data2);
-
-  t.equal(data2.attributes.POSITION.value.length, attributes.POSITION.length, 'POSITION matched');
-  t.equal(data2.attributes.COLOR_0.value.length, attributes.COLOR_0.length, 'COLOR matched');
-
-  t.end();
+  validateMeshCategoryData(data2);
+  expect(data2.attributes.POSITION.value.length, 'POSITION matched').toBe(
+    attributes.POSITION.length
+  );
+  expect(data2.attributes.COLOR_0.value.length, 'COLOR matched').toBe(attributes.COLOR_0.length);
 });

--- a/modules/draco/test/draco-loader.spec.ts
+++ b/modules/draco/test/draco-loader.spec.ts
@@ -1,72 +1,54 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-/* eslint-disable max-len */
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {validateLoader, validateMeshCategoryData} from 'test/common/conformance';
-
 import {DracoLoader, DracoWorkerLoader} from '@loaders.gl/draco';
 import {setLoaderOptions, load, isBrowser} from '@loaders.gl/core';
 import draco3d from 'draco3d';
-
 const BUNNY_DRC_URL = '@loaders.gl/draco/test/data/bunny.drc';
 const CESIUM_TILE_URL = '@loaders.gl/draco/test/data/cesium-tile.drc';
-
 setLoaderOptions({
   _workerType: 'test'
 });
-
-test('DracoLoader#loader conformance', t => {
-  validateLoader(t, DracoLoader, 'DracoLoader');
-  validateLoader(t, DracoWorkerLoader, 'DracoWorkerLoader');
-  t.end();
+test('DracoLoader#loader conformance', () => {
+  validateLoader(DracoLoader, 'DracoLoader');
+  validateLoader(DracoWorkerLoader, 'DracoWorkerLoader');
 });
-
-test('DracoLoader#parse(mainthread)', async t => {
-  if (skipBrowserDracoWasmTest(t)) {
+test('DracoLoader#parse(mainthread)', async () => {
+  if (skipBrowserDracoWasmTest()) {
     return;
   }
   const data = await load(BUNNY_DRC_URL, DracoLoader, {
     core: {worker: false}
   });
-  validateMeshCategoryData(t, data);
-  t.equal(data.attributes.POSITION.value.length, 104502, 'POSITION attribute was found');
-  t.ok(data.schema, 'Has arrow-like schema');
-  t.end();
+  validateMeshCategoryData(data);
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(104502);
+  expect(data.schema, 'Has arrow-like schema').toBeTruthy();
 });
-
-test('DracoLoader#draco3d npm package', async t => {
-  if (skipBrowserDracoWasmTest(t)) {
+test('DracoLoader#draco3d npm package', async () => {
+  if (skipBrowserDracoWasmTest()) {
     return;
   }
   const data = await load(BUNNY_DRC_URL, DracoLoader, {
     core: {worker: false},
     modules: {draco3d}
   });
-  validateMeshCategoryData(t, data);
-  t.equal(data.attributes.POSITION.value.length, 104502, 'POSITION attribute was found');
-  t.end();
+  validateMeshCategoryData(data);
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(104502);
 });
-
-test('DracoLoader#parse custom attributes(mainthread)', async t => {
-  if (skipBrowserDracoWasmTest(t)) {
+test('DracoLoader#parse custom attributes(mainthread)', async () => {
+  if (skipBrowserDracoWasmTest()) {
     return;
   }
   let data = await load(CESIUM_TILE_URL, DracoLoader, {
     core: {worker: false}
   });
-  t.equal(
+  expect(
     data.attributes.CUSTOM_ATTRIBUTE_2.value.length,
-    173210,
     'Custom (Intensity) attribute was found'
-  );
-  t.equal(
+  ).toBe(173210);
+  expect(
     data.attributes.CUSTOM_ATTRIBUTE_3.value.length,
-    173210,
     'Custom (Classification) attribute was found'
-  );
-
+  ).toBe(173210);
   data = await load(CESIUM_TILE_URL, DracoLoader, {
     core: {worker: false},
     draco: {
@@ -76,32 +58,23 @@ test('DracoLoader#parse custom attributes(mainthread)', async t => {
       }
     }
   });
-  t.equal(data.attributes.Intensity.value.length, 173210, 'Intensity attribute was found');
-  t.equal(
-    data.attributes.Classification.value.length,
-    173210,
-    'Classification attribute was found'
+  expect(data.attributes.Intensity.value.length, 'Intensity attribute was found').toBe(173210);
+  expect(data.attributes.Classification.value.length, 'Classification attribute was found').toBe(
+    173210
   );
-
-  t.end();
 });
-
 /**
  * Skips Draco tests that depend on direct WASM module initialization in browser runs.
  */
-function skipBrowserDracoWasmTest(t) {
+function skipBrowserDracoWasmTest() {
   if (isBrowser) {
-    t.comment('Skipping Draco WASM main-thread test in browser');
-    t.end();
+    console.log('Skipping Draco WASM main-thread test in browser');
     return true;
   }
   return false;
 }
-
-test('DracoWorkerLoader#parse', async t => {
+test('DracoWorkerLoader#parse', async () => {
   const data = await load(BUNNY_DRC_URL, DracoWorkerLoader, {_nodeWorkers: true});
-  validateMeshCategoryData(t, data);
-  t.equal(data.attributes.POSITION.value.length, 104502, 'POSITION attribute was found');
-
-  t.end();
+  validateMeshCategoryData(data);
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(104502);
 });

--- a/modules/draco/test/draco-module-loader.spec.ts
+++ b/modules/draco/test/draco-module-loader.spec.ts
@@ -1,45 +1,32 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import draco3d from 'draco3d';
 import {isBrowser} from '@loaders.gl/worker-utils';
-
 import {DracoLoader} from '../src/draco-loader';
 import {Draco3DLoaderWithParser} from '../src/draco3d-loader-with-parser';
 import {DracoJavaScriptLoaderWithParser} from '../src/draco-javascript-loader-with-parser';
 import {DracoWASMLoaderWithParser} from '../src/draco-wasm-loader-with-parser';
 import {loadDracoDecoderModule, loadDracoEncoderModule} from '../src/lib/draco-module-loader';
-
-test('DracoLoader#preload selects backend loader', async t => {
-  t.equal(
+test('DracoLoader#preload selects backend loader', async () => {
+  expect(
     await DracoLoader.preload?.('', {draco: {backend: 'wasm'}}),
-    DracoWASMLoaderWithParser,
     'selects the WASM backend loader'
-  );
-  t.equal(
+  ).toBe(DracoWASMLoaderWithParser);
+  expect(
     await DracoLoader.preload?.('', {draco: {backend: 'javascript'}}),
-    DracoJavaScriptLoaderWithParser,
     'selects the JavaScript backend loader'
-  );
-  t.equal(
+  ).toBe(DracoJavaScriptLoaderWithParser);
+  expect(
     await DracoLoader.preload?.('', {draco: {backend: 'draco3d'}, modules: {draco3d}}),
-    Draco3DLoaderWithParser,
     'selects the injected draco3d backend loader'
-  );
-  t.equal(
+  ).toBe(Draco3DLoaderWithParser);
+  expect(
     await DracoLoader.preload?.('', {draco: {decoderType: 'js'}}),
-    DracoJavaScriptLoaderWithParser,
     'maps legacy decoderType to the JavaScript backend loader'
-  );
-  t.end();
+  ).toBe(DracoJavaScriptLoaderWithParser);
 });
-
-test('draco-module-loader#uses injected decoder module', async t => {
+test('draco-module-loader#uses injected decoder module', async () => {
   if (isBrowser) {
-    t.comment('Skipping Draco WASM module test in browser');
-    t.end();
+    console.log('Skipping Draco WASM module test in browser');
     return;
   }
   const module = await loadDracoDecoderModule(
@@ -50,15 +37,11 @@ test('draco-module-loader#uses injected decoder module', async t => {
     },
     'wasm'
   );
-
-  t.ok(module.draco, 'returns a decoder instance from the injected draco3d package');
-  t.end();
+  expect(module.draco, 'returns a decoder instance from the injected draco3d package').toBeTruthy();
 });
-
-test('draco-module-loader#uses injected encoder module', async t => {
+test('draco-module-loader#uses injected encoder module', async () => {
   if (isBrowser) {
-    t.comment('Skipping Draco WASM module test in browser');
-    t.end();
+    console.log('Skipping Draco WASM module test in browser');
     return;
   }
   const module = await loadDracoEncoderModule({
@@ -66,7 +49,8 @@ test('draco-module-loader#uses injected encoder module', async t => {
       draco3d
     }
   });
-
-  t.ok(module.draco, 'returns an encoder instance from the injected draco3d package');
-  t.end();
+  expect(
+    module.draco,
+    'returns an encoder instance from the injected draco3d package'
+  ).toBeTruthy();
 });

--- a/modules/draco/test/draco-writer.spec.ts
+++ b/modules/draco/test/draco-writer.spec.ts
@@ -1,22 +1,15 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {validateWriter, validateMeshCategoryData} from 'test/common/conformance';
-
 import {DracoLoader, DracoWriterOptions, DracoWriter, DracoWriterWorker} from '@loaders.gl/draco';
 import {encode, fetchFile, parse} from '@loaders.gl/core';
 // import {getMeshSize} from '@loaders.gl/schema-utils';
 import draco3d from 'draco3d';
 import {isBrowser, processOnWorker, WorkerFarm} from '@loaders.gl/worker-utils';
 import {cloneTypeArray} from './test-utils/copyTypedArray';
-
 export type TestCase = {
   title: string;
   options: DracoWriterOptions;
 };
-
 const TEST_CASES: TestCase[] = [
   {
     title: 'Encoding Draco Mesh: SEQUENTIAL',
@@ -41,28 +34,22 @@ const TEST_CASES: TestCase[] = [
     }
   }
 ];
-
 const BUNNY_DRC_URL = '@loaders.gl/draco/test/data/bunny.drc';
-
 async function loadBunny() {
   const response = await fetchFile(BUNNY_DRC_URL);
   const arrayBuffer = await response.arrayBuffer();
   // Decode Loaded Mesh to use as input data for encoders
   return await parse(arrayBuffer, DracoLoader);
 }
-
-test('DracoWriter#loader conformance', t => {
-  validateWriter(t, DracoWriter, 'DracoWriter');
-  t.end();
+test('DracoWriter#loader conformance', () => {
+  validateWriter(DracoWriter, 'DracoWriter');
 });
-
-test('DracoWriter#encode(bunny.drc)', async t => {
-  if (skipBrowserDracoWasmTest(t)) {
+test('DracoWriter#encode(bunny.drc)', async () => {
+  if (skipBrowserDracoWasmTest()) {
     return;
   }
   const data = await loadBunny();
-  t.equal(data.attributes.POSITION.value.length, 104502, 'POSITION attribute was found');
-
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(104502);
   const MESH = {
     attributes: {
       POSITION: data.attributes.POSITION.value
@@ -75,60 +62,48 @@ test('DracoWriter#encode(bunny.drc)', async t => {
     }
   };
   const compressedMeshByteLengths = new Map<string, number>();
-
   for (const tc of TEST_CASES) {
     const mesh = tc.options.draco?.pointcloud ? POINTCLOUD : MESH;
-
     const compressedMesh = await encode(mesh, DracoWriter, tc.options);
     compressedMeshByteLengths.set(tc.title, compressedMesh.byteLength);
-
     // const meshSize = getMeshSize(mesh.attributes);
     // const ratio = meshSize / compressedMesh.byteLength;
     // t.comment(`${tc.title} ${compressedMesh.byteLength} bytes, ratio ${ratio.toFixed(1)}`);
-
     if (!tc.options.pointcloud) {
       // Decode the mesh
       const data2 = await parse(compressedMesh, DracoLoader);
-      validateMeshCategoryData(t, data2);
-
+      validateMeshCategoryData(data2);
       // t.comment(JSON.stringify(data));
-      t.equal(
+      expect(
         data2.attributes.POSITION.value.length,
-        data.attributes.POSITION.value.length,
         `${tc.title} decoded POSITION length matched`
-      );
+      ).toBe(data.attributes.POSITION.value.length);
     }
   }
-
   const sequentialMeshByteLength = compressedMeshByteLengths.get('Encoding Draco Mesh: SEQUENTIAL');
   const edgebreakerMeshByteLength = compressedMeshByteLengths.get(
     'Encoding Draco Mesh: EDGEBREAKER'
   );
-  t.ok(sequentialMeshByteLength, 'Sequential mesh encoded');
-  t.ok(edgebreakerMeshByteLength, 'Edgebreaker mesh encoded');
-  t.ok(
+  expect(sequentialMeshByteLength, 'Sequential mesh encoded').toBeTruthy();
+  expect(edgebreakerMeshByteLength, 'Edgebreaker mesh encoded').toBeTruthy();
+  expect(
     sequentialMeshByteLength &&
       edgebreakerMeshByteLength &&
       edgebreakerMeshByteLength < sequentialMeshByteLength,
     `Edgebreaker mesh encoding (${edgebreakerMeshByteLength}) is smaller than sequential mesh encoding (${sequentialMeshByteLength})`
-  );
-
-  t.end();
+  ).toBeTruthy();
 });
-
 /**
  * Cannot import draco_encoder module:
  * Refused to execute script from 'https://raw.githubusercontent.com/google/draco/1.4.1/javascript/draco_encoder.js' because its MIME type ('') is not executable.
  * [Error: Failed to execute 'importScripts' on 'WorkerGlobalScope': The script at 'https://raw.githubusercontent.com/google/draco/1.4.1/javascript/draco_encoder.js' failed to load.
  */
-test.skip('DracoWriter#Worker$encode(bunny.drc)', async t => {
+test.skip('DracoWriter#Worker$encode(bunny.drc)', async () => {
   if (!isBrowser) {
-    t.end();
     return;
   }
   const data = await loadBunny();
-  t.equal(data.attributes.POSITION.value.length, 104502, 'POSITION attribute was found');
-
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(104502);
   const MESH = {
     attributes: {
       POSITION: data.attributes.POSITION.value
@@ -140,44 +115,33 @@ test.skip('DracoWriter#Worker$encode(bunny.drc)', async t => {
       POSITION: data.attributes.POSITION.value
     }
   };
-
   for (const tc of TEST_CASES) {
     const mesh = tc.options.draco?.pointcloud ? POINTCLOUD : MESH;
-
     const compressedMesh = await processOnWorker(DracoWriterWorker, mesh, {
       ...tc.options,
       _workerType: 'test'
     });
-
     // const meshSize = getMeshSize(mesh.attributes);
     // const ratio = meshSize / compressedMesh.byteLength;
     // t.comment(`${tc.title} ${compressedMesh.byteLength} bytes, ratio ${ratio.toFixed(1)}`);
-
     if (!tc.options.pointcloud) {
       // Decode the mesh
       const data2 = await parse(compressedMesh, DracoLoader);
-      validateMeshCategoryData(t, data2);
-
+      validateMeshCategoryData(data2);
       // t.comment(JSON.stringify(data));
-      t.equal(
+      expect(
         data2.attributes.POSITION.value.length,
-        data.attributes.POSITION.value.length,
         `${tc.title} decoded POSITION length matched`
-      );
+      ).toBe(data.attributes.POSITION.value.length);
     }
   }
-
-  t.end();
 });
-
-test('DracoWriter#WorkerNodeJS#encode(bunny.drc)', async t => {
+test('DracoWriter#WorkerNodeJS#encode(bunny.drc)', async () => {
   if (isBrowser) {
-    t.end();
     return;
   }
   const data = await loadBunny();
-  t.equal(data.attributes.POSITION.value.length, 104502, 'POSITION attribute was found');
-
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(104502);
   for (const tc of TEST_CASES) {
     // Copy position buffer because it won't be available after being sent to the worker
     const mesh = {
@@ -190,47 +154,37 @@ test('DracoWriter#WorkerNodeJS#encode(bunny.drc)', async t => {
       // @ts-expect-error
       mesh.indices = cloneTypeArray(data.indices?.value);
     }
-
     const compressedMesh = await processOnWorker(DracoWriterWorker, mesh, {
       ...tc.options,
       _workerType: 'test'
     });
-
     // const compressedMesh = await encode(mesh, DracoWriter, tc.options);
     // const meshSize = getMeshSize(mesh.attributes);
     // const ratio = meshSize / compressedMesh.byteLength;
     // t.comment(`${tc.title} ${compressedMesh.byteLength} bytes, ratio ${ratio.toFixed(1)}`);
-
     if (!tc.options.pointcloud) {
       // Decode the mesh
       const data2 = await parse(compressedMesh, DracoLoader);
-      validateMeshCategoryData(t, data2);
-
+      validateMeshCategoryData(data2);
       // t.comment(JSON.stringify(data));
-      t.equal(
+      expect(
         data2.attributes.POSITION.value.length,
-        data.attributes.POSITION.value.length,
         `${tc.title} decoded POSITION length matched`
-      );
+      ).toBe(data.attributes.POSITION.value.length);
     }
   }
-
   // Destroy all workers in NodeJS
   if (!isBrowser) {
     const workerFarm = WorkerFarm.getWorkerFarm({});
     workerFarm.destroy();
   }
-
-  t.end();
 });
-
-test('DracoWriter#encode via draco3d npm package (bunny.drc)', async t => {
-  if (skipBrowserDracoWasmTest(t)) {
+test('DracoWriter#encode via draco3d npm package (bunny.drc)', async () => {
+  if (skipBrowserDracoWasmTest()) {
     return;
   }
   const data = await loadBunny();
-  t.equal(data.attributes.POSITION.value.length, 104502, 'POSITION attribute was found');
-
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(104502);
   const MESH = {
     attributes: {
       POSITION: data.attributes.POSITION.value
@@ -242,21 +196,17 @@ test('DracoWriter#encode via draco3d npm package (bunny.drc)', async t => {
       POSITION: data.attributes.POSITION.value
     }
   };
-
   for (const tc of TEST_CASES) {
     const mesh = tc.options.draco?.pointcloud ? POINTCLOUD : MESH;
-
     const compressedMesh = await encode(mesh, DracoWriter, {
       ...tc.options,
       modules: {
         draco3d
       }
     });
-
     // const meshSize = getMeshSize(mesh.attributes);
     // const ratio = meshSize / compressedMesh.byteLength;
     // t.comment(`${tc.title} ${compressedMesh.byteLength} bytes, ratio ${ratio.toFixed(1)}`);
-
     if (!tc.options.pointcloud) {
       // Decode the mesh
       const data2 = await parse(compressedMesh, DracoLoader, {
@@ -264,28 +214,22 @@ test('DracoWriter#encode via draco3d npm package (bunny.drc)', async t => {
           draco3d
         }
       });
-      validateMeshCategoryData(t, data2);
-
+      validateMeshCategoryData(data2);
       // t.comment(JSON.stringify(data));
-      t.equal(
+      expect(
         data2.attributes.POSITION.value.length,
-        data.attributes.POSITION.value.length,
         `${tc.title} decoded POSITION length matched`
-      );
+      ).toBe(data.attributes.POSITION.value.length);
     }
   }
-
-  t.end();
 });
-
-test('DracoWriter#encode(bunny.drc)', async t => {
-  if (skipBrowserDracoWasmTest(t)) {
+test('DracoWriter#encode(bunny.drc)', async () => {
+  if (skipBrowserDracoWasmTest()) {
     return;
   }
   const data = await loadBunny();
-  validateMeshCategoryData(t, data);
-  t.equal(data.attributes.POSITION.value.length, 104502, 'POSITION attribute was found');
-
+  validateMeshCategoryData(data);
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(104502);
   const meshAttributes = {
     POSITION: data.attributes.POSITION.value,
     indices: data.indices?.value
@@ -293,95 +237,70 @@ test('DracoWriter#encode(bunny.drc)', async t => {
   const pointCloudAttributes = {
     POSITION: data.attributes.POSITION.value
   };
-
   for (const tc of TEST_CASES) {
     const attributes = tc.options.draco?.pointcloud ? pointCloudAttributes : meshAttributes;
     const compressedMesh = await encode(attributes, DracoWriter, tc.options);
-
     // const meshSize = getMeshSize(attributes);
     // const ratio = meshSize / compressedMesh.byteLength;
     // t.comment(`${tc.title} ${compressedMesh.byteLength} bytes, ratio ${ratio.toFixed(1)}`);
-
     if (!tc.options.pointcloud) {
       // Decode the mesh
       const data2 = await parse(compressedMesh, DracoLoader);
-      validateMeshCategoryData(t, data2);
-
+      validateMeshCategoryData(data2);
       // t.comment(JSON.stringify(data));
-      t.equal(
+      expect(
         data2.attributes.POSITION.value.length,
-        data.attributes.POSITION.value.length,
         `${tc.title} decoded POSITION length matched`
-      );
+      ).toBe(data.attributes.POSITION.value.length);
     }
   }
-
-  t.end();
 });
-
-test('DracoWriter#should encode texCoord/texCoords attribute as TEX_COORD attribute type', async t => {
-  if (skipBrowserDracoWasmTest(t)) {
+test('DracoWriter#should encode texCoord/texCoords attribute as TEX_COORD attribute type', async () => {
+  if (skipBrowserDracoWasmTest()) {
     return;
   }
   const data = await loadBunny();
-  validateMeshCategoryData(t, data);
-  t.equal(data.attributes.POSITION.value.length, 104502, 'POSITION attribute was found');
-
+  validateMeshCategoryData(data);
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(104502);
   const vertexCount = data.attributes.POSITION.value.length / 3;
   const texCoord = new Float32Array(vertexCount * 2);
   texCoord.fill(1);
-
   const meshAttributes = {
     POSITION: data.attributes.POSITION.value,
     texCoord,
     indices: data.indices?.value
   };
-
   const compressedMesh = await encode(meshAttributes, DracoWriter);
   const data2 = await parse(compressedMesh, DracoLoader);
-
-  t.equal(
-    data2.attributes.TEXCOORD_0.value.length,
-    texCoord.length,
-    'Decoded texCoord length matched'
+  expect(data2.attributes.TEXCOORD_0.value.length, 'Decoded texCoord length matched').toBe(
+    texCoord.length
   );
-
   const meshAttributes2 = {
     POSITION: data.attributes.POSITION.value,
     texCoords: texCoord,
     indices: data.indices?.value
   };
-
   const compressedMesh2 = await encode(meshAttributes2, DracoWriter);
   const data3 = await parse(compressedMesh2, DracoLoader);
-
-  t.equal(
-    data3.attributes.TEXCOORD_0.value.length,
-    texCoord.length,
-    'Decoded texCoords length matched'
+  expect(data3.attributes.TEXCOORD_0.value.length, 'Decoded texCoords length matched').toBe(
+    texCoord.length
   );
-
-  t.end();
 });
-
-test('DracoWriter#geometry metadata', async t => {
-  if (skipBrowserDracoWasmTest(t)) {
+test('DracoWriter#geometry metadata', async () => {
+  if (skipBrowserDracoWasmTest()) {
     return;
   }
   const data = await loadBunny();
-  validateMeshCategoryData(t, data);
-  t.equal(data.attributes.POSITION.value.length, 104502, 'POSITION attribute was found');
-
+  validateMeshCategoryData(data);
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(104502);
   const attributes = {
     POSITION: data.attributes.POSITION.value,
     indices: data.indices?.value
   };
-
   let compressedMesh = await encode(attributes, DracoWriter, {
     draco: {}
   });
-  t.equal(compressedMesh.byteLength, 435479, 'Correct length');
-
+  expect(compressedMesh.byteLength, 'Correct length').toBe(435479);
   compressedMesh = await encode(attributes, DracoWriter, {
     draco: {
       metadata: {
@@ -393,58 +312,45 @@ test('DracoWriter#geometry metadata', async t => {
       }
     }
   });
-  t.equal(
+  expect(
     compressedMesh.byteLength,
-    435614,
     'Correct length - different from encoded geometry without metadata'
-  );
-
+  ).toBe(435614);
   // Decode the mesh
   const data2 = await parse(compressedMesh, DracoLoader, {
     core: {worker: false}
   });
-  validateMeshCategoryData(t, data2);
-
-  t.ok(data2.loaderData.metadata);
-  t.ok(data2.loaderData.metadata.author);
-  t.equal(data2.loaderData.metadata.author.string, 'loaders.gl');
-
-  t.ok(data2.loaderData.metadata['optional-entry-int']);
-  t.ok(data2.loaderData.metadata['optional-entry-int-negative']);
-  t.ok(data2.loaderData.metadata['optional-entry-int-zero']);
-  t.ok(data2.loaderData.metadata['optional-entry-double']);
-
-  t.equal(data2.loaderData.metadata['optional-entry-int'].int, 1444);
-  t.equal(data2.loaderData.metadata['optional-entry-int-negative'].int, -333333333);
-  t.equal(data2.loaderData.metadata['optional-entry-int-zero'].int, 0);
-  t.equal(data2.loaderData.metadata['optional-entry-double'].double, 1.00012323);
-
-  t.equal(
-    data2.attributes.POSITION.value.length,
-    data.attributes.POSITION.value.length,
-    'decoded POSITION length matched'
+  validateMeshCategoryData(data2);
+  expect(data2.loaderData.metadata).toBeTruthy();
+  expect(data2.loaderData.metadata.author).toBeTruthy();
+  expect(data2.loaderData.metadata.author.string).toBe('loaders.gl');
+  expect(data2.loaderData.metadata['optional-entry-int']).toBeTruthy();
+  expect(data2.loaderData.metadata['optional-entry-int-negative']).toBeTruthy();
+  expect(data2.loaderData.metadata['optional-entry-int-zero']).toBeTruthy();
+  expect(data2.loaderData.metadata['optional-entry-double']).toBeTruthy();
+  expect(data2.loaderData.metadata['optional-entry-int'].int).toBe(1444);
+  expect(data2.loaderData.metadata['optional-entry-int-negative'].int).toBe(-333333333);
+  expect(data2.loaderData.metadata['optional-entry-int-zero'].int).toBe(0);
+  expect(data2.loaderData.metadata['optional-entry-double'].double).toBe(1.00012323);
+  expect(data2.attributes.POSITION.value.length, 'decoded POSITION length matched').toBe(
+    data.attributes.POSITION.value.length
   );
-  t.end();
 });
-
-test('DracoWriter#attributes metadata', async t => {
-  if (skipBrowserDracoWasmTest(t)) {
+test('DracoWriter#attributes metadata', async () => {
+  if (skipBrowserDracoWasmTest()) {
     return;
   }
   const data = await loadBunny();
-  validateMeshCategoryData(t, data);
-  t.equal(data.attributes.POSITION.value.length, 104502, 'POSITION attribute was found');
-
+  validateMeshCategoryData(data);
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(104502);
   const attributes = {
     POSITION: data.attributes.POSITION.value,
     indices: data.indices?.value
   };
-
   let compressedMesh = await encode(attributes, DracoWriter, {
     draco: {}
   });
-  t.equal(compressedMesh.byteLength, 435479, 'Correct length');
-
+  expect(compressedMesh.byteLength, 'Correct length').toBe(435479);
   compressedMesh = await encode(attributes, DracoWriter, {
     draco: {
       attributesMetadata: {
@@ -459,34 +365,26 @@ test('DracoWriter#attributes metadata', async t => {
       }
     }
   });
-  t.equal(
+  expect(
     compressedMesh.byteLength,
-    435682,
     'Correct length - different from encoded geometry without metadata'
-  );
-
+  ).toBe(435682);
   // Decode the mesh
   const data2 = await parse(compressedMesh, DracoLoader, {
     core: {worker: false}
   });
-  validateMeshCategoryData(t, data2);
-  validatePositionMetadata(t, data2);
-  t.equals(
+  validateMeshCategoryData(data2);
+  validatePositionMetadata(data2);
+  expect(
     Object.keys(data2.schema.fields[0]?.metadata || {}).length,
-    7,
     'Schema: Attribute metadata correct number of keys'
+  ).toBe(7);
+  expect(data2.attributes.POSITION.value.length, 'decoded POSITION length matched').toBe(
+    data.attributes.POSITION.value.length
   );
-
-  t.equal(
-    data2.attributes.POSITION.value.length,
-    data.attributes.POSITION.value.length,
-    'decoded POSITION length matched'
-  );
-  t.end();
 });
-
-test('DracoWriter#metadata - should be able to define optional "name entry" for custom attribute', async t => {
-  if (skipBrowserDracoWasmTest(t)) {
+test('DracoWriter#metadata - should be able to define optional "name entry" for custom attribute', async () => {
+  if (skipBrowserDracoWasmTest()) {
     return;
   }
   const data = await loadBunny();
@@ -510,55 +408,44 @@ test('DracoWriter#metadata - should be able to define optional "name entry" for 
       attributeNameEntry: 'custom-attribute-name'
     }
   });
-  validateMeshCategoryData(t, data2);
-  t.ok(data2.attributes.featureId);
-  t.equal(
-    data2.attributes.POSITION.value.length,
-    data.attributes.POSITION.value.length,
-    'decoded POSITION length matched'
+  validateMeshCategoryData(data2);
+  expect(data2.attributes.featureId).toBeTruthy();
+  expect(data2.attributes.POSITION.value.length, 'decoded POSITION length matched').toBe(
+    data.attributes.POSITION.value.length
   );
-  t.end();
 });
-
-function validatePositionMetadata(t, data) {
+function validatePositionMetadata(data) {
   const POSITION = 0;
-  t.ok(data.loaderData.attributes[POSITION].metadata);
-  t.ok(data.loaderData.attributes[POSITION].metadata.name);
-  t.ok(data.loaderData.attributes[POSITION].metadata['optional-entry']);
-  t.ok(data.loaderData.attributes[POSITION].metadata['optional-entry-int']);
-  t.ok(data.loaderData.attributes[POSITION].metadata['optional-entry-int-negative']);
-  t.ok(data.loaderData.attributes[POSITION].metadata['optional-entry-int-zero']);
-  t.ok(data.loaderData.attributes[POSITION].metadata['optional-entry-double']);
-  t.ok(data.loaderData.attributes[POSITION].metadata['optional-entry-int-array']);
-
-  t.equal(data.loaderData.attributes[POSITION].metadata.name.string, 'POSITION');
-  t.equal(
-    data.loaderData.attributes[POSITION].metadata['optional-entry'].string,
+  expect(data.loaderData.attributes[POSITION].metadata).toBeTruthy();
+  expect(data.loaderData.attributes[POSITION].metadata.name).toBeTruthy();
+  expect(data.loaderData.attributes[POSITION].metadata['optional-entry']).toBeTruthy();
+  expect(data.loaderData.attributes[POSITION].metadata['optional-entry-int']).toBeTruthy();
+  expect(data.loaderData.attributes[POSITION].metadata['optional-entry-int-negative']).toBeTruthy();
+  expect(data.loaderData.attributes[POSITION].metadata['optional-entry-int-zero']).toBeTruthy();
+  expect(data.loaderData.attributes[POSITION].metadata['optional-entry-double']).toBeTruthy();
+  expect(data.loaderData.attributes[POSITION].metadata['optional-entry-int-array']).toBeTruthy();
+  expect(data.loaderData.attributes[POSITION].metadata.name.string).toBe('POSITION');
+  expect(data.loaderData.attributes[POSITION].metadata['optional-entry'].string).toBe(
     'optional-entry-value'
   );
-  t.equal(data.loaderData.attributes[POSITION].metadata['optional-entry-int'].int, 1444);
-  t.equal(
-    data.loaderData.attributes[POSITION].metadata['optional-entry-int-negative'].int,
+  expect(data.loaderData.attributes[POSITION].metadata['optional-entry-int'].int).toBe(1444);
+  expect(data.loaderData.attributes[POSITION].metadata['optional-entry-int-negative'].int).toBe(
     -333333333
   );
-  t.equal(data.loaderData.attributes[POSITION].metadata['optional-entry-int-zero'].int, 0);
-  t.equal(
-    data.loaderData.attributes[POSITION].metadata['optional-entry-double'].double,
+  expect(data.loaderData.attributes[POSITION].metadata['optional-entry-int-zero'].int).toBe(0);
+  expect(data.loaderData.attributes[POSITION].metadata['optional-entry-double'].double).toBe(
     1.00012323
   );
-  t.deepEqual(
-    data.loaderData.attributes[POSITION].metadata['optional-entry-int-array'].intArray,
-    [0, 1, 2, -3000, 31987, 77]
-  );
+  expect(
+    data.loaderData.attributes[POSITION].metadata['optional-entry-int-array'].intArray
+  ).toEqual([0, 1, 2, -3000, 31987, 77]);
 }
-
 /**
  * Skips Draco writer tests that depend on direct WASM module initialization in browser runs.
  */
-function skipBrowserDracoWasmTest(t) {
+function skipBrowserDracoWasmTest() {
   if (isBrowser) {
-    t.comment('Skipping Draco WASM writer test in browser');
-    t.end();
+    console.log('Skipping Draco WASM writer test in browser');
     return true;
   }
   return false;

--- a/modules/excel/test/excel-loader.slow.spec.ts
+++ b/modules/excel/test/excel-loader.slow.spec.ts
@@ -1,8 +1,4 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {load, loadInBatches} from '@loaders.gl/core';
 import type {ObjectRowTable, ObjectRowTableBatch} from '@loaders.gl/schema';
 import {ExcelLoader} from '@loaders.gl/excel';
@@ -11,28 +7,21 @@ import * as bundledExcel from '@loaders.gl/excel/bundled';
 import * as unbundledExcel from '@loaders.gl/excel/unbundled';
 import {CSVLoader} from '@loaders.gl/csv';
 import {convertExcelRowsToArrowTable} from '../src/lib/convert-excel-rows-to-arrow';
-
 const ZIPCODES_XLSX_PATH = '@loaders.gl/excel/test/data/zipcodes.xlsx';
 const ZIPCODES_XLSB_PATH = '@loaders.gl/excel/test/data/zipcodes.xlsb';
 const ZIPCODES_CSV_PATH = '@loaders.gl/excel/test/data/zipcodes.csv';
-
-test('ExcelLoader#load(ZIPCODES)', async t => {
+test('ExcelLoader#load(ZIPCODES)', async () => {
   const csvTable = (await load(ZIPCODES_CSV_PATH, CSVLoader, {
     csv: {shape: 'object-row-table'}
   })) as ObjectRowTable;
-
   let table = await load(ZIPCODES_XLSB_PATH, ExcelLoader);
-  t.equal(table.data.length, 42049, 'XLSB: Correct number of row received');
-  t.deepEqual(table.data[0], csvTable.data[0], 'XLSB: Data corresponds to CSV');
-
+  expect(table.data.length, 'XLSB: Correct number of row received').toBe(42049);
+  expect(table.data[0], 'XLSB: Data corresponds to CSV').toEqual(csvTable.data[0]);
   table = await load(ZIPCODES_XLSX_PATH, ExcelLoader);
-  t.equal(table.data.length, 42049, 'XLSX: Correct number of row received');
-  t.deepEqual(table.data[100], csvTable.data[100], 'XLSX: Data corresponds to CSV');
-
-  t.end();
+  expect(table.data.length, 'XLSX: Correct number of row received').toBe(42049);
+  expect(table.data[100], 'XLSX: Data corresponds to CSV').toEqual(csvTable.data[100]);
 });
-
-test('ExcelLoader#loadInBatches (on worker)', async t => {
+test('ExcelLoader#loadInBatches (on worker)', async () => {
   // This masquerades an atomic loader as batches
   const batches = (await loadInBatches(
     ZIPCODES_XLSX_PATH,
@@ -42,63 +31,55 @@ test('ExcelLoader#loadInBatches (on worker)', async t => {
   for await (const batch of batches) {
     firstBatch = firstBatch || batch;
   }
-  t.equal(firstBatch?.shape, 'object-row-table', 'XLSX: correct batch type received');
-  t.equal(firstBatch?.data.length, 42049, 'XLSX: Correct batch row count received');
-  t.end();
+  expect(firstBatch?.shape, 'XLSX: correct batch type received').toBe('object-row-table');
+  expect(firstBatch?.data.length, 'XLSX: Correct batch row count received').toBe(42049);
 });
-
-test('ExcelLoader#removed Arrow variant exports are absent', t => {
-  t.notOk('ExcelArrowLoader' in excel, 'root does not export ExcelArrowLoader');
-  t.notOk('ExcelArrowLoaderOptions' in excel, 'root does not export ExcelArrowLoaderOptions');
-  t.notOk('ExcelArrowLoader' in bundledExcel, 'bundled does not export ExcelArrowLoader');
-  t.notOk('ExcelArrowLoader' in unbundledExcel, 'unbundled does not export ExcelArrowLoader');
-  t.end();
+test('ExcelLoader#removed Arrow variant exports are absent', () => {
+  expect('ExcelArrowLoader' in excel, 'root does not export ExcelArrowLoader').toBeFalsy();
+  expect(
+    'ExcelArrowLoaderOptions' in excel,
+    'root does not export ExcelArrowLoaderOptions'
+  ).toBeFalsy();
+  expect(
+    'ExcelArrowLoader' in bundledExcel,
+    'bundled does not export ExcelArrowLoader'
+  ).toBeFalsy();
+  expect(
+    'ExcelArrowLoader' in unbundledExcel,
+    'unbundled does not export ExcelArrowLoader'
+  ).toBeFalsy();
 });
-
-test('ExcelLoader#load(ZIPCODES, shape: arrow-table)', async t => {
+test('ExcelLoader#load(ZIPCODES, shape: arrow-table)', async () => {
   const csvTable = (await load(ZIPCODES_CSV_PATH, CSVLoader, {
     csv: {shape: 'object-row-table'}
   })) as ObjectRowTable;
   const classicTable = await load(ZIPCODES_XLSX_PATH, ExcelLoader);
-
   const table = await load(ZIPCODES_XLSX_PATH, ExcelLoader, {
     excel: {shape: 'arrow-table'}
   });
-  t.equal(table.shape, 'arrow-table', 'XLSX: correct table type received');
-  t.equal(table.data.numRows, classicTable.data.length, 'XLSX: row count matches ExcelLoader');
-
+  expect(table.shape, 'XLSX: correct table type received').toBe('arrow-table');
+  expect(table.data.numRows, 'XLSX: row count matches ExcelLoader').toBe(classicTable.data.length);
   for (const rowIndex of [0, 100]) {
     const row = classicTable.data[rowIndex] || {};
     for (const [fieldName, value] of Object.entries(row)) {
-      t.equal(
+      expect(
         table.data.getChild(fieldName)?.get(rowIndex),
-        value,
         `XLSX: ${fieldName} row ${rowIndex} matches ExcelLoader`
-      );
+      ).toBe(value);
     }
   }
-
-  t.equal(
-    table.data.getChild('zip_code')?.get(0),
-    csvTable.data[0].zip_code,
-    'XLSX: zip_code corresponds to CSV'
+  expect(table.data.getChild('zip_code')?.get(0), 'XLSX: zip_code corresponds to CSV').toBe(
+    csvTable.data[0].zip_code
   );
-  t.equal(
-    table.data.getChild('city')?.get(100),
-    csvTable.data[100].city,
-    'XLSX: city corresponds to CSV'
+  expect(table.data.getChild('city')?.get(100), 'XLSX: city corresponds to CSV').toBe(
+    csvTable.data[100].city
   );
-
-  t.end();
 });
-
-test('convertExcelRowsToArrowTable handles empty and nullable primitive rows', t => {
+test('convertExcelRowsToArrowTable handles empty and nullable primitive rows', () => {
   const emptyTable = convertExcelRowsToArrowTable([]);
-
-  t.equal(emptyTable.shape, 'arrow-table', 'Empty rows return an Arrow table');
-  t.equal(emptyTable.data.numCols, 0, 'Empty rows return no columns');
-  t.equal(emptyTable.data.numRows, 0, 'Empty rows return no rows');
-
+  expect(emptyTable.shape, 'Empty rows return an Arrow table').toBe('arrow-table');
+  expect(emptyTable.data.numCols, 'Empty rows return no columns').toBe(0);
+  expect(emptyTable.data.numRows, 'Empty rows return no rows').toBe(0);
   const dateValue = new Date('2020-01-02T00:00:00.000Z');
   const table = convertExcelRowsToArrowTable([
     {
@@ -116,19 +97,18 @@ test('convertExcelRowsToArrowTable handles empty and nullable primitive rows', t
       emptyValue: null
     }
   ]);
-
-  t.equal(table.schema?.fields.find(field => field.name === 'numberValue')?.type, 'float64');
-  t.equal(table.schema?.fields.find(field => field.name === 'booleanValue')?.type, 'bool');
-  t.equal(table.schema?.fields.find(field => field.name === 'stringValue')?.type, 'utf8');
-  t.equal(table.schema?.fields.find(field => field.name === 'dateValue')?.type, 'date-millisecond');
-  t.equal(table.schema?.fields.find(field => field.name === 'emptyValue')?.type, 'null');
-  t.equal(table.data.getChild('numberValue')?.get(1), 1, 'Number value is preserved');
-  t.equal(table.data.getChild('booleanValue')?.get(1), true, 'Boolean value is preserved');
-  t.equal(table.data.getChild('stringValue')?.get(1), 'x', 'String value is preserved');
-  t.end();
+  expect(table.schema?.fields.find(field => field.name === 'numberValue')?.type).toBe('float64');
+  expect(table.schema?.fields.find(field => field.name === 'booleanValue')?.type).toBe('bool');
+  expect(table.schema?.fields.find(field => field.name === 'stringValue')?.type).toBe('utf8');
+  expect(table.schema?.fields.find(field => field.name === 'dateValue')?.type).toBe(
+    'date-millisecond'
+  );
+  expect(table.schema?.fields.find(field => field.name === 'emptyValue')?.type).toBe('null');
+  expect(table.data.getChild('numberValue')?.get(1), 'Number value is preserved').toBe(1);
+  expect(table.data.getChild('booleanValue')?.get(1), 'Boolean value is preserved').toBe(true);
+  expect(table.data.getChild('stringValue')?.get(1), 'String value is preserved').toBe('x');
 });
-
-test('ExcelLoader#loadInBatches(shape: arrow-table)', async t => {
+test('ExcelLoader#loadInBatches(shape: arrow-table)', async () => {
   const classicTable = await load(ZIPCODES_XLSX_PATH, ExcelLoader);
   const batches = (await loadInBatches(ZIPCODES_XLSX_PATH, ExcelLoader, {
     excel: {shape: 'arrow-table'}
@@ -137,13 +117,10 @@ test('ExcelLoader#loadInBatches(shape: arrow-table)', async t => {
   for await (const batch of batches) {
     firstBatch = firstBatch || batch;
   }
-
-  t.equal(firstBatch?.shape, 'arrow-table', 'XLSX: correct Arrow batch type received');
-  t.equal(firstBatch?.data.numRows, 42049, 'XLSX: correct Arrow batch row count received');
-  t.equal(
+  expect(firstBatch?.shape, 'XLSX: correct Arrow batch type received').toBe('arrow-table');
+  expect(firstBatch?.data.numRows, 'XLSX: correct Arrow batch row count received').toBe(42049);
+  expect(
     firstBatch?.data.getChild('city')?.get(100),
-    classicTable.data[100].city,
     'XLSX: Arrow batch values are preserved'
-  );
-  t.end();
+  ).toBe(classicTable.data[100].city);
 });

--- a/modules/geoarrow/test/geoarrow-geometry-converter.spec.ts
+++ b/modules/geoarrow/test/geoarrow-geometry-converter.spec.ts
@@ -1,9 +1,8 @@
 // loaders.gl
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
-
 import * as arrow from 'apache-arrow';
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {fetchFile} from '@loaders.gl/core';
 import {
   GEOARROW_LINE_WKT_FILE,
@@ -19,7 +18,6 @@ import {
   getGeometryColumnsFromSchema
 } from '@loaders.gl/geoarrow';
 import {convertArrowToSchema, convert} from '@loaders.gl/schema-utils';
-
 /**
  * Loads an Apache Arrow table from a GeoArrow fixture.
  * @param filePath Fixture path alias.
@@ -29,7 +27,6 @@ async function loadArrowTable(filePath: string): Promise<arrow.Table> {
   const file = await fetchFile(filePath);
   return arrow.tableFromIPC(await file.arrayBuffer());
 }
-
 /**
  * Rebuilds a table with GeoArrow field metadata on the geometry column.
  * @param table Source Arrow table.
@@ -48,7 +45,6 @@ function setGeometryFieldEncoding(table: arrow.Table, encoding: string): arrow.T
       : field
   );
   const nextSchema = new arrow.Schema(nextFields, table.schema.metadata);
-
   return new arrow.Table(
     new arrow.RecordBatch(
       nextSchema,
@@ -61,54 +57,41 @@ function setGeometryFieldEncoding(table: arrow.Table, encoding: string): arrow.T
     )
   );
 }
-
-test('GeoArrowGeometryConverter converts WKB geometry columns to native point encoding', async t => {
+test('GeoArrowGeometryConverter converts WKB geometry columns to native point encoding', async () => {
   const table = await loadArrowTable(GEOARROW_POINT_WKB_FILE);
   const convertedTable = convertGeoArrowGeometry(table, 'geoarrow.point');
   const convertedSchema = convertArrowToSchema(convertedTable.schema);
-
-  t.equal(
+  expect(
     getGeometryColumnsFromSchema(convertedSchema).geometry?.encoding,
-    'geoarrow.point',
     'updates the geometry column encoding metadata'
-  );
-  t.equal(
+  ).toBe('geoarrow.point');
+  expect(
     convertedTable.schema.fields.find(field => field.name === 'geometry')?.type.toString(),
-    'FixedSizeList[2]<Float64>',
     'builds a native point column'
-  );
-  t.deepEqual(
+  ).toBe('FixedSizeList[2]<Float64>');
+  expect(
     convertGeoArrowToTable(convertedTable, 'geojson-table').features,
-    convertGeoArrowToTable(table, 'geojson-table').features,
     'preserves feature content after conversion'
-  );
-  t.end();
+  ).toEqual(convertGeoArrowToTable(table, 'geojson-table').features);
 });
-
-test('GeoArrowGeometryConverter converts native point encoding to WKT', async t => {
+test('GeoArrowGeometryConverter converts native point encoding to WKT', async () => {
   const table = await loadArrowTable(GEOARROW_POINT_FILE);
   const convertedTable = convertGeoArrowGeometry(table, 'geoarrow.wkt');
   const convertedSchema = convertArrowToSchema(convertedTable.schema);
-
-  t.equal(
+  expect(
     getGeometryColumnsFromSchema(convertedSchema).geometry?.encoding,
-    'geoarrow.wkt',
     'updates the geometry column encoding metadata'
-  );
-  t.equal(
+  ).toBe('geoarrow.wkt');
+  expect(
     convertedTable.schema.fields.find(field => field.name === 'geometry')?.type.toString(),
-    'Utf8',
     'builds a WKT geometry column'
-  );
-  t.deepEqual(
+  ).toBe('Utf8');
+  expect(
     convertGeoArrowToTable(convertedTable, 'geojson-table').features,
-    convertGeoArrowToTable(table, 'geojson-table').features,
     'preserves feature content after conversion'
-  );
-  t.end();
+  ).toEqual(convertGeoArrowToTable(table, 'geojson-table').features);
 });
-
-test('GeoArrowGeometryConverter converts only selected geometry columns', async t => {
+test('GeoArrowGeometryConverter converts only selected geometry columns', async () => {
   const pointTable = await loadArrowTable(GEOARROW_POINT_WKB_FILE);
   const lineTable = await loadArrowTable(GEOARROW_LINE_WKT_FILE);
   const geometryVector = pointTable.getChild('geometry')!;
@@ -146,51 +129,35 @@ test('GeoArrowGeometryConverter converts only selected geometry columns', async 
       })
     )
   );
-
   const convertedTable = convertGeoArrowGeometry(tableWithSchema, 'geoarrow.point', {
     geometryColumn: 'geometry'
   });
   const convertedSchema = convertArrowToSchema(convertedTable.schema);
   const convertedGeometryColumns = getGeometryColumnsFromSchema(convertedSchema);
-
-  t.equal(
-    convertedGeometryColumns.geometry?.encoding,
-    'geoarrow.point',
-    'converts the selected column'
+  expect(convertedGeometryColumns.geometry?.encoding, 'converts the selected column').toBe(
+    'geoarrow.point'
   );
-  t.equal(
-    convertedGeometryColumns.geometry2?.encoding,
-    'geoarrow.wkt',
-    'leaves unselected columns alone'
+  expect(convertedGeometryColumns.geometry2?.encoding, 'leaves unselected columns alone').toBe(
+    'geoarrow.wkt'
   );
-  t.end();
 });
-
-test('GeoArrowGeometryConverter rejects incompatible target encodings', async t => {
+test('GeoArrowGeometryConverter rejects incompatible target encodings', async () => {
   const table = await loadArrowTable(GEOARROW_POINT_FILE);
-
-  t.throws(
+  expect(
     () => convertGeoArrowGeometry(table, 'geoarrow.linestring'),
-    /cannot encode Point as geoarrow\.linestring/i,
     'rejects changing geometry type during encoding conversion'
-  );
-  t.end();
+  ).toThrow(/cannot encode Point as geoarrow\.linestring/i);
 });
-
-test('GeoArrowGeometryConverter integrates with convert()', async t => {
+test('GeoArrowGeometryConverter integrates with convert()', async () => {
   const table = await loadArrowTable(GEOARROW_POINT_WKB_FILE);
   const convertedTable = convert(table, 'geoarrow.point', [GeoArrowGeometryConverter]);
   const convertedSchema = convertArrowToSchema((convertedTable as arrow.Table).schema);
-
-  t.equal(
+  expect(
     getGeometryColumnsFromSchema(convertedSchema).geometry?.encoding,
-    'geoarrow.point',
     'supports schema-utils convert() integration'
-  );
-  t.end();
+  ).toBe('geoarrow.point');
 });
-
-test('GeoArrowGeometryConverter converts mixed WKB tables to geoarrow.geometry', t => {
+test('GeoArrowGeometryConverter converts mixed WKB tables to geoarrow.geometry', () => {
   const features: Feature[] = [
     {
       type: 'Feature',
@@ -215,28 +182,22 @@ test('GeoArrowGeometryConverter converts mixed WKB tables to geoarrow.geometry',
   );
   const convertedTable = convertGeoArrowGeometry(table, 'geoarrow.geometry');
   const roundTripTable = convertGeoArrowGeometry(convertedTable, 'geoarrow.wkt');
-
-  t.equal(
+  expect(
     convertedTable.schema.fields
       .find(field => field.name === 'geometry')
       ?.metadata?.get('ARROW:extension:name'),
-    'geoarrow.geometry',
     'updates geometry metadata to geoarrow.geometry'
-  );
-  t.equal(
+  ).toBe('geoarrow.geometry');
+  expect(
     convertedTable.schema.fields.find(field => field.name === 'geometry')?.type.constructor.name,
-    'DenseUnion',
     'builds a dense union geometry column'
-  );
-  t.deepEqual(
+  ).toBe('DenseUnion');
+  expect(
     convertGeoArrowToTable(roundTripTable, 'geojson-table').features,
-    features,
     'round-trips mixed geometry content through the union encoding'
-  );
-  t.end();
+  ).toEqual(features);
 });
-
-test('GeoArrowGeometryConverter converts geometry collections to geoarrow.geometrycollection', t => {
+test('GeoArrowGeometryConverter converts geometry collections to geoarrow.geometrycollection', () => {
   const features: Feature[] = [
     {
       type: 'Feature',
@@ -262,25 +223,21 @@ test('GeoArrowGeometryConverter converts geometry collections to geoarrow.geomet
   );
   const convertedTable = convertGeoArrowGeometry(table, 'geoarrow.geometrycollection');
   const roundTripTable = convertGeoArrowGeometry(convertedTable, 'geoarrow.wkb');
-
-  t.equal(
+  expect(
     convertedTable.schema.fields
       .find(field => field.name === 'geometry')
       ?.metadata?.get('ARROW:extension:name'),
-    'geoarrow.geometrycollection',
     'updates geometry metadata to geoarrow.geometrycollection'
-  );
-  t.ok(
+  ).toBe('geoarrow.geometrycollection');
+  expect(
     convertedTable.schema.fields
       .find(field => field.name === 'geometry')
       ?.type.toString()
       .startsWith('List<Union<'),
     'builds a list of dense union members for geometry collections'
-  );
-  t.deepEqual(
+  ).toBeTruthy();
+  expect(
     convertGeoArrowToTable(roundTripTable, 'geojson-table').features,
-    features,
     'round-trips geometry collections through the collection encoding'
-  );
-  t.end();
+  ).toEqual(features);
 });

--- a/modules/geoarrow/test/geoarrow-metadata.spec.ts
+++ b/modules/geoarrow/test/geoarrow-metadata.spec.ts
@@ -1,51 +1,37 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import legacyTest from 'test/utils/vitest-tape';
 import {expect, test} from 'vitest';
-
 import type {GeoArrowMetadata} from '@loaders.gl/geoarrow';
 import {getGeometryColumnsFromSchema} from '@loaders.gl/geoarrow';
-
 // fix a bug that map bounds are not updated correctly from arrow samples
-legacyTest('geoarrow#getGeometryColumnsFromSchema', t => {
-  const testCases: {schema: string; columns: Record<string, GeoArrowMetadata>}[] = [
+test('geoarrow#getGeometryColumnsFromSchema', () => {
+  const testCases: {
+    schema: string;
+    columns: Record<string, GeoArrowMetadata>;
+  }[] = [
     {
       schema: '',
       columns: {}
     }
   ];
-
   for (const testCase of testCases) {
     const columns = getGeometryColumnsFromSchema(testCase.schema as any);
-    t.ok(columns);
+    expect(columns).toBeTruthy();
   }
-
-  t.end();
 });
-
-legacyTest(
-  'geoarrow#getGeometryColumnsFromSchema preserves encoding when extension metadata is empty',
-  t => {
-    const columns = getGeometryColumnsFromSchema({
-      fields: [
-        {
-          name: 'geometry',
-          type: 'binary',
-          metadata: {
-            'ARROW:extension:name': 'geoarrow.wkb',
-            'ARROW:extension:metadata': '{}'
-          }
+test('geoarrow#getGeometryColumnsFromSchema preserves encoding when extension metadata is empty', () => {
+  const columns = getGeometryColumnsFromSchema({
+    fields: [
+      {
+        name: 'geometry',
+        type: 'binary',
+        metadata: {
+          'ARROW:extension:name': 'geoarrow.wkb',
+          'ARROW:extension:metadata': '{}'
         }
-      ]
-    } as any);
-
-    t.deepEqual(columns, {geometry: {encoding: 'geoarrow.wkb'}});
-    t.end();
-  }
-);
-
+      }
+    ]
+  } as any);
+  expect(columns).toEqual({geometry: {encoding: 'geoarrow.wkb'}});
+});
 test('geoarrow#getGeometryColumnsFromSchema preserves a mislabeled string CRS as opaque', () => {
   const wkt = 'GEOGCRS["WGS 84",ID["EPSG",4326]]';
   const schema = {
@@ -60,7 +46,6 @@ test('geoarrow#getGeometryColumnsFromSchema preserves a mislabeled string CRS as
       }
     ]
   } as any;
-
   expect(getGeometryColumnsFromSchema(schema)).toEqual({
     geometry: {encoding: 'geoarrow.wkb', crs: wkt}
   });

--- a/modules/geoarrow/test/get-arrow-bounds.spec.ts
+++ b/modules/geoarrow/test/get-arrow-bounds.spec.ts
@@ -1,13 +1,7 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
-
+import {expect, test} from 'vitest';
 import {updateBoundsFromGeoArrowSamples} from '@loaders.gl/geoarrow';
-
 // fix a bug that map bounds are not updated correctly from arrow samples
-test('ArrowUtils#updateBoundsFromGeoArrowSamples', t => {
+test('ArrowUtils#updateBoundsFromGeoArrowSamples', () => {
   const testCases = [
     {
       coords: [0, 0, 1, 1, 2, 2],
@@ -34,17 +28,14 @@ test('ArrowUtils#updateBoundsFromGeoArrowSamples', t => {
       boundSample2: [0, 0, 4, 4]
     }
   ];
-
   testCases.forEach(testCase => {
     const initBound: [number, number, number, number] = [Infinity, Infinity, -Infinity, -Infinity];
-
     const updatedBound = updateBoundsFromGeoArrowSamples(
       new Float64Array(testCase.coords),
       testCase.nDim,
       initBound
     );
-    t.deepEqual(updatedBound, testCase.bound, 'bounds updated correctly');
-
+    expect(updatedBound, 'bounds updated correctly').toEqual(testCase.bound);
     const sampleSize = 2;
     const updateBoundWith2Samples = updateBoundsFromGeoArrowSamples(
       new Float64Array(testCase.coords),
@@ -52,11 +43,8 @@ test('ArrowUtils#updateBoundsFromGeoArrowSamples', t => {
       initBound,
       sampleSize
     );
-    t.deepEqual(
-      updateBoundWith2Samples,
-      testCase.boundSample2,
-      'bounds updated correctly with 2 samples'
+    expect(updateBoundWith2Samples, 'bounds updated correctly with 2 samples').toEqual(
+      testCase.boundSample2
     );
   });
-  t.end();
 });

--- a/modules/geoarrow/test/get-geoarrow-geometry-info.spec.ts
+++ b/modules/geoarrow/test/get-geoarrow-geometry-info.spec.ts
@@ -1,16 +1,13 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import * as arrow from 'apache-arrow';
-
 import {getGeoArrowGeometryInfo} from '@loaders.gl/geoarrow';
 import {GeoArrowGeometryInfo} from '../src/get-geoarrow-geometry-info';
-
 // fix a bug that map bounds are not updated correctly from arrow samples
-test('geoarrow#getGeoArrowGeometryInfo', t => {
-  const testCases: {field: arrow.Field; info: Partial<GeoArrowGeometryInfo>}[] = [
+test('geoarrow#getGeoArrowGeometryInfo', () => {
+  const testCases: {
+    field: arrow.Field;
+    info: Partial<GeoArrowGeometryInfo>;
+  }[] = [
     // {
     //   field: new arrow.Field('point', new arrow.Float(arrow.Precision.DOUBLE)),
     //   info: {
@@ -42,11 +39,8 @@ test('geoarrow#getGeoArrowGeometryInfo', t => {
       }
     }
   ];
-
   for (const testCase of testCases) {
     const info = getGeoArrowGeometryInfo(testCase.field);
-    t.deepEqual(info?.compatibleEncodings, info?.compatibleEncodings, testCase.field.toString());
+    expect(info?.compatibleEncodings, testCase.field.toString()).toEqual(info?.compatibleEncodings);
   }
-
-  t.end();
 });

--- a/modules/geoarrow/test/get-geoarrow-vertex-count.spec.ts
+++ b/modules/geoarrow/test/get-geoarrow-vertex-count.spec.ts
@@ -1,10 +1,5 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import * as arrow from 'apache-arrow';
-
 import {getGeoarrowVertexCount} from '@loaders.gl/geoarrow';
 import {
   convertGeometryToWKB,
@@ -13,8 +8,7 @@ import {
   makeWKBGeometryField
 } from '@loaders.gl/gis';
 import type {Schema} from '@loaders.gl/schema';
-
-test('geoarrow#getGeoarrowVertexCount counts WKB Data/Vector/Table vertices', t => {
+test('geoarrow#getGeoarrowVertexCount counts WKB Data/Vector/Table vertices', () => {
   const polygonWKB = convertGeometryToWKB({
     type: 'Polygon',
     coordinates: [
@@ -57,7 +51,6 @@ test('geoarrow#getGeoarrowVertexCount counts WKB Data/Vector/Table vertices', t 
       ]
     ]
   });
-
   const geometryData = makeWKBGeometryData([polygonWKB, null, multiPolygonWKB]);
   const geometryVector = new arrow.Vector([geometryData]);
   const schema: Schema = {
@@ -66,14 +59,11 @@ test('geoarrow#getGeoarrowVertexCount counts WKB Data/Vector/Table vertices', t 
   };
   const geometryTable = makeWKBGeometryArrowTable([polygonWKB, null, multiPolygonWKB], schema)
     .data as arrow.Table;
-
-  t.equal(getGeoarrowVertexCount(geometryData), 20, 'counts WKB Data vertices');
-  t.equal(getGeoarrowVertexCount(geometryVector), 20, 'counts WKB Vector vertices');
-  t.equal(getGeoarrowVertexCount(geometryTable), 20, 'counts WKB Table vertices');
-  t.end();
+  expect(getGeoarrowVertexCount(geometryData), 'counts WKB Data vertices').toBe(20);
+  expect(getGeoarrowVertexCount(geometryVector), 'counts WKB Vector vertices').toBe(20);
+  expect(getGeoarrowVertexCount(geometryTable), 'counts WKB Table vertices').toBe(20);
 });
-
-test('geoarrow#getGeoarrowVertexCount skips extra WKB ordinates', t => {
+test('geoarrow#getGeoarrowVertexCount skips extra WKB ordinates', () => {
   const polygonWKB = convertGeometryToWKB(
     {
       type: 'Polygon',
@@ -89,7 +79,7 @@ test('geoarrow#getGeoarrowVertexCount skips extra WKB ordinates', t => {
     {hasZ: true, hasM: true}
   );
   const geometryData = makeWKBGeometryData([polygonWKB]);
-
-  t.equal(getGeoarrowVertexCount(geometryData), 4, 'counts XYZM WKB vertices using source points');
-  t.end();
+  expect(getGeoarrowVertexCount(geometryData), 'counts XYZM WKB vertices using source points').toBe(
+    4
+  );
 });

--- a/modules/geopackage/test/geopackage-arrow-loader.spec.ts
+++ b/modules/geopackage/test/geopackage-arrow-loader.spec.ts
@@ -1,8 +1,4 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {validateLoader} from 'test/common/conformance';
 import {setLoaderOptions, fetchFile, load} from '@loaders.gl/core';
 import {getTableRowAsObject} from '@loaders.gl/schema-utils';
@@ -12,46 +8,42 @@ import {GeoPackageLoader} from '@loaders.gl/geopackage';
 import * as geopackage from '@loaders.gl/geopackage';
 import * as bundledGeopackage from '@loaders.gl/geopackage/bundled';
 import * as unbundledGeopackage from '@loaders.gl/geopackage/unbundled';
-
 const GPKG_RIVERS = '@loaders.gl/geopackage/test/data/rivers_small.gpkg';
 const GPKG_RIVERS_MULTI = '@loaders.gl/geopackage/test/data/rivers_multi.gpkg';
 const GPKG_RIVERS_GEOJSON = '@loaders.gl/geopackage/test/data/rivers_small.geojson';
-
 setLoaderOptions({
   _workerType: 'test',
   worker: false
 });
-
-test('GeoPackageLoader#loader conformance', t => {
-  validateLoader(t, GeoPackageLoader, 'GeoPackageLoader');
-  t.end();
+test('GeoPackageLoader#loader conformance', () => {
+  validateLoader(GeoPackageLoader, 'GeoPackageLoader');
 });
-
-test('GeoPackageLoader#removed Arrow loader exports', t => {
-  t.notOk('GeoPackageArrowLoader' in geopackage, 'root does not export GeoPackageArrowLoader');
-  t.notOk(
+test('GeoPackageLoader#removed Arrow loader exports', () => {
+  expect(
+    'GeoPackageArrowLoader' in geopackage,
+    'root does not export GeoPackageArrowLoader'
+  ).toBeFalsy();
+  expect(
     'GeoPackageArrowLoader' in bundledGeopackage,
     'bundled does not export GeoPackageArrowLoader'
-  );
-  t.notOk(
+  ).toBeFalsy();
+  expect(
     'GeoPackageArrowLoader' in unbundledGeopackage,
     'unbundled does not export GeoPackageArrowLoader'
-  );
-  t.end();
+  ).toBeFalsy();
 });
-
-test('GeoPackageLoader#load file as Arrow table', async t => {
+test('GeoPackageLoader#load file as Arrow table', async () => {
   const table = await load(GPKG_RIVERS, GeoPackageLoader, {
     geopackage: {shape: 'arrow-table'}
   });
   const geoMetadata = getGeoMetadata(table.schema.metadata);
-
-  t.equal(table.shape, 'arrow-table');
-  t.equal(table.data.numRows, 1, 'loads one feature');
-  t.equal(table.schema.fields.length, 5, 'schema replaces source geom column with geometry');
-  t.equal(geoMetadata?.primary_column, 'geometry', 'geo metadata primary column is set');
-  t.equal(geoMetadata?.columns.geometry.encoding, 'wkb', 'geo metadata identifies WKB encoding');
-
+  expect(table.shape).toBe('arrow-table');
+  expect(table.data.numRows, 'loads one feature').toBe(1);
+  expect(table.schema.fields.length, 'schema replaces source geom column with geometry').toBe(5);
+  expect(geoMetadata?.primary_column, 'geo metadata primary column is set').toBe('geometry');
+  expect(geoMetadata?.columns.geometry.encoding, 'geo metadata identifies WKB encoding').toBe(
+    'wkb'
+  );
   const rows = getRowsFromArrowTable(table);
   const roundTripped = convertWKBTableToGeoJSON(
     {shape: 'object-row-table', schema: table.schema, data: rows},
@@ -59,16 +51,11 @@ test('GeoPackageLoader#load file as Arrow table', async t => {
   );
   const response = await fetchFile(GPKG_RIVERS_GEOJSON);
   const expected = await response.json();
-
-  t.deepEqual(
-    normalizeFeatures(roundTripped.features),
-    normalizeFeatures(expected.features),
-    'Arrow output round-trips to GeoJSON'
+  expect(normalizeFeatures(roundTripped.features), 'Arrow output round-trips to GeoJSON').toEqual(
+    normalizeFeatures(expected.features)
   );
-  t.end();
 });
-
-test('GeoPackageLoader#load explicit table as Arrow table', async t => {
+test('GeoPackageLoader#load explicit table as Arrow table', async () => {
   const table = await load(GPKG_RIVERS_MULTI, GeoPackageLoader, {
     geopackage: {shape: 'arrow-table', table: 'FEATURESriversds'}
   });
@@ -80,32 +67,24 @@ test('GeoPackageLoader#load explicit table as Arrow table', async t => {
   const geojsonTable = await load(GPKG_RIVERS_MULTI, GeoPackageLoader, {
     geopackage: {shape: 'geojson-table', table: 'FEATURESriversds'}
   });
-
-  t.deepEqual(
+  expect(
     normalizeFeatures(roundTripped.features),
-    normalizeFeatures(geojsonTable.features),
     'explicit table matches GeoPackageLoader'
-  );
-  t.end();
+  ).toEqual(normalizeFeatures(geojsonTable.features));
 });
-
-test('GeoPackageLoader#load default table honors metadata heuristic', async t => {
+test('GeoPackageLoader#load default table honors metadata heuristic', async () => {
   const table = await load(GPKG_RIVERS_MULTI, GeoPackageLoader, {
     geopackage: {shape: 'arrow-table'}
   });
   const defaultTable = await load(GPKG_RIVERS_MULTI, GeoPackageLoader, {
     geopackage: {shape: 'arrow-table', table: 'preferred_rivers'}
   });
-
-  t.deepEqual(
+  expect(
     getRowsFromArrowTable(table),
-    getRowsFromArrowTable(defaultTable),
     'default selection prefers the metadata-marked table'
-  );
-  t.end();
+  ).toEqual(getRowsFromArrowTable(defaultTable));
 });
-
-test('GeoPackageLoader#load Arrow table reprojects like GeoJSON output', async t => {
+test('GeoPackageLoader#load Arrow table reprojects like GeoJSON output', async () => {
   const arrowTable = await load(GPKG_RIVERS, GeoPackageLoader, {
     geopackage: {shape: 'arrow-table'},
     gis: {reproject: true, _targetCrs: 'WGS84'}
@@ -114,37 +93,30 @@ test('GeoPackageLoader#load Arrow table reprojects like GeoJSON output', async t
     geopackage: {shape: 'geojson-table'},
     gis: {reproject: true, _targetCrs: 'WGS84'}
   });
-
   const rows = getRowsFromArrowTable(arrowTable);
   const roundTripped = convertWKBTableToGeoJSON(
     {shape: 'object-row-table', schema: arrowTable.schema, data: rows},
     arrowTable.schema
   );
-
-  t.deepEqual(
-    normalizeFeatures(roundTripped.features),
-    normalizeFeatures(geojsonTable.features),
-    'reprojected features match'
+  expect(normalizeFeatures(roundTripped.features), 'reprojected features match').toEqual(
+    normalizeFeatures(geojsonTable.features)
   );
-  t.end();
 });
-
-test('GeoPackageLoader#load missing table errors clearly', async t => {
+test('GeoPackageLoader#load missing table errors clearly', async () => {
   try {
     await load(GPKG_RIVERS_MULTI, GeoPackageLoader, {
       geopackage: {shape: 'arrow-table', table: 'missing_table_name'}
     });
-    t.fail('expected load to throw');
+    (() => {
+      throw new Error('expected load to throw');
+    })();
   } catch (error) {
-    t.ok(
+    expect(
       (error as Error).message.includes('GeoPackage table not found: missing_table_name'),
       'throws a clear missing-table error'
-    );
+    ).toBeTruthy();
   }
-
-  t.end();
 });
-
 function getRowsFromArrowTable(table): Record<string, unknown>[] {
   const rows: Record<string, unknown>[] = [];
   for (let rowIndex = 0; rowIndex < table.data.numRows; rowIndex++) {
@@ -152,7 +124,6 @@ function getRowsFromArrowTable(table): Record<string, unknown>[] {
   }
   return rows;
 }
-
 function normalizeFeatures(features: any[]) {
   return features.map(feature => {
     const properties = {...(feature.properties || {})};
@@ -160,11 +131,9 @@ function normalizeFeatures(features: any[]) {
       feature.id !== undefined && feature.id !== null
         ? feature.id
         : (properties.id as string | number);
-
     if (id !== undefined) {
       delete properties.id;
     }
-
     return {
       ...feature,
       id,

--- a/modules/geopackage/test/geopackage-loader.spec.ts
+++ b/modules/geopackage/test/geopackage-loader.spec.ts
@@ -1,90 +1,65 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {load, fetchFile} from '@loaders.gl/core';
 import {GeoPackageLoader} from '@loaders.gl/geopackage';
 // import type {Tables, ObjectRowTable, Feature} from '@loaders.gl/schema';
-
 const GPKG_RIVERS = '@loaders.gl/geopackage/test/data/rivers_small.gpkg';
 const GPKG_RIVERS_GEOJSON = '@loaders.gl/geopackage/test/data/rivers_small.geojson';
-
-test('GeoPackageLoader#load file as tables', async t => {
+test('GeoPackageLoader#load file as tables', async () => {
   const result = await load(GPKG_RIVERS, GeoPackageLoader, {
     geopackage: {
       shape: 'tables'
     }
   });
-
   const response = await fetchFile(GPKG_RIVERS_GEOJSON);
   const json = await response.json();
-
-  t.equal(result.shape, 'tables');
+  expect(result.shape).toBe('tables');
   if (result.shape === 'tables') {
     const tableName = result.tables[0].name;
     const table = result.tables[0].table;
-
-    t.equal(tableName, 'FEATURESriversds', 'loaded correct table name');
-    t.equal(table.features.length, 1, 'Correct number of rows received');
-    t.deepEqual(table.features[0], json.features[0], 'GeoPackage matches GeoJSON from OGR');
-
-    t.ok(table.schema);
-    t.equal(table.schema?.fields.length, 5);
+    expect(tableName, 'loaded correct table name').toBe('FEATURESriversds');
+    expect(table.features.length, 'Correct number of rows received').toBe(1);
+    expect(table.features[0], 'GeoPackage matches GeoJSON from OGR').toEqual(json.features[0]);
+    expect(table.schema).toBeTruthy();
+    expect(table.schema?.fields.length).toBe(5);
   }
-
-  t.end();
 });
-
-test('GeoPackageLoader#load supports core.shape', async t => {
+test('GeoPackageLoader#load supports core.shape', async () => {
   const result = await load(GPKG_RIVERS, GeoPackageLoader, {
     core: {shape: 'geojson-table'}
   });
-
-  t.equal(result.shape, 'geojson-table');
+  expect(result.shape).toBe('geojson-table');
   if (result.shape === 'geojson-table') {
-    t.equal(result.features.length, 1);
+    expect(result.features.length).toBe(1);
   }
-
-  t.end();
 });
-
-test('GeoPackageLoader#loader shape overrides core.shape', async t => {
+test('GeoPackageLoader#loader shape overrides core.shape', async () => {
   const result = await load(GPKG_RIVERS, GeoPackageLoader, {
     core: {shape: 'geojson-table'},
     geopackage: {shape: 'tables'}
   });
-
-  t.equal(result.shape, 'tables');
-  t.end();
+  expect(result.shape).toBe('tables');
 });
-
-test('GeoPackageLoader#load file and reproject to WGS84', async t => {
+test('GeoPackageLoader#load file and reproject to WGS84', async () => {
   const result = await load(GPKG_RIVERS, GeoPackageLoader, {
     geopackage: {shape: 'tables'},
     gis: {reproject: true, _targetCrs: 'WGS84'}
   });
-
-  t.equal(result.shape, 'tables');
+  expect(result.shape).toBe('tables');
   if (result.shape === 'tables') {
     const tableName = result.tables[0].name;
     const table = result.tables[0].table;
-
-    t.equal(tableName, 'FEATURESriversds', 'loaded correct table name');
-    t.ok(
+    expect(tableName, 'loaded correct table name').toBe('FEATURESriversds');
+    expect(
       // @ts-expect-error ignore geometry collection
       table.features[0].geometry.coordinates.every(coord =>
         insideBbox(coord, [-180, -90, 180, 90])
       ),
       'All coordinates in WGS84 lon-lat bounding box'
-    );
-
-    t.ok(table.schema);
-    t.equal(table.schema?.fields.length, 5);
+    ).toBeTruthy();
+    expect(table.schema).toBeTruthy();
+    expect(table.schema?.fields.length).toBe(5);
   }
-  t.end();
 });
-
 function insideBbox(coord: [number, number], bbox: number[]): boolean {
   const [minx, miny, maxx, maxy] = bbox;
   return coord[0] >= minx && coord[0] <= maxx && coord[1] >= miny && coord[1] <= maxy;

--- a/modules/geopackage/test/geopackage-source.spec.ts
+++ b/modules/geopackage/test/geopackage-source.spec.ts
@@ -1,103 +1,74 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {createDataSource, fetchFile, load, setLoaderOptions} from '@loaders.gl/core';
 import {getTableRowAsObject} from '@loaders.gl/schema-utils';
 import {GeoPackageDataSource, GeoPackageSource} from '@loaders.gl/geopackage';
 import {GeoPackageLoader as BundledGeoPackageLoader} from '@loaders.gl/geopackage/bundled';
-
 const GPKG_RIVERS_MULTI = '@loaders.gl/geopackage/test/data/rivers_multi.gpkg';
-
 setLoaderOptions({
   _workerType: 'test',
   worker: false
 });
-
-test('GeoPackageSource#createDataSource selects GeoPackage source from URL', t => {
+test('GeoPackageSource#createDataSource selects GeoPackage source from URL', () => {
   const dataSource = createDataSource(GPKG_RIVERS_MULTI, [GeoPackageSource], {
     geopackage: {}
   });
-
-  t.ok(dataSource instanceof GeoPackageDataSource, 'returns GeoPackageDataSource');
-  t.end();
+  expect(dataSource instanceof GeoPackageDataSource, 'returns GeoPackageDataSource').toBeTruthy();
 });
-
-test('GeoPackageSource#getMetadata returns tables and default selection', async t => {
+test('GeoPackageSource#getMetadata returns tables and default selection', async () => {
   const dataSource = createDataSource(await createFixtureBlob(), [GeoPackageSource], {
     core: {type: 'geopackage'},
     geopackage: {}
   }) as GeoPackageDataSource;
   const metadata = await dataSource.getMetadata();
-
-  t.equal(metadata.tables.length, 2, 'returns both vector tables');
-  t.equal(
+  expect(metadata.tables.length, 'returns both vector tables').toBe(2);
+  expect(
     metadata.tables.find(table => table.isDefault)?.name,
-    'preferred_rivers',
     'marks the metadata-selected default table'
-  );
-  t.equal(
+  ).toBe('preferred_rivers');
+  expect(
     metadata.tables.find(table => table.name === 'preferred_rivers')?.identifier,
-    'default',
     'includes GeoPackage table metadata'
-  );
-
-  t.end();
+  ).toBe('default');
 });
-
-test('GeoPackageSource#getQueryMetadata exposes the selected schema and bounds', async t => {
+test('GeoPackageSource#getQueryMetadata exposes the selected schema and bounds', async () => {
   const dataSource = createDataSource(await createFixtureBlob(), [GeoPackageSource], {
     core: {type: 'geopackage'},
     geopackage: {}
   }) as GeoPackageDataSource;
   const metadata = await dataSource.getQueryMetadata();
-  t.equal(metadata.sourceType, 'geopackage', 'uses the shared source identifier');
-  t.ok(metadata.columns.length > 0, 'publishes the selected table schema');
-  t.ok(metadata.spatial?.bounds, 'publishes feature bounds');
-  t.end();
+  expect(metadata.sourceType, 'uses the shared source identifier').toBe('geopackage');
+  expect(metadata.columns.length > 0, 'publishes the selected table schema').toBeTruthy();
+  expect(metadata.spatial?.bounds, 'publishes feature bounds').toBeTruthy();
 });
-
-test('GeoPackageSource#getTable matches GeoPackageLoader Arrow output', async t => {
+test('GeoPackageSource#getTable matches GeoPackageLoader Arrow output', async () => {
   const fixtureResponse = await fetchFile(GPKG_RIVERS_MULTI);
   const fixtureArrayBuffer = await fixtureResponse.arrayBuffer();
   const dataSource = createDataSource(new Blob([fixtureArrayBuffer]), [GeoPackageSource], {
     core: {type: 'geopackage'},
     geopackage: {}
   }) as GeoPackageDataSource;
-
   const sourceTable = await dataSource.getTable('FEATURESriversds');
   const loaderTable = await load(fixtureArrayBuffer, BundledGeoPackageLoader, {
     geopackage: {shape: 'arrow-table', table: 'FEATURESriversds'}
   });
-
-  t.deepEqual(getRows(sourceTable), getRows(loaderTable), 'source matches loader output');
-  t.end();
+  expect(getRows(sourceTable), 'source matches loader output').toEqual(getRows(loaderTable));
 });
-
-test('GeoPackageSource#getTable uses the default selection heuristic', async t => {
+test('GeoPackageSource#getTable uses the default selection heuristic', async () => {
   const dataSource = createDataSource(await createFixtureBlob(), [GeoPackageSource], {
     core: {type: 'geopackage'},
     geopackage: {}
   }) as GeoPackageDataSource;
-
   const defaultTable = await dataSource.getTable();
   const preferredTable = await dataSource.getTable('preferred_rivers');
-
-  t.deepEqual(
-    getRows(defaultTable),
-    getRows(preferredTable),
-    'default table matches the preferred table'
+  expect(getRows(defaultTable), 'default table matches the preferred table').toEqual(
+    getRows(preferredTable)
   );
-  t.end();
 });
-
 async function createFixtureBlob(): Promise<Blob> {
   const response = await fetchFile(GPKG_RIVERS_MULTI);
   const arrayBuffer = await response.arrayBuffer();
   return new Blob([arrayBuffer]);
 }
-
 function getRows(table): Record<string, unknown>[] {
   const rows: Record<string, unknown>[] = [];
   for (let rowIndex = 0; rowIndex < table.data.numRows; rowIndex++) {

--- a/modules/geotiff/test/geotiff-loader.spec.ts
+++ b/modules/geotiff/test/geotiff-loader.spec.ts
@@ -1,24 +1,13 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
-
+import {expect, test} from 'vitest';
 import {load} from '@loaders.gl/core';
 import {GeoTIFFLoader, GeoTIFFSourceLoader} from '@loaders.gl/geotiff';
-
 const TIFF_URL = '@loaders.gl/geotiff/test/data/gfw-azores.tif';
-
-test('GeoTIFFLoader.', async t => {
+test('GeoTIFFLoader.', async () => {
   const geoimage = await load(TIFF_URL, GeoTIFFLoader);
-  t.ok(geoimage, 'GeoTIFFLoader returned a result');
-
-  t.end();
+  expect(geoimage, 'GeoTIFFLoader returned a result').toBeTruthy();
 });
-
-test('GeoTIFF raster query capabilities report cancellation conservatively', async t => {
+test('GeoTIFF raster query capabilities report cancellation conservatively', async () => {
   const source = GeoTIFFSourceLoader.createDataSource('https://example.com/data.tif', {});
-  t.equal(source.getRasterQueryCapabilities().bounds, 'pushdown');
-  t.notOk(source.getRasterQueryCapabilities().cancellation);
-  t.end();
+  expect(source.getRasterQueryCapabilities().bounds).toBe('pushdown');
+  expect(source.getRasterQueryCapabilities().cancellation).toBeFalsy();
 });

--- a/modules/geotiff/test/ome-tiff.spec.ts
+++ b/modules/geotiff/test/ome-tiff.spec.ts
@@ -1,82 +1,65 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {fromFile} from 'geotiff';
 import {resolvePath, isBrowser} from '@loaders.gl/core';
-
 import {loadGeoTiff} from '@loaders.gl/geotiff';
-
 const TIFF_URL = resolvePath('@loaders.gl/geotiff/test/data/multi-channel.ome.tif');
-
-test('Creates correct TiffPixelSource for OME-TIFF.', async t => {
+test('Creates correct TiffPixelSource for OME-TIFF.', async () => {
   if (isBrowser) {
-    t.end();
     return;
   }
   const tiff = await fromFile(TIFF_URL);
   const {data} = await loadGeoTiff(tiff);
-  t.equal(data.length, 1, 'image should not be pyramidal.');
+  expect(data.length, 'image should not be pyramidal.').toBe(1);
   const [base] = data;
-  t.deepEqual(base.labels, ['t', 'c', 'z', 'y', 'x'], 'should have DimensionOrder "XYZCT".');
-  t.deepEqual(base.shape, [1, 3, 1, 167, 439], 'shape should match dimensions.');
-  t.equal(base.meta?.photometricInterpretation, 1, 'Photometric interpretation is 1.');
-  t.equal(base.meta?.physicalSizes, undefined, 'No physical sizes.');
-  t.end();
+  expect(base.labels, 'should have DimensionOrder "XYZCT".').toEqual(['t', 'c', 'z', 'y', 'x']);
+  expect(base.shape, 'shape should match dimensions.').toEqual([1, 3, 1, 167, 439]);
+  expect(base.meta?.photometricInterpretation, 'Photometric interpretation is 1.').toBe(1);
+  expect(base.meta?.physicalSizes, 'No physical sizes.').toBe(undefined);
 });
-
-test('Get raster data.', async t => {
+test('Get raster data.', async () => {
   if (isBrowser) {
-    t.end();
     return;
   }
   const tiff = await fromFile(TIFF_URL);
   const {data} = await loadGeoTiff(tiff);
   const [base] = data;
-
   for (let c = 0; c < 3; c += 1) {
     const selection = {c, z: 0, t: 0};
     const pixelData = await base.getRaster({selection}); // eslint-disable-line no-await-in-loop
-    t.equal(pixelData.width, 439);
-    t.equal(pixelData.height, 167);
-    t.equal(pixelData.data.length, 439 * 167);
-    t.equal(pixelData.data.constructor.name, 'Int8Array');
+    expect(pixelData.width).toBe(439);
+    expect(pixelData.height).toBe(167);
+    expect(pixelData.data.length).toBe(439 * 167);
+    expect(pixelData.data.constructor.name).toBe('Int8Array');
   }
-
   try {
     await base.getRaster({selection: {c: 3, z: 0, t: 0}});
   } catch (e) {
-    t.ok(e instanceof Error, 'index should be out of bounds.');
+    expect(e instanceof Error, 'index should be out of bounds.').toBeTruthy();
   }
-  t.end();
 });
-
-test('Correct OME-XML.', async t => {
+test('Correct OME-XML.', async () => {
   if (isBrowser) {
-    t.end();
     return;
   }
   const tiff = await fromFile(TIFF_URL);
   const {metadata} = await loadGeoTiff(tiff);
   const {Name, Pixels} = metadata;
   // biome-ignore format: preserve intentional fixture layout
-  t.equal(Name, 'multi-channel.ome.tif', 'Name should be \'multi-channel.ome.tif\'.');
+  expect(Name, 'Name should be \'multi-channel.ome.tif\'.').toBe('multi-channel.ome.tif');
   // @ts-ignore
-  t.equal(Pixels.SizeC, 3, 'Should have three channels.');
+  expect(Pixels.SizeC, 'Should have three channels.').toBe(3);
   // @ts-ignore
-  t.equal(Pixels.SizeT, 1, 'Should have one time index.');
+  expect(Pixels.SizeT, 'Should have one time index.').toBe(1);
   // @ts-ignore
-  t.equal(Pixels.SizeX, 439, 'Should have SizeX of 429.');
+  expect(Pixels.SizeX, 'Should have SizeX of 429.').toBe(439);
   // @ts-ignore
-  t.equal(Pixels.SizeY, 167, 'Should have SizeY of 167.');
+  expect(Pixels.SizeY, 'Should have SizeY of 167.').toBe(167);
   // @ts-ignore
-  t.equal(Pixels.SizeZ, 1, 'Should have one z index.');
+  expect(Pixels.SizeZ, 'Should have one z index.').toBe(1);
   // @ts-ignore
-  t.equal(Pixels.Type, 'int8', 'Should be int8 pixel type.');
+  expect(Pixels.Type, 'Should be int8 pixel type.').toBe('int8');
   // @ts-ignore
-  t.equal(Pixels.Channels.length, 3);
+  expect(Pixels.Channels.length).toBe(3);
   // @ts-ignore
-  t.equal(Pixels.Channels[0].SamplesPerPixel, 1);
-  t.end();
+  expect(Pixels.Channels[0].SamplesPerPixel).toBe(1);
 });

--- a/modules/geotiff/test/tiff.spec.ts
+++ b/modules/geotiff/test/tiff.spec.ts
@@ -1,81 +1,64 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {fromFile} from 'geotiff';
 import {resolvePath, isBrowser} from '@loaders.gl/core';
-
 import {loadGeoTiff} from '@loaders.gl/geotiff';
-
 const TIFF_URL = resolvePath('@loaders.gl/geotiff/test/data/multi-channel.ome.tif');
-
-test('Creates correct TiffPixelSource for OME-TIFF.', async t => {
+test('Creates correct TiffPixelSource for OME-TIFF.', async () => {
   if (isBrowser) {
-    t.end();
     return;
   }
   const tiff = await fromFile(TIFF_URL);
   const {data} = await loadGeoTiff(tiff);
-  t.equal(data.length, 1, 'image should not be pyramidal.');
+  expect(data.length, 'image should not be pyramidal.').toBe(1);
   const [base] = data;
-  t.deepEqual(base.labels, ['t', 'c', 'z', 'y', 'x'], 'should have DimensionOrder "XYZCT".');
-  t.deepEqual(base.shape, [1, 3, 1, 167, 439], 'shape should match dimensions.');
-  t.equal(base.meta?.photometricInterpretation, 1, 'Photometric interpretation is 1.');
-  t.equal(base.meta?.physicalSizes, undefined, 'No physical sizes.');
-  t.end();
+  expect(base.labels, 'should have DimensionOrder "XYZCT".').toEqual(['t', 'c', 'z', 'y', 'x']);
+  expect(base.shape, 'shape should match dimensions.').toEqual([1, 3, 1, 167, 439]);
+  expect(base.meta?.photometricInterpretation, 'Photometric interpretation is 1.').toBe(1);
+  expect(base.meta?.physicalSizes, 'No physical sizes.').toBe(undefined);
 });
-
-test('Get raster data.', async t => {
+test('Get raster data.', async () => {
   if (isBrowser) {
-    t.end();
     return;
   }
   const tiff = await fromFile(TIFF_URL);
   const {data} = await loadGeoTiff(tiff);
   const [base] = data;
-
   for (let c = 0; c < 3; c += 1) {
     const selection = {c, z: 0, t: 0};
     const pixelData = await base.getRaster({selection}); // eslint-disable-line no-await-in-loop
-    t.equal(pixelData.width, 439);
-    t.equal(pixelData.height, 167);
-    t.equal(pixelData.data.length, 439 * 167);
-    t.equal(pixelData.data.constructor.name, 'Int8Array');
+    expect(pixelData.width).toBe(439);
+    expect(pixelData.height).toBe(167);
+    expect(pixelData.data.length).toBe(439 * 167);
+    expect(pixelData.data.constructor.name).toBe('Int8Array');
   }
-
   try {
     await base.getRaster({selection: {c: 3, z: 0, t: 0}});
   } catch (e) {
-    t.ok(e instanceof Error, 'index should be out of bounds.');
+    expect(e instanceof Error, 'index should be out of bounds.').toBeTruthy();
   }
-  t.end();
 });
-
-test('Correct OME-XML.', async t => {
+test('Correct OME-XML.', async () => {
   if (isBrowser) {
-    t.end();
     return;
   }
   const tiff = await fromFile(TIFF_URL);
   const {metadata} = await loadGeoTiff(tiff);
   const {Name, Pixels} = metadata;
-  t.equal(Name, 'multi-channel.ome.tif', 'Name should be "multi-channel.ome.tif".');
+  expect(Name, 'Name should be "multi-channel.ome.tif".').toBe('multi-channel.ome.tif');
   // @ts-ignore
-  t.equal(Pixels.SizeC, 3, 'Should have three channels.');
+  expect(Pixels.SizeC, 'Should have three channels.').toBe(3);
   // @ts-ignore
-  t.equal(Pixels.SizeT, 1, 'Should have one time index.');
+  expect(Pixels.SizeT, 'Should have one time index.').toBe(1);
   // @ts-ignore
-  t.equal(Pixels.SizeX, 439, 'Should have SizeX of 429.');
+  expect(Pixels.SizeX, 'Should have SizeX of 429.').toBe(439);
   // @ts-ignore
-  t.equal(Pixels.SizeY, 167, 'Should have SizeY of 167.');
+  expect(Pixels.SizeY, 'Should have SizeY of 167.').toBe(167);
   // @ts-ignore
-  t.equal(Pixels.SizeZ, 1, 'Should have one z index.');
+  expect(Pixels.SizeZ, 'Should have one z index.').toBe(1);
   // @ts-ignore
-  t.equal(Pixels.Type, 'int8', 'Should be int8 pixel type.');
+  expect(Pixels.Type, 'Should be int8 pixel type.').toBe('int8');
   // @ts-ignore
-  t.equal(Pixels.Channels.length, 3);
+  expect(Pixels.Channels.length).toBe(3);
   // @ts-ignore
-  t.equal(Pixels.Channels[0].SamplesPerPixel, 1);
-  t.end();
+  expect(Pixels.Channels[0].SamplesPerPixel).toBe(1);
 });

--- a/modules/geotiff/test/utils.spec.ts
+++ b/modules/geotiff/test/utils.spec.ts
@@ -1,22 +1,13 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
-
+import {expect, test} from 'vitest';
 // @ts-ignore
 import {intToRgba, isInterleaved} from '@loaders.gl/geotiff/lib/utils/tiff-utils';
-
-test('Convert int to RGBA color', t => {
-  t.deepEqual(intToRgba(0), [0, 0, 0, 0]);
-  t.deepEqual(intToRgba(100100), [0, 1, 135, 4]);
-  t.end();
+test('Convert int to RGBA color', () => {
+  expect(intToRgba(0)).toEqual([0, 0, 0, 0]);
+  expect(intToRgba(100100)).toEqual([0, 1, 135, 4]);
 });
-
-test('isInterleaved', t => {
-  t.ok(isInterleaved([1, 2, 400, 400, 4]));
-  t.ok(isInterleaved([1, 2, 400, 400, 3]));
-  t.ok(!isInterleaved([1, 2, 400, 400]));
-  t.ok(!isInterleaved([1, 3, 4, 4000000]));
-  t.end();
+test('isInterleaved', () => {
+  expect(isInterleaved([1, 2, 400, 400, 4])).toBeTruthy();
+  expect(isInterleaved([1, 2, 400, 400, 3])).toBeTruthy();
+  expect(!isInterleaved([1, 2, 400, 400])).toBeTruthy();
+  expect(!isInterleaved([1, 3, 4, 4000000])).toBeTruthy();
 });

--- a/modules/i3s/test/arcgis-webscene-loader.spec.ts
+++ b/modules/i3s/test/arcgis-webscene-loader.spec.ts
@@ -1,24 +1,15 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {load} from '@loaders.gl/core';
 import {ArcGISWebSceneLoader} from '@loaders.gl/i3s';
-
 const ARCGIS_WEB_SCENE_WITH_SUPPORTED_LAYERS_URL =
   '@loaders.gl/i3s/test/data/arcgis-webscenes/arcgis-webscene-with-supported-layers.json';
-
 const ARCGIS_WEB_SCENE_WITH_UNSUPPORTED_LAYER_IN_LIST_URL =
   '@loaders.gl/i3s/test/data/arcgis-webscenes/arcgis-webscene-with-one-unsupported-layer.json';
-
 const ARCGIS_WEB_SCENE_WITH_UNSUPPORTED_CRS_URL =
   '@loaders.gl/i3s/test/data/arcgis-webscenes/arcgis-webscene-with-unsupported-crs.json';
-
 const ARCGIS_WEB_SCENE_WITH_UNSUPPORTED_LAYERS_URL =
   '@loaders.gl/i3s/test/data/arcgis-webscenes/arcgis-webscene-with-all-unsupported-layers.json';
-
-test('ArcGISWebSceneLoader#should load WebScene', async t => {
+test('ArcGISWebSceneLoader#should load WebScene', async () => {
   const WEB_SCENE_FIRST_OPERATIONAL_LAYER_EXPECTED = {
     id: '15f2fe08c8d-layer-0',
     showLegend: true,
@@ -55,61 +46,46 @@ test('ArcGISWebSceneLoader#should load WebScene', async t => {
       }
     }
   };
-
   const webScene = await load(ARCGIS_WEB_SCENE_WITH_SUPPORTED_LAYERS_URL, ArcGISWebSceneLoader);
-
-  t.ok(webScene);
-  t.ok(webScene.header);
-  t.equal(webScene.header.authoringApp, 'WebSceneViewer');
-  t.ok(webScene.layers);
-  t.equal(webScene.unsupportedLayers.length, 0);
-
+  expect(webScene).toBeTruthy();
+  expect(webScene.header).toBeTruthy();
+  expect(webScene.header.authoringApp).toBe('WebSceneViewer');
+  expect(webScene.layers).toBeTruthy();
+  expect(webScene.unsupportedLayers.length).toBe(0);
   const firstLayer = webScene.layers[0];
   const {url, ...dataWithoutUrl} = firstLayer;
-
-  t.ok(url);
-  t.equal(webScene.layers.length, 3, 'parent layers are good');
-  t.equal(webScene.layers[2]?.layers?.length, 4, 'child layers are good');
-  t.deepEqual(dataWithoutUrl, WEB_SCENE_FIRST_OPERATIONAL_LAYER_EXPECTED);
-
-  t.end();
+  expect(url).toBeTruthy();
+  expect(webScene.layers.length, 'parent layers are good').toBe(3);
+  expect(webScene.layers[2]?.layers?.length, 'child layers are good').toBe(4);
+  expect(dataWithoutUrl).toEqual(WEB_SCENE_FIRST_OPERATIONAL_LAYER_EXPECTED);
 });
-
-test('ArcGISWebSceneLoader#should load WebScene with partially unsupported layers', async t => {
+test('ArcGISWebSceneLoader#should load WebScene with partially unsupported layers', async () => {
   const webScene = await load(
     ARCGIS_WEB_SCENE_WITH_UNSUPPORTED_LAYER_IN_LIST_URL,
     ArcGISWebSceneLoader
   );
-
-  t.ok(webScene);
-  t.ok(webScene.header);
-  t.equal(webScene.header.authoringApp, 'WebSceneViewer');
-  t.ok(webScene.layers);
-  t.equal(webScene.layers.length, 1);
-  t.equal(webScene.unsupportedLayers.length, 1);
-
+  expect(webScene).toBeTruthy();
+  expect(webScene.header).toBeTruthy();
+  expect(webScene.header.authoringApp).toBe('WebSceneViewer');
+  expect(webScene.layers).toBeTruthy();
+  expect(webScene.layers.length).toBe(1);
+  expect(webScene.unsupportedLayers.length).toBe(1);
   const unsupportedLayerType = webScene.unsupportedLayers[0].layerType;
-  t.equal(unsupportedLayerType, 'ArcGISFeatureLayer');
-
-  t.end();
+  expect(unsupportedLayerType).toBe('ArcGISFeatureLayer');
 });
-
-test('ArcGISWebSceneLoader#should return error of loading WebScene if one layer has unsupported CRS', async t => {
+test('ArcGISWebSceneLoader#should return error of loading WebScene if one layer has unsupported CRS', async () => {
   try {
     await load(ARCGIS_WEB_SCENE_WITH_UNSUPPORTED_CRS_URL, ArcGISWebSceneLoader);
   } catch (error) {
     // @ts-expect-error - Object is of type 'unknown'
-    t.equal(error.message, 'NOT_SUPPORTED_CRS_ERROR');
+    expect(error.message).toBe('NOT_SUPPORTED_CRS_ERROR');
   }
-  t.end();
 });
-
-test('ArcGISWebSceneLoader#should return error of loading WebScene if no any supported layers', async t => {
+test('ArcGISWebSceneLoader#should return error of loading WebScene if no any supported layers', async () => {
   try {
     await load(ARCGIS_WEB_SCENE_WITH_UNSUPPORTED_LAYERS_URL, ArcGISWebSceneLoader);
   } catch (error) {
     // @ts-expect-error - Object is of type 'unknown'
-    t.equal(error.message, 'NO_AVAILABLE_SUPPORTED_LAYERS_ERROR');
+    expect(error.message).toBe('NO_AVAILABLE_SUPPORTED_LAYERS_ERROR');
   }
-  t.end();
 });

--- a/modules/i3s/test/helpers/i3s-nodepages-tiles.spec.ts
+++ b/modules/i3s/test/helpers/i3s-nodepages-tiles.spec.ts
@@ -1,52 +1,37 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {isBrowser} from '@loaders.gl/core';
 import I3SNodePagesTiles from '../../src/lib/helpers/i3s-nodepages-tiles';
 import {TEST_LAYER_URL, TILESET_STUB} from '../test-utils/load-utils';
-
-test('I3SNodePagesTiles#Forms tile header from node pages data', async t => {
+test('I3SNodePagesTiles#Forms tile header from node pages data', async () => {
   const i3SNodePagesTiles = new I3SNodePagesTiles(TILESET_STUB(), TEST_LAYER_URL, {});
   const rootNode = await i3SNodePagesTiles.formTileFromNodePages(0);
-  t.ok(rootNode);
-  t.end();
+  expect(rootNode).toBeTruthy();
 });
-
-test('I3SNodePagesTiles#Root tile should not have content', async t => {
+test('I3SNodePagesTiles#Root tile should not have content', async () => {
   const i3SNodePagesTiles = new I3SNodePagesTiles(TILESET_STUB(), TEST_LAYER_URL, {});
   const rootNode = await i3SNodePagesTiles.formTileFromNodePages(0);
-  t.ok(rootNode);
-  t.notOk(rootNode.contentUrl);
-  t.notOk(rootNode.textureUrl);
-  t.end();
+  expect(rootNode).toBeTruthy();
+  expect(rootNode.contentUrl).toBeFalsy();
+  expect(rootNode.textureUrl).toBeFalsy();
 });
-
-test('I3SNodePagesTiles#Tile with content', async t => {
+test('I3SNodePagesTiles#Tile with content', async () => {
   const i3SNodePagesTiles = new I3SNodePagesTiles(TILESET_STUB(), TEST_LAYER_URL, {});
   const node1 = await i3SNodePagesTiles.formTileFromNodePages(1);
-  t.ok(node1);
-  t.equal(
-    node1.contentUrl,
+  expect(node1).toBeTruthy();
+  expect(node1.contentUrl).toBe(
     'https://raw.githubusercontent.com/visgl/loaders.gl/master/modules/i3s/test/data/SanFrancisco_3DObjects_1_7/SceneServer/layers/0/nodes/1/geometries/0'
   );
   if (isBrowser) {
-    t.equal(
-      node1.textureUrl,
+    expect(node1.textureUrl).toBe(
       'https://raw.githubusercontent.com/visgl/loaders.gl/master/modules/i3s/test/data/SanFrancisco_3DObjects_1_7/SceneServer/layers/0/nodes/1/textures/0_0_1'
     );
   } else {
-    t.equal(
-      node1.textureUrl,
+    expect(node1.textureUrl).toBe(
       'https://raw.githubusercontent.com/visgl/loaders.gl/master/modules/i3s/test/data/SanFrancisco_3DObjects_1_7/SceneServer/layers/0/nodes/1/textures/0'
     );
   }
-
-  t.end();
 });
-
-test('I3SNodePagesTiles#Layer without textures', async t => {
+test('I3SNodePagesTiles#Layer without textures', async () => {
   const i3SNodePagesTiles = new I3SNodePagesTiles(
     // @ts-expect-error
     {...TILESET_STUB(), materialDefinitions: [{}]},
@@ -54,9 +39,8 @@ test('I3SNodePagesTiles#Layer without textures', async t => {
     {}
   );
   const node1 = await i3SNodePagesTiles.formTileFromNodePages(1);
-  t.ok(node1);
-  t.notOk(node1.textureUrl);
-
+  expect(node1).toBeTruthy();
+  expect(node1.textureUrl).toBeFalsy();
   const i3SNodePagesTiles2 = new I3SNodePagesTiles(
     {
       ...TILESET_STUB(),
@@ -67,9 +51,8 @@ test('I3SNodePagesTiles#Layer without textures', async t => {
     {}
   );
   const node2 = await i3SNodePagesTiles2.formTileFromNodePages(2);
-  t.ok(node2);
-  t.notOk(node2.textureUrl);
-
+  expect(node2).toBeTruthy();
+  expect(node2.textureUrl).toBeFalsy();
   const i3SNodePagesTiles3 = new I3SNodePagesTiles(
     {
       ...TILESET_STUB(),
@@ -79,25 +62,19 @@ test('I3SNodePagesTiles#Layer without textures', async t => {
     {}
   );
   const node3 = await i3SNodePagesTiles3.formTileFromNodePages(3);
-  t.ok(node3);
-  t.notOk(node3.textureUrl);
-
-  t.end();
+  expect(node3).toBeTruthy();
+  expect(node3.textureUrl).toBeFalsy();
 });
-
 // Logic moved to parse-i3s.js to avoid calling extra conversion the center from cartographic to cartesian
-test.skip('I3SNodePagesTiles#Tile should have mbs converted from obb', async t => {
+test.skip('I3SNodePagesTiles#Tile should have mbs converted from obb', async () => {
   const i3SNodePagesTiles = new I3SNodePagesTiles(TILESET_STUB(), TEST_LAYER_URL, {});
   const node1 = await i3SNodePagesTiles.formTileFromNodePages(1);
-  t.ok(node1);
-  t.deepEqual(
-    node1.mbs,
-    [8.676496951388435, 50.108416671362576, 189.47502169783516, 3243.264050599379]
-  );
-  t.end();
+  expect(node1).toBeTruthy();
+  expect(node1.mbs).toEqual([
+    8.676496951388435, 50.108416671362576, 189.47502169783516, 3243.264050599379
+  ]);
 });
-
-test('I3SNodePagesTiles#Select "dds" texture if it is supported', async t => {
+test('I3SNodePagesTiles#Select "dds" texture if it is supported', async () => {
   const i3SNodePagesTiles = new I3SNodePagesTiles(
     {
       ...TILESET_STUB(),
@@ -120,38 +97,33 @@ test('I3SNodePagesTiles#Select "dds" texture if it is supported', async t => {
     {}
   );
   const node = await i3SNodePagesTiles.formTileFromNodePages(2);
-  t.ok(node);
-
+  expect(node).toBeTruthy();
   if (isBrowser) {
     if (node.textureUrl?.endsWith('/0_0_1')) {
-      t.equal(
-        node.textureUrl,
+      expect(node.textureUrl).toBe(
         'https://raw.githubusercontent.com/visgl/loaders.gl/master/modules/i3s/test/data/SanFrancisco_3DObjects_1_7/SceneServer/layers/0/nodes/2/textures/0_0_1'
       );
-      t.deepEqual(i3SNodePagesTiles.textureDefinitionsSelectedFormats, [
+      expect(i3SNodePagesTiles.textureDefinitionsSelectedFormats).toEqual([
         {name: '0_0_1', format: 'dds'}
       ]);
     } else {
-      t.equal(
-        node.textureUrl,
+      expect(node.textureUrl).toBe(
         'https://raw.githubusercontent.com/visgl/loaders.gl/master/modules/i3s/test/data/SanFrancisco_3DObjects_1_7/SceneServer/layers/0/nodes/2/textures/0'
       );
-      t.deepEqual(i3SNodePagesTiles.textureDefinitionsSelectedFormats, [
+      expect(i3SNodePagesTiles.textureDefinitionsSelectedFormats).toEqual([
         {name: '0', format: 'jpg'}
       ]);
     }
   } else {
-    t.equal(
-      node.textureUrl,
+    expect(node.textureUrl).toBe(
       'https://raw.githubusercontent.com/visgl/loaders.gl/master/modules/i3s/test/data/SanFrancisco_3DObjects_1_7/SceneServer/layers/0/nodes/2/textures/0'
     );
-    t.deepEqual(i3SNodePagesTiles.textureDefinitionsSelectedFormats, [{name: '0', format: 'jpg'}]);
+    expect(i3SNodePagesTiles.textureDefinitionsSelectedFormats).toEqual([
+      {name: '0', format: 'jpg'}
+    ]);
   }
-
-  t.end();
 });
-
-test('I3SNodePagesTiles#Switch off compressed textures', async t => {
+test('I3SNodePagesTiles#Switch off compressed textures', async () => {
   const i3SNodePagesTiles = new I3SNodePagesTiles(
     {
       ...TILESET_STUB(),
@@ -174,58 +146,44 @@ test('I3SNodePagesTiles#Switch off compressed textures', async t => {
     {i3s: {useCompressedTextures: false}}
   );
   const node = await i3SNodePagesTiles.formTileFromNodePages(2);
-  t.ok(node);
-
+  expect(node).toBeTruthy();
   if (isBrowser) {
     if (node.textureUrl?.endsWith('/0')) {
-      t.equal(
-        node.textureUrl,
+      expect(node.textureUrl).toBe(
         'https://raw.githubusercontent.com/visgl/loaders.gl/master/modules/i3s/test/data/SanFrancisco_3DObjects_1_7/SceneServer/layers/0/nodes/2/textures/0'
       );
-      t.deepEqual(i3SNodePagesTiles.textureDefinitionsSelectedFormats, [
+      expect(i3SNodePagesTiles.textureDefinitionsSelectedFormats).toEqual([
         {name: '0', format: 'jpg'}
       ]);
     }
   }
-
-  t.end();
 });
-
-test('I3SNodePagesTiles#Should load DRACO geometry', async t => {
+test('I3SNodePagesTiles#Should load DRACO geometry', async () => {
   const i3SNodePagesTiles = new I3SNodePagesTiles(TILESET_STUB(), TEST_LAYER_URL, {
     i3s: {useDracoGeometry: true}
   });
   const node1 = await i3SNodePagesTiles.formTileFromNodePages(1);
-  t.ok(node1);
-  t.equal(
-    node1.contentUrl,
+  expect(node1).toBeTruthy();
+  expect(node1.contentUrl).toBe(
     'https://raw.githubusercontent.com/visgl/loaders.gl/master/modules/i3s/test/data/SanFrancisco_3DObjects_1_7/SceneServer/layers/0/nodes/1/geometries/1'
   );
-
   const tilesetJson = TILESET_STUB();
   // Remove compressed geometry metadata from geometry definitions
   if (tilesetJson.geometryDefinitions) {
     tilesetJson.geometryDefinitions[0].geometryBuffers =
       tilesetJson.geometryDefinitions[0].geometryBuffers.slice(0, 1);
   }
-
   const i3SNodePagesTiles2 = new I3SNodePagesTiles(tilesetJson, TEST_LAYER_URL, {
     i3s: {useDracoGeometry: true}
   });
   const node12 = await i3SNodePagesTiles2.formTileFromNodePages(1);
-  t.equal(
-    node12.contentUrl,
+  expect(node12.contentUrl).toBe(
     'https://raw.githubusercontent.com/visgl/loaders.gl/master/modules/i3s/test/data/SanFrancisco_3DObjects_1_7/SceneServer/layers/0/nodes/1/geometries/0'
   );
-
-  t.end();
 });
-
-test('I3SNodePagesTiles#Root tile should calculate nodesInNodePages metric', async t => {
+test('I3SNodePagesTiles#Root tile should calculate nodesInNodePages metric', async () => {
   const i3SNodePagesTiles = new I3SNodePagesTiles(TILESET_STUB(), TEST_LAYER_URL, {});
   await i3SNodePagesTiles.formTileFromNodePages(0);
-
   const nodesInNodePages = i3SNodePagesTiles.nodesInNodePages;
-  t.equal(nodesInNodePages, 16);
-  t.end();
+  expect(nodesInNodePages).toBe(16);
 });

--- a/modules/i3s/test/i3s-attribute-loader.spec.ts
+++ b/modules/i3s/test/i3s-attribute-loader.spec.ts
@@ -1,32 +1,23 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
-
+import {expect, test} from 'vitest';
 import {load} from '@loaders.gl/core';
 import {I3SAttributeLoader} from '@loaders.gl/i3s';
 // @ts-expect-error
 import {loadFeatureAttributes} from '@loaders.gl/i3s/i3s-attribute-loader';
-
 const objectIdsUrl = '@loaders.gl/i3s/test/data/attributes/f_0/0/index.bin';
 const namesUrl = '@loaders.gl/i3s/test/data/attributes/f_1/0/index.bin';
 const heightRoofUrl = '@loaders.gl/i3s/test/data/attributes/f_2/0/index.bin';
 const wrongNamesUrl = '@loaders.gl/i3s/test/data/attributes/f_1/0/wrong.bin';
 const wrongBufferNamesUrl = '@loaders.gl/i3s/test/data/attributes/f_1/0/wrong-buffer.bin';
-
 const objectIdsWithCodeValuesUrl =
   '@loaders.gl/i3s/test/data/BuildingSceneLayer/attributes/f_0/0/index.bin';
 const attributesWithCodeValuesUrl =
   '@loaders.gl/i3s/test/data/BuildingSceneLayer/attributes/f_27/0/index.bin';
 const shortInt16AttributesUrl =
   '@loaders.gl/i3s/test/data/BuildingSceneLayer/attributes/f_7/0/index.bin';
-
 const name602 = 'West End Building\0';
 const objecId0 = 979297;
 const heightRoof0 = 32.18;
 const codeValuesFeatureId = 5;
-
 const TILE_WITHOUT_URLS = {
   tileset: {
     tileset: {
@@ -37,7 +28,6 @@ const TILE_WITHOUT_URLS = {
     }
   }
 };
-
 const TILE = {
   tileset: {
     tileset: {
@@ -51,7 +41,6 @@ const TILE = {
     attributeUrls: [objectIdsUrl, namesUrl, heightRoofUrl]
   }
 };
-
 const TILE_WITH_WRONG_NAME_ATTRIBUTE_URL = {
   tileset: {
     tileset: {
@@ -65,7 +54,6 @@ const TILE_WITH_WRONG_NAME_ATTRIBUTE_URL = {
     attributeUrls: [objectIdsUrl, wrongNamesUrl, heightRoofUrl]
   }
 };
-
 const TILE_WITH_WRONG_BUFFER_NAME_ATTRIBUTE = {
   tileset: {
     tileset: {
@@ -79,7 +67,6 @@ const TILE_WITH_WRONG_BUFFER_NAME_ATTRIBUTE = {
     attributeUrls: [objectIdsUrl, wrongBufferNamesUrl, heightRoofUrl]
   }
 };
-
 const TILE_WITH_CODE_VALUES_ATTRIBUTE = {
   tileset: {
     tileset: {
@@ -135,7 +122,6 @@ const TILE_WITH_CODE_VALUES_ATTRIBUTE = {
     attributeUrls: [objectIdsWithCodeValuesUrl, attributesWithCodeValuesUrl]
   }
 };
-
 const TILE_WITH_INT_16_ATTRIBUTES = {
   tileset: {
     tileset: {
@@ -149,101 +135,79 @@ const TILE_WITH_INT_16_ATTRIBUTES = {
     attributeUrls: [objectIdsWithCodeValuesUrl, shortInt16AttributesUrl]
   }
 };
-
-test('I3SAttributeLoader# should return empty object if no attributeName provided', async t => {
+test('I3SAttributeLoader# should return empty object if no attributeName provided', async () => {
   const options = {
     attributeType: 'Oid32'
   };
   const attributes = await load(objectIdsUrl, I3SAttributeLoader, options);
-  t.ok(attributes);
-  t.deepEqual(attributes, {});
-  t.end();
+  expect(attributes).toBeTruthy();
+  expect(attributes).toEqual({});
 });
-
-test('I3SAttributeLoader# should return empty object if no attributeType provided', async t => {
+test('I3SAttributeLoader# should return empty object if no attributeType provided', async () => {
   const options = {
     attributeName: 'OBJECTID'
   };
   const attributes = await load(objectIdsUrl, I3SAttributeLoader, options);
-  t.ok(attributes);
-  t.deepEqual(attributes, {OBJECTID: null});
-  t.end();
+  expect(attributes).toBeTruthy();
+  expect(attributes).toEqual({OBJECTID: null});
 });
-
-test('I3SAttributeLoader# should return empty object if no attributeName and attributeType provided', async t => {
+test('I3SAttributeLoader# should return empty object if no attributeName and attributeType provided', async () => {
   const attributes = await load(objectIdsUrl, I3SAttributeLoader);
-  t.ok(attributes);
-  t.deepEqual(attributes, {});
-  t.end();
+  expect(attributes).toBeTruthy();
+  expect(attributes).toEqual({});
 });
-
-test('I3SAttributeLoader# should load OBJECTID attribute', async t => {
+test('I3SAttributeLoader# should load OBJECTID attribute', async () => {
   const options = {
     attributeName: 'OBJECTID',
     attributeType: 'Oid32'
   };
   const attributes = await load(objectIdsUrl, I3SAttributeLoader, options);
-  t.ok(attributes);
-  t.ok(attributes.OBJECTID);
-  t.equal(attributes.OBJECTID?.[0], objecId0);
-  t.end();
+  expect(attributes).toBeTruthy();
+  expect(attributes.OBJECTID).toBeTruthy();
+  expect(attributes.OBJECTID?.[0]).toBe(objecId0);
 });
-
-test('I3SAttributeLoader# should load string attribute', async t => {
+test('I3SAttributeLoader# should load string attribute', async () => {
   const options = {
     attributeName: 'NAME',
     attributeType: 'String'
   };
   const attributes = await load(namesUrl, I3SAttributeLoader, options);
-  t.ok(attributes);
-  t.ok(attributes.NAME);
-  t.equal(attributes.NAME?.[602], name602);
-  t.end();
+  expect(attributes).toBeTruthy();
+  expect(attributes.NAME).toBeTruthy();
+  expect(attributes.NAME?.[602]).toBe(name602);
 });
-
-test('I3SAttributeLoader# should load float attribute', async t => {
+test('I3SAttributeLoader# should load float attribute', async () => {
   const options = {
     attributeName: 'HEIGHTROOF',
     attributeType: 'Float64'
   };
   const attributes = await load(heightRoofUrl, I3SAttributeLoader, options);
-  t.ok(attributes);
-  t.ok(attributes.HEIGHTROOF);
-  t.equal(attributes.HEIGHTROOF?.[0], heightRoof0);
-  t.end();
+  expect(attributes).toBeTruthy();
+  expect(attributes.HEIGHTROOF).toBeTruthy();
+  expect(attributes.HEIGHTROOF?.[0]).toBe(heightRoof0);
 });
-
-test('I3SAttributeLoader#loadFeatureAttributes should return null if no tile', async t => {
+test('I3SAttributeLoader#loadFeatureAttributes should return null if no tile', async () => {
   const tile = {};
   const featureId = 1;
   const options = {};
-
   const attributes = await loadFeatureAttributes(tile, featureId, options);
-  t.equal(attributes, null);
-  t.end();
+  expect(attributes).toBe(null);
 });
-
-test('I3SAttributeLoader#loadFeatureAttributes should return null if no attributeUrls', async t => {
+test('I3SAttributeLoader#loadFeatureAttributes should return null if no attributeUrls', async () => {
   const tile = TILE_WITHOUT_URLS;
   const featureId = 1;
   const options = {};
-
   const attributes = await loadFeatureAttributes(tile, featureId, options);
-  t.equal(attributes, null);
-  t.end();
+  expect(attributes).toBe(null);
 });
-
-test('I3SAttributeLoader#loadFeatureAttributes should return null if no featureId', async t => {
+test('I3SAttributeLoader#loadFeatureAttributes should return null if no featureId', async () => {
   const tile = TILE;
   const featureId = null;
   const options = {};
-
   const attributes = await loadFeatureAttributes(tile, featureId, options);
-  t.equal(attributes, null);
-  t.end();
+  expect(attributes).toBe(null);
 });
-
-test('I3SAttributeLoader#loadFeatureAttributes should return null if no objectIds in attributes', async t => {
+test('I3SAttributeLoader#loadFeatureAttributes should return null if no objectIds in attributes', async () => {
   const tile = {
     ...TILE,
     tileset: {
@@ -257,53 +221,38 @@ test('I3SAttributeLoader#loadFeatureAttributes should return null if no objectId
   };
   const featureId = objecId0;
   const options = {};
-
   const attributes = await loadFeatureAttributes(tile, featureId, options);
-  t.equal(attributes, null);
-  t.end();
+  expect(attributes).toBe(null);
 });
-
-test('I3SAttributeLoader#loadFeatureAttributes should return null if no such objectId in objectIds array', async t => {
+test('I3SAttributeLoader#loadFeatureAttributes should return null if no such objectId in objectIds array', async () => {
   const tile = TILE;
   const featureId = 12345;
   const options = {};
-
   const attributes = await loadFeatureAttributes(tile, featureId, options);
-  t.equal(attributes, null);
-  t.end();
+  expect(attributes).toBe(null);
 });
-
-test('I3SAttributeLoader#loadFeatureAttributes should return attributes object', async t => {
+test('I3SAttributeLoader#loadFeatureAttributes should return attributes object', async () => {
   const tile = TILE;
   const featureId = objecId0;
   const options = {};
-
   const attributes = await loadFeatureAttributes(tile, featureId, options);
-  t.deepEqual(attributes, {OBJECTID: '979297', NAME: ''});
-  t.end();
+  expect(attributes).toEqual({OBJECTID: '979297', NAME: ''});
 });
-
-test('I3SAttributeLoader#loadFeatureAttributes if one of them are failed to fetch', async t => {
+test('I3SAttributeLoader#loadFeatureAttributes if one of them are failed to fetch', async () => {
   const tile = TILE_WITH_WRONG_NAME_ATTRIBUTE_URL;
   const featureId = objecId0;
   const options = {};
-
   const attributes = await loadFeatureAttributes(tile, featureId, options);
-  t.deepEqual(attributes, {OBJECTID: '979297', NAME: ''});
-  t.end();
+  expect(attributes).toEqual({OBJECTID: '979297', NAME: ''});
 });
-
-test('I3SAttributeLoader#loadFeatureAttributes string attribute should be empty if string attribute has multiple of 4 error from arrayBuffer', async t => {
+test('I3SAttributeLoader#loadFeatureAttributes string attribute should be empty if string attribute has multiple of 4 error from arrayBuffer', async () => {
   const tile = TILE_WITH_WRONG_BUFFER_NAME_ATTRIBUTE;
   const featureId = objecId0;
   const options = {};
-
   const attributes = await loadFeatureAttributes(tile, featureId, options);
-  t.deepEqual(attributes, {OBJECTID: '979297', NAME: ''});
-  t.end();
+  expect(attributes).toEqual({OBJECTID: '979297', NAME: ''});
 });
-
-test('I3SAttributeLoader#loadFeatureAttributes should work with fetch options', async t => {
+test('I3SAttributeLoader#loadFeatureAttributes should work with fetch options', async () => {
   const tile = TILE_WITH_WRONG_BUFFER_NAME_ATTRIBUTE;
   const featureId = objecId0;
   const options = {
@@ -311,35 +260,27 @@ test('I3SAttributeLoader#loadFeatureAttributes should work with fetch options', 
     attributeType: 'Float64',
     fetch: {headers: {Authorization: '123456'}}
   };
-
   const attributes = await loadFeatureAttributes(tile, featureId, options);
-  t.deepEqual(attributes, {OBJECTID: '979297', NAME: ''});
-  t.end();
+  expect(attributes).toEqual({OBJECTID: '979297', NAME: ''});
 });
-
-test('I3SAttributeLoader#loadFeatureAttributes should work with code values if tilesetFields is provided', async t => {
+test('I3SAttributeLoader#loadFeatureAttributes should work with code values if tilesetFields is provided', async () => {
   const tile = TILE_WITH_CODE_VALUES_ATTRIBUTE;
   const featureId = codeValuesFeatureId;
   const options = {
     attributeName: 'BaseLevel',
     attributeType: 'Int32'
   };
-
   const attributes = await loadFeatureAttributes(tile, featureId, options);
-  t.deepEqual(attributes, {OBJECTID_1: '5', BaseLevel: '1ST FLOOR'});
-  t.end();
+  expect(attributes).toEqual({OBJECTID_1: '5', BaseLevel: '1ST FLOOR'});
 });
-
-test('I3SAttributeLoader#loadFeatureAttributes should work with Int16 attribute type', async t => {
+test('I3SAttributeLoader#loadFeatureAttributes should work with Int16 attribute type', async () => {
   const tile = TILE_WITH_INT_16_ATTRIBUTES;
   const featureId = codeValuesFeatureId;
   const options = {
     attributeName: 'BldgLevel_IsBuildingStory',
     attributeType: 'Int16'
   };
-
   const attributes = await loadFeatureAttributes(tile, featureId, options);
   // eslint-disable-next-line camelcase
-  t.deepEqual(attributes, {OBJECTID_1: '5', BldgLevel_IsBuildingStory: '-1'});
-  t.end();
+  expect(attributes).toEqual({OBJECTID_1: '5', BldgLevel_IsBuildingStory: '-1'});
 });

--- a/modules/i3s/test/i3s-building-scene-layer-loader.spec.ts
+++ b/modules/i3s/test/i3s-building-scene-layer-loader.spec.ts
@@ -1,11 +1,6 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {load} from '@loaders.gl/core';
 import {I3SBuildingSceneLayerLoader} from '@loaders.gl/i3s';
-
 const BUILDING_SCENE_SUBLAYER_0_EXPECTED = {
   id: 31,
   layerType: '3DObject',
@@ -15,25 +10,18 @@ const BUILDING_SCENE_SUBLAYER_0_EXPECTED = {
   modelName: 'TelephoneDevices',
   discipline: 'Electrical'
 };
-
 const I3S_TILE_CONTENT =
   '@loaders.gl/i3s/test/data/BuildingSceneLayer/BuildingSceneLayerTileset.json';
-
-test('ParseI3sTileContent#should parse tile content', async t => {
+test('ParseI3sTileContent#should parse tile content', async () => {
   const buildingSceneLayerStructure = await load(I3S_TILE_CONTENT, I3SBuildingSceneLayerLoader);
-
-  t.ok(buildingSceneLayerStructure);
-  t.ok(buildingSceneLayerStructure.header);
-  t.equal(buildingSceneLayerStructure.header.id, 0);
-  t.equal(buildingSceneLayerStructure.header.layerType, 'Building');
-  t.ok(buildingSceneLayerStructure.sublayers);
-
+  expect(buildingSceneLayerStructure).toBeTruthy();
+  expect(buildingSceneLayerStructure.header).toBeTruthy();
+  expect(buildingSceneLayerStructure.header.id).toBe(0);
+  expect(buildingSceneLayerStructure.header.layerType).toBe('Building');
+  expect(buildingSceneLayerStructure.sublayers).toBeTruthy();
   const firstSublayer = buildingSceneLayerStructure.sublayers[0];
   const {url, ...dataWithoutUrl} = firstSublayer;
-
-  t.ok(url);
-  t.equal(buildingSceneLayerStructure.sublayers.length, 32);
-  t.deepEqual(dataWithoutUrl, BUILDING_SCENE_SUBLAYER_0_EXPECTED);
-
-  t.end();
+  expect(url).toBeTruthy();
+  expect(buildingSceneLayerStructure.sublayers.length).toBe(32);
+  expect(dataWithoutUrl).toEqual(BUILDING_SCENE_SUBLAYER_0_EXPECTED);
 });

--- a/modules/i3s/test/i3s-content-loader.spec.ts
+++ b/modules/i3s/test/i3s-content-loader.spec.ts
@@ -1,16 +1,10 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {fetchFile, isBrowser, parse} from '@loaders.gl/core';
 import {getImageData} from '@loaders.gl/images';
 // @ts-expect-error
 import I3SNodePagesTiles from '@loaders.gl/i3s/lib/helpers/i3s-nodepages-tiles';
 import {TEST_LAYER_URL, TILESET_STUB} from '@loaders.gl/i3s/test/test-utils/load-utils';
-
 import {I3SContentLoader} from '@loaders.gl/i3s';
-
 const I3S_TILE_CONTENT =
   '@loaders.gl/i3s/test/data/SanFrancisco_3DObjects_1_7/SceneServer/layers/0/nodes/1/geometries/0';
 const NEW_YORK_TILE_CONTENT =
@@ -21,8 +15,7 @@ const MONTREAL_TILE_CONTENT =
   '@loaders.gl/i3s/test/data/Montreal_3DObjects_subset_1_v17_ktx2/SceneServer/layers/0/nodes/1/geometries/1';
 const MONTREAL_CONTENT_LOADER_OPTIONS =
   '@loaders.gl/i3s/test/data/Montreal_3DObjects_subset_1_v17_ktx2/i3s-content-loader-options.json';
-
-test('ParseI3sTileContent#should parse tile content', async t => {
+test('ParseI3sTileContent#should parse tile content', async () => {
   const tileset = TILESET_STUB();
   const i3SNodePagesTiles = new I3SNodePagesTiles(tileset, TEST_LAYER_URL, {});
   const tile = await i3SNodePagesTiles.formTileFromNodePages(1);
@@ -34,21 +27,17 @@ test('ParseI3sTileContent#should parse tile content', async t => {
       useDracoGeometry: false
     }
   });
-  t.ok(content);
-
+  expect(content).toBeTruthy();
   // color array should be colorized by attribute
   const colorsArray = content!.attributes.colors.value;
   const testArray = new Uint8Array(9);
   testArray.fill(255);
-  t.deepEquals(colorsArray.subarray(0, 9), testArray);
+  expect(colorsArray.subarray(0, 9)).toEqual(testArray);
   const arrayMiddle = (colorsArray.length - (colorsArray.length % 2)) / 2;
-  t.deepEquals(colorsArray.subarray(arrayMiddle, arrayMiddle + 9), testArray);
-  t.deepEquals(colorsArray.subarray(colorsArray.length - 9), testArray);
-
-  t.end();
+  expect(colorsArray.subarray(arrayMiddle, arrayMiddle + 9)).toEqual(testArray);
+  expect(colorsArray.subarray(colorsArray.length - 9)).toEqual(testArray);
 });
-
-test('ParseI3sTileContent#should load "dds" texture if it is supported', async t => {
+test('ParseI3sTileContent#should load "dds" texture if it is supported', async () => {
   const tileset = TILESET_STUB();
   const i3SNodePagesTiles = new I3SNodePagesTiles(tileset, TEST_LAYER_URL, {});
   const tile = await i3SNodePagesTiles.formTileFromNodePages(1);
@@ -63,17 +52,17 @@ test('ParseI3sTileContent#should load "dds" texture if it is supported', async t
   });
   const texture = content!.material.pbrMetallicRoughness.baseColorTexture.texture.source.image;
   if (texture && typeof texture === 'object' && 'compressed' in texture) {
-    t.ok(texture.compressed);
-    t.ok(texture.data instanceof Array);
+    expect(texture.compressed).toBeTruthy();
+    expect(texture.data instanceof Array).toBeTruthy();
   } else {
     const imageData = getImageData(texture);
-    t.ok(texture instanceof ImageBitmap);
-    t.ok(imageData.data instanceof Uint8Array || imageData.data instanceof Uint8ClampedArray);
+    expect(texture instanceof ImageBitmap).toBeTruthy();
+    expect(
+      imageData.data instanceof Uint8Array || imageData.data instanceof Uint8ClampedArray
+    ).toBeTruthy();
   }
-  t.end();
 });
-
-test('ParseI3sTileContent#should decode "ktx2" texture with basis loader', async t => {
+test('ParseI3sTileContent#should decode "ktx2" texture with basis loader', async () => {
   const response = await fetchFile(MONTREAL_TILE_CONTENT);
   const data = await response.arrayBuffer();
   const responseOptions = await fetchFile(MONTREAL_CONTENT_LOADER_OPTIONS);
@@ -83,12 +72,10 @@ test('ParseI3sTileContent#should decode "ktx2" texture with basis loader', async
   });
   const texture =
     content!.material.pbrMetallicRoughness.baseColorTexture.texture.source.image.data[0];
-  t.ok(texture instanceof Object);
-  t.ok(texture.data instanceof Uint8Array);
-  t.end();
+  expect(texture instanceof Object).toBeTruthy();
+  expect(texture.data instanceof Uint8Array).toBeTruthy();
 });
-
-test('ParseI3sTileContent#should make PBR material', async t => {
+test('ParseI3sTileContent#should make PBR material', async () => {
   const tileset = TILESET_STUB();
   const i3SNodePagesTiles = new I3SNodePagesTiles(tileset, TEST_LAYER_URL, {});
   const tile = await i3SNodePagesTiles.formTileFromNodePages(1);
@@ -102,30 +89,29 @@ test('ParseI3sTileContent#should make PBR material', async t => {
     }
   });
   const material = content!.material;
-  t.ok(material.doubleSided);
-  t.deepEqual(material.emissiveFactor, [1, 1, 1]);
-  t.ok(material.pbrMetallicRoughness);
-  t.ok(material.pbrMetallicRoughness.baseColorTexture);
-
+  expect(material.doubleSided).toBeTruthy();
+  expect(material.emissiveFactor).toEqual([1, 1, 1]);
+  expect(material.pbrMetallicRoughness).toBeTruthy();
+  expect(material.pbrMetallicRoughness.baseColorTexture).toBeTruthy();
   const texture = material.pbrMetallicRoughness.baseColorTexture.texture;
-  t.ok(texture);
-  t.ok(texture.source);
+  expect(texture).toBeTruthy();
+  expect(texture.source).toBeTruthy();
   if (
     texture.source.image &&
     typeof texture.source.image === 'object' &&
     'compressed' in texture.source.image
   ) {
-    t.ok(texture.source.image.compressed);
-    t.ok(texture.source.image.data instanceof Array);
+    expect(texture.source.image.compressed).toBeTruthy();
+    expect(texture.source.image.data instanceof Array).toBeTruthy();
   } else {
     const imageData = getImageData(texture.source.image);
-    t.ok(texture.source.image instanceof ImageBitmap);
-    t.ok(imageData.data instanceof Uint8Array || imageData.data instanceof Uint8ClampedArray);
+    expect(texture.source.image instanceof ImageBitmap).toBeTruthy();
+    expect(
+      imageData.data instanceof Uint8Array || imageData.data instanceof Uint8ClampedArray
+    ).toBeTruthy();
   }
-  t.end();
 });
-
-test('ParseI3sTileContent#should have featureIds', async t => {
+test('ParseI3sTileContent#should have featureIds', async () => {
   const tileset = TILESET_STUB();
   const i3SNodePagesTiles = new I3SNodePagesTiles(tileset, TEST_LAYER_URL, {});
   const tile = await i3SNodePagesTiles.formTileFromNodePages(1);
@@ -138,23 +124,19 @@ test('ParseI3sTileContent#should have featureIds', async t => {
       decodeTextures: true
     }
   });
-  t.ok(content);
-  t.ok(content!.featureIds);
-  t.equal(content!.featureIds.length, 25638);
-  t.end();
+  expect(content).toBeTruthy();
+  expect(content!.featureIds).toBeTruthy();
+  expect(content!.featureIds.length).toBe(25638);
 });
-
-test('ParseI3sTileContent#should generate mbs from obb', async t => {
+test('ParseI3sTileContent#should generate mbs from obb', async () => {
   const tileset = TILESET_STUB();
   const i3SNodePagesTiles = new I3SNodePagesTiles(tileset, TEST_LAYER_URL, {});
   const tile = await i3SNodePagesTiles.formTileFromNodePages(1);
-  t.ok(tile.mbs);
-  t.equals(tile.mbs.length, 4);
-  t.deepEquals(tile.mbs.slice(0, 3), tile.obb.center);
-  t.end();
+  expect(tile.mbs).toBeTruthy();
+  expect(tile.mbs.length).toBe(4);
+  expect(tile.mbs.slice(0, 3)).toEqual(tile.obb.center);
 });
-
-test('ParseI3sTileContent#should not decode the texture image if "decodeTextures" === false', async t => {
+test('ParseI3sTileContent#should not decode the texture image if "decodeTextures" === false', async () => {
   const tileset = TILESET_STUB();
   const i3SNodePagesTiles = new I3SNodePagesTiles(tileset, TEST_LAYER_URL, {});
   const tile = await i3SNodePagesTiles.formTileFromNodePages(1);
@@ -168,17 +150,16 @@ test('ParseI3sTileContent#should not decode the texture image if "decodeTextures
     }
   });
   const texture = content!.material.pbrMetallicRoughness.baseColorTexture.texture.source.image;
-  t.ok(texture instanceof ArrayBuffer);
+  expect(texture instanceof ArrayBuffer).toBeTruthy();
   if (isBrowser) {
     if (texture.byteLength === 45200) {
-      t.equal(texture.byteLength, 45200);
+      expect(texture.byteLength).toBe(45200);
     } else {
-      t.equal(texture.byteLength, 7199);
+      expect(texture.byteLength).toBe(7199);
     }
   } else {
-    t.equal(texture.byteLength, 7199);
+    expect(texture.byteLength).toBe(7199);
   }
-
   const i3SNodePagesTiles2 = new I3SNodePagesTiles(tileset, TEST_LAYER_URL, {
     i3s: {useCompressedTextures: false}
   });
@@ -193,13 +174,10 @@ test('ParseI3sTileContent#should not decode the texture image if "decodeTextures
     }
   });
   const texture2 = content2!.material.pbrMetallicRoughness.baseColorTexture.texture.source.image;
-  t.ok(texture2 instanceof ArrayBuffer);
-  t.equal(texture2.byteLength, 7199);
-
-  t.end();
+  expect(texture2 instanceof ArrayBuffer).toBeTruthy();
+  expect(texture2.byteLength).toBe(7199);
 });
-
-test('ParseI3sTileContent#should colorize by attribute', async t => {
+test('ParseI3sTileContent#should colorize by attribute', async () => {
   const response = await fetchFile(NEW_YORK_TILE_CONTENT);
   const data = await response.arrayBuffer();
   const responseOptions = await fetchFile(NEW_YORK_CONTENT_LOADER_OPTIONS);
@@ -208,25 +186,19 @@ test('ParseI3sTileContent#should colorize by attribute', async t => {
   const content = await parse(data, I3SContentLoader, {
     i3s: i3sLoaderOptions
   });
-  t.ok(content);
-
+  expect(content).toBeTruthy();
   // color array should be colorized by attribute
   const colorsArray = content!.attributes.colors.value;
-  t.deepEquals(colorsArray.subarray(0, 9), [139, 139, 247, 255, 139, 139, 247, 255, 139]);
+  expect(colorsArray.subarray(0, 9)).toEqual([139, 139, 247, 255, 139, 139, 247, 255, 139]);
   const arrayMiddle = (colorsArray.length - (colorsArray.length % 2)) / 2;
-  t.deepEquals(
-    colorsArray.subarray(arrayMiddle, arrayMiddle + 9),
-    [244, 255, 135, 135, 244, 255, 135, 135, 244]
-  );
-  t.deepEquals(
-    colorsArray.subarray(colorsArray.length - 9),
-    [255, 141, 141, 248, 255, 141, 141, 248, 255]
-  );
-
-  t.end();
+  expect(colorsArray.subarray(arrayMiddle, arrayMiddle + 9)).toEqual([
+    244, 255, 135, 135, 244, 255, 135, 135, 244
+  ]);
+  expect(colorsArray.subarray(colorsArray.length - 9)).toEqual([
+    255, 141, 141, 248, 255, 141, 141, 248, 255
+  ]);
 });
-
-test('ParseI3sTileContent#should colorize by attribute using mutiplying colors', async t => {
+test('ParseI3sTileContent#should colorize by attribute using mutiplying colors', async () => {
   const response = await fetchFile(NEW_YORK_TILE_CONTENT);
   const data = await response.arrayBuffer();
   const responseOptions = await fetchFile(NEW_YORK_CONTENT_LOADER_OPTIONS);
@@ -235,24 +207,18 @@ test('ParseI3sTileContent#should colorize by attribute using mutiplying colors',
   const content = await parse(data, I3SContentLoader, {
     i3s: i3sLoaderOptions
   });
-  t.ok(content);
-
+  expect(content).toBeTruthy();
   // color array should be colorized by attribute using multiplying colors
   const colorsArray = content!.attributes.colors.value;
-  t.deepEquals(colorsArray.subarray(0, 9), [139, 139, 247, 255, 139, 139, 247, 255, 139]);
+  expect(colorsArray.subarray(0, 9)).toEqual([139, 139, 247, 255, 139, 139, 247, 255, 139]);
   const arrayMiddle = (colorsArray.length - (colorsArray.length % 2)) / 2;
-  t.deepEquals(
-    colorsArray.subarray(arrayMiddle, arrayMiddle + 9),
-    [244, 255, 135, 135, 244, 255, 135, 135, 244]
-  );
-  t.deepEquals(
-    colorsArray.subarray(colorsArray.length - 9),
-    [255, 141, 141, 248, 255, 141, 141, 248, 255]
-  );
-
-  t.end();
+  expect(colorsArray.subarray(arrayMiddle, arrayMiddle + 9)).toEqual([
+    244, 255, 135, 135, 244, 255, 135, 135, 244
+  ]);
+  expect(colorsArray.subarray(colorsArray.length - 9)).toEqual([
+    255, 141, 141, 248, 255, 141, 141, 248, 255
+  ]);
 });
-
 function getI3SOptions(tile, tileset) {
   return {
     _tileOptions: {

--- a/modules/i3s/test/i3s-loader.spec.ts
+++ b/modules/i3s/test/i3s-loader.spec.ts
@@ -1,14 +1,9 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {load} from '@loaders.gl/core';
 import {getImageData} from '@loaders.gl/images';
 import {loadI3STileContent} from './test-utils/load-utils';
 import {I3SLoader} from '@loaders.gl/i3s';
-
-test('I3SLoader#Load tile content', async t => {
+test('I3SLoader#Load tile content', async () => {
   const content = await loadI3STileContent({
     i3s: {
       useCompressedTextures: false
@@ -17,66 +12,57 @@ test('I3SLoader#Load tile content', async t => {
       core: {worker: false}
     }
   });
-  t.ok(content);
-  t.ok(content.attributes);
-  t.ok(content.attributes.positions);
-  t.equal(content.attributes.positions.value.length, 76914);
-  t.ok(content.attributes.normals);
-  t.equal(content.attributes.normals.value.length, 76914);
-  t.ok(content.attributes.colors);
-  t.equal(content.attributes.colors.value.length, 102552);
-  t.ok(content.attributes.texCoords);
-  t.equal(content.attributes.texCoords.value.length, 51276);
-  t.notOk(content.texture);
-  t.ok(content.material);
+  expect(content).toBeTruthy();
+  expect(content.attributes).toBeTruthy();
+  expect(content.attributes.positions).toBeTruthy();
+  expect(content.attributes.positions.value.length).toBe(76914);
+  expect(content.attributes.normals).toBeTruthy();
+  expect(content.attributes.normals.value.length).toBe(76914);
+  expect(content.attributes.colors).toBeTruthy();
+  expect(content.attributes.colors.value.length).toBe(102552);
+  expect(content.attributes.texCoords).toBeTruthy();
+  expect(content.attributes.texCoords.value.length).toBe(51276);
+  expect(content.texture).toBeFalsy();
+  expect(content.material).toBeTruthy();
   const texture = content.material.pbrMetallicRoughness.baseColorTexture.texture.source.image;
   const textureData = getImageData(texture);
-  t.ok(texture);
-  t.equal(textureData.data.byteLength, 131072);
-  t.end();
+  expect(texture).toBeTruthy();
+  expect(textureData.data.byteLength).toBe(131072);
 });
-
-test('I3SLoader#DRACO geometry', async t => {
+test('I3SLoader#DRACO geometry', async () => {
   const content = await loadI3STileContent({
     i3s: {useDracoGeometry: true},
     loadOptions: {
       core: {worker: false}
     }
   });
-  t.ok(content);
-  t.ok(content.attributes);
-  t.ok(content.attributes.positions);
-  t.equal(content.attributes.positions.value.length, 888);
-  t.notOk(content.attributes.normals);
-  t.ok(content.attributes.colors);
-  t.equal(content.attributes.colors.value.length, 1184);
-  t.ok(content.attributes.texCoords);
-  t.equal(content.attributes.texCoords.value.length, 592);
-
-  t.end();
+  expect(content).toBeTruthy();
+  expect(content.attributes).toBeTruthy();
+  expect(content.attributes.positions).toBeTruthy();
+  expect(content.attributes.positions.value.length).toBe(888);
+  expect(content.attributes.normals).toBeFalsy();
+  expect(content.attributes.colors).toBeTruthy();
+  expect(content.attributes.colors.value.length).toBe(1184);
+  expect(content.attributes.texCoords).toBeTruthy();
+  expect(content.attributes.texCoords.value.length).toBe(592);
 });
-
-test('I3SLoader#slpk is not supported', async t => {
+test('I3SLoader#slpk is not supported', async () => {
   const slpkUrl = '@loaders.gl/i3s/test/data/DA12_subset.slpk';
   const message = 'Files with .slpk extention currently are not supported by I3SLoader';
   try {
     await load(slpkUrl, I3SLoader, {});
   } catch (err) {
     // @ts-expect-error
-    t.equal(err.message, message);
+    expect(err.message).toBe(message);
   }
-  t.end();
 });
-
-test('I3SLoader#point cloud is not supported', async t => {
+test('I3SLoader#point cloud is not supported', async () => {
   const pointCloudUrl = '@loaders.gl/i3s/test/data/point-cloud/SceneServer/layers/0';
   const message = 'Point Cloud layers currently are not supported by I3SLoader';
-
   try {
     await load(pointCloudUrl, I3SLoader, {});
   } catch (err) {
     // @ts-expect-error
-    t.equal(err.message, message);
+    expect(err.message).toBe(message);
   }
-  t.end();
 });

--- a/modules/i3s/test/i3s-node-page-loader.spec.ts
+++ b/modules/i3s/test/i3s-node-page-loader.spec.ts
@@ -1,20 +1,13 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {parse, fetchFile} from '@loaders.gl/core';
 import {I3SNodePageLoader} from '@loaders.gl/i3s';
-
 const NODEPAGE_URL =
   '@loaders.gl/i3s/test/data/SanFrancisco_3DObjects_1_7/SceneServer/layers/0/nodepages/0';
-
-test('I3SNodePageLoader#Load node page', async t => {
+test('I3SNodePageLoader#Load node page', async () => {
   const response = await fetchFile(NODEPAGE_URL);
   const nodePage = await parse(response, I3SNodePageLoader);
-  t.ok(nodePage);
-  t.ok(nodePage.nodes);
-  t.equal(nodePage.nodes.length, 16);
-  t.equal(nodePage.nodes[2].lodThreshold, 870638.071285568);
-  t.end();
+  expect(nodePage).toBeTruthy();
+  expect(nodePage.nodes).toBeTruthy();
+  expect(nodePage.nodes.length).toBe(16);
+  expect(nodePage.nodes[2].lodThreshold).toBe(870638.071285568);
 });

--- a/modules/i3s/test/lib/parsers/url-utils.spec.ts
+++ b/modules/i3s/test/lib/parsers/url-utils.spec.ts
@@ -1,8 +1,4 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {
   getUrlWithToken,
   generateTileAttributeUrls,
@@ -10,45 +6,32 @@ import {
   // @ts-expect-error
 } from '@loaders.gl/i3s/lib/utils/url-utils';
 import {getUrlWithoutParams} from '../../../src/lib/utils/url-utils';
-
-test('i3s-utils#getUrlWithoutParams', async t => {
+test('i3s-utils#getUrlWithoutParams', async () => {
   const url = getUrlWithoutParams('http://a.b.c/x/y/z?token=efk');
-  t.equal(url, 'http://a.b.c/x/y/z');
-
+  expect(url).toBe('http://a.b.c/x/y/z');
   const url2 = getUrlWithoutParams('@loaders.gl/core/test/data/url');
-  t.equal(url2, '@loaders.gl/core/test/data/url');
-  t.end();
+  expect(url2).toBe('@loaders.gl/core/test/data/url');
 });
-
-test('i3s-utils#getUrlWithToken Should return URL without token if token null', async t => {
+test('i3s-utils#getUrlWithToken Should return URL without token if token null', async () => {
   const url = getUrlWithToken('test', null);
-
-  t.ok(url);
-  t.equal(url, 'test');
-  t.end();
+  expect(url).toBeTruthy();
+  expect(url).toBe('test');
 });
-
-test('i3s-utils#getUrlWithToken Should return URL with token token if token exists', async t => {
+test('i3s-utils#getUrlWithToken Should return URL with token token if token exists', async () => {
   const url = getUrlWithToken('test', '12345');
-
-  t.ok(url);
-  t.equal(url, 'test?token=12345');
-  t.end();
+  expect(url).toBeTruthy();
+  expect(url).toBe('test?token=12345');
 });
-
-test('i3s-utils#generateTileAttributeUrls Should return attribute URLs for tile', async t => {
+test('i3s-utils#generateTileAttributeUrls Should return attribute URLs for tile', async () => {
   const tile = {
     attributeData: [{href: './attributes/f_0/0'}, {href: './attributes/f_1/0'}]
   };
   const attrUrlsStub = ['test/attributes/f_0/0', 'test/attributes/f_1/0'];
   const attributeUrls = generateTileAttributeUrls('test', tile);
-
-  t.ok(attributeUrls);
-  t.deepEqual(attributeUrls, attrUrlsStub);
-  t.end();
+  expect(attributeUrls).toBeTruthy();
+  expect(attributeUrls).toEqual(attrUrlsStub);
 });
-
-test('i3s-utils#generateTilesetAttributeUrls Should return attribute URLs for tileset', async t => {
+test('i3s-utils#generateTilesetAttributeUrls Should return attribute URLs for tileset', async () => {
   const tileset = {
     attributeStorageInfo: [{key: 'f_0'}, {key: 'f_1'}],
     url: 'test'
@@ -56,8 +39,6 @@ test('i3s-utils#generateTilesetAttributeUrls Should return attribute URLs for ti
   const resource = '1';
   const attributeUrls = generateTilesetAttributeUrls(tileset, 'test', resource);
   const attrUrlsStub = ['test/nodes/1/attributes/f_0/0', 'test/nodes/1/attributes/f_1/0'];
-
-  t.ok(attributeUrls);
-  t.deepEqual(attributeUrls, attrUrlsStub);
-  t.end();
+  expect(attributeUrls).toBeTruthy();
+  expect(attributeUrls).toEqual(attrUrlsStub);
 });

--- a/modules/i3s/test/parse-slpk-readable-file.spec.ts
+++ b/modules/i3s/test/parse-slpk-readable-file.spec.ts
@@ -1,40 +1,23 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {parseSLPKArchive} from '../src/lib/parsers/parse-slpk/parse-slpk';
 import {createReadableFileFromBuffer, loadArrayBufferFromFile} from 'test/utils/readable-files';
-
 const SLPK_URL = '@loaders.gl/i3s/test/data/DA12_subset.slpk';
-
-test('parseSLPKArchive#ReadableFile - raw paths', async t => {
+test('parseSLPKArchive#ReadableFile - raw paths', async () => {
   const arrayBuffer = await loadArrayBufferFromFile(SLPK_URL);
   const archive = await parseSLPKArchive(await createReadableFileFromBuffer(arrayBuffer));
-
   const nodeDocument = await archive.getFile('nodes/root', 'http');
-  t.ok(nodeDocument.byteLength > 0, 'retrieves decompressed root node document');
-
+  expect(nodeDocument.byteLength > 0, 'retrieves decompressed root node document').toBeTruthy();
   const geometry = await archive.getFile('nodes/3/geometries/0.bin');
-  t.equal(
-    geometry.byteLength,
-    32208,
-    'returns decompressed geometry payload without hash provider'
+  expect(geometry.byteLength, 'returns decompressed geometry payload without hash provider').toBe(
+    32208
   );
-
-  t.end();
 });
-
-test('parseSLPKArchive#ReadableFile - http mode fallbacks', async t => {
+test('parseSLPKArchive#ReadableFile - http mode fallbacks', async () => {
   const arrayBuffer = await loadArrayBufferFromFile(SLPK_URL);
   const archive = await parseSLPKArchive(await createReadableFileFromBuffer(arrayBuffer));
-
   const nodePage = await archive.getFile('nodepages/0', 'http');
-  t.equal(nodePage.byteLength, 16153, 'expands nodepage lookup using http-style paths');
-
+  expect(nodePage.byteLength, 'expands nodepage lookup using http-style paths').toBe(16153);
   const shared = await archive.getFile('nodes/3/shared', 'http');
-  t.equal(shared.byteLength, 333, 'resolves shared resources through hash table');
-
-  await t.rejects(archive.getFile('missing/path', 'http'));
-  t.end();
+  expect(shared.byteLength, 'resolves shared resources through hash table').toBe(333);
+  await expect(archive.getFile('missing/path', 'http')).rejects.toBeDefined();
 });

--- a/modules/i3s/test/parse-slpk.spec.ts
+++ b/modules/i3s/test/parse-slpk.spec.ts
@@ -27,14 +27,9 @@ test('SLPKSource#initialize reads archive through I3SSource contract', async () 
   expect(tileset.store, 'loads root I3S metadata from the archive').toBeTruthy();
 });
 test('SLPKLoader#slpk load error', async () => {
-  try {
-    await load(SLPKUrl, SLPKLoader, {slpk: {path: 'nodepages/5.json'}});
-    (() => {
-      throw new Error('error should be thrown');
-    })();
-  } catch (e) {
-    if (e) expect(true, 'correct error thrown').toBe(true);
-  }
+  await expect(load(SLPKUrl, SLPKLoader, {slpk: {path: 'nodepages/5.json'}})).rejects.toThrow(
+    'No such file in the archive: nodepages/5.json'
+  );
 });
 test('SLPKLoader#slpk load http nodepage', async () => {
   const uncompressedFile = await load(SLPKUrl, SLPKLoader, {

--- a/modules/i3s/test/parse-slpk.spec.ts
+++ b/modules/i3s/test/parse-slpk.spec.ts
@@ -1,124 +1,96 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {coreApi, load, parseFile} from '@loaders.gl/core';
 import {I3SLoader, SLPKLoader, SLPKSource} from '../src';
 import {createReadableFileFromBuffer, loadArrayBufferFromFile} from 'test/utils/readable-files';
-
 const SLPKUrl = '@loaders.gl/i3s/test/data/DA12_subset.slpk';
-
-test('SLPKLoader#slpk load', async t => {
+test('SLPKLoader#slpk load', async () => {
   const uncompressedFile = await load(SLPKUrl, SLPKLoader, {slpk: {path: 'nodepages/0.json'}});
-  t.deepEqual(uncompressedFile.byteLength, 16153, 'SLPK nodepage has the correct length');
-  t.end();
+  expect(uncompressedFile.byteLength, 'SLPK nodepage has the correct length').toEqual(16153);
 });
-
-test('SLPKLoader#parseFile reads from ReadableFile', async t => {
+test('SLPKLoader#parseFile reads from ReadableFile', async () => {
   const arrayBuffer = await loadArrayBufferFromFile(SLPKUrl);
   const readableFile = await createReadableFileFromBuffer(arrayBuffer);
   const uncompressedFile = await parseFile(readableFile, SLPKLoader, {
     slpk: {path: 'nodepages/0.json'}
   });
-
-  t.deepEqual(uncompressedFile.byteLength, 16153, 'SLPK nodepage has the correct length');
-  t.end();
+  expect(uncompressedFile.byteLength, 'SLPK nodepage has the correct length').toEqual(16153);
 });
-
-test('SLPKSource#initialize reads archive through I3SSource contract', async t => {
+test('SLPKSource#initialize reads archive through I3SSource contract', async () => {
   const source = new SLPKSource({
     url: SLPKUrl,
     loader: I3SLoader,
     coreApi
   });
-
   await source.initialize();
   const tileset = await source.getRootTileset();
-
-  t.equal(source.type, 'I3S', 'uses the I3S source type');
-  t.ok(tileset.store, 'loads root I3S metadata from the archive');
-  t.end();
+  expect(source.type, 'uses the I3S source type').toBe('I3S');
+  expect(tileset.store, 'loads root I3S metadata from the archive').toBeTruthy();
 });
-
-test('SLPKLoader#slpk load error', async t => {
+test('SLPKLoader#slpk load error', async () => {
   try {
     await load(SLPKUrl, SLPKLoader, {slpk: {path: 'nodepages/5.json'}});
-    t.fail('error should be thrown');
+    (() => {
+      throw new Error('error should be thrown');
+    })();
   } catch (e) {
-    if (e) t.pass('correct error thrown');
+    if (e) expect(true, 'correct error thrown').toBe(true);
   }
-  t.end();
 });
-
-test('SLPKLoader#slpk load http nodepage', async t => {
+test('SLPKLoader#slpk load http nodepage', async () => {
   const uncompressedFile = await load(SLPKUrl, SLPKLoader, {
     slpk: {
       path: 'nodepages/0',
       pathMode: 'http'
     }
   });
-  t.deepEqual(uncompressedFile.byteLength, 16153);
-  t.end();
+  expect(uncompressedFile.byteLength).toEqual(16153);
 });
-
-test('SLPKLoader#slpk load http layer', async t => {
+test('SLPKLoader#slpk load http layer', async () => {
   const uncompressedFile = await load(SLPKUrl, SLPKLoader, {slpk: {path: '', pathMode: 'http'}});
-  t.deepEqual(uncompressedFile.byteLength, 4780);
-  t.end();
+  expect(uncompressedFile.byteLength).toEqual(4780);
 });
-
-test('SLPKLoader#slpk load http node', async t => {
+test('SLPKLoader#slpk load http node', async () => {
   const uncompressedFile = await load(SLPKUrl, SLPKLoader, {
     slpk: {
       path: 'nodes/0',
       pathMode: 'http'
     }
   });
-  t.deepEqual(uncompressedFile.byteLength, 1171);
-  t.end();
+  expect(uncompressedFile.byteLength).toEqual(1171);
 });
-
-test('SLPKLoader#slpk load http geometry', async t => {
+test('SLPKLoader#slpk load http geometry', async () => {
   const uncompressedFile = await load(SLPKUrl, SLPKLoader, {
     slpk: {
       path: 'nodes/0/geometries/0',
       pathMode: 'http'
     }
   });
-  t.deepEqual(uncompressedFile.byteLength, 156280);
-  t.end();
+  expect(uncompressedFile.byteLength).toEqual(156280);
 });
-
-test('SLPKLoader#slpk load http attributes', async t => {
+test('SLPKLoader#slpk load http attributes', async () => {
   const uncompressedFile = await load(SLPKUrl, SLPKLoader, {
     slpk: {
       path: 'nodes/2/attributes/f_2/0',
       pathMode: 'http'
     }
   });
-  t.deepEqual(uncompressedFile.byteLength, 8);
-  t.end();
+  expect(uncompressedFile.byteLength).toEqual(8);
 });
-
-test('SLPKLoader#slpk load http statistics', async t => {
+test('SLPKLoader#slpk load http statistics', async () => {
   const uncompressedFile = await load(SLPKUrl, SLPKLoader, {
     slpk: {
       path: 'statistics/f_3/0',
       pathMode: 'http'
     }
   });
-  t.deepEqual(uncompressedFile.byteLength, 735);
-  t.end();
+  expect(uncompressedFile.byteLength).toEqual(735);
 });
-
-test('SLPKLoader#slpk load http shared', async t => {
+test('SLPKLoader#slpk load http shared', async () => {
   const uncompressedFile = await load(SLPKUrl, SLPKLoader, {
     slpk: {
       path: 'nodes/2/shared',
       pathMode: 'http'
     }
   });
-  t.deepEqual(uncompressedFile.byteLength, 333);
-  t.end();
+  expect(uncompressedFile.byteLength).toEqual(333);
 });

--- a/modules/json/test/lib/clarinet/clarinet.spec.js
+++ b/modules/json/test/lib/clarinet/clarinet.spec.js
@@ -1,10 +1,5 @@
-// SPDX-License-Identifier: BSD-2-Clause
-
-/* eslint-disable */
-// @ts-nocheck
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import ClarinetParser from '@loaders.gl/json/lib/clarinet/clarinet';
-
 export const EVENTS = [
   'value',
   'string',
@@ -17,7 +12,6 @@ export const EVENTS = [
   'end',
   'ready'
 ];
-
 const seps = [undefined, /\t|\n|\r/, ''];
 const docs = {
   empty_array: {
@@ -753,8 +747,7 @@ const docs = {
     ]
   }
 };
-
-function generic(t, key, prechunked, sep) {
+function generic(key, prechunked, sep) {
   return function () {
     var doc = docs[key].text,
       events = docs[key].events,
@@ -765,7 +758,6 @@ function generic(t, key, prechunked, sep) {
       current,
       env = process && process.env ? process.env : window,
       record = [];
-
     events.forEach(function (event_pair) {
       l.push(event_pair);
     });
@@ -781,17 +773,14 @@ function generic(t, key, prechunked, sep) {
           if (!(current && current[0])) {
             return;
           }
-          t.equals(
-            current[0],
-            event,
-            '[ln' + i + '] event: [' + current[0] + '] got: [' + event + ']'
+          expect(current[0], '[ln' + i + '] event: [' + current[0] + '] got: [' + event + ']').toBe(
+            event
           );
           if (event !== 'error')
-            t.equals(
+            expect(
               current[1],
-              value,
               '[ln' + i + '] value: [' + current[1] + '] got: [' + value + ']'
-            );
+            ).toBe(value);
         }
       };
     });
@@ -799,8 +788,7 @@ function generic(t, key, prechunked, sep) {
     parser.end();
   };
 }
-
-test('clarinet#generic', t => {
+test('clarinet#generic', () => {
   for (const key in docs) {
     if (docs.hasOwnProperty(key)) {
       // undefined means no split
@@ -808,23 +796,19 @@ test('clarinet#generic', t => {
       // '' means on every char
       for (const sep in seps) {
         // t.comment('[' + key + '] should be able to parse -> ' + sep);
-        generic(t, key, false, sep);
+        generic(key, false, sep);
       }
     }
   }
-  t.end();
 });
-
-test('#pre-chunked', t => {
+test('#pre-chunked', () => {
   for (const key in docs) {
     if (docs.hasOwnProperty(key)) {
       if (!docs[key].chunks) {
         continue;
       }
-
       // t.comment('[' + key + '] should be able to parse pre-chunked');
-      generic(t, key, true);
+      generic(key, true);
     }
   }
-  t.end();
 });

--- a/modules/json/test/lib/clarinet/position.spec.js
+++ b/modules/json/test/lib/clarinet/position.spec.js
@@ -1,22 +1,15 @@
-// SPDX-License-Identifier: MIT
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import ClarinetParser from '../../../src/lib/clarinet/clarinet';
 import {fetchFile} from '@loaders.gl/core';
-
 const SAMPLE_PATH = '@loaders.gl/json/test/data/clarinet/sample.json';
-
-test('clarinet#track position', async t => {
+test('clarinet#track position', async () => {
   const response = await fetchFile(SAMPLE_PATH);
   const data = await response.text();
-
   const parser = new ClarinetParser({
     onend: () => {
-      t.equals(parser.position, 696, 'parser.position is correct');
-      t.end();
+      expect(parser.position, 'parser.position is correct').toBe(696);
     }
   });
-
   parser.write(data);
   parser.close();
 });

--- a/modules/json/test/lib/jsonpath/jsonpath.spec.js
+++ b/modules/json/test/lib/jsonpath/jsonpath.spec.js
@@ -1,10 +1,5 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {_JSONPath} from '@loaders.gl/json';
-
 const VALID_JSONPATHS = [
   {jsonpath: '$', expected: [], canonical: '$'},
   {jsonpath: '$.features', expected: ['features'], canonical: '$.features'},
@@ -21,7 +16,6 @@ const VALID_JSONPATHS = [
   //   canonical: "$['nested \\'quote\\' key']"
   // }
 ];
-
 const INVALID_JSONPATHS = [
   {jsonpath: 'features', message: /JSONPath must start with \$/},
   {jsonpath: '$.trailing.', message: /JSONPath cannot end with a period/},
@@ -40,54 +34,43 @@ const INVALID_JSONPATHS = [
     message: /JSONPath string in bracket property selector is unterminated/
   }
 ];
-
-test('JSONPath#parsing', async t => {
+test('JSONPath#parsing', async () => {
   for (const testCase of VALID_JSONPATHS) {
     const jsonpath = new _JSONPath(testCase.jsonpath);
     const expected = new _JSONPath(testCase.expected);
-    t.ok(jsonpath.equals(expected), `${testCase.jsonpath} parses correctly`);
-    t.equals(
-      jsonpath.toString(),
-      testCase.canonical,
-      `${testCase.jsonpath} normalizes to ${testCase.canonical}`
+    expect(jsonpath.equals(expected), `${testCase.jsonpath} parses correctly`).toBeTruthy();
+    expect(jsonpath.toString(), `${testCase.jsonpath} normalizes to ${testCase.canonical}`).toBe(
+      testCase.canonical
     );
-
     const jsonpathCopy = new _JSONPath(jsonpath);
-    t.ok(jsonpathCopy.equals(expected), `${testCase.jsonpath} copy parses correctly`);
-    t.equals(
-      jsonpathCopy.toString(),
-      testCase.canonical,
-      `${testCase.jsonpath} copy normalizes correctly`
+    expect(
+      jsonpathCopy.equals(expected),
+      `${testCase.jsonpath} copy parses correctly`
+    ).toBeTruthy();
+    expect(jsonpathCopy.toString(), `${testCase.jsonpath} copy normalizes correctly`).toBe(
+      testCase.canonical
     );
-
     const jsonpathClone = jsonpath.clone();
-    t.ok(jsonpathClone.equals(expected), `${testCase.jsonpath} clone parses correctly`);
-    t.equals(
-      jsonpathClone.toString(),
-      testCase.canonical,
-      `${testCase.jsonpath} clone normalizes correctly`
+    expect(
+      jsonpathClone.equals(expected),
+      `${testCase.jsonpath} clone parses correctly`
+    ).toBeTruthy();
+    expect(jsonpathClone.toString(), `${testCase.jsonpath} clone normalizes correctly`).toBe(
+      testCase.canonical
     );
   }
-
-  t.end();
 });
-
-test('JSONPath#validation', async t => {
+test('JSONPath#validation', async () => {
   for (const testCase of INVALID_JSONPATHS) {
-    t.throws(
-      () => new _JSONPath(testCase.jsonpath),
-      testCase.message,
-      `${testCase.jsonpath} is rejected`
+    expect(() => new _JSONPath(testCase.jsonpath), `${testCase.jsonpath} is rejected`).toThrow(
+      testCase.message
     );
   }
-  t.end();
 });
-
-test('JSONPath#deep set', async t => {
+test('JSONPath#deep set', async () => {
   const jsonpath = new _JSONPath('$.a.b');
   const deepValue = {a: {b: 1}};
-  t.equal(jsonpath.getFieldAtPath(deepValue), 1, 'JSONPath.getFieldAtPath');
+  expect(jsonpath.getFieldAtPath(deepValue), 'JSONPath.getFieldAtPath').toBe(1);
   jsonpath.setFieldAtPath(deepValue, 2);
-  t.equal(jsonpath.getFieldAtPath(deepValue), 2, 'JSONPath.setFieldAtPath');
-  t.end();
+  expect(jsonpath.getFieldAtPath(deepValue), 'JSONPath.setFieldAtPath').toBe(2);
 });

--- a/modules/json/test/lib/parser/json-parser.spec.js
+++ b/modules/json/test/lib/parser/json-parser.spec.js
@@ -1,10 +1,5 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import JSONParser from '../../../src/lib/json-parser/json-parser';
-
 // tslint:disable:object-literal-sort-keys
 const literalCases = [
   {type: 'null', cases: ['null']},
@@ -23,7 +18,6 @@ const literalCases = [
   }
 ];
 // tslint:enable:object-literal-sort-keys
-
 const stringLiterals = [
   ['empty', JSON.stringify('')],
   ['space', JSON.stringify(' ')],
@@ -35,60 +29,46 @@ const stringLiterals = [
   ['non-unicode', JSON.stringify('&#34; %22 0x22 034 &#x22;')],
   ['surrogate', '"😀"']
 ];
-
 const arrayLiterals = ['[]', '[null]', '[true, false]', '[0,1, 2,  3,\n4]', '[["2 deep"]]'];
-
 const objectLiterals = ['{}', '\n {\n "\\b"\n :\n""\n }\n ', '{"":""}', '{"1":{"2":"deep"}}'];
-
 const parse = (json, Parser) => {
   const parser = new Parser();
   parser.write(json);
   parser.close();
   return parser.result;
 };
-
-function runTests(t, json, description, Parser) {
+function runTests(json, description, Parser) {
   const expected = JSON.parse(json);
-  const message = `${JSON.stringify(json)} -> ${JSON.stringify(expected)}${
-    description ? ` (${description})` : ''
-  }`;
+  const message = `${JSON.stringify(json)} -> ${JSON.stringify(expected)}${description ? ` (${description})` : ''}`;
   const actual = parse(json, Parser);
-  t.deepEquals(actual, expected, message);
+  expect(actual, message).toEqual(expected);
 }
-
 for (const cases of literalCases) {
-  test(`JSONParser#${cases.type} literal`, t => {
+  test(`JSONParser#${cases.type} literal`, () => {
     for (const json of cases.cases) {
       stringLiterals.push([`quoted ${cases.type}`, `"${json}"`]);
       // Clarinet does not current support (null | boolean | number | string) as root value.
       // To work around this, we wrap the literal in an array before passing to 'runTests()'.
       // (See: https://github.com/dscape/clarinet/issues/49)
-      runTests(t, `[${json}]`, 'literal', JSONParser);
+      runTests(`[${json}]`, 'literal', JSONParser);
     }
-    t.end();
   });
 }
-
-test('JSONParser#string literal', t => {
+test('JSONParser#string literal', () => {
   for (const [description, json] of stringLiterals) {
     // Clarinet does not current support (null | boolean | number | string) as root value.
     // To work around this, we wrap the literal in an array before passing to 'runTests(t, )'.
     // (See: https://github.com/dscape/clarinet/issues/49)
-    runTests(t, `[${json}]`, description, JSONParser);
+    runTests(`[${json}]`, description, JSONParser);
   }
-  t.end();
 });
-
-test('JSONParser#array literal', t => {
+test('JSONParser#array literal', () => {
   for (const json of arrayLiterals) {
-    runTests(t, json, 'array literal', JSONParser);
+    runTests(json, 'array literal', JSONParser);
   }
-  t.end();
 });
-
-test('JSONParser#object literal', t => {
+test('JSONParser#object literal', () => {
   for (const json of objectLiterals) {
-    runTests(t, json, 'object literal', JSONParser);
+    runTests(json, 'object literal', JSONParser);
   }
-  t.end();
 });

--- a/modules/json/test/lib/parser/streaming-json-parser.spec.js
+++ b/modules/json/test/lib/parser/streaming-json-parser.spec.js
@@ -1,16 +1,9 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {fetchFile, makeIterator} from '@loaders.gl/core';
 import StreamingJSONParser from '../../../src/lib/json-parser/streaming-json-parser';
-
 const GEOJSON_PATH = `@loaders.gl/json/test/data/geojson-big.json`;
-
-test('StreamingJSONParser#geojson', async t => {
+test('StreamingJSONParser#geojson', async () => {
   const parser = new StreamingJSONParser();
-
   // Can return text stream by setting `{encoding: 'utf8'}`, but only works on Node
   const response = await fetchFile(GEOJSON_PATH);
   // TODO - https requests under Node return a Promise
@@ -18,7 +11,5 @@ test('StreamingJSONParser#geojson', async t => {
     const string = new TextDecoder().decode(chunk);
     parser.write(string);
   }
-
-  t.pass('should be able to parse geojson in chunks from a stream');
-  t.end();
+  expect(true, 'should be able to parse geojson in chunks from a stream').toBe(true);
 });

--- a/modules/loader-utils/test/lib/laz/laz-chunk-encoder.spec.ts
+++ b/modules/loader-utils/test/lib/laz/laz-chunk-encoder.spec.ts
@@ -1,8 +1,4 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {
   createLAZChunkEncoder,
   createLAZChunkDecoderCursor,
@@ -13,39 +9,30 @@ import {
   encodeLAZChunkTable,
   getLAZChunkByteLength
 } from '@loaders.gl/loader-utils';
-
-test('LAZChunkEncoder#encodes LASzip v3 PDRF 6-8 chunks', t => {
+test('LAZChunkEncoder#encodes LASzip v3 PDRF 6-8 chunks', () => {
   for (const pointDataRecordFormat of [6, 7, 8]) {
     const {rawPointData, metadata} = createLAZEncodingFixture(pointDataRecordFormat);
     const compressed = encodeLAZChunk(rawPointData, metadata);
-
-    t.deepEqual(
-      decodeLAZChunk(compressed, metadata),
-      rawPointData,
-      `PDRF ${pointDataRecordFormat} roundtrip`
+    expect(decodeLAZChunk(compressed, metadata), `PDRF ${pointDataRecordFormat} roundtrip`).toEqual(
+      rawPointData
     );
-    t.deepEqual(
+    expect(
       encodeLAZChunk(rawPointData, metadata),
-      compressed,
       `PDRF ${pointDataRecordFormat} output is deterministic`
-    );
-    t.equal(
+    ).toEqual(compressed);
+    expect(
       getLAZChunkByteLength(compressed, metadata),
-      compressed.byteLength,
       `PDRF ${pointDataRecordFormat} layered size headers are complete`
-    );
+    ).toBe(compressed.byteLength);
   }
-  t.end();
 });
-
-test('LAZChunkDecoder#decodes modern Extra Bytes directly into point-data targets', t => {
+test('LAZChunkDecoder#decodes modern Extra Bytes directly into point-data targets', () => {
   for (const pointDataRecordFormat of [6, 7, 8]) {
     const {rawPointData, metadata} = createLAZEncodingFixture(pointDataRecordFormat);
     const compressed = encodeLAZChunk(rawPointData, metadata);
     const extraBytes = new Uint8Array(metadata.pointCount * 2);
     const positions = new Float64Array(metadata.pointCount * 3);
     const cursor = createLAZChunkDecoderCursor(compressed, metadata);
-
     cursor.decodeIntoPointData(
       {
         positions,
@@ -56,7 +43,6 @@ test('LAZChunkDecoder#decodes modern Extra Bytes directly into point-data target
       },
       metadata.pointCount
     );
-
     const expectedExtraBytes = new Uint8Array(metadata.pointCount * 2);
     for (let pointIndex = 0; pointIndex < metadata.pointCount; pointIndex++) {
       const sourceOffset =
@@ -66,16 +52,13 @@ test('LAZChunkDecoder#decodes modern Extra Bytes directly into point-data target
     const mismatchIndex = extraBytes.findIndex(
       (value, index) => value !== expectedExtraBytes[index]
     );
-    t.equal(
+    expect(
       mismatchIndex,
-      -1,
       `PDRF ${pointDataRecordFormat} Extra Bytes (first mismatch ${mismatchIndex}: ${extraBytes[mismatchIndex]} vs ${expectedExtraBytes[mismatchIndex]})`
-    );
+    ).toBe(-1);
   }
-  t.end();
 });
-
-test('LAZChunkEncoder#feedable input preserves view ranges', t => {
+test('LAZChunkEncoder#feedable input preserves view ranges', () => {
   const {rawPointData, metadata} = createLAZEncodingFixture(8);
   const padded = new Uint8Array(rawPointData.byteLength + 16);
   padded.set(rawPointData, 8);
@@ -83,28 +66,22 @@ test('LAZChunkEncoder#feedable input preserves view ranges', t => {
   const splitOffset = Math.floor(rawPointData.byteLength / 2);
   encoder.feed(padded.subarray(8, 8 + splitOffset));
   encoder.feed(padded.subarray(8 + splitOffset, 8 + rawPointData.byteLength));
-  t.throws(
-    () => encoder.encode(),
-    /input is not closed/,
-    'feedable encoder requires close before encode'
+  expect(() => encoder.encode(), 'feedable encoder requires close before encode').toThrow(
+    /input is not closed/
   );
   encoder.close();
-  t.throws(
+  expect(
     () => encoder.feed(new Uint8Array(1)),
-    /closed LAZ chunk encoder/,
     'closed feedable encoder rejects more input'
-  );
-  t.deepEqual(
+  ).toThrow(/closed LAZ chunk encoder/);
+  expect(
     decodeLAZChunk(encoder.encode(), metadata),
-    rawPointData,
     'feedable encoder preserves input view byte ranges'
-  );
-  t.end();
+  ).toEqual(rawPointData);
 });
-
-test('LAZChunkEncoder#validates input and item versions', t => {
+test('LAZChunkEncoder#validates input and item versions', () => {
   const {rawPointData, metadata} = createLAZEncodingFixture(6);
-  t.throws(
+  expect(
     () =>
       encodeLASzipVLR({
         pointDataRecordFormat: 6,
@@ -112,10 +89,9 @@ test('LAZChunkEncoder#validates input and item versions', t => {
         chunkSize: 1,
         itemVersion: 2
       }),
-    /Modern LASzip point formats require item version 3/,
     'modern item version overrides are rejected'
-  );
-  t.throws(
+  ).toThrow(/Modern LASzip point formats require item version 3/);
+  expect(
     () =>
       encodeLASzipVLR({
         pointDataRecordFormat: 0,
@@ -123,10 +99,9 @@ test('LAZChunkEncoder#validates input and item versions', t => {
         chunkSize: 1,
         itemVersion: 3
       }),
-    /Legacy LASzip point formats require item version 2/,
     'legacy item version overrides are rejected'
-  );
-  t.throws(
+  ).toThrow(/Legacy LASzip point formats require item version 2/);
+  expect(
     () =>
       encodeLASzipVLR({
         pointDataRecordFormat: 0,
@@ -134,23 +109,18 @@ test('LAZChunkEncoder#validates input and item versions', t => {
         chunkSize: 1,
         itemVersion: 3
       }),
-    /Legacy LASzip point formats require item version 2/,
     'legacy item version overrides are rejected'
-  );
-  t.throws(
+  ).toThrow(/Legacy LASzip point formats require item version 2/);
+  expect(
     () => encodeLAZChunk(rawPointData.subarray(1), metadata),
-    /expected/,
     'incomplete point data is rejected'
-  );
-  t.throws(
+  ).toThrow(/expected/);
+  expect(
     () => encodeLAZChunk(rawPointData, {...metadata, point14ItemVersion: 4}),
-    /only supports Point14 item version 3/,
     'unsupported Point14 versions are rejected'
-  );
-  t.end();
+  ).toThrow(/only supports Point14 item version 3/);
 });
-
-test('LAZChunkEncoder#roundtrips legacy waveform items', t => {
+test('LAZChunkEncoder#roundtrips legacy waveform items', () => {
   for (const pointDataRecordFormat of [4, 5] as const) {
     const pointDataRecordLength = pointDataRecordFormat === 4 ? 57 : 63;
     const rawPointData = new Uint8Array(pointDataRecordLength * 2);
@@ -195,41 +165,35 @@ test('LAZChunkEncoder#roundtrips legacy waveform items', t => {
       pointDataRecordLength
     });
     const mismatchIndex = decoded.findIndex((value, index) => value !== rawPointData[index]);
-    t.equal(
+    expect(
       mismatchIndex,
-      -1,
       `PDRF ${pointDataRecordFormat} waveform item roundtrips (first mismatch ${mismatchIndex})`
-    );
+    ).toBe(-1);
   }
-  t.end();
 });
-
-test('LAZChunkEncoder#writes legacy waveform LASzip item descriptors', t => {
+test('LAZChunkEncoder#writes legacy waveform LASzip item descriptors', () => {
   const vlr = encodeLASzipVLR({
     pointDataRecordFormat: 5,
     pointDataRecordLength: 63,
-    chunkSize: 50_000
+    chunkSize: 50000
   });
   const dataView = new DataView(vlr.buffer, vlr.byteOffset, vlr.byteLength);
   const itemOffset = 54 + 34;
-  t.deepEqual(
+  expect(
     [0, 1, 2, 3].map(index => [
       dataView.getUint16(itemOffset + index * 6, true),
       dataView.getUint16(itemOffset + index * 6 + 2, true),
       dataView.getUint16(itemOffset + index * 6 + 4, true)
     ]),
-    [
-      [6, 20, 2],
-      [7, 8, 2],
-      [8, 6, 2],
-      [9, 29, 1]
-    ],
     'PDRF 5 items use the LASzip v1 waveform descriptor'
-  );
-  t.end();
+  ).toEqual([
+    [6, 20, 2],
+    [7, 8, 2],
+    [8, 6, 2],
+    [9, 29, 1]
+  ]);
 });
-
-test('LAZChunkEncoder#roundtrips modern waveform items', t => {
+test('LAZChunkEncoder#roundtrips modern waveform items', () => {
   for (const pointDataRecordFormat of [9, 10] as const) {
     const pointDataRecordLength = pointDataRecordFormat === 9 ? 59 : 67;
     const rawPointData = new Uint8Array(pointDataRecordLength * 2);
@@ -276,16 +240,13 @@ test('LAZChunkEncoder#roundtrips modern waveform items', t => {
       byte14ItemVersion: 3 as const
     };
     const compressed = encodeLAZChunk(rawPointData, metadata);
-    t.deepEqual(
+    expect(
       decodeLAZChunk(compressed, metadata),
-      rawPointData,
       `PDRF ${pointDataRecordFormat} waveform item roundtrips`
-    );
+    ).toEqual(rawPointData);
   }
-  t.end();
 });
-
-test('LAZChunkEncoder#encodes LASzip v2 PDRF 0 chunks', t => {
+test('LAZChunkEncoder#encodes LASzip v2 PDRF 0 chunks', () => {
   const pointCount = 32;
   const pointDataRecordLength = 22;
   const rawPointData = new Uint8Array(pointCount * pointDataRecordLength);
@@ -310,48 +271,42 @@ test('LAZChunkEncoder#encodes LASzip v2 PDRF 0 chunks', t => {
     pointDataRecordLength
   };
   const compressed = encodeLAZChunk(rawPointData, metadata);
-  t.deepEqual(decodeLAZChunk(compressed, metadata), rawPointData, 'PDRF 0 roundtrips');
-  t.deepEqual(encodeLAZChunk(rawPointData, metadata), compressed, 'PDRF 0 output is deterministic');
-  t.end();
+  expect(decodeLAZChunk(compressed, metadata), 'PDRF 0 roundtrips').toEqual(rawPointData);
+  expect(encodeLAZChunk(rawPointData, metadata), 'PDRF 0 output is deterministic').toEqual(
+    compressed
+  );
 });
-
-test('LAZChunkEncoder#encodes fixed and variable chunk tables', t => {
+test('LAZChunkEncoder#encodes fixed and variable chunk tables', () => {
   const chunks = [
-    {pointCount: 50_000, byteLength: 100_000},
-    {pointCount: 50_000, byteLength: 90_000},
+    {pointCount: 50000, byteLength: 100000},
+    {pointCount: 50000, byteLength: 90000},
     {pointCount: 23, byteLength: 800}
   ];
   const fixedTable = encodeLAZChunkTable(chunks);
-  t.deepEqual(
+  expect(
     decodeLAZChunkTable(fixedTable, {
       chunkCount: chunks.length,
-      pointCount: 100_023,
-      chunkSize: 50_000,
+      pointCount: 100023,
+      chunkSize: 50000,
       variable: false
     }),
-    chunks,
     'fixed-size chunk table roundtrips'
-  );
-
+  ).toEqual(chunks);
   const variableTable = encodeLAZChunkTable(chunks, {variable: true});
-  t.deepEqual(
+  expect(
     decodeLAZChunkTable(variableTable, {
       chunkCount: chunks.length,
-      pointCount: 100_023,
+      pointCount: 100023,
       chunkSize: 0xffffffff,
       variable: true
     }),
-    chunks,
     'variable-size chunk table roundtrips'
-  );
-  t.throws(
+  ).toEqual(chunks);
+  expect(
     () => encodeLAZChunkTable([{pointCount: 0, byteLength: 1}]),
-    /Invalid LAZ chunk point count/,
     'empty chunks are rejected'
-  );
-  t.end();
+  ).toThrow(/Invalid LAZ chunk point count/);
 });
-
 /** Create varied LAS 1.4 records for shared LAZ encoder tests. */
 function createLAZEncodingFixture(pointDataRecordFormat: number) {
   const baseRecordLength = {6: 30, 7: 36, 8: 38}[pointDataRecordFormat];
@@ -361,8 +316,7 @@ function createLAZEncodingFixture(pointDataRecordFormat: number) {
   const pointCount = 32;
   const pointDataRecordLength = baseRecordLength + 2;
   const rawPointData = new Uint8Array(pointCount * pointDataRecordLength);
-  let previousGpsTime = 1_000_000_000;
-
+  let previousGpsTime = 1000000000;
   for (let pointIndex = 0; pointIndex < pointCount; pointIndex++) {
     const recordOffset = pointIndex * pointDataRecordLength;
     const view = new DataView(
@@ -373,9 +327,8 @@ function createLAZEncodingFixture(pointDataRecordFormat: number) {
     const numberOfReturns = 1 + (pointIndex % 5);
     const returnNumber = 1 + (pointIndex % numberOfReturns);
     const scannerChannel = (pointIndex * 3 + 2) % 4;
-    const gpsTime = pointIndex % 7 === 0 ? previousGpsTime : 1_000_000_000 + pointIndex * 0.001;
+    const gpsTime = pointIndex % 7 === 0 ? previousGpsTime : 1000000000 + pointIndex * 0.001;
     previousGpsTime = gpsTime;
-
     view.setInt32(0, 1000 + pointIndex * 13, true);
     view.setInt32(4, -2000 + pointIndex * pointIndex, true);
     view.setInt32(8, 50 - pointIndex * 3, true);
@@ -387,7 +340,6 @@ function createLAZEncodingFixture(pointDataRecordFormat: number) {
     view.setInt16(18, -100 + pointIndex * 9, true);
     view.setUint16(20, 3 + (pointIndex >> 2), true);
     view.setFloat64(22, gpsTime, true);
-
     if (pointDataRecordFormat >= 7) {
       view.setUint16(30, pointIndex * 1000, true);
       view.setUint16(32, 65535 - pointIndex * 500, true);
@@ -399,7 +351,6 @@ function createLAZEncodingFixture(pointDataRecordFormat: number) {
     view.setUint8(baseRecordLength, pointIndex);
     view.setUint8(baseRecordLength + 1, 255 - pointIndex);
   }
-
   return {
     rawPointData,
     metadata: {

--- a/modules/mvt/test/lib/mapbox-vt-pbf/to-vector-tile.spec.js
+++ b/modules/mvt/test/lib/mapbox-vt-pbf/to-vector-tile.spec.js
@@ -1,17 +1,12 @@
-// SPDX-License-Identifier: MIT
-
-// @ts-nocheck
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {fetchFile} from '@loaders.gl/core';
 import Pbf from 'pbf';
 import VectorTile from '@loaders.gl/mvt/lib/mapbox-vector-tile-js/vector-tile';
 import {fromGeojsonVt} from '@loaders.gl/mvt/lib/mapbox-vt-pbf/to-vector-tile';
 import geojsonVt from 'geojson-vt';
 import GeoJsonEquality from 'geojson-equality';
-
 const eq = new GeoJsonEquality({precision: 1});
-
-test('property encoding: JSON.stringify non-primitive values', t => {
+test('property encoding: JSON.stringify non-primitive values', () => {
   // Includes two properties with a common non-primitive value for
   // https://github.com/mapbox/vt-pbf/issues/9
   const orig = {
@@ -45,24 +40,19 @@ test('property encoding: JSON.stringify non-primitive values', t => {
       }
     ]
   };
-
   const tileindex = geojsonVt(orig);
   const tile = tileindex.getTile(1, 0, 0);
   const buff = fromGeojsonVt({geojsonLayer: tile});
-
   const vt = new VectorTile(new Pbf(buff));
   const layer = vt.layers.geojsonLayer;
-
   const first = layer.feature(0).properties;
   const second = layer.feature(1).properties;
-  t.same(first.c, '{"hello":"world"}');
-  t.same(first.d, '[1,2,3]');
-  t.same(second.c, '{"goodbye":"planet"}');
-  t.same(second.d, '{"hello":"world"}');
-  t.end();
+  expect(first.c).toEqual('{"hello":"world"}');
+  expect(first.d).toEqual('[1,2,3]');
+  expect(second.c).toEqual('{"goodbye":"planet"}');
+  expect(second.d).toEqual('{"hello":"world"}');
 });
-
-test('number encoding https://github.com/mapbox/vt-pbf/pull/11', t => {
+test('number encoding https://github.com/mapbox/vt-pbf/pull/11', () => {
   const orig = {
     type: 'Feature',
     properties: {
@@ -74,20 +64,16 @@ test('number encoding https://github.com/mapbox/vt-pbf/pull/11', t => {
       coordinates: [0, 0]
     }
   };
-
   const tileindex = geojsonVt(orig);
   const tile = tileindex.getTile(1, 0, 0);
   const buff = fromGeojsonVt({geojsonLayer: tile});
   const vt = new VectorTile(new Pbf(buff));
   const layer = vt.layers.geojsonLayer;
-
   const properties = layer.feature(0).properties;
-  t.equal(properties.large_integer, 39953616224);
-  t.equal(properties.non_integer, 331.75415);
-  t.end();
+  expect(properties.large_integer).toBe(39953616224);
+  expect(properties.non_integer).toBe(331.75415);
 });
-
-test('id encoding', t => {
+test('id encoding', () => {
   const orig = {
     type: 'FeatureCollection',
     features: [
@@ -125,24 +111,20 @@ test('id encoding', t => {
   const buff = fromGeojsonVt({geojsonLayer: tile});
   const vt = new VectorTile(new Pbf(buff));
   const layer = vt.layers.geojsonLayer;
-  t.same(layer.feature(0).id, 123);
-  t.notOk(layer.feature(1).id, 'Non-integer values should not be saved');
-  t.notOk(layer.feature(2).id);
-  t.end();
+  expect(layer.feature(0).id).toEqual(123);
+  expect(layer.feature(1).id, 'Non-integer values should not be saved').toBeFalsy();
+  expect(layer.feature(2).id).toBeFalsy();
 });
-
-test('accept geojson-vt options https://github.com/mapbox/vt-pbf/pull/21', async t => {
+test('accept geojson-vt options https://github.com/mapbox/vt-pbf/pull/21', async () => {
   const RECTANGLE_URL = '@loaders.gl/mvt/test/data/mapbox-vt-pbf-fixtures/rectangle.geojson';
   const response = await fetchFile(RECTANGLE_URL);
   const orig = await response.json();
-
   const version = 2;
   const extent = 8192;
   const tileindex = geojsonVt(orig, {extent});
   const tile = tileindex.getTile(1, 0, 0);
   const options = {version, extent};
   const buff = fromGeojsonVt({geojsonLayer: tile}, options);
-
   const vt = new VectorTile(new Pbf(buff));
   const layer = vt.layers.geojsonLayer;
   const features = [];
@@ -150,18 +132,12 @@ test('accept geojson-vt options https://github.com/mapbox/vt-pbf/pull/21', async
     const feat = layer.feature(i).toGeoJSON(0, 0, 1);
     features.push(feat);
   }
-
-  t.equal(layer.version, options.version, 'version should be equal');
-  t.equal(layer.extent, options.extent, 'extent should be equal');
-
+  expect(layer.version, 'version should be equal').toBe(options.version);
+  expect(layer.extent, 'extent should be equal').toBe(options.extent);
   orig.features.forEach(function (expected) {
     const actual = features.shift();
-
     // TODO - this was added in loaders fork to make tests pass, investigate why it is needed
     delete expected.id;
-
-    t.ok(eq.compare(actual, expected));
+    expect(eq.compare(actual, expected)).toBeTruthy();
   });
-
-  t.end();
 });

--- a/modules/mvt/test/lib/mapbox-vt-pbf/vector-tile-roundtrip.spec.js
+++ b/modules/mvt/test/lib/mapbox-vt-pbf/vector-tile-roundtrip.spec.js
@@ -1,7 +1,4 @@
-// SPDX-License-Identifier: MIT
-
-// @ts-nocheck
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {isBrowser} from '@loaders.gl/loader-utils';
 import VectorTile from '@loaders.gl/mvt/lib/mapbox-vector-tile-js/vector-tile';
 import {fromGeojsonVt, fromVectorTileJs} from '@loaders.gl/mvt/lib/mapbox-vt-pbf/to-vector-tile';
@@ -10,23 +7,18 @@ import geojsonVt from 'geojson-vt';
 import geojsonFixtures from '@mapbox/geojson-fixtures';
 import mvtf from '@mapbox/mvt-fixtures';
 import GeoJsonEquality from 'geojson-equality';
-
 // Mock: vtvalidate library doesn't compile under Node 12
 const vtvalidate = {
   isValid(buff, onValidationComplete) {
     onValidationComplete(null, false);
   }
 };
-
 const eq = new GeoJsonEquality({precision: 1});
-
-test('geojson-vt', t => {
+test('geojson-vt', () => {
   if (isBrowser) {
-    t.comment('Skipping as @mapbox/geojson-fixtures is only supported in Node.js');
-    t.end();
+    console.log('Skipping as @mapbox/geojson-fixtures is only supported in Node.js');
     return;
   }
-
   const geometryTypes = [
     'polygon',
     'point',
@@ -35,98 +27,76 @@ test('geojson-vt', t => {
     'polygon',
     'multilinestring'
   ];
-
   const fixtures = geometryTypes.map(function (type) {
     return {
       name: type,
       data: {type: 'Feature', properties: {}, geometry: geojsonFixtures.geometry[type]}
     };
   });
-
   fixtures.forEach(function (fixture) {
-    t.comment(`Testing ${fixture.name}`);
+    console.log(`Testing ${fixture.name}`);
     const tile = geojsonVt(fixture.data).getTile(0, 0, 0);
     const buff = fromGeojsonVt({geojsonLayer: tile});
     vtvalidate.isValid(buff, (err, invalid) => {
-      t.error(err);
-
-      t.ok(!invalid, invalid);
-
+      expect(err, 'validation callback returns no error').toBeNull();
+      expect(!invalid, invalid).toBeTruthy();
       // Compare roundtripped features with originals
       const expected =
         fixture.data.type === 'FeatureCollection' ? fixture.data.features : [fixture.data];
       const layer = new VectorTile(new Pbf(buff)).layers.geojsonLayer;
-      t.equal(layer.length, expected.length, `${expected.length} features`);
+      expect(layer.length, `${expected.length} features`).toBe(expected.length);
       for (let i = 0; i < layer.length; i++) {
         const actual = layer.feature(i).toGeoJSON(0, 0, 0);
-        t.ok(eq.compare(actual, expected[i]), `feature ${i}`);
+        expect(eq.compare(actual, expected[i]), `feature ${i}`).toBeTruthy();
       }
-      t.end();
     });
   });
-
-  t.end();
 });
-
-test('vector-tile-js', t => {
+test('vector-tile-js', () => {
   // See https://github.com/mapbox/mvt-fixtures/blob/master/FIXTURES.md for
   // fixture descriptions
   mvtf.each(function (fixture) {
     // skip invalid tiles
     if (!fixture.validity.v2) return;
-
-    t.comment(`mvt-fixtures: ${fixture.id} ${fixture.description}`);
+    console.log(`mvt-fixtures: ${fixture.id} ${fixture.description}`);
     const original = new VectorTile(new Pbf(fixture.buffer));
-
     if (fixture.id === '020') {
-      t.comment('Skipping test due to https://github.com/mapbox/vt-pbf/issues/30');
-      t.end();
+      console.log('Skipping test due to https://github.com/mapbox/vt-pbf/issues/30');
       return;
     }
-
     if (fixture.id === '049' || fixture.id === '050') {
-      t.comment('Skipping test due to https://github.com/mapbox/vt-pbf/issues/31');
-      t.end();
+      console.log('Skipping test due to https://github.com/mapbox/vt-pbf/issues/31');
       return;
     }
-
     const buff = fromVectorTileJs(original);
     const roundtripped = new VectorTile(new Pbf(buff));
-
     vtvalidate.isValid(buff, (err, invalid) => {
-      t.error(err);
-
+      expect(err, 'validation callback returns no error').toBeNull();
       if (invalid && invalid === 'ClosePath command count is not 1') {
-        t.comment('Skipping test due to https://github.com/mapbox/vt-pbf/issues/28');
-        t.end();
+        console.log('Skipping test due to https://github.com/mapbox/vt-pbf/issues/28');
         return;
       }
-
       // UNKOWN geometry type is valid in the spec, but vtvalidate considers
       // it an error
       if (fixture.id === '016' || fixture.id === '039') {
         invalid = null;
       }
-
-      t.ok(!invalid, invalid);
-
+      expect(!invalid, invalid).toBeTruthy();
       // Compare roundtripped features with originals
       for (const name in original.layers) {
         const originalLayer = original.layers[name];
-        t.ok(roundtripped.layers[name], `layer ${name}`);
+        expect(roundtripped.layers[name], `layer ${name}`).toBeTruthy();
         const roundtrippedLayer = roundtripped.layers[name];
-        t.equal(roundtrippedLayer.length, originalLayer.length);
+        expect(roundtrippedLayer.length).toBe(originalLayer.length);
         for (let i = 0; i < originalLayer.length; i++) {
           const actual = roundtrippedLayer.feature(i);
           const expected = originalLayer.feature(i);
-
-          t.equal(actual.id, expected.id, 'id');
-          t.equal(actual.type, expected.type, 'type');
-          t.deepEqual(actual.properties, expected.properties, 'properties');
-          t.deepEqual(actual.loadGeometry(), expected.loadGeometry(), 'geometry');
+          expect(actual.id, 'id').toBe(expected.id);
+          expect(actual.type, 'type').toBe(expected.type);
+          expect(actual.properties, 'properties').toEqual(expected.properties);
+          expect(actual.loadGeometry(), 'geometry').toEqual(expected.loadGeometry());
         }
       }
     });
   });
-  t.end();
 });

--- a/modules/netcdf/test/netcdf-loader.spec.js
+++ b/modules/netcdf/test/netcdf-loader.spec.js
@@ -1,22 +1,16 @@
 // loaders.gl
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
-
-// import test from 'test/utils/vitest-tape';
-
 import {describe, it, expect} from 'test/utils/expect-assertions';
 import {NetCDFLoader} from '@loaders.gl/netcdf';
 import {load} from '@loaders.gl/core';
-
 const DATA_PATH = `@loaders.gl/netcdf/test/data`;
-
 describe('NetCDFLoader', () => {
   // it('Throws on non NetCDF file', async () => {
   //   // expect(() {
   //   //   await load(`${DATA_PATH}/not_nc.txt`, NetCDFLoader);
   //   // }).toThrow('Not a valid NetCDF v3.x file: should start with CDF');
   // });
-
   it('read header information', async () => {
     const result = await load(`${DATA_PATH}/madis-sao.nc`, NetCDFLoader);
     expect(result.loaderData.version).toBe(1);
@@ -50,7 +44,6 @@ describe('NetCDFLoader', () => {
       {name: 'nInventoryBins', size: 24},
       {name: 'recNum', size: 0}
     ]);
-
     expect(result.loaderData.attributes[0]).toStrictEqual({
       name: 'cdlDate',
       type: 'char',
@@ -61,7 +54,6 @@ describe('NetCDFLoader', () => {
       type: 'int',
       value: 3600
     });
-
     expect(result.loaderData.variables[0]).toStrictEqual({
       name: 'nStaticIds',
       dimensions: [],
@@ -92,15 +84,12 @@ describe('NetCDFLoader', () => {
       record: true
     });
   });
-
   it('read non-record variable', async () => {
     const result = await load(`${DATA_PATH}/madis-sao.nc`, NetCDFLoader, {
       netcdf: {loadData: true}
     });
-
     expect(result.data.nStaticIds[0]).toBe(145);
   });
-
   it('read 2 dimensional variable', async () => {
     const result = await load(`${DATA_PATH}/ichthyop.nc`, NetCDFLoader, {
       netcdf: {loadData: true}
@@ -111,22 +100,18 @@ describe('NetCDFLoader', () => {
     expect(result.data.lat[0]).toHaveLength(1000);
     expect(result.data.lat[0][0]).toBe(53.26256561279297);
   });
-
   it('read record variable with string', async () => {
     const result = await load(`${DATA_PATH}/madis-sao.nc`, NetCDFLoader, {
       netcdf: {loadData: true}
     });
-
     expect(result.data.wmoId[0]).toBe(71419);
     expect(result.data.wmoId[1]).toBe(71415);
     expect(result.data.wmoId[2]).toBe(71408);
   });
-
   it('read non-record variable with object', async () => {
     const result = await load(`${DATA_PATH}/madis-sao.nc`, NetCDFLoader, {
       netcdf: {loadData: true}
     });
-
     const withString = result.data.staticIds;
     const withObject = result.data[result.loaderData.variables[1].name];
     expect(withString[0]).toBe('W');
@@ -136,7 +121,6 @@ describe('NetCDFLoader', () => {
     expect(withString[1]).toBe(withObject[1]);
     expect(withString[2]).toBe(withObject[2]);
   });
-
   it('read 64 bit offset file', async () => {
     const result = await load(`${DATA_PATH}/model1_md2.nc`, NetCDFLoader, {
       netcdf: {loadData: true}
@@ -145,14 +129,11 @@ describe('NetCDFLoader', () => {
     expect(result.data.cell_angular[0]).toBe('a');
     expect(result.data.cell_spatial[0]).toBe('a');
   });
-
   it('read agilent hplc file file', async () => {
     const result = await load(`${DATA_PATH}/agilent_hplc.cdf`, NetCDFLoader, {
       netcdf: {loadData: true}
     });
-
     expect(result.loaderData.version).toBe(1);
-
     expect(Object.entries(result.data)).toHaveLength(24);
     expect(result.data.actual_delay_time).toStrictEqual([0.012000000104308128]);
     expect(result.data.ordinate_values).toHaveLength(4651);

--- a/modules/obj/test/mtl-loader.spec.js
+++ b/modules/obj/test/mtl-loader.spec.js
@@ -1,51 +1,35 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-/* eslint-disable max-len */
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {validateLoader} from 'test/common/conformance';
-
 import {MTLLoader} from '@loaders.gl/obj';
 import {load} from '@loaders.gl/core';
-
 const MTL_URL = '@loaders.gl/obj/test/data/windmill.mtl';
-
-test('MTLLoader#loader objects', t => {
-  validateLoader(t, MTLLoader, 'MTLLoader');
-  t.end();
+test('MTLLoader#loader objects', () => {
+  validateLoader(MTLLoader, 'MTLLoader');
 });
-
-test('MTLLoader#parse(windmill.mtl', async t => {
+test('MTLLoader#parse(windmill.mtl', async () => {
   /** @type {import('../src/lib/parse-mtl').MTLMaterial[]} */
   const materials = await load(MTL_URL, MTLLoader, {core: {worker: false}});
-
   // t.comment(JSON.stringify(materials));
-  t.equal(materials.length, 2, '2 material');
-
-  t.equal(materials[0].name, 'Material', 'Material');
-  t.equal(materials[0].shininess, 0.0);
-  t.deepEqual(materials[0].ambientColor, [1.0, 1.0, 1.0]);
-  t.deepEqual(materials[0].diffuseColor, [0.8, 0.8, 0.8]);
-  t.deepEqual(materials[0].specularColor, [0.0, 0.0, 0.0]);
-  t.deepEqual(materials[0].emissiveColor, [0.0, 0.0, 0.0]);
-  t.equal(materials[0].refraction, 1.0);
+  expect(materials.length, '2 material').toBe(2);
+  expect(materials[0].name, 'Material').toBe('Material');
+  expect(materials[0].shininess).toBe(0.0);
+  expect(materials[0].ambientColor).toEqual([1.0, 1.0, 1.0]);
+  expect(materials[0].diffuseColor).toEqual([0.8, 0.8, 0.8]);
+  expect(materials[0].specularColor).toEqual([0.0, 0.0, 0.0]);
+  expect(materials[0].emissiveColor).toEqual([0.0, 0.0, 0.0]);
+  expect(materials[0].refraction).toBe(1.0);
   // t.equal(materials[0].d, 1.000000);
   // t.equal(materials[0].illum, 1);
-  t.equal(materials[0].diffuseTextureUrl, 'windmill_001_lopatky_COL.jpg');
+  expect(materials[0].diffuseTextureUrl).toBe('windmill_001_lopatky_COL.jpg');
   // t.equal(materials[0].map_Bump, 'windmill_001_lopatky_NOR.jpg');
-
-  t.equal(materials[1].name, 'windmill', 'windmill');
-  t.equal(materials[1].shininess, 0.0);
-  t.deepEqual(materials[1].ambientColor, [1.0, 1.0, 1.0]);
-  t.deepEqual(materials[1].diffuseColor, [0.8, 0.8, 0.8]);
-  t.deepEqual(materials[1].specularColor, [0.0, 0.0, 0.0]);
-  t.deepEqual(materials[1].emissiveColor, [0.0, 0.0, 0.0]);
-  t.equal(materials[1].refraction, 1.0);
+  expect(materials[1].name, 'windmill').toBe('windmill');
+  expect(materials[1].shininess).toBe(0.0);
+  expect(materials[1].ambientColor).toEqual([1.0, 1.0, 1.0]);
+  expect(materials[1].diffuseColor).toEqual([0.8, 0.8, 0.8]);
+  expect(materials[1].specularColor).toEqual([0.0, 0.0, 0.0]);
+  expect(materials[1].emissiveColor).toEqual([0.0, 0.0, 0.0]);
+  expect(materials[1].refraction).toBe(1.0);
   // t.equal(materials[1].d, 1.000000);
   // t.equal(materials[1].illum, 1);
-  t.equal(materials[1].diffuseTextureUrl, 'windmill_001_base_COL.jpg');
-  // t.equal(materials[1].map_Bump, 'windmill_001_base_NOR.jpg');
-  // t.equal(materials[1].specularTextureUrl, 'windmill_001_base_SPEC.jpg');
-  t.end();
+  expect(materials[1].diffuseTextureUrl).toBe('windmill_001_base_COL.jpg');
 });

--- a/modules/obj/test/obj-loader.spec.js
+++ b/modules/obj/test/obj-loader.spec.js
@@ -1,50 +1,33 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-/* eslint-disable max-len */
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {validateLoader, validateMeshCategoryData} from 'test/common/conformance';
 import {validateArrowTableSchema} from '@loaders.gl/arrow';
 import {meshArrowSchema} from '@loaders.gl/schema';
-
 import {OBJLoader, OBJWorkerLoader} from '@loaders.gl/obj';
 import {setLoaderOptions, load, parseInBatches} from '@loaders.gl/core';
 import {equals} from '@math.gl/core';
-
 const OBJ_ASCII_URL = '@loaders.gl/obj/test/data/bunny.obj';
 const OBJ_NORMALS_URL = '@loaders.gl/obj/test/data/cube.obj';
 const OBJ_MULTI_PART_URL = '@loaders.gl/obj/test/data/magnolia.obj';
 const OBJ_VERTEX_COLOR_URL = '@loaders.gl/obj/test/data/cube-vertex-colors.obj';
-
 setLoaderOptions({
   _workerType: 'test'
 });
-
-test('OBJLoader#loader objects', t => {
-  validateLoader(t, OBJLoader, 'OBJLoader');
-  validateLoader(t, OBJWorkerLoader, 'OBJWorkerLoader');
-  t.end();
+test('OBJLoader#loader objects', () => {
+  validateLoader(OBJLoader, 'OBJLoader');
+  validateLoader(OBJWorkerLoader, 'OBJWorkerLoader');
 });
-
-test('OBJLoader#parseText', async t => {
+test('OBJLoader#parseText', async () => {
   const data = await load(OBJ_ASCII_URL, OBJLoader);
-  validateMeshCategoryData(t, data);
-
-  t.equal(data.mode, 4, 'mode is TRIANGLES (4)');
-
-  t.equal(data.attributes.POSITION.value.length, 14904 * 3, 'POSITION attribute was found');
-  t.equal(data.attributes.POSITION.size, 3, 'POSITION attribute was found');
-
-  t.end();
+  validateMeshCategoryData(data);
+  expect(data.mode, 'mode is TRIANGLES (4)').toBe(4);
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(14904 * 3);
+  expect(data.attributes.POSITION.size, 'POSITION attribute was found').toBe(3);
 });
-
-test('OBJLoader#parseText(shape: arrow-table)', async t => {
+test('OBJLoader#parseText(shape: arrow-table)', async () => {
   const table = await load(OBJ_ASCII_URL, OBJLoader, {
     obj: {shape: 'arrow-table'}
   });
-
-  t.equal(table.shape, 'arrow-table', 'table has arrow-table shape');
+  expect(table.shape, 'table has arrow-table shape').toBe('arrow-table');
   validateArrowTableSchema(table.data, meshArrowSchema, {
     schemaName: 'OBJLoader Mesh table'
   });
@@ -53,12 +36,9 @@ test('OBJLoader#parseText(shape: arrow-table)', async t => {
     table.data.length ??
     table.data.batches?.[0]?.numRows ??
     table.data.batches?.[0]?.data?.length;
-  t.equal(rowCount, 14904, 'table has expected vertex count');
-
-  t.end();
+  expect(rowCount, 'table has expected vertex count').toBe(14904);
 });
-
-test('OBJLoader#parseInBatches(vertex-only point cloud, arrow-table)', async t => {
+test('OBJLoader#parseInBatches(vertex-only point cloud, arrow-table)', async () => {
   const batches = await parseInBatches(
     [new TextEncoder().encode(['v 0 0 0', 'v 1 1 1', 'v 2 2 2', 'v 3 3 3', ''].join('\n')).buffer],
     OBJLoader,
@@ -68,19 +48,15 @@ test('OBJLoader#parseInBatches(vertex-only point cloud, arrow-table)', async t =
     }
   );
   const batchRowCounts = [];
-
   for await (const batch of batches) {
-    t.equal(batch.shape, 'arrow-table', 'batch has arrow-table shape');
-    t.equal(batch.batchType, 'data', 'batch has data batchType');
-    t.ok(batch.data.getChild('POSITION'), 'batch includes POSITION column');
+    expect(batch.shape, 'batch has arrow-table shape').toBe('arrow-table');
+    expect(batch.batchType, 'batch has data batchType').toBe('data');
+    expect(batch.data.getChild('POSITION'), 'batch includes POSITION column').toBeTruthy();
     batchRowCounts.push(batch.length);
   }
-
-  t.deepEqual(batchRowCounts, [2, 2], 'emits requested OBJ point cloud Arrow batches');
-  t.end();
+  expect(batchRowCounts, 'emits requested OBJ point cloud Arrow batches').toEqual([2, 2]);
 });
-
-test('OBJLoader#parseInBatches(pointCloud flag streams vertices without geometry scan)', async t => {
+test('OBJLoader#parseInBatches(pointCloud flag streams vertices without geometry scan)', async () => {
   const batches = await parseInBatches(
     [
       new TextEncoder().encode(
@@ -94,18 +70,14 @@ test('OBJLoader#parseInBatches(pointCloud flag streams vertices without geometry
     }
   );
   const batchRowCounts = [];
-
   for await (const batch of batches) {
-    t.equal(batch.shape, 'arrow-table', 'batch has arrow-table shape');
-    t.equal(batch.batchType, 'data', 'batch has data batchType');
+    expect(batch.shape, 'batch has arrow-table shape').toBe('arrow-table');
+    expect(batch.batchType, 'batch has data batchType').toBe('data');
     batchRowCounts.push(batch.length);
   }
-
-  t.deepEqual(batchRowCounts, [2, 2], 'pointCloud mode streams vertex rows and ignores faces');
-  t.end();
+  expect(batchRowCounts, 'pointCloud mode streams vertex rows and ignores faces').toEqual([2, 2]);
 });
-
-test('OBJLoader#parseInBatches(faces, arrow-table) falls back to atomic parse', async t => {
+test('OBJLoader#parseInBatches(faces, arrow-table) falls back to atomic parse', async () => {
   const batches = await parseInBatches(
     [new TextEncoder().encode(['v 0 0 0', 'v 1 0 0', 'v 0 1 0', 'f 1 2 3', ''].join('\n')).buffer],
     OBJLoader,
@@ -115,106 +87,78 @@ test('OBJLoader#parseInBatches(faces, arrow-table) falls back to atomic parse', 
     }
   );
   const batchRowCounts = [];
-
   for await (const batch of batches) {
-    t.equal(batch.shape, 'arrow-table', 'batch has arrow-table shape');
-    t.equal(batch.batchType, 'data', 'batch has data batchType');
+    expect(batch.shape, 'batch has arrow-table shape').toBe('arrow-table');
+    expect(batch.batchType, 'batch has data batchType').toBe('data');
     batchRowCounts.push(batch.length);
   }
-
-  t.deepEqual(batchRowCounts, [3], 'face geometry emits one atomic Arrow batch');
-  t.end();
+  expect(batchRowCounts, 'face geometry emits one atomic Arrow batch').toEqual([3]);
 });
-
-test('OBJLoader#parse(SCHEMA)', async t => {
+test('OBJLoader#parse(SCHEMA)', async () => {
   const data = await load(OBJ_NORMALS_URL, OBJLoader);
-  validateMeshCategoryData(t, data);
-
-  t.equal(data.schema.fields.length, 3, 'schema field count is correct');
-  t.equal(data.schema.metadata.mode, '4', 'schema metadata is correct');
-  t.ok(data.schema.metadata.boundingBox, 'schema metadata is correct');
-
+  validateMeshCategoryData(data);
+  expect(data.schema.fields.length, 'schema field count is correct').toBe(3);
+  expect(data.schema.metadata.mode, 'schema metadata is correct').toBe('4');
+  expect(data.schema.metadata.boundingBox, 'schema metadata is correct').toBeTruthy();
   const positionField = data.schema.fields.find(field => field.name === 'POSITION');
   // @ts-expect-error
-  t.equal(positionField?.type.listSize, 3, 'schema size correct');
+  expect(positionField?.type.listSize, 'schema size correct').toBe(3);
   // TODO/ActionEngine - restore this test
   // t.equal(positionField.type.valueType.precision, 32, 'schema type correct');
-
   const colorField = data.schema.fields.find(field => field.name === 'TEXCOORD_0');
   // @ts-expect-error
-  t.equal(colorField?.type.listSize, 2, 'schema size correct');
-
-  t.equal(data.mode, 4, 'mode is correct');
-  t.notOk(data.indices, 'INDICES attribute was not found');
-
-  t.end();
+  expect(colorField?.type.listSize, 'schema size correct').toBe(2);
+  expect(data.mode, 'mode is correct').toBe(4);
+  expect(data.indices, 'INDICES attribute was not found').toBeFalsy();
 });
-
-test('OBJLoader#parseText - object with normals', async t => {
+test('OBJLoader#parseText - object with normals', async () => {
   const data = await load(OBJ_NORMALS_URL, OBJLoader);
-  validateMeshCategoryData(t, data);
-
-  t.equal(data.attributes.POSITION.value.length, 108, 'POSITION attribute was found');
-  t.equal(data.attributes.POSITION.size, 3, 'POSITION attribute was found');
-  t.equal(data.attributes.NORMAL.value.length, 108, 'NORMAL attribute was found');
-  t.equal(data.attributes.NORMAL.size, 3, 'NORMAL attribute was found');
-  t.equal(data.attributes.TEXCOORD_0.value.length, 72, 'TEXCOORD_0 attribute was found');
-  t.equal(data.attributes.TEXCOORD_0.size, 2, 'TEXCOORD_0 attribute was found');
-  t.end();
+  validateMeshCategoryData(data);
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(108);
+  expect(data.attributes.POSITION.size, 'POSITION attribute was found').toBe(3);
+  expect(data.attributes.NORMAL.value.length, 'NORMAL attribute was found').toBe(108);
+  expect(data.attributes.NORMAL.size, 'NORMAL attribute was found').toBe(3);
+  expect(data.attributes.TEXCOORD_0.value.length, 'TEXCOORD_0 attribute was found').toBe(72);
+  expect(data.attributes.TEXCOORD_0.size, 'TEXCOORD_0 attribute was found').toBe(2);
 });
-
-test('OBJLoader#parseText - multi-part object', async t => {
+test('OBJLoader#parseText - multi-part object', async () => {
   const data = await load(OBJ_MULTI_PART_URL, OBJLoader);
-  validateMeshCategoryData(t, data);
-
-  t.equal(data.header?.vertexCount, 1372 * 3, 'Vertices are loaded');
-  t.end();
+  validateMeshCategoryData(data);
+  expect(data.header?.vertexCount, 'Vertices are loaded').toBe(1372 * 3);
 });
-
-test('OBJLoader#parseText - object with vertex colors', async t => {
+test('OBJLoader#parseText - object with vertex colors', async () => {
   const data = await load(OBJ_VERTEX_COLOR_URL, OBJLoader);
-  validateMeshCategoryData(t, data);
-
-  t.equal(data.attributes.POSITION.value.length, 108, 'POSITION attribute was found');
-  t.equal(data.attributes.POSITION.size, 3, 'POSITION attribute was found');
-  t.equal(data.attributes.NORMAL.value.length, 108, 'NORMAL attribute was found');
-  t.equal(data.attributes.NORMAL.size, 3, 'NORMAL attribute was found');
-  t.equal(data.attributes.COLOR_0.value.length, 108, 'COLOR_0 attribute was found');
-  t.equal(data.attributes.COLOR_0.size, 3, 'COLOR_0 attribute was found');
-
+  validateMeshCategoryData(data);
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(108);
+  expect(data.attributes.POSITION.size, 'POSITION attribute was found').toBe(3);
+  expect(data.attributes.NORMAL.value.length, 'NORMAL attribute was found').toBe(108);
+  expect(data.attributes.NORMAL.size, 'NORMAL attribute was found').toBe(3);
+  expect(data.attributes.COLOR_0.value.length, 'COLOR_0 attribute was found').toBe(108);
+  expect(data.attributes.COLOR_0.size, 'COLOR_0 attribute was found').toBe(3);
   // Test two verticies with different colors.
   const vertex1Color = [0.2801, 0.4429, 0.8987];
-  t.ok(
+  expect(
     vertex1Color.every((value, index) =>
       equals(data.attributes.COLOR_0.value[index], value, 0.0001)
     ),
     'vertex 1 color parsed as float rgb'
-  );
-
+  ).toBeTruthy();
   const vertex2Color = [0.6907, 0.2524, 0.8987];
-  t.ok(
+  expect(
     vertex2Color.every((value, index) =>
       equals(data.attributes.COLOR_0.value[index + 18], value, 0.0001)
     ),
     'vertex 2 color parsed as float rgb'
-  );
-  t.end();
+  ).toBeTruthy();
 });
-
-test('OBJWorkerLoader#parse(text)', async t => {
+test('OBJWorkerLoader#parse(text)', async () => {
   if (typeof Worker === 'undefined') {
-    t.comment('Worker is not usable in non-browser environments');
-    t.end();
+    console.log('Worker is not usable in non-browser environments');
     return;
   }
-
   const data = await load(OBJ_ASCII_URL, OBJWorkerLoader);
-
-  validateMeshCategoryData(t, data);
-
-  t.equal(data.mode, 4, 'mode is TRIANGLES (4)');
-
-  t.equal(data.attributes.POSITION.value.length, 14904 * 3, 'POSITION attribute was found');
-  t.equal(data.attributes.POSITION.size, 3, 'POSITION attribute was found');
-  t.end();
+  validateMeshCategoryData(data);
+  expect(data.mode, 'mode is TRIANGLES (4)').toBe(4);
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(14904 * 3);
+  expect(data.attributes.POSITION.size, 'POSITION attribute was found').toBe(3);
 });

--- a/modules/obj/test/obj-writer.spec.js
+++ b/modules/obj/test/obj-writer.spec.js
@@ -1,20 +1,13 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {validateWriter, validateMeshCategoryData} from 'test/common/conformance';
-
 import {OBJLoader, OBJWriter} from '@loaders.gl/obj';
 import {encode, parse} from '@loaders.gl/core';
 import {convertMeshToTable, deduceMeshSchema} from '@loaders.gl/schema-utils';
-
 const attributes = {
   POSITION: {value: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]), size: 3},
   NORMAL: {value: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]), size: 3},
   TEXCOORD_0: {value: new Float32Array([0, 0, 1, 0, 0, 1]), size: 2}
 };
-
 const mesh = {
   attributes,
   indices: {value: new Uint32Array([0, 1, 2]), size: 1},
@@ -22,25 +15,20 @@ const mesh = {
   mode: 4,
   schema: deduceMeshSchema(attributes, {topology: 'triangle-list', mode: '4'})
 };
-
-test('OBJWriter#writer conformance', t => {
-  validateWriter(t, OBJWriter, 'OBJWriter');
-  t.end();
+test('OBJWriter#writer conformance', () => {
+  validateWriter(OBJWriter, 'OBJWriter');
 });
-
-test('OBJWriter#encode plain and Arrow mesh data', async t => {
+test('OBJWriter#encode plain and Arrow mesh data', async () => {
   const arrayBuffer = await encode(mesh, OBJWriter);
   const data = await parse(arrayBuffer, OBJLoader, {core: {worker: false}});
-
-  validateMeshCategoryData(t, data);
-  t.equal(data.mode, 4, 'mode is TRIANGLES (4)');
-  t.equal(data.attributes.POSITION.value.length, 9, 'POSITION attribute roundtripped');
-
+  validateMeshCategoryData(data);
+  expect(data.mode, 'mode is TRIANGLES (4)').toBe(4);
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute roundtripped').toBe(9);
   const arrowTable = convertMeshToTable(mesh, 'arrow-table');
   const arrowArrayBuffer = await encode(arrowTable, OBJWriter);
   const arrowData = await parse(arrowArrayBuffer, OBJLoader, {core: {worker: false}});
-
-  validateMeshCategoryData(t, arrowData);
-  t.equal(arrowData.attributes.POSITION.value.length, 9, 'Arrow POSITION attribute roundtripped');
-  t.end();
+  validateMeshCategoryData(arrowData);
+  expect(arrowData.attributes.POSITION.value.length, 'Arrow POSITION attribute roundtripped').toBe(
+    9
+  );
 });

--- a/modules/pcd/test/pcd-loader.spec.ts
+++ b/modules/pcd/test/pcd-loader.spec.ts
@@ -1,23 +1,14 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-/* eslint-disable max-len */
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {validateLoader, validateMeshCategoryData} from 'test/common/conformance';
 import {validateArrowTableSchema} from '@loaders.gl/arrow';
 import {meshArrowSchema} from '@loaders.gl/schema';
-
 import {PCDLoader, PCDWorkerLoader} from '@loaders.gl/pcd';
 import {setLoaderOptions, fetchFile, parse, load, parseInBatches} from '@loaders.gl/core';
-
 const PCD_ASCII_URL = '@loaders.gl/pcd/test/data/simple-ascii.pcd';
 const PCD_BINARY_URL = '@loaders.gl/pcd/test/data/Zaghetto.pcd';
-
 setLoaderOptions({
   _workerType: 'test'
 });
-
 function createBinaryArrayBufferWithCountedField(): ArrayBuffer {
   const headerText = [
     '# .PCD v0.7 - Point Cloud Data file format',
@@ -43,7 +34,6 @@ function createBinaryArrayBufferWithCountedField(): ArrayBuffer {
     {padding: [10, 20], position: [1, 2, 3]},
     {padding: [30, 40], position: [4, 5, 6]}
   ];
-
   for (let pointIndex = 0; pointIndex < positionValues.length; pointIndex++) {
     const rowOffset = pointIndex * rowByteSize;
     const pointValues = positionValues[pointIndex];
@@ -53,88 +43,68 @@ function createBinaryArrayBufferWithCountedField(): ArrayBuffer {
     binaryDataView.setFloat32(rowOffset + 12, pointValues.position[1], littleEndian);
     binaryDataView.setFloat32(rowOffset + 16, pointValues.position[2], littleEndian);
   }
-
   const pcdArrayBuffer = new ArrayBuffer(headerBytes.length + binaryData.byteLength);
   const pcdBytes = new Uint8Array(pcdArrayBuffer);
   pcdBytes.set(headerBytes, 0);
   pcdBytes.set(new Uint8Array(binaryData), headerBytes.length);
   return pcdArrayBuffer;
 }
-
-test('PCDLoader#loader conformance', t => {
-  validateLoader(t, PCDLoader, 'PCDLoader');
-  validateLoader(t, PCDWorkerLoader, 'PCDWorkerLoader');
-  t.end();
+test('PCDLoader#loader conformance', () => {
+  validateLoader(PCDLoader, 'PCDLoader');
+  validateLoader(PCDWorkerLoader, 'PCDWorkerLoader');
 });
-
-test('PCDLoader#parse(text)', async t => {
+test('PCDLoader#parse(text)', async () => {
   const data = await parse(fetchFile(PCD_ASCII_URL), PCDLoader, {
     core: {worker: false}
   });
-  validateMeshCategoryData(t, data);
-
-  t.equal(Object.keys(data.schema.fields).length, 2, 'schema field count is correct');
-  t.equal(data.schema.metadata.mode, '0', 'schema metadata is correct');
-  t.equal(data.schema.metadata.topology, 'point-list', 'schema metadata is correct');
-  t.ok(data.schema.metadata.boundingBox, 'schema metadata is correct');
-
+  validateMeshCategoryData(data);
+  expect(Object.keys(data.schema.fields).length, 'schema field count is correct').toBe(2);
+  expect(data.schema.metadata.mode, 'schema metadata is correct').toBe('0');
+  expect(data.schema.metadata.topology, 'schema metadata is correct').toBe('point-list');
+  expect(data.schema.metadata.boundingBox, 'schema metadata is correct').toBeTruthy();
   const positionField = data.schema.fields.find(field => field.name === 'POSITION');
   // @ts-expect-error
-  t.equal(positionField?.type?.listSize, 3, 'schema size correct');
+  expect(positionField?.type?.listSize, 'schema size correct').toBe(3);
   // @ts-expect-error
-  t.equal(positionField?.type?.children[0]?.type, 'float32', 'schema type correct');
+  expect(positionField?.type?.children[0]?.type, 'schema type correct').toBe('float32');
   // t.equal(positionField.type.valueType.precision, 32, 'schema type correct');
-
   const colorField = data.schema.fields.find(field => field.name === 'COLOR_0');
   // @ts-expect-error
-  t.equal(colorField?.type?.listSize, 3, 'schema size correct');
+  expect(colorField?.type?.listSize, 'schema size correct').toBe(3);
   // @ts-expect-error
-  t.equal(colorField?.type?.children[0]?.type, 'uint8', 'schema type correct');
+  expect(colorField?.type?.children[0]?.type, 'schema type correct').toBe('uint8');
   // t.equal(colorField.type.valueType.bitWidth, 8, 'schema type correct');
   // t.equal(colorField.type.valueType.isSigned, false, 'schema type correct');
-
-  t.equal(data.mode, 0, 'mode is POINTS (0)');
-  t.notOk(data.indices, 'INDICES attribute was not found');
-
-  t.equal(data.attributes.POSITION.value.length, 639, 'POSITION attribute was found');
-  t.equal(data.attributes.COLOR_0.value.length, 639, 'COLOR attribute was found');
-
-  t.end();
+  expect(data.mode, 'mode is POINTS (0)').toBe(0);
+  expect(data.indices, 'INDICES attribute was not found').toBeFalsy();
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(639);
+  expect(data.attributes.COLOR_0.value.length, 'COLOR attribute was found').toBe(639);
 });
-
-test('PCDLoader#parse(shape: arrow-table)', async t => {
+test('PCDLoader#parse(shape: arrow-table)', async () => {
   const arrowTable = await parse(fetchFile(PCD_ASCII_URL), PCDLoader, {
     core: {worker: false},
     pcd: {shape: 'arrow-table'}
   });
-
   validateArrowTableSchema(arrowTable.data, meshArrowSchema, {
     schemaName: 'PCDLoader Mesh table'
   });
-
   const {data} = arrowTable;
-  t.equal(data.schema.fields.length, 2, 'schema field count is correct');
-  t.equal(data.schema.metadata.get('topology'), 'point-list', 'schema metadata is correct');
-  t.ok(data.schema.metadata.get('boundingBox'), 'schema metadata is correct');
-
-  t.equal(data.numRows, 639 / 3, 'table has 213 points');
-
+  expect(data.schema.fields.length, 'schema field count is correct').toBe(2);
+  expect(data.schema.metadata.get('topology'), 'schema metadata is correct').toBe('point-list');
+  expect(data.schema.metadata.get('boundingBox'), 'schema metadata is correct').toBeTruthy();
+  expect(data.numRows, 'table has 213 points').toBe(639 / 3);
   const positionField = arrowTable.schema?.fields.find(field => field.name === 'POSITION');
   // @ts-expect-error
-  t.equal(positionField?.type?.listSize, 3, 'position column size correct');
+  expect(positionField?.type?.listSize, 'position column size correct').toBe(3);
   // @ts-expect-error
-  t.equal(positionField?.type?.children[0]?.type, 'float32', 'position column type correct');
-
+  expect(positionField?.type?.children[0]?.type, 'position column type correct').toBe('float32');
   const colorField = arrowTable.schema?.fields.find(field => field.name === 'COLOR_0');
   // @ts-expect-error
-  t.equal(colorField?.type?.listSize, 3, 'color column size correct');
+  expect(colorField?.type?.listSize, 'color column size correct').toBe(3);
   // @ts-expect-error
-  t.equal(colorField?.type?.children[0]?.type, 'uint8', 'color column type correct');
-
-  t.end();
+  expect(colorField?.type?.children[0]?.type, 'color column type correct').toBe('uint8');
 });
-
-test('PCDLoader#parseInBatches(ascii, arrow-table)', async t => {
+test('PCDLoader#parseInBatches(ascii, arrow-table)', async () => {
   const response = await fetchFile(PCD_ASCII_URL);
   const batches = await parseInBatches(response, PCDLoader, {
     batchSize: 100,
@@ -142,54 +112,40 @@ test('PCDLoader#parseInBatches(ascii, arrow-table)', async t => {
     pcd: {shape: 'arrow-table'}
   });
   const batchRowCounts: number[] = [];
-
   for await (const batch of batches) {
-    t.equal(batch.shape, 'arrow-table', 'batch has arrow-table shape');
-    t.equal(batch.batchType, 'data', 'batch has data batchType');
-    t.ok(batch.data.getChild('POSITION'), 'batch includes POSITION column');
+    expect(batch.shape, 'batch has arrow-table shape').toBe('arrow-table');
+    expect(batch.batchType, 'batch has data batchType').toBe('data');
+    expect(batch.data.getChild('POSITION'), 'batch includes POSITION column').toBeTruthy();
     batchRowCounts.push(batch.length);
   }
-
-  t.deepEqual(batchRowCounts, [100, 100, 13], 'emits requested ASCII PCD Arrow batches');
-  t.end();
+  expect(batchRowCounts, 'emits requested ASCII PCD Arrow batches').toEqual([100, 100, 13]);
 });
-
-test('PCDLoader#parse(binary)', async t => {
+test('PCDLoader#parse(binary)', async () => {
   const data = await parse(fetchFile(PCD_BINARY_URL), PCDLoader, {
     core: {worker: false}
   });
-  validateMeshCategoryData(t, data);
-
-  t.equal(data.mode, 0, 'mode is POINTS (0)');
-  t.notOk(data.indices, 'indices were not preset');
-  t.notOk(data.attributes.COLOR_0, 'COLOR_0 attribute was not preset');
-  t.notOk(data.attributes.NORMAL, 'NORMAL attribute was not preset');
-  t.equal(data.attributes.POSITION.value.length, 179250, 'POSITION attribute was found');
-
-  t.end();
+  validateMeshCategoryData(data);
+  expect(data.mode, 'mode is POINTS (0)').toBe(0);
+  expect(data.indices, 'indices were not preset').toBeFalsy();
+  expect(data.attributes.COLOR_0, 'COLOR_0 attribute was not preset').toBeFalsy();
+  expect(data.attributes.NORMAL, 'NORMAL attribute was not preset').toBeFalsy();
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(179250);
 });
-
-test('PCDLoader#parse(binary with counted fields)', async t => {
+test('PCDLoader#parse(binary with counted fields)', async () => {
   const binaryArrayBuffer = createBinaryArrayBufferWithCountedField();
   const data = await parse(binaryArrayBuffer, PCDLoader, {
     core: {worker: false}
   });
-  validateMeshCategoryData(t, data);
-
-  t.equal(data.loaderData.rowSize, 20, 'row size accounts for count values');
-  t.equal(data.loaderData.offset.x, 8, 'offset for x accounts for count values');
-  t.equal(data.loaderData.offset.y, 12, 'offset for y accounts for count values');
-  t.equal(data.loaderData.offset.z, 16, 'offset for z accounts for count values');
-  t.deepEqual(
-    Array.from(data.attributes.POSITION.value),
-    [1, 2, 3, 4, 5, 6],
-    'positions read correctly'
-  );
-
-  t.end();
+  validateMeshCategoryData(data);
+  expect(data.loaderData.rowSize, 'row size accounts for count values').toBe(20);
+  expect(data.loaderData.offset.x, 'offset for x accounts for count values').toBe(8);
+  expect(data.loaderData.offset.y, 'offset for y accounts for count values').toBe(12);
+  expect(data.loaderData.offset.z, 'offset for z accounts for count values').toBe(16);
+  expect(Array.from(data.attributes.POSITION.value), 'positions read correctly').toEqual([
+    1, 2, 3, 4, 5, 6
+  ]);
 });
-
-test('PCDLoader#parseInBatches(binary with counted fields, arrow-table)', async t => {
+test('PCDLoader#parseInBatches(binary with counted fields, arrow-table)', async () => {
   const binaryArrayBuffer = createBinaryArrayBufferWithCountedField();
   const batches = await parseInBatches([binaryArrayBuffer], PCDLoader, {
     batchSize: 1,
@@ -198,34 +154,26 @@ test('PCDLoader#parseInBatches(binary with counted fields, arrow-table)', async 
   });
   const positions: number[] = [];
   const batchRowCounts: number[] = [];
-
   for await (const batch of batches) {
-    t.equal(batch.shape, 'arrow-table', 'batch has arrow-table shape');
-    t.equal(batch.batchType, 'data', 'batch has data batchType');
+    expect(batch.shape, 'batch has arrow-table shape').toBe('arrow-table');
+    expect(batch.batchType, 'batch has data batchType').toBe('data');
     batchRowCounts.push(batch.length);
     const positionColumn = batch.data.getChild('POSITION');
     positions.push(...Array.from(positionColumn.get(0)));
   }
-
-  t.deepEqual(batchRowCounts, [1, 1], 'emits requested binary PCD Arrow batches');
-  t.deepEqual(positions, [1, 2, 3, 4, 5, 6], 'positions read correctly across batches');
-  t.end();
+  expect(batchRowCounts, 'emits requested binary PCD Arrow batches').toEqual([1, 1]);
+  expect(positions, 'positions read correctly across batches').toEqual([1, 2, 3, 4, 5, 6]);
 });
-
-test('PCDWorkerLoader#parse(binary)', async t => {
+test('PCDWorkerLoader#parse(binary)', async () => {
   if (typeof Worker === 'undefined') {
-    t.comment('Worker is not usable in non-browser environments');
-    t.end();
+    console.log('Worker is not usable in non-browser environments');
     return;
   }
-
   const data = await load(PCD_BINARY_URL, PCDWorkerLoader);
-  validateMeshCategoryData(t, data);
-
-  t.equal(data.mode, 0, 'mode is POINTS (0)');
-  t.notOk(data.indices, 'indices were not preset');
-  t.notOk(data.attributes.COLOR_0, 'COLOR_0 attribute was not preset');
-  t.notOk(data.attributes.NORMAL, 'NORMAL attribute was not preset');
-  t.equal(data.attributes.POSITION.value.length, 179250, 'POSITION attribute was found');
-  t.end();
+  validateMeshCategoryData(data);
+  expect(data.mode, 'mode is POINTS (0)').toBe(0);
+  expect(data.indices, 'indices were not preset').toBeFalsy();
+  expect(data.attributes.COLOR_0, 'COLOR_0 attribute was not preset').toBeFalsy();
+  expect(data.attributes.NORMAL, 'NORMAL attribute was not preset').toBeFalsy();
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(179250);
 });

--- a/modules/pcd/test/pcd-writer.spec.ts
+++ b/modules/pcd/test/pcd-writer.spec.ts
@@ -1,44 +1,32 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {validateWriter, validateMeshCategoryData} from 'test/common/conformance';
-
 import {PCDLoader, PCDWriter} from '@loaders.gl/pcd';
 import {encode, parse} from '@loaders.gl/core';
 import {convertMeshToTable, deduceMeshSchema} from '@loaders.gl/schema-utils';
-
 const attributes = {
   POSITION: {value: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 1]), size: 3},
   NORMAL: {value: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]), size: 3}
 };
-
 const mesh = {
   attributes,
   topology: 'point-list' as const,
   mode: 0,
   schema: deduceMeshSchema(attributes, {topology: 'point-list', mode: '0'})
 };
-
-test('PCDWriter#writer conformance', t => {
-  validateWriter(t, PCDWriter, 'PCDWriter');
-  t.end();
+test('PCDWriter#writer conformance', () => {
+  validateWriter(PCDWriter, 'PCDWriter');
 });
-
-test('PCDWriter#encode plain and Arrow mesh data', async t => {
+test('PCDWriter#encode plain and Arrow mesh data', async () => {
   const arrayBuffer = await encode(mesh, PCDWriter);
   const data = await parse(arrayBuffer, PCDLoader, {core: {worker: false}});
-
-  validateMeshCategoryData(t, data);
-  t.equal(data.mode, 0, 'mode is POINTS (0)');
-  t.equal(data.attributes.POSITION.value.length, 9, 'POSITION attribute roundtripped');
-
+  validateMeshCategoryData(data);
+  expect(data.mode, 'mode is POINTS (0)').toBe(0);
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute roundtripped').toBe(9);
   const arrowTable = convertMeshToTable(mesh, 'arrow-table');
   const arrowArrayBuffer = await encode(arrowTable, PCDWriter);
   const arrowData = await parse(arrowArrayBuffer, PCDLoader, {core: {worker: false}});
-
-  validateMeshCategoryData(t, arrowData);
-  t.equal(arrowData.attributes.POSITION.value.length, 9, 'Arrow POSITION attribute roundtripped');
-  t.end();
+  validateMeshCategoryData(arrowData);
+  expect(arrowData.attributes.POSITION.value.length, 'Arrow POSITION attribute roundtripped').toBe(
+    9
+  );
 });

--- a/modules/ply/test/ply-loader.spec.js
+++ b/modules/ply/test/ply-loader.spec.js
@@ -1,14 +1,8 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-/* eslint-disable max-len */
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import * as arrow from 'apache-arrow';
 import {validateLoader, validateMeshCategoryData} from 'test/common/conformance';
 import {validateArrowTableSchema} from '@loaders.gl/arrow';
 import {indexedMeshArrowSchema} from '@loaders.gl/schema';
-
 import {PLYLoader, PLYWorkerLoader} from '@loaders.gl/ply';
 import {parsePLYToElementTables} from '../src/lib/parse-ply-arrow';
 import {
@@ -20,12 +14,10 @@ import {
   parseInBatches,
   makeIterator
 } from '@loaders.gl/core';
-
 const PLY_CUBE_ATT_URL = '@loaders.gl/ply/test/data/cube_att.ply';
 const PLY_BUN_ZIPPER_URL = '@loaders.gl/ply/test/data/bun_zipper.ply';
 const PLY_BUN_BINARY_URL = '@loaders.gl/ply/test/data/bunny.ply';
 const GAUSSIAN_SPLAT_BINARY_URL = '@loaders.gl/ply/test/data/gaussian/train-1000.ply';
-
 const GAUSSIAN_SPLAT_PLY = `ply
 format ascii 1.0
 element vertex 2
@@ -47,7 +39,6 @@ end_header
 0 0 0 0 0 0 1 0.1 0.2 0.3 1 0 0 0
 1 2 3 1 0 -1 0.5 0.4 0.5 0.6 0.707 0 0.707 0
 `;
-
 const ASCII_POINT_CLOUD_PLY = `ply
 format ascii 1.0
 element vertex 3
@@ -60,234 +51,190 @@ end_header
 1 2 3 0.5
 4 5 6 0.75
 `;
-
 setLoaderOptions({
   _workerType: 'test'
 });
-
-function validateTextPLY(t, data) {
-  t.equal(data.indices.value.length, 36, 'Indices found');
-  t.equal(data.attributes.POSITION.value.length, 72, 'POSITION attribute was found');
-  t.equal(data.attributes.NORMAL.value.length, 72, 'NORMAL attribute was found');
+function validateTextPLY(data) {
+  expect(data.indices.value.length, 'Indices found').toBe(36);
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(72);
+  expect(data.attributes.NORMAL.value.length, 'NORMAL attribute was found').toBe(72);
 }
-
-test('PLYLoader#loader conformance', t => {
-  validateLoader(t, PLYLoader, 'PLYLoader');
-  validateLoader(t, PLYWorkerLoader, 'PLYWorkerLoader');
-  t.end();
+test('PLYLoader#loader conformance', () => {
+  validateLoader(PLYLoader, 'PLYLoader');
+  validateLoader(PLYWorkerLoader, 'PLYWorkerLoader');
 });
-
-test('PLYLoader#parse(textFile)', async t => {
+test('PLYLoader#parse(textFile)', async () => {
   const data = await parse(fetchFile(PLY_CUBE_ATT_URL), PLYLoader, {});
-
-  validateMeshCategoryData(t, data);
-  validateTextPLY(t, data);
-  t.end();
+  validateMeshCategoryData(data);
+  validateTextPLY(data);
 });
-
-test('PLYLoader#parse(shape: arrow-table)', async t => {
+test('PLYLoader#parse(shape: arrow-table)', async () => {
   const table = await parse(fetchFile(PLY_CUBE_ATT_URL), PLYLoader, {
     ply: {shape: 'arrow-table'}
   });
-
-  t.equal(table.shape, 'arrow-table', 'table has arrow-table shape');
+  expect(table.shape, 'table has arrow-table shape').toBe('arrow-table');
   validateArrowTableSchema(table.data, indexedMeshArrowSchema, {
     schemaName: 'PLYLoader IndexedMesh table'
   });
-  t.deepEqual(
+  expect(
     table.data.schema.fields.map(field => field.name),
-    ['POSITION', 'indices', 'NORMAL'],
     'indexed schema fields are first'
-  );
-
+  ).toEqual(['POSITION', 'indices', 'NORMAL']);
   const indicesColumn = table.data.getChild('indices');
-  t.ok(indicesColumn, 'indices column was found');
-  t.equal(indicesColumn.get(0).length, 36, 'indices were found in row 0');
-  t.equal(indicesColumn.get(1), null, 'indices are null after row 0');
-
-  t.end();
+  expect(indicesColumn, 'indices column was found').toBeTruthy();
+  expect(indicesColumn.get(0).length, 'indices were found in row 0').toBe(36);
+  expect(indicesColumn.get(1), 'indices are null after row 0').toBe(null);
 });
-
-test('PLYLoader#parse(shape: arrow-table, pointCloud)', async t => {
+test('PLYLoader#parse(shape: arrow-table, pointCloud)', async () => {
   const table = await parse(fetchFile(PLY_CUBE_ATT_URL), PLYLoader, {
     ply: {shape: 'arrow-table', pointCloud: true}
   });
-
-  t.equal(table.shape, 'arrow-table', 'table has arrow-table shape');
-  t.equal(table.data.numRows, 24, 'table has one row per vertex');
-  t.ok(table.data.getChild('POSITION'), 'POSITION column was found');
-  t.notOk(table.data.getChild('indices'), 'indices column is skipped in pointCloud mode');
-  t.end();
+  expect(table.shape, 'table has arrow-table shape').toBe('arrow-table');
+  expect(table.data.numRows, 'table has one row per vertex').toBe(24);
+  expect(table.data.getChild('POSITION'), 'POSITION column was found').toBeTruthy();
+  expect(
+    table.data.getChild('indices'),
+    'indices column is skipped in pointCloud mode'
+  ).toBeFalsy();
 });
-
-test('PLYLoader#parse(raw element tables preserve list properties)', async t => {
+test('PLYLoader#parse(raw element tables preserve list properties)', async () => {
   const response = await fetchFile(PLY_CUBE_ATT_URL);
   const elementTables = parsePLYToElementTables(await response.text());
   const faceTable = elementTables.elements.find(
     elementTable => elementTable.element.name === 'face'
   );
-
-  t.ok(faceTable, 'face element table was found');
-  t.ok(
+  expect(faceTable, 'face element table was found').toBeTruthy();
+  expect(
     faceTable.table.getChild('vertex_indices')?.type instanceof arrow.List,
     'face indices are an Arrow list'
-  );
-  t.ok(
+  ).toBeTruthy();
+  expect(
     faceTable.table.getChild('texcoord')?.type instanceof arrow.List,
     'face texcoords are an Arrow list'
-  );
-  t.deepEqual(
+  ).toBeTruthy();
+  expect(
     Array.from(faceTable.table.getChild('vertex_indices').get(0)),
-    [9, 11, 13],
     'face vertex indices are preserved before mesh conversion'
-  );
-  t.equal(faceTable.table.getChild('texcoord').get(0).length, 6, 'face texcoord list is preserved');
-  t.end();
+  ).toEqual([9, 11, 13]);
+  expect(
+    faceTable.table.getChild('texcoord').get(0).length,
+    'face texcoord list is preserved'
+  ).toBe(6);
 });
-
-test('PLYLoader#parse(binary)', async t => {
+test('PLYLoader#parse(binary)', async () => {
   const data = await parse(fetchFile(PLY_BUN_BINARY_URL), PLYLoader);
-
-  validateMeshCategoryData(t, data);
-  t.equal(data.attributes.POSITION.value.length, 104502, 'POSITION attribute was found');
-  t.end();
+  validateMeshCategoryData(data);
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(104502);
 });
-
-test('PLYLoader#parse(ascii)', async t => {
+test('PLYLoader#parse(ascii)', async () => {
   const data = await parse(fetchFile(PLY_BUN_ZIPPER_URL), PLYLoader, {
     core: {worker: false}
   });
-
-  validateMeshCategoryData(t, data);
-  t.equal(data.attributes.POSITION.value.length, 107841, 'POSITION attribute was found');
-  t.equal(data.attributes.confidence.value.length, 35947, 'confidence attribute was found');
-  t.equal(data.attributes.intensity.value.length, 35947, 'intensity attribute was found');
-  t.end();
+  validateMeshCategoryData(data);
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(107841);
+  expect(data.attributes.confidence.value.length, 'confidence attribute was found').toBe(35947);
+  expect(data.attributes.intensity.value.length, 'intensity attribute was found').toBe(35947);
 });
-
-test('PLYLoader#parse(gaussian splat metadata)', async t => {
+test('PLYLoader#parse(gaussian splat metadata)', async () => {
   const table = parseSync(GAUSSIAN_SPLAT_PLY, PLYLoader, {
     ply: {shape: 'arrow-table'}
   });
-
-  t.equal(table.shape, 'arrow-table', 'table has arrow-table shape');
-  t.equal(table.data.numRows, 2, 'table has one row per splat');
-  t.equal(
+  expect(table.shape, 'table has arrow-table shape').toBe('arrow-table');
+  expect(table.data.numRows, 'table has one row per splat').toBe(2);
+  expect(
     table.data.schema.metadata.get('loaders_gl.semantic_type'),
-    'gaussian-splats',
     'schema identifies Gaussian splat data'
-  );
-
+  ).toBe('gaussian-splats');
   const scaleField = table.data.schema.fields.find(field => field.name === 'scale_0');
-  t.equal(
+  expect(
     scaleField?.metadata.get('loaders_gl.gaussian_splats.semantic'),
-    'scale',
     'scale field has semantic metadata'
-  );
-  t.equal(
+  ).toBe('scale');
+  expect(
     scaleField?.metadata.get('loaders_gl.gaussian_splats.encoding'),
-    'log',
     'scale field has encoding metadata'
-  );
-
+  ).toBe('log');
   const opacityField = table.data.schema.fields.find(field => field.name === 'opacity');
-  t.equal(
+  expect(
     opacityField?.metadata.get('loaders_gl.gaussian_splats.encoding'),
-    'logit',
     'opacity field has encoding metadata'
-  );
-
-  t.ok(table.data.getChild('f_dc_0'), 'f_dc_0 column was preserved');
-  t.ok(table.data.getChild('scale_0'), 'scale_0 column was preserved');
-  t.ok(table.data.getChild('rot_0'), 'rot_0 column was preserved');
-  t.end();
+  ).toBe('logit');
+  expect(table.data.getChild('f_dc_0'), 'f_dc_0 column was preserved').toBeTruthy();
+  expect(table.data.getChild('scale_0'), 'scale_0 column was preserved').toBeTruthy();
+  expect(table.data.getChild('rot_0'), 'rot_0 column was preserved').toBeTruthy();
 });
-
-test('PLYLoader#parse(gaussian splat binary fixture)', async t => {
+test('PLYLoader#parse(gaussian splat binary fixture)', async () => {
   const table = await parse(fetchFile(GAUSSIAN_SPLAT_BINARY_URL), PLYLoader, {
     ply: {shape: 'arrow-table'}
   });
-
-  t.equal(table.shape, 'arrow-table', 'table has arrow-table shape');
-  t.equal(table.data.numRows, 1000, 'table has one row per fixture splat');
-  t.equal(table.data.schema.fields.length, 58, 'schema has expected normalized PLY columns');
-  t.equal(
+  expect(table.shape, 'table has arrow-table shape').toBe('arrow-table');
+  expect(table.data.numRows, 'table has one row per fixture splat').toBe(1000);
+  expect(table.data.schema.fields.length, 'schema has expected normalized PLY columns').toBe(58);
+  expect(
     table.data.schema.metadata.get('loaders_gl.semantic_type'),
-    'gaussian-splats',
     'schema identifies Gaussian splat data'
-  );
-
+  ).toBe('gaussian-splats');
   const plyElements = JSON.parse(table.data.schema.metadata.get('ply_elements'));
-  t.equal(plyElements[0].name, 'vertex', 'schema preserves PLY vertex element metadata');
-  t.equal(plyElements[0].count, 1000, 'schema preserves truncated vertex count');
-  t.equal(plyElements[0].properties.length, 62, 'schema preserves source PLY property count');
-
+  expect(plyElements[0].name, 'schema preserves PLY vertex element metadata').toBe('vertex');
+  expect(plyElements[0].count, 'schema preserves truncated vertex count').toBe(1000);
+  expect(plyElements[0].properties.length, 'schema preserves source PLY property count').toBe(62);
   const positionField = table.data.schema.fields.find(field => field.name === 'POSITION');
-  t.ok(positionField?.type instanceof arrow.FixedSizeList, 'POSITION is a fixed size list');
-  t.equal(positionField?.type.listSize, 3, 'POSITION is a vec3');
-  t.ok(table.data.getChild('POSITION'), 'POSITION column was preserved');
-
+  expect(
+    positionField?.type instanceof arrow.FixedSizeList,
+    'POSITION is a fixed size list'
+  ).toBeTruthy();
+  expect(positionField?.type.listSize, 'POSITION is a vec3').toBe(3);
+  expect(table.data.getChild('POSITION'), 'POSITION column was preserved').toBeTruthy();
   const normalField = table.data.schema.fields.find(field => field.name === 'NORMAL');
-  t.ok(normalField?.type instanceof arrow.FixedSizeList, 'NORMAL is a fixed size list');
-  t.equal(normalField?.type.listSize, 3, 'NORMAL is a vec3');
-
+  expect(
+    normalField?.type instanceof arrow.FixedSizeList,
+    'NORMAL is a fixed size list'
+  ).toBeTruthy();
+  expect(normalField?.type.listSize, 'NORMAL is a vec3').toBe(3);
   const scaleField = table.data.schema.fields.find(field => field.name === 'scale_0');
-  t.equal(
+  expect(
     scaleField?.metadata.get('loaders_gl.gaussian_splats.semantic'),
-    'scale',
     'scale field has semantic metadata'
-  );
-  t.equal(
+  ).toBe('scale');
+  expect(
     scaleField?.metadata.get('loaders_gl.gaussian_splats.encoding'),
-    'log',
     'scale field has encoding metadata'
-  );
-
+  ).toBe('log');
   const opacityField = table.data.schema.fields.find(field => field.name === 'opacity');
-  t.equal(
+  expect(
     opacityField?.metadata.get('loaders_gl.gaussian_splats.encoding'),
-    'logit',
     'opacity field has encoding metadata'
-  );
-
+  ).toBe('logit');
   const sphericalHarmonicField = table.data.schema.fields.find(field => field.name === 'f_rest_44');
-  t.equal(
+  expect(
     sphericalHarmonicField?.metadata.get('loaders_gl.gaussian_splats.semantic'),
-    'spherical_harmonic_rest',
     'SH rest field has semantic metadata'
-  );
-  t.ok(table.data.getChild('f_rest_44'), 'last SH rest coefficient was preserved');
-  t.ok(table.data.getChild('scale_0'), 'scale_0 column was preserved');
-  t.ok(table.data.getChild('rot_3'), 'rot_3 column was preserved');
-  t.end();
+  ).toBe('spherical_harmonic_rest');
+  expect(table.data.getChild('f_rest_44'), 'last SH rest coefficient was preserved').toBeTruthy();
+  expect(table.data.getChild('scale_0'), 'scale_0 column was preserved').toBeTruthy();
+  expect(table.data.getChild('rot_3'), 'rot_3 column was preserved').toBeTruthy();
 });
-
-test('PLYLoader#parseInBatches(gaussian splat binary fixture, arrow-table)', async t => {
+test('PLYLoader#parseInBatches(gaussian splat binary fixture, arrow-table)', async () => {
   const response = await fetchFile(GAUSSIAN_SPLAT_BINARY_URL);
   const batches = await parseInBatches(makeIterator(response), PLYLoader, {
     batchSize: 400,
     ply: {shape: 'arrow-table'}
   });
   const batchRowCounts = [];
-
   for await (const table of batches) {
-    t.equal(table.shape, 'arrow-table', 'batch has arrow-table shape');
-    t.equal(table.batchType, 'data', 'batch has data batchType');
-    t.equal(
+    expect(table.shape, 'batch has arrow-table shape').toBe('arrow-table');
+    expect(table.batchType, 'batch has data batchType').toBe('data');
+    expect(
       table.data.schema.metadata.get('loaders_gl.semantic_type'),
-      'gaussian-splats',
       'batch schema identifies Gaussian splat data'
-    );
-    t.ok(table.data.getChild('POSITION'), 'batch includes POSITION column');
-    t.ok(table.data.getChild('scale_0'), 'batch includes scale_0 column');
+    ).toBe('gaussian-splats');
+    expect(table.data.getChild('POSITION'), 'batch includes POSITION column').toBeTruthy();
+    expect(table.data.getChild('scale_0'), 'batch includes scale_0 column').toBeTruthy();
     batchRowCounts.push(table.data.numRows);
   }
-
-  t.deepEqual(batchRowCounts, [400, 400, 200], 'binary PLY emits requested Arrow batches');
-  t.end();
+  expect(batchRowCounts, 'binary PLY emits requested Arrow batches').toEqual([400, 400, 200]);
 });
-
-test('PLYLoader#parseInBatches(gaussian splat binary fixture, arrow-table, chunk boundaries)', async t => {
+test('PLYLoader#parseInBatches(gaussian splat binary fixture, arrow-table, chunk boundaries)', async () => {
   const response = await fetchFile(GAUSSIAN_SPLAT_BINARY_URL);
   const arrayBuffer = await response.arrayBuffer();
   const batches = await parseInBatches(makeChunkIterator(arrayBuffer, 777), PLYLoader, {
@@ -295,36 +242,28 @@ test('PLYLoader#parseInBatches(gaussian splat binary fixture, arrow-table, chunk
     ply: {shape: 'arrow-table'}
   });
   const batchRowCounts = [];
-
   for await (const table of batches) {
-    t.equal(table.batchType, 'data', 'batch has data batchType');
+    expect(table.batchType, 'batch has data batchType').toBe('data');
     batchRowCounts.push(table.data.numRows);
   }
-
-  t.deepEqual(batchRowCounts, [333, 333, 333, 1], 'batches span input chunk boundaries');
-  t.end();
+  expect(batchRowCounts, 'batches span input chunk boundaries').toEqual([333, 333, 333, 1]);
 });
-
-test('PLYLoader#parseInBatches(ascii point cloud, arrow-table)', async t => {
+test('PLYLoader#parseInBatches(ascii point cloud, arrow-table)', async () => {
   const batches = await parseInBatches(makeTextIterator(ASCII_POINT_CLOUD_PLY), PLYLoader, {
     batchSize: 2,
     ply: {shape: 'arrow-table'}
   });
   const batchRowCounts = [];
-
   for await (const table of batches) {
-    t.equal(table.shape, 'arrow-table', 'batch has arrow-table shape');
-    t.equal(table.batchType, 'data', 'batch has data batchType');
-    t.ok(table.data.getChild('POSITION'), 'batch includes POSITION column');
-    t.ok(table.data.getChild('intensity'), 'batch includes custom scalar column');
+    expect(table.shape, 'batch has arrow-table shape').toBe('arrow-table');
+    expect(table.batchType, 'batch has data batchType').toBe('data');
+    expect(table.data.getChild('POSITION'), 'batch includes POSITION column').toBeTruthy();
+    expect(table.data.getChild('intensity'), 'batch includes custom scalar column').toBeTruthy();
     batchRowCounts.push(table.data.numRows);
   }
-
-  t.deepEqual(batchRowCounts, [2, 1], 'ASCII point cloud emits requested Arrow batches');
-  t.end();
+  expect(batchRowCounts, 'ASCII point cloud emits requested Arrow batches').toEqual([2, 1]);
 });
-
-test('PLYLoader#parseInBatches(mesh PLY, arrow-table, pointCloud)', async t => {
+test('PLYLoader#parseInBatches(mesh PLY, arrow-table, pointCloud)', async () => {
   const response = await fetchFile(PLY_CUBE_ATT_URL);
   const sourceText = await response.text();
   const batches = await parseInBatches(makeTextIterator(sourceText), PLYLoader, {
@@ -332,102 +271,83 @@ test('PLYLoader#parseInBatches(mesh PLY, arrow-table, pointCloud)', async t => {
     ply: {shape: 'arrow-table', pointCloud: true}
   });
   const batchRowCounts = [];
-
   for await (const table of batches) {
-    t.equal(table.shape, 'arrow-table', 'batch has arrow-table shape');
-    t.equal(table.batchType, 'data', 'batch has data batchType');
-    t.ok(table.data.getChild('POSITION'), 'batch includes POSITION column');
-    t.notOk(table.data.getChild('indices'), 'batch skips mesh indices');
+    expect(table.shape, 'batch has arrow-table shape').toBe('arrow-table');
+    expect(table.batchType, 'batch has data batchType').toBe('data');
+    expect(table.data.getChild('POSITION'), 'batch includes POSITION column').toBeTruthy();
+    expect(table.data.getChild('indices'), 'batch skips mesh indices').toBeFalsy();
     batchRowCounts.push(table.data.numRows);
   }
-
-  t.deepEqual(batchRowCounts, [10, 10, 4], 'pointCloud mode streams only vertex rows');
-  t.end();
+  expect(batchRowCounts, 'pointCloud mode streams only vertex rows').toEqual([10, 10, 4]);
 });
-
-test('PLYLoader#parseInBatches(mesh PLY, arrow-table)', async t => {
+test('PLYLoader#parseInBatches(mesh PLY, arrow-table)', async () => {
   const response = await fetchFile(PLY_CUBE_ATT_URL);
   const sourceText = await response.text();
   const batches = await parseInBatches(makeTextIterator(sourceText), PLYLoader, {
     batchSize: 10,
     ply: {shape: 'arrow-table'}
   });
-
   try {
     for await (const table of batches) {
-      t.fail(`unexpected batch with ${table.data.numRows} rows`);
+      (() => {
+        throw new Error(`unexpected batch with ${table.data.numRows} rows`);
+      })();
     }
-    t.fail('mesh PLY should not stream as Arrow table without pointCloud mode');
+    (() => {
+      throw new Error('mesh PLY should not stream as Arrow table without pointCloud mode');
+    })();
   } catch (error) {
-    t.match(
-      String(error),
-      /PLY arrow-table batch parsing requires one vertex element/,
-      'mesh PLY requires pointCloud mode for Arrow table streaming'
+    expect(String(error), 'mesh PLY requires pointCloud mode for Arrow table streaming').toMatch(
+      /PLY arrow-table batch parsing requires one vertex element/
     );
   }
-  t.end();
 });
-
-test('PLYLoader#parseInBatches(binary vertex list properties, arrow-table)', async t => {
+test('PLYLoader#parseInBatches(binary vertex list properties, arrow-table)', async () => {
   const arrayBuffer = makeBinaryVertexListPLY();
   const elementTables = parsePLYToElementTables(arrayBuffer);
   const vertexTable = elementTables.elements[0].table;
-
-  t.ok(
+  expect(
     vertexTable.getChild('neighbors')?.type instanceof arrow.List,
     'raw vertex list property is an Arrow list'
-  );
-  t.deepEqual(
+  ).toBeTruthy();
+  expect(
     Array.from(vertexTable.getChild('neighbors').get(1)),
-    [0, 2],
     'binary list values are preserved'
-  );
-
+  ).toEqual([0, 2]);
   const batches = await parseInBatches(makeChunkIterator(arrayBuffer, 11), PLYLoader, {
     batchSize: 2,
     ply: {shape: 'arrow-table'}
   });
   const batchRowCounts = [];
-
   for await (const table of batches) {
     batchRowCounts.push(table.data.numRows);
   }
-
-  t.deepEqual(batchRowCounts, [2, 1], 'binary variable-width vertex PLY emits Arrow batches');
-  t.end();
+  expect(batchRowCounts, 'binary variable-width vertex PLY emits Arrow batches').toEqual([2, 1]);
 });
-
-test('PLYLoader#parse(arrow-first mesh parity with legacy parser)', async t => {
+test('PLYLoader#parse(arrow-first mesh parity with legacy parser)', async () => {
   const response = await fetchFile(PLY_CUBE_ATT_URL);
   const arrayBuffer = await response.arrayBuffer();
   const arrowFirstMesh = parseSync(arrayBuffer, PLYLoader);
   const legacyMesh = parseSync(arrayBuffer, PLYLoader, {
     ply: {_useLegacyParser: true}
   });
-
-  t.deepEqual(
+  expect(
     Array.from(arrowFirstMesh.attributes.POSITION.value),
-    Array.from(legacyMesh.attributes.POSITION.value),
     'arrow-first mesh preserves positions'
-  );
-  t.deepEqual(
+  ).toEqual(Array.from(legacyMesh.attributes.POSITION.value));
+  expect(
     Array.from(arrowFirstMesh.indices.value),
-    Array.from(legacyMesh.indices.value),
     'arrow-first mesh preserves triangulated indices'
-  );
-  t.end();
+  ).toEqual(Array.from(legacyMesh.indices.value));
 });
-
 function* makeChunkIterator(arrayBuffer, chunkSize) {
   for (let byteOffset = 0; byteOffset < arrayBuffer.byteLength; byteOffset += chunkSize) {
     yield arrayBuffer.slice(byteOffset, byteOffset + chunkSize);
   }
 }
-
 function* makeTextIterator(text) {
   yield new TextEncoder().encode(text).buffer;
 }
-
 function makeBinaryVertexListPLY() {
   const header = [
     'ply',
@@ -454,7 +374,6 @@ function makeBinaryVertexListPLY() {
   bytes.set(headerBytes, 0);
   const dataView = new DataView(bytes.buffer);
   let byteOffset = headerBytes.length;
-
   for (const row of rows) {
     for (const coordinate of row.position) {
       dataView.setFloat32(byteOffset, coordinate, true);
@@ -467,46 +386,34 @@ function makeBinaryVertexListPLY() {
       byteOffset += 4;
     }
   }
-
   return bytes.buffer;
 }
-
-test('PLYLoader#parseSync(binary)', async t => {
+test('PLYLoader#parseSync(binary)', async () => {
   const arrayBuffer = await fetchFile(PLY_BUN_ZIPPER_URL).then(res => res.arrayBuffer());
   const data = parseSync(arrayBuffer, PLYLoader);
-
-  validateMeshCategoryData(t, data);
-  t.equal(data.attributes.POSITION.value.length, 107841, 'POSITION attribute was found');
-  t.equal(data.attributes.confidence.value.length, 35947, 'confidence attribute was found');
-  t.equal(data.attributes.intensity.value.length, 35947, 'intensity attribute was found');
-  t.end();
+  validateMeshCategoryData(data);
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(107841);
+  expect(data.attributes.confidence.value.length, 'confidence attribute was found').toBe(35947);
+  expect(data.attributes.intensity.value.length, 'intensity attribute was found').toBe(35947);
 });
-
-test('PLYLoader#parse(WORKER)', async t => {
+test('PLYLoader#parse(WORKER)', async () => {
   if (typeof Worker === 'undefined') {
-    t.comment('Worker is not usable in non-browser environments');
-    t.end();
+    console.log('Worker is not usable in non-browser environments');
     return;
   }
-
   const data = await load(PLY_BUN_ZIPPER_URL, PLYWorkerLoader);
-
-  validateMeshCategoryData(t, data);
-  t.equal(data.attributes.POSITION.value.length, 107841, 'POSITION attribute was found');
-  t.end();
+  validateMeshCategoryData(data);
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(107841);
 });
-
 // TODO - Update to use parseInBatches
-test('PLYLoader#parseInBatches(text)', async t => {
+test('PLYLoader#parseInBatches(text)', async () => {
   const response = await fetchFile(PLY_CUBE_ATT_URL);
   const batches = await parseInBatches(makeIterator(response), PLYLoader);
-
   for await (const data of batches) {
-    validateMeshCategoryData(t, data);
-    t.equal(data.indices.value.length, 36, 'Indices found');
-    t.equal(data.attributes.POSITION.value.length, 72, 'POSITION attribute was found');
-    t.equal(data.attributes.NORMAL.value.length, 72, 'NORMAL attribute was found');
-    t.end();
+    validateMeshCategoryData(data);
+    expect(data.indices.value.length, 'Indices found').toBe(36);
+    expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(72);
+    expect(data.attributes.NORMAL.value.length, 'NORMAL attribute was found').toBe(72);
     return;
   }
 });

--- a/modules/ply/test/ply-writer.spec.js
+++ b/modules/ply/test/ply-writer.spec.js
@@ -1,21 +1,14 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {validateWriter, validateMeshCategoryData} from 'test/common/conformance';
-
 import {PLYLoader, PLYWriter} from '@loaders.gl/ply';
 import {encode, parse} from '@loaders.gl/core';
 import {convertMeshToTable, deduceMeshSchema} from '@loaders.gl/schema-utils';
-
 const attributes = {
   POSITION: {value: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]), size: 3},
   NORMAL: {value: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]), size: 3},
   TEXCOORD_0: {value: new Float32Array([0, 0, 1, 0, 0, 1]), size: 2},
   COLOR_0: {value: new Uint8Array([255, 0, 0, 0, 255, 0, 0, 0, 255]), size: 3, normalized: true}
 };
-
 const mesh = {
   attributes,
   indices: {value: new Uint32Array([0, 1, 2]), size: 1},
@@ -23,26 +16,21 @@ const mesh = {
   mode: 4,
   schema: deduceMeshSchema(attributes, {topology: 'triangle-list', mode: '4'})
 };
-
-test('PLYWriter#writer conformance', t => {
-  validateWriter(t, PLYWriter, 'PLYWriter');
-  t.end();
+test('PLYWriter#writer conformance', () => {
+  validateWriter(PLYWriter, 'PLYWriter');
 });
-
-test('PLYWriter#encode plain and Arrow mesh data', async t => {
+test('PLYWriter#encode plain and Arrow mesh data', async () => {
   const arrayBuffer = await encode(mesh, PLYWriter);
   const data = await parse(arrayBuffer, PLYLoader, {core: {worker: false}});
-
-  validateMeshCategoryData(t, data);
-  t.equal(data.mode, 4, 'mode is TRIANGLES (4)');
-  t.equal(data.attributes.POSITION.value.length, 9, 'POSITION attribute roundtripped');
-  t.equal(data.indices.value.length, 3, 'indices roundtripped');
-
+  validateMeshCategoryData(data);
+  expect(data.mode, 'mode is TRIANGLES (4)').toBe(4);
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute roundtripped').toBe(9);
+  expect(data.indices.value.length, 'indices roundtripped').toBe(3);
   const arrowTable = convertMeshToTable(mesh, 'arrow-table');
   const arrowArrayBuffer = await encode(arrowTable, PLYWriter);
   const arrowData = await parse(arrowArrayBuffer, PLYLoader, {core: {worker: false}});
-
-  validateMeshCategoryData(t, arrowData);
-  t.equal(arrowData.attributes.POSITION.value.length, 9, 'Arrow POSITION attribute roundtripped');
-  t.end();
+  validateMeshCategoryData(arrowData);
+  expect(arrowData.attributes.POSITION.value.length, 'Arrow POSITION attribute roundtripped').toBe(
+    9
+  );
 });

--- a/modules/pmtiles/test/pmtiles-loader.spec.ts
+++ b/modules/pmtiles/test/pmtiles-loader.spec.ts
@@ -1,17 +1,10 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {isBrowser, load} from '@loaders.gl/core';
-
 import {PMTILESETS_VECTOR} from './data/tilesets';
 import {_PMTilesLoader as PMTilesLoader} from '@loaders.gl/pmtiles';
-
-test('PMTilesLoader#schemas', async t => {
+test('PMTilesLoader#schemas', async () => {
   if (!isBrowser) {
-    t.comment('PMTilesSourceLoader currently only supported in browser');
-    t.end();
+    console.log('PMTilesSourceLoader currently only supported in browser');
     return;
   }
   for (const tilesetUrl of PMTILESETS_VECTOR) {
@@ -20,7 +13,6 @@ test('PMTilesLoader#schemas', async t => {
     for (const layer of source.layers) {
       fields.push(...layer.schema.fields);
     }
-    t.equal(fields.length, 66);
+    expect(fields.length).toBe(66);
   }
-  t.end();
 });

--- a/modules/pmtiles/test/pmtiles-source.spec.ts
+++ b/modules/pmtiles/test/pmtiles-source.spec.ts
@@ -1,242 +1,30 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {isBrowser, fetchFile} from '@loaders.gl/core';
-
 import {PMTILESETS} from './data/tilesets';
 import {PMTilesSourceLoader} from '@loaders.gl/pmtiles';
-
-test('PMTilesSourceLoader#urls', async t => {
+test('PMTilesSourceLoader#urls', async () => {
   if (!isBrowser) {
-    t.comment('PMTilesSourceLoader currently only supported in browser');
-    t.end();
+    console.log('PMTilesSourceLoader currently only supported in browser');
     return;
   }
   for (const tilesetUrl of PMTILESETS) {
     const source = PMTilesSourceLoader.createDataSource(tilesetUrl, {url: tilesetUrl});
-    t.ok(source);
+    expect(source).toBeTruthy();
     const metadata = await source.getMetadata();
-    t.ok(metadata);
-    // console.error(JSON.stringify(metadata.tileJSON, null, 2));
+    expect(metadata).toBeTruthy();
   }
-  t.end();
 });
-
-test('PMTilesSourceLoader#Blobs', async t => {
+test('PMTilesSourceLoader#Blobs', async () => {
   if (!isBrowser) {
-    t.comment('PMTilesSourceLoader currently only supported in browser');
-    t.end();
+    console.log('PMTilesSourceLoader currently only supported in browser');
     return;
   }
   for (const tilesetUrl of PMTILESETS) {
     const response = await fetchFile(tilesetUrl);
     const blob = await response.blob();
     const source = PMTilesSourceLoader.createDataSource(blob, {url: blob});
-    t.ok(source);
+    expect(source).toBeTruthy();
     const metadata = await source.getMetadata();
-    t.ok(metadata);
-    // console.error(JSON.stringify(metadata.tileJSON, null, 2));
-  }
-  t.end();
-});
-
-// TBA - TILE LOADING TESTS
-
-/*
-import test from 'test/utils/vitest-tape';
-import {validateLoader} from 'test/common/conformance';
-
-import {load} from '@loaders.gl/core';
-import {PMTilesLoader} from '@loaders.gl/pmtiles';
-
-import {PMTILESETS} from './data/tilesets';
-
-test('PMTilesLoader#loader conformance', (t) => {
-  validateLoader(t, PMTilesLoader, 'PMTilesLoader');
-  t.end();
-});
-
-test.skip('PMTilesLoader#load', async (t) => {
-  for (const tilesetUrl of PMTILESETS) {
-    const metadata = await load(tilesetUrl, PMTilesLoader);
-    t.ok(metadata);
-  }
-  t.end();
-});
-
-/*
-// echo '{"type":"Polygon","coordinates":[[[0,0],[0,1],[1,1],[1,0],[0,0]]]}' | ./tippecanoe -zg -o test_fixture_1.pmtiles
-test('cache getHeader', async (t) => {
-  const source = new TestFileSource('@loaders.gl/pmtiles/test/data/test_fixture_1.pmtiles', '1');
-  const cache = new SharedPromiseCache();
-  const header = await cache.getHeader(source);
-  t.strictEqual(header.rootDirectoryOffset, 127);
-  t.strictEqual(header.rootDirectoryLength, 25);
-  t.strictEqual(header.jsonMetadataOffset, 152);
-  t.strictEqual(header.jsonMetadataLength, 247);
-  t.strictEqual(header.leafDirectoryOffset, 0);
-  t.strictEqual(header.leafDirectoryLength, 0);
-  t.strictEqual(header.tileDataOffset, 399);
-  t.strictEqual(header.tileDataLength, 69);
-  t.strictEqual(header.numAddressedTiles, 1);
-  t.strictEqual(header.numTileEntries, 1);
-  t.strictEqual(header.numTileContents, 1);
-  t.strictEqual(header.clustered, false);
-  t.strictEqual(header.internalCompression, 2);
-  t.strictEqual(header.tileCompression, 2);
-  t.strictEqual(header.tileType, 1);
-  t.strictEqual(header.minZoom, 0);
-  t.strictEqual(header.maxZoom, 0);
-  t.strictEqual(header.minLon, 0);
-  t.strictEqual(header.minLat, 0);
-  // t.strictEqual(header.maxLon,1); // TODO fix me
-  t.strictEqual(header.maxLat, 1);
-});
-
-test('cache check against empty', async (t) => {
-  const source = new TestFileSource('@loaders.gl/pmtiles/test/data/empty.pmtiles', '1');
-  const cache = new SharedPromiseCache();
-  t.rejects(async () => {
-    await cache.getHeader(source);
-  });
-});
-
-test('cache check magic number', async (t) => {
-  const source = new TestFileSource('@loaders.gl/pmtiles/test/data/invalid.pmtiles', '1');
-  const cache = new SharedPromiseCache();
-  t.rejects(async () => {
-    await cache.getHeader(source);
-  });
-});
-
-test('cache check future spec version', async (t) => {
-  const source = new TestFileSource('@loaders.gl/pmtiles/test/data/invalid_v4.pmtiles', '1');
-  const cache = new SharedPromiseCache();
-  t.rejects(async () => {
-    await cache.getHeader(source);
-  });
-});
-
-test('cache getDirectory', async (t) => {
-  const source = new TestFileSource('@loaders.gl/pmtiles/test/data/test_fixture_1.pmtiles', '1');
-
-  let cache = new SharedPromiseCache(6400, false);
-  let header = await cache.getHeader(source);
-  t.strictEqual(cache.cache.size, 1);
-
-  cache = new SharedPromiseCache(6400, true);
-  header = await cache.getHeader(source);
-
-  // prepopulates the root directory
-  t.strictEqual(cache.cache.size, 2);
-
-  const directory = await cache.getDirectory(
-    source,
-    header.rootDirectoryOffset,
-    header.rootDirectoryLength,
-    header
-  );
-  t.strictEqual(directory.length, 1);
-  t.strictEqual(directory[0].tileId, 0);
-  t.strictEqual(directory[0].offset, 0);
-  t.strictEqual(directory[0].length, 69);
-  t.strictEqual(directory[0].runLength, 1);
-
-  for (const v of cache.cache.values()) {
-    t.ok(v.lastUsed > 0);
+    expect(metadata).toBeTruthy();
   }
 });
-
-test('multiple sources in a single cache', async (t) => {
-  const cache = new SharedPromiseCache();
-  const source1 = new TestFileSource('@loaders.gl/pmtiles/test/data/test_fixture_1.pmtiles', '1');
-  const source2 = new TestFileSource('@loaders.gl/pmtiles/test/data/test_fixture_1.pmtiles', '2');
-  await cache.getHeader(source1);
-  t.strictEqual(cache.cache.size, 2);
-  await cache.getHeader(source2);
-  t.strictEqual(cache.cache.size, 4);
-});
-
-test('etags are part of key', async (t) => {
-  const cache = new SharedPromiseCache(6400, false);
-  const source = new TestFileSource('@loaders.gl/pmtiles/test/data/test_fixture_1.pmtiles', '1');
-  source.etag = 'etag_1';
-  let header = await cache.getHeader(source);
-  t.strictEqual(header.etag, 'etag_1');
-
-  source.etag = 'etag_2';
-
-  t.rejects(async () => {
-    await cache.getDirectory(
-      source,
-      header.rootDirectoryOffset,
-      header.rootDirectoryLength,
-      header
-    );
-  });
-
-  cache.invalidate(source, 'etag_2');
-  header = await cache.getHeader(source);
-  t.ok(
-    await cache.getDirectory(source, header.rootDirectoryOffset, header.rootDirectoryLength, header)
-  );
-});
-
-test.skip('soft failure on etag weirdness', async (t) => {
-  const cache = new SharedPromiseCache(6400, false);
-  const source = new TestFileSource('@loaders.gl/pmtiles/test/data/test_fixture_1.pmtiles', '1');
-  source.etag = 'etag_1';
-  let header = await cache.getHeader(source);
-  t.strictEqual(header.etag, 'etag_1');
-
-  source.etag = 'etag_2';
-
-  t.rejects(async () => {
-    await cache.getDirectory(
-      source,
-      header.rootDirectoryOffset,
-      header.rootDirectoryLength,
-      header
-    );
-  });
-
-  source.etag = 'etag_1';
-  cache.invalidate(source, 'etag_2');
-
-  header = await cache.getHeader(source);
-  t.strictEqual(header.etag, undefined);
-});
-
-test('cache pruning by byte size', async (t) => {
-  const cache = new SharedPromiseCache(2, false);
-  cache.cache.set('0', {lastUsed: 0, data: Promise.resolve([])});
-  cache.cache.set('1', {lastUsed: 1, data: Promise.resolve([])});
-  cache.cache.set('2', {lastUsed: 2, data: Promise.resolve([])});
-  cache.prune();
-  t.strictEqual(cache.cache.size, 2);
-  t.ok(cache.cache.get('2'));
-  t.ok(cache.cache.get('1'));
-  t.ok(!cache.cache.get('0'));
-});
-
-test('pmtiles get metadata', async (t) => {
-  const source = new TestFileSource('@loaders.gl/pmtiles/test/data/test_fixture_1.pmtiles', '1');
-  const p = new PMTiles(source);
-  const metadata = await p.getMetadata();
-  t.ok(metadata.name);
-});
-
-// echo '{"type":"Polygon","coordinates":[[[0,0],[0,1],[1,0],[0,0]]]}' | ./tippecanoe -zg -o test_fixture_2.pmtiles
-test('pmtiles handle retries', async (t) => {
-  const source = new TestFileSource('@loaders.gl/pmtiles/test/data/test_fixture_1.pmtiles', '1');
-  source.etag = '1';
-  const p = new PMTiles(source);
-  const metadata = await p.getMetadata();
-  t.ok(metadata.name);
-  source.etag = '2';
-  source.replaceData('@loaders.gl/pmtiles/test/data/test_fixture_2.pmtiles');
-  t.ok(await p.getZxy(0, 0, 0));
-});
-*/

--- a/modules/potree/test/potree-bin-loader.spec.ts
+++ b/modules/potree/test/potree-bin-loader.spec.ts
@@ -1,14 +1,9 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {parse} from '@loaders.gl/core';
 import {validateArrowTableSchema} from '@loaders.gl/arrow';
 import {meshArrowSchema} from '@loaders.gl/schema';
 import {PotreeBinLoader} from '@loaders.gl/potree';
-
-test('PotreeBinLoader#parse(shape: arrow-table)', async t => {
+test('PotreeBinLoader#parse(shape: arrow-table)', async () => {
   const arrayBuffer = makePotreeBinTile();
   const table = await parse(arrayBuffer, PotreeBinLoader, {
     potree: {
@@ -22,30 +17,23 @@ test('PotreeBinLoader#parse(shape: arrow-table)', async t => {
       ]
     }
   });
-
-  t.equal(table.shape, 'arrow-table', 'table has arrow-table shape');
+  expect(table.shape, 'table has arrow-table shape').toBe('arrow-table');
   validateArrowTableSchema(table.data, meshArrowSchema, {
     schemaName: 'PotreeBinLoader Mesh table'
   });
-  t.equal(table.data.numRows, 2, 'table has point rows');
-  t.ok(table.data.getChild('POSITION'), 'table includes POSITION column');
-  t.ok(table.data.getChild('COLOR_0'), 'table includes COLOR_0 column');
-
-  t.end();
+  expect(table.data.numRows, 'table has point rows').toBe(2);
+  expect(table.data.getChild('POSITION'), 'table includes POSITION column').toBeTruthy();
+  expect(table.data.getChild('COLOR_0'), 'table includes COLOR_0 column').toBeTruthy();
 });
-
 function makePotreeBinTile(): ArrayBuffer {
   const pointByteSize = 15;
   const arrayBuffer = new ArrayBuffer(pointByteSize * 2);
   const dataView = new DataView(arrayBuffer);
   const bytes = new Uint8Array(arrayBuffer);
-
   writePoint(dataView, bytes, 0, [1, 2, 3], [10, 20, 30]);
   writePoint(dataView, bytes, pointByteSize, [4, 5, 6], [40, 50, 60]);
-
   return arrayBuffer;
 }
-
 function writePoint(
   dataView: DataView,
   bytes: Uint8Array,

--- a/modules/potree/test/potree-hierarchy-chunk-loader.spec.ts
+++ b/modules/potree/test/potree-hierarchy-chunk-loader.spec.ts
@@ -1,29 +1,21 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {fetchFile, parse} from '@loaders.gl/core';
 import type {CoreAPI} from '@loaders.gl/loader-utils';
 import {PotreeHierarchyChunkLoader} from '@loaders.gl/potree';
 import {PotreeNodesSource} from '../src/lib/potree-node-source';
 import {buildPotreeHierarchyFromMetadata} from '../src/parsers/parse-potree-hierarchy-chunk';
-
 const POTREE_HIERARCHY_CHUNK_URL = '@loaders.gl/potree/test/data/lion_takanawa/data/r/r.hrc';
-
-test('PotreeHierarchyChunkLoader#parse', async t => {
+test('PotreeHierarchyChunkLoader#parse', async () => {
   const response = await fetchFile(POTREE_HIERARCHY_CHUNK_URL);
   const rootNode = await parse(response, PotreeHierarchyChunkLoader);
-  t.equal(countTreeNodes(rootNode), 167);
-  t.equal(rootNode.name, '', 'rootNode.name');
-  t.equal(rootNode.pointCount, 3751, 'rootNode.pointCount');
-  t.equal(rootNode.header.childCount, 6, 'rootNode.childCount');
-  t.equal(rootNode.children.length, 6, 'rootNode.children');
-  t.equal(rootNode.childrenByIndex.length, 8, 'rootNode.childrenByIndex');
-  t.end();
+  expect(countTreeNodes(rootNode)).toBe(167);
+  expect(rootNode.name, 'rootNode.name').toBe('');
+  expect(rootNode.pointCount, 'rootNode.pointCount').toBe(3751);
+  expect(rootNode.header.childCount, 'rootNode.childCount').toBe(6);
+  expect(rootNode.children.length, 'rootNode.children').toBe(6);
+  expect(rootNode.childrenByIndex.length, 'rootNode.childrenByIndex').toBe(8);
 });
-
-test('buildPotreeHierarchyFromMetadata', t => {
+test('buildPotreeHierarchyFromMetadata', () => {
   const rootNode = buildPotreeHierarchyFromMetadata(
     [
       ['r', 10],
@@ -34,21 +26,18 @@ test('buildPotreeHierarchyFromMetadata', t => {
     ],
     {spacing: 8}
   );
-
-  t.equal(countTreeNodes(rootNode), 5);
-  t.equal(rootNode.name, '', 'rootNode.name');
-  t.equal(rootNode.pointCount, 10, 'rootNode.pointCount');
-  t.equal(rootNode.header.childCount, 2, 'rootNode.childCount');
-  t.equal(rootNode.header.childMask, 0b00001001, 'rootNode.childMask');
-  t.equal(rootNode.childrenByIndex[0].name, '0', 'root child 0');
-  t.equal(rootNode.childrenByIndex[3].name, '3', 'root child 3');
-  t.equal(rootNode.childrenByIndex[3].childrenByIndex[6].name, '36', 'nested child');
-  t.equal(rootNode.childrenByIndex[3].spacing, 4, 'child spacing');
-  t.equal(rootNode.childrenByIndex[3].childrenByIndex[6].spacing, 2, 'nested child spacing');
-  t.end();
+  expect(countTreeNodes(rootNode)).toBe(5);
+  expect(rootNode.name, 'rootNode.name').toBe('');
+  expect(rootNode.pointCount, 'rootNode.pointCount').toBe(10);
+  expect(rootNode.header.childCount, 'rootNode.childCount').toBe(2);
+  expect(rootNode.header.childMask, 'rootNode.childMask').toBe(0b00001001);
+  expect(rootNode.childrenByIndex[0].name, 'root child 0').toBe('0');
+  expect(rootNode.childrenByIndex[3].name, 'root child 3').toBe('3');
+  expect(rootNode.childrenByIndex[3].childrenByIndex[6].name, 'nested child').toBe('36');
+  expect(rootNode.childrenByIndex[3].spacing, 'child spacing').toBe(4);
+  expect(rootNode.childrenByIndex[3].childrenByIndex[6].spacing, 'nested child spacing').toBe(2);
 });
-
-test('PotreeNodesSource#initialize preserves direct cloud.js URL', async t => {
+test('PotreeNodesSource#initialize preserves direct cloud.js URL', async () => {
   const loadedUrls: string[] = [];
   const sourceUrl = 'https://potree.github.io/potree/pointclouds/vol_total/cloud.js';
   const coreApi = {
@@ -69,7 +58,6 @@ test('PotreeNodesSource#initialize preserves direct cloud.js URL', async t => {
       };
     }
   } as unknown as CoreAPI;
-
   const dataSource = new PotreeNodesSource(
     sourceUrl,
     {
@@ -79,16 +67,11 @@ test('PotreeNodesSource#initialize preserves direct cloud.js URL', async t => {
     coreApi
   );
   await dataSource.initialize();
-
-  t.equal(loadedUrls[0], sourceUrl, 'loads the exact cloud.js URL passed by the app');
-  t.equal(
-    dataSource.baseUrl,
-    'https://potree.github.io/potree/pointclouds/vol_total',
-    'uses the cloud.js directory as payload base URL'
+  expect(loadedUrls[0], 'loads the exact cloud.js URL passed by the app').toBe(sourceUrl);
+  expect(dataSource.baseUrl, 'uses the cloud.js directory as payload base URL').toBe(
+    'https://potree.github.io/potree/pointclouds/vol_total'
   );
-  t.end();
 });
-
 function countTreeNodes(node) {
   let count = 1;
   for (const child of node.children) {

--- a/modules/potree/test/utils/bounding-box-utils.spec.ts
+++ b/modules/potree/test/utils/bounding-box-utils.spec.ts
@@ -1,27 +1,19 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {getCartographicOriginFromBoundingBox} from '../../src/utils/bounding-box-utils';
 import {createProjection} from '../../src/utils/projection-utils';
 import {areNumberArraysEqual} from './compareArrays';
-
-test('bounding-box-utils#getCartographicOriginFromBoundingBox', async t => {
-  t.deepEquals(getCartographicOriginFromBoundingBox(null), [0, 0, 0]);
-
-  t.deepEquals(
+test('bounding-box-utils#getCartographicOriginFromBoundingBox', async () => {
+  expect(getCartographicOriginFromBoundingBox(null)).toEqual([0, 0, 0]);
+  expect(
     getCartographicOriginFromBoundingBox(null, [
       [52.1, -0.2, 33],
       [52.3, 0.2, 35]
-    ]),
-    [52.2, 0, 34]
-  );
-
+    ])
+  ).toEqual([52.2, 0, 34]);
   const projection = createProjection(
     '+proj=utm +zone=32 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +type=crs'
   );
-  t.ok(
+  expect(
     areNumberArraysEqual(
       getCartographicOriginFromBoundingBox(projection, [
         [291750, 5744750, 33],
@@ -29,13 +21,11 @@ test('bounding-box-utils#getCartographicOriginFromBoundingBox', async t => {
       ]),
       [5.9786817797857745, 51.81475434812279, 34]
     )
-  );
-  t.ok(
+  ).toBeTruthy();
+  expect(
     areNumberArraysEqual(
       projection?.project([291750, 5744750]),
       [5.978647065934338, 51.814730970044465]
     )
-  );
-
-  t.end();
+  ).toBeTruthy();
 });

--- a/modules/potree/test/utils/projection-utils.spec.ts
+++ b/modules/potree/test/utils/projection-utils.spec.ts
@@ -1,23 +1,15 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {createProjection} from '../../src/utils/projection-utils';
 import {areNumberArraysEqual} from './compareArrays';
-
-test('projection-utils#createProjection', async t => {
-  t.equals(createProjection(), null);
-
+test('projection-utils#createProjection', async () => {
+  expect(createProjection()).toBe(null);
   const projection = createProjection(
     '+proj=utm +zone=32 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +type=crs'
   );
-  t.ok(
+  expect(
     areNumberArraysEqual(
       projection?.project([291750, 5744750]),
       [5.978647065934338, 51.814730970044465]
     )
-  );
-
-  t.end();
+  ).toBeTruthy();
 });

--- a/modules/scene/test/usd-loader.spec.ts
+++ b/modules/scene/test/usd-loader.spec.ts
@@ -1,21 +1,16 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {load, parse} from '@loaders.gl/core';
 import {USDLoader} from '@loaders.gl/scene';
 import {USDLoaderWithParser} from '@loaders.gl/scene/usd-loader';
-
-test('USDLoader exposes metadata at the package root', t => {
-  t.equal(USDLoader.id, 'usd', 'uses the usd identifier');
-  t.equal(typeof USDLoader.preload, 'function', 'exposes preload');
-  t.notOk('parse' in USDLoader, 'does not expose a parser at the package root');
-  t.equal(typeof USDLoaderWithParser.parse, 'function', 'exports parser from the loader subpath');
-  t.end();
+test('USDLoader exposes metadata at the package root', () => {
+  expect(USDLoader.id, 'uses the usd identifier').toBe('usd');
+  expect(typeof USDLoader.preload, 'exposes preload').toBe('function');
+  expect('parse' in USDLoader, 'does not expose a parser at the package root').toBeFalsy();
+  expect(typeof USDLoaderWithParser.parse, 'exports parser from the loader subpath').toBe(
+    'function'
+  );
 });
-
-test('USDLoader parses an ASCII scene hierarchy', async t => {
+test('USDLoader parses an ASCII scene hierarchy', async () => {
   const source = `#usda 1.0
 (
     defaultPrim = "World"
@@ -34,23 +29,19 @@ def Xform "World"
     }
 }`;
   const stage = await parse(source, USDLoader);
-
-  t.equal(stage.metadata['upAxis'], 'Z', 'preserves stage metadata');
-  t.equal(stage.metadata['metersPerUnit'], 0.01, 'parses numeric metadata');
-  t.equal(stage.rootPrims[0].children[0].type, 'Mesh', 'preserves nested prim types');
-  t.deepEqual(
+  expect(stage.metadata['upAxis'], 'preserves stage metadata').toBe('Z');
+  expect(stage.metadata['metersPerUnit'], 'parses numeric metadata').toBe(0.01);
+  expect(stage.rootPrims[0].children[0].type, 'preserves nested prim types').toBe('Mesh');
+  expect(
     stage.rootPrims[0].children[0].attributes['points'].value,
-    [
-      [0, 0, 0],
-      [1, 0, 0],
-      [0, 1, 0]
-    ],
     'decodes nested point arrays'
-  );
-  t.end();
+  ).toEqual([
+    [0, 0, 0],
+    [1, 0, 0],
+    [0, 1, 0]
+  ]);
 });
-
-test('USDLoader resolves references, variants, and local overrides', async t => {
+test('USDLoader resolves references, variants, and local overrides', async () => {
   const layers = new Map([
     [
       'https://example.com/assets/geometry.usda',
@@ -108,18 +99,14 @@ def Xform "World"
   });
   const vehicle = stage.rootPrims[0].children[0];
   const goldBody = vehicle.children.find(child => child.name === 'GoldBody');
-
-  t.equal(stage.layers.length, 3, 'tracks the root and referenced layers');
-  t.equal(goldBody?.type, 'Mesh', 'resolves referenced geometry for the selected variant');
-  t.deepEqual(
+  expect(stage.layers.length, 'tracks the root and referenced layers').toBe(3);
+  expect(goldBody?.type, 'resolves referenced geometry for the selected variant').toBe('Mesh');
+  expect(
     goldBody?.children[0].attributes['material:binding'].value,
-    {path: '/Materials/Gold'},
     'applies local overrides to referenced prims'
-  );
-  t.end();
+  ).toEqual({path: '/Materials/Gold'});
 });
-
-test('USDLoader resolves references from relative filesystem paths', async t => {
+test('USDLoader resolves references from relative filesystem paths', async () => {
   const source = `#usda 1.0
 def Xform "World" (prepend references = @./assets/model.usda@) {}`;
   const referencedLayer = `#usda 1.0
@@ -134,21 +121,15 @@ def Mesh "Model" {int[] faceVertexCounts = [3]}`;
       }
     }
   });
-
-  t.deepEqual(
-    requestedUrls,
-    ['fixtures/scenes/./assets/model.usda'],
-    'preserves the relative source location'
-  );
-  t.deepEqual(
+  expect(requestedUrls, 'preserves the relative source location').toEqual([
+    'fixtures/scenes/./assets/model.usda'
+  ]);
+  expect(
     stage.rootPrims[0].attributes['faceVertexCounts'].value,
-    [3],
     'composes the referenced layer'
-  );
-  t.end();
+  ).toEqual([3]);
 });
-
-test('USDLoader uses an absolute response URL when the configured location is relative', async t => {
+test('USDLoader uses an absolute response URL when the configured location is relative', async () => {
   const source = `#usda 1.0
 def Xform "World" (prepend references = @./assets/model.usda@) {}`;
   const referencedLayer = `#usda 1.0
@@ -172,21 +153,16 @@ def Mesh "Model" {int[] faceVertexCounts = [3]}`;
       }
     }
   });
-
-  t.deepEqual(
+  expect(
     requestedUrls,
-    ['relative/scene.usda', 'https://example.com/scenes/assets/model.usda'],
     'falls back to the response URL for browser-style reference resolution'
-  );
-  t.deepEqual(
+  ).toEqual(['relative/scene.usda', 'https://example.com/scenes/assets/model.usda']);
+  expect(
     stage.rootPrims[0].attributes['faceVertexCounts'].value,
-    [3],
     'composes the referenced layer'
-  );
-  t.end();
+  ).toEqual([3]);
 });
-
-test('USDLoader does not count prim nesting against reference depth', async t => {
+test('USDLoader does not count prim nesting against reference depth', async () => {
   const source = `#usda 1.0
 def Xform "Level1" {
   def Xform "Level2" {
@@ -194,29 +170,20 @@ def Xform "Level1" {
   }
 }`;
   const stage = await parse(source, USDLoader, {usd: {maxReferenceDepth: 0}});
-
-  t.equal(stage.rootPrims[0].children[0].children[0].name, 'Level3', 'parses nested prims');
-  t.end();
+  expect(stage.rootPrims[0].children[0].children[0].name, 'parses nested prims').toBe('Level3');
 });
-
-test('USDLoader rejects unsupported binary USDC layers', async t => {
-  await t.rejects(
+test('USDLoader rejects unsupported binary USDC layers', async () => {
+  await expect(
     parse(new TextEncoder().encode('PXR-USDC\0\0'), USDLoader),
-    /Binary USDC crate layers are not implemented/,
     'reports unsupported binary crates'
-  );
-  t.end();
+  ).rejects.toThrow(/Binary USDC crate layers are not implemented/);
 });
-
-test('USDLoader reads uncompressed ASCII-root USDZ archives', async t => {
+test('USDLoader reads uncompressed ASCII-root USDZ archives', async () => {
   const archive = makeUSDZArchive('scene.usda', '#usda 1.0\ndef Xform "PackagedWorld" {}');
   const stage = await parse(archive, USDLoader);
-
-  t.equal(stage.format, 'usdz', 'retains the USDZ container format');
-  t.equal(stage.rootPrims[0].name, 'PackagedWorld', 'parses the archive root layer');
-  t.end();
+  expect(stage.format, 'retains the USDZ container format').toBe('usdz');
+  expect(stage.rootPrims[0].name, 'parses the archive root layer').toBe('PackagedWorld');
 });
-
 /** Builds a minimal stored ZIP archive containing one ASCII USD layer. */
 function makeUSDZArchive(filenameValue: string, contentsValue: string): ArrayBuffer {
   const filename = new TextEncoder().encode(filenameValue);
@@ -227,7 +194,6 @@ function makeUSDZArchive(filenameValue: string, contentsValue: string): ArrayBuf
   const archive = new ArrayBuffer(centralDirectoryOffset + centralDirectoryLength + 22);
   const bytes = new Uint8Array(archive);
   const view = new DataView(archive);
-
   view.setUint32(0, 0x04034b50, true);
   view.setUint16(4, 20, true);
   view.setUint32(18, contents.length, true);
@@ -235,7 +201,6 @@ function makeUSDZArchive(filenameValue: string, contentsValue: string): ArrayBuf
   view.setUint16(26, filename.length, true);
   bytes.set(filename, 30);
   bytes.set(contents, localHeaderLength);
-
   view.setUint32(centralDirectoryOffset, 0x02014b50, true);
   view.setUint16(centralDirectoryOffset + 4, 20, true);
   view.setUint16(centralDirectoryOffset + 6, 20, true);
@@ -243,13 +208,11 @@ function makeUSDZArchive(filenameValue: string, contentsValue: string): ArrayBuf
   view.setUint32(centralDirectoryOffset + 24, contents.length, true);
   view.setUint16(centralDirectoryOffset + 28, filename.length, true);
   bytes.set(filename, centralDirectoryOffset + 46);
-
   const endOffset = centralDirectoryOffset + centralDirectoryLength;
   view.setUint32(endOffset, 0x06054b50, true);
   view.setUint16(endOffset + 8, 1, true);
   view.setUint16(endOffset + 10, 1, true);
   view.setUint32(endOffset + 12, centralDirectoryLength, true);
   view.setUint32(endOffset + 16, centralDirectoryOffset, true);
-
   return archive;
 }

--- a/modules/services/test/arcgis/arcgis-server.spec.ts
+++ b/modules/services/test/arcgis/arcgis-server.spec.ts
@@ -1,39 +1,27 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
-import {expect, test as vitestTest} from 'vitest';
+import {expect, test} from 'vitest';
 import {LERCLoader} from '@loaders.gl/lerc';
-
 import {
   ArcGISFeatureServerSourceLoader,
   ArcGISImageServerSourceLoader,
   ArcGISImageTileSource,
   ArcGISMapTileSource
 } from '@loaders.gl/services';
-
 const IMAGE_SERVER_URL = 'https://example.com/arcgis/rest/services/Imagery/ImageServer';
 const FEATURE_SERVER_URL = 'https://example.com/arcgis/rest/services/Roads/FeatureServer/0';
-
-test('ArcGISImageServerSourceLoader#testURL', t => {
-  t.ok(ArcGISImageServerSourceLoader);
-  t.ok(
+test('ArcGISImageServerSourceLoader#testURL', () => {
+  expect(ArcGISImageServerSourceLoader).toBeTruthy();
+  expect(
     ArcGISImageServerSourceLoader.testURL(IMAGE_SERVER_URL),
     'identifies ArcGIS ImageServer URLs'
-  );
-  t.end();
+  ).toBeTruthy();
 });
-
-test('ArcGISMapTileSource#getTileURL preserves endpoint parameters', t => {
+test('ArcGISMapTileSource#getTileURL preserves endpoint parameters', () => {
   const source = new ArcGISMapTileSource('https://example.com/MapServer?token=abc');
   const url = new URL(source.getTileURL({x: 3, y: 4, z: 5}));
-  t.equal(url.pathname, '/MapServer/tile/5/4/3');
-  t.equal(url.searchParams.get('token'), 'abc');
-  t.end();
+  expect(url.pathname).toBe('/MapServer/tile/5/4/3');
+  expect(url.searchParams.get('token')).toBe('abc');
 });
-
-vitestTest('ArcGISMapTileSource builds dynamic export tiles and updates parameters', () => {
+test('ArcGISMapTileSource builds dynamic export tiles and updates parameters', () => {
   const source = new ArcGISMapTileSource('https://example.com/MapServer', {
     'arcgis-map-server': {mode: 'dynamic', tileSize: 512}
   });
@@ -44,8 +32,7 @@ vitestTest('ArcGISMapTileSource builds dynamic export tiles and updates paramete
   expect(url.searchParams.get('layers')).toBe('show:0');
   expect(url.searchParams.get('format')).toBe('jpgpng');
 });
-
-vitestTest('ArcGISMapTileSource distributes requests across configured service URLs', () => {
+test('ArcGISMapTileSource distributes requests across configured service URLs', () => {
   const source = new ArcGISMapTileSource('https://example.com/MapServer', {
     'arcgis-map-server': {
       urls: ['https://tiles-a.example.com/MapServer', 'https://tiles-b.example.com/MapServer']
@@ -54,8 +41,7 @@ vitestTest('ArcGISMapTileSource distributes requests across configured service U
   const url = new URL(source.getTileURL({x: 1, y: 0, z: 0}));
   expect(url.origin).toBe('https://tiles-b.example.com');
 });
-
-vitestTest('ArcGISMapTileSource fetches and decodes cached tiles', async () => {
+test('ArcGISMapTileSource fetches and decodes cached tiles', async () => {
   let parseCount = 0;
   const source = new ArcGISMapTileSource(
     'https://example.com/MapServer',
@@ -68,12 +54,10 @@ vitestTest('ArcGISMapTileSource fetches and decodes cached tiles', async () => {
     } as never
   );
   source.fetch = async () => new Response(new Uint8Array([1, 2, 3]));
-
   expect(await source.getTile({x: 1, y: 2, z: 3})).toEqual({width: 1, height: 1});
   expect(parseCount).toBe(1);
 });
-
-vitestTest('ArcGISMapTileSource falls back to dynamic export for incompatible caches', async () => {
+test('ArcGISMapTileSource falls back to dynamic export for incompatible caches', async () => {
   const source = new ArcGISMapTileSource(
     'https://example.com/MapServer',
     {
@@ -89,19 +73,16 @@ vitestTest('ArcGISMapTileSource falls back to dynamic export for incompatible ca
     requestedURL = url;
     return new Response(new Uint8Array([1]));
   };
-
   await source.getTile({x: 0, y: 0, z: 0});
   expect(new URL(requestedURL).pathname).toBe('/MapServer/export');
 });
-
-vitestTest('ArcGISMapTileSource expands custom tile URL templates', () => {
+test('ArcGISMapTileSource expands custom tile URL templates', () => {
   const source = new ArcGISMapTileSource('https://example.com/MapServer', {
     'arcgis-map-server': {urlTemplate: 'https://tiles.example/{z}/{y}/{x}.png?token=abc'}
   });
   expect(source.getTileURL({x: 3, y: 4, z: 5})).toBe('https://tiles.example/5/4/3.png?token=abc');
 });
-
-vitestTest('ArcGISMapTileSource exposes its cached tile grid', async () => {
+test('ArcGISMapTileSource exposes its cached tile grid', async () => {
   const source = new ArcGISMapTileSource('https://example.com/MapServer', {
     'arcgis-map-server': {
       metadata: {
@@ -117,7 +98,6 @@ vitestTest('ArcGISMapTileSource exposes its cached tile grid', async () => {
       }
     }
   });
-
   expect(await source.getMetadata()).toMatchObject({
     tileGrid: {
       crs: 'EPSG:3857',
@@ -127,8 +107,7 @@ vitestTest('ArcGISMapTileSource exposes its cached tile grid', async () => {
     }
   });
 });
-
-vitestTest('ArcGISImageTileSource builds exportImage tile requests', () => {
+test('ArcGISImageTileSource builds exportImage tile requests', () => {
   const source = new ArcGISImageTileSource('https://example.com/ImageServer', {
     'arcgis-image-server-tiles': {tileSize: 512, parameters: {time: '2020-01-01'}}
   });
@@ -139,8 +118,7 @@ vitestTest('ArcGISImageTileSource builds exportImage tile requests', () => {
   expect(url.searchParams.get('time')).toBe('2020-01-01');
   expect(url.searchParams.get('renderingRule')).toBe('{"rasterFunction":"Hillshade"}');
 });
-
-vitestTest('ArcGISImageTileSource distributes requests across configured service URLs', () => {
+test('ArcGISImageTileSource distributes requests across configured service URLs', () => {
   const source = new ArcGISImageTileSource('https://example.com/ImageServer', {
     'arcgis-image-server-tiles': {
       urls: [
@@ -152,8 +130,7 @@ vitestTest('ArcGISImageTileSource distributes requests across configured service
   const url = new URL(source.getTileURL({x: 1, y: 0, z: 0}));
   expect(url.origin).toBe('https://imagery-b.example.com');
 });
-
-vitestTest('ArcGISImageTileSource parses the effective response format', () => {
+test('ArcGISImageTileSource parses the effective response format', () => {
   const source = new ArcGISImageTileSource('https://example.com/ImageServer', {
     'arcgis-image-server-tiles': {format: 'lerc', parameters: {format: 'png32'}}
   });
@@ -162,19 +139,14 @@ vitestTest('ArcGISImageTileSource parses the effective response format', () => {
   source.updateParameters({format: 'png32'});
   expect(new URL(source.getTileURL({x: 0, y: 0, z: 0})).searchParams.get('format')).toBe('png32');
 });
-
-test('ArcGISImageSource#metadataURL', t => {
+test('ArcGISImageSource#metadataURL', () => {
   const source = ArcGISImageServerSourceLoader.createDataSource(IMAGE_SERVER_URL, {});
-
   const metadataUrl = new URL(source.metadataURL());
-  t.equal(metadataUrl.origin + metadataUrl.pathname, IMAGE_SERVER_URL, 'metadata base URL');
-  t.equal(metadataUrl.searchParams.get('f'), 'pjson', 'metadata format');
-  t.end();
+  expect(metadataUrl.origin + metadataUrl.pathname, 'metadata base URL').toBe(IMAGE_SERVER_URL);
+  expect(metadataUrl.searchParams.get('f'), 'metadata format').toBe('pjson');
 });
-
-test('ArcGISImageSource#exportImageURL', t => {
+test('ArcGISImageSource#exportImageURL', () => {
   const source = ArcGISImageServerSourceLoader.createDataSource(IMAGE_SERVER_URL, {});
-
   const exportImageUrl = new URL(
     source.exportImageURL({
       bbox: [1, 2, 3, 4],
@@ -185,18 +157,15 @@ test('ArcGISImageSource#exportImageURL', t => {
       format: 'png'
     })
   );
-
-  t.equal(exportImageUrl.origin + exportImageUrl.pathname, `${IMAGE_SERVER_URL}/exportImage`);
-  t.equal(exportImageUrl.searchParams.get('bbox'), '1,2,3,4');
-  t.equal(exportImageUrl.searchParams.get('bboxSR'), '4326');
-  t.equal(exportImageUrl.searchParams.get('size'), '512,256');
-  t.equal(exportImageUrl.searchParams.get('imageSR'), '3857');
-  t.equal(exportImageUrl.searchParams.get('format'), 'png');
-  t.equal(exportImageUrl.searchParams.get('f'), 'image');
-  t.end();
+  expect(exportImageUrl.origin + exportImageUrl.pathname).toBe(`${IMAGE_SERVER_URL}/exportImage`);
+  expect(exportImageUrl.searchParams.get('bbox')).toBe('1,2,3,4');
+  expect(exportImageUrl.searchParams.get('bboxSR')).toBe('4326');
+  expect(exportImageUrl.searchParams.get('size')).toBe('512,256');
+  expect(exportImageUrl.searchParams.get('imageSR')).toBe('3857');
+  expect(exportImageUrl.searchParams.get('format')).toBe('png');
+  expect(exportImageUrl.searchParams.get('f')).toBe('image');
 });
-
-vitestTest('ArcGISImageSource#exportImageURL supports LERC analytical rasters', () => {
+test('ArcGISImageSource#exportImageURL supports LERC analytical rasters', () => {
   const source = ArcGISImageServerSourceLoader.createDataSource(IMAGE_SERVER_URL, {});
   const exportRasterUrl = new URL(
     source.exportImageURL({
@@ -210,8 +179,7 @@ vitestTest('ArcGISImageSource#exportImageURL supports LERC analytical rasters', 
   expect(exportRasterUrl.searchParams.get('format')).toBe('lerc');
   expect(exportRasterUrl.searchParams.get('pixelType')).toBe('F32');
 });
-
-vitestTest('ArcGISImageSource#exportRaster requests and returns typed raster data', async () => {
+test('ArcGISImageSource#exportRaster requests and returns typed raster data', async () => {
   const raster = {
     width: 2,
     height: 1,
@@ -245,13 +213,11 @@ vitestTest('ArcGISImageSource#exportRaster requests and returns typed raster dat
     height: 1,
     pixelType: 'F32'
   });
-
   expect(parsedLoader).toBe(LERCLoader);
   expect(result).toBe(raster);
   expect(result.pixels[0]).toBeInstanceOf(Float32Array);
 });
-
-test('ArcGISImageSource#getMetadata', async t => {
+test('ArcGISImageSource#getMetadata', async () => {
   const source = ArcGISImageServerSourceLoader.createDataSource(IMAGE_SERVER_URL, {});
   source.fetch = async () =>
     new Response(
@@ -261,22 +227,18 @@ test('ArcGISImageSource#getMetadata', async t => {
         keywords: ['raster', 'imagery']
       })
     );
-
   const metadata = await source.getMetadata();
-  t.equal(metadata.name, 'Imagery');
-  t.equal(metadata.abstract, 'Image service description');
-  t.deepEqual(metadata.keywords, ['raster', 'imagery']);
-  t.end();
+  expect(metadata.name).toBe('Imagery');
+  expect(metadata.abstract).toBe('Image service description');
+  expect(metadata.keywords).toEqual(['raster', 'imagery']);
 });
-
-test('ArcGISImageSource#getImage maps generic parameters', async t => {
+test('ArcGISImageSource#getImage maps generic parameters', async () => {
   const source = ArcGISImageServerSourceLoader.createDataSource(IMAGE_SERVER_URL, {});
   let exportImageParameters;
   source.exportImage = async parameters => {
     exportImageParameters = parameters;
     return {} as never;
   };
-
   await source.getImage({
     boundingBox: [
       [1, 2],
@@ -288,8 +250,7 @@ test('ArcGISImageSource#getImage maps generic parameters', async t => {
     format: 'image/png',
     layers: []
   });
-
-  t.deepEqual(exportImageParameters, {
+  expect(exportImageParameters).toEqual({
     bbox: [1, 2, 3, 4],
     bboxSR: '3857',
     imageSR: '3857',
@@ -297,17 +258,14 @@ test('ArcGISImageSource#getImage maps generic parameters', async t => {
     height: 256,
     format: 'png'
   });
-  t.end();
 });
-
-test('ArcGISImageSource#getImage normalizes EPSG-prefixed spatial references', async t => {
+test('ArcGISImageSource#getImage normalizes EPSG-prefixed spatial references', async () => {
   const source = ArcGISImageServerSourceLoader.createDataSource(IMAGE_SERVER_URL, {});
   let exportImageParameters;
   source.exportImage = async parameters => {
     exportImageParameters = parameters;
     return {} as never;
   };
-
   await source.getImage({
     boundingBox: [
       [1, 2],
@@ -319,8 +277,7 @@ test('ArcGISImageSource#getImage normalizes EPSG-prefixed spatial references', a
     format: 'image/png',
     layers: []
   });
-
-  t.deepEqual(exportImageParameters, {
+  expect(exportImageParameters).toEqual({
     bbox: [1, 2, 3, 4],
     bboxSR: '3857',
     imageSR: '3857',
@@ -328,28 +285,21 @@ test('ArcGISImageSource#getImage normalizes EPSG-prefixed spatial references', a
     height: 256,
     format: 'png'
   });
-  t.end();
 });
-
-test('ArcGISFeatureServerSourceLoader#testURL', t => {
-  t.ok(ArcGISFeatureServerSourceLoader);
-  t.ok(
+test('ArcGISFeatureServerSourceLoader#testURL', () => {
+  expect(ArcGISFeatureServerSourceLoader).toBeTruthy();
+  expect(
     ArcGISFeatureServerSourceLoader.testURL(FEATURE_SERVER_URL),
     'identifies ArcGIS FeatureServer URLs'
-  );
-  t.end();
+  ).toBeTruthy();
 });
-
-test('ArcGISVectorSource#metadataURL', t => {
+test('ArcGISVectorSource#metadataURL', () => {
   const source = ArcGISFeatureServerSourceLoader.createDataSource(FEATURE_SERVER_URL, {});
-
   const metadataUrl = new URL(source.metadataURL());
-  t.equal(metadataUrl.origin + metadataUrl.pathname, FEATURE_SERVER_URL, 'metadata base URL');
-  t.equal(metadataUrl.searchParams.get('f'), 'pjson', 'metadata format');
-  t.end();
+  expect(metadataUrl.origin + metadataUrl.pathname, 'metadata base URL').toBe(FEATURE_SERVER_URL);
+  expect(metadataUrl.searchParams.get('f'), 'metadata format').toBe('pjson');
 });
-
-test('ArcGISVectorSource#getFeaturesURL', t => {
+test('ArcGISVectorSource#getFeaturesURL', () => {
   const source = ArcGISFeatureServerSourceLoader.createDataSource(FEATURE_SERVER_URL, {});
   const featuresUrl = new URL(
     source.getFeaturesURL({
@@ -361,21 +311,18 @@ test('ArcGISVectorSource#getFeaturesURL', t => {
       crs: '3857'
     })
   );
-
-  t.equal(featuresUrl.origin + featuresUrl.pathname, `${FEATURE_SERVER_URL}/query`);
-  t.equal(featuresUrl.searchParams.get('returnGeometry'), 'true');
-  t.equal(featuresUrl.searchParams.get('where'), '1=1');
-  t.equal(featuresUrl.searchParams.get('outFields'), '*');
-  t.equal(featuresUrl.searchParams.get('outSR'), '3857');
-  t.equal(featuresUrl.searchParams.get('inSR'), '3857');
-  t.equal(featuresUrl.searchParams.get('geometry'), '1,2,3,4');
-  t.equal(featuresUrl.searchParams.get('geometryType'), 'esriGeometryEnvelope');
-  t.equal(featuresUrl.searchParams.get('spatialRel'), 'esriSpatialRelIntersects');
-  t.equal(featuresUrl.searchParams.get('f'), 'geojson');
-  t.end();
+  expect(featuresUrl.origin + featuresUrl.pathname).toBe(`${FEATURE_SERVER_URL}/query`);
+  expect(featuresUrl.searchParams.get('returnGeometry')).toBe('true');
+  expect(featuresUrl.searchParams.get('where')).toBe('1=1');
+  expect(featuresUrl.searchParams.get('outFields')).toBe('*');
+  expect(featuresUrl.searchParams.get('outSR')).toBe('3857');
+  expect(featuresUrl.searchParams.get('inSR')).toBe('3857');
+  expect(featuresUrl.searchParams.get('geometry')).toBe('1,2,3,4');
+  expect(featuresUrl.searchParams.get('geometryType')).toBe('esriGeometryEnvelope');
+  expect(featuresUrl.searchParams.get('spatialRel')).toBe('esriSpatialRelIntersects');
+  expect(featuresUrl.searchParams.get('f')).toBe('geojson');
 });
-
-test('ArcGISVectorSource#getFeaturesURL normalizes EPSG-prefixed spatial references', t => {
+test('ArcGISVectorSource#getFeaturesURL normalizes EPSG-prefixed spatial references', () => {
   const source = ArcGISFeatureServerSourceLoader.createDataSource(FEATURE_SERVER_URL, {});
   const featuresUrl = new URL(
     source.getFeaturesURL({
@@ -387,13 +334,10 @@ test('ArcGISVectorSource#getFeaturesURL normalizes EPSG-prefixed spatial referen
       crs: 'EPSG:3857'
     })
   );
-
-  t.equal(featuresUrl.searchParams.get('outSR'), '3857');
-  t.equal(featuresUrl.searchParams.get('inSR'), '3857');
-  t.end();
+  expect(featuresUrl.searchParams.get('outSR')).toBe('3857');
+  expect(featuresUrl.searchParams.get('inSR')).toBe('3857');
 });
-
-test('ArcGISVectorSource#getMetadata and getSchema', async t => {
+test('ArcGISVectorSource#getMetadata and getSchema', async () => {
   const source = ArcGISFeatureServerSourceLoader.createDataSource(FEATURE_SERVER_URL, {});
   source.fetch = async () =>
     new Response(
@@ -408,23 +352,22 @@ test('ArcGISVectorSource#getMetadata and getSchema', async t => {
         ]
       })
     );
-
   const metadata = await source.getMetadata({formatSpecificMetadata: true});
-  t.equal(metadata.name, 'Roads');
-  t.equal(metadata.abstract, 'Road centerlines');
-  t.deepEqual(metadata.layers, [{name: 'Road centerlines'}]);
-  t.ok(metadata.formatSpecificMetadata, 'preserves format-specific metadata when requested');
-
+  expect(metadata.name).toBe('Roads');
+  expect(metadata.abstract).toBe('Road centerlines');
+  expect(metadata.layers).toEqual([{name: 'Road centerlines'}]);
+  expect(
+    metadata.formatSpecificMetadata,
+    'preserves format-specific metadata when requested'
+  ).toBeTruthy();
   const schema = await source.getSchema();
-  t.deepEqual(schema.fields, [
+  expect(schema.fields).toEqual([
     {name: 'OBJECTID', type: 'int32', nullable: false},
     {name: 'NAME', type: 'utf8', nullable: true},
     {name: 'LENGTH', type: 'float64', nullable: true}
   ]);
-  t.end();
 });
-
-test('ArcGISVectorSource#getFeatures defaults to Arrow', async t => {
+test('ArcGISVectorSource#getFeatures defaults to Arrow', async () => {
   const source = ArcGISFeatureServerSourceLoader.createDataSource(FEATURE_SERVER_URL, {});
   const featureCollection = {
     type: 'FeatureCollection',
@@ -437,7 +380,6 @@ test('ArcGISVectorSource#getFeatures defaults to Arrow', async t => {
     ]
   };
   source.fetch = async () => new Response(JSON.stringify(featureCollection));
-
   const table = await source.getFeatures({
     boundingBox: [
       [1, 2],
@@ -446,14 +388,11 @@ test('ArcGISVectorSource#getFeatures defaults to Arrow', async t => {
     layers: [],
     crs: '4326'
   });
-
-  t.equal(table.shape, 'arrow-table', 'returns Arrow tables by default');
-  t.equal(table.data.numRows, 1, 'preserves feature rows');
-  t.ok(table.schema?.metadata?.geo, 'adds GeoArrow metadata');
-  t.end();
+  expect(table.shape, 'returns Arrow tables by default').toBe('arrow-table');
+  expect(table.data.numRows, 'preserves feature rows').toBe(1);
+  expect(table.schema?.metadata?.geo, 'adds GeoArrow metadata').toBeTruthy();
 });
-
-test('ArcGISVectorSource#getFeatures supports explicit GeoJSON', async t => {
+test('ArcGISVectorSource#getFeatures supports explicit GeoJSON', async () => {
   const source = ArcGISFeatureServerSourceLoader.createDataSource(FEATURE_SERVER_URL, {});
   const featureCollection = {
     type: 'FeatureCollection',
@@ -466,7 +405,6 @@ test('ArcGISVectorSource#getFeatures supports explicit GeoJSON', async t => {
     ]
   };
   source.fetch = async () => new Response(JSON.stringify(featureCollection));
-
   const table = await source.getFeatures({
     boundingBox: [
       [1, 2],
@@ -476,7 +414,5 @@ test('ArcGISVectorSource#getFeatures supports explicit GeoJSON', async t => {
     crs: '4326',
     format: 'geojson'
   });
-
-  t.deepEqual(table, {shape: 'geojson-table', ...featureCollection});
-  t.end();
+  expect(table).toEqual({shape: 'geojson-table', ...featureCollection});
 });

--- a/modules/splats/test/ksplat-loader.spec.ts
+++ b/modules/splats/test/ksplat-loader.spec.ts
@@ -1,78 +1,65 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {parse, parseSync} from '@loaders.gl/core';
 import {KSPLATLoader} from '@loaders.gl/splats';
 import {KSPLATLoaderWithParser} from '@loaders.gl/splats/ksplat-loader';
-
 const HEADER_BYTE_LENGTH = 4096;
 const SECTION_HEADER_BYTE_LENGTH = 1024;
 const BYTES_PER_SPLAT = 44;
 const COMPRESSED_BYTES_PER_SPLAT = 24;
-
-test('KSPLATLoader parses uncompressed GaussianSplats3D buffers', async t => {
+test('KSPLATLoader parses uncompressed GaussianSplats3D buffers', async () => {
   const data = makeKSPLATFixture();
   const table = await parse(data, KSPLATLoader);
-
-  t.equal(table.shape, 'arrow-table', 'returns MeshArrowTable');
-  t.equal(table.data.numRows, 2, 'parses row count');
-  t.equal(
+  expect(table.shape, 'returns MeshArrowTable').toBe('arrow-table');
+  expect(table.data.numRows, 'parses row count').toBe(2);
+  expect(
     table.data.schema.metadata.get('loaders_gl.gaussian_splats.source_format'),
-    'ksplat',
     'adds source format metadata'
-  );
-  t.deepEqual(table.data.getChild('POSITION')?.get(1)?.toArray(), [4, 5, 6], 'parses position');
-  t.equal(table.data.getChild('scale_2')?.get(0), 3, 'parses linear scale');
-  t.ok(
+  ).toBe('ksplat');
+  expect(
+    Array.from(table.data.getChild('POSITION')?.get(1)?.toArray() || []),
+    'parses position'
+  ).toEqual([4, 5, 6]);
+  expect(table.data.getChild('scale_2')?.get(0), 'parses linear scale').toBe(3);
+  expect(
     Math.abs(Number(table.data.getChild('opacity')?.get(1)) - 64 / 255) < 1e-6,
     'parses color alpha as opacity'
-  );
-  t.ok(Math.abs(Number(table.data.getChild('rot_0')?.get(0)) - 1) < 1e-6, 'parses rotation');
-
+  ).toBeTruthy();
+  expect(
+    Math.abs(Number(table.data.getChild('rot_0')?.get(0)) - 1) < 1e-6,
+    'parses rotation'
+  ).toBeTruthy();
   const syncTable = parseSync(data, KSPLATLoaderWithParser);
-  t.equal(syncTable.data.numRows, 2, 'parser subpath supports parseSync');
-  t.end();
+  expect(syncTable.data.numRows, 'parser subpath supports parseSync').toBe(2);
 });
-
-test('KSPLATLoader validates header and version', t => {
-  t.throws(
+test('KSPLATLoader validates header and version', () => {
+  expect(
     () => KSPLATLoaderWithParser.parseSync(new ArrayBuffer(128)),
-    /4096-byte header/,
     'rejects missing header'
-  );
-
+  ).toThrow(/4096-byte header/);
   const data = makeKSPLATFixture();
   new DataView(data).setUint8(1, 0);
-  t.throws(
-    () => KSPLATLoaderWithParser.parseSync(data),
-    /version 0.0 is not supported/,
-    'rejects unsupported version'
+  expect(() => KSPLATLoaderWithParser.parseSync(data), 'rejects unsupported version').toThrow(
+    /version 0.0 is not supported/
   );
-  t.end();
 });
-
-test('KSPLATLoader decodes compressed bucket-relative centers', t => {
+test('KSPLATLoader decodes compressed bucket-relative centers', () => {
   const table = KSPLATLoaderWithParser.parseSync(makeCompressedKSPLATFixture());
-
-  t.deepEqual(
-    table.data.getChild('POSITION')?.get(0)?.toArray(),
-    [10, 20, 30],
+  expect(
+    Array.from(table.data.getChild('POSITION')?.get(0)?.toArray() || []),
     'decodes uint16 bucket-relative center'
-  );
-  t.equal(table.data.getChild('scale_1')?.get(0), 2, 'decodes half-float scale');
-  t.ok(Math.abs(Number(table.data.getChild('rot_0')?.get(0)) - 1) < 1e-6, 'decodes rotation');
-  t.end();
+  ).toEqual([10, 20, 30]);
+  expect(table.data.getChild('scale_1')?.get(0), 'decodes half-float scale').toBe(2);
+  expect(
+    Math.abs(Number(table.data.getChild('rot_0')?.get(0)) - 1) < 1e-6,
+    'decodes rotation'
+  ).toBeTruthy();
 });
-
 /** Builds a deterministic uncompressed two-row `.ksplat` fixture. */
 function makeKSPLATFixture(): ArrayBuffer {
   const data = new ArrayBuffer(
     HEADER_BYTE_LENGTH + SECTION_HEADER_BYTE_LENGTH + BYTES_PER_SPLAT * 2
   );
   const dataView = new DataView(data);
-
   dataView.setUint8(0, 0);
   dataView.setUint8(1, 1);
   dataView.setUint32(4, 1, true);
@@ -82,25 +69,21 @@ function makeKSPLATFixture(): ArrayBuffer {
   dataView.setUint16(20, 0, true);
   dataView.setFloat32(36, -1.5, true);
   dataView.setFloat32(40, 1.5, true);
-
   const sectionHeaderOffset = HEADER_BYTE_LENGTH;
   dataView.setUint32(sectionHeaderOffset + 0, 2, true);
   dataView.setUint32(sectionHeaderOffset + 4, 2, true);
   dataView.setUint16(sectionHeaderOffset + 40, 0, true);
-
   const splatDataOffset = HEADER_BYTE_LENGTH + SECTION_HEADER_BYTE_LENGTH;
   writeKSPLATRow(data, splatDataOffset, 0, [1, 2, 3], [1, 2, 3], [1, 0, 0, 0], [255, 128, 0, 255]);
   writeKSPLATRow(data, splatDataOffset, 1, [4, 5, 6], [4, 5, 6], [0, 1, 0, 0], [0, 64, 255, 64]);
   return data;
 }
-
 /** Builds a deterministic compressed one-row `.ksplat` fixture. */
 function makeCompressedKSPLATFixture(): ArrayBuffer {
   const data = new ArrayBuffer(
     HEADER_BYTE_LENGTH + SECTION_HEADER_BYTE_LENGTH + 12 + COMPRESSED_BYTES_PER_SPLAT
   );
   const dataView = new DataView(data);
-
   dataView.setUint8(0, 0);
   dataView.setUint8(1, 1);
   dataView.setUint32(4, 1, true);
@@ -110,7 +93,6 @@ function makeCompressedKSPLATFixture(): ArrayBuffer {
   dataView.setUint16(20, 1, true);
   dataView.setFloat32(36, -1.5, true);
   dataView.setFloat32(40, 1.5, true);
-
   const sectionHeaderOffset = HEADER_BYTE_LENGTH;
   dataView.setUint32(sectionHeaderOffset + 0, 1, true);
   dataView.setUint32(sectionHeaderOffset + 4, 1, true);
@@ -121,12 +103,10 @@ function makeCompressedKSPLATFixture(): ArrayBuffer {
   dataView.setUint32(sectionHeaderOffset + 24, 32767, true);
   dataView.setUint32(sectionHeaderOffset + 32, 1, true);
   dataView.setUint16(sectionHeaderOffset + 40, 0, true);
-
   const bucketOffset = HEADER_BYTE_LENGTH + SECTION_HEADER_BYTE_LENGTH;
   dataView.setFloat32(bucketOffset + 0, 10, true);
   dataView.setFloat32(bucketOffset + 4, 20, true);
   dataView.setFloat32(bucketOffset + 8, 30, true);
-
   const splatOffset = bucketOffset + 12;
   dataView.setUint16(splatOffset + 0, 32767, true);
   dataView.setUint16(splatOffset + 2, 32767, true);
@@ -144,7 +124,6 @@ function makeCompressedKSPLATFixture(): ArrayBuffer {
   dataView.setUint8(splatOffset + 23, 255);
   return data;
 }
-
 /** Writes one uncompressed `.ksplat` fixture row. */
 function writeKSPLATRow(
   data: ArrayBuffer,
@@ -166,7 +145,6 @@ function writeKSPLATRow(
     dataView.setUint8(byteOffset + 40 + component, color[component]);
   }
 }
-
 /** Encodes the finite fixture values needed by the compressed KSPLAT test as float16. */
 function encodeFloat16(value: number): number {
   if (value === 0) {

--- a/modules/splats/test/splat-loader.spec.ts
+++ b/modules/splats/test/splat-loader.spec.ts
@@ -1,53 +1,45 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {parse, parseSync} from '@loaders.gl/core';
 import {SPLATLoader} from '@loaders.gl/splats';
 import {SPLATLoaderWithParser} from '@loaders.gl/splats/splat-loader';
-
-test('SPLATLoader parses raw Gaussian splats', async t => {
+test('SPLATLoader parses raw Gaussian splats', async () => {
   const data = makeSPLATFixture();
   const table = await parse(data, SPLATLoader);
-
-  t.equal(table.shape, 'arrow-table', 'returns MeshArrowTable');
-  t.equal(table.topology, 'point-list', 'returns point-list topology');
-  t.equal(table.data.numRows, 2, 'parses row count');
-  t.equal(
+  expect(table.shape, 'returns MeshArrowTable').toBe('arrow-table');
+  expect(table.topology, 'returns point-list topology').toBe('point-list');
+  expect(table.data.numRows, 'parses row count').toBe(2);
+  expect(
     table.data.schema.metadata.get('loaders_gl.semantic_type'),
-    'gaussian-splats',
     'adds Gaussian splat semantic metadata'
-  );
-  t.deepEqual(table.data.getChild('POSITION')?.get(0)?.toArray(), [1, 2, 3], 'parses position');
-  t.equal(table.data.getChild('scale_0')?.get(1), 4, 'parses linear scale');
-  t.ok(
+  ).toBe('gaussian-splats');
+  expect(
+    Array.from(table.data.getChild('POSITION')?.get(0)?.toArray() || []),
+    'parses position'
+  ).toEqual([1, 2, 3]);
+  expect(table.data.getChild('scale_0')?.get(1), 'parses linear scale').toBe(4);
+  expect(
     Math.abs(Number(table.data.getChild('opacity')?.get(0)) - 128 / 255) < 1e-6,
     'parses linear opacity'
-  );
-  t.equal(
+  ).toBeTruthy();
+  expect(
     table.data.schema.fields
       .find(field => field.name === 'opacity')
       ?.metadata.get('loaders_gl.gaussian_splats.encoding'),
-    'linear',
     'marks opacity as linear'
-  );
-  t.ok(Math.abs(Number(table.data.getChild('rot_0')?.get(0)) - 1) < 1e-6, 'normalizes rotation');
-
+  ).toBe('linear');
+  expect(
+    Math.abs(Number(table.data.getChild('rot_0')?.get(0)) - 1) < 1e-6,
+    'normalizes rotation'
+  ).toBeTruthy();
   const syncTable = parseSync(data, SPLATLoaderWithParser);
-  t.equal(syncTable.data.numRows, 2, 'parser subpath supports parseSync');
-  t.end();
+  expect(syncTable.data.numRows, 'parser subpath supports parseSync').toBe(2);
 });
-
-test('SPLATLoader rejects invalid byte length', t => {
-  t.throws(
+test('SPLATLoader rejects invalid byte length', () => {
+  expect(
     () => SPLATLoaderWithParser.parseSync(new ArrayBuffer(31)),
-    /multiple of 32/,
     'rejects partial rows'
-  );
-  t.end();
+  ).toThrow(/multiple of 32/);
 });
-
 /** Builds a deterministic two-row `.splat` fixture. */
 function makeSPLATFixture(): ArrayBuffer {
   const data = new ArrayBuffer(64);
@@ -55,7 +47,6 @@ function makeSPLATFixture(): ArrayBuffer {
   writeSPLATRow(data, 1, [-1, -2, -3], [4, 5, 6], [0, 255, 64, 255], [128, 255, 128, 128]);
   return data;
 }
-
 /** Writes one `.splat` fixture row. */
 function writeSPLATRow(
   data: ArrayBuffer,

--- a/modules/splats/test/spz-loader.spec.ts
+++ b/modules/splats/test/spz-loader.spec.ts
@@ -1,92 +1,83 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {parse} from '@loaders.gl/core';
 import {ZstdCompression} from '@loaders.gl/compression/zstd-compression';
 import {SPZLoader} from '@loaders.gl/splats';
 import {SPZLoaderWithParser} from '@loaders.gl/splats/spz-loader';
 import {ZstdCodec} from 'zstd-codec';
-
 const modules = {'zstd-codec': ZstdCodec};
-
-test('SPZLoader parses Niantic Spatial v4 Gaussian splats', async t => {
+test('SPZLoader parses Niantic Spatial v4 Gaussian splats', async () => {
   const data = await makeSPZFixture();
   const formats: string[] = [];
   const restoreDecompressionStream = installMockDecompressionStream(formats);
-
   try {
     const table = await parse(data, SPZLoader, {modules});
-
-    t.equal(table.shape, 'arrow-table', 'returns MeshArrowTable');
-    t.equal(table.topology, 'point-list', 'returns point-list topology');
-    t.equal(table.data.numRows, 2, 'parses row count');
-    t.equal(
+    expect(table.shape, 'returns MeshArrowTable').toBe('arrow-table');
+    expect(table.topology, 'returns point-list topology').toBe('point-list');
+    expect(table.data.numRows, 'parses row count').toBe(2);
+    expect(
       table.data.schema.metadata.get('loaders_gl.gaussian_splats.source_format'),
-      'spz',
       'adds source format metadata'
-    );
-    t.deepEqual(table.data.getChild('POSITION')?.get(0)?.toArray(), [1, 2, -3], 'parses position');
-    t.ok(Math.abs(Number(table.data.getChild('scale_1')?.get(0)) - 1) < 1e-6, 'decodes scale');
-    t.ok(
+    ).toBe('spz');
+    expect(
+      Array.from(table.data.getChild('POSITION')?.get(0)?.toArray() || []),
+      'parses position'
+    ).toEqual([1, 2, -3]);
+    expect(
+      Math.abs(Number(table.data.getChild('scale_1')?.get(0)) - 1) < 1e-6,
+      'decodes scale'
+    ).toBeTruthy();
+    expect(
       Math.abs(Number(table.data.getChild('opacity')?.get(1)) - 64 / 255) < 1e-6,
       'decodes linear opacity'
-    );
-    t.ok(
+    ).toBeTruthy();
+    expect(
       Math.abs(Number(table.data.getChild('f_dc_0')?.get(0)) - (140 / 255 - 0.5) / 0.15) < 1e-6,
       'decodes SPZ DC coefficient'
-    );
-    t.ok(Math.abs(Number(table.data.getChild('rot_0')?.get(0)) - 1) < 1e-6, 'decodes rotation');
-
+    ).toBeTruthy();
+    expect(
+      Math.abs(Number(table.data.getChild('rot_0')?.get(0)) - 1) < 1e-6,
+      'decodes rotation'
+    ).toBeTruthy();
     const directTable = await SPZLoaderWithParser.parse(data, {modules});
-    t.equal(directTable.data.numRows, 2, 'parser subpath supports async parse');
-    t.deepEqual(formats, [], 'provided zstd-codec bypasses native stream probing');
+    expect(directTable.data.numRows, 'parser subpath supports async parse').toBe(2);
+    expect(formats, 'provided zstd-codec bypasses native stream probing').toEqual([]);
   } finally {
     restoreDecompressionStream();
   }
-  t.end();
 });
-
-test('SPZLoader uses native zstd without a codec module', async t => {
+test('SPZLoader uses native zstd without a codec module', async () => {
   const data = await makeSPZFixture(false);
   const formats: string[] = [];
   const restoreDecompressionStream = installMockDecompressionStream(formats);
   const restoreZstd = removeRegisteredModule('zstd-codec');
-
   try {
     const table = await SPZLoaderWithParser.parse(data);
-    t.equal(table.data.numRows, 2, 'native zstd path parses SPZ data');
-    t.deepEqual(
-      formats,
-      ['zstd', 'zstd', 'zstd', 'zstd', 'zstd', 'zstd'],
-      'one capability probe and all SPZ streams use native zstd'
-    );
+    expect(table.data.numRows, 'native zstd path parses SPZ data').toBe(2);
+    expect(formats, 'one capability probe and all SPZ streams use native zstd').toEqual([
+      'zstd',
+      'zstd',
+      'zstd',
+      'zstd',
+      'zstd',
+      'zstd'
+    ]);
   } finally {
     restoreZstd();
     restoreDecompressionStream();
   }
-
-  t.end();
 });
-
-test('SPZLoader validates header', async t => {
-  await t.rejects(
-    () => SPZLoaderWithParser.parse(new ArrayBuffer(8), {modules}),
-    /32-byte header/,
+test('SPZLoader validates header', async () => {
+  await expect(
+    SPZLoaderWithParser.parse(new ArrayBuffer(8), {modules}),
     'rejects missing header'
-  );
-
+  ).rejects.toThrow(/32-byte header/);
   const data = await makeSPZFixture();
   new DataView(data).setUint32(4, 3, true);
-  await t.rejects(
-    () => SPZLoaderWithParser.parse(data, {modules}),
-    /version 3 is not supported/,
+  await expect(
+    SPZLoaderWithParser.parse(data, {modules}),
     'rejects unsupported version'
-  );
-  t.end();
+  ).rejects.toThrow(/version 3 is not supported/);
 });
-
 /**
  * Builds a deterministic two-row SPZ v4 fixture.
  *
@@ -118,7 +109,6 @@ async function makeSPZFixture(compressStreams = true): Promise<ArrayBuffer> {
   const data = new ArrayBuffer(byteLength);
   const dataView = new DataView(data);
   const bytes = new Uint8Array(data);
-
   dataView.setUint32(0, 0x5053474e, true);
   dataView.setUint32(4, 4, true);
   dataView.setUint32(8, 2, true);
@@ -127,7 +117,6 @@ async function makeSPZFixture(compressStreams = true): Promise<ArrayBuffer> {
   dataView.setUint8(14, 0);
   dataView.setUint8(15, compressedStreams.length);
   dataView.setUint32(16, headerByteLength, true);
-
   let compressedOffset = headerByteLength + tocByteLength;
   for (let streamIndex = 0; streamIndex < compressedStreams.length; streamIndex++) {
     const tocOffset = headerByteLength + streamIndex * 16;
@@ -136,10 +125,8 @@ async function makeSPZFixture(compressStreams = true): Promise<ArrayBuffer> {
     bytes.set(compressedStreams[streamIndex], compressedOffset);
     compressedOffset += compressedStreams[streamIndex].byteLength;
   }
-
   return data;
 }
-
 /**
  * Installs a pass-through native zstd stream and returns a restorer.
  *
@@ -148,11 +135,9 @@ async function makeSPZFixture(compressStreams = true): Promise<ArrayBuffer> {
  */
 function installMockDecompressionStream(formats: string[]): () => void {
   const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'DecompressionStream');
-
   class MockDecompressionStream {
     readonly readable: ReadableStream<Uint8Array>;
     readonly writable: WritableStream<BufferSource>;
-
     /** Creates a pass-through stream for the native zstd format. */
     constructor(format: string) {
       formats.push(format);
@@ -168,13 +153,11 @@ function installMockDecompressionStream(formats: string[]): () => void {
       this.writable = transformStream.writable;
     }
   }
-
   Object.defineProperty(globalThis, 'DecompressionStream', {
     configurable: true,
     writable: true,
     value: MockDecompressionStream
   });
-
   return () => {
     if (originalDescriptor) {
       Object.defineProperty(globalThis, 'DecompressionStream', originalDescriptor);
@@ -183,7 +166,6 @@ function installMockDecompressionStream(formats: string[]): () => void {
     }
   };
 }
-
 /**
  * Removes one registered injectable module and returns a restorer.
  *
@@ -199,7 +181,6 @@ function removeRegisteredModule(moduleName: string): () => void {
   const hadModule = Object.prototype.hasOwnProperty.call(registeredModules, moduleName);
   const originalModule = registeredModules[moduleName];
   delete registeredModules[moduleName];
-
   return () => {
     if (hadModule) {
       registeredModules[moduleName] = originalModule;
@@ -208,7 +189,6 @@ function removeRegisteredModule(moduleName: string): () => void {
     }
   };
 }
-
 /**
  * Copies a native stream input chunk into a Uint8Array.
  *
@@ -225,7 +205,6 @@ function copyBufferSource(bufferSource: BufferSource): Uint8Array {
     bufferSource.byteLength
   ).slice();
 }
-
 /** Builds packed 24-bit fixed-point position fixture bytes. */
 function makePositionStream(): Uint8Array {
   const positions = new Uint8Array(18);
@@ -237,14 +216,12 @@ function makePositionStream(): Uint8Array {
   writeFixed24(positions, 15, 6 * 4096);
   return positions;
 }
-
 /** Writes one signed little-endian 24-bit fixture value. */
 function writeFixed24(bytes: Uint8Array, byteOffset: number, value: number): void {
   bytes[byteOffset + 0] = value & 0xff;
   bytes[byteOffset + 1] = (value >> 8) & 0xff;
   bytes[byteOffset + 2] = (value >> 16) & 0xff;
 }
-
 /** Builds packed log-scale fixture bytes. */
 function makeScaleStream(): Uint8Array {
   return new Uint8Array([
@@ -256,12 +233,10 @@ function makeScaleStream(): Uint8Array {
     encodeScale(5)
   ]);
 }
-
 /** Encodes a linear scale fixture value as an SPZ log-scale byte. */
 function encodeScale(value: number): number {
   return Math.round((Math.log(value) + 10) * 16);
 }
-
 /** Builds packed smallest-three quaternion fixture bytes. */
 function makeRotationStream(): Uint8Array {
   const rotations = new Uint8Array(8);
@@ -269,7 +244,6 @@ function makeRotationStream(): Uint8Array {
   rotations.set(encodeQuaternionSmallestThree([1, 0, 0, 0]), 4);
   return rotations;
 }
-
 /** Encodes one `[x, y, z, w]` quaternion as SPZ smallest-three bytes. */
 function encodeQuaternionSmallestThree(quaternion: [number, number, number, number]): Uint8Array {
   let largestComponent = 0;
@@ -278,7 +252,6 @@ function encodeQuaternionSmallestThree(quaternion: [number, number, number, numb
       largestComponent = component;
     }
   }
-
   const negate = quaternion[largestComponent] < 0;
   let packed = largestComponent;
   for (let component = 0; component < 4; component++) {
@@ -290,7 +263,6 @@ function encodeQuaternionSmallestThree(quaternion: [number, number, number, numb
       packed = (packed << 10) | (Number(isNegative) << 9) | magnitude;
     }
   }
-
   return new Uint8Array([
     packed & 0xff,
     (packed >>> 8) & 0xff,

--- a/modules/terrain/test/quantized-mesh-loader.spec.js
+++ b/modules/terrain/test/quantized-mesh-loader.spec.js
@@ -1,91 +1,55 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-/* eslint-disable max-len */
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {validateLoader, validateMeshCategoryData} from 'test/common/conformance';
-
 import {QuantizedMeshLoader, QuantizedMeshWorkerLoader} from '@loaders.gl/terrain';
 import {setLoaderOptions, load} from '@loaders.gl/core';
-
 const TILE_WITH_EXTENSIONS_URL = '@loaders.gl/terrain/test/data/tile-with-extensions.terrain';
 const EXPECTED_TILE_VERTEX_COUNT = typeof window === 'undefined' ? 627 : 781;
 const EXPECTED_TILE_TRIANGLE_COUNT = typeof window === 'undefined' ? 1175 : 1329;
-
 setLoaderOptions({
   _workerType: 'test'
 });
-
-test('QuantizedMeshLoader#loader objects', async t => {
-  validateLoader(t, QuantizedMeshLoader, 'QuantizedMeshLoader');
-  validateLoader(t, QuantizedMeshWorkerLoader, 'QuantizedMeshWorkerLoader');
-  t.end();
+test('QuantizedMeshLoader#loader objects', async () => {
+  validateLoader(QuantizedMeshLoader, 'QuantizedMeshLoader');
+  validateLoader(QuantizedMeshWorkerLoader, 'QuantizedMeshWorkerLoader');
 });
-
-test('QuantizedMeshLoader#parse tile-with-extensions', async t => {
+test('QuantizedMeshLoader#parse tile-with-extensions', async () => {
   const data = await load(TILE_WITH_EXTENSIONS_URL, QuantizedMeshLoader);
-  validateMeshCategoryData(t, data); // TODO: should there be a validateMeshCategoryData?
-
-  t.equal(data.mode, 4, 'mode is TRIANGLES (4)');
-
-  t.equal(data.indices.value.length, EXPECTED_TILE_TRIANGLE_COUNT * 3, 'indices was found');
-  t.equal(data.indices.size, 1, 'indices was found');
-
-  t.equal(
-    data.attributes.TEXCOORD_0.value.length,
-    EXPECTED_TILE_VERTEX_COUNT * 2,
-    'TEXCOORD_0 attribute was found'
+  validateMeshCategoryData(data); // TODO: should there be a validateMeshCategoryData?
+  expect(data.mode, 'mode is TRIANGLES (4)').toBe(4);
+  expect(data.indices.value.length, 'indices was found').toBe(EXPECTED_TILE_TRIANGLE_COUNT * 3);
+  expect(data.indices.size, 'indices was found').toBe(1);
+  expect(data.attributes.TEXCOORD_0.value.length, 'TEXCOORD_0 attribute was found').toBe(
+    EXPECTED_TILE_VERTEX_COUNT * 2
   );
-  t.equal(data.attributes.TEXCOORD_0.size, 2, 'TEXCOORD_0 attribute was found');
-
-  t.equal(
-    data.attributes.POSITION.value.length,
-    EXPECTED_TILE_VERTEX_COUNT * 3,
-    'POSITION attribute was found'
+  expect(data.attributes.TEXCOORD_0.size, 'TEXCOORD_0 attribute was found').toBe(2);
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(
+    EXPECTED_TILE_VERTEX_COUNT * 3
   );
-  t.equal(data.attributes.POSITION.size, 3, 'POSITION attribute was found');
-
-  t.end();
+  expect(data.attributes.POSITION.size, 'POSITION attribute was found').toBe(3);
 });
-
-test('QuantizedMeshLoader#add skirt to tile-with-extensions', async t => {
+test('QuantizedMeshLoader#add skirt to tile-with-extensions', async () => {
   const options = {'quantized-mesh': {skirtHeight: 50}};
   const data = await load(TILE_WITH_EXTENSIONS_URL, QuantizedMeshLoader, options);
-  t.equal(data.indices.value.length, 1329 * 3, 'indices was found');
-  t.equal(data.attributes.TEXCOORD_0.value.length, 781 * 2, 'TEXCOORD_0 attribute was found');
-  t.equal(data.attributes.POSITION.value.length, 781 * 3, 'POSITION attribute was found');
-  t.end();
+  expect(data.indices.value.length, 'indices was found').toBe(1329 * 3);
+  expect(data.attributes.TEXCOORD_0.value.length, 'TEXCOORD_0 attribute was found').toBe(781 * 2);
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(781 * 3);
 });
-
-test('QuantizedMeshWorkerLoader#tile-with-extensions', async t => {
+test('QuantizedMeshWorkerLoader#tile-with-extensions', async () => {
   if (typeof Worker === 'undefined') {
-    t.comment('Worker is not usable in non-browser environments');
-    t.end();
+    console.log('Worker is not usable in non-browser environments');
     return;
   }
-
   const data = await load(TILE_WITH_EXTENSIONS_URL, QuantizedMeshWorkerLoader);
-  validateMeshCategoryData(t, data); // TODO: should there be a validateMeshCategoryData?
-
-  t.equal(data.mode, 4, 'mode is TRIANGLES (4)');
-
-  t.equal(data.indices.value.length, EXPECTED_TILE_TRIANGLE_COUNT * 3, 'indices was found');
-  t.equal(data.indices.size, 1, 'indices was found');
-
-  t.equal(
-    data.attributes.TEXCOORD_0.value.length,
-    EXPECTED_TILE_VERTEX_COUNT * 2,
-    'TEXCOORD_0 attribute was found'
+  validateMeshCategoryData(data); // TODO: should there be a validateMeshCategoryData?
+  expect(data.mode, 'mode is TRIANGLES (4)').toBe(4);
+  expect(data.indices.value.length, 'indices was found').toBe(EXPECTED_TILE_TRIANGLE_COUNT * 3);
+  expect(data.indices.size, 'indices was found').toBe(1);
+  expect(data.attributes.TEXCOORD_0.value.length, 'TEXCOORD_0 attribute was found').toBe(
+    EXPECTED_TILE_VERTEX_COUNT * 2
   );
-  t.equal(data.attributes.TEXCOORD_0.size, 2, 'TEXCOORD_0 attribute was found');
-
-  t.equal(
-    data.attributes.POSITION.value.length,
-    EXPECTED_TILE_VERTEX_COUNT * 3,
-    'POSITION attribute was found'
+  expect(data.attributes.TEXCOORD_0.size, 'TEXCOORD_0 attribute was found').toBe(2);
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(
+    EXPECTED_TILE_VERTEX_COUNT * 3
   );
-  t.equal(data.attributes.POSITION.size, 3, 'POSITION attribute was found');
-
-  t.end();
+  expect(data.attributes.POSITION.size, 'POSITION attribute was found').toBe(3);
 });

--- a/modules/terrain/test/quantized-mesh-writer.spec.js
+++ b/modules/terrain/test/quantized-mesh-writer.spec.js
@@ -1,18 +1,11 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {validateWriter, validateMeshCategoryData} from 'test/common/conformance';
-
 import {QuantizedMeshLoader, QuantizedMeshWriter} from '@loaders.gl/terrain';
 import {encode, parse} from '@loaders.gl/core';
 import {convertMeshToTable, deduceMeshSchema} from '@loaders.gl/schema-utils';
-
 const attributes = {
   POSITION: {value: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 1]), size: 3}
 };
-
 const mesh = {
   attributes,
   indices: {value: new Uint32Array([0, 1, 2]), size: 1},
@@ -20,32 +13,26 @@ const mesh = {
   mode: 4,
   schema: deduceMeshSchema(attributes, {topology: 'triangle-list', mode: '4'})
 };
-
-test('QuantizedMeshWriter#writer conformance', t => {
-  validateWriter(t, QuantizedMeshWriter, 'QuantizedMeshWriter');
-  t.end();
+test('QuantizedMeshWriter#writer conformance', () => {
+  validateWriter(QuantizedMeshWriter, 'QuantizedMeshWriter');
 });
-
-test('QuantizedMeshWriter#encode plain and Arrow mesh data', async t => {
+test('QuantizedMeshWriter#encode plain and Arrow mesh data', async () => {
   const options = {'quantized-mesh': {bounds: [0, 0, 1, 1]}};
   const arrayBuffer = await encode(mesh, QuantizedMeshWriter, options);
   const data = await parse(arrayBuffer, QuantizedMeshLoader, options);
-
-  validateMeshCategoryData(t, data);
-  t.equal(data.mode, 4, 'mode is TRIANGLES (4)');
-  t.equal(data.attributes.POSITION.value.length, 9, 'POSITION attribute roundtripped');
-  t.equal(data.indices.value.length, 3, 'indices roundtripped');
-
+  validateMeshCategoryData(data);
+  expect(data.mode, 'mode is TRIANGLES (4)').toBe(4);
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute roundtripped').toBe(9);
+  expect(data.indices.value.length, 'indices roundtripped').toBe(3);
   const arrowTable = convertMeshToTable(mesh, 'arrow-table');
   const arrowArrayBuffer = await encode(arrowTable, QuantizedMeshWriter, options);
   const arrowData = await parse(arrowArrayBuffer, QuantizedMeshLoader, options);
-
-  validateMeshCategoryData(t, arrowData);
-  t.equal(arrowData.attributes.POSITION.value.length, 9, 'Arrow POSITION attribute roundtripped');
-  t.end();
+  validateMeshCategoryData(arrowData);
+  expect(arrowData.attributes.POSITION.value.length, 'Arrow POSITION attribute roundtripped').toBe(
+    9
+  );
 });
-
-test('QuantizedMeshWriter#encodes non-sequential triangle indices', async t => {
+test('QuantizedMeshWriter#encodes non-sequential triangle indices', async () => {
   const reorderedMesh = {
     ...mesh,
     indices: {value: new Uint32Array([0, 2, 1]), size: 1}
@@ -53,9 +40,7 @@ test('QuantizedMeshWriter#encodes non-sequential triangle indices', async t => {
   const options = {'quantized-mesh': {bounds: [0, 0, 1, 1]}};
   const arrayBuffer = await encode(reorderedMesh, QuantizedMeshWriter, options);
   const data = await parse(arrayBuffer, QuantizedMeshLoader, options);
-
-  validateMeshCategoryData(t, data);
-  t.equal(data.mode, 4, 'mode is TRIANGLES (4)');
-  t.equal(data.indices.value.length, 3, 'indices roundtripped');
-  t.end();
+  validateMeshCategoryData(data);
+  expect(data.mode, 'mode is TRIANGLES (4)').toBe(4);
+  expect(data.indices.value.length, 'indices roundtripped').toBe(3);
 });

--- a/modules/terrain/test/terrain-arrow-loader.spec.js
+++ b/modules/terrain/test/terrain-arrow-loader.spec.js
@@ -1,11 +1,5 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-/* eslint-disable max-len */
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {validateLoader} from 'test/common/conformance';
-
 import {TerrainLoader, QuantizedMeshLoader} from '@loaders.gl/terrain';
 import * as terrain from '@loaders.gl/terrain';
 import * as bundledTerrain from '@loaders.gl/terrain/bundled';
@@ -14,39 +8,40 @@ import {setLoaderOptions, load, registerLoaders} from '@loaders.gl/core';
 import {ImageLoader} from '@loaders.gl/images';
 import {validateArrowTableSchema} from '@loaders.gl/arrow';
 import {indexedMeshArrowSchema} from '@loaders.gl/schema';
-
 registerLoaders([ImageLoader]);
-
 const TERRARIUM_TERRAIN_PNG_URL = '@loaders.gl/terrain/test/data/terrarium.png';
 const TILE_WITH_EXTENSIONS_URL = '@loaders.gl/terrain/test/data/tile-with-extensions.terrain';
-
 setLoaderOptions({
   _workerType: 'test'
 });
-
-test('TerrainLoader#loader objects', t => {
-  validateLoader(t, TerrainLoader, 'TerrainLoader');
-  validateLoader(t, QuantizedMeshLoader, 'QuantizedMeshLoader');
-  t.end();
+test('TerrainLoader#loader objects', () => {
+  validateLoader(TerrainLoader, 'TerrainLoader');
+  validateLoader(QuantizedMeshLoader, 'QuantizedMeshLoader');
 });
-
-test('TerrainLoader#removed Arrow loader exports', t => {
-  t.notOk('TerrainArrowLoader' in terrain, 'root does not export TerrainArrowLoader');
-  t.notOk('QuantizedMeshArrowLoader' in terrain, 'root does not export QuantizedMeshArrowLoader');
-  t.notOk('TerrainArrowLoader' in bundledTerrain, 'bundled does not export TerrainArrowLoader');
-  t.notOk(
+test('TerrainLoader#removed Arrow loader exports', () => {
+  expect('TerrainArrowLoader' in terrain, 'root does not export TerrainArrowLoader').toBeFalsy();
+  expect(
+    'QuantizedMeshArrowLoader' in terrain,
+    'root does not export QuantizedMeshArrowLoader'
+  ).toBeFalsy();
+  expect(
+    'TerrainArrowLoader' in bundledTerrain,
+    'bundled does not export TerrainArrowLoader'
+  ).toBeFalsy();
+  expect(
     'QuantizedMeshArrowLoader' in bundledTerrain,
     'bundled does not export QuantizedMeshArrowLoader'
-  );
-  t.notOk('TerrainArrowLoader' in unbundledTerrain, 'unbundled does not export TerrainArrowLoader');
-  t.notOk(
+  ).toBeFalsy();
+  expect(
+    'TerrainArrowLoader' in unbundledTerrain,
+    'unbundled does not export TerrainArrowLoader'
+  ).toBeFalsy();
+  expect(
     'QuantizedMeshArrowLoader' in unbundledTerrain,
     'unbundled does not export QuantizedMeshArrowLoader'
-  );
-  t.end();
+  ).toBeFalsy();
 });
-
-test('TerrainLoader#parse terrarium martini with shape: arrow-table', async t => {
+test('TerrainLoader#parse terrarium martini with shape: arrow-table', async () => {
   const table = await load(TERRARIUM_TERRAIN_PNG_URL, TerrainLoader, {
     worker: false,
     terrain: {
@@ -62,43 +57,35 @@ test('TerrainLoader#parse terrarium martini with shape: arrow-table', async t =>
       shape: 'arrow-table'
     }
   });
-
-  t.equal(table.shape, 'arrow-table', 'table has arrow-table shape');
+  expect(table.shape, 'table has arrow-table shape').toBe('arrow-table');
   validateArrowTableSchema(table.data, indexedMeshArrowSchema, {
     schemaName: 'TerrainLoader IndexedMesh table'
   });
-  t.equal(getArrowTableRowCount(table), 5696, 'table has one row per vertex');
-  t.ok(table.data.getChild('POSITION'), 'POSITION column was found');
-  t.ok(table.data.getChild('TEXCOORD_0'), 'TEXCOORD_0 column was found');
+  expect(getArrowTableRowCount(table), 'table has one row per vertex').toBe(5696);
+  expect(table.data.getChild('POSITION'), 'POSITION column was found').toBeTruthy();
+  expect(table.data.getChild('TEXCOORD_0'), 'TEXCOORD_0 column was found').toBeTruthy();
   const indicesColumn = table.data.getChild('indices');
-  t.ok(indicesColumn, 'indices column was found');
-  t.equal(indicesColumn.get(0).length, 11188 * 3, 'indices were found in row 0');
-  t.equal(indicesColumn.get(1), null, 'indices are null after row 0');
-
-  t.end();
+  expect(indicesColumn, 'indices column was found').toBeTruthy();
+  expect(indicesColumn.get(0).length, 'indices were found in row 0').toBe(11188 * 3);
+  expect(indicesColumn.get(1), 'indices are null after row 0').toBe(null);
 });
-
-test('QuantizedMeshLoader#parse tile-with-extensions with shape: arrow-table', async t => {
+test('QuantizedMeshLoader#parse tile-with-extensions with shape: arrow-table', async () => {
   const table = await load(TILE_WITH_EXTENSIONS_URL, QuantizedMeshLoader, {
     worker: false,
     'quantized-mesh': {shape: 'arrow-table'}
   });
-
-  t.equal(table.shape, 'arrow-table', 'table has arrow-table shape');
+  expect(table.shape, 'table has arrow-table shape').toBe('arrow-table');
   validateArrowTableSchema(table.data, indexedMeshArrowSchema, {
     schemaName: 'QuantizedMeshLoader IndexedMesh table'
   });
-  t.equal(getArrowTableRowCount(table), 627, 'table has one row per vertex');
-  t.ok(table.data.getChild('POSITION'), 'POSITION column was found');
-  t.ok(table.data.getChild('TEXCOORD_0'), 'TEXCOORD_0 column was found');
+  expect(getArrowTableRowCount(table), 'table has one row per vertex').toBe(627);
+  expect(table.data.getChild('POSITION'), 'POSITION column was found').toBeTruthy();
+  expect(table.data.getChild('TEXCOORD_0'), 'TEXCOORD_0 column was found').toBeTruthy();
   const indicesColumn = table.data.getChild('indices');
-  t.ok(indicesColumn, 'indices column was found');
-  t.equal(indicesColumn.get(0).length, 1175 * 3, 'indices were found in row 0');
-  t.equal(indicesColumn.get(1), null, 'indices are null after row 0');
-
-  t.end();
+  expect(indicesColumn, 'indices column was found').toBeTruthy();
+  expect(indicesColumn.get(0).length, 'indices were found in row 0').toBe(1175 * 3);
+  expect(indicesColumn.get(1), 'indices are null after row 0').toBe(null);
 });
-
 function getArrowTableRowCount(table) {
   const positionColumn =
     typeof table.data.getChild === 'function' ? table.data.getChild('POSITION') : undefined;

--- a/modules/terrain/test/terrain-loader.spec.js
+++ b/modules/terrain/test/terrain-loader.spec.js
@@ -1,32 +1,20 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-/* eslint-disable max-len */
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {validateLoader, validateMeshCategoryData} from 'test/common/conformance';
-
 import {TerrainLoader, TerrainWorkerLoader} from '@loaders.gl/terrain';
 import {setLoaderOptions, load, registerLoaders} from '@loaders.gl/core';
-
 // Should be possible to remove this
 import {ImageBitmapLoader} from '@loaders.gl/images';
 registerLoaders([ImageBitmapLoader]);
-
 const MAPBOX_TERRAIN_PNG_URL = '@loaders.gl/terrain/test/data/mapbox.png';
 const TERRARIUM_TERRAIN_PNG_URL = '@loaders.gl/terrain/test/data/terrarium.png';
-
 setLoaderOptions({
   _workerType: 'test'
 });
-
-test('TerrainLoader#loader objects', async t => {
-  validateLoader(t, TerrainLoader, 'TerrainLoader');
-  validateLoader(t, TerrainWorkerLoader, 'TerrainWorkerLoader');
-  t.end();
+test('TerrainLoader#loader objects', async () => {
+  validateLoader(TerrainLoader, 'TerrainLoader');
+  validateLoader(TerrainWorkerLoader, 'TerrainWorkerLoader');
 });
-
-test('TerrainLoader#parse mapbox martini', async t => {
+test('TerrainLoader#parse mapbox martini', async () => {
   const data = await load(MAPBOX_TERRAIN_PNG_URL, TerrainLoader, {
     terrain: {
       elevationDecoder: {
@@ -41,23 +29,16 @@ test('TerrainLoader#parse mapbox martini', async t => {
     },
     core: {worker: false}
   });
-  validateMeshCategoryData(t, data); // TODO: should there be a validateMeshCategoryData?
-
-  t.equal(data.mode, 4, 'mode is TRIANGLES (4)');
-
-  t.equal(data.indices.value.length, 103770 * 3, 'indices was found');
-  t.equal(data.indices.size, 1, 'indices was found');
-
-  t.equal(data.attributes.TEXCOORD_0.value.length, 52302 * 2, 'TEXCOORD_0 attribute was found');
-  t.equal(data.attributes.TEXCOORD_0.size, 2, 'TEXCOORD_0 attribute was found');
-
-  t.equal(data.attributes.POSITION.value.length, 52302 * 3, 'POSITION attribute was found');
-  t.equal(data.attributes.POSITION.size, 3, 'POSITION attribute was found');
-
-  t.end();
+  validateMeshCategoryData(data); // TODO: should there be a validateMeshCategoryData?
+  expect(data.mode, 'mode is TRIANGLES (4)').toBe(4);
+  expect(data.indices.value.length, 'indices was found').toBe(103770 * 3);
+  expect(data.indices.size, 'indices was found').toBe(1);
+  expect(data.attributes.TEXCOORD_0.value.length, 'TEXCOORD_0 attribute was found').toBe(52302 * 2);
+  expect(data.attributes.TEXCOORD_0.size, 'TEXCOORD_0 attribute was found').toBe(2);
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(52302 * 3);
+  expect(data.attributes.POSITION.size, 'POSITION attribute was found').toBe(3);
 });
-
-test('TerrainLoader#add skirt to mapbox martini', async t => {
+test('TerrainLoader#add skirt to mapbox martini', async () => {
   const data = await load(MAPBOX_TERRAIN_PNG_URL, TerrainLoader, {
     terrain: {
       elevationDecoder: {
@@ -72,13 +53,11 @@ test('TerrainLoader#add skirt to mapbox martini', async t => {
       skirtHeight: 50
     }
   });
-  t.equal(data.indices.value.length, 105434 * 3, 'indices was found');
-  t.equal(data.attributes.TEXCOORD_0.value.length, 53966 * 2, 'TEXCOORD_0 attribute was found');
-  t.equal(data.attributes.POSITION.value.length, 53966 * 3, 'POSITION attribute was found');
-  t.end();
+  expect(data.indices.value.length, 'indices was found').toBe(105434 * 3);
+  expect(data.attributes.TEXCOORD_0.value.length, 'TEXCOORD_0 attribute was found').toBe(53966 * 2);
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(53966 * 3);
 });
-
-test('TerrainLoader#parse terrarium martini', async t => {
+test('TerrainLoader#parse terrarium martini', async () => {
   const data = await load(TERRARIUM_TERRAIN_PNG_URL, TerrainLoader, {
     terrain: {
       elevationDecoder: {
@@ -92,23 +71,16 @@ test('TerrainLoader#parse terrarium martini', async t => {
       tesselator: 'martini'
     }
   });
-  validateMeshCategoryData(t, data); // TODO: should there be a validateMeshCategoryData?
-
-  t.equal(data.mode, 4, 'mode is TRIANGLES (4)');
-
-  t.equal(data.indices.value.length, 11188 * 3, 'indices was found');
-  t.equal(data.indices.size, 1, 'indices was found');
-
-  t.equal(data.attributes.TEXCOORD_0.value.length, 5696 * 2, 'TEXCOORD_0 attribute was found');
-  t.equal(data.attributes.TEXCOORD_0.size, 2, 'TEXCOORD_0 attribute was found');
-
-  t.equal(data.attributes.POSITION.value.length, 5696 * 3, 'POSITION attribute was found');
-  t.equal(data.attributes.POSITION.size, 3, 'POSITION attribute was found');
-
-  t.end();
+  validateMeshCategoryData(data); // TODO: should there be a validateMeshCategoryData?
+  expect(data.mode, 'mode is TRIANGLES (4)').toBe(4);
+  expect(data.indices.value.length, 'indices was found').toBe(11188 * 3);
+  expect(data.indices.size, 'indices was found').toBe(1);
+  expect(data.attributes.TEXCOORD_0.value.length, 'TEXCOORD_0 attribute was found').toBe(5696 * 2);
+  expect(data.attributes.TEXCOORD_0.size, 'TEXCOORD_0 attribute was found').toBe(2);
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(5696 * 3);
+  expect(data.attributes.POSITION.size, 'POSITION attribute was found').toBe(3);
 });
-
-test('TerrainLoader#parse mapbox delatin', async t => {
+test('TerrainLoader#parse mapbox delatin', async () => {
   const data = await load(MAPBOX_TERRAIN_PNG_URL, TerrainLoader, {
     terrain: {
       elevationDecoder: {
@@ -122,23 +94,16 @@ test('TerrainLoader#parse mapbox delatin', async t => {
       tesselator: 'delatin'
     }
   });
-  validateMeshCategoryData(t, data); // TODO: should there be a validateMeshCategoryData?
-
-  t.equal(data.mode, 4, 'mode is TRIANGLES (4)');
-
-  t.equal(data.indices.value.length, 90245 * 3, 'indices was found');
-  t.equal(data.indices.size, 1, 'indices was found');
-
-  t.equal(data.attributes.TEXCOORD_0.value.length, 45298 * 2, 'TEXCOORD_0 attribute was found');
-  t.equal(data.attributes.TEXCOORD_0.size, 2, 'TEXCOORD_0 attribute was found');
-
-  t.equal(data.attributes.POSITION.value.length, 45298 * 3, 'POSITION attribute was found');
-  t.equal(data.attributes.POSITION.size, 3, 'POSITION attribute was found');
-
-  t.end();
+  validateMeshCategoryData(data); // TODO: should there be a validateMeshCategoryData?
+  expect(data.mode, 'mode is TRIANGLES (4)').toBe(4);
+  expect(data.indices.value.length, 'indices was found').toBe(90245 * 3);
+  expect(data.indices.size, 'indices was found').toBe(1);
+  expect(data.attributes.TEXCOORD_0.value.length, 'TEXCOORD_0 attribute was found').toBe(45298 * 2);
+  expect(data.attributes.TEXCOORD_0.size, 'TEXCOORD_0 attribute was found').toBe(2);
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(45298 * 3);
+  expect(data.attributes.POSITION.size, 'POSITION attribute was found').toBe(3);
 });
-
-test('TerrainLoader#add skirt to mapbox delatin', async t => {
+test('TerrainLoader#add skirt to mapbox delatin', async () => {
   const data = await load(MAPBOX_TERRAIN_PNG_URL, TerrainLoader, {
     terrain: {
       elevationDecoder: {
@@ -153,13 +118,11 @@ test('TerrainLoader#add skirt to mapbox delatin', async t => {
       skirtHeight: 50
     }
   });
-  t.equal(data.indices.value.length, 90943 * 3, 'indices was found');
-  t.equal(data.attributes.TEXCOORD_0.value.length, 45996 * 2, 'TEXCOORD_0 attribute was found');
-  t.equal(data.attributes.POSITION.value.length, 45996 * 3, 'POSITION attribute was found');
-  t.end();
+  expect(data.indices.value.length, 'indices was found').toBe(90943 * 3);
+  expect(data.attributes.TEXCOORD_0.value.length, 'TEXCOORD_0 attribute was found').toBe(45996 * 2);
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(45996 * 3);
 });
-
-test('TerrainLoader#parse terrarium delatin', async t => {
+test('TerrainLoader#parse terrarium delatin', async () => {
   const data = await load(TERRARIUM_TERRAIN_PNG_URL, TerrainLoader, {
     terrain: {
       elevationDecoder: {
@@ -173,30 +136,20 @@ test('TerrainLoader#parse terrarium delatin', async t => {
       tesselator: 'delatin'
     }
   });
-
-  validateMeshCategoryData(t, data); // TODO: should there be a validateMeshCategoryData?
-
-  t.equal(data.mode, 4, 'mode is TRIANGLES (4)');
-
-  t.equal(data.indices.value.length, 6082 * 3, 'indices was found');
-  t.equal(data.indices.size, 1, 'indices was found');
-
-  t.equal(data.attributes.TEXCOORD_0.value.length, 3071 * 2, 'TEXCOORD_0 attribute was found');
-  t.equal(data.attributes.TEXCOORD_0.size, 2, 'TEXCOORD_0 attribute was found');
-
-  t.equal(data.attributes.POSITION.value.length, 3071 * 3, 'POSITION attribute was found');
-  t.equal(data.attributes.POSITION.size, 3, 'POSITION attribute was found');
-
-  t.end();
+  validateMeshCategoryData(data); // TODO: should there be a validateMeshCategoryData?
+  expect(data.mode, 'mode is TRIANGLES (4)').toBe(4);
+  expect(data.indices.value.length, 'indices was found').toBe(6082 * 3);
+  expect(data.indices.size, 'indices was found').toBe(1);
+  expect(data.attributes.TEXCOORD_0.value.length, 'TEXCOORD_0 attribute was found').toBe(3071 * 2);
+  expect(data.attributes.TEXCOORD_0.size, 'TEXCOORD_0 attribute was found').toBe(2);
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(3071 * 3);
+  expect(data.attributes.POSITION.size, 'POSITION attribute was found').toBe(3);
 });
-
-test('TerrainWorkerLoader#parse terrarium martini', async t => {
+test('TerrainWorkerLoader#parse terrarium martini', async () => {
   if (typeof Worker === 'undefined') {
-    t.comment('Worker is not usable in non-browser environments');
-    t.end();
+    console.log('Worker is not usable in non-browser environments');
     return;
   }
-
   const data = await load(TERRARIUM_TERRAIN_PNG_URL, TerrainWorkerLoader, {
     terrain: {
       elevationDecoder: {
@@ -210,29 +163,20 @@ test('TerrainWorkerLoader#parse terrarium martini', async t => {
       tesselator: 'martini'
     }
   });
-  validateMeshCategoryData(t, data); // TODO: should there be a validateMeshCategoryData?
-
-  t.equal(data.mode, 4, 'mode is TRIANGLES (4)');
-
-  t.equal(data.indices?.value.length, 11188 * 3, 'indices was found');
-  t.equal(data.indices?.size, 1, 'indices was found');
-
-  t.equal(data.attributes.TEXCOORD_0.value.length, 5696 * 2, 'TEXCOORD_0 attribute was found');
-  t.equal(data.attributes.TEXCOORD_0.size, 2, 'TEXCOORD_0 attribute was found');
-
-  t.equal(data.attributes.POSITION.value.length, 5696 * 3, 'POSITION attribute was found');
-  t.equal(data.attributes.POSITION.size, 3, 'POSITION attribute was found');
-
-  t.end();
+  validateMeshCategoryData(data); // TODO: should there be a validateMeshCategoryData?
+  expect(data.mode, 'mode is TRIANGLES (4)').toBe(4);
+  expect(data.indices?.value.length, 'indices was found').toBe(11188 * 3);
+  expect(data.indices?.size, 'indices was found').toBe(1);
+  expect(data.attributes.TEXCOORD_0.value.length, 'TEXCOORD_0 attribute was found').toBe(5696 * 2);
+  expect(data.attributes.TEXCOORD_0.size, 'TEXCOORD_0 attribute was found').toBe(2);
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(5696 * 3);
+  expect(data.attributes.POSITION.size, 'POSITION attribute was found').toBe(3);
 });
-
-test('TerrainWorkerLoader#parse terrarium delatin', async t => {
+test('TerrainWorkerLoader#parse terrarium delatin', async () => {
   if (typeof Worker === 'undefined') {
-    t.comment('Worker is not usable in non-browser environments');
-    t.end();
+    console.log('Worker is not usable in non-browser environments');
     return;
   }
-
   const data = await load(TERRARIUM_TERRAIN_PNG_URL, TerrainWorkerLoader, {
     terrain: {
       elevationDecoder: {
@@ -246,19 +190,12 @@ test('TerrainWorkerLoader#parse terrarium delatin', async t => {
       tesselator: 'delatin'
     }
   });
-
-  validateMeshCategoryData(t, data); // TODO: should there be a validateMeshCategoryData?
-
-  t.equal(data.mode, 4, 'mode is TRIANGLES (4)');
-
-  t.equal(data.indices?.value.length, 6082 * 3, 'indices was found');
-  t.equal(data.indices?.size, 1, 'indices was found');
-
-  t.equal(data.attributes.TEXCOORD_0.value.length, 3071 * 2, 'TEXCOORD_0 attribute was found');
-  t.equal(data.attributes.TEXCOORD_0.size, 2, 'TEXCOORD_0 attribute was found');
-
-  t.equal(data.attributes.POSITION.value.length, 3071 * 3, 'POSITION attribute was found');
-  t.equal(data.attributes.POSITION.size, 3, 'POSITION attribute was found');
-
-  t.end();
+  validateMeshCategoryData(data); // TODO: should there be a validateMeshCategoryData?
+  expect(data.mode, 'mode is TRIANGLES (4)').toBe(4);
+  expect(data.indices?.value.length, 'indices was found').toBe(6082 * 3);
+  expect(data.indices?.size, 'indices was found').toBe(1);
+  expect(data.attributes.TEXCOORD_0.value.length, 'TEXCOORD_0 attribute was found').toBe(3071 * 2);
+  expect(data.attributes.TEXCOORD_0.size, 'TEXCOORD_0 attribute was found').toBe(2);
+  expect(data.attributes.POSITION.value.length, 'POSITION attribute was found').toBe(3071 * 3);
+  expect(data.attributes.POSITION.size, 'POSITION attribute was found').toBe(3);
 });

--- a/modules/tiles/test/image-set.spec.ts
+++ b/modules/tiles/test/image-set.spec.ts
@@ -1,10 +1,5 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {ImageSet} from '@loaders.gl/tiles';
-
 function createImageSource() {
   return {
     async getMetadata() {
@@ -19,20 +14,14 @@ function createImageSource() {
     }
   };
 }
-
-test('ImageSet#loads metadata from ImageSource', async t => {
+test('ImageSet#loads metadata from ImageSource', async () => {
   const imageSet = ImageSet.fromImageSource(createImageSource() as any);
-
   const metadata = await imageSet.loadMetadata();
-
-  t.equal(metadata.name, 'test');
-  t.equal(imageSet.metadata?.name, 'test');
-
+  expect(metadata.name).toBe('test');
+  expect(imageSet.metadata?.name).toBe('test');
   imageSet.finalize();
-  t.end();
 });
-
-test('ImageSet#accepts the latest completed request', async t => {
+test('ImageSet#accepts the latest completed request', async () => {
   let resolveFirst;
   let resolveSecond;
   const imageSet = new ImageSet({
@@ -49,7 +38,6 @@ test('ImageSet#accepts the latest completed request', async t => {
       }) as Promise<any>;
     }
   });
-
   imageSet.requestImage({
     layers: [],
     boundingBox: [
@@ -68,20 +56,15 @@ test('ImageSet#accepts the latest completed request', async t => {
     width: 2,
     height: 2
   });
-
   resolveSecond?.();
   await new Promise(resolve => setTimeout(resolve, 0));
   resolveFirst?.();
   await new Promise(resolve => setTimeout(resolve, 0));
-
-  t.equal((imageSet.image as any)?.name, 'second');
-  t.equal(imageSet.currentRequest?.requestId, 1);
-
+  expect((imageSet.image as any)?.name).toBe('second');
+  expect(imageSet.currentRequest?.requestId).toBe(1);
   imageSet.finalize();
-  t.end();
 });
-
-test('ImageSet#emits metadata and image errors', async t => {
+test('ImageSet#emits metadata and image errors', async () => {
   const metadataErrors: string[] = [];
   const imageErrors: string[] = [];
   let metadataFailed = true;
@@ -100,12 +83,10 @@ test('ImageSet#emits metadata and image errors', async t => {
       return {name: 'image'} as any;
     }
   });
-
   imageSet.subscribe({
     onMetadataLoadError: error => metadataErrors.push(error.message),
     onImageLoadError: (_requestId, error) => imageErrors.push(error.message)
   });
-
   await imageSet.loadMetadata().catch(() => {});
   imageSet.requestImage({
     layers: [],
@@ -117,7 +98,6 @@ test('ImageSet#emits metadata and image errors', async t => {
     height: 1
   });
   await new Promise(resolve => setTimeout(resolve, 0));
-
   metadataFailed = false;
   imageFailed = false;
   await imageSet.loadMetadata();
@@ -131,17 +111,13 @@ test('ImageSet#emits metadata and image errors', async t => {
     height: 2
   });
   await new Promise(resolve => setTimeout(resolve, 0));
-
-  t.deepEqual(metadataErrors, ['metadata boom']);
-  t.deepEqual(imageErrors, ['image boom']);
-  t.equal(imageSet.metadata?.name, 'test');
-  t.equal((imageSet.image as any)?.name, 'image');
-
+  expect(metadataErrors).toEqual(['metadata boom']);
+  expect(imageErrors).toEqual(['image boom']);
+  expect(imageSet.metadata?.name).toBe('test');
+  expect((imageSet.image as any)?.name).toBe('image');
   imageSet.finalize();
-  t.end();
 });
-
-test('ImageSet#debounces image requests', async t => {
+test('ImageSet#debounces image requests', async () => {
   const calls: number[] = [];
   const imageSet = new ImageSet({
     debounceTime: 5,
@@ -153,7 +129,6 @@ test('ImageSet#debounces image requests', async t => {
       return {width: parameters.width} as any;
     }
   });
-
   imageSet.requestImage({
     layers: [],
     boundingBox: [
@@ -172,17 +147,12 @@ test('ImageSet#debounces image requests', async t => {
     width: 2,
     height: 2
   });
-
   await new Promise(resolve => setTimeout(resolve, 20));
-
-  t.deepEqual(calls, [2]);
-  t.equal((imageSet.image as any)?.width, 2);
-
+  expect(calls).toEqual([2]);
+  expect((imageSet.image as any)?.width).toBe(2);
   imageSet.finalize();
-  t.end();
 });
-
-test('ImageSet#emits loading state changes', async t => {
+test('ImageSet#emits loading state changes', async () => {
   let resolveImage;
   const loadingStates: boolean[] = [];
   const imageSet = new ImageSet({
@@ -195,11 +165,9 @@ test('ImageSet#emits loading state changes', async t => {
       }) as Promise<any>;
     }
   });
-
   imageSet.subscribe({
     onLoadingStateChange: isLoading => loadingStates.push(isLoading)
   });
-
   imageSet.requestImage({
     layers: [],
     boundingBox: [
@@ -212,9 +180,6 @@ test('ImageSet#emits loading state changes', async t => {
   await new Promise(resolve => setTimeout(resolve, 0));
   resolveImage?.();
   await new Promise(resolve => setTimeout(resolve, 0));
-
-  t.deepEqual(loadingStates, [true, false]);
-
+  expect(loadingStates).toEqual([true, false]);
   imageSet.finalize();
-  t.end();
 });

--- a/modules/tiles/test/point-cloud/point-cloud-tileset.spec.ts
+++ b/modules/tiles/test/point-cloud/point-cloud-tileset.spec.ts
@@ -1,18 +1,12 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import type {DataSourceOptions} from '@loaders.gl/loader-utils';
 import {DataSource} from '@loaders.gl/loader-utils';
 import type {MeshArrowTable} from '@loaders.gl/schema';
 import {PointCloudTileset} from '@loaders.gl/tiles';
-
 type Deferred<T> = {
   promise: Promise<T>;
   resolve: (value: T) => void;
 };
-
 type TileHeader = {
   id: string;
   level: number;
@@ -24,7 +18,6 @@ type TileHeader = {
     radius: number;
   };
 };
-
 type TileHeaderOptions = {
   id: string;
   level: number;
@@ -32,20 +25,16 @@ type TileHeaderOptions = {
   geometricError: number;
   bounds: [number[], number[]];
 };
-
 function createDeferred<T>(): Deferred<T> {
   let resolve!: (value: T) => void;
   const promise = new Promise<T>(resolveValue => {
     resolve = resolveValue;
   });
-
   return {promise, resolve};
 }
-
 class TestPointCloudSource extends DataSource<string, DataSourceOptions> {
   isReady = false;
   getChildrenCallIds: string[] = [];
-
   private readonly rootTile: TileHeader = createTileHeader({
     id: 'root',
     level: 0,
@@ -84,39 +73,31 @@ class TestPointCloudSource extends DataSource<string, DataSourceOptions> {
     left: createDeferred<any>(),
     right: createDeferred<any>()
   };
-
   constructor() {
     super('test://pointcloud', {});
   }
-
   async initialize(): Promise<void> {
     this.isReady = true;
   }
-
   async getRootTile(): Promise<TileHeader> {
     return this.rootTile;
   }
-
   async getChildren(tile: TileHeader): Promise<TileHeader[]> {
     this.getChildrenCallIds.push(tile.id);
     return this.childTiles[tile.id] || [];
   }
-
   async loadTileContent(tile: TileHeader) {
     if (tile.id === 'root') {
       return null;
     }
-
     return await this.deferredContent[tile.id].promise;
   }
-
   getViewState() {
     return {
       boundingVolume: this.rootTile.boundingVolume,
       cartographicCenter: this.rootTile.boundingVolume.center
     };
   }
-
   resolveTile(tileId: 'left' | 'right') {
     this.deferredContent[tileId].resolve({
       data: {shape: 'arrow-table'} as MeshArrowTable,
@@ -126,7 +107,6 @@ class TestPointCloudSource extends DataSource<string, DataSourceOptions> {
     });
   }
 }
-
 function createTileHeader({
   id,
   level,
@@ -139,7 +119,6 @@ function createTileHeader({
     (minBounds[1] + maxBounds[1]) / 2,
     (minBounds[2] + maxBounds[2]) / 2
   ];
-
   return {
     id,
     level,
@@ -152,7 +131,6 @@ function createTileHeader({
     }
   };
 }
-
 function createViewport(scale = 4) {
   return {
     id: 'main',
@@ -161,7 +139,6 @@ function createViewport(scale = 4) {
     project: ([longitude, latitude]) => [longitude * scale, latitude * scale]
   } as any;
 }
-
 function createFrustumViewport(scale = 4) {
   return {
     ...createViewport(scale),
@@ -176,8 +153,7 @@ function createFrustumViewport(scale = 4) {
     })
   } as any;
 }
-
-test('PointCloudTileset#selectTiles refines visible tiles by projected node size', async t => {
+test('PointCloudTileset#selectTiles refines visible tiles by projected node size', async () => {
   const source = new TestPointCloudSource();
   let tileLoadCount = 0;
   const tileset = new PointCloudTileset(source as any, {
@@ -185,61 +161,48 @@ test('PointCloudTileset#selectTiles refines visible tiles by projected node size
       tileLoadCount++;
     }
   });
-
   const frameNumber = await tileset.selectTiles(createViewport());
-
-  t.equal(frameNumber, 1, 'frame number increments after traversal');
-  t.equal(tileset.frameNumber, 1, 'tileset frame number is updated');
-  t.equal(tileset.tiles.length, 3, 'all discovered tiles are tracked');
-  t.deepEqual(
+  expect(frameNumber, 'frame number increments after traversal').toBe(1);
+  expect(tileset.frameNumber, 'tileset frame number is updated').toBe(1);
+  expect(tileset.tiles.length, 'all discovered tiles are tracked').toBe(3);
+  expect(
     tileset.selectedTiles.map(tile => tile.id).sort(),
-    ['left', 'right', 'root'],
     'point-cloud traversal keeps parent and child tiles selected when the root is large enough'
-  );
-  t.equal(tileset.isLoaded(), false, 'selected tiles are not loaded before content resolves');
-
+  ).toEqual(['left', 'right', 'root']);
+  expect(tileset.isLoaded(), 'selected tiles are not loaded before content resolves').toBe(false);
   source.resolveTile('left');
   source.resolveTile('right');
   await new Promise(resolve => setTimeout(resolve, 0));
-
-  t.equal(tileLoadCount, 2, 'tile load callback fires for loaded child tiles');
-  t.equal(tileset.isLoaded(), true, 'tileset reports loaded after selected content resolves');
-  t.end();
+  expect(tileLoadCount, 'tile load callback fires for loaded child tiles').toBe(2);
+  expect(tileset.isLoaded(), 'tileset reports loaded after selected content resolves').toBe(true);
 });
-
-test('PointCloudTileset#selectTiles culls tiles outside the viewport frustum', async t => {
+test('PointCloudTileset#selectTiles culls tiles outside the viewport frustum', async () => {
   const source = new TestPointCloudSource();
   const tileset = new PointCloudTileset(source as any);
-
   await tileset.selectTiles(createFrustumViewport());
-
-  t.deepEqual(
+  expect(
     tileset.selectedTiles.map(tile => tile.id).sort(),
-    ['left', 'root'],
     'right child is culled by the frustum even though its projected footprint overlaps the viewport'
+  ).toEqual(['left', 'root']);
+  expect(tileset.visibleTilesCount, 'only frustum-intersecting tiles are counted as visible').toBe(
+    2
   );
-  t.equal(tileset.visibleTilesCount, 2, 'only frustum-intersecting tiles are counted as visible');
-  t.end();
 });
-
-test('PointCloudTileset#selectTiles keeps coarse tiles when zoomed out', async t => {
+test('PointCloudTileset#selectTiles keeps coarse tiles when zoomed out', async () => {
   const source = new TestPointCloudSource();
   const tileset = new PointCloudTileset(source as any);
-
   await tileset.selectTiles(createViewport(0.4));
-
-  t.equal(tileset.visibleTilesCount, 1, 'only the root is visible at low projected size');
-  t.deepEqual(
+  expect(tileset.visibleTilesCount, 'only the root is visible at low projected size').toBe(1);
+  expect(
     tileset.selectedTiles.map(tile => tile.id),
-    ['root'],
     'only the root tile is selected when its projected radius is below the minimum'
+  ).toEqual(['root']);
+  expect(source.getChildrenCallIds, 'children are not requested below minimum node size').toEqual(
+    []
   );
-  t.deepEqual(source.getChildrenCallIds, [], 'children are not requested below minimum node size');
-  t.equal(tileset.tiles.length, 1, 'children are not discovered below minimum node size');
-  t.end();
+  expect(tileset.tiles.length, 'children are not discovered below minimum node size').toBe(1);
 });
-
-test('PointCloudTileset#density refinement increases as projected density falls', t => {
+test('PointCloudTileset#density refinement increases as projected density falls', () => {
   const source = new TestPointCloudSource();
   const tileset = new PointCloudTileset(source as any);
   const tile = {
@@ -249,59 +212,50 @@ test('PointCloudTileset#density refinement increases as projected density falls'
   };
   const shouldRefine = (tileset as any).shouldRefine.bind(tileset);
 
-  t.equal(shouldRefine(tile, 100), true, 'a large nearby footprint refines when density is low');
-  t.equal(shouldRefine(tile, 1), false, 'a compact distant footprint remains coarse');
-  t.end();
+  expect(
+    shouldRefine(tile, 100),
+    'a large nearby footprint refines when density is low'
+  ).toBe(true);
+  expect(shouldRefine(tile, 1), 'a compact distant footprint remains coarse').toBe(false);
 });
 
-test('PointCloudTileset#selectTiles respects point budget', async t => {
+test('PointCloudTileset#selectTiles respects point budget', async () => {
   const source = new TestPointCloudSource();
   const tileset = new PointCloudTileset(source as any, {
     pointBudget: 120
   });
-
   await tileset.selectTiles(createViewport());
-
-  t.deepEqual(
+  expect(
     tileset.selectedTiles.map(tile => tile.id),
-    ['root'],
     'child selection stops before exceeding the point budget'
-  );
-  t.deepEqual(source.getChildrenCallIds, ['root'], 'children are inspected after root refinement');
-  t.end();
+  ).toEqual(['root']);
+  expect(source.getChildrenCallIds, 'children are inspected after root refinement').toEqual([
+    'root'
+  ]);
 });
-
-test('PointCloudTileset#selectTiles respects maxDepth', async t => {
+test('PointCloudTileset#selectTiles respects maxDepth', async () => {
   const source = new TestPointCloudSource();
   const tileset = new PointCloudTileset(source as any, {
     maxDepth: 0
   });
-
   await tileset.selectTiles(createViewport());
-
-  t.deepEqual(
+  expect(
     tileset.selectedTiles.map(tile => tile.id),
-    ['root'],
     'child selection stops at maxDepth'
-  );
-  t.deepEqual(source.getChildrenCallIds, [], 'children are not requested at maxDepth');
-  t.end();
+  ).toEqual(['root']);
+  expect(source.getChildrenCallIds, 'children are not requested at maxDepth').toEqual([]);
 });
-
-test('PointCloudTileset#debounces repeated traversal requests', async t => {
+test('PointCloudTileset#debounces repeated traversal requests', async () => {
   const source = new TestPointCloudSource();
   const tileset = new PointCloudTileset(source as any, {
     debounceTime: 10
   });
-
   const firstPromise = tileset.selectTiles(createViewport());
   const secondPromise = tileset.selectTiles(createViewport());
   source.resolveTile('left');
   source.resolveTile('right');
-
   const [firstFrame, secondFrame] = await Promise.all([firstPromise, secondPromise]);
-  t.equal(firstFrame, 1, 'first traversal resolves once');
-  t.equal(secondFrame, 1, 'second traversal resolves to the same debounced frame');
-  t.equal(tileset.frameNumber, 1, 'only one traversal was executed');
-  t.end();
+  expect(firstFrame, 'first traversal resolves once').toBe(1);
+  expect(secondFrame, 'second traversal resolves to the same debounced frame').toBe(1);
+  expect(tileset.frameNumber, 'only one traversal was executed').toBe(1);
 });

--- a/modules/tiles/test/point-cloud/point-cloud-tileset.spec.ts
+++ b/modules/tiles/test/point-cloud/point-cloud-tileset.spec.ts
@@ -212,10 +212,9 @@ test('PointCloudTileset#density refinement increases as projected density falls'
   };
   const shouldRefine = (tileset as any).shouldRefine.bind(tileset);
 
-  expect(
-    shouldRefine(tile, 100),
-    'a large nearby footprint refines when density is low'
-  ).toBe(true);
+  expect(shouldRefine(tile, 100), 'a large nearby footprint refines when density is low').toBe(
+    true
+  );
   expect(shouldRefine(tile, 1), 'a compact distant footprint remains coarse').toBe(false);
 });
 

--- a/modules/tiles/test/raster-set.spec.ts
+++ b/modules/tiles/test/raster-set.spec.ts
@@ -1,10 +1,5 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {RasterSet} from '@loaders.gl/tiles';
-
 function createRasterSource() {
   return {
     async getMetadata() {
@@ -27,7 +22,6 @@ function createRasterSource() {
     }
   };
 }
-
 function createViewport(width = 2, height = 1) {
   return {
     id: `${width}x${height}`,
@@ -43,21 +37,15 @@ function createViewport(width = 2, height = 1) {
     unprojectPosition: (position: number[]) => [position[0], position[1], position[2] || 0]
   };
 }
-
-test('RasterSet#loads metadata from RasterSource', async t => {
+test('RasterSet#loads metadata from RasterSource', async () => {
   const rasterSet = RasterSet.fromRasterSource(createRasterSource() as any);
-
   const metadata = await rasterSet.loadMetadata();
-
-  t.equal(metadata.name, 'test');
-  t.equal(metadata.dtype, 'uint16');
-  t.equal(rasterSet.metadata?.bandCount, 1);
-
+  expect(metadata.name).toBe('test');
+  expect(metadata.dtype).toBe('uint16');
+  expect(rasterSet.metadata?.bandCount).toBe(1);
   rasterSet.finalize();
-  t.end();
 });
-
-test('RasterSet#accepts the latest completed request', async t => {
+test('RasterSet#accepts the latest completed request', async () => {
   let resolveFirst;
   let resolveSecond;
   const rasterSet = new RasterSet({
@@ -88,23 +76,17 @@ test('RasterSet#accepts the latest completed request', async t => {
       }) as Promise<any>;
     }
   });
-
   rasterSet.requestRaster({viewport: createViewport(1, 1)});
   rasterSet.requestRaster({viewport: createViewport(2, 2)});
-
   resolveSecond?.();
   await new Promise(resolve => setTimeout(resolve, 0));
   resolveFirst?.();
   await new Promise(resolve => setTimeout(resolve, 0));
-
-  t.equal(rasterSet.raster?.width, 2);
-  t.equal(rasterSet.currentRequest?.requestId, 1);
-
+  expect(rasterSet.raster?.width).toBe(2);
+  expect(rasterSet.currentRequest?.requestId).toBe(1);
   rasterSet.finalize();
-  t.end();
 });
-
-test('RasterSet#emits metadata and raster errors', async t => {
+test('RasterSet#emits metadata and raster errors', async () => {
   const metadataErrors: string[] = [];
   const rasterErrors: string[] = [];
   let metadataFailed = true;
@@ -129,32 +111,25 @@ test('RasterSet#emits metadata and raster errors', async t => {
       } as any;
     }
   });
-
   rasterSet.subscribe({
     onMetadataLoadError: error => metadataErrors.push(error.message),
     onRasterLoadError: (_requestId, error) => rasterErrors.push(error.message)
   });
-
   await rasterSet.loadMetadata().catch(() => {});
   rasterSet.requestRaster({viewport: createViewport(1, 1)});
   await new Promise(resolve => setTimeout(resolve, 0));
-
   metadataFailed = false;
   rasterFailed = false;
   await rasterSet.loadMetadata();
   rasterSet.requestRaster({viewport: createViewport(2, 2)});
   await new Promise(resolve => setTimeout(resolve, 0));
-
-  t.deepEqual(metadataErrors, ['metadata boom']);
-  t.deepEqual(rasterErrors, ['raster boom']);
-  t.equal(rasterSet.metadata?.dtype, 'uint8');
-  t.equal(rasterSet.raster?.width, 2);
-
+  expect(metadataErrors).toEqual(['metadata boom']);
+  expect(rasterErrors).toEqual(['raster boom']);
+  expect(rasterSet.metadata?.dtype).toBe('uint8');
+  expect(rasterSet.raster?.width).toBe(2);
   rasterSet.finalize();
-  t.end();
 });
-
-test('RasterSet#debounces raster requests', async t => {
+test('RasterSet#debounces raster requests', async () => {
   const calls: number[] = [];
   const rasterSet = new RasterSet({
     debounceTime: 5,
@@ -172,20 +147,14 @@ test('RasterSet#debounces raster requests', async t => {
       } as any;
     }
   });
-
   rasterSet.requestRaster({viewport: createViewport(1, 1)});
   rasterSet.requestRaster({viewport: createViewport(2, 2)});
-
   await new Promise(resolve => setTimeout(resolve, 20));
-
-  t.deepEqual(calls, [2]);
-  t.equal(rasterSet.raster?.width, 2);
-
+  expect(calls).toEqual([2]);
+  expect(rasterSet.raster?.width).toBe(2);
   rasterSet.finalize();
-  t.end();
 });
-
-test('RasterSet#emits loading state changes', async t => {
+test('RasterSet#emits loading state changes', async () => {
   let resolveRaster;
   const loadingStates: boolean[] = [];
   const rasterSet = new RasterSet({
@@ -205,23 +174,17 @@ test('RasterSet#emits loading state changes', async t => {
       }) as Promise<any>;
     }
   });
-
   rasterSet.subscribe({
     onLoadingStateChange: isLoading => loadingStates.push(isLoading)
   });
-
   rasterSet.requestRaster({viewport: createViewport(1, 1)});
   await new Promise(resolve => setTimeout(resolve, 0));
   resolveRaster?.();
   await new Promise(resolve => setTimeout(resolve, 0));
-
-  t.deepEqual(loadingStates, [true, false]);
-
+  expect(loadingStates).toEqual([true, false]);
   rasterSet.finalize();
-  t.end();
 });
-
-test('RasterSet#supports custom refetch policies', async t => {
+test('RasterSet#supports custom refetch policies', async () => {
   const calls: number[] = [];
   const rasterSet = new RasterSet({
     shouldRefetch: ({currentRequest, nextParameters}) =>
@@ -240,19 +203,13 @@ test('RasterSet#supports custom refetch policies', async t => {
       } as any;
     }
   });
-
   rasterSet.requestRaster({viewport: createViewport(2, 2)});
   await new Promise(resolve => setTimeout(resolve, 0));
-
-  t.equal(rasterSet.shouldRefetchRaster({viewport: createViewport(2, 2)}), false);
+  expect(rasterSet.shouldRefetchRaster({viewport: createViewport(2, 2)})).toBe(false);
   rasterSet.requestRaster({viewport: createViewport(2, 2)});
   rasterSet.requestRaster({viewport: createViewport(3, 2)});
-
   await new Promise(resolve => setTimeout(resolve, 0));
-
-  t.deepEqual(calls, [2, 3]);
-  t.equal(rasterSet.currentRequest?.parameters.viewport.width, 3);
-
+  expect(calls).toEqual([2, 3]);
+  expect(rasterSet.currentRequest?.parameters.viewport.width).toBe(3);
   rasterSet.finalize();
-  t.end();
 });

--- a/modules/tiles/test/tileset/format-i3s/i3s-lod.spec.ts
+++ b/modules/tiles/test/tileset/format-i3s/i3s-lod.spec.ts
@@ -1,8 +1,4 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {WebMercatorViewport} from '@deck.gl/core';
 import {coreApi} from '@loaders.gl/core';
 import {getI3sTileHeader} from '@loaders.gl/i3s/test/test-utils/load-utils';
@@ -20,93 +16,67 @@ import {
   VIEWPORT_ZOOM_OPTS,
   VIEWPORT_ZOOM_OUT_OPTS
 } from '../../data/viewport-opts-examples';
-
 async function createI3STileset(): Promise<Tileset3D> {
   const tilesetHeader = await getI3sTileHeader();
   tilesetHeader.root = ROOT_TILE_HEADER;
   return new Tileset3D(new I3SSource({...tilesetHeader, coreApi}));
 }
-
-test('I3S LOD#lodJudge - should return "DIG" if lodMetric is 0 or NaN', async t => {
+test('I3S LOD#lodJudge - should return "DIG" if lodMetric is 0 or NaN', async () => {
   const tileset = await createI3STileset();
   const viewport = new WebMercatorViewport(VIEWPORT_DEFAULT);
   const frameState = getFrameState(viewport, 1);
-
   if (tileset.root) {
     const lodResult = getLodStatus(tileset.root, frameState);
-    t.equal(lodResult, 'DIG');
+    expect(lodResult).toBe('DIG');
   }
-
   const tileHeader = getTileHeader();
   tileHeader.lodMetricValue = NaN;
   const tile2 = new Tile3D(tileset, tileHeader);
   const lodResult2 = getLodStatus(tile2, frameState);
-  t.equal(lodResult2, 'DIG');
-
-  t.end();
+  expect(lodResult2).toBe('DIG');
 });
-
-test('I3S LOD#lodJudge - should return "DRAW" if tile size projected on the screen plane less then LOD metric value', async t => {
+test('I3S LOD#lodJudge - should return "DRAW" if tile size projected on the screen plane less then LOD metric value', async () => {
   const tileset = await createI3STileset();
   const viewport = new WebMercatorViewport(VIEWPORT_DEFAULT);
   const frameState = getFrameState(viewport, 1);
-
   const tileHeader = getTileHeader();
   const tile2 = new Tile3D(tileset, tileHeader);
   const lodResult2 = getLodStatus(tile2, frameState);
-  t.equal(lodResult2, 'DRAW');
-
-  t.end();
+  expect(lodResult2).toBe('DRAW');
 });
-
-test('I3S LOD#lodJudge - should return "DIG" when zoom in', async t => {
+test('I3S LOD#lodJudge - should return "DIG" when zoom in', async () => {
   const tileset = await createI3STileset();
   const viewport = new WebMercatorViewport(VIEWPORT_ZOOM_OPTS);
   const frameState = getFrameState(viewport, 1);
-
   const tileHeader = getTileHeader();
   const tile2 = new Tile3D(tileset, tileHeader);
   const lodResult2 = getLodStatus(tile2, frameState);
-  t.equal(lodResult2, 'DIG');
-
-  t.end();
+  expect(lodResult2).toBe('DIG');
 });
-
-test('I3S LOD#lodJudge - should return "DRAW" after rotation', async t => {
+test('I3S LOD#lodJudge - should return "DRAW" after rotation', async () => {
   const tileset = await createI3STileset();
   const viewport = new WebMercatorViewport(VIEWPORT_ROTATED_OPTS);
   const frameState = getFrameState(viewport, 1);
-
   const tileHeader = getTileHeader();
   const tile2 = new Tile3D(tileset, tileHeader);
   const lodResult2 = getLodStatus(tile2, frameState);
-  t.equal(lodResult2, 'DRAW');
-
-  t.end();
+  expect(lodResult2).toBe('DRAW');
 });
-
-test('I3S LOD#lodJudge - should return "OUT" if projected size too small', async t => {
+test('I3S LOD#lodJudge - should return "OUT" if projected size too small', async () => {
   const tileset = await createI3STileset();
   const viewport = new WebMercatorViewport(VIEWPORT_ZOOM_OUT_OPTS);
   const frameState = getFrameState(viewport, 1);
-
   const tileHeader = getNextAfterRootTileHeader();
   const tile2 = new Tile3D(tileset, tileHeader);
   const lodResult2 = getLodStatus(tile2, frameState);
-  t.equal(lodResult2, 'OUT');
-
-  t.end();
+  expect(lodResult2).toBe('OUT');
 });
-
-test('I3S LOD#lodJudge - should return "DIG" in the large LOD metric value case', async t => {
+test('I3S LOD#lodJudge - should return "DIG" in the large LOD metric value case', async () => {
   const tileset = await createI3STileset();
   const viewport = new WebMercatorViewport(VIEWPORT_NEW_YORK_OPTS);
   const frameState = getFrameState(viewport, 1);
-
   const tileHeader = getBigLodMetricTileHeader();
   const tile = new Tile3D(tileset, tileHeader);
   const lodResult = getLodStatus(tile, frameState);
-  t.equal(lodResult, 'DIG');
-
-  t.end();
+  expect(lodResult).toBe('DIG');
 });

--- a/modules/tiles/test/tileset/format-i3s/i3s-pending-tiles-register.spec.ts
+++ b/modules/tiles/test/tileset/format-i3s/i3s-pending-tiles-register.spec.ts
@@ -1,30 +1,23 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {I3SPendingTilesRegister} from '../../../src/tileset-3d/format-i3s/i3s-pending-tiles-register';
-
-test('I3SPendingTilesRegister | one viewport', t => {
+test('I3SPendingTilesRegister | one viewport', () => {
   const register = new I3SPendingTilesRegister();
   const frameNumber = 0;
   const viewportId = 'default';
   for (let i = 0; i < 500; i++) {
     register.register(viewportId, frameNumber);
   }
-  t.notOk(register.isZero(viewportId, frameNumber));
-  t.ok(register.isZero(viewportId, frameNumber + 1));
-  t.ok(register.isZero('wrong viewport id', frameNumber));
+  expect(register.isZero(viewportId, frameNumber)).toBeFalsy();
+  expect(register.isZero(viewportId, frameNumber + 1)).toBeTruthy();
+  expect(register.isZero('wrong viewport id', frameNumber)).toBeTruthy();
   for (let i = 0; i < 499; i++) {
     register.deregister(viewportId, frameNumber);
   }
-  t.notOk(register.isZero(viewportId, frameNumber));
+  expect(register.isZero(viewportId, frameNumber)).toBeFalsy();
   register.deregister(viewportId, frameNumber);
-  t.ok(register.isZero(viewportId, frameNumber));
-  t.end();
+  expect(register.isZero(viewportId, frameNumber)).toBeTruthy();
 });
-
-test('I3SPendingTilesRegister | two viewports', t => {
+test('I3SPendingTilesRegister | two viewports', () => {
   const register = new I3SPendingTilesRegister();
   const frameNumber = 0;
   const mainViewportId = 'main';
@@ -35,17 +28,16 @@ test('I3SPendingTilesRegister | two viewports', t => {
   for (let i = 0; i < 100; i++) {
     register.register(minimapViewportId, frameNumber);
   }
-  t.notOk(register.isZero(mainViewportId, frameNumber));
-  t.notOk(register.isZero(minimapViewportId, frameNumber));
+  expect(register.isZero(mainViewportId, frameNumber)).toBeFalsy();
+  expect(register.isZero(minimapViewportId, frameNumber)).toBeFalsy();
   for (let i = 0; i < 100; i++) {
     register.deregister(mainViewportId, frameNumber);
     register.deregister(minimapViewportId, frameNumber);
   }
-  t.ok(register.isZero(minimapViewportId, frameNumber));
-  t.notOk(register.isZero(mainViewportId, frameNumber));
+  expect(register.isZero(minimapViewportId, frameNumber)).toBeTruthy();
+  expect(register.isZero(mainViewportId, frameNumber)).toBeFalsy();
   for (let i = 0; i < 400; i++) {
     register.deregister(mainViewportId, frameNumber);
   }
-  t.ok(register.isZero(mainViewportId, frameNumber));
-  t.end();
+  expect(register.isZero(mainViewportId, frameNumber)).toBeTruthy();
 });

--- a/modules/tiles/test/tileset/helpers/zoom.spec.ts
+++ b/modules/tiles/test/tileset/helpers/zoom.spec.ts
@@ -1,49 +1,37 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {BoundingSphere, OrientedBoundingBox} from '@math.gl/culling';
 import {Vector3} from '@math.gl/core';
-
 import {
   getZoomFromBoundingVolume,
   getZoomFromExtent,
   getZoomFromFullExtent
 } from '../../../src/tileset-3d/helpers/zoom';
 import {Ellipsoid} from '@math.gl/geospatial';
-
-test('Tiles zoom#getZoomFromBoundingVolume', t => {
+test('Tiles zoom#getZoomFromBoundingVolume', () => {
   const cartographicCenter = new Vector3([
     -122.46338343363956, 37.791575759047028, 87.413529296405613
   ]);
-
   const obb = new OrientedBoundingBox().fromCenterHalfSizeQuaternion(
     [-122.46338343363956, 37.791575759047028, 87.413529296405613],
     [860.66259765625, 1499.0565185546875, 72.744453430175781],
     [0.833251953125, -0.34349745512008667, 0.10557035356760025, -0.42018508911132813]
   );
   const zoomObb = getZoomFromBoundingVolume(obb, cartographicCenter);
-  t.equals(zoomObb, 11.772118243173631);
-
+  expect(zoomObb).toBe(11.772118243173631);
   const mbs = new BoundingSphere(
     [-122.44325696222157, 37.774355586589706, 113.91670957952738],
     9669.8994140625
   );
   const zoomMbs = getZoomFromBoundingVolume(mbs, cartographicCenter);
-  t.equals(zoomMbs, 9.347590260591668);
-
+  expect(zoomMbs).toBe(9.347590260591668);
   const frame = {width: 9669.8994140625, height: 9669.8994140625};
   const zoomFrame = getZoomFromBoundingVolume(frame, cartographicCenter);
-  t.equals(zoomFrame, 9.365418488216095);
-  t.end();
+  expect(zoomFrame).toBe(9.365418488216095);
 });
-
-test('Tiles zoom#getZoomFromFullExtent', t => {
+test('Tiles zoom#getZoomFromFullExtent', () => {
   const cartographicCenter = new Vector3([
     11.592257948984269, 48.13341656355044, 503.87951653264463
   ]);
-
   const fullExtent = {
     xmin: 11.564421696763986,
     xmax: 11.620110387574517,
@@ -57,15 +45,12 @@ test('Tiles zoom#getZoomFromFullExtent', t => {
     cartographicCenter,
     Ellipsoid.WGS84.cartographicToCartesian(cartographicCenter, new Vector3())
   );
-  t.equals(zoom, 11.00143423666113);
-  t.end();
+  expect(zoom).toBe(11.00143423666113);
 });
-
-test('Tiles zoom#getZoomFromExtent', t => {
+test('Tiles zoom#getZoomFromExtent', () => {
   const cartographicCenter = new Vector3([
     11.592257948984269, 48.13341656355044, 503.87951653264463
   ]);
-
   const extent: [number, number, number, number] = [
     11.564421696763986, 48.120129331330034, 11.620110387574517, 48.14669643878373
   ];
@@ -74,6 +59,5 @@ test('Tiles zoom#getZoomFromExtent', t => {
     cartographicCenter,
     Ellipsoid.WGS84.cartographicToCartesian(cartographicCenter, new Vector3())
   );
-  t.equals(zoom, 11.002543742881027);
-  t.end();
+  expect(zoom).toBe(11.002543742881027);
 });

--- a/modules/tiles/test/tileset/tileset-2d.spec.ts
+++ b/modules/tiles/test/tileset/tileset-2d.spec.ts
@@ -1,10 +1,5 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {Tileset2D, type Tileset2DAdapter} from '@loaders.gl/tiles';
-
 const TEST_ADAPTER: Tileset2DAdapter<null> = {
   getTileIndices: () => [
     {x: 0, y: 0, z: 0},
@@ -17,8 +12,7 @@ const TEST_ADAPTER: Tileset2DAdapter<null> = {
     north: index.y + 1
   })
 };
-
-test('Tileset2D#applies TileSource metadata overrides', async t => {
+test('Tileset2D#applies TileSource metadata overrides', async () => {
   const tileset = Tileset2D.fromTileSource(
     {
       async getMetadata() {
@@ -37,108 +31,85 @@ test('Tileset2D#applies TileSource metadata overrides', async t => {
     } as any,
     {adapter: TEST_ADAPTER}
   );
-
   await new Promise(resolve => setTimeout(resolve, 0));
-  t.equal(tileset.minZoom, 2);
-  t.equal(tileset.maxZoom, 5);
+  expect(tileset.minZoom).toBe(2);
+  expect(tileset.maxZoom).toBe(5);
   const indices = tileset.getTileIndices({viewState: null, zRange: null});
-  t.equal(indices.length, 2);
+  expect(indices.length).toBe(2);
   tileset.finalize();
-  t.end();
 });
-
-test('Tileset2D#tracks consumer visibility unions', async t => {
+test('Tileset2D#tracks consumer visibility unions', async () => {
   const tileset = new Tileset2D({
     adapter: TEST_ADAPTER,
     getTileData: async () => ({byteLength: 1})
   });
-
   const indices = tileset.getTileIndices({viewState: null, zRange: null});
   const firstTile = tileset.getTile(indices[0], true);
   const secondTile = tileset.getTile(indices[1], true);
   await Promise.all([firstTile.data, secondTile.data]);
   tileset.prepareTiles();
-
   const firstConsumer = Symbol('first');
   const secondConsumer = Symbol('second');
   tileset.attachConsumer(firstConsumer);
   tileset.attachConsumer(secondConsumer);
   tileset.updateConsumer(firstConsumer, [firstTile], [firstTile]);
   tileset.updateConsumer(secondConsumer, [secondTile], []);
-
-  t.equal(tileset.selectedTiles.length, 2);
-  t.equal(tileset.visibleTiles.length, 2);
-
+  expect(tileset.selectedTiles.length).toBe(2);
+  expect(tileset.visibleTiles.length).toBe(2);
   tileset.detachConsumer(secondConsumer);
-  t.equal(tileset.selectedTiles.length, 1);
-  t.equal(tileset.visibleTiles.length, 1);
-
+  expect(tileset.selectedTiles.length).toBe(1);
+  expect(tileset.visibleTiles.length).toBe(1);
   tileset.finalize();
-  t.end();
 });
-
-test('Tileset2D#reloadAll keeps selected tiles and drops unused cached tiles', async t => {
+test('Tileset2D#reloadAll keeps selected tiles and drops unused cached tiles', async () => {
   const tileset = new Tileset2D({
     adapter: TEST_ADAPTER,
     getTileData: async ({id}) => ({id, byteLength: 1})
   });
-
   const indices = tileset.getTileIndices({viewState: null, zRange: null});
   const firstTile = tileset.getTile(indices[0], true);
   const secondTile = tileset.getTile(indices[1], true);
   await Promise.all([firstTile.data, secondTile.data]);
   tileset.prepareTiles();
-
   const consumerId = Symbol('consumer');
   tileset.attachConsumer(consumerId);
   tileset.updateConsumer(consumerId, [firstTile], [firstTile]);
-
   tileset.reloadAll();
-
-  t.ok(tileset.getTile(firstTile.index));
-  t.ok(tileset.getTile(firstTile.index)?.needsReload);
-  t.notOk(tileset.getTile(secondTile.index));
-  t.notOk(
+  expect(tileset.getTile(firstTile.index)).toBeTruthy();
+  expect(tileset.getTile(firstTile.index)?.needsReload).toBeTruthy();
+  expect(tileset.getTile(secondTile.index)).toBeFalsy();
+  expect(
     tileset.tiles.some(tile => tile.id === secondTile.id),
     'removed tiles no longer remain in the prepared tile list'
-  );
-
+  ).toBeFalsy();
   tileset.finalize();
-  t.end();
 });
-
-test('Tileset2D#setOptions recreates the request scheduler when throttling changes', t => {
+test('Tileset2D#setOptions recreates the request scheduler when throttling changes', () => {
   const tileset = new Tileset2D({
     adapter: TEST_ADAPTER,
     getTileData: async () => null,
     maxRequests: 4,
     debounceTime: 0
   });
-
   const initialScheduler = (tileset as any)._requestScheduler;
   tileset.setOptions({maxRequests: 2});
   const updatedScheduler = (tileset as any)._requestScheduler;
-  t.notEqual(updatedScheduler, initialScheduler, 'scheduler recreated for maxRequests updates');
-
+  expect(updatedScheduler, 'scheduler recreated for maxRequests updates').not.toBe(
+    initialScheduler
+  );
   tileset.setOptions({tileSize: 512});
-  t.equal(
+  expect(
     (tileset as any)._requestScheduler,
-    updatedScheduler,
     'scheduler is reused when throttling options are unchanged'
-  );
-
+  ).toBe(updatedScheduler);
   tileset.setOptions({debounceTime: 10});
-  t.notEqual(
+  expect(
     (tileset as any)._requestScheduler,
-    updatedScheduler,
     'scheduler recreated for debounceTime updates'
-  );
-
+  ).not.toBe(updatedScheduler);
   tileset.finalize();
-  t.end();
 });
-
-test('Tileset2D#caches failed tiles until reloadAll', async t => {
+test('Tileset2D#caches failed tiles until reloadAll', async () => {
   let requestCount = 0;
   const tileset = new Tileset2D({
     adapter: TEST_ADAPTER,
@@ -147,26 +118,20 @@ test('Tileset2D#caches failed tiles until reloadAll', async t => {
       throw new Error('boom');
     }
   });
-
   const [firstIndex] = tileset.getTileIndices({viewState: null, zRange: null});
   const failedTile = tileset.getTile(firstIndex, true);
   await failedTile.data;
-
-  t.equal(requestCount, 1, 'first request failed once');
-  t.ok(failedTile.hasError, 'failed tile stores its error');
-  t.equal(failedTile.error?.message, 'boom', 'failed tile stores the error message');
-  t.equal(failedTile.content, null, 'failed tile keeps null content');
-
+  expect(requestCount, 'first request failed once').toBe(1);
+  expect(failedTile.hasError, 'failed tile stores its error').toBeTruthy();
+  expect(failedTile.error?.message, 'failed tile stores the error message').toBe('boom');
+  expect(failedTile.content, 'failed tile keeps null content').toBe(null);
   const cachedTile = tileset.getTile(firstIndex, true);
   await cachedTile.data;
-  t.equal(requestCount, 1, 'cached failed tile is not re-requested immediately');
-  t.ok(cachedTile.hasError, 'cached failed tile remains failed');
-
+  expect(requestCount, 'cached failed tile is not re-requested immediately').toBe(1);
+  expect(cachedTile.hasError, 'cached failed tile remains failed').toBeTruthy();
   tileset.reloadAll();
   const reloadedTile = tileset.getTile(firstIndex, true);
   await reloadedTile.data;
-  t.equal(requestCount, 2, 'reloadAll allows failed tiles to be requested again');
-
+  expect(requestCount, 'reloadAll allows failed tiles to be requested again').toBe(2);
   tileset.finalize();
-  t.end();
 });

--- a/modules/tiles/test/utils/doubly-linked-list.spec.ts
+++ b/modules/tiles/test/utils/doubly-linked-list.spec.ts
@@ -1,427 +1,317 @@
-// SPDX-License-Identifier: Apache-2.0
-
-// This file is derived from the Cesium code base under Apache 2 license
-// See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {DoublyLinkedList} from '../../src/utils/doubly-linked-list';
-
-function expectOrder(t, list, nodes) {
+function expectOrder(list, nodes) {
   // Assumes at least one node is in the list
   const length = nodes.length;
-
-  t.equals(list.length, length);
-
+  expect(list.length).toBe(length);
   // Verify head and tail pointers
-  t.equals(list.head, nodes[0]);
-  t.equals(list.tail, nodes[length - 1]);
-
+  expect(list.head).toBe(nodes[0]);
+  expect(list.tail).toBe(nodes[length - 1]);
   // Verify that linked list has nodes in the expected order
   let node = list.head;
   for (let i = 0; i < length; ++i) {
     const nextNode = i === length - 1 ? null : nodes[i + 1];
     const previousNode = i === 0 ? null : nodes[i - 1];
-
-    t.equals(node, nodes[i]);
-    t.equals(node.next, nextNode);
-    t.equals(node.previous, previousNode);
-
+    expect(node).toBe(nodes[i]);
+    expect(node.next).toBe(nextNode);
+    expect(node.previous).toBe(previousNode);
     node = node.next;
   }
 }
-
-test('DoublyLinkedList#constructs', t => {
+test('DoublyLinkedList#constructs', () => {
   const list = new DoublyLinkedList();
-  t.equals(list.head, null);
-  t.equals(list.head, null);
-  t.equals(list.length, 0);
-
-  t.end();
+  expect(list.head).toBe(null);
+  expect(list.head).toBe(null);
+  expect(list.length).toBe(0);
 });
-
 // eslint-disable-next-line max-statements
-test('DoublyLinkedList#adds items', t => {
+test('DoublyLinkedList#adds items', () => {
   const list = new DoublyLinkedList();
   const node = list.add(1);
-
   //   node
   //  ^     ^
   //  |     |
   // head  tail
-  t.equals(list.head, node);
-  t.equals(list.tail, node);
-  t.equals(list.length, 1);
-
-  t.ok(node);
-  t.equals(node.item, 1);
-  t.notOk(node.previous);
-  t.notOk(node.next);
-
+  expect(list.head).toBe(node);
+  expect(list.tail).toBe(node);
+  expect(list.length).toBe(1);
+  expect(node).toBeTruthy();
+  expect(node.item).toBe(1);
+  expect(node.previous).toBeFalsy();
+  expect(node.next).toBeFalsy();
   const node2 = list.add(2);
-
   //  node <-> node2
   //  ^         ^
   //  |         |
   // head      tail
-  t.equals(list.head, node);
-  t.equals(list.tail, node2);
-  t.equals(list.length, 2);
-
-  t.ok(node2);
-  t.equals(node2.item, 2);
-  t.equals(node2.previous, node);
-  t.notOk(node2.next);
-
-  t.equals(node.next, node2);
-
+  expect(list.head).toBe(node);
+  expect(list.tail).toBe(node2);
+  expect(list.length).toBe(2);
+  expect(node2).toBeTruthy();
+  expect(node2.item).toBe(2);
+  expect(node2.previous).toBe(node);
+  expect(node2.next).toBeFalsy();
+  expect(node.next).toBe(node2);
   const node3 = list.add(3);
-
   //  node <-> node2 <-> node3
   //  ^                    ^
   //  |                    |
   // head                 tail
-  t.equals(list.head, node);
-  t.equals(list.tail, node3);
-  t.equals(list.length, 3);
-
-  t.ok(node3);
-  t.equals(node3.item, 3);
-  t.equals(node3.previous, node2);
-  t.notOk(node3.next);
-  t.equals(node2.next, node3);
-
-  t.end();
+  expect(list.head).toBe(node);
+  expect(list.tail).toBe(node3);
+  expect(list.length).toBe(3);
+  expect(node3).toBeTruthy();
+  expect(node3.item).toBe(3);
+  expect(node3.previous).toBe(node2);
+  expect(node3.next).toBeFalsy();
+  expect(node2.next).toBe(node3);
 });
-
-test('DoublyLinkedList#removes from a list with one item', t => {
+test('DoublyLinkedList#removes from a list with one item', () => {
   const list = new DoublyLinkedList();
   const node = list.add(1);
-
   list.remove(node);
-  t.notOk(list.head);
-  t.notOk(list.tail);
-  t.equals(list.length, 0);
-
-  t.end();
+  expect(list.head).toBeFalsy();
+  expect(list.tail).toBeFalsy();
+  expect(list.length).toBe(0);
 });
-
-test('DoublyLinkedList#removes head of list', t => {
+test('DoublyLinkedList#removes head of list', () => {
   const list = new DoublyLinkedList();
   const node = list.add(1);
   const node2 = list.add(2);
-
   list.remove(node);
-
-  t.equals(list.head, node2);
-  t.equals(list.tail, node2);
-  t.equals(list.length, 1);
-
-  t.end();
+  expect(list.head).toBe(node2);
+  expect(list.tail).toBe(node2);
+  expect(list.length).toBe(1);
 });
-
-test('DoublyLinkedList#removes tail of list', t => {
+test('DoublyLinkedList#removes tail of list', () => {
   const list = new DoublyLinkedList();
   const node = list.add(1);
   const node2 = list.add(2);
-
   list.remove(node2);
-
-  t.equals(list.head, node);
-  t.equals(list.tail, node);
-  t.equals(list.length, 1);
-
-  t.end();
+  expect(list.head).toBe(node);
+  expect(list.tail).toBe(node);
+  expect(list.length).toBe(1);
 });
-
-test('DoublyLinkedList#removes middle of list', t => {
+test('DoublyLinkedList#removes middle of list', () => {
   const list = new DoublyLinkedList();
   const node = list.add(1);
   const node2 = list.add(2);
   const node3 = list.add(3);
-
   list.remove(node2);
-
-  t.equals(list.head, node);
-  t.equals(list.tail, node3);
-  t.equals(list.length, 2);
-
-  t.end();
+  expect(list.head).toBe(node);
+  expect(list.tail).toBe(node3);
+  expect(list.length).toBe(2);
 });
-
-test('DoublyLinkedList#removes nothing', t => {
+test('DoublyLinkedList#removes nothing', () => {
   const list = new DoublyLinkedList();
   const node = list.add(1);
-
   // @ts-ignore
   list.remove();
-
-  t.equals(list.head, node);
-  t.equals(list.tail, node);
-  t.equals(list.length, 1);
-
-  t.end();
+  expect(list.head).toBe(node);
+  expect(list.tail).toBe(node);
+  expect(list.length).toBe(1);
 });
-
-test('DoublyLinkedList#splices nextNode before node', t => {
+test('DoublyLinkedList#splices nextNode before node', () => {
   const list = new DoublyLinkedList();
   const node = list.add(1);
   const node2 = list.add(2);
   const node3 = list.add(3);
   const node4 = list.add(4);
   const node5 = list.add(5);
-
   // Before:
   //
   //  node <-> node2 <-> node3 <-> node4 <-> node5
   //  ^          ^                   ^          ^
   //  |          |                   |          |
   // head     nextNode             node        tail
-
   // After:
   //
   //  node <-> node3 <-> node4 <-> node2 <-> node5
   //  ^                                         ^
   //  |                                         |
   // head                                      tail
-
   // Move node2 after node4
   list.splice(node4, node2);
-  expectOrder(t, list, [node, node3, node4, node2, node5]);
-
-  t.end();
+  expectOrder(list, [node, node3, node4, node2, node5]);
 });
-
-test('DoublyLinkedList#splices nextNode after node', t => {
+test('DoublyLinkedList#splices nextNode after node', () => {
   const list = new DoublyLinkedList();
   const node = list.add(1);
   const node2 = list.add(2);
   const node3 = list.add(3);
   const node4 = list.add(4);
   const node5 = list.add(5);
-
   // Before:
   //
   //  node <-> node2 <-> node3 <-> node4 <-> node5
   //  ^          ^                   ^          ^
   //  |          |                   |          |
   // head      node              nextNode      tail
-
   // After:
   //
   //  node <-> node2 <-> node4 <-> node3 <-> node5
   //  ^                                         ^
   //  |                                         |
   // head                                      tail
-
   // Move node4 after node2
   list.splice(node2, node4);
-  expectOrder(t, list, [node, node2, node4, node3, node5]);
-
-  t.end();
+  expectOrder(list, [node, node2, node4, node3, node5]);
 });
-
-test('DoublyLinkedList#splices nextNode immediately before node', t => {
+test('DoublyLinkedList#splices nextNode immediately before node', () => {
   const list = new DoublyLinkedList();
   const node = list.add(1);
   const node2 = list.add(2);
   const node3 = list.add(3);
   const node4 = list.add(4);
-
   // Before:
   //
   //  node <-> node2 <-> node3 <-> node4
   //  ^          ^         ^         ^
   //  |          |         |         |
   // head     nextNode    node      tail
-
   // After:
   //
   //  node <-> node3 <-> node2 <-> node4
   //  ^                              ^
   //  |                              |
   // head                           tail
-
   // Move node2 after node4
   list.splice(node3, node2);
-  expectOrder(t, list, [node, node3, node2, node4]);
-
-  t.end();
+  expectOrder(list, [node, node3, node2, node4]);
 });
-
-test('DoublyLinkedList#splices nextNode immediately after node', t => {
+test('DoublyLinkedList#splices nextNode immediately after node', () => {
   const list = new DoublyLinkedList();
   const node = list.add(1);
   const node2 = list.add(2);
   const node3 = list.add(3);
   const node4 = list.add(4);
-
   // Before:
   //
   //  node <-> node2 <-> node3 <-> node4
   //  ^          ^         ^         ^
   //  |          |         |         |
   // head      node    nextNode     tail
-
   // After: does not change
-
   list.splice(node2, node3);
-  expectOrder(t, list, [node, node2, node3, node4]);
-
-  t.end();
+  expectOrder(list, [node, node2, node3, node4]);
 });
-
-test('DoublyLinkedList#splices node === nextNode', t => {
+test('DoublyLinkedList#splices node === nextNode', () => {
   const list = new DoublyLinkedList();
   const node = list.add(1);
   const node2 = list.add(2);
   const node3 = list.add(3);
-
   // Before:
   //
   //  node <-> node2 <-> node3
   //  ^          ^         ^
   //  |          |         |
   // head  node/nextNode  tail
-
   // After: does not change
-
   list.splice(node2, node2);
-  expectOrder(t, list, [node, node2, node3]);
-
-  t.end();
+  expectOrder(list, [node, node2, node3]);
 });
-
-test('DoublyLinkedList#splices when nextNode was tail', t => {
+test('DoublyLinkedList#splices when nextNode was tail', () => {
   const list = new DoublyLinkedList();
   const node = list.add(1);
   const node2 = list.add(2);
   const node3 = list.add(3);
   const node4 = list.add(4);
-
   // Before:
   //
   //  node <-> node2 <-> node3 <-> node4
   //  ^          ^                   ^
   //  |          |                   |
   // head      node           tail/nextNode
-
   // After:
   //
   //  node <-> node2 <-> node4 <-> node3
   //  ^                               ^
   //  |                               |
   // head                            tail
-
   list.splice(node2, node4);
-  expectOrder(t, list, [node, node2, node4, node3]);
-
-  t.end();
+  expectOrder(list, [node, node2, node4, node3]);
 });
-
-test('DoublyLinkedList#splices when node was tail', t => {
+test('DoublyLinkedList#splices when node was tail', () => {
   const list = new DoublyLinkedList();
   const node = list.add(1);
   const node2 = list.add(2);
   const node3 = list.add(3);
   const node4 = list.add(4);
-
   // Before:
   //
   //  node <-> node2 <-> node3 <-> node4
   //  ^          ^                   ^
   //  |          |                   |
   // head      nextNode           tail/node
-
   // After:
   //
   //  node <-> node3 <-> node4 <-> node2
   //  ^                              ^
   //  |                              |
   // head                         tail/node
-
   list.splice(node4, node2);
-  expectOrder(t, list, [node, node3, node4, node2]);
-
-  t.end();
+  expectOrder(list, [node, node3, node4, node2]);
 });
-
-test('DoublyLinkedList#splices when nextNode was head', t => {
+test('DoublyLinkedList#splices when nextNode was head', () => {
   const list = new DoublyLinkedList();
   const node = list.add(1);
   const node2 = list.add(2);
   const node3 = list.add(3);
   const node4 = list.add(4);
-
   // Before:
   //
   //  node <-> node2 <-> node3 <-> node4
   //  ^                   ^         ^
   //  |                   |         |
   // head/nextNode       node      tail
-
   // After:
   //
   //  node2 <-> node3 <-> node <-> node4
   //  ^                              ^
   //  |                              |
   // head                           tail
-
   list.splice(node3, node);
-  expectOrder(t, list, [node2, node3, node, node4]);
-
-  t.end();
+  expectOrder(list, [node2, node3, node, node4]);
 });
-
-test('DoublyLinkedList#splices when node was head', t => {
+test('DoublyLinkedList#splices when node was head', () => {
   const list = new DoublyLinkedList();
   const node = list.add(1);
   const node2 = list.add(2);
   const node3 = list.add(3);
   const node4 = list.add(4);
-
   // Before:
   //
   //  node <-> node2 <-> node3 <-> node4
   //  ^                   ^         ^
   //  |                   |         |
   // head/node        nextNode      tail
-
   // After:
   //
   //  node <-> node3 <-> node2 <-> node4
   //  ^                              ^
   //  |                              |
   // head                           tail
-
   list.splice(node, node3);
-  expectOrder(t, list, [node, node3, node2, node4]);
-
-  t.end();
+  expectOrder(list, [node, node3, node2, node4]);
 });
-
-test('DoublyLinkedList#insert', t => {
+test('DoublyLinkedList#insert', () => {
   const list = new DoublyLinkedList();
   const node = list.add(1);
   const node2 = list.add(2);
   const node3 = list.add(3);
   const node4 = list.add(4);
-
   // Before:
   //
   //  node <-> node2 <-> node3 <-> node4
   //  ^                   ^         ^
   //  |                   |         |
   // head/node        nextNode      tail
-
   // After:
   //
   //  node <-> node3 <-> node2 <-> node4
   //  ^                              ^
   //  |                              |
   // head                           tail
-
   list.splice(node, node3);
-  expectOrder(t, list, [node, node3, node2, node4]);
-
-  t.end();
+  expectOrder(list, [node, node3, node2, node4]);
 });

--- a/modules/video/test-included/parse-video.spec.js
+++ b/modules/video/test-included/parse-video.spec.js
@@ -1,29 +1,17 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test, {testIfBrowser} from 'test/utils/vitest-tape';
-
+import {expect, test} from 'vitest';
+import {testIfBrowser} from '@loaders.gl/test-utils/vitest';
 import parseVideo, {parseVideoBlob} from '../src/lib/parsers/parse-video';
 import {VideoLoaderWithParser} from '../src/video-loader-with-parser';
-
-test('VideoLoaderWithParser#parseBlob is defined', t => {
-  t.equal(VideoLoaderWithParser.parseBlob, parseVideoBlob, 'parseBlob uses the Blob parser');
-  t.end();
+test('VideoLoaderWithParser#parseBlob is defined', () => {
+  expect(VideoLoaderWithParser.parseBlob, 'parseBlob uses the Blob parser').toBe(parseVideoBlob);
 });
-
-testIfBrowser('parseVideoBlob creates a video element from a Blob URL', async t => {
+testIfBrowser('parseVideoBlob creates a video element from a Blob URL', async () => {
   const video = await parseVideoBlob(new Blob(['video data'], {type: 'video/mp4'}));
-
-  t.equal(video.tagName, 'VIDEO', 'Blob parser returns a video element');
-  t.ok(video.src.startsWith('blob:'), 'Blob parser uses an object URL');
-  t.end();
+  expect(video.tagName, 'Blob parser returns a video element').toBe('VIDEO');
+  expect(video.src.startsWith('blob:'), 'Blob parser uses an object URL').toBeTruthy();
 });
-
-testIfBrowser('parseVideo creates a video element from an ArrayBuffer', async t => {
+testIfBrowser('parseVideo creates a video element from an ArrayBuffer', async () => {
   const video = await parseVideo(new Uint8Array([1, 2, 3]).buffer);
-
-  t.equal(video.tagName, 'VIDEO', 'ArrayBuffer parser returns a video element');
-  t.ok(video.src.startsWith('blob:'), 'ArrayBuffer parser uses the Blob helper');
-  t.end();
+  expect(video.tagName, 'ArrayBuffer parser returns a video element').toBe('VIDEO');
+  expect(video.src.startsWith('blob:'), 'ArrayBuffer parser uses the Blob helper').toBeTruthy();
 });

--- a/modules/xml/test/html-loader.spec.ts
+++ b/modules/xml/test/html-loader.spec.ts
@@ -1,13 +1,7 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 // import {validateLoader} from 'test/common/conformance';
-
 import {HTMLLoader} from '@loaders.gl/xml';
 import {parse} from '@loaders.gl/core';
-
 const HTML = `
 <HTML>
 <HEAD>
@@ -29,11 +23,8 @@ support@yourcompany.com</a>.
 </BODY>
 </HTML>
 `;
-
-test('HTMLLoader#forecasts.xml', async t => {
+test('HTMLLoader#forecasts.xml', async () => {
   const html = await parse(HTML, HTMLLoader);
-
-  t.ok(html, 'got result');
-  t.equal(html.HTML.BODY.CENTER.IMG.SRC, 'clouds.jpg', 'HTML image tag src correct');
-  t.end();
+  expect(html, 'got result').toBeTruthy();
+  expect(html.HTML.BODY.CENTER.IMG.SRC, 'HTML image tag src correct').toBe('clouds.jpg');
 });

--- a/modules/xml/test/lib/pretty-print.spec.ts
+++ b/modules/xml/test/lib/pretty-print.spec.ts
@@ -1,30 +1,15 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-// Inspired by a sax-js example under ISC license
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {SAXParser} from '@loaders.gl/xml';
 import {fetchFile} from '@loaders.gl/core';
-
 const FORECASTS_URL = '@loaders.gl/xml/test/data/forecasts.xml';
-
-test('XML#pretty-print', async t => {
-  t.test('forecasts.xml', async t => {
-    const response = await fetchFile(FORECASTS_URL);
-    const json = await response.text();
-
-    const prettyPrinter = new PrettyPrinter();
-    prettyPrinter.onprintline = _line => {};
-    // prettyPrinter.onprintline = line => t.comment(line);
-    prettyPrinter.write(json);
-
-    t.end();
-  });
-
-  t.end();
+test('XML#pretty-print', async () => {
+  const response = await fetchFile(FORECASTS_URL);
+  const json = await response.text();
+  const prettyPrinter = new PrettyPrinter();
+  prettyPrinter.onprintline = _line => {};
+  // prettyPrinter.onprintline = line => console.log(line);
+  prettyPrinter.write(json);
 });
-
 class PrettyPrinter {
   readonly parser: SAXParser;
   // eslint-disable-next-line no-console
@@ -32,31 +17,25 @@ class PrettyPrinter {
   private tabstop = 2;
   private level = 0;
   private currentLine = '';
-
   constructor() {
     this.parser = this._createParser();
   }
-
   write(xml: string) {
     this.parser.write(xml);
   }
-
   private print(string: string) {
     this.currentLine += string;
   }
-
   private println() {
     this.onprintline(this.currentLine);
     this.currentLine = '';
   }
-
   private indent() {
     this.println();
     for (let i = this.level * this.tabstop; i > 0; i--) {
       this.print('.');
     }
   }
-
   private _createParser() {
     return new SAXParser({
       onopentag: tag => {
@@ -68,33 +47,27 @@ class PrettyPrinter {
         }
         this.print('>');
       },
-
       ontext: text => {
         this.indent();
         this.print(text);
       },
-
       ondoctype: text => {
         this.indent();
         this.print(text);
       },
-
       onclosetag: tag => {
         this.level--;
         this.indent();
         this.print(`</${tag}>`);
       },
-
       oncdata: data => {
         this.indent();
         this.print(`<![CDATA[${data}]]>`);
       },
-
       oncomment: comment => {
         this.indent();
         this.print(`<!--${comment}-->`);
       },
-
       onerror: error => {
         console.error(error); // eslint-disable-line no-console
         throw error;
@@ -102,7 +75,6 @@ class PrettyPrinter {
     });
   }
 }
-
 function entity(str) {
   return str.replace('"', '&quot;');
 }

--- a/modules/xml/test/xml-loader-internal-parser.node.spec.ts
+++ b/modules/xml/test/xml-loader-internal-parser.node.spec.ts
@@ -1,26 +1,15 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 import {readFile} from 'node:fs/promises';
-
 import {XMLLoader} from '@loaders.gl/xml/bundled';
-
 const FORECASTS_URL = new URL('./data/forecasts.xml', import.meta.url);
-
-test('XMLLoader#internal parser#forecasts.xml (NODE)', async t => {
+test('XMLLoader#internal parser#forecasts.xml (NODE)', async () => {
   const text = await readFile(FORECASTS_URL, 'utf8');
   const json = XMLLoader.parseTextSync?.(text, {xml: {_parser: 'internal'}});
-
-  t.ok(json, 'got result');
-  t.equal(typeof json, 'object', 'parsed');
-  t.equal(json.WMT_MS_Capabilities.Capability.Layer.Layer[2].Name, 'world_rivers', 'contents');
-
-  t.end();
+  expect(json, 'got result').toBeTruthy();
+  expect(typeof json, 'parsed').toBe('object');
+  expect(json.WMT_MS_Capabilities.Capability.Layer.Layer[2].Name, 'contents').toBe('world_rivers');
 });
-
-test('XMLLoader#internal parser#parity (NODE)', t => {
+test('XMLLoader#internal parser#parity (NODE)', () => {
   const testCases = [
     {
       title: 'text-only node',
@@ -92,7 +81,6 @@ test('XMLLoader#internal parser#parity (NODE)', t => {
       options: {_fastXML: {parseAttributeValue: true}}
     }
   ];
-
   for (const testCase of testCases) {
     const parserOptions = {textNodeName: 'value', ...testCase.options};
     const fastXML = XMLLoader.parseTextSync?.(testCase.xml, {
@@ -101,9 +89,6 @@ test('XMLLoader#internal parser#parity (NODE)', t => {
     const internalXML = XMLLoader.parseTextSync?.(testCase.xml, {
       xml: {...parserOptions, _parser: 'internal'}
     });
-
-    t.deepEqual(internalXML, fastXML, testCase.title);
+    expect(internalXML, testCase.title).toEqual(fastXML);
   }
-
-  t.end();
 });

--- a/modules/xml/test/xml-loader.spec.ts
+++ b/modules/xml/test/xml-loader.spec.ts
@@ -1,37 +1,22 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
+import {expect, test} from 'vitest';
 // import {validateLoader} from 'test/common/conformance';
-
 import {XMLLoader} from '@loaders.gl/xml';
 import {XMLLoader as BundledXMLLoader} from '@loaders.gl/xml/bundled';
 import {load} from '@loaders.gl/core';
-
 const FORECASTS_URL = '@loaders.gl/xml/test/data/forecasts.xml';
-
-test('XMLLoader#forecasts.xml', async t => {
+test('XMLLoader#forecasts.xml', async () => {
   const json = await load(FORECASTS_URL, XMLLoader);
-
-  t.ok(json, 'got result');
-  t.equal(typeof json, 'object', 'parsed');
-  t.equal(json.WMT_MS_Capabilities.Capability.Layer.Layer[2].Name, 'world_rivers', 'contents');
-
-  t.end();
+  expect(json, 'got result').toBeTruthy();
+  expect(typeof json, 'parsed').toBe('object');
+  expect(json.WMT_MS_Capabilities.Capability.Layer.Layer[2].Name, 'contents').toBe('world_rivers');
 });
-
-test('XMLLoader#internal parser#forecasts.xml', async t => {
+test('XMLLoader#internal parser#forecasts.xml', async () => {
   const json = await load(FORECASTS_URL, XMLLoader, {xml: {_parser: 'internal'}});
-
-  t.ok(json, 'got result');
-  t.equal(typeof json, 'object', 'parsed');
-  t.equal(json.WMT_MS_Capabilities.Capability.Layer.Layer[2].Name, 'world_rivers', 'contents');
-
-  t.end();
+  expect(json, 'got result').toBeTruthy();
+  expect(typeof json, 'parsed').toBe('object');
+  expect(json.WMT_MS_Capabilities.Capability.Layer.Layer[2].Name, 'contents').toBe('world_rivers');
 });
-
-test('XMLLoader#internal parser#parity', t => {
+test('XMLLoader#internal parser#parity', () => {
   const testCases = [
     {
       title: 'text-only node',
@@ -95,7 +80,6 @@ test('XMLLoader#internal parser#parity', t => {
       options: {_fastXML: {parseAttributeValue: true}}
     }
   ];
-
   for (const testCase of testCases) {
     const parserOptions = {textNodeName: 'value', ...testCase.options};
     const fastXML = BundledXMLLoader.parseTextSync?.(testCase.xml, {
@@ -104,9 +88,6 @@ test('XMLLoader#internal parser#parity', t => {
     const internalXML = BundledXMLLoader.parseTextSync?.(testCase.xml, {
       xml: {...parserOptions, _parser: 'internal'}
     });
-
-    t.deepEqual(internalXML, fastXML, testCase.title);
+    expect(internalXML, testCase.title).toEqual(fastXML);
   }
-
-  t.end();
 });

--- a/modules/zarr/test/geo-zarr-source.browser.spec.ts
+++ b/modules/zarr/test/geo-zarr-source.browser.spec.ts
@@ -1,202 +1,144 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
-import {createDataSource} from '@loaders.gl/core';
-import type {RasterBoundingBox, RasterViewport} from '@loaders.gl/loader-utils';
-import {
-  GeoZarrRasterSource,
-  GeoZarrSourceLoader,
-  type GeoZarrSourceLoaderOptions
-} from '@loaders.gl/zarr';
-
+import { expect, test } from "vitest";
+import { createDataSource } from '@loaders.gl/core';
+import type { RasterBoundingBox, RasterViewport } from '@loaders.gl/loader-utils';
+import { GeoZarrRasterSource, GeoZarrSourceLoader, type GeoZarrSourceLoaderOptions } from '@loaders.gl/zarr';
 const SPATIALDATA_V3_FIXTURE_URL = '/modules/zarr/test/data/spatialdata-v3.zarr';
-
-test('GeoZarrSourceLoader supports browser-relative store metadata', async t => {
-  const source = createDataSource(SPATIALDATA_V3_FIXTURE_URL, [GeoZarrSourceLoader], {
-    zarr: {path: 'images/example-image'},
-    geozarr: {array: '0'}
-  });
-  const metadata = await source.getMetadata();
-
-  t.equal(metadata.crs, 'EPSG:4326');
-  t.deepEqual(metadata.spatialDimensions, ['y', 'x']);
-  t.deepEqual(metadata.boundingBox, [
-    [-20, -6.7],
-    [23.9, 10]
-  ]);
-  t.end();
+test('GeoZarrSourceLoader supports browser-relative store metadata', async () => {
+    const source = createDataSource(SPATIALDATA_V3_FIXTURE_URL, [GeoZarrSourceLoader], {
+        zarr: { path: 'images/example-image' },
+        geozarr: { array: '0' }
+    });
+    const metadata = await source.getMetadata();
+    expect(metadata.crs).toBe('EPSG:4326');
+    expect(metadata.spatialDimensions).toEqual(['y', 'x']);
+    expect(metadata.boundingBox).toEqual([
+        [-20, -6.7],
+        [23.9, 10]
+    ]);
 });
-
-test('GeoZarrRasterSource reads regular CF coordinates and raster windows in browsers', async t => {
-  const source = createInMemoryGeoZarrSource();
-  const metadata = await source.getMetadata();
-  const raster = await source.getRaster({
-    viewport: createViewport(
-      [
-        [100.5, 8.5],
+test('GeoZarrRasterSource reads regular CF coordinates and raster windows in browsers', async () => {
+    const source = createInMemoryGeoZarrSource();
+    const metadata = await source.getMetadata();
+    const raster = await source.getRaster({
+        viewport: createViewport([
+            [100.5, 8.5],
+            [102.5, 10.5]
+        ], 'EPSG:4326')
+    });
+    expect(metadata.name).toBe('Air temperature');
+    expect(metadata.crs).toBe('EPSG:4326');
+    expect(metadata.transform).toEqual([1, 0, 99.5, 0, -1, 10.5]);
+    expect(metadata.boundingBox).toEqual([
+        [99.5, 8.5],
         [102.5, 10.5]
-      ],
-      'EPSG:4326'
-    )
-  });
-
-  t.equal(metadata.name, 'Air temperature');
-  t.equal(metadata.crs, 'EPSG:4326');
-  t.deepEqual(metadata.transform, [1, 0, 99.5, 0, -1, 10.5]);
-  t.deepEqual(metadata.boundingBox, [
-    [99.5, 8.5],
-    [102.5, 10.5]
-  ]);
-  t.deepEqual(metadata.selectionDimensions, [{name: 'time', size: 2, defaultIndex: 1}]);
-  t.equal(metadata.noData, 255);
-  t.equal(raster.width, 2);
-  t.equal(raster.height, 2);
-  t.equal(raster.dtype, 'uint8');
-  t.deepEqual(Array.from(raster.data as Uint8Array), [12, 13, 15, 16]);
-  t.end();
+    ]);
+    expect(metadata.selectionDimensions).toEqual([{ name: 'time', size: 2, defaultIndex: 1 }]);
+    expect(metadata.noData).toBe(255);
+    expect(raster.width).toBe(2);
+    expect(raster.height).toBe(2);
+    expect(raster.dtype).toBe('uint8');
+    expect(Array.from(raster.data as Uint8Array)).toEqual([12, 13, 15, 16]);
 });
-
-test('GeoZarrRasterSource validates browser viewport and dimension selections', async t => {
-  const source = createInMemoryGeoZarrSource();
-  const viewport = createViewport(
-    [
-      [100, 9],
-      [102, 10]
-    ],
-    'EPSG:3857'
-  );
-
-  await t.rejects(source.getRaster({viewport}), /does not support reprojection/);
-  viewport.crs = 'EPSG:4326';
-  await t.rejects(
-    source.getRaster({viewport, selection: {channel: 0}}),
-    /Unknown GeoZarr selection dimension channel/
-  );
-  await t.rejects(
-    source.getRaster({viewport, selection: {time: 2}}),
-    /time index 2 is out of bounds/
-  );
-  await t.rejects(
-    source.getRaster({viewport, resampleMethod: 'bilinear'}),
-    /native nearest-neighbor windows only/
-  );
-  t.end();
+test('GeoZarrRasterSource validates browser viewport and dimension selections', async () => {
+    const source = createInMemoryGeoZarrSource();
+    const viewport = createViewport([
+        [100, 9],
+        [102, 10]
+    ], 'EPSG:3857');
+    await expect(source.getRaster({ viewport })).rejects.toThrow(/does not support reprojection/);
+    viewport.crs = 'EPSG:4326';
+    await expect(source.getRaster({ viewport, selection: { channel: 0 } })).rejects.toThrow(/Unknown GeoZarr selection dimension channel/);
+    await expect(source.getRaster({ viewport, selection: { time: 2 } })).rejects.toThrow(/time index 2 is out of bounds/);
+    await expect(source.getRaster({ viewport, resampleMethod: 'bilinear' })).rejects.toThrow(/native nearest-neighbor windows only/);
 });
-
 /** Creates a GeoZarr source backed by a small in-memory CF/xarray-style Zarr v3 store. */
 function createInMemoryGeoZarrSource(): GeoZarrRasterSource {
-  const baseUrl = 'https://example.com/browser-cf.zarr';
-  const options: GeoZarrSourceLoaderOptions = {
-    core: {loadOptions: {core: {fetch: createCFZarrFetcher(baseUrl)}}},
-    zarr: {requireConsolidatedMetadata: false},
-    geozarr: {array: 'temperature', defaultSelection: {time: 1}}
-  };
-  return new GeoZarrRasterSource(baseUrl, options);
+    const baseUrl = 'https://example.com/browser-cf.zarr';
+    const options: GeoZarrSourceLoaderOptions = {
+        core: { loadOptions: { core: { fetch: createCFZarrFetcher(baseUrl) } } },
+        zarr: { requireConsolidatedMetadata: false },
+        geozarr: { array: 'temperature', defaultSelection: { time: 1 } }
+    };
+    return new GeoZarrRasterSource(baseUrl, options);
 }
-
 /** Creates the minimal viewport shape accepted by raster sources. */
-function createViewport(
-  bounds: RasterBoundingBox,
-  coordinateReferenceSystem?: string
-): RasterViewport {
-  const [[minimumX, minimumY], [maximumX, maximumY]] = bounds;
-  return {
-    id: 'geo-zarr-browser-test',
-    width: 256,
-    height: 256,
-    zoom: 0,
-    center: [(minimumX + maximumX) / 2, (minimumY + maximumY) / 2],
-    crs: coordinateReferenceSystem,
-    bounds,
-    project: coordinates => coordinates,
-    unprojectPosition: position => [position[0], position[1], position[2] || 0]
-  };
+function createViewport(bounds: RasterBoundingBox, coordinateReferenceSystem?: string): RasterViewport {
+    const [[minimumX, minimumY], [maximumX, maximumY]] = bounds;
+    return {
+        id: 'geo-zarr-browser-test',
+        width: 256,
+        height: 256,
+        zoom: 0,
+        center: [(minimumX + maximumX) / 2, (minimumY + maximumY) / 2],
+        crs: coordinateReferenceSystem,
+        bounds,
+        project: coordinates => coordinates,
+        unprojectPosition: position => [position[0], position[1], position[2] || 0]
+    };
 }
-
 /** Creates an in-memory HTTP view of a small xarray-style Zarr v3 climate store. */
 function createCFZarrFetcher(baseUrl: string): typeof fetch {
-  const responses = new Map<string, BodyInit>([
-    [`${baseUrl}/zarr.json`, encodeJson(createGroupMetadata())],
-    [
-      `${baseUrl}/temperature/zarr.json`,
-      encodeJson(
-        createArrayMetadata([2, 2, 3], [1, 2, 3], 'uint8', ['time', 'latitude', 'longitude'], {
-          long_name: 'Air temperature',
-          _FillValue: 255
-        })
-      )
-    ],
-    [`${baseUrl}/temperature/c/0/0/0`, new Uint8Array([1, 2, 3, 4, 5, 6])],
-    [`${baseUrl}/temperature/c/1/0/0`, new Uint8Array([11, 12, 13, 14, 15, 16])],
-    [
-      `${baseUrl}/latitude/zarr.json`,
-      encodeJson(
-        createArrayMetadata([2], [2], 'float64', ['latitude'], {
-          standard_name: 'latitude',
-          units: 'degrees_north'
-        })
-      )
-    ],
-    [`${baseUrl}/latitude/c/0`, encodeFloat64([10, 9])],
-    [
-      `${baseUrl}/longitude/zarr.json`,
-      encodeJson(
-        createArrayMetadata([3], [3], 'float64', ['longitude'], {
-          standard_name: 'longitude',
-          units: 'degrees_east'
-        })
-      )
-    ],
-    [`${baseUrl}/longitude/c/0`, encodeFloat64([100, 101, 102])]
-  ]);
-
-  return (async input => {
-    const url = input instanceof Request ? input.url : String(input);
-    const body = responses.get(url);
-    return body ? new Response(body) : new Response(null, {status: 404});
-  }) as typeof fetch;
+    const responses = new Map<string, BodyInit>([
+        [`${baseUrl}/zarr.json`, encodeJson(createGroupMetadata())],
+        [
+            `${baseUrl}/temperature/zarr.json`,
+            encodeJson(createArrayMetadata([2, 2, 3], [1, 2, 3], 'uint8', ['time', 'latitude', 'longitude'], {
+                long_name: 'Air temperature',
+                _FillValue: 255
+            }))
+        ],
+        [`${baseUrl}/temperature/c/0/0/0`, new Uint8Array([1, 2, 3, 4, 5, 6])],
+        [`${baseUrl}/temperature/c/1/0/0`, new Uint8Array([11, 12, 13, 14, 15, 16])],
+        [
+            `${baseUrl}/latitude/zarr.json`,
+            encodeJson(createArrayMetadata([2], [2], 'float64', ['latitude'], {
+                standard_name: 'latitude',
+                units: 'degrees_north'
+            }))
+        ],
+        [`${baseUrl}/latitude/c/0`, encodeFloat64([10, 9])],
+        [
+            `${baseUrl}/longitude/zarr.json`,
+            encodeJson(createArrayMetadata([3], [3], 'float64', ['longitude'], {
+                standard_name: 'longitude',
+                units: 'degrees_east'
+            }))
+        ],
+        [`${baseUrl}/longitude/c/0`, encodeFloat64([100, 101, 102])]
+    ]);
+    return (async (input) => {
+        const url = input instanceof Request ? input.url : String(input);
+        const body = responses.get(url);
+        return body ? new Response(body) : new Response(null, { status: 404 });
+    }) as typeof fetch;
 }
-
 /** Creates minimal Zarr v3 group metadata. */
 function createGroupMetadata(): Record<string, unknown> {
-  return {zarr_format: 3, node_type: 'group', attributes: {}};
+    return { zarr_format: 3, node_type: 'group', attributes: {} };
 }
-
 /** Creates minimal uncompressed Zarr v3 array metadata. */
-function createArrayMetadata(
-  shape: number[],
-  chunks: number[],
-  dataType: 'uint8' | 'float64',
-  dimensionNames: string[],
-  attributes: Record<string, unknown>
-): Record<string, unknown> {
-  return {
-    zarr_format: 3,
-    node_type: 'array',
-    shape,
-    data_type: dataType,
-    chunk_grid: {name: 'regular', configuration: {chunk_shape: chunks}},
-    chunk_key_encoding: {name: 'default', configuration: {separator: '/'}},
-    codecs: [{name: 'bytes', configuration: {endian: 'little'}}],
-    fill_value: 0,
-    dimension_names: dimensionNames,
-    attributes
-  };
+function createArrayMetadata(shape: number[], chunks: number[], dataType: 'uint8' | 'float64', dimensionNames: string[], attributes: Record<string, unknown>): Record<string, unknown> {
+    return {
+        zarr_format: 3,
+        node_type: 'array',
+        shape,
+        data_type: dataType,
+        chunk_grid: { name: 'regular', configuration: { chunk_shape: chunks } },
+        chunk_key_encoding: { name: 'default', configuration: { separator: '/' } },
+        codecs: [{ name: 'bytes', configuration: { endian: 'little' } }],
+        fill_value: 0,
+        dimension_names: dimensionNames,
+        attributes
+    };
 }
-
 /** Encodes Zarr metadata as UTF-8 bytes. */
 function encodeJson(value: unknown): Uint8Array {
-  return new TextEncoder().encode(JSON.stringify(value));
+    return new TextEncoder().encode(JSON.stringify(value));
 }
-
 /** Encodes float64 coordinate values using the explicit Zarr little-endian byte order. */
 function encodeFloat64(values: number[]): Uint8Array {
-  const buffer = new ArrayBuffer(values.length * Float64Array.BYTES_PER_ELEMENT);
-  const dataView = new DataView(buffer);
-  values.forEach((value, index) =>
-    dataView.setFloat64(index * Float64Array.BYTES_PER_ELEMENT, value, true)
-  );
-  return new Uint8Array(buffer);
+    const buffer = new ArrayBuffer(values.length * Float64Array.BYTES_PER_ELEMENT);
+    const dataView = new DataView(buffer);
+    values.forEach((value, index) => dataView.setFloat64(index * Float64Array.BYTES_PER_ELEMENT, value, true));
+    return new Uint8Array(buffer);
 }

--- a/modules/zarr/test/geo-zarr-source.node.spec.ts
+++ b/modules/zarr/test/geo-zarr-source.node.spec.ts
@@ -1,250 +1,190 @@
 // loaders.gl
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
-
-import {pathToFileURL} from 'node:url';
+import { pathToFileURL } from 'node:url';
 import '@loaders.gl/polyfills';
-import test from 'test/utils/vitest-tape';
-import {createDataSource, resolvePath} from '@loaders.gl/core';
-import {
-  GeoZarrRasterSource,
-  GeoZarrSourceLoader,
-  type GeoZarrSourceLoaderOptions
-} from '@loaders.gl/zarr';
-import type {RasterBoundingBox, RasterViewport} from '@loaders.gl/loader-utils';
-
+import { expect, test } from "vitest";
+import { createDataSource, resolvePath } from '@loaders.gl/core';
+import { GeoZarrRasterSource, GeoZarrSourceLoader, type GeoZarrSourceLoaderOptions } from '@loaders.gl/zarr';
+import type { RasterBoundingBox, RasterViewport } from '@loaders.gl/loader-utils';
 const CONTENT_BASE = resolvePath('@loaders.gl/zarr/test/data');
 const SPATIALDATA_V3_FIXTURE = `${CONTENT_BASE}/spatialdata-v3.zarr`;
 const SPATIALDATA_V3_FIXTURE_URL = pathToFileURL(SPATIALDATA_V3_FIXTURE).href;
-
 /** Creates the minimal viewport shape accepted by raster sources. */
-function createViewport(
-  bounds: RasterBoundingBox,
-  coordinateReferenceSystem?: string
-): RasterViewport {
-  const [[minimumX, minimumY], [maximumX, maximumY]] = bounds;
-  return {
-    id: 'geo-zarr-test',
-    width: 256,
-    height: 256,
-    zoom: 0,
-    center: [(minimumX + maximumX) / 2, (minimumY + maximumY) / 2],
-    crs: coordinateReferenceSystem,
-    bounds,
-    project: coordinates => coordinates,
-    unprojectPosition: position => [position[0], position[1], position[2] || 0]
-  };
+function createViewport(bounds: RasterBoundingBox, coordinateReferenceSystem?: string): RasterViewport {
+    const [[minimumX, minimumY], [maximumX, maximumY]] = bounds;
+    return {
+        id: 'geo-zarr-test',
+        width: 256,
+        height: 256,
+        zoom: 0,
+        center: [(minimumX + maximumX) / 2, (minimumY + maximumY) / 2],
+        crs: coordinateReferenceSystem,
+        bounds,
+        project: coordinates => coordinates,
+        unprojectPosition: position => [position[0], position[1], position[2] || 0]
+    };
 }
-
-test('GeoZarrSourceLoader creates a source via createDataSource()', t => {
-  const source = createDataSource(SPATIALDATA_V3_FIXTURE_URL, [GeoZarrSourceLoader], {
-    zarr: {path: 'images/example-image'},
-    geozarr: {array: '0'}
-  });
-
-  t.ok(source instanceof GeoZarrRasterSource);
-  t.end();
+test('GeoZarrSourceLoader creates a source via createDataSource()', () => {
+    const source = createDataSource(SPATIALDATA_V3_FIXTURE_URL, [GeoZarrSourceLoader], {
+        zarr: { path: 'images/example-image' },
+        geozarr: { array: '0' }
+    });
+    expect(source instanceof GeoZarrRasterSource).toBeTruthy();
 });
-
-test('GeoZarrRasterSource reads GeoZarr proj and spatial metadata', async t => {
-  const source = createDataSource(SPATIALDATA_V3_FIXTURE_URL, [GeoZarrSourceLoader], {
-    zarr: {path: 'images/example-image'},
-    geozarr: {array: '0', defaultSelection: {c: 1}}
-  });
-  const metadata = await source.getMetadata();
-
-  t.equal(metadata.name, 'Example georeferenced image');
-  t.equal(metadata.crs, 'EPSG:4326');
-  t.deepEqual(metadata.boundingBox, [
-    [-20, -6.7],
-    [23.9, 10]
-  ]);
-  t.deepEqual(metadata.dimensions, ['t', 'c', 'z', 'y', 'x']);
-  t.deepEqual(metadata.spatialDimensions, ['y', 'x']);
-  t.deepEqual(metadata.selectionDimensions, [
-    {name: 't', size: 1, defaultIndex: 0},
-    {name: 'c', size: 3, defaultIndex: 1},
-    {name: 'z', size: 1, defaultIndex: 0}
-  ]);
-  t.deepEqual(metadata.tileSize, {width: 439, height: 167});
-  t.end();
+test('GeoZarrRasterSource reads GeoZarr proj and spatial metadata', async () => {
+    const source = createDataSource(SPATIALDATA_V3_FIXTURE_URL, [GeoZarrSourceLoader], {
+        zarr: { path: 'images/example-image' },
+        geozarr: { array: '0', defaultSelection: { c: 1 } }
+    });
+    const metadata = await source.getMetadata();
+    expect(metadata.name).toBe('Example georeferenced image');
+    expect(metadata.crs).toBe('EPSG:4326');
+    expect(metadata.boundingBox).toEqual([
+        [-20, -6.7],
+        [23.9, 10]
+    ]);
+    expect(metadata.dimensions).toEqual(['t', 'c', 'z', 'y', 'x']);
+    expect(metadata.spatialDimensions).toEqual(['y', 'x']);
+    expect(metadata.selectionDimensions).toEqual([
+        { name: 't', size: 1, defaultIndex: 0 },
+        { name: 'c', size: 3, defaultIndex: 1 },
+        { name: 'z', size: 1, defaultIndex: 0 }
+    ]);
+    expect(metadata.tileSize).toEqual({ width: 439, height: 167 });
 });
-
-test('GeoZarrRasterSource reads a native spatial window and named dimension selection', async t => {
-  const source = createDataSource(SPATIALDATA_V3_FIXTURE_URL, [GeoZarrSourceLoader], {
-    zarr: {path: 'images/example-image'},
-    geozarr: {array: '0'}
-  });
-  const raster = await source.getRaster({
-    viewport: createViewport(
-      [
+test('GeoZarrRasterSource reads a native spatial window and named dimension selection', async () => {
+    const source = createDataSource(SPATIALDATA_V3_FIXTURE_URL, [GeoZarrSourceLoader], {
+        zarr: { path: 'images/example-image' },
+        geozarr: { array: '0' }
+    });
+    const raster = await source.getRaster({
+        viewport: createViewport([
+            [-20, 9],
+            [-19, 10]
+        ], 'EPSG:4326'),
+        selection: { t: 0, c: 2, z: 0 }
+    });
+    expect(raster.width).toBe(10);
+    expect(raster.height).toBe(10);
+    expect(raster.bandCount).toBe(1);
+    expect(raster.dtype).toBe('int8');
+    expect(raster.data instanceof Int8Array).toBeTruthy();
+    expect(raster.data.length).toBe(100);
+    expect(raster.boundingBox).toEqual([
         [-20, 9],
         [-19, 10]
-      ],
-      'EPSG:4326'
-    ),
-    selection: {t: 0, c: 2, z: 0}
-  });
-
-  t.equal(raster.width, 10);
-  t.equal(raster.height, 10);
-  t.equal(raster.bandCount, 1);
-  t.equal(raster.dtype, 'int8');
-  t.ok(raster.data instanceof Int8Array);
-  t.equal(raster.data.length, 100);
-  t.deepEqual(raster.boundingBox, [
-    [-20, 9],
-    [-19, 10]
-  ]);
-  t.end();
+    ]);
 });
-
-test('GeoZarrRasterSource derives georeferencing from regular CF coordinate arrays', async t => {
-  const baseUrl = 'https://example.com/cf.zarr';
-  const fetcher = createCFZarrFetcher(baseUrl);
-  const options: GeoZarrSourceLoaderOptions = {
-    core: {
-      loadOptions: {
-        core: {fetch: fetcher as typeof fetch}
-      }
-    },
-    zarr: {requireConsolidatedMetadata: false},
-    geozarr: {array: 'temperature', defaultSelection: {time: 1}}
-  };
-  const source = new GeoZarrRasterSource(baseUrl, options);
-  const metadata = await source.getMetadata();
-  const raster = await source.getRaster({
-    viewport: createViewport(
-      [
-        [100.5, 8.5],
+test('GeoZarrRasterSource derives georeferencing from regular CF coordinate arrays', async () => {
+    const baseUrl = 'https://example.com/cf.zarr';
+    const fetcher = createCFZarrFetcher(baseUrl);
+    const options: GeoZarrSourceLoaderOptions = {
+        core: {
+            loadOptions: {
+                core: { fetch: fetcher as typeof fetch }
+            }
+        },
+        zarr: { requireConsolidatedMetadata: false },
+        geozarr: { array: 'temperature', defaultSelection: { time: 1 } }
+    };
+    const source = new GeoZarrRasterSource(baseUrl, options);
+    const metadata = await source.getMetadata();
+    const raster = await source.getRaster({
+        viewport: createViewport([
+            [100.5, 8.5],
+            [102.5, 10.5]
+        ], 'EPSG:4326')
+    });
+    expect(metadata.crs).toBe('EPSG:4326');
+    expect(metadata.transform).toEqual([1, 0, 99.5, 0, -1, 10.5]);
+    expect(metadata.boundingBox).toEqual([
+        [99.5, 8.5],
         [102.5, 10.5]
-      ],
-      'EPSG:4326'
-    )
-  });
-
-  t.equal(metadata.crs, 'EPSG:4326');
-  t.deepEqual(metadata.transform, [1, 0, 99.5, 0, -1, 10.5]);
-  t.deepEqual(metadata.boundingBox, [
-    [99.5, 8.5],
-    [102.5, 10.5]
-  ]);
-  t.deepEqual(metadata.selectionDimensions, [{name: 'time', size: 2, defaultIndex: 1}]);
-  t.equal(metadata.noData, 255);
-  t.equal(raster.width, 2);
-  t.equal(raster.height, 2);
-  t.deepEqual(Array.from(raster.data as Uint8Array), [12, 13, 15, 16]);
-  t.end();
+    ]);
+    expect(metadata.selectionDimensions).toEqual([{ name: 'time', size: 2, defaultIndex: 1 }]);
+    expect(metadata.noData).toBe(255);
+    expect(raster.width).toBe(2);
+    expect(raster.height).toBe(2);
+    expect(Array.from(raster.data as Uint8Array)).toEqual([12, 13, 15, 16]);
 });
-
-test('GeoZarrRasterSource validates CRS and named selections', async t => {
-  const source = createDataSource(SPATIALDATA_V3_FIXTURE_URL, [GeoZarrSourceLoader], {
-    zarr: {path: 'images/example-image'},
-    geozarr: {array: '0'}
-  });
-  const viewport = createViewport(
-    [
-      [-20, 9],
-      [-19, 10]
-    ],
-    'EPSG:3857'
-  );
-
-  await t.rejects(source.getRaster({viewport}), /does not support reprojection/);
-  viewport.crs = 'EPSG:4326';
-  await t.rejects(
-    source.getRaster({viewport, selection: {time: 0}}),
-    /Unknown GeoZarr selection dimension time/
-  );
-  await t.rejects(
-    source.getRaster({viewport, selection: {c: 3}}),
-    /c index 3 is out of bounds/
-  );
-  t.end();
+test('GeoZarrRasterSource validates CRS and named selections', async () => {
+    const source = createDataSource(SPATIALDATA_V3_FIXTURE_URL, [GeoZarrSourceLoader], {
+        zarr: { path: 'images/example-image' },
+        geozarr: { array: '0' }
+    });
+    const viewport = createViewport([
+        [-20, 9],
+        [-19, 10]
+    ], 'EPSG:3857');
+    await expect(source.getRaster({ viewport })).rejects.toThrow(/does not support reprojection/);
+    viewport.crs = 'EPSG:4326';
+    await expect(source.getRaster({ viewport, selection: { time: 0 } })).rejects.toThrow(/Unknown GeoZarr selection dimension time/);
+    await expect(source.getRaster({ viewport, selection: { c: 3 } })).rejects.toThrow(/c index 3 is out of bounds/);
 });
-
 /** Creates an in-memory HTTP view of a small xarray-style Zarr v3 climate store. */
 function createCFZarrFetcher(baseUrl: string): typeof fetch {
-  const responses = new Map<string, BodyInit>([
-    [`${baseUrl}/zarr.json`, encodeJson(createGroupMetadata())],
-    [
-      `${baseUrl}/temperature/zarr.json`,
-      encodeJson(
-        createArrayMetadata([2, 2, 3], [1, 2, 3], 'uint8', ['time', 'latitude', 'longitude'], {
-          long_name: 'Air temperature',
-          _FillValue: 255
-        })
-      )
-    ],
-    [`${baseUrl}/temperature/c/0/0/0`, new Uint8Array([1, 2, 3, 4, 5, 6])],
-    [`${baseUrl}/temperature/c/1/0/0`, new Uint8Array([11, 12, 13, 14, 15, 16])],
-    [
-      `${baseUrl}/latitude/zarr.json`,
-      encodeJson(
-        createArrayMetadata([2], [2], 'float64', ['latitude'], {
-          standard_name: 'latitude',
-          units: 'degrees_north'
-        })
-      )
-    ],
-    [`${baseUrl}/latitude/c/0`, encodeFloat64([10, 9])],
-    [
-      `${baseUrl}/longitude/zarr.json`,
-      encodeJson(
-        createArrayMetadata([3], [3], 'float64', ['longitude'], {
-          standard_name: 'longitude',
-          units: 'degrees_east'
-        })
-      )
-    ],
-    [`${baseUrl}/longitude/c/0`, encodeFloat64([100, 101, 102])]
-  ]);
-
-  return (async input => {
-    const url = input instanceof Request ? input.url : String(input);
-    const body = responses.get(url);
-    return body ? new Response(body) : new Response(null, {status: 404});
-  }) as typeof fetch;
+    const responses = new Map<string, BodyInit>([
+        [`${baseUrl}/zarr.json`, encodeJson(createGroupMetadata())],
+        [
+            `${baseUrl}/temperature/zarr.json`,
+            encodeJson(createArrayMetadata([2, 2, 3], [1, 2, 3], 'uint8', ['time', 'latitude', 'longitude'], {
+                long_name: 'Air temperature',
+                _FillValue: 255
+            }))
+        ],
+        [`${baseUrl}/temperature/c/0/0/0`, new Uint8Array([1, 2, 3, 4, 5, 6])],
+        [`${baseUrl}/temperature/c/1/0/0`, new Uint8Array([11, 12, 13, 14, 15, 16])],
+        [
+            `${baseUrl}/latitude/zarr.json`,
+            encodeJson(createArrayMetadata([2], [2], 'float64', ['latitude'], {
+                standard_name: 'latitude',
+                units: 'degrees_north'
+            }))
+        ],
+        [`${baseUrl}/latitude/c/0`, encodeFloat64([10, 9])],
+        [
+            `${baseUrl}/longitude/zarr.json`,
+            encodeJson(createArrayMetadata([3], [3], 'float64', ['longitude'], {
+                standard_name: 'longitude',
+                units: 'degrees_east'
+            }))
+        ],
+        [`${baseUrl}/longitude/c/0`, encodeFloat64([100, 101, 102])]
+    ]);
+    return (async (input) => {
+        const url = input instanceof Request ? input.url : String(input);
+        const body = responses.get(url);
+        return body ? new Response(body) : new Response(null, { status: 404 });
+    }) as typeof fetch;
 }
-
 /** Creates minimal Zarr v3 group metadata. */
 function createGroupMetadata(): Record<string, unknown> {
-  return {zarr_format: 3, node_type: 'group', attributes: {}};
+    return { zarr_format: 3, node_type: 'group', attributes: {} };
 }
-
 /** Creates minimal uncompressed Zarr v3 array metadata. */
-function createArrayMetadata(
-  shape: number[],
-  chunks: number[],
-  dataType: 'uint8' | 'float64',
-  dimensionNames: string[],
-  attributes: Record<string, unknown>
-): Record<string, unknown> {
-  return {
-    zarr_format: 3,
-    node_type: 'array',
-    shape,
-    data_type: dataType,
-    chunk_grid: {name: 'regular', configuration: {chunk_shape: chunks}},
-    chunk_key_encoding: {name: 'default', configuration: {separator: '/'}},
-    codecs: [{name: 'bytes', configuration: {endian: 'little'}}],
-    fill_value: 0,
-    dimension_names: dimensionNames,
-    attributes
-  };
+function createArrayMetadata(shape: number[], chunks: number[], dataType: 'uint8' | 'float64', dimensionNames: string[], attributes: Record<string, unknown>): Record<string, unknown> {
+    return {
+        zarr_format: 3,
+        node_type: 'array',
+        shape,
+        data_type: dataType,
+        chunk_grid: { name: 'regular', configuration: { chunk_shape: chunks } },
+        chunk_key_encoding: { name: 'default', configuration: { separator: '/' } },
+        codecs: [{ name: 'bytes', configuration: { endian: 'little' } }],
+        fill_value: 0,
+        dimension_names: dimensionNames,
+        attributes
+    };
 }
-
 /** Encodes JSON metadata as UTF-8 bytes. */
 function encodeJson(value: unknown): Uint8Array {
-  return new TextEncoder().encode(JSON.stringify(value));
+    return new TextEncoder().encode(JSON.stringify(value));
 }
-
 /** Encodes float64 coordinate values using the explicit Zarr little-endian byte order. */
 function encodeFloat64(values: number[]): Uint8Array {
-  const buffer = new ArrayBuffer(values.length * Float64Array.BYTES_PER_ELEMENT);
-  const dataView = new DataView(buffer);
-  values.forEach((value, index) =>
-    dataView.setFloat64(index * Float64Array.BYTES_PER_ELEMENT, value, true)
-  );
-  return new Uint8Array(buffer);
+    const buffer = new ArrayBuffer(values.length * Float64Array.BYTES_PER_ELEMENT);
+    const dataView = new DataView(buffer);
+    values.forEach((value, index) => dataView.setFloat64(index * Float64Array.BYTES_PER_ELEMENT, value, true));
+    return new Uint8Array(buffer);
 }

--- a/modules/zarr/test/ome-zarr-source.browser.spec.ts
+++ b/modules/zarr/test/ome-zarr-source.browser.spec.ts
@@ -1,154 +1,128 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
-import {createDataSource} from '@loaders.gl/core';
-import {
-  OMEZarrImageSource,
-  OMEZarrSourceLoader,
-  type ZarrSourceLoaderOptions
-} from '@loaders.gl/zarr';
-
+import { expect, test } from "vitest";
+import { createDataSource } from '@loaders.gl/core';
+import { OMEZarrImageSource, OMEZarrSourceLoader, type ZarrSourceLoaderOptions } from '@loaders.gl/zarr';
 const SPATIALDATA_V3_FIXTURE_URL = '/modules/zarr/test/data/spatialdata-v3.zarr';
-
-test('OMEZarrSourceLoader supports browser-relative store URLs', async t => {
-  const source = createDataSource(SPATIALDATA_V3_FIXTURE_URL, [OMEZarrSourceLoader], {
-    zarr: {path: 'images/example-image'}
-  });
-  const metadata = await source.getMetadata();
-
-  t.equal(metadata.name, 'ome-zarr example');
-  t.equal(metadata.width, 439);
-  t.equal(metadata.height, 167);
-  t.equal(metadata.bandCount, 3);
-  t.end();
+test('OMEZarrSourceLoader supports browser-relative store URLs', async () => {
+    const source = createDataSource(SPATIALDATA_V3_FIXTURE_URL, [OMEZarrSourceLoader], {
+        zarr: { path: 'images/example-image' }
+    });
+    const metadata = await source.getMetadata();
+    expect(metadata.name).toBe('ome-zarr example');
+    expect(metadata.width).toBe(439);
+    expect(metadata.height).toBe(167);
+    expect(metadata.bandCount).toBe(3);
 });
-
-test('OMEZarrImageSource reads metadata and channel data in browsers', async t => {
-  const source = createInMemoryOMEZarrSource();
-  const metadata = await source.getMetadata();
-  const queryMetadata = await source.getQueryMetadata();
-  const planarRaster = await source.getRaster({channels: [0, 2]});
-  const interleavedRaster = await source.getRaster({channels: [0, 1], interleaved: true});
-
-  t.equal(metadata.name, 'Browser OME fixture');
-  t.equal(metadata.width, 3);
-  t.equal(metadata.height, 2);
-  t.equal(metadata.bandCount, 3);
-  t.equal(metadata.dtype, 'uint8');
-  t.deepEqual(queryMetadata.execution, {status: 'supported', method: 'getRaster'});
-  t.deepEqual(metadata.labels, ['t', 'c', 'z', 'y', 'x']);
-  t.deepEqual(metadata.tileSize, {width: 3, height: 2});
-  t.deepEqual(metadata.channels, [
-    {index: 0, name: 'red', color: 'FF0000', active: true},
-    {index: 1, name: 'green', color: '00FF00', active: true},
-    {index: 2, name: 'blue', color: '0000FF', active: false}
-  ]);
-
-  t.ok(Array.isArray(planarRaster.data));
-  t.deepEqual(Array.from(planarRaster.data[0]), [1, 2, 3, 4, 5, 6]);
-  t.deepEqual(Array.from(planarRaster.data[1]), [21, 22, 23, 24, 25, 26]);
-  t.equal(planarRaster.width, 3);
-  t.equal(planarRaster.height, 2);
-  t.equal(planarRaster.bandCount, 2);
-
-  t.ok(interleavedRaster.data instanceof Uint8Array);
-  t.deepEqual(Array.from(interleavedRaster.data as Uint8Array), [1, 11, 2, 12, 3, 13, 4, 14, 5, 15, 6, 16]);
-  t.equal(interleavedRaster.bandCount, 2);
-  t.equal(interleavedRaster.interleaved, true);
-  t.end();
+test('OMEZarrImageSource reads metadata and channel data in browsers', async () => {
+    const source = createInMemoryOMEZarrSource();
+    const metadata = await source.getMetadata();
+    const queryMetadata = await source.getQueryMetadata();
+    const planarRaster = await source.getRaster({ channels: [0, 2] });
+    const interleavedRaster = await source.getRaster({ channels: [0, 1], interleaved: true });
+    expect(metadata.name).toBe('Browser OME fixture');
+    expect(metadata.width).toBe(3);
+    expect(metadata.height).toBe(2);
+    expect(metadata.bandCount).toBe(3);
+    expect(metadata.dtype).toBe('uint8');
+    expect(queryMetadata.execution).toEqual({ status: 'supported', method: 'getRaster' });
+    expect(metadata.labels).toEqual(['t', 'c', 'z', 'y', 'x']);
+    expect(metadata.tileSize).toEqual({ width: 3, height: 2 });
+    expect(metadata.channels).toEqual([
+        { index: 0, name: 'red', color: 'FF0000', active: true },
+        { index: 1, name: 'green', color: '00FF00', active: true },
+        { index: 2, name: 'blue', color: '0000FF', active: false }
+    ]);
+    expect(Array.isArray(planarRaster.data)).toBeTruthy();
+    expect(Array.from(planarRaster.data[0])).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(Array.from(planarRaster.data[1])).toEqual([21, 22, 23, 24, 25, 26]);
+    expect(planarRaster.width).toBe(3);
+    expect(planarRaster.height).toBe(2);
+    expect(planarRaster.bandCount).toBe(2);
+    expect(interleavedRaster.data instanceof Uint8Array).toBeTruthy();
+    expect(Array.from(interleavedRaster.data as Uint8Array)).toEqual([1, 11, 2, 12, 3, 13, 4, 14, 5, 15, 6, 16]);
+    expect(interleavedRaster.bandCount).toBe(2);
+    expect(interleavedRaster.interleaved).toBe(true);
 });
-
-test('OMEZarrImageSource validates browser raster selections', async t => {
-  const source = createInMemoryOMEZarrSource();
-
-  await t.rejects(source.getRaster({level: 1}), /pyramid level 1 is not available/);
-  await t.rejects(source.getRaster({channels: []}), /must include at least one channel/);
-  await t.rejects(source.getRaster({channels: [3]}), /Channel 3 is out of bounds/);
-  await t.rejects(source.getRaster({t: 1}), /time index 1 is out of bounds/);
-  await t.rejects(source.getRaster({z: -1}), /z index -1 is out of bounds/);
-  t.end();
+test('OMEZarrImageSource validates browser raster selections', async () => {
+    const source = createInMemoryOMEZarrSource();
+    await expect(source.getRaster({ level: 1 })).rejects.toThrow(/pyramid level 1 is not available/);
+    await expect(source.getRaster({ channels: [] })).rejects.toThrow(/must include at least one channel/);
+    await expect(source.getRaster({ channels: [3] })).rejects.toThrow(/Channel 3 is out of bounds/);
+    await expect(source.getRaster({ t: 1 })).rejects.toThrow(/time index 1 is out of bounds/);
+    await expect(source.getRaster({ z: -1 })).rejects.toThrow(/z index -1 is out of bounds/);
 });
-
 /** Creates an OME-Zarr source backed by a small in-memory Zarr v3 store. */
 function createInMemoryOMEZarrSource(): OMEZarrImageSource {
-  const baseUrl = 'https://example.com/browser-ome.zarr';
-  const options: ZarrSourceLoaderOptions = {
-    core: {loadOptions: {core: {fetch: createOMEZarrFetcher(baseUrl)}}},
-    zarr: {requireConsolidatedMetadata: false}
-  };
-  return new OMEZarrImageSource(baseUrl, options);
+    const baseUrl = 'https://example.com/browser-ome.zarr';
+    const options: ZarrSourceLoaderOptions = {
+        core: { loadOptions: { core: { fetch: createOMEZarrFetcher(baseUrl) } } },
+        zarr: { requireConsolidatedMetadata: false }
+    };
+    return new OMEZarrImageSource(baseUrl, options);
 }
-
 /** Creates an in-memory HTTP view of a small OME-Zarr v3 store. */
 function createOMEZarrFetcher(baseUrl: string): typeof fetch {
-  const responses = new Map<string, BodyInit>([
-    [`${baseUrl}/zarr.json`, encodeJson(createOMEGroupMetadata())],
-    [`${baseUrl}/0/zarr.json`, encodeJson(createOMEArrayMetadata())],
-    [`${baseUrl}/0/c/0/0/0/0/0`, new Uint8Array([1, 2, 3, 4, 5, 6])],
-    [`${baseUrl}/0/c/0/1/0/0/0`, new Uint8Array([11, 12, 13, 14, 15, 16])],
-    [`${baseUrl}/0/c/0/2/0/0/0`, new Uint8Array([21, 22, 23, 24, 25, 26])]
-  ]);
-
-  return (async input => {
-    const url = input instanceof Request ? input.url : String(input);
-    const body = responses.get(url);
-    return body ? new Response(body) : new Response(null, {status: 404});
-  }) as typeof fetch;
+    const responses = new Map<string, BodyInit>([
+        [`${baseUrl}/zarr.json`, encodeJson(createOMEGroupMetadata())],
+        [`${baseUrl}/0/zarr.json`, encodeJson(createOMEArrayMetadata())],
+        [`${baseUrl}/0/c/0/0/0/0/0`, new Uint8Array([1, 2, 3, 4, 5, 6])],
+        [`${baseUrl}/0/c/0/1/0/0/0`, new Uint8Array([11, 12, 13, 14, 15, 16])],
+        [`${baseUrl}/0/c/0/2/0/0/0`, new Uint8Array([21, 22, 23, 24, 25, 26])]
+    ]);
+    return (async (input) => {
+        const url = input instanceof Request ? input.url : String(input);
+        const body = responses.get(url);
+        return body ? new Response(body) : new Response(null, { status: 404 });
+    }) as typeof fetch;
 }
-
 /** Creates OME metadata for the in-memory image group. */
 function createOMEGroupMetadata(): Record<string, unknown> {
-  return {
-    zarr_format: 3,
-    node_type: 'group',
-    attributes: {
-      ome: {
-        multiscales: [
-          {
-            version: '0.5',
-            axes: [
-              {name: 't', type: 'time'},
-              {name: 'c', type: 'channel'},
-              {name: 'z', type: 'space'},
-              {name: 'y', type: 'space'},
-              {name: 'x', type: 'space'}
-            ],
-            datasets: [{path: '0'}]
-          }
-        ],
-        omero: {
-          name: 'Browser OME fixture',
-          channels: [
-            {active: true, color: 'FF0000', label: 'red'},
-            {active: true, color: '00FF00', label: 'green'},
-            {active: false, color: '0000FF', label: 'blue'}
-          ],
-          rdefs: {defaultT: 0, defaultZ: 0, model: 'color'}
+    return {
+        zarr_format: 3,
+        node_type: 'group',
+        attributes: {
+            ome: {
+                multiscales: [
+                    {
+                        version: '0.5',
+                        axes: [
+                            { name: 't', type: 'time' },
+                            { name: 'c', type: 'channel' },
+                            { name: 'z', type: 'space' },
+                            { name: 'y', type: 'space' },
+                            { name: 'x', type: 'space' }
+                        ],
+                        datasets: [{ path: '0' }]
+                    }
+                ],
+                omero: {
+                    name: 'Browser OME fixture',
+                    channels: [
+                        { active: true, color: 'FF0000', label: 'red' },
+                        { active: true, color: '00FF00', label: 'green' },
+                        { active: false, color: '0000FF', label: 'blue' }
+                    ],
+                    rdefs: { defaultT: 0, defaultZ: 0, model: 'color' }
+                }
+            }
         }
-      }
-    }
-  };
+    };
 }
-
 /** Creates uncompressed uint8 array metadata for the in-memory image. */
 function createOMEArrayMetadata(): Record<string, unknown> {
-  return {
-    zarr_format: 3,
-    node_type: 'array',
-    shape: [1, 3, 1, 2, 3],
-    data_type: 'uint8',
-    chunk_grid: {name: 'regular', configuration: {chunk_shape: [1, 1, 1, 2, 3]}},
-    chunk_key_encoding: {name: 'default', configuration: {separator: '/'}},
-    codecs: [{name: 'bytes', configuration: {endian: 'little'}}],
-    fill_value: 0,
-    dimension_names: ['t', 'c', 'z', 'y', 'x'],
-    attributes: {}
-  };
+    return {
+        zarr_format: 3,
+        node_type: 'array',
+        shape: [1, 3, 1, 2, 3],
+        data_type: 'uint8',
+        chunk_grid: { name: 'regular', configuration: { chunk_shape: [1, 1, 1, 2, 3] } },
+        chunk_key_encoding: { name: 'default', configuration: { separator: '/' } },
+        codecs: [{ name: 'bytes', configuration: { endian: 'little' } }],
+        fill_value: 0,
+        dimension_names: ['t', 'c', 'z', 'y', 'x'],
+        attributes: {}
+    };
 }
-
 /** Encodes Zarr metadata as UTF-8 bytes. */
 function encodeJson(value: unknown): Uint8Array {
-  return new TextEncoder().encode(JSON.stringify(value));
+    return new TextEncoder().encode(JSON.stringify(value));
 }

--- a/modules/zarr/test/ome-zarr-source.node.spec.ts
+++ b/modules/zarr/test/ome-zarr-source.node.spec.ts
@@ -1,189 +1,143 @@
 // loaders.gl
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
-
-import {pathToFileURL} from 'node:url';
+import { pathToFileURL } from 'node:url';
 import '@loaders.gl/polyfills';
-import test from 'test/utils/vitest-tape';
-import {createDataSource, fetchFile, resolvePath} from '@loaders.gl/core';
-import {
-  OMEZarrImageSource,
-  OMEZarrSourceLoader,
-  loadZarrConsolidatedMetadata
-} from '@loaders.gl/zarr';
-
+import { expect, test } from "vitest";
+import { createDataSource, fetchFile, resolvePath } from '@loaders.gl/core';
+import { OMEZarrImageSource, OMEZarrSourceLoader, loadZarrConsolidatedMetadata } from '@loaders.gl/zarr';
 const CONTENT_BASE = resolvePath('@loaders.gl/zarr/test/data');
 const OME_FIXTURE = `${CONTENT_BASE}/ome.zarr`;
 const OME_FIXTURE_URL = pathToFileURL(OME_FIXTURE).href;
 const SPATIALDATA_V3_FIXTURE = `${CONTENT_BASE}/spatialdata-v3.zarr`;
 const SPATIALDATA_V3_FIXTURE_URL = pathToFileURL(SPATIALDATA_V3_FIXTURE).href;
-
-function createOMEZarrSource(
-  url: string,
-  options: Parameters<typeof OMEZarrSourceLoader.createDataSource>[1] = {}
-): OMEZarrImageSource {
-  return createDataSource(url, [OMEZarrSourceLoader], options);
+function createOMEZarrSource(url: string, options: Parameters<typeof OMEZarrSourceLoader.createDataSource>[1] = {}): OMEZarrImageSource {
+    return createDataSource(url, [OMEZarrSourceLoader], options);
 }
-
-test('OMEZarrSourceLoader creates a source via createDataSource()', t => {
-  const source = createOMEZarrSource(OME_FIXTURE_URL);
-  t.ok(source instanceof OMEZarrImageSource);
-  t.end();
+test('OMEZarrSourceLoader creates a source via createDataSource()', () => {
+    const source = createOMEZarrSource(OME_FIXTURE_URL);
+    expect(source instanceof OMEZarrImageSource).toBeTruthy();
 });
-
-test('OMEZarrImageSource exposes normalized metadata', async t => {
-  const source = createOMEZarrSource(OME_FIXTURE_URL);
-  const metadata = await source.getMetadata();
-
-  t.equal(metadata.name, 'ome-zarr example');
-  t.equal(metadata.width, 439);
-  t.equal(metadata.height, 167);
-  t.equal(metadata.bandCount, 3);
-  t.equal(metadata.dtype, 'int8');
-  t.deepEqual(metadata.labels, ['t', 'c', 'z', 'y', 'x']);
-  t.equal(metadata.levels.length, 2);
-  t.deepEqual(metadata.tileSize, {width: 439, height: 167});
-  t.end();
+test('OMEZarrImageSource exposes normalized metadata', async () => {
+    const source = createOMEZarrSource(OME_FIXTURE_URL);
+    const metadata = await source.getMetadata();
+    expect(metadata.name).toBe('ome-zarr example');
+    expect(metadata.width).toBe(439);
+    expect(metadata.height).toBe(167);
+    expect(metadata.bandCount).toBe(3);
+    expect(metadata.dtype).toBe('int8');
+    expect(metadata.labels).toEqual(['t', 'c', 'z', 'y', 'x']);
+    expect(metadata.levels.length).toBe(2);
+    expect(metadata.tileSize).toEqual({ width: 439, height: 167 });
 });
-
-test('OMEZarrImageSource#getRaster returns planar and interleaved channel data', async t => {
-  const source = createOMEZarrSource(OME_FIXTURE_URL);
-  const planarRaster = await source.getRaster({channels: [0, 1, 2]});
-  const interleavedRaster = await source.getRaster({channels: [0, 2], interleaved: true});
-
-  t.equal(planarRaster.width, 439);
-  t.equal(planarRaster.height, 167);
-  t.equal(planarRaster.bandCount, 3);
-  t.equal(planarRaster.dtype, 'int8');
-  t.ok(Array.isArray(planarRaster.data), 'planar channel selection returns array data');
-  t.equal(planarRaster.data[0].length, 439 * 167);
-  t.notOk(Array.isArray(interleavedRaster.data), 'interleaved selection returns one typed array');
-  t.equal(interleavedRaster.data.length, 439 * 167 * 2);
-  t.equal(interleavedRaster.bandCount, 2);
-  t.end();
+test('OMEZarrImageSource#getRaster returns planar and interleaved channel data', async () => {
+    const source = createOMEZarrSource(OME_FIXTURE_URL);
+    const planarRaster = await source.getRaster({ channels: [0, 1, 2] });
+    const interleavedRaster = await source.getRaster({ channels: [0, 2], interleaved: true });
+    expect(planarRaster.width).toBe(439);
+    expect(planarRaster.height).toBe(167);
+    expect(planarRaster.bandCount).toBe(3);
+    expect(planarRaster.dtype).toBe('int8');
+    expect(Array.isArray(planarRaster.data), 'planar channel selection returns array data').toBeTruthy();
+    expect(planarRaster.data[0].length).toBe(439 * 167);
+    expect(Array.isArray(interleavedRaster.data), 'interleaved selection returns one typed array').toBeFalsy();
+    expect(interleavedRaster.data.length).toBe(439 * 167 * 2);
+    expect(interleavedRaster.bandCount).toBe(2);
 });
-
-test('OMEZarrImageSource validates pyramid levels and channels', async t => {
-  const source = createOMEZarrSource(OME_FIXTURE_URL);
-
-  await t.rejects(source.getRaster({level: 10}), /pyramid level 10 is not available/);
-  await t.rejects(source.getRaster({channels: [3]}), /Channel 3 is out of bounds/);
-  await t.rejects(source.getRaster({channels: []}), /must include at least one channel/);
-  await t.rejects(source.getRaster({channels: [0.5]}), /Channel 0.5 is out of bounds/);
-  await t.rejects(source.getRaster({t: 1}), /time index 1 is out of bounds/);
-  await t.rejects(source.getRaster({z: -1}), /z index -1 is out of bounds/);
-  t.end();
+test('OMEZarrImageSource validates pyramid levels and channels', async () => {
+    const source = createOMEZarrSource(OME_FIXTURE_URL);
+    await expect(source.getRaster({ level: 10 })).rejects.toThrow(/pyramid level 10 is not available/);
+    await expect(source.getRaster({ channels: [3] })).rejects.toThrow(/Channel 3 is out of bounds/);
+    await expect(source.getRaster({ channels: [] })).rejects.toThrow(/must include at least one channel/);
+    await expect(source.getRaster({ channels: [0.5] })).rejects.toThrow(/Channel 0.5 is out of bounds/);
+    await expect(source.getRaster({ t: 1 })).rejects.toThrow(/time index 1 is out of bounds/);
+    await expect(source.getRaster({ z: -1 })).rejects.toThrow(/z index -1 is out of bounds/);
 });
-
-test('loadZarrConsolidatedMetadata handles .zmetadata and extracts top-level groups', async t => {
-  const metadata = await loadZarrConsolidatedMetadata(OME_FIXTURE, {fetch: fetchFile});
-
-  t.equal(metadata.format, 'v2');
-  t.equal(metadata.metadataPath, '.zmetadata');
-  t.deepEqual(metadata.topLevelGroups, []);
-  t.deepEqual(metadata.topLevelArrays, ['0', '1']);
-  t.end();
+test('loadZarrConsolidatedMetadata handles .zmetadata and extracts top-level groups', async () => {
+    const metadata = await loadZarrConsolidatedMetadata(OME_FIXTURE, { fetch: fetchFile });
+    expect(metadata.format).toBe('v2');
+    expect(metadata.metadataPath).toBe('.zmetadata');
+    expect(metadata.topLevelGroups).toEqual([]);
+    expect(metadata.topLevelArrays).toEqual(['0', '1']);
 });
-
-test('OMEZarrImageSource reads a v3 SpatialData fixture', async t => {
-  const source = createOMEZarrSource(SPATIALDATA_V3_FIXTURE_URL, {
-    zarr: {path: 'images/example-image'}
-  });
-  const metadata = await source.getMetadata();
-  const raster = await source.getRaster({channels: [0, 1, 2]});
-
-  t.equal(metadata.name, 'ome-zarr example');
-  t.equal(metadata.width, 439);
-  t.equal(metadata.height, 167);
-  t.deepEqual(metadata.labels, ['t', 'c', 'z', 'y', 'x']);
-  t.equal(raster.width, 439);
-  t.equal(raster.height, 167);
-  t.equal(raster.bandCount, 3);
-  t.end();
+test('OMEZarrImageSource reads a v3 SpatialData fixture', async () => {
+    const source = createOMEZarrSource(SPATIALDATA_V3_FIXTURE_URL, {
+        zarr: { path: 'images/example-image' }
+    });
+    const metadata = await source.getMetadata();
+    const raster = await source.getRaster({ channels: [0, 1, 2] });
+    expect(metadata.name).toBe('ome-zarr example');
+    expect(metadata.width).toBe(439);
+    expect(metadata.height).toBe(167);
+    expect(metadata.labels).toEqual(['t', 'c', 'z', 'y', 'x']);
+    expect(raster.width).toBe(439);
+    expect(raster.height).toBe(167);
+    expect(raster.bandCount).toBe(3);
 });
-
-test('loadZarrConsolidatedMetadata handles v3 zarr.json fixture metadata', async t => {
-  const metadata = await loadZarrConsolidatedMetadata(SPATIALDATA_V3_FIXTURE, {
-    fetch: fetchFile
-  });
-
-  t.equal(metadata.format, 'v3');
-  t.equal(metadata.metadataPath, 'zarr.json');
-  t.deepEqual(metadata.topLevelGroups, ['images', 'labels', 'points', 'shapes', 'tables']);
-  t.deepEqual(metadata.topLevelArrays, []);
-  t.end();
+test('loadZarrConsolidatedMetadata handles v3 zarr.json fixture metadata', async () => {
+    const metadata = await loadZarrConsolidatedMetadata(SPATIALDATA_V3_FIXTURE, {
+        fetch: fetchFile
+    });
+    expect(metadata.format).toBe('v3');
+    expect(metadata.metadataPath).toBe('zarr.json');
+    expect(metadata.topLevelGroups).toEqual(['images', 'labels', 'points', 'shapes', 'tables']);
+    expect(metadata.topLevelArrays).toEqual([]);
 });
-
-test('loadZarrConsolidatedMetadata handles zmetadata and zarr.json payloads', async t => {
-  const baseUrl = 'https://example.com/spatialdata.zarr';
-  const fetcher = async (url: string) => {
-    if (url === `${baseUrl}/zmetadata`) {
-      return new Response(
-        JSON.stringify({
-          metadata: {
-            '.zgroup': {zarr_format: 2},
-            'images/.zgroup': {zarr_format: 2},
-            'labels/.zgroup': {zarr_format: 2}
-          }
-        }),
-        {status: 200}
-      );
-    }
-    return new Response(null, {status: 404});
-  };
-
-  const zmetadata = await loadZarrConsolidatedMetadata(baseUrl, {
-    metadataPath: 'zmetadata',
-    fetch: fetcher
-  });
-  t.equal(zmetadata.format, 'v2');
-  t.deepEqual(zmetadata.topLevelGroups, ['images', 'labels']);
-  t.deepEqual(zmetadata.topLevelArrays, []);
-
-  const zarrJson = await loadZarrConsolidatedMetadata(baseUrl, {
-    metadataPath: 'zarr.json',
-    fetch: async () =>
-      new Response(
-        JSON.stringify({
-          consolidated_metadata: {
-            metadata: {
-              images: {node_type: 'group'},
-              'images/example': {node_type: 'group'},
-              labels: {node_type: 'group'}
+test('loadZarrConsolidatedMetadata handles zmetadata and zarr.json payloads', async () => {
+    const baseUrl = 'https://example.com/spatialdata.zarr';
+    const fetcher = async (url: string) => {
+        if (url === `${baseUrl}/zmetadata`) {
+            return new Response(JSON.stringify({
+                metadata: {
+                    '.zgroup': { zarr_format: 2 },
+                    'images/.zgroup': { zarr_format: 2 },
+                    'labels/.zgroup': { zarr_format: 2 }
+                }
+            }), { status: 200 });
+        }
+        return new Response(null, { status: 404 });
+    };
+    const zmetadata = await loadZarrConsolidatedMetadata(baseUrl, {
+        metadataPath: 'zmetadata',
+        fetch: fetcher
+    });
+    expect(zmetadata.format).toBe('v2');
+    expect(zmetadata.topLevelGroups).toEqual(['images', 'labels']);
+    expect(zmetadata.topLevelArrays).toEqual([]);
+    const zarrJson = await loadZarrConsolidatedMetadata(baseUrl, {
+        metadataPath: 'zarr.json',
+        fetch: async () => new Response(JSON.stringify({
+            consolidated_metadata: {
+                metadata: {
+                    images: { node_type: 'group' },
+                    'images/example': { node_type: 'group' },
+                    labels: { node_type: 'group' }
+                }
             }
-          }
-        }),
-        {status: 200}
-      )
-  });
-  t.equal(zarrJson.format, 'v3');
-  t.deepEqual(zarrJson.topLevelGroups, ['images', 'labels']);
-  t.deepEqual(zarrJson.topLevelArrays, []);
-  t.end();
+        }), { status: 200 })
+    });
+    expect(zarrJson.format).toBe('v3');
+    expect(zarrJson.topLevelGroups).toEqual(['images', 'labels']);
+    expect(zarrJson.topLevelArrays).toEqual([]);
 });
-
-test('loadZarrConsolidatedMetadata auto probing skips non-consolidated zarr.json', async t => {
-  const baseUrl = 'https://example.com/mixed.zarr';
-  const metadata = await loadZarrConsolidatedMetadata(baseUrl, {
-    fetch: async url => {
-      if (url.endsWith('/zarr.json')) {
-        return new Response(JSON.stringify({zarr_format: 3, node_type: 'group'}));
-      }
-      if (url.endsWith('/.zmetadata')) {
-        return new Response(
-          JSON.stringify({
-            metadata: {
-              '.zgroup': {zarr_format: 2},
-              'image/.zarray': {shape: [1, 1]}
+test('loadZarrConsolidatedMetadata auto probing skips non-consolidated zarr.json', async () => {
+    const baseUrl = 'https://example.com/mixed.zarr';
+    const metadata = await loadZarrConsolidatedMetadata(baseUrl, {
+        fetch: async (url) => {
+            if (url.endsWith('/zarr.json')) {
+                return new Response(JSON.stringify({ zarr_format: 3, node_type: 'group' }));
             }
-          })
-        );
-      }
-      return new Response(null, {status: 404});
-    }
-  });
-
-  t.equal(metadata.format, 'v2');
-  t.deepEqual(metadata.topLevelArrays, ['image']);
-  t.end();
+            if (url.endsWith('/.zmetadata')) {
+                return new Response(JSON.stringify({
+                    metadata: {
+                        '.zgroup': { zarr_format: 2 },
+                        'image/.zarray': { shape: [1, 1] }
+                    }
+                }));
+            }
+            return new Response(null, { status: 404 });
+        }
+    });
+    expect(metadata.format).toBe('v2');
+    expect(metadata.topLevelArrays).toEqual(['image']);
 });

--- a/modules/zarr/test/pixel-source.node.spec.ts
+++ b/modules/zarr/test/pixel-source.node.spec.ts
@@ -1,123 +1,90 @@
 // loaders.gl
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
-
-import {access, readFile} from 'node:fs/promises';
-import {join} from 'node:path';
-import test from 'test/utils/vitest-tape';
-import {loadZarr} from '@loaders.gl/zarr';
-import {resolvePath} from '@loaders.gl/core';
-import {KeyError} from 'zarr';
-import type {AsyncStore, ValidStoreType} from 'zarr/types/storage/types';
-
+import { access, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { expect, test } from "vitest";
+import { loadZarr } from '@loaders.gl/zarr';
+import { resolvePath } from '@loaders.gl/core';
+import { KeyError } from 'zarr';
+import type { AsyncStore, ValidStoreType } from 'zarr/types/storage/types';
 const CONTENT_BASE = resolvePath('@loaders.gl/zarr/test/data');
 const OME_FIXTURE = `${CONTENT_BASE}/ome.zarr`;
 const FIXTURE = `${CONTENT_BASE}/multiscale.zarr`;
 const LABELS = ['foo', 'bar', 'baz', 'y', 'x'];
-
 /** Read-only Zarr store backed by a local test-fixture directory. */
 class LocalFileStore implements AsyncStore<ValidStoreType> {
-  /** Root fixture directory. */
-  private readonly rootDirectory: string;
-
-  /** Creates a local read-only store for one fixture directory. */
-  constructor(rootDirectory: string) {
-    this.rootDirectory = rootDirectory;
-  }
-
-  /** Reads one Zarr metadata or chunk key. */
-  async getItem(item: string): Promise<Buffer> {
-    try {
-      return await readFile(join(this.rootDirectory, item));
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-        throw new KeyError(item);
-      }
-      throw error;
+    /** Root fixture directory. */
+    private readonly rootDirectory: string;
+    /** Creates a local read-only store for one fixture directory. */
+    constructor(rootDirectory: string) {
+        this.rootDirectory = rootDirectory;
     }
-  }
-
-  /** Returns whether a Zarr metadata or chunk key exists. */
-  async containsItem(item: string): Promise<boolean> {
-    try {
-      await access(join(this.rootDirectory, item));
-      return true;
-    } catch {
-      return false;
+    /** Reads one Zarr metadata or chunk key. */
+    async getItem(item: string): Promise<Buffer> {
+        try {
+            return await readFile(join(this.rootDirectory, item));
+        }
+        catch (error) {
+            if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+                throw new KeyError(item);
+            }
+            throw error;
+        }
     }
-  }
-
-  /** Local test fixtures are read-only. */
-  async setItem(): Promise<boolean> {
-    throw new Error('LocalFileStore is read-only.');
-  }
-
-  /** Local test fixtures are read-only. */
-  async deleteItem(): Promise<boolean> {
-    throw new Error('LocalFileStore is read-only.');
-  }
-
-  /** Key enumeration is not needed by the Zarr reader. */
-  async keys(): Promise<string[]> {
-    throw new Error('LocalFileStore does not enumerate keys.');
-  }
+    /** Returns whether a Zarr metadata or chunk key exists. */
+    async containsItem(item: string): Promise<boolean> {
+        try {
+            await access(join(this.rootDirectory, item));
+            return true;
+        }
+        catch {
+            return false;
+        }
+    }
+    /** Local test fixtures are read-only. */
+    async setItem(): Promise<boolean> {
+        throw new Error('LocalFileStore is read-only.');
+    }
+    /** Local test fixtures are read-only. */
+    async deleteItem(): Promise<boolean> {
+        throw new Error('LocalFileStore is read-only.');
+    }
+    /** Key enumeration is not needed by the Zarr reader. */
+    async keys(): Promise<string[]> {
+        throw new Error('LocalFileStore does not enumerate keys.');
+    }
 }
-
-test('Creates correct ZarrPixelSource.', async t => {
-  const {data} = await loadZarr(new LocalFileStore(FIXTURE), {labels: LABELS});
-  t.equal(data.length, 2, 'Image should have two levels.');
-  const [base] = data;
-  t.deepEqual(base.labels, ['foo', 'bar', 'baz', 'y', 'x']);
-  t.deepEqual(base.shape, [1, 3, 1, 167, 439], 'shape should match dimensions.');
-  t.end();
+test('Creates correct ZarrPixelSource.', async () => {
+    const { data } = await loadZarr(new LocalFileStore(FIXTURE), { labels: LABELS });
+    expect(data.length, 'Image should have two levels.').toBe(2);
+    const [base] = data;
+    expect(base.labels).toEqual(['foo', 'bar', 'baz', 'y', 'x']);
+    expect(base.shape, 'shape should match dimensions.').toEqual([1, 3, 1, 167, 439]);
 });
-
-test('Creates correct OME ZarrPixelSource.', async t => {
-  const {data} = await loadZarr(new LocalFileStore(OME_FIXTURE));
-  t.equal(data.length, 2, 'Image should have two levels.');
-  const [base] = data;
-  t.deepEqual(base.labels, ['t', 'c', 'z', 'y', 'x'], 'should have DimensionOrder "XYZCT".');
-  t.deepEqual(base.shape, [1, 3, 1, 167, 439], 'shape should match dimensions.');
-  t.end();
+test('Creates correct OME ZarrPixelSource.', async () => {
+    const { data } = await loadZarr(new LocalFileStore(OME_FIXTURE));
+    expect(data.length, 'Image should have two levels.').toBe(2);
+    const [base] = data;
+    expect(base.labels, 'should have DimensionOrder "XYZCT".').toEqual(['t', 'c', 'z', 'y', 'x']);
+    expect(base.shape, 'shape should match dimensions.').toEqual([1, 3, 1, 167, 439]);
 });
-
-test('Get raster data.', async t => {
-  const {data} = await loadZarr(new LocalFileStore(FIXTURE), {labels: LABELS});
-  const [base] = data;
-
-  for (let channelIndex = 0; channelIndex < 3; channelIndex++) {
-    const selection = {bar: channelIndex, foo: 0, baz: 0};
-    const pixelData = await base.getRaster({selection});
-    t.equal(pixelData.width, 439);
-    t.equal(pixelData.height, 167);
-    t.equal(pixelData.data.length, 439 * 167);
-    t.equal(pixelData.data.constructor.name, 'Int8Array');
-  }
-
-  await t.rejects(
-    base.getRaster({selection: {bar: 3, foo: 0, baz: 0}}),
-    /bounds/i,
-    'index should be out of bounds.'
-  );
-  t.end();
+test('Get raster data.', async () => {
+    const { data } = await loadZarr(new LocalFileStore(FIXTURE), { labels: LABELS });
+    const [base] = data;
+    for (let channelIndex = 0; channelIndex < 3; channelIndex++) {
+        const selection = { bar: channelIndex, foo: 0, baz: 0 };
+        const pixelData = await base.getRaster({ selection });
+        expect(pixelData.width).toBe(439);
+        expect(pixelData.height).toBe(167);
+        expect(pixelData.data.length).toBe(439 * 167);
+        expect(pixelData.data.constructor.name).toBe('Int8Array');
+    }
+    await expect(base.getRaster({ selection: { bar: 3, foo: 0, baz: 0 } }), 'index should be out of bounds.').rejects.toThrow(/bounds/i);
 });
-
-test('Invalid labels.', async t => {
-  const store = new LocalFileStore(FIXTURE);
-  await t.rejects(
-    loadZarr(store, {labels: ['a', 'b', 'y', 'x']}),
-    /Labels do not match/,
-    'labels should correspond to array shape.'
-  );
-  await t.rejects(
-    loadZarr(store, {labels: ['a', 'b', 'c', 'y', 'w']}),
-    /Invalid labels/,
-    'labels should end with y and x.'
-  );
-  await t.rejects(
-    loadZarr(store, {labels: ['a', 'b', 'c', 'x', '_c']}),
-    /Invalid labels/,
-    'interleaved labels should end with y, x, and _c.'
-  );
-  t.end();
+test('Invalid labels.', async () => {
+    const store = new LocalFileStore(FIXTURE);
+    await expect(loadZarr(store, { labels: ['a', 'b', 'y', 'x'] }), 'labels should correspond to array shape.').rejects.toThrow(/Labels do not match/);
+    await expect(loadZarr(store, { labels: ['a', 'b', 'c', 'y', 'w'] }), 'labels should end with y and x.').rejects.toThrow(/Invalid labels/);
+    await expect(loadZarr(store, { labels: ['a', 'b', 'c', 'x', '_c'] }), 'interleaved labels should end with y, x, and _c.').rejects.toThrow(/Invalid labels/);
 });

--- a/modules/zarr/test/utils.spec.js
+++ b/modules/zarr/test/utils.spec.js
@@ -1,26 +1,19 @@
-// loaders.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
-import test from 'test/utils/vitest-tape';
-
+import { expect, test } from "vitest";
 // @ts-ignore
-import {isInterleaved, getIndexer} from '@loaders.gl/zarr/lib/utils';
-
-test('isInterleaved', (t) => {
-  t.plan(4);
-  t.ok(isInterleaved([1, 2, 400, 400, 4]));
-  t.ok(isInterleaved([1, 2, 400, 400, 3]));
-  t.ok(!isInterleaved([1, 2, 400, 400]));
-  t.ok(!isInterleaved([1, 3, 4, 4000000]));
+import { isInterleaved, getIndexer } from '@loaders.gl/zarr/lib/utils';
+test('isInterleaved', () => {
+    expect.assertions(4);
+    expect(isInterleaved([1, 2, 400, 400, 4])).toBeTruthy();
+    expect(isInterleaved([1, 2, 400, 400, 3])).toBeTruthy();
+    expect(!isInterleaved([1, 2, 400, 400])).toBeTruthy();
+    expect(!isInterleaved([1, 3, 4, 4000000])).toBeTruthy();
 });
-
-test('Indexer creation and usage.', (t) => {
-  t.plan(4);
-  const labels = ['a', 'b', 'y', 'x'];
-  const indexer = getIndexer(labels);
-  t.deepEqual(indexer({a: 10, b: 20}), [10, 20, 0, 0], 'should allow named indexing.');
-  t.deepEqual(indexer([10, 20, 0, 0]), [10, 20, 0, 0], 'allows array like indexing.');
-  t.throws(() => indexer({c: 0, b: 0}), 'should throw with invalid dim name.');
-  t.throws(() => getIndexer(['a', 'b', 'c', 'b', 'y', 'x']), 'no duplicated labels names.');
+test('Indexer creation and usage.', () => {
+    expect.assertions(4);
+    const labels = ['a', 'b', 'y', 'x'];
+    const indexer = getIndexer(labels);
+    expect(indexer({ a: 10, b: 20 }), 'should allow named indexing.').toEqual([10, 20, 0, 0]);
+    expect(indexer([10, 20, 0, 0]), 'allows array like indexing.').toEqual([10, 20, 0, 0]);
+    expect(() => indexer({ c: 0, b: 0 }), 'should throw with invalid dim name.').toThrow();
+    expect(() => getIndexer(['a', 'b', 'c', 'b', 'y', 'x']), 'no duplicated labels names.').toThrow();
 });

--- a/modules/zarr/test/zarr-array-source.node.spec.ts
+++ b/modules/zarr/test/zarr-array-source.node.spec.ts
@@ -1,72 +1,51 @@
 // loaders.gl
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
-
-import {pathToFileURL} from 'node:url';
+import { pathToFileURL } from 'node:url';
 import '@loaders.gl/polyfills';
-import test from 'test/utils/vitest-tape';
-import {createDataSource, resolvePath} from '@loaders.gl/core';
-import {
-  ZarrArraySource,
-  ZarrArraySourceLoader,
-  type ZarrArraySourceLoaderOptions
-} from '@loaders.gl/zarr';
-
+import { expect, test } from "vitest";
+import { createDataSource, resolvePath } from '@loaders.gl/core';
+import { ZarrArraySource, ZarrArraySourceLoader, type ZarrArraySourceLoaderOptions } from '@loaders.gl/zarr';
 const FIXTURE_PATH = resolvePath('@loaders.gl/zarr/test/data/spatialdata-v3.zarr');
 const FIXTURE_URL = pathToFileURL(FIXTURE_PATH).href;
-
-test('ZarrArraySource reads array metadata and integer selections', async t => {
-  const options: ZarrArraySourceLoaderOptions = {
-    zarr: {path: 'images/example-image'},
-    zarrArray: {path: '0', dimensions: ['t', 'c', 'z', 'y', 'x']}
-  };
-  const source = createDataSource(FIXTURE_URL, [ZarrArraySourceLoader], options);
-
-  t.ok(source instanceof ZarrArraySource);
-  const metadata = await source.getMetadata();
-  t.deepEqual(metadata.shape, [1, 3, 1, 167, 439]);
-  t.deepEqual(metadata.chunks, [1, 1, 1, 167, 439]);
-  t.deepEqual(metadata.dimensions, ['t', 'c', 'z', 'y', 'x']);
-  t.equal(metadata.fillValue, 0);
-  t.equal(metadata.attributes['long_name'], 'Example georeferenced image');
-
-  const selected = await source.getArray({selection: [0, 1, 0, null, null]});
-  t.deepEqual(selected.shape, [167, 439]);
-  t.equal(selected.data.length, 167 * 439);
-
-  const window = await source.getArray({
-    selection: [0, 1, 0, {start: 2, stop: 5}, {start: 4, stop: 9, step: 2}]
-  });
-  t.deepEqual(window.shape, [3, 3]);
-  t.equal(window.data.length, 9);
-
-  const namedWindow = await source.getArray({
-    selectionByDimension: {t: 0, c: 1, z: 0, y: {start: 2, stop: 5}, x: {start: 4, stop: 9, step: 2}}
-  });
-  t.deepEqual(namedWindow.shape, [3, 3]);
-  t.end();
+test('ZarrArraySource reads array metadata and integer selections', async () => {
+    const options: ZarrArraySourceLoaderOptions = {
+        zarr: { path: 'images/example-image' },
+        zarrArray: { path: '0', dimensions: ['t', 'c', 'z', 'y', 'x'] }
+    };
+    const source = createDataSource(FIXTURE_URL, [ZarrArraySourceLoader], options);
+    expect(source instanceof ZarrArraySource).toBeTruthy();
+    const metadata = await source.getMetadata();
+    expect(metadata.shape).toEqual([1, 3, 1, 167, 439]);
+    expect(metadata.chunks).toEqual([1, 1, 1, 167, 439]);
+    expect(metadata.dimensions).toEqual(['t', 'c', 'z', 'y', 'x']);
+    expect(metadata.fillValue).toBe(0);
+    expect(metadata.attributes['long_name']).toBe('Example georeferenced image');
+    const selected = await source.getArray({ selection: [0, 1, 0, null, null] });
+    expect(selected.shape).toEqual([167, 439]);
+    expect(selected.data.length).toBe(167 * 439);
+    const window = await source.getArray({
+        selection: [0, 1, 0, { start: 2, stop: 5 }, { start: 4, stop: 9, step: 2 }]
+    });
+    expect(window.shape).toEqual([3, 3]);
+    expect(window.data.length).toBe(9);
+    const namedWindow = await source.getArray({
+        selectionByDimension: { t: 0, c: 1, z: 0, y: { start: 2, stop: 5 }, x: { start: 4, stop: 9, step: 2 } }
+    });
+    expect(namedWindow.shape).toEqual([3, 3]);
 });
-
-test('ZarrArraySource validates selection rank and dimension labels', async t => {
-  const source = createDataSource(FIXTURE_URL, [ZarrArraySourceLoader], {
-    zarr: {path: 'images/example-image'},
-    zarrArray: {path: '0', dimensions: ['t']}
-  });
-
-  await t.rejects(source.getMetadata(), /dimensions must have length 5/);
-  t.end();
+test('ZarrArraySource validates selection rank and dimension labels', async () => {
+    const source = createDataSource(FIXTURE_URL, [ZarrArraySourceLoader], {
+        zarr: { path: 'images/example-image' },
+        zarrArray: { path: '0', dimensions: ['t'] }
+    });
+    await expect(source.getMetadata()).rejects.toThrow(/dimensions must have length 5/);
 });
-
-test('ZarrArraySource rejects unknown named dimensions', async t => {
-  const source = createDataSource(FIXTURE_URL, [ZarrArraySourceLoader], {
-    zarr: {path: 'images/example-image'},
-    zarrArray: {path: '0'}
-  });
-
-  await t.rejects(source.getArray({selectionByDimension: {unknown: 0}}), /Unknown Zarr array dimension/);
-  await t.rejects(
-    source.getArray({selection: [null, null, null, null, null], selectionByDimension: {t: 0}}),
-    /cannot combine positional and named selections/
-  );
-  t.end();
+test('ZarrArraySource rejects unknown named dimensions', async () => {
+    const source = createDataSource(FIXTURE_URL, [ZarrArraySourceLoader], {
+        zarr: { path: 'images/example-image' },
+        zarrArray: { path: '0' }
+    });
+    await expect(source.getArray({ selectionByDimension: { unknown: 0 } })).rejects.toThrow(/Unknown Zarr array dimension/);
+    await expect(source.getArray({ selection: [null, null, null, null, null], selectionByDimension: { t: 0 } })).rejects.toThrow(/cannot combine positional and named selections/);
 });

--- a/scripts/convert-tape-to-vitest.mjs
+++ b/scripts/convert-tape-to-vitest.mjs
@@ -73,6 +73,15 @@ function transformTapeToVitest(sourceText, filePath) {
         return visitTestCallback(node, context, visitNode);
       }
 
+      if (ts.isCallExpression(node) && shouldDropAssertionTarget(node)) {
+        return ts.factory.updateCallExpression(
+          node,
+          node.expression,
+          node.typeArguments,
+          node.arguments.slice(1)
+        );
+      }
+
       if (ts.isCallExpression(node)) {
         return visitTapeCallExpression(node, context, visitNode);
       }
@@ -114,6 +123,23 @@ function transformTapeToVitest(sourceText, filePath) {
   transformed.dispose();
 
   return `${printedText}\n`;
+}
+
+/**
+ * Identifies shared assertion helpers whose first Tape argument is optional.
+ * @param {ts.CallExpression} node
+ * @returns {boolean}
+ */
+function shouldDropAssertionTarget(node) {
+  if (!ts.isIdentifier(node.expression) || node.arguments.length < 2) {
+    return false;
+  }
+
+  return (
+    /^validate/.test(node.expression.text) &&
+    ts.isIdentifier(node.arguments[0]) &&
+    TEST_CONTEXT_NAMES.has(node.arguments[0].text)
+  );
 }
 
 /**

--- a/test/common/conformance.ts
+++ b/test/common/conformance.ts
@@ -143,18 +143,23 @@ export function validateBuilder(
  * Check if the returned data from loaders use the format specified in:
  *  /docs/developer-guide/category-pointcloud.md
  */
-export function validateMeshCategoryData(t, data) {
+export function validateMeshCategoryData(assertionTargetOrData, data?) {
+  const {assertionTarget, value} = resolveAssertionsAndValue(assertionTargetOrData, data);
+  data = value;
   // t.ok(data.loaderData && data.loaderData.header, 'data has original header');
 
-  t.ok(data.header && Number.isFinite(data.header.vertexCount), 'data has normalized header');
-  t.ok(
+  assertionTarget.ok(
+    data.header && Number.isFinite(data.header.vertexCount),
+    'data has normalized header'
+  );
+  assertionTarget.ok(
     data.header.boundingBox &&
       data.header.boundingBox.length === 2 &&
       data.header.boundingBox.every(p => p.length === 3 && p.every(Number.isFinite)),
     'data header has boundingBox'
   );
 
-  t.ok(Number.isFinite(data.mode), 'data has draw mode');
+  assertionTarget.ok(Number.isFinite(data.mode), 'data has draw mode');
 
   let attributesError = data.attributes ? null : 'data does not have attributes';
   if (data.indices) {
@@ -164,7 +169,7 @@ export function validateMeshCategoryData(t, data) {
     attributesError =
       attributesError || validateAttribute(attributeName, data.attributes[attributeName]);
   }
-  t.notOk(attributesError, 'data has valid attributes');
+  assertionTarget.notOk(attributesError, 'data has valid attributes');
 }
 
 /**


### PR DESCRIPTION
## Goals

- Remove the remaining Tape compatibility-layer usage from published-module test suites.
- Complete the native Vitest migration in one reviewable follow-up tranche.
- Preserve runtime lanes and keep 3D Tiles excluded.

## Changes

- Migrated all 90 remaining actionable `vitest-tape` suites outside 3D Tiles.
- Covered BSON, compression, crypto, CSV, Draco, Excel, GeoArrow, GeoPackage, GeoTIFF, I3S, JSON, loader-utils, MVT, NetCDF, OBJ, PCD, PMTiles, PLY, Potree, scene, services, splats, terrain, tiles, video, XML, and Zarr tests.
- Converted nested Tape assertion assumptions, conformance-helper calls, browser-only helpers, and typed-array comparisons to native Vitest patterns.
- Added native assertion-target support to the shared mesh conformance helper and improved the migration codemod for helper calls.
- No production behavior or coverage thresholds changed.
- 3D Tiles remains intentionally excluded.

## Validation

- `yarn lint fix`
- `yarn test-audit` — 603 files, 0 Tape, 0 violations
- Migrated Node lane — 51 files, 360 passed, 6 skipped
- Migrated Chromium lane — 500 files, 3,038 passed, 40 skipped
- `yarn build-workers`
- Full `yarn build-modules` attempted; local worktree alias resolution fails at the existing `images:pre-build` bootstrap step, with no source or generated build artifacts included in the commit.