### PR TITLE
feat(services): complete v5 service foundations

### DIFF
--- a/docs/docs-sidebar.json
+++ b/docs/docs-sidebar.json
@@ -72,6 +72,7 @@
     "label": "Services",
     "items": [
       "modules/services/README",
+      "modules/wms/formats/csw",
       "modules/wms/formats/wcs",
       "modules/wms/formats/wfs",
       "modules/wms/formats/wmc",

--- a/docs/modules/services/README.md
+++ b/docs/modules/services/README.md
@@ -1,40 +1,146 @@
-# ArcGIS Services
+# Geospatial Services
 
 The `@loaders.gl/services` module provides framework-independent sources for ArcGIS REST services.
+The sources use the same loaders.gl contracts as file loaders: they can be selected by `load`,
+created with `createDataSource`, and rendered through deck.gl's generic `SourceLayer`.
 
-It supports FeatureServer, ImageServer, MapServer, and VectorTileServer endpoints. OGC protocols
-such as WMS, WMTS, WFS, GML, and CSW remain in [`@loaders.gl/wms`](/docs/modules/wms).
+OGC protocols such as WMS, WMTS, WFS, WCS, CSW, GML, and OGC API remain in
+[`@loaders.gl/wms`](/docs/modules/wms). Keeping the protocol implementations in their owning
+modules lets applications install only the service families they use.
+
+## Service support
+
+| Service | Source loader | Runtime contract | Primary output | deck.gl | Documentation |
+| --- | --- | --- | --- | --- | --- |
+| ArcGIS FeatureServer | `ArcGISFeatureServerSourceLoader` | `VectorSource` | GeoJSON, binary or Arrow features | `SourceLayer` | [FeatureServer](/docs/modules/services/arcgis-feature-server) |
+| ArcGIS ImageServer | `ArcGISImageServerSourceLoader` | `ImageSource` | Rendered image or decoded LERC raster | `SourceLayer` for rendered images | [ImageServer](/docs/modules/services/arcgis-image-server) |
+| ArcGIS ImageServer tiles | `ArcGISImageTileSourceLoader` | `TileSource` | Image tiles or decoded LERC tiles | `SourceLayer` for image tiles | [ImageServer](/docs/modules/services/arcgis-image-server) |
+| ArcGIS MapServer | `ArcGISMapTileSourceLoader` | `TileSource` | Cached or dynamically exported image tiles | `SourceLayer` | [MapServer](/docs/modules/services/arcgis-map-server) |
+| ArcGIS VectorTileServer | `ArcGISVectorTileServerSourceLoader` | `VectorTileSource` | Raw MVT or decoded WGS84 features | `SourceLayer` | [VectorTileServer](/docs/modules/services/arcgis-vector-tile-server) |
+| ArcGIS service directory | Capability graph utilities | Discovery graph | Ranked service endpoints | Not directly visual | [Capability discovery](#capability-discovery) |
 
 ## Installation
 
 ```bash
-npm install @loaders.gl/services @loaders.gl/core
+npm install @loaders.gl/core @loaders.gl/services
 ```
+
+Install `@loaders.gl/deck-layers` and deck.gl when a service should be rendered directly.
+
+## One registry, three entry points
+
+`SERVICE_LOADERS` is the recommended registry for applications that may receive more than one
+ArcGIS service type. URL detection handles conventional ArcGIS REST endpoint names. Use
+`core.type` when a proxy or rewritten URL hides the service type.
+
+### Load a service
+
+For a `SourceLoader`, `load` returns a source object rather than downloading an entire service:
+
+```ts
+import {load} from '@loaders.gl/core';
+import {SERVICE_LOADERS} from '@loaders.gl/services';
+
+const source = await load(serviceUrl, SERVICE_LOADERS);
+const metadata = await source.getMetadata();
+```
+
+### Create a typed source
+
+Use `createDataSource` when the application already knows the service type:
+
+```ts
+import {createDataSource} from '@loaders.gl/core';
+import {ArcGISFeatureServerSourceLoader} from '@loaders.gl/services';
+
+const source = createDataSource(serviceUrl, [ArcGISFeatureServerSourceLoader]);
+const features = await source.getFeatures({
+  layers: ['0'],
+  boundingBox: [[-123, 37], [-121, 39]]
+});
+```
+
+### Render through deck.gl
+
+`SourceLayer` resolves the source and dispatches it to the appropriate image, vector, image-tile,
+or vector-tile renderer. No ArcGIS-specific deck.gl layer is required.
+
+```ts
+import {SourceLayer} from '@loaders.gl/deck-layers';
+import {SERVICE_LOADERS} from '@loaders.gl/services';
+
+const layer = new SourceLayer({
+  id: 'city-service',
+  data: serviceUrl,
+  loaders: SERVICE_LOADERS,
+  layers: ['0'],
+  pickable: true
+});
+```
+
+`SourceLayer` is intended for visual sources. Catalogs and analytical LERC rasters remain data
+objects until the application chooses a record, band, color ramp, and NoData treatment.
+
+## Authentication and request customization
+
+ArcGIS tokens already present in a service URL are preserved on metadata and data requests.
+Headers, credentials, cancellation, proxies, and custom transports use standard loaders.gl fetch
+options:
+
+```ts
+const source = await load(serviceUrl, SERVICE_LOADERS, {
+  fetch: {
+    headers: {Authorization: `Bearer ${token}`}
+  }
+});
+```
+
+Service-specific options can add ArcGIS request parameters without bypassing the source API. See
+the individual service pages for the supported option names.
 
 ## Capability discovery
 
-For applications that need to choose among services, the module can discover an ArcGIS REST
- directory and normalize the shared service capability contract: service family, formats, and coordinate systems. The
-capability graph is intentionally separate from source loading, so direct source construction
-remains the simplest path when the endpoint is already known.
+Applications can discover an ArcGIS REST directory and rank its services by kind, format, and
+coordinate system. Discovery is optional: direct source construction is simpler when the endpoint
+is already known.
 
 ```ts
 import {
-  createServiceSource,
+  SERVICE_LOADERS,
   discoverArcGISCapabilities,
   selectArcGISService
 } from '@loaders.gl/services';
-import {coreApi} from '@loaders.gl/core';
+import {createDataSource} from '@loaders.gl/core';
 
 const graph = await discoverArcGISCapabilities('https://example.com/arcgis/rest/services');
 const imagery = graph && selectArcGISService(graph, {kind: 'image', format: 'lerc'});
-const source = imagery && createServiceSource(
-  imagery.url,
-  {},
-  imagery.capabilities.type,
-  coreApi
-);
+const source = imagery && createDataSource(imagery.url, SERVICE_LOADERS, {
+  core: {type: imagery.capabilities.type}
+});
 ```
 
-Discovery performs one metadata request per discovered service. Pass a custom `fetch` function when
-using authentication, a proxy, or a test transport.
+Discovery performs one metadata request per discovered service. Pass a custom `fetch` function
+when using authentication, a proxy, or a test transport.
+
+## Choosing a service
+
+| Need | Recommended source |
+| --- | --- |
+| Query individual vector features and properties | FeatureServer |
+| Display server-rendered analytical imagery | ImageServer |
+| Analyze pixel values, bands, masks, or statistics | ImageServer with LERC |
+| Display a cached ArcGIS basemap | MapServer |
+| Display a dynamic MapServer as tiles | MapServer in `dynamic` mode |
+| Decode and style ArcGIS-hosted vector tiles | VectorTileServer |
+| Select among many ArcGIS endpoints | Capability discovery, then a concrete source |
+
+## Design boundaries
+
+- Sources are read-only clients. Editing, transactions, and administrative ArcGIS APIs are out of
+  scope.
+- Service metadata is normalized for cross-provider use while provider-specific metadata remains
+  available from the concrete source.
+- Reprojection-aware metadata and tile grids are exposed, but loaders.gl does not silently resample
+  analytical raster values.
+- LERC decoding preserves typed arrays, masks, NoData values, and statistics. Visualization remains
+  explicit because a scientifically correct color mapping is application-specific.

--- a/docs/modules/services/api-reference/arcgis.md
+++ b/docs/modules/services/api-reference/arcgis.md
@@ -1,13 +1,58 @@
-# ArcGIS Server
+# ArcGIS service API reference
 
-An ArcGIS server can provide multiple service endpoints of different types
+ArcGIS Server directories can publish several endpoint families. loaders.gl v5 keeps one small
+source loader per visual data contract and a shared registry for automatic selection.
 
-| loaders.gl type         | ArcGIS type                   | Decription |
-| ----------------------- | ----------------------------- | ---------- |
-| `arcgis-image-server`   | [`ImageServer`][image_server] |            |
-| `arcgis-feature-server` | `FeatureServer`               |            |
-| `arcgis-map-server`     | `MapServer`                   |            |
-| `arcgis-scene-server`   | `SceneServer`                 |            |
-| `arcgis-image-server`   | `ImageServer`                 |            |
+| Loader type | ArcGIS endpoint | Source contract | Primary methods | Output |
+| --- | --- | --- | --- | --- |
+| `arcgis-feature-server` | `FeatureServer` | `VectorSource` | `getMetadata`, `getSchema`, `getFeatures` | GeoJSON, binary, Arrow |
+| `arcgis-image-server` | `ImageServer` | `ImageSource` | `getMetadata`, `getImage`, `exportImage`, `exportRaster` | Image or LERC raster |
+| `arcgis-image-server-tiles` | `ImageServer` | `TileSource` | `getMetadata`, `getTile`, `updateParameters` | Image or LERC tile |
+| `arcgis-map-server` | `MapServer` | `TileSource` | `getMetadata`, `getTile`, `updateParameters` | Cached or exported image tile |
+| `arcgis-vector-tile-server` | `VectorTileServer` | `VectorTileSource` | `getMetadata`, `getTile`, `getVectorTile` | PBF or decoded vector tile |
 
-[image_server]: https://developers.arcgis.com/rest/services-reference/enterprise/image-service.htm
+`SERVICE_LOADERS` contains these loaders in deterministic selection order. Pass it to `load`,
+`createDataSource`, or deck.gl's `SourceLayer`:
+
+```ts
+import {load} from '@loaders.gl/core';
+import {SERVICE_LOADERS} from '@loaders.gl/services';
+
+const source = await load(serviceUrl, SERVICE_LOADERS);
+```
+
+When endpoint rewriting hides `FeatureServer`, `ImageServer`, `MapServer`, or `VectorTileServer`
+from the URL, specify the table's loader type through `core.type`.
+
+## Exported classes
+
+| Source class | Source loader | Documentation |
+| --- | --- | --- |
+| `ArcGISVectorSource` | `ArcGISFeatureServerSourceLoader` | [FeatureServer](../arcgis-feature-server) |
+| `ArcGISImageSource` | `ArcGISImageServerSourceLoader` | [ImageServer](../arcgis-image-server) |
+| `ArcGISImageTileSource` | `ArcGISImageTileSourceLoader` | [ImageServer tiles](../arcgis-image-server#image-tiles) |
+| `ArcGISMapTileSource` | `ArcGISMapTileSourceLoader` | [MapServer](../arcgis-map-server) |
+| `ArcGISVectorTileServerSource` | `ArcGISVectorTileServerSourceLoader` | [VectorTileServer](../arcgis-vector-tile-server) |
+
+## Discovery exports
+
+`getArcGISServices()` reads an ArcGIS REST services directory.
+`discoverArcGISCapabilities()` enriches discovered endpoints with normalized service capabilities,
+and `selectArcGISService()` ranks them for an application requirement.
+
+Provider-neutral metadata is intentionally smaller than each ArcGIS metadata document. Concrete
+sources retain access to provider-specific metadata and request controls where those details are
+needed.
+
+## Excluded endpoint families
+
+ArcGIS `SceneServer` is handled by the I3S loaders in `@loaders.gl/i3s`, not by this 2D service
+module. Geocoding, routing, geoprocessing, editing, administration, and portal content APIs are not
+part of the v5 service source foundation.
+
+## ArcGIS references
+
+- [Feature Service](https://developers.arcgis.com/rest/services-reference/enterprise/feature-service/)
+- [Image Service](https://developers.arcgis.com/rest/services-reference/enterprise/image-service/)
+- [Map Service](https://developers.arcgis.com/rest/services-reference/enterprise/map-service/)
+- [Vector Tile Service](https://developers.arcgis.com/rest/services-reference/enterprise/vector-tile-service/)

--- a/docs/modules/services/arcgis-feature-server.md
+++ b/docs/modules/services/arcgis-feature-server.md
@@ -1,37 +1,103 @@
-# ArcGIS Feature Server
+import {ClientExample} from '@site/src/components';
+import {WmsDocsTabs} from '@site/src/components/docs/wms-docs-tabs';
 
-ArcGIS Feature Server endpoints expose vector feature layers through the ArcGIS REST API.
+# ArcGIS FeatureServer
 
-## loaders.gl Support
+<WmsDocsTabs active="arcgis-feature-server" />
 
-loaders.gl provides `ArcGISFeatureServerSourceLoader` as an experimental vector source loader for
-ArcGIS `FeatureServer` layer endpoints. It can load layer metadata and query GeoJSON features for a
-viewport.
+ArcGIS FeatureServer endpoints expose queryable vector feature layers through the ArcGIS REST API.
+`ArcGISFeatureServerSourceLoader` adapts a service or layer endpoint to the loaders.gl
+`VectorSource` contract.
 
-## Usage
+## Feature support
+
+| Capability | Support | API and behavior |
+| --- | --- | --- |
+| Service and layer endpoints | Supported | Accepts both `/FeatureServer` and `/FeatureServer/{layerId}` URLs |
+| Metadata and layer discovery | Supported | `getMetadata()` normalizes names, titles, bounds, CRS, and child layers |
+| Schema discovery | Supported | `getSchema()` maps ArcGIS fields to loaders.gl schema types |
+| Spatial queries | Supported | `getFeatures()` sends viewport bounds through the ArcGIS `query` operation |
+| Layer selection | Supported | Select with `layers`; a root service URL can target an explicit layer ID |
+| Server-side query parameters | Supported | Configure `where`, output fields, geometry filters, spatial relationship, and precision |
+| GeoJSON output | Supported | ArcGIS GeoJSON responses are parsed as vector-source data |
+| Binary and Arrow output | Supported | Select through the standard vector source `format` option |
+| Authentication | Supported | URL tokens, fetch headers, credentials, and custom fetch functions are preserved |
+| Pagination | Not automated | The source performs one ArcGIS query per `getFeatures()` call |
+| Editing and attachments | Not supported | The source is a read-only query client |
+| deck.gl rendering | First class | Pass the source loader or `SERVICE_LOADERS` to `SourceLayer` |
+
+## Create and query a source
 
 ```ts
 import {createDataSource} from '@loaders.gl/core';
 import {ArcGISFeatureServerSourceLoader} from '@loaders.gl/services';
 
-const source = createDataSource(url, [ArcGISFeatureServerSourceLoader], {
-  core: {type: 'arcgis-feature-server'}
-});
+const source = createDataSource(
+  'https://example.com/arcgis/rest/services/Roads/FeatureServer/0',
+  [ArcGISFeatureServerSourceLoader]
+);
 
 const metadata = await source.getMetadata();
 const features = await source.getFeatures({
-  layers: '0',
-  boundingBox: [
-    [-86, 36],
-    [-84, 39]
-  ]
+  layers: ['0'],
+  boundingBox: [[-86, 36], [-84, 39]]
 });
 ```
 
-## Example
+When the URL points to the FeatureServer root, `layers` chooses the layer used for the query:
 
-- [ArcGIS Feature Server example](/examples/tiles/arcgis-feature-server)
+```ts
+const source = createDataSource(featureServerUrl, [ArcGISFeatureServerSourceLoader]);
+const trails = await source.getFeatures({layers: ['3']});
+```
+
+## Request options
+
+ArcGIS query defaults live under `arcgis-feature-server`. Per-request viewport and layer values are
+combined with these parameters.
+
+```ts
+const source = createDataSource(featureServerUrl, [ArcGISFeatureServerSourceLoader], {
+  'arcgis-feature-server': {
+    queryParameters: {
+      where: 'status = 1',
+      outFields: ['name', 'category'],
+      returnGeometry: true,
+      maxAllowableOffset: 2
+    }
+  }
+});
+```
+
+Use the standard `fetch` option for bearer tokens or gateways. Tokens already encoded in the URL
+are forwarded to metadata and query requests.
+
+## deck.gl integration
+
+```ts
+import {SourceLayer} from '@loaders.gl/deck-layers';
+import {SERVICE_LOADERS} from '@loaders.gl/services';
+
+const layer = new SourceLayer({
+  id: 'bicycle-routes',
+  data: featureServerUrl,
+  loaders: SERVICE_LOADERS,
+  layers: ['0'],
+  pickable: true,
+  getLineColor: [0, 80, 255],
+  lineWidthMinPixels: 3
+});
+```
+
+The generic layer chooses a vector renderer and refreshes the query as the viewport changes.
+
+## Live example
+
+<div style={{height: '520px'}}>
+  <ClientExample kind="wms" format="ArcGIS Feature Server" />
+</div>
 
 ## References
 
-- [ArcGIS REST API Feature Service](https://developers.arcgis.com/rest/services-reference/enterprise/feature-service.htm)
+- [ArcGIS REST API Feature Service](https://developers.arcgis.com/rest/services-reference/enterprise/feature-service/)
+- [ArcGIS REST API Query](https://developers.arcgis.com/rest/services-reference/enterprise/query-feature-service-layer/)

--- a/docs/modules/services/arcgis-image-server.md
+++ b/docs/modules/services/arcgis-image-server.md
@@ -1,81 +1,144 @@
-# ArcGIS Image Server
+import {ClientExample} from '@site/src/components';
+import {WmsDocsTabs} from '@site/src/components/docs/wms-docs-tabs';
 
-ArcGIS Image Server endpoints expose raster imagery and image services through the ArcGIS REST API.
+# ArcGIS ImageServer
 
-## loaders.gl Support
+<WmsDocsTabs active="arcgis-image-server" />
 
-loaders.gl provides `ArcGISImageServerSourceLoader` as an experimental image source loader for
-ArcGIS `ImageServer` endpoints. It can load service metadata and request exported images for a
-viewport. `ArcGISImageTileSourceLoader` provides a deck.gl-compatible tile source backed by the
-`/exportImage` endpoint.
+ArcGIS ImageServer endpoints expose rendered imagery and analytical raster data. loaders.gl offers
+an `ImageSource` for viewport exports and a `TileSource` for tiled visualization or analysis.
 
-## Usage
+## Feature support
+
+| Capability | Image source | Tile source | API and behavior |
+| --- | --- | --- | --- |
+| Service metadata | Supported | Supported | Normalizes title, description, extent, CRS, and attribution |
+| Rendered imagery | `getImage()` / `exportImage()` | `getTile()` | Decodes PNG, JPEG, and other browser image formats |
+| Analytical LERC | `exportRaster()` | `getTile()` with `format: 'lerc'` | Returns typed bands, mask, dimensions, statistics, and NoData metadata |
+| Bounding box and output CRS | Supported | Web Mercator tiles | Viewport exports accept `bboxSR` and `imageSR` |
+| Pixel type | Supported | Forwarded parameter | ArcGIS integer and floating-point pixel types are preserved by LERC |
+| Band selection | Supported | Forwarded parameter | Use `bandIds` or tile request parameters |
+| Rendering and mosaic rules | Supported | Supported | Pass ArcGIS JSON objects or serialized rules |
+| Runtime parameter updates | Per request | Supported | Tile source `updateParameters()` affects subsequent requests |
+| URL pools | Not applicable | Supported | Optional URL pool distributes tile exports deterministically |
+| Authentication | Supported | Supported | URL tokens and standard fetch options are preserved |
+| deck.gl rendering | First class for images | First class for image tiles | Analytical LERC requires an application-selected visualization |
+
+## Viewport images
 
 ```ts
 import {createDataSource} from '@loaders.gl/core';
 import {ArcGISImageServerSourceLoader} from '@loaders.gl/services';
 
-const source = createDataSource(url, [ArcGISImageServerSourceLoader], {
-  core: {type: 'arcgis-image-server'}
-});
+const source = createDataSource(imageServerUrl, [ArcGISImageServerSourceLoader]);
 
 const metadata = await source.getMetadata();
 const image = await source.getImage({
-  layers: '0',
-  boundingBox: [
-    [-124, 32],
-    [-114, 42]
-  ],
+  layers: [],
+  boundingBox: [[-124, 32], [-114, 42]],
+  crs: 'EPSG:4326',
   width: 1024,
-  height: 768
+  height: 768,
+  format: 'image/png'
 });
 ```
 
-For deck.gl tile rendering, use `ArcGISImageTileSourceLoader`. It requests one `/exportImage`
-image per tile and supports ImageServer rendering parameters.
+`getImage()` uses the generic `ImageSource` request shape. `exportImage()` exposes ArcGIS-specific
+controls when an application needs exact pixel, band, mosaic, or rendering behavior:
+
+```ts
+const image = await source.exportImage({
+  bbox: [-124, 32, -114, 42],
+  bboxSR: 4326,
+  imageSR: 3857,
+  width: 1024,
+  height: 768,
+  format: 'png32',
+  renderingRule: {rasterFunction: 'Hillshade'}
+});
+```
+
+Defaults can be supplied under `arcgis-image-server.exportImageParameters` and overridden by each
+request.
+
+## Image tiles
+
+`ArcGISImageTileSourceLoader` requests one `/exportImage` response per Web Mercator tile:
 
 ```ts
 import {ArcGISImageTileSourceLoader} from '@loaders.gl/services';
 
-const tileSource = createDataSource(url, [ArcGISImageTileSourceLoader], {
-  type: 'arcgis-image-server-tiles',
+const tileSource = createDataSource(imageServerUrl, [ArcGISImageTileSourceLoader], {
   'arcgis-image-server-tiles': {
     tileSize: 512,
-    parameters: {format: 'png32', transparent: true}
+    format: 'png32',
+    parameters: {transparent: true}
   }
 });
 
-tileSource.updateParameters({renderingRule: JSON.stringify({rasterFunction: 'Hillshade'})});
+tileSource.updateParameters({
+  renderingRule: JSON.stringify({rasterFunction: 'Hillshade'})
+});
 ```
+
+The tile source is useful even when the server does not publish a cached tile endpoint. Requests
+are generated from the visible XYZ tile bounds.
 
 ## Analytical LERC rasters
 
-ArcGIS ImageServer can return [LERC](https://esri.github.io/lerc/) instead of a display image.
-Use `exportRaster` when the result should remain a typed, analysis-ready raster:
+Use `exportRaster()` when pixel values must remain analysis-ready:
 
-```js
+```ts
 const raster = await source.exportRaster({
   bbox: [-122.5, 37.7, -122.3, 37.85],
   bboxSR: 'EPSG:4326',
   imageSR: 'EPSG:4326',
   width: 512,
   height: 512,
-  format: 'lerc',
-  pixelType: 'F32'
+  pixelType: 'F32',
+  bandIds: [0]
 });
 
-// raster.pixels contains one typed array per band; raster.mask carries validity.
+const firstBand = raster.pixels[0];
+const validMask = raster.mask;
 ```
 
-For tile workflows, set `format: 'lerc'` under `arcgis-image-server-tiles`. The tile source then
-returns decoded `LERCData` values without an image round trip.
+For tiled analysis, set `format: 'lerc'` under `arcgis-image-server-tiles`. The source decodes each
+tile directly with `@loaders.gl/lerc`; it does not convert values through an 8-bit display image.
 
-## Example
+LERC data is deliberately not colorized automatically. Applications should choose a band, value
+domain, color ramp, and NoData policy appropriate to the dataset before uploading values to the GPU.
 
-- [ArcGIS Image Server example](/examples/tiles/arcgis-image-server)
-- [ArcGIS ImageServer analytical LERC example](/examples/tiles/arcgis-image-server-lerc)
-- [ArcGIS ImageServer tiles example](/examples/tiles/arcgis-image-server-tiles)
+## deck.gl integration
+
+```ts
+import {SourceLayer} from '@loaders.gl/deck-layers';
+import {SERVICE_LOADERS} from '@loaders.gl/services';
+
+const layer = new SourceLayer({
+  id: 'land-cover',
+  data: imageServerUrl,
+  loaders: SERVICE_LOADERS,
+  opacity: 0.8
+});
+```
+
+Use `core.type: 'arcgis-image-server-tiles'` in `sourceOptions` when tiled export is preferred over
+one viewport-sized image.
+
+## Live examples
+
+### Viewport image
+
+<div style={{height: '520px'}}>
+  <ClientExample kind="wms" format="ArcGIS Image Server" />
+</div>
+
+- [ImageServer export tiles](/examples/tiles/arcgis-image-server-tiles)
+- [Analytical ImageServer LERC](/examples/tiles/arcgis-image-server-lerc)
 
 ## References
 
-- [ArcGIS REST API Image Service](https://developers.arcgis.com/rest/services-reference/enterprise/image-service.htm)
+- [ArcGIS REST API Image Service](https://developers.arcgis.com/rest/services-reference/enterprise/image-service/)
+- [ArcGIS REST API Export Image](https://developers.arcgis.com/rest/services-reference/enterprise/export-image/)
+- [LERC codec](https://esri.github.io/lerc/)

--- a/docs/modules/services/arcgis-map-server.md
+++ b/docs/modules/services/arcgis-map-server.md
@@ -1,13 +1,30 @@
 import {ClientExample} from '@site/src/components';
+import {WmsDocsTabs} from '@site/src/components/docs/wms-docs-tabs';
 
 # ArcGIS MapServer
 
-ArcGIS MapServer services can expose cached map tiles through the REST `/tile/{z}/{y}/{x}`
-endpoint or render dynamic tiles through `/export`. loaders.gl provides an image `TileSource` that
-selects cached tiles automatically when `tileInfo` is advertised and can render dynamic services
-with runtime parameters.
+<WmsDocsTabs active="arcgis-map-server" />
 
-## Usage
+ArcGIS MapServer services expose cached map tiles, dynamically rendered maps, or both.
+`ArcGISMapTileSourceLoader` presents either mode through one loaders.gl `TileSource`.
+
+## Feature support
+
+| Capability | Support | API and behavior |
+| --- | --- | --- |
+| Cached tile services | Supported | Uses `/tile/{z}/{y}/{x}` when service metadata advertises `tileInfo` |
+| Dynamic map services | Supported | Uses `/export` with a Web Mercator tile bounding box |
+| Automatic mode selection | Supported | `mode: 'auto'` chooses cached tiles when available, otherwise export |
+| Explicit mode selection | Supported | Use `mode: 'cached'` or `mode: 'dynamic'` |
+| Service metadata | Supported | `getMetadata()` exposes bounds, CRS, layers, tile size, and ArcGIS LODs |
+| ArcGIS LOD grid | Supported | Advertised levels, origins, resolutions, and scale are normalized as a tile grid |
+| Dynamic rendering parameters | Supported | Layer visibility, format, transparency, time, and vendor parameters are forwarded |
+| Multiple service URLs | Supported | Optional URL pool distributes tile requests deterministically |
+| Authentication | Supported | URL tokens and standard fetch options are preserved |
+| Feature queries | Not provided | Use FeatureServer for vector queries or WMS `GetFeatureInfo` when available |
+| deck.gl rendering | First class | `SourceLayer` consumes the `TileSource` directly |
+
+## Cached tiles
 
 ```ts
 import {createDataSource} from '@loaders.gl/core';
@@ -15,33 +32,54 @@ import {ArcGISMapTileSourceLoader} from '@loaders.gl/services';
 
 const source = createDataSource(
   'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer',
-  [ArcGISMapTileSourceLoader],
-  {type: 'arcgis-map-server'}
+  [ArcGISMapTileSourceLoader]
 );
 
 const metadata = await source.getMetadata();
 const image = await source.getTile({x: 2, y: 1, z: 2});
 ```
 
-For dynamic services, select export mode and configure the request parameters. A pool of service
-URLs can be supplied for simple request distribution.
+## Dynamic export tiles
+
+Select export mode when a service is not cached or when dynamic layer, time, or rendering
+parameters are required:
 
 ```ts
-const source = createDataSource(url, [ArcGISMapTileSourceLoader], {
-  type: 'arcgis-map-server',
+const source = createDataSource(mapServerUrl, [ArcGISMapTileSourceLoader], {
   'arcgis-map-server': {
     mode: 'dynamic',
     tileSize: 512,
     urls: ['https://tiles-a.example.com/MapServer', 'https://tiles-b.example.com/MapServer'],
-    exportParameters: {layers: 'show:0', format: 'jpgpng'}
+    exportParameters: {
+      layers: 'show:0,2',
+      format: 'png32',
+      transparent: true
+    }
   }
 });
 
 source.updateParameters({time: '2024-01-01'});
 ```
 
-ArcGIS ImageServer export tiles are available through `ArcGISImageTileSourceLoader`, which uses
-the corresponding `/exportImage` endpoint and supports the same tile-source integration.
+Runtime parameters are merged into subsequent export requests, which makes time sliders and layer
+controls inexpensive to implement.
+
+## deck.gl integration
+
+```ts
+import {SourceLayer} from '@loaders.gl/deck-layers';
+import {SERVICE_LOADERS} from '@loaders.gl/services';
+
+const layer = new SourceLayer({
+  id: 'world-imagery',
+  data: mapServerUrl,
+  loaders: SERVICE_LOADERS,
+  minZoom: 0,
+  maxZoom: 19
+});
+```
+
+`SourceLayer` uses the normalized tile grid and requests only visible tiles.
 
 ## Live example
 
@@ -51,4 +89,5 @@ the corresponding `/exportImage` endpoint and supports the same tile-source inte
 
 ## References
 
-- [ArcGIS MapServer REST API](https://developers.arcgis.com/rest/services-reference/enterprise/map-service/)
+- [ArcGIS REST API Map Service](https://developers.arcgis.com/rest/services-reference/enterprise/map-service/)
+- [ArcGIS REST API Export Map](https://developers.arcgis.com/rest/services-reference/enterprise/export-map/)

--- a/docs/modules/services/arcgis-vector-tile-server.md
+++ b/docs/modules/services/arcgis-vector-tile-server.md
@@ -1,25 +1,84 @@
+import {ClientExample} from '@site/src/components';
+import {WmsDocsTabs} from '@site/src/components/docs/wms-docs-tabs';
+
 # ArcGIS VectorTileServer
 
-`ArcGISVectorTileServerSourceLoader` provides a source adapter for ArcGIS vector tile services.
-It loads service metadata, exposes the ArcGIS tile grid, constructs PBF tile URLs, and exposes the
-published Mapbox style and sprite resources.
+<WmsDocsTabs active="arcgis-vector-tile-server" />
 
-```js
-import {ArcGISVectorTileServerSourceLoader} from '@loaders.gl/services';
+ArcGIS VectorTileServer endpoints publish Mapbox Vector Tile (MVT) data together with an ArcGIS
+tile grid, style document, and sprite resources. `ArcGISVectorTileServerSourceLoader` implements the
+loaders.gl `VectorTileSource` contract.
+
+## Feature support
+
+| Capability | Support | API and behavior |
+| --- | --- | --- |
+| Service metadata | Supported | `getMetadata()` exposes extent, CRS, LOD grid, style URL, and sprite URL |
+| Raw vector tiles | Supported | `getTile()` returns the original PBF bytes |
+| Decoded vector tiles | Supported | `getVectorTile()` decodes MVT through `@loaders.gl/mvt` |
+| deck.gl tile data | Supported | `getTileData()` returns decoded WGS84 feature data |
+| Geometry coordinates | WGS84 | Decoded features are transformed from tile-local coordinates for visualization |
+| Layer filtering | Supported | Forward MVT loader options to select named source layers |
+| Feature shape | Configurable | Standard MVT loader shape options are honored |
+| ArcGIS style discovery | Supported | Metadata includes the published root style and sprite resource URLs |
+| Style application | Application controlled | loaders.gl exposes style resources but does not translate the full ArcGIS style into deck props |
+| Authentication | Supported | URL tokens and standard fetch options are preserved for all resources |
+| deck.gl rendering | First class | `SourceLayer` consumes decoded vector tiles directly |
+
+## Raw and decoded tiles
+
+```ts
 import {createDataSource} from '@loaders.gl/core';
+import {ArcGISVectorTileServerSourceLoader} from '@loaders.gl/services';
 
-const source = createDataSource(
-  'https://example.com/arcgis/rest/services/World/VectorTileServer',
-  [ArcGISVectorTileServerSourceLoader]
-);
+const source = createDataSource(vectorTileServiceUrl, [ArcGISVectorTileServerSourceLoader]);
 
 const metadata = await source.getMetadata();
 const tileBytes = await source.getTile({z: 4, x: 6, y: 7});
+const features = await source.getVectorTile({z: 4, x: 6, y: 7});
 ```
 
-The adapter returns raw PBF bytes so applications can decode them with the existing
-`@loaders.gl/mvt` loader. Authentication and request overrides are supplied through the normal
-load-options mechanism.
+Use `getTile` when caching or forwarding the original PBF. Use `getVectorTile` when an application
+needs decoded geometries and properties.
 
-ArcGIS documents the service resource at
-[Vector Tile Service](https://developers.arcgis.com/rest/services-reference/enterprise/vector-tile-service/).
+## Decoder options
+
+MVT options are forwarded to `@loaders.gl/mvt`:
+
+```ts
+const source = createDataSource(vectorTileServiceUrl, [ArcGISVectorTileServerSourceLoader], {
+  mvt: {
+    shape: 'geojson-table',
+    layers: ['roads', 'labels']
+  }
+});
+```
+
+## deck.gl integration
+
+```ts
+import {SourceLayer} from '@loaders.gl/deck-layers';
+import {SERVICE_LOADERS} from '@loaders.gl/services';
+
+const layer = new SourceLayer({
+  id: 'arcgis-vector-tiles',
+  data: vectorTileServiceUrl,
+  loaders: SERVICE_LOADERS,
+  pickable: true,
+  getFillColor: [60, 140, 210],
+  getLineColor: [20, 50, 80]
+});
+```
+
+The ArcGIS style URL remains available in source metadata for applications that want to translate
+or selectively reuse the service's authored style.
+
+## Live example
+
+<div style={{height: '520px'}}>
+  <ClientExample kind="wms" format="ArcGIS VectorTileServer" />
+</div>
+
+## References
+
+- [ArcGIS REST API Vector Tile Service](https://developers.arcgis.com/rest/services-reference/enterprise/vector-tile-service/)

--- a/docs/modules/wms/README.md
+++ b/docs/modules/wms/README.md
@@ -1,77 +1,128 @@
-# Overview
+# OGC geospatial services
 
-<p class="badges">
-  <img src="https://img.shields.io/badge/From-v3.3-blue.svg?style=flat-square" alt="From-v3.3" />
-</p>
+The `@loaders.gl/wms` module provides read-only clients and response parsers for classic OGC Web
+Services, modern OGC APIs, and GML. Despite the historical package name, it covers maps, tiles,
+features, coverages, environmental observations, and catalogs.
 
-![ogc-logo](../../images/logos/ogc-logo-60.png)
+## Service matrix
 
-# OGC Web Services
+| Service or format | Primary source or loader | Data category | Status | Best use |
+| --- | --- | --- | --- | --- |
+| [WMS](/docs/modules/wms/formats/wms) | `WMSSourceLoader` | Rendered image | Supported | Dynamic maps, feature information, legends |
+| [WMTS](/docs/modules/wms/formats/wmts) | `WMTSSourceLoader` | Image tiles | Supported | Capability-driven tiled imagery |
+| [WFS](/docs/modules/wms/formats/wfs) | `WFSSourceLoader` | Vector features | Supported | GeoJSON or streaming GML feature queries |
+| [WCS](/docs/modules/wms/formats/wcs) | `WCSCoverageSourceLoader` | Analytical raster | Focused | Binary coverages and decoded LERC |
+| [CSW](/docs/modules/wms/formats/csw) | `CSWSourceLoader` | Catalog records | Focused | Read-only catalog search and service references |
+| [GML](/docs/modules/wms/formats/gml) | `GMLLoader` | Vector format | Supported subset | High-volume WFS feature ingestion |
+| [OGC API Features](/docs/modules/wms/services/ogc-api#ogc-api-features) | `OGCAPIFeaturesSourceLoader` | Vector features | Minimal | Common collections/items read path |
+| [OGC API Tiles](/docs/modules/wms/services/ogc-api#ogc-api-tiles) | `OGCAPITilesSourceLoader` | Tile bytes | Minimal | Known tile templates |
+| [OGC API Coverages](/docs/modules/wms/services/ogc-api#ogc-api-coverages) | `OGCAPICoveragesSourceLoader` | Coverage data | Minimal | Common collection coverage endpoint |
+| [OGC API EDR](/docs/modules/wms/services/ogc-api#ogc-api-edr) | `OGCAPIEDRSourceLoader` | Environmental observations | Focused | Position, area, cube, and path queries |
+| [WMC](/docs/modules/wms/formats/wmc) | None | Map context | Not implemented | Documented to clarify scope |
+| [OWS Context](/docs/modules/wms/formats/ows-context) | None | Service context | Not implemented | Documented to clarify scope |
 
-The `@loaders.gl/wms` module provides support for a subset of the OGC Web Services which are a set of XML-based web mapping standards.
+“Focused” means the important read operations are implemented without claiming every optional
+operation. “Minimal” means a deliberately small interoperability adapter for the most common OGC
+API path.
 
-> The Open Geospatial Consortium (OGC) has produced a large set of related XML-based standards for web mapping. Some of these standards are not supported by loaders.gl, but are still mentioned here to provide context for the provided functionality (and minimize confusion as the standards have similar names and functionalities):
-
-## Services
-
-| OGC Protocol/Format                                                                 | Supported    | Description                                                                                                                          |
-| ----------------------------------------------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
-| [**CSW**](/docs/modules/wms/formats/csw) (Catalog Service for the Web) protocol     | Y            | protocol for reading a catalog of geospatial assets and services from a URL.                                                         |
-| [**WMS**](/docs/modules/wms/formats/wms) (Web Map Service) protocol                 | Y            | protocol for serving geo-referenced map images over the internet.                                                                    |
-| [**WFS**](/docs/modules/wms/formats/wfs) (Web Feature Service) protocol             | experimental | protocol for serving geo-referenced map features (geometries) over the internet.                                                     |
-| [**WMTS**](/docs/modules/wms/formats/wmts) (Web Map Tile Service) protocol          | experimental | protocol for serving pre-rendered or run-time computed georeferenced map tiles over the Internet.                                    |
-| [**GML**](/docs/modules/wms/formats/gml) (Geographic Markup Language) format        | experimental | an XML grammar that describes geographical features.                                                                                 |
-| [**WCS**](/docs/modules/wms/formats/wcs) (Web Coverage Service)                     | experimental | Load analytical coverage data (including binary and LERC responses) from a server.                                                  |
-| [**WMC**](/docs/modules/wms/formats/wmc) (Web Map Context)                          | No           | Used in WMS clients to save the configuration of maps and to load them again later. Can also be exchanged between different clients. |
-| [**OWS Context**](/docs/modules/wms/formats/ows-context) (OGC Web Services Context) | No           | Allows configured information resources to be passed between applications primarily as a collection of services.                     |
-
-The module also includes minimal adapters for the modern OGC API family. These adapters cover
-landing pages, collections, basic GeoJSON Features queries, advertised tile templates, coverage
-retrieval, and EDR queries. They are intentionally not a full conformance implementation;
-advanced filtering and service-specific extensions remain available through the regular loaders.gl
-fetch APIs.
-
-```js
-import {OGCAPIFeaturesSourceLoader} from '@loaders.gl/wms';
-import {createDataSource} from '@loaders.gl/core';
-
-const source = createDataSource('https://demo.ldproxy.net/daraa', [OGCAPIFeaturesSourceLoader], {
-  'ogc-api': {collectionId: 'VegetationSrf'}
-});
-const features = await source.getFeatures({
-  layers: 'VegetationSrf',
-  boundingBox: [
-    [12.4, 41.8],
-    [12.6, 42.0]
-  ]
-});
-```
-
-## API
-
-Support for the protocols is provided in the form of:
-
-- [`WMSService`][capabilities_loader].
-- [`WMSCapabilitiesLoader`][capabilities_loader].
-
-- a small collection of parsers for the XML responses from the various requests in these protocols.
-- a short write-up on each protocol to indicate how to use loaders.gl to parse responses
-
-Support for the GML format is provided as
-
-- A standard "geospatial category" loader that converts the data into GeoJSON format.
+ArcGIS REST services are provided by [`@loaders.gl/services`](/docs/modules/services).
 
 ## Installation
 
 ```bash
-npm install @loaders.gl/wms
-npm install @loaders.gl/core
+npm install @loaders.gl/core @loaders.gl/wms
 ```
+
+Install `@loaders.gl/deck-layers` when visual services should render directly through deck.gl.
+
+## Standard source workflow
+
+Every service source can be created through the loaders.gl core API:
+
+```ts
+import {createDataSource} from '@loaders.gl/core';
+import {WMSSourceLoader} from '@loaders.gl/wms';
+
+const source = createDataSource(wmsUrl, [WMSSourceLoader], {
+  wms: {wmsParameters: {layers: ['workspace:roads']}}
+});
+
+const metadata = await source.getMetadata();
+const image = await source.getImage({
+  layers: ['workspace:roads'],
+  boundingBox: [[-10, 40], [10, 50]],
+  crs: 'CRS:84',
+  width: 1024,
+  height: 512
+});
+```
+
+The concrete runtime contract reflects the data category:
+
+| Contract | Typical methods | Services |
+| --- | --- | --- |
+| `ImageSource` | `getMetadata`, `getImage` | WMS |
+| `TileSource` | `getMetadata`, `getTile`, `getTileData` | WMTS, OGC API Tiles |
+| `VectorSource` | `getMetadata`, `getSchema`, `getFeatures` | WFS, OGC API Features |
+| Coverage source | `getMetadata`, `getCoverage` | WCS, OGC API Coverages |
+| Catalog source | `getMetadata`, `search` | CSW |
+| EDR source | `getLandingPage`, `getCollections`, `query` | OGC API EDR |
+
+## deck.gl integration
+
+Visual service sources work through one generic `SourceLayer`:
+
+```ts
+import {SourceLayer} from '@loaders.gl/deck-layers';
+import {WMTSSourceLoader} from '@loaders.gl/wms';
+
+const layer = new SourceLayer({
+  id: 'satellite',
+  data: wmtsUrl,
+  loaders: [WMTSSourceLoader],
+  sourceOptions: {wmts: {layer: layerId, tileMatrixSet: matrixSetId}}
+});
+```
+
+WMS, WMTS, WFS, and OGC API Features map naturally to visual source contracts. Catalog, EDR, and
+analytical coverage outputs require an application choice before rendering: select a catalog
+record, EDR representation, raster band, color ramp, and NoData policy first.
+
+## Shared service infrastructure
+
+- [`ServiceRuntime`](/docs/modules/wms/services/universal-service-runtime) adds loader selection, source caching,
+  retries, cancellation, shared headers, and telemetry.
+- [`CapabilityGraph`](/docs/modules/wms/services/capability-discovery) records relationships among discovered
+  endpoints and ranks them by type, format, CRS, latency, and quality.
+- [CRS and tile-grid utilities](/docs/modules/wms/api-reference/crs-and-tile-grids) normalize identifiers, axis
+  order, matrix sets, ArcGIS LODs, and antimeridian-sensitive metadata.
+- [Service capabilities](/docs/modules/wms/api-reference/service-capabilities) provide a provider-neutral metadata
+  shape while concrete sources retain provider-specific details.
+
+These pieces are optional. If an endpoint and protocol are already known, creating the concrete
+source directly remains the smallest API.
+
+## Authentication and errors
+
+All sources inherit loaders.gl fetch configuration. Applications can provide headers, credentials,
+request middleware, proxies, and custom fetch functions without protocol-specific wrappers.
+Abort signals are accepted by data requests that may be long-running.
+
+Protocol errors are checked before parsing. WMS and related XML service exceptions use dedicated
+error parsers; focused adapters report the operation and HTTP status.
+
+## Testing and conformance policy
+
+Fast tests use deterministic fixtures and block public-network access. Fixtures cover protocol
+versions, namespace variations, axis order, matrix grids, streaming chunk boundaries, and provider
+metadata. Live examples are demonstrations, not CI dependencies.
+
+loaders.gl documents its actual implemented subset on each service page. Optional standards
+features are marked pass-through or unsupported instead of being implied by the existence of a
+capabilities parser.
 
 ## Attributions
 
-`@loaders.gl/wms` relies heavily on `@loaders.gl/xml` to parse the XML heavy OGC standards.
-
-Some test cases are forked from open layers, see license in test directory,
-however no openlayers code is included in the published module, in order to
-avoid downstream "binary attribution" requirements on loaders.gl users.
+`@loaders.gl/wms` uses `@loaders.gl/xml` for XML parsing. Some test fixtures originated from
+OpenLayers and retain their licenses in the test data; no OpenLayers runtime code is included in the
+published module.

--- a/docs/modules/wms/formats/csw.md
+++ b/docs/modules/wms/formats/csw.md
@@ -1,32 +1,67 @@
-# CSW - Catalog Service - Web
+# CSW - Catalogue Service for the Web
 
 ![ogc-logo](../../../images/logos/ogc-logo-60.png)
 
-- _[`@loaders.gl/wms`](/docs/modules/wms)_
-- _[Wikipedia article)][csw]_
+CSW is an OGC protocol for searching catalogs of geospatial datasets, services, and related
+resources. `CSWSourceLoader` adapts read-only CSW endpoints to the loaders.gl `CatalogSource`
+contract.
 
-CSW (Catalogue Service for the Web, sometimes written Catalogue Service - Web), is an OGC standard for exposing a catalogue of geospatial records in XML on the Internet (over HTTP). The catalogue is made up of records that describe geospatial data (e.g. KML), geospatial services (e.g. WMS), and related resources.
+## Feature support
 
-Operations defined by the CSW standard include:
+| Capability | Support | API and behavior |
+| --- | --- | --- |
+| `GetCapabilities` | Supported | `getCapabilities()` returns parsed, typed service metadata |
+| `GetRecords` | Supported | `getRecords()` and async `search()` return catalog records |
+| `GetDomain` | Supported | `getDomain()` parses advertised parameter domains |
+| Service directory | Supported | `getServiceDirectory()` extracts WMS, WMTS, and WFS references |
+| Normalized catalog contract | Supported | Implements read-only `CatalogSource` metadata and search |
+| Vendor query parameters | Supported | Appended to generated GET requests |
+| HTTP GET / KVP | Supported | All implemented operations use query parameters |
+| XML or form POST | Not supported | Request payload generation is outside the source |
+| `DescribeRecord` / `GetRecordById` | Not exposed | Use a custom request and the low-level XML loaders if needed |
+| Pagination and CQL filtering | Not normalized | The minimal catalog contract reports these capabilities as unavailable |
+| Harvest and transactions | Not supported | The source is read-only |
+| deck.gl rendering | Not applicable | Select a referenced visual service, then pass that service to `SourceLayer` |
 
-| Operation                | Description                                                                                   |
-| ------------------------ | --------------------------------------------------------------------------------------------- |
-| `GetCapabilities`        | allows CSW clients to retrieve service metadata from a server                                 |
-| `DescribeRecord`         | allows a client to discover the information model supported by a target catalogue or service. |
-| `GetRecords`             | search for records, returning record IDs                                                      |
-| `GetRecordById`          | retrieves the default representation of catalogue records using their identifier              |
-| `GetDomain` (optional)   | obtain information about the range of values of a metadata record or request parameter        |
-| `Harvest` (optional)     | create/update metadata by asking the server to 'pull' metadata from somewhere                 |
-| `Transaction` (optional) | create/edit metadata by 'pushing' the metadata to the server                                  |
+## Search a catalog
 
-Requests can encode the parameters in three different ways:
+```ts
+import {createDataSource} from '@loaders.gl/core';
+import {CSWSourceLoader} from '@loaders.gl/wms';
 
-| Parameter encoding               | loaders.gl support |
-| -------------------------------- | ------------------ |
-| `GET` with URL parameters        | Yes                |
-| `POST` with form-encoded payload | No                 |
-| `POST` with XML payload          | No                 |
+const catalog = createDataSource(cswUrl, [CSWSourceLoader]);
+const metadata = await catalog.getMetadata();
 
-Responses are in XML.
+for await (const record of catalog.search()) {
+  console.log(record.title, record.references);
+}
+```
 
-[csw]: https://en.wikipedia.org/wiki/Catalogue_Service_for_the_Web
+## Discover referenced services
+
+```ts
+const services = await catalog.getServiceDirectory({includeUnknown: true});
+
+// Each recognized entry includes a normalized type, base URL, and original query parameters.
+const firstWms = services.find(service => service.type === 'ogc-wms-service');
+```
+
+The directory recognizes `OGC:WMS`, `OGC:WMTS`, and `OGC:WFS` reference schemes. Unknown schemes
+can be retained for application-specific handling.
+
+## Request customization
+
+Authentication headers and custom transports use standard fetch options. Operation-specific and
+vendor parameters can be supplied separately:
+
+```ts
+const records = await catalog.getRecords(
+  {version: '2.0.0', typenames: 'csw:Record'},
+  {outputSchema: 'http://www.isotc211.org/2005/gmd'}
+);
+```
+
+## References
+
+- [OGC Catalogue Service standard](https://www.ogc.org/standard/cat/)
+- [CSW overview](https://en.wikipedia.org/wiki/Catalogue_Service_for_the_Web)

--- a/docs/modules/wms/formats/gml.md
+++ b/docs/modules/wms/formats/gml.md
@@ -2,76 +2,89 @@
 
 ![ogc-logo](../../../images/logos/ogc-logo-60.png)
 
-- _[`loaders.gl/wms`](/docs/modules/wms)_
-- _[Wikpedia article](https://en.wikipedia.org/wiki/Geography_Markup_Language)_
+GML is the OGC XML grammar for geographical features. loaders.gl focuses on the feature and
+geometry subset encountered in production WFS responses, with incremental parsing for large
+collections.
 
-The Geography Markup Language (GML) is an XML grammar defined by the Open Geospatial Consortium (OGC) to express geographical features.
+## Feature support
 
-GML serves as a modeling language for geographic systems as well as an open interchange format for geographic transactions on the Internet. Key to GML's utility is its ability to integrate all forms of geographic information, including not only conventional "vector" or discrete objects, but coverages (see also GMLJP2) and sensor data.
+| Capability | Support | Notes |
+| --- | --- | --- |
+| GML 2 feature members | Supported | Common WFS feature collection structures and geometry properties |
+| GML 3 / 3.2 feature members | Supported | Namespace-prefix independent parsing |
+| Point and MultiPoint | Supported | GML 2 and GML 3 coordinate encodings |
+| LineString, Curve, and multi-line geometry | Supported | Segment coordinates are normalized to GeoJSON-compatible lines |
+| Polygon, Surface, and multi-polygon geometry | Supported | Exterior and interior rings are preserved |
+| `coord` / `coordinates` | Supported | Legacy GML 2 coordinate encodings |
+| `pos` / `posList` | Supported | Dimensional GML 3 coordinate encodings |
+| CRS identifiers | Preserved | `srsName` is read; reprojection is not silently applied by the parser |
+| Axis order | Service-aware | WFS source logic handles known CRS axis-order rules |
+| Streaming | Supported | `parseInBatches` emits collections as feature members arrive |
+| Schema-aware scalar properties | Supported | Supply string, boolean, integer, number, date, and date-time hints |
+| GeoJSON output | Supported | Default geospatial representation |
+| Binary and Arrow output | Through WFS | `WFSSourceLoader` converts parsed GML to standard vector outputs |
+| Arbitrary GML application schemas | Best effort | Unknown XML properties are preserved instead of guessed |
+| Topologies, solids, and every ISO geometry primitive | Not supported | Outside the practical WFS feature subset |
 
-## Limitations
+## Parse a document
 
-GML is a very ambitious format, with a large set of primitives and many ways to express similar geometries by composing different primitives. Parsing GML is generally considered challenging, even when the goal is only to support the "GeoJSON subset" of primitives. Because of this, full support for every GML application schema is currently out of scope for loaders.gl. The parser supports streaming feature members and the common GML 2/3 geometry subset used by WFS services.
-
-The `GMLLoader` supports parsing the standard geospatial subset of features (points, multipoints, lines, linestrings, polygons and multipolygons), on a "best effort" basis. Its `parseInBatches` entry point emits feature collections as GML members arrive, so WFS responses do not need to be buffered in full. Because of this, the `GMLLoader` is treated as a geospatial loader and can return GeoJSON style output.
-
-GML 2 coordinate encodings (`coord` and `coordinates`) and GML 3 encodings (`pos`, `posList`,
-curves, surfaces, and dimensional positions) are accepted. Namespace prefixes are not required
-to be named `gml`; the parser matches the namespace-local names used by GML 2 and GML 3.2
-application schemas. When an application has a DescribeFeatureType schema, scalar property types
-can be supplied to preserve values while parsing:
+The package root exports metadata-only loaders. Import the parser-bearing loader from the bundled
+entry point when parsing directly:
 
 ```ts
+import {load} from '@loaders.gl/core';
 import {GMLLoader} from '@loaders.gl/wms/bundled';
 
+const featureCollection = await load('features.gml', GMLLoader);
+```
+
+## Stream a large response
+
+```ts
+import {loadInBatches} from '@loaders.gl/core';
+import {GMLLoader} from '@loaders.gl/wms/bundled';
+
+for await (const batch of await loadInBatches(wfsResponse, GMLLoader)) {
+  consume(batch.data);
+}
+```
+
+The SAX-based parser frames features from XML structure rather than searching text with regular
+expressions, so a member can span arbitrary network chunks.
+
+## Preserve property types
+
+GML application schemas often carry scalar types that cannot be inferred safely from text. Supply
+known types from `DescribeFeatureType` or application metadata:
+
+```ts
 const features = GMLLoader.parseTextSync!(xml, {
-  gml: {propertyTypes: {population: 'integer', active: 'boolean'}}
+  gml: {
+    propertyTypes: {
+      population: 'integer',
+      active: 'boolean',
+      observedAt: 'date-time'
+    }
+  }
 });
 ```
 
-Supported scalar type hints are `string`, `boolean`, `integer`, `number`, `date`, and `date-time`.
-Unknown or untyped properties remain strings or structured XML values, preserving the server
-response instead of guessing types.
+Unknown or untyped properties remain strings or structured XML values. This preserves the server
+response without silently turning identifiers, codes, or zero-padded values into numbers.
 
-A fun read that illustrates the challenge is the [GML madness](http://erouault.blogspot.com/2014/04/gml-madness.html) article by Even Rouault.
+## GML and WFS
 
-## Examples
+Most applications should use [`WFSSourceLoader`](./wfs) rather than invoke `GMLLoader` directly.
+The WFS source negotiates the response format, applies paging and CRS request rules, streams GML,
+and converts the result to GeoJSON, binary, or Arrow output.
 
-These examples are copied from [w3.org](https://www.w3.org/Mobile/posdep/GMLIntroduction.html):
+## Boundaries
 
-The following example encodes the geometry of a feature (a building in this case):
+GML is an extensible modeling language, not one fixed feature schema. loaders.gl intentionally
+does not claim universal GML conformance. The supported subset is designed for interoperable WFS
+feature ingestion; specialized domains may require an application-schema adapter.
 
-```xml
-<Feature   fid="142" featureType="school"  Description="A middle school">
-    <Polygon name="extent" srsName="epsg:27354">
-        <LineString name="extent" srsName="epsg:27354">
-            <CData>
-              491888.999999459,5458045.99963358 491904.999999458,5458044.99963358
-              491908.999999462,5458064.99963358 491924.999999461,5458064.99963358
-              491925.999999462,5458079.99963359 491977.999999466,5458120.9996336
-              491953.999999466,5458017.99963357
-            </CData>
-        </LineString>
-    </Polygon>
-</Feature>
-```
+## References
 
-Properties (in addition to the geometry the geometry) can also be added:
-
-```xml
-<Feature   fid="142" featureType="school" >
-    <Description>Balmoral Middle School</Description>>
-    <Property Name="NumFloors" type="Integer" value="3"/>
-    <Property Name="NumStudents" type="Integer" value="987"/>
-    <Polygon  name="extent" srsName="epsg:27354">
-        <LineString  name="extent" srsName="epsg:27354">
-            <CData>
-              491888.999999459,5458045.99963358 491904.999999458,5458044.99963358
-              491908.999999462,5458064.99963358 491924.999999461,5458064.99963358
-              491925.999999462,5458079.99963359 491977.999999466,5458120.9996336
-              491953.999999466,5458017.99963357
-            </CData>
-    </LineString>
-  </Polygon>
-</Feature>
-```
+- [OGC GML standard](https://www.ogc.org/standard/gml/)
+- [Geography Markup Language overview](https://en.wikipedia.org/wiki/Geography_Markup_Language)

--- a/docs/modules/wms/formats/ows-context.md
+++ b/docs/modules/wms/formats/ows-context.md
@@ -1,3 +1,24 @@
 # OWS Context
 
 ![ogc-logo](../../../images/logos/ogc-logo-60.png)
+
+OWS Context is an OGC exchange format for packaging a collection of configured geospatial
+resources and services.
+
+## Feature support
+
+| Capability | Support | Recommendation |
+| --- | --- | --- |
+| OWS Context Atom encoding | Not implemented | Parse the XML with `@loaders.gl/xml` and adapt links in application code |
+| OWS Context JSON encoding | Not implemented | Load JSON normally and pass referenced endpoints to service loaders |
+| Referenced WMS services | Supported separately | Use `WMSSourceLoader` |
+| Referenced WMTS services | Supported separately | Use `WMTSSourceLoader` |
+| Referenced WFS services | Supported separately | Use `WFSSourceLoader` |
+| General service discovery | Supported separately | Use `discoverServiceGraph` or a `CSWSourceLoader` catalog |
+
+This page is retained to clarify the boundary between a context document and the services it can
+reference. loaders.gl v5 does not expose an OWS Context loader.
+
+## References
+
+- [OGC OWS Context standard](https://www.ogc.org/standard/owc/)

--- a/docs/modules/wms/formats/wcs.md
+++ b/docs/modules/wms/formats/wcs.md
@@ -6,15 +6,36 @@ import {WmsDocsTabs} from '@site/src/components/docs/wms-docs-tabs';
 
 ![ogc-logo](../../../images/logos/ogc-logo-60.png)
 
-WCS provides access to analytical geospatial coverages rather than rendered map images. The
-`@loaders.gl/wms` module exposes a focused source for capabilities discovery and `GetCoverage`
-requests.
+WCS provides analytical geospatial coverages rather than server-rendered map images.
+`WCSCoverageSourceLoader` supports focused discovery and read-only coverage retrieval.
 
-```js
+## Feature support
+
+| Capability | Support | API and behavior |
+| --- | --- | --- |
+| `GetCapabilities` | Supported | Parses service metadata and advertised coverage summaries |
+| Normalized metadata | Supported | `getMetadata()` returns title, identifiers, formats, and bounds |
+| `GetCoverage` | Supported | Returns the requested binary coverage representation |
+| WCS 2.x subsets | Supported | `bbox` is converted to repeated axis subset expressions |
+| WCS 1.x bounding boxes | Supported | Legacy `bbox`, `crs`, and `responseCRS` parameters are generated |
+| Explicit subset expressions | Supported | Pass one or more server-specific `subset` values |
+| Output dimensions | Supported | Width and height are forwarded when accepted by the service |
+| CRS selection | Supported | Request and response CRS parameters are version-aware |
+| GeoTIFF and other binary formats | Preserved | Returned as `ArrayBuffer` for decoding by the appropriate loader |
+| LERC | Decoded | Returns typed per-band arrays, masks, NoData, and statistics |
+| `DescribeCoverage` | Not exposed | Use a custom request when detailed range metadata is required |
+| Coverage processing | Not provided | Resampling, algebra, and colorization remain application concerns |
+| deck.gl rendering | Explicit | Decode the format and choose a raster visualization policy first |
+
+## Retrieve a coverage
+
+```ts
+import {createDataSource} from '@loaders.gl/core';
 import {WCSCoverageSourceLoader} from '@loaders.gl/wms';
 
-const source = WCSCoverageSourceLoader.createDataSource('https://example.com/wcs', {
+const source = createDataSource('https://example.com/wcs', [WCSCoverageSourceLoader], {
   wcs: {
+    version: '2.0.1',
     coverageId: 'elevation',
     format: 'image/tiff'
   }
@@ -27,6 +48,33 @@ const coverage = await source.getCoverage({
 });
 ```
 
-Binary responses are returned as `ArrayBuffer`. When `format` is a LERC media type and the source
-was created with a loaders.gl Core API, the response is decoded through `@loaders.gl/lerc` and
-returned as typed per-band arrays with statistics and masks preserved.
+Binary formats are intentionally preserved. For example, pass a GeoTIFF `ArrayBuffer` to the TIFF
+loader when decoded pixels are required.
+
+## Analytical LERC
+
+When the requested format contains `lerc`, the response is decoded through `@loaders.gl/lerc`:
+
+```ts
+const raster = await source.getCoverage({
+  coverageId: 'temperature',
+  bbox: [-10, 40, 10, 50],
+  format: 'image/lerc'
+});
+
+if (!(raster instanceof ArrayBuffer)) {
+  console.log(raster.width, raster.height, raster.pixels, raster.mask);
+}
+```
+
+The returned values are analysis-ready. loaders.gl does not infer a color ramp or alter numerical
+values merely to make them displayable.
+
+## Request customization
+
+Use `wcs.parameters` for source-wide vendor defaults and `parameters` on `getCoverage()` for one
+request. Repeated `subset` values are encoded separately, as required by WCS 2.x.
+
+## References
+
+- [OGC Web Coverage Service standard](https://www.ogc.org/standard/wcs/)

--- a/docs/modules/wms/formats/wfs.md
+++ b/docs/modules/wms/formats/wfs.md
@@ -1,4 +1,5 @@
 import {WmsDocsTabs} from '@site/src/components/docs/wms-docs-tabs';
+import {ClientExample} from '@site/src/components';
 
 # WFS - Web Feature Service
 
@@ -6,65 +7,79 @@ import {WmsDocsTabs} from '@site/src/components/docs/wms-docs-tabs';
 
 ![ogc-logo](../../../images/logos/ogc-logo-60.png)
 
-- _[`@loaders.gl/wms`](/docs/modules/wms)_
-- _[Wikipedia article](https://en.wikipedia.org/wiki/Web_Feature_Service)_
+WFS serves vector features and properties over HTTP. `WFSSourceLoader` provides a read-only
+`VectorSource` with GeoJSON and streaming GML ingestion.
 
-WFS (Web Feature Service) is a standardized protocol for serving geographical features (points, lines and polygons) over the internet.
+## Feature support
 
-## Characteristics
+| Capability | Support | API and behavior |
+| --- | --- | --- |
+| WFS 2.0.0 | Supported | Default request version |
+| WFS 1.1.0 | Supported | Version-aware parameter names and axis handling |
+| `GetCapabilities` | Supported | Parses service and feature-type metadata |
+| `GetFeature` GeoJSON | Supported | Default response path when available |
+| `GetFeature` GML 2/3 | Supported | SAX-based parsing of common feature and geometry structures |
+| Streaming GML | Supported | `getFeaturesInBatches()` emits bounded batches without buffering the document |
+| GeoJSON output | Supported | Standard vector-source feature table |
+| Binary and Arrow output | Supported | Select with the standard `format` parameter |
+| Bounding-box queries | Supported | Builds a version- and CRS-aware `bbox` request |
+| Paging | Supported | WFS 2 uses `count`/`startIndex`; WFS 1.1 maps count to `maxFeatures` |
+| Property selection and sorting | Supported | `propertyName` and `sortBy` are forwarded |
+| FES XML filters | Pass through | Caller supplies filter XML appropriate for the server version |
+| Count-only queries | Supported | Use `resultType: 'hits'` when the server advertises it |
+| Schema type hints | Supported | GML property types can be supplied from application schema knowledge |
+| Transactions and locking | Not supported | WFS-T mutation APIs are outside the read-only source |
+| deck.gl rendering | First class | Pass `WFSSourceLoader` to `SourceLayer` |
 
-WFS is not a single file format but rather a protocol, specifying a number of required and optional requests. Some requests return binary images, and some return metadata formatted as XML (text) responses. The XML responses are fairly detailed and some variations exists, so when working with WFS it is typically useful to have access to pre-tested parsers for each response type.
-
-## Profiles
-
-- Basic WFS (`WFS-Basic`) - A READ-ONLY WFS. Unable to service transaction requests necessary for data manipulation
-- Transaction WFS (`WFS-T`) - Supports all the operations of basic WFS including the ability to manipulate the data (create, edit, delete, and update features).
-
-## Request Types
-
-The WFS standard specifies a number of "request types" that a standards-compliant WFS server should support. loaders.gl provides loaders for all WFS request responses:
-
-| **WFS Request** | **Response Loader** | **Description** |
-| --------------- | ------------------- | --------------- |
-
-| Basic WFS
-| `GetCapabilities` | `WFSCapabilitiesLoader` | Returns parameters about the WFS (such as map image format and WFS version compatibility) and the available layers (map bounding box, coordinate reference systems, URI of the data and whether the layer is mostly opaque or not) |
-| `DescribeFeatureType` | `WFSFeatureTypeLoader` | if a layer is marked as 'queryable' then you can request data about a coordinate of the map image. |
-| `GetFeature` | `WFSFeatureLoader` | returns a map image. Parameters include: width and height of the map, coordinate reference system, rendering style, image format |
-| Transaction WFS
-| `Transaction` | Not yet supported | Enables data manipulation (editing) of features via CRUD operations. |
-| `LockFeature` | Not yet supported | A lock request on one or more instances of a feature type elements. |
-
-Note that the response to `GetCapabilities` contains information about which request types are supported
-
-## Streaming feature access
-
-`WFSSourceLoader` accepts GeoJSON and GML `GetFeature` responses. GeoJSON remains the default;
-request GML explicitly when a service does not provide GeoJSON, or use the streaming API for
-large feature collections:
+## Query features
 
 ```ts
-const source = WFSSourceLoader.createDataSource(url, {
+import {createDataSource} from '@loaders.gl/core';
+import {WFSSourceLoader} from '@loaders.gl/wms';
+
+const source = createDataSource(wfsUrl, [WFSSourceLoader], {
+  wfs: {wfsParameters: {version: '2.0.0'}}
+});
+
+const metadata = await source.getMetadata();
+const features = await source.getFeatures({
+  layers: ['workspace:roads'],
+  boundingBox: [[-10, 35], [10, 55]],
+  crs: 'EPSG:4326',
+  format: 'arrow'
+});
+```
+
+## Stream GML
+
+Request GML explicitly when a service does not provide GeoJSON or when a large response should be
+processed incrementally:
+
+```ts
+const source = createDataSource(wfsUrl, [WFSSourceLoader], {
   wfs: {wfsParameters: {outputFormat: 'application/vnd.ogc.gml'}}
 });
 
 for await (const batch of source.getFeaturesInBatches(
-  {boundingBox: [[-10, 35], [10, 55]], layers: ['roads'], crs: 'EPSG:4326'},
+  {
+    layers: ['roads'],
+    boundingBox: [[-10, 35], [10, 55]],
+    crs: 'EPSG:4326',
+    format: 'arrow'
+  },
   {batchSize: 1000}
 )) {
-  // Each batch is an Arrow table by default.
   consume(batch);
 }
 ```
 
-The batch API parses GML feature members incrementally and supports `geojson`, `binary`, and
-Arrow output through the usual `format` parameter. Complete GML responses are converted to the
-same normalized vector-source outputs.
+The parser recognizes GML member structure across arbitrary network chunks and converts each batch
+to the requested vector representation.
 
-### Paging and filtering
+## Paging and filters
 
-The typed `getFeaturesURL` API exposes the standard WFS query controls. WFS 2.0 uses `count` and
-`startIndex`; WFS 1.1 requests automatically translate `count` to `maxFeatures`:
+`getFeaturesURL()` exposes request controls when an application needs explicit pages or a
+server-specific filter:
 
 ```ts
 const requestUrl = source.getFeaturesURL({
@@ -79,10 +94,37 @@ const requestUrl = source.getFeaturesURL({
 });
 ```
 
-`resultType: 'hits'` can be used for servers that support count-only requests. Filter XML is
-passed through as a request parameter; applications should use their server's supported FES
-version and escape or encode user-controlled values before constructing it.
+Filter XML is passed through. Escape user-controlled values and use the FES version supported by
+the target server.
 
-## Features
+## CRS and axis order
 
-A WFS server usually serves the map in a bitmap format, e.g. PNG, GIF, JPEG. In addition, vector graphics can be included, such as points, lines, curves and text, expressed in SVG or WebCGM format. The MIME types of the `GetMap` request can be inspected in the response to the `GetCapabilities` request.
+The source normalizes common CRS spellings and applies the WFS version's axis-order rules to
+bounding boxes. CRS transformation is not silently applied to returned feature coordinates; request
+the desired output CRS from the server.
+
+## deck.gl integration
+
+```ts
+import {SourceLayer} from '@loaders.gl/deck-layers';
+import {WFSSourceLoader} from '@loaders.gl/wms';
+
+const layer = new SourceLayer({
+  id: 'wfs-roads',
+  data: wfsUrl,
+  loaders: [WFSSourceLoader],
+  layers: ['workspace:roads'],
+  pickable: true
+});
+```
+
+## Live example
+
+<div style={{height: '520px'}}>
+  <ClientExample kind="wms" format="WFS" />
+</div>
+
+## References
+
+- [OGC Web Feature Service standard](https://www.ogc.org/standard/wfs/)
+- [GML support](./gml)

--- a/docs/modules/wms/formats/wmc.md
+++ b/docs/modules/wms/formats/wmc.md
@@ -5,3 +5,22 @@ import {WmsDocsTabs} from '@site/src/components/docs/wms-docs-tabs';
 <WmsDocsTabs active="wmc" />
 
 ![ogc-logo](../../../images/logos/ogc-logo-60.png)
+
+Web Map Context is a legacy OGC document format for saving and exchanging a configured set of map
+layers.
+
+## Feature support
+
+| Capability | Support | Recommendation |
+| --- | --- | --- |
+| WMC document parsing | Not implemented | Parse XML with `@loaders.gl/xml` when maintaining legacy applications |
+| WMC document writing | Not implemented | Keep application state in a modern JSON configuration |
+| Referenced WMS layers | Supported separately | Use `WMSSourceLoader` for each referenced service |
+| Modern context exchange | Not implemented | OWS Context is documented separately but also has no dedicated loader |
+
+This page is retained so users can distinguish WMC from WMS. loaders.gl v5 supports the referenced
+WMS services, not the context document itself.
+
+## References
+
+- [OGC Web Map Context specification](https://www.ogc.org/standard/wmc/)

--- a/docs/modules/wms/formats/wms.md
+++ b/docs/modules/wms/formats/wms.md
@@ -12,6 +12,54 @@ import {WmsDocsTabs} from '@site/src/components/docs/wms-docs-tabs';
 
 WMS (Web Map Service) is a protocol for serving geo-referenced **map images** over the internet. WMS was standardized in 1999 by the OGC (Open Geospatial Consortium).
 
+## Feature support
+
+| Capability | Support | API and behavior |
+| --- | --- | --- |
+| WMS 1.3.0 | Supported | Default protocol version with specification-correct axis order |
+| WMS 1.1.1 | Supported | Version-specific `SRS` and longitude/latitude request handling |
+| `GetCapabilities` | Supported | Parsed and normalized service, request, layer, CRS, extent, and dimension metadata |
+| `GetMap` | Supported | `getImage()` and `getMap()` return decoded image data |
+| `GetFeatureInfo` | Supported | Parsed feature information or raw text output |
+| `DescribeLayer` | Supported | Parses layer descriptions when the server advertises the operation |
+| `GetLegendGraphic` | Supported | Returns a decoded legend image |
+| Service exceptions | Supported | OGC XML errors are parsed and reported as request failures |
+| Layer hierarchy and inheritance | Supported | Parent metadata is inherited by renderable child layers |
+| Time, elevation, and custom dimensions | Supported | Standard and vendor parameters are forwarded |
+| CRS normalization and axis order | Supported | Handles the WMS 1.3.0 `EPSG:4326` axis-order change |
+| Server-side styling | Pass through | Named styles and vendor parameters are sent to the service |
+| Authentication | Supported | Standard fetch headers, credentials, proxies, and URL parameters |
+| deck.gl rendering | First class | Pass `WMSSourceLoader` to `SourceLayer` |
+
+## Quick start
+
+```ts
+import {createDataSource} from '@loaders.gl/core';
+import {WMSSourceLoader} from '@loaders.gl/wms';
+
+const source = createDataSource(wmsUrl, [WMSSourceLoader], {
+  wms: {
+    wmsParameters: {
+      version: '1.3.0',
+      layers: ['workspace:land-cover'],
+      transparent: true
+    }
+  }
+});
+
+const metadata = await source.getMetadata();
+const image = await source.getImage({
+  layers: ['workspace:land-cover'],
+  boundingBox: [[-10, 40], [10, 50]],
+  crs: 'CRS:84',
+  width: 1024,
+  height: 512
+});
+```
+
+The generic `ImageSource` API is the shortest path for rendering. Protocol-specific methods remain
+available for feature information, legends, URL generation, and advanced WMS controls.
+
 ## Characteristics
 
 WMS is not a single file format but rather a protocol, specifying a set of requests that the server should implement. Some WMS protocol requests return binary images, and some return metadata formatted as XML text responses.

--- a/docs/modules/wms/formats/wmts.md
+++ b/docs/modules/wms/formats/wmts.md
@@ -1,59 +1,87 @@
 import {WmsDocsTabs} from '@site/src/components/docs/wms-docs-tabs';
 import {ClientExample} from '@site/src/components';
 
-# WMTS - Web Map Tiling Service
+# WMTS - Web Map Tile Service
 
 <WmsDocsTabs active="wmts" />
 
 ![ogc-logo](../../../images/logos/ogc-logo-60.png)
 
-- _[`@loaders.gl/wms`](/docs/modules/wms)_
-- _[Wikipedia article](https://en.wikipedia.org/wiki/Web_Map_Tile_Service)_
+WMTS serves map imagery on discrete, advertised tile matrix sets. `WMTSSourceLoader` implements a
+loaders.gl `TileSource` and negotiates the layer, style, format, and grid from capabilities.
 
-WmTS (Web Map Tile Service) is a standardized protocol for serving pre-rendered or run-time computed georeferenced **map tiles** over the Internet.
+## Feature support
 
-The specification was developed and first published by the Open Geospatial Consortium in 2010.
+| Capability | Support | API and behavior |
+| --- | --- | --- |
+| WMTS 1.0.0 | Supported | Capabilities parsing and KVP `GetTile` requests |
+| `GetCapabilities` | Supported | `WMTSCapabilitiesLoader` parses layers and matrix sets |
+| Normalized tile metadata | Supported | `getMetadata()` exposes extent, CRS, tile size, and tile grid |
+| `GetTile` | Supported | Fetches and decodes advertised image formats |
+| KVP request encoding | Supported | Standard query-parameter operation |
+| RESTful resource templates | Supported | Uses advertised `ResourceURL` templates or `wmts.urlTemplate` |
+| SOAP encoding | Not supported | Outside browser-oriented tile retrieval |
+| Layer selection | Supported | Select by advertised layer identifier |
+| Tile matrix-set selection | Supported | Explicit selection or compatibility-ranked automatic choice |
+| Style and image format | Supported | Select advertised identifiers and MIME types |
+| Non-numeric matrix identifiers | Supported | Zoom levels map to identifiers from capabilities |
+| CRS and axis metadata | Supported | Normalized from the chosen matrix set |
+| `GetFeatureInfo` | Not exposed | Use a direct request when supported by the server |
+| deck.gl rendering | First class | `SourceLayer` requests visible image tiles from the source |
 
-## Characteristics
+## Create a tile source
 
-WMTS is not a single file format but rather a protocol, specifying a number of required and optional requests. Some requests return binary images, and some return metadata formatted as XML (text) responses. The XML responses are fairly detailed and some variations exists, so when working with WMTS it is typically useful to have access to pre-tested parsers for each response type.
+```ts
+import {createDataSource} from '@loaders.gl/core';
+import {WMTSSourceLoader} from '@loaders.gl/wms';
 
-## Request Types
+const source = createDataSource(wmtsUrl, [WMTSSourceLoader], {
+  wmts: {
+    layer: 'MODIS_Terra_CorrectedReflectance_TrueColor',
+    tileMatrixSet: 'GoogleMapsCompatible_Level9',
+    format: 'image/jpeg'
+  }
+});
 
-The WMTS standard specifies a number of "request types" that a standards-compliant WMTS server should support. loaders.gl provides loaders for all WMTS request responses:
+const metadata = await source.getMetadata();
+const image = await source.getTile({z: 3, x: 2, y: 4});
+```
 
-| **WMTS Request**   | **Response Loader**      | **Description**                                                                                                                                                                                                                      |
-| ------------------ | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `GetCapabilities`  | `WMTSCapabilitiesLoader` | Returns parameters about the WMTS (such as map image format and WMTS version compatibility) and the available layers (map bounding box, coordinate reference systems, URI of the data and whether the layer is mostly opaque or not) |
-| `GetTile`          | `ImageBitmapLoader`      | returns a map image. Parameters include: width and height of the map, coordinate reference system, rendering style, image format                                                                                                     |
-| `GetFeatureInfo`   | `WMTSFeatureInfoLoader`  | if a layer is marked as 'queryable' then you can request data about a coordinate of the map image.                                                                                                                                   |
-| `GetLegendGraphic` | `ImageBitmapLoader`      | An image of the map's legend, giving a visual guide to map elements.                                                                                                                                                                 |
+If the service endpoint and capabilities document have different URLs, provide `capabilitiesUrl`
+under `wmts`.
 
-Note that only the `GetCapabilities` and `GetTile` request types are are required to be supported by a WMTS server. The response to `GetCapabilities` contains information about which request types are supported
+## Tile-grid negotiation
 
-## Request Formats
+WMTS matrix sets may use provider-specific identifiers, origins, resolutions, and limits. The source
+keeps the advertised grid rather than assuming a Google-style XYZ pyramid. Applications can select
+a matrix set explicitly; otherwise loaders.gl ranks compatible sets and normalizes the selected
+grid for consumers such as deck.gl.
 
-The WMTS standard defines three different ways to send request parameters to the server.
+## deck.gl integration
 
-| Format          | Constant    | Supported | Description          |
-| --------------- | ----------- | --------- | -------------------- |
-| Key-Value Pairs | `'kvp'`     | Y         | Query parameters     |
-| RESTful         | `'restful'` | N         | URL path             |
-| SOAP            | `'soap'`    | N         | XML encoded payloads |
+```ts
+import {SourceLayer} from '@loaders.gl/deck-layers';
+import {WMTSSourceLoader} from '@loaders.gl/wms';
 
-## Map images
-
-A WMTS server usually serves the map in a bitmap format, e.g. PNG, GIF, JPEG. In addition, vector graphics can be included, such as points, lines, curves and text, expressed in SVG or WebCGM format. The MIME types of the `GetTile` request can be inspected in the response to the `GetCapabilities` request.
-
-## Layers
-
-Unlike WMS, there is no specified way to request a server to combine and return a map tile with information coming from more than one layer in a single retrieval. WMTS clients that want to show a combination of layers must make independent requests for the layer tiles and then combine or overlay the responses. Also, bounding boxes and scales of these WMTS tiles are constrained to a discrete set of values.
+const layer = new SourceLayer({
+  id: 'satellite-imagery',
+  data: wmtsUrl,
+  loaders: [WMTSSourceLoader],
+  sourceOptions: {
+    wmts: {layer: layerId, tileMatrixSet: matrixSetId}
+  }
+});
+```
 
 ## Live example
 
-This example loads NASA GIBS capabilities, selects a WMTS layer, and renders the advertised image
-tiles through deck.gl.
+This example loads NASA GIBS capabilities, selects a layer and matrix set, and renders the
+advertised image tiles through deck.gl.
 
 <div style={{height: '520px'}}>
   <ClientExample kind="wms" format="WMTS" />
 </div>
+
+## References
+
+- [OGC Web Map Tile Service standard](https://www.ogc.org/standard/wmts/)

--- a/docs/modules/wms/services/capability-discovery.md
+++ b/docs/modules/wms/services/capability-discovery.md
@@ -1,8 +1,23 @@
 # Capability graph and service discovery
 
 `discoverServiceGraph` follows service-directory JSON and OGC landing-page links and returns a
-serializable `CapabilityGraph`. Endpoint preferences can rank results after capabilities are
-attached by an application or catalog adapter.
+serializable `CapabilityGraph`. The graph records what was discovered without forcing applications
+through a universal service abstraction.
+
+## Feature support
+
+| Capability | Support | Behavior |
+| --- | --- | --- |
+| OGC landing-page links | Supported | Follows typed and related service links |
+| ArcGIS-style service directories | Supported | Records listed child service endpoints |
+| Relationship graph | Supported | Preserves `service`, `service-desc`, and other link relations |
+| Endpoint capabilities | Supported | Stores type, formats, CRS, tile grid, and quality when available |
+| Ranking | Supported | Preferences include type, format, CRS, latency, and quality |
+| Latency observations | Supported | Optional measurements contribute to ranking |
+| Serialization | Supported | Graph data can be cached outside the runtime |
+| Automatic invalidation | Application controlled | Persisted graphs require an application cache policy |
+| Deep web crawling | Not performed | Discovery follows service relationships, not arbitrary pages |
+| Source creation | Explicit | Select an endpoint, then use its concrete source loader |
 
 ```ts
 import {discoverServiceGraph} from '@loaders.gl/wms';
@@ -15,6 +30,6 @@ const preferred = graph.rank({
 });
 ```
 
-The graph keeps relationships (`service`, `service-desc`, and other link relations), endpoint
-types, optional capability summaries, and measured latency so applications can persist and rank
-service choices without reimplementing discovery logic.
+Each ranked item remains a normal endpoint description. Applications can inspect the reasoning,
+apply business rules, or create a source with the relevant loader. Discovery is therefore useful
+without becoming a mandatory abstraction layer for direct service access.

--- a/docs/modules/wms/services/ogc-api.md
+++ b/docs/modules/wms/services/ogc-api.md
@@ -1,105 +1,171 @@
-# OGC API
+# OGC API services
 
-The `@loaders.gl/wms` module provides a deliberately small compatibility layer for modern OGC
-APIs. It supports the common discovery shape and the two most useful data paths for applications:
-feature collections, tiled resources, coverages, and environmental observations.
+The OGC API family replaces monolithic XML web-service protocols with linked JSON resources and
+focused HTTP APIs. `@loaders.gl/wms` provides deliberately small, interoperable adapters for the
+common read paths. They are useful compatibility clients, not claims of complete conformance to
+every optional OGC API building block.
 
-## Features
+## Family overview
 
-```js
-import {OGCAPIFeaturesSourceLoader} from '@loaders.gl/wms';
+| API | Source loader | Discovery | Data path | Output | Scope |
+| --- | --- | --- | --- | --- | --- |
+| OGC API Features | `OGCAPIFeaturesSourceLoader` | Landing page and collections | Collection items with bbox and CRS | GeoJSON, binary, Arrow | Minimal read client |
+| OGC API Tiles | `OGCAPITilesSourceLoader` | Landing-page tile link | Explicit tile template | Raw tile bytes | Minimal template client |
+| OGC API Coverages | `OGCAPICoveragesSourceLoader` | Landing page and collections | Collection coverage with subsets | JSON object or binary bytes | Minimal read client |
+| OGC API EDR | `OGCAPIEDRSourceLoader` | Landing page and collections | Six spatiotemporal query shapes | JSON object or binary bytes | Focused query client |
+
+All four sources support standard loaders.gl fetch options for headers, credentials, proxies,
+cancellation, and custom transports.
+
+## OGC API Features
+
+| Capability | Support | Behavior |
+| --- | --- | --- |
+| Landing page | Supported | `getLandingPage()` returns linked service metadata |
+| Collections | Supported | `getCollections()` returns advertised collection descriptions |
+| Collection metadata | Supported | Normalizes title, description, CRS, and first spatial extent |
+| Items request | Supported | Requests `/collections/{id}/items` |
+| Bounding box | Supported | Sends the standard `bbox` parameter |
+| Output CRS | Supported | Sends the requested `crs` parameter |
+| GeoJSON | Supported | Validates a FeatureCollection response |
+| Binary and Arrow | Supported | Converts through standard vector-source outputs |
+| Paging links | Application controlled | Returned pages are not traversed automatically |
+| CQL2 and advanced filters | Not normalized | Use service parameters or a custom request |
+| Transactions | Not supported | Read-only source |
+| deck.gl | First class | Implements `VectorSource` and works with `SourceLayer` |
+
+```ts
 import {createDataSource} from '@loaders.gl/core';
+import {OGCAPIFeaturesSourceLoader} from '@loaders.gl/wms';
 
-const source = createDataSource('https://demo.ldproxy.net/daraa', [OGCAPIFeaturesSourceLoader], {
-  'ogc-api': {collectionId: 'VegetationSrf'}
-});
+const source = createDataSource(
+  'https://demo.ldproxy.net/daraa',
+  [OGCAPIFeaturesSourceLoader],
+  {'ogc-api': {collectionId: 'VegetationSrf'}}
+);
 
-const metadata = await source.getMetadata();
-const page = await source.getFeatures({
-  layers: 'VegetationSrf',
-  boundingBox: [
-    [12.4, 41.8],
-    [12.6, 42.0]
-  ]
+const features = await source.getFeatures({
+  layers: ['VegetationSrf'],
+  boundingBox: [[36.0, 32.5], [36.2, 32.7]],
+  format: 'arrow'
 });
 ```
 
-The result is a loaders.gl GeoJSON table. The adapter sends the standard `bbox` and optional `crs`
-query parameters. Paging links and advanced filters can be followed directly using the underlying
-fetch function when needed.
+## OGC API Tiles
 
-## Tiles
+| Capability | Support | Behavior |
+| --- | --- | --- |
+| Landing-page metadata | Supported | Reads title and advertised tileset media type |
+| Explicit tile template | Required | Configure `ogc-api.tileTemplate` |
+| OGC placeholders | Supported | `{tileMatrix}`, `{tileRow}`, `{tileCol}` |
+| XYZ placeholders | Supported | `{z}`, `{y}`, `{x}` |
+| Tile retrieval | Supported | `getTile()` returns the original `ArrayBuffer` |
+| Matrix-set negotiation | Not implemented | Use WMTS for capability-driven grid selection |
+| Tile decoding | Not automatic | Parse bytes with the loader matching the advertised media type |
+| deck.gl | Foundation only | The generic tile contract is present; callers must provide the appropriate decoded tile type |
 
-The tiles adapter expands a server-advertised template. Both OGC API names and conventional XYZ
-placeholders are accepted:
-
-```js
+```ts
+import {createDataSource} from '@loaders.gl/core';
 import {OGCAPITilesSourceLoader} from '@loaders.gl/wms';
 
-const source = OGCAPITilesSourceLoader.createDataSource('https://example.com/api', {
+const source = createDataSource(landingPageUrl, [OGCAPITilesSourceLoader], {
   'ogc-api': {
-    tileTemplate: 'https://example.com/api/tiles/{tileMatrix}/{tileRow}/{tileCol}.png'
+    tileTemplate: 'https://example.com/tiles/{tileMatrix}/{tileRow}/{tileCol}.png'
   }
 });
 
 const tileBytes = await source.getTile({z: 3, x: 4, y: 5});
 ```
 
-This is intentionally a minimal adapter. It does not attempt to implement every OGC API extension,
-server-side filter language, or conformance class.
+## OGC API Coverages
 
-## Coverages
+| Capability | Support | Behavior |
+| --- | --- | --- |
+| Landing page | Supported | `getLandingPage()` |
+| Collections | Supported | `getCollections()` |
+| Collection coverage | Supported | Requests `/collections/{id}/coverage` |
+| Bounding box | Supported | Sends `bbox` |
+| Dimension subsets | Supported | Sends repeated `subset` parameters |
+| Time selection | Supported | Sends `datetime` |
+| Format negotiation | Supported | Sends `f` and an `Accept` header |
+| JSON representations | Supported | Returned as parsed objects |
+| Binary representations | Preserved | Returned as `ArrayBuffer` |
+| Coverage decoding | Application controlled | Pass binary output to GeoTIFF, LERC, or another appropriate loader |
+| Processing and visualization | Not provided | Values are not resampled or colorized implicitly |
 
-The coverage adapter supports collection discovery and the standard collection coverage endpoint.
-It returns JSON coverage representations as objects and binary representations as `ArrayBuffer`
-values, leaving decoding to the appropriate loaders.
-
-```js
+```ts
+import {createDataSource} from '@loaders.gl/core';
 import {OGCAPICoveragesSourceLoader} from '@loaders.gl/wms';
 
-const source = OGCAPICoveragesSourceLoader.createDataSource('https://example.com/ogcapi', {
+const source = createDataSource(landingPageUrl, [OGCAPICoveragesSourceLoader], {
   'ogc-api-coverages': {collectionId: 'temperature'}
 });
+
 const coverage = await source.getCoverage({
   bbox: [-10, 40, 10, 50],
   subset: ['Lat(40,50)'],
+  datetime: '2025-01-01/2025-01-31',
   format: 'application/json'
 });
 ```
 
-## Environmental data
+## OGC API EDR
 
-OGC API EDR provides a small query client for position, area, radius, cube, trajectory, and
-corridor endpoints. The response is returned in the representation selected by the server,
-including GeoJSON and CoverageJSON.
+EDR—Environmental Data Retrieval—queries multidimensional observations by space, time, vertical
+level, and parameter.
 
-```js
+| Capability | Support | Behavior |
+| --- | --- | --- |
+| Landing page and collections | Supported | Common OGC API discovery methods |
+| Position query | Supported | Point observations |
+| Radius query | Supported | Observations around a position |
+| Area query | Supported | Polygon or bounding-area observations |
+| Cube query | Supported | Multidimensional bounding volume |
+| Trajectory query | Supported | Observations along a path |
+| Corridor query | Supported | Observations in a buffered path |
+| Time, vertical, parameter, and CRS controls | Supported | Standard query parameters are generated |
+| GeoJSON and CoverageJSON | Supported | JSON media types are returned as objects |
+| Binary representations | Preserved | Non-JSON responses are returned as `ArrayBuffer` |
+| Domain-specific interpretation | Application controlled | Unit conversion and scientific analysis remain explicit |
+| deck.gl | Not direct | Convert the selected response representation into a visual source first |
+
+```ts
+import {createDataSource} from '@loaders.gl/core';
 import {OGCAPIEDRSourceLoader} from '@loaders.gl/wms';
 
-const source = OGCAPIEDRSourceLoader.createDataSource('https://example.com/edr');
+const source = createDataSource(edrUrl, [OGCAPIEDRSourceLoader], {
+  'ogc-api-edr': {collectionId: 'weather'}
+});
+
 const observations = await source.query({
-  collectionId: 'weather',
   queryType: 'position',
   coords: 'POINT(10 20)',
   datetime: '2025-01-01',
-  parameterName: ['temperature', 'wind']
+  parameterName: ['temperature', 'wind'],
+  format: 'application/geo+json'
 });
 ```
 
-## WCS
+## Choosing OGC API or classic OGC Web Services
 
-`WCSCoverageSource` handles WCS `GetCapabilities` and `GetCoverage` requests. It preserves
-binary coverage responses and routes LERC responses through `@loaders.gl/lerc` when a Core API is
-available.
+| Need | Prefer |
+| --- | --- |
+| Broad server compatibility and mature map rendering | WMS or WMTS |
+| High-volume GML feature streaming | WFS |
+| A straightforward GeoJSON collection endpoint | OGC API Features |
+| Capability-driven tiled imagery with complex matrix sets | WMTS |
+| A known modern tile template | OGC API Tiles |
+| Established coverage servers and LERC decoding | WCS |
+| A modern JSON coverage endpoint | OGC API Coverages |
+| Environmental position, area, trajectory, or corridor queries | OGC API EDR |
 
-```js
-import {WCSCoverageSourceLoader} from '@loaders.gl/wms';
+## Scope boundary
 
-const source = WCSCoverageSourceLoader.createDataSource('https://example.com/wcs', {
-  wcs: {coverageId: 'elevation', format: 'image/tiff'}
-});
-const bytes = await source.getCoverage({bbox: [-10, 40, 10, 50]});
-```
+The adapters intentionally avoid implementing optional conformance classes merely to check boxes.
+Advanced CQL2 filters, transactions, schema extensions, process execution, and provider-specific
+extensions should be added only when real service interoperability requires them. Standard fetch
+APIs remain available for those escape hatches.
 
-For a live feature-service example, see the [ldproxy demo](https://demo.ldproxy.net/daraa). Live
-services are not used by the test suite; repository fixtures remain the source of truth for CI.
+For a live Features endpoint, see the [ldproxy Daraa demonstration](https://demo.ldproxy.net/daraa).
+Live services are not used by CI; deterministic repository fixtures remain the conformance source
+of truth.

--- a/docs/modules/wms/services/universal-service-runtime.md
+++ b/docs/modules/wms/services/universal-service-runtime.md
@@ -1,8 +1,25 @@
 # Universal service runtime
 
-`ServiceRuntime` provides one entry point for the OGC sources implemented by `@loaders.gl/wms`. It detects a source from its
-URL, preserves a cached source instance, and offers shared request retries, cancellation, headers,
-and telemetry.
+`ServiceRuntime` is an optional lifecycle wrapper for the OGC sources in `@loaders.gl/wms`. It
+selects a loader, caches the resulting source, and applies consistent request policy without hiding
+the source's protocol-specific methods.
+
+## Feature support
+
+| Capability | Support | Behavior |
+| --- | --- | --- |
+| Service loader selection | Supported | Uses URL detection or an explicit loader list |
+| Source instance cache | Supported | Repeated URLs reuse the resolved source |
+| Shared headers | Supported | Applied to runtime requests |
+| Retries | Supported | Configurable retry count around transient failures |
+| Cancellation | Supported | Abort signals propagate to requests |
+| Telemetry | Supported | Emits request phase, URL, timing, and error events |
+| Consistent errors | Supported | `ServiceRequestError` carries operation and request context |
+| Custom loaders | Supported | Supply a narrowed or extended loader list |
+| ArcGIS loaders | Injectable | ArcGIS sources live in `@loaders.gl/services`, not the default OGC registry |
+| Persistent HTTP cache | Not provided | Integrate through the fetch layer or application cache |
+
+## Usage
 
 ```ts
 import {ServiceRuntime} from '@loaders.gl/wms';
@@ -13,9 +30,15 @@ const runtime = new ServiceRuntime({
   onTelemetry: event => console.log(event.phase, event.url)
 });
 
-const source = runtime.getSource('https://example.com/arcgis/rest/services/World/MapServer');
+const source = runtime.getSource('https://example.com/geoserver/wms');
 const metadata = await source.getMetadata();
 ```
 
-Applications can supply a custom `loaders` list to control supported protocols while keeping the
-same lifecycle and error behavior.
+The default registry includes WMS, WMTS, WFS, WCS, CSW, OGC API Features, Tiles, Coverages, and
+EDR. Applications can supply `loaders` to reduce bundle scope or inject additional source loaders.
+
+## When to use it
+
+Use `ServiceRuntime` when an application needs a uniform operational policy across many dynamic
+service endpoints. Use `createDataSource()` directly when the endpoint and protocol are known and
+the extra lifecycle policy is unnecessary.

--- a/examples/website/wms/app.tsx
+++ b/examples/website/wms/app.tsx
@@ -15,10 +15,7 @@ import {
   WMTSSourceLoader
 } from '@loaders.gl/wms';
 import {
-  ArcGISFeatureServerSourceLoader,
-  ArcGISImageServerSourceLoader,
-  ArcGISImageTileSourceLoader,
-  ArcGISMapTileSourceLoader
+  SERVICE_LOADERS
 } from '@loaders.gl/services';
 
 import {Map} from 'react-map-gl';
@@ -59,12 +56,9 @@ type AppProps = {
 
 const SOURCE_FACTORIES = [
   WMSSourceLoader,
-  ArcGISImageServerSourceLoader,
-  ArcGISFeatureServerSourceLoader,
   WFSSourceLoader,
   WMTSSourceLoader,
-  ArcGISImageTileSourceLoader,
-  ArcGISMapTileSourceLoader
+  ...SERVICE_LOADERS
 ];
 
 /** Application state */
@@ -168,7 +162,10 @@ export default function App(props: AppProps = {}) {
       return null;
     }
 
-    const isVector = example.type === 'arcgis-feature-server' || example.type === 'wfs';
+    const isVector =
+      example.type === 'arcgis-feature-server' ||
+      example.type === 'arcgis-vector-tile-server' ||
+      example.type === 'wfs';
     const vectorLayerProps = isVector ? getVectorLayerProps(example.layerProps || {}) : {};
 
     return [

--- a/examples/website/wms/examples.ts
+++ b/examples/website/wms/examples.ts
@@ -138,6 +138,23 @@ export const EXAMPLES: Record<string, Record<string, Example>> = {
       }
     }
   },
+  'ArcGIS VectorTileServer': {
+    'Esri World Basemap vector tiles': {
+      type: 'arcgis-vector-tile-server',
+      url: 'https://basemaps.arcgis.com/arcgis/rest/services/World_Basemap_v2/VectorTileServer',
+      description:
+        'ArcGIS-hosted MVT tiles decoded to WGS84 features by loaders.gl and rendered through SourceLayer.',
+      viewState: {longitude: -98, latitude: 39, zoom: 4},
+      layerProps: {
+        pickable: true,
+        stroked: true,
+        filled: true,
+        lineWidthMinPixels: 1,
+        getLineColor: [48, 68, 82, 180],
+        getFillColor: [109, 166, 122, 150]
+      }
+    }
+  },
   WFS: {
     'Redon Reuse Sites': {
       type: 'wfs',

--- a/modules/deck-layers/README.md
+++ b/modules/deck-layers/README.md
@@ -69,6 +69,14 @@ new SourceLayer({
 new SourceLayer({data: tilesetUrl, loaders: [Tiles3DLoader, I3SLoader, SLPKLoader]});
 ```
 
+Service packages expose ordered registries for a single clean integration point:
+
+```ts
+import {SERVICE_LOADERS} from '@loaders.gl/services';
+
+new SourceLayer({data: arcgisUrl, loaders: SERVICE_LOADERS});
+```
+
 Use `sourceOptions.core.type` when a URL is ambiguous. The deprecated `sources` prop is merged with
 source loaders in `loaders` and deduplicated by identity. The singular `loader` prop and
 preconstructed runtime sources remain supported.

--- a/modules/deck-layers/src/tile-2d-source-layer.ts
+++ b/modules/deck-layers/src/tile-2d-source-layer.ts
@@ -41,13 +41,7 @@ export type TileSourceRuntime = TileSource & {
   /** Indicates that vector tiles can be rendered in local coordinates. */
   localCoordinates?: boolean;
   /** MIME type that identifies vector or image payload handling. */
-  mimeType: string | null;
-  /** Mutable source options forwarded to loaders.gl tile fetches. */
-  options: {
-    table?: {
-      coordinates?: string;
-    };
-  };
+  mimeType?: string | null;
   /** Source URL used for stable layer ids. */
   url?: string;
 };
@@ -414,17 +408,12 @@ export class Tile2DSourceLayer<DataT = any> extends CompositeLayer<Tile2DSourceL
     }
 
     if (this.sourceSupportsMVTLayer(resolvedData)) {
-      resolvedData.options.table = resolvedData.options.table || {};
-      resolvedData.options.table.coordinates = 'local';
       return this.renderMVTLayer(resolvedData);
     }
 
     if (!tileset) {
       return null;
     }
-
-    resolvedData.options.table = resolvedData.options.table || {};
-    resolvedData.options.table.coordinates = 'wgs84';
 
     return tileset.tiles.map(tile => {
       let layers = tileLayers.get(tile.id);

--- a/modules/deck-layers/test/services-source-layer.spec.ts
+++ b/modules/deck-layers/test/services-source-layer.spec.ts
@@ -1,0 +1,26 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {resolveVisualSource} from '../src/source-layer-utils';
+import {SERVICE_LOADERS} from '@loaders.gl/services';
+import {describe, expect, test} from 'vitest';
+
+describe('SourceLayer service integration', () => {
+  test.each([
+    ['Roads/FeatureServer/0', 'arcgis-feature-server', 'vector'],
+    ['Imagery/ImageServer', 'arcgis-image-server', 'image'],
+    ['Imagery/ImageServer', 'arcgis-image-server-tiles', 'tile-2d'],
+    ['Basemap/MapServer', 'arcgis-map-server', 'tile-2d'],
+    ['Basemap/VectorTileServer', 'arcgis-vector-tile-server', 'tile-2d']
+  ])('resolves %s as %s to the %s renderer', async (path, sourceType, rendererType) => {
+    const resolvedSource = await resolveVisualSource({
+      data: `https://example.com/arcgis/rest/services/${path}`,
+      loaders: SERVICE_LOADERS,
+      sourceOptions: {core: {type: sourceType}}
+    });
+
+    expect(resolvedSource.sourceLoader?.type).toBe(sourceType);
+    expect(resolvedSource.sourceType).toBe(rendererType);
+  });
+});

--- a/modules/loader-utils/src/lib/sources/tile-source.ts
+++ b/modules/loader-utils/src/lib/sources/tile-source.ts
@@ -15,6 +15,10 @@ export type TileSourceProps = {};
  * - If geospatial, bounding box is expected to be in web mercator coordinates
  */
 export interface TileSource {
+  /** MIME type of decoded tile payloads, when known. */
+  readonly mimeType?: string | null;
+  /** Whether decoded vector coordinates are local to each tile. */
+  readonly localCoordinates?: boolean;
   // extends DataSource {
   getMetadata(): Promise<TileSourceMetadata>;
   /** Flat parameters */

--- a/modules/mvt/src/table-tile-source-loader.ts
+++ b/modules/mvt/src/table-tile-source-loader.ts
@@ -150,7 +150,8 @@ export class TableVectorTileSource
 
   /** MIME type of the tiles emitted by this tile source */
   readonly mimeType = 'application/vnd.mapbox-vector-tile';
-  readonly localCoordinates = true;
+  /** Whether emitted tile geometries use tile-local coordinates. */
+  readonly localCoordinates: boolean;
   readonly tableOptions: Required<Required<TableTileSourceLoaderOptions>['table']>;
 
   /* Schema of the data */
@@ -169,6 +170,7 @@ export class TableVectorTileSource
   constructor(table: GeoJSONTable | Promise<GeoJSONTable>, options: TableTileSourceLoaderOptions) {
     super(table, options, TableTileSourceLoader.defaultOptions);
     this.tableOptions = getRequiredOptions(this.options).table;
+    this.localCoordinates = this.tableOptions.coordinates === 'local';
     this.getTileData = this.getTileData.bind(this);
     this.ready = this.initializeTilesAsync(table);
     this.metadata = this.getMetadata();

--- a/modules/mvt/test/table-tile-source.spec.ts
+++ b/modules/mvt/test/table-tile-source.spec.ts
@@ -25,6 +25,18 @@ const square = [
     id: '42'
   }
 ];
+test('TableTileSourceLoader reports the configured output coordinate mode', () => {
+  const table = makeGeoJSONTable({type: 'Point', coordinates: [0, 0]});
+  const localSource = TableTileSourceLoader.createDataSource(table, {
+    table: {coordinates: 'local'}
+  });
+  const wgs84Source = TableTileSourceLoader.createDataSource(table, {
+    table: {coordinates: 'wgs84'}
+  });
+
+  expect(localSource.localCoordinates).toBe(true);
+  expect(wgs84Source.localCoordinates).toBe(false);
+});
 test('TableTileSourceLoader#getTile#us-states.json', async () => {
   const geojson = await loadGeoJSONTable('us-states.json');
   const source = TableTileSourceLoader.createDataSource(geojson, {table: {coordinates: 'wgs84'}}); // , debug: 2});

--- a/modules/services/README.md
+++ b/modules/services/README.md
@@ -2,37 +2,50 @@
 
 Framework-independent sources for geospatial service APIs.
 
-This package is the home for ArcGIS REST service integrations including FeatureServer, ImageServer, MapServer, and VectorTileServer sources. OGC protocol implementations remain in `@loaders.gl/wms`; STAC and other catalog services are intentionally out of scope for this initial package.
+This package is the home for ArcGIS REST service integrations including FeatureServer, ImageServer,
+MapServer, and VectorTileServer sources. OGC protocol implementations remain in `@loaders.gl/wms`.
 
 ArcGIS sources are owned and exported exclusively by this package. OGC protocol implementations, including WMS, WMTS, WFS, GML, and CSW, are exported by `@loaders.gl/wms`.
 
 ```ts
-import {createDataSource} from '@loaders.gl/core';
-import {
-  ArcGISFeatureServerSourceLoader,
-  ArcGISImageServerSourceLoader,
-  ArcGISMapTileSourceLoader
-} from '@loaders.gl/services';
+import {createDataSource, load} from '@loaders.gl/core';
+import {SERVICE_LOADERS} from '@loaders.gl/services';
 
-const features = await createDataSource(
+const featureSource = createDataSource(
   'https://example.com/arcgis/rest/services/Roads/FeatureServer/0',
-  [ArcGISFeatureServerSourceLoader],
+  SERVICE_LOADERS,
   {}
 );
 
-const imagery = await createDataSource(
+const imageSource = createDataSource(
   'https://example.com/arcgis/rest/services/Elevation/ImageServer',
-  [ArcGISImageServerSourceLoader],
+  SERVICE_LOADERS,
   {}
 );
 
-const mapTiles = await createDataSource(
+const mapTileSource = createDataSource(
   'https://example.com/arcgis/rest/services/World/MapServer',
-  [ArcGISMapTileSourceLoader],
+  SERVICE_LOADERS,
   {}
 );
+
+// `load` accepts the same registry and returns the selected runtime source.
+const source = await load(serviceUrl, SERVICE_LOADERS, {
+  core: {type: 'arcgis-feature-server'}
+});
 ```
 
-The same source adapters provide normalized metadata and the generic vector, image, and tile APIs used by loaders.gl and deck.gl integrations.
+| Service | Generic contract | Output |
+| --- | --- | --- |
+| FeatureServer | `VectorSource` | GeoJSON, binary, or Arrow features |
+| ImageServer | `ImageSource` | Rendered images or decoded LERC rasters |
+| ImageServer tiles | `TileSource` | Image or LERC tiles |
+| MapServer | `TileSource` | Cached or dynamically exported image tiles |
+| VectorTileServer | `VectorTileSource` | Raw MVT or decoded WGS84 features |
 
-For documentation, visit the [loaders.gl website](https://loaders.gl/docs).
+The same source adapters provide normalized metadata and the generic vector, image, and tile APIs
+used by loaders.gl and deck.gl integrations. `SourceLayer` from `@loaders.gl/deck-layers` accepts
+`SERVICE_LOADERS` directly.
+
+See the [complete service guide](https://loaders.gl/docs/modules/services) and the feature table on
+each service page.

--- a/modules/services/package.json
+++ b/modules/services/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@loaders.gl/services",
   "version": "5.0.0-alpha.2",
-  "description": "Framework-independent loaders and sources for ArcGIS services",
+  "description": "Framework-independent loaders and sources for geospatial services",
   "license": "MIT",
   "type": "module",
   "publishConfig": {
@@ -49,6 +49,7 @@
     "@loaders.gl/images": "5.0.0-alpha.2",
     "@loaders.gl/lerc": "5.0.0-alpha.2",
     "@loaders.gl/loader-utils": "5.0.0-alpha.2",
+    "@loaders.gl/mvt": "5.0.0-alpha.2",
     "@loaders.gl/schema": "5.0.0-alpha.2"
   },
   "peerDependencies": {

--- a/modules/services/src/arcgis/arcgis-feature-server-source-loader.ts
+++ b/modules/services/src/arcgis/arcgis-feature-server-source-loader.ts
@@ -17,6 +17,7 @@ import type {
 } from '@loaders.gl/loader-utils';
 import type {SourceLoader} from '@loaders.gl/loader-utils';
 import {DataSource} from '@loaders.gl/loader-utils';
+import {buildArcGISResourceURL} from './arcgis-url-utils';
 
 /** Parameters for ArcGIS FeatureServer query requests. */
 export type ArcGISFeatureServiceQueryOptions = {
@@ -203,7 +204,10 @@ export class ArcGISVectorSource
       queryParameters.spatialRel ||= 'esriSpatialRelIntersects';
     }
 
-    return this.getUrl('query', queryParameters);
+    const layer = Array.isArray(parameters.layers) ? parameters.layers[0] : parameters.layers;
+    const isLayerEndpoint = /\/FeatureServer\/\d+\/?(?:\?|$)/i.test(this.url);
+    const resourcePath = isLayerEndpoint || !layer ? 'query' : `${layer}/query`;
+    return this.getUrl(resourcePath, queryParameters);
   }
 
   /** Builds an ArcGIS FeatureServer URL. */
@@ -212,8 +216,7 @@ export class ArcGISVectorSource
     options: Record<string, unknown>,
     extra?: Record<string, unknown>
   ): string {
-    const baseUrl = path ? `${this.url}/${path}` : this.url;
-    return `${baseUrl}?${encodeArcGISParameters({...options, ...extra})}`;
+    return buildArcGISResourceURL(this.url, path, {...options, ...extra});
   }
 
   /** Checks an ArcGIS FeatureServer response. */
@@ -229,9 +232,23 @@ export class ArcGISVectorSource
 function parseArcGISFeatureServerMetadata(json: any): VectorSourceMetadata {
   const layers: VectorSourceMetadata['layers'] = [];
   for (const layer of json.layers || []) {
+    const extent = layer.extent;
+    const spatialReference = layer.spatialReference || extent?.spatialReference;
     layers.push({
-      // id: layer.id,
-      name: layer.name
+      name: layer.id === undefined ? layer.name : String(layer.id),
+      title: layer.name,
+      crs: getArcGISCoordinateReferenceSystems(spatialReference),
+      boundingBox: normalizeArcGISExtent(extent)
+    });
+  }
+
+  if (!layers.length && (json.id !== undefined || json.name)) {
+    const extent = json.extent;
+    layers.push({
+      name: json.id === undefined ? json.name : String(json.id),
+      title: json.name,
+      crs: getArcGISCoordinateReferenceSystems(json.spatialReference || extent?.spatialReference),
+      boundingBox: normalizeArcGISExtent(extent)
     });
   }
 
@@ -245,6 +262,26 @@ function parseArcGISFeatureServerMetadata(json: any): VectorSourceMetadata {
     // crs: 'EPSG:4326',
     layers
   };
+}
+
+/** Normalizes an ArcGIS spatial reference to a one-element CRS list. */
+function getArcGISCoordinateReferenceSystems(
+  spatialReference: {wkid?: number; latestWkid?: number} | undefined
+): string[] | undefined {
+  const wellKnownIdentifier = spatialReference?.latestWkid || spatialReference?.wkid;
+  return wellKnownIdentifier ? [`EPSG:${wellKnownIdentifier}`] : undefined;
+}
+
+/** Normalizes an ArcGIS extent to the loaders.gl two-corner shape. */
+function normalizeArcGISExtent(
+  extent: {xmin?: number; ymin?: number; xmax?: number; ymax?: number} | undefined
+): [[number, number], [number, number]] | undefined {
+  return extent && [extent.xmin, extent.ymin, extent.xmax, extent.ymax].every(Number.isFinite)
+    ? [
+        [extent.xmin!, extent.ymin!],
+        [extent.xmax!, extent.ymax!]
+      ]
+    : undefined;
 }
 
 /** Normalizes EPSG-prefixed CRS strings to ArcGIS WKID values. */
@@ -289,19 +326,6 @@ function getSchemaTypeFromArcGISFieldType(type: string): DataType {
     default:
       return 'utf8';
   }
-}
-
-/** Encodes ArcGIS REST query parameters. */
-function encodeArcGISParameters(parameters: Record<string, unknown>): string {
-  const searchParameters = new URLSearchParams();
-  for (const [key, value] of Object.entries(parameters)) {
-    if (value === undefined || value === null) {
-      continue;
-    }
-    const encodedValue = Array.isArray(value) ? value.join(',') : String(value);
-    searchParameters.set(key, encodedValue);
-  }
-  return searchParameters.toString();
 }
 
 /** Parses a GeoJSON FeatureCollection into the loaders.gl GeoJSON table shape. */

--- a/modules/services/src/arcgis/arcgis-image-server-source-loader.ts
+++ b/modules/services/src/arcgis/arcgis-image-server-source-loader.ts
@@ -14,6 +14,7 @@ import type {
 import {DataSource, ImageSource} from '@loaders.gl/loader-utils';
 import type {LERCData} from '@loaders.gl/lerc';
 import {LERCLoader} from '@loaders.gl/lerc';
+import {buildArcGISResourceURL} from './arcgis-url-utils';
 
 /** Options for the ArcGIS ImageServer source. */
 export type ArcGISImageSourceLoaderProps = DataSourceOptions & {
@@ -183,8 +184,7 @@ export class ArcGISImageSource
     options: Record<string, unknown>,
     extra?: Record<string, unknown>
   ): string {
-    const baseUrl = path ? `${this.url}/${path}` : this.url;
-    return `${baseUrl}?${encodeArcGISParameters({...options, ...extra})}`;
+    return buildArcGISResourceURL(this.url, path, {...options, ...extra});
   }
 
   /** Checks an ArcGIS ImageServer response. */
@@ -195,24 +195,6 @@ export class ArcGISImageSource
       );
     }
   }
-}
-
-/** Encodes ArcGIS REST query parameters. */
-function encodeArcGISParameters(parameters: Record<string, unknown>): string {
-  const searchParameters = new URLSearchParams();
-  for (const [key, value] of Object.entries(parameters)) {
-    if (value === undefined || value === null) {
-      continue;
-    }
-    const encodedValue = Array.isArray(value) ? value.join(',') : getArcGISParameterValue(value);
-    searchParameters.set(key, encodedValue);
-  }
-  return searchParameters.toString();
-}
-
-/** Converts an ArcGIS REST parameter value to a query string value. */
-function getArcGISParameterValue(value: unknown): string {
-  return typeof value === 'object' ? JSON.stringify(value) : String(value);
 }
 
 /** Normalizes EPSG-prefixed CRS strings to ArcGIS WKID values. */
@@ -231,11 +213,29 @@ function normalizeArcGISSpatialReference(
 /** Normalizes ArcGIS ImageServer metadata to the generic ImageSource metadata shape. */
 function normalizeArcGISImageServerMetadata(metadata: unknown): ImageSourceMetadata {
   const arcgisMetadata = metadata as any;
+  const extent = arcgisMetadata.fullExtent || arcgisMetadata.extent;
+  const spatialReference = arcgisMetadata.spatialReference || extent?.spatialReference;
+  const wellKnownIdentifier = spatialReference?.latestWkid || spatialReference?.wkid;
+  const boundingBox =
+    extent && [extent.xmin, extent.ymin, extent.xmax, extent.ymax].every(Number.isFinite)
+      ? ([
+          [extent.xmin, extent.ymin],
+          [extent.xmax, extent.ymax]
+        ] as [[number, number], [number, number]])
+      : undefined;
+  const name = arcgisMetadata.name || arcgisMetadata.serviceDescription || '';
   return {
-    name: arcgisMetadata.name || arcgisMetadata.serviceDescription || '',
-    title: arcgisMetadata.name || arcgisMetadata.serviceDescription || '',
+    name,
+    title: name,
     abstract: arcgisMetadata.description || arcgisMetadata.serviceDescription || '',
     keywords: Array.isArray(arcgisMetadata.keywords) ? arcgisMetadata.keywords : [],
-    layers: []
+    layers: [
+      {
+        name,
+        title: name,
+        crs: wellKnownIdentifier ? [`EPSG:${wellKnownIdentifier}`] : undefined,
+        boundingBox
+      }
+    ]
   };
 }

--- a/modules/services/src/arcgis/arcgis-url-utils.ts
+++ b/modules/services/src/arcgis/arcgis-url-utils.ts
@@ -1,0 +1,26 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** Builds an ArcGIS REST resource URL while preserving authentication query parameters. */
+export function buildArcGISResourceURL(
+  serviceURL: string,
+  resourcePath: string,
+  parameters: Record<string, unknown>
+): string {
+  const url = new URL(serviceURL);
+  if (resourcePath) {
+    url.pathname = `${url.pathname.replace(/\/$/, '')}/${resourcePath.replace(/^\//, '')}`;
+  }
+  for (const [key, value] of Object.entries(parameters)) {
+    if (value === undefined || value === null) continue;
+    url.searchParams.set(key, encodeArcGISParameter(value));
+  }
+  return url.toString();
+}
+
+/** Converts a generic request value to ArcGIS REST query syntax. */
+function encodeArcGISParameter(value: unknown): string {
+  if (Array.isArray(value)) return value.join(',');
+  return typeof value === 'object' ? JSON.stringify(value) : String(value);
+}

--- a/modules/services/src/arcgis/arcgis-vector-tile-server-source-loader.ts
+++ b/modules/services/src/arcgis/arcgis-vector-tile-server-source-loader.ts
@@ -9,9 +9,12 @@ import type {
   GetTileParameters,
   SourceLoader,
   TileSourceMetadata,
-  TileSource
+  VectorTile,
+  VectorTileSource
 } from '@loaders.gl/loader-utils';
 import {DataSource} from '@loaders.gl/loader-utils';
+import {MVTLoader, type MVTLoaderOptions} from '@loaders.gl/mvt';
+import type {Schema} from '@loaders.gl/schema';
 
 /** ArcGIS vector tile service metadata. */
 export type ArcGISVectorTileServiceMetadata = {
@@ -44,15 +47,19 @@ export type ArcGISVectorTileServiceMetadata = {
 export type ArcGISVectorTileServerSourceLoaderOptions = DataSourceOptions & {
   'arcgis-vector-tile-server'?: {
     /** Optional MVT parser options. */
-    mvt?: Record<string, unknown>;
+    mvt?: MVTLoaderOptions['mvt'];
   };
 };
 
 /** A source for ArcGIS VectorTileServer metadata and PBF tiles. */
 export class ArcGISVectorTileServerSource
   extends DataSource<string, ArcGISVectorTileServerSourceLoaderOptions>
-  implements TileSource
+  implements VectorTileSource
 {
+  /** Decoded tile family consumed by generic tile renderers. */
+  readonly mimeType = 'application/vnd.mapbox-vector-tile';
+  /** ArcGIS tiles are decoded to WGS84 coordinates before rendering. */
+  readonly localCoordinates = false;
   /** Cached service metadata request. */
   private serviceMetadata: Promise<ArcGISVectorTileServiceMetadata> | null = null;
   /** Query parameters supplied with the service URL, such as an access token. */
@@ -117,9 +124,35 @@ export class ArcGISVectorTileServerSource
     return response.arrayBuffer();
   }
 
-  /** Provides raw PBF tiles through the deck.gl source interface. */
-  async getTileData(parameters: GetTileDataParameters): Promise<ArrayBuffer | null> {
-    return this.getTile(parameters.index, parameters.signal);
+  /** Returns the schema advertised by decoded vector tiles. */
+  async getSchema(): Promise<Schema> {
+    return {fields: [], metadata: {}};
+  }
+
+  /** Fetches and decodes one ArcGIS vector tile to geographic coordinates. */
+  async getVectorTile(parameters: GetTileParameters): Promise<VectorTile | null> {
+    const arrayBuffer = await this.getTile(parameters, parameters.signal);
+    if (!arrayBuffer) {
+      return null;
+    }
+    const inheritedOptions = (this.loadOptions as MVTLoaderOptions).mvt;
+    const sourceOptions = this.options['arcgis-vector-tile-server']?.mvt;
+    return (await this.coreApi.parse(arrayBuffer, MVTLoader, {
+      ...this.loadOptions,
+      mvt: {
+        ...inheritedOptions,
+        ...sourceOptions,
+        coordinates: 'wgs84',
+        tileIndex: {x: parameters.x, y: parameters.y, z: parameters.z},
+        layers:
+          normalizeLayers(parameters.layers) || sourceOptions?.layers || inheritedOptions?.layers
+      }
+    })) as VectorTile;
+  }
+
+  /** Provides decoded vector tiles through the deck.gl source interface. */
+  async getTileData(parameters: GetTileDataParameters): Promise<VectorTile | null> {
+    return this.getVectorTile({...parameters.index, signal: parameters.signal});
   }
 
   /** Builds the ArcGIS cached vector tile URL. */
@@ -191,4 +224,10 @@ export const ArcGISVectorTileServerSourceLoader = {
 /** Converts an ArcGIS spatial reference to an EPSG identifier. */
 function getSpatialReference(spatialReference: {wkid?: number; latestWkid?: number}): string {
   return `EPSG:${spatialReference.latestWkid || spatialReference.wkid}`;
+}
+
+/** Normalizes generic tile layer selection for the MVT parser. */
+function normalizeLayers(layers?: string | string[]): string[] | undefined {
+  if (!layers) return undefined;
+  return Array.isArray(layers) ? layers : [layers];
 }

--- a/modules/services/src/index.ts
+++ b/modules/services/src/index.ts
@@ -63,4 +63,4 @@ export type {
 } from './arcgis/arcgis-vector-tile-server-source-loader';
 
 export type {ServiceLoader} from './service-registry';
-export {createServiceSource, getServiceLoader} from './service-registry';
+export {SERVICE_LOADERS, getServiceLoader} from './service-registry';

--- a/modules/services/src/service-registry.ts
+++ b/modules/services/src/service-registry.ts
@@ -7,7 +7,6 @@ import {ArcGISImageServerSourceLoader} from './arcgis/arcgis-image-server-source
 import {ArcGISImageTileSourceLoader} from './arcgis/arcgis-image-tile-source-loader';
 import {ArcGISMapTileSourceLoader} from './arcgis/arcgis-map-tile-source-loader';
 import {ArcGISVectorTileServerSourceLoader} from './arcgis/arcgis-vector-tile-server-source-loader';
-import type {CoreAPI, DataSource, DataSourceOptions} from '@loaders.gl/loader-utils';
 
 /** A source loader currently exposed through the services package. */
 export type ServiceLoader =
@@ -17,8 +16,8 @@ export type ServiceLoader =
   | typeof ArcGISMapTileSourceLoader
   | typeof ArcGISVectorTileServerSourceLoader;
 
-/** The initial service loader registry. */
-const SERVICE_LOADERS: readonly ServiceLoader[] = [
+/** All source loaders owned by `@loaders.gl/services`, in URL-selection order. */
+export const SERVICE_LOADERS: ServiceLoader[] = [
   ArcGISFeatureServerSourceLoader,
   ArcGISImageServerSourceLoader,
   ArcGISImageTileSourceLoader,
@@ -38,27 +37,4 @@ export function getServiceLoader(serviceType: string): ServiceLoader | undefined
     serviceLoader =>
       serviceLoader.id === normalizedServiceType || serviceLoader.type === normalizedServiceType
   );
-}
-
-/**
- * Creates a service source from an explicit capability type or URL detection.
- *
- * The optional type should come from normalized service capabilities. When it is
- * omitted, the small registry tests each known service loader in declaration order.
- * A CoreAPI is required because image and tile sources decode responses through
- * the application's configured loaders.gl core integration.
- */
-export function createServiceSource(
-  url: string,
-  options: DataSourceOptions = {},
-  serviceType: string | undefined,
-  coreApi: CoreAPI
-): DataSource<unknown, DataSourceOptions> {
-  const serviceLoader = serviceType
-    ? getServiceLoader(serviceType)
-    : SERVICE_LOADERS.find(loader => loader.testURL(url));
-  if (!serviceLoader) {
-    throw new Error(`No service loader recognized type or URL: ${serviceType || url}`);
-  }
-  return serviceLoader.createDataSource(url, options, coreApi);
 }

--- a/modules/services/test/arcgis/arcgis-server.spec.ts
+++ b/modules/services/test/arcgis/arcgis-server.spec.ts
@@ -2,6 +2,7 @@ import {expect, test} from 'vitest';
 import {LERCLoader} from '@loaders.gl/lerc';
 import {
   ArcGISFeatureServerSourceLoader,
+  ArcGISVectorSource,
   ArcGISImageServerSourceLoader,
   ArcGISImageTileSource,
   ArcGISMapTileSource
@@ -15,6 +16,36 @@ test('ArcGISImageServerSourceLoader#testURL', () => {
     'identifies ArcGIS ImageServer URLs'
   ).toBeTruthy();
 });
+test('ArcGIS feature requests preserve tokens and select root-service layers', () => {
+  const source = new ArcGISVectorSource(
+    'https://example.com/arcgis/rest/services/Roads/FeatureServer?token=abc',
+    {}
+  );
+  const url = new URL(
+    source.getFeaturesURL({
+      layers: '3',
+      boundingBox: [
+        [-10, -5],
+        [10, 5]
+      ]
+    })
+  );
+  expect(url.pathname).toBe('/arcgis/rest/services/Roads/FeatureServer/3/query');
+  expect(url.searchParams.get('token')).toBe('abc');
+  expect(url.searchParams.get('geometry')).toBe('-10,-5,10,5');
+});
+
+test('ArcGIS ImageServer requests preserve authentication parameters', () => {
+  const source = ArcGISImageServerSourceLoader.createDataSource(
+    `${IMAGE_SERVER_URL}?token=abc`,
+    {}
+  );
+  const url = new URL(source.exportImageURL({bbox: [1, 2, 3, 4], width: 32, height: 16}));
+  expect(url.pathname).toBe('/arcgis/rest/services/Imagery/ImageServer/exportImage');
+  expect(url.searchParams.get('token')).toBe('abc');
+  expect(url.searchParams.get('size')).toBe('32,16');
+});
+
 test('ArcGISMapTileSource#getTileURL preserves endpoint parameters', () => {
   const source = new ArcGISMapTileSource('https://example.com/MapServer?token=abc');
   const url = new URL(source.getTileURL({x: 3, y: 4, z: 5}));
@@ -355,7 +386,7 @@ test('ArcGISVectorSource#getMetadata and getSchema', async () => {
   const metadata = await source.getMetadata({formatSpecificMetadata: true});
   expect(metadata.name).toBe('Roads');
   expect(metadata.abstract).toBe('Road centerlines');
-  expect(metadata.layers).toEqual([{name: 'Road centerlines'}]);
+  expect(metadata.layers).toEqual([{name: '0', title: 'Road centerlines'}]);
   expect(
     metadata.formatSpecificMetadata,
     'preserves format-specific metadata when requested'

--- a/modules/services/test/arcgis/arcgis-vector-tile-server-source.spec.ts
+++ b/modules/services/test/arcgis/arcgis-vector-tile-server-source.spec.ts
@@ -65,3 +65,30 @@ test('ArcGISVectorTileServerSource fetches raw PBF tiles', async () => {
   const result = await source.getTile({z: 2, x: 4, y: 5}, new AbortController().signal);
   expect(new Uint8Array(result!)).toEqual(tileBytes);
 });
+
+test('ArcGISVectorTileServerSource decodes deck.gl tile data to WGS84', async () => {
+  const parseCalls: Array<{options: any}> = [];
+  const decodedTile = {shape: 'geojson-table', type: 'FeatureCollection', features: []};
+  const source = ArcGISVectorTileServerSourceLoader.createDataSource(
+    VECTOR_TILE_SERVER_URL,
+    {'arcgis-vector-tile-server': {mvt: {shape: 'geojson-table'}}},
+    {
+      parse: async (_data: unknown, _loader: unknown, options: unknown) => {
+        parseCalls.push({options});
+        return decodedTile;
+      }
+    } as never
+  );
+  source.fetch = async () => new Response(new Uint8Array([1, 2, 3]));
+
+  await expect(
+    source.getTileData({index: {z: 2, x: 4, y: 5}, signal: new AbortController().signal})
+  ).resolves.toBe(decodedTile);
+  expect(source.mimeType).toBe('application/vnd.mapbox-vector-tile');
+  expect(source.localCoordinates).toBe(false);
+  expect(parseCalls[0].options.mvt).toMatchObject({
+    shape: 'geojson-table',
+    coordinates: 'wgs84',
+    tileIndex: {z: 2, x: 4, y: 5}
+  });
+});

--- a/modules/services/test/services-module.spec.ts
+++ b/modules/services/test/services-module.spec.ts
@@ -4,12 +4,13 @@ import {
   ArcGISImageTileSourceLoader,
   ArcGISMapTileSourceLoader,
   ArcGISVectorTileServerSourceLoader,
-  createServiceSource,
+  ArcGISVectorSource,
+  SERVICE_LOADERS,
   discoverArcGISCapabilities,
   getServiceLoader,
   selectArcGISService
 } from '../src/index';
-import {coreApi} from '@loaders.gl/core';
+import {load} from '@loaders.gl/core';
 import {getArcGISServices} from '../src/arcgis/arcgis-server';
 import * as bundledServices from '../src/bundled';
 import * as unbundledServices from '../src/unbundled';
@@ -38,26 +39,24 @@ describe('@loaders.gl/services', () => {
     expect(getServiceLoader('unknown-service')).toBeUndefined();
   });
 
-  test('creates a source from normalized capability type or URL', () => {
-    expect(
-      createServiceSource(
-        'https://example.com/arcgis/rest/services/Basemap/VectorTileServer',
-        {},
-        'arcgis-vector-tile-server',
-        coreApi
-      )
-    ).toBeInstanceOf(Object);
-    expect(
-      createServiceSource(
-        'https://example.com/arcgis/rest/services/Roads/FeatureServer/0',
-        {},
-        undefined,
-        coreApi
-      )
-    ).toBeInstanceOf(Object);
-    expect(() =>
-      createServiceSource('https://example.com/service', {}, 'unknown', coreApi)
-    ).toThrow('No service loader recognized type or URL');
+  test('exports one registry for core and deck.gl integration', () => {
+    expect(SERVICE_LOADERS).toEqual([
+      ArcGISFeatureServerSourceLoader,
+      ArcGISImageServerSourceLoader,
+      ArcGISImageTileSourceLoader,
+      ArcGISMapTileSourceLoader,
+      ArcGISVectorTileServerSourceLoader
+    ]);
+  });
+
+  test('passes the service registry directly to load', async () => {
+    const source = await load(
+      'https://example.com/arcgis/rest/services/Roads/FeatureServer/0',
+      SERVICE_LOADERS,
+      {core: {type: 'arcgis-feature-server'}}
+    );
+
+    expect(source).toBeInstanceOf(ArcGISVectorSource);
   });
 
   test('keeps the package entrypoints wired to the public exports', () => {

--- a/modules/services/tsconfig.json
+++ b/modules/services/tsconfig.json
@@ -12,6 +12,7 @@
     {"path": "../images"},
     {"path": "../lerc"},
     {"path": "../loader-utils"},
+    {"path": "../mvt"},
     {"path": "../schema"}
   ]
 }

--- a/modules/wms/README.md
+++ b/modules/wms/README.md
@@ -1,27 +1,42 @@
 # @loaders.gl/wms
 
-[loaders.gl](https://loaders.gl/docs) is a collection of framework-independent 3D and geospatial parsers and encoders.
+Framework-independent sources and response loaders for OGC geospatial services.
 
-This module contains loaders for the WMS format.
+| Service or format | Source or loader | Primary output |
+| --- | --- | --- |
+| WMS | `WMSSourceLoader` | Rendered map images |
+| WMTS | `WMTSSourceLoader` | Capability-driven image tiles |
+| WFS | `WFSSourceLoader` | GeoJSON, binary, Arrow, or streaming GML features |
+| WCS | `WCSCoverageSourceLoader` | Binary coverages or decoded LERC |
+| CSW | `CSWSourceLoader` | Catalog records and referenced services |
+| GML | `GMLLoader` | GeoJSON feature collections and streaming batches |
+| OGC API Features | `OGCAPIFeaturesSourceLoader` | GeoJSON, binary, or Arrow features |
+| OGC API Tiles | `OGCAPITilesSourceLoader` | Raw tile bytes from a template |
+| OGC API Coverages | `OGCAPICoveragesSourceLoader` | JSON or binary coverages |
+| OGC API EDR | `OGCAPIEDRSourceLoader` | Environmental observation responses |
 
-For documentation please visit the [website](https://loaders.gl).
-
-## WMTS tile sources
-
-WMTS services are available through the shared `TileSource` API:
+Create services through the standard loaders.gl source API:
 
 ```ts
-import {WMTSImageTileSource} from '@loaders.gl/wms';
+import {createDataSource} from '@loaders.gl/core';
+import {WMTSSourceLoader} from '@loaders.gl/wms';
 
-const wmts = new WMTSImageTileSource('https://example.com/wmts', {
+const source = createDataSource('https://example.com/wmts', [WMTSSourceLoader], {
   wmts: {
     layer: 'basemap',
-    tileMatrixSet: 'GoogleMapsCompatible',
-    urlTemplate: 'https://example.com/wmts/{TileMatrix}/{TileRow}/{TileCol}.png'
+    tileMatrixSet: 'GoogleMapsCompatible'
   }
 });
 
+const metadata = await source.getMetadata();
+const image = await source.getTile({z: 3, x: 4, y: 2});
 ```
 
-The source provides `getTile`, `getTileData`, and `getTileURL`, and supports REST templates and KVP
-`GetTile` requests. ArcGIS tile sources are provided by `@loaders.gl/services`.
+WMS, WMTS, WFS, and OGC API Features implement visual source contracts understood by
+`@loaders.gl/deck-layers`. Analytical coverage and observation outputs remain explicit data until an
+application chooses a visual representation.
+
+ArcGIS REST source loaders are provided by `@loaders.gl/services`.
+
+See the [complete OGC service guide](https://loaders.gl/docs/modules/wms) and the feature table on
+each service page.

--- a/modules/wms/src/ogc-api-edr-source-loader.ts
+++ b/modules/wms/src/ogc-api-edr-source-loader.ts
@@ -112,7 +112,10 @@ export const OGCAPIEDRSourceLoader = {
   fromBlob: false,
   options: {'ogc-api-edr': {}},
   defaultOptions: {'ogc-api-edr': {}},
-  testURL: (url: string): boolean => /(?:\/edr(?:\/|$)|ogc[/-]?api[/-]?edr)/i.test(url),
+  testURL: (url: string): boolean =>
+    /(?:\/edr(?:\/|$)|ogc[/-]?api[/-]?edr|\/collections\/[^/]+\/(?:position|radius|area|cube|trajectory|corridor|locations)(?:\/|$))/i.test(
+      url
+    ),
   createDataSource: (url: string, options: OGCAPIEDRSourceOptions = {}, coreApi?: CoreAPI) =>
     new OGCAPIEDRSource(url, options, coreApi)
 } as const satisfies SourceLoader<OGCAPIEDRSource>;

--- a/modules/wms/src/service-runtime.ts
+++ b/modules/wms/src/service-runtime.ts
@@ -9,6 +9,7 @@ import {WMTSSourceLoader} from './wmts-source-loader';
 import {WFSSourceLoader} from './wfs-source-loader';
 import {OGCAPIEDRSourceLoader} from './ogc-api-edr-source-loader';
 import {OGCAPICoveragesSourceLoader} from './ogc-api-coverages-source-loader';
+import {OGCAPIFeaturesSourceLoader, OGCAPITilesSourceLoader} from './ogc-api-source-loader';
 import {WCSCoverageSourceLoader} from './wcs-source-loader';
 
 /** A source loader that can be selected by the universal service runtime. */
@@ -74,6 +75,8 @@ export const DEFAULT_SERVICE_LOADERS: readonly ServiceSourceLoader[] = [
   WMSSourceLoader,
   WFSSourceLoader,
   WCSCoverageSourceLoader,
+  OGCAPIFeaturesSourceLoader,
+  OGCAPITilesSourceLoader,
   OGCAPICoveragesSourceLoader,
   OGCAPIEDRSourceLoader,
   CSWSourceLoader

--- a/modules/wms/src/service-runtime.ts
+++ b/modules/wms/src/service-runtime.ts
@@ -75,10 +75,10 @@ export const DEFAULT_SERVICE_LOADERS: readonly ServiceSourceLoader[] = [
   WMSSourceLoader,
   WFSSourceLoader,
   WCSCoverageSourceLoader,
-  OGCAPIFeaturesSourceLoader,
   OGCAPITilesSourceLoader,
   OGCAPICoveragesSourceLoader,
   OGCAPIEDRSourceLoader,
+  OGCAPIFeaturesSourceLoader,
   CSWSourceLoader
 ];
 

--- a/modules/wms/test/service-runtime.spec.ts
+++ b/modules/wms/test/service-runtime.spec.ts
@@ -2,6 +2,10 @@ import {afterEach, describe, expect, test, vi} from 'vitest';
 import {
   CapabilityGraph,
   DEFAULT_SERVICE_LOADERS,
+  OGCAPICoveragesSource,
+  OGCAPIEDRSource,
+  OGCAPIFeaturesSource,
+  OGCAPITilesSource,
   ServiceRequestError,
   ServiceRuntime,
   discoverServiceGraph
@@ -16,12 +20,22 @@ describe('ServiceRuntime', () => {
       'wms',
       'wfs',
       'wcs-coverage',
-      'ogc-api-features',
       'ogc-api-tiles',
       'ogc-api-coverages',
       'ogc-api-edr',
+      'ogc-api-features',
       'csw'
     ]);
+  });
+
+  test.each([
+    ['https://example.com/collections/world/tiles', OGCAPITilesSource],
+    ['https://example.com/collections/temperature/coverage', OGCAPICoveragesSource],
+    ['https://example.com/collections/weather/position', OGCAPIEDRSource],
+    ['https://example.com/collections/roads/items', OGCAPIFeaturesSource]
+  ])('selects the specific OGC API source for %s', (url, Source) => {
+    const runtime = new ServiceRuntime();
+    expect(runtime.getSource(url)).toBeInstanceOf(Source);
   });
 
   test('retries transient responses and emits lifecycle telemetry', async () => {

--- a/modules/wms/test/service-runtime.spec.ts
+++ b/modules/wms/test/service-runtime.spec.ts
@@ -1,6 +1,7 @@
 import {afterEach, describe, expect, test, vi} from 'vitest';
 import {
   CapabilityGraph,
+  DEFAULT_SERVICE_LOADERS,
   ServiceRequestError,
   ServiceRuntime,
   discoverServiceGraph
@@ -9,6 +10,20 @@ import {
 afterEach(() => vi.unstubAllGlobals());
 
 describe('ServiceRuntime', () => {
+  test('registers every implemented OGC service source family', () => {
+    expect(DEFAULT_SERVICE_LOADERS.map(loader => loader.type)).toEqual([
+      'wmts',
+      'wms',
+      'wfs',
+      'wcs-coverage',
+      'ogc-api-features',
+      'ogc-api-tiles',
+      'ogc-api-coverages',
+      'ogc-api-edr',
+      'csw'
+    ]);
+  });
+
   test('retries transient responses and emits lifecycle telemetry', async () => {
     const telemetry: string[] = [];
     let attempts = 0;

--- a/website/src/components/docs/format-logo-gallery.tsx
+++ b/website/src/components/docs/format-logo-gallery.tsx
@@ -65,6 +65,7 @@ const FORMAT_METADATA: ReadonlyArray<FormatMetadata> = [
   {slug: 'mlt', label: 'MapLibre Tile', logo: 'format-logo.svg', tags: ['geospatial']},
   {slug: 'mvt', label: 'MVT', logo: 'format-logo.svg', tags: ['geospatial']},
   {slug: 'obj', label: 'OBJ', logo: 'format-logo.svg', tags: ['meshes']},
+  {slug: 'ogc-api', label: 'OGC API Services', logo: 'ogc-logo.png', tags: ['geospatial', 'services']},
   {slug: 'ows-context', label: 'OWS Context', logo: 'ogc-logo.png', tags: ['geospatial', 'services']},
   {slug: 'parquet', label: 'Parquet', logo: 'parquet-logo.png', tags: ['tables']},
   {slug: 'pcd', label: 'PCD', logo: 'format-logo.svg', tags: ['pointclouds']},
@@ -87,7 +88,9 @@ const FORMAT_METADATA: ReadonlyArray<FormatMetadata> = [
   {slug: 'wms', label: 'WMS', logo: 'ogc-logo.png', tags: ['geospatial', 'services']},
   {slug: 'wmts', label: 'WMTS', logo: 'ogc-logo.png', tags: ['geospatial', 'services']},
   {slug: 'arcgis-image-server', label: 'ArcGIS Image Server', logo: 'arcgis-logo.svg', tags: ['geospatial', 'services']},
-  {slug: 'arcgis-feature-server', label: 'ArcGIS Feature Server', logo: 'arcgis-logo.svg', tags: ['geospatial', 'services']}
+  {slug: 'arcgis-feature-server', label: 'ArcGIS Feature Server', logo: 'arcgis-logo.svg', tags: ['geospatial', 'services']},
+  {slug: 'arcgis-map-server', label: 'ArcGIS MapServer', logo: 'arcgis-logo.svg', tags: ['geospatial', 'services']},
+  {slug: 'arcgis-vector-tile-server', label: 'ArcGIS VectorTileServer', logo: 'arcgis-logo.svg', tags: ['geospatial', 'services']}
 ];
 
 const Gallery = styled.section`

--- a/website/src/components/docs/wms-docs-tabs.tsx
+++ b/website/src/components/docs/wms-docs-tabs.tsx
@@ -18,6 +18,7 @@ export type WmsDocsTabId =
   | 'arcgis-image-server-example'
   | 'arcgis-feature-server-example'
   | 'arcgis-map-server-example'
+  | 'arcgis-vector-tile-server-example'
   | 'wcs'
   | 'wfs'
   | 'wmc'
@@ -25,7 +26,8 @@ export type WmsDocsTabId =
   | 'wmts'
   | 'arcgis-image-server'
   | 'arcgis-feature-server'
-  | 'arcgis-map-server';
+  | 'arcgis-map-server'
+  | 'arcgis-vector-tile-server';
 
 const WMS_TAB_GROUPS: Record<string, WmsDocsTab[]> = {
   wms: [
@@ -72,6 +74,18 @@ const WMS_TAB_GROUPS: Record<string, WmsDocsTab[]> = {
       href: '/docs/modules/services/arcgis-map-server'
     }
   ],
+  arcgisVectorTileServer: [
+    {
+      id: 'arcgis-vector-tile-server-example',
+      label: 'Try ArcGIS Vector Tiles',
+      href: '/examples/tiles/arcgis-vector-tile-server'
+    },
+    {
+      id: 'arcgis-vector-tile-server',
+      label: 'ArcGIS VectorTileServer',
+      href: '/docs/modules/services/arcgis-vector-tile-server'
+    }
+  ],
   wcs: [{id: 'wcs', label: 'WCS', href: '/docs/modules/wms/formats/wcs'}],
   wmc: [{id: 'wmc', label: 'WMC', href: '/docs/modules/wms/formats/wmc'}],
   wmts: [
@@ -95,6 +109,12 @@ function getWmsTabs(active: WmsDocsTabId): WmsDocsTab[] {
   }
   if (active === 'arcgis-map-server-example' || active === 'arcgis-map-server') {
     return WMS_TAB_GROUPS.arcgisMapServer;
+  }
+  if (
+    active === 'arcgis-vector-tile-server-example' ||
+    active === 'arcgis-vector-tile-server'
+  ) {
+    return WMS_TAB_GROUPS.arcgisVectorTileServer;
   }
   if (active === 'wmts-example' || active === 'wmts') {
     return WMS_TAB_GROUPS.wmts;

--- a/website/src/components/source-loader-graphic.jsx
+++ b/website/src/components/source-loader-graphic.jsx
@@ -10,7 +10,8 @@ const sourceTabs = [
       'PMTilesSourceLoader',
       'MVTSourceLoader',
       'MLTSourceLoader',
-      'TableTileSourceLoader'
+      'TableTileSourceLoader',
+      'ArcGISVectorTileServerSourceLoader'
     ],
     dataSource: 'VectorTileDataSource',
     methods: ['getMetadata()', 'getTile()'],
@@ -22,7 +23,12 @@ const sourceTabs = [
   {
     id: 'image-tile-source',
     label: 'Image Tiles',
-    sourceLoaders: ['PMTilesSourceLoader', 'MVTSourceLoader'],
+    sourceLoaders: [
+      'PMTilesSourceLoader',
+      'WMTSSourceLoader',
+      'ArcGISMapTileSourceLoader',
+      'ArcGISImageTileSourceLoader'
+    ],
     dataSource: 'ImageTileDataSource',
     methods: ['getMetadata()', 'getImageTile()'],
     outputCategory: 'ImageTile',
@@ -104,8 +110,11 @@ const sourceTabs = [
 ];
 
 const sourceTags = {
-  ArcGISFeatureServerSourceLoader: 'Experimental',
-  ArcGISImageServerSourceLoader: 'Experimental',
+  ArcGISFeatureServerSourceLoader: 'Web Service',
+  ArcGISImageServerSourceLoader: 'Web Service',
+  ArcGISImageTileSourceLoader: 'Web Service',
+  ArcGISMapTileSourceLoader: 'Web Service',
+  ArcGISVectorTileServerSourceLoader: 'Web Service',
   COPCSourceLoader: 'Cloud Archive',
   CSWSourceLoader: 'Web Service',
   DuckDBSQLSource: 'Database',
@@ -122,12 +131,16 @@ const sourceTags = {
   TableTileSourceLoader: 'Generated',
   Tiles3DSource: 'Tileset',
   WFSSourceLoader: 'Web Service',
-  WMSSourceLoader: 'Web Service'
+  WMSSourceLoader: 'Web Service',
+  WMTSSourceLoader: 'Web Service'
 };
 
 const sourceDocumentationLinks = {
   ArcGISFeatureServerSourceLoader: '/docs/modules/services/arcgis-feature-server',
   ArcGISImageServerSourceLoader: '/docs/modules/services/arcgis-image-server',
+  ArcGISImageTileSourceLoader: '/docs/modules/services/arcgis-image-server#image-tiles',
+  ArcGISMapTileSourceLoader: '/docs/modules/services/arcgis-map-server',
+  ArcGISVectorTileServerSourceLoader: '/docs/modules/services/arcgis-vector-tile-server',
   COPCSourceLoader: '/docs/modules/copc/api-reference/copc-source-loader',
   CSWSourceLoader: '/docs/modules/wms/api-reference/csw-source-loader',
   DuckDBSQLSource: '/docs/modules/sql/api-reference/sql-source',
@@ -143,8 +156,9 @@ const sourceDocumentationLinks = {
   SnowflakeSQLSource: '/docs/modules/sql/api-reference/sql-source',
   TableTileSourceLoader: '/docs/modules/mvt/api-reference/table-tile-source-loader',
   Tiles3DSource: '/docs/modules/tiles/api-reference/tiles-3d-source',
-  WFSSourceLoader: '/docs/modules/wms/api-reference/wfs-source-loader',
-  WMSSourceLoader: '/docs/modules/wms/api-reference/wms-source-loader'
+  WFSSourceLoader: '/docs/modules/wms/formats/wfs',
+  WMSSourceLoader: '/docs/modules/wms/api-reference/wms-source-loader',
+  WMTSSourceLoader: '/docs/modules/wms/formats/wmts'
 };
 
 const loadingManagerDocumentationLinks = {

--- a/website/src/examples-sidebar.js
+++ b/website/src/examples-sidebar.js
@@ -92,7 +92,8 @@ const sidebars = {
       items: [
         'tiles/arcgis-map-server',
         'tiles/arcgis-image-server',
-        'tiles/arcgis-feature-server'
+        'tiles/arcgis-feature-server',
+        'tiles/arcgis-vector-tile-server'
       ]
     },
     {

--- a/website/src/examples/tiles/arcgis-vector-tile-server.mdx
+++ b/website/src/examples/tiles/arcgis-vector-tile-server.mdx
@@ -1,0 +1,13 @@
+---
+title: "ArcGIS VectorTileServer"
+hide_title: true
+---
+
+import {ClientExample} from '../../components';
+import {WmsDocsTabs} from '@site/src/components/docs/wms-docs-tabs';
+
+<WmsDocsTabs active="arcgis-vector-tile-server-example" />
+
+<div style={{height: 'calc(100vh - var(--ifm-navbar-height) - 4rem)'}}>
+  <ClientExample kind="wms" format="ArcGIS VectorTileServer" />
+</div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5763,6 +5763,7 @@ __metadata:
     "@loaders.gl/images": "npm:5.0.0-alpha.2"
     "@loaders.gl/lerc": "npm:5.0.0-alpha.2"
     "@loaders.gl/loader-utils": "npm:5.0.0-alpha.2"
+    "@loaders.gl/mvt": "npm:5.0.0-alpha.2"
     "@loaders.gl/schema": "npm:5.0.0-alpha.2"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0


### PR DESCRIPTION
## Goals

- Complete the loaders.gl v5 geospatial-service foundation with a minimal, coherent public API.
- Make ArcGIS feature, image, raster-tile, map-tile, and vector-tile services work through standard loaders.gl and deck.gl contracts.
- Give users accurate, comprehensive documentation that clearly distinguishes supported, minimal, pass-through, and intentionally unsupported capabilities.

## Changes

### Unified service API

- Add `SERVICE_LOADERS` as the complete ArcGIS source-loader registry.
- Support passing the registry directly to `load`, `createDataSource`, and deck.gl `SourceLayer`.
- Keep concrete source loaders available when an application already knows the endpoint type.
- Include all implemented OGC API Features and Tiles sources in the default OGC service runtime.

### ArcGIS correctness and coverage

- Preserve authentication and other existing query parameters across metadata and data requests.
- Correct FeatureServer root-layer query routing and normalize layer IDs, titles, extents, CRS, and schema metadata.
- Normalize ImageServer metadata and export request URLs.
- Upgrade VectorTileServer to a real `VectorTileSource` with raw PBF access, MVT decoding, WGS84 feature output, tile-grid metadata, and style/sprite discovery.

### deck.gl integration

- Add optional tile MIME type and coordinate-space declarations to the shared tile-source contract.
- Remove deck-layer dependence on mutable provider-private source options.
- Add integration coverage proving that real ArcGIS sources dispatch to vector, image, and tile renderers through generic `SourceLayer` infrastructure.
- Add a live ArcGIS VectorTileServer website example backed by a verified public Esri service.

### Documentation

- Rebuild the ArcGIS and OGC service overviews around concrete source contracts and user workflows.
- Add detailed feature-support tables to every ArcGIS service page and every OGC service/format page.
- Document WMS, WMTS, WFS/GML streaming, WCS/LERC, CSW, OGC API Features, Tiles, Coverages, EDR, capability discovery, runtime policy, authentication, outputs, deck.gl suitability, and design boundaries.
- Add embedded live examples, service-selection guidance, API-reference tables, navigation entries, and source/format gallery coverage.
- Clearly document unsupported WMC and OWS Context behavior instead of implying implementation.

## Validation

- `yarn install`
- `yarn lint fix`
- `yarn build`
- `yarn test-node` — 52 files, 361 tests passed, 6 skipped
- `yarn test-headless` — 505 files passed, 1 skipped; 3,096 tests passed, 40 skipped
- `yarn test-audit` — 606 files, 0 Tape, 0 violations
- `cd website && yarn build` — successful, with only the repository's two pre-existing unrelated broken links
- Verified the live VectorTileServer example metadata and PBF tile endpoints

