### PR TITLE
docs(scan): document format support

### DIFF
--- a/docs/developer-guide/common-scan-architecture.md
+++ b/docs/developer-guide/common-scan-architecture.md
@@ -28,7 +28,8 @@ This is the end-user view of the architecture. The statuses are deliberately con
 | --- | --- | --- | --- |
 | In-memory Arrow / GeoArrow | Supported | `read()` | Portable predicates, projection, limit, expressions, ordering, aggregates, unions, and joins; `query()` also returns a materialized table. |
 | Arrow IPC | Supported | `read()` | Schema discovery, projection, global limit, cancellation, and streaming Arrow batches; predicates are rejected. |
-| Parquet / Iceberg | Supported | `read()` | Projection, predicate and metadata pruning, global limits, cancellation, and streaming Arrow batches. |
+| Parquet | Supported | `read()` | Projection, predicate and metadata pruning, global limits, cancellation, and streaming Arrow batches. |
+| Iceberg | Supported | `scan()` | Snapshot and manifest planning, file pruning, Parquet execution, global limits, cancellation, and streaming Arrow batches. |
 | Delta Lake | Supported | `read()` | Read-only versioned snapshot replay, active-file planning, Parquet filtering, global limits, cancellation, and explain output; tables with deletion vectors are rejected explicitly until decoding is available. |
 | FlatGeobuf | Supported | `read()` | R-tree bounding-box pruning, residual predicates, projection, limits, cancellation, and Arrow feature batches. |
 | CSV | Supported | `read()` | Streaming projection and limit with residual predicates. |
@@ -42,8 +43,10 @@ This is the end-user view of the architecture. The statuses are deliberately con
 | NetCDF | Supported | `getRaster()` | Numeric variable selection, named half-open dimension slices, typed output, cancellation, and validated raster queries. |
 | Lance / Shapefile / MLT / LAS / LAZ / PLY / PCD | Not implemented | — | Their existing loaders or specialized sources do not expose the common scan contract. |
 | DuckDB / Snowflake SQL | Supported | `query()` | Compiles the portable table query to bound SQL; this is a backend rather than a file-format adapter. |
-| MVT / PMTiles / 3D Tiles / I3S | Outside protocol | — | Use tile and tileset source APIs; tile addressing and level-of-detail remain outside `TableQuery`. |
-| WMS / WFS / STAC and other services | Outside protocol | — | Use the service or catalog APIs; they are not normalized into the scan contract. |
+| MVT / PMTiles | Outside protocol; optional table view | `read()` after binding one vector tile | Tile addressing remains specialized. The resolved Arrow feature table supports metadata, residual predicates, projection, relational operators, limits, and cancellation. |
+| WFS / ArcGIS FeatureServer | Outside protocol; optional table view | `read()` after binding one bounded request | Service parameters remain specialized. The resolved Arrow feature table supports the same portable table operations. |
+| 3D Tiles / I3S | Outside protocol | — | Use tileset source APIs; tile traversal and level-of-detail remain outside `TableQuery`. |
+| WMS / STAC and other services | Outside protocol | — | Use the imagery, service, or catalog APIs; they are not normalized into the table scan contract. |
 
 The matrix describes the public experience, not identical physical performance. A residual
 operator is still supported and correct; it simply does not avoid decoding work. Each scan-aware
@@ -226,9 +229,8 @@ const result = engine.query(table, {
 Arrow is the built-in reference backend. The factory is asynchronous so optional backends can be
 loaded later without adding backend-specific imports to application code. Format adapters continue
 to import only the lightweight contracts from `@loaders.gl/loader-utils`; importing a format or
-loading metadata does not require the scan runtime. The proof-of-concept backend registry is
-intentionally internal to this one public package rather than exposing a family of backend
-subpaths.
+loading metadata does not require the scan runtime. The backend registry is intentionally internal
+to this one public package rather than exposing a family of backend subpaths.
 
 The same optional package is also the application-facing home for the source-neutral query state
 and metadata vocabulary:
@@ -703,106 +705,30 @@ The architecture favors small, composable contracts over a speculative universal
 test for every addition is: can two materially different backends execute it with the same visible
 semantics?
 
-## SOTA scan roadmap
+## Support policy
 
-“SOTA scan support” means that a user can open a supported loaders.gl format, discover its queryable
-fields and capabilities, use the same query panel, and receive bounded Arrow/typed results without
-learning a format-specific API. It does not mean that every format gets the same physical plan. The
-winning strategy is to make more formats *scan-compatible* before making the portable language
-larger.
+The support matrix at the top of this page is the authoritative public status. A format is marked
+**Supported** only when its documented common entry point executes today. Accepting an option is
+not sufficient to claim pushdown: adapters report an operator as `residual` when they decode rows,
+features, points, or chunks before evaluating it.
 
-The roadmap is therefore format-support-first. Each tranche must ship three things together:
+Each supported adapter provides:
 
-1. metadata-only discovery (`getQueryMetadata()` and the shared panel);
-2. a correct scan adapter, even when initial filtering is residual; and
-3. capability, explain, and conformance coverage that makes the remaining gaps visible.
+1. metadata discovery through `getQueryMetadata()`;
+2. a working `read()`, `query()`, `scan()`, or `getRaster()` entry point;
+3. capability metadata that distinguishes pushdown from residual execution; and
+4. conformance coverage for ordering, limits, cancellation, and result shape where applicable.
 
-### Tranche sequence
+Formats that use specialized tile, service, imagery, or catalog APIs remain outside the table scan
+protocol unless an explicit adapter first binds the specialized request to an Arrow table. This
+keeps support claims concrete without forcing every data access pattern into one abstraction.
 
-0. **Contract and reference implementation — landed.** Keep the generic predicates, immutable
-   `TableQueryOptions`, point-cloud and raster siblings, canonical planning, late-bound parameters,
-   capability vocabulary, ordered scan tasks, Arrow execution, and lazy DuckDB compilation stable.
-1. **Optional package boundary — implemented in this stack.** Keep query state, metadata contracts,
-   and the reference runtime in `@loaders.gl/scan`, while format adapters retain lightweight
-   `@loaders.gl/loader-utils` dependencies. No UI or GPU code crosses this boundary.
-2. **Panel everywhere — concluded for support signaling.** The shared panel consumes package-level
-   metadata/query types, renders discovered raster overviews, and is exercised by FlatGeobuf,
-   Parquet, Iceberg, CSV, and Arrow examples. It now shows the source's declared execution method
-   and disables Apply with the source-provided reason for metadata-only adapters.
-3. **Existing tabular and vector adapters — concluded.** In-memory Arrow, Arrow IPC, ORC, CSV,
-   NDJSON, GeoPackage, and FlatGeobuf expose common executors. GeoPackage now closes the last
-   residual-execution gap in this set. Shapefile and MLT are explicitly not implemented rather than
-   being left in a planned state. Physical stripe, row-index, packed-index, and byte-range pruning
-   remain performance improvements and do not change the support conclusion.
-4. **Existing cloud and versioned tables — concluded.** Parquet, Iceberg, and Delta Lake read-only
-   snapshots expose common execution. Delta replays versioned transaction logs and plans active
-   Parquet fragments; checkpoint discovery, CDC, deletion-vector decoding, and writes remain
-   separate format features. Lance is explicitly not implemented.
-5. **Point-cloud execution — concluded.** COPC and Potree execute the shared point-cloud query through
-   `scan()`. A common breadth-first hierarchy planner applies bounds, levels, and target spacing;
-   adapters then apply exact bounds, residual predicates, caller-ordered projection, and one global
-   limit while emitting bounded Arrow point batches. LAS/LAZ, PLY, PCD, and splats remain explicitly
-   not implemented rather than partially supported.
-6. **Existing raster adapters — concluded.** GeoTIFF/COG, OME-TIFF, GeoZarr, OME-Zarr, and NetCDF
-   execute validated raster queries through `getRaster()`. NetCDF supports numeric variable reads
-   and named dimension index or half-open range slices with typed output. Terrain and LERC remain
-   explicitly not implemented.
-7. **Tiles and services bridge — feature-table slice landed.** MVT/PMTiles vector tiles and bounded
-   WFS/ArcGIS feature requests can now be bound through opt-in `@loaders.gl/scan` adapters. The
-   physical tile address, layers, bounds, and CRS remain outside `TableQuery`; the resolved Arrow
-   feature table exposes shared metadata, explain, cancellation, residual predicates, projection,
-   relational operators, and limits. 3D Tiles, I3S, WMS imagery, and STAC remain specialized while
-   shared time, level-of-detail, and non-table discovery metadata are still open.
-8. **Portable relational growth — second slice landed.** Arrow and DuckDB now execute the shared
-   ordering, scalar-expression, grouped-aggregate, `UNION ALL`, and equi-join request shapes.
-   Ordered append federation now resolves named `TableScanSource` instances through the existing
-   `DataSourceManager`, reconciles strict or union schemas with explicit column mappings, and
-   enforces source order, one global limit, cancellation, early termination, and batch provenance.
-   Managed multi-source joins remain outside this tranche.
-9. **GPU and acceleration — deferred.** Lower the same plan to luma.gl/WGSL masks or indices, add deferred or
-   materialized compaction, and compare GPU/CPU explain telemetry. Add spatial predicates and nearest
-   neighbor only when indexed CPU, GPU, and remote-source strategies have compatible semantics.
-
-### Format-support scorecard
-
-This repeats the end-user support view beside the implementation roadmap so progress cannot drift
-back into “foundation” or “planned” gray zones. “Supported,” “Metadata only,” “Not implemented,”
-and “Outside protocol” have the exact meanings defined at the top of this page.
-
-| Family and representative sources | Status | Execution | Correct behavior today | Remaining work |
-| --- | --- | --- | --- | --- |
-| In-memory Arrow / GeoArrow | Supported | `read()` | Portable relational execution; materialized `query()` is also available | Optimize vector paths and expand GeoArrow conformance |
-| Arrow IPC | Supported | `read()` | Projection, global limit, cancellation, Arrow batches | Predicate execution |
-| Parquet / Iceberg | Supported | `read()` | Pushdown plus residual filtering and streaming | More pruning and explain detail |
-| Delta Lake | Supported | `read()` | Versioned snapshot replay, active-file planning, Parquet filtering, and explicit deletion-vector rejection | Checkpoints, CDC, and deletion-vector decoding |
-| FlatGeobuf | Supported | `read()` | Bounding-box pushdown and residual table query | More packed-index telemetry |
-| CSV / NDJSON | Supported | `read()` | Streaming projection and limit, residual predicates | Byte-range and record-index pruning |
-| ORC | Supported | `read()` | Materialized residual table query | Stripe and row-index pruning |
-| GeoPackage | Supported | `read()` | Materialized residual feature-table query | SQL and spatial-index pushdown |
-| Shapefile / MLT / Lance | Not implemented | — | No common scan claims | Add adapters only when end-to-end execution is available |
-| COPC / Potree | Supported | `scan()` | Ordered hierarchy selection, exact bounds, residual predicates, projection, global limit, cancellation, and Arrow batches | Finer decoder projection and hierarchy telemetry |
-| LAS / LAZ / PLY / PCD / splats | Not implemented | — | No common scan claims | Decide which formats justify sequential adapters |
-| GeoTIFF / COG / OME-TIFF | Supported | `getRaster()` | Windows, bands/channels, levels, typed output | More chunk telemetry and pushdown |
-| GeoZarr / OME-Zarr | Supported | `getRaster()` | Chunk-aligned windows, channels, levels, slices | More variable and dimension UI |
-| NetCDF | Supported | `getRaster()` | Numeric variables, named dimension index/range slices, typed output, and cancellation | Range reads, chunk pruning, and broader NetCDF variants |
-| Terrain / LERC | Not implemented | — | No common scan claims | Raster adapter design |
-| MVT / PMTiles | Outside protocol; optional table view | `read()` after binding a vector tile | Tile addressing stays specialized; Arrow feature rows use portable residual queries | Cross-tile planning and tile-statistics discovery |
-| 3D Tiles / I3S | Outside protocol | — | Specialized tile APIs | Shared bounds, time, level-of-detail, and explain metadata |
-| WFS / ArcGIS FeatureServer | Outside protocol; optional table view | `read()` after binding a bounded request | Service controls stay specialized; Arrow feature rows use portable residual queries | DescribeFeatureType schema discovery and server-side filter translation |
-| WMS / STAC | Outside protocol | — | Specialized imagery and catalog APIs | Shared time and non-table discovery metadata |
-
-“Pushdown” is a promise about avoiding physical work, not merely accepting an option. Every adapter
-must report `residual` when it decodes rows, features, points, or chunks before evaluating a filter.
-The scorecard changes only when a source gains or loses a working common entry point. Optimization
-tranches update the behavior and remaining-work columns without downgrading correct residual
-execution to an ambiguous intermediate status.
-
-The desired end state is not one monolithic engine. It is a family of specialized planners and
+The architecture is not one monolithic engine. It is a family of specialized planners and
 executors that agree on what a query means.
 
-### Relational first slice
+## Relational execution
 
-The first relational tranche deliberately stays small enough to run without a database ingest. An
+The portable relational layer runs without requiring a database ingest. An
 in-memory Arrow table can evaluate computed numeric columns, stable multi-key ordering (including
 explicit null placement), and `count`, `sum`, `min`, `max`, and `avg` aggregates. DuckDB receives the
 same immutable options through the SQL compiler, with identifiers quoted and arithmetic guarded
@@ -819,10 +745,10 @@ const query = {
 };
 ```
 
-The Arrow executor remains intentionally row-oriented for this proof of concept: it materializes
-only the rows needed by the relational operators and returns a bounded Arrow table. This gives
-format adapters and the GPU executor a conformance target without committing them to the same
-physical implementation. In-memory unions resolve named child tables through an explicit table map;
+The Arrow reference executor is intentionally row-oriented: it materializes only the rows needed by
+the relational operators and returns a bounded Arrow table. This gives format adapters a
+conformance target without committing them to the same physical implementation. In-memory unions
+resolve named child tables through an explicit table map;
 joins expose child fields with a source-qualified name and use SQL inner-join null semantics. SQL
 backends compile the same child relations to `UNION ALL` and qualified `JOIN` statements. The
 following managed append layer adds source registration and streaming resolution without extending

--- a/docs/docs-sidebar.json
+++ b/docs/docs-sidebar.json
@@ -47,7 +47,9 @@
       "modules/mvt/formats/map-style",
       "modules/mlt/formats/mlt",
       "modules/mvt/formats/mvt",
+      "modules/netcdf/formats/netcdf",
       "modules/obj/formats/obj",
+      "modules/orc/formats/orc",
       "modules/wms/formats/ows-context",
       "modules/parquet/formats/parquet",
       "modules/traces/formats/perfetto-trace",
@@ -64,6 +66,7 @@
       "modules/wkt/formats/wkt",
       "modules/wkt/formats/wkt-crs",
       "modules/xml/formats/xml",
+      "modules/zarr/formats/zarr",
       "modules/zip/formats/zip"
     ]
   },
@@ -211,6 +214,8 @@
           "modules/tiles/api-reference/i3s-source",
           "modules/geotiff/api-reference/ometiff-source-loader",
           "modules/zarr/api-reference/ome-zarr-source-loader",
+          "modules/parquet/api-reference/delta-table-source",
+          "modules/parquet/api-reference/iceberg-table-source",
           "modules/parquet/api-reference/parquet-source-loader",
           "modules/pmtiles/api-reference/pmtiles-source-loader",
           "modules/potree/api-reference/potree-source-loader",
@@ -471,6 +476,13 @@
       },
       {
         "type": "category",
+        "label": "@loaders.gl/netcdf",
+        "items": [
+          "modules/netcdf/api-reference/README"
+        ]
+      },
+      {
+        "type": "category",
         "label": "@loaders.gl/mlt",
         "items": [
           "modules/mlt/README"
@@ -485,9 +497,19 @@
       },
       {
         "type": "category",
+        "label": "@loaders.gl/orc",
+        "items": [
+          "modules/orc/README"
+        ]
+      },
+      {
+        "type": "category",
         "label": "@loaders.gl/parquet",
         "items": [
-          "modules/parquet/README"
+          "modules/parquet/README",
+          "modules/parquet/api-reference/parquet-source-loader",
+          "modules/parquet/api-reference/iceberg-table-source",
+          "modules/parquet/api-reference/delta-table-source"
         ]
       },
       {
@@ -527,6 +549,13 @@
           "modules/schema/api-reference/schema",
           "modules/schema/api-reference/table",
           "modules/schema/api-reference/table-batch"
+        ]
+      },
+      {
+        "type": "category",
+        "label": "@loaders.gl/scan",
+        "items": [
+          "modules/scan/README"
         ]
       },
       {

--- a/docs/modules/arrow/formats/arrow.md
+++ b/docs/modules/arrow/formats/arrow.md
@@ -4,6 +4,12 @@ import {ArrowDocsTabs} from '@site/src/components/docs/arrow-docs-tabs';
 
 <ArrowDocsTabs active="overview" />
 
+<p class="badges">
+  <a href="/docs/developer-guide/common-scan-architecture">
+    <img src="https://img.shields.io/badge/Scan-Supported-2f855a.svg?style=flat-square" alt="Scan supported" />
+  </a>
+</p>
+
 Apache Arrow is a language-independent binary columnar memory format for table-like data. It enables efficient sharing between systems and languages with minimal copying.
 
 - _[`@loaders.gl/arrow`](/docs/modules/arrow)_ - loaders.gl implementation
@@ -20,6 +26,25 @@ Arrow stores values by column rather than by row. This layout improves cache loc
 ## Arrow JS
 
 `@loaders.gl/arrow` uses Apache Arrow JS for IPC parsing, writing, and table access. The loaders.gl wrapper adds loader metadata, worker integration, table shape conversion, and utilities for common Arrow table workflows.
+
+## Scan support
+
+The scan badge means this format has a working entry point in the [common scan
+architecture](/docs/developer-guide/common-scan-architecture). Arrow is both a transport format and
+the result representation used by the tabular scan adapters.
+
+| Capability | In-memory Arrow table | Arrow IPC source |
+| --- | --- | --- |
+| Entry point | `query()` or `read()` | `read()` |
+| Schema discovery | Available immediately | Available from IPC metadata |
+| Predicate | Portable predicate execution | Rejected as unsupported |
+| Projection | Supported | Pushdown |
+| Limit | Supported | Global limit across batches |
+| Streaming and cancellation | Materialized result | Streaming Arrow batches; cancellable |
+| Additional relational operators | Expressions, ordering, aggregates, unions, and joins | Not part of the IPC source contract |
+
+Predicate columns may be omitted from the final projection. The predicate is evaluated before
+projection, and the global limit counts only rows that survive filtering.
 
 ## Related Formats
 

--- a/docs/modules/arrow/formats/geoarrow.md
+++ b/docs/modules/arrow/formats/geoarrow.md
@@ -7,6 +7,12 @@ GeoArrow CRS representations, column-specific metadata, and current preservation
 
 <ArrowDocsTabs active="geoarrow" />
 
+<p class="badges">
+  <a href="/docs/developer-guide/common-scan-architecture">
+    <img src="https://img.shields.io/badge/Scan-Supported-2f855a.svg?style=flat-square" alt="Scan supported" />
+  </a>
+</p>
+
 - _[`@loaders.gl/arrow`](/docs/modules/arrow)_ - loaders.gl implementation
 - _[GeoArrow Specification](https://github.com/geoarrow/geoarrow)_
 - _[Apache Arrow](https://arrow.apache.org/)_ - A specification for large in-memory columnar data.
@@ -23,6 +29,21 @@ Aside from geometry, simple features can also have additional standard Arrow col
 Geospatial tabular data where one or more columns contains feature geometries and remaining columns define feature attributes. The GeoArrow specification defines how such vector features (geometries) can be stored in Arrow (and Arrow-compatible) data structures.
 
 Note that GeoArrow is not a separate format from Apache Arrow rather, the GeoArrow specification simply describes additional conventions for metadata and layout of geospatial data. This means that a valid GeoArrow file is always a valid Arrow file. This is done through [Arrow extension type](https://arrow.apache.org/docs/format/Columnar.html#extension-types) definitions that ensure type-level metadata (e.g., CRS) is propagated when used in Arrow implementations.
+
+## Scan support
+
+GeoArrow tables use the same portable table query as ordinary Arrow tables. Geometry extension
+metadata remains attached to the projected fields; scanning does not imply coordinate
+transformation or a spatial index.
+
+| Capability | Support |
+| --- | --- |
+| Schema and geometry-role discovery | Supported |
+| Attribute predicates, projection, and limit | Supported |
+| Expressions, ordering, aggregates, unions, and joins | Supported for in-memory tables |
+| Geometry representation | Preserved when the selected columns retain it |
+| Spatial predicate or spatial-index pushdown | Not provided by the generic Arrow executor |
+| CRS transformation | Not performed |
 
 ## Geometry Types
 

--- a/docs/modules/copc/README.md
+++ b/docs/modules/copc/README.md
@@ -11,6 +11,9 @@ current COPC/LAS projection-record support and vertical/compound CRS roadmap.
   <img src="https://img.shields.io/badge/From-v4.1-blue.svg?style=flat-square" alt="From-v4.1" />
   <img src="https://img.shields.io/badge/source_loader-From_v5.0-blue.svg?style=flat-square" alt="source loader from v5.0" />
   <img src="https://img.shields.io/badge/source_loader-Work--In--Progress-orange.svg?style=flat-square" alt="source loader work in progress" />
+  <a href="/docs/developer-guide/common-scan-architecture">
+    <img src="https://img.shields.io/badge/Scan-Supported-2f855a.svg?style=flat-square" alt="Scan supported" />
+  </a>
 </p>
 
 <CopcDocsTabs active="overview" />

--- a/docs/modules/copc/formats/copc.md
+++ b/docs/modules/copc/formats/copc.md
@@ -4,12 +4,37 @@ import {CopcDocsTabs} from '@site/src/components/docs/copc-docs-tabs';
 
 <CopcDocsTabs active="format" />
 
+<p class="badges">
+  <a href="/docs/developer-guide/common-scan-architecture">
+    <img src="https://img.shields.io/badge/Scan-Supported-2f855a.svg?style=flat-square" alt="Scan supported" />
+  </a>
+</p>
+
 - _[Specification at COPC.io](https://copc.io/)_
 - _[Video Overview](https://www.youtube.com/watch?v=rWkKKZYN86A)_
 
 COPC, short for Cloud Optimized Point Cloud, is a range-readable LAZ 1.4 file whose point data is organized as a clustered octree. A COPC reader can select spatial nodes and fetch only their compressed byte ranges instead of downloading the complete point cloud.
 
 Data organization is modeled after the [EPT data format](https://entwine.io/en/latest/entwine-point-tile.html), but COPC stores the octree as variably chunked LAZ data in one file. The same file can therefore be consumed sequentially by a variable-chunk LAZ reader or spatially by a COPC hierarchy reader.
+
+## Scan support
+
+`COPCSource` exposes point-cloud scan semantics directly. Bounds and level-of-detail select hierarchy
+nodes before LAZ decoding; exact bounds and attribute predicates are then applied to decoded points.
+
+| Capability | Support | Execution |
+| --- | --- | --- |
+| Entry point | `scan()` | Ordered Arrow point batches |
+| Schema, bounds, CRS, and point count | Supported | Header, VLR, and hierarchy metadata |
+| Bounds, minimum/maximum level, target spacing | Supported | Hierarchy pushdown followed by exact point filtering |
+| Attribute predicate | Supported | Residual after point decoding |
+| Projection | Supported | Requested LAZ fields are decoded selectively where possible |
+| Global limit | Supported | Counts points after bounds and predicates across nodes |
+| Cancellation and early return | Supported | Covers hierarchy ranges, node ranges, workers, and decoding |
+| Explainable hierarchy plan | Supported | Selected and pruned nodes remain visible |
+
+Coordinates and query bounds use the source coordinate system unless the documented COPC CRS path
+is configured to transform them. A global limit is never applied independently to each octree node.
 
 ## Feature Matrix
 

--- a/docs/modules/csv/formats/csv.md
+++ b/docs/modules/csv/formats/csv.md
@@ -4,6 +4,12 @@ import {CsvDocsTabs} from '@site/src/components/docs/csv-docs-tabs';
 
 <CsvDocsTabs active="overview" />
 
+<p class="badges">
+  <a href="/docs/developer-guide/common-scan-architecture">
+    <img src="https://img.shields.io/badge/Scan-Supported-2f855a.svg?style=flat-square" alt="Scan supported" />
+  </a>
+</p>
+
 Comma-separated values, and more generally delimiter-separated values, is a common text encoding for tabular data.
 
 - _[`@loaders.gl/csv`](/docs/modules/csv)_
@@ -23,6 +29,24 @@ The common CSV syntax uses commas between fields and line breaks between records
 ## Variants
 
 CSV files often vary in delimiter, quoting, header rows, empty-line handling, comments, character encoding, and type conventions. TSV uses tabs as delimiters, and DSV is the general name for delimiter-separated values with other separators such as semicolons or pipes.
+
+## Scan support
+
+`CSVSource` provides a lightweight sequential scan. It does not ingest the file into a database:
+records are parsed in source order and emitted as bounded Arrow batches.
+
+| Capability | Support | Execution |
+| --- | --- | --- |
+| Entry point | `read()` | Streaming Arrow batches |
+| Schema discovery | Supported | Columns are discovered from the CSV source |
+| Predicate | Supported | Residual, after record parsing |
+| Projection | Supported | Applied while producing result batches |
+| Limit | Supported | One global limit after filtering |
+| Cancellation | Supported | Stops parsing and batch production |
+| Random access or byte-range pruning | Not supported | The current adapter is a linear scan |
+
+For a large CSV, projection reduces the result width and a limit can stop the scan early. A
+predicate is correct but does not avoid parsing preceding records.
 
 ## Geospatial
 

--- a/docs/modules/flatgeobuf/formats/flatgeobuf.md
+++ b/docs/modules/flatgeobuf/formats/flatgeobuf.md
@@ -4,6 +4,12 @@ import {FlatGeobufDocsTabs} from '@site/src/components/docs/flatgeobuf-docs-tabs
 
 <FlatGeobufDocsTabs active="overview" />
 
+<p class="badges">
+  <a href="/docs/developer-guide/common-scan-architecture">
+    <img src="https://img.shields.io/badge/Scan-Supported-2f855a.svg?style=flat-square" alt="Scan supported" />
+  </a>
+</p>
+
 ![flatgeobuf-logo](../images/flatgeobuf-logo.png)
 
 - _[`@loaders.gl/flatgeobuf`](/docs/modules/flatgeobuf)_
@@ -126,15 +132,29 @@ Each column also has a string that can hold arbitrary metadata.
 
 ## Spatial indexing
 
-:::caution
-loaders.gl currently does not support spatial filtering.
-:::
-
 FlatGeobuf files can optionally contain a spatial index. The spatial index is optional to allow the format to be efficiently written as a stream, support appending, and for use cases where spatial filtering is not needed.
 
 The spatial index clusters the data on a [packed Hilbert R-Tree](https://en.wikipedia.org/wiki/Hilbert_R-tree#Packed_Hilbert_R-trees) enabling fast bounding box spatial filtering.
 
 The Hilbert curve imposes a linear ordering on the data rectangles and then traverses the sorted list, assigning each set of C rectangles to a node in the R-tree. The final result is that the set of data rectangles on the same node will be close to each other in the linear order.
+
+## Scan support
+
+`FlatGeobufSource` uses the packed R-tree when a bounds query is supplied and applies the remaining
+portable table query to the selected features.
+
+| Capability | Support | Execution |
+| --- | --- | --- |
+| Entry point | `read()` | Arrow feature batches |
+| Schema and bounds discovery | Supported | Header metadata |
+| Bounding box | Supported | Packed R-tree pushdown when the file contains an index |
+| Attribute predicate | Supported | Residual after feature decoding |
+| Projection and global limit | Supported | Applied to surviving features |
+| Cancellation | Supported | Covers range reads and result production |
+| Explain output | Supported | Distinguishes R-tree pruning from residual work |
+
+Spatial bounds use the source coordinate reference system. The adapter does not reproject query
+bounds.
 
 ### Optimizing Remotely Hosted FlatGeobufs
 

--- a/docs/modules/geopackage/formats/geopackage.md
+++ b/docs/modules/geopackage/formats/geopackage.md
@@ -4,6 +4,32 @@ import {GeoPackageDocsTabs} from '@site/src/components/docs/geopackage-docs-tabs
 
 <GeoPackageDocsTabs active="overview" />
 
+<p class="badges">
+  <a href="/docs/developer-guide/common-scan-architecture">
+    <img src="https://img.shields.io/badge/Scan-Supported-2f855a.svg?style=flat-square" alt="Scan supported" />
+  </a>
+</p>
+
 ![ogc-logo](../../../images/logos/ogc-logo-60.png)
 
 The `@loaders.gl/geopackage` module handles the OGC [GeoPackage](https://www.geopackage.org/) format.
+
+## Scan support
+
+`GeoPackageSource` discovers the feature tables in a package and exposes one selected table as an
+Arrow feature table. The current implementation favors portability and correctness over SQLite
+query pushdown.
+
+| Capability | Support | Execution |
+| --- | --- | --- |
+| Entry point | `read()` | One materialized Arrow batch |
+| Table and schema discovery | Supported | GeoPackage catalog and selected feature table |
+| Geometry role and source bounds | Supported | Exposed through scan metadata |
+| Attribute predicate | Supported | Residual after decoding |
+| Projection and global limit | Supported | Residual |
+| Streaming and cancellation | Not advertised | The selected table is materialized |
+| SQLite or spatial-index pushdown | Not implemented | No pushdown claim is made |
+
+Choose the feature table through the source options before calling `getQueryMetadata()` or
+`read()`. Predicate columns remain available for filtering even when they are absent from the final
+projection.

--- a/docs/modules/geotiff/README.md
+++ b/docs/modules/geotiff/README.md
@@ -9,6 +9,9 @@ CRS discovery, current native-CRS behavior, and the raster-warping roadmap.
 
 <p class="badges">
   <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
+  <a href="/docs/developer-guide/common-scan-architecture">
+    <img src="https://img.shields.io/badge/Scan-Supported-2f855a.svg?style=flat-square" alt="Scan supported" />
+  </a>
 </p>
 
 The `@loaders.gl/geotiff` module provides loader and source support for
@@ -28,8 +31,8 @@ npm install @loaders.gl/core @loaders.gl/geotiff
 
 `GeoTIFFRasterSource` also implements the shared scan metadata contract. Call
 `getQueryMetadata()` to discover raster bands, source bounds, and available overview levels for
-the source-neutral scan query panel. This is metadata discovery only; pixel reads continue to use
-the viewport-oriented `getRaster()` API and preserve GeoTIFF/COG range access.
+the source-neutral scan query panel. Pixel reads use the common raster entry point, `getRaster()`,
+and preserve GeoTIFF/COG range access, overview selection, band selection, and typed output.
 
 | Loader / Source | Description |
 | ---------------- | ----------- |

--- a/docs/modules/geotiff/formats/geotiff.md
+++ b/docs/modules/geotiff/formats/geotiff.md
@@ -4,6 +4,12 @@ import {GeoTiffDocsTabs} from '@site/src/components/docs/geotiff-docs-tabs';
 
 <GeoTiffDocsTabs active="format" />
 
+<p class="badges">
+  <a href="/docs/developer-guide/common-scan-architecture">
+    <img src="https://img.shields.io/badge/Scan-Supported-2f855a.svg?style=flat-square" alt="Scan supported" />
+  </a>
+</p>
+
 ![ogc-logo](../../../images/logos/ogc-logo-60.png)
 
 - _[`@loaders.gl/geotiff`](/docs/modules/geotiff)_
@@ -25,3 +31,24 @@ TIFF or TIF (Tagged Image Format) is an image file format for storing raster gra
 A TIFF file can contain multiple images, with tags pointing to each image.
 
 The latest version is TIFF 6.0 was released on 3 June 1992.
+
+## Scan support
+
+GeoTIFF and Cloud Optimized GeoTIFF participate through the raster side of the [common scan
+architecture](/docs/developer-guide/common-scan-architecture). Raster queries keep their natural
+window, resolution, and band vocabulary rather than pretending pixels are table rows.
+
+| Capability | GeoTIFF / COG | OME-TIFF |
+| --- | --- | --- |
+| Entry point | `getRaster()` | `getRaster()` |
+| Metadata discovery | Bands, dtype, bounds, CRS, overviews | Channels, dtype, dimensions, multiscale levels |
+| Spatial window | Bounds pushdown in the source CRS | Not geospatial |
+| Resolution | Overview/target-size selection | Multiscale level selection |
+| Components | Band selection | Channel selection plus time and z slices |
+| Output | Typed planar or interleaved raster data | Typed image planes |
+| Reprojection | Not performed | Not applicable |
+| Cancellation | Checked by the source, but not advertised as cooperative raster cancellation | Validated query execution |
+
+COG range access is preserved: a bounded request can select the relevant image and byte ranges
+without first downloading the entire file. When a viewport CRS differs from the source CRS, the
+source rejects the request rather than silently returning misregistered pixels.

--- a/docs/modules/json/formats/json.md
+++ b/docs/modules/json/formats/json.md
@@ -4,6 +4,12 @@ import {JsonDocsTabs} from '@site/src/components/docs/json-docs-tabs';
 
 <JsonDocsTabs active="overview" />
 
+<p class="badges">
+  <a href="/docs/developer-guide/common-scan-architecture">
+    <img src="https://img.shields.io/badge/Scan-NDJSON_supported-2f855a.svg?style=flat-square" alt="NDJSON scan supported" />
+  </a>
+</p>
+
 JavaScript Object Notation (JSON) is a text format for structured data. It is commonly used for configuration files, web APIs, tabular records, and nested documents.
 
 - _[`@loaders.gl/json`](/docs/modules/json)_
@@ -25,6 +31,22 @@ JSON objects use name/value pairs, arrays use ordered lists, and strings use dou
 ## Variants
 
 Line-oriented variants such as NDJSON, JSON Lines, and JSON text sequences store one JSON record per line or record separator. loaders.gl handles those formats with `NDJSONLoader`.
+
+## Scan support
+
+The scan badge on this page applies to line-oriented NDJSON/JSONL sources, not arbitrary nested JSON
+documents. `NDJSONSource` parses one record stream into bounded Arrow batches without a database
+ingest step.
+
+| Capability | NDJSON / JSONL | General JSON document |
+| --- | --- | --- |
+| Common entry point | `read()` | Not provided |
+| Schema discovery | Supported | Use the JSON loaders directly |
+| Predicate | Residual | — |
+| Projection | Supported | — |
+| Global limit | Supported | — |
+| Streaming and cancellation | Supported | Depends on the selected JSON loader API |
+| Physical pruning | Linear record scan | — |
 
 ## JSON Encoding
 

--- a/docs/modules/mvt/formats/mvt.md
+++ b/docs/modules/mvt/formats/mvt.md
@@ -4,6 +4,12 @@ import {TileDocsTabs} from '@site/src/components/docs/tile-docs-tabs';
 
 <TileDocsTabs active="mvt" />
 
+<p class="badges">
+  <a href="/docs/modules/scan#vector-table-views">
+    <img src="https://img.shields.io/badge/Scan-Table_view-3178C6.svg?style=flat-square" alt="Optional scan table view" />
+  </a>
+</p>
+
 - _[`@loaders.gl/mvt`](/docs/modules/mvt)_
 - _[Mapbox Vector Tile Specification](https://github.com/mapbox/vector-tile-spec)_
 
@@ -12,6 +18,24 @@ A specification for encoding tiled vector data.
 MVT is a protobuf-encoded format that defines geospatial geometries.
 
 tiles contain layers with features, the features can have geometries and properties.
+
+## Optional scan table view
+
+MVT remains a tile format: z/x/y and layer selection do not become relational query operators. When
+an `MVTSource` is configured for Arrow table output, `VectorTileTableScanSource` can bind one tile
+and expose its decoded features to the portable table executor.
+
+| Capability | Support |
+| --- | --- |
+| Tile address and layer selection | Specialized MVT source parameters |
+| Table metadata | Discovered after the bound tile is decoded |
+| Predicate, projection, expressions, ordering, aggregates, and limit | Residual Arrow execution |
+| Cancellation | Supported while resolving the tile and executing the table query |
+| Cross-tile scan planning | Not provided |
+| Tile-statistics pushdown | Not provided |
+
+The blue badge describes an optional view over one physically selected tile. It is intentionally
+different from a format-native common scan.
 
 ## Metadata
 

--- a/docs/modules/netcdf/api-reference/README.md
+++ b/docs/modules/netcdf/api-reference/README.md
@@ -2,20 +2,43 @@
 
 ![ogc-logo](../../../images/logos/ogc-logo-60.png)
 
+<p class="badges">
+  <a href="/docs/developer-guide/common-scan-architecture">
+    <img src="https://img.shields.io/badge/Scan-Supported-2f855a.svg?style=flat-square" alt="Scan supported" />
+  </a>
+</p>
+
 OGC network Common Data Form (netCDF) standards suite
 
-## Scan metadata
+## Scan support
 
 `NetCDFSource` and `NetCDFSourceLoader` expose NetCDF classic and 64-bit-offset headers through
 the shared scan architecture. `getQueryMetadata()` discovers variable names, portable scalar
-types, variable attributes, dimensions, and file size without decoding data arrays. This makes
-NetCDF files usable by source-neutral query panels today; projection, filtering, limits, and
-chunked slice reads are intentionally reported as unsupported until a data-scan executor is added.
+types, variable attributes, dimensions, and file size without decoding data arrays. `getRaster()`
+then reads selected numeric variables and applies named dimension slices.
+
+| Capability | Support | Execution |
+| --- | --- | --- |
+| Entry point | `getRaster()` | Typed raster data |
+| Header and schema discovery | Supported | Bounded leading range for remote files |
+| Variable selection | Supported | Selected numeric variables |
+| Dimension slices | Supported | Residual after loading the classic file |
+| Slice syntax | Index or half-open `[start, stop)` | Named dimensions |
+| Bounds and level-of-detail | Unsupported | NetCDF dimensions are not assumed to be geospatial |
+| Cancellation | Supported | Request and cooperative slice materialization |
+| Streaming or chunk pruning | Not implemented | Current classic-file execution materializes the source |
 
 ```ts
 import {NetCDFSource} from '@loaders.gl/netcdf/netcdf-source-loader';
 
 const source = new NetCDFSource('weather.nc', {});
 const metadata = await source.getQueryMetadata();
-console.log(metadata.columns, metadata.schema.metadata);
+const raster = await source.getRaster({
+  variables: ['temperature'],
+  slices: {time: 0, latitude: [20, 60], longitude: [40, 100]}
+});
 ```
+
+Multiple selected variables must retain the same shape and numeric type after slicing. A scalar
+dimension selection removes that dimension; a range retains it. The original variable and
+dimension names remain available in the result metadata.

--- a/docs/modules/netcdf/formats/netcdf.md
+++ b/docs/modules/netcdf/formats/netcdf.md
@@ -1,0 +1,42 @@
+# NetCDF
+
+<p class="badges">
+  <a href="/docs/developer-guide/common-scan-architecture">
+    <img src="https://img.shields.io/badge/Scan-Supported-2f855a.svg?style=flat-square" alt="Scan supported" />
+  </a>
+</p>
+
+- _[`@loaders.gl/netcdf`](/docs/modules/netcdf/api-reference)_
+- _[NetCDF documentation](https://docs.unidata.ucar.edu/netcdf-c/current/)_
+
+NetCDF stores named dimensions, variables, attributes, and typed multidimensional arrays. It is
+widely used for weather, climate, ocean, and scientific data where array dimensions carry domain
+meaning such as time, pressure level, latitude, and longitude.
+
+## loaders.gl support
+
+| Format feature | Support |
+| --- | --- |
+| NetCDF classic | Supported |
+| 64-bit-offset files | Supported |
+| Header-only remote discovery | Supported with bounded leading range reads |
+| Numeric variable reads | Supported |
+| Named dimension slicing | Supported |
+| NetCDF-4/HDF5 storage | Not supported by this source |
+| Automatic CF reprojection or coordinate-to-bounds planning | Not provided |
+
+## Scan support
+
+NetCDF uses the raster query vocabulary because variables and dimension slices are a more accurate
+model than relational rows.
+
+| Scan feature | Support |
+| --- | --- |
+| Entry point | `getRaster()` |
+| Metadata | Variables, types, attributes, dimensions, record length, and file size |
+| Variable selection | Pushdown to the selected result variables |
+| Dimension selection | Named index or half-open `[start, stop)` slice, evaluated residually |
+| Bounds and overview level | Unsupported |
+| Output | Typed raster data with original variable/dimension metadata |
+| Cancellation | Supported |
+| Chunk or range pruning during data reads | Not implemented for classic-file execution |

--- a/docs/modules/orc/README.md
+++ b/docs/modules/orc/README.md
@@ -1,0 +1,53 @@
+# @loaders.gl/orc
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v5.0-blue.svg?style=flat-square" alt="From v5.0" />
+  <a href="/docs/developer-guide/common-scan-architecture">
+    <img src="https://img.shields.io/badge/Scan-Supported-2f855a.svg?style=flat-square" alt="Scan supported" />
+  </a>
+</p>
+
+The `@loaders.gl/orc` module reads and writes Apache ORC files. `ORCSourceLoader` adds a portable
+table scan over a URL or `Blob` and returns Arrow data.
+
+## Installation
+
+```bash
+npm install @loaders.gl/core @loaders.gl/orc apache-arrow
+```
+
+## Scan support
+
+The current source is a correct materialized scan. It reads ORC footer metadata for discovery, then
+decodes the complete file before applying the portable query. It does not claim stripe or row-index
+pushdown.
+
+| Capability | Support | Execution |
+| --- | --- | --- |
+| Entry point | `read()` or `query()` | Arrow batch or materialized Arrow table |
+| Schema and row-count discovery | Supported | ORC footer metadata |
+| Predicate | Supported | Residual after decoding |
+| Projection | Supported | Residual |
+| Global limit | Supported | Residual after filtering |
+| Streaming and cooperative cancellation | Not advertised | Complete-file execution |
+| Stripe, row-index, or range pruning | Not implemented | No pushdown claim is made |
+
+```ts
+import {createDataSource} from '@loaders.gl/core';
+import {ORCSourceLoader} from '@loaders.gl/orc';
+import {parseSQLPredicate} from '@loaders.gl/scan';
+
+const source = createDataSource('events.orc', [ORCSourceLoader]);
+const metadata = await source.getQueryMetadata();
+
+for await (const batch of source.read({
+  predicate: parseSQLPredicate("status = 'active'"),
+  columns: ['id', 'status'],
+  limit: 100
+})) {
+  console.log(batch.data);
+}
+```
+
+Use Parquet when physical column and row-group pruning is a hard requirement. ORC remains useful
+when format compatibility matters and materializing the selected file is acceptable.

--- a/docs/modules/orc/formats/orc.md
+++ b/docs/modules/orc/formats/orc.md
@@ -1,0 +1,40 @@
+# Apache ORC
+
+<p class="badges">
+  <a href="/docs/developer-guide/common-scan-architecture">
+    <img src="https://img.shields.io/badge/Scan-Supported-2f855a.svg?style=flat-square" alt="Scan supported" />
+  </a>
+</p>
+
+- _[`@loaders.gl/orc`](/docs/modules/orc)_
+- _[Apache ORC](https://orc.apache.org/)_
+
+Apache ORC is a typed, column-oriented storage format. Files organize rows into stripes and keep a
+schema, encodings, stream locations, and statistics in their footer and stripe metadata.
+
+## Format characteristics
+
+| Characteristic | ORC |
+| --- | --- |
+| Layout | Column-oriented stripes containing encoded streams |
+| Schema | Stored in the file footer |
+| Compression | Per-stream codecs described by the postscript |
+| Selective-reading opportunities | Stripes, row indexes, Bloom filters, and column streams |
+| loaders.gl result | Arrow table data |
+
+## Scan support
+
+`ORCSource` currently provides a materialized common scan. Footer metadata drives discovery, while
+the data path decodes the complete file and applies predicates, projection, and limit residually.
+
+| Scan feature | Support |
+| --- | --- |
+| Entry point | `read()` or `query()` |
+| Schema discovery | Supported |
+| Predicate, projection, and global limit | Supported, residual |
+| Arrow output | Supported |
+| Streaming and cooperative cancellation | Not advertised |
+| Stripe, row-index, Bloom-filter, or range pushdown | Not implemented |
+
+The green badge means the query executes correctly. It does not claim the physical pruning features
+that the ORC format can theoretically support.

--- a/docs/modules/parquet/README.md
+++ b/docs/modules/parquet/README.md
@@ -4,6 +4,9 @@
   <img src="https://img.shields.io/badge/From-v3.1-blue.svg?style=flat-square" alt="From-v3.1" />
   &nbsp;
   <img src="https://img.shields.io/badge/Status-Experimental-orange.svg?style=flat-square" alt="Status: Experimental" />
+  <a href="/docs/developer-guide/common-scan-architecture">
+    <img src="https://img.shields.io/badge/Scan-Supported-2f855a.svg?style=flat-square" alt="Scan supported" />
+  </a>
 </p>
 
 Experimental loader and writer for the Apache Parquet format.

--- a/docs/modules/parquet/api-reference/delta-table-source.md
+++ b/docs/modules/parquet/api-reference/delta-table-source.md
@@ -1,0 +1,60 @@
+# Delta Lake table source
+
+<p class="badges">
+  <a href="/docs/developer-guide/common-scan-architecture">
+    <img src="https://img.shields.io/badge/Scan-Supported-2f855a.svg?style=flat-square" alt="Scan supported" />
+  </a>
+</p>
+
+`DeltaTableSource` is a read-only Delta Lake snapshot adapter. It replays newline-delimited
+transaction-log actions, resolves the active Parquet files, and delegates physical reads to
+`ParquetDatasetSource`.
+
+```ts
+import {DeltaTableSource} from '@loaders.gl/parquet/delta-source';
+
+const source = new DeltaTableSource(
+  'https://data.example.com/events/_delta_log/00000000000000000042.json'
+);
+
+const metadata = await source.getQueryMetadata();
+
+for await (const batch of source.read({
+  columns: ['timestamp', 'event_type'],
+  predicate: {op: '=', args: [{property: 'event_type'}, 'click']},
+  limit: 1000
+})) {
+  consume(batch);
+}
+```
+
+## Scan support
+
+| Capability | Support | Notes |
+| --- | --- | --- |
+| Entry point | `read()`; `scan()` alias | Streaming Arrow batches from active Parquet files |
+| Query metadata | Supported | Schema, capabilities, row count, and byte length when available |
+| Version selection | Supported | Replays JSON commits from version 0 through the selected version |
+| Add/remove actions | Supported | Produces the active file set |
+| Projection, predicate, limit, cancellation | Supported | Delegated to the Parquet dataset executor |
+| Explain/plan | Supported | Active fragments plus delegated Parquet plans |
+| Checkpoint files | Not decoded | Supply a JSON commit log URL |
+| Deletion vectors | Rejected | The source fails explicitly rather than returning deleted rows |
+| Reader protocol above version 1 or reader features | Rejected | Unsupported protocol requirements fail explicitly |
+| Writes, CDC, and catalog discovery | Not provided | Read-only source |
+
+## URL and version behavior
+
+When the input URL names a zero-padded Delta commit, the version is inferred from the filename. Set
+`delta.version` or the per-read `version` option to select another non-negative version. Relative
+Parquet paths are resolved from the table root; `delta.baseUrl` can override that root.
+
+The current implementation fetches and replays each JSON commit needed for the selected version. It
+does not use `_last_checkpoint` or Parquet checkpoint files, so very long transaction histories are
+not an efficient input yet.
+
+## Safety boundaries
+
+Delta features that can change row visibility are never ignored silently. Active files containing
+deletion vectors are rejected, as are protocol declarations the adapter cannot interpret. This
+ensures a successful scan represents the selected snapshot rather than an approximate view.

--- a/docs/modules/parquet/api-reference/iceberg-table-source.md
+++ b/docs/modules/parquet/api-reference/iceberg-table-source.md
@@ -1,5 +1,11 @@
 # Iceberg table source
 
+<p class="badges">
+  <a href="/docs/developer-guide/common-scan-architecture">
+    <img src="https://img.shields.io/badge/Scan-Supported-2f855a.svg?style=flat-square" alt="Scan supported" />
+  </a>
+</p>
+
 `IcebergTableSource` reads an Apache Iceberg table's metadata and manifest files, selects Parquet
 data files, and delegates the actual file reads to `ParquetDatasetSource`.
 
@@ -44,6 +50,21 @@ metadata-only bundle.
 
 The source accepts an explicit metadata JSON URL. It does not perform catalog lookup, refresh a
 catalog pointer, commit snapshots, or write Iceberg metadata.
+
+## Scan behavior at a glance
+
+| Layer | Current behavior |
+| --- | --- |
+| Entry point | `scan()` emits Arrow batches |
+| Snapshot selection | Current snapshot, explicit snapshot id, or named branch/tag |
+| Catalog pruning | Manifest status, partitions, scalar bounds, and optional spatial envelopes |
+| Data-file execution | Selected Parquet files use the shared projection, predicate, range, worker, limit, and cancellation paths |
+| Delete files | Discovered by default; position and equality deletes can be applied explicitly |
+| Ordering | Manifest and data-file order is preserved |
+| Writes and catalog refresh | Not provided |
+
+Iceberg planning selects files; Parquet remains responsible for row groups, pages, byte ranges, and
+exact residual filtering. The badge does not imply write support or a catalog-wide client.
 
 ## What is supported
 

--- a/docs/modules/parquet/formats/geoparquet.md
+++ b/docs/modules/parquet/formats/geoparquet.md
@@ -4,6 +4,12 @@ import {ParquetDocsTabs} from '@site/src/components/docs/parquet-docs-tabs';
 
 <ParquetDocsTabs active="geoparquet" />
 
+<p class="badges">
+  <a href="/docs/developer-guide/common-scan-architecture">
+    <img src="https://img.shields.io/badge/Scan-Supported-2f855a.svg?style=flat-square" alt="Scan supported" />
+  </a>
+</p>
+
 ![parquet-logo](../images/parquet-logo-small.png)
 &emsp;
 ![apache-logo](../../../images/logos/apache-logo.png)

--- a/docs/modules/parquet/formats/parquet.md
+++ b/docs/modules/parquet/formats/parquet.md
@@ -4,6 +4,12 @@ import {ParquetDocsTabs} from '@site/src/components/docs/parquet-docs-tabs';
 
 <ParquetDocsTabs active="overview" />
 
+<p class="badges">
+  <a href="/docs/developer-guide/common-scan-architecture">
+    <img src="https://img.shields.io/badge/Scan-Supported-2f855a.svg?style=flat-square" alt="Scan supported" />
+  </a>
+</p>
+
 ![parquet-logo](../images/parquet-logo-small.png)
 &emsp;
 ![apache-logo](../../../images/logos/apache-logo.png)
@@ -29,6 +35,26 @@ The support tables use these symbols:
 `ParquetLoader` and `ParquetWriter` use the separately maintained `parquet-wasm` implementation;
 their coverage can differ from the TypeScript `ParquetJSLoader`, `ParquetSourceLoader`, and
 `ParquetJSWriter` described in the matrices below.
+
+## Scan support
+
+`ParquetSourceLoader` is the selective scan API. It reads and caches the footer, plans physical
+ranges, emits Arrow batches, and explains which layers rejected work.
+
+| Capability | Support | Execution |
+| --- | --- | --- |
+| Entry point | `read()` | Streaming Arrow batches |
+| Schema and statistics discovery | Supported | Footer metadata |
+| Projection | Supported | Column-chunk pushdown |
+| Predicate | Supported | Row-group/page/statistics/Bloom pruning plus exact residual evaluation |
+| Global limit | Supported | Counts rows after filtering across all batches and files |
+| Cancellation and early return | Supported | Stops pending ranges, decoding, and later files |
+| Multi-file datasets | Supported | Bounded concurrency with catalog-selected fragments |
+| Explain output | Supported | Logical, file, row-group, page, and range decisions |
+
+`IcebergTableSource` and `DeltaTableSource` select active Parquet files before delegating to this
+same executor. Iceberg supports snapshot and manifest planning. Delta supports read-only log replay;
+tables with deletion vectors are rejected until deletion-vector decoding is available.
 
 ## File Layout
 

--- a/docs/modules/pmtiles/formats/pmtiles.mdx
+++ b/docs/modules/pmtiles/formats/pmtiles.mdx
@@ -4,6 +4,12 @@ import {TileDocsTabs} from '@site/src/components/docs/tile-docs-tabs';
 
 <TileDocsTabs active="pmtiles" />
 
+<p class="badges">
+  <a href="/docs/modules/scan#vector-table-views">
+    <img src="https://img.shields.io/badge/Scan-Table_view-3178C6.svg?style=flat-square" alt="Optional scan table view" />
+  </a>
+</p>
+
 - [*`@loaders.gl/pmtiles`*](/docs/modules/pmtiles)
 - [*PMTiles specification*](https://github.com/protomaps/PMTiles)
 - [*PMTiles example*](/examples/tiles/pmtiles).
@@ -15,6 +21,23 @@ PMTiles is commonly used for visualization (e.g. for cartographic basemap vector
 A PMTiles archive replaces a big directory tree of thousands of individual tile files, allowing an entire tileset to be manipulated (uploaded, downloaded, served, analyzed) as a single file.
 
 In addition, there is a range of utilities and libraries for working with PMTiles, such Python packages for reading and writing, and support for various programming languages and tools as well as a number of viewers. And tiling tools such as [tippecanoe](https://github.com/felt/tippecanoe) can now output directly to PMTiles.
+
+## Optional scan table view
+
+For a vector PMTiles archive, the PMTiles source first resolves z/x/y and returns one MVT tile as an
+Arrow table. `VectorTileTableScanSource` can then apply a portable query to those feature rows.
+
+| Capability | Support |
+| --- | --- |
+| Archive directory and tile range lookup | PMTiles source |
+| Tile address and layer selection | Specialized source parameters |
+| Predicate, projection, expressions, ordering, aggregates, and limit | Residual Arrow execution after tile decoding |
+| Cancellation | Supported while resolving the tile and executing the table query |
+| Cross-tile query | Not provided |
+| Raster or terrain tile table view | Not applicable |
+
+The adapter does not scan the archive as one logical table and does not imply server-side or
+directory-level predicate pruning.
 
 ## Tile types
 

--- a/docs/modules/potree/README.md
+++ b/docs/modules/potree/README.md
@@ -8,6 +8,9 @@ point-cloud CRS support matrix and reprojection roadmap.
 <p class="badges">
   <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
   <img src="https://img.shields.io/badge/source_loader-From_v5.0-blue.svg?style=flat-square" alt="source loader from v5.0" />
+  <a href="/docs/developer-guide/common-scan-architecture">
+    <img src="https://img.shields.io/badge/Scan-Supported_versions-2f855a.svg?style=flat-square" alt="Scan supported for compatible Potree versions" />
+  </a>
 </p>
 
 <PotreeDocsTabs active="overview" />
@@ -24,6 +27,24 @@ Support for loading and traversing [potree](http://potree.org/) format point clo
 | 1.7 | ✅ | Supports hierarchy chunk files and nested `octreeDir/r/r*.bin` node payloads. |
 | 1.8 | ✅ | Supports hierarchy chunk files and `LAS`, `LAZ`, or Potree binary point payloads. |
 | 2.x | ❌ | Potree 2.x metadata and octree layouts are not supported. |
+
+## Scan support
+
+For supported Potree versions and layouts, `PotreeNodeSource` exposes the same point-cloud query
+shape as COPC. Unsupported versions publish metadata with a reason and do not claim an executor.
+
+| Capability | Support | Execution |
+| --- | --- | --- |
+| Entry point | `scan()` for compatible sources | Ordered Arrow point batches |
+| Schema, bounds, CRS, and hierarchy | Supported | Potree metadata and hierarchy files |
+| Bounds, minimum/maximum level, target spacing | Supported | Hierarchy pushdown followed by exact point filtering |
+| Attribute predicate | Supported | Residual after node decoding |
+| Projection and global limit | Supported | Applied in caller column order across all nodes |
+| Cancellation and early return | Supported | Stops hierarchy, payload, and result work |
+| Unsupported layouts | Metadata only | Execution metadata contains the concrete reason |
+
+Potree currently decodes complete point records before projection. The capability metadata reports
+that distinction so applications do not confuse correct results with selective decoder pushdown.
 
 ## Installation
 

--- a/docs/modules/scan/README.md
+++ b/docs/modules/scan/README.md
@@ -1,0 +1,113 @@
+# @loaders.gl/scan
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v5.0-blue.svg?style=flat-square" alt="From v5.0" />
+</p>
+
+`@loaders.gl/scan` is the optional application-facing runtime for portable queries. It collects the
+reference Arrow executor, query parsing, source-neutral query metadata, ordered append federation,
+and adapters that expose an already-addressed vector result as a table.
+
+Format packages do not depend on this runtime. They implement lightweight contracts from
+`@loaders.gl/loader-utils`, so applications that only load or decode a format do not pay the scan
+runtime bundle cost.
+
+See the [common scan architecture](/docs/developer-guide/common-scan-architecture) for the complete
+support matrix and execution semantics.
+
+## Installation
+
+```bash
+npm install @loaders.gl/scan apache-arrow
+```
+
+## Query an Arrow table
+
+Arrow is the built-in reference backend. `createScanEngine()` is asynchronous so an application can
+register another backend lazily without changing its calling code.
+
+```ts
+import {createScanEngine, parseSQLPredicate} from '@loaders.gl/scan';
+
+const engine = await createScanEngine();
+const result = engine.query(table, {
+  predicate: parseSQLPredicate("status = 'active'"),
+  columns: ['id', 'status'],
+  limit: 100
+});
+```
+
+The query is immutable and follows `filter -> project -> limit` semantics. Predicate columns do not
+need to appear in the result projection, and a limit counts only rows that survive filtering.
+
+## Discover source controls
+
+Scan-aware sources expose metadata before execution. This is the contract used by the shared
+documentation query panel.
+
+```ts
+const metadata = await source.getQueryMetadata();
+
+console.log(metadata.execution); // supported method, or a concrete unsupported reason
+console.log(metadata.columns); // fields available to projection and predicates
+console.log(metadata.capabilities); // pushdown, residual, or unsupported operators
+```
+
+Applications should use `metadata.execution`, not the existence of a method with a familiar name,
+to decide whether Apply is enabled. Capability metadata distinguishes correct residual execution
+from physical pushdown.
+
+## Runtime surfaces
+
+| API | Use it for | Result |
+| --- | --- | --- |
+| `createScanEngine()` | Query one in-memory Arrow table | Materialized Arrow table |
+| `registerScanBackend()` | Register an application-owned lazy backend | No eager backend import |
+| `FederatedTableScanSource` | Append managed table sources in stable order | Arrow batches with provenance |
+| `VectorTileTableScanSource` | Query one already-addressed MVT or vector PMTiles tile | One Arrow feature batch |
+| `VectorFeatureTableScanSource` | Query one already-bounded WFS or ArcGIS feature request | One Arrow feature batch |
+| Query and metadata types | Build source-neutral controls | Serializable query state |
+
+## Ordered append federation
+
+`FederatedTableScanSource` resolves child sources through the existing `DataSourceManager`. It is an
+ordered `UNION ALL`, not a distributed database.
+
+| Behavior | Contract |
+| --- | --- |
+| Source order | Result rows preserve the caller's source list order |
+| Source-local query | Runs before schema reconciliation |
+| `strict` schema policy | Requires identical mapped fields and portable types |
+| `union` schema policy | Uses first-seen column order and typed nulls for missing fields |
+| Column mapping | Explicitly renames source fields into the federated namespace |
+| Global query and limit | Run after reconciliation across the complete append |
+| Early termination | Closes the active child and does not open later sources |
+| Provenance | Every batch reports source id, source index, and child batch index |
+| Cancellation | Covers deferred source resolution and child iteration |
+
+Parallel scheduling, implicit type coercion, optimizer-selected source order, and managed
+multi-source joins are intentionally outside this API.
+
+## Vector table views
+
+Tiles and feature services retain their specialized addressing APIs. An adapter can bind one tile
+or one bounded service request, require Arrow output, and expose the resolved feature table to the
+portable relational executor.
+
+This boundary is deliberate:
+
+- z/x/y, tile layers, service layers, bounds, and output CRS remain source parameters;
+- predicates, projection, expressions, ordering, aggregates, and limits apply to the resolved rows;
+- cross-tile planning and server-side filter translation are not implied by the adapter.
+
+The format page uses a blue **Scan table view** badge for this narrower participation mode rather
+than the green **Scan supported** badge used by sources with a native common scan entry point.
+
+## Bundle-size boundary
+
+- Import a format package alone for ordinary loader and source APIs.
+- Import `@loaders.gl/scan` only when the application needs the reference executor, shared query
+  parser, federation, or vector table-view adapters.
+- Register optional backends with a loader function so their implementation can remain in a
+  separate dynamic chunk.
+- UI components remain in the website/application layer and are not runtime dependencies.

--- a/docs/modules/services/arcgis-feature-server.md
+++ b/docs/modules/services/arcgis-feature-server.md
@@ -5,6 +5,12 @@ import {WmsDocsTabs} from '@site/src/components/docs/wms-docs-tabs';
 
 <WmsDocsTabs active="arcgis-feature-server" />
 
+<p class="badges">
+  <a href="/docs/modules/scan#vector-table-views">
+    <img src="https://img.shields.io/badge/Scan-Table_view-3178C6.svg?style=flat-square" alt="Optional scan table view" />
+  </a>
+</p>
+
 ArcGIS FeatureServer endpoints expose queryable vector feature layers through the ArcGIS REST API.
 `ArcGISFeatureServerSourceLoader` adapts a service or layer endpoint to the loaders.gl
 `VectorSource` contract.
@@ -25,6 +31,24 @@ ArcGIS FeatureServer endpoints expose queryable vector feature layers through th
 | Pagination | Not automated | The source performs one ArcGIS query per `getFeatures()` call |
 | Editing and attachments | Not supported | The source is a read-only query client |
 | deck.gl rendering | First class | Pass the source loader or `SERVICE_LOADERS` to `SourceLayer` |
+
+## Optional scan table view
+
+`VectorFeatureTableScanSource` can bind one bounded FeatureServer request that returns Arrow data.
+The ArcGIS source continues to own service discovery, layer ids, bounds, CRS, paging, and request
+parameters; the table view owns the relational operations over the returned feature rows.
+
+| Capability | Support |
+| --- | --- |
+| Layer metadata and service request | ArcGIS source |
+| Bound request schema | Discovered from the Arrow result |
+| Predicate, projection, expressions, ordering, aggregates, and limit | Residual Arrow execution |
+| Cancellation | Covers the service request and table query |
+| Automatic ArcGIS SQL translation | Not provided by the table-view adapter |
+| Multi-layer or unbounded service federation | Not provided |
+
+Use ArcGIS request parameters for server-side reduction whenever possible. The table view provides a
+common client-side query contract after the service has returned the bounded feature set.
 
 ## Create and query a source
 

--- a/docs/modules/wms/formats/wfs.md
+++ b/docs/modules/wms/formats/wfs.md
@@ -5,6 +5,12 @@ import {ClientExample} from '@site/src/components';
 
 <WmsDocsTabs active="wfs" />
 
+<p class="badges">
+  <a href="/docs/modules/scan#vector-table-views">
+    <img src="https://img.shields.io/badge/Scan-Table_view-3178C6.svg?style=flat-square" alt="Optional scan table view" />
+  </a>
+</p>
+
 ![ogc-logo](../../../images/logos/ogc-logo-60.png)
 
 WFS serves vector features and properties over HTTP. `WFSSourceLoader` provides a read-only
@@ -30,6 +36,24 @@ WFS serves vector features and properties over HTTP. `WFSSourceLoader` provides 
 | Schema type hints | Supported | GML property types can be supplied from application schema knowledge |
 | Transactions and locking | Not supported | WFS-T mutation APIs are outside the read-only source |
 | deck.gl rendering | First class | Pass `WFSSourceLoader` to `SourceLayer` |
+
+## Optional scan table view
+
+WFS remains a service protocol. Layers, request bounds, CRS, paging, and output format stay in the
+WFS request. `VectorFeatureTableScanSource` can bind one bounded request that returns an Arrow table
+and apply portable relational operations to the returned feature rows.
+
+| Capability | Support |
+| --- | --- |
+| Layer, bounds, CRS, paging, and service filters | WFS source parameters |
+| Table schema | Discovered from the bounded result |
+| Predicate, projection, expressions, ordering, aggregates, and limit | Residual Arrow execution |
+| Cancellation | Covers the service request and table query |
+| Automatic `DescribeFeatureType` planning | Not provided by the table-view adapter |
+| Automatic translation of portable predicates to OGC filters | Not provided |
+
+Prefer native WFS filters and paging when the service can reduce a large response. The table view is
+most useful for normalizing and refining an already-bounded result.
 
 ## Query features
 

--- a/docs/modules/zarr/README.md
+++ b/docs/modules/zarr/README.md
@@ -7,6 +7,9 @@ CRS discovery, current native-CRS behavior, and the raster-warping roadmap.
   <img src="https://img.shields.io/badge/From-v5.0-blue.svg?style=flat-square" alt="From-v5.0" />
   &nbsp;
   <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
+  <a href="/docs/developer-guide/common-scan-architecture">
+    <img src="https://img.shields.io/badge/Scan-Supported-2f855a.svg?style=flat-square" alt="Scan supported" />
+  </a>
 </p>
 
 The `@loaders.gl/zarr` module reads chunked, multidimensional [Zarr](https://zarr.dev/)
@@ -65,7 +68,7 @@ store directly from S3 and renders monthly solar irradiance on an interactive ma
 | OME image channels, time, and z planes | — | — | Yes | — | Available |
 | OME multiscale pyramids | — | — | Yes | — | Available |
 | Automatic display-level selection | — | — | Yes | — | Available |
-| Scan metadata and level-of-detail discovery | — | — | Yes | Planned for GeoZarr | Available for OME-Zarr |
+| Scan metadata and source discovery | — | — | Yes | Yes | Available through both raster sources |
 | GeoZarr `proj:` and `spatial:` metadata | — | — | — | Yes | Available |
 | CF/xarray coordinates, time, vertical, and band selection | — | — | — | Yes | Available |
 | Viewport-driven geospatial windows | — | — | — | Yes | Available |
@@ -73,7 +76,27 @@ store directly from S3 and renders monthly solar irradiance on an interactive ma
 | Zarrita-backed v2/v3 implementation | Yes | Yes | Yes | Yes | Available |
 | SpatialData tables, points, and shapes | — | — | Planned | — | Planned |
 | Codec expansion and broader multiscale layouts | Partial | Partial | Planned | Planned | Planned |
-| Scan pushdown for richer raster predicates | — | — | Planned | Planned | Planned |
+| Common raster query execution | — | — | Levels, channels, and slices | Native spatial windows and named selections | Available |
+
+## Scan support
+
+Zarr participates through two raster sources. Both read only the selected chunks and preserve typed
+array output, but their query vocabulary reflects the kind of array being opened.
+
+| Capability | OME-Zarr | GeoZarr / CF |
+| --- | --- | --- |
+| Entry point | `getRaster()` | `getRaster()` |
+| Metadata discovery | Channels, dimensions, multiscale levels | Variable, dtype, dimensions, bounds, CRS |
+| Spatial window | Image window | Native-CRS viewport bounds |
+| Resolution | Multiscale level pushdown | Native resolution; explicit level unsupported |
+| Non-spatial selection | Channels, time, and z slices | Named time, vertical, band, or other dimension indices |
+| Physical access | Selected Zarr chunks and codecs | Selected Zarr chunks and codecs |
+| Output | Typed planar or interleaved pixels | Typed raster data |
+| Reprojection | Not applicable to ordinary OME image coordinates | Not performed |
+
+Query metadata is suitable for populating source-neutral controls before pixel data is requested.
+GeoZarr bounds must use the source CRS; callers should reproject the viewport before requesting a
+window when necessary.
 
 ## Attributions
 

--- a/docs/modules/zarr/formats/zarr.md
+++ b/docs/modules/zarr/formats/zarr.md
@@ -1,0 +1,43 @@
+# Zarr, GeoZarr, and OME-Zarr
+
+<p class="badges">
+  <a href="/docs/developer-guide/common-scan-architecture">
+    <img src="https://img.shields.io/badge/Scan-Supported-2f855a.svg?style=flat-square" alt="Scan supported" />
+  </a>
+</p>
+
+- _[`@loaders.gl/zarr`](/docs/modules/zarr)_
+- _[Zarr specification](https://zarr-specs.readthedocs.io/)_
+- _[OME-Zarr specification](https://ngff.openmicroscopy.org/)_
+
+Zarr stores typed multidimensional arrays as independently addressable chunks. OME-Zarr adds
+bioimaging conventions such as multiscale image pyramids, channels, and labeled dimensions.
+GeoZarr and CF/xarray conventions add coordinate reference systems, transforms, coordinate arrays,
+and named scientific dimensions.
+
+## Format support
+
+| Capability | Zarr v2 | Zarr v3 | OME-Zarr | GeoZarr / CF |
+| --- | --- | --- | --- | --- |
+| Metadata discovery | Supported | Supported | Supported | Supported |
+| Chunk reads and codecs | Supported | Supported | Supported | Supported |
+| Multidimensional arrays | Supported | Supported | Supported | Supported |
+| Multiscale image levels | Format-specific | Format-specific | Supported | Not assumed |
+| Spatial CRS and transform | Not inherent | Not inherent | Not required | Supported |
+| Named time/z/band selection | Array-dependent | Array-dependent | Supported | Supported |
+
+## Scan support
+
+| Scan feature | OME-Zarr | GeoZarr / CF |
+| --- | --- | --- |
+| Entry point | `getRaster()` | `getRaster()` |
+| Discovery | Channels, dimensions, levels | Variable, dtype, dimensions, bounds, CRS |
+| Spatial selection | Image window | Native-CRS viewport window |
+| Resolution | Multiscale level pushdown | Native resolution |
+| Non-spatial selection | Channels, time, z | Named dimension indices |
+| Physical access | Selected chunks | Selected chunks |
+| Output | Typed image data | Typed raster data |
+| Reprojection | Not applicable to ordinary image coordinates | Not performed |
+
+The common contract standardizes discovery and query meaning; it does not hide the array's native
+dimension labels, chunk layout, or coordinate system.

--- a/modules/orc/src/orc-source-loader.ts
+++ b/modules/orc/src/orc-source-loader.ts
@@ -36,8 +36,8 @@ export type ORCQueryOptions = TableQueryOptions & Readonly<{signal?: AbortSignal
  * Lightweight ORC scan source.
  *
  * Footer parsing is metadata-only and exposes a shared query schema. The current decoder reads the
- * complete file before applying residual Arrow projection, predicates, and limits; stripe-level
- * pruning remains the next ORC-specific tranche.
+ * complete file before applying residual Arrow projection, predicates, and limits. Stripe-level
+ * pruning is not currently implemented.
  */
 export class ORCSource extends DataSource<string | Blob, ORCSourceOptions> {
   private arrayBufferPromise: Promise<ArrayBuffer> | null = null;

--- a/modules/scan/src/scan-engine.ts
+++ b/modules/scan/src/scan-engine.ts
@@ -14,7 +14,7 @@ import type {TableQueryExplain} from '@loaders.gl/loader-utils';
 /** Names accepted by the optional scan engine factory. */
 export type ScanBackendName = 'arrow' | (string & {});
 
-/** A backend implementation for the proof-of-concept Arrow table surface. */
+/** A backend implementation for the Arrow table query surface. */
 export type ScanBackend = Readonly<{
   /** Stable backend name reported by the engine. */
   name: ScanBackendName;
@@ -71,7 +71,7 @@ export async function createScanEngine(options: ScanEngineOptions = {}): Promise
   const loader = scanBackendLoaders.get(backendName);
   if (!loader) {
     throw new Error(
-      `Scan backend "${backendName}" is not registered. The proof of concept includes "arrow".`
+      `Scan backend "${backendName}" is not registered. The built-in backend is "arrow".`
     );
   }
   const backend = await loader();


### PR DESCRIPTION
## Goals

- Make common scan support discoverable and understandable from format and source documentation.
- Give users conclusive capability and execution-boundary information instead of internal roadmap terminology.
- Explain the optional scan runtime and its bundle-size boundary without forcing scan dependencies onto format packages.

## Changes

- Rework the common scan architecture guide around one authoritative support matrix and public support policy.
- Add linked Scan supported badges and source-specific feature tables across Arrow, GeoArrow, CSV, NDJSON, FlatGeobuf, GeoPackage, GeoTIFF, Parquet, GeoParquet, COPC, Potree, Zarr, NetCDF, ORC, Iceberg, and Delta documentation.
- Add a distinct Scan table view badge for bound MVT, PMTiles, WFS, and ArcGIS FeatureServer results so specialized addressing is not confused with a native scan.
- Add dedicated documentation for @loaders.gl/scan, ORC, NetCDF, Zarr, and Delta, and expose the pages in the documentation sidebar.
- Correct stale FlatGeobuf spatial-filtering, GeoTIFF metadata-only, GeoZarr, and NetCDF support descriptions.
- Replace proof-of-concept wording in scan-facing comments and diagnostics with stable reference-runtime terminology.

## Validation

- yarn lint fix
- git diff --check
- website/yarn build
- Root yarn build completed TypeScript and bundling for all 57 modules, then encountered the existing @loaders.gl/las pre-build copy failure because dist/libs/laz-rs-wasm is not created before the copy step.