### PR TITLE
docs(csv): explain Arrow parser performance paths

### DIFF
--- a/modules/csv/src/csv-arrow-table-parser.ts
+++ b/modules/csv/src/csv-arrow-table-parser.ts
@@ -621,8 +621,9 @@ function tryParseTypedUnquotedCSVBytes(
   }
   const headerEnd = findDirectRowEnd(bytes, 0);
   const headerRow = decodeDirectHeaderRow(bytes, 0, headerEnd.end, delimiterByte);
-  // Keep aggregate speculative typed storage proportional to input size. A large per-column
-  // minimum can exhaust memory for valid CSV files with tens of thousands of shallow columns.
+  // Keep aggregate speculative typed storage proportional to input size. The old fixed minimum
+  // multiplied by column count, so a valid wide file with shallow columns could reserve far more
+  // memory than its contents. This estimate is only initial capacity; builders still grow safely.
   const initialColumnCapacity = calculateInitialTypedColumnCapacity(bytes.length, headerRow.length);
   const columns: DirectTypedColumn[] = headerRow.map(() => ({
     values: [],
@@ -681,6 +682,8 @@ function tryParseTypedUnquotedCSVBytes(
 
 /**
  * Calculates per-column speculative storage for the direct typed parser.
+ * The aggregate initial allocation is bounded by roughly the input byte length divided by eight,
+ * while retaining at least one slot per column for empty or very small inputs.
  * @internal
  */
 export function calculateInitialTypedColumnCapacity(

--- a/modules/csv/src/lib/parsers/parse-csv-to-arrow.ts
+++ b/modules/csv/src/lib/parsers/parse-csv-to-arrow.ts
@@ -79,6 +79,10 @@ export async function parseRawArrowCSVText(
     return parseRawArrowCSVTextWithPapa(csvText, options, csvOptions);
   }
 
+  // Keep the common text case in the string domain: encoding the entire input before parsing
+  // duplicates the input and makes the parser pay a UTF-16-to-UTF-8 conversion that ASCII does
+  // not need. The direct parser is deliberately conservative and returns null for any case it
+  // cannot prove equivalent, allowing the general byte/Papa-compatible paths to preserve behavior.
   const rawASCIIArrowTable = parseRawArrowCSVASCIIText(csvText, csvOptions);
   if (rawASCIIArrowTable) {
     return rawASCIIArrowTable;

--- a/modules/csv/src/lib/parsers/parse-raw-arrow-csv-bytes.ts
+++ b/modules/csv/src/lib/parsers/parse-raw-arrow-csv-bytes.ts
@@ -35,6 +35,8 @@ const CARRIAGE_RETURN = 13;
 const LINE_FEED = 10;
 const SPACE = 32;
 const TAB = 9;
+// A bounded probe rejects the common quoted/UTF-8 cases before allocating Arrow builders. The
+// complete scan below remains authoritative, so late non-ASCII or quote characters still fall back.
 const ASCII_TEXT_PROBE_LENGTH = 256;
 
 const FLOAT = /^\s*-?(\d*\.?\d+|\d+\.?\d*)(e[-+]?\d+)?\s*$/i;
@@ -62,6 +64,8 @@ export function parseRawArrowCSVBytes(
 
   const bytes = new Uint8Array(arrayBuffer);
   if (!parserOptions.skipEmptyLines && bytes.indexOf(parserOptions.quote) === -1) {
+    // An unquoted file needs no row objects or quote-state machine. Write each field directly to
+    // its column's Arrow buffers after this one cheap quote probe.
     const parser = new RawArrowUnquotedCSVByteParser(bytes, parserOptions);
     return parser.parseTable();
   }
@@ -94,6 +98,8 @@ export function parseRawArrowCSVASCIIText(
     return null;
   }
 
+  // This is only an inexpensive admission test. The parser must still validate every field while
+  // scanning because a quote or non-ASCII code unit can occur after the probe window.
   const probeLength = Math.min(csvText.length, ASCII_TEXT_PROBE_LENGTH);
   for (let characterIndex = 0; characterIndex < probeLength; characterIndex++) {
     const characterCode = csvText.charCodeAt(characterIndex);
@@ -111,6 +117,8 @@ function getCSVASCIITextParserOptions(csvOptions: CSVRawArrowOptions): CSVBytePa
   const shouldUseUtf8View =
     csvOptions.viewTypes === 'require' ||
     (csvOptions.viewTypes === 'prefer' && getArrowViewTypeSupport().utf8View);
+  // The direct scanner intentionally supports a small, explicit option set. Falling back here is
+  // cheaper and safer than adding branches to the hot loop for comments, skipped rows, or views.
   if (shouldUseUtf8View || csvOptions.comments || csvOptions.skipEmptyLines) {
     return null;
   }
@@ -959,6 +967,8 @@ class RawArrowUnquotedCSVTextParser {
       );
     }
 
+    // Builders own the final Arrow offsets/data buffers. Parsing directly into them avoids the
+    // row arrays and per-cell strings normally needed by a row-oriented CSV representation.
     const columnBuilders = createRawArrowColumnBuilders(headerRow, this.csvText.length);
     if (!this.appendDataRows(dataStart, columnBuilders)) {
       return null;
@@ -978,6 +988,8 @@ class RawArrowUnquotedCSVTextParser {
     let fieldStart = start;
     let columnIndex = 0;
 
+    // Scan once over the source string. Delimiters and line endings are the only boundaries needed
+    // for this proven-unquoted path; CRLF is consumed as one row terminator below.
     for (let characterIndex = start; characterIndex <= this.csvText.length; characterIndex++) {
       const characterCode = this.csvText.charCodeAt(characterIndex);
       if (characterCode === quote || characterCode >= 128) {
@@ -1172,6 +1184,8 @@ class RawArrowUtf8ColumnBuilder {
 
   /** Appends a non-null value from a previously validated ASCII text range. */
   appendASCIITextRange(source: string, start: number, end: number): void {
+    // For validated ASCII, each UTF-16 code unit is already the corresponding UTF-8 byte. Copying
+    // directly into the Arrow data buffer avoids TextEncoder calls and temporary cell strings.
     const characterLength = end - start;
     this.reserveData(characterLength);
     for (let characterIndex = start; characterIndex < end; characterIndex++) {

--- a/website/src/examples/benchmarks-app.tsx
+++ b/website/src/examples/benchmarks-app.tsx
@@ -20,9 +20,12 @@ const SAMPLE_CSV_URL =
   'https://raw.githubusercontent.com/visgl/loaders.gl/master/modules/csv/test/data/sample-very-long.csv';
 const ROW_COUNT = 2000;
 const WIDE_COLUMN_COUNT = 40;
+// More samples and a longer measurement window reduce JIT/startup noise in the browser table.
+// These settings apply equally to every implementation; they are not a warmup or result filter.
 const BENCHMARK_OPTIONS = {minIterations: 5, time: 100, unit: 'rows'};
 
-// Keep these labels synchronized with the exact versions resolved in yarn.lock.
+// Keep these labels synchronized with the exact versions resolved in yarn.lock. The workspace
+// package can report "latest" during local development, which is not useful benchmark metadata.
 const CSV_LOADER_DISPLAY_NAME = 'CSVLoader v5.0.0-alpha.2 (arrow-table)';
 const D3_DSV_DISPLAY_NAME = 'd3-dsv v1.2.0';
 const UDSV_DISPLAY_NAME = 'uDSV v0.7.3';
@@ -504,6 +507,8 @@ function addLoaderParseBenchmark(
       scenario: scenario.name
     }),
     {...BENCHMARK_OPTIONS, multiplier: scenario.rowCount},
+    // Arrow's public parseText API is asynchronous; time its complete Arrow-table result without
+    // adding a conversion step to the synchronous competitors' benchmark bodies.
     async () => await parseText(scenario.text, loaderBenchmark.options)
   );
 }
@@ -526,6 +531,7 @@ function addD3ParseBenchmark(
       scenario: scenario.name
     }),
     {...BENCHMARK_OPTIONS, multiplier: scenario.rowCount},
+    // d3-dsv exposes a synchronous parser, so measure that API directly without Promise overhead.
     () =>
       scenario.delimiter === '\t'
         ? tsvParse(scenario.text, dynamicTyping ? autoType : undefined)
@@ -551,6 +557,7 @@ function addPapaParseNPMBenchmark(
       scenario: scenario.name
     }),
     {...BENCHMARK_OPTIONS, multiplier: scenario.rowCount},
+    // PapaParse is synchronous for a string input; keep its native return path in the timed body.
     () =>
       PapaParseNPM.parse(scenario.text, {
         header: true,
@@ -579,6 +586,7 @@ function addUDSVParseBenchmark(
     }),
     {...BENCHMARK_OPTIONS, multiplier: scenario.rowCount},
     () => {
+      // uDSV's schema inference and native row materialization are part of its parse operation.
       const schema = inferSchema(scenario.text, {col: scenario.delimiter});
       const parser = initParser(schema);
       return dynamicTyping ? parser.typedObjs(scenario.text) : parser.stringObjs(scenario.text);


### PR DESCRIPTION
## Goals

Document the performance-sensitive design of the Arrow CSV parser and make the browser benchmark methodology auditable, without changing parser behavior or benchmark results.

## Changes compared with `master`

- Explain why `parseText` tries the direct ASCII path before whole-input `TextEncoder` conversion, and why conservative cases fall back to the existing parser.
- Document the bounded ASCII admission probe and the full-scan validation that preserves correctness for late quotes and non-ASCII text.
- Explain why unsupported options (`comments`, skipped empty lines, and UTF8 views) intentionally leave the hot loop rather than adding branches to it.
- Document that the direct byte/string scanners write into final Arrow column buffers, avoiding row arrays and per-cell string objects.
- Explain the direct ASCII-to-UTF8 byte copy and the single-pass delimiter/line-ending scan, including CRLF handling.
- Explain why typed-parser initial capacity is bounded by aggregate input size instead of multiplying a fixed minimum by column count.
- Explain the benchmark stability settings, exact dependency labels, and native synchronous competitor APIs. Arrow remains measured through its public asynchronous `parseText` API, with no extra Arrow conversion added to the competitors.

## Behavior and performance

This PR contains comments only. It does not alter parsing, output materialization, options, fallback decisions, benchmark scenarios, or measured results. The documented architecture is the one introduced by the merged CSV Arrow performance work: direct parsing into Arrow buffers for compatible inputs, with existing general paths retained for unsupported CSV semantics.

The benchmark page labels the compared implementations as CSVLoader v5.0.0-alpha.2, d3-dsv v1.2.0, uDSV v0.7.3, and PapaParse v5.5.3. The browser harness uses the same measurement settings for all implementations; synchronous libraries use their native synchronous entry points, while CSVLoader uses its native async entry point.

## Validation

- `yarn lint fix`
- `yarn test-headless modules/csv/test/parse-raw-arrow-csv-bytes.spec.ts modules/csv/test/csv-fast-path.spec.ts`

Focused result: 2 test files passed, 29 tests passed.
