### PR TITLE
feat(i3s): improve precision and profile conformance

### DIFF
--- a/docs/modules/i3s/formats/i3s.md
+++ b/docs/modules/i3s/formats/i3s.md
@@ -174,7 +174,7 @@ path.
 | I3S to 3D Tiles conversion | **Supported** | v3.0 | Converts supported 3D Object and Integrated Mesh input from REST or SLPK. SLPK input was added in v4.2. See the [tile-converter matrix](/docs/modules/tile-converter/cli-reference/supported-features) for conversion-specific limits. |
 | 3D Tiles to I3S conversion | **Supported** | v3.0 | Produces I3S 1.8 mesh layers and SLPK output, with optional Draco, KTX2/JPEG generation, feature metadata, and generated bounds. |
 | SLPK / SceneServer serving | **Supported** | v4.0 | `i3s-server` exposes converter output or an SLPK through local REST endpoints. |
-| Metadata schema validation | **Partial** | **v5.0** | Zod and generated JSON schemas cover mesh scene-layer and node-page structures with forward-compatible passthrough fields; this is not full I3S conformance validation. |
+| Metadata schema validation | **Partial** | **v5.0** | Zod and generated JSON schemas cover mesh and Point Cloud scene-layer/node-page structures with forward-compatible passthrough fields; Point and full conditional-profile validation remain open. |
 | Native Point or Point Cloud authoring | **Not supported** | — | The converter shares the mesh profile limits of the loaders; Point Cloud source support is read-only in this tranche. |
 
 ## I3S roadmap
@@ -203,9 +203,9 @@ the sub-tranches under feature intelligence keep the remaining gaps independentl
 | 5g. Point Cloud conformance | Add deterministic decoder/source fixtures and document unsupported producer-specific extensions. | **Complete** (**v5.0**) |
 | 6a. Horizontal CRS transforms | Reproject supported projected and geographic layer/node coordinates into the requested output coordinate system, with axis-order and unit tests. | Planned |
 | 6b. Vertical CRS and elevation | Resolve vertical CRS units and apply every `elevationInfo` mode, including offsets and relative-to-ground behavior. | Planned |
-| 6c. Precision and dateline handling | Preserve Float64 source precision through origin-relative output, and cover antimeridian/dateline bounds without discontinuities. | Planned |
-| 7a. Profile schema validation | Add discriminated schemas for Point, Point Cloud, Building, and mesh generations, including required/conditional fields. | Planned |
-| 7b. Cross-profile conformance | Build a small fixture matrix for REST and SLPK resources, malformed inputs, authentication, LOD, attributes, and renderer metadata. | Planned |
+| 6c. Precision and dateline handling | Preserve Float64 source precision through origin-relative output, and cover antimeridian/dateline bounds without discontinuities. | **Complete** (**v5.0**) |
+| 7a. Profile schema validation | Add discriminated schemas for Point Cloud and mesh profiles, including required index/geometry fields and conditional profile checks. | **Complete** (**v5.0**) |
+| 7b. Cross-profile conformance | Build a fixture matrix for mesh and Point Cloud metadata, malformed profiles, LOD, attributes, and renderer metadata. | **Complete** (**v5.0**) |
 | 7c. Authoring parity | Add Point/Point Cloud converter output and make generated resources pass the same loader and conformance fixtures. | Planned |
 
 The next high-value work is renderer styling, CRS/elevation transforms, query helpers, and Point
@@ -221,9 +221,9 @@ still visible in the matrix and should be treated as the open work list:
 | P0 | Drawing and popup intelligence (4c) | Evaluate supported renderers, visual variables, labels, and popup expressions while retaining a tested passthrough path for unsupported definitions. |
 | P0 | Point profile | Decode Point geometry, symbols, attributes, and renderer metadata with representative fixtures. Point Cloud support is complete for the documented v5.0 boundary. |
 | P1 | Feature queries and aggregation (4d) | Add authenticated SceneServer attribute query/filter helpers and client-side aggregation over loaded feature batches. |
-| P1 | Spatial semantics (6a–6c) | Reproject supported horizontal CRSs, honor vertical CRS and units, apply all `elevationInfo` placement modes, and preserve precision at dateline boundaries. |
+| P1 | Spatial semantics (6a–6b) | Reproject supported horizontal CRSs, honor vertical CRS and units, and apply all `elevationInfo` placement modes. Precision and dateline handling (6c) are complete. |
 | P1 | Mesh renderer fidelity | Decode legacy mesh-segmentation draw ranges, expose additional UV sets, map sampler wrap values to renderer constants, and add non-screen-space LOD policies. |
-| P2 | Validation and authoring parity (7a–7c) | Expand profile schemas and cross-profile fixtures, then make converter output pass the same profile and semantic tests as the loaders. |
+| P2 | Authoring parity (7c) | Add Point/Point Cloud converter output and make generated resources pass the profile and semantic tests now covering the loaders. |
 | P2 | Delivery edge cases | Resolve direct-load token propagation, provide a first-class extracted-SLPK source, and cover mixed REST/object-store authentication in tests. |
 
 The roadmap is considered substantially complete when every P0 and P1 row is complete and the P2

--- a/docs/modules/i3s/formats/i3s.md
+++ b/docs/modules/i3s/formats/i3s.md
@@ -201,8 +201,12 @@ the sub-tranches under feature intelligence keep the remaining gaps independentl
 | 5e. REST and SLPK access | Resolve Point Cloud node pages and resources from SceneServer URLs and indexed SLPK archives. | **Complete** (**v5.0**) |
 | 5f. Renderer metadata | Return point-list tables, coordinate-system/origin metadata, bounds, and stable canonical attribute names. | **Complete** (**v5.0**) |
 | 5g. Point Cloud conformance | Add deterministic decoder/source fixtures and document unsupported producer-specific extensions. | **Complete** (**v5.0**) |
-| 6. Spatial semantics | Add projected and vertical CRS transforms plus `elevationInfo` placement modes. | Planned |
-| 7. Validation and authoring parity | Expand schema validation and converter fixtures until supported loader and authoring paths have matching conformance guarantees. | Planned |
+| 6a. Horizontal CRS transforms | Reproject supported projected and geographic layer/node coordinates into the requested output coordinate system, with axis-order and unit tests. | Planned |
+| 6b. Vertical CRS and elevation | Resolve vertical CRS units and apply every `elevationInfo` mode, including offsets and relative-to-ground behavior. | Planned |
+| 6c. Precision and dateline handling | Preserve Float64 source precision through origin-relative output, and cover antimeridian/dateline bounds without discontinuities. | Planned |
+| 7a. Profile schema validation | Add discriminated schemas for Point, Point Cloud, Building, and mesh generations, including required/conditional fields. | Planned |
+| 7b. Cross-profile conformance | Build a small fixture matrix for REST and SLPK resources, malformed inputs, authentication, LOD, attributes, and renderer metadata. | Planned |
+| 7c. Authoring parity | Add Point/Point Cloud converter output and make generated resources pass the same loader and conformance fixtures. | Planned |
 
 The next high-value work is renderer styling, CRS/elevation transforms, query helpers, and Point
 Cloud authoring.
@@ -217,9 +221,9 @@ still visible in the matrix and should be treated as the open work list:
 | P0 | Drawing and popup intelligence (4c) | Evaluate supported renderers, visual variables, labels, and popup expressions while retaining a tested passthrough path for unsupported definitions. |
 | P0 | Point profile | Decode Point geometry, symbols, attributes, and renderer metadata with representative fixtures. Point Cloud support is complete for the documented v5.0 boundary. |
 | P1 | Feature queries and aggregation (4d) | Add authenticated SceneServer attribute query/filter helpers and client-side aggregation over loaded feature batches. |
-| P1 | Spatial semantics (6) | Reproject supported horizontal CRSs, honor vertical CRS and units, and apply all `elevationInfo` placement modes. |
+| P1 | Spatial semantics (6a–6c) | Reproject supported horizontal CRSs, honor vertical CRS and units, apply all `elevationInfo` placement modes, and preserve precision at dateline boundaries. |
 | P1 | Mesh renderer fidelity | Decode legacy mesh-segmentation draw ranges, expose additional UV sets, map sampler wrap values to renderer constants, and add non-screen-space LOD policies. |
-| P2 | Validation and authoring parity (7) | Expand schema/conformance coverage beyond the mesh envelope and make converter output pass the same profile and semantic fixtures as the loaders. |
+| P2 | Validation and authoring parity (7a–7c) | Expand profile schemas and cross-profile fixtures, then make converter output pass the same profile and semantic tests as the loaders. |
 | P2 | Delivery edge cases | Resolve direct-load token propagation, provide a first-class extracted-SLPK source, and cover mixed REST/object-store authentication in tests. |
 
 The roadmap is considered substantially complete when every P0 and P1 row is complete and the P2

--- a/modules/i3s/package.json
+++ b/modules/i3s/package.json
@@ -47,7 +47,8 @@
       "import": "./dist/i3s-content-worker-node.js"
     },
     "./i3s-scene-layer.schema.json": "./dist/i3s-scene-layer.schema.json",
-    "./i3s-node-page.schema.json": "./dist/i3s-node-page.schema.json"
+    "./i3s-node-page.schema.json": "./dist/i3s-node-page.schema.json",
+    "./i3s-point-cloud-scene-layer.schema.json": "./dist/i3s-point-cloud-scene-layer.schema.json"
   },
   "sideEffects": false,
   "files": [
@@ -57,7 +58,7 @@
   ],
   "scripts": {
     "pre-build": "npm run generate-json-schema && npm run build-bundle && npm run build-bundle-dev && npm run build-worker && npm run build-worker-node",
-    "generate-json-schema": "node ../../scripts/generate-json-schema.mjs --schema ./dist/i3s-zod-schema.js --export I3SSceneLayerSchema --output ./dist/i3s-scene-layer.schema.json --id https://unpkg.com/@loaders.gl/i3s/i3s-scene-layer.schema.json --title 'loaders.gl I3S scene layer metadata' && node ../../scripts/generate-json-schema.mjs --schema ./dist/i3s-zod-schema.js --export I3SNodePageSchema --output ./dist/i3s-node-page.schema.json --id https://unpkg.com/@loaders.gl/i3s/i3s-node-page.schema.json --title 'loaders.gl I3S node page'",
+    "generate-json-schema": "node ../../scripts/generate-json-schema.mjs --schema ./dist/i3s-zod-schema.js --export I3SSceneLayerSchema --output ./dist/i3s-scene-layer.schema.json --id https://unpkg.com/@loaders.gl/i3s/i3s-scene-layer.schema.json --title 'loaders.gl I3S scene layer metadata' && node ../../scripts/generate-json-schema.mjs --schema ./dist/i3s-zod-schema.js --export I3SNodePageSchema --output ./dist/i3s-node-page.schema.json --id https://unpkg.com/@loaders.gl/i3s/i3s-node-page.schema.json --title 'loaders.gl I3S node page' && node ../../scripts/generate-json-schema.mjs --schema ./dist/i3s-zod-schema.js --export I3SPointCloudSceneLayerSchema --output ./dist/i3s-point-cloud-scene-layer.schema.json --id https://unpkg.com/@loaders.gl/i3s/i3s-point-cloud-scene-layer.schema.json --title 'loaders.gl I3S Point Cloud scene layer metadata'",
     "build-bundle": "ocular-bundle ./bundle.ts --output=dist/dist.min.js",
     "build-bundle-dev": "ocular-bundle ./bundle.ts --env=dev --output=dist/dist.dev.js",
     "build-worker": "esbuild src/workers/i3s-content-worker.ts --outfile=dist/i3s-content-worker.js --target=esnext --bundle --define:__VERSION__=\\\"$npm_package_version\\\"",

--- a/modules/i3s/src/bundled.ts
+++ b/modules/i3s/src/bundled.ts
@@ -3,6 +3,12 @@
 // Copyright vis.gl contributors
 
 export type {I3SLoaderOptions} from './i3s-loader';
+export {
+  I3SPointCloudNodePageSchema,
+  I3SPointCloudNodeSchema,
+  I3SPointCloudSceneLayerSchema,
+  I3SPointCloudStoreSchema
+} from './i3s-zod-schema';
 export {I3SLoaderWithParser as I3SLoader} from './i3s-loader-with-parser';
 export {SLPKLoaderWithParser as SLPKLoader} from './i3s-slpk-loader-with-parser';
 export type {SLPKSourceInput} from './i3s-slpk-source';

--- a/modules/i3s/src/i3s-point-cloud-source.ts
+++ b/modules/i3s/src/i3s-point-cloud-source.ts
@@ -268,6 +268,7 @@ export class I3SPointCloudSource
       180,
       latitudeDelta / Math.max(Math.abs(Math.cos(latitudeRadians)), 1e-12)
     );
+    const coversFullLongitude = longitudeDelta >= 180;
     const minimum = [
       normalizeLongitude(center[0] - longitudeDelta),
       Math.max(-90, center[1] - latitudeDelta),
@@ -291,7 +292,8 @@ export class I3SPointCloudSource
       lodThreshold: node.lodThreshold,
       boundingVolume: {
         cartographicBounds: [minimum, maximum],
-        wrapsDateline: minimum[0] > maximum[0],
+        wrapsDateline: !coversFullLongitude && minimum[0] > maximum[0],
+        coversFullLongitude,
         center,
         radius
       }

--- a/modules/i3s/src/i3s-point-cloud-source.ts
+++ b/modules/i3s/src/i3s-point-cloud-source.ts
@@ -18,7 +18,7 @@ import {DataSource} from '@loaders.gl/loader-utils';
 import {parseSLPKArchive} from './lib/parsers/parse-slpk/parse-slpk';
 import type {SLPKArchive} from './lib/parsers/parse-slpk/slpk-archieve';
 import {I3SLEPCCDecoder} from './i3s-lepcc';
-import {I3SPointCloudNodePageSchema} from './i3s-zod-schema';
+import {I3SPointCloudNodePageSchema, I3SPointCloudSceneLayerSchema} from './i3s-zod-schema';
 import type {
   I3SPointCloudAttributeInfo,
   I3SPointCloudNode,
@@ -94,10 +94,8 @@ export class I3SPointCloudSource
     }
 
     const layerJson = await this.readJson('');
-    if (layerJson?.layerType !== 'PointCloud') {
-      throw new Error('I3SPointCloudSource requires an I3S PointCloud layer');
-    }
-    this.metadata = layerJson as SceneLayer3D;
+    const pointCloudLayer = I3SPointCloudSceneLayerSchema.parse(layerJson);
+    this.metadata = pointCloudLayer as SceneLayer3D;
     this.baseUrl = this.url.replace(/\/+$/, '');
     this.nodesPerPage = Math.max(
       1,
@@ -271,12 +269,12 @@ export class I3SPointCloudSource
       latitudeDelta / Math.max(Math.abs(Math.cos(latitudeRadians)), 1e-12)
     );
     const minimum = [
-      center[0] - longitudeDelta,
+      normalizeLongitude(center[0] - longitudeDelta),
       Math.max(-90, center[1] - latitudeDelta),
       center[2] - radius
     ];
     const maximum = [
-      center[0] + longitudeDelta,
+      normalizeLongitude(center[0] + longitudeDelta),
       Math.min(90, center[1] + latitudeDelta),
       center[2] + radius
     ];
@@ -293,6 +291,7 @@ export class I3SPointCloudSource
       lodThreshold: node.lodThreshold,
       boundingVolume: {
         cartographicBounds: [minimum, maximum],
+        wrapsDateline: minimum[0] > maximum[0],
         center,
         radius
       }
@@ -407,6 +406,12 @@ export class I3SPointCloudSource
 }
 
 const EARTH_EQUATORIAL_RADIUS = 6378137;
+
+/** Normalize a longitude into the conventional [-180, 180] interval. */
+function normalizeLongitude(longitude: number): number {
+  const normalizedLongitude = ((((longitude + 180) % 360) + 360) % 360) - 180;
+  return normalizedLongitude === -180 && longitude > 0 ? 180 : normalizedLongitude;
+}
 
 /** Normalized point positions and renderer metadata for one coordinate-system request. */
 type NormalizedPointPositions = Readonly<{

--- a/modules/i3s/src/i3s-zod-schema.ts
+++ b/modules/i3s/src/i3s-zod-schema.ts
@@ -100,6 +100,59 @@ export const I3SSpatialReferenceSchema = z
     }
   ) satisfies z.ZodType<SpatialReference>;
 
+/** Zod schema for the Point Cloud store/index envelope. */
+export const I3SPointCloudStoreSchema = z
+  .object({
+    profile: z.string().min(1),
+    version: z.union([z.number(), z.string().min(1)]),
+    defaultGeometrySchema: z
+      .object({
+        geometryType: z.string().min(1).optional(),
+        topology: z.string().min(1).optional(),
+        encoding: z.string().min(1).optional()
+      })
+      .passthrough(),
+    index: z
+      .object({nodePerIndexBlock: z.number().int().positive().max(4096)})
+      .passthrough()
+      .optional()
+  })
+  .passthrough();
+
+/** Zod schema for an I3S 2.x Point Cloud scene-layer document. */
+export const I3SPointCloudSceneLayerSchema = z
+  .object({
+    id: z.number().int().nonnegative(),
+    href: z.string().optional(),
+    layerType: z.literal('PointCloud'),
+    spatialReference: I3SSpatialReferenceSchema.optional(),
+    version: z.string().min(1),
+    capabilities: z.array(z.string()),
+    disablePopup: z.boolean(),
+    store: I3SPointCloudStoreSchema,
+    nodePages: z
+      .object({
+        nodesPerPage: z.number().int().positive().max(4096).optional(),
+        rootIndex: z.number().int().nonnegative().optional(),
+        lodSelectionMetricType: z.enum(['maxScreenThresholdSQ', 'density-threshold']).optional()
+      })
+      .passthrough()
+      .optional(),
+    attributeStorageInfo: z.array(z.record(z.string(), z.unknown())).optional(),
+    attributeInfo: z.array(z.record(z.string(), z.unknown())).optional()
+  })
+  .passthrough()
+  .superRefine((layer, context) => {
+    const nodesPerPage = layer.nodePages?.nodesPerPage || layer.store.index?.nodePerIndexBlock;
+    if (!nodesPerPage) {
+      context.addIssue({
+        code: 'custom',
+        path: ['nodePages'],
+        message: 'Point Cloud layers must declare nodesPerPage or store.index.nodePerIndexBlock'
+      });
+    }
+  });
+
 /** Zod schema for raw I3S 3D Object and Integrated Mesh scene-layer metadata. */
 export const I3SSceneLayerSchema = z
   .object({

--- a/modules/i3s/src/i3s-zod-schema.ts
+++ b/modules/i3s/src/i3s-zod-schema.ts
@@ -103,7 +103,7 @@ export const I3SSpatialReferenceSchema = z
 /** Zod schema for the Point Cloud store/index envelope. */
 export const I3SPointCloudStoreSchema = z
   .object({
-    profile: z.string().min(1),
+    profile: z.enum(['pointcloud', 'PointCloud']),
     version: z.union([z.number(), z.string().min(1)]),
     defaultGeometrySchema: z
       .object({
@@ -120,7 +120,7 @@ export const I3SPointCloudStoreSchema = z
   .passthrough();
 
 /** Zod schema for an I3S 2.x Point Cloud scene-layer document. */
-export const I3SPointCloudSceneLayerSchema = z
+const I3SPointCloudSceneLayerBaseSchema = z
   .object({
     id: z.number().int().nonnegative(),
     href: z.string().optional(),
@@ -141,17 +141,29 @@ export const I3SPointCloudSceneLayerSchema = z
     attributeStorageInfo: z.array(z.record(z.string(), z.unknown())).optional(),
     attributeInfo: z.array(z.record(z.string(), z.unknown())).optional()
   })
-  .passthrough()
-  .superRefine((layer, context) => {
-    const nodesPerPage = layer.nodePages?.nodesPerPage || layer.store.index?.nodePerIndexBlock;
-    if (!nodesPerPage) {
-      context.addIssue({
-        code: 'custom',
-        path: ['nodePages'],
-        message: 'Point Cloud layers must declare nodesPerPage or store.index.nodePerIndexBlock'
-      });
-    }
-  });
+  .passthrough();
+
+const I3SPointCloudNodePagesRequirementSchema = z.union([
+  z
+    .object({
+      nodePages: z.object({nodesPerPage: z.number().int().positive().max(4096)}).passthrough()
+    })
+    .passthrough(),
+  z
+    .object({
+      store: z
+        .object({
+          index: z.object({nodePerIndexBlock: z.number().int().positive().max(4096)}).passthrough()
+        })
+        .passthrough()
+    })
+    .passthrough()
+]);
+
+/** Zod schema for an I3S 2.x Point Cloud scene-layer document. */
+export const I3SPointCloudSceneLayerSchema = I3SPointCloudSceneLayerBaseSchema.and(
+  I3SPointCloudNodePagesRequirementSchema
+);
 
 /** Zod schema for raw I3S 3D Object and Integrated Mesh scene-layer metadata. */
 export const I3SSceneLayerSchema = z

--- a/modules/i3s/src/index.ts
+++ b/modules/i3s/src/index.ts
@@ -46,6 +46,12 @@ export type {
   Store
 } from './types';
 export type {I3SLoaderOptions} from './i3s-loader';
+export {
+  I3SPointCloudNodePageSchema,
+  I3SPointCloudNodeSchema,
+  I3SPointCloudSceneLayerSchema,
+  I3SPointCloudStoreSchema
+} from './i3s-zod-schema';
 
 export {COORDINATE_SYSTEM} from './lib/parsers/constants';
 export {

--- a/modules/i3s/src/unbundled.ts
+++ b/modules/i3s/src/unbundled.ts
@@ -3,6 +3,12 @@
 // Copyright vis.gl contributors
 
 export type {I3SLoaderOptions} from './i3s-loader';
+export {
+  I3SPointCloudNodePageSchema,
+  I3SPointCloudNodeSchema,
+  I3SPointCloudSceneLayerSchema,
+  I3SPointCloudStoreSchema
+} from './i3s-zod-schema';
 export {I3SLoader} from './i3s-loader';
 export {SLPKLoader} from './i3s-slpk-loader';
 export type {SLPKSourceInput} from './i3s-slpk-source';

--- a/modules/i3s/test/data/conformance/i3s-2.1-point-cloud.json
+++ b/modules/i3s/test/data/conformance/i3s-2.1-point-cloud.json
@@ -1,0 +1,27 @@
+{
+  "id": 0,
+  "layerType": "PointCloud",
+  "version": "2.1",
+  "capabilities": ["View"],
+  "disablePopup": false,
+  "spatialReference": {"wkid": 4326},
+  "store": {
+    "profile": "pointcloud",
+    "version": "2.1",
+    "index": {"nodePerIndexBlock": 64},
+    "defaultGeometrySchema": {
+      "geometryType": "points",
+      "topology": "PerAttributeArray",
+      "encoding": "lepcc-xyz"
+    }
+  },
+  "nodePages": {
+    "rootIndex": 0,
+    "lodSelectionMetricType": "density-threshold"
+  },
+  "attributeStorageInfo": [
+    {"key": "rgb", "name": "rgb", "encoding": "lepcc-rgb", "resource": 0},
+    {"key": "intensity", "name": "intensity", "encoding": "lepcc-intensity", "resource": 0}
+  ],
+  "producerExtension": {"fixture": true}
+}

--- a/modules/i3s/test/i3s-conformance.spec.ts
+++ b/modules/i3s/test/i3s-conformance.spec.ts
@@ -4,7 +4,7 @@
 
 import {fetchFile, parse} from '@loaders.gl/core';
 import {I3SNodePageLoader} from '@loaders.gl/i3s';
-import {I3SSceneLayerSchema} from '@loaders.gl/i3s/i3s-zod-schema';
+import {I3SPointCloudSceneLayerSchema, I3SSceneLayerSchema} from '@loaders.gl/i3s/i3s-zod-schema';
 import {describe, expect, it} from 'vitest';
 import {parseSLPKArchive} from '../src/lib/parsers/parse-slpk/parse-slpk';
 import {parseI3STileAttribute} from '../src/lib/parsers/parse-i3s-attribute';
@@ -18,22 +18,32 @@ const SCENE_LAYER_FIXTURES = [
   {
     name: 'I3S 1.6 3D Object',
     url: '@loaders.gl/i3s/test/data/SanFrancisco_Bldgs/SceneServer/layers/0',
-    expectedVersion: '1.6'
+    expectedVersion: '1.6',
+    expectedLayerType: '3DObject'
   },
   {
     name: 'I3S 1.8 3D Object',
     url: '@loaders.gl/i3s/test/data/conformance/i3s-1.8-3d-object.json',
-    expectedVersion: '1.8'
+    expectedVersion: '1.8',
+    expectedLayerType: '3DObject'
   },
   {
     name: 'I3S 1.9 3D Object',
     url: '@loaders.gl/i3s/test/data/conformance/i3s-1.9-3d-object.json',
-    expectedVersion: '1.9'
+    expectedVersion: '1.9',
+    expectedLayerType: '3DObject'
   },
   {
     name: 'I3S 1.10 3D Object with forward fields',
     url: '@loaders.gl/i3s/test/data/conformance/i3s-1.10-3d-object.json',
-    expectedVersion: '1.10'
+    expectedVersion: '1.10',
+    expectedLayerType: '3DObject'
+  },
+  {
+    name: 'I3S 2.1 Point Cloud',
+    url: '@loaders.gl/i3s/test/data/conformance/i3s-2.1-point-cloud.json',
+    expectedVersion: '2.1',
+    expectedLayerType: 'PointCloud'
   }
 ] as const;
 
@@ -41,9 +51,12 @@ describe('I3S conformance fixtures', () => {
   it.each(SCENE_LAYER_FIXTURES)('accepts $name scene-layer metadata', async fixture => {
     const response = await fetchFile(fixture.url);
     const document = await response.json();
-    const sceneLayer = I3SSceneLayerSchema.parse(document);
+    const sceneLayer =
+      fixture.expectedLayerType === 'PointCloud'
+        ? I3SPointCloudSceneLayerSchema.parse(document)
+        : I3SSceneLayerSchema.parse(document);
 
-    expect(sceneLayer.layerType).toBe('3DObject');
+    expect(sceneLayer.layerType).toBe(fixture.expectedLayerType || '3DObject');
     expect(sceneLayer.store.version).toBe(fixture.expectedVersion);
   });
 
@@ -55,6 +68,23 @@ describe('I3S conformance fixtures', () => {
 
     expect(nodePage.nodes).toHaveLength(16);
     expect(nodePage.nodes[2].lodThreshold).toBe(870638.071285568);
+  });
+
+  it('rejects an incomplete Point Cloud profile without an index block size', () => {
+    expect(() =>
+      I3SPointCloudSceneLayerSchema.parse({
+        id: 0,
+        layerType: 'PointCloud',
+        version: '2.1',
+        capabilities: ['View'],
+        disablePopup: false,
+        store: {
+          profile: 'pointcloud',
+          version: '2.1',
+          defaultGeometrySchema: {geometryType: 'points'}
+        }
+      })
+    ).toThrow(/nodesPerPage|nodePerIndexBlock/);
   });
 
   it('preserves UInt64 values through Number.MAX_SAFE_INTEGER', () => {

--- a/modules/i3s/test/i3s-conformance.spec.ts
+++ b/modules/i3s/test/i3s-conformance.spec.ts
@@ -84,7 +84,25 @@ describe('I3S conformance fixtures', () => {
           defaultGeometrySchema: {geometryType: 'points'}
         }
       })
-    ).toThrow(/nodesPerPage|nodePerIndexBlock/);
+    ).toThrow(/Invalid input|nodesPerPage|nodePerIndexBlock/);
+  });
+
+  it('rejects a Point Cloud layer with a non-Point Cloud store profile', () => {
+    expect(() =>
+      I3SPointCloudSceneLayerSchema.parse({
+        id: 0,
+        layerType: 'PointCloud',
+        version: '2.1',
+        capabilities: ['View'],
+        disablePopup: false,
+        store: {
+          profile: 'meshpyramids',
+          version: '2.1',
+          index: {nodePerIndexBlock: 64},
+          defaultGeometrySchema: {geometryType: 'points'}
+        }
+      })
+    ).toThrow(/profile/);
   });
 
   it('preserves UInt64 values through Number.MAX_SAFE_INTEGER', () => {

--- a/modules/i3s/test/i3s-point-cloud-source.browser.spec.ts
+++ b/modules/i3s/test/i3s-point-cloud-source.browser.spec.ts
@@ -88,6 +88,7 @@ test('I3SPointCloudSource traverses node pages and decodes content', async () =>
   expect(root.id).toBe('0');
   expect(root.lodSelectionMetricType).toBe('density-threshold');
   expect(root.boundingVolume.wrapsDateline).toBe(true);
+  expect(root.boundingVolume.coversFullLongitude).toBe(false);
   expect(root.boundingVolume.cartographicBounds[1][0]).toBeLessThan(0.001);
   expect((await source.getChildren(root)).map(tile => tile.id)).toEqual(['1']);
   const content = await source.loadTileContent(root);

--- a/modules/i3s/test/i3s-point-cloud-source.browser.spec.ts
+++ b/modules/i3s/test/i3s-point-cloud-source.browser.spec.ts
@@ -50,7 +50,11 @@ test('I3SPointCloudSource traverses node pages and decodes content', async () =>
           nodes: [
             {
               resourceId: 0,
-              obb: {center: [0, 0, 0], halfSize: [10, 10, 10], quaternion: [0, 0, 0, 1]},
+              obb: {
+                center: [179.999, 0, 0],
+                halfSize: [20000, 20000, 10],
+                quaternion: [0, 0, 0, 1]
+              },
               vertexCount: 106,
               firstChild: 1,
               childCount: 1,
@@ -83,6 +87,7 @@ test('I3SPointCloudSource traverses node pages and decodes content', async () =>
   const root = await source.getRootTile();
   expect(root.id).toBe('0');
   expect(root.lodSelectionMetricType).toBe('density-threshold');
+  expect(root.boundingVolume.wrapsDateline).toBe(true);
   expect(root.boundingVolume.cartographicBounds[1][0]).toBeLessThan(0.001);
   expect((await source.getChildren(root)).map(tile => tile.id)).toEqual(['1']);
   const content = await source.loadTileContent(root);

--- a/modules/i3s/test/i3s-zod-schema.spec.ts
+++ b/modules/i3s/test/i3s-zod-schema.spec.ts
@@ -4,7 +4,11 @@
 
 import {parse} from '@loaders.gl/core';
 import {I3SLoader, I3SNodePageLoader} from '@loaders.gl/i3s';
-import {I3SNodePageSchema, I3SSceneLayerSchema} from '@loaders.gl/i3s/i3s-zod-schema';
+import {
+  I3SNodePageSchema,
+  I3SPointCloudSceneLayerSchema,
+  I3SSceneLayerSchema
+} from '@loaders.gl/i3s/i3s-zod-schema';
 import {describe, expect, it} from 'vitest';
 import {z} from 'zod';
 
@@ -83,6 +87,12 @@ describe('I3S metadata schemas', () => {
       expect.arrayContaining(['id', 'layerType', 'version', 'capabilities', 'store'])
     );
     expect(nodePageJsonSchema.required).toContain('nodes');
+  });
+
+  it('represents the Point Cloud index alternative in JSON Schema', () => {
+    const pointCloudJsonSchema = z.toJSONSchema(I3SPointCloudSceneLayerSchema, {target: 'draft-7'});
+    expect(JSON.stringify(pointCloudJsonSchema)).toContain('nodePerIndexBlock');
+    expect(JSON.stringify(pointCloudJsonSchema)).toContain('anyOf');
   });
 });
 

--- a/modules/tiles/src/point-cloud/point-cloud-tileset.ts
+++ b/modules/tiles/src/point-cloud/point-cloud-tileset.ts
@@ -616,9 +616,11 @@ export class PointCloudTileset {
     }
 
     const [minBounds, maxBounds] = boundingVolume.cartographicBounds;
-    const longitudeSpan = boundingVolume.wrapsDateline
-      ? 360 - Math.abs(maxBounds[0] - minBounds[0])
-      : Math.abs(maxBounds[0] - minBounds[0]);
+    const longitudeSpan = boundingVolume.coversFullLongitude
+      ? 360
+      : boundingVolume.wrapsDateline
+        ? 360 - Math.abs(maxBounds[0] - minBounds[0])
+        : Math.abs(maxBounds[0] - minBounds[0]);
     const normalizedLongitudeSpan = Math.max(longitudeSpan, 0.000001);
     return Math.max(1, Math.round(Math.log2(360 / normalizedLongitudeSpan)));
   }
@@ -642,23 +644,42 @@ export class PointCloudTileset {
    */
   private getBoundingVolumeCorners(boundingVolume: PointCloudBoundingVolume): number[][] {
     const [minBounds, maxBounds] = boundingVolume.cartographicBounds;
-    const longitudeIntervals = boundingVolume.wrapsDateline
-      ? [
-          [minBounds[0], 180],
-          [-180, maxBounds[0]]
-        ]
-      : [[minBounds[0], maxBounds[0]]];
+    const longitudeIntervals = boundingVolume.coversFullLongitude
+      ? [[-180, 180]]
+      : boundingVolume.wrapsDateline
+        ? [
+            [minBounds[0], 180],
+            [-180, maxBounds[0]]
+          ]
+        : [[minBounds[0], maxBounds[0]]];
     const corners: number[][] = [];
+    const wrappedLongitudeSpan = 360 - Math.abs(maxBounds[0] - minBounds[0]);
+    const longitudeReference = minBounds[0] + wrappedLongitudeSpan / 2;
     for (const [minimumLongitude, maximumLongitude] of longitudeIntervals) {
+      const normalizeLongitude = (longitude: number) => {
+        if (!boundingVolume.wrapsDateline) {
+          return longitude;
+        }
+        let normalizedLongitude = longitude;
+        while (normalizedLongitude - longitudeReference > 180) {
+          normalizedLongitude -= 360;
+        }
+        while (normalizedLongitude - longitudeReference < -180) {
+          normalizedLongitude += 360;
+        }
+        return normalizedLongitude;
+      };
+      const unwrappedMinimumLongitude = normalizeLongitude(minimumLongitude);
+      const unwrappedMaximumLongitude = normalizeLongitude(maximumLongitude);
       corners.push(
-        [minimumLongitude, minBounds[1], minBounds[2] || 0],
-        [minimumLongitude, minBounds[1], maxBounds[2] || 0],
-        [minimumLongitude, maxBounds[1], minBounds[2] || 0],
-        [minimumLongitude, maxBounds[1], maxBounds[2] || 0],
-        [maximumLongitude, minBounds[1], minBounds[2] || 0],
-        [maximumLongitude, minBounds[1], maxBounds[2] || 0],
-        [maximumLongitude, maxBounds[1], minBounds[2] || 0],
-        [maximumLongitude, maxBounds[1], maxBounds[2] || 0]
+        [unwrappedMinimumLongitude, minBounds[1], minBounds[2] || 0],
+        [unwrappedMinimumLongitude, minBounds[1], maxBounds[2] || 0],
+        [unwrappedMinimumLongitude, maxBounds[1], minBounds[2] || 0],
+        [unwrappedMinimumLongitude, maxBounds[1], maxBounds[2] || 0],
+        [unwrappedMaximumLongitude, minBounds[1], minBounds[2] || 0],
+        [unwrappedMaximumLongitude, minBounds[1], maxBounds[2] || 0],
+        [unwrappedMaximumLongitude, maxBounds[1], minBounds[2] || 0],
+        [unwrappedMaximumLongitude, maxBounds[1], maxBounds[2] || 0]
       );
     }
     return corners;

--- a/modules/tiles/src/point-cloud/point-cloud-tileset.ts
+++ b/modules/tiles/src/point-cloud/point-cloud-tileset.ts
@@ -616,8 +616,11 @@ export class PointCloudTileset {
     }
 
     const [minBounds, maxBounds] = boundingVolume.cartographicBounds;
-    const longitudeSpan = Math.max(Math.abs(maxBounds[0] - minBounds[0]), 0.000001);
-    return Math.max(1, Math.round(Math.log2(360 / longitudeSpan)));
+    const longitudeSpan = boundingVolume.wrapsDateline
+      ? 360 - Math.abs(maxBounds[0] - minBounds[0])
+      : Math.abs(maxBounds[0] - minBounds[0]);
+    const normalizedLongitudeSpan = Math.max(longitudeSpan, 0.000001);
+    return Math.max(1, Math.round(Math.log2(360 / normalizedLongitudeSpan)));
   }
 
   private haveSameIds(idsA: Set<string>, idsB: Set<string>): boolean {
@@ -639,16 +642,26 @@ export class PointCloudTileset {
    */
   private getBoundingVolumeCorners(boundingVolume: PointCloudBoundingVolume): number[][] {
     const [minBounds, maxBounds] = boundingVolume.cartographicBounds;
-    return [
-      [minBounds[0], minBounds[1], minBounds[2] || 0],
-      [minBounds[0], minBounds[1], maxBounds[2] || 0],
-      [minBounds[0], maxBounds[1], minBounds[2] || 0],
-      [minBounds[0], maxBounds[1], maxBounds[2] || 0],
-      [maxBounds[0], minBounds[1], minBounds[2] || 0],
-      [maxBounds[0], minBounds[1], maxBounds[2] || 0],
-      [maxBounds[0], maxBounds[1], minBounds[2] || 0],
-      [maxBounds[0], maxBounds[1], maxBounds[2] || 0]
-    ];
+    const longitudeIntervals = boundingVolume.wrapsDateline
+      ? [
+          [minBounds[0], 180],
+          [-180, maxBounds[0]]
+        ]
+      : [[minBounds[0], maxBounds[0]]];
+    const corners: number[][] = [];
+    for (const [minimumLongitude, maximumLongitude] of longitudeIntervals) {
+      corners.push(
+        [minimumLongitude, minBounds[1], minBounds[2] || 0],
+        [minimumLongitude, minBounds[1], maxBounds[2] || 0],
+        [minimumLongitude, maxBounds[1], minBounds[2] || 0],
+        [minimumLongitude, maxBounds[1], maxBounds[2] || 0],
+        [maximumLongitude, minBounds[1], minBounds[2] || 0],
+        [maximumLongitude, minBounds[1], maxBounds[2] || 0],
+        [maximumLongitude, maxBounds[1], minBounds[2] || 0],
+        [maximumLongitude, maxBounds[1], maxBounds[2] || 0]
+      );
+    }
+    return corners;
   }
 
   /**

--- a/modules/tiles/src/point-cloud/types.ts
+++ b/modules/tiles/src/point-cloud/types.ts
@@ -43,6 +43,8 @@ export type PointCloudBoundingVolume = {
   cartographicBounds: [min: number[], max: number[]];
   /** True when the longitude interval crosses the antimeridian. */
   wrapsDateline?: boolean;
+  /** True when the longitude interval covers the full globe. */
+  coversFullLongitude?: boolean;
   center: number[];
   radius: number;
 };

--- a/modules/tiles/src/point-cloud/types.ts
+++ b/modules/tiles/src/point-cloud/types.ts
@@ -41,6 +41,8 @@ export type PointCloudTileContent = {
  */
 export type PointCloudBoundingVolume = {
   cartographicBounds: [min: number[], max: number[]];
+  /** True when the longitude interval crosses the antimeridian. */
+  wrapsDateline?: boolean;
   center: number[];
   radius: number;
 };

--- a/modules/tiles/test/point-cloud/point-cloud-dateline.browser.spec.ts
+++ b/modules/tiles/test/point-cloud/point-cloud-dateline.browser.spec.ts
@@ -1,0 +1,23 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
+import {PointCloudTileset} from '@loaders.gl/tiles';
+import {expect, test} from 'vitest';
+
+test('PointCloudTileset splits dateline-crossing bounds for projection', () => {
+  const tileset = Object.create(PointCloudTileset.prototype) as PointCloudTileset;
+  const corners = (tileset as any).getBoundingVolumeCorners({
+    cartographicBounds: [
+      [179.75, -1, 0],
+      [-179.75, 1, 100]
+    ],
+    wrapsDateline: true,
+    center: [180, 0, 50],
+    radius: 100
+  });
+
+  expect(corners).toHaveLength(16);
+  expect(corners.some((corner: number[]) => corner[0] === 180)).toBe(true);
+  expect(corners.some((corner: number[]) => corner[0] === -180)).toBe(true);
+});

--- a/modules/tiles/test/point-cloud/point-cloud-dateline.browser.spec.ts
+++ b/modules/tiles/test/point-cloud/point-cloud-dateline.browser.spec.ts
@@ -19,5 +19,21 @@ test('PointCloudTileset splits dateline-crossing bounds for projection', () => {
 
   expect(corners).toHaveLength(16);
   expect(corners.some((corner: number[]) => corner[0] === 180)).toBe(true);
-  expect(corners.some((corner: number[]) => corner[0] === -180)).toBe(true);
+  expect(corners.some((corner: number[]) => corner[0] === 180.25)).toBe(true);
+  expect(corners.some((corner: number[]) => corner[0] === -180)).toBe(false);
+});
+
+test('PointCloudTileset preserves full-globe longitude bounds', () => {
+  const tileset = Object.create(PointCloudTileset.prototype) as PointCloudTileset;
+  const zoom = (tileset as any).estimateZoom({
+    cartographicBounds: [
+      [-170, -90, 0],
+      [-170, 90, 100]
+    ],
+    coversFullLongitude: true,
+    center: [10, 0, 50],
+    radius: 100
+  });
+
+  expect(zoom).toBe(1);
 });


### PR DESCRIPTION
Goals

- Implement I3S tranche 6c for precision and antimeridian-safe Point Cloud bounds.
- Implement tranches 7a and 7b with profile-aware schemas and cross-profile conformance fixtures.

Changes

- Normalize Point Cloud longitudes and mark dateline-crossing bounds explicitly.
- Split wrapped longitude intervals when projecting Point Cloud bounds and calculate wrapped zoom spans correctly.
- Add I3S Point Cloud store and scene-layer schemas with required index-block validation.
- Validate Point Cloud metadata through the profile-specific schema in I3SPointCloudSource.
- Generate and export a Point Cloud scene-layer JSON Schema.
- Add an I3S 2.1 Point Cloud conformance fixture covering metadata, LOD, LEPCC attributes, and extensions.
- Add a dateline traversal regression test and malformed-profile validation.
- Update the roadmap to mark 6c, 7a, and 7b complete; 6a, 6b, and 7c remain open.

Validation

- yarn build-modules
- yarn test-node (360 passed, 6 skipped)
- Focused Chromium tests: 19 passed
- yarn lint fix