### PR TITLE
fix(deck-layers): align source integration with latest APIs

### DIFF
--- a/modules/deck-layers/README.md
+++ b/modules/deck-layers/README.md
@@ -85,8 +85,10 @@ preconstructed runtime sources remain supported.
 
 `RasterSourceLayer` requests the active viewport through `RasterSet` and renders typed samples with
 `BitmapLayer`. It supports EPSG:4326 and EPSG:3857 bounds, RGB band selection, sampled 2nd/98th
-percentile scaling, transparent no-data pixels, and a blue-to-yellow single-band ramp. Rasters
-without geospatial bounds use a full pixel-coordinate plane for `OrthographicView`.
+percentile scaling, transparent no-data pixels (including metadata-level no-data values), and a
+blue-to-yellow single-band ramp. CRS identifiers may be supplied as strings or authority-coded
+PROJJSON definitions. Rasters without geospatial bounds use a full pixel-coordinate plane for
+`OrthographicView`.
 
 Use `rasterParameters` for source-specific dimensions, `getRasterParameters` for custom request or
 projection logic, and `colorizeRaster` for application color maps.

--- a/modules/deck-layers/src/raster-source-layer.ts
+++ b/modules/deck-layers/src/raster-source-layer.ts
@@ -29,6 +29,7 @@ import {RasterSet, type RasterSetRequest} from '@loaders.gl/tiles';
 import {projectWGS84ToPseudoMercator} from './image-source-layer/utils';
 import {
   finalizeOwnedSource,
+  getCoordinateReferenceSystemIdentifier,
   resolveVisualSource,
   type ResolvedVisualSource
 } from './source-layer-utils';
@@ -357,9 +358,13 @@ export function createDefaultRasterRenderResult(
   parameters: GetRasterParameters,
   metadata: RasterSourceMetadata
 ): RasterRenderResult {
+  const rasterWithMetadataNoData =
+    raster.noData === undefined && metadata.noData !== undefined
+      ? {...raster, noData: metadata.noData}
+      : raster;
   if (!raster.boundingBox && !metadata.boundingBox && !metadata.crs) {
     return {
-      image: colorizeRasterData(raster),
+      image: colorizeRasterData(rasterWithMetadataNoData),
       bounds: [0, metadata.height, metadata.width, 0],
       coordinateSystem: COORDINATE_SYSTEM.CARTESIAN
     };
@@ -367,18 +372,20 @@ export function createDefaultRasterRenderResult(
   const rasterBounds = raster.boundingBox || parameters.viewport.bounds || metadata.boundingBox;
   if (!rasterBounds) {
     return {
-      image: colorizeRasterData(raster),
+      image: colorizeRasterData(rasterWithMetadataNoData),
       bounds: [0, raster.height, raster.width, 0],
       coordinateSystem: COORDINATE_SYSTEM.CARTESIAN
     };
   }
-  const rasterCoordinateReferenceSystem = getRasterCRSIdentifier(raster.crs || metadata.crs);
+  const rasterCoordinateReferenceSystem = getCoordinateReferenceSystemIdentifier(
+    raster.crs || metadata.crs
+  );
   const bounds =
     rasterCoordinateReferenceSystem === 'EPSG:3857'
       ? unprojectPseudoMercatorBounds(rasterBounds)
       : flattenBounds(rasterBounds);
   return {
-    image: colorizeRasterData(raster),
+    image: colorizeRasterData(rasterWithMetadataNoData),
     bounds,
     coordinateSystem: COORDINATE_SYSTEM.LNGLAT
   };
@@ -421,7 +428,7 @@ export function createRasterViewport(
     Math.min(maxTextureSize, Math.round(viewport.height * devicePixelRatio))
   );
   const viewportBounds = viewport.getBounds?.();
-  const coordinateReferenceSystem = getRasterCRSIdentifier(metadata.crs);
+  const coordinateReferenceSystem = getCoordinateReferenceSystemIdentifier(metadata.crs);
   let bounds: RasterBoundingBox | undefined;
   if (!metadata.boundingBox && !metadata.crs) {
     bounds = [
@@ -441,7 +448,9 @@ export function createRasterViewport(
       !allowCustomProjection
     ) {
       throw new Error(
-        `RasterSourceLayer cannot infer viewport reprojection for ${metadata.crs}. Provide getRasterParameters().`
+        `RasterSourceLayer cannot infer viewport reprojection for ${
+          coordinateReferenceSystem || 'the declared CRS'
+        }. Provide getRasterParameters().`
       );
     }
   }
@@ -464,25 +473,6 @@ export function createRasterViewport(
     unprojectPosition: position =>
       viewport.unprojectPosition(position as any) as [number, number, number]
   };
-}
-
-/** Extracts an authority code from a serialized or PROJJSON CRS definition. */
-function getRasterCRSIdentifier(crs: RasterSourceMetadata['crs']): string | undefined {
-  if (typeof crs === 'string') {
-    return crs;
-  }
-  if (!crs || typeof crs !== 'object') {
-    return undefined;
-  }
-  const identifier = (crs as {id?: {authority?: string; code?: string | number}}).id;
-  if (identifier?.authority && identifier.code !== undefined) {
-    return `${identifier.authority}:${identifier.code}`;
-  }
-  const identifiers = (crs as {ids?: Array<{authority?: string; code?: string | number}>}).ids;
-  const firstIdentifier = identifiers?.[0];
-  return firstIdentifier?.authority && firstIdentifier.code !== undefined
-    ? `${firstIdentifier.authority}:${firstIdentifier.code}`
-    : undefined;
 }
 
 function writeSingleBand(

--- a/modules/deck-layers/src/source-layer-utils.ts
+++ b/modules/deck-layers/src/source-layer-utils.ts
@@ -203,17 +203,41 @@ export function getFirstSourceLayerName(metadata: unknown): string | null {
 /** Returns a CRS advertised by the selected layer or source metadata. */
 export function getSourceCoordinateReferenceSystem(metadata: unknown): string | undefined {
   const firstLayer = findFirstLeaf(getMetadataLayers(metadata)) as
-    | {crs?: string[]; srs?: string[]}
+    | {crs?: unknown[]; srs?: unknown[]}
     | undefined;
-  const coordinateReferenceSystems = firstLayer?.crs || firstLayer?.srs;
-  const preferredCoordinateReferenceSystem = coordinateReferenceSystems?.find(value =>
+  const coordinateReferenceSystems = firstLayer?.crs?.length ? firstLayer.crs : firstLayer?.srs;
+  const normalizedCoordinateReferenceSystems = coordinateReferenceSystems
+    ?.map(getCoordinateReferenceSystemIdentifier)
+    .filter((value): value is string => Boolean(value));
+  const preferredCoordinateReferenceSystem = normalizedCoordinateReferenceSystems?.find(value =>
     /EPSG:(3857|4326)|CRS:84/i.test(value)
   );
   return (
     preferredCoordinateReferenceSystem ||
-    coordinateReferenceSystems?.[0] ||
+    normalizedCoordinateReferenceSystems?.[0] ||
     getMetadataCrs(metadata)
   );
+}
+
+/** Converts a CRS identifier or PROJJSON authority object into a stable identifier. */
+export function getCoordinateReferenceSystemIdentifier(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const coordinateReferenceSystem = value as {
+    id?: {authority?: string; code?: string | number};
+    ids?: Array<{authority?: string; code?: string | number}>;
+  };
+  const identifier = [coordinateReferenceSystem.id, ...(coordinateReferenceSystem.ids || [])].find(
+    candidate => candidate?.authority && candidate.code !== undefined
+  );
+  return identifier?.authority && identifier.code !== undefined
+    ? `${identifier.authority}:${identifier.code}`
+    : undefined;
 }
 
 /** Creates a common view-state hint from normalized metadata and source view state. */
@@ -384,6 +408,7 @@ function getFirstLeafName(layer: unknown): string | null {
         return childName;
       }
     }
+    return null;
   }
   return typedLayer.name || null;
 }
@@ -406,15 +431,32 @@ function findFirstLeaf(layers: unknown[]): unknown | undefined {
 function getMetadataBounds(metadata: unknown): [[number, number], [number, number]] | undefined {
   const typedMetadata = metadata as {
     boundingBox?: unknown;
-    layers?: Array<{boundingBox?: unknown}>;
-    layer?: {boundingBox?: unknown; layers?: Array<{boundingBox?: unknown}>};
+    layers?: unknown[];
+    layer?: unknown;
   } | null;
   return (
     normalizeBounds(typedMetadata?.boundingBox) ||
-    normalizeBounds(typedMetadata?.layers?.[0]?.boundingBox) ||
-    normalizeBounds(typedMetadata?.layer?.boundingBox) ||
-    normalizeBounds(typedMetadata?.layer?.layers?.[0]?.boundingBox)
+    findFirstLayerBounds(typedMetadata?.layers) ||
+    findFirstLayerBounds(typedMetadata?.layer ? [typedMetadata.layer] : undefined)
   );
+}
+
+/** Finds the first available layer bounds in the same depth-first order as layer selection. */
+function findFirstLayerBounds(
+  layers: unknown[] | undefined
+): [[number, number], [number, number]] | undefined {
+  for (const layer of layers || []) {
+    const typedLayer = layer as {boundingBox?: unknown; layers?: unknown[]};
+    const childBounds = findFirstLayerBounds(typedLayer.layers);
+    if (childBounds) {
+      return childBounds;
+    }
+    const bounds = normalizeBounds(typedLayer.boundingBox);
+    if (bounds) {
+      return bounds;
+    }
+  }
+  return undefined;
 }
 
 function normalizeBounds(value: unknown): [[number, number], [number, number]] | undefined {
@@ -437,8 +479,8 @@ function normalizeBounds(value: unknown): [[number, number], [number, number]] |
 }
 
 function getMetadataCrs(metadata: unknown): string | undefined {
-  const typedMetadata = metadata as {crs?: string} | null;
-  return typedMetadata?.crs;
+  const typedMetadata = metadata as {crs?: unknown} | null;
+  return getCoordinateReferenceSystemIdentifier(typedMetadata?.crs);
 }
 
 function estimateZoom(bounds: [[number, number], [number, number]]): number {

--- a/modules/deck-layers/src/source-layer-utils.ts
+++ b/modules/deck-layers/src/source-layer-utils.ts
@@ -436,24 +436,30 @@ function getMetadataBounds(metadata: unknown): [[number, number], [number, numbe
   } | null;
   return (
     normalizeBounds(typedMetadata?.boundingBox) ||
-    findFirstLayerBounds(typedMetadata?.layers) ||
-    findFirstLayerBounds(typedMetadata?.layer ? [typedMetadata.layer] : undefined)
+    getFirstNamedLeafBounds(typedMetadata?.layers) ||
+    getFirstNamedLeafBounds(typedMetadata?.layer ? [typedMetadata.layer] : undefined)
   );
 }
 
-/** Finds the first available layer bounds in the same depth-first order as layer selection. */
-function findFirstLayerBounds(
+/** Finds bounds on the first named leaf using the same traversal as automatic layer selection. */
+function getFirstNamedLeafBounds(
   layers: unknown[] | undefined
 ): [[number, number], [number, number]] | undefined {
+  const firstNamedLeaf = findFirstNamedLeaf(layers);
+  return normalizeBounds((firstNamedLeaf as {boundingBox?: unknown} | undefined)?.boundingBox);
+}
+
+/** Finds the first named leaf in depth-first order, including leaves without bounds. */
+function findFirstNamedLeaf(layers: unknown[] | undefined): unknown | undefined {
   for (const layer of layers || []) {
-    const typedLayer = layer as {boundingBox?: unknown; layers?: unknown[]};
-    const childBounds = findFirstLayerBounds(typedLayer.layers);
-    if (childBounds) {
-      return childBounds;
-    }
-    const bounds = normalizeBounds(typedLayer.boundingBox);
-    if (bounds) {
-      return bounds;
+    const typedLayer = layer as {name?: unknown; layers?: unknown[]};
+    if (typedLayer.layers?.length) {
+      const childLayer = findFirstNamedLeaf(typedLayer.layers);
+      if (childLayer) {
+        return childLayer;
+      }
+    } else if (typeof typedLayer.name === 'string') {
+      return layer;
     }
   }
   return undefined;

--- a/modules/deck-layers/test/raster-source-layer.spec.ts
+++ b/modules/deck-layers/test/raster-source-layer.spec.ts
@@ -104,6 +104,16 @@ describe('raster viewport and placement', () => {
     expect(viewport.width).toBeGreaterThanOrEqual(400);
   });
 
+  test('accepts an authority-coded CRS object from current RasterSource metadata', () => {
+    const metadata = {
+      ...GEOGRAPHIC_METADATA,
+      crs: {id: {authority: 'EPSG', code: 4326}}
+    } as RasterSourceMetadata;
+    const viewport = createRasterViewport(createViewport([-10, -5, 20, 15]), metadata);
+
+    expect(viewport.crs).toBe('EPSG:4326');
+  });
+
   test('projects viewport bounds for EPSG:3857', () => {
     const viewport = createRasterViewport(
       createViewport([0, 0, 1, 1]),
@@ -178,5 +188,18 @@ describe('raster viewport and placement', () => {
     expect(result.image).toBe(customImage);
     expect(result.bounds).toEqual([-10, -5, 20, 15]);
     expect(result.coordinateSystem).toBe(COORDINATE_SYSTEM.LNGLAT);
+  });
+
+  test('uses metadata no-data values when a response omits the repeated field', () => {
+    const raster = createRaster(new Float32Array([0, 10, 20, 30]));
+    const metadata = {...GEOGRAPHIC_METADATA, noData: 10};
+    const result = createDefaultRasterRenderResult(
+      raster,
+      {viewport: createRasterViewport(createViewport([-10, -5, 20, 15]), metadata), bands: [0]},
+      metadata
+    );
+
+    const image = result.image as {data: Uint8ClampedArray};
+    expect(Array.from(image.data.slice(4, 8))).toEqual([0, 0, 0, 0]);
   });
 });

--- a/modules/deck-layers/test/source-layer.browser.spec.ts
+++ b/modules/deck-layers/test/source-layer.browser.spec.ts
@@ -4,6 +4,7 @@
 
 import {expect, test} from 'vitest';
 import {SourceLayer} from '@loaders.gl/deck-layers';
+import {createSourceViewState, getSourceCoordinateReferenceSystem} from '../src/source-layer-utils';
 
 const TEST_3D_LOADER = {
   id: '3d-tiles',
@@ -42,4 +43,60 @@ test('SourceLayer preserves URL inputs for parser-backed 3D dispatch', () => {
   expect(childLayer.id).toBe('tiles-3d-tile-3d');
   expect(childLayer.props.data).toBe(tilesetUrl);
   expect(childLayer.props.loaders).toEqual([TEST_3D_LOADER]);
+});
+
+test('source metadata discovery follows the first leaf and supports PROJJSON CRS identifiers', async () => {
+  const metadata = {
+    layers: [
+      {
+        name: 'group',
+        layers: [
+          {title: 'unnamed group', layers: [{name: 'first-leaf', boundingBox: [-20, -10, 20, 10]}]},
+          {name: 'second-leaf', boundingBox: [0, 0, 1, 1]}
+        ]
+      }
+    ],
+    crs: {id: {authority: 'EPSG', code: 3857}}
+  };
+
+  const viewState = await createSourceViewState({}, metadata);
+
+  expect(getSourceCoordinateReferenceSystem(metadata)).toBe('EPSG:3857');
+  expect(viewState).toMatchObject({
+    bounds: [
+      [-20, -10],
+      [20, 10]
+    ],
+    longitude: 0,
+    latitude: 0,
+    crs: 'EPSG:3857'
+  });
+});
+
+test('SourceLayer keeps an explicitly empty layer selection', () => {
+  const layer = new SourceLayer({
+    id: 'explicit-empty-layers',
+    data: {
+      getMetadata: async () => ({layers: [{name: 'discovered'}]}),
+      getSchema: async () => ({fields: [], metadata: {}}),
+      getFeatures: async () => ({shape: 'geojson-table', type: 'FeatureCollection', features: []})
+    } as any,
+    layers: []
+  }) as any;
+
+  layer.initializeState();
+  layer.state = {
+    resolvedSource: {
+      source: layer.props.data,
+      sourceType: 'vector',
+      parserLoaders: [],
+      owned: false
+    },
+    metadata: {layers: [{name: 'discovered'}]},
+    resolvedLayers: [],
+    resolvedCoordinateReferenceSystem: undefined,
+    isResolving: false
+  };
+
+  expect(layer.renderLayers()[0].props.layers).toEqual([]);
 });

--- a/modules/deck-layers/test/source-layer.browser.spec.ts
+++ b/modules/deck-layers/test/source-layer.browser.spec.ts
@@ -51,8 +51,8 @@ test('source metadata discovery follows the first leaf and supports PROJJSON CRS
       {
         name: 'group',
         layers: [
-          {title: 'unnamed group', layers: [{name: 'first-leaf', boundingBox: [-20, -10, 20, 10]}]},
-          {name: 'second-leaf', boundingBox: [0, 0, 1, 1]}
+          {title: 'unnamed leaf', boundingBox: [-20, -10, 20, 10]},
+          {name: 'first-leaf', boundingBox: [0, 0, 1, 1]}
         ]
       }
     ],
@@ -64,11 +64,11 @@ test('source metadata discovery follows the first leaf and supports PROJJSON CRS
   expect(getSourceCoordinateReferenceSystem(metadata)).toBe('EPSG:3857');
   expect(viewState).toMatchObject({
     bounds: [
-      [-20, -10],
-      [20, 10]
+      [0, 0],
+      [1, 1]
     ],
-    longitude: 0,
-    latitude: 0,
+    longitude: 0.5,
+    latitude: 0.5,
     crs: 'EPSG:3857'
   });
 });


### PR DESCRIPTION
## Goals

- Keep unified SourceLayer metadata discovery aligned with the latest loaders.gl source contracts.
- Make raster rendering honor current CRS and no-data metadata without adding application glue.
- Preserve deterministic, upstreamable behavior with focused regression coverage.

## Changes

- Normalize authority-coded PROJJSON CRS definitions into shared source view hints and raster viewport/rendering paths.
- Make nested metadata bounds follow the same depth-first semantics as automatic first-leaf layer selection.
- Ensure named group layers are not selected when only a descendant leaf can be rendered.
- Apply metadata-level no-data values when raster responses omit the repeated value.
- Improve unsupported-CRS diagnostics and document the latest raster metadata behavior.
- Add browser tests covering nested metadata/CRS discovery, explicit empty layer selections, CRS objects, and metadata no-data transparency.

## Validation

- `yarn lint fix`
- `yarn test-audit` — 609 files, 0 Tape violations
- `node_modules/.bin/tspc --build modules/deck-layers/tsconfig.json --pretty false`
- `yarn test-node` — 361 passed, 6 skipped
- `yarn build-workers`
- `yarn test-headless` — 3,105 passed, 40 skipped

`yarn build` was attempted but the linked worktree build harness resolved `@loaders.gl/compression` to the primary checkout's empty `modules/compression/dist`; this is unrelated to the changed files and did not affect the targeted typecheck, worker build, or test suites.