### PR TITLE
fix(gis): reject unsafe CRS reprojection

### DIFF
--- a/docs/developer-guide/coordinate-reference-systems.md
+++ b/docs/developer-guide/coordinate-reference-systems.md
@@ -64,7 +64,7 @@ mean coordinate transformation.
 | GeoParquet 1.1 / 2.0 | Per-column PROJJSON, `null`, omitted default, and coordinate `epoch` | Original `geo` JSON is retained; compatible GeoArrow field metadata is added | None |
 | Shapefile | `.prj` WKT sidecar | `.prj` is returned by legacy output; Arrow metadata is partial | Opt-in through `gis.reproject` and `_targetCrs` |
 | FlatGeobuf | Header authority code and WKT | Header metadata is retained; Arrow CRS metadata is partial | Opt-in through `gis.reproject` and `_targetCrs` |
-| GeoPackage | Spatial reference system tables | Format metadata is available while geometry output metadata is partial | Opt-in through `gis.reproject` and `_targetCrs` |
+| GeoPackage | Spatial reference system tables, preferring extension WKT2 over fallback WKT1 | Source and scan metadata retain the table CRS; Arrow geometry fields report the native or transformed output CRS | Opt-in through `gis.reproject` and `_targetCrs` |
 | GeoJSON | Deprecated GeoJSON `crs` member when present; otherwise WGS84 semantics | Original legacy value is retained; recognized CRS84/EPSG:4326 values map to GeoArrow/GeoParquet metadata | None in the GeoJSON loader |
 | CSV WKT / WKB | Geometry values can contain EWKT/EWKB SRIDs, but CSV has no dataset CRS convention | Geometry-level SRID support is partial; no common table CRS descriptor | None |
 | GML | `srsName` on geometry/envelope elements | Parsed format data retains identifiers inconsistently across output shapes | Service/server dependent; no general client transform |

--- a/docs/developer-guide/coordinate-reference-systems.md
+++ b/docs/developer-guide/coordinate-reference-systems.md
@@ -83,6 +83,11 @@ mean coordinate transformation.
 | KML | Implicit WGS84 longitude/latitude/altitude | Coordinate values retained | None |
 | GPX / TCX | Implicit WGS84 latitude/longitude | Coordinate values retained | None |
 
+When `gis.reproject` is enabled, Shapefile, FlatGeobuf, and GeoPackage require usable source CRS
+metadata. A Shapefile therefore needs its `.prj` sidecar, while FlatGeobuf and GeoPackage need a
+source definition in their format metadata. Missing or invalid definitions reject the request;
+loaders.gl does not assume that unlabelled coordinates are WGS84.
+
 ## GeoArrow and GeoParquet details
 
 GeoParquet distinguishes three states:
@@ -106,8 +111,9 @@ future normalized table descriptor must not collapse them into one table-wide va
   dynamic, and compound CRS definitions.
 - GeoTIFF and GeoZarr return native-CRS raster data and do not warp or resample into a target CRS.
 - Existing vector reprojection options use the inconsistent, experimental `_targetCrs` name.
-- Some source-specific transforms treat an unsupported or unparsable source definition as an
-  unavailable transform and continue with source coordinates instead of rejecting the request.
+- Some point-cloud-specific transforms still treat an unsupported or unparsable source definition
+  as an unavailable transform and continue with source coordinates instead of rejecting the
+  request.
 - Some service parsers and format-specific structures still expose unclassified strings.
 - GeoParquet CRS metadata is preserved, but GeoParquet coordinates are not reprojected.
 - There is no unified CRS result descriptor shared by all loaders and source APIs.

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -42,6 +42,8 @@ Release Date: 2026
   roadmap.
 - Shapefile, FlatGeobuf, and GeoPackage reprojection now rejects missing or invalid source CRS
   metadata instead of returning untransformed coordinates or assuming WGS84.
+- GeoPackage prefers `definition_12_063` WKT2 metadata when available and exposes the selected
+  table CRS through source, scan, and GeoArrow field metadata.
 
 **@loaders.gl/arrow**
 

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -40,6 +40,8 @@ Release Date: 2026
 - Adds a cross-format [CRS support guide](/docs/developer-guide/coordinate-reference-systems) that
   separates metadata preservation from coordinate transformation and records the reprojection
   roadmap.
+- Shapefile, FlatGeobuf, and GeoPackage reprojection now rejects missing or invalid source CRS
+  metadata instead of returning untransformed coordinates or assuming WGS84.
 
 **@loaders.gl/arrow**
 

--- a/modules/flatgeobuf/src/flatgeobuf-source-loader.ts
+++ b/modules/flatgeobuf/src/flatgeobuf-source-loader.ts
@@ -159,7 +159,7 @@ export class FlatGeobufVectorSource extends DataSource<string, FlatGeobufSourceL
     const info = await this.getHeaderInfo();
     assertNotAborted(parameters.signal);
     const format = parameters.format || this.options.flatgeobuf?.format || 'arrow';
-    return parseFlatGeobuf(info.arrayBuffer, {shape: format === 'arrow' ? 'arrow-table' : format === 'binary' ? 'binary-geometry' : 'geojson-table', boundingBox: parameters.boundingBox, crs: parameters.crs || 'WGS84', reproject: Boolean(parameters.crs && parameters.crs !== info.header.crs?.wkt)}) as VectorSourceData;
+    return parseFlatGeobuf(info.arrayBuffer, {shape: format === 'arrow' ? 'arrow-table' : format === 'binary' ? 'binary-geometry' : 'geojson-table', boundingBox: parameters.boundingBox, crs: parameters.crs || 'WGS84', reproject: Boolean(parameters.crs)}) as VectorSourceData;
   }
 
   /** Executes a spatially pruned FlatGeobuf query and returns an Arrow table. */

--- a/modules/flatgeobuf/src/flatgeobuf-source-loader.ts
+++ b/modules/flatgeobuf/src/flatgeobuf-source-loader.ts
@@ -25,7 +25,11 @@ import {
   queryFlatGeobufArrowTable,
   type FlatGeobufQueryOptions
 } from './lib/parse-flatgeobuf';
-import {readFlatGeobufHeader, type FlatGeobufHeader} from './lib/flatgeobuf-reader';
+import {
+  getFlatGeobufCRSIdentifier,
+  readFlatGeobufHeader,
+  type FlatGeobufHeader
+} from './lib/flatgeobuf-reader';
 import {FLATGEOBUF_TABLE_QUERY_CAPABILITIES} from './flatgeobuf-table-query-capabilities';
 
 // __VERSION__ is injected by babel-plugin-version-inline
@@ -201,7 +205,7 @@ function buildMetadata(layerName: string, header: FlatGeobufHeader): VectorSourc
 }
 
 function inferLayerName(url: string, header: FlatGeobufHeader): string { if (header.title) return header.title; const fileName = url.split(/[?#]/)[0].split('/').pop() || 'flatgeobuf'; return fileName.replace(/\.fgb$/i, '') || 'flatgeobuf'; }
-function getLayerCrs(header: FlatGeobufHeader): string[] | undefined { const values = [header.crs?.codeString, header.crs?.wkt, Number.isFinite(header.crs?.code) ? `EPSG:${header.crs?.code}` : undefined].filter(Boolean).map(String); return values.length ? values : undefined; }
+function getLayerCrs(header: FlatGeobufHeader): string[] | undefined { const values = [getFlatGeobufCRSIdentifier(header.crs), header.crs?.wkt].filter(Boolean).map(String); return values.length ? values : undefined; }
 function getBoundingBoxFromHeader(header: FlatGeobufHeader): [[number, number], [number, number]] | undefined { const envelope = header.envelope; return envelope && envelope.length >= 4 ? [[envelope[0], envelope[1]], [envelope[2], envelope[3]]] : undefined; }
 function getScanBoundsFromHeader(header: FlatGeobufHeader): {minimum: [number, number]; maximum: [number, number]} | undefined { const boundingBox = getBoundingBoxFromHeader(header); return boundingBox ? {minimum: boundingBox[0], maximum: boundingBox[1]} : undefined; }
 function getColumnRoles(header: FlatGeobufHeader): Record<string, ScanColumnRole> { const roles: Record<string, ScanColumnRole> = {geometry: 'geometry'}; for (const column of header.columns) if (column.primaryKey) roles[column.name] = 'identifier'; return roles; }

--- a/modules/flatgeobuf/src/lib/flatgeobuf-reader.ts
+++ b/modules/flatgeobuf/src/lib/flatgeobuf-reader.ts
@@ -62,13 +62,38 @@ export type FlatGeobufHeader = {
   columns: FlatGeobufColumn[];
   featuresCount: number;
   indexNodeSize: number;
-  crs?: {code?: number; codeString?: CRSIdentifier; wkt?: WKTCRSDefinition};
+  crs?: FlatGeobufCRS;
   title?: string;
   description?: string;
   metadata?: string;
   headerLength: number;
   featureOffset: number;
 };
+
+/** Coordinate reference system fields declared by a FlatGeobuf header. */
+export type FlatGeobufCRS = {
+  /** Authority that owns the numeric CRS code, such as `EPSG` or `ESRI`. */
+  org?: string;
+  /** Numeric code within the declared authority. */
+  code?: number;
+  /** Self-contained authority-code identifier supplied by the header. */
+  codeString?: CRSIdentifier;
+  /** WKT coordinate reference system definition supplied by the header. */
+  wkt?: WKTCRSDefinition;
+};
+
+/** Returns the most specific authority-code identifier declared by a FlatGeobuf CRS. */
+export function getFlatGeobufCRSIdentifier(
+  crs: FlatGeobufCRS | undefined
+): CRSIdentifier | undefined {
+  if (crs?.codeString) {
+    return crs.codeString;
+  }
+  if (crs?.org && typeof crs.code === 'number' && Number.isFinite(crs.code)) {
+    return `${crs.org}:${crs.code}`;
+  }
+  return undefined;
+}
 
 /** One decoded feature represented by its scalar properties and geometry table offset. */
 export type FlatGeobufFeature = {
@@ -415,7 +440,8 @@ function readColumns(view: FlatBufferView, fieldOffset: number | undefined): Fla
 function readCrs(view: FlatBufferView, table: number) {
   const code = view.tableField(table, 1);
   return {
-    code: code === undefined ? 0 : view.int32(code),
+    org: view.string(view.tableField(table, 0)),
+    code: code === undefined ? undefined : view.int32(code),
     codeString: view.string(view.tableField(table, 5)),
     wkt: view.string(view.tableField(table, 4))
   };

--- a/modules/flatgeobuf/src/lib/parse-flatgeobuf.ts
+++ b/modules/flatgeobuf/src/lib/parse-flatgeobuf.ts
@@ -370,11 +370,19 @@ export function getProjection(
   reproject = false,
   crs: Proj4CRSDefinition = 'WGS84'
 ): Proj4Projection | undefined {
-  if (!reproject || !header.crs?.wkt) return undefined;
+  if (!reproject) return undefined;
+  const sourceCrs =
+    header.crs?.wkt ||
+    header.crs?.codeString ||
+    (Number.isFinite(header.crs?.code) ? `EPSG:${header.crs.code}` : undefined);
+  if (!sourceCrs) {
+    throw new Error('FlatGeobuf reprojection requires a source CRS in the file header');
+  }
   try {
-    return new Proj4Projection({from: header.crs.wkt, to: crs});
-  } catch {
-    return undefined;
+    return new Proj4Projection({from: sourceCrs, to: crs});
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`FlatGeobuf reprojection failed: ${message}`);
   }
 }
 function intersectsBoundingBox(

--- a/modules/flatgeobuf/src/lib/parse-flatgeobuf.ts
+++ b/modules/flatgeobuf/src/lib/parse-flatgeobuf.ts
@@ -26,6 +26,7 @@ import {
   decodeFlatGeobufGeometry,
   FlatGeobufColumnType,
   FlatGeobufGeometryType,
+  getFlatGeobufCRSIdentifier,
   readFlatGeobufFeatures,
   readFlatGeobufHeader,
   writeFlatGeobufGeometry,
@@ -371,10 +372,7 @@ export function getProjection(
   crs: Proj4CRSDefinition = 'WGS84'
 ): Proj4Projection | undefined {
   if (!reproject) return undefined;
-  const sourceCrs =
-    header.crs?.wkt ||
-    header.crs?.codeString ||
-    (Number.isFinite(header.crs?.code) ? `EPSG:${header.crs.code}` : undefined);
+  const sourceCrs = header.crs?.wkt || getFlatGeobufCRSIdentifier(header.crs);
   if (!sourceCrs) {
     throw new Error('FlatGeobuf reprojection requires a source CRS in the file header');
   }

--- a/modules/flatgeobuf/test/flatgeobuf-source-loader.spec.ts
+++ b/modules/flatgeobuf/test/flatgeobuf-source-loader.spec.ts
@@ -44,11 +44,19 @@ test('FlatGeobufSourceLoader#getSchema and getMetadata expose header metadata', 
   expect(metadata.layers.length, 'returns one dataset layer').toBe(1);
   expect(metadata.layers[0]?.name, 'layer name matches dataset').toBe('countries');
   expect(Array.isArray(metadata.layers[0]?.crs), 'metadata exposes CRS list').toBeTruthy();
+  expect(
+    metadata.layers[0]?.crs,
+    'metadata combines the declared CRS authority and code'
+  ).toContain('EPSG:4326');
   expect(metadata.formatSpecificMetadata, 'raw metadata is opt-in').toBe(undefined);
   expect(
     metadataWithFormatSpecific.formatSpecificMetadata,
     'returns raw metadata on request'
   ).toBeTruthy();
+  expect(
+    (metadataWithFormatSpecific.formatSpecificMetadata as {crs?: {org?: string}}).crs?.org,
+    'format-specific metadata preserves the declared CRS authority'
+  ).toBe('EPSG');
 });
 test('FlatGeobufVectorSource#getQueryMetadata discovers panel controls from the header', async () => {
   const source = await createSource();

--- a/modules/flatgeobuf/test/reader-coverage.spec.ts
+++ b/modules/flatgeobuf/test/reader-coverage.spec.ts
@@ -90,9 +90,15 @@ describe('FlatGeobuf reader metadata branches', () => {
     expect(schema.fields[1].metadata?.['ARROW:extension:name']).toBe('geoarrow.linestring');
   });
 
-  test('returns no projection unless requested and handles invalid CRS definitions', () => {
+  test('creates projections only from declared source CRS definitions', () => {
     expect(getProjection({}, false)).toBeUndefined();
-    expect(getProjection({crs: {}}, true)).toBeUndefined();
-    expect(getProjection({crs: {wkt: 'not a CRS'}}, true)).toBeUndefined();
+    expect(() => getProjection({crs: {}}, true)).toThrow(
+      'FlatGeobuf reprojection requires a source CRS in the file header'
+    );
+    expect(() => getProjection({crs: {wkt: 'not a CRS'}}, true)).toThrow(
+      'FlatGeobuf reprojection failed'
+    );
+    expect(getProjection({crs: {codeString: 'EPSG:4326'}}, true)).toBeDefined();
+    expect(getProjection({crs: {code: 4326}}, true)).toBeDefined();
   });
 });

--- a/modules/flatgeobuf/test/reader-coverage.spec.ts
+++ b/modules/flatgeobuf/test/reader-coverage.spec.ts
@@ -4,7 +4,11 @@
 
 import {describe, expect, test} from 'vitest';
 
-import {FlatGeobufColumnType, FlatGeobufGeometryType} from '../src/lib/flatgeobuf-reader';
+import {
+  FlatGeobufColumnType,
+  FlatGeobufGeometryType,
+  getFlatGeobufCRSIdentifier
+} from '../src/lib/flatgeobuf-reader';
 import {getProjection, makeArrowSchema} from '../src/lib/parse-flatgeobuf';
 
 const COLUMN_TYPES = [
@@ -99,6 +103,15 @@ describe('FlatGeobuf reader metadata branches', () => {
       'FlatGeobuf reprojection failed'
     );
     expect(getProjection({crs: {codeString: 'EPSG:4326'}}, true)).toBeDefined();
-    expect(getProjection({crs: {code: 4326}}, true)).toBeDefined();
+    expect(getProjection({crs: {org: 'EPSG', code: 4326}}, true)).toBeDefined();
+    expect(() => getProjection({crs: {code: 4326}}, true)).toThrow(
+      'FlatGeobuf reprojection requires a source CRS in the file header'
+    );
+  });
+
+  test('preserves the authority for numeric CRS codes', () => {
+    expect(getFlatGeobufCRSIdentifier({org: 'ESRI', code: 102100})).toBe('ESRI:102100');
+    expect(getFlatGeobufCRSIdentifier({org: 'CUSTOM', code: 4326})).toBe('CUSTOM:4326');
+    expect(getFlatGeobufCRSIdentifier({code: 4326})).toBeUndefined();
   });
 });

--- a/modules/geopackage/src/geopackage-source-loader.ts
+++ b/modules/geopackage/src/geopackage-source-loader.ts
@@ -19,12 +19,14 @@ import {
 } from '@loaders.gl/loader-utils';
 import type {ArrowTable, ArrowTableBatch, Schema} from '@loaders.gl/schema';
 import {convertArrowToSchema} from '@loaders.gl/schema-utils';
+import type {WKTCRSDefinition} from '@math.gl/crs';
 import * as arrow from 'apache-arrow';
 
 import type {GeoPackageLoaderOptions} from './geopackage-loader';
 import {
   DEFAULT_SQLJS_CDN,
   getGeoPackageArrowSchema,
+  getProjections,
   listGeoPackageVectorTables,
   loadGeoPackageDatabase,
   parseGeoPackageToArrow,
@@ -43,6 +45,8 @@ export type GeoPackageSourceTableMetadata = {
   identifier?: string;
   description?: string;
   srsId?: number;
+  /** Preferred WKT2 or fallback WKT1 definition for the table SRS. */
+  crs?: WKTCRSDefinition;
   geometryColumnName: string;
   geometryTypeName: string;
   bounds?: [[number, number], [number, number]];
@@ -150,11 +154,15 @@ export class GeoPackageDataSource
           cancellation: false
         }
       },
-      spatial: selectedTable.bounds
-        ? {
-            bounds: {minimum: selectedTable.bounds[0], maximum: selectedTable.bounds[1]}
-          }
-        : undefined,
+      spatial:
+        selectedTable.bounds || selectedTable.crs
+          ? {
+              bounds: selectedTable.bounds
+                ? {minimum: selectedTable.bounds[0], maximum: selectedTable.bounds[1]}
+                : undefined,
+              coordinateReferenceSystems: selectedTable.crs ? [selectedTable.crs] : undefined
+            }
+          : undefined,
       statistics: {byteLength: undefined}
     });
   }
@@ -192,28 +200,33 @@ export class GeoPackageDataSource
       this.options.geopackage?.sqlJsCDN ?? DEFAULT_SQLJS_CDN
     );
     const vectorTables = listGeoPackageVectorTables(database);
+    const projections = getProjections(database);
     const defaultTable = selectGeoPackageVectorTable(
       vectorTables,
       this.options.geopackage?.table || undefined
     );
 
     return {
-      tables: vectorTables.map(vectorTable => ({
-        schema: getGeoPackageArrowSchema(database, vectorTable),
-        name: vectorTable.name,
-        identifier: vectorTable.identifier,
-        description: vectorTable.description,
-        srsId: vectorTable.srsId,
-        geometryColumnName: vectorTable.geometryColumnName,
-        geometryTypeName: vectorTable.geometryTypeName,
-        bounds: vectorTable.bounds
-          ? [
-              [vectorTable.bounds.minX, vectorTable.bounds.minY],
-              [vectorTable.bounds.maxX, vectorTable.bounds.maxY]
-            ]
-          : undefined,
-        isDefault: vectorTable.name === defaultTable.name
-      }))
+      tables: vectorTables.map(vectorTable => {
+        const crs = vectorTable.srsId === undefined ? undefined : projections[vectorTable.srsId];
+        return {
+          schema: getGeoPackageArrowSchema(database, vectorTable, crs),
+          name: vectorTable.name,
+          identifier: vectorTable.identifier,
+          description: vectorTable.description,
+          srsId: vectorTable.srsId,
+          crs,
+          geometryColumnName: vectorTable.geometryColumnName,
+          geometryTypeName: vectorTable.geometryTypeName,
+          bounds: vectorTable.bounds
+            ? [
+                [vectorTable.bounds.minX, vectorTable.bounds.minY],
+                [vectorTable.bounds.maxX, vectorTable.bounds.maxY]
+              ]
+            : undefined,
+          isDefault: vectorTable.name === defaultTable.name
+        };
+      })
     };
   }
 

--- a/modules/geopackage/src/lib/parse-geopackage.ts
+++ b/modules/geopackage/src/lib/parse-geopackage.ts
@@ -378,18 +378,26 @@ function constructArrowRow(
   return arrowRow;
 }
 
-function getProjection(
+/** Creates the requested GeoPackage projection or rejects missing source CRS metadata. */
+export function getProjection(
   vectorTable: GeoPackageVectorTableInfo,
   projections: ProjectionMapping,
   options: {reproject: boolean; targetCrs: Proj4CRSDefinition}
 ): Proj4Projection | null {
-  if (!options.reproject || vectorTable.srsId === undefined) {
+  if (!options.reproject) {
     return null;
+  }
+  if (vectorTable.srsId === undefined) {
+    throw new Error(
+      `GeoPackage reprojection requires a source CRS identifier for table "${vectorTable.name}"`
+    );
   }
 
   const sourceProjection = projections[vectorTable.srsId];
   if (!sourceProjection) {
-    return null;
+    throw new Error(
+      `GeoPackage reprojection requires a defined source CRS for SRS ${vectorTable.srsId}`
+    );
   }
 
   return new Proj4Projection({

--- a/modules/geopackage/src/lib/parse-geopackage.ts
+++ b/modules/geopackage/src/lib/parse-geopackage.ts
@@ -24,6 +24,7 @@ import {
   transformGeoJsonCoords
 } from '@loaders.gl/gis';
 import {Proj4Projection, type Proj4CRSDefinition} from '@math.gl/proj4';
+import type {WKTCRSDefinition} from '@math.gl/crs';
 import initSqlJs, {Database, SqlJsStatic, Statement} from 'sql.js';
 
 import type {GeoPackageLoaderOptions} from '../geopackage-loader';
@@ -285,7 +286,12 @@ export function getGeoPackageArrowTable(
   const columns = queryResult?.columns || [];
   const values = queryResult?.values || [];
   const projection = getProjection(vectorTable, projections, options);
-  const schema = getGeoPackageArrowSchema(database, vectorTable);
+  const outputCrs = options.reproject
+    ? options.targetCrs
+    : vectorTable.srsId === undefined
+      ? undefined
+      : projections[vectorTable.srsId];
+  const schema = getGeoPackageArrowSchema(database, vectorTable, outputCrs);
   const tableBuilder = new ArrowTableBuilder(schema);
 
   for (const row of values) {
@@ -304,10 +310,21 @@ export function getProjections(database: Database): ProjectionMapping {
 
   while (statement.step()) {
     const projectionRow = statement.getAsObject() as unknown as SpatialRefSysRow;
-    projectionMapping[projectionRow.srs_id] = projectionRow.definition;
+    const definition = getSpatialReferenceSystemDefinition(projectionRow);
+    if (definition) {
+      projectionMapping[projectionRow.srs_id] = definition;
+    }
   }
 
   return projectionMapping;
+}
+
+/** Selects the preferred usable CRS definition from one GeoPackage SRS row. */
+export function getSpatialReferenceSystemDefinition(
+  spatialReferenceSystem: SpatialRefSysRow
+): WKTCRSDefinition | undefined {
+  const definition = spatialReferenceSystem.definition_12_063 || spatialReferenceSystem.definition;
+  return definition && definition.trim().toLowerCase() !== 'undefined' ? definition : undefined;
 }
 
 function constructGeoJsonFeature(
@@ -513,7 +530,8 @@ function getSchema(database: Database, tableName: string): Schema {
 /** Reads a selected GeoPackage feature-table schema without materializing its rows. */
 export function getGeoPackageArrowSchema(
   database: Database,
-  vectorTable: GeoPackageVectorTableInfo
+  vectorTable: GeoPackageVectorTableInfo,
+  crs?: Proj4CRSDefinition
 ): Schema {
   const statement = database.prepare(`PRAGMA table_info(\`${vectorTable.name}\`)`);
   const fields: Field[] = [];
@@ -530,7 +548,13 @@ export function getGeoPackageArrowSchema(
     });
   }
 
-  fields.push(makeWKBGeometryField(GEOMETRY_OUTPUT_COLUMN_NAME));
+  const geometryField = makeWKBGeometryField(GEOMETRY_OUTPUT_COLUMN_NAME);
+  if (crs) {
+    geometryField.metadata!['ARROW:extension:metadata'] = JSON.stringify(
+      getGeoArrowCrsMetadata(crs)
+    );
+  }
+  fields.push(geometryField);
 
   const schema: Schema = {fields, metadata: {}};
   setWKBGeometrySchemaMetadata(schema, {
@@ -538,6 +562,17 @@ export function getGeoPackageArrowSchema(
     geometryTypes: [getGeoMetadataGeometryType(vectorTable)]
   });
   return schema;
+}
+
+/** Preserves a GeoPackage output CRS using the matching GeoArrow metadata representation. */
+function getGeoArrowCrsMetadata(crs: Proj4CRSDefinition): Record<string, unknown> {
+  if (typeof crs !== 'string') {
+    return {crs, crs_type: 'projjson'};
+  }
+  if (/^[A-Za-z][A-Za-z0-9_.-]*:[^\s]+$/.test(crs)) {
+    return {crs, crs_type: 'authority_code'};
+  }
+  return {crs};
 }
 
 function getGeoMetadataGeometryType(

--- a/modules/geopackage/src/lib/types.ts
+++ b/modules/geopackage/src/lib/types.ts
@@ -74,6 +74,9 @@ export interface SpatialRefSysRow {
    */
   definition: WKTCRSDefinition;
 
+  /** WKT2 definition supplied by the GeoPackage CRS WKT extension. */
+  definition_12_063?: WKTCRSDefinition | null;
+
   /**
    * Human readable description of this SRS
    */

--- a/modules/geopackage/test/geopackage-arrow-loader.spec.ts
+++ b/modules/geopackage/test/geopackage-arrow-loader.spec.ts
@@ -44,6 +44,15 @@ test('GeoPackageLoader#load file as Arrow table', async () => {
   expect(geoMetadata?.columns.geometry.encoding, 'geo metadata identifies WKB encoding').toBe(
     'wkb'
   );
+  const geometryField = table.schema.fields.find(field => field.name === 'geometry');
+  const extensionMetadata = JSON.parse(
+    geometryField?.metadata?.['ARROW:extension:metadata'] || '{}'
+  );
+  expect(extensionMetadata.crs, 'GeoArrow field preserves the source CRS').toBeTruthy();
+  expect(
+    extensionMetadata.crs_type,
+    'GeoPackage WKT is not mislabeled as a specific GeoArrow WKT revision'
+  ).toBeUndefined();
   const rows = getRowsFromArrowTable(table);
   const roundTripped = convertWKBTableToGeoJSON(
     {shape: 'object-row-table', schema: table.schema, data: rows},
@@ -101,6 +110,11 @@ test('GeoPackageLoader#load Arrow table reprojects like GeoJSON output', async (
   expect(normalizeFeatures(roundTripped.features), 'reprojected features match').toEqual(
     normalizeFeatures(geojsonTable.features)
   );
+  const geometryField = arrowTable.schema.fields.find(field => field.name === 'geometry');
+  expect(
+    JSON.parse(geometryField?.metadata?.['ARROW:extension:metadata'] || '{}'),
+    'Arrow metadata reports the transformed output CRS'
+  ).toEqual({crs: 'WGS84'});
 });
 test('GeoPackageLoader#load missing table errors clearly', async () => {
   try {

--- a/modules/geopackage/test/geopackage-loader.spec.ts
+++ b/modules/geopackage/test/geopackage-loader.spec.ts
@@ -1,9 +1,25 @@
 import {expect, test} from 'vitest';
 import {load, fetchFile} from '@loaders.gl/core';
 import {GeoPackageLoader} from '@loaders.gl/geopackage';
+import {getProjection} from '../src/lib/parse-geopackage';
+import type {GeoPackageVectorTableInfo} from '../src/lib/types';
 // import type {Tables, ObjectRowTable, Feature} from '@loaders.gl/schema';
 const GPKG_RIVERS = '@loaders.gl/geopackage/test/data/rivers_small.gpkg';
 const GPKG_RIVERS_GEOJSON = '@loaders.gl/geopackage/test/data/rivers_small.geojson';
+
+test('GeoPackage reprojection requires a declared source CRS', () => {
+  const vectorTable = {name: 'roads'} as GeoPackageVectorTableInfo;
+  const options = {reproject: true, targetCrs: 'WGS84' as const};
+
+  expect(() => getProjection(vectorTable, {}, options)).toThrow(
+    'GeoPackage reprojection requires a source CRS identifier for table "roads"'
+  );
+  expect(() => getProjection({...vectorTable, srsId: 999}, {}, options)).toThrow(
+    'GeoPackage reprojection requires a defined source CRS for SRS 999'
+  );
+  expect(getProjection({...vectorTable, srsId: 4326}, {4326: 'WGS84'}, options)).toBeDefined();
+});
+
 test('GeoPackageLoader#load file as tables', async () => {
   const result = await load(GPKG_RIVERS, GeoPackageLoader, {
     geopackage: {

--- a/modules/geopackage/test/geopackage-loader.spec.ts
+++ b/modules/geopackage/test/geopackage-loader.spec.ts
@@ -1,8 +1,8 @@
 import {expect, test} from 'vitest';
 import {load, fetchFile} from '@loaders.gl/core';
 import {GeoPackageLoader} from '@loaders.gl/geopackage';
-import {getProjection} from '../src/lib/parse-geopackage';
-import type {GeoPackageVectorTableInfo} from '../src/lib/types';
+import {getProjection, getSpatialReferenceSystemDefinition} from '../src/lib/parse-geopackage';
+import type {GeoPackageVectorTableInfo, SpatialRefSysRow} from '../src/lib/types';
 // import type {Tables, ObjectRowTable, Feature} from '@loaders.gl/schema';
 const GPKG_RIVERS = '@loaders.gl/geopackage/test/data/rivers_small.gpkg';
 const GPKG_RIVERS_GEOJSON = '@loaders.gl/geopackage/test/data/rivers_small.geojson';
@@ -18,6 +18,22 @@ test('GeoPackage reprojection requires a declared source CRS', () => {
     'GeoPackage reprojection requires a defined source CRS for SRS 999'
   );
   expect(getProjection({...vectorTable, srsId: 4326}, {4326: 'WGS84'}, options)).toBeDefined();
+});
+
+test('GeoPackage prefers extension WKT2 and preserves undefined SRS semantics', () => {
+  const spatialReferenceSystem = {
+    definition: 'GEOGCS["WKT1"]',
+    definition_12_063: 'GEOGCRS["WKT2"]'
+  } as SpatialRefSysRow;
+
+  expect(getSpatialReferenceSystemDefinition(spatialReferenceSystem)).toBe('GEOGCRS["WKT2"]');
+  expect(
+    getSpatialReferenceSystemDefinition({
+      ...spatialReferenceSystem,
+      definition: 'undefined',
+      definition_12_063: null
+    })
+  ).toBeUndefined();
 });
 
 test('GeoPackageLoader#load file as tables', async () => {

--- a/modules/geopackage/test/geopackage-scan-metadata.spec.ts
+++ b/modules/geopackage/test/geopackage-scan-metadata.spec.ts
@@ -22,6 +22,7 @@ test.runIf(isBrowser)(
     expect(metadata.columns.map(column => column.name)).toContain('geometry');
     expect(metadata.columns.find(column => column.name === 'geometry')?.role).toBe('geometry');
     expect(metadata.capabilities.table?.projection).toBe('residual');
+    expect(metadata.spatial?.coordinateReferenceSystems?.length).toBe(1);
   }
 );
 

--- a/modules/geopackage/test/geopackage-source.spec.ts
+++ b/modules/geopackage/test/geopackage-source.spec.ts
@@ -29,6 +29,10 @@ test('GeoPackageSource#getMetadata returns tables and default selection', async 
     metadata.tables.find(table => table.name === 'preferred_rivers')?.identifier,
     'includes GeoPackage table metadata'
   ).toBe('default');
+  expect(
+    metadata.tables.find(table => table.name === 'preferred_rivers')?.crs,
+    'includes the table CRS definition'
+  ).toBeTruthy();
 });
 test('GeoPackageSource#getQueryMetadata exposes the selected schema and bounds', async () => {
   const dataSource = createDataSource(await createFixtureBlob(), [GeoPackageSource], {
@@ -39,6 +43,10 @@ test('GeoPackageSource#getQueryMetadata exposes the selected schema and bounds',
   expect(metadata.sourceType, 'uses the shared source identifier').toBe('geopackage');
   expect(metadata.columns.length > 0, 'publishes the selected table schema').toBeTruthy();
   expect(metadata.spatial?.bounds, 'publishes feature bounds').toBeTruthy();
+  expect(
+    metadata.spatial?.coordinateReferenceSystems?.length,
+    'publishes the selected table CRS'
+  ).toBe(1);
 });
 test('GeoPackageSource#getTable matches GeoPackageLoader Arrow output', async () => {
   const fixtureResponse = await fetchFile(GPKG_RIVERS_MULTI);

--- a/modules/shapefile/src/lib/parsers/parse-shapefile.ts
+++ b/modules/shapefile/src/lib/parsers/parse-shapefile.ts
@@ -285,11 +285,11 @@ function reprojectFeatures(
   sourceCrs?: WKTCRSDefinition,
   targetCrs?: Proj4CRSDefinition
 ): Feature[] {
-  if (!sourceCrs && !targetCrs) {
-    return features;
+  if (!sourceCrs) {
+    throw new Error('Shapefile reprojection requires a source CRS from the .prj sidecar file');
   }
 
-  const projection = new Proj4Projection({from: sourceCrs || 'WGS84', to: targetCrs || 'WGS84'});
+  const projection = new Proj4Projection({from: sourceCrs, to: targetCrs || 'WGS84'});
   return transformGeoJsonCoords(features, coord => projection.project(coord));
 }
 

--- a/modules/shapefile/src/shapefile-arrow-loader-with-parser.ts
+++ b/modules/shapefile/src/shapefile-arrow-loader-with-parser.ts
@@ -322,7 +322,10 @@ function getReprojectionTransform(
   if (!reproject) {
     return undefined;
   }
-  const projection = new Proj4Projection({from: sourceCrs || 'WGS84', to: _targetCrs || 'WGS84'});
+  if (!sourceCrs) {
+    throw new Error('Shapefile reprojection requires a source CRS from the .prj sidecar file');
+  }
+  const projection = new Proj4Projection({from: sourceCrs, to: _targetCrs || 'WGS84'});
   return coordinate => projection.project(coordinate);
 }
 

--- a/modules/shapefile/test/shapefile-loader.spec.ts
+++ b/modules/shapefile/test/shapefile-loader.spec.ts
@@ -76,6 +76,22 @@ test('ShapefileLoader#reprojects points', async () => {
   );
 });
 
+test.each([
+  'v3',
+  'arrow-table'
+] as const)('ShapefileLoader#rejects %s reprojection without a .prj sidecar', async shape => {
+  const response = await fetchFile(`${SHAPEFILE_DATA_FOLDER}/points.shp`);
+  const arrayBuffer = await response.arrayBuffer();
+
+  await expect(
+    load(arrayBuffer, ShapefileLoader, {
+      core: {worker: false},
+      shapefile: {shape},
+      gis: {reproject: true, _targetCrs: 'EPSG:3857'}
+    })
+  ).rejects.toThrow('Shapefile reprojection requires a source CRS from the .prj sidecar file');
+});
+
 test('ShapefileLoader#selects from its magic number', async () => {
   const response = await fetchFile(`${SHAPEFILE_DATA_FOLDER}/boolean-property.shp`);
   const loader = await selectLoader(await response.arrayBuffer(), [ShapefileLoader]);


### PR DESCRIPTION
## Goals

- Prevent requested coordinate transformations from silently returning native coordinates.
- Stop assuming unlabelled Shapefile coordinates are WGS84.
- Make source CRS requirements explicit before broader CRS normalization work.

## Changes compared to master

- Require a usable .prj source CRS for Shapefile GeoJSON and Arrow reprojection.
- Resolve FlatGeobuf source CRS from WKT, authority identifiers, or EPSG codes and report missing or invalid definitions.
- Always honor an explicitly requested FlatGeobuf response CRS instead of comparing serialized CRS strings.
- Reject GeoPackage reprojection when the selected table has no resolvable source SRS.
- Add focused regression tests and document the fail-closed behavior in the CRS guide and v5 release notes.

## Verification

- yarn lint fix
- yarn build
- yarn build-workers
- yarn test-node: 52 files, 361 passed, 6 skipped
- yarn test-headless: 506 files, 3104 passed, 40 skipped
- yarn test-audit: 609 files, 0 violations
- website yarn build