### PR TITLE
feat(geopackage): preserve CRS metadata

### DIFF
--- a/docs/developer-guide/coordinate-reference-systems.md
+++ b/docs/developer-guide/coordinate-reference-systems.md
@@ -64,7 +64,7 @@ mean coordinate transformation.
 | GeoParquet 1.1 / 2.0 | Per-column PROJJSON, `null`, omitted default, and coordinate `epoch` | Original `geo` JSON is retained; compatible GeoArrow field metadata is added | None |
 | Shapefile | `.prj` WKT sidecar | `.prj` is returned by legacy output; Arrow metadata is partial | Opt-in through `gis.reproject` and `_targetCrs` |
 | FlatGeobuf | Header authority code and WKT | Header metadata is retained; Arrow CRS metadata is partial | Opt-in through `gis.reproject` and `_targetCrs` |
-| GeoPackage | Spatial reference system tables | Format metadata is available while geometry output metadata is partial | Opt-in through `gis.reproject` and `_targetCrs` |
+| GeoPackage | Spatial reference system tables, preferring extension WKT2 over fallback WKT1 | Source and scan metadata retain the table CRS; Arrow geometry fields report the native or transformed output CRS | Opt-in through `gis.reproject` and `_targetCrs` |
 | GeoJSON | Deprecated GeoJSON `crs` member when present; otherwise WGS84 semantics | Original legacy value is retained; recognized CRS84/EPSG:4326 values map to GeoArrow/GeoParquet metadata | None in the GeoJSON loader |
 | CSV WKT / WKB | Geometry values can contain EWKT/EWKB SRIDs, but CSV has no dataset CRS convention | Geometry-level SRID support is partial; no common table CRS descriptor | None |
 | GML | `srsName` on geometry/envelope elements | Parsed format data retains identifiers inconsistently across output shapes | Service/server dependent; no general client transform |

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -42,6 +42,8 @@ Release Date: 2026
   roadmap.
 - Shapefile, FlatGeobuf, and GeoPackage reprojection now rejects missing or invalid source CRS
   metadata instead of returning untransformed coordinates or assuming WGS84.
+- GeoPackage prefers `definition_12_063` WKT2 metadata when available and exposes the selected
+  table CRS through source, scan, and GeoArrow field metadata.
 
 **@loaders.gl/arrow**
 

--- a/modules/geopackage/src/geopackage-source-loader.ts
+++ b/modules/geopackage/src/geopackage-source-loader.ts
@@ -19,12 +19,14 @@ import {
 } from '@loaders.gl/loader-utils';
 import type {ArrowTable, ArrowTableBatch, Schema} from '@loaders.gl/schema';
 import {convertArrowToSchema} from '@loaders.gl/schema-utils';
+import type {WKTCRSDefinition} from '@math.gl/crs';
 import * as arrow from 'apache-arrow';
 
 import type {GeoPackageLoaderOptions} from './geopackage-loader';
 import {
   DEFAULT_SQLJS_CDN,
   getGeoPackageArrowSchema,
+  getProjections,
   listGeoPackageVectorTables,
   loadGeoPackageDatabase,
   parseGeoPackageToArrow,
@@ -43,6 +45,8 @@ export type GeoPackageSourceTableMetadata = {
   identifier?: string;
   description?: string;
   srsId?: number;
+  /** Preferred WKT2 or fallback WKT1 definition for the table SRS. */
+  crs?: WKTCRSDefinition;
   geometryColumnName: string;
   geometryTypeName: string;
   bounds?: [[number, number], [number, number]];
@@ -150,11 +154,15 @@ export class GeoPackageDataSource
           cancellation: false
         }
       },
-      spatial: selectedTable.bounds
-        ? {
-            bounds: {minimum: selectedTable.bounds[0], maximum: selectedTable.bounds[1]}
-          }
-        : undefined,
+      spatial:
+        selectedTable.bounds || selectedTable.crs
+          ? {
+              bounds: selectedTable.bounds
+                ? {minimum: selectedTable.bounds[0], maximum: selectedTable.bounds[1]}
+                : undefined,
+              coordinateReferenceSystems: selectedTable.crs ? [selectedTable.crs] : undefined
+            }
+          : undefined,
       statistics: {byteLength: undefined}
     });
   }
@@ -192,28 +200,33 @@ export class GeoPackageDataSource
       this.options.geopackage?.sqlJsCDN ?? DEFAULT_SQLJS_CDN
     );
     const vectorTables = listGeoPackageVectorTables(database);
+    const projections = getProjections(database);
     const defaultTable = selectGeoPackageVectorTable(
       vectorTables,
       this.options.geopackage?.table || undefined
     );
 
     return {
-      tables: vectorTables.map(vectorTable => ({
-        schema: getGeoPackageArrowSchema(database, vectorTable),
-        name: vectorTable.name,
-        identifier: vectorTable.identifier,
-        description: vectorTable.description,
-        srsId: vectorTable.srsId,
-        geometryColumnName: vectorTable.geometryColumnName,
-        geometryTypeName: vectorTable.geometryTypeName,
-        bounds: vectorTable.bounds
-          ? [
-              [vectorTable.bounds.minX, vectorTable.bounds.minY],
-              [vectorTable.bounds.maxX, vectorTable.bounds.maxY]
-            ]
-          : undefined,
-        isDefault: vectorTable.name === defaultTable.name
-      }))
+      tables: vectorTables.map(vectorTable => {
+        const crs = vectorTable.srsId === undefined ? undefined : projections[vectorTable.srsId];
+        return {
+          schema: getGeoPackageArrowSchema(database, vectorTable, crs),
+          name: vectorTable.name,
+          identifier: vectorTable.identifier,
+          description: vectorTable.description,
+          srsId: vectorTable.srsId,
+          crs,
+          geometryColumnName: vectorTable.geometryColumnName,
+          geometryTypeName: vectorTable.geometryTypeName,
+          bounds: vectorTable.bounds
+            ? [
+                [vectorTable.bounds.minX, vectorTable.bounds.minY],
+                [vectorTable.bounds.maxX, vectorTable.bounds.maxY]
+              ]
+            : undefined,
+          isDefault: vectorTable.name === defaultTable.name
+        };
+      })
     };
   }
 

--- a/modules/geopackage/src/lib/parse-geopackage.ts
+++ b/modules/geopackage/src/lib/parse-geopackage.ts
@@ -24,6 +24,7 @@ import {
   transformGeoJsonCoords
 } from '@loaders.gl/gis';
 import {Proj4Projection, type Proj4CRSDefinition} from '@math.gl/proj4';
+import type {WKTCRSDefinition} from '@math.gl/crs';
 import initSqlJs, {Database, SqlJsStatic, Statement} from 'sql.js';
 
 import type {GeoPackageLoaderOptions} from '../geopackage-loader';
@@ -285,7 +286,12 @@ export function getGeoPackageArrowTable(
   const columns = queryResult?.columns || [];
   const values = queryResult?.values || [];
   const projection = getProjection(vectorTable, projections, options);
-  const schema = getGeoPackageArrowSchema(database, vectorTable);
+  const outputCrs = options.reproject
+    ? options.targetCrs
+    : vectorTable.srsId === undefined
+      ? undefined
+      : projections[vectorTable.srsId];
+  const schema = getGeoPackageArrowSchema(database, vectorTable, outputCrs);
   const tableBuilder = new ArrowTableBuilder(schema);
 
   for (const row of values) {
@@ -304,10 +310,21 @@ export function getProjections(database: Database): ProjectionMapping {
 
   while (statement.step()) {
     const projectionRow = statement.getAsObject() as unknown as SpatialRefSysRow;
-    projectionMapping[projectionRow.srs_id] = projectionRow.definition;
+    const definition = getSpatialReferenceSystemDefinition(projectionRow);
+    if (definition) {
+      projectionMapping[projectionRow.srs_id] = definition;
+    }
   }
 
   return projectionMapping;
+}
+
+/** Selects the preferred usable CRS definition from one GeoPackage SRS row. */
+export function getSpatialReferenceSystemDefinition(
+  spatialReferenceSystem: SpatialRefSysRow
+): WKTCRSDefinition | undefined {
+  const definition = spatialReferenceSystem.definition_12_063 || spatialReferenceSystem.definition;
+  return definition && definition.trim().toLowerCase() !== 'undefined' ? definition : undefined;
 }
 
 function constructGeoJsonFeature(
@@ -513,7 +530,8 @@ function getSchema(database: Database, tableName: string): Schema {
 /** Reads a selected GeoPackage feature-table schema without materializing its rows. */
 export function getGeoPackageArrowSchema(
   database: Database,
-  vectorTable: GeoPackageVectorTableInfo
+  vectorTable: GeoPackageVectorTableInfo,
+  crs?: Proj4CRSDefinition
 ): Schema {
   const statement = database.prepare(`PRAGMA table_info(\`${vectorTable.name}\`)`);
   const fields: Field[] = [];
@@ -530,7 +548,13 @@ export function getGeoPackageArrowSchema(
     });
   }
 
-  fields.push(makeWKBGeometryField(GEOMETRY_OUTPUT_COLUMN_NAME));
+  const geometryField = makeWKBGeometryField(GEOMETRY_OUTPUT_COLUMN_NAME);
+  if (crs) {
+    geometryField.metadata!['ARROW:extension:metadata'] = JSON.stringify(
+      getGeoArrowCrsMetadata(crs)
+    );
+  }
+  fields.push(geometryField);
 
   const schema: Schema = {fields, metadata: {}};
   setWKBGeometrySchemaMetadata(schema, {
@@ -538,6 +562,17 @@ export function getGeoPackageArrowSchema(
     geometryTypes: [getGeoMetadataGeometryType(vectorTable)]
   });
   return schema;
+}
+
+/** Preserves a GeoPackage output CRS using the matching GeoArrow metadata representation. */
+function getGeoArrowCrsMetadata(crs: Proj4CRSDefinition): Record<string, unknown> {
+  if (typeof crs !== 'string') {
+    return {crs, crs_type: 'projjson'};
+  }
+  if (/^[A-Za-z][A-Za-z0-9_.-]*:[^\s]+$/.test(crs)) {
+    return {crs, crs_type: 'authority_code'};
+  }
+  return {crs};
 }
 
 function getGeoMetadataGeometryType(

--- a/modules/geopackage/src/lib/types.ts
+++ b/modules/geopackage/src/lib/types.ts
@@ -74,6 +74,9 @@ export interface SpatialRefSysRow {
    */
   definition: WKTCRSDefinition;
 
+  /** WKT2 definition supplied by the GeoPackage CRS WKT extension. */
+  definition_12_063?: WKTCRSDefinition | null;
+
   /**
    * Human readable description of this SRS
    */

--- a/modules/geopackage/test/geopackage-arrow-loader.spec.ts
+++ b/modules/geopackage/test/geopackage-arrow-loader.spec.ts
@@ -44,6 +44,15 @@ test('GeoPackageLoader#load file as Arrow table', async () => {
   expect(geoMetadata?.columns.geometry.encoding, 'geo metadata identifies WKB encoding').toBe(
     'wkb'
   );
+  const geometryField = table.schema.fields.find(field => field.name === 'geometry');
+  const extensionMetadata = JSON.parse(
+    geometryField?.metadata?.['ARROW:extension:metadata'] || '{}'
+  );
+  expect(extensionMetadata.crs, 'GeoArrow field preserves the source CRS').toBeTruthy();
+  expect(
+    extensionMetadata.crs_type,
+    'GeoPackage WKT is not mislabeled as a specific GeoArrow WKT revision'
+  ).toBeUndefined();
   const rows = getRowsFromArrowTable(table);
   const roundTripped = convertWKBTableToGeoJSON(
     {shape: 'object-row-table', schema: table.schema, data: rows},
@@ -101,6 +110,11 @@ test('GeoPackageLoader#load Arrow table reprojects like GeoJSON output', async (
   expect(normalizeFeatures(roundTripped.features), 'reprojected features match').toEqual(
     normalizeFeatures(geojsonTable.features)
   );
+  const geometryField = arrowTable.schema.fields.find(field => field.name === 'geometry');
+  expect(
+    JSON.parse(geometryField?.metadata?.['ARROW:extension:metadata'] || '{}'),
+    'Arrow metadata reports the transformed output CRS'
+  ).toEqual({crs: 'WGS84'});
 });
 test('GeoPackageLoader#load missing table errors clearly', async () => {
   try {

--- a/modules/geopackage/test/geopackage-loader.spec.ts
+++ b/modules/geopackage/test/geopackage-loader.spec.ts
@@ -1,8 +1,8 @@
 import {expect, test} from 'vitest';
 import {load, fetchFile} from '@loaders.gl/core';
 import {GeoPackageLoader} from '@loaders.gl/geopackage';
-import {getProjection} from '../src/lib/parse-geopackage';
-import type {GeoPackageVectorTableInfo} from '../src/lib/types';
+import {getProjection, getSpatialReferenceSystemDefinition} from '../src/lib/parse-geopackage';
+import type {GeoPackageVectorTableInfo, SpatialRefSysRow} from '../src/lib/types';
 // import type {Tables, ObjectRowTable, Feature} from '@loaders.gl/schema';
 const GPKG_RIVERS = '@loaders.gl/geopackage/test/data/rivers_small.gpkg';
 const GPKG_RIVERS_GEOJSON = '@loaders.gl/geopackage/test/data/rivers_small.geojson';
@@ -18,6 +18,22 @@ test('GeoPackage reprojection requires a declared source CRS', () => {
     'GeoPackage reprojection requires a defined source CRS for SRS 999'
   );
   expect(getProjection({...vectorTable, srsId: 4326}, {4326: 'WGS84'}, options)).toBeDefined();
+});
+
+test('GeoPackage prefers extension WKT2 and preserves undefined SRS semantics', () => {
+  const spatialReferenceSystem = {
+    definition: 'GEOGCS["WKT1"]',
+    definition_12_063: 'GEOGCRS["WKT2"]'
+  } as SpatialRefSysRow;
+
+  expect(getSpatialReferenceSystemDefinition(spatialReferenceSystem)).toBe('GEOGCRS["WKT2"]');
+  expect(
+    getSpatialReferenceSystemDefinition({
+      ...spatialReferenceSystem,
+      definition: 'undefined',
+      definition_12_063: null
+    })
+  ).toBeUndefined();
 });
 
 test('GeoPackageLoader#load file as tables', async () => {

--- a/modules/geopackage/test/geopackage-scan-metadata.spec.ts
+++ b/modules/geopackage/test/geopackage-scan-metadata.spec.ts
@@ -22,6 +22,7 @@ test.runIf(isBrowser)(
     expect(metadata.columns.map(column => column.name)).toContain('geometry');
     expect(metadata.columns.find(column => column.name === 'geometry')?.role).toBe('geometry');
     expect(metadata.capabilities.table?.projection).toBe('residual');
+    expect(metadata.spatial?.coordinateReferenceSystems?.length).toBe(1);
   }
 );
 

--- a/modules/geopackage/test/geopackage-source.spec.ts
+++ b/modules/geopackage/test/geopackage-source.spec.ts
@@ -29,6 +29,10 @@ test('GeoPackageSource#getMetadata returns tables and default selection', async 
     metadata.tables.find(table => table.name === 'preferred_rivers')?.identifier,
     'includes GeoPackage table metadata'
   ).toBe('default');
+  expect(
+    metadata.tables.find(table => table.name === 'preferred_rivers')?.crs,
+    'includes the table CRS definition'
+  ).toBeTruthy();
 });
 test('GeoPackageSource#getQueryMetadata exposes the selected schema and bounds', async () => {
   const dataSource = createDataSource(await createFixtureBlob(), [GeoPackageSource], {
@@ -39,6 +43,10 @@ test('GeoPackageSource#getQueryMetadata exposes the selected schema and bounds',
   expect(metadata.sourceType, 'uses the shared source identifier').toBe('geopackage');
   expect(metadata.columns.length > 0, 'publishes the selected table schema').toBeTruthy();
   expect(metadata.spatial?.bounds, 'publishes feature bounds').toBeTruthy();
+  expect(
+    metadata.spatial?.coordinateReferenceSystems?.length,
+    'publishes the selected table CRS'
+  ).toBe(1);
 });
 test('GeoPackageSource#getTable matches GeoPackageLoader Arrow output', async () => {
   const fixtureResponse = await fetchFile(GPKG_RIVERS_MULTI);


### PR DESCRIPTION
## Goals

- Preserve the selected GeoPackage CRS from discovery through scan and Arrow output metadata.
- Honor the GeoPackage CRS WKT extension before the legacy fallback definition.
- Keep native and transformed output CRS metadata aligned with the coordinates.

## Changes compared to the base CRS safety PR

- Prefer definition_12_063 WKT2 when populated, then fall back to definition WKT1.
- Preserve undefined GeoPackage SRS rows as unknown instead of treating the literal undefined value as a projection.
- Add the table WKT definition to GeoPackage source metadata and common scan metadata.
- Attach native or transformed CRS metadata to the GeoArrow WKB field.
- Preserve PROJJSON targets as projjson and authority identifiers as authority_code; retain GeoPackage WKT without falsely claiming a WKT revision.
- Update the CRS support guide and v5 release notes.

## Stack

This PR is intentionally based on #3866. Retarget it to master after #3866 merges.

## Verification

- yarn lint fix
- yarn build
- yarn build-workers
- yarn test-node: 52 files, 361 passed, 6 skipped
- yarn test-headless: 506 files, 3105 passed, 40 skipped
- yarn test-audit: 609 files, 0 violations
- website yarn build