### PR TITLE
feat(services): add ArcGIS SceneServer source

### DIFF
--- a/docs/docs-sidebar.json
+++ b/docs/docs-sidebar.json
@@ -86,6 +86,7 @@
       "modules/services/arcgis-image-server",
       "modules/services/arcgis-feature-server",
       "modules/services/arcgis-vector-tile-server",
+      "modules/services/arcgis-scene-server",
       "modules/services/api-reference/arcgis"
     ]
   },

--- a/docs/modules/i3s/formats/i3s.md
+++ b/docs/modules/i3s/formats/i3s.md
@@ -65,6 +65,7 @@ those versions.
 | Capability | Status | Since | Notes |
 | --- | :---: | :---: | --- |
 | SceneServer / i3sREST resources | **Supported** | v2.0 | Loads a layer document and resolves node pages, nodes, geometries, textures, and attributes on demand. The formal `I3SSource` interface was added in **v5.0**. |
+| ArcGIS SceneServer source facade | **Supported** | **v5.0** | `ArcGISSceneServerSource` normalizes a SceneServer layer and creates the existing mesh or Point Cloud source, preserving authentication and custom fetch options. |
 | Cloud/object-store REST layouts | **Supported** | v2.0 | Relative resources are resolved from the layer URL; custom fetch support was added in v3.2 for application-specific transport. |
 | ArcGIS token propagation | **Partial** | v3.1 | `I3SSource` appends `i3s.token` to the initial layer request as well as node, geometry, texture, and attribute requests. A direct `load(url, I3SLoader, ...)` call still needs the token in the input URL or authenticated fetch handling because core fetches the root before the parser runs. |
 | Lightweight metadata loaders and preloading | **Supported** | **v5.0** | Root exports carry loader metadata and dynamically preload parser-bearing implementations, reducing eager imports without changing async `load` behavior. |
@@ -201,12 +202,15 @@ the sub-tranches under feature intelligence keep the remaining gaps independentl
 | 5e. REST and SLPK access | Resolve Point Cloud node pages and resources from SceneServer URLs and indexed SLPK archives. | **Complete** (**v5.0**) |
 | 5f. Renderer metadata | Return point-list tables, coordinate-system/origin metadata, bounds, and stable canonical attribute names. | **Complete** (**v5.0**) |
 | 5g. Point Cloud conformance | Add deterministic decoder/source fixtures and document unsupported producer-specific extensions. | **Complete** (**v5.0**) |
+| 5h. Point profile support | Decode Point geometry, symbols, attributes, and renderer metadata with representative fixtures. | Planned |
 | 6a. Horizontal CRS transforms | Reproject supported projected and geographic layer/node coordinates into the requested output coordinate system, with axis-order and unit tests. | Planned |
 | 6b. Vertical CRS and elevation | Resolve vertical CRS units and apply every `elevationInfo` mode, including offsets and relative-to-ground behavior. | Planned |
 | 6c. Precision and dateline handling | Preserve Float64 source precision through origin-relative output, and cover antimeridian/dateline bounds without discontinuities. | **Complete** (**v5.0**) |
 | 7a. Profile schema validation | Add discriminated schemas for Point Cloud and mesh profiles, including required index/geometry fields and conditional profile checks. | **Complete** (**v5.0**) |
 | 7b. Cross-profile conformance | Build a fixture matrix for mesh and Point Cloud metadata, malformed profiles, LOD, attributes, and renderer metadata. | **Complete** (**v5.0**) |
 | 7c. Authoring parity | Add Point/Point Cloud converter output and make generated resources pass the same loader and conformance fixtures. | Planned |
+| 8a. ArcGIS SceneServer source | Provide a typed service facade and registry entry that selects the existing mesh or Point Cloud source for an explicit SceneServer layer. | **Complete** (**v5.0**) |
+| 8b. Service discovery and selection | Extend ArcGIS capability discovery to recognize SceneServer metadata and select compatible mesh/Point Cloud layers. | Planned |
 
 The next high-value work is renderer styling, CRS/elevation transforms, query helpers, and Point
 Cloud authoring.
@@ -219,15 +223,18 @@ still visible in the matrix and should be treated as the open work list:
 | Priority | Remaining gap | Exit criteria |
 | --- | --- | --- |
 | P0 | Drawing and popup intelligence (4c) | Evaluate supported renderers, visual variables, labels, and popup expressions while retaining a tested passthrough path for unsupported definitions. |
-| P0 | Point profile | Decode Point geometry, symbols, attributes, and renderer metadata with representative fixtures. Point Cloud support is complete for the documented v5.0 boundary. |
+| P0 | Point profile (5h) | Decode Point geometry, symbols, attributes, and renderer metadata with representative fixtures. Point Cloud support is complete for the documented v5.0 boundary. |
 | P1 | Feature queries and aggregation (4d) | Add authenticated SceneServer attribute query/filter helpers and client-side aggregation over loaded feature batches. |
+| P1 | Service discovery and selection (8b) | Recognize SceneServer entries in ArcGIS service directories and select compatible mesh or Point Cloud layer endpoints. |
 | P1 | Spatial semantics (6a–6b) | Reproject supported horizontal CRSs, honor vertical CRS and units, and apply all `elevationInfo` placement modes. Precision and dateline handling (6c) are complete. |
 | P1 | Mesh renderer fidelity | Decode legacy mesh-segmentation draw ranges, expose additional UV sets, map sampler wrap values to renderer constants, and add non-screen-space LOD policies. |
 | P2 | Authoring parity (7c) | Add Point/Point Cloud converter output and make generated resources pass the profile and semantic tests now covering the loaders. |
 | P2 | Delivery edge cases | Resolve direct-load token propagation, provide a first-class extracted-SLPK source, and cover mixed REST/object-store authentication in tests. |
 
 The roadmap is considered substantially complete when every P0 and P1 row is complete and the P2
-rows have either landed or an explicit, versioned compatibility boundary.
+rows have either landed or an explicit, versioned compatibility boundary. The v5.0 service facade
+is intentionally limited to explicit SceneServer layer URLs; directory discovery and service
+selection remain tranche 8b.
 
 ## Related specifications and documentation
 

--- a/docs/modules/services/README.md
+++ b/docs/modules/services/README.md
@@ -17,6 +17,7 @@ modules lets applications install only the service families they use.
 | ArcGIS ImageServer tiles | `ArcGISImageTileSourceLoader` | `TileSource` | Image tiles or decoded LERC tiles | `SourceLayer` for image tiles | [ImageServer](/docs/modules/services/arcgis-image-server) |
 | ArcGIS MapServer | `ArcGISMapTileSourceLoader` | `TileSource` | Cached or dynamically exported image tiles | `SourceLayer` | [MapServer](/docs/modules/services/arcgis-map-server) |
 | ArcGIS VectorTileServer | `ArcGISVectorTileServerSourceLoader` | `VectorTileSource` | Raw MVT or decoded WGS84 features | `SourceLayer` | [VectorTileServer](/docs/modules/services/arcgis-vector-tile-server) |
+| ArcGIS SceneServer | `ArcGISSceneServerSourceLoader` | `Tileset3DSource` or `PointCloudTilesetSource` | I3S mesh or Point Cloud tiles | Application-specific 3D renderer | [SceneServer](/docs/modules/services/arcgis-scene-server) |
 | ArcGIS service directory | Capability graph utilities | Discovery graph | Ranked service endpoints | Not directly visual | [Capability discovery](#capability-discovery) |
 
 ## Installation
@@ -121,6 +122,29 @@ const source = imagery && createDataSource(imagery.url, SERVICE_LOADERS, {
 
 Discovery performs one metadata request per discovered service. Pass a custom `fetch` function
 when using authentication, a proxy, or a test transport.
+
+## SceneServer layers
+
+`ArcGISSceneServerSource` provides a thin service facade for explicit I3S SceneServer layer
+endpoints. It normalizes layer metadata and delegates traversal and decoding to the existing I3S
+mesh or Point Cloud source.
+
+```ts
+import {ArcGISSceneServerSource} from '@loaders.gl/services';
+import {coreApi} from '@loaders.gl/core';
+
+const service = new ArcGISSceneServerSource(
+  'https://example.com/arcgis/rest/services/City/SceneServer/layers/0',
+  {'arcgis-scene-server': {token: 'secret'}},
+  coreApi
+);
+
+const metadata = await service.getMetadata();
+const tilesetSource = await service.getTilesetSource();
+```
+
+For a URL ending at `/SceneServer`, provide `arcgis-scene-server.layerId`. Point profiles are
+rejected explicitly; mesh and Point Cloud profiles are selected automatically.
 
 ## Choosing a service
 

--- a/docs/modules/services/api-reference/arcgis.md
+++ b/docs/modules/services/api-reference/arcgis.md
@@ -10,6 +10,7 @@ source loader per visual data contract and a shared registry for automatic selec
 | `arcgis-image-server-tiles` | `ImageServer` | `TileSource` | `getMetadata`, `getTile`, `updateParameters` | Image or LERC tile |
 | `arcgis-map-server` | `MapServer` | `TileSource` | `getMetadata`, `getTile`, `updateParameters` | Cached or exported image tile |
 | `arcgis-vector-tile-server` | `VectorTileServer` | `VectorTileSource` | `getMetadata`, `getTile`, `getVectorTile` | PBF or decoded vector tile |
+| `arcgis-scene-server` | `SceneServer` | `Tileset3DSource` or `PointCloudTilesetSource` | `getMetadata`, `getTilesetSource` | I3S mesh or Point Cloud source |
 
 `SERVICE_LOADERS` contains these loaders in deterministic selection order. Pass it to `load`,
 `createDataSource`, or deck.gl's `SourceLayer`:
@@ -21,7 +22,8 @@ import {SERVICE_LOADERS} from '@loaders.gl/services';
 const source = await load(serviceUrl, SERVICE_LOADERS);
 ```
 
-When endpoint rewriting hides `FeatureServer`, `ImageServer`, `MapServer`, or `VectorTileServer`
+When endpoint rewriting hides `FeatureServer`, `ImageServer`, `MapServer`, `VectorTileServer`, or
+`SceneServer`
 from the URL, specify the table's loader type through `core.type`.
 
 ## Exported classes
@@ -33,6 +35,7 @@ from the URL, specify the table's loader type through `core.type`.
 | `ArcGISImageTileSource` | `ArcGISImageTileSourceLoader` | [ImageServer tiles](../arcgis-image-server#image-tiles) |
 | `ArcGISMapTileSource` | `ArcGISMapTileSourceLoader` | [MapServer](../arcgis-map-server) |
 | `ArcGISVectorTileServerSource` | `ArcGISVectorTileServerSourceLoader` | [VectorTileServer](../arcgis-vector-tile-server) |
+| `ArcGISSceneServerSource` | `ArcGISSceneServerSourceLoader` | [SceneServer](../arcgis-scene-server) |
 
 ## Discovery exports
 
@@ -46,9 +49,8 @@ needed.
 
 ## Excluded endpoint families
 
-ArcGIS `SceneServer` is handled by the I3S loaders in `@loaders.gl/i3s`, not by this 2D service
-module. Geocoding, routing, geoprocessing, editing, administration, and portal content APIs are not
-part of the v5 service source foundation.
+Geocoding, routing, geoprocessing, editing, administration, and portal content APIs are not part of
+the v5 service source foundation.
 
 ## ArcGIS references
 

--- a/docs/modules/services/arcgis-scene-server.md
+++ b/docs/modules/services/arcgis-scene-server.md
@@ -1,0 +1,49 @@
+# ArcGIS SceneServer
+
+`ArcGISSceneServerSource` provides a thin service facade for I3S layers published through an ArcGIS
+`SceneServer` endpoint. It fetches and normalizes layer metadata, then delegates traversal and
+content decoding to the existing `I3SSource` or `I3SPointCloudSource` implementation.
+
+## Usage
+
+```ts
+import {coreApi} from '@loaders.gl/core';
+import {ArcGISSceneServerSource} from '@loaders.gl/services';
+
+const source = new ArcGISSceneServerSource(
+  'https://example.com/arcgis/rest/services/City/SceneServer/layers/0',
+  {'arcgis-scene-server': {token: 'secret'}},
+  coreApi
+);
+
+const metadata = await source.getMetadata();
+const tilesetSource = await source.getTilesetSource();
+```
+
+A URL ending at `/SceneServer` can be used with an explicit layer identifier:
+
+```ts
+const source = new ArcGISSceneServerSource(SCENE_SERVER_URL, {
+  'arcgis-scene-server': {layerId: 0}
+});
+```
+
+The source accepts custom fetch implementations through the normal `core.loadOptions` mechanism.
+Tokens can be supplied through `arcgis-scene-server.token` or `i3s.token`. Point profiles are
+reported as unsupported; mesh and Point Cloud profiles are selected automatically.
+
+## API
+
+### `getMetadata()`
+
+Returns the layer URL, layer type, version, storage profile, capabilities, spatial reference,
+extent, and parsed I3S layer document.
+
+### `getTilesetSource()`
+
+Returns an `I3SSource` for mesh layers or an `I3SPointCloudSource` for Point Cloud layers.
+
+### `getLayerURL()`
+
+Returns the normalized `/SceneServer/layers/{id}` URL. A `layerId` option is required when the
+constructor receives a service URL without a layer segment.

--- a/modules/i3s/src/bundled.ts
+++ b/modules/i3s/src/bundled.ts
@@ -28,4 +28,11 @@ export {
   type I3SLEPCCDecoderOptions
 } from './i3s-lepcc';
 export {I3SPointCloudSource} from './i3s-point-cloud-source';
+export {
+  createI3SLayerSource,
+  I3SUnsupportedProfileError,
+  normalizeI3SServiceMetadata,
+  parseI3SSceneLayerMetadata
+} from './i3s-service';
+export type {I3SLayerSource, I3SServiceMetadata} from './i3s-service';
 export type {I3SPointCloudSourceOptions} from './i3s-point-cloud-source';

--- a/modules/i3s/src/i3s-service.ts
+++ b/modules/i3s/src/i3s-service.ts
@@ -1,0 +1,102 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {CoreAPI, DataSourceOptions, LoaderOptions} from '@loaders.gl/loader-utils';
+import {I3SSource} from '@loaders.gl/tiles';
+import {I3SLoaderWithParser} from './i3s-loader-with-parser';
+import {I3SPointCloudSource} from './i3s-point-cloud-source';
+import {I3SPointCloudSceneLayerSchema, I3SSceneLayerSchema} from './i3s-zod-schema';
+import type {SceneLayer3D, SpatialReference, FullExtent} from './types';
+
+/** A source created from an I3S SceneServer layer. */
+export type I3SLayerSource = I3SSource | I3SPointCloudSource;
+
+/** Normalized metadata exposed by a SceneServer layer service. */
+export type I3SServiceMetadata = {
+  /** URL of the SceneServer layer resource. */
+  url: string;
+  /** I3S profile discriminator. */
+  layerType: SceneLayer3D['layerType'];
+  /** I3S document version. */
+  version: string;
+  /** Physical I3S storage profile. */
+  profile: string;
+  /** Layer capabilities advertised by the service. */
+  capabilities: string[];
+  /** Horizontal and vertical spatial reference metadata. */
+  spatialReference?: SpatialReference;
+  /** Layer extent, when advertised. */
+  fullExtent?: FullExtent;
+  /** Human-readable layer name. */
+  name?: string;
+  /** Human-readable layer description. */
+  description?: string;
+  /** Parsed layer document retained for source construction and advanced consumers. */
+  layer: SceneLayer3D;
+};
+
+/** Error raised when a SceneServer layer profile is not supported by loaders.gl. */
+export class I3SUnsupportedProfileError extends Error {
+  /** Unsupported profile or layer type reported by the service. */
+  readonly profile: string;
+
+  /** Creates an unsupported-profile error. */
+  constructor(profile: string) {
+    super(`Unsupported I3S layer profile: ${profile}`);
+    this.name = 'I3SUnsupportedProfileError';
+    this.profile = profile;
+  }
+}
+
+/** Parses and validates a mesh or Point Cloud I3S scene-layer document. */
+export function parseI3SSceneLayerMetadata(document: unknown): SceneLayer3D {
+  const layerType =
+    document && typeof document === 'object' && 'layerType' in document
+      ? (document as {layerType?: unknown}).layerType
+      : undefined;
+  if (layerType === 'Point') {
+    throw new I3SUnsupportedProfileError('Point');
+  }
+  if (layerType === 'PointCloud') {
+    return I3SPointCloudSceneLayerSchema.parse(document) as SceneLayer3D;
+  }
+  return I3SSceneLayerSchema.parse(document) as SceneLayer3D;
+}
+
+/** Normalizes a parsed I3S layer into service metadata. */
+export function normalizeI3SServiceMetadata(url: string, layer: SceneLayer3D): I3SServiceMetadata {
+  return {
+    url,
+    layerType: layer.layerType,
+    version: layer.version,
+    profile: layer.store.profile,
+    capabilities: [...layer.capabilities],
+    spatialReference: layer.spatialReference,
+    fullExtent: layer.fullExtent,
+    name: layer.name,
+    description: layer.description,
+    layer
+  };
+}
+
+/** Creates the profile-specific source used to traverse an I3S layer. */
+export function createI3SLayerSource(
+  url: string,
+  layer: SceneLayer3D,
+  options: DataSourceOptions = {},
+  coreApi?: CoreAPI
+): I3SLayerSource {
+  if (layer.layerType === 'PointCloud') {
+    return new I3SPointCloudSource(url, options);
+  }
+
+  const loadOptions = {
+    ...(options.core?.loadOptions || {}),
+    i3s: {
+      ...((options.core?.loadOptions?.i3s as Record<string, unknown> | undefined) || {}),
+      ...((options['i3s'] as Record<string, unknown> | undefined) || {})
+    }
+  } as LoaderOptions;
+  return new I3SSource({url, loader: I3SLoaderWithParser, coreApi}, loadOptions);
+}

--- a/modules/i3s/src/index.ts
+++ b/modules/i3s/src/index.ts
@@ -89,3 +89,10 @@ export {
 } from './i3s-lepcc';
 export {I3SPointCloudSource} from './i3s-point-cloud-source';
 export type {I3SPointCloudSourceOptions} from './i3s-point-cloud-source';
+export {
+  createI3SLayerSource,
+  I3SUnsupportedProfileError,
+  normalizeI3SServiceMetadata,
+  parseI3SSceneLayerMetadata
+} from './i3s-service';
+export type {I3SLayerSource, I3SServiceMetadata} from './i3s-service';

--- a/modules/i3s/src/unbundled.ts
+++ b/modules/i3s/src/unbundled.ts
@@ -25,4 +25,11 @@ export {
   type I3SLEPCCDecoderOptions
 } from './i3s-lepcc';
 export {I3SPointCloudSource} from './i3s-point-cloud-source';
+export {
+  createI3SLayerSource,
+  I3SUnsupportedProfileError,
+  normalizeI3SServiceMetadata,
+  parseI3SSceneLayerMetadata
+} from './i3s-service';
+export type {I3SLayerSource, I3SServiceMetadata} from './i3s-service';
 export type {I3SPointCloudSourceOptions} from './i3s-point-cloud-source';

--- a/modules/services/package.json
+++ b/modules/services/package.json
@@ -46,6 +46,7 @@
   ],
   "dependencies": {
     "@loaders.gl/gis": "5.0.0-alpha.2",
+    "@loaders.gl/i3s": "5.0.0-alpha.2",
     "@loaders.gl/images": "5.0.0-alpha.2",
     "@loaders.gl/lerc": "5.0.0-alpha.2",
     "@loaders.gl/loader-utils": "5.0.0-alpha.2",

--- a/modules/services/src/arcgis/arcgis-scene-server-source-loader.ts
+++ b/modules/services/src/arcgis/arcgis-scene-server-source-loader.ts
@@ -50,6 +50,7 @@ export class ArcGISSceneServerSource extends DataSource<string, ArcGISSceneServe
   /** Returns the layer URL, resolving an explicit layer ID when needed. */
   getLayerURL(): string {
     const url = new URL(this.url);
+    url.pathname = url.pathname.replace(/\/+$/, '');
     if (/\/SceneServer\/layers\/[^/]+$/i.test(url.pathname)) {
       url.search = '';
       url.hash = '';

--- a/modules/services/src/arcgis/arcgis-scene-server-source-loader.ts
+++ b/modules/services/src/arcgis/arcgis-scene-server-source-loader.ts
@@ -1,0 +1,159 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {CoreAPI, DataSourceOptions, SourceLoader} from '@loaders.gl/loader-utils';
+import {DataSource} from '@loaders.gl/loader-utils';
+import {
+  createI3SLayerSource,
+  normalizeI3SServiceMetadata,
+  parseI3SSceneLayerMetadata
+} from '@loaders.gl/i3s';
+import type {I3SLayerSource, I3SServiceMetadata, SceneLayer3D} from '@loaders.gl/i3s';
+
+/** Options for an ArcGIS SceneServer source. */
+export type ArcGISSceneServerSourceOptions = DataSourceOptions & {
+  'arcgis-scene-server'?: {
+    /** Layer identifier used when the input URL ends at `/SceneServer`. */
+    layerId?: number | string;
+    /** ArcGIS token applied to metadata and tile-resource requests. */
+    token?: string;
+    /** Optional metadata document for offline or preloaded use. */
+    metadata?: unknown;
+  };
+};
+
+/** Source facade for an ArcGIS SceneServer I3S layer. */
+export class ArcGISSceneServerSource extends DataSource<string, ArcGISSceneServerSourceOptions> {
+  /** Cached normalized layer metadata. */
+  private metadataPromise: Promise<I3SServiceMetadata> | null = null;
+  /** Cached profile-specific tileset source. */
+  private sourcePromise: Promise<I3SLayerSource> | null = null;
+
+  /** Creates a SceneServer source. */
+  constructor(url: string, options: ArcGISSceneServerSourceOptions = {}, coreApi?: CoreAPI) {
+    super(url.replace(/\/+$/, ''), options, ArcGISSceneServerSourceLoader.defaultOptions, coreApi);
+  }
+
+  /** Returns normalized SceneServer layer metadata. */
+  async getMetadata(): Promise<I3SServiceMetadata> {
+    this.metadataPromise ||= this.loadMetadata();
+    return await this.metadataPromise;
+  }
+
+  /** Creates the existing mesh or Point Cloud source for this layer. */
+  async getTilesetSource(): Promise<I3SLayerSource> {
+    this.sourcePromise ||= this.createTilesetSource();
+    return await this.sourcePromise;
+  }
+
+  /** Returns the layer URL, resolving an explicit layer ID when needed. */
+  getLayerURL(): string {
+    const url = new URL(this.url);
+    if (/\/SceneServer\/layers\/[^/]+$/i.test(url.pathname)) {
+      url.search = '';
+      url.hash = '';
+      return url.toString();
+    }
+
+    if (!/\/SceneServer$/i.test(url.pathname)) {
+      throw new Error(
+        'ArcGISSceneServerSource requires a /SceneServer/layers/{id} URL or a /SceneServer URL with arcgis-scene-server.layerId'
+      );
+    }
+
+    const layerId = this.options['arcgis-scene-server']?.layerId;
+    if (layerId === undefined) {
+      throw new Error(
+        'ArcGISSceneServerSource requires a /SceneServer/layers/{id} URL or a /SceneServer URL with arcgis-scene-server.layerId'
+      );
+    }
+    url.pathname = `${url.pathname.replace(/\/$/, '')}/layers/${encodeURIComponent(String(layerId))}`;
+    url.search = '';
+    url.hash = '';
+    return url.toString();
+  }
+
+  /** Returns the metadata request URL with ArcGIS JSON and authentication parameters. */
+  metadataURL(): string {
+    const url = new URL(this.getLayerURL());
+    url.searchParams.set('f', 'pjson');
+    const token = this.getToken();
+    if (token && !url.searchParams.has('token')) {
+      url.searchParams.set('token', token);
+    }
+    return url.toString();
+  }
+
+  private async loadMetadata(): Promise<I3SServiceMetadata> {
+    const configuredMetadata = this.options['arcgis-scene-server']?.metadata;
+    const layer = configuredMetadata
+      ? parseI3SSceneLayerMetadata(configuredMetadata)
+      : await this.fetchLayerMetadata();
+    return normalizeI3SServiceMetadata(this.getLayerURL(), layer);
+  }
+
+  private async fetchLayerMetadata(): Promise<SceneLayer3D> {
+    const response = await this.fetch(this.metadataURL());
+    if (!response.ok) {
+      throw new Error(
+        `ArcGIS SceneServer metadata request failed: ${response.status} ${response.statusText}`
+      );
+    }
+    return parseI3SSceneLayerMetadata(await response.json());
+  }
+
+  private async createTilesetSource(): Promise<I3SLayerSource> {
+    const metadata = await this.getMetadata();
+    return createI3SLayerSource(
+      metadata.url,
+      metadata.layer,
+      this.getSourceOptions(),
+      this.coreApi
+    );
+  }
+
+  private getSourceOptions(): DataSourceOptions {
+    const i3sOptions = (this.options['i3s'] as Record<string, unknown> | undefined) || {};
+    const token = this.getToken();
+    return {
+      ...this.options,
+      i3s: token ? {...i3sOptions, token} : i3sOptions
+    };
+  }
+
+  private getToken(): string | undefined {
+    const serviceToken = this.options['arcgis-scene-server']?.token;
+    const i3sToken = (this.options['i3s'] as Record<string, unknown> | undefined)?.token;
+    if (serviceToken) {
+      return serviceToken;
+    }
+    if (typeof i3sToken === 'string' && i3sToken) {
+      return i3sToken;
+    }
+    return new URL(this.url).searchParams.get('token') || undefined;
+  }
+}
+
+/** Source loader for ArcGIS SceneServer I3S layers. */
+export const ArcGISSceneServerSourceLoader = {
+  dataType: null as unknown as ArcGISSceneServerSource,
+  batchType: null as never,
+  name: 'ArcGIS SceneServer',
+  id: 'arcgis-scene-server',
+  module: 'services',
+  version: '0.0.0',
+  extensions: [],
+  mimeTypes: ['application/json'],
+  type: 'arcgis-scene-server',
+  fromUrl: true,
+  fromBlob: false,
+  options: {'arcgis-scene-server': {}},
+  defaultOptions: {'arcgis-scene-server': {}},
+  testURL: (url: string): boolean => /\/SceneServer(?:[\/?#]|$)/i.test(url),
+  createDataSource: (
+    url: string,
+    options: ArcGISSceneServerSourceOptions = {},
+    coreApi?: CoreAPI
+  ) => new ArcGISSceneServerSource(url, options, coreApi)
+} as const satisfies SourceLoader<ArcGISSceneServerSource>;

--- a/modules/services/src/index.ts
+++ b/modules/services/src/index.ts
@@ -62,5 +62,12 @@ export type {
   ArcGISVectorTileServerSourceLoaderOptions
 } from './arcgis/arcgis-vector-tile-server-source-loader';
 
+/** ArcGIS SceneServer I3S source and loader. */
+export {
+  ArcGISSceneServerSourceLoader,
+  ArcGISSceneServerSource
+} from './arcgis/arcgis-scene-server-source-loader';
+export type {ArcGISSceneServerSourceOptions} from './arcgis/arcgis-scene-server-source-loader';
+
 export type {ServiceLoader} from './service-registry';
 export {SERVICE_LOADERS, getServiceLoader} from './service-registry';

--- a/modules/services/src/service-registry.ts
+++ b/modules/services/src/service-registry.ts
@@ -6,6 +6,7 @@ import {ArcGISFeatureServerSourceLoader} from './arcgis/arcgis-feature-server-so
 import {ArcGISImageServerSourceLoader} from './arcgis/arcgis-image-server-source-loader';
 import {ArcGISImageTileSourceLoader} from './arcgis/arcgis-image-tile-source-loader';
 import {ArcGISMapTileSourceLoader} from './arcgis/arcgis-map-tile-source-loader';
+import {ArcGISSceneServerSourceLoader} from './arcgis/arcgis-scene-server-source-loader';
 import {ArcGISVectorTileServerSourceLoader} from './arcgis/arcgis-vector-tile-server-source-loader';
 
 /** A source loader currently exposed through the services package. */
@@ -14,7 +15,8 @@ export type ServiceLoader =
   | typeof ArcGISImageServerSourceLoader
   | typeof ArcGISImageTileSourceLoader
   | typeof ArcGISMapTileSourceLoader
-  | typeof ArcGISVectorTileServerSourceLoader;
+  | typeof ArcGISVectorTileServerSourceLoader
+  | typeof ArcGISSceneServerSourceLoader;
 
 /** All source loaders owned by `@loaders.gl/services`, in URL-selection order. */
 export const SERVICE_LOADERS: ServiceLoader[] = [
@@ -22,7 +24,8 @@ export const SERVICE_LOADERS: ServiceLoader[] = [
   ArcGISImageServerSourceLoader,
   ArcGISImageTileSourceLoader,
   ArcGISMapTileSourceLoader,
-  ArcGISVectorTileServerSourceLoader
+  ArcGISVectorTileServerSourceLoader,
+  ArcGISSceneServerSourceLoader
 ];
 
 /**

--- a/modules/services/test/arcgis/arcgis-scene-server-source.spec.ts
+++ b/modules/services/test/arcgis/arcgis-scene-server-source.spec.ts
@@ -133,3 +133,10 @@ test('ArcGISSceneServerSourceLoader detects SceneServer URLs', () => {
   expect(ArcGISSceneServerSourceLoader.testURL(`${SCENE_SERVER_URL}/layers/0`)).toBe(true);
   expect(ArcGISSceneServerSourceLoader.testURL('https://example.com/FeatureServer/0')).toBe(false);
 });
+
+test('ArcGISSceneServerSource normalizes a trailing slash before query parameters', () => {
+  const source = new ArcGISSceneServerSource(`${SCENE_SERVER_URL}/layers/0/?token=url-secret`);
+
+  expect(source.getLayerURL()).toBe(`${SCENE_SERVER_URL}/layers/0`);
+  expect(source.metadataURL()).toBe(`${SCENE_SERVER_URL}/layers/0?f=pjson&token=url-secret`);
+});

--- a/modules/services/test/arcgis/arcgis-scene-server-source.spec.ts
+++ b/modules/services/test/arcgis/arcgis-scene-server-source.spec.ts
@@ -1,0 +1,135 @@
+import {fetchFile} from '@loaders.gl/core';
+import {I3SPointCloudSource} from '@loaders.gl/i3s';
+import {I3SSource} from '@loaders.gl/tiles';
+import {ArcGISSceneServerSource, ArcGISSceneServerSourceLoader} from '@loaders.gl/services';
+import {expect, test, vi} from 'vitest';
+
+const SCENE_SERVER_URL = 'https://example.com/arcgis/rest/services/City/SceneServer';
+const MESH_FIXTURE = '@loaders.gl/i3s/test/data/conformance/i3s-1.8-3d-object.json';
+const POINT_CLOUD_FIXTURE = '@loaders.gl/i3s/test/data/conformance/i3s-2.1-point-cloud.json';
+
+const MESH_LAYER = {
+  id: 0,
+  layerType: '3DObject',
+  version: '1.7',
+  name: 'Buildings',
+  description: 'Building scene layer',
+  capabilities: ['View'],
+  disablePopup: false,
+  spatialReference: {wkid: 4326},
+  fullExtent: {xmin: -1, ymin: -2, xmax: 3, ymax: 4, zmin: 0, zmax: 20},
+  store: {
+    profile: 'meshpyramids',
+    version: '1.7',
+    defaultGeometrySchema: {}
+  },
+  nodePages: {nodesPerPage: 64, lodSelectionMetricType: 'maxScreenThresholdSQ'}
+};
+
+const POINT_CLOUD_LAYER = {
+  id: 0,
+  layerType: 'PointCloud',
+  version: '2.1',
+  capabilities: ['View'],
+  disablePopup: false,
+  spatialReference: {wkid: 4326},
+  store: {
+    profile: 'pointcloud',
+    version: '2.1',
+    index: {nodePerIndexBlock: 64},
+    defaultGeometrySchema: {geometryType: 'points', encoding: 'lepcc-xyz'}
+  }
+};
+
+/** Reads a JSON fixture through the same fetch abstraction used by service consumers. */
+async function loadJSONFixture(url: string): Promise<unknown> {
+  const response = await fetchFile(url);
+  return JSON.parse(await response.text());
+}
+
+test('ArcGISSceneServerSource normalizes metadata and creates a mesh source', async () => {
+  const source = new ArcGISSceneServerSource(`${SCENE_SERVER_URL}/layers/0`, {
+    'arcgis-scene-server': {token: 'secret'}
+  });
+  const fetch = vi.fn(async (url: string) => {
+    expect(new URL(url).searchParams.get('token')).toBe('secret');
+    return new Response(JSON.stringify(MESH_LAYER));
+  });
+  source.fetch = fetch;
+
+  const metadata = await source.getMetadata();
+  expect(metadata).toMatchObject({
+    url: `${SCENE_SERVER_URL}/layers/0`,
+    layerType: '3DObject',
+    profile: 'meshpyramids',
+    version: '1.7',
+    spatialReference: {wkid: 4326}
+  });
+  expect(await source.getTilesetSource()).toBeInstanceOf(I3SSource);
+  expect(fetch).toHaveBeenCalledTimes(1);
+});
+
+test('ArcGISSceneServerSource selects Point Cloud sources', async () => {
+  const source = new ArcGISSceneServerSource(`${SCENE_SERVER_URL}/layers/0`, {
+    'arcgis-scene-server': {metadata: POINT_CLOUD_LAYER}
+  });
+
+  const metadata = await source.getMetadata();
+  expect(metadata.layerType).toBe('PointCloud');
+  expect(await source.getTilesetSource()).toBeInstanceOf(I3SPointCloudSource);
+});
+
+test('ArcGISSceneServerSource accepts the mesh and Point Cloud conformance fixtures', async () => {
+  const [meshLayer, pointCloudLayer] = await Promise.all([
+    loadJSONFixture(MESH_FIXTURE),
+    loadJSONFixture(POINT_CLOUD_FIXTURE)
+  ]);
+
+  const meshSource = new ArcGISSceneServerSource(`${SCENE_SERVER_URL}/layers/0`, {
+    'arcgis-scene-server': {metadata: meshLayer}
+  });
+  const pointCloudSource = new ArcGISSceneServerSource(`${SCENE_SERVER_URL}/layers/1`, {
+    'arcgis-scene-server': {metadata: pointCloudLayer}
+  });
+
+  expect((await meshSource.getMetadata()).version).toBe('1.8');
+  expect(await meshSource.getTilesetSource()).toBeInstanceOf(I3SSource);
+  expect((await pointCloudSource.getMetadata()).version).toBe('2.1');
+  expect(await pointCloudSource.getTilesetSource()).toBeInstanceOf(I3SPointCloudSource);
+});
+
+test('ArcGISSceneServerSource resolves a layer ID and preserves source tokens', async () => {
+  const source = new ArcGISSceneServerSource(SCENE_SERVER_URL, {
+    'arcgis-scene-server': {layerId: 2, token: 'secret'},
+    core: {loadOptions: {core: {fetch: async () => new Response(JSON.stringify(MESH_LAYER))}}}
+  });
+  source.fetch = async url => {
+    expect(url).toBe(`${SCENE_SERVER_URL}/layers/2?f=pjson&token=secret`);
+    return new Response(JSON.stringify(MESH_LAYER));
+  };
+
+  expect(source.getLayerURL()).toBe(`${SCENE_SERVER_URL}/layers/2`);
+  await source.getMetadata();
+  const tilesetSource = (await source.getTilesetSource()) as I3SSource;
+  expect(tilesetSource.getTileUrl(`${SCENE_SERVER_URL}/layers/2/nodes/1`)).toBe(
+    `${SCENE_SERVER_URL}/layers/2/nodes/1?token=secret`
+  );
+});
+
+test('ArcGISSceneServerSource rejects unsupported Point layers with a typed error', async () => {
+  const source = new ArcGISSceneServerSource(`${SCENE_SERVER_URL}/layers/0`, {
+    'arcgis-scene-server': {
+      metadata: {...MESH_LAYER, layerType: 'Point'}
+    }
+  });
+
+  await expect(source.getMetadata()).rejects.toMatchObject({
+    name: 'I3SUnsupportedProfileError',
+    profile: 'Point'
+  });
+});
+
+test('ArcGISSceneServerSourceLoader detects SceneServer URLs', () => {
+  expect(ArcGISSceneServerSourceLoader.testURL(`${SCENE_SERVER_URL}/layers/0`)).toBe(true);
+  expect(ArcGISSceneServerSourceLoader.testURL('https://example.com/FeatureServer/0')).toBe(false);
+});

--- a/modules/services/test/services-module.spec.ts
+++ b/modules/services/test/services-module.spec.ts
@@ -3,6 +3,7 @@ import {
   ArcGISImageServerSourceLoader,
   ArcGISImageTileSourceLoader,
   ArcGISMapTileSourceLoader,
+  ArcGISSceneServerSourceLoader,
   ArcGISVectorTileServerSourceLoader,
   ArcGISVectorSource,
   SERVICE_LOADERS,
@@ -23,6 +24,7 @@ describe('@loaders.gl/services', () => {
     expect(ArcGISMapTileSourceLoader.id).toBe('arcgis-map-server');
     expect(ArcGISImageTileSourceLoader.id).toBe('arcgis-image-server-tiles');
     expect(ArcGISVectorTileServerSourceLoader.id).toBe('arcgis-vector-tile-server');
+    expect(ArcGISSceneServerSourceLoader.id).toBe('arcgis-scene-server');
   });
 
   test('identifies services-owned loaders', () => {
@@ -36,6 +38,7 @@ describe('@loaders.gl/services', () => {
   test('finds service loaders by id or type', () => {
     expect(getServiceLoader('ArcGIS-Feature-Server')).toBe(ArcGISFeatureServerSourceLoader);
     expect(getServiceLoader('arcgis-vector-tile-server')).toBe(ArcGISVectorTileServerSourceLoader);
+    expect(getServiceLoader('arcgis-scene-server')).toBe(ArcGISSceneServerSourceLoader);
     expect(getServiceLoader('unknown-service')).toBeUndefined();
   });
 
@@ -45,7 +48,8 @@ describe('@loaders.gl/services', () => {
       ArcGISImageServerSourceLoader,
       ArcGISImageTileSourceLoader,
       ArcGISMapTileSourceLoader,
-      ArcGISVectorTileServerSourceLoader
+      ArcGISVectorTileServerSourceLoader,
+      ArcGISSceneServerSourceLoader
     ]);
   });
 
@@ -62,6 +66,8 @@ describe('@loaders.gl/services', () => {
   test('keeps the package entrypoints wired to the public exports', () => {
     expect(bundledServices.ArcGISFeatureServerSourceLoader).toBe(ArcGISFeatureServerSourceLoader);
     expect(unbundledServices.ArcGISFeatureServerSourceLoader).toBe(ArcGISFeatureServerSourceLoader);
+    expect(bundledServices.ArcGISSceneServerSourceLoader).toBe(ArcGISSceneServerSourceLoader);
+    expect(unbundledServices.ArcGISSceneServerSourceLoader).toBe(ArcGISSceneServerSourceLoader);
   });
 
   test('discovers services from ArcGIS server directories', async () => {

--- a/modules/services/tsconfig.json
+++ b/modules/services/tsconfig.json
@@ -10,6 +10,7 @@
   "references": [
     {"path": "../gis"},
     {"path": "../images"},
+    {"path": "../i3s"},
     {"path": "../lerc"},
     {"path": "../loader-utils"},
     {"path": "../mvt"},

--- a/yarn.lock
+++ b/yarn.lock
@@ -5760,6 +5760,7 @@ __metadata:
   resolution: "@loaders.gl/services@workspace:modules/services"
   dependencies:
     "@loaders.gl/gis": "npm:5.0.0-alpha.2"
+    "@loaders.gl/i3s": "npm:5.0.0-alpha.2"
     "@loaders.gl/images": "npm:5.0.0-alpha.2"
     "@loaders.gl/lerc": "npm:5.0.0-alpha.2"
     "@loaders.gl/loader-utils": "npm:5.0.0-alpha.2"


### PR DESCRIPTION
## Goals

- Add a canonical `ArcGISSceneServerSource` facade for explicit I3S SceneServer layers.
- Reuse the existing mesh and Point Cloud sources while preserving metadata, authentication, fetch, and core API integration.
- Update the I3S roadmap and ArcGIS services documentation with the remaining tranches.

## Changes

- Added shared I3S metadata normalization, profile selection, and typed unsupported-profile errors.
- Added `ArcGISSceneServerSource` and `ArcGISSceneServerSourceLoader` with `arcgis-scene-server` registry support.
- Supports `/SceneServer/layers/{id}` URLs and `/SceneServer` URLs with an explicit `layerId`.
- Selects `I3SSource` for mesh profiles and `I3SPointCloudSource` for Point Cloud profiles; rejects Point profiles clearly.
- Added bundled/unbundled exports, services build reference, registry coverage, token/custom-fetch tests, and conformance-fixture tests.
- Documented the SceneServer API and updated the I3S roadmap, including tranche 5h and service discovery tranche 8b.

## Validation

- `yarn build-modules`
- `yarn test-node`
- Focused Chromium tests for the SceneServer facade and services registry
- `yarn test-audit`
- `yarn lint fix`
