### PR TITLE
test: cover Lance and Draco parser branches

### DIFF
--- a/modules/draco/test/lib/draco-parser.spec.ts
+++ b/modules/draco/test/lib/draco-parser.spec.ts
@@ -156,3 +156,40 @@ test('DracoParser copies mesh indices and handles metadata absence', () => {
   expect(parser._getDracoMetadata({ptr: 0} as any)).toEqual({});
   parser.destroy();
 });
+
+test('DracoParser maps supported scalar data types and rejects unknown types', () => {
+  const parser = createParser();
+  const attribute = {
+    unique_id: 1,
+    attribute_type: 4,
+    num_components: 1,
+    byte_offset: 0,
+    byte_stride: 4,
+    normalized: false,
+    attribute_index: 0,
+    metadata: {}
+  } as any;
+  const constructors = [
+    Int8Array,
+    Uint8Array,
+    Int16Array,
+    Uint16Array,
+    Int32Array,
+    Uint32Array,
+    Float32Array
+  ];
+  const dataTypes = [1, 2, 3, 4, 5, 6, 9];
+
+  for (const [index, constructor] of constructors.entries()) {
+    expect(
+      parser._getAttributeValues({num_points: () => 2} as any, {
+        ...attribute,
+        data_type: dataTypes[index]
+      }).value
+    ).toBeInstanceOf(constructor);
+  }
+
+  expect(
+    parser._getAttributeValues({num_points: () => 2} as any, {...attribute, data_type: 99})
+  ).toBeNull();
+});

--- a/modules/lance/test/manifest-coverage.spec.ts
+++ b/modules/lance/test/manifest-coverage.spec.ts
@@ -1,0 +1,137 @@
+import {expect, test} from 'vitest';
+import {parseLanceManifest} from '../src/lance-manifest';
+import {LanceSourceLoader} from '../src/lance-source-loader';
+
+function varint(value: number): number[] {
+  const bytes: number[] = [];
+  do {
+    let byte = value & 0x7f;
+    value >>>= 7;
+    if (value) byte |= 0x80;
+    bytes.push(byte);
+  } while (value);
+  return bytes;
+}
+
+function field(number: number, value: number | number[]): number[] {
+  const bytes = varint(number << 3);
+  return [...bytes, ...(Array.isArray(value) ? value : varint(value))];
+}
+
+function bytesField(number: number, value: number[]): number[] {
+  return [...varint((number << 3) | 2), ...varint(value.length), ...value];
+}
+
+function stringField(number: number, value: string): number[] {
+  return bytesField(number, Array.from(new TextEncoder().encode(value)));
+}
+
+function createManifest(): Uint8Array {
+  const fieldMessage = [
+    ...field(1, 2),
+    ...stringField(2, 'temperature'),
+    ...field(3, 7),
+    ...field(4, 0),
+    ...stringField(5, 'float32'),
+    ...field(6, 1),
+    0x49,
+    ...new Array(8).fill(0)
+  ];
+  const dataFile = [
+    ...stringField(1, 'fragment.lance'),
+    ...field(2, 7),
+    ...bytesField(2, [8, 9]),
+    ...field(4, 1),
+    ...field(5, 2),
+    ...field(6, 123),
+    ...field(7, 4)
+  ];
+  const fragment = [...field(1, 3), ...bytesField(2, dataFile), ...field(4, 12)];
+  const dataFormat = [...stringField(1, 'lance'), ...stringField(2, '2.0')];
+  return Uint8Array.from([
+    ...bytesField(1, fieldMessage),
+    ...bytesField(2, fragment),
+    ...field(3, 9),
+    ...field(9, 5),
+    ...bytesField(15, dataFormat),
+    0x2d,
+    1,
+    2,
+    3,
+    4
+  ]);
+}
+
+test('parseLanceManifest decodes optional fields, packed ids, and skipped protobuf fields', () => {
+  const manifest = parseLanceManifest(createManifest());
+
+  expect(manifest.version).toBe(9);
+  expect(manifest.readerFeatureFlags).toBe(5);
+  expect(manifest.dataFormat).toEqual({fileFormat: 'lance', version: '2.0'});
+  expect(manifest.fields[0]).toEqual({
+    type: 2,
+    name: 'temperature',
+    id: 7,
+    parentId: 0,
+    logicalType: 'float32',
+    nullable: true
+  });
+  expect(manifest.fragments[0]).toEqual({
+    id: 3,
+    physicalRows: 12,
+    files: [
+      {
+        path: 'fragment.lance',
+        fieldIds: [7, 8, 9],
+        fileMajorVersion: 1,
+        fileMinorVersion: 2,
+        fileSizeBytes: 123,
+        baseId: 4
+      }
+    ]
+  });
+});
+
+test('LanceSource resolves latest and explicit manifest URLs', async () => {
+  const manifest = createManifest();
+  const fetch = async (url: string) => {
+    if (url.endsWith('latest_version_hint.json'))
+      return new Response(JSON.stringify({version: 9}), {status: 200});
+    return new Response(manifest, {status: 200});
+  };
+
+  const latestSource = LanceSourceLoader.createDataSource('https://example.com/table.lance/', {
+    core: {loadOptions: {core: {fetch}}}
+  } as any);
+  expect((await latestSource.getMetadata()).manifestURL).toBe(
+    'https://example.com/table.lance/_versions/9.manifest'
+  );
+
+  const explicitSource = LanceSourceLoader.createDataSource('https://example.com/table.lance', {
+    lance: {version: 4},
+    core: {loadOptions: {core: {fetch}}}
+  } as any);
+  expect((await explicitSource.getMetadata()).manifestURL).toBe(
+    'https://example.com/table.lance/_versions/4.manifest'
+  );
+});
+
+test('LanceSource reports manifest discovery and HTTP failures', async () => {
+  const failingFetch = async () => new Response('missing', {status: 404});
+  const source = LanceSourceLoader.createDataSource('https://example.com/table.lance', {
+    core: {loadOptions: {core: {fetch: failingFetch}}}
+  } as any);
+
+  await expect(source.getMetadata()).rejects.toThrow(
+    'Unable to discover the latest Lance manifest'
+  );
+
+  const invalidHintSource = LanceSourceLoader.createDataSource('https://example.com/table.lance', {
+    core: {
+      loadOptions: {
+        core: {fetch: async () => new Response(JSON.stringify({}), {status: 200})}
+      }
+    }
+  } as any);
+  await expect(invalidHintSource.getMetadata()).rejects.toThrow('does not contain a version');
+});


### PR DESCRIPTION
Goals

Increase coverage meaningfully in high-debt published modules while keeping the required test path fast and hermetic.

Changes

- Add Lance manifest protobuf coverage for optional metadata, packed and unpacked field IDs, skipped wire types, and nested data-file metadata.
- Add Lance source coverage for latest-version discovery, explicit-version manifests, and discovery failure paths.
- Add Draco parser coverage for every supported scalar data type and unsupported attribute handling.
- Keep all cases in-memory with small deterministic fixtures; no 3D Tiles, network calls, large files, or worker suites were added.

Validation

- yarn lint fix
- yarn test-headless modules/lance/test/manifest-coverage.spec.ts modules/lance/test/lance-scaffold.spec.ts modules/draco/test/lib/draco-parser.spec.ts
- 26 tests passed in 1.14s
- yarn test-audit: 616 files, 0 Tape, 45 skipped, 0 violations
- git diff --check

No production code or coverage thresholds were changed.