### PR TITLE
test: expand high-impact module coverage

### DIFF
--- a/modules/geotiff/test/ome-helpers.spec.ts
+++ b/modules/geotiff/test/ome-helpers.spec.ts
@@ -6,6 +6,7 @@ import {describe, expect, test, vi} from 'vitest';
 
 import {getOmeLegacyIndexer, getOmeSubIFDIndexer} from '../src/lib/ome/ome-indexers';
 import {getOmePixelSourceMeta} from '../src/lib/ome/ome-utils';
+import {getDims, getLabels} from '../src/lib/ome/utils';
 
 const PIXELS = {
   SizeT: 2,
@@ -18,6 +19,14 @@ const PIXELS = {
 };
 
 describe('OME-TIFF helpers', () => {
+  test('maps dimension orders and rejects duplicate or unknown dimensions', () => {
+    expect(getLabels('XYZCT')).toEqual(['t', 'c', 'z', 'y', 'x']);
+    const dimensions = getDims(['t', 'c', 'z', 'y', 'x']);
+    expect(dimensions('x')).toBe(4);
+    expect(() => getDims(['x', 'y', 'x'])).toThrow('duplicated label');
+    expect(() => dimensions('missing' as any)).toThrow('Invalid dimension');
+  });
+
   test.each([
     ['XYZCT', 6],
     ['XYZTC', 2],

--- a/modules/netcdf/test/netcdfjs/read-type.spec.ts
+++ b/modules/netcdf/test/netcdfjs/read-type.spec.ts
@@ -63,4 +63,15 @@ describe('NetCDF type helpers', () => {
     expect(num2bytes(99)).toBe(-1);
     expect(str2num('unknown')).toBe(-1);
   });
+
+  test('reads numeric arrays with their native scalar readers', () => {
+    const buffer = createBuffer();
+
+    expect(readType(buffer, TYPES.SHORT, 2)).toEqual([-16, -16]);
+    expect(readType(buffer, TYPES.FLOAT, 2)).toEqual([32.5, 32.5]);
+    expect(readType(buffer, TYPES.DOUBLE, 2)).toEqual([64.5, 64.5]);
+    expect(buffer.readInt16).toHaveBeenCalledTimes(2);
+    expect(buffer.readFloat32).toHaveBeenCalledTimes(2);
+    expect(buffer.readFloat64).toHaveBeenCalledTimes(2);
+  });
 });

--- a/modules/wms/test/gml/parse-gml.spec.ts
+++ b/modules/wms/test/gml/parse-gml.spec.ts
@@ -9,6 +9,7 @@ import {
   parseCurveSegments,
   parseGMLFeature,
   parseGMLFeatureCollection,
+  parseGML,
   parseGMLToGeometry,
   parseLinearRingOrLineString,
   parseMultiLineString,
@@ -36,6 +37,69 @@ const POLYGON = {
 };
 
 describe('GML geometry helpers', () => {
+  test('parses XML feature collections and typed properties', () => {
+    const result = parseGML(
+      `<gml:FeatureCollection xmlns:gml="http://www.opengis.net/gml" xmlns:app="urn:app">
+        <gml:featureMembers>
+          <app:place gml:id="place.2">
+            <app:name>Harbor</app:name>
+            <app:active>true</app:active>
+            <app:count>7</app:count>
+            <app:score>2.5</app:score>
+            <app:when>2026-08-28</app:when>
+            <app:shape><gml:Point srsDimension="3"><gml:pos>1 2 3</gml:pos></gml:Point></app:shape>
+          </app:place>
+        </gml:featureMembers>
+      </gml:FeatureCollection>`,
+      {
+        propertyTypes: {
+          active: 'boolean',
+          count: 'integer',
+          score: 'number',
+          when: 'date'
+        }
+      }
+    ) as any;
+
+    expect(result.type).toBe('FeatureCollection');
+    expect(result.features[0]).toMatchObject({
+      id: 'place.2',
+      properties: {
+        name: 'Harbor',
+        active: true,
+        count: 7,
+        score: 2.5
+      },
+      geometry: {type: 'Point', coordinates: [1, 2, 3]}
+    });
+    expect(result.features[0].properties.when).toBe('2026-08-28');
+  });
+
+  test('parses bare XML geometries and four-dimensional coordinates', () => {
+    expect(
+      parseGML(
+        '<gml:Point xmlns:gml="http://www.opengis.net/gml"><gml:pos>1 2</gml:pos></gml:Point>',
+        {}
+      )
+    ).toEqual({
+      type: 'Point',
+      coordinates: [1, 2]
+    });
+    expect(
+      parseGMLToGeometry(
+        {'gml:LineString': {'gml:posList': '1 2 3 4 5 6 7 8'}},
+        {stride: 4},
+        CONTEXT
+      )
+    ).toMatchObject({
+      type: 'LineString',
+      coordinates: [
+        [1, 2, 3, 4],
+        [5, 6, 7, 8]
+      ]
+    });
+  });
+
   test('parses point and line coordinate encodings', () => {
     expect(parsePos({value: '1 2'}, OPTIONS, CONTEXT)).toEqual([1, 2]);
     expect(parsePosList({value: '1 2 3 4'}, OPTIONS, CONTEXT)).toEqual([

--- a/modules/wms/test/service-capabilities.spec.ts
+++ b/modules/wms/test/service-capabilities.spec.ts
@@ -1,5 +1,11 @@
 import {expect, test} from 'vitest';
-import {normalizeWMSCapabilities, normalizeWMTSCapabilities} from '@loaders.gl/wms';
+import {
+  normalizeTileServiceCapabilities,
+  normalizeVectorServiceCapabilities,
+  normalizeWFSCapabilities,
+  normalizeWMSCapabilities,
+  normalizeWMTSCapabilities
+} from '@loaders.gl/wms';
 
 test('normalizes WMS capabilities into shared service metadata', () => {
   const normalized = normalizeWMSCapabilities(
@@ -53,4 +59,89 @@ test('normalizes WMTS matrix CRS and formats', () => {
   expect(normalized.type).toBe('wmts');
   expect(normalized.crs).toEqual(['EPSG:3857']);
   expect(normalized.operations).toEqual(['GetTile']);
+});
+
+test('flattens nested WMS layers and removes duplicate metadata', () => {
+  const normalized = normalizeWMSCapabilities({
+    name: 'catalog',
+    layers: [
+      {
+        title: 'Group',
+        crs: ['EPSG:3857', 'EPSG:3857'],
+        layers: [
+          {
+            name: 'buildings',
+            title: 'Buildings',
+            crs: ['EPSG:4326'],
+            geographicBoundingBox: [
+              [0, 1],
+              [2, 3]
+            ],
+            keywords: []
+          }
+        ],
+        keywords: []
+      }
+    ],
+    requests: {GetMap: {mimeTypes: ['image/png', 'image/png']}, GetFeatureInfo: {mimeTypes: []}},
+    keywords: []
+  });
+
+  expect(normalized.layers).toHaveLength(2);
+  expect(normalized.layers[0].name).toBe('');
+  expect(normalized.layers[1]).toMatchObject({name: 'buildings', bounds: [0, 1, 2, 3]});
+  expect(normalized.crs).toEqual(['EPSG:3857', 'EPSG:4326']);
+  expect(normalized.formats).toEqual(['image/png']);
+});
+
+test('normalizes WFS, tile, and vector metadata variants', () => {
+  const wfs = normalizeWFSCapabilities(
+    {
+      serviceIdentification: {serviceType: 'WFS', title: 'Features'},
+      contents: {layers: [{identifier: 'roads', title: 'Roads', formats: ['geojson', 'geojson']}]},
+      operationsMetadata: {GetCapabilities: {}, GetFeature: {}}
+    } as any,
+    'https://example.com/wfs'
+  );
+  expect(wfs).toMatchObject({
+    type: 'wfs',
+    name: 'WFS',
+    formats: ['geojson'],
+    layers: [{name: 'roads', title: 'Roads'}]
+  });
+
+  const tile = normalizeTileServiceCapabilities(
+    {
+      name: 'satellite',
+      title: 'Satellite',
+      format: 'image/jpeg',
+      layer: {name: 'imagery', title: 'Imagery', srs: ['EPSG:3857']}
+    } as any,
+    'arcgis-map-server'
+  );
+  expect(tile).toMatchObject({
+    type: 'arcgis-map-server',
+    formats: ['image/jpeg'],
+    operations: ['GetTile']
+  });
+
+  const vector = normalizeVectorServiceCapabilities(
+    {
+      name: 'roads',
+      title: 'Road network',
+      abstract: 'Roads',
+      layers: [
+        {name: 'roads', title: 'Roads', crs: ['EPSG:4326']},
+        {name: undefined, title: 'Bridges', crs: ['EPSG:4326', 'EPSG:3857']}
+      ],
+      formatSpecificMetadata: {source: 'test'}
+    } as any,
+    'arcgis-feature-server'
+  );
+  expect(vector).toMatchObject({
+    type: 'arcgis-feature-server',
+    crs: ['EPSG:4326', 'EPSG:3857'],
+    layers: [{name: 'roads'}, {name: ''}],
+    operations: ['GetFeature']
+  });
 });


### PR DESCRIPTION
## Goals

- Increase coverage in several low-coverage, high-value published modules with one substantial tranche.
- Continue the Tape-to-Vitest migration without increasing fixture size or adding slow network-dependent tests.

## Changes

- Expand WMS GML parsing coverage for XML feature collections, typed properties, bare geometries, and four-dimensional coordinates.
- Cover WMS capability normalization for nested layers, duplicate metadata, WFS, tile, and vector service variants.
- Cover GeoTIFF OME dimension mapping and invalid dimension handling.
- Cover NetCDF numeric array readers for short, float, and double values.

## Validation

- 36 focused Chromium tests passed.
- `yarn test-audit` passed: 615 files, 0 Tape, 45 skipped, 0 violations.
- `yarn lint fix` passed.
- No large fixtures, workers, public-network calls, or 3D Tiles tests added.