### PR TITLE
test: add mega coverage tranche for dense paths

### DIFF
--- a/modules/csv/test/parse-raw-arrow-csv-bytes.spec.ts
+++ b/modules/csv/test/parse-raw-arrow-csv-bytes.spec.ts
@@ -160,6 +160,30 @@ describe('raw Arrow CSV parser', () => {
     expect(getArrowColumnValues(arrayBufferTable, 'label')).toEqual(['alpha', null, 'beta']);
   });
 
+  test.each([
+    ['true,false\nTRUE,false\n', ['bool', 'bool'], [{true: true, false: false}]],
+    ['integer,decimal\n-12,3.5\n', ['float64', 'float64'], [{integer: -12, decimal: 3.5}]],
+    [
+      'when\n2025-01-02T03:04:05Z\n',
+      ['date-millisecond'],
+      [{when: Date.parse('2025-01-02T03:04:05Z')}]
+    ]
+  ])('infers direct typed columns for %s', async (csvText, expectedTypes, expectedRows) => {
+    const table = await parseCSVTextAsArrow(csvText, {
+      csv: {header: true, dynamicTyping: true}
+    });
+    expect(table.schema.fields.map(field => field.type)).toEqual(expectedTypes);
+    expect(toRows(table)).toEqual(expectedRows);
+  });
+
+  test('falls back to UTF-8 when a typed column mixes scalar kinds', async () => {
+    const table = await parseCSVTextAsArrow('value\n1\ntrue\ntext\n', {
+      csv: {header: true, dynamicTyping: true}
+    });
+    expect(table.schema.fields[0].type).toBe('utf8');
+    expect(toRows(table)).toEqual([{value: '1'}, {value: 'true'}, {value: 'text'}]);
+  });
+
   test('freezes inferred types across Arrow batches', async () => {
     const chunks = [encode('value,name\n1,first\n'), encode('text,second\n3,third\n')];
     const batches = parseCSVInArrowBatches(chunks, {

--- a/modules/gis/test/geometry-converters/wkb/convert-wkb-to-geometry.spec.ts
+++ b/modules/gis/test/geometry-converters/wkb/convert-wkb-to-geometry.spec.ts
@@ -219,6 +219,24 @@ test('triangulateWKB#handles empty and degenerate polygons', () => {
   expect(triangulateWKB(degeneratePolygon)).toEqual([]);
 });
 
+test('triangulateWKB#handles EWKB SRID metadata without changing indices', () => {
+  const polygon = {
+    type: 'Polygon' as const,
+    coordinates: [
+      [
+        [0, 0],
+        [4, 0],
+        [4, 4],
+        [0, 4],
+        [0, 0]
+      ]
+    ]
+  };
+  const plain = triangulateWKB(convertGeometryToWKB(polygon));
+  const withSrid = triangulateWKB(convertGeometryToWKB(polygon, {wkb: {srid: 4326}}));
+  expect(withSrid).toEqual(plain);
+});
+
 test('triangulateWKB#rejects invalid multipolygon children', () => {
   const bytes = new Uint8Array(
     convertGeometryToWKB({

--- a/modules/loader-utils/test/lib/laz/laz-chunk-encoder.spec.ts
+++ b/modules/loader-utils/test/lib/laz/laz-chunk-encoder.spec.ts
@@ -26,6 +26,56 @@ test('LAZChunkEncoder#encodes LASzip v3 PDRF 6-8 chunks', () => {
     ).toBe(compressed.byteLength);
   }
 });
+
+test.each([
+  [0, 20],
+  [1, 28],
+  [2, 26],
+  [3, 34]
+])('LAZChunkEncoder#roundtrips legacy PDRF %s records', (pointDataRecordFormat, recordLength) => {
+  const pointCount = 3;
+  const rawPointData = new Uint8Array(pointCount * recordLength);
+  const dataView = new DataView(rawPointData.buffer);
+  for (let pointIndex = 0; pointIndex < pointCount; pointIndex++) {
+    const offset = pointIndex * recordLength;
+    dataView.setInt32(offset, 100 + pointIndex, true);
+    dataView.setInt32(offset + 4, -200 - pointIndex, true);
+    dataView.setInt32(offset + 8, 300 + pointIndex, true);
+    dataView.setUint16(offset + 12, 50 + pointIndex, true);
+    dataView.setUint8(offset + 14, 0x20 | pointIndex);
+    dataView.setUint8(offset + 15, 4 + pointIndex);
+    dataView.setInt8(offset + 16, -2 - pointIndex);
+    dataView.setUint8(offset + 17, 9 + pointIndex);
+    dataView.setUint16(offset + 18, 1000 + pointIndex, true);
+    if (pointDataRecordFormat === 1 || pointDataRecordFormat === 3) {
+      dataView.setFloat64(offset + 20, 123.5 + pointIndex, true);
+    }
+    if (pointDataRecordFormat === 3) {
+      dataView.setUint16(offset + 28, 100 + pointIndex, true);
+      dataView.setUint16(offset + 30, 200 + pointIndex, true);
+      dataView.setUint16(offset + 32, 300 + pointIndex, true);
+    }
+  }
+  const metadata = {pointCount, pointDataRecordFormat, pointDataRecordLength: recordLength};
+  const decoded = decodeLAZChunk(encodeLAZChunk(rawPointData, metadata), metadata);
+  const decodedDataView = new DataView(decoded.buffer, decoded.byteOffset, decoded.byteLength);
+  expect(decoded.byteLength).toBe(rawPointData.byteLength);
+  for (let pointIndex = 0; pointIndex < pointCount; pointIndex++) {
+    const offset = pointIndex * recordLength;
+    expect(
+      Math.abs(decodedDataView.getInt32(offset, true) - (100 + pointIndex))
+    ).toBeLessThanOrEqual(1);
+    expect(
+      Math.abs(decodedDataView.getInt32(offset + 4, true) + 200 + pointIndex)
+    ).toBeLessThanOrEqual(1);
+    expect(
+      Math.abs(decodedDataView.getInt32(offset + 8, true) - (300 + pointIndex))
+    ).toBeLessThanOrEqual(1);
+    expect(
+      Math.abs(decodedDataView.getUint16(offset + 12, true) - (50 + pointIndex))
+    ).toBeLessThanOrEqual(1);
+  }
+});
 test('LAZChunkDecoder#decodes modern Extra Bytes directly into point-data targets', () => {
   for (const pointDataRecordFormat of [6, 7, 8]) {
     const {rawPointData, metadata} = createLAZEncodingFixture(pointDataRecordFormat);

--- a/modules/parquet/test/avro-schema-loader.spec.ts
+++ b/modules/parquet/test/avro-schema-loader.spec.ts
@@ -4,6 +4,7 @@
 
 import { expect, test } from "vitest";
 import { AvroSchemaLoaderWithParser } from '@loaders.gl/parquet/avro-schema-loader';
+import { getAvroSchemaFingerprint } from '../src/lib/parsers/parse-avro';
 test('AvroSchemaLoader#parse validates standalone schemas', async () => {
     const schema = await AvroSchemaLoaderWithParser.parse(new TextEncoder().encode(JSON.stringify({
         type: 'record',
@@ -36,4 +37,38 @@ test('AvroSchemaLoader#parse validates defaults against field schemas', async ()
         name: 'InvalidDefaults',
         fields: [{ name: 'value', type: ['null', 'string'], default: 'not-null' }]
     })).buffer)).rejects.toThrow(/default.*expected null/);
+});
+
+test('AvroSchemaLoader#parse accepts recursive named schemas and rejects invalid unions', async () => {
+    const recursiveSchema = {
+        type: 'record',
+        name: 'Node',
+        fields: [
+            { name: 'value', type: 'long' },
+            { name: 'next', type: ['null', 'Node'], default: null }
+        ]
+    };
+    await expect(AvroSchemaLoaderWithParser.parse(new TextEncoder().encode(JSON.stringify(recursiveSchema)).buffer)).resolves.toMatchObject({ name: 'Node' });
+    await expect(AvroSchemaLoaderWithParser.parse(new TextEncoder().encode(JSON.stringify({
+        type: 'record',
+        name: 'InvalidUnion',
+        fields: [{ name: 'value', type: [] }]
+    })).buffer)).rejects.toThrow(/Invalid Avro schema/);
+});
+
+test('Avro schema fingerprints use canonical field order and named references', () => {
+    const first = {
+        type: 'record',
+        name: 'Fingerprint',
+        namespace: 'example',
+        fields: [{ name: 'id', type: 'long' }, { name: 'name', type: 'string' }]
+    };
+    const reorderedProperties = {
+        fields: [{ type: 'long', name: 'id' }, { type: 'string', name: 'name' }],
+        namespace: 'example',
+        name: 'Fingerprint',
+        type: 'record'
+    };
+    expect(getAvroSchemaFingerprint(first)).toBe(getAvroSchemaFingerprint(reorderedProperties));
+    expect(getAvroSchemaFingerprint({...first, name: 'Other'})).not.toBe(getAvroSchemaFingerprint(first));
 });

--- a/modules/sql/test/arrow-query.spec.ts
+++ b/modules/sql/test/arrow-query.spec.ts
@@ -343,6 +343,60 @@ test('queryArrowTable reports cancellation before scanning', () => {
   );
 });
 
+test.each([
+  ['=', [{value: 2}]],
+  ['<>', [{value: 1}, {value: 3}]],
+  ['<', [{value: 1}]],
+  ['<=', [{value: 1}, {value: 2}]],
+  ['>', [{value: 3}]],
+  ['>=', [{value: 2}, {value: 3}]]
+])('queryArrowTable evaluates comparison operator %s', (operator, expected) => {
+  const result = queryArrowTable(makeArrowTable({value: [1, 2, 3]}), {
+    predicate: parseSQLPredicate(`value ${operator} 2`)
+  });
+  expect(toRows(result)).toEqual(expected);
+});
+
+test('queryArrowTable handles IN, NOT, null predicates, and empty matches', () => {
+  const table = makeArrowTable({value: [1, 2, null, 4], label: ['a', 'b', 'c', 'd']});
+  expect(toRows(queryArrowTable(table, {predicate: parseSQLPredicate('value IN (1, 4)')}))).toEqual(
+    [
+      {value: 1, label: 'a'},
+      {value: 4, label: 'd'}
+    ]
+  );
+  expect(
+    toRows(queryArrowTable(table, {predicate: parseSQLPredicate('NOT (value IN (1, 4))')}))
+  ).toEqual([{value: 2, label: 'b'}]);
+  expect(toRows(queryArrowTable(table, {predicate: parseSQLPredicate('value = 99')}))).toEqual([]);
+});
+
+test('queryArrowTable computes min, max, count-all, and empty aggregates', () => {
+  const result = queryArrowTable(makeArrowTable({group: ['a', 'a', 'b'], value: [2, null, 5]}), {
+    groupBy: ['group'],
+    aggregates: [
+      {name: 'rows', function: 'count'},
+      {name: 'minimum', function: 'min', column: 'value'},
+      {name: 'maximum', function: 'max', column: 'value'}
+    ],
+    columns: ['group', 'rows', 'minimum', 'maximum'],
+    orderBy: [{column: 'group'}]
+  });
+  expect(toRows(result)).toEqual([
+    {group: 'a', rows: 2, minimum: 2, maximum: 2},
+    {group: 'b', rows: 1, minimum: 5, maximum: 5}
+  ]);
+  expect(
+    toRows(
+      queryArrowTable(makeArrowTable({value: [1]}), {
+        groupBy: ['value'],
+        aggregates: [{name: 'total', function: 'sum', column: 'value'}],
+        predicate: parseSQLPredicate('value > 10')
+      })
+    )
+  ).toEqual([]);
+});
+
 /** Wraps simple test columns in the loaders.gl Arrow table shape. */
 function makeArrowTable(columns: Record<string, readonly unknown[]>): ArrowTable {
   const data = arrow.tableFromArrays(columns);


### PR DESCRIPTION
## Goals

- Add a substantial, multi-module coverage tranche against the largest uncovered production files identified by merged CI coverage.
- Exercise high-branch parser, query, conversion, and codec paths with fast deterministic tests.

## Changes

- Parquet/Avro: validate recursive schemas, invalid unions, canonical schema fingerprints, and named-schema behavior.
- Loader utilities / LAZ: round-trip legacy PDRF 0-3 chunks in addition to the existing modern and waveform coverage.
- SQL Arrow executor: cover all comparison operators, IN/NOT/null behavior, empty matches, and min/max/count aggregates.
- CSV Arrow-table parser: cover boolean, numeric, date, mixed-type inference, and UTF-8 fallback paths.
- GIS WKB triangulation: cover EWKB SRID metadata while preserving triangle indices.

## Validation

- 79 focused Chromium tests passed.
- `node scripts/audit-tests.mjs`: 618 files, 0 Tape, 44 skipped, 0 violations.
- Biome formatting/check passed; existing explicit-`any` warnings remain in the pre-existing CSV test helpers.
- Focused coverage execution completed without test failures; the repository CI merge job will provide the authoritative merged package ratchet.
- No production code, thresholds, exclusions, large fixtures, or network-dependent tests were added.