### PR TITLE
feat(tiles): add shared 3D CRS foundation

### DIFF
--- a/docs/developer-guide/coordinate-reference-systems.md
+++ b/docs/developer-guide/coordinate-reference-systems.md
@@ -51,6 +51,116 @@ The `WKTCRSLoader` and `WKTCRSWriter` remain loaders.gl adapters, but their v5 d
 `WKTCRSAst` exported by `@math.gl/crs`. The old hybrid array/object result and the `raw`, `sort`,
 and `debug` options have been removed.
 
+## 3D spatial API
+
+I3S and 3D Tiles share a normalized spatial descriptor in `@loaders.gl/tiles`. Normal loading does
+not require an application to populate source CRS, axis, epoch, or height-model fields. The format
+adapter discovers them and exposes the result on `Tileset3D.spatialReference`:
+
+```ts
+const tileset = new Tileset3D(source);
+await tileset.tilesetInitializationPromise;
+
+console.log(tileset.spatialReference);
+// sourceCrs, coordinateFrame, heightReference, axisOrder,
+// provenance, status, and warnings
+```
+
+`provenance` distinguishes explicit metadata from a format default, caller recovery override,
+legacy assumption, or unknown value. `warnings` reports qualifications such as an unresolved
+external metadata schema or an I3S ground-relative mode that needs an elevation provider. These
+fields are diagnostic output, not configuration.
+
+The application-facing target contract is intentionally small:
+
+```ts
+type TilesetSpatialOptions = {
+  targetCrs?: CRSDefinition;
+  targetHeightReference?: 'native' | 'ellipsoidal' | 'orthometric';
+  outputCoordinates?: 'auto' | 'ecef' | 'local-enu' | 'target-crs';
+
+  // Expert recovery for missing or incorrect source metadata
+  sourceCrs?: CRSDefinition;
+  coordinateEpoch?: number;
+  geoidModel?: string | Geoid;
+};
+```
+
+The v5 foundation normalizes these options and provides `SpatialCoordinateTransformer` for
+format-owned transformation paths. A descriptor with status `transformable` says that the
+requested operation can be constructed; only `transformed` can claim returned positions, bounds,
+normals, and origins have all moved into the target frame. During staged I3S/3D Tiles integration,
+applications should check the status instead of assuming a target rewrites every tile payload.
+
+### Registering non-bundled resources
+
+Common EPSG definitions supported by Proj4 require no setup. Custom definitions, datum grids, and
+geoid models are application resources registered once during startup:
+
+```ts
+import {
+  registerGeoidModelFromPgm,
+  registerSpatialCrs,
+  registerSpatialDatumGrid
+} from '@loaders.gl/tiles';
+
+registerSpatialCrs('LOCAL:SURVEY_GRID', '+proj=tmerc +lat_0=... +lon_0=...');
+registerSpatialDatumGrid('regional.gsb', datumGridArrayBuffer);
+registerGeoidModelFromPgm('egm96-5', geoidPgmBytes, {cubic: true});
+```
+
+Registration is explicit. Loading a tileset never downloads an EPSG definition, NTv2 grid, or
+geoid model in the background. This keeps offline applications deterministic, avoids surprising
+network and licensing behavior, and lets each application choose its accuracy/resource tradeoff.
+
+### Division of responsibility
+
+| Module | Responsibility | Deliberate boundary |
+| --- | --- | --- |
+| `@math.gl/crs` | Typed identifiers, WKT/PROJ syntax, and PROJJSON definitions | Does not look up definitions or transform coordinates |
+| `@math.gl/proj4` | Horizontal/projected/geocentric transformations and NTv2 grid registration | Not assumed to perform vertical datum or epoch operations |
+| `@math.gl/geoid` | GeographicLib-compatible interpolation from application-supplied PGM data | Is not terrain and does not load a model automatically |
+| `@math.gl/geospatial` | Ellipsoid, cartographic/ECEF, and local-frame mathematics | Does not interpret format metadata |
+| loaders.gl adapters | Axis normalization, profile semantics, bounds, origins, normals, elevation placement, and diagnostics | Never silently invent missing metadata |
+
+### Vertical height conversion
+
+A geoid model returns undulation `N`, the signed separation between the ellipsoid and
+gravity-related height surface. loaders.gl follows the GeographicLib convention:
+
+```text
+ellipsoidal height h = orthometric height H + geoid undulation N
+orthometric height H = ellipsoidal height h - geoid undulation N
+```
+
+The geoid is sampled at longitude/latitude derived from the source horizontal CRS before the target
+horizontal projection. Conversion therefore needs a usable source CRS, known source height
+reference, finite Z value, and compatible registered model. Missing input is an error, not a reason
+to leave Z unchanged.
+
+A geoid is not terrain. I3S `onTheGround`, `relativeToGround`, and `relativeToScene` modes need a
+terrain or scene elevation provider in addition to vertical datum conversion.
+
+### Axis order, precision, and bounds
+
+Format wire order is normalized before Proj4. Authoritative `EPSG:4326` order is
+latitude/longitude, while I3S geometry and rendering arrays use longitude/latitude.
+`SpatialCoordinateTransformer` deliberately accepts conventional `[x, y, z]` arrays with Proj4
+authority-axis enforcement disabled; the descriptor records the adapter's normalized order.
+
+Positions remain `Float64` through reconstruction and transformation. Rendering paths may downcast
+only after subtracting a nearby origin. Bounds are sampled or rebuilt in the target frame; an
+arbitrary projection must not be approximated by transforming two corners or attaching one affine
+matrix to a large tile.
+
+### Failure model
+
+Requested transformations reject when the source CRS is unknown, a preserved definition is not
+executable by Proj4, a custom definition/grid is unregistered, vertical conversion lacks a height
+model or geoid, an epoch operation is unsupported, local ENU has no derived origin, or relative
+placement lacks an elevation provider. The error names the missing resource or operation. A loader
+must not catch it and continue in source coordinates after a different target was requested.
+
 ## Current support
 
 The table describes loaders.gl v5 behavior. “Partial” means some variants, output shapes, or
@@ -77,8 +187,8 @@ mean coordinate transformation.
 | WFS | Capability/request identifiers and GML `srsName` | Identifier preservation is partial | Server-side output CRS request where supported |
 | WMTS | Tile-matrix-set supported CRS | Capability metadata | Server-selected tile matrix set; no client tile reprojection |
 | ArcGIS services | Spatial reference WKID/latestWKID fields | Service metadata and request fields are retained | Server-side `outSR`/image request behavior where implemented |
-| I3S | Spatial reference metadata; commonly geocentric or WGS84-based | Format metadata retained | Format-specific processing only |
-| 3D Tiles | Implicit earth-fixed Cartesian coordinates with tileset transforms | Tileset transforms are preserved | Not a general CRS reprojection path |
+| I3S | WKID/latestWKID, WKT, VCS WKIDs, `heightModelInfo`, and extent CRS | Raw fields plus normalized `spatialMetadata`; longitude/latitude wire order is explicit | Shared Proj4/geoid transformer available; complete mesh/Point Cloud bounds and elevation integration is in progress |
+| 3D Tiles | CRS/epoch metadata semantics and region-established global frames | Raw schema/entity metadata plus normalized `spatialMetadata`; local/unknown tilesets stay unknown | Shared transformer available; nonlinear content/bounds and nested-tileset integration is in progress |
 | MVT / TileJSON | Implicit tile coordinates; TileJSON bounds are longitude/latitude | Tile transform and metadata retained | Implicit Web Mercator tiling; no arbitrary CRS |
 | KML | Implicit WGS84 longitude/latitude/altitude | Coordinate values retained | None |
 | GPX / TCX | Implicit WGS84 latitude/longitude | Coordinate values retained | None |
@@ -116,7 +226,8 @@ future normalized table descriptor must not collapse them into one table-wide va
   request.
 - Some service parsers and format-specific structures still expose unclassified strings.
 - GeoParquet CRS metadata is preserved, but GeoParquet coordinates are not reprojected.
-- There is no unified CRS result descriptor shared by all loaders and source APIs.
+- The unified 3D descriptor covers I3S and 3D Tiles; table, raster, and service APIs do not yet all
+  expose the same result shape.
 
 Applications should not infer transformation from metadata presence or compare serialized
 definitions for semantic equality. They should also account for each loader's documented axis

--- a/docs/docs-sidebar.json
+++ b/docs/docs-sidebar.json
@@ -289,7 +289,8 @@
             "label": "Runtime Concepts",
             "items": [
               "modules/3d-tiles/concepts/README",
-      "modules/3d-tiles/concepts/correctness-and-conformance",
+              "modules/3d-tiles/concepts/correctness-and-conformance",
+              "modules/3d-tiles/concepts/coordinate-reference-systems",
               "modules/3d-tiles/concepts/resource-resolution-and-content-detection",
               "modules/3d-tiles/concepts/tile-hierarchy-and-refinement",
               "modules/3d-tiles/concepts/implicit-tiling-and-subtrees",
@@ -421,7 +422,8 @@
         "type": "category",
         "label": "@loaders.gl/i3s",
         "items": [
-          "modules/i3s/README"
+          "modules/i3s/README",
+          "modules/i3s/concepts/coordinate-reference-systems"
         ]
       },
       {

--- a/docs/modules/3d-tiles/concepts/coordinate-reference-systems.md
+++ b/docs/modules/3d-tiles/concepts/coordinate-reference-systems.md
@@ -1,0 +1,115 @@
+# Coordinate reference systems in 3D Tiles
+
+3D Tiles separates its affine tile hierarchy from the CRS of the world frame containing that
+hierarchy. Many global tilesets use ECEF coordinates, but local tilesets are valid. loaders.gl uses
+specification semantics and volume rules; it does not guess ECEF from large-looking numbers.
+
+For shared types, Proj4/geoid registration, and vertical conversion, see
+[Coordinate Reference Systems](/docs/developer-guide/coordinate-reference-systems).
+
+## Discovery precedence
+
+loaders.gl classifies the world frame in this order:
+
+1. an explicit application source override for incomplete or incorrect data;
+2. `TILESET_CRS_GEOCENTRIC` in the tileset metadata entity and schema;
+3. a root geographic `region`, which establishes the specification global frame;
+4. inherited placement from a parent or external tileset;
+5. unknown/local when no authoritative evidence exists.
+
+`TILESET_CRS_GEOCENTRIC: "UNKNOWN"` stays explicitly unknown and is not replaced by a region
+fallback. `TILESET_CRS_COORDINATE_EPOCH` is retained alongside the CRS. An unresolved external
+schema produces a diagnostic because its semantics must be loaded before discovery is complete.
+
+```ts
+const tilesetJson = await load(url, Tiles3DLoader);
+console.log(tilesetJson.spatialMetadata);
+```
+
+After source initialization the same normalized information is exposed on
+`tileset.spatialReference`. Original schema classes, metadata entities, and values remain intact.
+
+## Regions and Cartesian bounds
+
+A `region` contains west, south, east, north in radians and minimum/maximum ellipsoidal height. Its
+geographic semantics are analogous to EPSG:4979, while content and runtime culling use a geocentric
+world frame. Region subdivision preserves wrapped longitude at the antimeridian.
+
+Tile affine transforms apply to box and sphere bounds. They do not transform a `region`; it already
+describes a geographic world-space volume. S2 extension volumes similarly retain their geospatial
+meaning while normalizing to conservative runtime bounds.
+
+## Tile and content transforms
+
+The complete position path may contain:
+
+```text
+content coordinates
+  → quantization and feature-table decode
+  → glTF up-axis conversion
+  → RTC_CENTER or CESIUM_RTC origin
+  → tile and ancestor transforms
+  → external-tileset placement
+  → source world CRS
+  → requested output frame
+```
+
+Affine stages compose in double precision. A nonlinear CRS operation cannot generally be folded
+into that matrix. Reprojection operates on absolute vertices and instances, then selects a new
+local origin and rebuilds bounds. Normals, tangents, orientations, and geometric error use local
+scale/Jacobian information rather than the position function.
+
+For large projected tiles, transforming only the center while retaining original offsets is not
+correct. Transforming only eight box corners can also be non-conservative when projected edges
+curve; bounds need adaptive edge/face sampling or a documented conservative geographic method.
+
+## Nested tilesets and epochs
+
+An external tileset may declare a different CRS or coordinate epoch from its parent. Its descriptor
+is resolved independently before placing the child root in the parent's requested output frame. A
+nonlinear datum or epoch operation is not approximated by one affine matrix.
+
+Dynamic CRS epochs are preserved today. The current `@math.gl/proj4` API has no coordinate-epoch
+argument, so an operation that changes epoch rejects until an epoch-aware engine is available.
+Copying an epoch number while transforming dynamic frames would overstate accuracy.
+
+## Ellipsoids and local frames
+
+The runtime derives the ellipsoid from resolved CRS metadata where possible. WGS84 is a default
+only when the specification establishes that global frame; it is not a fallback for local or
+explicitly different geocentric CRSs.
+
+`local-enu` output needs an origin derived from dataset bounds. The frame uses exact geocentric
+differences rotated into east/north/up, not meters-per-degree approximations. Origin selection and
+precision match I3S so renderers receive one coordinate contract.
+
+## Current v5 boundary
+
+| Capability | Status |
+| --- | --- |
+| Inline geocentric CRS semantic discovery | Implemented |
+| Coordinate epoch preservation | Implemented |
+| Explicit `UNKNOWN` and local-frame handling | Implemented |
+| Region-established global-frame discovery | Implemented |
+| Normalized loader/source/runtime metadata | Implemented |
+| Deterministic Proj4/geoid primitive | Implemented |
+| External schema semantic resolution | Planned source-loading integration |
+| Per-vertex nonlinear reprojection and bound rebuilding | Integration in progress |
+| Cross-epoch operations | Not yet executable |
+
+Conventional ECEF tilesets need no options. Overrides are for incomplete, mislabeled, or local
+datasets and should be accompanied by application validation.
+
+## Authoring requirements
+
+Writers should emit `TILESET_CRS_GEOCENTRIC` when the frame differs from the conventional global
+default or ambiguity remains. Dynamic coordinates should also emit the epoch semantic. Regions
+always use longitude/latitude radians and ellipsoidal height; projected values must not be written
+into them. External tilesets declare independent semantics when CRS or epoch differs.
+
+## Related material
+
+- [3D Tiles format matrix](../formats/3d-tiles)
+- [Tile hierarchy and refinement](./tile-hierarchy-and-refinement)
+- [3D Tiles metadata semantics](https://github.com/CesiumGS/3d-tiles/blob/main/specification/Metadata/Semantics/README.adoc)
+- [3D Tiles specification](https://github.com/CesiumGS/3d-tiles/blob/main/specification/README.adoc)

--- a/docs/modules/3d-tiles/formats/3d-tiles.md
+++ b/docs/modules/3d-tiles/formats/3d-tiles.md
@@ -61,6 +61,22 @@ provides a visual implementation for that feature.
 | Metadata-derived bounding volumes | [x] | Direct numeric `TILE_BOUNDING_*` and `CONTENT_BOUNDING_*` semantic arrays are normalized; property-table value decoding remains application-owned. |
 | Styling expressions | [ ] | Rendering-side style evaluation is not provided by this module. |
 
+### Coordinate reference systems
+
+See [Coordinate reference systems in 3D Tiles](../concepts/coordinate-reference-systems) for CRS
+semantic discovery, regions, affine versus nonlinear transforms, nested tilesets, epochs, local
+frames, and precision rules.
+
+| Capability | Status | Notes |
+| --- | :---: | --- |
+| `TILESET_CRS_GEOCENTRIC` | [x] | Resolved from inline schema and tileset metadata; explicit `UNKNOWN` remains unknown. |
+| `TILESET_CRS_COORDINATE_EPOCH` | [x] | Finite epoch values are preserved in normalized metadata. |
+| Region-established global frame | [x] | A root region establishes the specification frame without coordinate-magnitude guessing. |
+| Local or ambiguous frames | [x] | Stay unknown unless metadata or an expert override resolves them. |
+| Horizontal/geocentric transform primitive | [x] | Shared Proj4 pipeline and custom definition/grid registration are available. |
+| Complete nonlinear content reprojection | [~] | Per-vertex content, nested placement, normals, bounds, and SSE integration are the next tranche. |
+| Dynamic cross-epoch transformation | [ ] | Epoch is preserved; current Proj4 bindings do not execute epoch operations. |
+
 ## How to read the matrix
 
 The loader and runtime have separate responsibilities. `Tiles3DLoader` parses tileset and tile
@@ -109,6 +125,8 @@ called out explicitly rather than being counted as parser support.
 | Metadata | `EXT_mesh_features` | [x] | Parse + preserve | Feature identifiers are retained for supported glTF payloads. |
 | Metadata | `EXT_structural_metadata` | [x] | Parse + preserve | Schema, property tables, groups, and entity links are exposed; value decoding is application-side. |
 | Metadata | Metadata-derived bounding volumes | [x] | Culling | Direct numeric semantic arrays are normalized into tile/content volumes; property-table decoding remains application-owned. |
+| Spatial | CRS and coordinate-epoch semantics | [x] | Parse + normalize | Inline semantics produce readonly `spatialMetadata`; explicit unknown and invalid epochs retain diagnostics. |
+| Spatial | End-to-end nonlinear reprojection | [~] | Runtime | Shared operations are implemented; content, hierarchy, bound, and orientation integration remains staged. |
 | Renderer | Styling expressions | [ ] | Renderer | Style evaluation and visual feature selection are outside this loader/runtime package. |
 | Renderer | GPU upload and draw policy | [ ] | Renderer | Applications such as deck.gl or Cesium decide how normalized payloads become draw calls. |
 

--- a/docs/modules/i3s/concepts/coordinate-reference-systems.md
+++ b/docs/modules/i3s/concepts/coordinate-reference-systems.md
@@ -1,0 +1,109 @@
+# Coordinate reference systems in I3S
+
+I3S combines a horizontal CRS, optional vertical CRS, height model, and layer placement rules.
+These inputs answer different questions and must be handled separately. loaders.gl discovers them
+automatically and exposes both the original fields and normalized spatial metadata.
+
+For the framework model, resource registration, and transformation API, see
+[Coordinate Reference Systems](/docs/developer-guide/coordinate-reference-systems).
+
+## Discovery
+
+The loader reads CRS information in this order:
+
+1. `spatialReference.latestWkid`, then legacy `wkid`;
+2. embedded `spatialReference.wkt` when no WKID is available;
+3. the equivalent `fullExtent` spatial reference as a fallback;
+4. `heightModelInfo.vertCRS`, then `latestVcsWkid` or `vcsWkid`;
+5. `heightModelInfo.heightModel` for ellipsoidal versus gravity-related heights;
+6. `elevationInfo` for placement after source height interpretation.
+
+Legacy ArcGIS WKIDs often have a current alias. `wkid: 102100` with `latestWkid: 3857`, for
+example, normalizes to `EPSG:3857`; the original values remain on the parsed layer.
+
+```ts
+const layer = await load(url, I3SLoader);
+
+console.log(layer.spatialReference); // original I3S object
+console.log(layer.spatialMetadata);  // normalized descriptor
+```
+
+SceneServer metadata exposes the descriptor as `spatialMetadata`; mesh `Tileset3D` exposes it as
+`tileset.spatialReference`; `I3SPointCloudSource.spatialReference` is populated at initialization.
+
+## Wire order
+
+I3S global geometry, node centers, spheres, boxes, and extents use longitude, latitude, height
+order. This remains true for `EPSG:4326`, whose authoritative axes are latitude, longitude.
+loaders.gl records normalized `xyz` wire order and maps values before calling Proj4. Applications
+should not swap I3S longitude and latitude based only on EPSG axis metadata.
+
+Projected and custom WKT layers retain declared X/Y order. WKT axis declarations are interpreted by
+the I3S adapter instead of being delegated to different Proj4 defaults.
+
+## Heights and placement
+
+| Metadata | Meaning | Runtime dependency |
+| --- | --- | --- |
+| `heightModel: ellipsoidal` | Z is measured from the reference ellipsoid | Ellipsoid from resolved CRS |
+| `heightModel: gravity_related_height` | Z is orthometric/gravity-related | Compatible geoid for ellipsoidal conversion |
+| `absoluteHeight` | Use interpreted source Z, then apply offset | CRS, units, and optional geoid |
+| `onTheGround` | Replace feature Z with sampled ground | Terrain provider |
+| `relativeToGround` | Add feature Z and offset to sampled ground | Terrain provider plus CRS conversion |
+| `relativeToScene` | Add feature Z and offset to the scene surface | Scene elevation provider |
+
+A geoid is not terrain. Converting an orthometric height to ellipsoidal height does not determine
+ground elevation at that location.
+
+`ZFactor`, `heightUnit`, and `elevationInfo.unit` apply before height-reference conversion. All
+intermediate positions remain double precision. Renderer-facing `Float32` attributes are created
+only after subtracting the tile origin.
+
+## Geometry, origins, and bounds
+
+An I3S mesh normally stores vertex offsets from a node center. Correct transformation is:
+
+1. reconstruct an absolute `Float64` source position;
+2. normalize I3S axis order and units;
+3. apply source-height and `elevationInfo` semantics;
+4. apply Proj4 and any geoid conversion;
+5. choose a stable target origin;
+6. subtract the origin, then downcast renderer attributes;
+7. rebuild bounds in the target frame.
+
+Transforming only the node center is insufficient because projected operations are not generally
+affine across a tile. Normals use local inverse-transpose/Jacobian information; they are not passed
+through the position function.
+
+At the antimeridian, geographic bounds use wrapped intervals rather than expanding across nearly
+the entire globe. Cartesian bounds are rebuilt from samples so culling and LOD remain continuous.
+
+## Current v5 boundary
+
+| Capability | Status |
+| --- | --- |
+| WKID/latestWKID and WKT discovery | Implemented |
+| VCS and height-model discovery | Implemented |
+| Normalized loader, source, service, and runtime metadata | Implemented |
+| Deterministic Proj4 and geoid primitive | Implemented |
+| Existing WGS84 mesh and Point Cloud output | Implemented |
+| Arbitrary projected vertices, normals, origins, and bounds | Integration in progress |
+| All elevation placement modes | Requires terrain/scene provider integration |
+| Dynamic coordinate-epoch operations | Not yet executable |
+
+Missing metadata or registered resources cause an actionable error. A requested operation never
+falls back to coordinates in a different CRS.
+
+## Authoring requirements
+
+Writers should emit a current horizontal WKID when available, preserve custom WKT, emit vertical
+CRS and `heightModelInfo` together, specify units, and calculate extents in the declared source
+CRS. Generated bounds and geometry must agree with the metadata. Conformance round trips compare
+normalized metadata, reconstructed absolute positions, and bounds in one frame.
+
+## Related material
+
+- [I3S format and feature matrix](../formats/i3s)
+- [I3S spatial reference specification](https://github.com/Esri/i3s-spec/blob/master/docs/1.8/spatialReference.cmn.md)
+- [I3S height model specification](https://github.com/Esri/i3s-spec/blob/master/docs/1.8/heightModelInfo.cmn.md)
+- [ArcGIS elevationInfo](https://developers.arcgis.com/web-scene-specification/objects/elevationInfo/)

--- a/docs/modules/i3s/formats/i3s.md
+++ b/docs/modules/i3s/formats/i3s.md
@@ -156,13 +156,18 @@ those versions.
 
 ### Coordinate systems and scene semantics
 
+See [Coordinate reference systems in I3S](../concepts/coordinate-reference-systems) for discovery
+precedence, wire-axis order, height models, geoid conversion, elevation placement, and the staged
+transformation boundary.
+
 | Capability | Status | Since | Notes |
 | --- | :---: | :---: | --- |
 | WGS84 geographic layers | **Supported** | v2.0 | Geometry, extents, MBSs, and OBB centers are interpreted as longitude, latitude, and elevation on the WGS84 ellipsoid. |
+| Normalized CRS discovery metadata | **Supported** | **v5.0** | WKID aliases, WKT, VCS, height model, axis order, provenance, and placement qualifications are exposed on loader, source, service, and tileset results. |
 | Cartesian meter-offset output | **Supported** | v2.0 | This is the default geometry representation for deck.gl-compatible rendering. |
 | Longitude/latitude-offset output | **Supported** | v3.1 | Select with `i3s.coordinateSystem: 'lnglat-offsets'`. |
-| Projected or custom horizontal CRS | **Not supported** | — | `spatialReference` metadata is preserved but geometry is not reprojected. The WebScene loader rejects any supported layer whose horizontal CRS is not WGS84 (`WKID 4326`). |
-| Vertical CRS and height models | **Not supported** | — | `heightModelInfo`, VCS WKIDs, and elevation units are preserved as metadata but are not transformed. |
+| Projected or custom horizontal CRS | **Partial** | **v5.0** | Definitions are normalized and the shared Proj4 path is implemented; complete per-profile vertex, origin, normal, and bound integration remains tranche 6a. The WebScene loader retains its WGS84 boundary. |
+| Vertical CRS and height models | **Partial** | **v5.0** | Height models and VCS are normalized, geoid resources can be registered, and conversion follows `h = H + N`; profile unit/placement integration remains tranche 6b. |
 | `elevationInfo` placement modes | **Not supported** | — | Ground-relative and scene-relative placement policies are not applied by the loader. |
 
 ### Authoring, conversion, and validation
@@ -203,8 +208,8 @@ the sub-tranches under feature intelligence keep the remaining gaps independentl
 | 5f. Renderer metadata | Return point-list tables, coordinate-system/origin metadata, bounds, and stable canonical attribute names. | **Complete** (**v5.0**) |
 | 5g. Point Cloud conformance | Add deterministic decoder/source fixtures and document unsupported producer-specific extensions. | **Complete** (**v5.0**) |
 | 5h. Point profile support | Decode Point geometry, symbols, attributes, and renderer metadata with representative fixtures. | Planned |
-| 6a. Horizontal CRS transforms | Reproject supported projected and geographic layer/node coordinates into the requested output coordinate system, with axis-order and unit tests. | Planned |
-| 6b. Vertical CRS and elevation | Resolve vertical CRS units and apply every `elevationInfo` mode, including offsets and relative-to-ground behavior. | Planned |
+| 6a. Horizontal CRS transforms | Reproject supported projected and geographic layer/node coordinates into the requested output coordinate system, with axis-order and unit tests. | **In progress**: discovery/Proj4 foundation complete |
+| 6b. Vertical CRS and elevation | Resolve vertical CRS units and apply every `elevationInfo` mode, including offsets and relative-to-ground behavior. | **In progress**: height/geoid foundation complete |
 | 6c. Precision and dateline handling | Preserve Float64 source precision through origin-relative output, and cover antimeridian/dateline bounds without discontinuities. | **Complete** (**v5.0**) |
 | 7a. Profile schema validation | Add discriminated schemas for Point Cloud and mesh profiles, including required index/geometry fields and conditional profile checks. | **Complete** (**v5.0**) |
 | 7b. Cross-profile conformance | Build a fixture matrix for mesh and Point Cloud metadata, malformed profiles, LOD, attributes, and renderer metadata. | **Complete** (**v5.0**) |

--- a/modules/3d-tiles/src/tiles-3d-loader-with-parser.ts
+++ b/modules/3d-tiles/src/tiles-3d-loader-with-parser.ts
@@ -8,7 +8,7 @@ import type {DracoLoaderOptions} from '@loaders.gl/draco';
 import type {ImageBitmapLoaderOptions} from '@loaders.gl/images';
 
 import {path} from '@loaders.gl/loader-utils';
-import {TILESET_TYPE, LOD_METRIC_TYPE} from '@loaders.gl/tiles';
+import {get3DTilesSpatialReference, TILESET_TYPE, LOD_METRIC_TYPE} from '@loaders.gl/tiles';
 import {parse3DTile} from './lib/parsers/parse-3d-tile';
 import {normalizeTileHeaders} from './lib/parsers/parse-3d-tile-header';
 import {
@@ -157,6 +157,7 @@ async function parseTileset(
     basePath,
     root: normalizedRoot || tilesetJson.root,
     type: TILESET_TYPE.TILES3D,
+    spatialMetadata: get3DTilesSpatialReference(tilesetJson),
     lodMetricType: LOD_METRIC_TYPE.GEOMETRIC_ERROR,
     lodMetricValue: tilesetJson.root?.geometricError || 0
   };

--- a/modules/3d-tiles/src/types.ts
+++ b/modules/3d-tiles/src/types.ts
@@ -9,6 +9,7 @@ import {LoaderWithParser} from '@loaders.gl/loader-utils';
 import {Matrix4, Vector3} from '@math.gl/core';
 import {TILESET_TYPE, LOD_METRIC_TYPE, TILE_TYPE, TILE_REFINEMENT} from '@loaders.gl/tiles';
 import type {ImplicitSubtreeReference} from '@loaders.gl/tiles';
+import type {TilesetSpatialReference} from '@loaders.gl/tiles';
 
 export type B3DMContent = {
   batchTableJson?: FeatureTableJson;
@@ -114,6 +115,8 @@ export type Tiles3DTilesetJSON = {
   extensions?: Record<string, unknown>;
   /** Application-specific data. */
   extras?: unknown;
+  /** Normalized CRS discovery metadata added by the loader. */
+  spatialMetadata?: TilesetSpatialReference;
 };
 
 /** Metadata about the complete 3D Tiles tileset asset. */

--- a/modules/3d-tiles/test/tiles-3d-loader.spec.ts
+++ b/modules/3d-tiles/test/tiles-3d-loader.spec.ts
@@ -71,6 +71,34 @@ test('Tiles3DLoader#detects extensionless tileset JSON from structure', async ()
   expect(tileset.asset.version).toBe('1.1');
   expect(tileset.root.lodMetricValue).toBe(0);
 });
+test('Tiles3DLoader#exposes normalized CRS semantics', async () => {
+  const tileset = await parse(
+    encodeTilesetJson({
+      schema: {
+        classes: {
+          tileset: {
+            properties: {
+              crs: {semantic: 'TILESET_CRS_GEOCENTRIC'},
+              epoch: {semantic: 'TILESET_CRS_COORDINATE_EPOCH'}
+            }
+          }
+        }
+      },
+      metadata: {
+        class: 'tileset',
+        properties: {crs: 'EPSG:4978', epoch: 2021.5}
+      }
+    }),
+    Tiles3DLoader,
+    {worker: false}
+  );
+
+  expect(tileset.spatialMetadata).toMatchObject({
+    sourceCrs: 'EPSG:4978',
+    coordinateEpoch: 2021.5,
+    coordinateFrame: 'geocentric'
+  });
+});
 test('Tiles3DLoader#detects JSON glTF tile content from structure', async () => {
   const gltfJson = new TextEncoder().encode(
     JSON.stringify({asset: {version: '2.0'}, scenes: [{nodes: []}], scene: 0})

--- a/modules/i3s/src/i3s-point-cloud-source.ts
+++ b/modules/i3s/src/i3s-point-cloud-source.ts
@@ -12,8 +12,10 @@ import type {
   PointCloudTileContent,
   PointCloudTileHeader,
   PointCloudTilesetSource,
-  PointCloudCoordinateSystem
+  PointCloudCoordinateSystem,
+  TilesetSpatialReference
 } from '@loaders.gl/tiles';
+import {getI3SSpatialReference} from '@loaders.gl/tiles';
 import {DataSource} from '@loaders.gl/loader-utils';
 import {parseSLPKArchive} from './lib/parsers/parse-slpk/parse-slpk';
 import type {SLPKArchive} from './lib/parsers/parse-slpk/slpk-archieve';
@@ -57,6 +59,9 @@ export class I3SPointCloudSource
   /** Parsed Point Cloud layer metadata. */
   metadata: SceneLayer3D | null = null;
 
+  /** Normalized source CRS metadata populated during initialization. */
+  spatialReference: TilesetSpatialReference | null = null;
+
   /** Random-access archive used for SLPK-backed resources. */
   private archive: SLPKArchive | null = null;
   /** Node pages cached by physical page index. */
@@ -96,6 +101,7 @@ export class I3SPointCloudSource
     const layerJson = await this.readJson('');
     const pointCloudLayer = I3SPointCloudSceneLayerSchema.parse(layerJson);
     this.metadata = pointCloudLayer as SceneLayer3D;
+    this.spatialReference = getI3SSpatialReference(this.metadata);
     this.baseUrl = this.url.replace(/\/+$/, '');
     this.nodesPerPage = Math.max(
       1,

--- a/modules/i3s/src/i3s-service.ts
+++ b/modules/i3s/src/i3s-service.ts
@@ -3,7 +3,8 @@
 // Copyright (c) vis.gl contributors
 
 import type {CoreAPI, DataSourceOptions, LoaderOptions} from '@loaders.gl/loader-utils';
-import {I3SSource} from '@loaders.gl/tiles';
+import {getI3SSpatialReference, I3SSource} from '@loaders.gl/tiles';
+import type {TilesetSpatialReference} from '@loaders.gl/tiles';
 import {I3SLoaderWithParser} from './i3s-loader-with-parser';
 import {I3SPointCloudSource} from './i3s-point-cloud-source';
 import {I3SPointCloudSceneLayerSchema, I3SSceneLayerSchema} from './i3s-zod-schema';
@@ -26,6 +27,8 @@ export type I3SServiceMetadata = {
   capabilities: string[];
   /** Horizontal and vertical spatial reference metadata. */
   spatialReference?: SpatialReference;
+  /** Normalized horizontal, vertical, axis, and height-reference metadata. */
+  spatialMetadata: TilesetSpatialReference;
   /** Layer extent, when advertised. */
   fullExtent?: FullExtent;
   /** Human-readable layer name. */
@@ -73,6 +76,7 @@ export function normalizeI3SServiceMetadata(url: string, layer: SceneLayer3D): I
     profile: layer.store.profile,
     capabilities: [...layer.capabilities],
     spatialReference: layer.spatialReference,
+    spatialMetadata: getI3SSpatialReference(layer),
     fullExtent: layer.fullExtent,
     name: layer.name,
     description: layer.description,

--- a/modules/i3s/src/lib/parsers/parse-i3s.ts
+++ b/modules/i3s/src/lib/parsers/parse-i3s.ts
@@ -22,6 +22,7 @@ import {
 } from '../../types';
 import type {LoaderOptions, LoaderContext} from '@loaders.gl/loader-utils';
 import {I3SLoaderWithParser} from '../../i3s-loader-with-parser';
+import {getI3SSpatialReference} from '@loaders.gl/tiles';
 
 export async function normalizeTileData(
   tile: Node3DIndexDocument,
@@ -269,6 +270,7 @@ export async function normalizeTilesetData(tileset : SceneLayer3D, options : Loa
     url,
     basePath: url,
     type: TILESET_TYPE.I3S,
+    spatialMetadata: getI3SSpatialReference(tileset),
     nodePagesTile,
     // @ts-expect-error
     root,

--- a/modules/i3s/src/types.ts
+++ b/modules/i3s/src/types.ts
@@ -8,6 +8,7 @@ import type {Matrix4, Quaternion, Vector3} from '@math.gl/core';
 import type {ImageDataType} from '@loaders.gl/images';
 import type {TypedArray, MeshAttribute, TextureLevel} from '@loaders.gl/schema';
 import {TILESET_TYPE, TILE_REFINEMENT, TILE_TYPE, Tile3D, Tileset3D} from '@loaders.gl/tiles';
+import type {TilesetSpatialReference} from '@loaders.gl/tiles';
 import I3SNodePagesTiles from './lib/helpers/i3s-nodepages-tiles';
 import {LoaderWithParser} from '@loaders.gl/loader-utils';
 import type {CoordinateSystem} from './lib/parsers/constants';
@@ -34,6 +35,8 @@ export interface I3STilesetHeader extends SceneLayer3D {
   lodMetricValue?: number;
   /** Loader that has to be used to load content */
   loader: LoaderWithParser;
+  /** Normalized CRS discovery metadata added by the loader. */
+  spatialMetadata?: TilesetSpatialReference;
 }
 /** https://github.com/Esri/i3s-spec/blob/master/docs/1.8/nodePage.cmn.md */
 export type NodePage = {

--- a/modules/tiles/package.json
+++ b/modules/tiles/package.json
@@ -45,9 +45,12 @@
     "@loaders.gl/loader-utils": "5.0.0-alpha.2",
     "@loaders.gl/schema": "5.0.0-alpha.2",
     "@math.gl/core": "4.2.0-alpha.5",
+    "@math.gl/crs": "^4.2.0-alpha.5",
     "@math.gl/culling": "4.2.0-alpha.5",
+    "@math.gl/geoid": "4.2.0-alpha.5",
     "@math.gl/geometry-utils": "4.2.0-alpha.5",
     "@math.gl/geospatial": "4.2.0-alpha.5",
+    "@math.gl/proj4": "^4.2.0-alpha.5",
     "@math.gl/web-mercator": "4.2.0-alpha.5",
     "@probe.gl/stats": "^4.1.1"
   },

--- a/modules/tiles/src/index.ts
+++ b/modules/tiles/src/index.ts
@@ -102,6 +102,33 @@ export {PointCloudTile} from './point-cloud/point-cloud-tile';
 export {createBoundingVolume} from './tileset-3d/helpers/bounding-volume';
 export {calculateTransformProps} from './tileset-3d/helpers/transform-utils';
 
+export type {
+  CreateTilesetSpatialReferenceOptions,
+  TilesetCoordinateFrame,
+  TilesetHeightReference,
+  TilesetOutputCoordinates,
+  TilesetSpatialOptions,
+  TilesetSpatialReference,
+  TilesetSpatialReferenceProvenance,
+  TilesetTargetHeightReference
+} from './spatial/spatial-types';
+export {
+  applyTilesetSpatialOptions,
+  createTilesetSpatialReference
+} from './spatial/spatial-types';
+export {
+  get3DTilesSpatialReference,
+  getI3SSpatialReference
+} from './spatial/format-spatial-reference';
+export {SpatialCoordinateTransformer} from './spatial/spatial-coordinate-transformer';
+export {
+  getGeoidModel,
+  registerGeoidModel,
+  registerGeoidModelFromPgm,
+  registerSpatialCrs,
+  registerSpatialDatumGrid
+} from './spatial/spatial-resource-registry';
+
 export {getFrameState} from './tileset-3d/helpers/frame-state';
 export type {GetFrameStateOptions} from './tileset-3d/helpers/frame-state';
 export {getLodStatus} from './tileset-3d/helpers/i3s-lod';

--- a/modules/tiles/src/spatial/format-spatial-reference.ts
+++ b/modules/tiles/src/spatial/format-spatial-reference.ts
@@ -1,0 +1,182 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {CRSDefinition} from '@math.gl/crs';
+import {createTilesetSpatialReference} from './spatial-types';
+import type {TilesetSpatialReference} from './spatial-types';
+
+/** ArcGIS/I3S spatial reference fields used without depending on the I3S package. */
+type I3SSpatialReferenceLike = {
+  wkid?: number;
+  latestWkid?: number;
+  vcsWkid?: number;
+  latestVcsWkid?: number;
+  wkt?: string;
+};
+
+/** I3S layer fields needed for spatial metadata discovery. */
+type I3SLayerLike = {
+  spatialReference?: I3SSpatialReferenceLike;
+  fullExtent?: {spatialReference?: I3SSpatialReferenceLike};
+  heightModelInfo?: {
+    heightModel?: string;
+    vertCRS?: CRSDefinition;
+  };
+  elevationInfo?: {mode?: string};
+};
+
+/** 3D Tiles metadata schema property used for semantic lookup. */
+type Tiles3DMetadataProperty = {semantic?: string};
+
+/** 3D Tiles document fields needed for CRS semantic discovery. */
+type Tiles3DLike = {
+  schema?: {
+    classes?: Record<string, unknown>;
+  };
+  schemaUri?: string;
+  metadata?: {class?: string; properties?: Record<string, unknown>};
+  root?: {boundingVolume?: {region?: unknown}};
+};
+
+/**
+ * Discovers normalized spatial metadata from an I3S scene-layer document.
+ *
+ * I3S encodes geographic coordinates in longitude/latitude wire order even for authority
+ * definitions whose formal axis order differs.
+ *
+ * @param layer - Parsed I3S layer document.
+ * @returns Normalized source spatial metadata.
+ */
+export function getI3SSpatialReference(layer: I3SLayerLike): TilesetSpatialReference {
+  const spatialReference = layer.spatialReference || layer.fullExtent?.spatialReference;
+  const sourceCrs = getI3SCrsDefinition(spatialReference);
+  const verticalCrs =
+    layer.heightModelInfo?.vertCRS || getI3SVerticalCrsDefinition(spatialReference);
+  const heightModel = layer.heightModelInfo?.heightModel;
+  const heightReference =
+    heightModel === 'ellipsoidal'
+      ? 'ellipsoidal'
+      : heightModel === 'gravity_related_height'
+        ? 'orthometric'
+        : 'unknown';
+  const sourceIdentifier = getCrsIdentifier(spatialReference);
+  const coordinateFrame =
+    sourceIdentifier === 4326 || sourceIdentifier === 4490
+      ? 'geographic'
+      : sourceCrs
+        ? 'projected'
+        : 'unknown';
+  const warnings: string[] = [];
+  const elevationMode = layer.elevationInfo?.mode;
+  if (elevationMode && elevationMode !== 'absoluteHeight') {
+    warnings.push(
+      `I3S elevation mode ${elevationMode} requires a terrain or scene elevation provider`
+    );
+  }
+
+  return createTilesetSpatialReference({
+    sourceCrs,
+    verticalCrs,
+    heightReference,
+    coordinateFrame,
+    axisOrder: sourceCrs ? 'xyz' : 'unknown',
+    provenance: sourceCrs ? 'metadata' : 'unknown',
+    warnings
+  });
+}
+
+/**
+ * Discovers the 3D Tiles geocentric CRS and coordinate epoch from structured metadata semantics.
+ *
+ * The method intentionally does not infer ECEF from coordinate magnitude. A root `region`
+ * establishes the format's global ellipsoidal frame, while local tilesets without an explicit
+ * semantic remain unknown.
+ *
+ * @param tileset - Parsed 3D Tiles tileset document.
+ * @returns Normalized source spatial metadata.
+ */
+export function get3DTilesSpatialReference(tileset: Tiles3DLike): TilesetSpatialReference {
+  const geocentricCrs = getTilesetSemanticValue(tileset, 'TILESET_CRS_GEOCENTRIC');
+  const coordinateEpoch = getTilesetSemanticValue(tileset, 'TILESET_CRS_COORDINATE_EPOCH');
+  const warnings: string[] = [];
+
+  let sourceCrs: CRSDefinition | undefined;
+  let provenance: TilesetSpatialReference['provenance'] = 'unknown';
+  if (typeof geocentricCrs === 'string' && geocentricCrs.toUpperCase() !== 'UNKNOWN') {
+    sourceCrs = geocentricCrs;
+    provenance = 'metadata';
+  } else if (geocentricCrs !== undefined) {
+    warnings.push('3D Tiles geocentric CRS is explicitly unknown');
+  } else if (tileset.root?.boundingVolume?.region) {
+    sourceCrs = 'EPSG:4978';
+    provenance = 'format-default';
+  } else if (tileset.schemaUri && !tileset.schema) {
+    warnings.push(
+      'External 3D Tiles metadata schema must be loaded before CRS semantics can resolve'
+    );
+  }
+
+  const epoch =
+    typeof coordinateEpoch === 'number' && Number.isFinite(coordinateEpoch)
+      ? coordinateEpoch
+      : undefined;
+  if (coordinateEpoch !== undefined && epoch === undefined) {
+    warnings.push('3D Tiles coordinate epoch is not a finite number');
+  }
+
+  return createTilesetSpatialReference({
+    sourceCrs,
+    coordinateEpoch: epoch,
+    heightReference: sourceCrs ? 'ellipsoidal' : 'unknown',
+    coordinateFrame: sourceCrs ? 'geocentric' : 'unknown',
+    axisOrder: sourceCrs ? 'xyz' : 'unknown',
+    provenance,
+    warnings
+  });
+}
+
+/** Return an I3S horizontal CRS definition, preferring current WKID aliases over legacy values. */
+function getI3SCrsDefinition(
+  spatialReference?: I3SSpatialReferenceLike
+): CRSDefinition | undefined {
+  const identifier = getCrsIdentifier(spatialReference);
+  if (identifier !== undefined) {
+    return `EPSG:${identifier}`;
+  }
+  return spatialReference?.wkt;
+}
+
+/** Return an I3S vertical CRS definition. */
+function getI3SVerticalCrsDefinition(
+  spatialReference?: I3SSpatialReferenceLike
+): CRSDefinition | undefined {
+  const identifier = spatialReference?.latestVcsWkid ?? spatialReference?.vcsWkid;
+  return identifier === undefined ? undefined : `EPSG:${identifier}`;
+}
+
+/** Return the preferred horizontal WKID. */
+function getCrsIdentifier(spatialReference?: I3SSpatialReferenceLike): number | undefined {
+  return spatialReference?.latestWkid ?? spatialReference?.wkid;
+}
+
+/** Resolve a tileset-wide structured metadata property by its standard semantic. */
+function getTilesetSemanticValue(tileset: Tiles3DLike, semantic: string): unknown {
+  const classIdentifier = tileset.metadata?.class;
+  if (!classIdentifier) {
+    return undefined;
+  }
+  const classDefinition = tileset.schema?.classes?.[classIdentifier] as
+    | {properties?: Record<string, Tiles3DMetadataProperty>}
+    | undefined;
+  const propertyDefinitions = classDefinition?.properties;
+  const propertyValues = tileset.metadata?.properties;
+  for (const [propertyIdentifier, propertyDefinition] of Object.entries(
+    propertyDefinitions || {}
+  )) {
+    if (propertyDefinition.semantic === semantic) {
+      return propertyValues?.[propertyIdentifier];
+    }
+  }
+  return undefined;
+}

--- a/modules/tiles/src/spatial/format-spatial-reference.ts
+++ b/modules/tiles/src/spatial/format-spatial-reference.ts
@@ -62,11 +62,9 @@ export function getI3SSpatialReference(layer: I3SLayerLike): TilesetSpatialRefer
         : 'unknown';
   const sourceIdentifier = getCrsIdentifier(spatialReference);
   const coordinateFrame =
-    sourceIdentifier === 4326 || sourceIdentifier === 4490
-      ? 'geographic'
-      : sourceCrs
-        ? 'projected'
-        : 'unknown';
+    sourceIdentifier === undefined
+      ? getWktCoordinateFrame(spatialReference?.wkt)
+      : getIdentifierCoordinateFrame(sourceIdentifier);
   const warnings: string[] = [];
   const elevationMode = layer.elevationInfo?.mode;
   if (elevationMode && elevationMode !== 'absoluteHeight') {
@@ -158,6 +156,57 @@ function getI3SVerticalCrsDefinition(
 /** Return the preferred horizontal WKID. */
 function getCrsIdentifier(spatialReference?: I3SSpatialReferenceLike): number | undefined {
   return spatialReference?.latestWkid ?? spatialReference?.wkid;
+}
+
+/** Classify common EPSG identifiers used by I3S into their coordinate frames. */
+function getIdentifierCoordinateFrame(
+  identifier: number
+): TilesetSpatialReference['coordinateFrame'] {
+  if (identifier === 4978) {
+    return 'geocentric';
+  }
+  if (identifier === 4326 || identifier === 4490 || identifier === 4979) {
+    return 'geographic';
+  }
+  return 'projected';
+}
+
+/**
+ * Classify a WKT root coordinate system without guessing when the declaration is ambiguous.
+ *
+ * WKT2 uses `GEODCRS` for both geographic and geocentric systems, so its `CS` declaration is
+ * inspected before assigning a frame.
+ */
+function getWktCoordinateFrame(wkt?: string): TilesetSpatialReference['coordinateFrame'] {
+  if (!wkt) {
+    return 'unknown';
+  }
+
+  const normalizedWkt = wkt.trim().toUpperCase();
+  const rootKeyword = normalizedWkt.match(/^([A-Z][A-Z0-9_]*)\s*[\[(]/)?.[1];
+  if (rootKeyword === 'GEOCCS') {
+    return 'geocentric';
+  }
+  if (
+    rootKeyword === 'GEOGCS' ||
+    rootKeyword === 'GEOGRAPHICCRS' ||
+    rootKeyword === 'GEOGRAPHIC2DCRS' ||
+    rootKeyword === 'GEOGRAPHIC3DCRS'
+  ) {
+    return 'geographic';
+  }
+  if (rootKeyword === 'PROJCS' || rootKeyword === 'PROJCRS' || rootKeyword === 'PROJECTEDCRS') {
+    return 'projected';
+  }
+  if (rootKeyword === 'GEODCRS' || rootKeyword === 'GEODETICCRS') {
+    if (/\bCS\s*[\[(]\s*CARTESIAN\s*,\s*3\b/.test(normalizedWkt)) {
+      return 'geocentric';
+    }
+    if (/\bCS\s*[\[(]\s*ELLIPSOIDAL\s*,\s*[23]\b/.test(normalizedWkt)) {
+      return 'geographic';
+    }
+  }
+  return 'unknown';
 }
 
 /** Resolve a tileset-wide structured metadata property by its standard semantic. */

--- a/modules/tiles/src/spatial/spatial-coordinate-transformer.ts
+++ b/modules/tiles/src/spatial/spatial-coordinate-transformer.ts
@@ -26,8 +26,16 @@ export class SpatialCoordinateTransformer {
   /** Normalized spatial metadata describing this transformation. */
   readonly spatialReference: TilesetSpatialReference;
 
+  /** Projection from the source CRS directly to the requested horizontal target CRS. */
   private readonly horizontalProjection?: Proj4Projection;
+
+  /** Projection from the source CRS to geographic longitude, latitude, and ellipsoidal height. */
   private readonly geographicProjection?: Proj4Projection;
+
+  /** Projection from adjusted geographic coordinates to the requested output CRS. */
+  private readonly heightOutputProjection?: Proj4Projection;
+
+  /** Geoid model used to convert between ellipsoidal and orthometric heights. */
   private readonly geoid?: Geoid;
 
   /**
@@ -62,6 +70,11 @@ export class SpatialCoordinateTransformer {
         to: GEOGRAPHIC_CRS,
         enforceAxis: false
       });
+      this.heightOutputProjection = new Proj4Projection({
+        from: GEOGRAPHIC_CRS,
+        to: (spatialReference.targetCrs || spatialReference.sourceCrs) as Proj4CRSDefinition,
+        enforceAxis: false
+      });
     }
   }
 
@@ -83,12 +96,15 @@ export class SpatialCoordinateTransformer {
       }
       const geographic = this.geographicProjection!.project([result[0], result[1], result[2]]);
       const geoidUndulation = this.geoid!.getHeight(geographic[1], geographic[0]);
-      result[2] = transformHeight(
-        result[2],
+      geographic[2] = transformHeight(
+        geographic[2],
         geoidUndulation,
         this.spatialReference.heightReference,
         this.spatialReference.targetHeightReference
       );
+      const projected = this.heightOutputProjection!.project(geographic);
+      result.splice(0, projected.length, ...projected);
+      return result;
     }
 
     if (this.horizontalProjection) {
@@ -117,6 +133,15 @@ function validateTransformRequest(spatialReference: TilesetSpatialReference): vo
     spatialReference.heightReference === 'unknown'
   ) {
     throw new Error('Cannot convert heights because the source height reference is unknown');
+  }
+  if (
+    requiresHeightTransformation(spatialReference) &&
+    spatialReference.coordinateFrame === 'geocentric'
+  ) {
+    throw new Error(
+      'Geocentric height conversion is not supported until the projection runtime can convert ' +
+        'between geocentric coordinates and geographic ellipsoidal heights'
+    );
   }
   if (spatialReference.status === 'unresolved') {
     throw new Error('The requested spatial output cannot be resolved from the available metadata');

--- a/modules/tiles/src/spatial/spatial-coordinate-transformer.ts
+++ b/modules/tiles/src/spatial/spatial-coordinate-transformer.ts
@@ -1,0 +1,154 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Geoid} from '@math.gl/geoid';
+import {Proj4Projection} from '@math.gl/proj4';
+import type {Proj4CRSDefinition} from '@math.gl/proj4';
+import {getGeoidModel} from './spatial-resource-registry';
+import type {
+  TilesetHeightReference,
+  TilesetSpatialOptions,
+  TilesetSpatialReference,
+  TilesetTargetHeightReference
+} from './spatial-types';
+
+const GEOGRAPHIC_CRS = 'EPSG:4326';
+
+/**
+ * Deterministic coordinate transformer used by 3D tile format adapters.
+ *
+ * The transformer uses conventional `[x, y, z]` array order at its boundary. Format adapters are
+ * responsible for mapping authority-axis order into their documented wire order. Requested
+ * transformations fail when required definitions or geoid resources are unavailable.
+ */
+export class SpatialCoordinateTransformer {
+  /** Normalized spatial metadata describing this transformation. */
+  readonly spatialReference: TilesetSpatialReference;
+
+  private readonly horizontalProjection?: Proj4Projection;
+  private readonly geographicProjection?: Proj4Projection;
+  private readonly geoid?: Geoid;
+
+  /**
+   * Creates a coordinate transformer.
+   *
+   * @param spatialReference - Format-discovered and option-normalized spatial metadata.
+   * @param options - Application options containing an optional geoid model.
+   */
+  constructor(spatialReference: TilesetSpatialReference, options: TilesetSpatialOptions = {}) {
+    this.spatialReference = spatialReference;
+    validateTransformRequest(spatialReference);
+
+    if (spatialReference.sourceCrs && spatialReference.targetCrs) {
+      this.horizontalProjection = new Proj4Projection({
+        from: spatialReference.sourceCrs as Proj4CRSDefinition,
+        to: spatialReference.targetCrs as Proj4CRSDefinition,
+        enforceAxis: false
+      });
+    }
+
+    if (requiresHeightTransformation(spatialReference)) {
+      this.geoid = resolveGeoid(options.geoidModel);
+      if (!this.geoid) {
+        const modelName = typeof options.geoidModel === 'string' ? ` "${options.geoidModel}"` : '';
+        throw new Error(
+          `Height conversion requires a registered geoid model${modelName}; ` +
+            'call registerGeoidModel() or pass a parsed Geoid instance'
+        );
+      }
+      this.geographicProjection = new Proj4Projection({
+        from: spatialReference.sourceCrs as Proj4CRSDefinition,
+        to: GEOGRAPHIC_CRS,
+        enforceAxis: false
+      });
+    }
+  }
+
+  /**
+   * Transforms one `[x, y, z?]` coordinate while retaining additional components.
+   *
+   * @param coordinate - Source coordinate in the format adapter's normalized `x/y/z` order.
+   * @returns A new transformed coordinate array.
+   */
+  transformPosition(coordinate: readonly number[]): number[] {
+    if (coordinate.length < 2) {
+      throw new Error('A spatial coordinate must contain at least x and y components');
+    }
+
+    const result = [...coordinate];
+    if (requiresHeightTransformation(this.spatialReference)) {
+      if (result.length < 3 || !Number.isFinite(result[2])) {
+        throw new Error('Height conversion requires a finite z coordinate');
+      }
+      const geographic = this.geographicProjection!.project([result[0], result[1], result[2]]);
+      const geoidUndulation = this.geoid!.getHeight(geographic[1], geographic[0]);
+      result[2] = transformHeight(
+        result[2],
+        geoidUndulation,
+        this.spatialReference.heightReference,
+        this.spatialReference.targetHeightReference
+      );
+    }
+
+    if (this.horizontalProjection) {
+      const projected = this.horizontalProjection.project(result.slice(0, 3));
+      result.splice(0, projected.length, ...projected);
+    }
+    return result;
+  }
+}
+
+/** Validate that all requested operations can be represented by the current runtime. */
+function validateTransformRequest(spatialReference: TilesetSpatialReference): void {
+  if (spatialReference.outputCoordinates === 'local-enu') {
+    throw new Error(
+      'local-enu output requires a dataset-derived local origin and must be created by a tileset source'
+    );
+  }
+  if (spatialReference.outputCoordinates === 'target-crs' && !spatialReference.targetCrs) {
+    throw new Error('target-crs output requires targetCrs');
+  }
+  if (!spatialReference.sourceCrs && spatialReference.status === 'unresolved') {
+    throw new Error('Cannot transform coordinates because the source CRS is unknown');
+  }
+  if (
+    requiresHeightTransformation(spatialReference) &&
+    spatialReference.heightReference === 'unknown'
+  ) {
+    throw new Error('Cannot convert heights because the source height reference is unknown');
+  }
+  if (spatialReference.status === 'unresolved') {
+    throw new Error('The requested spatial output cannot be resolved from the available metadata');
+  }
+}
+
+/** Return whether source and target height interpretations differ. */
+function requiresHeightTransformation(spatialReference: TilesetSpatialReference): boolean {
+  const target = spatialReference.targetHeightReference;
+  return target !== 'native' && target !== spatialReference.heightReference;
+}
+
+/** Resolve an inline or registered geoid model. */
+function resolveGeoid(model: string | Geoid | undefined): Geoid | undefined {
+  return typeof model === 'string' ? getGeoidModel(model) : model;
+}
+
+/** Apply the GeographicLib geoid undulation convention, h = H + N. */
+function transformHeight(
+  height: number,
+  geoidUndulation: number,
+  source: TilesetHeightReference,
+  target: TilesetTargetHeightReference
+): number {
+  if (source === target || target === 'native') {
+    return height;
+  }
+  if (source === 'orthometric' && target === 'ellipsoidal') {
+    return height + geoidUndulation;
+  }
+  if (source === 'ellipsoidal' && target === 'orthometric') {
+    return height - geoidUndulation;
+  }
+  throw new Error(`Unsupported height conversion from ${source} to ${target}`);
+}

--- a/modules/tiles/src/spatial/spatial-resource-registry.ts
+++ b/modules/tiles/src/spatial/spatial-resource-registry.ts
@@ -1,0 +1,79 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Geoid, parsePGM} from '@math.gl/geoid';
+import {Proj4Projection} from '@math.gl/proj4';
+import type {Proj4CRSDefinition} from '@math.gl/proj4';
+
+const geoidModels = new Map<string, Geoid>();
+
+/**
+ * Registers an application-supplied CRS alias for deterministic Proj4 transformations.
+ *
+ * loaders.gl never downloads registry definitions implicitly.
+ *
+ * @param name - Identifier used by dataset metadata or application options.
+ * @param definition - CRS definition understood by `@math.gl/proj4`.
+ */
+export function registerSpatialCrs(name: string, definition: Proj4CRSDefinition): void {
+  validateResourceName(name, 'CRS');
+  Proj4Projection.defineProjectionAliases({[name]: definition});
+}
+
+/**
+ * Registers an NTv2 datum grid used by a previously or subsequently registered CRS definition.
+ *
+ * @param name - Grid name referenced by the Proj4 definition.
+ * @param data - Complete NTv2 grid bytes.
+ */
+export function registerSpatialDatumGrid(name: string, data: ArrayBuffer): void {
+  validateResourceName(name, 'datum grid');
+  Proj4Projection.registerDatumGrid(name, data);
+}
+
+/**
+ * Registers an already parsed geoid model.
+ *
+ * @param name - Stable application-local model name.
+ * @param geoid - Parsed `@math.gl/geoid` model.
+ */
+export function registerGeoidModel(name: string, geoid: Geoid): void {
+  validateResourceName(name, 'geoid model');
+  geoidModels.set(name, geoid);
+}
+
+/**
+ * Parses and registers a GeographicLib PGM geoid model.
+ *
+ * @param name - Stable application-local model name.
+ * @param data - Complete PGM model bytes.
+ * @param options - Interpolation options forwarded to `@math.gl/geoid`.
+ * @returns The parsed and registered geoid model.
+ */
+export function registerGeoidModelFromPgm(
+  name: string,
+  data: Uint8Array,
+  options: {cubic?: boolean} = {}
+): Geoid {
+  const geoid = parsePGM(data, options);
+  registerGeoidModel(name, geoid);
+  return geoid;
+}
+
+/**
+ * Returns a registered geoid model without initiating network access.
+ *
+ * @param name - Application-local model name.
+ * @returns Registered model, or `undefined` when the application has not supplied it.
+ */
+export function getGeoidModel(name: string): Geoid | undefined {
+  return geoidModels.get(name);
+}
+
+/** Validate a caller-controlled spatial resource name. */
+function validateResourceName(name: string, resourceType: string): void {
+  if (!name.trim()) {
+    throw new Error(`${resourceType} name must not be empty`);
+  }
+}

--- a/modules/tiles/src/spatial/spatial-types.ts
+++ b/modules/tiles/src/spatial/spatial-types.ts
@@ -1,0 +1,177 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {CRSDefinition} from '@math.gl/crs';
+import type {Geoid} from '@math.gl/geoid';
+
+/** How height values in a 3D dataset relate to the earth. */
+export type TilesetHeightReference = 'native' | 'ellipsoidal' | 'orthometric' | 'unknown';
+
+/** Height reference that an application may request for transformed output. */
+export type TilesetTargetHeightReference = 'native' | 'ellipsoidal' | 'orthometric';
+
+/** Coordinate representation requested from a 3D tileset. */
+export type TilesetOutputCoordinates = 'auto' | 'ecef' | 'local-enu' | 'target-crs';
+
+/** Broad coordinate frame used by a 3D dataset. */
+export type TilesetCoordinateFrame =
+  | 'geographic'
+  | 'geocentric'
+  | 'projected'
+  | 'local'
+  | 'unknown';
+
+/** Origin of a normalized spatial-reference value. */
+export type TilesetSpatialReferenceProvenance =
+  | 'metadata'
+  | 'format-default'
+  | 'caller-override'
+  | 'legacy-assumption'
+  | 'unknown';
+
+/**
+ * Simple application-facing spatial options shared by 3D Tiles and I3S.
+ *
+ * Source CRS details are normally discovered from dataset metadata. The source overrides are
+ * expert recovery controls for incomplete or non-standard datasets.
+ */
+export type TilesetSpatialOptions = {
+  /** CRS of transformed output coordinates. Omit to retain the format's natural world frame. */
+  targetCrs?: CRSDefinition;
+  /** Height reference of transformed output coordinates. Defaults to `native`. */
+  targetHeightReference?: TilesetTargetHeightReference;
+  /** Output coordinate representation. Defaults to `auto`. */
+  outputCoordinates?: TilesetOutputCoordinates;
+  /** Expert override used when source metadata is absent or incorrect. */
+  sourceCrs?: CRSDefinition;
+  /** Expert override for a dynamic coordinate reference epoch. */
+  coordinateEpoch?: number;
+  /** Registered geoid model name or an already parsed geoid model. */
+  geoidModel?: string | Geoid;
+};
+
+/**
+ * Normalized, readonly spatial metadata discovered for a 3D tileset.
+ *
+ * This is diagnostic output. Applications normally do not construct it.
+ */
+export type TilesetSpatialReference = {
+  /** Source horizontal or compound CRS, when it can be identified. */
+  readonly sourceCrs?: CRSDefinition;
+  /** Source vertical CRS, when independently identified. */
+  readonly verticalCrs?: CRSDefinition;
+  /** Coordinate epoch attached to the source coordinates. */
+  readonly coordinateEpoch?: number;
+  /** Source height interpretation. */
+  readonly heightReference: TilesetHeightReference;
+  /** Broad frame in which source coordinates are encoded. */
+  readonly coordinateFrame: TilesetCoordinateFrame;
+  /** Coordinate component order used by the format wire representation. */
+  readonly axisOrder: 'xy' | 'yx' | 'xyz' | 'unknown';
+  /** How the source CRS was established. */
+  readonly provenance: TilesetSpatialReferenceProvenance;
+  /** Target CRS selected by application options, if any. */
+  readonly targetCrs?: CRSDefinition;
+  /** Target height interpretation selected by application options. */
+  readonly targetHeightReference: TilesetTargetHeightReference;
+  /** Output representation selected by application options. */
+  readonly outputCoordinates: TilesetOutputCoordinates;
+  /** Whether coordinates are native, ready to transform, transformed, or unresolved. */
+  readonly status: 'native' | 'transformable' | 'transformed' | 'unresolved';
+  /** Non-fatal qualifications retained for diagnostics and user interfaces. */
+  readonly warnings: readonly string[];
+};
+
+/** Input used by format adapters to create normalized spatial metadata. */
+export type CreateTilesetSpatialReferenceOptions = {
+  /** Discovered source CRS. */
+  sourceCrs?: CRSDefinition;
+  /** Discovered vertical CRS. */
+  verticalCrs?: CRSDefinition;
+  /** Discovered coordinate epoch. */
+  coordinateEpoch?: number;
+  /** Discovered height interpretation. */
+  heightReference?: TilesetHeightReference;
+  /** Discovered broad coordinate frame. */
+  coordinateFrame?: TilesetCoordinateFrame;
+  /** Format wire-axis order. */
+  axisOrder?: 'xy' | 'yx' | 'xyz' | 'unknown';
+  /** Metadata provenance. */
+  provenance?: TilesetSpatialReferenceProvenance;
+  /** Non-fatal discovery qualifications. */
+  warnings?: readonly string[];
+};
+
+/**
+ * Combines format discovery with the intentionally small application option surface.
+ *
+ * @param discovered - Values derived from dataset metadata and format defaults.
+ * @param options - Application target options and expert recovery overrides.
+ * @returns Normalized immutable spatial metadata.
+ */
+export function createTilesetSpatialReference(
+  discovered: CreateTilesetSpatialReferenceOptions,
+  options: TilesetSpatialOptions = {}
+): TilesetSpatialReference {
+  const sourceCrs = options.sourceCrs || discovered.sourceCrs;
+  const outputCoordinates = options.outputCoordinates || 'auto';
+  const targetCrs =
+    options.targetCrs ||
+    (outputCoordinates === 'ecef' ? ('EPSG:4978' as CRSDefinition) : undefined);
+  const targetHeightReference = options.targetHeightReference || 'native';
+  const needsHeightTransform =
+    targetHeightReference !== 'native' && targetHeightReference !== discovered.heightReference;
+  const hasRequestedTransform =
+    Boolean(targetCrs) || targetHeightReference !== 'native' || outputCoordinates !== 'auto';
+  const hasRequiredTarget = outputCoordinates !== 'target-crs' || Boolean(targetCrs);
+  const hasHeightMetadata =
+    !needsHeightTransform || (discovered.heightReference || 'unknown') !== 'unknown';
+  const canTransform =
+    Boolean(sourceCrs) &&
+    hasRequestedTransform &&
+    hasRequiredTarget &&
+    hasHeightMetadata &&
+    outputCoordinates !== 'local-enu';
+
+  return Object.freeze({
+    sourceCrs,
+    verticalCrs: discovered.verticalCrs,
+    coordinateEpoch: options.coordinateEpoch ?? discovered.coordinateEpoch,
+    heightReference: discovered.heightReference || 'unknown',
+    coordinateFrame: discovered.coordinateFrame || 'unknown',
+    axisOrder: discovered.axisOrder || 'unknown',
+    provenance: options.sourceCrs ? 'caller-override' : discovered.provenance || 'unknown',
+    targetCrs,
+    targetHeightReference,
+    outputCoordinates,
+    status: hasRequestedTransform ? (canTransform ? 'transformable' : 'unresolved') : 'native',
+    warnings: Object.freeze([...(discovered.warnings || [])])
+  });
+}
+
+/**
+ * Applies application target and recovery options to format-discovered spatial metadata.
+ *
+ * @param discovered - Readonly metadata returned by a format adapter.
+ * @param options - Application target options and expert recovery overrides.
+ * @returns A new normalized immutable descriptor.
+ */
+export function applyTilesetSpatialOptions(
+  discovered: TilesetSpatialReference | undefined,
+  options: TilesetSpatialOptions = {}
+): TilesetSpatialReference {
+  return createTilesetSpatialReference(
+    {
+      sourceCrs: discovered?.sourceCrs,
+      verticalCrs: discovered?.verticalCrs,
+      coordinateEpoch: discovered?.coordinateEpoch,
+      heightReference: discovered?.heightReference,
+      coordinateFrame: discovered?.coordinateFrame,
+      axisOrder: discovered?.axisOrder,
+      provenance: discovered?.provenance,
+      warnings: discovered?.warnings
+    },
+    options
+  );
+}

--- a/modules/tiles/src/tileset-3d/common/tileset-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tileset-3d.ts
@@ -22,6 +22,11 @@ import type {FoveatedInterpolationCallback} from '../helpers/tiles-3d-request-pr
 import type {GeospatialViewport, Viewport} from '../../types';
 import {Tile3D} from './tile-3d';
 import {TILESET_TYPE} from '../../constants';
+import type {TilesetSpatialOptions, TilesetSpatialReference} from '../../spatial/spatial-types';
+import {
+  applyTilesetSpatialOptions,
+  createTilesetSpatialReference
+} from '../../spatial/spatial-types';
 
 import {TilesetTraverser} from './tileset-traverser';
 import {
@@ -72,6 +77,8 @@ export type Tileset3DProps = {
 
   ellipsoid?: object;
   modelMatrix?: Matrix4;
+  /** Automatic CRS output options and expert source-metadata recovery overrides. */
+  spatial?: TilesetSpatialOptions;
 
   maximumScreenSpaceError?: number;
   /**
@@ -178,6 +185,8 @@ type Props = {
   basePath: string;
   contentLoader?: (tile: Tile3D) => Promise<void>;
   i3s: Record<string, any>;
+  /** Automatic CRS output options and expert source-metadata recovery overrides. */
+  spatial: TilesetSpatialOptions;
 };
 
 const BYTES_PER_MEBIBYTE = 1024 * 1024;
@@ -284,7 +293,8 @@ const DEFAULT_PROPS: Props = {
   loadOptions: {fetch: {}},
   attributions: [],
   basePath: '',
-  i3s: {}
+  i3s: {},
+  spatial: {}
 };
 
 const TILES_TOTAL = 'Tiles In Tileset(s)';
@@ -333,6 +343,8 @@ export class Tileset3D {
   metadata: Record<string, any> | null = null;
   /** Tileset statistics metadata, preserved for application-level inspection. */
   statistics: unknown = null;
+  /** Normalized source and target coordinate reference system metadata. */
+  spatialReference: TilesetSpatialReference = createTilesetSpatialReference({});
 
   description = '';
   properties: any;
@@ -441,6 +453,13 @@ export class Tileset3D {
     this.memoryAdjustedScreenSpaceError = this.options.maximumScreenSpaceError;
     this._cacheBytes = cacheBytes;
     this._maximumCacheOverflowBytes = maximumCacheOverflowBytes;
+    const metadata = this._getSourceMetadata();
+    if (metadata) {
+      this.spatialReference = applyTilesetSpatialOptions(
+        metadata.spatialReference,
+        this.options.spatial
+      );
+    }
 
     this.stats = new Stats({id: this.url});
     this._initializeStats();
@@ -1077,6 +1096,10 @@ export class Tileset3D {
     this.groups = tileset.groups || [];
     this.metadata = tileset.metadata || null;
     this.statistics = tileset.statistics ?? null;
+    this.spatialReference = applyTilesetSpatialOptions(
+      metadata.spatialReference,
+      this.options.spatial
+    );
     this.properties = this.source.properties ?? this.properties;
     this.extras = this.source.extras ?? this.extras;
     if (this.options.attributions?.length) {

--- a/modules/tiles/src/tileset-3d/common/tileset-source.ts
+++ b/modules/tiles/src/tileset-3d/common/tileset-source.ts
@@ -9,6 +9,7 @@ import type {Tile3D} from './tile-3d';
 import type {Tileset3D} from './tileset-3d';
 import type {FrameState} from '../helpers/frame-state';
 import type {TILESET_TYPE} from '../../constants';
+import type {TilesetSpatialReference} from '../../spatial/spatial-types';
 
 /**
  * Parsed top-level tileset payload consumed by {@link Tileset3D} or a {@link Tileset3DSource}.
@@ -132,6 +133,8 @@ export type TilesetSourceMetadata = {
   lodMetricValue: number;
   /** Root refinement mode used as fallback by runtime tiles. */
   refine: string;
+  /** Format-discovered coordinate reference system metadata. */
+  spatialReference?: TilesetSpatialReference;
 };
 
 /**

--- a/modules/tiles/src/tileset-3d/format-3d-tiles/tiles-3d-source.ts
+++ b/modules/tiles/src/tileset-3d/format-3d-tiles/tiles-3d-source.ts
@@ -26,6 +26,7 @@ import {getZoomFromBoundingVolume} from '../helpers/zoom';
 import {TILESET_TYPE} from '../../constants';
 import type {TilesetTraverser, TilesetTraverserProps} from '../common/tileset-traverser';
 import type {FrameState} from '../helpers/frame-state';
+import {get3DTilesSpatialReference} from '../../spatial/format-spatial-reference';
 import {
   materializeImplicitSubtree,
   type ImplicitSubtreeReference,
@@ -201,7 +202,8 @@ export class Tiles3DSource implements Tileset3DSource {
       tileset: this.rootTileset,
       lodMetricType: this.rootTileset.lodMetricType,
       lodMetricValue: this.rootTileset.lodMetricValue,
-      refine: this.rootTileset.root?.refine
+      refine: this.rootTileset.root?.refine,
+      spatialReference: get3DTilesSpatialReference(this.rootTileset)
     };
   }
 

--- a/modules/tiles/src/tileset-3d/format-i3s/i3s-source.ts
+++ b/modules/tiles/src/tileset-3d/format-i3s/i3s-source.ts
@@ -25,6 +25,7 @@ import type {
 import {getZoomFromExtent, getZoomFromFullExtent} from '../helpers/zoom';
 import {TILESET_TYPE} from '../../constants';
 import type {TilesetTraverser, TilesetTraverserProps} from '../common/tileset-traverser';
+import {getI3SSpatialReference} from '../../spatial/format-spatial-reference';
 
 const EMPTY_CONTENT_FORMATS: TilesetContentFormats = {
   draco: false,
@@ -103,7 +104,8 @@ export class I3SSource implements Tileset3DSource {
       tileset: this.rootTileset,
       lodMetricType: this.rootTileset.lodMetricType,
       lodMetricValue: this.rootTileset.lodMetricValue,
-      refine: this.rootTileset.root?.refine
+      refine: this.rootTileset.root?.refine,
+      spatialReference: getI3SSpatialReference(this.rootTileset)
     };
   }
 

--- a/modules/tiles/test/spatial/format-spatial-reference.spec.ts
+++ b/modules/tiles/test/spatial/format-spatial-reference.spec.ts
@@ -1,0 +1,109 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+import {get3DTilesSpatialReference, getI3SSpatialReference} from '@loaders.gl/tiles';
+
+describe('getI3SSpatialReference', () => {
+  test('prefers current horizontal and vertical WKIDs and preserves I3S wire order', () => {
+    const spatialReference = getI3SSpatialReference({
+      spatialReference: {
+        wkid: 102100,
+        latestWkid: 3857,
+        vcsWkid: 105703,
+        latestVcsWkid: 5703
+      },
+      heightModelInfo: {
+        heightModel: 'gravity_related_height',
+        vertCRS: 'EPSG:5703'
+      }
+    });
+
+    expect(spatialReference).toMatchObject({
+      sourceCrs: 'EPSG:3857',
+      verticalCrs: 'EPSG:5703',
+      heightReference: 'orthometric',
+      coordinateFrame: 'projected',
+      axisOrder: 'xyz',
+      provenance: 'metadata'
+    });
+  });
+
+  test('uses custom WKT and reports terrain-dependent elevation placement', () => {
+    const spatialReference = getI3SSpatialReference({
+      spatialReference: {wkt: 'PROJCS["Custom"]'},
+      elevationInfo: {mode: 'relativeToGround'}
+    });
+
+    expect(spatialReference.sourceCrs).toBe('PROJCS["Custom"]');
+    expect(spatialReference.warnings[0]).toContain(
+      'requires a terrain or scene elevation provider'
+    );
+  });
+});
+
+describe('get3DTilesSpatialReference', () => {
+  test('resolves geocentric CRS and epoch through structured metadata semantics', () => {
+    const spatialReference = get3DTilesSpatialReference({
+      schema: {
+        classes: {
+          tileset: {
+            properties: {
+              crs: {semantic: 'TILESET_CRS_GEOCENTRIC'},
+              epoch: {semantic: 'TILESET_CRS_COORDINATE_EPOCH'}
+            }
+          }
+        }
+      },
+      metadata: {
+        class: 'tileset',
+        properties: {crs: 'EPSG:4978', epoch: 2020.25}
+      }
+    });
+
+    expect(spatialReference).toMatchObject({
+      sourceCrs: 'EPSG:4978',
+      coordinateEpoch: 2020.25,
+      coordinateFrame: 'geocentric',
+      heightReference: 'ellipsoidal',
+      provenance: 'metadata'
+    });
+  });
+
+  test('keeps an explicitly unknown geocentric CRS unresolved', () => {
+    const spatialReference = get3DTilesSpatialReference({
+      schema: {
+        classes: {
+          tileset: {
+            properties: {crs: {semantic: 'TILESET_CRS_GEOCENTRIC'}}
+          }
+        }
+      },
+      metadata: {class: 'tileset', properties: {crs: 'UNKNOWN'}},
+      root: {boundingVolume: {region: [0, 0, 1, 1, 0, 1]}}
+    });
+
+    expect(spatialReference.sourceCrs).toBeUndefined();
+    expect(spatialReference.provenance).toBe('unknown');
+    expect(spatialReference.warnings).toContain('3D Tiles geocentric CRS is explicitly unknown');
+  });
+
+  test('uses the specification frame established by a root region', () => {
+    const spatialReference = get3DTilesSpatialReference({
+      root: {boundingVolume: {region: [0, 0, 1, 1, 0, 1]}}
+    });
+
+    expect(spatialReference).toMatchObject({
+      sourceCrs: 'EPSG:4978',
+      provenance: 'format-default'
+    });
+  });
+
+  test('does not infer ECEF for an unlabelled local tileset', () => {
+    const spatialReference = get3DTilesSpatialReference({root: {boundingVolume: {}}});
+
+    expect(spatialReference.sourceCrs).toBeUndefined();
+    expect(spatialReference.coordinateFrame).toBe('unknown');
+  });
+});

--- a/modules/tiles/test/spatial/format-spatial-reference.spec.ts
+++ b/modules/tiles/test/spatial/format-spatial-reference.spec.ts
@@ -37,8 +37,30 @@ describe('getI3SSpatialReference', () => {
     });
 
     expect(spatialReference.sourceCrs).toBe('PROJCS["Custom"]');
+    expect(spatialReference.coordinateFrame).toBe('projected');
     expect(spatialReference.warnings[0]).toContain(
       'requires a terrain or scene elevation provider'
+    );
+  });
+
+  test.each([
+    ['GEOGCS["WGS 84"]', 'geographic'],
+    ['GEOCCS["WGS 84"]', 'geocentric'],
+    ['GEODCRS["WGS 84",DATUM["WGS 84"],CS[ellipsoidal,3]]', 'geographic'],
+    ['GEODCRS["WGS 84",DATUM["WGS 84"],CS[Cartesian,3]]', 'geocentric'],
+    ['COMPOUNDCRS["Unclassified"]', 'unknown']
+  ] as const)('classifies the WKT coordinate frame for %s', (wkt, coordinateFrame) => {
+    const spatialReference = getI3SSpatialReference({spatialReference: {wkt}});
+
+    expect(spatialReference.coordinateFrame).toBe(coordinateFrame);
+  });
+
+  test('classifies geocentric and three-dimensional geographic WKIDs', () => {
+    expect(getI3SSpatialReference({spatialReference: {wkid: 4978}}).coordinateFrame).toBe(
+      'geocentric'
+    );
+    expect(getI3SSpatialReference({spatialReference: {wkid: 4979}}).coordinateFrame).toBe(
+      'geographic'
     );
   });
 });

--- a/modules/tiles/test/spatial/spatial-coordinate-transformer.spec.ts
+++ b/modules/tiles/test/spatial/spatial-coordinate-transformer.spec.ts
@@ -1,0 +1,98 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+import type {Geoid} from '@math.gl/geoid';
+import {
+  createTilesetSpatialReference,
+  registerGeoidModel,
+  SpatialCoordinateTransformer
+} from '@loaders.gl/tiles';
+
+describe('SpatialCoordinateTransformer', () => {
+  test('retains native coordinates and extra components', () => {
+    const spatialReference = createTilesetSpatialReference({
+      sourceCrs: 'EPSG:4326',
+      coordinateFrame: 'geographic',
+      axisOrder: 'xy',
+      heightReference: 'ellipsoidal',
+      provenance: 'metadata'
+    });
+    const transformer = new SpatialCoordinateTransformer(spatialReference);
+
+    expect(transformer.transformPosition([-122, 37, 10, 99])).toEqual([-122, 37, 10, 99]);
+  });
+
+  test('uses Proj4 for horizontal transformation', () => {
+    const spatialReference = createTilesetSpatialReference(
+      {
+        sourceCrs: 'EPSG:3857',
+        coordinateFrame: 'projected',
+        axisOrder: 'xy',
+        heightReference: 'ellipsoidal',
+        provenance: 'metadata'
+      },
+      {targetCrs: 'EPSG:4326'}
+    );
+    const transformer = new SpatialCoordinateTransformer(spatialReference);
+    const transformed = transformer.transformPosition([1113194.9079327357, 0, 12]);
+
+    expect(transformed[0]).toBeCloseTo(10, 8);
+    expect(transformed[1]).toBeCloseTo(0, 8);
+    expect(transformed[2]).toBe(12);
+  });
+
+  test('converts orthometric and ellipsoidal heights with a registered geoid', () => {
+    const constantGeoid = {getHeight: () => 30} as Geoid;
+    registerGeoidModel('test-geoid', constantGeoid);
+    const spatialReference = createTilesetSpatialReference(
+      {
+        sourceCrs: 'EPSG:4326',
+        coordinateFrame: 'geographic',
+        axisOrder: 'xy',
+        heightReference: 'orthometric',
+        provenance: 'metadata'
+      },
+      {targetHeightReference: 'ellipsoidal'}
+    );
+    const transformer = new SpatialCoordinateTransformer(spatialReference, {
+      geoidModel: 'test-geoid'
+    });
+
+    expect(transformer.transformPosition([10, 20, 100])).toEqual([10, 20, 130]);
+  });
+
+  test('rejects requested conversion with unknown source metadata', () => {
+    const spatialReference = createTilesetSpatialReference({}, {targetCrs: 'EPSG:4326'});
+
+    expect(() => new SpatialCoordinateTransformer(spatialReference)).toThrow(
+      'source CRS is unknown'
+    );
+  });
+
+  test('rejects height conversion without a supplied geoid model', () => {
+    const spatialReference = createTilesetSpatialReference(
+      {
+        sourceCrs: 'EPSG:4326',
+        heightReference: 'orthometric'
+      },
+      {targetHeightReference: 'ellipsoidal'}
+    );
+
+    expect(() => new SpatialCoordinateTransformer(spatialReference)).toThrow(
+      'requires a registered geoid model'
+    );
+  });
+
+  test('rejects height conversion when the source height reference is unknown', () => {
+    const spatialReference = createTilesetSpatialReference(
+      {sourceCrs: 'EPSG:4326'},
+      {targetHeightReference: 'ellipsoidal'}
+    );
+
+    expect(() => new SpatialCoordinateTransformer(spatialReference)).toThrow(
+      'source height reference is unknown'
+    );
+  });
+});

--- a/modules/tiles/test/spatial/spatial-coordinate-transformer.spec.ts
+++ b/modules/tiles/test/spatial/spatial-coordinate-transformer.spec.ts
@@ -63,6 +63,24 @@ describe('SpatialCoordinateTransformer', () => {
     expect(transformer.transformPosition([10, 20, 100])).toEqual([10, 20, 130]);
   });
 
+  test('rejects geocentric height conversion instead of treating Cartesian z as height', () => {
+    const constantGeoid = {getHeight: () => 30} as Geoid;
+    const spatialReference = createTilesetSpatialReference(
+      {
+        sourceCrs: 'EPSG:4978',
+        coordinateFrame: 'geocentric',
+        axisOrder: 'xyz',
+        heightReference: 'ellipsoidal',
+        provenance: 'metadata'
+      },
+      {targetCrs: 'EPSG:4326', targetHeightReference: 'orthometric'}
+    );
+
+    expect(
+      () => new SpatialCoordinateTransformer(spatialReference, {geoidModel: constantGeoid})
+    ).toThrow('Geocentric height conversion is not supported');
+  });
+
   test('rejects requested conversion with unknown source metadata', () => {
     const spatialReference = createTilesetSpatialReference({}, {targetCrs: 'EPSG:4326'});
 

--- a/modules/tiles/test/tileset/tileset-3d-source.spec.ts
+++ b/modules/tiles/test/tileset/tileset-3d-source.spec.ts
@@ -142,13 +142,22 @@ test('Tiles3DSource initializes metadata and merges source query parameters', as
     lodMetricType: 'geometricError',
     lodMetricValue: 16,
     queryString: 'session=abc123',
-    extensionsUsed: ['KHR_texture_basisu']
+    extensionsUsed: ['KHR_texture_basisu'],
+    schema: {
+      classes: {
+        tileset: {
+          properties: {crs: {semantic: 'TILESET_CRS_GEOCENTRIC'}}
+        }
+      }
+    },
+    metadata: {class: 'tileset', properties: {crs: 'EPSG:4978'}}
   };
   const source = new Tiles3DSource({...tilesetJson, coreApi});
   await source.initialize();
   const metadata = source.getMetadata();
   expect(metadata.basePath).toBe('https://example.com/root');
   expect(metadata.refine).toBe('ADD');
+  expect(metadata.spatialReference?.sourceCrs).toBe('EPSG:4978');
   expect(source.hasExtension('KHR_texture_basisu')).toBeTruthy();
   expect(source.getTileUrl('https://example.com/root/tile.b3dm?existing=1')).toBe(
     'https://example.com/root/tile.b3dm?existing=1&session=abc123&v=42'
@@ -167,6 +176,11 @@ test('I3SSource initializes promised roots and appends auth tokens to tile urls'
       lodMetricType: 'maxScreenThresholdSQ',
       lodMetricValue: 4,
       nodePagesTile: {nodesInNodePages: 7},
+      spatialReference: {wkid: 4326, vcsWkid: 5703},
+      heightModelInfo: {
+        heightModel: 'gravity_related_height',
+        vertCRS: 'EPSG:5703'
+      },
       store: {extent: [0, 0, 1, 1]}
     } as any,
     {i3s: {token: 'secret-token'}}
@@ -176,6 +190,11 @@ test('I3SSource initializes promised roots and appends auth tokens to tile urls'
   expect(metadata.tileset.root.id, 'promised roots are awaited during initialization').toBe(
     'root-node'
   );
+  expect(metadata.spatialReference).toMatchObject({
+    sourceCrs: 'EPSG:4326',
+    verticalCrs: 'EPSG:5703',
+    heightReference: 'orthometric'
+  });
   expect(source.getTileUrl('https://example.com/SceneServer/layers/0/nodes/1')).toBe(
     'https://example.com/SceneServer/layers/0/nodes/1?token=secret-token'
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -5921,9 +5921,12 @@ __metadata:
     "@loaders.gl/loader-utils": "npm:5.0.0-alpha.2"
     "@loaders.gl/schema": "npm:5.0.0-alpha.2"
     "@math.gl/core": "npm:4.2.0-alpha.5"
+    "@math.gl/crs": "npm:^4.2.0-alpha.5"
     "@math.gl/culling": "npm:4.2.0-alpha.5"
+    "@math.gl/geoid": "npm:4.2.0-alpha.5"
     "@math.gl/geometry-utils": "npm:4.2.0-alpha.5"
     "@math.gl/geospatial": "npm:4.2.0-alpha.5"
+    "@math.gl/proj4": "npm:^4.2.0-alpha.5"
     "@math.gl/web-mercator": "npm:4.2.0-alpha.5"
     "@probe.gl/stats": "npm:^4.1.1"
   peerDependencies:


### PR DESCRIPTION
## Goals

- Establish one simple, metadata-driven CRS contract for I3S and 3D Tiles.
- Use math.gl/crs for definitions, math.gl/proj4 for executable horizontal/geocentric operations, and math.gl/geoid for explicit vertical conversion resources.
- Make CRS support and remaining integration boundaries exceptionally clear in framework and format documentation.

## Changes

- Adds shared TilesetSpatialOptions and readonly TilesetSpatialReference metadata to @loaders.gl/tiles.
- Adds deterministic CRS alias, NTv2 datum-grid, and PGM geoid registration without implicit network loading.
- Adds SpatialCoordinateTransformer with conventional x/y/z order, Proj4 execution, explicit failure behavior, and GeographicLib height conversion using h = H + N.
- Normalizes I3S WKID/current-WKID, WKT, vertical CRS, height model, axis order, and elevation-provider diagnostics.
- Normalizes 3D Tiles TILESET_CRS_GEOCENTRIC and TILESET_CRS_COORDINATE_EPOCH semantics, explicit UNKNOWN, root-region defaults, and unresolved external-schema diagnostics.
- Exposes normalized metadata through I3S loader/service/mesh/Point Cloud paths, the 3D Tiles loader/source, and Tileset3D.
- Adds a framework CRS guide and dedicated I3S and 3D Tiles CRS concept pages, including precision, antimeridian, nested tileset, vertical datum, elevation placement, authoring, and failure-model guidance.
- Updates the I3S roadmap and both format feature matrices to distinguish the completed foundation from remaining end-to-end per-vertex, bounds, normals, nested placement, and terrain integration.

## Validation

- yarn lint fix
- yarn build
- yarn test-node: 361 passed, 6 skipped
- yarn build-workers
- yarn test-headless: 3,180 passed, 40 skipped
- yarn test-audit: 619 files, 0 Tape, 0 violations
- Focused CRS/source/loader coverage: 48 passed

## Follow-up

This PR deliberately does not label coordinates as transformed merely because a target operation can be constructed. Follow-up runtime tranches will consume this foundation for absolute Float64 vertex reconstruction, nonlinear reprojection, stable target origins, normals/orientations, conservative bounds, nested tilesets, terrain/scene-relative elevation, and authoring conformance.
